### PR TITLE
Clean up new-user dashboard onboarding

### DIFF
--- a/apps/web/src/components/dashboard/dashboard-contracts.test.tsx
+++ b/apps/web/src/components/dashboard/dashboard-contracts.test.tsx
@@ -49,7 +49,9 @@ describe("dashboard data contracts", () => {
 
 	test("does not show first-agent empty copy while membership is unresolved", () => {
 		expect(agentGreetingSummary(0, "loading")).toBe("Loading agent status…");
-		expect(agentGreetingSummary(0, "resolved")).toBe("Connect your first agent to start syncing.");
+		expect(agentGreetingSummary(0, "resolved")).toBe(
+			"Get your first agent running to start syncing.",
+		);
 		expect(agentGreetingSummary(0, "error")).toBe("Agent status is unavailable right now.");
 	});
 });

--- a/apps/web/src/components/dashboard/greeting.ts
+++ b/apps/web/src/components/dashboard/greeting.ts
@@ -4,6 +4,6 @@ export function agentGreetingSummary(total: number, state: AgentGreetingState): 
 	if (state === "loading") return "Loading agent status…";
 	if (state === "error") return "Agent status is unavailable right now.";
 	return total === 0
-		? "Connect your first agent to start syncing."
+		? "Get your first agent running to start syncing."
 		: `${total} agent${total === 1 ? "" : "s"}`;
 }

--- a/apps/web/src/components/dashboard/onboarding-card.tsx
+++ b/apps/web/src/components/dashboard/onboarding-card.tsx
@@ -51,9 +51,7 @@ export function OnboardingCard({
 				<CardContent>
 					<div
 						className={
-							canDeployOnClawdi && !isAdditionalAgent
-								? "grid gap-2 xl:grid-cols-2"
-								: "grid gap-2"
+							canDeployOnClawdi && !isAdditionalAgent ? "grid gap-2 xl:grid-cols-2" : "grid gap-2"
 						}
 					>
 						{canDeployOnClawdi ? (

--- a/apps/web/src/components/dashboard/onboarding-card.tsx
+++ b/apps/web/src/components/dashboard/onboarding-card.tsx
@@ -36,7 +36,7 @@ export function OnboardingCard({
 			: "Connect another agent on your machine and manage it from this dashboard."
 		: canDeployOnClawdi
 			? "Deploy on Clawdi in minutes, or connect an agent on your machine."
-			: "Connect an agent first. Then create a Project to organize reusable skills and credentials you can share with teammates.";
+			: "Connect an agent on your machine and manage it from this dashboard.";
 
 	return (
 		<>
@@ -49,9 +49,20 @@ export function OnboardingCard({
 					<CardDescription>{description}</CardDescription>
 				</CardHeader>
 				<CardContent>
-					<div className="flex flex-col gap-2">
+					<div
+						className={
+							canDeployOnClawdi && !isAdditionalAgent
+								? "grid gap-2 xl:grid-cols-2"
+								: "grid gap-2"
+						}
+					>
 						{canDeployOnClawdi ? (
-							<Button render={<Link to="/deploy" />} nativeButton={false} size="lg">
+							<Button
+								render={<Link to="/deploy" />}
+								nativeButton={false}
+								size="lg"
+								className="w-full"
+							>
 								<Rocket data-icon="inline-start" /> Deploy on Clawdi
 							</Button>
 						) : null}
@@ -59,6 +70,7 @@ export function OnboardingCard({
 							type="button"
 							variant={canDeployOnClawdi ? "outline" : "default"}
 							size="lg"
+							className="w-full"
 							onClick={() => setConnectOpen(true)}
 						>
 							<TerminalSquare data-icon="inline-start" /> Connect an agent on your machine

--- a/apps/web/src/components/dashboard/resources-card.tsx
+++ b/apps/web/src/components/dashboard/resources-card.tsx
@@ -68,18 +68,6 @@ export function ResourcesCard({
 							: LIBRARY_ROW_IDS.map((id) => <ResourceRowSkeleton key={id} />)}
 					</div>
 				)}
-				{ready && stats.projects_count === 0 ? (
-					<div className="border-t px-6 py-3 text-xs text-muted-foreground">
-						Next:{" "}
-						<Link
-							to="/projects"
-							className="font-medium text-foreground underline-offset-4 hover:underline"
-						>
-							create your first Project
-						</Link>{" "}
-						to organize reusable skills and credentials for your agents.
-					</div>
-				) : null}
 			</CardContent>
 		</Card>
 	);
@@ -101,7 +89,6 @@ function ResourceRow({ resource }: { resource: Resource }) {
 	const Icon = resource.icon;
 	const { definition } = resource;
 	const scopeLabel = projectResourceScopeLabel(definition.projectScope);
-	const isProjectRow = definition.id === "projects";
 	const count = (
 		<span
 			className={cn(
@@ -113,17 +100,6 @@ function ResourceRow({ resource }: { resource: Resource }) {
 			{countUnavailable ? "—" : formatNumber(resource.count ?? 0)}
 		</span>
 	);
-	const countCluster =
-		isProjectRow && empty ? (
-			<span className="flex shrink-0 items-center gap-2" title={scopeLabel}>
-				{count}
-				<span className="rounded-md bg-primary px-2 py-1 text-xs font-medium text-primary-foreground">
-					1. Create project
-				</span>
-			</span>
-		) : (
-			count
-		);
 	return (
 		<Link
 			to={definition.href}
@@ -142,7 +118,7 @@ function ResourceRow({ resource }: { resource: Resource }) {
 			<div className="min-w-0 flex-1">
 				<div className="text-sm font-medium">{definition.label}</div>
 			</div>
-			{countCluster}
+			{count}
 		</Link>
 	);
 }

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -16,7 +16,6 @@ import {
 	isComputeSubscriptionRenewing,
 	isComputeSubscriptionTermChangeable,
 	isIncludedBasicSubscription,
-	largestSignupGrantUsd,
 	pendingComputePlanSlug,
 	pendingPlanScheduleCopy,
 	resolveBasicPlan,
@@ -101,30 +100,6 @@ describe("compute plan resolvers", () => {
 
 		expect(resolveBasicPlan([otherPaid, basic])).toBe(basic);
 		expect(resolveBasicPlan([otherPaid])).toBeUndefined();
-	});
-});
-
-describe("largestSignupGrantUsd", () => {
-	test("returns the largest positive configured grant", () => {
-		expect(
-			largestSignupGrantUsd([
-				plan({ slug: COMPUTE_BASIC_SLUG, price_cents: 0, signup_grant_usd: "5.00" }),
-				plan({
-					slug: COMPUTE_PERFORMANCE_SLUG,
-					price_cents: 1900,
-					signup_grant_usd: "12.50",
-				}),
-			]),
-		).toBe("12.50");
-	});
-
-	test("returns null when no positive grant is configured", () => {
-		expect(largestSignupGrantUsd(undefined)).toBeNull();
-		expect(
-			largestSignupGrantUsd([
-				plan({ slug: COMPUTE_BASIC_SLUG, price_cents: 0, signup_grant_usd: "0" }),
-			]),
-		).toBeNull();
 	});
 });
 

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -65,14 +65,6 @@ export function resolvePerformancePlan(plans: Plan[] | undefined): Plan | undefi
 	return plans?.find((plan) => plan.slug === COMPUTE_PERFORMANCE_SLUG);
 }
 
-export function largestSignupGrantUsd(plans: readonly Plan[] | undefined): string | null {
-	return (plans ?? []).reduce<string | null>((largest, plan) => {
-		const grant = Number(plan.signup_grant_usd);
-		if (!Number.isFinite(grant) || grant <= 0) return largest;
-		return largest === null || grant > Number(largest) ? plan.signup_grant_usd : largest;
-	}, null);
-}
-
 export function isBasicCompute(planSlug: string | null | undefined): boolean {
 	return planSlug === COMPUTE_BASIC_SLUG;
 }

--- a/apps/web/src/hosted/billing/subscription/welcome-wallet-card.logic.test.ts
+++ b/apps/web/src/hosted/billing/subscription/welcome-wallet-card.logic.test.ts
@@ -2,38 +2,39 @@ import { describe, expect, test } from "bun:test";
 import { welcomeWalletDescription } from "@/hosted/billing/subscription/welcome-wallet-card.logic";
 
 describe("welcomeWalletDescription", () => {
-	test("explains the funding order when deployment is available", () => {
+	test("describes an applied grant using its transaction amount", () => {
 		expect(
 			welcomeWalletDescription({
 				grantApplied: true,
 				grantPending: false,
 				grantCheckTimedOut: false,
 				grantAmount: "$5.00",
-				showDeployAction: true,
 			}),
-		).toContain(
-			"welcome balance covers Clawdi AI first; after that, usage draws from your Wallet.",
-		);
+		).toBe("Your $5.00 welcome balance is available in your Wallet.");
 	});
 
-	test("does not advertise deployment when the account has no deploy action", () => {
+	test("preserves unavailable, pending, and delayed grant feedback", () => {
 		const unavailable = welcomeWalletDescription({
 			grantApplied: false,
 			grantPending: false,
 			grantCheckTimedOut: false,
-			grantAmount: "$5.00",
-			showDeployAction: false,
+			grantAmount: null,
 		});
 		const pending = welcomeWalletDescription({
 			grantApplied: false,
 			grantPending: true,
 			grantCheckTimedOut: false,
 			grantAmount: "$5.00",
-			showDeployAction: false,
+		});
+		const delayed = welcomeWalletDescription({
+			grantApplied: false,
+			grantPending: true,
+			grantCheckTimedOut: true,
+			grantAmount: "$5.00",
 		});
 
 		expect(unavailable).toBe("Your Wallet is ready.");
 		expect(pending).toBe("Your $5.00 welcome balance is on the way.");
-		expect(`${unavailable} ${pending}`).not.toContain("deploy");
+		expect(delayed).toBe("It hasn’t appeared yet. Refresh to check again.");
 	});
 });

--- a/apps/web/src/hosted/billing/subscription/welcome-wallet-card.logic.ts
+++ b/apps/web/src/hosted/billing/subscription/welcome-wallet-card.logic.ts
@@ -3,34 +3,23 @@ export function welcomeWalletDescription({
 	grantPending,
 	grantCheckTimedOut,
 	grantAmount,
-	showDeployAction,
 }: {
 	grantApplied: boolean;
 	grantPending: boolean;
 	grantCheckTimedOut: boolean;
 	grantAmount: string | null;
-	showDeployAction: boolean;
 }): string {
 	if (grantApplied) {
-		if (!showDeployAction) {
-			return grantAmount
-				? `Your ${grantAmount} welcome balance is available in your Wallet.`
-				: "Your welcome balance is available in your Wallet.";
-		}
 		return grantAmount
-			? `Your free Basic compute is ready. Your ${grantAmount} welcome balance covers Clawdi AI first; after that, usage draws from your Wallet.`
-			: "Your free Basic compute is ready. Clawdi AI usage draws from your Wallet.";
+			? `Your ${grantAmount} welcome balance is available in your Wallet.`
+			: "Your welcome balance is available in your Wallet.";
 	}
 	if (grantPending) {
 		if (grantCheckTimedOut) return "It hasn’t appeared yet. Refresh to check again.";
 		const balance = grantAmount
 			? `Your ${grantAmount} welcome balance is on the way.`
 			: "Your welcome balance is on the way.";
-		return showDeployAction
-			? `${balance} You can deploy now; it’ll be ready in a moment.`
-			: balance;
+		return balance;
 	}
-	return showDeployAction
-		? "Your free Basic compute slot is ready. Deploy your first agent to get going."
-		: "Your Wallet is ready.";
+	return "Your Wallet is ready.";
 }

--- a/apps/web/src/hosted/billing/subscription/welcome-wallet-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/welcome-wallet-card.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { Link } from "@tanstack/react-router";
-import { Gift, PartyPopper, RefreshCw, Rocket } from "lucide-react";
+import { Gift, PartyPopper, RefreshCw } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { Button } from "@/components/ui/button";
@@ -10,8 +9,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { formatUsdExact } from "@/hosted/billing/format";
-import { useHostedDeployments, usePlans, useWalletTransactions } from "@/hosted/billing/hooks";
-import { largestSignupGrantUsd } from "@/hosted/billing/subscription/subscription-utils";
+import { useWalletTransactions } from "@/hosted/billing/hooks";
 import { welcomeWalletDescription } from "@/hosted/billing/subscription/welcome-wallet-card.logic";
 import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
 import { shouldBlockQueryError } from "@/lib/query-state";
@@ -22,30 +20,24 @@ const WELCOME_GRANT_TIMEOUT_MS = 60_000;
 /**
  * Pure-$0 welcome + signup-grant feedback.
  *
- * Renders for a new wallet user who hasn't deployed yet: it
- * confirms the welcome grant landed (reading the `grant_signup` transaction)
- * and can point them at the deploy wizard. Returns null once the user has an
- * agent. Read failures render a retry action instead of hiding onboarding.
+ * Confirms that a new user's welcome grant landed by reading the
+ * `grant_signup` transaction. Its parent only mounts it after the unified agent
+ * inventory has authoritatively resolved empty. Read failures render a retry
+ * action instead of hiding onboarding.
  */
-export function WelcomeWalletCard({ showDeployAction = true }: { showDeployAction?: boolean }) {
+export function WelcomeWalletCard() {
 	const wallet = useWalletSnapshot();
 	const transactions = useWalletTransactions();
-	const deployments = useHostedDeployments();
-	const plans = usePlans();
 	const grant = transactions.data?.pages
 		.flatMap((page) => page.items)
 		.find((entry) => entry.kind === "grant_signup");
 	const grantApplied = grant?.status === "applied";
 	const grantPending = grant?.status === "pending";
-	const hasDeployments = (deployments.data?.length ?? 0) > 0;
 	const blockingWalletError = shouldBlockQueryError(wallet.error, wallet.data)
 		? wallet.error
 		: null;
 	const blockingTransactionsError = shouldBlockQueryError(transactions.error, transactions.data)
 		? transactions.error
-		: null;
-	const blockingDeploymentsError = shouldBlockQueryError(deployments.error, deployments.data)
-		? deployments.error
 		: null;
 	const transactionsHaveError = Boolean(blockingTransactionsError);
 	const [grantCheckTimedOut, setGrantCheckTimedOut] = useState(false);
@@ -55,7 +47,7 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 	const refetchTransactions = transactions.refetch;
 
 	useEffect(() => {
-		if (hasDeployments || transactionsHaveError || !grantPending || grantCheckTimedOut) return;
+		if (transactionsHaveError || !grantPending || grantCheckTimedOut) return;
 		const deadline = Date.now() + WELCOME_GRANT_TIMEOUT_MS;
 		let disposed = false;
 
@@ -99,7 +91,6 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 		grantCheckGeneration,
 		grantCheckTimedOut,
 		grantPending,
-		hasDeployments,
 		refetchTransactions,
 		transactionsHaveError,
 	]);
@@ -116,22 +107,19 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 		}
 	}
 
-	// Past onboarding — they already have at least one agent.
-	if (hasDeployments) return null;
-	if (transactions.isLoading || wallet.isLoading || deployments.isLoading) {
+	if (transactions.isLoading || wallet.isLoading) {
 		return (
 			<Card data-hosted="true" aria-label="Loading welcome balance">
-				<CardContent className="flex items-center justify-between gap-4">
+				<CardContent>
 					<div className="flex flex-1 flex-col gap-2">
 						<Skeleton className="h-5 w-56 max-w-full" />
 						<Skeleton className="h-4 w-96 max-w-full" />
 					</div>
-					{showDeployAction ? <Skeleton className="h-9 w-32" /> : null}
 				</CardContent>
 			</Card>
 		);
 	}
-	const loadError = blockingWalletError ?? blockingTransactionsError ?? blockingDeploymentsError;
+	const loadError = blockingWalletError ?? blockingTransactionsError;
 	if (loadError) {
 		return (
 			<Card data-hosted="true">
@@ -142,7 +130,6 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 						onRetry={() => {
 							if (blockingWalletError) void wallet.refetch();
 							if (blockingTransactionsError) void transactions.refetch();
-							if (blockingDeploymentsError) void deployments.refetch();
 						}}
 						title="Couldn't load welcome balance"
 					/>
@@ -152,18 +139,12 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 	}
 	if (!wallet.data) return null;
 
-	const configuredSignupGrantUsd = largestSignupGrantUsd(plans.data);
-	const grantAmount = grant
-		? formatUsdExact(grant.amount)
-		: configuredSignupGrantUsd
-			? formatUsdExact(configuredSignupGrantUsd)
-			: null;
+	const grantAmount = grant ? formatUsdExact(grant.amount) : null;
 	const description = welcomeWalletDescription({
 		grantApplied,
 		grantPending,
 		grantCheckTimedOut,
 		grantAmount,
-		showDeployAction,
 	});
 
 	return (
@@ -176,7 +157,9 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 					<div className="space-y-1">
 						<p className="font-medium">
 							{grantApplied
-								? `You’re all set — ${grantAmount} added to your Wallet`
+								? grantAmount
+									? `You’re all set — ${grantAmount} added to your Wallet`
+									: "You’re all set — your welcome balance was added to your Wallet"
 								: grantPending
 									? grantCheckTimedOut
 										? "Your welcome balance is taking longer than expected"
@@ -186,7 +169,7 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 						<p className="text-sm text-muted-foreground">{description}</p>
 					</div>
 				</div>
-				{grantPending || showDeployAction ? (
+				{grantPending ? (
 					<div className="flex flex-wrap items-center gap-2">
 						{grantPending && !grantCheckTimedOut ? (
 							<Spinner className="size-4 text-muted-foreground" />
@@ -200,11 +183,6 @@ export function WelcomeWalletCard({ showDeployAction = true }: { showDeployActio
 							>
 								{manualRefreshing ? <Spinner /> : <RefreshCw />}
 								Refresh balance
-							</Button>
-						) : null}
-						{showDeployAction ? (
-							<Button render={<Link to="/deploy" />} nativeButton={false}>
-								<Rocket /> Deploy an agent
 							</Button>
 						) : null}
 					</div>

--- a/apps/web/src/hosted/hosted-agents-section.tsx
+++ b/apps/web/src/hosted/hosted-agents-section.tsx
@@ -20,7 +20,7 @@ function HostedEmptyAccountHero({ canDeployOnClawdi }: { canDeployOnClawdi: bool
 	return (
 		<div className="space-y-4">
 			<OnboardingCard variant="first-agent" canDeployOnClawdi={canDeployOnClawdi} />
-			<WelcomeWalletCard showDeployAction={false} />
+			<WelcomeWalletCard />
 		</div>
 	);
 }
@@ -101,6 +101,8 @@ export function HostedAgentsSection({
 		connectedTiles.length === 0 &&
 		!unified.isLoading &&
 		!unified.error;
+	// WelcomeWalletCard relies on this authoritative unified empty state; it
+	// does not issue a second deployments query of its own.
 	return (
 		<div data-hosted="true" className="space-y-4">
 			{isEmptyState ? (

--- a/apps/web/src/hosted/use-unified-agent-list.test.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.test.ts
@@ -307,7 +307,7 @@ describe("unified list consumers", () => {
 		expect(homepage).not.toContain("connectedAgentTilesForHostedView");
 		expect(homepage).not.toContain("useHostedAgentTiles({");
 		expect(homepage).toContain("<HostedEmptyAccountHero canDeployOnClawdi={canDeployOnClawdi} />");
-		expect(homepage).toContain("<WelcomeWalletCard showDeployAction={false} />");
+		expect(homepage).toContain("<WelcomeWalletCard />");
 		expect(onboarding).toContain("Deploy on Clawdi");
 		expect(onboarding).toContain("Connect an agent on your machine");
 	});

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -15,8 +15,6 @@ Severity legend for open gaps: 🔴 blocks · 🟡 friction · ⚪ nitpick.
   agent appears in the rail and on `/`.
 - **State**: `ossIsEmptyState` gates the card; the rail hydrates from
   `/v1/agents` (10s polling, `refetchIntervalInBackground: false`).
-- **Next-step hint**: with ≥1 agent and `projects_count === 0`, the
-  dashboard Library card shows a one-line "create your first Project" link.
 - **Guarded by**: e2e `query-refresh-no-flicker`, onboarding screenshots in
   the sidebar suite.
 


### PR DESCRIPTION
## Summary
- show first-agent deploy/connect actions side by side at equal width on wide screens while keeping narrow layouts and the additional-agent side panel stacked
- remove the zero-project badge/footer from Library and use neutral, agent-first onboarding and greeting copy
- keep the welcome Wallet card only under the authoritative unified zero-agent state; derive applied grant copy from the actual `grant_signup` transaction and remove the dead deploy CTA, duplicate deployment/plans queries, and unused grant helper
- update the first-run journey and focused contract tests

## Wallet condition
`WelcomeWalletCard` is mounted only by `HostedEmptyAccountHero`, after self-managed, hosted deployment, and connected/legacy inventories have resolved with zero agents and without a blocking inventory error. Applied copy uses the required transaction `amount`; pending/timeout/refresh and wallet/transaction loading/error behavior remain intact.

## Verification
- isolated Docker focused web tests: 50 passed
- web typecheck: passed in the isolated runner
- OSS production build: passed in the isolated runner
- Biome and `git diff --check`: passed
- attempted a one-off Playwright geometry harness, but the hosted fixture did not render the Deploy action, so it did not reach the target empty state; the temporary test and all owned container/image/network resources were removed

Not merged.