### PR TITLE
fix(channels): order bot pool by provider and creation time

### DIFF
--- a/apps/web/src/hosted/v2/channels/agent-channel-cards.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/agent-channel-cards.logic.test.ts
@@ -22,9 +22,14 @@ function account(id: string, visibility: "private" | "public" = "private"): Chan
 	};
 }
 
-function poolBot(id: string, access: "owner" | "public"): ChannelBotPoolItem {
+function poolBot(
+	id: string,
+	access: "owner" | "public",
+	overrides: Partial<ChannelAccount> = {},
+): ChannelBotPoolItem {
 	return {
 		...account(id, access === "public" ? "public" : "private"),
+		...overrides,
 		access,
 		capabilities: {
 			link_agent: true,
@@ -135,6 +140,38 @@ describe("Agent channel card normalization", () => {
 		expect(groups.clawdiBots[0]?.name).toBe("Current shared name");
 		expect(groups.customBots).toHaveLength(1);
 		expect(groups.customBots[0]?.link?.id).toBe(customLink.id);
+	});
+
+	test("orders Telegram first and preserves creation order within each provider", () => {
+		const telegramNewer = poolBot("telegram-newer", "public", {
+			provider: "telegram",
+			name: "A Telegram bot",
+			created_at: "2026-08-02T00:00:00Z",
+		});
+		const telegramOlder = poolBot("telegram-older", "public", {
+			provider: "telegram",
+			name: "Z Telegram bot",
+			created_at: "2026-08-01T00:00:00Z",
+		});
+		const discord = poolBot("discord", "public", { provider: "discord" });
+		const whatsapp = poolBot("whatsapp", "public", { provider: "whatsapp" });
+
+		const groups = buildAgentChannelCardGroups({
+			channels: [],
+			poolProviders: {
+				discord: [discord],
+				telegram: [telegramNewer, telegramOlder],
+				whatsapp: [whatsapp],
+			},
+			links: [],
+		});
+
+		expect(groups.clawdiBots.map((bot) => bot.id)).toEqual([
+			"telegram-older",
+			"telegram-newer",
+			"discord",
+			"whatsapp",
+		]);
 	});
 
 	test("reconciles an idempotent or conflict response only to this bot on this Agent", () => {

--- a/apps/web/src/hosted/v2/channels/agent-channel-cards.logic.ts
+++ b/apps/web/src/hosted/v2/channels/agent-channel-cards.logic.ts
@@ -1,4 +1,5 @@
 import type { AgentChannelLink } from "@/hosted/v2/channels/channel-edit-client.logic";
+import { orderedProviderIds } from "@/hosted/v2/channels/channel-providers";
 import type { ChannelAccount, ChannelBotPoolItem } from "@/hosted/v2/channels/channel-types";
 
 export type AgentChannelCardItem = {
@@ -82,8 +83,8 @@ export function activeAgentLinkForAccount({
 	);
 }
 
-type MutableCard = Omit<AgentChannelCardItem, "link"> & {
-	link: AgentChannelLink | null;
+type MutableCard = AgentChannelCardItem & {
+	createdAt: string;
 	poolPriority: boolean;
 };
 
@@ -97,6 +98,7 @@ function fallbackCardFromLink(link: AgentChannelLink): MutableCard {
 		available: true,
 		canLink: true,
 		maxLinks: null,
+		createdAt: link.created_at,
 		link,
 		poolPriority: false,
 	};
@@ -112,6 +114,7 @@ function cardFromAccount(account: ChannelAccount, link: AgentChannelLink | null)
 		available: account.status.toLowerCase() === "active",
 		canLink: account.status.toLowerCase() === "active",
 		maxLinks: null,
+		createdAt: account.created_at,
 		link,
 		poolPriority: false,
 	};
@@ -127,17 +130,33 @@ function cardFromPool(bot: ChannelBotPoolItem, link: AgentChannelLink | null): M
 		available: bot.available,
 		canLink: bot.capabilities.link_agent,
 		maxLinks: bot.max_links ?? null,
+		createdAt: bot.created_at,
 		link,
 		poolPriority: true,
 	};
 }
 
-function compareCards(left: AgentChannelCardItem, right: AgentChannelCardItem): number {
+function compareCards(
+	left: MutableCard,
+	right: MutableCard,
+	providerRanks: ReadonlyMap<string, number>,
+): number {
+	const leftCreatedAt = Date.parse(left.createdAt);
+	const rightCreatedAt = Date.parse(right.createdAt);
+	const createdAtOrder =
+		Number.isFinite(leftCreatedAt) && Number.isFinite(rightCreatedAt)
+			? leftCreatedAt - rightCreatedAt
+			: left.createdAt.localeCompare(right.createdAt);
 	return (
-		left.provider.localeCompare(right.provider) ||
-		left.name.localeCompare(right.name) ||
+		(providerRanks.get(left.provider) ?? Number.MAX_SAFE_INTEGER) -
+			(providerRanks.get(right.provider) ?? Number.MAX_SAFE_INTEGER) ||
+		createdAtOrder ||
 		left.id.localeCompare(right.id)
 	);
+}
+
+function cardItem({ createdAt: _createdAt, poolPriority: _poolPriority, ...card }: MutableCard) {
+	return card;
 }
 
 /** Build the two Agent-page inventories while deduplicating every source by bot id. */
@@ -170,13 +189,20 @@ export function buildAgentChannelCardGroups({
 		}
 	}
 
-	const clawdiBots: AgentChannelCardItem[] = [];
-	const customBots: AgentChannelCardItem[] = [];
-	for (const { poolPriority: _poolPriority, ...card } of cards.values()) {
+	const clawdiBots: MutableCard[] = [];
+	const customBots: MutableCard[] = [];
+	for (const card of cards.values()) {
 		if (card.visibility === "public") clawdiBots.push(card);
 		else customBots.push(card);
 	}
-	clawdiBots.sort(compareCards);
-	customBots.sort(compareCards);
-	return { clawdiBots, customBots };
+	const providerRanks = new Map(
+		orderedProviderIds(Array.from(cards.values(), (card) => card.provider)).map(
+			(provider, index) => [provider, index],
+		),
+	);
+	const compare = (left: MutableCard, right: MutableCard) =>
+		compareCards(left, right, providerRanks);
+	clawdiBots.sort(compare);
+	customBots.sort(compare);
+	return { clawdiBots: clawdiBots.map(cardItem), customBots: customBots.map(cardItem) };
 }

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -363,7 +363,7 @@ async def list_channel_bot_pool(
                 ),
             ),
         )
-        .order_by(ChannelAccount.provider, ChannelAccount.visibility.desc(), ChannelAccount.name)
+        .order_by(ChannelAccount.provider, ChannelAccount.created_at, ChannelAccount.id)
     )
     providers: dict[str, list[ChannelBotPoolItem]] = {
         provider: [] for provider in CHANNEL_PROVIDERS
@@ -390,8 +390,6 @@ async def list_channel_bot_pool(
                 link_count=link_counts.get(account.id, 0),
             )
         )
-    for items in providers.values():
-        items.sort(key=lambda item: (not item.available, item.link_count, item.name, str(item.id)))
     return ChannelBotPoolResponse(providers=providers)
 
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -1905,11 +1905,22 @@ async def test_channel_bot_pool_lists_public_bots_and_owned_private_bots(
         )
     ).scalar_one()
     disabled_whatsapp_account.status = CHANNEL_STATUS_DISABLED
+
+    private_account = await db_session.get(ChannelAccount, UUID(private["id"]))
+    public_account = await db_session.get(ChannelAccount, UUID(public_body["id"]))
+    assert private_account is not None
+    assert public_account is not None
+    public_account.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    private_account.created_at = datetime(2026, 1, 2, tzinfo=UTC)
     await db_session.flush()
 
     pool = await client.get("/v1/channels/bot-pool")
     assert pool.status_code == 200
     telegram = pool.json()["providers"]["telegram"]
+    relevant_ids = [
+        item["id"] for item in telegram if item["id"] in {private["id"], public_body["id"]}
+    ]
+    assert relevant_ids == [public_body["id"], private["id"]]
     pool_by_id = {item["id"]: item for item in telegram}
     assert pool_by_id[private["id"]]["visibility"] == "private"
     assert pool_by_id[private["id"]]["access"] == "owner"


### PR DESCRIPTION
## Summary

- keep bot-pool items in database creation order with a stable ID tie-breaker
- show Telegram before Discord and WhatsApp on Agent channel inventories
- stop availability, link count, and bot names from silently changing card order

## Verification

- `scripts/test.sh web src/hosted/v2/channels/agent-channel-cards.logic.test.ts` (TypeScript check, 7 tests, OSS build)
- `scripts/test.sh backend tests/test_channels.py::test_channel_bot_pool_lists_public_bots_and_owned_private_bots` (1 passed)
- `git diff --check origin/main..HEAD`

## Release impact

Backend and web only. No schema migration, generated client change, CLI publish, or sidecar change.