### PR TITLE
release(cli): prepare 0.13.64

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.63",
+      "version": "0.13.64",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.63",
+	"version": "0.13.64",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary

- bump the Clawdi CLI package to 0.13.64
- refresh the workspace lockfile package version

## Verification

- `git diff --check`
- `bun run --cwd packages/cli check:publish-manifest`
- confirmed `clawdi@0.13.64` is not already published