### PR TITLE
fix(web): stabilize hosted dashboard loading states

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1229,6 +1229,7 @@ type HostedApiStubOptions = {
 	canCreateCloudAgents?: boolean;
 	canUseLegacyHostedDashboard?: boolean;
 	productAccessRequests?: string[];
+	productAccessResponseGate?: Promise<void>;
 	cancelRequests?: string[];
 	cancelResponses?: StubResponse[];
 	checkoutRequests?: string[];
@@ -1278,7 +1279,7 @@ type HostedApiStubOptions = {
 	deploymentDetailResponses?: StubResponse[];
 	deploymentDetailResponseGates?: Array<Promise<void> | undefined>;
 	deploymentListRequests?: string[];
-	deploymentListResponses?: unknown[][];
+	deploymentListResponses?: Array<unknown[] | StubResponse>;
 	deploymentListResponseGates?: Array<Promise<void> | undefined>;
 	deploymentRequestReads?: string[];
 	deployments?: readonly unknown[];
@@ -1336,6 +1337,7 @@ type HostedApiStubOptions = {
 	walletState?: typeof walletState;
 	walletRequests?: string[];
 	walletResponses?: StubResponse[];
+	walletResponseGates?: Array<Promise<void> | undefined>;
 	onTopUpSuccess?: () => void;
 	onWalletCheckoutSuccess?: () => void;
 };
@@ -1459,6 +1461,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		const p = new URL(r.request().url()).pathname;
 		if (p === "/me" || p === "/v1/me") {
 			options.productAccessRequests?.push(`DEPLOY ${p}`);
+			await options.productAccessResponseGate;
 			return fulfillJson(
 				r,
 				hostedUser(
@@ -1486,6 +1489,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		if (p === "/v2/wallet" && r.request().method() === "GET") {
 			options.walletRequests?.push(r.request().url());
 			const response = options.walletResponses?.shift();
+			await options.walletResponseGates?.shift();
 			if (response) {
 				if (response.status < 400) currentWallet = response.body as typeof walletState;
 				return fulfillJson(r, response.body, response.status);
@@ -1523,6 +1527,9 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			const deploymentListResponseGate = options.deploymentListResponseGates?.shift();
 			if (deploymentListResponse) {
 				await deploymentListResponseGate;
+				if (isStubResponse(deploymentListResponse)) {
+					return fulfillJson(r, deploymentListResponse.body, deploymentListResponse.status);
+				}
 				return fulfillJson(
 					r,
 					deploymentListResponse.map((deployment) =>
@@ -1939,6 +1946,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		const p = url.pathname;
 		if (p === "/v1/me") {
 			options.productAccessRequests?.push(`CLOUD ${p}`);
+			await options.productAccessResponseGate;
 			return fulfillJson(
 				r,
 				hostedUser(
@@ -3203,6 +3211,270 @@ for (const projectionFailure of [
 		await expect(main).not.toContainText("projection gateway failed");
 	});
 }
+
+test("cold hosted live-tool routes keep full-bleed loading geometry", async ({ page }) => {
+	let releaseDeploymentList: (() => void) | undefined;
+	const deploymentListGate = new Promise<void>((resolve) => {
+		releaseDeploymentList = resolve;
+	});
+	await stubHostedApi(page, {
+		cloudAgents: [railHostedCloudAgent],
+		deploymentListResponses: [[railHostedDeployment]],
+		deploymentListResponseGates: [deploymentListGate],
+	});
+
+	try {
+		await page.goto(
+			`/agents/${railHostedEnvironmentId}/console?source=on-clawdi&d=${railHostedDeployment.id}`,
+		);
+		const loadingShell = page.getByTestId("agent-live-tool-loading-shell");
+		await expect(loadingShell).toBeVisible();
+		await expect(page.getByTestId("overview-status-card-skeleton")).toHaveCount(0);
+		const loadingBox = await loadingShell.boundingBox();
+		if (!loadingBox) throw new Error("Live-tool loading shell should have stable geometry.");
+
+		releaseDeploymentList?.();
+		const liveSurface = page.getByTestId("hosted-agent-live-surface");
+		await expect(liveSurface).toBeVisible();
+		const liveBox = await liveSurface.boundingBox();
+		if (!liveBox) throw new Error("Hosted live-tool surface should have stable geometry.");
+		expect(Math.abs(liveBox.x - loadingBox.x)).toBeLessThanOrEqual(1);
+		expect(Math.abs(liveBox.width - loadingBox.width)).toBeLessThanOrEqual(1);
+		expect(Math.abs(liveBox.height - loadingBox.height)).toBeLessThanOrEqual(1);
+	} finally {
+		releaseDeploymentList?.();
+	}
+});
+
+test("agent rail keeps its command anchor stable with one agent and retains cache after list failure", async ({
+	page,
+}) => {
+	let releaseColdList: (() => void) | undefined;
+	let releaseFailedRefetch: (() => void) | undefined;
+	const coldListGate = new Promise<void>((resolve) => {
+		releaseColdList = resolve;
+	});
+	const failedRefetchGate = new Promise<void>((resolve) => {
+		releaseFailedRefetch = resolve;
+	});
+	const deploymentListRequests: string[] = [];
+	const failedList = { body: { detail: "projection failed" }, status: 500 };
+	await stubHostedApi(page, {
+		cloudAgents: [railHostedCloudAgent],
+		deploymentListRequests,
+		deploymentListResponses: [[railHostedDeployment], failedList, failedList, failedList],
+		deploymentListResponseGates: [coldListGate, failedRefetchGate],
+	});
+
+	try {
+		await page.goto("/agents");
+		const rail = page.getByTestId("app-sidebar-agent-rail");
+		const newAgent = rail.getByRole("button", { name: "New agent" });
+		await expect(rail.getByTestId("app-sidebar-agent-loading-slot")).toHaveCount(2);
+		await expect(rail.getByTestId("app-sidebar-agent-tile")).toHaveCount(0);
+		await expect(rail.getByRole("button", { name: "e2e-2", exact: true })).toHaveCount(0);
+		const coldNewAgentBox = await newAgent.boundingBox();
+		if (!coldNewAgentBox) throw new Error("Cold rail New agent control should be visible.");
+
+		releaseColdList?.();
+		await expect(rail.getByTestId("app-sidebar-agent-tile")).toHaveCount(1);
+		await expect(rail.getByTestId("app-sidebar-agent-loading-slot")).toHaveCount(0);
+		const loadedNewAgentBox = await newAgent.boundingBox();
+		if (!loadedNewAgentBox) throw new Error("Loaded rail New agent control should be visible.");
+		expect(Math.abs(loadedNewAgentBox.x - coldNewAgentBox.x)).toBeLessThanOrEqual(1);
+		expect(Math.abs(loadedNewAgentBox.y - coldNewAgentBox.y)).toBeLessThanOrEqual(1);
+		expect(Math.abs(loadedNewAgentBox.width - coldNewAgentBox.width)).toBeLessThanOrEqual(1);
+		expect(Math.abs(loadedNewAgentBox.height - coldNewAgentBox.height)).toBeLessThanOrEqual(1);
+
+		await rail.getByRole("button", { name: "e2e-2", exact: true }).click();
+		await expect(page.locator('[data-agent-overview="hosted"]')).toBeVisible();
+		const currentTime = await page.evaluate(() => Date.now());
+		await page.clock.setFixedTime(currentTime + 31_000);
+		await page.evaluate(() => window.dispatchEvent(new Event("visibilitychange")));
+		await expect.poll(() => deploymentListRequests.length).toBeGreaterThanOrEqual(2);
+		await expect(rail.getByTestId("app-sidebar-agent-tile")).toHaveCount(1);
+		await expect(page.locator('[data-agent-overview="hosted"]')).toBeVisible();
+
+		releaseFailedRefetch?.();
+		await expect.poll(() => deploymentListRequests.length).toBe(4);
+		await expect(rail.getByTestId("app-sidebar-agent-tile")).toHaveCount(1);
+		await expect(page.locator('[data-agent-overview="hosted"]')).toBeVisible();
+	} finally {
+		releaseColdList?.();
+		releaseFailedRefetch?.();
+	}
+});
+
+test("header Wallet slot stays stable from unresolved access through a long balance", async ({
+	page,
+	browser,
+	baseURL,
+}) => {
+	if (!baseURL) throw new Error("Playwright baseURL is required for the Wallet header test.");
+	let releaseProductAccess: (() => void) | undefined;
+	let releaseDeploymentList: (() => void) | undefined;
+	let releaseWalletChunk: (() => void) | undefined;
+	let releaseWalletResponse: (() => void) | undefined;
+	const productAccessGate = new Promise<void>((resolve) => {
+		releaseProductAccess = resolve;
+	});
+	const deploymentListGate = new Promise<void>((resolve) => {
+		releaseDeploymentList = resolve;
+	});
+	const walletChunkGate = new Promise<void>((resolve) => {
+		releaseWalletChunk = resolve;
+	});
+	const walletResponseGate = new Promise<void>((resolve) => {
+		releaseWalletResponse = resolve;
+	});
+	const productAccessRequests: string[] = [];
+	const deploymentListRequests: string[] = [];
+	const walletRequests: string[] = [];
+	const longBalance = "$12,345,678,901,234,567,890.12";
+	let walletChunkRequests = 0;
+	await page.route("**/src/hosted/global-wallet-balance.tsx*", async (route) => {
+		walletChunkRequests += 1;
+		await walletChunkGate;
+		await route.continue();
+	});
+	await stubHostedApi(page, {
+		productAccessRequests,
+		productAccessResponseGate: productAccessGate,
+		deploymentListRequests,
+		deploymentListResponses: [[railHostedDeployment]],
+		deploymentListResponseGates: [deploymentListGate],
+		walletRequests,
+		walletResponses: [
+			{
+				body: { ...walletState, balance_usd: "12345678901234567890.12" },
+				status: 200,
+			},
+		],
+		walletResponseGates: [walletResponseGate],
+	});
+
+	try {
+		await page.goto("/agents");
+		const walletSlot = page.getByTestId("global-wallet-balance-slot");
+		const walletControl = page.getByTestId("global-wallet-balance");
+		await expect(walletSlot).toBeVisible();
+		await expect.poll(() => productAccessRequests.length).toBeGreaterThan(0);
+		await expect.poll(() => deploymentListRequests.length).toBeGreaterThan(0);
+		await expect(walletSlot).toBeEmpty();
+		await expect(walletControl).toHaveCount(0);
+		expect(walletChunkRequests).toBe(0);
+		const unresolvedSlotBox = await walletSlot.boundingBox();
+		if (!unresolvedSlotBox) throw new Error("Unresolved Wallet slot should reserve geometry.");
+
+		releaseProductAccess?.();
+		releaseDeploymentList?.();
+		await expect(walletControl).toBeVisible();
+		await expect(walletControl).toBeDisabled();
+		await expect(walletControl.locator('[data-slot="skeleton"]')).toBeVisible();
+		const fallbackSlotBox = await walletSlot.boundingBox();
+		if (!fallbackSlotBox) throw new Error("Wallet chunk fallback should preserve slot geometry.");
+		expect(Math.abs(fallbackSlotBox.x - unresolvedSlotBox.x)).toBeLessThanOrEqual(1);
+		expect(Math.abs(fallbackSlotBox.y - unresolvedSlotBox.y)).toBeLessThanOrEqual(1);
+		expect(Math.abs(fallbackSlotBox.width - unresolvedSlotBox.width)).toBeLessThanOrEqual(1);
+		expect(Math.abs(fallbackSlotBox.height - unresolvedSlotBox.height)).toBeLessThanOrEqual(1);
+
+		releaseWalletChunk?.();
+		await expect.poll(() => walletRequests.length).toBe(1);
+		await expect(walletControl).toBeEnabled();
+
+		releaseWalletResponse?.();
+		await expect(walletControl).toContainText(longBalance);
+		await expect(walletControl).toHaveAttribute(
+			"aria-label",
+			`Wallet balance ${longBalance}. Open Wallet settings`,
+		);
+		await expect(walletControl).toHaveAttribute(
+			"title",
+			`Wallet balance ${longBalance}. Open Wallet settings`,
+		);
+		const finalSlotBox = await walletSlot.boundingBox();
+		if (!finalSlotBox) throw new Error("Loaded Wallet slot should preserve header geometry.");
+		expect(Math.abs(finalSlotBox.x - unresolvedSlotBox.x)).toBeLessThanOrEqual(1);
+		expect(Math.abs(finalSlotBox.y - unresolvedSlotBox.y)).toBeLessThanOrEqual(1);
+		expect(Math.abs(finalSlotBox.width - unresolvedSlotBox.width)).toBeLessThanOrEqual(1);
+		expect(Math.abs(finalSlotBox.height - unresolvedSlotBox.height)).toBeLessThanOrEqual(1);
+		const balanceText = walletControl.locator("span").filter({ hasText: longBalance });
+		await expect(balanceText).toBeVisible();
+		expect(
+			await balanceText.evaluate(
+				(element) => element.clientWidth > 0 && element.scrollWidth > element.clientWidth,
+			),
+		).toBe(true);
+		expect(walletChunkRequests).toBe(1);
+	} finally {
+		releaseProductAccess?.();
+		releaseDeploymentList?.();
+		releaseWalletChunk?.();
+		releaseWalletResponse?.();
+	}
+
+	const inapplicableContext = await browser.newContext({ baseURL });
+	const inapplicablePage = await inapplicableContext.newPage();
+	const inapplicableProductAccessRequests: string[] = [];
+	const inapplicableDeploymentListRequests: string[] = [];
+	let releaseInapplicableProductAccess: (() => void) | undefined;
+	let releaseInapplicableDeploymentList: (() => void) | undefined;
+	const inapplicableProductAccessGate = new Promise<void>((resolve) => {
+		releaseInapplicableProductAccess = resolve;
+	});
+	const inapplicableDeploymentListGate = new Promise<void>((resolve) => {
+		releaseInapplicableDeploymentList = resolve;
+	});
+	let inapplicableChunkRequests = 0;
+	try {
+		await inapplicablePage.route("**/src/hosted/global-wallet-balance.tsx*", async (route) => {
+			inapplicableChunkRequests += 1;
+			await route.continue();
+		});
+		await stubHostedApi(inapplicablePage, {
+			canCreateCloudAgents: false,
+			productAccessResponseGate: inapplicableProductAccessGate,
+			productAccessRequests: inapplicableProductAccessRequests,
+			deploymentListRequests: inapplicableDeploymentListRequests,
+			deploymentListResponses: [[]],
+			deploymentListResponseGates: [inapplicableDeploymentListGate],
+		});
+		await inapplicablePage.goto("/agents");
+		const walletSlot = inapplicablePage.getByTestId("global-wallet-balance-slot");
+		await expect(walletSlot).toBeVisible();
+		await expect.poll(() => inapplicableProductAccessRequests.length).toBeGreaterThan(0);
+		await expect.poll(() => inapplicableDeploymentListRequests.length).toBeGreaterThan(0);
+		await expect(walletSlot).toBeEmpty();
+		const unresolvedSlotBox = await walletSlot.boundingBox();
+		if (!unresolvedSlotBox) throw new Error("Inapplicable Wallet slot should reserve geometry.");
+
+		releaseInapplicableProductAccess?.();
+		releaseInapplicableDeploymentList?.();
+		await expect(
+			inapplicablePage
+				.getByTestId("app-sidebar-agent-rail")
+				.getByTestId("app-sidebar-agent-loading-slot"),
+		).toHaveCount(0);
+		await expect(
+			inapplicablePage
+				.getByTestId("app-sidebar-agent-rail")
+				.getByRole("button", { name: "New agent" }),
+		).toBeEnabled();
+		await expect(inapplicablePage.getByTestId("global-wallet-balance")).toHaveCount(0);
+		await expect(walletSlot).toBeEmpty();
+		const resolvedSlotBox = await walletSlot.boundingBox();
+		if (!resolvedSlotBox) throw new Error("Resolved Wallet slot should preserve geometry.");
+		expect(Math.abs(resolvedSlotBox.x - unresolvedSlotBox.x)).toBeLessThanOrEqual(1);
+		expect(Math.abs(resolvedSlotBox.y - unresolvedSlotBox.y)).toBeLessThanOrEqual(1);
+		expect(Math.abs(resolvedSlotBox.width - unresolvedSlotBox.width)).toBeLessThanOrEqual(1);
+		expect(Math.abs(resolvedSlotBox.height - unresolvedSlotBox.height)).toBeLessThanOrEqual(1);
+		expect(inapplicableChunkRequests).toBe(0);
+	} finally {
+		releaseInapplicableProductAccess?.();
+		releaseInapplicableDeploymentList?.();
+		await inapplicableContext.close();
+	}
+});
 
 test("hosted mixed agent rail uses whole semantic buttons for context switching", async ({
 	page,

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -204,6 +204,7 @@ const restrictRailDragToVerticalAxis: Modifier = ({ transform }) => ({
 });
 
 const RAIL_DND_MODIFIERS = [restrictRailDragToVerticalAxis];
+const RAIL_COLD_LOADING_SLOTS = ["primary", "secondary"] as const;
 
 function reorderEnvironmentsForCache(
 	current: SidebarEnvironment[],
@@ -926,14 +927,30 @@ function SortableAgentRailItem({
 	);
 }
 
+function AgentRailLoadingSlots() {
+	return RAIL_COLD_LOADING_SLOTS.map((slot) => (
+		<SidebarMenuItem
+			key={slot}
+			data-testid="app-sidebar-agent-loading-slot"
+			aria-hidden="true"
+			className="flex h-[4.25rem] w-full flex-col items-center justify-center gap-1 px-1 py-1"
+		>
+			<Skeleton className="size-10 shrink-0 rounded-md" />
+			<Skeleton className="h-2.5 w-12 max-w-full" />
+		</SidebarMenuItem>
+	));
+}
+
 function FocusRailContent({
 	agents,
+	loading,
 	activeAgentId,
 	activeDeploymentSelector,
 	onNavigate,
 	showTooltips = true,
 }: {
 	agents: AgentTile[];
+	loading: boolean;
 	activeAgentId: string | null;
 	activeDeploymentSelector: string | null;
 	onNavigate?: () => void;
@@ -1079,6 +1096,9 @@ function FocusRailContent({
 						</IconChip>
 					</RailTileButton>
 				</SidebarMenu>
+				<SidebarMenu className="w-full items-center">
+					<NewAgentButton compact showTooltip={showTooltips} onNavigate={onNavigate} />
+				</SidebarMenu>
 
 				<SidebarSeparator className="mx-auto w-8" />
 
@@ -1114,7 +1134,7 @@ function FocusRailContent({
 							))}
 						</SortableContext>
 					</DndContext>
-					<NewAgentButton compact showTooltip={showTooltips} onNavigate={onNavigate} />
+					{loading ? <AgentRailLoadingSlots /> : null}
 				</SidebarMenu>
 			</SidebarContent>
 		</>
@@ -1306,10 +1326,12 @@ function FocusStatusFallback() {
 
 function RailSidebar({
 	agents,
+	loading,
 	activeAgentId,
 	activeDeploymentSelector,
 }: {
 	agents: AgentTile[];
+	loading: boolean;
 	activeAgentId: string | null;
 	activeDeploymentSelector: string | null;
 }) {
@@ -1323,6 +1345,7 @@ function RailSidebar({
 		>
 			<FocusRailContent
 				agents={agents}
+				loading={loading}
 				activeAgentId={activeAgentId}
 				activeDeploymentSelector={activeDeploymentSelector}
 			/>
@@ -1643,6 +1666,7 @@ export function AppSidebar({
 		? hostedAgentTiles !== null && hostedMembershipResolved
 		: hydratedEnvironments !== undefined;
 	const agents = unifiedAgentListEnabled ? (hostedAgentTiles ?? []) : selfManagedTiles;
+	const agentRailColdLoading = !agentsLoaded && agents.length === 0;
 	const activeAgentTile = activeAgentId
 		? (agents.find((tile) =>
 				agentTileMatchesRouteId(tile, activeAgentId, activeDeploymentSelector),
@@ -1743,6 +1767,7 @@ export function AppSidebar({
 			{!isMobile ? (
 				<RailSidebar
 					agents={agents}
+					loading={agentRailColdLoading}
 					activeAgentId={activeAgentId}
 					activeDeploymentSelector={activeDeploymentSelector}
 				/>
@@ -1794,6 +1819,7 @@ export function AppSidebar({
 						>
 							<FocusRailContent
 								agents={agents}
+								loading={agentRailColdLoading}
 								activeAgentId={activeAgentId}
 								activeDeploymentSelector={activeDeploymentSelector}
 								onNavigate={closeMobileSidebar}

--- a/apps/web/src/components/dashboard/agent-detail-loading-shell.test.ts
+++ b/apps/web/src/components/dashboard/agent-detail-loading-shell.test.ts
@@ -1,0 +1,43 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+type DetailSkeleton =
+	typeof import("@/components/dashboard/connected-agent-detail").ConnectedAgentDetailSkeleton;
+
+let detailSkeleton: DetailSkeleton | null = null;
+
+beforeAll(async () => {
+	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
+	process.env.VITE_CLAWDI_DEPLOY_API_URL = "http://localhost:50021";
+	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
+	const module = await import("@/components/dashboard/connected-agent-detail");
+	detailSkeleton = module.ConnectedAgentDetailSkeleton;
+});
+
+function render(section: Parameters<DetailSkeleton>[0]["section"]): string {
+	if (!detailSkeleton) throw new Error("agent detail loading shell was not loaded");
+	return renderToStaticMarkup(createElement(detailSkeleton, { hosted: true, section }));
+}
+
+describe("agent detail loading shells", () => {
+	test("uses full-bleed live-tool geometry for live sections", () => {
+		for (const section of ["console", "files", "terminal"] as const) {
+			const markup = render(section);
+			expect(markup).toContain('data-testid="agent-live-tool-loading-shell"');
+			expect(markup).toContain("min-h-[calc(100svh-var(--header-height))]");
+			expect(markup).not.toContain("data-agent-detail-skeleton");
+			expect(markup).not.toContain("overview-status-card-skeleton");
+		}
+	});
+
+	test("keeps overview structure out of ordinary section fallbacks", () => {
+		const memories = render("memories");
+		const overview = render("overview");
+
+		expect(memories).toContain('data-agent-detail-section="memories"');
+		expect(memories).not.toContain("overview-status-card-skeleton");
+		expect(overview).toContain('data-agent-detail-section="overview"');
+		expect(overview).toContain("overview-status-card-skeleton");
+	});
+});

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -189,7 +189,7 @@ export function ConnectedAgentDetail({
 					/>
 				)
 			) : isLoading ? (
-				<AgentDetailContentSkeleton variant="connected" />
+				<AgentDetailContentSkeleton variant="connected" section={activeTab} />
 			) : agent ? (
 				<section className="flex flex-col gap-6">
 					{activeTab === "projects" ? null : (
@@ -357,20 +357,81 @@ export function ConnectedAgentDetail({
 	);
 }
 
-export function ConnectedAgentDetailSkeleton({ hosted = false }: { hosted?: boolean }) {
+export function ConnectedAgentDetailSkeleton({
+	hosted = false,
+	section = "overview",
+}: {
+	hosted?: boolean;
+	section?: AgentSectionId;
+}) {
+	if (section === "console" || section === "files" || section === "terminal") {
+		return (
+			<div
+				data-hosted={hosted ? "true" : undefined}
+				data-testid="agent-live-tool-loading-shell"
+				role="status"
+				aria-label={`${agentSectionLabel(section)} loading`}
+				className="-my-4 flex min-h-[calc(100svh-var(--header-height))] w-full flex-col md:-my-5 md:min-h-[calc(100svh-var(--header-height)-1rem)]"
+			>
+				<div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
+					<div className="flex h-12 shrink-0 items-center justify-between gap-3 px-4 lg:px-6">
+						<div className="flex min-w-0 items-center gap-2">
+							<Skeleton className="size-4 shrink-0 rounded-sm" />
+							<Skeleton className="h-4 w-32 max-w-[45vw]" />
+						</div>
+						<Skeleton className="h-8 w-20 shrink-0" />
+					</div>
+					<Skeleton className="min-h-0 flex-1 rounded-none" />
+				</div>
+			</div>
+		);
+	}
+
 	return (
 		<div
 			data-hosted={hosted ? "true" : undefined}
 			className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6")}
 		>
-			<AgentDetailContentSkeleton variant={hosted ? "hosted" : "connected"} />
+			<AgentDetailContentSkeleton variant={hosted ? "hosted" : "connected"} section={section} />
 		</div>
 	);
 }
 
-function AgentDetailContentSkeleton({ variant }: { variant: "connected" | "hosted" }) {
+function AgentDetailContentSkeleton({
+	variant,
+	section = "overview",
+}: {
+	variant: "connected" | "hosted";
+	section?: AgentSectionId;
+}) {
+	if (section !== "overview") {
+		return (
+			<section
+				className="flex flex-col gap-6"
+				data-agent-detail-skeleton
+				data-agent-detail-section={section}
+			>
+				<PageHeaderSkeleton
+					icon
+					iconClassName="size-4 rounded-sm"
+					actions={variant === "hosted"}
+					description={false}
+				/>
+				<div className="space-y-4">
+					<Skeleton className="h-4 w-28" />
+					<Skeleton className="h-4 w-56 max-w-full" />
+					<Skeleton className="h-40 w-full" />
+				</div>
+			</section>
+		);
+	}
+
 	return (
-		<section className="flex flex-col gap-8" data-agent-detail-skeleton>
+		<section
+			className="flex flex-col gap-8"
+			data-agent-detail-skeleton
+			data-agent-detail-section="overview"
+		>
 			<PageHeaderSkeleton
 				icon
 				iconClassName="size-4 rounded-sm"

--- a/apps/web/src/components/header-wallet-balance.tsx
+++ b/apps/web/src/components/header-wallet-balance.tsx
@@ -1,0 +1,68 @@
+import { WalletCards } from "lucide-react";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function HeaderWalletBalanceSlot({ children }: { children?: ReactNode }) {
+	return (
+		<div
+			data-hosted="true"
+			data-testid="global-wallet-balance-slot"
+			className="flex h-8 w-20 shrink-0 items-stretch sm:w-24"
+		>
+			{children}
+		</div>
+	);
+}
+
+export function headerWalletBalanceApplicable({
+	canCreateCloudAgents,
+	existingCloudDeploymentCount,
+}: {
+	canCreateCloudAgents: boolean;
+	existingCloudDeploymentCount: number | null;
+}): boolean {
+	return canCreateCloudAgents || (existingCloudDeploymentCount ?? 0) > 0;
+}
+
+export function HeaderWalletBalanceControl({
+	state,
+	formattedBalance,
+	onOpenWallet,
+}: {
+	state: "loading" | "ready" | "unavailable";
+	formattedBalance?: string | null;
+	onOpenWallet?: () => void;
+}) {
+	const displayedBalance = state === "ready" ? formattedBalance : null;
+	const statusLabel = displayedBalance
+		? `Wallet balance ${displayedBalance}`
+		: state === "loading"
+			? "Wallet balance loading"
+			: "Wallet balance unavailable";
+	const label = onOpenWallet ? `${statusLabel}. Open Wallet settings` : statusLabel;
+
+	return (
+		<Button
+			type="button"
+			data-hosted="true"
+			aria-label={label}
+			title={displayedBalance ? label : undefined}
+			onClick={onOpenWallet}
+			disabled={!onOpenWallet}
+			variant="ghost"
+			size="sm"
+			data-testid="global-wallet-balance"
+			className="w-full min-w-0 gap-1.5 px-2 text-muted-foreground hover:text-foreground"
+		>
+			<WalletCards className="size-4" />
+			{state === "loading" ? (
+				<Skeleton aria-hidden="true" className="h-3.5 w-12" />
+			) : displayedBalance ? (
+				<span className="min-w-0 flex-1 truncate font-medium text-foreground tabular-nums">
+					{displayedBalance}
+				</span>
+			) : null}
+		</Button>
+	);
+}

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -230,13 +230,13 @@ export function AgentHome({
 				</div>
 			);
 		}
-		return <ConnectedAgentDetailSkeleton hosted />;
+		return <ConnectedAgentDetailSkeleton hosted section={section} />;
 	}
 
 	// Hold a skeleton until the deployment lookup settles, so a hosted agent
 	// doesn't flash the connected detail (and fire its queries) first.
 	if (isLoading) {
-		return <ConnectedAgentDetailSkeleton hosted />;
+		return <ConnectedAgentDetailSkeleton hosted section={section} />;
 	}
 
 	if (error && requestedHostedAgent && !deployment) {

--- a/apps/web/src/hosted/agents/ownership-sensor.ts
+++ b/apps/web/src/hosted/agents/ownership-sensor.ts
@@ -102,7 +102,7 @@ export function useLegacyEnvIds() {
 export function HostedAgentOwnershipSensor({
 	onChange,
 }: {
-	onChange: (ownership: AgentOwnership | null) => void;
+	onChange: (ownership: AgentOwnership | null, existingCloudDeploymentCount: number | null) => void;
 }) {
 	const cloudInventory = useHostedDeploymentInventory();
 	const legacy = useLegacyEnvIds();
@@ -122,9 +122,9 @@ export function HostedAgentOwnershipSensor({
 	);
 
 	useEffect(() => {
-		onChange(ownership);
-		return () => onChange(null);
-	}, [ownership, onChange]);
+		onChange(ownership, cloudInventory.deployments?.length ?? null);
+	}, [cloudInventory.deployments?.length, ownership, onChange]);
+	useEffect(() => () => onChange(null, null), [onChange]);
 
 	return null;
 }

--- a/apps/web/src/hosted/global-wallet-balance.test.ts
+++ b/apps/web/src/hosted/global-wallet-balance.test.ts
@@ -4,19 +4,20 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 type GlobalWalletBalanceView =
 	typeof import("@/hosted/global-wallet-balance").GlobalWalletBalanceView;
-type HostedWalletBalanceApplicable =
-	typeof import("@/hosted/global-wallet-balance").hostedWalletBalanceApplicable;
+type HeaderWalletBalanceApplicable =
+	typeof import("@/components/header-wallet-balance").headerWalletBalanceApplicable;
 
 let globalWalletBalanceView: GlobalWalletBalanceView | null = null;
-let walletBalanceApplicable: HostedWalletBalanceApplicable | null = null;
+let walletBalanceApplicable: HeaderWalletBalanceApplicable | null = null;
 
 beforeAll(async () => {
 	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
 	process.env.VITE_CLAWDI_DEPLOY_API_URL = "http://localhost:50021";
 	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
 	const module = await import("@/hosted/global-wallet-balance");
+	const headerModule = await import("@/components/header-wallet-balance");
 	globalWalletBalanceView = module.GlobalWalletBalanceView;
-	walletBalanceApplicable = module.hostedWalletBalanceApplicable;
+	walletBalanceApplicable = headerModule.headerWalletBalanceApplicable;
 });
 
 describe("global Wallet balance applicability", () => {
@@ -32,6 +33,9 @@ describe("global Wallet balance applicability", () => {
 		expect(
 			walletBalanceApplicable({ canCreateCloudAgents: false, existingCloudDeploymentCount: 0 }),
 		).toBe(false);
+		expect(
+			walletBalanceApplicable({ canCreateCloudAgents: false, existingCloudDeploymentCount: null }),
+		).toBe(false);
 	});
 });
 
@@ -39,11 +43,16 @@ describe("global Wallet balance presentation", () => {
 	test("renders a real balance as the compact global action", () => {
 		if (!globalWalletBalanceView) throw new Error("global Wallet balance was not loaded");
 		const markup = renderToStaticMarkup(
-			createElement(globalWalletBalanceView, { state: "ready", balanceUsd: "1250.5" }),
+			createElement(globalWalletBalanceView, {
+				state: "ready",
+				balanceUsd: "1250.5",
+				onOpenWallet: () => undefined,
+			}),
 		);
 
 		expect(markup).toContain("$1,250.50");
 		expect(markup).toContain("Wallet balance $1,250.50. Open Wallet settings");
+		expect(markup).toContain('title="Wallet balance $1,250.50. Open Wallet settings"');
 		expect(markup).toContain('data-testid="global-wallet-balance"');
 		expect(markup).toContain("lucide-wallet-cards");
 		expect(markup).not.toMatch(/>\s*Wallet\s*</);
@@ -59,6 +68,7 @@ describe("global Wallet balance presentation", () => {
 		);
 
 		expect(loading).toContain('data-slot="skeleton"');
+		expect(loading).toContain("disabled");
 		expect(loading).toContain("Wallet balance loading");
 		expect(unavailable).toContain("Wallet balance unavailable");
 		expect(loading).toContain("lucide-wallet-cards");

--- a/apps/web/src/hosted/global-wallet-balance.tsx
+++ b/apps/web/src/hosted/global-wallet-balance.tsx
@@ -1,49 +1,9 @@
 "use client";
 
 import { useRouter } from "@tanstack/react-router";
-import { WalletCards } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
+import { HeaderWalletBalanceControl } from "@/components/header-wallet-balance";
 import { formatUsdExact } from "@/hosted/billing/format";
 import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
-import { useHostedDeploymentInventory } from "@/hosted/use-hosted-deployment-inventory";
-import { useHostedProductAccess } from "@/lib/hosted-product-access";
-
-export function hostedWalletBalanceApplicable({
-	canCreateCloudAgents,
-	existingCloudDeploymentCount,
-}: {
-	canCreateCloudAgents: boolean;
-	existingCloudDeploymentCount: number;
-}): boolean {
-	return canCreateCloudAgents || existingCloudDeploymentCount > 0;
-}
-
-function WalletBalanceEntry({
-	label,
-	children,
-	onOpenWallet,
-}: {
-	label: string;
-	children?: React.ReactNode;
-	onOpenWallet?: () => void;
-}) {
-	return (
-		<Button
-			type="button"
-			data-hosted="true"
-			aria-label={label}
-			onClick={onOpenWallet}
-			variant="ghost"
-			size="sm"
-			data-testid="global-wallet-balance"
-			className="max-w-40 gap-1.5 px-2 text-muted-foreground hover:text-foreground"
-		>
-			<WalletCards className="size-4" />
-			{children}
-		</Button>
-	);
-}
 
 export function GlobalWalletBalanceView({
 	state,
@@ -55,47 +15,26 @@ export function GlobalWalletBalanceView({
 	onOpenWallet?: () => void;
 }) {
 	if (state === "loading") {
-		return (
-			<WalletBalanceEntry
-				label="Wallet balance loading. Open Wallet settings"
-				onOpenWallet={onOpenWallet}
-			>
-				<Skeleton aria-hidden="true" className="h-3.5 w-12" />
-			</WalletBalanceEntry>
-		);
+		return <HeaderWalletBalanceControl state="loading" onOpenWallet={onOpenWallet} />;
 	}
 
 	const formattedBalance = state === "ready" && balanceUsd ? formatUsdExact(balanceUsd) : null;
 	if (!formattedBalance || formattedBalance === "—") {
-		return (
-			<WalletBalanceEntry
-				label="Wallet balance unavailable. Open Wallet settings"
-				onOpenWallet={onOpenWallet}
-			/>
-		);
+		return <HeaderWalletBalanceControl state="unavailable" onOpenWallet={onOpenWallet} />;
 	}
 
 	return (
-		<WalletBalanceEntry
-			label={`Wallet balance ${formattedBalance}. Open Wallet settings`}
+		<HeaderWalletBalanceControl
+			state="ready"
+			formattedBalance={formattedBalance}
 			onOpenWallet={onOpenWallet}
-		>
-			<span className="font-medium text-foreground tabular-nums">{formattedBalance}</span>
-		</WalletBalanceEntry>
+		/>
 	);
 }
 
 export function GlobalWalletBalance() {
 	const router = useRouter();
-	const hostedAccess = useHostedProductAccess();
-	const cloudInventory = useHostedDeploymentInventory();
-	const billingApplies = hostedWalletBalanceApplicable({
-		canCreateCloudAgents: hostedAccess.canCreateCloudAgents,
-		existingCloudDeploymentCount: cloudInventory.deployments?.length ?? 0,
-	});
-	const wallet = useWalletSnapshot({ enabled: billingApplies });
-
-	if (!billingApplies) return null;
+	const wallet = useWalletSnapshot();
 	const openWallet = () => {
 		void router.navigate({
 			to: ".",
@@ -106,18 +45,20 @@ export function GlobalWalletBalance() {
 		});
 	};
 
-	if (wallet.isLoading) {
-		return <GlobalWalletBalanceView state="loading" onOpenWallet={openWallet} />;
-	}
-	if (!wallet.data) {
-		return <GlobalWalletBalanceView state="unavailable" onOpenWallet={openWallet} />;
-	}
 	return (
-		<GlobalWalletBalanceView
-			state="ready"
-			balanceUsd={wallet.data.balance_usd}
-			onOpenWallet={openWallet}
-		/>
+		<div data-hosted="true" className="contents">
+			{wallet.isLoading ? (
+				<GlobalWalletBalanceView state="loading" onOpenWallet={openWallet} />
+			) : wallet.data ? (
+				<GlobalWalletBalanceView
+					state="ready"
+					balanceUsd={wallet.data.balance_usd}
+					onOpenWallet={openWallet}
+				/>
+			) : (
+				<GlobalWalletBalanceView state="unavailable" onOpenWallet={openWallet} />
+			)}
+		</div>
 	);
 }
 

--- a/apps/web/src/pages/dashboard/agents/agent-detail-client.tsx
+++ b/apps/web/src/pages/dashboard/agents/agent-detail-client.tsx
@@ -28,7 +28,7 @@ export function AgentDetailClient({
 }) {
 	if (AgentHome) {
 		return (
-			<Suspense fallback={<ConnectedAgentDetailSkeleton hosted />}>
+			<Suspense fallback={<ConnectedAgentDetailSkeleton hosted section={section} />}>
 				<AgentHome environmentId={environmentId} section={section} routeSearch={routeSearch} />
 			</Suspense>
 		);

--- a/apps/web/src/pages/dashboard/layout.tsx
+++ b/apps/web/src/pages/dashboard/layout.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import { lazy, type ReactNode, Suspense, useState } from "react";
+import { lazy, type ReactNode, Suspense, useCallback, useState } from "react";
 import { AppSidebar } from "@/components/app-sidebar";
 import { BreadcrumbTitleProvider } from "@/components/breadcrumb-title";
 import { CommandPaletteProvider } from "@/components/command-palette";
+import {
+	HeaderWalletBalanceControl,
+	HeaderWalletBalanceSlot,
+	headerWalletBalanceApplicable,
+} from "@/components/header-wallet-balance";
 import { SiteHeader } from "@/components/site-header";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { Toaster } from "@/components/ui/sonner";
@@ -14,6 +19,7 @@ import {
 } from "@/lib/agent-ownership";
 import { IS_HOSTED } from "@/lib/hosted";
 import { isDeployApiConfigured } from "@/lib/hosted-api";
+import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { useHydrated } from "@/lib/use-hydrated";
 
 // Cap dashboard content at 1536px (= Tailwind's 2xl screen) and center it in
@@ -44,7 +50,18 @@ const GlobalWalletBalance = IS_HOSTED_BUILD
 export default function DashboardLayout({ children }: { children: ReactNode }) {
 	const hydrated = useHydrated();
 	const [ownership, setOwnership] = useState<AgentOwnership | null>(null);
+	const [existingCloudDeploymentCount, setExistingCloudDeploymentCount] = useState<number | null>(
+		null,
+	);
+	const hostedAccess = useHostedProductAccess();
 	const showOwnershipSensor = hydrated && IS_HOSTED && isDeployApiConfigured();
+	const updateHostedOwnership = useCallback(
+		(nextOwnership: AgentOwnership | null, nextExistingCloudDeploymentCount: number | null) => {
+			setOwnership(nextOwnership);
+			setExistingCloudDeploymentCount(nextExistingCloudDeploymentCount);
+		},
+		[],
+	);
 	// `null` strictly means "resolving" (destructive actions wait on it), so
 	// the provider must decide when there is nothing to resolve: OSS builds,
 	// and hosted mirrors without a configured deploy API get resolved empty
@@ -53,6 +70,12 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
 	// existing Cloud deployments remain manageable under rollback.
 	const noExternalControlPlane = !IS_HOSTED || !isDeployApiConfigured();
 	const providedOwnership = noExternalControlPlane ? EMPTY_AGENT_OWNERSHIP : ownership;
+	const showHeaderWallet =
+		IS_HOSTED &&
+		headerWalletBalanceApplicable({
+			canCreateCloudAgents: hostedAccess.canCreateCloudAgents,
+			existingCloudDeploymentCount,
+		});
 
 	return (
 		<SidebarProvider
@@ -68,7 +91,7 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
 			<AgentOwnershipProvider value={providedOwnership}>
 				{HostedAgentOwnershipSensor && showOwnershipSensor ? (
 					<Suspense fallback={null}>
-						<HostedAgentOwnershipSensor onChange={setOwnership} />
+						<HostedAgentOwnershipSensor onChange={updateHostedOwnership} />
 					</Suspense>
 				) : null}
 				<CommandPaletteProvider>
@@ -84,10 +107,14 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
 						>
 							<SiteHeader
 								actions={
-									GlobalWalletBalance ? (
-										<Suspense fallback={null}>
-											<GlobalWalletBalance />
-										</Suspense>
+									IS_HOSTED_BUILD ? (
+										<HeaderWalletBalanceSlot>
+											{GlobalWalletBalance && showHeaderWallet ? (
+												<Suspense fallback={<HeaderWalletBalanceControl state="loading" />}>
+													<GlobalWalletBalance />
+												</Suspense>
+											) : null}
+										</HeaderWalletBalanceSlot>
 									) : null
 								}
 							/>


### PR DESCRIPTION
## Summary
- match agent detail fallbacks to overview, ordinary-section, and full-bleed live-tool geometry
- keep rail commands and cached agent tiles stable while hosted ownership resolves or refetch fails
- reserve one header Wallet slot and load billing UI only when hosted billing applies
- avoid transient ownership resets during sensor updates

## Verification
- clean Docker runner: Web TypeScript typecheck
- 5 focused Bun tests
- OSS client, SSR, and Nitro production build
- hosted Playwright: 3 focused loading/geometry scenarios
- Biome CI on all 11 changed files
- git diff --check