### PR TITLE
fix(runtime): fence clean boot session handoffs

### DIFF
--- a/backend/alembic/versions/b7e1c4a9d2f6_add_runtime_boot_session_handoff.py
+++ b/backend/alembic/versions/b7e1c4a9d2f6_add_runtime_boot_session_handoff.py
@@ -1,0 +1,110 @@
+"""Add causally fenced runtime boot-session handoff.
+
+Revision ID: b7e1c4a9d2f6
+Revises: a4f9c2e7d1b6
+Create Date: 2026-08-11 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b7e1c4a9d2f6"
+down_revision: str | Sequence[str] | None = "a4f9c2e7d1b6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _replace_head_guard(*, protect_successor: bool) -> None:
+    successor_guard = (
+        """
+                IF OLD.authorized_successor_boot_session_id IS NOT NULL
+                   AND NEW.authorized_successor_boot_session_id
+                        IS DISTINCT FROM OLD.authorized_successor_boot_session_id THEN
+                    RAISE EXCEPTION
+                        'v2 runtime observation authorized successor is immutable';
+                END IF;
+"""
+        if protect_successor
+        else ""
+    )
+    op.execute(
+        sa.text(
+            f"""
+            CREATE OR REPLACE FUNCTION enforce_v2_runtime_head_immutability()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    RAISE EXCEPTION 'v2 runtime observation heads are permanent';
+                END IF;
+                IF OLD.environment_id IS DISTINCT FROM NEW.environment_id
+                   OR OLD.boot_session_id IS DISTINCT FROM NEW.boot_session_id
+                   OR OLD.deployment_id IS DISTINCT FROM NEW.deployment_id
+                   OR OLD.generation IS DISTINCT FROM NEW.generation
+                   OR OLD.manifest_etag IS DISTINCT FROM NEW.manifest_etag
+                   OR OLD.apply_receipt_id IS DISTINCT FROM NEW.apply_receipt_id
+                   OR OLD.boot_nonce IS DISTINCT FROM NEW.boot_nonce
+                   OR OLD.created_at IS DISTINCT FROM NEW.created_at THEN
+                    RAISE EXCEPTION 'v2 runtime observation head binding is immutable';
+                END IF;
+{successor_guard}
+                IF OLD.state = 'retired' AND NEW IS DISTINCT FROM OLD THEN
+                    RAISE EXCEPTION 'retired v2 runtime observation head is immutable';
+                END IF;
+                IF NEW.highest_sequence < OLD.highest_sequence
+                   OR NEW.latest_stream_position < OLD.latest_stream_position THEN
+                    RAISE EXCEPTION 'v2 runtime observation head high-water cannot regress';
+                END IF;
+                IF OLD.captured_at IS NOT NULL AND NEW.state = 'active'
+                   AND (NEW.captured_at IS NULL OR NEW.captured_at < OLD.captured_at) THEN
+                    RAISE EXCEPTION 'v2 runtime observation capture time cannot regress';
+                END IF;
+                IF OLD.freshness_deadline IS NOT NULL AND NEW.state = 'active'
+                   AND (NEW.freshness_deadline IS NULL
+                        OR NEW.freshness_deadline < OLD.freshness_deadline) THEN
+                    RAISE EXCEPTION 'v2 runtime observation freshness cannot regress';
+                END IF;
+                IF NEW.state = 'active' AND NEW.highest_sequence = OLD.highest_sequence
+                   AND (NEW.latest_inbox_id IS DISTINCT FROM OLD.latest_inbox_id
+                        OR NEW.latest_stream_position IS DISTINCT FROM OLD.latest_stream_position
+                        OR NEW.latest_event_id IS DISTINCT FROM OLD.latest_event_id
+                        OR NEW.latest_payload_hash IS DISTINCT FROM OLD.latest_payload_hash
+                        OR NEW.captured_at IS DISTINCT FROM OLD.captured_at
+                        OR NEW.freshness_deadline IS DISTINCT FROM OLD.freshness_deadline
+                        OR NEW.health IS DISTINCT FROM OLD.health) THEN
+                    RAISE EXCEPTION 'v2 runtime observation head cannot rebind a sequence';
+                END IF;
+                IF NEW.state = 'active' AND NEW.highest_sequence > OLD.highest_sequence
+                   AND NEW.latest_stream_position <= OLD.latest_stream_position THEN
+                    RAISE EXCEPTION 'v2 runtime observation head stream must advance';
+                END IF;
+                IF NEW.state = 'retired'
+                   AND (NEW.highest_sequence IS DISTINCT FROM OLD.highest_sequence
+                        OR NEW.latest_stream_position IS DISTINCT FROM OLD.latest_stream_position
+                        OR NEW.latest_event_id IS DISTINCT FROM OLD.latest_event_id
+                        OR NEW.latest_payload_hash IS DISTINCT FROM OLD.latest_payload_hash) THEN
+                    RAISE EXCEPTION 'v2 runtime observation tombstone high-water is immutable';
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    op.add_column(
+        "v2_runtime_observation_heads",
+        sa.Column("authorized_successor_boot_session_id", sa.String(length=128), nullable=True),
+    )
+    _replace_head_guard(protect_successor=True)
+
+
+def downgrade() -> None:
+    _replace_head_guard(protect_successor=False)
+    op.drop_column("v2_runtime_observation_heads", "authorized_successor_boot_session_id")

--- a/backend/app/models/runtime_observation.py
+++ b/backend/app/models/runtime_observation.py
@@ -249,6 +249,7 @@ class V2RuntimeObservationHead(Base, TimestampMixin):
     manifest_etag: Mapped[str] = mapped_column(String(1024), nullable=False)
     apply_receipt_id: Mapped[str] = mapped_column(String(128), nullable=False)
     boot_nonce: Mapped[str] = mapped_column(String(128), nullable=False)
+    authorized_successor_boot_session_id: Mapped[str | None] = mapped_column(String(128))
     highest_sequence: Mapped[int] = mapped_column(BigInteger, nullable=False)
     latest_inbox_id: Mapped[int | None] = mapped_column(BigInteger)
     latest_stream_position: Mapped[int] = mapped_column(BigInteger, nullable=False)

--- a/backend/app/schemas/runtime_observation.py
+++ b/backend/app/schemas/runtime_observation.py
@@ -57,6 +57,18 @@ class RuntimeObservationEventV2(RuntimeObservationRequestModel):
     apply_receipt_id: str = Field(alias="applyReceiptId", min_length=16, max_length=128)
     boot_nonce: str = Field(alias="bootNonce", min_length=16, max_length=128)
     boot_session_id: str = Field(alias="bootSessionId", min_length=1, max_length=128)
+    successor_boot_session_id: str | None = Field(
+        alias="successorBootSessionId",
+        default=None,
+        min_length=1,
+        max_length=128,
+    )
+    predecessor_boot_session_id: str | None = Field(
+        alias="predecessorBootSessionId",
+        default=None,
+        min_length=1,
+        max_length=128,
+    )
     sequence: int = Field(ge=1, le=9_007_199_254_740_991)
     event_id: str = Field(alias="eventId", min_length=1, max_length=128)
     captured_at: datetime = Field(alias="capturedAt")
@@ -83,6 +95,10 @@ class RuntimeObservationEventV2(RuntimeObservationRequestModel):
             raise ValueError("runtime observation generation must be at least 1")
         if self.reported_at != self.captured_at:
             raise ValueError("reportedAt must equal capturedAt")
+        if self.predecessor_boot_session_id == self.boot_session_id:
+            raise ValueError("predecessorBootSessionId must differ from bootSessionId")
+        if self.successor_boot_session_id == self.boot_session_id:
+            raise ValueError("successorBootSessionId must differ from bootSessionId")
         return self
 
 

--- a/backend/app/services/runtime_observation.py
+++ b/backend/app/services/runtime_observation.py
@@ -310,6 +310,19 @@ def _head_identity_matches(
     )
 
 
+def _retire_runtime_observation_head(
+    head: V2RuntimeObservationHead,
+    *,
+    tombstoned_at: datetime,
+) -> None:
+    head.state = RUNTIME_OBSERVATION_HEAD_RETIRED
+    head.latest_inbox_id = None
+    head.captured_at = None
+    head.freshness_deadline = None
+    head.health = None
+    head.tombstoned_at = tombstoned_at
+
+
 async def ingest_runtime_observation(
     db: AsyncSession,
     *,
@@ -369,13 +382,6 @@ async def ingest_runtime_observation(
             "runtime_observation_identity_conflict",
             "boot session is already bound to another apply identity",
         )
-    if head is not None:
-        if head.state != RUNTIME_OBSERVATION_HEAD_ACTIVE:
-            raise RuntimeObservationProtocolError(
-                409,
-                "runtime_environment_retired",
-                "retired boot-session tombstones are immutable",
-            )
 
     async def duplicate_or_conflict() -> RuntimeObservationIngestResult:
         existing_by_event = (
@@ -431,6 +437,55 @@ async def ingest_runtime_observation(
     if existing_by_event is not None or existing_by_sequence is not None:
         return await duplicate_or_conflict()
 
+    if head is not None and head.state != RUNTIME_OBSERVATION_HEAD_ACTIVE:
+        raise RuntimeObservationProtocolError(
+            409,
+            "runtime_environment_retired",
+            "retired boot-session tombstones are immutable",
+        )
+    if head is not None and value.predecessor_boot_session_id is not None:
+        raise RuntimeObservationProtocolError(
+            409,
+            "runtime_observation_handoff_conflict",
+            "boot-session handoff is only valid when creating its successor",
+        )
+    if (
+        head is not None
+        and value.successor_boot_session_id is not None
+        and head.authorized_successor_boot_session_id is not None
+        and head.authorized_successor_boot_session_id != value.successor_boot_session_id
+    ):
+        raise RuntimeObservationProtocolError(
+            409,
+            "runtime_observation_successor_conflict",
+            "boot session already authorizes another successor",
+        )
+
+    predecessor: V2RuntimeObservationHead | None = None
+    if head is None and value.predecessor_boot_session_id is not None:
+        predecessor = (
+            await db.execute(
+                select(V2RuntimeObservationHead)
+                .where(
+                    V2RuntimeObservationHead.environment_id == environment_id,
+                    V2RuntimeObservationHead.boot_session_id == value.predecessor_boot_session_id,
+                )
+                .execution_options(populate_existing=True)
+                .with_for_update()
+            )
+        ).scalar_one_or_none()
+        if (
+            predecessor is None
+            or predecessor.state != RUNTIME_OBSERVATION_HEAD_ACTIVE
+            or not _head_identity_matches(predecessor, identity)
+            or predecessor.authorized_successor_boot_session_id != value.boot_session_id
+        ):
+            raise RuntimeObservationProtocolError(
+                409,
+                "runtime_observation_handoff_conflict",
+                "boot-session predecessor did not authorize this exact successor",
+            )
+
     inbox = V2RuntimeObservationInbox(
         environment_id=environment_id,
         deployment_id=fence.deployment_id,
@@ -462,6 +517,8 @@ async def ingest_runtime_observation(
     fence.stream_high_water = inbox.id
     if head is None:
         outcome = "accepted_head_created"
+        if predecessor is not None:
+            _retire_runtime_observation_head(predecessor, tombstoned_at=now)
         head = V2RuntimeObservationHead(
             environment_id=environment_id,
             deployment_id=fence.deployment_id,
@@ -470,6 +527,7 @@ async def ingest_runtime_observation(
             apply_receipt_id=identity.apply_receipt_id,
             boot_nonce=identity.boot_nonce,
             boot_session_id=value.boot_session_id,
+            authorized_successor_boot_session_id=value.successor_boot_session_id,
             highest_sequence=value.sequence,
             latest_inbox_id=inbox.id,
             latest_stream_position=inbox.id,
@@ -481,25 +539,28 @@ async def ingest_runtime_observation(
             state=RUNTIME_OBSERVATION_HEAD_ACTIVE,
         )
         db.add(head)
-    elif value.sequence > head.highest_sequence and (
-        head.captured_at is None or captured_at >= _utc(head.captured_at)
-    ):
-        outcome = "accepted_head_advanced"
-        # Every unique correctly-bound event is immutable inbox evidence. Only
-        # the compact head has a monotonic CAS rule; lower sequence or regressing
-        # capture time remains historical and cannot replace the current head.
-        head.highest_sequence = value.sequence
-        head.latest_inbox_id = inbox.id
-        head.latest_stream_position = inbox.id
-        head.latest_event_id = value.event_id
-        head.latest_payload_hash = payload_hash
-        head.captured_at = captured_at
-        head.freshness_deadline = freshness_deadline
-        head.health = value.status
-    elif value.sequence <= head.highest_sequence:
-        outcome = "accepted_non_advance_sequence"
     else:
-        outcome = "accepted_non_advance_captured_at"
+        if head.authorized_successor_boot_session_id is None:
+            head.authorized_successor_boot_session_id = value.successor_boot_session_id
+        if value.sequence > head.highest_sequence and (
+            head.captured_at is None or captured_at >= _utc(head.captured_at)
+        ):
+            outcome = "accepted_head_advanced"
+            # Every unique correctly-bound event is immutable inbox evidence. Only
+            # the compact head has a monotonic CAS rule; lower sequence or regressing
+            # capture time remains historical and cannot replace the current head.
+            head.highest_sequence = value.sequence
+            head.latest_inbox_id = inbox.id
+            head.latest_stream_position = inbox.id
+            head.latest_event_id = value.event_id
+            head.latest_payload_hash = payload_hash
+            head.captured_at = captured_at
+            head.freshness_deadline = freshness_deadline
+            head.health = value.status
+        elif value.sequence <= head.highest_sequence:
+            outcome = "accepted_non_advance_sequence"
+        else:
+            outcome = "accepted_non_advance_captured_at"
     await db.flush()
     return RuntimeObservationIngestResult(
         event_id=value.event_id,
@@ -628,12 +689,7 @@ async def retire_runtime_environment(
     fence.final_stream_position = final_position
     fence.final_session_high_waters = high_waters
     for head in heads:
-        head.state = RUNTIME_OBSERVATION_HEAD_RETIRED
-        head.latest_inbox_id = None
-        head.captured_at = None
-        head.freshness_deadline = None
-        head.health = None
-        head.tombstoned_at = now
+        _retire_runtime_observation_head(head, tombstoned_at=now)
     await db.flush()
     return RuntimeEnvironmentRetirementResult(
         receipt=receipt,

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -87,6 +87,8 @@ def _payload(
     manifest_etag: str = _MANIFEST_ETAG,
     apply_receipt_id: str = _APPLY_RECEIPT_ID,
     boot_nonce: str = _BOOT_NONCE,
+    successor_boot_session_id: str | None = None,
+    predecessor_boot_session_id: str | None = None,
     status: str = "ok",
     error: str | None = None,
 ) -> RuntimeObservationEventV2:
@@ -111,6 +113,16 @@ def _payload(
             "applyReceiptId": apply_receipt_id,
             "bootNonce": boot_nonce,
             "bootSessionId": boot_session_id,
+            **(
+                {"successorBootSessionId": successor_boot_session_id}
+                if successor_boot_session_id is not None
+                else {}
+            ),
+            **(
+                {"predecessorBootSessionId": predecessor_boot_session_id}
+                if predecessor_boot_session_id is not None
+                else {}
+            ),
             "sequence": sequence,
             "eventId": event_id or f"event-{uuid.uuid4()}",
             "capturedAt": captured.isoformat(),
@@ -259,6 +271,167 @@ async def test_unique_regressions_enter_inbox_without_regressing_head(
     assert head.captured_at == base + timedelta(seconds=3)
 
 
+@pytest.mark.asyncio
+async def test_authorized_successor_atomically_tombstones_predecessor(
+    db_session: AsyncSession,
+    seed_user,
+):
+    environment, _ = await _provision_environment(db_session, seed_user)
+    base = datetime.now(UTC)
+    predecessor = _payload(
+        boot_session_id="boot-session-predecessor",
+        successor_boot_session_id="boot-session-successor",
+        captured_at=base,
+    )
+    successor = _payload(
+        boot_session_id="boot-session-successor",
+        successor_boot_session_id="boot-session-next",
+        predecessor_boot_session_id="boot-session-predecessor",
+        captured_at=base + timedelta(seconds=1),
+    )
+    await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=predecessor,
+        received_at=base,
+    )
+    with pytest.raises(RuntimeObservationProtocolError) as rebound:
+        await ingest_runtime_observation(
+            db_session,
+            environment_id=environment.id,
+            value=_payload(
+                boot_session_id="boot-session-predecessor",
+                successor_boot_session_id="boot-session-other",
+                sequence=2,
+                captured_at=base + timedelta(seconds=1),
+            ),
+            received_at=base + timedelta(seconds=1),
+        )
+    assert rebound.value.code == "runtime_observation_successor_conflict"
+
+    accepted = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=successor,
+        received_at=base + timedelta(seconds=1),
+    )
+    await db_session.commit()
+
+    heads = {
+        head.boot_session_id: head
+        for head in (
+            (
+                await db_session.execute(
+                    select(V2RuntimeObservationHead).where(
+                        V2RuntimeObservationHead.environment_id == environment.id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    }
+    assert heads["boot-session-predecessor"].state == "retired"
+    assert heads["boot-session-predecessor"].latest_inbox_id is None
+    assert heads["boot-session-predecessor"].authorized_successor_boot_session_id == (
+        "boot-session-successor"
+    )
+    assert heads["boot-session-successor"].state == "active"
+    assert heads["boot-session-successor"].authorized_successor_boot_session_id == (
+        "boot-session-next"
+    )
+
+    replay = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=successor,
+        received_at=base + timedelta(seconds=2),
+    )
+    assert replay.outcome == "duplicate_replay"
+    assert replay.stream_position == accepted.stream_position
+
+    with pytest.raises(RuntimeObservationProtocolError) as late_predecessor:
+        await ingest_runtime_observation(
+            db_session,
+            environment_id=environment.id,
+            value=_payload(
+                boot_session_id="boot-session-predecessor",
+                sequence=2,
+                successor_boot_session_id="boot-session-successor",
+                captured_at=base + timedelta(seconds=2),
+            ),
+            received_at=base + timedelta(seconds=2),
+        )
+    assert late_predecessor.value.code == "runtime_environment_retired"
+
+
+@pytest.mark.asyncio
+async def test_handoff_cannot_hide_an_unauthorized_active_head(
+    db_session: AsyncSession,
+    seed_user,
+):
+    environment, _ = await _provision_environment(db_session, seed_user)
+    base = datetime.now(UTC)
+    await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            boot_session_id="boot-session-predecessor",
+            successor_boot_session_id="boot-session-successor",
+            captured_at=base,
+        ),
+        received_at=base,
+    )
+    await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            boot_session_id="boot-session-unrelated",
+            captured_at=base + timedelta(seconds=1),
+        ),
+        received_at=base + timedelta(seconds=1),
+    )
+    await db_session.commit()
+
+    with pytest.raises(RuntimeObservationProtocolError) as unauthorized:
+        await ingest_runtime_observation(
+            db_session,
+            environment_id=environment.id,
+            value=_payload(
+                boot_session_id="boot-session-not-authorized",
+                predecessor_boot_session_id="boot-session-predecessor",
+                captured_at=base + timedelta(seconds=2),
+            ),
+            received_at=base + timedelta(seconds=2),
+        )
+    assert unauthorized.value.code == "runtime_observation_handoff_conflict"
+    await db_session.rollback()
+
+    await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            boot_session_id="boot-session-successor",
+            predecessor_boot_session_id="boot-session-predecessor",
+            captured_at=base + timedelta(seconds=2),
+        ),
+        received_at=base + timedelta(seconds=2),
+    )
+    await db_session.commit()
+
+    active_sessions = set(
+        (
+            await db_session.execute(
+                select(V2RuntimeObservationHead.boot_session_id).where(
+                    V2RuntimeObservationHead.environment_id == environment.id,
+                    V2RuntimeObservationHead.state == "active",
+                )
+            )
+        ).scalars()
+    )
+    assert active_sessions == {"boot-session-successor", "boot-session-unrelated"}
+
+
 @pytest.mark.committed_db
 @pytest.mark.asyncio
 async def test_ingestion_and_retirement_serialize_on_the_environment_fence(
@@ -394,7 +567,7 @@ async def test_database_guards_reject_runtime_rebinding_regression_and_tombstone
     event = await ingest_runtime_observation(
         db_session,
         environment_id=environment.id,
-        value=_payload(),
+        value=_payload(successor_boot_session_id="boot-session-successor"),
     )
     page = await read_runtime_observations(
         db_session,
@@ -494,6 +667,15 @@ async def test_database_guards_reject_runtime_rebinding_regression_and_tombstone
             )
             .values(latest_event_id="rebound-event"),
             "head cannot rebind a sequence",
+        ),
+        (
+            update(V2RuntimeObservationHead)
+            .where(
+                V2RuntimeObservationHead.environment_id == environment.id,
+                V2RuntimeObservationHead.boot_session_id == "boot-session-0001",
+            )
+            .values(authorized_successor_boot_session_id="boot-session-rebound"),
+            "authorized successor is immutable",
         ),
         (
             update(V2RuntimeObservationConsumerCursor)
@@ -2208,6 +2390,8 @@ def _legacy_runtime_observed(value: RuntimeObservationEventV2) -> dict:
         "applyReceiptId",
         "bootNonce",
         "bootSessionId",
+        "successorBootSessionId",
+        "predecessorBootSessionId",
         "sequence",
         "eventId",
         "capturedAt",

--- a/packages/cli/src/runtime/heartbeat-observation.test.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { type RuntimeAppliedStateV2, writeRuntimeAppliedState } from "./applied-state";
@@ -260,6 +268,7 @@ describe("hosted runtime heartbeat observation", () => {
 			paths,
 			now: clockSequence(["2026-07-16T02:00:00.000Z", "2026-07-16T02:01:00.000Z"]),
 			createId: idSequence(["boot-session-0001", "event-0000000001", "event-0000000002"]),
+			createSuccessorId: () => "boot-session-0002",
 		});
 		const first = firstSession.nextEvent();
 		if (!first) throw new Error("expected first event");
@@ -278,7 +287,8 @@ describe("hosted runtime heartbeat observation", () => {
 			environmentId: "env_retry",
 			paths,
 			now: clockSequence(["2026-07-16T02:02:00.000Z"]),
-			createId: idSequence(["boot-session-0002", "event-0000000003"]),
+			createId: idSequence(["event-0000000003"]),
+			createSuccessorId: () => "boot-session-0003",
 		});
 		const retryAfterRestart = restarted.nextEvent();
 		if (!retryAfterRestart) throw new Error("expected retry after restart");
@@ -291,9 +301,61 @@ describe("hosted runtime heartbeat observation", () => {
 		if (!nextBootEvent) throw new Error("expected new-boot event");
 		expect(nextBootEvent.event).toMatchObject({
 			bootSessionId: "boot-session-0002",
+			predecessorBootSessionId: "boot-session-0001",
+			successorBootSessionId: "boot-session-0003",
 			sequence: 1,
 			eventId: "event-0000000003",
 			capturedAt: "2026-07-16T02:02:00.000Z",
+		});
+	});
+
+	test("advertises a successor before rotating legacy durable state", () => {
+		const paths = tempRuntimePaths();
+		writeRuntimeAppliedState(companionAppliedState(7), paths);
+		const statePath = runtimeHeartbeatObservationStatePath(paths, "env_legacy_handoff");
+		mkdirSync(dirname(statePath), { recursive: true });
+		writeFileSync(
+			statePath,
+			`${JSON.stringify({
+				schemaVersion: "clawdi.runtimeHeartbeatObservation.v1",
+				environmentId: "env_legacy_handoff",
+				bootIdentity: {
+					generation: 7,
+					manifestETag: '"frozen-manifest-7"',
+					applyReceiptId: "apply-receipt-0007",
+					bootNonce: "boot-nonce-000007",
+					bootSessionId: "boot-session-legacy",
+				},
+				nextSequence: 4,
+				lastCapturedAt: "2026-07-16T02:00:00.000Z",
+				pending: null,
+			})}\n`,
+		);
+		const session = new HostedRuntimeHeartbeatSession({
+			environmentId: "env_legacy_handoff",
+			paths,
+			now: clockSequence(["2026-07-16T02:01:00.000Z", "2026-07-16T02:02:00.000Z"]),
+			createId: idSequence(["event-prepare-handoff", "event-successor"]),
+			createSuccessorId: idSequence(["boot-session-successor", "boot-session-next"]),
+		});
+
+		const preparation = session.nextEvent();
+		if (!preparation) throw new Error("expected successor preparation event");
+		expect(preparation.event).toMatchObject({
+			bootSessionId: "boot-session-legacy",
+			successorBootSessionId: "boot-session-successor",
+			sequence: 4,
+		});
+		expect(preparation.event.predecessorBootSessionId).toBeUndefined();
+		expect(session.acknowledge(preparation.event.eventId)).toBe(true);
+
+		const successor = session.nextEvent();
+		if (!successor) throw new Error("expected causally fenced successor event");
+		expect(successor.event).toMatchObject({
+			bootSessionId: "boot-session-successor",
+			predecessorBootSessionId: "boot-session-legacy",
+			successorBootSessionId: "boot-session-next",
+			sequence: 1,
 		});
 	});
 

--- a/packages/cli/src/runtime/heartbeat-observation.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.ts
@@ -108,6 +108,8 @@ const hostedRuntimeObservedEventSchema: z.ZodType<HostedRuntimeObservedEvent> = 
 		applyReceiptId: z.string().min(16).max(128),
 		bootNonce: z.string().min(16).max(128),
 		bootSessionId: z.string().min(1).max(128),
+		successorBootSessionId: z.string().min(1).max(128).optional(),
+		predecessorBootSessionId: z.string().min(1).max(128).optional(),
 		sequence: positiveSafeIntegerSchema,
 		eventId: z.string().min(1).max(128),
 		capturedAt: isoTimestampSchema,
@@ -119,6 +121,20 @@ const hostedRuntimeObservedEventSchema: z.ZodType<HostedRuntimeObservedEvent> = 
 				code: "custom",
 				message: "reportedAt must equal the original capturedAt for companion events",
 				path: ["reportedAt"],
+			});
+		}
+		if (event.predecessorBootSessionId === event.bootSessionId) {
+			ctx.addIssue({
+				code: "custom",
+				message: "predecessorBootSessionId must differ from bootSessionId",
+				path: ["predecessorBootSessionId"],
+			});
+		}
+		if (event.successorBootSessionId === event.bootSessionId) {
+			ctx.addIssue({
+				code: "custom",
+				message: "successorBootSessionId must differ from bootSessionId",
+				path: ["successorBootSessionId"],
 			});
 		}
 	});
@@ -136,7 +152,7 @@ const pendingEventSchema = z
 	})
 	.strict();
 
-const heartbeatStateSchema = z
+const legacyHeartbeatStateSchema = z
 	.object({
 		schemaVersion: z.literal("clawdi.runtimeHeartbeatObservation.v1"),
 		environmentId: z.string().min(1),
@@ -147,7 +163,38 @@ const heartbeatStateSchema = z
 	})
 	.strict();
 
+const heartbeatStateSchema = z
+	.object({
+		schemaVersion: z.literal("clawdi.runtimeHeartbeatObservation.v2"),
+		environmentId: z.string().min(1),
+		bootIdentity: persistedBootIdentitySchema,
+		successorBootSessionId: z.string().min(1).max(128),
+		predecessorBootSessionId: z.string().min(1).max(128).nullable(),
+		phase: z.enum(["preparing-successor", "unestablished", "active"]),
+		nextSequence: positiveSafeIntegerSchema,
+		lastCapturedAt: isoTimestampSchema.nullable().optional(),
+		pending: pendingEventSchema.nullable(),
+	})
+	.strict()
+	.superRefine((state, ctx) => {
+		if (state.successorBootSessionId === state.bootIdentity.bootSessionId) {
+			ctx.addIssue({
+				code: "custom",
+				message: "successor boot session must differ from the current boot session",
+				path: ["successorBootSessionId"],
+			});
+		}
+		if (state.predecessorBootSessionId === state.bootIdentity.bootSessionId) {
+			ctx.addIssue({
+				code: "custom",
+				message: "predecessor boot session must differ from the current boot session",
+				path: ["predecessorBootSessionId"],
+			});
+		}
+	});
+
 type PersistedHeartbeatState = z.infer<typeof heartbeatStateSchema>;
+type LegacyHeartbeatState = z.infer<typeof legacyHeartbeatStateSchema>;
 type PersistedBootIdentity = z.infer<typeof persistedBootIdentitySchema>;
 
 export interface BufferedRuntimeObservedEvent {
@@ -161,6 +208,7 @@ interface HostedRuntimeHeartbeatOptions {
 	paths?: RuntimePaths;
 	now?: () => Date;
 	createId?: () => string;
+	createSuccessorId?: () => string;
 }
 
 export class HostedRuntimeHeartbeatSession {
@@ -172,22 +220,24 @@ export class HostedRuntimeHeartbeatSession {
 	private currentBootIdentity: PersistedBootIdentity | null = null;
 	private readonly now: () => Date;
 	private readonly createId: () => string;
+	private readonly createSuccessorId: () => string;
 
 	constructor(options: HostedRuntimeHeartbeatOptions) {
 		this.paths = options.paths ?? getRuntimePaths();
 		this.environmentId = options.environmentId;
 		this.now = options.now ?? (() => new Date());
 		this.createId = options.createId ?? randomUUID;
+		this.createSuccessorId = options.createSuccessorId ?? randomUUID;
 		this.statePath = runtimeHeartbeatObservationStatePath(this.paths, options.environmentId);
-		this.state = this.paths.mode === "hosted" ? readState(this.statePath) : null;
-		if (this.state && this.state.environmentId !== options.environmentId) {
+		const persisted = this.paths.mode === "hosted" ? readState(this.statePath) : null;
+		if (persisted && persisted.environmentId !== options.environmentId) {
 			throw new Error("runtime heartbeat state environment binding does not match");
 		}
-
-		this.refreshAppliedState(true);
+		this.state = null;
+		this.initializeAppliedState(persisted);
 	}
 
-	refreshAppliedState(forceNewBoot = false): boolean {
+	refreshAppliedState(): boolean {
 		const appliedState = this.paths.mode === "hosted" ? readRuntimeAppliedState(this.paths) : null;
 		const applyIdentity = appliedState ? runtimeAppliedApplyIdentity(appliedState) : null;
 		if (!appliedState || !applyIdentity) {
@@ -195,36 +245,93 @@ export class HostedRuntimeHeartbeatSession {
 			this.currentBootIdentity = null;
 			return false;
 		}
-		if (
-			!forceNewBoot &&
-			this.currentBootIdentity &&
-			sameApplyIdentity(this.currentBootIdentity, applyIdentity)
-		) {
+		if (this.currentBootIdentity && sameApplyIdentity(this.currentBootIdentity, applyIdentity)) {
 			this.capturedAppliedState = appliedState;
 			return false;
 		}
 
-		const nextBootIdentity = {
-			...applyIdentity,
-			bootSessionId: nonEmptyId(this.createId(), "boot session ID"),
-		};
-		const pending = this.state?.pending ?? null;
-		const candidate: PersistedHeartbeatState = {
-			schemaVersion: "clawdi.runtimeHeartbeatObservation.v1",
-			environmentId: this.environmentId,
-			bootIdentity: nextBootIdentity,
-			nextSequence: 1,
-			lastCapturedAt: null,
-			pending:
-				pending && eventMatchesApplyIdentity(decodePendingEvent(pending).event, applyIdentity)
-					? pending
-					: null,
-		};
+		const candidate = this.freshState(applyIdentity);
 		writeState(this.paths, this.statePath, candidate);
 		this.state = candidate;
 		this.capturedAppliedState = appliedState;
-		this.currentBootIdentity = nextBootIdentity;
+		this.currentBootIdentity = candidate.bootIdentity;
 		return true;
+	}
+
+	private initializeAppliedState(
+		persisted: PersistedHeartbeatState | LegacyHeartbeatState | null,
+	): void {
+		const appliedState = this.paths.mode === "hosted" ? readRuntimeAppliedState(this.paths) : null;
+		const applyIdentity = appliedState ? runtimeAppliedApplyIdentity(appliedState) : null;
+		if (!appliedState || !applyIdentity) return;
+
+		let candidate: PersistedHeartbeatState;
+		if (persisted && sameApplyIdentity(persisted.bootIdentity, applyIdentity)) {
+			if (persisted.schemaVersion === "clawdi.runtimeHeartbeatObservation.v1") {
+				candidate = {
+					schemaVersion: "clawdi.runtimeHeartbeatObservation.v2",
+					environmentId: this.environmentId,
+					bootIdentity: persisted.bootIdentity,
+					successorBootSessionId: this.newSuccessorId(persisted.bootIdentity.bootSessionId),
+					predecessorBootSessionId: null,
+					phase: "preparing-successor",
+					nextSequence: persisted.nextSequence,
+					lastCapturedAt: persisted.lastCapturedAt ?? null,
+					pending: persisted.pending,
+				};
+			} else if (persisted.phase === "active") {
+				candidate = this.rotateState(persisted);
+			} else {
+				candidate = persisted;
+			}
+		} else {
+			candidate = this.freshState(applyIdentity);
+		}
+		writeState(this.paths, this.statePath, candidate);
+		this.state = candidate;
+		this.capturedAppliedState = appliedState;
+		this.currentBootIdentity = candidate.bootIdentity;
+	}
+
+	private freshState(applyIdentity: RuntimeApplyIdentity): PersistedHeartbeatState {
+		const bootSessionId = nonEmptyId(this.createId(), "boot session ID");
+		return {
+			schemaVersion: "clawdi.runtimeHeartbeatObservation.v2",
+			environmentId: this.environmentId,
+			bootIdentity: {
+				...applyIdentity,
+				bootSessionId,
+			},
+			successorBootSessionId: this.newSuccessorId(bootSessionId),
+			predecessorBootSessionId: null,
+			phase: "unestablished",
+			nextSequence: 1,
+			lastCapturedAt: null,
+			pending: null,
+		};
+	}
+
+	private rotateState(state: PersistedHeartbeatState): PersistedHeartbeatState {
+		return {
+			...state,
+			bootIdentity: {
+				...state.bootIdentity,
+				bootSessionId: state.successorBootSessionId,
+			},
+			successorBootSessionId: this.newSuccessorId(state.successorBootSessionId),
+			predecessorBootSessionId: state.bootIdentity.bootSessionId,
+			phase: "unestablished",
+			nextSequence: 1,
+			pending: state.pending,
+		};
+	}
+
+	private newSuccessorId(currentBootSessionId: string): string {
+		const successor = nonEmptyId(this.createSuccessorId(), "successor boot session ID");
+		if (successor === currentBootSessionId) {
+			throw new Error("successor boot session ID must differ from the current boot session ID");
+		}
+		return successor;
 	}
 
 	nextEvent(): BufferedRuntimeObservedEvent | null {
@@ -252,6 +359,10 @@ export class HostedRuntimeHeartbeatSession {
 			applyReceiptId: this.currentBootIdentity.applyReceiptId,
 			bootNonce: this.currentBootIdentity.bootNonce,
 			bootSessionId: this.currentBootIdentity.bootSessionId,
+			successorBootSessionId: this.state.successorBootSessionId,
+			...(this.state.predecessorBootSessionId
+				? { predecessorBootSessionId: this.state.predecessorBootSessionId }
+				: {}),
 			sequence: this.state.nextSequence,
 			eventId: nonEmptyId(this.createId(), "runtime heartbeat event ID"),
 			capturedAt,
@@ -273,7 +384,25 @@ export class HostedRuntimeHeartbeatSession {
 	}
 
 	acknowledge(eventId: string): boolean {
-		return this.clearPending(eventId);
+		if (!this.state?.pending) return false;
+		const pending = decodePendingEvent(this.state.pending);
+		if (pending.event.eventId !== eventId) return false;
+		let candidate: PersistedHeartbeatState = { ...this.state, pending: null };
+		if (
+			candidate.phase === "preparing-successor" &&
+			pending.event.successorBootSessionId === candidate.successorBootSessionId
+		) {
+			candidate = this.rotateState(candidate);
+		} else if (
+			candidate.phase === "unestablished" &&
+			pending.event.bootSessionId === candidate.bootIdentity.bootSessionId
+		) {
+			candidate = { ...candidate, predecessorBootSessionId: null, phase: "active" };
+		}
+		writeState(this.paths, this.statePath, candidate);
+		this.state = candidate;
+		this.currentBootIdentity = candidate.bootIdentity;
+		return true;
 	}
 
 	retireTerminallyStale(eventId: string): boolean {
@@ -303,11 +432,11 @@ export function runtimeHeartbeatObservationStatePath(
 	return join(paths.runtimeHeartbeatRoot, `${environmentKey}.json`);
 }
 
-function readState(path: string): PersistedHeartbeatState | null {
+function readState(path: string): PersistedHeartbeatState | LegacyHeartbeatState | null {
 	if (!existsSync(path)) return null;
 	try {
 		const raw: unknown = JSON.parse(readFileSync(path, "utf-8"));
-		return heartbeatStateSchema.parse(raw);
+		return z.union([heartbeatStateSchema, legacyHeartbeatStateSchema]).parse(raw);
 	} catch (error) {
 		throw new Error(
 			`invalid durable runtime heartbeat state at ${path}: ${
@@ -377,17 +506,5 @@ function sameApplyIdentity(
 		left.manifestETag === right.manifestETag &&
 		left.applyReceiptId === right.applyReceiptId &&
 		left.bootNonce === right.bootNonce
-	);
-}
-
-function eventMatchesApplyIdentity(
-	event: HostedRuntimeObservedEvent,
-	identity: RuntimeApplyIdentity,
-): boolean {
-	return (
-		event.applied.generation === identity.generation &&
-		event.applied.etag === identity.manifestETag &&
-		event.applyReceiptId === identity.applyReceiptId &&
-		event.bootNonce === identity.bootNonce
 	);
 }

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -6567,6 +6567,10 @@ export interface components {
             bootNonce: string;
             /** Bootsessionid */
             bootSessionId: string;
+            /** Successorbootsessionid */
+            successorBootSessionId?: string | null;
+            /** Predecessorbootsessionid */
+            predecessorBootSessionId?: string | null;
             /** Sequence */
             sequence: number;
             /** Eventid */


### PR DESCRIPTION
## Summary

- add an explicit predecessor/successor boot-session handoff to hosted runtime observations
- atomically retire only the exact authorized predecessor under the existing environment fence
- migrate durable CLI heartbeat state without rotating a legacy session before successor authorization is acknowledged
- preserve permanent tombstones, replay/cursor semantics, strict split-brain detection, and additive API compatibility

## Root cause

Every clean daemon start minted a new bootSessionId for the same apply identity. The predecessor head remained fresh for the observation TTL while the successor immediately became fresh, so cloud-api correctly observed multiple exact-identity active heads and returned active_boot_session_ambiguous. The second production rotation about five minutes after rollout matches the daemon auto-update initial poll and clean restart.

## Safety

A heartbeat advertises one immutable successor ID before restart. A successor may retire a predecessor only when the predecessor is active, has the exact same apply identity, and previously authorized that exact successor ID. Validation, predecessor tombstoning, successor insertion, and stream advancement occur in one environment-fenced transaction.

The implementation never selects the newest head. Unrelated or unauthorized active heads remain active and therefore keep ambiguity fail-closed. Retired heads remain permanent immutable tombstones. Exact duplicate replay is accepted without advancing or mutating a tombstone, and the append-only inbox and consumer cursor model is unchanged.

## Verification

- bun run typecheck
- bun run check
- focused CLI runtime tests: 21 passed
- focused backend runtime observation tests on migrated throwaway PostgreSQL 18.4: 31 passed
- full isolated bun run test: web 994 passed; shared 72 passed; sidecar 71 passed; CLI 1640 passed, 4 skipped; backend 2249 passed, 11 skipped
- focused Ruff lint and format checks
- generated OpenAPI TypeScript client consistency check
- Alembic upgrade, downgrade, and re-upgrade round trip
