### PR TITLE
fix(cli): ignore checkpoint issue time for restart impact

### DIFF
--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -218,6 +218,7 @@ function runtimeCheckpointContent(
 	const {
 		generation: _generation,
 		applyGeneration: _applyGeneration,
+		issuedAt: _issuedAt,
 		clawdiCli,
 		...manifest
 	} = load.manifest;

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -8580,7 +8580,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		});
 	});
 
-	it("classifies only a package-spec-only runtime checkpoint as CLI-only", () => {
+	it("classifies a fresh CLI package checkpoint as CLI-only", () => {
 		const home = join(root, "home", "clawdi");
 		const previousManifest = {
 			...runtimeWatchLocaleManifest(home, 13),
@@ -8589,6 +8589,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		const nextManifest: RuntimeManifest = {
 			...previousManifest,
 			generation: 14,
+			issuedAt: "2026-06-06T00:00:14Z",
 			clawdiCli: {
 				...previousManifest.clawdiCli,
 				packageSpec: "clawdi@1.2.4-test",
@@ -8896,7 +8897,7 @@ chmod +x "$prefix/bin/clawdi"
 								...hostedRequiredState(),
 								instanceId: "iid_cli_update",
 								generation: runtimeGeneration,
-								issuedAt: "2026-06-06T00:00:00Z",
+								issuedAt: `2026-06-06T00:00:${runtimeGeneration}Z`,
 								locale: TEST_HOSTED_LOCALE,
 								system: hostedSystemFixture(home),
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },


### PR DESCRIPTION
## Summary
- treat hosted manifest `issuedAt` as checkpoint metadata when classifying CLI-package-only changes
- preserve strict comparison of expiry, runtime projection, policy, and recoverable secrets
- exercise the existing two-tick handoff test with a freshly issued checkpoint

## Production evidence
Cloud audit for Hermes deployment `hdep_vtGRM2ZO` recorded generation 9 -> 10 with only `generation` and `cli_package_spec` changed, while the generated manifest also received a fresh `issuedAt`. Incus generation, boot ID, instance identity, and runtime-context remained unchanged, but the metadata timestamp prevented the CLI-only classification and restarted active runtime units.

## Verification
- `scripts/test.sh cli tests/runtime.test.ts --test-name-pattern 'classifies a fresh CLI package checkpoint as CLI-only|preserves active units across a CLI-only checkpoint with legacy renderer drift'`
- `scripts/test.sh cli`
- Biome on `packages/cli/src/commands/runtime.ts`
- `git diff --check`
