### PR TITLE
fix(runtime): follow official agent workspace defaults

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.47",
+      "version": "0.13.48",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.47",
+	"version": "0.13.48",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/adapters/openclaw-workspace.ts
+++ b/packages/cli/src/adapters/openclaw-workspace.ts
@@ -10,6 +10,20 @@ export function openClawAgentId(): string {
 	return process.env.OPENCLAW_AGENT_ID?.trim() || "main";
 }
 
+export function parseOpenClawAgentWorkspaces(output: string): OpenClawAgentWorkspace[] {
+	const parsed = JSON.parse(output) as unknown;
+	if (!Array.isArray(parsed)) return [];
+	return parsed.flatMap((value): OpenClawAgentWorkspace[] => {
+		if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+		const entry = value as Record<string, unknown>;
+		return typeof entry.id === "string" &&
+			typeof entry.workspace === "string" &&
+			isAbsolute(entry.workspace)
+			? [{ id: entry.id, workspace: entry.workspace }]
+			: [];
+	});
+}
+
 export function listOpenClawAgentWorkspaces(): OpenClawAgentWorkspace[] {
 	const result = spawnSync("openclaw", ["agents", "list", "--json"], {
 		encoding: "utf8",
@@ -19,19 +33,8 @@ export function listOpenClawAgentWorkspaces(): OpenClawAgentWorkspace[] {
 	});
 	if (result.status === 0) {
 		try {
-			const parsed = JSON.parse(result.stdout) as unknown;
-			if (Array.isArray(parsed)) {
-				const summaries = parsed.flatMap((value): OpenClawAgentWorkspace[] => {
-					if (!value || typeof value !== "object" || Array.isArray(value)) return [];
-					const entry = value as Record<string, unknown>;
-					return typeof entry.id === "string" &&
-						typeof entry.workspace === "string" &&
-						isAbsolute(entry.workspace)
-						? [{ id: entry.id, workspace: entry.workspace }]
-						: [];
-				});
-				if (summaries.length > 0) return summaries;
-			}
+			const summaries = parseOpenClawAgentWorkspaces(result.stdout);
+			if (summaries.length > 0) return summaries;
 		} catch {
 			// Invalid public CLI output is reported below.
 		}

--- a/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
@@ -37,7 +37,7 @@ if test "$1 $2 $3" = "agents list --json"; then
     printf '[{"id":"main","workspace":"${join(home, "different-workspace")}"}]\n'
     exit 0
   fi
-  printf '[{"id":"main","workspace":"%s"}]\n' "$PWD"
+  printf '%s\n' '[{"id":"main","workspace":"${workspaceRoot}"}]'
   exit 0
 fi
 test "$1 $2" = "skills install"
@@ -49,11 +49,11 @@ test "$2" = "main"
 test "$3" = "--as"
 skill_id="$4"
 test "$5" = "--force"
-mkdir -p "$PWD/skills"
-rm -rf "$PWD/skills/$skill_id"
-cp -R "$source_dir" "$PWD/skills/$skill_id"
-mkdir -p "$PWD/skills/$skill_id/.openclaw"
-printf '{}\n' > "$PWD/skills/$skill_id/.openclaw/source-origin.json"
+mkdir -p '${workspaceRoot}/skills'
+rm -rf '${workspaceRoot}/skills/'"$skill_id"
+cp -R "$source_dir" '${workspaceRoot}/skills/'"$skill_id"
+mkdir -p '${workspaceRoot}/skills/'"$skill_id"'/.openclaw'
+printf '{}\n' > '${workspaceRoot}/skills/'"$skill_id"'/.openclaw/source-origin.json'
 if test "\${FAKE_OPENCLAW_FAIL_AFTER_WRITE:-}" = "1"; then exit 45; fi
 if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDriftMarker}'; fi
 `,
@@ -73,8 +73,7 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 			path: "skills/review-pr",
 			commit: "a".repeat(40),
 		},
-		sourceIdentity:
-			"github\0review-pr\0https://github.com/Clawdi-AI/store\0skills/review-pr\0" + "a".repeat(40),
+		sourceIdentity: `github\0review-pr\0https://github.com/Clawdi-AI/store\0skills/review-pr\0${"a".repeat(40)}`,
 		archiveSha256: "b".repeat(64),
 		tarBytes: readFileSync(archive),
 	};
@@ -111,7 +110,7 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 			sourceDir,
 			ownershipIdentity: `${skill.sourceIdentity}-v2`,
 		}),
-	).toThrow("does not match");
+	).toThrow("changed during Skill reconciliation");
 	expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("# Review PR\n");
 	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, skill })).toBe(true);
 	delete process.env.FAKE_OPENCLAW_DRIFT_AFTER_WRITE;
@@ -146,7 +145,7 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 	expect(existsSync(receipt)).toBe(false);
 });
 
-test("fails before official install when the OpenClaw main workspace differs", async () => {
+test("fails before official install when the OpenClaw workspace changes during reconciliation", async () => {
 	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-workspace-mismatch-"));
 	const home = join(root, "home");
 	const workspaceRoot = join(home, "desired-workspace");
@@ -179,7 +178,7 @@ exit 0
 				"github\0review-pr\0https://github.com/Clawdi-AI/store\0skills/review-pr\0" +
 				"a".repeat(40),
 		}),
-	).toThrow("does not match");
+	).toThrow("changed during Skill reconciliation");
 	expect(existsSync(installMarker)).toBe(false);
 	expect(existsSync(join(workspaceRoot, "skills", "review-pr"))).toBe(false);
 });

--- a/packages/cli/src/runtime/hosted-openclaw-skill.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.ts
@@ -1,5 +1,9 @@
 import { existsSync, rmSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
+import {
+	type OpenClawAgentWorkspace,
+	parseOpenClawAgentWorkspaces,
+} from "../adapters/openclaw-workspace";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import {
 	collectManagedSkillTree,
@@ -18,6 +22,7 @@ const EXCLUDED_NATIVE_FILES = new Set([SOURCE_RECEIPT]);
 const RECEIPT_SCHEMA = "clawdi.openclawManifestSkillReceipt.v2";
 
 export interface HostedOpenClawSkillDriver {
+	resolveWorkspace(input: { home: string }): string;
 	installDirectory(input: {
 		home: string;
 		workspaceRoot: string;
@@ -38,12 +43,18 @@ export interface HostedOpenClawSkillDriver {
 	}): "absent" | "removed";
 }
 
-function commandPath(home: string): string {
+function installedCommandPath(home: string): string | null {
 	for (const candidate of [
 		join(home, ".local", "bin", "openclaw"),
 		join(home, ".openclaw", "bin", "openclaw"),
 	])
 		if (executableExists(candidate)) return candidate;
+	return null;
+}
+
+function commandPath(home: string): string {
+	const command = installedCommandPath(home);
+	if (command) return command;
 	throw new Error("installed OpenClaw Skill CLI is unavailable");
 }
 const targetDir = (workspaceRoot: string, skillId: string) =>
@@ -61,38 +72,29 @@ function receiptInput(workspaceRoot: string, skillId: string, ownershipIdentity:
 	};
 }
 
-function assertOfficialWorkspace(input: { home: string; workspaceRoot: string }): void {
-	const result = spawnRuntimeUserCommand(
-		commandPath(input.home),
-		["agents", "list", "--json"],
-		input.home,
-		input.workspaceRoot,
-		{ timeoutMs: 15_000, maxBufferBytes: 1024 * 1024 },
-	);
+function resolveOfficialWorkspace(home: string): string {
+	const command = commandPath(home);
+	const result = spawnRuntimeUserCommand(command, ["agents", "list", "--json"], home, home, {
+		timeoutMs: 15_000,
+		maxBufferBytes: 1024 * 1024,
+	});
 	if (result.status !== 0)
 		throw new Error("OpenClaw official agent workspace roster is unavailable");
-	let roster: unknown;
+	let roster: OpenClawAgentWorkspace[];
 	try {
-		roster = JSON.parse(String(result.stdout));
+		roster = parseOpenClawAgentWorkspaces(String(result.stdout));
 	} catch {
 		throw new Error("OpenClaw official agent workspace roster is malformed");
 	}
-	if (!Array.isArray(roster))
+	const main = roster.filter((entry) => entry.id === OPENCLAW_AGENT_ID);
+	if (main.length !== 1 || !isAbsolute(main[0].workspace))
 		throw new Error("OpenClaw official agent workspace roster is malformed");
-	const main = roster.filter((entry): entry is Record<string, unknown> =>
-		Boolean(
-			entry &&
-				typeof entry === "object" &&
-				!Array.isArray(entry) &&
-				(entry as Record<string, unknown>).id === OPENCLAW_AGENT_ID,
-		),
-	);
-	if (main.length !== 1 || typeof main[0].workspace !== "string" || !isAbsolute(main[0].workspace))
-		throw new Error("OpenClaw official agent workspace roster is malformed");
-	if (resolve(main[0].workspace) !== resolve(input.workspaceRoot))
-		throw new Error(
-			"OpenClaw official agent workspace does not match the desired manifest workspace",
-		);
+	return resolve(main[0].workspace);
+}
+
+function assertOfficialWorkspace(input: { home: string; workspaceRoot: string }): void {
+	if (resolveOfficialWorkspace(input.home) !== resolve(input.workspaceRoot))
+		throw new Error("OpenClaw official agent workspace changed during Skill reconciliation");
 }
 
 function nativeResultMatches(sourceDir: string, target: string): boolean {
@@ -103,6 +105,9 @@ function nativeResultMatches(sourceDir: string, target: string): boolean {
 }
 
 export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
+	resolveWorkspace(input) {
+		return resolveOfficialWorkspace(input.home);
+	},
 	installDirectory(input) {
 		const target = targetDir(input.workspaceRoot, input.skillId);
 		const receipt = receiptInput(input.workspaceRoot, input.skillId, input.ownershipIdentity);

--- a/packages/cli/src/runtime/manifest-mutation-parity.test.ts
+++ b/packages/cli/src/runtime/manifest-mutation-parity.test.ts
@@ -127,7 +127,11 @@ test("keeps real Hosted converge mutations inside its exact root and runtime-use
 	fsOriginals.writeFileSync(
 		openclaw,
 		`#!/bin/sh
-[ "\${1:-}" != "--version" ] || printf '%s\\n' '2026.7.1'
+if [ "$*" = "agents list --json" ]; then
+  printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace"
+elif [ "\${1:-}" = "--version" ]; then
+  printf '%s\\n' '2026.7.1'
+fi
 exit 0
 `,
 	);

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -565,17 +565,18 @@ EOF
   "gateway uninstall")
     rm -f '${input.unitPath}'
     ;;
-  "agents list --json")
-    printf '[{"id":"main","workspace":"%s"}]\n' "$PWD"
-    ;;
-  "skills install "*)
-    source_dir="$3"
-    skill_id="$7"
-    mkdir -p "$PWD/skills"
-    rm -rf "$PWD/skills/$skill_id"
-    cp -R "$source_dir" "$PWD/skills/$skill_id"
-    mkdir -p "$PWD/skills/$skill_id/.openclaw"
-    printf '{}\n' > "$PWD/skills/$skill_id/.openclaw/source-origin.json"
+	  "agents list --json")
+	    printf '[{"id":"main","workspace":"%s"}]\n' "$HOME/.openclaw/workspace"
+	    ;;
+	  "skills install "*)
+	    source_dir="$3"
+	    skill_id="$7"
+	    workspace="$HOME/.openclaw/workspace"
+	    mkdir -p "$workspace/skills"
+	    rm -rf "$workspace/skills/$skill_id"
+	    cp -R "$source_dir" "$workspace/skills/$skill_id"
+	    mkdir -p "$workspace/skills/$skill_id/.openclaw"
+	    printf '{}\n' > "$workspace/skills/$skill_id/.openclaw/source-origin.json"
     ;;
   *)
     printf 'unexpected ${input.runtime} command: %s\\n' "$*" >&2
@@ -1409,6 +1410,10 @@ describe("runtime manifest reconciliation invariants", () => {
 			openclawBin,
 			[
 				"#!/bin/sh",
+				'if [ "$1 $2 $3" = "agents list --json" ]; then',
+				'  printf \'[{"id":"main","workspace":"%s"}]\\n\' "$HOME/.openclaw/workspace"',
+				"  exit 0",
+				"fi",
 				'if [ "$1 $2 $3" = "config patch --stdin" ]; then',
 				`  cat > '${patchPath}'`,
 				"  exit 0",
@@ -1465,6 +1470,10 @@ describe("runtime manifest reconciliation invariants", () => {
 			openclawBin,
 			[
 				"#!/bin/sh",
+				'if [ "$1 $2 $3" = "agents list --json" ]; then',
+				'  printf \'[{"id":"main","workspace":"%s"}]\\n\' "$HOME/.openclaw/workspace"',
+				"  exit 0",
+				"fi",
 				'if [ "$1 $2 $3" = "config patch --stdin" ]; then',
 				`  cat > '${patchPath}'`,
 				"  exit 0",
@@ -2041,6 +2050,11 @@ describe("runtime manifest reconciliation invariants", () => {
 
 	test("converges OpenClaw native token auth from canonical bundle secret refs", () => {
 		const paths = tempRuntimePaths();
+		writeFakeGatewayCli({
+			path: join(paths.userHome, ".openclaw", "bin", "openclaw"),
+			runtime: "openclaw",
+			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
+		});
 		const manifest = baseManifest(
 			paths,
 			{
@@ -2121,6 +2135,11 @@ describe("runtime manifest reconciliation invariants", () => {
 
 	test("keeps hosted managed provider key out of the agent env", () => {
 		const paths = tempRuntimePaths();
+		writeFakeGatewayCli({
+			path: join(paths.userHome, ".openclaw", "bin", "openclaw"),
+			runtime: "openclaw",
+			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
+		});
 		const manifest = baseManifest(
 			paths,
 			{
@@ -3474,17 +3493,34 @@ describe("runtime manifest reconciliation invariants", () => {
 
 	test("does not mutate live state when runtime planning fails", () => {
 		const paths = tempRuntimePaths();
-		const workspaceRoot = join(paths.userHome, "clawdi");
-		const soulPath = join(workspaceRoot, "SOUL.md");
+		const openClawWorkspaceRoot = join(paths.userHome, ".openclaw", "workspace");
+		const soulPath = join(openClawWorkspaceRoot, "SOUL.md");
 		const staleRunConfig = join(paths.runConfigRoot, "stale-runtime.json");
 		const systemdUnit = join(paths.systemdUserRoot, "clawdi-openclaw.service");
 		const installerPath = join(dirname(paths.userHome), "openclaw-installer.sh");
 		const installerLog = join(dirname(paths.userHome), "openclaw-installer.log");
-		writeFileSync(installerPath, `#!/usr/bin/env bash\necho spawned > '${installerLog}'\nexit 0\n`);
+		writeFileSync(
+			installerPath,
+			`#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "$HOME/.openclaw/bin"
+cat > "$HOME/.openclaw/bin/openclaw" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$*" = "agents list --json" ]; then
+  printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace"
+  exit 0
+fi
+exit 64
+EOF
+chmod 0700 "$HOME/.openclaw/bin/openclaw"
+echo spawned > '${installerLog}'
+`,
+		);
 		chmodSync(installerPath, 0o700);
 		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
 		process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER = installerPath;
-		mkdirSync(workspaceRoot, { recursive: true });
+		mkdirSync(openClawWorkspaceRoot, { recursive: true });
 		mkdirSync(dirname(paths.managedConfig), { recursive: true });
 		mkdirSync(paths.runConfigRoot, { recursive: true });
 		mkdirSync(paths.systemdUserRoot, { recursive: true });
@@ -3535,7 +3571,8 @@ describe("runtime manifest reconciliation invariants", () => {
 			if (!expected) throw new Error(`missing preserved fixture for ${path}`);
 			expect(readFileSync(path)).toEqual(expected);
 		}
-		expect(existsSync(installerLog)).toBe(false);
+		expect(readFileSync(installerLog, "utf8")).toBe("spawned\n");
+		expect(existsSync(join(paths.userHome, ".openclaw", "bin", "openclaw"))).toBe(false);
 	});
 
 	test("keeps the hosted skill ledger root owned while mutating the runtime-user skill tree", () => {
@@ -3815,8 +3852,8 @@ describe("runtime manifest reconciliation invariants", () => {
 			runtime: "openclaw",
 			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
 		});
-		const workspaceRoot = join(paths.userHome, "clawdi");
-		const target = join(workspaceRoot, "skills", "clawdi");
+		const openClawWorkspaceRoot = join(paths.userHome, ".openclaw", "workspace");
+		const target = join(openClawWorkspaceRoot, "skills", "clawdi");
 		const source = resolve(import.meta.dir, "../..", "skills", "hosted-versions", "1", "clawdi");
 		const bundle = loadHostedBundledSkill("clawdi", 1, source);
 		reconcileHostedBundledSkill({ bundle, targetDir: target, reserved: true });
@@ -3831,6 +3868,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			paths,
 			{
 				hostedOpenClawSkillDriver: {
+					resolveWorkspace: () => openClawWorkspaceRoot,
 					installDirectory: () => "installed",
 					install: () => "installed",
 					verifyOwned: () => false,
@@ -4049,6 +4087,7 @@ describe("runtime manifest reconciliation invariants", () => {
 	test("uses an explicit managed snapshot allowlist without broad runtime roots", () => {
 		const paths = tempRuntimePaths();
 		const workspaceRoot = join(paths.userHome, "clawdi");
+		const openClawWorkspaceRoot = join(paths.userHome, ".openclaw", "workspace");
 		const manifest = baseManifest(paths, {
 			openclaw: { enabled: true, run: runSettings("openclaw", []), services: {} },
 			hermes: { enabled: true, run: runSettings("hermes", []), services: {} },
@@ -4109,7 +4148,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				existingSystemDropIn,
 			].sort(),
 		);
-		expect(runtimeUserMutationTargets(manifest, paths, workspaceRoot, new Map())).toEqual(
+		expect(runtimeUserMutationTargets(manifest, paths, openClawWorkspaceRoot, new Map())).toEqual(
 			expect.arrayContaining([
 				join(paths.userHome, ".hermes", "auth.json"),
 				join(paths.userHome, ".hermes", "auth.lock"),
@@ -4123,13 +4162,13 @@ describe("runtime manifest reconciliation invariants", () => {
 			paths.runRoot,
 			paths.userHome,
 			workspaceRoot,
-			join(workspaceRoot, "SOUL.md"),
+			join(openClawWorkspaceRoot, "SOUL.md"),
 			join(paths.userHome, ".openclaw", "openclaw.json"),
 			join(paths.userHome, ".hermes", "config.yaml"),
 			join(paths.userHome, ".hermes", "SOUL.md"),
 			join(paths.userHome, ".hermes", "plugins", "model-providers", "clawdi"),
 			join(paths.userHome, ".codex", "config.toml"),
-			join(workspaceRoot, "skills", "clawdi"),
+			join(openClawWorkspaceRoot, "skills", "clawdi"),
 			join(paths.userHome, ".hermes", "skills", "clawdi"),
 			join(paths.localEnvironments, "openclaw.json"),
 			join(paths.systemdUserRoot, "clawdi-openclaw.service"),
@@ -4316,7 +4355,15 @@ describe("runtime manifest reconciliation invariants", () => {
 		const commandPath = join(appRoot, "bin", "openclaw");
 		const commandTarget = join(appRoot, "openclaw-entrypoint");
 		mkdirSync(dirname(commandPath), { recursive: true });
-		writeFileSync(commandTarget, "#!/bin/sh\nexit 0\n");
+		writeFileSync(
+			commandTarget,
+			`#!/bin/sh
+if [ "$*" = "agents list --json" ]; then
+  printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace"
+fi
+exit 0
+`,
+		);
 		chmodSync(commandTarget, 0o755);
 		symlinkSync(commandTarget, commandPath);
 		const manifest = baseManifest(paths, {
@@ -4504,7 +4551,7 @@ printf '{"ok":true}\\n'
 		expect(statSync(paths.daemonAuthToken).mode & 0o777).toBe(0o600);
 	});
 
-	test("restores exact installer targets and reconciles the planned units after installer failure", () => {
+	test("restores exact installer targets before Apply when installation fails", () => {
 		const paths = tempRuntimePaths();
 		const home = paths.userHome;
 		const binDir = join(home, ".openclaw", "bin");
@@ -4554,11 +4601,7 @@ exit 42
 			},
 		});
 		let activateCalls = 0;
-		let rollbackSignal: {
-			reconcileUserUnits: string[];
-			staleSystemUnits: string[];
-			staleUserUnits: string[];
-		} | null = null;
+		let rollbackCalls = 0;
 		const result = convergeRuntimeManifest(manifestLoad(manifest, "installer-failure"), paths, {
 			systemdApply: {
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
@@ -4566,20 +4609,14 @@ exit 42
 					activateCalls += 1;
 					return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
 				},
-				rollback: (signal) => {
-					rollbackSignal = signal;
-				},
+				rollback: () => rollbackCalls++,
 			},
 		});
 
 		expect(result.installErrors.join("\n")).toContain("runtime openclaw installer exited 42");
 		expect(readFileSync(installerLog, "utf8")).toBe("ran\n");
 		expect(activateCalls).toBe(0);
-		expect(rollbackSignal).toMatchObject({
-			reconcileUserUnits: ["openclaw-gateway.service"],
-			staleSystemUnits: [],
-			staleUserUnits: [],
-		});
+		expect(rollbackCalls).toBe(0);
 		expect(readFileSync(existingBinFile, "utf8")).toBe("original-bin\n");
 		expect(readFileSync(existingToolFile, "utf8")).toBe("original-tool\n");
 		expect(existsSync(commandPath)).toBe(false);
@@ -4683,6 +4720,11 @@ exit 42
 
 	test("rolls back managed state when the authority commit fails", () => {
 		const paths = tempRuntimePaths();
+		writeFakeGatewayCli({
+			path: join(paths.userHome, ".openclaw", "bin", "openclaw"),
+			runtime: "openclaw",
+			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
+		});
 		mkdirSync(dirname(paths.managedConfig), { recursive: true });
 		mkdirSync(dirname(paths.appliedState), { recursive: true });
 		writeFileSync(paths.managedConfig, "old-managed\n");
@@ -4722,6 +4764,11 @@ exit 42
 
 	test("garbage collects stale run configs when a runtime is removed", () => {
 		const paths = tempRuntimePaths();
+		writeFakeGatewayCli({
+			path: join(paths.userHome, ".openclaw", "bin", "openclaw"),
+			runtime: "openclaw",
+			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
+		});
 		const initialManifest = baseManifest(paths, {
 			hermes: {
 				enabled: true,

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -12,6 +12,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { hostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
 import {
 	readRuntimeInstallReceipts,
 	runtimeInstallReceiptsPath,
@@ -66,6 +67,10 @@ function convergeRuntimeManifest(
 		paths,
 		{
 			...opts,
+			hostedOpenClawSkillDriver: opts?.hostedOpenClawSkillDriver ?? {
+				...hostedOpenClawSkillDriver,
+				resolveWorkspace: () => join(paths.userHome, ".openclaw", "workspace"),
+			},
 			hostedRuntimeContract: opts?.hostedRuntimeContract ?? {
 				expectedIdentity: {
 					home: paths.userHome,

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -429,7 +429,6 @@ export function hostedManifestToRuntimeManifest(
 	applyGeneration?: number,
 ): RuntimeManifest {
 	const paths = getRuntimePaths({ mode: "hosted" });
-	const workspaceRoot = paths.workspaceRoot;
 	const selectedRuntime = hosted.runtime;
 	const runtime = hosted.runtimes[selectedRuntime];
 	return {
@@ -442,7 +441,6 @@ export function hostedManifestToRuntimeManifest(
 		issuedAt: hosted.issuedAt,
 		expiresAt: hosted.expiresAt,
 		locale: hosted.locale,
-		workspaceRoot,
 		runtime: selectedRuntime,
 		controlPlane: {
 			apiUrl: hosted.controlPlane.cloudApiUrl,
@@ -461,11 +459,11 @@ export function hostedManifestToRuntimeManifest(
 					home: paths.userHome,
 					args: OFFICIAL_INSTALL_ARGS[selectedRuntime],
 				},
-				run: hostedRuntimeRunSettings(runtime.run, workspaceRoot),
+				run: hostedRuntimeRunSettings(runtime.run),
 				services: Object.fromEntries(
 					Object.entries(runtime.services ?? {}).map(([service, run]) => [
 						service,
-						hostedRuntimeServiceRunSettings(run, workspaceRoot),
+						hostedRuntimeServiceRunSettings(run),
 					]),
 				),
 				...hostedRuntimeProviderBinding(runtime),
@@ -501,27 +499,20 @@ function hostedRuntimeProviderBinding(
 	return { provider_ids: runtime.provider_ids, primary_model: runtime.primary_model };
 }
 
-function hostedRuntimeRunSettings(
-	run: RuntimeRunSettings | undefined,
-	runtimeWorkspace: string,
-): RuntimeRunSettings {
-	const cwd = run?.cwd ?? runtimeWorkspace;
+function hostedRuntimeRunSettings(run: RuntimeRunSettings | undefined): RuntimeRunSettings {
 	const settings: RuntimeRunSettings = {
 		env: run?.env ?? {},
-		cwd,
 		prependPath: run?.prependPath ?? [],
 	};
 	if (run?.command !== undefined) settings.command = run.command;
 	if (run?.args !== undefined) settings.args = run.args;
 	if (run?.secretEnv !== undefined) settings.secretEnv = run.secretEnv;
+	if (run?.cwd !== undefined) settings.cwd = run.cwd;
 	return settings;
 }
 
-function hostedRuntimeServiceRunSettings(
-	run: RuntimeRunSettings,
-	runtimeWorkspace: string,
-): RuntimeRunSettings {
-	return hostedRuntimeRunSettings(run, runtimeWorkspace);
+function hostedRuntimeServiceRunSettings(run: RuntimeRunSettings): RuntimeRunSettings {
+	return hostedRuntimeRunSettings(run);
 }
 
 function loadExistingState(paths: RuntimePaths): ExistingManifestState {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1398,12 +1398,14 @@ function applyHostedLocaleProjection(
 	runtime: string,
 	manifest: RuntimeManifest,
 	home: string,
-	workspaceRoot: string,
+	openClawWorkspaceRoot: string | null,
 ): string | null {
+	if (manifest.runtimes[runtime]?.enabled !== true) return null;
 	const locale = manifest.locale;
 	if (runtime === "openclaw") {
+		if (!openClawWorkspaceRoot) throw new Error("OpenClaw official agent workspace is unavailable");
 		return locale
-			? updateManagedLocaleFile(join(workspaceRoot, "SOUL.md"), managedLocaleBlock(locale))
+			? updateManagedLocaleFile(join(openClawWorkspaceRoot, "SOUL.md"), managedLocaleBlock(locale))
 			: null;
 	}
 	if (runtime === "hermes") {
@@ -3464,12 +3466,13 @@ function hostedBundledSkillTargetDir(
 	name: string,
 	skillName: string,
 	home: string,
-	workspaceRoot?: string,
+	openClawWorkspaceRoot?: string,
 ): string | null {
 	if (name !== "openclaw" && name !== "hermes") return null;
-	if (name === "openclaw" && workspaceRoot) return join(workspaceRoot, "skills", skillName);
-	const agentHome = name === "openclaw" ? join(home, ".openclaw") : join(home, ".hermes");
-	return agentSkillTargetDir(name, skillName, agentHome);
+	if (name === "openclaw") {
+		return openClawWorkspaceRoot ? join(openClawWorkspaceRoot, "skills", skillName) : null;
+	}
+	return agentSkillTargetDir(name, skillName, join(home, ".hermes"));
 }
 
 function managedSkillReservationDigest(targetDir: string, skillId: string): string {
@@ -3494,15 +3497,23 @@ function validateHostedSkillsPlan(
 	name: string,
 	manifest: RuntimeManifest,
 	home: string,
-	workspaceRoot: string,
+	openClawWorkspaceRoot: string | null,
 	preparedSourcedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
 ): void {
 	if (!hostedBundledSkillsEnabled()) return;
+	if (name === "openclaw" && !openClawWorkspaceRoot) {
+		if (manifest.runtimes.openclaw?.enabled === true) {
+			throw new Error("OpenClaw official agent workspace is unavailable");
+		}
+		return;
+	}
 	for (const [skillName, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
-		const targetDir =
-			"source" in desired && name === "openclaw"
-				? join(workspaceRoot, "skills", skillName)
-				: hostedBundledSkillTargetDir(name, skillName, home, workspaceRoot);
+		const targetDir = hostedBundledSkillTargetDir(
+			name,
+			skillName,
+			home,
+			openClawWorkspaceRoot ?? undefined,
+		);
 		const runtimeEnabled = manifest.runtimes[name]?.enabled === true;
 		if ("source" in desired) {
 			if (hostedBundledSkillIds().includes(skillName)) {
@@ -3582,7 +3593,7 @@ function recoverHostedSourcedSkillReservations(
 
 function recoverHostedOpenClawSourcedSkillReservations(
 	manifest: RuntimeManifest,
-	workspaceRoot: string,
+	openClawWorkspaceRoot: string,
 	prepared: ReadonlyMap<string, PreparedHostedSourcedSkill>,
 	driver: HostedOpenClawSkillDriver,
 ): void {
@@ -3594,14 +3605,14 @@ function recoverHostedOpenClawSourcedSkillReservations(
 			hostedBundledSkillIds().includes(skillId)
 		)
 			continue;
-		const targetDir = join(workspaceRoot, "skills", skillId);
+		const targetDir = join(openClawWorkspaceRoot, "skills", skillId);
 		if (!existsSync(targetDir) || managedSkillReservationOwner(targetDir, skillId) !== "unreserved")
 			continue;
 		const skill = prepared.get(skillId);
 		if (
 			!skill ||
 			JSON.stringify(skill.source) !== JSON.stringify(desired.source) ||
-			!driver.verifyOwned({ workspaceRoot, skill })
+			!driver.verifyOwned({ workspaceRoot: openClawWorkspaceRoot, skill })
 		)
 			continue;
 		reserveManagedSkill({
@@ -3618,15 +3629,25 @@ function applyHostedBundledSkills(
 	observation: RuntimeInstallObservation | undefined,
 	manifest: RuntimeManifest,
 	home: string,
-	workspaceRoot: string,
+	openClawWorkspaceRoot: string | null,
 	openClawDriver: HostedOpenClawSkillDriver,
 ): string[] {
 	// Reservation state is root-authoritative. Drop privilege only inside the
 	// callbacks that mutate runtime-user-owned Skill trees.
 	const installEnabled = hostedBundledSkillsEnabled();
+	if (name === "openclaw" && !openClawWorkspaceRoot) return [];
+	const requireOpenClawWorkspace = (): string => {
+		if (!openClawWorkspaceRoot) throw new Error("OpenClaw official agent workspace is unavailable");
+		return openClawWorkspaceRoot;
+	};
 	const targets: string[] = [];
 	for (const skillName of hostedBundledSkillIds()) {
-		const targetDir = hostedBundledSkillTargetDir(name, skillName, home, workspaceRoot);
+		const targetDir = hostedBundledSkillTargetDir(
+			name,
+			skillName,
+			home,
+			openClawWorkspaceRoot ?? undefined,
+		);
 		if (!targetDir) continue;
 		targets.push(targetDir);
 		const desired = manifest.projection?.skills?.entries[skillName];
@@ -3656,7 +3677,7 @@ function applyHostedBundledSkills(
 				removeTarget: () =>
 					name === "openclaw" && !legacyAdopted
 						? openClawDriver.cleanupManifestOwned({
-								workspaceRoot,
+								workspaceRoot: requireOpenClawWorkspace(),
 								skillId: skillName,
 								ownershipIdentity: `content-sha256\0${managedSkillReservationDigest(targetDir, skillName)}`,
 							})
@@ -3691,7 +3712,7 @@ function applyHostedBundledSkills(
 				name === "openclaw"
 					? openClawDriver.installDirectory({
 							home,
-							workspaceRoot,
+							workspaceRoot: requireOpenClawWorkspace(),
 							skillId: skillName,
 							sourceDir,
 							ownershipIdentity: `content-sha256\0${bundled.digest}`,
@@ -3784,11 +3805,11 @@ function applyHostedOpenClawSourcedSkills(
 	observation: RuntimeInstallObservation | undefined,
 	manifest: RuntimeManifest,
 	home: string,
-	workspaceRoot: string,
+	openClawWorkspaceRoot: string,
 	preparedSourcedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
 	driver: HostedOpenClawSkillDriver,
 ): string[] {
-	const skillsRoot = join(workspaceRoot, "skills");
+	const skillsRoot = join(openClawWorkspaceRoot, "skills");
 	const desiredEntries = manifest.projection?.skills?.entries ?? {};
 	const desiredIds = Object.entries(desiredEntries).flatMap(([id, desired]) =>
 		"source" in desired ? [id] : [],
@@ -3820,7 +3841,7 @@ function applyHostedOpenClawSourcedSkills(
 				manager: "hosted-manifest",
 				removeTarget: () =>
 					driver.cleanupManifestOwned({
-						workspaceRoot,
+						workspaceRoot: openClawWorkspaceRoot,
 						skillId,
 						ownershipIdentity: managedSkillReservationSourceIdentity(targetDir, skillId),
 					}),
@@ -3840,7 +3861,7 @@ function applyHostedOpenClawSourcedSkills(
 				manager: "hosted-manifest",
 				sourceIdentity: prepared.sourceIdentity,
 			},
-			() => driver.install({ home, workspaceRoot, skill: prepared }),
+			() => driver.install({ home, workspaceRoot: openClawWorkspaceRoot, skill: prepared }),
 		);
 	}
 	return ids.map((id) => join(skillsRoot, id));
@@ -4595,12 +4616,12 @@ function runtimeSecretValues(load: RuntimeManifestLoad): Record<string, string> 
 function validateRuntimeManifestPlan(
 	manifest: RuntimeManifest,
 	paths: RuntimePaths,
+	openClawWorkspaceRoot: string | null,
 	preparedSourcedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
 ): void {
-	const workspaceRoot = runtimeWorkspaceRoot(manifest, paths);
 	const home = hostedRuntimeProjectionHome(manifest, paths);
 	for (const name of HOSTED_RUNTIME_TARGETS) {
-		validateHostedSkillsPlan(name, manifest, home, workspaceRoot, preparedSourcedSkills);
+		validateHostedSkillsPlan(name, manifest, home, openClawWorkspaceRoot, preparedSourcedSkills);
 	}
 	for (const [name, runtime] of Object.entries(manifest.runtimes)) {
 		const runtimeName = runtimeNameSchema.parse(name);
@@ -4624,10 +4645,12 @@ function validateRuntimeManifestPlan(
 			);
 			if (runtime.enabled) mergeRuntimeServiceSecretEnv(name, service, settings, secretEnv);
 		}
-		if (!manifest.locale) continue;
+		if (!runtime.enabled || !manifest.locale) continue;
 		const block = managedLocaleBlock(manifest.locale);
 		if (runtimeName === "openclaw") {
-			nextManagedLocaleFileContent(join(workspaceRoot, "SOUL.md"), block);
+			if (!openClawWorkspaceRoot)
+				throw new Error("OpenClaw official agent workspace is unavailable");
+			nextManagedLocaleFileContent(join(openClawWorkspaceRoot, "SOUL.md"), block);
 		} else if (runtimeName === "hermes") {
 			nextManagedLocaleFileContent(join(home, ".hermes", "SOUL.md"), block);
 		}
@@ -4845,7 +4868,7 @@ function runtimeConvergenceWithoutApply(input: {
 function validateRuntimeProjectionPlan(input: {
 	manifest: RuntimeManifest;
 	paths: RuntimePaths;
-	workspaceRoot: string;
+	openClawWorkspaceRoot: string | null;
 	secretValues: Record<string, string> | undefined;
 	observations: Map<string, RuntimeInstallObservation>;
 	previousProjectedProviderIds: Record<string, string[]>;
@@ -4853,7 +4876,7 @@ function validateRuntimeProjectionPlan(input: {
 	const {
 		manifest,
 		paths,
-		workspaceRoot,
+		openClawWorkspaceRoot,
 		secretValues,
 		observations,
 		previousProjectedProviderIds,
@@ -4862,8 +4885,11 @@ function validateRuntimeProjectionPlan(input: {
 	const localeBlock = manifest.locale ? managedLocaleBlock(manifest.locale) : null;
 	if (localeBlock) {
 		for (const name of Object.keys(manifest.runtimes)) {
+			if (manifest.runtimes[name]?.enabled !== true) continue;
 			if (name === "openclaw") {
-				nextManagedLocaleFileContent(join(workspaceRoot, "SOUL.md"), localeBlock);
+				if (!openClawWorkspaceRoot)
+					throw new Error("OpenClaw official agent workspace is unavailable");
+				nextManagedLocaleFileContent(join(openClawWorkspaceRoot, "SOUL.md"), localeBlock);
 			}
 			if (name === "hermes") {
 				nextManagedLocaleFileContent(join(home, ".hermes", "SOUL.md"), localeBlock);
@@ -4962,13 +4988,15 @@ export function runtimeInstallerMutationTargets(
 	manifest: RuntimeManifest,
 	home: string,
 	observations: ReadonlyMap<string, Pick<RuntimeInstallObservation, "status">>,
+	options: { includeOAuthRefresh?: boolean } = {},
 ): string[] {
 	const targets = new Set<string>();
 	const openclawObservation = observations.get("openclaw");
 	if (
 		manifest.runtimes.openclaw?.enabled &&
 		manifest.runtimes.openclaw.install &&
-		(openclawObservation?.status !== "present" || hostedRuntimeOAuthDeclared(manifest, "openclaw"))
+		(openclawObservation?.status !== "present" ||
+			(options.includeOAuthRefresh !== false && hostedRuntimeOAuthDeclared(manifest, "openclaw")))
 	) {
 		targets.add(join(home, ".openclaw", "bin"));
 		targets.add(join(home, ".openclaw", "tools"));
@@ -4996,6 +5024,48 @@ export function runtimeInstallerMutationTargets(
 		}
 	}
 	return [...targets];
+}
+
+function runtimeColdInstallMutationPlan(
+	manifest: RuntimeManifest,
+	paths: RuntimePaths,
+	observations: ReadonlyMap<string, RuntimeInstallObservation>,
+): { snapshot: RuntimeManagedMutationPlan; runtimeUserOwnershipTargets: string[] } | null {
+	const pending = Object.entries(manifest.runtimes).some(([name, runtime]) => {
+		if (!runtime.enabled || !runtime.install) return false;
+		return observations.get(name)?.status !== "present";
+	});
+	if (!pending) return null;
+	const home = hostedRuntimeProjectionHome(manifest, paths);
+	const runtimeUserTargets = runtimeInstallerMutationTargets(manifest, home, observations, {
+		includeOAuthRefresh: false,
+	}).sort();
+	if (runtimeUserTargets.length === 0) return null;
+	const runtimeUserTrustedRoots = [paths.userHome, paths.clawdiHome];
+	const metadataTargets = [
+		...new Set([
+			paths.userHome,
+			paths.clawdiHome,
+			...mutationAncestorMetadataTargets(runtimeUserTargets, runtimeUserTrustedRoots),
+		]),
+	].sort();
+	const runtimeCommandTargets = Object.keys(manifest.runtimes).flatMap((name) => {
+		const command = runtimeCommandPath(name, home);
+		return command && runtimeUserTargets.includes(command) ? [command] : [];
+	});
+	return {
+		snapshot: {
+			rootTargets: [],
+			trustedRootDirectories: [],
+			runtimeUserTargets,
+			runtimeUserTrustedRoots,
+			runtimeUserSymlinkTargets: runtimeCommandTargets,
+			metadataTargets,
+		},
+		runtimeUserOwnershipTargets: [...new Set([...metadataTargets, ...runtimeUserTargets])].sort(
+			(left, right) => left.length - right.length || left.localeCompare(right),
+		),
+	};
 }
 
 function hostedChannelCredentialMutationTargets(manifest: RuntimeManifest, home: string): string[] {
@@ -5032,7 +5102,7 @@ function managedWhatsAppCompatibilityRuntime(
 export function runtimeUserMutationTargets(
 	manifest: RuntimeManifest,
 	paths: RuntimePaths,
-	workspaceRoot: string,
+	openClawWorkspaceRoot: string | null,
 	observations: ReadonlyMap<string, Pick<RuntimeInstallObservation, "status">>,
 ): string[] {
 	const home = hostedRuntimeProjectionHome(manifest, paths);
@@ -5055,13 +5125,13 @@ export function runtimeUserMutationTargets(
 		openClawDatabase,
 		`${openClawDatabase}-wal`,
 		`${openClawDatabase}-shm`,
-		join(workspaceRoot, "SOUL.md"),
 		join(hostedCodexHome(home), CODEX_MANAGED_PROVIDER_CONFIG_FILE),
 		legacyHermesModelProviderPluginDir(home),
 		...installerTargets,
 		...hostedChannelCredentialMutationTargets(manifest, home),
 		...channelPluginTargets,
 	]);
+	if (openClawWorkspaceRoot) targets.add(join(openClawWorkspaceRoot, "SOUL.md"));
 	if (
 		hostedCodexManagedProvider(manifest) ||
 		manifest.projection?.sourceSchemaVersion === "clawdi.hosted-runtime.manifest.v1"
@@ -5122,12 +5192,17 @@ export function runtimeUserMutationTargets(
 	}
 	for (const runtime of HOSTED_RUNTIME_TARGETS) {
 		for (const skillId of hostedBundledSkillIds()) {
-			const target = hostedBundledSkillTargetDir(runtime, skillId, home, workspaceRoot);
+			const target = hostedBundledSkillTargetDir(
+				runtime,
+				skillId,
+				home,
+				openClawWorkspaceRoot ?? undefined,
+			);
 			if (target) targets.add(target);
 		}
 	}
 	const hermesSkillsRoot = join(home, ".hermes", "skills");
-	const openClawSkillsRoot = join(workspaceRoot, "skills");
+	const openClawSkillsRoot = openClawWorkspaceRoot ? join(openClawWorkspaceRoot, "skills") : null;
 	let managesHermesSourcedSkill = false;
 	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
 		if (!("source" in desired)) continue;
@@ -5135,7 +5210,7 @@ export function runtimeUserMutationTargets(
 			managesHermesSourcedSkill = true;
 			targets.add(join(hermesSkillsRoot, skillId));
 		}
-		if (manifest.runtimes.openclaw?.enabled === true)
+		if (manifest.runtimes.openclaw?.enabled === true && openClawSkillsRoot)
 			targets.add(join(openClawSkillsRoot, skillId));
 	}
 	for (const reservation of managedSkillReservations("hosted-manifest")) {
@@ -5147,6 +5222,7 @@ export function runtimeUserMutationTargets(
 			targets.add(reservation.targetDir);
 		}
 		if (
+			openClawSkillsRoot &&
 			dirname(reservation.targetDir) === openClawSkillsRoot &&
 			!hostedBundledSkillIds().includes(reservation.id)
 		)
@@ -5186,7 +5262,7 @@ function mutationAncestorMetadataTargets(
 function runtimeManagedMutationPlan(input: {
 	manifest: RuntimeManifest;
 	paths: RuntimePaths;
-	workspaceRoot: string;
+	openClawWorkspaceRoot: string | null;
 	programs: RuntimeSystemdUserProgram[];
 	observations: ReadonlyMap<string, RuntimeInstallObservation>;
 }): {
@@ -5221,7 +5297,7 @@ function runtimeManagedMutationPlan(input: {
 			...runtimeUserMutationTargets(
 				input.manifest,
 				input.paths,
-				input.workspaceRoot,
+				input.openClawWorkspaceRoot,
 				input.observations,
 			),
 			...systemd.targets,
@@ -5391,32 +5467,11 @@ export function convergeRuntimeManifest(
 	const hermesSkillNativeReconciler =
 		opts.hostedHermesSkillExactSourceDriver ?? hostedHermesSkillExactSourceDriver;
 	const openClawSkillDriver = opts.hostedOpenClawSkillDriver ?? hostedOpenClawSkillDriver;
-	recoverHostedSourcedSkillReservations(
-		manifest,
-		projectionHome,
-		preparedHostedSourcedSkills,
-		hermesSkillNativeReconciler,
-	);
-	recoverHostedOpenClawSourcedSkillReservations(
-		manifest,
-		workspaceRoot,
-		preparedHostedSourcedSkills,
-		openClawSkillDriver,
-	);
-	validateRuntimeManifestPlan(manifest, paths, preparedHostedSourcedSkills);
 	for (const [name, runtime] of runtimeEntries) {
 		const observation = planRuntimeInstallObservation(name, runtime, projectionHome);
 		observations.set(name, observation);
 		if (observation.error) installErrors.push(observation.error);
 	}
-	validateRuntimeProjectionPlan({
-		manifest,
-		paths,
-		workspaceRoot,
-		secretValues,
-		observations,
-		previousProjectedProviderIds,
-	});
 	if (installErrors.length > 0) {
 		return runtimeConvergenceWithoutApply({
 			load,
@@ -5450,25 +5505,115 @@ export function convergeRuntimeManifest(
 			),
 		});
 	}
-	const plannedRuntimePrograms = planRuntimeSystemdUserPrograms({
-		manifest,
-		paths,
-		workspaceRoot,
-		generatedAt,
-		secretValues,
-		observations,
-		egressProfileBundlePath: plannedEgressProfileBundlePath,
-		egress: null,
-	});
-	validateRuntimeSystemdPlan(plannedRuntimePrograms);
-	const mutationPlan = runtimeManagedMutationPlan({
-		manifest,
-		paths,
-		workspaceRoot,
-		programs: plannedRuntimePrograms,
-		observations,
-	});
+
+	const coldInstallPlan = runtimeColdInstallMutationPlan(manifest, paths, observations);
+	const coldInstallSnapshot = coldInstallPlan
+		? captureRuntimeLiveSnapshot(coldInstallPlan.snapshot)
+		: null;
+	try {
+		if (coldInstallPlan) {
+			hostedRuntimeContract.assertPlatformRoots();
+			ensureRuntimeUserOwnershipBoundaries(coldInstallPlan.runtimeUserOwnershipTargets);
+		}
+		observations.clear();
+		for (const [name, runtime] of runtimeEntries) {
+			const observation = observeRuntimeInstall(name, runtime, projectionHome);
+			observations.set(name, observation);
+			if (observation.error) installErrors.push(observation.error);
+		}
+		if (installErrors.length > 0) throw new Error(installErrors.join("; "));
+	} catch (error) {
+		if (coldInstallSnapshot) {
+			try {
+				restoreRuntimeLiveSnapshot(coldInstallSnapshot);
+			} catch (rollbackError) {
+				installErrors.push(
+					`runtime installer rollback failed: ${
+						rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+					}`,
+				);
+			}
+		}
+		const message = error instanceof Error ? error.message : String(error);
+		if (installErrors.length === 0) installErrors.push(message);
+		return runtimeConvergenceWithoutApply({
+			load,
+			paths,
+			workspaceRoot,
+			enabledRuntimes,
+			installErrors,
+			projectedProviderIds: Object.fromEntries(
+				Object.entries(previousProjectedProviderIds).map(([runtime, providerIds]) => [
+					runtime,
+					[...providerIds],
+				]),
+			),
+		});
+	}
+
+	let openClawWorkspaceRoot: string | null;
+	let plannedRuntimePrograms: RuntimeSystemdUserProgram[];
+	let mutationPlan: ReturnType<typeof runtimeManagedMutationPlan>;
+	try {
+		const openClawCommand = runtimeCommandPath("openclaw", projectionHome);
+		const shouldResolveOpenClawWorkspace =
+			manifest.runtimes.openclaw?.enabled === true ||
+			Boolean(openClawCommand && executableExists(openClawCommand));
+		openClawWorkspaceRoot = shouldResolveOpenClawWorkspace
+			? openClawSkillDriver.resolveWorkspace({ home: projectionHome })
+			: null;
+		recoverHostedSourcedSkillReservations(
+			manifest,
+			projectionHome,
+			preparedHostedSourcedSkills,
+			hermesSkillNativeReconciler,
+		);
+		if (openClawWorkspaceRoot) {
+			recoverHostedOpenClawSourcedSkillReservations(
+				manifest,
+				openClawWorkspaceRoot,
+				preparedHostedSourcedSkills,
+				openClawSkillDriver,
+			);
+		}
+		validateRuntimeManifestPlan(
+			manifest,
+			paths,
+			openClawWorkspaceRoot,
+			preparedHostedSourcedSkills,
+		);
+		validateRuntimeProjectionPlan({
+			manifest,
+			paths,
+			openClawWorkspaceRoot,
+			secretValues,
+			observations,
+			previousProjectedProviderIds,
+		});
+		plannedRuntimePrograms = planRuntimeSystemdUserPrograms({
+			manifest,
+			paths,
+			workspaceRoot,
+			generatedAt,
+			secretValues,
+			observations,
+			egressProfileBundlePath: plannedEgressProfileBundlePath,
+			egress: null,
+		});
+		validateRuntimeSystemdPlan(plannedRuntimePrograms);
+		mutationPlan = runtimeManagedMutationPlan({
+			manifest,
+			paths,
+			openClawWorkspaceRoot,
+			programs: plannedRuntimePrograms,
+			observations,
+		});
+	} catch (error) {
+		if (coldInstallSnapshot) restoreRuntimeLiveSnapshot(coldInstallSnapshot);
+		throw error;
+	}
 	if (mutationPlan.systemdDriftErrors.length > 0) {
+		if (coldInstallSnapshot) restoreRuntimeLiveSnapshot(coldInstallSnapshot);
 		installErrors.push(...mutationPlan.systemdDriftErrors);
 		return runtimeConvergenceWithoutApply({
 			load,
@@ -5485,7 +5630,18 @@ export function convergeRuntimeManifest(
 		});
 	}
 	const workspaceExistedBeforeApply = existsSync(workspaceRoot);
-	const liveSnapshot = captureRuntimeLiveSnapshot(mutationPlan.snapshot);
+	let liveSnapshot: ReturnType<typeof captureRuntimeLiveSnapshot>;
+	try {
+		liveSnapshot = captureRuntimeLiveSnapshot(mutationPlan.snapshot);
+		if (coldInstallSnapshot) {
+			for (const [path, node] of coldInstallSnapshot.entries) {
+				liveSnapshot.entries.set(path, node);
+			}
+		}
+	} catch (error) {
+		if (coldInstallSnapshot) restoreRuntimeLiveSnapshot(coldInstallSnapshot);
+		throw error;
+	}
 	let systemdActivationApplied = false;
 	let restartDaemon = false;
 	let desiredDaemonAuthTokenRevision: string | undefined;
@@ -5518,13 +5674,6 @@ export function convergeRuntimeManifest(
 				fileBrowserInstall.receiptTarget,
 			);
 		}
-		observations.clear();
-		for (const [name, runtime] of runtimeEntries) {
-			const observation = observeRuntimeInstall(name, runtime, projectionHome);
-			observations.set(name, observation);
-			if (observation.error) installErrors.push(observation.error);
-		}
-		if (installErrors.length > 0) throw new Error(installErrors.join("; "));
 		const openClawObservation = observations.get("openclaw");
 		if (openClawObservation) {
 			try {
@@ -5546,6 +5695,13 @@ export function convergeRuntimeManifest(
 			}
 		}
 		if (installErrors.length > 0) throw new Error(installErrors.join("; "));
+		if (
+			openClawWorkspaceRoot &&
+			resolve(openClawSkillDriver.resolveWorkspace({ home: projectionHome })) !==
+				resolve(openClawWorkspaceRoot)
+		) {
+			throw new Error("OpenClaw official agent workspace changed during runtime reconciliation");
+		}
 
 		hostedRuntimeContract.assertPlatformRoots();
 		let codexCli: Record<string, string> | null = null;
@@ -5812,7 +5968,7 @@ export function convergeRuntimeManifest(
 		validateRuntimeProjectionPlan({
 			manifest,
 			paths,
-			workspaceRoot,
+			openClawWorkspaceRoot,
 			secretValues,
 			observations,
 			previousProjectedProviderIds,
@@ -5852,7 +6008,7 @@ export function convergeRuntimeManifest(
 					observations.get(name),
 					manifest,
 					projectionHome,
-					workspaceRoot,
+					openClawWorkspaceRoot,
 					openClawSkillDriver,
 				);
 			} catch (error) {
@@ -5878,19 +6034,21 @@ export function convergeRuntimeManifest(
 				}`,
 			);
 		}
-		try {
-			applyHostedOpenClawSourcedSkills(
-				observations.get("openclaw"),
-				manifest,
-				projectionHome,
-				workspaceRoot,
-				preparedHostedSourcedSkills,
-				openClawSkillDriver,
-			);
-		} catch (error) {
-			installErrors.push(
-				`runtime openclaw sourced Skill delivery failed: ${error instanceof Error ? error.message : String(error)}`,
-			);
+		if (openClawWorkspaceRoot) {
+			try {
+				applyHostedOpenClawSourcedSkills(
+					observations.get("openclaw"),
+					manifest,
+					projectionHome,
+					openClawWorkspaceRoot,
+					preparedHostedSourcedSkills,
+					openClawSkillDriver,
+				);
+			} catch (error) {
+				installErrors.push(
+					`runtime openclaw sourced Skill delivery failed: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
 		}
 		try {
 			applyHostedMcpProjections(manifest, paths, observations, workspaceRoot);
@@ -5984,7 +6142,7 @@ export function convergeRuntimeManifest(
 			}
 			try {
 				const localeFile = withRuntimeUserFileAccess(() =>
-					applyHostedLocaleProjection(name, manifest, projectionHome, workspaceRoot),
+					applyHostedLocaleProjection(name, manifest, projectionHome, openClawWorkspaceRoot),
 				);
 				if (localeFile) managedLocaleFiles.push(localeFile);
 			} catch (error) {

--- a/packages/cli/src/runtime/platform-root-modes.test.ts
+++ b/packages/cli/src/runtime/platform-root-modes.test.ts
@@ -45,7 +45,11 @@ test("never chmods the four platform roots that child writes touch", async () =>
 	writeFileSync(
 		openclaw,
 		`#!/bin/sh
-[ "\${1:-}" != "--version" ] || printf '%s\\n' '2026.7.1'
+if [ "$*" = "agents list --json" ]; then
+  printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace"
+elif [ "\${1:-}" = "--version" ]; then
+  printf '%s\\n' '2026.7.1'
+fi
 exit 0
 `,
 	);

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -494,7 +494,9 @@ describe("hosted runtime bundle v2", () => {
 			[
 				"#!/usr/bin/env bash",
 				"set -euo pipefail",
-				'if [[ "$1 $2 $3" == "config patch --stdin" ]]; then',
+				'if [[ "$1 $2 $3" == "agents list --json" ]]; then',
+				'  printf \'[{"id":"main","workspace":"%s"}]\\n\' "$HOME/.openclaw/workspace"',
+				'elif [[ "$1 $2 $3" == "config patch --stdin" ]]; then',
 				"  payload=$(cat)",
 				`  if [[ "$payload" == *'"channels"'* && "$payload" == *'"telegram"'* ]]; then`,
 				`    printf '%s\\n' "$payload" > '${channelPatchPath}'`,
@@ -1199,7 +1201,17 @@ describe("hosted runtime bundle v2", () => {
 		chmodSync(goldenMitmdump, 0o755);
 		const openclawBin = join(paths.userHome, ".openclaw", "bin", "openclaw");
 		mkdirSync(dirname(openclawBin), { recursive: true });
-		writeFileSync(openclawBin, "#!/usr/bin/env sh\ncat >/dev/null || true\nexit 0\n");
+		writeFileSync(
+			openclawBin,
+			`#!/usr/bin/env sh
+if [ "$*" = "agents list --json" ]; then
+  printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace"
+  exit 0
+fi
+cat >/dev/null || true
+exit 0
+`,
+		);
 		chmodSync(openclawBin, 0o700);
 
 		let networkAvailable = true;

--- a/packages/cli/tests/egress-handoff-access-contract.test.ts
+++ b/packages/cli/tests/egress-handoff-access-contract.test.ts
@@ -177,8 +177,10 @@ function convergeHostedEgressFixture(): { paths: RuntimePaths; root: string } {
 	writeFileSync(
 		join(home, ".openclaw", "bin", "openclaw"),
 		`#!/bin/sh
-[ "\${1:-}" != "--version" ] || printf '%s\\n' '2026.7.1'
-exit 0
+case "$*" in
+  "--version") printf '%s\\n' '2026.7.1' ;;
+  "agents list --json") printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace" ;;
+esac
 `,
 	);
 	chmodSync(join(home, ".openclaw", "bin", "openclaw"), 0o755);

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -51,13 +51,13 @@ import {
 	rollbackPendingRuntimeCliUpgrade,
 } from "../src/runtime/cli-update";
 import { withRuntimeConvergeLock } from "../src/runtime/converge-lock";
-import { MANAGED_EGRESS_PLACEHOLDER_VALUE } from "../src/runtime/egress-env";
 import {
 	deniedCommandReason,
 	evaluateHostPolicyForCommand,
 	readHostPolicy,
 } from "../src/runtime/host-policy";
 import { hostedManifestEgressProfiles } from "../src/runtime/hosted-egress-profiles";
+import { hostedOpenClawSkillDriver } from "../src/runtime/hosted-openclaw-skill";
 import { hostedAiProviderCatalog } from "../src/runtime/hosted-provider-resolution";
 import { releaseManagedSkill, reserveManagedSkill } from "../src/runtime/managed-skill-reservation";
 import {
@@ -230,6 +230,10 @@ function convergeRuntimeManifest(
 		paths,
 		{
 			...opts,
+			hostedOpenClawSkillDriver: opts?.hostedOpenClawSkillDriver ?? {
+				...hostedOpenClawSkillDriver,
+				resolveWorkspace: () => join(paths.userHome, ".openclaw", "workspace"),
+			},
 			hostedRuntimeContract: opts?.hostedRuntimeContract ?? testHostedRuntimeContract(paths),
 		},
 	);
@@ -1065,12 +1069,17 @@ function cachedHostedCliDesiredState(home: string, packageSpec: string): Runtime
 function seedOpenClawBinary(home: string): void {
 	const openclawBin = join(home, ".openclaw", "bin", "openclaw");
 	const unitPath = join(home, ".config", "systemd", "user", "openclaw-gateway.service");
+	const workspace = join(home, ".openclaw", "workspace");
 	mkdirSync(dirname(openclawBin), { recursive: true });
 	writeFileSync(
 		openclawBin,
 		`#!/bin/sh
 if [ "\${1:-}" = "--version" ]; then
   printf 'openclaw test-version\n'
+  exit 0
+fi
+if [ "$*" = "agents list --json" ]; then
+  printf '[{"id":"main","workspace":"${workspace}"}]\n'
   exit 0
 fi
 if [ "$*" = "gateway install --force --json" ]; then
@@ -1134,6 +1143,7 @@ function openClawWhatsAppPluginInspectFixture(pluginSource: string): Record<stri
 function seedOfficialOpenClawServiceInstaller(home: string): void {
 	const openclawBin = join(home, ".openclaw", "bin", "openclaw");
 	const unitPath = join(home, ".config", "systemd", "user", "openclaw-gateway.service");
+	const workspace = join(home, ".openclaw", "workspace");
 	mkdirSync(dirname(openclawBin), { recursive: true });
 	writeFileSync(
 		openclawBin,
@@ -1141,6 +1151,10 @@ function seedOfficialOpenClawServiceInstaller(home: string): void {
 set -euo pipefail
 if [ "\${1:-}" = "--version" ]; then
   printf 'openclaw test-version\\n'
+  exit 0
+fi
+if [ "$*" = "agents list --json" ]; then
+  printf '[{"id":"main","workspace":"${workspace}"}]\\n'
   exit 0
 fi
 if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
@@ -1597,6 +1611,7 @@ function writeFakeOpenClawMcpBinary(
 ): { commandPath: string; configPath: string } {
 	const commandPath = join(home, ".openclaw", "bin", "openclaw");
 	const configPath = join(home, ".openclaw", "openclaw.json");
+	const workspace = join(home, ".openclaw", "workspace");
 	const logSet = options.callsPath
 		? `printf 'set %s\\n' "\${3:?missing server name}" >> '${options.callsPath}'`
 		: ":";
@@ -1618,7 +1633,7 @@ function writeFakeOpenClawMcpBinary(
 		`#!/usr/bin/env bash
 set -euo pipefail
 if [ "$*" = "agents list --json" ]; then
-  printf '[{"id":"main","workspace":"${home}/workspace"}]\n'
+  printf '[{"id":"main","workspace":"${workspace}"}]\n'
   exit 0
 fi
 if [ "\${1:-} \${2:-}" = "skills install" ]; then
@@ -1627,9 +1642,9 @@ if [ "\${1:-} \${2:-}" = "skills install" ]; then
     if [ "$1" = "--as" ]; then slug="\${2:?missing slug}"; shift; fi
     shift
   done
-  rm -rf "${home}/workspace/skills/$slug"
-  mkdir -p "${home}/workspace/skills/$slug"
-  cp -R "$source/." "${home}/workspace/skills/$slug/"
+  rm -rf "${workspace}/skills/$slug"
+  mkdir -p "${workspace}/skills/$slug"
+  cp -R "$source/." "${workspace}/skills/$slug/"
   exit 0
 fi
 if [ "\${1:-}" = "mcp" ] && [ "\${2:-}" = "set" ]; then
@@ -2873,7 +2888,7 @@ describe("runtime manifest datasource", () => {
 			expect(loaded.source).toBe("remote-datasource");
 			expect(loaded.sourcePath).toBe("https://runtime.test/v1/runtime/manifest");
 			expect(loaded.manifest.schemaVersion).toBe("clawdi.runtimeDesiredState.v1");
-			expect(loaded.manifest.workspaceRoot).toBe(home);
+			expect(loaded.manifest.workspaceRoot).toBeUndefined();
 			expect(loaded.manifest.environmentId).toBe("env_test");
 			expect(loaded.manifest.controlPlane.apiUrl).toBe("https://cloud-api.test");
 			expect(loaded.manifest.clawdiCli?.source).toBe("npm:clawdi");
@@ -7081,6 +7096,10 @@ if [ "\${1:-}" = "--version" ]; then
   printf 'openclaw test-version\\n'
   exit 0
 fi
+if [ "$*" = "agents list --json" ]; then
+  printf '[{"id":"main","workspace":"${join(home, ".openclaw", "workspace")}"}]\\n'
+  exit 0
+fi
 if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
   cat >> '${openclawPatch}'
   printf '\\n' >> '${openclawPatch}'
@@ -8984,6 +9003,8 @@ set -euo pipefail
 printf '%s\n' "$*" >> '${installerLog}'
 if [ "$*" = "--version" ]; then
   printf '%s\n' '${runtime}-test-version'
+elif [ "$*" = "agents list --json" ]; then
+  printf '[{"id":"main","workspace":"${join(home, ".openclaw", "workspace")}"}]\n'
 elif [ "$*" = "${installArgs}" ]; then
   printf '%s\n' 'official ${runtime} installer' >> '${systemctlLog}'
   test -r '${paths.egressSystemCaFile}'
@@ -11915,6 +11936,10 @@ if [ "\${1:-}" = "--version" ]; then
   printf 'openclaw test-version\\n'
   exit 0
 fi
+if [ "$*" = "agents list --json" ]; then
+  printf '[{"id":"main","workspace":"${join(home, ".openclaw", "workspace")}"}]\\n'
+  exit 0
+fi
 if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
   printf '%s\n' "$*" >> '${openclawPatchArgs}'
   cat >> '${openclawPatch}'
@@ -13932,7 +13957,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		).toThrow("no bundled hosted skill clawdi version 2 is registered");
 		expect(existsSync(ledgerPath)).toBe(false);
 
-		const openclawSkill = join(home, "workspace", "skills", "clawdi");
+		const openclawSkill = join(home, ".openclaw", "workspace", "skills", "clawdi");
 		mkdirSync(openclawSkill, { recursive: true });
 		writeFileSync(join(openclawSkill, "SKILL.md"), "local setup skill\n");
 		reserveManagedSkill({
@@ -13966,9 +13991,9 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 			schemaVersion: "clawdi.hostedManagedMcpServers.v2",
 			runtimes: { openclaw: ["clawdi", "search-proxy"] },
 		});
-		expect(existsSync(join(workspace, "skills", ".clawdi-manifest-receipts", "clawdi.json"))).toBe(
-			true,
-		);
+		expect(
+			existsSync(join(dirname(openclawSkill), ".clawdi-manifest-receipts", "clawdi.json")),
+		).toBe(true);
 
 		const updated = convergeRuntimeManifest(load(2, "openclaw", updatedServers), getRuntimePaths());
 		expect(updated.installErrors).toEqual([]);
@@ -15047,9 +15072,10 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const workspace = join(home, "clawdi");
-		const soulPath = join(workspace, "SOUL.md");
+		const soulPath = join(home, ".openclaw", "workspace", "SOUL.md");
 		const userPath = join(workspace, "USER.md");
 		mkdirSync(workspace, { recursive: true });
+		mkdirSync(dirname(soulPath), { recursive: true });
 		writeFileSync(soulPath, "User preface.\n\nUser epilogue.\n");
 		writeFileSync(userPath, "User profile stays untouched.\n");
 		process.env.HOME = home;


### PR DESCRIPTION
## Summary

- stop projecting a hosted `workspaceRoot` or implicit runtime `cwd`; derive the host process cwd from the runtime HOME only at launch
- resolve the OpenClaw `main` workspace exclusively through `openclaw agents list --json`, while Hermes keeps its upstream `~/.hermes` layout
- make first-time official runtime installation a two-stage transaction so the installed CLI can provide its official workspace before the remaining mutation plan is captured
- publish `clawdi@0.13.48`

## Design

Agent-native configuration contains no hosted HOME or workspace override. `/home/clawdi` remains only the tenant Linux HOME, persistence mount, Terminal/Files root, and systemd working directory. Incus and systemd continue to receive absolute paths because neither expands shell `~` or `$HOME` syntax.

No retry, sleep, guessed OpenClaw workspace, `OPENCLAW_WORKSPACE*`, or compatibility fallback is introduced.

## Verification

- `bash scripts/test.sh cli`: 1645 passed, 4 native-artifact tests skipped, 0 failed
- focused manifest/runtime bundle tests: 214 passed, 0 failed
- egress handoff contract: 2 passed, 0 failed
- CLI publish/version contract: 7 passed, 0 failed
- TypeScript typecheck: passed in the clean Docker runner
- Biome check on every changed TS/JSON file: passed
- `git diff --check`: passed

## Release impact

Merging changes `packages/cli/package.json` to `0.13.48`, triggering the protected immutable CLI publish workflow. Hosted must remain pinned to its existing exact CLI version until `clawdi@0.13.48` and its registry identity are verified, then update the tenant image exact pin in a separate reviewed Hosted PR.
