### PR TITLE
fix(cli): isolate Hermes managed provider env

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -630,6 +630,13 @@ BYOK, Codex OAuth, and unmanaged runtime-provider modes all receive the same
 terminal Codex default. Unmanaged OpenClaw or Hermes units receive no provider
 environment.
 
+For a Clawdi-managed runtime provider, the CLI gives each native runtime a
+reserved local placeholder name: `CLAWDI_OPENCLAW_API_KEY` for OpenClaw and
+`CLAWDI_MANAGED_OPENAI_API_KEY` for Hermes. The endpoint-scoped egress profile
+still matches that placeholder and rewrites Authorization from the provider
+secret reference. Terminal Codex continues to use `OPENAI_API_KEY`, and
+user-managed provider environment names are not remapped.
+
 Only the selected model and managed endpoint vary for the terminal consumer;
 the provider model catalog remains on runtime provider projections where
 OpenClaw and Hermes consume its capability and compatibility facts. Fixed v1

--- a/packages/cli/src/runtime/hosted-provider-resolution.ts
+++ b/packages/cli/src/runtime/hosted-provider-resolution.ts
@@ -11,6 +11,7 @@ import { isClawdiManagedProviderProjection } from "./hosted-egress-profiles";
 import type { RuntimeManifest } from "./manifest-contract";
 
 const OPENCLAW_PROVIDER_RUNTIME_ENV_NAME = "CLAWDI_OPENCLAW_API_KEY";
+const HERMES_PROVIDER_RUNTIME_ENV_NAME = "CLAWDI_MANAGED_OPENAI_API_KEY";
 
 export function hostedAiProviderCatalog(
 	manifest: RuntimeManifest,
@@ -188,6 +189,9 @@ function hostedProviderRuntimeEnvName(
 ): string {
 	if (runtimeName === "openclaw" && isClawdiManagedProviderProjection(input)) {
 		return OPENCLAW_PROVIDER_RUNTIME_ENV_NAME;
+	}
+	if (runtimeName === "hermes" && isClawdiManagedProviderProjection(input)) {
+		return HERMES_PROVIDER_RUNTIME_ENV_NAME;
 	}
 	const raw = typeof input.runtimeEnvName === "string" ? input.runtimeEnvName : null;
 	if (raw && isEnvKey(raw)) return raw;

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -3052,7 +3052,22 @@ describe("runtime manifest datasource", () => {
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const hermesInstaller = join(root, "install-hermes.sh");
+		const hermesConfig = join(home, ".hermes", "config.yaml");
 		mkdirSync(home, { recursive: true });
+		mkdirSync(dirname(hermesConfig), { recursive: true });
+		writeFileSync(
+			hermesConfig,
+			[
+				"providers:",
+				"  clawdi:",
+				"    api: https://ai-gateway.test/v1",
+				"    key_env: OPENAI_API_KEY",
+				"    models:",
+				"      gpt-5.5: {}",
+				"    transport: openai_chat",
+				"",
+			].join("\n"),
+		);
 		writeFileSync(
 			hermesInstaller,
 			`#!/usr/bin/env bash
@@ -3099,10 +3114,13 @@ chmod +x "$HOME/.local/bin/hermes"
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
-								hermes: hostedHermesRuntime({}),
+								hermes: hostedHermesRuntime({
+									provider_ids: ["clawdi"],
+									primary_model: { provider_id: "clawdi", model: "gpt-5.5" },
+								}),
 							},
 							providers: {
-								default: {
+								clawdi: {
 									kind: "openai-compatible",
 									type: "custom_openai_compatible",
 									baseUrl: "https://ai-gateway.test/v1",
@@ -3125,18 +3143,59 @@ chmod +x "$HOME/.local/bin/hermes"
 			const paths = getRuntimePaths();
 			const loaded = await loadRuntimeManifest(paths);
 			if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+			const provider = hostedAiProviderCatalog(loaded.manifest, "hermes")?.catalog.providers[0];
+			expect(provider?.runtime_env_name).toBe("CLAWDI_MANAGED_OPENAI_API_KEY");
+			expectProviderEgressProfileUsesSecretRef(
+				loaded.manifest.egressProfiles?.profiles,
+				"secret://provider.default.apiKey",
+				"sk-runtime",
+			);
 			const convergence = convergeRuntimeManifest(loaded, paths);
 			expect(convergence.installErrors).toEqual([]);
 			const hermesEnv = readSystemdEnvFile(paths, "hermes-gateway");
 			const hermesDashboardEnv = readSystemdEnvFile(paths, "clawdi-hermes-dashboard");
+			const hermesRunConfig = expectRecord(
+				JSON.parse(readFileSync(join(paths.runConfigRoot, "hermes.json"), "utf-8")),
+				"Hermes run config",
+			);
+			const hermesDashboardRunConfig = expectRecord(
+				JSON.parse(readFileSync(join(paths.runConfigRoot, "hermes+dashboard.json"), "utf-8")),
+				"Hermes dashboard run config",
+			);
+			const providers = expectRecord(readHermesConfigYaml(home).providers, "Hermes providers");
+			const managedProvider = expectRecord(providers.clawdi, "Hermes managed provider");
+			const hermesRunEnv = expectRecord(hermesRunConfig.env, "Hermes run environment");
+			const hermesDashboardRunEnv = expectRecord(
+				hermesDashboardRunConfig.env,
+				"Hermes dashboard run environment",
+			);
 
 			expect(convergence.outputs.systemdSystemUnits).toContain(
 				join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service"),
 			);
+			expect(managedProvider.key_env).toBe("CLAWDI_MANAGED_OPENAI_API_KEY");
 			expect(hermesEnv).not.toContain("CLAWDI_OPENCLAW_API_KEY");
-			expect(hermesEnv).toContain('OPENAI_API_KEY="clawdi-egress-placeholder"');
+			expect(hermesEnv).toContain('CLAWDI_MANAGED_OPENAI_API_KEY="clawdi-egress-placeholder"');
+			expect(hermesEnv).not.toMatch(/^OPENAI_API_KEY=/m);
 			expect(hermesDashboardEnv).not.toContain("CLAWDI_OPENCLAW_API_KEY");
-			expect(hermesDashboardEnv).toContain('OPENAI_API_KEY="clawdi-egress-placeholder"');
+			expect(hermesDashboardEnv).toContain(
+				'CLAWDI_MANAGED_OPENAI_API_KEY="clawdi-egress-placeholder"',
+			);
+			expect(hermesDashboardEnv).not.toMatch(/^OPENAI_API_KEY=/m);
+			expect(hermesRunEnv.CLAWDI_MANAGED_OPENAI_API_KEY).toBe("clawdi-egress-placeholder");
+			expect(hermesRunEnv.OPENAI_API_KEY).toBeUndefined();
+			expect(hermesDashboardRunEnv.CLAWDI_MANAGED_OPENAI_API_KEY).toBe("clawdi-egress-placeholder");
+			expect(hermesDashboardRunEnv.OPENAI_API_KEY).toBeUndefined();
+			expectEgressProfileBundleUsesSecretRef(
+				convergence.outputs.egressProfileBundle,
+				"secret://provider.default.apiKey",
+				"sk-runtime",
+			);
+			if (!convergence.outputs.egressProfileBundle) {
+				throw new Error("expected managed provider egress profile bundle");
+			}
+			const egressProfileBundle = readFileSync(convergence.outputs.egressProfileBundle, "utf-8");
+			expect(egressProfileBundle).toContain('"value": "clawdi-egress-placeholder"');
 			expect(readSystemdUserServiceConfig(paths, "hermes-gateway")).not.toContain("sk-runtime");
 			expect(readSystemdUserServiceConfig(paths, "clawdi-hermes-dashboard")).not.toContain(
 				"sk-runtime",


### PR DESCRIPTION
## Summary
- remap Clawdi-managed Hermes provider credentials to the reserved `CLAWDI_MANAGED_OPENAI_API_KEY` alias during CLI projection
- keep `OPENAI_API_KEY` out of Hermes provider config and runtime service environments while preserving managed egress placeholder rewriting
- document the per-runtime aliases and cover stale generated Hermes `key_env` reconciliation

## Verification
- `bun run --cwd packages/cli test tests/runtime.test.ts -t "projects direct Hermes dashboard exposure"` (Docker clean runner; CLI `tsc --noEmit` plus 1 focused test passed)
- `bunx biome check packages/cli/src/runtime/hosted-provider-resolution.ts`
- `git diff --check`

## Cross-repo dependency
The clawdi-hosted counterpart must continue emitting the generic managed manifest contract with `runtimeEnvName: OPENAI_API_KEY`. This PR remaps that name only when the CLI projects a Clawdi-managed provider into Hermes; OpenClaw and terminal Codex behavior remain unchanged.