### PR TITLE
fix(e2e): unskip and modernize BYOK/wallet hosted tests, sessions result count

### DIFF
--- a/apps/web/e2e/hosted-channels-providers.pw.ts
+++ b/apps/web/e2e/hosted-channels-providers.pw.ts
@@ -4,9 +4,7 @@ import { collectBrowserErrors, stubCloudApi } from "./hosted-fixtures";
 test.beforeEach(async ({ page }) => {
 	await stubCloudApi(page);
 });
-// The save flow's stub endpoints predate the current validate-then-accept
-// contract — re-enable after re-stubbing to the live API shape.
-test.skip("AI providers BYOK flow saves and renders a custom provider", async ({ page }) => {
+test("AI providers BYOK flow saves and renders a custom provider", async ({ page }) => {
 	const errors = collectBrowserErrors(page);
 
 	await page.goto("/ai-providers");
@@ -20,7 +18,11 @@ test.skip("AI providers BYOK flow saves and renders a custom provider", async ({
 	await page.getByRole("button", { name: "Add provider", exact: true }).click();
 
 	await expect(page.getByRole("dialog", { name: /Set up OpenAI/ })).toBeHidden();
-	await expect(page.getByText("OpenAI", { exact: true }).first()).toBeVisible();
+	// The provider icon carries an SVG <title>OpenAI</title> (always hidden) —
+	// assert on a visible text node instead.
+	await expect(
+		page.getByText("OpenAI", { exact: true }).locator("visible=true").first(),
+	).toBeVisible();
 	expect(errors, `providers flow: ${errors.join(" | ")}`).toEqual([]);
 });
 

--- a/apps/web/e2e/hosted-fixtures.ts
+++ b/apps/web/e2e/hosted-fixtures.ts
@@ -51,15 +51,20 @@ function initialChannel(): JsonRecord {
 
 function managedProvider(): JsonRecord {
 	return {
+		id: "prov_e2e_managed",
 		provider_id: "clawdi-managed-v2",
 		type: "openai",
 		label: "Clawdi managed",
 		base_url: "https://api.openai.com/v1",
 		api_mode: "openai_chat",
-		auth: { type: "managed" },
 		managed_by: "clawdi",
 		runtime_env_name: null,
 		models: [{ id: "openai/gpt-4o-mini", label: "GPT-4o mini" }],
+		scope: "account",
+		auth: { type: "secret_ref", secret_ref: "clawdi://e2e/managed" },
+		usable: true,
+		created_at: "2026-07-11T12:00:00Z",
+		updated_at: "2026-07-11T12:00:00Z",
 	};
 }
 
@@ -193,6 +198,32 @@ export async function stubCloudApi(page: Page) {
 		}
 
 		if (path === "/v1/ai-providers" && method === "GET") return fulfillJson(route, { providers });
+		// The save flow validates then accepts; accept carries the credential.
+		if (path === "/v1/ai-providers/accept" && method === "POST") {
+			const body = requestJson(route);
+			const incoming = (body.provider ?? {}) as JsonRecord;
+			const provider: JsonRecord = {
+				id: `prov_e2e_${providers.length + 1}`,
+				provider_id: incoming.provider_id ?? "openai",
+				type: incoming.type ?? "openai",
+				label: incoming.label ?? null,
+				base_url: incoming.base_url ?? "https://api.openai.com/v1",
+				api_mode: incoming.api_mode ?? "openai_chat",
+				managed_by: "user",
+				runtime_env_name: incoming.runtime_env_name ?? null,
+				models: incoming.models ?? [],
+				scope: "account",
+				auth: { type: "secret_ref", secret_ref: "clawdi://e2e/provider/key" },
+				usable: true,
+				created_at: "2026-07-11T12:00:00Z",
+				updated_at: "2026-07-11T12:00:00Z",
+			};
+			providers.push(provider);
+			return fulfillJson(route, { status: "ready", provider });
+		}
+		if (path === "/v1/ai-providers/test" && method === "POST") {
+			return fulfillJson(route, { ok: true });
+		}
 		if (path === "/v1/ai-providers" && method === "POST") {
 			const body = requestJson(route);
 			const provider: JsonRecord = {

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2,6 +2,13 @@ import type { DeploymentRead } from "@clawdi/shared/api";
 import { expect, type Locator, type Page, type Route, test } from "@playwright/test";
 import type { ManagedModelCatalogItem } from "../src/hosted/billing/contracts";
 import type { AiProvider } from "../src/hosted/v2/ai-providers/types";
+import {
+	type DeploymentMutationFixture,
+	isDeploymentMutationFixture,
+	isRecord,
+	mutationDeploymentReadFixture,
+	readDeploymentFixture,
+} from "./hosted-stub-api";
 
 declare global {
 	interface Window {
@@ -580,48 +587,6 @@ function _userProvider(
 	};
 }
 
-type DeploymentComputeSubscription = NonNullable<
-	NonNullable<DeploymentRead["commercial_display"]>["compute_subscription"]
->;
-
-type DeploymentMutationFixture = {
-	id: string;
-	user_id: string;
-	name: string;
-	app_id: string;
-	status: string;
-	created_at: string;
-	upgrade_available: boolean;
-	upgrade_eligibility?: DeploymentRead["upgrade_eligibility"];
-	compute_subscription: DeploymentComputeSubscription | null;
-	config_info: {
-		compute_plan_slug: string;
-		runtime: "openclaw" | "hermes";
-		ai_provider_auth_kind: "unmanaged" | "managed" | "api_key" | "codex_oauth";
-		ai_provider_bindings?: Record<string, { auth_kind?: string | null }>;
-		clawdi_cloud_environments?: Record<string, string>;
-		mux_enabled?: boolean;
-		telegram_mux_enabled?: boolean;
-		discord_mux_enabled?: boolean;
-		whatsapp_mux_enabled?: boolean;
-		imessage_mux_enabled?: boolean;
-		kobb_available?: boolean;
-		public_ports?: number[];
-		runtime_configuration?: DeploymentRead["resource"]["spec"]["runtime_configuration"];
-	};
-	endpoints?: string[];
-	failure_reason?: string | null;
-	hermes_control_ui_url?: string | null;
-	openclaw_control_ui_url?: string | null;
-	last_funding_event?: {
-		funding_source: "stripe" | "wallet";
-		reason: "payment_failure" | "canceled" | "refunded" | "disputed" | "admin_forced";
-		prior_plan_slug: string;
-		occurred_at: string;
-		subscription_id: number;
-	} | null;
-};
-
 // Mirrors the user-facing GET /v2/subscription/plans response. clawdi-hosted resolves
 // the owner-approved Stripe prices from scripts/stripe/create-compute-{basic,performance}.py.
 const basicPlan = {
@@ -1109,202 +1074,12 @@ function planChangeResponse({
 	};
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function _checkoutDeployRequestId(requestBody: string): string | null {
 	const request: unknown = JSON.parse(requestBody);
 	if (!isRecord(request) || !isRecord(request.deploy_config)) return null;
 	return typeof request.deploy_config.deploy_request_id === "string"
 		? request.deploy_config.deploy_request_id
 		: null;
-}
-
-function isDeploymentMutationFixture(value: unknown): value is DeploymentMutationFixture {
-	return (
-		isRecord(value) &&
-		typeof value.id === "string" &&
-		typeof value.user_id === "string" &&
-		typeof value.name === "string" &&
-		typeof value.app_id === "string" &&
-		typeof value.status === "string" &&
-		typeof value.created_at === "string" &&
-		isRecord(value.config_info) &&
-		typeof value.config_info.compute_plan_slug === "string" &&
-		(value.config_info.runtime === "openclaw" || value.config_info.runtime === "hermes")
-	);
-}
-
-function readSummaryState(
-	status: string,
-): NonNullable<DeploymentRead["resource"]["status"]>["summary_state"] {
-	switch (status) {
-		case "creating":
-		case "starting":
-		case "running":
-		case "stopping":
-		case "stopped":
-		case "restarting":
-		case "updating":
-		case "deleting":
-		case "deleted":
-		case "failed":
-			return status;
-		case "provisioning":
-			return "creating";
-		case "ready":
-			return "running";
-		default:
-			throw new Error(`Unsupported deployment fixture status: ${status}`);
-	}
-}
-
-function readProviderAuthKind(
-	value: string | null | undefined,
-): DeploymentRead["ai_provider_auth_kinds"][string] {
-	switch (value) {
-		case "unmanaged":
-		case "managed":
-		case "api_key":
-		case "codex_oauth":
-			return value;
-		default:
-			throw new Error(`Unsupported deployment fixture provider mode: ${value ?? "missing"}`);
-	}
-}
-
-function mutationDeploymentReadFixture(deployment: DeploymentMutationFixture): DeploymentRead {
-	const config = deployment.config_info;
-	const runtime = config.runtime;
-	if (runtime !== "openclaw" && runtime !== "hermes") {
-		throw new Error(`Unsupported deployment fixture runtime: ${runtime}`);
-	}
-	const summaryState = readSummaryState(deployment.status);
-	const backingInfrastructure =
-		summaryState === "stopped" || summaryState === "deleted" ? "absent" : "present";
-	const runtimeBinding = config.ai_provider_bindings?.[runtime];
-	const providerAuthKind = readProviderAuthKind(
-		runtimeBinding?.auth_kind ?? config.ai_provider_auth_kind,
-	);
-	const runtimeUiUrl =
-		runtime === "openclaw" ? deployment.openclaw_control_ui_url : deployment.hermes_control_ui_url;
-	const failure = deployment.failure_reason
-		? {
-				type: "https://api.clawdi.ai/problems/runtime-readiness-timeout",
-				title: deployment.failure_reason,
-				status: 504,
-				detail: "The runtime did not become ready before the startup deadline.",
-				instance: deployment.id,
-				code: "runtime_readiness_timeout",
-				phase: "readiness",
-				retryable: true,
-				conditionReason: "RuntimeReadinessTimeout",
-				conditionMessage: deployment.failure_reason,
-				observedGeneration: 1,
-			}
-		: null;
-	const fundingFact = deployment.last_funding_event
-		? {
-				fact_kind: "funding_revoked" as const,
-				commercial_revision: 1,
-				compute_subscription_id: deployment.last_funding_event.subscription_id,
-				compute_plan_slug: null,
-				funding_source: deployment.last_funding_event.funding_source,
-				reason: deployment.last_funding_event.reason,
-				prior_plan_slug: deployment.last_funding_event.prior_plan_slug,
-				occurred_at: deployment.last_funding_event.occurred_at,
-				emitted_at: deployment.last_funding_event.occurred_at,
-			}
-		: null;
-
-	return {
-		resource: {
-			id: deployment.id,
-			name: deployment.name,
-			owner_user_id: deployment.user_id,
-			commercial_revision: 1,
-			deployment_target: "saas",
-			metadata: {
-				generation: 1,
-				manifestETag: `etag_${deployment.id}`,
-				resourceVersion: `rv_${deployment.id}`,
-				createdAt: deployment.created_at,
-				updatedAt: deployment.created_at,
-			},
-			spec: {
-				schema_version: 1,
-				desired_lifecycle:
-					summaryState === "stopped"
-						? "stopped"
-						: summaryState === "deleted"
-							? "deleted"
-							: "running",
-				runtime,
-				runtime_version: "latest",
-				resources: {
-					vcpu: config.compute_plan_slug === "compute_performance" ? 4 : 2,
-					memory_mib: config.compute_plan_slug === "compute_performance" ? 8192 : 4096,
-					disk_gib: config.compute_plan_slug === "compute_performance" ? 40 : 20,
-				},
-				agents: [],
-				ports: [],
-				runtime_configuration: config.runtime_configuration ?? { providers: [], features: [] },
-				rollout_nonce: 0,
-				secret_references: [],
-			},
-			status: {
-				summary_state: summaryState,
-				observedGeneration: 1,
-				conditions: [],
-				failure,
-				backing_infrastructure: backingInfrastructure,
-				driver_acknowledged_generation: 1,
-				driver_applied_generation: 1,
-				driver_observation_sequence: 1,
-				endpoints: (deployment.endpoints ?? []).map((url, index) => ({
-					name: `endpoint-${index + 1}`,
-					url,
-				})),
-			},
-		},
-		clawdi_cloud_environments: config.clawdi_cloud_environments ?? {},
-		ai_provider_auth_kinds: { [runtime]: providerAuthKind },
-		runtime_ui_endpoint: runtimeUiUrl
-			? runtime === "hermes"
-				? {
-						runtime,
-						role: "control_ui",
-						url: runtimeUiUrl,
-						auth_mode: "password",
-						browser_mode: "embedded_and_top_level",
-					}
-				: {
-						runtime,
-						role: "control_ui",
-						url: runtimeUiUrl,
-						auth_mode: "openclaw_token",
-						browser_mode: "embedded_and_top_level",
-					}
-			: null,
-		accepted_operation: null,
-		commercial_display: {
-			compute_subscription: deployment.compute_subscription ?? null,
-			latest_funding_fact: fundingFact,
-		},
-		current_plan_slug: config.compute_plan_slug,
-		upgrade_available: deployment.upgrade_available,
-		upgrade_eligibility: deployment.upgrade_eligibility ?? {
-			eligible: deployment.upgrade_available,
-			reason: null,
-		},
-		compute_slot_occupancy: {
-			occupies_slot: backingInfrastructure === "present",
-			backing_infra: backingInfrastructure,
-			reason:
-				backingInfrastructure === "present" ? "backing_infra_present" : "authoritative_absence",
-		},
-	};
 }
 
 function completedDeploymentOperation(
@@ -1409,10 +1184,6 @@ function acceptedDeletionReadFixture(deployment: DeploymentMutationFixture): Dep
 			reason: "delete_accepted",
 		},
 	};
-}
-
-function readDeploymentFixture(value: unknown): unknown {
-	return isDeploymentMutationFixture(value) ? mutationDeploymentReadFixture(value) : value;
 }
 
 type StubResponse = { body: unknown; status: number; delayMs?: number };

--- a/apps/web/e2e/hosted-stub-api.ts
+++ b/apps/web/e2e/hosted-stub-api.ts
@@ -1,4 +1,243 @@
+import type { DeploymentRead } from "@clawdi/shared/api";
 import { expect, type Page, type Route } from "@playwright/test";
+
+export type DeploymentComputeSubscription = NonNullable<
+	NonNullable<DeploymentRead["commercial_display"]>["compute_subscription"]
+>;
+
+export type DeploymentMutationFixture = {
+	id: string;
+	user_id: string;
+	name: string;
+	app_id: string;
+	status: string;
+	created_at: string;
+	upgrade_available: boolean;
+	upgrade_eligibility?: DeploymentRead["upgrade_eligibility"];
+	compute_subscription: DeploymentComputeSubscription | null;
+	config_info: {
+		compute_plan_slug: string;
+		runtime: "openclaw" | "hermes";
+		ai_provider_auth_kind: "unmanaged" | "managed" | "api_key" | "codex_oauth";
+		ai_provider_bindings?: Record<string, { auth_kind?: string | null }>;
+		clawdi_cloud_environments?: Record<string, string>;
+		mux_enabled?: boolean;
+		telegram_mux_enabled?: boolean;
+		discord_mux_enabled?: boolean;
+		whatsapp_mux_enabled?: boolean;
+		imessage_mux_enabled?: boolean;
+		kobb_available?: boolean;
+		public_ports?: number[];
+		runtime_configuration?: DeploymentRead["resource"]["spec"]["runtime_configuration"];
+	};
+	endpoints?: string[];
+	failure_reason?: string | null;
+	hermes_control_ui_url?: string | null;
+	openclaw_control_ui_url?: string | null;
+	last_funding_event?: {
+		funding_source: "stripe" | "wallet";
+		reason: "payment_failure" | "canceled" | "refunded" | "disputed" | "admin_forced";
+		prior_plan_slug: string;
+		occurred_at: string;
+		subscription_id: number;
+	} | null;
+};
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isDeploymentMutationFixture(value: unknown): value is DeploymentMutationFixture {
+	return (
+		isRecord(value) &&
+		typeof value.id === "string" &&
+		typeof value.user_id === "string" &&
+		typeof value.name === "string" &&
+		typeof value.app_id === "string" &&
+		typeof value.status === "string" &&
+		typeof value.created_at === "string" &&
+		isRecord(value.config_info) &&
+		typeof value.config_info.compute_plan_slug === "string" &&
+		(value.config_info.runtime === "openclaw" || value.config_info.runtime === "hermes")
+	);
+}
+
+export function readSummaryState(
+	status: string,
+): NonNullable<DeploymentRead["resource"]["status"]>["summary_state"] {
+	switch (status) {
+		case "creating":
+		case "starting":
+		case "running":
+		case "stopping":
+		case "stopped":
+		case "restarting":
+		case "updating":
+		case "deleting":
+		case "deleted":
+		case "failed":
+			return status;
+		case "provisioning":
+			return "creating";
+		case "ready":
+			return "running";
+		default:
+			throw new Error(`Unsupported deployment fixture status: ${status}`);
+	}
+}
+
+export function readProviderAuthKind(
+	value: string | null | undefined,
+): DeploymentRead["ai_provider_auth_kinds"][string] {
+	switch (value) {
+		case "unmanaged":
+		case "managed":
+		case "api_key":
+		case "codex_oauth":
+			return value;
+		default:
+			throw new Error(`Unsupported deployment fixture provider mode: ${value ?? "missing"}`);
+	}
+}
+
+export function mutationDeploymentReadFixture(
+	deployment: DeploymentMutationFixture,
+): DeploymentRead {
+	const config = deployment.config_info;
+	const runtime = config.runtime;
+	if (runtime !== "openclaw" && runtime !== "hermes") {
+		throw new Error(`Unsupported deployment fixture runtime: ${runtime}`);
+	}
+	const summaryState = readSummaryState(deployment.status);
+	const backingInfrastructure =
+		summaryState === "stopped" || summaryState === "deleted" ? "absent" : "present";
+	const runtimeBinding = config.ai_provider_bindings?.[runtime];
+	const providerAuthKind = readProviderAuthKind(
+		runtimeBinding?.auth_kind ?? config.ai_provider_auth_kind,
+	);
+	const runtimeUiUrl =
+		runtime === "openclaw" ? deployment.openclaw_control_ui_url : deployment.hermes_control_ui_url;
+	const failure = deployment.failure_reason
+		? {
+				type: "https://api.clawdi.ai/problems/runtime-readiness-timeout",
+				title: deployment.failure_reason,
+				status: 504,
+				detail: "The runtime did not become ready before the startup deadline.",
+				instance: deployment.id,
+				code: "runtime_readiness_timeout",
+				phase: "readiness",
+				retryable: true,
+				conditionReason: "RuntimeReadinessTimeout",
+				conditionMessage: deployment.failure_reason,
+				observedGeneration: 1,
+			}
+		: null;
+	const fundingFact = deployment.last_funding_event
+		? {
+				fact_kind: "funding_revoked" as const,
+				commercial_revision: 1,
+				compute_subscription_id: deployment.last_funding_event.subscription_id,
+				compute_plan_slug: null,
+				funding_source: deployment.last_funding_event.funding_source,
+				reason: deployment.last_funding_event.reason,
+				prior_plan_slug: deployment.last_funding_event.prior_plan_slug,
+				occurred_at: deployment.last_funding_event.occurred_at,
+				emitted_at: deployment.last_funding_event.occurred_at,
+			}
+		: null;
+
+	return {
+		resource: {
+			id: deployment.id,
+			name: deployment.name,
+			owner_user_id: deployment.user_id,
+			commercial_revision: 1,
+			deployment_target: "saas",
+			metadata: {
+				generation: 1,
+				manifestETag: `etag_${deployment.id}`,
+				resourceVersion: `rv_${deployment.id}`,
+				createdAt: deployment.created_at,
+				updatedAt: deployment.created_at,
+			},
+			spec: {
+				schema_version: 1,
+				desired_lifecycle:
+					summaryState === "stopped"
+						? "stopped"
+						: summaryState === "deleted"
+							? "deleted"
+							: "running",
+				runtime,
+				runtime_version: "latest",
+				resources: {
+					vcpu: config.compute_plan_slug === "compute_performance" ? 4 : 2,
+					memory_mib: config.compute_plan_slug === "compute_performance" ? 8192 : 4096,
+					disk_gib: config.compute_plan_slug === "compute_performance" ? 40 : 20,
+				},
+				agents: [],
+				ports: [],
+				runtime_configuration: config.runtime_configuration ?? { providers: [], features: [] },
+				rollout_nonce: 0,
+				secret_references: [],
+			},
+			status: {
+				summary_state: summaryState,
+				observedGeneration: 1,
+				conditions: [],
+				failure,
+				backing_infrastructure: backingInfrastructure,
+				driver_acknowledged_generation: 1,
+				driver_applied_generation: 1,
+				driver_observation_sequence: 1,
+				endpoints: (deployment.endpoints ?? []).map((url, index) => ({
+					name: `endpoint-${index + 1}`,
+					url,
+				})),
+			},
+		},
+		clawdi_cloud_environments: config.clawdi_cloud_environments ?? {},
+		ai_provider_auth_kinds: { [runtime]: providerAuthKind },
+		runtime_ui_endpoint: runtimeUiUrl
+			? runtime === "hermes"
+				? {
+						runtime,
+						role: "control_ui",
+						url: runtimeUiUrl,
+						auth_mode: "password",
+						browser_mode: "embedded_and_top_level",
+					}
+				: {
+						runtime,
+						role: "control_ui",
+						url: runtimeUiUrl,
+						auth_mode: "openclaw_token",
+						browser_mode: "embedded_and_top_level",
+					}
+			: null,
+		accepted_operation: null,
+		commercial_display: {
+			compute_subscription: deployment.compute_subscription ?? null,
+			latest_funding_fact: fundingFact,
+		},
+		current_plan_slug: config.compute_plan_slug,
+		upgrade_available: deployment.upgrade_available,
+		upgrade_eligibility: deployment.upgrade_eligibility ?? {
+			eligible: deployment.upgrade_available,
+			reason: null,
+		},
+		compute_slot_occupancy: {
+			occupies_slot: backingInfrastructure === "present",
+			backing_infra: backingInfrastructure,
+			reason:
+				backingInfrastructure === "present" ? "backing_infra_present" : "authoritative_absence",
+		},
+	};
+}
+
+export function readDeploymentFixture(value: unknown): unknown {
+	return isDeploymentMutationFixture(value) ? mutationDeploymentReadFixture(value) : value;
+}
 
 // HOSTED (Clawdi Cloud) smoke against the vite dev server with dev-auth-bypass
 // (NO Clerk key needed) + deploy-api enabled so /deploy renders. Exercises the
@@ -554,7 +793,11 @@ export async function stubHostedApi(page: Page, options: HostedApiStubOptions = 
 			if (options.deploymentsResponse) {
 				return fulfillJson(r, options.deploymentsResponse.body, options.deploymentsResponse.status);
 			}
-			return fulfillJson(r, deployments);
+			// Flat mutation fixtures must go out as DeploymentRead rows.
+			return fulfillJson(
+				r,
+				deployments.map((d) => readDeploymentFixture(d)),
+			);
 		}
 		if (p === "/v2/deployments" && r.request().method() === "POST") {
 			options.createRequests?.push(r.request().postData() ?? "");
@@ -738,6 +981,16 @@ export async function stubHostedApi(page: Page, options: HostedApiStubOptions = 
 		if (p.startsWith("/v2/deployments/") && r.request().method() === "DELETE") {
 			options.deleteRequests?.push(p);
 			return fulfillJson(r, { status: "deleted", cvm_deleted: true });
+		}
+		if (p.startsWith("/v2/deployments/") && r.request().method() === "GET") {
+			const id = decodeURIComponent(p.slice("/v2/deployments/".length));
+			const deployment = deployments.find(
+				(d): d is typeof d & { id: string } =>
+					typeof d === "object" && d !== null && (d as { id?: unknown }).id === id,
+			);
+			return deployment
+				? fulfillJson(r, readDeploymentFixture(deployment))
+				: fulfillJson(r, { detail: "Deployment not found" }, 404);
 		}
 		return fulfillJson(r, {});
 	});

--- a/apps/web/e2e/hosted-wallet-billing.pw.ts
+++ b/apps/web/e2e/hosted-wallet-billing.pw.ts
@@ -9,12 +9,7 @@ import {
 	walletPastDueDeployment,
 } from "./hosted-stub-api";
 
-// The walletPastDueDeployment fixture predates the current DeploymentRead
-// shape (inventory render crashes on it) — re-enable after modernizing the
-// fixture to the live contract.
-test.skip("wallet top-up completion refreshes an automatically paid open invoice", async ({
-	page,
-}) => {
+test("wallet top-up completion refreshes an automatically paid open invoice", async ({ page }) => {
 	const errors = collectBrowserErrors(page);
 	const deployments: unknown[] = [walletPastDueDeployment];
 	const topUpRequests: string[] = [];
@@ -36,12 +31,12 @@ test.skip("wallet top-up completion refreshes an automatically paid open invoice
 	await expect(page.getByRole("button", { name: /Retry payment/ })).toHaveCount(0);
 
 	await pastDueAlert.getByRole("button", { name: "Top up" }).click();
-	const topUpDialog = page.getByRole("dialog").filter({ hasText: "Top up AI Credits" });
+	const topUpDialog = page.getByRole("dialog").filter({ hasText: "Top up Wallet" });
 	await expect(topUpDialog).toBeVisible();
 	await topUpDialog.getByRole("button", { name: "Continue with $25.00" }).click();
 
 	await expect.poll(() => topUpRequests.length).toBe(1);
-	await expect(page.getByText("Top-up complete", { exact: true })).toBeVisible();
+	await expect(page.getByText("Payment accepted", { exact: true })).toBeVisible();
 	await expect(pastDueAlert).toHaveCount(0);
 	await expect(page.getByText("Wallet", { exact: true })).toBeVisible();
 	expect(JSON.parse(topUpRequests[0] ?? "{}")).toEqual({ amount_cents: 2_500 });

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -1,4 +1,4 @@
-import { expect, type Locator, type Page, type Route, test } from "@playwright/test";
+import { expect, type Page, type Route, test } from "@playwright/test";
 
 const now = new Date("2026-07-04T12:00:00.000Z");
 
@@ -162,7 +162,7 @@ const sessions = {
 	page: 1,
 	page_size: 25,
 };
-const overviewSessions = {
+const _overviewSessions = {
 	...sessions,
 	items: Array.from({ length: 5 }, (_, index) => ({
 		...sessions.items[0],

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -26,7 +26,7 @@ import { shouldBlockQueryError } from "@/lib/query-state";
 import { type SessionListQuery, sessionListQueryOptions } from "@/lib/session-queries";
 import { parseAsPositiveInt } from "@/lib/url-search-parsers";
 import { useDebouncedValue } from "@/lib/use-debounced";
-import { cn, recencyBucketFor } from "@/lib/utils";
+import { cn, formatNumber, recencyBucketFor } from "@/lib/utils";
 
 // `relevance` (trgm similarity) joins the legacy date/count sorts.
 // Relevance is special-cased server-side: it's only meaningful when q
@@ -267,6 +267,11 @@ function SessionsListInner() {
 			}
 			actions={
 				<>
+					{isFiltered && data ? (
+						<span className="text-xs text-muted-foreground tabular-nums">
+							{formatNumber(total)} {total === 1 ? "result" : "results"}
+						</span>
+					) : null}
 					{isFiltered ? (
 						<Button
 							variant="ghost"


### PR DESCRIPTION
## What

Closes out the two remaining skipped hosted tests and the last journey nitpick:

- **BYOK provider save** — unskipped and repaired end to end: the chooser step (pick OpenAI first), strict selectors, and `hosted-fixtures.ts` now serves the current contract (`/v1/ai-providers/accept` + `/test`, current `AiProviderResponse` shape for the managed provider).
- **Wallet top-up refresh** — unskipped and repaired: the shared fixture readers (`mutationDeploymentReadFixture`/`readDeploymentFixture` etc.) moved from `hosted-smoke.pw.ts` into `hosted-stub-api.ts` so both suites use one current-shape builder; the stub now wraps flat fixtures as `DeploymentRead` on list and detail reads (the July flat fixtures crashed the inventory render); copy updated ("Top up Wallet" dialog, "Payment accepted" toast).
- **Sessions search result count** — the sessions list now shows "N results" next to Reset whenever filters/search are active (the J1 nitpick from the journey audit).

## Verification

- Hosted suite 18/18 green locally (0 skips left)
- OSS suite 25/25 green
- typecheck / biome / 979 unit tests clean