### PR TITLE
Harden post-checkout deployment handoff

### DIFF
--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -11,7 +11,6 @@ import {
 	BillingNetworkError,
 	DEPLOYMENT_CONFLICT_MESSAGE,
 	DeploymentConflictError,
-	DeploymentRequestTerminalError,
 	PlanChangePendingError,
 	PlanChangeTerminalError,
 } from "@/hosted/billing/errors";
@@ -474,31 +473,51 @@ describe("declarative deployment mutations", () => {
 		]);
 	});
 
-	it("bounds an initial by-request not-found race", async () => {
+	it("stops an in-flight deployment request read at its wall-clock deadline", async () => {
 		const requests: Request[] = [];
 		const deployRequestId = "checkout/race:stable";
-		let sleeps = 0;
+		let requestWasAborted = false;
 		const client = createBillingClient(async () => "test-token", {
 			fetch: async (request) => {
 				requests.push(request.clone());
-				return jsonResponse({ detail: "Deploy request not visible yet" }, 404);
+				return await new Promise<Response>((_resolve, reject) => {
+					const rejectAbort = () => {
+						requestWasAborted = true;
+						reject(request.signal.reason ?? new DOMException("Aborted", "AbortError"));
+					};
+					if (request.signal.aborted) rejectAbort();
+					else request.signal.addEventListener("abort", rejectAbort, { once: true });
+				});
 			},
-			operationPollLimit: 2,
-			sleep: async () => {
-				sleeps += 1;
-			},
+			deploymentRequestTimeoutMs: 25,
 		});
 
+		const startedAt = Date.now();
 		await expect(client.waitForDeploymentRequest(deployRequestId)).rejects.toBeInstanceOf(
 			BillingNetworkError,
 		);
-		expect(requests.map((request) => new URL(request.url).pathname)).toEqual(
-			Array.from(
-				{ length: 3 },
-				() => `/v2/deployments/by-request/${encodeURIComponent(deployRequestId)}`,
-			),
+		expect(Date.now() - startedAt).toBeLessThan(1_000);
+		expect(requests.map((request) => new URL(request.url).pathname)).toEqual([
+			`/v2/deployments/by-request/${encodeURIComponent(deployRequestId)}`,
+		]);
+		expect(requestWasAborted).toBe(true);
+	});
+
+	it("caps zero-delay transient reads independently of the deadline", async () => {
+		let requestCount = 0;
+		const client = createBillingClient(async () => "test-token", {
+			fetch: async () => {
+				requestCount += 1;
+				return jsonResponse({ detail: "Deploy request not visible yet" }, 404);
+			},
+			operationPollLimit: 2,
+			sleep: async () => undefined,
+		});
+
+		await expect(client.waitForDeploymentRequest("checkout-not-visible")).rejects.toBeInstanceOf(
+			BillingNetworkError,
 		);
-		expect(sleeps).toBe(2);
+		expect(requestCount).toBe(3);
 	});
 
 	it("surfaces a checkout deployment request that fails before acceptance", async () => {
@@ -522,9 +541,10 @@ describe("declarative deployment mutations", () => {
 			throw new Error(`Unexpected request: ${request.method} ${path}`);
 		});
 
-		await expect(client.waitForDeploymentRequest(intentKey)).rejects.toBeInstanceOf(
-			DeploymentRequestTerminalError,
-		);
+		await expect(client.waitForDeploymentRequest(intentKey)).rejects.toMatchObject({
+			name: "DeploymentRequestTerminalError",
+			request: { deploy_request_id: intentKey, request_status: "failed" },
+		});
 		expect(requests.map((request) => new URL(request.url).pathname)).toEqual([
 			`/v2/deployments/by-request/${intentKey}`,
 		]);

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -65,6 +65,7 @@ export type BillingClientOptions = {
 	fetch?: BillingFetch;
 	operationPollIntervalMs?: number;
 	operationPollLimit?: number;
+	deploymentRequestTimeoutMs?: number;
 	sleep?: (delayMs: number) => Promise<void>;
 };
 
@@ -191,11 +192,10 @@ function isWorkspaceSkillResourceVersionConflict(error: unknown): error is Billi
 
 function terminalDeployRequestError(status: HostedDeployRequestStatus): BillingApiError {
 	return new DeploymentRequestTerminalError(
-		409,
+		status,
 		status.request_status === "superseded"
 			? "This agent creation was superseded by a newer attempt."
 			: "The agent could not be created.",
-		status,
 	);
 }
 
@@ -309,8 +309,18 @@ export function createBillingClient(
 		},
 	});
 
-	const pollIntervalMs = options.operationPollIntervalMs ?? 1_000;
-	const pollLimit = options.operationPollLimit ?? 120;
+	const configuredPollIntervalMs = options.operationPollIntervalMs ?? 1_000;
+	const pollIntervalMs = Number.isFinite(configuredPollIntervalMs)
+		? Math.max(0, configuredPollIntervalMs)
+		: 1_000;
+	const configuredPollLimit = options.operationPollLimit ?? 120;
+	const pollLimit = Number.isFinite(configuredPollLimit)
+		? Math.max(0, Math.floor(configuredPollLimit))
+		: 120;
+	const configuredDeploymentRequestTimeoutMs = options.deploymentRequestTimeoutMs ?? 120_000;
+	const deploymentRequestTimeoutMs = Number.isFinite(configuredDeploymentRequestTimeoutMs)
+		? Math.max(0, configuredDeploymentRequestTimeoutMs)
+		: 120_000;
 	const sleep =
 		options.sleep ??
 		((delayMs: number) => new Promise<void>((resolve) => globalThis.setTimeout(resolve, delayMs)));
@@ -322,10 +332,14 @@ export function createBillingClient(
 			}),
 		);
 
-	const getOperation = async (operationId: string): Promise<DeploymentOperation> =>
+	const getOperation = async (
+		operationId: string,
+		signal?: AbortSignal,
+	): Promise<DeploymentOperation> =>
 		unwrapDeploy(
 			await api.GET("/v2/operations/{operation_id}", {
 				params: { path: { operation_id: operationId } },
+				signal,
 			}),
 		);
 
@@ -351,25 +365,38 @@ export function createBillingClient(
 
 	const getDeploymentByRequest = async (
 		deployRequestId: string,
+		signal?: AbortSignal,
 	): Promise<HostedDeployRequestStatus> =>
 		unwrapDeploy(
 			await api.GET("/v2/deployments/by-request/{deploy_request_id}", {
 				params: { path: { deploy_request_id: deployRequestId } },
+				signal,
 			}),
 		);
 
 	const waitForDeploymentRequest = async (deployRequestId: string) => {
 		let lastTransientError: unknown;
-		for (let poll = 0; poll <= pollLimit; poll += 1) {
+		const deadline = Date.now() + deploymentRequestTimeoutMs;
+		for (let poll = 0; poll <= pollLimit && Date.now() < deadline; poll += 1) {
+			const requestController = new AbortController();
+			const requestTimeoutId = globalThis.setTimeout(
+				() => requestController.abort(),
+				Math.max(0, deadline - Date.now()),
+			);
 			let status: HostedDeployRequestStatus;
 			try {
-				status = await getDeploymentByRequest(deployRequestId);
+				status = await getDeploymentByRequest(deployRequestId, requestController.signal);
 			} catch (error) {
+				if (requestController.signal.aborted) break;
 				if (!isTransientDeployRequestRead(error)) throw error;
 				lastTransientError = error;
 				if (poll === pollLimit) break;
-				await sleep(pollIntervalMs);
+				const remainingMs = deadline - Date.now();
+				if (remainingMs <= 0) break;
+				await sleep(Math.min(pollIntervalMs, remainingMs));
 				continue;
+			} finally {
+				globalThis.clearTimeout(requestTimeoutId);
 			}
 			const projection = projectHostedDeployRequest(status);
 			if (projection.kind === "terminal") {
@@ -382,8 +409,27 @@ export function createBillingClient(
 				});
 			}
 			if (projection.kind === "operation_name") {
+				const remainingMs = deadline - Date.now();
+				if (remainingMs <= 0) break;
+				const operationController = new AbortController();
+				const operationTimeoutId = globalThis.setTimeout(
+					() => operationController.abort(),
+					remainingMs,
+				);
+				let operation: DeploymentOperation;
+				try {
+					operation = await getOperation(
+						operationIdFromName(projection.operationName),
+						operationController.signal,
+					);
+				} catch (error) {
+					if (operationController.signal.aborted) break;
+					throw error;
+				} finally {
+					globalThis.clearTimeout(operationTimeoutId);
+				}
 				return acceptDeclarativeOperation({
-					operation: await getOperation(operationIdFromName(projection.operationName)),
+					operation,
 					deploymentId: projection.deploymentId,
 				});
 			}
@@ -398,7 +444,9 @@ export function createBillingClient(
 			}
 			lastTransientError = undefined;
 			if (poll === pollLimit) break;
-			await sleep(pollIntervalMs);
+			const remainingMs = deadline - Date.now();
+			if (remainingMs <= 0) break;
+			await sleep(Math.min(pollIntervalMs, remainingMs));
 		}
 		throw new BillingNetworkError("timeout", { cause: lastTransientError });
 	};

--- a/apps/web/src/hosted/billing/components/stripe-checkout-dialog.tsx
+++ b/apps/web/src/hosted/billing/components/stripe-checkout-dialog.tsx
@@ -5,7 +5,11 @@ import {
 	PaymentElement,
 	useCheckoutElements,
 } from "@stripe/react-stripe-js/checkout";
-import type { Stripe, StripeCheckoutElementsSdkOptions } from "@stripe/stripe-js";
+import type {
+	Stripe,
+	StripeCheckoutElementsSdkOptions,
+	StripeCheckoutStatus,
+} from "@stripe/stripe-js";
 import { AlertCircle, CreditCard, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -23,6 +27,10 @@ import { useDialogExitLifecycle } from "@/components/ui/use-dialog-exit-lifecycl
 import { getStripe, resetStripeCache } from "@/hosted/billing/stripe";
 import type { CheckoutSessionClientSecret } from "@/hosted/billing/stripe-client-secret";
 import { env } from "@/lib/env";
+import {
+	completedCheckoutPaymentStatus,
+	type StripeCheckoutPaymentStatus,
+} from "./stripe-checkout.logic";
 
 export type StripeCheckoutSummary = {
 	detail: string;
@@ -34,7 +42,8 @@ export type StripeCheckoutSummary = {
 type StripeCheckoutDialogProps = {
 	clientSecret: CheckoutSessionClientSecret | null;
 	description: string;
-	onComplete: () => void;
+	onComplete: (paymentStatus: StripeCheckoutPaymentStatus) => void;
+	onExpired: () => void;
 	onOpenChange: (open: boolean) => void;
 	open: boolean;
 	summary: StripeCheckoutSummary | null;
@@ -161,10 +170,12 @@ function CheckoutSummaryPanel({ summary }: { summary: StripeCheckoutSummary | nu
 
 function CheckoutElementForm({
 	onComplete,
+	onExpired,
 	onLoadError,
 	onSubmittingChange,
 }: {
-	onComplete: () => void;
+	onComplete: (paymentStatus: StripeCheckoutPaymentStatus) => void;
+	onExpired: () => void;
 	onLoadError: (message: string) => void;
 	onSubmittingChange: (submitting: boolean) => void;
 }) {
@@ -173,7 +184,21 @@ function CheckoutElementForm({
 	const [takingLong, setTakingLong] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const submittingRef = useRef(false);
+	const settledRef = useRef(false);
 	const loadErrorMessage = checkoutState.type === "error" ? checkoutState.error.message : null;
+	const checkout = checkoutState.type === "success" ? checkoutState.checkout : null;
+	const settleOnce = useCallback(
+		(status: StripeCheckoutStatus): boolean => {
+			if (settledRef.current) return true;
+			const paymentStatus = completedCheckoutPaymentStatus(status);
+			if (!paymentStatus && status.type !== "expired") return false;
+			settledRef.current = true;
+			if (paymentStatus) onComplete(paymentStatus);
+			else onExpired();
+			return true;
+		},
+		[onComplete, onExpired],
+	);
 
 	function finishSubmitting() {
 		submittingRef.current = false;
@@ -191,6 +216,10 @@ function CheckoutElementForm({
 	useEffect(() => {
 		if (loadErrorMessage) onLoadError(loadErrorMessage);
 	}, [loadErrorMessage, onLoadError]);
+
+	useEffect(() => {
+		if (checkout) settleOnce(checkout.status);
+	}, [checkout, settleOnce]);
 
 	if (checkoutState.type === "loading") {
 		return (
@@ -215,25 +244,22 @@ function CheckoutElementForm({
 		);
 	}
 
-	const { checkout } = checkoutState;
+	const { checkout: readyCheckout } = checkoutState;
 
 	async function confirmCheckout() {
-		if (submittingRef.current || !checkout.canConfirm) return;
+		if (submittingRef.current || !readyCheckout.canConfirm) return;
 		submittingRef.current = true;
 		setSubmitting(true);
 		onSubmittingChange(true);
 		setError(null);
 		try {
-			const result = await checkout.confirm({ redirect: "if_required" });
+			const result = await readyCheckout.confirm({ redirect: "if_required" });
 			if (result.type === "error") {
 				setError(result.error.message || "We could not confirm this payment. Please try again.");
 				finishSubmitting();
 				return;
 			}
-			if (result.session.status.type === "complete") {
-				onComplete();
-				return;
-			}
+			if (settleOnce(result.session.status)) return;
 			setError("Stripe needs another step before this checkout can finish.");
 			finishSubmitting();
 		} catch {
@@ -266,7 +292,7 @@ function CheckoutElementForm({
 				<Button
 					type="button"
 					onClick={confirmCheckout}
-					disabled={submitting || !checkout.canConfirm}
+					disabled={submitting || !readyCheckout.canConfirm}
 				>
 					{submitting ? (
 						<>
@@ -285,6 +311,7 @@ export function StripeCheckoutDialog({
 	clientSecret,
 	description,
 	onComplete,
+	onExpired,
 	onOpenChange,
 	open,
 	summary,
@@ -303,19 +330,21 @@ export function StripeCheckoutDialog({
 		emptyValue: { clientSecret: null, description: "", summary: null, title: "" },
 	});
 	const appearance = useCheckoutAppearance(open);
-	const onCompleteRef = useRef(onComplete);
-
-	useEffect(() => {
-		onCompleteRef.current = onComplete;
-	}, [onComplete]);
 
 	const renderedCheckout = exit.renderedValue;
 	const renderedClientSecret = renderedCheckout.clientSecret;
 
-	const completeCheckout = useCallback(() => {
+	const completeCheckout = useCallback(
+		(paymentStatus: StripeCheckoutPaymentStatus) => {
+			exit.beginClose();
+			onComplete(paymentStatus);
+		},
+		[exit.beginClose, onComplete],
+	);
+	const expireCheckout = useCallback(() => {
 		exit.beginClose();
-		onCompleteRef.current();
-	}, [exit.beginClose]);
+		onExpired();
+	}, [exit.beginClose, onExpired]);
 
 	const handleProviderLoadError = useCallback(() => {
 		setState("error");
@@ -413,6 +442,7 @@ export function StripeCheckoutDialog({
 					>
 						<CheckoutElementForm
 							onComplete={completeCheckout}
+							onExpired={expireCheckout}
 							onLoadError={handleProviderLoadError}
 							onSubmittingChange={setCheckoutSubmitting}
 						/>

--- a/apps/web/src/hosted/billing/components/stripe-checkout.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/stripe-checkout.logic.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import type { StripeCheckoutStatus } from "@stripe/stripe-js";
 import type { CheckoutOperationResult } from "@/hosted/billing/billing-client";
 import {
 	CHECKOUT_ELEMENTS_UI_MODE,
 	checkoutRedirectUrl,
 	checkoutSessionClientSecret,
 	checkoutUiModeForPublishableKey,
+	completedCheckoutPaymentStatus,
 } from "@/hosted/billing/components/stripe-checkout.logic";
 
 describe("stripe checkout logic", () => {
@@ -40,6 +42,22 @@ describe("stripe checkout logic", () => {
 
 	test("documents the checkout elements ui mode for the installed Stripe SDK", () => {
 		expect(CHECKOUT_ELEMENTS_UI_MODE).toBe("custom");
+	});
+
+	test("reads payment settlement only from a completed Checkout Session", () => {
+		const cases: ReadonlyArray<
+			[StripeCheckoutStatus, ReturnType<typeof completedCheckoutPaymentStatus>]
+		> = [
+			[{ type: "open" }, null],
+			[{ type: "expired" }, null],
+			[{ type: "complete", paymentStatus: "paid" }, "paid"],
+			[{ type: "complete", paymentStatus: "unpaid" }, "unpaid"],
+			[{ type: "complete", paymentStatus: "no_payment_required" }, "no_payment_required"],
+		];
+
+		for (const [status, expected] of cases) {
+			expect(completedCheckoutPaymentStatus(status)).toBe(expected);
+		}
 	});
 
 	test("starts with hosted Checkout when Stripe.js cannot be configured", () => {

--- a/apps/web/src/hosted/billing/components/stripe-checkout.logic.ts
+++ b/apps/web/src/hosted/billing/components/stripe-checkout.logic.ts
@@ -1,9 +1,21 @@
+import type { StripeCheckoutStatus } from "@stripe/stripe-js";
 import type { CheckoutOperationResult } from "@/hosted/billing/billing-client";
 
 export { checkoutSessionClientSecret } from "@/hosted/billing/stripe-client-secret";
 
 export const CHECKOUT_ELEMENTS_UI_MODE = "custom";
 export const HOSTED_CHECKOUT_UI_MODE = "hosted";
+
+export type StripeCheckoutPaymentStatus = Extract<
+	StripeCheckoutStatus,
+	{ type: "complete" }
+>["paymentStatus"];
+
+export function completedCheckoutPaymentStatus(
+	status: StripeCheckoutStatus,
+): StripeCheckoutPaymentStatus | null {
+	return status.type === "complete" ? status.paymentStatus : null;
+}
 
 export function checkoutUiModeForPublishableKey(
 	publishableKey: string | undefined,

--- a/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.test.ts
+++ b/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.test.ts
@@ -108,6 +108,7 @@ describe("accepted deployment navigation", () => {
 				events.push(`get:${deploymentId}`);
 				return authoritative;
 			},
+			onAccepted: () => events.push("accepted"),
 			navigate: async () => {
 				events.push("navigate");
 				expect(queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments)).toEqual([
@@ -124,7 +125,12 @@ describe("accepted deployment navigation", () => {
 		for (let turn = 0; turn < 10 && !events.includes("navigate"); turn += 1) {
 			await Promise.resolve();
 		}
-		expect(events).toEqual(["resolve:checkout/stable:key", "get:hdep_from_request", "navigate"]);
+		expect(events).toEqual([
+			"resolve:checkout/stable:key",
+			"accepted",
+			"get:hdep_from_request",
+			"navigate",
+		]);
 		expect(settled).toBe(false);
 
 		navigationGate.resolve();

--- a/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.ts
+++ b/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.ts
@@ -63,12 +63,15 @@ export async function navigateToAcceptedDeployment({
 /** Resolve the durable checkout lineage, then reuse the canonical deployment handoff. */
 export async function navigateToAcceptedDeploymentRequest({
 	deployRequestId,
+	onAccepted,
 	resolveDeploymentRequest,
 	...navigation
 }: Omit<Parameters<typeof navigateToAcceptedDeployment>[0], "deploymentId"> & {
 	deployRequestId: string;
+	onAccepted?: () => void;
 	resolveDeploymentRequest: AcceptedDeploymentRequestResolver;
 }): Promise<void> {
 	const { deploymentId } = await resolveDeploymentRequest(deployRequestId);
+	onAccepted?.();
 	await navigateToAcceptedDeployment({ ...navigation, deploymentId });
 }

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -370,7 +370,6 @@ describe("deploy acceptance", () => {
 		expect(wizardSource).toContain(
 			"const lastSuccessfulSubscriptionQuote = subscriptionCreateQuote.data ?? null;",
 		);
-		expect(wizardSource.match(/quote: lastSuccessfulSubscriptionQuote/g)).toHaveLength(2);
 		expect(wizardSource).toContain(
 			"submitting || lastSuccessfulSubscriptionQuote ? null : subscriptionCreateQuote.error;",
 		);

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -370,7 +370,7 @@ describe("deploy acceptance", () => {
 		expect(wizardSource).toContain(
 			"const lastSuccessfulSubscriptionQuote = subscriptionCreateQuote.data ?? null;",
 		);
-		expect(wizardSource.match(/quote: lastSuccessfulSubscriptionQuote/g)).toHaveLength(3);
+		expect(wizardSource.match(/quote: lastSuccessfulSubscriptionQuote/g)).toHaveLength(2);
 		expect(wizardSource).toContain(
 			"submitting || lastSuccessfulSubscriptionQuote ? null : subscriptionCreateQuote.error;",
 		);

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -241,18 +241,6 @@ describe("first Basic agent copy", () => {
 		expect(wizardSource).toContain("toast.dismiss(WALLET_PAYMENT_TOAST_ID)");
 	});
 
-	test("keeps accepted hydration quiet while preserving pre-acceptance long waits", () => {
-		expect(wizardSource).toContain('setSubmitBusyLabel("Loading agent details…");');
-		expect(wizardSource).toContain("setSubmitTakingLongCopy(null);");
-		expect(wizardSource).toContain("{submitTakingLong && submitTakingLongCopy ? (");
-		expect(wizardSource).not.toContain(
-			"Your deployment was accepted. Keep this page open while we load its committed details.",
-		);
-		expect(wizardSource).toContain(
-			"Secure checkout is still opening. No payment has been submitted yet; keep this page open to continue.",
-		);
-	});
-
 	test("keeps infrastructure vocabulary out of customer copy", () => {
 		expect(providerFieldsFormSource).toContain("Agent environment variable");
 		expect(providerFieldsFormSource).not.toContain("Runtime mapping");

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -241,6 +241,18 @@ describe("first Basic agent copy", () => {
 		expect(wizardSource).toContain("toast.dismiss(WALLET_PAYMENT_TOAST_ID)");
 	});
 
+	test("keeps accepted hydration quiet while preserving pre-acceptance long waits", () => {
+		expect(wizardSource).toContain('setSubmitBusyLabel("Loading agent details…");');
+		expect(wizardSource).toContain("setSubmitTakingLongCopy(null);");
+		expect(wizardSource).toContain("{submitTakingLong && submitTakingLongCopy ? (");
+		expect(wizardSource).not.toContain(
+			"Your deployment was accepted. Keep this page open while we load its committed details.",
+		);
+		expect(wizardSource).toContain(
+			"Secure checkout is still opening. No payment has been submitted yet; keep this page open to continue.",
+		);
+	});
+
 	test("keeps infrastructure vocabulary out of customer copy", () => {
 		expect(providerFieldsFormSource).toContain("Agent environment variable");
 		expect(providerFieldsFormSource).not.toContain("Runtime mapping");

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -53,6 +53,7 @@ import {
 	checkoutRedirectUrl,
 	checkoutSessionClientSecret,
 	checkoutUiModeForPublishableKey,
+	type StripeCheckoutPaymentStatus,
 } from "@/hosted/billing/components/stripe-checkout.logic";
 import {
 	StripeCheckoutDialog,
@@ -103,6 +104,7 @@ import {
 } from "@/hosted/billing/deploy/language-timezone-controls";
 import {
 	billingErrorNormalizer,
+	deploymentRequestTerminalOutcome,
 	deploySubmissionErrorPresentation,
 	isIdempotencyKeyReusedError,
 	normalizeBillingError,
@@ -117,6 +119,7 @@ import {
 } from "@/hosted/billing/hooks";
 import {
 	forgetIdempotencyAttempt,
+	forgetIdempotencyAttemptByKey,
 	type IdempotencyAttempt,
 	idempotencyAttemptFor,
 	idempotencyFingerprint,
@@ -125,7 +128,6 @@ import {
 import { useSensitiveCreateSubscription } from "@/hosted/billing/sensitive-actions";
 import type { CheckoutSessionClientSecret } from "@/hosted/billing/stripe-client-secret";
 import {
-	type SubscriptionCreateRequestView,
 	type SubscriptionCreateSelection,
 	supportedBillingTerm,
 } from "@/hosted/billing/subscription/subscription-create-adapter";
@@ -178,13 +180,17 @@ type Compute = "basic" | "performance";
 type DeployPaymentMethod = "card" | "wallet";
 type NativeDeployCheckout = {
 	clientSecret: CheckoutSessionClientSecret;
-	request: SubscriptionCreateRequestView;
+	requestKey: string;
 	summary: StripeCheckoutSummary;
 	tierLabel: "Basic" | "Performance";
 };
 type AcceptedDeploymentRecovery = {
 	replace: boolean;
 	target: CheckoutReturnNavigationTarget;
+};
+type DeploymentRequestProgress = {
+	busyLabel: string;
+	takingLongCopy: string;
 };
 type PaidDeploySelection = {
 	billingTermMonths: number;
@@ -196,6 +202,29 @@ type PaidDeploySelection = {
 const DEPLOY_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 const WALLET_PAYMENT_TOAST_ID = "agent-create-wallet-payment";
 const WALLET_PAYMENT_TOAST_DURATION_MS = 8_000;
+const DEFAULT_DEPLOYMENT_REQUEST_PROGRESS: DeploymentRequestProgress = {
+	busyLabel: "Finishing checkout…",
+	takingLongCopy:
+		"Checkout is complete and agent creation is still starting. Keep this page open; we’ll take you to your agent as soon as its page is available.",
+};
+
+function checkoutDeploymentRequestProgress(
+	paymentStatus: StripeCheckoutPaymentStatus,
+): DeploymentRequestProgress {
+	if (paymentStatus === "unpaid") {
+		return {
+			busyLabel: "Waiting for payment…",
+			takingLongCopy:
+				"Stripe is still processing your payment. Agent creation will start after payment is confirmed.",
+		};
+	}
+	if (paymentStatus === "no_payment_required") return DEFAULT_DEPLOYMENT_REQUEST_PROGRESS;
+	return {
+		busyLabel: "Creating agent…",
+		takingLongCopy:
+			"Payment was confirmed and agent creation is still starting. Keep this page open; we’ll take you to your agent as soon as its page is available.",
+	};
+}
 
 function showWalletPaymentConfirmation(amount: string) {
 	toast.success("Wallet payment confirmed", {
@@ -315,28 +344,47 @@ export function DeployWizard() {
 	const queryClient = useQueryClient();
 	const billingClient = useBillingClient();
 	const resolveDeploymentRequest = useResolveDeploymentRequest().mutateAsync;
+	const checkoutAttemptRef = useRef<IdempotencyAttempt | null>(null);
+	const clearCheckoutAttempt = useCallback((requestKey: string) => {
+		forgetIdempotencyAttemptByKey("subscription-checkout", requestKey);
+		if (checkoutAttemptRef.current?.key === requestKey) checkoutAttemptRef.current = null;
+	}, []);
 	const [acceptedDeploymentRecovery, setAcceptedDeploymentRecovery] =
 		useState<AcceptedDeploymentRecovery | null>(null);
 	const acceptanceNavigatingRef = useRef(false);
 	const acceptDeployment = useCallback(
-		async (target: CheckoutReturnNavigationTarget, replace = false): Promise<boolean> => {
+		async (
+			target: CheckoutReturnNavigationTarget,
+			replace = false,
+			requestProgress: DeploymentRequestProgress = DEFAULT_DEPLOYMENT_REQUEST_PROGRESS,
+		): Promise<boolean> => {
 			setAcceptedDeploymentRecovery(null);
-			setSubmitBusyLabel("Loading agent details…");
-			setSubmitTakingLongCopy(null);
+			setSubmitBusyLabel(
+				target.kind === "deploy_request" ? requestProgress.busyLabel : "Loading agent details…",
+			);
+			setSubmitTakingLongCopy(
+				target.kind === "deploy_request" ? requestProgress.takingLongCopy : null,
+			);
 			setSubmitTakingLong(false);
 			setSubmitting(true);
 			acceptanceNavigatingRef.current = true;
+			const navigation = {
+				getDeployment: billingClient.getDeployment,
+				navigate: (options: { href: string; replace: boolean }) => router.navigate(options),
+				queryClient,
+				replace,
+			};
 			try {
-				const navigation = {
-					getDeployment: billingClient.getDeployment,
-					navigate: (options: { href: string; replace: boolean }) => router.navigate(options),
-					queryClient,
-					replace,
-				};
 				if (target.kind === "deploy_request") {
 					await navigateToAcceptedDeploymentRequest({
 						...navigation,
 						deployRequestId: target.deployRequestId,
+						onAccepted: () => {
+							clearCheckoutAttempt(target.deployRequestId);
+							setSubmitBusyLabel("Loading agent details…");
+							setSubmitTakingLongCopy(null);
+							setSubmitTakingLong(false);
+						},
 						resolveDeploymentRequest,
 					});
 				} else {
@@ -346,15 +394,56 @@ export function DeployWizard() {
 					});
 				}
 				return true;
-			} catch {
+			} catch (error) {
 				acceptanceNavigatingRef.current = false;
-				setAcceptedDeploymentRecovery({ replace, target });
+				const terminalOutcome = deploymentRequestTerminalOutcome(error);
+				if (target.kind === "deploy_request" && terminalOutcome) {
+					clearCheckoutAttempt(target.deployRequestId);
+					if (terminalOutcome.kind === "open_deployment") {
+						const deploymentTarget = {
+							kind: "deployment",
+							deploymentId: terminalOutcome.deploymentId,
+						} as const;
+						acceptanceNavigatingRef.current = true;
+						try {
+							await navigateToAcceptedDeployment({
+								...navigation,
+								deploymentId: deploymentTarget.deploymentId,
+							});
+							return true;
+						} catch {
+							acceptanceNavigatingRef.current = false;
+							setAcceptedDeploymentRecovery({ replace, target: deploymentTarget });
+						}
+					} else {
+						toast.error(terminalOutcome.title, {
+							description: terminalOutcome.description,
+						});
+						if (terminalOutcome.kind === "review_agents") {
+							acceptanceNavigatingRef.current = true;
+							try {
+								await router.navigate({ href: "/agents", replace });
+								return true;
+							} catch {
+								acceptanceNavigatingRef.current = false;
+							}
+						}
+					}
+				} else {
+					setAcceptedDeploymentRecovery({ replace, target });
+				}
 				setSubmitting(false);
 				setSubmitTakingLong(false);
 				return false;
 			}
 		},
-		[billingClient.getDeployment, queryClient, resolveDeploymentRequest, router],
+		[
+			billingClient.getDeployment,
+			clearCheckoutAttempt,
+			queryClient,
+			resolveDeploymentRequest,
+			router,
+		],
 	);
 	const navigateCheckoutReturn = useCallback(
 		async (target: CheckoutReturnNavigationTarget) => {
@@ -373,7 +462,6 @@ export function DeployWizard() {
 	const aiProviders = useUserAiProviders();
 	const createSubscription = useSensitiveCreateSubscription();
 	const runAction = useActionLock();
-	const checkoutAttemptRef = useRef<IdempotencyAttempt | null>(null);
 	const walletCreateAttemptRef = useRef<IdempotencyAttempt | null>(null);
 	const includedCreateAttemptRef = useRef<IdempotencyAttempt | null>(null);
 	const agentNameEditedRef = useRef(false);
@@ -704,35 +792,25 @@ export function DeployWizard() {
 		return false;
 	}
 
-	async function navigateToReusedSubscription({ deploymentId }: { deploymentId: string }) {
+	async function handleCheckoutComplete(
+		requestKey: string,
+		paymentStatus: StripeCheckoutPaymentStatus,
+	) {
 		setCheckoutSession(null);
-		await acceptDeployment({ kind: "deployment", deploymentId });
-	}
-	async function handleCheckoutComplete(request: SubscriptionCreateRequestView) {
-		setCheckoutSession(null);
-		setSubmitTakingLong(false);
-		setSubmitBusyLabel("Creating agent…");
-		setSubmitTakingLongCopy(
-			"Payment was confirmed and agent creation is still starting. Keep this page open; we’ll take you to your agent as soon as its page is available.",
+		await acceptDeployment(
+			{ kind: "deploy_request", deployRequestId: requestKey },
+			true,
+			checkoutDeploymentRequestProgress(paymentStatus),
 		);
-		setSubmitting(true);
-		try {
-			const requestFingerprint = idempotencyFingerprint({
-				selection: request.selection,
-				target: request.target,
-			});
-			const accepted = await acceptDeployment(
-				{ kind: "deploy_request", deployRequestId: request.idempotencyKey },
-				true,
-			);
-			if (accepted) {
-				forgetIdempotencyAttempt("subscription-checkout", requestFingerprint);
-				checkoutAttemptRef.current = null;
-			}
-		} finally {
-			setSubmitting(false);
-			setSubmitTakingLong(false);
-		}
+	}
+
+	function handleCheckoutExpired(requestKey: string) {
+		setCheckoutSession(null);
+		clearCheckoutAttempt(requestKey);
+		setSubmitTakingLong(false);
+		toast.error("Checkout expired", {
+			description: "This secure checkout can no longer be used. Start a new checkout to try again.",
+		});
 	}
 
 	async function onDeploy() {
@@ -839,7 +917,7 @@ export function DeployWizard() {
 				if (outcome.flowType === "subscription_activation") {
 					forgetIdempotencyAttempt("subscription-checkout", checkoutFingerprint);
 					checkoutAttemptRef.current = null;
-					await navigateToReusedSubscription(outcome);
+					await acceptDeployment({ kind: "deployment", deploymentId: outcome.deploymentId });
 					return;
 				}
 				const result = outcome.checkout;
@@ -847,13 +925,7 @@ export function DeployWizard() {
 				if (cardCheckoutUiMode === CHECKOUT_ELEMENTS_UI_MODE && clientSecret) {
 					setCheckoutSession({
 						clientSecret,
-						request: {
-							selection,
-							target,
-							uiMode: cardCheckoutUiMode,
-							idempotencyKey: checkoutAttemptRef.current.key,
-							quote: lastSuccessfulSubscriptionQuote,
-						},
+						requestKey: checkoutAttemptRef.current.key,
 						summary: computeCheckoutSummary({
 							offer: paidSelection.offer,
 							plan: paidSelection.plan,
@@ -951,6 +1023,22 @@ export function DeployWizard() {
 		: walletTopUpAction
 			? submitting || !wallet.data
 			: !canSubmit;
+	const primaryActionOnClick = acceptedDeploymentRecovery
+		? () =>
+				void acceptDeployment(acceptedDeploymentRecovery.target, acceptedDeploymentRecovery.replace)
+		: walletTopUpAction
+			? () => walletTopUp.show(walletShortfallUsd)
+			: undefined;
+	const PrimaryActionIcon = submitting
+		? Spinner
+		: acceptedDeploymentHydrationFailed
+			? RefreshCw
+			: Rocket;
+	const primaryActionLabel = submitting
+		? submitBusyLabel
+		: acceptedDeploymentHydrationFailed
+			? "Retry opening agent"
+			: deployLabel;
 	const amountExplainsBlocking =
 		paidSelection !== null &&
 		paymentMethod === "wallet" &&
@@ -1498,31 +1586,11 @@ export function DeployWizard() {
 									aria-describedby={
 										visibleSubmitBlockingReason ? "deploy-blocking-reason" : undefined
 									}
-									onClick={
-										acceptedDeploymentHydrationFailed && acceptedDeploymentRecovery
-											? () =>
-													void acceptDeployment(
-														acceptedDeploymentRecovery.target,
-														acceptedDeploymentRecovery.replace,
-													)
-											: walletTopUpAction
-												? () => walletTopUp.show(walletShortfallUsd)
-												: undefined
-									}
+									onClick={primaryActionOnClick}
 									className="w-full shrink-0 @2xl/main:w-auto"
 								>
-									{submitting ? (
-										<Spinner data-icon="inline-start" />
-									) : acceptedDeploymentHydrationFailed ? (
-										<RefreshCw data-icon="inline-start" />
-									) : (
-										<Rocket data-icon="inline-start" />
-									)}
-									{submitting
-										? submitBusyLabel
-										: acceptedDeploymentHydrationFailed
-											? "Retry opening agent"
-											: deployLabel}
+									<PrimaryActionIcon data-icon="inline-start" />
+									{primaryActionLabel}
 								</Button>
 								{submitTakingLong && submitTakingLongCopy ? (
 									<p
@@ -1572,8 +1640,13 @@ export function DeployWizard() {
 				title={`Complete ${checkoutSession?.tierLabel ?? "compute"} checkout`}
 				description="Enter payment details without leaving this page. Redirect-based payment methods return here after confirmation."
 				summary={checkoutSession?.summary ?? null}
-				onComplete={() => {
-					if (checkoutSession) void handleCheckoutComplete(checkoutSession.request);
+				onComplete={(paymentStatus) => {
+					if (checkoutSession) {
+						void handleCheckoutComplete(checkoutSession.requestKey, paymentStatus);
+					}
+				}}
+				onExpired={() => {
+					if (checkoutSession) handleCheckoutExpired(checkoutSession.requestKey);
 				}}
 			/>
 		</div>

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -1023,22 +1023,6 @@ export function DeployWizard() {
 		: walletTopUpAction
 			? submitting || !wallet.data
 			: !canSubmit;
-	const primaryActionOnClick = acceptedDeploymentRecovery
-		? () =>
-				void acceptDeployment(acceptedDeploymentRecovery.target, acceptedDeploymentRecovery.replace)
-		: walletTopUpAction
-			? () => walletTopUp.show(walletShortfallUsd)
-			: undefined;
-	const PrimaryActionIcon = submitting
-		? Spinner
-		: acceptedDeploymentHydrationFailed
-			? RefreshCw
-			: Rocket;
-	const primaryActionLabel = submitting
-		? submitBusyLabel
-		: acceptedDeploymentHydrationFailed
-			? "Retry opening agent"
-			: deployLabel;
 	const amountExplainsBlocking =
 		paidSelection !== null &&
 		paymentMethod === "wallet" &&
@@ -1586,11 +1570,31 @@ export function DeployWizard() {
 									aria-describedby={
 										visibleSubmitBlockingReason ? "deploy-blocking-reason" : undefined
 									}
-									onClick={primaryActionOnClick}
+									onClick={
+										acceptedDeploymentHydrationFailed && acceptedDeploymentRecovery
+											? () =>
+													void acceptDeployment(
+														acceptedDeploymentRecovery.target,
+														acceptedDeploymentRecovery.replace,
+													)
+											: walletTopUpAction
+												? () => walletTopUp.show(walletShortfallUsd)
+												: undefined
+									}
 									className="w-full shrink-0 @2xl/main:w-auto"
 								>
-									<PrimaryActionIcon data-icon="inline-start" />
-									{primaryActionLabel}
+									{submitting ? (
+										<Spinner data-icon="inline-start" />
+									) : acceptedDeploymentHydrationFailed ? (
+										<RefreshCw data-icon="inline-start" />
+									) : (
+										<Rocket data-icon="inline-start" />
+									)}
+									{submitting
+										? submitBusyLabel
+										: acceptedDeploymentHydrationFailed
+											? "Retry opening agent"
+											: deployLabel}
 								</Button>
 								{submitTakingLong && submitTakingLongCopy ? (
 									<p

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -807,7 +807,6 @@ export function DeployWizard() {
 	function handleCheckoutExpired(requestKey: string) {
 		setCheckoutSession(null);
 		clearCheckoutAttempt(requestKey);
-		setSubmitTakingLong(false);
 		toast.error("Checkout expired", {
 			description: "This secure checkout can no longer be used. Start a new checkout to try again.",
 		});

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -322,9 +322,7 @@ export function DeployWizard() {
 		async (target: CheckoutReturnNavigationTarget, replace = false): Promise<boolean> => {
 			setAcceptedDeploymentRecovery(null);
 			setSubmitBusyLabel("Loading agent details…");
-			setSubmitTakingLongCopy(
-				"Your deployment was accepted. Keep this page open while we load its committed details.",
-			);
+			setSubmitTakingLongCopy(null);
 			setSubmitTakingLong(false);
 			setSubmitting(true);
 			acceptanceNavigatingRef.current = true;
@@ -391,7 +389,7 @@ export function DeployWizard() {
 	const [submitting, setSubmitting] = useState(false);
 	const [submitTakingLong, setSubmitTakingLong] = useState(false);
 	const [submitBusyLabel, setSubmitBusyLabel] = useState("Creating agent…");
-	const [submitTakingLongCopy, setSubmitTakingLongCopy] = useState(
+	const [submitTakingLongCopy, setSubmitTakingLongCopy] = useState<string | null>(
 		"Agent creation is still starting. Keep this page open; we’ll take you to your agent as soon as its page is available.",
 	);
 	const [paymentMethod, setPaymentMethod] = useState<DeployPaymentMethod>("card");
@@ -1526,7 +1524,7 @@ export function DeployWizard() {
 											? "Retry opening agent"
 											: deployLabel}
 								</Button>
-								{submitTakingLong ? (
+								{submitTakingLong && submitTakingLongCopy ? (
 									<p
 										className="max-w-sm text-xs text-muted-foreground @2xl/main:text-right"
 										role="status"

--- a/apps/web/src/hosted/billing/errors.test.ts
+++ b/apps/web/src/hosted/billing/errors.test.ts
@@ -3,6 +3,8 @@ import {
 	BillingApiError,
 	BillingNetworkError,
 	billingQueryRetry,
+	DeploymentRequestTerminalError,
+	deploymentRequestTerminalOutcome,
 	deploySubmissionErrorPresentation,
 	isAuthError,
 	isForbiddenError,
@@ -214,5 +216,48 @@ describe("deploySubmissionErrorPresentation", () => {
 		expect(presentation.title).toBe("Payment and creation didn’t start");
 		expect(presentation.description).toContain("No Wallet payment was made");
 		expect(presentation.description).not.toContain("internal validation trace");
+	});
+});
+
+describe("deployment request terminal outcome", () => {
+	test("distinguishes a new attempt, superseded review, and existing deployment", () => {
+		const withoutLineage = deploymentRequestTerminalOutcome(
+			new DeploymentRequestTerminalError(
+				{
+					deploy_request_id: "checkout-expired",
+					request_status: "expired",
+					lineage_tail: null,
+				},
+				"expired",
+			),
+		);
+		const superseded = deploymentRequestTerminalOutcome(
+			new DeploymentRequestTerminalError(
+				{
+					deploy_request_id: "checkout-superseded",
+					request_status: "superseded",
+					lineage_tail: null,
+				},
+				"superseded",
+			),
+		);
+		const withLineage = deploymentRequestTerminalOutcome(
+			new DeploymentRequestTerminalError(
+				{
+					deploy_request_id: "checkout-failed",
+					request_status: "failed",
+					lineage_tail: {
+						deployment_id: "hdep_failed",
+						lineage_version: 1,
+						lineage_state: "failed",
+					},
+				},
+				"failed",
+			),
+		);
+
+		expect(withoutLineage?.kind).toBe("new_attempt");
+		expect(superseded?.kind).toBe("review_agents");
+		expect(withLineage).toEqual({ kind: "open_deployment", deploymentId: "hdep_failed" });
 	});
 });

--- a/apps/web/src/hosted/billing/errors.ts
+++ b/apps/web/src/hosted/billing/errors.ts
@@ -10,6 +10,7 @@
  */
 
 import { toast } from "sonner";
+import type { HostedDeployRequestStatus } from "@/hosted/billing/contracts";
 
 export class BillingApiError extends Error {
 	constructor(
@@ -53,9 +54,49 @@ export class DeploymentConflictError extends Error {
 	}
 }
 
-/** A checkout-funded deploy request reached a terminal state before acceptance. */
+/** A checkout-funded deploy request reached an explicit terminal state. */
 export class DeploymentRequestTerminalError extends BillingApiError {
 	override name = "DeploymentRequestTerminalError";
+
+	constructor(
+		public readonly request: HostedDeployRequestStatus,
+		detail: string,
+	) {
+		super(409, detail, request);
+	}
+}
+
+export type DeploymentRequestTerminalOutcome =
+	| { kind: "open_deployment"; deploymentId: string }
+	| {
+			kind: "new_attempt" | "review_agents";
+			title: string;
+			description: string;
+	  };
+
+export function deploymentRequestTerminalOutcome(
+	error: unknown,
+): DeploymentRequestTerminalOutcome | null {
+	if (!(error instanceof DeploymentRequestTerminalError)) return null;
+	const requestStatus = error.request.request_status;
+	const deploymentId = error.request.lineage_tail?.deployment_id?.trim();
+	if (deploymentId) {
+		return { kind: "open_deployment", deploymentId };
+	}
+	if (requestStatus === "superseded") {
+		return {
+			kind: "review_agents",
+			title: "Checkout was replaced",
+			description:
+				"A newer checkout attempt replaced this agent request. Review your agents before starting another checkout.",
+		};
+	}
+	return {
+		kind: "new_attempt",
+		title: requestStatus === "expired" ? "Agent request expired" : "Agent creation failed",
+		description:
+			"No agent was accepted from this checkout. Review your choices and start a new checkout when you’re ready.",
+	};
 }
 
 /** A plan change remains nonterminal after the bounded foreground poll. */

--- a/apps/web/src/hosted/billing/idempotency.test.ts
+++ b/apps/web/src/hosted/billing/idempotency.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
 	forgetIdempotencyAttempt,
+	forgetIdempotencyAttemptByKey,
 	IDEMPOTENCY_ATTEMPT_TTL_MS,
 	idempotencyAttemptFor,
 	idempotencyFingerprint,
@@ -200,5 +201,17 @@ describe("idempotencyAttemptFor", () => {
 
 		expect(first.key).toBe("wallet-deploy-1");
 		expect(next.key).toBe("wallet-deploy-2");
+	});
+
+	test("forgets a persisted attempt by its durable request key", () => {
+		const storage = new MemoryStorage();
+		let counter = 0;
+		const mint = (prefix: string) => `${prefix}-${++counter}`;
+		const first = idempotencyAttemptFor(null, "checkout", "same", mint, { storage });
+
+		forgetIdempotencyAttemptByKey("checkout", first.key, { storage });
+		const next = idempotencyAttemptFor(null, "checkout", "same", mint, { storage });
+
+		expect(next.key).toBe("checkout-2");
 	});
 });

--- a/apps/web/src/hosted/billing/idempotency.ts
+++ b/apps/web/src/hosted/billing/idempotency.ts
@@ -188,3 +188,24 @@ export function forgetIdempotencyAttempt(
 	delete attempts[entryKey];
 	writeStoredAttempts(storage, attempts);
 }
+
+/** Remove a finished attempt when only its durable request key is available. */
+export function forgetIdempotencyAttemptByKey(
+	prefix: string,
+	key: string,
+	options: IdempotencyPersistenceOptions = {},
+): void {
+	const storage = options.storage === undefined ? browserSessionStorage() : options.storage;
+	if (!storage) return;
+	const now = options.now?.() ?? Date.now();
+	const ttlMs = options.ttlMs ?? IDEMPOTENCY_ATTEMPT_TTL_MS;
+	const attempts = readStoredAttempts(storage, now, ttlMs);
+	if (!attempts) return;
+	const entryPrefix = `${prefix}:`;
+	const entry = Object.entries(attempts).find(
+		([entryKey, attempt]) => entryKey.startsWith(entryPrefix) && attempt.key === key,
+	);
+	if (!entry) return;
+	delete attempts[entry[0]];
+	writeStoredAttempts(storage, attempts);
+}


### PR DESCRIPTION
## Summary
- remove the accepted-deployment wait message while retaining quiet loading during authoritative hydration
- resume already-complete embedded Checkout sessions exactly once and reset expired sessions for a fresh attempt
- preserve Stripe’s exact `paid`, `unpaid`, and `no_payment_required` semantics in post-checkout progress
- bound deploy-request polling by both a 120-second wall-clock deadline and a request-count cap, including in-flight aborts
- route terminal deploy requests by durable lineage: open an accepted deployment, allow a new pre-acceptance attempt, or return superseded attempts to Agents
- clear the persisted checkout attempt as soon as the durable request is accepted or terminal

The backend latency fix is in Clawdi-AI/clawdi-hosted#1657. Stripe confirmation was already durable; the avoidable delay was the backend lifecycle consumer waiting for its 30-second periodic wakeup.

## Verification
- Docker clean runner: complete web suite passed (typecheck, all web tests, OSS production build)
- Biome on all changed files: passed
- `git diff --check`: passed

A live Stripe browser E2E was not run because it requires a configured hosted backend and Checkout account. Coverage stays focused on the Stripe SDK status union, exactly-once settlement logic, deadline/abort behavior, terminal routing, accepted handoff ordering, and durable idempotency cleanup.