### PR TITLE
fix(web): restore New Agent rail order

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3246,7 +3246,7 @@ test("cold hosted live-tool routes keep full-bleed loading geometry", async ({ p
 	}
 });
 
-test("agent rail keeps its command anchor stable with one agent and retains cache after list failure", async ({
+test("agent rail keeps New agent after agents and retains cache after list failure", async ({
 	page,
 }) => {
 	let releaseColdList: (() => void) | undefined;
@@ -3273,18 +3273,17 @@ test("agent rail keeps its command anchor stable with one agent and retains cach
 		await expect(rail.getByTestId("app-sidebar-agent-loading-slot")).toHaveCount(2);
 		await expect(rail.getByTestId("app-sidebar-agent-tile")).toHaveCount(0);
 		await expect(rail.getByRole("button", { name: "e2e-2", exact: true })).toHaveCount(0);
-		const coldNewAgentBox = await newAgent.boundingBox();
-		if (!coldNewAgentBox) throw new Error("Cold rail New agent control should be visible.");
 
 		releaseColdList?.();
-		await expect(rail.getByTestId("app-sidebar-agent-tile")).toHaveCount(1);
+		const agentTile = rail.getByTestId("app-sidebar-agent-tile");
+		await expect(agentTile).toHaveCount(1);
 		await expect(rail.getByTestId("app-sidebar-agent-loading-slot")).toHaveCount(0);
+		const agentTileBox = await agentTile.boundingBox();
 		const loadedNewAgentBox = await newAgent.boundingBox();
-		if (!loadedNewAgentBox) throw new Error("Loaded rail New agent control should be visible.");
-		expect(Math.abs(loadedNewAgentBox.x - coldNewAgentBox.x)).toBeLessThanOrEqual(1);
-		expect(Math.abs(loadedNewAgentBox.y - coldNewAgentBox.y)).toBeLessThanOrEqual(1);
-		expect(Math.abs(loadedNewAgentBox.width - coldNewAgentBox.width)).toBeLessThanOrEqual(1);
-		expect(Math.abs(loadedNewAgentBox.height - coldNewAgentBox.height)).toBeLessThanOrEqual(1);
+		if (!agentTileBox || !loadedNewAgentBox) {
+			throw new Error("Loaded agent rail controls should be visible.");
+		}
+		expect(loadedNewAgentBox.y).toBeGreaterThan(agentTileBox.y);
 
 		await rail.getByRole("button", { name: "e2e-2", exact: true }).click();
 		await expect(page.locator('[data-agent-overview="hosted"]')).toBeVisible();

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1096,9 +1096,6 @@ function FocusRailContent({
 						</IconChip>
 					</RailTileButton>
 				</SidebarMenu>
-				<SidebarMenu className="w-full items-center">
-					<NewAgentButton compact showTooltip={showTooltips} onNavigate={onNavigate} />
-				</SidebarMenu>
 
 				<SidebarSeparator className="mx-auto w-8" />
 
@@ -1135,6 +1132,7 @@ function FocusRailContent({
 						</SortableContext>
 					</DndContext>
 					{loading ? <AgentRailLoadingSlots /> : null}
+					<NewAgentButton compact showTooltip={showTooltips} onNavigate={onNavigate} />
 				</SidebarMenu>
 			</SidebarContent>
 		</>


### PR DESCRIPTION
## Summary

- restore New Agent to the end of the agent rail
- keep loading placeholders and cached agent tiles intact
- replace the incorrect fixed-anchor assertion with a visual-order assertion

## Verification

- `scripts/test.sh web`
- Biome check for both changed files
- focused hosted Playwright test in Chromium