### PR TITLE
fix(web): one Library group, no split, no separator

### DIFF
--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -569,8 +569,7 @@ test("Console and connected agents use the scoped navigation grammar", async ({ 
 	await page.goto("/");
 	await expectSidebarNavigationGroups(page, [
 		{ label: null, items: ["Overview", "Agents", "Sessions", "Memories"] },
-		{ label: "Library", items: ["Projects", "Skills", "Vaults"] },
-		{ label: "Integrations", items: ["Connectors"] },
+		{ label: "Library", items: ["Projects", "Skills", "Vaults", "Connectors"] },
 	]);
 
 	await page.goto("/agents/agent-smoke-1");

--- a/apps/web/src/lib/navigation-model.test.ts
+++ b/apps/web/src/lib/navigation-model.test.ts
@@ -30,7 +30,7 @@ function groupShape(
 
 function expectNavigationHeadings(
 	groups: ReadonlyArray<{ label: string | null; items: readonly unknown[] }>,
-	expected = ["Library", "Integrations"],
+	expected = ["Library"],
 ) {
 	expect(groups.filter((group) => group.label !== null).map((group) => group.label)).toEqual(
 		expected,
@@ -61,24 +61,21 @@ describe("sidebar navigation model", () => {
 					{ id: "projects", label: "Projects" },
 					{ id: "skills", label: "Skills" },
 					{ id: "vaults", label: "Vaults" },
-				],
-			},
-			{
-				id: "integrations",
-				label: "Integrations",
-				separated: true,
-				items: [
+					{ id: "connectors", label: "Connectors" },
 					{ id: "channels", label: "Channels" },
 					{ id: "ai-providers", label: "AI Providers" },
-					{ id: "connectors", label: "Connectors" },
 				],
 			},
 		]);
 		expectNavigationHeadings(cloudGroups);
 
 		const ossGroups = consoleNavigationGroups(false);
-		expect(ossGroups[1]?.items.map((item) => item.id)).toEqual(["projects", "skills", "vaults"]);
-		expect(ossGroups[2]?.items.map((item) => item.id)).toEqual(["connectors"]);
+		expect(ossGroups[1]?.items.map((item) => item.id)).toEqual([
+			"projects",
+			"skills",
+			"vaults",
+			"connectors",
+		]);
 		expectNavigationHeadings(ossGroups);
 	});
 
@@ -99,9 +96,9 @@ describe("sidebar navigation model", () => {
 			"projects",
 			"skills",
 			"vaults",
+			"connectors",
 			"channels",
 			"ai-providers",
-			"connectors",
 		]);
 	});
 

--- a/apps/web/src/lib/navigation-model.ts
+++ b/apps/web/src/lib/navigation-model.ts
@@ -61,7 +61,7 @@ type ConsoleNavigationItemId =
 	| "channels"
 	| "ai-providers";
 
-type ConsoleNavigationGroupId = "primary" | "library" | "integrations";
+type ConsoleNavigationGroupId = "primary" | "library";
 
 type ConsoleCommandPaletteMetadata = {
 	subtitle: string;
@@ -222,14 +222,10 @@ const CONSOLE_NAVIGATION_GROUPS = [
 	{
 		id: "library",
 		label: "Library",
-		itemIds: ["projects", "skills", "vaults"],
+		// Assets first (mirrors the dashboard Library card), integrations last;
+		// cloud-gated items drop out in OSS without disturbing the order.
+		itemIds: ["projects", "skills", "vaults", "connectors", "channels", "ai-providers"],
 		separated: false,
-	},
-	{
-		id: "integrations",
-		label: "Integrations",
-		itemIds: ["channels", "ai-providers", "connectors"],
-		separated: true,
 	},
 ] as const satisfies readonly {
 	id: ConsoleNavigationGroupId;

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -104,7 +104,7 @@ Severity legend for open gaps: 🔴 blocks · 🟡 friction · ⚪ nitpick.
 
 ## 12. Connectors / channels
 
-- **Path**: Integrations → Connectors → catalog → connect (OAuth returns
+- **Path**: Library → Connectors → catalog → connect (OAuth returns
   to the same page; state params clean themselves up). Hosted adds
   Channels/AI Providers.
 - **Guards**: connector nested-navigation e2e; hosted channel suites.


### PR DESCRIPTION
## What

#888 split the console nav into Library + Integrations with a separator — an unasked invention that broke vocabulary consistency with the agent sidebar and the dashboard Library card. Reverted to a single **Library** group everywhere:

- Console sidebar: one Library group — Projects, Skills, Vaults, Connectors (+ Channels, AI Providers when hosted; they drop out in OSS without disturbing the order). Assets first, mirroring the dashboard Library card; integrations last; no separator.
- Group id back to a single \`library\`; palette order follows.
- Tests and e2e grammar assertions updated; journey doc corrected.

## Verification

- navigation-model unit tests, typecheck, biome clean
- Full OSS e2e 25/25 green
- Sidebar screenshot verified: one Library group, no separator