### PR TITLE
fix(cli): reconcile hosted CLI updates without service restarts

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -163,6 +163,7 @@ from app.services.managed_ai_provider import (
     find_clawdi_managed_provider,
     is_v2_deployment_managed_provider_id,
     lock_deployment_managed_provider_mutation,
+    runtime_managed_provider_id,
     upsert_clawdi_managed_provider,
 )
 from app.services.principal_lifecycle import (
@@ -2194,6 +2195,23 @@ def _runtime_state_values(
             return None
         return value.model_dump(exclude_none=True, exclude_unset=True, mode="json")
 
+    runtimes: dict[str, dict[str, Any]] = {}
+    for name, runtime in body.runtimes.items():
+        value = runtime.model_dump(exclude_none=True, mode="json")
+        value["provider_ids"] = [
+            runtime_managed_provider_id(provider_id) for provider_id in runtime.provider_ids
+        ]
+        primary_model = value.get("primary_model")
+        if primary_model is not None:
+            primary_model["provider_id"] = runtime_managed_provider_id(primary_model["provider_id"])
+        runtimes[name] = value
+
+    tools = body.tools.model_dump(exclude_none=True, exclude_unset=True, mode="json")
+    codex = tools["codex"]
+    codex_provider_id = runtime_managed_provider_id(codex["provider_id"])
+    codex["provider_id"] = codex_provider_id
+    codex["primary_model"]["provider_id"] = codex_provider_id
+
     return {
         "deployment_id": body.deployment_id,
         "instance_id": body.instance_id,
@@ -2204,16 +2222,13 @@ def _runtime_state_values(
         "system": body.system.model_dump(exclude_none=True, mode="json"),
         "egress_engine": optional_wire_value("egress_engine"),
         "companions": optional_wire_value("companions"),
-        "runtimes": {
-            name: runtime.model_dump(exclude_none=True, mode="json")
-            for name, runtime in body.runtimes.items()
-        },
+        "runtimes": runtimes,
         "live_sync": body.live_sync.model_dump(mode="json"),
         "recovery": body.recovery.model_dump(mode="json"),
         "egress_profiles": optional_wire_value("egress_profiles"),
         "mcp": optional_wire_value("mcp"),
         "skills": optional_wire_value("skills"),
-        "tools": body.tools.model_dump(exclude_none=True, exclude_unset=True, mode="json"),
+        "tools": tools,
     }
 
 

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -103,7 +103,6 @@ from app.services.agent_lifecycle import (
 )
 from app.services.file_store import get_file_store
 from app.services.http_cache import if_none_match_contains, strong_json_etag
-from app.services.managed_ai_provider import runtime_managed_provider_id
 from app.services.memory_provider import get_memory_provider
 from app.services.runtime_generation import resolve_runtime_apply_generation
 from app.services.runtime_source import (
@@ -1621,15 +1620,8 @@ def _runtime_desired_provider_binding(
     except ValidationError:
         return None, [], None
     primary_model = getattr(runtime, "primary_model", None)
-    provider_ids = [
-        runtime_managed_provider_id(provider_id) for provider_id in runtime.provider_ids
-    ]
-    primary_provider_id = (
-        runtime_managed_provider_id(primary_model.provider_id)
-        if primary_model is not None
-        else None
-    )
-    return runtime.providerMode, provider_ids, primary_provider_id
+    primary_provider_id = primary_model.provider_id if primary_model is not None else None
+    return runtime.providerMode, runtime.provider_ids, primary_provider_id
 
 
 def _runtime_observed_provider_status(

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -103,6 +103,7 @@ from app.services.agent_lifecycle import (
 )
 from app.services.file_store import get_file_store
 from app.services.http_cache import if_none_match_contains, strong_json_etag
+from app.services.managed_ai_provider import runtime_managed_provider_id
 from app.services.memory_provider import get_memory_provider
 from app.services.runtime_generation import resolve_runtime_apply_generation
 from app.services.runtime_source import (
@@ -1620,8 +1621,15 @@ def _runtime_desired_provider_binding(
     except ValidationError:
         return None, [], None
     primary_model = getattr(runtime, "primary_model", None)
-    primary_provider_id = primary_model.provider_id if primary_model is not None else None
-    return runtime.providerMode, runtime.provider_ids, primary_provider_id
+    provider_ids = [
+        runtime_managed_provider_id(provider_id) for provider_id in runtime.provider_ids
+    ]
+    primary_provider_id = (
+        runtime_managed_provider_id(primary_model.provider_id)
+        if primary_model is not None
+        else None
+    )
+    return runtime.providerMode, provider_ids, primary_provider_id
 
 
 def _runtime_observed_provider_status(

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -88,6 +88,16 @@ pytestmark = pytest.mark.committed_db
 _ADMIN_KEY = "runtime-state-admin-secret"
 _AUTH = {"X-Admin-Key": _ADMIN_KEY}
 TEST_LOCALE = {"language": "en", "timezone": "America/Los_Angeles"}
+AGENT_FACING_CODEX_TOOLS = {
+    "codex": {
+        "enabled": True,
+        "provider_id": CLAWDI_MANAGED_PROVIDER_ID,
+        "primary_model": {
+            "provider_id": CLAWDI_MANAGED_PROVIDER_ID,
+            "model": "gpt-5.5",
+        },
+    }
+}
 TEST_SYSTEM = {}
 TEST_EGRESS_ENGINE_PIN = {
     "type": "mitmproxy",
@@ -3167,7 +3177,7 @@ async def test_admin_runtime_state_clears_optional_state(
     assert state.egress_profiles is None
     assert state.mcp is None
     assert state.skills is None
-    assert state.tools == {**TEST_CODEX_TOOLS, "catalog": "clawdi-default"}
+    assert state.tools == {**AGENT_FACING_CODEX_TOOLS, "catalog": "clawdi-default"}
 
 
 @pytest.mark.asyncio
@@ -3213,7 +3223,7 @@ async def test_equal_generation_optional_state_clear_is_material_conflict(
     assert state.egress_profiles == TEST_EGRESS_PROFILES
     assert state.mcp == {"servers": {"clawdi": {"command": "clawdi", "args": ["mcp"]}}}
     assert state.skills == {"entries": {"clawdi": {"enabled": True, "version": 1}}}
-    assert state.tools == {**TEST_CODEX_TOOLS, "catalog": "clawdi-default"}
+    assert state.tools == {**AGENT_FACING_CODEX_TOOLS, "catalog": "clawdi-default"}
 
 
 def test_control_plane_audit_sanitizes_auth_cookie_and_credential_keys():

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -807,14 +807,13 @@ def test_managed_health_compares_agent_facing_provider_ids():
     now = datetime.now(UTC)
     source_revision = "e" * 64
     etag = expected_runtime_bundle_v2_etag(source_revision)
-    internal_provider_id = "clawdi-v2-deployment-42"
     state = SimpleNamespace(
         deployment_id="42",
         instance_id="hri-managed-health",
         generation=3,
         cli_package_spec=TEST_CLI_PACKAGE_SPEC,
         updated_at=now,
-        runtimes=_runtime_state(provider_ids=[internal_provider_id]),
+        runtimes=_runtime_state(provider_ids=[CLAWDI_MANAGED_PROVIDER_ID]),
         mcp=None,
         tools=None,
     )
@@ -4867,7 +4866,7 @@ async def test_runtime_manifest_projects_provider_secret_values_for_managed_acco
 
 
 @pytest.mark.asyncio
-async def test_runtime_manifest_resolves_bare_managed_alias_to_deployment_catalog(
+async def test_runtime_state_normalizes_deployment_provider_and_resolves_its_catalog(
     admin_client,
     db_session,
     seed_user,
@@ -4908,8 +4907,8 @@ async def test_runtime_manifest_resolves_bare_managed_alias_to_deployment_catalo
         ]
     )
     await db_session.commit()
-    primary_model = {
-        "provider_id": CLAWDI_MANAGED_PROVIDER_ID,
+    internal_primary_model = {
+        "provider_id": internal_provider_id,
         "model": "gpt-5.5",
     }
     await _write_runtime_state(
@@ -4917,17 +4916,28 @@ async def test_runtime_manifest_resolves_bare_managed_alias_to_deployment_catalo
         str(env.id),
         deployment_id="42",
         runtimes=_runtime_state(
-            provider_ids=[CLAWDI_MANAGED_PROVIDER_ID],
-            primary_model=primary_model,
+            provider_ids=[internal_provider_id],
+            primary_model=internal_primary_model,
         ),
         tools={
             "codex": {
                 "enabled": True,
-                "provider_id": CLAWDI_MANAGED_PROVIDER_ID,
-                "primary_model": primary_model,
+                "provider_id": internal_provider_id,
+                "primary_model": internal_primary_model,
             }
         },
     )
+
+    state = await db_session.get(HostedRuntimeState, env.id)
+    assert state is not None
+    primary_model = {
+        "provider_id": CLAWDI_MANAGED_PROVIDER_ID,
+        "model": "gpt-5.5",
+    }
+    assert state.runtimes["openclaw"]["provider_ids"] == [CLAWDI_MANAGED_PROVIDER_ID]
+    assert state.runtimes["openclaw"]["primary_model"] == primary_model
+    assert state.tools["codex"]["provider_id"] == CLAWDI_MANAGED_PROVIDER_ID
+    assert state.tools["codex"]["primary_model"] == primary_model
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
     async with await _runtime_client(db_session, seed_user, api_key) as client:

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -41,7 +41,11 @@ from app.models.session import AgentEnvironment
 from app.models.skill import SKILL_AUTHORITY_CLOUD, Skill
 from app.models.user import User
 from app.routes.admin import _admin_upsert_runtime_state
-from app.routes.sessions import _runtime_observed_health
+from app.routes.sessions import (
+    _runtime_observed_desired,
+    _runtime_observed_health,
+    _runtime_observed_provider_health,
+)
 from app.schemas.admin import AdminRuntimeStateUpsert
 from app.schemas.runtime import (
     HostedEgressEngine,
@@ -797,6 +801,69 @@ def test_unmanaged_health_requires_exact_empty_applied_provider_set():
     assert "applied_provider_ids_extra" in stale.reasons
     assert malformed.status == "unknown"
     assert "desired_provider_contract_invalid" in malformed.reasons
+
+
+def test_managed_health_compares_agent_facing_provider_ids():
+    now = datetime.now(UTC)
+    source_revision = "e" * 64
+    etag = expected_runtime_bundle_v2_etag(source_revision)
+    internal_provider_id = "clawdi-v2-deployment-42"
+    state = SimpleNamespace(
+        deployment_id="42",
+        instance_id="hri-managed-health",
+        generation=3,
+        cli_package_spec=TEST_CLI_PACKAGE_SPEC,
+        updated_at=now,
+        runtimes=_runtime_state(provider_ids=[internal_provider_id]),
+        mcp=None,
+        tools=None,
+    )
+    env = SimpleNamespace(last_sync_error=None, last_sync_at=now)
+    observation = SimpleNamespace(
+        observed_at=now,
+        observed_config_generation=3,
+        observed_manifest_etag=etag,
+        observed_source_revision=source_revision,
+        diagnostics={
+            "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
+            "reportedAt": now.isoformat(),
+            "runtimeMode": "hosted",
+            "status": "ok",
+            "activeCliVersion": TEST_CLI_PACKAGE_SPEC.split("@", 1)[1],
+            "applied": {
+                "etag": etag,
+                "sourceRevision": source_revision,
+                "generation": 3,
+                "instanceId": "hri-managed-health",
+                "appliedProviderIds": [CLAWDI_MANAGED_PROVIDER_ID],
+            },
+            "boot": None,
+            "cli": None,
+            "providers": {
+                CLAWDI_MANAGED_PROVIDER_ID: {
+                    "status": "ok",
+                    "configured": True,
+                    "secretAvailable": True,
+                }
+            },
+        },
+    )
+
+    health = _runtime_observed_health(
+        env,
+        state,
+        observation,
+        desired_source_revision=source_revision,
+        desired_cli_package_spec=TEST_CLI_PACKAGE_SPEC,
+    )
+    provider_health = _runtime_observed_provider_health(state, observation)
+
+    assert _runtime_observed_desired(state).provider_id == CLAWDI_MANAGED_PROVIDER_ID
+    assert health.status == "ok"
+    assert health.reasons == []
+    assert [provider.provider_id for provider in provider_health] == [CLAWDI_MANAGED_PROVIDER_ID]
+    assert provider_health[0].status == "ok"
+    assert provider_health[0].desired == {"selected": True, "primary": True}
 
 
 async def _write_runtime_state(admin_client: httpx.AsyncClient, environment_id: str, **overrides):

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.59",
+      "version": "0.13.60",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
+++ b/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
@@ -33,10 +33,11 @@ Hosted mode is an explicit CLI contract selected by
 command policy is built into the CLI. The image substrate supplies mode and
 runtime-user facts; the provisioner atomically delivers the root-owned strict
 `0400` `/etc/clawdi/runtime-context.json`, containing the apply tuple, exact CLI
-package pin, and typed manifest URL plus bootstrap bearer. On the current Incus
-substrate, the Incus file API atomically replaces that single file; no wrapper
-directory is part of the filesystem ABI. The CLI validates the context and
-fails closed before datasource access. It has no ambient manifest selector,
+bootstrap identity, and typed manifest URL plus bootstrap bearer. The fetched
+manifest independently owns later exact CLI package selection. On the current
+Incus substrate, the Incus file API atomically replaces that single file; no
+wrapper directory is part of the filesystem ABI. The CLI validates the context
+and fails closed before datasource access. It has no ambient manifest selector,
 auth selector, local-manifest path, or substrate-specific datasource branch.
 
 Hosted runtime manifests use the single canonical `/v1/runtime/manifest`

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -842,16 +842,18 @@ installs and hands off to the selected package or fails before applying the new
 desired state.
 
 When only the exact CLI package changes and the capability image remains
-compatible, the substrate may atomically replace the single fixed runtime-context
-file without replacing the workload. The running watcher first requires the
-context `cliPackageSpec` to match the fetched manifest package, installs and
-verifies that exact package, atomically activates it, and exits cleanly. The
-`Restart=always` systemd unit then starts the watcher from the absolute managed
-CLI path. The new CLI performs the complete manifest and systemd convergence;
-the old applied authority remains current until that convergence commits the
-new Apply identity. A failed first convergence rolls back to the previously
-verified CLI. This is a process handoff inside the existing workload, not a
-workload restart or replacement.
+compatible, the runtime context and workload stay unchanged. The fetched
+manifest is the desired CLI authority. The running watcher installs and verifies
+that exact package, atomically activates it, and exits before manifest or systemd
+convergence. The `Restart=always` systemd unit then starts the watcher from the
+absolute managed CLI path. The new CLI completes convergence without restarting
+the daemon, sidecar, or runtime gateway; their independent program and secret
+revisions remain unchanged. The old applied authority remains current until the
+new watcher commits the manifest. A failed first convergence rolls back to the
+previously verified CLI. This is a watcher process handoff inside the existing
+workload: systemd launches the watcher's new `ExecStart` after its clean exit,
+without an explicit `systemctl restart`, an unrelated service restart, or a
+workload replacement.
 
 ## Commands
 
@@ -1054,7 +1056,7 @@ Strict-v2 workloads provide their bootstrap and apply authority through the
 single fixed file `/etc/clawdi/runtime-context.json`. The file
 is a strict `clawdi.runtimeContext.v2` object containing an `apply` tuple
 (`generation`, `manifestETag`, `applyReceiptId`, and `bootNonce`), an exact
-`backend: "incus"` attestation, an exact `cliPackageSpec`, and a typed HTTP
+`backend: "incus"` attestation, the exact bootstrap `cliPackageSpec`, and a typed HTTP
 `manifestSource` with bearer auth. `backend` is required for every Hosted v2
 context and is validated by the common precondition gate before convergence.
 Business secrets are not bootstrap context: the fetched bundle's `secretValues`
@@ -1063,10 +1065,12 @@ that are already in the manifest, auth selectors, paths, mode, runtime user, and
 process environment are not duplicated in the context. A missing or malformed
 context
 fails closed, and no field falls back to ambient process environment. The
-applied generation and exact CLI package must match the fetched manifest and
-are validated before CLI installation, systemd mutation, or applied-authority
-commit can occur. The paired-image local tarball exception exists only when the
-explicit test-installer gate is enabled. `manifestETag` names the
+applied generation must match the fetched manifest before CLI installation,
+systemd mutation, or applied-authority commit can occur. The context package is
+validated as bootstrap identity but is not desired-state authority and need not
+match a later exact package selected by the manifest. The paired-image local
+tarball exception exists only when the explicit test-installer gate is enabled.
+`manifestETag` names the
 Hosted control-plane snapshot and is persisted separately from the fetched
 bundle's HTTP ETag, which remains the strong validator derived from
 `sourceRevision`; the two values are intentionally independent. This lets one

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.59",
+	"version": "0.13.60",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -522,7 +522,6 @@ export function applySystemdRuntimeUpdate(
 	opts: {
 		forceRestartSystemUnits?: readonly string[];
 		forceStopSystemUnits?: readonly string[];
-		forceRestartUserUnits?: readonly string[];
 		recoverFailedUnits?: boolean;
 		activationScope?: {
 			systemUnits: readonly string[];
@@ -560,9 +559,6 @@ export function applySystemdRuntimeUpdate(
 	const forcedSystemStops = (opts.forceStopSystemUnits ?? []).filter(
 		(unit) => after.system.has(unit) && (!scopedSystemUnits || scopedSystemUnits.has(unit)),
 	);
-	const forcedUserRestarts = (opts.forceRestartUserUnits ?? []).filter((unit) =>
-		after.user.has(unit),
-	);
 	const recoverFailedUnits = opts.recoverFailedUnits !== false;
 	const activationChanged =
 		system.added.length > 0 ||
@@ -572,8 +568,7 @@ export function applySystemdRuntimeUpdate(
 		user.changed.length > 0 ||
 		user.removed.length > 0 ||
 		forcedSystemRestarts.length > 0 ||
-		forcedSystemStops.length > 0 ||
-		forcedUserRestarts.length > 0;
+		forcedSystemStops.length > 0;
 	if (!shouldApplySystemdRuntimeUpdate(paths)) {
 		return { applied: !activationChanged, systemUnitsChanged, userUnitsChanged };
 	}
@@ -638,7 +633,6 @@ export function applySystemdRuntimeUpdate(
 	if (restartSystemUnits.length > 0) systemctl(["restart", ...restartSystemUnits]);
 
 	const changedUserUnits = new Set(user.changed);
-	const forcedRestartUserUnits = new Set(forcedUserRestarts);
 	const resetFailedUserUnits: string[] = [];
 	const startUserUnits: string[] = [];
 	const enableUserUnits: string[] = [];
@@ -660,7 +654,7 @@ export function applySystemdRuntimeUpdate(
 		}
 		if (state.activeState !== "active") continue;
 		if (!enabled) enableUserUnits.push(unit);
-		if (changedUserUnits.has(unit) || forcedRestartUserUnits.has(unit)) {
+		if (changedUserUnits.has(unit)) {
 			restartUserUnits.push(unit);
 		}
 	}
@@ -1745,7 +1739,6 @@ async function applyRuntimeDesiredState(
 						...staleSystemUnits,
 					],
 					forceStopSystemUnits: stopEgressSidecar ? [RUNTIME_SIDECAR_SYSTEM_UNIT] : [],
-					forceRestartUserUnits: [...previousSystemdUnits.user.keys()],
 					recoverFailedUnits: false,
 				});
 			},

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -18,7 +18,6 @@ import {
 	isClawdiManagedProviderProjection,
 } from "./hosted-egress-profiles";
 import {
-	HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE,
 	type HostedRuntimeManifest,
 	hostedCliPayloadPolicySchema,
 	hostedRuntimeBundleV2ManifestSchema,
@@ -335,7 +334,7 @@ async function loadRemoteRuntimeManifestPipeline(
 	try {
 		normalized = normalizeRemoteManifestPayload(fetched.raw);
 		assertRemoteBundleAuthority(normalized.sourceRevision, fetched.etag);
-		assertRuntimeApplyContextMatchesManifest(normalized.manifest, applyContext);
+		assertRuntimeApplyIdentityMatchesManifest(normalized.manifest, applyContext);
 	} catch (error) {
 		return {
 			mode: "manifest-rejected",
@@ -375,7 +374,7 @@ function runtimeApplyContextLoadFields(applyContext: RuntimeApplyContext): {
 	return { applyContext };
 }
 
-function assertRuntimeApplyContextMatchesManifest(
+function assertRuntimeApplyIdentityMatchesManifest(
 	manifest: RuntimeManifest,
 	applyContext: RuntimeApplyContext,
 ): void {
@@ -385,15 +384,6 @@ function assertRuntimeApplyContextMatchesManifest(
 	) {
 		throw new Error(
 			`runtime apply identity generation ${applyContext.identity.generation} does not match resolved manifest apply generation ${resolveRuntimeApplyGeneration(manifest)}`,
-		);
-	}
-	const manifestCliPackageSpec = manifest.clawdiCli?.packageSpec;
-	const pairedFixtureMatch =
-		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS === "1" &&
-		applyContext.cliPackageSpec === HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE;
-	if (applyContext.cliPackageSpec !== manifestCliPackageSpec && !pairedFixtureMatch) {
-		throw new Error(
-			`runtime context CLI package ${applyContext.cliPackageSpec} does not match manifest CLI package ${manifestCliPackageSpec ?? "missing"}`,
 		);
 	}
 }

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -1243,6 +1243,43 @@ describe("hosted runtime bundle v2", () => {
 		expect(loaded.channelBindings).toHaveLength(1);
 	});
 
+	test("takes the desired CLI package from the runtime manifest", async () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-runtime-bundle-cli-update-"));
+		roots.push(root);
+		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+		process.env.CLAWDI_RUN_DIR = join(root, "run");
+		process.env.CLAWDI_RUNTIME_HOME = "/home/clawdi";
+		const applyContext = setRuntimeApplyIdentityFile(
+			root,
+			{
+				generation: 1,
+				manifestETag: '"bundle-golden"',
+				applyReceiptId: "apply-receipt-golden-0001",
+				bootNonce: "boot-nonce-golden-000001",
+			},
+			"clawdi@1.2.2-test",
+		);
+		globalThis.fetch = Object.assign(
+			async () =>
+				new Response(readFileSync(goldenPath, "utf-8"), {
+					status: 200,
+					headers: {
+						"content-type": HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
+						etag: `"sha256:${EXPECTED_GOLDEN_SOURCE_REVISION}"`,
+					},
+				}),
+			{ preconnect: () => undefined },
+		);
+
+		const loaded = await loadRemoteRuntimeManifest(getRuntimePaths({ mode: "hosted" }), {
+			applyContext,
+		});
+
+		if (!("manifest" in loaded)) throw new Error(JSON.stringify(loaded));
+		expect(applyContext.cliPackageSpec).toBe("clawdi@1.2.2-test");
+		expect(loaded.manifest.clawdiCli?.packageSpec).toBe("clawdi@1.2.3-test");
+	});
+
 	test("rejects a bundle whose HTTP validator does not name its source revision", async () => {
 		const root = mkdtempSync(join(tmpdir(), "clawdi-runtime-bundle-authority-"));
 		roots.push(root);

--- a/packages/cli/src/runtime/runtime-impact-revision.test.ts
+++ b/packages/cli/src/runtime/runtime-impact-revision.test.ts
@@ -7,7 +7,6 @@ import {
 } from "./runtime-impact-revision";
 
 const daemonManifest = {
-	clawdiCli: { packageSpec: "clawdi@1.0.0" },
 	controlPlane: { apiUrl: "https://cloud.test" },
 	liveSync: { enabled: false, agents: [] },
 };
@@ -52,6 +51,17 @@ describe("runtime impact revisions", () => {
 		expect(daemonProgramRevision({ ...daemonManifest })).toBe(
 			daemonProgramRevision(daemonManifest),
 		);
+		const cliOnlyChange = {
+			...daemonManifest,
+			clawdiCli: { packageSpec: "clawdi@2.0.0" },
+		};
+		expect(daemonProgramRevision(cliOnlyChange)).toBe(daemonProgramRevision(daemonManifest));
+		expect(
+			daemonProgramRevision({
+				...daemonManifest,
+				controlPlane: { apiUrl: "https://other.test" },
+			}),
+		).not.toBe(daemonProgramRevision(daemonManifest));
 		expect(runtimeSidecarProgramRevision({ ...sidecarManifest, instanceId: "other" })).not.toBe(
 			runtimeSidecarProgramRevision(sidecarManifest),
 		);

--- a/packages/cli/src/runtime/runtime-impact-revision.ts
+++ b/packages/cli/src/runtime/runtime-impact-revision.ts
@@ -85,10 +85,9 @@ export function runtimeServiceProgramRevision(program: RuntimeServiceProgramImpa
 }
 
 export function daemonProgramRevision(
-	manifest: Pick<RuntimeManifest, "clawdiCli" | "controlPlane" | "liveSync">,
+	manifest: Pick<RuntimeManifest, "controlPlane" | "liveSync">,
 ): string {
 	return runtimeImpactRevision({
-		clawdiCli: manifest.clawdiCli ?? null,
 		controlPlane: manifest.controlPlane,
 		liveSync: manifest.liveSync ?? null,
 	});

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -7360,34 +7360,6 @@ fi
 					applyReceiptId: "apply-receipt-generation-0031",
 					bootNonce: "boot-nonce-generation-0001",
 				},
-				{
-					...CANONICAL_TEST_CONTEXT,
-					cliPackageSpec: "clawdi@1.2.4-test",
-				},
-			);
-			const committedBeforeMismatchedCliPackage = readFileSync(paths.appliedState, "utf-8");
-			writeFileSync(systemctlLog, "");
-			process.exitCode = undefined;
-			await runtimeWatch({ once: true, json: true });
-
-			expect(process.exitCode).toBe(1);
-			expect(JSON.parse(logs.at(-1) ?? "{}")).toMatchObject({
-				status: "error",
-				mode: "manifest-rejected",
-			});
-			expect(JSON.parse(logs.at(-1) ?? "{}").error).toContain(
-				"runtime context CLI package clawdi@1.2.4-test does not match manifest CLI package clawdi@1.2.3-test",
-			);
-			expect(readFileSync(paths.appliedState, "utf-8")).toBe(committedBeforeMismatchedCliPackage);
-			expect(readFileSync(systemctlLog, "utf-8")).toBe("");
-
-			setRuntimeApplyContextFixture(
-				{
-					generation,
-					manifestETag: '"hosted-control-plane-generation-31"',
-					applyReceiptId: "apply-receipt-generation-0031",
-					bootNonce: "boot-nonce-generation-0001",
-				},
 				CANONICAL_TEST_CONTEXT,
 			);
 			process.exitCode = undefined;
@@ -7430,7 +7402,7 @@ fi
 				applyReceiptId: "apply-receipt-generation-0031",
 				bootNonce: "boot-nonce-generation-0001",
 			});
-			expect(watchFetch.captured).toHaveLength(12);
+			expect(watchFetch.captured).toHaveLength(10);
 			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
 				"--user restart openclaw-gateway.service",
 			);
@@ -8705,7 +8677,7 @@ fi
 		]);
 	});
 
-	it("runtime watch hands off before convergence and the new CLI completes the transaction", async () => {
+	it("runtime watch updates from the manifest without rewriting bootstrap context", async () => {
 		installSuccessfulSystemctlFixture();
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -8718,9 +8690,10 @@ fi
 		const currentVersion = getCliVersion();
 		const cliContext = {
 			...CANONICAL_TEST_CONTEXT,
-			cliPackageSpec: `clawdi@${currentVersion}`,
+			cliPackageSpec: "clawdi@1.2.3-test",
 		};
 		setRuntimeApplyGeneration(13, cliContext);
+		const runtimeContextBefore = JSON.stringify(currentTestApplyContext);
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
@@ -8835,6 +8808,7 @@ chmod +x "$prefix/bin/clawdi"
 			expect(event.cliUpdate.status).toBe("installed");
 			expect(event.cliUpdate.packageSpec).toBe(`clawdi@${currentVersion}`);
 			expect(event.systemdUnitsChanged).toBe(false);
+			expect(JSON.stringify(currentTestApplyContext)).toBe(runtimeContextBefore);
 			expect(event.systemdApply).toEqual({
 				applied: false,
 				systemUnitsChanged: [],
@@ -8861,6 +8835,7 @@ chmod +x "$prefix/bin/clawdi"
 			expect(completedEvent.selfReexec).toBe(false);
 			expect(completedEvent.cliUpdate.status).toBe("current");
 			expect(readRuntimeAppliedState(paths)).toMatchObject({ generation: 13 });
+			expect(JSON.stringify(currentTestApplyContext)).toBe(runtimeContextBefore);
 			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
 				transaction: null,
 				badVersions: [],

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1279,6 +1279,7 @@ function seedRuntimeWatchLocaleBaseline(home: string, state: string, run: string
 
 function installSuccessfulSystemctlFixture(
 	sidecarReadyPath = join(root, "run", "clawdi", "egress", "systemd", "ca.pem"),
+	systemctlLog?: string,
 ): void {
 	const systemctlPath = join(root, "bin", "systemctl");
 	mkdirSync(dirname(systemctlPath), { recursive: true });
@@ -1286,6 +1287,7 @@ function installSuccessfulSystemctlFixture(
 		systemctlPath,
 		`#!/usr/bin/env bash
 set -euo pipefail
+${systemctlLog ? `printf '%s\\n' "$*" >> '${systemctlLog}'` : ""}
 if [ "\${1:-}" = "--user" ]; then shift; fi
 if [ "\${1:-}" = "show" ]; then
   printf 'LoadState=loaded\\nActiveState=active\\n'
@@ -8677,13 +8679,14 @@ fi
 		]);
 	});
 
-	it("runtime watch updates from the manifest without rewriting bootstrap context", async () => {
-		installSuccessfulSystemctlFixture();
+	it("runtime watch applies a CLI-only update by handoff without restarting existing units", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const bin = join(root, "bin");
 		const npmLog = join(root, "npm.log");
+		const systemctlLog = join(root, "systemctl-cli-update.log");
+		installSuccessfulSystemctlFixture(join(run, "egress", "systemd", "ca.pem"), systemctlLog);
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
@@ -8742,7 +8745,9 @@ chmod +x "$prefix/bin/clawdi"
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
+		seedCurrentCliInstall(state, "clawdi@1.2.3-test", "1.2.3-test", "https://registry.npmjs.org");
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
+		let desiredCliPackageSpec = "clawdi@1.2.3-test";
 		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
@@ -8764,7 +8769,7 @@ chmod +x "$prefix/bin/clawdi"
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
-									packageSpec: `clawdi@${currentVersion}`,
+									packageSpec: desiredCliPackageSpec,
 									registry: "https://registry.npmjs.org",
 								},
 								runtimes: {
@@ -8773,20 +8778,37 @@ chmod +x "$prefix/bin/clawdi"
 							},
 							secretValues: {},
 						},
-						{ etag: testBundleEtag("etag-cli-update-13") },
+						{ etag: testBundleEtag(desiredCliPackageSpec) },
 					),
 			},
 		]);
 
 		try {
 			await runtimeWatch({ once: true, json: true });
+			if (process.exitCode !== undefined && process.exitCode !== 0) {
+				throw new Error(logs.join("\n"));
+			}
+			const paths = getRuntimePaths();
+			expect(JSON.parse(logs[0])).toMatchObject({ status: "applied" });
+			expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"))).toBe(true);
+			expect(existsSync(join(paths.systemdSystemRoot, "clawdi-daemon.service"))).toBe(true);
+			expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service"))).toBe(
+				true,
+			);
+			expect(existsSync(join(paths.systemdUserRoot, "openclaw-gateway.service"))).toBe(true);
+			expect(existsSync(paths.daemonAuthToken)).toBe(true);
+
+			logs.length = 0;
+			writeFileSync(systemctlLog, "");
+			process.exitCode = undefined;
+			desiredCliPackageSpec = `clawdi@${currentVersion}`;
+			await runtimeWatch({ once: true, json: true });
 
 			if (process.exitCode !== undefined && process.exitCode !== 0) {
 				throw new Error(logs.join("\n"));
 			}
 			expect(process.exitCode ?? 0).toBe(0);
-			expect(captured).toHaveLength(1);
-			const paths = getRuntimePaths();
+			expect(captured).toHaveLength(2);
 			const active = paths.cliManagedBin;
 			const sharedPrefixTarget = join(paths.cliNpmPrefix, "bin", "clawdi");
 			const activeTarget = readlinkSync(active);
@@ -8814,10 +8836,8 @@ chmod +x "$prefix/bin/clawdi"
 				systemUnitsChanged: [],
 				userUnitsChanged: [],
 			});
-			expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"))).toBe(false);
-			expect(existsSync(join(paths.systemdUserRoot, "openclaw-gateway.service"))).toBe(false);
-			expect(existsSync(paths.manifestLastGood)).toBe(false);
-			expect(existsSync(paths.appliedState)).toBe(false);
+			expect(readFileSync(systemctlLog, "utf-8")).toBe("");
+			expect(readRuntimeAppliedState(paths)).toMatchObject({ generation: 13 });
 			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
 				transaction: { phase: "activated" },
 				badVersions: [],
@@ -8825,17 +8845,25 @@ chmod +x "$prefix/bin/clawdi"
 
 			logs.length = 0;
 			process.exitCode = undefined;
-			setRuntimeApplyGeneration(13, cliContext);
 			await runtimeWatch({ once: true, json: true });
 
 			expect(process.exitCode ?? 0).toBe(0);
-			expect(captured).toHaveLength(2);
+			expect(captured).toHaveLength(3);
 			const completedEvent = JSON.parse(logs[0]);
 			expect(completedEvent.status).toBe("applied");
 			expect(completedEvent.selfReexec).toBe(false);
 			expect(completedEvent.cliUpdate.status).toBe("current");
+			expect(completedEvent.systemdUnitsChanged).toBe(false);
+			expect(completedEvent.systemdApply).toEqual({
+				applied: true,
+				systemUnitsChanged: [],
+				userUnitsChanged: [],
+			});
 			expect(readRuntimeAppliedState(paths)).toMatchObject({ generation: 13 });
 			expect(JSON.stringify(currentTestApplyContext)).toBe(runtimeContextBefore);
+			expect(readFileSync(systemctlLog, "utf-8")).not.toMatch(
+				/(?:^|\s)(?:daemon-reload|start|restart|stop|enable|disable|reset-failed)(?:\s|$)/m,
+			);
 			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
 				transaction: null,
 				badVersions: [],
@@ -9321,6 +9349,8 @@ fi
 			expect(readFileSync(paths.managedSecretCacheFile, "utf-8")).toBe(committedSecretCache);
 			const rollbackSystemctlCalls = readFileSync(systemctlLog, "utf-8").trim().split("\n");
 			expect(rollbackSystemctlCalls).not.toContain("official openclaw installer");
+			expect(rollbackSystemctlCalls).not.toContain("restart openclaw-gateway.service");
+			expect(rollbackSystemctlCalls).not.toContain("restart clawdi-daemon.service");
 			const failedRestart = rollbackSystemctlCalls.indexOf(
 				"restart clawdi-runtime-sidecar.service",
 			);
@@ -9380,7 +9410,8 @@ fi
 			expect(readFileSync(paths.manifestLastGood, "utf-8")).toBe(committedLastGood);
 			expect(readFileSync(paths.managedSecretCacheFile, "utf-8")).toBe(committedSecretCache);
 			const invalidEngineRollbackCalls = readFileSync(systemctlLog, "utf-8");
-			expect(invalidEngineRollbackCalls).toContain("--user restart openclaw-gateway.service");
+			expect(invalidEngineRollbackCalls).not.toContain("--user restart openclaw-gateway.service");
+			expect(invalidEngineRollbackCalls).not.toContain("restart clawdi-daemon.service");
 		} finally {
 			console.log = previousLog;
 			process.exitCode = previousExitCode;


### PR DESCRIPTION
## Summary

- make the fetched hosted manifest authoritative for exact CLI package selection
- install and verify versioned CLI packages, atomically hand off the watcher, and leave runtime-context unchanged
- scope daemon, sidecar, and runtime unit revisions to their actual dependencies
- normalize managed provider IDs at the runtime-state ingress boundary without changing frozen observation logic

## Restart contract

CLI-only updates do not roll out the workload and do not explicitly restart watcher, daemon, sidecar, or runtime gateway units. The watcher exits cleanly after activation and systemd `Restart=always` launches the managed binary for the second convergence tick. Rollback reconciles only units whose rendered bytes actually changed.

## Release note

`clawdi@0.13.60` was already published from main by #944 and does not contain this PR. After this PR merges, its CLI changes require the next immutable CLI version.

## Verification

- frozen v1 byte contract
- focused backend provider state/health tests on isolated PostgreSQL
- CLI typecheck
- focused CLI handoff, revision, rollback, and sidecar tests
- Ruff, Biome, and `git diff --check`
- GitHub CI: backend, client, clean runner, web E2E, WhatsApp native E2E, and sidecar all green

Production rollout and tenant bridge are intentionally out of scope for this PR.
