### PR TITLE
fix(cli): make runtime activation rollback transactional

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.50",
+      "version": "0.13.51",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.50",
+	"version": "0.13.51",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1635,6 +1635,21 @@ export function applySystemdRuntimeUpdate(
 	};
 }
 
+export function quiesceSystemdRuntimeCandidate(
+	paths: ReturnType<typeof getRuntimePaths>,
+	candidate: SystemdUnitSnapshot,
+): void {
+	if (!shouldApplySystemdRuntimeUpdate(paths)) return;
+	const userUnits = [...candidate.user.keys()]
+		.filter((unit) => unit !== RUNTIME_WATCH_SYSTEM_UNIT)
+		.sort();
+	if (userUnits.length > 0) runtimeUserSystemctl(paths, ["stop", ...userUnits]);
+	const systemUnits = [...candidate.system.keys()]
+		.filter((unit) => unit !== RUNTIME_WATCH_SYSTEM_UNIT)
+		.sort();
+	if (systemUnits.length > 0) systemctl(["stop", ...systemUnits]);
+}
+
 function systemdUnitManagerState(
 	paths: ReturnType<typeof getRuntimePaths>,
 	scope: "system" | "user",
@@ -2636,6 +2651,9 @@ async function applyRuntimeDesiredState(
 						`systemd apply failed: ${error instanceof Error ? error.message : String(error)}`,
 					);
 				}
+			},
+			quiesce: () => {
+				quiesceSystemdRuntimeCandidate(paths, readSystemdUnitSnapshot(paths));
 			},
 			rollback: ({
 				restartDaemon,

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -680,9 +680,15 @@ function fileBrowserManifestLoad(manifest: RuntimeManifest): RuntimeManifestLoad
 }
 
 function fileBrowserApplyHooks(
-	input: { activationApplied?: boolean; onActivate?: () => void; onRollback?: () => void } = {},
+	input: {
+		activationApplied?: boolean;
+		onActivate?: () => void;
+		onQuiesce?: () => void;
+		onRollback?: () => void;
+	} = {},
 ) {
 	return {
+		quiesce: () => input.onQuiesce?.(),
 		activateEgressPrerequisite: successfulPrerequisiteActivation,
 		activate: () => {
 			input.onActivate?.();
@@ -2576,6 +2582,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			},
 			egressEngineEnsureOptions: { downloadCommand: curl.commandPath },
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: successfulPrerequisiteActivation,
 				rollback: () => {},
@@ -2613,6 +2620,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			{
 				cacheLastGood: false,
 				systemdApply: {
+					quiesce: () => {},
 					activateEgressPrerequisite: successfulPrerequisiteActivation,
 					activate: successfulPrerequisiteActivation,
 					rollback: () => {},
@@ -2745,6 +2753,7 @@ describe("runtime manifest reconciliation invariants", () => {
 						);
 					},
 					systemdApply: {
+						quiesce: () => {},
 						activateEgressPrerequisite: successfulPrerequisiteActivation,
 						activate: ({ restartEgressSidecar }) => {
 							signals.push(restartEgressSidecar);
@@ -2946,6 +2955,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				revisionA = authority.egressSidecarSecretRevision;
 			},
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: () => ({ applied: true, systemUnitsChanged: [], userUnitsChanged: [] }),
 				rollback: () => {},
@@ -2967,6 +2977,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				commit("000001", revisionB);
 			},
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					recoverySignals.push(restartEgressSidecar);
@@ -2997,6 +3008,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				throw new Error("restart failure must not commit authority");
 			},
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
@@ -3026,6 +3038,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				throw new Error("injected authority commit failure");
 			},
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
@@ -3057,6 +3070,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				commit("000002", revisionC);
 			},
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
@@ -3093,6 +3107,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				mixedFailureCommits++;
 			},
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
@@ -3138,6 +3153,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				legacyFailureCommits++;
 			},
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
@@ -3182,6 +3198,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				legacyMissingCacheRestartCommits++;
 			},
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
@@ -3230,6 +3247,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				throw new Error("injected legacy authority commit failure");
 			},
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
@@ -3277,6 +3295,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				commitAuthority: (_convergence, authority) =>
 					writeAuthority("000001", authority.egressSidecarSecretRevision),
 				systemdApply: {
+					quiesce: () => {},
 					activateEgressPrerequisite: successfulPrerequisiteActivation,
 					activate: ({ restartEgressSidecar }) => {
 						legacySignals.push(restartEgressSidecar);
@@ -3401,6 +3420,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			commitAuthority: (committedConvergence, authority) =>
 				commitTestRuntimeAuthority(currentLoad, paths, committedConvergence, authority),
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: ({ restartEgressSidecar }) => {
 					expect(restartEgressSidecar).toBe(true);
@@ -4021,6 +4041,7 @@ echo spawned > '${installerLog}'
 		let rollbackCalls = 0;
 		const result = convergeRuntimeManifest(manifestLoad(manifest, "inline-patch-failure"), paths, {
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: () => {
 					activateCalls += 1;
@@ -4114,6 +4135,7 @@ echo spawned > '${installerLog}'
 					committed = true;
 				},
 				systemdApply: {
+					quiesce: () => {},
 					activateEgressPrerequisite: successfulPrerequisiteActivation,
 					activate: (signal) => {
 						expect(signal.staleSystemUnits).toEqual(["clawdi-runtime-sidecar.service"]);
@@ -4657,6 +4679,7 @@ exit 42
 		let rollbackCalls = 0;
 		const result = convergeRuntimeManifest(manifestLoad(manifest, "installer-failure"), paths, {
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: () => {
 					activateCalls += 1;
@@ -4948,8 +4971,10 @@ exit 42
 		expect(unit).toContain(FILE_BROWSER_VERSION);
 		expect(unit).toContain(FILE_BROWSER_COMMIT.slice(0, 7));
 		expect(unit).not.toContain(`ReadOnlyPaths=${paths.fileBrowserConfig}`);
-		expect(unit).toContain(`ExecStart="${paths.fileBrowserServiceBinary}"`);
-		expect(unit).toContain(`"-c" "\${CREDENTIALS_DIRECTORY}/filebrowser.yaml"`);
+		expect(unit.match(/^ExecStart=.*$/m)?.[0]).toBe(
+			`ExecStart="${paths.fileBrowserServiceBinary}" "-c" "/run/credentials/clawdi-files.service/filebrowser.yaml"`,
+		);
+		expect(unit).not.toContain("CREDENTIALS_DIRECTORY");
 		expect(unit).toContain(`NoExecPaths=${paths.userHome} ${paths.fileBrowserStateRoot}`);
 		expect(unit).toContain("ProtectSystem=strict");
 		expect(unit).toContain("CapabilityBoundingSet=");
@@ -5036,13 +5061,24 @@ exit 42
 		});
 		let readinessCommits = 0;
 		let rollbacks = 0;
+		const rollbackLifecycle: string[] = [];
 		const readinessFailure = convergeRuntimeManifest(
 			fileBrowserManifestLoad(readinessManifest),
 			paths,
 			{
 				...readyOptions,
 				fileBrowserReadinessProbe: () => false,
-				systemdApply: fileBrowserApplyHooks({ onRollback: () => rollbacks++ }),
+				systemdApply: fileBrowserApplyHooks({
+					onQuiesce: () => {
+						rollbackLifecycle.push("quiesce");
+						expect(readFileSync(paths.fileBrowserConfig, "utf8")).not.toBe(originalConfig);
+					},
+					onRollback: () => {
+						rollbackLifecycle.push("reconcile");
+						expect(readFileSync(paths.fileBrowserConfig, "utf8")).toBe(originalConfig);
+						rollbacks++;
+					},
+				}),
 				commitAuthority: () => readinessCommits++,
 			},
 		);
@@ -5051,12 +5087,76 @@ exit 42
 		);
 		expect(readinessCommits).toBe(0);
 		expect(rollbacks).toBe(1);
+		expect(rollbackLifecycle).toEqual(["quiesce", "reconcile"]);
 		expect(readFileSync(active, "utf8")).toBe(originalBinary);
 		expect(readFileSync(paths.fileBrowserConfig, "utf8")).toBe(originalConfig);
 		expect(readFileSync(join(paths.systemdSystemRoot, "clawdi-files.service"), "utf8")).toBe(
 			originalUnit,
 		);
 		expect(readFileSync(paths.installReceipts, "utf8")).toBe(originalReceipts);
+	});
+
+	test("preserves candidate inputs when service quiesce fails", () => {
+		const paths = tempRuntimePaths();
+		const binary = "Files rollback ordering binary\n";
+		const installOptions = {
+			serviceIsolation: testFileBrowserServiceIsolation,
+			download: (_url: string, destination: string) => writeFileSync(destination, binary),
+			versionProbe: () => `${FILE_BROWSER_VERSION} ${FILE_BROWSER_COMMIT.slice(0, 7)}`,
+		};
+		const initial = convergeRuntimeManifest(
+			fileBrowserManifestLoad(fileBrowserManifest(paths, { generation: 1, binary })),
+			paths,
+			{
+				fileBrowserInstallOptions: installOptions,
+				fileBrowserReadinessProbe: () => true,
+				systemdApply: fileBrowserApplyHooks(),
+			},
+		);
+		expect(initial.installErrors).toEqual([]);
+		const originalConfig = readFileSync(paths.fileBrowserConfig, "utf8");
+		const candidateEgressEnv = "CLAWDI_EGRESS_TRANSPARENT_PORT=27212\n";
+		let candidateConfig: string | null = null;
+		let reconciles = 0;
+
+		const failed = convergeRuntimeManifest(
+			fileBrowserManifestLoad(
+				fileBrowserManifest(paths, {
+					generation: 2,
+					binary,
+					accessRevision: "c".repeat(64),
+				}),
+			),
+			paths,
+			{
+				fileBrowserInstallOptions: installOptions,
+				fileBrowserReadinessProbe: () => true,
+				systemdApply: fileBrowserApplyHooks({
+					onActivate: () => {
+						mkdirSync(dirname(paths.egressTransparentEnv), { recursive: true });
+						writeFileSync(paths.egressTransparentEnv, candidateEgressEnv);
+						throw new Error("injected candidate activation failure");
+					},
+					onQuiesce: () => {
+						candidateConfig = readFileSync(paths.fileBrowserConfig, "utf8");
+						throw new Error("injected candidate quiesce failure");
+					},
+					onRollback: () => reconciles++,
+				}),
+			},
+		);
+
+		expect(failed.installErrors.join("\n")).toContain("injected candidate activation failure");
+		expect(failed.installErrors.join("\n")).toContain("injected candidate quiesce failure");
+		expect(failed.installErrors).toContain(
+			"runtime filesystem rollback skipped because candidate services did not quiesce",
+		);
+		expect(reconciles).toBe(0);
+		expect(candidateConfig).not.toBeNull();
+		if (candidateConfig === null) throw new Error("candidate Files config was not observed");
+		expect(candidateConfig).not.toBe(originalConfig);
+		expect(readFileSync(paths.fileBrowserConfig, "utf8")).toBe(candidateConfig);
+		expect(readFileSync(paths.egressTransparentEnv, "utf8")).toBe(candidateEgressEnv);
 	});
 
 	test("retains only the desired Files candidate after authority commit", () => {
@@ -5121,6 +5221,7 @@ exit 42
 		let staleSystemUnits: string[] = [];
 		const result = convergeRuntimeManifest(fileBrowserManifestLoad(withoutFileBrowser), paths, {
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: (signal) => {
 					staleSystemUnits = signal.staleSystemUnits;
@@ -5266,6 +5367,7 @@ exit 42
 		const result = convergeRuntimeManifest(manifestLoad(manifest, "missing-late-run-root"), paths, {
 			cacheLastGood: false,
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: successfulPrerequisiteActivation,
 				activate: () => {
 					rmSync(paths.runRoot, { recursive: true });

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -1204,6 +1204,7 @@ describe("runtime manifest services", () => {
 			paths,
 			{
 				systemdApply: {
+					quiesce: () => {},
 					activateEgressPrerequisite: () => {
 						prerequisiteActivations += 1;
 						return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
@@ -1287,6 +1288,7 @@ describe("runtime manifest services", () => {
 				paths,
 				{
 					systemdApply: {
+						quiesce: () => {},
 						activateEgressPrerequisite: () => ({
 							applied: true,
 							systemUnitsChanged: [],
@@ -1506,6 +1508,7 @@ describe("runtime manifest services", () => {
 					authorityCommits += 1;
 				},
 				systemdApply: {
+					quiesce: () => {},
 					activateEgressPrerequisite: () => ({
 						applied: true,
 						systemUnitsChanged: [],
@@ -1548,6 +1551,7 @@ describe("runtime manifest services", () => {
 			paths,
 			{
 				systemdApply: {
+					quiesce: () => {},
 					activateEgressPrerequisite: () => ({
 						applied: true,
 						systemUnitsChanged: [],
@@ -1665,6 +1669,7 @@ describe("runtime manifest services", () => {
 				authorityCommits += 1;
 			},
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: () => ({
 					applied: true,
 					systemUnitsChanged: [],
@@ -1691,6 +1696,7 @@ describe("runtime manifest services", () => {
 
 		const retried = convergeRuntimeManifest(load, paths, {
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: () => ({
 					applied: true,
 					systemUnitsChanged: [],
@@ -1741,6 +1747,7 @@ describe("runtime manifest services", () => {
 			paths,
 			{
 				systemdApply: {
+					quiesce: () => {},
 					activateEgressPrerequisite: () => ({
 						applied: true,
 						systemUnitsChanged: [],
@@ -1805,6 +1812,7 @@ describe("runtime manifest services", () => {
 					authorityCommits += 1;
 				},
 				systemdApply: {
+					quiesce: () => {},
 					activateEgressPrerequisite: () => ({
 						applied: true,
 						systemUnitsChanged: [],
@@ -2256,6 +2264,7 @@ esac
 				authorityCommits += 1;
 			},
 			systemdApply: {
+				quiesce: () => {},
 				activateEgressPrerequisite: () => ({
 					applied: true,
 					systemUnitsChanged: [],

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -290,6 +290,7 @@ interface RuntimeSystemdApplySignal {
 interface RuntimeSystemdApplyHooks {
 	activateEgressPrerequisite: (signal: RuntimeSystemdApplySignal) => RuntimeSystemdApplyResult;
 	activate: (signal: RuntimeSystemdApplySignal) => RuntimeSystemdApplyResult;
+	quiesce: () => void;
 	rollback: (signal: RuntimeSystemdApplySignal) => void;
 }
 
@@ -5646,6 +5647,7 @@ export function convergeRuntimeManifest(
 		throw error;
 	}
 	let systemdActivationApplied = false;
+	let systemdActivationAttempted = false;
 	let restartDaemon = false;
 	let desiredDaemonAuthTokenRevision: string | undefined;
 	let restartEgressSidecar = false;
@@ -6262,6 +6264,7 @@ export function convergeRuntimeManifest(
 			systemdUnits.egressSidecarActive &&
 			opts.systemdApply
 		) {
+			systemdActivationAttempted = true;
 			const prerequisite = opts.systemdApply.activateEgressPrerequisite({
 				restartDaemon,
 				restartEgressSidecar,
@@ -6291,6 +6294,7 @@ export function convergeRuntimeManifest(
 		const bootFinished = join(instanceRoot, "boot-finished");
 		writeRuntimePrivateFileAtomic(paths, bootFinished, `${generatedAt}\n`);
 		if (opts.systemdApply) {
+			systemdActivationAttempted = true;
 			const activation = opts.systemdApply.activate({
 				restartDaemon,
 				restartEgressSidecar,
@@ -6402,32 +6406,52 @@ export function convergeRuntimeManifest(
 		return convergence;
 	} catch (error) {
 		const applyError = error instanceof Error ? error.message : String(error);
+		let candidateQuiesced = !systemdActivationAttempted;
+		if (systemdActivationAttempted) {
+			try {
+				opts.systemdApply?.quiesce();
+				candidateQuiesced = true;
+			} catch (quiesceError) {
+				installErrors.push(
+					`runtime candidate service quiesce failed: ${
+						quiesceError instanceof Error ? quiesceError.message : String(quiesceError)
+					}`,
+				);
+			}
+		}
 		let filesystemRollbackSucceeded = false;
-		try {
-			hostedRuntimeContract.assertPlatformRoots();
-			restoreRuntimeLiveSnapshot(liveSnapshot);
-			if (rollbackEgressSecretOverride) {
-				writeEgressSecretMaterial(rollbackEgressSecretOverride, paths);
-			} else if (rollbackEgressSecretRevision) {
-				const committedMaterial = verifiedCommittedEgressSecretMaterial(paths, applyContext);
-				if (committedMaterial?.revision === rollbackEgressSecretRevision) {
-					writeEgressSecretMaterial(committedMaterial, paths);
-				} else {
-					egressRollbackAuthorityVerified = false;
+		if (candidateQuiesced) {
+			try {
+				hostedRuntimeContract.assertPlatformRoots();
+				restoreRuntimeLiveSnapshot(liveSnapshot);
+				if (rollbackEgressSecretOverride) {
+					writeEgressSecretMaterial(rollbackEgressSecretOverride, paths);
+				} else if (rollbackEgressSecretRevision) {
+					const committedMaterial = verifiedCommittedEgressSecretMaterial(paths, applyContext);
+					if (committedMaterial?.revision === rollbackEgressSecretRevision) {
+						writeEgressSecretMaterial(committedMaterial, paths);
+					} else {
+						egressRollbackAuthorityVerified = false;
+						rmSync(egressSecretFilePath(paths), { force: true });
+					}
+				} else if (!egressRollbackAuthorityVerified) {
 					rmSync(egressSecretFilePath(paths), { force: true });
 				}
-			} else if (!egressRollbackAuthorityVerified) {
-				rmSync(egressSecretFilePath(paths), { force: true });
+				filesystemRollbackSucceeded = true;
+			} catch (rollbackError) {
+				installErrors.push(
+					`runtime filesystem rollback failed: ${
+						rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+					}`,
+				);
 			}
-			filesystemRollbackSucceeded = true;
-		} catch (rollbackError) {
+		} else {
 			installErrors.push(
-				`runtime filesystem rollback failed: ${
-					rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
-				}`,
+				"runtime filesystem rollback skipped because candidate services did not quiesce",
 			);
 		}
 		if (
+			filesystemRollbackSucceeded &&
 			!workspaceExistedBeforeApply &&
 			resolve(workspaceRoot) !== resolve(paths.userHome) &&
 			existsSync(workspaceRoot)
@@ -6463,9 +6487,13 @@ export function convergeRuntimeManifest(
 					}`,
 				);
 			}
-		} else if (opts.systemdApply) {
+		} else if (opts.systemdApply && candidateQuiesced) {
 			installErrors.push(
 				"runtime systemd rollback skipped because filesystem authority restoration failed",
+			);
+		} else if (opts.systemdApply) {
+			installErrors.push(
+				"runtime systemd reconciliation skipped because candidate services did not quiesce",
 			);
 		}
 		if (!egressRollbackAuthorityVerified) {

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -292,6 +292,7 @@ function systemdUnitFileName(name: string): string {
 }
 
 const RUNTIME_SYSTEMD_DROP_IN_FILE = "10-clawdi-hosted.conf";
+const FILE_BROWSER_SYSTEMD_CREDENTIAL = "/run/credentials/clawdi-files.service/filebrowser.yaml";
 
 function systemdDropInFilePath(paths: RuntimePaths, unitName: string): string {
 	return join(
@@ -317,7 +318,7 @@ function systemdExec(command: string, args: string[]): string {
 }
 
 function fileBrowserSystemdExec(command: string): string {
-	return `${systemdQuote(command)} "-c" "\${CREDENTIALS_DIRECTORY}/filebrowser.yaml"`;
+	return systemdExec(command, ["-c", FILE_BROWSER_SYSTEMD_CREDENTIAL]);
 }
 
 function fileBrowserVersionProbeExec(command: string, version: string, commit: string): string {

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -14,7 +14,11 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { applySystemdRuntimeUpdate, readSystemdUnitSnapshot } from "../../src/commands/runtime";
+import {
+	applySystemdRuntimeUpdate,
+	quiesceSystemdRuntimeCandidate,
+	readSystemdUnitSnapshot,
+} from "../../src/commands/runtime";
 import { convergeRuntimeManifest } from "../../src/runtime/manifest";
 import {
 	FILE_BROWSER_AMD64_SHA256,
@@ -350,6 +354,10 @@ http.createServer((request, response) => {
 			download: (_url, destination) => writeFileSync(destination, binary),
 		},
 		systemdApply: {
+			quiesce: () => {
+				failed = readSystemdUnitSnapshot(paths);
+				quiesceSystemdRuntimeCandidate(paths, failed);
+			},
 			activateEgressPrerequisite: () => ({
 				applied: true,
 				systemUnitsChanged: [],

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -20,6 +20,7 @@ import { parse as parseYaml } from "yaml";
 import {
 	applySystemdRuntimeUpdate,
 	commitRuntimeAppliedState,
+	quiesceSystemdRuntimeCandidate,
 	readSystemdUnitSnapshot,
 	runtimeAppliedContentIdentity,
 	runtimeInit as runtimeInitWithContext,
@@ -6081,6 +6082,7 @@ exit 64
 			const apply = (load: RuntimeManifestLoad) =>
 				convergeRuntimeManifest(load, paths, {
 					systemdApply: {
+						quiesce: () => {},
 						activateEgressPrerequisite: () => ({
 							applied: true,
 							systemUnitsChanged: [],
@@ -7721,17 +7723,28 @@ fi
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const bin = join(root, "bin");
+		const failNextSidecarActivation = join(root, "fail-next-sidecar-activation");
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
 		seedOpenClawBinary(home);
+		writeFileSync(failNextSidecarActivation, "fail\n");
 		writeFileSync(
 			join(bin, "systemctl"),
 			`#!/usr/bin/env bash
-printf 'systemctl failed\\n' >&2
-exit 42
+set -euo pipefail
+if [ "\${1:-}" = "--user" ]; then shift; fi
+if [ "\${1:-}" = "show" ]; then
+  printf 'LoadState=loaded\\nActiveState=active\\n'
+elif [ "\${1:-}" = "is-enabled" ]; then
+  printf 'enabled\\n'
+elif { [ "\${1:-}" = "start" ] || [ "\${1:-}" = "restart" ]; } && [[ " $* " = *" clawdi-runtime-sidecar.service "* ]] && [ -f '${failNextSidecarActivation}' ]; then
+  rm -f '${failNextSidecarActivation}'
+  printf 'injected sidecar activation failure\\n' >&2
+  exit 42
+fi
 `,
 		);
 		chmodSync(join(bin, "systemctl"), 0o700);
@@ -8779,6 +8792,53 @@ fi
 		expect(readFileSync(sidecarState, "utf-8")).toBe("inactive\n");
 	});
 
+	it("quiesces candidate services before their transparent-egress handoff is removed", () => {
+		const home = join(root, "home", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const systemctlPath = join(root, "bin", "systemctl");
+		const systemctlLog = join(root, "systemctl-quiesce.log");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlPath;
+		process.env.CLAWDI_SYSTEMD_APPLY = "1";
+		const paths = getRuntimePaths();
+		mkdirSync(dirname(systemctlPath), { recursive: true });
+		mkdirSync(dirname(paths.egressTransparentEnv), { recursive: true });
+		writeFileSync(paths.egressTransparentEnv, "CLAWDI_EGRESS_TRANSPARENT_PORT=27212\n");
+		writeFileSync(
+			systemctlPath,
+			`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> '${systemctlLog}'
+if [ "\${1:-}" = "stop" ] && [[ " $* " = *" clawdi-runtime-sidecar.service "* ]]; then
+  test -f '${paths.egressTransparentEnv}'
+  printf 'sidecar-env-present\\n' >> '${systemctlLog}'
+fi
+`,
+		);
+		chmodSync(systemctlPath, 0o700);
+		const candidate: Parameters<typeof quiesceSystemdRuntimeCandidate>[1] = {
+			system: new Map([
+				["clawdi-runtime-watch.service", "watch"],
+				["clawdi-daemon.service", "daemon"],
+				["clawdi-runtime-sidecar.service", "sidecar"],
+				["clawdi-files.service", "files"],
+			]),
+			user: new Map([["openclaw-gateway.service", "gateway"]]),
+		};
+
+		quiesceSystemdRuntimeCandidate(paths, candidate);
+		rmSync(paths.egressTransparentEnv);
+
+		expect(readFileSync(systemctlLog, "utf-8").trim().split("\n")).toEqual([
+			"--user stop openclaw-gateway.service",
+			"stop clawdi-daemon.service clawdi-files.service clawdi-runtime-sidecar.service",
+			"sidecar-env-present",
+		]);
+	});
+
 	it("runtime watch hands off before convergence and the new CLI completes the transaction", async () => {
 		installSuccessfulSystemctlFixture();
 		const home = join(root, "home", "clawdi");
@@ -9420,9 +9480,21 @@ fi
 			expect(readFileSync(paths.managedSecretCacheFile, "utf-8")).toBe(committedSecretCache);
 			const rollbackSystemctlCalls = readFileSync(systemctlLog, "utf-8").trim().split("\n");
 			expect(rollbackSystemctlCalls).not.toContain("official openclaw installer");
-			expect(
-				rollbackSystemctlCalls.filter((call) => call === "restart clawdi-runtime-sidecar.service"),
-			).toHaveLength(2);
+			const failedRestart = rollbackSystemctlCalls.indexOf(
+				"restart clawdi-runtime-sidecar.service",
+			);
+			const quiesce = rollbackSystemctlCalls.findIndex(
+				(call) => call.startsWith("stop ") && call.includes("clawdi-runtime-sidecar.service"),
+			);
+			const priorStart = rollbackSystemctlCalls.findIndex(
+				(call, index) =>
+					index > quiesce &&
+					(call.startsWith("start ") || call.startsWith("restart ")) &&
+					call.includes("clawdi-runtime-sidecar.service"),
+			);
+			expect(failedRestart).toBeGreaterThanOrEqual(0);
+			expect(quiesce).toBeGreaterThan(failedRestart);
+			expect(priorStart).toBeGreaterThan(quiesce);
 
 			writeFileSync(systemctlLog, "");
 			logs.length = 0;


### PR DESCRIPTION
## Root cause

The Hosted Files unit passed `${CREDENTIALS_DIRECTORY}/filebrowser.yaml` to File Browser, but the production Incus system manager did not provide that environment variable. File Browser fell back to `/filebrowser.yaml`, then to `0.0.0.0:80`, and failed as the unprivileged runtime user.

Activation failure then restored the live filesystem before stopping candidate services. That could remove binaries and transparent-egress handoff files while daemon and sidecar processes were still running.

## Changes

- Read the Files config from the systemd-supported fixed system-service credential path `/run/credentials/clawdi-files.service/filebrowser.yaml`.
- Add a required transactional quiesce phase before filesystem restoration.
- Stop candidate user workloads first, then candidate system services, while excluding the currently executing `clawdi-runtime-watch.service`.
- Reconcile the prior unit snapshot only after filesystem authority is restored.
- Fail closed when quiesce fails: preserve candidate inputs and skip filesystem/systemd rollback.
- Keep official OpenClaw and Hermes HOME/workspace defaults unchanged.
- Bump the immutable CLI artifact to `clawdi@0.13.51`.

## Verification

- CLI clean runner: 1649 passed, 4 gated skips, 0 failed
- Focused manifest suites: 209 passed
- Focused rollback/quiesce tests passed
- TypeScript typecheck passed
- Biome lint passed
- Publish manifest check passed
- `git diff --check` passed
- Local `systemd.exec(5)` confirms `/run/credentials/UNITNAME` is supported for system services when interpolation is unavailable

## Release impact

Merging this PR triggers the immutable `clawdi@0.13.51` npm/GitHub release. Hosted must then pin and verify that exact version in a new tenant image before the prod11 canary is rolled forward.