### PR TITLE
release(cli): prepare 0.13.62

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.61",
+      "version": "0.13.62",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.61",
+	"version": "0.13.62",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary

- bump the immutable CLI package from `0.13.61` to `0.13.62`
- synchronize the Bun workspace lockfile
- keep the release diff strictly limited to those two version fields

## Included fixes

- #952 preserves active managed units across CLI-only runtime checkpoints, including legacy renderer byte drift
- #953 preserves authored OpenClaw configuration when a managed provider model list intentionally shrinks past OpenClaw's size-drop threshold

## Verification

- release branch rebased onto `f3f7b50ec` (the #953 merge commit)
- exact two-file release diff
- `git diff --check origin/main..HEAD`
- #953: Biome, 4-package typecheck, CLI isolated suite (`1642 passed, 4 skipped`), and real official OpenClaw systemd fixture
- this PR's Client CI, Backend CI, Clean Test Runner, and required integration checks must pass on head `770e700202eb8b8038bb87b0557d368667339d04`

## Release behavior

Merging changes `packages/cli/package.json`, which triggers the protected CLI publish workflow for the immutable `clawdi@0.13.62` artifact. Hosted rollout remains a separate exact-version activation step after npm and GitHub release verification.
