### PR TITLE
fix(runtime): gate Codex managed env cutover

### DIFF
--- a/backend/app/schemas/runtime.py
+++ b/backend/app/schemas/runtime.py
@@ -210,7 +210,7 @@ def _is_string_object_dict(value: object) -> TypeGuard[dict[str, object]]:
     return _is_object_dict(value) and all(isinstance(key, str) for key in value)
 
 
-def _parse_exact_semver(value: str) -> tuple[int, int, int, tuple[str, ...]] | None:
+def parse_exact_semver(value: str) -> tuple[int, int, int, tuple[str, ...]] | None:
     match = _EXACT_SEMVER_PATTERN.fullmatch(value)
     if match is None:
         return None
@@ -223,37 +223,11 @@ def _parse_exact_semver(value: str) -> tuple[int, int, int, tuple[str, ...]] | N
     )
 
 
-def exact_semver_is_at_least(value: str, minimum: str) -> bool:
-    parsed = _parse_exact_semver(value)
-    parsed_minimum = _parse_exact_semver(minimum)
-    if parsed is None or parsed_minimum is None:
-        raise ValueError("versions must be exact semver without build metadata")
-
-    core, prerelease = parsed[:3], parsed[3]
-    minimum_core, minimum_prerelease = parsed_minimum[:3], parsed_minimum[3]
-    if core != minimum_core:
-        return core > minimum_core
-    if not prerelease or not minimum_prerelease:
-        return not prerelease
-
-    for identifier, minimum_identifier in zip(prerelease, minimum_prerelease, strict=False):
-        if identifier == minimum_identifier:
-            continue
-        identifier_is_numeric = identifier.isdigit()
-        minimum_is_numeric = minimum_identifier.isdigit()
-        if identifier_is_numeric and minimum_is_numeric:
-            return int(identifier) > int(minimum_identifier)
-        if identifier_is_numeric != minimum_is_numeric:
-            return not identifier_is_numeric
-        return identifier > minimum_identifier
-    return len(prerelease) >= len(minimum_prerelease)
-
-
 def validate_clawdi_cli_package_spec(value: object) -> str:
     if not isinstance(value, str) or not value.startswith("clawdi@"):
         raise ValueError("cli_package_spec must be clawdi@<exact-semver> without build metadata")
     version = value.removeprefix("clawdi@")
-    if _parse_exact_semver(version) is None:
+    if parse_exact_semver(version) is None:
         raise ValueError("cli_package_spec must be clawdi@<exact-semver> without build metadata")
     return value
 

--- a/backend/app/schemas/runtime.py
+++ b/backend/app/schemas/runtime.py
@@ -223,6 +223,32 @@ def _parse_exact_semver(value: str) -> tuple[int, int, int, tuple[str, ...]] | N
     )
 
 
+def exact_semver_is_at_least(value: str, minimum: str) -> bool:
+    parsed = _parse_exact_semver(value)
+    parsed_minimum = _parse_exact_semver(minimum)
+    if parsed is None or parsed_minimum is None:
+        raise ValueError("versions must be exact semver without build metadata")
+
+    core, prerelease = parsed[:3], parsed[3]
+    minimum_core, minimum_prerelease = parsed_minimum[:3], parsed_minimum[3]
+    if core != minimum_core:
+        return core > minimum_core
+    if not prerelease or not minimum_prerelease:
+        return not prerelease
+
+    for identifier, minimum_identifier in zip(prerelease, minimum_prerelease, strict=False):
+        if identifier == minimum_identifier:
+            continue
+        identifier_is_numeric = identifier.isdigit()
+        minimum_is_numeric = minimum_identifier.isdigit()
+        if identifier_is_numeric and minimum_is_numeric:
+            return int(identifier) > int(minimum_identifier)
+        if identifier_is_numeric != minimum_is_numeric:
+            return not identifier_is_numeric
+        return identifier > minimum_identifier
+    return len(prerelease) >= len(minimum_prerelease)
+
+
 def validate_clawdi_cli_package_spec(value: object) -> str:
     if not isinstance(value, str) or not value.startswith("clawdi@"):
         raise ValueError("cli_package_spec must be clawdi@<exact-semver> without build metadata")
@@ -667,7 +693,7 @@ class HostedCodexProviderProjection(BaseModel):
     baseUrl: str = Field(min_length=1, max_length=1000)
     apiMode: Literal["openai_responses"]
     managed_by: Literal["clawdi"]
-    runtimeEnvName: Literal["OPENAI_API_KEY"]
+    runtimeEnvName: Literal["OPENAI_API_KEY", "CLAWDI_AI_API_KEY"]
     apiKeySecretRef: Literal["secret://tool.codex.apiKey"]
 
 

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -76,6 +76,7 @@ from app.services.project_runtime_skills import (
     agent_supports_project_skills,
     project_skill_file_signature,
 )
+from app.services.runtime_generation import resolve_runtime_apply_generation
 from app.services.url_security import UnsafePublicHttpsUrlError, validate_public_https_url
 from app.services.vault_crypto import decrypt
 from app.services.whatsapp_baileys import (
@@ -113,10 +114,10 @@ def expected_runtime_bundle_v2_etag(source_revision: str) -> str:
 
 
 def _codex_tool_runtime_env(
-    cli_package_spec: str,
+    state: HostedRuntimeState,
     observation: HostedRuntimeConfigObservation | None,
 ) -> str:
-    desired_version = cli_package_spec.removeprefix("clawdi@")
+    desired_version = state.cli_package_spec.removeprefix("clawdi@")
     if not exact_semver_is_at_least(
         desired_version,
         _CODEX_TOOL_CANONICAL_ENV_MINIMUM_CLI_VERSION,
@@ -128,7 +129,21 @@ def _codex_tool_runtime_env(
         observed = HostedRuntimeObservedV2.model_validate(observation.diagnostics)
     except ValidationError:
         return _CODEX_TOOL_LEGACY_RUNTIME_ENV
-    if observed.active_cli_version != desired_version:
+    expected_generation = resolve_runtime_apply_generation(
+        generation=state.generation,
+        apply_generation=state.apply_generation,
+    )
+    if not (
+        observed.status == "ok"
+        and observed.converge_error is None
+        and observed.active_cli_version == desired_version
+        and observed.applied is not None
+        and observed.applied.instance_id == state.instance_id
+        and observed.applied.generation == expected_generation
+        and observation.observed_config_generation == expected_generation
+        and observation.observed_manifest_etag == observed.applied.etag
+        and observation.observed_source_revision == observed.applied.source_revision
+    ):
         return _CODEX_TOOL_LEGACY_RUNTIME_ENV
     return _MANAGED_PROVIDER_RUNTIME_ENV
 
@@ -759,7 +774,7 @@ def render_runtime_source(
         "baseUrl": codex_provider_material.get("baseUrl"),
         "apiMode": _CODEX_TOOL_API_MODE,
         "managed_by": codex_provider_material.get("managed_by"),
-        "runtimeEnvName": _codex_tool_runtime_env(cli_package_spec, row.observation),
+        "runtimeEnvName": _codex_tool_runtime_env(state, row.observation),
         "apiKeySecretRef": codex_provider_material.get("apiKeySecretRef"),
     }
     try:

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -49,8 +49,8 @@ from app.schemas.runtime import (
     HostedRuntimeSystem,
     HostedRuntimeTools,
     PersistedHostedRuntimeSkills,
-    exact_semver_is_at_least,
     is_canonical_secret_ref,
+    parse_exact_semver,
     validate_clawdi_cli_package_spec,
     validate_hosted_runtime_desired_state,
     validate_hosted_runtime_mcp_desired_state,
@@ -91,7 +91,7 @@ RUNTIME_BUNDLE_V2_SCHEMA_VERSION = "clawdi.hosted-runtime.bundle.v2"
 _SUPPORTED_RUNTIMES = {"hermes", "openclaw"}
 _MANAGED_PROVIDER_RUNTIME_ENV = "CLAWDI_AI_API_KEY"
 _CODEX_TOOL_LEGACY_RUNTIME_ENV = "OPENAI_API_KEY"
-_CODEX_TOOL_CANONICAL_ENV_MINIMUM_CLI_VERSION = "0.13.69"
+_CODEX_TOOL_CANONICAL_ENV_MINIMUM_CLI_VERSION = (0, 13, 69)
 _CODEX_TOOL_SECRET_REF = "secret://tool.codex.apiKey"
 _CODEX_TOOL_API_MODE = "openai_responses"
 _CODEX_PROVIDER_SOURCE_API_MODES = {"openai_chat", "openai_responses"}
@@ -118,9 +118,13 @@ def _codex_tool_runtime_env(
     observation: HostedRuntimeConfigObservation | None,
 ) -> str:
     desired_version = state.cli_package_spec.removeprefix("clawdi@")
-    if not exact_semver_is_at_least(
-        desired_version,
-        _CODEX_TOOL_CANONICAL_ENV_MINIMUM_CLI_VERSION,
+    parsed_version = parse_exact_semver(desired_version)
+    if parsed_version is None or (
+        parsed_version[:3] < _CODEX_TOOL_CANONICAL_ENV_MINIMUM_CLI_VERSION
+        or (
+            parsed_version[:3] == _CODEX_TOOL_CANONICAL_ENV_MINIMUM_CLI_VERSION
+            and parsed_version[3]
+        )
     ):
         return _CODEX_TOOL_LEGACY_RUNTIME_ENV
     if observation is None:
@@ -133,6 +137,8 @@ def _codex_tool_runtime_env(
         generation=state.generation,
         apply_generation=state.apply_generation,
     )
+    # The env-name change creates the next source revision, so gate only on the
+    # last applied record's internal identity instead of this render's revision.
     if not (
         observed.status == "ok"
         and observed.converge_error is None

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -49,11 +49,13 @@ from app.schemas.runtime import (
     HostedRuntimeSystem,
     HostedRuntimeTools,
     PersistedHostedRuntimeSkills,
+    exact_semver_is_at_least,
     is_canonical_secret_ref,
     validate_clawdi_cli_package_spec,
     validate_hosted_runtime_desired_state,
     validate_hosted_runtime_mcp_desired_state,
 )
+from app.schemas.runtime_observed import HostedRuntimeObservedV2
 from app.services.channels import (
     HOSTED_RUNTIME_SINGLE_ACCOUNT_PROVIDERS,
     channel_runtime_account_key,
@@ -87,7 +89,8 @@ RUNTIME_BUNDLE_V2_MEDIA_TYPE = "application/vnd.clawdi.runtime-bundle.v2+json"
 RUNTIME_BUNDLE_V2_SCHEMA_VERSION = "clawdi.hosted-runtime.bundle.v2"
 _SUPPORTED_RUNTIMES = {"hermes", "openclaw"}
 _MANAGED_PROVIDER_RUNTIME_ENV = "CLAWDI_AI_API_KEY"
-_CODEX_TOOL_RUNTIME_ENV = "OPENAI_API_KEY"
+_CODEX_TOOL_LEGACY_RUNTIME_ENV = "OPENAI_API_KEY"
+_CODEX_TOOL_CANONICAL_ENV_MINIMUM_CLI_VERSION = "0.13.69"
 _CODEX_TOOL_SECRET_REF = "secret://tool.codex.apiKey"
 _CODEX_TOOL_API_MODE = "openai_responses"
 _CODEX_PROVIDER_SOURCE_API_MODES = {"openai_chat", "openai_responses"}
@@ -107,6 +110,27 @@ def expected_runtime_bundle_v2_etag(source_revision: str) -> str:
     if not re.fullmatch(r"[0-9a-f]{64}", source_revision):
         raise ValueError("runtime bundle source revision must be a SHA-256 digest")
     return f'"sha256:{source_revision}"'
+
+
+def _codex_tool_runtime_env(
+    cli_package_spec: str,
+    observation: HostedRuntimeConfigObservation | None,
+) -> str:
+    desired_version = cli_package_spec.removeprefix("clawdi@")
+    if not exact_semver_is_at_least(
+        desired_version,
+        _CODEX_TOOL_CANONICAL_ENV_MINIMUM_CLI_VERSION,
+    ):
+        return _CODEX_TOOL_LEGACY_RUNTIME_ENV
+    if observation is None:
+        return _CODEX_TOOL_LEGACY_RUNTIME_ENV
+    try:
+        observed = HostedRuntimeObservedV2.model_validate(observation.diagnostics)
+    except ValidationError:
+        return _CODEX_TOOL_LEGACY_RUNTIME_ENV
+    if observed.active_cli_version != desired_version:
+        return _CODEX_TOOL_LEGACY_RUNTIME_ENV
+    return _MANAGED_PROVIDER_RUNTIME_ENV
 
 
 @dataclass(frozen=True)
@@ -735,7 +759,7 @@ def render_runtime_source(
         "baseUrl": codex_provider_material.get("baseUrl"),
         "apiMode": _CODEX_TOOL_API_MODE,
         "managed_by": codex_provider_material.get("managed_by"),
-        "runtimeEnvName": _CODEX_TOOL_RUNTIME_ENV,
+        "runtimeEnvName": _codex_tool_runtime_env(cli_package_spec, row.observation),
         "apiKeySecretRef": codex_provider_material.get("apiKeySecretRef"),
     }
     try:

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -2497,7 +2497,7 @@ async def test_runtime_manifest_etag_ignores_heartbeat_liveness(
                     "reportedAt": "2026-06-11T00:00:00+00:00",
                     "runtimeMode": "hosted",
                     "status": "ok",
-                    "activeCliVersion": TEST_CLI_PACKAGE_SPEC.split("@", 1)[1],
+                    "activeCliVersion": "0.13.68",
                     "applied": {
                         "etag": etag,
                         "sourceRevision": bundle["sourceRevision"],

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -311,66 +311,47 @@ def _render(batch: RuntimeSourceBatch):
     )
 
 
-def _set_cli_versions(
+def _set_healthy_cli_observation(
     batch: RuntimeSourceBatch,
     *,
     desired: str,
     active: str | None = None,
-    diagnostics: object | None = None,
-    applied_generation: int | None = None,
-    applied_instance_id: str | None = None,
-    observed_generation: int | None = None,
-    observed_etag: str | None = None,
-    observed_source_revision: str | None = None,
-    status: str = "ok",
-    converge_error: str | None = None,
-) -> None:
+    source_revision: str = "a" * 64,
+) -> HostedRuntimeConfigObservation:
     row = batch.rows[ENV_ID]
     assert row.state is not None
     row.state.cli_package_spec = desired
-    observation = None
-    if active is not None or diagnostics is not None:
-        expected_generation = (
-            row.state.apply_generation
-            if row.state.apply_generation is not None
-            else row.state.generation
-        )
-        source_revision = "a" * 64
-        etag = expected_runtime_bundle_v2_etag(source_revision)
-        observation = HostedRuntimeConfigObservation(
-            environment_id=ENV_ID,
-            observed_config_generation=(
-                observed_generation if observed_generation is not None else expected_generation
-            ),
-            observed_manifest_etag=observed_etag or etag,
-            observed_source_revision=observed_source_revision or source_revision,
-            diagnostics=(
-                diagnostics
-                if diagnostics is not None
-                else {
-                    "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
-                    "reportedAt": "2026-07-13T00:00:00Z",
-                    "runtimeMode": "hosted",
-                    "status": status,
-                    "activeCliVersion": active,
-                    "applied": {
-                        "etag": etag,
-                        "sourceRevision": source_revision,
-                        "generation": (
-                            applied_generation
-                            if applied_generation is not None
-                            else expected_generation
-                        ),
-                        "instanceId": applied_instance_id or row.state.instance_id,
-                        "appliedProviderIds": ["managed"],
-                    },
-                    "boot": None,
-                    "cli": None,
-                    "convergeError": converge_error,
-                }
-            ),
-        )
+    expected_generation = (
+        row.state.apply_generation
+        if row.state.apply_generation is not None
+        else row.state.generation
+    )
+    etag = expected_runtime_bundle_v2_etag(source_revision)
+    observation = HostedRuntimeConfigObservation(
+        environment_id=ENV_ID,
+        observed_config_generation=expected_generation,
+        observed_manifest_etag=etag,
+        observed_source_revision=source_revision,
+        diagnostics={
+            "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
+            "reportedAt": "2026-07-13T00:00:00Z",
+            "runtimeMode": "hosted",
+            "status": "ok",
+            "activeCliVersion": active or desired.removeprefix("clawdi@"),
+            "applied": {
+                "etag": etag,
+                "sourceRevision": source_revision,
+                "generation": expected_generation,
+                "instanceId": row.state.instance_id,
+                "appliedProviderIds": ["managed"],
+            },
+            "boot": None,
+            "cli": None,
+            "convergeError": None,
+        },
+    )
     batch.rows[ENV_ID] = RuntimeSourceRow(row.environment, row.state, observation)
+    return observation
 
 
 def _codex_runtime_env(batch: RuntimeSourceBatch) -> str:
@@ -752,148 +733,136 @@ def test_unmanaged_runtime_tool_secret_uses_auth_payload_without_user_vault_refs
     assert "clawdi://" not in json.dumps(bundle)
 
 
-def test_codex_tool_projection_pydantic_contract_rejects_openai_chat() -> None:
-    with pytest.raises(ValueError):
-        HostedCodexProviderProjection.model_validate(
-            {
-                "kind": "openai-compatible",
-                "type": "custom_openai_compatible",
-                "baseUrl": "https://provider.test/v1",
-                "apiMode": "openai_chat",
-                "managed_by": "clawdi",
-                "runtimeEnvName": "OPENAI_API_KEY",
-                "apiKeySecretRef": "secret://tool.codex.apiKey",
-            }
-        )
-
-
-def test_codex_tool_projection_rejects_arbitrary_runtime_env_name() -> None:
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("apiMode", "openai_chat"),
+        ("runtimeEnvName", "CUSTOM_OPENAI_API_KEY"),
+    ],
+)
+def test_codex_tool_projection_rejects_invalid_fixed_fields(field: str, value: str) -> None:
     projection = {
         "kind": "openai-compatible",
         "type": "custom_openai_compatible",
         "baseUrl": "https://provider.test/v1",
         "apiMode": "openai_responses",
         "managed_by": "clawdi",
-        "runtimeEnvName": "CUSTOM_OPENAI_API_KEY",
+        "runtimeEnvName": "OPENAI_API_KEY",
         "apiKeySecretRef": "secret://tool.codex.apiKey",
     }
+    projection[field] = value
 
     with pytest.raises(ValueError):
         HostedCodexProviderProjection.model_validate(projection)
 
 
-def test_codex_tool_env_stays_legacy_for_old_cli_observations() -> None:
-    old = _batch()
-    _set_cli_versions(old, desired="clawdi@0.13.68", active="0.13.68")
-    prerelease = _batch()
-    _set_cli_versions(
-        prerelease,
-        desired="clawdi@0.13.69-rc.1",
-        active="0.13.69-rc.1",
+@pytest.mark.parametrize(
+    ("desired", "active", "expected"),
+    [
+        ("0.13.68", "0.13.68", "OPENAI_API_KEY"),
+        ("0.13.69-rc.1", "0.13.69-rc.1", "OPENAI_API_KEY"),
+        ("0.13.69", "0.13.68", "OPENAI_API_KEY"),
+        ("0.13.69", "0.13.69", "CLAWDI_AI_API_KEY"),
+        ("0.14.0-rc.1", "0.14.0-rc.1", "CLAWDI_AI_API_KEY"),
+        ("0.13.68", "0.14.0", "OPENAI_API_KEY"),
+    ],
+)
+def test_codex_tool_env_respects_cli_version_boundary(
+    desired: str,
+    active: str,
+    expected: str,
+) -> None:
+    batch = _batch()
+    _set_healthy_cli_observation(
+        batch,
+        desired=f"clawdi@{desired}",
+        active=active,
     )
 
-    assert _codex_runtime_env(old) == "OPENAI_API_KEY"
-    assert _codex_runtime_env(prerelease) == "OPENAI_API_KEY"
+    assert _codex_runtime_env(batch) == expected
 
 
 def test_codex_tool_env_stays_legacy_until_new_cli_is_observed() -> None:
-    old_active = _batch()
-    _set_cli_versions(old_active, desired="clawdi@0.13.69", active="0.13.68")
     missing = _batch()
-    _set_cli_versions(missing, desired="clawdi@0.13.69")
+    assert missing.rows[ENV_ID].state is not None
+    missing.rows[ENV_ID].state.cli_package_spec = "clawdi@0.13.69"
     invalid = _batch()
-    _set_cli_versions(
-        invalid,
-        desired="clawdi@0.13.69",
-        diagnostics={"schemaVersion": "clawdi.hostedRuntimeObserved.v2"},
-    )
+    invalid_observation = _set_healthy_cli_observation(invalid, desired="clawdi@0.13.69")
+    invalid_observation.diagnostics = {"schemaVersion": "clawdi.hostedRuntimeObserved.v2"}
 
-    assert [_codex_runtime_env(batch) for batch in (old_active, missing, invalid)] == [
-        "OPENAI_API_KEY",
+    assert [_codex_runtime_env(batch) for batch in (missing, invalid)] == [
         "OPENAI_API_KEY",
         "OPENAI_API_KEY",
     ]
 
 
-def test_codex_tool_env_is_canonical_for_exact_new_cli_observation() -> None:
+@pytest.mark.parametrize(
+    ("diagnostics_update", "applied_update", "observation_update"),
+    [
+        ({"status": "error"}, {}, {}),
+        ({"convergeError": "apply failed"}, {}, {}),
+        ({"applied": None}, {}, {}),
+        ({}, {"instanceId": "hri_previous"}, {}),
+        ({}, {"generation": 0}, {}),
+        ({}, {}, {"observed_config_generation": 0}),
+        ({}, {}, {"observed_manifest_etag": expected_runtime_bundle_v2_etag("b" * 64)}),
+        ({}, {}, {"observed_source_revision": "b" * 64}),
+    ],
+)
+def test_codex_tool_env_rejects_unhealthy_or_inconsistent_observations(
+    diagnostics_update: dict[str, object],
+    applied_update: dict[str, object],
+    observation_update: dict[str, object],
+) -> None:
     batch = _batch()
-    _set_cli_versions(batch, desired="clawdi@0.13.69", active="0.13.69")
-
-    assert _codex_runtime_env(batch) == "CLAWDI_AI_API_KEY"
-
-
-def test_codex_tool_env_rejects_stale_same_version_observations() -> None:
-    stale_generation = _batch(generation=4, apply_generation=3)
-    _set_cli_versions(
-        stale_generation,
-        desired="clawdi@0.13.69",
-        active="0.13.69",
-        applied_generation=2,
-        observed_generation=2,
-    )
-    stale_instance = _batch()
-    _set_cli_versions(
-        stale_instance,
-        desired="clawdi@0.13.69",
-        active="0.13.69",
-        applied_instance_id="hri_previous",
-    )
-
-    assert _codex_runtime_env(stale_generation) == "OPENAI_API_KEY"
-    assert _codex_runtime_env(stale_instance) == "OPENAI_API_KEY"
-
-
-def test_codex_tool_env_rejects_unhealthy_or_inconsistent_observations() -> None:
-    runtime_error = _batch()
-    _set_cli_versions(
-        runtime_error,
-        desired="clawdi@0.13.69",
-        active="0.13.69",
-        status="error",
-    )
-    converge_error = _batch()
-    _set_cli_versions(
-        converge_error,
-        desired="clawdi@0.13.69",
-        active="0.13.69",
-        converge_error="apply failed",
-    )
-    inconsistent = _batch()
-    _set_cli_versions(
-        inconsistent,
-        desired="clawdi@0.13.69",
-        active="0.13.69",
-        observed_etag=expected_runtime_bundle_v2_etag("b" * 64),
-        observed_source_revision="b" * 64,
-    )
-
-    assert [
-        _codex_runtime_env(batch) for batch in (runtime_error, converge_error, inconsistent)
-    ] == [
-        "OPENAI_API_KEY",
-        "OPENAI_API_KEY",
-        "OPENAI_API_KEY",
-    ]
-
-
-def test_codex_tool_env_is_canonical_for_matching_newer_prerelease() -> None:
-    batch = _batch()
-    _set_cli_versions(batch, desired="clawdi@0.14.0-rc.1", active="0.14.0-rc.1")
-
-    assert _codex_runtime_env(batch) == "CLAWDI_AI_API_KEY"
-
-
-def test_codex_tool_env_returns_to_legacy_during_rollback() -> None:
-    batch = _batch()
-    _set_cli_versions(batch, desired="clawdi@0.13.68", active="0.14.0")
+    observation = _set_healthy_cli_observation(batch, desired="clawdi@0.13.69")
+    assert isinstance(observation.diagnostics, dict)
+    applied = observation.diagnostics["applied"]
+    observation.diagnostics.update(diagnostics_update)
+    if applied_update:
+        assert isinstance(applied, dict)
+        applied.update(applied_update)
+    for field, value in observation_update.items():
+        setattr(observation, field, value)
 
     assert _codex_runtime_env(batch) == "OPENAI_API_KEY"
+
+
+def test_codex_tool_env_cutover_reaches_a_stable_source_revision() -> None:
+    batch = _batch()
+    assert batch.rows[ENV_ID].state is not None
+    batch.rows[ENV_ID].state.cli_package_spec = "clawdi@0.13.69"
+    legacy = _render(batch)
+    assert _codex_runtime_env(batch) == "OPENAI_API_KEY"
+
+    observation = _set_healthy_cli_observation(
+        batch,
+        desired="clawdi@0.13.69",
+        source_revision=legacy.source_revision,
+    )
+    canonical = _render(batch)
+    assert canonical.source_revision != legacy.source_revision
+    assert observation.observed_source_revision == legacy.source_revision
+    assert observation.observed_source_revision != canonical.source_revision
+    assert _codex_runtime_env(batch) == "CLAWDI_AI_API_KEY"
+    assert _render(batch).source_revision == canonical.source_revision
+
+    assert isinstance(observation.diagnostics, dict)
+    applied = observation.diagnostics["applied"]
+    assert isinstance(applied, dict)
+    canonical_etag = expected_runtime_bundle_v2_etag(canonical.source_revision)
+    applied.update({"etag": canonical_etag, "sourceRevision": canonical.source_revision})
+    observation.observed_manifest_etag = canonical_etag
+    observation.observed_source_revision = canonical.source_revision
+    assert _render(batch).source_revision == canonical.source_revision
 
 
 def test_shared_managed_provider_material_has_distinct_codex_wire_mode() -> None:
     source = _render(_batch())
 
-    assert source.manifest["providers"][CLAWDI_MANAGED_PROVIDER_ID]["apiMode"] == "openai_chat"
+    runtime_provider = source.manifest["providers"][CLAWDI_MANAGED_PROVIDER_ID]
+    assert runtime_provider["apiMode"] == "openai_chat"
+    assert runtime_provider["models"] == [{"id": "gpt-test"}]
     codex_provider = source.manifest["terminalTooling"]["codex"]["provider"]
     assert codex_provider == {
         "kind": "openai-compatible",

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -317,14 +317,33 @@ def _set_cli_versions(
     desired: str,
     active: str | None = None,
     diagnostics: object | None = None,
+    applied_generation: int | None = None,
+    applied_instance_id: str | None = None,
+    observed_generation: int | None = None,
+    observed_etag: str | None = None,
+    observed_source_revision: str | None = None,
+    status: str = "ok",
+    converge_error: str | None = None,
 ) -> None:
     row = batch.rows[ENV_ID]
     assert row.state is not None
     row.state.cli_package_spec = desired
     observation = None
     if active is not None or diagnostics is not None:
+        expected_generation = (
+            row.state.apply_generation
+            if row.state.apply_generation is not None
+            else row.state.generation
+        )
+        source_revision = "a" * 64
+        etag = expected_runtime_bundle_v2_etag(source_revision)
         observation = HostedRuntimeConfigObservation(
             environment_id=ENV_ID,
+            observed_config_generation=(
+                observed_generation if observed_generation is not None else expected_generation
+            ),
+            observed_manifest_etag=observed_etag or etag,
+            observed_source_revision=observed_source_revision or source_revision,
             diagnostics=(
                 diagnostics
                 if diagnostics is not None
@@ -332,11 +351,22 @@ def _set_cli_versions(
                     "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
                     "reportedAt": "2026-07-13T00:00:00Z",
                     "runtimeMode": "hosted",
-                    "status": "ok",
+                    "status": status,
                     "activeCliVersion": active,
-                    "applied": None,
+                    "applied": {
+                        "etag": etag,
+                        "sourceRevision": source_revision,
+                        "generation": (
+                            applied_generation
+                            if applied_generation is not None
+                            else expected_generation
+                        ),
+                        "instanceId": applied_instance_id or row.state.instance_id,
+                        "appliedProviderIds": ["managed"],
+                    },
                     "boot": None,
                     "cli": None,
+                    "convergeError": converge_error,
                 }
             ),
         )
@@ -790,6 +820,60 @@ def test_codex_tool_env_is_canonical_for_exact_new_cli_observation() -> None:
     _set_cli_versions(batch, desired="clawdi@0.13.69", active="0.13.69")
 
     assert _codex_runtime_env(batch) == "CLAWDI_AI_API_KEY"
+
+
+def test_codex_tool_env_rejects_stale_same_version_observations() -> None:
+    stale_generation = _batch(generation=4, apply_generation=3)
+    _set_cli_versions(
+        stale_generation,
+        desired="clawdi@0.13.69",
+        active="0.13.69",
+        applied_generation=2,
+        observed_generation=2,
+    )
+    stale_instance = _batch()
+    _set_cli_versions(
+        stale_instance,
+        desired="clawdi@0.13.69",
+        active="0.13.69",
+        applied_instance_id="hri_previous",
+    )
+
+    assert _codex_runtime_env(stale_generation) == "OPENAI_API_KEY"
+    assert _codex_runtime_env(stale_instance) == "OPENAI_API_KEY"
+
+
+def test_codex_tool_env_rejects_unhealthy_or_inconsistent_observations() -> None:
+    runtime_error = _batch()
+    _set_cli_versions(
+        runtime_error,
+        desired="clawdi@0.13.69",
+        active="0.13.69",
+        status="error",
+    )
+    converge_error = _batch()
+    _set_cli_versions(
+        converge_error,
+        desired="clawdi@0.13.69",
+        active="0.13.69",
+        converge_error="apply failed",
+    )
+    inconsistent = _batch()
+    _set_cli_versions(
+        inconsistent,
+        desired="clawdi@0.13.69",
+        active="0.13.69",
+        observed_etag=expected_runtime_bundle_v2_etag("b" * 64),
+        observed_source_revision="b" * 64,
+    )
+
+    assert [
+        _codex_runtime_env(batch) for batch in (runtime_error, converge_error, inconsistent)
+    ] == [
+        "OPENAI_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENAI_API_KEY",
+    ]
 
 
 def test_codex_tool_env_is_canonical_for_matching_newer_prerelease() -> None:

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -15,6 +15,7 @@ from app.models.channel import (
     ChannelWhatsAppAuthCert,
 )
 from app.models.hosted_runtime import (
+    HostedRuntimeConfigObservation,
     HostedRuntimeSecret,
     HostedRuntimeState,
 )
@@ -308,6 +309,42 @@ def _render(batch: RuntimeSourceBatch):
         vault_key_identity="vault-key-generation-1",
         decrypt_secrets=False,
     )
+
+
+def _set_cli_versions(
+    batch: RuntimeSourceBatch,
+    *,
+    desired: str,
+    active: str | None = None,
+    diagnostics: object | None = None,
+) -> None:
+    row = batch.rows[ENV_ID]
+    assert row.state is not None
+    row.state.cli_package_spec = desired
+    observation = None
+    if active is not None or diagnostics is not None:
+        observation = HostedRuntimeConfigObservation(
+            environment_id=ENV_ID,
+            diagnostics=(
+                diagnostics
+                if diagnostics is not None
+                else {
+                    "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
+                    "reportedAt": "2026-07-13T00:00:00Z",
+                    "runtimeMode": "hosted",
+                    "status": "ok",
+                    "activeCliVersion": active,
+                    "applied": None,
+                    "boot": None,
+                    "cli": None,
+                }
+            ),
+        )
+    batch.rows[ENV_ID] = RuntimeSourceRow(row.environment, row.state, observation)
+
+
+def _codex_runtime_env(batch: RuntimeSourceBatch) -> str:
+    return _render(batch).manifest["terminalTooling"]["codex"]["provider"]["runtimeEnvName"]
 
 
 def test_runtime_source_revision_uses_only_projected_descriptor_and_secret_sources() -> None:
@@ -698,6 +735,75 @@ def test_codex_tool_projection_pydantic_contract_rejects_openai_chat() -> None:
                 "apiKeySecretRef": "secret://tool.codex.apiKey",
             }
         )
+
+
+def test_codex_tool_projection_rejects_arbitrary_runtime_env_name() -> None:
+    projection = {
+        "kind": "openai-compatible",
+        "type": "custom_openai_compatible",
+        "baseUrl": "https://provider.test/v1",
+        "apiMode": "openai_responses",
+        "managed_by": "clawdi",
+        "runtimeEnvName": "CUSTOM_OPENAI_API_KEY",
+        "apiKeySecretRef": "secret://tool.codex.apiKey",
+    }
+
+    with pytest.raises(ValueError):
+        HostedCodexProviderProjection.model_validate(projection)
+
+
+def test_codex_tool_env_stays_legacy_for_old_cli_observations() -> None:
+    old = _batch()
+    _set_cli_versions(old, desired="clawdi@0.13.68", active="0.13.68")
+    prerelease = _batch()
+    _set_cli_versions(
+        prerelease,
+        desired="clawdi@0.13.69-rc.1",
+        active="0.13.69-rc.1",
+    )
+
+    assert _codex_runtime_env(old) == "OPENAI_API_KEY"
+    assert _codex_runtime_env(prerelease) == "OPENAI_API_KEY"
+
+
+def test_codex_tool_env_stays_legacy_until_new_cli_is_observed() -> None:
+    old_active = _batch()
+    _set_cli_versions(old_active, desired="clawdi@0.13.69", active="0.13.68")
+    missing = _batch()
+    _set_cli_versions(missing, desired="clawdi@0.13.69")
+    invalid = _batch()
+    _set_cli_versions(
+        invalid,
+        desired="clawdi@0.13.69",
+        diagnostics={"schemaVersion": "clawdi.hostedRuntimeObserved.v2"},
+    )
+
+    assert [_codex_runtime_env(batch) for batch in (old_active, missing, invalid)] == [
+        "OPENAI_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENAI_API_KEY",
+    ]
+
+
+def test_codex_tool_env_is_canonical_for_exact_new_cli_observation() -> None:
+    batch = _batch()
+    _set_cli_versions(batch, desired="clawdi@0.13.69", active="0.13.69")
+
+    assert _codex_runtime_env(batch) == "CLAWDI_AI_API_KEY"
+
+
+def test_codex_tool_env_is_canonical_for_matching_newer_prerelease() -> None:
+    batch = _batch()
+    _set_cli_versions(batch, desired="clawdi@0.14.0-rc.1", active="0.14.0-rc.1")
+
+    assert _codex_runtime_env(batch) == "CLAWDI_AI_API_KEY"
+
+
+def test_codex_tool_env_returns_to_legacy_during_rollback() -> None:
+    batch = _batch()
+    _set_cli_versions(batch, desired="clawdi@0.13.68", active="0.14.0")
+
+    assert _codex_runtime_env(batch) == "OPENAI_API_KEY"
 
 
 def test_shared_managed_provider_material_has_distinct_codex_wire_mode() -> None:

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -997,7 +997,7 @@ async def test_v2_applied_authority_persists_and_drives_health(
             deployment_id="dep-observed-v2",
             instance_id="iid-observed-v2",
             generation=4,
-            cli_package_spec=_TEST_CLI_PACKAGE_SPEC,
+            cli_package_spec="clawdi@0.13.68",
             locale=_TEST_LOCALE,
             system=_TEST_SYSTEM,
             live_sync={"enabled": False, "agents": []},
@@ -1014,6 +1014,7 @@ async def test_v2_applied_authority_persists_and_drives_health(
         json={
             "runtime_observed": _runtime_observed(
                 source_revision=source_revision,
+                active_cli_version="0.13.68",
                 applied_instance_id="iid-observed-v2",
             )
         },
@@ -1024,26 +1025,7 @@ async def test_v2_applied_authority_persists_and_drives_health(
     assert observation.observed_config_generation == 4
     assert observation.observed_manifest_etag == expected_runtime_bundle_v2_etag(source_revision)
     assert observation.observed_source_revision == source_revision
-    assert observation.diagnostics["activeCliVersion"] == "1.2.3-test"
-
-    transitioning = (await client.get(f"/v1/environments/{env_id}/runtime-observed")).json()
-    canonical_source_revision = transitioning["desired"]["desired_source_revision"]
-    assert canonical_source_revision != source_revision
-    heartbeat = await client.post(
-        f"/v1/agents/{env_id}/sync-heartbeat",
-        json={
-            "runtime_observed": _runtime_observed(
-                source_revision=canonical_source_revision,
-                applied_instance_id="iid-observed-v2",
-            )
-        },
-    )
-    assert heartbeat.status_code == 204, heartbeat.text
-    await db_session.refresh(observation)
-    assert observation.observed_manifest_etag == expected_runtime_bundle_v2_etag(
-        canonical_source_revision
-    )
-    assert observation.observed_source_revision == canonical_source_revision
+    assert observation.diagnostics["activeCliVersion"] == "0.13.68"
     healthy = (await client.get(f"/v1/environments/{env_id}/runtime-observed")).json()
     assert healthy["health"] == {
         "status": "ok",
@@ -1052,8 +1034,8 @@ async def test_v2_applied_authority_persists_and_drives_health(
     }
 
     mismatch = _runtime_observed(
-        source_revision=canonical_source_revision,
-        active_cli_version="1.2.1-test",
+        source_revision=source_revision,
+        active_cli_version="0.13.67",
         applied_instance_id="iid-observed-v2",
         providers={},
     )

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -574,6 +574,23 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
         applied_generation=4,
         applied_instance_id="iid-observed-api",
     )
+    heartbeat = await client.post(
+        f"/v1/agents/{env_id}/sync-heartbeat",
+        json={"queue_depth": 1, "runtime_observed": observed},
+    )
+    assert heartbeat.status_code == 204, heartbeat.text
+
+    transitioning = (await client.get(f"/v1/environments/{env_id}/runtime-observed")).json()
+    canonical_source_revision = transitioning["desired"]["desired_source_revision"]
+    assert canonical_source_revision != desired_source_revision
+    assert transitioning["health"]["status"] == "unknown"
+
+    observed = _runtime_observed(
+        source_revision=canonical_source_revision,
+        active_cli_version="1.2.5-test",
+        applied_generation=4,
+        applied_instance_id="iid-observed-api",
+    )
     received_at_lower_bound = datetime.now(UTC)
     heartbeat = await client.post(
         f"/v1/agents/{env_id}/sync-heartbeat",
@@ -615,9 +632,9 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
     ) == datetime.fromisoformat(observed["reportedAt"])
     assert payload["observed"]["observed_config_generation"] == 4
     assert payload["observed"]["observed_manifest_etag"] == expected_runtime_bundle_v2_etag(
-        desired_source_revision
+        canonical_source_revision
     )
-    assert payload["observed"]["observed_source_revision"] == desired_source_revision
+    assert payload["observed"]["observed_source_revision"] == canonical_source_revision
     assert payload["observed"]["diagnostics"]["schemaVersion"] == (
         "clawdi.hostedRuntimeObserved.v2"
     )
@@ -1008,6 +1025,25 @@ async def test_v2_applied_authority_persists_and_drives_health(
     assert observation.observed_manifest_etag == expected_runtime_bundle_v2_etag(source_revision)
     assert observation.observed_source_revision == source_revision
     assert observation.diagnostics["activeCliVersion"] == "1.2.3-test"
+
+    transitioning = (await client.get(f"/v1/environments/{env_id}/runtime-observed")).json()
+    canonical_source_revision = transitioning["desired"]["desired_source_revision"]
+    assert canonical_source_revision != source_revision
+    heartbeat = await client.post(
+        f"/v1/agents/{env_id}/sync-heartbeat",
+        json={
+            "runtime_observed": _runtime_observed(
+                source_revision=canonical_source_revision,
+                applied_instance_id="iid-observed-v2",
+            )
+        },
+    )
+    assert heartbeat.status_code == 204, heartbeat.text
+    await db_session.refresh(observation)
+    assert observation.observed_manifest_etag == expected_runtime_bundle_v2_etag(
+        canonical_source_revision
+    )
+    assert observation.observed_source_revision == canonical_source_revision
     healthy = (await client.get(f"/v1/environments/{env_id}/runtime-observed")).json()
     assert healthy["health"] == {
         "status": "ok",
@@ -1016,7 +1052,7 @@ async def test_v2_applied_authority_persists_and_drives_health(
     }
 
     mismatch = _runtime_observed(
-        source_revision=source_revision,
+        source_revision=canonical_source_revision,
         active_cli_version="1.2.1-test",
         applied_instance_id="iid-observed-v2",
         providers={},

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -661,6 +661,9 @@ strict v2 diagnostics prove the exact desired version, current apply generation,
 and current instance. Observation generation, ETag, and source revision must
 agree with that applied record. Every missing, invalid, stale, or mismatched
 state retains `OPENAI_API_KEY`, including upgrades and rollbacks.
+The gate does not compare that last applied revision with the revision currently
+being rendered: changing the env name creates a new revision, and the internally
+consistent applied record keeps the canonical projection stable while it catches up.
 
 This mode controls default configuration ownership, not pod-wide network
 isolation. Egress matching is domain based, so another pod process could call a

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -661,6 +661,8 @@ strict v2 diagnostics prove the exact desired version, current apply generation,
 and current instance. Observation generation, ETag, and source revision must
 agree with that applied record. Every missing, invalid, stale, or mismatched
 state retains `OPENAI_API_KEY`, including upgrades and rollbacks.
+Phase B may therefore deploy before the fleet upgrades: each deployment remains
+on the legacy env name until its own CLI and observation have converged.
 The gate does not compare that last applied revision with the revision currently
 being rendered: changing the env name creates a new revision, and the internally
 consistent applied record keeps the canonical projection stable while it catches up.

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -655,11 +655,12 @@ CLIs can reach this compatibility release.
 
 This change is Phase A: publish `clawdi@0.13.69`, which reads both legacy and
 canonical terminal-Codex env names while writing only the canonical local env.
-The backend still emits legacy `OPENAI_API_KEY`. Phase B must be a separate
-backend change after `0.13.69` is published, deployment desired package specs
-have advanced, and `activeCliVersion` has converged; only then may backend
-emission switch to `CLAWDI_AI_API_KEY`. Otherwise an older CLI can reject the
-manifest before installing and re-executing the requested CLI.
+Phase B keeps backend emission deployment-scoped: terminal Codex receives
+`CLAWDI_AI_API_KEY` only when the desired CLI is `clawdi@0.13.69` or later and
+strict v2 diagnostics prove the exact desired version, current apply generation,
+and current instance. Observation generation, ETag, and source revision must
+agree with that applied record. Every missing, invalid, stale, or mismatched
+state retains `OPENAI_API_KEY`, including upgrades and rollbacks.
 
 This mode controls default configuration ownership, not pod-wide network
 isolation. Egress matching is domain based, so another pod process could call a

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -247,7 +247,9 @@ discoverable from account state and should be reconciled separately with
    package specs and active CLI observations have converged. The backend then
    switches each deployment to `CLAWDI_AI_API_KEY` only when its desired
    version is at least `0.13.69` and strict v2 diagnostics report that exact
-   desired version; every other state continues to receive `OPENAI_API_KEY`.
+   desired version plus the current apply generation and instance. Observation
+   generation, ETag, and source revision must agree with that applied record;
+   every other state continues to receive `OPENAI_API_KEY`.
 
    Managed provider egress rewrites require the public
    `Bearer clawdi-egress-placeholder` authorization value as an explicit intent

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -242,6 +242,13 @@ discoverable from account state and should be reconciled separately with
    release and the same registry/pairing smoke gate; it is not an image,
    manifest, environment override, or npm dist-tag setting.
 
+   Do not merge or deploy the backend terminal Codex environment-name cutover
+   until `clawdi@0.13.69` is published and existing deployments' desired
+   package specs and active CLI observations have converged. The backend then
+   switches each deployment to `CLAWDI_AI_API_KEY` only when its desired
+   version is at least `0.13.69` and strict v2 diagnostics report that exact
+   desired version; every other state continues to receive `OPENAI_API_KEY`.
+
    Managed provider egress rewrites require the public
    `Bearer clawdi-egress-placeholder` authorization value as an explicit intent
    marker. Requests with a user token or no authorization header are not

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -242,14 +242,14 @@ discoverable from account state and should be reconciled separately with
    release and the same registry/pairing smoke gate; it is not an image,
    manifest, environment override, or npm dist-tag setting.
 
-   Do not merge or deploy the backend terminal Codex environment-name cutover
-   until `clawdi@0.13.69` is published and existing deployments' desired
-   package specs and active CLI observations have converged. The backend then
-   switches each deployment to `CLAWDI_AI_API_KEY` only when its desired
+   The backend terminal Codex environment-name cutover may deploy after
+   `clawdi@0.13.69` is published. Existing deployments do not need to converge
+   first: each deployment switches to `CLAWDI_AI_API_KEY` only when its desired
    version is at least `0.13.69` and strict v2 diagnostics report that exact
    desired version plus the current apply generation and instance. Observation
    generation, ETag, and source revision must agree with that applied record;
-   every other state continues to receive `OPENAI_API_KEY`.
+   every older, upgrading, stale, or unhealthy deployment continues to receive
+   `OPENAI_API_KEY`.
 
    Managed provider egress rewrites require the public
    `Bearer clawdi-egress-placeholder` authorization value as an explicit intent


### PR DESCRIPTION
## Summary

- Gate terminal Codex `CLAWDI_AI_API_KEY` projection per deployment on desired `clawdi@0.13.69` or later plus strict, internally consistent `HostedRuntimeObservedV2` evidence for that exact active CLI.
- Retain `OPENAI_API_KEY` for older desired versions, upgrades and rollbacks in progress, missing or invalid observations, unhealthy diagnostics, and stale generation, instance, ETag, or source-revision evidence.
- Keep terminal Managed Codex model/catalog-free while preserving OpenClaw and Hermes frozen runtime catalogs.

## Rollout contract

`clawdi@0.13.69` is published. This backend change may deploy before existing deployments upgrade: the gate is deployment-scoped, so every older or unconverged deployment keeps the legacy env name. A deployment switches only after its own desired CLI, active CLI, apply generation, instance, and observation identity have converged.

Changing `runtimeEnvName` creates the next source revision. The gate therefore checks the last applied observation's internal identity rather than requiring it to equal the revision currently being rendered. Focused coverage proves the transition reaches a stable fixed point without oscillation.

No fleet-wide cut, database change, migration, feature flag, setting, TTL, or new runtime state is required.

## Base contracts preserved

- #979 supplies CLI 0.13.69 dual-read/canonical-write compatibility.
- #983 selected-model projection remains runtime-provider-only; terminal Codex stays model-free.
- OpenClaw and Hermes managed provider snapshots remain unchanged.

## Verification

- Isolated backend cohort: `335 passed`
- Focused tests: `55 passed`
- Managed-runtime docs contract after rollout clarification: `3 passed`
- Type governance: `186 files, 0 errors, 0 warnings`
- Ruff, format, compileall, `git diff --check`: passed
- GitHub Backend CI and Vercel: passed at the reviewed implementation head; fresh CI runs for this documentation-only follow-up
