### PR TITLE
fix(web): isolate shared session hydration data

### DIFF
--- a/apps/web/src/clerk-middleware.server.ts
+++ b/apps/web/src/clerk-middleware.server.ts
@@ -1,0 +1,10 @@
+import { clerkMiddleware } from "@clerk/tanstack-react-start/server";
+import { env } from "@/lib/env";
+
+export function createClerkRequestMiddleware() {
+	return clerkMiddleware({
+		publishableKey: env.VITE_CLERK_PUBLISHABLE_KEY,
+		signInUrl: "/sign-in",
+		signUpUrl: "/sign-up",
+	});
+}

--- a/apps/web/src/pages/public-share/session-page-boundary.test.ts
+++ b/apps/web/src/pages/public-share/session-page-boundary.test.ts
@@ -1,25 +1,40 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 
-const source = readFileSync(new URL("./session-page.tsx", import.meta.url), "utf8");
+const functionsSource = readFileSync(
+	new URL("./session-page.functions.ts", import.meta.url),
+	"utf8",
+);
+const pageSource = readFileSync(new URL("./session-page.tsx", import.meta.url), "utf8");
+const routeSource = readFileSync(new URL("../../routes/s/$id.tsx", import.meta.url), "utf8");
+const protectedRouteSource = readFileSync(
+	new URL("../../routes/_protected.tsx", import.meta.url),
+	"utf8",
+);
 
-describe("public session server boundary", () => {
-	test("keeps auth and both backend reads inside one server function", () => {
-		const serverFnStart = source.indexOf("const getPublicShareData = createServerFn");
-		const pageStart = source.indexOf("export default async function PublicSharePage");
+describe("server hydration boundaries", () => {
+	test("keeps identity-dependent reads and response policy in one server function", () => {
+		expect(functionsSource).toContain('setResponseHeader("cache-control", "no-store")');
+		expect(functionsSource).toContain("await auth()");
+		expect(functionsSource).toContain('api.GET("/v1/public/sessions/{session_id}"');
+		expect(functionsSource).toContain('api.GET("/v1/public/sessions/{session_id}/messages"');
+		expect(functionsSource).toContain(
+			'return { kind: "ok", share: shareResult.data, messagesPage }',
+		);
+		expect(protectedRouteSource).toContain(
+			'const getAuthState = createServerFn({ method: "GET" }).handler',
+		);
+		expect(protectedRouteSource).toContain('setResponseHeader("cache-control", "no-store")');
+	});
 
-		expect(serverFnStart).toBeGreaterThan(-1);
-		expect(pageStart).toBeGreaterThan(serverFnStart);
-
-		const serverFn = source.slice(serverFnStart, pageStart);
-		const page = source.slice(pageStart);
-
-		expect(serverFn).toContain("await auth()");
-		expect(serverFn).toContain('api.GET("/v1/public/sessions/{session_id}"');
-		expect(serverFn).toContain('api.GET("/v1/public/sessions/{session_id}/messages"');
-		expect(serverFn).toContain('return { kind: "ok", share: shareResult.data, messagesPage }');
-		expect(page).toContain("await getPublicShareData({ data: { sessionId: id } })");
-		expect(page).not.toContain("auth()");
-		expect(page).not.toMatch(/\btoken\b/);
+	test("loads once through the route and renders synchronously from dehydrated data", () => {
+		expect(routeSource).toContain("loader: async ({ params }) =>");
+		expect(routeSource).toContain("await getPublicShareData({ data: { sessionId: params.id } })");
+		expect(routeSource).toContain('if (result.kind === "not-found") throw notFound()');
+		expect(routeSource).toContain("Route.useLoaderData()");
+		expect(pageSource).toContain("export default function PublicSharePage");
+		expect(pageSource).not.toContain("export default async function PublicSharePage");
+		expect(pageSource).not.toContain("getPublicShareData");
+		expect(pageSource).not.toContain("auth()");
 	});
 });

--- a/apps/web/src/pages/public-share/session-page-boundary.test.ts
+++ b/apps/web/src/pages/public-share/session-page-boundary.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./session-page.tsx", import.meta.url), "utf8");
+
+describe("public session server boundary", () => {
+	test("keeps auth and both backend reads inside one server function", () => {
+		const serverFnStart = source.indexOf("const getPublicShareData = createServerFn");
+		const pageStart = source.indexOf("export default async function PublicSharePage");
+
+		expect(serverFnStart).toBeGreaterThan(-1);
+		expect(pageStart).toBeGreaterThan(serverFnStart);
+
+		const serverFn = source.slice(serverFnStart, pageStart);
+		const page = source.slice(pageStart);
+
+		expect(serverFn).toContain("await auth()");
+		expect(serverFn).toContain('api.GET("/v1/public/sessions/{session_id}"');
+		expect(serverFn).toContain('api.GET("/v1/public/sessions/{session_id}/messages"');
+		expect(serverFn).toContain('return { kind: "ok", share: shareResult.data, messagesPage }');
+		expect(page).toContain("await getPublicShareData({ data: { sessionId: id } })");
+		expect(page).not.toContain("auth()");
+		expect(page).not.toMatch(/\btoken\b/);
+	});
+});

--- a/apps/web/src/pages/public-share/session-page.functions.ts
+++ b/apps/web/src/pages/public-share/session-page.functions.ts
@@ -1,0 +1,66 @@
+import type { components, paths } from "@clawdi/shared/api";
+import { auth } from "@clerk/tanstack-react-start/server";
+import { createServerFn } from "@tanstack/react-start";
+import { setResponseHeader } from "@tanstack/react-start/server";
+import createClient from "openapi-fetch";
+import { z } from "zod";
+import { env } from "@/lib/env";
+
+const PAGE_SIZE = 100;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type PublicShare = components["schemas"]["PublicSessionResponse"];
+type PublicMessagesPage = components["schemas"]["SessionMessagesPage"];
+
+export type PublicShareResult =
+	| { kind: "ok"; share: PublicShare; messagesPage: PublicMessagesPage }
+	| { kind: "unauthorized" }
+	| { kind: "forbidden" }
+	| { kind: "not-found" };
+
+/**
+ * Authentication and both API reads stay inside this server function so
+ * Clerk's server runtime and the JWT never enter the client route chunk.
+ */
+export const getPublicShareData = createServerFn({ method: "GET" })
+	.validator(z.object({ sessionId: z.string().regex(UUID_RE) }))
+	.handler(async ({ data }): Promise<PublicShareResult> => {
+		setResponseHeader("cache-control", "no-store");
+
+		let token: string | null;
+		if (env.VITE_DEV_AUTH_BYPASS) {
+			token = env.VITE_DEV_AUTH_TOKEN;
+		} else {
+			const { getToken } = await auth();
+			token = await getToken();
+		}
+
+		const api = createClient<paths>({
+			baseUrl: env.VITE_CLAWDI_API_URL,
+			headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+		});
+		const shareResult = await api.GET("/v1/public/sessions/{session_id}", {
+			params: { path: { session_id: data.sessionId } },
+			cache: "no-store",
+		});
+		if (shareResult.response.status === 404) return { kind: "not-found" };
+		if (shareResult.response.status === 401) return { kind: "unauthorized" };
+		if (shareResult.response.status === 403) return { kind: "forbidden" };
+		if (shareResult.error !== undefined) {
+			throw new Error(`backend returned ${shareResult.response.status}`);
+		}
+
+		const messagesResult = await api.GET("/v1/public/sessions/{session_id}/messages", {
+			params: {
+				path: { session_id: data.sessionId },
+				query: { offset: 0, limit: PAGE_SIZE },
+			},
+			cache: "no-store",
+		});
+		const messagesPage =
+			messagesResult.error === undefined
+				? messagesResult.data
+				: { items: [], total: 0, offset: 0, limit: PAGE_SIZE };
+
+		return { kind: "ok", share: shareResult.data, messagesPage };
+	});

--- a/apps/web/src/pages/public-share/session-page.tsx
+++ b/apps/web/src/pages/public-share/session-page.tsx
@@ -1,9 +1,10 @@
 import type { components, paths } from "@clawdi/shared/api";
 import { auth } from "@clerk/tanstack-react-start/server";
 import { Link, notFound } from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
 import { Clock, Hash, MessageSquare, Zap } from "lucide-react";
 import createClient from "openapi-fetch";
-import { cache } from "react";
+import { z } from "zod";
 import { AgentInline } from "@/components/dashboard/agent-label";
 import { DetailMeta, DetailStats, DetailTitle } from "@/components/detail/layout";
 import { ModelBadge } from "@/components/meta/model-badge";
@@ -23,8 +24,10 @@ import { formatNumber, formatSessionSummary, relativeTime } from "@/lib/utils";
 /**
  * Public share page for a Clawdi session.
  *
- * Server component — must work for curl, link unfurlers, and agents that
- * don't run JavaScript. Mirrors the dashboard `/sessions/[id]` layout
+ * SSR-capable route component — must work for curl, link unfurlers, and
+ * agents that don't run JavaScript. Server-only auth and data access stay
+ * behind `getPublicShareData` so client hydration uses the RPC boundary.
+ * Mirrors the dashboard `/sessions/[id]` layout
  * (DetailTitle / DetailMeta / SessionSidebar / DetailStats / message
  * stream) so a visitor's view of a session looks the same as the owner's
  * — minus owner-only chrome (no visibility toggle, no breadcrumb, no
@@ -54,70 +57,65 @@ type PublicShare = components["schemas"]["PublicSessionResponse"];
 type PublicMessagesPage = components["schemas"]["SessionMessagesPage"];
 
 type FetchResult =
-	| { kind: "ok"; share: PublicShare }
+	| { kind: "ok"; share: PublicShare; messagesPage: PublicMessagesPage }
 	| { kind: "unauthorized" }
 	| { kind: "forbidden" }
 	| { kind: "not-found" };
 
 /**
- * `token` is passed as an argument (rather than calling `auth()` inside)
- * because Clerk's `auth()` returns an object with non-serializable refs
- * that React's `cache()` chokes on. Caller resolves the JWT once outside
- * this boundary.
+ * Authentication and both API reads stay inside this server function so
+ * Clerk's server runtime and the JWT never enter the client route chunk.
  */
-const fetchShare = cache(async (sessionId: string, token: string | null): Promise<FetchResult> => {
-	const api = createPublicApi(token);
-	const result = await api.GET("/v1/public/sessions/{session_id}", {
-		params: { path: { session_id: sessionId } },
-		cache: "no-store",
-	});
-	if (result.response.status === 404) return { kind: "not-found" };
-	if (result.response.status === 401) return { kind: "unauthorized" };
-	if (result.response.status === 403) return { kind: "forbidden" };
-	if (result.error !== undefined) throw new Error(`backend returned ${result.response.status}`);
-	return { kind: "ok", share: result.data };
-});
+const getPublicShareData = createServerFn({ method: "GET" })
+	.validator(z.object({ sessionId: z.string().regex(UUID_RE) }))
+	.handler(async ({ data }): Promise<FetchResult> => {
+		let token: string | null;
+		if (env.VITE_DEV_AUTH_BYPASS) {
+			token = env.VITE_DEV_AUTH_TOKEN;
+		} else {
+			const { getToken } = await auth();
+			token = await getToken();
+		}
 
-function createPublicApi(token: string | null) {
-	return createClient<paths>({
-		baseUrl: env.VITE_CLAWDI_API_URL,
-		headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-	});
-}
+		const api = createClient<paths>({
+			baseUrl: env.VITE_CLAWDI_API_URL,
+			headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+		});
+		const shareResult = await api.GET("/v1/public/sessions/{session_id}", {
+			params: { path: { session_id: data.sessionId } },
+			cache: "no-store",
+		});
+		if (shareResult.response.status === 404) return { kind: "not-found" };
+		if (shareResult.response.status === 401) return { kind: "unauthorized" };
+		if (shareResult.response.status === 403) return { kind: "forbidden" };
+		if (shareResult.error !== undefined) {
+			throw new Error(`backend returned ${shareResult.response.status}`);
+		}
 
-async function getOptionalToken(): Promise<string | null> {
-	if (env.VITE_DEV_AUTH_BYPASS) return env.VITE_DEV_AUTH_TOKEN;
-	const { getToken } = await auth();
-	return await getToken();
-}
+		const messagesResult = await api.GET("/v1/public/sessions/{session_id}/messages", {
+			params: {
+				path: { session_id: data.sessionId },
+				query: { offset: 0, limit: PAGE_SIZE },
+			},
+			cache: "no-store",
+		});
+		const messagesPage =
+			messagesResult.error === undefined
+				? messagesResult.data
+				: { items: [], total: 0, offset: 0, limit: PAGE_SIZE };
 
-async function fetchFirstMessages(
-	sessionId: string,
-	token: string | null,
-): Promise<PublicMessagesPage> {
-	const api = createPublicApi(token);
-	const result = await api.GET("/v1/public/sessions/{session_id}/messages", {
-		params: { path: { session_id: sessionId }, query: { offset: 0, limit: PAGE_SIZE } },
-		cache: "no-store",
+		return { kind: "ok", share: shareResult.data, messagesPage };
 	});
-	if (result.error !== undefined) {
-		// Soft-failure: render the header even if messages errored.
-		return { items: [], total: 0, offset: 0, limit: PAGE_SIZE };
-	}
-	return result.data;
-}
 
 export default async function PublicSharePage({ id }: { id: string }) {
 	if (!UUID_RE.test(id)) throw notFound();
 
-	const token = await getOptionalToken();
-	const result = await fetchShare(id, token);
+	const result = await getPublicShareData({ data: { sessionId: id } });
 	if (result.kind === "not-found") throw notFound();
 	if (result.kind === "unauthorized") return <SignInToView shareUrl={`/s/${id}`} />;
 	if (result.kind === "forbidden") return <NoAccess />;
 
-	const share = result.share;
-	const messagesPage = await fetchFirstMessages(id, token);
+	const { share, messagesPage } = result;
 
 	const summaryText = formatSessionSummary(share.summary) || `Session ${share.id.slice(0, 8)}`;
 	const totalTokens = (share.input_tokens ?? 0) + (share.output_tokens ?? 0);

--- a/apps/web/src/pages/public-share/session-page.tsx
+++ b/apps/web/src/pages/public-share/session-page.tsx
@@ -1,10 +1,5 @@
-import type { components, paths } from "@clawdi/shared/api";
-import { auth } from "@clerk/tanstack-react-start/server";
-import { Link, notFound } from "@tanstack/react-router";
-import { createServerFn } from "@tanstack/react-start";
+import { Link } from "@tanstack/react-router";
 import { Clock, Hash, MessageSquare, Zap } from "lucide-react";
-import createClient from "openapi-fetch";
-import { z } from "zod";
 import { AgentInline } from "@/components/dashboard/agent-label";
 import { DetailMeta, DetailStats, DetailTitle } from "@/components/detail/layout";
 import { ModelBadge } from "@/components/meta/model-badge";
@@ -17,16 +12,16 @@ import { NoAccess } from "@/components/share/no-access";
 import { PublicShareControls } from "@/components/share/public-share-controls";
 import { SignInToView } from "@/components/share/sign-in-to-view";
 import { TimeTooltip } from "@/components/time-tooltip";
-import { env } from "@/lib/env";
 import { formatDuration } from "@/lib/format";
 import { formatNumber, formatSessionSummary, relativeTime } from "@/lib/utils";
+import type { PublicShareResult } from "./session-page.functions";
 
 /**
  * Public share page for a Clawdi session.
  *
  * SSR-capable route component — must work for curl, link unfurlers, and
- * agents that don't run JavaScript. Server-only auth and data access stay
- * behind `getPublicShareData` so client hydration uses the RPC boundary.
+ * agents that don't run JavaScript. The route loader owns server data so
+ * initial hydration reuses dehydrated data without rerunning the loader fetch.
  * Mirrors the dashboard `/sessions/[id]` layout
  * (DetailTitle / DetailMeta / SessionSidebar / DetailStats / message
  * stream) so a visitor's view of a session looks the same as the owner's
@@ -50,68 +45,15 @@ import { formatNumber, formatSessionSummary, relativeTime } from "@/lib/utils";
  *   404 → `notFound()` (session doesn't exist)
  */
 
-const PAGE_SIZE = 100;
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+type PublicSharePageResult = Exclude<PublicShareResult, { kind: "not-found" }>;
 
-type PublicShare = components["schemas"]["PublicSessionResponse"];
-type PublicMessagesPage = components["schemas"]["SessionMessagesPage"];
-
-type FetchResult =
-	| { kind: "ok"; share: PublicShare; messagesPage: PublicMessagesPage }
-	| { kind: "unauthorized" }
-	| { kind: "forbidden" }
-	| { kind: "not-found" };
-
-/**
- * Authentication and both API reads stay inside this server function so
- * Clerk's server runtime and the JWT never enter the client route chunk.
- */
-const getPublicShareData = createServerFn({ method: "GET" })
-	.validator(z.object({ sessionId: z.string().regex(UUID_RE) }))
-	.handler(async ({ data }): Promise<FetchResult> => {
-		let token: string | null;
-		if (env.VITE_DEV_AUTH_BYPASS) {
-			token = env.VITE_DEV_AUTH_TOKEN;
-		} else {
-			const { getToken } = await auth();
-			token = await getToken();
-		}
-
-		const api = createClient<paths>({
-			baseUrl: env.VITE_CLAWDI_API_URL,
-			headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-		});
-		const shareResult = await api.GET("/v1/public/sessions/{session_id}", {
-			params: { path: { session_id: data.sessionId } },
-			cache: "no-store",
-		});
-		if (shareResult.response.status === 404) return { kind: "not-found" };
-		if (shareResult.response.status === 401) return { kind: "unauthorized" };
-		if (shareResult.response.status === 403) return { kind: "forbidden" };
-		if (shareResult.error !== undefined) {
-			throw new Error(`backend returned ${shareResult.response.status}`);
-		}
-
-		const messagesResult = await api.GET("/v1/public/sessions/{session_id}/messages", {
-			params: {
-				path: { session_id: data.sessionId },
-				query: { offset: 0, limit: PAGE_SIZE },
-			},
-			cache: "no-store",
-		});
-		const messagesPage =
-			messagesResult.error === undefined
-				? messagesResult.data
-				: { items: [], total: 0, offset: 0, limit: PAGE_SIZE };
-
-		return { kind: "ok", share: shareResult.data, messagesPage };
-	});
-
-export default async function PublicSharePage({ id }: { id: string }) {
-	if (!UUID_RE.test(id)) throw notFound();
-
-	const result = await getPublicShareData({ data: { sessionId: id } });
-	if (result.kind === "not-found") throw notFound();
+export default function PublicSharePage({
+	id,
+	result,
+}: {
+	id: string;
+	result: PublicSharePageResult;
+}) {
 	if (result.kind === "unauthorized") return <SignInToView shareUrl={`/s/${id}`} />;
 	if (result.kind === "forbidden") return <NoAccess />;
 

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -1,9 +1,11 @@
 import { auth } from "@clerk/tanstack-react-start/server";
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
+import { setResponseHeader } from "@tanstack/react-start/server";
 import { env } from "@/lib/env";
 
 const getAuthState = createServerFn({ method: "GET" }).handler(async () => {
+	setResponseHeader("cache-control", "no-store");
 	if (env.VITE_DEV_AUTH_BYPASS) return { userId: "dev_browser" };
 	const { userId } = await auth();
 	return { userId };

--- a/apps/web/src/routes/s/$id.tsx
+++ b/apps/web/src/routes/s/$id.tsx
@@ -1,13 +1,23 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, notFound } from "@tanstack/react-router";
 import { routeHeadTitle } from "@/lib/document-title";
 import PublicSharePage from "@/pages/public-share/session-page";
+import { getPublicShareData } from "@/pages/public-share/session-page.functions";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export const Route = createFileRoute("/s/$id")({
 	head: () => routeHeadTitle("Shared Session"),
+	loader: async ({ params }) => {
+		if (!UUID_RE.test(params.id)) throw notFound();
+		const result = await getPublicShareData({ data: { sessionId: params.id } });
+		if (result.kind === "not-found") throw notFound();
+		return result;
+	},
 	component: PublicShareRoute,
 });
 
 function PublicShareRoute() {
 	const { id } = Route.useParams();
-	return <PublicSharePage id={id} />;
+	const result = Route.useLoaderData();
+	return <PublicSharePage id={id} result={result} />;
 }

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -1,4 +1,3 @@
-import { clerkMiddleware } from "@clerk/tanstack-react-start/server";
 import {
 	sentryGlobalFunctionMiddleware,
 	sentryGlobalRequestMiddleware,
@@ -6,9 +5,15 @@ import {
 import {
 	type AnyRequestMiddleware,
 	createCsrfMiddleware,
+	createIsomorphicFn,
 	createStart,
 } from "@tanstack/react-start";
+import { createClerkRequestMiddleware } from "@/clerk-middleware.server";
 import { env } from "@/lib/env";
+
+const getClerkRequestMiddleware = createIsomorphicFn()
+	.client(() => undefined)
+	.server(() => createClerkRequestMiddleware());
 
 const csrfMiddleware = createCsrfMiddleware({
 	filter: (ctx) => ctx.handlerType === "serverFn",
@@ -21,13 +26,8 @@ if (env.VITE_SENTRY_DSN) {
 }
 
 if (!env.VITE_DEV_AUTH_BYPASS) {
-	requestMiddleware.push(
-		clerkMiddleware({
-			publishableKey: env.VITE_CLERK_PUBLISHABLE_KEY,
-			signInUrl: "/sign-in",
-			signUpUrl: "/sign-up",
-		}),
-	);
+	const clerkRequestMiddleware = getClerkRequestMiddleware();
+	if (clerkRequestMiddleware) requestMiddleware.push(clerkRequestMiddleware);
 }
 
 requestMiddleware.push(csrfMiddleware);

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -41,6 +41,16 @@ export default defineConfig(({ mode }) => {
 		resolve: {
 			tsconfigPaths: true,
 		},
-		plugins: [tanstackStart(), nitro(), tailwindcss(), viteReact(), ...sentryPlugins],
+		plugins: [
+			tanstackStart({
+				importProtection: {
+					client: { specifiers: ["@clerk/tanstack-react-start/server"] },
+				},
+			}),
+			nitro(),
+			tailwindcss(),
+			viteReact(),
+			...sentryPlugins,
+		],
 	};
 });


### PR DESCRIPTION
## Cause

The public shared-session route rendered successfully during SSR, but its async route component reran during hydration while directly importing and calling Clerk server `auth()`. That placed the Clerk server implementation in the public client route chunk and caused hydration to fail while reading server request auth state in Chromium.

## Fix

- Move optional Clerk token acquisition and both public-session API reads into one TanStack Start `createServerFn` handler.
- Return only the public share payload, the first messages page, or the existing access status union; the Clerk JWT never crosses the server-function boundary.
- Preserve public SSR, anonymous/optional auth behavior, 401/403/404 handling, and the existing soft failure to an empty messages page.
- Add a focused boundary regression test covering the auth/read placement and token-free rendering call site.

## Verification

- `bun test src/pages/public-share/session-page-boundary.test.ts src/pages/public-share/session-export-route.test.ts src/routes/-shared-export-routes.test.ts` (8 pass)
- `bun run typecheck`
- `bun run lint`
- `bun run build:oss`
- Inspected the production output: the `/s/$id` client chunk contains only the server-function RPC stub; Clerk `auth()`, `getToken()`, bearer-header construction, and both `/v1/public/sessions` reads appear only in the server bundle.