### PR TITLE
fix(channels): acknowledge unpair without archived link

### DIFF
--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -2659,7 +2659,7 @@ async def send_control_command_reply(
     )
     reply_link_id = (
         binding_result.binding.bot_agent_link_id
-        if binding_result.binding is not None and (binding_result.paired or binding_result.unpaired)
+        if binding_result.binding is not None and binding_result.paired
         else None
     )
     bind_reply_to_existing = reply_link_id is not None

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -12396,6 +12396,48 @@ async def test_telegram_webhook_unpair_sends_user_reply(
 
 
 @pytest.mark.asyncio
+async def test_public_telegram_unpair_reply_uses_platform_unbound_send(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account = ChannelAccount(
+        id=uuid4(),
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        visibility=CHANNEL_VISIBILITY_PUBLIC,
+        user_id=None,
+    )
+    binding = ChannelBinding(bot_agent_link_id=uuid4())
+    binding_result = channel_service.InboundBindingResult(
+        binding=binding,
+        unpaired=True,
+        command_handled=True,
+    )
+    unbound_send = AsyncMock()
+    bound_send = AsyncMock(side_effect=AssertionError("archived binding must not authorize reply"))
+    monkeypatch.setattr(channel_service, "send_platform_unbound_channel_message", unbound_send)
+    monkeypatch.setattr(channel_service, "send_channel_outbound_message", bound_send)
+
+    reply = await channel_service.send_control_command_reply(
+        db_session,
+        account=account,
+        external_chat_id="987654323",
+        telegram_message_thread_id=324,
+        command=channel_service.ChannelControlCommand(kind="unpair"),
+        binding_result=binding_result,
+    )
+
+    assert reply is None
+    unbound_send.assert_awaited_once_with(
+        account=account,
+        external_chat_id="987654323",
+        text="Unpaired. This chat is no longer connected to an agent.",
+        telegram_message_thread_id=324,
+        telegram_direct_messages_topic_id=None,
+    )
+    bound_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_telegram_channel_direct_message_pairing_replies_stay_in_originating_topic(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -16725,7 +16767,10 @@ async def test_discord_guild_interaction_pair_denies_non_authoritative_permissio
 @pytest.mark.asyncio
 async def test_discord_guild_unpair_requires_current_authority_and_pairing_actor(
     client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
 ):
+    provider_reply = AsyncMock()
+    monkeypatch.setattr(discord_router, "send_control_command_reply", provider_reply)
     created = await _create_paired_discord_channel(
         client,
         name="discord-unpair-two-part-authority",
@@ -16777,6 +16822,7 @@ async def test_discord_guild_unpair_requires_current_authority_and_pairing_actor
     )
     assert allowed.json()["data"]["content"].startswith("Server unpaired.")
     assert (await client.get(f"/v1/channels/{created['id']}/bindings")).json() == []
+    provider_reply.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_whatsapp_provider_bridge.py
+++ b/backend/tests/test_whatsapp_provider_bridge.py
@@ -14,6 +14,9 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.channel import (
     BINDING_STATUS_ARCHIVED,
+    CHANNEL_PROVIDER_WHATSAPP,
+    CHANNEL_VISIBILITY_PRIVATE,
+    CHANNEL_VISIBILITY_PUBLIC,
     MESSAGE_DIRECTION_INBOUND,
     MESSAGE_DIRECTION_OUTBOUND,
     ChannelAccount,
@@ -27,6 +30,7 @@ from app.models.channel import (
 from app.services.channel_delivery_worker import ChannelDeliveryWorker
 from app.services.channels import (
     archive_bot_agent_link,
+    build_channel_account,
     channel_control_help_reply,
     enqueue_channel_outbound_message,
     generate_agent_token,
@@ -1258,6 +1262,92 @@ async def test_whatsapp_unpaired_traffic_is_silent_and_replayed_command_replies_
     )
     assert len(unknown_messages) == 1
     assert unknown_messages[0].delivered_at is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("visibility", "expect_recorded_outbound"),
+    [
+        (CHANNEL_VISIBILITY_PUBLIC, False),
+        (CHANNEL_VISIBILITY_PRIVATE, True),
+    ],
+)
+async def test_whatsapp_unpair_ack_uses_post_unpair_account_send(
+    db_session: AsyncSession,
+    channel_agent,
+    visibility: str,
+    expect_recorded_outbound: bool,
+) -> None:
+    external_chat_id = "15551114444@s.whatsapp.net"
+    account = build_channel_account(
+        owner_user_id=(channel_agent.user_id if visibility == CHANNEL_VISIBILITY_PRIVATE else None),
+        provider=CHANNEL_PROVIDER_WHATSAPP,
+        name=f"wa-{visibility}-unpair-ack",
+        visibility=visibility,
+        webhook_secret_hash=hash_token(uuid4().hex),
+    )
+    db_session.add(account)
+    await db_session.flush()
+    link = ChannelBotAgentLink(
+        account_id=account.id,
+        user_id=channel_agent.user_id,
+        agent_id=channel_agent.id,
+    )
+    store_agent_link_token(link, generate_agent_token(CHANNEL_PROVIDER_WHATSAPP))
+    db_session.add(link)
+    await db_session.flush()
+    binding = ChannelBinding(
+        account_id=account.id,
+        bot_agent_link_id=link.id,
+        user_id=channel_agent.user_id,
+        external_chat_id=external_chat_id,
+        external_chat_type="dm",
+        paired_external_user_id=external_chat_id,
+    )
+    db_session.add(binding)
+    await db_session.commit()
+    transport = _FakeProviderTransport()
+    register_whatsapp_provider_transport(account.id, transport)
+
+    try:
+        await persist_whatsapp_provider_event(
+            db_session,
+            account_id=account.id,
+            event=WhatsAppProviderMessageEvent(
+                sequence=1,
+                message_id=f"{visibility}-unpair",
+                remote_jid=external_chat_id,
+                remote_jid_alt=None,
+                participant=None,
+                participant_alt=None,
+                push_name=None,
+                message_timestamp=None,
+                message_proto=whatsapp_text_message_proto("/clawdi_unpair"),
+            ),
+        )
+    finally:
+        unregister_whatsapp_provider_transport(account.id)
+
+    await db_session.refresh(binding)
+    assert binding.status == BINDING_STATUS_ARCHIVED
+    assert [message.conversation for message in transport.outbound_messages] == [
+        "Unpaired. This chat is no longer connected to an agent."
+    ]
+    outbound_message = (
+        await db_session.execute(
+            select(ChannelMessage).where(
+                ChannelMessage.account_id == account.id,
+                ChannelMessage.direction == MESSAGE_DIRECTION_OUTBOUND,
+            )
+        )
+    ).scalar_one_or_none()
+    if expect_recorded_outbound:
+        assert outbound_message is not None
+        assert outbound_message.user_id == channel_agent.user_id
+        assert outbound_message.bot_agent_link_id is None
+        assert outbound_message.binding_id is None
+    else:
+        assert outbound_message is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- stop successful unpair acknowledgements from reusing the binding link that was just archived
- send shared bot acknowledgements through the existing platform-owned unbound provider path, while private WhatsApp keeps the active-account authorization lock
- cover shared Telegram, public/private WhatsApp, and the Discord interaction response boundary

## Root cause

`send_control_command_reply` treated successful pair and unpair results alike. Pair replies have a newly active binding, but unpair replies run after the binding is archived. WhatsApp validates the binding before provider I/O and rejected the acknowledgement with `403 chat is not paired with this agent link`. Telegram sent before its stale binding lookup, while Discord slash commands reply directly through the interaction response.

## Verification

- `bun run test backend tests/test_channels.py::test_public_telegram_unpair_reply_uses_platform_unbound_send tests/test_channels.py::test_discord_guild_unpair_requires_current_authority_and_pairing_actor tests/test_whatsapp_provider_bridge.py::test_whatsapp_unpair_ack_uses_post_unpair_account_send` (`4 passed`)
- broader isolated regression set (`11 passed`)
- Ruff lint and format checks passed
- `git diff --check origin/main..HEAD`
