### PR TITLE
fix(files): refine managed Quantum UX

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
@@ -43,6 +43,8 @@ describe("hosted agent detail header", () => {
 		// never URL, iframe src, DOM, or a persisted browser credential.
 		expect(hookSource).toContain("Authorization");
 		expect(hookSource).toContain('credentials: "include"');
+		expect(hookSource).toContain("openSecureRuntimeWindow(window.open.bind(window))");
+		expect(hookSource).not.toContain('"noopener,noreferrer"');
 		expect(hookSource).not.toContain("fileBrowserPassword");
 		expect(hookSource).not.toContain("Files credentials");
 	});

--- a/apps/web/src/hosted/agents/use-files-grant-bootstrap.ts
+++ b/apps/web/src/hosted/agents/use-files-grant-bootstrap.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
+import { openSecureRuntimeWindow } from "@/hosted/agents/runtime-ui-credentials";
 import { useAuthToken } from "@/lib/auth-client";
+import { toastError } from "@/lib/toast";
 
 export type FilesGrantBootstrapState = "pending" | "ready" | "error";
 
@@ -55,14 +57,29 @@ export function useFilesGrantBootstrap(url: string): FilesGrantBootstrapState {
 export function useOpenFilesInNewTab(url: string): () => Promise<void> {
 	const { getToken } = useAuthToken();
 	return useCallback(async () => {
-		const tab = window.open("about:blank", "_blank", "noopener,noreferrer");
+		const tab = openSecureRuntimeWindow(window.open.bind(window));
+		if (!tab) {
+			toastError("Couldn't open Files", {
+				id: "files-new-tab",
+				description: "Allow pop-ups for Clawdi, then try again.",
+			});
+			return;
+		}
 		try {
 			const token = await getToken();
 			if (!token) throw new Error("No Clerk session token");
 			await primeFilesGrant(url, token);
-			if (tab) tab.location.replace(url);
+			tab.location.replace(url);
 		} catch {
-			tab?.close();
+			try {
+				tab.close();
+			} catch {
+				// Browser isolation may have severed the WindowProxy.
+			}
+			toastError("Couldn't open Files", {
+				id: "files-new-tab",
+				description: "Files access couldn't be authenticated. Refresh the page and try again.",
+			});
 		}
 	}, [url, getToken]);
 }

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.57",
+      "version": "0.13.58",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -374,7 +374,16 @@ controls. File Browser receives its official JWT header configuration with
 password, signup, passkey, sharing, admin, API-token management, realtime, and
 WebDAV disabled. It accepts only the manifest-bound external JWT assertion; no
 password, pairing code, access code, or URL token is part of this runtime
-contract. When a later manifest omits the companion, normal stale-unit
+contract. The non-admin profile settings remain available for safe display and
+file-viewing preferences, with dotfiles visible and the sidebar unpinned by
+default; those settings cannot elevate the separately disabled permissions or
+unlock password auth. Quantum applies those defaults when it first creates the
+external-JWT user and preserves that user's later preferences across config
+changes; reconciliation never rewrites or deletes the service database to force
+new defaults onto an existing account. Files still refuses symlinks rather than
+traversing them.
+
+When a later manifest omits the companion, normal stale-unit
 reconciliation stops and withdraws only `clawdi-files.service` while preserving
 the selected Hermes or OpenClaw unit.
 
@@ -395,6 +404,8 @@ The pinned upstream contracts are File Browser's
 [JWT verifier](https://github.com/gtsteffaniak/filebrowser/blob/79552f8adb27c3e29934c4001660eb98f4aab5d6/backend/auth/jwt.go),
 [JWT middleware](https://github.com/gtsteffaniak/filebrowser/blob/79552f8adb27c3e29934c4001660eb98f4aab5d6/backend/http/middleware.go),
 and [authentication settings](https://github.com/gtsteffaniak/filebrowser/blob/79552f8adb27c3e29934c4001660eb98f4aab5d6/backend/common/settings/auth.go),
+the [user-default and permission fields](https://github.com/gtsteffaniak/filebrowser/blob/79552f8adb27c3e29934c4001660eb98f4aab5d6/backend/common/settings/structs.go),
+and the [non-admin profile update boundary](https://github.com/gtsteffaniak/filebrowser/blob/79552f8adb27c3e29934c4001660eb98f4aab5d6/backend/http/users.go),
 plus the documented
 [systemd execution sandbox](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html)
 and [`systemd-tmpfiles` POSIX ACL types](https://www.freedesktop.org/software/systemd/man/latest/tmpfiles.d.html).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.57",
+	"version": "0.13.58",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/file-browser-companion.ts
+++ b/packages/cli/src/runtime/file-browser-companion.ts
@@ -166,7 +166,7 @@ function renderFileBrowserConfig(
 					config: {
 						defaultEnabled: true,
 						private: true,
-						rules: [{ folderPath: "/", ignoreHidden: true, ignoreSymlinks: true }],
+						rules: [{ folderPath: "/", ignoreSymlinks: true }],
 					},
 				},
 			],
@@ -193,9 +193,15 @@ function renderFileBrowserConfig(
 			},
 		},
 		userDefaults: {
+			sidebar: {
+				sticky: false,
+			},
+			listing: {
+				showHidden: true,
+			},
 			account: {
 				lockPassword: true,
-				disableSettings: true,
+				disableSettings: false,
 				disableUpdateNotifications: true,
 				loginMethod: "jwt",
 				permissions: {

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -4981,10 +4981,40 @@ exit 42
 		const active = fileBrowserBinaryPath(paths, binary);
 		expect(readFileSync(active, "utf8")).toBe(binary);
 		const config = readFileSync(paths.fileBrowserConfig, "utf8");
+		expect(parseYaml(config)).toMatchObject({
+			server: {
+				sources: [
+					{
+						config: {
+							rules: [{ folderPath: "/", ignoreSymlinks: true }],
+						},
+					},
+				],
+			},
+			userDefaults: {
+				sidebar: { sticky: false },
+				listing: { showHidden: true },
+				account: {
+					lockPassword: true,
+					disableSettings: false,
+					loginMethod: "jwt",
+					permissions: {
+						admin: false,
+						api: false,
+						modify: true,
+						share: false,
+						realtime: false,
+						delete: true,
+						create: true,
+						download: true,
+					},
+				},
+			},
+		});
 		expect(config).toContain("listen: 0.0.0.0");
 		expect(config).toContain("port: 9120");
 		expect(config).toContain("path: /home/clawdi");
-		expect(config).toContain("ignoreHidden: true");
+		expect(config).not.toContain("ignoreHidden");
 		expect(config).toContain("ignoreSymlinks: true");
 		expect(config).toContain("disableWebDAV: true");
 		expect(config).toContain("password:\n      enabled: false");


### PR DESCRIPTION
## Summary

- enable non-admin Quantum profile settings while retaining managed permission restrictions
- show dotfiles by default, keep symlink traversal disabled, and leave the sidebar unpinned for new JWT users
- fix the Files new-tab bootstrap by retaining a secure window handle and reporting popup/auth failures
- document Quantum first-user default semantics and the upstream permission boundary
- release the runtime change as exact CLI package `clawdi@0.13.58`

## Verification

- `bash scripts/test.sh web src/hosted/agents/hosted-agent-detail.test.ts src/hosted/agents/runtime-ui-credentials.test.ts`
- `bash scripts/test.sh cli src/runtime/manifest-reconciliation.test.ts`
- `bunx biome check apps/web/src/hosted/agents/use-files-grant-bootstrap.ts apps/web/src/hosted/agents/hosted-agent-detail.test.ts packages/cli/src/runtime/file-browser-companion.ts packages/cli/src/runtime/manifest-reconciliation.test.ts`
- `node packages/cli/scripts/check-publish-manifest.mjs`

## Release impact

- Head: `462620b1e56dc544678abda581b94692a3a351bd`
- Publishes `clawdi@0.13.58`; existing Hosted V2 deployments require an exact-package manifest update and controlled reconcile.
- Quantum applies `userDefaults` only when it first creates an external-JWT user. Reconcile updates the managed config and indexing rule but does not overwrite an existing users persisted Settings/sidebar/listing preferences or delete the service database.