### PR TITLE
fix(cli): bind Files auth to its deployment

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.46",
+      "version": "0.13.47",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.46",
+	"version": "0.13.47",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -204,6 +204,42 @@ const fileBrowserAssetSchema = z
 	})
 	.strict();
 
+const FILE_BROWSER_AUDIENCE_PREFIX = "clawdi-files:";
+
+const fileBrowserAuthSchema = z
+	.object({
+		method: z.literal("jwt"),
+		algorithm: z.literal("HS256"),
+		header: z.literal("X-JWT-Assertion"),
+		userIdentifier: z.literal("sub"),
+		groupsClaim: z.literal("groups"),
+		secret: z
+			.string()
+			.min(43)
+			.max(128)
+			.regex(/^[A-Za-z0-9_-]+$/),
+		audience: z.string().min(1).max(256),
+		subject: z.string().min(1).max(256),
+		requiredGroup: z.string().min(1).max(256),
+		accessRevision: z.string().regex(/^[a-f0-9]{64}$/),
+	})
+	.strict()
+	.superRefine((auth, ctx) => {
+		const deploymentId = auth.audience.startsWith(FILE_BROWSER_AUDIENCE_PREFIX)
+			? auth.audience.slice(FILE_BROWSER_AUDIENCE_PREFIX.length)
+			: "";
+		if (
+			!deploymentId ||
+			auth.subject !== `deployment:${deploymentId}:owner` ||
+			auth.requiredGroup !== `${auth.audience}:${auth.accessRevision}`
+		) {
+			ctx.addIssue({
+				code: "custom",
+				message: "Files authentication fields must reference one deployment revision",
+			});
+		}
+	});
+
 export const fileBrowserCompanionSchema = z
 	.object({
 		version: z.literal(FILE_BROWSER_VERSION),
@@ -229,24 +265,7 @@ export const fileBrowserCompanionSchema = z
 				}),
 			})
 			.strict(),
-		auth: z
-			.object({
-				method: z.literal("jwt"),
-				algorithm: z.literal("HS256"),
-				header: z.literal("X-JWT-Assertion"),
-				userIdentifier: z.literal("sub"),
-				groupsClaim: z.literal("groups"),
-				secret: z
-					.string()
-					.min(43)
-					.max(128)
-					.regex(/^[A-Za-z0-9_-]+$/),
-				audience: z.string().min(1).max(256),
-				subject: z.string().min(1).max(256),
-				requiredGroup: z.string().min(1).max(256),
-				accessRevision: z.string().regex(/^[a-f0-9]{64}$/),
-			})
-			.strict(),
+		auth: fileBrowserAuthSchema,
 	})
 	.strict();
 
@@ -711,25 +730,6 @@ function validateHostedRuntimeManifest(
 	manifest: HostedRuntimeManifestBase,
 	ctx: z.RefinementCtx,
 ): void {
-	const filebrowser = manifest.companions?.filebrowser;
-	if (filebrowser) {
-		const expectedAudience = `clawdi-files:${manifest.deploymentId}`;
-		const expectedSubject = `deployment:${manifest.deploymentId}:owner`;
-		const expectedGroup = `${expectedAudience}:${filebrowser.auth.accessRevision}`;
-		for (const [field, actual, expected] of [
-			["audience", filebrowser.auth.audience, expectedAudience],
-			["subject", filebrowser.auth.subject, expectedSubject],
-			["requiredGroup", filebrowser.auth.requiredGroup, expectedGroup],
-		] as const) {
-			if (actual !== expected) {
-				ctx.addIssue({
-					code: "custom",
-					message: `Files ${field} must be bound to this deployment and access revision`,
-					path: ["companions", "filebrowser", "auth", field],
-				});
-			}
-		}
-	}
 	const runtimeKeys = Object.keys(manifest.runtimes);
 	const unexpectedRuntimeKeys = runtimeKeys.filter((runtime) => runtime !== manifest.runtime);
 	if (!manifest.runtimes[manifest.runtime]) {

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -590,7 +590,7 @@ esac
 type FileBrowserCompanion = NonNullable<NonNullable<RuntimeManifest["companions"]>["filebrowser"]>;
 
 function fileBrowserCompanion(accessRevision = "a".repeat(64)): FileBrowserCompanion {
-	const audience = "clawdi-files:hdep_reconcile";
+	const audience = "clawdi-files:hdep_files_reconcile";
 	return {
 		version: FILE_BROWSER_VERSION,
 		commit: FILE_BROWSER_COMMIT,
@@ -617,7 +617,7 @@ function fileBrowserCompanion(accessRevision = "a".repeat(64)): FileBrowserCompa
 			groupsClaim: "groups",
 			secret: accessRevision.slice(0, 43),
 			audience,
-			subject: "deployment:hdep_reconcile:owner",
+			subject: "deployment:hdep_files_reconcile:owner",
 			requiredGroup: `${audience}:${accessRevision}`,
 			accessRevision,
 		},
@@ -5092,7 +5092,7 @@ exit 42
 		);
 	});
 
-	test("rejects user-overridden Files contracts", () => {
+	test("enforces pinned and internally bound Files contracts", () => {
 		const paths = tempRuntimePaths();
 		const binary = "Files gate fixture\n";
 		const manifest = fileBrowserManifest(paths, { generation: 1, binary });
@@ -5104,6 +5104,19 @@ exit 42
 
 		const pinned = fileBrowserCompanion();
 		expect(fileBrowserCompanionSchema.safeParse(pinned).success).toBe(true);
+		expect(manifest.deploymentId).not.toBe("hdep_files_reconcile");
+		for (const [field, value] of [
+			["audience", "clawdi-files:hdep_other"],
+			["subject", "deployment:hdep_other:owner"],
+			["requiredGroup", `clawdi-files:hdep_files_reconcile:${"b".repeat(64)}`],
+		] as const) {
+			expect(
+				fileBrowserCompanionSchema.safeParse({
+					...pinned,
+					auth: { ...pinned.auth, [field]: value },
+				}).success,
+			).toBe(false);
+		}
 		expect(
 			hostedRuntimeBundleV2ManifestSchema.safeParse({
 				...manifest,

--- a/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
+++ b/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
@@ -20,6 +20,8 @@ const dockerfile = readFileSync(
 );
 const lockfile = readFileSync(resolve(repoRoot, "bun.lock"), "utf8");
 const cliPackage = readFileSync(resolve(repoRoot, "packages/cli/package.json"), "utf8");
+const cliVersion = (JSON.parse(cliPackage) as { version: string }).version;
+const cliRevisionProbeVersion = `${cliVersion}-revision-probe`;
 const sidecarPackage = readFileSync(
 	resolve(repoRoot, "packages/whatsapp-baileys-sidecar/package.json"),
 	"utf8",
@@ -144,9 +146,20 @@ describe("WhatsApp sidecar production deployment contract", () => {
 			new Map([
 				[
 					"packages/cli/package.json",
-					replaceOnce(cliPackage, '"version": "0.13.46"', '"version": "0.13.47"'),
+					replaceOnce(
+						cliPackage,
+						`"version": "${cliVersion}"`,
+						`"version": "${cliRevisionProbeVersion}"`,
+					),
 				],
-				["bun.lock", replaceOnce(lockfile, '"version": "0.13.46"', '"version": "0.13.47"')],
+				[
+					"bun.lock",
+					replaceOnce(
+						lockfile,
+						`"version": "${cliVersion}"`,
+						`"version": "${cliRevisionProbeVersion}"`,
+					),
+				],
 			]),
 		);
 		const unrelatedDeploy = calculateWhatsAppSidecarDeploymentRevision(


### PR DESCRIPTION
## Summary
- validate Files JWT identity as one self-contained deployment/revision contract
- remove the incorrect dependency on the parent runtime deployment id
- prove distinct runtime and Files deployment identities in the existing focused contract test
- release the corrected CLI as `0.13.47` through the existing protected workflow

## Verification
- `bash scripts/test.sh cli` (1645 passed, 4 skipped)
- focused Files contract rerun (1 passed)
- release version/workflow contracts (7 passed)
- Biome 2.5.2 on both implementation/test files
- `git diff --check`