### PR TITLE
fix(web): align Checkout attempt lifetime

### DIFF
--- a/apps/web/src/hosted/billing/idempotency.ts
+++ b/apps/web/src/hosted/billing/idempotency.ts
@@ -21,7 +21,7 @@ export type IdempotencyAttempt = {
 
 type MintIdempotencyKey = (prefix: string) => string;
 
-export const IDEMPOTENCY_ATTEMPT_TTL_MS = 30 * 60_000;
+export const IDEMPOTENCY_ATTEMPT_TTL_MS = 24 * 60 * 60_000;
 
 const IDEMPOTENCY_STORAGE_KEY = "clawdi:idempotency-attempts";
 


### PR DESCRIPTION
## Summary
- keep the persisted Checkout request key for the backend's full 24-hour authority window
- reuse the existing TTL behavior without adding contract-only tests

## Verification
- 13 focused idempotency tests passed
- web typecheck passed
- OSS production build passed
