### PR TITLE
fix(whatsapp): authorize Hermes self LID in USync

### DIFF
--- a/backend/app/routes/channel_routers/whatsapp.py
+++ b/backend/app/routes/channel_routers/whatsapp.py
@@ -287,6 +287,7 @@ async def _run_whatsapp_baileys_websocket(
             node,
             tenant_id,
             bot_agent_link_id=bot_agent_link_id,
+            self_lid=session.tenant.lid if session.tenant is not None else None,
         )
 
     async def resolve_outbound_signal_jid(jid: str) -> str | None:

--- a/backend/app/services/whatsapp_baileys.py
+++ b/backend/app/services/whatsapp_baileys.py
@@ -2891,14 +2891,15 @@ def _usync_devices_result(
 def whatsapp_usync_device_result(
     req: BinaryNode,
     *,
-    recipient_lids: Mapping[str, str],
+    target_lids: Mapping[str, str],
+    self_lid: str | None = None,
 ) -> BinaryNode:
-    """Build the stock Baileys device/LID result from authorized durable mappings."""
+    """Build the stock Baileys device/LID result from authorized target mappings."""
     return _usync_devices_result(
         req,
         agent_user=None,
-        agent_lid=None,
-        resolve_recipient_lid=recipient_lids.get,
+        agent_lid=self_lid,
+        resolve_recipient_lid=target_lids.get,
     )
 
 

--- a/backend/app/services/whatsapp_provider_bridge.py
+++ b/backend/app/services/whatsapp_provider_bridge.py
@@ -341,21 +341,23 @@ class WhatsAppProviderBridge:
         tenant_id: str | None,
         *,
         bot_agent_link_id: UUID,
+        self_lid: str | None = None,
     ) -> BinaryNode | None:
         if tenant_id != str(bot_agent_link_id):
             return None
         async with self._sessionmaker() as db:
             account = await _load_active_whatsapp_account(db, account_id=self._account_id)
             usync_targets = parse_whatsapp_usync_device_targets(node)
-            recipient_lids: dict[str, str] | None = None
+            usync_lids: dict[str, str] | None = None
             if usync_targets is not None:
-                recipient_lids = await _authorized_usync_recipient_lids(
+                usync_lids = await _authorized_usync_target_lids(
                     db,
                     account=account,
                     targets=usync_targets,
                     bot_agent_link_id=bot_agent_link_id,
+                    self_lid=self_lid,
                 )
-                if recipient_lids is None:
+                if usync_lids is None:
                     return None
             elif _is_authorized_provider_service_iq(node):
                 if not await _active_link_owns_account(
@@ -384,8 +386,12 @@ class WhatsAppProviderBridge:
                     self._forward_iq_inflight -= 1
             if forwarded is not None:
                 return forwarded
-            if recipient_lids is not None:
-                return whatsapp_usync_device_result(node, recipient_lids=recipient_lids)
+            if usync_lids is not None:
+                return whatsapp_usync_device_result(
+                    node,
+                    target_lids=usync_lids,
+                    self_lid=self_lid,
+                )
             return None
 
     async def resolve_recipient_lid(
@@ -396,7 +402,7 @@ class WhatsAppProviderBridge:
     ) -> str | None:
         async with self._sessionmaker() as db:
             account = await _load_active_whatsapp_account(db, account_id=self._account_id)
-            recipient_lids = await _authorized_usync_recipient_lids(
+            recipient_lids = await _authorized_usync_target_lids(
                 db,
                 account=account,
                 targets=(jid,),
@@ -770,16 +776,22 @@ async def _build_bound_jid_resolver(
     return resolved.get
 
 
-async def _authorized_usync_recipient_lids(
+async def _authorized_usync_target_lids(
     db: AsyncSession,
     *,
     account: ChannelAccount,
     targets: tuple[str, ...],
     bot_agent_link_id: UUID,
+    self_lid: str | None = None,
 ) -> dict[str, str] | None:
+    normalized_self_lid = strip_whatsapp_device(self_lid) if self_lid is not None else None
+    resolved: dict[str, str] = {}
     target_bindings: dict[str, ChannelBinding] = {}
     bindings: dict[UUID, ChannelBinding] = {}
     for target in targets:
+        if normalized_self_lid is not None and strip_whatsapp_device(target) == normalized_self_lid:
+            resolved[target] = normalized_self_lid
+            continue
         binding = await find_binding(
             db,
             account=account,
@@ -790,6 +802,13 @@ async def _authorized_usync_recipient_lids(
             return None
         target_bindings[target] = binding
         bindings[binding.id] = binding
+
+    if resolved and not await _active_link_owns_account(
+        db,
+        account=account,
+        bot_agent_link_id=bot_agent_link_id,
+    ):
+        return None
 
     authorized: dict[UUID, ChannelBinding] = {}
     for binding_id in sorted(bindings, key=str):
@@ -817,7 +836,6 @@ async def _authorized_usync_recipient_lids(
     for alias in aliases_result.scalars():
         identifiers[alias.binding_id].add(strip_whatsapp_device(alias.alias_external_chat_id))
 
-    resolved: dict[str, str] = {}
     for target, binding in target_bindings.items():
         target_jid = strip_whatsapp_device(target)
         binding_identifiers = identifiers[binding.id]

--- a/backend/tests/test_whatsapp_provider_bridge.py
+++ b/backend/tests/test_whatsapp_provider_bridge.py
@@ -534,6 +534,8 @@ async def test_whatsapp_provider_usync_requires_link_binding_and_uses_durable_li
         external_chat_id="15551112222@s.whatsapp.net",
     )
     lid_jid = "184207372460253@lid"
+    self_lid_jid = "900000000000004:1@lid"
+    self_lid_target = "900000000000004@lid"
     await remember_whatsapp_binding_aliases(
         db_session,
         binding=binding,
@@ -586,10 +588,16 @@ async def test_whatsapp_provider_usync_requires_link_binding_and_uses_durable_li
         tenant_id=str(link.id),
         bot_agent_link_id=link.id,
     )
+    mixed = await bridge.forward_iq(
+        _stock_usync_device_iq(self_lid_target, binding.external_chat_id),
+        tenant_id=str(link.id),
+        bot_agent_link_id=link.id,
+        self_lid=self_lid_jid,
+    )
 
     assert unbound is None
     assert cross_link is None
-    assert len(transport.iq_queries) == 1
+    assert len(transport.iq_queries) == 2
     assert transport.iq_queries[0][0]["attrs"] == {
         "to": "s.whatsapp.net",
         "type": "get",
@@ -616,6 +624,14 @@ async def test_whatsapp_provider_usync_requires_link_binding_and_uses_durable_li
             },
         ],
     }
+    assert mixed is not None
+    mixed_users = mixed["content"][0]["content"][0]["content"]
+    assert [user["attrs"]["jid"] for user in mixed_users] == [
+        self_lid_target,
+        binding.external_chat_id,
+    ]
+    assert mixed_users[0]["content"][1]["content"][0]["content"] == []
+    assert mixed_users[1] == resolved_user
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- treat the authenticated Hermes session LID as self identity during mixed USync queries
- keep recipient PN/LID resolution behind the existing binding and alias authority checks
- emit an empty device list for self while preserving recipient device 0 in the fallback response

## Root cause

Baileys requests USync devices for both its own LID and the message recipient. The provider bridge required a chat binding for every target, so the self LID rejected the whole batch. Baileys then received no recipient devices and emitted a message stanza without `enc`, which the backend correctly dropped as `missing-enc`.

## Verification

- isolated Docker backend focus: 74 passed, 6 skipped
- Ruff check and format check
- compileall
- owned type governance: 186 files, 0 errors, 0 warnings
- git diff --check

The 6 skips are the existing stock Baileys rc14 `authCert` seam gate. No migration is required, and `missing-enc` remains fail-closed.