### PR TITLE
fix(web): simplify agent card metadata

### DIFF
--- a/apps/web/src/components/dashboard/agents-card.test.ts
+++ b/apps/web/src/components/dashboard/agents-card.test.ts
@@ -85,7 +85,7 @@ describe("selfManagedAgentTiles", () => {
 });
 
 describe("agentTileCardProjection", () => {
-	it("shows real v2 hosted live sync and retains useful card metadata", () => {
+	it("prioritizes hosted card status over activity and runtime identity", () => {
 		const projected = env({
 			last_seen_at: new Date(Date.now() - 30_000).toISOString(),
 			last_sync_at: new Date().toISOString(),
@@ -98,17 +98,19 @@ describe("agentTileCardProjection", () => {
 			agentType: "openclaw",
 			href: `/agents/${projected.id}`,
 			env: projected,
+			cardStatus: {
+				visual: { label: "Running", tooltip: "Compute status: Running.", dotClass: "dot" },
+				labels: ["Running", "Restart required"],
+			},
 		};
 
 		const projection = agentTileCardProjection(tile);
 
 		expect(projection.statusVisual).toMatchObject({
-			kind: "live",
-			label: "Live",
-			tooltip: "Sync is live.",
+			label: "Running",
+			tooltip: "Compute status: Running.",
 		});
-		expect(projection.meta[0]).toBe("OpenClaw");
-		expect(projection.meta[1]).toStartWith("Synced ");
+		expect(projection.meta).toEqual(["Running"]);
 	});
 
 	it("does not manufacture hosted sync status without an environment projection", () => {
@@ -147,12 +149,23 @@ describe("agentTileCardProjection", () => {
 		expect(agentTileCardProjection(legacy).statusVisual?.label).toBe("Live");
 	});
 
-	it("labels last-seen fallback explicitly when no sync timestamp exists", () => {
-		const [tile] = selfManagedAgentTiles([
-			env({ last_seen_at: new Date().toISOString(), last_sync_at: null }),
+	it("falls back to activity ahead of runtime identity", () => {
+		const [syncedTile, seenTile] = selfManagedAgentTiles([
+			env({ last_sync_at: new Date().toISOString() }),
+			env({
+				id: "33333333-3333-4333-8333-333333333333",
+				last_seen_at: new Date().toISOString(),
+				last_sync_at: null,
+			}),
 		]);
 
-		expect(agentTileCardProjection(tile).meta[1]).toStartWith("Seen ");
+		const syncedMeta = agentTileCardProjection(syncedTile).meta;
+		const seenMeta = agentTileCardProjection(seenTile).meta;
+
+		expect(syncedMeta).toHaveLength(1);
+		expect(syncedMeta[0]).toStartWith("Synced ");
+		expect(seenMeta).toHaveLength(1);
+		expect(seenMeta[0]).toStartWith("Seen ");
 	});
 });
 

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -317,9 +317,10 @@ function AgentStatusDot({ visual }: { visual: AgentCardStatusVisual }) {
  * daemon's null-env "pending" state there would turn missing data into a
  * reassuring status. Self-managed and legacy tiles retain their established
  * setup status because their environment record is their source of truth.
+ * Metadata is intentionally limited to the highest-priority available label.
  */
 export function agentTileCardProjection(tile: AgentTile): {
-	meta: string[];
+	meta: [] | [string];
 	statusVisual: AgentCardStatusVisual | null;
 } {
 	const identity = agentIdentity({
@@ -327,17 +328,14 @@ export function agentTileCardProjection(tile: AgentTile): {
 		machine_name: tile.name,
 		agent_type: tile.agentType,
 	});
-	const meta = [
-		identity.secondaryLabel,
-		...(tile.cardStatus?.labels ?? []),
-		agentTileActivityLabel(tile),
-	].filter((value): value is string => Boolean(value));
+	const metaLabel =
+		tile.cardStatus?.labels[0] ?? agentTileActivityLabel(tile) ?? identity.secondaryLabel;
 	const statusVisual = tile.cardStatus
 		? tile.cardStatus.visual
 		: tile.source === "on-clawdi" && !tile.env
 			? null
 			: daemonStatusVisual(tile.env, tile.source === "self-managed" ? "self-managed" : "on-clawdi");
-	return { meta, statusVisual };
+	return { meta: metaLabel ? [metaLabel] : [], statusVisual };
 }
 
 function agentTileActivityLabel(tile: AgentTile): string | null {


### PR DESCRIPTION
## Summary

- show at most one metadata label on each agent card
- prioritize hosted status, then sync activity, then runtime identity
- keep existing status-dot semantics and shared card primitives unchanged

## Verification

- ./scripts/test.sh web src/components/dashboard/agents-card.test.ts
- 13 focused tests passed
- web typecheck passed
- OSS production build passed
- git diff --check passed