### PR TITLE
fix(cli): converge managed gateway token

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -33,15 +33,17 @@ The public contract covers:
 - installing or verifying supported agent runtimes through their normal
   installers;
 - writing non-secret local run configuration;
-- projecting short-lived secrets only for the current runtime session;
+- projecting runtime secrets only onto their declared runtime surfaces,
+  including the OpenClaw gateway's official config and transient installer
+  environment;
 - running final hosted runtimes from direct process-manager entries that name
   official Hermes/OpenClaw binaries;
 - running Clawdi-owned support programs under the runtime process manager;
 - supporting explicit `clawdi run -- <command>` when a caller opts into Clawdi
   runtime env injection;
 - exposing strict-v2 OpenClaw directly on its native `18789` gateway with
-  official token and device authentication when the typed authorization
-  capability is active;
+  official shared-token authentication and no device-pairing step when the
+  typed authorization capability is active;
 - exposing a dashboard Terminal contract for one deployment shell;
 - reporting status and diagnostics through runtime commands.
 
@@ -532,7 +534,7 @@ Normalization maps hosted fields into the internal shape:
 | `runtime` | Required selected compute runtime; exactly one enabled `openclaw` or `hermes` entry must match it |
 | `locale.language`, `locale.timezone` | Required supported language and valid IANA timezone |
 | `system.openclawControlUiAllowedOrigins` | Strict-v2 OpenClaw public origin allowlist |
-| `system.openclawGatewayAuth` | Strict-v2 OpenClaw token and required device-auth capability; the token itself is an environment secret reference |
+| `system.openclawGatewayAuth` | Strict-v2 OpenClaw token and required native shared-token capability; the token itself is an environment secret reference |
 | `system.hermesDashboardAuth` | Strict-v2 Hermes Basic provider settings, public URL, session TTL, and environment secret references; plaintext credentials are never part of the manifest |
 | `controlPlane.cloudApiUrl` | Required and only control-plane field; `appId`, `apiUrl`, and `manifestUrl` are not public manifest fields |
 | `clawdiCli.source` | Required literal `npm:clawdi` for Hosted managed CLI updates |
@@ -846,23 +848,38 @@ enabled.
 ## Runtime UI Authentication
 
 Strict-v2 OpenClaw binds the official gateway directly to the pod network with
-`gateway run --allow-unconfigured --port 18789 --bind lan --force`, and provide
-`OPENCLAW_GATEWAY_TOKEN` only through `run.secretEnv`. The local config patch
-sets official shared-token auth, intentionally sets
+`gateway run --allow-unconfigured --port 18789 --bind lan --force`. Before the
+official service installer runs, Clawdi uses the official `openclaw config patch
+--stdin` flow to persist the managed token at `gateway.auth.token`, and passes
+that same value to the installer through its `OPENCLAW_GATEWAY_TOKEN`
+environment. The token never appears in installer argv. OpenClaw's installer
+resolves configured tokens before its environment fallback and only persists a
+token itself when it generated the token, so the preceding official config
+patch is required for caller-selected tokens:
+[`gateway-install-token.ts` lines 169-205](https://github.com/openclaw/openclaw/blob/2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4/src/commands/gateway-install-token.ts#L169-L205),
+[`auth-token-resolution.ts` lines 38-60](https://github.com/openclaw/openclaw/blob/2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4/src/gateway/auth-token-resolution.ts#L38-L60),
+and the official [`config patch --stdin` contract](https://github.com/openclaw/openclaw/blob/2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4/docs/cli/config.md#L249-L263).
+
+The local config patch also sets official shared-token auth, intentionally sets
 `dangerouslyDisableDeviceAuth: true` for the managed v2 product, disables
 insecure and Host-header fallback modes, derives `gateway.controlUi.basePath`
 from the clean public URL, and includes that URL's origin in `allowedOrigins`.
-The patch writes `gateway.auth.token: null` to delete any stale durable token;
-OpenClaw documents this RFC 7396 behavior in
-[`merge-patch.ts` lines 88-113](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/src/config/merge-patch.ts#L88-L113),
-while the active token comes from the ephemeral service environment.
+The managed backend value, transient installer environment, and
+`openclaw.json` token must remain identical. The gateway unit does not receive
+an `OPENCLAW_GATEWAY_TOKEN` environment entry because runtime auth resolves the
+persisted config first, making `openclaw.json` the gateway's only at-rest token
+store. A config-patch failure aborts convergence before service installation or
+systemd activation. A changed token updates the official config and restarts the
+gateway; an unchanged token does not rewrite the config or restart the gateway.
 
 Direct OpenClaw exposure remains fail closed behind the typed
 `openclaw-native-auth-v1` capability and an available
-`OPENCLAW_GATEWAY_TOKEN`. Hosted returns a clean endpoint plus an explicit token
+managed gateway token. Hosted returns a clean endpoint plus an explicit token
 and `handoff_url` through an owner-checked, no-store credential endpoint. The
-handoff carries exactly one official `#token=` fragment. Device pairing and
-device-auth behavior are deliberately outside this managed token-only contract.
+handoff carries exactly one official `#token=` fragment. In hosted mode that
+managed token is the authentication, so device pairing is intentionally
+disabled to avoid an additional approval step in the iframe or new-window
+handoff. OpenClaw retains its normal device-auth behavior outside hosted mode.
 
 Hermes direct exposure requires `hermes-basic-auth-v1`, a stable HTTPS public
 URL (including any path prefix), exact `0.0.0.0:9119` service args, and the
@@ -1129,12 +1146,16 @@ manifest.
 
 ## Command And Launch Model
 
-`clawdi run -- <command>` is a local vault-injection command and an interactive
-hosted shell boundary. In hosted mode, it first tries to resolve the command
-against a generated runtime run config. If a matching enabled config exists, it
-launches that runtime with the configured command, args, cwd, env, PATH, secret
-refs, and optional sidecar profile. If the config exists but is disabled,
-`clawdi run` exits with a disabled-runtime error.
+The tenant terminal runs official runtime commands directly. For OpenClaw, the
+product path is `openclaw agent`; OpenClaw resolves managed runtime credentials
+through its official config-first behavior and native config/credential stores.
+There is no Clawdi wrapper in that credential path.
+
+`clawdi run -- <command>` remains an explicit local vault-injection command. It
+is not the hosted tenant terminal boundary and does not mediate hosted managed
+credentials. When a caller opts into it, an enabled generated runtime run config
+can supply that command's configured args, cwd, env, PATH, secret refs, and
+optional sidecar profile. A disabled matching config is rejected.
 
 Interactive shell commands are not intercepted. `openclaw`, `hermes`, and
 future runtime names resolve to official binaries on PATH. Clawdi only
@@ -1144,8 +1165,9 @@ participates when the caller explicitly invokes `clawdi run` or when
 Hosted daemon startup avoids `clawdi run`. For OpenClaw/Hermes gateways,
 `runtime init` invokes the official service installer to create the base user
 unit, then writes a hosted drop-in with the minimum local environment needed by
-the Linux-like container. Sensitive env lives under `$CLAWDI_RUN_DIR/systemd/env`
-instead of durable unit files:
+the Linux-like container. Service environment that is still required at runtime
+lives under `$CLAWDI_RUN_DIR/systemd/env` instead of durable unit files; the
+OpenClaw gateway token is not part of that environment:
 
 ```ini
 # $HOME/.config/systemd/user/openclaw-gateway.service.d/10-clawdi-hosted.conf
@@ -1188,8 +1210,9 @@ official dashboard installer or claim the compatibility unit is upstream-owned.
 
 Strict-v2 OpenClaw uses the official gateway directly on native port `18789`.
 Clawdi patches `gateway.port=18789`, `gateway.bind=lan`, and
-`gateway.auth.mode=token` from `OPENCLAW_GATEWAY_TOKEN`; the launch command does
-not pass a conflicting `--auth` override:
+`gateway.auth.mode=token` with the managed token. The service receives no token
+environment entry, and the launch command does not pass a conflicting `--auth`
+override:
 
 ```bash
 openclaw gateway run --allow-unconfigured --port 18789 --bind lan --force
@@ -1197,9 +1220,11 @@ openclaw gateway run --allow-unconfigured --port 18789 --bind lan --force
 
 The strict manifest references the token only as
 `secret://runtime/openclaw/gateway-token`; its value comes only from the fetched
-bundle's `secretValues` map and is absent from manifest config and durable
-general config. Missing token, native-auth capability, deployment policy,
-public origin or exact command rejects the
+bundle's `secretValues` map. It is absent from manifest config and Clawdi's
+general managed config, but is deliberately persisted by the official config
+writer to the owner-only OpenClaw config. The installer receives the same value
+only through its transient subprocess environment. Missing token, native-auth
+capability, deployment policy, public origin or exact command rejects the
 strict-v2 configuration before exposure.
 
 ## Official Update Compatibility
@@ -1304,7 +1329,9 @@ fallback for environments that reject custom WebSocket subprotocols.
 ## Security Rules
 
 - Do not persist auth tokens, private keys, provider secrets, or resolved vault
-  values in durable runtime config.
+  values in Clawdi-owned durable runtime config. The managed OpenClaw gateway
+  token is deliberately persisted only through OpenClaw's official owner-only
+  config writer.
 - Keep non-secret desired state separate from secret values.
 - Treat runtime policy as an input to the CLI, not as hardcoded private logic.
 - Prefer official runtime configuration and installers before proxying or
@@ -1315,8 +1342,10 @@ fallback for environments that reject custom WebSocket subprotocols.
   channel descriptors, filesystem paths, and process launch arguments.
 - Remove `CLAWDI_AUTH_TOKEN` from agent child process environments unless that
   process is explicitly the Clawdi daemon or runtime reconciler.
-- Never disable OpenClaw device auth or enable its insecure/Host-header fallback
-  modes for strict v2.
+- Disable OpenClaw device auth only for hosted strict v2, where the managed
+  shared token authenticates the dashboard handoff without an additional
+  pairing approval. Keep device auth enabled outside hosted mode, and never
+  enable insecure or Host-header fallback modes.
 - Prefer WebSocket subprotocol auth for Terminal sessions so bearer tokens do
   not normally appear in URLs or proxy access logs.
 

--- a/docs/scenarios/scenario-5-gateway-unified-api.md
+++ b/docs/scenarios/scenario-5-gateway-unified-api.md
@@ -3,7 +3,9 @@
 > HISTORICAL - early 2026-04 managed-gateway concept. Current AI Provider
 > behavior does not proxy BYOK model traffic; see
 > [`../ai-providers.md`](../ai-providers.md) and
-> [`../architecture.md#ai-providers`](../architecture.md#ai-providers).
+> [`../architecture.md#ai-providers`](../architecture.md#ai-providers). Its
+> `clawdi run` managed-credential path was conceptual and is not the hosted
+> product path; hosted tenant terminals invoke official runtime CLIs directly.
 
 **Date:** 2026-04-15
 **Context:** A managed API gateway can provide a zero-config fallback when a

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -1458,7 +1458,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			gateway: {
 				port: 18789,
 				bind: "lan",
-				auth: { mode: "token", token: null },
+				auth: { mode: "token", token: "gateway-token" },
 				controlUi: {
 					allowedOrigins,
 					allowInsecureAuth: false,
@@ -1525,7 +1525,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				bind: "lan",
 				auth: {
 					mode: "token",
-					token: null,
+					token: "gateway-token",
 				},
 				controlUi: {
 					basePath: "/control",
@@ -1536,12 +1536,13 @@ describe("runtime manifest reconciliation invariants", () => {
 				},
 			},
 		});
-		expect(JSON.stringify(gatewayPatch)).not.toContain("gateway-token");
+		expect(JSON.stringify(gatewayPatch)).toContain("gateway-token");
 		const gatewayEnv = readFileSync(
 			join(paths.systemdEnvRoot, "openclaw-gateway.service.env"),
 			"utf8",
 		);
-		expect(gatewayEnv).toContain('OPENCLAW_GATEWAY_TOKEN="gateway-token"');
+		expect(gatewayEnv).not.toContain("OPENCLAW_GATEWAY_TOKEN");
+		expect(gatewayEnv).not.toContain("gateway-token");
 		expect(result.outputs.systemdSystemUnits.map((path) => path.split("/").at(-1))).toContain(
 			"clawdi-runtime-sidecar.service",
 		);

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -2978,7 +2978,7 @@ function openClawGatewayHostedPatch(
 							? {
 									auth: {
 										mode: "token",
-										...(nativeAuth ? { token: null } : { token: gatewayToken }),
+										token: gatewayToken,
 									},
 								}
 							: {}),
@@ -3003,6 +3003,28 @@ function openClawGatewayHostedPatch(
 	};
 }
 
+function jsonMergePatchIsApplied(current: unknown, patch: unknown): boolean {
+	if (!isPlainRecord(patch)) return canonicalJsonEqual(current, patch);
+	if (!isPlainRecord(current)) return false;
+	return Object.entries(patch).every(([key, value]) =>
+		value === null ? !Object.hasOwn(current, key) : jsonMergePatchIsApplied(current[key], value),
+	);
+}
+
+function openClawGatewayHostedPatchIsApplied(
+	home: string,
+	patch: Record<string, unknown>,
+): boolean {
+	try {
+		const current = JSON.parse(
+			readFileSync(join(home, ".openclaw", "openclaw.json"), "utf-8"),
+		) as unknown;
+		return jsonMergePatchIsApplied(current, patch);
+	} catch {
+		return false;
+	}
+}
+
 function openClawControlUiBasePath(manifest: RuntimeManifest): string {
 	const system = manifest.projection?.system;
 	if (!isPlainRecord(system)) return "/";
@@ -3019,7 +3041,7 @@ function applyOpenClawGatewayHostedProjection(
 	workspaceRoot: string,
 ): void {
 	const patch = openClawGatewayHostedPatch(manifest, secretValues);
-	if (!patch) return;
+	if (!patch || openClawGatewayHostedPatchIsApplied(home, patch)) return;
 	runRuntimeUserCommand(
 		command,
 		["config", "patch", "--stdin"],

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -610,7 +610,6 @@ describe("hosted runtime bundle v2", () => {
 		);
 		const watchEnvPath = join(paths.systemdEnvRoot, "clawdi-runtime-watch.service.env");
 		expect(watchUnit).toContain(`EnvironmentFile=${watchEnvPath}`);
-		const gatewayTokenLine = 'OPENCLAW_GATEWAY_TOKEN="openclaw-gateway-token-golden"';
 		const watchEnv = readFileSync(watchEnvPath, "utf-8");
 		expect(statSync(watchEnvPath).mode & 0o777).toBe(0o600);
 		const sidecarOnlySecrets = [
@@ -627,9 +626,12 @@ describe("hosted runtime bundle v2", () => {
 			expect(watchEnv).not.toContain(secret);
 		}
 		expect(watchEnv).not.toContain("OPENCLAW_GATEWAY_TOKEN");
-		expect(
-			readFileSync(join(paths.systemdEnvRoot, "openclaw-gateway.service.env"), "utf-8"),
-		).toContain(gatewayTokenLine);
+		const gatewayEnv = readFileSync(
+			join(paths.systemdEnvRoot, "openclaw-gateway.service.env"),
+			"utf-8",
+		);
+		expect(gatewayEnv).not.toContain("OPENCLAW_GATEWAY_TOKEN");
+		expect(gatewayEnv).not.toContain("openclaw-gateway-token-golden");
 		const persistentLastGood = [
 			readFileSync(paths.manifestLastGood, "utf-8"),
 			readFileSync(paths.managedSecretCacheFile, "utf-8"),

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -362,6 +362,8 @@ type OfficialRuntimeServiceDescriptor = {
 	command: string;
 	installArgs: string[];
 	uninstallArgs: string[];
+	// Resolved in memory for the installer subprocess; strict native auth may omit it from the unit.
+	installSecretEnv?: readonly string[];
 	// Manifest `services` key the official unit corresponds to; used for
 	// program naming even when such an entry is not official for the runtime.
 	service: string;
@@ -381,6 +383,7 @@ const OFFICIAL_RUNTIME_SERVICE_DESCRIPTORS: OfficialRuntimeServiceDescriptor[] =
 		command: "openclaw",
 		installArgs: ["gateway", "install", "--force", "--json"],
 		uninstallArgs: ["gateway", "uninstall"],
+		installSecretEnv: ["OPENCLAW_GATEWAY_TOKEN"],
 		service: "gateway",
 		unitEnv: (unitName) => ({ OPENCLAW_SYSTEMD_UNIT: unitName }),
 		matchesProgram: (program) => !program.service,
@@ -743,11 +746,23 @@ function writeSystemdEnvironmentFile(input: {
 			}
 			return `${key}=${systemdEnvironmentFileQuote(value)}`;
 		});
-	writePrivateFileAtomic(path, `${GENERATED_RUNTIME_SYSTEMD_FILE_HEADER}\n${lines.join("\n")}\n`, {
-		mode: 0o600,
-		dirMode: 0o711,
-		trustedRoot: input.paths.runRoot,
-	});
+	const content = `${GENERATED_RUNTIME_SYSTEMD_FILE_HEADER}\n${lines.join("\n")}\n`;
+	let unchanged = false;
+	try {
+		const current = lstatSync(path);
+		unchanged = current.isFile() && current.nlink === 1 && readFileSync(path, "utf8") === content;
+	} catch {
+		// A missing or unreadable target is replaced by the trusted atomic writer below.
+	}
+	if (!unchanged) {
+		writePrivateFileAtomic(path, content, {
+			mode: 0o600,
+			dirMode: 0o711,
+			trustedRoot: input.paths.runRoot,
+		});
+	} else {
+		chmodSync(path, 0o600);
+	}
 	if (input.owner === "runtime-user") makeRuntimeUserOwned(path);
 	return path;
 }
@@ -1051,7 +1066,14 @@ function installOfficialRuntimeUserService(
 	}
 	try {
 		resetFailedRuntimeUserService(runtimeSystemdProgramName(program), paths, program.cwd);
+		const environment = Object.fromEntries(
+			(descriptor.installSecretEnv ?? []).flatMap((name) => {
+				const value = program.resolvedSecretEnv[name];
+				return value ? [[name, value]] : [];
+			}),
+		);
 		const result = spawnRuntimeUserCommand(program.command, args, paths.userHome, program.cwd, {
+			environment,
 			maxBufferBytes: OFFICIAL_INSTALLER_MAX_BUFFER_BYTES,
 			timeoutMs: OFFICIAL_SERVICE_INSTALL_TIMEOUT_MS,
 		});
@@ -1458,9 +1480,20 @@ function writeRuntimeSystemdUserProgram(input: {
 			: program.args;
 	const name = runtimeSystemdProgramName(program);
 	const unitName = systemdUnitFileName(name);
+	const runtimeEnv = { ...program.env };
+	const descriptor = officialRuntimeServiceDescriptorForProgram(program);
+	const installerOnlySecretEnv =
+		descriptor?.runtime === "openclaw" &&
+		input.manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2" &&
+		input.manifest.openclawGatewayAuth?.activation.enabled === true
+			? (descriptor.installSecretEnv ?? [])
+			: [];
+	for (const envName of installerOnlySecretEnv) {
+		delete runtimeEnv[envName];
+	}
 	const env = {
 		...input.commonEnvironment,
-		...program.env,
+		...runtimeEnv,
 		...(input.manifest.locale ? { TZ: input.manifest.locale.timezone } : {}),
 		CLAWDI_AUTH_TOKEN: "",
 		CLAWDI_RUNTIME_REV: runtimeSystemdProgramRevision(
@@ -1470,7 +1503,7 @@ function writeRuntimeSystemdUserProgram(input: {
 			input.providerProjectionRevisions,
 			input.runtimeRevision,
 		),
-		...(officialRuntimeServiceDescriptorForProgram(program)?.unitEnv?.(unitName) ?? {}),
+		...(descriptor?.unitEnv?.(unitName) ?? {}),
 	};
 	if (officialRuntimeServiceInstallArgs(program)) {
 		return writeSystemdUserDropIn({

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -374,6 +374,7 @@ export function spawnRuntimeUserCommand(
 	cwd: string,
 	options: {
 		egressSystemCaFile?: string;
+		environment?: Record<string, string>;
 		input?: string;
 		maxBufferBytes?: number;
 		timeoutMs?: number;
@@ -399,6 +400,7 @@ export function spawnRuntimeUserCommand(
 		env: {
 			...runtimeUserCommandEnv(home, runtimeUid, options),
 			...child.env,
+			...options.environment,
 		},
 		cwd,
 		encoding: "utf8",

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -230,6 +230,212 @@ test("propagates the real official OpenClaw installer failure and rolls back as 
 	expect(existsSync(workspaceRoot)).toBe(false);
 });
 
+test("persists and serves the managed token through the real official OpenClaw gateway", async () => {
+	if (process.env[REAL_SYSTEMD_GATE] !== "1") return;
+
+	expect(process.geteuid?.()).toBe(0);
+	const runtimeHome = "/home/clawdi";
+	const runtimeUid = 10_001;
+	const runtimeGid = 10_001;
+	const commandPath = join(runtimeHome, ".local", "bin", "openclaw");
+	const root = mkdtempSync(join(tmpdir(), "clawdi-real-openclaw-token-"));
+	chmodSync(root, 0o755);
+	const clawdiHome = join(root, "clawdi-home");
+	mkdirSync(clawdiHome);
+	chownSync(clawdiHome, runtimeUid, runtimeGid);
+	chmodSync(clawdiHome, 0o700);
+	process.env.CLAWDI_RUNTIME_MODE = "hosted";
+	process.env.CLAWDI_RUNTIME_USER = "clawdi";
+	process.env.CLAWDI_RUNTIME_UID = String(runtimeUid);
+	process.env.CLAWDI_RUNTIME_GID = String(runtimeGid);
+	process.env.CLAWDI_RUNTIME_HOME = runtimeHome;
+	process.env.CLAWDI_HOME = clawdiHome;
+	process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+	process.env.CLAWDI_RUN_DIR = join(root, "run");
+	process.env.CLAWDI_SYSTEMD_SYSTEM_ROOT = join(root, "run", "systemd", "system");
+	process.env.CLAWDI_AUTH_TOKEN = "real-token-test-auth-token";
+	process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
+	const paths = getRuntimePaths({ mode: "hosted" });
+	ensureRuntimeStateDirs(paths);
+	const unitPath = join(paths.systemdUserRoot, "openclaw-gateway.service");
+	const dropInRoot = join(paths.systemdUserRoot, "openclaw-gateway.service.d");
+	const enablementPath = join(
+		paths.systemdUserRoot,
+		"default.target.wants",
+		"openclaw-gateway.service",
+	);
+	const openClawConfig = join(runtimeHome, ".openclaw", "openclaw.json");
+	const officialGatewayEnvironment = join(runtimeHome, ".openclaw", "gateway.systemd.env");
+	const managedToken = "managed-gateway-token";
+	const staleToken = "stale-config-token";
+	const runUserSystemctl = (...args: string[]) =>
+		spawnSync(
+			"runuser",
+			[
+				"-u",
+				"clawdi",
+				"--",
+				"env",
+				`HOME=${runtimeHome}`,
+				`XDG_RUNTIME_DIR=/run/user/${runtimeUid}`,
+				`DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${runtimeUid}/bus`,
+				"systemctl",
+				"--user",
+				...args,
+			],
+			{ encoding: "utf8" },
+		);
+
+	runUserSystemctl("disable", "--now", "openclaw-gateway.service");
+	rmSync(unitPath, { recursive: true, force: true });
+	rmSync(dropInRoot, { recursive: true, force: true });
+	rmSync(enablementPath, { force: true });
+	const workspaceRoot = join(runtimeHome, ".openclaw", "workspace");
+	writeFileSync(
+		openClawConfig,
+		`${JSON.stringify({
+			agents: { defaults: { workspace: workspaceRoot } },
+			gateway: { mode: "local", auth: { mode: "token", token: staleToken } },
+		})}\n`,
+		{ mode: 0o600 },
+	);
+	chownSync(openClawConfig, runtimeUid, runtimeGid);
+
+	const manifest: RuntimeManifest = {
+		schemaVersion: "clawdi.runtimeDesiredState.v1",
+		deploymentId: "hdep_real_openclaw_token",
+		environmentId: "env_real_openclaw_token",
+		instanceId: "hri_real_openclaw_token",
+		generation: 1,
+		issuedAt: "2026-08-11T00:00:00.000Z",
+		workspaceRoot,
+		projection: {
+			sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
+			system: {
+				openclawControlUiAllowedOrigins: ["https://agent.example.test"],
+			},
+		},
+		openclawGatewayAuth: {
+			mode: "token",
+			tokenRef: "secret://runtime/openclaw/gateway-token",
+			deviceAuthRequired: false,
+			activation: { enabled: true, capability: "openclaw-native-auth-v1" },
+		},
+		controlPlane: { apiUrl: "https://cloud-api.example.test" },
+		runtimes: {
+			openclaw: {
+				enabled: true,
+				run: {
+					command: commandPath,
+					args: [
+						"gateway",
+						"run",
+						"--allow-unconfigured",
+						"--port",
+						"18789",
+						"--bind",
+						"lan",
+						"--force",
+					],
+					env: {},
+					secretEnv: {
+						OPENCLAW_GATEWAY_TOKEN: "secret://runtime/openclaw/gateway-token",
+					},
+					prependPath: [],
+				},
+				services: {},
+			},
+		},
+		recovery: {},
+	};
+	const load: RuntimeManifestLoad = {
+		manifest,
+		source: "remote-datasource",
+		sourcePath: "real-openclaw-token-fixture",
+		offline: false,
+		secretValues: { "secret://runtime/openclaw/gateway-token": managedToken },
+		applyContext: {
+			kind: "context-file",
+			backend: "incus",
+			identity: {
+				generation: manifest.generation,
+				manifestETag: '"real-token-test"',
+				applyReceiptId: "real-token-test-receipt",
+				bootNonce: "real-token-test-boot",
+			},
+			cliPackageSpec: "clawdi@1.2.3",
+			manifestSource: {
+				type: "http",
+				url: "https://runtime.test/v1/runtime/manifest?environment_id=env_real_openclaw_token",
+				auth: { type: "bearer", token: "real-token-test-auth-token" },
+			},
+		},
+	};
+
+	try {
+		const result = convergeRuntimeManifest(load, paths, {
+			executeOfficialServiceInstallers: true,
+			cacheLastGood: false,
+		});
+		expect(result.installErrors).toEqual([]);
+		const config = JSON.parse(readFileSync(openClawConfig, "utf8")) as {
+			gateway?: { auth?: { token?: string } };
+		};
+		expect(config.gateway?.auth?.token).toBe(managedToken);
+		expect(readFileSync(unitPath, "utf8")).not.toContain(managedToken);
+		if (existsSync(officialGatewayEnvironment)) {
+			expect(readFileSync(officialGatewayEnvironment, "utf8")).not.toContain(managedToken);
+			expect(readFileSync(officialGatewayEnvironment, "utf8")).not.toContain(staleToken);
+		}
+		const managedEnvironment = join(paths.systemdEnvRoot, "openclaw-gateway.service.env");
+		expect(statSync(managedEnvironment).mode & 0o777).toBe(0o600);
+		expect(readFileSync(managedEnvironment, "utf8")).not.toContain("OPENCLAW_GATEWAY_TOKEN");
+		expect(readFileSync(managedEnvironment, "utf8")).not.toContain(managedToken);
+		expect(readFileSync(managedEnvironment, "utf8")).not.toContain(staleToken);
+
+		expect(runUserSystemctl("daemon-reload").status).toBe(0);
+		expect(runUserSystemctl("enable", "--now", "openclaw-gateway.service").status).toBe(0);
+		expect(runUserSystemctl("restart", "openclaw-gateway.service").status).toBe(0);
+		const gatewayHealth = (token?: string, configPath = openClawConfig) => {
+			const env: NodeJS.ProcessEnv = {
+				...process.env,
+				HOME: runtimeHome,
+				OPENCLAW_CONFIG_PATH: configPath,
+			};
+			if (token === undefined) delete env.OPENCLAW_GATEWAY_TOKEN;
+			else env.OPENCLAW_GATEWAY_TOKEN = token;
+			return spawnSync(commandPath, ["gateway", "health", "--port", "18789", "--timeout", "1000"], {
+				encoding: "utf8",
+				env,
+			});
+		};
+		let managedHealth = gatewayHealth(managedToken);
+		for (let attempt = 0; attempt < 30 && managedHealth.status !== 0; attempt += 1) {
+			await Bun.sleep(100);
+			managedHealth = gatewayHealth(managedToken);
+		}
+		expect(`${managedHealth.stdout}\n${managedHealth.stderr}`).toContain("Gateway Health");
+		expect(managedHealth.status).toBe(0);
+		// With no env override, the official client resolves the persisted config token.
+		expect(gatewayHealth().status).toBe(0);
+
+		const staleClientConfig = join(root, "stale-openclaw-client.json");
+		writeFileSync(
+			staleClientConfig,
+			`${JSON.stringify({ gateway: { auth: { mode: "token", token: staleToken } } })}\n`,
+			{ mode: 0o600 },
+		);
+		const staleHealth = gatewayHealth(undefined, staleClientConfig);
+		expect(staleHealth.status).not.toBe(0);
+		expect(`${staleHealth.stdout}\n${staleHealth.stderr}`).toMatch(/unauthorized|token mismatch/i);
+	} finally {
+		runUserSystemctl("disable", "--now", "openclaw-gateway.service");
+		rmSync(unitPath, { recursive: true, force: true });
+		rmSync(dropInRoot, { recursive: true, force: true });
+		rmSync(enablementPath, { force: true });
+	}
+}, 60_000);
+
 test("isolates File Browser from the tenant while preserving workspace access", () => {
 	if (process.env[REAL_SYSTEMD_GATE] !== "1") return;
 

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1145,6 +1145,7 @@ function openClawWhatsAppPluginInspectFixture(pluginSource: string): Record<stri
 
 function seedOfficialOpenClawServiceInstaller(home: string): void {
 	const openclawBin = join(home, ".local", "bin", "openclaw");
+	const openclawConfig = join(home, ".openclaw", "openclaw.json");
 	const unitPath = join(home, ".config", "systemd", "user", "openclaw-gateway.service");
 	const workspace = join(home, ".openclaw", "workspace");
 	mkdirSync(dirname(openclawBin), { recursive: true });
@@ -1161,8 +1162,11 @@ if [ "$*" = "agents list --json" ]; then
   exit 0
 fi
 if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
-  cat >/dev/null
-  exit 0
+	patch="$(cat)"
+	case "$patch" in
+	  *'"gateway"'*) printf '%s\n' "$patch" > '${openclawConfig}' ;;
+	esac
+	exit 0
 fi
 if [ "$*" = "gateway install --force --json" ]; then
   mkdir -p '${dirname(unitPath)}'
@@ -4378,8 +4382,12 @@ exit 0
 		const run = join(root, "run", "clawdi");
 		const openclawBin = join(home, ".local", "bin", "openclaw");
 		const openclawCommand = join(root, "openclaw-command.log");
+		const openclawConfig = join(home, ".openclaw", "openclaw.json");
+		const installerToken = join(root, "openclaw-installer-token");
+		const configPatchFailure = join(root, "fail-openclaw-config-patch");
 		const patchCount = join(root, "openclaw-patch-count");
 		const unitPath = join(home, ".config", "systemd", "user", "openclaw-gateway.service");
+		const gatewayEnvPath = join(run, "systemd", "env", "openclaw-gateway.service.env");
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
@@ -4392,13 +4400,21 @@ exit 0
 				'if [ "$1" = "--version" ]; then printf "OpenClaw test-version\\n"; exit 0; fi',
 				`printf '%s\\n' "$*" >> '${openclawCommand}'`,
 				'if [ "$1 $2 $3" = "config patch --stdin" ]; then',
+				`  [ ! -e '${configPatchFailure}' ] || exit 73`,
 				`  count=$(cat '${patchCount}' 2>/dev/null || printf '0')`,
 				"  count=$((count + 1))",
 				`  printf '%s' "$count" > '${patchCount}'`,
 				`  cat > '${root}'/openclaw-patch-"$count".json`,
+				`  if grep -F '"gateway"' '${root}'/openclaw-patch-"$count".json >/dev/null; then`,
+				`    mkdir -p '${dirname(openclawConfig)}'`,
+				`    cp '${root}'/openclaw-patch-"$count".json '${openclawConfig}'`,
+				"  fi",
 				"  exit 0",
 				"fi",
 				'if [ "$1 $2 $3 $4" = "gateway install --force --json" ]; then',
+				`  [ "\${OPENCLAW_GATEWAY_TOKEN:-}" = 'gateway-token' ] || exit 71`,
+				`  grep -F '"token": "gateway-token"' '${openclawConfig}' >/dev/null || exit 72`,
+				`  printf '%s\\n' "\${OPENCLAW_GATEWAY_TOKEN}" > '${installerToken}'`,
 				`  mkdir -p '${dirname(unitPath)}'`,
 				`  printf '%s\\n' '[Unit]' '[Service]' 'ExecStart=${openclawBin} gateway run' > '${unitPath}'`,
 				"  printf '{\"ok\":true}\\n'",
@@ -4410,6 +4426,18 @@ exit 0
 			].join("\n"),
 		);
 		chmodSync(openclawBin, 0o700);
+		// Prior-generation state: a stale persisted gateway token in the official
+		// config location, exactly as a previous boot would have left it.
+		mkdirSync(dirname(openclawConfig), { recursive: true });
+		writeFileSync(
+			openclawConfig,
+			`${JSON.stringify({
+				gateway: {
+					mode: "local",
+					auth: { mode: "token", token: "stale-installer-token" },
+				},
+			})}\n`,
+		);
 
 		const loaded: RuntimeManifestLoad = {
 			source: "remote-datasource",
@@ -4437,6 +4465,24 @@ exit 0
 				runtimes: {
 					openclaw: {
 						enabled: true,
+						run: {
+							command: openclawBin,
+							args: [
+								"gateway",
+								"run",
+								"--allow-unconfigured",
+								"--port",
+								"18789",
+								"--bind",
+								"lan",
+								"--force",
+							],
+							env: {},
+							secretEnv: {
+								OPENCLAW_GATEWAY_TOKEN: "secret://runtime/openclaw/gateway-token",
+							},
+							prependPath: [],
+						},
 						provider_ids: ["default"],
 						primary_model: { provider_id: "default", model: "gpt-5.4-mini" },
 						install: {
@@ -4449,6 +4495,7 @@ exit 0
 					},
 				},
 				projection: {
+					sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
 					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
 					system: {
 						...hostedSystemFixture(home),
@@ -4471,6 +4518,23 @@ exit 0
 			},
 		};
 
+		writeFileSync(configPatchFailure, "fail\n");
+		const failedConfigPatch = convergeRuntimeManifest(loaded, getRuntimePaths(), {
+			executeOfficialServiceInstallers: true,
+		});
+		expect(failedConfigPatch.installErrors).toContainEqual(
+			expect.stringContaining("runtime openclaw provider projection failed"),
+		);
+		expect(failedConfigPatch.outputs.systemdUserUnits).toEqual([]);
+		expect(JSON.parse(readFileSync(openclawConfig, "utf8")).gateway.auth.token).toBe(
+			"stale-installer-token",
+		);
+		expect(readFileSync(openclawCommand, "utf8").trim()).toBe("config patch --stdin");
+		expect(existsSync(installerToken)).toBe(false);
+		expect(existsSync(unitPath)).toBe(false);
+		expect(existsSync(gatewayEnvPath)).toBe(false);
+		rmSync(configPatchFailure);
+
 		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths(), {
 			executeOfficialServiceInstallers: true,
 		});
@@ -4478,27 +4542,93 @@ exit 0
 		expect(convergence.installErrors).toEqual([]);
 		expect(readFileSync(openclawCommand, "utf-8").trim().split("\n")).toEqual([
 			"config patch --stdin",
+			"config patch --stdin",
 			'config patch --stdin --replace-path models.providers["default"].models',
 			"gateway install --force --json",
 		]);
 		expect(JSON.parse(readFileSync(join(root, "openclaw-patch-1.json"), "utf-8"))).toEqual({
 			gateway: {
 				mode: "local",
+				port: 18789,
+				bind: "lan",
 				auth: {
 					mode: "token",
 					token: "gateway-token",
 				},
 				controlUi: {
+					basePath: "/",
 					allowedOrigins: ["https://app-v2-18789.k3s.example.test"],
+					allowInsecureAuth: false,
+					dangerouslyAllowHostHeaderOriginFallback: false,
 					dangerouslyDisableDeviceAuth: true,
 				},
 			},
 		});
+		expect(readFileSync(installerToken, "utf8")).toBe("gateway-token\n");
+		expect(JSON.parse(readFileSync(openclawConfig, "utf8")).gateway.auth.token).toBe(
+			"gateway-token",
+		);
+		expect(readFileSync(openclawCommand, "utf8")).not.toContain("gateway-token");
+		expect(readSystemdEnvFile(getRuntimePaths(), "openclaw-gateway")).not.toContain(
+			"OPENCLAW_GATEWAY_TOKEN",
+		);
 		const openclawUnit = readSystemdUserServiceConfig(getRuntimePaths(), "openclaw-gateway");
 		expect(openclawUnit).toContain(
-			'"gateway" "run" "--allow-unconfigured" "--bind" "loopback" "--force"',
+			'"gateway" "run" "--allow-unconfigured" "--port" "18789" "--bind" "lan" "--force"',
 		);
 		expect(openclawUnit).not.toContain('"--auth"');
+
+		const fixedCredentialTime = new Date("2026-08-11T00:00:00.000Z");
+		utimesSync(openclawConfig, fixedCredentialTime, fixedCredentialTime);
+		utimesSync(gatewayEnvPath, fixedCredentialTime, fixedCredentialTime);
+		const configMtime = statSync(openclawConfig).mtimeMs;
+		const envMtime = statSync(gatewayEnvPath).mtimeMs;
+		const idempotent = convergeRuntimeManifest(loaded, getRuntimePaths(), {
+			executeOfficialServiceInstallers: true,
+		});
+		expect(idempotent.installErrors).toEqual([]);
+		expect(readFileSync(openclawCommand, "utf8").trim().split("\n").slice(-1)).toEqual([
+			'config patch --stdin --replace-path models.providers["default"].models',
+		]);
+		expect(statSync(openclawConfig).mtimeMs).toBe(configMtime);
+		expect(statSync(gatewayEnvPath).mtimeMs).toBe(envMtime);
+
+		rmSync(unitPath, { force: true });
+		const reinstalled = convergeRuntimeManifest(loaded, getRuntimePaths(), {
+			executeOfficialServiceInstallers: true,
+		});
+		expect(reinstalled.installErrors).toEqual([]);
+		expect(readFileSync(openclawCommand, "utf8").trim().split("\n").slice(-2)).toEqual([
+			'config patch --stdin --replace-path models.providers["default"].models',
+			"gateway install --force --json",
+		]);
+		expect(readFileSync(installerToken, "utf8")).toBe("gateway-token\n");
+		expect(JSON.parse(readFileSync(openclawConfig, "utf8")).gateway.auth.token).toBe(
+			"gateway-token",
+		);
+		expect(statSync(openclawConfig).mtimeMs).toBe(configMtime);
+		expect(statSync(gatewayEnvPath).mtimeMs).toBe(envMtime);
+
+		if (!loaded.secretValues) throw new Error("expected runtime secret fixture");
+		loaded.secretValues["secret://runtime/openclaw/gateway-token"] = "rotated-gateway-token";
+		const rotated = convergeRuntimeManifest(loaded, getRuntimePaths(), {
+			executeOfficialServiceInstallers: true,
+		});
+		expect(rotated.installErrors).toEqual([]);
+		expect(readFileSync(openclawCommand, "utf8").trim().split("\n").slice(-2)).toEqual([
+			"config patch --stdin",
+			'config patch --stdin --replace-path models.providers["default"].models',
+		]);
+		expect(JSON.parse(readFileSync(openclawConfig, "utf8")).gateway.auth.token).toBe(
+			"rotated-gateway-token",
+		);
+		expect(readSystemdEnvFile(getRuntimePaths(), "openclaw-gateway")).not.toContain(
+			"OPENCLAW_GATEWAY_TOKEN",
+		);
+		expect(readSystemdEnvFile(getRuntimePaths(), "openclaw-gateway")).not.toContain(
+			"rotated-gateway-token",
+		);
+		expect(readFileSync(openclawCommand, "utf8")).not.toContain("rotated-gateway-token");
 	});
 
 	it("projects runtime-scoped hosted providers into each enabled agent config", () => {
@@ -7312,7 +7442,8 @@ fi
 			const gatewayEnv = readSystemdEnvFile(paths, "openclaw-gateway");
 			expect(watchEnv).not.toContain("gateway-token-watch");
 			expect(watchEnv).not.toContain("OPENCLAW_GATEWAY_TOKEN");
-			expect(gatewayEnv).toContain('OPENCLAW_GATEWAY_TOKEN="gateway-token-watch"');
+			expect(gatewayEnv).not.toContain("OPENCLAW_GATEWAY_TOKEN");
+			expect(gatewayEnv).not.toContain("gateway-token-watch");
 			expect(watchEnv).not.toContain("file-runtime-token");
 			const patchText = readFileSync(openclawPatch, "utf-8");
 			expect(patchText).toContain('"telegram"');
@@ -7339,6 +7470,7 @@ fi
 		const run = join(root, "run", "clawdi");
 		const systemctlPath = join(root, "bin", "systemctl");
 		const systemctlLog = join(root, "systemctl.log");
+		const openclawConfig = join(home, ".openclaw", "openclaw.json");
 		const sidecarReadyPath = join(run, "egress", "systemd", "ca.pem");
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
@@ -7431,6 +7563,9 @@ fi
 			});
 			const initialDaemonAuthTokenRevision = initialAppliedState?.daemonAuthTokenRevision;
 			expect(initialDaemonAuthTokenRevision).toMatch(/^[a-f0-9]{64}$/);
+			expect(JSON.parse(readFileSync(openclawConfig, "utf8")).gateway.auth.token).toBe(
+				gatewayToken,
+			);
 			const initialDaemonUnit = readSystemdSystemUnit(paths, "clawdi-daemon");
 			const initialDaemonEnv = readSystemdEnvFile(paths, "clawdi-daemon");
 			const requestsBeforeMatchingTuple = watchFetch.captured.length;
@@ -7675,8 +7810,14 @@ fi
 				manifestETag: manifestEtag,
 				bootNonce: "boot-nonce-generation-0001",
 			});
-			expect(readSystemdEnvFile(getRuntimePaths(), "openclaw-gateway")).toContain(
-				'OPENCLAW_GATEWAY_TOKEN="rotated-projected-gateway-token"',
+			expect(readSystemdEnvFile(getRuntimePaths(), "openclaw-gateway")).not.toContain(
+				"OPENCLAW_GATEWAY_TOKEN",
+			);
+			expect(readSystemdEnvFile(getRuntimePaths(), "openclaw-gateway")).not.toContain(
+				"rotated-projected-gateway-token",
+			);
+			expect(JSON.parse(readFileSync(openclawConfig, "utf8")).gateway.auth.token).toBe(
+				"rotated-projected-gateway-token",
 			);
 			expect(readFileSync(systemctlLog, "utf-8")).toContain(
 				"--user restart openclaw-gateway.service",


### PR DESCRIPTION
## Root cause (launch blocker, proven by live production diagnosis)

`openclaw gateway install --force` ran without our resolved gateway secret, so the official installer generated and persisted its own token into `openclaw.json` (official behavior when no token is provided). The gateway resolves auth config-first, and our manifest then patched `gateway.auth.token: null` to strip it — a boot-time race. During the window config != env, so browser Control UI connects failed with structured `AUTH_TOKEN_MISMATCH` after every boot/restart.

## Fix (owner-ratified: align with official behavior)

- Persist the managed token via the official `openclaw config patch --stdin` (the official caller-selected-token entry point), with JSON-merge-patch idempotency; the `token: null` patch is deleted.
- The installer subprocess receives the same token transiently via `OPENCLAW_GATEWAY_TOKEN` spawn env (never argv), so it adopts ours instead of generating a divergent one.
- The token no longer appears in the gateway unit's persistent `/run` EnvironmentFile — config is the single at-rest home (official config-first), delivery to the installer is transient. Filter is scoped to the declared installer secret only, strict-v2 native auth only.
- Fail-closed ordering: config patch success is verified before systemd state, installer, and activation — first boot and rotation can never start a gateway on a wrong/stale token.
- Rotation-ready: a changed token converges config in one pass and restarts the gateway via runtime revision; same token is a strict no-op.
- Tenant terminal docs corrected: official `openclaw agent` directly with official config-first credential resolution (never `clawdi run`). `dangerouslyDisableDeviceAuth` stays enabled-off by design; docs now state the hosted token handoff is the authentication path (device pairing disabled in hosted only).

End-state invariant: `backend token == config-patch token == installer env token == openclaw.json gateway.auth.token`, and no token in the unit env.

## Gates

- Privileged systemd e2e: 3 pass / 0 fail / 133 expect — managed token authenticates, old token rejected, official client authenticates from config without env override; task containers/images cleaned
- CLI: 1651 pass / 4 skip / 0 fail / 8745 expect
- bun run check: 970 files, 0 errors; `git diff --check` clean

Official citations (openclaw v2026.7.1 @ 2d2ddc43): installer honors invocation env and only auto-persists self-generated tokens (`gateway-install-token.ts:169-205`); gateway is config-first (`auth-resolve.ts:71-82`); `config patch --stdin` is the official persistence contract (`docs/cli/config.md:249-263`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)