### PR TITLE
fix(cli): standardize transparent egress port

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.45",
+      "version": "0.13.46",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.45",
+	"version": "0.13.46",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -5735,7 +5735,6 @@ export function convergeRuntimeManifest(
 		const egressSecretFile = egressSecretWrite.path;
 		const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
 		const resolvedSystemdIdentity = resolveRuntimeSystemdIdentity({
-			manifest,
 			paths,
 			profileBundlePath: egressProfileBundlePath,
 			secretFilePath: egressSecretFile,

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -58,6 +58,7 @@ import {
 	GENERATED_RUNTIME_SYSTEMD_FILE_HEADER,
 	isGeneratedRuntimeSystemdFile,
 } from "./systemd-user";
+import { TRANSPARENT_EGRESS_PORT } from "./transparent-egress";
 
 function runtimeCommandPath(name: string, home: string): string | null {
 	if (name === "openclaw") return join(home, ".openclaw", "bin", "openclaw");
@@ -128,7 +129,6 @@ interface RuntimeEgressIdentity {
 }
 
 function runtimeEgressSystemdProgram(
-	manifest: RuntimeManifest,
 	paths: RuntimePaths,
 	profileBundlePath: string | null,
 	secretFilePath: string | null,
@@ -138,11 +138,10 @@ function runtimeEgressSystemdProgram(
 	if (!profileBundlePath) return null;
 	if (engine?.status !== "ready") return null;
 	if (!addon) return null;
-	const port = 18_080 + (hashToUInt16(`${manifest.instanceId}:${paths.serviceStateRoot}`) % 20_000);
 	return {
 		profileBundlePath,
 		envFilePath: paths.egressTransparentEnv,
-		transparentPort: port,
+		transparentPort: TRANSPARENT_EGRESS_PORT,
 		addonPath: addon.path,
 		addonSha256: addon.sha256,
 		engine,
@@ -152,7 +151,6 @@ function runtimeEgressSystemdProgram(
 }
 
 export function resolveRuntimeSystemdIdentity(input: {
-	manifest: RuntimeManifest;
 	paths: RuntimePaths;
 	profileBundlePath: string | null;
 	secretFilePath: string | null;
@@ -164,7 +162,6 @@ export function resolveRuntimeSystemdIdentity(input: {
 	identity: RuntimeEgressIdentity | null;
 } {
 	const egressProgram = runtimeEgressSystemdProgram(
-		input.manifest,
 		input.paths,
 		input.profileBundlePath,
 		input.secretFilePath,
@@ -228,10 +225,6 @@ export function buildRuntimeSystemdUserProgram(input: {
 		env,
 		resolvedSecretEnv,
 	};
-}
-
-function hashToUInt16(input: string): number {
-	return createHash("sha256").update(input).digest().readUInt16BE(0);
 }
 
 function runtimeSystemdProgramName(program: RuntimeSystemdUserProgram): string {

--- a/packages/cli/src/runtime/transparent-egress.ts
+++ b/packages/cli/src/runtime/transparent-egress.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 
 export const TRANSPARENT_EGRESS_TRANSPORT_VERSION = "clawdi-transparent-egress-v1";
 export const TRANSPARENT_EGRESS_TABLE = "clawdi_transparent_egress";
+export const TRANSPARENT_EGRESS_PORT = 27_212;
 
 export interface TransparentEgressNftRulesInput {
 	table?: string;

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -92,6 +92,7 @@ import {
 	writeRuntimeWatchStatus,
 } from "../src/runtime/state";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "../src/runtime/systemd-user";
+import { TRANSPARENT_EGRESS_PORT } from "../src/runtime/transparent-egress";
 import { getDaemonControlTokenPath } from "../src/serve/paths";
 import { mockFetch } from "./commands/helpers";
 
@@ -14876,6 +14877,9 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		expect(sidecarEnv).toContain(`CLAWDI_EGRESS_ENV_FILE="${paths.egressTransparentEnv}"`);
 		expect(transparentEgressEnv).toContain(
 			'CLAWDI_EGRESS_TRANSPORT_VERSION="clawdi-transparent-egress-v1"',
+		);
+		expect(transparentEgressEnv).toContain(
+			`CLAWDI_EGRESS_TRANSPARENT_PORT="${TRANSPARENT_EGRESS_PORT}"`,
 		);
 		expect(transparentEgressEnv).toContain('CLAWDI_EGRESS_NFT_TABLE="clawdi_transparent_egress"');
 		expect(transparentEgressEnv).toContain('CLAWDI_RUNTIME_UID="10001"');

--- a/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
+++ b/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
@@ -144,9 +144,9 @@ describe("WhatsApp sidecar production deployment contract", () => {
 			new Map([
 				[
 					"packages/cli/package.json",
-					replaceOnce(cliPackage, '"version": "0.13.45"', '"version": "0.13.46"'),
+					replaceOnce(cliPackage, '"version": "0.13.46"', '"version": "0.13.47"'),
 				],
-				["bun.lock", replaceOnce(lockfile, '"version": "0.13.45"', '"version": "0.13.46"')],
+				["bun.lock", replaceOnce(lockfile, '"version": "0.13.46"', '"version": "0.13.47"')],
 			]),
 		);
 		const unrelatedDeploy = calculateWhatsAppSidecarDeploymentRevision(


### PR DESCRIPTION
## Summary

- make `27212` the single platform-owned transparent egress port
- remove per-instance port hashing because each tenant has an isolated network namespace
- verify the converged systemd environment uses the fixed port

## Validation

- full CLI suite: 1645 pass, 4 skip, 0 fail
- focused runtime suite: 182 pass, 0 fail
- CLI TypeScript typecheck
- `git diff --check`

The listener remains bound inside the tenant network namespace and is not exposed through Incus, Traefik, or the host.