### PR TITLE
Fix Stripe wallet return and theme handling

### DIFF
--- a/apps/web/src/client.tsx
+++ b/apps/web/src/client.tsx
@@ -1,4 +1,6 @@
-// Sentry initialization must be the first import so pre-hydration errors are captured.
+// Remove Stripe return secrets before telemetry modules evaluate.
+import "./wallet-topup-return.bootstrap";
+
 import "./instrument.client";
 
 import { StartClient } from "@tanstack/react-start/client";

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -46,7 +46,7 @@ describe("idempotent billing transport", () => {
 	});
 
 	it("does not retry responses, aborts, or a second network failure", async () => {
-		for (const scenario of ["response", "abort", "second-failure"] as const) {
+		for (const scenario of ["response", "abort", "other-endpoint", "second-failure"] as const) {
 			let calls = 0;
 			const controller = new AbortController();
 			const transport = retryIdempotentBillingTransport(async () => {
@@ -55,7 +55,8 @@ describe("idempotent billing transport", () => {
 				if (scenario === "abort") controller.abort();
 				throw new BillingNetworkError("offline");
 			});
-			const request = new Request("https://api.clawdi.ai/v2/wallet/topup", {
+			const path = scenario === "other-endpoint" ? "/v2/subscription/checkout" : "/v2/wallet/topup";
+			const request = new Request(`https://api.clawdi.ai${path}`, {
 				method: "POST",
 				headers: { "Idempotency-Key": "topup-1" },
 				signal: controller.signal,

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
 	acceptDeclarativeOperation,
 	createBillingClient,
+	retryIdempotentBillingTransport,
 	unwrapDeploy,
 } from "@/hosted/billing/billing-client";
 import { hostedApiBaseUrl } from "@/hosted/billing/billing-url";
@@ -17,6 +18,54 @@ import {
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
 const NOW = "2026-07-22T00:00:00Z";
+
+describe("idempotent billing transport", () => {
+	it("retries one network failure with the exact request", async () => {
+		const seen: Array<{ body: string; key: string | null; auth: string | null }> = [];
+		const transport = retryIdempotentBillingTransport(async (request) => {
+			seen.push({
+				body: await request.text(),
+				key: request.headers.get("Idempotency-Key"),
+				auth: request.headers.get("Authorization"),
+			});
+			if (seen.length === 1) throw new BillingNetworkError("offline");
+			return new Response(null, { status: 204 });
+		});
+		const response = await transport(
+			new Request("https://api.clawdi.ai/v2/wallet/topup", {
+				method: "POST",
+				headers: { "Idempotency-Key": "topup-1", Authorization: "Bearer token" },
+				body: '{"amount_usd":12}',
+			}),
+		);
+		expect(response.status).toBe(204);
+		expect(seen).toEqual([
+			{ body: '{"amount_usd":12}', key: "topup-1", auth: "Bearer token" },
+			{ body: '{"amount_usd":12}', key: "topup-1", auth: "Bearer token" },
+		]);
+	});
+
+	it("does not retry responses, aborts, or a second network failure", async () => {
+		for (const scenario of ["response", "abort", "second-failure"] as const) {
+			let calls = 0;
+			const controller = new AbortController();
+			const transport = retryIdempotentBillingTransport(async () => {
+				calls += 1;
+				if (scenario === "response") return new Response(null, { status: 502 });
+				if (scenario === "abort") controller.abort();
+				throw new BillingNetworkError("offline");
+			});
+			const request = new Request("https://api.clawdi.ai/v2/wallet/topup", {
+				method: "POST",
+				headers: { "Idempotency-Key": "topup-1" },
+				signal: controller.signal,
+			});
+			if (scenario === "response") expect((await transport(request)).status).toBe(502);
+			else await expect(transport(request)).rejects.toBeInstanceOf(BillingNetworkError);
+			expect(calls).toBe(scenario === "second-failure" ? 2 : 1);
+		}
+	});
+});
 
 function jsonResponse(body: unknown, status = 200): Response {
 	return new Response(JSON.stringify(body), {

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -111,8 +111,11 @@ export function retryIdempotentBillingTransport(fetcher: BillingFetch): BillingF
 			return await fetcher(request);
 		} catch (error) {
 			const idempotencyKey = request.headers.get("Idempotency-Key");
+			const url = new URL(request.url);
 			if (
 				!(error instanceof BillingNetworkError) ||
+				request.method !== "POST" ||
+				url.pathname !== "/v2/wallet/topup" ||
 				!idempotencyKey?.trim() ||
 				request.signal.aborted
 			) {

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -104,6 +104,25 @@ function fetchWithTimeout(request: Request, init?: RequestInit): Promise<Respons
 		});
 }
 
+export function retryIdempotentBillingTransport(fetcher: BillingFetch): BillingFetch {
+	return async (request) => {
+		const retryRequest = request.clone();
+		try {
+			return await fetcher(request);
+		} catch (error) {
+			const idempotencyKey = request.headers.get("Idempotency-Key");
+			if (
+				!(error instanceof BillingNetworkError) ||
+				!idempotencyKey?.trim() ||
+				request.signal.aborted
+			) {
+				throw error;
+			}
+			return fetcher(retryRequest);
+		}
+	};
+}
+
 export function unwrapDeploy<T>(result: DeployResult<T>): T {
 	if (result.error !== undefined || !result.response.ok) {
 		const detail =
@@ -299,7 +318,7 @@ export function createBillingClient(
 ) {
 	const api = createClient<DeployPaths>({
 		baseUrl: ROOT_BASE_URL,
-		fetch: options.fetch ?? fetchWithTimeout,
+		fetch: retryIdempotentBillingTransport(options.fetch ?? fetchWithTimeout),
 	});
 	api.use({
 		async onRequest({ request }) {

--- a/apps/web/src/hosted/billing/components/stripe-checkout-dialog.tsx
+++ b/apps/web/src/hosted/billing/components/stripe-checkout-dialog.tsx
@@ -25,6 +25,7 @@ import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
 import { useDialogExitLifecycle } from "@/components/ui/use-dialog-exit-lifecycle";
 import { getStripe, resetStripeCache } from "@/hosted/billing/stripe";
+import { useStripeAppearance } from "@/hosted/billing/stripe-appearance";
 import type { CheckoutSessionClientSecret } from "@/hosted/billing/stripe-client-secret";
 import { env } from "@/lib/env";
 import {
@@ -55,91 +56,6 @@ type RetainedCheckout = Pick<
 	StripeCheckoutDialogProps,
 	"clientSecret" | "description" | "summary" | "title"
 >;
-type CheckoutAppearance = NonNullable<
-	NonNullable<StripeCheckoutElementsSdkOptions["elementsOptions"]>["appearance"]
->;
-
-const FALLBACK_THEME = {
-	background: "oklch(0.175 0.004 95)",
-	border: "oklch(0.275 0.005 95)",
-	destructive: "oklch(0.62 0.19 27)",
-	foreground: "oklch(0.92 0.004 95)",
-	input: "oklch(0.33 0.006 95)",
-	muted: "oklch(0.245 0.005 95)",
-	mutedForeground: "oklch(0.63 0.006 95)",
-	primary: "oklch(0.6724 0.1308 38.7559)",
-	radius: "0.625rem",
-};
-
-function checkoutAppearanceFromTheme(): CheckoutAppearance {
-	const style =
-		typeof window === "undefined" ? null : window.getComputedStyle(document.documentElement);
-	const token = (name: string, fallback: string) =>
-		style?.getPropertyValue(name).trim() || fallback;
-	const isDark =
-		typeof document !== "undefined" && document.documentElement.classList.contains("dark");
-
-	return {
-		theme: isDark ? "night" : "stripe",
-		variables: {
-			borderRadius: token("--radius", FALLBACK_THEME.radius),
-			colorBackground: token("--background", FALLBACK_THEME.background),
-			colorDanger: token("--destructive", FALLBACK_THEME.destructive),
-			colorIconTab: token("--muted-foreground", FALLBACK_THEME.mutedForeground),
-			colorIconTabSelected: token("--primary", FALLBACK_THEME.primary),
-			colorPrimary: token("--primary", FALLBACK_THEME.primary),
-			colorText: token("--foreground", FALLBACK_THEME.foreground),
-			colorTextPlaceholder: token("--muted-foreground", FALLBACK_THEME.mutedForeground),
-			colorTextSecondary: token("--muted-foreground", FALLBACK_THEME.mutedForeground),
-			fontFamily: token("--font-sans", '"Geist Sans", sans-serif'),
-			spacingUnit: "4px",
-		},
-		rules: {
-			".Block": {
-				backgroundColor: token("--muted", FALLBACK_THEME.muted),
-				borderColor: token("--border", FALLBACK_THEME.border),
-			},
-			".Input": {
-				backgroundColor: token("--background", FALLBACK_THEME.background),
-				borderColor: token("--input", FALLBACK_THEME.input),
-				boxShadow: "none",
-			},
-			".Input:focus": {
-				borderColor: token("--primary", FALLBACK_THEME.primary),
-				boxShadow: "none",
-			},
-			".Tab": {
-				backgroundColor: token("--muted", FALLBACK_THEME.muted),
-				borderColor: token("--border", FALLBACK_THEME.border),
-				boxShadow: "none",
-			},
-			".Tab--selected": {
-				borderColor: token("--primary", FALLBACK_THEME.primary),
-				boxShadow: "none",
-			},
-		},
-	};
-}
-
-function useCheckoutAppearance(open: boolean): CheckoutAppearance {
-	const [appearance, setAppearance] = useState<CheckoutAppearance>(() =>
-		checkoutAppearanceFromTheme(),
-	);
-
-	useEffect(() => {
-		if (!open || typeof MutationObserver === "undefined") return;
-		const update = () => setAppearance(checkoutAppearanceFromTheme());
-		update();
-		const observer = new MutationObserver(update);
-		observer.observe(document.documentElement, {
-			attributeFilter: ["class", "style"],
-			attributes: true,
-		});
-		return () => observer.disconnect();
-	}, [open]);
-
-	return appearance;
-}
 
 function CheckoutSummaryPanel({ summary }: { summary: StripeCheckoutSummary | null }) {
 	if (!summary) return null;
@@ -329,7 +245,7 @@ export function StripeCheckoutDialog({
 		value: checkout,
 		emptyValue: { clientSecret: null, description: "", summary: null, title: "" },
 	});
-	const appearance = useCheckoutAppearance(open);
+	const appearance = useStripeAppearance(open);
 
 	const renderedCheckout = exit.renderedValue;
 	const renderedClientSecret = renderedCheckout.clientSecret;

--- a/apps/web/src/hosted/billing/stripe-appearance.test.ts
+++ b/apps/web/src/hosted/billing/stripe-appearance.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+	stripeAppearanceForTheme,
+	watchStripeThemeChanges,
+} from "@/hosted/billing/stripe-appearance";
+
+describe("Stripe appearance", () => {
+	test("maps light and dark theme snapshots", () => {
+		expect(stripeAppearanceForTheme(false).theme).toBe("stripe");
+		expect(stripeAppearanceForTheme(true).theme).toBe("night");
+	});
+
+	test("updates immediately and on a live root theme change", () => {
+		const update = mock(() => {});
+		let notify = () => {};
+		const disconnect = mock(() => {});
+
+		const cleanup = watchStripeThemeChanges(update, (onMutation) => {
+			notify = onMutation;
+			return disconnect;
+		});
+		notify();
+		cleanup();
+
+		expect(update).toHaveBeenCalledTimes(2);
+		expect(disconnect).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/hosted/billing/stripe-appearance.test.ts
+++ b/apps/web/src/hosted/billing/stripe-appearance.test.ts
@@ -6,8 +6,15 @@ import {
 
 describe("Stripe appearance", () => {
 	test("maps light and dark theme snapshots", () => {
-		expect(stripeAppearanceForTheme(false).theme).toBe("stripe");
-		expect(stripeAppearanceForTheme(true).theme).toBe("night");
+		const light = stripeAppearanceForTheme(false);
+		const dark = stripeAppearanceForTheme(true);
+		expect(light.theme).toBe("stripe");
+		expect(dark.theme).toBe("night");
+		expect(light.variables?.colorBackground).toBe("oklch(0.985 0.0025 95)");
+		expect(light.variables?.colorText).toBe("oklch(0.235 0.008 95)");
+		expect(dark.variables?.colorBackground).toBe("oklch(0.175 0.004 95)");
+		expect(dark.variables?.colorText).toBe("oklch(0.92 0.004 95)");
+		expect(light.variables?.colorBackground).not.toBe(dark.variables?.colorBackground);
 	});
 
 	test("updates immediately and on a live root theme change", () => {

--- a/apps/web/src/hosted/billing/stripe-appearance.ts
+++ b/apps/web/src/hosted/billing/stripe-appearance.ts
@@ -1,0 +1,102 @@
+import type { Appearance, StripeCheckoutElementsSdkOptions } from "@stripe/stripe-js";
+import { useEffect, useState } from "react";
+
+type CheckoutAppearance = NonNullable<
+	NonNullable<StripeCheckoutElementsSdkOptions["elementsOptions"]>["appearance"]
+>;
+
+const FALLBACK_THEME = {
+	background: "oklch(0.175 0.004 95)",
+	border: "oklch(0.275 0.005 95)",
+	destructive: "oklch(0.62 0.19 27)",
+	foreground: "oklch(0.92 0.004 95)",
+	input: "oklch(0.33 0.006 95)",
+	muted: "oklch(0.245 0.005 95)",
+	mutedForeground: "oklch(0.63 0.006 95)",
+	primary: "oklch(0.6724 0.1308 38.7559)",
+	radius: "0.625rem",
+};
+
+export function stripeAppearanceForTheme(
+	isDark: boolean,
+	token: (name: string, fallback: string) => string = (_name, fallback) => fallback,
+): Appearance & CheckoutAppearance {
+	return {
+		theme: isDark ? "night" : "stripe",
+		variables: {
+			borderRadius: token("--radius", FALLBACK_THEME.radius),
+			colorBackground: token("--background", FALLBACK_THEME.background),
+			colorDanger: token("--destructive", FALLBACK_THEME.destructive),
+			colorIconTab: token("--muted-foreground", FALLBACK_THEME.mutedForeground),
+			colorIconTabSelected: token("--primary", FALLBACK_THEME.primary),
+			colorPrimary: token("--primary", FALLBACK_THEME.primary),
+			colorText: token("--foreground", FALLBACK_THEME.foreground),
+			colorTextPlaceholder: token("--muted-foreground", FALLBACK_THEME.mutedForeground),
+			colorTextSecondary: token("--muted-foreground", FALLBACK_THEME.mutedForeground),
+			fontFamily: token("--font-sans", '"Geist Sans", sans-serif'),
+			spacingUnit: "4px",
+		},
+		rules: {
+			".Block": {
+				backgroundColor: token("--muted", FALLBACK_THEME.muted),
+				borderColor: token("--border", FALLBACK_THEME.border),
+			},
+			".Input": {
+				backgroundColor: token("--background", FALLBACK_THEME.background),
+				borderColor: token("--input", FALLBACK_THEME.input),
+				boxShadow: "none",
+			},
+			".Input:focus": {
+				borderColor: token("--primary", FALLBACK_THEME.primary),
+				boxShadow: "none",
+			},
+			".Tab": {
+				backgroundColor: token("--muted", FALLBACK_THEME.muted),
+				borderColor: token("--border", FALLBACK_THEME.border),
+				boxShadow: "none",
+			},
+			".Tab--selected": {
+				borderColor: token("--primary", FALLBACK_THEME.primary),
+				boxShadow: "none",
+			},
+		},
+	};
+}
+
+export function stripeAppearanceFromTheme(): Appearance & CheckoutAppearance {
+	const style =
+		typeof window === "undefined" ? null : window.getComputedStyle(document.documentElement);
+	const token = (name: string, fallback: string) =>
+		style?.getPropertyValue(name).trim() || fallback;
+	const isDark =
+		typeof document !== "undefined" && document.documentElement.classList.contains("dark");
+	return stripeAppearanceForTheme(isDark, token);
+}
+
+type ThemeChangeSubscription = (update: () => void) => () => void;
+
+export function watchStripeThemeChanges(
+	update: () => void,
+	subscribe: ThemeChangeSubscription = (onMutation) => {
+		const observer = new MutationObserver(onMutation);
+		observer.observe(document.documentElement, {
+			attributeFilter: ["class", "style"],
+			attributes: true,
+		});
+		return () => observer.disconnect();
+	},
+): () => void {
+	update();
+	return subscribe(update);
+}
+
+export function useStripeAppearance(active = true): Appearance & CheckoutAppearance {
+	const [appearance, setAppearance] = useState(stripeAppearanceFromTheme);
+
+	useEffect(() => {
+		if (!active || typeof MutationObserver === "undefined") return;
+		return watchStripeThemeChanges(() => setAppearance(stripeAppearanceFromTheme()));
+	}, [active]);
+
+	return appearance;
+}

--- a/apps/web/src/hosted/billing/stripe-appearance.ts
+++ b/apps/web/src/hosted/billing/stripe-appearance.ts
@@ -5,7 +5,7 @@ type CheckoutAppearance = NonNullable<
 	NonNullable<StripeCheckoutElementsSdkOptions["elementsOptions"]>["appearance"]
 >;
 
-const FALLBACK_THEME = {
+const DARK_FALLBACK_THEME = {
 	background: "oklch(0.175 0.004 95)",
 	border: "oklch(0.275 0.005 95)",
 	destructive: "oklch(0.62 0.19 27)",
@@ -17,46 +17,59 @@ const FALLBACK_THEME = {
 	radius: "0.625rem",
 };
 
+const LIGHT_FALLBACK_THEME = {
+	background: "oklch(0.985 0.0025 95)",
+	border: "oklch(0.91 0.005 95)",
+	destructive: "oklch(0.55 0.19 27)",
+	foreground: "oklch(0.235 0.008 95)",
+	input: "oklch(0.87 0.006 95)",
+	muted: "oklch(0.955 0.004 95)",
+	mutedForeground: "oklch(0.51 0.008 95)",
+	primary: "oklch(0.6171 0.1375 39.0427)",
+	radius: "0.625rem",
+};
+
 export function stripeAppearanceForTheme(
 	isDark: boolean,
 	token: (name: string, fallback: string) => string = (_name, fallback) => fallback,
 ): Appearance & CheckoutAppearance {
+	const fallback = isDark ? DARK_FALLBACK_THEME : LIGHT_FALLBACK_THEME;
 	return {
 		theme: isDark ? "night" : "stripe",
 		variables: {
-			borderRadius: token("--radius", FALLBACK_THEME.radius),
-			colorBackground: token("--background", FALLBACK_THEME.background),
-			colorDanger: token("--destructive", FALLBACK_THEME.destructive),
-			colorIconTab: token("--muted-foreground", FALLBACK_THEME.mutedForeground),
-			colorIconTabSelected: token("--primary", FALLBACK_THEME.primary),
-			colorPrimary: token("--primary", FALLBACK_THEME.primary),
-			colorText: token("--foreground", FALLBACK_THEME.foreground),
-			colorTextPlaceholder: token("--muted-foreground", FALLBACK_THEME.mutedForeground),
-			colorTextSecondary: token("--muted-foreground", FALLBACK_THEME.mutedForeground),
+			borderRadius: token("--radius", fallback.radius),
+			colorBackground: token("--background", fallback.background),
+			colorDanger: token("--destructive", fallback.destructive),
+			colorIconTab: token("--muted-foreground", fallback.mutedForeground),
+			colorIconTabSelected: token("--primary", fallback.primary),
+			colorPrimary: token("--primary", fallback.primary),
+			colorText: token("--foreground", fallback.foreground),
+			colorTextPlaceholder: token("--muted-foreground", fallback.mutedForeground),
+			colorTextSecondary: token("--muted-foreground", fallback.mutedForeground),
 			fontFamily: token("--font-sans", '"Geist Sans", sans-serif'),
 			spacingUnit: "4px",
 		},
 		rules: {
 			".Block": {
-				backgroundColor: token("--muted", FALLBACK_THEME.muted),
-				borderColor: token("--border", FALLBACK_THEME.border),
+				backgroundColor: token("--muted", fallback.muted),
+				borderColor: token("--border", fallback.border),
 			},
 			".Input": {
-				backgroundColor: token("--background", FALLBACK_THEME.background),
-				borderColor: token("--input", FALLBACK_THEME.input),
+				backgroundColor: token("--background", fallback.background),
+				borderColor: token("--input", fallback.input),
 				boxShadow: "none",
 			},
 			".Input:focus": {
-				borderColor: token("--primary", FALLBACK_THEME.primary),
+				borderColor: token("--primary", fallback.primary),
 				boxShadow: "none",
 			},
 			".Tab": {
-				backgroundColor: token("--muted", FALLBACK_THEME.muted),
-				borderColor: token("--border", FALLBACK_THEME.border),
+				backgroundColor: token("--muted", fallback.muted),
+				borderColor: token("--border", fallback.border),
 				boxShadow: "none",
 			},
 			".Tab--selected": {
-				borderColor: token("--primary", FALLBACK_THEME.primary),
+				borderColor: token("--primary", fallback.primary),
 				boxShadow: "none",
 			},
 		},

--- a/apps/web/src/hosted/billing/wallet/stripe-payment-form.tsx
+++ b/apps/web/src/hosted/billing/wallet/stripe-payment-form.tsx
@@ -8,6 +8,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { getStripe, resetStripeCache } from "@/hosted/billing/stripe";
+import { useStripeAppearance } from "@/hosted/billing/stripe-appearance";
 import type { PaymentIntentClientSecret } from "@/hosted/billing/stripe-client-secret";
 import {
 	type PaymentOutcome,
@@ -132,6 +133,7 @@ export function StripePaymentForm({
 	const key = env.VITE_STRIPE_PUBLISHABLE_KEY;
 	const [stripe, setStripe] = useState<Stripe | null | undefined>(undefined);
 	const [attempt, setAttempt] = useState(0);
+	const appearance = useStripeAppearance();
 
 	useEffect(() => {
 		if (!key) return;
@@ -200,7 +202,7 @@ export function StripePaymentForm({
 
 	return (
 		<div data-hosted="true">
-			<Elements stripe={stripe} options={{ clientSecret, appearance: { theme: "stripe" } }}>
+			<Elements stripe={stripe} options={{ clientSecret, appearance }}>
 				<InnerForm
 					onComplete={onComplete}
 					onCancel={onCancel}

--- a/apps/web/src/hosted/billing/wallet/top-up-return.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-return.logic.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
+	bootstrapWalletTopupReturn,
 	buildWalletTopupReturnUrl,
+	cleanMarkedWalletTopupReturnRequest,
 	cleanWalletTopupReturnUrl,
 	consumeWalletTopupReturn,
+	coordinateWalletTopupReturn,
 	readWalletTopupReturn,
 	walletTopupReturnToast,
 } from "@/hosted/billing/wallet/top-up-return.logic";
@@ -27,6 +30,43 @@ describe("wallet top-up return URL helpers", () => {
 
 		expect(result?.clientSecret === "pi_secret").toBe(true);
 		expect(calls).toEqual([[state, "", "https://cloud.clawdi.ai/?settings=billing-wallet&keep=1"]]);
+	});
+
+	test("bootstraps before consumers and coordinates retrieval across remounts", async () => {
+		const state = { key: "router-entry", __TSR_index: 4 };
+		const calls: unknown[][] = [];
+		bootstrapWalletTopupReturn(
+			"https://cloud.clawdi.ai/?keep=1&topup_return=1&payment_intent_client_secret=pi_secret#billing",
+			state,
+			(...args) => calls.push(args),
+		);
+
+		expect(calls).toEqual([[state, "", "https://cloud.clawdi.ai/?keep=1#billing"]]);
+		let retrievals = 0;
+		const retrieve = async () => {
+			retrievals += 1;
+			return { status: "succeeded", paymentIntentId: "pi_1", errorMessage: null };
+		};
+		const first = coordinateWalletTopupReturn(retrieve);
+		const remount = coordinateWalletTopupReturn(retrieve);
+		expect(remount).toBe(first);
+		expect(await remount).toEqual({
+			status: "succeeded",
+			paymentIntentId: "pi_1",
+			errorMessage: null,
+		});
+		expect(retrievals).toBe(1);
+	});
+
+	test("scrubs a marked server request before routing", async () => {
+		const request = new Request(
+			"https://cloud.clawdi.ai/?keep=1&topup_return=bad&payment_intent_client_secret=secret#billing",
+			{ method: "POST", headers: { Authorization: "Bearer token" }, body: "body" },
+		);
+		const clean = cleanMarkedWalletTopupReturnRequest(request);
+		expect(clean.url).toBe("https://cloud.clawdi.ai/?keep=1#billing");
+		expect(clean.headers.get("Authorization")).toBe("Bearer token");
+		expect(await clean.text()).toBe("body");
 	});
 
 	test("consumes malformed marked returns before returning null", () => {

--- a/apps/web/src/hosted/billing/wallet/top-up-return.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-return.logic.test.ts
@@ -2,15 +2,45 @@ import { describe, expect, test } from "bun:test";
 import {
 	buildWalletTopupReturnUrl,
 	cleanWalletTopupReturnUrl,
+	consumeWalletTopupReturn,
 	readWalletTopupReturn,
 	walletTopupReturnToast,
 } from "@/hosted/billing/wallet/top-up-return.logic";
 
 describe("wallet top-up return URL helpers", () => {
 	test("builds a wallet settings return URL with the top-up marker", () => {
-		const url = buildWalletTopupReturnUrl("https://cloud.clawdi.ai/?settings=general&x=1");
+		const url = buildWalletTopupReturnUrl(
+			"https://cloud.clawdi.ai/?settings=general&x=1&payment_intent=stale&payment_intent_client_secret=old&redirect_status=failed&topup_return=1",
+		);
 
 		expect(url).toBe("https://cloud.clawdi.ai/?settings=billing-wallet&x=1&topup_return=1");
+	});
+
+	test("synchronously consumes a valid return and preserves history state", () => {
+		const calls: unknown[][] = [];
+		const state = { key: "router-entry", __TSR_index: 4 };
+		const result = consumeWalletTopupReturn(
+			"https://cloud.clawdi.ai/?settings=billing-wallet&keep=1&topup_return=1&payment_intent=pi_1&payment_intent_client_secret=pi_secret&redirect_status=succeeded",
+			state,
+			(...args) => calls.push(args),
+		);
+
+		expect(result?.clientSecret === "pi_secret").toBe(true);
+		expect(calls).toEqual([[state, "", "https://cloud.clawdi.ai/?settings=billing-wallet&keep=1"]]);
+	});
+
+	test("consumes malformed marked returns before returning null", () => {
+		for (const marker of ["1", "invalid"]) {
+			const calls: unknown[][] = [];
+			const result = consumeWalletTopupReturn(
+				`https://cloud.clawdi.ai/?topup_return=${marker}&redirect_status=succeeded&keep=1`,
+				null,
+				(...args) => calls.push(args),
+			);
+
+			expect(result).toBe(null);
+			expect(calls).toEqual([[null, "", "https://cloud.clawdi.ai/?keep=1"]]);
+		}
 	});
 
 	test("reads only marked Stripe PaymentIntent returns", () => {

--- a/apps/web/src/hosted/billing/wallet/top-up-return.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-return.logic.ts
@@ -21,6 +21,15 @@ export interface WalletTopupReturnToast {
 	description: string;
 }
 
+export interface WalletTopupReturnResolution {
+	status: string | null;
+	paymentIntentId: string | null;
+	errorMessage: string | null;
+}
+
+let pendingWalletTopupReturn: WalletTopupReturnState | null = null;
+let walletTopupReturnResolution: Promise<WalletTopupReturnResolution> | null = null;
+
 export const WALLET_TOPUP_ACCEPTED_TOAST = {
 	title: "Payment accepted",
 	description: "We're confirming your Wallet credit now.",
@@ -43,6 +52,31 @@ export function consumeWalletTopupReturn(
 	const result = readWalletTopupReturn(url.search);
 	replaceState(historyState, "", cleanWalletTopupReturnUrl(currentHref));
 	return result;
+}
+
+export function bootstrapWalletTopupReturn(
+	currentHref: string,
+	historyState: unknown,
+	replaceState: (state: unknown, unused: string, url: string) => void,
+): void {
+	pendingWalletTopupReturn = consumeWalletTopupReturn(currentHref, historyState, replaceState);
+}
+
+export function coordinateWalletTopupReturn(
+	retrieve: (clientSecret: PaymentIntentClientSecret) => Promise<WalletTopupReturnResolution>,
+): Promise<WalletTopupReturnResolution> | null {
+	if (walletTopupReturnResolution) return walletTopupReturnResolution;
+	if (!pendingWalletTopupReturn) return null;
+	const { clientSecret } = pendingWalletTopupReturn;
+	pendingWalletTopupReturn = null;
+	walletTopupReturnResolution = retrieve(clientSecret);
+	return walletTopupReturnResolution;
+}
+
+export function cleanMarkedWalletTopupReturnRequest(request: Request): Request {
+	const url = new URL(request.url);
+	if (!url.searchParams.has(WALLET_TOPUP_RETURN_PARAM)) return request;
+	return new Request(cleanWalletTopupReturnUrl(request.url), request);
 }
 
 export function readWalletTopupReturn(search: string): WalletTopupReturnState | null {

--- a/apps/web/src/hosted/billing/wallet/top-up-return.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-return.logic.ts
@@ -1,34 +1,22 @@
-import {
-	type PaymentIntentClientSecret,
-	stripeReturnPaymentIntentClientSecret,
-} from "@/hosted/billing/stripe-client-secret";
 import { SETTINGS_QUERY_KEY } from "@/lib/settings-routes";
+import { cleanWalletTopupReturnUrl, WALLET_TOPUP_RETURN_PARAM } from "@/lib/wallet-topup-return";
 
-export const WALLET_TOPUP_RETURN_PARAM = "topup_return";
-export const STRIPE_PAYMENT_INTENT_PARAM = "payment_intent";
-export const STRIPE_PAYMENT_INTENT_CLIENT_SECRET_PARAM = "payment_intent_client_secret";
-export const STRIPE_REDIRECT_STATUS_PARAM = "redirect_status";
+export {
+	bootstrapWalletTopupReturn,
+	cleanMarkedWalletTopupReturnRequest,
+	cleanWalletTopupReturnUrl,
+	consumeWalletTopupReturn,
+	coordinateWalletTopupReturn,
+	readWalletTopupReturn,
+} from "@/lib/wallet-topup-return";
 
 export type WalletTopupReturnToastKind = "info" | "error";
-
-export interface WalletTopupReturnState {
-	clientSecret: PaymentIntentClientSecret;
-}
 
 export interface WalletTopupReturnToast {
 	kind: WalletTopupReturnToastKind;
 	title: string;
 	description: string;
 }
-
-export interface WalletTopupReturnResolution {
-	status: string | null;
-	paymentIntentId: string | null;
-	errorMessage: string | null;
-}
-
-let pendingWalletTopupReturn: WalletTopupReturnState | null = null;
-let walletTopupReturnResolution: Promise<WalletTopupReturnResolution> | null = null;
 
 export const WALLET_TOPUP_ACCEPTED_TOAST = {
 	title: "Payment accepted",
@@ -39,62 +27,6 @@ export function buildWalletTopupReturnUrl(currentHref: string): string {
 	const url = new URL(cleanWalletTopupReturnUrl(currentHref));
 	url.searchParams.set(SETTINGS_QUERY_KEY, "billing-wallet");
 	url.searchParams.set(WALLET_TOPUP_RETURN_PARAM, "1");
-	return url.toString();
-}
-
-export function consumeWalletTopupReturn(
-	currentHref: string,
-	historyState: unknown,
-	replaceState: (state: unknown, unused: string, url: string) => void,
-): WalletTopupReturnState | null {
-	const url = new URL(currentHref);
-	if (!url.searchParams.has(WALLET_TOPUP_RETURN_PARAM)) return null;
-	const result = readWalletTopupReturn(url.search);
-	replaceState(historyState, "", cleanWalletTopupReturnUrl(currentHref));
-	return result;
-}
-
-export function bootstrapWalletTopupReturn(
-	currentHref: string,
-	historyState: unknown,
-	replaceState: (state: unknown, unused: string, url: string) => void,
-): void {
-	pendingWalletTopupReturn = consumeWalletTopupReturn(currentHref, historyState, replaceState);
-}
-
-export function coordinateWalletTopupReturn(
-	retrieve: (clientSecret: PaymentIntentClientSecret) => Promise<WalletTopupReturnResolution>,
-): Promise<WalletTopupReturnResolution> | null {
-	if (walletTopupReturnResolution) return walletTopupReturnResolution;
-	if (!pendingWalletTopupReturn) return null;
-	const { clientSecret } = pendingWalletTopupReturn;
-	pendingWalletTopupReturn = null;
-	walletTopupReturnResolution = retrieve(clientSecret);
-	return walletTopupReturnResolution;
-}
-
-export function cleanMarkedWalletTopupReturnRequest(request: Request): Request {
-	const url = new URL(request.url);
-	if (!url.searchParams.has(WALLET_TOPUP_RETURN_PARAM)) return request;
-	return new Request(cleanWalletTopupReturnUrl(request.url), request);
-}
-
-export function readWalletTopupReturn(search: string): WalletTopupReturnState | null {
-	const params = new URLSearchParams(search);
-	if (params.get(WALLET_TOPUP_RETURN_PARAM) !== "1") return null;
-	const clientSecret = stripeReturnPaymentIntentClientSecret(
-		params.get(STRIPE_PAYMENT_INTENT_CLIENT_SECRET_PARAM),
-	);
-	if (!clientSecret) return null;
-	return { clientSecret };
-}
-
-export function cleanWalletTopupReturnUrl(currentHref: string): string {
-	const url = new URL(currentHref);
-	url.searchParams.delete(WALLET_TOPUP_RETURN_PARAM);
-	url.searchParams.delete(STRIPE_PAYMENT_INTENT_PARAM);
-	url.searchParams.delete(STRIPE_PAYMENT_INTENT_CLIENT_SECRET_PARAM);
-	url.searchParams.delete(STRIPE_REDIRECT_STATUS_PARAM);
 	return url.toString();
 }
 

--- a/apps/web/src/hosted/billing/wallet/top-up-return.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-return.logic.ts
@@ -27,10 +27,22 @@ export const WALLET_TOPUP_ACCEPTED_TOAST = {
 } as const;
 
 export function buildWalletTopupReturnUrl(currentHref: string): string {
-	const url = new URL(currentHref);
+	const url = new URL(cleanWalletTopupReturnUrl(currentHref));
 	url.searchParams.set(SETTINGS_QUERY_KEY, "billing-wallet");
 	url.searchParams.set(WALLET_TOPUP_RETURN_PARAM, "1");
 	return url.toString();
+}
+
+export function consumeWalletTopupReturn(
+	currentHref: string,
+	historyState: unknown,
+	replaceState: (state: unknown, unused: string, url: string) => void,
+): WalletTopupReturnState | null {
+	const url = new URL(currentHref);
+	if (!url.searchParams.has(WALLET_TOPUP_RETURN_PARAM)) return null;
+	const result = readWalletTopupReturn(url.search);
+	replaceState(historyState, "", cleanWalletTopupReturnUrl(currentHref));
+	return result;
 }
 
 export function readWalletTopupReturn(search: string): WalletTopupReturnState | null {

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -17,8 +17,7 @@ import { BalanceCard } from "@/hosted/billing/wallet/balance-card";
 import { confirmWalletTopup, TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
 import { invalidateWalletData } from "@/hosted/billing/wallet/top-up-dialog.logic";
 import {
-	cleanWalletTopupReturnUrl,
-	readWalletTopupReturn,
+	consumeWalletTopupReturn,
 	type WalletTopupReturnToast,
 	walletTopupReturnToast,
 } from "@/hosted/billing/wallet/top-up-return.logic";
@@ -73,7 +72,11 @@ export function WalletPage() {
 	}
 
 	useEffect(() => {
-		const topupReturn = readWalletTopupReturn(window.location.search);
+		const topupReturn = consumeWalletTopupReturn(
+			window.location.href,
+			window.history.state,
+			window.history.replaceState.bind(window.history),
+		);
 		if (!topupReturn) return;
 		const { clientSecret } = topupReturn;
 		let cancelled = false;
@@ -114,10 +117,6 @@ export function WalletPage() {
 					toast.error("Couldn't refresh top-up", {
 						description: "Check your connection and reload Wallet.",
 					});
-				}
-			} finally {
-				if (!cancelled) {
-					window.history.replaceState(null, "", cleanWalletTopupReturnUrl(window.location.href));
 				}
 			}
 		}

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -17,7 +17,7 @@ import { BalanceCard } from "@/hosted/billing/wallet/balance-card";
 import { confirmWalletTopup, TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
 import { invalidateWalletData } from "@/hosted/billing/wallet/top-up-dialog.logic";
 import {
-	consumeWalletTopupReturn,
+	coordinateWalletTopupReturn,
 	type WalletTopupReturnToast,
 	walletTopupReturnToast,
 } from "@/hosted/billing/wallet/top-up-return.logic";
@@ -72,56 +72,66 @@ export function WalletPage() {
 	}
 
 	useEffect(() => {
-		const topupReturn = consumeWalletTopupReturn(
-			window.location.href,
-			window.history.state,
-			window.history.replaceState.bind(window.history),
-		);
-		if (!topupReturn) return;
-		const { clientSecret } = topupReturn;
 		let cancelled = false;
-
-		async function refreshReturnedTopup() {
+		const resolution = coordinateWalletTopupReturn(async (clientSecret) => {
 			try {
 				const key = env.VITE_STRIPE_PUBLISHABLE_KEY;
 				if (!key) {
 					toast.error("Couldn't refresh top-up", {
 						description: "Stripe isn't configured in this environment.",
 					});
-					return;
+					return {
+						status: null,
+						paymentIntentId: null,
+						errorMessage: "Stripe isn't configured in this environment.",
+					};
 				}
 				const stripe = await getStripe(key);
 				if (!stripe) {
 					toast.error("Couldn't refresh top-up", {
 						description: "Reload the page and try again.",
 					});
-					return;
+					return {
+						status: null,
+						paymentIntentId: null,
+						errorMessage: "Reload the page and try again.",
+					};
 				}
 				const result = await stripe.retrievePaymentIntent(clientSecret);
-				if (cancelled) return;
 				if (result.error) {
-					toast.error("Couldn't refresh top-up", {
-						description: result.error.message ?? "Open Wallet and try again.",
-					});
-					return;
+					return {
+						status: null,
+						paymentIntentId: null,
+						errorMessage: result.error.message ?? "Open Wallet and try again.",
+					};
 				}
 				const paymentIntent = result.paymentIntent;
-				const status = paymentIntent?.status;
-				showWalletTopupReturnToast(walletTopupReturnToast(status));
-				invalidateWalletData(queryClient);
-				if (status === "succeeded" || status === "processing" || status === "requires_capture") {
-					void confirmWalletTopup(queryClient, paymentIntent?.id ?? null);
-				}
+				return {
+					status: paymentIntent?.status ?? null,
+					paymentIntentId: paymentIntent?.id ?? null,
+					errorMessage: null,
+				};
 			} catch {
-				if (!cancelled) {
-					toast.error("Couldn't refresh top-up", {
-						description: "Check your connection and reload Wallet.",
-					});
-				}
+				return {
+					status: null,
+					paymentIntentId: null,
+					errorMessage: "Check your connection and reload Wallet.",
+				};
 			}
-		}
-
-		void refreshReturnedTopup();
+		});
+		if (!resolution) return;
+		void resolution.then(({ status, paymentIntentId, errorMessage }) => {
+			if (cancelled) return;
+			if (errorMessage) {
+				toast.error("Couldn't refresh top-up", { description: errorMessage });
+				return;
+			}
+			showWalletTopupReturnToast(walletTopupReturnToast(status));
+			invalidateWalletData(queryClient);
+			if (status === "succeeded" || status === "processing" || status === "requires_capture") {
+				void confirmWalletTopup(queryClient, paymentIntentId);
+			}
+		});
 		return () => {
 			cancelled = true;
 		};

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -77,9 +77,6 @@ export function WalletPage() {
 			try {
 				const key = env.VITE_STRIPE_PUBLISHABLE_KEY;
 				if (!key) {
-					toast.error("Couldn't refresh top-up", {
-						description: "Stripe isn't configured in this environment.",
-					});
 					return {
 						status: null,
 						paymentIntentId: null,
@@ -88,9 +85,6 @@ export function WalletPage() {
 				}
 				const stripe = await getStripe(key);
 				if (!stripe) {
-					toast.error("Couldn't refresh top-up", {
-						description: "Reload the page and try again.",
-					});
 					return {
 						status: null,
 						paymentIntentId: null,

--- a/apps/web/src/hosted/oss-clean.test.ts
+++ b/apps/web/src/hosted/oss-clean.test.ts
@@ -411,6 +411,12 @@ describe("@xterm packages are hosted-only", () => {
 });
 
 describe("instrumentation-client hosted imports", () => {
+	test("server instrumentation is the first static import", () => {
+		const serverEntry = readFileSync(join(SRC_DIR, "server.ts"), "utf8");
+		expect(serverEntry.trimStart().startsWith('import "../instrument.server.mjs";')).toBe(true);
+		expect(serverEntry).not.toContain('await import("../instrument.server.mjs")');
+	});
+
 	test("hosted dynamic imports are gated by compile-time hosted checks", () => {
 		const instrumentationClient = join(SRC_DIR, "..", "instrumentation-client.ts");
 		if (!existsSync(instrumentationClient)) return;

--- a/apps/web/src/lib/wallet-topup-return.ts
+++ b/apps/web/src/lib/wallet-topup-return.ts
@@ -1,0 +1,71 @@
+export const WALLET_TOPUP_RETURN_PARAM = "topup_return";
+export const STRIPE_PAYMENT_INTENT_PARAM = "payment_intent";
+export const STRIPE_PAYMENT_INTENT_CLIENT_SECRET_PARAM = "payment_intent_client_secret";
+export const STRIPE_REDIRECT_STATUS_PARAM = "redirect_status";
+
+export interface WalletTopupReturnState {
+	clientSecret: string;
+}
+
+export interface WalletTopupReturnResolution {
+	status: string | null;
+	paymentIntentId: string | null;
+	errorMessage: string | null;
+}
+
+let pendingReturn: WalletTopupReturnState | null = null;
+let resolution: Promise<WalletTopupReturnResolution> | null = null;
+
+export function readWalletTopupReturn(search: string): WalletTopupReturnState | null {
+	const params = new URLSearchParams(search);
+	if (params.get(WALLET_TOPUP_RETURN_PARAM) !== "1") return null;
+	const clientSecret = params.get(STRIPE_PAYMENT_INTENT_CLIENT_SECRET_PARAM);
+	if (!clientSecret?.trim()) return null;
+	return { clientSecret };
+}
+
+export function cleanWalletTopupReturnUrl(currentHref: string): string {
+	const url = new URL(currentHref);
+	url.searchParams.delete(WALLET_TOPUP_RETURN_PARAM);
+	url.searchParams.delete(STRIPE_PAYMENT_INTENT_PARAM);
+	url.searchParams.delete(STRIPE_PAYMENT_INTENT_CLIENT_SECRET_PARAM);
+	url.searchParams.delete(STRIPE_REDIRECT_STATUS_PARAM);
+	return url.toString();
+}
+
+export function consumeWalletTopupReturn(
+	currentHref: string,
+	historyState: unknown,
+	replaceState: (state: unknown, unused: string, url: string) => void,
+): WalletTopupReturnState | null {
+	const url = new URL(currentHref);
+	if (!url.searchParams.has(WALLET_TOPUP_RETURN_PARAM)) return null;
+	const result = readWalletTopupReturn(url.search);
+	replaceState(historyState, "", cleanWalletTopupReturnUrl(currentHref));
+	return result;
+}
+
+export function bootstrapWalletTopupReturn(
+	currentHref: string,
+	historyState: unknown,
+	replaceState: (state: unknown, unused: string, url: string) => void,
+): void {
+	pendingReturn = consumeWalletTopupReturn(currentHref, historyState, replaceState);
+}
+
+export function coordinateWalletTopupReturn(
+	retrieve: (clientSecret: string) => Promise<WalletTopupReturnResolution>,
+): Promise<WalletTopupReturnResolution> | null {
+	if (resolution) return resolution;
+	if (!pendingReturn) return null;
+	const { clientSecret } = pendingReturn;
+	pendingReturn = null;
+	resolution = retrieve(clientSecret);
+	return resolution;
+}
+
+export function cleanMarkedWalletTopupReturnRequest(request: Request): Request {
+	const url = new URL(request.url);
+	if (!url.searchParams.has(WALLET_TOPUP_RETURN_PARAM)) return request;
+	return new Request(cleanWalletTopupReturnUrl(request.url), request);
+}

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -1,6 +1,6 @@
 import { wrapFetchWithSentry } from "@sentry/tanstackstart-react";
 import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
-import { cleanMarkedWalletTopupReturnRequest } from "@/hosted/billing/wallet/top-up-return.logic";
+import { cleanMarkedWalletTopupReturnRequest } from "@/lib/wallet-topup-return";
 
 await import("../instrument.server.mjs");
 

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -1,14 +1,20 @@
-import "../instrument.server.mjs";
-
 import { wrapFetchWithSentry } from "@sentry/tanstackstart-react";
 import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
+import { cleanMarkedWalletTopupReturnRequest } from "@/hosted/billing/wallet/top-up-return.logic";
 
-const serverEntry = {
+await import("../instrument.server.mjs");
+
+const routerEntry = {
 	fetch(request: Request) {
 		return handler.fetch(request);
 	},
 };
+const instrumentedEntry = process.env.VITE_SENTRY_DSN
+	? wrapFetchWithSentry(routerEntry)
+	: routerEntry;
 
-export default createServerEntry(
-	process.env.VITE_SENTRY_DSN ? wrapFetchWithSentry(serverEntry) : serverEntry,
-);
+export default createServerEntry({
+	fetch(request: Request) {
+		return instrumentedEntry.fetch(cleanMarkedWalletTopupReturnRequest(request));
+	},
+});

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -1,8 +1,8 @@
+import "../instrument.server.mjs";
+
 import { wrapFetchWithSentry } from "@sentry/tanstackstart-react";
 import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
 import { cleanMarkedWalletTopupReturnRequest } from "@/lib/wallet-topup-return";
-
-await import("../instrument.server.mjs");
 
 const routerEntry = {
 	fetch(request: Request) {

--- a/apps/web/src/wallet-topup-return.bootstrap.ts
+++ b/apps/web/src/wallet-topup-return.bootstrap.ts
@@ -1,0 +1,9 @@
+import { bootstrapWalletTopupReturn } from "@/hosted/billing/wallet/top-up-return.logic";
+
+if (typeof window !== "undefined") {
+	bootstrapWalletTopupReturn(
+		window.location.href,
+		window.history.state,
+		window.history.replaceState.bind(window.history),
+	);
+}

--- a/apps/web/src/wallet-topup-return.bootstrap.ts
+++ b/apps/web/src/wallet-topup-return.bootstrap.ts
@@ -1,4 +1,4 @@
-import { bootstrapWalletTopupReturn } from "@/hosted/billing/wallet/top-up-return.logic";
+import { bootstrapWalletTopupReturn } from "@/lib/wallet-topup-return";
 
 if (typeof window !== "undefined") {
 	bootstrapWalletTopupReturn(


### PR DESCRIPTION
## Summary

- consume Stripe wallet return parameters synchronously before async status retrieval while preserving TanStack Router history state
- remove stale Stripe return parameters when building a new return URL and sanitize malformed marked returns
- share the existing Stripe appearance token mapping across Checkout and PaymentIntent Elements
- use the Stripe light theme in light mode and night theme in dark mode, including live theme changes

## Payment flow

PaymentElement remains the payment-method selector. confirmPayment keeps redirect: if_required and the backend webhook remains authoritative for wallet credit.

## Verification

- web typecheck passed
- focused return and appearance tests passed
- isolated full web test and production build passed
- Biome and git diff checks passed

No API schema changes.