### PR TITLE
fix(whatsapp): answer authorized USync locally

### DIFF
--- a/backend/app/services/whatsapp_provider_bridge.py
+++ b/backend/app/services/whatsapp_provider_bridge.py
@@ -348,7 +348,6 @@ class WhatsAppProviderBridge:
         async with self._sessionmaker() as db:
             account = await _load_active_whatsapp_account(db, account_id=self._account_id)
             usync_targets = parse_whatsapp_usync_device_targets(node)
-            usync_lids: dict[str, str] | None = None
             if usync_targets is not None:
                 usync_lids = await _authorized_usync_target_lids(
                     db,
@@ -359,7 +358,12 @@ class WhatsAppProviderBridge:
                 )
                 if usync_lids is None:
                     return None
-            elif _is_authorized_provider_service_iq(node):
+                return whatsapp_usync_device_result(
+                    node,
+                    target_lids=usync_lids,
+                    self_lid=self_lid,
+                )
+            if _is_authorized_provider_service_iq(node):
                 if not await _active_link_owns_account(
                     db,
                     account=account,
@@ -386,12 +390,6 @@ class WhatsAppProviderBridge:
                     self._forward_iq_inflight -= 1
             if forwarded is not None:
                 return forwarded
-            if usync_lids is not None:
-                return whatsapp_usync_device_result(
-                    node,
-                    target_lids=usync_lids,
-                    self_lid=self_lid,
-                )
             return None
 
     async def resolve_recipient_lid(

--- a/backend/tests/test_whatsapp_provider_bridge.py
+++ b/backend/tests/test_whatsapp_provider_bridge.py
@@ -561,12 +561,7 @@ async def test_whatsapp_provider_usync_requires_link_binding_and_uses_durable_li
     db_session.add(other_binding)
     await db_session.commit()
 
-    class UnavailableUsyncTransport(_FakeProviderTransport):
-        async def query_iq(self, node, timeout_ms):
-            self.iq_queries.append((node, timeout_ms))
-            return None
-
-    transport = UnavailableUsyncTransport()
+    transport = _FakeProviderTransport()
     bridge = WhatsAppProviderBridge(
         async_sessionmaker(db_session.bind, expire_on_commit=False),
         account_id=account.id,
@@ -597,12 +592,7 @@ async def test_whatsapp_provider_usync_requires_link_binding_and_uses_durable_li
 
     assert unbound is None
     assert cross_link is None
-    assert len(transport.iq_queries) == 2
-    assert transport.iq_queries[0][0]["attrs"] == {
-        "to": "s.whatsapp.net",
-        "type": "get",
-        "xmlns": "usync",
-    }
+    assert transport.iq_queries == []
     assert resolved is not None
     assert resolved["attrs"]["id"] == "stock-usync-devices"
     resolved_user = resolved["content"][0]["content"][0]["content"][0]


### PR DESCRIPTION
## Production symptom

Hermes received the inbound message and attempted a reply, but the outbound stanza had no participant `enc` node. The backend correctly dropped it as `missing-enc`.

## Root cause

After the existing Link/binding/alias authorization succeeded, exact stock-Baileys USync still queried the physical sidecar first. A non-null empty device result suppressed the deterministic local response, so Baileys produced no recipient devices and an empty message stanza.

## Fix

Return the deterministic local device/LID result immediately after exact USync authorization. Do not query the physical sidecar for this synthetic linked-device lookup. Other provider IQ forwarding and the fail-closed `missing-enc` behavior remain unchanged.

The implementation removes the obsolete fallback shape: 8 insertions, 20 deletions across the bridge and its existing authority test.

## Verification

- Isolated Docker/PostgreSQL focused test: 1 passed
- Ruff lint and format: passed
- basedpyright: 0 errors, 0 warnings
- Python syntax compile: passed
- `git diff --check`: passed
- Branch based on current `origin/main`; diff limited to two WhatsApp files

## Rollout check

After backend deployment, verify a fresh message produces an outbound stanza with recipient `enc`, followed by physical relay/delivery, with no new `missing-enc` drop.