### PR TITLE
fix(whatsapp): derive durable provider payload targets

### DIFF
--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -7158,6 +7158,7 @@ def _delivery_error_code(error: str) -> str:
         "telegram api rejected message": DELIVERY_ERROR_PROVIDER_REJECTED,
         "discord api rejected message": DELIVERY_ERROR_PROVIDER_REJECTED,
         "whatsapp provider transport rejected message": DELIVERY_ERROR_PROVIDER_REJECTED,
+        "whatsapp provider payload target mismatch": DELIVERY_ERROR_PROVIDER_REJECTED,
         "channel delivery failed": DELIVERY_ERROR_FAILED,
         hosted_agent_provider_link_limit_detail(
             CHANNEL_PROVIDER_TELEGRAM,

--- a/backend/app/services/whatsapp_provider_bridge.py
+++ b/backend/app/services/whatsapp_provider_bridge.py
@@ -43,6 +43,7 @@ from app.services.whatsapp_baileys import (
     forward_iq_over,
     parse_whatsapp_jid,
     parse_whatsapp_usync_device_targets,
+    relay_outbound_extra_attrs,
     remember_whatsapp_binding_aliases,
     resolve_whatsapp_binding_by_jids,
     strip_whatsapp_device,
@@ -585,12 +586,15 @@ async def _active_link_owns_account(
 def _provider_payload_from_outbound(
     message: WhatsAppOutboundMessage,
 ) -> dict[str, JsonValue]:
+    attrs: dict[str, JsonValue] = {
+        key: value for key, value in relay_outbound_extra_attrs(message.attrs).items()
+    }
     payload: dict[str, JsonValue] = {
         "schemaVersion": WHATSAPP_PROVIDER_PAYLOAD_SCHEMA,
         "messageId": message.message_id,
         "messageProtoBase64": base64.b64encode(message.message_proto).decode("ascii"),
         "encType": message.enc_type,
-        "attrs": dict(message.attrs),
+        "attrs": attrs,
     }
     additional_nodes = validate_relay_outbound_additional_nodes(message.additional_nodes)
     if additional_nodes:

--- a/backend/tests/test_whatsapp_provider_bridge.py
+++ b/backend/tests/test_whatsapp_provider_bridge.py
@@ -33,6 +33,7 @@ from app.models.channel import (
 )
 from app.services.channel_delivery_worker import ChannelDeliveryWorker
 from app.services.channels import (
+    _delivery_error_code,
     archive_bot_agent_link,
     build_channel_account,
     channel_control_help_reply,
@@ -248,18 +249,25 @@ async def test_whatsapp_provider_bridge_queues_exact_proto_before_physical_deliv
         "connection_mode": "baileys_managed",
         "sidecar_config_revision": sidecar_config.binding_revision,
     }
+    lid_jid = "184207372460253@lid"
+    await remember_whatsapp_binding_aliases(
+        db_session,
+        binding=binding,
+        remote_jid=binding.external_chat_id,
+        alt_jid=lid_jid,
+    )
     await db_session.commit()
     sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
     bridge = WhatsAppProviderBridge(sessionmaker, account_id=account.id)
     message_proto = b"\x32\x0c\x0a\x0aexact-edit"
     message = WhatsAppOutboundMessage(
-        to_jid=binding.external_chat_id,
+        to_jid=lid_jid,
         message_id="agent-exact-1",
         message_proto=message_proto,
         enc_type="msg",
         attrs={
             "id": "agent-exact-1",
-            "to": binding.external_chat_id,
+            "to": lid_jid,
             "edit": "8",
             "addressing_mode": "lid",
         },
@@ -342,16 +350,46 @@ async def test_whatsapp_provider_bridge_queues_exact_proto_before_physical_deliv
     assert stored is not None
     assert delivery is not None
     assert stored.direction == MESSAGE_DIRECTION_OUTBOUND
+    assert stored.external_chat_id == binding.external_chat_id
     assert stored.payload["providerPayload"] == {
         "schemaVersion": WHATSAPP_PROVIDER_PAYLOAD_SCHEMA,
         "messageId": "agent-exact-1",
         "messageProtoBase64": base64.b64encode(message_proto).decode("ascii"),
         "encType": "msg",
-        "attrs": message.attrs,
+        "attrs": {"edit": "8", "addressing_mode": "lid"},
         "additionalNodes": [{"tag": "meta", "attrs": {"polltype": "creation"}}],
     }
     assert stored.provider_message_id == "physical-agent-exact-1"
     assert delivery.status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_provider_payload_foreign_target_fails_with_safe_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account = ChannelAccount(id=uuid4())
+    external_chat_id = "15551114444@s.whatsapp.net"
+    provider_payload = {
+        "schemaVersion": WHATSAPP_PROVIDER_PAYLOAD_SCHEMA,
+        "messageId": "agent-foreign-target-1",
+        "messageProtoBase64": base64.b64encode(b"foreign target").decode("ascii"),
+        "encType": "msg",
+        "attrs": {"to": "15559999999@s.whatsapp.net"},
+    }
+    transport = _FakeProviderTransport()
+    _use_delivery_transport(monkeypatch, transport)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await relay_whatsapp_provider_payload(
+            account=account,
+            external_chat_id=external_chat_id,
+            text="must fail closed",
+            provider_payload=provider_payload,
+        )
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "whatsapp provider payload target mismatch"
+    assert _delivery_error_code(exc_info.value.detail) == "channel_provider_rejected"
+    assert transport.outbound_messages == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- persist only relay-safe extra WhatsApp stanza attributes in durable `providerPayload.attrs`
- continue deriving managed `to` and `id` attributes from the canonical `external_chat_id` and `messageId` at delivery
- classify future payload target mismatches as `channel_provider_rejected` while preserving the existing fail-closed 403 guard

## Production evidence and root cause

After #986 made the physical delivery transport resolvable, two production deliveries reached provider payload validation and failed immediately with `whatsapp provider payload target mismatch`. The durable channel message used the binding canonical PN chat id, while the stored Hermes stanza `attrs.to` retained the LID alias used for enqueue resolution. String equality therefore rejected a valid alias-resolved delivery before relay.

`attrs.to` and `attrs.id` are circular durable fields: delivery already overwrites them from `external_chat_id` and `messageId`, and the relay boundary strips managed attributes before sending sidecar `additionalAttributes`. Persisting only `relay_outbound_extra_attrs` removes that stale alias comparison while retaining wire-relevant attributes such as `edit` and `addressing_mode`. The existing mismatch guard remains unchanged and still rejects foreign durable payloads that explicitly carry a different `to`.

This change intentionally does not backfill, migrate, retry, or replay already-terminal deliveries.

## Verification

- `scripts/test.sh backend tests/test_whatsapp_baileys.py tests/test_whatsapp_baileys_smoke.py tests/test_whatsapp_custom_onboarding.py tests/test_whatsapp_managed_onboarding.py tests/test_whatsapp_native_transport.py tests/test_whatsapp_noise.py tests/test_whatsapp_provider_bridge.py tests/test_whatsapp_sidecar_registry.py` (`162 passed, 6 skipped`)
- focused LID enqueue / PN sidecar relay regression and foreign-target guard regression (`2 passed`)
- channel delivery behavior tests (`9 passed`)
- `uv run ruff check .`
- `uv run python -m compileall app scripts tests alembic`
- backend dependency authority and outbound API governance checks
- backend type governance: owned, strict, and exceptions

`uv run ruff format --check .` is blocked by a pre-existing format difference in `backend/tests/test_projects_routes.py`; all three files changed by this PR pass Ruff format checks.

Production round-trip verification is pending.