### PR TITLE
fix(web): stabilize v2 agent deletion and ownership loading

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3419,6 +3419,16 @@ test("accepted detail delete dismisses immediately while teardown finishes in th
 	});
 	await gotoHostedAgentSettings(page, "hdep_included", "Basic");
 	const historyLengthBeforeDelete = await page.evaluate(() => window.history.length);
+	await page.evaluate(() => {
+		document.documentElement.dataset.deleteNotFoundFlash = "false";
+		const observer = new MutationObserver(() => {
+			if (document.body.textContent?.includes("Clawdi Cloud agent not found")) {
+				document.documentElement.dataset.deleteNotFoundFlash = "true";
+			}
+			if (window.location.pathname === "/") observer.disconnect();
+		});
+		observer.observe(document.body, { childList: true, subtree: true });
+	});
 
 	await page.locator("main").getByRole("button", { name: "Delete", exact: true }).click();
 	await page
@@ -3427,10 +3437,11 @@ test("accepted detail delete dismisses immediately while teardown finishes in th
 		.click();
 
 	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_included"]);
-	await expect.poll(() => new URL(page.url()).pathname).toBe("/agents");
+	await expect.poll(() => new URL(page.url()).pathname).toBe("/");
 	await expect
 		.poll(() => page.evaluate(() => window.history.length))
 		.toBe(historyLengthBeforeDelete);
+	await expect(page.locator("html")).toHaveAttribute("data-delete-not-found-flash", "false");
 	await expect(page.getByText("Agent removed", { exact: true })).toBeVisible();
 	await expect(
 		page.getByText("Cleanup continues in the background.", { exact: true }),

--- a/apps/web/src/components/hosted-product-gate.tsx
+++ b/apps/web/src/components/hosted-product-gate.tsx
@@ -23,7 +23,7 @@ export function HostedProductGate({
 			void router.navigate({ href: fallbackHref, replace: true });
 	}, [access.isDenied, fallbackHref, isLatestTarget, router]);
 
-	if (access.isLoading) return <HostedRouteSkeleton />;
+	if (access.isLoading || access.isDenied) return <HostedRouteSkeleton />;
 	if (access.isError) {
 		return (
 			<div className="mx-auto flex min-h-[50vh] w-full max-w-2xl items-center p-6">

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -285,7 +285,7 @@ export function AgentHome({
 				runtime={runtime}
 				section={section}
 				routeSearch={deploymentRouteSearch}
-				onDeleteAccepted={() => router.navigate({ href: "/agents", replace: true })}
+				onDeleteAccepted={() => router.navigate({ href: "/", replace: true })}
 				deploymentTransitionTimedOut={deploymentTransitionTimedOut}
 				deploymentTransitionEscalated={deploymentTransitionEscalated}
 				isCheckingDeployment={manualChecking}

--- a/apps/web/src/hosted/agents/deployment-delete-action.tsx
+++ b/apps/web/src/hosted/agents/deployment-delete-action.tsx
@@ -2,7 +2,6 @@
 
 import { useRouter } from "@tanstack/react-router";
 import { type ReactElement, useRef, useState } from "react";
-import { toast } from "sonner";
 import { agentDisplayName } from "@/components/dashboard/agent-label";
 import {
 	AlertDialog,
@@ -36,7 +35,9 @@ export function HostedDeploymentDeleteAction({
 	onAccepted?: () => Promise<void> | void;
 }) {
 	const router = useRouter();
-	const deleteDeployment = useDeleteDeployment();
+	const deleteDeployment = useDeleteDeployment(
+		onAccepted ?? (() => router.navigate({ href: "/", replace: true })),
+	);
 	const [open, setOpen] = useState(false);
 	const [choice, setChoice] =
 		useState<DeploymentDeleteRequest["subscription_choice"]>("cancel_subscription");
@@ -70,17 +71,6 @@ export function HostedDeploymentDeleteAction({
 				return;
 			}
 			setOpen(false);
-			try {
-				if (onAccepted) {
-					await onAccepted();
-				} else {
-					await router.navigate({ href: "/agents", replace: true });
-				}
-			} catch {
-				toast.error("Agent removed, but navigation failed", {
-					description: "Use Agents in the sidebar to check its status.",
-				});
-			}
 		} finally {
 			setPending(false);
 			locked.current = false;

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -25,6 +25,8 @@ type InvalidateDeploymentSnapshots =
 	typeof import("@/hosted/agents/deployment-hooks").invalidateDeploymentSnapshots;
 type ProjectAcceptedDeploymentTransition =
 	typeof import("@/hosted/agents/deployment-hooks").projectAcceptedDeploymentTransition;
+type SettleAcceptedDeploymentDelete =
+	typeof import("@/hosted/agents/deployment-hooks").settleAcceptedDeploymentDelete;
 type ShouldShowHostedProjectionNotice =
 	typeof import("@/hosted/agents/hosted-agent-detail").shouldShowHostedProjectionNotice;
 type RunManualDeploymentRefetch =
@@ -42,6 +44,7 @@ type CanRetryInitialDeployment =
 
 let invalidateSnapshots: InvalidateDeploymentSnapshots | null = null;
 let projectAcceptedTransition: ProjectAcceptedDeploymentTransition | null = null;
+let settleAcceptedDelete: SettleAcceptedDeploymentDelete | null = null;
 let shouldShowProjectionNotice: ShouldShowHostedProjectionNotice | null = null;
 let runManualDeploymentRefetch: RunManualDeploymentRefetch | null = null;
 let overviewComputeStatus: OverviewComputeStatus | null = null;
@@ -66,6 +69,7 @@ beforeAll(async () => {
 	const module = await import("@/hosted/agents/deployment-hooks");
 	invalidateSnapshots = module.invalidateDeploymentSnapshots;
 	projectAcceptedTransition = module.projectAcceptedDeploymentTransition;
+	settleAcceptedDelete = module.settleAcceptedDeploymentDelete;
 	const agentHomeModule = await import("@/hosted/agents/agent-home");
 	runManualDeploymentRefetch = agentHomeModule.runManualDeploymentRefetch;
 	const detailModule = await import("@/hosted/agents/hosted-agent-detail");
@@ -762,20 +766,65 @@ describe("deployment mutation settlement", () => {
 		expect(settlementInvalidations).toHaveLength(5);
 	});
 
-	test("describes accepted deletion as background cleanup and replace-navigates detail", () => {
-		const hooksSource = readFileSync(new URL("./deployment-hooks.ts", import.meta.url), "utf8");
-		const homeSource = readFileSync(new URL("./agent-home.tsx", import.meta.url), "utf8");
-		const actionSource = readFileSync(
-			new URL("./deployment-delete-action.tsx", import.meta.url),
-			"utf8",
+	test("waits for accepted navigation before projecting the delete transition", async () => {
+		if (!settleAcceptedDelete) throw new Error("deployment hooks were not loaded");
+		const queryClient = new QueryClient();
+		queryClient.setQueryData<HostedDeployment[]>(billingKeys.deployments, [
+			hostedDeploymentFixture({ id: "hdep_delete" }),
+		]);
+		const navigation = Promise.withResolvers<void>();
+		let navigationStarts = 0;
+
+		const settlement = settleAcceptedDelete(
+			queryClient,
+			{ deploymentId: "hdep_delete", operation: acceptedOperation("delete") },
+			() => {
+				navigationStarts += 1;
+				return navigation.promise;
+			},
+			() => undefined,
 		);
 
-		expect(hooksSource).toContain('toast.message("Agent removed", {');
-		expect(hooksSource).toContain('description: "Cleanup continues in the background."');
-		expect(homeSource).toContain(
-			'onDeleteAccepted={() => router.navigate({ href: "/agents", replace: true })}',
+		expect(navigationStarts).toBe(1);
+		const beforeNavigation = queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments);
+		expect(requiredDeploymentStatus(beforeNavigation?.[0]).summary_state).not.toBe("deleting");
+
+		navigation.resolve();
+		expect(await settlement).toBe(true);
+
+		const projected = queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments);
+		expect(requiredDeploymentStatus(projected?.[0]).summary_state).toBe("deleting");
+		expect(navigationStarts).toBe(1);
+	});
+
+	test("settles an accepted delete when navigation fails", async () => {
+		if (!settleAcceptedDelete) throw new Error("deployment hooks were not loaded");
+		const queryClient = new QueryClient();
+		queryClient.setQueryData<HostedDeployment[]>(billingKeys.deployments, [
+			hostedDeploymentFixture({ id: "hdep_delete" }),
+		]);
+		const navigation = Promise.withResolvers<void>();
+		let navigationStarts = 0;
+
+		const settlement = settleAcceptedDelete(
+			queryClient,
+			{ deploymentId: "hdep_delete", operation: acceptedOperation("delete") },
+			() => {
+				navigationStarts += 1;
+				return navigation.promise;
+			},
+			() => undefined,
 		);
-		expect(actionSource).toContain('await router.navigate({ href: "/agents", replace: true });');
+
+		expect(navigationStarts).toBe(1);
+		const beforeFailure = queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments);
+		expect(requiredDeploymentStatus(beforeFailure?.[0]).summary_state).not.toBe("deleting");
+
+		navigation.reject(new Error("navigation failed"));
+		expect(await settlement).toBe(false);
+
+		const projected = queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments);
+		expect(requiredDeploymentStatus(projected?.[0]).summary_state).toBe("deleting");
 	});
 
 	test("retires old runtime windows only after restart, access reset, or delete is accepted", () => {

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -4,7 +4,11 @@ import { type QueryClient, useMutation, useQueryClient } from "@tanstack/react-q
 import { useMemo } from "react";
 import { toast } from "sonner";
 import { retireRuntimeWindows } from "@/hosted/agents/runtime-window-lifecycle";
-import { type AcceptedOperation, useBillingClient } from "@/hosted/billing/billing-client";
+import {
+	type AcceptedOperation,
+	type DeploymentDeleteResult,
+	useBillingClient,
+} from "@/hosted/billing/billing-client";
 import type {
 	DeploymentDeleteRequest,
 	DeploymentUpdateRequest,
@@ -86,6 +90,25 @@ export function projectAcceptedDeploymentTransition(
 		),
 	);
 	scheduleRefresh(qc);
+}
+
+/** Attempts to leave detail before accepted cache projection can hide it. */
+export async function settleAcceptedDeploymentDelete(
+	qc: QueryClient,
+	accepted: DeploymentDeleteResult,
+	dismissDetail: () => Promise<void> | void,
+	scheduleRefresh = scheduleDeploymentSettlingRefresh,
+): Promise<boolean> {
+	let detailDismissed = true;
+	try {
+		await dismissDetail();
+	} catch {
+		detailDismissed = false;
+	}
+	if (accepted.operation) {
+		projectAcceptedDeploymentTransition(qc, accepted, scheduleRefresh);
+	}
+	return detailDismissed;
 }
 
 async function runStableDeploymentIntent<T>(
@@ -232,7 +255,7 @@ export function useResetRuntimeUiAccess() {
 	});
 }
 
-export function useDeleteDeployment() {
+export function useDeleteDeployment(dismissDetail: () => Promise<void> | void) {
 	const client = useBillingClient();
 	const qc = useQueryClient();
 	return useMutation({
@@ -242,8 +265,13 @@ export function useDeleteDeployment() {
 				{ action: "delete", id: vars.id, request: vars.request },
 				(key) => client.deleteDeployment(vars.id, vars.request, key, vars.resourceVersion),
 			),
-		onSuccess: (accepted) => {
-			if (accepted.operation) projectAcceptedDeploymentTransition(qc, accepted);
+		onSuccess: async (accepted) => {
+			const detailDismissed = await settleAcceptedDeploymentDelete(qc, accepted, dismissDetail);
+			if (!detailDismissed) {
+				toast.error("Agent removed, but navigation failed", {
+					description: "Use Overview in the sidebar to continue.",
+				});
+			}
 			retireRuntimeWindows(accepted.deploymentId);
 			toast.message("Agent removed", {
 				description: "Cleanup continues in the background.",

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -382,7 +382,7 @@ function DeleteComputeAction({
 	label = "Delete",
 }: {
 	deployment: HostedDeployment;
-	onDeleteAccepted: (deploymentId: string) => void;
+	onDeleteAccepted: (deploymentId: string) => Promise<void> | void;
 	variant?: React.ComponentProps<typeof Button>["variant"];
 	className?: string;
 	label?: string;
@@ -467,7 +467,7 @@ export function HostedAgentDetail({
 	runtime: Runtime;
 	section?: AgentSectionId;
 	routeSearch: AgentRouteSearch;
-	onDeleteAccepted: (deploymentId: string) => void;
+	onDeleteAccepted: (deploymentId: string) => Promise<void> | void;
 	deploymentTransitionTimedOut: boolean;
 	deploymentTransitionEscalated: boolean;
 	isCheckingDeployment: boolean;
@@ -3417,7 +3417,7 @@ function HostedAgentSettingsTab({
 	environmentId: string;
 	deployment: HostedDeployment;
 	projectionAvailable: boolean;
-	onDeleteAccepted: (deploymentId: string) => void;
+	onDeleteAccepted: (deploymentId: string) => Promise<void> | void;
 }) {
 	return (
 		<UnsavedNavigationBoundary description="Your agent settings will return to the last values saved on the server.">
@@ -3528,7 +3528,7 @@ function ComputeSettingsSections({
 	onDeleteAccepted,
 }: {
 	deployment: HostedDeployment;
-	onDeleteAccepted: (deploymentId: string) => void;
+	onDeleteAccepted: (deploymentId: string) => Promise<void> | void;
 }) {
 	const router = useRouter();
 	const queryClient = useQueryClient();

--- a/apps/web/src/hosted/agents/ownership-sensor.ts
+++ b/apps/web/src/hosted/agents/ownership-sensor.ts
@@ -12,6 +12,7 @@ import { useHostedDeploymentInventory } from "@/hosted/use-hosted-deployment-inv
 import type { AgentOwnership } from "@/lib/agent-ownership";
 import { normalizeAgentEnvId } from "@/lib/agent-ownership";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
+import type { LegacyHostedAccessStatus } from "@/lib/hosted-product-access-model";
 
 const EMPTY_ENV_IDS: ReadonlySet<string> = new Set();
 
@@ -25,7 +26,7 @@ function envIdSet(ids: readonly string[] | undefined): ReadonlySet<string> {
 }
 
 export function resolveLegacyEnvIds(
-	enabled: boolean,
+	accessStatus: LegacyHostedAccessStatus,
 	environmentIds: readonly string[] | undefined,
 	error: Error | null,
 ): {
@@ -33,7 +34,12 @@ export function resolveLegacyEnvIds(
 	error: Error | null;
 	isLoading: boolean;
 } {
-	if (!enabled) return { envIds: EMPTY_ENV_IDS, error: null, isLoading: false };
+	if (accessStatus === "disabled") {
+		return { envIds: EMPTY_ENV_IDS, error: null, isLoading: false };
+	}
+	if (accessStatus === "unresolved") {
+		return { envIds: null, error, isLoading: error === null };
+	}
 	if (environmentIds !== undefined) {
 		return { envIds: envIdSet(environmentIds), error: null, isLoading: false };
 	}
@@ -43,7 +49,8 @@ export function resolveLegacyEnvIds(
 export function useLegacyEnvIds() {
 	const access = useHostedProductAccess();
 	const client = useBillingClient();
-	const enabled = access.canUseLegacyHostedDashboard && isDeployApiConfigured();
+	const accessStatus = isDeployApiConfigured() ? access.legacyHostedAccessStatus : "disabled";
+	const enabled = accessStatus === "enabled";
 	const query = useQuery({
 		queryKey: billingKeys.legacyAgentEnvironments,
 		enabled,
@@ -56,15 +63,31 @@ export function useLegacyEnvIds() {
 	});
 
 	const resolution = useMemo(() => {
-		// Only data (fresh or stale cache) resolves the set. The endpoint has
-		// no 404 in its success contract — users without live v1 deployments
-		// get an empty list — so a 404 can only mean "route not deployed
-		// yet" (rollout skew) and, like every other error, stays UNRESOLVED:
-		// destructive consumers fail closed instead of treating live legacy
-		// agents as connected.
-		return resolveLegacyEnvIds(enabled, query.data?.environment_ids, query.error);
-	}, [enabled, query.data, query.error]);
-	return { ...resolution, refetch: query.refetch };
+		let error = query.error;
+		if (accessStatus === "unresolved") {
+			error =
+				access.error == null
+					? null
+					: access.error instanceof Error
+						? access.error
+						: new Error("Hosted product access check failed");
+		}
+		// A successful access profile can authoritatively disable v1. When it
+		// enables v1, only endpoint data (fresh or cached) resolves ownership;
+		// loading and every error stay unresolved so destructive consumers fail
+		// closed instead of treating a live legacy agent as connected.
+		return resolveLegacyEnvIds(accessStatus, query.data?.environment_ids, error);
+	}, [access.error, accessStatus, query.data, query.error]);
+	return {
+		...resolution,
+		refetch: async () => {
+			if (accessStatus === "unresolved") {
+				await access.refetch();
+			} else if (accessStatus === "enabled") {
+				await query.refetch();
+			}
+		},
+	};
 }
 
 /**

--- a/apps/web/src/hosted/use-unified-agent-list.test.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.test.ts
@@ -125,6 +125,37 @@ describe("selectUnifiedAgentList", () => {
 		expect(selection.membershipResolved).toBe(false);
 	});
 
+	test("withholds connected classification when legacy access is unresolved but legacy tiles are hidden", () => {
+		const possibleLegacy = env("22222222-2222-4222-8222-222222222222", "possible-legacy-env");
+		const selection = selectUnifiedAgentList({
+			cloudEnvs: [possibleLegacy],
+			hostedTiles: [],
+			claimedEnvIds: new Set(),
+			legacyEnvIds: null,
+			hostedInventoryStatus: "resolved",
+			showLegacyAgents: false,
+		});
+
+		expect(selection.connectedTiles).toEqual([]);
+		expect(selection.membershipResolved).toBe(false);
+	});
+
+	test("uses resolved legacy ownership for deduplication even when legacy tiles are hidden", () => {
+		const legacy = env("22222222-2222-4222-8222-222222222222", "legacy-env");
+		const connected = env("33333333-3333-4333-8333-333333333333", "connected-env");
+		const selection = selectUnifiedAgentList({
+			cloudEnvs: [legacy, connected],
+			hostedTiles: [],
+			claimedEnvIds: new Set(),
+			legacyEnvIds: new Set([legacy.id]),
+			hostedInventoryStatus: "resolved",
+			showLegacyAgents: false,
+		});
+
+		expect(selection.connectedTiles.map((tile) => tile.id)).toEqual([connected.id]);
+		expect(selection.membershipResolved).toBe(true);
+	});
+
 	test("never reclassifies cloud projections while deployment membership is unresolved", () => {
 		const possibleHostedProjection = env(
 			"11111111-1111-4111-8111-111111111111",
@@ -214,6 +245,29 @@ describe("selectUnifiedAgentList", () => {
 });
 
 describe("legacy membership resolution", () => {
+	test("keeps loading and failed access unresolved", () => {
+		const error = new Error("access unavailable");
+
+		expect(resolveLegacyEnvIds("unresolved", ["cached-legacy-env"], null)).toEqual({
+			envIds: null,
+			error: null,
+			isLoading: true,
+		});
+		expect(resolveLegacyEnvIds("unresolved", ["cached-legacy-env"], error)).toEqual({
+			envIds: null,
+			error,
+			isLoading: false,
+		});
+	});
+
+	test("only treats an authoritative denial as empty legacy ownership", () => {
+		expect(resolveLegacyEnvIds("disabled", undefined, null)).toEqual({
+			envIds: new Set(),
+			error: null,
+			isLoading: false,
+		});
+	});
+
 	test("surfaces an initial endpoint failure instead of remaining in loading state", () => {
 		const error = new Error("legacy endpoint unavailable");
 		const unifiedSource = readFileSync(
@@ -225,14 +279,12 @@ describe("legacy membership resolution", () => {
 			"utf8",
 		);
 
-		expect(resolveLegacyEnvIds(true, undefined, error)).toEqual({
+		expect(resolveLegacyEnvIds("enabled", undefined, error)).toEqual({
 			envIds: null,
 			error,
 			isLoading: false,
 		});
-		expect(unifiedSource).toContain(
-			"error: hosted.error ?? (showLegacyAgents ? legacy.error : null)",
-		);
+		expect(unifiedSource).toContain("error: hosted.error ?? legacy.error");
 		expect(sectionSource).toContain("{unified.error ? (");
 		expect(sectionSource).toContain("<HostedUnavailableBanner");
 	});

--- a/apps/web/src/hosted/use-unified-agent-list.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.ts
@@ -16,8 +16,6 @@ import { normalizeAgentEnvId } from "@/lib/agent-ownership";
 
 type Env = components["schemas"]["AgentResponse"];
 
-const EMPTY_ENV_IDS: ReadonlySet<string> = new Set();
-
 export interface UnifiedAgentListSelection {
 	tiles: AgentTile[];
 	hostedTiles: AgentTile[];
@@ -31,6 +29,7 @@ export interface UnifiedAgentListSelection {
  * A Cloud deployment owns its configured environment even while that
  * environment is absent from the Cloud API response. Legacy environments are
  * bridged once, and every remaining environment is rendered as self-managed.
+ * `showLegacyAgents` controls their tiles, never whether ownership must resolve.
  */
 export function selectUnifiedAgentList({
 	cloudEnvs,
@@ -47,9 +46,7 @@ export function selectUnifiedAgentList({
 	hostedInventoryStatus: HostedInventoryStatus;
 	showLegacyAgents: boolean;
 }): UnifiedAgentListSelection {
-	const membershipResolved =
-		hostedInventoryStatus === "resolved" && (!showLegacyAgents || legacyEnvIds !== null);
-	if (!membershipResolved) {
+	if (hostedInventoryStatus !== "resolved" || legacyEnvIds === null) {
 		return {
 			tiles: hostedTiles,
 			hostedTiles,
@@ -58,13 +55,11 @@ export function selectUnifiedAgentList({
 		};
 	}
 
-	const legacyConnectedTiles =
-		showLegacyAgents && legacyEnvIds
-			? legacyConnectedAgentTiles(cloudEnvs, legacyEnvIds, claimedEnvIds)
-			: [];
+	const legacyConnectedTiles = showLegacyAgents
+		? legacyConnectedAgentTiles(cloudEnvs, legacyEnvIds, claimedEnvIds)
+		: [];
 	const dedupedSelfManaged = selfManagedAgentTiles(cloudEnvs).filter(
-		(tile) =>
-			!isOwnedEnvId(tile.id, claimedEnvIds, showLegacyAgents ? legacyEnvIds : EMPTY_ENV_IDS),
+		(tile) => !isOwnedEnvId(tile.id, claimedEnvIds, legacyEnvIds),
 	);
 	const connectedTiles = [...legacyConnectedTiles, ...dedupedSelfManaged];
 	return {
@@ -78,10 +73,10 @@ export function selectUnifiedAgentList({
 function isOwnedEnvId(
 	id: string,
 	claimedEnvIds: ReadonlySet<string>,
-	legacyEnvIds: ReadonlySet<string> | null,
+	legacyEnvIds: ReadonlySet<string>,
 ): boolean {
 	const envId = normalizeAgentEnvId(id);
-	return Boolean(envId && (claimedEnvIds.has(envId) || legacyEnvIds?.has(envId)));
+	return Boolean(envId && (claimedEnvIds.has(envId) || legacyEnvIds.has(envId)));
 }
 
 export function useUnifiedAgentList({
@@ -98,14 +93,13 @@ export function useUnifiedAgentList({
 		includeDeployments: showCloudDeployments,
 	});
 	const legacy = useLegacyEnvIds();
-	const legacyEnvIds = showLegacyAgents ? legacy.envIds : EMPTY_ENV_IDS;
 	const selection = useMemo(
 		() =>
 			selectUnifiedAgentList({
 				cloudEnvs,
 				hostedTiles: hosted.tiles,
 				claimedEnvIds: hosted.claimedEnvIds,
-				legacyEnvIds,
+				legacyEnvIds: legacy.envIds,
 				hostedInventoryStatus: hosted.inventoryStatus,
 				showLegacyAgents,
 			}),
@@ -114,7 +108,7 @@ export function useUnifiedAgentList({
 			hosted.claimedEnvIds,
 			hosted.inventoryStatus,
 			hosted.tiles,
-			legacyEnvIds,
+			legacy.envIds,
 			showLegacyAgents,
 		],
 	);
@@ -124,13 +118,10 @@ export function useUnifiedAgentList({
 		hasExistingDeployments: hosted.hasExistingDeployments,
 		inventoryStatus: hosted.inventoryStatus,
 		isFetching: hosted.isFetching,
-		isLoading: (showCloudDeployments && hosted.isLoading) || (showLegacyAgents && legacy.isLoading),
-		error: hosted.error ?? (showLegacyAgents ? legacy.error : null),
+		isLoading: (showCloudDeployments && hosted.isLoading) || legacy.isLoading,
+		error: hosted.error ?? legacy.error,
 		refetch: () =>
-			Promise.all([
-				...(showCloudDeployments ? [hosted.refetch()] : []),
-				...(showLegacyAgents ? [legacy.refetch()] : []),
-			]),
+			Promise.all([...(showCloudDeployments ? [hosted.refetch()] : []), legacy.refetch()]),
 	};
 }
 

--- a/apps/web/src/lib/agent-ownership.test.ts
+++ b/apps/web/src/lib/agent-ownership.test.ts
@@ -120,6 +120,17 @@ describe("agentDisconnectUnavailable", () => {
 				envId: "aaaa",
 				explicitIdentity: false,
 				ownership: {
+					cloudEnvIds: new Set(),
+					legacyEnvIds: new Set(),
+					isResolved: false,
+				},
+			}),
+		).toBe(true);
+		expect(
+			agentDisconnectUnavailable({
+				envId: "aaaa",
+				explicitIdentity: false,
+				ownership: {
 					cloudEnvIds: new Set(["aaaa"]),
 					legacyEnvIds: new Set(),
 					isResolved: true,

--- a/apps/web/src/lib/hosted-product-access-model.ts
+++ b/apps/web/src/lib/hosted-product-access-model.ts
@@ -7,8 +7,12 @@ export interface HostedProductAccessProfile {
 	capabilities?: HostedProductCapabilities | null;
 }
 
+/** `disabled` is authoritative only after a successful profile response. */
+export type LegacyHostedAccessStatus = "unresolved" | "enabled" | "disabled";
+
 export interface HostedProductAccess {
 	canUseLegacyHostedDashboard: boolean;
+	legacyHostedAccessStatus: LegacyHostedAccessStatus;
 	canCreateCloudAgents: boolean;
 	/**
 	 * Back-compat alias for the rollout flag. New code should choose the
@@ -46,9 +50,16 @@ export function hostedProductAccessFromProfile(
 	profile: HostedProductAccessProfile | undefined,
 ): HostedProductAccess {
 	const capabilities = profile?.capabilities;
+	const legacyHostedAccessStatus =
+		profile === undefined
+			? "unresolved"
+			: capabilities?.can_use_v1 === true
+				? "enabled"
+				: "disabled";
 	const canCreateCloudAgents = capabilities?.can_use_v2 === true;
 	return {
-		canUseLegacyHostedDashboard: capabilities?.can_use_v1 === true,
+		canUseLegacyHostedDashboard: legacyHostedAccessStatus === "enabled",
+		legacyHostedAccessStatus,
 		canCreateCloudAgents,
 		canUseCloudAgents: canCreateCloudAgents,
 	};

--- a/apps/web/src/lib/hosted-product-access.test.ts
+++ b/apps/web/src/lib/hosted-product-access.test.ts
@@ -8,6 +8,7 @@ describe("hostedProductAccessFromProfile", () => {
 	it("keeps hosted product surfaces hidden by default", () => {
 		expect(hostedProductAccessFromProfile(undefined)).toEqual({
 			canUseLegacyHostedDashboard: false,
+			legacyHostedAccessStatus: "unresolved",
 			canCreateCloudAgents: false,
 			canUseCloudAgents: false,
 		});
@@ -20,6 +21,7 @@ describe("hostedProductAccessFromProfile", () => {
 			}),
 		).toEqual({
 			canUseLegacyHostedDashboard: false,
+			legacyHostedAccessStatus: "disabled",
 			canCreateCloudAgents: true,
 			canUseCloudAgents: true,
 		});
@@ -32,6 +34,7 @@ describe("hostedProductAccessFromProfile", () => {
 			}),
 		).toEqual({
 			canUseLegacyHostedDashboard: true,
+			legacyHostedAccessStatus: "enabled",
 			canCreateCloudAgents: false,
 			canUseCloudAgents: false,
 		});
@@ -47,6 +50,7 @@ describe("hostedProductAccessFromProfile", () => {
 			}),
 		).toEqual({
 			canUseLegacyHostedDashboard: false,
+			legacyHostedAccessStatus: "disabled",
 			canCreateCloudAgents: false,
 			canUseCloudAgents: false,
 		});

--- a/apps/web/src/lib/query-refresh-contract.test.ts
+++ b/apps/web/src/lib/query-refresh-contract.test.ts
@@ -16,6 +16,8 @@ describe("query refresh presentation contract", () => {
 		const providerDialog = source("hosted/v2/ai-providers/add-provider-dialog.tsx");
 		const hostedInventory = source("hosted/hosted-agent-resolution.ts");
 		const hostedAgentHome = source("hosted/agents/agent-home.tsx");
+		const agentDetailClient = source("pages/dashboard/agents/agent-detail-client.tsx");
+		const hostedProductGate = source("components/hosted-product-gate.tsx");
 		const connectedAgentDetail = source("components/dashboard/connected-agent-detail.tsx");
 		const channelDetail = source("hosted/v2/channels/channel-detail-page.tsx");
 		const memoryDetail = source("pages/dashboard/memories/[id]/page.tsx");
@@ -53,6 +55,11 @@ describe("query refresh presentation contract", () => {
 		expect(unresolvedAgentBranch).toContain("Check again");
 		expect(unresolvedAgentBranch).not.toContain("HostedDeploymentDeleteAction");
 		expect(unresolvedAgentBranch).not.toContain("Delete");
+		expect(agentDetailClient).not.toContain("useHostedProductAccess");
+		expect(agentDetailClient).toContain("<AgentHome");
+		expect(hostedProductGate).toContain(
+			"if (access.isLoading || access.isDenied) return <HostedRouteSkeleton />;",
+		);
 		expect(connectedAgentDetail).toContain(
 			"isApiNotFoundError(error) || shouldBlockQueryError(error, agent)",
 		);

--- a/apps/web/src/pages/dashboard/agents/agent-detail-client.tsx
+++ b/apps/web/src/pages/dashboard/agents/agent-detail-client.tsx
@@ -6,7 +6,6 @@ import {
 	ConnectedAgentDetailSkeleton,
 } from "@/components/dashboard/connected-agent-detail";
 import type { AgentRouteSearch, AgentSectionId } from "@/lib/agent-routes";
-import { useHostedProductAccess } from "@/lib/hosted-product-access";
 
 const IS_HOSTED_BUILD = import.meta.env.VITE_CLAWDI_HOSTED === "true";
 
@@ -27,10 +26,6 @@ export function AgentDetailClient({
 	section: AgentSectionId;
 	routeSearch: AgentRouteSearch;
 }) {
-	const hostedAccess = useHostedProductAccess();
-	if (AgentHome && hostedAccess.isLoading) {
-		return <ConnectedAgentDetailSkeleton hosted />;
-	}
 	if (AgentHome) {
 		return (
 			<Suspense fallback={<ConnectedAgentDetailSkeleton hosted />}>
@@ -38,15 +33,11 @@ export function AgentDetailClient({
 			</Suspense>
 		);
 	}
-	const showSourceBadge = IS_HOSTED_BUILD
-		? hostedAccess.canCreateCloudAgents || hostedAccess.canUseLegacyHostedDashboard
-		: true;
 	return (
 		<ConnectedAgentDetail
 			environmentId={environmentId}
 			section={section}
 			routeSearch={routeSearch}
-			showSourceBadge={showSourceBadge}
 		/>
 	);
 }


### PR DESCRIPTION
## Summary\n\n- return accepted v2 agent deletion to Console Overview with replace navigation\n- keep legacy ownership unresolved until the access profile and legacy inventory are authoritative, preventing Connected/Disconnect flashes\n- keep the hosted route skeleton mounted during denied redirects and remove the redundant serial access wait from agent detail\n- await detail dismissal before projecting accepted deletion, preventing a transient not-found frame\n\n## Verification\n\n- clean Docker web runner: TypeScript, 61 focused tests, OSS client/SSR/Nitro production build\n- isolated hosted Chromium: accepted-delete smoke test (1 pass), including transient DOM and history assertions\n- Biome on all 15 changed files and git diff --check