### PR TITLE
fix(runtime): bind Files auth to its deployment

### DIFF
--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -188,22 +188,6 @@ class AdminRuntimeStateUpsert(BaseModel):
             raise ValueError("runtimes must contain exactly one enabled runtime")
         return value
 
-    @model_validator(mode="after")
-    def _validate_filebrowser_binding(self) -> AdminRuntimeStateUpsert:
-        filebrowser = self.companions.filebrowser if self.companions is not None else None
-        if filebrowser is None:
-            return self
-        expected_audience = f"clawdi-files:{self.deployment_id}"
-        expected_subject = f"deployment:{self.deployment_id}:owner"
-        expected_group = f"{expected_audience}:{filebrowser.auth.accessRevision}"
-        if (
-            filebrowser.auth.audience != expected_audience
-            or filebrowser.auth.subject != expected_subject
-            or filebrowser.auth.requiredGroup != expected_group
-        ):
-            raise ValueError("Files authentication must be bound to this deployment revision")
-        return self
-
 
 class AdminRuntimeStateResponse(BaseModel):
     environment_id: UUID

--- a/backend/app/schemas/runtime.py
+++ b/backend/app/schemas/runtime.py
@@ -122,6 +122,19 @@ class HostedFileBrowserAuth(BaseModel):
     requiredGroup: str = Field(min_length=1, max_length=256)
     accessRevision: str = Field(pattern=r"^[0-9a-f]{64}$")
 
+    @model_validator(mode="after")
+    def validate_deployment_binding(self) -> "HostedFileBrowserAuth":
+        audience_prefix = "clawdi-files:"
+        deployment_id = self.audience.removeprefix(audience_prefix)
+        if (
+            not deployment_id
+            or self.audience != f"{audience_prefix}{deployment_id}"
+            or self.subject != f"deployment:{deployment_id}:owner"
+            or self.requiredGroup != f"{self.audience}:{self.accessRevision}"
+        ):
+            raise ValueError("Files authentication fields must reference one deployment revision")
+        return self
+
 
 class HostedFileBrowserCompanion(BaseModel):
     model_config = ConfigDict(extra="forbid")

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -140,14 +140,15 @@ TEST_HERMES_DASHBOARD_AUTH = {
 }
 
 
-def test_hosted_filebrowser_companion_enforces_pins_and_deployment_binding() -> None:
-    deployment_id = "hdep_files_contract"
-    companion = _filebrowser_companion(deployment_id)
+def test_hosted_filebrowser_companion_enforces_pins_and_auth_binding() -> None:
+    files_deployment_id = "hdep_files_contract"
+    companion = _filebrowser_companion(files_deployment_id)
     body = _runtime_state_body(
         str(uuid4()),
-        deployment_id=deployment_id,
         companions=companion,
     )
+
+    assert body["deployment_id"] != files_deployment_id
 
     validated = AdminRuntimeStateUpsert.model_validate(body)
     assert validated.companions is not None
@@ -166,11 +167,11 @@ def test_hosted_filebrowser_companion_enforces_pins_and_deployment_binding() -> 
     for field, value in (
         ("audience", "clawdi-files:hdep_other"),
         ("subject", "deployment:hdep_other:owner"),
-        ("requiredGroup", f"clawdi-files:{deployment_id}:{'b' * 64}"),
+        ("requiredGroup", f"clawdi-files:{files_deployment_id}:{'b' * 64}"),
     ):
         invalid = json.loads(json.dumps(body))
         invalid["companions"]["filebrowser"]["auth"][field] = value
-        with pytest.raises(ValidationError, match="Files authentication must be bound"):
+        with pytest.raises(ValidationError, match="Files authentication fields must reference"):
             AdminRuntimeStateUpsert.model_validate(invalid)
 
     unpinned = json.loads(json.dumps(body))


### PR DESCRIPTION
## Summary

- validate the Files audience, subject, and access group as one self-contained deployment revision
- stop coupling Files `hdep_*` identity to the runtime instance `hri_*` identity
- keep the rule in the shared Files auth schema used by all runtime-state entry points

## Verification

- `scripts/test.sh backend` (`2245 passed, 11 skipped`)
- focused runtime manifest test
- Ruff lint and format checks
- changed-production type gate (`2 files, 0 diagnostics`)
- compileall and `git diff --check`