### PR TITLE
feat(web): split Library/Integrations nav, converge truncation, e2e in CI, journey archive

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -187,6 +187,25 @@ jobs:
           DEPLOY_CONTRACT_FETCH_MODE: warn
         run: scripts/check-deploy-generated-api.sh
 
+  web-e2e:
+    needs: changes
+    if: >-
+      github.event_name != 'schedule' &&
+      needs.changes.outputs.client == 'true'
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
+    timeout-minutes: 25
+    env:
+      VITE_CLERK_PUBLISHABLE_KEY: pk_test_dummy
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-bun-ci
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - name: Install Chromium for Playwright
+        run: bunx playwright install --with-deps chromium
+      - name: OSS web e2e
+        run: bun run --cwd apps/web e2e
+
   whatsapp-native-e2e:
     needs: changes
     # Keep the required check name stable. A backend-only PR gets a successful

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -905,7 +905,8 @@ test("Console and connected agents use the scoped navigation grammar", async ({ 
 	await page.goto("/");
 	await expectSidebarNavigationGroups(page, [
 		{ label: null, items: ["Overview", "Agents", "Sessions", "Memories"] },
-		{ label: "Library", items: ["Connectors", "Projects", "Skills", "Vaults"] },
+		{ label: "Library", items: ["Projects", "Skills", "Vaults"] },
+		{ label: "Integrations", items: ["Connectors"] },
 	]);
 
 	await page.goto("/agents/agent-smoke-1");

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -4,6 +4,7 @@ import { keepPreviousData } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import { Brain, Key, type LucideIcon, MessageSquare, Settings, Sparkles } from "lucide-react";
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { TruncatedText } from "@/components/truncated-text";
 import {
 	Command,
 	CommandDialog,
@@ -260,8 +261,10 @@ function CommandPalette({
 								>
 									<s.icon className="mt-0.5 size-4 shrink-0" />
 									<div className={COMMAND_RESULT_TEXT_CLASS}>
-										<span className="truncate">{s.label}</span>
-										<span className="truncate text-xs text-muted-foreground">{s.subtitle}</span>
+										<TruncatedText>{s.label}</TruncatedText>
+										<TruncatedText className="text-xs text-muted-foreground">
+											{s.subtitle}
+										</TruncatedText>
 									</div>
 								</CommandItem>
 							))}
@@ -286,11 +289,11 @@ function CommandPalette({
 												>
 													<Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
 													<div className={COMMAND_RESULT_TEXT_CLASS}>
-														<span className="truncate">{hit.title}</span>
+														<TruncatedText>{hit.title}</TruncatedText>
 														{hit.subtitle ? (
-															<span className="truncate text-xs text-muted-foreground">
+															<TruncatedText className="text-xs text-muted-foreground">
 																{hit.subtitle}
-															</span>
+															</TruncatedText>
 														) : null}
 													</div>
 												</CommandItem>

--- a/apps/web/src/components/skills/skill-card.tsx
+++ b/apps/web/src/components/skills/skill-card.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/entity-card";
 import { IconChip } from "@/components/icon-chip";
 import { SendSkillDialog } from "@/components/skills/send-skill-dialog";
+import { TruncatedText } from "@/components/truncated-text";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
@@ -129,7 +130,7 @@ export function SkillCard({
 						<span aria-hidden className="select-none">
 							{sourceLabel.emoji}
 						</span>
-						<span className="truncate">{sourceLabel.name}</span>
+						<TruncatedText>{sourceLabel.name}</TruncatedText>
 					</span>
 				) : null,
 				skill.source_repo ? (

--- a/apps/web/src/components/user-menu.tsx
+++ b/apps/web/src/components/user-menu.tsx
@@ -2,6 +2,7 @@
 
 import { LogOut, Monitor, Moon, Sun } from "lucide-react";
 import { useTheme } from "@/components/theme-provider";
+import { TruncatedText } from "@/components/truncated-text";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
 	DropdownMenuGroup,
@@ -49,10 +50,10 @@ export function UserMenuItems() {
 							<AvatarFallback className="rounded-lg">{user?.fullName?.[0] ?? "U"}</AvatarFallback>
 						</Avatar>
 						<div className="grid flex-1 text-left text-sm leading-tight">
-							<span className="truncate font-medium">{user?.fullName}</span>
-							<span className="truncate text-xs text-muted-foreground">
+							<TruncatedText className="font-medium">{user?.fullName}</TruncatedText>
+							<TruncatedText className="text-xs text-muted-foreground">
 								{user?.primaryEmailAddress?.emailAddress}
-							</span>
+							</TruncatedText>
 						</div>
 					</div>
 				</DropdownMenuLabel>

--- a/apps/web/src/lib/navigation-model.test.ts
+++ b/apps/web/src/lib/navigation-model.test.ts
@@ -30,7 +30,7 @@ function groupShape(
 
 function expectNavigationHeadings(
 	groups: ReadonlyArray<{ label: string | null; items: readonly unknown[] }>,
-	expected = ["Library"],
+	expected = ["Library", "Integrations"],
 ) {
 	expect(groups.filter((group) => group.label !== null).map((group) => group.label)).toEqual(
 		expected,
@@ -54,28 +54,31 @@ describe("sidebar navigation model", () => {
 				],
 			},
 			{
-				id: "resources",
+				id: "library",
 				label: "Library",
 				separated: false,
+				items: [
+					{ id: "projects", label: "Projects" },
+					{ id: "skills", label: "Skills" },
+					{ id: "vaults", label: "Vaults" },
+				],
+			},
+			{
+				id: "integrations",
+				label: "Integrations",
+				separated: true,
 				items: [
 					{ id: "channels", label: "Channels" },
 					{ id: "ai-providers", label: "AI Providers" },
 					{ id: "connectors", label: "Connectors" },
-					{ id: "projects", label: "Projects" },
-					{ id: "skills", label: "Skills" },
-					{ id: "vaults", label: "Vaults" },
 				],
 			},
 		]);
 		expectNavigationHeadings(cloudGroups);
 
 		const ossGroups = consoleNavigationGroups(false);
-		expect(ossGroups[1]?.items.map((item) => item.id)).toEqual([
-			"connectors",
-			"projects",
-			"skills",
-			"vaults",
-		]);
+		expect(ossGroups[1]?.items.map((item) => item.id)).toEqual(["projects", "skills", "vaults"]);
+		expect(ossGroups[2]?.items.map((item) => item.id)).toEqual(["connectors"]);
 		expectNavigationHeadings(ossGroups);
 	});
 
@@ -84,21 +87,21 @@ describe("sidebar navigation model", () => {
 			"overview",
 			"sessions",
 			"memories",
-			"connectors",
 			"projects",
 			"skills",
 			"vaults",
+			"connectors",
 		]);
 		expect(consoleCommandPaletteItems(true).map((item) => item.id)).toEqual([
 			"overview",
 			"sessions",
 			"memories",
-			"channels",
-			"ai-providers",
-			"connectors",
 			"projects",
 			"skills",
 			"vaults",
+			"channels",
+			"ai-providers",
+			"connectors",
 		]);
 	});
 

--- a/apps/web/src/lib/navigation-model.ts
+++ b/apps/web/src/lib/navigation-model.ts
@@ -61,7 +61,7 @@ type ConsoleNavigationItemId =
 	| "channels"
 	| "ai-providers";
 
-type ConsoleNavigationGroupId = "primary" | "resources";
+type ConsoleNavigationGroupId = "primary" | "library" | "integrations";
 
 type ConsoleCommandPaletteMetadata = {
 	subtitle: string;
@@ -220,10 +220,16 @@ const CONSOLE_NAVIGATION_GROUPS = [
 		separated: false,
 	},
 	{
-		id: "resources",
+		id: "library",
 		label: "Library",
-		itemIds: ["channels", "ai-providers", "connectors", "projects", "skills", "vaults"],
+		itemIds: ["projects", "skills", "vaults"],
 		separated: false,
+	},
+	{
+		id: "integrations",
+		label: "Integrations",
+		itemIds: ["channels", "ai-providers", "connectors"],
+		separated: true,
 	},
 ] as const satisfies readonly {
 	id: ConsoleNavigationGroupId;

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -1,0 +1,138 @@
+# User journeys
+
+Living archive of every path a user can take through the web app: the goal,
+the entry points, the steps, what state moves where, and what guards it.
+Update this file whenever a journey changes shape. Historical redesign
+audits live in `docs/plans/`; this document describes the current product.
+
+Severity legend for open gaps: 🔴 blocks · 🟡 friction · ⚪ nitpick.
+
+## 1. First run
+
+- **Goal**: get the first agent running.
+- **Path**: `/` → empty state renders `OnboardingCard` → "Deploy on Clawdi"
+  (hosted) or "Connect an agent on your machine" → `AddAgentDialog` →
+  agent appears in the rail and on `/`.
+- **State**: `ossIsEmptyState` gates the card; the rail hydrates from
+  `/v1/agents` (10s polling, `refetchIntervalInBackground: false`).
+- **Next-step hint**: with ≥1 agent and `projects_count === 0`, the
+  dashboard Library card shows a one-line "create your first Project" link.
+- **Guarded by**: e2e `query-refresh-no-flicker`, onboarding screenshots in
+  the sidebar suite.
+
+## 2. Find something (session / memory / skill / vault / project)
+
+- **Path A (palette)**: Cmd/Ctrl+K → type → grouped hits
+  (Sessions, Memories, Projects, Skills, Vaults) → Enter jumps to the
+  hit's href. Backed by `/v1/search`; each searcher enforces the same
+  scope rules as its direct route.
+- **Path B (lists)**: every top-level list keeps its view in the URL via
+  nuqs (`q`, `category`, `page`, `pageSize`, filters) — back/forward and
+  deep links restore the exact list state.
+- **Guards**: `sidebar-runtime-smoke` navigation grammar tests;
+  backend search tests; `pages-smoke`.
+
+## 3. Read a session
+
+- **Path**: Sessions list (feed default; table one toggle away, in URL) →
+  card → detail. Newest-first by default; direction toggle persists in
+  localStorage (hydration-safe). Long sessions paginate messages.
+- **Cross-links**: agent identity links back into the agent scope.
+- **Guards**: `sessions` page e2e, session detail states in
+  `sidebar-runtime-smoke`.
+
+## 4. Share a session publicly
+
+- **Path**: session detail → Share → visibility toggle → copy link
+  (markdown/JSON variants too). Recipient: public link renders the shared
+  page directly; a private URL hit anonymously renders `SignInToView`
+  (sign-in returns to the same URL, then access-check again).
+- **Guards**: `share-project-dialog-lifecycle`, public-share page tests.
+
+## 5. Create and wire a Project
+
+- **Path**: Library → Projects → New project → lands on the project hub
+  (toast offers an "Open project" deep link when created from an agent
+  context). Hub tabs: Overview / Skills / Vaults / Agents / Access.
+- **Wiring**: add skills, attach vaults, link to agents, invite people —
+  all from the hub. The `?from=` param preserves the return path.
+- **Guards**: `project-detail.pw.ts` end to end.
+
+## 6. Install or add a skill
+
+- **Path**: Library → Skills → pick a Project first (fail-closed), then
+  Add/Import; or an agent Workspace tab → Install skill. Legacy key-only
+  URLs canonicalize to explicit-project URLs.
+- **Guards**: skills flows in `sidebar-runtime-smoke`, `project-detail`.
+
+## 7. Manage API keys (vault)
+
+- **Path**: Library → Vaults → create → add keys (masked on write,
+  copy/move/batch supported) → attach to Projects. "Share keys" opens the
+  guided two-hop chain (attach → invite) with preselection.
+- **Guards**: `vault-detail-identity`, vault flows in the sidebar suite.
+
+## 8. Capture and recall a memory
+
+- **Path**: Library → Memories (or an agent's Memories tab) → New memory →
+  save; search + category filter; card or detail delete (ConfirmAction).
+- **Note**: memories are account-wide; agent scopes show the shared pool.
+- **Guards**: memories nested-navigation e2e.
+
+## 9. Manage agents
+
+- **Rail**: drag/keyboard reorder (optimistic, persists via
+  `/v1/agents/order`), corner source badges (cloud/legacy), active marker.
+- **Detail**: overview (status, sessions slot, resource summaries),
+  sections (Sessions, Workspace Projects/Skills/Vaults, Shared
+  Memories/Connectors), settings (rename with unsaved-change guard).
+- **Health**: sync/daemon badge opens a remediation dialog with commands.
+- **Guards**: rail interaction tests, overview hierarchy tests.
+
+## 10. Invite people / accept invitations
+
+- **Path**: project → share/invite → invitee gets a Notification Center
+  item → accept lands in their Library; toasts confirm both directions.
+- **Guards**: `share-project-dialog-lifecycle`, notification-center e2e.
+
+## 11. Settings
+
+- **Path**: sidebar user menu / palette "Settings" → dialog sections
+  (general, profile, API keys, providers). URL-driven via `?settings=`.
+  API-key secrets shown once, optimistic revokes reconciled.
+- **Guards**: `api-keys-settings.pw.ts`.
+
+## 12. Connectors / channels
+
+- **Path**: Integrations → Connectors → catalog → connect (OAuth returns
+  to the same page; state params clean themselves up). Hosted adds
+  Channels/AI Providers.
+- **Guards**: connector nested-navigation e2e; hosted channel suites.
+
+## 13. Error and dead-end recovery
+
+- Every list/detail has loading → content, error → `ApiErrorPanel` with
+  retry, not-found → `DetailNotFound`, all with a visible exit (back link
+  on every viewport for dead ends, breadcrumb otherwise).
+- URL canonicalizers only fire while their page is still the navigation
+  target (`useCommittedRouteIsLatestTarget`).
+
+## 14. Mobile
+
+- Rail collapses into a drawer; the same nav grammar applies. Touch
+  targets on icon buttons bump to 44px under `pointer-coarse`.
+- **Guards**: 320px variants across the sidebar suite.
+
+## Known gaps
+
+- 🔴 **Hosted e2e suite drift** (`playwright.hosted.config.ts`,
+  `hosted-smoke.pw.ts`): as of 2026-08-07 it runs 89 pass / 39 fail.
+  The failures cluster around deploy-acceptance navigation, wallet/plan
+  price copy, channel-pairing semantics, and projection-state wording —
+  i.e. the hosted surface evolved faster than the suite. Needs a
+  dedicated repair pass before it can join CI.
+- 🟡 Sessions search has no "N results" line (the pagination total is the
+  only count).
+- ⚪ The OSS e2e suite flakes on cold dev-server first paint under load;
+  mitigated (single worker, route warm-up in `global-setup.ts`, 10s
+  expect default) but not mathematically eliminated.


### PR DESCRIPTION
## What

1. **Nav split** — the console Library group mixed account assets with integrations. Now **Library** = Projects/Skills/Vaults and **Integrations** = Channels/AI Providers/Connectors (separated group). Cloud-gated items still drop out in OSS. Unit + e2e assertions updated.
2. **Truncation sweep** — `TruncatedText` (from #882) adopted in the command palette rows, user menu, and skill card source label — the remaining spots where user-meaningful names could clip invisibly.
3. **OSS e2e joins CI** — new `web-e2e` job in `client-ci.yml` (same `client` path filter; installs Chromium, boots the dev server itself). The suite is green today; this keeps it that way.
4. **Journey archive** — `docs/user-journeys.md`: every user path with goal / entry / steps / state / guarding tests, plus a Known-gaps section (see below).

## Honest known gap (deliberately not fixed here)

The **hosted e2e suite** (`playwright.hosted.config.ts`, ~14k lines, 124 tests) currently runs **89 pass / 39 fail**. The failures cluster around deploy-acceptance navigation, wallet/plan price copy, channel-pairing semantics, and projection-state wording — the hosted surface evolved faster than the suite. Repairing it means re-verifying each flow against intended product behavior, which is a dedicated pass, not a sweep item. The journey archive records this so it can't silently rot further.

## Verification

- `bun run typecheck`, `bun run lint`, 960 unit tests pass
- Full OSS Playwright suite 37/37 green locally