### PR TITLE
fix(cli): simplify Files ACL convergence

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.51",
+      "version": "0.13.52",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.51",
+	"version": "0.13.52",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/file-browser-isolation.ts
+++ b/packages/cli/src/runtime/file-browser-isolation.ts
@@ -177,7 +177,7 @@ function ensureWorkspaceAcl(
 			"d:m::rwx",
 		].join(",");
 		const fileAcl = [`u:${runtimeUid}:rw-`, `g:${identity.gid}:rw-`, "m::rwx"].join(",");
-		const contents = workspaceAclEntries(sourceRoot)
+		const contents = workspaceAclEntries(sourceRoot, runtimeUid, identity.uid)
 			.map(
 				(entry) =>
 					`a+ ${tmpfilesPath(entry.path)} - - - - ${entry.directory ? directoryAcl : fileAcl}`,
@@ -208,10 +208,17 @@ function ensureWorkspaceAcl(
 	}
 }
 
-function workspaceAclEntries(sourceRoot: string): Array<{ path: string; directory: boolean }> {
+function workspaceAclEntries(
+	sourceRoot: string,
+	runtimeUid: number,
+	serviceUid: number,
+): Array<{ path: string; directory: boolean }> {
 	const root = lstatSync(sourceRoot);
 	if (!root.isDirectory() || root.isSymbolicLink()) {
 		throw new Error("Files source root must be a trusted directory");
+	}
+	if (root.uid !== runtimeUid) {
+		throw new Error("Files source root must be owned by the tenant runtime user");
 	}
 	const entries: Array<{ path: string; directory: boolean }> = [
 		{ path: sourceRoot, directory: true },
@@ -230,6 +237,10 @@ function workspaceAclEntries(sourceRoot: string): Array<{ path: string; director
 				throw error;
 			}
 			if (stat.isSymbolicLink()) continue;
+			// Service-owned paths already grant Files access and inherit the
+			// tenant ACL. Do not cross that ownership boundary with tmpfiles.
+			if (stat.uid === serviceUid) continue;
+			if (stat.uid !== runtimeUid) continue;
 			if (stat.isFile()) {
 				entries.push({ path, directory: false });
 				continue;

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -250,7 +250,9 @@ const fs = require("fs");
 const http = require("http");
 const existing = fs.readFileSync(${JSON.stringify(tenantExisting)}, "utf8");
 fs.writeFileSync(${JSON.stringify(serviceCreated)}, existing);
-fs.mkdirSync(${JSON.stringify(join(paths.fileBrowserStateRoot, "cache"))});
+fs.mkdirSync(${JSON.stringify(join(runtimeHome, "tmp", "thumbnails"))}, { recursive: true });
+fs.writeFileSync(${JSON.stringify(join(runtimeHome, "tmp", "thumbnails", "preview.jpg"))}, "preview\\n");
+fs.mkdirSync(${JSON.stringify(join(paths.fileBrowserStateRoot, "cache"))}, { recursive: true });
 fs.writeFileSync(${JSON.stringify(join(paths.fileBrowserStateRoot, "filebrowser.db"))}, "service-state\\n");
 http.createServer((request, response) => {
   if (request.url === "/read-new") {
@@ -347,33 +349,36 @@ http.createServer((request, response) => {
 			},
 		},
 	};
-	const before = readSystemdUnitSnapshot(paths);
-	let failed = before;
-	const result = convergeRuntimeManifest(load, paths, {
-		fileBrowserInstallOptions: {
-			download: (_url, destination) => writeFileSync(destination, binary),
-		},
-		systemdApply: {
-			quiesce: () => {
-				failed = readSystemdUnitSnapshot(paths);
-				quiesceSystemdRuntimeCandidate(paths, failed);
+	const converge = () => {
+		const before = readSystemdUnitSnapshot(paths);
+		let failed = before;
+		return convergeRuntimeManifest(load, paths, {
+			fileBrowserInstallOptions: {
+				download: (_url, destination) => writeFileSync(destination, binary),
 			},
-			activateEgressPrerequisite: () => ({
-				applied: true,
-				systemUnitsChanged: [],
-				userUnitsChanged: [],
-			}),
-			activate: () => {
-				failed = readSystemdUnitSnapshot(paths);
-				return applySystemdRuntimeUpdate(paths, before, failed);
+			systemdApply: {
+				quiesce: () => {
+					failed = readSystemdUnitSnapshot(paths);
+					quiesceSystemdRuntimeCandidate(paths, failed);
+				},
+				activateEgressPrerequisite: () => ({
+					applied: true,
+					systemUnitsChanged: [],
+					userUnitsChanged: [],
+				}),
+				activate: () => {
+					failed = readSystemdUnitSnapshot(paths);
+					return applySystemdRuntimeUpdate(paths, before, failed);
+				},
+				rollback: () => {
+					applySystemdRuntimeUpdate(paths, failed, readSystemdUnitSnapshot(paths), {
+						recoverFailedUnits: false,
+					});
+				},
 			},
-			rollback: () => {
-				applySystemdRuntimeUpdate(paths, failed, readSystemdUnitSnapshot(paths), {
-					recoverFailedUnits: false,
-				});
-			},
-		},
-	});
+		});
+	};
+	const result = converge();
 	expect(result.installErrors).toEqual([]);
 
 	const serviceIdentity = spawnSync("getent", ["passwd", "clawdi-files"], {
@@ -491,6 +496,8 @@ http.createServer((request, response) => {
 		spawnSync("sleep", ["0.1"]);
 	}
 	expect(readinessStatus).toBe(0);
+	const reconverged = converge();
+	expect(reconverged.installErrors).toEqual([]);
 
 	const tenantWrite = spawnSync("runuser", [
 		"-u",


### PR DESCRIPTION
## Summary

- reconcile Files ACLs only across tenant-owned paths
- skip Files-owned subtrees that already inherit the tenant ACL, avoiding systemd-tmpfiles unsafe ownership transitions on reconvergence
- release the fix as `clawdi@0.13.52`

This keeps OpenClaw and Hermes on their official HOME/workspace defaults and does not change the tenant base image or add runtime configuration.

## Production root cause

`clawdi-files` creates private cache paths such as `/home/clawdi/tmp/thumbnails`. A later convergence enumerated those service-owned paths into a root tmpfiles ACL transaction. systemd correctly rejected the cross-owner path transition, so bootstrap exited 23 before the agent runtime started.

## Verification

- `bash scripts/test.sh cli ./src/runtime/manifest-reconciliation.test.ts` (typecheck + 173 tests)
- privileged real-systemd Files test, including service-owned `tmp/thumbnails` followed by a second convergence (1 pass, 68 assertions)
- Biome check on both changed TypeScript files
- `git diff --check`
