### PR TITLE
fix(openclaw): enforce managed model projection

### DIFF
--- a/docs/ai-providers.md
+++ b/docs/ai-providers.md
@@ -201,12 +201,16 @@ and a reserved Clawdi-owned credential-pool entry.
 
 For OpenClaw, Hosted provider convergence uses the public
 `openclaw/plugin-sdk/config-mutation` export. The mutation starts from authored
-source config, exactly replaces Clawdi-owned provider model arrays, and leaves
-unrelated provider and user settings intact. It enables OpenClaw's targeted
-`allowConfigSizeDrop` write option because removing stale managed models is an
-intentional size reduction; schema, SecretRef preflight, config-path ownership,
-locking, and compare-and-swap guards remain active. Gateway and channel patches
-continue to use `openclaw config patch --stdin`.
+source config, sets `models.mode` to `replace`, exactly replaces each selected
+provider object, and leaves unrelated provider and user settings intact. In the
+verified OpenClaw target, replace mode skips implicit provider discovery, so
+the active managed catalog comes only from the manifest projection; replacing
+the provider object also removes stale API modes and key references. The
+mutation enables OpenClaw's targeted `allowConfigSizeDrop` write option because
+removing stale managed models is an intentional size reduction; schema,
+SecretRef preflight, config-path ownership, locking, and compare-and-swap guards
+remain active. Gateway and channel patches continue to use `openclaw config
+patch --stdin`.
 
 This contract is verified against `openclaw@2026.7.1-2`, official source commit
 [`0790d9f`](https://github.com/openclaw/openclaw/commit/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c).

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -2947,10 +2947,7 @@ function openClawProviderReplacementArgs(content: string): string[] {
 	});
 }
 
-function withOpenClawProviderMode(
-	patchContent: string,
-	mode: "merge" | "replace",
-): string {
+function withOpenClawProviderMode(patchContent: string, mode: "merge" | "replace"): string {
 	const parsed = JSON.parse(patchContent) as unknown;
 	const root = recordValue(parsed);
 	if (!root) return patchContent;

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -2827,6 +2827,9 @@ const applyMergePatch = (target, source, path = []) => {
     if (value === null) {
       delete target[key];
       unsetPaths.push(nextPath);
+    } else if (path.length === 2 && path[0] === "models" && path[1] === "providers") {
+      target[key] = structuredClone(value);
+      explicitSetPaths.push(nextPath);
     } else if (isRecord(value)) {
       if (!isRecord(target[key])) target[key] = {};
       if (Object.keys(value).length === 0) explicitSetPaths.push(nextPath);
@@ -2908,10 +2911,12 @@ export function buildOpenClawHostedProviderPatch(
 	if (!file) throw new Error("OpenClaw projection did not include a config patch JSON file.");
 	const providerIds = [...openClawProviderIdsFromPatch(file.content)].sort();
 	const deletedProviderIds = staleProviderIds(new Set(previousProviderIds), new Set(providerIds));
+	const providerPatchContent =
+		providerIds.length > 0 ? withOpenClawProviderMode(file.content, "replace") : file.content;
 	return {
 		apply: true,
-		args: openClawProviderModelReplacementArgs(file.content),
-		content: mergeOpenClawProviderDeletes(file.content, deletedProviderIds),
+		args: openClawProviderReplacementArgs(file.content),
+		content: mergeOpenClawProviderDeletes(providerPatchContent, deletedProviderIds),
 		providerIds,
 	};
 }
@@ -2929,7 +2934,7 @@ function openClawProviderIdsFromPatch(content: string): Set<string> {
 	);
 }
 
-function openClawProviderModelReplacementArgs(content: string): string[] {
+function openClawProviderReplacementArgs(content: string): string[] {
 	const parsed = JSON.parse(content) as unknown;
 	const root = recordValue(parsed);
 	const models = root ? recordValue(root.models) : null;
@@ -2937,9 +2942,22 @@ function openClawProviderModelReplacementArgs(content: string): string[] {
 	if (!providers) return [];
 	return Object.entries(providers).flatMap(([providerId, provider]) => {
 		const providerConfig = recordValue(provider);
-		if (!providerConfig || !Array.isArray(providerConfig.models)) return [];
-		return ["--replace-path", `models.providers[${JSON.stringify(providerId)}].models`];
+		if (!providerConfig) return [];
+		return ["--replace-path", `models.providers[${JSON.stringify(providerId)}]`];
 	});
+}
+
+function withOpenClawProviderMode(
+	patchContent: string,
+	mode: "merge" | "replace",
+): string {
+	const parsed = JSON.parse(patchContent) as unknown;
+	const root = recordValue(parsed);
+	if (!root) return patchContent;
+	const patch = { ...root };
+	const models = { ...(recordValue(patch.models) ?? {}), mode };
+	patch.models = models;
+	return `${JSON.stringify(patch, null, 2)}\n`;
 }
 
 function mergeOpenClawProviderDeletes(
@@ -2960,7 +2978,6 @@ function mergeOpenClawProviderDeletes(
 	for (const providerId of deletedProviderIds) {
 		providers[providerId] = null;
 	}
-	models.mode = "merge";
 	models.providers = providers;
 	patch.models = models;
 	return `${JSON.stringify(patch, null, 2)}\n`;

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -399,7 +399,7 @@ test("projects a large OpenClaw provider model-list reduction through the public
 		const projectionInput = hostedAiProviderCatalog(manifest, "openclaw");
 		if (!projectionInput) throw new Error("expected OpenClaw provider projection");
 		const intendedPatch = buildOpenClawHostedProviderPatch(projectionInput, ["clawdi"]);
-		expect(intendedPatch.args).toEqual(["--replace-path", 'models.providers["clawdi"].models']);
+		expect(intendedPatch.args).toEqual(["--replace-path", 'models.providers["clawdi"]']);
 		const rejected = spawnSync(
 			"runuser",
 			[
@@ -433,6 +433,10 @@ test("projects a large OpenClaw provider model-list reduction through the public
 		expect(convergence.installErrors).toEqual([]);
 		const intendedConfig = JSON.parse(intendedPatch.content);
 		const appliedConfig = JSON.parse(readFileSync(configPath, "utf8"));
+		expect(appliedConfig.models.mode).toBe("replace");
+		expect(appliedConfig.models.providers.clawdi).toEqual(
+			intendedConfig.models.providers.clawdi,
+		);
 		expect(appliedConfig.models.providers.clawdi.models).toEqual(
 			intendedConfig.models.providers.clawdi.models,
 		);

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -434,9 +434,7 @@ test("projects a large OpenClaw provider model-list reduction through the public
 		const intendedConfig = JSON.parse(intendedPatch.content);
 		const appliedConfig = JSON.parse(readFileSync(configPath, "utf8"));
 		expect(appliedConfig.models.mode).toBe("replace");
-		expect(appliedConfig.models.providers.clawdi).toEqual(
-			intendedConfig.models.providers.clawdi,
-		);
+		expect(appliedConfig.models.providers.clawdi).toEqual(intendedConfig.models.providers.clawdi);
 		expect(appliedConfig.models.providers.clawdi.models).toEqual(
 			intendedConfig.models.providers.clawdi.models,
 		);

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -3434,7 +3434,7 @@ chmod +x "$HOME/.local/bin/hermes"
 		expect(convergence.installErrors).toEqual([]);
 		expect(readFileSync(openclawCommand, "utf-8").trim().split("\n")).toEqual([
 			"config patch --stdin",
-			'config patch --stdin --replace-path models.providers["default"].models',
+			'config patch --stdin --replace-path models.providers["default"]',
 		]);
 		expect(JSON.parse(readFileSync(openclawPatch, "utf-8"))).toEqual({
 			agents: {
@@ -3529,9 +3529,10 @@ chmod +x "$HOME/.local/bin/hermes"
 							api: "openai-completions",
 							models: [{ id: "user-model", name: "User model" }],
 						},
-						"clawdi-managed": {
+						clawdi: {
 							baseUrl: "https://managed.provider.example.test/v1",
 							api: "openai-responses",
+							apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
 							models: legacyModels,
 						},
 					},
@@ -3590,11 +3591,13 @@ export async function mutateConfigFile(options) {
 		process.env.CLAWDI_RUN_DIR = run;
 
 		const loaded = hostedSingleProviderModeLoad(home, "openclaw", "configured", 2);
+		const providerId = "clawdi-v2-deployment-42";
 		const providers = {
-			"clawdi-managed": {
+			[providerId]: {
 				...loaded.manifest.projection?.providers?.["clawdi-managed"],
 				model: "sol",
 				models: [{ id: "sol" }],
+				apiMode: "openai_chat",
 			},
 		};
 		loaded.manifest = {
@@ -3602,7 +3605,8 @@ export async function mutateConfigFile(options) {
 			runtimes: {
 				openclaw: {
 					...loaded.manifest.runtimes.openclaw,
-					primary_model: { provider_id: "clawdi-managed", model: "sol" },
+					provider_ids: [providerId],
+					primary_model: { provider_id: providerId, model: "sol" },
 				},
 			},
 			projection: {
@@ -3627,17 +3631,19 @@ export async function mutateConfigFile(options) {
 			allowConfigSizeDrop: true,
 		});
 		expect(mutation.nextBytes).toBeLessThan(Math.floor(mutation.beforeBytes * 0.5));
-		expect(mutation.explicitSetPaths).toContainEqual([
-			"models",
-			"providers",
-			"clawdi-managed",
-			"models",
-		]);
+		expect(mutation.explicitSetPaths).toContainEqual(["models", "providers", "clawdi"]);
 		const appliedConfig = JSON.parse(readFileSync(openclawConfig, "utf-8"));
-		expect(appliedConfig.agents.defaults.model.primary).toBe("clawdi-managed/sol");
-		expect(appliedConfig.models.providers["clawdi-managed"].models).toEqual([
+		expect(appliedConfig.agents.defaults.model.primary).toBe("clawdi/sol");
+		expect(appliedConfig.models.mode).toBe("replace");
+		expect(appliedConfig.models.providers.clawdi.models).toEqual([
 			expect.objectContaining({ id: "sol" }),
 		]);
+		expect(appliedConfig.models.providers.clawdi.api).toBeUndefined();
+		expect(appliedConfig.models.providers.clawdi.apiKey).toEqual({
+			source: "env",
+			provider: "default",
+			id: "CLAWDI_OPENCLAW_API_KEY",
+		});
 		expect(appliedConfig.models.providers["user-owned"].models).toEqual([
 			{ id: "user-model", name: "User model" },
 		]);
@@ -3652,9 +3658,10 @@ export async function mutateConfigFile(options) {
 		);
 		expect(unmanaged.installErrors).toEqual([]);
 		const deletionMutation = JSON.parse(readFileSync(mutationLog, "utf8"));
-		expect(deletionMutation.unsetPaths).toContainEqual(["models", "providers", "clawdi-managed"]);
+		expect(deletionMutation.unsetPaths).toContainEqual(["models", "providers", "clawdi"]);
 		const unmanagedConfig = JSON.parse(readFileSync(openclawConfig, "utf8"));
-		expect(unmanagedConfig.models.providers["clawdi-managed"]).toBeUndefined();
+		expect(unmanagedConfig.models.mode).toBe("merge");
+		expect(unmanagedConfig.models.providers.clawdi).toBeUndefined();
 		expect(unmanagedConfig.models.providers["user-owned"]).toEqual(
 			appliedConfig.models.providers["user-owned"],
 		);
@@ -4647,7 +4654,7 @@ exit 0
 		expect(readFileSync(openclawCommand, "utf-8").trim().split("\n")).toEqual([
 			"config patch --stdin",
 			"config patch --stdin",
-			'config patch --stdin --replace-path models.providers["default"].models',
+			'config patch --stdin --replace-path models.providers["default"]',
 			"gateway install --force --json",
 		]);
 		expect(JSON.parse(readFileSync(join(root, "openclaw-patch-1.json"), "utf-8"))).toEqual({
@@ -4692,7 +4699,7 @@ exit 0
 		});
 		expect(idempotent.installErrors).toEqual([]);
 		expect(readFileSync(openclawCommand, "utf8").trim().split("\n").slice(-1)).toEqual([
-			'config patch --stdin --replace-path models.providers["default"].models',
+			'config patch --stdin --replace-path models.providers["default"]',
 		]);
 		expect(statSync(openclawConfig).mtimeMs).toBe(configMtime);
 		expect(statSync(gatewayEnvPath).mtimeMs).toBe(envMtime);
@@ -4703,7 +4710,7 @@ exit 0
 		});
 		expect(reinstalled.installErrors).toEqual([]);
 		expect(readFileSync(openclawCommand, "utf8").trim().split("\n").slice(-2)).toEqual([
-			'config patch --stdin --replace-path models.providers["default"].models',
+			'config patch --stdin --replace-path models.providers["default"]',
 			"gateway install --force --json",
 		]);
 		expect(readFileSync(installerToken, "utf8")).toBe("gateway-token\n");
@@ -4721,7 +4728,7 @@ exit 0
 		expect(rotated.installErrors).toEqual([]);
 		expect(readFileSync(openclawCommand, "utf8").trim().split("\n").slice(-2)).toEqual([
 			"config patch --stdin",
-			'config patch --stdin --replace-path models.providers["default"].models',
+			'config patch --stdin --replace-path models.providers["default"]',
 		]);
 		expect(JSON.parse(readFileSync(openclawConfig, "utf8")).gateway.auth.token).toBe(
 			"rotated-gateway-token",


### PR DESCRIPTION
## Summary

- use OpenClaw `models.mode: replace` for managed provider projections so implicit provider discovery cannot expand the frozen catalog
- atomically replace projected provider objects so stale API modes, key references, and models cannot survive reconciliation
- preserve user-owned providers and restore merge mode when an agent becomes unmanaged

## Verification

- `bun run --cwd packages/cli test -- tests/runtime.test.ts tests/runtime-egress-profiles.test.ts src/lib/ai-provider-projection.test.ts` (198 pass, 0 fail)
- `bunx biome check packages/cli/src/runtime/manifest.ts packages/cli/tests/runtime.test.ts packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts`
- `git diff --check`
- official installer/systemd suite: first rollback test passed; remaining suite was intentionally stopped during audit closeout and its task-scoped container/image were cleaned up