### PR TITLE
fix(cli): stage bundled OpenClaw skills for runtime user

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.49",
+      "version": "0.13.50",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.49",
+	"version": "0.13.50",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/hosted-bundled-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.test.ts
@@ -13,12 +13,13 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import {
 	adoptableLegacyHostedBundledSkill,
 	loadHostedBundledSkill,
 	reconcileHostedBundledSkill,
 	resolveHostedBundledSkill,
+	withStagedHostedBundledSkill,
 } from "./hosted-bundled-skill";
 import {
 	installReservedManagedSkill,
@@ -244,6 +245,41 @@ describe("hosted bundled skill reconciliation", () => {
 		expect(readFileSync(join(targetDir, "SKILL.md"))).toEqual(
 			readFileSync(join(bundledSourceDir, "SKILL.md")),
 		);
+	});
+
+	it("stages exact captured bytes with canonical readable modes and always cleans up", () => {
+		const protectedRoot = join(root, "root-private");
+		const copiedSource = join(protectedRoot, "clawdi");
+		mkdirSync(protectedRoot, { mode: 0o700 });
+		cpSync(bundledSourceDir, copiedSource, { recursive: true });
+		chmodSync(protectedRoot, 0o700);
+		const expectedSkill = readFileSync(join(copiedSource, "SKILL.md"));
+		const bundle = loadHostedBundledSkill("clawdi", 1, copiedSource);
+		rmSync(copiedSource, { recursive: true });
+
+		let successfulStagingRoot = "";
+		expect(
+			withStagedHostedBundledSkill(bundle, (sourceDir) => {
+				successfulStagingRoot = dirname(sourceDir);
+				expect(sourceDir).not.toBe(copiedSource);
+				expect(statSync(successfulStagingRoot).mode & 0o777).toBe(0o755);
+				expect(statSync(sourceDir).mode & 0o777).toBe(0o755);
+				expect(statSync(join(sourceDir, "SKILL.md")).mode & 0o777).toBe(0o644);
+				expect(readFileSync(join(sourceDir, "SKILL.md"))).toEqual(expectedSkill);
+				return "installed";
+			}),
+		).toBe("installed");
+		expect(existsSync(successfulStagingRoot)).toBe(false);
+
+		let failedStagingRoot = "";
+		expect(() =>
+			withStagedHostedBundledSkill(bundle, (sourceDir) => {
+				failedStagingRoot = dirname(sourceDir);
+				throw new Error("official installer failed");
+			}),
+		).toThrow("official installer failed");
+		expect(existsSync(failedStagingRoot)).toBe(false);
+		expect(statSync(protectedRoot).mode & 0o777).toBe(0o700);
 	});
 
 	it("fails closed for unknown ids, unknown versions, and unmanaged targets", () => {

--- a/packages/cli/src/runtime/hosted-bundled-skill.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.ts
@@ -10,6 +10,7 @@ import {
 	rmSync,
 	writeFileSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import {
 	canonicalManagedBundleFileMode,
@@ -313,6 +314,26 @@ function materializeHostedBundledSkill(bundle: HostedBundledSkillBundle, targetD
 		const path = join(targetDir, file.relativePath);
 		mkdirSync(dirname(path), { recursive: true, mode: HOSTED_BUNDLED_SKILL_DIRECTORY_MODE });
 		writeFileSync(path, Buffer.from(file.contentBase64, "base64"), { mode: file.mode });
+	}
+}
+
+export function withStagedHostedBundledSkill<T>(
+	bundle: HostedBundledSkillBundle,
+	operation: (sourceDir: string) => T,
+): T {
+	const stagingRoot = mkdtempSync(join(tmpdir(), "clawdi-hosted-bundled-skill-"));
+	const sourceDir = join(stagingRoot, bundle.catalogEntry.id);
+	try {
+		materializeHostedBundledSkill(bundle, sourceDir);
+		normalizeHostedBundledSkillModes(stagingRoot);
+		if (hostedBundledSkillDigest(sourceDir, false, true) !== bundle.catalogEntry.digest) {
+			throw new Error(
+				`bundled hosted skill catalog digest mismatch for ${bundle.catalogEntry.id} version ${bundle.catalogEntry.version}`,
+			);
+		}
+		return operation(sourceDir);
+	} finally {
+		rmSync(stagingRoot, { recursive: true, force: true });
 	}
 }
 

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -534,6 +534,7 @@ function writeFakeGatewayCli(input: {
 	unitPath: string;
 	configPatchPath?: string;
 	failInstall?: boolean;
+	skillInstallSourceLog?: string;
 }): void {
 	mkdirSync(dirname(input.path), { recursive: true });
 	writeFileSync(
@@ -571,6 +572,7 @@ EOF
 	  "skills install "*)
 	    source_dir="$3"
 	    skill_id="$7"
+	    ${input.skillInstallSourceLog ? `printf '%s\\n' "$source_dir" > '${input.skillInstallSourceLog}'` : ""}
 	    workspace="$HOME/.openclaw/workspace"
 	    mkdir -p "$workspace/skills"
 	    rm -rf "$workspace/skills/$skill_id"
@@ -3841,6 +3843,57 @@ echo spawned > '${installerLog}'
 		expect(existsSync(skillDir)).toBe(false);
 		expect(readFileSync(join(userOwnedSibling, "SKILL.md"), "utf8")).toBe("keep me\n");
 		expect(shouldIgnoreUserSkill(userOwnedSibling, "user-owned")).toBe(false);
+	});
+
+	test("installs a bundled OpenClaw Skill from cleaned runtime-readable staging", () => {
+		const paths = tempRuntimePaths();
+		const command = join(paths.userHome, ".local", "bin", "openclaw");
+		const unitPath = join(paths.systemdUserRoot, "openclaw-gateway.service");
+		const sourceLog = join(dirname(paths.serviceStateRoot), "openclaw-skill-source.log");
+		writeFakeGatewayCli({
+			path: command,
+			runtime: "openclaw",
+			unitPath,
+			skillInstallSourceLog: sourceLog,
+		});
+		const manifest = baseManifest(
+			paths,
+			{ openclaw: { enabled: true, run: runSettings(command, ["gateway"]), services: {} } },
+			{ projection: { skills: { entries: { clawdi: { enabled: true, version: 1 } } } } },
+		);
+		const target = join(paths.userHome, ".openclaw", "workspace", "skills", "clawdi");
+		const packageSource = resolve(
+			import.meta.dir,
+			"../..",
+			"skills",
+			"hosted-versions",
+			"1",
+			"clawdi",
+		);
+
+		const result = convergeRuntimeManifest(manifestLoad(manifest, "bundled-openclaw-skill"), paths);
+
+		expect(result.installErrors).toEqual([]);
+		const stagedSource = readFileSync(sourceLog, "utf8").trim();
+		expect(stagedSource).not.toBe(packageSource);
+		expect(stagedSource.startsWith(join(tmpdir(), "clawdi-hosted-bundled-skill-"))).toBe(true);
+		expect(existsSync(stagedSource)).toBe(false);
+		expect(readFileSync(join(target, "SKILL.md"))).toEqual(
+			readFileSync(join(packageSource, "SKILL.md")),
+		);
+		expect(
+			existsSync(
+				join(
+					paths.userHome,
+					".openclaw",
+					"workspace",
+					"skills",
+					".clawdi-manifest-receipts",
+					"clawdi.json",
+				),
+			),
+		).toBe(true);
+		expect(shouldIgnoreUserSkill(target, "clawdi")).toBe(true);
 	});
 
 	test("removes only strictly identified legacy bundled OpenClaw Skills without requiring a new receipt", () => {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -88,6 +88,7 @@ import {
 	loadHostedBundledSkill,
 	reconcileHostedBundledSkill,
 	resolveHostedBundledSkill,
+	withStagedHostedBundledSkill,
 } from "./hosted-bundled-skill";
 import { managedMcpHeaderPlaceholder, normalizeSecretRef } from "./hosted-egress-profiles";
 import {
@@ -3710,13 +3711,15 @@ function applyHostedBundledSkills(
 			},
 			() =>
 				name === "openclaw"
-					? openClawDriver.installDirectory({
-							home,
-							workspaceRoot: requireOpenClawWorkspace(),
-							skillId: skillName,
-							sourceDir,
-							ownershipIdentity: `content-sha256\0${bundled.digest}`,
-						})
+					? withStagedHostedBundledSkill(bundle, (stagedSourceDir) =>
+							openClawDriver.installDirectory({
+								home,
+								workspaceRoot: requireOpenClawWorkspace(),
+								skillId: skillName,
+								sourceDir: stagedSourceDir,
+								ownershipIdentity: `content-sha256\0${bundled.digest}`,
+							}),
+						)
 					: withRuntimeUserFileAccess(() =>
 							reconcileHostedBundledSkill({ bundle, targetDir, reserved: true }),
 						),


### PR DESCRIPTION
## Summary

- capture and verify bundled hosted Skill bytes before dropping privileges
- materialize exact catalog bytes into a canonical runtime-readable temporary tree for the official OpenClaw installer
- clean staging on success and failure without changing Hermes, workspace defaults, or ownership receipts
- bump the CLI package and workspace lock identity to `0.13.50`

## Release Impact

This PR is the release identity for `clawdi@0.13.50`, which remains unpublished. The release fixes Hosted OpenClaw bootstrap when the packed CLI is installed under a root-private umask-077 npm tree and the official Skill installer runs as UID/GID 10001.

## Verification

- `bun run --cwd packages/cli check:publish-manifest`
- `bun test packages/cli/tests/cli-publish-workflow.test.ts` (6 pass)
- `bun test --max-concurrency=1 packages/cli/src/runtime/hosted-bundled-skill.test.ts packages/cli/src/runtime/hosted-openclaw-skill.test.ts packages/cli/src/runtime/manifest-reconciliation.test.ts` (188 pass)
- `bun run --cwd packages/cli typecheck`
- `bunx biome check` on the changed runtime and package manifest files
- fixed local tarball passed the Hosted paired release and real systemd image smoke

## Regression Evidence

The paired Hosted gate fails with published `clawdi@0.13.49` because the dropped OpenClaw installer receives the root-private maintained npm source. The same gate passes with the fixed local tarball and verifies UID/GID 10001, canonical staged modes, exact Skill bytes, staging cleanup, and unchanged root-only npm ownership.
