### PR TITLE
fix(web): keep agent failures and progress on detail

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3398,8 +3398,9 @@ test("paid checkout navigates on deployment acceptance without LRO convergence",
 	await expect(page).toHaveURL(/\/agents\/hdep_created/);
 	await expect(page.getByText("Setting up Hermes", { exact: true })).toBeVisible();
 	await expect(
-		page.getByText("This page updates automatically as setup progresses.", { exact: false }),
+		page.getByText("Setup usually takes about 7–10 minutes.", { exact: false }),
 	).toBeVisible();
+	await expect(page.getByText("Preparing cloud resources", { exact: true })).toBeVisible();
 	expect(deploymentRequestReads).toHaveLength(1);
 	expect(operationPollRequests).toEqual([]);
 	await expect(page.getByText("Couldn’t deploy", { exact: true })).toHaveCount(0);

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -17,6 +17,7 @@ import {
 	DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
 	type DeploymentOperationVerb,
 	deploymentRefetchInterval,
+	deploymentStatusFromResource,
 } from "@/hosted/deployment-status";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
@@ -34,6 +35,10 @@ type OverviewComputeSummary =
 	typeof import("@/hosted/agents/hosted-agent-detail").OverviewComputeSummary;
 type InitialDeploymentPage =
 	typeof import("@/hosted/agents/hosted-agent-detail").InitialDeploymentPage;
+type ShouldShowInitialDeploymentProgress =
+	typeof import("@/hosted/agents/hosted-agent-detail").shouldShowInitialDeploymentProgress;
+type CanRetryInitialDeployment =
+	typeof import("@/hosted/agents/hosted-agent-detail").canRetryInitialDeployment;
 
 let invalidateSnapshots: InvalidateDeploymentSnapshots | null = null;
 let projectAcceptedTransition: ProjectAcceptedDeploymentTransition | null = null;
@@ -42,6 +47,8 @@ let runManualDeploymentRefetch: RunManualDeploymentRefetch | null = null;
 let overviewComputeStatus: OverviewComputeStatus | null = null;
 let overviewComputeSummary: OverviewComputeSummary | null = null;
 let initialDeploymentPage: InitialDeploymentPage | null = null;
+let shouldShowInitialDeploymentProgress: ShouldShowInitialDeploymentProgress | null = null;
+let canRetryInitialDeployment: CanRetryInitialDeployment | null = null;
 
 function requiredDeploymentStatus(
 	deployment: HostedDeployment | undefined,
@@ -66,6 +73,8 @@ beforeAll(async () => {
 	overviewComputeStatus = detailModule.OverviewComputeStatus;
 	overviewComputeSummary = detailModule.OverviewComputeSummary;
 	initialDeploymentPage = detailModule.InitialDeploymentPage;
+	shouldShowInitialDeploymentProgress = detailModule.shouldShowInitialDeploymentProgress;
+	canRetryInitialDeployment = detailModule.canRetryInitialDeployment;
 });
 
 describe("deployment failure status rendering", () => {
@@ -264,7 +273,8 @@ describe("deployment transition timeout rendering", () => {
 				status: "creating",
 				runtime: "hermes",
 				title: "Setting up Hermes",
-				activeLabel: "Preparing your environment",
+				activeLabel: "Preparing cloud resources",
+				activeDescription: "Creating a private environment and connecting your AI provider.",
 				step: "Step 1 of 3",
 				currentStage: "creating",
 				states: { creating: "active", starting: "pending", running: "pending" },
@@ -273,7 +283,9 @@ describe("deployment transition timeout rendering", () => {
 				status: "starting",
 				runtime: "openclaw",
 				title: "Setting up OpenClaw",
-				activeLabel: "Installing OpenClaw",
+				activeLabel: "Installing and starting OpenClaw",
+				activeDescription:
+					"Booting the environment, installing Clawdi and the agent runtime, then checking readiness.",
 				step: "Step 2 of 3",
 				currentStage: "starting",
 				states: { creating: "completed", starting: "active", running: "pending" },
@@ -283,6 +295,7 @@ describe("deployment transition timeout rendering", () => {
 				runtime: "hermes",
 				title: "Setting up Hermes",
 				activeLabel: "Ready",
+				activeDescription: "Setup is complete.",
 				step: "Step 3 of 3",
 				currentStage: "running",
 				states: { creating: "completed", starting: "completed", running: "completed" },
@@ -305,6 +318,7 @@ describe("deployment transition timeout rendering", () => {
 			expect(markup).not.toContain("Deploying your agent");
 			expect(markup).not.toContain("Current status");
 			expect(markup).toContain(fixture.activeLabel);
+			expect(markup).toContain(fixture.activeDescription);
 			expect(markup).toContain(fixture.step);
 			expect(markup).toContain('aria-label="Deployment progress"');
 			for (const [stage, state] of Object.entries(fixture.states)) {
@@ -314,9 +328,10 @@ describe("deployment transition timeout rendering", () => {
 					),
 				);
 			}
-			for (const shortLabel of ["Environment", "Install", "Ready"])
+			for (const shortLabel of ["Cloud resources", "Agent software", "Ready"])
 				expect(markup).toContain(`>${shortLabel}</p>`);
 			expect(markup).toContain("updates automatically");
+			expect(markup).toContain("7–10 minutes");
 			if (fixture.status === "running") {
 				expect(markup).not.toContain('data-slot="spinner"');
 			} else {
@@ -347,10 +362,69 @@ describe("deployment transition timeout rendering", () => {
 		expect(markup).toContain("Setup is taking longer than expected");
 		expect(markup).toContain("Check again");
 		expect(markup).not.toContain("Current status");
-		expect(markup).toContain(">Installing OpenClaw</p>");
+		expect(markup).toContain(">Installing and starting OpenClaw</p>");
 		expect(markup).toContain("Step 2 of 3");
 		expect(markup).toContain('data-deployment-stage="starting" data-stage-state="active"');
 		expect(markup).not.toContain('data-slot="spinner"');
+	});
+
+	test("keeps deployment progress on the agent surface after its env identity is projected", () => {
+		if (!shouldShowInitialDeploymentProgress) throw new Error("agent detail was not loaded");
+		for (const status of ["creating", "starting"] as const) {
+			const deployment = hostedDeploymentFixture({
+				status,
+				cloudEnvironments: { openclaw: "11111111-1111-4111-8111-111111111111" },
+			});
+			expect(
+				shouldShowInitialDeploymentProgress(
+					deploymentStatusFromResource(deployment.resource.status),
+					null,
+				),
+			).toBe(true);
+		}
+	});
+
+	test("renders a create failure in the setup panel without exposing internal details", () => {
+		if (
+			!initialDeploymentPage ||
+			!shouldShowInitialDeploymentProgress ||
+			!canRetryInitialDeployment
+		) {
+			throw new Error("agent detail was not loaded");
+		}
+		const deployment = hostedDeploymentFixture({
+			id: "hdep_create_failed",
+			status: "failed",
+			acceptedOperation: failedOperation("create"),
+		});
+		const failure = deploymentFailurePresentation(deployment);
+		if (!failure) throw new Error("Expected create failure presentation");
+		const nonRetryableFailure = { ...failure, retryable: false };
+		expect(canRetryInitialDeployment(failure)).toBe(true);
+		expect(canRetryInitialDeployment(nonRetryableFailure)).toBe(false);
+		expect(
+			shouldShowInitialDeploymentProgress(
+				deploymentStatusFromResource(deployment.resource.status),
+				failure,
+			),
+		).toBe(true);
+
+		const markup = renderToStaticMarkup(
+			createElement(initialDeploymentPage, {
+				deployment,
+				failure: nonRetryableFailure,
+				deploymentTransitionTimedOut: false,
+				deploymentTransitionEscalated: false,
+				isCheckingDeployment: false,
+				onCheckDeploymentAgain: () => undefined,
+			}),
+		);
+
+		expect(markup).toContain("Agent setup failed");
+		expect(markup).not.toContain("Retry startup");
+		expect(markup).toContain("The Clawdi service could not complete this request.");
+		expect(markup).not.toContain("Internal operation failure");
+		expect(markup).not.toContain("Contact support");
 	});
 
 	test("keeps projection availability notices off the deployment-backed overview", () => {
@@ -382,7 +456,7 @@ describe("deployment transition timeout rendering", () => {
 		expect(overviewStatusSource).not.toContain("<Button");
 		expect(overviewStatusSource).not.toContain("href=");
 		expect(detailSource).not.toContain("OverviewFailureAction");
-		expect(detailSource).toContain("!hasTerminalDeploymentFailure &&");
+		expect(detailSource).toContain("shouldShowInitialDeploymentProgress(");
 	});
 
 	test("wires the timed-out inventory state and real refetch action into the detail", () => {
@@ -537,7 +611,6 @@ describe("hosted agent customer language", () => {
 
 		for (const staleLifecycleCopy of [
 			"Provisioning",
-			"Booting",
 			"Getting your agent ready",
 			"Setting up your agent",
 			"Your agent is ready",

--- a/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
@@ -2,6 +2,22 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 
 describe("hosted agent detail header", () => {
+	test("keeps per-agent failures off the dashboard home", () => {
+		const homeSource = readFileSync(
+			new URL("../hosted-agents-section.tsx", import.meta.url),
+			"utf8",
+		);
+
+		for (const misplacedCopy of [
+			"HostedDeletionFailureNotices",
+			"Cleanup for",
+			"Retry cleanup",
+			"Contact support before trying again",
+		]) {
+			expect(homeSource).not.toContain(misplacedCopy);
+		}
+	});
+
 	test("embeds owner SSO Files without credentials and keeps a top-level launch", () => {
 		const source = readFileSync(new URL("./hosted-agent-detail.tsx", import.meta.url), "utf8");
 

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -353,6 +353,17 @@ function isStartingStatus(status: DeploymentStatus): boolean {
 	return status.kind === "creating" || status.kind === "starting";
 }
 
+export function shouldShowInitialDeploymentProgress(
+	status: DeploymentStatus,
+	failure: DeploymentFailurePresentation | null,
+): boolean {
+	return (isStartingStatus(status) && failure === null) || failure?.failedVerb === "create";
+}
+
+export function canRetryInitialDeployment(failure: DeploymentFailurePresentation): boolean {
+	return failure.retryable !== false && failure.remediation.kind === "restart";
+}
+
 function startingTitle(): string {
 	return "Starting your agent…";
 }
@@ -459,7 +470,7 @@ export function HostedAgentDetail({
 	const $api = useOpenApi();
 	const [isCheckingProjection, setIsCheckingProjection] = useState(false);
 	const deploymentStatus = deploymentStatusFromResource(deployment.resource.status);
-	const hasTerminalDeploymentFailure = deploymentFailurePresentation(deployment) !== null;
+	const deploymentFailure = deploymentFailurePresentation(deployment);
 	const deploymentProjectionQueryable = canQueryDeploymentProjection(deploymentStatus);
 	const cloudEnvironmentId = isCloudEnvId(environmentId);
 	const sessionsQueryable = canQueryHostedAgentSessions(environmentId);
@@ -521,13 +532,11 @@ export function HostedAgentDetail({
 	const activeTabLabel = agentSectionLabel(activeTab);
 	const ActiveTabIcon = activeNavItem.icon;
 	const resourceScope = agentResourceScope(environmentId, routeSearch);
-	const showInitialStartingPage =
+	const showInitialDeploymentPage =
 		activeTab === "overview" &&
-		isStartingStatus(deploymentStatus) &&
-		!hasTerminalDeploymentFailure &&
-		!cloudEnvironmentId;
+		shouldShowInitialDeploymentProgress(deploymentStatus, deploymentFailure);
 	const interfaceAvailable =
-		activeTab === "overview" && !showInitialStartingPage && isRunningStatus(deploymentStatus);
+		activeTab === "overview" && !showInitialDeploymentPage && isRunningStatus(deploymentStatus);
 	const isLiveToolTab =
 		activeTab === "console" || activeTab === "files" || activeTab === "terminal";
 	return (
@@ -587,9 +596,10 @@ export function HostedAgentDetail({
 					/>
 				) : null}
 				<div className={isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : "w-full"}>
-					{showInitialStartingPage ? (
+					{showInitialDeploymentPage ? (
 						<InitialDeploymentPage
 							deployment={deployment}
+							failure={deploymentFailure}
 							deploymentTransitionTimedOut={deploymentTransitionTimedOut}
 							deploymentTransitionEscalated={deploymentTransitionEscalated}
 							isCheckingDeployment={isCheckingDeployment}
@@ -963,12 +973,14 @@ export function OverviewComputeSummary({
 
 export function InitialDeploymentPage({
 	deployment,
+	failure = null,
 	deploymentTransitionTimedOut,
 	deploymentTransitionEscalated,
 	isCheckingDeployment,
 	onCheckDeploymentAgain,
 }: {
 	deployment: HostedDeployment;
+	failure?: DeploymentFailurePresentation | null;
 	deploymentTransitionTimedOut: boolean;
 	deploymentTransitionEscalated: boolean;
 	isCheckingDeployment: boolean;
@@ -976,18 +988,55 @@ export function InitialDeploymentPage({
 }) {
 	const status = deploymentStatusFromResource(deployment.resource.status);
 	const runtimeLabel = runtimeDisplayName(deployment.resource.spec.runtime);
+	if (failure?.failedVerb === "create") {
+		const canRetry = canRetryInitialDeployment(failure);
+		return (
+			<DetailPanel className="border-destructive/30 bg-destructive-muted p-6 md:p-8">
+				<div data-testid="hosted-initial-deployment-panel" role="alert" className="space-y-5">
+					<div>
+						<h2 className="flex items-center gap-2 text-lg font-semibold">
+							<AlertCircle className="size-5 text-destructive" />
+							Agent setup failed
+						</h2>
+						<p className="mt-1 text-sm text-muted-foreground">
+							Setup stopped before this agent became ready.
+						</p>
+					</div>
+					<Alert variant="destructive">
+						<AlertCircle />
+						<AlertTitle>{failure.title}</AlertTitle>
+						<AlertDescription className="space-y-1">
+							<p>{failure.reason}</p>
+							<p>{failure.description}</p>
+						</AlertDescription>
+					</Alert>
+					{canRetry ? <StartComputeAction deployment={deployment} label="Retry startup" /> : null}
+				</div>
+			</DetailPanel>
+		);
+	}
 	const stages = [
-		{ status: "creating", label: "Environment" },
-		{ status: "starting", label: "Install" },
+		{ status: "creating", label: "Cloud resources" },
+		{ status: "starting", label: "Agent software" },
 		{ status: "running", label: "Ready" },
 	] as const;
 	const activeStageIndex = status.kind === "starting" ? 1 : status.kind === "running" ? 2 : 0;
-	const activeStageLabel =
+	const activeStage =
 		activeStageIndex === 0
-			? "Preparing your environment"
+			? {
+					label: "Preparing cloud resources",
+					description: "Creating a private environment and connecting your AI provider.",
+				}
 			: activeStageIndex === 1
-				? `Installing ${runtimeLabel}`
-				: "Ready";
+				? {
+						label: `Installing and starting ${runtimeLabel}`,
+						description:
+							"Booting the environment, installing Clawdi and the agent runtime, then checking readiness.",
+					}
+				: {
+						label: "Ready",
+						description: "Setup is complete.",
+					};
 	return (
 		<DetailPanel
 			className={cn(
@@ -1017,7 +1066,7 @@ export function InitialDeploymentPage({
 							? "We’ll keep checking automatically. If you want, cancel this setup and try again."
 							: deploymentTransitionTimedOut
 								? "Your agent may still be starting. We’ll keep checking automatically."
-								: "This page updates automatically as setup progresses."}
+								: "Setup usually takes about 7–10 minutes. It continues if you leave, and this page updates automatically while open."}
 					</p>
 				</div>
 				<div>
@@ -1035,12 +1084,13 @@ export function InitialDeploymentPage({
 									<Spinner className="size-3.5 shrink-0 text-primary" />
 								</span>
 							) : null}
-							{activeStageLabel}
+							{activeStage.label}
 						</p>
 						<p className="shrink-0 text-xs font-medium text-muted-foreground">
 							Step {activeStageIndex + 1} of {stages.length}
 						</p>
 					</div>
+					<p className="mt-2 text-sm text-muted-foreground">{activeStage.description}</p>
 					<ol aria-label="Deployment progress" className="mt-4 grid w-full grid-cols-3 gap-2">
 						{stages.map((stage, index) => {
 							const stageState =

--- a/apps/web/src/hosted/agents/hosted-agent-session-query.test.ts
+++ b/apps/web/src/hosted/agents/hosted-agent-session-query.test.ts
@@ -164,12 +164,12 @@ describe("hosted agent sessions refresh", () => {
 		expect(HOSTED_AGENT_SESSIONS_EMPTY_MESSAGE).toBe("No sessions from this agent yet.");
 	});
 
-	test("keeps Overview sessions visible during starting, updating, stopped, and failed states", () => {
+	test("keeps the Overview sessions query independent from deployment lifecycle", () => {
 		const detailStart = detailSource.indexOf("export function HostedAgentDetail(");
 		const sessionsQueryStart = detailSource.indexOf("const sessions = useQuery({", detailStart);
 		const sessionsQueryEnd = detailSource.indexOf("\n\t});", sessionsQueryStart) + "\n\t});".length;
 		const sessionsQuerySource = detailSource.slice(sessionsQueryStart, sessionsQueryEnd);
-		const initialPageStart = detailSource.indexOf("const showInitialStartingPage", detailStart);
+		const initialPageStart = detailSource.indexOf("const showInitialDeploymentPage", detailStart);
 		const initialPageEnd = detailSource.indexOf("const interfaceAvailable", initialPageStart);
 		const initialPageSource = detailSource.slice(initialPageStart, initialPageEnd);
 		const overviewStart = detailSource.indexOf("function OverviewTab(");
@@ -188,7 +188,8 @@ describe("hosted agent sessions refresh", () => {
 		expect(sessionsQuerySource).toContain('enabled: activeTab === "overview" && sessionsQueryable');
 		expect(sessionsQuerySource).not.toContain("deploymentStatus");
 		expect(sessionsQuerySource).not.toContain("projection.status");
-		expect(initialPageSource).toContain("!cloudEnvironmentId");
+		expect(initialPageSource).toContain("shouldShowInitialDeploymentProgress(");
+		expect(initialPageSource).not.toContain("cloudEnvironmentId");
 		expect(initialPageSource).not.toContain('projection.status !== "resolved"');
 		expect(recentSessionsStart).toBeGreaterThan(overviewStart);
 		expect(recentSessionsEnd).toBeGreaterThan(recentSessionsStart);

--- a/apps/web/src/hosted/deployment-status.test.ts
+++ b/apps/web/src/hosted/deployment-status.test.ts
@@ -7,6 +7,7 @@ import {
 	canRestart,
 	canStart,
 	canStop,
+	DEPLOYMENT_CREATION_TRANSITION_TIMEOUT_MS,
 	DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS,
 	DEPLOYMENT_TRANSITION_ESCALATION_MS,
 	DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
@@ -355,7 +356,7 @@ describe("DeploymentStatus", () => {
 		expect(terminal.trackers.size).toBe(0);
 	});
 
-	test("keeps reconciling a create observed from 05:00 through Running at 05:09", () => {
+	test("keeps fast polling a create through the measured ten-minute setup window", () => {
 		const acceptedAtMs = Date.parse("2026-07-29T05:00:00Z");
 		const operation = acceptedOperation("create");
 		operation.metadata.deploymentId = "hdep_slow_create";
@@ -370,12 +371,12 @@ describe("DeploymentStatus", () => {
 		const lastFast = deploymentPollingState(
 			[creating],
 			accepted.trackers,
-			Date.parse("2026-07-29T05:04:59Z"),
+			Date.parse("2026-07-29T05:09:59Z"),
 		);
 		const delayed = deploymentPollingState(
 			[creating],
 			lastFast.trackers,
-			Date.parse("2026-07-29T05:05:00Z"),
+			Date.parse("2026-07-29T05:10:00Z"),
 		);
 		const running = deploymentPollingState(
 			[
@@ -386,7 +387,7 @@ describe("DeploymentStatus", () => {
 				}),
 			],
 			delayed.trackers,
-			Date.parse("2026-07-29T05:09:00Z"),
+			Date.parse("2026-07-29T05:10:01Z"),
 		);
 
 		expect([accepted.refetchInterval, lastFast.refetchInterval]).toEqual([
@@ -395,6 +396,7 @@ describe("DeploymentStatus", () => {
 		]);
 		expect(delayed.refetchInterval).toBe(DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS);
 		expect(delayed.transitions.get("hdep_slow_create")?.kind).toBe("timed_out");
+		expect(DEPLOYMENT_CREATION_TRANSITION_TIMEOUT_MS).toBe(10 * 60_000);
 		expect(running.refetchInterval).toBe(DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS);
 		expect(running.transitions.size).toBe(0);
 		expect(running.trackers.size).toBe(0);

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -55,6 +55,7 @@ export type DeploymentOperationVerb =
 
 export const DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS = 10_000;
 export const DEPLOYMENT_TRANSITION_TIMEOUT_MS = 5 * 60_000;
+export const DEPLOYMENT_CREATION_TRANSITION_TIMEOUT_MS = 10 * 60_000;
 // The backend controller keeps recovering stalled generations on its own
 // (60s scan, `clawdi_v2_a3_stalled_generation_seconds` in clawdi-hosted
 // backend/app/v2/hosted/controller_scheduling.py). Escalation waits well
@@ -457,7 +458,10 @@ export function deploymentPollingState(
 			tracker: trackers.get(deploymentId) ?? null,
 			nowMs,
 			pollIntervalMs: DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
-			timeoutMs: DEPLOYMENT_TRANSITION_TIMEOUT_MS,
+			timeoutMs:
+				operation?.metadata.verb === "create"
+					? DEPLOYMENT_CREATION_TRANSITION_TIMEOUT_MS
+					: DEPLOYMENT_TRANSITION_TIMEOUT_MS,
 			escalationMs: DEPLOYMENT_TRANSITION_ESCALATION_MS,
 		});
 		nextTrackers.set(deploymentId, pollState.tracker);

--- a/apps/web/src/hosted/hosted-agents-section.tsx
+++ b/apps/web/src/hosted/hosted-agents-section.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import type { components } from "@clawdi/shared/api";
-import { AlertCircle, LifeBuoy } from "lucide-react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
-import { AgentSourceBadge, agentDisplayName } from "@/components/dashboard/agent-label";
+import { AgentSourceBadge } from "@/components/dashboard/agent-label";
 import {
 	AgentsCard,
 	AgentTileGrid,
@@ -11,13 +10,8 @@ import {
 } from "@/components/dashboard/agents-card";
 import { OnboardingCard } from "@/components/dashboard/onboarding-card";
 import { SectionLabel } from "@/components/section-label";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Button } from "@/components/ui/button";
-import { HostedDeploymentDeleteAction } from "@/hosted/agents/deployment-delete-action";
-import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { WelcomeWalletCard } from "@/hosted/billing/subscription/welcome-wallet-card";
-import { deploymentFailurePresentation } from "@/hosted/deployment-failure";
 import { useUnifiedAgentList } from "@/hosted/use-unified-agent-list";
 
 type Env = components["schemas"]["AgentResponse"];
@@ -27,54 +21,6 @@ function HostedEmptyAccountHero({ canDeployOnClawdi }: { canDeployOnClawdi: bool
 		<div className="space-y-4">
 			<OnboardingCard variant="first-agent" canDeployOnClawdi={canDeployOnClawdi} />
 			<WelcomeWalletCard showDeployAction={false} />
-		</div>
-	);
-}
-
-function HostedDeletionFailureNotices({ deployments }: { deployments: HostedDeployment[] }) {
-	if (deployments.length === 0) return null;
-	return (
-		<div className="space-y-3">
-			{deployments.map((deployment) => {
-				const failure = deploymentFailurePresentation(deployment);
-				if (failure?.failedVerb !== "delete") return null;
-				// A user-cancelled deletion is deliberate, not a cleanup failure.
-				if (failure.code === "operation_cancelled") return null;
-				const name = agentDisplayName({
-					name: deployment.resource.name,
-					agent_type: deployment.resource.spec.runtime,
-				});
-				const retrySafe = failure.retryable !== false;
-				return (
-					<Alert key={deployment.resource.id} variant="destructive">
-						<AlertCircle />
-						<AlertTitle>{`Cleanup for ${name} needs attention`}</AlertTitle>
-						<AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-							<span>
-								The agent stays out of your list, but the Clawdi service couldn’t finish releasing
-								its resources.{" "}
-								{retrySafe ? "Retry cleanup." : "Contact support before trying again."}
-							</span>
-							{retrySafe ? (
-								<HostedDeploymentDeleteAction deployment={deployment}>
-									<Button type="button" variant="outline" size="sm">
-										Retry cleanup
-									</Button>
-								</HostedDeploymentDeleteAction>
-							) : (
-								<Button
-									render={<a href="mailto:support@clawdi.ai" />}
-									nativeButton={false}
-									variant="outline"
-									size="sm"
-								>
-									<LifeBuoy data-icon="inline-start" /> Contact support
-								</Button>
-							)}
-						</AlertDescription>
-					</Alert>
-				);
-			})}
 		</div>
 	);
 }
@@ -139,7 +85,6 @@ export function HostedAgentsSection({
 	if (envsLoading) {
 		return (
 			<div data-hosted="true" className="space-y-4">
-				<HostedDeletionFailureNotices deployments={unified.deletionFailures} />
 				<AgentsCard agents={[]} isLoading />
 			</div>
 		);
@@ -158,7 +103,6 @@ export function HostedAgentsSection({
 		!unified.error;
 	return (
 		<div data-hosted="true" className="space-y-4">
-			<HostedDeletionFailureNotices deployments={unified.deletionFailures} />
 			{isEmptyState ? (
 				<HostedEmptyAccountHero canDeployOnClawdi={canDeployOnClawdi} />
 			) : (
@@ -254,7 +198,6 @@ export function HostedAgentsByCompute({
 	if (envsLoading) {
 		return (
 			<div data-hosted="true" className="space-y-6">
-				<HostedDeletionFailureNotices deployments={unified.deletionFailures} />
 				<AgentsCard agents={[]} isLoading />
 			</div>
 		);
@@ -271,7 +214,6 @@ export function HostedAgentsByCompute({
 	if (isEmptyState) {
 		return (
 			<div data-hosted="true" className="space-y-6">
-				<HostedDeletionFailureNotices deployments={unified.deletionFailures} />
 				<HostedEmptyAccountHero canDeployOnClawdi={canDeployOnClawdi} />
 			</div>
 		);
@@ -284,7 +226,6 @@ export function HostedAgentsByCompute({
 	) {
 		return (
 			<div data-hosted="true" className="space-y-6">
-				<HostedDeletionFailureNotices deployments={unified.deletionFailures} />
 				<AgentsCard agents={[]} isLoading />
 			</div>
 		);
@@ -292,7 +233,6 @@ export function HostedAgentsByCompute({
 
 	return (
 		<div data-hosted="true" className="space-y-6">
-			<HostedDeletionFailureNotices deployments={unified.deletionFailures} />
 			{hostedTiles.length > 0 ? (
 				<section className="space-y-2">
 					<SectionLabel

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -399,7 +399,7 @@ describe("deploymentToTiles", () => {
 		expect(resolveAgentDeployment([deleting], environmentId).match).toBeNull();
 	});
 
-	test("keeps a deployment without an env identity non-navigable and summary-only", () => {
+	test("links a visible deployment by deployment identity before its env identity exists", () => {
 		const hostedDeployment = deployment({
 			status: "failed",
 			failureReason: "creation_interrupted",
@@ -410,11 +410,10 @@ describe("deploymentToTiles", () => {
 		expect(tile).toMatchObject({
 			id: "dep_123",
 			name: "hosted-test",
-			href: null,
+			href: "/agents/dep_123?source=on-clawdi&d=dep_123",
 			env: null,
 		});
 		expectHostedTileStatus(tile, "Temporarily unavailable");
-		expect(JSON.stringify(tile)).not.toContain("/agents/dep_123");
 	});
 });
 

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -12,7 +12,6 @@ import {
 	compactDeploymentFailureReason,
 	type DeploymentFailurePresentation,
 	deploymentFailurePresentation,
-	deploymentFailureProjection,
 	deploymentFailureReason,
 } from "@/hosted/deployment-failure";
 import {
@@ -156,23 +155,12 @@ export function useHostedAgentTiles({
 		if (!includeDeployments) return new Set<string>();
 		return claimedEnvIdsFromDeployments(deployments);
 	}, [deployments, includeDeployments]);
-	const deletionFailures = useMemo(
-		() =>
-			includeDeployments
-				? deployments.filter(
-						(deployment) => deploymentFailureProjection(deployment)?.failedVerb === "delete",
-					)
-				: [],
-		[deployments, includeDeployments],
-	);
-
 	return {
 		inventoryStatus: inventory.status,
 		hasExistingDeployments:
 			includeDeployments && hasExistingCloudDeployments(inventory.deployments),
 		tiles,
 		claimedEnvIds,
-		deletionFailures,
 		isFetching: inventory.isFetching,
 		isLoading: inventory.status === "loading" && !inventory.hasSnapshot,
 		error: inventory.error,
@@ -199,7 +187,7 @@ export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>
 		source: "on-clawdi",
 		[AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY]: d.resource.id,
 	};
-	const detailHref = envId ? agentSectionHref(envId, "overview", routeQuery) : null;
+	const detailHref = agentSectionHref(envId ?? d.resource.id, "overview", routeQuery);
 	const failure = deploymentFailurePresentation(d);
 	const runtimeStatus = hostedRuntimeStatusView(d.resource.status, matchedEnv, failure);
 	const cardStatus: AgentCardStatusProjection = {

--- a/apps/web/src/hosted/use-unified-agent-list.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.ts
@@ -122,7 +122,6 @@ export function useUnifiedAgentList({
 	return {
 		...selection,
 		hasExistingDeployments: hosted.hasExistingDeployments,
-		deletionFailures: hosted.deletionFailures,
 		inventoryStatus: hosted.inventoryStatus,
 		isFetching: hosted.isFetching,
 		isLoading: (showCloudDeployments && hosted.isLoading) || (showLegacyAgents && legacy.isLoading),


### PR DESCRIPTION
## Summary

- remove per-agent cleanup failures from the dashboard-level alert area
- keep visible deployment failures on the agent card and agent detail, including a deployment-ID detail link before the agent UUID exists
- keep accepted deploy flows on the agent Overview progress surface while the authoritative deployment state is `creating` or `starting`, even after the agent UUID has been projected
- describe the real provisioning/install/readiness work, use the measured 7-10 minute expectation, and keep fast create polling through ten minutes
- render a failed create on the same setup surface with backend-published customer-safe failure copy and only show retry when the published failure is retryable and the existing restart remediation applies

## Failure placement

The deploy API's published lifecycle classification remains authoritative. This change does not infer a USER/INTERNAL class or reinterpret free-form failure text in the client.

A deployment that remains visible but degraded gets a compact failure status on its card and the full failure on its own detail page. Cards now fall back to the deployment-ID route when an agent UUID has not been projected yet, so an early setup failure still has an owner surface.

A deployment that the existing membership/visibility projection removes (`deleted`, deleting, or accepted deletion) has no remaining user-facing object or meaningful action, so it produces no notice. In particular, the dashboard no longer asks the user to contact support or retry cleanup for an agent that is already gone from their world. If backend authority instead keeps a failed deployment visible, its card and detail page remain available.

## Deploy destination and progress

All successful wizard paths already converge on `navigateToAcceptedDeployment` (direct creates, deployment-request checkout returns, and reused subscriptions). That helper hydrates the authoritative deployment and navigates to `/agents/{deploymentId}?source=on-clawdi`.

The defect was in the destination rendering: once the deployment projected an agent UUID, `HostedAgentDetail` stopped showing `InitialDeploymentPage` even though deployment status was still `creating`/`starting`. Progress rendering now depends on authoritative deployment status/failure, not on whether the route has resolved to a deployment ID or agent UUID. Reloading or returning to the page reconstructs the same view from the latest deployment snapshot.

## Backend data gap

The current contract exposes `summary_state` (`creating`, `starting`, `running`) plus generic conditions whose `reason` and `message` are open/free-form. It does not expose stable structured stages or timestamps for cloud key creation, provider binding, runtime cluster/credential/agent provisioning, Incus creation, tenant boot, CLI installation, runtime installation, or readiness.

The UI therefore maps only the stable backend states to three honest macro stages: Cloud resources, Agent software, and Ready. It does not fake percentages, timers, or infer sub-stages from free-form condition text. A finer progress breakdown requires a backend contract with a stable stage enum (and optionally stage transition timestamps).

## Verification

- `bun run --cwd apps/web typecheck`
- `bun run --cwd packages/shared typecheck`
- `bun run --cwd apps/web test`
- `bun run --cwd packages/shared test`
- `bun run --cwd apps/web e2e:hosted --grep "paid checkout navigates on deployment acceptance"`
- focused hosted tests: 119 passed
- Biome check on all touched files
