### PR TITLE
fix(cli): preserve OpenClaw config during provider shrink

### DIFF
--- a/docs/ai-providers.md
+++ b/docs/ai-providers.md
@@ -199,10 +199,20 @@ modes to Hermes transport names, and writes only environment-variable names
 for API-key providers. Codex OAuth uses Hermes' native `openai-codex` selector
 and a reserved Clawdi-owned credential-pool entry.
 
-For OpenClaw, Hosted convergence sends a native config patch through
-`openclaw config patch --stdin`. API-key providers use env-backed `apiKey`
-references. Codex OAuth uses the native subscription route and the public
-provider-auth SDK with a namespaced Clawdi-owned profile.
+For OpenClaw, Hosted provider convergence uses the public
+`openclaw/plugin-sdk/config-mutation` export. The mutation starts from authored
+source config, exactly replaces Clawdi-owned provider model arrays, and leaves
+unrelated provider and user settings intact. It enables OpenClaw's targeted
+`allowConfigSizeDrop` write option because removing stale managed models is an
+intentional size reduction; schema, SecretRef preflight, config-path ownership,
+locking, and compare-and-swap guards remain active. Gateway and channel patches
+continue to use `openclaw config patch --stdin`.
+
+This contract is verified against `openclaw@2026.7.1-2`, official source commit
+[`0790d9f`](https://github.com/openclaw/openclaw/commit/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c).
+API-key providers use env-backed `apiKey` references. Codex OAuth uses the
+native subscription route and the public provider-auth SDK with a namespaced
+Clawdi-owned profile.
 
 OAuth reconcile is durable and target-native:
 

--- a/packages/cli/src/lib/ai-provider-projection.ts
+++ b/packages/cli/src/lib/ai-provider-projection.ts
@@ -40,9 +40,10 @@ export const AGENT_TARGET_CONTRACTS: Record<
 		status: "enabled",
 	},
 	openclaw: {
-		settingMethod: "openclaw config patch --stdin",
+		settingMethod:
+			"public openclaw/plugin-sdk/config-mutation for provider projection; openclaw config patch --stdin for other native patches",
 		verifiedContractBaseline:
-			"OpenClaw config patch and public provider-auth SDK contracts with namespaced SQLite profiles",
+			"OpenClaw 2026.7.1-2 public config-mutation/provider-auth SDK contracts and namespaced SQLite profiles",
 		status: "enabled",
 	},
 };

--- a/packages/cli/src/lib/codex-oauth-native-store.test.ts
+++ b/packages/cli/src/lib/codex-oauth-native-store.test.ts
@@ -7,6 +7,7 @@ import {
 	HERMES_CODEX_AUTH_HELPER,
 	hermesCodexAuthInvocation,
 	oauthCredentialFingerprint,
+	resolveOpenClawConfigMutationSdkExport,
 	resolveOpenClawProviderAuthSdkExport,
 } from "./codex-oauth-native-store";
 
@@ -46,23 +47,29 @@ describe("native OAuth store contracts", () => {
 		);
 	}
 
-	test("resolves OpenClaw provider auth through the public package export", () => {
+	test("resolves OpenClaw public SDK exports from the installed package", () => {
 		const packageRoot = tempRoot();
-		const sdkPath = join(packageRoot, "provider-auth.mjs");
+		const providerAuthPath = join(packageRoot, "provider-auth.mjs");
+		const configMutationPath = join(packageRoot, "config-mutation.mjs");
 		const commandPath = join(packageRoot, "bin", "openclaw");
 		mkdirSync(join(packageRoot, "bin"), { recursive: true });
 		writeFileSync(commandPath, "#!/bin/sh\n");
-		writeFileSync(sdkPath, "export const publicProviderAuth = true;\n");
+		writeFileSync(providerAuthPath, "export const publicProviderAuth = true;\n");
+		writeFileSync(configMutationPath, "export const publicConfigMutation = true;\n");
 		writeFileSync(
 			join(packageRoot, "package.json"),
 			JSON.stringify({
 				name: "openclaw",
 				type: "module",
-				exports: { "./plugin-sdk/provider-auth": "./provider-auth.mjs" },
+				exports: {
+					"./plugin-sdk/provider-auth": "./provider-auth.mjs",
+					"./plugin-sdk/config-mutation": "./config-mutation.mjs",
+				},
 			}),
 		);
 
-		expect(resolveOpenClawProviderAuthSdkExport([commandPath])).toBe(sdkPath);
+		expect(resolveOpenClawProviderAuthSdkExport([commandPath])).toBe(providerAuthPath);
+		expect(resolveOpenClawConfigMutationSdkExport([commandPath])).toBe(configMutationPath);
 	});
 
 	test("preserves a future Hermes store version and unrelated pool entries", () => {

--- a/packages/cli/src/lib/codex-oauth-native-store.test.ts
+++ b/packages/cli/src/lib/codex-oauth-native-store.test.ts
@@ -1,8 +1,17 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
 	HERMES_CODEX_AUTH_HELPER,
 	hermesCodexAuthInvocation,
@@ -47,13 +56,23 @@ describe("native OAuth store contracts", () => {
 		);
 	}
 
-	test("resolves OpenClaw public SDK exports from the installed package", () => {
-		const packageRoot = tempRoot();
+	test("resolves OpenClaw public SDK exports through the official installer node symlink", () => {
+		const home = tempRoot();
+		const versionedNodeRoot = join(home, ".local", "tools", "node-v24.15.0");
+		const packageRoot = join(versionedNodeRoot, "lib", "node_modules", "openclaw");
 		const providerAuthPath = join(packageRoot, "provider-auth.mjs");
 		const configMutationPath = join(packageRoot, "config-mutation.mjs");
-		const commandPath = join(packageRoot, "bin", "openclaw");
-		mkdirSync(join(packageRoot, "bin"), { recursive: true });
-		writeFileSync(commandPath, "#!/bin/sh\n");
+		const commandPath = join(home, ".local", "bin", "openclaw");
+		mkdirSync(dirname(commandPath), { recursive: true });
+		mkdirSync(packageRoot, { recursive: true });
+		symlinkSync(versionedNodeRoot, join(home, ".local", "tools", "node"), "dir");
+		writeFileSync(
+			commandPath,
+			`#!/usr/bin/env bash
+set -euo pipefail
+exec "${join(home, ".local", "tools", "node", "bin", "node")}" "${join(packageRoot, "dist", "entry.js")}" "$@"
+`,
+		);
 		writeFileSync(providerAuthPath, "export const publicProviderAuth = true;\n");
 		writeFileSync(configMutationPath, "export const publicConfigMutation = true;\n");
 		writeFileSync(
@@ -68,8 +87,10 @@ describe("native OAuth store contracts", () => {
 			}),
 		);
 
-		expect(resolveOpenClawProviderAuthSdkExport([commandPath])).toBe(providerAuthPath);
-		expect(resolveOpenClawConfigMutationSdkExport([commandPath])).toBe(configMutationPath);
+		expect(lstatSync(commandPath).isFile()).toBe(true);
+		expect(lstatSync(commandPath).isSymbolicLink()).toBe(false);
+		expect(resolveOpenClawProviderAuthSdkExport(home, [commandPath])).toBe(providerAuthPath);
+		expect(resolveOpenClawConfigMutationSdkExport(home, [commandPath])).toBe(configMutationPath);
 	});
 
 	test("preserves a future Hermes store version and unrelated pool entries", () => {

--- a/packages/cli/src/lib/codex-oauth-native-store.ts
+++ b/packages/cli/src/lib/codex-oauth-native-store.ts
@@ -77,8 +77,9 @@ export function nativeOAuthCredentialEvidenceFingerprint(value: unknown): string
 		.digest("hex")}`;
 }
 
-export function resolveOpenClawProviderAuthSdkExport(
+function resolveOpenClawSdkExport(
 	startPaths: ReadonlyArray<string | null | undefined>,
+	exportPath: `openclaw/plugin-sdk/${string}`,
 ): string | null {
 	const packageRoots = new Set<string>();
 	for (const startPath of startPaths) {
@@ -109,15 +110,25 @@ export function resolveOpenClawProviderAuthSdkExport(
 	}
 	for (const packageRoot of packageRoots) {
 		try {
-			const resolved = createRequire(join(packageRoot, "package.json")).resolve(
-				"openclaw/plugin-sdk/provider-auth",
-			);
+			const resolved = createRequire(join(packageRoot, "package.json")).resolve(exportPath);
 			if (existsSync(resolved)) return resolved;
 		} catch {
-			// The installed package does not expose the public provider-auth SDK.
+			// The installed package does not expose this public SDK subpath.
 		}
 	}
 	return null;
+}
+
+export function resolveOpenClawProviderAuthSdkExport(
+	startPaths: ReadonlyArray<string | null | undefined>,
+): string | null {
+	return resolveOpenClawSdkExport(startPaths, "openclaw/plugin-sdk/provider-auth");
+}
+
+export function resolveOpenClawConfigMutationSdkExport(
+	startPaths: ReadonlyArray<string | null | undefined>,
+): string | null {
+	return resolveOpenClawSdkExport(startPaths, "openclaw/plugin-sdk/config-mutation");
 }
 
 export function nativeOAuthObservation(value: unknown): NativeOAuthCredentialObservation {

--- a/packages/cli/src/lib/codex-oauth-native-store.ts
+++ b/packages/cli/src/lib/codex-oauth-native-store.ts
@@ -78,11 +78,21 @@ export function nativeOAuthCredentialEvidenceFingerprint(value: unknown): string
 }
 
 function resolveOpenClawSdkExport(
+	home: string,
 	startPaths: ReadonlyArray<string | null | undefined>,
 	exportPath: `openclaw/plugin-sdk/${string}`,
 ): string | null {
 	const packageRoots = new Set<string>();
-	for (const startPath of startPaths) {
+	const officialInstallerPackageRoot = join(
+		home,
+		".local",
+		"tools",
+		"node",
+		"lib",
+		"node_modules",
+		"openclaw",
+	);
+	for (const startPath of [...startPaths, officialInstallerPackageRoot]) {
 		if (!startPath || !existsSync(startPath)) continue;
 		let current = realpathSync(startPath);
 		if (!existsSync(join(current, "package.json"))) current = dirname(current);
@@ -120,15 +130,17 @@ function resolveOpenClawSdkExport(
 }
 
 export function resolveOpenClawProviderAuthSdkExport(
+	home: string,
 	startPaths: ReadonlyArray<string | null | undefined>,
 ): string | null {
-	return resolveOpenClawSdkExport(startPaths, "openclaw/plugin-sdk/provider-auth");
+	return resolveOpenClawSdkExport(home, startPaths, "openclaw/plugin-sdk/provider-auth");
 }
 
 export function resolveOpenClawConfigMutationSdkExport(
+	home: string,
 	startPaths: ReadonlyArray<string | null | undefined>,
 ): string | null {
-	return resolveOpenClawSdkExport(startPaths, "openclaw/plugin-sdk/config-mutation");
+	return resolveOpenClawSdkExport(home, startPaths, "openclaw/plugin-sdk/config-mutation");
 }
 
 export function nativeOAuthObservation(value: unknown): NativeOAuthCredentialObservation {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1950,7 +1950,7 @@ function openClawProviderAuthSdkPath(
 		return testOverride;
 	}
 	const commandPath = observation?.commandPath;
-	const resolved = resolveOpenClawProviderAuthSdkExport([
+	const resolved = resolveOpenClawProviderAuthSdkExport(home, [
 		commandPath,
 		observation?.appRoot,
 		join(home, ".openclaw", "lib", "node_modules", "openclaw"),
@@ -2850,7 +2850,7 @@ function openClawConfigMutationSdkPath(
 	home: string,
 ): string | null {
 	const commandPath = observation.commandPath;
-	return resolveOpenClawConfigMutationSdkExport([
+	return resolveOpenClawConfigMutationSdkExport(home, [
 		commandPath,
 		observation.appRoot,
 		join(home, ".openclaw", "lib", "node_modules", "openclaw"),

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -45,6 +45,7 @@ import {
 	OPENCLAW_PROVIDER_AUTH_HELPER,
 	type OpenClawProviderAuthAction,
 	oauthCredentialFingerprint,
+	resolveOpenClawConfigMutationSdkExport,
 	resolveOpenClawProviderAuthSdkExport,
 } from "../lib/codex-oauth-native-store";
 import { resolveCurrentCliResourceRoot } from "../lib/current-cli-invocation";
@@ -2480,13 +2481,7 @@ function applyHostedAiProviderProjection(
 		);
 		const providerPatch = buildOpenClawHostedProviderPatch(projectionInput, previousProviderIds);
 		if (providerPatch.apply) {
-			runRuntimeUserCommand(
-				observation.commandPath,
-				["config", "patch", "--stdin", ...providerPatch.args],
-				providerPatch.content,
-				home,
-				workspaceRoot,
-			);
+			applyOpenClawHostedProviderPatch(observation, providerPatch, home, workspaceRoot);
 		}
 		return {
 			path: observation.commandPath,
@@ -2809,6 +2804,86 @@ export interface OpenClawHostedProviderPatch {
 	args: string[];
 	content: string;
 	providerIds: string[];
+}
+
+const OPENCLAW_CONFIG_MUTATION_HELPER = `
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const sdk = await import(pathToFileURL(process.argv[1]).href);
+if (typeof sdk.mutateConfigFile !== "function") {
+  throw new Error("required public config-mutation export is missing");
+}
+const patch = JSON.parse(readFileSync(0, "utf8"));
+const isRecord = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
+if (!isRecord(patch)) throw new Error("OpenClaw provider patch must be an object");
+const blockedKeys = new Set(["__proto__", "constructor", "prototype"]);
+const explicitSetPaths = [];
+const unsetPaths = [];
+const applyMergePatch = (target, source, path = []) => {
+  for (const [key, value] of Object.entries(source)) {
+    if (blockedKeys.has(key)) throw new Error("OpenClaw provider patch contains a blocked key");
+    const nextPath = [...path, key];
+    if (value === null) {
+      delete target[key];
+      unsetPaths.push(nextPath);
+    } else if (isRecord(value)) {
+      if (!isRecord(target[key])) target[key] = {};
+      if (Object.keys(value).length === 0) explicitSetPaths.push(nextPath);
+      applyMergePatch(target[key], value, nextPath);
+    } else {
+      target[key] = structuredClone(value);
+      explicitSetPaths.push(nextPath);
+    }
+  }
+};
+await sdk.mutateConfigFile({
+  base: "source",
+  afterWrite: { mode: "none", reason: "Clawdi runtime convergence owns service reconciliation" },
+  writeOptions: { allowConfigSizeDrop: true, explicitSetPaths, unsetPaths },
+  mutate: (draft) => applyMergePatch(draft, patch),
+});
+`;
+
+function openClawConfigMutationSdkPath(
+	observation: RuntimeInstallObservation,
+	home: string,
+): string | null {
+	const commandPath = observation.commandPath;
+	return resolveOpenClawConfigMutationSdkExport([
+		commandPath,
+		observation.appRoot,
+		join(home, ".openclaw", "lib", "node_modules", "openclaw"),
+		join(home, ".openclaw", "node_modules", "openclaw"),
+		join(home, ".local", "lib", "node_modules", "openclaw"),
+	]);
+}
+
+function applyOpenClawHostedProviderPatch(
+	observation: RuntimeInstallObservation,
+	patch: OpenClawHostedProviderPatch,
+	home: string,
+	workspaceRoot: string,
+): void {
+	const sdkPath = openClawConfigMutationSdkPath(observation, home);
+	if (!sdkPath) {
+		runRuntimeUserCommand(
+			observation.commandPath ?? "openclaw",
+			["config", "patch", "--stdin", ...patch.args],
+			patch.content,
+			home,
+			workspaceRoot,
+		);
+		return;
+	}
+	ensureRuntimeUserHome(home);
+	runRuntimeUserCommand(
+		"node",
+		["--input-type=module", "--eval", OPENCLAW_CONFIG_MUTATION_HELPER, sdkPath],
+		patch.content,
+		home,
+		workspaceRoot,
+	);
 }
 
 export function buildOpenClawHostedProviderPatch(

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -5,9 +5,11 @@ import {
 	chmodSync,
 	chownSync,
 	existsSync,
+	lstatSync,
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
+	realpathSync,
 	rmSync,
 	statSync,
 	symlinkSync,
@@ -243,6 +245,14 @@ test("projects a large OpenClaw provider model-list reduction through the public
 	const runtimeUid = 10_001;
 	const runtimeGid = 10_001;
 	const commandPath = join(runtimeHome, ".local", "bin", "openclaw");
+	const expectedNodeVersion = process.env.CLAWDI_TEST_OPENCLAW_NODE_VERSION ?? "";
+	const commandStat = lstatSync(commandPath);
+	expect(commandStat.isFile()).toBe(true);
+	expect(commandStat.isSymbolicLink()).toBe(false);
+	expect(commandStat.size).toBe(172);
+	expect(realpathSync(join(runtimeHome, ".local", "tools", "node"))).toBe(
+		join(runtimeHome, ".local", "tools", `node-v${expectedNodeVersion}`),
+	);
 	const root = mkdtempSync(join(tmpdir(), "clawdi-real-openclaw-size-drop-"));
 	chmodSync(root, 0o755);
 	const clawdiHome = join(root, "clawdi-home");

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -20,7 +20,11 @@ import {
 	quiesceSystemdRuntimeCandidate,
 	readSystemdUnitSnapshot,
 } from "../../src/commands/runtime";
-import { convergeRuntimeManifest } from "../../src/runtime/manifest";
+import { hostedAiProviderCatalog } from "../../src/runtime/hosted-provider-resolution";
+import {
+	buildOpenClawHostedProviderPatch,
+	convergeRuntimeManifest,
+} from "../../src/runtime/manifest";
 import {
 	FILE_BROWSER_AMD64_SHA256,
 	FILE_BROWSER_ARM64_SHA256,
@@ -230,6 +234,217 @@ test("propagates the real official OpenClaw installer failure and rolls back as 
 	}
 	expect(existsSync(workspaceRoot)).toBe(false);
 });
+
+test("projects a large OpenClaw provider model-list reduction through the public mutation SDK", () => {
+	if (process.env[REAL_SYSTEMD_GATE] !== "1") return;
+
+	expect(process.geteuid?.()).toBe(0);
+	const runtimeHome = "/home/clawdi";
+	const runtimeUid = 10_001;
+	const runtimeGid = 10_001;
+	const commandPath = join(runtimeHome, ".local", "bin", "openclaw");
+	const root = mkdtempSync(join(tmpdir(), "clawdi-real-openclaw-size-drop-"));
+	chmodSync(root, 0o755);
+	const clawdiHome = join(root, "clawdi-home");
+	mkdirSync(clawdiHome);
+	chownSync(clawdiHome, runtimeUid, runtimeGid);
+	chmodSync(clawdiHome, 0o700);
+	const configRoot = join(root, "openclaw");
+	mkdirSync(configRoot, { mode: 0o700 });
+	chownSync(configRoot, runtimeUid, runtimeGid);
+	const configPath = join(configRoot, "openclaw.json");
+	const staleModels = Array.from({ length: 18 }, (_, index) => ({
+		id: `legacy-managed-${index}`,
+		name: `Legacy managed responses model ${index}`,
+		api: "openai-completions",
+		input: ["text", "image"],
+		reasoning: true,
+		contextWindow: 200_000,
+		maxTokens: 64_000,
+		cost: { input: 1.25, output: 10, cacheRead: 0.125, cacheWrite: 1.25 },
+	}));
+	const userProvider = {
+		baseUrl: "https://user-provider.example.test/v1",
+		api: "openai-completions",
+		models: [
+			{
+				id: "user-model",
+				name: "User-owned model",
+				api: "openai-completions",
+				input: ["text"],
+				contextWindow: 32_768,
+				maxTokens: 8_192,
+			},
+		],
+	};
+	const existingConfig = {
+		agents: { defaults: { workspace: join(runtimeHome, "user-workspace") } },
+		gateway: { mode: "local", port: 19_022 },
+		logging: { level: "debug" },
+		models: {
+			mode: "merge",
+			providers: {
+				"user-owned": userProvider,
+				clawdi: {
+					baseUrl: "https://ai-gateway.example.test/v1",
+					api: "openai-completions",
+					models: staleModels,
+				},
+			},
+		},
+	};
+	const originalConfig = `${JSON.stringify(existingConfig, null, 2)}\n`;
+	writeFileSync(configPath, originalConfig, { mode: 0o600 });
+	chownSync(configPath, runtimeUid, runtimeGid);
+
+	const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+	const previousProviderKey = process.env.CLAWDI_OPENCLAW_API_KEY;
+	process.env.OPENCLAW_CONFIG_PATH = configPath;
+	process.env.CLAWDI_OPENCLAW_API_KEY = "clawdi-egress-placeholder";
+	process.env.CLAWDI_RUNTIME_MODE = "hosted";
+	process.env.CLAWDI_RUNTIME_USER = "clawdi";
+	process.env.CLAWDI_RUNTIME_UID = String(runtimeUid);
+	process.env.CLAWDI_RUNTIME_GID = String(runtimeGid);
+	process.env.CLAWDI_RUNTIME_HOME = runtimeHome;
+	process.env.CLAWDI_HOME = clawdiHome;
+	process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+	process.env.CLAWDI_RUN_DIR = join(root, "run");
+	process.env.CLAWDI_SYSTEMD_SYSTEM_ROOT = join(root, "run", "systemd", "system");
+	process.env.CLAWDI_AUTH_TOKEN = "real-size-drop-test-auth-token";
+	process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
+	const paths = getRuntimePaths({ mode: "hosted" });
+	ensureRuntimeStateDirs(paths);
+
+	const manifest: RuntimeManifest = {
+		schemaVersion: "clawdi.runtimeDesiredState.v1",
+		deploymentId: "hdep_real_openclaw_size_drop",
+		environmentId: "env_real_openclaw_size_drop",
+		instanceId: "hri_real_openclaw_size_drop",
+		generation: 1,
+		issuedAt: "2026-08-11T23:08:17.000Z",
+		workspaceRoot: runtimeHome,
+		controlPlane: { apiUrl: "https://cloud-api.example.test" },
+		projection: {
+			providers: {
+				clawdi: {
+					type: "custom_openai_compatible",
+					managed_by: "clawdi",
+					baseUrl: "https://ai-gateway.example.test/v1",
+					models: [
+						{
+							id: "sol",
+							label: "Sol",
+							api_mode: "openai_chat",
+							input_modalities: ["text"],
+							supports_tools: true,
+							supports_reasoning: true,
+							context_window: 200_000,
+							max_tokens: 64_000,
+							cost: { input: 1.5, output: 12, cache_read: 0.15, cache_write: 1.5 },
+						},
+					],
+					apiMode: "openai_chat",
+					runtimeEnvName: "OPENAI_API_KEY",
+					apiKeySecretRef: "secret://providers/clawdi/api-key",
+				},
+			},
+		},
+		runtimes: {
+			openclaw: {
+				enabled: true,
+				providerMode: "configured",
+				provider_ids: ["clawdi"],
+				primary_model: { provider_id: "clawdi", model: "sol" },
+				run: { command: commandPath, args: ["gateway", "run"], env: {}, prependPath: [] },
+				services: {},
+			},
+		},
+		recovery: {},
+	};
+	const load: RuntimeManifestLoad = {
+		manifest,
+		source: "remote-datasource",
+		sourcePath: "real-openclaw-size-drop-fixture",
+		offline: false,
+		secretValues: { "secret://providers/clawdi/api-key": "sk-size-drop-fixture" },
+		applyContext: {
+			kind: "context-file",
+			backend: "incus",
+			identity: {
+				generation: manifest.generation,
+				manifestETag: '"real-size-drop-test"',
+				applyReceiptId: "real-size-drop-test-receipt",
+				bootNonce: "real-size-drop-test-boot",
+			},
+			cliPackageSpec: "clawdi@1.2.3",
+			manifestSource: {
+				type: "http",
+				url: "https://runtime.test/v1/runtime/manifest?environment_id=env_real_openclaw_size_drop",
+				auth: { type: "bearer", token: "real-size-drop-test-auth-token" },
+			},
+		},
+	};
+
+	try {
+		const projectionInput = hostedAiProviderCatalog(manifest, "openclaw");
+		if (!projectionInput) throw new Error("expected OpenClaw provider projection");
+		const intendedPatch = buildOpenClawHostedProviderPatch(projectionInput, ["clawdi"]);
+		expect(intendedPatch.args).toEqual(["--replace-path", 'models.providers["clawdi"].models']);
+		const rejected = spawnSync(
+			"runuser",
+			[
+				"-u",
+				"clawdi",
+				"--",
+				"env",
+				`HOME=${runtimeHome}`,
+				`OPENCLAW_CONFIG_PATH=${configPath}`,
+				"CLAWDI_OPENCLAW_API_KEY=clawdi-egress-placeholder",
+				commandPath,
+				"config",
+				"patch",
+				"--stdin",
+				...intendedPatch.args,
+			],
+			{ encoding: "utf8", input: intendedPatch.content },
+		);
+		expect(rejected.status).not.toBe(0);
+		const rejectedOutput = `${rejected.stdout}\n${rejected.stderr}`;
+		const sizeDrop = rejectedOutput.match(/size-drop:(\d+)->(\d+)/);
+		expect(sizeDrop).not.toBeNull();
+		if (!sizeDrop) throw new Error(rejectedOutput);
+		const beforeBytes = Number(sizeDrop[1]);
+		const rejectedBytes = Number(sizeDrop[2]);
+		expect(beforeBytes).toBeGreaterThan(5_000);
+		expect(rejectedBytes).toBeLessThan(Math.floor(beforeBytes * 0.5));
+		expect(readFileSync(configPath, "utf8")).toBe(originalConfig);
+
+		const convergence = convergeRuntimeManifest(load, paths, { cacheLastGood: false });
+		expect(convergence.installErrors).toEqual([]);
+		const intendedConfig = JSON.parse(intendedPatch.content);
+		const appliedConfig = JSON.parse(readFileSync(configPath, "utf8"));
+		expect(appliedConfig.models.providers.clawdi.models).toEqual(
+			intendedConfig.models.providers.clawdi.models,
+		);
+		expect(appliedConfig.models.providers["user-owned"]).toEqual(userProvider);
+		expect(appliedConfig.agents.defaults.workspace).toBe(existingConfig.agents.defaults.workspace);
+		expect(appliedConfig.gateway).toEqual(existingConfig.gateway);
+		expect(appliedConfig.logging).toEqual(existingConfig.logging);
+		expect(JSON.stringify(appliedConfig)).not.toContain("legacy-managed-");
+		expect(Buffer.byteLength(readFileSync(configPath, "utf8"))).toBeLessThan(
+			Math.floor(beforeBytes * 0.5),
+		);
+		const configStat = statSync(configPath);
+		expect(configStat.uid).toBe(runtimeUid);
+		expect(configStat.gid).toBe(runtimeGid);
+		expect(configStat.mode & 0o777).toBe(0o600);
+	} finally {
+		if (previousConfigPath === undefined) delete process.env.OPENCLAW_CONFIG_PATH;
+		else process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+		if (previousProviderKey === undefined) delete process.env.CLAWDI_OPENCLAW_API_KEY;
+		else process.env.CLAWDI_OPENCLAW_API_KEY = previousProviderKey;
+	}
+}, 60_000);
 
 test("persists and serves the managed token through the real official OpenClaw gateway", async () => {
 	if (process.env[REAL_SYSTEMD_GATE] !== "1") return;

--- a/packages/cli/tests/fixtures/runtime-official-installer-systemd/Dockerfile
+++ b/packages/cli/tests/fixtures/runtime-official-installer-systemd/Dockerfile
@@ -24,16 +24,32 @@ RUN groupadd --gid 10001 clawdi \
 ARG OPENCLAW_VERSION=2026.7.1-2
 ARG OPENCLAW_COMMIT=0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c
 ARG OPENCLAW_INTEGRITY=sha512-ycF3yPcbjN6bUPeaUx6Mh6vze1hQWoD3CT/wWcmD7a8xaHHHRUaAlaq+lFxMHf1ssEgODVAwjlzYqp2twkYZ7g==
+ARG OPENCLAW_NODE_VERSION=24.15.0
 RUN npm pack "openclaw@${OPENCLAW_VERSION}" --pack-destination /tmp --silent >/dev/null \
 	&& OPENCLAW_TARBALL="/tmp/openclaw-${OPENCLAW_VERSION}.tgz" \
 		OPENCLAW_EXPECTED_INTEGRITY="${OPENCLAW_INTEGRITY}" \
 		node --input-type=module --eval \
 			'import { createHash } from "node:crypto"; import { readFileSync } from "node:fs"; const actual = `sha512-${createHash("sha512").update(readFileSync(process.env.OPENCLAW_TARBALL)).digest("base64")}`; if (actual !== process.env.OPENCLAW_EXPECTED_INTEGRITY) { throw new Error(`OpenClaw package integrity mismatch: ${actual}`); }' \
+	&& OPENCLAW_NODE_DIR="/home/clawdi/.local/tools/node-v${OPENCLAW_NODE_VERSION}" \
+	&& mkdir -p "${OPENCLAW_NODE_DIR}" /home/clawdi/.local/bin \
+	&& chown -R clawdi:clawdi /home/clawdi/.local \
 	&& runuser -u clawdi -- env HOME=/home/clawdi npm install --global \
-		--prefix /home/clawdi/.local \
+		--prefix "${OPENCLAW_NODE_DIR}" \
 		"/tmp/openclaw-${OPENCLAW_VERSION}.tgz" \
 		--ignore-scripts --no-audit --no-fund \
 	&& rm "/tmp/openclaw-${OPENCLAW_VERSION}.tgz" \
+	&& ln -s /usr/local/bin/node "${OPENCLAW_NODE_DIR}/bin/node" \
+	&& ln -s "${OPENCLAW_NODE_DIR}" /home/clawdi/.local/tools/node \
+	&& printf '%s\n' \
+		'#!/usr/bin/env bash' \
+		'set -euo pipefail' \
+		"exec \"/home/clawdi/.local/tools/node/bin/node\" \"${OPENCLAW_NODE_DIR}/lib/node_modules/openclaw/dist/entry.js\" \"\$@\"" \
+		> /home/clawdi/.local/bin/openclaw \
+	&& chown -h clawdi:clawdi \
+		/home/clawdi/.local/bin/openclaw \
+		/home/clawdi/.local/tools/node \
+		"${OPENCLAW_NODE_DIR}/bin/node" \
+	&& chmod 0755 /home/clawdi/.local/bin/openclaw \
 	&& OPENCLAW_VERSION_OUTPUT="$(runuser -u clawdi -- env HOME=/home/clawdi \
 		/home/clawdi/.local/bin/openclaw --version)" \
 	&& printf '%s\n' "$OPENCLAW_VERSION_OUTPUT" | grep -F "OpenClaw ${OPENCLAW_VERSION}" \
@@ -41,7 +57,8 @@ RUN npm pack "openclaw@${OPENCLAW_VERSION}" --pack-destination /tmp --silent >/d
 		| grep -F "$(printf '%s' "$OPENCLAW_COMMIT" | cut -c1-7)"
 
 ENV CLAWDI_TEST_OPENCLAW_VERSION=${OPENCLAW_VERSION} \
-	CLAWDI_TEST_OPENCLAW_COMMIT=${OPENCLAW_COMMIT}
+	CLAWDI_TEST_OPENCLAW_COMMIT=${OPENCLAW_COMMIT} \
+	CLAWDI_TEST_OPENCLAW_NODE_VERSION=${OPENCLAW_NODE_VERSION}
 
 STOPSIGNAL SIGRTMIN+3
 CMD ["/sbin/init"]

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -3495,41 +3495,90 @@ chmod +x "$HOME/.local/bin/hermes"
 		const state = join(root, "model-switch", "var", "lib", "clawdi");
 		const run = join(root, "model-switch", "run", "clawdi");
 		const openclawBin = join(home, ".local", "bin", "openclaw");
+		const openclawPackage = join(home, ".local", "lib", "node_modules", "openclaw");
 		const openclawConfig = join(home, ".openclaw", "openclaw.json");
-		const providerPatch = join(root, "openclaw-model-switch-patch.json");
 		const commandLog = join(root, "openclaw-model-switch-command.txt");
+		const mutationLog = join(root, "openclaw-model-switch-mutation.json");
+		const configMutationSdk = join(openclawPackage, "config-mutation.mjs");
+		const legacyModels = Array.from({ length: 24 }, (_, index) => ({
+			id: `legacy-${index}`,
+			name: `Legacy managed model ${index}`,
+			api: "openai-responses",
+			input: ["text", "image"],
+			reasoning: true,
+			contextWindow: 200_000,
+			maxTokens: 64_000,
+		}));
 		mkdirSync(dirname(openclawBin), { recursive: true });
+		mkdirSync(openclawPackage, { recursive: true });
 		mkdirSync(dirname(openclawConfig), { recursive: true });
 		writeFileSync(
 			openclawConfig,
 			`${JSON.stringify({
+				gateway: { mode: "local", port: 19_001 },
+				logging: { level: "debug" },
 				models: {
 					providers: {
-						"clawdi-managed": { models: [{ id: "luna" }] },
+						"user-owned": {
+							baseUrl: "https://user.provider.example.test/v1",
+							api: "openai-completions",
+							models: [{ id: "user-model", name: "User model" }],
+						},
+						"clawdi-managed": {
+							baseUrl: "https://managed.provider.example.test/v1",
+							api: "openai-responses",
+							models: legacyModels,
+						},
 					},
 				},
 			})}\n`,
 		);
+		writeFileSync(commandLog, "");
 		writeFileSync(
 			openclawBin,
 			`#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> '${commandLog}'
-if [ "\${1:-} \${2:-} \${3:-}" = "config patch --stdin" ]; then
-  cat > '${providerPatch}'
-  if grep -q '"models"' '${providerPatch}'; then
-    if [ "\${4:-}" != "--replace-path" ] || [ "\${5:-}" != 'models.providers["clawdi-managed"].models' ] || [ -n "\${6:-}" ]; then
-      echo 'Refusing to replace models.providers.clawdi-managed.models; use --merge or --replace intentionally.' >&2
-      exit 42
-    fi
-    cp '${providerPatch}' '${openclawConfig}'
-  fi
-  exit 0
-fi
 exit 0
 `,
 		);
 		chmodSync(openclawBin, 0o700);
+		writeFileSync(
+			join(openclawPackage, "package.json"),
+			JSON.stringify({
+				name: "openclaw",
+				type: "module",
+				exports: { "./plugin-sdk/config-mutation": "./config-mutation.mjs" },
+			}),
+		);
+		writeFileSync(
+			configMutationSdk,
+			`import { readFileSync, writeFileSync } from "node:fs";
+export async function mutateConfigFile(options) {
+  if (options.base !== "source") throw new Error("expected source config mutation");
+  if (options.afterWrite?.mode !== "none") throw new Error("expected no SDK-owned restart");
+  const before = JSON.parse(readFileSync(${JSON.stringify(openclawConfig)}, "utf8"));
+  const draft = structuredClone(before);
+  await options.mutate(draft, { snapshot: {}, previousHash: null, attempt: 1 });
+  const next = JSON.stringify(draft, null, 2) + "\\n";
+  const beforeBytes = Buffer.byteLength(JSON.stringify(before, null, 2) + "\\n");
+  const nextBytes = Buffer.byteLength(next);
+  if (nextBytes < Math.floor(beforeBytes * 0.5) && options.writeOptions?.allowConfigSizeDrop !== true) {
+    throw new Error(\`size-drop:\${beforeBytes}->\${nextBytes}\`);
+  }
+  writeFileSync(${JSON.stringify(openclawConfig)}, next);
+  writeFileSync(${JSON.stringify(mutationLog)}, JSON.stringify({
+    base: options.base,
+    afterWrite: options.afterWrite,
+    allowConfigSizeDrop: options.writeOptions?.allowConfigSizeDrop,
+    explicitSetPaths: options.writeOptions?.explicitSetPaths,
+    unsetPaths: options.writeOptions?.unsetPaths,
+    beforeBytes,
+    nextBytes,
+  }));
+}
+`,
+		);
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
@@ -3561,18 +3610,49 @@ exit 0
 			}),
 		};
 
-		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+		const paths = getRuntimePaths();
+		const convergence = convergeRuntimeManifest(loaded, paths);
 
 		expect(convergence.installErrors).toEqual([]);
-		expect(readFileSync(commandLog, "utf-8")).toContain(
-			'config patch --stdin --replace-path models.providers["clawdi-managed"].models',
-		);
+		expect(readFileSync(commandLog, "utf-8")).not.toContain("config patch --stdin");
+		const mutation = JSON.parse(readFileSync(mutationLog, "utf8"));
+		expect(mutation).toMatchObject({
+			base: "source",
+			afterWrite: { mode: "none" },
+			allowConfigSizeDrop: true,
+		});
+		expect(mutation.nextBytes).toBeLessThan(Math.floor(mutation.beforeBytes * 0.5));
+		expect(mutation.explicitSetPaths).toContainEqual([
+			"models",
+			"providers",
+			"clawdi-managed",
+			"models",
+		]);
 		const appliedConfig = JSON.parse(readFileSync(openclawConfig, "utf-8"));
 		expect(appliedConfig.agents.defaults.model.primary).toBe("clawdi-managed/sol");
 		expect(appliedConfig.models.providers["clawdi-managed"].models).toEqual([
 			expect.objectContaining({ id: "sol" }),
 		]);
-		expect(JSON.stringify(appliedConfig)).not.toContain("luna");
+		expect(appliedConfig.models.providers["user-owned"].models).toEqual([
+			{ id: "user-model", name: "User model" },
+		]);
+		expect(appliedConfig.gateway).toEqual({ mode: "local", port: 19_001 });
+		expect(appliedConfig.logging).toEqual({ level: "debug" });
+		expect(JSON.stringify(appliedConfig)).not.toContain("legacy-");
+
+		writeTestRuntimeAppliedState(paths, loaded, convergence);
+		const unmanaged = convergeRuntimeManifest(
+			hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 3),
+			paths,
+		);
+		expect(unmanaged.installErrors).toEqual([]);
+		const deletionMutation = JSON.parse(readFileSync(mutationLog, "utf8"));
+		expect(deletionMutation.unsetPaths).toContainEqual(["models", "providers", "clawdi-managed"]);
+		const unmanagedConfig = JSON.parse(readFileSync(openclawConfig, "utf8"));
+		expect(unmanagedConfig.models.providers["clawdi-managed"]).toBeUndefined();
+		expect(unmanagedConfig.models.providers["user-owned"]).toEqual(
+			appliedConfig.models.providers["user-owned"],
+		);
 	});
 
 	it("writes Codex managed provider config from hosted runtime converge", () => {


### PR DESCRIPTION
## Summary

- apply Hosted OpenClaw provider projection through the public `openclaw/plugin-sdk/config-mutation` API
- mutate from authored source config so managed model-list reductions preserve unrelated user configuration
- opt into only OpenClaw's targeted `allowConfigSizeDrop` override while retaining locking, CAS, schema, SecretRef, config-path, and gateway-mode guards
- resolve public SDK exports through the official installer's stable `~/.local/tools/node` layout, with the existing CLI fallback for older OpenClaw versions

## Root cause

A provider projection that intentionally reduced the managed model list produced a candidate under 50% of the existing config size. `openclaw config patch --stdin` rejected it with `size-drop`, leaving Hosted convergence unhealthy even though the desired model catalog had not changed.

## Verification

- `bun run check` (975 files)
- `bun run typecheck` (4/4 packages)
- `bun run --cwd packages/cli test` (1642 passed, 4 skipped)
- real official-installer systemd fixture covers the actual wrapper + stable Node symlink layout and reproduces then fixes the `>5000 bytes -> <50%` rejection
- `git diff --check origin/main..HEAD`

## Upstream contract

Verified against `openclaw@2026.7.1-2`, source commit `0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c`. The package publicly exports `openclaw/plugin-sdk/config-mutation`; `mutateConfigFile` retains locking and source-hash conflict checks. `allowConfigSizeDrop` exempts only the size-drop blocker, not unreadable-config or gateway-mode removal.

## Release impact

This PR intentionally does not change the CLI package version. After merge, publish the fix as a separate `clawdi@0.13.62` release PR so the immutable `0.13.61` artifact is not reused.
