### PR TITLE
docs: refresh current release and runtime guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.13.65
+
+Package: `clawdi@0.13.65`
+
+This entry summarizes notable upgrade behavior from v0.13.44 through v0.13.65.
+
+### Added
+
+- Hosted Hermes and OpenClaw runtimes can receive managed WhatsApp channel
+  bindings through the runtime bundle, with Link-scoped credentials and
+  fail-closed validation.
+
+### Fixed
+
+- Exact Hosted CLI-only updates hand off to the new CLI without restarting
+  healthy daemon, egress sidecar, or runtime services. Failed or inactive units
+  still follow the normal recovery path.
+- Hermes WhatsApp restores recipient encryption state and restarts only the
+  affected Hermes gateway when its managed credentials rotate.
+- Hosted upgrades and restarts preserve active service state and OpenClaw
+  configuration while repairing Clawdi-owned Skill, MCP, provider, and gateway
+  state when its durable ownership or generated files need reconstruction.
+
 ## Clawdi CLI v0.13.43
 
 Package: `clawdi@0.13.43`

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Clawdi is the shared layer underneath:
 
 - **Cross-agent memory** — Store durable preferences, decisions, facts, and project context once. Search them from any connected agent.
 - **Portable skills** — Author instructions in each Agent's guarded filesystem and project a read-only Cloud inventory; explicitly import Cloud-owned Project Skills when needed.
-- **Project sharing** — Share read-only Project access from the dashboard or CLI, accept it from a share page or CLI inbox, and explicitly attach accepted Projects to Agents when they should be used at runtime.
+- **Project sharing** — Share read-only Project access from the dashboard or CLI, accept it from a share page or CLI inbox, and explicitly link accepted Projects to Agents when they should be used at runtime.
 - **Session sync** — Push local session history to the dashboard for review and recall.
 - **Vault secrets** — Store secrets server-side, commit only `clawdi://` references, and resolve them at runtime.
 - **AI Providers** — Keep a multi-record provider catalog and auth references while Core Hosted manifests bind at most one provider to Hermes or OpenClaw, without proxying BYOK model traffic.
@@ -248,7 +248,10 @@ Local self-hosting currently expects:
 - PostgreSQL 16 with `pg_trgm` and `pgvector`
 - Clerk keys for dashboard auth
 - Two generated encryption keys for vault data and backend security material
-- **One backend process** until v1.5. The `clawdi daemon` realtime SSE fan-out lives in process memory (`backend/app/services/sync_events.py`), so a broadcast on worker A doesn't reach a daemon attached to worker B. Run a single uvicorn worker (or one gunicorn worker with `--workers 1`) behind your reverse proxy. Multi-process fan-out via Postgres LISTEN/NOTIFY ships in v1.5.
+- PostgreSQL-backed realtime sync event delivery. Each API process listens for
+  committed events through PostgreSQL `LISTEN/NOTIFY`, so SSE subscribers receive
+  invalidations published by other API processes without Redis or a separate
+  message broker. Periodic reconciliation remains the missed-event fallback.
 
 See [`backend/.env.example`](backend/.env.example) and [`apps/web/.env.example`](apps/web/.env.example) for the exact environment variables.
 
@@ -303,7 +306,7 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](packages/cli
 | `clawdi skill list/add/install/rm/init` | Manage portable skills |
 | `clawdi project create/list/show/share/share-links/invite/invites/members/leave/unshare` | Manage Projects and read-only sharing |
 | `clawdi inbox [accept/decline/forget]` | Accept invitations and share links |
-| `clawdi agent projects list/attach/detach/move` | View the fixed Agent Project and manage attached Projects |
+| `clawdi agent projects list/link/unlink/move` | View the fixed Agent Project and manage linked Projects (`attach`/`detach` remain compatibility aliases) |
 | `clawdi agent credentials import/materialize` | Compatibility backup/restore for local CLI credential profiles; use `ai-provider import-auth/connect` for Codex provider auth |
 | `clawdi ai-provider list/add/edit/remove/validate/test/connect/complete-oauth/import-auth/export/import` | Manage local provider catalog records, auth refs, Codex OAuth/profile auth, direct tests, and provider-only export/import; Core Hosted activation comes from controller desired state |
 | `clawdi channel list/available/get/create/links/link/rotate-token/pair-code/send/bindings/sync-commands/delete` | Manage channel bots, bot-agent links, chat pairing, outbound messages, and provider slash-command sync |

--- a/docs/adr/0003-runtime-bundle-media-type-is-the-render-contract.md
+++ b/docs/adr/0003-runtime-bundle-media-type-is-the-render-contract.md
@@ -1,6 +1,6 @@
 # ADR-0003: Runtime Bundle Media Type Is the Render Contract
 
-**Status:** Accepted (amended 2026-08-11)
+**Status:** Accepted (amended 2026-08-12)
 **Date:** 2026-07-13
 **Deciders:** Clawdi maintainers
 
@@ -24,8 +24,9 @@ The v2 renderer and canonical JSON encoding are frozen except for the narrow
 consumer-first amendments below. Any other response-affecting behavior change
 requires a new media type and schema version. An unsupported
 or missing media type returns `406`; the CLI does not fall back to a legacy
-manifest representation or a separate `/v1/channels` flow. Agent v2 had no
-released client, so the endpoint has no unpublished compatibility response.
+manifest representation or a separate `/v1/channels` flow. At adoption, Agent
+v2 had no released client, so the endpoint needed no unpublished compatibility
+response.
 
 The backend loads environment state, providers, selected encrypted auth
 payloads, and active Telegram/Discord/WhatsApp links with set-based queries
@@ -72,6 +73,10 @@ with current desired provider IDs. SSE invalidation only reduces latency;
 conditional polling and the applied ETag/sourceRevision preserve correctness.
 
 ### 2026-07-30 generation identity amendment
+
+> HISTORICAL ROLLOUT RECORD - The pre-activation sequence below completed before
+> Agent v2 became publicly enabled on 2026-08-12. The resulting
+> `applyGeneration` compatibility contract remains current.
 
 The inner manifest `generation` permanently remains the checkpoint/content
 generation. The bundle root may additionally contain positive

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,7 +181,7 @@ resource rows. Agent Workspaces and hidden compatibility containers are
 protected from these lifecycle mutations.
 
 Local folder links are CLI selection hints for `clawdi run`. They do not grant
-membership, attach Projects, or mutate cloud Project relationships.
+membership, link Projects to Agents, or mutate cloud Project relationships.
 
 ## Skills
 
@@ -397,7 +397,7 @@ Core tables verified under `backend/app/models/`:
 | `hosted_runtime_config_observations` | Daemon-reported CONFIG convergence with `observed_at`, observed config generation, observed manifest ETag, and validated diagnostics JSONB; distinct from hosted provider COMPUTE observations. |
 | `v2_runtime_environment_fences`, `v2_runtime_observation_inbox`, `v2_runtime_observation_heads`, `v2_runtime_observation_consumer_cursors` | Additive declarative-v2 runtime evidence under direct `/v2/runtime/*` routes, permanent retirement fencing, boot-session high-waters/tombstones, and Hosted workload-bound replay cursors. Retention compacts private inbox payloads in place while permanent identity rows preserve event/session uniqueness. The existing v1 heartbeat and observation table remain unchanged. |
 | `projects`, `project_memberships`, `project_share_links`, `project_invitations`, `share_redeem_attempts` | Project ownership, viewer access, share links, directed invites, and redeem throttling/idempotency. |
-| `agent_project_bindings` | One fixed `primary` Agent Project plus ordered `context` attached Projects. |
+| `agent_project_bindings` | One fixed `primary` Agent Project plus ordered `context` linked Projects. |
 | `sessions`, `session_permissions` | Conversation metadata, object-store body pointer, public/user/email sharing permissions. |
 | `skills` | Project-scoped skill metadata and object-store tarball pointer. |
 | `vaults`, `vault_project_attachments`, `vault_project_slug_aliases`, `vault_items`, `vault_credential_profiles` | Account-owned vaults, Project access attachments, compatibility slug aliases, encrypted secret fields, encrypted local auth profiles. |

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -336,12 +336,13 @@ Cloud-owned Hosted manifests select `clawdi@<exact-semver>` only. The runtime
 installs that exact public version directly and never calls `npm view` for
 Hosted desired state.
 
-Agent deployment v2 is not live, so there is no rolling compatibility window.
-Keep v2 creation and runtime-state reconciliation disabled until the final
-Hosted capability envelope, exact CLI release, and Cloud manifest contract are
-all deployed. Then verify a fresh deployment's runtime-state write, canonical
-`/v1/runtime/manifest` fetch, SSE invalidation, and runtime services before
-enabling v2. Do not add legacy fields or aliases.
+Agent deployment v2 became publicly enabled on 2026-08-12 while v1 remained
+enabled. Treat its runtime contract as a released surface: roll out additive
+manifest capabilities consumer first, preserve compatibility with deployed
+exact CLI versions, and verify runtime-state writes, canonical
+`/v1/runtime/manifest` fetches, SSE invalidation, and runtime services during
+each controlled rollout. Do not repurpose or remove released fields without an
+explicit compatibility path.
 
 The monorepo has two GitHub Release lines:
 

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1462,35 +1462,11 @@ through ordinary higher-generation runtime-state reconciliation. Database
 migrations backfill stored authority where required; operators do not patch
 individual production rows to advance deployments.
 
-The WhatsApp channel binding follows that same order: this producer change stays
-stacked and unmerged until `clawdi@0.13.56` is published, selected by Hosted, and
-verified on active runtimes. Only then may the Hosted producer emit WhatsApp
-bindings. This is operational release sequencing, not a code gate: the OSS
-consumer has no producer-version detection, feature flag, fallback datasource,
-or dual contract.
-
-For the optional v2 `applyGeneration` amendment, strict older consumers reject
-the new root field. This OSS consumer release must deploy before Hosted producer
-activation. The nullable database field is the default-closed receiving edge;
-Hosted must not write it until compatible CLI deployment is confirmed.
-
-The pre-activation sequence uses existing Hosted desired-state behavior. If a
-deployment is at metadata/apply `1` and checkpoint `2`, first leave the CLI pin
-unchanged and accept the existing
-`POST /v2/deployments/{deployment_id}/restart` mutation, whose desired-state
-change increments only `rollout_nonce`; while the producer gate is off, the
-legacy checkpoint floor aligns the deployment to `2/2` without a runtime-state
-content change. Next, select the exact compatible CLI and use its ordinary
-controlled rollout to advance metadata and the CLI-pin checkpoint together to
-`3/3`. A direct CLI pin from `1/2` would produce `2/3`, so it is not an
-alignment mechanism. Verify the online bundle, `runtime-applied.json`,
-last-good cache, offline boot, observation tuple, and canonical Agent health
-before enabling the Hosted producer gate. No direct database, Cloud state, Pod
-cache, or tenant filesystem mutation is part of this protocol.
-
-After every active CLI and stored applied state has explicit Apply identity, a
-narrow follow-up contract release removes the optionality, legacy fallback,
-null omission gate, temporary rollout text, and legacy compatibility tests.
+WhatsApp bindings and `applyGeneration` followed this consumer-first rollout
+order before their producers were enabled. They are now part of the released
+manifest contract; later changes must use the same additive sequencing and
+must not depend on producer-version detection, a fallback datasource, or
+direct mutation of Cloud state or tenant filesystems.
 
 Bundled-Skill versioning follows expand, migrate, contract ordering. During
 expand, the CLI accepts the prior enabled-only Skill entry and canonicalizes

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -250,17 +250,15 @@ discoverable from account state and should be reconciled separately with
    deliberately sends the public marker can opt in, and resulting usage is
    charged to that deployment user's wallet.
 
-   For the current direct-cut release, keep Agent v2 creation disabled until
-   `clawdi@0.13.36` is published and its exact registry identity and provenance
-   are verified, then set and read back the Hosted database AppSetting
-   `agent_v2_cli_package_spec` as exactly `clawdi@0.13.36`. Only after those
-   gates pass may any new Agent deployment be allowed. A missing setting fails
-   closed; if it still contains a previous valid exact spec, keep deployment
-   creation disabled until the operator updates it. There is no code default or
-   fallback to a previous package. Then validate one fresh deployment end to
-   end through persisted deployment state, `/v1/runtime/manifest`, exact CLI
-   handoff, SSE, and runtime services. Do not add version floors, compatibility
-   fields, aliases, or fallback package channels.
+   The one-time `clawdi@0.13.36` direct-cut gate completed before Agent v2
+   became publicly enabled on 2026-08-12; it is not a current release step.
+   Later Hosted CLI rollouts still require the exact artifact, registry
+   identity, and provenance checks above. A missing or invalid desired package
+   spec fails closed, with no version floor, code default, previous-package
+   fallback, or dist-tag resolution. The first-party Hosted repository's
+   current `docs/v2/ops/README.md` is the authority for selecting and rolling
+   out that exact package; this OSS runbook neither authorizes nor duplicates
+   Hosted operations.
 
 4. For app/backend/web releases, run `Release Clawdi` manually with the
    deployed commit SHA, then verify the GitHub release exists and has


### PR DESCRIPTION
## Summary

- replace the obsolete single-backend-process/v1.5 roadmap note with the released PostgreSQL `LISTEN/NOTIFY` cross-process SSE fan-out contract
- record Hosted Agent v2 public enablement on 2026-08-12 and retire the completed `clawdi@0.13.36` direct-cut and `clawdi@0.13.56` WhatsApp pre-activation gates while preserving consumer-first, exact-package, provenance, and fail-closed rules
- make Agent Project `link`/`unlink` the current user-facing terms while retaining `attach`/`detach` as compatibility aliases
- add one cumulative notable-user-impact entry for the latest stable `clawdi@0.13.65` release instead of backfilling every patch release

## Baseline

This branch is rebased onto `origin/main` commit `3d6bac9b08c3fb67c6bcfa87dd0ce369bfcbd26a`, tagged `clawdi-cli-v0.13.65`. At final verification, npm `latest` was `0.13.65` with a published integrity value, and the non-draft, non-prerelease GitHub release targeted the same commit.

## Evidence

OSS repository evidence:

- `backend/app/main.py` starts the PostgreSQL sync-event listener for each API process; `backend/app/services/sync_events.py` publishes committed events through PostgreSQL and fans received notifications into process-local subscribers.
- `backend/tests/test_sync_events.py::test_postgres_listener_delivers_remote_process_event` proves notification delivery from another API-process origin.
- `packages/cli/src/index.ts` registers `link`/`unlink` as primary Agent Project commands and `attach`/`detach` as aliases.
- CLI release diffs `f578c2196`, `430b9ef50`, `a970c3a90`, `f3f7b50ec`, `d289fe991`, and `3d6bac9b0` prove the cumulative WhatsApp binding, restart-free CLI-only handoff, active-unit/config preservation, ownership repair, and Hermes credential-rotation behavior summarized in `CHANGELOG.md`.

Read-only Hosted evidence:

- Hosted commit `b6c7fca12` records the 2026-08-12 V2 public launch while V1 remained enabled.
- Current `docs/v2/ops/README.md` owns Hosted exact-package selection and rollout authority; this OSS change links that authority by repository path without copying private operations.
- Current Hosted runtime-state producer tests write `apply_generation`, confirming that the pre-activation gate is completed rather than pending.

No live, production, tenant, credential, daemon, or Hosted checkout mutations were performed.

## Verification

Documentation/static verification run:

- `git diff --check origin/main..HEAD`
- validated 26 relative Markdown links and anchors across all 7 changed documents
- asserted the current CLI command/alias registrations and PostgreSQL listener startup/test locations with exact `rg` checks
- scanned current owner docs for the removed single-worker, V2-not-live, `0.13.36`, and `0.13.56` gate wording
- confirmed `docs/user-journeys.md` is unchanged
- confirmed npm `latest`, package integrity, GitHub release status, tag, and target commit for `0.13.65`

Focused runtime verification run against a throwaway PostgreSQL 18 container:

- `uv run python scripts/check_postgres_runtime.py` passed (`server_version_num=180004`, pgvector `0.8.6`, pg_trgm `1.6`)
- `uv run alembic upgrade head` passed
- `uv run pytest -q tests/test_sync_events.py::test_postgres_listener_delivers_remote_process_event` passed (`1 passed`)

Not run due to the docs-only scope:

- full `bun run check`
- full `bun run typecheck`
- full `bun run test`
- full backend pytest suite

## Scope

Changed only `CHANGELOG.md`, `README.md`, and current architecture/CLI/runtime/release owner docs. Historical plans, designs, scenarios, `docs/user-journeys.md`, and Hosted files remain unchanged.