### PR TITLE
feat(cli): consume strict WhatsApp runtime bindings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.55",
+      "version": "0.13.56",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.55",
+	"version": "0.13.56",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -2,13 +2,7 @@ import { createHash } from "node:crypto";
 import { join } from "node:path";
 import type { EgressProfileInputBundle } from "./egress-profiles";
 import type { RuntimeManifest } from "./manifest-contract";
-import type {
-	RuntimeBundleChannelBinding,
-	RuntimeChannelAccount,
-	RuntimeChannelCredential,
-	RuntimeChannelsLoad,
-	RuntimeManifestLoad,
-} from "./manifest-source";
+import type { RuntimeBundleChannelBinding, RuntimeManifestLoad } from "./manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { hostedRuntimeProjectionHome } from "./projection-home";
 import { runtimeSecretValue } from "./secret-values";
@@ -21,7 +15,7 @@ import {
 } from "./whatsapp-upstream-contract";
 
 type EgressProfile = EgressProfileInputBundle["profiles"][number];
-type ChannelProvider = RuntimeChannelAccount["provider"];
+type ChannelProvider = RuntimeBundleChannelBinding["provider"];
 
 const HERMES_MANAGED_CHANNEL_ENV = [
 	"TELEGRAM_ALLOW_ALL_USERS",
@@ -34,15 +28,28 @@ const HERMES_MANAGED_CHANNEL_SECRET_ENV = ["TELEGRAM_BOT_TOKEN", "DISCORD_BOT_TO
 const OPENCLAW_CHANNEL_TOKEN_ENV_PREFIX = "CLAWDI_CHANNEL_";
 const OPENCLAW_CHANNEL_TOKEN_ENV_SUFFIX = "_AGENT_TOKEN";
 
+interface ManagedChannelAccount {
+	id: string;
+	provider: ChannelProvider;
+}
+
+interface ManagedChannelCredential {
+	id: string;
+	credsSecretRef: string;
+	material: {
+		schemaVersion: "clawdi.whatsappBaileysAuthState.v1";
+		creds: Record<string, unknown>;
+		authCert: ManagedWhatsAppSocketMetadataJson["authCert"];
+	};
+}
+
 interface ManagedChannelLink {
-	account: RuntimeChannelAccount;
+	account: ManagedChannelAccount;
 	accountKey: string;
 	linkId: string;
-	agentId: string;
-	agentToken: string;
 	secretRef: string;
 	placeholderSecretRef: string;
-	credentials: RuntimeChannelCredential[];
+	credential?: ManagedChannelCredential;
 }
 
 interface OpenClawEnvSecretRef {
@@ -74,29 +81,9 @@ interface RuntimeChannelCredentialProjection {
 }
 
 interface WhatsAppBaileysCredentialMaterial {
-	credential: RuntimeChannelCredential;
+	credential: ManagedChannelCredential;
 	creds: Record<string, unknown>;
 	authCert: ManagedWhatsAppSocketMetadataJson["authCert"];
-}
-
-export function applyRuntimeChannelsToManifestLoad(
-	load: RuntimeManifestLoad,
-	channels: RuntimeChannelsLoad | null,
-	paths: RuntimePaths = getRuntimePaths({ mode: "hosted" }),
-): RuntimeManifestLoad {
-	if (!channels) return load;
-	const managedLinks = managedChannelLinks(channels.channels);
-	const manifest = applyRuntimeChannelProjection(load.manifest, managedLinks, paths);
-	const secretValues = {
-		...(load.secretValues ?? {}),
-		...channelSecretValues(managedLinks, manifest.projection?.channelCredentials),
-	};
-	return {
-		...load,
-		manifest,
-		sourceManifest: load.sourceManifest ?? load.manifest,
-		secretValues: Object.keys(secretValues).length > 0 ? secretValues : undefined,
-	};
 }
 
 export function applyRuntimeBundleChannelsToManifestLoad(
@@ -108,10 +95,16 @@ export function applyRuntimeBundleChannelsToManifestLoad(
 	const links: ManagedChannelLink[] = load.channelBindings.map((binding) =>
 		managedBundleChannelLink(binding, secretValues),
 	);
+	const manifest = applyRuntimeChannelProjection(load.manifest, links, paths);
+	const whatsappSecretValues = managedWhatsAppSecretValues(
+		links.filter((link) => link.account.provider === "whatsapp"),
+		manifest.projection?.channelCredentials,
+	);
 	return {
 		...load,
-		manifest: applyRuntimeChannelProjection(load.manifest, links, paths),
+		manifest,
 		sourceManifest: load.sourceManifest ?? load.manifest,
+		secretValues: { ...secretValues, ...whatsappSecretValues },
 	};
 }
 
@@ -125,52 +118,68 @@ function managedBundleChannelLink(
 	if (!placeholderToken) {
 		throw new Error(`runtime bundle is missing ${binding.placeholderTokenSecretRef}`);
 	}
+	if (binding.provider === "whatsapp") {
+		const expectedAgentRef = whatsappAgentTokenSecretRef(binding.accountKey, binding.linkId);
+		const expectedCapabilityRef = whatsappCapabilitySecretRef(binding.accountKey, binding.linkId);
+		const expectedCapability = whatsappCapabilityToken(binding.accountKey, binding.linkId);
+		if (binding.agentTokenSecretRef !== expectedAgentRef) {
+			throw new Error("runtime bundle WhatsApp agent token ref does not match its Link");
+		}
+		if (binding.placeholderTokenSecretRef !== expectedCapabilityRef) {
+			throw new Error("runtime bundle WhatsApp capability ref does not match its Link");
+		}
+		if (placeholderToken !== expectedCapability) {
+			throw new Error("runtime bundle WhatsApp capability does not match its Link");
+		}
+	}
 	return {
 		account: {
-			id: binding.accountKey,
+			id: binding.provider === "whatsapp" ? binding.accountId : binding.accountKey,
 			provider: binding.provider,
-			name: binding.accountKey,
-			status: "active",
-			visibility: "private",
-			runtime_links: [],
-			runtime_credentials: [],
 		},
 		accountKey: binding.accountKey,
-		linkId: binding.accountKey,
-		agentId: "bundle",
-		agentToken,
+		linkId: binding.provider === "whatsapp" ? binding.linkId : binding.accountKey,
 		secretRef: binding.agentTokenSecretRef,
 		placeholderSecretRef: binding.placeholderTokenSecretRef,
-		credentials: [],
+		credential:
+			binding.provider === "whatsapp"
+				? runtimeBundleWhatsAppCredential(binding, secretValues)
+				: undefined,
 	};
 }
 
-function managedChannelLinks(channels: RuntimeChannelAccount[]): ManagedChannelLink[] {
-	const links: ManagedChannelLink[] = [];
-	for (const account of channels) {
-		if (account.status !== "active") continue;
-		for (const link of account.runtime_links) {
-			if (link.status !== "active" || !link.agent_token) continue;
-			const accountKey = channelAccountKey(account);
-			links.push({
-				account,
-				accountKey,
-				linkId: link.id,
-				agentId: link.agent_id,
-				agentToken: link.agent_token,
-				secretRef: channelLinkSecretRef(account.provider, accountKey, link.id),
-				placeholderSecretRef: channelPlaceholderSecretRef(account.provider, accountKey, link.id),
-				credentials: (account.runtime_credentials ?? []).filter(
-					(credential) => credential.agent_link_id === link.id,
-				),
-			});
-		}
+function runtimeBundleWhatsAppCredential(
+	binding: Extract<RuntimeBundleChannelBinding, { provider: "whatsapp" }>,
+	secretValues: Record<string, string>,
+): ManagedChannelCredential {
+	const secretRef = binding.credential.credsSecretRef;
+	const expectedSecretRef = whatsappCredentialSecretRef(binding.accountKey, binding.credential.id);
+	if (secretRef !== expectedSecretRef) {
+		throw new Error("runtime bundle WhatsApp credential ref does not match its credential");
 	}
-	return links.sort((left, right) =>
-		`${left.account.provider}:${left.accountKey}:${left.linkId}`.localeCompare(
-			`${right.account.provider}:${right.accountKey}:${right.linkId}`,
-		),
-	);
+	const rawCreds = runtimeSecretValue(secretValues, secretRef);
+	if (!rawCreds) throw new Error(`runtime bundle is missing ${secretRef}`);
+	let creds: unknown;
+	try {
+		creds = JSON.parse(rawCreds);
+	} catch (error) {
+		throw new Error(
+			`runtime bundle WhatsApp credential is invalid: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	const parsedCreds = recordValue(creds);
+	if (!parsedCreds) {
+		throw new Error("runtime bundle WhatsApp credential must be a JSON object");
+	}
+	return {
+		id: binding.credential.id,
+		credsSecretRef: secretRef,
+		material: {
+			schemaVersion: "clawdi.whatsappBaileysAuthState.v1",
+			creds: parsedCreds,
+			authCert: binding.credential.authCert,
+		},
+	};
 }
 
 function applyRuntimeChannelProjection(
@@ -613,28 +622,18 @@ function isChannelProjectionProfile(profile: EgressProfile): boolean {
 	);
 }
 
-function channelSecretValues(
+function managedWhatsAppSecretValues(
 	links: ManagedChannelLink[],
 	channelCredentials: unknown,
 ): Record<string, string> {
 	const values: Record<string, string> = {};
 	const projectedCredentialSecrets = projectedWhatsAppCredentialSecretRefs(channelCredentials);
 	for (const link of links) {
-		addSecretValue(values, link.secretRef, link.agentToken);
-		addSecretValue(
-			values,
-			link.placeholderSecretRef,
-			channelPlaceholderToken(link.account.provider, link.accountKey, link.linkId),
-		);
 		const material = whatsappBaileysCredentialMaterial(link);
 		if (material) {
-			const credsSecretRef = whatsappBaileysCredsJsonSecretRef(link, material.credential);
+			const credsSecretRef = material.credential.credsSecretRef;
 			if (projectedCredentialSecrets.has(credsSecretRef)) {
-				addSecretValue(
-					values,
-					credsSecretRef,
-					JSON.stringify(managedWhatsAppCreds(link, material)),
-				);
+				values[credsSecretRef] = JSON.stringify(managedWhatsAppCreds(link, material));
 			}
 		}
 	}
@@ -661,40 +660,23 @@ function projectedWhatsAppCredentialSecretRefs(channelCredentials: unknown): Set
 	return refs;
 }
 
-function addSecretValue(values: Record<string, string>, ref: string, value: string): void {
-	values[ref] = value;
+function whatsappAgentTokenSecretRef(accountKey: string, linkId: string): string {
+	return `secret://channels/whatsapp/${accountKey}/links/${linkId}/agent-token`;
 }
 
-function channelLinkSecretRef(
-	provider: ChannelProvider,
-	accountKey: string,
-	linkId: string,
-): string {
-	return `secret://channels/${provider}/${accountKey}/links/${linkId}/agent-token`;
+function whatsappCapabilitySecretRef(accountKey: string, linkId: string): string {
+	return `secret://channels/whatsapp/${accountKey}/links/${linkId}/egress-capability`;
 }
 
-function channelPlaceholderSecretRef(
-	provider: ChannelProvider,
-	accountKey: string,
-	linkId?: string,
-): string {
-	if (provider === "whatsapp") {
-		if (!linkId) throw new Error("managed WhatsApp capability requires a Link id");
-		return `secret://channels/whatsapp/${accountKey}/links/${linkId}/egress-capability`;
-	}
-	return `secret://channels/${provider}/${accountKey}/placeholder-token`;
+function whatsappCredentialSecretRef(accountKey: string, credentialId: string): string {
+	return `secret://channels/whatsapp/${accountKey}/credentials/${credentialId}/creds-json`;
 }
 
-function channelPlaceholderToken(
-	provider: ChannelProvider,
-	accountKey: string,
-	linkId?: string,
-): string {
+function whatsappCapabilityToken(accountKey: string, linkId: string): string {
 	const suffix = createHash("sha256")
-		.update(`${provider}:${accountKey}${provider === "whatsapp" ? `:${linkId ?? ""}` : ""}`)
+		.update(`whatsapp:${accountKey}:${linkId}`)
 		.digest("hex")
 		.slice(0, 32);
-	if (provider === "telegram") return `999999999:${suffix}`;
 	return `clawdi_${suffix}`;
 }
 
@@ -727,37 +709,25 @@ function whatsappBaileysCredentialProjection(
 		files: [
 			{
 				path: "creds.json",
-				secretRef: whatsappBaileysCredsJsonSecretRef(link, material.credential),
+				secretRef: material.credential.credsSecretRef,
 			},
 		],
 		targets: targetProjection,
 	};
 }
 
-function whatsappBaileysCredentials(link: ManagedChannelLink): RuntimeChannelCredential[] {
-	if (link.account.provider !== "whatsapp") return [];
-	return link.credentials.filter(
-		(credential) =>
-			credential.provider === "whatsapp" && credential.kind === "whatsapp_baileys_auth_state",
-	);
-}
-
 function whatsappBaileysCredentialMaterial(
 	link: ManagedChannelLink,
 ): WhatsAppBaileysCredentialMaterial | null {
-	const credential = whatsappBaileysCredentials(link)[0];
+	if (link.account.provider !== "whatsapp") return null;
+	const credential = link.credential;
 	if (!credential) return null;
-	const material = recordValue(credential.material);
-	if (material?.schemaVersion !== "clawdi.whatsappBaileysAuthState.v1") {
-		return null;
-	}
-	const creds = recordValue(material.creds);
-	if (!creds) return null;
+	const { material } = credential;
 	let metadata: ManagedWhatsAppSocketMetadataJson;
 	try {
 		metadata = parseManagedWhatsAppSocketMetadataJson({
 			schemaVersion: CLAWDI_MANAGED_WHATSAPP_SOCKET_SCHEMA,
-			capability: channelPlaceholderToken(link.account.provider, link.accountKey, link.linkId),
+			capability: whatsappCapabilityToken(link.accountKey, link.linkId),
 			authCert: material.authCert,
 		});
 	} catch {
@@ -765,7 +735,7 @@ function whatsappBaileysCredentialMaterial(
 	}
 	return {
 		credential,
-		creds,
+		creds: material.creds,
 		authCert: metadata.authCert,
 	};
 }
@@ -782,7 +752,7 @@ function managedWhatsAppCreds(
 	}
 	const metadata = parseManagedWhatsAppSocketMetadataJson({
 		schemaVersion: CLAWDI_MANAGED_WHATSAPP_SOCKET_SCHEMA,
-		capability: channelPlaceholderToken(link.account.provider, link.accountKey, link.linkId),
+		capability: whatsappCapabilityToken(link.accountKey, link.linkId),
 		authCert: material.authCert,
 	});
 	return {
@@ -792,13 +762,6 @@ function managedWhatsAppCreds(
 			[CLAWDI_MANAGED_WHATSAPP_SOCKET_METADATA_KEY]: metadata,
 		},
 	};
-}
-
-function whatsappBaileysCredsJsonSecretRef(
-	link: ManagedChannelLink,
-	credential: RuntimeChannelCredential,
-): string {
-	return `secret://channels/whatsapp/${link.accountKey}/credentials/${credential.id}/creds-json`;
 }
 
 function openClawWhatsAppAuthDir(runtimeHome: string, accountKey: string): string {
@@ -828,23 +791,6 @@ function recordValue(value: unknown): Record<string, unknown> | null {
 
 function stringValue(value: unknown): string | null {
 	return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
-}
-
-function channelAccountKey(account: RuntimeChannelAccount): string {
-	const compactId = account.id
-		.replace(/[^a-zA-Z0-9]/g, "")
-		.slice(0, 12)
-		.toLowerCase();
-	return `clawdi_${compactId || slug(account.name)}`;
-}
-
-function slug(value: string): string {
-	const slugged = value
-		.toLowerCase()
-		.replace(/[^a-z0-9]+/g, "_")
-		.replace(/^_+|_+$/g, "")
-		.slice(0, 24);
-	return slugged || "channel";
 }
 
 function stripTrailingSlash(value: string): string {

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -55,14 +55,7 @@ export interface RuntimeManifestLoad {
 
 export const HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE = "application/vnd.clawdi.runtime-bundle.v2+json";
 
-export interface RuntimeBundleChannelBinding {
-	provider: "telegram" | "discord";
-	accountKey: string;
-	agentTokenSecretRef: string;
-	placeholderTokenSecretRef: string;
-}
-
-const runtimeBundleChannelBindingSchema = z
+const runtimeBundleTokenChannelBindingSchema = z
 	.object({
 		provider: z.enum(["telegram", "discord"]),
 		accountKey: z.string().min(1),
@@ -70,6 +63,42 @@ const runtimeBundleChannelBindingSchema = z
 		placeholderTokenSecretRef: canonicalSecretRefSchema,
 	})
 	.strict();
+
+const runtimeBundleWhatsAppBindingSchema = z
+	.object({
+		provider: z.literal("whatsapp"),
+		accountId: z.string().uuid(),
+		accountKey: z.string().min(1),
+		linkId: z.string().uuid(),
+		agentTokenSecretRef: canonicalSecretRefSchema,
+		placeholderTokenSecretRef: canonicalSecretRefSchema,
+		credential: z
+			.object({
+				id: z.string().uuid(),
+				credsSecretRef: canonicalSecretRefSchema,
+				authCert: z
+					.object({
+						SERIAL: z.number().int().nonnegative().safe(),
+						ISSUER: z.string().trim().min(1).max(256),
+						PUBLIC_KEY: z
+							.object({
+								type: z.literal("Buffer"),
+								data: z.string().min(1),
+							})
+							.strict(),
+					})
+					.strict(),
+			})
+			.strict(),
+	})
+	.strict();
+
+const runtimeBundleChannelBindingSchema = z.discriminatedUnion("provider", [
+	runtimeBundleTokenChannelBindingSchema,
+	runtimeBundleWhatsAppBindingSchema,
+]);
+
+export type RuntimeBundleChannelBinding = z.infer<typeof runtimeBundleChannelBindingSchema>;
 
 const hostedRuntimeBundleV2Schema = z
 	.object({
@@ -137,44 +166,6 @@ export interface RuntimeManifestFailure {
 	errors: string[];
 	rejectedGeneration?: number | null;
 	activeGeneration?: number | null;
-}
-
-export interface RuntimeChannelAgentLink {
-	id: string;
-	account_id: string;
-	agent_id: string;
-	status: string;
-	agent_token: string | null;
-}
-
-export interface RuntimeChannelCredential {
-	id: string;
-	account_id: string;
-	agent_link_id: string;
-	agent_id: string;
-	provider: string;
-	kind: string;
-	created_at?: string;
-	jid?: string | null;
-	identity_pub_key_hex?: string | null;
-	material?: unknown;
-}
-
-export interface RuntimeChannelAccount {
-	id: string;
-	provider: "telegram" | "discord" | "whatsapp";
-	name: string;
-	status: string;
-	visibility: "private" | "public";
-	runtime_links: RuntimeChannelAgentLink[];
-	runtime_credentials: RuntimeChannelCredential[];
-}
-
-export interface RuntimeChannelsLoad {
-	channels: RuntimeChannelAccount[];
-	source: "remote-datasource";
-	sourcePath: string;
-	etag?: string;
 }
 
 interface ExistingManifestState {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -3113,7 +3113,10 @@ function applyHostedChannelProjection(
 	if (name === "hermes") {
 		const configPath = join(home, ".hermes", "config.yaml");
 		withRuntimeUserFileAccess(() => {
-			mergeHermesChannelConfig(configPath, hermesManagedChannelsPatch(channels));
+			mergeHermesChannelConfig(
+				configPath,
+				hermesManagedChannelsPatch(channels, manifest.projection?.channelCredentials),
+			);
 			makeRuntimeUserOwned(configPath);
 		});
 		return configPath;
@@ -3153,10 +3156,19 @@ function installHostedChannelProjectionDependencies(
 	});
 }
 
-function hermesManagedChannelsPatch(channels: Record<string, unknown>): Record<string, unknown> {
+function hermesManagedChannelsPatch(
+	channels: Record<string, unknown>,
+	channelCredentials: unknown,
+): Record<string, unknown> {
 	const telegramEnabled = channelHasAccounts(channels.telegram);
 	const discordEnabled = channelHasAccounts(channels.discord);
 	const whatsappEnabled = channelHasAccounts(channels.whatsapp);
+	const whatsappSessionPath = whatsappEnabled
+		? hermesManagedWhatsAppSessionPath(channelCredentials)
+		: null;
+	if (whatsappEnabled && !whatsappSessionPath) {
+		throw new Error("managed Hermes WhatsApp projection is missing its auth directory");
+	}
 	const sharedChannelSessionsEnabled = telegramEnabled || discordEnabled || whatsappEnabled;
 	return {
 		telegram: telegramEnabled
@@ -3209,6 +3221,7 @@ function hermesManagedChannelsPatch(channels: Record<string, unknown>): Record<s
 						whatsapp: {
 							enabled: true,
 							extra: {
+								session_path: whatsappSessionPath,
 								dm_policy: "allowlist",
 								group_policy: "open",
 								allow_from: ["*"],
@@ -3228,6 +3241,21 @@ function hermesManagedChannelsPatch(channels: Record<string, unknown>): Record<s
 			},
 		},
 	};
+}
+
+function hermesManagedWhatsAppSessionPath(channelCredentials: unknown): string | null {
+	if (!Array.isArray(channelCredentials)) return null;
+	for (const value of channelCredentials) {
+		const credential = recordValue(value);
+		if (credential?.provider !== "whatsapp" || credential.kind !== "whatsapp_baileys_auth_state") {
+			continue;
+		}
+		const targets = recordValue(credential.targets);
+		const hermes = recordValue(targets?.hermes);
+		const authDir = stringValue(hermes?.authDir);
+		if (authDir) return authDir;
+	}
+	return null;
 }
 
 function channelHasAccounts(channel: unknown): boolean {
@@ -4727,13 +4755,15 @@ function runtimeProgramRevisionForManifest(
 		: [];
 	const channels = hostedChannelProjection(manifest);
 	const hostedTarget = runtime === "openclaw" || runtime === "hermes";
-	const channelProjection = channels
-		? runtime === "openclaw"
-			? openClawManagedChannelsPatch(channels)
-			: runtime === "hermes"
-				? hermesManagedChannelsPatch(channels)
-				: null
-		: null;
+	let channelProjection: Record<string, unknown> | null = null;
+	if (channels && runtime === "openclaw") {
+		channelProjection = openClawManagedChannelsPatch(channels);
+	} else if (channels && runtime === "hermes" && desiredRuntime?.enabled) {
+		channelProjection = hermesManagedChannelsPatch(
+			channels,
+			manifest.projection?.channelCredentials,
+		);
+	}
 	return runtimeProgramRevision({
 		renderedProjection: {
 			channels: channelProjection,
@@ -5124,8 +5154,11 @@ function validateRuntimeProjectionPlan(input: {
 
 		const channels = hostedChannelProjection(manifest);
 		if (channels && name === "openclaw") JSON.stringify(openClawManagedChannelsPatch(channels));
-		if (channels && name === "hermes") {
-			hermesConfig = renderHermesChannelConfig(hermesConfig, hermesManagedChannelsPatch(channels));
+		if (channels && name === "hermes" && runtime.enabled) {
+			hermesConfig = renderHermesChannelConfig(
+				hermesConfig,
+				hermesManagedChannelsPatch(channels, manifest.projection?.channelCredentials),
+			);
 		}
 	}
 	validateHostedMcpProjectionPlan(manifest, paths, observations);

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
 	chmodSync,
 	existsSync,
@@ -206,6 +207,154 @@ describe("hosted runtime bundle v2", () => {
 				},
 			},
 		});
+	});
+
+	test("strictly projects Link-scoped WhatsApp auth and capability for OpenClaw", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-runtime-bundle-whatsapp-"));
+		roots.push(root);
+		process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
+		const paths = getRuntimePaths({ mode: "hosted" });
+		const raw = z
+			.record(z.string(), z.unknown())
+			.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
+		const accountId = "50000000-0000-4000-8000-000000000005";
+		const accountKey = "clawdi_50000000000040008000000000000005";
+		const linkId = "60000000-0000-4000-8000-000000000006";
+		const credentialId = "80000000-0000-4000-8000-000000000011";
+		const agentRef = `secret://channels/whatsapp/${accountKey}/links/${linkId}/agent-token`;
+		const capabilityRef = `secret://channels/whatsapp/${accountKey}/links/${linkId}/egress-capability`;
+		const credentialRef = `secret://channels/whatsapp/${accountKey}/credentials/${credentialId}/creds-json`;
+		const capability = `clawdi_${createHash("sha256")
+			.update(`whatsapp:${accountKey}:${linkId}`)
+			.digest("hex")
+			.slice(0, 32)}`;
+		const secretValues = z.record(z.string(), z.string()).parse(raw.secretValues);
+		const bundle = {
+			...raw,
+			sourceRevision: "b".repeat(64),
+			channelBindings: [
+				{
+					provider: "whatsapp",
+					accountId,
+					accountKey,
+					linkId,
+					agentTokenSecretRef: agentRef,
+					placeholderTokenSecretRef: capabilityRef,
+					credential: {
+						id: credentialId,
+						credsSecretRef: credentialRef,
+						authCert: {
+							SERIAL: 7,
+							ISSUER: "clawdi",
+							PUBLIC_KEY: {
+								type: "Buffer",
+								data: Buffer.alloc(32, 7).toString("base64"),
+							},
+						},
+					},
+				},
+			],
+			secretValues: {
+				...secretValues,
+				[agentRef]: "whatsapp-agent-token",
+				[capabilityRef]: capability,
+				[credentialRef]: JSON.stringify({
+					advSecretKey: "managed-whatsapp",
+					me: { id: "15551234567:1@s.whatsapp.net" },
+				}),
+			},
+		};
+
+		const loaded = normalizeHostedRuntimeBundleV2(bundle);
+		const projected = applyRuntimeBundleChannelsToManifestLoadWithContext(loaded, paths);
+		const credentialProjection = z
+			.array(z.record(z.string(), z.unknown()))
+			.parse(projected.manifest.projection?.channelCredentials)[0];
+		if (!credentialProjection) throw new Error("missing WhatsApp credential projection");
+		const openclawAuthDir = join(
+			paths.userHome,
+			".openclaw",
+			"credentials",
+			"whatsapp",
+			accountKey,
+		);
+		expect(credentialProjection).toMatchObject({
+			accountId,
+			accountKey,
+			linkId,
+			credentialId,
+			targets: { openclaw: { authDir: openclawAuthDir } },
+		});
+		expect(projected.manifest.projection?.channels).toMatchObject({
+			whatsapp: {
+				accounts: { [accountKey]: { enabled: true, authDir: openclawAuthDir } },
+			},
+		});
+		const projectedCreds = z
+			.record(z.string(), z.unknown())
+			.parse(JSON.parse(projected.secretValues?.[credentialRef] ?? "null"));
+		expect(projectedCreds).toMatchObject({
+			additionalData: {
+				"clawdi.managedWhatsAppSocket": { capability },
+			},
+		});
+		const websocketProfile = projected.manifest.egressProfiles?.profiles.find(
+			(profile) => profile.owner === "clawdi-native-whatsapp" && profile.kind === "websocket",
+		);
+		expect(websocketProfile).toMatchObject({
+			match: {
+				headers: {
+					"x-clawdi-whatsapp-link-capability": {
+						type: "secretRefEquals",
+						secretRef: capabilityRef,
+					},
+				},
+			},
+			rewrite: {
+				setHeaders: {
+					authorization: { secretRef: agentRef },
+				},
+			},
+		});
+		expect(projected.secretValues?.[capabilityRef]).toBe(capability);
+
+		expect(() =>
+			applyRuntimeBundleChannelsToManifestLoadWithContext(
+				normalizeHostedRuntimeBundleV2({
+					...bundle,
+					secretValues: { ...bundle.secretValues, [capabilityRef]: `clawdi_${"0".repeat(32)}` },
+				}),
+				paths,
+			),
+		).toThrow("runtime bundle WhatsApp capability does not match its Link");
+
+		const binding = bundle.channelBindings[0];
+		if (!binding) throw new Error("missing WhatsApp binding");
+		expect(() =>
+			applyRuntimeBundleChannelsToManifestLoadWithContext(
+				normalizeHostedRuntimeBundleV2({
+					...bundle,
+					channelBindings: [
+						{
+							...binding,
+							credential: {
+								...binding.credential,
+								credsSecretRef: `secret://channels/whatsapp/${accountKey}/credentials/${linkId}/creds-json`,
+							},
+						},
+					],
+				}),
+				paths,
+			),
+		).toThrow("runtime bundle WhatsApp credential ref does not match its credential");
+		const incompleteCredential = z.record(z.string(), z.unknown()).parse(binding.credential);
+		delete incompleteCredential.credsSecretRef;
+		expect(() =>
+			normalizeHostedRuntimeBundleV2({
+				...bundle,
+				channelBindings: [{ ...binding, credential: incompleteCredential }],
+			}),
+		).toThrow();
 	});
 
 	test("accepts generic hosted MCP and skill resource intent with a future CLI fixture", () => {
@@ -724,7 +873,7 @@ describe("hosted runtime bundle v2", () => {
 		expect(reconciledPersistentState).not.toContain("deployment-auth-token-rotated");
 	});
 
-	test("rejects unknown fields and dormant providers", () => {
+	test("rejects unknown fields and incomplete provider-swapped bindings", () => {
 		const raw = JSON.parse(readFileSync(goldenPath, "utf-8")) as Record<string, unknown>;
 		expect(() =>
 			normalizeHostedRuntimeBundleV2({ ...raw, rendererIdentity: "forbidden" }),

--- a/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/project.e2e.ts
+++ b/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/project.e2e.ts
@@ -1,12 +1,11 @@
 import { expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import type {
-	RuntimeChannelsLoad,
-	RuntimeManifestLoad,
-} from "../../../src/runtime/manifest-source";
+import { z } from "zod";
+import type { RuntimeManifestLoad } from "../../../src/runtime/manifest-source";
 
-const { applyRuntimeChannelsToManifestLoad } = await import("../../../src/runtime/channels");
+const { applyRuntimeBundleChannelsToManifestLoad } = await import("../../../src/runtime/channels");
 const { buildEgressProfileBundle, egressProfileSecretRefs } = await import(
 	"../../../src/runtime/egress-profiles"
 );
@@ -21,44 +20,58 @@ test("projects and reconciles the real managed WhatsApp runtime", () => {
 	const scenarioPath = requiredEnvironment("E2E_SCENARIO");
 	const outputRoot = requiredEnvironment("E2E_OUTPUT");
 	const scenario = recordValue(JSON.parse(readFileSync(scenarioPath, "utf8")));
-	const channelMaterial = recordValue(scenario.channelMaterial);
+	const channelMaterial = z
+		.object({
+			creds: z.record(z.string(), z.unknown()),
+			authCert: z
+				.object({
+					SERIAL: z.number().int().nonnegative(),
+					ISSUER: z.string().min(1),
+					PUBLIC_KEY: z
+						.object({ type: z.literal("Buffer"), data: z.string().min(1) })
+						.strict(),
+				})
+				.strict(),
+		})
+		.passthrough()
+		.parse(scenario.channelMaterial);
 
-	const manifest = runtimeManifest(runtime, home);
-	const channels: RuntimeChannelsLoad = {
-		channels: [
+	const accountId = "50000000-0000-4000-8000-000000000005";
+	const accountKey = "clawdi_50000000000040008000000000000005";
+	const linkId = "60000000-0000-4000-8000-000000000006";
+	const credentialId = "80000000-0000-4000-8000-000000000011";
+	const agentTokenSecretRef = `secret://channels/whatsapp/${accountKey}/links/${linkId}/agent-token`;
+	const capabilitySecretRef = `secret://channels/whatsapp/${accountKey}/links/${linkId}/egress-capability`;
+	const credentialSecretRef = `secret://channels/whatsapp/${accountKey}/credentials/${credentialId}/creds-json`;
+	const capability = `clawdi_${createHash("sha256")
+		.update(`whatsapp:${accountKey}:${linkId}`)
+		.digest("hex")
+		.slice(0, 32)}`;
+	const manifest: RuntimeManifestLoad = {
+		...runtimeManifest(runtime, home),
+		channelBindings: [
 			{
-				id: "acct-native-e2e",
 				provider: "whatsapp",
-				name: "Managed WhatsApp native E2E",
-				status: "active",
-				visibility: "public",
-				runtime_links: [
-					{
-						id: "link-native-e2e",
-						account_id: "acct-native-e2e",
-						agent_id: "agent-native-e2e",
-						status: "active",
-						agent_token: "wa-native-e2e-link-bearer",
-					},
-				],
-				runtime_credentials: [
-					{
-						id: "credential-native-e2e",
-						account_id: "acct-native-e2e",
-						agent_link_id: "link-native-e2e",
-						agent_id: "agent-native-e2e",
-						provider: "whatsapp",
-						kind: "whatsapp_baileys_auth_state",
-						material: channelMaterial,
-					},
-				],
+				accountId,
+				accountKey,
+				linkId,
+				agentTokenSecretRef,
+				placeholderTokenSecretRef: capabilitySecretRef,
+				credential: {
+					id: credentialId,
+					credsSecretRef: credentialSecretRef,
+					authCert: channelMaterial.authCert,
+				},
 			},
 		],
-		source: "native-e2e",
-		sourcePath: "test://native-e2e/channels",
+		secretValues: {
+			[agentTokenSecretRef]: "wa-native-e2e-link-bearer",
+			[capabilitySecretRef]: capability,
+			[credentialSecretRef]: JSON.stringify(channelMaterial.creds),
+		},
 	};
 
-	const projected = applyRuntimeChannelsToManifestLoad(manifest, channels);
+	const projected = applyRuntimeBundleChannelsToManifestLoad(manifest);
 	materializeHostedChannelCredentials(projected.manifest, projected.secretValues, home);
 	const credential = projected.manifest.projection?.channelCredentials?.[0];
 	if (!credential) throw new Error("managed WhatsApp credential was not projected");

--- a/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/project.e2e.ts
+++ b/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/project.e2e.ts
@@ -27,9 +27,7 @@ test("projects and reconciles the real managed WhatsApp runtime", () => {
 				.object({
 					SERIAL: z.number().int().nonnegative(),
 					ISSUER: z.string().min(1),
-					PUBLIC_KEY: z
-						.object({ type: z.literal("Buffer"), data: z.string().min(1) })
-						.strict(),
+					PUBLIC_KEY: z.object({ type: z.literal("Buffer"), data: z.string().min(1) }).strict(),
 				})
 				.strict(),
 		})

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
 	chmodSync,
+	copyFileSync,
 	existsSync,
 	mkdirSync,
 	readdirSync,
@@ -15,7 +16,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import {
 	applySystemdRuntimeUpdate,
@@ -43,7 +44,6 @@ import {
 } from "../src/runtime/apply-identity";
 import {
 	applyRuntimeBundleChannelsToManifestLoad as applyRuntimeBundleChannelsToManifestLoadWithContext,
-	applyRuntimeChannelsToManifestLoad,
 } from "../src/runtime/channels";
 import {
 	applyRuntimeCliDesiredState,
@@ -60,6 +60,7 @@ import {
 import { hostedManifestEgressProfiles } from "../src/runtime/hosted-egress-profiles";
 import { hostedOpenClawSkillDriver } from "../src/runtime/hosted-openclaw-skill";
 import { hostedAiProviderCatalog } from "../src/runtime/hosted-provider-resolution";
+import { MANAGED_BAILEYS_STATIC_PATCH_TARGETS } from "../src/runtime/managed-baileys-compat";
 import { releaseManagedSkill, reserveManagedSkill } from "../src/runtime/managed-skill-reservation";
 import {
 	buildOpenClawHostedProviderPatch,
@@ -80,7 +81,6 @@ import {
 	loadRemoteRuntimeManifest as loadRemoteRuntimeManifestWithContext,
 	manifestSecretRefs,
 	type RuntimeBundleChannelBinding,
-	type RuntimeChannelsLoad,
 	type RuntimeManifestLoad,
 } from "../src/runtime/manifest-source";
 import { readHostedRuntimeObserved } from "../src/runtime/observed";
@@ -239,6 +239,25 @@ function convergeRuntimeManifest(
 			hostedRuntimeContract: opts?.hostedRuntimeContract ?? testHostedRuntimeContract(paths),
 		},
 	);
+}
+
+function seedHermesManagedBaileys(home: string): void {
+	const sourceRoot = resolve(
+		import.meta.dir,
+		"../../whatsapp-baileys-sidecar/node_modules/baileys",
+	);
+	const bridgeRoot = join(home, ".hermes", "hermes-agent", "scripts", "whatsapp-bridge");
+	const baileysRoot = join(bridgeRoot, "node_modules", "@whiskeysockets", "baileys");
+	for (const relativePath of [
+		"package.json",
+		...MANAGED_BAILEYS_STATIC_PATCH_TARGETS.map((target) => target.relativePath),
+	]) {
+		const destination = join(baileysRoot, relativePath);
+		mkdirSync(dirname(destination), { recursive: true });
+		copyFileSync(join(sourceRoot, relativePath), destination);
+	}
+	writeFileSync(join(bridgeRoot, "package.json"), '{"name":"hermes-whatsapp-bridge"}\n');
+	writeFileSync(join(bridgeRoot, "package-lock.json"), '{"lockfileVersion":3}\n');
 }
 
 function applyRuntimeBundleChannelsToManifestLoad(
@@ -6375,45 +6394,6 @@ exit 64
 		}
 	});
 
-	it("projects an empty runtime channel list with the invalid WhatsApp capability deny rule", () => {
-		const loaded: RuntimeManifestLoad = {
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				runtime: "openclaw",
-				deploymentId: "dep_empty_channels",
-				environmentId: "env_empty_channels",
-				instanceId: "iid_empty_channels",
-				generation: 3,
-				issuedAt: "2026-06-14T00:00:00Z",
-				system: { home: "/home/clawdi", workspace: "/home/clawdi" },
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					openclaw: { enabled: true },
-				},
-			},
-			source: "remote-datasource",
-			sourcePath: "https://runtime.test/manifest",
-			secretValues: { "secret://provider.default.apiKey": "sk-provider" },
-		};
-		const channels: RuntimeChannelsLoad = {
-			channels: [],
-			source: "remote-datasource",
-			sourcePath: "https://runtime.test/v1/channels",
-			etag: testBundleEtag("empty-channels"),
-		};
-
-		const projected = applyRuntimeChannelsToManifestLoad(loaded, channels);
-
-		expect(projected.manifest.projection?.channels).toEqual({});
-		expect(projected.manifest.egressProfiles?.profiles ?? []).toEqual([
-			expect.objectContaining({
-				id: "native-whatsapp-baileys-invalid-capability",
-				kind: "deny",
-			}),
-		]);
-		expect(projected.secretValues).toEqual({ "secret://provider.default.apiKey": "sk-provider" });
-	});
-
 	it("fails closed instead of selecting a historical duplicate runtime account", () => {
 		for (const runtime of ["openclaw", "hermes"] as const) {
 			for (const provider of ["telegram", "discord"] as const) {
@@ -6525,253 +6505,6 @@ exit 64
 		expect(removed.secretValues).toEqual({});
 	});
 
-	it("merges channel secrets into source-level secretValues during pure projection", () => {
-		const loaded: RuntimeManifestLoad = {
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				runtime: "openclaw",
-				deploymentId: "dep_channel_secret_boundary",
-				environmentId: "env_channel_secret_boundary",
-				instanceId: "iid_channel_secret_boundary",
-				generation: 6,
-				issuedAt: "2026-07-08T00:00:00Z",
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					openclaw: { enabled: true },
-					hermes: { enabled: true },
-				},
-			},
-			source: "remote-datasource",
-			sourcePath: "https://runtime.test/manifest",
-			offline: false,
-			secretValues: { "secret://provider.default.apiKey": "sk-provider" },
-		};
-		const channels: RuntimeChannelsLoad = {
-			channels: [
-				{
-					id: "acct-telegram-1",
-					provider: "telegram",
-					name: "Runtime Telegram",
-					status: "active",
-					visibility: "private",
-					runtime_links: [
-						{
-							id: "link-telegram-1",
-							account_id: "acct-telegram-1",
-							agent_id: "env_channel_secret_boundary",
-							status: "active",
-							agent_token: "telegram-agent-token",
-						},
-					],
-					runtime_credentials: [],
-				},
-				{
-					id: "acct-discord-1",
-					provider: "discord",
-					name: "Runtime Discord",
-					status: "active",
-					visibility: "private",
-					runtime_links: [
-						{
-							id: "link-discord-1",
-							account_id: "acct-discord-1",
-							agent_id: "env_channel_secret_boundary",
-							status: "active",
-							agent_token: "discord-agent-token",
-						},
-					],
-					runtime_credentials: [],
-				},
-			],
-			source: "remote-datasource",
-			sourcePath: "https://runtime.test/v1/channels",
-			etag: testBundleEtag("channel-secret-boundary"),
-		};
-
-		const projected = applyRuntimeChannelsToManifestLoad(loaded, channels);
-		expect(projected.secretValues).toMatchObject({
-			"secret://provider.default.apiKey": "sk-provider",
-			"secret://channels/telegram/clawdi_accttelegram/links/link-telegram-1/agent-token":
-				"telegram-agent-token",
-			"secret://channels/discord/clawdi_acctdiscord1/links/link-discord-1/agent-token":
-				"discord-agent-token",
-		});
-		expect(projected.sourceManifest).toEqual(loaded.manifest);
-		expect(JSON.stringify(projected.sourceManifest)).not.toContain('"channels"');
-		expect(
-			projected.secretValues?.[
-				"secret://channels/telegram/clawdi_accttelegram/links/link-telegram-1/agent-token"
-			],
-		).toBe("telegram-agent-token");
-		expect(
-			projected.secretValues?.["secret://channels/telegram/clawdi_accttelegram/placeholder-token"],
-		).toBe("999999999:877c68b5e40fa4531f180a6a4842a8bf");
-		expect(
-			projected.secretValues?.[
-				"secret://channels/discord/clawdi_acctdiscord1/links/link-discord-1/agent-token"
-			],
-		).toBe("discord-agent-token");
-		expect(
-			projected.secretValues?.["secret://channels/discord/clawdi_acctdiscord1/placeholder-token"],
-		).toBe("clawdi_5e99010fed052f9ee65e2764748fd451");
-		const discordGateway = projected.manifest.egressProfiles?.profiles.find(
-			(profile) => profile.id === "native-discord-clawdi_acctdiscord1-gateway-managed",
-		);
-		expect(discordGateway).toMatchObject({
-			kind: "websocket",
-			match: { scheme: "wss", host: "gateway.discord.gg", pathPrefix: "/" },
-			rewrite: {
-				upstreamBaseUrl: "wss://cloud-api.test/v1/channels/discord/gateway",
-				preservePath: false,
-				setHeaders: {
-					authorization: {
-						type: "secretRef",
-						secretRef:
-							"secret://channels/discord/clawdi_acctdiscord1/links/link-discord-1/agent-token",
-						prefix: "Bearer ",
-					},
-				},
-			},
-			logging: { redactHeaders: ["authorization"] },
-		});
-		expect(projected.manifest.projection?.channels).toMatchObject({
-			telegram: { enabled: true },
-			discord: {
-				enabled: true,
-				accounts: {
-					clawdi_acctdiscord1: {
-						actions: {
-							stickers: false,
-							polls: false,
-							threads: false,
-							pins: false,
-							roles: false,
-							voiceStatus: false,
-							events: false,
-							moderation: false,
-							emojiUploads: false,
-							stickerUploads: false,
-							channels: false,
-							presence: false,
-						},
-					},
-				},
-			},
-		});
-	});
-
-	it("projects managed WhatsApp auth, Link-scoped egress, and stock OpenClaw config", () => {
-		const accountId = "00000000-0000-0000-0000-000000000001";
-		const linkId = "link-whatsapp-1";
-		const credentialId = "credential-whatsapp-1";
-		const loaded: RuntimeManifestLoad = {
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				runtime: "openclaw",
-				deploymentId: "dep_whatsapp_creds_projection",
-				environmentId: "env_whatsapp_creds_projection",
-				instanceId: "iid_whatsapp_creds_projection",
-				generation: 5,
-				issuedAt: "2026-06-14T00:00:00Z",
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					openclaw: { enabled: true },
-				},
-				projection: {
-					system: { home: "/home/clawdi", workspace: "/home/clawdi" },
-				},
-			},
-			source: "remote-datasource",
-			sourcePath: "https://runtime.test/manifest",
-			secretValues: {},
-		};
-		const channels: RuntimeChannelsLoad = {
-			channels: [
-				{
-					id: accountId,
-					provider: "whatsapp",
-					name: "Hosted WhatsApp",
-					status: "active",
-					visibility: "private",
-					runtime_links: [
-						{
-							id: linkId,
-							account_id: accountId,
-							agent_id: "env_whatsapp_creds_projection",
-							status: "active",
-							agent_token: "wa-agent-token",
-						},
-					],
-					runtime_credentials: [
-						{
-							id: credentialId,
-							account_id: accountId,
-							agent_link_id: linkId,
-							agent_id: "env_whatsapp_creds_projection",
-							provider: "whatsapp",
-							kind: "whatsapp_baileys_auth_state",
-							created_at: "2026-07-07T00:00:00Z",
-							jid: "15551234567:1@s.whatsapp.net",
-							identity_pub_key_hex: "aabbcc",
-							material: {
-								schemaVersion: "clawdi.whatsappBaileysAuthState.v1",
-								creds: {
-									advSecretKey: "wa-adv-secret",
-									me: { id: "15551234567:1@s.whatsapp.net" },
-								},
-								authCert: {
-									SERIAL: 7,
-									ISSUER: "clawdi",
-									PUBLIC_KEY: {
-										type: "Buffer",
-										data: Buffer.alloc(32, 7).toString("base64"),
-									},
-								},
-							},
-						},
-					],
-				},
-			],
-			source: "remote-datasource",
-			sourcePath: "https://runtime.test/v1/channels",
-			etag: testBundleEtag("whatsapp-creds"),
-		};
-
-		const projected = applyRuntimeChannelsToManifestLoad(loaded, channels);
-		const accountKey = "clawdi_000000000000";
-		expect(projected.manifest.projection?.channels).toMatchObject({
-			whatsapp: {
-				enabled: true,
-				defaultAccount: accountKey,
-				accounts: {
-					[accountKey]: {
-						enabled: true,
-						dmPolicy: "allowlist",
-						allowFrom: ["*"],
-					},
-				},
-			},
-		});
-		expect(projected.manifest.projection?.channelCredentials).toEqual([
-			expect.objectContaining({
-				provider: "whatsapp",
-				kind: "whatsapp_baileys_auth_state",
-				accountId,
-				accountKey,
-				linkId,
-				credentialId,
-			}),
-		]);
-		expect(projected.manifest.egressProfiles?.profiles.map((profile) => profile.id)).toEqual([
-			expect.stringMatching(/^native-whatsapp-baileys-[a-f0-9]{16}$/),
-			"native-whatsapp-baileys-invalid-capability",
-		]);
-		expect(JSON.stringify(projected.manifest)).not.toContain("wa-agent-token");
-		expect(JSON.stringify(projected.manifest)).not.toContain("wa-adv-secret");
-		expect(JSON.stringify(projected.secretValues ?? {})).toContain("wa-agent-token");
-		expect(JSON.stringify(projected.secretValues ?? {})).toContain("wa-adv-secret");
-	});
-
 	it("removes stale channel-driven egress profiles when runtime channels are disabled", () => {
 		const loaded: RuntimeManifestLoad = {
 			manifest: {
@@ -6854,15 +6587,10 @@ exit 64
 			source: "remote-datasource",
 			sourcePath: "https://runtime.test/manifest",
 			secretValues: { "secret://provider.default.apiKey": "sk-provider" },
-		};
-		const channels: RuntimeChannelsLoad = {
-			channels: [],
-			source: "remote-datasource",
-			sourcePath: "https://runtime.test/v1/channels",
-			etag: testBundleEtag("empty-channels"),
+			channelBindings: [],
 		};
 
-		const projected = applyRuntimeChannelsToManifestLoad(loaded, channels);
+		const projected = applyRuntimeBundleChannelsToManifestLoad(loaded);
 
 		expect(projected.manifest.egressProfiles?.profiles.map((profile) => profile.id)).toEqual([
 			"explicit-provider-profile",
@@ -6871,6 +6599,9 @@ exit 64
 	});
 
 	it("keeps managed channels separate from provider projection profiles", () => {
+		const accountKey = "clawdi_accttelegram";
+		const agentTokenSecretRef = `secret://channels/telegram/${accountKey}/agent-token`;
+		const placeholderTokenSecretRef = `secret://channels/telegram/${accountKey}/placeholder-token`;
 		const loaded: RuntimeManifestLoad = {
 			manifest: {
 				schemaVersion: "clawdi.runtimeDesiredState.v1",
@@ -6905,33 +6636,20 @@ exit 64
 			secretValues: {
 				"secret://provider.openclaw.apiKey": "sk-openclaw-provider",
 				"secret://provider.hermes.apiKey": "sk-hermes-provider",
+				[agentTokenSecretRef]: "agent-token-runtime",
+				[placeholderTokenSecretRef]: "999999999:0123456789abcdef0123456789abcdef",
 			},
-		};
-		const channels: RuntimeChannelsLoad = {
-			channels: [
+			channelBindings: [
 				{
-					id: "acct-telegram-1",
 					provider: "telegram",
-					name: "Runtime Telegram",
-					status: "active",
-					visibility: "private",
-					runtime_links: [
-						{
-							id: "link-telegram-1",
-							account_id: "acct-telegram-1",
-							agent_id: "env_channel_provider",
-							status: "active",
-							agent_token: "agent-token-runtime",
-						},
-					],
+					accountKey,
+					agentTokenSecretRef,
+					placeholderTokenSecretRef,
 				},
 			],
-			source: "remote-datasource",
-			sourcePath: "https://runtime.test/v1/channels",
-			etag: testBundleEtag("channels"),
 		};
 
-		const projected = applyRuntimeChannelsToManifestLoad(loaded, channels);
+		const projected = applyRuntimeBundleChannelsToManifestLoad(loaded);
 
 		expect(projected.manifest.egressProfiles?.profiles.map((profile) => profile.id)).toEqual([
 			"native-telegram-clawdi_accttelegram-managed",
@@ -12527,6 +12245,24 @@ exit 64
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_SYSTEMD_APPLY = "0";
 		const paths = getRuntimePaths();
+		const telegramAccountKey = "clawdi_accttelegram";
+		const telegramAgentRef = `secret://channels/telegram/${telegramAccountKey}/agent-token`;
+		const telegramPlaceholderRef = `secret://channels/telegram/${telegramAccountKey}/placeholder-token`;
+		const discordAccountKey = "clawdi_acctdiscordh";
+		const discordAgentRef = `secret://channels/discord/${discordAccountKey}/agent-token`;
+		const discordPlaceholderRef = `secret://channels/discord/${discordAccountKey}/placeholder-token`;
+		const telegramBinding: RuntimeBundleChannelBinding = {
+			provider: "telegram",
+			accountKey: telegramAccountKey,
+			agentTokenSecretRef: telegramAgentRef,
+			placeholderTokenSecretRef: telegramPlaceholderRef,
+		};
+		const discordBinding: RuntimeBundleChannelBinding = {
+			provider: "discord",
+			accountKey: discordAccountKey,
+			agentTokenSecretRef: discordAgentRef,
+			placeholderTokenSecretRef: discordPlaceholderRef,
+		};
 
 		const load: RuntimeManifestLoad = {
 			manifest: {
@@ -12567,56 +12303,16 @@ exit 64
 			source: "remote-datasource",
 			sourcePath: "test://hermes-channels",
 			offline: false,
-			secretValues: {},
-		};
-		const channels: RuntimeChannelsLoad = {
-			channels: [
-				{
-					id: "acct-telegram-hermes",
-					provider: "telegram",
-					name: "Hermes Telegram",
-					status: "active",
-					visibility: "private",
-					runtime_links: [
-						{
-							id: "link-telegram-hermes",
-							account_id: "acct-telegram-hermes",
-							agent_id: "env_hermes_channels",
-							status: "active",
-							agent_token: "123456789:telegram-agent-token",
-						},
-					],
-				},
-				{
-					id: "acct-discord-hermes",
-					provider: "discord",
-					name: "Hermes Discord",
-					status: "active",
-					visibility: "private",
-					runtime_links: [
-						{
-							id: "link-discord-hermes",
-							account_id: "acct-discord-hermes",
-							agent_id: "env_hermes_channels",
-							status: "active",
-							agent_token: "discord-agent-token",
-						},
-					],
-				},
-			],
-			source: "remote-datasource",
-			sourcePath: "https://runtime.test/v1/channels",
-			etag: testBundleEtag("hermes-channels"),
+			secretValues: {
+				[telegramAgentRef]: "123456789:telegram-agent-token",
+				[telegramPlaceholderRef]: `999999999:${"a".repeat(32)}`,
+				[discordAgentRef]: "discord-agent-token",
+				[discordPlaceholderRef]: `clawdi_${"b".repeat(32)}`,
+			},
+			channelBindings: [telegramBinding, discordBinding],
 		};
 
-		const projected = applyRuntimeChannelsToManifestLoad(load, channels, paths);
-		const projectedChannels = projected.manifest.projection?.channels;
-		if (!projectedChannels) throw new Error("missing managed channel projection");
-		projectedChannels.whatsapp = {
-			enabled: true,
-			defaultAccount: "clawdi_acctwhatsapp",
-			accounts: { clawdi_acctwhatsapp: { enabled: true } },
-		};
+		const projected = applyRuntimeBundleChannelsToManifestLoad(load, paths);
 		const convergence = convergeRuntimeManifest(projected, paths);
 
 		expect(convergence.installErrors).toEqual([]);
@@ -12637,32 +12333,6 @@ exit 64
 		expect(parsedHermesConfig.thread_sessions_per_user).toBe(false);
 		expect(parsedHermesConfig).not.toHaveProperty("discord.allow_from");
 		expect(parsedHermesConfig).not.toHaveProperty("discord.group_allow_from");
-		expect(parsedHermesConfig).toMatchObject({
-			whatsapp: {
-				enabled: true,
-				dm_policy: "allowlist",
-				group_policy: "open",
-				allow_from: ["*"],
-				group_allow_from: ["*"],
-			},
-			platforms: {
-				whatsapp: {
-					enabled: true,
-					extra: {
-						dm_policy: "allowlist",
-						group_policy: "open",
-						allow_from: ["*"],
-						group_allow_from: ["*"],
-					},
-				},
-			},
-		});
-		expect(
-			JSON.stringify({
-				whatsapp: parsedHermesConfig.whatsapp,
-				platformWhatsapp: parsedHermesConfig.platforms?.whatsapp,
-			}),
-		).not.toContain('"dm_policy":"open"');
 		expect(parsedHermesConfig).not.toHaveProperty("streaming.transport");
 		expect(parsedHermesConfig).toMatchObject({
 			custom_root: "keep",
@@ -12712,14 +12382,8 @@ exit 64
 		expect(profileBundle).toContain("/v1/channels/discord");
 
 		const discordOnly = convergeRuntimeManifest(
-			applyRuntimeChannelsToManifestLoad(
-				load,
-				{
-					channels: [channels.channels[1]],
-					source: "remote-datasource",
-					sourcePath: "https://runtime.test/v1/channels",
-					etag: testBundleEtag("discord-only-hermes-channels"),
-				},
+			applyRuntimeBundleChannelsToManifestLoad(
+				{ ...load, channelBindings: [discordBinding] },
 				paths,
 			),
 			paths,
@@ -12736,14 +12400,8 @@ exit 64
 		);
 
 		const removed = convergeRuntimeManifest(
-			applyRuntimeChannelsToManifestLoad(
-				load,
-				{
-					channels: [],
-					source: "remote-datasource",
-					sourcePath: "https://runtime.test/v1/channels",
-					etag: testBundleEtag("empty-hermes-channels"),
-				},
+			applyRuntimeBundleChannelsToManifestLoad(
+				{ ...load, channelBindings: [] },
 				paths,
 			),
 			paths,
@@ -12788,9 +12446,18 @@ exit 64
 		const hermesBin = join(home, ".local", "bin", "hermes");
 		const accountId = "00000000-0000-0000-0000-000000000001";
 		const accountKey = "clawdi_000000000000";
-		const credentialId = "credential-whatsapp-hermes";
+		const linkId = "60000000-0000-4000-8000-000000000006";
+		const credentialId = "80000000-0000-4000-8000-000000000011";
+		const agentTokenSecretRef = `secret://channels/whatsapp/${accountKey}/links/${linkId}/agent-token`;
+		const capabilitySecretRef = `secret://channels/whatsapp/${accountKey}/links/${linkId}/egress-capability`;
 		const credentialSecretRef = `secret://channels/whatsapp/${accountKey}/credentials/${credentialId}/creds-json`;
+		const capability = `clawdi_${createHash("sha256")
+			.update(`whatsapp:${accountKey}:${linkId}`)
+			.digest("hex")
+			.slice(0, 32)}`;
 		const sessionDir = join(home, ".hermes", "platforms", "whatsapp", "session");
+		const legacySessionDir = join(home, ".hermes", "whatsapp", "session");
+		const legacySentinel = join(legacySessionDir, "unmanaged-session-sentinel");
 		const creds = {
 			advSecretKey: "wa-hermes-secret",
 			me: { id: "15551234567:1@s.whatsapp.net" },
@@ -12799,11 +12466,15 @@ exit 64
 		mkdirSync(workspace, { recursive: true });
 		writeFileSync(hermesBin, "#!/usr/bin/env bash\nexit 0\n");
 		chmodSync(hermesBin, 0o700);
+		seedHermesManagedBaileys(home);
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_SYSTEMD_APPLY = "0";
+		const paths = getRuntimePaths();
+		mkdirSync(legacySessionDir, { recursive: true });
+		writeFileSync(legacySentinel, "preserved\n");
 
 		const load: RuntimeManifestLoad = {
 			manifest: {
@@ -12815,6 +12486,7 @@ exit 64
 				generation: 14,
 				issuedAt: "2026-07-07T00:00:00Z",
 				controlPlane: { apiUrl: "https://cloud-api.test/" },
+				egressEngine: seedMitmproxyCache(paths),
 				runtimes: {
 					hermes: {
 						enabled: true,
@@ -12841,58 +12513,36 @@ exit 64
 			source: "remote-datasource",
 			sourcePath: "test://hermes-whatsapp",
 			offline: false,
-			secretValues: {},
-		};
-		const channels: RuntimeChannelsLoad = {
-			channels: [
+			secretValues: {
+				[agentTokenSecretRef]: "wa-hermes-agent-token",
+				[capabilitySecretRef]: capability,
+				[credentialSecretRef]: JSON.stringify(creds),
+			},
+			channelBindings: [
 				{
-					id: accountId,
 					provider: "whatsapp",
-					name: "Hermes WhatsApp",
-					status: "active",
-					visibility: "private",
-					runtime_links: [
-						{
-							id: "link-whatsapp-hermes",
-							account_id: accountId,
-							agent_id: "env_hermes_whatsapp",
-							status: "active",
-							agent_token: "wa-hermes-agent-token",
-						},
-					],
-					runtime_credentials: [
-						{
-							id: credentialId,
-							account_id: accountId,
-							agent_link_id: "link-whatsapp-hermes",
-							agent_id: "env_hermes_whatsapp",
-							provider: "whatsapp",
-							kind: "whatsapp_baileys_auth_state",
-							created_at: "2026-07-07T00:00:00Z",
-							jid: "15551234567:1@s.whatsapp.net",
-							identity_pub_key_hex: "aabbcc",
-							material: {
-								schemaVersion: "clawdi.whatsappBaileysAuthState.v1",
-								creds,
-								authCert: {
-									SERIAL: 7,
-									ISSUER: "clawdi",
-									PUBLIC_KEY: {
-										type: "Buffer",
-										data: Buffer.alloc(32, 7).toString("base64"),
-									},
-								},
+					accountId,
+					accountKey,
+					linkId,
+					agentTokenSecretRef,
+					placeholderTokenSecretRef: capabilitySecretRef,
+					credential: {
+						id: credentialId,
+						credsSecretRef: credentialSecretRef,
+						authCert: {
+							SERIAL: 7,
+							ISSUER: "clawdi",
+							PUBLIC_KEY: {
+								type: "Buffer",
+								data: Buffer.alloc(32, 7).toString("base64"),
 							},
 						},
-					],
+					},
 				},
 			],
-			source: "remote-datasource",
-			sourcePath: "https://runtime.test/v1/channels",
-			etag: testBundleEtag("hermes-whatsapp"),
 		};
 
-		const projected = applyRuntimeChannelsToManifestLoad(load, channels);
+		const projected = applyRuntimeBundleChannelsToManifestLoad(load, paths);
 		const credentialProjection = projected.manifest.projection?.channelCredentials as unknown[];
 		expect(credentialProjection).toEqual([
 			expect.objectContaining({
@@ -12900,7 +12550,7 @@ exit 64
 				kind: "whatsapp_baileys_auth_state",
 				accountId,
 				accountKey,
-				linkId: "link-whatsapp-hermes",
+				linkId,
 				credentialId,
 				authDir: sessionDir,
 				targets: { hermes: { authDir: sessionDir } },
@@ -12924,15 +12574,19 @@ exit 64
 			WHATSAPP_MODE: "bot",
 			WHATSAPP_ALLOWED_USERS: "*",
 		});
-		materializeHostedChannelCredentials(projected.manifest, projected.secretValues, home);
+		const convergence = convergeRuntimeManifest(projected, paths);
+		expect(convergence.installErrors).toEqual([]);
 		expect(existsSync(sessionDir)).toBe(true);
+		expect(readFileSync(legacySentinel, "utf-8")).toBe("preserved\n");
+		expect(readHermesConfigYaml(home)).toHaveProperty(
+			"platforms.whatsapp.extra.session_path",
+			sessionDir,
+		);
 
-		const removed = applyRuntimeChannelsToManifestLoad(load, {
-			channels: [],
-			source: "remote-datasource",
-			sourcePath: "https://runtime.test/v1/channels",
-			etag: testBundleEtag("empty-hermes-whatsapp"),
-		});
+		const removed = applyRuntimeBundleChannelsToManifestLoad(
+			{ ...load, channelBindings: [], secretValues: {} },
+			paths,
+		);
 		materializeHostedChannelCredentials(removed.manifest, removed.secretValues, home);
 		expect(existsSync(sessionDir)).toBe(false);
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_MODE).toBeUndefined();
@@ -13028,13 +12682,9 @@ exit 64
 				"secret://channels/whatsapp/clawdi_stale/credentials/stale/creds-json":
 					'{"me":"user-owned"}',
 			},
+			channelBindings: [],
 		};
-		const projected = applyRuntimeChannelsToManifestLoad(load, {
-			channels: [],
-			source: "remote-datasource",
-			sourcePath: "https://runtime.test/v1/channels",
-			etag: testBundleEtag("empty-hermes-channels"),
-		});
+		const projected = applyRuntimeBundleChannelsToManifestLoad(load);
 
 		const convergence = convergeRuntimeManifest(projected, getRuntimePaths());
 
@@ -13191,6 +12841,9 @@ exit 0
 			.map((entry) => JSON.parse(entry));
 		expect(patches).toHaveLength(2);
 		expect(patches[0].channels.whatsapp.accounts).toHaveProperty("clawdi_whatsapp");
+		expect(patches[0].channels.whatsapp.accounts.clawdi_whatsapp.authDir).toBe(
+			join(home, ".openclaw", "credentials", "whatsapp"),
+		);
 		expect(patches[0].session).toEqual({ dmScope: "per-account-channel-peer" });
 		expect(patches[1].channels.whatsapp).toBeNull();
 		expect(patches[1].session).toEqual({ dmScope: null });

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -42,9 +42,7 @@ import {
 	type RuntimeApplyContext,
 	runtimeManifestSourceSchema,
 } from "../src/runtime/apply-identity";
-import {
-	applyRuntimeBundleChannelsToManifestLoad as applyRuntimeBundleChannelsToManifestLoadWithContext,
-} from "../src/runtime/channels";
+import { applyRuntimeBundleChannelsToManifestLoad as applyRuntimeBundleChannelsToManifestLoadWithContext } from "../src/runtime/channels";
 import {
 	applyRuntimeCliDesiredState,
 	completePendingRuntimeCliUpgrade,
@@ -12400,10 +12398,7 @@ exit 64
 		);
 
 		const removed = convergeRuntimeManifest(
-			applyRuntimeBundleChannelsToManifestLoad(
-				{ ...load, channelBindings: [] },
-				paths,
-			),
+			applyRuntimeBundleChannelsToManifestLoad({ ...load, channelBindings: [] }, paths),
 			paths,
 		);
 		expect(removed.installErrors).toEqual([]);


### PR DESCRIPTION
## Summary

- extend the strict hosted runtime bundle v2 consumer with Link-scoped WhatsApp bindings
- materialize managed Baileys auth into OpenClaw's official per-account `authDir`
- set Hermes' official `platforms.whatsapp.extra.session_path` so legacy state cannot shadow managed auth
- retire the unused CLI `RuntimeChannelsLoad` datasource; strict bundle v2 remains the only managed runtime channel desired-state source
- release the consumer as `clawdi@0.13.56`

## Rollout boundary

This PR is intentionally consumer-only. It does not make the backend emit WhatsApp bindings.

Merge and publish this CLI first, then update hosted runtimes and confirm the active CLI is `0.13.56`. Only after that should the backend producer in #923 be merged. This ordering avoids sending a strict binding variant to older CLI processes that correctly reject it.

## Verification

- `bash scripts/test.sh cli src/runtime/runtime-bundle-v2.test.ts tests/runtime.test.ts`
  - CLI typecheck passed
  - 211 passed, 0 failed
- `git diff --check origin/main..HEAD`
- native WhatsApp E2E remains covered by the repository fixture and runs in CI with the pinned runtime images
