### PR TITLE
fix(runtime): invalidate managed provider manifests

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -187,7 +187,9 @@ from app.services.runtime_manifest_resources import (
 )
 from app.services.sync_events import (
     queue_environment_runtime_manifest_changed,
+    queue_provider_runtime_manifest_changed,
     queue_runtime_manifest_changed,
+    runtime_manifest_provider_non_auth_signature,
 )
 from app.services.user_provisioning import (
     lazy_create_partner_user_with_personal_project,
@@ -889,6 +891,14 @@ async def admin_upsert_clawdi_managed_ai_provider(
         # Legacy route ids remain accepted during the cross-service rollout,
         # but fixed managed-provider writes and responses are canonical.
         target = await _resolve_or_create_user(db, body.target_clerk_id)
+        await lock_ai_provider_owner(db, target.id)
+        existing = await find_clawdi_managed_provider(
+            db,
+            owner_user_id=target.id,
+            provider_id=V2_MANAGED_AI_PROVIDER_ID,
+            include_archived=True,
+        )
+        previous_non_auth_signature = runtime_manifest_provider_non_auth_signature(existing)
         try:
             provider = await upsert_clawdi_managed_provider(
                 db,
@@ -908,6 +918,8 @@ async def admin_upsert_clawdi_managed_ai_provider(
         except ValueError as e:
             raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, str(e)) from e
 
+        if previous_non_auth_signature != runtime_manifest_provider_non_auth_signature(provider):
+            await queue_provider_runtime_manifest_changed(db, target.id, provider.provider_id)
         record_control_plane_audit(
             db,
             actor_type="admin",
@@ -957,6 +969,13 @@ async def admin_upsert_clawdi_managed_ai_provider(
         owner_user_id=target.id,
         provider_id=provider_id,
     )
+    existing = await find_clawdi_managed_provider(
+        db,
+        owner_user_id=target.id,
+        provider_id=provider_id,
+        include_archived=True,
+    )
+    previous_non_auth_signature = runtime_manifest_provider_non_auth_signature(existing)
     try:
         provider = await upsert_clawdi_managed_provider(
             db,
@@ -986,6 +1005,8 @@ async def admin_upsert_clawdi_managed_ai_provider(
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e)) from e
 
     await db.flush()
+    if previous_non_auth_signature != runtime_manifest_provider_non_auth_signature(provider):
+        await queue_provider_runtime_manifest_changed(db, target.id, provider.provider_id)
     _record_deployment_managed_provider_audit(
         db,
         action="ai_provider.managed.upsert",
@@ -1093,6 +1114,7 @@ async def admin_delete_clawdi_managed_ai_provider(
             owner_user_id=target.id,
             provider_id=provider_id,
         )
+    await queue_provider_runtime_manifest_changed(db, target.id, provider_id)
     _record_deployment_managed_provider_audit(
         db,
         action=action,

--- a/backend/app/routes/ai_providers.py
+++ b/backend/app/routes/ai_providers.py
@@ -128,7 +128,10 @@ from app.services.platform_contract import (
     store_platform_response,
 )
 from app.services.private_ip import is_private_hostname
-from app.services.sync_events import queue_provider_runtime_manifest_changed
+from app.services.sync_events import (
+    queue_provider_runtime_manifest_changed,
+    runtime_manifest_provider_non_auth_signature,
+)
 from app.services.url_security import is_public_https_url
 from app.services.vault_crypto import decrypt
 
@@ -246,7 +249,7 @@ async def upsert_ai_provider(
     existing = await _find_provider(db, auth, body.provider_id, include_archived=True)
     if existing is not None and existing.archived_at is None and not replace:
         raise HTTPException(status.HTTP_409_CONFLICT, "AI Provider already exists")
-    previous_non_auth_signature = _runtime_manifest_provider_non_auth_signature(existing)
+    previous_non_auth_signature = runtime_manifest_provider_non_auth_signature(existing)
     auth_event_queued = False
     provider = existing or AiProvider(owner_user_id=auth.user_id, provider_id=body.provider_id)
     _apply_provider_body(provider, body, apply_auth=False)
@@ -280,7 +283,7 @@ async def upsert_ai_provider(
     provider.archived_at = None
     db.add(provider)
     if (
-        previous_non_auth_signature != _runtime_manifest_provider_non_auth_signature(provider)
+        previous_non_auth_signature != runtime_manifest_provider_non_auth_signature(provider)
         and not auth_event_queued
     ):
         await queue_provider_runtime_manifest_changed(db, auth.user_id, provider.provider_id)
@@ -661,7 +664,7 @@ async def patch_ai_provider(
 ) -> AiProviderResponse:
     await lock_ai_provider_owner(db, auth.user_id)
     provider = await _get_provider_or_404_for_update(db, auth, provider_id)
-    previous_non_auth_signature = _runtime_manifest_provider_non_auth_signature(provider)
+    previous_non_auth_signature = runtime_manifest_provider_non_auth_signature(provider)
     auth_event_queued = False
     merged = await _to_response(db, auth, provider)
     update = {field: getattr(body, field) for field in body.model_fields_set}
@@ -696,7 +699,7 @@ async def patch_ai_provider(
             raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
         auth_event_queued = transition.manifest_event_queued
     if (
-        previous_non_auth_signature != _runtime_manifest_provider_non_auth_signature(provider)
+        previous_non_auth_signature != runtime_manifest_provider_non_auth_signature(provider)
         and not auth_event_queued
     ):
         await queue_provider_runtime_manifest_changed(db, auth.user_id, provider.provider_id)
@@ -1113,7 +1116,7 @@ async def _accept_ai_provider(
         if not body.replace and not can_resume:
             raise HTTPException(status.HTTP_409_CONFLICT, "AI Provider already exists")
 
-    previous_non_auth_signature = _runtime_manifest_provider_non_auth_signature(existing)
+    previous_non_auth_signature = runtime_manifest_provider_non_auth_signature(existing)
     provider = existing or AiProvider(
         owner_user_id=auth.user_id,
         provider_id=provider_body.provider_id,
@@ -1160,7 +1163,7 @@ async def _accept_ai_provider(
             ),
         )
         if (
-            previous_non_auth_signature != _runtime_manifest_provider_non_auth_signature(provider)
+            previous_non_auth_signature != runtime_manifest_provider_non_auth_signature(provider)
             and not transition.manifest_event_queued
         ):
             await queue_provider_runtime_manifest_changed(
@@ -1187,7 +1190,7 @@ async def _accept_ai_provider(
         oauth_provider=oauth_provider,
     )
     if (
-        previous_non_auth_signature != _runtime_manifest_provider_non_auth_signature(provider)
+        previous_non_auth_signature != runtime_manifest_provider_non_auth_signature(provider)
         or existing is None
     ):
         await queue_provider_runtime_manifest_changed(
@@ -1704,38 +1707,6 @@ def _build_response(
             "updated_at": provider.updated_at,
         }
     )
-
-
-def _runtime_manifest_provider_signature(
-    provider: AiProvider | None,
-) -> dict[str, object] | None:
-    if provider is None:
-        return None
-    return {
-        "type": provider.type,
-        "base_url": provider.base_url,
-        "api_mode": provider.api_mode,
-        "models": provider.models,
-        "auth_type": provider.auth_type,
-        "auth_ref": provider.auth_ref,
-        "auth_metadata": provider.auth_metadata,
-        "managed_by": provider.managed_by,
-        "runtime_env_name": provider.runtime_env_name,
-        "archived_at": provider.archived_at,
-    }
-
-
-def _runtime_manifest_provider_non_auth_signature(
-    provider: AiProvider | None,
-) -> dict[str, object] | None:
-    signature = _runtime_manifest_provider_signature(provider)
-    if signature is None:
-        return None
-    return {
-        key: value
-        for key, value in signature.items()
-        if key not in {"auth_type", "auth_ref", "auth_metadata"}
-    }
 
 
 def _provider_capability_input(

--- a/backend/app/services/sync_events.py
+++ b/backend/app/services/sync_events.py
@@ -72,6 +72,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
+from app.models.ai_provider import AiProvider
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.project_membership import ProjectMembership
 from app.models.session import AgentEnvironment
@@ -356,6 +357,23 @@ async def queue_provider_runtime_manifest_changed(
     return affected
 
 
+def runtime_manifest_provider_non_auth_signature(
+    provider: AiProvider | None,
+) -> dict[str, object] | None:
+    """Return the provider fields that contribute to a runtime manifest."""
+    if provider is None:
+        return None
+    return {
+        "type": provider.type,
+        "base_url": provider.base_url,
+        "api_mode": provider.api_mode,
+        "models": provider.models,
+        "managed_by": provider.managed_by,
+        "runtime_env_name": provider.runtime_env_name,
+        "archived_at": provider.archived_at,
+    }
+
+
 def _runtime_state_may_use_provider(state: HostedRuntimeState, provider_id: str) -> bool:
     runtimes = state.runtimes
     if len(runtimes) != 1:
@@ -376,7 +394,10 @@ def _runtime_state_may_use_provider(state: HostedRuntimeState, provider_id: str)
     if provider_id == tools.codex.provider_id:
         return True
     if not is_v2_deployment_managed_provider_id(provider_id):
-        return False
+        normalized_provider_id = runtime_managed_provider_id(provider_id)
+        return normalized_provider_id in {
+            runtime_managed_provider_id(value) for value in runtime.provider_ids
+        } or normalized_provider_id == runtime_managed_provider_id(tools.codex.provider_id)
     if v2_deployment_managed_provider_id(state.deployment_id) != provider_id:
         return False
     runtime_provider_ids = {runtime_managed_provider_id(value) for value in runtime.provider_ids}

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -1095,6 +1095,16 @@ async def test_admin_fixed_managed_provider_invalidates_bound_runtime_on_manifes
             system={},
             live_sync={"enabled": False, "agents": []},
             recovery={"cacheManifest": True, "allowOfflineBoot": True},
+            tools={
+                "codex": {
+                    "enabled": True,
+                    "provider_id": V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+                    "primary_model": {
+                        "provider_id": V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+                        "model": "gpt-5.5",
+                    },
+                }
+            },
             runtimes={
                 "openclaw": {
                     "enabled": True,
@@ -1358,6 +1368,16 @@ async def test_admin_deployment_provider_invalidates_only_bound_runtime_on_manif
                 system={},
                 live_sync={"enabled": False, "agents": []},
                 recovery={"cacheManifest": True, "allowOfflineBoot": True},
+                tools={
+                    "codex": {
+                        "enabled": True,
+                        "provider_id": V2_MANAGED_AI_PROVIDER_ID,
+                        "primary_model": {
+                            "provider_id": V2_MANAGED_AI_PROVIDER_ID,
+                            "model": "gpt-5.5",
+                        },
+                    }
+                },
                 runtimes={
                     "openclaw": {
                         "enabled": True,

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -1148,6 +1148,16 @@ async def test_admin_fixed_managed_provider_invalidates_bound_runtime_on_manifes
             json={**body, "api_key": "sk-fixed-rotated"},
         )
         assert credential_only.status_code == 200, credential_only.text
+        assert queue.get_nowait() == expected_event
+        assert queue.empty()
+
+        replayed_write = await admin_client.put(
+            f"/v1/admin/ai-providers/{V2_MANAGED_AI_PROVIDER_ID}",
+            headers=_AUTH,
+            json={**body, "api_key": "sk-fixed-rotated"},
+        )
+        assert replayed_write.status_code == 200, replayed_write.text
+        assert queue.get_nowait() == expected_event
         assert queue.empty()
 
         catalog_changed = await admin_client.put(
@@ -1425,15 +1435,21 @@ async def test_admin_deployment_provider_invalidates_only_bound_runtime_on_manif
             json={**request_body, "api_key": "sk-rotated"},
         )
         assert credential_only.status_code == 200, credential_only.text
-        assert all(queue.empty() for queue in queues)
+        assert queues[0].get_nowait() == expected_event
+        assert queues[0].empty()
+        assert queues[1].empty()
+        assert queues[2].empty()
 
-        no_op = await admin_client.put(
+        replayed_write = await admin_client.put(
             f"/v1/admin/ai-providers/{provider_id}",
             headers=_AUTH,
             json={**request_body, "api_key": "sk-rotated"},
         )
-        assert no_op.status_code == 200, no_op.text
-        assert all(queue.empty() for queue in queues)
+        assert replayed_write.status_code == 200, replayed_write.text
+        assert queues[0].get_nowait() == expected_event
+        assert queues[0].empty()
+        assert queues[1].empty()
+        assert queues[2].empty()
 
         catalog_changed = await admin_client.put(
             f"/v1/admin/ai-providers/{provider_id}",

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -1068,6 +1068,95 @@ async def test_admin_fixed_managed_ai_provider_preserves_null_models_wire_respon
 
 
 @pytest.mark.asyncio
+async def test_admin_fixed_managed_provider_invalidates_bound_runtime_on_manifest_changes(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    from app.models.hosted_runtime import HostedRuntimeState
+    from app.services import sync_events
+    from tests.conftest import create_env_with_project
+
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"fixed-managed-provider-event-{uuid.uuid4().hex[:8]}",
+        machine_name="Fixed managed provider event",
+        agent_type="openclaw",
+    )
+    db_session.add(
+        HostedRuntimeState(
+            environment_id=env.id,
+            deployment_id="fixed-managed-provider-event",
+            instance_id=f"instance-{uuid.uuid4().hex}",
+            generation=1,
+            cli_package_spec="clawdi@1.2.3-test",
+            locale={"language": "en", "timezone": "UTC"},
+            system={},
+            live_sync={"enabled": False, "agents": []},
+            recovery={"cacheManifest": True, "allowOfflineBoot": True},
+            runtimes={
+                "openclaw": {
+                    "enabled": True,
+                    "providerMode": "configured",
+                    "provider_ids": [V2_LEGACY_MANAGED_AI_PROVIDER_ID],
+                    "primary_model": {
+                        "provider_id": V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+                        "model": "gpt-5.5",
+                    },
+                    "install": {"source": "official"},
+                }
+            },
+        )
+    )
+    await db_session.commit()
+
+    queue = sync_events.subscribe(seed_user.id, frozenset(), environment_id=env.id)
+    body = {
+        "target_clerk_id": seed_user.clerk_id,
+        "base_url": "https://ai-gateway.clawdi.ai/v1",
+        "api_key": "sk-fixed-initial",
+        "models": [{"id": "gpt-5.5"}],
+    }
+    expected_event = {
+        "type": "runtime_manifest_changed",
+        "environment_id": str(env.id),
+    }
+    try:
+        created = await admin_client.put(
+            f"/v1/admin/ai-providers/{V2_LEGACY_MANAGED_AI_PROVIDER_ID}",
+            headers=_AUTH,
+            json=body,
+        )
+        assert created.status_code == 200, created.text
+        assert queue.get_nowait() == expected_event
+        assert queue.empty()
+
+        credential_only = await admin_client.put(
+            f"/v1/admin/ai-providers/{V2_MANAGED_AI_PROVIDER_ID}",
+            headers=_AUTH,
+            json={**body, "api_key": "sk-fixed-rotated"},
+        )
+        assert credential_only.status_code == 200, credential_only.text
+        assert queue.empty()
+
+        catalog_changed = await admin_client.put(
+            f"/v1/admin/ai-providers/{V2_MANAGED_AI_PROVIDER_ID}",
+            headers=_AUTH,
+            json={
+                **body,
+                "api_key": "sk-fixed-rotated",
+                "models": [{"id": "gpt-5.6"}],
+            },
+        )
+        assert catalog_changed.status_code == 200, catalog_changed.text
+        assert queue.get_nowait() == expected_event
+        assert queue.empty()
+    finally:
+        sync_events.unsubscribe(seed_user.id, queue)
+
+
+@pytest.mark.asyncio
 async def test_admin_deployment_managed_ai_provider_lifecycle_is_owner_scoped_and_audited(
     admin_client,
     db_session,
@@ -1225,6 +1314,129 @@ async def test_admin_deployment_managed_ai_provider_lifecycle_is_owner_scoped_an
         assert event.details["owner"] == expected_owners[event.target_user_id]
         assert event.details["owner_user_id"] == str(event.target_user_id)
         assert event.details["provider_id"] == provider_id
+
+
+@pytest.mark.asyncio
+async def test_admin_deployment_provider_invalidates_only_bound_runtime_on_manifest_changes(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    from app.models.hosted_runtime import HostedRuntimeState
+    from app.models.user import User
+    from app.services import sync_events
+    from tests.conftest import create_env_with_project
+
+    deployment_id = "8403"
+    provider_id = f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}{deployment_id}"
+    owner = {"kind": "clerk", "ref": seed_user.clerk_id}
+    other = User(clerk_id="managed_provider_manifest_event_other_owner")
+    db_session.add(other)
+    await db_session.flush()
+
+    environments = []
+    for user, state_deployment_id in (
+        (seed_user, deployment_id),
+        (seed_user, "unbound-deployment"),
+        (other, deployment_id),
+    ):
+        env = await create_env_with_project(
+            db_session,
+            user_id=user.id,
+            machine_id=f"managed-provider-event-{uuid.uuid4().hex[:8]}",
+            machine_name="Managed provider event",
+            agent_type="openclaw",
+        )
+        db_session.add(
+            HostedRuntimeState(
+                environment_id=env.id,
+                deployment_id=state_deployment_id,
+                instance_id=f"instance-{uuid.uuid4().hex}",
+                generation=1,
+                cli_package_spec="clawdi@1.2.3-test",
+                locale={"language": "en", "timezone": "UTC"},
+                system={},
+                live_sync={"enabled": False, "agents": []},
+                recovery={"cacheManifest": True, "allowOfflineBoot": True},
+                runtimes={
+                    "openclaw": {
+                        "enabled": True,
+                        "providerMode": "configured",
+                        "provider_ids": [V2_MANAGED_AI_PROVIDER_ID],
+                        "primary_model": {
+                            "provider_id": V2_MANAGED_AI_PROVIDER_ID,
+                            "model": "gpt-5.5",
+                        },
+                        "install": {"source": "official"},
+                    }
+                },
+            )
+        )
+        environments.append((user, env))
+    await db_session.commit()
+
+    queues = [
+        sync_events.subscribe(user.id, frozenset(), environment_id=env.id)
+        for user, env in environments
+    ]
+    request_body = {
+        "owner": owner,
+        "base_url": "https://ai-gateway.clawdi.ai/v1",
+        "api_key": "sk-initial",
+        "models": [{"id": "gpt-5.5"}],
+    }
+    expected_event = {
+        "type": "runtime_manifest_changed",
+        "environment_id": str(environments[0][1].id),
+    }
+    try:
+        created = await admin_client.put(
+            f"/v1/admin/ai-providers/{provider_id}", headers=_AUTH, json=request_body
+        )
+        assert created.status_code == 200, created.text
+        assert queues[0].get_nowait() == expected_event
+        assert queues[0].empty()
+        assert queues[1].empty()
+        assert queues[2].empty()
+
+        credential_only = await admin_client.put(
+            f"/v1/admin/ai-providers/{provider_id}",
+            headers=_AUTH,
+            json={**request_body, "api_key": "sk-rotated"},
+        )
+        assert credential_only.status_code == 200, credential_only.text
+        assert all(queue.empty() for queue in queues)
+
+        no_op = await admin_client.put(
+            f"/v1/admin/ai-providers/{provider_id}",
+            headers=_AUTH,
+            json={**request_body, "api_key": "sk-rotated"},
+        )
+        assert no_op.status_code == 200, no_op.text
+        assert all(queue.empty() for queue in queues)
+
+        catalog_changed = await admin_client.put(
+            f"/v1/admin/ai-providers/{provider_id}",
+            headers=_AUTH,
+            json={**request_body, "api_key": "sk-rotated", "models": [{"id": "gpt-5.6"}]},
+        )
+        assert catalog_changed.status_code == 200, catalog_changed.text
+        assert queues[0].get_nowait() == expected_event
+        assert queues[0].empty()
+        assert queues[1].empty()
+        assert queues[2].empty()
+
+        deleted = await admin_client.delete(
+            f"/v1/admin/ai-providers/{provider_id}", headers=_AUTH, params=owner
+        )
+        assert deleted.status_code == 200, deleted.text
+        assert queues[0].get_nowait() == expected_event
+        assert queues[0].empty()
+        assert queues[1].empty()
+        assert queues[2].empty()
+    finally:
+        for (user, _), queue in zip(environments, queues, strict=True):
+            sync_events.unsubscribe(user.id, queue)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sync_events.py
+++ b/backend/tests/test_sync_events.py
@@ -620,6 +620,10 @@ def test_managed_runtime_provider_usage_resolves_deployment_credential_identity(
 
     assert sync_events._runtime_state_may_use_provider(state, "clawdi-v2-deployment-42") is True
     assert sync_events._runtime_state_may_use_provider(state, "clawdi-v2-deployment-43") is False
+    assert sync_events._runtime_state_may_use_provider(state, CLAWDI_MANAGED_PROVIDER_ID) is True
+    assert (
+        sync_events._runtime_state_may_use_provider(state, V2_LEGACY_MANAGED_AI_PROVIDER_ID) is True
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- queue `runtime_manifest_changed` in the same transaction when fixed or deployment-scoped managed provider metadata changes
- avoid invalidation for credential-only rotations and non-rendered/no-op metadata
- invalidate only the owner runtime bound to the provider, including canonical/legacy managed aliases, and invalidate deployment-scoped deletion
- centralize the existing non-auth manifest signature beside provider invalidation filtering

## Design notes

The fixed admin route is included because active Hermes/OpenClaw runtime state still binds the canonical or legacy managed aliases, and runtime source falls back to the fixed managed provider row when no deployment-scoped row exists.

The non-auth signature mirrors provider fields rendered by `runtime_source._provider_entry`: type, base URL, API mode, models, managed marker, runtime environment name, and archived state. Label and capabilities are intentionally excluded because they are not rendered. Credential changes remain owned by the auth transition path.

## Verification

- `scripts/test.sh backend tests/test_admin_endpoints.py::test_admin_fixed_managed_provider_invalidates_bound_runtime_on_manifest_changes tests/test_admin_endpoints.py::test_admin_deployment_provider_invalidates_only_bound_runtime_on_manifest_changes tests/test_sync_events.py::test_managed_runtime_provider_usage_resolves_deployment_credential_identity tests/test_ai_providers.py::test_provider_and_secret_mutations_invalidate_only_bound_runtime tests/test_runtime_manifest.py::test_runtime_manifest_provider_label_is_not_projected_but_projected_fields_change_etag`
- `uv run ruff check app/routes/admin.py app/routes/ai_providers.py app/services/sync_events.py tests/test_admin_endpoints.py tests/test_sync_events.py`
- `uv run ruff format --check app/routes/admin.py app/routes/ai_providers.py app/services/sync_events.py tests/test_admin_endpoints.py tests/test_sync_events.py`
- `uv run python -m compileall -q app/routes/admin.py app/routes/ai_providers.py app/services/sync_events.py tests/test_admin_endpoints.py tests/test_sync_events.py`
- `uv run python scripts/type_governance.py owned`
- `uv run python scripts/type_governance.py strict`
- `uv run python scripts/type_governance.py exceptions`

Full-repository Ruff format check remains blocked by a pre-existing formatting difference in untouched `backend/tests/test_projects_routes.py`.
