### PR TITLE
fix(web): converge on one Library vocabulary, flatten dashboard Library card

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1191,9 +1191,7 @@ function FocusHeader({
 		return (
 			<div className="min-w-0">
 				<div className="truncate text-sm font-semibold leading-5">Console</div>
-				<div className="truncate text-xs leading-4 text-muted-foreground">
-					Account resources and agents
-				</div>
+				<div className="truncate text-xs leading-4 text-muted-foreground">Library and agents</div>
 			</div>
 		);
 	}

--- a/apps/web/src/components/dashboard/resources-card.tsx
+++ b/apps/web/src/components/dashboard/resources-card.tsx
@@ -9,11 +9,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import type { DashboardStats } from "@/lib/api-schemas";
 import {
 	getProjectResourceDefinition,
-	PROJECT_RESOURCE_GROUPS,
-	PROJECT_RESOURCE_NAV_IDS,
 	type ProjectResourceDefinition,
 	projectResourceCount,
-	projectResourceDefinitionsForGroup,
 	projectResourceScopeLabel,
 } from "@/lib/project-resource-model";
 import { RESOURCE_TINT_CLASSES } from "@/lib/resource-identity";
@@ -25,8 +22,10 @@ type Resource = {
 	count: number | null;
 };
 
+const LIBRARY_ROW_IDS = ["projects", "skills", "vaults", "connectors"] as const;
+
 function buildResources(stats: DashboardStats): Resource[] {
-	return PROJECT_RESOURCE_NAV_IDS.map((id) => {
+	return LIBRARY_ROW_IDS.map((id) => {
 		const definition = getProjectResourceDefinition(id);
 		return {
 			icon: PROJECT_RESOURCE_ICONS[id],
@@ -62,18 +61,11 @@ export function ResourcesCard({
 					</div>
 				) : (
 					<div className="divide-y">
-						{ready ? (
-							<ProjectResourceGroups resources={buildResources(stats)} />
-						) : (
-							PROJECT_RESOURCE_GROUPS.map((group) => (
-								<div key={group.id}>
-									{group.resourceIds.length > 1 ? <ResourceGroupLabel label={group.label} /> : null}
-									{group.resourceIds.map((id) => (
-										<ResourceRowSkeleton key={id} />
-									))}
-								</div>
-							))
-						)}
+						{ready
+							? buildResources(stats).map((resource) => (
+									<ResourceRow key={resource.definition.id} resource={resource} />
+								))
+							: LIBRARY_ROW_IDS.map((id) => <ResourceRowSkeleton key={id} />)}
 					</div>
 				)}
 				{ready && stats.projects_count === 0 ? (
@@ -90,29 +82,6 @@ export function ResourcesCard({
 				) : null}
 			</CardContent>
 		</Card>
-	);
-}
-
-function ProjectResourceGroups({ resources }: { resources: Resource[] }) {
-	const byId = new Map(resources.map((resource) => [resource.definition.id, resource]));
-	return (
-		<>
-			{PROJECT_RESOURCE_GROUPS.map((group) => (
-				<div key={group.id}>
-					{group.resourceIds.length > 1 ? <ResourceGroupLabel label={group.label} /> : null}
-					{projectResourceDefinitionsForGroup(group.id).map((definition) => {
-						const resource = byId.get(definition.id);
-						return resource ? <ResourceRow key={definition.id} resource={resource} /> : null;
-					})}
-				</div>
-			))}
-		</>
-	);
-}
-
-function ResourceGroupLabel({ label }: { label: string }) {
-	return (
-		<div className="bg-muted/20 px-6 py-2 text-xs font-medium text-muted-foreground">{label}</div>
 	);
 }
 

--- a/apps/web/src/components/projects/project-metadata.tsx
+++ b/apps/web/src/components/projects/project-metadata.tsx
@@ -584,7 +584,7 @@ export function projectKindMeta(kind: string): {
 		return {
 			label: "Private resources",
 			groupLabel: "Private resources",
-			description: "Private account resources.",
+			description: "Private library item.",
 			icon: FolderKanban,
 			iconClassName: "border-border bg-muted/50 text-muted-foreground",
 			badgeClassName: "border-border bg-muted/50 text-muted-foreground",

--- a/apps/web/src/lib/navigation-model.ts
+++ b/apps/web/src/lib/navigation-model.ts
@@ -132,9 +132,9 @@ function projectResourceNavigationItem(
 	const commandGroupLabel =
 		id === "projects"
 			? "Projects"
-			: id === "skills" || id === "vaults"
-				? "Project resources"
-				: "Account resources";
+			: id === "skills" || id === "vaults" || id === "connectors"
+				? "Library"
+				: "Account activity";
 	return {
 		id,
 		...CANONICAL_NAVIGATION_IDENTITIES[id],
@@ -192,7 +192,7 @@ export const CONSOLE_NAVIGATION_ITEMS: Record<
 		tooltip: "Channels — Account integrations",
 		availability: "cloud",
 		commandPalette: {
-			subtitle: "Account resources",
+			subtitle: "Library",
 			searchText: "channels telegram discord whatsapp bots messaging",
 		},
 	},
@@ -205,7 +205,7 @@ export const CONSOLE_NAVIGATION_ITEMS: Record<
 		tooltip: "AI Providers — Account integrations",
 		availability: "cloud",
 		commandPalette: {
-			subtitle: "Account resources",
+			subtitle: "Library",
 			searchText:
 				"model providers ai providers models openai anthropic openrouter gemini mistral byok api key",
 		},

--- a/apps/web/src/lib/project-resource-model.test.ts
+++ b/apps/web/src/lib/project-resource-model.test.ts
@@ -54,13 +54,14 @@ describe("project resource model", () => {
 			"projects",
 			"skills",
 			"vaults",
+			"connectors",
 			"sessions",
 			"memories",
-			"connectors",
 		]);
-		expect(projectResourceDefinitionsForGroup("project-resources").map((r) => r.id)).toEqual([
+		expect(projectResourceDefinitionsForGroup("library").map((r) => r.id)).toEqual([
 			"skills",
 			"vaults",
+			"connectors",
 		]);
 		expect(projectManagedResourceDefinitions().map((r) => r.id)).toEqual(["skills", "vaults"]);
 	});
@@ -68,7 +69,7 @@ describe("project resource model", () => {
 	it("renders stable user-facing scope labels", () => {
 		expect(projectResourceScopeLabel("container")).toBe("Project home");
 		expect(projectResourceScopeLabel("project-managed")).toBe("Saved in a Project");
-		expect(projectResourceScopeLabel("activity")).toBe("Account resources");
+		expect(projectResourceScopeLabel("activity")).toBe("Account activity");
 		expect(projectResourceScopeLabel("all-agents")).toBe("All agents");
 		expect(projectResourceScopeDescription(getProjectResourceDefinition("memories"))).toContain(
 			"all agents",
@@ -87,13 +88,13 @@ describe("project resource model", () => {
 			"Projects / Selected Project / Vaults",
 		);
 		expect(projectResourcePathLabel(getProjectResourceDefinition("sessions"))).toBe(
-			"Account resources / Sessions",
+			"Activity / Sessions",
 		);
 		expect(projectResourcePathLabel(getProjectResourceDefinition("memories"))).toBe(
-			"Account resources / Memory",
+			"Activity / Memory",
 		);
 		expect(projectResourcePathLabel(getProjectResourceDefinition("connectors"))).toBe(
-			"Account resources / Connectors",
+			"Library / Connectors",
 		);
 		expect(getProjectResourceDefinition("vaults").navLabel).toBe("Vaults");
 		expect(getProjectResourceDefinition("vaults").href).toBe("/vaults");

--- a/apps/web/src/lib/project-resource-model.ts
+++ b/apps/web/src/lib/project-resource-model.ts
@@ -9,7 +9,7 @@ export type ProjectResourceId =
 	| "connectors";
 
 export type ProjectResourceScope = "container" | "project-managed" | "activity" | "all-agents";
-export type ProjectResourceGroup = "project-registry" | "project-resources" | "user-resources";
+export type ProjectResourceGroup = "projects" | "library" | "activity";
 
 export const PROJECT_RESOURCE_LIST_PATHS = {
 	projects: "/projects",
@@ -55,7 +55,7 @@ const PROJECT_RESOURCE_DEFINITIONS = [
 			"Create shareable Projects that bundle Skills with attached Vault access. Each Agent also has a private Workspace on that Agent's page.",
 		href: PROJECT_RESOURCE_LIST_PATHS.projects,
 		emptyCta: "Create project",
-		routeGroup: "project-registry",
+		routeGroup: "projects",
 		projectScope: "container",
 		pathSegments: ["Projects"],
 		countLabel: "projects",
@@ -70,7 +70,7 @@ const PROJECT_RESOURCE_DEFINITIONS = [
 			"Skills belong to Projects. Choose a Project before adding, editing, removing, copying, or moving a Skill. Linked Agents use the whole Project bundle.",
 		href: PROJECT_RESOURCE_LIST_PATHS.skills,
 		emptyCta: "Add skill",
-		routeGroup: "project-resources",
+		routeGroup: "library",
 		projectScope: "project-managed",
 		pathSegments: ["Projects", "Selected Project", "Skills"],
 		projectQueryParam: "project",
@@ -87,7 +87,7 @@ const PROJECT_RESOURCE_DEFINITIONS = [
 			"Keep API keys in a Vault, then attach it to the Projects where Agents should use those keys.",
 		href: PROJECT_RESOURCE_LIST_PATHS.vaults,
 		emptyCta: "Create vault",
-		routeGroup: "project-resources",
+		routeGroup: "library",
 		projectScope: "project-managed",
 		pathSegments: ["Projects", "Selected Project", "Vaults"],
 		projectQueryParam: "project",
@@ -104,9 +104,9 @@ const PROJECT_RESOURCE_DEFINITIONS = [
 			"Sessions are agent activity. Browse conversations and filter by the agent that produced them.",
 		href: PROJECT_RESOURCE_LIST_PATHS.sessions,
 		emptyCta: "Start syncing",
-		routeGroup: "user-resources",
+		routeGroup: "activity",
 		projectScope: "activity",
-		pathSegments: ["Account resources", "Sessions"],
+		pathSegments: ["Activity", "Sessions"],
 		statsKey: "total_sessions",
 		countLabel: "sessions",
 	},
@@ -119,9 +119,9 @@ const PROJECT_RESOURCE_DEFINITIONS = [
 		managementDescription: "Memories are shared across all agents in this account.",
 		href: PROJECT_RESOURCE_LIST_PATHS.memories,
 		emptyCta: "Create memory",
-		routeGroup: "user-resources",
+		routeGroup: "activity",
 		projectScope: "all-agents",
-		pathSegments: ["Account resources", "Memory"],
+		pathSegments: ["Activity", "Memory"],
 		statsKey: "memories_count",
 		countLabel: "memories",
 	},
@@ -134,9 +134,9 @@ const PROJECT_RESOURCE_DEFINITIONS = [
 		managementDescription: "Connect apps once to share approved tools across all agents.",
 		href: PROJECT_RESOURCE_LIST_PATHS.connectors,
 		emptyCta: "Browse connectors",
-		routeGroup: "user-resources",
+		routeGroup: "library",
 		projectScope: "all-agents",
-		pathSegments: ["Account resources", "Connectors"],
+		pathSegments: ["Library", "Connectors"],
 		statsKey: "connectors_count",
 		countLabel: "connectors",
 	},
@@ -144,19 +144,19 @@ const PROJECT_RESOURCE_DEFINITIONS = [
 
 export const PROJECT_RESOURCE_GROUPS = [
 	{
-		id: "project-registry",
+		id: "projects",
 		label: "Projects",
 		resourceIds: ["projects"],
 	},
 	{
-		id: "project-resources",
-		label: "Project resources",
-		resourceIds: ["skills", "vaults"],
+		id: "library",
+		label: "Library",
+		resourceIds: ["skills", "vaults", "connectors"],
 	},
 	{
-		id: "user-resources",
-		label: "Account resources",
-		resourceIds: ["sessions", "memories", "connectors"],
+		id: "activity",
+		label: "Activity",
+		resourceIds: ["sessions", "memories"],
 	},
 ] as const satisfies readonly {
 	id: ProjectResourceGroup;
@@ -243,7 +243,7 @@ export function projectResourceScopeLabel(scope: ProjectResourceScope): string {
 		case "project-managed":
 			return "Saved in a Project";
 		case "activity":
-			return "Account resources";
+			return "Account activity";
 		case "all-agents":
 			return "All agents";
 	}
@@ -252,7 +252,7 @@ export function projectResourceScopeLabel(scope: ProjectResourceScope): string {
 export function projectResourceScopeDescription(resource: ProjectResourceDefinition): string {
 	switch (resource.projectScope) {
 		case "container":
-			return "Start here to create shareable Projects or open Project resources.";
+			return "Start here to create shareable Projects, then browse the Library for reusable Skills and Vaults.";
 		case "project-managed":
 			return "Saved in a Project. Pick the Project before you add, edit, or remove it.";
 		case "activity":

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -1152,7 +1152,7 @@ export default function ProjectDetailPage({
 						project.kind === "environment"
 							? "Agent that owns this Workspace."
 							: project.kind === "personal"
-								? "Private account resources are not linked to individual Agents."
+								? "Private library items are not linked to individual Agents."
 								: "Agents you own that use this Project's Skills and attached Vaults."
 					}
 				>
@@ -1172,7 +1172,7 @@ export default function ProjectDetailPage({
 								project.kind === "environment"
 									? "The home Agent for this Workspace is unavailable."
 									: project.kind === "personal"
-										? "Private account resources have no Agent links."
+										? "Private library items have no Agent links."
 										: "None of your Agents are linked yet. Link this Project to let one use its Skills and attached Vaults."
 							}
 						/>


### PR DESCRIPTION
## What

The Library rename left the old grouping vocabulary alive inside the dashboard card and palette subtitles. This removes "Project resources" and "Account resources" from every user-facing surface:

- **Dashboard Library card**: flat rows now — Projects, Skills, Vaults, Connectors — no subgroup labels (Sessions/Memories rows removed; they're activity, already covered by Recent sessions and the primary nav).
- **Resource model**: groups renamed to `projects` / `library` / `activity`; path segments now read "Library / Connectors", "Activity / Sessions", "Activity / Memory"; scope label "activity" → "Account activity".
- **Palette subtitles** for Library items read "Library"; the console pane subtitle reads "Library and agents"; "Private account resources" → "Private library item(s)".
- Tests updated (nav order, group ids, scope labels, path labels).

## Verification

- 979 unit tests, typecheck, biome clean
- Full OSS e2e 25/25 green
- Dashboard screenshot verified: Library card is a flat 4-row list, no subgroup labels