### PR TITLE
fix(cli): preserve active units across package checkpoints

### DIFF
--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -60,6 +60,7 @@ import {
 } from "../runtime/manifest";
 import { manifestSchema as runtimeDesiredStateSchema } from "../runtime/manifest-contract";
 import {
+	loadCommittedRuntimeManifest,
 	loadRemoteRuntimeManifest,
 	type RuntimeManifestFailure,
 	type RuntimeManifestLoad,
@@ -209,6 +210,60 @@ export function runtimeAppliedContentIdentity(
 // Keep secret-dependent recoverability verification in the root-only applied state.
 export function runtimePublicContentRevision(load: RuntimeManifestLoad): string {
 	return runtimeContentSha256({ manifest: load.manifest });
+}
+
+function runtimeCheckpointContent(
+	load: Pick<RuntimeManifestLoad, "manifest" | "secretValues">,
+): unknown {
+	const {
+		generation: _generation,
+		applyGeneration: _applyGeneration,
+		clawdiCli,
+		...manifest
+	} = load.manifest;
+	const { packageSpec: _packageSpec, ...cliPolicy } = clawdiCli ?? {};
+	return {
+		manifest: {
+			...manifest,
+			...(clawdiCli === undefined ? {} : { clawdiCli: cliPolicy }),
+		},
+		secretValues: runtimeRecoverableSecretValues(load.manifest, load.secretValues),
+	};
+}
+
+export function runtimeOnlyChangesCliPackage(
+	previous: Pick<RuntimeManifestLoad, "manifest" | "secretValues">,
+	next: Pick<RuntimeManifestLoad, "manifest" | "secretValues">,
+): boolean {
+	const previousPackageSpec = previous.manifest.clawdiCli?.packageSpec?.trim();
+	const nextPackageSpec = next.manifest.clawdiCli?.packageSpec?.trim();
+	if (!previousPackageSpec || !nextPackageSpec || previousPackageSpec === nextPackageSpec) {
+		return false;
+	}
+	try {
+		return (
+			runtimeContentSha256(runtimeCheckpointContent(previous)) ===
+			runtimeContentSha256(runtimeCheckpointContent(next))
+		);
+	} catch {
+		return false;
+	}
+}
+
+function isRuntimeCliOnlyCheckpoint(load: RuntimeManifestLoad, paths: RuntimePaths): boolean {
+	const activeAppliedState = readRuntimeAppliedState(paths);
+	const activeApplyIdentity = activeAppliedState
+		? runtimeAppliedApplyIdentity(activeAppliedState)
+		: null;
+	if (
+		!load.applyContext ||
+		!activeApplyIdentity ||
+		!runtimeApplyIdentitiesEqual(load.applyContext.identity, activeApplyIdentity)
+	) {
+		return false;
+	}
+	const committed = loadCommittedRuntimeManifest(paths, load.applyContext);
+	return "errors" in committed ? false : runtimeOnlyChangesCliPackage(committed, load);
 }
 
 export function commitRuntimeAppliedState(input: {
@@ -527,6 +582,7 @@ export function applySystemdRuntimeUpdate(
 			systemUnits: readonly string[];
 			userUnits: readonly string[];
 		};
+		preserveActiveUnits?: boolean;
 		skipActivatedSystemUnits?: readonly string[];
 	} = {},
 ): { applied: boolean; systemUnitsChanged: string[]; userUnitsChanged: string[] } {
@@ -550,8 +606,8 @@ export function applySystemdRuntimeUpdate(
 	const user = opts.activationScope
 		? filterChanges(allUser, opts.activationScope.userUnits)
 		: allUser;
-	const systemUnitsChanged = [...system.added, ...system.changed].sort();
-	const userUnitsChanged = [...user.added, ...user.changed].sort();
+	const systemUnitsChanged = new Set([...system.added, ...system.removed]);
+	const userUnitsChanged = new Set([...user.added, ...user.removed]);
 	const scopedSystemUnits = opts.activationScope ? new Set(opts.activationScope.systemUnits) : null;
 	const forcedSystemRestarts = (opts.forceRestartSystemUnits ?? []).filter(
 		(unit) => after.system.has(unit) && (!scopedSystemUnits || scopedSystemUnits.has(unit)),
@@ -570,7 +626,11 @@ export function applySystemdRuntimeUpdate(
 		forcedSystemRestarts.length > 0 ||
 		forcedSystemStops.length > 0;
 	if (!shouldApplySystemdRuntimeUpdate(paths)) {
-		return { applied: !activationChanged, systemUnitsChanged, userUnitsChanged };
+		return {
+			applied: !activationChanged,
+			systemUnitsChanged: [...systemUnitsChanged].sort(),
+			userUnitsChanged: [...userUnitsChanged].sort(),
+		};
 	}
 
 	for (const unit of system.removed) {
@@ -585,7 +645,10 @@ export function applySystemdRuntimeUpdate(
 	}
 	for (const unit of forcedSystemStops) {
 		const state = systemdUnitManagerState(paths, "system", unit);
-		if (!systemdUnitAbsentOrInactive(state)) systemctl(["stop", unit]);
+		if (!systemdUnitAbsentOrInactive(state)) {
+			systemctl(["stop", unit]);
+			systemUnitsChanged.add(unit);
+		}
 	}
 
 	if (system.added.length > 0 || system.changed.length > 0 || system.removed.length > 0) {
@@ -610,20 +673,23 @@ export function applySystemdRuntimeUpdate(
 		if (state.activeState === "failed" && recoverFailedUnits) {
 			resetFailedSystemUnits.push(unit);
 			startSystemUnits.push(unit);
+			systemUnitsChanged.add(unit);
 			continue;
 		}
 		if (state.activeState === "inactive") {
 			startSystemUnits.push(unit);
+			systemUnitsChanged.add(unit);
 			continue;
 		}
 		if (
 			state.activeState === "active" &&
 			unit !== RUNTIME_WATCH_SYSTEM_UNIT &&
-			(changedSystemUnits.has(unit) ||
+			((changedSystemUnits.has(unit) && !opts.preserveActiveUnits) ||
 				(forcedRestartUnits.has(unit) &&
 					(!addedSystemUnits.has(unit) || unit === RUNTIME_SIDECAR_SYSTEM_UNIT)))
 		) {
 			restartSystemUnits.push(unit);
+			systemUnitsChanged.add(unit);
 		}
 	}
 	// Each reconciliation makes at most one recovery attempt per failed unit.
@@ -643,6 +709,7 @@ export function applySystemdRuntimeUpdate(
 		const enabled = systemdUnitEnabled(state);
 		if (state.activeState === "failed" && recoverFailedUnits) {
 			resetFailedUserUnits.push(unit);
+			userUnitsChanged.add(unit);
 		}
 		if (
 			state.activeState === "inactive" ||
@@ -650,12 +717,17 @@ export function applySystemdRuntimeUpdate(
 		) {
 			if (enabled) startUserUnits.push(unit);
 			else enableAndStartUserUnits.push(unit);
+			userUnitsChanged.add(unit);
 			continue;
 		}
 		if (state.activeState !== "active") continue;
-		if (!enabled) enableUserUnits.push(unit);
-		if (changedUserUnits.has(unit)) {
+		if (!enabled) {
+			enableUserUnits.push(unit);
+			userUnitsChanged.add(unit);
+		}
+		if (changedUserUnits.has(unit) && !opts.preserveActiveUnits) {
 			restartUserUnits.push(unit);
+			userUnitsChanged.add(unit);
 		}
 	}
 	if (resetFailedUserUnits.length > 0) {
@@ -690,8 +762,8 @@ export function applySystemdRuntimeUpdate(
 	});
 	return {
 		applied: systemConverged && userConverged && removedSystemConverged && removedUserConverged,
-		systemUnitsChanged,
-		userUnitsChanged,
+		systemUnitsChanged: [...systemUnitsChanged].sort(),
+		userUnitsChanged: [...userUnitsChanged].sort(),
 	};
 }
 
@@ -1632,6 +1704,7 @@ async function applyRuntimeDesiredState(
 	if (cliUpdate.selfReexec) {
 		return { kind: "cli_handoff", cliUpdate };
 	}
+	const preserveActiveUnits = isRuntimeCliOnlyCheckpoint(load, paths);
 	const preparedHostedSourcedSkills =
 		opts.preparedHostedSourcedSkills ??
 		(await prepareHostedSourcedSkillArchives(load.manifest, paths, {
@@ -1644,6 +1717,7 @@ async function applyRuntimeDesiredState(
 		systemUnitsChanged: [] as string[],
 		userUnitsChanged: [] as string[],
 	};
+	let egressPrerequisiteApply: typeof systemdApply | null = null;
 	let egressPrerequisiteActivated = false;
 	const convergence = convergeRuntimeManifest(load, paths, {
 		cacheLastGood: false,
@@ -1669,6 +1743,7 @@ async function applyRuntimeDesiredState(
 								userUnits: [],
 							},
 							forceRestartSystemUnits: restartEgressSidecar ? [RUNTIME_SIDECAR_SYSTEM_UNIT] : [],
+							preserveActiveUnits,
 							recoverFailedUnits: opts.recoverFailedSystemdUnits,
 						},
 					);
@@ -1676,6 +1751,7 @@ async function applyRuntimeDesiredState(
 						assertRuntimeUserCanRead(paths.egressSystemCaFile, paths.userHome);
 						egressPrerequisiteActivated = true;
 					}
+					egressPrerequisiteApply = prerequisite;
 					return prerequisite;
 				} catch (error) {
 					throw new Error(
@@ -1695,16 +1771,37 @@ async function applyRuntimeDesiredState(
 						staleSystemUnits,
 						staleUserUnits,
 					);
-					systemdApply = applySystemdRuntimeUpdate(paths, previousSystemdUnits, activationTarget, {
-						forceRestartSystemUnits: [
-							...(restartDaemon ? [RUNTIME_DAEMON_SYSTEM_UNIT] : []),
-							...(restartEgressSidecar ? [RUNTIME_SIDECAR_SYSTEM_UNIT] : []),
-						],
-						recoverFailedUnits: opts.recoverFailedSystemdUnits,
-						skipActivatedSystemUnits: egressPrerequisiteActivated
-							? [RUNTIME_SIDECAR_SYSTEM_UNIT]
-							: [],
-					});
+					const activation = applySystemdRuntimeUpdate(
+						paths,
+						previousSystemdUnits,
+						activationTarget,
+						{
+							forceRestartSystemUnits: [
+								...(restartDaemon ? [RUNTIME_DAEMON_SYSTEM_UNIT] : []),
+								...(restartEgressSidecar ? [RUNTIME_SIDECAR_SYSTEM_UNIT] : []),
+							],
+							preserveActiveUnits,
+							recoverFailedUnits: opts.recoverFailedSystemdUnits,
+							skipActivatedSystemUnits: egressPrerequisiteActivated
+								? [RUNTIME_SIDECAR_SYSTEM_UNIT]
+								: [],
+						},
+					);
+					systemdApply = {
+						applied: activation.applied && (egressPrerequisiteApply?.applied ?? true),
+						systemUnitsChanged: [
+							...new Set([
+								...(egressPrerequisiteApply?.systemUnitsChanged ?? []),
+								...activation.systemUnitsChanged,
+							]),
+						].sort(),
+						userUnitsChanged: [
+							...new Set([
+								...(egressPrerequisiteApply?.userUnitsChanged ?? []),
+								...activation.userUnitsChanged,
+							]),
+						].sort(),
+					};
 					return systemdApply;
 				} catch (error) {
 					throw new Error(

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -25,6 +25,7 @@ import {
 	readSystemdUnitSnapshot,
 	runtimeAppliedContentIdentity,
 	runtimeInit as runtimeInitWithContext,
+	runtimeOnlyChangesCliPackage,
 	runtimePublicContentRevision,
 	runtimeWatch as runtimeWatchWithContext,
 } from "../src/commands/runtime";
@@ -827,6 +828,7 @@ function testBundleEtag(label: string): string {
 function hostedRuntimeBundleResponse(
 	payload: HostedRuntimeResponseFixture,
 	options: {
+		applyGeneration?: number;
 		etag?: string;
 		sourceRevision?: string;
 		includeRuntimeServiceSecrets?: boolean;
@@ -878,6 +880,9 @@ function hostedRuntimeBundleResponse(
 			schemaVersion: "clawdi.hosted-runtime.bundle.v2",
 			sourceRevision,
 			manifest: payload.manifest,
+			...(options.applyGeneration === undefined
+				? {}
+				: { applyGeneration: options.applyGeneration }),
 			channelBindings,
 			secretValues,
 		}),
@@ -8495,6 +8500,53 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		});
 	});
 
+	it("classifies only a package-spec-only runtime checkpoint as CLI-only", () => {
+		const home = join(root, "home", "clawdi");
+		const previousManifest = {
+			...runtimeWatchLocaleManifest(home, 13),
+			applyGeneration: 13,
+		};
+		const nextManifest: RuntimeManifest = {
+			...previousManifest,
+			generation: 14,
+			clawdiCli: {
+				...previousManifest.clawdiCli,
+				packageSpec: "clawdi@1.2.4-test",
+			},
+		};
+		const previous = {
+			manifest: previousManifest,
+			secretValues: { "secret://runtime/openclaw/gateway-token": "gateway-token" },
+		};
+		const next = { manifest: nextManifest, secretValues: previous.secretValues };
+
+		expect(runtimeOnlyChangesCliPackage(previous, next)).toBe(true);
+		expect(
+			runtimeOnlyChangesCliPackage(previous, {
+				...next,
+				manifest: {
+					...nextManifest,
+					controlPlane: { apiUrl: "https://other-cloud-api.test" },
+				},
+			}),
+		).toBe(false);
+		expect(
+			runtimeOnlyChangesCliPackage(previous, {
+				...next,
+				secretValues: { "secret://runtime/openclaw/gateway-token": "rotated-token" },
+			}),
+		).toBe(false);
+		expect(
+			runtimeOnlyChangesCliPackage(previous, {
+				...next,
+				manifest: {
+					...nextManifest,
+					clawdiCli: { ...nextManifest.clawdiCli, source: "other-source" },
+				},
+			}),
+		).toBe(false);
+	});
+
 	it("does not restart runtime units when only the bootstrap CLI package pin changes", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -8621,7 +8673,7 @@ fi
 
 		expect(applied).toEqual({
 			applied: true,
-			systemUnitsChanged: [],
+			systemUnitsChanged: ["clawdi-daemon.service", "clawdi-runtime-sidecar.service"],
 			userUnitsChanged: [],
 		});
 		const calls = readFileSync(systemctlLog, "utf-8").trim().split("\n");
@@ -8679,7 +8731,7 @@ fi
 		]);
 	});
 
-	it("runtime watch applies a CLI-only update by handoff without restarting existing units", async () => {
+	it("preserves active units across a CLI-only checkpoint with legacy renderer drift", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -8747,6 +8799,7 @@ chmod +x "$prefix/bin/clawdi"
 		};
 		seedCurrentCliInstall(state, "clawdi@1.2.3-test", "1.2.3-test", "https://registry.npmjs.org");
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
+		let runtimeGeneration = 13;
 		let desiredCliPackageSpec = "clawdi@1.2.3-test";
 		const { captured, restore } = mockFetch([
 			{
@@ -8762,7 +8815,7 @@ chmod +x "$prefix/bin/clawdi"
 								environmentId: "env_cli_update",
 								...hostedRequiredState(),
 								instanceId: "iid_cli_update",
-								generation: 13,
+								generation: runtimeGeneration,
 								issuedAt: "2026-06-06T00:00:00Z",
 								locale: TEST_HOSTED_LOCALE,
 								system: hostedSystemFixture(home),
@@ -8778,7 +8831,10 @@ chmod +x "$prefix/bin/clawdi"
 							},
 							secretValues: {},
 						},
-						{ etag: testBundleEtag(desiredCliPackageSpec) },
+						{
+							applyGeneration: 13,
+							etag: testBundleEtag(`${runtimeGeneration}:${desiredCliPackageSpec}`),
+						},
 					),
 			},
 		]);
@@ -8797,10 +8853,29 @@ chmod +x "$prefix/bin/clawdi"
 			);
 			expect(existsSync(join(paths.systemdUserRoot, "openclaw-gateway.service"))).toBe(true);
 			expect(existsSync(paths.daemonAuthToken)).toBe(true);
+			const legacyUnitPaths = [
+				...readdirSync(paths.systemdSystemRoot)
+					.filter((entry) => entry.endsWith(".service"))
+					.map((entry) => join(paths.systemdSystemRoot, entry)),
+				...readdirSync(paths.systemdUserRoot).flatMap((entry) => {
+					if (entry.endsWith(".service")) {
+						const unitPath = join(paths.systemdUserRoot, entry);
+						return readFileSync(unitPath, "utf-8").includes(GENERATED_RUNTIME_SYSTEMD_FILE_HEADER)
+							? [unitPath]
+							: [];
+					}
+					const dropIn = join(paths.systemdUserRoot, entry, "10-clawdi-hosted.conf");
+					return entry.endsWith(".service.d") && existsSync(dropIn) ? [dropIn] : [];
+				}),
+			];
+			for (const unitPath of legacyUnitPaths) {
+				writeFileSync(unitPath, `${readFileSync(unitPath, "utf-8")}# legacy renderer drift\n`);
+			}
 
 			logs.length = 0;
 			writeFileSync(systemctlLog, "");
 			process.exitCode = undefined;
+			runtimeGeneration = 14;
 			desiredCliPackageSpec = `clawdi@${currentVersion}`;
 			await runtimeWatch({ once: true, json: true });
 
@@ -8837,7 +8912,10 @@ chmod +x "$prefix/bin/clawdi"
 				userUnitsChanged: [],
 			});
 			expect(readFileSync(systemctlLog, "utf-8")).toBe("");
-			expect(readRuntimeAppliedState(paths)).toMatchObject({ generation: 13 });
+			expect(readRuntimeAppliedState(paths)).toMatchObject({
+				generation: 13,
+				applyGeneration: 13,
+			});
 			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
 				transaction: { phase: "activated" },
 				badVersions: [],
@@ -8859,11 +8937,20 @@ chmod +x "$prefix/bin/clawdi"
 				systemUnitsChanged: [],
 				userUnitsChanged: [],
 			});
-			expect(readRuntimeAppliedState(paths)).toMatchObject({ generation: 13 });
+			expect(readRuntimeAppliedState(paths)).toMatchObject({
+				generation: 14,
+				applyGeneration: 13,
+			});
 			expect(JSON.stringify(currentTestApplyContext)).toBe(runtimeContextBefore);
-			expect(readFileSync(systemctlLog, "utf-8")).not.toMatch(
-				/(?:^|\s)(?:daemon-reload|start|restart|stop|enable|disable|reset-failed)(?:\s|$)/m,
-			);
+			const activationCalls = readFileSync(systemctlLog, "utf-8")
+				.trim()
+				.split("\n")
+				.filter((call) =>
+					/(?:^|\s)(?:daemon-reload|start|restart|stop|enable|disable|reset-failed)(?:\s|$)/.test(
+						call,
+					),
+				);
+			expect(activationCalls).toEqual(["daemon-reload", "--user daemon-reload"]);
 			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
 				transaction: null,
 				badVersions: [],
@@ -9245,10 +9332,10 @@ fi
 			const appliedEvent = JSON.parse(logs.at(-1) ?? "{}");
 			const appliedEventText = JSON.stringify(appliedEvent);
 			expect(appliedEvent.status).toBe("applied");
-			expect(appliedEvent.systemdUnitsChanged).toBe(false);
+			expect(appliedEvent.systemdUnitsChanged).toBe(true);
 			expect(appliedEvent.systemdApply).toEqual({
 				applied: true,
-				systemUnitsChanged: [],
+				systemUnitsChanged: ["clawdi-runtime-sidecar.service"],
 				userUnitsChanged: [],
 			});
 			expect(appliedEventText).not.toContain(initialSecret);


### PR DESCRIPTION
## Summary

- classify CLI-only runtime checkpoints from the durable last-good manifest, cached secret material, and unchanged apply identity
- reload renderer-updated unit files without restarting already-active daemon, sidecar, gateway, or watcher units
- preserve normal recovery for missing, inactive, or failed units and explicit force-restart signals
- report units affected across both egress prerequisite and final activation phases

## Verification

- `scripts/test.sh cli` (`1642 passed, 4 skipped`)
- focused legacy-renderer two-tick regression (`4 passed`)
- Biome CI on changed files
- `git diff --check`