### PR TITLE
fix(web): recover accepted plan changes after refresh

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -909,14 +909,12 @@ const _cardPastDueDeployment = {
 	},
 };
 
-const _terminalFallbackDeployment = {
+const terminalFallbackDeployment: DeploymentMutationFixture = {
 	...includedBasicDeployment,
 	id: "hdep_terminal_fallback",
 	name: "Fallback Basic",
 	upgrade_available: false,
-	compute_subscription: { ...includedBasicDeployment.compute_subscription },
 	last_funding_event: {
-		type: "compute_subscription_fallback",
 		funding_source: "stripe",
 		reason: "payment_failure",
 		prior_plan_slug: "compute_performance",
@@ -1041,7 +1039,7 @@ function planChangeResponse({
 	targetBillingTermMonths: 1 | 12;
 	status: "awaiting_payment" | "awaiting_projection" | "scheduled" | "complete";
 	effectiveAt: string;
-}) {
+}): { body: NonNullable<DeploymentRead["accepted_operation"]>; status: number } {
 	return {
 		status: 202,
 		body: {
@@ -3648,6 +3646,73 @@ test("paid card subscription confirms an immediate quoted upgrade", async ({ pag
 	await expect(page.getByRole("button", { name: "Check plan change status" })).toBeVisible();
 	await expect(page.getByText("Plan changed", { exact: true })).toBeVisible();
 	expect(errors, `paid card upgrade: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("accepted plan change recovers from the deployment projection after refresh", async ({
+	page,
+}) => {
+	const errors = collectBrowserErrors(page);
+	const planChangeRequests: string[] = [];
+	const operation = (status: "awaiting_projection" | "complete") =>
+		planChangeResponse({
+			operationId: "op_recovered_card",
+			subscriptionId: 42,
+			fundingSource: "stripe",
+			currentPlanSlug: "compute_basic",
+			targetPlanSlug: "compute_performance",
+			targetBillingTermMonths: 12,
+			status,
+			effectiveAt: "2026-07-16T00:00:00Z",
+		});
+	const pendingOperation = operation("awaiting_projection").body;
+	const failedOperation = {
+		...pendingOperation,
+		done: true,
+		error: { code: 9, message: "Plan change failed", details: [] },
+	};
+	const projectedDeployment = mutationDeploymentReadFixture(terminalFallbackDeployment);
+	projectedDeployment.accepted_operation = {
+		...pendingOperation,
+		metadata: { ...pendingOperation.metadata, deploymentId: projectedDeployment.resource.id },
+	};
+	const terminalDeployment = {
+		...projectedDeployment,
+		accepted_operation: {
+			...failedOperation,
+			metadata: { ...failedOperation.metadata, deploymentId: projectedDeployment.resource.id },
+		},
+	};
+
+	await stubHostedApi(page, {
+		deployments: [terminalDeployment],
+		deploymentListResponses: [[projectedDeployment], [projectedDeployment]],
+		planChangeRequests,
+		planChangeOperationResponses: [{ body: terminalDeployment.accepted_operation, status: 200 }],
+		plans: [basicPlan, performancePlan],
+	});
+	await gotoHostedAgentSettings(page, "hdep_terminal_fallback", "Basic");
+	await page.reload();
+
+	await page.getByRole("button", { name: "Check plan change status" }).click();
+	const recoveryDialog = page.getByRole("dialog", { name: "Check plan change status" });
+	await expect(
+		recoveryDialog.getByText(
+			"This plan change was already accepted. Checking its status will not submit another charge.",
+			{ exact: true },
+		),
+	).toBeVisible();
+	await recoveryDialog.getByRole("button", { name: "Check status", exact: true }).click();
+	await expect(page.getByText("Couldn’t change plan", { exact: true })).toBeVisible();
+	const retryDialog = page.getByRole("dialog", { name: "Change compute subscription" });
+	await expect(retryDialog).toBeVisible();
+	await retryDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+	await expect(
+		page
+			.locator("#compute-plan-controls")
+			.getByRole("button", { name: "Start a new subscription" }),
+	).toBeVisible();
+	expect(planChangeRequests).toEqual([]);
+	expect(errors, `recovered plan change: ${errors.join(" | ")}`).toEqual([]);
 });
 
 for (const firstTimeViewport of [

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -138,6 +138,7 @@ import { ComputeDunningBanner } from "@/hosted/billing/components/compute-dunnin
 import type {
 	ComputePlanChangeQuoteRequest,
 	ComputePlanChangeQuoteResponse,
+	ComputePlanChangeResult,
 	DeploymentUpdateRequest,
 	HostedDeployment,
 } from "@/hosted/billing/contracts";
@@ -170,6 +171,7 @@ import {
 	useResumeSubscription,
 } from "@/hosted/billing/hooks";
 import {
+	activePlanChangeOperationName,
 	type PlanChangeSelection,
 	performanceUpgradeUnavailableReason,
 	planChangeUnavailableReason,
@@ -3551,8 +3553,10 @@ function ComputeSettingsSections({
 	const lifecycle = useDeploymentLifecycle();
 	const plans = usePlans();
 	const quotePlanChange = useQuotePlanChange();
-	const [pendingPlanChangeName, setPendingPlanChangeName] = useState<string | null>(null);
-	const changePlan = useChangePlan(setPendingPlanChangeName);
+	const projectedPlanChangeName = activePlanChangeOperationName(deployment);
+	const [acceptedPlanChangeName, setAcceptedPlanChangeName] = useState<string | null>(null);
+	const pendingPlanChangeName = projectedPlanChangeName ?? acceptedPlanChangeName;
+	const changePlan = useChangePlan(setAcceptedPlanChangeName);
 	const checkPlanChange = useCheckPlanChange();
 	const [subscriptionCreateOpen, setSubscriptionCreateOpen] = useState(false);
 	const [planChangeOpen, setPlanChangeOpen] = useState(false);
@@ -3687,7 +3691,7 @@ function ComputeSettingsSections({
 		if (hostedAccess.isLoading || hostedAccess.canCreateCloudAgents) return;
 		setSubscriptionCreateOpen(false);
 		setPlanChangeOpen(false);
-		setPendingPlanChangeName(null);
+		setAcceptedPlanChangeName(null);
 		walletTopUp.reset();
 	}, [hostedAccess.canCreateCloudAgents, hostedAccess.isLoading, walletTopUp.reset]);
 
@@ -3708,13 +3712,52 @@ function ComputeSettingsSections({
 				subscription_id: subscriptionId,
 				...selection,
 			});
-			setPendingPlanChangeName(null);
+			setAcceptedPlanChangeName(null);
 			setPlanChangeQuote(quote);
 		} catch (error) {
 			toast.error("Couldn’t quote plan change", {
 				description: normalizeBillingError(error),
 			});
 		}
+	}
+
+	function showPlanChangeResult(result: ComputePlanChangeResult) {
+		if (result.kind === "scheduled") {
+			toast.success("Downgrade scheduled", {
+				description: `Your current compute remains active until ${formatShortDate(result.effectiveAt)}.`,
+			});
+		} else if (result.kind === "complete") {
+			toast.success("Plan changed", {
+				description: "Your compute subscription has been updated.",
+			});
+		} else {
+			toast.info("Plan change in progress", {
+				description:
+					result.waitingFor === "payment"
+						? "We’re still waiting for payment confirmation. Your compute plan has not changed yet."
+						: "Your request was received, but the compute plan has not updated yet. You can watch its status here.",
+			});
+		}
+		setAcceptedPlanChangeName(null);
+		setPlanChangeDialogOpen(false);
+	}
+
+	function handlePlanChangeError(error: unknown) {
+		if (error instanceof PlanChangePendingError) {
+			setAcceptedPlanChangeName(error.operationName);
+			toast.info("Still waiting for confirmation", {
+				description:
+					"We don’t have a final result yet. Don’t submit another plan change. Check again in a few minutes; if it still hasn’t finished, contact support. Checking only reads the status and does not submit another charge.",
+			});
+			return;
+		}
+		if (error instanceof PlanChangeTerminalError) {
+			setAcceptedPlanChangeName(null);
+		}
+		if (walletTopUp.handleFundingError(error)) return;
+		toast.error("Couldn’t change plan", {
+			description: normalizeBillingError(error),
+		});
 	}
 
 	async function confirmPlanChange(operationId: string) {
@@ -3724,43 +3767,18 @@ function ComputeSettingsSections({
 				setPlanChangeDialogOpen(false);
 				return;
 			}
-			const result = pendingPlanChangeName
-				? await checkPlanChange.mutateAsync(pendingPlanChangeName)
-				: await changePlan.mutateAsync({ operation_id: operationId });
-			if (result.kind === "scheduled") {
-				toast.success("Downgrade scheduled", {
-					description: `Your current compute remains active until ${formatShortDate(result.effectiveAt)}.`,
-				});
-			} else if (result.kind === "complete") {
-				toast.success("Plan changed", {
-					description: "Your compute subscription has been updated.",
-				});
-			} else {
-				toast.info("Plan change in progress", {
-					description:
-						result.waitingFor === "payment"
-							? "We’re still waiting for payment confirmation. Your compute plan has not changed yet."
-							: "Your request was received, but the compute plan has not updated yet. You can watch its status here.",
-				});
-			}
-			setPendingPlanChangeName(null);
-			setPlanChangeDialogOpen(false);
+			showPlanChangeResult(await changePlan.mutateAsync({ operation_id: operationId }));
 		} catch (error) {
-			if (error instanceof PlanChangePendingError) {
-				setPendingPlanChangeName(error.operationName);
-				toast.info("Still waiting for confirmation", {
-					description:
-						"We don’t have a final result yet. Don’t submit another plan change. Check again in a few minutes; if it still hasn’t finished, contact support. Checking only reads the status and does not submit another charge.",
-				});
-				return;
-			}
-			if (error instanceof PlanChangeTerminalError) {
-				setPendingPlanChangeName(null);
-			}
-			if (walletTopUp.handleFundingError(error)) return;
-			toast.error("Couldn’t change plan", {
-				description: normalizeBillingError(error),
-			});
+			handlePlanChangeError(error);
+		}
+	}
+
+	async function checkAcceptedPlanChange() {
+		if (!pendingPlanChangeName) return;
+		try {
+			showPlanChangeResult(await checkPlanChange.mutateAsync(pendingPlanChangeName));
+		} catch (error) {
+			handlePlanChangeError(error);
 		}
 	}
 
@@ -3831,6 +3849,7 @@ function ComputeSettingsSections({
 					hasAcceptedChange={pendingPlanChangeName !== null}
 					onQuote={requestPlanChangeQuote}
 					onConfirm={confirmPlanChange}
+					onCheckStatus={checkAcceptedPlanChange}
 					onTopUp={() => walletTopUp.show()}
 					onExitComplete={() => {
 						if (pendingPlanChangeName === null) setPlanChangeQuote(null);
@@ -3914,9 +3933,11 @@ function ComputeSettingsSections({
 											(hasTerminalFallback ? !canStartNewSubscription : !canUpgrade || !perfPlan))
 									}
 									onClick={() =>
-										hasTerminalFallback
-											? setSubscriptionCreateOpen(true)
-											: setPlanChangeDialogOpen(true)
+										pendingPlanChangeName
+											? setPlanChangeDialogOpen(true)
+											: hasTerminalFallback
+												? setSubscriptionCreateOpen(true)
+												: setPlanChangeDialogOpen(true)
 									}
 								>
 									{hasTerminalFallback ? (

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -22,7 +22,7 @@ import type {
 	HostedComputeSubscription,
 	HostedDeployment,
 } from "@/hosted/billing/contracts";
-import { billingQueryRetry } from "@/hosted/billing/errors";
+import { billingQueryRetry, PlanChangeTerminalError } from "@/hosted/billing/errors";
 import { billingKeys } from "@/hosted/billing/query-keys";
 import {
 	type SubscriptionCreateQuoteView,
@@ -221,7 +221,8 @@ export function useCheckPlanChange() {
 	const qc = useQueryClient();
 	return useMutation<ComputePlanChangeResult, Error, string>({
 		mutationFn: (operationName) => client.checkPlanChange(operationName),
-		onSuccess: () => {
+		onSettled: (_result, error) => {
+			if (error && !(error instanceof PlanChangeTerminalError)) return;
 			qc.invalidateQueries({ queryKey: billingKeys.deployments });
 			qc.invalidateQueries({ queryKey: billingKeys.wallet });
 			qc.invalidateQueries({ queryKey: billingKeys.billingHistoryRoot });

--- a/apps/web/src/hosted/billing/subscription/plan-change-dialog.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-change-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CalendarClock, CreditCard, TriangleAlert, WalletCards } from "lucide-react";
+import { CalendarClock, CreditCard, RefreshCw, TriangleAlert, WalletCards } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -72,6 +72,7 @@ export function PlanChangeDialog({
 	hasAcceptedChange,
 	onQuote,
 	onConfirm,
+	onCheckStatus,
 	onTopUp,
 	onExitComplete,
 }: {
@@ -89,6 +90,7 @@ export function PlanChangeDialog({
 	hasAcceptedChange: boolean;
 	onQuote: (selection: PlanChangeSelection) => void;
 	onConfirm: (operationId: string) => void;
+	onCheckStatus: () => void;
 	onTopUp?: () => void;
 	onExitComplete?: () => void;
 }) {
@@ -186,17 +188,54 @@ export function PlanChangeDialog({
 		>
 			<DialogContent data-hosted="true" className="sm:max-w-lg" showCloseButton={!blocksClose}>
 				<DialogHeader>
-					<DialogTitle>{displayedQuote ? quoteTitle : "Change compute subscription"}</DialogTitle>
+					<DialogTitle>
+						{hasAcceptedChange
+							? "Check plan change status"
+							: displayedQuote
+								? quoteTitle
+								: "Change compute subscription"}
+					</DialogTitle>
 					<DialogDescription>
-						{displayedQuote
-							? displayedQuote.change_kind === "immediate_upgrade"
-								? "The quoted proration is charged now. Compute changes after payment is confirmed."
-								: `The current plan remains active until ${formatShortDate(displayedQuote.effective_at)}.`
-							: "Choose a compute plan and monthly or annual billing, then review the exact price and timing."}
+						{hasAcceptedChange
+							? "This plan change was already accepted. Checking its status will not submit another charge."
+							: displayedQuote
+								? displayedQuote.change_kind === "immediate_upgrade"
+									? "The quoted proration is charged now. Compute changes after payment is confirmed."
+									: `The current plan remains active until ${formatShortDate(displayedQuote.effective_at)}.`
+								: "Choose a compute plan and monthly or annual billing, then review the exact price and timing."}
 					</DialogDescription>
 				</DialogHeader>
 
-				{displayedQuote ? (
+				{hasAcceptedChange ? (
+					<div className="flex flex-col gap-4">
+						<Alert>
+							<CalendarClock aria-hidden />
+							<AlertTitle>Still waiting for confirmation</AlertTitle>
+							<AlertDescription>
+								We don’t have a final result yet. Don’t submit another plan change. You can close
+								this window and check again in a few minutes; if it still hasn’t finished, contact
+								support.
+							</AlertDescription>
+						</Alert>
+						<DialogFooter>
+							<Button
+								variant="ghost"
+								onClick={() => requestOpenChange(false)}
+								disabled={blocksClose}
+							>
+								Close
+							</Button>
+							<Button onClick={onCheckStatus} disabled={isConfirming}>
+								{isConfirming ? (
+									<Spinner data-icon="inline-start" />
+								) : (
+									<RefreshCw data-icon="inline-start" />
+								)}
+								{isConfirming ? "Checking status…" : "Check status"}
+							</Button>
+						</DialogFooter>
+					</div>
+				) : displayedQuote ? (
 					<div className="flex flex-col gap-4">
 						<div className="grid gap-3 rounded-lg border bg-muted/20 p-3 sm:grid-cols-2">
 							<dl>
@@ -267,24 +306,13 @@ export function PlanChangeDialog({
 								</AlertDescription>
 							</Alert>
 						) : null}
-						{hasAcceptedChange ? (
-							<Alert>
-								<CalendarClock aria-hidden />
-								<AlertTitle>Still waiting for confirmation</AlertTitle>
-								<AlertDescription>
-									We don’t have a final result yet. Don’t submit another plan change. You can close
-									this window and check again in a few minutes; if it still hasn’t finished, contact
-									support. Checking only reads the status and does not submit another charge.
-								</AlertDescription>
-							</Alert>
-						) : null}
 						<DialogFooter>
 							<Button
 								variant="ghost"
 								onClick={() => requestOpenChange(false)}
 								disabled={blocksClose}
 							>
-								{hasAcceptedChange ? "Close" : "Back"}
+								Back
 							</Button>
 							<Button
 								onClick={() => onConfirm(displayedQuote.operation_id)}
@@ -297,13 +325,7 @@ export function PlanChangeDialog({
 								) : (
 									<CreditCard data-icon="inline-start" />
 								)}
-								{isConfirming
-									? hasAcceptedChange
-										? "Checking status…"
-										: busyLabel
-									: hasAcceptedChange
-										? "Check status"
-										: confirmLabel}
+								{isConfirming ? busyLabel : confirmLabel}
 							</Button>
 						</DialogFooter>
 					</div>

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts
@@ -1,11 +1,50 @@
 import { describe, expect, test } from "bun:test";
+import { hostedDeploymentFixture } from "../../hosted-deployment.test-fixture";
+import type { HostedDeployment } from "../contracts";
 import {
+	activePlanChangeOperationName,
 	defaultPlanChangeSelection,
 	isSamePlanChangeSelection,
 	performanceUpgradeUnavailableReason,
 	planChangeUnavailableReason,
 	walletBalanceAfterDebit,
 } from "./plan-change.logic";
+
+describe("plan change recovery", () => {
+	type AcceptedOperation = NonNullable<HostedDeployment["accepted_operation"]>;
+	const acceptedPlanChange: AcceptedOperation = {
+		name: "operations/plan-change-pending",
+		metadata: {
+			"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
+			deploymentId: "dep_test",
+			verb: "plan_change",
+			targetGeneration: 2,
+			manifestETag: "etag_plan_change",
+			createTime: "2026-08-11T00:00:00Z",
+			updateTime: "2026-08-11T00:00:00Z",
+		},
+		done: false,
+	};
+	const recover = (operation: AcceptedOperation) =>
+		activePlanChangeOperationName(hostedDeploymentFixture({ acceptedOperation: operation }));
+
+	test("recovers only an active plan change belonging to the projected deployment", () => {
+		expect(recover(acceptedPlanChange)).toBe("operations/plan-change-pending");
+		expect(recover({ ...acceptedPlanChange, done: true })).toBeNull();
+		expect(
+			recover({
+				...acceptedPlanChange,
+				metadata: { ...acceptedPlanChange.metadata, verb: "restart" },
+			}),
+		).toBeNull();
+		expect(
+			recover({
+				...acceptedPlanChange,
+				metadata: { ...acceptedPlanChange.metadata, deploymentId: "dep_other" },
+			}),
+		).toBeNull();
+	});
+});
 
 describe("walletBalanceAfterDebit", () => {
 	test("preserves the exact quoted decimal debit", () => {

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
@@ -39,6 +39,21 @@ const PERFORMANCE_UPGRADE_UNAVAILABLE_COPY = {
 const UNKNOWN_PERFORMANCE_UPGRADE_UNAVAILABLE_COPY =
 	"Clawdi can’t confirm why this agent can’t be upgraded right now. Check again later, or contact support if this continues.";
 
+/** Recover an active plan change from the authoritative deployment projection. */
+export function activePlanChangeOperationName(
+	deployment: Pick<HostedDeployment, "accepted_operation" | "resource">,
+): string | null {
+	const operation = deployment.accepted_operation;
+	if (
+		operation?.done !== false ||
+		operation.metadata.verb !== "plan_change" ||
+		operation.metadata.deploymentId !== deployment.resource.id
+	) {
+		return null;
+	}
+	return operation.name.trim() || null;
+}
+
 function isHostedComputeUpgradeIneligibilityReason(
 	reason: string,
 ): reason is HostedComputeUpgradeIneligibilityReason {


### PR DESCRIPTION
## Summary

- recover an active plan change from the authoritative deployment projection after refresh
- keep recovery status checks GET-only so they cannot submit another plan change or charge
- refresh deployment, wallet, and billing history when the operation reaches success or an explicit terminal error

## Verification

- 49 focused web tests in the clean Docker runner
- web typecheck
- OSS production build
- Biome on all 6 changed files
- focused hosted Playwright recovery flow