### PR TITLE
chore(channels): trim Telegram and Discord vestiges

### DIFF
--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -218,17 +218,6 @@ class _DiscordGatewaySessionStore:
             self._prune(now)
             self._enforce_bound()
 
-    def get(self, session_id: str) -> _DiscordGatewaySessionState | None:
-        now = self._now()
-        with self._lock:
-            self._prune(now)
-            entry = self._entries.get(session_id)
-            if entry is None:
-                return None
-            entry.touched_at = now
-            self._entries.move_to_end(session_id)
-            return entry.state
-
     def touch(self, session_id: str) -> bool:
         now = self._now()
         with self._lock:
@@ -240,25 +229,9 @@ class _DiscordGatewaySessionStore:
             self._entries.move_to_end(session_id)
             return True
 
-    def clear(self) -> None:
-        with self._lock:
-            self._entries.clear()
-
     def discard(self, session_id: str) -> None:
         with self._lock:
             self._entries.pop(session_id, None)
-
-    def __len__(self) -> int:
-        now = self._now()
-        with self._lock:
-            self._prune(now)
-            return len(self._entries)
-
-    def session_ids(self) -> tuple[str, ...]:
-        now = self._now()
-        with self._lock:
-            self._prune(now)
-            return tuple(self._entries)
 
     def _prune(self, now: float) -> None:
         expired = [

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -47,12 +47,19 @@ from app.models.channel import (
     ChannelDelivery,
     ChannelMessage,
 )
+from app.routes.channel_routers.discord import (
+    cleanup_discord_guild_commands_after_authority_revoked,
+)
 from app.routes.channel_routers.shared import (
     account_response,
     binding_response,
     channel_visibility,
     discord_binding_guild_id,
     message_response,
+)
+from app.routes.channel_routers.telegram import (
+    reconcile_telegram_binding_unpair_from_ui,
+    reconcile_telegram_link_unlink,
 )
 from app.schemas.channel import (
     ChannelAccountCreate,
@@ -983,10 +990,6 @@ async def delete_channel_agent_link(
     )
     await db.commit()
     if discord_guild_ids:
-        from app.routes.channel_routers.discord import (
-            cleanup_discord_guild_commands_after_authority_revoked,
-        )
-
         background_tasks.add_task(
             cleanup_discord_guild_commands_after_authority_revoked,
             account_id=account.id,
@@ -994,8 +997,6 @@ async def delete_channel_agent_link(
             guild_ids=discord_guild_ids,
         )
     elif account.provider == CHANNEL_PROVIDER_TELEGRAM and bindings:
-        from app.routes.channel_routers.telegram import reconcile_telegram_link_unlink
-
         cleaned = await reconcile_telegram_link_unlink(
             db=db,
             account=account,
@@ -1157,10 +1158,6 @@ async def delete_channel_binding(
     provider_cleanup_status = "not_applicable"
     warning: str | None = None
     if account.provider == CHANNEL_PROVIDER_TELEGRAM:
-        from app.routes.channel_routers.telegram import (
-            reconcile_telegram_binding_unpair_from_ui,
-        )
-
         outcome = await reconcile_telegram_binding_unpair_from_ui(
             db=db,
             account=account,
@@ -1194,10 +1191,6 @@ async def delete_channel_binding(
         )
         await db.commit()
     elif account.provider == CHANNEL_PROVIDER_DISCORD and discord_guild_id is not None:
-        from app.routes.channel_routers.discord import (
-            cleanup_discord_guild_commands_after_authority_revoked,
-        )
-
         cleanup_succeeded = await cleanup_discord_guild_commands_after_authority_revoked(
             account_id=account.id,
             bot_agent_link_id=link.id,

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -439,7 +439,7 @@ async def telegram_bot_api(
         webhook_url = optional_str(params.get("url"))
         if webhook_url is None:
             return _telegram_error_response("Bad Request: url is required", 400)
-        webhook_error = await _validate_telegram_webhook_url(account, webhook_url)
+        webhook_error = await _validate_telegram_webhook_url(webhook_url)
         if webhook_error is not None:
             return webhook_error
         _set_link_config(
@@ -1060,12 +1060,12 @@ async def _deliver_telegram_agent_webhook_for_binding(
         link=current_link,
     ):
         return False
-    return await deliver_telegram_agent_webhook(current_account, current_link, payload)
+    return await deliver_telegram_agent_webhook(current_link, payload)
 
 
-async def _validate_telegram_webhook_url(account: ChannelAccount, url: str) -> JSONResponse | None:
+async def _validate_telegram_webhook_url(url: str) -> JSONResponse | None:
     try:
-        await validate_agent_webhook_url(account, url)
+        await validate_agent_webhook_url(url)
     except HTTPException as exc:
         return _telegram_error_response(f"Bad Request: {exc.detail}", 400)
     return None
@@ -1515,16 +1515,6 @@ def _telegram_materialize_command_target(target: _TelegramJsonObject) -> _Telegr
     if isinstance(language_code, str) and language_code:
         payload["language_code"] = language_code
     return payload
-
-
-def telegram_binding_command_projections(
-    shadow: dict[str, _TelegramCommands],
-    binding: ChannelBinding,
-) -> list[_TelegramJsonObject]:
-    return [
-        _telegram_materialize_command_target(target)
-        for target in _telegram_binding_command_targets(shadow, binding)
-    ]
 
 
 def _telegram_projection_identity(payload: _TelegramJsonObject) -> str:

--- a/backend/app/services/channel_webhook_delivery_worker.py
+++ b/backend/app/services/channel_webhook_delivery_worker.py
@@ -176,7 +176,6 @@ class ChannelWebhookDeliveryWorker:
             )
 
         delivered = await deliver_telegram_agent_webhook(
-            account,
             link,
             telegram_update_payload(message),
         )

--- a/backend/app/services/channel_webhooks.py
+++ b/backend/app/services/channel_webhooks.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import HTTPException, status
 from pydantic import JsonValue, TypeAdapter, ValidationError
 
-from app.models.channel import ChannelAccount, ChannelBotAgentLink
+from app.models.channel import ChannelBotAgentLink
 from app.services.metrics import webhook_deliveries
 from app.services.safe_public_http import SafePublicHttpClient, SafePublicHttpError
 from app.services.url_security import UnsafeOutboundUrlError, validate_outbound_url
@@ -39,7 +39,7 @@ def telegram_link_webhook_url(link: ChannelBotAgentLink) -> str | None:
     return _optional_str(telegram_link_webhook_config(link).get("url"))
 
 
-async def validate_agent_webhook_url(_account: ChannelAccount, url: str) -> None:
+async def validate_agent_webhook_url(url: str) -> None:
     try:
         await validate_outbound_url(
             url,
@@ -54,7 +54,6 @@ async def validate_agent_webhook_url(_account: ChannelAccount, url: str) -> None
 
 
 async def deliver_telegram_agent_webhook(
-    _account: ChannelAccount,
     link: ChannelBotAgentLink,
     payload: JsonObject,
 ) -> bool:

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -247,10 +247,6 @@ CHANNEL_RETENTION_PROVIDERS = (
     CHANNEL_PROVIDER_DISCORD,
     CHANNEL_PROVIDER_WHATSAPP,
 )
-DISCORD_EPHEMERAL_REFERENCE_KINDS = (
-    DISCORD_REF_INTERACTION_ID_TOKEN,
-    DISCORD_REF_INTERACTION_TOKEN,
-)
 # Discord interaction tokens are valid for 15 minutes. Keep a five-minute
 # grace period for clock skew and in-flight follow-ups, then remove the exact
 # credential fields independently of the message retention horizon.
@@ -2388,14 +2384,14 @@ def discord_guild_command_denied_reason(
     return DISCORD_GUILD_PERMISSION_DENIED
 
 
-def discord_pair_install_denied_reason(
+def _discord_pair_install_admission(
     payload: JsonObject,
     *,
     command: ChannelControlCommand | None,
     guild_id: str | None,
     external_user_id: str | None,
     trusted_interaction: bool,
-) -> str | None:
+) -> tuple[str | None, bool]:
     """Require the Discord installation that owns a pairing mutation.
 
     ``authorizing_integration_owners`` is Discord's authoritative mapping from
@@ -2406,24 +2402,6 @@ def discord_pair_install_denied_reason(
     active scope and the original pairing actor. A present-but-mismatched owner
     is never accepted.
     """
-    denied_reason, _cleanup_owner_missing = _discord_pair_install_admission(
-        payload,
-        command=command,
-        guild_id=guild_id,
-        external_user_id=external_user_id,
-        trusted_interaction=trusted_interaction,
-    )
-    return denied_reason
-
-
-def _discord_pair_install_admission(
-    payload: JsonObject,
-    *,
-    command: ChannelControlCommand | None,
-    guild_id: str | None,
-    external_user_id: str | None,
-    trusted_interaction: bool,
-) -> tuple[str | None, bool]:
     if command is None or command.kind not in {"pair", "unpair"}:
         return None, False
     data = _discord_event_data(payload)
@@ -2632,11 +2610,6 @@ def discord_control_reply_for_command(
     if command is not None and command.kind == "unknown" and command.command:
         return f"Unknown command: {command.command}. Use {HELP_COMMAND} for instructions."
     return pairing_reply_for_command(command, result)
-
-
-def extract_pair_code(text: str | None) -> str | None:
-    command = parse_channel_control_command(text)
-    return command.code if command is not None and command.kind == "pair" else None
 
 
 async def send_control_command_reply(
@@ -3025,7 +2998,7 @@ async def _record_inbound_message_with_status(
 ) -> tuple[ChannelMessage, bool]:
     event_id = provider_event_id or provider_message_id
     if event_id is not None:
-        existing = await _find_existing_inbound_message(
+        existing = await find_existing_inbound_provider_event(
             db,
             account=account,
             external_chat_id=external_chat_id,
@@ -3056,7 +3029,7 @@ async def _record_inbound_message_with_status(
             db.add(message)
             await db.flush()
     except IntegrityError:
-        existing = await _find_existing_inbound_message(
+        existing = await find_existing_inbound_provider_event(
             db,
             account=account,
             external_chat_id=external_chat_id,
@@ -3068,33 +3041,6 @@ async def _record_inbound_message_with_status(
         raise
     inbound_messages.labels(channel=account.provider).inc()
     return message, True
-
-
-async def _find_existing_inbound_message(
-    db: AsyncSession,
-    *,
-    account: ChannelAccount,
-    external_chat_id: str,
-    provider_event_id: str | None,
-    provider_event_scope: str,
-) -> ChannelMessage | None:
-    if provider_event_id is None:
-        return None
-    filters = [
-        ChannelMessage.account_id == account.id,
-        ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
-        ChannelMessage.provider_event_scope == provider_event_scope,
-        ChannelMessage.provider_event_id == provider_event_id,
-    ]
-    if provider_event_scope == PROVIDER_EVENT_SCOPE_CHAT:
-        filters.append(ChannelMessage.external_chat_id == external_chat_id)
-    result = await db.execute(
-        select(ChannelMessage)
-        .where(*filters)
-        .order_by(ChannelMessage.created_at.asc(), ChannelMessage.id.asc())
-        .limit(1)
-    )
-    return result.scalar_one_or_none()
 
 
 async def find_existing_inbound_provider_event(

--- a/backend/app/services/discord_gateway_worker.py
+++ b/backend/app/services/discord_gateway_worker.py
@@ -6,7 +6,6 @@ import hashlib
 import json
 import logging
 import random
-import uuid
 from dataclasses import dataclass
 from types import TracebackType
 from typing import Protocol
@@ -108,7 +107,6 @@ class DiscordGatewayWorker:
         self,
         sessionmaker: async_sessionmaker[AsyncSession],
         *,
-        worker_id: str | None = None,
         lock_engine: AsyncEngine | None = None,
         scan_interval_seconds: float = 10.0,
         reconnect_initial_seconds: float = 1.0,
@@ -116,7 +114,6 @@ class DiscordGatewayWorker:
         connect_factory: _GatewayConnectFactory = connect,
     ) -> None:
         self._sessionmaker = sessionmaker
-        self._worker_id = worker_id or f"discord-gateway-{uuid.uuid4()}"
         self._lock_engine = lock_engine or _sessionmaker_bind(sessionmaker)
         self._scan_interval_seconds = scan_interval_seconds
         self._reconnect_initial_seconds = reconnect_initial_seconds

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -69,7 +69,6 @@ from app.routes.channel_routers import public as public_router
 from app.routes.channel_routers import shared as shared_router
 from app.routes.channel_routers import telegram as telegram_router
 from app.routes.channel_routers.discord import (
-    _DISCORD_GATEWAY_SESSIONS,
     _discord_gateway_authority,
     _discord_gateway_url,
     _discord_guild_create_payload,
@@ -2699,7 +2698,7 @@ async def test_historical_duplicate_managed_accounts_are_visible_but_fail_closed
 
     agent_deliveries: list[dict[str, Any]] = []
 
-    async def _record_agent_delivery(_account, _link, payload):
+    async def _record_agent_delivery(_link, payload):
         agent_deliveries.append(payload)
         return True
 
@@ -7154,7 +7153,10 @@ def test_telegram_binding_command_projection_follows_provider_precedence(
         external_chat_type=chat_type,
     )
 
-    projections = telegram_router.telegram_binding_command_projections(shadow, binding)
+    projections = [
+        telegram_router._telegram_materialize_command_target(target)
+        for target in telegram_router._telegram_binding_command_targets(shadow, binding)
+    ]
     projected = {
         (payload["scope"]["type"], payload.get("language_code", "")): payload["commands"][3][
             "command"
@@ -9439,7 +9441,7 @@ async def test_discord_gateway_shared_account_link_bearers_are_isolated(
     second_channel_agent,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    _DISCORD_GATEWAY_SESSIONS.clear()
+    _reset_discord_gateway_sessions(monkeypatch)
     created = (
         await client.post(
             "/v1/channels",
@@ -14785,7 +14787,7 @@ def _install_discord_gateway_protocol_fakes(
     channels: dict[str, str | None] | None = None,
     provider_channels: dict[str, dict[str, Any]] | None = None,
 ) -> list[str]:
-    _DISCORD_GATEWAY_SESSIONS.clear()
+    _reset_discord_gateway_sessions(monkeypatch)
     event_queue = events if events is not None else []
     for event in event_queue:
         if event.id is None:
@@ -14922,6 +14924,17 @@ def _install_discord_gateway_protocol_fakes(
     return provider_paths
 
 
+def _reset_discord_gateway_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> discord_router._DiscordGatewaySessionStore:
+    store = discord_router._DiscordGatewaySessionStore(
+        max_sessions=discord_router._DISCORD_GATEWAY_MAX_SESSIONS,
+        ttl_seconds=discord_router._DISCORD_GATEWAY_SESSION_TTL_SECONDS,
+    )
+    monkeypatch.setattr(discord_router, "_DISCORD_GATEWAY_SESSIONS", store)
+    return store
+
+
 def _install_discord_gateway_test_session_factory(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep TestClient's worker loop off pytest's session-bound asyncpg pool."""
     gateway_engine = create_async_engine(
@@ -14995,7 +15008,7 @@ def test_discord_gateway_resume_validates_session_id_and_token(monkeypatch):
             )
             assert websocket.receive_json()["t"] == "RESUMED"
 
-        _DISCORD_GATEWAY_SESSIONS.clear()
+        _reset_discord_gateway_sessions(monkeypatch)
         with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
             assert websocket.receive_json()["op"] == 10
             websocket.send_json(
@@ -15099,7 +15112,7 @@ async def test_discord_gateway_new_identify_replays_unacknowledged_db_message_af
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    _DISCORD_GATEWAY_SESSIONS.clear()
+    _reset_discord_gateway_sessions(monkeypatch)
     channel_id = "restart-replay-channel"
     guild_id = "restart-replay-guild"
     created = await _create_paired_discord_channel(
@@ -15164,7 +15177,7 @@ async def test_discord_gateway_new_identify_replays_unacknowledged_db_message_af
     assert message.delivered_at is None
 
     # Process-local Resume state is gone, but the durable pending row remains.
-    _DISCORD_GATEWAY_SESSIONS.clear()
+    _reset_discord_gateway_sessions(monkeypatch)
     with TestClient(app) as sync_client:
         with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
             assert websocket.receive_json()["op"] == 10
@@ -15198,7 +15211,7 @@ async def test_discord_gateway_resume_sequence_acks_and_replays_exact_db_message
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    _DISCORD_GATEWAY_SESSIONS.clear()
+    _reset_discord_gateway_sessions(monkeypatch)
     channel_id = "resume-ack-channel"
     guild_id = "resume-ack-guild"
     created = await _create_paired_discord_channel(
@@ -15258,8 +15271,10 @@ async def test_discord_gateway_resume_sequence_acks_and_replays_exact_db_message
 
     # Model cancellation after the frame/checkpoint was registered and sent but
     # before the connection-local durable inbox cursor was advanced.
-    session_state = _DISCORD_GATEWAY_SESSIONS.get(ready["d"]["session_id"])
+    session_id = ready["d"]["session_id"]
+    session_state = discord_router._DISCORD_GATEWAY_SESSIONS.connect(session_id)
     assert session_state is not None
+    discord_router._DISCORD_GATEWAY_SESSIONS.disconnect(session_id)
     session_state["last_inbox_sequence"] = 0
 
     with TestClient(app) as sync_client:
@@ -20147,13 +20162,13 @@ def test_discord_pair_install_contract_requires_matching_context_and_owner(
     command = channel_service.ChannelControlCommand(kind="pair", code="BCDFGHJKLM")
 
     assert (
-        channel_service.discord_pair_install_denied_reason(
+        channel_service._discord_pair_install_admission(
             payload,
             command=command,
             guild_id=guild_id,
             external_user_id=external_user_id,
             trusted_interaction=True,
-        )
+        )[0]
         == expected
     )
 

--- a/backend/tests/test_discord_gateway_session_store.py
+++ b/backend/tests/test_discord_gateway_session_store.py
@@ -14,14 +14,13 @@ def test_discord_gateway_session_store_expires_idle_sessions():
     store.put("session-a", state)
 
     now = 10.0
-    assert store.get("session-a") is state
+    assert store.touch("session-a") is True
     store.disconnect("session-a")
     now = 14.9
-    assert store.get("session-a") is state
+    assert store.touch("session-a") is True
     now = 20.0
 
-    assert store.get("session-a") is None
-    assert len(store) == 0
+    assert store.touch("session-a") is False
 
 
 def test_discord_gateway_session_store_uses_deterministic_lru_eviction():
@@ -39,8 +38,9 @@ def test_discord_gateway_session_store_uses_deterministic_lru_eviction():
     store.put("session-c", {})
     store.disconnect("session-c")
 
-    assert store.session_ids() == ("session-a", "session-c")
-    assert store.get("session-b") is None
+    assert store.touch("session-b") is False
+    assert store.touch("session-a") is True
+    assert store.touch("session-c") is True
 
 
 def test_discord_gateway_session_store_stays_bounded_under_churn():
@@ -54,8 +54,8 @@ def test_discord_gateway_session_store_stays_bounded_under_churn():
         store.put(f"session-{index}", {"last_sequence": index})
         store.disconnect(f"session-{index}")
 
-    assert len(store) == 3
-    assert store.session_ids() == ("session-97", "session-98", "session-99")
+    assert store.touch("session-96") is False
+    assert all(store.touch(f"session-{index}") for index in range(97, 100))
 
 
 def test_discord_gateway_session_store_never_evicts_connected_sessions():
@@ -72,5 +72,5 @@ def test_discord_gateway_session_store_never_evicts_connected_sessions():
         store.disconnect(f"idle-{index}")
     now = 100.0
 
-    assert store.get("active") is active
-    assert store.session_ids() == ("active",)
+    assert store.touch("active") is True
+    assert all(store.touch(f"idle-{index}") is False for index in range(3))


### PR DESCRIPTION
## Summary

- remove provably dead Telegram/Discord channel symbols and test-only observation APIs
- collapse one byte-for-byte equivalent inbound provider-event lookup into the existing shared implementation
- remove unused parameters/state and replace four unnecessary function-local imports with cycle-safe module imports

This is a zero-behavior-change cleanup. It changes no provider request/response semantics, delivery scheduling, credentials handling, migrations, API schemas, emitted dictionaries, or WhatsApp paths.

## Evidence for removals

- `extract_pair_code` and `DISCORD_EPHEMERAL_REFERENCE_KINDS`: repository-wide closure across `backend/app`, `backend/tests`, `packages`, routes, and `apps/web` found definitions only.
- `discord_pair_install_denied_reason`: the only caller was its focused test; production already calls `_discord_pair_install_admission` directly. The test now exercises that production function.
- `telegram_binding_command_projections`: the only caller was its focused test; it only composed `_telegram_binding_command_targets` with `_telegram_materialize_command_target`. The test now uses those production operations directly.
- `_find_existing_inbound_message`: its query was identical to `find_existing_inbound_provider_event`; both call sites pass the same explicit scope, so replacing them is mechanical.
- Discord gateway `worker_id` / `_worker_id`: written in the constructor and never read anywhere in the repository.
- `_DiscordGatewaySessionStore.get`, `clear`, `__len__`, and `session_ids`: no production caller. Tests now use the production operations (`touch`, `connect`, and `disconnect`) and replace the process-local store to model restart.
- Telegram webhook `ChannelAccount` arguments: unused by validation/delivery and supplied by only the known router/worker call sites; removing them does not change webhook URL, headers, payload, timeout, or outcome handling.
- Four imports in `channel_routers/public.py`: module dependency checks found no reverse import from the Telegram or Discord routers, so they are safely module-level and the function-local cycle workaround is unnecessary.

The post-change scan found no Telegram/Discord function-local imports in scope. The two remaining channel-router local imports are WhatsApp-specific and intentionally untouched.

## Consumer check

There is no emitted-dictionary, API schema, or wire-shape change in this diff. No `apps/web` consumer migration is required.

## Audit findings intentionally left unchanged

- Telegram account-level profile fallback reads legacy account config only when exactly one active link exists. Dedicated regression coverage establishes this as legacy-data behavior, so removing it belongs in a compatibility change.
- A Discord 2xx send with invalid JSON/metadata can still return provider success while skipping the local outbound record and logging a warning. That can split provider and backend state and needs a separate behavioral fix.
- Telegram/Discord pair/unpair command replay has best-effort `HTTPException` return paths; some outer paths log/audit while some replay paths return silently. Changing error propagation after durable pairing is not cleanup-only.
- Telegram reference persistence failure rolls back local reference bookkeeping but still returns the successful provider response. This is logged and is explicitly provider-success-after-bookkeeping behavior.
- Telegram webhook delivery maps `SafePublicHttpError` to `false` and a failure metric without a log; the durable webhook worker owns backoff/retry. Adding diagnostics requires a separate sensitive-data review.
- Message send paths contain no nested retry: Telegram and Discord each issue one provider request, and 429 handling only carries `Retry-After` to the durable delivery scheduler. Gateway reconnect and command reconciliation retries are separate protocol/projection workers.

## Diff size

9 files changed, 54 insertions, 142 deletions: net **-88 lines**.

## Verification

- focused non-database channel/Telegram/Discord tests: **51 passed**
- core database-backed channel/Telegram/Discord suite: **502 passed, 1 skipped**
- peripheral related selectors: **19 passed**
- throwaway database contract: PostgreSQL **18.4**, pgvector **0.8.6**, pg_trgm **1.6**
- `uv run ruff check .`
- `uv run ruff format --check` on all changed Python files
- `uv run python -m compileall app scripts tests alembic`
- `uv run --extra mem0 python scripts/type_governance.py owned`: **187 files, 0 errors, 0 warnings**
- `git diff --check origin/main..HEAD`

The full-repository Ruff format check still reports only the pre-existing formatting difference in unchanged `backend/tests/test_projects_routes.py`.
