### PR TITLE
feat(billing): switch compute payment source

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1,4 +1,4 @@
-import type { DeploymentRead } from "@clawdi/shared/api";
+import type { DeployComponents, DeploymentRead } from "@clawdi/shared/api";
 import { expect, type Locator, type Page, type Route, test } from "@playwright/test";
 import type { ManagedModelCatalogItem } from "../src/hosted/billing/contracts";
 import type { AiProvider } from "../src/hosted/v2/ai-providers/types";
@@ -9,6 +9,22 @@ import {
 	mutationDeploymentReadFixture,
 	readDeploymentFixture,
 } from "./hosted-stub-api";
+
+type PlanChangeProgress = DeployComponents["schemas"]["ComputePlanChangeProgress"];
+type PlanChangeKind = PlanChangeProgress["changeKind"];
+type PlanChangeBillingEffect = PlanChangeProgress["billingEffect"];
+type PlanChangeQuote = DeployComponents["schemas"]["V2ComputePlanChangeQuoteResponse"];
+
+function planChangeBillingEffect(changeKind: PlanChangeKind): PlanChangeBillingEffect {
+	switch (changeKind) {
+		case "immediate_upgrade":
+			return "immediate_proration";
+		case "scheduled_downgrade":
+			return "period_end";
+		case "funding_source_switch":
+			return "future_renewals";
+	}
+}
 
 declare global {
 	interface Window {
@@ -992,11 +1008,11 @@ function planChangeQuoteResponse({
 	targetPlanSlug: "compute_basic" | "compute_performance";
 	currentBillingTermMonths: 1 | 12;
 	targetBillingTermMonths: 1 | 12;
-	changeKind: "immediate_upgrade" | "scheduled_downgrade";
+	changeKind: PlanChangeKind;
 	effectiveAt: string;
 	amountCents: number;
 	amountUsd: string | null;
-}) {
+}): PlanChangeQuote {
 	return {
 		operation_id: operationId,
 		subscription_id: subscriptionId,
@@ -1006,6 +1022,7 @@ function planChangeQuoteResponse({
 		current_billing_term_months: currentBillingTermMonths,
 		target_billing_term_months: targetBillingTermMonths,
 		change_kind: changeKind,
+		billing_effect: planChangeBillingEffect(changeKind),
 		status: "quoted",
 		effective_at: effectiveAt,
 		proration_date: "2026-07-16T00:00:00Z",
@@ -1024,6 +1041,7 @@ function planChangeResponse({
 	currentPlanSlug,
 	targetPlanSlug,
 	targetBillingTermMonths,
+	changeKind,
 	status,
 	effectiveAt,
 }: {
@@ -1033,16 +1051,20 @@ function planChangeResponse({
 	currentPlanSlug: "compute_basic" | "compute_performance";
 	targetPlanSlug: "compute_basic" | "compute_performance";
 	targetBillingTermMonths: 1 | 12;
+	changeKind?: PlanChangeKind;
 	status: "awaiting_payment" | "awaiting_projection" | "scheduled" | "complete";
 	effectiveAt: string;
 }): { body: NonNullable<DeploymentRead["accepted_operation"]>; status: number } {
+	const resolvedChangeKind =
+		changeKind ?? (status === "scheduled" ? "scheduled_downgrade" : "immediate_upgrade");
+	const deploymentId = `hdep_plan_${subscriptionId}`;
 	return {
 		status: 202,
 		body: {
 			name: `operations/${operationId}`,
 			metadata: {
 				"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
-				deploymentId: `hdep_plan_${subscriptionId}`,
+				deploymentId,
 				verb: "plan_change",
 				targetGeneration: 1,
 				manifestETag: `plan-change-${operationId}`,
@@ -1053,6 +1075,8 @@ function planChangeResponse({
 					operationId,
 					subscriptionId,
 					fundingSource,
+					changeKind: resolvedChangeKind,
+					billingEffect: planChangeBillingEffect(resolvedChangeKind),
 					sourcePlanSlug: currentPlanSlug,
 					targetPlanSlug,
 					targetBillingTermMonths,
@@ -1063,7 +1087,20 @@ function planChangeResponse({
 			},
 			done: status === "complete" || status === "scheduled",
 			error: null,
-			response: null,
+			response:
+				status === "complete" || status === "scheduled"
+					? {
+							"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationResponse",
+							deployment: mutationDeploymentReadFixture({
+								...paidBasicDeployment,
+								id: deploymentId,
+								config_info: {
+									...paidBasicDeployment.config_info,
+									compute_plan_slug: targetPlanSlug,
+								},
+							}).resource,
+						}
+					: null,
 		},
 	};
 }
@@ -3959,9 +3996,14 @@ test("paid card subscription confirms an immediate quoted upgrade", async ({ pag
 	});
 	await gotoHostedAgentSettings(page, "hdep_paid", "Basic");
 
-	await page.getByRole("button", { name: "Change plan or billing term" }).click();
+	await page.getByRole("button", { name: "Change plan, term, or payment source" }).click();
 	const changeDialog = page.getByRole("dialog");
-	await expect(changeDialog.getByText("Funding source: Card", { exact: true })).toBeVisible();
+	await expect(changeDialog.getByRole("button", { name: "Card", exact: true })).toHaveAttribute(
+		"aria-pressed",
+		"true",
+	);
+	await changeDialog.getByRole("combobox", { name: "Compute plan" }).click();
+	await page.getByRole("option", { name: "Performance", exact: true }).click();
 	await changeDialog.getByRole("button", { name: "Review change" }).click();
 	await expect.poll(() => planQuoteRequests.length).toBe(1);
 	await expect(changeDialog.getByText("$93.60", { exact: true })).toBeVisible();
@@ -3982,9 +4024,76 @@ test("paid card subscription confirms an immediate quoted upgrade", async ({ pag
 	).toBeVisible();
 	await changeDialog.getByRole("button", { name: "Close", exact: true }).last().click();
 	await expect(changeDialog).not.toBeVisible();
-	await expect(page.getByRole("button", { name: "Check plan change status" })).toBeVisible();
+	await expect(
+		page.getByRole("button", { name: "Check subscription change status" }),
+	).toBeVisible();
 	await expect(page.getByText("Plan changed", { exact: true })).toBeVisible();
 	expect(errors, `paid card upgrade: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("paid card subscription switches future renewals to Wallet", async ({ page }) => {
+	const errors = collectBrowserErrors(page);
+	const planChangeRequests: string[] = [];
+	const planQuoteRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [paidBasicDeployment],
+		planChangeRequests,
+		planChangeResponses: [
+			planChangeResponse({
+				operationId: "op_card_to_wallet",
+				subscriptionId: 42,
+				fundingSource: "wallet",
+				currentPlanSlug: "compute_basic",
+				targetPlanSlug: "compute_basic",
+				targetBillingTermMonths: 12,
+				changeKind: "funding_source_switch",
+				status: "complete",
+				effectiveAt: "2026-07-16T00:00:00Z",
+			}),
+		],
+		planQuoteRequests,
+		planQuoteResponses: [
+			planChangeQuoteResponse({
+				operationId: "op_card_to_wallet",
+				subscriptionId: 42,
+				fundingSource: "wallet",
+				currentPlanSlug: "compute_basic",
+				targetPlanSlug: "compute_basic",
+				currentBillingTermMonths: 12,
+				targetBillingTermMonths: 12,
+				changeKind: "funding_source_switch",
+				effectiveAt: "2026-07-16T00:00:00Z",
+				amountCents: 0,
+				amountUsd: "0.00",
+			}),
+		],
+		plans: [basicPlan, performancePlan],
+	});
+	await gotoHostedAgentSettings(page, "hdep_paid", "Basic");
+
+	await page.getByRole("button", { name: "Change plan, term, or payment source" }).click();
+	const changeDialog = page.getByRole("dialog");
+	await changeDialog.getByRole("button", { name: "Wallet", exact: true }).click();
+	await changeDialog.getByRole("button", { name: "Review change" }).click();
+
+	await expect.poll(() => planQuoteRequests.length).toBe(1);
+	expect(JSON.parse(planQuoteRequests[0] ?? "{}")).toEqual({
+		subscription_id: 42,
+		target_plan_slug: "compute_basic",
+		target_billing_term_months: 12,
+		funding_source: "wallet",
+	});
+	await expect(changeDialog.getByText("$0.00", { exact: true })).toBeVisible();
+	await expect(changeDialog.getByText("Future renewals use Wallet", { exact: true })).toBeVisible();
+	await changeDialog.getByRole("button", { name: "Update payment source" }).click();
+
+	await expect.poll(() => planChangeRequests.length).toBe(1);
+	expect(JSON.parse(planChangeRequests[0] ?? "{}")).toEqual({
+		operation_id: "op_card_to_wallet",
+	});
+	await expect(page.getByText("Payment method updated", { exact: true })).toBeVisible();
+	await expect(page.getByText("Future renewals will use Wallet.", { exact: true })).toBeVisible();
+	expect(errors, `card to Wallet switch: ${errors.join(" | ")}`).toEqual([]);
 });
 
 test("accepted plan change recovers from the deployment projection after refresh", async ({
@@ -4032,16 +4141,16 @@ test("accepted plan change recovers from the deployment projection after refresh
 	await gotoHostedAgentSettings(page, "hdep_terminal_fallback", "Basic");
 	await page.reload();
 
-	await page.getByRole("button", { name: "Check plan change status" }).click();
-	const recoveryDialog = page.getByRole("dialog", { name: "Check plan change status" });
+	await page.getByRole("button", { name: "Check subscription change status" }).click();
+	const recoveryDialog = page.getByRole("dialog", { name: "Check subscription change status" });
 	await expect(
 		recoveryDialog.getByText(
-			"This plan change was already accepted. Checking its status will not submit another charge.",
+			"This subscription change was already accepted. Checking its status will not submit another request or charge.",
 			{ exact: true },
 		),
 	).toBeVisible();
 	await recoveryDialog.getByRole("button", { name: "Check status", exact: true }).click();
-	await expect(page.getByText("Couldn’t change plan", { exact: true })).toBeVisible();
+	await expect(page.getByText("Couldn’t update subscription", { exact: true })).toBeVisible();
 	const retryDialog = page.getByRole("dialog", { name: "Change compute subscription" });
 	await expect(retryDialog).toBeVisible();
 	await retryDialog.getByRole("button", { name: "Cancel", exact: true }).click();

--- a/apps/web/e2e/hosted-stub-api.ts
+++ b/apps/web/e2e/hosted-stub-api.ts
@@ -1,9 +1,26 @@
-import type { DeploymentRead } from "@clawdi/shared/api";
+import type { DeployComponents, DeploymentRead } from "@clawdi/shared/api";
 import { expect, type Page, type Route } from "@playwright/test";
 
 export type DeploymentComputeSubscription = NonNullable<
 	NonNullable<DeploymentRead["commercial_display"]>["compute_subscription"]
 >;
+
+type PlanChangeProgress = DeployComponents["schemas"]["ComputePlanChangeProgress"];
+type PlanChangeKind = PlanChangeProgress["changeKind"];
+type PlanChangeBillingEffect = PlanChangeProgress["billingEffect"];
+type PlanChangeQuote = DeployComponents["schemas"]["V2ComputePlanChangeQuoteResponse"];
+type PlanChangeOperation = DeployComponents["schemas"]["LongRunningOperation"];
+
+function planChangeBillingEffect(changeKind: PlanChangeKind): PlanChangeBillingEffect {
+	switch (changeKind) {
+		case "immediate_upgrade":
+			return "immediate_proration";
+		case "scheduled_downgrade":
+			return "period_end";
+		case "funding_source_switch":
+			return "future_renewals";
+	}
+}
 
 export type DeploymentMutationFixture = {
 	id: string;
@@ -347,7 +364,7 @@ export const includedBasicDeployment = {
 		ai_provider_bindings: {},
 		public_ports: [],
 	},
-};
+} satisfies DeploymentMutationFixture;
 
 export const paidBasicDeployment = {
 	...includedBasicDeployment,
@@ -364,7 +381,7 @@ export const paidBasicDeployment = {
 		cancel_at_period_end: false,
 		current_period_end: "2027-07-15T00:00:00Z",
 	},
-};
+} satisfies DeploymentMutationFixture;
 
 export const performanceDeployment = {
 	...paidBasicDeployment,
@@ -611,7 +628,7 @@ export function planChangeQuoteResponse({
 	changeKind,
 	effectiveAt,
 	amountCents,
-	amountCredits,
+	amountUsd,
 }: {
 	operationId: string;
 	subscriptionId: number;
@@ -620,11 +637,11 @@ export function planChangeQuoteResponse({
 	targetPlanSlug: "compute_basic" | "compute_performance";
 	currentBillingTermMonths: 1 | 12;
 	targetBillingTermMonths: 1 | 12;
-	changeKind: "immediate_upgrade" | "scheduled_downgrade";
+	changeKind: PlanChangeKind;
 	effectiveAt: string;
 	amountCents: number;
-	amountCredits: string | null;
-}) {
+	amountUsd: string | null;
+}): PlanChangeQuote {
 	return {
 		operation_id: operationId,
 		subscription_id: subscriptionId,
@@ -634,13 +651,13 @@ export function planChangeQuoteResponse({
 		current_billing_term_months: currentBillingTermMonths,
 		target_billing_term_months: targetBillingTermMonths,
 		change_kind: changeKind,
+		billing_effect: planChangeBillingEffect(changeKind),
 		status: "quoted",
 		effective_at: effectiveAt,
 		proration_date: "2026-07-16T00:00:00Z",
 		expires_at: "2026-07-16T00:15:00Z",
 		amount_cents: amountCents,
-		amount_credits: amountCredits,
-		points_per_usd: fundingSource === "wallet" ? 1_000 : null,
+		amount_usd: amountUsd,
 		currency: "usd",
 		stripe_invoice_preview_id: "in_preview_browser",
 	};
@@ -653,6 +670,7 @@ export function planChangeResponse({
 	currentPlanSlug,
 	targetPlanSlug,
 	targetBillingTermMonths,
+	changeKind,
 	status,
 	effectiveAt,
 }: {
@@ -662,19 +680,55 @@ export function planChangeResponse({
 	currentPlanSlug: "compute_basic" | "compute_performance";
 	targetPlanSlug: "compute_basic" | "compute_performance";
 	targetBillingTermMonths: 1 | 12;
+	changeKind?: PlanChangeKind;
 	status: "awaiting_payment" | "awaiting_projection" | "scheduled" | "complete";
 	effectiveAt: string;
-}) {
+}): PlanChangeOperation {
+	const resolvedChangeKind =
+		changeKind ?? (status === "scheduled" ? "scheduled_downgrade" : "immediate_upgrade");
+	const deploymentId = `hdep_plan_${subscriptionId}`;
 	return {
-		operation_id: operationId,
-		subscription_id: subscriptionId,
-		funding_source: fundingSource,
-		current_plan_slug: currentPlanSlug,
-		target_plan_slug: targetPlanSlug,
-		target_billing_term_months: targetBillingTermMonths,
-		status,
-		effective_at: effectiveAt,
-		funding_invoice_id: status === "scheduled" ? null : "in_plan_browser",
+		name: `operations/${operationId}`,
+		metadata: {
+			"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
+			deploymentId,
+			verb: "plan_change",
+			targetGeneration: 1,
+			manifestETag: `plan-change-${operationId}`,
+			createTime: effectiveAt,
+			updateTime: effectiveAt,
+			planChange: {
+				"@type": "type.googleapis.com/clawdi.v2.ComputePlanChangeProgress",
+				operationId,
+				subscriptionId,
+				fundingSource,
+				changeKind: resolvedChangeKind,
+				billingEffect: planChangeBillingEffect(resolvedChangeKind),
+				sourcePlanSlug: currentPlanSlug,
+				targetPlanSlug,
+				targetBillingTermMonths,
+				state: status,
+				effectiveAt,
+				fundingInvoiceId: status === "scheduled" ? null : "in_plan_browser",
+			},
+		},
+		done: status === "complete" || status === "scheduled",
+		error: null,
+		response:
+			status === "complete" || status === "scheduled"
+				? {
+						"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationResponse",
+						deployment: mutationDeploymentReadFixture({
+							...paidBasicDeployment,
+							id: deploymentId,
+							config_info: {
+								...paidBasicDeployment.config_info,
+								compute_plan_slug: targetPlanSlug,
+								runtime: "hermes",
+							},
+						}).resource,
+					}
+				: null,
 	};
 }
 
@@ -861,13 +915,13 @@ export async function stubHostedApi(page: Page, options: HostedApiStubOptions = 
 				current_billing_term_months: 1,
 				target_billing_term_months: 1,
 				change_kind: "immediate_upgrade",
+				billing_effect: "immediate_proration",
 				status: "quoted",
 				effective_at: "2026-07-16T00:00:00Z",
 				proration_date: "2026-07-16T00:00:00Z",
 				expires_at: "2026-07-16T00:15:00Z",
 				amount_cents: 1_000,
-				amount_credits: null,
-				points_per_usd: null,
+				amount_usd: null,
 				currency: "usd",
 				stripe_invoice_preview_id: "in_preview_browser",
 			};
@@ -877,17 +931,18 @@ export async function stubHostedApi(page: Page, options: HostedApiStubOptions = 
 		}
 		if (p === "/v2/subscription/plan/change" && r.request().method() === "POST") {
 			options.planChangeRequests?.push(r.request().postData() ?? "");
-			const response = options.planChangeResponses?.shift() ?? {
-				operation_id: "op_plan_browser",
-				subscription_id: 42,
-				funding_source: "stripe",
-				current_plan_slug: "compute_basic",
-				target_plan_slug: "compute_performance",
-				target_billing_term_months: 1,
-				status: "complete",
-				effective_at: "2026-07-16T00:00:00Z",
-				funding_invoice_id: "in_plan_browser",
-			};
+			const response =
+				options.planChangeResponses?.shift() ??
+				planChangeResponse({
+					operationId: "op_plan_browser",
+					subscriptionId: 42,
+					fundingSource: "stripe",
+					currentPlanSlug: "compute_basic",
+					targetPlanSlug: "compute_performance",
+					targetBillingTermMonths: 1,
+					status: "complete",
+					effectiveAt: "2026-07-16T00:00:00Z",
+				});
 			return isStubResponse(response)
 				? fulfillJson(r, response.body, response.status)
 				: fulfillJson(r, response);

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -159,6 +159,7 @@ import {
 import {
 	billingErrorNormalizer,
 	billingQueryRetry,
+	isPaymentMethodRequiredError,
 	normalizeBillingError,
 	PlanChangePendingError,
 	PlanChangeTerminalError,
@@ -174,11 +175,17 @@ import {
 	useQuotePlanChange,
 	useResumeSubscription,
 } from "@/hosted/billing/hooks";
+import { useSensitiveBillingPortal } from "@/hosted/billing/sensitive-actions";
 import {
 	activePlanChangeOperationName,
+	isCombinedPaidPlanChange,
+	isFundingSourceOnlySelection,
+	isValidPaidPlanChangeQuote,
 	type PlanChangeSelection,
 	performanceUpgradeUnavailableReason,
 	planChangeUnavailableReason,
+	shouldRecoverWalletToCardSwitch,
+	visiblePlanChangeOperationName,
 } from "@/hosted/billing/subscription/plan-change.logic";
 import { PlanChangeDialog } from "@/hosted/billing/subscription/plan-change-dialog";
 import { SubscriptionCreateDialog } from "@/hosted/billing/subscription/subscription-create-dialog";
@@ -3582,10 +3589,18 @@ function ComputeSettingsSections({
 	const lifecycle = useDeploymentLifecycle();
 	const plans = usePlans();
 	const quotePlanChange = useQuotePlanChange();
+	const billingPortal = useSensitiveBillingPortal();
 	const projectedPlanChangeName = activePlanChangeOperationName(deployment);
 	const [acceptedPlanChangeName, setAcceptedPlanChangeName] = useState<string | null>(null);
-	const pendingPlanChangeName = projectedPlanChangeName ?? acceptedPlanChangeName;
-	const changePlan = useChangePlan(setAcceptedPlanChangeName);
+	const [ignoredPlanChangeNames, setIgnoredPlanChangeNames] = useState<readonly string[]>([]);
+	const visibleProjectedPlanChangeName = visiblePlanChangeOperationName(
+		projectedPlanChangeName,
+		ignoredPlanChangeNames,
+	);
+	const pendingPlanChangeName = acceptedPlanChangeName ?? visibleProjectedPlanChangeName;
+	const changePlan = useChangePlan((operationName) => {
+		setAcceptedPlanChangeName(operationName);
+	});
 	const checkPlanChange = useCheckPlanChange();
 	const [subscriptionCreateOpen, setSubscriptionCreateOpen] = useState(false);
 	const [planChangeOpen, setPlanChangeOpen] = useState(false);
@@ -3632,6 +3647,7 @@ function ComputeSettingsSections({
 	const [planChangeQuote, setPlanChangeQuote] = useState<ComputePlanChangeQuoteResponse | null>(
 		null,
 	);
+	const [planChangePaymentMethodRequired, setPlanChangePaymentMethodRequired] = useState(false);
 	const walletTopUp = useWalletTopUpDialog(PLAN_CHANGE_WALLET_FUNDING_ERROR_COPY);
 	const basicPlan = useMemo(() => resolveBasicPlan(plans.data), [plans.data]);
 	const perfPlan = useMemo(() => resolvePerformancePlan(plans.data), [plans.data]);
@@ -3675,6 +3691,7 @@ function ComputeSettingsSections({
 			)
 		: null;
 	const subscriptionCancelable = isComputeSubscriptionCancelable(currentSubscription);
+	const paymentSourceOnly = currentSubscription?.status === "past_due";
 	const planChangeUnavailable = currentSubscription
 		? planChangeUnavailableReason({
 				canCreateCloudAgents: hostedAccess.canCreateCloudAgents,
@@ -3723,13 +3740,76 @@ function ComputeSettingsSections({
 		setAcceptedPlanChangeName(null);
 		walletTopUp.reset();
 	}, [hostedAccess.canCreateCloudAgents, hostedAccess.isLoading, walletTopUp.reset]);
+	function ignorePlanChangeOperation(operationName: string | null) {
+		if (operationName === null) return;
+		setIgnoredPlanChangeNames((current) =>
+			current.includes(operationName) ? current : [...current, operationName],
+		);
+	}
 
 	function setPlanChangeDialogOpen(open: boolean) {
 		setPlanChangeOpen(open);
 	}
 
+	async function openPaymentMethods() {
+		ignorePlanChangeOperation(pendingPlanChangeName);
+		setPlanChangeQuote(null);
+		setPlanChangePaymentMethodRequired(false);
+		setAcceptedPlanChangeName(null);
+		try {
+			const result = await billingPortal.execute({});
+			const url = result.url || result.portal_url;
+			if (url) {
+				window.location.href = url;
+				return;
+			}
+			toast.error("Billing portal unavailable", {
+				description: "Refresh this page and try again in a moment.",
+			});
+			setPlanChangePaymentMethodRequired(true);
+		} catch (error) {
+			setPlanChangePaymentMethodRequired(true);
+			toast.error("Couldn’t open billing", { description: normalizeBillingError(error) });
+		}
+	}
+
 	async function requestPlanChangeQuote(selection: PlanChangeSelection) {
-		if (!hostedAccess.canCreateCloudAgents || !subscriptionId || planChangeUnavailable !== null) {
+		if (
+			!hostedAccess.canCreateCloudAgents ||
+			!subscriptionId ||
+			!computePlanSlug ||
+			planChangeUnavailable !== null
+		) {
+			return;
+		}
+		if (
+			paymentSourceOnly &&
+			!isFundingSourceOnlySelection(
+				selection,
+				computePlanSlug,
+				currentBillingTerm,
+				isWalletFunded ? "wallet" : "stripe",
+			)
+		) {
+			toast.error("Only the payment source can be changed", {
+				description:
+					"This subscription can’t change plan or billing term while past due. Choose a different payment source to continue.",
+			});
+			return;
+		}
+		if (
+			isPaidCompute &&
+			isCombinedPaidPlanChange(
+				selection,
+				computePlanSlug,
+				currentBillingTerm,
+				isWalletFunded ? "wallet" : "stripe",
+			)
+		) {
+			toast.error("Choose one subscription change", {
+				description:
+					"Change the plan or billing term using the current payment source, or change only the payment source.",
+			});
 			return;
 		}
 		try {
@@ -3741,10 +3821,45 @@ function ComputeSettingsSections({
 				subscription_id: subscriptionId,
 				...selection,
 			});
+			const currentFundingSource = isWalletFunded ? "wallet" : "stripe";
+			const validPaidQuote =
+				!isPaidCompute ||
+				isValidPaidPlanChangeQuote(
+					quote,
+					selection,
+					computePlanSlug,
+					currentBillingTerm,
+					currentFundingSource,
+				);
+			if (!validPaidQuote) {
+				setPlanChangeQuote(null);
+				setAcceptedPlanChangeName(null);
+				setPlanChangePaymentMethodRequired(false);
+				toast.error("Couldn’t verify subscription change", {
+					description: "The quote did not match the requested change. Request a fresh quote.",
+				});
+				return;
+			}
 			setAcceptedPlanChangeName(null);
+			setPlanChangePaymentMethodRequired(false);
 			setPlanChangeQuote(quote);
 		} catch (error) {
-			toast.error("Couldn’t quote plan change", {
+			if (
+				isPaidCompute &&
+				shouldRecoverWalletToCardSwitch(
+					error,
+					selection,
+					computePlanSlug,
+					currentBillingTerm,
+					isWalletFunded ? "wallet" : "stripe",
+				)
+			) {
+				setPlanChangeQuote(null);
+				setAcceptedPlanChangeName(null);
+				setPlanChangePaymentMethodRequired(true);
+				return;
+			}
+			toast.error("Couldn’t quote subscription change", {
 				description: normalizeBillingError(error),
 			});
 		}
@@ -3755,19 +3870,24 @@ function ComputeSettingsSections({
 			toast.success("Downgrade scheduled", {
 				description: `Your current compute remains active until ${formatShortDate(result.effectiveAt)}.`,
 			});
-		} else if (result.kind === "complete") {
-			toast.success("Plan changed", {
-				description: "Your compute subscription has been updated.",
-			});
 		} else {
-			toast.info("Plan change in progress", {
-				description:
-					result.waitingFor === "payment"
-						? "We’re still waiting for payment confirmation. Your compute plan has not changed yet."
-						: "Your request was received, but the compute plan has not updated yet. You can watch its status here.",
-			});
+			if (result.changeKind === "funding_source_switch") {
+				toast.success("Payment method updated", {
+					description:
+						result.fundingSource === "wallet"
+							? "Future renewals will use Wallet."
+							: "Future renewals will use Card.",
+				});
+			} else {
+				toast.success("Plan changed", {
+					description: "Your compute subscription has been updated.",
+				});
+			}
 		}
 		setAcceptedPlanChangeName(null);
+		ignorePlanChangeOperation(result.operationName);
+		setPlanChangeQuote(null);
+		setPlanChangePaymentMethodRequired(false);
 		setPlanChangeDialogOpen(false);
 	}
 
@@ -3776,15 +3896,26 @@ function ComputeSettingsSections({
 			setAcceptedPlanChangeName(error.operationName);
 			toast.info("Still waiting for confirmation", {
 				description:
-					"We don’t have a final result yet. Don’t submit another plan change. Check again in a few minutes; if it still hasn’t finished, contact support. Checking only reads the status and does not submit another charge.",
+					"We don’t have a final result yet. Don’t submit another subscription change. Check again in a few minutes; if it still hasn’t finished, contact support. Checking only reads the status and does not submit another request or charge.",
 			});
 			return;
 		}
 		if (error instanceof PlanChangeTerminalError) {
 			setAcceptedPlanChangeName(null);
+			ignorePlanChangeOperation(error.operationName ?? pendingPlanChangeName);
+			setPlanChangeQuote(null);
+			setPlanChangePaymentMethodRequired(false);
+			if (
+				error.fundingSource === "stripe" &&
+				error.changeKind === "funding_source_switch" &&
+				isPaymentMethodRequiredError(error)
+			) {
+				setPlanChangePaymentMethodRequired(true);
+				return;
+			}
 		}
 		if (walletTopUp.handleFundingError(error)) return;
-		toast.error("Couldn’t change plan", {
+		toast.error("Couldn’t update subscription", {
 			description: normalizeBillingError(error),
 		});
 	}
@@ -3868,9 +3999,11 @@ function ComputeSettingsSections({
 					onOpenChange={setPlanChangeDialogOpen}
 					plans={plans.data ?? []}
 					currentPlanSlug={computePlanSlug}
+					initialPlanSlug={isIncludedBasic ? COMPUTE_PERFORMANCE_SLUG : computePlanSlug}
 					currentBillingTermMonths={currentBillingTerm}
-					defaultFundingSource={isWalletFunded ? "wallet" : "stripe"}
-					fundingSourceSelectable={isIncludedBasic}
+					currentFundingSource={isWalletFunded ? "wallet" : "stripe"}
+					allowCombinedChange={isIncludedBasic}
+					paymentSourceOnly={paymentSourceOnly}
 					quote={planChangeQuote}
 					walletBalanceUsd={wallet.data?.balance_usd ?? null}
 					isQuoting={quotePlanChange.isPending}
@@ -3880,8 +4013,14 @@ function ComputeSettingsSections({
 					onConfirm={confirmPlanChange}
 					onCheckStatus={checkAcceptedPlanChange}
 					onTopUp={() => walletTopUp.show()}
+					paymentMethodRequired={planChangePaymentMethodRequired}
+					isManagingPaymentMethods={billingPortal.isPending}
+					onManagePaymentMethods={() => void openPaymentMethods()}
 					onExitComplete={() => {
-						if (pendingPlanChangeName === null) setPlanChangeQuote(null);
+						if (pendingPlanChangeName === null) {
+							setPlanChangeQuote(null);
+							setPlanChangePaymentMethodRequired(false);
+						}
 					}}
 				/>
 			) : null}
@@ -3903,7 +4042,7 @@ function ComputeSettingsSections({
 							</Badge>
 							{isPaidCompute ? (
 								<Badge variant="outline" className="font-normal text-muted-foreground">
-									{isWalletFunded ? "Wallet" : "Card"}
+									Payment source: {isWalletFunded ? "Wallet" : "Card"}
 								</Badge>
 							) : hasWalletFallback ? (
 								<Badge variant="outline" className="font-normal text-muted-foreground">
@@ -3975,7 +4114,7 @@ function ComputeSettingsSections({
 										<Zap data-icon="inline-start" />
 									)}
 									{pendingPlanChangeName
-										? "Check plan change status"
+										? "Check subscription change status"
 										: hasTerminalFallback
 											? "Start a new subscription"
 											: "Upgrade to Performance"}
@@ -4023,8 +4162,10 @@ function ComputeSettingsSections({
 											onClick={() => setPlanChangeDialogOpen(true)}
 										>
 											{pendingPlanChangeName
-												? "Check plan change status"
-												: "Change plan or billing term"}
+												? "Check subscription change status"
+												: paymentSourceOnly
+													? "Change payment source"
+													: "Change plan, term, or payment source"}
 										</Button>
 										<ConfirmAction
 											title={`Cancel ${tierLabel} subscription?`}

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -6,7 +6,12 @@ import {
 	unwrapDeploy,
 } from "@/hosted/billing/billing-client";
 import { hostedApiBaseUrl } from "@/hosted/billing/billing-url";
-import type { DeploymentOperation } from "@/hosted/billing/contracts";
+import type {
+	ComputePlanChangeBillingEffect,
+	ComputePlanChangeKind,
+	ComputePlanChangeProgress,
+	DeploymentOperation,
+} from "@/hosted/billing/contracts";
 import {
 	BillingApiError,
 	BillingNetworkError,
@@ -109,9 +114,29 @@ function operation({
 }
 
 function planChangeOperation(
-	state: string,
-	{ done = false, error = null }: { done?: boolean; error?: unknown } = {},
-) {
+	state: ComputePlanChangeProgress["state"],
+	{
+		done = false,
+		error = null,
+		changeKind = "immediate_upgrade",
+		billingEffect = changeKind === "funding_source_switch"
+			? "future_renewals"
+			: "immediate_proration",
+		fundingSource = "wallet",
+		sourcePlanSlug = "compute_basic",
+		targetPlanSlug = changeKind === "funding_source_switch"
+			? sourcePlanSlug
+			: "compute_performance",
+	}: {
+		done?: boolean;
+		error?: DeploymentOperation["error"];
+		changeKind?: ComputePlanChangeKind;
+		billingEffect?: ComputePlanChangeBillingEffect;
+		fundingSource?: "stripe" | "wallet";
+		sourcePlanSlug?: string;
+		targetPlanSlug?: string;
+	} = {},
+): DeploymentOperation {
 	return {
 		name: "operations/plan-change-1",
 		metadata: {
@@ -126,9 +151,11 @@ function planChangeOperation(
 				"@type": "type.googleapis.com/clawdi.v2.ComputePlanChangeProgress",
 				operationId: "plan-change-1",
 				subscriptionId: 42,
-				fundingSource: "wallet",
-				sourcePlanSlug: "compute_basic",
-				targetPlanSlug: "compute_performance",
+				fundingSource,
+				changeKind,
+				billingEffect,
+				sourcePlanSlug,
+				targetPlanSlug,
 				targetBillingTermMonths: 1,
 				state,
 				effectiveAt: NOW,
@@ -136,7 +163,13 @@ function planChangeOperation(
 		},
 		done,
 		error,
-		response: null,
+		response:
+			done && error === null
+				? {
+						"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationResponse",
+						deployment: hostedDeploymentFixture({ id: "hdep_test" }).resource,
+					}
+				: null,
 	};
 }
 
@@ -946,6 +979,7 @@ describe("account compute subscriptions", () => {
 						{
 							subscription_id: "csub_test",
 							plan_slug: "compute_performance",
+							funding_source: "stripe",
 							status: "active",
 							price_cents: 2_000,
 							currency: "usd",
@@ -1018,7 +1052,11 @@ describe("compute plan changes", () => {
 			}),
 		).resolves.toEqual({
 			kind: "complete",
+			operationName: "operations/plan-change-1",
 			effectiveAt: NOW,
+			changeKind: "immediate_upgrade",
+			billingEffect: "immediate_proration",
+			fundingSource: "wallet",
 		});
 		expect(acceptedOperations).toEqual(["operations/plan-change-1"]);
 		expect(requests.map((request) => request.method)).toEqual(["POST", "GET", "GET"]);
@@ -1063,7 +1101,11 @@ describe("compute plan changes", () => {
 		complete = true;
 		await expect(client.checkPlanChange(pending.operationName)).resolves.toEqual({
 			kind: "complete",
+			operationName: "operations/plan-change-1",
 			effectiveAt: NOW,
+			changeKind: "immediate_upgrade",
+			billingEffect: "immediate_proration",
+			fundingSource: "wallet",
 		});
 		expect(requests.map((request) => request.method)).toEqual(["GET"]);
 	});
@@ -1103,5 +1145,86 @@ describe("compute plan changes", () => {
 		const result = client.changePlan({ operation_id: "plan-change-1" });
 		await expect(result).rejects.toBeInstanceOf(PlanChangeTerminalError);
 		await expect(result).rejects.toThrow("The payment method was rejected");
+	});
+
+	it("keeps funding-source switch context on terminal outcomes", async () => {
+		const completed = planChangeOperation("complete", {
+			done: true,
+			changeKind: "funding_source_switch",
+			fundingSource: "stripe",
+		});
+		const completeClient = testClient(async () => jsonResponse(completed));
+
+		await expect(completeClient.checkPlanChange(completed.name)).resolves.toEqual({
+			kind: "complete",
+			operationName: "operations/plan-change-1",
+			effectiveAt: NOW,
+			changeKind: "funding_source_switch",
+			billingEffect: "future_renewals",
+			fundingSource: "stripe",
+		});
+
+		const failed = planChangeOperation("failed", {
+			done: true,
+			changeKind: "funding_source_switch",
+			fundingSource: "stripe",
+			error: {
+				code: 9,
+				message: "A card is required.",
+				details: [
+					{
+						"@type": "type.googleapis.com/clawdi.v2.LifecycleProblemDetails",
+						type: "https://api.clawdi.ai/problems/payment-method-required",
+						title: "A card is required",
+						status: 409,
+						detail: "payment_method_required",
+						code: "payment_method_required",
+						phase: "plan_change",
+						retryable: false,
+						conditionReason: "PaymentMethodRequired",
+						conditionMessage: "Add a card and try again.",
+						observedGeneration: 2,
+					},
+				],
+			},
+		});
+		const failedClient = testClient(async () => jsonResponse(failed));
+
+		try {
+			await failedClient.checkPlanChange(failed.name);
+			throw new Error("Expected the plan change to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(PlanChangeTerminalError);
+			if (!(error instanceof PlanChangeTerminalError)) throw error;
+			expect(error.changeKind).toBe("funding_source_switch");
+			expect(error.fundingSource).toBe("stripe");
+			expect(error.operationName).toBe("operations/plan-change-1");
+		}
+	});
+
+	it("rejects incomplete or mismatched plan-change metadata instead of reporting success", async () => {
+		const mismatched = planChangeOperation("complete", {
+			done: true,
+			changeKind: "funding_source_switch",
+			billingEffect: "immediate_proration",
+			fundingSource: "stripe",
+		});
+		const missingFundingSource = planChangeOperation("complete", { done: true });
+		if (missingFundingSource.metadata.planChange) {
+			Reflect.deleteProperty(missingFundingSource.metadata.planChange, "fundingSource");
+		}
+		const missingMetadata = {
+			...planChangeOperation("complete", { done: true }),
+			metadata: undefined,
+		};
+		const invalidResponse = {
+			...planChangeOperation("complete", { done: true }),
+			response: { "@type": "type.googleapis.com/google.protobuf.Empty" },
+		};
+
+		for (const operation of [mismatched, missingFundingSource, missingMetadata, invalidResponse]) {
+			const client = testClient(async () => jsonResponse(operation));
+			await expect(client.checkPlanChange(operation.name)).rejects.toMatchObject({ status: 502 });
+		}
 	});
 });

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -986,8 +986,9 @@ describe("account compute subscriptions", () => {
 							billing_term_months: 1,
 							current_period_end: "2026-08-22T00:00:00Z",
 							cancel_at_period_end: false,
-							deployment_id: null,
-							is_orphan: true,
+							deployment_id: "hdep_test",
+							agent_name: "Performance agent",
+							is_orphan: false,
 						},
 					],
 					has_more: true,
@@ -1004,7 +1005,13 @@ describe("account compute subscriptions", () => {
 		});
 
 		await expect(client.getSubscriptions(3, "cursor-current")).resolves.toEqual({
-			items: [expect.objectContaining({ subscription_id: "csub_test", is_orphan: true })],
+			items: [
+				expect.objectContaining({
+					subscription_id: "csub_test",
+					agent_name: "Performance agent",
+					is_orphan: false,
+				}),
+			],
 			has_more: true,
 			next_cursor: "cursor-next",
 		});

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -8,10 +8,12 @@ import {
 } from "@clawdi/shared/api";
 import createClient from "openapi-fetch";
 import { useMemo } from "react";
+import { z } from "zod";
 import { hostedApiBaseUrl } from "@/hosted/billing/billing-url";
 import type {
 	CheckoutRequest,
 	ComputeFixPaymentRequest,
+	ComputePlanChangeProgress,
 	ComputePlanChangeQuoteRequest,
 	ComputePlanChangeRequest,
 	ComputePlanChangeResult,
@@ -229,12 +231,37 @@ function isTransientDeployRequestRead(error: unknown): boolean {
 	);
 }
 
+type ParsedPlanChangeProgress = Pick<
+	ComputePlanChangeProgress,
+	| "@type"
+	| "billingEffect"
+	| "changeKind"
+	| "effectiveAt"
+	| "fundingSource"
+	| "operationId"
+	| "sourcePlanSlug"
+	| "state"
+	| "subscriptionId"
+	| "targetBillingTermMonths"
+	| "targetPlanSlug"
+>;
+
+type DeploymentOperationSuccessResponse = Extract<
+	NonNullable<DeploymentOperation["response"]>,
+	{ "@type": "type.googleapis.com/clawdi.v2.DeploymentOperationResponse" }
+>;
+
+type ParsedPlanChangeResponse = Pick<DeploymentOperationSuccessResponse, "@type"> & {
+	deployment: Pick<DeploymentOperationSuccessResponse["deployment"], "id">;
+};
+
 type ParsedPlanChangeOperation = {
-	name: string;
+	deploymentId: string;
 	done: boolean;
-	state: string;
-	effectiveAt: string;
 	error: unknown;
+	name: string;
+	progress: ParsedPlanChangeProgress;
+	response: ParsedPlanChangeResponse | null | undefined;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -244,37 +271,103 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function invalidPlanChangeResponse(): BillingApiError {
 	return new BillingApiError(
 		502,
-		"We couldn't verify the plan change status. Check again in a moment.",
+		"We couldn't verify the subscription change status. Check again in a moment.",
 	);
 }
 
+const planChangeProgressSchema: z.ZodType<ParsedPlanChangeProgress> = z.object({
+	"@type": z.literal("type.googleapis.com/clawdi.v2.ComputePlanChangeProgress"),
+	operationId: z.string().min(1),
+	subscriptionId: z.number().int().positive(),
+	fundingSource: z.enum(["stripe", "wallet"]),
+	changeKind: z.enum(["immediate_upgrade", "scheduled_downgrade", "funding_source_switch"]),
+	billingEffect: z.enum(["immediate_proration", "period_end", "future_renewals"]),
+	sourcePlanSlug: z.string().trim().min(1),
+	targetPlanSlug: z.string().trim().min(1),
+	targetBillingTermMonths: z.union([z.literal(1), z.literal(12)]),
+	state: z.enum([
+		"quoted",
+		"wallet_debit_pending",
+		"wallet_debit_applied",
+		"stripe_update_pending",
+		"invoice_pending",
+		"settlement_pending",
+		"awaiting_payment",
+		"awaiting_projection",
+		"compensation_pending",
+		"reversal_pending",
+		"reconciliation_required",
+		"scheduled",
+		"complete",
+		"compensated",
+		"failed",
+		"terminated_paid_unapplied",
+	]),
+	effectiveAt: z.string().trim().min(1),
+});
+
+const planChangeOperationSchema = z.object({
+	name: z.string().min(1),
+	metadata: z.object({
+		deploymentId: z.string().min(1),
+		verb: z.literal("plan_change"),
+		planChange: planChangeProgressSchema,
+	}),
+	done: z.boolean(),
+	error: z.unknown().nullable().optional(),
+	response: z
+		.object({
+			"@type": z.literal("type.googleapis.com/clawdi.v2.DeploymentOperationResponse"),
+			deployment: z.object({ id: z.string().min(1) }),
+		})
+		.nullable()
+		.optional(),
+});
+
 function parsePlanChangeOperation(value: unknown): ParsedPlanChangeOperation {
-	if (!isRecord(value) || typeof value.name !== "string" || typeof value.done !== "boolean") {
+	const parsed = planChangeOperationSchema.safeParse(value);
+	if (!parsed.success) {
 		throw invalidPlanChangeResponse();
 	}
-	const metadata = value.metadata;
-	if (!isRecord(metadata) || metadata.verb !== "plan_change") {
-		throw invalidPlanChangeResponse();
-	}
-	const progress = metadata.planChange;
-	if (
-		!isRecord(progress) ||
-		typeof progress.state !== "string" ||
-		typeof progress.effectiveAt !== "string"
-	) {
-		throw invalidPlanChangeResponse();
-	}
-	operationIdFromName(value.name);
+	const operationId = operationIdFromName(parsed.data.name);
+	const progress = parsed.data.metadata.planChange;
+	if (progress.operationId !== operationId) throw invalidPlanChangeResponse();
 	return {
-		name: value.name,
-		done: value.done,
-		state: progress.state,
-		effectiveAt: progress.effectiveAt,
-		error: value.error,
+		deploymentId: parsed.data.metadata.deploymentId,
+		name: parsed.data.name,
+		done: parsed.data.done,
+		progress,
+		error: parsed.data.error,
+		response: parsed.data.response,
 	};
 }
 
-function planChangeTerminalError(error: unknown): BillingApiError {
+function hasValidPlanChangeSemantics(progress: ParsedPlanChangeProgress): boolean {
+	if (
+		!progress.effectiveAt?.trim() ||
+		(progress.fundingSource !== "stripe" && progress.fundingSource !== "wallet")
+	) {
+		return false;
+	}
+	switch (progress.changeKind) {
+		case "immediate_upgrade":
+			return progress.billingEffect === "immediate_proration";
+		case "scheduled_downgrade":
+			return progress.billingEffect === "period_end";
+		case "funding_source_switch":
+			return (
+				progress.billingEffect === "future_renewals" &&
+				progress.sourcePlanSlug === progress.targetPlanSlug
+			);
+		default:
+			return false;
+	}
+}
+
+function planChangeTerminalError(
+	error: unknown,
+	operation: ParsedPlanChangeOperation,
+): BillingApiError {
 	if (isRecord(error) && Array.isArray(error.details)) {
 		const detail = error.details.find(
 			(item) =>
@@ -285,27 +378,73 @@ function planChangeTerminalError(error: unknown): BillingApiError {
 			typeof detail.status === "number" &&
 			typeof detail.detail === "string"
 		) {
-			return new PlanChangeTerminalError(detail.status, detail.detail, { detail });
+			return new PlanChangeTerminalError(
+				detail.status,
+				detail.detail,
+				{ detail },
+				operation.progress.changeKind,
+				operation.progress.fundingSource,
+				operation.name,
+			);
 		}
 	}
 	return new PlanChangeTerminalError(
 		409,
-		"The plan change could not be completed. Review the price and try again.",
+		"The subscription change could not be completed. Review the details and try again.",
+		undefined,
+		operation.progress.changeKind,
+		operation.progress.fundingSource,
+		operation.name,
 	);
 }
 
 function completedPlanChange(operation: ParsedPlanChangeOperation): ComputePlanChangeResult | null {
+	if (!hasValidPlanChangeSemantics(operation.progress)) {
+		throw invalidPlanChangeResponse();
+	}
 	if (!operation.done) {
-		if (operation.error !== undefined && operation.error !== null) {
+		if (
+			(operation.error !== undefined && operation.error !== null) ||
+			(operation.response !== undefined && operation.response !== null)
+		) {
 			throw invalidPlanChangeResponse();
 		}
 		return null;
 	}
-	if (operation.error !== undefined && operation.error !== null) {
-		throw planChangeTerminalError(operation.error);
+	const hasError = operation.error !== undefined && operation.error !== null;
+	const hasResponse = operation.response !== undefined && operation.response !== null;
+	if (hasError === hasResponse) throw invalidPlanChangeResponse();
+	if (hasError) {
+		throw planChangeTerminalError(operation.error, operation);
 	}
-	if (operation.state === "complete" || operation.state === "scheduled") {
-		return { kind: operation.state, effectiveAt: operation.effectiveAt };
+	if (operation.response?.deployment.id !== operation.deploymentId) {
+		throw invalidPlanChangeResponse();
+	}
+	if (
+		operation.progress.changeKind === "scheduled_downgrade" &&
+		operation.progress.state === "scheduled"
+	) {
+		return {
+			kind: "scheduled",
+			operationName: operation.name,
+			effectiveAt: operation.progress.effectiveAt,
+			changeKind: operation.progress.changeKind,
+			billingEffect: operation.progress.billingEffect,
+			fundingSource: operation.progress.fundingSource,
+		};
+	}
+	if (
+		operation.progress.changeKind !== "scheduled_downgrade" &&
+		operation.progress.state === "complete"
+	) {
+		return {
+			kind: "complete",
+			operationName: operation.name,
+			effectiveAt: operation.progress.effectiveAt,
+			changeKind: operation.progress.changeKind,
+			billingEffect: operation.progress.billingEffect,
+			fundingSource: operation.progress.fundingSource,
+		};
 	}
 	throw invalidPlanChangeResponse();
 }
@@ -366,7 +505,7 @@ export function createBillingClient(
 		);
 
 	const waitForPlanChange = async (
-		initial: unknown,
+		initial: DeploymentOperation,
 		expectedOperationId: string,
 		onAccepted?: (operationName: string) => void,
 	): Promise<ComputePlanChangeResult> => {

--- a/apps/web/src/hosted/billing/contracts.ts
+++ b/apps/web/src/hosted/billing/contracts.ts
@@ -16,10 +16,18 @@ export type ComputeSubscriptionCancelRequest = Schemas["V2ComputeSubscriptionCan
 export type ComputeSubscriptionListItem = Schemas["V2ComputeSubscriptionListItem"];
 export type ComputeFixPaymentRequest = Schemas["V2ComputeFixPaymentRequest"];
 export type ComputePlanChangeRequest = Schemas["V2ComputePlanChangeRequest"];
-export type ComputePlanChangeResult =
-	| { kind: "complete"; effectiveAt: string }
-	| { kind: "scheduled"; effectiveAt: string }
-	| { kind: "pending"; waitingFor: "payment" | "update" };
+export type ComputePlanChangeProgress = Schemas["ComputePlanChangeProgress"];
+export type ComputePlanChangeKind = ComputePlanChangeProgress["changeKind"];
+export type ComputePlanChangeBillingEffect = ComputePlanChangeProgress["billingEffect"];
+export type ComputePlanChangeFundingSource = ComputePlanChangeProgress["fundingSource"];
+export type ComputePlanChangeResult = {
+	kind: Extract<ComputePlanChangeProgress["state"], "complete" | "scheduled">;
+	operationName: string;
+	effectiveAt: string;
+	changeKind: ComputePlanChangeKind;
+	billingEffect: ComputePlanChangeBillingEffect;
+	fundingSource: ComputePlanChangeFundingSource;
+};
 export type ComputePlanChangeQuoteRequest = Schemas["V2ComputePlanChangeQuoteRequest"];
 export type ComputePlanChangeQuoteResponse = Schemas["V2ComputePlanChangeQuoteResponse"];
 export type ComputeSubscriptionQuoteRequest = Schemas["V2ComputeSubscriptionQuoteRequest"];

--- a/apps/web/src/hosted/billing/errors.test.ts
+++ b/apps/web/src/hosted/billing/errors.test.ts
@@ -10,6 +10,7 @@ import {
 	isForbiddenError,
 	isInsufficientBalanceError,
 	isNetworkError,
+	isPaymentMethodRequiredError,
 	isRetryableError,
 	isServerError,
 	normalizeBillingError,
@@ -134,9 +135,16 @@ describe("normalizeBillingError", () => {
 	});
 
 	test("snake_case codes stay internal while real sentences pass through", () => {
-		expect(normalizeBillingError(new BillingApiError(400, "payment_method_required"))).toBe(
+		const paymentMethodRequired = new BillingApiError(400, "payment_method_required");
+		expect(normalizeBillingError(paymentMethodRequired)).toBe(
 			"Add a payment method and try again.",
 		);
+		expect(isPaymentMethodRequiredError(paymentMethodRequired)).toBe(true);
+		expect(
+			isPaymentMethodRequiredError(
+				new BillingApiError(409, "Request failed", { detail: { code: "payment_method_required" } }),
+			),
+		).toBe(true);
 		expect(normalizeBillingError(new BillingApiError(400, "bridge_internal_17"))).not.toContain(
 			"bridge_internal_17",
 		);

--- a/apps/web/src/hosted/billing/errors.ts
+++ b/apps/web/src/hosted/billing/errors.ts
@@ -10,7 +10,11 @@
  */
 
 import { toast } from "sonner";
-import type { HostedDeployRequestStatus } from "@/hosted/billing/contracts";
+import type {
+	ComputePlanChangeFundingSource,
+	ComputePlanChangeKind,
+	HostedDeployRequestStatus,
+} from "@/hosted/billing/contracts";
 
 export class BillingApiError extends Error {
 	constructor(
@@ -102,7 +106,7 @@ export function deploymentRequestTerminalOutcome(
 /** A plan change remains nonterminal after the bounded foreground poll. */
 export class PlanChangePendingError extends Error {
 	constructor(public readonly operationName: string) {
-		super("We're still waiting for the plan change to finish. Check the status again in a moment.");
+		super("We're still waiting for the subscription change to finish. Check again in a moment.");
 		this.name = "PlanChangePendingError";
 	}
 }
@@ -110,6 +114,17 @@ export class PlanChangePendingError extends Error {
 /** The accepted plan change reached an explicit failed terminal state. */
 export class PlanChangeTerminalError extends BillingApiError {
 	override name = "PlanChangeTerminalError";
+
+	constructor(
+		status: number,
+		detail: string,
+		payload?: unknown,
+		public readonly changeKind: ComputePlanChangeKind | null = null,
+		public readonly fundingSource: ComputePlanChangeFundingSource | null = null,
+		public readonly operationName: string | null = null,
+	) {
+		super(status, detail, payload);
+	}
 }
 
 function hasDetail(value: unknown): value is { detail: unknown } {
@@ -314,6 +329,14 @@ export function isInsufficientBalanceError(error: unknown): boolean {
 	if (!(error instanceof BillingApiError)) return false;
 	if (error.status !== 403 && error.status !== 402) return false;
 	return billingErrorDetail(error)?.code === INSUFFICIENT_WALLET_BALANCE_CODE;
+}
+
+export function isPaymentMethodRequiredError(error: unknown): boolean {
+	return (
+		error instanceof BillingApiError &&
+		(error.detail === "payment_method_required" ||
+			billingErrorDetail(error)?.code === "payment_method_required")
+	);
 }
 
 /**

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -165,11 +165,7 @@ describe("applySubscriptionActionSuccess", () => {
 		qc.setQueryData(billingKeys.deployments, { current: true });
 		qc.setQueryData(billingKeys.subscriptions, { current: true });
 
-		applySubscriptionActionSuccess(
-			qc,
-			{ subscription_id: "csub_test" },
-			subscriptionAction(true),
-		);
+		applySubscriptionActionSuccess(qc, { subscription_id: "csub_test" }, subscriptionAction(true));
 
 		expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(true);
 		expect(qc.getQueryState(billingKeys.subscriptions)?.isInvalidated).toBe(true);

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -12,12 +12,14 @@ import type {
 	HostedDeployment,
 	HostedDeploymentStatus,
 } from "@/hosted/billing/contracts";
+import { BillingApiError, PlanChangeTerminalError } from "@/hosted/billing/errors";
 import {
 	applyDeploymentSubscriptionResult,
 	billingKeys,
 	billingNextPageParam,
 	billingRecoveryRefetchIntervalFor,
 	HOSTED_DEPLOYMENTS_REFRESH_POLICY,
+	invalidateSettledPlanChangeQueries,
 	reconcileDeploymentSnapshots,
 	refreshCheckoutReturnQueries,
 } from "@/hosted/billing/hooks";
@@ -87,6 +89,37 @@ describe("subscription pagination", () => {
 		);
 		expect(billingNextPageParam({ has_more: true, next_cursor: null })).toBeUndefined();
 		expect(billingNextPageParam({ has_more: false, next_cursor: "cursor-stale" })).toBeUndefined();
+	});
+});
+
+describe("plan change cache invalidation", () => {
+	test("invalidates all billing inventory only after success or a terminal outcome", () => {
+		const affectedKeys = [
+			billingKeys.deployments,
+			billingKeys.wallet,
+			billingKeys.transactions,
+			billingKeys.subscriptions,
+		] as const;
+		for (const error of [
+			null,
+			new PlanChangeTerminalError(409, "payment_method_required"),
+		] as const) {
+			const qc = new QueryClient();
+			for (const queryKey of affectedKeys) qc.setQueryData(queryKey, { current: true });
+
+			invalidateSettledPlanChangeQueries(qc, error);
+
+			for (const queryKey of affectedKeys) {
+				expect(qc.getQueryState(queryKey)?.isInvalidated).toBe(true);
+			}
+		}
+
+		const pending = new QueryClient();
+		for (const queryKey of affectedKeys) pending.setQueryData(queryKey, { current: true });
+		invalidateSettledPlanChangeQueries(pending, new BillingApiError(503, "still processing"));
+		for (const queryKey of affectedKeys) {
+			expect(pending.getQueryState(queryKey)?.isInvalidated).toBe(false);
+		}
 	});
 });
 

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -15,6 +15,7 @@ import type {
 import { BillingApiError, PlanChangeTerminalError } from "@/hosted/billing/errors";
 import {
 	applyDeploymentSubscriptionResult,
+	applySubscriptionActionSuccess,
 	billingKeys,
 	billingNextPageParam,
 	billingRecoveryRefetchIntervalFor,
@@ -155,6 +156,23 @@ describe("applyDeploymentSubscriptionResult", () => {
 		);
 		expect(patched?.[0]?.commercial_display?.compute_subscription?.cancel_at).toBeNull();
 		expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(false);
+	});
+});
+
+describe("applySubscriptionActionSuccess", () => {
+	test("invalidates deployments and subscriptions when targeting a subscription id", () => {
+		const qc = new QueryClient();
+		qc.setQueryData(billingKeys.deployments, { current: true });
+		qc.setQueryData(billingKeys.subscriptions, { current: true });
+
+		applySubscriptionActionSuccess(
+			qc,
+			{ subscription_id: "csub_test" },
+			subscriptionAction(true),
+		);
+
+		expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(true);
+		expect(qc.getQueryState(billingKeys.subscriptions)?.isInvalidated).toBe(true);
 	});
 });
 

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -103,6 +103,19 @@ export function applyDeploymentSubscriptionResult(
 	);
 }
 
+export function applySubscriptionActionSuccess(
+	qc: QueryClient,
+	body: ComputeSubscriptionCancelRequest | ComputeSubscriptionResumeRequest,
+	next: ComputeSubscriptionActionResult,
+): void {
+	if (body.deployment_id) {
+		applyDeploymentSubscriptionResult(qc, body.deployment_id, next);
+	} else if (body.subscription_id) {
+		qc.invalidateQueries({ queryKey: billingKeys.deployments });
+	}
+	qc.invalidateQueries({ queryKey: billingKeys.subscriptions });
+}
+
 /**
  * Shared billing read: gates fetches on `isDeployApiConfigured()` and applies
  * the transient-only `billingQueryRetry` so deterministic 4xx (auth,
@@ -245,12 +258,7 @@ export function useCancelSubscription() {
 	const qc = useQueryClient();
 	return useMutation({
 		mutationFn: (body: ComputeSubscriptionCancelRequest) => client.cancelSubscription(body),
-		onSuccess: (next, body) => {
-			if (body.deployment_id) {
-				applyDeploymentSubscriptionResult(qc, body.deployment_id, next);
-			}
-			qc.invalidateQueries({ queryKey: billingKeys.subscriptions });
-		},
+		onSuccess: (next, body) => applySubscriptionActionSuccess(qc, body, next),
 	});
 }
 
@@ -259,12 +267,7 @@ export function useResumeSubscription() {
 	const qc = useQueryClient();
 	return useMutation({
 		mutationFn: (body: ComputeSubscriptionResumeRequest) => client.resumeSubscription(body),
-		onSuccess: (next, body) => {
-			if (body.deployment_id) {
-				applyDeploymentSubscriptionResult(qc, body.deployment_id, next);
-			}
-			qc.invalidateQueries({ queryKey: billingKeys.subscriptions });
-		},
+		onSuccess: (next, body) => applySubscriptionActionSuccess(qc, body, next),
 	});
 }
 

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -210,16 +210,24 @@ export function useQuotePlanChange() {
 	});
 }
 
+export function invalidatePlanChangeQueries(qc: QueryClient): void {
+	qc.invalidateQueries({ queryKey: billingKeys.deployments });
+	qc.invalidateQueries({ queryKey: billingKeys.wallet });
+	qc.invalidateQueries({ queryKey: billingKeys.transactions });
+	qc.invalidateQueries({ queryKey: billingKeys.subscriptions });
+}
+
+export function invalidateSettledPlanChangeQueries(qc: QueryClient, error: Error | null): void {
+	if (error && !(error instanceof PlanChangeTerminalError)) return;
+	invalidatePlanChangeQueries(qc);
+}
+
 export function useChangePlan(onAccepted?: (operationName: string) => void) {
 	const client = useBillingClient();
 	const qc = useQueryClient();
 	return useMutation<ComputePlanChangeResult, Error, ComputePlanChangeRequest>({
 		mutationFn: (body) => client.changePlan(body, onAccepted),
-		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: billingKeys.deployments });
-			qc.invalidateQueries({ queryKey: billingKeys.wallet });
-			qc.invalidateQueries({ queryKey: billingKeys.transactions });
-		},
+		onSettled: (_result, error) => invalidateSettledPlanChangeQueries(qc, error),
 	});
 }
 
@@ -228,12 +236,7 @@ export function useCheckPlanChange() {
 	const qc = useQueryClient();
 	return useMutation<ComputePlanChangeResult, Error, string>({
 		mutationFn: (operationName) => client.checkPlanChange(operationName),
-		onSettled: (_result, error) => {
-			if (error && !(error instanceof PlanChangeTerminalError)) return;
-			qc.invalidateQueries({ queryKey: billingKeys.deployments });
-			qc.invalidateQueries({ queryKey: billingKeys.wallet });
-			qc.invalidateQueries({ queryKey: billingKeys.transactions });
-		},
+		onSettled: (_result, error) => invalidateSettledPlanChangeQueries(qc, error),
 	});
 }
 

--- a/apps/web/src/hosted/billing/subscription/plan-change-dialog.test.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-change-dialog.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+	FundingSourceSwitchSummary,
+	PaymentMethodRequiredRecovery,
+	planChangeDialogStep,
+} from "./plan-change-dialog";
+
+describe("funding source switch quote", () => {
+	test("shows zero due now and future-renewal semantics without debit copy", () => {
+		const markup = renderToStaticMarkup(
+			<FundingSourceSwitchSummary amountCents={0} fundingSource="wallet" />,
+		);
+
+		expect(markup).toContain("Due now");
+		expect(markup).toContain("$0.00");
+		expect(markup).toContain("Future renewals use Wallet");
+		expect(markup).toContain("does not debit your Wallet today");
+		expect(markup).not.toContain("Wallet balance");
+		expect(markup).not.toContain("proration");
+	});
+});
+
+describe("payment method recovery", () => {
+	test("offers the portal without a quote and requires a fresh submission", () => {
+		expect(
+			planChangeDialogStep({
+				hasAcceptedChange: false,
+				hasQuote: false,
+				paymentMethodRequired: true,
+			}),
+		).toBe("payment_method_required");
+		const markup = renderToStaticMarkup(
+			<PaymentMethodRequiredRecovery
+				isManagingPaymentMethods={false}
+				onClose={() => undefined}
+				onManagePaymentMethods={() => undefined}
+			/>,
+		);
+
+		expect(markup).toContain("Manage payment methods");
+		expect(markup).toContain("does not complete this payment source change");
+		expect(markup).toContain("request a fresh quote and submit it again");
+		expect(markup).not.toContain("Update payment source");
+		expect(markup).not.toContain("Confirm upgrade");
+	});
+});

--- a/apps/web/src/hosted/billing/subscription/plan-change-dialog.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-change-dialog.tsx
@@ -43,8 +43,14 @@ import {
 import { formatShortDate } from "@/lib/format";
 import {
 	defaultPlanChangeSelection,
+	isFundingSourceSwitchQuote,
 	isSamePlanChangeSelection,
+	isValidFundingSourceSwitchQuote,
 	type PlanChangeSelection,
+	planChangeNeedsOffer,
+	planChangeNeedsWalletBalance,
+	selectPlanChangeFundingSource,
+	selectPlanChangeOffer,
 	walletBalanceAfterDebit,
 } from "./plan-change.logic";
 
@@ -57,14 +63,97 @@ function planSlug(value: string | null): ComputePlanSlug | null {
 	return value === "compute_basic" || value === "compute_performance" ? value : null;
 }
 
+export function planChangeDialogStep({
+	hasAcceptedChange,
+	hasQuote,
+	paymentMethodRequired,
+}: {
+	hasAcceptedChange: boolean;
+	hasQuote: boolean;
+	paymentMethodRequired: boolean;
+}): "pending" | "payment_method_required" | "quote" | "selection" {
+	if (hasAcceptedChange) return "pending";
+	if (paymentMethodRequired) return "payment_method_required";
+	if (hasQuote) return "quote";
+	return "selection";
+}
+
+export function PaymentMethodRequiredRecovery({
+	isManagingPaymentMethods,
+	onClose,
+	onManagePaymentMethods,
+}: {
+	isManagingPaymentMethods: boolean;
+	onClose: () => void;
+	onManagePaymentMethods: () => void;
+}) {
+	return (
+		<div className="flex flex-col gap-4">
+			<Alert variant="destructive">
+				<CreditCard aria-hidden />
+				<AlertTitle>A card is required</AlertTitle>
+				<AlertDescription>
+					Opening billing settings does not complete this payment source change. After you return,
+					request a fresh quote and submit it again.
+				</AlertDescription>
+			</Alert>
+			<DialogFooter>
+				<Button variant="ghost" onClick={onClose} disabled={isManagingPaymentMethods}>
+					Close
+				</Button>
+				<Button onClick={onManagePaymentMethods} disabled={isManagingPaymentMethods}>
+					{isManagingPaymentMethods ? (
+						<Spinner data-icon="inline-start" />
+					) : (
+						<CreditCard data-icon="inline-start" />
+					)}
+					Manage payment methods
+				</Button>
+			</DialogFooter>
+		</div>
+	);
+}
+
+export function FundingSourceSwitchSummary({
+	amountCents,
+	fundingSource,
+}: {
+	amountCents: number;
+	fundingSource: PlanChangeSelection["funding_source"];
+}) {
+	const paymentSourceLabel = fundingSource === "wallet" ? "Wallet" : "Card";
+	return (
+		<>
+			<div className="grid gap-3 rounded-lg border bg-muted/20 p-3 sm:grid-cols-2">
+				<dl>
+					<dt className="text-xs text-muted-foreground">Payment source</dt>
+					<dd className="font-medium">{paymentSourceLabel}</dd>
+				</dl>
+				<dl>
+					<dt className="text-xs text-muted-foreground">Due now</dt>
+					<dd className="font-medium tabular-nums">{formatCents(amountCents)}</dd>
+				</dl>
+			</div>
+			<Alert>
+				{fundingSource === "wallet" ? <WalletCards aria-hidden /> : <CreditCard aria-hidden />}
+				<AlertTitle>Future renewals use {paymentSourceLabel}</AlertTitle>
+				<AlertDescription>
+					Your plan, billing term, price, and renewal date stay the same. This change does not{" "}
+					{fundingSource === "wallet" ? "debit your Wallet" : "charge your card"} today.
+				</AlertDescription>
+			</Alert>
+		</>
+	);
+}
+
 export function PlanChangeDialog({
 	open,
 	onOpenChange,
 	plans,
 	currentPlanSlug,
+	initialPlanSlug,
 	currentBillingTermMonths,
-	defaultFundingSource,
-	fundingSourceSelectable,
+	currentFundingSource,
 	quote,
 	walletBalanceUsd,
 	isQuoting,
@@ -74,15 +163,20 @@ export function PlanChangeDialog({
 	onConfirm,
 	onCheckStatus,
 	onTopUp,
+	allowCombinedChange,
+	paymentSourceOnly,
+	paymentMethodRequired,
+	isManagingPaymentMethods,
+	onManagePaymentMethods,
 	onExitComplete,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	plans: Plan[];
 	currentPlanSlug: ComputePlanSlug;
+	initialPlanSlug: ComputePlanSlug;
 	currentBillingTermMonths: ComputePlanChangeQuoteRequest["target_billing_term_months"];
-	defaultFundingSource: PlanChangeSelection["funding_source"];
-	fundingSourceSelectable: boolean;
+	currentFundingSource: PlanChangeSelection["funding_source"];
 	quote: ComputePlanChangeQuoteResponse | null;
 	walletBalanceUsd: string | null;
 	isQuoting: boolean;
@@ -92,16 +186,31 @@ export function PlanChangeDialog({
 	onConfirm: (operationId: string) => void;
 	onCheckStatus: () => void;
 	onTopUp?: () => void;
+	allowCombinedChange: boolean;
+	paymentSourceOnly: boolean;
+	paymentMethodRequired: boolean;
+	isManagingPaymentMethods: boolean;
+	onManagePaymentMethods: () => void;
 	onExitComplete?: () => void;
 }) {
 	const initialSelection = useMemo(
 		() =>
-			defaultPlanChangeSelection(currentPlanSlug, currentBillingTermMonths, defaultFundingSource),
-		[currentBillingTermMonths, currentPlanSlug, defaultFundingSource],
+			defaultPlanChangeSelection(
+				currentPlanSlug,
+				currentBillingTermMonths,
+				currentFundingSource,
+				initialPlanSlug,
+			),
+		[currentBillingTermMonths, currentFundingSource, currentPlanSlug, initialPlanSlug],
 	);
 	const [selection, setSelection] = useState(initialSelection);
 	const exit = useDialogExitLifecycle({ open, value: quote, emptyValue: null });
 	const displayedQuote = exit.renderedValue;
+	const step = planChangeDialogStep({
+		hasAcceptedChange,
+		hasQuote: displayedQuote !== null,
+		paymentMethodRequired,
+	});
 	const selectedPlan =
 		selection.target_plan_slug === "compute_performance"
 			? resolvePerformancePlan(plans)
@@ -114,18 +223,43 @@ export function PlanChangeDialog({
 	const selectedOffer = offers.find(
 		(offer) => offer.billing_term_months === selection.target_billing_term_months,
 	);
-	const noChange = isSamePlanChangeSelection(selection, currentPlanSlug, currentBillingTermMonths);
+	const noChange = isSamePlanChangeSelection(
+		selection,
+		currentPlanSlug,
+		currentBillingTermMonths,
+		currentFundingSource,
+	);
+	const fundingSourceSwitch = isFundingSourceSwitchQuote(displayedQuote);
 	const quoteFundingSource = displayedQuote?.funding_source ?? selection.funding_source;
 	const walletBalanceAfter =
-		quoteFundingSource === "wallet" && displayedQuote?.amount_usd && walletBalanceUsd
+		!fundingSourceSwitch &&
+		quoteFundingSource === "wallet" &&
+		displayedQuote?.amount_usd &&
+		walletBalanceUsd
 			? walletBalanceAfterDebit(walletBalanceUsd, displayedQuote.amount_usd)
 			: null;
 	const walletInsufficient = walletBalanceAfter?.startsWith("-") ?? false;
 	const walletQuoteMissingAmount =
 		quoteFundingSource === "wallet" &&
+		!fundingSourceSwitch &&
 		displayedQuote?.change_kind === "immediate_upgrade" &&
 		!displayedQuote.amount_usd;
-	const walletReady = selection.funding_source !== "wallet" || walletBalanceUsd !== null;
+	const invalidFundingSourceSwitchQuote =
+		fundingSourceSwitch &&
+		displayedQuote !== null &&
+		!isValidFundingSourceSwitchQuote(
+			displayedQuote,
+			selection,
+			currentPlanSlug,
+			currentBillingTermMonths,
+			currentFundingSource,
+		);
+	const offerReady =
+		!planChangeNeedsOffer(selection, currentPlanSlug, currentBillingTermMonths) ||
+		selectedOffer !== undefined;
+	const walletReady =
+		!planChangeNeedsWalletBalance(selection, currentPlanSlug, currentBillingTermMonths) ||
+		walletBalanceUsd !== null;
 
 	useEffect(() => {
 		if (open) setSelection(initialSelection);
@@ -146,25 +280,34 @@ export function PlanChangeDialog({
 		const keepsTerm = nextOffers.some(
 			(offer) => offer.billing_term_months === selection.target_billing_term_months,
 		);
-		setSelection({
-			...selection,
-			target_plan_slug: nextPlanSlug,
-			target_billing_term_months: keepsTerm
-				? selection.target_billing_term_months
-				: nextOffers[0]?.billing_term_months === 12
-					? 12
-					: 1,
-		});
+		setSelection(
+			selectPlanChangeOffer(
+				selection,
+				nextPlanSlug,
+				keepsTerm
+					? selection.target_billing_term_months
+					: nextOffers[0]?.billing_term_months === 12
+						? 12
+						: 1,
+				currentFundingSource,
+				allowCombinedChange,
+			),
+		);
 	}
 
-	const quoteTitle =
-		displayedQuote?.change_kind === "immediate_upgrade"
+	const quoteTitle = fundingSourceSwitch
+		? "Confirm payment source change"
+		: displayedQuote?.change_kind === "immediate_upgrade"
 			? "Confirm immediate upgrade"
 			: "Schedule downgrade";
-	const confirmLabel =
-		displayedQuote?.change_kind === "immediate_upgrade" ? "Confirm upgrade" : "Schedule downgrade";
-	const busyLabel =
-		displayedQuote?.change_kind === "immediate_upgrade"
+	const confirmLabel = fundingSourceSwitch
+		? "Update payment source"
+		: displayedQuote?.change_kind === "immediate_upgrade"
+			? "Confirm upgrade"
+			: "Schedule downgrade";
+	const busyLabel = fundingSourceSwitch
+		? "Updating payment source…"
+		: displayedQuote?.change_kind === "immediate_upgrade"
 			? "Confirming plan change…"
 			: "Scheduling downgrade…";
 	const blocksClose = isQuoting || (isConfirming && !hasAcceptedChange);
@@ -189,32 +332,42 @@ export function PlanChangeDialog({
 			<DialogContent data-hosted="true" className="sm:max-w-lg" showCloseButton={!blocksClose}>
 				<DialogHeader>
 					<DialogTitle>
-						{hasAcceptedChange
-							? "Check plan change status"
-							: displayedQuote
-								? quoteTitle
-								: "Change compute subscription"}
+						{step === "pending"
+							? "Check subscription change status"
+							: step === "payment_method_required"
+								? "Add a card to continue"
+								: step === "quote"
+									? quoteTitle
+									: paymentSourceOnly
+										? "Change payment source"
+										: "Change compute subscription"}
 					</DialogTitle>
 					<DialogDescription>
-						{hasAcceptedChange
-							? "This plan change was already accepted. Checking its status will not submit another charge."
-							: displayedQuote
-								? displayedQuote.change_kind === "immediate_upgrade"
-									? "The quoted proration is charged now. Compute changes after payment is confirmed."
-									: `The current plan remains active until ${formatShortDate(displayedQuote.effective_at)}.`
-								: "Choose a compute plan and monthly or annual billing, then review the exact price and timing."}
+						{step === "pending"
+							? "This subscription change was already accepted. Checking its status will not submit another request or charge."
+							: step === "payment_method_required"
+								? "Add or choose a card in secure billing settings, then return and request a new quote."
+								: step === "quote" && displayedQuote
+									? fundingSourceSwitch
+										? `No payment is due now. Future renewals will use ${quoteFundingSource === "wallet" ? "Wallet" : "Card"}.`
+										: displayedQuote.change_kind === "immediate_upgrade"
+											? "The quoted proration is charged now. Compute changes after payment is confirmed."
+											: `The current plan remains active until ${formatShortDate(displayedQuote.effective_at)}.`
+									: paymentSourceOnly
+										? "Choose a new payment source. Your plan and billing term stay the same; eligibility is verified before the change is applied."
+										: "Choose a compute plan, billing term, and payment source, then review the exact price and timing."}
 					</DialogDescription>
 				</DialogHeader>
 
-				{hasAcceptedChange ? (
+				{step === "pending" ? (
 					<div className="flex flex-col gap-4">
 						<Alert>
 							<CalendarClock aria-hidden />
 							<AlertTitle>Still waiting for confirmation</AlertTitle>
 							<AlertDescription>
-								We don’t have a final result yet. Don’t submit another plan change. You can close
-								this window and check again in a few minutes; if it still hasn’t finished, contact
-								support.
+								We don’t have a final result yet. Don’t submit another subscription change. You can
+								close this window and check again in a few minutes; if it still hasn’t finished,
+								contact support.
 							</AlertDescription>
 						</Alert>
 						<DialogFooter>
@@ -235,33 +388,49 @@ export function PlanChangeDialog({
 							</Button>
 						</DialogFooter>
 					</div>
-				) : displayedQuote ? (
+				) : step === "payment_method_required" ? (
+					<PaymentMethodRequiredRecovery
+						isManagingPaymentMethods={isManagingPaymentMethods}
+						onClose={() => requestOpenChange(false)}
+						onManagePaymentMethods={onManagePaymentMethods}
+					/>
+				) : step === "quote" && displayedQuote ? (
 					<div className="flex flex-col gap-4">
 						<div className="grid gap-3 rounded-lg border bg-muted/20 p-3 sm:grid-cols-2">
 							<dl>
-								<dt className="text-xs text-muted-foreground">New subscription</dt>
+								<dt className="text-xs text-muted-foreground">
+									{fundingSourceSwitch ? "Subscription" : "New subscription"}
+								</dt>
 								<dd className="font-medium">
 									{computeTierLabel(planSlug(displayedQuote.target_plan_slug))} ·{" "}
 									{billingTermLabel(displayedQuote.target_billing_term_months)}
 								</dd>
 							</dl>
-							<dl>
-								<dt className="text-xs text-muted-foreground">
-									{displayedQuote.change_kind === "immediate_upgrade"
-										? "Due now"
-										: "Effective date"}
-								</dt>
-								<dd className="font-medium tabular-nums">
-									{displayedQuote.change_kind === "immediate_upgrade"
-										? quoteFundingSource === "wallet"
-											? displayedQuote.amount_usd
-												? formatUsdExact(displayedQuote.amount_usd)
-												: "—"
-											: formatCents(displayedQuote.amount_cents)
-										: formatShortDate(displayedQuote.effective_at)}
-								</dd>
-							</dl>
+							{!fundingSourceSwitch ? (
+								<dl>
+									<dt className="text-xs text-muted-foreground">
+										{displayedQuote.change_kind === "immediate_upgrade"
+											? "Due now"
+											: "Effective date"}
+									</dt>
+									<dd className="font-medium tabular-nums">
+										{displayedQuote.change_kind === "immediate_upgrade"
+											? quoteFundingSource === "wallet"
+												? displayedQuote.amount_usd
+													? formatUsdExact(displayedQuote.amount_usd)
+													: "—"
+												: formatCents(displayedQuote.amount_cents)
+											: formatShortDate(displayedQuote.effective_at)}
+									</dd>
+								</dl>
+							) : null}
 						</div>
+						{fundingSourceSwitch ? (
+							<FundingSourceSwitchSummary
+								amountCents={displayedQuote.amount_cents}
+								fundingSource={quoteFundingSource}
+							/>
+						) : null}
 						{quoteFundingSource === "wallet" &&
 						displayedQuote.change_kind === "immediate_upgrade" &&
 						displayedQuote.amount_usd &&
@@ -306,6 +475,16 @@ export function PlanChangeDialog({
 								</AlertDescription>
 							</Alert>
 						) : null}
+						{invalidFundingSourceSwitchQuote ? (
+							<Alert variant="destructive">
+								<TriangleAlert aria-hidden />
+								<AlertTitle>Payment source quote is invalid</AlertTitle>
+								<AlertDescription>
+									A payment source-only change must keep the current plan and term, have $0 due now,
+									and apply to future renewals. Go back and request a fresh quote.
+								</AlertDescription>
+							</Alert>
+						) : null}
 						<DialogFooter>
 							<Button
 								variant="ghost"
@@ -316,7 +495,12 @@ export function PlanChangeDialog({
 							</Button>
 							<Button
 								onClick={() => onConfirm(displayedQuote.operation_id)}
-								disabled={isConfirming || walletInsufficient || walletQuoteMissingAmount}
+								disabled={
+									isConfirming ||
+									walletInsufficient ||
+									walletQuoteMissingAmount ||
+									invalidFundingSourceSwitchQuote
+								}
 							>
 								{isConfirming ? (
 									<Spinner data-icon="inline-start" />
@@ -331,73 +515,90 @@ export function PlanChangeDialog({
 					</div>
 				) : (
 					<div className="flex flex-col gap-5">
-						<div className="grid gap-4 sm:grid-cols-2">
-							<div className="flex flex-col gap-1.5">
-								<Label htmlFor="plan-change-tier">Compute plan</Label>
-								<Select
-									items={PLAN_ITEMS}
-									value={selection.target_plan_slug}
-									onValueChange={updatePlan}
-								>
-									<SelectTrigger id="plan-change-tier" className="w-full">
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										<SelectGroup>
-											{PLAN_ITEMS.map((item) => (
-												<SelectItem key={item.value} value={item.value}>
-													{item.label}
-												</SelectItem>
-											))}
-										</SelectGroup>
-									</SelectContent>
-								</Select>
-							</div>
-							<div className="flex flex-col gap-1.5">
-								<Label>Billing term</Label>
-								<TermSwitcher
-									offers={offers}
-									value={selection.target_billing_term_months}
-									onChange={(billingTermMonths) =>
-										setSelection((current) => ({
-											...current,
-											target_billing_term_months: billingTermMonths === 12 ? 12 : 1,
-										}))
-									}
-								/>
-							</div>
-						</div>
-						{fundingSourceSelectable ? (
-							<div className="flex flex-col gap-1.5">
-								<Label id="plan-change-funding-label">Funding source</Label>
-								<ToggleGroup
-									value={[selection.funding_source]}
-									onValueChange={(value) => {
-										const next = value[0];
-										if (next === "stripe" || next === "wallet") {
-											setSelection((current) => ({
-												...current,
-												funding_source: next,
-											}));
-										}
-									}}
-									variant="outline"
-									className="grid w-full grid-cols-2"
-									aria-labelledby="plan-change-funding-label"
-								>
-									<ToggleGroupItem value="stripe">
-										<CreditCard data-icon="inline-start" /> Card
-									</ToggleGroupItem>
-									<ToggleGroupItem value="wallet">
-										<WalletCards data-icon="inline-start" /> Wallet
-									</ToggleGroupItem>
-								</ToggleGroup>
+						{paymentSourceOnly ? (
+							<div className="grid gap-3 border-y py-3 sm:grid-cols-2">
+								<dl>
+									<dt className="text-xs text-muted-foreground">Current plan</dt>
+									<dd className="font-medium">{computeTierLabel(currentPlanSlug)}</dd>
+								</dl>
+								<dl>
+									<dt className="text-xs text-muted-foreground">Billing term</dt>
+									<dd className="font-medium">{billingTermLabel(currentBillingTermMonths)}</dd>
+								</dl>
 							</div>
 						) : (
-							<p className="text-sm text-muted-foreground">
-								Funding source: {selection.funding_source === "wallet" ? "Wallet" : "Card"}
-							</p>
+							<div className="grid gap-4 sm:grid-cols-2">
+								<div className="flex flex-col gap-1.5">
+									<Label htmlFor="plan-change-tier">Compute plan</Label>
+									<Select
+										items={PLAN_ITEMS}
+										value={selection.target_plan_slug}
+										onValueChange={updatePlan}
+									>
+										<SelectTrigger id="plan-change-tier" className="w-full">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectGroup>
+												{PLAN_ITEMS.map((item) => (
+													<SelectItem key={item.value} value={item.value}>
+														{item.label}
+													</SelectItem>
+												))}
+											</SelectGroup>
+										</SelectContent>
+									</Select>
+								</div>
+								<div className="flex flex-col gap-1.5">
+									<Label>Billing term</Label>
+									<TermSwitcher
+										offers={offers}
+										value={selection.target_billing_term_months}
+										onChange={(billingTermMonths) =>
+											setSelection((current) =>
+												selectPlanChangeOffer(
+													current,
+													current.target_plan_slug,
+													billingTermMonths === 12 ? 12 : 1,
+													currentFundingSource,
+													allowCombinedChange,
+												),
+											)
+										}
+									/>
+								</div>
+							</div>
 						)}
+						<div className="flex flex-col gap-1.5">
+							<Label id="plan-change-funding-label">Payment source</Label>
+							<ToggleGroup
+								value={[selection.funding_source]}
+								onValueChange={(value) => {
+									const next = value[0];
+									if (next === "stripe" || next === "wallet") {
+										setSelection((current) =>
+											selectPlanChangeFundingSource(
+												current,
+												next,
+												currentPlanSlug,
+												currentBillingTermMonths,
+												allowCombinedChange,
+											),
+										);
+									}
+								}}
+								variant="outline"
+								className="grid w-full grid-cols-2"
+								aria-labelledby="plan-change-funding-label"
+							>
+								<ToggleGroupItem value="stripe">
+									<CreditCard data-icon="inline-start" /> Card
+								</ToggleGroupItem>
+								<ToggleGroupItem value="wallet">
+									<WalletCards data-icon="inline-start" /> Wallet
+								</ToggleGroupItem>
+							</ToggleGroup>
+						</div>
 						{selection.funding_source === "wallet" && !walletReady ? (
 							<p className="text-sm text-muted-foreground" role="status">
 								Loading Wallet balance…
@@ -415,7 +616,7 @@ export function PlanChangeDialog({
 							</Button>
 							<Button
 								onClick={() => onQuote(selection)}
-								disabled={isQuoting || noChange || !selectedOffer || !walletReady}
+								disabled={isQuoting || noChange || !offerReady || !walletReady}
 							>
 								{isQuoting ? <Spinner data-icon="inline-start" /> : null}
 								Review change

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts
@@ -1,12 +1,25 @@
 import { describe, expect, test } from "bun:test";
 import { hostedDeploymentFixture } from "../../hosted-deployment.test-fixture";
-import type { HostedDeployment } from "../contracts";
+import type { ComputePlanChangeQuoteResponse, HostedDeployment } from "../contracts";
+import { BillingApiError } from "../errors";
 import {
 	activePlanChangeOperationName,
 	defaultPlanChangeSelection,
+	isCombinedPaidPlanChange,
+	isFundingSourceOnlySelection,
+	isFundingSourceSwitchChangeKind,
 	isSamePlanChangeSelection,
+	isValidFundingSourceSwitchQuote,
+	isValidPaidPlanChangeQuote,
+	isWalletToCardSwitchSelection,
 	performanceUpgradeUnavailableReason,
+	planChangeNeedsOffer,
+	planChangeNeedsWalletBalance,
 	planChangeUnavailableReason,
+	selectPlanChangeFundingSource,
+	selectPlanChangeOffer,
+	shouldRecoverWalletToCardSwitch,
+	visiblePlanChangeOperationName,
 	walletBalanceAfterDebit,
 } from "./plan-change.logic";
 
@@ -44,6 +57,17 @@ describe("plan change recovery", () => {
 			}),
 		).toBeNull();
 	});
+
+	test("does not resurrect an explicitly terminated projected operation", () => {
+		expect(
+			visiblePlanChangeOperationName("operations/plan-change-pending", [
+				"operations/plan-change-pending",
+			]),
+		).toBeNull();
+		expect(
+			visiblePlanChangeOperationName("operations/plan-change-new", ["operations/plan-change-old"]),
+		).toBe("operations/plan-change-new");
+	});
 });
 
 describe("walletBalanceAfterDebit", () => {
@@ -60,6 +84,31 @@ describe("walletBalanceAfterDebit", () => {
 });
 
 describe("plan change selection", () => {
+	const fundingSourceSwitchQuote: ComputePlanChangeQuoteResponse = {
+		operation_id: "funding-source-switch-1",
+		subscription_id: 42,
+		funding_source: "wallet",
+		current_plan_slug: "compute_performance",
+		target_plan_slug: "compute_performance",
+		current_billing_term_months: 12,
+		target_billing_term_months: 12,
+		change_kind: "funding_source_switch",
+		billing_effect: "future_renewals",
+		status: "quoted",
+		effective_at: "2026-08-12T00:00:00Z",
+		proration_date: "2026-08-12T00:00:00Z",
+		expires_at: "2026-08-12T00:10:00Z",
+		amount_cents: 0,
+		amount_usd: "0.00",
+		currency: "usd",
+		stripe_invoice_preview_id: null,
+	};
+	const fundingSourceSwitchSelection = {
+		target_plan_slug: "compute_performance",
+		target_billing_term_months: 12,
+		funding_source: "wallet",
+	} as const;
+
 	test("defaults to the other compute tier while preserving the term", () => {
 		expect(defaultPlanChangeSelection("compute_basic", 12, "wallet")).toEqual({
 			target_plan_slug: "compute_performance",
@@ -73,7 +122,17 @@ describe("plan change selection", () => {
 		});
 	});
 
-	test("detects a no-op plan and term selection", () => {
+	test("can start a paid-subscription change on the current plan", () => {
+		expect(
+			defaultPlanChangeSelection("compute_performance", 12, "wallet", "compute_performance"),
+		).toEqual({
+			target_plan_slug: "compute_performance",
+			target_billing_term_months: 12,
+			funding_source: "wallet",
+		});
+	});
+
+	test("requires the plan, term, and funding source to match for a no-op", () => {
 		expect(
 			isSamePlanChangeSelection(
 				{
@@ -83,17 +142,237 @@ describe("plan change selection", () => {
 				},
 				"compute_performance",
 				12,
+				"stripe",
 			),
 		).toBe(true);
 		expect(
 			isSamePlanChangeSelection(
 				{
 					target_plan_slug: "compute_performance",
-					target_billing_term_months: 1,
-					funding_source: "stripe",
+					target_billing_term_months: 12,
+					funding_source: "wallet",
 				},
 				"compute_performance",
 				12,
+				"stripe",
+			),
+		).toBe(false);
+	});
+
+	test("keeps paid offer and funding-source changes mutually exclusive", () => {
+		const current = {
+			target_plan_slug: "compute_performance",
+			target_billing_term_months: 12,
+			funding_source: "stripe",
+		} as const;
+		const railSwitch = selectPlanChangeFundingSource(
+			{ ...current, target_plan_slug: "compute_basic", target_billing_term_months: 1 },
+			"wallet",
+			"compute_performance",
+			12,
+			false,
+		);
+		expect(railSwitch).toEqual({
+			target_plan_slug: "compute_performance",
+			target_billing_term_months: 12,
+			funding_source: "wallet",
+		});
+		expect(planChangeNeedsWalletBalance(railSwitch, "compute_performance", 12)).toBe(false);
+		expect(planChangeNeedsOffer(railSwitch, "compute_performance", 12)).toBe(false);
+
+		const offerChange = selectPlanChangeOffer(railSwitch, "compute_basic", 1, "stripe", false);
+		expect(offerChange).toEqual({
+			target_plan_slug: "compute_basic",
+			target_billing_term_months: 1,
+			funding_source: "stripe",
+		});
+		expect(isCombinedPaidPlanChange(offerChange, "compute_performance", 12, "stripe")).toBe(false);
+		expect(planChangeNeedsOffer(offerChange, "compute_performance", 12)).toBe(true);
+		expect(
+			isCombinedPaidPlanChange(
+				{ ...offerChange, funding_source: "wallet" },
+				"compute_performance",
+				12,
+				"stripe",
+			),
+		).toBe(true);
+	});
+
+	test("allows a past-due flow to select only a different funding source", () => {
+		const railOnly = {
+			target_plan_slug: "compute_performance",
+			target_billing_term_months: 12,
+			funding_source: "wallet",
+		} as const;
+		expect(isFundingSourceOnlySelection(railOnly, "compute_performance", 12, "stripe")).toBe(true);
+		expect(
+			isFundingSourceOnlySelection(
+				{ ...railOnly, target_plan_slug: "compute_basic" },
+				"compute_performance",
+				12,
+				"stripe",
+			),
+		).toBe(false);
+		expect(
+			isFundingSourceOnlySelection(
+				{ ...railOnly, funding_source: "stripe" },
+				"compute_performance",
+				12,
+				"stripe",
+			),
+		).toBe(false);
+	});
+
+	test("preserves Included Basic funding selection during its upgrade", () => {
+		const selection = selectPlanChangeFundingSource(
+			{
+				target_plan_slug: "compute_performance",
+				target_billing_term_months: 1,
+				funding_source: "stripe",
+			},
+			"wallet",
+			"compute_basic",
+			1,
+			true,
+		);
+		expect(selection).toEqual({
+			target_plan_slug: "compute_performance",
+			target_billing_term_months: 1,
+			funding_source: "wallet",
+		});
+		expect(planChangeNeedsWalletBalance(selection, "compute_basic", 1)).toBe(true);
+	});
+
+	test("recognizes a rail-only Wallet to Card selection", () => {
+		const selection = {
+			target_plan_slug: "compute_performance",
+			target_billing_term_months: 12,
+			funding_source: "stripe",
+		} as const;
+		expect(isWalletToCardSwitchSelection(selection, "compute_performance", 12, "wallet")).toBe(
+			true,
+		);
+		expect(
+			isWalletToCardSwitchSelection(
+				{ ...selection, target_billing_term_months: 1 },
+				"compute_performance",
+				12,
+				"wallet",
+			),
+		).toBe(false);
+	});
+
+	test("recognizes the additive funding-source switch quote kind", () => {
+		expect(isFundingSourceSwitchChangeKind("funding_source_switch")).toBe(true);
+		expect(isFundingSourceSwitchChangeKind("immediate_upgrade")).toBe(false);
+	});
+
+	test("accepts only the exact zero-due future-renewal rail switch contract", () => {
+		expect(
+			isValidFundingSourceSwitchQuote(
+				fundingSourceSwitchQuote,
+				fundingSourceSwitchSelection,
+				"compute_performance",
+				12,
+				"stripe",
+			),
+		).toBe(true);
+
+		for (const quote of [
+			{ ...fundingSourceSwitchQuote, amount_cents: 1 },
+			{ ...fundingSourceSwitchQuote, billing_effect: "immediate_proration" as const },
+			{ ...fundingSourceSwitchQuote, target_billing_term_months: 1 as const },
+		]) {
+			expect(
+				isValidFundingSourceSwitchQuote(
+					quote,
+					fundingSourceSwitchSelection,
+					"compute_performance",
+					12,
+					"stripe",
+				),
+			).toBe(false);
+		}
+	});
+
+	test("keeps ordinary paid quotes on the selected offer and current payment source", () => {
+		const selection = {
+			target_plan_slug: "compute_performance",
+			target_billing_term_months: 12,
+			funding_source: "stripe",
+		} as const;
+		const quote = {
+			...fundingSourceSwitchQuote,
+			current_plan_slug: "compute_basic",
+			target_plan_slug: "compute_performance",
+			current_billing_term_months: 1,
+			target_billing_term_months: 12,
+			change_kind: "immediate_upgrade",
+			billing_effect: "immediate_proration",
+			funding_source: "stripe",
+			amount_cents: 2_000,
+		} as const;
+
+		expect(isValidPaidPlanChangeQuote(quote, selection, "compute_basic", 1, "stripe")).toBe(true);
+		expect(
+			isValidPaidPlanChangeQuote(
+				{ ...quote, funding_source: "wallet" },
+				selection,
+				"compute_basic",
+				1,
+				"stripe",
+			),
+		).toBe(false);
+		expect(
+			isValidPaidPlanChangeQuote(
+				{ ...quote, target_billing_term_months: 1 },
+				selection,
+				"compute_basic",
+				1,
+				"stripe",
+			),
+		).toBe(false);
+		expect(
+			isValidPaidPlanChangeQuote(
+				{ ...quote, billing_effect: "period_end" },
+				selection,
+				"compute_basic",
+				1,
+				"stripe",
+			),
+		).toBe(false);
+	});
+
+	test("offers payment-method recovery for the quote-time stable token only", () => {
+		const walletToCard = {
+			...fundingSourceSwitchSelection,
+			funding_source: "stripe",
+		} as const;
+		expect(
+			shouldRecoverWalletToCardSwitch(
+				new BillingApiError(409, "payment_method_required"),
+				walletToCard,
+				"compute_performance",
+				12,
+				"wallet",
+			),
+		).toBe(true);
+		expect(
+			shouldRecoverWalletToCardSwitch(
+				new BillingApiError(409, "payment_method_required"),
+				{ ...walletToCard, target_billing_term_months: 1 },
+				"compute_performance",
+				12,
+				"wallet",
+			),
+		).toBe(false);
+		expect(
+			shouldRecoverWalletToCardSwitch(
+				new BillingApiError(409, "operation_aborted"),
+				walletToCard,
+				"compute_performance",
+				12,
+				"wallet",
 			),
 		).toBe(false);
 	});
@@ -108,7 +387,7 @@ describe("planChangeUnavailableReason", () => {
 				status: "active",
 				subscriptionId: 42,
 			}),
-		).toBe("Plan changes are temporarily unavailable.");
+		).toBe("Subscription changes are temporarily unavailable.");
 	});
 
 	test("requires pending cancellation to be resumed first", () => {
@@ -119,15 +398,23 @@ describe("planChangeUnavailableReason", () => {
 				status: "active",
 				subscriptionId: 42,
 			}),
-		).toBe("Resume this subscription before changing its plan or billing term.");
+		).toBe("Resume this subscription before changing its plan, billing term, or payment source.");
 	});
 
-	test("allows only active subscriptions with a server id", () => {
+	test("allows active and past-due subscriptions with a server id", () => {
 		expect(
 			planChangeUnavailableReason({
 				canCreateCloudAgents: true,
 				cancelAtPeriodEnd: false,
 				status: "active",
+				subscriptionId: 42,
+			}),
+		).toBeNull();
+		expect(
+			planChangeUnavailableReason({
+				canCreateCloudAgents: true,
+				cancelAtPeriodEnd: false,
+				status: "past_due",
 				subscriptionId: 42,
 			}),
 		).toBeNull();

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts
@@ -7,7 +7,6 @@ import {
 	defaultPlanChangeSelection,
 	isCombinedPaidPlanChange,
 	isFundingSourceOnlySelection,
-	isFundingSourceSwitchChangeKind,
 	isSamePlanChangeSelection,
 	isValidFundingSourceSwitchQuote,
 	isValidPaidPlanChangeQuote,
@@ -260,11 +259,6 @@ describe("plan change selection", () => {
 				"wallet",
 			),
 		).toBe(false);
-	});
-
-	test("recognizes the additive funding-source switch quote kind", () => {
-		expect(isFundingSourceSwitchChangeKind("funding_source_switch")).toBe(true);
-		expect(isFundingSourceSwitchChangeKind("immediate_upgrade")).toBe(false);
 	});
 
 	test("accepts only the exact zero-due future-renewal rail switch contract", () => {

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
@@ -1,5 +1,4 @@
 import type {
-	ComputePlanChangeKind,
 	ComputePlanChangeQuoteRequest,
 	ComputePlanChangeQuoteResponse,
 	ComputePlanSlug,
@@ -252,14 +251,10 @@ export function shouldRecoverWalletToCardSwitch(
 	);
 }
 
-export function isFundingSourceSwitchChangeKind(changeKind: ComputePlanChangeKind): boolean {
-	return changeKind === "funding_source_switch";
-}
-
 export function isFundingSourceSwitchQuote(
 	quote: Pick<ComputePlanChangeQuoteResponse, "change_kind"> | null,
 ): boolean {
-	return quote !== null && isFundingSourceSwitchChangeKind(quote.change_kind);
+	return quote?.change_kind === "funding_source_switch";
 }
 
 export function isValidFundingSourceSwitchQuote(

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
@@ -1,8 +1,11 @@
 import type {
+	ComputePlanChangeKind,
 	ComputePlanChangeQuoteRequest,
+	ComputePlanChangeQuoteResponse,
 	ComputePlanSlug,
 	HostedDeployment,
 } from "@/hosted/billing/contracts";
+import { isPaymentMethodRequiredError } from "@/hosted/billing/errors";
 import { COMPUTE_BASIC_SLUG, COMPUTE_PERFORMANCE_SLUG } from "./subscription-utils";
 
 export type PlanChangeSelection = Omit<ComputePlanChangeQuoteRequest, "subscription_id"> & {
@@ -52,6 +55,15 @@ export function activePlanChangeOperationName(
 		return null;
 	}
 	return operation.name.trim() || null;
+}
+
+export function visiblePlanChangeOperationName(
+	projectedOperationName: string | null,
+	ignoredOperationNames: readonly string[],
+): string | null {
+	return projectedOperationName !== null && ignoredOperationNames.includes(projectedOperationName)
+		? null
+		: projectedOperationName;
 }
 
 function isHostedComputeUpgradeIneligibilityReason(
@@ -105,10 +117,12 @@ export function defaultPlanChangeSelection(
 	currentPlanSlug: ComputePlanSlug,
 	currentBillingTermMonths: ComputePlanChangeQuoteRequest["target_billing_term_months"],
 	fundingSource: PlanChangeSelection["funding_source"],
+	initialPlanSlug: ComputePlanSlug = currentPlanSlug === COMPUTE_PERFORMANCE_SLUG
+		? COMPUTE_BASIC_SLUG
+		: COMPUTE_PERFORMANCE_SLUG,
 ): PlanChangeSelection {
 	return {
-		target_plan_slug:
-			currentPlanSlug === COMPUTE_PERFORMANCE_SLUG ? COMPUTE_BASIC_SLUG : COMPUTE_PERFORMANCE_SLUG,
+		target_plan_slug: initialPlanSlug,
 		target_billing_term_months: currentBillingTermMonths,
 		funding_source: fundingSource,
 	};
@@ -118,10 +132,185 @@ export function isSamePlanChangeSelection(
 	selection: PlanChangeSelection,
 	currentPlanSlug: ComputePlanSlug,
 	currentBillingTermMonths: number,
+	currentFundingSource: PlanChangeSelection["funding_source"],
 ): boolean {
 	return (
 		selection.target_plan_slug === currentPlanSlug &&
+		selection.target_billing_term_months === currentBillingTermMonths &&
+		selection.funding_source === currentFundingSource
+	);
+}
+
+export function selectPlanChangeOffer(
+	selection: PlanChangeSelection,
+	targetPlanSlug: ComputePlanSlug,
+	targetBillingTermMonths: PlanChangeSelection["target_billing_term_months"],
+	currentFundingSource: PlanChangeSelection["funding_source"],
+	allowCombinedChange: boolean,
+): PlanChangeSelection {
+	return {
+		...selection,
+		target_plan_slug: targetPlanSlug,
+		target_billing_term_months: targetBillingTermMonths,
+		funding_source: allowCombinedChange ? selection.funding_source : currentFundingSource,
+	};
+}
+
+export function selectPlanChangeFundingSource(
+	selection: PlanChangeSelection,
+	fundingSource: PlanChangeSelection["funding_source"],
+	currentPlanSlug: ComputePlanSlug,
+	currentBillingTermMonths: PlanChangeSelection["target_billing_term_months"],
+	allowCombinedChange: boolean,
+): PlanChangeSelection {
+	return {
+		...selection,
+		target_plan_slug: allowCombinedChange ? selection.target_plan_slug : currentPlanSlug,
+		target_billing_term_months: allowCombinedChange
+			? selection.target_billing_term_months
+			: currentBillingTermMonths,
+		funding_source: fundingSource,
+	};
+}
+
+export function planChangeNeedsWalletBalance(
+	selection: PlanChangeSelection,
+	currentPlanSlug: ComputePlanSlug,
+	currentBillingTermMonths: number,
+): boolean {
+	return (
+		selection.funding_source === "wallet" &&
+		(selection.target_plan_slug !== currentPlanSlug ||
+			selection.target_billing_term_months !== currentBillingTermMonths)
+	);
+}
+
+export function planChangeNeedsOffer(
+	selection: PlanChangeSelection,
+	currentPlanSlug: ComputePlanSlug,
+	currentBillingTermMonths: number,
+): boolean {
+	return (
+		selection.target_plan_slug !== currentPlanSlug ||
+		selection.target_billing_term_months !== currentBillingTermMonths
+	);
+}
+
+export function isCombinedPaidPlanChange(
+	selection: PlanChangeSelection,
+	currentPlanSlug: ComputePlanSlug,
+	currentBillingTermMonths: number,
+	currentFundingSource: PlanChangeSelection["funding_source"],
+): boolean {
+	const offerChanges =
+		selection.target_plan_slug !== currentPlanSlug ||
+		selection.target_billing_term_months !== currentBillingTermMonths;
+	return offerChanges && selection.funding_source !== currentFundingSource;
+}
+
+export function isFundingSourceOnlySelection(
+	selection: PlanChangeSelection,
+	currentPlanSlug: ComputePlanSlug,
+	currentBillingTermMonths: number,
+	currentFundingSource: PlanChangeSelection["funding_source"],
+): boolean {
+	return (
+		selection.target_plan_slug === currentPlanSlug &&
+		selection.target_billing_term_months === currentBillingTermMonths &&
+		selection.funding_source !== currentFundingSource
+	);
+}
+
+export function isWalletToCardSwitchSelection(
+	selection: PlanChangeSelection,
+	currentPlanSlug: ComputePlanSlug,
+	currentBillingTermMonths: number,
+	currentFundingSource: PlanChangeSelection["funding_source"],
+): boolean {
+	return (
+		currentFundingSource === "wallet" &&
+		selection.funding_source === "stripe" &&
+		selection.target_plan_slug === currentPlanSlug &&
 		selection.target_billing_term_months === currentBillingTermMonths
+	);
+}
+
+export function shouldRecoverWalletToCardSwitch(
+	error: unknown,
+	selection: PlanChangeSelection,
+	currentPlanSlug: ComputePlanSlug,
+	currentBillingTermMonths: number,
+	currentFundingSource: PlanChangeSelection["funding_source"],
+): boolean {
+	return (
+		isWalletToCardSwitchSelection(
+			selection,
+			currentPlanSlug,
+			currentBillingTermMonths,
+			currentFundingSource,
+		) && isPaymentMethodRequiredError(error)
+	);
+}
+
+export function isFundingSourceSwitchChangeKind(changeKind: ComputePlanChangeKind): boolean {
+	return changeKind === "funding_source_switch";
+}
+
+export function isFundingSourceSwitchQuote(
+	quote: Pick<ComputePlanChangeQuoteResponse, "change_kind"> | null,
+): boolean {
+	return quote !== null && isFundingSourceSwitchChangeKind(quote.change_kind);
+}
+
+export function isValidFundingSourceSwitchQuote(
+	quote: ComputePlanChangeQuoteResponse,
+	selection: PlanChangeSelection,
+	currentPlanSlug: ComputePlanSlug,
+	currentBillingTermMonths: PlanChangeSelection["target_billing_term_months"],
+	currentFundingSource: PlanChangeSelection["funding_source"],
+): boolean {
+	return (
+		selection.funding_source !== currentFundingSource &&
+		quote.change_kind === "funding_source_switch" &&
+		quote.billing_effect === "future_renewals" &&
+		quote.amount_cents === 0 &&
+		quote.current_plan_slug === currentPlanSlug &&
+		quote.target_plan_slug === currentPlanSlug &&
+		quote.current_billing_term_months === currentBillingTermMonths &&
+		quote.target_billing_term_months === currentBillingTermMonths &&
+		selection.target_plan_slug === currentPlanSlug &&
+		selection.target_billing_term_months === currentBillingTermMonths &&
+		quote.funding_source === selection.funding_source
+	);
+}
+
+export function isValidPaidPlanChangeQuote(
+	quote: ComputePlanChangeQuoteResponse,
+	selection: PlanChangeSelection,
+	currentPlanSlug: ComputePlanSlug,
+	currentBillingTermMonths: PlanChangeSelection["target_billing_term_months"],
+	currentFundingSource: PlanChangeSelection["funding_source"],
+): boolean {
+	if (selection.funding_source !== currentFundingSource) {
+		return isValidFundingSourceSwitchQuote(
+			quote,
+			selection,
+			currentPlanSlug,
+			currentBillingTermMonths,
+			currentFundingSource,
+		);
+	}
+	const billingEffectMatches =
+		quote.change_kind === "immediate_upgrade"
+			? quote.billing_effect === "immediate_proration"
+			: quote.change_kind === "scheduled_downgrade" && quote.billing_effect === "period_end";
+	return (
+		billingEffectMatches &&
+		quote.current_plan_slug === currentPlanSlug &&
+		quote.current_billing_term_months === currentBillingTermMonths &&
+		quote.target_plan_slug === selection.target_plan_slug &&
+		quote.target_billing_term_months === selection.target_billing_term_months &&
+		quote.funding_source === currentFundingSource
 	);
 }
 
@@ -136,13 +325,13 @@ export function planChangeUnavailableReason({
 	status: string;
 	subscriptionId: number | null;
 }): string | null {
-	if (!canCreateCloudAgents) return "Plan changes are temporarily unavailable.";
+	if (!canCreateCloudAgents) return "Subscription changes are temporarily unavailable.";
 	if (cancelAtPeriodEnd)
-		return "Resume this subscription before changing its plan or billing term.";
+		return "Resume this subscription before changing its plan, billing term, or payment source.";
 	if (!subscriptionId)
-		return "Plan changes will be available after subscription details finish syncing.";
-	if (status !== "active") {
-		return "Resolve the subscription status before changing its plan or billing term.";
+		return "Subscription changes will be available after details finish syncing.";
+	if (status !== "active" && status !== "past_due") {
+		return "Resolve the subscription status before changing its plan, billing term, or payment source.";
 	}
 	return null;
 }

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, test } from "bun:test";
+import { isValidElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 type SubscriptionsSectionModule =
@@ -21,14 +22,32 @@ beforeAll(async () => {
 });
 
 describe("SubscriptionsSection", () => {
-	test("keeps deleted agents unlinked and exposes pagination", () => {
+	test("links a named agent to its billing plan and keeps deleted agents unlinked", () => {
 		if (!SubscriptionAgentLink || !SubscriptionLoadMore) {
 			throw new Error("Subscriptions section components were not loaded");
 		}
-		const deletedAgent = renderToStaticMarkup(<SubscriptionAgentLink deploymentId={null} />);
-		expect(deletedAgent).toContain("Deleted agent");
-		expect(deletedAgent).not.toContain("View agent");
-		expect(deletedAgent).not.toContain("href=");
+		const namedAgent = SubscriptionAgentLink({
+			deploymentId: "hdep_live",
+			agentName: "Production agent",
+		});
+		if (!isValidElement(namedAgent)) throw new Error("Expected a named agent link");
+		expect(namedAgent.props).toMatchObject({
+			children: "Production agent",
+			to: "/agents/$id/$section",
+			params: { id: "hdep_live", section: "settings" },
+			search: { source: "on-clawdi", settings: "billing-plan" },
+		});
+
+		for (const deletedAgent of [
+			renderToStaticMarkup(<SubscriptionAgentLink deploymentId={null} agentName={null} />),
+			renderToStaticMarkup(
+				<SubscriptionAgentLink deploymentId="hdep_stale" agentName={null} />,
+			),
+			renderToStaticMarkup(<SubscriptionAgentLink deploymentId={null} agentName="Stale agent" />),
+		]) {
+			expect(deletedAgent).toContain("Deleted agent");
+			expect(deletedAgent).not.toContain("href=");
+		}
 
 		const loadMore = renderToStaticMarkup(
 			<SubscriptionLoadMore isLoading={false} onLoadMore={() => undefined} />,

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
@@ -40,9 +40,7 @@ describe("SubscriptionsSection", () => {
 
 		for (const deletedAgent of [
 			renderToStaticMarkup(<SubscriptionAgentLink deploymentId={null} agentName={null} />),
-			renderToStaticMarkup(
-				<SubscriptionAgentLink deploymentId="hdep_stale" agentName={null} />,
-			),
+			renderToStaticMarkup(<SubscriptionAgentLink deploymentId="hdep_stale" agentName={null} />),
 			renderToStaticMarkup(<SubscriptionAgentLink deploymentId={null} agentName="Stale agent" />),
 		]) {
 			expect(deletedAgent).toContain("Deleted agent");

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
@@ -6,6 +6,9 @@ type SubscriptionsSectionModule =
 
 let SubscriptionAgentLink: SubscriptionsSectionModule["SubscriptionAgentLink"] | null = null;
 let SubscriptionLoadMore: SubscriptionsSectionModule["SubscriptionLoadMore"] | null = null;
+let subscriptionPaymentSourceLabel:
+	| SubscriptionsSectionModule["subscriptionPaymentSourceLabel"]
+	| null = null;
 
 beforeAll(async () => {
 	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
@@ -14,6 +17,7 @@ beforeAll(async () => {
 	const module = await import("@/hosted/billing/subscription/subscriptions-section");
 	SubscriptionAgentLink = module.SubscriptionAgentLink;
 	SubscriptionLoadMore = module.SubscriptionLoadMore;
+	subscriptionPaymentSourceLabel = module.subscriptionPaymentSourceLabel;
 });
 
 describe("SubscriptionsSection", () => {
@@ -30,5 +34,14 @@ describe("SubscriptionsSection", () => {
 			<SubscriptionLoadMore isLoading={false} onLoadMore={() => undefined} />,
 		);
 		expect(loadMore).toContain("Load more");
+	});
+
+	test("labels Included, Card, and Wallet from the generated funding source", () => {
+		if (!subscriptionPaymentSourceLabel) {
+			throw new Error("Subscription payment source helper was not loaded");
+		}
+		expect(subscriptionPaymentSourceLabel(null)).toBe("Included");
+		expect(subscriptionPaymentSourceLabel("stripe")).toBe("Card");
+		expect(subscriptionPaymentSourceLabel("wallet")).toBe("Wallet");
 	});
 });

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -32,7 +32,7 @@ import { formatShortDate } from "@/lib/format";
 import { shouldBlockQueryError } from "@/lib/query-state";
 
 const SUBSCRIPTION_GRID_CLASS =
-	"grid gap-4 lg:grid-cols-[minmax(10rem,1.35fr)_minmax(9rem,1fr)_minmax(7rem,.65fr)_minmax(8rem,.8fr)_minmax(9rem,auto)] lg:items-center";
+	"grid gap-4 lg:grid-cols-[minmax(10rem,1.35fr)_minmax(8rem,1fr)_minmax(7rem,.7fr)_minmax(7rem,.65fr)_minmax(8rem,.8fr)_minmax(9rem,auto)] lg:items-center";
 
 const STATUS_PRESENTATION: Record<
 	ComputeSubscriptionListItem["status"],
@@ -49,6 +49,15 @@ function planLabel(planSlug: string): string {
 		return `Compute ${computeTierLabel(planSlug)}`;
 	}
 	return planSlug.replace(/^compute_/, "").replaceAll("_", " ");
+}
+
+export function subscriptionPaymentSourceLabel(
+	fundingSource: ComputeSubscriptionListItem["funding_source"],
+): string {
+	if (fundingSource === null) return "Included";
+	if (fundingSource === "stripe") return "Card";
+	if (fundingSource === "wallet") return "Wallet";
+	return "Unavailable";
 }
 
 function priceLabel(subscription: ComputeSubscriptionListItem): string {
@@ -215,6 +224,12 @@ function SubscriptionRow({ subscription }: { subscription: ComputeSubscriptionLi
 				<SubscriptionAgentLink deploymentId={subscription.deployment_id} />
 			</div>
 			<div>
+				<FieldLabel>Payment source</FieldLabel>
+				<span className="text-sm font-medium">
+					{subscriptionPaymentSourceLabel(subscription.funding_source)}
+				</span>
+			</div>
+			<div>
 				<FieldLabel>Price</FieldLabel>
 				<div className="font-medium tabular-nums">{priceLabel(subscription)}</div>
 				<div className="mt-0.5 text-xs text-muted-foreground">
@@ -240,6 +255,7 @@ function SubscriptionListSkeleton() {
 				<div key={key} className={`${SUBSCRIPTION_GRID_CLASS} px-3 py-4`}>
 					<Skeleton className="h-9 w-36" />
 					<Skeleton className="h-4 w-24" />
+					<Skeleton className="h-4 w-16" />
 					<Skeleton className="h-9 w-20" />
 					<Skeleton className="h-4 w-28" />
 					<Skeleton className="h-8 w-20 lg:justify-self-end" />
@@ -258,7 +274,7 @@ export function SubscriptionsSection() {
 			data-hosted="true"
 			headingLevel={3}
 			title="Your subscriptions"
-			description="Manage every paid compute subscription in one place."
+			description="Manage every compute subscription in one place."
 		>
 			{subscriptions.isLoading ? (
 				<SubscriptionListSkeleton />
@@ -278,6 +294,7 @@ export function SubscriptionsSection() {
 						>
 							<span>Subscription</span>
 							<span>Agent</span>
+							<span>Payment source</span>
 							<span>Price</span>
 							<span>Renewal / end</span>
 							<span className="text-right">Actions</span>
@@ -308,7 +325,7 @@ export function SubscriptionsSection() {
 					variant="inset"
 					icon={CreditCard}
 					title="No compute subscriptions"
-					description="Paid subscriptions will appear here when you start a hosted agent."
+					description="Compute subscriptions will appear here when you start a hosted agent."
 					className="py-8 md:p-8"
 				/>
 			)}

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -172,18 +172,21 @@ function SubscriptionActions({ subscription }: { subscription: ComputeSubscripti
 
 export function SubscriptionAgentLink({
 	deploymentId,
+	agentName,
 }: {
 	deploymentId: ComputeSubscriptionListItem["deployment_id"];
+	agentName: ComputeSubscriptionListItem["agent_name"];
 }) {
-	return deploymentId ? (
+	return deploymentId && agentName ? (
 		<Link
 			{...agentSectionLink(deploymentId, "settings", {
 				source: "on-clawdi",
 				settings: "billing-plan",
 			})}
-			className="font-medium text-primary underline-offset-4 hover:underline"
+			className="block min-w-0 truncate font-medium text-primary underline-offset-4 hover:underline"
+			title={agentName}
 		>
-			View agent
+			{agentName}
 		</Link>
 	) : (
 		<span className="font-medium text-muted-foreground">Deleted agent</span>
@@ -221,7 +224,10 @@ function SubscriptionRow({ subscription }: { subscription: ComputeSubscriptionLi
 			</div>
 			<div className="min-w-0">
 				<FieldLabel>Agent</FieldLabel>
-				<SubscriptionAgentLink deploymentId={subscription.deployment_id} />
+				<SubscriptionAgentLink
+					deploymentId={subscription.deployment_id}
+					agentName={subscription.agent_name}
+				/>
 			</div>
 			<div>
 				<FieldLabel>Payment source</FieldLabel>

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -581,6 +581,16 @@ export interface components {
              * @enum {string}
              */
             fundingSource: "stripe" | "wallet";
+            /**
+             * Changekind
+             * @enum {string}
+             */
+            changeKind: "immediate_upgrade" | "scheduled_downgrade" | "funding_source_switch";
+            /**
+             * Billingeffect
+             * @enum {string}
+             */
+            billingEffect: "immediate_proration" | "period_end" | "future_renewals";
             /** Sourceplanslug */
             sourcePlanSlug: string;
             /** Targetplanslug */
@@ -1237,7 +1247,12 @@ export interface components {
              * Change Kind
              * @enum {string}
              */
-            change_kind: "immediate_upgrade" | "scheduled_downgrade";
+            change_kind: "immediate_upgrade" | "scheduled_downgrade" | "funding_source_switch";
+            /**
+             * Billing Effect
+             * @enum {string}
+             */
+            billing_effect: "immediate_proration" | "period_end" | "future_renewals";
             /**
              * Status
              * @default quoted
@@ -1319,6 +1334,8 @@ export interface components {
             subscription_id: string;
             /** Plan Slug */
             plan_slug: string;
+            /** Funding Source */
+            funding_source: ("stripe" | "wallet") | null;
             /**
              * Status
              * @enum {string}

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1359,6 +1359,8 @@ export interface components {
             cancel_at_period_end: boolean;
             /** Deployment Id */
             deployment_id?: string | null;
+            /** Agent Name */
+            agent_name: string | null;
             /** Is Orphan */
             is_orphan: boolean;
         };


### PR DESCRIPTION
## Summary

- let existing paid Compute subscriptions switch future renewals between Card and Wallet
- keep plan and billing-term changes mutually exclusive from payment-source changes
- show strict zero-due/future-renewal confirmation semantics and surface Included/Card/Wallet in subscription inventory
- recover quote-time and LRO `payment_method_required` through the existing Stripe billing portal, requiring a fresh quote and submit afterward
- parse the generated LRO contract strictly and invalidate subscription inventory after terminal plan-change outcomes

## Dependency

Depends on Clawdi-AI/clawdi-hosted#1700 for the additive `funding_source_switch`, `future_renewals`, required-nullable `funding_source`, and stable payment-method recovery contract.

## Verification

- Docker clean runner: `bash scripts/test.sh web shared`
  - Web typecheck, full unit tests, Biome, and OSS production build passed
  - shared checks passed
- focused billing suite: 92 passed
- hosted Card to Wallet Playwright flow: passed
- `git diff --check`: passed

No hosted backend implementation or production operation is included in this repository.