### PR TITLE
fix(cli): persist hosted resource ownership across restarts

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1056,6 +1056,7 @@ and ephemeral runtime handoffs. Important outputs include:
 | `/var/lib/clawdi/sync/runtimes.json` | Runtime sync state |
 | `/var/lib/clawdi/status/*` | Boot, apply, upgrade, provider, egress, watch, and receipt status/result files |
 | `/var/lib/clawdi/install-inventory/<runtime>.json` | Install/verify observation |
+| `/var/lib/clawdi/managed-resources/*.json` | Durable managed Skill and MCP ownership ledgers |
 | `/var/lib/clawdi/maintained/filebrowser/candidates/<sha256>/filebrowser` | Root-owned, verified Files executable |
 | `/var/lib/clawdi/maintained/clawdi/` | Root-only managed CLI activation and versioned package prefixes |
 | `/var/lib/clawdi-files/` | `clawdi-files`-owned `0700` DB and component cache state |

--- a/packages/cli/src/runtime/hosted-bundled-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.test.ts
@@ -118,7 +118,7 @@ describe("hosted bundled skill reconciliation", () => {
 	it("treats activation as committed before best-effort previous-target cleanup", () => {
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
-		mkdirSync(join(root, "config"));
+		mkdirSync(join(root, "state"));
 		const install = (
 			activation?: Parameters<typeof reconcileHostedBundledSkill>[0]["activation"],
 		) =>

--- a/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
@@ -7,6 +7,7 @@ import {
 	mkdtempSync,
 	readFileSync,
 	rmSync,
+	statSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -89,9 +90,39 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 	const target = join(workspaceRoot, "skills", "review-pr");
 	const receipt = join(workspaceRoot, "skills", ".clawdi-manifest-receipts", "review-pr.json");
 	const receiptBytes = readFileSync(receipt);
+	const receiptStat = statSync(receipt);
+	expect(receiptStat.mode & 0o777).toBe(0o600);
+	if (process.geteuid) expect(receiptStat.uid).toBe(process.geteuid());
 	rmSync(receipt);
 	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, skill })).toBe(false);
 	writeFileSync(receipt, receiptBytes);
+	expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("# Review PR\n");
+	writeFileSync(join(target, "SKILL.md"), "tenant mutation\n");
+	chmodSync(receipt, 0o622);
+	expect(
+		hostedOpenClawSkillDriver.hasOwnershipReceipt({
+			workspaceRoot,
+			skillId: "review-pr",
+			ownershipIdentity: skill.sourceIdentity,
+		}),
+	).toBe(false);
+	chmodSync(receipt, 0o600);
+	expect(
+		hostedOpenClawSkillDriver.hasOwnershipReceipt({
+			workspaceRoot,
+			skillId: "review-pr",
+			ownershipIdentity: skill.sourceIdentity,
+		}),
+	).toBe(true);
+	expect(
+		hostedOpenClawSkillDriver.installDirectory({
+			home,
+			workspaceRoot,
+			skillId: "review-pr",
+			sourceDir,
+			ownershipIdentity: skill.sourceIdentity,
+		}),
+	).toBe("installed");
 	expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("# Review PR\n");
 	writeFileSync(join(sourceDir, "SKILL.md"), "# Review PR v2\n");
 	process.env.FAKE_OPENCLAW_FAIL_AFTER_WRITE = "1";

--- a/packages/cli/src/runtime/hosted-openclaw-skill.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.ts
@@ -7,8 +7,9 @@ import {
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import {
 	collectManagedSkillTree,
+	managedSkillMarkerMatchesIdentity,
+	managedSkillMarkerOwnsTarget,
 	managedSkillReceiptMatchesIdentity,
-	managedSkillReceiptOwnsTarget,
 	managedSkillTreesEqual,
 	withManagedTargetRollback,
 	withStagedManagedSkill,
@@ -35,6 +36,11 @@ export interface HostedOpenClawSkillDriver {
 		workspaceRoot: string;
 		skill: PreparedHostedSourcedSkill;
 	}): "installed" | "unchanged";
+	hasOwnershipReceipt(input: {
+		workspaceRoot: string;
+		skillId: string;
+		ownershipIdentity: string;
+	}): boolean;
 	verifyOwned(input: { workspaceRoot: string; skill: PreparedHostedSourcedSkill }): boolean;
 	cleanupManifestOwned(input: {
 		workspaceRoot: string;
@@ -129,7 +135,7 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 		const receipt = receiptInput(input.workspaceRoot, input.skillId, input.ownershipIdentity);
 		if (nativeResultMatches(input.sourceDir, target) && managedSkillReceiptMatchesIdentity(receipt))
 			return "unchanged";
-		if (existsSync(target) && !managedSkillReceiptOwnsTarget(receipt))
+		if (existsSync(target) && !managedSkillMarkerOwnsTarget(receipt))
 			throw new Error(
 				"refusing to replace an OpenClaw Skill without a matching Clawdi ownership receipt",
 			);
@@ -180,12 +186,17 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 			}),
 		);
 	},
+	hasOwnershipReceipt(input) {
+		return managedSkillMarkerMatchesIdentity(
+			receiptInput(input.workspaceRoot, input.skillId, input.ownershipIdentity),
+		);
+	},
 	verifyOwned(input) {
 		return withStagedManagedSkill(
 			input.skill,
 			(sourceDir) =>
 				nativeResultMatches(sourceDir, targetDir(input.workspaceRoot, input.skill.skillId)) &&
-				managedSkillReceiptMatchesIdentity(
+				managedSkillMarkerMatchesIdentity(
 					receiptInput(input.workspaceRoot, input.skill.skillId, input.skill.sourceIdentity),
 				),
 		);

--- a/packages/cli/src/runtime/live-state-snapshot.ts
+++ b/packages/cli/src/runtime/live-state-snapshot.ts
@@ -63,6 +63,7 @@ export function runtimeRootLiveMutationTargets(
 		paths.runConfigRoot,
 		paths.egressProfileBundle,
 		paths.installInventory,
+		paths.managedResourceRoot,
 		paths.projectionRoot,
 		join(paths.instanceRoot, manifest.instanceId),
 		paths.daemonAuthToken,
@@ -180,6 +181,7 @@ export function runtimeRootLiveMutationDirectories(
 		paths.systemdEnvRoot,
 		paths.installInventory,
 		paths.oauthCredentialRoot,
+		paths.managedResourceRoot,
 		paths.projectionRoot,
 		join(paths.instanceRoot, manifest.instanceId),
 	];

--- a/packages/cli/src/runtime/managed-skill-delivery.ts
+++ b/packages/cli/src/runtime/managed-skill-delivery.ts
@@ -103,7 +103,7 @@ export function writeManagedSkillReceipt(input: {
 	});
 }
 
-function readManagedSkillReceipt(input: {
+function readManagedSkillMarker(input: {
 	path: string;
 	schemaVersion: string;
 	skillId: string;
@@ -111,6 +111,17 @@ function readManagedSkillReceipt(input: {
 	exclude?: ReadonlySet<string>;
 }): ManagedSkillReceipt | null {
 	try {
+		const target = lstatSync(input.target);
+		if (target.isSymbolicLink() || !target.isDirectory()) return null;
+		const receiptStat = lstatSync(input.path);
+		const effectiveUid = process.geteuid?.();
+		if (
+			receiptStat.isSymbolicLink() ||
+			!receiptStat.isFile() ||
+			(receiptStat.mode & 0o022) !== 0 ||
+			(effectiveUid !== undefined && receiptStat.uid !== effectiveUid)
+		)
+			return null;
 		const receipt = JSON.parse(readFileSync(input.path, "utf8")) as Record<string, unknown>;
 		if (
 			receipt.schemaVersion === input.schemaVersion &&
@@ -119,17 +130,48 @@ function readManagedSkillReceipt(input: {
 			receipt.ownershipIdentity.length > 0 &&
 			receipt.ownershipIdentity.length <= 2048 &&
 			typeof receipt.treeFingerprint === "string" &&
-			/^[a-f0-9]{64}$/.test(receipt.treeFingerprint) &&
-			receipt.treeFingerprint ===
-				managedSkillTreeFingerprint(
-					collectManagedSkillTree(input.target, { exclude: input.exclude }),
-				)
+			/^[a-f0-9]{64}$/.test(receipt.treeFingerprint)
 		)
 			return receipt as ManagedSkillReceipt;
 		return null;
 	} catch {
 		return null;
 	}
+}
+
+function readManagedSkillReceipt(input: {
+	path: string;
+	schemaVersion: string;
+	skillId: string;
+	target: string;
+	exclude?: ReadonlySet<string>;
+}): ManagedSkillReceipt | null {
+	const marker = readManagedSkillMarker(input);
+	return marker?.treeFingerprint ===
+		managedSkillTreeFingerprint(collectManagedSkillTree(input.target, { exclude: input.exclude }))
+		? marker
+		: null;
+}
+
+export function managedSkillMarkerOwnsTarget(input: {
+	path: string;
+	schemaVersion: string;
+	skillId: string;
+	target: string;
+	exclude?: ReadonlySet<string>;
+}): boolean {
+	return readManagedSkillMarker(input) !== null;
+}
+
+export function managedSkillMarkerMatchesIdentity(input: {
+	path: string;
+	schemaVersion: string;
+	skillId: string;
+	ownershipIdentity: string;
+	target: string;
+	exclude?: ReadonlySet<string>;
+}): boolean {
+	return readManagedSkillMarker(input)?.ownershipIdentity === input.ownershipIdentity;
 }
 
 export function managedSkillReceiptOwnsTarget(input: {

--- a/packages/cli/src/runtime/managed-skill-reservation.test.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.test.ts
@@ -78,7 +78,7 @@ describe("managed Skill reservations", () => {
 		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
-		mkdirSync(join(root, "config"));
+		mkdirSync(join(root, "state"));
 		const path = target();
 		reserveManagedSkill({
 			targetDir: path,
@@ -152,7 +152,7 @@ describe("managed Skill reservations", () => {
 		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
-		mkdirSync(join(root, "config"));
+		mkdirSync(join(root, "state"));
 		const path = target();
 		const sourceIdentity = [
 			"project",

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -68,9 +68,16 @@ function ledgerPath(): string {
 	const root = process.env.CLAWDI_SERVICE_STATE_DIR?.trim();
 	const mode = process.env.CLAWDI_RUNTIME_MODE?.trim().toLowerCase();
 	if (mode === "hosted" || root) {
-		return join(getRuntimePaths({ mode: "hosted" }).projectionRoot, LEDGER_FILE);
+		return join(getRuntimePaths({ mode: "hosted" }).managedResourceRoot, LEDGER_FILE);
 	}
 	return join(getClawdiDir(), "managed-resources", LEDGER_FILE);
+}
+
+function legacyHostedLedgerPath(path: string): string | null {
+	const runtimePaths = getRuntimePaths({ mode: "hosted" });
+	return path === join(runtimePaths.managedResourceRoot, LEDGER_FILE)
+		? join(runtimePaths.projectionRoot, LEDGER_FILE)
+		: null;
 }
 
 function emptyLedger(): ManagedSkillReservationLedger {
@@ -78,12 +85,18 @@ function emptyLedger(): ManagedSkillReservationLedger {
 }
 
 function readLedger(path: string): ManagedSkillReservationLedger {
-	if (!existsSync(path)) return emptyLedger();
+	const legacyPath = legacyHostedLedgerPath(path);
+	const sourcePath = existsSync(path)
+		? path
+		: legacyPath && existsSync(legacyPath)
+			? legacyPath
+			: null;
+	if (!sourcePath) return emptyLedger();
 	let value: unknown;
 	try {
-		const stat = lstatSync(path);
+		const stat = lstatSync(sourcePath);
 		if (!stat.isFile() || stat.isSymbolicLink()) throw new Error("not a regular file");
-		value = JSON.parse(readFileSync(path, "utf8"));
+		value = JSON.parse(readFileSync(sourcePath, "utf8"));
 	} catch {
 		throw new Error("managed Skill ownership state is invalid");
 	}

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -3603,7 +3603,7 @@ echo spawned > '${installerLog}'
 		const fixtureRoot = dirname(paths.serviceStateRoot);
 		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
 		const skillDir = join(paths.userHome, ".hermes", "skills", "clawdi");
-		const ledger = join(paths.projectionRoot, "managed-skills.json");
+		const ledger = join(paths.managedResourceRoot, "managed-skills.json");
 		const cliRoot = resolve(import.meta.dir, "../..");
 		const skillSource = join(cliRoot, "skills", "hosted-versions", "1", "clawdi");
 		const protectedSourceAncestors = [
@@ -3679,6 +3679,8 @@ echo spawned > '${installerLog}'
 			expect(statSync(join(skillDir, "SKILL.md")).uid).toBe(runtimeUid);
 			expect(statSync(paths.projectionRoot).uid).toBe(0);
 			expect(statSync(paths.projectionRoot).mode & 0o777).toBe(0o755);
+			expect(statSync(paths.managedResourceRoot).uid).toBe(0);
+			expect(statSync(paths.managedResourceRoot).mode & 0o777).toBe(0o755);
 			expect(statSync(ledger).uid).toBe(0);
 			expect(statSync(ledger).mode & 0o022).toBe(0);
 			for (const path of protectedSourceAncestors) {
@@ -3692,7 +3694,7 @@ echo spawned > '${installerLog}'
 					"--",
 					"test",
 					"-w",
-					paths.projectionRoot,
+					paths.managedResourceRoot,
 				]),
 			).toThrow();
 
@@ -3914,6 +3916,18 @@ echo spawned > '${installerLog}'
 			),
 		).toBe(true);
 		expect(shouldIgnoreUserSkill(target, "clawdi")).toBe(true);
+
+		writeFileSync(join(target, "SKILL.md"), "tenant mutation\n");
+		rmSync(paths.managedResourceRoot, { recursive: true, force: true });
+		const reconverged = convergeRuntimeManifest(
+			manifestLoad({ ...manifest, generation: 2 }, "bundled-openclaw-skill-restart"),
+			paths,
+		);
+		expect(reconverged.installErrors).toEqual([]);
+		expect(readFileSync(join(target, "SKILL.md"))).toEqual(
+			readFileSync(join(packageSource, "SKILL.md")),
+		);
+		expect(shouldIgnoreUserSkill(target, "clawdi")).toBe(true);
 	});
 
 	test("removes only strictly identified legacy bundled OpenClaw Skills without requiring a new receipt", () => {
@@ -3944,6 +3958,7 @@ echo spawned > '${installerLog}'
 					resolveWorkspace: () => openClawWorkspaceRoot,
 					installDirectory: () => "installed",
 					install: () => "installed",
+					hasOwnershipReceipt: () => false,
 					verifyOwned: () => false,
 					cleanupManifestOwned: () => {
 						guardedCleanupCalls += 1;
@@ -4203,6 +4218,7 @@ echo spawned > '${installerLog}'
 				paths.runConfigRoot,
 				paths.egressProfileBundle,
 				paths.installInventory,
+				paths.managedResourceRoot,
 				paths.projectionRoot,
 				join(paths.instanceRoot, manifest.instanceId),
 				paths.daemonAuthToken,

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -3366,17 +3366,23 @@ function hostedMcpIntent(manifest: RuntimeManifest): HostedMcpIntent {
 }
 
 function hostedMcpLedgerPath(paths: RuntimePaths): string {
+	return join(paths.managedResourceRoot, HOSTED_MCP_LEDGER_FILE);
+}
+
+function legacyHostedMcpLedgerPath(paths: RuntimePaths): string {
 	return join(paths.projectionRoot, HOSTED_MCP_LEDGER_FILE);
 }
 
 function readHostedMcpManagedLedger(paths: RuntimePaths): HostedMcpManagedLedger {
 	const path = hostedMcpLedgerPath(paths);
-	if (!existsSync(path)) {
+	const legacyPath = legacyHostedMcpLedgerPath(paths);
+	const sourcePath = existsSync(path) ? path : existsSync(legacyPath) ? legacyPath : null;
+	if (!sourcePath) {
 		return { schemaVersion: HOSTED_MCP_LEDGER_SCHEMA_VERSION, runtimes: {} };
 	}
 	let payload: unknown;
 	try {
-		payload = JSON.parse(readFileSync(path, "utf-8"));
+		payload = JSON.parse(readFileSync(sourcePath, "utf-8"));
 	} catch (error) {
 		throw new Error(
 			`hosted MCP last-applied ledger is invalid: ${
@@ -3622,6 +3628,36 @@ function recoverHostedOpenClawSourcedSkillReservations(
 			id: skillId,
 			manager: "hosted-manifest",
 			sourceIdentity: skill.sourceIdentity,
+		});
+	}
+}
+
+function recoverHostedOpenClawBundledSkillReservations(
+	manifest: RuntimeManifest,
+	openClawWorkspaceRoot: string,
+	driver: HostedOpenClawSkillDriver,
+): void {
+	if (!hostedBundledSkillsEnabled() || manifest.runtimes.openclaw?.enabled !== true) return;
+	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
+		if (desired.enabled !== true || "source" in desired) continue;
+		const targetDir = join(openClawWorkspaceRoot, "skills", skillId);
+		if (!existsSync(targetDir) || managedSkillReservationOwner(targetDir, skillId) !== "unreserved")
+			continue;
+		const bundled = resolveHostedBundledSkill(skillId, desired.version);
+		if (
+			!driver.hasOwnershipReceipt({
+				workspaceRoot: openClawWorkspaceRoot,
+				skillId,
+				ownershipIdentity: `content-sha256\0${bundled.digest}`,
+			})
+		)
+			continue;
+		reserveManagedSkill({
+			targetDir,
+			id: skillId,
+			manager: "hosted-manifest",
+			version: bundled.version,
+			digest: bundled.digest,
 		});
 	}
 }
@@ -3936,7 +3972,11 @@ function applyHostedMcpProjections(
 		outputs.add(runtime.commandPath);
 	}
 	// The last-applied ownership map advances only after every native target.
-	if (Object.keys(plan.nextLedger.runtimes).length > 0 || existsSync(ledgerPath)) {
+	if (
+		Object.keys(plan.nextLedger.runtimes).length > 0 ||
+		existsSync(ledgerPath) ||
+		existsSync(legacyHostedMcpLedgerPath(paths))
+	) {
 		writeHostedMcpManagedLedger(paths, plan.nextLedger);
 	}
 	return [...outputs];
@@ -5573,6 +5613,11 @@ export function convergeRuntimeManifest(
 			hermesSkillNativeReconciler,
 		);
 		if (openClawWorkspaceRoot) {
+			recoverHostedOpenClawBundledSkillReservations(
+				manifest,
+				openClawWorkspaceRoot,
+				openClawSkillDriver,
+			);
 			recoverHostedOpenClawSourcedSkillReservations(
 				manifest,
 				openClawWorkspaceRoot,

--- a/packages/cli/src/runtime/paths.test.ts
+++ b/packages/cli/src/runtime/paths.test.ts
@@ -31,6 +31,7 @@ describe("runtime paths", () => {
 		expect(paths.cliNpmPrefix).toBe("/var/lib/clawdi/maintained/clawdi/npm");
 		expect(paths.cliNpmCache).toBe("/var/cache/clawdi/npm");
 		expect(paths.fileBrowserInstallRoot).toBe("/var/lib/clawdi/maintained/filebrowser");
+		expect(paths.managedResourceRoot).toBe("/var/lib/clawdi/managed-resources");
 		expect(paths.fileBrowserStateRoot).toBe("/var/lib/clawdi-files");
 		expect(paths.egressServiceBinary).toBe("/run/clawdi/egress/systemd/mitmdump");
 		expect(paths.fileBrowserServiceBinary).toBe("/run/clawdi-files/filebrowser");

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -71,6 +71,7 @@ export interface RuntimePaths {
 	instanceRoot: string;
 	installInventory: string;
 	installReceipts: string;
+	managedResourceRoot: string;
 	projectionRoot: string;
 	runRoot: string;
 	convergeLock: string;
@@ -229,6 +230,7 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 		instanceRoot,
 		installInventory: join(serviceStateRoot, "install-inventory"),
 		installReceipts: join(statusRoot, "runtime-install-receipts.json"),
+		managedResourceRoot: join(serviceStateRoot, "managed-resources"),
 		projectionRoot: join(configurationRoot, "projections"),
 		runRoot,
 		convergeLock: join(runRoot, "locks", "converge.lock"),

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -13917,7 +13917,8 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		const ledgerPath = join(getRuntimePaths().projectionRoot, "managed-mcp-servers.json");
+		const paths = getRuntimePaths();
+		const ledgerPath = join(paths.managedResourceRoot, "managed-mcp-servers.json");
 		mkdirSync(dirname(hermesBin), { recursive: true });
 		mkdirSync(dirname(openclawUserSkill), { recursive: true });
 		writeFileSync(
@@ -14067,6 +14068,14 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 			existsSync(join(dirname(openclawSkill), ".clawdi-manifest-receipts", "clawdi.json")),
 		).toBe(true);
 
+		writeFileSync(join(openclawSkill, "SKILL.md"), "tenant mutation before restart\n");
+		rmSync(paths.configurationRoot, { recursive: true, force: true });
+		const restarted = convergeRuntimeManifest(load(1, "openclaw", initialServers), paths);
+		expect(restarted.installErrors).toEqual([]);
+		expect(readFileSync(join(openclawSkill, "SKILL.md"), "utf-8")).not.toContain("tenant mutation");
+		expect(readOpenClawMcpServers(home).clawdi).toEqual(initialServers.clawdi);
+		expect(existsSync(ledgerPath)).toBe(true);
+
 		const updated = convergeRuntimeManifest(load(2, "openclaw", updatedServers), getRuntimePaths());
 		expect(updated.installErrors).toEqual([]);
 		expect(readOpenClawMcpServers(home)["search-proxy"]).toEqual(updatedServers["search-proxy"]);
@@ -14164,7 +14173,9 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		const ledgerPath = join(getRuntimePaths().projectionRoot, "managed-mcp-servers.json");
+		const paths = getRuntimePaths();
+		const legacyLedgerPath = join(paths.projectionRoot, "managed-mcp-servers.json");
+		const ledgerPath = join(paths.managedResourceRoot, "managed-mcp-servers.json");
 		const hermesConfigPath = join(home, ".hermes", "config.yaml");
 		const legacySecretRef = "env://REDACTED_LEGACY_NAME";
 		const legacyPrefix = "Bearer ";
@@ -14185,8 +14196,8 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 			hermesConfigPath,
 			`${JSON.stringify({ mcp_servers: { clawdi: legacyServer } }, null, 2)}\n`,
 		);
-		mkdirSync(dirname(ledgerPath), { recursive: true });
-		writeFileSync(ledgerPath, `${JSON.stringify(retainedV1Ledger, null, 2)}\n`);
+		mkdirSync(dirname(legacyLedgerPath), { recursive: true });
+		writeFileSync(legacyLedgerPath, `${JSON.stringify(retainedV1Ledger, null, 2)}\n`);
 		expect(legacyPrefix).toHaveLength(7);
 		const load = (generation: number, includeServer: boolean): RuntimeManifestLoad => ({
 			manifest: {
@@ -14323,7 +14334,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		const ledgerPath = join(getRuntimePaths().projectionRoot, "managed-mcp-servers.json");
+		const ledgerPath = join(getRuntimePaths().managedResourceRoot, "managed-mcp-servers.json");
 		const originalLedger = `${JSON.stringify(ledger, null, 2)}\n`;
 		mkdirSync(dirname(ledgerPath), { recursive: true });
 		writeFileSync(ledgerPath, originalLedger);
@@ -14371,7 +14382,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		const ledgerPath = join(getRuntimePaths().projectionRoot, "managed-mcp-servers.json");
+		const ledgerPath = join(getRuntimePaths().managedResourceRoot, "managed-mcp-servers.json");
 		writeFileSync(
 			openclawConfigPath,
 			`${JSON.stringify(
@@ -14502,7 +14513,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 			callsPath: calls,
 			failSetServer: "second",
 		});
-		const ledgerPath = join(getRuntimePaths().projectionRoot, "managed-mcp-servers.json");
+		const ledgerPath = join(getRuntimePaths().managedResourceRoot, "managed-mcp-servers.json");
 		const originalConfig = `${JSON.stringify(
 			{
 				custom: "keep",
@@ -14585,7 +14596,7 @@ install -D -m 700 '${fixtureBinary}' "$HOME/.openclaw/bin/openclaw"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		const ledgerPath = join(getRuntimePaths().projectionRoot, "managed-mcp-servers.json");
+		const ledgerPath = join(getRuntimePaths().managedResourceRoot, "managed-mcp-servers.json");
 		const hermesConfig = join(home, ".hermes", "config.yaml");
 
 		const load = (


### PR DESCRIPTION
## Root cause (launch blocker)

On a fresh v2 hosted OpenClaw deployment, the first converge installs the bundled clawdi skill, but the second boot (after stop/start) refuses it with exit 23 `refusing to replace unmanaged clawdi skill` — the guard rejecting our own install. The skill/MCP ownership ledger lived in rebuildable `/etc/clawdi/projections`, so it vanished across boots while the guard consulted it first. Every OpenClaw deployment broke on its first restart, regenerating "dirty volume" corruption.

## Fix

- Ownership ledger moves to durable `/var/lib/clawdi/managed-resources`; old `/etc` ledger readable as migration fallback; durable root included in snapshot/rollback/trusted-directory checks.
- OpenClaw bundled-skill reservations recover from the protected receipt (root-owned, 0600, platform-UID-verified) using marker identity — ownership is proven by the receipt, not the mutable tree fingerprint, so legitimate tenant-side content changes no longer forfeit ownership.
- Fail-closed preserved: recovery requires a matching protected receipt; genuinely foreign directories are still refused; MCP entries without a ledger are refused even when values match desired, so user config is never claimed.

## Tests

Existing suites extended: two-converge cycle, tenant mutation, `/etc` rebuild, receipt recovery, and unmanaged skill/MCP refusal.

## Gates

- Privileged systemd e2e: 2 pass / 0 fail / 115 expect; task containers/images cleaned
- CLI: 1650 pass / 4 skip / 0 fail / 8756 expect
- bun run check: 970 files, 0 errors; `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)