### PR TITLE
fix(runtime): never chmod platform roots from child-file writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.13.43
+
+Package: `clawdi@0.13.43`
+
+### Fixed
+
+- Hosted runtime platform roots keep their systemd-defined access modes:
+  the CLI no longer re-asserts modes on `/etc/clawdi`, `/var/lib/clawdi`,
+  `/var/cache/clawdi`, or `/run/clawdi` when it writes files inside them, so
+  the root-owned `0700` configuration and cache boundaries stay closed to
+  the tenant user.
+
 ## Clawdi CLI v0.13.42
 
 Package: `clawdi@0.13.42`

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.42",
+      "version": "0.13.43",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.42",
+	"version": "0.13.43",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/lib/private-file.test.ts
+++ b/packages/cli/src/lib/private-file.test.ts
@@ -1,0 +1,83 @@
+import { afterAll, expect, test } from "bun:test";
+import {
+	chmodSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writePrivateFileAtomic } from "./private-file";
+
+const roots: string[] = [];
+
+function tempRoot(label: string): string {
+	const root = mkdtempSync(join(tmpdir(), `clawdi-private-file-${label}-`));
+	roots.push(root);
+	return root;
+}
+
+afterAll(() => {
+	for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+test("never chmods a pre-existing trusted root when writing a child file", () => {
+	const root = tempRoot("root");
+	chmodSync(root, 0o700);
+	// The parent directory of this file IS the trusted root; dirMode is
+	// only for directories the writer creates itself, so the root's mode
+	// must survive untouched.
+	writePrivateFileAtomic(join(root, "child.json"), "{}", {
+		mode: 0o600,
+		dirMode: 0o755,
+		trustedRoot: root,
+	});
+	expect(statSync(root).mode & 0o777).toBe(0o700);
+	expect(statSync(join(root, "child.json")).mode & 0o777).toBe(0o600);
+});
+
+test("applies dirMode to subdirectories it creates inside a trusted root", () => {
+	const root = tempRoot("subdir");
+	chmodSync(root, 0o700);
+	writePrivateFileAtomic(join(root, "private", "child.json"), "{}", {
+		mode: 0o600,
+		dirMode: 0o700,
+		trustedRoot: root,
+	});
+	expect(statSync(root).mode & 0o777).toBe(0o700);
+	expect(statSync(join(root, "private")).mode & 0o777).toBe(0o700);
+	expect(statSync(join(root, "private", "child.json")).mode & 0o777).toBe(0o600);
+});
+
+test("never re-chmods a pre-existing subdirectory inside a trusted root", () => {
+	const root = tempRoot("existing-subdir");
+	chmodSync(root, 0o700);
+	const sub = join(root, "sub");
+	mkdirSync(sub, { recursive: true });
+	// 0711 is deliberately traversable, mirroring the runtime root contract.
+	chmodSync(sub, 0o711);
+	writePrivateFileAtomic(join(sub, "child.json"), "{}", {
+		mode: 0o600,
+		dirMode: 0o700,
+		trustedRoot: root,
+	});
+	expect(statSync(root).mode & 0o777).toBe(0o700);
+	expect(statSync(sub).mode & 0o777).toBe(0o711);
+});
+
+test("never re-chmods a pre-existing user directory without a trusted root", () => {
+	const root = tempRoot("user-dir");
+	chmodSync(root, 0o700);
+	writePrivateFileAtomic(join(root, "first.json"), "{}", { mode: 0o600, dirMode: 0o700 });
+	writePrivateFileAtomic(join(root, "second.json"), "{}", { mode: 0o600, dirMode: 0o700 });
+	expect(statSync(root).mode & 0o777).toBe(0o700);
+	expect(readFileSync(join(root, "first.json"), "utf-8")).toBe("{}");
+	// The directory is no longer the CLI's to re-assert once it pre-exists.
+	chmodSync(root, 0o711);
+	writePrivateFileAtomic(join(root, "third.json"), "{}", { mode: 0o600, dirMode: 0o700 });
+	expect(statSync(root).mode & 0o777).toBe(0o711);
+	expect(lstatSync(join(root, "third.json")).isFile()).toBe(true);
+});

--- a/packages/cli/src/lib/private-file.ts
+++ b/packages/cli/src/lib/private-file.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { ensureDirectoryWithinTrustedRoot } from "./trusted-directory";
 
@@ -7,6 +7,12 @@ export const PRIVATE_DIR_MODE = 0o700;
 
 interface PrivateFileWriteOptions {
 	mode?: number;
+	/**
+	 * Mode for directories created by this write only. Pre-existing
+	 * directories are never chmodded: platform roots own their mode via
+	 * systemd directory directives, and user directories are not ours to
+	 * re-assert.
+	 */
 	dirMode?: number;
 	trustedRoot?: string;
 }
@@ -19,16 +25,23 @@ export function writePrivateFileAtomic(
 	const mode = options.mode ?? PRIVATE_FILE_MODE;
 	const dir = dirname(path);
 	if (options.trustedRoot) {
+		// Creation-time modes for subdirectories are applied by
+		// ensureDirectoryWithinTrustedRoot; a pre-existing trusted root is
+		// never chmodded by a child-file writer.
 		ensureDirectoryWithinTrustedRoot(options.trustedRoot, dir, {
 			...(options.dirMode === undefined ? {} : { mode: options.dirMode }),
 		});
 	} else {
+		const existed = existsSync(dir);
 		mkdirSync(dir, {
 			recursive: true,
 			...(options.dirMode === undefined ? {} : { mode: options.dirMode }),
 		});
+		// mkdir modes are filtered by umask, so re-assert the exact mode on
+		// directories this write created; pre-existing directories are not
+		// touched.
+		if (!existed && options.dirMode !== undefined) chmodBestEffort(dir, options.dirMode);
 	}
-	if (options.dirMode !== undefined) chmodBestEffort(dir, options.dirMode);
 	const tmp = join(
 		dir,
 		`.${basename(path)}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`,

--- a/packages/cli/src/runtime/file-browser-companion.ts
+++ b/packages/cli/src/runtime/file-browser-companion.ts
@@ -353,7 +353,9 @@ export function ensureFileBrowserCompanion(
 		installCandidate(companion, paths, asset, options);
 		writeRuntimePlatformFileAtomic(paths, paths.fileBrowserConfig, config, {
 			mode: 0o600,
-			dirMode: 0o700,
+			// The parent is the configuration platform root; its mode is owned
+			// by the systemd ConfigurationDirectory directive, never by this
+			// writer.
 		});
 	}
 	const current = () => currentRevision(companion, paths, asset.sha256, config);

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -461,7 +461,8 @@ function writeLastGoodSecretValues(
 		`${JSON.stringify(recoverable, null, 2)}\n`,
 		{
 			mode: 0o600,
-			dirMode: 0o755,
+			// The parent is the cache platform root; its mode is owned by the
+			// systemd CacheDirectory directive, never by this writer.
 		},
 	);
 }
@@ -4610,7 +4611,12 @@ function writeLiveSyncEnvironmentIndex(agentTypes: Set<RuntimeName>, paths: Runt
 			null,
 			2,
 		)}\n`,
-		{ mode: 0o644, dirMode: 0o755 },
+		{
+			mode: 0o644,
+			// The parent is the configuration platform root; its mode is owned
+			// by the systemd ConfigurationDirectory directive, never by this
+			// writer.
+		},
 	);
 }
 

--- a/packages/cli/src/runtime/platform-root-modes.test.ts
+++ b/packages/cli/src/runtime/platform-root-modes.test.ts
@@ -1,0 +1,164 @@
+import { afterAll, expect, test } from "bun:test";
+import {
+	chmodSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { cacheRuntimeLastGoodManifest, convergeRuntimeManifest } from "./manifest";
+import { normalizeHostedRuntimeBundleV2 } from "./manifest-source";
+import type { RuntimePaths } from "./paths";
+import { ensureRuntimeStateDirs } from "./state";
+
+const ROOT_MODE_TEST_SECRET_REF = "secret://runtime/root-modes/test-secret";
+
+const roots: string[] = [];
+
+function tempRoot(): string {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-platform-root-modes-"));
+	roots.push(root);
+	return root;
+}
+
+afterAll(() => {
+	for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+function statSummary(path: string): { mode: number; uid: number } {
+	const stat = statSync(path);
+	return { mode: stat.mode & 0o777, uid: stat.uid };
+}
+
+test("never chmods the four platform roots that child writes touch", async () => {
+	const root = tempRoot();
+	const home = join(root, "home", "clawdi");
+	const state = join(root, "state");
+	const run = join(root, "run");
+	const systemdSystemRoot = join(run, "systemd", "system");
+	const openclaw = join(home, ".openclaw", "bin", "openclaw");
+	mkdirSync(dirname(openclaw), { recursive: true });
+	writeFileSync(
+		openclaw,
+		`#!/bin/sh
+[ "\${1:-}" != "--version" ] || printf '%s\\n' '2026.7.1'
+exit 0
+`,
+	);
+	chmodSync(openclaw, 0o755);
+
+	const originalEnv = { ...process.env };
+	process.env.HOME = home;
+	process.env.CLAWDI_RUNTIME_MODE = "hosted";
+	const runtimeUid = process.getuid?.() ?? 1_000;
+	const runtimeGid = process.getgid?.() ?? 1_000;
+	process.env.CLAWDI_RUNTIME_USER = String(runtimeUid);
+	process.env.CLAWDI_SERVICE_STATE_DIR = state;
+	process.env.CLAWDI_RUN_DIR = run;
+	process.env.CLAWDI_SYSTEMD_SYSTEM_ROOT = systemdSystemRoot;
+	process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
+
+	try {
+		const fixture = JSON.parse(
+			readFileSync(
+				join(import.meta.dir, "../../../../test-fixtures/runtime-bundle-v2.golden.json"),
+				"utf-8",
+			),
+		) as Record<string, unknown>;
+		const manifest = fixture.manifest as Record<string, unknown>;
+		const runtimes = manifest.runtimes as Record<string, Record<string, unknown>>;
+		const openclawRuntime = runtimes.openclaw;
+		openclawRuntime.providerMode = "unmanaged";
+		openclawRuntime.provider_ids = [];
+		delete openclawRuntime.primary_model;
+		manifest.providers = {};
+		manifest.skills = { entries: {} };
+		// A recoverable secret ensures writeLastGoodSecretValues persists the
+		// cache file directly inside the cache platform root.
+		const openclawRun = openclawRuntime.run as Record<string, unknown>;
+		openclawRuntime.run = {
+			...openclawRun,
+			secretEnv: {
+				...(openclawRun.secretEnv as Record<string, unknown>),
+				ROOT_MODE_TEST_SECRET: ROOT_MODE_TEST_SECRET_REF,
+			},
+		};
+		fixture.secretValues = {
+			"secret://clawdi/auth-token": "runtime-auth-token-root-modes",
+			"secret://runtime/openclaw/gateway-token": "gateway-token-root-modes",
+			"secret://tool.codex.apiKey": "codex-provider-key-root-modes",
+			[ROOT_MODE_TEST_SECRET_REF]: "root-modes-secret-value",
+		};
+
+		const { getRuntimePaths } = await import("./paths");
+		const paths: RuntimePaths = getRuntimePaths();
+		const layout = [
+			{ path: paths.configurationRoot, mode: 0o700, label: "configuration" },
+			{ path: paths.serviceStateRoot, mode: 0o700, label: "service state" },
+			{ path: paths.cacheRoot, mode: 0o700, label: "cache" },
+			{ path: paths.runRoot, mode: 0o711, label: "runtime" },
+		];
+		// Mirror the tenant image: systemd directory directives pre-create the
+		// four platform roots with their canonical modes before the CLI runs.
+		for (const entry of layout) {
+			mkdirSync(entry.path, { recursive: true, mode: entry.mode });
+			chmodSync(entry.path, entry.mode);
+		}
+
+		ensureRuntimeStateDirs(paths);
+		const before = new Map(layout.map((entry) => [entry.path, statSummary(entry.path)]));
+
+		const load = normalizeHostedRuntimeBundleV2(fixture);
+		load.applyContext = {
+			kind: "context-file",
+			backend: "incus",
+			identity: {
+				generation: 2,
+				manifestETag: '"manifest-root-modes"',
+				applyReceiptId: "apply-receipt-root-modes-0001",
+				bootNonce: "boot-nonce-root-modes-0000001",
+			},
+			cliPackageSpec: "clawdi@1.2.3-test",
+			manifestSource: {
+				type: "http",
+				url: "https://runtime.test/v1/runtime/manifest",
+				auth: { type: "bearer", token: "bootstrap-bearer-root-modes" },
+			},
+		};
+		const result = convergeRuntimeManifest(load, paths, {
+			hostedRuntimeContract: {
+				expectedIdentity: {
+					home,
+					user: String(runtimeUid),
+					uid: runtimeUid,
+					gid: runtimeGid,
+				},
+				resolveUserIdentity: () => ({ uid: runtimeUid, gid: runtimeGid }),
+			},
+		});
+		expect(result.installErrors).toEqual([]);
+		// The convergence loop just ran writeLiveSyncEnvironmentIndex (into
+		// the configuration root) and writeLastGoodSecretValues (into the
+		// cache root); the explicit call re-runs the secret cache writer.
+		cacheRuntimeLastGoodManifest(result.manifest, paths, load.secretValues);
+
+		for (const entry of layout) {
+			const expected = before.get(entry.path);
+			if (!expected) throw new Error(`missing before snapshot for ${entry.path}`);
+			expect(statSummary(entry.path)).toEqual(expected);
+			expect(statSummary(entry.path).mode).toBe(entry.mode);
+			expect(statSummary(entry.path).uid).toBe(runtimeUid);
+		}
+		expect(statSync(paths.liveSyncEnvironmentIndex).mode & 0o777).toBe(0o644);
+		expect(statSync(paths.managedSecretCacheFile).mode & 0o777).toBe(0o600);
+	} finally {
+		for (const key of Object.keys(process.env)) {
+			if (!(key in originalEnv)) delete process.env[key];
+		}
+		Object.assign(process.env, originalEnv);
+	}
+});

--- a/packages/cli/tests/clerk-oauth.test.ts
+++ b/packages/cli/tests/clerk-oauth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, rmSync, statSync } from "node:fs";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -126,7 +126,10 @@ beforeEach(() => {
 	priorAuthToken = process.env.CLAWDI_AUTH_TOKEN;
 	delete process.env.CLAWDI_AUTH_TOKEN;
 	stateDir = join(tmpdir(), `clawdi-oauth-${crypto.randomUUID()}`);
+	// The state home is private CLI-owned state; the CLI creates it at 0700
+	// (mkdir modes are umask-filtered, so re-assert the exact mode).
 	mkdirSync(stateDir, { recursive: true });
+	chmodSync(stateDir, 0o700);
 	process.env.CLAWDI_HOME = stateDir;
 });
 

--- a/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
+++ b/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
@@ -144,9 +144,9 @@ describe("WhatsApp sidecar production deployment contract", () => {
 			new Map([
 				[
 					"packages/cli/package.json",
-					replaceOnce(cliPackage, '"version": "0.13.42"', '"version": "0.13.43"'),
+					replaceOnce(cliPackage, '"version": "0.13.43"', '"version": "0.13.44"'),
 				],
-				["bun.lock", replaceOnce(lockfile, '"version": "0.13.42"', '"version": "0.13.43"')],
+				["bun.lock", replaceOnce(lockfile, '"version": "0.13.43"', '"version": "0.13.44"')],
 			]),
 		);
 		const unrelatedDeploy = calculateWhatsAppSidecarDeploymentRevision(


### PR DESCRIPTION
## Summary

A release gate installing the pinned CLI into a real Incus tenant image observed the CLI widening its own platform roots: `/etc/clawdi` and `/var/cache/clawdi` ended at `0755` instead of the systemd-asserted `0700`. Both hold platform-private material (bootstrap bearer token, runtime context, cached secret values), so the tenant user (uid 10001) could read them — defeating the single-root `0700` barrier model from #868/#872.

### Root cause (verified)

`writePrivateFileAtomic` in `packages/cli/src/lib/private-file.ts` applied its `dirMode` option to the **parent directory unconditionally** (line 31), even when the parent **is** a trusted platform root. `writeLiveSyncEnvironmentIndex()` (→ `/etc/clawdi/runtime-live-sync-agents.json`, `dirMode 0o755`) and `writeLastGoodSecretValues()` (→ `/var/cache/clawdi/runtime-secrets.last-good.json`, `dirMode 0o755`) both hit exactly that case. A third writer, `file-browser-companion.ts` (`/etc/clawdi/filebrowser.yaml`, `dirMode 0o700`), re-asserted the configuration root mode — same defect class, harmless value.

### Fix chosen

**Structural, in the writer** — `dirMode` is now only ever applied to directories the write itself creates:

- `trustedRoot` branch: `ensureDirectoryWithinTrustedRoot` already applies create-time modes to subdirectory segments it creates and never touches a pre-existing root (the `if (!childPath) return` path). The unconditional parent chmod is deleted.
- plain-`mkdirSync` branch: chmod only when the directory did not exist before this write.

So the API makes it **impossible** for a child-file writer to chmod any pre-existing directory — including all four platform roots. The three root-direct call sites drop their now-dead `dirMode`, with a comment stating the root's mode is owned by the systemd directory directive.

**Rejected alternatives:**
- Gating each call site on `dirname(path) === root` — patching around the edge; the defect lives in the shared writer, so that's where it dies. Leaves every future writer vulnerable.
- Keeping `dirMode` semantics but skipping only the four known roots — a path list is the wrong mechanism; `trustedRoot` machinery from #872 already expresses "this parent is not ours to chmod".

### Sweep of other platform-root writers

- `ensureRuntimeStateDirs` (state.ts) — already only chmods roots it **created**; systemd roots that don't exist throw. Correct, unchanged.
- `makeManagedSecretRoot`, `ensureOwnedDirectory`, `writeDurableAtomic`, `publishEgressSystemCaBundle`, egress/systemd dirs — all target CLI-created subdirectories of roots, never a root itself. Correct, unchanged.
- `makeRuntimeUserOwned` / `chownSync` sites — files and CLI-owned user-space dirs only; `runningAsRoot()`-gated. No root chowns.
- live-state-snapshot restore — only mutation-plan paths (files + CLI subdirs), never the four roots.

## Tests

- `packages/cli/src/lib/private-file.test.ts` — unit invariant: write into a pre-existing trusted root with `dirMode` leaves the root untouched; subdirs created by the write get `dirMode`; pre-existing subdirs are not re-chmodded; pre-existing user dirs are not re-chmodded.
- `packages/cli/src/runtime/platform-root-modes.test.ts` — hosted convergence against the golden bundle: roots pre-created exactly as systemd directives would (0700/0700/0700/0711), then `convergeRuntimeManifest` + explicit `cacheRuntimeLastGoodManifest` (running both reporters); asserts each root retains mode **and** owner.
- **Both fail on current main** with the exact gate symptom (`0700 → 0755`).
- `tests/clerk-oauth.test.ts` — one test pre-created its CLAWDI_HOME at the default `0755` and relied on the old write-time re-chmod to narrow it; setup now creates the private state dir at `0700` (as the CLI itself does). No production behavior was weakened.

## Release

`clawdi@0.13.42` is pinned/immutable in production, so this ships as **0.13.43**: `packages/cli/package.json`, `bun.lock`, the sidecar deploy-contract probe (`0.13.43 → 0.13.44`), plus a `Clawdi CLI v0.13.43` CHANGELOG entry.

## Verification

- `bun run typecheck` — exit 0
- `bun run check` — exit 0
- `bun run test` — exit 0: **2241 passed, 11 skipped** (1661 TS/JS tests across 126 files + backend pytest)