### PR TITLE
release(cli): prepare 0.13.55

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.54",
+      "version": "0.13.55",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.54",
+	"version": "0.13.55",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary

- bump the CLI package and Bun workspace lock to `0.13.55`
- publish the already-merged restart ownership fix from #917, plus subsequent green fixes #919 and #920

## Production reason

A real prod11 Hermes restart replaced the instance root while preserving tenant HOME. `clawdi@0.13.54` stored managed MCP ownership under `/etc/clawdi/projections`, so the new root lost the ledger while `~/.hermes/config.yaml` correctly persisted. Bootstrap then failed closed with `refusing to replace unmanaged hermes MCP server clawdi`. #917 moves this ownership state to persistent `/var/lib/clawdi/managed-resources`; this release makes that merged fix publishable without rebuilding the tenant base image.

## Verification

- `node packages/cli/scripts/check-publish-manifest.mjs`
- `git diff --check`
- pre-commit Biome hook
- #917, #919, and #920 Client CI are green