### PR TITLE
Redesign compute subscriptions as responsive cards

### DIFF
--- a/apps/web/e2e/hosted-stub-api.ts
+++ b/apps/web/e2e/hosted-stub-api.ts
@@ -7,6 +7,7 @@ export type DeploymentComputeSubscription = NonNullable<
 
 type PlanChangeProgress = DeployComponents["schemas"]["ComputePlanChangeProgress"];
 type PlanChangeKind = PlanChangeProgress["changeKind"];
+type SubscriptionListResponse = DeployComponents["schemas"]["V2ComputeSubscriptionListResponse"];
 type PlanChangeBillingEffect = PlanChangeProgress["billingEffect"];
 type PlanChangeQuote = DeployComponents["schemas"]["V2ComputePlanChangeQuoteResponse"];
 type PlanChangeOperation = DeployComponents["schemas"]["LongRunningOperation"];
@@ -774,6 +775,7 @@ export type HostedApiStubOptions = {
 	runtimeUiRedemptionRequests?: string[];
 	runtimeUiRedemptionResponses?: StubResponse[];
 	resumeRequests?: string[];
+	subscriptionPages?: Record<string, SubscriptionListResponse>;
 	subscriptionQuoteRequests?: string[];
 	subscriptionQuoteResponses?: unknown[];
 	startError?: { status: number; detail: string };
@@ -809,6 +811,17 @@ export async function stubHostedApi(page: Page, options: HostedApiStubOptions = 
 			);
 		}
 		if (p === "/v2/subscription/plans") return fulfillJson(r, plans);
+		if (p === "/v2/subscriptions" && r.request().method() === "GET") {
+			const cursor = new URL(r.request().url()).searchParams.get("cursor") ?? "initial";
+			return fulfillJson(
+				r,
+				options.subscriptionPages?.[cursor] ?? {
+					items: [],
+					has_more: false,
+					next_cursor: null,
+				},
+			);
+		}
 		if (p === "/v2/wallet" && r.request().method() === "GET") {
 			return fulfillJson(r, currentWallet);
 		}

--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -1,0 +1,248 @@
+import type { DeployComponents } from "@clawdi/shared/api";
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import {
+	basicPlan,
+	cancelPendingBasicDeployment,
+	cardPastDueDeployment,
+	collectBrowserErrors,
+	gotoHostedAgentSettings,
+	gotoHostedSettingsDialog,
+	paidBasicDeployment,
+	performancePlan,
+	stubHostedApi,
+	terminalFallbackDeployment,
+} from "./hosted-stub-api";
+
+type Subscription = DeployComponents["schemas"]["V2ComputeSubscriptionListItem"];
+
+const longAgentName =
+	"Production research agent with an intentionally long name for compact subscription layouts";
+
+function subscription(
+	subscriptionId: string,
+	status: Subscription["status"],
+	overrides: Partial<Subscription> = {},
+): Subscription {
+	return {
+		subscription_id: subscriptionId,
+		plan_slug: "compute_performance",
+		funding_source: "stripe",
+		status,
+		price_cents: 19_000,
+		currency: "usd",
+		billing_term_months: 12,
+		current_period_end: "2099-08-12T12:00:00Z",
+		cancel_at_period_end: false,
+		deployment_id: `hdep_${subscriptionId}`,
+		agent_name: subscriptionId,
+		is_orphan: false,
+		...overrides,
+	};
+}
+
+async function expectCardsFit(container: Locator) {
+	const metrics = await container
+		.locator('[data-slot="compute-subscription-card"]')
+		.evaluateAll((cards) =>
+			cards.map((card) => {
+				const box = card.getBoundingClientRect();
+				const action = card.querySelector<HTMLElement>(
+					'[data-slot="compute-subscription-actions"]',
+				);
+				const actionBox = action?.getBoundingClientRect();
+				return {
+					clientWidth: card.clientWidth,
+					scrollWidth: card.scrollWidth,
+					box: box.toJSON(),
+					actionBox: actionBox?.toJSON() ?? null,
+					detailCount: card.querySelectorAll("dl > div").length,
+				};
+			}),
+		);
+
+	expect(metrics).not.toHaveLength(0);
+	for (const metric of metrics) {
+		expect(metric.scrollWidth).toBeLessThanOrEqual(metric.clientWidth + 1);
+		expect(metric.detailCount).toBe(4);
+		if (metric.actionBox) {
+			expect(metric.actionBox.x).toBeGreaterThanOrEqual(metric.box.x - 1);
+			expect(metric.actionBox.x + metric.actionBox.width).toBeLessThanOrEqual(
+				metric.box.x + metric.box.width + 1,
+			);
+			expect(metric.actionBox.y).toBeGreaterThanOrEqual(metric.box.y - 1);
+		}
+	}
+}
+
+async function openSubscriptions(page: Page) {
+	return gotoHostedSettingsDialog(page, "billing-plan");
+}
+
+test("subscription cards preserve pagination and reveal loaded history", async ({ page }) => {
+	await page.setViewportSize({ width: 1440, height: 900 });
+	const errors = collectBrowserErrors(page);
+	await stubHostedApi(page, {
+		subscriptionPages: {
+			initial: {
+				items: [],
+				has_more: true,
+				next_cursor: "history-page",
+			},
+			"history-page": {
+				items: [
+					subscription("ended_first", "canceled", {
+						current_period_end: "2025-08-12T12:00:00Z",
+					}),
+				],
+				has_more: true,
+				next_cursor: "current-page",
+			},
+			"current-page": {
+				items: [
+					subscription("active", "active", { agent_name: longAgentName }),
+					subscription("canceling", "canceling", {
+						cancel_at_period_end: true,
+						current_period_end: "2025-08-12T12:00:00Z",
+						agent_name: "Canceling agent",
+					}),
+					subscription("ended_second", "canceled", {
+						current_period_end: "2024-08-12T12:00:00Z",
+					}),
+				],
+				has_more: false,
+				next_cursor: null,
+			},
+		},
+	});
+
+	const dialog = await openSubscriptions(page);
+	await expect(dialog.getByText("No current subscriptions", { exact: true })).toBeVisible();
+	await expect(dialog.getByRole("button", { name: "Load more" })).toBeVisible();
+	await expect(dialog.getByRole("button", { name: /Show history/ })).toHaveCount(0);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(0);
+
+	await dialog.getByRole("button", { name: "Load more" }).click();
+	await expect(dialog.getByText("No current subscriptions", { exact: true })).toBeVisible();
+	await expect(dialog.getByRole("button", { name: "Load more" })).toBeVisible();
+	await expect(dialog.getByRole("button", { name: "Show history (1)" })).toBeVisible();
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(0);
+
+	await dialog.getByRole("button", { name: "Load more" }).click();
+	await expect(dialog.getByText(longAgentName, { exact: true })).toBeVisible();
+	await expect(dialog.getByText("Canceling agent", { exact: true })).toBeVisible();
+	await expect(dialog.getByText("Active", { exact: true })).toBeVisible();
+	await expect(dialog.getByText("Canceling", { exact: true })).toBeVisible();
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(2);
+	await expect(dialog.getByRole("button", { name: "Cancel", exact: true })).toBeVisible();
+	await expect(dialog.getByRole("button", { name: "Resume", exact: true })).toBeVisible();
+	await expect(dialog.getByRole("button", { name: "Show history (2)" })).toBeVisible();
+	await expectCardsFit(dialog);
+
+	await dialog.getByRole("button", { name: "Show history (2)" }).click();
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(4);
+	await expect(dialog.getByText("Canceled", { exact: true })).toHaveCount(2);
+	await expect(dialog.getByText("ended_first", { exact: true })).toBeVisible();
+	await expect(dialog.getByText("ended_second", { exact: true })).toBeVisible();
+	await expectCardsFit(dialog);
+
+	await dialog.getByRole("button", { name: "Hide history" }).click();
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(2);
+	await expect(dialog.getByText("ended_first", { exact: true })).toHaveCount(0);
+
+	await page.setViewportSize({ width: 320, height: 568 });
+	await expect(dialog).toBeVisible();
+	await expectCardsFit(dialog);
+	const longAgentStyle = await dialog
+		.getByText(longAgentName, { exact: true })
+		.evaluate((agent) => {
+			const style = getComputedStyle(agent);
+			return {
+				overflow: style.overflow,
+				textOverflow: style.textOverflow,
+				whiteSpace: style.whiteSpace,
+				scrollWidth: agent.scrollWidth,
+				clientWidth: agent.clientWidth,
+			};
+		});
+	expect(longAgentStyle).toMatchObject({
+		overflow: "hidden",
+		textOverflow: "ellipsis",
+		whiteSpace: "nowrap",
+	});
+	expect(longAgentStyle.scrollWidth).toBeGreaterThan(longAgentStyle.clientWidth);
+	expect(errors, `subscription cards: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("agent settings uses the subscription card without changing plan actions", async ({
+	page,
+}) => {
+	await page.setViewportSize({ width: 1440, height: 900 });
+	const errors = collectBrowserErrors(page);
+	await stubHostedApi(page, {
+		deployments: [
+			paidBasicDeployment,
+			cancelPendingBasicDeployment,
+			cardPastDueDeployment,
+			terminalFallbackDeployment,
+		],
+		plans: [basicPlan, performancePlan],
+	});
+
+	await gotoHostedAgentSettings(page, "hdep_paid", "Basic");
+	const activeCard = page
+		.locator('[data-slot="compute-subscription-card"]')
+		.filter({ hasText: "Basic compute" });
+	await expect(activeCard).toBeVisible();
+	await expect(activeCard.getByText("Active", { exact: true })).toHaveAttribute(
+		"data-status",
+		"success",
+	);
+	await expect(activeCard.locator("dl > div")).toHaveCount(4);
+	await expect(
+		activeCard.getByRole("button", { name: "Change plan, term, or payment source" }),
+	).toBeVisible();
+	await expect(activeCard.getByRole("button", { name: "Cancel subscription" })).toBeVisible();
+	await expectCardsFit(page.locator("body"));
+
+	await page.setViewportSize({ width: 320, height: 568 });
+	await expectCardsFit(page.locator("body"));
+	await expect(activeCard.getByRole("button", { name: "Cancel subscription" })).toBeVisible();
+
+	await gotoHostedAgentSettings(page, "hdep_cancel_pending", "Basic");
+	const cancelingCard = page
+		.locator('[data-slot="compute-subscription-card"]')
+		.filter({ hasText: "Basic compute" });
+	await expect(cancelingCard.getByText("Canceling", { exact: true })).toHaveAttribute(
+		"data-status",
+		"warning",
+	);
+	await expect(cancelingCard.locator("dl > div")).toHaveCount(4);
+	await expect(cancelingCard.getByRole("button", { name: "Resume subscription" })).toBeVisible();
+	await expectCardsFit(page.locator("body"));
+
+	await gotoHostedAgentSettings(page, "hdep_card_due", "Basic");
+	const pastDueCard = page
+		.locator('[data-slot="compute-subscription-card"]')
+		.filter({ hasText: "Basic compute" });
+	await expect(pastDueCard.getByText("Past due", { exact: true })).toHaveAttribute(
+		"data-status",
+		"destructive",
+	);
+	await expect(pastDueCard.getByRole("button", { name: "Change payment source" })).toBeVisible();
+	await expectCardsFit(page.locator("body"));
+
+	await gotoHostedAgentSettings(page, "hdep_terminal_fallback", "Basic");
+	const fallbackCard = page
+		.locator('[data-slot="compute-subscription-card"]')
+		.filter({ hasText: "Basic compute" });
+	await expect(fallbackCard.getByText("Current", { exact: true })).toHaveAttribute(
+		"data-status",
+		"success",
+	);
+	await expect(fallbackCard.getByText("Funding", { exact: true })).toBeVisible();
+	await expect(fallbackCard.getByText("Included", { exact: true })).toBeVisible();
+	await expect(
+		fallbackCard.getByRole("button", { name: "Start a new subscription" }),
+	).toBeVisible();
+	expect(errors, `agent subscription cards: ${errors.join(" | ")}`).toEqual([]);
+});

--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -136,12 +136,12 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(dialog.getByRole("button", { name: "Cancel", exact: true })).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Resume", exact: true })).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Show history (2)" })).toBeVisible();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"] h3')).toHaveCount(2);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(2);
 	await expectCardsFit(dialog);
 
 	await dialog.getByRole("button", { name: "Show history (2)" }).click();
 	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(4);
-	await expect(dialog.locator('[data-slot="compute-subscription-card"] h3')).toHaveCount(4);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(4);
 	await expect(dialog.getByText("Canceled", { exact: true })).toHaveCount(2);
 	await expect(dialog.getByText("ended_first", { exact: true })).toBeVisible();
 	await expect(dialog.getByText("ended_second", { exact: true })).toBeVisible();

--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -136,10 +136,12 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(dialog.getByRole("button", { name: "Cancel", exact: true })).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Resume", exact: true })).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Show history (2)" })).toBeVisible();
+	await expect(dialog.locator('[data-slot="compute-subscription-card"] h3')).toHaveCount(2);
 	await expectCardsFit(dialog);
 
 	await dialog.getByRole("button", { name: "Show history (2)" }).click();
 	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(4);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"] h3')).toHaveCount(4);
 	await expect(dialog.getByText("Canceled", { exact: true })).toHaveCount(2);
 	await expect(dialog.getByText("ended_first", { exact: true })).toBeVisible();
 	await expect(dialog.getByText("ended_second", { exact: true })).toBeVisible();
@@ -182,7 +184,24 @@ test("agent settings uses the subscription card without changing plan actions", 
 		deployments: [
 			paidBasicDeployment,
 			cancelPendingBasicDeployment,
-			cardPastDueDeployment,
+			{
+				...paidBasicDeployment,
+				id: "hdep_card_action_required",
+				name: "Card authentication required",
+				compute_subscription: {
+					...paidBasicDeployment.compute_subscription,
+					payment_state: "requires_action",
+					latest_failed_invoice_id: "in_card_action_required",
+					latest_failed_invoice_hosted_url: "https://billing.example/invoice/action-required",
+				},
+			},
+			{
+				...cardPastDueDeployment,
+				compute_subscription: {
+					...cardPastDueDeployment.compute_subscription,
+					status: "active",
+				},
+			},
 			terminalFallbackDeployment,
 		],
 		plans: [basicPlan, performancePlan],
@@ -228,7 +247,21 @@ test("agent settings uses the subscription card without changing plan actions", 
 		"data-status",
 		"destructive",
 	);
-	await expect(pastDueCard.getByRole("button", { name: "Change payment source" })).toBeVisible();
+	await expect(
+		pastDueCard.getByRole("button", { name: "Change plan, term, or payment source" }),
+	).toBeVisible();
+	await expectCardsFit(page.locator("body"));
+
+	await gotoHostedAgentSettings(page, "hdep_card_action_required", "Basic");
+	const actionRequiredCard = page
+		.locator('[data-slot="compute-subscription-card"]')
+		.filter({ hasText: "Basic compute" });
+	await expect(
+		actionRequiredCard.getByText("Payment action required", { exact: true }),
+	).toHaveAttribute("data-status", "warning");
+	await expect(
+		actionRequiredCard.getByRole("button", { name: "Change plan, term, or payment source" }),
+	).toBeVisible();
 	await expectCardsFit(page.locator("body"));
 
 	await gotoHostedAgentSettings(page, "hdep_terminal_fallback", "Basic");

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -176,6 +176,7 @@ import {
 	useResumeSubscription,
 } from "@/hosted/billing/hooks";
 import { useSensitiveBillingPortal } from "@/hosted/billing/sensitive-actions";
+import { ComputeSubscriptionCard } from "@/hosted/billing/subscription/compute-subscription-card";
 import {
 	activePlanChangeOperationName,
 	isCombinedPaidPlanChange,
@@ -3683,6 +3684,27 @@ function ComputeSettingsSections({
 		? computeSubscriptionLifecycle(currentSubscription)
 		: null;
 	const subscriptionLifecycleDateLabel = formatShortDate(subscriptionLifecycle?.dateAt);
+	const currentSubscriptionStatus = currentSubscription?.status.toLowerCase();
+	const computePlanStatusTone: StatusTone =
+		currentSubscriptionStatus === "past_due" ||
+		currentSubscriptionStatus === "unpaid" ||
+		currentSubscription?.payment_state === "past_due" ||
+		currentSubscription?.payment_state === "unpaid"
+			? "destructive"
+			: currentSubscriptionStatus === "canceling" ||
+					currentSubscription?.payment_state === "requires_action" ||
+					subscriptionCancelPending ||
+					pendingPlanSlug
+				? "warning"
+				: isIncludedBasic ||
+						currentSubscriptionStatus === "active" ||
+						currentSubscriptionStatus === "trialing"
+					? "success"
+					: "neutral";
+	const computePlanStatus = {
+		label: isPaidCompute && subscriptionLifecycle ? subscriptionLifecycle.badgeLabel : "Current",
+		tone: computePlanStatusTone,
+	};
 	const pendingPlanCopy = pendingPlanSlug
 		? pendingPlanScheduleCopy(
 				pendingPlanSlug,
@@ -4026,187 +4048,193 @@ function ComputeSettingsSections({
 			) : null}
 
 			<SettingsSection title="Compute plan" description="Compute resources for this hosted agent.">
-				<div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
-					<div className="min-w-0 flex-1">
-						<div className="flex flex-wrap items-center gap-1.5 text-sm font-medium">
+				<ComputeSubscriptionCard
+					headingLevel={3}
+					title={
+						<span className="flex min-w-0 items-center gap-1.5">
 							{tierLabel === "Performance" ? (
-								<Zap className="size-4" />
+								<Zap className="size-4 shrink-0" />
 							) : (
-								<Cpu className="size-4" />
+								<Cpu className="size-4 shrink-0" />
 							)}
 							<span>{tierLabel} compute</span>
+						</span>
+					}
+					status={computePlanStatus}
+					description="Basic includes one free active slot per user. Paid Basic and Performance each use one subscription per agent."
+					badges={
+						hasWalletFallback ? (
 							<Badge variant="outline" className="font-normal text-muted-foreground">
-								{isPaidCompute && subscriptionLifecycle
-									? subscriptionLifecycle.badgeLabel
-									: "Current"}
+								Wallet fallback
 							</Badge>
-							{isPaidCompute ? (
-								<Badge variant="outline" className="font-normal text-muted-foreground">
-									Payment source: {isWalletFunded ? "Wallet" : "Card"}
-								</Badge>
-							) : hasWalletFallback ? (
-								<Badge variant="outline" className="font-normal text-muted-foreground">
-									Wallet fallback
-								</Badge>
-							) : null}
-						</div>
-						<p className="mt-1 text-xs text-muted-foreground">
-							Basic includes one free active slot per user. Paid Basic and Performance each use one
-							subscription per agent.
-						</p>
-						{isPaidCompute && currentSubscription ? (
-							<div className="mt-2 flex flex-col gap-1 text-xs text-muted-foreground">
-								<p>
-									{billingTermLabel(currentBillingTerm)}
-									{currentPriceCents !== null ? (
-										<>
-											{" "}
-											· {formatCents(currentPriceCents)}
-											{billingTermSuffix(currentBillingTerm)}
-										</>
-									) : null}
-									{subscriptionLifecycle?.dateVerb && subscriptionLifecycle.dateAt ? (
-										<>
-											{" · "}
-											{subscriptionLifecycle.dateVerb} {subscriptionLifecycleDateLabel}
-										</>
-									) : null}
-								</p>
-								{pendingPlanCopy ? (
-									<p className="font-medium text-warning-muted-foreground">{pendingPlanCopy}</p>
-								) : null}
-							</div>
-						) : null}
-					</div>
-					<div
-						id="compute-plan-controls"
-						className="flex w-full scroll-mt-6 flex-col gap-2 lg:w-auto lg:min-w-64 lg:items-end"
-					>
-						{(hasTerminalFallback || isIncludedBasic) && blockingPlansError ? (
-							<div className="w-full lg:w-72">
-								<ApiErrorPanel
-									normalizer={billingErrorNormalizer}
-									error={blockingPlansError}
-									onRetry={() => void plans.refetch()}
-									title="Couldn’t check paid compute availability"
-								/>
-							</div>
-						) : hasTerminalFallback || isIncludedBasic ? (
-							<div className="flex w-full flex-col gap-2 lg:w-64">
-								<Button
-									size="sm"
-									disabled={
-										pendingPlanChangeName === null &&
-										(plans.isLoading ||
-											(hasTerminalFallback ? !canStartNewSubscription : !canUpgrade || !perfPlan))
-									}
-									onClick={() =>
-										pendingPlanChangeName
-											? setPlanChangeDialogOpen(true)
-											: hasTerminalFallback
-												? setSubscriptionCreateOpen(true)
-												: setPlanChangeDialogOpen(true)
-									}
-								>
-									{hasTerminalFallback ? (
-										<Plus data-icon="inline-start" />
-									) : (
-										<Zap data-icon="inline-start" />
-									)}
-									{pendingPlanChangeName
-										? "Check subscription change status"
-										: hasTerminalFallback
-											? "Start a new subscription"
-											: "Upgrade to Performance"}
-								</Button>
-								{hasTerminalFallback ? (
-									canStartNewSubscription ? null : (
-										<p className="text-xs text-muted-foreground">{createUnavailableMessage}</p>
-									)
-								) : canUpgrade ? null : (
-									<p className="text-xs text-muted-foreground">{upgradeUnavailableMessage}</p>
-								)}
-							</div>
-						) : isPaidCompute && currentSubscription ? (
-							<div className="flex w-full flex-col gap-2 lg:w-72">
-								{subscriptionCancelPending ? (
-									<>
+						) : null
+					}
+					details={
+						isPaidCompute && currentSubscription
+							? [
+									{ label: "Payment", value: isWalletFunded ? "Wallet" : "Card" },
+									{ label: "Term", value: billingTermLabel(currentBillingTerm) },
+									{
+										label: "Price",
+										value:
+											currentPriceCents === null
+												? "Unavailable"
+												: `${formatCents(currentPriceCents)}${billingTermSuffix(currentBillingTerm)}`,
+									},
+									{
+										label: "Schedule",
+										value:
+											subscriptionLifecycle?.dateVerb && subscriptionLifecycle.dateAt
+												? `${subscriptionLifecycle.dateVerb} ${subscriptionLifecycleDateLabel}`
+												: "Unavailable",
+									},
+								]
+							: [
+									{ label: "Funding", value: "Included" },
+									{ label: "Billing", value: "No subscription charge" },
+								]
+					}
+					notice={
+						pendingPlanCopy ? (
+							<p className="text-xs font-medium text-warning-muted-foreground">{pendingPlanCopy}</p>
+						) : null
+					}
+					actions={
+						hasTerminalFallback || isIncludedBasic || (isPaidCompute && currentSubscription) ? (
+							<div
+								id="compute-plan-controls"
+								className="flex w-full scroll-mt-6 flex-col gap-2 sm:ml-auto sm:w-auto sm:min-w-64 sm:items-end"
+							>
+								{(hasTerminalFallback || isIncludedBasic) && blockingPlansError ? (
+									<div className="w-full sm:w-72">
+										<ApiErrorPanel
+											normalizer={billingErrorNormalizer}
+											error={blockingPlansError}
+											onRetry={() => void plans.refetch()}
+											title="Couldn’t check paid compute availability"
+										/>
+									</div>
+								) : hasTerminalFallback || isIncludedBasic ? (
+									<div className="flex w-full flex-col gap-2 sm:w-64">
 										<Button
-											type="button"
-											variant="outline"
-											size="sm"
-											disabled={resumeSubscription.isPending || !subscriptionCancelable}
-											onClick={() =>
-												void runAction(resumeComputeSubscription).catch(() => undefined)
-											}
-										>
-											{resumeSubscription.isPending ? (
-												<Spinner data-icon="inline-start" />
-											) : (
-												<RefreshCw data-icon="inline-start" />
-											)}
-											Resume subscription
-										</Button>
-										<p className="text-xs text-muted-foreground">{planChangeUnavailable}</p>
-									</>
-								) : (
-									<>
-										<Button
-											type="button"
-											variant="outline"
 											size="sm"
 											disabled={
 												pendingPlanChangeName === null &&
-												(planChangeUnavailable !== null || !!pendingPlanSlug)
+												(plans.isLoading ||
+													(hasTerminalFallback
+														? !canStartNewSubscription
+														: !canUpgrade || !perfPlan))
 											}
-											onClick={() => setPlanChangeDialogOpen(true)}
+											onClick={() =>
+												pendingPlanChangeName
+													? setPlanChangeDialogOpen(true)
+													: hasTerminalFallback
+														? setSubscriptionCreateOpen(true)
+														: setPlanChangeDialogOpen(true)
+											}
 										>
+											{hasTerminalFallback ? (
+												<Plus data-icon="inline-start" />
+											) : (
+												<Zap data-icon="inline-start" />
+											)}
 											{pendingPlanChangeName
 												? "Check subscription change status"
-												: paymentSourceOnly
-													? "Change payment source"
-													: "Change plan, term, or payment source"}
+												: hasTerminalFallback
+													? "Start a new subscription"
+													: "Upgrade to Performance"}
 										</Button>
-										<ConfirmAction
-											title={`Cancel ${tierLabel} subscription?`}
-											description={
-												<p>
-													Cancellation takes effect {subscriptionPeriodLabel}. The agent then falls
-													back to included Basic funding if available; otherwise, it stops.
-												</p>
-											}
-											confirmLabel="Cancel at period end"
-											destructive
-											onConfirm={() => runAction(cancelComputeSubscription)}
-										>
-											<Button
-												type="button"
-												variant="outline"
-												size="sm"
-												disabled={cancelSubscription.isPending || !subscriptionCancelable}
-											>
-												{cancelSubscription.isPending ? (
-													<Spinner data-icon="inline-start" />
-												) : (
-													<Link2Off data-icon="inline-start" />
-												)}
-												Cancel subscription
-											</Button>
-										</ConfirmAction>
-										{pendingPlanSlug ? (
-											<p className="text-xs text-muted-foreground">
-												A plan change is already scheduled. It will apply on the effective date
-												shown above.
-											</p>
-										) : planChangeUnavailable ? (
-											<p className="text-xs text-muted-foreground">{planChangeUnavailable}</p>
-										) : null}
-									</>
-								)}
+										{hasTerminalFallback ? (
+											canStartNewSubscription ? null : (
+												<p className="text-xs text-muted-foreground">{createUnavailableMessage}</p>
+											)
+										) : canUpgrade ? null : (
+											<p className="text-xs text-muted-foreground">{upgradeUnavailableMessage}</p>
+										)}
+									</div>
+								) : isPaidCompute && currentSubscription ? (
+									<div className="flex w-full flex-col gap-2 sm:w-72">
+										{subscriptionCancelPending ? (
+											<>
+												<Button
+													type="button"
+													variant="outline"
+													size="sm"
+													disabled={resumeSubscription.isPending || !subscriptionCancelable}
+													onClick={() =>
+														void runAction(resumeComputeSubscription).catch(() => undefined)
+													}
+												>
+													{resumeSubscription.isPending ? (
+														<Spinner data-icon="inline-start" />
+													) : (
+														<RefreshCw data-icon="inline-start" />
+													)}
+													Resume subscription
+												</Button>
+												<p className="text-xs text-muted-foreground">{planChangeUnavailable}</p>
+											</>
+										) : (
+											<>
+												<Button
+													type="button"
+													variant="outline"
+													size="sm"
+													disabled={
+														pendingPlanChangeName === null &&
+														(planChangeUnavailable !== null || !!pendingPlanSlug)
+													}
+													onClick={() => setPlanChangeDialogOpen(true)}
+												>
+													{pendingPlanChangeName
+														? "Check subscription change status"
+														: paymentSourceOnly
+															? "Change payment source"
+															: "Change plan, term, or payment source"}
+												</Button>
+												<ConfirmAction
+													title={`Cancel ${tierLabel} subscription?`}
+													description={
+														<p>
+															Cancellation takes effect {subscriptionPeriodLabel}. The agent then
+															falls back to included Basic funding if available; otherwise, it
+															stops.
+														</p>
+													}
+													confirmLabel="Cancel at period end"
+													destructive
+													onConfirm={() => runAction(cancelComputeSubscription)}
+												>
+													<Button
+														type="button"
+														variant="outline"
+														size="sm"
+														disabled={cancelSubscription.isPending || !subscriptionCancelable}
+													>
+														{cancelSubscription.isPending ? (
+															<Spinner data-icon="inline-start" />
+														) : (
+															<Link2Off data-icon="inline-start" />
+														)}
+														Cancel subscription
+													</Button>
+												</ConfirmAction>
+												{pendingPlanSlug ? (
+													<p className="text-xs text-muted-foreground">
+														A plan change is already scheduled. It will apply on the effective date
+														shown above.
+													</p>
+												) : planChangeUnavailable ? (
+													<p className="text-xs text-muted-foreground">{planChangeUnavailable}</p>
+												) : null}
+											</>
+										)}
+									</div>
+								) : null}
 							</div>
-						) : null}
-					</div>
-				</div>
+						) : null
+					}
+				/>
 			</SettingsSection>
 
 			<SettingsSection title="Lifecycle" description="Restart, stop, or start this agent.">

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -3701,8 +3701,21 @@ function ComputeSettingsSections({
 						currentSubscriptionStatus === "trialing"
 					? "success"
 					: "neutral";
+	const computePlanStatusLabel =
+		!isPaidCompute || !subscriptionLifecycle
+			? "Current"
+			: currentSubscriptionStatus === "past_due" ||
+					currentSubscription?.payment_state === "past_due"
+				? "Past due"
+				: currentSubscriptionStatus === "unpaid" || currentSubscription?.payment_state === "unpaid"
+					? "Unpaid"
+					: currentSubscription?.payment_state === "requires_action"
+						? "Payment action required"
+						: currentSubscriptionStatus === "canceling" || subscriptionCancelPending
+							? "Canceling"
+							: subscriptionLifecycle.badgeLabel;
 	const computePlanStatus = {
-		label: isPaidCompute && subscriptionLifecycle ? subscriptionLifecycle.badgeLabel : "Current",
+		label: computePlanStatusLabel,
 		tone: computePlanStatusTone,
 	};
 	const pendingPlanCopy = pendingPlanSlug

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
@@ -1,0 +1,84 @@
+import type { ReactNode } from "react";
+import { StatusBadge, type StatusTone } from "@/components/ui/status-badge";
+import { cn } from "@/lib/utils";
+
+export type ComputeSubscriptionCardDetail = {
+	label: string;
+	value: ReactNode;
+};
+
+export function ComputeSubscriptionCard({
+	title,
+	status,
+	description,
+	badges,
+	details,
+	notice,
+	actions,
+	headingLevel = 3,
+	className,
+}: {
+	title: ReactNode;
+	status: { label: string; tone: StatusTone };
+	description?: ReactNode;
+	badges?: ReactNode;
+	details?: readonly ComputeSubscriptionCardDetail[];
+	notice?: ReactNode;
+	actions?: ReactNode;
+	headingLevel?: 3 | 4;
+	className?: string;
+}) {
+	const Heading = headingLevel === 4 ? "h4" : "h3";
+
+	return (
+		<article
+			data-hosted="true"
+			data-slot="compute-subscription-card"
+			className={cn("min-w-0 overflow-hidden rounded-lg border bg-card", className)}
+		>
+			<header className="flex min-w-0 flex-col gap-2 p-4 sm:flex-row sm:items-start sm:justify-between">
+				<div className="min-w-0 flex-1">
+					<Heading className="min-w-0 text-sm font-semibold [overflow-wrap:anywhere]">
+						{title}
+					</Heading>
+					{description ? (
+						<div className="mt-1 min-w-0 text-xs leading-5 text-muted-foreground">
+							{description}
+						</div>
+					) : null}
+				</div>
+				<div className="flex min-w-0 shrink-0 flex-wrap items-center gap-1.5">
+					<StatusBadge status={status.tone}>{status.label}</StatusBadge>
+					{badges}
+				</div>
+			</header>
+
+			{details?.length ? (
+				<dl className="grid min-w-0 grid-cols-2 gap-x-4 gap-y-3 border-t px-4 py-3 sm:[grid-template-columns:repeat(auto-fit,minmax(8rem,1fr))]">
+					{details.map((detail) => (
+						<div key={detail.label} className="min-w-0">
+							<dt className="text-xs text-muted-foreground">{detail.label}</dt>
+							<dd className="mt-0.5 min-w-0 text-sm font-medium [overflow-wrap:anywhere]">
+								{detail.value}
+							</dd>
+						</div>
+					))}
+				</dl>
+			) : null}
+
+			{notice ? (
+				<div data-slot="compute-subscription-notice" className="min-w-0 border-t px-4 py-3">
+					{notice}
+				</div>
+			) : null}
+			{actions ? (
+				<div
+					data-slot="compute-subscription-actions"
+					className="min-w-0 border-t bg-muted/20 px-4 py-3"
+				>
+					{actions}
+				</div>
+			) : null}
+		</article>
+	);
+}

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -15,6 +15,7 @@ import {
 	isComputeSubscriptionCancelable,
 	isComputeSubscriptionRenewing,
 	isComputeSubscriptionTermChangeable,
+	isEndedAccountSubscription,
 	isIncludedBasicSubscription,
 	pendingComputePlanSlug,
 	pendingPlanScheduleCopy,
@@ -302,6 +303,29 @@ describe("commonExplicitBillingOffers", () => {
 });
 
 describe("compute subscription action status gates", () => {
+	test("hides only canceled subscriptions whose service period has ended", () => {
+		const nowMs = Date.parse("2026-08-12T12:00:00Z");
+		const ended = {
+			status: "canceled" as const,
+			cancel_at_period_end: false,
+			current_period_end: "2026-08-12T12:00:00Z",
+		};
+
+		expect(isEndedAccountSubscription(ended, nowMs)).toBe(true);
+		expect(
+			isEndedAccountSubscription(
+				{ ...ended, current_period_end: "2026-08-12T12:00:00.001Z" },
+				nowMs,
+			),
+		).toBe(false);
+		expect(isEndedAccountSubscription({ ...ended, status: "canceling" }, nowMs)).toBe(false);
+		expect(isEndedAccountSubscription({ ...ended, cancel_at_period_end: true }, nowMs)).toBe(false);
+		expect(isEndedAccountSubscription({ ...ended, current_period_end: null }, nowMs)).toBe(false);
+		expect(isEndedAccountSubscription({ ...ended, current_period_end: "not-a-date" }, nowMs)).toBe(
+			false,
+		);
+	});
+
 	test("matches the backend cancel and resume status set", () => {
 		expect(isComputeSubscriptionCancelable({ status: "trialing" })).toBe(true);
 		expect(isComputeSubscriptionCancelable({ status: "active" })).toBe(true);
@@ -381,7 +405,7 @@ describe("compute subscription lifecycle presentation", () => {
 				status: "past_due",
 			}),
 		).toMatchObject({
-			badgeLabel: "Payment past due",
+			badgeLabel: "Past due",
 			dateAt: null,
 			dateVerb: null,
 			renews: true,

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -319,7 +319,7 @@ describe("compute subscription action status gates", () => {
 			),
 		).toBe(false);
 		expect(isEndedAccountSubscription({ ...ended, status: "canceling" }, nowMs)).toBe(false);
-		expect(isEndedAccountSubscription({ ...ended, cancel_at_period_end: true }, nowMs)).toBe(false);
+		expect(isEndedAccountSubscription({ ...ended, cancel_at_period_end: true }, nowMs)).toBe(true);
 		expect(isEndedAccountSubscription({ ...ended, current_period_end: null }, nowMs)).toBe(false);
 		expect(isEndedAccountSubscription({ ...ended, current_period_end: "not-a-date" }, nowMs)).toBe(
 			false,

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -64,7 +64,7 @@ export function isEndedAccountSubscription(
 	>,
 	nowMs: number,
 ): boolean {
-	if (subscription.status !== "canceled" || subscription.cancel_at_period_end) return false;
+	if (subscription.status !== "canceled") return false;
 	if (!subscription.current_period_end) return false;
 	const periodEndMs = Date.parse(subscription.current_period_end);
 	return Number.isFinite(periodEndMs) && periodEndMs <= nowMs;

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -57,6 +57,19 @@ export function canResumeAccountSubscription(
 	);
 }
 
+export function isEndedAccountSubscription(
+	subscription: Pick<
+		ComputeSubscriptionListItem,
+		"cancel_at_period_end" | "current_period_end" | "status"
+	>,
+	nowMs: number,
+): boolean {
+	if (subscription.status !== "canceled" || subscription.cancel_at_period_end) return false;
+	if (!subscription.current_period_end) return false;
+	const periodEndMs = Date.parse(subscription.current_period_end);
+	return Number.isFinite(periodEndMs) && periodEndMs <= nowMs;
+}
+
 export function resolveBasicPlan(plans: Plan[] | undefined): Plan | undefined {
 	return plans?.find((plan) => plan.slug === COMPUTE_BASIC_SLUG);
 }
@@ -181,7 +194,7 @@ export function computeSubscriptionLifecycle(
 	}
 	if (status === "active") {
 		return {
-			badgeLabel: "Current",
+			badgeLabel: "Active",
 			dateAt: subscription.current_period_end ?? null,
 			dateVerb: "Renews",
 			renews: true,
@@ -197,7 +210,7 @@ export function computeSubscriptionLifecycle(
 	}
 	if (status === "past_due") {
 		return {
-			badgeLabel: "Payment past due",
+			badgeLabel: "Past due",
 			dateAt: null,
 			dateVerb: null,
 			renews: true,

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -212,7 +212,6 @@ function SubscriptionRow({ subscription }: { subscription: ComputeSubscriptionLi
 	return (
 		<li className="min-w-0">
 			<ComputeSubscriptionCard
-				headingLevel={4}
 				title={planLabel(subscription.plan_slug)}
 				status={status}
 				badges={subscription.is_orphan ? <Badge variant="outline">Orphaned</Badge> : null}

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Link } from "@tanstack/react-router";
-import { CreditCard, Link2Off, RefreshCw } from "lucide-react";
-import type { ReactNode } from "react";
+import { CreditCard, History, Link2Off, RefreshCw } from "lucide-react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EmptyState } from "@/components/empty-state";
@@ -12,7 +12,7 @@ import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
-import { StatusBadge, type StatusTone } from "@/components/ui/status-badge";
+import type { StatusTone } from "@/components/ui/status-badge";
 import type { ComputeSubscriptionListItem } from "@/hosted/billing/contracts";
 import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
 import { billingTermLabel, billingTermSuffix, formatCents } from "@/hosted/billing/format";
@@ -21,18 +21,17 @@ import {
 	useResumeSubscription,
 	useSubscriptions,
 } from "@/hosted/billing/hooks";
+import { ComputeSubscriptionCard } from "@/hosted/billing/subscription/compute-subscription-card";
 import {
 	canCancelAccountSubscription,
 	canResumeAccountSubscription,
 	computeTierLabel,
+	isEndedAccountSubscription,
 } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { agentSectionLink } from "@/lib/agent-routes";
 import { formatShortDate } from "@/lib/format";
 import { shouldBlockQueryError } from "@/lib/query-state";
-
-const SUBSCRIPTION_GRID_CLASS =
-	"grid gap-4 lg:grid-cols-[minmax(10rem,1.35fr)_minmax(8rem,1fr)_minmax(7rem,.7fr)_minmax(7rem,.65fr)_minmax(8rem,.8fr)_minmax(9rem,auto)] lg:items-center";
 
 const STATUS_PRESENTATION: Record<
 	ComputeSubscriptionListItem["status"],
@@ -85,10 +84,6 @@ function periodLabel(subscription: ComputeSubscriptionListItem): string {
 	return `Renews ${date}`;
 }
 
-function FieldLabel({ children }: { children: ReactNode }) {
-	return <div className="mb-1 text-xs font-medium text-muted-foreground lg:hidden">{children}</div>;
-}
-
 function SubscriptionActions({ subscription }: { subscription: ComputeSubscriptionListItem }) {
 	const cancelSubscription = useCancelSubscription();
 	const resumeSubscription = useResumeSubscription();
@@ -127,11 +122,11 @@ function SubscriptionActions({ subscription }: { subscription: ComputeSubscripti
 	}
 
 	if (!canCancel && !canResume) {
-		return <span className="hidden text-muted-foreground lg:inline">-</span>;
+		return null;
 	}
 
 	return (
-		<div className="flex flex-wrap gap-2 lg:justify-end">
+		<div className="flex flex-wrap gap-2 sm:justify-end">
 			{canResume ? (
 				<Button
 					type="button"
@@ -211,60 +206,69 @@ export function SubscriptionLoadMore({
 
 function SubscriptionRow({ subscription }: { subscription: ComputeSubscriptionListItem }) {
 	const status = STATUS_PRESENTATION[subscription.status];
+	const hasActions =
+		canCancelAccountSubscription(subscription) || canResumeAccountSubscription(subscription);
 
 	return (
-		<li className={`${SUBSCRIPTION_GRID_CLASS} px-3 py-4`}>
-			<div className="min-w-0">
-				<FieldLabel>Subscription</FieldLabel>
-				<div className="font-medium capitalize">{planLabel(subscription.plan_slug)}</div>
-				<div className="mt-1 flex flex-wrap items-center gap-1.5">
-					<StatusBadge status={status.tone}>{status.label}</StatusBadge>
-					{subscription.is_orphan ? <Badge variant="outline">Orphaned</Badge> : null}
-				</div>
-			</div>
-			<div className="min-w-0">
-				<FieldLabel>Agent</FieldLabel>
-				<SubscriptionAgentLink
-					deploymentId={subscription.deployment_id}
-					agentName={subscription.agent_name}
-				/>
-			</div>
-			<div>
-				<FieldLabel>Payment source</FieldLabel>
-				<span className="text-sm font-medium">
-					{subscriptionPaymentSourceLabel(subscription.funding_source)}
-				</span>
-			</div>
-			<div>
-				<FieldLabel>Price</FieldLabel>
-				<div className="font-medium tabular-nums">{priceLabel(subscription)}</div>
-				<div className="mt-0.5 text-xs text-muted-foreground">
-					{billingTermLabel(subscription.billing_term_months)}
-				</div>
-			</div>
-			<div>
-				<FieldLabel>Renewal / end</FieldLabel>
-				<span className="text-sm text-muted-foreground">{periodLabel(subscription)}</span>
-			</div>
-			<div>
-				<FieldLabel>Actions</FieldLabel>
-				<SubscriptionActions subscription={subscription} />
-			</div>
+		<li className="min-w-0">
+			<ComputeSubscriptionCard
+				headingLevel={4}
+				title={planLabel(subscription.plan_slug)}
+				status={status}
+				badges={subscription.is_orphan ? <Badge variant="outline">Orphaned</Badge> : null}
+				details={[
+					{
+						label: "Agent",
+						value: (
+							<SubscriptionAgentLink
+								deploymentId={subscription.deployment_id}
+								agentName={subscription.agent_name}
+							/>
+						),
+					},
+					{
+						label: "Payment",
+						value: subscriptionPaymentSourceLabel(subscription.funding_source),
+					},
+					{
+						label: "Billing",
+						value: (
+							<>
+								<span className="tabular-nums">{priceLabel(subscription)}</span>
+								<span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+									{billingTermLabel(subscription.billing_term_months)}
+								</span>
+							</>
+						),
+					},
+					{ label: "Schedule", value: periodLabel(subscription) },
+				]}
+				actions={hasActions ? <SubscriptionActions subscription={subscription} /> : null}
+			/>
 		</li>
 	);
 }
 
 function SubscriptionListSkeleton() {
 	return (
-		<div className="divide-y overflow-hidden rounded-lg border">
+		<div className="space-y-3" role="status">
+			<span className="sr-only">Loading subscriptions</span>
 			{Array.from({ length: 3 }, (_, index) => `subscription-skeleton-${index}`).map((key) => (
-				<div key={key} className={`${SUBSCRIPTION_GRID_CLASS} px-3 py-4`}>
-					<Skeleton className="h-9 w-36" />
-					<Skeleton className="h-4 w-24" />
-					<Skeleton className="h-4 w-16" />
-					<Skeleton className="h-9 w-20" />
-					<Skeleton className="h-4 w-28" />
-					<Skeleton className="h-8 w-20 lg:justify-self-end" />
+				<div key={key} className="overflow-hidden rounded-lg border bg-card">
+					<div className="flex items-start justify-between gap-3 p-4">
+						<Skeleton className="h-5 w-36" />
+						<Skeleton className="h-5 w-16" />
+					</div>
+					<div className="grid grid-cols-2 gap-4 border-t px-4 py-3 sm:grid-cols-4">
+						{Array.from({ length: 4 }, (_, detailIndex) => `${key}-${detailIndex}`).map(
+							(detailKey) => (
+								<div key={detailKey} className="space-y-1.5">
+									<Skeleton className="h-3 w-12" />
+									<Skeleton className="h-4 w-20 max-w-full" />
+								</div>
+							),
+						)}
+					</div>
 				</div>
 			))}
 		</div>
@@ -273,7 +277,17 @@ function SubscriptionListSkeleton() {
 
 export function SubscriptionsSection() {
 	const subscriptions = useSubscriptions();
+	const [showHistory, setShowHistory] = useState(false);
+	const [historyCutoffMs] = useState(Date.now);
 	const rows = subscriptions.data?.pages.flatMap((page) => page.items ?? []) ?? [];
+	const endedRows = rows.filter((subscription) =>
+		isEndedAccountSubscription(subscription, historyCutoffMs),
+	);
+	const visibleRows = showHistory
+		? rows
+		: rows.filter((subscription) => !isEndedAccountSubscription(subscription, historyCutoffMs));
+	const canLoadMore = subscriptions.hasNextPage && !subscriptions.isFetchNextPageError;
+	const historyControlVisible = endedRows.length > 0 || showHistory;
 
 	return (
 		<SettingsSection
@@ -291,27 +305,44 @@ export function SubscriptionsSection() {
 					onRetry={() => void subscriptions.refetch()}
 					title="Couldn't load subscriptions"
 				/>
-			) : rows.length ? (
+			) : rows.length || subscriptions.hasNextPage ? (
 				<>
-					<div className="overflow-hidden rounded-lg border">
-						<div
-							aria-hidden
-							className={`${SUBSCRIPTION_GRID_CLASS} hidden border-b bg-muted/30 px-3 py-2 text-xs font-medium text-muted-foreground lg:grid`}
-						>
-							<span>Subscription</span>
-							<span>Agent</span>
-							<span>Payment source</span>
-							<span>Price</span>
-							<span>Renewal / end</span>
-							<span className="text-right">Actions</span>
+					{historyControlVisible ? (
+						<div className="flex justify-end">
+							<Button
+								type="button"
+								variant="ghost"
+								size="sm"
+								aria-pressed={showHistory}
+								onClick={() => setShowHistory((current) => !current)}
+							>
+								<History />
+								{showHistory
+									? "Hide history"
+									: `Show history${endedRows.length ? ` (${endedRows.length})` : ""}`}
+							</Button>
 						</div>
-						<ul className="divide-y">
-							{rows.map((subscription) => (
+					) : null}
+					{visibleRows.length ? (
+						<ul className="space-y-3">
+							{visibleRows.map((subscription) => (
 								<SubscriptionRow key={subscription.subscription_id} subscription={subscription} />
 							))}
 						</ul>
-					</div>
-					{subscriptions.hasNextPage && !subscriptions.isFetchNextPageError ? (
+					) : (
+						<EmptyState
+							variant="inset"
+							icon={CreditCard}
+							title="No current subscriptions"
+							description={
+								endedRows.length
+									? "Ended subscriptions are hidden. Show history to view them."
+									: "Load more records to find current subscriptions."
+							}
+							className="py-8 md:p-8"
+						/>
+					)}
+					{canLoadMore ? (
 						<SubscriptionLoadMore
 							isLoading={subscriptions.isFetchingNextPage}
 							onLoadMore={() => void subscriptions.fetchNextPage()}

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -212,6 +212,7 @@ function SubscriptionRow({ subscription }: { subscription: ComputeSubscriptionLi
 	return (
 		<li className="min-w-0">
 			<ComputeSubscriptionCard
+				headingLevel={4}
 				title={planLabel(subscription.plan_slug)}
 				status={status}
 				badges={subscription.is_orphan ? <Badge variant="outline">Orphaned</Badge> : null}


### PR DESCRIPTION
## Summary

- replace the Settings > Compute subscription table with compact responsive cards
- reuse a presentation-only `ComputeSubscriptionCard` in Agent Settings while keeping mutations, dialogs, and LRO recovery in each parent
- hide locally loaded canceled subscriptions after their service period ends, with honest Show/Hide history controls and unchanged cursor pagination
- unify paid lifecycle labels across both surfaces: Active, Canceling, Past due, and Canceled

## Behavior

- cancel-at-period-end and future-period canceled subscriptions remain visible
- Load more remains available when a loaded page contains only hidden history
- Show history appears only after an ended subscription is actually loaded and reveals all loaded history
- Included Basic remains `Current` with `Funding: Included`; terminal fallback still offers Start a new subscription
- no deploy-time subscription reuse protocol or speculative UI is included

## Validation

- Docker clean runner: web typecheck, 30 focused tests, OSS client/SSR build
- Biome: `apps/web/src` plus the hosted E2E/stub files
- Hosted Playwright: 2 tests passed at 1440x900 and 320x568
- browser assertions cover no card/action overflow, four paid details, long Agent-name ellipsis, lifecycle tones, history pagination, and Cancel/Resume/payment/start actions
- `git diff --check`
