### PR TITLE
fix(whatsapp): restore Hermes recipient encryption

### DIFF
--- a/backend/app/services/whatsapp_baileys.py
+++ b/backend/app/services/whatsapp_baileys.py
@@ -1387,8 +1387,14 @@ async def respond_to_iq(
         return _iq_result(
             req,
             [
-                _recipient_bundle_node(jid, resolve_recipient_bundle(jid))
-                for jid in _extract_user_jids_from_key_request(req)
+                {
+                    "tag": "list",
+                    "attrs": {},
+                    "content": [
+                        _recipient_bundle_node(jid, resolve_recipient_bundle(jid))
+                        for jid in _extract_user_jids_from_key_request(req)
+                    ],
+                }
             ],
         )
 
@@ -1842,11 +1848,33 @@ async def save_whatsapp_credential_self_identity(
     }
     if name := validated.get("name"):
         stored_identity["name"] = name
+
+    creds = decode_buffer_json(
+        json.loads(decrypt(credential.encrypted_credentials, credential.credential_nonce))
+    )
+    if not _is_object_dict(creds):
+        raise ValueError("WhatsApp credential creds must be an object")
+    me = creds.get("me")
+    if not _is_object_dict(me):
+        raise ValueError("WhatsApp credential creds.me must be an object")
+
     config = dict(credential.config or {})
-    if config.get("self_identity") == stored_identity:
+    creds_changed = me.get("id") != credential.synthetic_jid or me.get("lid") != validated["lid"]
+    config_changed = config.get("self_identity") != stored_identity
+    if not creds_changed and not config_changed:
         return False
-    config["self_identity"] = stored_identity
-    credential.config = config
+    if creds_changed:
+        creds["me"] = {
+            **me,
+            "id": credential.synthetic_jid,
+            "lid": validated["lid"],
+        }
+        ciphertext, nonce = encrypt(serialize_creds(creds))
+        credential.encrypted_credentials = ciphertext
+        credential.credential_nonce = nonce
+    if config_changed:
+        config["self_identity"] = stored_identity
+        credential.config = config
     await db.flush()
     return True
 
@@ -2748,66 +2776,64 @@ def _recipient_bundle_node(jid: str, bundle: AgentBundle | None) -> BinaryNode:
             "attrs": {"jid": jid},
             "content": [{"tag": "error", "attrs": {"code": "404"}}],
         }
-    return {
-        "tag": "user",
-        "attrs": {"jid": jid},
-        "content": [
+    content: list[BinaryNode] = [
+        {
+            "tag": "registration",
+            "attrs": {},
+            "content": _encode_big_endian(bundle.registration_id, 4),
+        },
+        {"tag": "type", "attrs": {}, "content": b"\x05"},
+        {
+            "tag": "identity",
+            "attrs": {},
+            "content": _maybe_prefixed_key(bundle.identity_key),
+        },
+        {
+            "tag": "skey",
+            "attrs": {},
+            "content": [
+                {
+                    "tag": "id",
+                    "attrs": {},
+                    "content": _encode_big_endian(bundle.signed_pre_key.id, 3),
+                },
+                {
+                    "tag": "value",
+                    "attrs": {},
+                    "content": _maybe_prefixed_key(bundle.signed_pre_key.public_key),
+                },
+                {
+                    "tag": "signature",
+                    "attrs": {},
+                    "content": bundle.signed_pre_key.signature,
+                },
+            ],
+        },
+    ]
+    if bundle.pre_keys:
+        pre_key = bundle.pre_keys[0]
+        content.append(
             {
-                "tag": "registration",
-                "attrs": {},
-                "content": _encode_big_endian(bundle.registration_id, 4),
-            },
-            {"tag": "type", "attrs": {}, "content": b"\x05"},
-            {
-                "tag": "identity",
-                "attrs": {},
-                "content": _maybe_prefixed_key(bundle.identity_key),
-            },
-            {
-                "tag": "skey",
+                "tag": "key",
                 "attrs": {},
                 "content": [
                     {
                         "tag": "id",
                         "attrs": {},
-                        "content": _encode_big_endian(bundle.signed_pre_key.id, 3),
+                        "content": _encode_big_endian(pre_key.id, 3),
                     },
                     {
                         "tag": "value",
                         "attrs": {},
-                        "content": _maybe_prefixed_key(bundle.signed_pre_key.public_key),
-                    },
-                    {
-                        "tag": "signature",
-                        "attrs": {},
-                        "content": bundle.signed_pre_key.signature,
+                        "content": _maybe_prefixed_key(pre_key.public_key),
                     },
                 ],
-            },
-            {
-                "tag": "list",
-                "attrs": {},
-                "content": [
-                    {
-                        "tag": "key",
-                        "attrs": {},
-                        "content": [
-                            {
-                                "tag": "id",
-                                "attrs": {},
-                                "content": _encode_big_endian(pre_key.id, 3),
-                            },
-                            {
-                                "tag": "value",
-                                "attrs": {},
-                                "content": _maybe_prefixed_key(pre_key.public_key),
-                            },
-                        ],
-                    }
-                    for pre_key in bundle.pre_keys
-                ],
-            },
-        ],
+            }
+        )
+    return {
+        "tag": "user",
+        "attrs": {"jid": jid},
+        "content": content,
     }
 
 

--- a/backend/tests/test_whatsapp_baileys.py
+++ b/backend/tests/test_whatsapp_baileys.py
@@ -665,7 +665,25 @@ async def test_respond_to_iq_handles_key_usync_and_group_shapes():
         resolve_recipient_bundle=lambda _jid: bundle,
     )
     assert key_response["attrs"]["id"] == "keys"
-    assert key_response["content"][0]["content"][0]["tag"] == "registration"
+    key_list = key_response["content"][0]
+    assert key_list["tag"] == "list"
+    key_user = key_list["content"][0]
+    assert key_user["attrs"]["jid"] == "15551112222@s.whatsapp.net"
+    assert [child["tag"] for child in key_user["content"]] == [
+        "registration",
+        "type",
+        "identity",
+        "skey",
+        "key",
+    ]
+    assert key_user["content"][-1] == {
+        "tag": "key",
+        "attrs": {},
+        "content": [
+            {"tag": "id", "attrs": {}, "content": b"\x00\x00\x03"},
+            {"tag": "value", "attrs": {}, "content": b"\x05" + bytes(range(64, 96))},
+        ],
+    }
 
     usync_response = await respond_to_iq(
         {

--- a/backend/tests/test_whatsapp_noise.py
+++ b/backend/tests/test_whatsapp_noise.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import hashlib
+import json
 from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID, uuid4
@@ -29,12 +30,15 @@ from app.routes.channel_routers import whatsapp as whatsapp_router_module
 from app.routes.channel_routers.whatsapp import router as whatsapp_router
 from app.routes.channel_routers.whatsapp import whatsapp_baileys_managed_websocket
 from app.services.channels import generate_agent_token, store_agent_link_token
+from app.services.vault_crypto import decrypt, encrypt
 from app.services.whatsapp_baileys import (
     SignalSender,
     StoredWhatsAppCredential,
     WhatsAppAuthCert,
+    decode_buffer_json,
     encrypt_whatsapp_group_message_for_sender_key,
     mint_whatsapp_agent_credential,
+    serialize_creds,
     whatsapp_signal_senders_from_config,
     whatsapp_text_message_proto,
 )
@@ -156,6 +160,29 @@ async def test_whatsapp_noise_prefers_current_account_identity(
             "lid": "900000000000002:1@lid",
         }
     }
+    credential_config = dict(stored.credential.config or {})
+    credential_config["self_identity"] = {
+        "id": stored.credential.synthetic_jid,
+        "lid": "900000000000002:1@lid",
+    }
+    stored.credential.config = credential_config
+
+    legacy_creds = decode_buffer_json(
+        json.loads(
+            decrypt(
+                stored.credential.encrypted_credentials,
+                stored.credential.credential_nonce,
+            )
+        )
+    )
+    assert isinstance(legacy_creds, dict)
+    legacy_me = legacy_creds.get("me")
+    assert isinstance(legacy_me, dict)
+    legacy_me.pop("lid")
+    preserved_auth_state = {key: value for key, value in legacy_creds.items() if key != "me"}
+    ciphertext, nonce = encrypt(serialize_creds(legacy_creds))
+    stored.credential.encrypted_credentials = ciphertext
+    stored.credential.credential_nonce = nonce
     await db_session.commit()
 
     lid = await whatsapp_router_module._resolve_whatsapp_noise_lid(
@@ -167,6 +194,23 @@ async def test_whatsapp_noise_prefers_current_account_identity(
     assert lid == "900000000000002:1@lid"
     await db_session.refresh(stored.credential)
     assert stored.credential.config["self_identity"] == {
+        "id": stored.credential.synthetic_jid,
+        "lid": "900000000000002:1@lid",
+    }
+    repaired_creds = decode_buffer_json(
+        json.loads(
+            decrypt(
+                stored.credential.encrypted_credentials,
+                stored.credential.credential_nonce,
+            )
+        )
+    )
+    assert isinstance(repaired_creds, dict)
+    assert {key: value for key, value in repaired_creds.items() if key != "me"} == (
+        preserved_auth_state
+    )
+    assert repaired_creds["me"] == {
+        **legacy_me,
         "id": stored.credential.synthetic_jid,
         "lid": "900000000000002:1@lid",
     }

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.64",
+      "version": "0.13.65",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.64",
+	"version": "0.13.65",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -4834,13 +4834,22 @@ function runtimeProgramRevisionForManifest(
 ): string {
 	const desiredRuntime = manifest.runtimes[runtime];
 	const runtimeSecretRefs = desiredRuntime
-		? Object.values(
-				mergeRuntimeSecretEnv(
-					runtime,
-					desiredRuntime,
-					hostedProviderEnvironment(manifest, runtime).secretEnv,
+		? [
+				...Object.values(
+					mergeRuntimeSecretEnv(
+						runtime,
+						desiredRuntime,
+						hostedProviderEnvironment(manifest, runtime).secretEnv,
+					),
 				),
-			)
+				...hostedWhatsAppAuthCredentials(manifest)
+					.filter(
+						(credential) =>
+							credential.target === runtime ||
+							(runtime === "openclaw" && credential.target === "legacy"),
+					)
+					.map((credential) => credential.credsJsonSecretRef),
+			]
 		: [];
 	const channels = hostedChannelProjection(manifest);
 	const hostedTarget = runtime === "openclaw" || runtime === "hermes";

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -12693,6 +12693,9 @@ exit 64
 		const sessionDir = join(home, ".hermes", "platforms", "whatsapp", "session");
 		const legacySessionDir = join(home, ".hermes", "whatsapp", "session");
 		const legacySentinel = join(legacySessionDir, "unmanaged-session-sentinel");
+		const systemctlPath = join(root, "bin", "systemctl");
+		const systemctlLog = join(root, "whatsapp-systemctl.log");
+		const systemctlStateRoot = join(root, "whatsapp-systemctl-state");
 		const creds = {
 			advSecretKey: "wa-hermes-secret",
 			me: { id: "15551234567:1@s.whatsapp.net" },
@@ -12702,11 +12705,19 @@ exit 64
 		writeFileSync(hermesBin, "#!/usr/bin/env bash\nexit 0\n");
 		chmodSync(hermesBin, 0o700);
 		seedHermesManagedBaileys(home);
+		seedOpenClawBinary(home);
+		writeFakeSystemdManager({
+			path: systemctlPath,
+			logPath: systemctlLog,
+			stateRoot: systemctlStateRoot,
+		});
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_SYSTEMD_APPLY = "0";
+		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlPath;
+		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
 		const paths = getRuntimePaths();
 		mkdirSync(legacySessionDir, { recursive: true });
 		writeFileSync(legacySentinel, "preserved\n");
@@ -12778,6 +12789,15 @@ exit 64
 		};
 
 		const projected = applyRuntimeBundleChannelsToManifestLoad(load, paths);
+		projected.manifest.runtimes.openclaw = {
+			enabled: true,
+			run: {
+				args: ["gateway", "run"],
+				env: {},
+				prependPath: [],
+			},
+			services: {},
+		};
 		const credentialProjection = projected.manifest.projection?.channelCredentials as unknown[];
 		expect(credentialProjection).toEqual([
 			expect.objectContaining({
@@ -12818,6 +12838,77 @@ exit 64
 			"platforms.whatsapp.extra.session_path",
 			sessionDir,
 		);
+		const initialHermesRevision = systemdEnvRevision(readSystemdEnvFile(paths, "hermes-gateway"));
+		const initialOpenClawRevision = systemdEnvRevision(
+			readSystemdEnvFile(paths, "openclaw-gateway"),
+		);
+		const initialUnits = readSystemdUnitSnapshot(paths);
+		for (const unit of initialUnits.system.keys()) {
+			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "system", unit, "active"), "\n");
+		}
+		for (const unit of initialUnits.user.keys()) {
+			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "active"), "\n");
+			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "enabled"), "\n");
+		}
+
+		const unrelatedSecret = convergeRuntimeManifest(
+			{
+				...projected,
+				secretValues: { ...projected.secretValues, "secret://unrelated": "changed" },
+			},
+			paths,
+		);
+		expect(unrelatedSecret.installErrors).toEqual([]);
+		process.env.CLAWDI_SYSTEMD_APPLY = "1";
+		expect(applySystemdRuntimeUpdate(paths, initialUnits, readSystemdUnitSnapshot(paths))).toEqual({
+			applied: true,
+			systemUnitsChanged: [],
+			userUnitsChanged: [],
+		});
+		expect(systemdEnvRevision(readSystemdEnvFile(paths, "hermes-gateway"))).toBe(
+			initialHermesRevision,
+		);
+		expect(systemdEnvRevision(readSystemdEnvFile(paths, "openclaw-gateway"))).toBe(
+			initialOpenClawRevision,
+		);
+
+		const projectedCreds = JSON.parse(
+			projected.secretValues?.[credentialSecretRef] ?? "null",
+		) as Record<string, unknown>;
+		const beforeCredentialChange = readSystemdUnitSnapshot(paths);
+		process.env.CLAWDI_SYSTEMD_APPLY = "0";
+		const changedCredential = convergeRuntimeManifest(
+			{
+				...projected,
+				secretValues: {
+					...projected.secretValues,
+					[credentialSecretRef]: JSON.stringify({
+						...projectedCreds,
+						advSecretKey: "wa-hermes-secret-rotated",
+					}),
+				},
+			},
+			paths,
+		);
+		expect(changedCredential.installErrors).toEqual([]);
+		expect(systemdEnvRevision(readSystemdEnvFile(paths, "hermes-gateway"))).not.toBe(
+			initialHermesRevision,
+		);
+		expect(systemdEnvRevision(readSystemdEnvFile(paths, "openclaw-gateway"))).toBe(
+			initialOpenClawRevision,
+		);
+		writeFileSync(systemctlLog, "");
+		process.env.CLAWDI_SYSTEMD_APPLY = "1";
+		expect(
+			applySystemdRuntimeUpdate(paths, beforeCredentialChange, readSystemdUnitSnapshot(paths)),
+		).toEqual({
+			applied: true,
+			systemUnitsChanged: [],
+			userUnitsChanged: ["hermes-gateway.service"],
+		});
+		const systemctlCalls = readFileSync(systemctlLog, "utf-8");
+		expect(systemctlCalls).toContain("--user restart hermes-gateway.service");
+		expect(systemctlCalls).not.toContain("restart openclaw-gateway.service");
 
 		const removed = applyRuntimeBundleChannelsToManifestLoad(
 			{ ...load, channelBindings: [], secretValues: {} },


### PR DESCRIPTION
## Summary

- persist the authenticated physical LID into the encrypted Baileys `creds.me` state consumed by Hermes rc13 while preserving the remaining BufferJSON auth state
- emit the exact rc13 `encrypt/get` response tree (`list > user > key`) so stock Baileys can inject a recipient Signal session
- include the target-owned managed WhatsApp credential secret in the runtime revision so credential repair restarts only the owning Hermes gateway through the existing systemd reconcile path
- release the compatible CLI as `clawdi@0.13.65`

## Root cause

Production received and delivered the inbound message to Hermes, then dropped every reply as `missing-enc`. Stock Baileys `7.0.0-rc13` reads `authState.creds.me.lid` during device enumeration, but the existing repair only persisted the LID in credential config. Its Signal parser also reads users only from the root `<list>` and the pre-key directly from each `<user>`; the previous backend response used different nesting. The resulting recipient set/session was empty, so no recipient `enc` node was emitted.

## Scope

Seven existing files only: one backend service, two existing backend tests, one CLI runtime owner, one existing CLI runtime test, and the CLI package/lock version. No schema migration, sidecar change, fallback, production special case, `missing-enc` relaxation, or new test file.

## Verification

- stock rc13 parser/session/encryption proof: old backend shape injects 0 sessions; fixed shape injects 1 and produces `pkmsg`
- isolated backend PostgreSQL/Docker focused suite: 55 passed
- isolated CLI WhatsApp restart behavior: 1 passed, 30 assertions
- isolated full `packages/cli/tests/runtime.test.ts`: 168 passed, 1726 assertions
- isolated CLI publish/sidecar deployment contract tests: 15 passed, 177 assertions
- frozen lockfile install, CLI typecheck, Biome, Ruff, basedpyright, Python compile, and `git diff --check`: passed

## Release impact

No database migration. After merge, the normal backend image release and CLI publish workflows must complete. Existing Hermes deployments need the exact `clawdi@0.13.65` controlled rollout after hosted image pairing validation; no `force_restart` is required because credential rotation now changes the owning runtime revision.
