### PR TITLE
fix(cli): keep watcher relaunch out of tenant readiness

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.65",
+      "version": "0.13.66",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.65",
+	"version": "0.13.66",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -96,7 +96,7 @@ function observedStatus(
 		return "error";
 	}
 	if (!hasAppliedAuthority) return "unknown";
-	if (systemd?.status === "unknown") return "unknown";
+	if (systemd && systemdReadinessStatus(systemd.units) === "unknown") return "unknown";
 	if (watchEvent?.status === "applied" || watchEvent?.status === "not_modified") return "ok";
 	if (bootStatus?.status === "ok") return "ok";
 	return "unknown";
@@ -357,6 +357,21 @@ function systemdUnitsStatus(units: HostedRuntimeObservedSystemdUnit[]): Observed
 	if (units.some((unit) => unit.status === "error")) return "error";
 	if (units.some((unit) => unit.status === "unknown")) return "unknown";
 	return "ok";
+}
+
+function systemdReadinessStatus(units: HostedRuntimeObservedSystemdUnit[]): ObservedStatus {
+	return systemdUnitsStatus(units.filter((unit) => !isRuntimeWatchRestartTransition(unit)));
+}
+
+function isRuntimeWatchRestartTransition(unit: HostedRuntimeObservedSystemdUnit): boolean {
+	return (
+		unit.scope === "system" &&
+		unit.name === "clawdi-runtime-watch.service" &&
+		unit.activeState === "activating" &&
+		unit.subState === "auto-restart" &&
+		unit.status === "unknown" &&
+		unit.error === null
+	);
 }
 
 function systemdUnitObservedStatus(

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -8328,6 +8328,81 @@ esac
 		}
 	});
 
+	it("runtime observed keeps runtime-watch auto-restart outside data-plane readiness", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const bin = join(root, "bin");
+		const watchFailed = join(root, "watch-failed");
+		mkdirSync(run, { recursive: true });
+		mkdirSync(bin, { recursive: true });
+		const systemctl = join(bin, "systemctl");
+		writeFileSync(
+			systemctl,
+			`#!/usr/bin/env bash
+if [ -f '${watchFailed}' ]; then
+  printf 'ActiveState=failed\\nSubState=failed\\n'
+else
+  printf 'ActiveState=activating\\nSubState=auto-restart\\n'
+fi
+`,
+		);
+		chmodSync(systemctl, 0o700);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_SYSTEMCTL_PATH = systemctl;
+		const paths = getRuntimePaths();
+		mkdirSync(paths.serviceStateRoot, { recursive: true });
+		mkdirSync(paths.systemdSystemRoot, { recursive: true });
+		writeFileSync(join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"), "[Service]\n");
+		writeRuntimeWatchStatus(
+			{ status: "applied", generation: 5, instanceId: "iid-watch-restart" },
+			paths,
+		);
+		const appliedState = {
+			schemaVersion: "clawdi.runtimeAppliedState.v2" as const,
+			appliedAt: "2026-08-12T04:21:24.000Z",
+			instanceId: "iid-watch-restart",
+			etag: '"watch-restart"',
+			sourceRevision: "a".repeat(64),
+			generation: 5,
+			contentIdentity: {
+				sourcePath: "https://runtime.test/v1/runtime/manifest",
+				sha256: "b".repeat(64),
+			},
+			providerIds: [],
+			projectedProviderIds: {},
+		};
+
+		const restarting = readHostedRuntimeObserved(paths, { appliedState });
+
+		expect(restarting?.status).toBe("ok");
+		expect(restarting?.systemd).toEqual({
+			status: "unknown",
+			unitCount: 1,
+			units: [
+				{
+					scope: "system",
+					name: "clawdi-runtime-watch.service",
+					activeState: "activating",
+					subState: "auto-restart",
+					status: "unknown",
+					error: null,
+				},
+			],
+		});
+
+		writeFileSync(watchFailed, "");
+		const failed = readHostedRuntimeObserved(paths, { appliedState });
+		expect(failed?.status).toBe("error");
+		expect(failed?.systemd).toMatchObject({
+			status: "error",
+			units: [{ name: "clawdi-runtime-watch.service", status: "error" }],
+		});
+	});
+
 	it("runtime observed does not report ok when managed systemd units are inactive", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");


### PR DESCRIPTION
## Root cause

During an exact CLI hot handoff, `clawdi-runtime-watch.service` intentionally exits cleanly and systemd relaunches it through `Restart=always`. A heartbeat sampled during `activating/auto-restart` reported overall health `unknown`, even though boot/apply identity, provider state, daemon, files, sidecar, and tenant gateway remained healthy. Hosted then withdrew the tenant route for one observation interval.

## Fix

- Keep the complete systemd diagnostic, including the watcher unit as `unknown`.
- Exclude only the exact system-scope watcher `activating/auto-restart` transition with a successful systemctl sample from tenant readiness.
- Continue failing closed for tenant unit unknown/error, explicit watcher systemd errors, and watch event errors.
- Release the fix as immutable `clawdi@0.13.66` through the existing CLI publish workflow.

## Verification

- `packages/cli/tests/runtime.test.ts`: 169 passed
- observed/heartbeat tests: 14 passed
- CLI TypeScript typecheck
- Biome check
- `git diff --check`

No tenant restart, image publication, live mutation, or production write was performed.