### PR TITLE
fix(cli): let Files read its config handoff directory (0750)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.53",
+      "version": "0.13.54",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -339,7 +339,8 @@ hand-built chroot.
 UID/GID, never as the tenant runtime user. CLI/root reconciliation is the only
 identity, installer, updater, ACL, and unit controller. Candidate directories
 and binaries are root-owned; the service reads its root-authored
-`root:clawdi-files` `0440` per-boot config handoff directly, and systemd
+per-boot config handoff from a `root:clawdi-files` `0750` directory containing
+a `root:clawdi-files` `0440` file, and systemd
 publishes only the verified binary through a unit-private `BindReadOnlyPaths=`
 mount. DB/cache state lives in the service-owned `0700`
 `StateDirectory=clawdi-files`; install
@@ -1049,7 +1050,8 @@ and ephemeral runtime handoffs. Important outputs include:
 | Output | Purpose |
 | --- | --- |
 | `/etc/clawdi/clawdi.json` | Redacted managed runtime config |
-| `/run/clawdi/files/filebrowser.yaml` | `root:clawdi-files` `0440` per-boot Files config handoff read directly by the existing service |
+| `/run/clawdi/files/` | `root:clawdi-files` `0750` per-boot Files config handoff directory |
+| `/run/clawdi/files/filebrowser.yaml` | `root:clawdi-files` `0440` Files config read directly by the existing service |
 | `/etc/clawdi/projections/*` and `/etc/clawdi/run/*` | Managed projections and `clawdi run` launch config |
 | `/var/lib/clawdi/sync/runtimes.json` | Runtime sync state |
 | `/var/lib/clawdi/status/*` | Boot, apply, upgrade, provider, egress, watch, and receipt status/result files |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.53",
+	"version": "0.13.54",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/file-browser-companion.ts
+++ b/packages/cli/src/runtime/file-browser-companion.ts
@@ -30,6 +30,8 @@ import { runningAsRoot } from "./runtime-user-command";
 const FILE_BROWSER_BINARY = "filebrowser";
 const FILE_BROWSER_CANDIDATES = "candidates";
 const FILE_BROWSER_RECEIPT = "filebrowser";
+const FILE_BROWSER_CONFIG_ROOT_MODE = 0o750;
+const FILE_BROWSER_CONFIG_MODE = 0o440;
 
 type FileBrowserCompanion = NonNullable<NonNullable<RuntimeManifest["companions"]>["filebrowser"]>;
 type FileBrowserAsset = FileBrowserCompanion["assets"][keyof FileBrowserCompanion["assets"]];
@@ -329,7 +331,7 @@ function currentRevision(
 			configRootStat.isSymbolicLink() ||
 			configRootStat.uid !== owner.uid ||
 			configRootStat.gid !== identity.gid ||
-			(configRootStat.mode & 0o777) !== 0o710
+			(configRootStat.mode & 0o777) !== FILE_BROWSER_CONFIG_ROOT_MODE
 		)
 			return null;
 		const configStat = lstatSync(paths.fileBrowserConfig);
@@ -338,7 +340,7 @@ function currentRevision(
 			configStat.isSymbolicLink() ||
 			configStat.uid !== owner.uid ||
 			configStat.gid !== identity.gid ||
-			(configStat.mode & 0o777) !== 0o440
+			(configStat.mode & 0o777) !== FILE_BROWSER_CONFIG_MODE
 		)
 			return null;
 		if (readFileSync(paths.fileBrowserConfig, "utf8") !== config) return null;
@@ -372,13 +374,13 @@ export function ensureFileBrowserCompanion(
 	ensureOwnedDirectory(
 		paths.fileBrowserConfigRoot,
 		{ uid: managedRootIdentity().uid, gid: identity.gid },
-		0o710,
+		FILE_BROWSER_CONFIG_ROOT_MODE,
 	);
 	cleanStaleStaging(paths);
 	if (!verifiedReceipt || before === null) {
 		installCandidate(companion, paths, asset, options);
 		writePrivateFileAtomic(paths.fileBrowserConfig, config, {
-			mode: 0o440,
+			mode: FILE_BROWSER_CONFIG_MODE,
 			trustedRoot: paths.runRoot,
 		});
 		chownSync(paths.fileBrowserConfig, managedRootIdentity().uid, identity.gid);

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -115,9 +115,14 @@ test("propagates the real official OpenClaw installer failure and rolls back as 
 	expect(existsSync(unitPath)).toBe(false);
 	expect(existsSync(openClawConfig)).toBe(false);
 	expect(existsSync(gatewayEnvironment)).toBe(false);
-	const previousOpenClawConfig = '{"gateway":{"mode":"local"}}\n';
+	const openClawWorkspaceRoot = join(runtimeHome, ".openclaw", "workspace");
+	const previousOpenClawConfig = `${JSON.stringify({
+		agents: { defaults: { workspace: openClawWorkspaceRoot } },
+		gateway: { mode: "local" },
+	})}\n`;
 	const previousGatewayEnvironment = "PRESERVED_ENV=before\n";
 	writeFileSync(openClawConfig, previousOpenClawConfig, { mode: 0o600 });
+	chownSync(openClawConfig, runtimeUid, runtimeGid);
 	writeFileSync(gatewayEnvironment, previousGatewayEnvironment, { mode: 0o600 });
 	mkdirSync(dirname(unitPath), { recursive: true });
 	mkdirSync(unitPath, { recursive: false });
@@ -185,11 +190,13 @@ test("propagates the real official OpenClaw installer failure and rolls back as 
 	expect(readFileSync(unitSentinel, "utf8")).toBe("preserve exact rollback target\n");
 	expect(readFileSync(openClawConfig, "utf8")).toBe(previousOpenClawConfig);
 	expect(readFileSync(gatewayEnvironment, "utf8")).toBe(previousGatewayEnvironment);
-	for (const path of [unitPath, openClawConfig, gatewayEnvironment]) {
+	for (const path of [unitPath, gatewayEnvironment]) {
 		const stat = statSync(path);
 		expect(stat.uid).toBe(0);
 		expect(stat.gid).toBe(0);
 	}
+	expect(statSync(openClawConfig).uid).toBe(runtimeUid);
+	expect(statSync(openClawConfig).gid).toBe(runtimeGid);
 	expect(statSync(openClawConfig).mode & 0o777).toBe(0o600);
 	expect(statSync(gatewayEnvironment).mode & 0o777).toBe(0o600);
 	for (const path of [
@@ -232,6 +239,16 @@ test("isolates File Browser from the tenant while preserving workspace access", 
 	process.env.CLAWDI_SYSTEMD_SYSTEM_ROOT = "/run/systemd/system";
 	process.env.CLAWDI_AUTH_TOKEN = "real-filebrowser-systemd-test-auth-token";
 	process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
+	const openClawConfig = join(runtimeHome, ".openclaw", "openclaw.json");
+	const openClawWorkspaceRoot = join(runtimeHome, ".openclaw", "workspace");
+	writeFileSync(
+		openClawConfig,
+		`${JSON.stringify({
+			agents: { defaults: { workspace: openClawWorkspaceRoot } },
+		})}\n`,
+		{ mode: 0o600 },
+	);
+	chownSync(openClawConfig, runtimeUid, runtimeGid);
 	const paths = getRuntimePaths({ mode: "hosted" });
 	ensureRuntimeStateDirs(paths);
 	const globalServiceDropInRoot = join(paths.systemdSystemRoot, "service.d");
@@ -427,10 +444,14 @@ http.createServer((request, response) => {
 	}
 	expect(statSync(paths.fileBrowserConfigRoot).uid).toBe(0);
 	expect(statSync(paths.fileBrowserConfigRoot).gid).toBe(serviceGid);
-	expect(statSync(paths.fileBrowserConfigRoot).mode & 0o777).toBe(0o710);
+	expect(statSync(paths.fileBrowserConfigRoot).mode & 0o777).toBe(0o750);
 	expect(statSync(paths.fileBrowserConfig).uid).toBe(0);
 	expect(statSync(paths.fileBrowserConfig).gid).toBe(serviceGid);
 	expect(statSync(paths.fileBrowserConfig).mode & 0o777).toBe(0o440);
+	expect(
+		spawnSync("runuser", ["-u", "clawdi-files", "--", "test", "-r", paths.fileBrowserConfigRoot])
+			.status,
+	).toBe(0);
 	expect(
 		spawnSync("runuser", ["-u", "clawdi-files", "--", "test", "-r", paths.fileBrowserConfig])
 			.status,


### PR DESCRIPTION
## Root cause

File Browser scans the directory containing its YAML config before opening the file. The handoff directory `/run/clawdi/files` was `root:clawdi-files 0710` — traversal but no directory listing — so production Files failed with:

```
failed to combine YAML files: failed to read config directory: open /run/clawdi/files: permission denied
```

and the manifest transaction correctly rolled back, leaving the deployment stuck before Ready.

## Fix

- Handoff directory contract changes from `0710` to `0750` (`root:clawdi-files`); the config file stays `0440`. Tenant user still has no access and cannot write or replace either object.
- Modes are centralized as constants in `file-browser-companion.ts` so the writer (`ensureFileBrowserCompanion`) and the checker (`currentRevision`) share one definition.
- Docs updated to state directory `0750` + file `0440` explicitly.
- Version bump `0.13.53` → `0.13.54` (CLI-only rollout; no tenant base image change).

## Tests

- Existing privileged systemd e2e assertion updated `0710` → `0750`, plus one positive assertion that `clawdi-files` can read/list the config directory (`runuser -u clawdi-files -- test -r`). Tenant-denial assertions preserved.
- The two existing e2e fixtures now supply the official OpenClaw agent workspace roster (`agents.defaults.workspace`, shape from the existing canonical fixture) with production-faithful tenant ownership, so the unchanged production roster check passes honestly. The rollback test now asserts exact restoration of that prior ownership.

## Gates (all green from the worktree)

- `scripts/test-runtime-official-installer-systemd.sh`: 2 pass / 0 fail / 115 expect(); task-scoped container and image removed (`task_containers=0`, `task_images=0`)
- `scripts/test.sh cli`: 1650 pass / 4 skip / 0 fail / 8712 expect()
- `bun run check`: 970 files, 0 errors
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)