### PR TITLE
feat(web): unify compute subscription cards

### DIFF
--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -9,6 +9,7 @@ import {
 	gotoHostedSettingsDialog,
 	paidBasicDeployment,
 	performancePlan,
+	sharedLegacyCloudAgent,
 	stubHostedApi,
 	terminalFallbackDeployment,
 } from "./hosted-stub-api";
@@ -18,6 +19,47 @@ type ReusableSubscription = DeployComponents["schemas"]["V2ComputeReusableSubscr
 
 const longAgentName =
 	"Production research agent with an intentionally long name for compact subscription layouts";
+const testAvatarUrl =
+	"data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Crect%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22%230f766e%22%2F%3E%3C%2Fsvg%3E";
+
+const activeEnvironmentId = "11111111-1111-4111-8111-111111111111";
+const cancelingEnvironmentId = "22222222-2222-4222-8222-222222222222";
+const paidEnvironmentId = "33333333-3333-4333-8333-333333333333";
+const accountActiveDeployment = {
+	...paidBasicDeployment,
+	id: "hdep_active",
+	name: "Account active deployment",
+	config_info: {
+		...paidBasicDeployment.config_info,
+		clawdi_cloud_environments: { hermes: activeEnvironmentId },
+	},
+};
+const accountCancelingDeployment = {
+	...cancelPendingBasicDeployment,
+	id: "hdep_canceling",
+	name: "Account canceling deployment",
+	config_info: {
+		...cancelPendingBasicDeployment.config_info,
+		clawdi_cloud_environments: { hermes: cancelingEnvironmentId },
+	},
+};
+const accountCloudAgents = [
+	{
+		...sharedLegacyCloudAgent,
+		id: activeEnvironmentId,
+		name: "account-active",
+		default_name: "Account active",
+		display_name: longAgentName,
+		avatar_url: testAvatarUrl,
+	},
+	{
+		...sharedLegacyCloudAgent,
+		id: cancelingEnvironmentId,
+		name: "account-canceling",
+		default_name: "Canceling agent",
+		display_name: null,
+	},
+];
 
 function subscription(
 	subscriptionId: string,
@@ -51,11 +93,17 @@ async function expectCardsFit(container: Locator) {
 					'[data-slot="compute-subscription-actions"]',
 				);
 				const actionBox = action?.getBoundingClientRect();
+				const actionItemBoxes = Array.from(
+					card.querySelectorAll<HTMLElement>(
+						'[data-slot="compute-subscription-actions"] button, [data-slot="compute-subscription-actions"] a',
+					),
+				).map((item) => item.getBoundingClientRect().toJSON());
 				return {
 					clientWidth: card.clientWidth,
 					scrollWidth: card.scrollWidth,
 					box: box.toJSON(),
 					actionBox: actionBox?.toJSON() ?? null,
+					actionItemBoxes,
 					detailCount: card.querySelectorAll("dl > div").length,
 				};
 			}),
@@ -71,8 +119,36 @@ async function expectCardsFit(container: Locator) {
 				metric.box.x + metric.box.width + 1,
 			);
 			expect(metric.actionBox.y).toBeGreaterThanOrEqual(metric.box.y - 1);
+			for (const itemBox of metric.actionItemBoxes) {
+				expect(itemBox.x).toBeGreaterThanOrEqual(metric.actionBox.x - 1);
+				expect(itemBox.x + itemBox.width).toBeLessThanOrEqual(
+					metric.actionBox.x + metric.actionBox.width + 1,
+				);
+			}
+			for (let index = 1; index < metric.actionItemBoxes.length; index += 1) {
+				const previous = metric.actionItemBoxes[index - 1];
+				const current = metric.actionItemBoxes[index];
+				if (!previous || !current) continue;
+				const overlapWidth =
+					Math.min(previous.right, current.right) - Math.max(previous.left, current.left);
+				const overlapHeight =
+					Math.min(previous.bottom, current.bottom) - Math.max(previous.top, current.top);
+				expect(overlapWidth <= 0 || overlapHeight <= 0).toBe(true);
+			}
 		}
 	}
+}
+
+async function expectFactLabels(card: Locator) {
+	await expect(card.locator("dt")).toHaveText(["Plan", "Payment", "Price", "Schedule"]);
+}
+
+async function expectNoHorizontalOverflow(page: Page) {
+	const metrics = await page.evaluate(() => ({
+		clientWidth: document.documentElement.clientWidth,
+		scrollWidth: document.documentElement.scrollWidth,
+	}));
+	expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth);
 }
 
 async function openSubscriptions(page: Page) {
@@ -130,6 +206,8 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await page.setViewportSize({ width: 1440, height: 900 });
 	const errors = collectBrowserErrors(page);
 	await stubHostedApi(page, {
+		deployments: [accountActiveDeployment, accountCancelingDeployment],
+		cloudAgents: accountCloudAgents,
 		subscriptionPages: {
 			initial: {
 				items: [],
@@ -140,6 +218,9 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 				items: [
 					subscription("ended_first", "canceled", {
 						current_period_end: "2025-08-12T12:00:00Z",
+						agent_name: "Former deleted agent",
+						deployment_id: null,
+						is_orphan: true,
 					}),
 				],
 				has_more: true,
@@ -181,17 +262,53 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(dialog.getByText("Active", { exact: true })).toBeVisible();
 	await expect(dialog.getByText("Canceling", { exact: true })).toBeVisible();
 	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(2);
-	await expect(dialog.getByRole("button", { name: "Cancel", exact: true })).toBeVisible();
-	await expect(dialog.getByRole("button", { name: "Resume", exact: true })).toBeVisible();
+	const accountManage = dialog.getByRole("button", { name: "Manage", exact: true }).first();
+	await expect(accountManage).toHaveAttribute(
+		"href",
+		/\/agents\/hdep_active\/settings.*settings=billing-plan/,
+	);
+	await expect(accountManage.locator("svg.lucide-settings")).toHaveCount(1);
+	await expect(dialog.getByRole("button", { name: "Cancel subscription" })).toBeVisible();
+	await expect(dialog.getByRole("button", { name: "Resume subscription" })).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Show history (2)" })).toBeVisible();
 	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(2);
+	const currentCards = dialog.locator('[data-slot="compute-subscription-card"]');
+	const activeCard = currentCards.nth(0);
+	await expect(activeCard.locator("h4")).toHaveText(`${longAgentName}: Performance compute`);
+	await expect(activeCard.getByText(longAgentName, { exact: true })).toBeVisible();
+	await expect(activeCard.locator("img")).toHaveCount(1);
+	await expectFactLabels(activeCard);
+	const currentStatuses = await currentCards.evaluateAll((cards) =>
+		cards.map((card) => card.getAttribute("data-subscription-status")),
+	);
+	expect(currentStatuses).toEqual(["active", "canceling"]);
+	const desktopCardBoxes = await currentCards.evaluateAll((cards) =>
+		cards.map((card) => card.getBoundingClientRect().toJSON()),
+	);
+	expect(
+		Math.abs((desktopCardBoxes[0]?.y ?? 0) - (desktopCardBoxes[1]?.y ?? 1)),
+	).toBeLessThanOrEqual(1);
+	expect(Math.abs((desktopCardBoxes[0]?.x ?? 0) - (desktopCardBoxes[1]?.x ?? 0))).toBeGreaterThan(
+		100,
+	);
 	await expectCardsFit(dialog);
 
 	await dialog.getByRole("button", { name: "Show history (2)" }).click();
 	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(4);
 	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(4);
 	await expect(dialog.getByText("Canceled", { exact: true })).toHaveCount(2);
-	await expect(dialog.getByText("ended_first", { exact: true })).toBeVisible();
+	const visibleStatuses = await dialog
+		.locator('[data-slot="compute-subscription-card"]')
+		.evaluateAll((cards) => cards.map((card) => card.getAttribute("data-subscription-status")));
+	expect(visibleStatuses).toEqual(["active", "canceling", "canceled", "canceled"]);
+	const orphanCard = dialog
+		.locator('[data-slot="compute-subscription-card"]')
+		.filter({ hasText: "Deleted agent" });
+	await expect(orphanCard).toBeVisible();
+	await expect(orphanCard.getByText("Orphaned", { exact: true })).toBeVisible();
+	await expect(orphanCard.getByText("Former deleted agent", { exact: true })).toHaveCount(0);
+	await expect(orphanCard.getByText("Unknown", { exact: true })).toHaveCount(0);
+	await expect(orphanCard.getByText("No linked agent", { exact: true })).toHaveCount(0);
 	await expect(dialog.getByText("ended_second", { exact: true })).toBeVisible();
 	await expectCardsFit(dialog);
 
@@ -202,6 +319,11 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await page.setViewportSize({ width: 320, height: 568 });
 	await expect(dialog).toBeVisible();
 	await expectCardsFit(dialog);
+	await expectNoHorizontalOverflow(page);
+	const mobileCardBoxes = await dialog
+		.locator('[data-slot="compute-subscription-card"]')
+		.evaluateAll((cards) => cards.map((card) => card.getBoundingClientRect().toJSON()));
+	expect(mobileCardBoxes[1]?.y ?? 0).toBeGreaterThan(mobileCardBoxes[0]?.bottom ?? 0);
 	const longAgentStyle = await dialog
 		.getByText(longAgentName, { exact: true })
 		.evaluate((agent) => {
@@ -229,8 +351,18 @@ test("agent settings uses the subscription card without changing plan actions", 
 	await page.setViewportSize({ width: 1440, height: 900 });
 	const errors = collectBrowserErrors(page);
 	await stubHostedApi(page, {
+		cloudAgentOverrides: {
+			display_name: "Paid research agent",
+			avatar_url: testAvatarUrl,
+		},
 		deployments: [
-			paidBasicDeployment,
+			{
+				...paidBasicDeployment,
+				config_info: {
+					...paidBasicDeployment.config_info,
+					clawdi_cloud_environments: { hermes: paidEnvironmentId },
+				},
+			},
 			cancelPendingBasicDeployment,
 			{
 				...paidBasicDeployment,
@@ -255,7 +387,7 @@ test("agent settings uses the subscription card without changing plan actions", 
 		plans: [basicPlan, performancePlan],
 	});
 
-	await gotoHostedAgentSettings(page, "hdep_paid", "Basic");
+	await gotoHostedAgentSettings(page, paidEnvironmentId, "Basic", "?source=on-clawdi&d=hdep_paid");
 	const activeCard = page
 		.locator('[data-slot="compute-subscription-card"]')
 		.filter({ hasText: "Basic compute" });
@@ -265,14 +397,22 @@ test("agent settings uses the subscription card without changing plan actions", 
 		"success",
 	);
 	await expect(activeCard.locator("dl > div")).toHaveCount(4);
-	await expect(
-		activeCard.getByRole("button", { name: "Change plan, term, or payment source" }),
-	).toBeVisible();
+	await expect(activeCard.locator("h3")).toHaveText("Paid research agent: Basic compute");
+	await expect(activeCard.getByText("Paid research agent", { exact: true })).toBeVisible();
+	await expect(activeCard.locator("img")).toHaveCount(1);
+	await expectFactLabels(activeCard);
+	const agentManage = activeCard.getByRole("button", { name: "Manage", exact: true });
+	await expect(agentManage).toBeVisible();
+	await expect(agentManage.locator("svg.lucide-settings")).toHaveCount(1);
 	await expect(activeCard.getByRole("button", { name: "Cancel subscription" })).toBeVisible();
+	const activeCardWidth = await activeCard.evaluate((card) => card.getBoundingClientRect().width);
+	expect(activeCardWidth).toBeLessThanOrEqual(672);
 	await expectCardsFit(page.locator("body"));
 
 	await page.setViewportSize({ width: 320, height: 568 });
 	await expectCardsFit(page.locator("body"));
+	await expectNoHorizontalOverflow(page);
+	await expect(activeCard.getByRole("button", { name: "Manage", exact: true })).toBeVisible();
 	await expect(activeCard.getByRole("button", { name: "Cancel subscription" })).toBeVisible();
 
 	await gotoHostedAgentSettings(page, "hdep_cancel_pending", "Basic");
@@ -284,6 +424,8 @@ test("agent settings uses the subscription card without changing plan actions", 
 		"warning",
 	);
 	await expect(cancelingCard.locator("dl > div")).toHaveCount(4);
+	await expectFactLabels(cancelingCard);
+	await expect(cancelingCard.getByRole("button", { name: "Manage", exact: true })).toBeDisabled();
 	await expect(cancelingCard.getByRole("button", { name: "Resume subscription" })).toBeVisible();
 	await expectCardsFit(page.locator("body"));
 
@@ -295,9 +437,7 @@ test("agent settings uses the subscription card without changing plan actions", 
 		"data-status",
 		"destructive",
 	);
-	await expect(
-		pastDueCard.getByRole("button", { name: "Change plan, term, or payment source" }),
-	).toBeVisible();
+	await expect(pastDueCard.getByRole("button", { name: "Manage", exact: true })).toBeVisible();
 	await expectCardsFit(page.locator("body"));
 
 	await gotoHostedAgentSettings(page, "hdep_card_action_required", "Basic");
@@ -308,7 +448,7 @@ test("agent settings uses the subscription card without changing plan actions", 
 		actionRequiredCard.getByText("Payment action required", { exact: true }),
 	).toHaveAttribute("data-status", "warning");
 	await expect(
-		actionRequiredCard.getByRole("button", { name: "Change plan, term, or payment source" }),
+		actionRequiredCard.getByRole("button", { name: "Manage", exact: true }),
 	).toBeVisible();
 	await expectCardsFit(page.locator("body"));
 
@@ -320,7 +460,8 @@ test("agent settings uses the subscription card without changing plan actions", 
 		"data-status",
 		"success",
 	);
-	await expect(fallbackCard.getByText("Funding", { exact: true })).toBeVisible();
+	await expectFactLabels(fallbackCard);
+	await expect(fallbackCard.getByText("Payment", { exact: true })).toBeVisible();
 	await expect(fallbackCard.getByText("Included", { exact: true })).toBeVisible();
 	await expect(fallbackCard.getByRole("button", { name: "Choose a subscription" })).toBeVisible();
 	expect(errors, `agent subscription cards: ${errors.join(" | ")}`).toEqual([]);

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -355,7 +355,7 @@ function SettingsPanel({
 		case "billing-plan":
 			return SubscriptionPage ? (
 				<Suspense fallback={<HostedRouteSkeleton />}>
-					<SubscriptionPage />
+					<SubscriptionPage agentTiles={agentTiles} />
 				</Suspense>
 			) : (
 				<GeneralPanel />

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -164,7 +164,6 @@ import {
 	PlanChangePendingError,
 	PlanChangeTerminalError,
 } from "@/hosted/billing/errors";
-import { billingTermLabel, billingTermSuffix, formatCents } from "@/hosted/billing/format";
 import {
 	billingKeys,
 	useCancelSubscription,
@@ -176,7 +175,10 @@ import {
 	useResumeSubscription,
 } from "@/hosted/billing/hooks";
 import { useSensitiveBillingPortal } from "@/hosted/billing/sensitive-actions";
-import { ComputeSubscriptionCard } from "@/hosted/billing/subscription/compute-subscription-card";
+import {
+	ComputeSubscriptionCard,
+	computeSubscriptionCardView,
+} from "@/hosted/billing/subscription/compute-subscription-card";
 import {
 	activePlanChangeOperationName,
 	isCombinedPaidPlanChange,
@@ -706,7 +708,7 @@ export function HostedAgentDetail({
 						<HostedAgentSettingsTab
 							environmentId={environmentId}
 							deployment={deployment}
-							projectionAvailable={projection.status === "resolved"}
+							agent={agent}
 							onDeleteAccepted={onDeleteAccepted}
 						/>
 					) : null}
@@ -3428,24 +3430,28 @@ function LinkedChannelRow({
 function HostedAgentSettingsTab({
 	environmentId,
 	deployment,
-	projectionAvailable,
+	agent,
 	onDeleteAccepted,
 }: {
 	environmentId: string;
 	deployment: HostedDeployment;
-	projectionAvailable: boolean;
+	agent: components["schemas"]["AgentResponse"] | null;
 	onDeleteAccepted: (deploymentId: string) => Promise<void> | void;
 }) {
 	return (
 		<UnsavedNavigationBoundary description="Your agent settings will return to the last values saved on the server.">
 			<div className="flex flex-col gap-8">
-				{projectionAvailable ? (
+				{agent ? (
 					<AgentSettingsPanel environmentId={environmentId} />
 				) : (
 					<ProjectionDependentUnavailable label="Profile settings" />
 				)}
 				<LanguageTimezoneSettingsSection deployment={deployment} />
-				<ComputeSettingsSections deployment={deployment} onDeleteAccepted={onDeleteAccepted} />
+				<ComputeSettingsSections
+					deployment={deployment}
+					agent={agent}
+					onDeleteAccepted={onDeleteAccepted}
+				/>
 			</div>
 		</UnsavedNavigationBoundary>
 	);
@@ -3542,9 +3548,11 @@ function LanguageTimezoneSettingsSection({ deployment }: { deployment: HostedDep
 
 function ComputeSettingsSections({
 	deployment,
+	agent,
 	onDeleteAccepted,
 }: {
 	deployment: HostedDeployment;
+	agent: components["schemas"]["AgentResponse"] | null;
 	onDeleteAccepted: (deploymentId: string) => Promise<void> | void;
 }) {
 	const router = useRouter();
@@ -3683,7 +3691,6 @@ function ComputeSettingsSections({
 	const subscriptionLifecycle = currentSubscription
 		? computeSubscriptionLifecycle(currentSubscription)
 		: null;
-	const subscriptionLifecycleDateLabel = formatShortDate(subscriptionLifecycle?.dateAt);
 	const currentSubscriptionStatus = currentSubscription?.status.toLowerCase();
 	const computePlanStatusTone: StatusTone =
 		currentSubscriptionStatus === "past_due" ||
@@ -3702,22 +3709,52 @@ function ComputeSettingsSections({
 					? "success"
 					: "neutral";
 	const computePlanStatusLabel =
-		!isPaidCompute || !subscriptionLifecycle
-			? "Current"
-			: currentSubscriptionStatus === "past_due" ||
-					currentSubscription?.payment_state === "past_due"
-				? "Past due"
-				: currentSubscriptionStatus === "unpaid" || currentSubscription?.payment_state === "unpaid"
-					? "Unpaid"
-					: currentSubscription?.payment_state === "requires_action"
-						? "Payment action required"
-						: currentSubscriptionStatus === "canceling" || subscriptionCancelPending
-							? "Canceling"
-							: subscriptionLifecycle.badgeLabel;
+		fundingMode === "unknown"
+			? "Unavailable"
+			: !isPaidCompute || !subscriptionLifecycle
+				? "Current"
+				: currentSubscriptionStatus === "past_due" ||
+						currentSubscription?.payment_state === "past_due"
+					? "Past due"
+					: currentSubscriptionStatus === "unpaid" ||
+							currentSubscription?.payment_state === "unpaid"
+						? "Unpaid"
+						: currentSubscription?.payment_state === "requires_action"
+							? "Payment action required"
+							: currentSubscriptionStatus === "canceling" || subscriptionCancelPending
+								? "Canceling"
+								: subscriptionLifecycle.badgeLabel;
 	const computePlanStatus = {
 		label: computePlanStatusLabel,
 		tone: computePlanStatusTone,
 	};
+	const computeCardView = computeSubscriptionCardView({
+		identity: {
+			kind: "agent",
+			name: agent
+				? agentDisplayName(agent)
+				: agentDisplayName({
+						default_name: deployment.resource.name,
+						agent_type: deployment.resource.spec.runtime,
+					}),
+			agentType: deployment.resource.spec.runtime,
+			avatarUrl: agent?.avatar_url,
+		},
+		status: computePlanStatus,
+		planSlug: computePlanSlug ?? rawComputePlanSlug,
+		fundingSource: isIncludedBasic
+			? "included"
+			: currentSubscription?.funding_source === "wallet"
+				? "wallet"
+				: currentSubscription
+					? "stripe"
+					: "unavailable",
+		priceCents: currentPriceCents,
+		currency: currentSubscription?.currency ?? "usd",
+		billingTermMonths: currentBillingTerm,
+		scheduleVerb: subscriptionLifecycle?.dateVerb ?? null,
+		scheduleAt: subscriptionLifecycle?.dateAt,
+	});
 	const pendingPlanCopy = pendingPlanSlug
 		? pendingPlanScheduleCopy(
 				pendingPlanSlug,
@@ -4062,49 +4099,14 @@ function ComputeSettingsSections({
 			<SettingsSection title="Compute plan" description="Compute resources for this hosted agent.">
 				<ComputeSubscriptionCard
 					headingLevel={3}
-					title={
-						<span className="flex min-w-0 items-center gap-1.5">
-							{tierLabel === "Performance" ? (
-								<Zap className="size-4 shrink-0" />
-							) : (
-								<Cpu className="size-4 shrink-0" />
-							)}
-							<span>{tierLabel} compute</span>
-						</span>
-					}
-					status={computePlanStatus}
-					description="Basic includes one free active slot per user. Paid Basic and Performance each use one subscription per agent."
+					view={computeCardView}
+					className="max-w-2xl"
 					badges={
 						hasWalletFallback ? (
 							<Badge variant="outline" className="font-normal text-muted-foreground">
 								Wallet fallback
 							</Badge>
 						) : null
-					}
-					details={
-						isPaidCompute && currentSubscription
-							? [
-									{ label: "Payment", value: isWalletFunded ? "Wallet" : "Card" },
-									{ label: "Term", value: billingTermLabel(currentBillingTerm) },
-									{
-										label: "Price",
-										value:
-											currentPriceCents === null
-												? "Unavailable"
-												: `${formatCents(currentPriceCents)}${billingTermSuffix(currentBillingTerm)}`,
-									},
-									{
-										label: "Schedule",
-										value:
-											subscriptionLifecycle?.dateVerb && subscriptionLifecycle.dateAt
-												? `${subscriptionLifecycle.dateVerb} ${subscriptionLifecycleDateLabel}`
-												: "Unavailable",
-									},
-								]
-							: [
-									{ label: "Funding", value: "Included" },
-									{ label: "Billing", value: "No subscription charge" },
-								]
 					}
 					notice={
 						pendingPlanCopy ? (
@@ -4115,7 +4117,7 @@ function ComputeSettingsSections({
 						hasTerminalFallback || isIncludedBasic || (isPaidCompute && currentSubscription) ? (
 							<div
 								id="compute-plan-controls"
-								className="flex w-full scroll-mt-6 flex-col gap-2 sm:ml-auto sm:w-auto sm:min-w-64 sm:items-end"
+								className="flex w-full scroll-mt-6 flex-wrap items-center justify-end gap-2"
 							>
 								{isIncludedBasic && blockingPlansError ? (
 									<div className="w-full sm:w-72">
@@ -4127,7 +4129,7 @@ function ComputeSettingsSections({
 										/>
 									</div>
 								) : hasTerminalFallback || isIncludedBasic ? (
-									<div className="flex w-full flex-col gap-2 sm:w-64">
+									<>
 										<Button
 											size="sm"
 											disabled={
@@ -4157,90 +4159,102 @@ function ComputeSettingsSections({
 										</Button>
 										{hasTerminalFallback ? (
 											canStartNewSubscription ? null : (
-												<p className="text-xs text-muted-foreground">{createUnavailableMessage}</p>
+												<p className="basis-full text-right text-xs text-muted-foreground">
+													{createUnavailableMessage}
+												</p>
 											)
 										) : canUpgrade ? null : (
-											<p className="text-xs text-muted-foreground">{upgradeUnavailableMessage}</p>
+											<p className="basis-full text-right text-xs text-muted-foreground">
+												{upgradeUnavailableMessage}
+											</p>
 										)}
-									</div>
+									</>
 								) : isPaidCompute && currentSubscription ? (
-									<div className="flex w-full flex-col gap-2 sm:w-72">
-										{subscriptionCancelPending ? (
-											<>
+									subscriptionCancelPending ? (
+										<>
+											<Button
+												type="button"
+												variant="outline"
+												size="sm"
+												disabled
+												title={planChangeUnavailable ?? undefined}
+											>
+												<Settings data-icon="inline-start" />
+												Manage
+											</Button>
+											<Button
+												type="button"
+												variant="outline"
+												size="sm"
+												disabled={resumeSubscription.isPending || !subscriptionCancelable}
+												onClick={() =>
+													void runAction(resumeComputeSubscription).catch(() => undefined)
+												}
+											>
+												{resumeSubscription.isPending ? (
+													<Spinner data-icon="inline-start" />
+												) : (
+													<RefreshCw data-icon="inline-start" />
+												)}
+												Resume subscription
+											</Button>
+											<p className="basis-full text-right text-xs text-muted-foreground">
+												{planChangeUnavailable}
+											</p>
+										</>
+									) : (
+										<>
+											<Button
+												type="button"
+												variant="outline"
+												size="sm"
+												disabled={
+													pendingPlanChangeName === null &&
+													(planChangeUnavailable !== null || !!pendingPlanSlug)
+												}
+												onClick={() => setPlanChangeDialogOpen(true)}
+											>
+												<Settings data-icon="inline-start" />
+												Manage
+											</Button>
+											<ConfirmAction
+												title={`Cancel ${tierLabel} subscription?`}
+												description={
+													<p>
+														Cancellation takes effect {subscriptionPeriodLabel}. The agent then
+														falls back to included Basic funding if available; otherwise, it stops.
+													</p>
+												}
+												confirmLabel="Cancel at period end"
+												destructive
+												onConfirm={() => runAction(cancelComputeSubscription)}
+											>
 												<Button
 													type="button"
 													variant="outline"
 													size="sm"
-													disabled={resumeSubscription.isPending || !subscriptionCancelable}
-													onClick={() =>
-														void runAction(resumeComputeSubscription).catch(() => undefined)
-													}
+													disabled={cancelSubscription.isPending || !subscriptionCancelable}
 												>
-													{resumeSubscription.isPending ? (
+													{cancelSubscription.isPending ? (
 														<Spinner data-icon="inline-start" />
 													) : (
-														<RefreshCw data-icon="inline-start" />
+														<Link2Off data-icon="inline-start" />
 													)}
-													Resume subscription
+													Cancel subscription
 												</Button>
-												<p className="text-xs text-muted-foreground">{planChangeUnavailable}</p>
-											</>
-										) : (
-											<>
-												<Button
-													type="button"
-													variant="outline"
-													size="sm"
-													disabled={
-														pendingPlanChangeName === null &&
-														(planChangeUnavailable !== null || !!pendingPlanSlug)
-													}
-													onClick={() => setPlanChangeDialogOpen(true)}
-												>
-													{pendingPlanChangeName
-														? "Check subscription change status"
-														: paymentSourceOnly
-															? "Change payment source"
-															: "Change plan, term, or payment source"}
-												</Button>
-												<ConfirmAction
-													title={`Cancel ${tierLabel} subscription?`}
-													description={
-														<p>
-															Cancellation takes effect {subscriptionPeriodLabel}. The agent then
-															falls back to included Basic funding if available; otherwise, it
-															stops.
-														</p>
-													}
-													confirmLabel="Cancel at period end"
-													destructive
-													onConfirm={() => runAction(cancelComputeSubscription)}
-												>
-													<Button
-														type="button"
-														variant="outline"
-														size="sm"
-														disabled={cancelSubscription.isPending || !subscriptionCancelable}
-													>
-														{cancelSubscription.isPending ? (
-															<Spinner data-icon="inline-start" />
-														) : (
-															<Link2Off data-icon="inline-start" />
-														)}
-														Cancel subscription
-													</Button>
-												</ConfirmAction>
-												{pendingPlanSlug ? (
-													<p className="text-xs text-muted-foreground">
-														A plan change is already scheduled. It will apply on the effective date
-														shown above.
-													</p>
-												) : planChangeUnavailable ? (
-													<p className="text-xs text-muted-foreground">{planChangeUnavailable}</p>
-												) : null}
-											</>
-										)}
-									</div>
+											</ConfirmAction>
+											{pendingPlanSlug ? (
+												<p className="basis-full text-right text-xs text-muted-foreground">
+													A plan change is already scheduled. It will apply on the effective date
+													shown above.
+												</p>
+											) : planChangeUnavailable ? (
+												<p className="basis-full text-right text-xs text-muted-foreground">
+													{planChangeUnavailable}
+												</p>
+											) : null}
+										</>
+									)
 								) : null}
 							</div>
 						) : null

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
@@ -1,80 +1,219 @@
+import { Link } from "@tanstack/react-router";
+import { UserRoundX } from "lucide-react";
 import type { ReactNode } from "react";
+import { AgentIcon } from "@/components/dashboard/agent-icon";
+import { AgentLabel } from "@/components/dashboard/agent-label";
 import { StatusBadge, type StatusTone } from "@/components/ui/status-badge";
+import { billingTermLabel, billingTermSuffix, formatCurrencyCents } from "@/hosted/billing/format";
+import { computeTierLabel } from "@/hosted/billing/subscription/subscription-utils";
+import { formatShortDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
-export type ComputeSubscriptionCardDetail = {
-	label: string;
-	value: ReactNode;
+export type ComputeSubscriptionIdentity =
+	| {
+			kind: "agent";
+			name: string;
+			agentType: string | null;
+			avatarUrl?: string | null;
+			href?: string;
+	  }
+	| { kind: "unavailable"; label: string };
+
+export type ComputeSubscriptionCardView = {
+	identity: ComputeSubscriptionIdentity;
+	status: { label: string; tone: StatusTone };
+	facts: readonly [
+		{ label: "Plan"; value: string },
+		{ label: "Payment"; value: string },
+		{ label: "Price"; value: string; meta: string },
+		{ label: "Schedule"; value: string },
+	];
 };
 
-export function ComputeSubscriptionCard({
-	title,
+export type ComputeSubscriptionPaymentSource = "included" | "stripe" | "wallet" | "unavailable";
+
+export function computeSubscriptionPlanLabel(planSlug: string): string {
+	if (planSlug === "compute_basic" || planSlug === "compute_performance") {
+		return `${computeTierLabel(planSlug)} compute`;
+	}
+	return planSlug.replace(/^compute_/, "").replaceAll("_", " ");
+}
+
+export function computeSubscriptionCardView({
+	identity,
 	status,
-	description,
+	planSlug,
+	fundingSource,
+	priceCents,
+	currency,
+	billingTermMonths,
+	scheduleVerb,
+	scheduleAt,
+}: {
+	identity: ComputeSubscriptionIdentity;
+	status: ComputeSubscriptionCardView["status"];
+	planSlug: string;
+	fundingSource: ComputeSubscriptionPaymentSource;
+	priceCents: number | null | undefined;
+	currency: string;
+	billingTermMonths: number;
+	scheduleVerb: string | null;
+	scheduleAt: string | null | undefined;
+}): ComputeSubscriptionCardView {
+	const included = fundingSource === "included";
+	return {
+		identity,
+		status,
+		facts: [
+			{ label: "Plan", value: computeSubscriptionPlanLabel(planSlug) },
+			{
+				label: "Payment",
+				value:
+					fundingSource === "included"
+						? "Included"
+						: fundingSource === "wallet"
+							? "Wallet"
+							: fundingSource === "stripe"
+								? "Card"
+								: "Unavailable",
+			},
+			{
+				label: "Price",
+				value:
+					included || priceCents === 0
+						? "No charge"
+						: priceCents == null
+							? "Unavailable"
+							: `${formatCurrencyCents(priceCents, currency)}${billingTermSuffix(billingTermMonths)}`,
+				meta: included ? "Included plan" : billingTermLabel(billingTermMonths),
+			},
+			{
+				label: "Schedule",
+				value:
+					scheduleVerb && scheduleAt
+						? `${scheduleVerb} ${formatShortDate(scheduleAt)}`
+						: included
+							? "Current"
+							: "Unavailable",
+			},
+		],
+	};
+}
+
+function SubscriptionIdentity({ identity }: { identity: ComputeSubscriptionIdentity }) {
+	if (identity.kind === "unavailable") {
+		return (
+			<div className="flex min-w-0 items-center gap-3 text-muted-foreground">
+				<span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-muted">
+					<UserRoundX className="size-3.5" aria-hidden />
+				</span>
+				<span className="truncate text-sm font-medium" title={identity.label}>
+					{identity.label}
+				</span>
+			</div>
+		);
+	}
+
+	const label = identity.agentType ? (
+		<AgentLabel
+			name={identity.name}
+			machineName={null}
+			type={identity.agentType}
+			avatarUrl={identity.avatarUrl}
+			size="md"
+			className={cn("min-w-0", identity.href && "transition-opacity hover:opacity-80")}
+		/>
+	) : (
+		<div className="flex min-w-0 items-center gap-3">
+			<AgentIcon agent={null} size="md" avatarUrl={identity.avatarUrl} />
+			<span className="truncate text-sm font-medium" title={identity.name}>
+				{identity.name}
+			</span>
+		</div>
+	);
+
+	return identity.href ? (
+		<Link
+			to={identity.href}
+			className="min-w-0 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+		>
+			{label}
+		</Link>
+	) : (
+		<div className="min-w-0">{label}</div>
+	);
+}
+
+export function ComputeSubscriptionCard({
+	view,
 	badges,
-	details,
 	notice,
 	actions,
 	headingLevel = 3,
 	className,
 }: {
-	title: ReactNode;
-	status: { label: string; tone: StatusTone };
-	description?: ReactNode;
+	view: ComputeSubscriptionCardView;
 	badges?: ReactNode;
-	details?: readonly ComputeSubscriptionCardDetail[];
 	notice?: ReactNode;
 	actions?: ReactNode;
 	headingLevel?: 3 | 4;
 	className?: string;
 }) {
 	const Heading = headingLevel === 4 ? "h4" : "h3";
+	const plan = view.facts[0];
+	const identityLabel = view.identity.kind === "agent" ? view.identity.name : view.identity.label;
 
 	return (
 		<article
 			data-hosted="true"
 			data-slot="compute-subscription-card"
-			className={cn("min-w-0 overflow-hidden rounded-lg border bg-card", className)}
+			data-subscription-status={view.status.label.toLowerCase().replaceAll(" ", "-")}
+			className={cn(
+				"flex h-full min-w-0 flex-col overflow-hidden rounded-lg border bg-card",
+				className,
+			)}
 		>
-			<header className="flex min-w-0 flex-col gap-2 p-4 sm:flex-row sm:items-start sm:justify-between">
-				<div className="min-w-0 flex-1">
-					<Heading className="min-w-0 text-sm font-semibold [overflow-wrap:anywhere]">
-						{title}
-					</Heading>
-					{description ? (
-						<div className="mt-1 min-w-0 text-xs leading-5 text-muted-foreground">
-							{description}
-						</div>
-					) : null}
-				</div>
-				<div className="flex min-w-0 shrink-0 flex-wrap items-center gap-1.5">
-					<StatusBadge status={status.tone}>{status.label}</StatusBadge>
+			<Heading className="sr-only">{`${identityLabel}: ${plan.value}`}</Heading>
+			<header className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-3 px-4 py-3.5">
+				<SubscriptionIdentity identity={view.identity} />
+				<div className="flex min-w-0 flex-wrap justify-end gap-1.5">
+					<StatusBadge status={view.status.tone} withDot>
+						{view.status.label}
+					</StatusBadge>
 					{badges}
 				</div>
 			</header>
 
-			{details?.length ? (
-				<dl className="grid min-w-0 grid-cols-2 gap-x-4 gap-y-3 border-t px-4 py-3 sm:[grid-template-columns:repeat(auto-fit,minmax(8rem,1fr))]">
-					{details.map((detail) => (
-						<div key={detail.label} className="min-w-0">
-							<dt className="text-xs text-muted-foreground">{detail.label}</dt>
-							<dd className="mt-0.5 min-w-0 text-sm font-medium [overflow-wrap:anywhere]">
-								{detail.value}
-							</dd>
-						</div>
-					))}
-				</dl>
-			) : null}
+			<dl className="grid min-w-0 grid-cols-2 border-t">
+				{view.facts.map((fact, index) => (
+					<div
+						key={fact.label}
+						className={cn(
+							"min-w-0 px-4 py-3",
+							index % 2 === 1 && "border-l",
+							index >= 2 && "border-t",
+						)}
+					>
+						<dt className="text-xs text-muted-foreground">{fact.label}</dt>
+						<dd className="mt-0.5 min-w-0 text-sm font-medium [overflow-wrap:anywhere]">
+							{fact.value}
+						</dd>
+						{"meta" in fact ? (
+							<span className="mt-0.5 block text-xs text-muted-foreground">{fact.meta}</span>
+						) : null}
+					</div>
+				))}
+			</dl>
 
 			{notice ? (
-				<div data-slot="compute-subscription-notice" className="min-w-0 border-t px-4 py-3">
+				<div data-slot="compute-subscription-notice" className="min-w-0 border-t px-4 py-2.5">
 					{notice}
 				</div>
 			) : null}
 			{actions ? (
 				<div
 					data-slot="compute-subscription-actions"
-					className="min-w-0 border-t bg-muted/20 px-4 py-3"
+					className="mt-auto flex min-w-0 flex-wrap items-center justify-end gap-2 border-t bg-muted/15 px-3 py-2"
 				>
 					{actions}
 				</div>

--- a/apps/web/src/hosted/billing/subscription/subscription-page.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import type { AgentTile } from "@/components/dashboard/agents-card";
 import { SettingsPanelHeader } from "@/components/settings/settings-panel-header";
 import { PlanComparison } from "@/hosted/billing/subscription/plan-comparison";
 import { SubscriptionsSection } from "@/hosted/billing/subscription/subscriptions-section";
@@ -8,14 +9,14 @@ import { SubscriptionsSection } from "@/hosted/billing/subscription/subscription
 const DESCRIPTION = "Subscriptions, plans, and account billing for hosted agents.";
 const SUBSCRIPTION_PAGE_CLASS = "flex flex-col gap-8 px-5 sm:px-6 lg:px-8";
 
-export function SubscriptionPage() {
+export function SubscriptionPage({ agentTiles }: { agentTiles: readonly AgentTile[] }) {
 	const [term, setTerm] = useState(1);
 
 	return (
 		<div data-hosted="true" className={SUBSCRIPTION_PAGE_CLASS}>
 			<SettingsPanelHeader title="Compute" description={DESCRIPTION} />
 
-			<SubscriptionsSection />
+			<SubscriptionsSection agentTiles={agentTiles} />
 
 			<PlanComparison term={term} onTermChange={setTerm} />
 		</div>

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
@@ -1,64 +1,63 @@
 import { beforeAll, describe, expect, test } from "bun:test";
-import { isValidElement } from "react";
-import { renderToStaticMarkup } from "react-dom/server";
+import type { ComputeSubscriptionListItem } from "@/hosted/billing/contracts";
 
 type SubscriptionsSectionModule =
 	typeof import("@/hosted/billing/subscription/subscriptions-section");
 
-let SubscriptionAgentLink: SubscriptionsSectionModule["SubscriptionAgentLink"] | null = null;
-let SubscriptionLoadMore: SubscriptionsSectionModule["SubscriptionLoadMore"] | null = null;
-let subscriptionPaymentSourceLabel:
-	| SubscriptionsSectionModule["subscriptionPaymentSourceLabel"]
-	| null = null;
+let sortLoadedSubscriptions: SubscriptionsSectionModule["sortLoadedSubscriptions"] | null = null;
 
 beforeAll(async () => {
 	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
 	process.env.VITE_CLAWDI_DEPLOY_API_URL = "http://localhost:50021";
 	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
 	const module = await import("@/hosted/billing/subscription/subscriptions-section");
-	SubscriptionAgentLink = module.SubscriptionAgentLink;
-	SubscriptionLoadMore = module.SubscriptionLoadMore;
-	subscriptionPaymentSourceLabel = module.subscriptionPaymentSourceLabel;
+	sortLoadedSubscriptions = module.sortLoadedSubscriptions;
 });
 
+function subscription(
+	subscriptionId: string,
+	status: ComputeSubscriptionListItem["status"],
+): ComputeSubscriptionListItem {
+	return {
+		subscription_id: subscriptionId,
+		plan_slug: "compute_basic",
+		funding_source: "stripe",
+		status,
+		currency: "usd",
+		billing_term_months: 1,
+		cancel_at_period_end: status === "canceling",
+		agent_name: subscriptionId,
+		is_orphan: false,
+	};
+}
+
 describe("SubscriptionsSection", () => {
-	test("links a named agent to its billing plan and keeps deleted agents unlinked", () => {
-		if (!SubscriptionAgentLink || !SubscriptionLoadMore) {
-			throw new Error("Subscriptions section components were not loaded");
-		}
-		const namedAgent = SubscriptionAgentLink({
-			deploymentId: "hdep_live",
-			agentName: "Production agent",
-		});
-		if (!isValidElement(namedAgent)) throw new Error("Expected a named agent link");
-		expect(namedAgent.props).toMatchObject({
-			children: "Production agent",
-			to: "/agents/$id/$section",
-			params: { id: "hdep_live", section: "settings" },
-			search: { source: "on-clawdi", settings: "billing-plan" },
-		});
+	test("stably prioritizes loaded current subscriptions without mutating query data", () => {
+		if (!sortLoadedSubscriptions) throw new Error("Subscriptions helpers were not loaded");
+		const loaded = [
+			subscription("canceled", "canceled"),
+			subscription("canceling-first", "canceling"),
+			subscription("active-first", "active"),
+			subscription("past-due", "past_due"),
+			subscription("active-second", "active"),
+			subscription("canceling-second", "canceling"),
+		];
 
-		for (const deletedAgent of [
-			renderToStaticMarkup(<SubscriptionAgentLink deploymentId={null} agentName={null} />),
-			renderToStaticMarkup(<SubscriptionAgentLink deploymentId="hdep_stale" agentName={null} />),
-			renderToStaticMarkup(<SubscriptionAgentLink deploymentId={null} agentName="Stale agent" />),
-		]) {
-			expect(deletedAgent).toContain("Deleted agent");
-			expect(deletedAgent).not.toContain("href=");
-		}
-
-		const loadMore = renderToStaticMarkup(
-			<SubscriptionLoadMore isLoading={false} onLoadMore={() => undefined} />,
-		);
-		expect(loadMore).toContain("Load more");
-	});
-
-	test("labels Included, Card, and Wallet from the generated funding source", () => {
-		if (!subscriptionPaymentSourceLabel) {
-			throw new Error("Subscription payment source helper was not loaded");
-		}
-		expect(subscriptionPaymentSourceLabel(null)).toBe("Included");
-		expect(subscriptionPaymentSourceLabel("stripe")).toBe("Card");
-		expect(subscriptionPaymentSourceLabel("wallet")).toBe("Wallet");
+		expect(sortLoadedSubscriptions(loaded).map((item) => item.subscription_id)).toEqual([
+			"active-first",
+			"active-second",
+			"past-due",
+			"canceling-first",
+			"canceling-second",
+			"canceled",
+		]);
+		expect(loaded.map((item) => item.subscription_id)).toEqual([
+			"canceled",
+			"canceling-first",
+			"active-first",
+			"past-due",
+			"active-second",
+			"canceling-second",
+		]);
 	});
 });

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { Link } from "@tanstack/react-router";
-import { CreditCard, History, Link2Off, RefreshCw } from "lucide-react";
+import { CreditCard, History, Link2Off, RefreshCw, Settings } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
+import type { AgentTile } from "@/components/dashboard/agents-card";
 import { EmptyState } from "@/components/empty-state";
 import { SettingsSection } from "@/components/settings-section";
 import { Badge } from "@/components/ui/badge";
@@ -15,21 +16,23 @@ import { Spinner } from "@/components/ui/spinner";
 import type { StatusTone } from "@/components/ui/status-badge";
 import type { ComputeSubscriptionListItem } from "@/hosted/billing/contracts";
 import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
-import { billingTermLabel, billingTermSuffix, formatCurrencyCents } from "@/hosted/billing/format";
 import {
 	useCancelSubscription,
 	useResumeSubscription,
 	useSubscriptions,
 } from "@/hosted/billing/hooks";
-import { ComputeSubscriptionCard } from "@/hosted/billing/subscription/compute-subscription-card";
+import {
+	ComputeSubscriptionCard,
+	computeSubscriptionCardView,
+	computeSubscriptionPlanLabel,
+} from "@/hosted/billing/subscription/compute-subscription-card";
 import {
 	canCancelAccountSubscription,
 	canResumeAccountSubscription,
-	computeTierLabel,
 	isEndedAccountSubscription,
 } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
-import { agentSectionLink } from "@/lib/agent-routes";
+import { agentSectionHref } from "@/lib/agent-routes";
 import { formatShortDate } from "@/lib/format";
 import { shouldBlockQueryError } from "@/lib/query-state";
 
@@ -43,37 +46,20 @@ const STATUS_PRESENTATION: Record<
 	canceled: { label: "Canceled", tone: "neutral" },
 };
 
-function planLabel(planSlug: string): string {
-	if (planSlug === "compute_basic" || planSlug === "compute_performance") {
-		return `Compute ${computeTierLabel(planSlug)}`;
-	}
-	return planSlug.replace(/^compute_/, "").replaceAll("_", " ");
+function subscriptionScheduleVerb(status: ComputeSubscriptionListItem["status"]): string {
+	if (status === "canceling") return "Ends";
+	if (status === "canceled") return "Ended";
+	if (status === "past_due") return "Due";
+	return "Renews";
 }
 
-export function subscriptionPaymentSourceLabel(
-	fundingSource: ComputeSubscriptionListItem["funding_source"],
-): string {
-	if (fundingSource === null) return "Included";
-	if (fundingSource === "stripe") return "Card";
-	if (fundingSource === "wallet") return "Wallet";
-	return "Unavailable";
-}
-
-function priceLabel(subscription: ComputeSubscriptionListItem): string {
-	if (subscription.price_cents == null) return "Unavailable";
-	return `${formatCurrencyCents(subscription.price_cents, subscription.currency)}${billingTermSuffix(subscription.billing_term_months)}`;
-}
-
-function periodLabel(subscription: ComputeSubscriptionListItem): string {
-	if (!subscription.current_period_end) return "Unavailable";
-	const date = formatShortDate(subscription.current_period_end);
-	if (subscription.status === "canceling") return `Ends ${date}`;
-	if (subscription.status === "canceled") return `Ended ${date}`;
-	if (subscription.status === "past_due") return `Due ${date}`;
-	return `Renews ${date}`;
-}
-
-function SubscriptionActions({ subscription }: { subscription: ComputeSubscriptionListItem }) {
+function SubscriptionActions({
+	subscription,
+	manageHref,
+}: {
+	subscription: ComputeSubscriptionListItem;
+	manageHref: string | null;
+}) {
 	const cancelSubscription = useCancelSubscription();
 	const resumeSubscription = useResumeSubscription();
 	const runAction = useActionLock();
@@ -110,12 +96,24 @@ function SubscriptionActions({ subscription }: { subscription: ComputeSubscripti
 		}
 	}
 
-	if (!canCancel && !canResume) {
+	if (!manageHref && !canCancel && !canResume) {
 		return null;
 	}
 
 	return (
-		<div className="flex flex-wrap gap-2 sm:justify-end">
+		<>
+			{manageHref ? (
+				<Button
+					render={<Link to={manageHref} />}
+					nativeButton={false}
+					type="button"
+					variant="outline"
+					size="sm"
+				>
+					<Settings data-icon="inline-start" />
+					Manage
+				</Button>
+			) : null}
 			{canResume ? (
 				<Button
 					type="button"
@@ -125,12 +123,12 @@ function SubscriptionActions({ subscription }: { subscription: ComputeSubscripti
 					onClick={() => void runAction(resume).catch(() => undefined)}
 				>
 					{resumeSubscription.isPending ? <Spinner /> : <RefreshCw />}
-					Resume
+					Resume subscription
 				</Button>
 			) : null}
 			{canCancel ? (
 				<ConfirmAction
-					title={`Cancel ${planLabel(subscription.plan_slug)} subscription?`}
+					title={`Cancel ${computeSubscriptionPlanLabel(subscription.plan_slug)} subscription?`}
 					description={
 						<p>
 							The subscription will stop renewing
@@ -146,35 +144,21 @@ function SubscriptionActions({ subscription }: { subscription: ComputeSubscripti
 				>
 					<Button type="button" variant="outline" size="sm" disabled={pending}>
 						{cancelSubscription.isPending ? <Spinner /> : <Link2Off />}
-						Cancel
+						Cancel subscription
 					</Button>
 				</ConfirmAction>
 			) : null}
-		</div>
+		</>
 	);
 }
 
-export function SubscriptionAgentLink({
-	deploymentId,
-	agentName,
-}: {
-	deploymentId: ComputeSubscriptionListItem["deployment_id"];
-	agentName: ComputeSubscriptionListItem["agent_name"];
-}) {
-	return deploymentId && agentName ? (
-		<Link
-			{...agentSectionLink(deploymentId, "settings", {
-				source: "on-clawdi",
-				settings: "billing-plan",
-			})}
-			className="block min-w-0 truncate font-medium text-primary underline-offset-4 hover:underline"
-			title={agentName}
-		>
-			{agentName}
-		</Link>
-	) : (
-		<span className="font-medium text-muted-foreground">Deleted agent</span>
-	);
+function subscriptionManageHref(subscription: ComputeSubscriptionListItem): string | null {
+	if (subscription.is_orphan || !subscription.deployment_id || !subscription.agent_name)
+		return null;
+	return agentSectionHref(subscription.deployment_id, "settings", {
+		source: "on-clawdi",
+		settings: "billing-plan",
+	});
 }
 
 export function SubscriptionLoadMore({
@@ -193,54 +177,78 @@ export function SubscriptionLoadMore({
 	);
 }
 
-function SubscriptionRow({ subscription }: { subscription: ComputeSubscriptionListItem }) {
+function SubscriptionRow({
+	subscription,
+	agentTile,
+}: {
+	subscription: ComputeSubscriptionListItem;
+	agentTile?: AgentTile;
+}) {
 	const status = STATUS_PRESENTATION[subscription.status];
+	const manageHref = subscriptionManageHref(subscription);
 	const hasActions =
-		canCancelAccountSubscription(subscription) || canResumeAccountSubscription(subscription);
+		manageHref !== null ||
+		canCancelAccountSubscription(subscription) ||
+		canResumeAccountSubscription(subscription);
+	const view = computeSubscriptionCardView({
+		identity: manageHref
+			? {
+					kind: "agent",
+					name: agentTile?.name ?? subscription.agent_name ?? "Agent",
+					agentType: agentTile?.agentType ?? null,
+					avatarUrl: agentTile?.avatarUrl,
+					href: manageHref,
+				}
+			: { kind: "unavailable", label: "Deleted agent" },
+		status,
+		planSlug: subscription.plan_slug,
+		fundingSource: subscription.funding_source === null ? "included" : subscription.funding_source,
+		priceCents: subscription.price_cents,
+		currency: subscription.currency,
+		billingTermMonths: subscription.billing_term_months,
+		scheduleVerb: subscriptionScheduleVerb(subscription.status),
+		scheduleAt: subscription.current_period_end,
+	});
 
 	return (
 		<li className="min-w-0">
 			<ComputeSubscriptionCard
 				headingLevel={4}
-				title={planLabel(subscription.plan_slug)}
-				status={status}
+				view={view}
 				badges={subscription.is_orphan ? <Badge variant="outline">Orphaned</Badge> : null}
-				details={[
-					{
-						label: "Agent",
-						value: (
-							<SubscriptionAgentLink
-								deploymentId={subscription.deployment_id}
-								agentName={subscription.agent_name}
-							/>
-						),
-					},
-					{
-						label: "Payment",
-						value: subscriptionPaymentSourceLabel(subscription.funding_source),
-					},
-					{
-						label: "Billing",
-						value: (
-							<>
-								<span className="tabular-nums">{priceLabel(subscription)}</span>
-								<span className="mt-0.5 block text-xs font-normal text-muted-foreground">
-									{billingTermLabel(subscription.billing_term_months)}
-								</span>
-							</>
-						),
-					},
-					{ label: "Schedule", value: periodLabel(subscription) },
-				]}
-				actions={hasActions ? <SubscriptionActions subscription={subscription} /> : null}
+				actions={
+					hasActions ? (
+						<SubscriptionActions subscription={subscription} manageHref={manageHref} />
+					) : null
+				}
 			/>
 		</li>
 	);
 }
 
+const SUBSCRIPTION_STATUS_PRIORITY: Record<ComputeSubscriptionListItem["status"], number> = {
+	active: 0,
+	past_due: 1,
+	canceling: 2,
+	canceled: 3,
+};
+
+export function sortLoadedSubscriptions(
+	subscriptions: readonly ComputeSubscriptionListItem[],
+): ComputeSubscriptionListItem[] {
+	return subscriptions
+		.map((subscription, index) => ({ subscription, index }))
+		.sort(
+			(a, b) =>
+				SUBSCRIPTION_STATUS_PRIORITY[a.subscription.status] -
+					SUBSCRIPTION_STATUS_PRIORITY[b.subscription.status] || a.index - b.index,
+		)
+		.map(({ subscription }) => subscription);
+}
+
 function SubscriptionListSkeleton() {
 	return (
-		<div className="space-y-3" role="status">
+		<div className="grid gap-3 lg:grid-cols-2" role="status">
 			<span className="sr-only">Loading subscriptions</span>
 			{Array.from({ length: 3 }, (_, index) => `subscription-skeleton-${index}`).map((key) => (
 				<div key={key} className="overflow-hidden rounded-lg border bg-card">
@@ -248,7 +256,7 @@ function SubscriptionListSkeleton() {
 						<Skeleton className="h-5 w-36" />
 						<Skeleton className="h-5 w-16" />
 					</div>
-					<div className="grid grid-cols-2 gap-4 border-t px-4 py-3 sm:grid-cols-4">
+					<div className="grid grid-cols-2 gap-4 border-t px-4 py-3">
 						{Array.from({ length: 4 }, (_, detailIndex) => `${key}-${detailIndex}`).map(
 							(detailKey) => (
 								<div key={detailKey} className="space-y-1.5">
@@ -264,17 +272,25 @@ function SubscriptionListSkeleton() {
 	);
 }
 
-export function SubscriptionsSection() {
+export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly AgentTile[] }) {
 	const subscriptions = useSubscriptions();
 	const [showHistory, setShowHistory] = useState(false);
 	const [historyCutoffMs] = useState(Date.now);
 	const rows = subscriptions.data?.pages.flatMap((page) => page.items ?? []) ?? [];
+	const orderedRows = sortLoadedSubscriptions(rows);
+	const agentTilesByDeploymentId = new Map(
+		agentTiles
+			.filter((tile) => tile.source === "on-clawdi")
+			.map((tile) => [tile.id.toLowerCase(), tile] as const),
+	);
 	const endedRows = rows.filter((subscription) =>
 		isEndedAccountSubscription(subscription, historyCutoffMs),
 	);
 	const visibleRows = showHistory
-		? rows
-		: rows.filter((subscription) => !isEndedAccountSubscription(subscription, historyCutoffMs));
+		? orderedRows
+		: orderedRows.filter(
+				(subscription) => !isEndedAccountSubscription(subscription, historyCutoffMs),
+			);
 	const canLoadMore = subscriptions.hasNextPage && !subscriptions.isFetchNextPageError;
 	const historyControlVisible = endedRows.length > 0 || showHistory;
 
@@ -313,9 +329,17 @@ export function SubscriptionsSection() {
 						</div>
 					) : null}
 					{visibleRows.length ? (
-						<ul className="space-y-3">
+						<ul className="grid gap-3 lg:grid-cols-2">
 							{visibleRows.map((subscription) => (
-								<SubscriptionRow key={subscription.subscription_id} subscription={subscription} />
+								<SubscriptionRow
+									key={subscription.subscription_id}
+									subscription={subscription}
+									agentTile={
+										subscription.deployment_id
+											? agentTilesByDeploymentId.get(subscription.deployment_id.toLowerCase())
+											: undefined
+									}
+								/>
 							))}
 						</ul>
 					) : (


### PR DESCRIPTION
## Summary

- replace the two Compute subscription presentations with one identity-first card/view model using the same `Plan`, `Payment`, `Price`, and `Schedule` layout
- render canonical Agent icon/avatar + name in account Settings, with a restrained deleted/orphan fallback, and use a responsive two-column account inventory plus a bounded Agent Settings card
- align both surfaces on the same compact gear `Manage` + lifecycle action syntax, including quiet cancel and icon-preserving resume states
- preserve hidden ended history and stably prioritize active/attention/current subscriptions within the rows already loaded

## Pagination scope

The Web sort is deliberately defensive and limited to loaded rows. Hosted `/v2/subscriptions` currently uses a `(created_at, id)` cursor, so this PR does **not** claim global active-first ordering across unloaded pages. A stable status-priority Hosted cursor is required for that global guarantee; automatically draining every page would make initial load unbounded and undermine the existing Load more workflow.

## Verification

- `bun run --cwd apps/web typecheck`
- focused subscription tests: 29 passed
- Biome checks on all changed files
- `bun run --cwd apps/web build:oss`
- `bun run --cwd apps/web test` (Docker clean runner: typecheck, full Bun test suite, OSS build)
- `hosted-subscriptions.pw.ts`: 3 passed on a clean, prewarmed local hosted runner
- inspected actual desktop and 320px screenshots for both account Settings and Agent Settings, including orphan fallback, truncation, action wrapping, card width, and horizontal overflow

No backend API or generated contracts changed. Hosted was inspected read-only only. This PR must not be merged without review.
