### PR TITLE
feat(web): unified subscription center in Settings

### DIFF
--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -884,6 +884,56 @@ describe("declarative deployment mutations", () => {
 	});
 });
 
+describe("account compute subscriptions", () => {
+	it("lists subscriptions and targets cancel or resume by subscription id", async () => {
+		const requests: Request[] = [];
+		const client = testClient(async (request) => {
+			requests.push(request.clone());
+			const path = new URL(request.url).pathname;
+			if (path === "/v2/subscriptions") {
+				return jsonResponse([
+					{
+						subscription_id: "csub_test",
+						plan_slug: "compute_performance",
+						status: "active",
+						price_cents: 2_000,
+						currency: "usd",
+						billing_term_months: 1,
+						current_period_end: "2026-08-22T00:00:00Z",
+						cancel_at_period_end: false,
+						deployment_id: null,
+						is_orphan: true,
+					},
+				]);
+			}
+			return jsonResponse({
+				status: "active",
+				funding_source: "stripe",
+				billing_term_months: 1,
+				cancel_at_period_end: path.endsWith("/cancel"),
+				current_period_end: "2026-08-22T00:00:00Z",
+			});
+		});
+
+		await expect(client.getSubscriptions()).resolves.toEqual([
+			expect.objectContaining({ subscription_id: "csub_test", is_orphan: true }),
+		]);
+		await client.cancelSubscription({ subscription_id: "csub_test" });
+		await client.resumeSubscription({ subscription_id: "csub_test" });
+
+		expect(requests.map((request) => [request.method, new URL(request.url).pathname])).toEqual([
+			["GET", "/v2/subscriptions"],
+			["POST", "/v2/subscription/cancel"],
+			["POST", "/v2/subscription/resume"],
+		]);
+		expect(await requests[1]?.json()).toEqual({ subscription_id: "csub_test" });
+		expect(await requests[2]?.json()).toEqual({ subscription_id: "csub_test" });
+		expect(
+			requests.every((request) => request.headers.get("Authorization") === "Bearer test-token"),
+		).toBe(true);
+	});
+});
+
 describe("compute plan changes", () => {
 	it("accepts once and waits through awaiting_payment for terminal success", async () => {
 		const requests: Request[] = [];

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -591,6 +591,7 @@ export function createBillingClient(
 		setAutoReload: async (body: WalletAutoReloadRequest) =>
 			unwrapDeploy(await api.PUT("/v2/wallet/auto-reload", { body })),
 
+		getSubscriptions: async () => unwrapDeploy(await api.GET("/v2/subscriptions")),
 		getPlans: async () => unwrapDeploy(await api.GET("/v2/subscription/plans")),
 		getBillingHistory: async (limit = 20, cursor?: string | null) =>
 			unwrapDeploy(

--- a/apps/web/src/hosted/billing/contracts.ts
+++ b/apps/web/src/hosted/billing/contracts.ts
@@ -13,6 +13,7 @@ export type CheckoutRequest = Schemas["V2ComputeCheckoutRequest"];
 export type ComputePlanSlug = Schemas["V2HostedDeployRequest"]["compute_plan_slug"];
 export type ComputeSubscriptionActionResult = Schemas["V2ComputeSubscriptionActionResponse"];
 export type ComputeSubscriptionCancelRequest = Schemas["V2ComputeSubscriptionCancelRequest"];
+export type ComputeSubscriptionListItem = Schemas["V2ComputeSubscriptionListItem"];
 export type ComputeFixPaymentRequest = Schemas["V2ComputeFixPaymentRequest"];
 export type ComputeBillingHistoryItem = Schemas["V2ComputeBillingHistoryItem"];
 export type ComputePlanChangeRequest = Schemas["V2ComputePlanChangeRequest"];

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -171,6 +171,14 @@ export function usePlans() {
 	});
 }
 
+export function useSubscriptions() {
+	const client = useBillingClient();
+	return useBillingQuery({
+		queryKey: billingKeys.subscriptions,
+		queryFn: () => client.getSubscriptions(),
+	});
+}
+
 export function useSubscriptionCreateQuote(
 	selection: SubscriptionCreateSelection | null,
 	{ enabled = true }: { enabled?: boolean } = {},
@@ -236,7 +244,10 @@ export function useCancelSubscription() {
 	return useMutation({
 		mutationFn: (body: ComputeSubscriptionCancelRequest) => client.cancelSubscription(body),
 		onSuccess: (next, body) => {
-			applyDeploymentSubscriptionResult(qc, body.deployment_id, next);
+			if (body.deployment_id) {
+				applyDeploymentSubscriptionResult(qc, body.deployment_id, next);
+			}
+			qc.invalidateQueries({ queryKey: billingKeys.subscriptions });
 		},
 	});
 }
@@ -261,7 +272,10 @@ export function useResumeSubscription() {
 	return useMutation({
 		mutationFn: (body: ComputeSubscriptionResumeRequest) => client.resumeSubscription(body),
 		onSuccess: (next, body) => {
-			applyDeploymentSubscriptionResult(qc, body.deployment_id, next);
+			if (body.deployment_id) {
+				applyDeploymentSubscriptionResult(qc, body.deployment_id, next);
+			}
+			qc.invalidateQueries({ queryKey: billingKeys.subscriptions });
 		},
 	});
 }

--- a/apps/web/src/hosted/billing/query-keys.ts
+++ b/apps/web/src/hosted/billing/query-keys.ts
@@ -15,6 +15,7 @@ export const billingKeys = {
 	billingHistoryRoot,
 	billingHistory: (limit: number) => [...billingHistoryRoot, limit] as const,
 	plans: ["billing", "plans"] as const,
+	subscriptions: ["billing", "subscriptions"] as const,
 	deployments: ["billing", "deployments"] as const,
 	workspaceSkills: (deploymentId: string) =>
 		["hosted", "deployments", deploymentId, "skills"] as const,

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -2,11 +2,14 @@
 
 import { Check, Cpu, Zap } from "lucide-react";
 import { useMemo } from "react";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { SettingsSection } from "@/components/settings-section";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
 import type { Plan } from "@/hosted/billing/contracts";
 import { computePricePresentation } from "@/hosted/billing/deploy/deploy-price-presentation";
+import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { usePlans } from "@/hosted/billing/hooks";
 import {
 	commonExplicitBillingOffers,
@@ -14,6 +17,7 @@ import {
 	resolveBasicPlan,
 	resolvePerformancePlan,
 } from "@/hosted/billing/subscription/subscription-utils";
+import { shouldBlockQueryError } from "@/lib/query-state";
 
 function partitionPlans(plans: Plan[]): { basic?: Plan; performance?: Plan } {
 	return {
@@ -50,7 +54,29 @@ export function PlanComparison({
 		[plansQuery.data],
 	);
 
-	if (!plansQuery.data) return null;
+	if (plansQuery.isLoading) {
+		return (
+			<SettingsSection headingLevel={3} title="Plans" description="Compare hosted compute plans.">
+				<div className="grid gap-3 lg:grid-cols-2">
+					<Skeleton className="h-72 w-full rounded-lg" />
+					<Skeleton className="h-72 w-full rounded-lg" />
+				</div>
+			</SettingsSection>
+		);
+	}
+
+	if (shouldBlockQueryError(plansQuery.error, plansQuery.data)) {
+		return (
+			<SettingsSection headingLevel={3} title="Plans" description="Compare hosted compute plans.">
+				<ApiErrorPanel
+					normalizer={billingErrorNormalizer}
+					error={plansQuery.error}
+					onRetry={() => void plansQuery.refetch()}
+					title="Couldn't load plans"
+				/>
+			</SettingsSection>
+		);
+	}
 
 	const basicOffers = basic ? explicitPlanOffers(basic) : [];
 	const performanceOffers = performance ? explicitPlanOffers(performance) : [];
@@ -79,7 +105,7 @@ export function PlanComparison({
 		<SettingsSection
 			data-hosted="true"
 			headingLevel={3}
-			title="Compare compute plans"
+			title="Plans"
 			actions={
 				commonOffers.length > 1 && selectedTerm !== null ? (
 					<div className="w-56">
@@ -96,7 +122,7 @@ export function PlanComparison({
 			description={
 				sharedPricingUnavailable
 					? "A shared Basic and Performance billing term is not currently available."
-					: undefined
+					: "Compare hosted compute plans before starting another agent."
 			}
 		>
 			<div>

--- a/apps/web/src/hosted/billing/subscription/subscription-page.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-page.tsx
@@ -4,26 +4,22 @@ import { Link } from "@tanstack/react-router";
 import { CreditCard, Rocket } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
-import { ApiErrorPanel } from "@/components/api-error-panel";
 import { SettingsPanelHeader } from "@/components/settings/settings-panel-header";
 import { SettingsSection } from "@/components/settings-section";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
-import { SubscriptionSkeleton } from "@/hosted/billing/components/state-views";
-import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
-import { usePlans } from "@/hosted/billing/hooks";
+import { normalizeBillingError } from "@/hosted/billing/errors";
 import { useSensitiveBillingPortal } from "@/hosted/billing/sensitive-actions";
 import { BillingHistorySection } from "@/hosted/billing/subscription/billing-history-section";
 import { PlanComparison } from "@/hosted/billing/subscription/plan-comparison";
+import { SubscriptionsSection } from "@/hosted/billing/subscription/subscriptions-section";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
-import { shouldBlockQueryError } from "@/lib/query-state";
 
-const DESCRIPTION = "Plans and account billing for hosted agents.";
+const DESCRIPTION = "Subscriptions, plans, and account billing for hosted agents.";
 const SUBSCRIPTION_PAGE_CLASS = "flex flex-col gap-8 px-5 sm:px-6 lg:px-8";
 
 export function SubscriptionPage() {
-	const plans = usePlans();
 	const portal = useSensitiveBillingPortal();
 	const hostedAccess = useHostedProductAccess();
 	const runAction = useActionLock();
@@ -44,61 +40,42 @@ export function SubscriptionPage() {
 		}
 	}
 
-	if (plans.isLoading) {
-		return (
-			<div data-hosted="true" className={SUBSCRIPTION_PAGE_CLASS}>
-				<SettingsPanelHeader title="Compute" description={DESCRIPTION} />
-				<SubscriptionSkeleton />
-			</div>
-		);
-	}
-
-	if (shouldBlockQueryError(plans.error, plans.data)) {
-		return (
-			<div data-hosted="true" className={SUBSCRIPTION_PAGE_CLASS}>
-				<SettingsPanelHeader title="Compute" description={DESCRIPTION} />
-				<ApiErrorPanel
-					normalizer={billingErrorNormalizer}
-					error={plans.error}
-					onRetry={() => plans.refetch()}
-					title="Couldn’t load plans"
-				/>
-			</div>
-		);
-	}
-
 	return (
 		<div data-hosted="true" className={SUBSCRIPTION_PAGE_CLASS}>
 			<SettingsPanelHeader title="Compute" description={DESCRIPTION} />
 
-			<SettingsSection
-				headingLevel={3}
-				title="Manage compute"
-				description="Deploy a new hosted agent here. Manage existing plans from each agent’s Settings."
-			>
-				<div className="flex flex-wrap gap-2">
-					{hostedAccess.canCreateCloudAgents ? (
-						<Button render={<Link to="/deploy" />} nativeButton={false}>
-							<Rocket /> Deploy hosted agent
-						</Button>
-					) : (
-						<Button disabled>
-							<Rocket /> Deploy hosted agent
-						</Button>
-					)}
+			<SubscriptionsSection
+				actions={
 					<Button
 						variant="outline"
+						size="sm"
 						onClick={() => runAction(openBillingPortal)}
 						disabled={portal.isPending}
 					>
 						{portal.isPending ? <Spinner /> : <CreditCard />} Open billing portal
 					</Button>
-				</div>
+				}
+			/>
+
+			<SettingsSection
+				headingLevel={3}
+				title="Start a new agent"
+				description="Choose a compute plan and deploy another hosted agent."
+			>
+				{hostedAccess.canCreateCloudAgents ? (
+					<Button render={<Link to="/deploy" />} nativeButton={false}>
+						<Rocket /> Deploy hosted agent
+					</Button>
+				) : (
+					<Button disabled>
+						<Rocket /> Deploy hosted agent
+					</Button>
+				)}
 			</SettingsSection>
 
-			<BillingHistorySection />
-
 			<PlanComparison term={term} onTermChange={setTerm} />
+
+			<BillingHistorySection />
 		</div>
 	);
 }

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -3,6 +3,8 @@ import type { BillingOffer, HostedComputeSubscription, Plan } from "@/hosted/bil
 import {
 	COMPUTE_BASIC_SLUG,
 	COMPUTE_PERFORMANCE_SLUG,
+	canCancelAccountSubscription,
+	canResumeAccountSubscription,
 	commonExplicitBillingOffers,
 	computeFundingMode,
 	computeFundingSource,
@@ -343,6 +345,40 @@ describe("compute subscription action status gates", () => {
 		expect(isComputeSubscriptionTermChangeable({ status: "past_due" })).toBe(false);
 		expect(isComputeSubscriptionTermChangeable({ status: "unpaid" })).toBe(false);
 		expect(isComputeSubscriptionTermChangeable(undefined)).toBe(false);
+	});
+
+	test("offers account resume only for a canceling subscription bound to a live agent", () => {
+		const liveCanceling = {
+			status: "canceling" as const,
+			cancel_at_period_end: true,
+			deployment_id: "hdep_live",
+			is_orphan: false,
+		};
+
+		expect(canResumeAccountSubscription(liveCanceling)).toBe(true);
+		expect(canResumeAccountSubscription({ ...liveCanceling, deployment_id: null })).toBe(false);
+		expect(canResumeAccountSubscription({ ...liveCanceling, is_orphan: true })).toBe(false);
+		expect(
+			canResumeAccountSubscription({
+				...liveCanceling,
+				status: "active",
+				cancel_at_period_end: false,
+			}),
+		).toBe(false);
+	});
+
+	test("keeps cancellation available for active orphan subscriptions without repeating it", () => {
+		const orphan = {
+			status: "active" as const,
+			cancel_at_period_end: false,
+			deployment_id: null,
+			is_orphan: true,
+		};
+
+		expect(canCancelAccountSubscription(orphan)).toBe(true);
+		expect(canCancelAccountSubscription({ ...orphan, cancel_at_period_end: true })).toBe(false);
+		expect(canCancelAccountSubscription({ ...orphan, status: "canceling" })).toBe(false);
+		expect(canCancelAccountSubscription({ ...orphan, status: "canceled" })).toBe(false);
 	});
 });
 

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -3,6 +3,7 @@ import {
 	COMPUTE_BASIC_SLUG,
 	COMPUTE_PERFORMANCE_SLUG,
 	type ComputePlanSlug,
+	type ComputeSubscriptionListItem,
 	type HostedComputeSubscription,
 	type Plan,
 } from "@/hosted/billing/contracts";
@@ -33,6 +34,27 @@ export function isComputeSubscriptionTermChangeable(
 	subscription: ComputeSubscriptionStatusInput,
 ): boolean {
 	return COMPUTE_SUBSCRIPTION_TERM_CHANGEABLE_STATUSES.has(subscription?.status ?? "");
+}
+
+type AccountSubscriptionActionState = Pick<
+	ComputeSubscriptionListItem,
+	"cancel_at_period_end" | "deployment_id" | "is_orphan" | "status"
+>;
+
+export function canCancelAccountSubscription(
+	subscription: AccountSubscriptionActionState,
+): boolean {
+	return !subscription.cancel_at_period_end && isComputeSubscriptionCancelable(subscription);
+}
+
+export function canResumeAccountSubscription(
+	subscription: AccountSubscriptionActionState,
+): boolean {
+	return (
+		!subscription.is_orphan &&
+		Boolean(subscription.deployment_id) &&
+		(subscription.cancel_at_period_end || subscription.status === "canceling")
+	);
 }
 
 export function resolveBasicPlan(plans: Plan[] | undefined): Plan | undefined {

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { Link } from "@tanstack/react-router";
+import { CreditCard, Link2Off, RefreshCw } from "lucide-react";
+import type { ReactNode } from "react";
+import { toast } from "sonner";
+import { ApiErrorPanel } from "@/components/api-error-panel";
+import { EmptyState } from "@/components/empty-state";
+import { SettingsSection } from "@/components/settings-section";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ConfirmAction } from "@/components/ui/confirm-action";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+import { StatusBadge, type StatusTone } from "@/components/ui/status-badge";
+import type { ComputeSubscriptionListItem } from "@/hosted/billing/contracts";
+import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
+import { billingTermLabel, billingTermSuffix, formatCents } from "@/hosted/billing/format";
+import {
+	useCancelSubscription,
+	useResumeSubscription,
+	useSubscriptions,
+} from "@/hosted/billing/hooks";
+import {
+	canCancelAccountSubscription,
+	canResumeAccountSubscription,
+	computeTierLabel,
+} from "@/hosted/billing/subscription/subscription-utils";
+import { useActionLock } from "@/hosted/billing/use-action-lock";
+import { agentSectionLink } from "@/lib/agent-routes";
+import { formatShortDate } from "@/lib/format";
+import { shouldBlockQueryError } from "@/lib/query-state";
+
+const SUBSCRIPTION_GRID_CLASS =
+	"grid gap-4 lg:grid-cols-[minmax(10rem,1.35fr)_minmax(9rem,1fr)_minmax(7rem,.65fr)_minmax(8rem,.8fr)_minmax(9rem,auto)] lg:items-center";
+
+const STATUS_PRESENTATION: Record<
+	ComputeSubscriptionListItem["status"],
+	{ label: string; tone: StatusTone }
+> = {
+	active: { label: "Active", tone: "success" },
+	canceling: { label: "Canceling", tone: "warning" },
+	past_due: { label: "Past due", tone: "destructive" },
+	canceled: { label: "Canceled", tone: "neutral" },
+};
+
+function planLabel(planSlug: string): string {
+	if (planSlug === "compute_basic" || planSlug === "compute_performance") {
+		return `Compute ${computeTierLabel(planSlug)}`;
+	}
+	return planSlug.replace(/^compute_/, "").replaceAll("_", " ");
+}
+
+function priceLabel(subscription: ComputeSubscriptionListItem): string {
+	if (subscription.price_cents == null) return "Unavailable";
+	if (subscription.currency.toLowerCase() === "usd") {
+		return `${formatCents(subscription.price_cents)}${billingTermSuffix(subscription.billing_term_months)}`;
+	}
+	try {
+		const amount = new Intl.NumberFormat("en-US", {
+			style: "currency",
+			currency: subscription.currency,
+		}).format(subscription.price_cents / 100);
+		return `${amount}${billingTermSuffix(subscription.billing_term_months)}`;
+	} catch {
+		return `${(subscription.price_cents / 100).toFixed(2)} ${subscription.currency.toUpperCase()}${billingTermSuffix(subscription.billing_term_months)}`;
+	}
+}
+
+function periodLabel(subscription: ComputeSubscriptionListItem): string {
+	if (!subscription.current_period_end) return "Unavailable";
+	const date = formatShortDate(subscription.current_period_end);
+	if (subscription.status === "canceling") return `Ends ${date}`;
+	if (subscription.status === "canceled") return `Ended ${date}`;
+	if (subscription.status === "past_due") return `Due ${date}`;
+	return `Renews ${date}`;
+}
+
+function FieldLabel({ children }: { children: ReactNode }) {
+	return <div className="mb-1 text-xs font-medium text-muted-foreground lg:hidden">{children}</div>;
+}
+
+function SubscriptionActions({ subscription }: { subscription: ComputeSubscriptionListItem }) {
+	const cancelSubscription = useCancelSubscription();
+	const resumeSubscription = useResumeSubscription();
+	const runAction = useActionLock();
+	const canCancel = canCancelAccountSubscription(subscription);
+	const canResume = canResumeAccountSubscription(subscription);
+	const pending = cancelSubscription.isPending || resumeSubscription.isPending;
+
+	async function cancel() {
+		try {
+			const result = await cancelSubscription.mutateAsync({
+				subscription_id: subscription.subscription_id,
+			});
+			toast.success(
+				result.cancel_at_period_end ? "Cancellation scheduled" : "Subscription canceled",
+				{
+					description: result.current_period_end
+						? `Access continues through ${formatShortDate(result.current_period_end)}.`
+						: undefined,
+				},
+			);
+		} catch (error) {
+			toast.error("Couldn't cancel subscription", { description: normalizeBillingError(error) });
+			throw error;
+		}
+	}
+
+	async function resume() {
+		try {
+			await resumeSubscription.mutateAsync({ subscription_id: subscription.subscription_id });
+			toast.success("Subscription resumed");
+		} catch (error) {
+			toast.error("Couldn't resume subscription", { description: normalizeBillingError(error) });
+			throw error;
+		}
+	}
+
+	if (!canCancel && !canResume) {
+		return <span className="hidden text-muted-foreground lg:inline">-</span>;
+	}
+
+	return (
+		<div className="flex flex-wrap gap-2 lg:justify-end">
+			{canResume ? (
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					disabled={pending}
+					onClick={() => void runAction(resume).catch(() => undefined)}
+				>
+					{resumeSubscription.isPending ? <Spinner /> : <RefreshCw />}
+					Resume
+				</Button>
+			) : null}
+			{canCancel ? (
+				<ConfirmAction
+					title={`Cancel ${planLabel(subscription.plan_slug)} subscription?`}
+					description={
+						<p>
+							The subscription will stop renewing
+							{subscription.current_period_end
+								? ` and remain active through ${formatShortDate(subscription.current_period_end)}`
+								: ""}
+							. This cannot restore a deleted agent.
+						</p>
+					}
+					confirmLabel="Cancel subscription"
+					destructive
+					onConfirm={() => runAction(cancel)}
+				>
+					<Button type="button" variant="outline" size="sm" disabled={pending}>
+						{cancelSubscription.isPending ? <Spinner /> : <Link2Off />}
+						Cancel
+					</Button>
+				</ConfirmAction>
+			) : null}
+		</div>
+	);
+}
+
+function SubscriptionRow({ subscription }: { subscription: ComputeSubscriptionListItem }) {
+	const status = STATUS_PRESENTATION[subscription.status];
+	const deploymentId = subscription.deployment_id;
+
+	return (
+		<li className={`${SUBSCRIPTION_GRID_CLASS} px-3 py-4`}>
+			<div className="min-w-0">
+				<FieldLabel>Subscription</FieldLabel>
+				<div className="font-medium capitalize">{planLabel(subscription.plan_slug)}</div>
+				<div className="mt-1 flex flex-wrap items-center gap-1.5">
+					<StatusBadge status={status.tone}>{status.label}</StatusBadge>
+					{subscription.is_orphan ? <Badge variant="outline">Orphaned</Badge> : null}
+				</div>
+			</div>
+			<div className="min-w-0">
+				<FieldLabel>Agent</FieldLabel>
+				{deploymentId ? (
+					<Link
+						{...agentSectionLink(deploymentId, "settings", {
+							source: "on-clawdi",
+							settings: "billing-plan",
+						})}
+						className="font-medium text-primary underline-offset-4 hover:underline"
+					>
+						View agent
+					</Link>
+				) : (
+					<span className="font-medium text-muted-foreground">Deleted agent</span>
+				)}
+			</div>
+			<div>
+				<FieldLabel>Price</FieldLabel>
+				<div className="font-medium tabular-nums">{priceLabel(subscription)}</div>
+				<div className="mt-0.5 text-xs text-muted-foreground">
+					{billingTermLabel(subscription.billing_term_months)}
+				</div>
+			</div>
+			<div>
+				<FieldLabel>Renewal / end</FieldLabel>
+				<span className="text-sm text-muted-foreground">{periodLabel(subscription)}</span>
+			</div>
+			<div>
+				<FieldLabel>Actions</FieldLabel>
+				<SubscriptionActions subscription={subscription} />
+			</div>
+		</li>
+	);
+}
+
+function SubscriptionListSkeleton() {
+	return (
+		<div className="divide-y overflow-hidden rounded-lg border">
+			{Array.from({ length: 3 }, (_, index) => `subscription-skeleton-${index}`).map((key) => (
+				<div key={key} className={`${SUBSCRIPTION_GRID_CLASS} px-3 py-4`}>
+					<Skeleton className="h-9 w-36" />
+					<Skeleton className="h-4 w-24" />
+					<Skeleton className="h-9 w-20" />
+					<Skeleton className="h-4 w-28" />
+					<Skeleton className="h-8 w-20 lg:justify-self-end" />
+				</div>
+			))}
+		</div>
+	);
+}
+
+export function SubscriptionsSection({ actions }: { actions?: ReactNode }) {
+	const subscriptions = useSubscriptions();
+
+	return (
+		<SettingsSection
+			data-hosted="true"
+			headingLevel={3}
+			title="Your subscriptions"
+			description="Manage every paid compute subscription in one place."
+			actions={actions}
+		>
+			{subscriptions.isLoading ? (
+				<SubscriptionListSkeleton />
+			) : shouldBlockQueryError(subscriptions.error, subscriptions.data) ? (
+				<ApiErrorPanel
+					normalizer={billingErrorNormalizer}
+					error={subscriptions.error}
+					onRetry={() => void subscriptions.refetch()}
+					title="Couldn't load subscriptions"
+				/>
+			) : subscriptions.data?.length ? (
+				<div className="overflow-hidden rounded-lg border">
+					<div
+						aria-hidden
+						className={`${SUBSCRIPTION_GRID_CLASS} hidden border-b bg-muted/30 px-3 py-2 text-xs font-medium text-muted-foreground lg:grid`}
+					>
+						<span>Subscription</span>
+						<span>Agent</span>
+						<span>Price</span>
+						<span>Renewal / end</span>
+						<span className="text-right">Actions</span>
+					</div>
+					<ul className="divide-y">
+						{subscriptions.data.map((subscription) => (
+							<SubscriptionRow key={subscription.subscription_id} subscription={subscription} />
+						))}
+					</ul>
+				</div>
+			) : (
+				<EmptyState
+					variant="inset"
+					icon={CreditCard}
+					title="No compute subscriptions"
+					description="Paid subscriptions will appear here when you start a hosted agent."
+					className="py-8 md:p-8"
+				/>
+			)}
+		</SettingsSection>
+	);
+}

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -450,6 +450,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v2/subscriptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List V2 Subscriptions */
+        get: operations["list_v2_subscriptions_v2_subscriptions_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v2/usage": {
         parameters: {
             query?: never;
@@ -986,6 +1003,7 @@ export interface components {
              * @default []
              */
             providers: components["schemas"]["RuntimeProviderConfiguration"][];
+            terminal_tooling?: components["schemas"]["TerminalToolingConfiguration"] | null;
             /**
              * Features
              * @default []
@@ -1021,6 +1039,15 @@ export interface components {
             name: string;
             /** Version */
             version?: string | null;
+        };
+        /** TerminalToolProviderConfiguration */
+        TerminalToolProviderConfiguration: {
+            provider: components["schemas"]["RuntimeProviderConfiguration"];
+            primary_model: components["schemas"]["ProviderModelReference"];
+        };
+        /** TerminalToolingConfiguration */
+        TerminalToolingConfiguration: {
+            codex: components["schemas"]["TerminalToolProviderConfiguration"];
         };
         /**
          * V1AgentEnvironmentsResponse
@@ -1346,12 +1373,46 @@ export interface components {
         };
         /** V2ComputeSubscriptionCancelRequest */
         V2ComputeSubscriptionCancelRequest: {
+            /** Deployment Id */
+            deployment_id?: string | null;
+            /** Subscription Id */
+            subscription_id?: string | null;
+        };
+        /** V2ComputeSubscriptionListItem */
+        V2ComputeSubscriptionListItem: {
             /**
-             * Deployment Id
+             * Subscription Id
              * Format: sqid
-             * @example hdep_K8fJ3pQm
+             * @example csub_K8fJ3pQm
              */
-            deployment_id: string;
+            subscription_id: string;
+            /** Plan Slug */
+            plan_slug: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "active" | "canceling" | "past_due" | "canceled";
+            /** Price Cents */
+            price_cents?: number | null;
+            /**
+             * Currency
+             * @default usd
+             */
+            currency: string;
+            /**
+             * Billing Term Months
+             * @enum {integer}
+             */
+            billing_term_months: 1 | 12;
+            /** Current Period End */
+            current_period_end?: string | null;
+            /** Cancel At Period End */
+            cancel_at_period_end: boolean;
+            /** Deployment Id */
+            deployment_id?: string | null;
+            /** Is Orphan */
+            is_orphan: boolean;
         };
         /** V2ComputeSubscriptionQuoteRequest */
         V2ComputeSubscriptionQuoteRequest: {
@@ -1450,12 +1511,10 @@ export interface components {
         };
         /** V2ComputeSubscriptionResumeRequest */
         V2ComputeSubscriptionResumeRequest: {
-            /**
-             * Deployment Id
-             * Format: sqid
-             * @example hdep_K8fJ3pQm
-             */
-            deployment_id: string;
+            /** Deployment Id */
+            deployment_id?: string | null;
+            /** Subscription Id */
+            subscription_id?: string | null;
         };
         /** V2DeleteDeploymentConvergedResponse */
         V2DeleteDeploymentConvergedResponse: {
@@ -1905,7 +1964,7 @@ export interface components {
             is_featured: boolean;
             /**
              * Description
-             * @description Authoritative single-sentence choice guidance from the atomic Hosted setting.
+             * @description Authoritative single-sentence choice guidance from the curated Hosted managed catalog.
              */
             description: string | null;
             /** @description Factual metadata from the bundled Hosted model catalog. */
@@ -2521,7 +2580,7 @@ export interface operations {
             };
         };
         responses: {
-            /** @description The deployment is definitively absent for the caller in both Hosted and Cloud. Repeating the delete returns the same response. */
+            /** @description The deployment is deleted for the caller. Repeating the delete returns the same response. */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -3536,6 +3595,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_v2_subscriptions_v2_subscriptions_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["V2ComputeSubscriptionListItem"][];
                 };
             };
         };

--- a/scripts/filter-deploy-openapi.py
+++ b/scripts/filter-deploy-openapi.py
@@ -76,6 +76,7 @@ KEEP_OPERATIONS_BY_PATH: dict[str, set[str]] = {
     "/v2/subscription/portal": {"post"},
     "/v2/subscription/quote": {"post"},
     "/v2/subscription/resume": {"post"},
+    "/v2/subscriptions": {"get"},
     "/v2/usage": {"get"},
     "/v2/wallet": {"get"},
     "/v2/wallet/auto-reload": {"put"},


### PR DESCRIPTION
Frontend for the unified subscription center (backend: clawdi-hosted #1669, deployed). One place to see and manage ALL subscriptions — the missing account-level view (previously only per-agent + Stripe portal; orphans were invisible).

## What
- **Your subscriptions** atop Settings → Compute: lists all via GET /v2/subscriptions — plan, status badge (active/canceling/past_due/canceled), bound agent (link, or 'Deleted agent' for orphans), price, renewal/end date, orphan indicator.
- Row actions: Cancel by subscription_id (works for orphans); Resume by subscription_id gated to !is_orphan && deployment_id && canceling (orphan resume-into-new-deployment is a backend follow-up returning 409 — never invoked from UI).
- Panel reordered: Subscriptions → Start a new agent → Plans → Billing history; Stripe portal in section header.
- **SSOT**: per-agent ComputeSettingsSections reuse the SAME billing-client cancel/resume methods — no duplicated logic.
- Regenerated deploy API client from live openapi (scoped to the subscription endpoint).

## Gates
bun run check + typecheck (4/4); web tests + OSS build; 83 focused tests pass; Playwright mock 1440px/390px (no overflow, orphan gate correct). Existing modules extended; no junk test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)