### PR TITLE
release: clawdi@0.13.67

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.66",
+      "version": "0.13.67",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.66",
+	"version": "0.13.67",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Version bump to publish the CLI carrying:
- #973 — unified \`CLAWDI_AI_API_KEY\` placeholder (manifest contract change; backend deploy + prod11 policy switch are sequenced right after this publishes)
- #972 — Degraded failure evidence, Files behavioral e2e, roster single-source

🤖 Generated with [Claude Code](https://claude.com/claude-code)