### PR TITLE
Harden post-launch CLI systemd operations

### DIFF
--- a/.github/workflows/cli-systemd-e2e.yml
+++ b/.github/workflows/cli-systemd-e2e.yml
@@ -1,0 +1,26 @@
+name: CLI Privileged systemd E2E
+
+on:
+  pull_request:
+    paths:
+      - "packages/cli/package.json"
+      - "packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts"
+      - "packages/cli/tests/fixtures/runtime-official-installer-systemd/**"
+      - "scripts/test-runtime-official-installer-systemd.sh"
+      - ".github/workflows/cli-systemd-e2e.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cli-systemd-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  privileged-systemd-e2e:
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - name: Test CLI against systemd as PID 1
+        run: scripts/test-runtime-official-installer-systemd.sh

--- a/packages/cli/scripts/generate-fixtures.ts
+++ b/packages/cli/scripts/generate-fixtures.ts
@@ -12,6 +12,7 @@ import { Database } from "bun:sqlite";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { AGENT_TYPES, type AgentType } from "../src/adapters/agent-types";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const fixturesRoot = join(here, "..", "tests", "fixtures");
@@ -464,12 +465,14 @@ description: If this appears in test results, SKIP_DIRS is broken
 
 // ─────────────────────────────────────────────────────────────
 console.log("Generating fixtures into", fixturesRoot);
-generateClaudeCode();
-console.log("  ✓ claude-code");
-generateCodex();
-console.log("  ✓ codex");
-generateHermes();
-console.log("  ✓ hermes");
-generateOpenClaw();
-console.log("  ✓ openclaw");
+const generators: Record<AgentType, () => void> = {
+	claude_code: generateClaudeCode,
+	codex: generateCodex,
+	openclaw: generateOpenClaw,
+	hermes: generateHermes,
+};
+for (const agentType of AGENT_TYPES) {
+	generators[agentType]();
+	console.log(`  ✓ ${agentType === "claude_code" ? "claude-code" : agentType}`);
+}
 console.log("Done.");

--- a/packages/cli/src/adapters/agent-types.ts
+++ b/packages/cli/src/adapters/agent-types.ts
@@ -1,0 +1,3 @@
+/** Canonical agent identities supported by the CLI. */
+export const AGENT_TYPES = ["claude_code", "codex", "openclaw", "hermes"] as const;
+export type AgentType = (typeof AGENT_TYPES)[number];

--- a/packages/cli/src/adapters/registry.ts
+++ b/packages/cli/src/adapters/registry.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { AGENT_TYPES, type AgentType } from "./agent-types";
 import type { AgentAdapter } from "./base";
 import { ClaudeCodeAdapter } from "./claude-code";
 import { CodexAdapter } from "./codex";
@@ -7,12 +8,7 @@ import { OpenClawAdapter } from "./openclaw";
 import { resolveOpenClawAgentWorkspace } from "./openclaw-workspace";
 import { getClaudeHome, getCodexHome, getHermesHome, getOpenClawHome } from "./paths";
 
-// Agent identity is declared as a literal tuple so `AgentType` doesn't depend
-// on the registry object — avoids a type-level cycle when `AdapterRegistryEntry`
-// references `AgentAdapter` (which references `AgentType`).
-// Adding an agent: append here AND add the matching entry to `adapterRegistry`.
-export const AGENT_TYPES = ["claude_code", "codex", "openclaw", "hermes"] as const;
-export type AgentType = (typeof AGENT_TYPES)[number];
+export { AGENT_TYPES, type AgentType } from "./agent-types";
 
 export interface AdapterRegistryEntry {
 	displayName: string;
@@ -59,7 +55,7 @@ export interface AnnotatedAdapterEntry extends AdapterRegistryEntry {
 }
 
 export function allAdapterEntries(): AnnotatedAdapterEntry[] {
-	return (Object.keys(adapterRegistry) as AgentType[]).map((agentType) => ({
+	return AGENT_TYPES.map((agentType) => ({
 		agentType,
 		...adapterRegistry[agentType],
 	}));

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { components } from "@clawdi/shared/api";
+import { safeTruncate, sanitizeMetadata } from "../lib/sanitize";
 import { getCliVersion } from "../lib/version";
 import { type RuntimeAppliedState, readRuntimeAppliedState } from "./applied-state";
 import { resolveRuntimeApplyGeneration } from "./apply-identity";
@@ -23,6 +24,9 @@ type HostedRuntimeObservedSystemd = components["schemas"]["HostedRuntimeObserved
 type HostedRuntimeObservedSystemdUnit = components["schemas"]["HostedRuntimeObservedSystemdUnitV1"];
 
 const SYSTEMD_STATUS_TIMEOUT_MS = 1_000;
+const SYSTEMD_FAILURE_EVIDENCE_MAX_LENGTH = 500;
+const SENSITIVE_FAILURE_EVIDENCE =
+	/(?:^|[^a-z0-9])(?:api[_-]?key|key|token|secret|password|passwd|credential|authorization|bearer)(?:[^a-z0-9]|$)|(?:^|\s)[A-Z][A-Z0-9_]{1,}=|(?:^|[^a-z0-9])(?:sk-|gh[pousr]_|clawdi_)[a-z0-9_-]+/i;
 
 export function readHostedRuntimeObserved(
 	paths: RuntimePaths = getRuntimePaths(),
@@ -274,27 +278,98 @@ function systemdUnitStatus(
 ): HostedRuntimeObservedSystemdUnit {
 	const result =
 		scope === "system"
-			? runSystemctl(["show", unit, "--property=ActiveState", "--property=SubState"])
+			? runSystemctl([
+					"show",
+					unit,
+					"--property=ActiveState",
+					"--property=SubState",
+					"--property=Result",
+					"--property=ExecMainCode",
+					"--property=ExecMainStatus",
+				])
 			: runRuntimeUserSystemctl(paths, [
 					"show",
 					unit,
 					"--property=ActiveState",
 					"--property=SubState",
+					"--property=Result",
+					"--property=ExecMainCode",
+					"--property=ExecMainStatus",
 				]);
 	const parsed = parseSystemctlShow(result.output);
+	const status = systemdUnitObservedStatus(parsed.ActiveState, result.exitCode);
 	return {
 		scope,
 		name: unit,
 		activeState: parsed.ActiveState ?? "unknown",
 		subState: parsed.SubState ?? "unknown",
-		status: systemdUnitObservedStatus(parsed.ActiveState, result.exitCode),
-		error: result.exitCode === 0 ? null : result.output.slice(0, 500) || "systemctl show failed",
+		status,
+		error:
+			status === "error"
+				? systemdFailureEvidence(scope, unit, parsed)
+				: result.exitCode === 0
+					? null
+					: (nonSensitiveFailureEvidence(result.output) ?? "systemctl show failed"),
 	};
+}
+
+function systemdFailureEvidence(
+	scope: "system" | "user",
+	unit: string,
+	properties: Record<string, string>,
+): string {
+	const journal = runJournalctl([
+		"--quiet",
+		"--no-pager",
+		"--output=cat",
+		"--boot=0",
+		"--priority=err",
+		"--lines=20",
+		scope === "system" ? "--unit" : "--user-unit",
+		unit,
+	]);
+	if (journal.exitCode === 0) {
+		const firstLine = journal.output.split(/\r?\n/).find((line) => line.trim());
+		const evidence = firstLine ? nonSensitiveFailureEvidence(firstLine) : null;
+		if (evidence) return evidence;
+	}
+	return (
+		safeFailureEvidence(
+			[
+				`Result=${properties.Result || "unknown"}`,
+				`ExecMainCode=${properties.ExecMainCode || "unknown"}`,
+				`ExecMainStatus=${properties.ExecMainStatus || "unknown"}`,
+			].join("; "),
+		) ?? "Result=unknown; ExecMainCode=unknown; ExecMainStatus=unknown"
+	);
+}
+
+function safeFailureEvidence(value: string): string | null {
+	const line = sanitizeMetadata(value).replace(/\s+/g, " ").trim();
+	return line ? safeTruncate(line, SYSTEMD_FAILURE_EVIDENCE_MAX_LENGTH) : null;
+}
+
+function nonSensitiveFailureEvidence(value: string): string | null {
+	const evidence = safeFailureEvidence(value);
+	return evidence && !SENSITIVE_FAILURE_EVIDENCE.test(evidence) ? evidence : null;
 }
 
 function runSystemctl(args: string[]): { exitCode: number | null; output: string } {
 	const result = spawnSync(systemctlPath(), args, {
 		encoding: "utf8",
+		maxBuffer: 64 * 1024,
+		timeout: SYSTEMD_STATUS_TIMEOUT_MS,
+	});
+	return {
+		exitCode: result.status,
+		output: [result.stdout, result.stderr, result.error?.message].filter(Boolean).join("\n").trim(),
+	};
+}
+
+function runJournalctl(args: string[]): { exitCode: number | null; output: string } {
+	const result = spawnSync("journalctl", args, {
+		encoding: "utf8",
+		env: process.env,
 		maxBuffer: 64 * 1024,
 		timeout: SYSTEMD_STATUS_TIMEOUT_MS,
 	});

--- a/packages/cli/src/serve/installer.ts
+++ b/packages/cli/src/serve/installer.ts
@@ -34,6 +34,7 @@ import {
 } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
+import { AGENT_TYPES, type AgentType } from "../adapters/agent-types";
 import {
 	type CurrentCliInvocation,
 	resolveCurrentCliInvocation,
@@ -660,11 +661,9 @@ function shellEscape(s: string): string {
  * the clawdi unit name shape. Skips agents not in `AGENT_TYPES` so
  * a malicious filename can't smuggle into the iteration.
  */
-type KnownAgent = "claude_code" | "codex" | "openclaw" | "hermes";
-export function listInstalledAgents(): KnownAgent[] {
-	const knownAgents: KnownAgent[] = ["claude_code", "codex", "openclaw", "hermes"];
-	const installed: KnownAgent[] = [];
-	for (const agent of knownAgents) {
+export function listInstalledAgents(): AgentType[] {
+	const installed: AgentType[] = [];
+	for (const agent of AGENT_TYPES) {
 		const p = platform();
 		const path = p === "darwin" ? plistPath(agent) : p === "linux" ? unitPath(agent) : null;
 		if (path && existsSync(path)) installed.push(agent);
@@ -672,7 +671,7 @@ export function listInstalledAgents(): KnownAgent[] {
 	return installed;
 }
 
-export type InstalledDaemonTarget = KnownAgent | "daemon";
+export type InstalledDaemonTarget = AgentType | "daemon";
 
 export function isSingletonDaemonInstalled(): boolean {
 	const p = platform();

--- a/packages/cli/tests/adapters/claude-code.test.ts
+++ b/packages/cli/tests/adapters/claude-code.test.ts
@@ -20,7 +20,7 @@ beforeEach(() => {
 	origConfigDir = process.env.CLAUDE_CONFIG_DIR;
 	origPath = process.env.PATH;
 	delete process.env.CLAUDE_CONFIG_DIR;
-	tmpHome = copyFixtureToTmp("claude-code");
+	tmpHome = copyFixtureToTmp("claude_code");
 	process.env.HOME = tmpHome;
 });
 

--- a/packages/cli/tests/adapters/helpers.ts
+++ b/packages/cli/tests/adapters/helpers.ts
@@ -2,6 +2,7 @@ import { cpSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { AgentType } from "../../src/adapters/agent-types";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const fixturesRoot = join(here, "..", "fixtures");
@@ -12,11 +13,12 @@ const fixturesRoot = join(here, "..", "fixtures");
  * Tests should set `process.env.HOME = tmpHome` immediately after calling
  * this — lib/config.ts and adapters/paths.ts read $HOME lazily on every call.
  */
-export function copyFixtureToTmp(agent: "claude-code" | "codex" | "hermes" | "openclaw"): string {
-	const src = join(fixturesRoot, agent);
+export function copyFixtureToTmp(agent: AgentType): string {
+	const fixtureName = agent === "claude_code" ? "claude-code" : agent;
+	const src = join(fixturesRoot, fixtureName);
 	const dst = join(
 		tmpdir(),
-		`clawdi-fixture-${agent}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		`clawdi-fixture-${fixtureName}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
 	);
 	mkdirSync(dst, { recursive: true });
 	cpSync(src, dst, { recursive: true });

--- a/packages/cli/tests/commands/pull.test.ts
+++ b/packages/cli/tests/commands/pull.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { AgentType } from "../../src/adapters/agent-types";
 import { pull } from "../../src/commands/pull";
 import {
 	readProjectSkillMaterialization,
@@ -22,25 +23,17 @@ import {
 
 const TEST_PROJECT_ID = "00000000-0000-0000-0000-000000000099";
 
-type AgentKey = "claude-code" | "codex" | "hermes" | "openclaw";
-const AGENT_TYPE: Record<AgentKey, string> = {
-	"claude-code": "claude_code",
-	codex: "codex",
-	hermes: "hermes",
-	openclaw: "openclaw",
-};
-
 let tmpHome: string;
 let origHome: string | undefined;
 let origHomeOverrides: AgentHomeOverrideSnapshot = {};
 let origPath: string | undefined;
 
-function setup(agent: AgentKey) {
+function setup(agent: AgentType) {
 	origHome = process.env.HOME;
 	origHomeOverrides = snapshotAndClearAgentHomeOverrides();
 	tmpHome = copyFixtureToTmp(agent);
 	process.env.HOME = tmpHome;
-	seedAuthAndEnv(tmpHome, AGENT_TYPE[agent]);
+	seedAuthAndEnv(tmpHome, agent);
 	if (agent === "openclaw") {
 		origPath = process.env.PATH;
 		const bin = join(tmpHome, "bin");
@@ -395,7 +388,7 @@ content
 
 describe("pull — Claude Code fixture", () => {
 	it("imports an explicit workspace Skill into $HOME/.claude/skills/<key>/", async () => {
-		setup("claude-code");
+		setup("claude_code");
 		const tarBytes = await buildSkillTar(
 			"fresh",
 			`---

--- a/packages/cli/tests/commands/push.test.ts
+++ b/packages/cli/tests/commands/push.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import type { AgentType } from "../../src/adapters/agent-types";
 import { push } from "../../src/commands/push";
 import { recordProjectSkillMaterialization } from "../../src/lib/skills-lock";
 import { cleanupTmp, copyFixtureToTmp } from "../adapters/helpers";
@@ -28,20 +29,11 @@ function batchSessions(c: CapturedRequest | undefined): BatchSession[] {
 	return body?.sessions ?? [];
 }
 
-type AgentKey = "claude-code" | "codex" | "hermes" | "openclaw";
-
-const AGENT_TYPE: Record<AgentKey, string> = {
-	"claude-code": "claude_code",
-	codex: "codex",
-	hermes: "hermes",
-	openclaw: "openclaw",
-};
-
 let tmpHome: string;
 let origHome: string | undefined;
 let origHomeOverrides: AgentHomeOverrideSnapshot = {};
 
-function setup(agent: AgentKey): {
+function setup(agent: AgentType): {
 	sent: ReturnType<typeof mockFetch>["captured"];
 	restore: () => void;
 } {
@@ -49,7 +41,7 @@ function setup(agent: AgentKey): {
 	origHomeOverrides = snapshotAndClearAgentHomeOverrides();
 	tmpHome = copyFixtureToTmp(agent);
 	process.env.HOME = tmpHome;
-	seedAuthAndEnv(tmpHome, AGENT_TYPE[agent]);
+	seedAuthAndEnv(tmpHome, agent);
 	return { sent: [], restore: () => {} };
 }
 
@@ -257,7 +249,7 @@ describe("push — Hermes fixture", () => {
 
 describe("push — Claude Code fixture", () => {
 	it("uploads the single fixture session", async () => {
-		setup("claude-code");
+		setup("claude_code");
 		const { captured, restore } = mockFetch([
 			okEnvironmentProbe(),
 			{
@@ -424,7 +416,7 @@ describe("push — preflight checks", () => {
 
 describe("push — --all flag fan-out", () => {
 	it("--all + explicit --agent narrows to that agent (explicit wins)", async () => {
-		setup("claude-code");
+		setup("claude_code");
 		// Seed a second env so the only way "claude_code" gets selected
 		// is if the explicit --agent flag overrides --all's broadening.
 		writeFileSync(
@@ -454,7 +446,7 @@ describe("push — --all flag fan-out", () => {
 	});
 
 	it("--all + --project narrows project (silent-precedence bug fix)", async () => {
-		setup("claude-code");
+		setup("claude_code");
 		const { captured, restore } = mockFetch([okEnvironmentProbe()]);
 		try {
 			// Project that no fixture session lives in. Old behavior:
@@ -475,7 +467,7 @@ describe("push — --all flag fan-out", () => {
 	});
 
 	it("--all alone reaches all axes for a single registered agent", async () => {
-		setup("claude-code");
+		setup("claude_code");
 		const { captured, restore } = mockFetch([
 			okEnvironmentProbe(),
 			{
@@ -509,7 +501,7 @@ describe("push — --all flag fan-out", () => {
 	});
 
 	it("multi-agent push scans every agent then uploads (scan/upload split)", async () => {
-		setup("claude-code");
+		setup("claude_code");
 		// Two registered agents. The claude-code fixture only has
 		// claude_code session data; codex has an env file but no
 		// session dir — it scans empty. The push must still iterate

--- a/packages/cli/tests/commands/teardown.test.ts
+++ b/packages/cli/tests/commands/teardown.test.ts
@@ -9,6 +9,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import type { AgentType } from "../../src/adapters/agent-types";
 import { ClaudeCodeAdapter } from "../../src/adapters/claude-code";
 import { teardown } from "../../src/commands/teardown";
 import { managedSkillDirectoryDigest } from "../../src/runtime/hosted-bundled-skill";
@@ -25,14 +26,6 @@ import {
 	snapshotAndClearAgentHomeOverrides,
 } from "./helpers";
 
-type AgentKey = "claude-code" | "codex" | "hermes" | "openclaw";
-const AGENT_TYPE: Record<AgentKey, string> = {
-	"claude-code": "claude_code",
-	codex: "codex",
-	hermes: "hermes",
-	openclaw: "openclaw",
-};
-
 let tmpHome: string;
 let origHome: string | undefined;
 let origPath: string | undefined;
@@ -41,7 +34,7 @@ let origHomeOverrides: AgentHomeOverrideSnapshot = {};
 let origIsTTY: boolean | undefined;
 
 function setup(
-	agent: AgentKey,
+	agent: AgentType,
 	options: { managed?: boolean } = {},
 ): {
 	envPath: string;
@@ -52,9 +45,9 @@ function setup(
 	tmpHome = copyFixtureToTmp(agent);
 	process.env.HOME = tmpHome;
 	process.env.HERMES_HOME = join(tmpHome, ".hermes");
-	seedAuthAndEnv(tmpHome, AGENT_TYPE[agent]);
+	seedAuthAndEnv(tmpHome, agent);
 
-	const envPath = join(tmpHome, ".clawdi", "environments", `${AGENT_TYPE[agent]}.json`);
+	const envPath = join(tmpHome, ".clawdi", "environments", `${agent}.json`);
 
 	// Plant a clawdi skill where the registry expects to find it.
 	let skillPath: string;
@@ -62,7 +55,7 @@ function setup(
 		const oid = process.env.OPENCLAW_AGENT_ID || "main";
 		skillPath = join(tmpHome, ".openclaw", "agents", oid, "skills", "clawdi", "SKILL.md");
 	} else {
-		const home = `.${agent === "claude-code" ? "claude" : agent}`;
+		const home = `.${agent === "claude_code" ? "claude" : agent}`;
 		skillPath = join(tmpHome, home, "skills", "clawdi", "SKILL.md");
 	}
 	mkdirSync(join(skillPath, ".."), { recursive: true });
@@ -138,7 +131,7 @@ function installOpenClawStub(): string {
 
 describe("teardown — basic round-trip per agent", () => {
 	it("Claude Code: removes env file + bundled skill (--keep-mcp to skip claude exec)", async () => {
-		const { envPath, skillPath } = setup("claude-code");
+		const { envPath, skillPath } = setup("claude_code");
 		expect(existsSync(envPath)).toBe(true);
 		expect(existsSync(skillPath)).toBe(true);
 
@@ -174,7 +167,7 @@ describe("teardown — basic round-trip per agent", () => {
 
 describe("teardown — flag behavior", () => {
 	it("--keep-skill leaves the bundled skill in place", async () => {
-		const { envPath, skillPath } = setup("claude-code");
+		const { envPath, skillPath } = setup("claude_code");
 		const target = dirname(skillPath);
 		await teardown({ agent: "claude_code", yes: true, keepMcp: true, keepSkill: true });
 		expect(existsSync(envPath)).toBe(false);
@@ -189,7 +182,7 @@ describe("teardown — flag behavior", () => {
 	});
 
 	it("adopts and removes a genuine pre-ledger bundle on direct teardown only once", async () => {
-		const { skillPath } = setup("claude-code", { managed: false });
+		const { skillPath } = setup("claude_code", { managed: false });
 		const target = dirname(skillPath);
 		rmSync(target, { recursive: true, force: true });
 		cpSync(resolve(import.meta.dir, "../../skills/clawdi"), target, { recursive: true });
@@ -217,7 +210,7 @@ describe("teardown — flag behavior", () => {
 	});
 
 	it("preserves an unproven custom same-name Skill on direct teardown", async () => {
-		const { skillPath } = setup("claude-code", { managed: false });
+		const { skillPath } = setup("claude_code", { managed: false });
 		const target = dirname(skillPath);
 		writeFileSync(skillPath, "---\nname: clawdi\ndescription: Custom Skill\n---\n");
 

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -1064,7 +1064,6 @@ http.createServer((request, response) => {
 		{ timeout: 5000 },
 	);
 	expect(unitControl.status).not.toBe(0);
-	expect(spawnSync("systemctl", ["is-active", "--quiet", "clawdi-files.service"]).status).toBe(0);
 	const effectiveUnit = spawnSync("systemctl", ["cat", "clawdi-files.service"], {
 		encoding: "utf8",
 	});
@@ -1080,13 +1079,23 @@ http.createServer((request, response) => {
 	expect(statSync(configMountPoint).isFile()).toBe(true);
 	expect(readFileSync(configMountPoint, "utf8")).toBe("");
 
-	let readinessStatus: number | null = null;
+	let health = spawnSync("curl", ["-fsS", "http://127.0.0.1:9120/health"], {
+		encoding: "utf8",
+	});
 	for (let attempt = 0; attempt < 50; attempt++) {
-		readinessStatus = spawnSync("curl", ["-fsS", "http://127.0.0.1:9120/health"]).status;
-		if (readinessStatus === 0) break;
+		if (health.status === 0) break;
 		spawnSync("sleep", ["0.1"]);
+		health = spawnSync("curl", ["-fsS", "http://127.0.0.1:9120/health"], {
+			encoding: "utf8",
+		});
 	}
-	expect(readinessStatus).toBe(0);
+	expect({
+		unit: spawnSync("systemctl", ["is-active", "clawdi-files.service"], {
+			encoding: "utf8",
+		}).stdout.trim(),
+		healthStatus: health.status,
+		healthBody: health.stdout,
+	}).toEqual({ unit: "active", healthStatus: 0, healthBody: "ok" });
 	const reconverged = converge();
 	expect(reconverged.installErrors).toEqual([]);
 

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -8220,6 +8220,7 @@ exit 64
 		const previousPath = process.env.PATH;
 		mkdirSync(run, { recursive: true });
 		mkdirSync(bin, { recursive: true });
+		const longJournalLine = `Gateway startup failed: ${"x".repeat(600)}`;
 		writeFileSync(
 			join(bin, "systemctl"),
 			`#!/usr/bin/env bash
@@ -8233,8 +8234,11 @@ case "$unit" in
   clawdi-runtime-watch.service|clawdi-daemon.service)
     printf 'ActiveState=active\\nSubState=running\\n'
     ;;
+  clawdi-files.service)
+    printf 'ActiveState=failed\\nSubState=failed\\nResult=exit-code\\nExecMainCode=exited\\nExecMainStatus=78\\n'
+    ;;
   openclaw-gateway.service)
-    printf 'ActiveState=failed\\nSubState=failed\\n'
+    printf 'ActiveState=failed\\nSubState=failed\\nResult=exit-code\\nExecMainCode=exited\\nExecMainStatus=1\\n'
     ;;
   *)
     printf 'ActiveState=inactive\\nSubState=dead\\n'
@@ -8243,6 +8247,16 @@ esac
 `,
 		);
 		chmodSync(join(bin, "systemctl"), 0o700);
+		writeFileSync(
+			join(bin, "journalctl"),
+			`#!/usr/bin/env bash
+case "$*" in
+  *clawdi-files.service*) printf 'OPENAI_API_KEY=sk-must-not-leak\\n' ;;
+  *openclaw-gateway.service*) printf '\\033[31m%s\\033[0m\\nignored second line\\n' '${longJournalLine}' ;;
+esac
+		`,
+		);
+		chmodSync(join(bin, "journalctl"), 0o700);
 		process.env.PATH = `${bin}:${previousPath ?? ""}`;
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
@@ -8257,6 +8271,7 @@ esac
 		mkdirSync(paths.systemdUserRoot, { recursive: true });
 		writeFileSync(join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"), "[Service]\n");
 		writeFileSync(join(paths.systemdSystemRoot, "clawdi-daemon.service"), "[Service]\n");
+		writeFileSync(join(paths.systemdSystemRoot, "clawdi-files.service"), "[Service]\n");
 		writeFileSync(
 			join(paths.systemdUserRoot, "openclaw-gateway.service"),
 			`${GENERATED_RUNTIME_SYSTEMD_FILE_HEADER}\n[Service]\n`,
@@ -8294,7 +8309,7 @@ esac
 			expect(observed?.status).toBe("error");
 			expect(observed?.systemd).toEqual({
 				status: "error",
-				unitCount: 3,
+				unitCount: 4,
 				units: [
 					{
 						scope: "system",
@@ -8303,6 +8318,14 @@ esac
 						subState: "running",
 						status: "ok",
 						error: null,
+					},
+					{
+						scope: "system",
+						name: "clawdi-files.service",
+						activeState: "failed",
+						subState: "failed",
+						status: "error",
+						error: "Result=exit-code; ExecMainCode=exited; ExecMainStatus=78",
 					},
 					{
 						scope: "system",
@@ -8318,10 +8341,11 @@ esac
 						activeState: "failed",
 						subState: "failed",
 						status: "error",
-						error: null,
+						error: longJournalLine.slice(0, 500),
 					},
 				],
 			});
+			expect(JSON.stringify(observed)).not.toContain("sk-must-not-leak");
 		} finally {
 			if (previousPath === undefined) delete process.env.PATH;
 			else process.env.PATH = previousPath;


### PR DESCRIPTION
## Summary

This PR closes the four post-launch CLI follow-ups as four separate commits:

1. `731edd9cf` adds a single, path-scoped PR job for the privileged real-systemd suite. It uses the existing bounded Docker harness with systemd as PID 1 and matches the `packages/cli/package.json` input that triggers CLI publishing.
2. `16c4f3262` attaches the first safe journal error line to failed systemd unit observations, bounded to 500 Unicode codepoints. Sensitive-looking output falls back to `Result`, `ExecMainCode`, and `ExecMainStatus`; retry and pacing behavior is unchanged.
3. `b2f6e08cd` makes the existing Files privileged scenario require both an active real `clawdi-files.service` and an `ok` response from `http://127.0.0.1:9120/health` on tenant loopback.
4. `6ebaaccd5` confirms the roster duplication was real and makes `AGENT_TYPES` plus `AgentType` the single source for the product registry, daemon migration scan, fixture generator, and fixture consumers.

The CLI version is unchanged.

## Evaluations

**Gateway token dual copy, not implemented:** The current hosted contract names the same `secret://runtime/openclaw/gateway-token` twice: `openclawGatewayAuth.tokenRef` drives the authoritative `openclaw.json` `gateway.auth.token`, while `runtimes.openclaw.run.secretEnv.OPENCLAW_GATEWAY_TOKEN` feeds the official installer; v2 unit rendering then removes that installer-only variable from the persistent runtime environment. A lean reshape would make `openclawGatewayAuth.tokenRef` the sole manifest authority and derive the temporary installer environment inside CLI planning. The blast radius is the backend manifest schema/emitter, CLI schema and source validation, installer planning, rotation and rollback fixtures, and the paired CLI image rollout. Provider egress-profile Authorization rewriting is unrelated and would not change. Rotation would remain one secretRef update that refreshes the config patch and reconciles the official service, without a second manifest field that can drift.

**Tenant-facing provider placeholder, owner-decided follow-up:** In a separate pre-launch PR, rename `CLAWDI_MANAGED_OPENAI_API_KEY` to `CLAWDI_AI_API_KEY` with no compatibility shim, and also replace `CLAWDI_OPENCLAW_API_KEY` with that same name. Writers and readers to change are the backend managed-provider `runtime_env_name` constant, runtime-schema reserved-name checks, dev seed and hosted manifest fixtures; shared provider reserved-name recognition and tests; CLI hosted provisioning/projection, manifest admission checks, OpenClaw config and Hermes YAML projection, unit environment rendering, command and privileged e2e fixtures; and `docs/managed-runtime.md`. The paired v2 CLI image and backend manifest writer must roll together, but the egress addon and Authorization-rewrite match contract do not depend on the environment name: matching uses endpoint host/path plus the fixed placeholder value, and replacement uses the provider secretRef. Provider-key rotation is likewise secretRef-driven. Unifying OpenClaw and Hermes on `CLAWDI_AI_API_KEY` is therefore a pure simplification: the runtimes have separate units and config projections, so the current names provide no process-isolation value and no egress matching granularity. Terminal Codex remains on its separate `OPENAI_API_KEY` tool-plane contract, and `OPENCLAW_GATEWAY_TOKEN` remains a distinct native gateway-auth contract.

## Verification

- `bun run typecheck` - 4 workspace packages passed
- `bun run check` - 973 files passed Biome CI
- `bun run --cwd packages/cli test` - 1,645 passed, 4 expected native lifecycle skips, 0 failed
- Focused adapter, command, and installer tests - 122 passed, 0 failed
- Privileged real-systemd e2e on final HEAD - 4 passed, 0 failed, 164 assertions
- `git diff --check origin/main..HEAD` - passed

The privileged harness cleaned up its task-scoped container and image after the run.