### PR TITLE
chore(web): regenerate deploy client for the slim v2 public contract

### DIFF
--- a/apps/web/e2e/hosted-stub-api.ts
+++ b/apps/web/e2e/hosted-stub-api.ts
@@ -150,7 +150,6 @@ export function mutationDeploymentReadFixture(
 		resource: {
 			id: deployment.id,
 			name: deployment.name,
-			owner_user_id: deployment.user_id,
 			commercial_revision: 1,
 			deployment_target: "saas",
 			metadata: {
@@ -186,7 +185,6 @@ export function mutationDeploymentReadFixture(
 				observedGeneration: 1,
 				conditions: [],
 				failure,
-				backing_infrastructure: backingInfrastructure,
 				driver_acknowledged_generation: 1,
 				driver_applied_generation: 1,
 				driver_observation_sequence: 1,

--- a/apps/web/src/hosted/hosted-deployment.test-fixture.ts
+++ b/apps/web/src/hosted/hosted-deployment.test-fixture.ts
@@ -20,7 +20,7 @@ type HostedDeploymentFixtureOptions = {
 	resources?: HostedDeploymentSpec["resources"];
 	endpoints?: HostedDeploymentStatus["endpoints"];
 	failure?: HostedDeploymentStatus["failure"];
-	backingInfrastructure?: HostedDeploymentStatus["backing_infrastructure"];
+	backingInfrastructure?: NonNullable<HostedDeployment["compute_slot_occupancy"]>["backing_infra"];
 	computeSubscription?: HostedComputeSubscription | null;
 	fundingFact?: HostedFundingFact | null;
 	occupiesSlot?: boolean;
@@ -51,7 +51,6 @@ export function hostedDeploymentFixture(
 		resource: {
 			id: options.id ?? "dep_test",
 			name: options.name ?? "Test deployment",
-			owner_user_id: "usr_test",
 			commercial_revision: 0,
 			deployment_target: "saas",
 			metadata: {
@@ -84,7 +83,6 @@ export function hostedDeploymentFixture(
 							observedGeneration: 1,
 							conditions: [],
 							failure: options.failure,
-							backing_infrastructure: backingInfrastructure,
 							driver_acknowledged_generation: 1,
 							driver_applied_generation: 1,
 							driver_observation_sequence: 1,

--- a/packages/shared/src/api/deploy-wizard.test.ts
+++ b/packages/shared/src/api/deploy-wizard.test.ts
@@ -66,7 +66,6 @@ function includedDeployment(occupiesSlot: boolean | null): HostedDeployDeploymen
 		resource: {
 			id: "hdep_test",
 			name: "Hermes",
-			owner_user_id: "usr_test",
 			commercial_revision: 0,
 			deployment_target: "test",
 			metadata: {
@@ -92,7 +91,6 @@ function includedDeployment(occupiesSlot: boolean | null): HostedDeployDeploymen
 				summary_state: "running",
 				observedGeneration: 1,
 				conditions: [],
-				backing_infrastructure: "present",
 				driver_acknowledged_generation: 1,
 				driver_applied_generation: 1,
 				driver_observation_sequence: 1,

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -768,22 +768,10 @@ export interface components {
             /** Name */
             name: string;
             /**
-             * Owner User Id
-             * Format: sqid
-             * @example usr_K8fJ3pQm
-             */
-            owner_user_id: string;
-            /** Commercial Reference */
-            commercial_reference?: string | null;
-            /** Commercial Event Id */
-            commercial_event_id?: string | null;
-            /**
              * Commercial Revision
              * @default 0
              */
             commercial_revision: number;
-            /** Deploy Request Id */
-            deploy_request_id?: string | null;
             /** Deployment Target */
             deployment_target: string;
             metadata: components["schemas"]["DeploymentMetadata"];
@@ -848,12 +836,6 @@ export interface components {
              */
             conditions: components["schemas"]["DeploymentCondition"][];
             failure?: components["schemas"]["LifecycleFailureOccurrence"] | null;
-            /**
-             * Backing Infrastructure
-             * @default unknown
-             * @enum {string}
-             */
-            backing_infrastructure: "present" | "absent" | "unknown";
             /** Driver Acknowledged Generation */
             driver_acknowledged_generation: number;
             /** Driver Applied Generation */


### PR DESCRIPTION
Companion to Clawdi-AI/clawdi-hosted#1549 (merged + deployed; live openapi verified to no longer carry the stripped fields). Regenerates `deploy.generated.ts` from the live spec (−18 lines, exactly the five stripped fields) and removes those fields from test fixtures and the e2e stub. No production code reads any of the stripped fields (surveyed in the P3/P5 reports).

Verification: turbo typecheck green (4/4), `bun test` 651 pass / 0 fail, `check-deploy-generated-api.sh` green against live spec, biome clean, hosted playwright config collects 148 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)