### PR TITLE
fix(cli): hide hosted platform state from tenants (0.13.55)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.54",
+      "version": "0.13.55",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -158,8 +158,14 @@ flowchart TB
     subgraph Durable["Durable non-secret state: /var/lib/clawdi"]
         Inventory[install-inventory/<runtime>.json]
         CliBin[root-only maintained/clawdi/bin/clawdi]
-        UserUnits[$HOME/.config/systemd/user/*.service]
     end
+
+    subgraph TenantState["Tenant-UID CLI state: /var/lib/clawdi-user"]
+        LiveSync[environments/<agent>.json]
+    end
+
+    Init --> TenantState
+    Init --> UserUnits[$HOME/.config/systemd/user/*.service]
 
     subgraph Cache["Disposable cache: /var/cache/clawdi"]
         LastGood[manifest and secret last-good fallbacks]
@@ -227,6 +233,10 @@ systemd-owned roots instead of recursively hardening their ownership. The run
 root is searchable only for the two explicit platform-to-tenant handoff
 classes: the egress CA and per-unit tenant environment files. All other
 platform files remain private or are exposed only to dedicated system services.
+Tenant-context CLI state has a separate durable root,
+`/var/lib/clawdi-user`, owned by `10001:10001` with mode `0750`. Hosted
+convergence sets `CLAWDI_HOME` to that path for every generated tenant user
+unit; `/var/lib/clawdi` remains the root-owned platform state root.
 Before directory preparation, lock acquisition, or any external runtime command,
 Hosted convergence requires the explicit process contract
 `CLAWDI_RUNTIME_MODE=hosted`, a resolved HOME of exactly `/home/clawdi`, and
@@ -790,6 +800,13 @@ its exact managed package is isolated under
 egress wrapper can delegate to it without replacing the tenant's general npm
 global tree.
 
+The hosted image's bootstrap package may expose
+`/usr/local/bin/clawdi -> ../lib/node_modules/clawdi/bin/clawdi.mjs` while root
+convergence starts. Reconciliation removes only that exact system-npm symlink
+and rejects any unexpected entry or target at the same path. All continuing
+platform invocations use `/var/lib/clawdi/maintained/clawdi/bin/clawdi`
+directly, so a tenant shell cannot discover `clawdi` through `PATH`.
+
 CLI self-upgrade verifies a new exact package before atomically switching the
 active link inside the root-only managed directory. There is no shared
 `/var/lib/clawdi/bin` compatibility path and no migration or dual-path read.
@@ -1076,6 +1093,7 @@ and ephemeral runtime handoffs. Important outputs include:
 | `/var/lib/clawdi/managed-resources/*.json` | Durable managed Skill and MCP ownership ledgers |
 | `/var/lib/clawdi/maintained/filebrowser/candidates/<sha256>/filebrowser` | Root-owned, verified Files executable |
 | `/var/lib/clawdi/maintained/clawdi/` | Root-only managed CLI activation and versioned package prefixes |
+| `/var/lib/clawdi-user/` | Tenant-owned `0750` hosted CLI state selected by `CLAWDI_HOME` |
 | `/var/lib/clawdi-files/` | `clawdi-files`-owned `0700` DB and component cache state |
 | `/var/cache/clawdi/manifest.last-good.json` | Refetchable last-good manifest fallback |
 | `/var/cache/clawdi/runtime-secrets.last-good.json` | Root-only refetchable secret fallback for offline recovery |
@@ -1086,6 +1104,11 @@ and ephemeral runtime handoffs. Important outputs include:
 | `$CLAWDI_RUN_DIR/systemd/system/*.service` or `/run/systemd/system/*.service` | Generated system units for root-owned Clawdi support programs |
 | `$HOME/.config/systemd/user/*.service` | Official runtime gateway base units and direct runtime-user programs |
 | `$HOME/.config/systemd/user/*.service.d/10-clawdi-hosted.conf` | Transparent hosted drop-ins for official runtime units |
+
+Hosted convergence never writes `~/.clawdi`. Before launch it removes legacy
+`~/.clawdi/environments/*.json` files only when their `managedBy` value is
+exactly `clawdi runtime init`, then removes the directories only if empty.
+Unmarked files, non-regular files, and symlinks are never adopted or removed.
 
 Each reconciliation plan declares the exact managed root and runtime-user file
 targets it may mutate. Before any command that can change live state, Apply
@@ -1157,10 +1180,10 @@ credentials. When a caller opts into it, an enabled generated runtime run config
 can supply that command's configured args, cwd, env, PATH, secret refs, and
 optional sidecar profile. A disabled matching config is rejected.
 
-Interactive shell commands are not intercepted. `openclaw`, `hermes`, and
-future runtime names resolve to official binaries on PATH. Clawdi only
-participates when the caller explicitly invokes `clawdi run` or when
-`runtime init` projects manifest-selected config.
+Interactive tenant shell commands are not intercepted. `openclaw`, `hermes`,
+and future runtime names resolve to official binaries on PATH; `clawdi` does
+not. The platform invokes its root-only CLI by absolute path when it projects
+manifest-selected config.
 
 Hosted daemon startup avoids `clawdi run`. For OpenClaw/Hermes gateways,
 `runtime init` invokes the official service installer to create the base user
@@ -1178,6 +1201,9 @@ Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus"
 EnvironmentFile="/run/clawdi/systemd/env/openclaw-gateway.service.env"
 ExecStart="/home/clawdi/.openclaw/bin/openclaw" "gateway" "run" "--allow-unconfigured" "--port" "18789" "--bind" "lan" "--force"
 ```
+
+The generated environment file includes
+`CLAWDI_HOME=/var/lib/clawdi-user`; it never points into the tenant home.
 
 When egress profiles are enabled, systemd runs the Clawdi sidecar. Egress
 interception uses a runtime-fetched `mitmdump` (mitmproxy) transparent gateway

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.54",
+	"version": "0.13.55",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -4,6 +4,7 @@ import {
 	accessSync,
 	constants,
 	existsSync,
+	lstatSync,
 	mkdirSync,
 	mkdtempSync,
 	readdirSync,
@@ -17,6 +18,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { z } from "zod";
+import { HOSTED_RUNTIME_HOME, HOSTED_RUNTIME_USER } from "./hosted-runtime-contract";
 import {
 	HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE,
 	hostedCliPackageSpecSchema,
@@ -107,6 +109,36 @@ const NPM_INSTALL_TIMEOUT_MS = 180_000;
 const VERSION_SMOKE_TIMEOUT_MS = 20_000;
 const RUNTIME_VERIFY_TIMEOUT_MS = 20_000;
 const CLI_VERIFY_CACHE_MAX_AGE_MS = 300_000;
+const HOSTED_TENANT_PATH_CLI = "/usr/local/bin/clawdi";
+const HOSTED_SYSTEM_NPM_CLI = "/usr/local/lib/node_modules/clawdi/bin/clawdi.mjs";
+
+export function removeHostedCliPathExposure(paths: RuntimePaths): void {
+	if (
+		paths.mode !== "hosted" ||
+		paths.userHome !== HOSTED_RUNTIME_HOME ||
+		process.env.CLAWDI_RUNTIME_USER?.trim() !== HOSTED_RUNTIME_USER ||
+		(typeof process.geteuid === "function" && process.geteuid() !== 0)
+	) {
+		return;
+	}
+	let node: ReturnType<typeof lstatSync>;
+	try {
+		node = lstatSync(HOSTED_TENANT_PATH_CLI);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
+	if (!node.isSymbolicLink()) {
+		throw new Error(
+			`hosted tenant PATH contains an unmanaged clawdi entrypoint: ${HOSTED_TENANT_PATH_CLI}`,
+		);
+	}
+	const target = resolve(dirname(HOSTED_TENANT_PATH_CLI), readlinkSync(HOSTED_TENANT_PATH_CLI));
+	if (target !== HOSTED_SYSTEM_NPM_CLI) {
+		throw new Error(`hosted tenant PATH contains an unmanaged clawdi symlink target: ${target}`);
+	}
+	rmSync(HOSTED_TENANT_PATH_CLI);
+}
 
 interface RuntimeCliReconciliationOptions {
 	runningVersion?: string;

--- a/packages/cli/src/runtime/hosted-runtime-contract.test.ts
+++ b/packages/cli/src/runtime/hosted-runtime-contract.test.ts
@@ -40,6 +40,34 @@ describe("hosted runtime convergence contract", () => {
 		).toThrow("hosted runtime HOME must resolve to /home/clawdi; resolved /root");
 	});
 
+	test("rejects a hosted CLI state root inside the tenant home", () => {
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_HOME = "/home/clawdi";
+		process.env.CLAWDI_RUNTIME_USER = "clawdi";
+		process.env.CLAWDI_HOME = "/home/clawdi/.clawdi";
+
+		expect(() =>
+			assertHostedRuntimeContract(getRuntimePaths(), applyContext, {
+				platformRoots: "deferred",
+				resolveUserIdentity: () => ({ uid: 10_001, gid: 10_001 }),
+			}),
+		).toThrow("hosted CLAWDI_HOME must be outside the tenant home");
+	});
+
+	test("rejects a hosted CLI state root outside the service-state directory family", () => {
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_HOME = "/home/clawdi";
+		process.env.CLAWDI_RUNTIME_USER = "clawdi";
+		process.env.CLAWDI_HOME = "/var/cache/clawdi-user";
+
+		expect(() =>
+			assertHostedRuntimeContract(getRuntimePaths(), applyContext, {
+				platformRoots: "deferred",
+				resolveUserIdentity: () => ({ uid: 10_001, gid: 10_001 }),
+			}),
+		).toThrow("hosted CLAWDI_HOME must be an absolute sibling of /var/lib/clawdi");
+	});
+
 	test("rejects a hosted convergence whose runtime user is wrong", () => {
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_RUNTIME_HOME = "/home/clawdi";

--- a/packages/cli/src/runtime/hosted-runtime-contract.ts
+++ b/packages/cli/src/runtime/hosted-runtime-contract.ts
@@ -1,3 +1,4 @@
+import { dirname, isAbsolute, relative, resolve } from "node:path";
 import type { RuntimeApplyContext } from "./apply-identity";
 import type { RuntimePaths } from "./paths";
 import {
@@ -119,6 +120,23 @@ export function assertHostedRuntimeContract(
 		(check) => !check.ok,
 	)?.error;
 	if (error) throw new Error(error);
+	const stateRoot = resolve(paths.clawdiHome);
+	const serviceStateRoot = resolve(paths.serviceStateRoot);
+	const relativeState = relative(resolve(paths.userHome), stateRoot);
+	if (relativeState === "" || (!relativeState.startsWith("..") && !isAbsolute(relativeState))) {
+		throw new Error(
+			`hosted CLAWDI_HOME must be outside the tenant home; resolved ${paths.clawdiHome}`,
+		);
+	}
+	if (
+		!isAbsolute(paths.clawdiHome) ||
+		stateRoot === serviceStateRoot ||
+		dirname(stateRoot) !== dirname(serviceStateRoot)
+	) {
+		throw new Error(
+			`hosted CLAWDI_HOME must be an absolute sibling of ${paths.serviceStateRoot}; resolved ${paths.clawdiHome}`,
+		);
+	}
 	if (applyContext.backend !== "incus") {
 		throw new Error(
 			`hosted v2 convergence requires runtime context backend incus; resolved ${String(applyContext.backend ?? "missing")}`,

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -609,8 +609,10 @@ describe("runtime manifest services", () => {
 		expect(openclawEnv).toContain('CLAWDI_AUTH_TOKEN=""');
 		for (const name of ["openclaw-gateway", "hermes-gateway", "clawdi-hermes-dashboard"]) {
 			const env = readFileSync(join(paths.systemdEnvRoot, `${name}.service.env`), "utf8");
+			expect(env).toContain(`CLAWDI_HOME="${paths.clawdiHome}"`);
 			expect(env).not.toContain(dirname(paths.cliManagedBin));
 		}
+		expect(runtimeWatchEnv).toContain(`CLAWDI_HOME="${paths.clawdiHome}"`);
 
 		const serviceConfig = JSON.parse(
 			readFileSync(join(paths.runConfigRoot, "hermes+dashboard.json"), "utf8"),

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -11,6 +11,7 @@ import {
 	readdirSync,
 	readFileSync,
 	readlinkSync,
+	rmdirSync,
 	rmSync,
 	statSync,
 } from "node:fs";
@@ -73,6 +74,7 @@ import {
 	RUNTIME_AUTH_TOKEN_SECRET_REF,
 	readRuntimeAuthToken,
 } from "./auth-token";
+import { removeHostedCliPathExposure } from "./cli-update";
 import {
 	ensureFileBrowserCompanion,
 	type FileBrowserCompanionInstallOptions,
@@ -168,8 +170,7 @@ import {
 	ensureRuntimeMitmproxy,
 	type RuntimeMitmproxyEnsureResult,
 } from "./mitmproxy-fetch";
-import type { RuntimePaths } from "./paths";
-import { detectRuntimeMode } from "./paths";
+import { detectRuntimeMode, RUNTIME_USER_CLI_STATE_ROOT_MODE, type RuntimePaths } from "./paths";
 import { hostedRuntimeProjectionHome } from "./projection-home";
 import {
 	buildRuntimeRunConfig,
@@ -955,6 +956,24 @@ function makeRuntimeUserPrivateDir(path: string, home: string): void {
 		chmodSync(path, 0o700);
 	} catch {
 		// Best effort for non-POSIX local development environments.
+	}
+}
+
+function ensureRuntimeUserCliStateRoot(path: string, identity: { uid: number; gid: number }): void {
+	mkdirSync(path, { recursive: true });
+	let node = lstatSync(path);
+	if (!node.isDirectory() || node.isSymbolicLink()) {
+		throw new Error(`hosted CLAWDI_HOME must be a real directory: ${path}`);
+	}
+	if (runningAsRoot()) chownSync(path, identity.uid, identity.gid);
+	chmodSync(path, RUNTIME_USER_CLI_STATE_ROOT_MODE);
+	node = lstatSync(path);
+	if (
+		(node.mode & 0o777) !== RUNTIME_USER_CLI_STATE_ROOT_MODE ||
+		node.uid !== identity.uid ||
+		node.gid !== identity.gid
+	) {
+		throw new Error(`hosted CLAWDI_HOME ownership or mode is invalid: ${path}`);
 	}
 }
 
@@ -4576,6 +4595,67 @@ function writeLiveSyncEnvironmentFiles(manifest: RuntimeManifest, paths: Runtime
 	return written;
 }
 
+function removeLegacyTenantClawdiState(paths: RuntimePaths): void {
+	const legacyRoot = join(paths.userHome, ".clawdi");
+	if (resolve(legacyRoot) === resolve(paths.clawdiHome)) return;
+	let root: ReturnType<typeof lstatSync>;
+	try {
+		root = lstatSync(legacyRoot);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
+	if (!root.isDirectory() || root.isSymbolicLink()) return;
+	const environments = join(legacyRoot, "environments");
+	let directory: ReturnType<typeof lstatSync>;
+	try {
+		directory = lstatSync(environments);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
+	if (!directory.isDirectory() || directory.isSymbolicLink()) return;
+	let removedManagedFile = false;
+	for (const entry of readdirSync(environments)) {
+		if (!entry.endsWith(".json")) continue;
+		const path = join(environments, entry);
+		try {
+			const node = lstatSync(path);
+			if (!node.isFile() || node.isSymbolicLink()) continue;
+			let value: unknown;
+			try {
+				value = JSON.parse(readFileSync(path, "utf8")) as unknown;
+			} catch {
+				continue;
+			}
+			if (
+				typeof value !== "object" ||
+				value === null ||
+				Array.isArray(value) ||
+				(value as Record<string, unknown>).managedBy !== "clawdi runtime init"
+			) {
+				continue;
+			}
+			rmSync(path);
+			removedManagedFile = true;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+	}
+	if (!removedManagedFile) return;
+	removeEmptyLegacyDirectory(environments);
+	removeEmptyLegacyDirectory(legacyRoot);
+}
+
+function removeEmptyLegacyDirectory(path: string): void {
+	try {
+		rmdirSync(path);
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code !== "ENOENT" && code !== "ENOTEMPTY") throw error;
+	}
+}
+
 function liveSyncEnvironmentIndexPath(paths: RuntimePaths): string {
 	return paths.liveSyncEnvironmentIndex;
 }
@@ -5485,6 +5565,8 @@ export function convergeRuntimeManifest(
 		applyContext,
 		opts.hostedRuntimeContract,
 	);
+	removeHostedCliPathExposure(paths);
+	removeLegacyTenantClawdiState(paths);
 	if (manifest.companions?.filebrowser) {
 		if (manifest.projection?.sourceBundleVersion !== "clawdi.hosted-runtime.bundle.v2") {
 			throw new Error("Files companion requires a hosted v2 bundle");
@@ -5843,9 +5925,9 @@ export function convergeRuntimeManifest(
 
 		hostedRuntimeContract.assertPlatformRoots();
 		ensureRuntimeUserHome(paths.userHome);
+		ensureRuntimeUserCliStateRoot(paths.clawdiHome, hostedRuntimeContract.identity);
 		withRuntimeUserFileAccess(() => {
 			mkdirSync(workspaceRoot, { recursive: true });
-			makeRuntimeUserPrivateDir(paths.clawdiHome, paths.userHome);
 			makeRuntimeUserOwned(workspaceRoot);
 		});
 		for (const directory of [paths.installInventory, paths.projectionRoot, instanceRoot, semRoot]) {

--- a/packages/cli/src/runtime/paths.test.ts
+++ b/packages/cli/src/runtime/paths.test.ts
@@ -22,6 +22,7 @@ describe("runtime paths", () => {
 		expect(paths.fileBrowserConfigRoot).toBe("/run/clawdi/files");
 		expect(paths.fileBrowserConfig).toBe("/run/clawdi/files/filebrowser.yaml");
 		expect(paths.serviceStateRoot).toBe("/var/lib/clawdi");
+		expect(paths.clawdiHome).toBe("/var/lib/clawdi-user");
 		expect(paths.cacheRoot).toBe("/var/cache/clawdi");
 		expect(paths.runRoot).toBe("/run/clawdi");
 		expect(paths.bootStatus).toBe("/var/lib/clawdi/status/boot-status.json");
@@ -49,10 +50,11 @@ describe("runtime paths", () => {
 		expect(paths.fileBrowserConfigRoot).toBe("/tmp/runtime-fixture/run/clawdi/files");
 		expect(paths.fileBrowserConfig).toBe("/tmp/runtime-fixture/run/clawdi/files/filebrowser.yaml");
 		expect(paths.cacheRoot).toBe("/tmp/runtime-fixture/var/cache/clawdi");
+		expect(paths.clawdiHome).toBe("/tmp/runtime-fixture/var/lib/clawdi-user");
 		expect(paths.fileBrowserStateRoot).toBe("/var/lib/clawdi-files");
 	});
 
-	test("anchors hosted user state to the default runtime home", () => {
+	test("keeps hosted CLI user state outside the default runtime home", () => {
 		delete process.env.HOME;
 		delete process.env.CLAWDI_RUNTIME_HOME;
 		delete process.env.CLAWDI_HOME;
@@ -60,11 +62,11 @@ describe("runtime paths", () => {
 		const paths = getRuntimePaths({ mode: "hosted" });
 
 		expect(paths.userHome).toBe("/home/clawdi");
-		expect(paths.clawdiHome).toBe("/home/clawdi/.clawdi");
+		expect(paths.clawdiHome).toBe("/var/lib/clawdi-user");
 		expect(paths.systemdUserRoot).toBe("/home/clawdi/.config/systemd/user");
 	});
 
-	test("derives hosted user state from an explicit runtime home", () => {
+	test("keeps hosted CLI user state outside an explicit runtime home", () => {
 		process.env.HOME = "/root";
 		process.env.CLAWDI_RUNTIME_HOME = "/srv/clawdi";
 		delete process.env.CLAWDI_HOME;
@@ -72,7 +74,7 @@ describe("runtime paths", () => {
 		const paths = getRuntimePaths({ mode: "hosted" });
 
 		expect(paths.userHome).toBe("/srv/clawdi");
-		expect(paths.clawdiHome).toBe("/srv/clawdi/.clawdi");
+		expect(paths.clawdiHome).toBe("/var/lib/clawdi-user");
 	});
 
 	test("preserves the explicit Clawdi state override in hosted mode", () => {

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -11,8 +11,10 @@ export const DEFAULT_CONFIGURATION_ROOT = "/etc/clawdi";
 export const DEFAULT_SERVICE_STATE_ROOT = "/var/lib/clawdi";
 export const DEFAULT_CACHE_ROOT = "/var/cache/clawdi";
 export const DEFAULT_RUN_ROOT = "/run/clawdi";
+export const DEFAULT_RUNTIME_USER_CLI_STATE_ROOT = "/var/lib/clawdi-user";
 export const DEFAULT_FILE_BROWSER_STATE_ROOT = "/var/lib/clawdi-files";
 export const DEFAULT_FILE_BROWSER_RUNTIME_ROOT = "/run/clawdi-files";
+export const RUNTIME_USER_CLI_STATE_ROOT_MODE = 0o750;
 
 export interface RuntimePaths {
 	mode: RuntimeMode;
@@ -104,10 +106,14 @@ function defaultHome(mode: RuntimeMode): string {
 	return process.env.HOME || homedir();
 }
 
-function defaultClawdiHome(mode: RuntimeMode, userHome: string): string {
+function defaultClawdiHome(mode: RuntimeMode, serviceStateRoot: string): string {
 	if (mode === "hosted") {
-		// Keep the hosted user-state tree anchored to the resolved runtime home.
-		return process.env.CLAWDI_HOME || join(userHome, ".clawdi");
+		const override = envPath("CLAWDI_HOME");
+		if (override) return override;
+		if (serviceStateRoot === DEFAULT_SERVICE_STATE_ROOT) {
+			return DEFAULT_RUNTIME_USER_CLI_STATE_ROOT;
+		}
+		return join(dirname(serviceStateRoot), `${basename(serviceStateRoot)}-user`);
 	}
 	return getClawdiDir();
 }
@@ -152,11 +158,11 @@ export function detectRuntimeMode(): RuntimeMode {
 export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths {
 	const mode = opts.mode ?? detectRuntimeMode();
 	const userHome = defaultHome(mode);
-	const clawdiHome = defaultClawdiHome(mode, userHome);
+	const serviceStateRoot = envPath("CLAWDI_SERVICE_STATE_DIR") ?? DEFAULT_SERVICE_STATE_ROOT;
+	const clawdiHome = defaultClawdiHome(mode, serviceStateRoot);
 	const userLocalRoot = join(userHome, ".local");
 	const userLocalBin = join(userLocalRoot, "bin");
 	const userDataRoot = join(userLocalRoot, "share");
-	const serviceStateRoot = envPath("CLAWDI_SERVICE_STATE_DIR") ?? DEFAULT_SERVICE_STATE_ROOT;
 	const configurationRoot = derivedPlatformRoot(
 		serviceStateRoot,
 		DEFAULT_CONFIGURATION_ROOT,

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -1453,6 +1453,7 @@ export function removeStaleRuntimeSystemdFiles(
 export function runtimeSystemdCommonEnvironment(paths: RuntimePaths): Record<string, string> {
 	const environment: Record<string, string> = {
 		HOME: paths.userHome,
+		CLAWDI_HOME: paths.clawdiHome,
 		CLAWDI_RUNTIME_MODE: "hosted",
 		CLAWDI_RUNTIME_USER: "clawdi",
 		PATH: runtimeSystemdPath(paths),
@@ -1496,6 +1497,7 @@ function writeRuntimeSystemdUserProgram(input: {
 		...runtimeEnv,
 		...(input.manifest.locale ? { TZ: input.manifest.locale.timezone } : {}),
 		CLAWDI_AUTH_TOKEN: "",
+		CLAWDI_HOME: input.paths.clawdiHome,
 		CLAWDI_RUNTIME_REV: runtimeSystemdProgramRevision(
 			input.manifest,
 			program,

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -10,6 +10,7 @@ import {
 	readFileSync,
 	rmSync,
 	statSync,
+	symlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -446,10 +447,6 @@ test("isolates File Browser from the tenant while preserving workspace access", 
 	const openClawCommand = join(runtimeHome, ".local", "bin", "openclaw");
 	const root = mkdtempSync("/var/lib/clawdi-real-filebrowser-systemd-");
 	chmodSync(root, 0o755);
-	const clawdiHome = join(root, "clawdi-home");
-	mkdirSync(clawdiHome);
-	chownSync(clawdiHome, runtimeUid, runtimeGid);
-	chmodSync(clawdiHome, 0o700);
 	const tenantExisting = join(runtimeHome, "files-tenant-existing.txt");
 	writeFileSync(tenantExisting, "tenant-existing\n", { mode: 0o600 });
 	chownSync(tenantExisting, runtimeUid, runtimeGid);
@@ -459,7 +456,7 @@ test("isolates File Browser from the tenant while preserving workspace access", 
 	process.env.CLAWDI_RUNTIME_UID = String(runtimeUid);
 	process.env.CLAWDI_RUNTIME_GID = String(runtimeGid);
 	process.env.CLAWDI_RUNTIME_HOME = runtimeHome;
-	process.env.CLAWDI_HOME = clawdiHome;
+	delete process.env.CLAWDI_HOME;
 	process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
 	process.env.CLAWDI_RUN_DIR = join(root, "run");
 	process.env.CLAWDI_SYSTEMD_SYSTEM_ROOT = "/run/systemd/system";
@@ -479,6 +476,37 @@ test("isolates File Browser from the tenant while preserving workspace access", 
 	chownSync(openClawConfig, runtimeUid, runtimeGid);
 	const paths = getRuntimePaths({ mode: "hosted" });
 	ensureRuntimeStateDirs(paths);
+	const legacyEnvironmentRoot = join(runtimeHome, ".clawdi", "environments");
+	mkdirSync(legacyEnvironmentRoot, { recursive: true });
+	writeFileSync(
+		join(legacyEnvironmentRoot, "openclaw.json"),
+		`${JSON.stringify({
+			id: "env_legacy_openclaw",
+			agentType: "openclaw",
+			managedBy: "clawdi runtime init",
+		})}\n`,
+	);
+	const systemNpmCli = "/usr/local/lib/node_modules/clawdi/bin/clawdi.mjs";
+	mkdirSync(dirname(systemNpmCli), { recursive: true });
+	writeFileSync(systemNpmCli, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+	symlinkSync("../lib/node_modules/clawdi/bin/clawdi.mjs", "/usr/local/bin/clawdi");
+	const tenantClawdi = () =>
+		spawnSync(
+			"runuser",
+			[
+				"-u",
+				"clawdi",
+				"--",
+				"env",
+				`HOME=${runtimeHome}`,
+				"PATH=/usr/local/bin:/usr/bin:/bin",
+				"/bin/sh",
+				"-c",
+				"command -v clawdi",
+			],
+			{ encoding: "utf8" },
+		);
+	expect(tenantClawdi().stdout.trim()).toBe("/usr/local/bin/clawdi");
 	const globalServiceDropInRoot = join(paths.systemdSystemRoot, "service.d");
 	mkdirSync(globalServiceDropInRoot, { recursive: true });
 	writeFileSync(
@@ -688,6 +716,14 @@ http.createServer((request, response) => {
 		baseUrl: "https://ai-gateway.example.test/v1",
 		apiKey: { id: "CLAWDI_OPENCLAW_API_KEY" },
 	});
+	expect(existsSync(join(runtimeHome, ".clawdi"))).toBe(false);
+	expect(statSync(paths.clawdiHome).uid).toBe(runtimeUid);
+	expect(statSync(paths.clawdiHome).gid).toBe(runtimeGid);
+	expect(statSync(paths.clawdiHome).mode & 0o777).toBe(0o750);
+	const tenantClawdiAfterConverge = tenantClawdi();
+	expect(tenantClawdiAfterConverge.status).not.toBe(0);
+	expect(tenantClawdiAfterConverge.stdout).toBe("");
+
 	const serviceIdentity = spawnSync("getent", ["passwd", "clawdi-files"], {
 		encoding: "utf8",
 	});

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -15814,15 +15814,15 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			const daemonUnit = readSystemdSystemUnit(paths, "clawdi-daemon");
 			const daemonEnv = readSystemdEnvFile(paths, "clawdi-daemon");
 			const openclawEnv = JSON.parse(
-				readFileSync(join(home, ".clawdi", "environments", "openclaw.json"), "utf-8"),
+				readFileSync(join(paths.localEnvironments, "openclaw.json"), "utf-8"),
 			);
 			const codexEnv = JSON.parse(
-				readFileSync(join(home, ".clawdi", "environments", "codex.json"), "utf-8"),
+				readFileSync(join(paths.localEnvironments, "codex.json"), "utf-8"),
 			);
 
 			expect(convergence.outputs.liveSyncEnvironments.sort()).toEqual([
-				join(home, ".clawdi", "environments", "codex.json"),
-				join(home, ".clawdi", "environments", "openclaw.json"),
+				join(paths.localEnvironments, "codex.json"),
+				join(paths.localEnvironments, "openclaw.json"),
 			]);
 			expect(convergence.outputs.daemonAuthTokenFile).toBe(join(run, "secrets", "auth-token"));
 			expect(readFileSync(join(run, "secrets", "auth-token"), "utf-8")).toBe(


### PR DESCRIPTION
Owner-ratified: in hosted mode the clawdi platform layer must be COMPLETELY invisible to the tenant. Tenant product surface is only the official agents (~/.openclaw, ~/.hermes) and the cloud dashboard. **Carries the 0.13.55 version bump — this is the release car for the whole train (skill-restart #917, terminal-tooling #919, gateway-token #920 already merged).**

## Changes

- **CLAWDI_HOME relocation**: all hosted-runtime-managed CLI state moves out of the tenant home to `/var/lib/clawdi-user` (tenant-owned 0750, sibling of the root-owned `/var/lib/clawdi` service-state tree). Injected into every root-reconciliation write and tenant-UID systemd unit via the CLI's existing `CLAWDI_HOME` override (designed for service accounts). Laptop/self-hosted behavior unchanged when `CLAWDI_HOME` is unset.
- **PATH**: the `clawdi` binary is removed from the tenant PATH (the `/usr/local/bin/clawdi` symlink to the system npm CLI is removed, fail-closed — non-symlink or wrong target aborts). Platform calls use absolute paths. Tenant `command -v clawdi` finds nothing.
- **Legacy cleanup**: the pre-launch tenant-home `~/.clawdi/environments/<agent>.json` (managedBy "clawdi runtime init") is removed on reconcile; unmarked/foreign files are never touched.

## Tests

Privileged systemd e2e asserts tenant-home purity (`~/.clawdi` absent after converge, tenant `clawdi` non-discoverable) alongside the existing provider-scope assertions. No new test files.

## Gates (final combined tree, all four cars integrated)

- Privileged systemd e2e: 3 pass / 0 fail / 146 expect; task containers/images cleaned
- CLI: 0 fail / 8800 expect across 126 files
- bun run check: 970 files, 0 errors; `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)