### PR TITLE
fix(files): run with tenant home identity

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.58",
+      "version": "0.13.59",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -347,33 +347,33 @@ state, so a download, verification, systemd, or readiness failure restores the
 previous exact pre-image. There is no separate active/previous link state or
 hand-built chroot.
 
-`clawdi-files.service` runs as the dedicated non-login `clawdi-files` system
-UID/GID, never as the tenant runtime user. CLI/root reconciliation is the only
-identity, installer, updater, ACL, and unit controller. Candidate directories
-and binaries are root-owned; the service reads its root-authored
-per-boot config handoff from a `root:clawdi-files` `0750` directory containing
-a `root:clawdi-files` `0440` file, and systemd
-publishes only the verified binary through a unit-private `BindReadOnlyPaths=`
-mount. DB/cache state lives in the service-owned `0700`
-`StateDirectory=clawdi-files`; install
-receipts remain root-only `0600`. The tenant cannot replace those assets, read
-the derived JWT secret or state, signal the distinct-UID process, or control
-the system unit.
+`clawdi-files.service` runs as the non-root tenant runtime UID/GID so Files has
+native read/write access to the complete tenant home, including `0600` files,
+`0700` directories, and dotfiles. Reconciliation does not rewrite ownership,
+modes, or ACLs across the home. Candidate directories and binaries remain
+root-owned. The root-authored JWT configuration is a `root:<runtime group>`
+`0440` file below a root-only `0700` directory, so other tenant processes
+cannot traverse to it; systemd publishes that file and the verified binary only
+inside the Files mount namespace through `BindReadOnlyPaths=`. Install receipts
+remain root-only `0600`.
 
-The CLI grants the service only named-group `rwX` access to `/home/clawdi`
-using recursive access and default POSIX ACLs through the image's existing
-`systemd-tmpfiles` `+ACL` support. Symlinks are not followed, existing content
-is reconciled, and new content inherits reciprocal tenant/service access. The
-base runtime image remains unchanged and contains no File Browser binary,
-configuration, state, service identity, installer, or File Browser-specific
+DB/cache state lives in the tenant-owned `0700`
+`StateDirectory=clawdi-files`. The tenant can therefore inspect or alter its
+own Files state and can signal the same-UID Files process, but cannot replace
+the root-owned binary or configuration source, write receipts, or control the
+system unit. Systemd restarts a terminated Files process and readiness gates
+activation. The base runtime image remains unchanged and contains no File
+Browser binary, configuration, state, installer, or File Browser-specific
 package. The service reuses the generated system-unit and environment-file
 writer and applies systemd's native
 `ProtectSystem=strict`, `ProtectHome=tmpfs`, `BindPaths`, `ReadWritePaths`,
-`ReadOnlyPaths`, `NoExecPaths`, private device/tmp, capability, namespace, and task-limit
-controls. File Browser receives its official JWT header configuration with
-password, signup, passkey, sharing, admin, API-token management, realtime, and
-WebDAV disabled. It accepts only the manifest-bound external JWT assertion; no
-password, pairing code, access code, or URL token is part of this runtime
+`ReadOnlyPaths`, `NoExecPaths`, `PrivatePIDs`, private device/tmp, capability,
+namespace, and task-limit controls. `PrivatePIDs` prevents Files from observing
+or signaling the tenant's other runtime processes. File Browser receives its
+official JWT header configuration with password, signup, passkey, sharing,
+admin, API-token management, realtime, and WebDAV disabled. It accepts only the
+manifest-bound external JWT assertion; no password, pairing code, access code,
+or URL token is part of this runtime
 contract. The non-admin profile settings remain available for safe display and
 file-viewing preferences, with dotfiles visible and the sidebar unpinned by
 default; those settings cannot elevate the separately disabled permissions or
@@ -387,18 +387,14 @@ When a later manifest omits the companion, normal stale-unit
 reconciliation stops and withdraws only `clawdi-files.service` while preserving
 the selected Hermes or OpenClaw unit.
 
-The unavoidable workspace boundary is content-level: the tenant owns its
-workspace and can edit or delete its contents. It can also make an individual
-file or directory temporarily inaccessible to File Browser by changing its own
-permissions or ACL mask; the next CLI reconciliation repairs the managed ACL
-baseline. This does not grant the tenant control over the managed service,
-binary, configuration, secret, DB/cache state, receipts, unit, or active
-listener. Port 9120 has normal socket exclusivity rather than a separate
-tenant-slice reservation: the tenant cannot displace the running service, but
-can bind 9120 while it is not listening and thereby cause later service
-activation/systemd readiness proof to fail. That remaining availability/DoS
-boundary does not let reconciliation adopt the tenant process as the managed
-unit.
+The unavoidable workspace boundary is content-level: the tenant owns its home
+and can edit or delete its contents and Files state. This does not grant the
+tenant control over the root-owned binary, configuration secret source,
+receipts, unit, or listener authority. Port 9120 has normal socket exclusivity
+rather than a separate tenant-slice reservation: the tenant cannot displace the
+running service, but can bind 9120 while it is not listening and thereby cause
+later activation/readiness proof to fail. That remaining availability boundary
+does not let reconciliation adopt the tenant process as the managed unit.
 
 The pinned upstream contracts are File Browser's
 [JWT verifier](https://github.com/gtsteffaniak/filebrowser/blob/79552f8adb27c3e29934c4001660eb98f4aab5d6/backend/auth/jwt.go),
@@ -407,8 +403,7 @@ and [authentication settings](https://github.com/gtsteffaniak/filebrowser/blob/7
 the [user-default and permission fields](https://github.com/gtsteffaniak/filebrowser/blob/79552f8adb27c3e29934c4001660eb98f4aab5d6/backend/common/settings/structs.go),
 and the [non-admin profile update boundary](https://github.com/gtsteffaniak/filebrowser/blob/79552f8adb27c3e29934c4001660eb98f4aab5d6/backend/http/users.go),
 plus the documented
-[systemd execution sandbox](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html)
-and [`systemd-tmpfiles` POSIX ACL types](https://www.freedesktop.org/software/systemd/man/latest/tmpfiles.d.html).
+[systemd execution sandbox](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html).
 Repository tests verify the manifest, rollback, and systemd sandbox contracts.
 
 Done: `bash scripts/test.sh cli src/runtime/manifest-reconciliation.test.ts`
@@ -1104,8 +1099,8 @@ and ephemeral runtime handoffs. Important outputs include:
 | Output | Purpose |
 | --- | --- |
 | `/etc/clawdi/clawdi.json` | Redacted managed runtime config |
-| `/run/clawdi/files/` | `root:clawdi-files` `0750` per-boot Files config handoff directory |
-| `/run/clawdi/files/filebrowser.yaml` | `root:clawdi-files` `0440` Files config read directly by the existing service |
+| `/run/clawdi/files/` | Root-only `0700` per-boot Files config source directory |
+| `/run/clawdi/files/filebrowser.yaml` | `root:<runtime group>` `0440` Files config published only through the unit-private bind mount |
 | `/etc/clawdi/projections/*` and `/etc/clawdi/run/*` | Managed projections and `clawdi run` launch config |
 | `/var/lib/clawdi/sync/runtimes.json` | Runtime sync state |
 | `/var/lib/clawdi/status/*` | Boot, apply, upgrade, provider, egress, watch, and receipt status/result files |
@@ -1114,7 +1109,7 @@ and ephemeral runtime handoffs. Important outputs include:
 | `/var/lib/clawdi/maintained/filebrowser/candidates/<sha256>/filebrowser` | Root-owned, verified Files executable |
 | `/var/lib/clawdi/maintained/clawdi/` | Root-only managed CLI activation and versioned package prefixes |
 | `/var/lib/clawdi-user/` | Tenant-owned `0750` hosted CLI state selected by `CLAWDI_HOME` |
-| `/var/lib/clawdi-files/` | `clawdi-files`-owned `0700` DB and component cache state |
+| `/var/lib/clawdi-files/` | Tenant-owned `0700` Files DB and component cache state |
 | `/var/cache/clawdi/manifest.last-good.json` | Refetchable last-good manifest fallback |
 | `/var/cache/clawdi/runtime-secrets.last-good.json` | Root-only refetchable secret fallback for offline recovery |
 | `/var/cache/clawdi/npm/` | Managed CLI npm download cache |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.58",
+	"version": "0.13.59",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/file-browser-companion.ts
+++ b/packages/cli/src/runtime/file-browser-companion.ts
@@ -30,7 +30,7 @@ import { runningAsRoot } from "./runtime-user-command";
 const FILE_BROWSER_BINARY = "filebrowser";
 const FILE_BROWSER_CANDIDATES = "candidates";
 const FILE_BROWSER_RECEIPT = "filebrowser";
-const FILE_BROWSER_CONFIG_ROOT_MODE = 0o750;
+const FILE_BROWSER_CONFIG_ROOT_MODE = 0o700;
 const FILE_BROWSER_CONFIG_MODE = 0o440;
 
 type FileBrowserCompanion = NonNullable<NonNullable<RuntimeManifest["companions"]>["filebrowser"]>;
@@ -336,7 +336,7 @@ function currentRevision(
 			!configRootStat.isDirectory() ||
 			configRootStat.isSymbolicLink() ||
 			configRootStat.uid !== owner.uid ||
-			configRootStat.gid !== identity.gid ||
+			configRootStat.gid !== owner.gid ||
 			(configRootStat.mode & 0o777) !== FILE_BROWSER_CONFIG_ROOT_MODE
 		)
 			return null;
@@ -379,7 +379,7 @@ export function ensureFileBrowserCompanion(
 	ensureOwnedDirectory(candidatesRoot(paths), managedRootIdentity(), 0o755);
 	ensureOwnedDirectory(
 		paths.fileBrowserConfigRoot,
-		{ uid: managedRootIdentity().uid, gid: identity.gid },
+		managedRootIdentity(),
 		FILE_BROWSER_CONFIG_ROOT_MODE,
 	);
 	cleanStaleStaging(paths);

--- a/packages/cli/src/runtime/file-browser-isolation.ts
+++ b/packages/cli/src/runtime/file-browser-isolation.ts
@@ -1,18 +1,6 @@
-import { spawnSync } from "node:child_process";
-import { chmodSync, existsSync, lstatSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
-import { join } from "node:path";
-import { writePrivateFileAtomic } from "../lib/private-file";
+import { lstatSync } from "node:fs";
 import type { RuntimePaths } from "./paths";
-import {
-	buildRuntimeUserCommand,
-	commandExists,
-	runningAsRoot,
-	runtimeUserGid,
-	runtimeUserUid,
-} from "./runtime-user-command";
-
-export const FILE_BROWSER_SERVICE_USER = "clawdi-files";
-export const FILE_BROWSER_SERVICE_GROUP = "clawdi-files";
+import { runtimeUserGid, runtimeUserUid } from "./runtime-user-command";
 
 export interface FileBrowserServiceIdentity {
 	uid: number;
@@ -24,279 +12,24 @@ export type FileBrowserServiceIsolation = (
 	sourceRoot: string,
 ) => FileBrowserServiceIdentity;
 
-interface PasswdEntry {
-	uid: number;
-	gid: number;
-	home: string;
-	shell: string;
-}
-
-function commandOutput(command: string, args: string[]): string {
-	const result = spawnSync(command, args, {
-		encoding: "utf8",
-		maxBuffer: 64 * 1024,
-		timeout: 30_000,
-	});
-	if (result.status !== 0) {
-		const detail = [result.error?.message, result.stderr, result.stdout]
-			.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
-			.join("\n")
-			.trim()
-			.slice(-2000);
-		throw new Error(
-			`Files service isolation command failed: ${command}${detail ? `: ${detail}` : ""}`,
-		);
-	}
-	return result.stdout.trim();
-}
-
-function lookupGroup(name: string): number | null {
-	const result = spawnSync("getent", ["group", name], { encoding: "utf8" });
-	if (result.status !== 0) return null;
-	const fields = result.stdout.trim().split(":");
-	const gid = Number.parseInt(fields[2] ?? "", 10);
-	if (!Number.isInteger(gid) || gid <= 0) {
-		throw new Error(`Files service group ${name} has an invalid gid`);
-	}
-	return gid;
-}
-
-function lookupUser(name: string): PasswdEntry | null {
-	const result = spawnSync("getent", ["passwd", name], { encoding: "utf8" });
-	if (result.status !== 0) return null;
-	const fields = result.stdout.trim().split(":");
-	const uid = Number.parseInt(fields[2] ?? "", 10);
-	const gid = Number.parseInt(fields[3] ?? "", 10);
-	if (!Number.isInteger(uid) || uid <= 0 || !Number.isInteger(gid) || gid <= 0) {
-		throw new Error(`Files service user ${name} has an invalid filesystem identity`);
-	}
-	return { uid, gid, home: fields[5] ?? "", shell: fields[6] ?? "" };
-}
-
-function groupIdsForUser(name: string): number[] {
-	const output = commandOutput("id", ["-G", name]);
-	const gids = output.split(/\s+/).map((value) => Number.parseInt(value, 10));
-	if (gids.length === 0 || gids.some((gid) => !Number.isInteger(gid) || gid <= 0)) {
-		throw new Error(`Files service identity ${name} has invalid group membership`);
-	}
-	return [...new Set(gids)];
-}
-
-function groupNameForGid(gid: number): string {
-	const result = spawnSync("getent", ["group", String(gid)], { encoding: "utf8" });
-	const name = result.status === 0 ? result.stdout.trim().split(":")[0]?.trim() : "";
-	if (!name) throw new Error(`Files service identity group ${gid} cannot be resolved`);
-	return name;
-}
-
-function removeSupplementaryGroup(user: string, gid: number): void {
-	commandOutput("gpasswd", ["--delete", user, groupNameForGid(gid)]);
-}
-
-function ensureServiceIdentity(runtimeUser: string): FileBrowserServiceIdentity {
-	let gid = lookupGroup(FILE_BROWSER_SERVICE_GROUP);
-	if (gid === null) {
-		commandOutput("groupadd", ["--system", FILE_BROWSER_SERVICE_GROUP]);
-		gid = lookupGroup(FILE_BROWSER_SERVICE_GROUP);
-	}
-	if (gid === null) throw new Error("Files service group was not created");
-
-	let user = lookupUser(FILE_BROWSER_SERVICE_USER);
-	if (user === null) {
-		commandOutput("useradd", [
-			"--system",
-			"--gid",
-			FILE_BROWSER_SERVICE_GROUP,
-			"--home-dir",
-			"/nonexistent",
-			"--no-create-home",
-			"--shell",
-			"/usr/sbin/nologin",
-			FILE_BROWSER_SERVICE_USER,
-		]);
-		user = lookupUser(FILE_BROWSER_SERVICE_USER);
-	}
-	if (user === null) throw new Error("Files service user was not created");
-	const runtimeUid = runtimeUserUid(runtimeUser);
-	const runtimeGid = runtimeUserGid(runtimeUser);
-	if (user.uid === 0 || user.uid === runtimeUid || user.gid !== gid || user.gid === runtimeGid) {
-		throw new Error("Files service identity is not distinct from the tenant runtime identity");
-	}
-	if (user.home !== "/nonexistent" || !user.shell.endsWith("/nologin")) {
-		throw new Error("Files service identity must be non-login with no home directory");
-	}
-	if (groupIdsForUser(runtimeUser).includes(gid)) {
-		removeSupplementaryGroup(runtimeUser, gid);
-	}
-	for (const supplementaryGid of groupIdsForUser(FILE_BROWSER_SERVICE_USER)) {
-		if (supplementaryGid !== gid) {
-			removeSupplementaryGroup(FILE_BROWSER_SERVICE_USER, supplementaryGid);
-		}
-	}
-	if (
-		groupIdsForUser(runtimeUser).includes(gid) ||
-		groupIdsForUser(FILE_BROWSER_SERVICE_USER).some((memberGid) => memberGid !== gid)
-	) {
-		throw new Error("Files service identity has unsafe supplementary group membership");
-	}
-	return { uid: user.uid, gid };
-}
-
-function ensureWorkspaceAcl(
-	paths: RuntimePaths,
-	sourceRoot: string,
-	runtimeUid: number,
-	identity: FileBrowserServiceIdentity,
-): void {
-	if (!existsSync(sourceRoot)) {
-		throw new Error(`Files source root does not exist: ${sourceRoot}`);
-	}
-	if (sourceRoot !== paths.userHome || /\s/.test(sourceRoot)) {
-		throw new Error("Files source root must be the canonical tenant home path");
-	}
-	if (!commandExists("systemd-tmpfiles")) {
-		throw new Error("Files service isolation requires systemd-tmpfiles");
-	}
-	if (!/(?:^|\s)\+ACL(?:\s|$)/.test(commandOutput("systemd-tmpfiles", ["--version"]))) {
-		throw new Error("Files service isolation requires systemd-tmpfiles POSIX ACL support");
-	}
-	const runRoot = lstatSync(paths.runRoot);
-	if (!runRoot.isDirectory() || runRoot.isSymbolicLink() || runRoot.uid !== 0) {
-		throw new Error("Files service isolation requires a trusted root-owned runtime directory");
-	}
-	const temporaryRoot = mkdtempSync(paths.fileBrowserAclTempPrefix);
-	chmodSync(temporaryRoot, 0o700);
-	try {
-		const config = join(temporaryRoot, "filebrowser.conf");
-		const directoryAcl = [
-			`u:${runtimeUid}:rwx`,
-			`g:${identity.gid}:rwx`,
-			"m::rwx",
-			`d:u:${runtimeUid}:rwx`,
-			`d:g:${identity.gid}:rwx`,
-			"d:m::rwx",
-		].join(",");
-		const fileAcl = [`u:${runtimeUid}:rw-`, `g:${identity.gid}:rw-`, "m::rwx"].join(",");
-		const contents = workspaceAclEntries(sourceRoot, runtimeUid, identity.uid)
-			.map(
-				(entry) =>
-					`a+ ${tmpfilesPath(entry.path)} - - - - ${entry.directory ? directoryAcl : fileAcl}`,
-			)
-			.join("\n");
-		writePrivateFileAtomic(config, `${contents}\n`, {
-			mode: 0o600,
-			dirMode: 0o700,
-		});
-		commandOutput("systemd-tmpfiles", ["--create", config]);
-	} finally {
-		rmSync(temporaryRoot, { recursive: true, force: true });
-	}
-	for (const access of ["-r", "-w", "-x"]) {
-		const command = buildRuntimeUserCommand(
-			FILE_BROWSER_SERVICE_USER,
-			"/nonexistent",
-			"/usr/bin/test",
-			[access, sourceRoot],
-			{ currentUid: 0, runtimeUid: identity.uid, runtimeGid: identity.gid },
-		);
-		if (
-			spawnSync(command.command, command.args, { env: { ...process.env, ...command.env } })
-				.status !== 0
-		) {
-			throw new Error("Files service identity cannot access the tenant workspace ACL");
-		}
-	}
-}
-
-function workspaceAclEntries(
-	sourceRoot: string,
-	runtimeUid: number,
-	serviceUid: number,
-): Array<{ path: string; directory: boolean }> {
-	const root = lstatSync(sourceRoot);
-	if (!root.isDirectory() || root.isSymbolicLink()) {
-		throw new Error("Files source root must be a trusted directory");
-	}
-	if (root.uid !== runtimeUid) {
-		throw new Error("Files source root must be owned by the tenant runtime user");
-	}
-	const entries: Array<{ path: string; directory: boolean }> = [
-		{ path: sourceRoot, directory: true },
-	];
-	const visit = (directory: string): void => {
-		for (const entry of readdirSync(directory, { withFileTypes: true }).sort((left, right) =>
-			left.name.localeCompare(right.name),
-		)) {
-			if (entry.name.startsWith(".")) continue;
-			const path = join(directory, entry.name);
-			let stat: ReturnType<typeof lstatSync>;
-			try {
-				stat = lstatSync(path);
-			} catch (error) {
-				if (errorCode(error) === "ENOENT") continue;
-				throw error;
-			}
-			if (stat.isSymbolicLink()) continue;
-			// Service-owned paths already grant Files access and inherit the
-			// tenant ACL. Do not cross that ownership boundary with tmpfiles.
-			if (stat.uid === serviceUid) continue;
-			if (stat.uid !== runtimeUid) continue;
-			if (stat.isFile()) {
-				entries.push({ path, directory: false });
-				continue;
-			}
-			if (!stat.isDirectory() || stat.dev !== root.dev) continue;
-			entries.push({ path, directory: true });
-			visit(path);
-		}
-	};
-	visit(sourceRoot);
-	return entries;
-}
-
-function tmpfilesPath(path: string): string {
-	let escaped = "";
-	for (const byte of Buffer.from(path)) {
-		if (byte === 0x25) {
-			escaped += "%%";
-			continue;
-		}
-		if (
-			(byte >= 0x30 && byte <= 0x39) ||
-			(byte >= 0x41 && byte <= 0x5a) ||
-			(byte >= 0x61 && byte <= 0x7a) ||
-			[0x2d, 0x2e, 0x2f, 0x5f].includes(byte)
-		) {
-			escaped += String.fromCharCode(byte);
-			continue;
-		}
-		escaped += `\\x${byte.toString(16).padStart(2, "0")}`;
-	}
-	return escaped;
-}
-
-function errorCode(error: unknown): string | null {
-	if (typeof error !== "object" || error === null || !("code" in error)) return null;
-	return typeof error.code === "string" ? error.code : null;
-}
-
 export function ensureFileBrowserServiceIsolation(
 	paths: RuntimePaths,
 	sourceRoot: string,
 ): FileBrowserServiceIdentity {
-	if (!runningAsRoot()) {
-		throw new Error("Files service isolation requires root reconciliation");
+	if (sourceRoot !== paths.userHome || /\s/.test(sourceRoot)) {
+		throw new Error("Files source root must be the canonical tenant home path");
 	}
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
 	if (runtimeUser === "root" || runtimeUser === "0") {
-		throw new Error("Files service isolation requires a non-root tenant runtime user");
+		throw new Error("Files requires a non-root tenant runtime user");
 	}
-	for (const command of ["getent", "gpasswd", "groupadd", "id", "useradd"]) {
-		if (!commandExists(command)) {
-			throw new Error(`Files service isolation requires ${command}`);
-		}
+	const identity = {
+		uid: runtimeUserUid(runtimeUser),
+		gid: runtimeUserGid(runtimeUser),
+	};
+	const root = lstatSync(sourceRoot);
+	if (!root.isDirectory() || root.isSymbolicLink() || root.uid !== identity.uid) {
+		throw new Error("Files source root must be owned by the tenant runtime user");
 	}
-	const identity = ensureServiceIdentity(runtimeUser);
-	ensureWorkspaceAcl(paths, sourceRoot, runtimeUserUid(runtimeUser), identity);
 	return identity;
 }

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -25,7 +25,6 @@ import {
 	writeRuntimeAppliedState,
 } from "./applied-state";
 import { gcFileBrowserCompanionCandidates } from "./file-browser-companion";
-import { FILE_BROWSER_SERVICE_GROUP, FILE_BROWSER_SERVICE_USER } from "./file-browser-isolation";
 import { loadHostedBundledSkill, reconcileHostedBundledSkill } from "./hosted-bundled-skill";
 import { hostedAiProviderCatalog } from "./hosted-provider-resolution";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
@@ -5026,8 +5025,8 @@ exit 42
 			join(paths.systemdUserRoot, "clawdi-files.service"),
 		);
 		expect(unit).not.toContain("RootDirectory=");
-		expect(unit).toContain(`User=${FILE_BROWSER_SERVICE_USER}`);
-		expect(unit).toContain(`Group=${FILE_BROWSER_SERVICE_GROUP}`);
+		expect(unit).toContain(`User=${TEST_RUNTIME_USER}`);
+		expect(unit).toContain(`Group=${process.getegid?.() ?? 0}`);
 		expect(unit).toContain("ProtectHome=tmpfs");
 		expect(unit).toContain(`BindPaths=${paths.userHome}`);
 		expect(unit).toContain("StateDirectory=clawdi-files");
@@ -5038,16 +5037,20 @@ exit 42
 		expect(unit).not.toContain("LoadCredential=");
 		expect(unit).toContain(`ReadWritePaths=${paths.userHome}`);
 		expect(unit).toContain(`BindReadOnlyPaths=${active}:${paths.fileBrowserServiceBinary}:norbind`);
+		expect(unit).toContain(
+			`BindReadOnlyPaths=${paths.fileBrowserConfig}:${dirname(paths.fileBrowserServiceBinary)}/filebrowser.yaml:norbind`,
+		);
 		expect(unit).toContain('ExecStartPre="/bin/sh" "-c"');
 		expect(unit).toContain(paths.fileBrowserServiceBinary);
 		expect(unit).toContain(FILE_BROWSER_VERSION);
 		expect(unit).toContain(FILE_BROWSER_COMMIT.slice(0, 7));
-		expect(unit).not.toContain(`ReadOnlyPaths=${paths.fileBrowserConfig}`);
+		expect(unit.split("\n")).not.toContain(`ReadOnlyPaths=${paths.fileBrowserConfig}`);
 		expect(unit.match(/^ExecStart=.*$/m)?.[0]).toBe(
-			`ExecStart="${paths.fileBrowserServiceBinary}" "-c" "${paths.fileBrowserConfig}"`,
+			`ExecStart="${paths.fileBrowserServiceBinary}" "-c" "${dirname(paths.fileBrowserServiceBinary)}/filebrowser.yaml"`,
 		);
 		expect(unit).toContain(`NoExecPaths=${paths.userHome} ${paths.fileBrowserStateRoot}`);
 		expect(unit).toContain("ProtectSystem=strict");
+		expect(unit).toContain("PrivatePIDs=true");
 		expect(unit).toContain("CapabilityBoundingSet=");
 		expect(unit).toContain("TasksMax=128");
 		expect(unit).toContain(

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -77,7 +77,6 @@ export interface RuntimePaths {
 	projectionRoot: string;
 	runRoot: string;
 	convergeLock: string;
-	fileBrowserAclTempPrefix: string;
 	managedSecretRoot: string;
 	daemonStateRoot: string;
 	egressRoot: string;
@@ -240,7 +239,6 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 		projectionRoot: join(configurationRoot, "projections"),
 		runRoot,
 		convergeLock: join(runRoot, "locks", "converge.lock"),
-		fileBrowserAclTempPrefix: join(runRoot, ".filebrowser-acl-"),
 		managedSecretRoot: join(runRoot, "secrets"),
 		daemonStateRoot: join(serviceStateRoot, "daemon"),
 		egressRoot: join(runRoot, "egress"),

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -17,7 +17,6 @@ import { stripTerminalEscapes } from "../lib/sanitize";
 import { ensureDirectoryWithinTrustedRoot } from "../lib/trusted-directory";
 import { runtimeContentSha256 } from "./applied-state";
 import { applyEgressTransparentRuntimeEnv } from "./egress-env";
-import { FILE_BROWSER_SERVICE_GROUP, FILE_BROWSER_SERVICE_USER } from "./file-browser-isolation";
 import type { RuntimeInstallReceiptEntry, RuntimeInstallReceipts } from "./install-receipts";
 import type { RuntimeManifest } from "./manifest-contract";
 import type { RuntimeMitmproxyEnsureResult } from "./mitmproxy-fetch";
@@ -1535,16 +1534,18 @@ function writeFileBrowserSystemdUnit(input: {
 }): string {
 	const companion = input.manifest.companions?.filebrowser;
 	if (!companion) throw new Error("Files systemd unit requires a companion manifest");
+	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
+	if (runtimeUser === "root" || runtimeUser === "0") {
+		throw new Error("Files systemd unit requires a non-root tenant runtime user");
+	}
+	const serviceConfig = join(dirname(input.paths.fileBrowserServiceBinary), "filebrowser.yaml");
 	return writeSystemdSystemUnit({
 		paths: input.paths,
 		name: "clawdi-files",
 		description: "Clawdi hosted Files companion",
 		command: input.program.command,
 		args: input.program.args,
-		execStart: fileBrowserSystemdExec(
-			input.paths.fileBrowserServiceBinary,
-			input.paths.fileBrowserConfig,
-		),
+		execStart: fileBrowserSystemdExec(input.paths.fileBrowserServiceBinary, serviceConfig),
 		cwd: input.program.cwd,
 		directoryKind: "file-browser",
 		env: {
@@ -1555,11 +1556,12 @@ function writeFileBrowserSystemdUnit(input: {
 		},
 		extraUnitLines: ["After=network-online.target", "Wants=network-online.target"],
 		extraServiceLines: [
-			`User=${FILE_BROWSER_SERVICE_USER}`,
-			`Group=${FILE_BROWSER_SERVICE_GROUP}`,
+			`User=${runtimeUser}`,
+			`Group=${runtimeUserGid(runtimeUser)}`,
 			// Publish only this verified executable into the component service's
 			// private runtime directory; the platform state root stays untraversable.
 			`BindReadOnlyPaths=${systemdPath(input.program.command)}:${systemdPath(input.paths.fileBrowserServiceBinary)}:norbind`,
+			`BindReadOnlyPaths=${systemdPath(input.paths.fileBrowserConfig)}:${systemdPath(serviceConfig)}:norbind`,
 			`ExecStartPre=${fileBrowserVersionProbeExec(
 				input.paths.fileBrowserServiceBinary,
 				companion.version,
@@ -1582,6 +1584,7 @@ function writeFileBrowserSystemdUnit(input: {
 			"ProtectHostname=true",
 			"ProtectProc=invisible",
 			"ProcSubset=pid",
+			"PrivatePIDs=true",
 			"LockPersonality=true",
 			"RestrictSUIDSGID=true",
 			"RestrictRealtime=true",

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -437,7 +437,7 @@ test("persists and serves the managed token through the real official OpenClaw g
 	}
 }, 60_000);
 
-test("isolates File Browser from the tenant while preserving workspace access", () => {
+test("runs Files as the tenant while preserving platform isolation", () => {
 	if (process.env[REAL_SYSTEMD_GATE] !== "1") return;
 
 	expect(process.geteuid?.()).toBe(0);
@@ -450,6 +450,13 @@ test("isolates File Browser from the tenant while preserving workspace access", 
 	const tenantExisting = join(runtimeHome, "files-tenant-existing.txt");
 	writeFileSync(tenantExisting, "tenant-existing\n", { mode: 0o600 });
 	chownSync(tenantExisting, runtimeUid, runtimeGid);
+	const rootOwnedControl = join(runtimeHome, "files-root-owned-control.txt");
+	writeFileSync(rootOwnedControl, "root-owned\n", { mode: 0o600 });
+	const hermesConfig = join(runtimeHome, ".hermes", "config.yaml");
+	mkdirSync(dirname(hermesConfig), { recursive: true, mode: 0o700 });
+	chownSync(dirname(hermesConfig), runtimeUid, runtimeGid);
+	writeFileSync(hermesConfig, "model: test\n", { mode: 0o600 });
+	chownSync(hermesConfig, runtimeUid, runtimeGid);
 
 	process.env.CLAWDI_RUNTIME_MODE = "hosted";
 	process.env.CLAWDI_RUNTIME_USER = "clawdi";
@@ -532,6 +539,14 @@ const listen = config.match(/^\\s*listen:\\s*(\\S+)\\s*$/m)?.[1];
 const port = Number(config.match(/^\\s*port:\\s*(\\d+)\\s*$/m)?.[1]);
 if (!listen || !Number.isInteger(port)) process.exit(64);
 const existing = fs.readFileSync(${JSON.stringify(tenantExisting)}, "utf8");
+const hermes = fs.readFileSync(${JSON.stringify(hermesConfig)}, "utf8");
+fs.writeFileSync(${JSON.stringify(hermesConfig)}, hermes);
+try {
+  fs.readFileSync(${JSON.stringify(rootOwnedControl)});
+  process.exit(77);
+} catch (error) {
+  if (error?.code !== "EACCES") throw error;
+}
 fs.writeFileSync(${JSON.stringify(serviceCreated)}, existing);
 fs.mkdirSync(${JSON.stringify(join(runtimeHome, "tmp", "thumbnails"))}, { recursive: true });
 fs.writeFileSync(${JSON.stringify(join(runtimeHome, "tmp", "thumbnails", "preview.jpg"))}, "preview\\n");
@@ -724,24 +739,18 @@ http.createServer((request, response) => {
 	expect(tenantClawdiAfterConverge.status).not.toBe(0);
 	expect(tenantClawdiAfterConverge.stdout).toBe("");
 
-	const serviceIdentity = spawnSync("getent", ["passwd", "clawdi-files"], {
-		encoding: "utf8",
-	});
-	expect(serviceIdentity.status).toBe(0);
-	const serviceFields = serviceIdentity.stdout.trim().split(":");
-	const serviceUid = Number.parseInt(serviceFields[2] ?? "", 10);
-	const serviceGid = Number.parseInt(serviceFields[3] ?? "", 10);
-	expect(serviceUid).not.toBe(runtimeUid);
-	expect(serviceUid).not.toBe(0);
-	expect(serviceGid).not.toBe(runtimeGid);
-	expect(serviceFields[5]).toBe("/nonexistent");
-	expect(serviceFields[6]).toBe("/usr/sbin/nologin");
-	const tenantGroups = spawnSync("id", ["-G", "clawdi"], { encoding: "utf8" });
-	expect(tenantGroups.status).toBe(0);
-	expect(tenantGroups.stdout.trim().split(/\s+/)).not.toContain(String(serviceGid));
-	const serviceGroups = spawnSync("id", ["-G", "clawdi-files"], { encoding: "utf8" });
-	expect(serviceGroups.status).toBe(0);
-	expect(serviceGroups.stdout.trim().split(/\s+/)).toEqual([String(serviceGid)]);
+	expect(spawnSync("getent", ["passwd", "clawdi-files"]).status).not.toBe(0);
+	for (const config of [openClawConfig, hermesConfig]) {
+		for (const access of ["-r", "-w"] as const) {
+			expect(spawnSync("runuser", ["-u", "clawdi", "--", "test", access, config]).status).toBe(0);
+		}
+		expect(spawnSync("runuser", ["-u", "clawdi", "--", "test", "-x", dirname(config)]).status).toBe(
+			0,
+		);
+	}
+	expect(
+		spawnSync("runuser", ["-u", "clawdi", "--", "test", "!", "-r", rootOwnedControl]).status,
+	).toBe(0);
 
 	const candidatesRoot = join(paths.fileBrowserInstallRoot, "candidates");
 	const activeCandidate = join(candidatesRoot, binarySha256);
@@ -759,21 +768,13 @@ http.createServer((request, response) => {
 		expect(statSync(path).gid).toBe(0);
 	}
 	expect(statSync(paths.fileBrowserConfigRoot).uid).toBe(0);
-	expect(statSync(paths.fileBrowserConfigRoot).gid).toBe(serviceGid);
-	expect(statSync(paths.fileBrowserConfigRoot).mode & 0o777).toBe(0o750);
+	expect(statSync(paths.fileBrowserConfigRoot).gid).toBe(0);
+	expect(statSync(paths.fileBrowserConfigRoot).mode & 0o777).toBe(0o700);
 	expect(statSync(paths.fileBrowserConfig).uid).toBe(0);
-	expect(statSync(paths.fileBrowserConfig).gid).toBe(serviceGid);
+	expect(statSync(paths.fileBrowserConfig).gid).toBe(runtimeGid);
 	expect(statSync(paths.fileBrowserConfig).mode & 0o777).toBe(0o440);
-	expect(
-		spawnSync("runuser", ["-u", "clawdi-files", "--", "test", "-r", paths.fileBrowserConfigRoot])
-			.status,
-	).toBe(0);
-	expect(
-		spawnSync("runuser", ["-u", "clawdi-files", "--", "test", "-r", paths.fileBrowserConfig])
-			.status,
-	).toBe(0);
-	expect(statSync(paths.fileBrowserStateRoot).uid).toBe(serviceUid);
-	expect(statSync(paths.fileBrowserStateRoot).gid).toBe(serviceGid);
+	expect(statSync(paths.fileBrowserStateRoot).uid).toBe(runtimeUid);
+	expect(statSync(paths.fileBrowserStateRoot).gid).toBe(runtimeGid);
 	expect(statSync(paths.fileBrowserStateRoot).mode & 0o777).toBe(0o700);
 	expect(statSync(receipt).mode & 0o777).toBe(0o600);
 	expect(statSync(paths.manifestLastGood).mode & 0o777).toBe(0o600);
@@ -781,8 +782,8 @@ http.createServer((request, response) => {
 	const cache = join(paths.fileBrowserStateRoot, "cache");
 	const database = join(paths.fileBrowserStateRoot, "filebrowser.db");
 	for (const path of [cache, database]) {
-		expect(statSync(path).uid).toBe(serviceUid);
-		expect(statSync(path).gid).toBe(serviceGid);
+		expect(statSync(path).uid).toBe(runtimeUid);
+		expect(statSync(path).gid).toBe(runtimeGid);
 	}
 	expect(statSync(cache).mode & 0o777).toBe(0o700);
 	expect(statSync(database).mode & 0o777).toBe(0o600);
@@ -790,8 +791,6 @@ http.createServer((request, response) => {
 	for (const path of [
 		paths.fileBrowserConfigRoot,
 		paths.fileBrowserConfig,
-		paths.fileBrowserStateRoot,
-		database,
 		receipt,
 		paths.manifestLastGood,
 	]) {
@@ -804,8 +803,6 @@ http.createServer((request, response) => {
 		activeCandidate,
 		activeBinary,
 		paths.fileBrowserConfig,
-		paths.fileBrowserStateRoot,
-		database,
 		receipt,
 		paths.manifestLastGood,
 		join(paths.systemdSystemRoot, "clawdi-files.service"),
@@ -833,9 +830,7 @@ http.createServer((request, response) => {
 	expect(mainPidResult.status).toBe(0);
 	const mainPid = Number.parseInt(mainPidResult.stdout.trim(), 10);
 	expect(mainPid).toBeGreaterThan(1);
-	expect(statSync(`/proc/${mainPid}`).uid).toBe(serviceUid);
-	const signal = spawnSync("runuser", ["-u", "clawdi", "--", "kill", "-TERM", String(mainPid)]);
-	expect(signal.status).not.toBe(0);
+	expect(statSync(`/proc/${mainPid}`).uid).toBe(runtimeUid);
 	const unitControl = spawnSync(
 		"runuser",
 		["-u", "clawdi", "--", "systemctl", "stop", "clawdi-files.service"],
@@ -848,8 +843,15 @@ http.createServer((request, response) => {
 	});
 	expect(effectiveUnit.status).toBe(0);
 	expect(effectiveUnit.stdout).toContain("/run/systemd/system/service.d/zzz-lxc-service.conf");
+	expect(effectiveUnit.stdout).toContain("PrivatePIDs=true");
+	expect(effectiveUnit.stdout).toContain(
+		`BindReadOnlyPaths=${paths.fileBrowserConfig}:${dirname(paths.fileBrowserServiceBinary)}/filebrowser.yaml:norbind`,
+	);
 	expect(effectiveUnit.stdout).toContain("LoadCredential=");
 	expect(existsSync("/run/credentials/clawdi-files.service/filebrowser.yaml")).toBe(false);
+	const configMountPoint = join(dirname(paths.fileBrowserServiceBinary), "filebrowser.yaml");
+	expect(statSync(configMountPoint).isFile()).toBe(true);
+	expect(readFileSync(configMountPoint, "utf8")).toBe("");
 
 	let readinessStatus: number | null = null;
 	for (let attempt = 0; attempt < 50; attempt++) {

--- a/packages/cli/tests/fixtures/runtime-official-installer-systemd/Dockerfile
+++ b/packages/cli/tests/fixtures/runtime-official-installer-systemd/Dockerfile
@@ -2,7 +2,7 @@ ARG BUN_VERSION=1.3.14
 ARG NODE_VERSION=24.18.0
 
 FROM oven/bun:${BUN_VERSION} AS bun
-FROM node:${NODE_VERSION}-bookworm
+FROM node:${NODE_VERSION}-trixie
 
 COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=bun /usr/local/bin/bunx /usr/local/bin/bunx


### PR DESCRIPTION
## Summary

- run the managed Files service as the hosted runtime UID/GID so all tenant-owned home content, including strict-mode dotfiles, is natively readable and writable
- remove recursive POSIX ACL convergence and dedicated clawdi-files account creation
- keep the binary and JWT config source root-managed, publishing the config only through a unit-private read-only bind
- retain the systemd sandbox and add PrivatePIDs; bump the CLI to 0.13.59

Existing deployments converge through the normal manifest path: the unit identity, config ownership, and StateDirectory ownership are repaired without scanning or rewriting the tenant home.

## Verification

- Biome and git diff check
- non-root isolated manifest reconciliation: 173 pass, 0 fail
- CLI TypeScript typecheck
- real trixie/systemd lifecycle: 3 pass, 0 fail (official installer rollback, OpenClaw gateway, Files UID/home/config isolation)