### PR TITLE
fix(runtime): accept companions in platform state upsert

### DIFF
--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -1249,6 +1249,7 @@ def _assign_runtime_state(
     state.locale = body.locale.model_dump()
     state.system = body.system.model_dump(exclude_none=True, mode="json")
     state.egress_engine = _optional_runtime_model(body.egress_engine)
+    state.companions = _optional_runtime_model(body.companions)
     state.runtimes = {
         name: runtime.model_dump(exclude_none=True, mode="json")
         for name, runtime in body.runtimes.items()
@@ -1290,6 +1291,7 @@ def _runtime_state_changed_fields(
         "locale",
         "system",
         "egress_engine",
+        "companions",
         "runtimes",
         "live_sync",
         "recovery",
@@ -1315,7 +1317,7 @@ def _runtime_state_changed_fields(
                 name: runtime.model_dump(exclude_none=True, mode="json")
                 for name, runtime in body.runtimes.items()
             }
-        elif field in {"egress_engine", "egress_profiles", "mcp", "skills"}:
+        elif field in {"egress_engine", "companions", "egress_profiles", "mcp", "skills"}:
             body_value = _optional_runtime_model(getattr(body, field))
         elif field in {"live_sync", "recovery"}:
             body_value = getattr(body, field).model_dump(mode="json")

--- a/backend/app/schemas/platform.py
+++ b/backend/app/schemas/platform.py
@@ -10,6 +10,7 @@ from app.core.api_scopes import RUNTIME_MCP_SCOPES
 from app.schemas.runtime import (
     HostedEgressEngine,
     HostedEgressProfiles,
+    HostedRuntimeCompanions,
     HostedRuntimeDesiredState,
     HostedRuntimeLiveSync,
     HostedRuntimeLocale,
@@ -97,6 +98,7 @@ class PlatformRuntimeStateUpsert(PlatformMutationBody):
     locale: HostedRuntimeLocale
     system: HostedRuntimeSystem
     egress_engine: HostedEgressEngine | None = None
+    companions: HostedRuntimeCompanions | None = None
     runtimes: dict[str, HostedRuntimeDesiredState]
     live_sync: HostedRuntimeLiveSync
     recovery: HostedRuntimeRecovery

--- a/backend/tests/hosted_runtime_fixtures.py
+++ b/backend/tests/hosted_runtime_fixtures.py
@@ -24,6 +24,44 @@ CANONICAL_CODEX_TOOLS = {
 }
 
 
+def filebrowser_companion(deployment_id: str, access_revision: str = "a" * 64) -> dict[str, Any]:
+    audience = f"clawdi-files:{deployment_id}"
+    release = "https://github.com/gtsteffaniak/filebrowser/releases/download/v1.5.0-stable"
+    return {
+        "filebrowser": {
+            "version": "v1.5.0-stable",
+            "commit": "79552f8adb27c3e29934c4001660eb98f4aab5d6",
+            "listen": "0.0.0.0",
+            "port": 9120,
+            "baseURL": "/",
+            "healthPath": "/health",
+            "sourceRoot": "/home/clawdi",
+            "assets": {
+                "amd64": {
+                    "url": f"{release}/linux-amd64-filebrowser",
+                    "sha256": "8d51d1718d576d22e73e1f41a5194b451d152ddab0df97697cabe839cf59524e",
+                },
+                "arm64": {
+                    "url": f"{release}/linux-arm64-filebrowser",
+                    "sha256": "3e18838ae33750a25da434dc6156a359968bf7935e01bdd884711f47f08ad92f",
+                },
+            },
+            "auth": {
+                "method": "jwt",
+                "algorithm": "HS256",
+                "header": "X-JWT-Assertion",
+                "userIdentifier": "sub",
+                "groupsClaim": "groups",
+                "secret": "s" * 43,
+                "audience": audience,
+                "subject": f"deployment:{deployment_id}:owner",
+                "requiredGroup": f"{audience}:{access_revision}",
+                "accessRevision": access_revision,
+            },
+        }
+    }
+
+
 def canonical_codex_tool_provider_graph(
     user: User,
     *,

--- a/backend/tests/test_platform_endpoints.py
+++ b/backend/tests/test_platform_endpoints.py
@@ -28,7 +28,10 @@ from app.services.runtime_source import load_runtime_source_batch, render_runtim
 from app.services.user_provisioning import lazy_create_partner_user_with_personal_project
 from app.services.vault_crypto import decrypt
 from tests.conftest import create_env_with_project
-from tests.hosted_runtime_fixtures import ensure_canonical_codex_tool_provider
+from tests.hosted_runtime_fixtures import (
+    ensure_canonical_codex_tool_provider,
+    filebrowser_companion,
+)
 
 _ADMIN_KEY = "test-platform-admin-secret"
 _CLERK_ISSUER = "https://platform-tests.clerk.example.test"
@@ -64,6 +67,7 @@ _TEST_TOOLS = {
         },
     }
 }
+_TEST_COMPANIONS = filebrowser_companion("deployment-1")
 
 
 @pytest_asyncio.fixture
@@ -460,6 +464,64 @@ async def test_platform_agent_reregistration_updates_its_name(
     agent = await db_session.get(AgentEnvironment, agent_id)
     assert agent is not None
     assert agent.default_name == "Writing"
+
+
+@pytest.mark.asyncio
+async def test_platform_runtime_state_accepts_and_projects_filebrowser_companion(
+    platform_client,
+    db_session,
+    seed_user,
+):
+    owner = _clerk_owner(seed_user)
+    agent_id = uuid.uuid4()
+    await ensure_canonical_codex_tool_provider(db_session, seed_user)
+    created = await _create_platform_agent(
+        platform_client,
+        owner,
+        agent_id,
+        key="runtime-companion-agent",
+    )
+    assert created.status_code == 200, created.text
+
+    response = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_headers("runtime-companion-upsert"),
+        json={**_runtime_body(owner, agent_id), "companions": _TEST_COMPANIONS},
+    )
+
+    assert response.status_code == 200, response.text
+    state = await db_session.get(HostedRuntimeState, agent_id)
+    assert state is not None
+    assert state.companions == _TEST_COMPANIONS
+
+    batch = await load_runtime_source_batch(db_session, environment_ids=[agent_id])
+    source = render_runtime_source(
+        batch,
+        environment_id=agent_id,
+        public_api_url="https://cloud.test",
+        vault_key_identity="test-key-version",
+        decrypt_secrets=False,
+    )
+    assert source.manifest["companions"]["filebrowser"] == _TEST_COMPANIONS["filebrowser"]
+
+    cleared = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_headers("runtime-companion-clear"),
+        json={**_runtime_body(owner, agent_id), "generation": 2},
+    )
+    assert cleared.status_code == 200, cleared.text
+    await db_session.refresh(state)
+    assert state.companions is None
+
+    cleared_batch = await load_runtime_source_batch(db_session, environment_ids=[agent_id])
+    cleared_source = render_runtime_source(
+        cleared_batch,
+        environment_id=agent_id,
+        public_api_url="https://cloud.test",
+        vault_key_identity="test-key-version",
+        decrypt_secrets=False,
+    )
+    assert "companions" not in cleared_source.manifest
 
 
 @pytest.mark.asyncio
@@ -1321,6 +1383,10 @@ async def test_platform_routes_are_canonical_and_exposed_in_openapi(platform_cli
     }
     assert all(not path.startswith("/api/platform") for path in paths)
     assert set(paths["/v1/platform/agents/{agent_id}/runtime-state"]) == {"put", "delete"}
+    companions_schema = response.json()["components"]["schemas"]["PlatformRuntimeStateUpsert"][
+        "properties"
+    ]["companions"]
+    assert companions_schema["anyOf"][0] == {"$ref": "#/components/schemas/HostedRuntimeCompanions"}
 
     missing_alias = await platform_client.post(
         "/api/platform/agents",

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -71,6 +71,9 @@ from tests.hosted_runtime_fixtures import (
 from tests.hosted_runtime_fixtures import (
     canonical_hosted_runtime_state,
 )
+from tests.hosted_runtime_fixtures import (
+    filebrowser_companion as _filebrowser_companion,
+)
 
 pytestmark = pytest.mark.committed_db
 
@@ -135,44 +138,6 @@ TEST_HERMES_DASHBOARD_AUTH = {
         "capability": "hermes-basic-auth-v1",
     },
 }
-
-
-def _filebrowser_companion(deployment_id: str, access_revision: str = "a" * 64) -> dict:
-    audience = f"clawdi-files:{deployment_id}"
-    release = "https://github.com/gtsteffaniak/filebrowser/releases/download/v1.5.0-stable"
-    return {
-        "filebrowser": {
-            "version": "v1.5.0-stable",
-            "commit": "79552f8adb27c3e29934c4001660eb98f4aab5d6",
-            "listen": "0.0.0.0",
-            "port": 9120,
-            "baseURL": "/",
-            "healthPath": "/health",
-            "sourceRoot": "/home/clawdi",
-            "assets": {
-                "amd64": {
-                    "url": f"{release}/linux-amd64-filebrowser",
-                    "sha256": "8d51d1718d576d22e73e1f41a5194b451d152ddab0df97697cabe839cf59524e",
-                },
-                "arm64": {
-                    "url": f"{release}/linux-arm64-filebrowser",
-                    "sha256": "3e18838ae33750a25da434dc6156a359968bf7935e01bdd884711f47f08ad92f",
-                },
-            },
-            "auth": {
-                "method": "jwt",
-                "algorithm": "HS256",
-                "header": "X-JWT-Assertion",
-                "userIdentifier": "sub",
-                "groupsClaim": "groups",
-                "secret": "s" * 43,
-                "audience": audience,
-                "subject": f"deployment:{deployment_id}:owner",
-                "requiredGroup": f"{audience}:{access_revision}",
-                "accessRevision": access_revision,
-            },
-        }
-    }
 
 
 def test_hosted_filebrowser_companion_enforces_pins_and_deployment_binding() -> None:

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -5364,6 +5364,96 @@ export interface components {
             /** Profiles */
             profiles?: components["schemas"]["HostedEgressProfile"][] | null;
         };
+        /** HostedFileBrowserAsset */
+        HostedFileBrowserAsset: {
+            /** Url */
+            url: string;
+            /** Sha256 */
+            sha256: string;
+        };
+        /** HostedFileBrowserAssets */
+        HostedFileBrowserAssets: {
+            amd64: components["schemas"]["HostedFileBrowserAsset"];
+            arm64: components["schemas"]["HostedFileBrowserAsset"];
+        };
+        /** HostedFileBrowserAuth */
+        HostedFileBrowserAuth: {
+            /**
+             * Method
+             * @constant
+             */
+            method: "jwt";
+            /**
+             * Algorithm
+             * @constant
+             */
+            algorithm: "HS256";
+            /**
+             * Header
+             * @constant
+             */
+            header: "X-JWT-Assertion";
+            /**
+             * Useridentifier
+             * @constant
+             */
+            userIdentifier: "sub";
+            /**
+             * Groupsclaim
+             * @constant
+             */
+            groupsClaim: "groups";
+            /** Secret */
+            secret: string;
+            /** Audience */
+            audience: string;
+            /** Subject */
+            subject: string;
+            /** Requiredgroup */
+            requiredGroup: string;
+            /** Accessrevision */
+            accessRevision: string;
+        };
+        /** HostedFileBrowserCompanion */
+        HostedFileBrowserCompanion: {
+            /**
+             * Version
+             * @constant
+             */
+            version: "v1.5.0-stable";
+            /**
+             * Commit
+             * @constant
+             */
+            commit: "79552f8adb27c3e29934c4001660eb98f4aab5d6";
+            /**
+             * Listen
+             * @constant
+             */
+            listen: "0.0.0.0";
+            /**
+             * Port
+             * @constant
+             */
+            port: 9120;
+            /**
+             * Baseurl
+             * @constant
+             */
+            baseURL: "/";
+            /**
+             * Healthpath
+             * @constant
+             */
+            healthPath: "/health";
+            /**
+             * Sourceroot
+             * @constant
+             */
+            sourceRoot: "/home/clawdi";
+            assets: components["schemas"]["HostedFileBrowserAssets"];
+            auth: components["schemas"]["HostedFileBrowserAuth"];
+        };
         /** HostedHermesDashboardActivation */
         HostedHermesDashboardActivation: {
             /**
@@ -5448,6 +5538,10 @@ export interface components {
             enabled: boolean;
             /** Version */
             version: number;
+        };
+        /** HostedRuntimeCompanions */
+        HostedRuntimeCompanions: {
+            filebrowser?: components["schemas"]["HostedFileBrowserCompanion"] | null;
         };
         /** HostedRuntimeConfiguredDesiredState */
         HostedRuntimeConfiguredDesiredState: {
@@ -6152,6 +6246,7 @@ export interface components {
             locale: components["schemas"]["HostedRuntimeLocale"];
             system: components["schemas"]["HostedRuntimeSystem"];
             egress_engine?: components["schemas"]["HostedEgressEngine"] | null;
+            companions?: components["schemas"]["HostedRuntimeCompanions"] | null;
             /** Runtimes */
             runtimes: {
                 [key: string]: components["schemas"]["HostedRuntimeConfiguredDesiredState"] | components["schemas"]["HostedRuntimeUnmanagedDesiredState"];


### PR DESCRIPTION
## Summary

- accept the existing HostedRuntimeCompanions contract on PlatformRuntimeStateUpsert
- persist and compare companions symmetrically with sibling optional runtime fields
- cover platform ingestion, JSONB persistence, tenant manifest projection, omission clearing, and the public OpenAPI property
- regenerate the shared API client from FastAPI OpenAPI

## Verification

- pdm lint
- pdm typecheck: 186 files, 0 errors, 0 warnings
- pdm test: 2244 passed, 11 skipped
- focused platform endpoints: 38 passed
- uv run python scripts/check_generated_api.py
- focused Ruff format check for all touched Python files

## Hosted follow-up

After this cloud-api change is deployed, clawdi-hosted should remove the clawdi_cloud_runtime_companions_enabled capability gate and its conditional push path, then always include the filebrowser companion in the platform runtime-state upsert. Keep the OFF-coherent behavior from clawdi-hosted#1562 as failure coherence: suppress the files route and endpoint only when the companion payload was not successfully pushed. With the unconditional push accepted by this schema, the files route and endpoint become active without an opt-in flag.