### PR TITLE
fix(web): URL-back vault/project search, rename dashboard Library, next-step hint

### DIFF
--- a/apps/web/src/components/dashboard/resources-card.tsx
+++ b/apps/web/src/components/dashboard/resources-card.tsx
@@ -49,7 +49,7 @@ export function ResourcesCard({
 	return (
 		<Card className="gap-0 pb-0">
 			<CardHeader className="border-b">
-				<CardTitle>Resources</CardTitle>
+				<CardTitle>Library</CardTitle>
 			</CardHeader>
 			<CardContent className="p-0">
 				{statsError ? (
@@ -76,6 +76,18 @@ export function ResourcesCard({
 						)}
 					</div>
 				)}
+				{ready && stats.projects_count === 0 ? (
+					<div className="border-t px-6 py-3 text-xs text-muted-foreground">
+						Next:{" "}
+						<Link
+							to="/projects"
+							className="font-medium text-foreground underline-offset-4 hover:underline"
+						>
+							create your first Project
+						</Link>{" "}
+						to organize reusable skills and credentials for your agents.
+					</div>
+				) : null}
 			</CardContent>
 		</Card>
 	);

--- a/apps/web/src/components/vault/vaults-surface.tsx
+++ b/apps/web/src/components/vault/vaults-surface.tsx
@@ -66,7 +66,12 @@ export function VaultsSurface({
 	navigationScope?: ResourceNavigationScope;
 }) {
 	const $api = useOpenApi();
-	const [search, setSearch] = useState("");
+	// URL-backed like the other lists: open a vault and come back with the
+	// filter text intact.
+	const [search, setSearch] = useQueryState(
+		"q",
+		parseAsString.withDefault("").withOptions({ clearOnDefault: true, history: "replace" }),
+	);
 	const [projectParam, setProjectParam] = useQueryState(
 		"project",
 		parseAsString.withDefault("all").withOptions({ clearOnDefault: true, history: "replace" }),

--- a/apps/web/src/pages/dashboard/projects/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/page.tsx
@@ -3,6 +3,7 @@
 import { keepPreviousData, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import { Plus, Share2 } from "lucide-react";
+import { parseAsString, useQueryState } from "nuqs";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -53,7 +54,12 @@ export default function ProjectsPage() {
 	const [newProjectName, setNewProjectName] = useState("");
 	const [newProjectDescription, setNewProjectDescription] = useState("");
 	const [createOpen, setCreateOpen] = useState(false);
-	const [search, setSearch] = useState("");
+	// URL-backed like the other lists: open a project and come back with the
+	// filter text intact.
+	const [search, setSearch] = useQueryState(
+		"q",
+		parseAsString.withDefault("").withOptions({ clearOnDefault: true, history: "replace" }),
+	);
 
 	const projects = $api.useQuery(
 		"get",


### PR DESCRIPTION
## What

Full user-journey audit follow-up (journeys walked end to end; the rest came back clean):

1. **Filter text survives navigation** — the vaults and projects lists kept their search text in component state, so list → detail → back silently cleared the filter (sessions/connectors/memories/skills were already URL-backed). Both now use the shared nuqs `q` pattern.
2. **Dashboard \"Library\"** — the dashboard card was still titled \"Resources\" after the sidebar group was renamed to Library (#883); now the same word everywhere.
3. **First-agent next step** — after connecting their first agent, a user with zero projects saw no forward path on the dashboard. The Library card now shows a one-line hint linking to create the first Project (only while `projects_count === 0`).

## Verification

- `bun run typecheck`, `bun run lint` clean
- Full OSS Playwright suite 37/37 green
- Browser screenshot of the dashboard state (1 agent, 0 projects): hint and Library title render as intended