### PR TITLE
fix(cli): opt in to Hermes WhatsApp open policy

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.56",
+      "version": "0.13.57",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.56",
+	"version": "0.13.57",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -23,6 +23,7 @@ const HERMES_MANAGED_CHANNEL_ENV = [
 	"HERMES_TELEGRAM_DISABLE_FALLBACK_IPS",
 	"WHATSAPP_MODE",
 	"WHATSAPP_ALLOWED_USERS",
+	"WHATSAPP_ALLOW_ALL_USERS",
 ] as const;
 const HERMES_MANAGED_CHANNEL_SECRET_ENV = ["TELEGRAM_BOT_TOKEN", "DISCORD_BOT_TOKEN"] as const;
 const OPENCLAW_CHANNEL_TOKEN_ENV_PREFIX = "CLAWDI_CHANNEL_";
@@ -352,6 +353,7 @@ function applyHermesRuntimeChannelSettings(
 	if (whatsapp) {
 		env.WHATSAPP_MODE = "bot";
 		env.WHATSAPP_ALLOWED_USERS = "*";
+		env.WHATSAPP_ALLOW_ALL_USERS = "true";
 	}
 	return {
 		...manifest,

--- a/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/hermes_consumer.py
+++ b/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/hermes_consumer.py
@@ -27,6 +27,8 @@ async def main() -> None:
         os.environ[key] = value
     if os.environ.get("WHATSAPP_ALLOWED_USERS") != "*":
         raise RuntimeError("managed Hermes projection must use the stock wildcard allowlist")
+    if os.environ.get("WHATSAPP_ALLOW_ALL_USERS") != "true":
+        raise RuntimeError("managed Hermes projection must explicitly opt in to allow all users")
     discover_plugins()
 
     received: list[dict[str, Any]] = []

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -12568,6 +12568,7 @@ exit 64
 			HERMES_EXISTING_ENV: "kept",
 			WHATSAPP_MODE: "bot",
 			WHATSAPP_ALLOWED_USERS: "*",
+			WHATSAPP_ALLOW_ALL_USERS: "true",
 		});
 		const convergence = convergeRuntimeManifest(projected, paths);
 		expect(convergence.installErrors).toEqual([]);
@@ -12586,6 +12587,9 @@ exit 64
 		expect(existsSync(sessionDir)).toBe(false);
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_MODE).toBeUndefined();
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ALLOWED_USERS).toBeUndefined();
+		expect(
+			removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ALLOW_ALL_USERS,
+		).toBeUndefined();
 	});
 
 	it("clears managed Hermes channels without touching user-owned WhatsApp settings", () => {
@@ -12653,6 +12657,7 @@ exit 64
 								WHATSAPP_ENABLED: "true",
 								WHATSAPP_MODE: "bot",
 								WHATSAPP_ALLOWED_USERS: "*",
+								WHATSAPP_ALLOW_ALL_USERS: "true",
 							},
 							secretEnv: {
 								TELEGRAM_BOT_TOKEN: "secret://channels/telegram/clawdi_stale/agent-token",
@@ -12711,6 +12716,7 @@ exit 64
 		expect(runConfig.env.WHATSAPP_ENABLED).toBe("true");
 		expect(runConfig.env.WHATSAPP_MODE).toBeUndefined();
 		expect(runConfig.env.WHATSAPP_ALLOWED_USERS).toBeUndefined();
+		expect(runConfig.env.WHATSAPP_ALLOW_ALL_USERS).toBeUndefined();
 		expect(runConfig.secretEnv.TELEGRAM_BOT_TOKEN).toBeUndefined();
 		expect(runConfig.secretEnv.DISCORD_BOT_TOKEN).toBeUndefined();
 		expect(runConfig.secretEnv.HERMES_WA_CREDS_JSON).toBe(
@@ -12723,6 +12729,7 @@ exit 64
 		expect(hermesEnv).toContain("WHATSAPP_ENABLED");
 		expect(hermesEnv).not.toContain("WHATSAPP_MODE");
 		expect(hermesEnv).not.toContain("WHATSAPP_ALLOWED_USERS");
+		expect(hermesEnv).not.toContain("WHATSAPP_ALLOW_ALL_USERS");
 	});
 
 	it("isolates OpenClaw WhatsApp DMs and clears stale managed config", () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -12587,9 +12587,7 @@ exit 64
 		expect(existsSync(sessionDir)).toBe(false);
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_MODE).toBeUndefined();
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ALLOWED_USERS).toBeUndefined();
-		expect(
-			removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ALLOW_ALL_USERS,
-		).toBeUndefined();
+		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ALLOW_ALL_USERS).toBeUndefined();
 	});
 
 	it("clears managed Hermes channels without touching user-owned WhatsApp settings", () => {


### PR DESCRIPTION
## Summary

- project the explicit Hermes `WHATSAPP_ALLOW_ALL_USERS=true` opt-in for managed WhatsApp links
- clear the managed opt-in when WhatsApp is unlinked while preserving user-owned settings
- enforce the contract in runtime coverage and the stock Hermes native E2E fixture
- bump the CLI package to `0.13.57`

## Root cause

Hermes now rejects an open WhatsApp group policy unless the environment explicitly opts in to allow all users. Clawdi projected the wildcard allowlist and open policy, but omitted that opt-in, so the WhatsApp adapter exited during gateway startup.

## Verification

- `scripts/test.sh cli tests/runtime.test.ts` (CLI typecheck + 167 tests, Docker-isolated)