### PR TITLE
fix(runtime): install OpenClaw skill before default workspace exists

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.48",
+      "version": "0.13.49",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.48",
+	"version": "0.13.49",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
@@ -19,15 +19,15 @@ afterEach(() => {
 	root = "";
 });
 
-test("uses official OpenClaw install and guards manifest cleanup with a content fingerprint", async () => {
+test("runs official install from home before its first workspace exists and guards cleanup", async () => {
 	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-driver-"));
 	const home = join(root, "home");
 	const workspaceRoot = join(home, "agent-workspace");
 	const command = join(home, ".local", "bin", "openclaw");
 	const installLog = join(root, "install.log");
+	const installCwdLog = join(root, "install-cwd.log");
 	const workspaceDriftMarker = join(root, "workspace-drift");
 	mkdirSync(dirname(command), { recursive: true });
-	mkdirSync(workspaceRoot, { recursive: true });
 	writeFileSync(
 		command,
 		`#!/bin/sh
@@ -42,6 +42,7 @@ if test "$1 $2 $3" = "agents list --json"; then
 fi
 test "$1 $2" = "skills install"
 printf '%s\n' "$*" >> '${installLog}'
+printf '%s\n' "$PWD" >> '${installCwdLog}'
 source_dir="$3"
 shift 3
 test "$1" = "--agent"
@@ -78,7 +79,12 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 		tarBytes: readFileSync(archive),
 	};
 
+	expect(existsSync(workspaceRoot)).toBe(false);
 	expect(hostedOpenClawSkillDriver.install({ home, workspaceRoot, skill })).toBe("installed");
+	expect(readFileSync(installCwdLog, "utf8")).toBe(`${home}\n`);
+	expect(readFileSync(installLog, "utf8")).toMatch(
+		/^skills install .* --agent main --as review-pr --force\n$/,
+	);
 	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, skill })).toBe(true);
 	const target = join(workspaceRoot, "skills", "review-pr");
 	const receipt = join(workspaceRoot, "skills", ".clawdi-manifest-receipts", "review-pr.json");
@@ -97,7 +103,7 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 			sourceDir,
 			ownershipIdentity: `${skill.sourceIdentity}-v2`,
 		}),
-	).toThrow("official Skill install failed");
+	).toThrow("official Skill install failed: exit code 45 without output");
 	expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("# Review PR\n");
 	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, skill })).toBe(true);
 	delete process.env.FAKE_OPENCLAW_FAIL_AFTER_WRITE;
@@ -181,4 +187,44 @@ exit 0
 	).toThrow("changed during Skill reconciliation");
 	expect(existsSync(installMarker)).toBe(false);
 	expect(existsSync(join(workspaceRoot, "skills", "review-pr"))).toBe(false);
+});
+
+test("reports a spawn error when the official install process cannot start", () => {
+	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-spawn-error-"));
+	const home = join(root, "home");
+	const workspaceRoot = join(home, "agent-workspace");
+	const command = join(home, ".local", "bin", "openclaw");
+	mkdirSync(dirname(command), { recursive: true });
+	writeFileSync(
+		command,
+		`#!/bin/sh
+if test "$1 $2 $3" = "agents list --json"; then
+  printf '[{"id":"main","workspace":"${workspaceRoot}"}]\n'
+  printf '%s\n' '#!/definitely/missing/openclaw-interpreter' > "$0"
+  exit 0
+fi
+exit 64
+`,
+	);
+	chmodSync(command, 0o755);
+	const sourceDir = join(root, "source", "review-pr");
+	mkdirSync(sourceDir, { recursive: true });
+	writeFileSync(join(sourceDir, "SKILL.md"), "# Review PR\n");
+	let message = "";
+	try {
+		hostedOpenClawSkillDriver.installDirectory({
+			home,
+			workspaceRoot,
+			skillId: "review-pr",
+			sourceDir,
+			ownershipIdentity:
+				"github\0review-pr\0https://github.com/Clawdi-AI/store\0skills/review-pr\0" +
+				"a".repeat(40),
+		});
+	} catch (error) {
+		message = error instanceof Error ? error.message : String(error);
+	}
+	expect(message).toContain("OpenClaw official Skill install failed: spawn error:");
+	expect(message).toContain("ENOENT");
+	expect(message).not.toContain("undefined");
 });

--- a/packages/cli/src/runtime/hosted-openclaw-skill.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.ts
@@ -104,6 +104,22 @@ function nativeResultMatches(sourceDir: string, target: string): boolean {
 	);
 }
 
+function commandFailureDetail(result: ReturnType<typeof spawnRuntimeUserCommand>): string {
+	const details: string[] = [];
+	if (result.error) details.push(`spawn error: ${result.error.message}`);
+	if (result.signal) details.push(`terminated by signal ${result.signal}`);
+	for (const output of [result.stderr, result.stdout]) {
+		if (typeof output === "string" && output.trim()) {
+			details.push(output.trim());
+			break;
+		}
+	}
+	if (details.length === 0 && typeof result.status === "number") {
+		details.push(`exit code ${result.status} without output`);
+	}
+	return details.join("; ") || "process failed without details";
+}
+
 export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 	resolveWorkspace(input) {
 		return resolveOfficialWorkspace(input.home);
@@ -122,6 +138,7 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 			target,
 			receipt: receipt.path,
 			operation: () => {
+				// The roster may reference a workspace OpenClaw has not created yet on first run.
 				const result = spawnRuntimeUserCommand(
 					commandPath(input.home),
 					[
@@ -135,12 +152,12 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 						"--force",
 					],
 					input.home,
-					input.workspaceRoot,
+					input.home,
 					{ timeoutMs: 120_000, maxBufferBytes: 1024 * 1024 },
 				);
 				if (result.status !== 0)
 					throw new Error(
-						`OpenClaw official Skill install failed: ${String(result.stderr || result.stdout).trim() || "unknown error"}`,
+						`OpenClaw official Skill install failed: ${commandFailureDetail(result)}`,
 					);
 				if (!nativeResultMatches(input.sourceDir, target))
 					throw new Error(


### PR DESCRIPTION
## Summary

- launch the official OpenClaw Skill installer from the existing runtime HOME while retaining `--agent main`, so OpenClaw remains the authority that creates its first default workspace
- preserve spawn errors, signals, and output instead of collapsing process-start failures to `undefined`
- publish the correction as immutable CLI patch `0.13.49`

## Root cause

`openclaw@2026.7.1-2 agents list --json` reports the official default workspace before creating that directory. Clawdi 0.13.48 used the reported path as `spawnSync.cwd`, so the first Skill install failed in Node with `ENOENT` before OpenClaw received its supported `skills install <dir> --agent main --as <id> --force` command.

The upstream package source at commit `0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c` confirms both behaviors: agent scope resolution computes the default path, while the Skill CLI owns local-directory installation.

## Verification

- `bun test --isolate --max-concurrency=1 packages/cli/src/runtime/hosted-openclaw-skill.test.ts packages/cli/src/runtime/manifest-reconciliation.test.ts` (174 pass)
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd packages/cli build`
- `bun run --cwd packages/cli check:publish-manifest`
- `git diff --check origin/main..HEAD`
- isolated execution of published `openclaw@2026.7.1-2` confirmed the official command and first-run workspace behavior
