### PR TITLE
fix(runtime): use active CLI diagnostics evidence

### DIFF
--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -95,6 +95,7 @@ _CODEX_TOOL_CANONICAL_ENV_MINIMUM_CLI_VERSION = (0, 13, 69)
 _CODEX_TOOL_SECRET_REF = "secret://tool.codex.apiKey"
 _CODEX_TOOL_API_MODE = "openai_responses"
 _CODEX_PROVIDER_SOURCE_API_MODES = {"openai_chat", "openai_responses"}
+_HOSTED_CLI_NPM_REGISTRY = "https://registry.npmjs.org"
 _AI_PROVIDER_MODELS_ADAPTER: TypeAdapter[list[AiProviderModel]] = TypeAdapter(list[AiProviderModel])
 
 
@@ -111,6 +112,29 @@ def expected_runtime_bundle_v2_etag(source_revision: str) -> str:
     if not re.fullmatch(r"[0-9a-f]{64}", source_revision):
         raise ValueError("runtime bundle source revision must be a SHA-256 digest")
     return f'"sha256:{source_revision}"'
+
+
+def _has_exact_active_cli_evidence(
+    diagnostics: HostedRuntimeObservedV2,
+    package_spec: str,
+) -> bool:
+    prefix = "clawdi@"
+    if not package_spec.startswith(prefix):
+        return False
+    version = package_spec.removeprefix(prefix)
+    if parse_exact_semver(version) is None:
+        return False
+    cli = diagnostics.cli
+    return bool(
+        cli is not None
+        and cli.status == "installed"
+        and cli.source == "npm"
+        and cli.package_spec == package_spec
+        and cli.registry == _HOSTED_CLI_NPM_REGISTRY
+        and cli.active_path
+        and cli.active_target
+        and cli.version == version
+    )
 
 
 def _codex_tool_runtime_env(
@@ -142,7 +166,7 @@ def _codex_tool_runtime_env(
     if not (
         observed.status == "ok"
         and observed.converge_error is None
-        and observed.active_cli_version == desired_version
+        and _has_exact_active_cli_evidence(observed, state.cli_package_spec)
         and observed.applied is not None
         and observed.applied.instance_id == state.instance_id
         and observed.applied.generation == expected_generation
@@ -812,7 +836,7 @@ def render_runtime_source(
         "clawdiCli": {
             "source": "npm:clawdi",
             "packageSpec": cli_package_spec,
-            "registry": "https://registry.npmjs.org",
+            "registry": _HOSTED_CLI_NPM_REGISTRY,
         },
         "runtimes": {runtime_name: runtime},
         "providers": providers,

--- a/backend/tests/hosted_runtime_fixtures.py
+++ b/backend/tests/hosted_runtime_fixtures.py
@@ -24,6 +24,19 @@ CANONICAL_CODEX_TOOLS = {
 }
 
 
+def active_cli_diagnostics(package_spec: str) -> dict[str, str]:
+    version = package_spec.removeprefix("clawdi@")
+    return {
+        "status": "installed",
+        "source": "npm",
+        "packageSpec": package_spec,
+        "registry": "https://registry.npmjs.org",
+        "activePath": "/test/managed/clawdi",
+        "activeTarget": f"/test/managed/packages/{version}/clawdi",
+        "version": version,
+    }
+
+
 def filebrowser_companion(deployment_id: str, access_revision: str = "a" * 64) -> dict[str, Any]:
     audience = f"clawdi-files:{deployment_id}"
     release = "https://github.com/gtsteffaniak/filebrowser/releases/download/v1.5.0-stable"

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -36,7 +36,10 @@ from app.services.runtime_source import (
     render_runtime_bundle,
     render_runtime_source,
 )
-from tests.hosted_runtime_fixtures import CANONICAL_CODEX_TOOL_PROVIDER_ID
+from tests.hosted_runtime_fixtures import (
+    CANONICAL_CODEX_TOOL_PROVIDER_ID,
+    active_cli_diagnostics,
+)
 
 USER_ID = UUID("10000000-0000-0000-0000-000000000001")
 ENV_ID = UUID("20000000-0000-0000-0000-000000000002")
@@ -315,7 +318,7 @@ def _set_healthy_cli_observation(
     batch: RuntimeSourceBatch,
     *,
     desired: str,
-    active: str | None = None,
+    daemon_version: str = "0.13.68",
     source_revision: str = "a" * 64,
 ) -> HostedRuntimeConfigObservation:
     row = batch.rows[ENV_ID]
@@ -337,7 +340,7 @@ def _set_healthy_cli_observation(
             "reportedAt": "2026-07-13T00:00:00Z",
             "runtimeMode": "hosted",
             "status": "ok",
-            "activeCliVersion": active or desired.removeprefix("clawdi@"),
+            "activeCliVersion": daemon_version,
             "applied": {
                 "etag": etag,
                 "sourceRevision": source_revision,
@@ -346,7 +349,7 @@ def _set_healthy_cli_observation(
                 "appliedProviderIds": ["managed"],
             },
             "boot": None,
-            "cli": None,
+            "cli": active_cli_diagnostics(desired),
             "convergeError": None,
         },
     )
@@ -757,29 +760,34 @@ def test_codex_tool_projection_rejects_invalid_fixed_fields(field: str, value: s
 
 
 @pytest.mark.parametrize(
-    ("desired", "active", "expected"),
+    ("desired", "expected"),
     [
-        ("0.13.68", "0.13.68", "OPENAI_API_KEY"),
-        ("0.13.69-rc.1", "0.13.69-rc.1", "OPENAI_API_KEY"),
-        ("0.13.69", "0.13.68", "OPENAI_API_KEY"),
-        ("0.13.69", "0.13.69", "CLAWDI_AI_API_KEY"),
-        ("0.14.0-rc.1", "0.14.0-rc.1", "CLAWDI_AI_API_KEY"),
-        ("0.13.68", "0.14.0", "OPENAI_API_KEY"),
+        ("0.13.68", "OPENAI_API_KEY"),
+        ("0.13.69-rc.1", "OPENAI_API_KEY"),
+        ("0.13.69", "CLAWDI_AI_API_KEY"),
+        ("0.14.0-rc.1", "CLAWDI_AI_API_KEY"),
     ],
 )
 def test_codex_tool_env_respects_cli_version_boundary(
     desired: str,
-    active: str,
     expected: str,
 ) -> None:
     batch = _batch()
-    _set_healthy_cli_observation(
-        batch,
-        desired=f"clawdi@{desired}",
-        active=active,
-    )
+    _set_healthy_cli_observation(batch, desired=f"clawdi@{desired}")
 
     assert _codex_runtime_env(batch) == expected
+
+
+def test_codex_tool_env_accepts_current_cli_diagnostics_from_old_daemon() -> None:
+    batch = _batch()
+    observation = _set_healthy_cli_observation(
+        batch,
+        desired="clawdi@0.13.69",
+        daemon_version="0.13.68",
+    )
+
+    assert observation.diagnostics["activeCliVersion"] == "0.13.68"
+    assert _codex_runtime_env(batch) == "CLAWDI_AI_API_KEY"
 
 
 def test_codex_tool_env_stays_legacy_until_new_cli_is_observed() -> None:
@@ -794,6 +802,45 @@ def test_codex_tool_env_stays_legacy_until_new_cli_is_observed() -> None:
         "OPENAI_API_KEY",
         "OPENAI_API_KEY",
     ]
+
+
+@pytest.mark.parametrize(
+    "cli_update",
+    [
+        pytest.param(None, id="missing"),
+        pytest.param({"status": "deferred"}, id="not-installed"),
+        pytest.param(
+            {
+                "packageSpec": "clawdi@0.13.68",
+                "activeTarget": (
+                    "/var/lib/clawdi/maintained/clawdi/npm/packages/0.13.68/bin/clawdi"
+                ),
+                "version": "0.13.68",
+            },
+            id="stale",
+        ),
+        pytest.param({"source": "fixture"}, id="source-mismatch"),
+        pytest.param({"packageSpec": "clawdi@0.13.70"}, id="package-mismatch"),
+        pytest.param({"registry": "https://registry.test"}, id="registry-mismatch"),
+        pytest.param({"activePath": None}, id="active-path-missing"),
+        pytest.param({"activeTarget": None}, id="active-target-missing"),
+        pytest.param({"version": "0.13.70"}, id="version-mismatch"),
+    ],
+)
+def test_codex_tool_env_rejects_inexact_cli_diagnostics(
+    cli_update: dict[str, object] | None,
+) -> None:
+    batch = _batch()
+    observation = _set_healthy_cli_observation(batch, desired="clawdi@0.13.69")
+    assert isinstance(observation.diagnostics, dict)
+    cli = observation.diagnostics["cli"]
+    if cli_update is None:
+        observation.diagnostics["cli"] = None
+    else:
+        assert isinstance(cli, dict)
+        cli.update(cli_update)
+
+    assert _codex_runtime_env(batch) == "OPENAI_API_KEY"
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -39,6 +39,7 @@ from app.services.runtime_source import expected_runtime_bundle_v2_etag
 from tests.conftest import create_env_with_project
 from tests.hosted_runtime_fixtures import (
     CANONICAL_CODEX_TOOLS,
+    active_cli_diagnostics,
     canonical_hosted_runtime_state,
     ensure_canonical_codex_tool_provider,
 )
@@ -574,6 +575,7 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
         applied_generation=4,
         applied_instance_id="iid-observed-api",
     )
+    observed["cli"] = active_cli_diagnostics(_TEST_HOSTED_INTEGRATIONS_CLI_PACKAGE_SPEC)
     heartbeat = await client.post(
         f"/v1/agents/{env_id}/sync-heartbeat",
         json={"queue_depth": 1, "runtime_observed": observed},
@@ -591,6 +593,7 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
         applied_generation=4,
         applied_instance_id="iid-observed-api",
     )
+    observed["cli"] = active_cli_diagnostics(_TEST_HOSTED_INTEGRATIONS_CLI_PACKAGE_SPEC)
     received_at_lower_bound = datetime.now(UTC)
     heartbeat = await client.post(
         f"/v1/agents/{env_id}/sync-heartbeat",

--- a/docs/ai-provider-agent-contract-audit.md
+++ b/docs/ai-provider-agent-contract-audit.md
@@ -83,9 +83,11 @@ choice.
 Deployment is two-stage. Phase A publishes the dual-read/canonical-write
 `clawdi@0.13.69`; the backend continues to emit legacy `OPENAI_API_KEY`. Phase B
 is a separate backend change gated on the exact CLI being published, desired
-package specs advancing, and `activeCliVersion` converging. The current flow
-parses the strict manifest before `applyRuntimeCliDesiredState`, so enabling
-canonical backend emission earlier would strand an older CLI before
+package specs advancing, and strict `diagnostics.cli` evidence proving that exact
+package is installed and active. An in-place update preserves the long-running
+daemon, so `activeCliVersion` may correctly remain its older running version.
+The current flow parses the strict manifest before `applyRuntimeCliDesiredState`,
+so enabling canonical backend emission earlier would strand an older CLI before
 self-upgrade.
 
 ## Hermes

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -657,10 +657,12 @@ This change is Phase A: publish `clawdi@0.13.69`, which reads both legacy and
 canonical terminal-Codex env names while writing only the canonical local env.
 Phase B keeps backend emission deployment-scoped: terminal Codex receives
 `CLAWDI_AI_API_KEY` only when the desired CLI is `clawdi@0.13.69` or later and
-strict v2 diagnostics prove the exact desired version, current apply generation,
-and current instance. Observation generation, ETag, and source revision must
-agree with that applied record. Every missing, invalid, stale, or mismatched
-state retains `OPENAI_API_KEY`, including upgrades and rollbacks.
+strict v2 `diagnostics.cli` proves the exact desired package is installed and
+active, along with the current apply generation and instance. An in-place update
+preserves the daemon process, so its `activeCliVersion` may remain the older
+running version. Observation generation, ETag, and source revision must agree
+with that applied record. Every missing, invalid, stale, or mismatched state
+retains `OPENAI_API_KEY`, including upgrades and rollbacks.
 Phase B may therefore deploy before the fleet upgrades: each deployment remains
 on the legacy env name until its own CLI and observation have converged.
 The gate does not compare that last applied revision with the revision currently


### PR DESCRIPTION
## Summary

- recognize an in-place hosted CLI upgrade from verified active-install diagnostics instead of the preserved daemon process version
- reuse the same exact package, registry, activation evidence for Codex env cutover, runtime health, and hosted Project Skill capability
- keep the existing generation, instance, ETag, source-revision, health-reason, and fallback fences unchanged

## Why

A CLI-only rollout intentionally preserves `clawdi-daemon`. After `clawdi@0.13.69` is installed, verified, and atomically activated, that process can continue reporting its old running `activeCliVersion`. Treating the process version as the deployment CLI version blocks healthy no-restart convergence.

## Verification

- isolated focused backend tests for runtime source, runtime health, and hosted Project Skill capability
- Ruff lint and format
- strict type governance / basedpyright
- compileall
- `git diff --check`

Production rollout is intentionally separate. No tenant or infrastructure mutation is part of this PR.
