### PR TITLE
fix(web): show managed model brand icons

### DIFF
--- a/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
@@ -118,7 +118,7 @@ export function ModelBindingPicker({
 												aria-describedby={item.description ? descriptionId : undefined}
 												className="sr-only !absolute !size-px !border-0 !p-0"
 											/>
-											<EntityIcon kind="provider" id={item.providerId} size="sm" />
+											<EntityIcon kind="provider" id={item.iconId} size="sm" />
 											<span className="flex min-w-0 flex-1 flex-col gap-0.5 leading-tight">
 												<span
 													id={titleId}
@@ -173,7 +173,7 @@ export function ModelBindingPicker({
 										{compactManagedItems.overflow.map((item) => (
 											<SelectItem key={item.value} value={item.value} className="items-start py-2">
 												<span className="flex min-w-0 items-start gap-2 whitespace-normal">
-													<EntityIcon kind="provider" id={item.providerId} size="sm" />
+													<EntityIcon kind="provider" id={item.iconId} size="sm" />
 													<span className="flex min-w-0 flex-col items-start gap-0.5">
 														<span className="font-medium">{item.label}</span>
 														{item.description ? (

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
@@ -123,18 +123,19 @@ describe("model binding", () => {
 			{
 				...managedMetadata,
 				description: "Variable cost for long, detailed work.",
-				id: "k3",
-				display_name: "Kimi K3",
-				provider_id: "kimi-coding",
+				id: "glm-5.2",
+				display_name: "GLM-5.2",
+				provider_id: "redpill",
 				is_default: false,
 				is_featured: true,
 			},
 			{
 				...managedMetadata,
-				id: "future-model",
-				display_name: "Future model",
+				id: "deepseek-v4-flash-0731",
+				display_name: "DeepSeek V4 Flash 0731",
+				provider_id: "redpill",
 				is_default: false,
-				is_featured: false,
+				is_featured: true,
 			},
 			{
 				...managedMetadata,
@@ -159,28 +160,32 @@ describe("model binding", () => {
 				{
 					value: "gpt-5.6-sol",
 					label: "GPT-5.6 Sol",
-					providerId: "openai-codex",
+					iconId: "openai-codex",
 					description: "Higher cost for complex work.",
 				},
 				{
-					value: "k3",
-					label: "Kimi K3",
-					providerId: "kimi-coding",
+					value: "glm-5.2",
+					label: "GLM-5.2",
+					iconId: "zhipu",
 					description: "Variable cost for long, detailed work.",
+				},
+				{
+					value: "deepseek-v4-flash-0731",
+					label: "DeepSeek V4 Flash 0731",
+					iconId: "deepseek",
 				},
 			],
 			overflow: [
-				{ value: "future-model", label: "Future model", providerId: "openai-codex" },
 				{
 					value: "gpt-5.6-luna",
 					label: "GPT-5.6 Luna",
-					providerId: "openai-codex",
+					iconId: "openai-codex",
 					description: "Low cost for routine work.",
 				},
 				{
 					value: "gpt-5.6-terra",
 					label: "GPT-5.6 Terra",
-					providerId: "openai-codex",
+					iconId: "openai-codex",
 					description: "Balanced cost for everyday work.",
 				},
 			],
@@ -209,14 +214,14 @@ describe("model binding", () => {
 			{
 				value: "provider-model-a",
 				label: "Provider Model A (Canonical)",
-				providerId: "openai-codex",
+				iconId: "openai-codex",
 			},
 		]);
 		expect(items.overflow).toEqual([
 			{
 				value: "provider-model-b",
 				label: "Provider Model B — Full Name",
-				providerId: "openai-codex",
+				iconId: "openai-codex",
 			},
 		]);
 	});

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -28,7 +28,7 @@ export type ModelBindingPickerItem = {
 };
 
 export type ManagedModelBindingPickerItem = ModelBindingPickerItem & {
-	providerId: string;
+	iconId: string;
 };
 
 export type ManagedModelPickerItems = {
@@ -308,7 +308,7 @@ export function managedModelPickerItems(
 		seen.add(modelId);
 		const item = {
 			value: modelId,
-			providerId: model.provider_id,
+			iconId: managedModelBrandIconId(modelId, model.provider_id),
 			// Managed display names are authoritative catalog data. Keep them
 			// verbatim instead of deriving a friendlier label from the model id.
 			label: model.display_name,
@@ -317,6 +317,13 @@ export function managedModelPickerItems(
 		sections[model.is_featured ? "featured" : "overflow"].push(item);
 	}
 	return sections;
+}
+
+function managedModelBrandIconId(modelId: string, providerId: string): string {
+	const normalizedModelId = modelId.toLowerCase();
+	if (normalizedModelId.startsWith("deepseek-")) return "deepseek";
+	if (normalizedModelId.startsWith("glm-")) return "zhipu";
+	return providerId;
 }
 
 export function firstModelForProvider(


### PR DESCRIPTION
## Summary
- resolve managed DeepSeek and GLM models to their existing LobeHub brand icons even when both use the `redpill` proxy provider
- pass the resolved icon ID through both managed model picker layouts
- fold coverage into the existing featured/overflow ordering test; no new test cases or E2E fixtures

## Verification
- `bash scripts/test.sh web src/hosted/v2/ai-providers/model-binding.test.ts`
- focused Biome check for the three changed files