### PR TITLE
fix(web): use Z.AI icon for GLM

### DIFF
--- a/apps/web/src/components/entity-brand-icon-ids.ts
+++ b/apps/web/src/components/entity-brand-icon-ids.ts
@@ -16,6 +16,6 @@ export const PROVIDER_BRAND_ICON_IDS = [
 	"stepfun",
 	"together",
 	"xai",
-	"zhipu",
+	"zai",
 ] as const;
 export type ProviderBrandIconId = (typeof PROVIDER_BRAND_ICON_IDS)[number];

--- a/apps/web/src/components/entity-brand-icons.ts
+++ b/apps/web/src/components/entity-brand-icons.ts
@@ -16,7 +16,7 @@ import Qwen from "@lobehub/icons/es/Qwen/components/Color.js";
 import Stepfun from "@lobehub/icons/es/Stepfun/components/Mono.js";
 import Together from "@lobehub/icons/es/Together/components/Color.js";
 import XAI from "@lobehub/icons/es/XAI/components/Mono.js";
-import Zhipu from "@lobehub/icons/es/Zhipu/components/Color.js";
+import ZAI from "@lobehub/icons/es/ZAI/components/Mono.js";
 import type { BrandIconComponent } from "@/components/brand-icon-tile";
 import type { FrameworkBrandIconId, ProviderBrandIconId } from "@/components/entity-brand-icon-ids";
 
@@ -66,7 +66,7 @@ const PROVIDER_BRAND_ICON_DEFINITIONS = {
 	stepfun: { icon: Stepfun, label: "StepFun" },
 	together: { icon: Together, label: "Together AI" },
 	xai: { icon: XAI, label: "xAI" },
-	zhipu: { icon: Zhipu, label: "Zhipu" },
+	zai: { icon: ZAI, label: "Z.ai" },
 } satisfies Readonly<Record<ProviderBrandIconId, BrandIconMetadata>>;
 
 const PROVIDER_BRAND_ICONS: Readonly<Record<string, BrandIconMetadata>> =
@@ -81,7 +81,7 @@ const PROVIDER_ICON_ALIASES: Readonly<Record<string, string>> = {
 	"qwen-dashscope": "qwen",
 	"together-ai": "together",
 	"xai-grok": "grok",
-	"zhipu-glm": "zhipu",
+	"zhipu-glm": "zai",
 };
 
 export function frameworkBrandIcon(id: string | null | undefined): BrandIconMetadata | undefined {

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
@@ -166,7 +166,7 @@ describe("model binding", () => {
 				{
 					value: "glm-5.2",
 					label: "GLM-5.2",
-					iconId: "zhipu",
+					iconId: "zai",
 					description: "Variable cost for long, detailed work.",
 				},
 				{

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -322,7 +322,7 @@ export function managedModelPickerItems(
 function managedModelBrandIconId(modelId: string, providerId: string): string {
 	const normalizedModelId = modelId.toLowerCase();
 	if (normalizedModelId.startsWith("deepseek-")) return "deepseek";
-	if (normalizedModelId.startsWith("glm-")) return "zhipu";
+	if (normalizedModelId.startsWith("glm-")) return "zai";
 	return providerId;
 }
 

--- a/apps/web/src/hosted/v2/ai-providers/provider-ui-consistency.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-ui-consistency.test.ts
@@ -47,7 +47,7 @@ describe("AI provider icon coverage", () => {
 			"qwen-dashscope": "qwen",
 			"together-ai": "together",
 			"xai-grok": "grok",
-			"zhipu-glm": "zhipu",
+			"zhipu-glm": "zai",
 		} as const;
 
 		for (const [alias, canonical] of Object.entries(aliases)) {


### PR DESCRIPTION
## Summary
- replace the Zhipu LobeHub icon registration with the official Z.AI component
- use Z.AI for managed `glm-*` models
- map the BYOK `zhipu-glm` preset to Z.AI as well
- update only existing assertions; no new tests or fixtures

## Verification
- `bash scripts/test.sh web src/hosted/v2/ai-providers/model-binding.test.ts src/hosted/v2/ai-providers/provider-ui-consistency.test.ts`
- focused Biome check for the five changed files