### PR TITLE
fix(whatsapp): accept the rc13 USync target

### DIFF
--- a/backend/app/services/whatsapp_baileys.py
+++ b/backend/app/services/whatsapp_baileys.py
@@ -2969,7 +2969,7 @@ def parse_whatsapp_usync_device_targets(req: BinaryNode) -> tuple[str, ...] | No
         not attrs["id"]
         or attrs["type"] != "get"
         or attrs["xmlns"] != "usync"
-        or attrs["to"] != "s.whatsapp.net"
+        or attrs["to"] != "@s.whatsapp.net"
     ):
         return None
     content = req.get("content")

--- a/backend/tests/test_whatsapp_provider_bridge.py
+++ b/backend/tests/test_whatsapp_provider_bridge.py
@@ -127,7 +127,7 @@ def _stock_usync_device_iq(*jids: str) -> dict[str, Any]:
         "tag": "iq",
         "attrs": {
             "id": "stock-usync-devices",
-            "to": "s.whatsapp.net",
+            "to": "@s.whatsapp.net",
             "type": "get",
             "xmlns": "usync",
         },

--- a/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/hermes_consumer.py
+++ b/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/hermes_consumer.py
@@ -12,7 +12,7 @@ from gateway.platform_registry import platform_registry
 from hermes_cli.plugins import discover_plugins
 
 CONTROL_BASE = "http://127.0.0.1:9000"
-CHAT_JID = "15551112222@s.whatsapp.net"
+CHAT_JID = "184207372460253@lid"
 
 
 async def main() -> None:

--- a/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/server.py
+++ b/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/server.py
@@ -17,7 +17,10 @@ from app.services.whatsapp_baileys import (
     WhatsAppAuthCert,
     encode_buffer_json,
     mint_whatsapp_synthetic_creds,
+    parse_whatsapp_usync_device_targets,
+    strip_whatsapp_device,
     whatsapp_text_message_proto,
+    whatsapp_usync_device_result,
 )
 from app.services.whatsapp_noise import (
     WhatsAppNoiseEmulatorSession,
@@ -137,6 +140,32 @@ def create_app(state: HarnessState) -> FastAPI:
         await websocket.accept()
         state.connections += 1
         state.authorized_connections += 1
+
+        def resolve_recipient_lid(jid: str) -> str | None:
+            normalized = strip_whatsapp_device(jid)
+            return INBOUND_LID if normalized in {INBOUND_JID, INBOUND_LID} else None
+
+        async def forward_iq(
+            node: dict[str, Any], _tenant_id: str | None
+        ) -> dict[str, Any] | None:
+            targets = parse_whatsapp_usync_device_targets(node)
+            if targets is None:
+                return None
+            target_lids: dict[str, str] = {}
+            for target in targets:
+                normalized = strip_whatsapp_device(target)
+                if normalized == strip_whatsapp_device(SYNTHETIC_LID):
+                    continue
+                lid = resolve_recipient_lid(normalized)
+                if lid is None:
+                    return None
+                target_lids[target] = lid
+            return whatsapp_usync_device_result(
+                node,
+                target_lids=target_lids,
+                self_lid=SYNTHETIC_LID,
+            )
+
         session = WhatsAppNoiseEmulatorSession(
             auth_cert=state.cert,
             lid=SYNTHETIC_LID,
@@ -144,15 +173,7 @@ def create_app(state: HarnessState) -> FastAPI:
             on_event=state.record_event,
             on_outbound_message=state.record_outbound_message,
             on_outbound_relay=state.record_outbound_node,
-            resolve_recipient_lid=lambda jid: (
-                INBOUND_LID
-                if jid.split("@", 1)[0].split(":", 1)[0]
-                in {
-                    INBOUND_JID.split("@", 1)[0],
-                    INBOUND_LID.split("@", 1)[0],
-                }
-                else None
-            ),
+            forward_iq=forward_iq,
         )
         state.websocket = websocket
         state.session = session
@@ -226,7 +247,7 @@ def create_app(state: HarnessState) -> FastAPI:
         proto = whatsapp_text_message_proto(request.text)
         try:
             frame, result = await state.session.push_inbound_message(
-                from_jid=INBOUND_JID,
+                from_jid=INBOUND_LID,
                 message_id=request.message_id,
                 message_proto=proto,
                 push_name="Native E2E",


### PR DESCRIPTION
## Root cause

Baileys 7.0.0-rc13 emits its exact device-enumeration USync IQ with `to="@s.whatsapp.net"`. The backend exact-shape parser expected `to="s.whatsapp.net"`, so the authorized local USync path never ran. The fallback omitted the recipient device, allowing rc13 to generate a message stanza without `<enc>`; the Noise boundary correctly dropped it as `missing-enc`.

## Fix

- Match the actual pinned rc13 IQ target.
- Correct the existing native WhatsApp E2E to use LID-primary inbound and the production parser/USync response path.
- Keep authorization, cross-Link isolation, and `missing-enc` fail-closed unchanged.

## Verification

- Provider bridge: 18 passed
- Baileys + Noise: 55 passed
- Stock Hermes native E2E: passed (2 inbound, 4 outbound messages)
- OpenClaw native E2E: passed (2 inbound, 4 outbound messages)
- Ruff + format: passed
- BasedPyright changed production gate: 0 errors, 0 warnings
- `git diff --check`: passed