### PR TITLE
ci: reduce transient artifact storage

### DIFF
--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -38,6 +38,7 @@ concurrency:
 
 env:
   BACKEND_IMAGE_NAME: ghcr.io/clawdi-ai/clawdi-backend
+  DOCKER_BUILD_RECORD_UPLOAD: "false"
   SIDECAR_IMAGE_NAME: ghcr.io/clawdi-ai/clawdi-whatsapp-baileys-sidecar
   WEB_IMAGE_NAME: ghcr.io/clawdi-ai/clawdi-web
 

--- a/.github/workflows/clean-test-runner-ci.yml
+++ b/.github/workflows/clean-test-runner-ci.yml
@@ -88,6 +88,9 @@ concurrency:
   group: clean-test-runner-ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  DOCKER_BUILD_RECORD_UPLOAD: "false"
+
 jobs:
   docker-runner:
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -122,7 +122,7 @@ jobs:
           name: ${{ env.CLI_ARTIFACT_NAME }}
           path: ${{ runner.temp }}/clawdi-cli-release/
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 1
 
   publish-immutable-artifact-with-oidc:
     needs: build-immutable-artifact

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -61,6 +61,7 @@ concurrency:
 
 env:
   BUN_VERSION: "1.3.14"
+  DOCKER_BUILD_RECORD_UPLOAD: "false"
   TURBO_TELEMETRY_DISABLED: "1"
 
 jobs:

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -100,8 +100,24 @@ describe("CLI publish workflow contract", () => {
 	});
 
 	test("builds and publishes the same verified tarball exactly once", () => {
+		const build = workflowDocument.jobs["build-immutable-artifact"];
+		const publish = workflowDocument.jobs["publish-immutable-artifact-with-oidc"];
+		const uploadArtifact = build.steps?.find((step) => step.uses === "actions/upload-artifact@v7");
+		const downloadArtifact = publish.steps?.find(
+			(step) => step.uses === "actions/download-artifact@v8",
+		);
 		const publishCommands = workflow.match(/npm publish /g) ?? [];
 
+		expect(uploadArtifact?.with).toEqual({
+			name: `\${{ env.CLI_ARTIFACT_NAME }}`,
+			path: `\${{ runner.temp }}/clawdi-cli-release/`,
+			"if-no-files-found": "error",
+			"retention-days": 1,
+		});
+		expect(downloadArtifact?.with).toEqual({
+			name: `\${{ env.CLI_ARTIFACT_NAME }}`,
+			path: "release",
+		});
 		expect(publishCommands).toHaveLength(1);
 		expect(workflow).not.toContain("publishConfig");
 		expect(workflow).toContain(

--- a/packages/cli/tests/docker-build-workflows.test.ts
+++ b/packages/cli/tests/docker-build-workflows.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse } from "yaml";
+
+interface WorkflowDocument {
+	env?: Record<string, unknown>;
+	jobs?: Record<string, { steps?: Array<{ uses?: string }> }>;
+}
+
+const workflowsDirectory = resolve(import.meta.dir, "../../../.github/workflows");
+
+describe("Docker build workflow contract", () => {
+	test("disables build record artifact uploads for every build-push action", () => {
+		const buildWorkflows = readdirSync(workflowsDirectory)
+			.filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
+			.map((name) => ({
+				name,
+				workflow: parse(
+					readFileSync(resolve(workflowsDirectory, name), "utf8"),
+				) as WorkflowDocument,
+			}))
+			.filter(({ workflow }) =>
+				Object.values(workflow.jobs ?? {}).some((job) =>
+					job.steps?.some((step) => step.uses?.startsWith("docker/build-push-action@")),
+				),
+			);
+
+		expect(buildWorkflows.length).toBeGreaterThan(0);
+		for (const { name, workflow } of buildWorkflows) {
+			expect(workflow.env?.DOCKER_BUILD_RECORD_UPLOAD, name).toBe("false");
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- disable Docker Buildx build-record artifact uploads in every workflow using docker/build-push-action
- retain the immutable CLI release handoff for only GitHub's minimum supported one day
- add focused workflow contracts that prevent either storage regression

## Why

The repository currently retains about 6.0 GB across 31 transient clawdi-cli-release handoff artifacts. Buildx also uploads .dockerbuild diagnostics by default even though no workflow consumes them. npm and the GitHub Release remain the durable CLI release authorities; OCI images, cache, provenance, and release contents are unchanged.

## Verification

- bun test --isolate --max-concurrency=1 packages/cli/tests/cli-publish-workflow.test.ts packages/cli/tests/docker-build-workflows.test.ts packages/cli/tests/clawdi-image-release-workflow.test.ts packages/cli/tests/clean-test-runner.test.ts (22 passed)
- all workflow YAML parsed structurally
- all 6 Buildx invocations covered; no .dockerbuild consumer
- git diff --check
