### PR TITLE
fix(web): bootstrap Files grant before rendering iframe (kills redirect loop)

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
@@ -18,23 +18,33 @@ describe("hosted agent detail header", () => {
 		}
 	});
 
-	test("embeds owner SSO Files without credentials and keeps a top-level launch", () => {
+	test("primes the owner Files grant before embedding and launches via bootstrap", () => {
 		const source = readFileSync(new URL("./hosted-agent-detail.tsx", import.meta.url), "utf8");
+		const hookSource = readFileSync(
+			new URL("./use-files-grant-bootstrap.ts", import.meta.url),
+			"utf8",
+		);
 
-		expect(source).toContain("function FilesTab(");
+		// The Files iframe is only rendered after the deployment-scoped grant is
+		// primed; the new-tab launch bootstraps then navigates (no direct anchor).
+		expect(source).toContain("function FilesFrame(");
+		expect(source).toContain("useFilesGrantBootstrap(url)");
+		expect(source).toContain("useOpenFilesInNewTab(url)");
 		expect(source).toContain("src={url}");
 		expect(source).toContain('title="Files"');
-		expect(source).toContain('target="_blank"');
 		expect(source).toContain("Open in new tab");
-		expect(source).not.toContain("Opening Files…");
-		expect(source).not.toContain("Couldn’t open Files");
-		expect(source).not.toContain("onError=");
+		expect(source).toContain("Opening Files…");
+		expect(source).not.toContain('target="_blank"');
 		expect(source).toContain(
 			'const activeTab = requestedTab === "files" && filesUrl === null ? "overview" : requestedTab;',
 		);
-		expect(source).not.toContain("The secure Files endpoint did not load");
-		expect(source).not.toContain("fileBrowserPassword");
-		expect(source).not.toContain("Files credentials");
+
+		// The Clerk token only ever travels in the HTTPS Authorization header —
+		// never URL, iframe src, DOM, or a persisted browser credential.
+		expect(hookSource).toContain("Authorization");
+		expect(hookSource).toContain('credentials: "include"');
+		expect(hookSource).not.toContain("fileBrowserPassword");
+		expect(hookSource).not.toContain("Files credentials");
 	});
 
 	test("shows Cloud origin only on the established Overview title", () => {

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -129,6 +129,10 @@ import {
 	runtimeUiLaunchTarget,
 } from "@/hosted/agents/runtime-ui-credentials";
 import { trackRuntimeWindow } from "@/hosted/agents/runtime-window-lifecycle";
+import {
+	useFilesGrantBootstrap,
+	useOpenFilesInNewTab,
+} from "@/hosted/agents/use-files-grant-bootstrap";
 import { useBillingClient } from "@/hosted/billing/billing-client";
 import {
 	type CheckoutReturnNavigationTarget,
@@ -1581,28 +1585,44 @@ function FilesTab({ deployment, url }: { deployment: HostedDeployment; url: stri
 		);
 	}
 
+	return <FilesFrame url={url} />;
+}
+
+function FilesFrame({ url }: { url: string }) {
+	const bootstrap = useFilesGrantBootstrap(url);
+	const openInNewTab = useOpenFilesInNewTab(url);
+
 	return (
 		<LiveToolFrame
 			icon={FolderOpen}
 			title="Files"
 			action={
-				<Button
-					render={<a href={url} target="_blank" rel="noopener noreferrer" />}
-					nativeButton={false}
-					variant="outline"
-					size="sm"
-				>
+				<Button nativeButton variant="outline" size="sm" onClick={() => void openInNewTab()}>
 					Open in new tab
 					<ExternalLink className="size-3.5" />
 				</Button>
 			}
 		>
-			<iframe
-				src={url}
-				title="Files"
-				className="min-h-[420px] flex-1 border-0 bg-background"
-				allow="clipboard-read; clipboard-write"
-			/>
+			{bootstrap === "error" ? (
+				<EmptyState
+					icon={FolderOpen}
+					title="Files could not be opened"
+					description="We could not authenticate your Files session. Refresh the page and try again."
+				/>
+			) : bootstrap === "pending" ? (
+				<EmptyState
+					icon={FolderOpen}
+					title="Opening Files…"
+					description="Authenticating your private Workspace session."
+				/>
+			) : (
+				<iframe
+					src={url}
+					title="Files"
+					className="min-h-[420px] flex-1 border-0 bg-background"
+					allow="clipboard-read; clipboard-write"
+				/>
+			)}
 		</LiveToolFrame>
 	);
 }

--- a/apps/web/src/hosted/agents/use-files-grant-bootstrap.ts
+++ b/apps/web/src/hosted/agents/use-files-grant-bootstrap.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from "react";
+import { useAuthToken } from "@/lib/auth-client";
+
+export type FilesGrantBootstrapState = "pending" | "ready" | "error";
+
+/**
+ * The Files origin is a distinct subdomain that never receives the Clerk
+ * `__session` cookie. We prime a deployment-scoped `__Host-clawdi_files_grant`
+ * HttpOnly cookie by sending the Clerk session token in the `Authorization`
+ * header (never in the URL/iframe src/DOM) to the Files origin, then render the
+ * iframe only after that grant is set. See the ForwardAuth bootstrap contract.
+ */
+async function primeFilesGrant(url: string, token: string): Promise<void> {
+	const response = await fetch(url, {
+		method: "GET",
+		headers: { Authorization: `Bearer ${token}` },
+		credentials: "include",
+		cache: "no-store",
+	});
+	if (!response.ok) {
+		throw new Error(`Files bootstrap rejected with status ${response.status}`);
+	}
+}
+
+export function useFilesGrantBootstrap(url: string): FilesGrantBootstrapState {
+	const { getToken } = useAuthToken();
+	const [state, setState] = useState<FilesGrantBootstrapState>("pending");
+
+	useEffect(() => {
+		let cancelled = false;
+		setState("pending");
+		void (async () => {
+			try {
+				const token = await getToken();
+				if (!token) throw new Error("No Clerk session token");
+				await primeFilesGrant(url, token);
+				if (!cancelled) setState("ready");
+			} catch {
+				if (!cancelled) setState("error");
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [url, getToken]);
+
+	return state;
+}
+
+/**
+ * Open the Files origin in a new tab. The blank tab is opened synchronously so
+ * the browser does not block it, the grant is primed, then the tab navigates —
+ * the token still only travels in the `Authorization` header.
+ */
+export function useOpenFilesInNewTab(url: string): () => Promise<void> {
+	const { getToken } = useAuthToken();
+	return useCallback(async () => {
+		const tab = window.open("about:blank", "_blank", "noopener,noreferrer");
+		try {
+			const token = await getToken();
+			if (!token) throw new Error("No Clerk session token");
+			await primeFilesGrant(url, token);
+			if (tab) tab.location.replace(url);
+		} catch {
+			tab?.close();
+		}
+	}, [url, getToken]);
+}


### PR DESCRIPTION
Frontend half of the Files cross-origin auth fix (backend: Clawdi-AI/clawdi-hosted #1662, deployed).

The Files iframe pointed at a subdomain that never receives the Clerk `__session` cookie → infinite sign-in redirect loop. This primes the deployment-scoped `__Host-clawdi_files_grant` HttpOnly cookie before rendering:

- `useFilesGrantBootstrap(url)`: `getToken()` → `fetch(filesOrigin, {headers:{Authorization: Bearer}, credentials:'include'})`; iframe `src` is set only after the grant is primed (`ready`); `pending`/`error` show the existing EmptyState.
- `useOpenFilesInNewTab(url)`: opens a blank tab synchronously (not popup-blocked), primes the grant, then navigates.
- The Clerk token only ever travels in the HTTPS `Authorization` header — never URL, iframe src, DOM, or postMessage. The HttpOnly grant is unreadable by tenant/File-Browser JS.

Matches the backend ForwardAuth bootstrap wire contract exactly. Biome clean; touched files typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)