### PR TITLE
fix(ai): preserve hosted model metadata

### DIFF
--- a/apps/web/src/hosted/v2/ai-providers/provider-types.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-types.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { API_MODE_LABEL, PROVIDER_TYPE_META } from "@/hosted/v2/ai-providers/provider-types";
+import {
+	API_MODE_LABEL,
+	PROVIDER_TYPE_META,
+	toProviderCatalogModels,
+} from "@/hosted/v2/ai-providers/provider-types";
 
 describe("AI provider type metadata", () => {
 	test("uses current model placeholders for known providers", () => {
@@ -43,6 +47,30 @@ describe("AI provider type metadata", () => {
 			"gpt-5.4-mini",
 		]);
 		expect(PROVIDER_TYPE_META.custom_openai_compatible.defaultModels).toEqual([]);
+	});
+
+	test("preserves generated model capabilities and omits empty compat", () => {
+		expect(
+			toProviderCatalogModels([
+				{
+					id: "complete-model",
+					supports_vision: true,
+					supports_tools: false,
+					max_input_tokens: 120_000,
+					compat: { supportsDeveloperRole: false, future: { opaque: true } },
+				},
+				{ id: "empty-compat", compat: {} },
+			]),
+		).toEqual([
+			{
+				id: "complete-model",
+				supports_vision: true,
+				supports_tools: false,
+				max_input_tokens: 120_000,
+				compat: { supportsDeveloperRole: false, future: { opaque: true } },
+			},
+			{ id: "empty-compat" },
+		]);
 	});
 
 	test("uses the factual protocol names shown in Advanced settings", () => {

--- a/apps/web/src/hosted/v2/ai-providers/provider-types.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-types.ts
@@ -141,9 +141,7 @@ export function toProviderCatalogModels(
 			? { supports_reasoning: model.supports_reasoning }
 			: {}),
 		...(model.context_window !== undefined ? { context_window: model.context_window } : {}),
-		...(model.max_input_tokens !== undefined
-			? { max_input_tokens: model.max_input_tokens }
-			: {}),
+		...(model.max_input_tokens !== undefined ? { max_input_tokens: model.max_input_tokens } : {}),
 		...(model.max_tokens !== undefined ? { max_tokens: model.max_tokens } : {}),
 		...(model.compat && Object.keys(model.compat).length > 0
 			? { compat: { ...model.compat } }

--- a/apps/web/src/hosted/v2/ai-providers/provider-types.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-types.ts
@@ -141,7 +141,13 @@ export function toProviderCatalogModels(
 			? { supports_reasoning: model.supports_reasoning }
 			: {}),
 		...(model.context_window !== undefined ? { context_window: model.context_window } : {}),
+		...(model.max_input_tokens !== undefined
+			? { max_input_tokens: model.max_input_tokens }
+			: {}),
 		...(model.max_tokens !== undefined ? { max_tokens: model.max_tokens } : {}),
+		...(model.compat && Object.keys(model.compat).length > 0
+			? { compat: { ...model.compat } }
+			: {}),
 		...(model.cost ? { cost: { ...model.cost } } : {}),
 		...(model.capabilities ? { capabilities: { ...model.capabilities } } : {}),
 	}));

--- a/backend/app/schemas/ai_provider.py
+++ b/backend/app/schemas/ai_provider.py
@@ -303,6 +303,7 @@ class AiProviderModel(BaseModel):
     supports_vision: bool | SkipJsonSchema[None] = None
     supports_tools: bool | SkipJsonSchema[None] = None
     supports_reasoning: bool | SkipJsonSchema[None] = None
+    compat: dict[str, JsonValue] | SkipJsonSchema[None] = None
     context_window: int | SkipJsonSchema[None] = Field(default=None, gt=0)
     max_input_tokens: int | SkipJsonSchema[None] = Field(default=None, gt=0)
     max_tokens: int | SkipJsonSchema[None] = Field(default=None, gt=0)
@@ -323,6 +324,7 @@ class AiProviderModel(BaseModel):
                     "supports_vision",
                     "supports_tools",
                     "supports_reasoning",
+                    "compat",
                     "context_window",
                     "max_input_tokens",
                     "max_tokens",

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -1703,7 +1703,12 @@ async def test_ai_provider_accepts_complete_hosted_model_contract(client: httpx.
         "supports_vision": True,
         "supports_tools": True,
         "supports_reasoning": False,
+        "compat": {
+            "supportsDeveloperRole": False,
+            "future": {"nested": [True, 7, "opaque"]},
+        },
         "context_window": 128000,
+        "max_input_tokens": 120000,
         "max_tokens": 16384,
         "cost": {"input": 1, "output": 2, "cache_read": 0.1, "cache_write": 0.2},
         "capabilities": {

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.44",
+      "version": "0.13.45",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.44",
+	"version": "0.13.45",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
+++ b/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
@@ -144,9 +144,9 @@ describe("WhatsApp sidecar production deployment contract", () => {
 			new Map([
 				[
 					"packages/cli/package.json",
-					replaceOnce(cliPackage, '"version": "0.13.44"', '"version": "0.13.45"'),
+					replaceOnce(cliPackage, '"version": "0.13.45"', '"version": "0.13.46"'),
 				],
-				["bun.lock", replaceOnce(lockfile, '"version": "0.13.44"', '"version": "0.13.45"')],
+				["bun.lock", replaceOnce(lockfile, '"version": "0.13.45"', '"version": "0.13.46"')],
 			]),
 		);
 		const unrelatedDeploy = calculateWhatsAppSidecarDeploymentRevision(

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -3456,6 +3456,10 @@ export interface components {
             supports_tools?: boolean;
             /** Supports Reasoning */
             supports_reasoning?: boolean;
+            /** Compat */
+            compat?: {
+                [key: string]: components["schemas"]["JsonValue"];
+            };
             /** Context Window */
             context_window?: number;
             /** Max Input Tokens */

--- a/packages/shared/src/api/hosted-ai-binding.test.ts
+++ b/packages/shared/src/api/hosted-ai-binding.test.ts
@@ -44,7 +44,15 @@ const apiKeyProvider = {
 	managed_by: "user",
 	runtime_env_name: "OPENAI_API_KEY",
 	capabilities: { chat: true, responses: true },
-	models: [{ id: "gpt-catalog" }],
+	models: [
+		{
+			id: "gpt-catalog",
+			supports_vision: true,
+			supports_tools: false,
+			max_input_tokens: 120_000,
+			compat: { supportsDeveloperRole: false, future: { opaque: true } },
+		},
+	],
 	auth: { type: "api_key", source: "managed", profile: "work" },
 	usable: true,
 	readiness: {
@@ -154,6 +162,13 @@ describe("shared Hosted AI provider binding", () => {
 				type: "api_key",
 				source: "managed",
 				profile: "work",
+			});
+			expect(fields.ai_provider_bootstrap?.catalog.providers[0]?.models?.[0]).toEqual({
+				id: "gpt-catalog",
+				supports_vision: true,
+				supports_tools: false,
+				max_input_tokens: 120_000,
+				compat: { supportsDeveloperRole: false, future: { opaque: true } },
 			});
 		}
 	});
@@ -276,6 +291,7 @@ describe("shared Hosted AI provider binding", () => {
 				models: [
 					{
 						id: "gpt-nullable",
+						compat: {},
 						supports_reasoning: null,
 						context_window: null,
 						max_tokens: null,

--- a/packages/shared/src/api/hosted-ai-binding.ts
+++ b/packages/shared/src/api/hosted-ai-binding.ts
@@ -275,11 +275,23 @@ function toRuntimeModels(models: HostedSavedAiProvider["models"]): RuntimeAiProv
 		if (model.supports_reasoning !== null && model.supports_reasoning !== undefined) {
 			runtimeModel.supports_reasoning = model.supports_reasoning;
 		}
+		if (model.supports_vision !== null && model.supports_vision !== undefined) {
+			runtimeModel.supports_vision = model.supports_vision;
+		}
+		if (model.supports_tools !== null && model.supports_tools !== undefined) {
+			runtimeModel.supports_tools = model.supports_tools;
+		}
 		if (model.context_window !== null && model.context_window !== undefined) {
 			runtimeModel.context_window = model.context_window;
 		}
+		if (model.max_input_tokens !== null && model.max_input_tokens !== undefined) {
+			runtimeModel.max_input_tokens = model.max_input_tokens;
+		}
 		if (model.max_tokens !== null && model.max_tokens !== undefined) {
 			runtimeModel.max_tokens = model.max_tokens;
+		}
+		if (model.compat && Object.keys(model.compat).length > 0) {
+			runtimeModel.compat = { ...model.compat };
 		}
 		const cost = toRuntimeModelCost(model.cost);
 		if (cost) runtimeModel.cost = cost;


### PR DESCRIPTION
## Summary

- accept opaque per-model `compat` in the AI-provider wire contract
- preserve `supports_vision`, `supports_tools`, `max_input_tokens`, and non-empty `compat` through the Hosted web/bootstrap projection
- regenerate the shared API type from the backend schema

## Verification

- `bash scripts/test.sh backend`: 2244 passed, 11 skipped
- `bash scripts/test.sh shared`: 72 passed
- web typecheck, tests, and OSS build passed
- `git diff --check origin/main..HEAD`

## Coordination

The paired clawdi-hosted PR should deploy after this contract is available. This PR is intentionally left unmerged.