### PR TITLE
v2 P0.5: escalate stuck deployment transitions with operation cancellation

### DIFF
--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -90,6 +90,7 @@ export function AgentHome({
 		isLoading,
 		isFetching,
 		deploymentTransitionTimedOut,
+		deploymentTransitionEscalated,
 		error,
 		refetch,
 	} = useAgentDeployment(environmentId, deploymentSelector);
@@ -286,6 +287,7 @@ export function AgentHome({
 				routeSearch={deploymentRouteSearch}
 				onDeleteAccepted={() => router.navigate({ href: "/agents", replace: true })}
 				deploymentTransitionTimedOut={deploymentTransitionTimedOut}
+				deploymentTransitionEscalated={deploymentTransitionEscalated}
 				isCheckingDeployment={manualChecking}
 				onCheckDeploymentAgain={() => void handleCheckAgain()}
 			/>

--- a/apps/web/src/hosted/agents/deployment-cancel-action.tsx
+++ b/apps/web/src/hosted/agents/deployment-cancel-action.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { CircleStop } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { useCancelDeploymentOperation } from "@/hosted/agents/deployment-hooks";
+import type { HostedDeployment } from "@/hosted/billing/contracts";
+import { canCancelOperation } from "@/hosted/deployment-status";
+
+/**
+ * Escalation action for a deployment transition that stayed stuck well past
+ * the convergence window: request cancellation of the in-flight accepted
+ * operation. Only rendered where the backend would accept the cancel request
+ * (`canCancelOperation` mirrors the cancel acceptance contract).
+ */
+export function DeploymentCancelAction({ deployment }: { deployment: HostedDeployment }) {
+	const operation = deployment.accepted_operation;
+	const cancel = useCancelDeploymentOperation();
+	if (!operation || !canCancelOperation(operation)) return null;
+
+	return (
+		<Button
+			type="button"
+			data-hosted="true"
+			variant="outline"
+			size="sm"
+			disabled={cancel.isPending}
+			onClick={() => cancel.mutate({ operationName: operation.name })}
+		>
+			{cancel.isPending ? <Spinner className="size-3.5" /> : <CircleStop className="size-3.5" />}
+			Cancel this change
+		</Button>
+	);
+}

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -97,6 +97,7 @@ describe("deployment failure status rendering", () => {
 				deployment,
 				failure,
 				deploymentTransitionTimedOut: false,
+				deploymentTransitionEscalated: false,
 			}),
 		);
 
@@ -117,6 +118,7 @@ describe("deployment failure status rendering", () => {
 				deployment: hostedDeploymentFixture({ status: "failed" }),
 				failure: null,
 				deploymentTransitionTimedOut: false,
+				deploymentTransitionEscalated: false,
 			}),
 		);
 
@@ -155,6 +157,7 @@ describe("deployment failure status rendering", () => {
 				deployment,
 				failure,
 				deploymentTransitionTimedOut: false,
+				deploymentTransitionEscalated: false,
 			}),
 		);
 
@@ -181,6 +184,7 @@ describe("deployment failure status rendering", () => {
 				deployment,
 				failure,
 				deploymentTransitionTimedOut: false,
+				deploymentTransitionEscalated: false,
 			}),
 		);
 
@@ -212,6 +216,7 @@ describe("deployment failure status rendering", () => {
 					deployment: hostedDeploymentFixture({ status: fixture.status }),
 					failure: null,
 					deploymentTransitionTimedOut: false,
+					deploymentTransitionEscalated: false,
 				}),
 			);
 			expect(markup).toContain(fixture.copy);
@@ -290,6 +295,7 @@ describe("deployment transition timeout rendering", () => {
 						runtime: fixture.runtime,
 					}),
 					deploymentTransitionTimedOut: false,
+					deploymentTransitionEscalated: false,
 					isCheckingDeployment: false,
 					onCheckDeploymentAgain: () => undefined,
 				}),
@@ -331,6 +337,7 @@ describe("deployment transition timeout rendering", () => {
 			createElement(initialDeploymentPage, {
 				deployment: hostedDeploymentFixture({ status: "starting" }),
 				deploymentTransitionTimedOut: true,
+				deploymentTransitionEscalated: false,
 				isCheckingDeployment: false,
 				onCheckDeploymentAgain: () => undefined,
 			}),
@@ -454,6 +461,60 @@ describe("deployment transition timeout rendering", () => {
 		expect(observer.getCurrentResult().data).toBe("fresh deployment");
 		unsubscribe();
 		client.clear();
+	});
+
+	test("escalates a stuck transition on every timed-out surface with a cancel action", () => {
+		const detailSource = readFileSync(
+			new URL("./hosted-agent-detail.tsx", import.meta.url),
+			"utf8",
+		);
+		const overviewStatusSource = detailSource.slice(
+			detailSource.indexOf("export function OverviewComputeStatus"),
+			detailSource.indexOf("export function OverviewComputeSummary"),
+		);
+		const initialPageSource = detailSource.slice(
+			detailSource.indexOf("export function InitialDeploymentPage"),
+			detailSource.indexOf("function OverviewTab"),
+		);
+		const consoleTabSource = detailSource.slice(
+			detailSource.indexOf("function ConsoleTab"),
+			detailSource.indexOf("function FilesTab"),
+		);
+
+		for (const source of [overviewStatusSource, initialPageSource, consoleTabSource]) {
+			expect(source).toContain("appears to be stuck");
+			expect(source).toContain("<DeploymentCancelAction");
+			expect(source).toContain("taking longer than expected");
+		}
+		expect(initialPageSource).toContain("Setup appears to be stuck");
+	});
+
+	test("gates the cancel action behind the backend cancel acceptance contract", () => {
+		const actionSource = readFileSync(
+			new URL("./deployment-cancel-action.tsx", import.meta.url),
+			"utf8",
+		);
+		expect(actionSource).toContain("canCancelOperation(operation)");
+		expect(actionSource).toContain("Cancel this change");
+		expect(actionSource).toContain('data-hosted="true"');
+		const statusSource = readFileSync(new URL("../deployment-status.ts", import.meta.url), "utf8");
+		expect(statusSource).toContain('verb !== "migrate_image"');
+		expect(statusSource).toContain('verb !== "rollback_image"');
+	});
+
+	test("keeps the escalation honest as a stuck state, not a warning badge for running compute", () => {
+		if (!overviewComputeStatus) throw new Error("agent detail was not loaded");
+		const markup = renderToStaticMarkup(
+			createElement(overviewComputeStatus, {
+				deployment: hostedDeploymentFixture({ status: "running" }),
+				failure: null,
+				deploymentTransitionTimedOut: false,
+				deploymentTransitionEscalated: false,
+			}),
+		);
+
+		expect(markup).not.toContain("appears to be stuck");
+		expect(markup).not.toContain("<button");
 	});
 });
 
@@ -622,9 +683,10 @@ describe("deployment mutation settlement", () => {
 			/onSettled: \(\) => invalidateDeploymentSnapshots\(qc\)/g,
 		);
 
-		// Declarative lifecycle, access reset, delete, and settings updates all reconcile even
-		// when the request rejects or times out.
-		expect(settlementInvalidations).toHaveLength(4);
+		// Declarative lifecycle, access reset, delete, settings updates, and
+		// operation cancellation all reconcile even when the request rejects
+		// or times out.
+		expect(settlementInvalidations).toHaveLength(5);
 	});
 
 	test("describes accepted deletion as background cleanup and replace-navigates detail", () => {

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -19,7 +19,10 @@ import {
 	idempotencyFingerprint,
 	newIdempotencyKey,
 } from "@/hosted/billing/idempotency";
-import { deploymentMutationErrorMessage } from "@/hosted/deployment-failure";
+import {
+	deploymentMutationErrorMessage,
+	operationCancelErrorMessage,
+} from "@/hosted/deployment-failure";
 import type { DeploymentOperationVerb } from "@/hosted/deployment-status";
 import { resolveAgentDeployment } from "@/hosted/hosted-agent-resolution";
 import { deploymentRuntime, runtimeEnvironmentId } from "@/hosted/runtimes";
@@ -154,6 +157,7 @@ export function useAgentDeployment(environmentId: string, deploymentSelector?: s
 		isFetching: inventory.isFetching,
 		deploymentTransition,
 		deploymentTransitionTimedOut: deploymentTransition?.kind === "timed_out",
+		deploymentTransitionEscalated: deploymentTransition?.kind === "escalated",
 		deploymentFailure,
 		error: inventory.error,
 		refetch: inventory.refetch,
@@ -271,6 +275,30 @@ export function useUpdateDeployment() {
 			if (toastDeploymentConflict(error)) return;
 			toast.error("Couldn't update agent settings", {
 				description: deploymentMutationErrorMessage(error),
+			});
+		},
+		onSettled: () => invalidateDeploymentSnapshots(qc),
+	});
+}
+
+/** Request cancellation of an in-flight accepted deployment operation. */
+export function useCancelDeploymentOperation() {
+	const client = useBillingClient();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (vars: { operationName: string }) =>
+			runStableDeploymentIntent("deployment-cancel", vars, (idempotencyKey) =>
+				client.cancelDeploymentOperation(vars.operationName, idempotencyKey),
+			),
+		onSuccess: () => {
+			toast.message("Cancellation requested", {
+				description: "The change will be stopped. This page updates automatically.",
+			});
+		},
+		onError: (error) => {
+			if (toastDeploymentConflict(error)) return;
+			toast.error("Couldn't cancel this change", {
+				description: operationCancelErrorMessage(error),
 			});
 		},
 		onSettled: () => invalidateDeploymentSnapshots(qc),

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -107,6 +107,7 @@ import {
 } from "@/components/unsaved-navigation-state";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { isCloudEnvId } from "@/hosted/agent-route";
+import { DeploymentCancelAction } from "@/hosted/agents/deployment-cancel-action";
 import { HostedDeploymentDeleteAction } from "@/hosted/agents/deployment-delete-action";
 import {
 	useDeploymentLifecycle,
@@ -440,6 +441,7 @@ export function HostedAgentDetail({
 	routeSearch,
 	onDeleteAccepted,
 	deploymentTransitionTimedOut,
+	deploymentTransitionEscalated,
 	isCheckingDeployment,
 	onCheckDeploymentAgain,
 }: {
@@ -450,6 +452,7 @@ export function HostedAgentDetail({
 	routeSearch: AgentRouteSearch;
 	onDeleteAccepted: (deploymentId: string) => void;
 	deploymentTransitionTimedOut: boolean;
+	deploymentTransitionEscalated: boolean;
 	isCheckingDeployment: boolean;
 	onCheckDeploymentAgain: () => void;
 }) {
@@ -588,6 +591,7 @@ export function HostedAgentDetail({
 						<InitialDeploymentPage
 							deployment={deployment}
 							deploymentTransitionTimedOut={deploymentTransitionTimedOut}
+							deploymentTransitionEscalated={deploymentTransitionEscalated}
 							isCheckingDeployment={isCheckingDeployment}
 							onCheckDeploymentAgain={onCheckDeploymentAgain}
 						/>
@@ -607,6 +611,7 @@ export function HostedAgentDetail({
 							onRetrySessions={() => sessions.refetch()}
 							sessionLink={(session) => scopedSessionLink(session.id)}
 							deploymentTransitionTimedOut={deploymentTransitionTimedOut}
+							deploymentTransitionEscalated={deploymentTransitionEscalated}
 						/>
 					) : null}
 					{deploymentStatus.known && activeTab === "console" ? (
@@ -615,6 +620,7 @@ export function HostedAgentDetail({
 							runtime={runtime}
 							terminalHref={terminalHref}
 							deploymentTransitionTimedOut={deploymentTransitionTimedOut}
+							deploymentTransitionEscalated={deploymentTransitionEscalated}
 							isCheckingDeployment={isCheckingDeployment}
 							onCheckDeploymentAgain={onCheckDeploymentAgain}
 						/>
@@ -851,10 +857,12 @@ export function OverviewComputeStatus({
 	deployment,
 	failure,
 	deploymentTransitionTimedOut,
+	deploymentTransitionEscalated,
 }: {
 	deployment: HostedDeployment;
 	failure: DeploymentFailurePresentation | null;
 	deploymentTransitionTimedOut: boolean;
+	deploymentTransitionEscalated: boolean;
 }) {
 	const status = deploymentStatusFromResource(deployment.resource.status);
 	return (
@@ -872,6 +880,13 @@ export function OverviewComputeStatus({
 				<p className="text-destructive-muted-foreground" role="status">
 					The last compute change did not complete.
 				</p>
+			) : deploymentTransitionEscalated ? (
+				<div className="flex flex-wrap items-center justify-between gap-2" role="status">
+					<p className="text-warning-muted-foreground">
+						This change appears to be stuck. You can cancel it and try again.
+					</p>
+					<DeploymentCancelAction deployment={deployment} />
+				</div>
 			) : status.kind === "restarting" ? (
 				<p className="inline-flex items-center gap-2 text-muted-foreground" role="status">
 					<Spinner className="size-3.5" /> Restarting
@@ -949,11 +964,13 @@ export function OverviewComputeSummary({
 export function InitialDeploymentPage({
 	deployment,
 	deploymentTransitionTimedOut,
+	deploymentTransitionEscalated,
 	isCheckingDeployment,
 	onCheckDeploymentAgain,
 }: {
 	deployment: HostedDeployment;
 	deploymentTransitionTimedOut: boolean;
+	deploymentTransitionEscalated: boolean;
 	isCheckingDeployment: boolean;
 	onCheckDeploymentAgain: () => void;
 }) {
@@ -975,25 +992,32 @@ export function InitialDeploymentPage({
 		<DetailPanel
 			className={cn(
 				"p-6 md:p-8",
-				deploymentTransitionTimedOut && "border-warning/30 bg-warning-muted",
+				(deploymentTransitionTimedOut || deploymentTransitionEscalated) &&
+					"border-warning/30 bg-warning-muted",
 			)}
 		>
 			<div
 				data-testid="hosted-initial-deployment-panel"
-				role={deploymentTransitionTimedOut ? "alert" : undefined}
+				role={deploymentTransitionTimedOut || deploymentTransitionEscalated ? "alert" : undefined}
 				className="space-y-6"
 			>
 				<div>
 					<h2 className="flex items-center gap-2 text-lg font-semibold">
-						{deploymentTransitionTimedOut ? <AlertCircle className="size-5" /> : null}
-						{deploymentTransitionTimedOut
-							? "Setup is taking longer than expected"
-							: `Setting up ${runtimeLabel}`}
+						{deploymentTransitionTimedOut || deploymentTransitionEscalated ? (
+							<AlertCircle className="size-5" />
+						) : null}
+						{deploymentTransitionEscalated
+							? "Setup appears to be stuck"
+							: deploymentTransitionTimedOut
+								? "Setup is taking longer than expected"
+								: `Setting up ${runtimeLabel}`}
 					</h2>
 					<p className="mt-1 text-sm text-muted-foreground">
-						{deploymentTransitionTimedOut
-							? "Your agent may still be starting. We’ll keep checking automatically."
-							: "This page updates automatically as setup progresses."}
+						{deploymentTransitionEscalated
+							? "We’ll keep checking automatically. If you want, cancel this setup and try again."
+							: deploymentTransitionTimedOut
+								? "Your agent may still be starting. We’ll keep checking automatically."
+								: "This page updates automatically as setup progresses."}
 					</p>
 				</div>
 				<div>
@@ -1004,7 +1028,9 @@ export function InitialDeploymentPage({
 							aria-live="polite"
 							aria-atomic="true"
 						>
-							{!deploymentTransitionTimedOut && status.kind !== "running" ? (
+							{!deploymentTransitionTimedOut &&
+							!deploymentTransitionEscalated &&
+							status.kind !== "running" ? (
 								<span className="inline-flex" aria-hidden="true">
 									<Spinner className="size-3.5 shrink-0 text-primary" />
 								</span>
@@ -1058,16 +1084,21 @@ export function InitialDeploymentPage({
 						})}
 					</ol>
 				</div>
-				{deploymentTransitionTimedOut ? (
-					<Button
-						type="button"
-						variant="outline"
-						size="sm"
-						disabled={isCheckingDeployment}
-						onClick={onCheckDeploymentAgain}
-					>
-						{isCheckingDeployment ? <Spinner className="size-3.5" /> : <RefreshCw />}Check again
-					</Button>
+				{deploymentTransitionTimedOut || deploymentTransitionEscalated ? (
+					<div className="flex flex-wrap gap-2">
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							disabled={isCheckingDeployment}
+							onClick={onCheckDeploymentAgain}
+						>
+							{isCheckingDeployment ? <Spinner className="size-3.5" /> : <RefreshCw />}Check again
+						</Button>
+						{deploymentTransitionEscalated ? (
+							<DeploymentCancelAction deployment={deployment} />
+						) : null}
+					</div>
 				) : null}
 			</div>
 		</DetailPanel>
@@ -1087,6 +1118,7 @@ function OverviewTab({
 	onRetrySessions,
 	sessionLink,
 	deploymentTransitionTimedOut,
+	deploymentTransitionEscalated,
 }: {
 	agentId: string;
 	routeSearch: AgentRouteSearch;
@@ -1103,6 +1135,7 @@ function OverviewTab({
 		params: { id: string; sessionId: string };
 	};
 	deploymentTransitionTimedOut: boolean;
+	deploymentTransitionEscalated: boolean;
 }) {
 	const spec = deployment.resource.spec;
 	const primaryModel = spec.runtime_configuration.primary_model;
@@ -1228,6 +1261,7 @@ function OverviewTab({
 										deployment={deployment}
 										failure={deploymentFailure}
 										deploymentTransitionTimedOut={deploymentTransitionTimedOut}
+										deploymentTransitionEscalated={deploymentTransitionEscalated}
 									/>
 								</div>
 							)}
@@ -1325,6 +1359,7 @@ function ConsoleTab({
 	runtime,
 	terminalHref,
 	deploymentTransitionTimedOut,
+	deploymentTransitionEscalated,
 	isCheckingDeployment,
 	onCheckDeploymentAgain,
 }: {
@@ -1332,6 +1367,7 @@ function ConsoleTab({
 	runtime: Runtime;
 	terminalHref: string;
 	deploymentTransitionTimedOut: boolean;
+	deploymentTransitionEscalated: boolean;
 	isCheckingDeployment: boolean;
 	onCheckDeploymentAgain: () => void;
 }) {
@@ -1350,37 +1386,48 @@ function ConsoleTab({
 	if (!isRunning) {
 		return (
 			<EmptyState
-				icon={deploymentTransitionTimedOut ? AlertCircle : MonitorPlay}
+				icon={
+					deploymentTransitionTimedOut || deploymentTransitionEscalated ? AlertCircle : MonitorPlay
+				}
 				title={
-					deploymentTransitionTimedOut
-						? "Your agent is taking longer than expected"
-						: isStarting
-							? startingTitle()
-							: "Agent is not running"
+					deploymentTransitionEscalated
+						? "Your agent’s setup appears to be stuck"
+						: deploymentTransitionTimedOut
+							? "Your agent is taking longer than expected"
+							: isStarting
+								? startingTitle()
+								: "Agent is not running"
 				}
 				description={
-					deploymentTransitionTimedOut
-						? "The latest status still shows this change in progress after five minutes. It may still finish. We’ll keep checking automatically once a minute while you’re here, or you can check again now."
-						: isStarting
-							? `The live ${browserUiLabel} opens here once your agent is running. This page updates automatically.`
-							: `Start the agent to open the live ${browserUiLabel}. Current status: ${deploymentStatusLabel(status).toLowerCase()}.`
+					deploymentTransitionEscalated
+						? "The latest status still shows this change in progress after fifteen minutes. We’ll keep checking automatically once a minute while you’re here, or you can cancel the change and try again."
+						: deploymentTransitionTimedOut
+							? "The latest status still shows this change in progress after five minutes. It may still finish. We’ll keep checking automatically once a minute while you’re here, or you can check again now."
+							: isStarting
+								? `The live ${browserUiLabel} opens here once your agent is running. This page updates automatically.`
+								: `Start the agent to open the live ${browserUiLabel}. Current status: ${deploymentStatusLabel(status).toLowerCase()}.`
 				}
 				action={
-					deploymentTransitionTimedOut ? (
-						<Button
-							type="button"
-							variant="outline"
-							size="sm"
-							disabled={isCheckingDeployment}
-							onClick={onCheckDeploymentAgain}
-						>
-							{isCheckingDeployment ? (
-								<Spinner className="size-3.5" />
-							) : (
-								<RefreshCw className="size-3.5" />
-							)}
-							Check again
-						</Button>
+					deploymentTransitionTimedOut || deploymentTransitionEscalated ? (
+						<div className="flex flex-wrap justify-center gap-2">
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								disabled={isCheckingDeployment}
+								onClick={onCheckDeploymentAgain}
+							>
+								{isCheckingDeployment ? (
+									<Spinner className="size-3.5" />
+								) : (
+									<RefreshCw className="size-3.5" />
+								)}
+								Check again
+							</Button>
+							{deploymentTransitionEscalated ? (
+								<DeploymentCancelAction deployment={deployment} />
+							) : null}
+						</div>
 					) : canStartDeployment(status) ? (
 						<StartComputeAction deployment={deployment} />
 					) : null

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -4,7 +4,6 @@ import {
 	type DeployPaths,
 	extractApiDetail,
 	projectHostedDeployRequest,
-	unwrapDeploymentEventStreamSnapshotHandoff,
 	unwrapDeploymentList,
 } from "@clawdi/shared/api";
 import createClient from "openapi-fetch";
@@ -27,7 +26,6 @@ import type {
 	DeploymentUpdateRequest,
 	HostedDeployment,
 	HostedDeployRequestStatus,
-	HostedEventStreamSnapshotHandoff,
 	HostedWorkspaceSkillInstallRequest,
 	HostedWorkspaceSkillListResponse,
 	HostedWorkspaceSkillMutationResponse,
@@ -78,6 +76,36 @@ type MutationHeaders = {
 type WorkspaceSkillMutation =
 	| { action: "install"; request: HostedWorkspaceSkillInstallRequest }
 	| { action: "uninstall"; skillKey: string };
+
+/**
+ * The generated deploy-api client predates the operation-cancel endpoint
+ * (`/v2/operations/{operation_id}:cancel` in the hosted backend OpenAPI). The
+ * path is hand-typed here in the generated `post` style until the client is
+ * regenerated against that contract; the empty response body matches
+ * `CancelOperationResponse` in the backend.
+ */
+type OperationCancelPost = {
+	POST: (
+		path: "/v2/operations/{operation_id}:cancel",
+		init: {
+			params: { path: { operation_id: string }; header: { "Idempotency-Key": string } };
+			body?: never;
+		},
+	) => Promise<DeployResult<Record<string, never>>>;
+};
+
+function postOperationCancel(
+	api: ReturnType<typeof createClient<DeployPaths>>,
+	operationId: string,
+	idempotencyKey: string,
+): Promise<DeployResult<Record<string, never>>> {
+	return (api as unknown as OperationCancelPost).POST("/v2/operations/{operation_id}:cancel", {
+		params: {
+			path: { operation_id: operationId },
+			header: { "Idempotency-Key": idempotencyKey },
+		},
+	});
+}
 
 function fetchWithTimeout(request: Request, init?: RequestInit): Promise<Response> {
 	const caller = init?.signal ?? request.signal;
@@ -633,14 +661,6 @@ export function createBillingClient(
 
 		listDeployments: async (): Promise<HostedDeployment[]> =>
 			unwrapDeploymentList(unwrapDeploy(await api.GET("/v2/deployments"))),
-		listEventStreamHandoff: async (): Promise<HostedEventStreamSnapshotHandoff> =>
-			unwrapDeploymentEventStreamSnapshotHandoff(
-				unwrapDeploy(
-					await api.GET("/v2/deployments", {
-						params: { query: { eventStreamHandoff: true } },
-					}),
-				),
-			),
 		getDeployment,
 		waitForDeploymentRequest,
 		createDeployment: async (
@@ -703,6 +723,11 @@ export function createBillingClient(
 					body,
 				}),
 			),
+		cancelDeploymentOperation: async (operationName: string, idempotencyKey: string) => {
+			unwrapDeploy(
+				await postOperationCancel(api, operationIdFromName(operationName), idempotencyKey),
+			);
+		},
 		deleteDeployment,
 	};
 }

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -77,36 +77,6 @@ type WorkspaceSkillMutation =
 	| { action: "install"; request: HostedWorkspaceSkillInstallRequest }
 	| { action: "uninstall"; skillKey: string };
 
-/**
- * The generated deploy-api client predates the operation-cancel endpoint
- * (`/v2/operations/{operation_id}:cancel` in the hosted backend OpenAPI). The
- * path is hand-typed here in the generated `post` style until the client is
- * regenerated against that contract; the empty response body matches
- * `CancelOperationResponse` in the backend.
- */
-type OperationCancelPost = {
-	POST: (
-		path: "/v2/operations/{operation_id}:cancel",
-		init: {
-			params: { path: { operation_id: string }; header: { "Idempotency-Key": string } };
-			body?: never;
-		},
-	) => Promise<DeployResult<Record<string, never>>>;
-};
-
-function postOperationCancel(
-	api: ReturnType<typeof createClient<DeployPaths>>,
-	operationId: string,
-	idempotencyKey: string,
-): Promise<DeployResult<Record<string, never>>> {
-	return (api as unknown as OperationCancelPost).POST("/v2/operations/{operation_id}:cancel", {
-		params: {
-			path: { operation_id: operationId },
-			header: { "Idempotency-Key": idempotencyKey },
-		},
-	});
-}
-
 function fetchWithTimeout(request: Request, init?: RequestInit): Promise<Response> {
 	const caller = init?.signal ?? request.signal;
 	const controller = new AbortController();
@@ -725,7 +695,12 @@ export function createBillingClient(
 			),
 		cancelDeploymentOperation: async (operationName: string, idempotencyKey: string) => {
 			unwrapDeploy(
-				await postOperationCancel(api, operationIdFromName(operationName), idempotencyKey),
+				await api.POST("/v2/operations/{operation_id}:cancel", {
+					params: {
+						path: { operation_id: operationIdFromName(operationName) },
+						header: { "Idempotency-Key": idempotencyKey },
+					},
+				}),
 			);
 		},
 		deleteDeployment,

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -326,7 +326,7 @@ export function useUsage(
 
 const BILLING_RECOVERY_POLL_INTERVAL_MS = 30_000;
 
-/** Foreground polling is a bridge until deployment SSE is wired into this client. */
+/** Foreground polling is a bridge for live updates; no background polling. */
 export const HOSTED_DEPLOYMENTS_REFRESH_POLICY = {
 	refetchIntervalInBackground: false,
 	refetchOnWindowFocus: true,

--- a/apps/web/src/hosted/deployment-failure.test.ts
+++ b/apps/web/src/hosted/deployment-failure.test.ts
@@ -6,6 +6,7 @@ import {
 	deploymentFailureProjection,
 	deploymentFailureReason,
 	deploymentMutationErrorMessage,
+	operationCancelErrorMessage,
 } from "@/hosted/deployment-failure";
 import type { DeploymentOperationVerb } from "@/hosted/deployment-status";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
@@ -390,5 +391,99 @@ describe("deploymentMutationErrorMessage", () => {
 				new BillingApiError(403, "The Compute Basic free slot allows only one active deployment."),
 			),
 		).toBe("Your Clawdi account can’t change this agent. Ask the agent owner to update it.");
+	});
+});
+
+describe("cancelled operation presentation", () => {
+	function cancelledOperation(verb: DeploymentOperationVerb): DeploymentOperation {
+		return {
+			...failedOperation(verb),
+			name: `operations/${verb}-cancelled`,
+			error: {
+				code: 1,
+				message: "Operation was cancelled",
+				details: [
+					{
+						"@type": "type.googleapis.com/clawdi.v2.LifecycleProblemDetails",
+						type: "https://api.clawdi.ai/problems/operation-cancelled",
+						title: "Deployment operation was cancelled",
+						status: 409,
+						detail: "Cancellation committed a compensating desired-state generation.",
+						code: "operation_cancelled",
+						retryable: false,
+						conditionReason: "OperationCancelled",
+						conditionMessage: "Cancellation committed a compensating desired-state generation.",
+						observedGeneration: 2,
+					},
+				],
+			},
+		};
+	}
+
+	test("presents a user-cancelled delete as cancelled, not failed, with no retry", () => {
+		const presentation = deploymentFailurePresentation(
+			hostedDeploymentFixture({
+				status: "running",
+				acceptedOperation: cancelledOperation("delete"),
+			}),
+		);
+
+		expect(presentation).toMatchObject({
+			title: "Agent deletion cancelled",
+			status: { kind: "cancelled", label: "Cancelled", tone: "neutral" },
+			remediation: { kind: "none", label: null },
+		});
+		expect(presentation?.description).toContain("was stopped before it completed");
+	});
+
+	test("labels every cancelled operation verb without inventing a retry", () => {
+		for (const verb of ["create", "start", "restart", "update", "plan_change"] as const) {
+			const presentation = deploymentFailurePresentation(
+				hostedDeploymentFixture({
+					status: "starting",
+					acceptedOperation: cancelledOperation(verb),
+				}),
+			);
+			expect(presentation?.title).toContain("cancelled");
+			expect(presentation?.remediation.kind).toBe("none");
+		}
+	});
+
+	test("does not claim failure for a cancelled operation", () => {
+		const presentation = deploymentFailurePresentation(
+			hostedDeploymentFixture({
+				status: "running",
+				acceptedOperation: cancelledOperation("start"),
+			}),
+		);
+		expect(presentation?.status.kind).toBe("cancelled");
+		expect(presentation?.title).not.toContain("failed");
+	});
+});
+
+describe("operationCancelErrorMessage", () => {
+	test("explains a completed-change race instead of the generic mutation copy", () => {
+		const error = new BillingApiError(409, "Deployment operation was cancelled", {
+			detail: { code: "operation_cancelled" },
+		});
+		expect(operationCancelErrorMessage(error)).toBe(
+			"This change already finished before cancellation could be applied.",
+		);
+	});
+
+	test("explains an idempotency-key reuse without leaking the key", () => {
+		const error = new BillingApiError(409, "Deployment idempotency key was reused", {
+			detail: { code: "idempotency_key_reused" },
+		});
+		expect(operationCancelErrorMessage(error)).toBe(
+			"This cancellation was already requested. Check the latest status, then try again.",
+		);
+	});
+
+	test("falls back to the shared mutation copy for other rejections", () => {
+		const error = new BillingApiError(404, "Operation not found");
+		expect(operationCancelErrorMessage(error)).toBe(
+			"This agent is no longer available. Return to Agents and refresh the list.",
+		);
 	});
 });

--- a/apps/web/src/hosted/deployment-failure.ts
+++ b/apps/web/src/hosted/deployment-failure.ts
@@ -2,6 +2,7 @@ import type { HostedDeployment } from "@/hosted/billing/contracts";
 import {
 	BillingApiError,
 	BillingNetworkError,
+	billingErrorDetail,
 	DeploymentConflictError,
 } from "@/hosted/billing/errors";
 import type { DeploymentOperationVerb } from "@/hosted/deployment-status";
@@ -30,9 +31,9 @@ export type DeploymentFailurePresentation = DeploymentFailureProjection & {
 	title: string;
 	description: string;
 	status: {
-		kind: "failed" | "runtime_unavailable";
-		label: "Failed" | "Temporarily unavailable";
-		tone: "destructive" | "warning";
+		kind: "failed" | "runtime_unavailable" | "cancelled";
+		label: "Failed" | "Temporarily unavailable" | "Cancelled";
+		tone: "destructive" | "warning" | "neutral";
 	};
 	remediation: DeploymentFailureRemediation;
 };
@@ -44,6 +45,7 @@ const RUNTIME_UNAVAILABLE_STATUS = {
 	label: "Temporarily unavailable",
 	tone: "warning",
 } as const;
+const CANCELLED_STATUS = { kind: "cancelled", label: "Cancelled", tone: "neutral" } as const;
 
 function isRuntimeStatusFailure(failure: { code?: string }): boolean {
 	return RUNTIME_FAILURE_CODES.has(failure.code ?? "");
@@ -72,6 +74,24 @@ export function deploymentMutationErrorMessage(error: unknown): string {
 		}
 	}
 	return "Clawdi couldn’t apply this agent change. Check the latest status and settings, then try again.";
+}
+
+/**
+ * Copy for a cancellation request rejected by the deploy API. Cancellation is
+ * accepted while an operation is still in flight; the backend races the
+ * operation itself, so a completed change or a reused key get their own honest
+ * messages instead of the generic mutation copy.
+ */
+export function operationCancelErrorMessage(error: unknown): string {
+	if (error instanceof DeploymentConflictError) return error.message;
+	const detail = error instanceof BillingApiError ? billingErrorDetail(error) : null;
+	if (detail?.code === "operation_cancelled") {
+		return "This change already finished before cancellation could be applied.";
+	}
+	if (detail?.code === "idempotency_key_reused") {
+		return "This cancellation was already requested. Check the latest status, then try again.";
+	}
+	return deploymentMutationErrorMessage(error);
 }
 
 /** Stable product name for every operation verb; never render the wire value. */
@@ -138,6 +158,18 @@ export function deploymentFailurePresentation(
 			title: "Temporarily unavailable",
 			description: RUNTIME_UNAVAILABLE_REASON,
 			status: RUNTIME_UNAVAILABLE_STATUS,
+			remediation: { kind: "none", label: null },
+		};
+	}
+	// A user-initiated cancellation is not a failure: the operation was stopped
+	// deliberately and the backend committed a compensating desired state. Say
+	// so instead of offering the failure's retry actions.
+	if (failure.code === "operation_cancelled") {
+		return {
+			...failure,
+			title: `${operationLabel} cancelled`,
+			description: `The in-progress ${operationName} was stopped before it completed. Check the latest status and try again when you’re ready.`,
+			status: CANCELLED_STATUS,
 			remediation: { kind: "none", label: null },
 		};
 	}

--- a/apps/web/src/hosted/deployment-status.test.ts
+++ b/apps/web/src/hosted/deployment-status.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import type { DeploymentOperation } from "@/hosted/billing/contracts";
 import {
+	canCancelOperation,
 	canDelete,
 	canQueryDeploymentProjection,
 	canRestart,
 	canStart,
 	canStop,
 	DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS,
+	DEPLOYMENT_TRANSITION_ESCALATION_MS,
 	DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
 	type DeploymentOperationVerb,
 	deploymentPollingState,
@@ -226,6 +228,33 @@ describe("DeploymentStatus", () => {
 		expect(canDelete(parseDeploymentStatus("future_status"))).toBe(false);
 	});
 
+	test("gates cancellation on the backend cancel acceptance contract", () => {
+		expect(canCancelOperation(undefined)).toBe(false);
+		expect(canCancelOperation(null)).toBe(false);
+		for (const verb of [
+			"create",
+			"start",
+			"stop",
+			"restart",
+			"update",
+			"delete",
+			"rename",
+		] as const) {
+			const inFlight = acceptedOperation(verb);
+			expect(canCancelOperation(inFlight)).toBe(true);
+		}
+		const done = acceptedOperation("delete");
+		done.done = true;
+		expect(canCancelOperation(done)).toBe(false);
+	});
+
+	test("refuses cancellation for backend-managed image cohort operations", () => {
+		for (const verb of ["migrate_image", "rollback_image"] as const) {
+			const operation = acceptedOperation(verb);
+			expect(canCancelOperation(operation)).toBe(false);
+		}
+	});
+
 	test("classifies whether any deployment is non-terminal", () => {
 		expect(
 			shouldPollDeployments([
@@ -369,6 +398,84 @@ describe("DeploymentStatus", () => {
 		expect(running.refetchInterval).toBe(DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS);
 		expect(running.transitions.size).toBe(0);
 		expect(running.trackers.size).toBe(0);
+	});
+
+	test("escalates a transition stuck past the escalation window with reconciliation polling intact", () => {
+		const acceptedAtMs = Date.parse("2026-07-29T05:00:00Z");
+		const operation = acceptedOperation("update");
+		operation.metadata.deploymentId = "hdep_stuck_update";
+		operation.metadata.createTime = "2026-07-29T05:00:00Z";
+		operation.metadata.updateTime = "2026-07-29T05:00:00Z";
+		const stuck = hostedDeploymentFixture({
+			id: "hdep_stuck_update",
+			status: "updating",
+			acceptedOperation: operation,
+		});
+		const accepted = deploymentPollingState([stuck], new Map(), acceptedAtMs);
+		const stillTimedOut = deploymentPollingState(
+			[stuck],
+			accepted.trackers,
+			Date.parse("2026-07-29T05:14:59Z"),
+		);
+		const escalated = deploymentPollingState(
+			[stuck],
+			stillTimedOut.trackers,
+			Date.parse("2026-07-29T05:15:00Z"),
+		);
+
+		expect(stillTimedOut.transitions.get("hdep_stuck_update")?.kind).toBe("timed_out");
+		expect(escalated.transitions.get("hdep_stuck_update")).toMatchObject({
+			kind: "escalated",
+			verb: "update",
+		});
+		expect(escalated.refetchInterval).toBe(DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS);
+		expect(DEPLOYMENT_TRANSITION_ESCALATION_MS).toBe(15 * 60_000);
+	});
+
+	test("drops the escalation as soon as the deployment reaches a terminal state", () => {
+		const operation = acceptedOperation("restart");
+		operation.metadata.deploymentId = "hdep_stuck_restart";
+		operation.metadata.createTime = "2026-07-29T05:00:00Z";
+		operation.metadata.updateTime = "2026-07-29T05:00:00Z";
+		const stuck = hostedDeploymentFixture({
+			id: "hdep_stuck_restart",
+			status: "restarting",
+			acceptedOperation: operation,
+		});
+		const escalated = deploymentPollingState(
+			[stuck],
+			new Map(),
+			Date.parse("2026-07-29T05:20:00Z"),
+		);
+		const resolved = deploymentPollingState(
+			[
+				hostedDeploymentFixture({
+					id: "hdep_stuck_restart",
+					status: "running",
+					acceptedOperation: operation,
+				}),
+			],
+			escalated.trackers,
+			Date.parse("2026-07-29T05:21:00Z"),
+		);
+
+		expect(escalated.transitions.get("hdep_stuck_restart")?.kind).toBe("escalated");
+		expect(resolved.transitions.size).toBe(0);
+		expect(resolved.trackers.size).toBe(0);
+	});
+
+	test("cancels fast polling on a failed accepted operation before escalation matters", () => {
+		const operation = acceptedOperation("create");
+		operation.done = true;
+		operation.error = { code: 1, message: "cancelled", details: [] };
+		const result = deploymentPollingState(
+			[hostedDeploymentFixture({ status: "deleting", acceptedOperation: operation })],
+			new Map(),
+			Date.parse("2026-07-29T05:20:00Z"),
+		);
+
+		expect(result.refetchInterval).toBe(DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS);
+		expect(result.transitions.size).toBe(0);
 	});
 
 	test("schedules a modest reconciliation interval for steady inventory", () => {

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -55,6 +55,13 @@ export type DeploymentOperationVerb =
 
 export const DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS = 10_000;
 export const DEPLOYMENT_TRANSITION_TIMEOUT_MS = 5 * 60_000;
+// The backend controller keeps recovering stalled generations on its own
+// (60s scan, `clawdi_v2_a3_stalled_generation_seconds` in clawdi-hosted
+// backend/app/v2/hosted/controller_scheduling.py). Escalation waits well
+// past that recovery cadence and past the "taking longer than expected"
+// window before offering cancellation, anchored on the same backend-reported
+// operation create time.
+export const DEPLOYMENT_TRANSITION_ESCALATION_MS = 15 * 60_000;
 export const DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS = 60_000;
 
 export type SettlingTracker = {
@@ -65,11 +72,12 @@ export type SettlingTracker = {
 export type SettlingPollState = {
 	refetchInterval: number | false;
 	timedOut: boolean;
+	escalated: boolean;
 	tracker: SettlingTracker;
 };
 
 export type DeploymentTransitionState = {
-	kind: "converging" | "timed_out";
+	kind: "converging" | "timed_out" | "escalated";
 	verb: DeploymentOperationVerb | null;
 	startedAtMs: number;
 };
@@ -358,6 +366,19 @@ export function canDelete(status: DeploymentStatus): boolean {
 	}
 }
 
+/**
+ * Whether the in-flight accepted operation can accept a cancel request. Mirrors
+ * the cancel acceptance side in clawdi-hosted operation_cancellation.py: only
+ * operations that are still running and are not backend-managed image cohort
+ * operations are cancellable.
+ */
+export function canCancelOperation(operation: DeploymentOperation | null | undefined): boolean {
+	if (!operation || operation.done) return false;
+	return (
+		operation.metadata.verb !== "migrate_image" && operation.metadata.verb !== "rollback_image"
+	);
+}
+
 /** Shared started-at/timeout primitive for lifecycle and runtime-UI convergence. */
 export function boundedSettlingPollState({
 	key,
@@ -366,6 +387,7 @@ export function boundedSettlingPollState({
 	nowMs,
 	pollIntervalMs,
 	timeoutMs,
+	escalationMs = Infinity,
 }: {
 	key: string;
 	startedAtMs: number;
@@ -373,14 +395,18 @@ export function boundedSettlingPollState({
 	nowMs: number;
 	pollIntervalMs: number;
 	timeoutMs: number;
+	escalationMs?: number;
 }): SettlingPollState {
 	const safeStartedAtMs =
 		Number.isFinite(startedAtMs) && startedAtMs <= nowMs ? startedAtMs : nowMs;
 	const nextTracker = tracker?.key === key ? tracker : { key, startedAtMs: safeStartedAtMs };
-	const timedOut = nowMs - nextTracker.startedAtMs >= timeoutMs;
+	const ageMs = nowMs - nextTracker.startedAtMs;
+	const timedOut = ageMs >= timeoutMs;
+	const escalated = timedOut && ageMs >= escalationMs;
 	return {
 		refetchInterval: timedOut ? false : pollIntervalMs,
 		timedOut,
+		escalated,
 		tracker: nextTracker,
 	};
 }
@@ -404,9 +430,9 @@ export function shouldPollDeployments(
 
 /**
  * Fast-poll each accepted lifecycle operation only during its bounded
- * convergence window. Until the existing deployment SSE stream is wired into
- * the client, delayed transitions and stable snapshots use a modest
- * foreground-only reconciliation interval.
+ * convergence window, then fall back to the foreground reconciliation
+ * interval so delayed transitions still surface without a background
+ * polling loop.
  */
 export function deploymentPollingState(
 	deployments: readonly HostedDeployment[] | null | undefined,
@@ -432,10 +458,11 @@ export function deploymentPollingState(
 			nowMs,
 			pollIntervalMs: DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
 			timeoutMs: DEPLOYMENT_TRANSITION_TIMEOUT_MS,
+			escalationMs: DEPLOYMENT_TRANSITION_ESCALATION_MS,
 		});
 		nextTrackers.set(deploymentId, pollState.tracker);
 		transitions.set(deploymentId, {
-			kind: pollState.timedOut ? "timed_out" : "converging",
+			kind: pollState.escalated ? "escalated" : pollState.timedOut ? "timed_out" : "converging",
 			verb: operation?.metadata.verb ?? null,
 			startedAtMs: pollState.tracker.startedAtMs,
 		});

--- a/apps/web/src/hosted/hosted-agents-section.tsx
+++ b/apps/web/src/hosted/hosted-agents-section.tsx
@@ -38,6 +38,8 @@ function HostedDeletionFailureNotices({ deployments }: { deployments: HostedDepl
 			{deployments.map((deployment) => {
 				const failure = deploymentFailurePresentation(deployment);
 				if (failure?.failedVerb !== "delete") return null;
+				// A user-cancelled deletion is deliberate, not a cleanup failure.
+				if (failure.code === "operation_cancelled") return null;
 				const name = agentDisplayName({
 					name: deployment.resource.name,
 					agent_type: deployment.resource.spec.runtime,

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -263,6 +263,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v2/operations/{operation_id}:cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Cancel V2 Operation */
+        post: operations["cancel_v2_operation_v2_operations__operation_id__cancel_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v2/subscription/checkout": {
         parameters: {
             query?: never;
@@ -538,6 +555,16 @@ export interface components {
              */
             secret_references: components["schemas"]["SecretReference"][];
         };
+        /**
+         * CancelOperationRequest
+         * @description Google LRO cancellation has an intentionally empty request body.
+         */
+        CancelOperationRequest: Record<string, never>;
+        /**
+         * CancelOperationResponse
+         * @description JSON projection of the standard empty cancellation response.
+         */
+        CancelOperationResponse: Record<string, never>;
         /** ComputePlanChangeProgress */
         ComputePlanChangeProgress: {
             /**
@@ -3152,6 +3179,43 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["LongRunningOperation"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_v2_operation_v2_operations__operation_id__cancel_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
+            path: {
+                operation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["CancelOperationRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CancelOperationResponse"];
                 };
             };
             /** @description Validation Error */

--- a/scripts/filter-deploy-openapi.py
+++ b/scripts/filter-deploy-openapi.py
@@ -65,6 +65,7 @@ KEEP_OPERATIONS_BY_PATH: dict[str, set[str]] = {
     "/v2/deployments/{deployment_id}/workspace-skills": {"get", "post"},
     "/v2/deployments/{deployment_id}/workspace-skills/{skill_key}": {"delete"},
     "/v2/operations/{operation_id}": {"get"},
+    "/v2/operations/{operation_id}:cancel": {"post"},
     "/v2/subscription/checkout": {"post"},
     "/v2/subscription/cancel": {"post"},
     "/v2/subscription/fix-payment": {"post"},


### PR DESCRIPTION
## What

Phase 2 of the v2 remediation (frontend-led): a deployment transition stuck well past the patience window no longer shows "taking longer than expected" forever. It escalates to an honest stuck state that offers a **Cancel this change** action wired to the existing owner-scoped `POST /v2/operations/{operation_id}:cancel` endpoint.

## Changes

- **Escalation state machine** (`deployment-status.ts`): `converging` (fast poll, 10s) → `timed_out` at 5 min ("taking longer than expected", unchanged) → `escalated` at 15 min ("appears to be stuck" + cancel action). Age is anchored on the backend-reported operation `metadata.createTime`, with one new named constant cross-referencing the backend recovery threshold (`clawdi_v2_a3_stalled_generation_seconds`, 60s, in `backend/app/v2/hosted/controller_scheduling.py`). No new backend endpoint or config.
- **Cancel wiring**: `cancelDeploymentOperation` on the deploy client calling the generated `POST /v2/operations/{operation_id}:cancel` operation (regenerated; see below), `useCancelDeploymentOperation` hook reusing the shared `runStableDeploymentIntent` idempotency path, and a `DeploymentCancelAction` component surfaced on the three timed-out surfaces (overview compute status, initial setup page, console tab). Button is gated by `canCancelOperation`, which mirrors the backend acceptance contract (not done; not `migrate_image`/`rollback_image`).
- **Honest rejection copy**: `operationCancelErrorMessage` maps 409 `operation_cancelled` ("already finished") and `idempotency_key_reused`, falling back to the existing mutation error path.
- **Cancelled ≠ failed**: a user-cancelled operation now presents as `cancelled` (neutral tone, no retry remediation) instead of a failure; cancelled deletes are excluded from the list-level cleanup-failure notices.
- **Dead code removed**: `listEventStreamHandoff` client method (zero call sites) and both stale "until SSE is wired into the client" comments. No SSE built.

## Verified backend semantics (read-only, no backend changes)

- Cancel acceptance (`backend/app/v2/routes.py` cancel handler + `operation_cancellation.py`): 200 accepted when the operation exists, is owner-scoped (404 otherwise), is not done, and is not an image-cohort operation (409 `operation_aborted`); requires `Idempotency-Key` (400 without). Apply is asynchronous compensation; a completed change races to 409 `operation_cancelled`.
- The backend's "stalled" concept (60s recovery scan) is an internal controller metric, not exposed as a status condition — so the escalation keys on operation age from the payload instead.

## Generated client regeneration (done)

The cancel path was missing from `packages/shared/src/api/deploy.generated.ts` (filtered OpenAPI allowlist). Regenerated against the live contract via `bun run --cwd apps/web generate-deploy-api:live` (`https://api.clawdi.ai/openapi.json`), with `/v2/operations/{operation_id}:cancel` added to the `KEEP_OPERATIONS_BY_PATH` allowlist in `scripts/filter-deploy-openapi.py`. The regenerated diff is additive only: the cancel operation plus its two empty request/response schemas (`CancelOperationRequest`/`CancelOperationResponse`) — no unrelated contract churn. The hand-typed shim and its cast are removed; `billing-client.ts` now calls the generated typed path. `scripts/check-deploy-generated-api.sh` (CI contract check against the live spec) passes.

## Tests

Fast bun tests only: escalation threshold transitions, `canCancelOperation` gates, cancelled-operation presentation, cancel rejection copy, and surface-level escalation wiring. Web suite: 979 pass / 0 fail; `typecheck` and `biome` green; problem-code contract test green (fixtures untouched). Hosted Playwright: collection verified (`--list`, 148 tests); a targeted run of deployment lifecycle/delete tests fails identically on the unmodified base (app renders "Page Unavailable" under current machine load) — environmental, not caused by this change.