### PR TITLE
fix(runtime): publish egress profiles through the sidecar handoff root

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.43",
+      "version": "0.13.44",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.43",
+	"version": "0.13.44",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/egress-profiles.ts
+++ b/packages/cli/src/runtime/egress-profiles.ts
@@ -1,7 +1,5 @@
 import { z } from "zod";
-import type { RuntimePaths } from "./paths";
 import { canonicalSecretRefSchema } from "./secret-values";
-import { writeRuntimePlatformFileAtomic } from "./state";
 
 export const secretRefSchema = canonicalSecretRefSchema;
 const profileIdSchema = z
@@ -250,17 +248,4 @@ export function buildEgressProfileBundle(input: {
 
 export function hasEnabledEgressProfiles(bundle: EgressProfileBundle): boolean {
 	return bundle.profiles.some((profile) => profile.enabled);
-}
-
-export function writeEgressProfileBundle(bundle: EgressProfileBundle, paths: RuntimePaths): string {
-	writeRuntimePlatformFileAtomic(
-		paths,
-		paths.egressProfileBundle,
-		`${JSON.stringify(bundle, null, 2)}\n`,
-		{
-			mode: 0o644,
-			dirMode: 0o755,
-		},
-	);
-	return paths.egressProfileBundle;
 }

--- a/packages/cli/src/runtime/live-state-snapshot.ts
+++ b/packages/cli/src/runtime/live-state-snapshot.ts
@@ -61,7 +61,7 @@ export function runtimeRootLiveMutationTargets(
 		paths.oauthCredentialRoot,
 		runtimeInstallReceiptsPath(paths),
 		paths.runConfigRoot,
-		paths.egressProfileRoot,
+		paths.egressProfileBundle,
 		paths.installInventory,
 		paths.projectionRoot,
 		join(paths.instanceRoot, manifest.instanceId),
@@ -178,7 +178,6 @@ export function runtimeRootLiveMutationDirectories(
 	return [
 		paths.runConfigRoot,
 		paths.systemdEnvRoot,
-		paths.egressProfileRoot,
 		paths.installInventory,
 		paths.oauthCredentialRoot,
 		paths.projectionRoot,

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -4581,7 +4581,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				paths.oauthCredentialRoot,
 				paths.installReceipts,
 				paths.runConfigRoot,
-				paths.egressProfileRoot,
+				paths.egressProfileBundle,
 				paths.installInventory,
 				paths.projectionRoot,
 				join(paths.instanceRoot, manifest.instanceId),

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -5745,13 +5745,7 @@ export function convergeRuntimeManifest(
 			makeRuntimeUserPrivateDir(paths.clawdiHome, paths.userHome);
 			makeRuntimeUserOwned(workspaceRoot);
 		});
-		for (const directory of [
-			paths.installInventory,
-			paths.projectionRoot,
-			instanceRoot,
-			semRoot,
-			paths.egressProfileRoot,
-		]) {
+		for (const directory of [paths.installInventory, paths.projectionRoot, instanceRoot, semRoot]) {
 			ensureRuntimePlatformDirectory(paths, directory, { mode: 0o755 });
 		}
 		ensureRuntimePlatformDirectory(paths, paths.managedSecretRoot);

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -157,9 +157,9 @@ export {
 import { MANAGED_EGRESS_PLACEHOLDER_VALUE, SYSTEM_CA_BUNDLE } from "./egress-env";
 import {
 	buildEgressProfileBundle,
+	type EgressProfileBundle,
 	egressProfileSecretRefs,
 	hasEnabledEgressProfiles,
-	writeEgressProfileBundle,
 } from "./egress-profiles";
 import {
 	loadCommittedRuntimeManifest,
@@ -4415,6 +4415,24 @@ function requireV2EgressEngineReady(
 			`required egress engine is not ready: ${engine?.error ?? "status unavailable"}`,
 		);
 	}
+}
+
+function writeEgressProfileBundle(bundle: EgressProfileBundle, paths: RuntimePaths): string {
+	// Published handoff: the egress sidecar (clawdi-egress uid) reads this
+	// bundle, so it lives under the traversable run root next to the other
+	// sidecar inputs (addon, transparent env, CA) — never under a private
+	// platform root the sidecar cannot traverse.
+	writeRuntimePrivateFileAtomic(
+		paths,
+		paths.egressProfileBundle,
+		`${JSON.stringify(bundle, null, 2)}\n`,
+		{
+			mode: 0o640,
+			dirMode: 0o711,
+		},
+	);
+	if (runningAsRoot()) chownSync(paths.egressProfileBundle, 0, runtimeEgressGid());
+	return paths.egressProfileBundle;
 }
 
 function writeEgressAddon(paths: RuntimePaths): { path: string; sha256: string } {

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -210,8 +210,8 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 		appliedState: join(statusRoot, "runtime-applied.json"),
 		managedSecretCacheFile: join(cacheRoot, "runtime-secrets.last-good.json"),
 		runConfigRoot: join(configurationRoot, "run"),
-		egressProfileRoot: join(configurationRoot, "egress"),
-		egressProfileBundle: join(configurationRoot, "egress", "profiles.json"),
+		egressProfileRoot: join(runRoot, "egress"),
+		egressProfileBundle: join(runRoot, "egress", "profiles.json"),
 		liveSyncEnvironmentIndex: join(configurationRoot, "runtime-live-sync-agents.json"),
 		systemdSystemRoot:
 			envPath("CLAWDI_SYSTEMD_SYSTEM_ROOT") ?? defaultSystemdSystemRoot(mode, runRoot),

--- a/packages/cli/src/runtime/state.ts
+++ b/packages/cli/src/runtime/state.ts
@@ -259,7 +259,10 @@ export function ensureRuntimeStateDirs(paths = getRuntimePaths()): void {
 		[paths.installInventory, 0o755],
 		[paths.projectionRoot, 0o755],
 		[paths.runConfigRoot, 0o755],
-		[paths.egressProfileRoot, 0o755],
+		// Egress profile bundle handoff dir under the traversable run root:
+		// 0711 lets the sidecar identity reach the named bundle without letting
+		// any identity list the directory. Matches writeEgressAddon's dirMode.
+		[paths.egressProfileRoot, 0o711],
 		[paths.systemdSystemRoot, 0o755],
 		[paths.systemdEnvRoot, 0o711],
 		[dirname(paths.syncState), 0o755],

--- a/packages/cli/tests/commands/run.test.ts
+++ b/packages/cli/tests/commands/run.test.ts
@@ -562,9 +562,9 @@ describe("run command project folder selection", () => {
 		const runRoot = join(tmpRoot, "run", "clawdi");
 		const hermesPath = join(tmpRoot, "home", "clawdi", ".local", "bin", "hermes");
 		const runConfigRoot = join(tmpRoot, "etc", "clawdi", "run");
-		const egressProfileBundle = join(tmpRoot, "etc", "clawdi", "egress", "profiles.json");
+		const egressProfileBundle = join(tmpRoot, "run", "clawdi", "egress", "profiles.json");
 		mkdirSync(runConfigRoot, { recursive: true });
-		mkdirSync(join(tmpRoot, "etc", "clawdi", "egress"), { recursive: true });
+		mkdirSync(join(tmpRoot, "run", "clawdi", "egress"), { recursive: true });
 		mkdirSync(join(tmpRoot, "home", "clawdi", ".local", "bin"), { recursive: true });
 		writeFileSync(egressProfileBundle, "{}\n");
 		writeFileSync(
@@ -628,9 +628,9 @@ describe("run command project folder selection", () => {
 		const runRoot = join(tmpRoot, "run", "clawdi");
 		const hermesPath = join(tmpRoot, "home", "clawdi", ".local", "bin", "hermes");
 		const runConfigRoot = join(tmpRoot, "etc", "clawdi", "run");
-		const egressProfileBundle = join(tmpRoot, "etc", "clawdi", "egress", "profiles.json");
+		const egressProfileBundle = join(tmpRoot, "run", "clawdi", "egress", "profiles.json");
 		mkdirSync(runConfigRoot, { recursive: true });
-		mkdirSync(join(tmpRoot, "etc", "clawdi", "egress"), { recursive: true });
+		mkdirSync(join(tmpRoot, "run", "clawdi", "egress"), { recursive: true });
 		mkdirSync(join(tmpRoot, "home", "clawdi", ".local", "bin"), { recursive: true });
 		writeFileSync(egressProfileBundle, "{}\n");
 		writeFileSync(
@@ -669,9 +669,9 @@ describe("run command project folder selection", () => {
 		const runRoot = join(tmpRoot, "run", "clawdi");
 		const hermesPath = join(tmpRoot, "home", "clawdi", ".local", "bin", "hermes");
 		const runConfigRoot = join(tmpRoot, "etc", "clawdi", "run");
-		const egressProfileBundle = join(tmpRoot, "etc", "clawdi", "egress", "profiles.json");
+		const egressProfileBundle = join(tmpRoot, "run", "clawdi", "egress", "profiles.json");
 		mkdirSync(runConfigRoot, { recursive: true });
-		mkdirSync(join(tmpRoot, "etc", "clawdi", "egress"), { recursive: true });
+		mkdirSync(join(tmpRoot, "run", "clawdi", "egress"), { recursive: true });
 		mkdirSync(join(tmpRoot, "home", "clawdi", ".local", "bin"), { recursive: true });
 		writeFileSync(
 			egressProfileBundle,
@@ -733,8 +733,8 @@ describe("run command project folder selection", () => {
 		unlinkSync(join(fakeClawdiHome, "auth.json"));
 		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
 		const runRoot = join(tmpRoot, "run", "clawdi");
-		const egressProfileBundle = join(tmpRoot, "etc", "clawdi", "egress", "profiles.json");
-		mkdirSync(join(tmpRoot, "etc", "clawdi", "egress"), { recursive: true });
+		const egressProfileBundle = join(tmpRoot, "run", "clawdi", "egress", "profiles.json");
+		mkdirSync(join(tmpRoot, "run", "clawdi", "egress"), { recursive: true });
 		writeFileSync(
 			egressProfileBundle,
 			JSON.stringify({
@@ -792,9 +792,9 @@ describe("run command project folder selection", () => {
 	it("does not inject cloud-managed AI provider keys into hosted runtime commands", async () => {
 		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
 		const runRoot = join(tmpRoot, "run", "clawdi");
-		const egressProfileBundle = join(tmpRoot, "etc", "clawdi", "egress", "profiles.json");
+		const egressProfileBundle = join(tmpRoot, "run", "clawdi", "egress", "profiles.json");
 		const catalogDir = join(fakeClawdiHome, "ai-providers");
-		mkdirSync(join(tmpRoot, "etc", "clawdi", "egress"), { recursive: true });
+		mkdirSync(join(tmpRoot, "run", "clawdi", "egress"), { recursive: true });
 		mkdirSync(catalogDir, { recursive: true });
 		writeFileSync(
 			egressProfileBundle,

--- a/packages/cli/tests/egress-handoff-access-contract.test.ts
+++ b/packages/cli/tests/egress-handoff-access-contract.test.ts
@@ -373,8 +373,6 @@ describe("runtime handoff filesystem access contract", () => {
 
 	test("the tenant workload user (uid 10001) cannot read any platform-rendered file", () => {
 		const { paths, root } = convergeHostedEgressFixture();
-		const files = platformRenderedFiles(paths);
-		expect(files.length).toBeGreaterThan(10);
 		const labels = new Map<string, string>([
 			[paths.managedConfig, "hosted managed config"],
 			[paths.runtimeContextFile, "runtime context"],
@@ -387,6 +385,7 @@ describe("runtime handoff filesystem access contract", () => {
 			[paths.egressProfileBundle, "egress profile bundle"],
 			[paths.egressTransparentEnv, "transparent-egress env handoff"],
 			[paths.egressAddon, "egress addon script"],
+			[paths.egressSystemCaFile, "tenant-published CA bundle"],
 			[join(paths.managedSecretRoot, "egress-secrets.json"), "egress sidecar secrets"],
 			[paths.daemonAuthToken, "daemon auth token"],
 			[paths.bootStatus, "boot status"],
@@ -415,6 +414,8 @@ describe("runtime handoff filesystem access contract", () => {
 			chownSync(paths.egressSystemCaFile, 0, TENANT_GID);
 		}
 		const publishedCaOwner = { uid: 0, gid: TENANT_GID };
+		const files = platformRenderedFiles(paths);
+		expect(files.length).toBeGreaterThan(10);
 
 		for (const file of files) {
 			const label = labels.get(file) ?? `platform-rendered file ${file}`;

--- a/packages/cli/tests/egress-handoff-access-contract.test.ts
+++ b/packages/cli/tests/egress-handoff-access-contract.test.ts
@@ -1,0 +1,454 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import {
+	chmodSync,
+	chownSync,
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { convergeRuntimeManifest } from "../src/runtime/manifest";
+import { normalizeHostedRuntimeBundleV2 } from "../src/runtime/manifest-source";
+import { getRuntimePaths, type RuntimePaths } from "../src/runtime/paths";
+import { ensureRuntimeStateDirs } from "../src/runtime/state";
+
+/**
+ * Hosted tenant platform-identity contract.
+ *
+ * The tenant image runs three filesystem identities:
+ *  - root: boot + convergence writes every platform artifact,
+ *  - uid/gid 10001: the tenant workload user (member of no privileged groups),
+ *  - uid/gid 10002: the egress sidecar identity that mitmproxy drops to.
+ *
+ * /etc/clawdi, /var/lib/clawdi, and /var/cache/clawdi are 0700 root-owned;
+ * /run/clawdi is 0711 root-owned so only explicitly named handoff files are
+ * reachable by other identities. This test simulates kernel access checks
+ * (traversal needs x on every ancestor, read needs r on the file itself)
+ * because CI runs the suite as an unprivileged user and the writers only
+ * chown when running as root. The `intendedOwner` tables below encode the
+ * ownership the writers apply in production (each entry cites its writer);
+ * when the suite actually runs as root, a guarded assertion additionally
+ * verifies stat(uid/gid) matches the intended ownership, proving the
+ * writers' chown calls.
+ */
+const TENANT_UID = 10_001;
+const TENANT_GID = 10_001;
+const EGRESS_UID = 10_002;
+const EGRESS_GID = 10_002;
+
+interface LinuxIdentity {
+	uid: number;
+	gid: number;
+}
+
+const TENANT: LinuxIdentity = { uid: TENANT_UID, gid: TENANT_GID };
+const EGRESS: LinuxIdentity = { uid: EGRESS_UID, gid: EGRESS_GID };
+
+const HANDOFF_TEST_SECRET_REF = "secret://handoff/access-contract";
+
+const fixtureRoots: string[] = [];
+
+afterAll(() => {
+	for (const root of fixtureRoots) rmSync(root, { recursive: true, force: true });
+});
+
+function permissionGranted(
+	mode: number,
+	identity: LinuxIdentity,
+	nodeUid: number,
+	nodeGid: number,
+	ownerBit: number,
+): boolean {
+	if (nodeUid === identity.uid) return (mode & ownerBit) !== 0;
+	if (nodeGid === identity.gid) return (mode & (ownerBit >> 3)) !== 0;
+	return (mode & (ownerBit >> 6)) !== 0;
+}
+
+/** Simulates the kernel walking `path` from the fixture root for `identity`. */
+function accessVerdict(
+	path: string,
+	fixtureRoot: string,
+	identity: LinuxIdentity,
+	intendedOwner: { uid: number; gid: number } | undefined,
+	fileCheck: "read" | "traverse",
+): { allowed: boolean; blockedBy: string; nodeMode: number } {
+	const owned = intendedOwner
+		? () => intendedOwner
+		: () => {
+				const stat = lstatSync(path);
+				return { uid: stat.uid, gid: stat.gid };
+			};
+	const relative = path.slice(fixtureRoot.length + 1);
+	const parts = relative.split("/");
+	let current = fixtureRoot;
+	for (let index = 0; index < parts.length - 1; index++) {
+		current = join(current, parts[index]);
+		const stat = lstatSync(current);
+		if (!permissionGranted(stat.mode, identity, stat.uid, stat.gid, 0o100)) {
+			return { allowed: false, blockedBy: current, nodeMode: stat.mode & 0o777 };
+		}
+	}
+	const fileStat = lstatSync(path);
+	const owner = owned();
+	const bit = fileCheck === "read" ? 0o400 : 0o100;
+	return {
+		allowed: permissionGranted(fileStat.mode, identity, owner.uid, owner.gid, bit),
+		blockedBy: path,
+		nodeMode: fileStat.mode & 0o777,
+	};
+}
+
+function assertIdentityCanAccess(
+	path: string,
+	fixtureRoot: string,
+	identity: LinuxIdentity,
+	label: string,
+	intendedOwner?: { uid: number; gid: number },
+	fileCheck: "read" | "traverse" = "read",
+): void {
+	const verdict = accessVerdict(path, fixtureRoot, identity, intendedOwner, fileCheck);
+	expect(
+		verdict.allowed,
+		`${label} must be accessible to ${identity.uid}:${identity.gid} (blocked at ${verdict.blockedBy}, mode ${verdict.nodeMode.toString(
+			8,
+		)})`,
+	).toBe(true);
+	if (intendedOwner && typeof process.getuid === "function" && process.getuid() === 0) {
+		const stat = statSync(path);
+		expect(stat.uid, `${label} owner`).toBe(intendedOwner.uid);
+		expect(stat.gid, `${label} group`).toBe(intendedOwner.gid);
+	}
+}
+
+function assertIdentityCannotAccess(
+	path: string,
+	fixtureRoot: string,
+	identity: LinuxIdentity,
+	label: string,
+	intendedOwner?: { uid: number; gid: number },
+): void {
+	const verdict = accessVerdict(path, fixtureRoot, identity, intendedOwner, "read");
+	expect(
+		verdict.allowed,
+		`${label} must NOT be readable by ${identity.uid}:${identity.gid} (traversal/read at ${verdict.blockedBy} granted, mode ${verdict.nodeMode.toString(8)})`,
+	).toBe(false);
+}
+
+/** Walks a platform root subtree and returns every regular file it contains. */
+function platformRenderedFiles(paths: RuntimePaths): string[] {
+	const roots = [paths.configurationRoot, paths.serviceStateRoot, paths.cacheRoot, paths.runRoot];
+	const walk = (directory: string, files: string[]): string[] => {
+		for (const entry of readdirSync(directory)) {
+			const path = join(directory, entry);
+			const stat = lstatSync(path);
+			if (stat.isDirectory()) {
+				walk(path, files);
+			} else if (stat.isFile()) {
+				files.push(path);
+			}
+		}
+		return files;
+	};
+	const files: string[] = [];
+	for (const root of roots) walk(root, files);
+	return files.filter((path) => roots.some((root) => path.startsWith(`${root}/`)));
+}
+
+function convergeHostedEgressFixture(): { paths: RuntimePaths; root: string } {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-handoff-access-"));
+	fixtureRoots.push(root);
+	const home = join(root, "home", "clawdi");
+	const state = join(root, "var", "lib", "clawdi");
+	const cache = join(root, "var", "cache", "clawdi");
+	const run = join(root, "run", "clawdi");
+	// Production (hosted, root) uses /run/systemd/system — systemd's own
+	// runtime unit directory, outside the clawdi platform roots, with
+	// systemd-prescribed 0755 directory modes. Mirror that topology so the
+	// platform-root walk sees the same boundaries production has.
+	const systemdSystemRoot = join(root, "systemd-run", "system");
+	mkdirSync(join(home, ".openclaw", "bin"), { recursive: true });
+	writeFileSync(
+		join(home, ".openclaw", "bin", "openclaw"),
+		`#!/bin/sh
+[ "\${1:-}" != "--version" ] || printf '%s\\n' '2026.7.1'
+exit 0
+`,
+	);
+	chmodSync(join(home, ".openclaw", "bin", "openclaw"), 0o755);
+
+	const originalEnv = { ...process.env };
+	process.env.HOME = home;
+	process.env.CLAWDI_RUNTIME_MODE = "hosted";
+	const runtimeUid = process.getuid?.() ?? 1_000;
+	const runtimeGid = process.getgid?.() ?? 1_000;
+	process.env.CLAWDI_RUNTIME_USER = String(runtimeUid);
+	process.env.CLAWDI_RUNTIME_UID = String(runtimeUid);
+	process.env.CLAWDI_RUNTIME_GID = String(runtimeGid);
+	process.env.CLAWDI_SERVICE_STATE_DIR = state;
+	process.env.CLAWDI_RUN_DIR = run;
+	process.env.CLAWDI_SYSTEMD_SYSTEM_ROOT = systemdSystemRoot;
+	process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
+	try {
+		// Mirror the tenant image: systemd directory directives pre-create the
+		// four platform roots with their canonical modes before the CLI runs.
+		for (const [path, mode] of [
+			[join(root, "etc", "clawdi"), 0o700],
+			[state, 0o700],
+			[cache, 0o700],
+			[run, 0o711],
+			// systemd pre-creates its runtime unit directory before the CLI.
+			[systemdSystemRoot, 0o755],
+		] as const) {
+			mkdirSync(path, { recursive: true, mode });
+			chmodSync(path, mode);
+		}
+
+		const paths = getRuntimePaths();
+		ensureRuntimeStateDirs(paths);
+		const engineBinary = join(
+			paths.egressEngineMaintainedRoot,
+			"12.2.3",
+			"2e95286b618fa6fd33e5e62a78c2e5112571d85f42ec2bac29b97ee242bdb5c5",
+			"mitmdump",
+		);
+		mkdirSync(dirname(engineBinary), { recursive: true });
+		writeFileSync(engineBinary, "#!/usr/bin/env sh\necho fake mitmdump\n");
+		chmodSync(engineBinary, 0o755);
+
+		const fixture = JSON.parse(
+			readFileSync(
+				join(import.meta.dir, "../../../test-fixtures/runtime-bundle-v2.golden.json"),
+				"utf-8",
+			),
+		) as Record<string, unknown>;
+		const manifest = fixture.manifest as Record<string, unknown>;
+		const runtimes = manifest.runtimes as Record<string, Record<string, unknown>>;
+		const openclaw = runtimes.openclaw;
+		openclaw.providerMode = "unmanaged";
+		openclaw.provider_ids = [];
+		delete openclaw.primary_model;
+		manifest.providers = {};
+		manifest.skills = { entries: {} };
+		manifest.egressProfiles = {
+			profiles: [
+				{
+					id: "access-contract",
+					enabled: true,
+					kind: "provider",
+					match: { scheme: "https", host: "api.example.test", headers: {}, query: {} },
+					rewrite: {
+						setHeaders: {
+							authorization: {
+								type: "secretRef",
+								secretRef: HANDOFF_TEST_SECRET_REF,
+								prefix: "Bearer ",
+							},
+						},
+					},
+					priority: 10,
+				},
+			],
+		};
+		fixture.secretValues = {
+			"secret://clawdi/auth-token": "handoff-runtime-auth-token",
+			"secret://runtime/openclaw/gateway-token": "handoff-gateway-token",
+			"secret://tool.codex.apiKey": "handoff-codex-key",
+			[HANDOFF_TEST_SECRET_REF]: "handoff-sidecar-secret",
+		};
+		const load = normalizeHostedRuntimeBundleV2(fixture);
+		load.applyContext = {
+			kind: "context-file",
+			backend: "incus",
+			identity: {
+				generation: 2,
+				manifestETag: '"manifest-handoff-access"',
+				applyReceiptId: "apply-receipt-handoff-access-0001",
+				bootNonce: "boot-nonce-handoff-access-0000001",
+			},
+			cliPackageSpec: "clawdi@1.2.3-test",
+			manifestSource: {
+				type: "http",
+				url: "https://runtime.test/v1/runtime/manifest",
+				auth: { type: "bearer", token: "bootstrap-bearer-handoff-access" },
+			},
+		};
+		const result = convergeRuntimeManifest(load, paths, {
+			hostedRuntimeContract: {
+				expectedIdentity: {
+					home,
+					user: String(runtimeUid),
+					uid: runtimeUid,
+					gid: runtimeGid,
+				},
+				resolveUserIdentity: () => ({ uid: runtimeUid, gid: runtimeGid }),
+			},
+		});
+		expect(result.installErrors).toEqual([]);
+		return { paths: getRuntimePaths(), root };
+	} finally {
+		for (const key of Object.keys(process.env)) {
+			if (!(key in originalEnv)) delete process.env[key];
+		}
+		Object.assign(process.env, originalEnv);
+	}
+}
+
+describe("runtime handoff filesystem access contract", () => {
+	test("the egress sidecar identity (uid 10002) can traverse and read every file it consumes", () => {
+		const { paths, root } = convergeHostedEgressFixture();
+
+		// Every path the egress sidecar opens. Owners are what the writers
+		// apply when running as root:
+		//  - writeTransparentEgressEnvFile: chownSync(path, 0, egressGid)
+		//  - writeEgressProfileBundle: chownSync(path, 0, egressGid)
+		//  - writeEgressAddon: chownSync(path, 0, egressGid)
+		//  - writeEgressSecretMaterial: makeEgressIdentityOwned(path)
+		//  - makeEgressIdentityPrivateDir: makeEgressIdentityOwned(path)
+		const egressConsumed = [
+			{
+				path: paths.egressTransparentEnv,
+				label: "transparent-egress env handoff",
+				mode: 0o640,
+				owner: { uid: 0, gid: EGRESS_GID },
+			},
+			{
+				path: paths.egressProfileBundle,
+				label: "egress profile bundle",
+				mode: 0o640,
+				owner: { uid: 0, gid: EGRESS_GID },
+			},
+			{
+				path: paths.egressAddon,
+				label: "egress addon script",
+				mode: 0o640,
+				owner: { uid: 0, gid: EGRESS_GID },
+			},
+			{
+				path: join(paths.managedSecretRoot, "egress-secrets.json"),
+				label: "egress sidecar secrets",
+				mode: 0o600,
+				owner: { uid: EGRESS_UID, gid: EGRESS_GID },
+			},
+			{
+				path: paths.egressCaDir,
+				label: "mitmproxy confdir",
+				mode: 0o700,
+				owner: { uid: EGRESS_UID, gid: EGRESS_GID },
+				fileCheck: "traverse" as const,
+			},
+		];
+
+		for (const entry of egressConsumed) {
+			expect(existsSync(entry.path), `${entry.label} must be rendered`).toBe(true);
+			expect(statSync(entry.path).mode & 0o777, `mode of ${entry.label}`).toBe(entry.mode);
+			assertIdentityCanAccess(
+				entry.path,
+				root,
+				EGRESS,
+				entry.label,
+				entry.owner,
+				entry.fileCheck ?? "read",
+			);
+		}
+
+		// mitmdump writes its CA cert into its confdir after starting; the
+		// file it creates inherits the egress-owned directory, and the
+		// engine reads it back through that same identity. The cert is not
+		// present right after convergence, so this assert only fires when a
+		// sidecar run has produced it (root-hosted local runs).
+		if (existsSync(paths.egressCaCert)) {
+			assertIdentityCanAccess(paths.egressCaCert, root, EGRESS, "mitmproxy CA cert", {
+				uid: EGRESS_UID,
+				gid: EGRESS_GID,
+			});
+		}
+	});
+
+	test("the tenant workload user (uid 10001) cannot read any platform-rendered file", () => {
+		const { paths, root } = convergeHostedEgressFixture();
+		const files = platformRenderedFiles(paths);
+		expect(files.length).toBeGreaterThan(10);
+		const labels = new Map<string, string>([
+			[paths.managedConfig, "hosted managed config"],
+			[paths.runtimeContextFile, "runtime context"],
+			[paths.syncState, "sync state"],
+			[paths.instanceData, "instance data"],
+			[paths.sensitiveInstanceData, "sensitive instance data"],
+			[paths.manifestLastGood, "last-good manifest cache"],
+			[paths.appliedState, "applied state"],
+			[paths.managedSecretCacheFile, "runtime secrets cache"],
+			[paths.egressProfileBundle, "egress profile bundle"],
+			[paths.egressTransparentEnv, "transparent-egress env handoff"],
+			[paths.egressAddon, "egress addon script"],
+			[join(paths.managedSecretRoot, "egress-secrets.json"), "egress sidecar secrets"],
+			[paths.daemonAuthToken, "daemon auth token"],
+			[paths.bootStatus, "boot status"],
+			[paths.cloudStatus, "cloud status"],
+			[paths.cloudResult, "cloud result"],
+			[paths.liveSyncEnvironmentIndex, "live-sync environment index"],
+			[paths.channelsEtag, "channels etag cache"],
+			[paths.runtimeWatchStatus, "runtime watch status"],
+		]);
+
+		const publishedToTenant = new Set([paths.egressSystemCaFile]);
+
+		// The sidecar runtime publishes the combined system+mitmproxy CA
+		// bundle to the tenant workload as its SSL_CERT_FILE. Convergence
+		// does not render it, so materialize it exactly the way
+		// publishEgressSystemCaBundle does (writePrivateFileAtomic with
+		// mode 0640 dirMode 0711, chown root:runtimeGid when root) to
+		// exercise the published handoff in both directions.
+		mkdirSync(dirname(paths.egressSystemCaFile), { recursive: true, mode: 0o711 });
+		chmodSync(dirname(paths.egressSystemCaFile), 0o711);
+		writeFileSync(paths.egressSystemCaFile, "# system CA bundle\n# mitmproxy CA cert\n", {
+			mode: 0o640,
+		});
+		chmodSync(paths.egressSystemCaFile, 0o640);
+		if (typeof process.getuid === "function" && process.getuid() === 0) {
+			chownSync(paths.egressSystemCaFile, 0, TENANT_GID);
+		}
+		const publishedCaOwner = { uid: 0, gid: TENANT_GID };
+
+		for (const file of files) {
+			const label = labels.get(file) ?? `platform-rendered file ${file}`;
+			if (publishedToTenant.has(file)) {
+				assertIdentityCanAccess(file, root, TENANT, label, publishedCaOwner);
+				continue;
+			}
+			assertIdentityCannotAccess(file, root, TENANT, label);
+		}
+
+		// The one explicit publish to the tenant must not leak anything else:
+		// every sidecar-consumed handoff that is group-readable by the egress
+		// identity is exercised explicitly above through the owned-by-table.
+		for (const file of [paths.egressProfileBundle, paths.egressTransparentEnv, paths.egressAddon]) {
+			assertIdentityCannotAccess(file, root, TENANT, `tenant denial of ${file}`);
+		}
+
+		// Systemd's runtime unit directory (/run/systemd/system in
+		// production) is systemd-managed 0755 with standard 0644 unit files —
+		// the same interface every distro exposes to every local user. Unit
+		// files are wiring (ExecStart, paths, User=) and never carry secret
+		// values: environment variables live in the 0600 files under the
+		// clawdi env root, which the platform-root walk above already
+		// verified as unreadable. Assert that contract explicitly.
+		const systemdUnits = readdirSync(paths.systemdSystemRoot)
+			.filter((entry) => entry.endsWith(".service"))
+			.map((entry) => join(paths.systemdSystemRoot, entry));
+		expect(systemdUnits.length).toBeGreaterThan(0);
+		for (const unit of systemdUnits) {
+			expect(statSync(unit).mode & 0o777, `mode of ${unit}`).toBe(0o644);
+			const content = readFileSync(unit, "utf-8");
+			expect(content).not.toContain("handoff-runtime-auth-token");
+			expect(content).not.toContain("handoff-gateway-token");
+			expect(content).not.toContain("handoff-sidecar-secret");
+		}
+	});
+});

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -2222,8 +2222,8 @@ describe("runtime paths", () => {
 		expect(paths.cliManagedBin).toBe(join(state, "maintained", "clawdi", "bin", "clawdi"));
 		expect(paths.cliNpmPrefix).toBe(join(state, "maintained", "clawdi", "npm"));
 		expect(paths.cliNpmCache).toBe(join(root, "var", "cache", "clawdi", "npm"));
-		expect(paths.egressProfileRoot).toBe(join(root, "etc", "clawdi", "egress"));
-		expect(paths.egressProfileBundle).toBe(join(root, "etc", "clawdi", "egress", "profiles.json"));
+		expect(paths.egressProfileRoot).toBe(join(run, "egress"));
+		expect(paths.egressProfileBundle).toBe(join(run, "egress", "profiles.json"));
 		expect(paths.instanceData).toBe(join(run, "instance-data.json"));
 	});
 
@@ -15197,13 +15197,15 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		expect(sidecarUnit).toContain(
 			`BindReadOnlyPaths=${cachedMitmproxyBinary(paths, mitmproxy)}:${paths.egressServiceBinary}:norbind`,
 		);
-		expect(statSync(getRuntimePaths().egressProfileRoot).mode & 0o777).toBe(0o755);
-		expect(statSync(getRuntimePaths().egressProfileBundle).mode & 0o777).toBe(0o644);
+		expect(statSync(paths.egressProfileRoot).mode & 0o777).toBe(0o711);
+		expect(statSync(paths.egressProfileBundle).mode & 0o777).toBe(0o640);
 		expect(statSync(paths.egressRoot).mode & 0o777).toBe(0o711);
 		expect(statSync(paths.egressAddon).mode & 0o777).toBe(0o640);
 		expect(statSync(paths.egressTransparentEnv).mode & 0o777).toBe(0o640);
 		expect(statSync(paths.egressCaDir).mode & 0o777).toBe(0o700);
 		if (typeof process.getuid === "function" && process.getuid() === 0) {
+			expect(statSync(paths.egressProfileBundle).uid).toBe(0);
+			expect(statSync(paths.egressProfileBundle).gid).toBe(10002);
 			expect(statSync(paths.egressCaDir).uid).toBe(10002);
 			expect(statSync(paths.egressCaDir).gid).toBe(10002);
 			expect(statSync(paths.egressAddon).uid).toBe(0);

--- a/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
+++ b/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
@@ -144,9 +144,9 @@ describe("WhatsApp sidecar production deployment contract", () => {
 			new Map([
 				[
 					"packages/cli/package.json",
-					replaceOnce(cliPackage, '"version": "0.13.43"', '"version": "0.13.44"'),
+					replaceOnce(cliPackage, '"version": "0.13.44"', '"version": "0.13.45"'),
 				],
-				["bun.lock", replaceOnce(lockfile, '"version": "0.13.43"', '"version": "0.13.44"')],
+				["bun.lock", replaceOnce(lockfile, '"version": "0.13.44"', '"version": "0.13.45"')],
 			]),
 		);
 		const unrelatedDeploy = calculateWhatsAppSidecarDeploymentRevision(


### PR DESCRIPTION
## Production incident

Every hosted tenant boot using `clawdi@0.13.43` fails while waiting for the egress sidecar to become ready:

`runtime apply failed: systemd runtime services did not reach required readiness` -> exit 23 -> rollback -> retry every 15 seconds.

The profile bundle was written to `/etc/clawdi/egress/profiles.json`, but the sidecar runs as uid 10002 and cannot traverse the deliberately private `/etc/clawdi` platform root (0700).

Before 0.13.43, `private-file.ts` chmodded pre-existing parent directories to a child `dirMode`. That silently widened the platform root and made this handoff appear to work. The 0.13.43 parent-permission fix correctly removed that widening and exposed the profile handoff as load-bearing on the old hack.

## Fix

- Move `egressProfileRoot` and `egressProfileBundle` under `/run/clawdi/egress`, beside the addon, transparent env, and CA inputs already consumed by the sidecar.
- Publish the bundle with the same handoff discipline as the addon: mode 0640, directory mode 0711, and `root:egress-gid` ownership when converging as root.
- Snapshot the bundle file instead of the shared egress directory, so rollback remains exact and never removes sibling handoff artifacts.
- Keep the shared egress directory out of the generic 0755 platform-directory path and assert the final 0711/0640 ownership contract.
- Release the CLI as `0.13.44`.

This makes the sidecar input boundary a single source of truth: every published sidecar input lives in one place under `/run/clawdi/egress` and follows one permission/ownership discipline. The fix does not chmod parents, re-widen platform roots, or add a per-file traversal exception.

## Regression evidence

The new `egress-handoff-access-contract.test.ts` simulates Linux traversal and read checks in both directions:

- uid 10002 can traverse to and read every sidecar-consumed file.
- uid 10001 cannot read any platform-rendered file except the explicitly tenant-published CA bundle.
- systemd units contain no secret values.

The sidecar half fails against `main`: traversal stops at the 0700 `/etc/clawdi` ancestor. It passes on this branch after the bundle moves into the published run-root handoff.

During final review, two additional coverage gaps were fixed: the shared egress alias was removed from a generic 0755 directory loop, and the tenant-published CA is now created before the contract test enumerates platform files, so the allowed exception is actually exercised.

## Validation

- `cd packages/cli && bun test`: 1659 pass, 4 skip, 0 fail; 8975 assertions across 1663 tests in 127 files
- `bun run typecheck`: 4/4 workspace tasks successful
- `bun run check`: exit 0; 972 files checked
- focused egress lifecycle test: 1 pass, 0 fail
- focused bidirectional handoff contract: 2 pass, 0 fail

## Release

Merging this PR automatically publishes `clawdi@0.13.44`.