### PR TITLE
release(cli): prepare 0.13.63

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.62",
+      "version": "0.13.63",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.62",
+	"version": "0.13.63",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary
- prepare immutable CLI release `0.13.63`
- include the restart-impact fix from #960

## Release impact
- triggers the protected CLI publish workflow after merge
- does not build or roll out a runtime image
- does not change Hosted gates, overrides, Incus generation, or runtime context

## Verification
- full CLI suite passed on #960 and locally through `scripts/test.sh cli`
- `bun run --cwd packages/cli check:publish-manifest`
- confirmed `clawdi@0.13.63` and `clawdi-cli-v0.13.63` do not already exist
- `git diff --check`

No database migration.
