### PR TITLE
ci: fix web-e2e Playwright browser version mismatch

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -202,6 +202,11 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
       - name: Install Chromium for Playwright
+        # Run from apps/web so bunx resolves the workspace-pinned playwright.
+        # At the repo root the bin is absent and bunx silently downloads the
+        # latest release, installing browsers the pinned @playwright/test
+        # version then can't find.
+        working-directory: apps/web
         run: bunx playwright install --with-deps chromium
       - name: OSS web e2e
         run: bun run --cwd apps/web e2e


### PR DESCRIPTION
web-e2e has been red on main since #888 landed: the "Install Chromium for Playwright" step runs `bunx playwright install` at the repo root, where the playwright bin is not linked (it is an apps/web dependency). bunx silently downloads the latest playwright release and installs its browser builds, while `bun run --cwd apps/web e2e` uses the workspace-pinned @playwright/test (1.61.1), which then fails with `Executable doesn't exist … chromium_headless_shell-1228` on every test.

Fix: run the install step from `apps/web` so bunx resolves the workspace-pinned playwright and installs the matching browser build.

Verified locally: `bunx playwright --version` from apps/web resolves 1.61.1; from the repo root it downloads a fresh copy ("Resolved, downloaded and extracted" in the failed CI log at run 31174604264).

Unblocks #890 (its web-e2e failure is this infra issue, all other checks green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)