### PR TITLE
fix(runtime): repair stale WhatsApp credentials

### DIFF
--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -45,9 +45,9 @@ from app.services.runtime_source import (
     ensure_runtime_whatsapp_credentials,
     expected_runtime_bundle_v2_etag,
     load_runtime_source_batch,
-    missing_runtime_whatsapp_credential_link_ids,
     render_runtime_bundle,
     render_runtime_source,
+    runtime_whatsapp_credential_repair_link_ids,
     vault_key_identity,
 )
 from app.services.tar_utils import tar_from_content
@@ -76,19 +76,19 @@ async def get_runtime_manifest(
         )
 
     try:
-        source, missing_link_ids = await _render_runtime_source_snapshot(
+        source, repair_link_ids = await _render_runtime_source_snapshot(
             environment_id=environment_id,
             owner_user_id=auth.user_id,
         )
-        if missing_link_ids:
+        if repair_link_ids:
             await ensure_runtime_whatsapp_credentials(
                 db,
                 environment_id=environment_id,
                 owner_user_id=auth.user_id,
-                link_ids=missing_link_ids,
+                link_ids=repair_link_ids,
             )
             await db.commit()
-            source, missing_link_ids = await _render_runtime_source_snapshot(
+            source, repair_link_ids = await _render_runtime_source_snapshot(
                 environment_id=environment_id,
                 owner_user_id=auth.user_id,
             )
@@ -125,12 +125,12 @@ async def _render_runtime_source_snapshot(
             environment_ids=[environment_id],
             owner_user_id=owner_user_id,
         )
-        missing_link_ids = missing_runtime_whatsapp_credential_link_ids(
+        repair_link_ids = runtime_whatsapp_credential_repair_link_ids(
             batch,
             environment_id=environment_id,
         )
-        if missing_link_ids:
-            return None, missing_link_ids
+        if repair_link_ids:
+            return None, repair_link_ids
         return (
             render_runtime_source(
                 batch,

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -81,6 +81,8 @@ from app.services.vault_crypto import decrypt
 from app.services.whatsapp_baileys import (
     buffer_json,
     ensure_whatsapp_agent_credential,
+    whatsapp_credential_needs_self_identity_repair,
+    whatsapp_self_identity_from_config,
 )
 
 RUNTIME_BUNDLE_V2_MEDIA_TYPE = "application/vnd.clawdi.runtime-bundle.v2+json"
@@ -402,19 +404,28 @@ async def ensure_runtime_whatsapp_credentials(
         raise RuntimeSourceError("Hosted runtime WhatsApp credential source is invalid") from exc
 
 
-def missing_runtime_whatsapp_credential_link_ids(
+def runtime_whatsapp_credential_repair_link_ids(
     batch: RuntimeSourceBatch,
     *,
     environment_id: UUID,
 ) -> tuple[UUID, ...]:
-    return tuple(
-        link.id
-        for account, link in batch.channels.get(environment_id, ())
-        if account.provider == CHANNEL_PROVIDER_WHATSAPP
-        and (
-            link.id not in batch.channel_credentials or account.id not in batch.whatsapp_auth_certs
-        )
-    )
+    repair_link_ids: list[UUID] = []
+    try:
+        for account, link in batch.channels.get(environment_id, ()):
+            if account.provider != CHANNEL_PROVIDER_WHATSAPP:
+                continue
+            credential = batch.channel_credentials.get(link.id)
+            if credential is None or account.id not in batch.whatsapp_auth_certs:
+                repair_link_ids.append(link.id)
+                continue
+            if whatsapp_credential_needs_self_identity_repair(
+                credential,
+                self_identity=whatsapp_self_identity_from_config(account.config),
+            ):
+                repair_link_ids.append(link.id)
+    except Exception as exc:
+        raise RuntimeSourceError("Hosted runtime WhatsApp credential source is invalid") from exc
+    return tuple(repair_link_ids)
 
 
 def _project_runtime_skills(

--- a/backend/app/services/whatsapp_baileys.py
+++ b/backend/app/services/whatsapp_baileys.py
@@ -176,14 +176,6 @@ class ResolvedWhatsAppCredential:
 
 
 @dataclass(frozen=True)
-class _WhatsAppCredentialSelfIdentityState:
-    creds: dict[str, object]
-    me: dict[str, object]
-    self_identity: dict[str, str]
-    needs_repair: bool
-
-
-@dataclass(frozen=True)
 class RelayDecision:
     action: Literal["relay", "drop"]
     node: BinaryNode | None = None
@@ -1846,11 +1838,11 @@ def whatsapp_credential_needs_self_identity_repair(
 ) -> bool:
     if self_identity is None or credential.revoked_at is not None:
         return False
-    state = _whatsapp_credential_self_identity_state(
+    *_, needs_repair = _load_whatsapp_credential_self_identity_state(
         credential,
         self_identity=self_identity,
     )
-    return state.needs_repair
+    return needs_repair
 
 
 async def save_whatsapp_credential_self_identity(
@@ -1861,28 +1853,28 @@ async def save_whatsapp_credential_self_identity(
 ) -> bool:
     if self_identity is None or credential.revoked_at is not None:
         return False
-    state = _whatsapp_credential_self_identity_state(
+    creds, me, validated, needs_repair = _load_whatsapp_credential_self_identity_state(
         credential,
         self_identity=self_identity,
     )
     stored_identity: dict[str, JsonValue] = {
         "id": credential.synthetic_jid,
-        "lid": state.self_identity["lid"],
+        "lid": validated["lid"],
     }
-    if name := state.self_identity.get("name"):
+    if name := validated.get("name"):
         stored_identity["name"] = name
 
     config = dict(credential.config or {})
     config_changed = config.get("self_identity") != stored_identity
-    if not state.needs_repair and not config_changed:
+    if not needs_repair and not config_changed:
         return False
-    if state.needs_repair:
-        state.creds["me"] = {
-            **state.me,
+    if needs_repair:
+        creds["me"] = {
+            **me,
             "id": credential.synthetic_jid,
-            "lid": state.self_identity["lid"],
+            "lid": validated["lid"],
         }
-        ciphertext, nonce = encrypt(serialize_creds(state.creds))
+        ciphertext, nonce = encrypt(serialize_creds(creds))
         credential.encrypted_credentials = ciphertext
         credential.credential_nonce = nonce
     if config_changed:
@@ -1892,11 +1884,11 @@ async def save_whatsapp_credential_self_identity(
     return True
 
 
-def _whatsapp_credential_self_identity_state(
+def _load_whatsapp_credential_self_identity_state(
     credential: ChannelAgentCredential,
     *,
     self_identity: Mapping[str, str],
-) -> _WhatsAppCredentialSelfIdentityState:
+) -> tuple[dict[str, object], dict[str, object], dict[str, str], bool]:
     validated = whatsapp_self_identity_from_config({"self_identity": dict(self_identity)})
     if validated is None:
         raise ValueError("WhatsApp self identity requires a valid PN and LID pair")
@@ -1908,13 +1900,11 @@ def _whatsapp_credential_self_identity_state(
     me = creds.get("me")
     if not _is_object_dict(me):
         raise ValueError("WhatsApp credential creds.me must be an object")
-    return _WhatsAppCredentialSelfIdentityState(
-        creds=creds,
-        me=me,
-        self_identity=validated,
-        needs_repair=(
-            me.get("id") != credential.synthetic_jid or me.get("lid") != validated["lid"]
-        ),
+    return (
+        creds,
+        me,
+        validated,
+        me.get("id") != credential.synthetic_jid or me.get("lid") != validated["lid"],
     )
 
 

--- a/backend/app/services/whatsapp_baileys.py
+++ b/backend/app/services/whatsapp_baileys.py
@@ -176,6 +176,14 @@ class ResolvedWhatsAppCredential:
 
 
 @dataclass(frozen=True)
+class _WhatsAppCredentialSelfIdentityState:
+    creds: dict[str, object]
+    me: dict[str, object]
+    self_identity: dict[str, str]
+    needs_repair: bool
+
+
+@dataclass(frozen=True)
 class RelayDecision:
     action: Literal["relay", "drop"]
     node: BinaryNode | None = None
@@ -1831,6 +1839,20 @@ def whatsapp_self_identity_from_config(
     return identity
 
 
+def whatsapp_credential_needs_self_identity_repair(
+    credential: ChannelAgentCredential,
+    *,
+    self_identity: Mapping[str, str] | None,
+) -> bool:
+    if self_identity is None or credential.revoked_at is not None:
+        return False
+    state = _whatsapp_credential_self_identity_state(
+        credential,
+        self_identity=self_identity,
+    )
+    return state.needs_repair
+
+
 async def save_whatsapp_credential_self_identity(
     db: AsyncSession,
     *,
@@ -1839,16 +1861,45 @@ async def save_whatsapp_credential_self_identity(
 ) -> bool:
     if self_identity is None or credential.revoked_at is not None:
         return False
+    state = _whatsapp_credential_self_identity_state(
+        credential,
+        self_identity=self_identity,
+    )
+    stored_identity: dict[str, JsonValue] = {
+        "id": credential.synthetic_jid,
+        "lid": state.self_identity["lid"],
+    }
+    if name := state.self_identity.get("name"):
+        stored_identity["name"] = name
+
+    config = dict(credential.config or {})
+    config_changed = config.get("self_identity") != stored_identity
+    if not state.needs_repair and not config_changed:
+        return False
+    if state.needs_repair:
+        state.creds["me"] = {
+            **state.me,
+            "id": credential.synthetic_jid,
+            "lid": state.self_identity["lid"],
+        }
+        ciphertext, nonce = encrypt(serialize_creds(state.creds))
+        credential.encrypted_credentials = ciphertext
+        credential.credential_nonce = nonce
+    if config_changed:
+        config["self_identity"] = stored_identity
+        credential.config = config
+    await db.flush()
+    return True
+
+
+def _whatsapp_credential_self_identity_state(
+    credential: ChannelAgentCredential,
+    *,
+    self_identity: Mapping[str, str],
+) -> _WhatsAppCredentialSelfIdentityState:
     validated = whatsapp_self_identity_from_config({"self_identity": dict(self_identity)})
     if validated is None:
         raise ValueError("WhatsApp self identity requires a valid PN and LID pair")
-    stored_identity: dict[str, JsonValue] = {
-        "id": credential.synthetic_jid,
-        "lid": validated["lid"],
-    }
-    if name := validated.get("name"):
-        stored_identity["name"] = name
-
     creds = decode_buffer_json(
         json.loads(decrypt(credential.encrypted_credentials, credential.credential_nonce))
     )
@@ -1857,26 +1908,14 @@ async def save_whatsapp_credential_self_identity(
     me = creds.get("me")
     if not _is_object_dict(me):
         raise ValueError("WhatsApp credential creds.me must be an object")
-
-    config = dict(credential.config or {})
-    creds_changed = me.get("id") != credential.synthetic_jid or me.get("lid") != validated["lid"]
-    config_changed = config.get("self_identity") != stored_identity
-    if not creds_changed and not config_changed:
-        return False
-    if creds_changed:
-        creds["me"] = {
-            **me,
-            "id": credential.synthetic_jid,
-            "lid": validated["lid"],
-        }
-        ciphertext, nonce = encrypt(serialize_creds(creds))
-        credential.encrypted_credentials = ciphertext
-        credential.credential_nonce = nonce
-    if config_changed:
-        config["self_identity"] = stored_identity
-        credential.config = config
-    await db.flush()
-    return True
+    return _WhatsAppCredentialSelfIdentityState(
+        creds=creds,
+        me=me,
+        self_identity=validated,
+        needs_repair=(
+            me.get("id") != credential.synthetic_jid or me.get("lid") != validated["lid"]
+        ),
+    )
 
 
 def _clean_optional_whatsapp_text(value: object) -> str | None:

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -63,7 +63,7 @@ from app.services.runtime_source import (
     expected_runtime_bundle_v2_etag,
     runtime_manifest_issued_at,
 )
-from app.services.vault_crypto import encrypt
+from app.services.vault_crypto import decrypt, encrypt
 from scripts.seed_dashboard_dev import (
     _create_hosted_runtime_graph,
     _seed_ai_provider,
@@ -4315,15 +4315,14 @@ async def test_runtime_manifest_repairs_and_invalidates_an_existing_whatsapp_lin
         seed_user,
     )
     account.provider = "whatsapp"
+    account_lid = "900000000000001:1@lid"
+    account.config = {
+        "self_identity": {
+            "id": "15551234567:1@s.whatsapp.net",
+            "lid": account_lid,
+        }
+    }
     await db_session.commit()
-
-    def reject_auth_cert_private_key_decrypt(*_args) -> str:
-        raise AssertionError("runtime manifest must not decrypt WhatsApp auth-cert private keys")
-
-    monkeypatch.setattr(
-        "app.services.whatsapp_baileys.decrypt",
-        reject_auth_cert_private_key_decrypt,
-    )
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="whatsapp-repair")
     target_queue = sync_events.subscribe(
@@ -4343,14 +4342,35 @@ async def test_runtime_manifest_repairs_and_invalidates_an_existing_whatsapp_lin
                 )
             )
             assert credential is not None
-            assert (
-                await db_session.scalar(
-                    select(ChannelWhatsAppAuthCert).where(
-                        ChannelWhatsAppAuthCert.account_id == account.id
-                    )
+            auth_cert = await db_session.scalar(
+                select(ChannelWhatsAppAuthCert).where(
+                    ChannelWhatsAppAuthCert.account_id == account.id
                 )
-                is not None
             )
+            assert auth_cert is not None
+
+            def decrypt_credential_only(ciphertext: bytes, nonce: bytes) -> str:
+                if ciphertext in {
+                    auth_cert.encrypted_root_private_key,
+                    auth_cert.encrypted_intermediate_private_key,
+                }:
+                    raise AssertionError(
+                        "runtime manifest must not decrypt WhatsApp auth-cert private keys"
+                    )
+                return decrypt(ciphertext, nonce)
+
+            monkeypatch.setattr(
+                "app.services.whatsapp_baileys.decrypt",
+                decrypt_credential_only,
+            )
+
+            def load_credential_creds() -> dict:
+                value = json.loads(
+                    decrypt(credential.encrypted_credentials, credential.credential_nonce)
+                )
+                assert isinstance(value, dict)
+                return value
+
             account_key = channel_runtime_account_key(account.id)
             capability_ref = (
                 f"secret://channels/whatsapp/{account_key}/links/{link.id}/egress-capability"
@@ -4377,9 +4397,46 @@ async def test_runtime_manifest_repairs_and_invalidates_an_existing_whatsapp_lin
                 channel_runtime_placeholder_token("whatsapp", account_key, link_id=link.id)
             )
 
+            legacy_creds = load_credential_creds()
+            legacy_me = legacy_creds.get("me")
+            assert isinstance(legacy_me, dict)
+            legacy_me.pop("lid")
+            credential.encrypted_credentials, credential.credential_nonce = encrypt(
+                json.dumps(legacy_creds)
+            )
+            await db_session.commit()
+
+            identity_repaired = await client.get("/v1/runtime/manifest")
+            assert identity_repaired.status_code == 200, identity_repaired.text
+            assert identity_repaired.json()["sourceRevision"] != repaired.json()["sourceRevision"]
+            await db_session.refresh(credential)
+            repaired_creds = load_credential_creds()
+            repaired_me = repaired_creds.get("me")
+            assert isinstance(repaired_me, dict)
+            assert repaired_me["id"] == credential.synthetic_jid
+            assert repaired_me["lid"] == account_lid
+            healthy_material = (
+                credential.encrypted_credentials,
+                credential.credential_nonce,
+                credential.updated_at,
+            )
+
+            async def reject_healthy_credential_ensure(*_args, **_kwargs):
+                raise AssertionError("healthy WhatsApp credential must not enter repair")
+
+            monkeypatch.setattr(
+                "app.routes.runtime.ensure_runtime_whatsapp_credentials",
+                reject_healthy_credential_ensure,
+            )
             repeated = await client.get("/v1/runtime/manifest")
             assert repeated.status_code == 200, repeated.text
-            assert repeated.json()["sourceRevision"] == repaired.json()["sourceRevision"]
+            assert repeated.json()["sourceRevision"] == identity_repaired.json()["sourceRevision"]
+            await db_session.refresh(credential)
+            assert (
+                credential.encrypted_credentials,
+                credential.credential_nonce,
+                credential.updated_at,
+            ) == healthy_material
             credential_count = await db_session.scalar(
                 select(func.count())
                 .select_from(ChannelAgentCredential)
@@ -4398,7 +4455,9 @@ async def test_runtime_manifest_repairs_and_invalidates_an_existing_whatsapp_lin
             }
             token_rotated = await client.get("/v1/runtime/manifest")
             assert token_rotated.status_code == 200, token_rotated.text
-            assert token_rotated.json()["sourceRevision"] != repaired.json()["sourceRevision"]
+            assert (
+                token_rotated.json()["sourceRevision"] != identity_repaired.json()["sourceRevision"]
+            )
 
             deleted = await client.delete(f"/v1/channels/{account.id}/agent-links/{link.id}")
             assert deleted.status_code == 204, deleted.text

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.67",
+      "version": "0.13.68",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.67",
+	"version": "0.13.68",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -650,13 +650,6 @@ export function applySystemdRuntimeUpdate(
 	);
 	const changedSystemUnits = new Set(system.changed);
 	const changedUserUnits = new Set(user.changed);
-	const systemProcessRevisionDrift = new Set(
-		system.present.filter((unit) => {
-			if (unit === RUNTIME_WATCH_SYSTEM_UNIT) return false;
-			const state = systemdUnitManagerState(paths, "system", unit);
-			return state.activeState === "active" && !systemdProcessRevisionMatches(paths, unit, state);
-		}),
-	);
 	const userProcessRevisionDrift = new Set(
 		user.present.filter((unit) => {
 			const state = systemdUnitManagerState(paths, "user", unit);
@@ -724,8 +717,7 @@ export function applySystemdRuntimeUpdate(
 		if (
 			state.activeState === "active" &&
 			unit !== RUNTIME_WATCH_SYSTEM_UNIT &&
-			(systemProcessRevisionDrift.has(unit) ||
-				(changedSystemUnits.has(unit) && !opts.preserveActiveUnits) ||
+			((changedSystemUnits.has(unit) && !opts.preserveActiveUnits) ||
 				(forcedRestartUnits.has(unit) &&
 					(!addedSystemUnits.has(unit) || unit === RUNTIME_SIDECAR_SYSTEM_UNIT)))
 		) {
@@ -789,8 +781,7 @@ export function applySystemdRuntimeUpdate(
 		return (
 			state.loadState !== "not-found" &&
 			state.activeState === "active" &&
-			!state.needDaemonReload &&
-			(unit === RUNTIME_WATCH_SYSTEM_UNIT || systemdProcessRevisionMatches(paths, unit, state))
+			!state.needDaemonReload
 		);
 	});
 	const userConverged = user.present.every((unit) => {

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -933,10 +933,17 @@ function systemdProcessRevisionMatches(
 		const procDir = `/proc/${state.mainPid}`;
 		const owner = statSync(procDir);
 		const readEnvironment = () => readFileSync(join(procDir, "environ"));
-		const environment =
-			owner.uid === 0
-				? readEnvironment()
-				: withEffectiveFilesystemIdentity({ uid: owner.uid, gid: owner.gid }, readEnvironment);
+		let environment: Buffer;
+		try {
+			environment = readEnvironment();
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code;
+			if (owner.uid === 0 || (code !== "EACCES" && code !== "EPERM")) throw error;
+			environment = withEffectiveFilesystemIdentity(
+				{ uid: owner.uid, gid: owner.gid },
+				readEnvironment,
+			);
+		}
 		processRevision = runtimeRevisionFromProcessEnvironment(environment);
 	} catch (error) {
 		throw new Error(`could not prove active runtime revision for managed systemd unit ${unit}`, {

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -485,6 +485,7 @@ export interface SystemdUnitSnapshot {
 interface SystemdUnitManagerState {
 	loadState: string;
 	activeState: string;
+	needDaemonReload: boolean;
 	enabledState?: string;
 }
 
@@ -633,6 +634,26 @@ export function applySystemdRuntimeUpdate(
 			userUnitsChanged: [...userUnitsChanged].sort(),
 		};
 	}
+	const systemManagerNeedsReload = new Set(
+		system.present.filter(
+			(unit) => systemdUnitManagerState(paths, "system", unit).needDaemonReload,
+		),
+	);
+	const userManagerNeedsReload = new Set(
+		user.present.filter((unit) => systemdUnitManagerState(paths, "user", unit).needDaemonReload),
+	);
+	const changedSystemUnits = new Set(system.changed);
+	const changedUserUnits = new Set(user.changed);
+	const preExistingStaleSystemUnits = new Set(
+		[...systemManagerNeedsReload].filter(
+			(unit) => !changedSystemUnits.has(unit) && !system.added.includes(unit),
+		),
+	);
+	const preExistingStaleUserUnits = new Set(
+		[...userManagerNeedsReload].filter(
+			(unit) => !changedUserUnits.has(unit) && !user.added.includes(unit),
+		),
+	);
 
 	for (const unit of system.removed) {
 		const state = systemdUnitManagerState(paths, "system", unit);
@@ -652,15 +673,24 @@ export function applySystemdRuntimeUpdate(
 		}
 	}
 
-	if (system.added.length > 0 || system.changed.length > 0 || system.removed.length > 0) {
+	if (
+		system.added.length > 0 ||
+		system.changed.length > 0 ||
+		system.removed.length > 0 ||
+		systemManagerNeedsReload.size > 0
+	) {
 		systemctl(["daemon-reload"]);
 	}
-	if (user.added.length > 0 || user.changed.length > 0 || user.removed.length > 0) {
+	if (
+		user.added.length > 0 ||
+		user.changed.length > 0 ||
+		user.removed.length > 0 ||
+		userManagerNeedsReload.size > 0
+	) {
 		runtimeUserSystemctl(paths, ["daemon-reload"]);
 	}
 
 	const addedSystemUnits = new Set(system.added);
-	const changedSystemUnits = new Set(system.changed);
 	const forcedRestartUnits = new Set(forcedSystemRestarts);
 	const forcedStopUnits = new Set(forcedSystemStops);
 	const skipActivatedSystemUnits = new Set(opts.skipActivatedSystemUnits ?? []);
@@ -685,7 +715,8 @@ export function applySystemdRuntimeUpdate(
 		if (
 			state.activeState === "active" &&
 			unit !== RUNTIME_WATCH_SYSTEM_UNIT &&
-			((changedSystemUnits.has(unit) && !opts.preserveActiveUnits) ||
+			(preExistingStaleSystemUnits.has(unit) ||
+				(changedSystemUnits.has(unit) && !opts.preserveActiveUnits) ||
 				(forcedRestartUnits.has(unit) &&
 					(!addedSystemUnits.has(unit) || unit === RUNTIME_SIDECAR_SYSTEM_UNIT)))
 		) {
@@ -699,7 +730,6 @@ export function applySystemdRuntimeUpdate(
 	if (startSystemUnits.length > 0) systemctl(["start", ...startSystemUnits]);
 	if (restartSystemUnits.length > 0) systemctl(["restart", ...restartSystemUnits]);
 
-	const changedUserUnits = new Set(user.changed);
 	const resetFailedUserUnits: string[] = [];
 	const startUserUnits: string[] = [];
 	const enableUserUnits: string[] = [];
@@ -726,7 +756,10 @@ export function applySystemdRuntimeUpdate(
 			enableUserUnits.push(unit);
 			userUnitsChanged.add(unit);
 		}
-		if (changedUserUnits.has(unit) && !opts.preserveActiveUnits) {
+		if (
+			preExistingStaleUserUnits.has(unit) ||
+			(changedUserUnits.has(unit) && !opts.preserveActiveUnits)
+		) {
 			restartUserUnits.push(unit);
 			userUnitsChanged.add(unit);
 		}
@@ -744,12 +777,17 @@ export function applySystemdRuntimeUpdate(
 	const systemConverged = system.present.every((unit) => {
 		const state = systemdUnitManagerState(paths, "system", unit);
 		if (forcedStopUnits.has(unit)) return systemdUnitAbsentOrInactive(state);
-		return state.loadState !== "not-found" && state.activeState === "active";
+		return (
+			state.loadState !== "not-found" && state.activeState === "active" && !state.needDaemonReload
+		);
 	});
 	const userConverged = user.present.every((unit) => {
 		const state = systemdUnitManagerState(paths, "user", unit);
 		return (
-			state.loadState !== "not-found" && state.activeState === "active" && systemdUnitEnabled(state)
+			state.loadState !== "not-found" &&
+			state.activeState === "active" &&
+			!state.needDaemonReload &&
+			systemdUnitEnabled(state)
 		);
 	});
 	const removedSystemConverged = system.removed.every(
@@ -788,7 +826,13 @@ function systemdUnitManagerState(
 	scope: "system" | "user",
 	unit: string,
 ): SystemdUnitManagerState {
-	const showArgs = ["show", unit, "--property=LoadState", "--property=ActiveState"];
+	const showArgs = [
+		"show",
+		unit,
+		"--property=LoadState",
+		"--property=ActiveState",
+		"--property=NeedDaemonReload",
+	];
 	const show =
 		scope === "system" ? systemctlResult(showArgs) : runtimeUserSystemctlResult(paths, showArgs);
 	assertCommandSucceeded(scope === "system" ? systemctlPath() : "systemctl --user", showArgs, show);
@@ -804,10 +848,17 @@ function systemdUnitManagerState(
 	);
 	const loadState = properties.LoadState;
 	const activeState = properties.ActiveState;
-	if (!loadState || !activeState) {
+	const needDaemonReload = properties.NeedDaemonReload;
+	if (!loadState || !activeState || !needDaemonReload) {
 		throw new Error(`systemd ${scope} unit ${unit} returned incomplete manager state`);
 	}
-	if (scope === "system") return { loadState, activeState };
+	if (needDaemonReload !== "yes" && needDaemonReload !== "no") {
+		throw new Error(
+			`systemd ${scope} unit ${unit} returned invalid NeedDaemonReload: ${needDaemonReload}`,
+		);
+	}
+	const managerState = { loadState, activeState, needDaemonReload: needDaemonReload === "yes" };
+	if (scope === "system") return managerState;
 
 	const enabledArgs = ["is-enabled", unit];
 	const enabled = runtimeUserSystemctlResult(paths, enabledArgs);
@@ -816,7 +867,7 @@ function systemdUnitManagerState(
 		assertCommandSucceeded("systemctl --user", enabledArgs, enabled);
 		throw new Error(`systemd user unit ${unit} returned unknown enabled state: ${enabledState}`);
 	}
-	return { loadState, activeState, enabledState };
+	return { ...managerState, enabledState };
 }
 
 const SYSTEMD_ENABLED_STATES = new Set([

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -779,9 +779,7 @@ export function applySystemdRuntimeUpdate(
 		const state = systemdUnitManagerState(paths, "system", unit);
 		if (forcedStopUnits.has(unit)) return systemdUnitAbsentOrInactive(state);
 		return (
-			state.loadState !== "not-found" &&
-			state.activeState === "active" &&
-			!state.needDaemonReload
+			state.loadState !== "not-found" && state.activeState === "active" && !state.needDaemonReload
 		);
 	});
 	const userConverged = user.present.every((unit) => {

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -8,10 +8,12 @@ import {
 	existsSync,
 	readdirSync,
 	readFileSync,
+	statSync,
 } from "node:fs";
 import { join } from "node:path";
 import chalk from "chalk";
 import { z } from "zod";
+import { parseDotenv } from "../lib/dotenv";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { getCliVersion } from "../lib/version";
 import {
@@ -40,6 +42,7 @@ import {
 	rollbackPendingRuntimeCliUpgrade,
 } from "../runtime/cli-update";
 import { withRuntimeConvergeLockAsync } from "../runtime/converge-lock";
+import { withEffectiveFilesystemIdentity } from "../runtime/effective-identity";
 import { buildEgressEngineEnv, SYSTEM_CA_BUNDLE } from "../runtime/egress-env";
 import { readHostPolicy } from "../runtime/host-policy";
 import {
@@ -66,6 +69,7 @@ import {
 	type RuntimeManifestLoad,
 } from "../runtime/manifest-source";
 import { detectRuntimeMode, getRuntimePaths, type RuntimePaths } from "../runtime/paths";
+import { systemdEnvironmentFilePath } from "../runtime/runtime-systemd-reconciliation";
 import {
 	buildNumericUserCommand,
 	buildRuntimeUserCommand,
@@ -485,6 +489,7 @@ export interface SystemdUnitSnapshot {
 interface SystemdUnitManagerState {
 	loadState: string;
 	activeState: string;
+	mainPid: number;
 	needDaemonReload: boolean;
 	enabledState?: string;
 }
@@ -499,6 +504,7 @@ interface CommandResult {
 const RUNTIME_WATCH_SYSTEM_UNIT = "clawdi-runtime-watch.service";
 const RUNTIME_DAEMON_SYSTEM_UNIT = "clawdi-daemon.service";
 const RUNTIME_SIDECAR_SYSTEM_UNIT = "clawdi-runtime-sidecar.service";
+const RUNTIME_REVISION_RE = /^[a-f0-9]{32}$/;
 
 export function readSystemdUnitSnapshot(
 	paths: ReturnType<typeof getRuntimePaths>,
@@ -644,15 +650,18 @@ export function applySystemdRuntimeUpdate(
 	);
 	const changedSystemUnits = new Set(system.changed);
 	const changedUserUnits = new Set(user.changed);
-	const preExistingStaleSystemUnits = new Set(
-		[...systemManagerNeedsReload].filter(
-			(unit) => !changedSystemUnits.has(unit) && !system.added.includes(unit),
-		),
+	const systemProcessRevisionDrift = new Set(
+		system.present.filter((unit) => {
+			if (unit === RUNTIME_WATCH_SYSTEM_UNIT) return false;
+			const state = systemdUnitManagerState(paths, "system", unit);
+			return state.activeState === "active" && !systemdProcessRevisionMatches(paths, unit, state);
+		}),
 	);
-	const preExistingStaleUserUnits = new Set(
-		[...userManagerNeedsReload].filter(
-			(unit) => !changedUserUnits.has(unit) && !user.added.includes(unit),
-		),
+	const userProcessRevisionDrift = new Set(
+		user.present.filter((unit) => {
+			const state = systemdUnitManagerState(paths, "user", unit);
+			return state.activeState === "active" && !systemdProcessRevisionMatches(paths, unit, state);
+		}),
 	);
 
 	for (const unit of system.removed) {
@@ -715,7 +724,7 @@ export function applySystemdRuntimeUpdate(
 		if (
 			state.activeState === "active" &&
 			unit !== RUNTIME_WATCH_SYSTEM_UNIT &&
-			(preExistingStaleSystemUnits.has(unit) ||
+			(systemProcessRevisionDrift.has(unit) ||
 				(changedSystemUnits.has(unit) && !opts.preserveActiveUnits) ||
 				(forcedRestartUnits.has(unit) &&
 					(!addedSystemUnits.has(unit) || unit === RUNTIME_SIDECAR_SYSTEM_UNIT)))
@@ -757,7 +766,7 @@ export function applySystemdRuntimeUpdate(
 			userUnitsChanged.add(unit);
 		}
 		if (
-			preExistingStaleUserUnits.has(unit) ||
+			userProcessRevisionDrift.has(unit) ||
 			(changedUserUnits.has(unit) && !opts.preserveActiveUnits)
 		) {
 			restartUserUnits.push(unit);
@@ -778,7 +787,10 @@ export function applySystemdRuntimeUpdate(
 		const state = systemdUnitManagerState(paths, "system", unit);
 		if (forcedStopUnits.has(unit)) return systemdUnitAbsentOrInactive(state);
 		return (
-			state.loadState !== "not-found" && state.activeState === "active" && !state.needDaemonReload
+			state.loadState !== "not-found" &&
+			state.activeState === "active" &&
+			!state.needDaemonReload &&
+			(unit === RUNTIME_WATCH_SYSTEM_UNIT || systemdProcessRevisionMatches(paths, unit, state))
 		);
 	});
 	const userConverged = user.present.every((unit) => {
@@ -787,7 +799,8 @@ export function applySystemdRuntimeUpdate(
 			state.loadState !== "not-found" &&
 			state.activeState === "active" &&
 			!state.needDaemonReload &&
-			systemdUnitEnabled(state)
+			systemdUnitEnabled(state) &&
+			systemdProcessRevisionMatches(paths, unit, state)
 		);
 	});
 	const removedSystemConverged = system.removed.every(
@@ -831,6 +844,7 @@ function systemdUnitManagerState(
 		unit,
 		"--property=LoadState",
 		"--property=ActiveState",
+		"--property=MainPID",
 		"--property=NeedDaemonReload",
 	];
 	const show =
@@ -848,16 +862,29 @@ function systemdUnitManagerState(
 	);
 	const loadState = properties.LoadState;
 	const activeState = properties.ActiveState;
+	const mainPidValue = properties.MainPID;
 	const needDaemonReload = properties.NeedDaemonReload;
-	if (!loadState || !activeState || !needDaemonReload) {
+	if (!loadState || !activeState || mainPidValue === undefined || !needDaemonReload) {
 		throw new Error(`systemd ${scope} unit ${unit} returned incomplete manager state`);
+	}
+	if (!/^(0|[1-9]\d*)$/.test(mainPidValue)) {
+		throw new Error(`systemd ${scope} unit ${unit} returned invalid MainPID`);
+	}
+	const mainPid = Number(mainPidValue);
+	if (!Number.isSafeInteger(mainPid)) {
+		throw new Error(`systemd ${scope} unit ${unit} returned invalid MainPID`);
 	}
 	if (needDaemonReload !== "yes" && needDaemonReload !== "no") {
 		throw new Error(
 			`systemd ${scope} unit ${unit} returned invalid NeedDaemonReload: ${needDaemonReload}`,
 		);
 	}
-	const managerState = { loadState, activeState, needDaemonReload: needDaemonReload === "yes" };
+	const managerState = {
+		loadState,
+		activeState,
+		mainPid,
+		needDaemonReload: needDaemonReload === "yes",
+	};
 	if (scope === "system") return managerState;
 
 	const enabledArgs = ["is-enabled", unit];
@@ -868,6 +895,73 @@ function systemdUnitManagerState(
 		throw new Error(`systemd user unit ${unit} returned unknown enabled state: ${enabledState}`);
 	}
 	return { ...managerState, enabledState };
+}
+
+function systemdProcessRevisionMatches(
+	paths: ReturnType<typeof getRuntimePaths>,
+	unit: string,
+	state: SystemdUnitManagerState,
+): boolean {
+	if (state.mainPid === 0) {
+		throw new Error(`active managed systemd unit ${unit} has no MainPID`);
+	}
+	if (!unit.endsWith(".service")) {
+		throw new Error(`managed systemd unit has invalid name: ${unit}`);
+	}
+	const programName = unit.slice(0, -".service".length);
+	const envPath = systemdEnvironmentFilePath(paths, programName);
+	let desiredRevision: string;
+	try {
+		const content = readFileSync(envPath, "utf8");
+		const parsed = parseDotenv(content).filter(([key]) => key === "CLAWDI_RUNTIME_REV");
+		const declarations = content
+			.split(/\r?\n/)
+			.filter((line) => line.startsWith("CLAWDI_RUNTIME_REV="));
+		const match = /^CLAWDI_RUNTIME_REV="([a-f0-9]{32})"$/.exec(declarations[0] ?? "");
+		if (parsed.length !== 1 || declarations.length !== 1 || !match) {
+			throw new Error("invalid revision declaration");
+		}
+		desiredRevision = match[1];
+	} catch (error) {
+		throw new Error(`could not prove desired runtime revision for managed systemd unit ${unit}`, {
+			cause: error,
+		});
+	}
+
+	let processRevision: string;
+	try {
+		const procDir = `/proc/${state.mainPid}`;
+		const owner = statSync(procDir);
+		const readEnvironment = () => readFileSync(join(procDir, "environ"));
+		const environment =
+			owner.uid === 0
+				? readEnvironment()
+				: withEffectiveFilesystemIdentity({ uid: owner.uid, gid: owner.gid }, readEnvironment);
+		processRevision = runtimeRevisionFromProcessEnvironment(environment);
+	} catch (error) {
+		throw new Error(`could not prove active runtime revision for managed systemd unit ${unit}`, {
+			cause: error,
+		});
+	}
+	return processRevision === desiredRevision;
+}
+
+function runtimeRevisionFromProcessEnvironment(environment: Buffer): string {
+	const prefix = Buffer.from("CLAWDI_RUNTIME_REV=");
+	const revisions: string[] = [];
+	for (let start = 0; start < environment.length; ) {
+		const separator = environment.indexOf(0, start);
+		const end = separator < 0 ? environment.length : separator;
+		const entry = environment.subarray(start, end);
+		if (entry.subarray(0, prefix.length).equals(prefix)) {
+			revisions.push(entry.subarray(prefix.length).toString("ascii"));
+		}
+		start = end + 1;
+	}
+	if (revisions.length !== 1 || !RUNTIME_REVISION_RE.test(revisions[0])) {
+		throw new Error("invalid revision entry");
+	}
+	return revisions[0];
 }
 
 const SYSTEMD_ENABLED_STATES = new Set([

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -6,6 +6,7 @@ import type { RuntimeBundleChannelBinding, RuntimeManifestLoad } from "./manifes
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { hostedRuntimeProjectionHome } from "./projection-home";
 import { runtimeSecretValue } from "./secret-values";
+import { managedWhatsAppAuthCredentials } from "./whatsapp-credential-projection";
 import { buildManagedWhatsAppEgressProfiles } from "./whatsapp-egress";
 import {
 	CLAWDI_MANAGED_WHATSAPP_SOCKET_METADATA_KEY,
@@ -629,7 +630,11 @@ function managedWhatsAppSecretValues(
 	channelCredentials: unknown,
 ): Record<string, string> {
 	const values: Record<string, string> = {};
-	const projectedCredentialSecrets = projectedWhatsAppCredentialSecretRefs(channelCredentials);
+	const projectedCredentialSecrets = new Set(
+		managedWhatsAppAuthCredentials(channelCredentials).map(
+			(credential) => credential.credsJsonSecretRef,
+		),
+	);
 	for (const link of links) {
 		const material = whatsappBaileysCredentialMaterial(link);
 		if (material) {
@@ -640,26 +645,6 @@ function managedWhatsAppSecretValues(
 		}
 	}
 	return values;
-}
-
-function projectedWhatsAppCredentialSecretRefs(channelCredentials: unknown): Set<string> {
-	const refs = new Set<string>();
-	if (!Array.isArray(channelCredentials)) return refs;
-	for (const credential of channelCredentials) {
-		const record = recordValue(credential);
-		if (record?.provider !== "whatsapp" || record.kind !== "whatsapp_baileys_auth_state") {
-			continue;
-		}
-		const files = Array.isArray(record.files) ? record.files : [];
-		for (const file of files) {
-			const fileRecord = recordValue(file);
-			const secretRef = stringValue(fileRecord?.secretRef);
-			if (fileRecord?.path === "creds.json" && secretRef) {
-				refs.add(secretRef);
-			}
-		}
-	}
-	return refs;
 }
 
 function whatsappAgentTokenSecretRef(accountKey: string, linkId: string): string {
@@ -789,10 +774,6 @@ function runtimeCredentialTargets(manifest: RuntimeManifest): RuntimeCredentialT
 function recordValue(value: unknown): Record<string, unknown> | null {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
 	return value as Record<string, unknown>;
-}
-
-function stringValue(value: unknown): string | null {
-	return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
 function stripTrailingSlash(value: string): string {

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -35,6 +35,7 @@ import {
 	normalizeSecretValues,
 	runtimeSecretValue,
 } from "./secret-values";
+import { managedWhatsAppAuthCredentials } from "./whatsapp-credential-projection";
 
 export interface RuntimeManifestLoad {
 	manifest: RuntimeManifest;
@@ -934,6 +935,11 @@ export function manifestSecretRefs(manifest: RuntimeManifest): string[] {
 	}
 	if (hasEnabledRuntime) {
 		for (const ref of egressProfileSecretRefs(manifest.egressProfiles)) refs.add(ref);
+		for (const credential of managedWhatsAppAuthCredentials(
+			manifest.projection?.channelCredentials,
+		)) {
+			refs.add(credential.credsJsonSecretRef);
+		}
 	}
 	return [...refs].sort();
 }

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -230,6 +230,10 @@ import {
 	TRANSPARENT_EGRESS_TRANSPORT_VERSION,
 } from "./transparent-egress";
 import {
+	type ManagedWhatsAppAuthCredential,
+	managedWhatsAppAuthCredentials,
+} from "./whatsapp-credential-projection";
+import {
 	CLAWDI_MANAGED_WHATSAPP_SOCKET_METADATA_KEY,
 	parseManagedWhatsAppSocketMetadataJson,
 } from "./whatsapp-upstream-contract";
@@ -475,14 +479,6 @@ function omitSecretRefs(
 	return normalized;
 }
 
-interface ManagedWhatsAppAuthCredential {
-	accountKey: string;
-	credentialId: string;
-	authDir: string;
-	credsJsonSecretRef: string;
-	target: "openclaw" | "hermes" | "legacy";
-}
-
 const MANAGED_WHATSAPP_AUTH_MARKER = ".clawdi-managed-whatsapp-auth.json";
 
 export function materializeHostedChannelCredentials(
@@ -581,62 +577,7 @@ function hostedChannelCredentialsDeclared(manifest: RuntimeManifest): boolean {
 }
 
 function hostedWhatsAppAuthCredentials(manifest: RuntimeManifest): ManagedWhatsAppAuthCredential[] {
-	const raw = manifest.projection?.channelCredentials;
-	if (!Array.isArray(raw)) return [];
-	return raw
-		.flatMap(parseManagedWhatsAppAuthCredentials)
-		.filter((entry): entry is ManagedWhatsAppAuthCredential => entry !== null)
-		.sort((left, right) =>
-			`${left.target}:${left.accountKey}:${left.credentialId}`.localeCompare(
-				`${right.target}:${right.accountKey}:${right.credentialId}`,
-			),
-		);
-}
-
-function parseManagedWhatsAppAuthCredentials(value: unknown): ManagedWhatsAppAuthCredential[] {
-	const record = recordValue(value);
-	if (!record) return [];
-	if (record.provider !== "whatsapp" || record.kind !== "whatsapp_baileys_auth_state") return [];
-	const accountKey = stringValue(record.accountKey);
-	const credentialId = stringValue(record.credentialId);
-	const files = Array.isArray(record.files) ? record.files : [];
-	const credsFile = files
-		.map(recordValue)
-		.find((file) => file?.path === "creds.json" && typeof file.secretRef === "string");
-	const credsJsonSecretRef = credsFile ? stringValue(credsFile.secretRef) : null;
-	if (!accountKey || !credentialId || !credsJsonSecretRef) {
-		throw new Error("WhatsApp auth credential projection is incomplete");
-	}
-	const targets = recordValue(record.targets);
-	const parsedTargets: ManagedWhatsAppAuthCredential[] = [];
-	const openclawTarget = targets ? recordValue(targets.openclaw) : null;
-	const openclawAuthDir = targets
-		? stringValue(openclawTarget?.authDir)
-		: stringValue(record.authDir);
-	if (openclawAuthDir) {
-		parsedTargets.push({
-			accountKey,
-			credentialId,
-			authDir: openclawAuthDir,
-			credsJsonSecretRef,
-			target: targets ? "openclaw" : "legacy",
-		});
-	}
-	const hermesTarget = targets ? recordValue(targets.hermes) : null;
-	const hermesAuthDir = hermesTarget ? stringValue(hermesTarget.authDir) : null;
-	if (hermesAuthDir) {
-		parsedTargets.push({
-			accountKey,
-			credentialId,
-			authDir: hermesAuthDir,
-			credsJsonSecretRef,
-			target: "hermes",
-		});
-	}
-	if (parsedTargets.length === 0) {
-		throw new Error("WhatsApp auth credential projection is incomplete");
-	}
-	return parsedTargets;
+	return managedWhatsAppAuthCredentials(manifest.projection?.channelCredentials);
 }
 
 function materializeManagedWhatsAppAuthDir(

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
 	chmodSync,
+	chownSync,
 	existsSync,
 	lstatSync,
 	readdirSync,
@@ -44,6 +45,7 @@ import {
 	executableExists,
 	makeRuntimeUserOwned,
 	RuntimeUserCommandTimeoutError,
+	runningAsRoot,
 	runRuntimeUserCommand,
 	runtimeEgressGid,
 	runtimeEgressUid,
@@ -746,24 +748,43 @@ function writeSystemdEnvironmentFile(input: {
 			return `${key}=${systemdEnvironmentFileQuote(value)}`;
 		});
 	const content = `${GENERATED_RUNTIME_SYSTEMD_FILE_HEADER}\n${lines.join("\n")}\n`;
+	writeSystemdManagedFile({
+		path,
+		content,
+		mode: 0o600,
+		dirMode: 0o711,
+		trustedRoot: input.paths.runRoot,
+		owner: input.owner,
+	});
+	return path;
+}
+
+function writeSystemdManagedFile(input: {
+	path: string;
+	content: string;
+	mode: number;
+	dirMode: number;
+	trustedRoot: string;
+	owner: "root" | "runtime-user";
+}): void {
 	let unchanged = false;
 	try {
-		const current = lstatSync(path);
-		unchanged = current.isFile() && current.nlink === 1 && readFileSync(path, "utf8") === content;
+		const current = lstatSync(input.path);
+		unchanged =
+			current.isFile() && current.nlink === 1 && readFileSync(input.path, "utf8") === input.content;
 	} catch {
 		// A missing or unreadable target is replaced by the trusted atomic writer below.
 	}
-	if (!unchanged) {
-		writePrivateFileAtomic(path, content, {
-			mode: 0o600,
-			dirMode: 0o711,
-			trustedRoot: input.paths.runRoot,
+	if (unchanged) chmodSync(input.path, input.mode);
+	else {
+		writePrivateFileAtomic(input.path, input.content, {
+			mode: input.mode,
+			dirMode: input.dirMode,
+			trustedRoot: input.trustedRoot,
 		});
-	} else {
-		chmodSync(path, 0o600);
 	}
-	if (input.owner === "runtime-user") makeRuntimeUserOwned(path);
-	return path;
+	if (input.owner === "runtime-user") makeRuntimeUserOwned(input.path);
+	else if (runningAsRoot()) chownSync(input.path, 0, 0);
 }
 
 function writeSystemdProgramEnvironment(input: {
@@ -861,12 +882,14 @@ function writeSystemdUnit(input: {
 	const writeUnitFile = (): string => {
 		ensureDirectoryWithinTrustedRoot(input.root, input.root);
 		if (input.owner === "runtime-user") makeRuntimeUserOwned(input.root);
-		writePrivateFileAtomic(path, `${lines.join("\n")}`, {
+		writeSystemdManagedFile({
+			path,
+			content: lines.join("\n"),
 			mode: 0o644,
 			dirMode: 0o755,
 			trustedRoot: input.root,
+			owner: input.owner,
 		});
-		if (input.owner === "runtime-user") makeRuntimeUserOwned(path);
 		return path;
 	};
 	return input.owner === "runtime-user"
@@ -939,12 +962,14 @@ function writeSystemdUserDropIn(input: {
 		removeGeneratedRuntimeBaseUnit(input.paths, unitName);
 		ensureDirectoryWithinTrustedRoot(input.paths.systemdUserRoot, dirname(path));
 		makeRuntimeUserOwned(dirname(path));
-		writePrivateFileAtomic(path, `${lines.join("\n")}`, {
+		writeSystemdManagedFile({
+			path,
+			content: lines.join("\n"),
 			mode: 0o644,
 			dirMode: 0o755,
 			trustedRoot: input.paths.systemdUserRoot,
+			owner: "runtime-user",
 		});
-		makeRuntimeUserOwned(path);
 		return join(input.paths.systemdUserRoot, unitName);
 	});
 }

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -346,7 +346,7 @@ function systemdUnitEnvironmentLines(values: Record<string, string>): string[] {
 	);
 }
 
-function systemdEnvironmentFilePath(paths: RuntimePaths, unitName: string): string {
+export function systemdEnvironmentFilePath(paths: RuntimePaths, unitName: string): string {
 	return join(paths.systemdEnvRoot, `${systemdUnitFileName(unitName)}.env`);
 }
 

--- a/packages/cli/src/runtime/whatsapp-credential-projection.ts
+++ b/packages/cli/src/runtime/whatsapp-credential-projection.ts
@@ -1,0 +1,76 @@
+export interface ManagedWhatsAppAuthCredential {
+	accountKey: string;
+	credentialId: string;
+	authDir: string;
+	credsJsonSecretRef: string;
+	target: "openclaw" | "hermes" | "legacy";
+}
+
+export function managedWhatsAppAuthCredentials(
+	channelCredentials: unknown,
+): ManagedWhatsAppAuthCredential[] {
+	if (!Array.isArray(channelCredentials)) return [];
+	return channelCredentials
+		.flatMap(parseManagedWhatsAppAuthCredential)
+		.sort((left, right) =>
+			`${left.target}:${left.accountKey}:${left.credentialId}`.localeCompare(
+				`${right.target}:${right.accountKey}:${right.credentialId}`,
+			),
+		);
+}
+
+function parseManagedWhatsAppAuthCredential(value: unknown): ManagedWhatsAppAuthCredential[] {
+	const record = recordValue(value);
+	if (!record) return [];
+	if (record.provider !== "whatsapp" || record.kind !== "whatsapp_baileys_auth_state") return [];
+	const accountKey = stringValue(record.accountKey);
+	const credentialId = stringValue(record.credentialId);
+	const files = Array.isArray(record.files) ? record.files : [];
+	const credsFile = files
+		.map(recordValue)
+		.find((file) => file?.path === "creds.json" && typeof file.secretRef === "string");
+	const credsJsonSecretRef = credsFile ? stringValue(credsFile.secretRef) : null;
+	if (!accountKey || !credentialId || !credsJsonSecretRef) {
+		throw new Error("WhatsApp auth credential projection is incomplete");
+	}
+	const targets = recordValue(record.targets);
+	const credentials: ManagedWhatsAppAuthCredential[] = [];
+	const openclawTarget = targets ? recordValue(targets.openclaw) : null;
+	const openclawAuthDir = targets
+		? stringValue(openclawTarget?.authDir)
+		: stringValue(record.authDir);
+	if (openclawAuthDir) {
+		credentials.push({
+			accountKey,
+			credentialId,
+			authDir: openclawAuthDir,
+			credsJsonSecretRef,
+			target: targets ? "openclaw" : "legacy",
+		});
+	}
+	const hermesTarget = targets ? recordValue(targets.hermes) : null;
+	const hermesAuthDir = hermesTarget ? stringValue(hermesTarget.authDir) : null;
+	if (hermesAuthDir) {
+		credentials.push({
+			accountKey,
+			credentialId,
+			authDir: hermesAuthDir,
+			credsJsonSecretRef,
+			target: "hermes",
+		});
+	}
+	if (credentials.length === 0) {
+		throw new Error("WhatsApp auth credential projection is incomplete");
+	}
+	return credentials;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function stringValue(value: unknown): string | null {
+	return typeof value === "string" && value.trim() ? value.trim() : null;
+}

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -1058,6 +1058,35 @@ http.createServer((request, response) => {
 	const mainPid = Number.parseInt(mainPidResult.stdout.trim(), 10);
 	expect(mainPid).toBeGreaterThan(1);
 	expect(statSync(`/proc/${mainPid}`).uid).toBe(runtimeUid);
+	const gatewayMainPidResult = spawnSync(
+		"runuser",
+		[
+			"-u",
+			"clawdi",
+			"--",
+			"env",
+			`HOME=${runtimeHome}`,
+			`XDG_RUNTIME_DIR=/run/user/${runtimeUid}`,
+			`DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${runtimeUid}/bus`,
+			"systemctl",
+			"--user",
+			"show",
+			"openclaw-gateway.service",
+			"--property=MainPID",
+			"--value",
+		],
+		{ encoding: "utf8" },
+	);
+	expect(gatewayMainPidResult.status).toBe(0);
+	const gatewayMainPid = Number.parseInt(gatewayMainPidResult.stdout.trim(), 10);
+	expect(gatewayMainPid).toBeGreaterThan(1);
+	expect(statSync(`/proc/${gatewayMainPid}`).uid).toBe(runtimeUid);
+	const activeUnits = readSystemdUnitSnapshot(paths);
+	expect(
+		applySystemdRuntimeUpdate(paths, activeUnits, activeUnits, {
+			activationScope: { systemUnits: [], userUnits: ["openclaw-gateway.service"] },
+		}),
+	).toEqual({ applied: true, systemUnitsChanged: [], userUnitsChanged: [] });
 	const unitControl = spawnSync(
 		"runuser",
 		["-u", "clawdi", "--", "systemctl", "stop", "clawdi-files.service"],

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -311,7 +311,7 @@ function fakeSystemdStatePath(
 	stateRoot: string,
 	scope: "system" | "user",
 	unit: string,
-	state: "active" | "enabled" | "failed" | "not-found",
+	state: "active" | "enabled" | "failed" | "not-found" | "reload",
 ): string {
 	return join(stateRoot, `${scope}-${unit}.${state}`);
 }
@@ -349,7 +349,9 @@ case "$command" in
     [ ! -f "$(state_path "$unit" active)" ] || active_state=active
     [ ! -f "$(state_path "$unit" failed)" ] || active_state=failed
     if [ -f "$(state_path "$unit" not-found)" ]; then load_state=not-found; active_state=inactive; fi
-    printf 'LoadState=%s\\nActiveState=%s\\n' "$load_state" "$active_state"
+    need_daemon_reload=no
+    [ ! -f "$(state_path "$unit" reload)" ] || need_daemon_reload=yes
+    printf 'LoadState=%s\\nActiveState=%s\\nNeedDaemonReload=%s\\n' "$load_state" "$active_state" "$need_daemon_reload"
     ;;
   is-enabled)
     unit="\${1:-}"
@@ -392,7 +394,7 @@ case "$command" in
     ;;
   disable) for unit in "$@"; do rm -f "$(state_path "$unit" enabled)"; done ;;
   reset-failed) for unit in "$@"; do rm -f "$(state_path "$unit" failed)"; done ;;
-  daemon-reload) ;;
+  daemon-reload) rm -f '${input.stateRoot}'/"$scope"-*.reload ;;
   *)
     printf 'unexpected systemctl command: %s\\n' "$raw" >&2
     exit 64
@@ -1295,7 +1297,7 @@ set -euo pipefail
 ${systemctlLog ? `printf '%s\\n' "$*" >> '${systemctlLog}'` : ""}
 if [ "\${1:-}" = "--user" ]; then shift; fi
 if [ "\${1:-}" = "show" ]; then
-  printf 'LoadState=loaded\\nActiveState=active\\n'
+  printf 'LoadState=loaded\\nActiveState=active\\nNeedDaemonReload=no\\n'
 elif [ "\${1:-}" = "is-enabled" ]; then
   printf 'enabled\\n'
 elif [ "\${1:-}" = "start" ] || [ "\${1:-}" = "restart" ]; then
@@ -6825,7 +6827,7 @@ set -euo pipefail
 printf '%s\\n' "$*" >> '${systemctlLog}'
 if [ "\${1:-}" = "--user" ]; then shift; fi
 if [ "\${1:-}" = "show" ]; then
-  printf 'LoadState=loaded\\nActiveState=active\\n'
+  printf 'LoadState=loaded\\nActiveState=active\\nNeedDaemonReload=no\\n'
 elif [ "\${1:-}" = "is-enabled" ]; then
   printf 'enabled\\n'
 elif [ "\${1:-}" = "start" ] || [ "\${1:-}" = "restart" ]; then
@@ -7130,7 +7132,7 @@ exit 64
 set -euo pipefail
 if [ "\${1:-}" = "--user" ]; then shift; fi
 if [ "\${1:-}" = "show" ]; then
-  printf 'LoadState=loaded\\nActiveState=active\\n'
+  printf 'LoadState=loaded\\nActiveState=active\\nNeedDaemonReload=no\\n'
 elif [ "\${1:-}" = "is-enabled" ]; then
   printf 'enabled\\n'
 elif [ "\${1:-}" = "start" ] || [ "\${1:-}" = "restart" ]; then
@@ -7356,7 +7358,7 @@ set -euo pipefail
 printf '%s\\n' "$*" >> '${systemctlLog}'
 if [ "\${1:-}" = "--user" ]; then shift; fi
 if [ "\${1:-}" = "show" ]; then
-  printf 'LoadState=loaded\\nActiveState=active\\n'
+  printf 'LoadState=loaded\\nActiveState=active\\nNeedDaemonReload=no\\n'
 elif [ "\${1:-}" = "is-enabled" ]; then
   printf 'enabled\\n'
 elif [ "\${1:-}" = "start" ] || [ "\${1:-}" = "restart" ]; then
@@ -7726,7 +7728,7 @@ fi
 set -euo pipefail
 if [ "\${1:-}" = "--user" ]; then shift; fi
 if [ "\${1:-}" = "show" ]; then
-  printf 'LoadState=loaded\\nActiveState=active\\n'
+  printf 'LoadState=loaded\\nActiveState=active\\nNeedDaemonReload=no\\n'
 elif [ "\${1:-}" = "is-enabled" ]; then
   printf 'enabled\\n'
 elif { [ "\${1:-}" = "start" ] || [ "\${1:-}" = "restart" ]; } && [[ " $* " = *" clawdi-runtime-sidecar.service "* ]] && [ -f '${failNextSidecarActivation}' ]; then
@@ -8797,20 +8799,12 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		const run = join(root, "run", "clawdi");
 		const systemctlPath = join(root, "bin", "systemctl");
 		const systemctlLog = join(root, "systemctl.log");
-		mkdirSync(dirname(systemctlPath), { recursive: true });
-		writeFileSync(
-			systemctlPath,
-			`#!/usr/bin/env bash
-printf '%s\\n' "$*" >> '${systemctlLog}'
-if [ "\${1:-}" = "--user" ]; then shift; fi
-if [ "\${1:-}" = "show" ]; then
-  printf 'LoadState=loaded\\nActiveState=active\\n'
-elif [ "\${1:-}" = "is-enabled" ]; then
-  printf 'enabled\\n'
-fi
-`,
-		);
-		chmodSync(systemctlPath, 0o700);
+		const systemctlStateRoot = join(root, "systemctl-cli-only-state");
+		writeFakeSystemdManager({
+			path: systemctlPath,
+			logPath: systemctlLog,
+			stateRoot: systemctlStateRoot,
+		});
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
@@ -8822,6 +8816,10 @@ fi
 		seedOpenClawBinary(home);
 		const paths = getRuntimePaths();
 		const current = runtimeWatchLocaleManifest(home, 10);
+		const runtimeAuthSecret = {
+			"secret://clawdi/auth-token":
+				TEST_RUNTIME_SERVICE_SECRET_VALUES["secret://clawdi/auth-token"],
+		};
 		expect(
 			convergeRuntimeManifest(
 				{
@@ -8829,11 +8827,16 @@ fi
 					source: "remote-datasource",
 					sourcePath: "test://cli-current",
 					offline: false,
+					secretValues: runtimeAuthSecret,
 				},
 				paths,
 			).installErrors,
 		).toEqual([]);
 		const before = readSystemdUnitSnapshot(paths);
+		const unchangedUnitInodes = [
+			join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"),
+			join(paths.systemdUserRoot, "openclaw-gateway.service.d", "10-clawdi-hosted.conf"),
+		].map((path) => statSync(path).ino);
 		const next: RuntimeManifest = {
 			...current,
 			generation: 11,
@@ -8850,10 +8853,25 @@ fi
 					source: "remote-datasource",
 					sourcePath: "test://cli-next",
 					offline: false,
+					secretValues: runtimeAuthSecret,
 				},
 				paths,
 			).installErrors,
 		).toEqual([]);
+		expect(
+			[
+				join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"),
+				join(paths.systemdUserRoot, "openclaw-gateway.service.d", "10-clawdi-hosted.conf"),
+			].map((path) => statSync(path).ino),
+		).toEqual(unchangedUnitInodes);
+		for (const unit of before.system.keys()) {
+			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "system", unit, "active"), "\n");
+		}
+		for (const unit of before.user.keys()) {
+			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "active"), "\n");
+			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "enabled"), "\n");
+		}
+		writeFileSync(systemctlLog, "");
 
 		const applied = applySystemdRuntimeUpdate(paths, before, readSystemdUnitSnapshot(paths));
 
@@ -8863,9 +8881,74 @@ fi
 			userUnitsChanged: [],
 		});
 		const calls = readFileSync(systemctlLog, "utf-8");
+		expect(calls).not.toContain("daemon-reload");
 		expect(calls).not.toContain("restart clawdi-daemon.service");
 		expect(calls).not.toContain("restart openclaw-gateway.service");
 		expect(calls).not.toContain("restart clawdi-runtime-sidecar.service");
+
+		const currentCheckpointUnits = {
+			system: new Map<string, string>(),
+			user: new Map([["hermes-gateway.service", "current"]]),
+		};
+		writeFileSync(
+			fakeSystemdStatePath(systemctlStateRoot, "user", "hermes-gateway.service", "active"),
+			"\n",
+		);
+		writeFileSync(
+			fakeSystemdStatePath(systemctlStateRoot, "user", "hermes-gateway.service", "enabled"),
+			"\n",
+		);
+		writeFileSync(
+			fakeSystemdStatePath(systemctlStateRoot, "user", "hermes-gateway.service", "reload"),
+			"\n",
+		);
+		writeFileSync(systemctlLog, "");
+		expect(
+			applySystemdRuntimeUpdate(
+				paths,
+				{
+					system: new Map<string, string>(),
+					user: new Map([["hermes-gateway.service", "legacy"]]),
+				},
+				currentCheckpointUnits,
+				{ preserveActiveUnits: true },
+			),
+		).toEqual({ applied: true, systemUnitsChanged: [], userUnitsChanged: [] });
+		const currentCheckpointCalls = readFileSync(systemctlLog, "utf-8");
+		expect(currentCheckpointCalls).toContain("--user daemon-reload");
+		expect(currentCheckpointCalls).not.toContain("restart hermes-gateway.service");
+
+		const driftedUnits = {
+			system: new Map([["clawdi-runtime-watch.service", "watch"]]),
+			user: new Map([["hermes-gateway.service", "hermes"]]),
+		};
+		for (const [scope, unit] of [
+			["system", "clawdi-runtime-watch.service"],
+			["user", "hermes-gateway.service"],
+		] as const) {
+			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, scope, unit, "active"), "\n");
+			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, scope, unit, "reload"), "\n");
+		}
+		writeFileSync(
+			fakeSystemdStatePath(systemctlStateRoot, "user", "hermes-gateway.service", "enabled"),
+			"\n",
+		);
+		writeFileSync(systemctlLog, "");
+
+		expect(
+			applySystemdRuntimeUpdate(paths, driftedUnits, driftedUnits, {
+				preserveActiveUnits: true,
+			}),
+		).toEqual({
+			applied: true,
+			systemUnitsChanged: [],
+			userUnitsChanged: ["hermes-gateway.service"],
+		});
+		const driftRepairCalls = readFileSync(systemctlLog, "utf-8");
+		expect(driftRepairCalls).toContain("daemon-reload");
+		expect(driftRepairCalls).toContain("--user daemon-reload");
+		expect(driftRepairCalls).toContain("--user restart hermes-gateway.service");
+		expect(driftRepairCalls).not.toContain("restart clawdi-runtime-watch.service");
 	});
 
 	it("stops the egress sidecar while proving independent system units ready", () => {
@@ -8883,7 +8966,7 @@ fi
 set -euo pipefail
 printf '%s\\n' "$*" >> '${systemctlLog}'
 if [ "\${1:-}" = "show" ]; then
-  printf 'LoadState=loaded\\n'
+  printf 'LoadState=loaded\\nNeedDaemonReload=no\\n'
   if [ "\${2:-}" = "clawdi-runtime-sidecar.service" ]; then
     printf 'ActiveState=%s\\n' "$(tr -d '\\n' < '${sidecarState}')"
   else
@@ -9809,7 +9892,7 @@ set -euo pipefail
 printf '%s\\n' "$*" >> '${systemctlLog}'
 if [ "\${1:-}" = "--user" ]; then shift; fi
 if [ "\${1:-}" = "show" ]; then
-  printf 'LoadState=loaded\\nActiveState=active\\n'
+  printf 'LoadState=loaded\\nActiveState=active\\nNeedDaemonReload=no\\n'
 elif [ "\${1:-}" = "is-enabled" ]; then
   printf 'enabled\\n'
 elif [ "\${1:-}" = "start" ] || [ "\${1:-}" = "restart" ]; then
@@ -12829,6 +12912,11 @@ exit 64
 				generation: 14,
 				issuedAt: "2026-07-07T00:00:00Z",
 				controlPlane: { apiUrl: "https://cloud-api.test/" },
+				clawdiCli: {
+					source: "npm:clawdi",
+					packageSpec: "clawdi@0.13.66",
+					registry: "https://registry.npmjs.org",
+				},
 				egressEngine: seedMitmproxyCache(paths),
 				runtimes: {
 					hermes: {
@@ -12939,6 +13027,12 @@ exit 64
 		const initialOpenClawRevision = systemdEnvRevision(
 			readSystemdEnvFile(paths, "openclaw-gateway"),
 		);
+		const hermesDropIn = join(
+			paths.systemdUserRoot,
+			"hermes-gateway.service.d",
+			"10-clawdi-hosted.conf",
+		);
+		const initialHermesDropInInode = statSync(hermesDropIn).ino;
 		const initialUnits = readSystemdUnitSnapshot(paths);
 		for (const unit of initialUnits.system.keys()) {
 			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "system", unit, "active"), "\n");
@@ -12956,6 +13050,7 @@ exit 64
 			paths,
 		);
 		expect(unrelatedSecret.installErrors).toEqual([]);
+		expect(statSync(hermesDropIn).ino).toBe(initialHermesDropInInode);
 		process.env.CLAWDI_SYSTEMD_APPLY = "1";
 		expect(applySystemdRuntimeUpdate(paths, initialUnits, readSystemdUnitSnapshot(paths))).toEqual({
 			applied: true,
@@ -12974,19 +13069,26 @@ exit 64
 		) as Record<string, unknown>;
 		const beforeCredentialChange = readSystemdUnitSnapshot(paths);
 		process.env.CLAWDI_SYSTEMD_APPLY = "0";
-		const changedCredential = convergeRuntimeManifest(
-			{
-				...projected,
-				secretValues: {
-					...projected.secretValues,
-					[credentialSecretRef]: JSON.stringify({
-						...projectedCreds,
-						advSecretKey: "wa-hermes-secret-rotated",
-					}),
+		const changedCheckpoint: RuntimeManifestLoad = {
+			...projected,
+			manifest: {
+				...projected.manifest,
+				clawdiCli: {
+					...projected.manifest.clawdiCli,
+					packageSpec: "clawdi@0.13.67",
 				},
 			},
-			paths,
-		);
+			secretValues: {
+				...projected.secretValues,
+				[credentialSecretRef]: JSON.stringify({
+					...projectedCreds,
+					advSecretKey: "wa-hermes-secret-rotated",
+				}),
+			},
+		};
+		const preserveActiveUnits = runtimeOnlyChangesCliPackage(projected, changedCheckpoint);
+		expect(preserveActiveUnits).toBe(false);
+		const changedCredential = convergeRuntimeManifest(changedCheckpoint, paths);
 		expect(changedCredential.installErrors).toEqual([]);
 		expect(systemdEnvRevision(readSystemdEnvFile(paths, "hermes-gateway"))).not.toBe(
 			initialHermesRevision,
@@ -12997,7 +13099,9 @@ exit 64
 		writeFileSync(systemctlLog, "");
 		process.env.CLAWDI_SYSTEMD_APPLY = "1";
 		expect(
-			applySystemdRuntimeUpdate(paths, beforeCredentialChange, readSystemdUnitSnapshot(paths)),
+			applySystemdRuntimeUpdate(paths, beforeCredentialChange, readSystemdUnitSnapshot(paths), {
+				preserveActiveUnits,
+			}),
 		).toEqual({
 			applied: true,
 			systemUnitsChanged: [],

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -6896,44 +6896,33 @@ exit 64
 		]);
 	});
 
-	it("runtime watch restarts changed runtime and egress units without restarting itself", async () => {
+	it("runtime watch reconciles changed runtime and egress units without restarting itself", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const bin = join(root, "bin");
 		const systemctlLog = join(root, "systemctl-locale.log");
+		const systemctlStateRoot = join(root, "systemctl-locale-state");
 		const sidecarReadyPath = join(run, "egress", "systemd", "ca.pem");
 		const abort = new AbortController();
 		const previousLog = console.log;
 		const logs: string[] = [];
-		mkdirSync(bin, { recursive: true });
-		writeFileSync(
-			join(bin, "systemctl"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\n' "$*" >> '${systemctlLog}'
-if [ "\${1:-}" = "--user" ]; then shift; fi
-if [ "\${1:-}" = "show" ]; then
-  printf 'LoadState=loaded\\nActiveState=active\\nNeedDaemonReload=no\\n'
-elif [ "\${1:-}" = "is-enabled" ]; then
-  printf 'enabled\\n'
-elif [ "\${1:-}" = "start" ] || [ "\${1:-}" = "restart" ]; then
-  shift
-  for unit in "$@"; do
-    if [ "$unit" = "clawdi-runtime-sidecar.service" ]; then
-      mkdir -p '${dirname(sidecarReadyPath)}'
-      touch '${sidecarReadyPath}'
-    fi
-  done
-fi
-exit 0
-`,
-		);
-		chmodSync(join(bin, "systemctl"), 0o700);
+		writeFakeSystemdManager({
+			path: join(bin, "systemctl"),
+			logPath: systemctlLog,
+			stateRoot: systemctlStateRoot,
+			environmentRoot: join(run, "systemd", "env"),
+			sidecarReadyPath,
+		});
 		process.env.CLAWDI_SYSTEMD_APPLY = "1";
 		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
 		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
-		seedRuntimeWatchLocaleBaseline(home, state, run);
+		const paths = seedRuntimeWatchLocaleBaseline(home, state, run);
+		const baselineUnits = readSystemdUnitSnapshot(paths);
+		seedFakeSystemdSnapshotProcesses(paths, systemctlStateRoot, baselineUnits);
+		for (const unit of baselineUnits.user.keys()) {
+			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "enabled"), "\n");
+		}
 		let resolveInitialWatchEvent: (() => void) | null = null;
 		const initialWatchEvent = new Promise<void>((resolveEvent) => {
 			resolveInitialWatchEvent = resolveEvent;
@@ -7014,7 +7003,7 @@ exit 0
 			expect(systemctlCalls).toContain("--user restart openclaw-gateway.service");
 			expect(systemctlCalls).toContain("--user reset-failed openclaw-gateway.service");
 			expect(systemctlCalls.some((call) => call.includes("enable --now"))).toBe(false);
-			expect(systemctlCalls).toContain("restart clawdi-runtime-sidecar.service");
+			expect(systemctlCalls).toContain("start clawdi-runtime-sidecar.service");
 			expect(systemctlCalls).toContain("restart clawdi-daemon.service");
 			expect(systemctlCalls.some((call) => call.includes("restart clawdi-runtime-watch"))).toBe(
 				false,
@@ -7183,7 +7172,6 @@ exit 0
 		const previousLog = console.log;
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
-		mkdirSync(bin, { recursive: true });
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		writeFileSync(
 			openclawBin,
@@ -7213,27 +7201,13 @@ exit 64
 `,
 		);
 		chmodSync(openclawBin, 0o700);
-		writeFileSync(
-			join(bin, "systemctl"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-if [ "\${1:-}" = "--user" ]; then shift; fi
-if [ "\${1:-}" = "show" ]; then
-  printf 'LoadState=loaded\\nActiveState=active\\nNeedDaemonReload=no\\n'
-elif [ "\${1:-}" = "is-enabled" ]; then
-  printf 'enabled\\n'
-elif [ "\${1:-}" = "start" ] || [ "\${1:-}" = "restart" ]; then
-  shift
-  for unit in "$@"; do
-    if [ "$unit" = "clawdi-runtime-sidecar.service" ]; then
-      mkdir -p '${dirname(sidecarReadyPath)}'
-      touch '${sidecarReadyPath}'
-    fi
-  done
-fi
-`,
-		);
-		chmodSync(join(bin, "systemctl"), 0o700);
+		writeFakeSystemdManager({
+			path: join(bin, "systemctl"),
+			logPath: join(root, "systemctl-watch-channel.log"),
+			stateRoot: join(root, "systemctl-watch-channel-state"),
+			environmentRoot: join(run, "systemd", "env"),
+			sidecarReadyPath,
+		});
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
@@ -7437,29 +7411,13 @@ fi
 		let daemonToken = "file-runtime-token";
 		let gatewayToken: string | undefined = "test-openclaw-gateway-token";
 		mkdirSync(join(run, "secrets"), { recursive: true });
-		mkdirSync(dirname(systemctlPath), { recursive: true });
-		writeFileSync(
-			systemctlPath,
-			`#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\n' "$*" >> '${systemctlLog}'
-if [ "\${1:-}" = "--user" ]; then shift; fi
-if [ "\${1:-}" = "show" ]; then
-  printf 'LoadState=loaded\\nActiveState=active\\nNeedDaemonReload=no\\n'
-elif [ "\${1:-}" = "is-enabled" ]; then
-  printf 'enabled\\n'
-elif [ "\${1:-}" = "start" ] || [ "\${1:-}" = "restart" ]; then
-  shift
-  for unit in "$@"; do
-    if [ "$unit" = "clawdi-runtime-sidecar.service" ]; then
-      mkdir -p '${dirname(sidecarReadyPath)}'
-      touch '${sidecarReadyPath}'
-    fi
-  done
-fi
-`,
-		);
-		chmodSync(systemctlPath, 0o700);
+		writeFakeSystemdManager({
+			path: systemctlPath,
+			logPath: systemctlLog,
+			stateRoot: join(root, "systemctl-generation-state"),
+			environmentRoot: join(run, "systemd", "env"),
+			sidecarReadyPath,
+		});
 		seedOfficialOpenClawServiceInstaller(home);
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
@@ -9050,7 +9008,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 set -euo pipefail
 printf '%s\\n' "$*" >> '${systemctlLog}'
 if [ "\${1:-}" = "show" ]; then
-  printf 'LoadState=loaded\\nNeedDaemonReload=no\\n'
+	  printf 'LoadState=loaded\\nMainPID=0\\nNeedDaemonReload=no\\n'
   if [ "\${2:-}" = "clawdi-runtime-sidecar.service" ]; then
     printf 'ActiveState=%s\\n' "$(tr -d '\\n' < '${sidecarState}')"
   else
@@ -9440,8 +9398,7 @@ elif [ "$*" = "${installArgs}" ]; then
   test -s '${join(paths.systemdUserRoot, `${serviceName}.service.d`, "10-clawdi-hosted.conf")}'
   mkdir -p '${dirname(runtimeUnit)}' '${systemctlStateRoot}'
   printf '[Service]\\nExecStart=${runtime} gateway run\\n' > '${runtimeUnit}'
-  touch '${fakeSystemdStatePath(systemctlStateRoot, "user", `${serviceName}.service`, "active")}'
-  touch '${fakeSystemdStatePath(systemctlStateRoot, "user", `${serviceName}.service`, "enabled")}'
+	  systemctl --user enable --now '${serviceName}.service'
 fi
 exit 0
 `,
@@ -9919,12 +9876,12 @@ fi
 	});
 
 	it("runtime watch reapplies transparent egress across CLI self-upgrade", async () => {
-		installSuccessfulSystemctlFixture();
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const bin = join(root, "bin");
 		const systemctlLog = join(root, "systemctl.log");
+		const systemctlStateRoot = join(root, "systemctl-self-upgrade-state");
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
@@ -9971,29 +9928,14 @@ SH
 chmod +x "$prefix/bin/clawdi"
 `,
 		);
-		writeFileSync(
-			join(bin, "systemctl"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\n' "$*" >> '${systemctlLog}'
-if [ "\${1:-}" = "--user" ]; then shift; fi
-if [ "\${1:-}" = "show" ]; then
-  printf 'LoadState=loaded\\nActiveState=active\\nNeedDaemonReload=no\\n'
-elif [ "\${1:-}" = "is-enabled" ]; then
-  printf 'enabled\\n'
-elif [ "\${1:-}" = "start" ] || [ "\${1:-}" = "restart" ]; then
-  shift
-  for unit in "$@"; do
-    if [ "$unit" = "clawdi-runtime-sidecar.service" ]; then
-      mkdir -p '${join(run, "egress", "systemd")}'
-      touch '${join(run, "egress", "systemd", "ca.pem")}'
-    fi
-  done
-fi
-`,
-		);
+		writeFakeSystemdManager({
+			path: join(bin, "systemctl"),
+			logPath: systemctlLog,
+			stateRoot: systemctlStateRoot,
+			environmentRoot: join(run, "systemd", "env"),
+			sidecarReadyPath: join(run, "egress", "systemd", "ca.pem"),
+		});
 		chmodSync(join(bin, "npm"), 0o700);
-		chmodSync(join(bin, "systemctl"), 0o700);
 		process.env.PATH = `${bin}:${previousPath ?? ""}`;
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
@@ -10076,6 +10018,11 @@ fi
 			},
 			paths,
 		);
+		const activeUnits = readSystemdUnitSnapshot(paths);
+		seedFakeSystemdSnapshotProcesses(paths, systemctlStateRoot, activeUnits);
+		for (const unit of activeUnits.user.keys()) {
+			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "enabled"), "\n");
+		}
 		writeFileSync(systemctlLog, "");
 		const { restore } = mockFetch([
 			{

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
 	chmodSync,
@@ -306,23 +306,87 @@ type EnvKey = (typeof ENV_KEYS)[number];
 let originalEnv: Partial<Record<EnvKey, string>>;
 let originalUmask: number;
 let root: string;
+const fakeSystemdStateRoots = new Set<string>();
 
 function fakeSystemdStatePath(
 	stateRoot: string,
 	scope: "system" | "user",
 	unit: string,
-	state: "active" | "enabled" | "failed" | "not-found" | "reload",
+	state: "active" | "enabled" | "failed" | "not-found" | "pid" | "reload",
 ): string {
 	return join(stateRoot, `${scope}-${unit}.${state}`);
+}
+
+function seedFakeSystemdProcess(
+	stateRoot: string,
+	scope: "system" | "user",
+	unit: string,
+	revision: string,
+): number {
+	const pidPath = fakeSystemdStatePath(stateRoot, scope, unit, "pid");
+	if (existsSync(pidPath)) {
+		const existingPid = Number(readFileSync(pidPath, "utf8").trim());
+		if (Number.isSafeInteger(existingPid) && existingPid > 0) {
+			try {
+				process.kill(existingPid, "SIGTERM");
+			} catch {}
+		}
+	}
+	const child = spawn("sleep", ["300"], {
+		env: { ...process.env, CLAWDI_RUNTIME_REV: revision },
+		stdio: "ignore",
+	});
+	if (!child.pid) throw new Error(`failed to start fake process for ${unit}`);
+	child.unref();
+	writeFileSync(fakeSystemdStatePath(stateRoot, scope, unit, "active"), "\n");
+	writeFileSync(pidPath, `${child.pid}\n`);
+	for (let attempt = 0; attempt < 10; attempt += 1) {
+		try {
+			if (
+				readFileSync(`/proc/${child.pid}/environ`)
+					.toString("utf8")
+					.split("\0")
+					.includes(`CLAWDI_RUNTIME_REV=${revision}`)
+			) {
+				return child.pid;
+			}
+		} catch {}
+		spawnSync("sleep", ["0.01"]);
+	}
+	throw new Error(`fake process for ${unit} did not publish its runtime revision`);
+}
+
+function seedFakeSystemdSnapshotProcesses(
+	paths: RuntimePaths,
+	stateRoot: string,
+	snapshot: Parameters<typeof applySystemdRuntimeUpdate>[1],
+): void {
+	for (const [scope, units] of [
+		["system", snapshot.system],
+		["user", snapshot.user],
+	] as const) {
+		for (const unit of units.keys()) {
+			if (unit === "clawdi-runtime-watch.service") {
+				writeFileSync(fakeSystemdStatePath(stateRoot, scope, unit, "active"), "\n");
+				continue;
+			}
+			const revision = systemdEnvRevision(
+				readFileSync(join(paths.systemdEnvRoot, `${unit}.env`), "utf8"),
+			);
+			seedFakeSystemdProcess(stateRoot, scope, unit, revision);
+		}
+	}
 }
 
 function writeFakeSystemdManager(input: {
 	path: string;
 	logPath: string;
 	stateRoot: string;
+	environmentRoot: string;
 	failNextSidecarRestart?: string;
 	sidecarReadyPath?: string;
 }): void {
+	fakeSystemdStateRoots.add(input.stateRoot);
 	mkdirSync(input.stateRoot, { recursive: true });
 	mkdirSync(dirname(input.path), { recursive: true });
 	writeFileSync(
@@ -341,6 +405,25 @@ shift || true
 state_path() {
   printf '%s/%s-%s.%s' '${input.stateRoot}' "$scope" "$1" "$2"
 }
+desired_revision() {
+  env_file='${input.environmentRoot}'/$1.env
+  [ "$(grep -c '^CLAWDI_RUNTIME_REV=' "$env_file" || true)" -eq 1 ]
+  revision="$(grep -E '^CLAWDI_RUNTIME_REV="[a-f0-9]{32}"$' "$env_file" | cut -d '"' -f 2)"
+  printf '%s' "$revision"
+}
+start_process() {
+  unit="$1"
+  pid_path="$(state_path "$unit" pid)"
+  if [ -f "$pid_path" ]; then kill "$(cat "$pid_path")" 2>/dev/null || true; fi
+  revision="$(desired_revision "$unit")"
+  env CLAWDI_RUNTIME_REV="$revision" sleep 300 >/dev/null 2>&1 &
+  printf '%s\n' "$!" > "$pid_path"
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    tr '\0' '\n' < "/proc/$!/environ" | grep -Fxq "CLAWDI_RUNTIME_REV=$revision" && return
+    sleep 0.01
+  done
+  return 1
+}
 case "$command" in
   show)
     unit="\${1:-}"
@@ -351,7 +434,9 @@ case "$command" in
     if [ -f "$(state_path "$unit" not-found)" ]; then load_state=not-found; active_state=inactive; fi
     need_daemon_reload=no
     [ ! -f "$(state_path "$unit" reload)" ] || need_daemon_reload=yes
-    printf 'LoadState=%s\\nActiveState=%s\\nNeedDaemonReload=%s\\n' "$load_state" "$active_state" "$need_daemon_reload"
+    main_pid=0
+    [ ! -f "$(state_path "$unit" pid)" ] || main_pid="$(cat "$(state_path "$unit" pid)")"
+    printf 'LoadState=%s\\nActiveState=%s\\nMainPID=%s\\nNeedDaemonReload=%s\\n' "$load_state" "$active_state" "$main_pid" "$need_daemon_reload"
     ;;
   is-enabled)
     unit="\${1:-}"
@@ -366,6 +451,7 @@ case "$command" in
     for unit in "$@"; do
       rm -f "$(state_path "$unit" failed)" "$(state_path "$unit" not-found)"
       touch "$(state_path "$unit" active)"
+      start_process "$unit"
       if [ "$unit" = "clawdi-runtime-sidecar.service" ] && [ -n '${input.sidecarReadyPath ?? ""}' ]; then touch '${input.sidecarReadyPath ?? ""}'; fi
     done
     ;;
@@ -378,18 +464,23 @@ case "$command" in
     for unit in "$@"; do
       rm -f "$(state_path "$unit" failed)" "$(state_path "$unit" not-found)"
       touch "$(state_path "$unit" active)"
+      start_process "$unit"
       if [ "$unit" = "clawdi-runtime-sidecar.service" ] && [ -n '${input.sidecarReadyPath ?? ""}' ]; then touch '${input.sidecarReadyPath ?? ""}'; fi
     done
     ;;
   stop)
-    for unit in "$@"; do rm -f "$(state_path "$unit" active)" "$(state_path "$unit" failed)"; touch "$(state_path "$unit" not-found)"; done
+    for unit in "$@"; do
+      if [ -f "$(state_path "$unit" pid)" ]; then kill "$(cat "$(state_path "$unit" pid)")" 2>/dev/null || true; fi
+      rm -f "$(state_path "$unit" active)" "$(state_path "$unit" failed)" "$(state_path "$unit" pid)"
+      touch "$(state_path "$unit" not-found)"
+    done
     ;;
   enable)
     start_now=0
     if [ "\${1:-}" = "--now" ]; then start_now=1; shift; fi
     for unit in "$@"; do
       touch "$(state_path "$unit" enabled)"
-      if [ "$start_now" = "1" ]; then rm -f "$(state_path "$unit" failed)" "$(state_path "$unit" not-found)"; touch "$(state_path "$unit" active)"; fi
+      if [ "$start_now" = "1" ]; then rm -f "$(state_path "$unit" failed)" "$(state_path "$unit" not-found)"; touch "$(state_path "$unit" active)"; start_process "$unit"; fi
     done
     ;;
   disable) for unit in "$@"; do rm -f "$(state_path "$unit" enabled)"; done ;;
@@ -421,6 +512,19 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	for (const stateRoot of fakeSystemdStateRoots) {
+		if (!existsSync(stateRoot)) continue;
+		for (const entry of readdirSync(stateRoot)) {
+			if (!entry.endsWith(".pid")) continue;
+			const pid = Number(readFileSync(join(stateRoot, entry), "utf8").trim());
+			if (Number.isSafeInteger(pid) && pid > 0) {
+				try {
+					process.kill(pid, "SIGTERM");
+				} catch {}
+			}
+		}
+	}
+	fakeSystemdStateRoots.clear();
 	process.umask(originalUmask);
 	for (const key of ENV_KEYS) delete process.env[key];
 	for (const [key, value] of Object.entries(originalEnv)) {
@@ -1289,30 +1393,13 @@ function installSuccessfulSystemctlFixture(
 	systemctlLog?: string,
 ): void {
 	const systemctlPath = join(root, "bin", "systemctl");
-	mkdirSync(dirname(systemctlPath), { recursive: true });
-	writeFileSync(
-		systemctlPath,
-		`#!/usr/bin/env bash
-set -euo pipefail
-${systemctlLog ? `printf '%s\\n' "$*" >> '${systemctlLog}'` : ""}
-if [ "\${1:-}" = "--user" ]; then shift; fi
-if [ "\${1:-}" = "show" ]; then
-  printf 'LoadState=loaded\\nActiveState=active\\nNeedDaemonReload=no\\n'
-elif [ "\${1:-}" = "is-enabled" ]; then
-  printf 'enabled\\n'
-elif [ "\${1:-}" = "start" ] || [ "\${1:-}" = "restart" ]; then
-	  shift
-	  for unit in "$@"; do
-	    if [ "$unit" = "clawdi-runtime-sidecar.service" ]; then
-	      mkdir -p '${dirname(sidecarReadyPath)}'
-	      touch '${sidecarReadyPath}'
-	    fi
-	  done
-fi
-exit 0
-`,
-	);
-	chmodSync(systemctlPath, 0o700);
+	writeFakeSystemdManager({
+		path: systemctlPath,
+		logPath: systemctlLog ?? join(root, "systemctl-success.log"),
+		stateRoot: join(root, "systemctl-success-state"),
+		environmentRoot: join(dirname(dirname(dirname(sidecarReadyPath))), "systemd", "env"),
+		sidecarReadyPath,
+	});
 	process.env.CLAWDI_SYSTEMD_APPLY = "1";
 	process.env.CLAWDI_SYSTEMCTL_PATH = systemctlPath;
 	process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
@@ -8804,6 +8891,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 			path: systemctlPath,
 			logPath: systemctlLog,
 			stateRoot: systemctlStateRoot,
+			environmentRoot: join(run, "systemd", "env"),
 		});
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
@@ -8864,11 +8952,8 @@ printf 'ActiveState=active\\nSubState=running\\n'
 				join(paths.systemdUserRoot, "openclaw-gateway.service.d", "10-clawdi-hosted.conf"),
 			].map((path) => statSync(path).ino),
 		).toEqual(unchangedUnitInodes);
-		for (const unit of before.system.keys()) {
-			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "system", unit, "active"), "\n");
-		}
+		seedFakeSystemdSnapshotProcesses(paths, systemctlStateRoot, before);
 		for (const unit of before.user.keys()) {
-			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "active"), "\n");
 			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "enabled"), "\n");
 		}
 		writeFileSync(systemctlLog, "");
@@ -8890,10 +8975,12 @@ printf 'ActiveState=active\\nSubState=running\\n'
 			system: new Map<string, string>(),
 			user: new Map([["hermes-gateway.service", "current"]]),
 		};
+		const currentRevision = "a".repeat(32);
 		writeFileSync(
-			fakeSystemdStatePath(systemctlStateRoot, "user", "hermes-gateway.service", "active"),
-			"\n",
+			join(paths.systemdEnvRoot, "hermes-gateway.service.env"),
+			`CLAWDI_RUNTIME_REV="${currentRevision}"\n`,
 		);
+		seedFakeSystemdProcess(systemctlStateRoot, "user", "hermes-gateway.service", currentRevision);
 		writeFileSync(
 			fakeSystemdStatePath(systemctlStateRoot, "user", "hermes-gateway.service", "enabled"),
 			"\n",
@@ -8922,13 +9009,11 @@ printf 'ActiveState=active\\nSubState=running\\n'
 			system: new Map([["clawdi-runtime-watch.service", "watch"]]),
 			user: new Map([["hermes-gateway.service", "hermes"]]),
 		};
-		for (const [scope, unit] of [
-			["system", "clawdi-runtime-watch.service"],
-			["user", "hermes-gateway.service"],
-		] as const) {
-			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, scope, unit, "active"), "\n");
-			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, scope, unit, "reload"), "\n");
-		}
+		writeFileSync(
+			fakeSystemdStatePath(systemctlStateRoot, "system", "clawdi-runtime-watch.service", "active"),
+			"\n",
+		);
+		seedFakeSystemdProcess(systemctlStateRoot, "user", "hermes-gateway.service", "b".repeat(32));
 		writeFileSync(
 			fakeSystemdStatePath(systemctlStateRoot, "user", "hermes-gateway.service", "enabled"),
 			"\n",
@@ -8945,8 +9030,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 			userUnitsChanged: ["hermes-gateway.service"],
 		});
 		const driftRepairCalls = readFileSync(systemctlLog, "utf-8");
-		expect(driftRepairCalls).toContain("daemon-reload");
-		expect(driftRepairCalls).toContain("--user daemon-reload");
+		expect(driftRepairCalls).not.toContain("daemon-reload");
 		expect(driftRepairCalls).toContain("--user restart hermes-gateway.service");
 		expect(driftRepairCalls).not.toContain("restart clawdi-runtime-watch.service");
 	});
@@ -9337,6 +9421,7 @@ chmod +x "$prefix/bin/clawdi"
 			path: join(bin, "systemctl"),
 			logPath: systemctlLog,
 			stateRoot: systemctlStateRoot,
+			environmentRoot: paths.systemdEnvRoot,
 			sidecarReadyPath: publishCa ? paths.egressSystemCaFile : undefined,
 		});
 		writeFileSync(
@@ -9495,6 +9580,7 @@ fi
 			path: join(bin, "systemctl"),
 			logPath: systemctlLog,
 			stateRoot: systemctlStateRoot,
+			environmentRoot: join(run, "systemd", "env"),
 			failNextSidecarRestart,
 			sidecarReadyPath: join(run, "egress", "systemd", "ca.pem"),
 		});
@@ -12890,6 +12976,7 @@ exit 64
 			path: systemctlPath,
 			logPath: systemctlLog,
 			stateRoot: systemctlStateRoot,
+			environmentRoot: join(run, "systemd", "env"),
 		});
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
@@ -13034,11 +13121,8 @@ exit 64
 		);
 		const initialHermesDropInInode = statSync(hermesDropIn).ino;
 		const initialUnits = readSystemdUnitSnapshot(paths);
-		for (const unit of initialUnits.system.keys()) {
-			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "system", unit, "active"), "\n");
-		}
+		seedFakeSystemdSnapshotProcesses(paths, systemctlStateRoot, initialUnits);
 		for (const unit of initialUnits.user.keys()) {
-			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "active"), "\n");
 			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "enabled"), "\n");
 		}
 


### PR DESCRIPTION
## Summary

- repair existing managed WhatsApp credentials when encrypted Baileys `creds.me.id/lid` drifts from the authenticated PN/LID identity
- make managed `creds.json` a first-class recoverable runtime secret and keep a single structured projection parser
- reconcile active managed user runtime services against their exact desired `CLAWDI_RUNTIME_REV`, restarting only a runtime whose live process revision is stale
- release the compatible CLI as `clawdi@0.13.68`

## Root cause

The protocol fix in #966 repaired and re-encrypted the credential, and its desired Hermes runtime revision changed. A CLI-only checkpoint could still preserve the active Hermes process, however, leaving the old Baileys auth state in memory. The process then emitted a reply stanza without recipient `enc`, which the backend correctly rejected as `missing-enc`.

This change closes that lifecycle gap with two general invariants: the persisted credential identity must match the authenticated PN/LID identity, and every active managed user runtime must run the revision declared by its rendered environment file.

## Scope

- no schema migration
- no tenant or Hermes special case
- no force restart, mtime heuristic, or relaxation of `missing-enc`
- no production-only test seam
- one shared WhatsApp projection parser and one shared backend credential decode/validate path
- hardened system services retain their existing unit activation contract; process revision proof applies to user runtime gateways where the credential lives

## Verification

- focused CLI runtime suite: CLI typecheck plus 2 passed / 52 assertions for CLI-only and Hermes credential-change behavior
- real privileged systemd E2E exercises UID 10001 user gateway revision proof and hardened Files isolation
- focused backend manifest repair test: passed
- Backend full tests, Clean Test Runner, sidecar, Ruff, basedpyright, and `git diff --check`: passed on the reviewed revision; final CI reruns after the latest rebase/version bump

## Release impact

After merge, publish `clawdi@0.13.68` and deploy the backend/image from the merge SHA. Existing affected deployments converge through the supported exact rollout with `force_restart=false`; revision reconciliation restarts only a stale managed user runtime.
