### PR TITLE
fix(whatsapp): restore Hermes replies with real LID mapping

### DIFF
--- a/backend/app/routes/channel_routers/whatsapp.py
+++ b/backend/app/routes/channel_routers/whatsapp.py
@@ -14,12 +14,15 @@ from fastapi import (
 )
 from pydantic import JsonValue
 from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.database import async_session_factory
 from app.models.channel import (
     CHANNEL_PROVIDER_WHATSAPP,
     MESSAGE_DIRECTION_INBOUND,
+    ChannelAccount,
+    ChannelAgentCredential,
     ChannelMessage,
 )
 from app.routes.channel_routers.shared import (
@@ -42,13 +45,20 @@ from app.services.whatsapp_baileys import (
     load_or_create_whatsapp_auth_cert,
     resolve_whatsapp_credential_by_identity,
     save_whatsapp_agent_bundle,
+    save_whatsapp_credential_self_identity,
     save_whatsapp_group_sender_keys,
     save_whatsapp_signal_senders,
     whatsapp_agent_bundle_from_config,
     whatsapp_agent_bundle_pre_key_count,
     whatsapp_group_sender_keys_from_config,
     whatsapp_message_proto_bytes,
+    whatsapp_self_identity_from_config,
     whatsapp_signal_senders_from_config,
+)
+from app.services.whatsapp_native_transport import (
+    WhatsAppSidecarHealth,
+    WhatsAppSidecarProtocolError,
+    whatsapp_phone_number_from_pn_jid,
 )
 from app.services.whatsapp_noise import (
     WhatsAppNoiseEmulatorSession,
@@ -59,6 +69,7 @@ from app.services.whatsapp_provider_bridge import (
     WhatsAppProviderBridge,
 )
 from app.services.whatsapp_runtime_types import WhatsAppOutboundMessage
+from app.services.whatsapp_sidecar_registry import get_active_whatsapp_sidecar_registry
 
 router = APIRouter(prefix="/channels/whatsapp", tags=["channels"])
 
@@ -163,9 +174,17 @@ async def _run_whatsapp_baileys_websocket(
             bundle = whatsapp_agent_bundle_from_config(credential.config)
             signal_senders = whatsapp_signal_senders_from_config(credential.config)
             group_sender_keys = whatsapp_group_sender_keys_from_config(credential.config)
+            resolved_account = await db.get(ChannelAccount, account_id)
+            if resolved_account is None:
+                return None
+            lid = await _resolve_whatsapp_noise_lid(
+                db,
+                account=resolved_account,
+                credential=credential,
+            )
             return WhatsAppNoiseTenant(
                 tenant_id=str(credential.bot_agent_link_id),
-                lid=credential.synthetic_jid,
+                lid=lid,
                 pre_key_count=len(bundle.pre_keys)
                 if bundle is not None
                 else whatsapp_agent_bundle_pre_key_count(credential.config),
@@ -355,6 +374,71 @@ async def _run_whatsapp_baileys_websocket(
                 _WhatsAppSessionAuthorityRevoked,
             ):
                 await inbox_pump_task
+
+
+async def _resolve_whatsapp_noise_lid(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    credential: ChannelAgentCredential,
+) -> str:
+    account_changed = False
+    identity = whatsapp_self_identity_from_config(account.config)
+    if identity is None:
+        identity = whatsapp_self_identity_from_config(credential.config)
+    if identity is None:
+        health = await _authenticated_sidecar_health(account)
+        if health.account_jid is None or health.account_lid is None:
+            raise WhatsAppSidecarProtocolError("authenticated WhatsApp LID is unavailable")
+        identity = {"id": health.account_jid, "lid": health.account_lid}
+        account_config = dict(account.config) if isinstance(account.config, dict) else {}
+        account_config["self_identity"] = identity
+        account.config = account_config
+        account_changed = True
+    changed = await save_whatsapp_credential_self_identity(
+        db,
+        credential=credential,
+        self_identity=identity,
+    )
+    if changed or account_changed:
+        await db.commit()
+    return identity["lid"]
+
+
+async def _authenticated_sidecar_health(account: ChannelAccount) -> WhatsAppSidecarHealth:
+    registry = get_active_whatsapp_sidecar_registry()
+    config = account.config if isinstance(account.config, dict) else {}
+    revision = config.get("sidecar_config_revision")
+    if registry is None or not isinstance(revision, str):
+        raise WhatsAppSidecarProtocolError("WhatsApp sidecar identity is unavailable")
+    mode = config.get("connection_mode")
+    if mode == "baileys_managed":
+        if registry.managed_account_revision(account.id) != revision:
+            raise WhatsAppSidecarProtocolError("managed WhatsApp sidecar revision mismatch")
+        client = registry.get_managed_client(account.id)
+    elif mode == "baileys_custom":
+        raw_session_id = config.get("sidecar_account_id")
+        try:
+            session_id = UUID(raw_session_id) if isinstance(raw_session_id, str) else None
+        except ValueError:
+            session_id = None
+        client = (
+            registry.get_custom_lifecycle_client(session_id, config_revision=revision)
+            if session_id is not None
+            else None
+        )
+    else:
+        client = None
+    if client is None:
+        raise WhatsAppSidecarProtocolError("WhatsApp sidecar identity is unavailable")
+    health = await client.health()
+    phone_number = whatsapp_phone_number_from_pn_jid(health.account_jid)
+    if not health.registered or phone_number is None or health.account_lid is None:
+        raise WhatsAppSidecarProtocolError("authenticated WhatsApp PN/LID identity is unavailable")
+    configured_phone = config.get("phone_number")
+    if isinstance(configured_phone, str) and configured_phone != phone_number:
+        raise WhatsAppSidecarProtocolError("managed WhatsApp sidecar identity mismatch")
+    return health
 
 
 class _WhatsAppSessionAuthorityRevoked(RuntimeError):

--- a/backend/app/routes/channel_routers/whatsapp.py
+++ b/backend/app/routes/channel_routers/whatsapp.py
@@ -392,7 +392,11 @@ async def _resolve_whatsapp_noise_lid(
             raise WhatsAppSidecarProtocolError("authenticated WhatsApp LID is unavailable")
         identity = {"id": health.account_jid, "lid": health.account_lid}
         account_config = dict(account.config) if isinstance(account.config, dict) else {}
-        account_config["self_identity"] = identity
+        stored_identity: dict[str, JsonValue] = {
+            "id": identity["id"],
+            "lid": identity["lid"],
+        }
+        account_config["self_identity"] = stored_identity
         account.config = account_config
         account_changed = True
     changed = await save_whatsapp_credential_self_identity(

--- a/backend/app/services/whatsapp_baileys.py
+++ b/backend/app/services/whatsapp_baileys.py
@@ -988,7 +988,7 @@ def mint_whatsapp_synthetic_creds(
     phone_user: str | None = None,
     device: int = 1,
     name: str | None = None,
-    self_identity: dict[str, str | None] | None = None,
+    self_identity: Mapping[str, str | None] | None = None,
 ) -> MintedWhatsAppCreds:
     noise_key = _x25519_key_pair()
     signed_identity_key = _x25519_key_pair()
@@ -1660,7 +1660,7 @@ async def mint_whatsapp_agent_credential(
     phone_user: str | None = None,
     device: int = 1,
     name: str | None = None,
-    self_identity: dict[str, str | None] | None = None,
+    self_identity: Mapping[str, str | None] | None = None,
 ) -> StoredWhatsAppCredential:
     minted = mint_whatsapp_synthetic_creds(
         tenant_id=str(bot_agent_link_id),
@@ -1777,7 +1777,7 @@ def whatsapp_agent_credential_config(
     device: int,
     name: str | None,
     phone_user: str | None,
-    self_identity: dict[str, str | None] | None,
+    self_identity: Mapping[str, str | None] | None,
 ) -> dict[str, JsonValue]:
     config: dict[str, JsonValue] = {
         "device": device,
@@ -1836,11 +1836,16 @@ async def save_whatsapp_credential_self_identity(
     validated = whatsapp_self_identity_from_config({"self_identity": dict(self_identity)})
     if validated is None:
         raise ValueError("WhatsApp self identity requires a valid PN and LID pair")
-    validated["id"] = credential.synthetic_jid
+    stored_identity: dict[str, JsonValue] = {
+        "id": credential.synthetic_jid,
+        "lid": validated["lid"],
+    }
+    if name := validated.get("name"):
+        stored_identity["name"] = name
     config = dict(credential.config or {})
-    if config.get("self_identity") == validated:
+    if config.get("self_identity") == stored_identity:
         return False
-    config["self_identity"] = validated
+    config["self_identity"] = stored_identity
     credential.config = config
     await db.flush()
     return True
@@ -2603,7 +2608,7 @@ def _stamp_whatsapp_self_identity(
     phone_user: str | None,
     device: int,
     name: str | None,
-    self_identity: dict[str, str | None] | None,
+    self_identity: Mapping[str, str | None] | None,
 ) -> str:
     del name
     if self_identity and self_identity.get("id"):

--- a/backend/app/services/whatsapp_baileys.py
+++ b/backend/app/services/whatsapp_baileys.py
@@ -1723,10 +1723,15 @@ async def ensure_whatsapp_agent_credential(
     credential = await load_credential()
     auth_cert = await _load_whatsapp_auth_cert_row(db, account_id=account.id)
     if credential is not None and auth_cert is not None:
+        material_changed = await save_whatsapp_credential_self_identity(
+            db,
+            credential=credential,
+            self_identity=whatsapp_self_identity_from_config(account.config),
+        )
         return ResolvedWhatsAppCredential(
             credential=credential,
             auth_cert=auth_cert,
-            material_changed=False,
+            material_changed=material_changed,
         )
 
     await db.execute(
@@ -1746,9 +1751,19 @@ async def ensure_whatsapp_agent_credential(
                 account=account,
                 bot_agent_link_id=link.id,
                 user_id=link.user_id,
+                self_identity=whatsapp_self_identity_from_config(account.config),
             )
         ).credential
         material_changed = True
+    else:
+        material_changed = (
+            await save_whatsapp_credential_self_identity(
+                db,
+                credential=credential,
+                self_identity=whatsapp_self_identity_from_config(account.config),
+            )
+            or material_changed
+        )
 
     return ResolvedWhatsAppCredential(
         credential=credential,
@@ -1783,6 +1798,52 @@ def whatsapp_agent_credential_config(
     if clean_self_identity:
         config["self_identity"] = clean_self_identity
     return config
+
+
+def whatsapp_self_identity_from_config(
+    config: Mapping[str, JsonValue] | None,
+) -> dict[str, str] | None:
+    if config is None:
+        return None
+    value = config.get("self_identity")
+    if not isinstance(value, dict):
+        return None
+    identity_id = _clean_optional_whatsapp_text(value.get("id"))
+    lid = _clean_optional_whatsapp_text(value.get("lid"))
+    if identity_id is None or lid is None:
+        return None
+    parsed_lid = parse_whatsapp_jid(lid)
+    if parsed_lid is None or parsed_lid.server != "lid":
+        return None
+    parsed_id = parse_whatsapp_jid(identity_id)
+    if parsed_id is None or parsed_id.server != "s.whatsapp.net":
+        return None
+    identity = {"id": identity_id, "lid": lid}
+    name = _clean_optional_whatsapp_text(value.get("name"))
+    if name is not None:
+        identity["name"] = name
+    return identity
+
+
+async def save_whatsapp_credential_self_identity(
+    db: AsyncSession,
+    *,
+    credential: ChannelAgentCredential,
+    self_identity: Mapping[str, str] | None,
+) -> bool:
+    if self_identity is None or credential.revoked_at is not None:
+        return False
+    validated = whatsapp_self_identity_from_config({"self_identity": dict(self_identity)})
+    if validated is None:
+        raise ValueError("WhatsApp self identity requires a valid PN and LID pair")
+    validated["id"] = credential.synthetic_jid
+    config = dict(credential.config or {})
+    if config.get("self_identity") == validated:
+        return False
+    config["self_identity"] = validated
+    credential.config = config
+    await db.flush()
+    return True
 
 
 def _clean_optional_whatsapp_text(value: object) -> str | None:

--- a/backend/app/services/whatsapp_device_onboarding.py
+++ b/backend/app/services/whatsapp_device_onboarding.py
@@ -45,6 +45,7 @@ from app.services.whatsapp_native_transport import (
     WhatsAppSidecarPairingStatus,
     WhatsAppSidecarProtocolError,
     WhatsAppSidecarUnavailableError,
+    whatsapp_phone_number_from_pn_jid,
 )
 from app.services.whatsapp_sidecar_registry import (
     ConfiguredWhatsAppSidecarRegistry,
@@ -55,7 +56,7 @@ WHATSAPP_ONBOARDING_TTL = timedelta(minutes=5)
 _E164_DIGITS = re.compile(r"^[1-9][0-9]{6,14}$")
 _ALLOCATION_LOCK_ID = 8_071_323_912
 _LOGOUT_RECOVERY_TTL_SECONDS = 10.0
-_WhatsAppRepairReason = Literal["remote_logged_out", "unregistered"]
+_WhatsAppRepairReason = Literal["missing_lid", "remote_logged_out", "unregistered"]
 _UNRELEASED_SESSION_STATES = (*WHATSAPP_ONBOARDING_ACTIVE_STATES, WHATSAPP_ONBOARDING_STATE_ERROR)
 _REPAIR_IN_PROGRESS_STATES = (
     WHATSAPP_ONBOARDING_STATE_GENERATING,
@@ -202,12 +203,13 @@ async def start_whatsapp_onboarding(
         return await _mark_session_error(db, onboarding)
     try:
         capabilities = await client.capabilities()
-        await client.health()
         pairing = await client.pairing_qr()
+        health = await client.health()
         response = await _apply_pairing_status(
             db,
             onboarding=onboarding,
             pairing=pairing,
+            health=health,
             capabilities=capabilities,
             registry=registry,
         )
@@ -249,12 +251,13 @@ async def refresh_whatsapp_onboarding(
         return await _mark_session_error(db, onboarding)
     try:
         capabilities = await client.capabilities()
-        await client.health()
+        health = await client.health()
         pairing = await client.pairing_status()
         response = await _apply_pairing_status(
             db,
             onboarding=onboarding,
             pairing=pairing,
+            health=health,
             capabilities=capabilities,
             registry=registry,
         )
@@ -301,18 +304,19 @@ async def request_whatsapp_pairing_code(
         )
     try:
         capabilities = await client.capabilities()
-        await client.health()
         if "code" not in capabilities.pairing:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Manual WhatsApp pairing is not supported",
             )
         pairing = await client.pairing_code(phone_number)
+        health = await client.health()
         onboarding.method = "code"
         response = await _apply_pairing_status(
             db,
             onboarding=onboarding,
             pairing=pairing,
+            health=health,
             capabilities=capabilities,
             registry=registry,
         )
@@ -456,12 +460,13 @@ async def retry_whatsapp_onboarding(
         return await _mark_session_error(db, onboarding)
     try:
         capabilities = await client.capabilities()
-        await client.health()
         pairing = await client.pairing_qr()
+        health = await client.health()
         response = await _apply_pairing_status(
             db,
             onboarding=onboarding,
             pairing=pairing,
+            health=health,
             capabilities=capabilities,
             registry=registry,
         )
@@ -573,11 +578,17 @@ async def repair_whatsapp_account(
             recovered = await client.pairing_recover()
             if recovered.status != "stopped" or recovered.registered:
                 raise WhatsAppSidecarProtocolError("custom Baileys recovery was not confirmed")
+        elif repair_reason == "missing_lid":
+            logged_out = await client.pairing_logout()
+            if logged_out.status != "stopped" or logged_out.registered:
+                raise WhatsAppSidecarProtocolError("custom Baileys logout was not confirmed")
         pairing = await client.pairing_qr()
+        health = await client.health()
         response = await _apply_pairing_status(
             db,
             onboarding=onboarding,
             pairing=pairing,
+            health=health,
             capabilities=capabilities,
             registry=registry,
         )
@@ -645,6 +656,8 @@ def _repair_reason(health: WhatsAppSidecarHealth) -> _WhatsAppRepairReason | Non
         return "remote_logged_out"
     if not health.registered:
         return "unregistered"
+    if health.account_lid is None:
+        return "missing_lid"
     return None
 
 
@@ -871,12 +884,25 @@ async def _apply_pairing_status(
     *,
     onboarding: ChannelWhatsAppOnboardingSession,
     pairing: WhatsAppSidecarPairingStatus,
+    health: WhatsAppSidecarHealth,
     capabilities: WhatsAppSidecarCapabilities,
     registry: ConfiguredWhatsAppSidecarRegistry,
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     manual_supported = "code" in capabilities.pairing
     if pairing.status == "connected" and pairing.registered:
-        await _finalize_connected_account(db, onboarding=onboarding, registry=registry)
+        if (
+            not health.connected
+            or not health.registered
+            or whatsapp_phone_number_from_pn_jid(health.account_jid) is None
+            or health.account_lid is None
+        ):
+            return await _mark_session_error(db, onboarding)
+        await _finalize_connected_account(
+            db,
+            onboarding=onboarding,
+            registry=registry,
+            health=health,
+        )
         return _session_response(
             onboarding,
             manual_pairing_code_supported=manual_supported,
@@ -930,7 +956,10 @@ async def _finalize_connected_account(
     *,
     onboarding: ChannelWhatsAppOnboardingSession,
     registry: ConfiguredWhatsAppSidecarRegistry,
+    health: WhatsAppSidecarHealth,
 ) -> None:
+    if health.account_jid is None or health.account_lid is None:
+        raise WhatsAppSidecarProtocolError("custom sidecar PN/LID identity is unavailable")
     session_id = onboarding.sidecar_account_id
     session_revision = onboarding.sidecar_config_revision
     account_id: UUID | None = None
@@ -960,6 +989,10 @@ async def _finalize_connected_account(
                     "connection_mode": "baileys_custom",
                     "sidecar_account_id": str(session_id),
                     "sidecar_config_revision": session_revision,
+                    "self_identity": {
+                        "id": health.account_jid,
+                        "lid": health.account_lid,
+                    },
                 },
             )
             db.add(existing)
@@ -977,6 +1010,13 @@ async def _finalize_connected_account(
             or existing.config.get("sidecar_config_revision") != session_revision
         ):
             raise WhatsAppSidecarProtocolError("custom sidecar ownership conflict")
+        else:
+            config = dict(existing.config)
+            config["self_identity"] = {
+                "id": health.account_jid,
+                "lid": health.account_lid,
+            }
+            existing.config = config
         account_id = existing.id
         newly_bound = await registry.bind_custom_account(
             session_id=session_id,
@@ -1056,14 +1096,25 @@ async def _expire_session(
     if client is None:
         return await _mark_session_error(db, onboarding)
     try:
-        await client.health()
+        health = await client.health()
         current = await client.pairing_status()
         if (
             onboarding.state != WHATSAPP_ONBOARDING_STATE_ERROR
             and current.status == "connected"
             and current.registered
         ):
-            await _finalize_connected_account(db, onboarding=onboarding, registry=registry)
+            if (
+                not health.connected
+                or whatsapp_phone_number_from_pn_jid(health.account_jid) is None
+                or health.account_lid is None
+            ):
+                return await _mark_session_error(db, onboarding)
+            await _finalize_connected_account(
+                db,
+                onboarding=onboarding,
+                registry=registry,
+                health=health,
+            )
             await db.commit()
             return _session_response(
                 onboarding,

--- a/backend/app/services/whatsapp_managed_onboarding.py
+++ b/backend/app/services/whatsapp_managed_onboarding.py
@@ -267,13 +267,15 @@ async def _refresh(
         return await _error(db, onboarding)
     if health.connected and pairing.status == "connected" and pairing.registered:
         phone_number = whatsapp_phone_number_from_pn_jid(health.account_jid)
-        if phone_number is None:
+        if phone_number is None or health.account_jid is None or health.account_lid is None:
             return await _error(db, onboarding)
         await _promote(
             db,
             onboarding=onboarding,
             registry=registry,
             phone_number=phone_number,
+            account_jid=health.account_jid,
+            account_lid=health.account_lid,
         )
         return _response(onboarding)
     if pairing.status == "starting" and not pairing.registered:
@@ -312,6 +314,8 @@ async def _promote(
     onboarding: ChannelWhatsAppOnboardingSession,
     registry: ConfiguredWhatsAppSidecarRegistry,
     phone_number: str,
+    account_jid: str,
+    account_lid: str,
 ) -> None:
     account_id = onboarding.sidecar_account_id
     session_id = onboarding.id
@@ -330,6 +334,7 @@ async def _promote(
                     "connection_mode": "baileys_managed",
                     "sidecar_config_revision": onboarding.sidecar_config_revision,
                     "phone_number": phone_number,
+                    "self_identity": {"id": account_jid, "lid": account_lid},
                 },
             )
             db.add(account)
@@ -339,6 +344,7 @@ async def _promote(
         else:
             config = dict(account.config) if isinstance(account.config, dict) else {}
             config["phone_number"] = phone_number
+            config["self_identity"] = {"id": account_jid, "lid": account_lid}
             account.config = config
         newly_bound = await registry.bind_managed_account(
             account.id, config_revision=onboarding.sidecar_config_revision

--- a/backend/app/services/whatsapp_native_transport.py
+++ b/backend/app/services/whatsapp_native_transport.py
@@ -19,6 +19,7 @@ from pydantic import JsonValue, TypeAdapter, ValidationError
 
 from app.services.whatsapp_baileys import (
     BinaryNode,
+    parse_whatsapp_jid,
     relay_outbound_extra_attrs,
     validate_relay_outbound_additional_nodes,
 )
@@ -95,6 +96,7 @@ class WhatsAppSidecarHealth:
     connected: bool
     registered: bool
     account_jid: str | None = field(default=None, repr=False)
+    account_lid: str | None = field(default=None, repr=False)
     last_disconnect_reason: str | None = None
 
 
@@ -296,6 +298,7 @@ class WhatsAppBaileysSidecarClient:
             connected=connected,
             registered=_required_bool(payload, "registered"),
             account_jid=_sidecar_account_jid(payload.get("user")),
+            account_lid=_sidecar_account_lid(payload.get("user")),
             last_disconnect_reason=_sidecar_disconnect_reason(payload.get("lastDisconnectReason")),
         )
 
@@ -699,6 +702,18 @@ def _sidecar_account_jid(value: JsonValue | None) -> str | None:
     if not isinstance(account_jid, str) or not account_jid or len(account_jid) > 128:
         return None
     return account_jid
+
+
+def _sidecar_account_lid(value: JsonValue | None) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    account_lid = value.get("lid")
+    if not isinstance(account_lid, str) or len(account_lid) > 128:
+        return None
+    parsed = parse_whatsapp_jid(account_lid)
+    if parsed is None or parsed.server != "lid":
+        return None
+    return account_lid
 
 
 def _sidecar_disconnect_reason(value: JsonValue | None) -> str | None:

--- a/backend/app/services/whatsapp_sidecar_registry.py
+++ b/backend/app/services/whatsapp_sidecar_registry.py
@@ -271,6 +271,7 @@ class ConfiguredWhatsAppSidecarRegistry:
                 if (
                     not health.connected
                     or not health.registered
+                    or health.account_lid is None
                     or pairing.status != "connected"
                     or not pairing.registered
                 ):
@@ -486,6 +487,7 @@ class ConfiguredWhatsAppSidecarRegistry:
                 if (
                     expected_revision is None
                     or health.registered != pairing.registered
+                    or (health.registered and health.account_lid is None)
                     or (owner is not None and owner[1] != expected_revision)
                     or (
                         reservation_revision is not None

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -82,6 +82,7 @@ class _ManagedOnboardingSidecar:
             connected=self.connected,
             registered=self.registered,
             account_jid="15551234567:1@s.whatsapp.net" if self.registered else None,
+            account_lid="900000000000001:1@lid" if self.registered else None,
         )
 
     async def pairing_qr(self):

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -11985,6 +11985,7 @@ async def test_whatsapp_pair_code_never_links_to_a_private_custom_identity(
             connected=True,
             registered=True,
             account_jid="15559876543@s.whatsapp.net",
+            account_lid="900000000000001@lid",
         )
     )
     registry = _WhatsAppPairLinkRegistry(account_id=account.id, client=sidecar)

--- a/backend/tests/test_whatsapp_baileys.py
+++ b/backend/tests/test_whatsapp_baileys.py
@@ -50,6 +50,7 @@ from app.services.whatsapp_baileys import (
     strip_whatsapp_device,
     whatsapp_jid_candidates,
     whatsapp_message_proto_bytes,
+    whatsapp_self_identity_from_config,
     whatsapp_text_from_message_proto,
     whatsapp_text_message_proto,
 )
@@ -132,6 +133,37 @@ def test_whatsapp_synthetic_creds_are_baileys_json_compatible_and_provider_secre
     assert '"type":"Buffer"' in serialized
     assert "providerToken" not in serialized
     assert "physicalAuthState" not in serialized
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (
+            {
+                "self_identity": {
+                    "id": "15551234567:1@s.whatsapp.net",
+                    "lid": "900000000000001:1@lid",
+                }
+            },
+            {
+                "id": "15551234567:1@s.whatsapp.net",
+                "lid": "900000000000001:1@lid",
+            },
+        ),
+        ({"self_identity": {"lid": "900000000000001:1@lid"}}, None),
+        (
+            {
+                "self_identity": {
+                    "id": "15551234567:1@s.whatsapp.net",
+                    "lid": "15551234567:1@s.whatsapp.net",
+                }
+            },
+            None,
+        ),
+    ],
+)
+def test_whatsapp_self_identity_requires_pn_and_lid_pair(config, expected):
+    assert whatsapp_self_identity_from_config(config) == expected
 
 
 def test_whatsapp_jid_helpers_resolve_lid_and_device_aliases():

--- a/backend/tests/test_whatsapp_baileys_smoke.py
+++ b/backend/tests/test_whatsapp_baileys_smoke.py
@@ -48,7 +48,7 @@ def _baileys_protocol_smoke_gate(env: Mapping[str, str]) -> tuple[bool, str | No
     if env.get("CLAWDI_BAILEYS_AUTH_CERT_SEAM_AVAILABLE") != "1":
         return (
             False,
-            "stock Baileys 7.0.0-rc13 has no authCert SocketConfig trust seam; "
+            "stock Baileys 7.0.0-rc14 has no authCert SocketConfig trust seam; "
             "CLAWDI_BAILEYS_AUTH_CERT_SEAM_AVAILABLE=1 must only describe a supplied seam",
         )
     return True, None
@@ -68,7 +68,7 @@ def test_real_baileys_protocol_smoke_gate_requires_opt_in_and_an_available_seam(
     )
     enabled, reason = _baileys_protocol_smoke_gate({"CLAWDI_RUN_BAILEYS_SMOKE": "1"})
     assert enabled is False
-    assert reason is not None and "stock Baileys 7.0.0-rc13" in reason
+    assert reason is not None and "stock Baileys 7.0.0-rc14" in reason
     assert _baileys_protocol_smoke_gate(
         {
             "CLAWDI_RUN_BAILEYS_SMOKE": "1",
@@ -96,6 +96,7 @@ async def test_whatsapp_baileys_websocket_reaches_open_with_real_baileys() -> No
         opened = json.loads(result.stdout)
         assert opened["status"] == "open"
         assert opened["user"]["id"] == seeded["jid"]
+        assert opened["user"]["lid"] == seeded["lid"]
 
 
 @real_baileys_protocol_smoke
@@ -114,8 +115,31 @@ async def test_whatsapp_baileys_websocket_delivers_inbox_to_real_baileys() -> No
         )
         opened = json.loads(result.stdout)
         assert opened["status"] == "open"
+        assert opened["user"]["lid"] == seeded["lid"]
         assert opened["inbound"] == seeded["expected_inbound"]
         assert ("inbound_message", "pushed") in {
+            (event["stage"], event["outcome"]) for event in debug_events
+        }
+
+
+@real_baileys_protocol_smoke
+@pytest.mark.asyncio
+async def test_whatsapp_baileys_websocket_round_trips_encrypted_reply() -> None:
+    baileys_cwd = _baileys_smoke_cwd()
+    _assert_baileys_available(baileys_cwd)
+    seeded = await _seed_whatsapp_smoke_account(
+        include_inbox=True,
+        expected_reply="encrypted reply from real Baileys",
+    )
+    async with _running_smoke_backend(seeded):
+        result = await _run_node_baileys_smoke(baileys_cwd=baileys_cwd, seeded=seeded)
+        debug_events = await _debug_events_for(seeded["account_id"])
+        assert result.returncode == 0, (result.stdout, result.stderr, debug_events)
+        opened = json.loads(result.stdout)
+        assert opened["status"] == "open"
+        assert opened["user"]["lid"] == seeded["lid"]
+        assert opened["reply"]["id"]
+        assert ("outbound_message", "decoded") in {
             (event["stage"], event["outcome"]) for event in debug_events
         }
 
@@ -314,6 +338,7 @@ async def _seed_whatsapp_smoke_account(
     inbox_payload: dict[str, Any] | None = None,
     expected_conversation: str | None = None,
     expected_message_hex: str | None = None,
+    expected_reply: str | None = None,
 ) -> dict[str, Any]:
     marker = f"wa-baileys-smoke-{uuid.uuid4().hex[:10]}"
     async with async_session_factory() as db:
@@ -471,12 +496,15 @@ async def _seed_whatsapp_smoke_account(
             "user_id": str(user.id),
             "account_id": str(account.id),
             "jid": stored.minted.jid,
+            "lid": "900000000000001:7@lid",
             "creds": encode_buffer_json(stored.minted.creds),
             "auth_cert": serialize_whatsapp_auth_cert(auth_cert),
             "agent_token": agent_token,
         }
         if expected_inbound is not None:
             seeded["expected_inbound"] = expected_inbound
+        if expected_reply is not None:
+            seeded["expected_reply"] = expected_reply
         return seeded
 
 
@@ -570,6 +598,8 @@ const sock = makeWASocket({
 const result = await new Promise((resolve) => {
   let openedUser = null;
   let inbound = null;
+  let reply = null;
+  let replyStarted = false;
   let resolved = false;
   const done = (value) => {
     if (resolved) return;
@@ -578,8 +608,8 @@ const result = await new Promise((resolve) => {
     resolve(value);
   };
   const maybeDone = () => {
-    if (openedUser && (!input.expected_inbound || inbound)) {
-      done({ status: "open", user: openedUser, inbound });
+    if (openedUser && (!input.expected_inbound || inbound) && (!input.expected_reply || reply)) {
+      done({ status: "open", user: openedUser, inbound, reply });
     }
   };
   const timer = setTimeout(() => done({ status: "timeout", inbound }), 8000);
@@ -591,7 +621,7 @@ const result = await new Promise((resolve) => {
       done({ status: "close", close: update.lastDisconnect, inbound });
     }
   });
-  sock.ev.on("messages.upsert", ({ messages }) => {
+  sock.ev.on("messages.upsert", async ({ messages }) => {
     for (const message of messages) {
       const conversation =
         message.message?.conversation ?? message.message?.extendedTextMessage?.text ?? null;
@@ -610,6 +640,14 @@ const result = await new Promise((resolve) => {
           inbound.messageHex = message.message
             ? Buffer.from(proto.Message.encode(message.message).finish()).toString("hex")
             : null;
+        }
+        if (input.expected_reply && !replyStarted) {
+          replyStarted = true;
+          const sent = await sock.sendMessage(
+            message.key.remoteJid,
+            { text: input.expected_reply },
+          );
+          reply = { id: sent?.key?.id ?? null };
         }
         maybeDone();
         return;

--- a/backend/tests/test_whatsapp_custom_onboarding.py
+++ b/backend/tests/test_whatsapp_custom_onboarding.py
@@ -82,6 +82,7 @@ class FakeCustomSidecar:
         self.service_ready_result = True
         self.health_failures_remaining = 0
         self.last_disconnect_reason: str | None = None
+        self.account_lid: str | None = "900000000000001:1@lid"
         self.pairing_recover_calls = 0
         self.health_entered: asyncio.Event | None = None
         self.health_release: asyncio.Event | None = None
@@ -108,6 +109,8 @@ class FakeCustomSidecar:
             status=self.current.status,
             connected=self.current.status == "connected",
             registered=self.current.registered,
+            account_jid=("15551234567:1@s.whatsapp.net" if self.current.registered else None),
+            account_lid=self.account_lid if self.current.registered else None,
             last_disconnect_reason=self.last_disconnect_reason,
         )
 
@@ -359,6 +362,10 @@ async def test_qr_lifecycle_is_idempotent_and_finishes_only_after_connection(
         "connection_mode": "baileys_custom",
         "sidecar_account_id": str(sidecar_account_id),
         "sidecar_config_revision": custom_sidecar_registry_revision(sidecar_account_id),
+        "self_identity": {
+            "id": "15551234567:1@s.whatsapp.net",
+            "lid": "900000000000001:1@lid",
+        },
     }
     assert account.encrypted_provider_token is None
     assert account.provider_token_nonce is None
@@ -457,6 +464,29 @@ async def test_custom_link_prompts_owner_repair_and_preserves_the_durable_accoun
         )
     ).all()
     assert account_ids == [account_id]
+
+
+@pytest.mark.asyncio
+async def test_registered_custom_account_without_lid_requires_explicit_reonboarding(
+    client: httpx.AsyncClient,
+    custom_sidecar: tuple[UUID, FakeCustomSidecar],
+) -> None:
+    _sidecar_account_id, fake = custom_sidecar
+    _onboarding_id, account_id = await _connect_custom_account(
+        client,
+        fake,
+        name="Missing LID phone",
+    )
+    fake.account_lid = None
+
+    link_attempt = await client.post(f"/v1/channels/{account_id}/agent-links", json={})
+    assert link_attempt.status_code == 409
+    assert link_attempt.json() == {"detail": "whatsapp_repair_required"}
+
+    repair = await client.post(f"/v1/channels/whatsapp/onboarding/accounts/{account_id}/repair")
+    assert repair.status_code == 200, repair.text
+    assert repair.json()["state"] == "ready"
+    assert fake.logout_calls == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_whatsapp_managed_onboarding.py
+++ b/backend/tests/test_whatsapp_managed_onboarding.py
@@ -70,6 +70,7 @@ class FakeManagedSidecar:
             connected=self.connected,
             registered=self.registered,
             account_jid="15551234567:1@s.whatsapp.net" if self.registered else None,
+            account_lid="900000000000001:1@lid" if self.registered else None,
             last_disconnect_reason=self.last_disconnect_reason,
         )
 
@@ -228,6 +229,10 @@ async def test_multiple_shared_accounts_use_distinct_sessions_on_one_service(
         assert first_account is not None and first_account.user_id is None
         assert second_account is not None and second_account.user_id is None
         assert first_account.config["phone_number"] == "15551234567"
+        assert first_account.config["self_identity"] == {
+            "id": "15551234567:1@s.whatsapp.net",
+            "lid": "900000000000001:1@lid",
+        }
         assert second_account.config["phone_number"] == "15551234567"
     finally:
         await registry.stop()
@@ -293,6 +298,10 @@ async def test_existing_shared_account_reauth_preserves_inventory_and_history(
         assert registry.managed_is_bound(account_id)
         await db_session.refresh(account)
         assert account.config["phone_number"] == "15551234567"
+        assert account.config["self_identity"] == {
+            "id": "15551234567:1@s.whatsapp.net",
+            "lid": "900000000000001:1@lid",
+        }
 
         await db_session.refresh(previous)
         assert previous.state == "connected"

--- a/backend/tests/test_whatsapp_native_transport.py
+++ b/backend/tests/test_whatsapp_native_transport.py
@@ -19,6 +19,7 @@ from app.services.whatsapp_native_transport import (
     WhatsAppNativeRelayRequest,
     WhatsAppProviderTransportAdapter,
     WhatsAppSidecarUnavailableError,
+    _sidecar_account_lid,
     whatsapp_phone_number_from_pn_jid,
 )
 from app.services.whatsapp_provider_bridge import (
@@ -196,6 +197,7 @@ async def test_whatsapp_baileys_sidecar_client_uses_internal_contract():
                     },
                     "user": {
                         "id": "15551234567:17@s.whatsapp.net",
+                        "lid": "900000000000001:17@lid",
                         "name": "Clawdi Public WhatsApp",
                     },
                 },
@@ -276,6 +278,7 @@ async def test_whatsapp_baileys_sidecar_client_uses_internal_contract():
     health = await client.health()
     assert health.connected is True
     assert health.account_jid == "15551234567:17@s.whatsapp.net"
+    assert health.account_lid == "900000000000001:17@lid"
     assert client.connected is True
 
     relayed_message_id = await transport.relay_outbound_message(
@@ -351,6 +354,20 @@ def test_whatsapp_phone_number_requires_strict_pn_jid(
     phone_number: str | None,
 ) -> None:
     assert whatsapp_phone_number_from_pn_jid(account_jid) == phone_number
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ({"lid": "900000000000001:7@lid"}, "900000000000001:7@lid"),
+        ({"lid": "15551234567@s.whatsapp.net"}, None),
+        ({"lid": "900000000000001@lid.evil.example"}, None),
+        ({"lid": ""}, None),
+        ({}, None),
+    ],
+)
+def test_sidecar_health_accepts_only_lid_domain(value, expected) -> None:
+    assert _sidecar_account_lid(value) == expected
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_whatsapp_noise.py
+++ b/backend/tests/test_whatsapp_noise.py
@@ -5,7 +5,7 @@ import base64
 import hashlib
 from datetime import UTC, datetime
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 import xeddsa
@@ -25,6 +25,7 @@ from app.models.channel import (
     ChannelDebugEvent,
     ChannelMessage,
 )
+from app.routes.channel_routers import whatsapp as whatsapp_router_module
 from app.routes.channel_routers.whatsapp import router as whatsapp_router
 from app.routes.channel_routers.whatsapp import whatsapp_baileys_managed_websocket
 from app.services.channels import generate_agent_token, store_agent_link_token
@@ -37,6 +38,7 @@ from app.services.whatsapp_baileys import (
     whatsapp_signal_senders_from_config,
     whatsapp_text_message_proto,
 )
+from app.services.whatsapp_native_transport import WhatsAppSidecarHealth
 from app.services.whatsapp_noise import (
     NOISE_MODE,
     NOISE_WA_HEADER,
@@ -116,10 +118,58 @@ async def _mint_synthetic_credential(
         account=account,
         bot_agent_link_id=selected_link_id,
         user_id=link.user_id,
-        self_identity=self_identity,
+        self_identity=self_identity
+        or {
+            "id": "16693773518:2@s.whatsapp.net",
+            "lid": "117901482786828:2@lid",
+        },
     )
     await db_session.commit()
     return stored
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_noise_prefers_current_account_identity(
+    client,
+    db_session,
+    channel_agent,
+):
+    created = await _create_whatsapp_channel_with_existing_link(
+        client,
+        db_session,
+        channel_agent,
+        name="wa-current-self-identity",
+    )
+    stored = await _mint_synthetic_credential(
+        db_session,
+        created,
+        self_identity={
+            "id": "15550000001:1@s.whatsapp.net",
+            "lid": "900000000000001:1@lid",
+        },
+    )
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    account.config = {
+        "self_identity": {
+            "id": "15550000002:1@s.whatsapp.net",
+            "lid": "900000000000002:1@lid",
+        }
+    }
+    await db_session.commit()
+
+    lid = await whatsapp_router_module._resolve_whatsapp_noise_lid(
+        db_session,
+        account=account,
+        credential=stored.credential,
+    )
+
+    assert lid == "900000000000002:1@lid"
+    await db_session.refresh(stored.credential)
+    assert stored.credential.config["self_identity"] == {
+        "id": stored.credential.synthetic_jid,
+        "lid": "900000000000002:1@lid",
+    }
 
 
 def test_whatsapp_noise_pack_unpack_round_trips_partial_frames():
@@ -1397,6 +1447,7 @@ async def test_whatsapp_baileys_websocket_records_noise_runtime_debug_events(
     client,
     db_session,
     channel_agent,
+    monkeypatch,
 ):
     created = await _create_whatsapp_channel_with_existing_link(
         client, db_session, channel_agent, name="wa-runtime-debug"
@@ -1406,7 +1457,6 @@ async def test_whatsapp_baileys_websocket_records_noise_runtime_debug_events(
         created,
         self_identity={
             "id": "16693773518:2@s.whatsapp.net",
-            "lid": "117901482786828:2@lid",
         },
     )
     credential_id = synthetic.credential.id
@@ -1417,6 +1467,38 @@ async def test_whatsapp_baileys_websocket_records_noise_runtime_debug_events(
     )
     account = await db_session.get(ChannelAccount, UUID(created["id"]))
     assert account is not None
+    sidecar_session_id = uuid4()
+    sidecar_revision = "self-heal-lid-revision"
+    account.config = {
+        "connection_mode": "baileys_custom",
+        "sidecar_account_id": str(sidecar_session_id),
+        "sidecar_config_revision": sidecar_revision,
+    }
+
+    class AuthenticatedSidecar:
+        async def health(self) -> WhatsAppSidecarHealth:
+            return WhatsAppSidecarHealth(
+                status="connected",
+                connected=True,
+                registered=True,
+                account_jid="15551234567:1@s.whatsapp.net",
+                account_lid="117901482786828:2@lid",
+            )
+
+    class AuthenticatedSidecarRegistry:
+        def custom_session_revision(self, session_id: UUID) -> str | None:
+            return sidecar_revision if session_id == sidecar_session_id else None
+
+        def get_custom_lifecycle_client(self, session_id: UUID, *, config_revision: str):
+            if session_id == sidecar_session_id and config_revision == sidecar_revision:
+                return AuthenticatedSidecar()
+            return None
+
+    monkeypatch.setattr(
+        whatsapp_router_module,
+        "get_active_whatsapp_sidecar_registry",
+        lambda: AuthenticatedSidecarRegistry(),
+    )
     binding = ChannelBinding(
         account_id=account.id,
         bot_agent_link_id=UUID(created["agent_link_id"]),
@@ -1459,7 +1541,7 @@ async def test_whatsapp_baileys_websocket_records_noise_runtime_debug_events(
     success_ciphertext, _rest = unpack_frame(bootstrap_frames[0]) or (b"", b"")
     success = decode_binary_node_minimal(client_noise.transport.decrypt(success_ciphertext))
     assert success["tag"] == "success"
-    assert success["attrs"]["lid"] == "16693773518:2@s.whatsapp.net"
+    assert success["attrs"]["lid"] == "117901482786828:2@lid"
     offline_ciphertext, _rest = unpack_frame(bootstrap_frames[1]) or (b"", b"")
     offline = decode_binary_node_minimal(client_noise.transport.decrypt(offline_ciphertext))
     assert offline == {"tag": "offline", "attrs": {"count": "0"}}
@@ -1518,6 +1600,10 @@ async def test_whatsapp_baileys_websocket_records_noise_runtime_debug_events(
     )
     assert credential is not None
     assert credential.config is not None
+    assert credential.config["self_identity"] == {
+        "id": "16693773518:2@s.whatsapp.net",
+        "lid": "117901482786828:2@lid",
+    }
     assert credential.config["agent_bundle"]["registrationId"] == 12345
     assert len(credential.config["agent_bundle"]["preKeys"]) == 1
     assert "15551112222:0@s.whatsapp.net" in credential.config["signal_senders"]
@@ -1565,9 +1651,9 @@ async def test_whatsapp_baileys_websocket_records_noise_runtime_debug_events(
     bootstrap = next(event for event in events if event.stage == "bootstrap")
     assert bootstrap.provider == "whatsapp"
     assert bootstrap.direction == "agent"
-    assert bootstrap.external_chat_id == "16693773518:2@s.whatsapp.net"
+    assert bootstrap.external_chat_id == "117901482786828:2@lid"
     assert bootstrap.details["runtime"] == "baileys_websocket"
-    assert bootstrap.details["jidDescription"] == "server=s.whatsapp.net device=true"
+    assert bootstrap.details["jidDescription"] == "server=lid device=true"
     identity_pub_key_hex = synthetic.minted.identity_pub_key.hex()
     assert identity_pub_key_hex not in repr([event.details for event in events])
     tenant_event = next(event for event in events if event.stage == "tenant_resolution")

--- a/packages/whatsapp-baileys-sidecar/src/runtime.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/runtime.test.ts
@@ -19,6 +19,37 @@ import type { ProviderMessageEventInput } from "./sqlite-state.js";
 const ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
 
 describe("physical Baileys runtime", () => {
+	it("exposes only the authenticated durable user LID in health", async () => {
+		const validHarness = createHarness({
+			user: {
+				id: "15550001111:1@s.whatsapp.net",
+				name: "Test account",
+				lid: "900000000000001:7@lid",
+			},
+		});
+		const valid = new BaileysSocketRuntime(sidecarConfig(), validHarness.dependencies);
+		expect(valid.health().user).toEqual({
+			id: "15550001111:1@s.whatsapp.net",
+			name: "Test account",
+			lid: "900000000000001:7@lid",
+		});
+
+		const invalidHarness = createHarness({
+			user: {
+				id: "15550001111:1@s.whatsapp.net",
+				name: "Test account",
+				lid: "15550001111@s.whatsapp.net",
+			},
+		});
+		const invalid = new BaileysSocketRuntime(sidecarConfig(), invalidHarness.dependencies);
+		expect(invalid.health().user).toEqual({
+			id: "15550001111:1@s.whatsapp.net",
+			name: "Test account",
+		});
+		await valid.stop();
+		await invalid.stop();
+	});
+
 	it("retains verified rc14 QR identity through restart and SQLite reopen", async () => {
 		const sessionDir = mkdtempSync(join(tmpdir(), "clawdi-wa-runtime-qr-"));
 		const config = { ...sidecarConfig(), sessionDir };
@@ -525,6 +556,7 @@ describe("physical Baileys runtime", () => {
 
 type HarnessOptions = {
 	registered?: boolean;
+	user?: AuthenticationCreds["me"];
 	failCredsWrite?: boolean;
 	failInboxWrite?: boolean;
 	failRetryWrite?: boolean;
@@ -557,7 +589,7 @@ function createHarness(options: HarnessOptions = {}) {
 	const creds = initAuthCreds();
 	creds.registered = options.registered ?? true;
 	if (creds.registered) {
-		creds.me = { id: "15550001111:1@s.whatsapp.net", name: "Test account" };
+		creds.me = options.user ?? { id: "15550001111:1@s.whatsapp.net", name: "Test account" };
 	}
 	const providerState = {
 		state: {

--- a/packages/whatsapp-baileys-sidecar/src/runtime.ts
+++ b/packages/whatsapp-baileys-sidecar/src/runtime.ts
@@ -5,6 +5,9 @@ import {
 	type CacheStore,
 	type ConnectionState,
 	DisconnectReason,
+	isLidUser,
+	jidDecode,
+	jidEncode,
 	makeWASocket,
 	proto,
 	type SignalKeyStore,
@@ -90,6 +93,13 @@ export type BaileysRuntimeDependencies = {
 };
 
 const defaultProviderSocketFactory: ProviderSocketFactory = (config) => makeWASocket(config);
+
+function validatedUserLid(lid: string | undefined): { lid: string } | Record<string, never> {
+	if (!isLidUser(lid)) return {};
+	const decoded = jidDecode(lid);
+	if (!decoded?.user || decoded.server !== "lid") return {};
+	return { lid: jidEncode(decoded.user, decoded.server, decoded.device) };
+}
 
 export class BaileysSocketRuntime implements BaileysRuntime {
 	private socket: ProviderSocket | null = null;
@@ -195,6 +205,7 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 		const user = durableUser
 			? {
 					id: durableUser.id,
+					...validatedUserLid(durableUser.lid),
 					name: durableUser.name,
 				}
 			: undefined;

--- a/packages/whatsapp-baileys-sidecar/src/types.ts
+++ b/packages/whatsapp-baileys-sidecar/src/types.ts
@@ -24,6 +24,7 @@ export type RuntimeHealth = {
 	uptimeSeconds: number;
 	user?: {
 		id?: string;
+		lid?: string;
 		name?: string;
 	};
 	lastDisconnectReason?: string;


### PR DESCRIPTION
## Summary

- expose the authenticated Baileys creds.me.lid through the internal sidecar health contract
- persist the verified PN/LID pair during managed and custom onboarding
- self-heal existing Hermes credentials on the next Noise handshake without rotating Noise or Signal keys
- fail closed into explicit repair or re-onboarding when the physical credential has no real LID
- keep the missing-enc outbound drop unchanged

## Verification

- sidecar Docker typecheck and tests: 72 passed
- focused backend Docker suite: 136 passed, 6 skipped
- pair-code and runtime credential boundaries: 5 passed
- Ruff check and format check passed
- git diff --check passed

The 6 skipped tests are the existing real-Baileys authCert seam gate. The gated smoke now asserts the PN/LID identity, messages.upsert delivery, and encrypted reply round trip.

## Rollout

No database migration. Deploy the sidecar before or together with the backend. Existing authenticated sidecar credentials are healed automatically when creds.me.lid is available; a physical credential that genuinely lacks LID requires explicit rotation or re-onboarding.