### PR TITLE
chore(whatsapp): remove legacy transport vestiges

### DIFF
--- a/apps/web/src/hosted/v2/channels/channel-detail-page.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.logic.test.ts
@@ -94,7 +94,6 @@ describe("nativeTransportSummary", () => {
 				mode: "none",
 				reason: "shared-bot-transport-unavailable",
 				supportsOutboundMessages: false,
-				supportsRawRelay: false,
 			}),
 		).toEqual({
 			status: "Unavailable",

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.logic.ts
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.logic.ts
@@ -63,13 +63,11 @@ export function nativeTransportSummary(transport: Record<string, unknown>): Nati
 				? "Unavailable"
 				: "Unknown";
 	const connection =
-		transport.mode === "in_process"
-			? "Direct connection"
-			: transport.mode === "sidecar"
-				? "Managed connection"
-				: transport.mode === "none"
-					? "Not connected"
-					: "Details unavailable";
+		transport.mode === "sidecar"
+			? "Managed connection"
+			: transport.mode === "none"
+				? "Not connected"
+				: "Details unavailable";
 	const delivery =
 		transport.supportsOutboundMessages === true
 			? "Available"

--- a/backend/app/services/channel_delivery_worker.py
+++ b/backend/app/services/channel_delivery_worker.py
@@ -50,9 +50,3 @@ class ChannelDeliveryWorker:
                     await asyncio.wait_for(stop_event.wait(), timeout=self._poll_interval_seconds)
                 except TimeoutError:
                     pass
-
-
-async def run_channel_delivery_once(
-    sessionmaker: async_sessionmaker[AsyncSession],
-) -> UUID | None:
-    return await ChannelDeliveryWorker(sessionmaker).run_once()

--- a/backend/app/services/whatsapp_baileys.py
+++ b/backend/app/services/whatsapp_baileys.py
@@ -1334,19 +1334,6 @@ class GroupCipherBackend:
             self._store.save(key_name, _copy_sender_key_record(record))
 
 
-def encrypt_whatsapp_group_message_for_sender_key(
-    *,
-    axolotl_bytes: bytes,
-    plaintext: bytes,
-) -> bytes:
-    record: SenderKeyRecordSnapshot = {
-        "version": 1,
-        "key": hashlib.sha256(axolotl_bytes).digest(),
-        "iteration": 0,
-    }
-    return _encrypt_sender_key_record(record, plaintext)
-
-
 def _copy_sender_key_record(
     record: SenderKeyRecordSnapshot,
 ) -> SenderKeyRecordSnapshot:
@@ -1496,22 +1483,6 @@ def decide_whatsapp_relay(
     )
 
 
-async def find_whatsapp_binding_by_jids(
-    db: AsyncSession,
-    *,
-    account: ChannelAccount,
-    remote_jid: str,
-    alt_jid: str | None = None,
-) -> ChannelBinding | None:
-    lookup = await resolve_whatsapp_binding_by_jids(
-        db,
-        account=account,
-        remote_jid=remote_jid,
-        alt_jid=alt_jid,
-    )
-    return lookup.binding
-
-
 async def resolve_whatsapp_binding_by_jids(
     db: AsyncSession,
     *,
@@ -1644,16 +1615,6 @@ def _decrypt_whatsapp_auth_cert(row: ChannelWhatsAppAuthCert) -> WhatsAppAuthCer
                 row.intermediate_private_key_nonce,
             )
         ),
-    )
-
-
-def serialize_whatsapp_auth_cert(cert: WhatsAppAuthCert) -> dict[str, JsonValue]:
-    return _encoded_json_object(
-        {
-            "SERIAL": cert.serial,
-            "ISSUER": cert.issuer,
-            "PUBLIC_KEY": buffer_json(cert.root_public_key),
-        }
     )
 
 
@@ -2641,22 +2602,12 @@ def _encrypt_signal_peer_record(
     return bytes([version]) + message_proto + mac
 
 
-def _encrypt_sender_key_record(record: SenderKeyRecordSnapshot, plaintext: bytes) -> bytes:
-    iteration = record["iteration"]
-    nonce = _record_nonce(b"sender-key", iteration)
-    return nonce + AESGCM(record["key"]).encrypt(nonce, plaintext, None)
-
-
 def _decrypt_sender_key_record(record: SenderKeyRecordSnapshot, ciphertext: bytes) -> bytes:
     if len(ciphertext) < 13:
         raise ValueError("sender-key ciphertext too short")
     nonce = ciphertext[:12]
     body = ciphertext[12:]
     return AESGCM(record["key"]).decrypt(nonce, body, None)
-
-
-def _record_nonce(prefix: bytes, counter: int) -> bytes:
-    return hashlib.sha256(prefix + counter.to_bytes(8, "big")).digest()[:12]
 
 
 def _stamp_whatsapp_self_identity(

--- a/backend/app/services/whatsapp_delivery_transport.py
+++ b/backend/app/services/whatsapp_delivery_transport.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import replace
+from uuid import UUID
+
+from app.core.config import settings
+from app.models.channel import CHANNEL_PROVIDER_WHATSAPP, ChannelAccount
+from app.services.whatsapp_native_transport import (
+    WhatsAppBaileysSidecarConfig,
+    WhatsAppBaileysSidecarService,
+    WhatsAppProviderTransportAdapter,
+)
+
+DEFAULT_WHATSAPP_SIDECAR_SOCKET_PATH = "/run/clawdi-whatsapp/sidecar.sock"
+
+_delivery_sidecar_service: WhatsAppBaileysSidecarService | None = None
+
+
+def resolve_whatsapp_delivery_transport(
+    account: ChannelAccount,
+) -> WhatsAppProviderTransportAdapter | None:
+    if account.provider != CHANNEL_PROVIDER_WHATSAPP:
+        return None
+    config = account.config if isinstance(account.config, dict) else {}
+    connection_mode = config.get("connection_mode")
+    if connection_mode == "baileys_managed":
+        session_id = account.id
+    elif connection_mode == "baileys_custom":
+        session_id = configured_whatsapp_sidecar_session_id(config)
+    else:
+        return None
+    if session_id is None:
+        return None
+
+    service_config = _configured_delivery_service()
+    if service_config is None:
+        return None
+    session_config = replace(service_config, account_id=session_id)
+    if config.get("sidecar_config_revision") != session_config.binding_revision:
+        return None
+
+    global _delivery_sidecar_service
+    if _delivery_sidecar_service is None:
+        _delivery_sidecar_service = WhatsAppBaileysSidecarService(service_config)
+    return WhatsAppProviderTransportAdapter(_delivery_sidecar_service.session_client(session_id))
+
+
+def _configured_delivery_service() -> WhatsAppBaileysSidecarConfig | None:
+    api_token = settings.channel_whatsapp_baileys_sidecar_token.get_secret_value().strip()
+    if not api_token:
+        return None
+    base_url = settings.channel_whatsapp_baileys_sidecar_url.strip() or None
+    return WhatsAppBaileysSidecarConfig(
+        api_token=api_token,
+        base_url=base_url,
+        unix_socket_path=None if base_url else DEFAULT_WHATSAPP_SIDECAR_SOCKET_PATH,
+    )
+
+
+def configured_whatsapp_sidecar_session_id(config: Mapping[str, object]) -> UUID | None:
+    raw = config.get("sidecar_account_id")
+    try:
+        return UUID(raw) if isinstance(raw, str) else None
+    except ValueError:
+        return None

--- a/backend/app/services/whatsapp_native_transport.py
+++ b/backend/app/services/whatsapp_native_transport.py
@@ -190,8 +190,8 @@ class WhatsAppNativeUpstreamClient(Protocol):
 class WhatsAppProviderTransportAdapter:
     """Map authorized provider operations to the physical Baileys transport.
 
-    The wrapped client can be in-process or a narrow HTTP client. It never owns
-    Agent synthetic auth state and exposes no application-level channel adapter.
+    The wrapped client never owns Agent synthetic auth state and exposes no
+    application-level channel adapter.
     """
 
     def __init__(self, client: WhatsAppNativeUpstreamClient) -> None:
@@ -200,11 +200,6 @@ class WhatsAppProviderTransportAdapter:
     @property
     def connected(self) -> bool:
         return self._client.connected
-
-    @property
-    def transport_mode(self) -> Literal["in_process", "sidecar"]:
-        mode = getattr(self._client, "transport_mode", "in_process")
-        return "sidecar" if mode == "sidecar" else "in_process"
 
     async def relay_outbound_message(self, message: WhatsAppOutboundMessage) -> str | None:
         return await self._client.relay_message(
@@ -231,8 +226,6 @@ class WhatsAppBaileysSidecarClient:
     routing, chunking, allowlist, or product database knowledge. The sidecar owns
     only Baileys socket/session/protocol operations.
     """
-
-    transport_mode: Literal["sidecar"] = "sidecar"
 
     def __init__(
         self,

--- a/backend/app/services/whatsapp_provider_bridge.py
+++ b/backend/app/services/whatsapp_provider_bridge.py
@@ -22,6 +22,7 @@ from app.models.channel import (
     ChannelBinding,
     ChannelBindingAlias,
 )
+from app.services import whatsapp_delivery_transport
 from app.services.channel_debug_events import record_channel_debug_event
 from app.services.channels import (
     channel_control_command_event_was_handled,
@@ -80,11 +81,9 @@ class WhatsAppProviderNodeRelayResult:
 @dataclass(frozen=True)
 class WhatsAppProviderTransportStatus:
     available: bool
-    mode: Literal["in_process", "sidecar", "none"]
+    mode: Literal["sidecar", "none"]
     reason: str | None
     supports_outbound_messages: bool
-    supports_raw_relay: bool
-    supports_iq_queries: bool
 
     def as_dict(self) -> dict[str, JsonValue]:
         return {
@@ -92,8 +91,6 @@ class WhatsAppProviderTransportStatus:
             "mode": self.mode,
             "reason": self.reason,
             "supportsOutboundMessages": self.supports_outbound_messages,
-            "supportsRawRelay": self.supports_raw_relay,
-            "supportsIqQueries": self.supports_iq_queries,
         }
 
 
@@ -143,17 +140,13 @@ def whatsapp_provider_transport_status(account_id: UUID) -> WhatsAppProviderTran
             mode="none",
             reason="provider-transport-unavailable",
             supports_outbound_messages=False,
-            supports_raw_relay=False,
-            supports_iq_queries=False,
         )
     connected = _transport_connected(transport)
     return WhatsAppProviderTransportStatus(
         available=connected,
-        mode=_transport_mode(transport),
+        mode="sidecar",
         reason=None if connected else "provider-transport-disconnected",
-        supports_outbound_messages=callable(getattr(transport, "relay_outbound_message", None)),
-        supports_raw_relay=callable(getattr(transport, "relay_raw_node", None)),
-        supports_iq_queries=callable(getattr(transport, "query_iq", None)),
+        supports_outbound_messages=True,
     )
 
 
@@ -417,9 +410,7 @@ async def relay_whatsapp_provider_payload(
     text: str,
     provider_payload: object | None,
 ) -> tuple[str | None, dict[str, JsonValue]]:
-    from app.services.whatsapp_sidecar_registry import resolve_whatsapp_delivery_transport
-
-    transport = resolve_whatsapp_delivery_transport(account)
+    transport = whatsapp_delivery_transport.resolve_whatsapp_delivery_transport(account)
     if transport is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -948,13 +939,6 @@ def _transport_connected(transport: WhatsAppProviderTransport) -> bool:
     except Exception:
         return False
     return connected if isinstance(connected, bool) else True
-
-
-def _transport_mode(
-    transport: WhatsAppProviderTransport,
-) -> Literal["in_process", "sidecar"]:
-    mode = getattr(transport, "transport_mode", "in_process")
-    return "sidecar" if mode == "sidecar" else "in_process"
 
 
 def _query_iq(

--- a/backend/app/services/whatsapp_sidecar_registry.py
+++ b/backend/app/services/whatsapp_sidecar_registry.py
@@ -2,15 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable, Mapping
-from dataclasses import replace
+from collections.abc import Callable
 from typing import Protocol
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
 from app.core.database import async_session_factory
 from app.models.channel import (
     CHANNEL_PROVIDER_WHATSAPP,
@@ -20,6 +18,10 @@ from app.models.channel import (
     WHATSAPP_ONBOARDING_STATE_ERROR,
     ChannelAccount,
     ChannelWhatsAppOnboardingSession,
+)
+from app.services.whatsapp_delivery_transport import (
+    DEFAULT_WHATSAPP_SIDECAR_SOCKET_PATH,
+    configured_whatsapp_sidecar_session_id,
 )
 from app.services.whatsapp_native_transport import (
     WhatsAppBaileysSidecarClient,
@@ -42,8 +44,6 @@ from app.services.whatsapp_provider_bridge import (
 )
 
 log = logging.getLogger(__name__)
-
-DEFAULT_WHATSAPP_SIDECAR_SOCKET_PATH = "/run/clawdi-whatsapp/sidecar.sock"
 _UNRELEASED_STATES = (
     "generating",
     "ready",
@@ -84,48 +84,6 @@ class WhatsAppSidecarClient(WhatsAppNativeUpstreamClient, Protocol):
 
 SidecarClientFactory = Callable[[WhatsAppBaileysSidecarConfig], WhatsAppSidecarClient]
 _active_registry: ConfiguredWhatsAppSidecarRegistry | None = None
-_delivery_sidecar_service: WhatsAppBaileysSidecarService | None = None
-
-
-def resolve_whatsapp_delivery_transport(
-    account: ChannelAccount,
-) -> WhatsAppProviderTransportAdapter | None:
-    if account.provider != CHANNEL_PROVIDER_WHATSAPP:
-        return None
-    config = account.config if isinstance(account.config, dict) else {}
-    connection_mode = config.get("connection_mode")
-    if connection_mode == "baileys_managed":
-        session_id = account.id
-    elif connection_mode == "baileys_custom":
-        session_id = _configured_session_id(config)
-    else:
-        return None
-    if session_id is None:
-        return None
-
-    service_config = _configured_delivery_service()
-    if service_config is None:
-        return None
-    session_config = replace(service_config, account_id=session_id)
-    if config.get("sidecar_config_revision") != session_config.binding_revision:
-        return None
-
-    global _delivery_sidecar_service
-    if _delivery_sidecar_service is None:
-        _delivery_sidecar_service = WhatsAppBaileysSidecarService(service_config)
-    return WhatsAppProviderTransportAdapter(_delivery_sidecar_service.session_client(session_id))
-
-
-def _configured_delivery_service() -> WhatsAppBaileysSidecarConfig | None:
-    api_token = settings.channel_whatsapp_baileys_sidecar_token.get_secret_value().strip()
-    if not api_token:
-        return None
-    base_url = settings.channel_whatsapp_baileys_sidecar_url.strip() or None
-    return WhatsAppBaileysSidecarConfig(
-        api_token=api_token,
-        base_url=base_url,
-        unix_socket_path=None if base_url else DEFAULT_WHATSAPP_SIDECAR_SOCKET_PATH,
-    )
 
 
 class ConfiguredWhatsAppSidecarRegistry:
@@ -481,7 +439,7 @@ class ConfiguredWhatsAppSidecarRegistry:
                 config = account.config if isinstance(account.config, dict) else {}
                 if config.get("connection_mode") != "baileys_custom":
                     continue
-                session_id = _configured_session_id(config)
+                session_id = configured_whatsapp_sidecar_session_id(config)
                 revision = config.get("sidecar_config_revision")
                 if session_id is None or not isinstance(revision, str) or session_id in owners:
                     if session_id is not None:
@@ -678,11 +636,3 @@ class ConfiguredWhatsAppSidecarRegistry:
 
 def get_active_whatsapp_sidecar_registry() -> ConfiguredWhatsAppSidecarRegistry | None:
     return _active_registry
-
-
-def _configured_session_id(config: Mapping[str, object]) -> UUID | None:
-    raw = config.get("sidecar_account_id")
-    try:
-        return UUID(raw) if isinstance(raw, str) else None
-    except ValueError:
-        return None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -288,6 +288,7 @@ strict = [
     "app/services/user_provisioning.py",
     "app/services/vault_crypto.py",
     "app/services/whatsapp_baileys.py",
+    "app/services/whatsapp_delivery_transport.py",
     "app/services/whatsapp_device_onboarding.py",
     "app/services/whatsapp_managed_onboarding.py",
     "app/services/whatsapp_native_transport.py",

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -54,8 +54,6 @@ def _configured_clerk_issuer(monkeypatch):
 
 
 class _ManagedOnboardingSidecar:
-    transport_mode = "sidecar"
-
     def __init__(self) -> None:
         self.connected = False
         self.registered = False

--- a/backend/tests/test_channel_debug_events.py
+++ b/backend/tests/test_channel_debug_events.py
@@ -374,8 +374,6 @@ async def test_channel_debug_health_reports_whatsapp_native_transport_status(
         "mode": "none",
         "reason": "provider-transport-unavailable",
         "supportsOutboundMessages": False,
-        "supportsRawRelay": False,
-        "supportsIqQueries": False,
     }
 
     account_id = UUID(created["id"])
@@ -391,9 +389,7 @@ async def test_channel_debug_health_reports_whatsapp_native_transport_status(
     )
     assert health["nativeTransport"] == {
         "available": True,
-        "mode": "in_process",
+        "mode": "sidecar",
         "reason": None,
         "supportsOutboundMessages": True,
-        "supportsRawRelay": True,
-        "supportsIqQueries": True,
     }

--- a/backend/tests/test_whatsapp_baileys.py
+++ b/backend/tests/test_whatsapp_baileys.py
@@ -39,7 +39,6 @@ from app.services.whatsapp_baileys import (
     decide_whatsapp_relay,
     describe_whatsapp_jid_for_log,
     encode_buffer_json,
-    encrypt_whatsapp_group_message_for_sender_key,
     forward_iq_over,
     mint_whatsapp_synthetic_creds,
     parse_agent_bundle,
@@ -54,6 +53,7 @@ from app.services.whatsapp_baileys import (
     whatsapp_text_from_message_proto,
     whatsapp_text_message_proto,
 )
+from tests.whatsapp_helpers import encrypt_whatsapp_group_message_for_sender_key
 
 pytestmark = [pytest.mark.usefixtures("channel_agent"), pytest.mark.committed_db]
 

--- a/backend/tests/test_whatsapp_baileys_smoke.py
+++ b/backend/tests/test_whatsapp_baileys_smoke.py
@@ -35,8 +35,8 @@ from app.services.whatsapp_baileys import (
     encode_buffer_json,
     load_or_create_whatsapp_auth_cert,
     mint_whatsapp_agent_credential,
-    serialize_whatsapp_auth_cert,
 )
+from tests.whatsapp_helpers import serialize_whatsapp_auth_cert
 
 
 def _baileys_protocol_smoke_gate(env: Mapping[str, str]) -> tuple[bool, str | None]:

--- a/backend/tests/test_whatsapp_custom_onboarding.py
+++ b/backend/tests/test_whatsapp_custom_onboarding.py
@@ -13,6 +13,7 @@ import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
+import app.services.whatsapp_delivery_transport as delivery_transport_module
 import app.services.whatsapp_sidecar_registry as sidecar_registry_module
 from app.core.auth import AuthContext, get_auth
 from app.core.database import get_session
@@ -47,8 +48,6 @@ from app.services.whatsapp_sidecar_registry import (
 
 
 class FakeCustomSidecar:
-    transport_mode = "sidecar"
-
     def __init__(self) -> None:
         self.current = WhatsAppSidecarPairingStatus(
             status="stopped",
@@ -202,7 +201,7 @@ async def custom_sidecar(
         client_factory=lambda _config: fake,
     )
     monkeypatch.setattr(
-        sidecar_registry_module,
+        delivery_transport_module,
         "resolve_whatsapp_delivery_transport",
         lambda _account: WhatsAppProviderTransportAdapter(fake),
     )
@@ -597,7 +596,7 @@ async def test_concurrent_cross_tenant_start_allocates_isolated_sessions(
 
 @pytest.mark.asyncio
 @pytest.mark.committed_db
-async def test_custom_bind_waits_for_in_process_ownership_reconciliation(
+async def test_custom_bind_waits_for_ownership_reconciliation(
     db_session: AsyncSession,
     seed_user: User,
     custom_sidecar: tuple[UUID, FakeCustomSidecar],
@@ -664,7 +663,7 @@ async def test_backend_restart_rehydrates_durable_account_transport_and_pump(
     revision = registry.custom_session_revision(provider_session_id)
     assert revision is not None
     monkeypatch.setattr(
-        sidecar_registry_module,
+        delivery_transport_module,
         "resolve_whatsapp_delivery_transport",
         lambda _account: WhatsAppProviderTransportAdapter(fake),
     )

--- a/backend/tests/test_whatsapp_managed_onboarding.py
+++ b/backend/tests/test_whatsapp_managed_onboarding.py
@@ -38,8 +38,6 @@ from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarRegi
 
 
 class FakeManagedSidecar:
-    transport_mode = "sidecar"
-
     def __init__(self) -> None:
         self.connected = False
         self.registered = False

--- a/backend/tests/test_whatsapp_native_transport.py
+++ b/backend/tests/test_whatsapp_native_transport.py
@@ -120,8 +120,6 @@ def test_whatsapp_provider_transport_health_reports_disconnected_adapter():
     assert status.available is False
     assert status.reason == "provider-transport-disconnected"
     assert status.supports_outbound_messages is True
-    assert status.supports_raw_relay is True
-    assert status.supports_iq_queries is True
 
 
 @pytest.mark.asyncio
@@ -433,8 +431,6 @@ async def test_whatsapp_provider_transport_health_reports_sidecar_mode():
     assert status.available is True
     assert status.mode == "sidecar"
     assert status.supports_outbound_messages is True
-    assert status.supports_raw_relay is True
-    assert status.supports_iq_queries is True
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_whatsapp_noise.py
+++ b/backend/tests/test_whatsapp_noise.py
@@ -36,7 +36,6 @@ from app.services.whatsapp_baileys import (
     StoredWhatsAppCredential,
     WhatsAppAuthCert,
     decode_buffer_json,
-    encrypt_whatsapp_group_message_for_sender_key,
     mint_whatsapp_agent_credential,
     serialize_creds,
     whatsapp_signal_senders_from_config,
@@ -74,6 +73,7 @@ from app.services.whatsapp_noise import (
     pack_frame,
     unpack_frame,
 )
+from tests.whatsapp_helpers import encrypt_whatsapp_group_message_for_sender_key
 
 pytestmark = [pytest.mark.usefixtures("channel_agent"), pytest.mark.committed_db]
 

--- a/backend/tests/test_whatsapp_provider_bridge.py
+++ b/backend/tests/test_whatsapp_provider_bridge.py
@@ -14,7 +14,7 @@ from pydantic import SecretStr
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-import app.services.whatsapp_sidecar_registry as sidecar_registry_module
+import app.services.whatsapp_delivery_transport as delivery_transport_module
 from app.core.config import settings
 from app.models.channel import (
     BINDING_STATUS_ARCHIVED,
@@ -101,7 +101,7 @@ def _use_delivery_transport(
     transport: _FakeProviderTransport,
 ) -> None:
     monkeypatch.setattr(
-        sidecar_registry_module,
+        delivery_transport_module,
         "resolve_whatsapp_delivery_transport",
         lambda _account: transport,
     )
@@ -195,7 +195,7 @@ def test_whatsapp_provider_transport_registration_is_exclusive_per_account():
             register_whatsapp_provider_transport(account_id, second)
         status = whatsapp_provider_transport_status(account_id)
         assert status.available is True
-        assert status.mode == "in_process"
+        assert status.mode == "sidecar"
     finally:
         unregister_whatsapp_provider_transport(account_id)
 
@@ -294,7 +294,7 @@ async def test_whatsapp_provider_bridge_queues_exact_proto_before_physical_deliv
     original_url = settings.channel_whatsapp_baileys_sidecar_url
     settings.channel_whatsapp_baileys_sidecar_token = SecretStr("sidecar-secret")
     settings.channel_whatsapp_baileys_sidecar_url = sidecar_url
-    monkeypatch.setattr(sidecar_registry_module, "_delivery_sidecar_service", sidecar_service)
+    monkeypatch.setattr(delivery_transport_module, "_delivery_sidecar_service", sidecar_service)
 
     try:
         assert get_whatsapp_provider_transport(account.id) is None
@@ -431,12 +431,12 @@ async def test_whatsapp_delivery_revision_mismatch_fails_without_sidecar_call(
             raise AssertionError("revision mismatch must not construct a session client")
 
     monkeypatch.setattr(
-        sidecar_registry_module,
+        delivery_transport_module,
         "_configured_delivery_service",
         lambda: service_config,
     )
     monkeypatch.setattr(
-        sidecar_registry_module,
+        delivery_transport_module,
         "_delivery_sidecar_service",
         FakeDeliveryService(),
     )

--- a/backend/tests/test_whatsapp_sidecar_registry.py
+++ b/backend/tests/test_whatsapp_sidecar_registry.py
@@ -5,7 +5,9 @@ from uuid import UUID
 
 import pytest
 
+import app.services.whatsapp_delivery_transport as delivery_transport_module
 import app.services.whatsapp_sidecar_registry as sidecar_registry_module
+from app.services.whatsapp_delivery_transport import resolve_whatsapp_delivery_transport
 from app.services.whatsapp_native_transport import (
     WhatsAppBaileysSidecarConfig,
     WhatsAppProviderMessageEvent,
@@ -16,13 +18,10 @@ from app.services.whatsapp_provider_bridge import (
 )
 from app.services.whatsapp_sidecar_registry import (
     ConfiguredWhatsAppSidecarRegistry,
-    resolve_whatsapp_delivery_transport,
 )
 
 
 class _FakeSidecarClient:
-    transport_mode = "sidecar"
-
     def __init__(self, config: WhatsAppBaileysSidecarConfig) -> None:
         self.config = config
         self.connected = False
@@ -115,12 +114,12 @@ def test_delivery_transport_resolves_custom_session(
             return client
 
     monkeypatch.setattr(
-        sidecar_registry_module,
+        delivery_transport_module,
         "_configured_delivery_service",
         lambda: service_config,
     )
     monkeypatch.setattr(
-        sidecar_registry_module,
+        delivery_transport_module,
         "_delivery_sidecar_service",
         FakeDeliveryService(),
     )

--- a/backend/tests/whatsapp_helpers.py
+++ b/backend/tests/whatsapp_helpers.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import hashlib
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from pydantic import JsonValue
+
+from app.services.whatsapp_baileys import SenderKeyRecordSnapshot, WhatsAppAuthCert, buffer_json
+
+
+def serialize_whatsapp_auth_cert(cert: WhatsAppAuthCert) -> dict[str, JsonValue]:
+    return {
+        "SERIAL": cert.serial,
+        "ISSUER": cert.issuer,
+        "PUBLIC_KEY": buffer_json(cert.root_public_key),
+    }
+
+
+def encrypt_whatsapp_group_message_for_sender_key(
+    *,
+    axolotl_bytes: bytes,
+    plaintext: bytes,
+) -> bytes:
+    record: SenderKeyRecordSnapshot = {
+        "version": 1,
+        "key": hashlib.sha256(axolotl_bytes).digest(),
+        "iteration": 0,
+    }
+    return _encrypt_sender_key_record(record, plaintext)
+
+
+def _encrypt_sender_key_record(record: SenderKeyRecordSnapshot, plaintext: bytes) -> bytes:
+    iteration = record["iteration"]
+    nonce = _record_nonce(b"sender-key", iteration)
+    return nonce + AESGCM(record["key"]).encrypt(nonce, plaintext, None)
+
+
+def _record_nonce(prefix: bytes, counter: int) -> bytes:
+    return hashlib.sha256(prefix + counter.to_bytes(8, "big")).digest()[:12]

--- a/packages/whatsapp-baileys-sidecar/src/audited-version.ts
+++ b/packages/whatsapp-baileys-sidecar/src/audited-version.ts
@@ -1,10 +1,10 @@
 import type { WAVersion } from "baileys";
 
 export const AUDITED_BAILEYS_RELEASE = "7.0.0-rc14";
-export const AUDITED_BAILEYS_PACKAGE = "@whiskeysockets/baileys";
-export const AUDITED_BAILEYS_SOURCE_COMMIT = "7e7b0757e3f9f3c7789fb1cfd2f241d5002a199a";
+const AUDITED_BAILEYS_PACKAGE = "@whiskeysockets/baileys";
+const AUDITED_BAILEYS_SOURCE_COMMIT = "7e7b0757e3f9f3c7789fb1cfd2f241d5002a199a";
 export const AUDITED_WHATSAPP_WEB_VERSION_TEXT = "2.3000.1043857760";
-export const AUDITED_WHATSAPP_WEB_VERSION = [2, 3000, 1_043_857_760] as const satisfies WAVersion;
+const AUDITED_WHATSAPP_WEB_VERSION = [2, 3000, 1_043_857_760] as const satisfies WAVersion;
 
 export const AUDITED_PROVIDER_RELEASE = {
 	packageName: AUDITED_BAILEYS_PACKAGE,

--- a/packages/whatsapp-baileys-sidecar/src/json-bytes.ts
+++ b/packages/whatsapp-baileys-sidecar/src/json-bytes.ts
@@ -1,8 +1,8 @@
 import type { BinaryNode } from "baileys";
 
-export const BYTE_SENTINEL = "base64-bytes";
+const BYTE_SENTINEL = "base64-bytes";
 
-export type JsonValue =
+type JsonValue =
 	| null
 	| boolean
 	| number

--- a/packages/whatsapp-baileys-sidecar/src/server.ts
+++ b/packages/whatsapp-baileys-sidecar/src/server.ts
@@ -16,7 +16,7 @@ import {
 	RuntimeNotConnectedError,
 } from "./types.js";
 
-export type ServerConfig = {
+type ServerConfig = {
 	apiToken: string;
 	maxBodyBytes?: number;
 };

--- a/packages/whatsapp-baileys-sidecar/src/session-supervisor.ts
+++ b/packages/whatsapp-baileys-sidecar/src/session-supervisor.ts
@@ -10,7 +10,7 @@ import { type BaileysRuntime, SIDECAR_CAPABILITIES, type SidecarCapabilities } f
 const SESSION_ID_PATTERN =
 	/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
-export type SessionRuntimeFactory = (
+type SessionRuntimeFactory = (
 	config: SidecarSessionConfig,
 	dependencies?: BaileysRuntimeDependencies,
 ) => BaileysRuntime;
@@ -88,7 +88,7 @@ export class BaileysSessionSupervisor {
 	}
 }
 
-export function assertSessionId(value: string): void {
+function assertSessionId(value: string): void {
 	if (!SESSION_ID_PATTERN.test(value)) {
 		throw new InvalidSessionIdError();
 	}

--- a/packages/whatsapp-baileys-sidecar/src/sqlite-state.ts
+++ b/packages/whatsapp-baileys-sidecar/src/sqlite-state.ts
@@ -33,7 +33,7 @@ export type ProviderMessageEvent = {
 
 export type ProviderMessageEventInput = Omit<ProviderMessageEvent, "sequence">;
 
-export type ProviderInboxConfig = {
+type ProviderInboxConfig = {
 	maxEvents: number;
 	maxBytes: number;
 };
@@ -1173,9 +1173,3 @@ function secureStateFiles(sessionDir: string): void {
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
-
-export const AUDITED_PROVIDER_STATE_METADATA = {
-	schemaVersion: STATE_SCHEMA_VERSION,
-	baileysRelease: AUDITED_BAILEYS_RELEASE,
-	whatsappWebVersion: AUDITED_WHATSAPP_WEB_VERSION_TEXT,
-} as const;


### PR DESCRIPTION
## Summary

- delete the caller-free `find_whatsapp_binding_by_jids` and `run_channel_delivery_once` wrappers after checking `backend/app`, `backend/tests`, and the managed WhatsApp native e2e fixture
- remove the pre-sidecar `in_process` transport vestige and constant-fold capabilities guaranteed by the registered transport protocol
- move the #986 delivery resolver into a dependency-neutral module so the provider bridge can import it at module scope
- move two test-only Baileys helpers out of production code and narrow unused sidecar package exports
- complete a definition-only closure sweep across the WhatsApp service modules and sidecar micro-cleanup

## Behavior

No delivery behavior changes. The #986 resolver logic is preserved exactly:

- managed accounts resolve with `account.id`
- custom accounts resolve with `sidecar_account_id`
- missing configuration and unsupported connection modes still return no transport
- `sidecar_config_revision` still fails closed on mismatch
- the delivery sidecar service remains lazily cached

The test-only sender-key helper moved with its complete private encryption closure, so no production private API was widened.

## Native transport consumers

I searched `apps/web`, backend routes/tests, API schemas, shared types, and the managed WhatsApp e2e fixture.

- the web dashboard reads `mode` and `supportsOutboundMessages`, so both keys remain; registered transports now emit `sidecar` and `true` directly
- no product or schema consumer reads `supportsRawRelay` or `supportsIqQueries`; only exact-shape backend tests referenced them, so those keys were removed
- the obsolete web-only `in_process` label branch was removed with the backend mode

## Verification

- backend WhatsApp, channel debug/worker/delivery, and admin WhatsApp tests: `188 passed, 6 skipped`
- sidecar tests: `72 passed`
- CLI WhatsApp egress contract: `5 passed`
- web channel detail tests: `5 passed`
- `bun run typecheck`
- `bun run check`
- web OSS build
- sidecar typecheck and build
- backend Ruff lint and focused format checks
- backend production type governance: 187 files, 0 diagnostics
- backend compileall
- `git diff --check`

The six skips are the existing real-Baileys smoke tests that require explicit external opt-in and an audited authCert seam.