### PR TITLE
fix(web): describe dynamic wallet top-up methods

### DIFF
--- a/apps/web/src/hosted/billing/wallet/stripe-payment-form.tsx
+++ b/apps/web/src/hosted/billing/wallet/stripe-payment-form.tsx
@@ -62,7 +62,7 @@ function InnerForm({
 				},
 			});
 			if (result.error) {
-				setError(result.error.message ?? "We couldn't process that card. Please try again.");
+				setError(result.error.message ?? "We couldn't process that payment. Please try again.");
 				finishSubmitting();
 				return;
 			}
@@ -71,8 +71,8 @@ function InnerForm({
 			if (!outcome) {
 				setError(
 					status === "requires_action"
-						? "Your bank needs to confirm this payment. Complete the prompt, then select the payment button again."
-						: "This payment is not ready to complete. Review the card details and try again.",
+						? "Your payment method needs confirmation. Complete the prompt, then select the payment button again."
+						: "This payment is not ready to complete. Review the payment details and try again.",
 				);
 				finishSubmitting();
 				return;
@@ -155,7 +155,7 @@ export function StripePaymentForm({
 			<Alert data-hosted="true">
 				<AlertCircle aria-hidden />
 				<AlertDescription>
-					Card payments aren’t configured in this environment. Set a Stripe publishable key to
+					Stripe payments aren’t configured in this environment. Set a Stripe publishable key to
 					continue.
 				</AlertDescription>
 			</Alert>

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
@@ -189,7 +189,7 @@ export function TopUpDialog({
 	const description =
 		step === "amount"
 			? `Add a whole-dollar amount from ${TOPUP_AMOUNT_RANGE_LABEL} to your Wallet.`
-			: `Enter your card details to pay ${formatCents(amountCents)}.`;
+			: `Choose a payment method to pay ${formatCents(amountCents)}.`;
 	const content =
 		step === "amount" ? (
 			<div className="space-y-4">


### PR DESCRIPTION
## Summary

- make wallet top-up copy describe payment methods rather than cards only
- keep Stripe Payment Element as the single payment-method selector
- keep wallet top-up as one HTTP request without a client-side mutation retry

## Payment methods

The top-up flow already renders Stripe `PaymentElement` from the PaymentIntent client secret. Stripe chooses the eligible subset of methods enabled for the live account, currency, amount, customer, and location; an outer selector would duplicate Stripe state and could drift from the PaymentIntent.

The Hosted request continues to use dynamic payment methods, including its valid WeChat Pay web client option. This PR changes copy only.

References:

- https://docs.stripe.com/payments/payment-element
- https://docs.stripe.com/payments/payment-methods/dynamic-payment-methods

## Root-cause scope

The reported top-up failure was not caused by payment-method configuration. The proven defect was a Hosted stripe-python 15.4 object-field boundary that misclassified successfully created PaymentIntents and returned HTTP 502. That root fix is in https://github.com/Clawdi-AI/clawdi-hosted/pull/1670.

An earlier browser transport retry from this branch was removed completely. HTTP 502 remains a `BillingApiError`; only a request that receives no HTTP response is a `BillingNetworkError`.

## Verification

- `bash scripts/test.sh web src/hosted/billing/billing-client.test.ts`
- TypeScript check passed
- 27 tests passed
- OSS production build passed
- `git diff --check origin/main..HEAD`

Final diff: two copy files, 5 insertions and 5 deletions. No API schema changes.
