### PR TITLE
fix(runtime): produce strict WhatsApp runtime bindings

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -29,11 +29,6 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
         yield session
 
 
-async def get_runtime_snapshot_session() -> AsyncGenerator[AsyncSession, None]:
-    async with runtime_snapshot_session() as session:
-        yield session
-
-
 async def get_runtime_observation_session() -> AsyncGenerator[AsyncSession, None]:
     """Open one repeatable-read observation snapshot that may persist expiry.
 

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -122,6 +122,7 @@ from app.services.channel_config import (
     validate_required_discord_interactions_config,
 )
 from app.services.channels import (
+    RUNTIME_CHANNEL_PROVIDERS,
     archive_channel_account,
     build_channel_account,
     channel_webhook_url,
@@ -1584,7 +1585,7 @@ async def admin_delete_channel(
         registry=get_active_whatsapp_sidecar_registry(),
     )
     await archive_channel_account(db, account=account)
-    if account.provider in (CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD):
+    if account.provider in RUNTIME_CHANNEL_PROVIDERS:
         for link in active_links:
             await queue_environment_runtime_manifest_changed(
                 db,

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import (
     AuthContext,
     require_user_auth,
+    require_user_auth_unbound,
 )
 from app.core.database import get_session
 from app.models.channel import (
@@ -40,14 +41,12 @@ from app.models.channel import (
     DELIVERY_STATUS_IN_PROGRESS,
     DELIVERY_STATUS_PENDING,
     ChannelAccount,
-    ChannelAgentCredential,
     ChannelBinding,
     ChannelBotAgentLink,
     ChannelDebugEvent,
     ChannelDelivery,
     ChannelMessage,
 )
-from app.models.session import AgentEnvironment
 from app.routes.channel_routers.shared import (
     account_response,
     binding_response,
@@ -77,9 +76,6 @@ from app.schemas.channel import (
     ChannelMessageResponse,
     ChannelPairCodeCreate,
     ChannelPairCodeResponse,
-    ChannelRuntimeAccountResponse,
-    ChannelRuntimeAgentLinkResponse,
-    ChannelRuntimeCredentialResponse,
     ChannelSendMessageRequest,
 )
 from app.services.agent_bindings import get_owned_agent_or_404
@@ -97,6 +93,7 @@ from app.services.channel_debug_events import (
 )
 from app.services.channels import (
     PAIR_COMMAND,
+    RUNTIME_CHANNEL_PROVIDERS,
     archive_bot_agent_link,
     archive_channel_account,
     bot_agent_link_has_strict_v2_authority,
@@ -107,7 +104,6 @@ from app.services.channels import (
     configure_telegram_provider_webhook,
     consume_pending_inbound_messages_for_bindings,
     create_pair_code,
-    decrypt_agent_link_token,
     discord_bot_install_url,
     discord_config_without_unverified_install_state,
     discord_install_config_is_current,
@@ -142,15 +138,7 @@ from app.services.channels import (
 )
 from app.services.http_cache import if_none_match_contains, strong_json_etag
 from app.services.sync_events import queue_environment_runtime_manifest_changed
-from app.services.vault_crypto import decrypt
-from app.services.whatsapp_baileys import (
-    buffer_json,
-    deserialize_creds,
-    encode_buffer_json,
-    load_or_create_whatsapp_auth_cert,
-    mint_whatsapp_agent_credential,
-    whatsapp_agent_websocket_url,
-)
+from app.services.whatsapp_baileys import ensure_whatsapp_agent_credential
 from app.services.whatsapp_device_onboarding import (
     require_whatsapp_custom_link_ready,
     require_whatsapp_logout_for_archive,
@@ -163,12 +151,6 @@ from app.services.whatsapp_sidecar_registry import get_active_whatsapp_sidecar_r
 
 router = APIRouter(prefix="/channels", tags=["channels"])
 
-RUNTIME_CHANNEL_PROVIDERS = (
-    CHANNEL_PROVIDER_TELEGRAM,
-    CHANNEL_PROVIDER_DISCORD,
-    CHANNEL_PROVIDER_WHATSAPP,
-)
-
 
 async def _queue_agent_link_runtime_changed(
     db: AsyncSession,
@@ -176,11 +158,22 @@ async def _queue_agent_link_runtime_changed(
     account: ChannelAccount,
     link: ChannelBotAgentLink,
 ) -> None:
-    # The strict v2 runtime source currently projects Telegram and Discord
-    # AgentLinks. Bindings are deliberately absent from that source identity.
-    if account.provider not in (CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD):
+    if account.provider not in RUNTIME_CHANNEL_PROVIDERS:
         return
     await queue_environment_runtime_manifest_changed(db, link.user_id, link.agent_id)
+
+
+async def _ensure_whatsapp_runtime_material(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    link: ChannelBotAgentLink,
+) -> bool:
+    if account.provider == CHANNEL_PROVIDER_WHATSAPP:
+        return (
+            await ensure_whatsapp_agent_credential(db, account=account, link=link)
+        ).material_changed
+    return False
 
 
 def _agent_link_response(
@@ -196,108 +189,6 @@ def _agent_link_response(
         created_at=link.created_at,
         agent_token=agent_token,
     )
-
-
-def _runtime_agent_link_response(
-    link: ChannelBotAgentLink,
-    *,
-    agent_token: str | None = None,
-) -> ChannelRuntimeAgentLinkResponse:
-    return ChannelRuntimeAgentLinkResponse(
-        id=link.id,
-        account_id=link.account_id,
-        agent_id=link.agent_id,
-        status=link.status,
-        created_at=link.created_at,
-        agent_token=agent_token,
-    )
-
-
-async def _runtime_account_response(
-    db: AsyncSession,
-    account: ChannelAccount,
-    link: ChannelBotAgentLink,
-) -> ChannelRuntimeAccountResponse:
-    runtime_link = _runtime_agent_link_response(
-        link,
-        agent_token=decrypt_agent_link_token(link),
-    )
-    return ChannelRuntimeAccountResponse(
-        **account_response(account).model_dump(),
-        runtime_links=[runtime_link],
-        runtime_credentials=await _runtime_credentials_response(db, account=account, link=link),
-    )
-
-
-async def _runtime_credentials_response(
-    db: AsyncSession,
-    *,
-    account: ChannelAccount,
-    link: ChannelBotAgentLink,
-) -> list[ChannelRuntimeCredentialResponse]:
-    if account.provider != CHANNEL_PROVIDER_WHATSAPP:
-        return []
-    await db.execute(
-        select(ChannelAccount.id)
-        .where(
-            ChannelAccount.id == account.id,
-        )
-        .with_for_update()
-    )
-    credential = (
-        await db.execute(
-            select(ChannelAgentCredential)
-            .where(
-                ChannelAgentCredential.account_id == account.id,
-                ChannelAgentCredential.bot_agent_link_id == link.id,
-                ChannelAgentCredential.provider == CHANNEL_PROVIDER_WHATSAPP,
-                ChannelAgentCredential.revoked_at.is_(None),
-            )
-            .order_by(ChannelAgentCredential.created_at.desc(), ChannelAgentCredential.id.desc())
-            .limit(1)
-        )
-    ).scalar_one_or_none()
-    auth_cert = await load_or_create_whatsapp_auth_cert(db, account=account)
-    if credential is None:
-        stored = await mint_whatsapp_agent_credential(
-            db,
-            account=account,
-            bot_agent_link_id=link.id,
-            user_id=link.user_id,
-        )
-        credential = stored.credential
-        creds = stored.minted.creds
-        await db.commit()
-        await db.refresh(credential)
-    else:
-        creds = deserialize_creds(
-            decrypt(credential.encrypted_credentials, credential.credential_nonce)
-        )
-        await db.commit()
-    material: dict[str, Any] = {
-        "schemaVersion": "clawdi.whatsappBaileysAuthState.v1",
-        "creds": encode_buffer_json(creds),
-        "websocketUrl": whatsapp_agent_websocket_url(),
-        "authCert": {
-            "SERIAL": auth_cert.serial,
-            "ISSUER": auth_cert.issuer,
-            "PUBLIC_KEY": buffer_json(auth_cert.root_public_key),
-        },
-    }
-    return [
-        ChannelRuntimeCredentialResponse(
-            id=credential.id,
-            account_id=credential.account_id,
-            agent_link_id=credential.bot_agent_link_id,
-            agent_id=link.agent_id,
-            provider=CHANNEL_PROVIDER_WHATSAPP,
-            kind="whatsapp_baileys_auth_state",
-            created_at=credential.created_at,
-            jid=credential.synthetic_jid,
-            identity_pub_key_hex=credential.identity_public_key.hex(),
-            material=material,
-        )
-    ]
 
 
 def _agent_link_with_account_response(
@@ -421,68 +312,12 @@ async def _active_bot_agent_link_counts(
     return {account_id: int(count) for account_id, count in result.all()}
 
 
-@router.get("", response_model=list[ChannelAccountResponse | ChannelRuntimeAccountResponse])
+@router.get("", response_model=list[ChannelAccountResponse])
 async def list_channels(
     request: Request,
-    requested_environment_id: UUID | None = Query(default=None, alias="environment_id"),
-    auth: AuthContext = Depends(require_user_auth),
+    auth: AuthContext = Depends(require_user_auth_unbound),
     db: AsyncSession = Depends(get_session),
 ) -> Response:
-    runtime_environment_id = await _runtime_channels_environment_id(
-        db,
-        auth=auth,
-        requested_environment_id=requested_environment_id,
-    )
-    if runtime_environment_id is not None:
-        try:
-            await get_strict_v2_hosted_channel_agent_or_409(
-                db,
-                user_id=auth.user_id,
-                agent_id=runtime_environment_id,
-            )
-        except HTTPException as exc:
-            if exc.status_code != status.HTTP_409_CONFLICT:
-                raise
-            runtime_rows: list[tuple[ChannelAccount, ChannelBotAgentLink]] = []
-        else:
-            result = await db.execute(
-                select(ChannelAccount, ChannelBotAgentLink)
-                .join(ChannelBotAgentLink, ChannelBotAgentLink.account_id == ChannelAccount.id)
-                .where(
-                    ChannelAccount.archived_at.is_(None),
-                    ChannelAccount.provider.in_(RUNTIME_CHANNEL_PROVIDERS),
-                    ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
-                    ChannelBotAgentLink.archived_at.is_(None),
-                    ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
-                    ChannelBotAgentLink.user_id == auth.user_id,
-                    ChannelBotAgentLink.agent_id == runtime_environment_id,
-                )
-                .order_by(
-                    ChannelAccount.provider,
-                    ChannelAccount.visibility,
-                    ChannelAccount.name,
-                    ChannelAccount.id,
-                )
-            )
-            runtime_rows = list(result.tuples().all())
-        payload: list[object] = []
-        for account, link in runtime_rows:
-            if not await bot_agent_link_has_strict_v2_authority(db, link=link):
-                continue
-            await ensure_bot_agent_link_provider_cardinality_or_409(
-                db,
-                account=account,
-                link=link,
-            )
-            payload.append(
-                (await _runtime_account_response(db, account, link)).model_dump(mode="json")
-            )
-        etag = strong_json_etag(payload)
-        headers = {"ETag": etag, "Cache-Control": "no-store"}
-        if if_none_match_contains(request.headers.get("if-none-match"), etag):
-            return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
-        return JSONResponse(payload, headers=headers)
-
     result = await db.execute(
         select(ChannelAccount)
         .where(
@@ -505,44 +340,6 @@ async def list_channels(
     if if_none_match_contains(request.headers.get("if-none-match"), etag):
         return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
     return JSONResponse(payload, headers=headers)
-
-
-async def _runtime_channels_environment_id(
-    db: AsyncSession,
-    *,
-    auth: AuthContext,
-    requested_environment_id: UUID | None,
-) -> UUID | None:
-    if not auth.is_cli or auth.api_key is None:
-        return None
-
-    bound_environment_id = auth.api_key.environment_id
-    if bound_environment_id is not None:
-        if (
-            requested_environment_id is not None
-            and requested_environment_id != bound_environment_id
-        ):
-            raise HTTPException(
-                status.HTTP_403_FORBIDDEN,
-                "api key bound to a different environment",
-            )
-        return bound_environment_id
-
-    if requested_environment_id is None:
-        return None
-
-    env = (
-        await db.execute(
-            select(AgentEnvironment.id).where(
-                AgentEnvironment.id == requested_environment_id,
-                AgentEnvironment.user_id == auth.user_id,
-                AgentEnvironment.archived_at.is_(None),
-            )
-        )
-    ).scalar_one_or_none()
-    if env is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent environment not found")
-    return requested_environment_id
 
 
 @router.get("/bot-pool")
@@ -702,6 +499,7 @@ async def create_channel(
                 replace_existing_provider_link=body.replace_existing_provider_link,
             )
             link_agent_token = created_token or link_agent_token
+            await _ensure_whatsapp_runtime_material(db, account=account, link=link)
             await _queue_agent_link_runtime_changed(db, account=account, link=link)
         await store_channel_secrets(db, account=account, secrets_by_name=body.secrets)
         record_control_plane_audit(
@@ -973,6 +771,7 @@ async def create_channel_pair_code(
             account.config = config
             mark_discord_reserved_commands_current(account)
     link, agent_token = await _resolve_pair_code_link(db, auth=auth, account=account, body=body)
+    material_changed = await _ensure_whatsapp_runtime_material(db, account=account, link=link)
     created = await create_pair_code(
         db,
         account=account,
@@ -980,7 +779,7 @@ async def create_channel_pair_code(
         ttl_seconds=body.ttl_seconds,
         agent_token=agent_token,
     )
-    if agent_token is not None:
+    if agent_token is not None or material_changed:
         await _queue_agent_link_runtime_changed(db, account=account, link=created.link)
     record_control_plane_audit(
         db,
@@ -1064,7 +863,8 @@ async def create_channel_agent_link(
         user_id=auth.user_id,
         replace_existing_provider_link=body.replace_existing_provider_link,
     )
-    if agent_token is not None:
+    material_changed = await _ensure_whatsapp_runtime_material(db, account=account, link=link)
+    if agent_token is not None or material_changed:
         await _queue_agent_link_runtime_changed(db, account=account, link=link)
     record_control_plane_audit(
         db,

--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -19,7 +19,7 @@ from app.core.auth import (
     require_cli_auth,
 )
 from app.core.config import settings
-from app.core.database import get_runtime_snapshot_session, get_session
+from app.core.database import get_session, runtime_snapshot_session
 from app.models.agent_project_binding import AgentProjectBinding
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
@@ -39,10 +39,13 @@ from app.services.project_runtime_skills import (
 )
 from app.services.runtime_source import (
     RUNTIME_BUNDLE_V2_MEDIA_TYPE,
+    RenderedRuntimeSource,
     RuntimeSourceError,
     RuntimeSourceNotFoundError,
+    ensure_runtime_whatsapp_credentials,
     expected_runtime_bundle_v2_etag,
     load_runtime_source_batch,
+    missing_runtime_whatsapp_credential_link_ids,
     render_runtime_bundle,
     render_runtime_source,
     vault_key_identity,
@@ -62,7 +65,7 @@ async def get_runtime_manifest(
     request: Request,
     requested_environment_id: UUID | None = Query(default=None, alias="environment_id"),
     auth: AuthContext = Depends(require_cli_auth),
-    db: AsyncSession = Depends(get_runtime_snapshot_session),
+    db: AsyncSession = Depends(get_session),
 ) -> Response:
     environment_id = _authorized_environment_id(auth, requested_environment_id)
     if request.headers.get("accept") != RUNTIME_BUNDLE_V2_MEDIA_TYPE:
@@ -72,19 +75,27 @@ async def get_runtime_manifest(
             headers={"Cache-Control": "no-store", "Vary": "Accept"},
         )
 
-    batch = await load_runtime_source_batch(
-        db,
-        environment_ids=[environment_id],
-        owner_user_id=auth.user_id,
-    )
     try:
-        source = render_runtime_source(
-            batch,
+        source, missing_link_ids = await _render_runtime_source_snapshot(
             environment_id=environment_id,
-            public_api_url=settings.public_api_url,
-            vault_key_identity=vault_key_identity(settings.vault_encryption_key),
-            decrypt_secrets=True,
+            owner_user_id=auth.user_id,
         )
+        if missing_link_ids:
+            await ensure_runtime_whatsapp_credentials(
+                db,
+                environment_id=environment_id,
+                owner_user_id=auth.user_id,
+                link_ids=missing_link_ids,
+            )
+            await db.commit()
+            source, missing_link_ids = await _render_runtime_source_snapshot(
+                environment_id=environment_id,
+                owner_user_id=auth.user_id,
+            )
+        if source is None:
+            raise RuntimeSourceError(
+                "Active runtime WhatsApp Link has no synthetic credential material"
+            )
     except RuntimeSourceNotFoundError as exc:
         raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
     except RuntimeSourceError as exc:
@@ -101,6 +112,35 @@ async def get_runtime_manifest(
     if if_none_match_contains(request.headers.get("if-none-match"), etag):
         return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
     return JSONResponse(payload, headers=headers)
+
+
+async def _render_runtime_source_snapshot(
+    *,
+    environment_id: UUID,
+    owner_user_id: UUID,
+) -> tuple[RenderedRuntimeSource | None, tuple[UUID, ...]]:
+    async with runtime_snapshot_session() as source_db:
+        batch = await load_runtime_source_batch(
+            source_db,
+            environment_ids=[environment_id],
+            owner_user_id=owner_user_id,
+        )
+        missing_link_ids = missing_runtime_whatsapp_credential_link_ids(
+            batch,
+            environment_id=environment_id,
+        )
+        if missing_link_ids:
+            return None, missing_link_ids
+        return (
+            render_runtime_source(
+                batch,
+                environment_id=environment_id,
+                public_api_url=settings.public_api_url,
+                vault_key_identity=vault_key_identity(settings.vault_encryption_key),
+                decrypt_secrets=True,
+            ),
+            (),
+        )
 
 
 def _authorized_environment_id(auth: AuthContext, requested_environment_id: UUID | None) -> UUID:

--- a/backend/app/schemas/channel.py
+++ b/backend/app/schemas/channel.py
@@ -80,33 +80,6 @@ class ChannelAccountResponse(BaseModel):
     created_at: datetime
 
 
-class ChannelRuntimeAgentLinkResponse(BaseModel):
-    id: UUID
-    account_id: UUID
-    agent_id: UUID
-    status: str
-    created_at: datetime
-    agent_token: str | None = None
-
-
-class ChannelRuntimeCredentialResponse(BaseModel):
-    id: UUID
-    account_id: UUID
-    agent_link_id: UUID
-    agent_id: UUID
-    provider: str
-    kind: str
-    created_at: datetime
-    jid: str | None = None
-    identity_pub_key_hex: str | None = None
-    material: dict[str, Any] | None = None
-
-
-class ChannelRuntimeAccountResponse(ChannelAccountResponse):
-    runtime_links: list[ChannelRuntimeAgentLinkResponse] = Field(default_factory=list)
-    runtime_credentials: list[ChannelRuntimeCredentialResponse] = Field(default_factory=list)
-
-
 class ChannelBotPoolCapabilities(BaseModel):
     link_agent: bool
     pair_chat: bool

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -204,6 +204,13 @@ DELIVERY_ERROR_PROVIDER_UNREACHABLE = "channel_provider_unreachable"
 HERMES_AGENT_TYPE = "hermes"
 OPENCLAW_AGENT_TYPE = "openclaw"
 HOSTED_RUNTIME_AGENT_TYPES = frozenset({HERMES_AGENT_TYPE, OPENCLAW_AGENT_TYPE})
+RUNTIME_CHANNEL_PROVIDERS = frozenset(
+    {
+        CHANNEL_PROVIDER_TELEGRAM,
+        CHANNEL_PROVIDER_DISCORD,
+        CHANNEL_PROVIDER_WHATSAPP,
+    }
+)
 HOSTED_RUNTIME_SINGLE_ACCOUNT_PROVIDERS = frozenset(
     {
         CHANNEL_PROVIDER_TELEGRAM,
@@ -374,8 +381,20 @@ def channel_runtime_account_key(account_id: UUID) -> str:
     return f"clawdi_{account_id.hex}"
 
 
-def channel_runtime_placeholder_token(provider: str, account_key: str) -> str:
-    suffix = hashlib.sha256(f"{provider}:{account_key}".encode()).hexdigest()[:32]
+def channel_runtime_placeholder_token(
+    provider: str,
+    account_key: str,
+    *,
+    link_id: UUID | None = None,
+) -> str:
+    if provider == CHANNEL_PROVIDER_WHATSAPP and link_id is None:
+        raise ValueError("WhatsApp runtime capability requires a Link id")
+    identity = (
+        f"{provider}:{account_key}:{link_id}"
+        if provider == CHANNEL_PROVIDER_WHATSAPP
+        else f"{provider}:{account_key}"
+    )
+    suffix = hashlib.sha256(identity.encode()).hexdigest()[:32]
     if provider == CHANNEL_PROVIDER_TELEGRAM:
         return f"999999999:{suffix}"
     return f"clawdi_{suffix}"

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -20,9 +20,12 @@ from app.models.channel import (
     BOT_AGENT_LINK_STATUS_ACTIVE,
     CHANNEL_PROVIDER_DISCORD,
     CHANNEL_PROVIDER_TELEGRAM,
+    CHANNEL_PROVIDER_WHATSAPP,
     CHANNEL_STATUS_ACTIVE,
     ChannelAccount,
+    ChannelAgentCredential,
     ChannelBotAgentLink,
+    ChannelWhatsAppAuthCert,
 )
 from app.models.hosted_runtime import (
     HostedRuntimeConfigObservation,
@@ -75,6 +78,10 @@ from app.services.project_runtime_skills import (
 )
 from app.services.url_security import UnsafePublicHttpsUrlError, validate_public_https_url
 from app.services.vault_crypto import decrypt
+from app.services.whatsapp_baileys import (
+    buffer_json,
+    ensure_whatsapp_agent_credential,
+)
 
 RUNTIME_BUNDLE_V2_MEDIA_TYPE = "application/vnd.clawdi.runtime-bundle.v2+json"
 RUNTIME_BUNDLE_V2_SCHEMA_VERSION = "clawdi.hosted-runtime.bundle.v2"
@@ -122,6 +129,8 @@ class RuntimeSourceBatch:
     providers: dict[tuple[UUID, str], AiProvider]
     auth_payloads: dict[tuple[UUID, str, str], AiProviderAuthPayload]
     channels: dict[UUID, tuple[tuple[ChannelAccount, ChannelBotAgentLink], ...]]
+    channel_credentials: dict[UUID, ChannelAgentCredential] = field(default_factory=dict)
+    whatsapp_auth_certs: dict[UUID, ChannelWhatsAppAuthCert] = field(default_factory=dict)
     runtime_secrets: dict[UUID, tuple[HostedRuntimeSecret, ...]] = field(default_factory=dict)
     project_skills: dict[UUID, tuple[RuntimeProjectSkill, ...]] = field(default_factory=dict)
 
@@ -129,7 +138,7 @@ class RuntimeSourceBatch:
 @dataclass(frozen=True)
 class RenderedRuntimeSource:
     manifest: dict[str, Any]
-    channel_bindings: list[dict[str, str]]
+    channel_bindings: list[dict[str, Any]]
     secret_values: dict[str, str]
     source_revision: str
     apply_generation: int | None
@@ -150,7 +159,7 @@ async def load_runtime_source_batch(
     owner_user_id: UUID | None = None,
 ) -> RuntimeSourceBatch:
     if not environment_ids:
-        return RuntimeSourceBatch({}, {}, {}, {}, {}, {})
+        return RuntimeSourceBatch(rows={}, providers={}, auth_payloads={}, channels={})
     env_filters: list[ColumnElement[bool]] = [
         AgentEnvironment.id.in_(environment_ids),
         AgentEnvironment.archived_at.is_(None),
@@ -178,7 +187,7 @@ async def load_runtime_source_batch(
     }
     user_ids = sorted({row.environment.user_id for row in rows.values()}, key=str)
     if not user_ids:
-        return RuntimeSourceBatch(rows, {}, {}, {}, {}, {})
+        return RuntimeSourceBatch(rows=rows, providers={}, auth_payloads={}, channels={})
     providers = list(
         (
             await db.execute(
@@ -210,7 +219,13 @@ async def load_runtime_source_batch(
                 ChannelBotAgentLink.archived_at.is_(None),
                 ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
                 ChannelAccount.archived_at.is_(None),
-                ChannelAccount.provider.in_((CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD)),
+                ChannelAccount.provider.in_(
+                    (
+                        CHANNEL_PROVIDER_TELEGRAM,
+                        CHANNEL_PROVIDER_DISCORD,
+                        CHANNEL_PROVIDER_WHATSAPP,
+                    )
+                ),
             )
             .order_by(
                 ChannelBotAgentLink.agent_id,
@@ -223,6 +238,52 @@ async def load_runtime_source_batch(
     channels: dict[UUID, list[tuple[ChannelAccount, ChannelBotAgentLink]]] = {}
     for environment_id, account, link in channel_rows:
         channels.setdefault(environment_id, []).append((account, link))
+    whatsapp_links = [
+        (account, link)
+        for _environment_id, account, link in channel_rows
+        if account.provider == CHANNEL_PROVIDER_WHATSAPP
+    ]
+    credential_rows = (
+        list(
+            (
+                await db.execute(
+                    select(ChannelAgentCredential)
+                    .where(
+                        ChannelAgentCredential.bot_agent_link_id.in_(
+                            [link.id for _account, link in whatsapp_links]
+                        ),
+                        ChannelAgentCredential.provider == CHANNEL_PROVIDER_WHATSAPP,
+                        ChannelAgentCredential.revoked_at.is_(None),
+                    )
+                    .order_by(
+                        ChannelAgentCredential.bot_agent_link_id,
+                        ChannelAgentCredential.created_at.desc(),
+                        ChannelAgentCredential.id.desc(),
+                    )
+                )
+            ).scalars()
+        )
+        if whatsapp_links
+        else []
+    )
+    channel_credentials: dict[UUID, ChannelAgentCredential] = {}
+    for credential in credential_rows:
+        channel_credentials.setdefault(credential.bot_agent_link_id, credential)
+    auth_cert_rows = (
+        list(
+            (
+                await db.execute(
+                    select(ChannelWhatsAppAuthCert).where(
+                        ChannelWhatsAppAuthCert.account_id.in_(
+                            [account.id for account, _link in whatsapp_links]
+                        )
+                    )
+                )
+            ).scalars()
+        )
+        if whatsapp_links
+        else []
+    )
     runtime_secret_rows = list(
         (
             await db.execute(
@@ -293,12 +354,65 @@ async def load_runtime_source_batch(
             )
         )
     return RuntimeSourceBatch(
-        rows,
-        {(item.owner_user_id, item.provider_id): item for item in providers},
-        {(item.owner_user_id, item.provider_id, item.auth_profile): item for item in auth_payloads},
-        {key: tuple(value) for key, value in channels.items()},
-        {key: tuple(value) for key, value in runtime_secrets.items()},
-        {key: tuple(value) for key, value in project_skills.items()},
+        rows=rows,
+        providers={(item.owner_user_id, item.provider_id): item for item in providers},
+        auth_payloads={
+            (item.owner_user_id, item.provider_id, item.auth_profile): item
+            for item in auth_payloads
+        },
+        channels={key: tuple(value) for key, value in channels.items()},
+        channel_credentials=channel_credentials,
+        whatsapp_auth_certs={item.account_id: item for item in auth_cert_rows},
+        runtime_secrets={key: tuple(value) for key, value in runtime_secrets.items()},
+        project_skills={key: tuple(value) for key, value in project_skills.items()},
+    )
+
+
+async def ensure_runtime_whatsapp_credentials(
+    db: AsyncSession,
+    *,
+    environment_id: UUID,
+    owner_user_id: UUID,
+    link_ids: tuple[UUID, ...],
+) -> None:
+    if not link_ids:
+        return
+    rows = (
+        await db.execute(
+            select(ChannelAccount, ChannelBotAgentLink)
+            .join(ChannelBotAgentLink, ChannelBotAgentLink.account_id == ChannelAccount.id)
+            .where(
+                ChannelBotAgentLink.id.in_(link_ids),
+                ChannelBotAgentLink.agent_id == environment_id,
+                ChannelBotAgentLink.user_id == owner_user_id,
+                ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                ChannelBotAgentLink.archived_at.is_(None),
+                ChannelAccount.provider == CHANNEL_PROVIDER_WHATSAPP,
+                ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+                ChannelAccount.archived_at.is_(None),
+            )
+            .order_by(ChannelAccount.id, ChannelBotAgentLink.id)
+        )
+    ).all()
+    try:
+        for account, link in rows:
+            await ensure_whatsapp_agent_credential(db, account=account, link=link)
+    except Exception as exc:
+        raise RuntimeSourceError("Hosted runtime WhatsApp credential source is invalid") from exc
+
+
+def missing_runtime_whatsapp_credential_link_ids(
+    batch: RuntimeSourceBatch,
+    *,
+    environment_id: UUID,
+) -> tuple[UUID, ...]:
+    return tuple(
+        link.id
+        for account, link in batch.channels.get(environment_id, ())
+        if account.provider == CHANNEL_PROVIDER_WHATSAPP
+        and (
+            link.id not in batch.channel_credentials or account.id not in batch.whatsapp_auth_certs
+        )
     )
 
 
@@ -670,7 +784,7 @@ def render_runtime_source(
         manifest["tools"] = tool_projection
     manifest["terminalTooling"] = terminal_tooling
 
-    bindings: list[dict[str, str]] = []
+    bindings: list[dict[str, Any]] = []
     channel_rows = batch.channels.get(environment_id, ())
     projected_providers: set[str] = set()
     for account, link in channel_rows:
@@ -685,16 +799,71 @@ def render_runtime_source(
         if not link.encrypted_agent_token or not link.agent_token_nonce:
             raise RuntimeSourceError("Active runtime channel link has no token material")
         account_key = channel_runtime_account_key(account.id)
-        agent_ref = f"secret://channels/{account.provider}/{account_key}/agent-token"
-        placeholder_ref = f"secret://channels/{account.provider}/{account_key}/placeholder-token"
-        bindings.append(
-            {
-                "provider": account.provider,
-                "accountKey": account_key,
-                "agentTokenSecretRef": agent_ref,
-                "placeholderTokenSecretRef": placeholder_ref,
-            }
-        )
+        if account.provider == CHANNEL_PROVIDER_WHATSAPP:
+            agent_ref = f"secret://channels/whatsapp/{account_key}/links/{link.id}/agent-token"
+            placeholder_ref = (
+                f"secret://channels/whatsapp/{account_key}/links/{link.id}/egress-capability"
+            )
+            credential = batch.channel_credentials.get(link.id)
+            auth_cert = batch.whatsapp_auth_certs.get(account.id)
+            if credential is None or auth_cert is None:
+                raise RuntimeSourceError(
+                    "Active runtime WhatsApp Link has no synthetic credential material"
+                )
+            credential_ref = (
+                f"secret://channels/whatsapp/{account_key}/credentials/{credential.id}/creds-json"
+            )
+            bindings.append(
+                {
+                    "provider": CHANNEL_PROVIDER_WHATSAPP,
+                    "accountId": str(account.id),
+                    "accountKey": account_key,
+                    "linkId": str(link.id),
+                    "agentTokenSecretRef": agent_ref,
+                    "placeholderTokenSecretRef": placeholder_ref,
+                    "credential": {
+                        "id": str(credential.id),
+                        "credsSecretRef": credential_ref,
+                        "authCert": {
+                            "SERIAL": auth_cert.serial,
+                            "ISSUER": "clawdi",
+                            "PUBLIC_KEY": buffer_json(auth_cert.root_public_key),
+                        },
+                    },
+                }
+            )
+            _add_secret_source(
+                secret_sources,
+                credential_ref,
+                _secret_identity(
+                    credential.id,
+                    credential.encrypted_credentials,
+                    credential.credential_nonce,
+                    vault_key_identity,
+                    "channel-whatsapp-synthetic-credential",
+                ),
+            )
+            secret_materials.append(
+                RuntimeSecretMaterial(
+                    secret_ref=credential_ref,
+                    ciphertext=credential.encrypted_credentials,
+                    nonce=credential.credential_nonce,
+                    error_message="Hosted runtime WhatsApp credential source is invalid",
+                )
+            )
+        else:
+            agent_ref = f"secret://channels/{account.provider}/{account_key}/agent-token"
+            placeholder_ref = (
+                f"secret://channels/{account.provider}/{account_key}/placeholder-token"
+            )
+            bindings.append(
+                {
+                    "provider": account.provider,
+                    "accountKey": account_key,
+                    "agentTokenSecretRef": agent_ref,
+                    "placeholderTokenSecretRef": placeholder_ref,
+                }
+            )
         _add_secret_source(
             secret_sources,
             agent_ref,
@@ -724,7 +893,13 @@ def render_runtime_source(
         for binding in bindings:
             placeholder_ref = binding["placeholderTokenSecretRef"]
             secrets[placeholder_ref] = channel_runtime_placeholder_token(
-                binding["provider"], binding["accountKey"]
+                binding["provider"],
+                binding["accountKey"],
+                link_id=(
+                    UUID(binding["linkId"])
+                    if binding["provider"] == CHANNEL_PROVIDER_WHATSAPP
+                    else None
+                ),
             )
 
     descriptor: dict[str, object] = {

--- a/backend/app/services/whatsapp_baileys.py
+++ b/backend/app/services/whatsapp_baileys.py
@@ -21,7 +21,6 @@ from pydantic import JsonValue
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     BOT_AGENT_LINK_STATUS_ACTIVE,
@@ -167,6 +166,13 @@ class WhatsAppAuthCert:
 class StoredWhatsAppCredential:
     credential: ChannelAgentCredential
     minted: MintedWhatsAppCreds
+
+
+@dataclass(frozen=True)
+class ResolvedWhatsAppCredential:
+    credential: ChannelAgentCredential
+    auth_cert: ChannelWhatsAppAuthCert
+    material_changed: bool
 
 
 @dataclass(frozen=True)
@@ -685,13 +691,6 @@ def decode_buffer_json(value: object) -> object:
 
 def serialize_creds(creds: Mapping[str, object]) -> str:
     return json.dumps(encode_buffer_json(creds), separators=(",", ":"), sort_keys=True)
-
-
-def deserialize_creds(serialized: str) -> dict[str, object]:
-    decoded = decode_buffer_json(json.loads(serialized))
-    if not _is_object_dict(decoded):
-        raise ValueError("stored WhatsApp credentials must be an object")
-    return decoded
 
 
 def serialize_agent_bundle(bundle: AgentBundle) -> dict[str, JsonValue]:
@@ -1570,54 +1569,75 @@ async def load_or_create_whatsapp_auth_cert(
     await db.execute(
         select(ChannelAccount.id).where(ChannelAccount.id == account.id).with_for_update()
     )
-    result = await db.execute(
-        select(ChannelWhatsAppAuthCert).where(ChannelWhatsAppAuthCert.account_id == account.id)
-    )
-    row = result.scalar_one_or_none()
+    row = await _load_whatsapp_auth_cert_row(db, account_id=account.id)
     if row is not None:
-        return WhatsAppAuthCert(
-            serial=row.serial,
-            issuer="clawdi",
-            root_public_key=row.root_public_key,
-            root_private_key=base64.b64decode(
-                decrypt(row.encrypted_root_private_key, row.root_private_key_nonce)
-            ),
-            intermediate_public_key=row.intermediate_public_key,
-            intermediate_private_key=base64.b64decode(
-                decrypt(
-                    row.encrypted_intermediate_private_key,
-                    row.intermediate_private_key_nonce,
-                )
-            ),
-        )
+        return _decrypt_whatsapp_auth_cert(row)
 
+    _, auth_cert = await _create_whatsapp_auth_cert(db, account=account)
+    return auth_cert
+
+
+async def _load_whatsapp_auth_cert_row(
+    db: AsyncSession,
+    *,
+    account_id: UUID,
+) -> ChannelWhatsAppAuthCert | None:
+    return (
+        await db.execute(
+            select(ChannelWhatsAppAuthCert).where(ChannelWhatsAppAuthCert.account_id == account_id)
+        )
+    ).scalar_one_or_none()
+
+
+async def _create_whatsapp_auth_cert(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+) -> tuple[ChannelWhatsAppAuthCert, WhatsAppAuthCert]:
     root = _x25519_key_pair()
     intermediate = _x25519_key_pair()
     root_ciphertext, root_nonce = encrypt(base64.b64encode(root["private"]).decode("ascii"))
     intermediate_ciphertext, intermediate_nonce = encrypt(
         base64.b64encode(intermediate["private"]).decode("ascii")
     )
-    db.add(
-        ChannelWhatsAppAuthCert(
-            account_id=account.id,
-            user_id=account.user_id,
-            root_public_key=root["public"],
-            encrypted_root_private_key=root_ciphertext,
-            root_private_key_nonce=root_nonce,
-            intermediate_public_key=intermediate["public"],
-            encrypted_intermediate_private_key=intermediate_ciphertext,
-            intermediate_private_key_nonce=intermediate_nonce,
-            serial=0,
-        )
+    row = ChannelWhatsAppAuthCert(
+        account_id=account.id,
+        user_id=account.user_id,
+        root_public_key=root["public"],
+        encrypted_root_private_key=root_ciphertext,
+        root_private_key_nonce=root_nonce,
+        intermediate_public_key=intermediate["public"],
+        encrypted_intermediate_private_key=intermediate_ciphertext,
+        intermediate_private_key_nonce=intermediate_nonce,
+        serial=0,
     )
+    db.add(row)
     await db.flush()
-    return WhatsAppAuthCert(
+    return row, WhatsAppAuthCert(
         serial=0,
         issuer="clawdi",
         root_public_key=root["public"],
         root_private_key=root["private"],
         intermediate_public_key=intermediate["public"],
         intermediate_private_key=intermediate["private"],
+    )
+
+
+def _decrypt_whatsapp_auth_cert(row: ChannelWhatsAppAuthCert) -> WhatsAppAuthCert:
+    return WhatsAppAuthCert(
+        serial=row.serial,
+        issuer="clawdi",
+        root_public_key=row.root_public_key,
+        root_private_key=base64.b64decode(
+            decrypt(row.encrypted_root_private_key, row.root_private_key_nonce)
+        ),
+        intermediate_public_key=row.intermediate_public_key,
+        intermediate_private_key=base64.b64decode(
+            decrypt(
+                row.encrypted_intermediate_private_key,
+                row.intermediate_private_key_nonce,
+            )
+        ),
     )
 
 
@@ -1671,6 +1691,70 @@ async def mint_whatsapp_agent_credential(
     db.add(credential)
     await db.flush()
     return StoredWhatsAppCredential(credential=credential, minted=minted)
+
+
+async def ensure_whatsapp_agent_credential(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    link: ChannelBotAgentLink,
+) -> ResolvedWhatsAppCredential:
+    if account.provider != CHANNEL_PROVIDER_WHATSAPP or link.account_id != account.id:
+        raise ValueError("WhatsApp runtime credential requires a matching WhatsApp Link")
+
+    async def load_credential() -> ChannelAgentCredential | None:
+        return (
+            await db.execute(
+                select(ChannelAgentCredential)
+                .where(
+                    ChannelAgentCredential.account_id == account.id,
+                    ChannelAgentCredential.bot_agent_link_id == link.id,
+                    ChannelAgentCredential.provider == CHANNEL_PROVIDER_WHATSAPP,
+                    ChannelAgentCredential.revoked_at.is_(None),
+                )
+                .order_by(
+                    ChannelAgentCredential.created_at.desc(),
+                    ChannelAgentCredential.id.desc(),
+                )
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+    credential = await load_credential()
+    auth_cert = await _load_whatsapp_auth_cert_row(db, account_id=account.id)
+    if credential is not None and auth_cert is not None:
+        return ResolvedWhatsAppCredential(
+            credential=credential,
+            auth_cert=auth_cert,
+            material_changed=False,
+        )
+
+    await db.execute(
+        select(ChannelAccount.id).where(ChannelAccount.id == account.id).with_for_update()
+    )
+    credential = await load_credential()
+    auth_cert = await _load_whatsapp_auth_cert_row(db, account_id=account.id)
+    material_changed = False
+    if auth_cert is None:
+        auth_cert, _ = await _create_whatsapp_auth_cert(db, account=account)
+        material_changed = True
+
+    if credential is None:
+        credential = (
+            await mint_whatsapp_agent_credential(
+                db,
+                account=account,
+                bot_agent_link_id=link.id,
+                user_id=link.user_id,
+            )
+        ).credential
+        material_changed = True
+
+    return ResolvedWhatsAppCredential(
+        credential=credential,
+        auth_cert=auth_cert,
+        material_changed=material_changed,
+    )
 
 
 def whatsapp_agent_credential_config(
@@ -1734,10 +1818,6 @@ async def resolve_whatsapp_credential_by_identity(
         )
     )
     return result.scalar_one_or_none()
-
-
-def whatsapp_agent_websocket_url() -> str:
-    return _public_ws_url("/v1/channels/whatsapp/baileys")
 
 
 def _x25519_key_pair() -> dict[str, bytes]:
@@ -3079,12 +3159,3 @@ async def _find_binding_alias(
         )
     )
     return result.scalar_one_or_none()
-
-
-def _public_ws_url(path: str) -> str:
-    base = settings.public_api_url.rstrip("/")
-    if base.startswith("https://"):
-        return "wss://" + base.removeprefix("https://") + path
-    if base.startswith("http://"):
-        return "ws://" + base.removeprefix("http://") + path
-    return base + path

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -2942,10 +2942,15 @@ async def test_admin_endpoints_excluded_from_openapi_schema(admin_client, seed_u
 
 @pytest.mark.asyncio
 async def test_admin_platform_whatsapp_qr_promotes_only_after_connected_and_logout_is_fail_closed(
-    admin_client, db_session, monkeypatch
+    admin_client, db_session, seed_user, channel_agent, monkeypatch
 ):
     import app.routes.admin as admin_routes
-    from app.models.channel import ChannelAccount, ChannelWhatsAppOnboardingSession
+    from app.models.channel import (
+        ChannelAccount,
+        ChannelBotAgentLink,
+        ChannelWhatsAppOnboardingSession,
+    )
+    from app.services import sync_events
 
     account_id = uuid.uuid4()
     fake = _ManagedOnboardingSidecar()
@@ -2962,6 +2967,7 @@ async def test_admin_platform_whatsapp_qr_promotes_only_after_connected_and_logo
         "name": "Shared WhatsApp",
     }
     pairing_url = "/v1/admin/channels/whatsapp/pairing-sessions"
+    queue = None
     try:
         assert (await admin_client.post(pairing_url, json=payload)).status_code == 401
         started = await admin_client.post(pairing_url, json=payload, headers=_AUTH)
@@ -2997,17 +3003,39 @@ async def test_admin_platform_whatsapp_qr_promotes_only_after_connected_and_logo
         await registry.reconcile_managed_ownership(db_session)
         assert registry.managed_is_bound(account_id)
         monkeypatch.setattr(admin_routes, "get_active_whatsapp_sidecar_registry", lambda: registry)
+        db_session.add(
+            ChannelBotAgentLink(
+                account_id=account.id,
+                user_id=seed_user.id,
+                agent_id=channel_agent.id,
+                status="active",
+            )
+        )
+        await db_session.commit()
+        queue = sync_events.subscribe(
+            seed_user.id,
+            frozenset(),
+            environment_id=channel_agent.id,
+        )
         fake.logout_fails = True
         assert (
             await admin_client.delete(f"/v1/admin/channels/{account_id}", headers=_AUTH)
         ).status_code == 503
         await db_session.refresh(account)
         assert account.archived_at is None
+        assert queue.empty()
         fake.logout_fails = False
         assert (
             await admin_client.delete(f"/v1/admin/channels/{account_id}", headers=_AUTH)
         ).status_code == 204
+        assert queue.get_nowait() == {
+            "type": "runtime_manifest_changed",
+            "environment_id": str(channel_agent.id),
+        }
+        assert queue.empty()
     finally:
+        if queue is not None:
+            sync_events.unsubscribe(seed_user.id, queue)
         await registry.stop()
 
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -59,6 +59,7 @@ from app.models.channel import (
     ChannelMessage,
     ChannelPairCode,
     ChannelSecret,
+    ChannelWhatsAppAuthCert,
 )
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.runtime_observation import V2RuntimeEnvironmentFence
@@ -1796,146 +1797,30 @@ async def test_channel_health_includes_public_bound_channels_without_cross_user_
 
 
 @pytest.mark.asyncio
-async def test_env_bound_list_channels_returns_runtime_agent_token(
+async def test_environment_bound_key_cannot_list_control_plane_channels(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user,
     channel_agent,
 ):
+    channel_name = f"unbound-only-{uuid4().hex}"
     created_response = await client.post(
         "/v1/channels",
         json={
             "provider": "telegram",
-            "name": f"runtime-list-{uuid4().hex}",
+            "name": channel_name,
             "provider_token": "123456:telegram-secret",
         },
     )
     assert created_response.status_code == 201, created_response.text
-    created = created_response.json()
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=channel_agent.id, label="hosted")
     async with _client_for_api_key(db_session, seed_user, api_key) as runtime_client:
         listed = await runtime_client.get("/v1/channels")
 
-    assert listed.status_code == 200, listed.text
-    payload = listed.json()
-    assert len(payload) == 1
-    assert payload[0]["id"] == created["id"]
-    assert payload[0]["runtime_links"] == [
-        {
-            "id": created["agent_link_id"],
-            "account_id": created["id"],
-            "agent_id": str(channel_agent.id),
-            "status": "active",
-            "created_at": payload[0]["runtime_links"][0]["created_at"],
-            "agent_token": created["agent_token"],
-        }
-    ]
+    assert listed.status_code == 403, listed.text
+    assert channel_name not in listed.text
     assert "telegram-secret" not in listed.text
-    assert "webhook_secret" not in listed.text
-
-
-@pytest.mark.asyncio
-async def test_account_level_managed_key_lists_runtime_channels_with_environment_query(
-    client: httpx.AsyncClient,
-    db_session: AsyncSession,
-    seed_user,
-    channel_agent,
-):
-    created_response = await client.post(
-        "/v1/channels",
-        json={
-            "provider": "telegram",
-            "name": f"runtime-managed-list-{uuid4().hex}",
-            "provider_token": "123456:telegram-secret",
-        },
-    )
-    assert created_response.status_code == 201, created_response.text
-    created = created_response.json()
-
-    api_key = ApiKey(
-        user_id=seed_user.id,
-        environment_id=None,
-        managed=True,
-        label="hosted",
-    )
-    async with _client_for_api_key(db_session, seed_user, api_key) as runtime_client:
-        listed = await runtime_client.get(f"/v1/channels?environment_id={channel_agent.id}")
-
-    assert listed.status_code == 200, listed.text
-    payload = listed.json()
-    assert len(payload) == 1
-    assert payload[0]["id"] == created["id"]
-    assert payload[0]["runtime_links"][0]["agent_id"] == str(channel_agent.id)
-    assert payload[0]["runtime_links"][0]["agent_token"] == created["agent_token"]
-    assert "telegram-secret" not in listed.text
-    assert "webhook_secret" not in listed.text
-
-
-@pytest.mark.asyncio
-async def test_env_bound_channel_etag_is_stable(
-    client: httpx.AsyncClient,
-    db_session: AsyncSession,
-    seed_user,
-    channel_agent,
-):
-    duplicate_name = f"Runtime Duplicate {uuid4().hex}"
-    created_response = await client.post(
-        "/v1/channels",
-        json={
-            "provider": "telegram",
-            "name": duplicate_name,
-            "provider_token": "123456:telegram-secret-0",
-        },
-    )
-    assert created_response.status_code == 201, created_response.text
-    api_key = ApiKey(user_id=seed_user.id, environment_id=channel_agent.id, label="hosted")
-    async with _client_for_api_key(db_session, seed_user, api_key) as runtime_client:
-        first = await runtime_client.get("/v1/channels")
-        assert first.status_code == 200, first.text
-        etag = first.headers["etag"]
-        second = await runtime_client.get("/v1/channels", headers={"If-None-Match": etag})
-
-    assert second.status_code == 304, second.text
-    assert [item["id"] for item in first.json()] == [created_response.json()["id"]]
-
-
-@pytest.mark.asyncio
-async def test_env_bound_channel_etag_changes_when_agent_token_rotates(
-    client: httpx.AsyncClient,
-    db_session: AsyncSession,
-    seed_user,
-    channel_agent,
-):
-    created = (
-        await client.post(
-            "/v1/channels",
-            json={
-                "provider": "telegram",
-                "name": f"runtime-etag-{uuid4().hex}",
-                "provider_token": "123456:telegram-secret",
-            },
-        )
-    ).json()
-
-    api_key = ApiKey(user_id=seed_user.id, environment_id=channel_agent.id, label="hosted")
-    async with _client_for_api_key(db_session, seed_user, api_key) as runtime_client:
-        first = await runtime_client.get("/v1/channels")
-    assert first.status_code == 200, first.text
-    etag = first.headers["etag"]
-
-    rotated = await client.post(
-        f"/v1/channels/{created['id']}/agent-links/{created['agent_link_id']}/token"
-    )
-    assert rotated.status_code == 200, rotated.text
-    rotated_token = rotated.json()["agent_token"]
-
-    async with _client_for_api_key(db_session, seed_user, api_key) as runtime_client:
-        changed = await runtime_client.get("/v1/channels", headers={"If-None-Match": etag})
-
-    assert changed.status_code == 200, changed.text
-    assert changed.headers["etag"] != etag
-    assert changed.json()[0]["runtime_links"][0]["agent_token"] == rotated_token
 
 
 @pytest.mark.asyncio
@@ -2235,9 +2120,6 @@ async def test_hosted_agent_rejects_second_provider_account_but_keeps_existing_l
         rotated = await user_client.post(
             f"/v1/channels/{first_account.json()['id']}/agent-links/{first_link.json()['id']}/token"
         )
-        api_key = ApiKey(user_id=user.id, environment_id=agent.id, label="multi-account")
-        async with _client_for_api_key(db_session, user, api_key) as runtime_client:
-            runtime_channels = await runtime_client.get("/v1/channels")
     eligible_agent_ids = await channel_service.list_strict_v2_hosted_channel_agent_ids(
         db_session,
         user_id=user.id,
@@ -2258,8 +2140,6 @@ async def test_hosted_agent_rejects_second_provider_account_but_keeps_existing_l
     assert rotated.status_code == 200, rotated.text
     assert rotated.json()["agent_token"] != first_link.json()["agent_token"]
     assert agent.id not in eligible_agent_ids
-    assert runtime_channels.status_code == 200, runtime_channels.text
-    assert [item["id"] for item in runtime_channels.json()] == [first_account.json()["id"]]
 
 
 @pytest.mark.asyncio
@@ -2850,9 +2730,6 @@ async def test_historical_duplicate_managed_accounts_are_visible_but_fail_closed
         duplicate_rotate = await user_client.post(
             f"/v1/channels/{second.json()['id']}/agent-links/{second_link.id}/token"
         )
-    api_key = ApiKey(user_id=user.id, environment_id=agent.id, label="duplicate-runtime")
-    async with _client_for_api_key(db_session, user, api_key) as runtime_client:
-        runtime_channels = await runtime_client.get("/v1/channels")
     first_auth = await client.post(
         _telegram_bot_path(
             {"id": first.json()["id"], "agent_token": first_token},
@@ -2888,8 +2765,6 @@ async def test_historical_duplicate_managed_accounts_are_visible_but_fail_closed
     assert duplicate_pair.json()["detail"] == remediation
     assert duplicate_rotate.status_code == 409
     assert duplicate_rotate.json()["detail"] == remediation
-    assert runtime_channels.status_code == 409
-    assert runtime_channels.json()["detail"] == remediation
     assert first_auth.status_code == 409
     assert first_auth.json()["detail"] == remediation
     assert second_auth.status_code == 409
@@ -2907,14 +2782,9 @@ async def test_historical_duplicate_managed_accounts_are_visible_but_fail_closed
         rotated = await user_client.post(
             f"/v1/channels/{first.json()['id']}/agent-links/{first_link.id}/token"
         )
-    async with _client_for_api_key(db_session, user, api_key) as runtime_client:
-        recovered_runtime_channels = await runtime_client.get("/v1/channels")
-
     assert unlinked.status_code == 204
     assert [item["id"] for item in remaining_links.json()] == [str(first_link.id)]
     assert rotated.status_code == 200, rotated.text
-    assert recovered_runtime_channels.status_code == 200
-    assert [item["id"] for item in recovered_runtime_channels.json()] == [first.json()["id"]]
 
 
 @pytest.mark.asyncio
@@ -3368,9 +3238,6 @@ async def test_historical_local_link_remains_listable_and_cleanable_but_cannot_p
     db_session.add(binding)
     await db_session.commit()
 
-    api_key = ApiKey(user_id=user.id, environment_id=agent.id, label="historical-local-runtime")
-    async with _client_for_api_key(db_session, user, api_key) as runtime_client:
-        runtime_channels = await runtime_client.get("/v1/channels")
     bot_api = await client.post(
         _telegram_bot_path(
             {"id": str(account_id), "agent_token": historical_agent_token},
@@ -3422,9 +3289,6 @@ async def test_historical_local_link_remains_listable_and_cleanable_but_cannot_p
     assert rotate.status_code == 409
     assert pair_by_link.json()["detail"] == channel_service.STRICT_V2_AGENT_LINK_DETAIL
     assert rotate.json()["detail"] == channel_service.STRICT_V2_AGENT_LINK_DETAIL
-    assert runtime_channels.status_code == 200
-    assert runtime_channels.json() == []
-    assert historical_agent_token not in runtime_channels.text
     assert bot_api.status_code == 401
     assert inbound.status_code == 200
     assert inbound.json()["binding_id"] is None
@@ -3596,10 +3460,6 @@ async def test_delete_channel_agent_link_archives_link_and_releases_capacity(
         assert active_link.encrypted_agent_token is not None
         assert active_link.agent_token_nonce is not None
         full_pool = await client_a.get("/v1/channels/bot-pool")
-        api_key = ApiKey(user_id=user_a.id, environment_id=agent_a.id, label="hosted")
-        async with _client_for_api_key(db_session, user_a, api_key) as runtime_client:
-            desired_before = await runtime_client.get("/v1/channels")
-
         deleted = await client_a.delete(f"/v1/channels/{account_id}/agent-links/{first_link_id}")
         second_delete = await client_a.delete(
             f"/v1/channels/{account_id}/agent-links/{first_link_id}"
@@ -3608,8 +3468,6 @@ async def test_delete_channel_agent_link_archives_link_and_releases_capacity(
 
         links_after = await client_a.get(f"/v1/channels/{account_id}/agent-links")
         pool_after_delete = await client_a.get("/v1/channels/bot-pool")
-        async with _client_for_api_key(db_session, user_a, api_key) as runtime_client:
-            desired_after = await runtime_client.get("/v1/channels")
         audit_response = await client_a.get(
             "/v1/audit/events",
             params={"channel_account_id": account_id, "limit": 20},
@@ -3620,8 +3478,6 @@ async def test_delete_channel_agent_link_archives_link_and_releases_capacity(
             json={"agent_id": str(agent_b.id)},
         )
 
-    assert desired_before.status_code == 200, desired_before.text
-    assert [item["id"] for item in desired_before.json()] == [account_id]
     before_item = next(
         item for item in full_pool.json()["providers"]["telegram"] if item["id"] == account_id
     )
@@ -3633,8 +3489,6 @@ async def test_delete_channel_agent_link_archives_link_and_releases_capacity(
     assert missing_delete.status_code == 204, missing_delete.text
     assert links_after.status_code == 200, links_after.text
     assert links_after.json() == []
-    assert desired_after.status_code == 200, desired_after.text
-    assert desired_after.json() == []
     after_item = next(
         item
         for item in pool_after_delete.json()["providers"]["telegram"]
@@ -4488,7 +4342,7 @@ async def test_public_preset_channel_links_and_bindings_are_user_scoped(
 
 
 @pytest.mark.asyncio
-async def test_env_bound_list_channels_hides_historical_local_whatsapp_credentials(
+async def test_control_plane_list_hides_historical_credentials_and_unlink_revokes_them(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
 ):
@@ -4510,8 +4364,7 @@ async def test_env_bound_list_channels_hides_historical_local_whatsapp_credentia
     )
     account = await db_session.get(ChannelAccount, UUID(account_id))
     assert account is not None
-    # Seed historical persisted state directly to verify the env-bound read
-    # projection without reopening tenant-credential admission.
+    # Seed historical persisted state without reopening tenant-credential admission.
     await load_or_create_whatsapp_auth_cert(db_session, account=account)
     first = await mint_whatsapp_agent_credential(
         db_session,
@@ -4556,14 +4409,6 @@ async def test_env_bound_list_channels_hides_historical_local_whatsapp_credentia
         str(second.credential.id),
     }
 
-    api_key = ApiKey(user_id=user.id, environment_id=agent.id, label="hosted-wa-runtime")
-    async with _client_for_api_key(db_session, user, api_key) as runtime_client:
-        listed = await runtime_client.get("/v1/channels")
-
-    assert listed.status_code == 200, listed.text
-    assert str(first.credential.id) not in listed.text
-    assert listed.json() == []
-
     async with _client_for_user(db_session, user) as user_client:
         deleted = await user_client.delete(f"/v1/channels/{account_id}/agent-links/{link.id}")
     assert deleted.status_code == 204, deleted.text
@@ -4584,9 +4429,21 @@ async def test_env_bound_list_channels_hides_historical_local_whatsapp_credentia
 
 
 @pytest.mark.asyncio
-async def test_agent_bound_runtime_contract_issues_only_synthetic_whatsapp_state(
+async def test_whatsapp_agent_link_maintains_synthetic_credential_lifecycle(
     db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
 ):
+    runtime_signals: list[tuple[UUID, UUID]] = []
+
+    async def record_runtime_signal(_db, user_id: UUID, environment_id: UUID) -> bool:
+        runtime_signals.append((user_id, environment_id))
+        return True
+
+    monkeypatch.setattr(
+        public_router,
+        "queue_environment_runtime_manifest_changed",
+        record_runtime_signal,
+    )
     user, agent = await _create_user_with_channel_agent(
         db_session,
         label="runtime-wa-synthetic",
@@ -4605,50 +4462,72 @@ async def test_agent_bound_runtime_contract_issues_only_synthetic_whatsapp_state
             json={"agent_id": str(agent.id)},
         )
     assert linked.status_code == 201, linked.text
+    assert runtime_signals == [(user.id, agent.id)]
     link = await db_session.get(ChannelBotAgentLink, UUID(linked.json()["id"]))
     assert link is not None
-    agent_token = linked.json()["agent_token"]
-
-    api_key = ApiKey(user_id=user.id, environment_id=agent.id, label="hosted-wa-runtime")
-    async with _client_for_api_key(db_session, user, api_key) as runtime_client:
-        listed = await runtime_client.get("/v1/channels")
-        listed_again = await runtime_client.get("/v1/channels")
-
-    assert listed.status_code == 200, listed.text
-    assert listed_again.status_code == 200, listed_again.text
-    assert len(listed.json()) == 1
-    runtime_account = listed.json()[0]
-    assert runtime_account["id"] == created["id"]
-    assert runtime_account["runtime_links"] == [
-        {
-            "id": str(link.id),
-            "account_id": created["id"],
-            "agent_id": str(agent.id),
-            "status": "active",
-            "created_at": runtime_account["runtime_links"][0]["created_at"],
-            "agent_token": agent_token,
-        }
-    ]
-    assert len(runtime_account["runtime_credentials"]) == 1
-    credential = runtime_account["runtime_credentials"][0]
-    assert credential["agent_link_id"] == str(link.id)
-    assert credential["kind"] == "whatsapp_baileys_auth_state"
-    assert credential["material"]["schemaVersion"] == "clawdi.whatsappBaileysAuthState.v1"
-    assert credential["material"]["websocketUrl"].endswith("/v1/channels/whatsapp/baileys")
-    assert credential["material"]["authCert"]["ISSUER"] == "clawdi"
-    serialized = json.dumps(credential["material"])
-    assert "providerToken" not in serialized
-    assert "physicalAuthState" not in serialized
-    assert "phone_number_id" not in serialized
-    assert listed_again.json()[0]["runtime_credentials"][0]["id"] == credential["id"]
-    credential_count = await db_session.scalar(
-        select(func.count(ChannelAgentCredential.id)).where(
+    credential = await db_session.scalar(
+        select(ChannelAgentCredential).where(
             ChannelAgentCredential.account_id == UUID(created["id"]),
             ChannelAgentCredential.bot_agent_link_id == link.id,
             ChannelAgentCredential.revoked_at.is_(None),
         )
     )
-    assert credential_count == 1
+    assert credential is not None
+    credential.revoked_at = datetime.now(UTC)
+    await db_session.commit()
+
+    runtime_signals.clear()
+    async with _client_for_user(db_session, user) as user_client:
+        credential_repaired_pair_code = await user_client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"agent_link_id": str(link.id), "ttl_seconds": 900},
+        )
+    assert credential_repaired_pair_code.status_code == 201, credential_repaired_pair_code.text
+    assert runtime_signals == [(user.id, agent.id)]
+    repaired_credential = await db_session.scalar(
+        select(ChannelAgentCredential).where(
+            ChannelAgentCredential.account_id == UUID(created["id"]),
+            ChannelAgentCredential.bot_agent_link_id == link.id,
+            ChannelAgentCredential.revoked_at.is_(None),
+        )
+    )
+    assert repaired_credential is not None
+    repaired_credential_id = repaired_credential.id
+    auth_cert = await db_session.scalar(
+        select(ChannelWhatsAppAuthCert).where(
+            ChannelWhatsAppAuthCert.account_id == UUID(created["id"])
+        )
+    )
+    assert auth_cert is not None
+    await db_session.delete(auth_cert)
+    await db_session.commit()
+
+    runtime_signals.clear()
+    async with _client_for_user(db_session, user) as user_client:
+        auth_cert_repaired_pair_code = await user_client.post(
+            f"/v1/channels/{created['id']}/pair-codes",
+            json={"agent_link_id": str(link.id), "ttl_seconds": 900},
+        )
+    assert auth_cert_repaired_pair_code.status_code == 201, auth_cert_repaired_pair_code.text
+    assert runtime_signals == [(user.id, agent.id)]
+    active_credential_ids = set(
+        await db_session.scalars(
+            select(ChannelAgentCredential.id).where(
+                ChannelAgentCredential.account_id == UUID(created["id"]),
+                ChannelAgentCredential.bot_agent_link_id == link.id,
+                ChannelAgentCredential.revoked_at.is_(None),
+            )
+        )
+    )
+    assert active_credential_ids == {repaired_credential_id}
+    assert (
+        await db_session.scalar(
+            select(ChannelWhatsAppAuthCert.id).where(
+                ChannelWhatsAppAuthCert.account_id == UUID(created["id"])
+            )
+        )
+        is not None
+    )
 
     async with _client_for_user(db_session, user) as user_client:
         browser_list = await user_client.get("/v1/channels")
@@ -4663,11 +4542,14 @@ async def test_agent_bound_runtime_contract_issues_only_synthetic_whatsapp_state
         deleted = await user_client.delete(f"/v1/channels/{created['id']}/agent-links/{link.id}")
     assert deleted.status_code == 204, deleted.text
 
-    async with _client_for_api_key(db_session, user, api_key) as runtime_client:
-        listed_after_unlink = await runtime_client.get("/v1/channels")
-
-    assert listed_after_unlink.status_code == 200, listed_after_unlink.text
-    assert listed_after_unlink.json() == []
+    active_after_unlink = await db_session.scalar(
+        select(func.count(ChannelAgentCredential.id)).where(
+            ChannelAgentCredential.account_id == UUID(created["id"]),
+            ChannelAgentCredential.bot_agent_link_id == link.id,
+            ChannelAgentCredential.revoked_at.is_(None),
+        )
+    )
+    assert active_after_unlink == 0
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -19,7 +19,8 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.auth import AuthContext, get_auth
 from app.core.config import settings
-from app.core.database import get_runtime_snapshot_session, get_session
+from app.core.database import engine as runtime_engine
+from app.core.database import get_session
 from app.main import app
 from app.models.agent_project_binding import AgentProjectBinding
 from app.models.ai_provider import AiProvider, AiProviderAuthPayload
@@ -28,8 +29,10 @@ from app.models.audit import ControlPlaneAuditEvent
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     ChannelAccount,
+    ChannelAgentCredential,
     ChannelBinding,
     ChannelBotAgentLink,
+    ChannelWhatsAppAuthCert,
 )
 from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
 from app.models.project import PROJECT_KIND_WORKSPACE, Project
@@ -49,6 +52,7 @@ from app.schemas.runtime import (
 )
 from app.services import sync_events
 from app.services.audit import _sanitize_audit_details
+from app.services.channels import channel_runtime_account_key, channel_runtime_placeholder_token
 from app.services.managed_ai_provider import CLAWDI_MANAGED_PROVIDER_ID
 from app.services.runtime_source import (
     RUNTIME_BUNDLE_V2_MEDIA_TYPE,
@@ -430,7 +434,6 @@ async def _runtime_client(db_session, seed_user, api_key: ApiKey | None):
         return AuthContext(user=seed_user, api_key=api_key)
 
     app.dependency_overrides[get_session] = _override_get_session
-    app.dependency_overrides[get_runtime_snapshot_session] = _override_get_session
     app.dependency_overrides[get_auth] = _override_get_auth
     transport = ASGITransport(app=app)
     return httpx.AsyncClient(
@@ -4224,12 +4227,124 @@ async def test_agent_link_lifecycle_advances_polled_source_but_chat_binding_does
 
 
 @pytest.mark.asyncio
+async def test_runtime_manifest_repairs_and_invalidates_an_existing_whatsapp_link(
+    admin_client,
+    db_session,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    env, _, _, account, link = await _create_bundle_runtime(
+        admin_client,
+        db_session,
+        seed_user,
+    )
+    account.provider = "whatsapp"
+    await db_session.commit()
+
+    def reject_auth_cert_private_key_decrypt(*_args) -> str:
+        raise AssertionError("runtime manifest must not decrypt WhatsApp auth-cert private keys")
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_baileys.decrypt",
+        reject_auth_cert_private_key_decrypt,
+    )
+
+    api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="whatsapp-repair")
+    target_queue = sync_events.subscribe(
+        seed_user.id,
+        frozenset(),
+        environment_id=env.id,
+    )
+    try:
+        async with await _runtime_client(db_session, seed_user, api_key) as client:
+            repaired = await client.get("/v1/runtime/manifest")
+            assert repaired.status_code == 200, repaired.text
+            binding = repaired.json()["channelBindings"][0]
+            credential = await db_session.scalar(
+                select(ChannelAgentCredential).where(
+                    ChannelAgentCredential.bot_agent_link_id == link.id,
+                    ChannelAgentCredential.revoked_at.is_(None),
+                )
+            )
+            assert credential is not None
+            assert (
+                await db_session.scalar(
+                    select(ChannelWhatsAppAuthCert).where(
+                        ChannelWhatsAppAuthCert.account_id == account.id
+                    )
+                )
+                is not None
+            )
+            account_key = channel_runtime_account_key(account.id)
+            capability_ref = (
+                f"secret://channels/whatsapp/{account_key}/links/{link.id}/egress-capability"
+            )
+            assert binding == {
+                "provider": "whatsapp",
+                "accountId": str(account.id),
+                "accountKey": account_key,
+                "linkId": str(link.id),
+                "agentTokenSecretRef": (
+                    f"secret://channels/whatsapp/{account_key}/links/{link.id}/agent-token"
+                ),
+                "placeholderTokenSecretRef": capability_ref,
+                "credential": {
+                    "id": str(credential.id),
+                    "credsSecretRef": (
+                        f"secret://channels/whatsapp/{account_key}/credentials/"
+                        f"{credential.id}/creds-json"
+                    ),
+                    "authCert": binding["credential"]["authCert"],
+                },
+            }
+            assert repaired.json()["secretValues"][capability_ref] == (
+                channel_runtime_placeholder_token("whatsapp", account_key, link_id=link.id)
+            )
+
+            repeated = await client.get("/v1/runtime/manifest")
+            assert repeated.status_code == 200, repeated.text
+            assert repeated.json()["sourceRevision"] == repaired.json()["sourceRevision"]
+            credential_count = await db_session.scalar(
+                select(func.count())
+                .select_from(ChannelAgentCredential)
+                .where(
+                    ChannelAgentCredential.bot_agent_link_id == link.id,
+                    ChannelAgentCredential.revoked_at.is_(None),
+                )
+            )
+            assert credential_count == 1
+
+            rotated = await client.post(f"/v1/channels/{account.id}/agent-links/{link.id}/token")
+            assert rotated.status_code == 200, rotated.text
+            assert target_queue.get_nowait() == {
+                "type": "runtime_manifest_changed",
+                "environment_id": str(env.id),
+            }
+            token_rotated = await client.get("/v1/runtime/manifest")
+            assert token_rotated.status_code == 200, token_rotated.text
+            assert token_rotated.json()["sourceRevision"] != repaired.json()["sourceRevision"]
+
+            deleted = await client.delete(f"/v1/channels/{account.id}/agent-links/{link.id}")
+            assert deleted.status_code == 204, deleted.text
+            assert target_queue.get_nowait() == {
+                "type": "runtime_manifest_changed",
+                "environment_id": str(env.id),
+            }
+            removed = await client.get("/v1/runtime/manifest")
+            assert removed.status_code == 200, removed.text
+            assert removed.json()["channelBindings"] == []
+    finally:
+        app.dependency_overrides.clear()
+        sync_events.unsubscribe(seed_user.id, target_queue)
+
+
+@pytest.mark.asyncio
 async def test_runtime_bundle_missing_token_fails_closed_and_query_count_is_constant(
     admin_client, db_session, seed_user
 ):
     env, _, _, _, link = await _create_bundle_runtime(admin_client, db_session, seed_user)
     api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="bundle")
-    engine = db_session.bind.sync_engine
+    observed_engines = {db_session.bind.sync_engine, runtime_engine.sync_engine}
     select_count = 0
 
     def count_selects(_connection, _cursor, statement, _parameters, _context, _many):
@@ -4237,7 +4352,8 @@ async def test_runtime_bundle_missing_token_fails_closed_and_query_count_is_cons
         if statement.lstrip().upper().startswith("SELECT"):
             select_count += 1
 
-    event.listen(engine, "before_cursor_execute", count_selects)
+    for observed_engine in observed_engines:
+        event.listen(observed_engine, "before_cursor_execute", count_selects)
     try:
         async with await _runtime_client(db_session, seed_user, api_key) as client:
             select_count = 0
@@ -4255,7 +4371,8 @@ async def test_runtime_bundle_missing_token_fails_closed_and_query_count_is_cons
                 "/v1/runtime/manifest", headers={"Accept": "application/json"}
             )
     finally:
-        event.remove(engine, "before_cursor_execute", count_selects)
+        for observed_engine in observed_engines:
+            event.remove(observed_engine, "before_cursor_execute", count_selects)
         app.dependency_overrides.clear()
     assert healthy.status_code == 200
     # One bounded Project Skill graph query joins all requested Agents; the

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -8,10 +8,19 @@ from uuid import UUID, uuid4
 import pytest
 
 from app.models.ai_provider import AiProvider, AiProviderAuthPayload
-from app.models.channel import ChannelAccount, ChannelBotAgentLink
-from app.models.hosted_runtime import HostedRuntimeSecret, HostedRuntimeState
+from app.models.channel import (
+    ChannelAccount,
+    ChannelAgentCredential,
+    ChannelBotAgentLink,
+    ChannelWhatsAppAuthCert,
+)
+from app.models.hosted_runtime import (
+    HostedRuntimeSecret,
+    HostedRuntimeState,
+)
 from app.models.session import AgentEnvironment
 from app.schemas.runtime import HostedCodexProviderProjection
+from app.services.channels import channel_runtime_account_key, channel_runtime_placeholder_token
 from app.services.managed_ai_provider import (
     CLAWDI_MANAGED_PROVIDER_ID,
     V2_LEGACY_MANAGED_AI_PROVIDER_ID,
@@ -250,6 +259,40 @@ def _add_prefix_colliding_channel(batch: RuntimeSourceBatch) -> None:
     batch.channels[ENV_ID] = (*batch.channels[ENV_ID], (account, link))
 
 
+def _use_whatsapp_channel(
+    batch: RuntimeSourceBatch,
+) -> tuple[ChannelAgentCredential, ChannelWhatsAppAuthCert]:
+    account, link = batch.channels[ENV_ID][0]
+    account.provider = "whatsapp"
+    credential = ChannelAgentCredential(
+        id=UUID("80000000-0000-0000-0000-000000000011"),
+        account_id=account.id,
+        bot_agent_link_id=link.id,
+        user_id=USER_ID,
+        provider="whatsapp",
+        identity_pub_key_hash="1" * 64,
+        identity_public_key=b"identity-public-key",
+        synthetic_jid="15551234567:1@s.whatsapp.net",
+        encrypted_credentials=b'{"advSecretKey":"managed-whatsapp"}',
+        credential_nonce=b"credential-nonce",
+    )
+    auth_cert = ChannelWhatsAppAuthCert(
+        id=UUID("90000000-0000-0000-0000-000000000012"),
+        account_id=account.id,
+        user_id=USER_ID,
+        root_public_key=b"r" * 32,
+        encrypted_root_private_key=b"root-private",
+        root_private_key_nonce=b"root-nonce",
+        intermediate_public_key=b"i" * 32,
+        encrypted_intermediate_private_key=b"intermediate-private",
+        intermediate_private_key_nonce=b"intermediate-nonce",
+        serial=7,
+    )
+    batch.channel_credentials[link.id] = credential
+    batch.whatsapp_auth_certs[account.id] = auth_cert
+    return credential, auth_cert
+
+
 def _use_managed_provider(
     batch: RuntimeSourceBatch,
     *,
@@ -317,6 +360,67 @@ def test_runtime_source_revision_uses_only_projected_descriptor_and_secret_sourc
             ),
         }
     ]
+
+
+def test_runtime_source_binds_whatsapp_capability_and_revision_to_link_credential_and_cert(
+    monkeypatch,
+) -> None:
+    from app.services import runtime_source
+
+    batch = _batch()
+    credential, auth_cert = _use_whatsapp_channel(batch)
+    account, link = batch.channels[ENV_ID][0]
+    monkeypatch.setattr(runtime_source, "decrypt", lambda ciphertext, _nonce: ciphertext.decode())
+
+    source = render_runtime_source(
+        batch,
+        environment_id=ENV_ID,
+        public_api_url="https://cloud.test/",
+        vault_key_identity="vault-key-generation-1",
+        decrypt_secrets=True,
+    )
+    account_key = channel_runtime_account_key(account.id)
+    agent_ref = f"secret://channels/whatsapp/{account_key}/links/{link.id}/agent-token"
+    capability_ref = f"secret://channels/whatsapp/{account_key}/links/{link.id}/egress-capability"
+    credential_ref = (
+        f"secret://channels/whatsapp/{account_key}/credentials/{credential.id}/creds-json"
+    )
+    assert source.channel_bindings == [
+        {
+            "provider": "whatsapp",
+            "accountId": str(account.id),
+            "accountKey": account_key,
+            "linkId": str(link.id),
+            "agentTokenSecretRef": agent_ref,
+            "placeholderTokenSecretRef": capability_ref,
+            "credential": {
+                "id": str(credential.id),
+                "credsSecretRef": credential_ref,
+                "authCert": {
+                    "SERIAL": 7,
+                    "ISSUER": "clawdi",
+                    "PUBLIC_KEY": {
+                        "type": "Buffer",
+                        "data": "cnJycnJycnJycnJycnJycnJycnJycnJycnJycnJycnI=",
+                    },
+                },
+            },
+        }
+    ]
+    assert source.secret_values[capability_ref] == channel_runtime_placeholder_token(
+        "whatsapp", account_key, link_id=link.id
+    )
+    assert source.secret_values[credential_ref] == credential.encrypted_credentials.decode()
+
+    initial_revision = source.source_revision
+    credential.encrypted_credentials = b'{"advSecretKey":"rotated"}'
+    credential_rotated = _render(batch)
+    credential.encrypted_credentials = b'{"advSecretKey":"managed-whatsapp"}'
+    auth_cert.root_public_key = b"s" * 32
+    cert_rotated = _render(batch)
+
+    assert credential_rotated.source_revision != initial_revision
+    assert cert_rotated.source_revision != initial_revision
 
 
 def test_runtime_source_delivers_owned_oauth_only_to_selected_runtime(monkeypatch) -> None:

--- a/docs/adr/0003-runtime-bundle-media-type-is-the-render-contract.md
+++ b/docs/adr/0003-runtime-bundle-media-type-is-the-render-contract.md
@@ -1,6 +1,6 @@
 # ADR-0003: Runtime Bundle Media Type Is the Render Contract
 
-**Status:** Accepted (amended 2026-07-30)
+**Status:** Accepted (amended 2026-08-11)
 **Date:** 2026-07-13
 **Deciders:** Clawdi maintainers
 
@@ -17,20 +17,35 @@ renderer setting would add invalidation paths that can be missed.
 `application/vnd.clawdi.runtime-bundle.v2+json` is the immutable renderer
 contract for Agent v2. A client requesting that exact representation receives
 one strict `clawdi.hosted-runtime.bundle.v2` response containing the hosted
-manifest, sanitized Telegram and Discord channel bindings, merged secret
-values, and a deterministic `sourceRevision`.
+manifest, sanitized Telegram, Discord, and WhatsApp channel bindings, merged
+secret values, and a deterministic `sourceRevision`.
 
 The v2 renderer and canonical JSON encoding are frozen except for the narrow
-consumer-first amendment below. Any other response-affecting behavior change
+consumer-first amendments below. Any other response-affecting behavior change
 requires a new media type and schema version. An unsupported
 or missing media type returns `406`; the CLI does not fall back to a legacy
 manifest representation or a separate `/v1/channels` flow. Agent v2 had no
 released client, so the endpoint has no unpublished compatibility response.
 
 The backend loads environment state, providers, selected encrypted auth
-payloads, and active Telegram/Discord links with set-based queries inside one
-`REPEATABLE READ READ ONLY` snapshot. The endpoint and runtime health summary
-use the same pure materializer. Summary rendering does not decrypt secrets.
+payloads, and active Telegram/Discord/WhatsApp links with set-based queries
+inside one `REPEATABLE READ READ ONLY` snapshot. The endpoint and runtime health
+summary use the same pure materializer. Summary rendering does not decrypt
+secrets.
+
+WhatsApp bindings scope agent-token and egress-capability references to the
+Agent Link. Their credential descriptor declares an id, `credsSecretRef`, and
+public auth-certificate material; the CLI consumes that declared reference
+rather than reconstructing a path. Missing persisted material is repaired only
+after a snapshot detects it, under one account lock with a locked recheck, then
+rendered from a new snapshot. Healthy polling performs no repair lookup, lock,
+or auth-certificate private-key decryption.
+
+This addition follows consumer-first release order: the CLI consumer that
+validates and projects the fields is published and selected before the Hosted
+producer emits them. The ordering is operational, not a code gate; v2 contains
+no producer-version detection, compatibility fallback, or alternate channel
+datasource.
 
 The runtime provider plane has an explicit `configured | unmanaged`
 discriminator. Runtime `providers` remains an exact projection of runtime
@@ -114,7 +129,8 @@ permanent dual-track protocol.
 - Missing or unsupported media-type `406` responses vary on `Accept` and are
   not cached.
 - Database mutation fan-out and cross-table revision triggers are unnecessary.
-- WhatsApp uses the same v2 render contract and Link-scoped CLI projection.
+- WhatsApp uses the same v2 render contract with Link-scoped agent-token and
+  capability references plus an explicit credential secret reference.
 - Offline recovery caches the effective projected manifest. Secret persistence
   remains limited to the existing root-only, reference-scoped secret cache; the
   plaintext bundle is never persisted as a whole.

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -13,6 +13,10 @@ system map, read [`architecture.md`](architecture.md#api-and-identity).
 
 ## Canonical surface
 
+`/v1` is the canonical Clawdi Cloud API namespace. Hosted runtime “bundle v2” is
+a media-type and schema contract served by `GET /v1/runtime/manifest`; it is not
+a replacement `/v2` URL namespace.
+
 `/v1/agents` is the canonical first-party API for Agent identity. New dashboard
 and CLI code should use `/v1/agents` and `agent_id` path parameters for
 registration, listing, detail reads, updates, ordering, avatars, disconnect, and
@@ -21,6 +25,13 @@ sync heartbeat.
 `/v1/admin/agents` is the agent-first admin route family for local/admin callers
 that use `X-Admin-Key`. Admin routes are live but hidden from the public OpenAPI
 schema because `backend/app/routes/admin.py` sets `include_in_schema=False`.
+
+`GET /v1/channels` is the user control-plane channel list and rejects
+environment-bound Agent API keys. Managed runtimes receive channel desired state
+only through the strict bundle returned by `GET /v1/runtime/manifest`.
+The removed environment-bound response variant was not used by released Hosted
+init/watch consumers; unbound CLI control-plane channel operations remain
+supported.
 
 The stable agent id is still stored in `agent_environments.id`; code and older
 wire contracts still use `AgentEnvironment` and `environment_id` names in many

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -479,10 +479,10 @@ auth when exposing the official OpenClaw port directly.
 The control plane accepts only exact
 `Accept: application/vnd.clawdi.runtime-bundle.v2+json` and returns strict
 `clawdi.hosted-runtime.bundle.v2`. The response contains the hosted manifest,
-sanitized Telegram and Discord `channelBindings`, one merged `secretValues`
-map, and deterministic `sourceRevision`. Missing or unsupported media types
-return `406`; the CLI does not fall back to another representation or a second
-`/v1/channels` request.
+sanitized Telegram, Discord, and WhatsApp `channelBindings`, one merged
+`secretValues` map, and deterministic `sourceRevision`. Missing or unsupported
+media types return `406`; the CLI does not fall back to another representation
+or a second `/v1/channels` request.
 
 Bundle responses identify the vendor media type and return `Vary: Accept`.
 Negotiation `406` responses also return `Vary: Accept` and
@@ -493,16 +493,24 @@ validator without decrypting secrets in the health summary.
 
 ### Channel reconcile boundary
 
-Telegram and Discord `ChannelBotAgentLink` rows are runtime desired state. A
-link create or re-link, link delete, account archive, or link credential
-rotation changes the rendered channel projection and therefore
+Telegram, Discord, and WhatsApp `ChannelBotAgentLink` rows are runtime desired
+state. A link create or re-link, link delete, account archive, or link
+credential rotation changes the rendered channel projection and therefore
 `sourceRevision`. Those mutation transactions also enqueue the existing
 signal-only `runtime_manifest_changed` event for the linked Agent. The event is
 delivered only after commit; the runtime refetches the manifest and converges at
 the normal ETag/sourceRevision boundary. ETag polling remains the missed-event
 fallback, so no separate restart or channel-specific reconcile state machine is
 required. Creating a pair code emits this signal only when that request also
-creates an AgentLink.
+creates an AgentLink or repairs missing WhatsApp credential material.
+
+Each WhatsApp binding carries Link-scoped agent-token and egress-capability
+secret references plus a credential descriptor containing its id, explicit
+`credsSecretRef`, and public auth-certificate material. The matching serialized
+Baileys credentials are present in `secretValues` only under that declared
+reference. Healthy manifest reads use the repeatable-read snapshot directly;
+missing credential or auth-certificate rows enter a locked, idempotent repair
+path and then render from a fresh snapshot.
 
 `ChannelBinding` rows are provider routing state, not runtime identity. Pairing
 or unpairing a chat updates only the binding and provider-owned per-chat
@@ -1436,6 +1444,13 @@ CLI version that understands the new fields, then advance existing deployments
 through ordinary higher-generation runtime-state reconciliation. Database
 migrations backfill stored authority where required; operators do not patch
 individual production rows to advance deployments.
+
+The WhatsApp channel binding follows that same order: this producer change stays
+stacked and unmerged until `clawdi@0.13.56` is published, selected by Hosted, and
+verified on active runtimes. Only then may the Hosted producer emit WhatsApp
+bindings. This is operational release sequencing, not a code gate: the OSS
+consumer has no producer-version detection, feature flag, fallback datasource,
+or dual contract.
 
 For the optional v2 `applyGeneration` amendment, strict older consumers reject
 the new root field. This OSS consumer release must deploy before Hosted producer

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -4539,106 +4539,6 @@ export interface components {
             /** Discord User Install Url */
             discord_user_install_url?: string | null;
         };
-        /** ChannelRuntimeAccountResponse */
-        ChannelRuntimeAccountResponse: {
-            /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
-            /** Provider */
-            provider: string;
-            /** Name */
-            name: string;
-            /** Status */
-            status: string;
-            /**
-             * Visibility
-             * @default private
-             * @enum {string}
-             */
-            visibility: "private" | "public";
-            /** Has Provider Token */
-            has_provider_token: boolean;
-            /** Webhook Url */
-            webhook_url: string;
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /** Runtime Links */
-            runtime_links?: components["schemas"]["ChannelRuntimeAgentLinkResponse"][];
-            /** Runtime Credentials */
-            runtime_credentials?: components["schemas"]["ChannelRuntimeCredentialResponse"][];
-        };
-        /** ChannelRuntimeAgentLinkResponse */
-        ChannelRuntimeAgentLinkResponse: {
-            /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
-            /**
-             * Account Id
-             * Format: uuid
-             */
-            account_id: string;
-            /**
-             * Agent Id
-             * Format: uuid
-             */
-            agent_id: string;
-            /** Status */
-            status: string;
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /** Agent Token */
-            agent_token?: string | null;
-        };
-        /** ChannelRuntimeCredentialResponse */
-        ChannelRuntimeCredentialResponse: {
-            /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
-            /**
-             * Account Id
-             * Format: uuid
-             */
-            account_id: string;
-            /**
-             * Agent Link Id
-             * Format: uuid
-             */
-            agent_link_id: string;
-            /**
-             * Agent Id
-             * Format: uuid
-             */
-            agent_id: string;
-            /** Provider */
-            provider: string;
-            /** Kind */
-            kind: string;
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /** Jid */
-            jid?: string | null;
-            /** Identity Pub Key Hex */
-            identity_pub_key_hex?: string | null;
-            /** Material */
-            material?: {
-                [key: string]: unknown;
-            } | null;
-        };
         /** ChannelSendMessageRequest */
         ChannelSendMessageRequest: {
             /** Binding Id */
@@ -8859,9 +8759,7 @@ export interface operations {
     };
     list_channels_v1_channels_get: {
         parameters: {
-            query?: {
-                environment_id?: string | null;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
@@ -8874,16 +8772,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": (components["schemas"]["ChannelAccountResponse"] | components["schemas"]["ChannelRuntimeAccountResponse"])[];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["ChannelAccountResponse"][];
                 };
             };
         };


### PR DESCRIPTION
## Summary

- emit Link-scoped WhatsApp bindings, synthetic credential references, and public auth-certificate material from strict runtime bundle v2
- repair only missing credential/auth-certificate material under an account lock, then render from a fresh repeatable-read snapshot
- invalidate runtime manifests on WhatsApp Link creation, token rotation, unlink, account archive, and material repair through control-plane mutations
- retire the unused environment-bound runtime variant of `GET /v1/channels`; that endpoint remains the user control-plane list, while strict bundle v2 is the sole managed runtime channel datasource
- regenerate the typed API client and document the v1 URL namespace versus the bundle v2 media/schema contract

## Stacked rollout boundary

This PR is producer-only and is stacked on consumer PR #927.

There is deliberately no CLI-version gate, feature flag, fallback datasource, or dual contract. Do not merge this producer until:

1. #927 is merged and `clawdi@0.13.56` is published.
2. Hosted selects that exact CLI package spec.
3. Active Hosted runtimes are verified to be running `0.13.56`.

After those consumer-first checks, this producer can merge and ordinary manifest invalidation/polling will converge WhatsApp exactly like Telegram and Discord. No production, tenant, or Hosted AppSetting operation is part of this PR.

`/v1` remains the canonical Cloud API namespace. Bundle v2 is the exact media/schema returned by `GET /v1/runtime/manifest`, not a `/v2` URL replacement. The separate `/v2/runtime/*` routes remain declarative runtime observation APIs.

## Reconcile behavior

Creating an Agent Link prepares WhatsApp runtime material in the same transaction and emits the normal `runtime_manifest_changed` signal. Creating a chat Pair only changes `ChannelBinding`, so it does not restart or reconfigure the runtime. If historical material is missing, the next manifest read repairs it idempotently and returns the newly rendered bundle; pair-code/link control-plane repair also emits invalidation.

`sourceRevision` covers Link token ciphertext/nonce, Link-scoped capability identity, credential ciphertext/nonce, and public auth-certificate material. Healthy polling remains read-only and does not decrypt auth-certificate private keys.

## Upstream contracts

- OpenClaw account `authDir`: https://github.com/openclaw/openclaw/blob/2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4/extensions/whatsapp/src/accounts.ts#L96-L115
- OpenClaw Baileys auth loading: https://github.com/openclaw/openclaw/blob/2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4/extensions/whatsapp/src/session.ts#L157-L188
- Hermes `session_path` preference: https://github.com/NousResearch/hermes-agent/blob/cc4cab2f592e60a197e796506de9168f74baf3ea/plugins/platforms/whatsapp/adapter.py#L393-L408
- Hermes legacy session fallback: https://github.com/NousResearch/hermes-agent/blob/cc4cab2f592e60a197e796506de9168f74baf3ea/hermes_constants.py#L239-L274

## Verification

- focused isolated backend suite: 759 passed
- full backend suite on a fresh isolated database: 2244 passed, 11 skipped
- Ruff lint and touched-file formatting: passed
- Python compileall: passed
- generated API client consistency: passed
- `git diff --check`: passed

The repository-wide Ruff format check is blocked only by pre-existing formatting in untouched `backend/tests/test_projects_routes.py`.