### PR TITLE
fix(runtime): exclude retired observation heads

### DIFF
--- a/backend/app/services/runtime_observation.py
+++ b/backend/app/services/runtime_observation.py
@@ -1169,6 +1169,7 @@ async def read_runtime_observations(
                 select(V2RuntimeObservationHead)
                 .where(
                     V2RuntimeObservationHead.environment_id == environment_id,
+                    V2RuntimeObservationHead.state == RUNTIME_OBSERVATION_HEAD_ACTIVE,
                     V2RuntimeObservationHead.generation == expected_apply_identity.generation,
                     V2RuntimeObservationHead.manifest_etag == expected_apply_identity.manifest_etag,
                     V2RuntimeObservationHead.apply_receipt_id

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -277,6 +277,14 @@ async def test_authorized_successor_atomically_tombstones_predecessor(
     seed_user,
 ):
     environment, _ = await _provision_environment(db_session, seed_user)
+    owner_id = seed_user.id
+    registration = await register_runtime_observation_consumer(
+        db_session,
+        environment_id=environment.id,
+        owner_id=owner_id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="handoff-controller",
+    )
     base = datetime.now(UTC)
     predecessor = _payload(
         boot_session_id="boot-session-predecessor",
@@ -340,6 +348,20 @@ async def test_authorized_successor_atomically_tombstones_predecessor(
     assert heads["boot-session-successor"].authorized_successor_boot_session_id == (
         "boot-session-next"
     )
+    page = await read_runtime_observations(
+        db_session,
+        environment_id=environment.id,
+        owner_id=owner_id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="handoff-controller",
+        expected_apply_identity=_expected_identity(),
+        after_cursor=registration["cursor"],
+        limit=100,
+    )
+    assert [head["runtimeIdentity"]["bootSessionId"] for head in page["heads"]] == [
+        "boot-session-successor"
+    ]
+    assert page["heads"][0]["state"] == "active"
 
     replay = await ingest_runtime_observation(
         db_session,
@@ -371,6 +393,14 @@ async def test_handoff_cannot_hide_an_unauthorized_active_head(
     seed_user,
 ):
     environment, _ = await _provision_environment(db_session, seed_user)
+    owner_id = seed_user.id
+    registration = await register_runtime_observation_consumer(
+        db_session,
+        environment_id=environment.id,
+        owner_id=owner_id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="ambiguous-handoff-controller",
+    )
     base = datetime.now(UTC)
     await ingest_runtime_observation(
         db_session,
@@ -430,6 +460,18 @@ async def test_handoff_cannot_hide_an_unauthorized_active_head(
         ).scalars()
     )
     assert active_sessions == {"boot-session-successor", "boot-session-unrelated"}
+    page = await read_runtime_observations(
+        db_session,
+        environment_id=environment.id,
+        owner_id=owner_id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="ambiguous-handoff-controller",
+        expected_apply_identity=_expected_identity(),
+        after_cursor=registration["cursor"],
+        limit=100,
+    )
+    assert {head["runtimeIdentity"]["bootSessionId"] for head in page["heads"]} == active_sessions
+    assert {head["state"] for head in page["heads"]} == {"active"}
 
 
 @pytest.mark.committed_db


### PR DESCRIPTION
## Root cause

A clean boot-session handoff keeps the predecessor as a retired tombstone, but the runtime observation read projected every head for the exact apply identity. Hosted correctly rejects retired heads on an active read, so both affected deployments became runtime_unreachable and Traefik withdrew their routes.

## Fix

- Return only active heads from the exact apply-identity read.
- Preserve retired tombstones in storage.
- Preserve every concurrent active head so ambiguity remains fail closed.
- Extend the existing handoff tests through the real read path.

## Verification

- Focused PostgreSQL regressions: 2 passed
- Isolated backend gate: 2260 passed, 12 skipped
- Ruff lint and touched-file formatting: passed
- Python compileall: passed
- Owned type gate: 186 files, 0 errors, 0 warnings
- git diff --check origin/main..HEAD: passed

The repository-wide ruff format check remains blocked by the pre-existing untouched backend/tests/test_projects_routes.py:234 baseline issue.