### PR TITLE
fix(backend): package IANA timezone data

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -39,6 +39,8 @@ dependencies = [
     "boto3==1.43.14",
     "botocore==1.43.14",
     "xeddsa==1.2.0",
+    # ZoneInfo fallback for slim production images without system zoneinfo.
+    "tzdata==2026.3",
 ]
 
 [project.optional-dependencies]
@@ -323,6 +325,7 @@ DEP002 = [
     "aiofiles",           # FastAPI's UploadFile uses async file I/O internally.
     "psycopg2-binary",    # Sync PG driver kept for alembic offline-mode SQL.
     "mem0ai",             # Optional untyped SDK; loaded by the narrow Mem0 adapter at runtime.
+    "tzdata",             # IANA database loaded indirectly by the stdlib zoneinfo module.
 ]
 
 # `app/services/memory_provider_mem0.py` imports `mem0` only inside

--- a/backend/tests/test_timezone_runtime_dependency.py
+++ b/backend/tests/test_timezone_runtime_dependency.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import tomllib
+import zoneinfo
+from importlib.metadata import version
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_production_dependencies_resolve_iana_timezone_without_system_database(
+    tmp_path: Path,
+) -> None:
+    project = tomllib.loads((BACKEND_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    assert f"tzdata=={version('tzdata')}" in project["project"]["dependencies"]
+
+    original_tzpath = zoneinfo.TZPATH
+    try:
+        zoneinfo.reset_tzpath([tmp_path])
+        zoneinfo.ZoneInfo.clear_cache()
+        assert zoneinfo.ZoneInfo("Asia/Calcutta").key == "Asia/Calcutta"
+    finally:
+        zoneinfo.reset_tzpath(original_tzpath)
+        zoneinfo.ZoneInfo.clear_cache()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -400,6 +400,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockets" },
     { name = "xeddsa" },
@@ -452,6 +453,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.66.1" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
+    { name = "tzdata", specifier = "==2026.3" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
     { name = "websockets", specifier = "==17.0.1" },
     { name = "xeddsa", specifier = "==1.2.0" },
@@ -2390,6 +2392,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add pinned `tzdata==2026.3` to the backend production dependency set used by `uv sync --frozen --no-dev --no-install-project`
- keep deptry explicit about the standard-library `zoneinfo` indirect consumer
- add one runtime dependency contract that disables every system TZPATH and resolves the production value `Asia/Calcutta` from the installed wheel

## Root cause

The slim Cloud backend image has neither a system zoneinfo database nor the Python `tzdata` package. `HostedRuntimeLocale` correctly validates IANA names with `ZoneInfo`, so a valid timezone already accepted and persisted by Hosted could fail Cloud validation with `ZoneInfoNotFoundError` and return 422.

This fixes the image dependency closure without changing the CLI contract, validator behavior, aliases, tenants, deployments, or production data.

## Verification

- `uv run pytest -q tests/test_timezone_runtime_dependency.py`
- production `backend/Dockerfile` build; container has no pytest, has tzdata, and resolves `Asia/Calcutta` after `zoneinfo.reset_tzpath([])`
- `uv lock --check`
- `uv run deptry app`
- `uv run ruff check .`
- focused Ruff format check on the new test
- `uv run python -m compileall -q app scripts tests alembic`
- dependency authority and outbound API governance checks
- type governance owned / strict / exceptions
- `bun run typecheck`
- `bun run test` (`2262 passed, 12 skipped` backend; all JS suites 0 failed)
- `bun run check`

No release or deployment was triggered.
