### PR TITLE
feat(search): index projects in global search for the Cmd+K palette

### DIFF
--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -2,7 +2,15 @@
 
 import { keepPreviousData } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
-import { Brain, Key, type LucideIcon, MessageSquare, Settings, Sparkles } from "lucide-react";
+import {
+	Brain,
+	FolderKanban,
+	Key,
+	type LucideIcon,
+	MessageSquare,
+	Settings,
+	Sparkles,
+} from "lucide-react";
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import {
 	Command,
@@ -35,6 +43,7 @@ interface NavShortcut {
 const TYPE_ICON: Record<SearchHit["type"], LucideIcon> = {
 	session: MessageSquare,
 	memory: Brain,
+	project: FolderKanban,
 	skill: Sparkles,
 	vault: Key,
 };
@@ -42,6 +51,7 @@ const TYPE_ICON: Record<SearchHit["type"], LucideIcon> = {
 const TYPE_LABEL: Record<SearchHit["type"], string> = {
 	session: "Sessions",
 	memory: "Memories",
+	project: "Projects",
 	skill: "Skills",
 	vault: "Vaults",
 };
@@ -269,7 +279,7 @@ function CommandPalette({
 					) : null}
 
 					{hasQuery
-						? (["session", "memory", "skill", "vault"] as const).map((type, i) => {
+						? (["session", "memory", "project", "skill", "vault"] as const).map((type, i) => {
 								const hits = grouped[type];
 								if (!hits?.length) return null;
 								const Icon = TYPE_ICON[type];

--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -21,6 +21,7 @@ from app.core.auth import AuthContext, get_auth, is_scoped_api_key
 from app.core.database import get_session
 from app.core.project import project_ids_visible_to
 from app.core.query_utils import like_needle
+from app.models.project import Project
 from app.models.session import AgentEnvironment, Session
 from app.models.skill import Skill
 from app.models.vault import Vault, VaultProjectAttachment
@@ -44,7 +45,7 @@ log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/search", tags=["search"])
 
-SearchType = Literal["session", "memory", "skill", "vault"]
+SearchType = Literal["session", "memory", "project", "skill", "vault"]
 
 
 class SearchHit(BaseModel):
@@ -179,6 +180,35 @@ async def _search_skills(db: AsyncSession, auth: AuthContext, query: str) -> lis
     ]
 
 
+async def _search_projects(db: AsyncSession, auth: AuthContext, query: str) -> list[SearchHit]:
+    needle = like_needle(query)
+    visible_project_ids = await project_ids_visible_to(db, auth)
+    stmt = (
+        select(Project)
+        .where(
+            Project.id.in_(visible_project_ids),
+            Project.archived_at.is_(None),
+            or_(
+                Project.name.ilike(needle, escape="\\"),
+                Project.slug.ilike(needle, escape="\\"),
+            ),
+        )
+        .order_by(Project.name)
+        .limit(TYPE_LIMIT)
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+    return [
+        SearchHit(
+            type="project",
+            id=str(p.id),
+            title=p.name,
+            subtitle=p.slug,
+            href=f"/projects/{p.id}",
+        )
+        for p in rows
+    ]
+
+
 async def _search_vaults(db: AsyncSession, auth: AuthContext, query: str) -> list[SearchHit]:
     needle = like_needle(query)
     visible_project_ids = await project_ids_visible_to(db, auth)
@@ -254,6 +284,10 @@ async def global_search(
         # Insert memories right after sessions if present, otherwise first.
         idx = 1 if any(label == "sessions" for label, _fn in jobs) else 0
         jobs.insert(idx, ("memories", _search_memories))
+    if _has_scope(auth, "projects:read"):
+        # Projects are the Library hubs — after activity objects, before assets.
+        idx = next((i + 1 for i, (label, _fn) in enumerate(jobs) if label == "memories"), len(jobs))
+        jobs.insert(idx, ("projects", _search_projects))
     hits: list[SearchHit] = []
     for source, searcher in jobs:
         try:

--- a/backend/tests/test_projects_routes.py
+++ b/backend/tests/test_projects_routes.py
@@ -222,3 +222,32 @@ async def test_agents_project_filter_is_explicit_and_bounded(
     response = await client.get("/v1/agents", params={"project_id": str(workspace_project.id)})
     assert response.status_code == 200, response.text
     assert [agent["id"] for agent in response.json()] == [str(channel_agent.id)]
+
+
+async def test_global_search_finds_projects_by_name_and_slug(client):
+    created = await client.post("/v1/projects", json={"name": "Redpill Launch"})
+    assert created.status_code == 201, created.text
+    project_id = created.json()["id"]
+
+    by_name = await client.get("/v1/search", params={"q": "redpill"})
+    assert by_name.status_code == 200, by_name.text
+    project_hits = [h for h in by_name.json()["results"] if h["type"] == "project"]
+    assert [(h["id"], h["href"]) for h in project_hits] == [
+        (project_id, f"/projects/{project_id}")
+    ]
+
+    by_slug = await client.get("/v1/search", params={"q": "redpill-launch"})
+    slug_hits = [h for h in by_slug.json()["results"] if h["type"] == "project"]
+    assert [h["id"] for h in slug_hits] == [project_id]
+
+
+async def test_global_search_projects_excludes_archived(client):
+    created = await client.post("/v1/projects", json={"name": "Archived Search Target"})
+    assert created.status_code == 201, created.text
+    project_id = created.json()["id"]
+    archived = await client.delete(f"/v1/projects/{project_id}")
+    assert archived.status_code == 200, archived.text
+
+    response = await client.get("/v1/search", params={"q": "Archived Search Target"})
+    assert response.status_code == 200, response.text
+    assert [h for h in response.json()["results"] if h["type"] == "project"] == []

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -6833,7 +6833,7 @@ export interface components {
              * Type
              * @enum {string}
              */
-            type: "session" | "memory" | "skill" | "vault";
+            type: "session" | "memory" | "project" | "skill" | "vault";
             /** Id */
             id: string;
             /** Title */


### PR DESCRIPTION
## What

The journey audit (docs/plans/ui-2.0-journey-evaluation.md, J10 🔴) flagged that the palette could not reach Projects — the Library hubs — only sessions/memories/skills/vaults. This closes the gap end to end:

- **Backend**: new `_search_projects` source in `/v1/search` — name/slug ILIKE over `project_ids_visible_to`, archived excluded, capped at the shared `TYPE_LIMIT`, gated by the registered `projects:read` scope. Hits deep-link to `/projects/{id}`. Ordered between memories and skills (activity objects → hubs → assets).
- **Client types**: regenerated via `scripts/openapi-typescript.sh` against the updated backend (union gains `"project"`).
- **Palette**: Projects group with the FolderKanban icon between Memories and Skills; clicking a hit jumps straight to the project hub.

## Verification

- Backend: 2 new pytest cases (name/slug hit + href, archived exclusion); full project/search/visibility suites green against a real postgres (docker, cleaned up after)
- `ruff check`/`ruff format` clean; OpenAPI client regenerated
- Web: typecheck, biome clean
- Live screenshot of the palette with a stubbed project hit: Projects group renders correctly