### PR TITLE
fix(runtime): require exact hosted provider source

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -163,7 +163,6 @@ from app.services.managed_ai_provider import (
     find_clawdi_managed_provider,
     is_v2_deployment_managed_provider_id,
     lock_deployment_managed_provider_mutation,
-    runtime_managed_provider_id,
     upsert_clawdi_managed_provider,
 )
 from app.services.principal_lifecycle import (
@@ -2217,23 +2216,6 @@ def _runtime_state_values(
             return None
         return value.model_dump(exclude_none=True, exclude_unset=True, mode="json")
 
-    runtimes: dict[str, dict[str, Any]] = {}
-    for name, runtime in body.runtimes.items():
-        value = runtime.model_dump(exclude_none=True, mode="json")
-        value["provider_ids"] = [
-            runtime_managed_provider_id(provider_id) for provider_id in runtime.provider_ids
-        ]
-        primary_model = value.get("primary_model")
-        if primary_model is not None:
-            primary_model["provider_id"] = runtime_managed_provider_id(primary_model["provider_id"])
-        runtimes[name] = value
-
-    tools = body.tools.model_dump(exclude_none=True, exclude_unset=True, mode="json")
-    codex = tools["codex"]
-    codex_provider_id = runtime_managed_provider_id(codex["provider_id"])
-    codex["provider_id"] = codex_provider_id
-    codex["primary_model"]["provider_id"] = codex_provider_id
-
     return {
         "deployment_id": body.deployment_id,
         "instance_id": body.instance_id,
@@ -2244,13 +2226,16 @@ def _runtime_state_values(
         "system": body.system.model_dump(exclude_none=True, mode="json"),
         "egress_engine": optional_wire_value("egress_engine"),
         "companions": optional_wire_value("companions"),
-        "runtimes": runtimes,
+        "runtimes": {
+            name: runtime.model_dump(exclude_none=True, mode="json")
+            for name, runtime in body.runtimes.items()
+        },
         "live_sync": body.live_sync.model_dump(mode="json"),
         "recovery": body.recovery.model_dump(mode="json"),
         "egress_profiles": optional_wire_value("egress_profiles"),
         "mcp": optional_wire_value("mcp"),
         "skills": optional_wire_value("skills"),
-        "tools": tools,
+        "tools": body.tools.model_dump(exclude_none=True, exclude_unset=True, mode="json"),
     }
 
 

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -62,14 +62,12 @@ from app.services.channels import (
 )
 from app.services.hosted_runtime_secrets import validate_hosted_runtime_secret_key_version
 from app.services.managed_ai_provider import (
-    V2_LEGACY_MANAGED_AI_PROVIDER_ID,
-    V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
-    V2_MANAGED_AI_PROVIDER_ID,
+    V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX,
     V2_MANAGED_AI_PROVIDER_IDS,
     is_managed_provider_id,
+    is_v2_deployment_managed_provider_id,
     managed_provider_api_mode,
     runtime_managed_provider_id,
-    v2_deployment_managed_provider_id,
 )
 from app.services.project_runtime_skills import (
     RUNTIME_PROJECT_SKILL_KEY_PATTERN,
@@ -617,14 +615,13 @@ def render_runtime_source(
             )
         )
     codex_tool = tools.codex
+    if not is_v2_deployment_managed_provider_id(codex_tool.provider_id):
+        raise RuntimeSourceError("Hosted Codex tool provider must use its exact deployment source")
     codex_agent_provider_id = runtime_managed_provider_id(codex_tool.provider_id)
     provider_sources: dict[str, str] = {}
     for bound_provider_id in [*bound_runtime_provider_ids, codex_tool.provider_id]:
         agent_provider_id = runtime_managed_provider_id(bound_provider_id)
-        source_provider_id = _provider_source_id(
-            batch,
-            user_id=user_id,
-            deployment_id=state.deployment_id,
+        source_provider_id = _exact_provider_source_id(
             bound_provider_id=bound_provider_id,
         )
         existing_source = provider_sources.get(agent_provider_id)
@@ -1011,27 +1008,21 @@ def _agent_codex_tool(codex_tool: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _provider_source_id(
-    batch: RuntimeSourceBatch,
+def _exact_provider_source_id(
     *,
-    user_id: UUID,
-    deployment_id: str,
     bound_provider_id: str,
 ) -> str:
-    """Resolve an agent alias to the deployment-scoped credential/catalog row."""
+    """Validate and return the exact provider credential/catalog identity."""
 
-    if bound_provider_id not in V2_MANAGED_AI_PROVIDER_IDS:
-        return bound_provider_id
-    deployment_provider_id = v2_deployment_managed_provider_id(deployment_id)
-    if deployment_provider_id is not None and (user_id, deployment_provider_id) in batch.providers:
-        return deployment_provider_id
-    if (user_id, V2_MANAGED_AI_PROVIDER_ID) in batch.providers:
-        return V2_MANAGED_AI_PROVIDER_ID
-    if (user_id, V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID) in batch.providers:
-        return V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID
-    if (user_id, V2_LEGACY_MANAGED_AI_PROVIDER_ID) in batch.providers:
-        return V2_LEGACY_MANAGED_AI_PROVIDER_ID
-    return V2_MANAGED_AI_PROVIDER_ID
+    if bound_provider_id in V2_MANAGED_AI_PROVIDER_IDS:
+        raise RuntimeSourceError(
+            "Hosted v2 managed provider binding must use its exact deployment source"
+        )
+    if bound_provider_id.startswith(V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX) and not (
+        is_v2_deployment_managed_provider_id(bound_provider_id)
+    ):
+        raise RuntimeSourceError("Hosted v2 managed provider source is invalid")
+    return bound_provider_id
 
 
 def _selected_auth_payload(

--- a/backend/scripts/seed_dashboard_dev.py
+++ b/backend/scripts/seed_dashboard_dev.py
@@ -65,7 +65,6 @@ from app.services.channels import (  # noqa: E402
     generate_agent_token,
     hash_token,
 )
-from app.services.managed_ai_provider import CLAWDI_MANAGED_PROVIDER_ID  # noqa: E402
 from app.services.vault_crypto import encrypt  # noqa: E402
 
 DEV_V2_DEPLOYMENT_ID = "hdep_dev_sidebar"
@@ -73,7 +72,7 @@ DEV_V2_APP_ID = "app_dev_sidebar"
 DEV_V2_HOSTED_MACHINE_ID = "dev-hosted-sidebar"
 DEV_V2_HOSTED_MACHINE_NAME = "Dev Hosted Compute"
 DEV_V2_PROVIDER_ID = "openrouter-dev"
-DEV_V2_CODEX_PROVIDER_ID = CLAWDI_MANAGED_PROVIDER_ID
+DEV_V2_CODEX_PROVIDER_SOURCE_ID = "clawdi-v2-deployment-1"
 DEV_V2_CLI_PACKAGE_SPEC = "clawdi@1.2.3-test"
 _STABLE_UUID_NAMESPACE = uuid.UUID("6a9575fd-7eb5-464a-89e7-e13f090f8de6")
 
@@ -315,9 +314,9 @@ async def _create_hosted_runtime_graph(
                 tools={
                     "codex": {
                         "enabled": True,
-                        "provider_id": DEV_V2_CODEX_PROVIDER_ID,
+                        "provider_id": DEV_V2_CODEX_PROVIDER_SOURCE_ID,
                         "primary_model": {
-                            "provider_id": DEV_V2_CODEX_PROVIDER_ID,
+                            "provider_id": DEV_V2_CODEX_PROVIDER_SOURCE_ID,
                             "model": "gpt-5.5",
                         },
                     },
@@ -453,7 +452,7 @@ def _seed_codex_provider_graph(
     ciphertext, nonce = encrypt("dev-hosted-codex-platform-credential")
     provider = AiProvider(
         owner_user_id=user.id,
-        provider_id=DEV_V2_CODEX_PROVIDER_ID,
+        provider_id=DEV_V2_CODEX_PROVIDER_SOURCE_ID,
         type="custom_openai_compatible",
         label="Clawdi Managed Codex",
         base_url="https://ai-gateway.invalid/v1",
@@ -466,7 +465,7 @@ def _seed_codex_provider_graph(
     )
     payload = AiProviderAuthPayload(
         owner_user_id=user.id,
-        provider_id=DEV_V2_CODEX_PROVIDER_ID,
+        provider_id=DEV_V2_CODEX_PROVIDER_SOURCE_ID,
         auth_profile="default",
         kind="api_key",
         source="managed",

--- a/backend/tests/hosted_runtime_fixtures.py
+++ b/backend/tests/hosted_runtime_fixtures.py
@@ -10,7 +10,7 @@ from app.models.hosted_runtime import HostedRuntimeState
 from app.models.user import User
 from app.services.vault_crypto import encrypt
 
-CANONICAL_CODEX_TOOL_PROVIDER_ID = "clawdi-managed-v2"
+CANONICAL_CODEX_TOOL_PROVIDER_ID = "clawdi-v2-deployment-42"
 CANONICAL_CODEX_TOOL_SECRET = "sk-codex-tool"
 CANONICAL_CODEX_TOOLS = {
     "codex": {

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -2451,9 +2451,13 @@ async def test_admin_agents_alias_registers_with_agent_id_and_runtime_state(
     from app.models.session import AgentEnvironment
     from app.services.runtime_source import load_runtime_source_batch, render_runtime_source
     from app.services.vault_crypto import decrypt
-    from tests.hosted_runtime_fixtures import ensure_canonical_codex_tool_provider
+    from tests.hosted_runtime_fixtures import (
+        CANONICAL_CODEX_TOOL_PROVIDER_ID,
+        ensure_canonical_codex_tool_provider,
+    )
 
     agent_id = uuid.uuid4()
+    provider_id = CANONICAL_CODEX_TOOL_PROVIDER_ID
     created = await admin_client.post(
         "/v1/admin/agents",
         headers=_AUTH,
@@ -2492,9 +2496,9 @@ async def test_admin_agents_alias_registers_with_agent_id_and_runtime_state(
         "tools": {
             "codex": {
                 "enabled": True,
-                "provider_id": "clawdi-managed-v2",
+                "provider_id": provider_id,
                 "primary_model": {
-                    "provider_id": "clawdi-managed-v2",
+                    "provider_id": provider_id,
                     "model": "gpt-5.5",
                 },
             }
@@ -2507,9 +2511,9 @@ async def test_admin_agents_alias_registers_with_agent_id_and_runtime_state(
             "openclaw": {
                 "enabled": True,
                 "providerMode": "configured",
-                "provider_ids": ["clawdi-managed-v2"],
+                "provider_ids": [provider_id],
                 "primary_model": {
-                    "provider_id": "clawdi-managed-v2",
+                    "provider_id": provider_id,
                     "model": "gpt-5.5",
                 },
                 "install": {"source": "official"},
@@ -2531,6 +2535,8 @@ async def test_admin_agents_alias_registers_with_agent_id_and_runtime_state(
     ).scalar_one_or_none()
     assert state is not None
     assert state.deployment_id == "dep-admin-agent-alias"
+    assert state.runtimes["openclaw"]["provider_ids"] == [provider_id]
+    assert state.tools["codex"]["provider_id"] == provider_id
     secret_rows = list(
         (
             await db_session.execute(
@@ -2562,6 +2568,8 @@ async def test_admin_agents_alias_registers_with_agent_id_and_runtime_state(
         vault_key_identity="test-key-version",
         decrypt_secrets=False,
     )
+    assert first_source.manifest["runtimes"]["openclaw"]["provider_ids"] == ["clawdi"]
+    assert first_source.manifest["terminalTooling"]["codex"]["provider_id"] == "clawdi"
 
     repeated = await admin_client.put(
         f"/v1/admin/agents/{agent_id}/runtime-state",

--- a/backend/tests/test_platform_endpoints.py
+++ b/backend/tests/test_platform_endpoints.py
@@ -29,6 +29,7 @@ from app.services.user_provisioning import lazy_create_partner_user_with_persona
 from app.services.vault_crypto import decrypt
 from tests.conftest import create_env_with_project
 from tests.hosted_runtime_fixtures import (
+    CANONICAL_CODEX_TOOL_PROVIDER_ID,
     ensure_canonical_codex_tool_provider,
     filebrowser_companion,
 )
@@ -155,8 +156,28 @@ def _runtime_payload(agent_id: uuid.UUID) -> dict[str, object]:
     }
 
 
-def _runtime_body(owner: dict[str, str], agent_id: uuid.UUID) -> dict[str, object]:
-    return {"owner": owner, **_runtime_payload(agent_id)}
+def _runtime_body(
+    owner: dict[str, str],
+    agent_id: uuid.UUID,
+    *,
+    provider_id: str | None = None,
+) -> dict[str, object]:
+    payload = _runtime_payload(agent_id)
+    if provider_id is not None:
+        runtime = payload["runtimes"]["openclaw"]
+        runtime["provider_ids"] = [provider_id]
+        runtime["primary_model"]["provider_id"] = provider_id
+        payload["tools"] = {
+            "codex": {
+                "enabled": True,
+                "provider_id": provider_id,
+                "primary_model": {
+                    "provider_id": provider_id,
+                    "model": "gpt-5.5",
+                },
+            }
+        }
+    return {"owner": owner, **payload}
 
 
 async def _create_platform_agent(
@@ -474,6 +495,7 @@ async def test_platform_runtime_state_accepts_and_projects_filebrowser_companion
 ):
     owner = _clerk_owner(seed_user)
     agent_id = uuid.uuid4()
+    provider_id = CANONICAL_CODEX_TOOL_PROVIDER_ID
     await ensure_canonical_codex_tool_provider(db_session, seed_user)
     created = await _create_platform_agent(
         platform_client,
@@ -486,13 +508,18 @@ async def test_platform_runtime_state_accepts_and_projects_filebrowser_companion
     response = await platform_client.put(
         f"/v1/platform/agents/{agent_id}/runtime-state",
         headers=_headers("runtime-companion-upsert"),
-        json={**_runtime_body(owner, agent_id), "companions": _TEST_COMPANIONS},
+        json={
+            **_runtime_body(owner, agent_id, provider_id=provider_id),
+            "companions": _TEST_COMPANIONS,
+        },
     )
 
     assert response.status_code == 200, response.text
     state = await db_session.get(HostedRuntimeState, agent_id)
     assert state is not None
     assert state.companions == _TEST_COMPANIONS
+    assert state.runtimes["openclaw"]["provider_ids"] == [provider_id]
+    assert state.tools["codex"]["provider_id"] == provider_id
 
     batch = await load_runtime_source_batch(db_session, environment_ids=[agent_id])
     source = render_runtime_source(
@@ -502,12 +529,17 @@ async def test_platform_runtime_state_accepts_and_projects_filebrowser_companion
         vault_key_identity="test-key-version",
         decrypt_secrets=False,
     )
+    assert source.manifest["runtimes"]["openclaw"]["provider_ids"] == ["clawdi"]
+    assert source.manifest["terminalTooling"]["codex"]["provider_id"] == "clawdi"
     assert source.manifest["companions"]["filebrowser"] == _TEST_COMPANIONS["filebrowser"]
 
     cleared = await platform_client.put(
         f"/v1/platform/agents/{agent_id}/runtime-state",
         headers=_headers("runtime-companion-clear"),
-        json={**_runtime_body(owner, agent_id), "generation": 2},
+        json={
+            **_runtime_body(owner, agent_id, provider_id=provider_id),
+            "generation": 2,
+        },
     )
     assert cleared.status_code == 200, cleared.text
     await db_session.refresh(state)
@@ -532,6 +564,7 @@ async def test_platform_runtime_secret_upsert_preserves_ciphertext_and_source_re
 ):
     owner = _clerk_owner(seed_user)
     agent_id = uuid.uuid4()
+    provider_id = CANONICAL_CODEX_TOOL_PROVIDER_ID
     await ensure_canonical_codex_tool_provider(db_session, seed_user)
     created = await _create_platform_agent(
         platform_client,
@@ -540,7 +573,7 @@ async def test_platform_runtime_secret_upsert_preserves_ciphertext_and_source_re
         key="stable-runtime-secret-agent",
     )
     assert created.status_code == 200, created.text
-    body = _runtime_body(owner, agent_id)
+    body = _runtime_body(owner, agent_id, provider_id=provider_id)
     first = await platform_client.put(
         f"/v1/platform/agents/{agent_id}/runtime-state",
         headers=_headers("stable-runtime-secret-first"),

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -71,13 +71,14 @@ from scripts.seed_dashboard_dev import (
 )
 from tests.conftest import create_env_with_project
 from tests.hosted_runtime_fixtures import (
+    CANONICAL_CODEX_TOOL_PROVIDER_ID,
+    canonical_hosted_runtime_state,
+)
+from tests.hosted_runtime_fixtures import (
     CANONICAL_CODEX_TOOLS as TEST_CODEX_TOOLS,
 )
 from tests.hosted_runtime_fixtures import (
     canonical_codex_tool_provider_graph as _managed_codex_provider_graph,
-)
-from tests.hosted_runtime_fixtures import (
-    canonical_hosted_runtime_state,
 )
 from tests.hosted_runtime_fixtures import (
     filebrowser_companion as _filebrowser_companion,
@@ -88,16 +89,6 @@ pytestmark = pytest.mark.committed_db
 _ADMIN_KEY = "runtime-state-admin-secret"
 _AUTH = {"X-Admin-Key": _ADMIN_KEY}
 TEST_LOCALE = {"language": "en", "timezone": "America/Los_Angeles"}
-AGENT_FACING_CODEX_TOOLS = {
-    "codex": {
-        "enabled": True,
-        "provider_id": CLAWDI_MANAGED_PROVIDER_ID,
-        "primary_model": {
-            "provider_id": CLAWDI_MANAGED_PROVIDER_ID,
-            "model": "gpt-5.5",
-        },
-    }
-}
 TEST_SYSTEM = {}
 TEST_EGRESS_ENGINE_PIN = {
     "type": "mitmproxy",
@@ -430,7 +421,7 @@ async def _runtime_client(db_session, seed_user, api_key: ApiKey | None):
     provider = await db_session.scalar(
         select(AiProvider).where(
             AiProvider.owner_user_id == seed_user.id,
-            AiProvider.provider_id == "clawdi-managed-v2",
+            AiProvider.provider_id == CANONICAL_CODEX_TOOL_PROVIDER_ID,
         )
     )
     if provider is None:
@@ -518,7 +509,7 @@ def _runtime_state(
     **overrides,
 ) -> dict:
     selected_provider_ids = (
-        ([] if provider_mode == "unmanaged" else ["clawdi-managed-v2"])
+        ([] if provider_mode == "unmanaged" else [CANONICAL_CODEX_TOOL_PROVIDER_ID])
         if provider_ids is None
         else provider_ids
     )
@@ -1211,7 +1202,7 @@ async def test_admin_upsert_runtime_state_and_manifest_omit_channels(
     assert set(manifest["locale"]) == {"language", "timezone"}
     assert manifest["system"] == TEST_SYSTEM
     expected_runtime = expected["runtimes"]["openclaw"]
-    assert expected_runtime["provider_ids"] == ["clawdi-managed-v2"]
+    assert expected_runtime["provider_ids"] == [CANONICAL_CODEX_TOOL_PROVIDER_ID]
     assert manifest["runtimes"]["openclaw"] == {
         **expected_runtime,
         "provider_ids": [CLAWDI_MANAGED_PROVIDER_ID],
@@ -3177,7 +3168,7 @@ async def test_admin_runtime_state_clears_optional_state(
     assert state.egress_profiles is None
     assert state.mcp is None
     assert state.skills is None
-    assert state.tools == {**AGENT_FACING_CODEX_TOOLS, "catalog": "clawdi-default"}
+    assert state.tools == {**TEST_CODEX_TOOLS, "catalog": "clawdi-default"}
 
 
 @pytest.mark.asyncio
@@ -3223,7 +3214,7 @@ async def test_equal_generation_optional_state_clear_is_material_conflict(
     assert state.egress_profiles == TEST_EGRESS_PROFILES
     assert state.mcp == {"servers": {"clawdi": {"command": "clawdi", "args": ["mcp"]}}}
     assert state.skills == {"entries": {"clawdi": {"enabled": True, "version": 1}}}
-    assert state.tools == {**AGENT_FACING_CODEX_TOOLS, "catalog": "clawdi-default"}
+    assert state.tools == {**TEST_CODEX_TOOLS, "catalog": "clawdi-default"}
 
 
 def test_control_plane_audit_sanitizes_auth_cookie_and_credential_keys():
@@ -3585,7 +3576,7 @@ async def test_runtime_manifest_marks_explicit_archived_provider_binding_unhealt
             ),
             AiProvider(
                 owner_user_id=seed_user.id,
-                provider_id="clawdi-managed-v2",
+                provider_id=CANONICAL_CODEX_TOOL_PROVIDER_ID,
                 type="custom_openai_compatible",
                 base_url="https://managed-provider.test/v1",
                 models=[{"id": "gpt-5.5"}],
@@ -3597,7 +3588,7 @@ async def test_runtime_manifest_marks_explicit_archived_provider_binding_unhealt
             ),
             AiProviderAuthPayload(
                 owner_user_id=seed_user.id,
-                provider_id="clawdi-managed-v2",
+                provider_id=CANONICAL_CODEX_TOOL_PROVIDER_ID,
                 auth_profile="default",
                 kind="api_key",
                 source="managed",
@@ -4826,12 +4817,11 @@ async def test_runtime_manifest_projects_provider_secret_values_for_managed_acco
     ]
     provider = AiProvider(
         owner_user_id=seed_user.id,
-        provider_id="clawdi-managed-v2",
+        provider_id=CANONICAL_CODEX_TOOL_PROVIDER_ID,
         type="custom_openai_compatible",
         base_url="https://sub2api.test/v1",
         models=managed_models,
-        # Simulate a stale v2 managed provider row from before the chat-completions contract.
-        api_mode="openai_responses",
+        api_mode="openai_chat",
         auth_type="api_key",
         auth_metadata={"source": "managed"},
         managed_by="clawdi",
@@ -4841,7 +4831,7 @@ async def test_runtime_manifest_projects_provider_secret_values_for_managed_acco
     db_session.add(
         AiProviderAuthPayload(
             owner_user_id=seed_user.id,
-            provider_id="clawdi-managed-v2",
+            provider_id=CANONICAL_CODEX_TOOL_PROVIDER_ID,
             auth_profile="default",
             kind="api_key",
             source="managed",
@@ -4902,7 +4892,7 @@ async def test_runtime_manifest_projects_provider_secret_values_for_managed_acco
         await db_session.execute(
             AiProviderAuthPayload.__table__.select().where(
                 AiProviderAuthPayload.owner_user_id == seed_user.id,
-                AiProviderAuthPayload.provider_id == "clawdi-managed-v2",
+                AiProviderAuthPayload.provider_id == CANONICAL_CODEX_TOOL_PROVIDER_ID,
             )
         )
     ).first()
@@ -4911,7 +4901,7 @@ async def test_runtime_manifest_projects_provider_secret_values_for_managed_acco
         AiProviderAuthPayload.__table__.update()
         .where(
             AiProviderAuthPayload.owner_user_id == seed_user.id,
-            AiProviderAuthPayload.provider_id == "clawdi-managed-v2",
+            AiProviderAuthPayload.provider_id == CANONICAL_CODEX_TOOL_PROVIDER_ID,
         )
         .values(encrypted_payload=ciphertext, nonce=nonce)
     )
@@ -4935,7 +4925,7 @@ async def test_runtime_manifest_projects_provider_secret_values_for_managed_acco
 
 
 @pytest.mark.asyncio
-async def test_runtime_state_normalizes_deployment_provider_and_resolves_its_catalog(
+async def test_runtime_state_preserves_deployment_provider_and_resolves_its_catalog(
     admin_client,
     db_session,
     seed_user,
@@ -4983,7 +4973,6 @@ async def test_runtime_state_normalizes_deployment_provider_and_resolves_its_cat
     await _write_runtime_state(
         admin_client,
         str(env.id),
-        deployment_id="42",
         runtimes=_runtime_state(
             provider_ids=[internal_provider_id],
             primary_model=internal_primary_model,
@@ -4999,14 +4988,14 @@ async def test_runtime_state_normalizes_deployment_provider_and_resolves_its_cat
 
     state = await db_session.get(HostedRuntimeState, env.id)
     assert state is not None
-    primary_model = {
+    agent_primary_model = {
         "provider_id": CLAWDI_MANAGED_PROVIDER_ID,
         "model": "gpt-5.5",
     }
-    assert state.runtimes["openclaw"]["provider_ids"] == [CLAWDI_MANAGED_PROVIDER_ID]
-    assert state.runtimes["openclaw"]["primary_model"] == primary_model
-    assert state.tools["codex"]["provider_id"] == CLAWDI_MANAGED_PROVIDER_ID
-    assert state.tools["codex"]["primary_model"] == primary_model
+    assert state.runtimes["openclaw"]["provider_ids"] == [internal_provider_id]
+    assert state.runtimes["openclaw"]["primary_model"] == internal_primary_model
+    assert state.tools["codex"]["provider_id"] == internal_provider_id
+    assert state.tools["codex"]["primary_model"] == internal_primary_model
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
     async with await _runtime_client(db_session, seed_user, api_key) as client:
@@ -5017,7 +5006,7 @@ async def test_runtime_state_normalizes_deployment_provider_and_resolves_its_cat
     payload = response.json()
     manifest = payload["manifest"]
     assert manifest["runtimes"]["openclaw"]["provider_ids"] == [CLAWDI_MANAGED_PROVIDER_ID]
-    assert manifest["runtimes"]["openclaw"]["primary_model"] == primary_model
+    assert manifest["runtimes"]["openclaw"]["primary_model"] == agent_primary_model
     assert set(manifest["providers"]) == {CLAWDI_MANAGED_PROVIDER_ID}
     assert manifest["providers"][CLAWDI_MANAGED_PROVIDER_ID]["models"] == models
     assert manifest["terminalTooling"]["codex"]["provider_id"] == (CLAWDI_MANAGED_PROVIDER_ID)
@@ -5132,10 +5121,10 @@ async def test_admin_managed_provider_models_project_exact_hosted_wire_contract(
         },
     }
     upsert = await admin_client.put(
-        "/v1/admin/ai-providers/clawdi-managed-v2",
+        f"/v1/admin/ai-providers/{CANONICAL_CODEX_TOOL_PROVIDER_ID}",
         headers=_AUTH,
         json={
-            "target_clerk_id": seed_user.clerk_id,
+            "owner": {"kind": "clerk", "ref": seed_user.clerk_id},
             "base_url": "https://sub2api.test/v1",
             "api_key": "sk-complete-provider",
             "models": [model],

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -35,6 +35,7 @@ from app.services.runtime_source import (
     render_runtime_bundle,
     render_runtime_source,
 )
+from tests.hosted_runtime_fixtures import CANONICAL_CODEX_TOOL_PROVIDER_ID
 
 USER_ID = UUID("10000000-0000-0000-0000-000000000001")
 ENV_ID = UUID("20000000-0000-0000-0000-000000000002")
@@ -96,8 +97,11 @@ def _batch(
             "openclaw": {
                 "enabled": True,
                 "providerMode": "configured",
-                "provider_ids": ["managed"],
-                "primary_model": {"provider_id": "managed", "model": "gpt-test"},
+                "provider_ids": [CANONICAL_CODEX_TOOL_PROVIDER_ID],
+                "primary_model": {
+                    "provider_id": CANONICAL_CODEX_TOOL_PROVIDER_ID,
+                    "model": "gpt-test",
+                },
                 "install": {"source": "official"},
                 "run": {
                     "args": [
@@ -126,8 +130,11 @@ def _batch(
         tools={
             "codex": {
                 "enabled": True,
-                "provider_id": "managed",
-                "primary_model": {"provider_id": "managed", "model": "gpt-test"},
+                "provider_id": CANONICAL_CODEX_TOOL_PROVIDER_ID,
+                "primary_model": {
+                    "provider_id": CANONICAL_CODEX_TOOL_PROVIDER_ID,
+                    "model": "gpt-test",
+                },
             }
         },
     )
@@ -135,7 +142,7 @@ def _batch(
     provider = AiProvider(
         id=PROVIDER_ROW_ID,
         owner_user_id=USER_ID,
-        provider_id="managed",
+        provider_id=CANONICAL_CODEX_TOOL_PROVIDER_ID,
         type="custom_openai_compatible",
         label=provider_label,
         base_url="https://provider.test/v1",
@@ -147,7 +154,7 @@ def _batch(
     auth = AiProviderAuthPayload(
         id=AUTH_ROW_ID,
         owner_user_id=USER_ID,
-        provider_id="managed",
+        provider_id=CANONICAL_CODEX_TOOL_PROVIDER_ID,
         auth_profile="default",
         kind="api_key",
         source="managed",
@@ -174,8 +181,8 @@ def _batch(
     )
     return RuntimeSourceBatch(
         rows={ENV_ID: RuntimeSourceRow(environment, state)},
-        providers={(USER_ID, "managed"): provider},
-        auth_payloads={(USER_ID, "managed", "default"): auth},
+        providers={(USER_ID, CANONICAL_CODEX_TOOL_PROVIDER_ID): provider},
+        auth_payloads={(USER_ID, CANONICAL_CODEX_TOOL_PROVIDER_ID, "default"): auth},
         channels={ENV_ID: ((account, link),)},
         runtime_secrets={
             ENV_ID: (
@@ -291,42 +298,6 @@ def _use_whatsapp_channel(
     batch.channel_credentials[link.id] = credential
     batch.whatsapp_auth_certs[account.id] = auth_cert
     return credential, auth_cert
-
-
-def _use_managed_provider(
-    batch: RuntimeSourceBatch,
-    *,
-    bound_provider_id: str,
-    source_provider_id: str,
-) -> str:
-    state = batch.rows[ENV_ID].state
-    assert state is not None
-    state.deployment_id = "42"
-    runtime = dict(state.runtimes["openclaw"])
-    runtime["provider_ids"] = [bound_provider_id]
-    runtime["primary_model"] = {
-        "provider_id": bound_provider_id,
-        "model": "gpt-test",
-    }
-    state.runtimes = {"openclaw": runtime}
-    state.tools = {
-        "codex": {
-            "enabled": True,
-            "provider_id": bound_provider_id,
-            "primary_model": {
-                "provider_id": bound_provider_id,
-                "model": "gpt-test",
-            },
-        }
-    }
-
-    provider = batch.providers.pop((USER_ID, "managed"))
-    provider.provider_id = source_provider_id
-    batch.providers[(USER_ID, source_provider_id)] = provider
-    auth = batch.auth_payloads.pop((USER_ID, "managed", "default"))
-    auth.provider_id = source_provider_id
-    batch.auth_payloads[(USER_ID, source_provider_id, "default")] = auth
-    return source_provider_id
 
 
 def _render(batch: RuntimeSourceBatch):
@@ -586,7 +557,7 @@ def test_runtime_source_rejects_non_public_provider_without_decrypting_secret(mo
     from app.services import runtime_source
 
     batch = _batch()
-    provider = batch.providers[(USER_ID, "managed")]
+    provider = batch.providers[(USER_ID, CANONICAL_CODEX_TOOL_PROVIDER_ID)]
     provider.base_url = "https://provider.home.arpa/v1"
 
     decrypt_calls: list[tuple[bytes, bytes]] = []
@@ -703,7 +674,9 @@ def test_unmanaged_runtime_tool_secret_uses_auth_payload_without_user_vault_refs
 
     assert source.manifest["providers"] == {}
     assert source.manifest["runtimes"]["openclaw"]["providerMode"] == "unmanaged"
-    assert source.manifest["terminalTooling"]["codex"]["provider_id"] == "managed"
+    assert source.manifest["terminalTooling"]["codex"]["provider_id"] == (
+        CLAWDI_MANAGED_PROVIDER_ID
+    )
     assert source.manifest["terminalTooling"]["codex"]["provider"]["apiMode"] == (
         "openai_responses"
     )
@@ -730,7 +703,7 @@ def test_codex_tool_projection_pydantic_contract_rejects_openai_chat() -> None:
 def test_shared_managed_provider_material_has_distinct_codex_wire_mode() -> None:
     source = _render(_batch())
 
-    assert source.manifest["providers"]["managed"]["apiMode"] == "openai_chat"
+    assert source.manifest["providers"][CLAWDI_MANAGED_PROVIDER_ID]["apiMode"] == "openai_chat"
     codex_provider = source.manifest["terminalTooling"]["codex"]["provider"]
     assert codex_provider == {
         "kind": "openai-compatible",
@@ -743,41 +716,23 @@ def test_shared_managed_provider_material_has_distinct_codex_wire_mode() -> None
     }
 
 
-@pytest.mark.parametrize(
-    ("bound_provider_id", "source_provider_id"),
-    [
-        (CLAWDI_MANAGED_PROVIDER_ID, "clawdi-v2-deployment-42"),
-        (CLAWDI_MANAGED_PROVIDER_ID, V2_MANAGED_AI_PROVIDER_ID),
-        (CLAWDI_MANAGED_PROVIDER_ID, V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID),
-        (CLAWDI_MANAGED_PROVIDER_ID, V2_LEGACY_MANAGED_AI_PROVIDER_ID),
-        (V2_MANAGED_AI_PROVIDER_ID, "clawdi-v2-deployment-42"),
-        ("clawdi-v2-deployment-42", "clawdi-v2-deployment-42"),
-        (
-            V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
-            V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
-        ),
-        (V2_LEGACY_MANAGED_AI_PROVIDER_ID, V2_LEGACY_MANAGED_AI_PROVIDER_ID),
-    ],
-    ids=[
-        "agent-alias-scoped-source",
-        "agent-alias-base-source",
-        "agent-alias-legacy-public-source",
-        "agent-alias-legacy-source",
-        "stable-internal",
-        "deployment-scoped",
-        "legacy-public",
-        "legacy-internal",
-    ],
-)
-def test_managed_v2_provider_projects_bare_agent_identity(
-    bound_provider_id: str,
-    source_provider_id: str,
-) -> None:
+def test_managed_v2_exact_provider_source_projects_bare_agent_identity() -> None:
     batch = _batch()
-    persisted_provider_id = _use_managed_provider(
-        batch,
-        bound_provider_id=bound_provider_id,
-        source_provider_id=source_provider_id,
+    source_provider_id = CANONICAL_CODEX_TOOL_PROVIDER_ID
+    scoped_provider = batch.providers[(USER_ID, source_provider_id)]
+    scoped_provider.models = [{"id": "scoped-model"}]
+    batch.providers[(USER_ID, V2_MANAGED_AI_PROVIDER_ID)] = AiProvider(
+        id=uuid4(),
+        owner_user_id=USER_ID,
+        provider_id=V2_MANAGED_AI_PROVIDER_ID,
+        type=scoped_provider.type,
+        label=scoped_provider.label,
+        base_url=scoped_provider.base_url,
+        api_mode=scoped_provider.api_mode,
+        auth_type=scoped_provider.auth_type,
+        auth_metadata=scoped_provider.auth_metadata,
+        managed_by=scoped_provider.managed_by,
+        models=[{"id": "wrong-user-level-model"}],
     )
 
     source = _render(batch)
@@ -789,6 +744,7 @@ def test_managed_v2_provider_projects_bare_agent_identity(
         "model": "gpt-test",
     }
     assert set(manifest["providers"]) == {CLAWDI_MANAGED_PROVIDER_ID}
+    assert manifest["providers"][CLAWDI_MANAGED_PROVIDER_ID]["models"] == [{"id": "scoped-model"}]
     assert manifest["providers"][CLAWDI_MANAGED_PROVIDER_ID]["apiKeySecretRef"] == (
         "secret://tool.codex.apiKey"
     )
@@ -796,40 +752,76 @@ def test_managed_v2_provider_projects_bare_agent_identity(
     assert manifest["terminalTooling"]["codex"]["primary_model"]["provider_id"] == (
         CLAWDI_MANAGED_PROVIDER_ID
     )
-    if persisted_provider_id != CLAWDI_MANAGED_PROVIDER_ID:
-        assert persisted_provider_id not in json.dumps(manifest)
+    assert source_provider_id not in json.dumps(manifest)
 
 
-def test_bare_managed_alias_prefers_deployment_source_over_fallback_rows() -> None:
+@pytest.mark.parametrize(
+    ("runtime_provider_id", "codex_provider_id", "error"),
+    [
+        (
+            CLAWDI_MANAGED_PROVIDER_ID,
+            CANONICAL_CODEX_TOOL_PROVIDER_ID,
+            "exact deployment source",
+        ),
+        (
+            V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
+            CANONICAL_CODEX_TOOL_PROVIDER_ID,
+            "exact deployment source",
+        ),
+        (
+            V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+            CANONICAL_CODEX_TOOL_PROVIDER_ID,
+            "exact deployment source",
+        ),
+        (
+            "clawdi-v2-deployment-0",
+            CANONICAL_CODEX_TOOL_PROVIDER_ID,
+            "source is invalid",
+        ),
+        (
+            "clawdi-v2-deployment-43",
+            "clawdi-v2-deployment-43",
+            "missing or archived",
+        ),
+        (
+            CANONICAL_CODEX_TOOL_PROVIDER_ID,
+            "custom-managed-provider",
+            "Codex tool provider must use its exact deployment source",
+        ),
+        (
+            CANONICAL_CODEX_TOOL_PROVIDER_ID,
+            "clawdi-v2-deployment-43",
+            "multiple provider bindings",
+        ),
+    ],
+    ids=[
+        "bare",
+        "legacy-public",
+        "legacy-internal",
+        "malformed",
+        "missing",
+        "custom-codex-source",
+        "mismatch",
+    ],
+)
+def test_managed_v2_provider_source_fails_closed(
+    runtime_provider_id: str,
+    codex_provider_id: str,
+    error: str,
+) -> None:
     batch = _batch()
-    _use_managed_provider(
-        batch,
-        bound_provider_id=CLAWDI_MANAGED_PROVIDER_ID,
-        source_provider_id="clawdi-v2-deployment-42",
-    )
-    scoped_provider = batch.providers[(USER_ID, "clawdi-v2-deployment-42")]
-    scoped_provider.models = [{"id": "scoped-model"}]
-    for provider_id, model in [
-        (V2_MANAGED_AI_PROVIDER_ID, "base-model"),
-        (V2_LEGACY_MANAGED_AI_PROVIDER_ID, "legacy-model"),
-    ]:
-        batch.providers[(USER_ID, provider_id)] = AiProvider(
-            id=uuid4(),
-            owner_user_id=USER_ID,
-            provider_id=provider_id,
-            type=scoped_provider.type,
-            label=scoped_provider.label,
-            base_url=scoped_provider.base_url,
-            api_mode=scoped_provider.api_mode,
-            auth_type=scoped_provider.auth_type,
-            auth_metadata=scoped_provider.auth_metadata,
-            managed_by=scoped_provider.managed_by,
-            models=[{"id": model}],
-        )
+    state = batch.rows[ENV_ID].state
+    assert state is not None and state.tools is not None
+    runtime = state.runtimes["openclaw"]
+    runtime["provider_ids"] = [runtime_provider_id]
+    runtime["primary_model"]["provider_id"] = runtime_provider_id
+    state.tools["codex"]["provider_id"] = codex_provider_id
+    state.tools["codex"]["primary_model"]["provider_id"] = codex_provider_id
+    batch.providers.clear()
+    batch.auth_payloads.clear()
 
-    manifest = _render(batch).manifest
-
-    assert manifest["providers"][CLAWDI_MANAGED_PROVIDER_ID]["models"] == [{"id": "scoped-model"}]
+    with pytest.raises(RuntimeSourceError, match=error):
+        _render(batch)
 
 
 @pytest.mark.parametrize(
@@ -849,17 +841,19 @@ def test_codex_tool_provider_fails_closed_without_platform_credential(failure: s
     if failure == "missing_provider":
         batch.providers.clear()
     elif failure == "user_owned":
-        batch.providers[(USER_ID, "managed")].managed_by = "user"
+        batch.providers[(USER_ID, CANONICAL_CODEX_TOOL_PROVIDER_ID)].managed_by = "user"
     elif failure == "missing_payload":
         batch.auth_payloads.clear()
     elif failure == "payload_kind":
-        batch.auth_payloads[(USER_ID, "managed", "default")].kind = "oauth_profile"
+        batch.auth_payloads[
+            (USER_ID, CANONICAL_CODEX_TOOL_PROVIDER_ID, "default")
+        ].kind = "oauth_profile"
     elif failure == "payload_source":
-        batch.auth_payloads[(USER_ID, "managed", "default")].source = "vault"
+        batch.auth_payloads[(USER_ID, CANONICAL_CODEX_TOOL_PROVIDER_ID, "default")].source = "vault"
     elif failure == "provider_auth_type":
-        batch.providers[(USER_ID, "managed")].auth_type = "agent_profile"
+        batch.providers[(USER_ID, CANONICAL_CODEX_TOOL_PROVIDER_ID)].auth_type = "agent_profile"
     else:
-        batch.providers[(USER_ID, "managed")].api_mode = "anthropic_messages"
+        batch.providers[(USER_ID, CANONICAL_CODEX_TOOL_PROVIDER_ID)].api_mode = "anthropic_messages"
 
     with pytest.raises(RuntimeSourceError, match="Hosted Codex tool provider"):
         _render(batch)

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -47,7 +47,7 @@ const goldenPath = resolve(
 	"../../../../test-fixtures/runtime-bundle-v2.golden.json",
 );
 const EXPECTED_GOLDEN_SOURCE_REVISION =
-	"4f520b142dc64f7ebfcdedefc0cdc6ad587c097670cc5008154209b27a668070";
+	"764b225e72d3e539c099de4185901dfcf1fe62a1a884df1e48ed8f7c516308d2";
 const originalEnv = { ...process.env };
 const originalFetch = globalThis.fetch;
 const roots: string[] = [];

--- a/test-fixtures/runtime-bundle-v2.golden.json
+++ b/test-fixtures/runtime-bundle-v2.golden.json
@@ -42,7 +42,7 @@
 			"timezone": "UTC"
 		},
 		"providers": {
-			"managed": {
+			"clawdi": {
 				"apiKeySecretRef": "secret://tool.codex.apiKey",
 				"apiMode": "openai_chat",
 				"baseUrl": "https://provider.test/v1",
@@ -66,9 +66,9 @@
 				"providerMode": "configured",
 				"primary_model": {
 					"model": "gpt-test",
-					"provider_id": "managed"
+					"provider_id": "clawdi"
 				},
-				"provider_ids": ["managed"],
+				"provider_ids": ["clawdi"],
 				"run": {
 					"args": [
 						"gateway",
@@ -113,7 +113,7 @@
 				"enabled": true,
 				"primary_model": {
 					"model": "gpt-test",
-					"provider_id": "managed"
+					"provider_id": "clawdi"
 				},
 				"provider": {
 					"apiKeySecretRef": "secret://tool.codex.apiKey",
@@ -124,7 +124,7 @@
 					"runtimeEnvName": "OPENAI_API_KEY",
 					"type": "custom_openai_compatible"
 				},
-				"provider_id": "managed"
+				"provider_id": "clawdi"
 			}
 		}
 	},
@@ -136,5 +136,5 @@
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/agent-token": "123456789:telegram-agent-golden",
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/placeholder-token": "999999999:9ded1453047ec0a48ec3b735075f7448"
 	},
-	"sourceRevision": "4f520b142dc64f7ebfcdedefc0cdc6ad587c097670cc5008154209b27a668070"
+	"sourceRevision": "764b225e72d3e539c099de4185901dfcf1fe62a1a884df1e48ed8f7c516308d2"
 }


### PR DESCRIPTION
## Summary

- preserve authenticated Hosted deployment-scoped provider source IDs at runtime-state ingress
- resolve managed runtime and Codex material from that exact owner-scoped source with no user-level or legacy fallback
- keep the tenant manifest projection stable as clawdi and fail closed on malformed, missing, or mismatched managed sources

## Trust boundary

Cloud has no authoritative mapping from the Hosted public runtime identity (hdep_* / hri_*) to the Hosted numeric deployment ID. The authenticated Hosted producer owns that mapping. Cloud validates exact-source syntax, reads only the same owner unarchived row, and requires runtime and Codex to use the same exact source.

## Verification

- focused runtime-source tests: 35 passed
- CLI golden: 45 passed
- full bun run test: CLI/JS 1647 passed, 4 skipped; backend 2261 passed, 12 skipped
- Ruff, format, compileall, and diff check passed

No v1 behavior, schema, migration, or generated client changes.