### PR TITLE
fix(runtime): project selected provider model

### DIFF
--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -632,6 +632,10 @@ def render_runtime_source(
         provider_sources[agent_provider_id] = source_provider_id
     provider_material: dict[str, dict[str, Any]] = {}
     runtime_provider_ids = set(runtime["provider_ids"])
+    primary_model = runtime.get("primary_model")
+    selected_models = (
+        {primary_model["provider_id"]: primary_model["model"]} if primary_model else {}
+    )
     for agent_provider_id, source_provider_id in sorted(provider_sources.items()):
         provider = batch.providers.get((user_id, source_provider_id))
         is_codex_provider = agent_provider_id == codex_agent_provider_id
@@ -678,6 +682,7 @@ def render_runtime_source(
                 if payload is not None and payload.kind in {"agent_profile", "oauth_profile"}
                 else None
             ),
+            selected_model=selected_models.get(agent_provider_id),
         )
         if is_codex_provider and (
             provider_entry.get("apiMode") not in _CODEX_PROVIDER_SOURCE_API_MODES
@@ -1058,6 +1063,7 @@ def _provider_entry(
     *,
     secret_ref: str | None,
     credential_revision: str | None,
+    selected_model: str | None,
 ) -> dict[str, Any]:
     result: dict[str, Any] = {
         "kind": "openai-compatible",
@@ -1079,6 +1085,7 @@ def _provider_entry(
         result["apiMode"] = api_mode
     if provider.managed_by == "clawdi":
         result["managed_by"] = provider.managed_by
+    models: list[dict[str, Any]] = []
     if provider.models is not None:
         try:
             models = [
@@ -1087,8 +1094,10 @@ def _provider_entry(
             ]
         except ValidationError as exc:
             raise RuntimeSourceError("Stored AI provider model metadata is invalid") from exc
-        if models:
-            result["models"] = models
+    if selected_model and not any(model["id"] == selected_model for model in models):
+        models.insert(0, {"id": selected_model})
+    if models:
+        result["models"] = models
     if runtime_env:
         result["runtimeEnvName"] = runtime_env
     if provider.auth_type in {"api_key", "secret_ref"} and not secret_ref:

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -5298,7 +5298,7 @@ async def test_runtime_manifest_projects_legacy_managed_provider_as_responses(
 
 
 @pytest.mark.asyncio
-async def test_runtime_manifest_uses_structured_primary_model_without_catalog_model(
+async def test_runtime_manifest_projects_primary_model_when_provider_models_is_null(
     admin_client,
     db_session,
     seed_user,
@@ -5321,6 +5321,7 @@ async def test_runtime_manifest_uses_structured_primary_model_without_catalog_mo
             auth_type="api_key",
             auth_metadata={"source": "managed"},
             managed_by="user",
+            models=None,
             runtime_env_name="CUSTOM_OPENAI_API_KEY",
         )
     )
@@ -5360,10 +5361,10 @@ async def test_runtime_manifest_uses_structured_primary_model_without_catalog_mo
         "type": "custom_openai_compatible",
         "baseUrl": "https://provider.test/v1",
         "apiMode": "openai_responses",
+        "models": [{"id": "gpt-5.5"}],
         "runtimeEnvName": "CUSTOM_OPENAI_API_KEY",
         "apiKeySecretRef": "secret://provider.custom-openai.apiKey",
     }
-    assert "models" not in payload["manifest"]["providers"]["custom-openai"]
     assert payload["manifest"]["runtimes"]["openclaw"]["primary_model"] == {
         "provider_id": "custom-openai",
         "model": "gpt-5.5",

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -720,7 +720,7 @@ def test_managed_v2_exact_provider_source_projects_bare_agent_identity() -> None
     batch = _batch()
     source_provider_id = CANONICAL_CODEX_TOOL_PROVIDER_ID
     scoped_provider = batch.providers[(USER_ID, source_provider_id)]
-    scoped_provider.models = [{"id": "scoped-model"}]
+    scoped_provider.models = [{"id": "scoped-model", "label": "Scoped model"}]
     batch.providers[(USER_ID, V2_MANAGED_AI_PROVIDER_ID)] = AiProvider(
         id=uuid4(),
         owner_user_id=USER_ID,
@@ -744,7 +744,11 @@ def test_managed_v2_exact_provider_source_projects_bare_agent_identity() -> None
         "model": "gpt-test",
     }
     assert set(manifest["providers"]) == {CLAWDI_MANAGED_PROVIDER_ID}
-    assert manifest["providers"][CLAWDI_MANAGED_PROVIDER_ID]["models"] == [{"id": "scoped-model"}]
+    assert manifest["providers"][CLAWDI_MANAGED_PROVIDER_ID]["models"] == [
+        {"id": "gpt-test"},
+        {"id": "scoped-model", "label": "Scoped model"},
+    ]
+    assert scoped_provider.models == [{"id": "scoped-model", "label": "Scoped model"}]
     assert manifest["providers"][CLAWDI_MANAGED_PROVIDER_ID]["apiKeySecretRef"] == (
         "secret://tool.codex.apiKey"
     )

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -2142,51 +2142,32 @@ describe("runtime manifest reconciliation invariants", () => {
 			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
 			configPatchPath: providerPatchPath,
 		});
-		const manifest = baseManifest(
-			paths,
-			{
-				openclaw: {
-					enabled: true,
-					install: {
-						authority: "official",
-						method: "official-installer",
-						url: OFFICIAL_INSTALL_URLS.openclaw,
-						home: paths.userHome,
-						args: officialInstallArgs("openclaw", paths.userHome),
-					},
-					providerMode: "configured",
-					run: runSettings("openclaw", ["gateway", "run"]),
-					provider_ids: ["default"],
-					primary_model: { provider_id: "default", model: "gpt-test" },
-					services: {},
-				},
-			},
-			{
-				runtime: "openclaw",
-				projection: {
-					providers: {
-						default: {
-							type: "custom_openai_compatible",
-							// managed_by:"clawdi" marks this as a Clawdi-managed provider
-							// (cloud-api emits it as `n:"clawdi"`), which routes the key
-							// through the egress placeholder path — the agent env gets the
-							// placeholder while the real key stays out of its env.
-							managed_by: "clawdi",
-							baseUrl: "https://api.example.test/v1",
-							model: "gpt-test",
-							apiMode: "openai_chat",
-							runtimeEnvName: "CLAWDI_AI_API_KEY",
-							apiKeySecretRef: "secret://providers/default/api-key",
-						},
+		const hosted = hostedRuntimeManifestSchema.parse(
+			hostedManifestFixture({
+				providers: {
+					default: {
+						kind: "openai-compatible",
+						type: "custom_openai_compatible",
+						managed_by: "clawdi",
+						baseUrl: "https://api.example.test/v1",
+						models: [{ id: "gpt-test" }],
+						apiMode: "openai_chat",
+						runtimeEnvName: "CLAWDI_AI_API_KEY",
+						apiKeySecretRef: "secret://providers/default/api-key",
 					},
 				},
-			},
+			}),
 		);
+		const manifest = {
+			...hostedManifestToRuntimeManifest(hosted),
+			egressEngine: installCachedTestEgressEngine(paths, "12.2.3-test-provider-model"),
+		};
 		const provider = hostedAiProviderCatalog(manifest, "openclaw")?.catalog.providers[0];
 		expect(provider?.runtime_env_name).toBe("CLAWDI_AI_API_KEY");
 
 		const result = convergeRuntimeManifest(
 			manifestLoad(manifest, "inline-managed-provider", {
+				...TEST_HOSTED_SECRET_VALUES,
 				"secret://providers/default/api-key": "sk-managed",
 			}),
 			paths,
@@ -2219,6 +2200,15 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(envFile).toContain('CLAWDI_AI_API_KEY="clawdi-egress-placeholder"');
 		expect(envFile).not.toMatch(/^OPENAI_API_KEY=/m);
 		expect(envFile).not.toContain("sk-managed");
+		expect(JSON.parse(readFileSync(paths.providerHealthStatus, "utf8"))).toMatchObject({
+			providers: {
+				default: {
+					status: "ok",
+					models: [{ id: "gpt-test" }],
+					reasons: [],
+				},
+			},
+		});
 	});
 
 	test("replaces the selected Hermes provider with secret refs and stale cleanup", () => {

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -47,7 +47,7 @@ const goldenPath = resolve(
 	"../../../../test-fixtures/runtime-bundle-v2.golden.json",
 );
 const EXPECTED_GOLDEN_SOURCE_REVISION =
-	"764b225e72d3e539c099de4185901dfcf1fe62a1a884df1e48ed8f7c516308d2";
+	"2d0331a0dc7ef429482850b872ff43b0f5a5b8a3c3ddcb2648d1ef77d95a3918";
 const originalEnv = { ...process.env };
 const originalFetch = globalThis.fetch;
 const roots: string[] = [];

--- a/test-fixtures/runtime-bundle-v2.golden.json
+++ b/test-fixtures/runtime-bundle-v2.golden.json
@@ -48,6 +48,11 @@
 				"baseUrl": "https://provider.test/v1",
 				"kind": "openai-compatible",
 				"managed_by": "clawdi",
+				"models": [
+					{
+						"id": "gpt-test"
+					}
+				],
 				"runtimeEnvName": "CLAWDI_AI_API_KEY",
 				"type": "custom_openai_compatible"
 			}
@@ -136,5 +141,5 @@
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/agent-token": "123456789:telegram-agent-golden",
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/placeholder-token": "999999999:9ded1453047ec0a48ec3b735075f7448"
 	},
-	"sourceRevision": "764b225e72d3e539c099de4185901dfcf1fe62a1a884df1e48ed8f7c516308d2"
+	"sourceRevision": "2d0331a0dc7ef429482850b872ff43b0f5a5b8a3c3ddcb2648d1ef77d95a3918"
 }


### PR DESCRIPTION
## Root cause

Hosted runtime state selects a primary model independently from an AI provider catalog. When a valid BYOK provider has `models = null`, Cloud projected no model authority, so the Hosted CLI failed readiness with `model_missing`.

## Fix

- merge the selected runtime primary model into that provider's canonical `models` projection
- preserve stored model metadata and do not mutate provider rows
- keep the terminal Codex provider as its distinct, model-free projection
- keep the strict Hosted schema; no singular `model` compatibility path

## Verification

- focused backend: 3 passed
- focused CLI renderer/manifest/health: 217 passed
- `bun run test`: all suites passed (CLI 1646 passed / 4 skipped; backend 2261 passed / 12 skipped)
- `bun run typecheck`: 4/4
- `bun run check`: 984 files
- Ruff lint, target formatting, compileall, and `git diff --check` passed

Full-repo Ruff format remains blocked only by pre-existing drift in `backend/tests/test_projects_routes.py`; this branch does not modify that file.