### PR TITLE
fix(web): manage compute subscriptions in place

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3996,7 +3996,10 @@ test("paid card subscription confirms an immediate quoted upgrade", async ({ pag
 	});
 	await gotoHostedAgentSettings(page, "hdep_paid", "Basic");
 
-	await page.getByRole("button", { name: "Change plan, term, or payment source" }).click();
+	await page
+		.locator('[data-slot="compute-subscription-card"]')
+		.getByRole("button", { name: "Manage", exact: true })
+		.click();
 	const changeDialog = page.getByRole("dialog");
 	await expect(changeDialog.getByRole("button", { name: "Card", exact: true })).toHaveAttribute(
 		"aria-pressed",
@@ -4010,7 +4013,7 @@ test("paid card subscription confirms an immediate quoted upgrade", async ({ pag
 	await changeDialog.getByRole("button", { name: "Confirm upgrade" }).click();
 
 	expect(JSON.parse(planQuoteRequests[0] ?? "{}")).toEqual({
-		subscription_id: 42,
+		deployment_id: "hdep_paid",
 		target_plan_slug: "compute_performance",
 		target_billing_term_months: 12,
 		funding_source: "stripe",
@@ -4025,7 +4028,9 @@ test("paid card subscription confirms an immediate quoted upgrade", async ({ pag
 	await changeDialog.getByRole("button", { name: "Close", exact: true }).last().click();
 	await expect(changeDialog).not.toBeVisible();
 	await expect(
-		page.getByRole("button", { name: "Check subscription change status" }),
+		page
+			.locator('[data-slot="compute-subscription-card"]')
+			.getByRole("button", { name: "Manage", exact: true }),
 	).toBeVisible();
 	await expect(page.getByText("Plan changed", { exact: true })).toBeVisible();
 	expect(errors, `paid card upgrade: ${errors.join(" | ")}`).toEqual([]);
@@ -4071,14 +4076,17 @@ test("paid card subscription switches future renewals to Wallet", async ({ page 
 	});
 	await gotoHostedAgentSettings(page, "hdep_paid", "Basic");
 
-	await page.getByRole("button", { name: "Change plan, term, or payment source" }).click();
+	await page
+		.locator('[data-slot="compute-subscription-card"]')
+		.getByRole("button", { name: "Manage", exact: true })
+		.click();
 	const changeDialog = page.getByRole("dialog");
 	await changeDialog.getByRole("button", { name: "Wallet", exact: true }).click();
 	await changeDialog.getByRole("button", { name: "Review change" }).click();
 
 	await expect.poll(() => planQuoteRequests.length).toBe(1);
 	expect(JSON.parse(planQuoteRequests[0] ?? "{}")).toEqual({
-		subscription_id: 42,
+		deployment_id: "hdep_paid",
 		target_plan_slug: "compute_basic",
 		target_billing_term_months: 12,
 		funding_source: "wallet",

--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -9,9 +9,11 @@ import {
 	gotoHostedSettingsDialog,
 	paidBasicDeployment,
 	performancePlan,
+	planChangeQuoteResponse,
 	sharedLegacyCloudAgent,
 	stubHostedApi,
 	terminalFallbackDeployment,
+	walletActiveDeployment,
 } from "./hosted-stub-api";
 
 type Subscription = DeployComponents["schemas"]["V2ComputeSubscriptionListItem"];
@@ -25,6 +27,7 @@ const testAvatarUrl =
 const activeEnvironmentId = "11111111-1111-4111-8111-111111111111";
 const cancelingEnvironmentId = "22222222-2222-4222-8222-222222222222";
 const paidEnvironmentId = "33333333-3333-4333-8333-333333333333";
+const pastDueEnvironmentId = "44444444-4444-4444-8444-444444444444";
 const accountActiveDeployment = {
 	...paidBasicDeployment,
 	id: "hdep_active",
@@ -43,6 +46,15 @@ const accountCancelingDeployment = {
 		clawdi_cloud_environments: { hermes: cancelingEnvironmentId },
 	},
 };
+const accountPastDueDeployment = {
+	...walletActiveDeployment,
+	id: "hdep_past_due",
+	name: "Account past due deployment",
+	config_info: {
+		...walletActiveDeployment.config_info,
+		clawdi_cloud_environments: { hermes: pastDueEnvironmentId },
+	},
+};
 const accountCloudAgents = [
 	{
 		...sharedLegacyCloudAgent,
@@ -57,6 +69,13 @@ const accountCloudAgents = [
 		id: cancelingEnvironmentId,
 		name: "account-canceling",
 		default_name: "Canceling agent",
+		display_name: null,
+	},
+	{
+		...sharedLegacyCloudAgent,
+		id: pastDueEnvironmentId,
+		name: "account-past-due",
+		default_name: "Past due agent",
 		display_name: null,
 	},
 ];
@@ -104,7 +123,6 @@ async function expectCardsFit(container: Locator) {
 					box: box.toJSON(),
 					actionBox: actionBox?.toJSON() ?? null,
 					actionItemBoxes,
-					detailCount: card.querySelectorAll("dl > div").length,
 				};
 			}),
 		);
@@ -112,7 +130,6 @@ async function expectCardsFit(container: Locator) {
 	expect(metrics).not.toHaveLength(0);
 	for (const metric of metrics) {
 		expect(metric.scrollWidth).toBeLessThanOrEqual(metric.clientWidth + 1);
-		expect(metric.detailCount).toBe(4);
 		if (metric.actionBox) {
 			expect(metric.actionBox.x).toBeGreaterThanOrEqual(metric.box.x - 1);
 			expect(metric.actionBox.x + metric.actionBox.width).toBeLessThanOrEqual(
@@ -137,10 +154,6 @@ async function expectCardsFit(container: Locator) {
 			}
 		}
 	}
-}
-
-async function expectFactLabels(card: Locator) {
-	await expect(card.locator("dt")).toHaveText(["Plan", "Payment", "Price", "Schedule"]);
 }
 
 async function expectNoHorizontalOverflow(page: Page) {
@@ -205,9 +218,27 @@ async function expectSourceDialogGeometry(
 test("subscription cards preserve pagination and reveal loaded history", async ({ page }) => {
 	await page.setViewportSize({ width: 1440, height: 900 });
 	const errors = collectBrowserErrors(page);
+	const planQuoteRequests: string[] = [];
 	await stubHostedApi(page, {
-		deployments: [accountActiveDeployment, accountCancelingDeployment],
+		deployments: [accountActiveDeployment, accountPastDueDeployment, accountCancelingDeployment],
 		cloudAgents: accountCloudAgents,
+		planQuoteRequests,
+		planQuoteResponses: [
+			planChangeQuoteResponse({
+				operationId: "op_account_past_due_to_card",
+				subscriptionId: 42,
+				fundingSource: "stripe",
+				currentPlanSlug: "compute_basic",
+				targetPlanSlug: "compute_basic",
+				currentBillingTermMonths: 1,
+				targetBillingTermMonths: 1,
+				changeKind: "funding_source_switch",
+				effectiveAt: "2026-07-16T00:00:00Z",
+				amountCents: 0,
+				amountUsd: "0.00",
+			}),
+		],
+		plans: [basicPlan, performancePlan],
 		subscriptionPages: {
 			initial: {
 				items: [],
@@ -229,6 +260,13 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 			"current-page": {
 				items: [
 					subscription("active", "active", { agent_name: longAgentName }),
+					subscription("past_due", "past_due", {
+						plan_slug: "compute_basic",
+						funding_source: "wallet",
+						price_cents: 900,
+						billing_term_months: 1,
+						agent_name: "Past due agent",
+					}),
 					subscription("canceling", "canceling", {
 						cancel_at_period_end: true,
 						current_period_end: "2025-08-12T12:00:00Z",
@@ -261,27 +299,29 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(dialog.getByText("Canceling agent", { exact: true })).toBeVisible();
 	await expect(dialog.getByText("Active", { exact: true })).toBeVisible();
 	await expect(dialog.getByText("Canceling", { exact: true })).toBeVisible();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(2);
-	const accountManage = dialog.getByRole("button", { name: "Manage", exact: true }).first();
-	await expect(accountManage).toHaveAttribute(
-		"href",
-		/\/agents\/hdep_active\/settings.*settings=billing-plan/,
-	);
-	await expect(accountManage.locator("svg.lucide-settings")).toHaveCount(1);
-	await expect(dialog.getByRole("button", { name: "Cancel subscription" })).toBeVisible();
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(3);
+	await expect(dialog.getByRole("button", { name: "Manage", exact: true })).toHaveCount(2);
 	await expect(dialog.getByRole("button", { name: "Resume subscription" })).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Show history (2)" })).toBeVisible();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(2);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(3);
 	const currentCards = dialog.locator('[data-slot="compute-subscription-card"]');
 	const activeCard = currentCards.nth(0);
+	const pastDueCard = currentCards.nth(1);
+	const cancelingCard = currentCards.nth(2);
+	await expect(activeCard.getByRole("button", { name: "Cancel subscription" })).toBeVisible();
 	await expect(activeCard.locator("h4")).toHaveText(`${longAgentName}: Performance compute`);
 	await expect(activeCard.getByText(longAgentName, { exact: true })).toBeVisible();
 	await expect(activeCard.locator("img")).toHaveCount(1);
-	await expectFactLabels(activeCard);
+	await expect(activeCard.getByText("Performance compute", { exact: true })).toBeVisible();
+	await expect(activeCard.getByText("Card", { exact: true })).toBeVisible();
+	await expect(activeCard.getByText("$190.00/yr", { exact: true })).toBeVisible();
+	await expect(pastDueCard.getByText("Past due", { exact: true })).toBeVisible();
+	await expect(pastDueCard.getByText("Due Aug 12, 2099", { exact: true })).toBeVisible();
+	await expect(cancelingCard.getByRole("button", { name: "Manage", exact: true })).toHaveCount(0);
 	const currentStatuses = await currentCards.evaluateAll((cards) =>
 		cards.map((card) => card.getAttribute("data-subscription-status")),
 	);
-	expect(currentStatuses).toEqual(["active", "canceling"]);
+	expect(currentStatuses).toEqual(["active", "past-due", "canceling"]);
 	const desktopCardBoxes = await currentCards.evaluateAll((cards) =>
 		cards.map((card) => card.getBoundingClientRect().toJSON()),
 	);
@@ -294,13 +334,13 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expectCardsFit(dialog);
 
 	await dialog.getByRole("button", { name: "Show history (2)" }).click();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(4);
-	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(4);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(5);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(5);
 	await expect(dialog.getByText("Canceled", { exact: true })).toHaveCount(2);
 	const visibleStatuses = await dialog
 		.locator('[data-slot="compute-subscription-card"]')
 		.evaluateAll((cards) => cards.map((card) => card.getAttribute("data-subscription-status")));
-	expect(visibleStatuses).toEqual(["active", "canceling", "canceled", "canceled"]);
+	expect(visibleStatuses).toEqual(["active", "past-due", "canceling", "canceled", "canceled"]);
 	const orphanCard = dialog
 		.locator('[data-slot="compute-subscription-card"]')
 		.filter({ hasText: "Deleted agent" });
@@ -310,10 +350,64 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(orphanCard.getByText("Unknown", { exact: true })).toHaveCount(0);
 	await expect(orphanCard.getByText("No linked agent", { exact: true })).toHaveCount(0);
 	await expect(dialog.getByText("ended_second", { exact: true })).toBeVisible();
+	await expect(orphanCard.getByRole("button", { name: "Manage", exact: true })).toHaveCount(0);
+	const canceledCards = dialog
+		.locator('[data-slot="compute-subscription-card"]')
+		.filter({ hasText: "Canceled" });
+	await expect(canceledCards.getByRole("button", { name: "Manage", exact: true })).toHaveCount(0);
 	await expectCardsFit(dialog);
 
+	const accountSettingsUrl = page.url();
+	await activeCard.getByRole("button", { name: "Manage", exact: true }).click();
+	const fullManagementDialog = page.getByRole("dialog", { name: "Change compute subscription" });
+	await expect(fullManagementDialog).toBeVisible();
+	await expect(dialog).toBeVisible();
+	expect(page.url()).toBe(accountSettingsUrl);
+	await expect(fullManagementDialog.getByLabel("Compute plan")).toHaveText(/Performance/);
+	await fullManagementDialog.getByLabel("Compute plan").click();
+	await page.getByRole("option", { name: "Basic", exact: true }).click();
+	await expect(fullManagementDialog.getByLabel("Compute plan")).toHaveText(/Basic/);
+	await fullManagementDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+	await expect(fullManagementDialog).toBeHidden();
+	await expect(dialog).toBeVisible();
+	await expect(dialog.getByRole("button", { name: "Hide history" })).toBeVisible();
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(5);
+	expect(page.url()).toBe(accountSettingsUrl);
+
+	await pastDueCard.getByRole("button", { name: "Manage", exact: true }).click();
+	const paymentSourceDialog = page.getByRole("dialog", { name: "Change payment source" });
+	await expect(paymentSourceDialog).toBeVisible();
+	await expect(dialog).toBeVisible();
+	expect(page.url()).toBe(accountSettingsUrl);
+	await expect(paymentSourceDialog.getByText("Current plan", { exact: true })).toBeVisible();
+	await expect(paymentSourceDialog.getByText("Basic", { exact: true })).toBeVisible();
+	await expect(paymentSourceDialog.getByText("Monthly", { exact: true })).toBeVisible();
+	await expect(paymentSourceDialog.getByLabel("Compute plan")).toHaveCount(0);
+	await expect(
+		paymentSourceDialog.getByRole("button", { name: "Wallet", exact: true }),
+	).toHaveAttribute("aria-pressed", "true");
+	await paymentSourceDialog.getByRole("button", { name: "Card", exact: true }).click();
+	await paymentSourceDialog.getByRole("button", { name: "Review change" }).click();
+	await expect.poll(() => planQuoteRequests.length).toBe(1);
+	expect(JSON.parse(planQuoteRequests[0] ?? "{}")).toEqual({
+		deployment_id: "hdep_past_due",
+		target_plan_slug: "compute_basic",
+		target_billing_term_months: 1,
+		funding_source: "stripe",
+	});
+	const confirmPaymentSourceDialog = page.getByRole("dialog", {
+		name: "Confirm payment source change",
+	});
+	await expect(confirmPaymentSourceDialog).toBeVisible();
+	await confirmPaymentSourceDialog.getByRole("button", { name: "Back", exact: true }).click();
+	await expect(paymentSourceDialog).toBeHidden();
+	await expect(dialog).toBeVisible();
+	await expect(dialog.getByRole("button", { name: "Hide history" })).toBeVisible();
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(5);
+	expect(page.url()).toBe(accountSettingsUrl);
+
 	await dialog.getByRole("button", { name: "Hide history" }).click();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(2);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(3);
 	await expect(dialog.getByText("ended_first", { exact: true })).toHaveCount(0);
 
 	await page.setViewportSize({ width: 320, height: 568 });
@@ -323,7 +417,7 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	const mobileCardBoxes = await dialog
 		.locator('[data-slot="compute-subscription-card"]')
 		.evaluateAll((cards) => cards.map((card) => card.getBoundingClientRect().toJSON()));
-	expect(mobileCardBoxes[1]?.y ?? 0).toBeGreaterThan(mobileCardBoxes[0]?.bottom ?? 0);
+	expect(mobileCardBoxes[1]?.y ?? 0).toBeGreaterThanOrEqual(mobileCardBoxes[0]?.bottom ?? 0);
 	const longAgentStyle = await dialog
 		.getByText(longAgentName, { exact: true })
 		.evaluate((agent) => {
@@ -396,11 +490,9 @@ test("agent settings uses the subscription card without changing plan actions", 
 		"data-status",
 		"success",
 	);
-	await expect(activeCard.locator("dl > div")).toHaveCount(4);
 	await expect(activeCard.locator("h3")).toHaveText("Paid research agent: Basic compute");
 	await expect(activeCard.getByText("Paid research agent", { exact: true })).toBeVisible();
 	await expect(activeCard.locator("img")).toHaveCount(1);
-	await expectFactLabels(activeCard);
 	const agentManage = activeCard.getByRole("button", { name: "Manage", exact: true });
 	await expect(agentManage).toBeVisible();
 	await expect(agentManage.locator("svg.lucide-settings")).toHaveCount(1);
@@ -423,8 +515,6 @@ test("agent settings uses the subscription card without changing plan actions", 
 		"data-status",
 		"warning",
 	);
-	await expect(cancelingCard.locator("dl > div")).toHaveCount(4);
-	await expectFactLabels(cancelingCard);
 	await expect(cancelingCard.getByRole("button", { name: "Manage", exact: true })).toBeDisabled();
 	await expect(cancelingCard.getByRole("button", { name: "Resume subscription" })).toBeVisible();
 	await expectCardsFit(page.locator("body"));
@@ -438,6 +528,12 @@ test("agent settings uses the subscription card without changing plan actions", 
 		"destructive",
 	);
 	await expect(pastDueCard.getByRole("button", { name: "Manage", exact: true })).toBeVisible();
+	await pastDueCard.getByRole("button", { name: "Manage", exact: true }).click();
+	const paymentSourceDialog = page.getByRole("dialog", { name: "Change payment source" });
+	await expect(paymentSourceDialog).toBeVisible();
+	await expect(paymentSourceDialog.getByLabel("Compute plan")).toHaveCount(0);
+	await expect(paymentSourceDialog.getByText("Current plan", { exact: true })).toBeVisible();
+	await paymentSourceDialog.getByRole("button", { name: "Cancel", exact: true }).click();
 	await expectCardsFit(page.locator("body"));
 
 	await gotoHostedAgentSettings(page, "hdep_card_action_required", "Basic");
@@ -460,7 +556,6 @@ test("agent settings uses the subscription card without changing plan actions", 
 		"data-status",
 		"success",
 	);
-	await expectFactLabels(fallbackCard);
 	await expect(fallbackCard.getByText("Payment", { exact: true })).toBeVisible();
 	await expect(fallbackCard.getByText("Included", { exact: true })).toBeVisible();
 	await expect(fallbackCard.getByRole("button", { name: "Choose a subscription" })).toBeVisible();

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -139,13 +139,7 @@ import {
 	useCheckoutReturnHandler,
 } from "@/hosted/billing/checkout-return";
 import { ComputeDunningBanner } from "@/hosted/billing/components/compute-dunning-banner";
-import type {
-	ComputePlanChangeQuoteRequest,
-	ComputePlanChangeQuoteResponse,
-	ComputePlanChangeResult,
-	DeploymentUpdateRequest,
-	HostedDeployment,
-} from "@/hosted/billing/contracts";
+import type { DeploymentUpdateRequest, HostedDeployment } from "@/hosted/billing/contracts";
 import { navigateToAcceptedDeployment } from "@/hosted/billing/deploy/accepted-deployment-navigation";
 import {
 	fallbackTimezones,
@@ -159,45 +153,35 @@ import {
 import {
 	billingErrorNormalizer,
 	billingQueryRetry,
-	isPaymentMethodRequiredError,
 	normalizeBillingError,
-	PlanChangePendingError,
-	PlanChangeTerminalError,
 } from "@/hosted/billing/errors";
 import {
 	billingKeys,
 	useCancelSubscription,
-	useChangePlan,
-	useCheckPlanChange,
 	useManagedModelCatalog,
 	usePlans,
-	useQuotePlanChange,
 	useResumeSubscription,
 } from "@/hosted/billing/hooks";
-import { useSensitiveBillingPortal } from "@/hosted/billing/sensitive-actions";
 import {
 	ComputeSubscriptionCard,
 	computeSubscriptionCardView,
 } from "@/hosted/billing/subscription/compute-subscription-card";
 import {
 	activePlanChangeOperationName,
-	isCombinedPaidPlanChange,
-	isFundingSourceOnlySelection,
-	isValidPaidPlanChangeQuote,
-	type PlanChangeSelection,
 	performanceUpgradeUnavailableReason,
-	planChangeUnavailableReason,
-	shouldRecoverWalletToCardSwitch,
-	visiblePlanChangeOperationName,
 } from "@/hosted/billing/subscription/plan-change.logic";
-import { PlanChangeDialog } from "@/hosted/billing/subscription/plan-change-dialog";
+import {
+	PlanChangeController,
+	type PlanChangeTarget,
+	planChangeBillingTerm,
+	planChangeTargetUnavailableReason,
+} from "@/hosted/billing/subscription/plan-change-controller";
 import { SubscriptionCreateDialog } from "@/hosted/billing/subscription/subscription-create-dialog";
 import {
 	COMPUTE_BASIC_SLUG,
 	COMPUTE_PERFORMANCE_SLUG,
 	computeFundingMode,
 	computeFundingSource,
-	computeSubscriptionId,
 	computeSubscriptionLifecycle,
 	computeTierLabel,
 	isComputeSubscriptionCancelable,
@@ -210,12 +194,6 @@ import {
 	selectOfferForTerm,
 } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
-import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
-import {
-	useWalletTopUpDialog,
-	type WalletFundingErrorCopy,
-} from "@/hosted/billing/wallet/wallet-funding";
-import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
 import {
 	type DeploymentFailurePresentation,
 	deploymentFailurePresentation,
@@ -444,17 +422,6 @@ function StartComputeAction({
 		</Button>
 	);
 }
-
-function planChangeBillingTerm(
-	value: number,
-): ComputePlanChangeQuoteRequest["target_billing_term_months"] {
-	return value === 12 ? 12 : 1;
-}
-
-const PLAN_CHANGE_WALLET_FUNDING_ERROR_COPY = {
-	insufficientBalance: "Top up the shortfall, then request a fresh plan-change quote.",
-	refundDebt: "Top up before confirming this wallet-funded plan change.",
-} satisfies WalletFundingErrorCopy;
 
 /**
  * Hosted agent detail. A compute (deployment) hosts one selected execution
@@ -3597,27 +3564,9 @@ function ComputeSettingsSections({
 	const hostedAccess = useHostedProductAccess();
 	const lifecycle = useDeploymentLifecycle();
 	const plans = usePlans();
-	const quotePlanChange = useQuotePlanChange();
-	const billingPortal = useSensitiveBillingPortal();
-	const projectedPlanChangeName = activePlanChangeOperationName(deployment);
-	const [acceptedPlanChangeName, setAcceptedPlanChangeName] = useState<string | null>(null);
-	const [ignoredPlanChangeNames, setIgnoredPlanChangeNames] = useState<readonly string[]>([]);
-	const visibleProjectedPlanChangeName = visiblePlanChangeOperationName(
-		projectedPlanChangeName,
-		ignoredPlanChangeNames,
-	);
-	const pendingPlanChangeName = acceptedPlanChangeName ?? visibleProjectedPlanChangeName;
-	const changePlan = useChangePlan((operationName) => {
-		setAcceptedPlanChangeName(operationName);
-	});
-	const checkPlanChange = useCheckPlanChange();
 	const [subscriptionCreateOpen, setSubscriptionCreateOpen] = useState(false);
 	const [planChangeOpen, setPlanChangeOpen] = useState(false);
-	const wallet = useWalletSnapshot({
-		enabled:
-			deployment.commercial_display?.compute_subscription?.funding_source === "wallet" ||
-			(hostedAccess.canCreateCloudAgents && planChangeOpen),
-	});
+	const [hasPendingPlanChange, setHasPendingPlanChange] = useState(false);
 	const cancelSubscription = useCancelSubscription();
 	const resumeSubscription = useResumeSubscription();
 	const runAction = useActionLock();
@@ -3649,15 +3598,9 @@ function ComputeSettingsSections({
 		isIncludedBasic && fundingFact?.fact_kind === "funding_revoked" ? fundingFact : null;
 	const hasWalletFallback = terminalFundingFact?.funding_source === "wallet";
 	const hasTerminalFallback = terminalFundingFact !== null;
-	const subscriptionId = computeSubscriptionId(currentSubscription);
 	const pendingPlanSlug = pendingComputePlanSlug(currentSubscription);
 	const tierLabel = computeTierLabel(computePlanSlug);
 	const currentBillingTerm = planChangeBillingTerm(currentSubscription?.billing_term_months ?? 1);
-	const [planChangeQuote, setPlanChangeQuote] = useState<ComputePlanChangeQuoteResponse | null>(
-		null,
-	);
-	const [planChangePaymentMethodRequired, setPlanChangePaymentMethodRequired] = useState(false);
-	const walletTopUp = useWalletTopUpDialog(PLAN_CHANGE_WALLET_FUNDING_ERROR_COPY);
 	const basicPlan = useMemo(() => resolveBasicPlan(plans.data), [plans.data]);
 	const perfPlan = useMemo(() => resolvePerformancePlan(plans.data), [plans.data]);
 	const blockingPlansError = shouldBlockQueryError(plans.error, plans.data) ? plans.error : null;
@@ -3763,13 +3706,34 @@ function ComputeSettingsSections({
 			)
 		: null;
 	const subscriptionCancelable = isComputeSubscriptionCancelable(currentSubscription);
-	const paymentSourceOnly = currentSubscription?.status === "past_due";
-	const planChangeUnavailable = currentSubscription
-		? planChangeUnavailableReason({
+	const paymentSourceOnly =
+		currentSubscription?.status === "past_due" || currentSubscription?.payment_state === "past_due";
+	const planChangeStatus =
+		currentSubscription?.status === "unpaid" || currentSubscription?.payment_state === "unpaid"
+			? "unpaid"
+			: paymentSourceOnly
+				? "past_due"
+				: currentSubscription?.status;
+	const planChangeTarget: PlanChangeTarget | null =
+		currentSubscription && computePlanSlug && planChangeStatus
+			? {
+					deploymentId: deployment.resource.id,
+					currentPlanSlug: computePlanSlug,
+					initialPlanSlug: isIncludedBasic ? COMPUTE_PERFORMANCE_SLUG : computePlanSlug,
+					currentBillingTermMonths: currentBillingTerm,
+					currentFundingSource: isWalletFunded ? "wallet" : "stripe",
+					status: planChangeStatus,
+					paymentSourceOnly,
+					cancelAtPeriodEnd: subscriptionCancelPending,
+					isPaidCompute,
+					allowCombinedChange: isIncludedBasic,
+					projectedOperationName: activePlanChangeOperationName(deployment),
+				}
+			: null;
+	const planChangeUnavailable = planChangeTarget
+		? planChangeTargetUnavailableReason({
 				canCreateCloudAgents: hostedAccess.canCreateCloudAgents,
-				cancelAtPeriodEnd: subscriptionCancelPending,
-				status: currentSubscription.status,
-				subscriptionId,
+				target: planChangeTarget,
 			})
 		: "Choose a subscription to change this agent’s paid compute.";
 	const upgradeUnavailableMessage = performanceUpgradeUnavailableReason({
@@ -3808,210 +3772,7 @@ function ComputeSettingsSections({
 		if (hostedAccess.isLoading || hostedAccess.canCreateCloudAgents) return;
 		setSubscriptionCreateOpen(false);
 		setPlanChangeOpen(false);
-		setAcceptedPlanChangeName(null);
-		walletTopUp.reset();
-	}, [hostedAccess.canCreateCloudAgents, hostedAccess.isLoading, walletTopUp.reset]);
-	function ignorePlanChangeOperation(operationName: string | null) {
-		if (operationName === null) return;
-		setIgnoredPlanChangeNames((current) =>
-			current.includes(operationName) ? current : [...current, operationName],
-		);
-	}
-
-	function setPlanChangeDialogOpen(open: boolean) {
-		setPlanChangeOpen(open);
-	}
-
-	async function openPaymentMethods() {
-		ignorePlanChangeOperation(pendingPlanChangeName);
-		setPlanChangeQuote(null);
-		setPlanChangePaymentMethodRequired(false);
-		setAcceptedPlanChangeName(null);
-		try {
-			const result = await billingPortal.execute({});
-			const url = result.url || result.portal_url;
-			if (url) {
-				window.location.href = url;
-				return;
-			}
-			toast.error("Billing portal unavailable", {
-				description: "Refresh this page and try again in a moment.",
-			});
-			setPlanChangePaymentMethodRequired(true);
-		} catch (error) {
-			setPlanChangePaymentMethodRequired(true);
-			toast.error("Couldn’t open billing", { description: normalizeBillingError(error) });
-		}
-	}
-
-	async function requestPlanChangeQuote(selection: PlanChangeSelection) {
-		if (
-			!hostedAccess.canCreateCloudAgents ||
-			!subscriptionId ||
-			!computePlanSlug ||
-			planChangeUnavailable !== null
-		) {
-			return;
-		}
-		if (
-			paymentSourceOnly &&
-			!isFundingSourceOnlySelection(
-				selection,
-				computePlanSlug,
-				currentBillingTerm,
-				isWalletFunded ? "wallet" : "stripe",
-			)
-		) {
-			toast.error("Only the payment source can be changed", {
-				description:
-					"This subscription can’t change plan or billing term while past due. Choose a different payment source to continue.",
-			});
-			return;
-		}
-		if (
-			isPaidCompute &&
-			isCombinedPaidPlanChange(
-				selection,
-				computePlanSlug,
-				currentBillingTerm,
-				isWalletFunded ? "wallet" : "stripe",
-			)
-		) {
-			toast.error("Choose one subscription change", {
-				description:
-					"Change the plan or billing term using the current payment source, or change only the payment source.",
-			});
-			return;
-		}
-		try {
-			if (pendingPlanChangeName === null && !(await hostedAccess.recheckCanCreateCloudAgents())) {
-				setPlanChangeDialogOpen(false);
-				return;
-			}
-			const quote = await quotePlanChange.mutateAsync({
-				subscription_id: subscriptionId,
-				...selection,
-			});
-			const currentFundingSource = isWalletFunded ? "wallet" : "stripe";
-			const validPaidQuote =
-				!isPaidCompute ||
-				isValidPaidPlanChangeQuote(
-					quote,
-					selection,
-					computePlanSlug,
-					currentBillingTerm,
-					currentFundingSource,
-				);
-			if (!validPaidQuote) {
-				setPlanChangeQuote(null);
-				setAcceptedPlanChangeName(null);
-				setPlanChangePaymentMethodRequired(false);
-				toast.error("Couldn’t verify subscription change", {
-					description: "The quote did not match the requested change. Request a fresh quote.",
-				});
-				return;
-			}
-			setAcceptedPlanChangeName(null);
-			setPlanChangePaymentMethodRequired(false);
-			setPlanChangeQuote(quote);
-		} catch (error) {
-			if (
-				isPaidCompute &&
-				shouldRecoverWalletToCardSwitch(
-					error,
-					selection,
-					computePlanSlug,
-					currentBillingTerm,
-					isWalletFunded ? "wallet" : "stripe",
-				)
-			) {
-				setPlanChangeQuote(null);
-				setAcceptedPlanChangeName(null);
-				setPlanChangePaymentMethodRequired(true);
-				return;
-			}
-			toast.error("Couldn’t quote subscription change", {
-				description: normalizeBillingError(error),
-			});
-		}
-	}
-
-	function showPlanChangeResult(result: ComputePlanChangeResult) {
-		if (result.kind === "scheduled") {
-			toast.success("Downgrade scheduled", {
-				description: `Your current compute remains active until ${formatShortDate(result.effectiveAt)}.`,
-			});
-		} else {
-			if (result.changeKind === "funding_source_switch") {
-				toast.success("Payment method updated", {
-					description:
-						result.fundingSource === "wallet"
-							? "Future renewals will use Wallet."
-							: "Future renewals will use Card.",
-				});
-			} else {
-				toast.success("Plan changed", {
-					description: "Your compute subscription has been updated.",
-				});
-			}
-		}
-		setAcceptedPlanChangeName(null);
-		ignorePlanChangeOperation(result.operationName);
-		setPlanChangeQuote(null);
-		setPlanChangePaymentMethodRequired(false);
-		setPlanChangeDialogOpen(false);
-	}
-
-	function handlePlanChangeError(error: unknown) {
-		if (error instanceof PlanChangePendingError) {
-			setAcceptedPlanChangeName(error.operationName);
-			toast.info("Still waiting for confirmation", {
-				description:
-					"We don’t have a final result yet. Don’t submit another subscription change. Check again in a few minutes; if it still hasn’t finished, contact support. Checking only reads the status and does not submit another request or charge.",
-			});
-			return;
-		}
-		if (error instanceof PlanChangeTerminalError) {
-			setAcceptedPlanChangeName(null);
-			ignorePlanChangeOperation(error.operationName ?? pendingPlanChangeName);
-			setPlanChangeQuote(null);
-			setPlanChangePaymentMethodRequired(false);
-			if (
-				error.fundingSource === "stripe" &&
-				error.changeKind === "funding_source_switch" &&
-				isPaymentMethodRequiredError(error)
-			) {
-				setPlanChangePaymentMethodRequired(true);
-				return;
-			}
-		}
-		if (walletTopUp.handleFundingError(error)) return;
-		toast.error("Couldn’t update subscription", {
-			description: normalizeBillingError(error),
-		});
-	}
-
-	async function confirmPlanChange(operationId: string) {
-		if (!planChangeQuote) return;
-		try {
-			if (!(await hostedAccess.recheckCanCreateCloudAgents())) {
-				setPlanChangeDialogOpen(false);
-				return;
-			}
-			showPlanChangeResult(await changePlan.mutateAsync({ operation_id: operationId }));
-		} catch (error) {
-			handlePlanChangeError(error);
-		}
-	}
-
-	async function checkAcceptedPlanChange() {
-		if (!pendingPlanChangeName) return;
-		try {
-			showPlanChangeResult(await checkPlanChange.mutateAsync(pendingPlanChangeName));
-		} catch (error) {
-			handlePlanChangeError(error);
-		}
-	}
+	}, [hostedAccess.canCreateCloudAgents, hostedAccess.isLoading]);
 
 	async function cancelComputeSubscription() {
 		if (!subscriptionCancelable || subscriptionCancelPending) {
@@ -4050,9 +3811,6 @@ function ComputeSettingsSections({
 
 	return (
 		<div className="flex flex-col gap-8">
-			{wallet.data ? (
-				<TopUpDialog {...walletTopUp.dialogProps} onComplete={() => setPlanChangeQuote(null)} />
-			) : null}
 			{hasTerminalFallback ? (
 				<SubscriptionCreateDialog
 					open={subscriptionCreateOpen}
@@ -4063,36 +3821,13 @@ function ComputeSettingsSections({
 					initialBillingTermMonths={currentBillingTerm}
 				/>
 			) : null}
-			{currentSubscription &&
-			(computePlanSlug === COMPUTE_BASIC_SLUG || computePlanSlug === COMPUTE_PERFORMANCE_SLUG) ? (
-				<PlanChangeDialog
+			{planChangeTarget ? (
+				<PlanChangeController
 					open={planChangeOpen}
-					onOpenChange={setPlanChangeDialogOpen}
+					onOpenChange={setPlanChangeOpen}
+					onPendingChange={setHasPendingPlanChange}
+					target={planChangeTarget}
 					plans={plans.data ?? []}
-					currentPlanSlug={computePlanSlug}
-					initialPlanSlug={isIncludedBasic ? COMPUTE_PERFORMANCE_SLUG : computePlanSlug}
-					currentBillingTermMonths={currentBillingTerm}
-					currentFundingSource={isWalletFunded ? "wallet" : "stripe"}
-					allowCombinedChange={isIncludedBasic}
-					paymentSourceOnly={paymentSourceOnly}
-					quote={planChangeQuote}
-					walletBalanceUsd={wallet.data?.balance_usd ?? null}
-					isQuoting={quotePlanChange.isPending}
-					isConfirming={changePlan.isPending || checkPlanChange.isPending}
-					hasAcceptedChange={pendingPlanChangeName !== null}
-					onQuote={requestPlanChangeQuote}
-					onConfirm={confirmPlanChange}
-					onCheckStatus={checkAcceptedPlanChange}
-					onTopUp={() => walletTopUp.show()}
-					paymentMethodRequired={planChangePaymentMethodRequired}
-					isManagingPaymentMethods={billingPortal.isPending}
-					onManagePaymentMethods={() => void openPaymentMethods()}
-					onExitComplete={() => {
-						if (pendingPlanChangeName === null) {
-							setPlanChangeQuote(null);
-							setPlanChangePaymentMethodRequired(false);
-						}
-					}}
 				/>
 			) : null}
 
@@ -4117,7 +3852,7 @@ function ComputeSettingsSections({
 						hasTerminalFallback || isIncludedBasic || (isPaidCompute && currentSubscription) ? (
 							<div
 								id="compute-plan-controls"
-								className="flex w-full scroll-mt-6 flex-wrap items-center justify-end gap-2"
+								className="flex scroll-mt-6 flex-wrap items-center justify-end gap-2"
 							>
 								{isIncludedBasic && blockingPlansError ? (
 									<div className="w-full sm:w-72">
@@ -4133,17 +3868,17 @@ function ComputeSettingsSections({
 										<Button
 											size="sm"
 											disabled={
-												pendingPlanChangeName === null &&
+												!hasPendingPlanChange &&
 												(hasTerminalFallback
 													? !canStartNewSubscription
 													: plans.isLoading || !canUpgrade || !perfPlan)
 											}
 											onClick={() =>
-												pendingPlanChangeName
-													? setPlanChangeDialogOpen(true)
+												hasPendingPlanChange
+													? setPlanChangeOpen(true)
 													: hasTerminalFallback
 														? setSubscriptionCreateOpen(true)
-														: setPlanChangeDialogOpen(true)
+														: setPlanChangeOpen(true)
 											}
 										>
 											{hasTerminalFallback ? (
@@ -4151,7 +3886,7 @@ function ComputeSettingsSections({
 											) : (
 												<Zap data-icon="inline-start" />
 											)}
-											{pendingPlanChangeName
+											{hasPendingPlanChange
 												? "Check subscription change status"
 												: hasTerminalFallback
 													? "Choose a subscription"
@@ -4209,10 +3944,10 @@ function ComputeSettingsSections({
 												variant="outline"
 												size="sm"
 												disabled={
-													pendingPlanChangeName === null &&
+													!hasPendingPlanChange &&
 													(planChangeUnavailable !== null || !!pendingPlanSlug)
 												}
-												onClick={() => setPlanChangeDialogOpen(true)}
+												onClick={() => setPlanChangeOpen(true)}
 											>
 												<Settings data-icon="inline-start" />
 												Manage

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
@@ -3,8 +3,9 @@ import { UserRoundX } from "lucide-react";
 import type { ReactNode } from "react";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import { AgentLabel } from "@/components/dashboard/agent-label";
+import { entityCardChassisClass } from "@/components/entity-card";
 import { StatusBadge, type StatusTone } from "@/components/ui/status-badge";
-import { billingTermLabel, billingTermSuffix, formatCurrencyCents } from "@/hosted/billing/format";
+import { billingTermSuffix, formatCurrencyCents } from "@/hosted/billing/format";
 import { computeTierLabel } from "@/hosted/billing/subscription/subscription-utils";
 import { formatShortDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
@@ -25,7 +26,7 @@ export type ComputeSubscriptionCardView = {
 	facts: readonly [
 		{ label: "Plan"; value: string },
 		{ label: "Payment"; value: string },
-		{ label: "Price"; value: string; meta: string },
+		{ label: "Price"; value: string },
 		{ label: "Schedule"; value: string },
 	];
 };
@@ -85,7 +86,6 @@ export function computeSubscriptionCardView({
 						: priceCents == null
 							? "Unavailable"
 							: `${formatCurrencyCents(priceCents, currency)}${billingTermSuffix(billingTermMonths)}`,
-				meta: included ? "Included plan" : billingTermLabel(billingTermMonths),
 			},
 			{
 				label: "Schedule",
@@ -160,7 +160,11 @@ export function ComputeSubscriptionCard({
 	className?: string;
 }) {
 	const Heading = headingLevel === 4 ? "h4" : "h3";
-	const plan = view.facts[0];
+	const [plan, payment, price] = view.facts;
+	const hideIncludedPrice = payment.value === "Included" && price.value === "No charge";
+	const visibleMetadataFacts = view.facts
+		.slice(1)
+		.filter((fact) => !(fact.label === "Price" && hideIncludedPrice));
 	const identityLabel = view.identity.kind === "agent" ? view.identity.name : view.identity.label;
 
 	return (
@@ -168,13 +172,13 @@ export function ComputeSubscriptionCard({
 			data-hosted="true"
 			data-slot="compute-subscription-card"
 			data-subscription-status={view.status.label.toLowerCase().replaceAll(" ", "-")}
-			className={cn(
-				"flex h-full min-w-0 flex-col overflow-hidden rounded-lg border bg-card",
-				className,
-			)}
+			className={entityCardChassisClass({
+				variant: "compact",
+				className: cn("flex h-full min-w-0 flex-col gap-4", className),
+			})}
 		>
 			<Heading className="sr-only">{`${identityLabel}: ${plan.value}`}</Heading>
-			<header className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-3 px-4 py-3.5">
+			<header className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
 				<SubscriptionIdentity identity={view.identity} />
 				<div className="flex min-w-0 flex-wrap justify-end gap-1.5">
 					<StatusBadge status={view.status.tone} withDot>
@@ -184,36 +188,30 @@ export function ComputeSubscriptionCard({
 				</div>
 			</header>
 
-			<dl className="grid min-w-0 grid-cols-2 border-t">
-				{view.facts.map((fact, index) => (
-					<div
-						key={fact.label}
-						className={cn(
-							"min-w-0 px-4 py-3",
-							index % 2 === 1 && "border-l",
-							index >= 2 && "border-t",
-						)}
-					>
-						<dt className="text-xs text-muted-foreground">{fact.label}</dt>
-						<dd className="mt-0.5 min-w-0 text-sm font-medium [overflow-wrap:anywhere]">
-							{fact.value}
-						</dd>
-						{"meta" in fact ? (
-							<span className="mt-0.5 block text-xs text-muted-foreground">{fact.meta}</span>
-						) : null}
+			<dl className="flex min-w-0 flex-wrap items-baseline gap-x-4 gap-y-1.5">
+				<div className="min-w-0 basis-full">
+					<dt className="sr-only">{plan.label}</dt>
+					<dd className="min-w-0 text-base font-semibold leading-6 [overflow-wrap:anywhere]">
+						{plan.value}
+					</dd>
+				</div>
+				{visibleMetadataFacts.map((fact) => (
+					<div key={fact.label} className="min-w-0 text-xs text-muted-foreground">
+						<dt className="sr-only">{fact.label}</dt>
+						<dd className="[overflow-wrap:anywhere]">{fact.value}</dd>
 					</div>
 				))}
 			</dl>
 
 			{notice ? (
-				<div data-slot="compute-subscription-notice" className="min-w-0 border-t px-4 py-2.5">
+				<div data-slot="compute-subscription-notice" className="min-w-0 pt-1">
 					{notice}
 				</div>
 			) : null}
 			{actions ? (
 				<div
 					data-slot="compute-subscription-actions"
-					className="mt-auto flex min-w-0 flex-wrap items-center justify-end gap-2 border-t bg-muted/15 px-3 py-2"
+					className="mt-auto flex min-w-0 flex-wrap items-center justify-end gap-2"
 				>
 					{actions}
 				</div>

--- a/apps/web/src/hosted/billing/subscription/plan-change-controller.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-change-controller.tsx
@@ -1,0 +1,378 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import type {
+	ComputePlanChangeQuoteRequest,
+	ComputePlanChangeQuoteResponse,
+	ComputePlanChangeResult,
+	ComputePlanSlug,
+	Plan,
+} from "@/hosted/billing/contracts";
+import {
+	isPaymentMethodRequiredError,
+	normalizeBillingError,
+	PlanChangePendingError,
+	PlanChangeTerminalError,
+} from "@/hosted/billing/errors";
+import { useChangePlan, useCheckPlanChange, useQuotePlanChange } from "@/hosted/billing/hooks";
+import { useSensitiveBillingPortal } from "@/hosted/billing/sensitive-actions";
+import {
+	isCombinedPaidPlanChange,
+	isFundingSourceOnlySelection,
+	isValidPaidPlanChangeQuote,
+	type PlanChangeSelection,
+	planChangeUnavailableReason,
+	shouldRecoverWalletToCardSwitch,
+	visiblePlanChangeOperationName,
+} from "@/hosted/billing/subscription/plan-change.logic";
+import { PlanChangeDialog } from "@/hosted/billing/subscription/plan-change-dialog";
+import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
+import {
+	useWalletTopUpDialog,
+	type WalletFundingErrorCopy,
+} from "@/hosted/billing/wallet/wallet-funding";
+import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
+import { formatShortDate } from "@/lib/format";
+import { useHostedProductAccess } from "@/lib/hosted-product-access";
+
+const PLAN_CHANGE_WALLET_FUNDING_ERROR_COPY = {
+	insufficientBalance: "Top up the shortfall, then request a fresh plan-change quote.",
+	refundDebt: "Top up before confirming this wallet-funded plan change.",
+} satisfies WalletFundingErrorCopy;
+
+export type PlanChangeTarget = {
+	deploymentId: string;
+	currentPlanSlug: ComputePlanSlug;
+	initialPlanSlug: ComputePlanSlug;
+	currentBillingTermMonths: ComputePlanChangeQuoteRequest["target_billing_term_months"];
+	currentFundingSource: PlanChangeSelection["funding_source"];
+	status: string;
+	paymentSourceOnly: boolean;
+	cancelAtPeriodEnd: boolean;
+	isPaidCompute: boolean;
+	allowCombinedChange: boolean;
+	projectedOperationName: string | null;
+};
+
+export function planChangeBillingTerm(
+	value: number,
+): ComputePlanChangeQuoteRequest["target_billing_term_months"] {
+	return value === 12 ? 12 : 1;
+}
+
+export function planChangeTargetUnavailableReason({
+	canCreateCloudAgents,
+	target,
+}: {
+	canCreateCloudAgents: boolean;
+	target: PlanChangeTarget;
+}): string | null {
+	return planChangeUnavailableReason({
+		canCreateCloudAgents,
+		cancelAtPeriodEnd: target.cancelAtPeriodEnd,
+		status: target.status,
+		hasSubscriptionTarget: target.deploymentId.trim().length > 0,
+	});
+}
+
+export function planChangeTargetFingerprint(target: PlanChangeTarget): string {
+	return [
+		target.deploymentId.trim(),
+		target.currentPlanSlug,
+		target.initialPlanSlug,
+		target.currentBillingTermMonths,
+		target.currentFundingSource,
+		target.status,
+		target.paymentSourceOnly ? "payment-source-only" : "full-management",
+		target.cancelAtPeriodEnd ? "canceling" : "renewing",
+		target.isPaidCompute ? "paid-compute" : "included-compute",
+		target.allowCombinedChange ? "combined-change" : "single-change",
+	].join(":");
+}
+
+export function PlanChangeController({
+	...props
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onPendingChange?: (pending: boolean) => void;
+	target: PlanChangeTarget;
+	plans: Plan[];
+}) {
+	return <PlanChangeControllerState key={planChangeTargetFingerprint(props.target)} {...props} />;
+}
+
+function PlanChangeControllerState({
+	open,
+	onOpenChange,
+	onPendingChange,
+	target,
+	plans,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onPendingChange?: (pending: boolean) => void;
+	target: PlanChangeTarget;
+	plans: Plan[];
+}) {
+	const hostedAccess = useHostedProductAccess();
+	const quotePlanChange = useQuotePlanChange();
+	const billingPortal = useSensitiveBillingPortal();
+	const [acceptedOperationName, setAcceptedOperationName] = useState<string | null>(null);
+	const [ignoredOperationNames, setIgnoredOperationNames] = useState<readonly string[]>([]);
+	const [quote, setQuote] = useState<ComputePlanChangeQuoteResponse | null>(null);
+	const [paymentMethodRequired, setPaymentMethodRequired] = useState(false);
+	const walletTopUp = useWalletTopUpDialog(PLAN_CHANGE_WALLET_FUNDING_ERROR_COPY);
+	const deploymentId = target.deploymentId.trim();
+	const projectedOperationName = visiblePlanChangeOperationName(
+		target.projectedOperationName,
+		ignoredOperationNames,
+	);
+	const pendingOperationName = acceptedOperationName ?? projectedOperationName;
+	const changePlan = useChangePlan(setAcceptedOperationName);
+	const checkPlanChange = useCheckPlanChange();
+	const wallet = useWalletSnapshot({
+		enabled:
+			target.currentFundingSource === "wallet" || (hostedAccess.canCreateCloudAgents && open),
+	});
+	const unavailableReason = planChangeTargetUnavailableReason({
+		canCreateCloudAgents: hostedAccess.canCreateCloudAgents,
+		target,
+	});
+	useEffect(() => {
+		onPendingChange?.(pendingOperationName !== null);
+	}, [onPendingChange, pendingOperationName]);
+
+	useEffect(() => {
+		if (hostedAccess.isLoading || hostedAccess.canCreateCloudAgents) return;
+		onOpenChange(false);
+		setAcceptedOperationName(null);
+		walletTopUp.reset();
+	}, [hostedAccess.canCreateCloudAgents, hostedAccess.isLoading, onOpenChange, walletTopUp.reset]);
+
+	function ignoreOperation(operationName: string | null) {
+		if (operationName === null) return;
+		setIgnoredOperationNames((current) =>
+			current.includes(operationName) ? current : [...current, operationName],
+		);
+	}
+
+	async function openPaymentMethods() {
+		ignoreOperation(pendingOperationName);
+		setQuote(null);
+		setPaymentMethodRequired(false);
+		setAcceptedOperationName(null);
+		try {
+			const result = await billingPortal.execute({});
+			const url = result.url || result.portal_url;
+			if (url) {
+				window.location.href = url;
+				return;
+			}
+			toast.error("Billing portal unavailable", {
+				description: "Refresh this page and try again in a moment.",
+			});
+			setPaymentMethodRequired(true);
+		} catch (error) {
+			setPaymentMethodRequired(true);
+			toast.error("Couldn’t open billing", { description: normalizeBillingError(error) });
+		}
+	}
+
+	async function requestQuote(selection: PlanChangeSelection) {
+		if (!deploymentId || unavailableReason !== null) return;
+		if (
+			target.paymentSourceOnly &&
+			!isFundingSourceOnlySelection(
+				selection,
+				target.currentPlanSlug,
+				target.currentBillingTermMonths,
+				target.currentFundingSource,
+			)
+		) {
+			toast.error("Only the payment source can be changed", {
+				description:
+					"This subscription can’t change plan or billing term while past due. Choose a different payment source to continue.",
+			});
+			return;
+		}
+		if (
+			target.isPaidCompute &&
+			isCombinedPaidPlanChange(
+				selection,
+				target.currentPlanSlug,
+				target.currentBillingTermMonths,
+				target.currentFundingSource,
+			)
+		) {
+			toast.error("Choose one subscription change", {
+				description:
+					"Change the plan or billing term using the current payment source, or change only the payment source.",
+			});
+			return;
+		}
+		try {
+			if (pendingOperationName === null && !(await hostedAccess.recheckCanCreateCloudAgents())) {
+				onOpenChange(false);
+				return;
+			}
+			const nextQuote = await quotePlanChange.mutateAsync({
+				deployment_id: deploymentId,
+				...selection,
+			});
+			if (
+				target.isPaidCompute &&
+				!isValidPaidPlanChangeQuote(
+					nextQuote,
+					selection,
+					target.currentPlanSlug,
+					target.currentBillingTermMonths,
+					target.currentFundingSource,
+				)
+			) {
+				setQuote(null);
+				setAcceptedOperationName(null);
+				setPaymentMethodRequired(false);
+				toast.error("Couldn’t verify subscription change", {
+					description: "The quote did not match the requested change. Request a fresh quote.",
+				});
+				return;
+			}
+			setAcceptedOperationName(null);
+			setPaymentMethodRequired(false);
+			setQuote(nextQuote);
+		} catch (error) {
+			if (
+				target.isPaidCompute &&
+				shouldRecoverWalletToCardSwitch(
+					error,
+					selection,
+					target.currentPlanSlug,
+					target.currentBillingTermMonths,
+					target.currentFundingSource,
+				)
+			) {
+				setQuote(null);
+				setAcceptedOperationName(null);
+				setPaymentMethodRequired(true);
+				return;
+			}
+			toast.error("Couldn’t quote subscription change", {
+				description: normalizeBillingError(error),
+			});
+		}
+	}
+
+	function showResult(result: ComputePlanChangeResult) {
+		if (result.kind === "scheduled") {
+			toast.success("Downgrade scheduled", {
+				description: `Your current compute remains active until ${formatShortDate(result.effectiveAt)}.`,
+			});
+		} else if (result.changeKind === "funding_source_switch") {
+			toast.success("Payment method updated", {
+				description:
+					result.fundingSource === "wallet"
+						? "Future renewals will use Wallet."
+						: "Future renewals will use Card.",
+			});
+		} else {
+			toast.success("Plan changed", {
+				description: "Your compute subscription has been updated.",
+			});
+		}
+		setAcceptedOperationName(null);
+		ignoreOperation(result.operationName);
+		setQuote(null);
+		setPaymentMethodRequired(false);
+		onOpenChange(false);
+	}
+
+	function handleError(error: unknown) {
+		if (error instanceof PlanChangePendingError) {
+			setAcceptedOperationName(error.operationName);
+			toast.info("Still waiting for confirmation", {
+				description:
+					"We don’t have a final result yet. Don’t submit another subscription change. Check again in a few minutes; if it still hasn’t finished, contact support. Checking only reads the status and does not submit another request or charge.",
+			});
+			return;
+		}
+		if (error instanceof PlanChangeTerminalError) {
+			setAcceptedOperationName(null);
+			ignoreOperation(error.operationName ?? pendingOperationName);
+			setQuote(null);
+			setPaymentMethodRequired(false);
+			if (
+				error.fundingSource === "stripe" &&
+				error.changeKind === "funding_source_switch" &&
+				isPaymentMethodRequiredError(error)
+			) {
+				setPaymentMethodRequired(true);
+				return;
+			}
+		}
+		if (walletTopUp.handleFundingError(error)) return;
+		toast.error("Couldn’t update subscription", {
+			description: normalizeBillingError(error),
+		});
+	}
+
+	async function confirm(operationId: string) {
+		if (!quote) return;
+		try {
+			if (!(await hostedAccess.recheckCanCreateCloudAgents())) {
+				onOpenChange(false);
+				return;
+			}
+			showResult(await changePlan.mutateAsync({ operation_id: operationId }));
+		} catch (error) {
+			handleError(error);
+		}
+	}
+
+	async function checkStatus() {
+		if (!pendingOperationName) return;
+		try {
+			showResult(await checkPlanChange.mutateAsync(pendingOperationName));
+		} catch (error) {
+			handleError(error);
+		}
+	}
+
+	return (
+		<div data-hosted="true" className="contents">
+			{wallet.data ? (
+				<TopUpDialog {...walletTopUp.dialogProps} onComplete={() => setQuote(null)} />
+			) : null}
+			<PlanChangeDialog
+				open={open}
+				onOpenChange={onOpenChange}
+				plans={plans}
+				currentPlanSlug={target.currentPlanSlug}
+				initialPlanSlug={target.initialPlanSlug}
+				currentBillingTermMonths={target.currentBillingTermMonths}
+				currentFundingSource={target.currentFundingSource}
+				allowCombinedChange={target.allowCombinedChange}
+				paymentSourceOnly={target.paymentSourceOnly}
+				quote={quote}
+				walletBalanceUsd={wallet.data?.balance_usd ?? null}
+				isQuoting={quotePlanChange.isPending}
+				isConfirming={changePlan.isPending || checkPlanChange.isPending}
+				hasAcceptedChange={pendingOperationName !== null}
+				onQuote={(selection) => void requestQuote(selection)}
+				onConfirm={(operationId) => void confirm(operationId)}
+				onCheckStatus={() => void checkStatus()}
+				onTopUp={() => walletTopUp.show()}
+				paymentMethodRequired={paymentMethodRequired}
+				isManagingPaymentMethods={billingPortal.isPending}
+				onManagePaymentMethods={() => void openPaymentMethods()}
+				onExitComplete={() => {
+					if (pendingOperationName === null) {
+						setQuote(null);
+						setPaymentMethodRequired(false);
+					}
+				}}
+			/>
+		</div>
+	);
+}

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts
@@ -379,7 +379,7 @@ describe("planChangeUnavailableReason", () => {
 				canCreateCloudAgents: false,
 				cancelAtPeriodEnd: false,
 				status: "active",
-				subscriptionId: 42,
+				hasSubscriptionTarget: true,
 			}),
 		).toBe("Subscription changes are temporarily unavailable.");
 	});
@@ -390,7 +390,7 @@ describe("planChangeUnavailableReason", () => {
 				canCreateCloudAgents: true,
 				cancelAtPeriodEnd: true,
 				status: "active",
-				subscriptionId: 42,
+				hasSubscriptionTarget: true,
 			}),
 		).toBe("Resume this subscription before changing its plan, billing term, or payment source.");
 	});
@@ -401,7 +401,7 @@ describe("planChangeUnavailableReason", () => {
 				canCreateCloudAgents: true,
 				cancelAtPeriodEnd: false,
 				status: "active",
-				subscriptionId: 42,
+				hasSubscriptionTarget: true,
 			}),
 		).toBeNull();
 		expect(
@@ -409,7 +409,7 @@ describe("planChangeUnavailableReason", () => {
 				canCreateCloudAgents: true,
 				cancelAtPeriodEnd: false,
 				status: "past_due",
-				subscriptionId: 42,
+				hasSubscriptionTarget: true,
 			}),
 		).toBeNull();
 		expect(
@@ -417,7 +417,7 @@ describe("planChangeUnavailableReason", () => {
 				canCreateCloudAgents: true,
 				cancelAtPeriodEnd: false,
 				status: "trialing",
-				subscriptionId: 42,
+				hasSubscriptionTarget: true,
 			}),
 		).toContain("Resolve the subscription status");
 	});

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
@@ -7,7 +7,10 @@ import type {
 import { isPaymentMethodRequiredError } from "@/hosted/billing/errors";
 import { COMPUTE_BASIC_SLUG, COMPUTE_PERFORMANCE_SLUG } from "./subscription-utils";
 
-export type PlanChangeSelection = Omit<ComputePlanChangeQuoteRequest, "subscription_id"> & {
+export type PlanChangeSelection = Omit<
+	ComputePlanChangeQuoteRequest,
+	"subscription_id" | "deployment_id"
+> & {
 	funding_source: NonNullable<ComputePlanChangeQuoteRequest["funding_source"]>;
 };
 
@@ -313,17 +316,17 @@ export function planChangeUnavailableReason({
 	canCreateCloudAgents,
 	cancelAtPeriodEnd,
 	status,
-	subscriptionId,
+	hasSubscriptionTarget,
 }: {
 	canCreateCloudAgents: boolean;
 	cancelAtPeriodEnd: boolean;
 	status: string;
-	subscriptionId: number | null;
+	hasSubscriptionTarget: boolean;
 }): string | null {
 	if (!canCreateCloudAgents) return "Subscription changes are temporarily unavailable.";
 	if (cancelAtPeriodEnd)
 		return "Resume this subscription before changing its plan, billing term, or payment source.";
-	if (!subscriptionId)
+	if (!hasSubscriptionTarget)
 		return "Subscription changes will be available after details finish syncing.";
 	if (status !== "active" && status !== "past_due") {
 		return "Resolve the subscription status before changing its plan, billing term, or payment source.";

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
@@ -5,6 +5,9 @@ type SubscriptionsSectionModule =
 	typeof import("@/hosted/billing/subscription/subscriptions-section");
 
 let sortLoadedSubscriptions: SubscriptionsSectionModule["sortLoadedSubscriptions"] | null = null;
+let canManageAccountSubscription:
+	| SubscriptionsSectionModule["canManageAccountSubscription"]
+	| null = null;
 
 beforeAll(async () => {
 	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
@@ -12,6 +15,7 @@ beforeAll(async () => {
 	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
 	const module = await import("@/hosted/billing/subscription/subscriptions-section");
 	sortLoadedSubscriptions = module.sortLoadedSubscriptions;
+	canManageAccountSubscription = module.canManageAccountSubscription;
 });
 
 function subscription(
@@ -26,6 +30,7 @@ function subscription(
 		currency: "usd",
 		billing_term_months: 1,
 		cancel_at_period_end: status === "canceling",
+		deployment_id: `hdep_${subscriptionId}`,
 		agent_name: subscriptionId,
 		is_orphan: false,
 	};
@@ -59,5 +64,18 @@ describe("SubscriptionsSection", () => {
 			"active-second",
 			"canceling-second",
 		]);
+	});
+
+	test("only exposes management for current paid subscriptions", () => {
+		if (!canManageAccountSubscription) throw new Error("Subscriptions helpers were not loaded");
+		const active = subscription("active", "active");
+
+		expect(canManageAccountSubscription(active)).toBe(true);
+		expect(canManageAccountSubscription(subscription("past-due", "past_due"))).toBe(true);
+		expect(canManageAccountSubscription(subscription("canceling", "canceling"))).toBe(false);
+		expect(canManageAccountSubscription(subscription("canceled", "canceled"))).toBe(false);
+		expect(canManageAccountSubscription({ ...active, is_orphan: true })).toBe(false);
+		expect(canManageAccountSubscription({ ...active, deployment_id: null })).toBe(false);
+		expect(canManageAccountSubscription({ ...active, cancel_at_period_end: true })).toBe(false);
 	});
 });

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { Link } from "@tanstack/react-router";
 import { CreditCard, History, Link2Off, RefreshCw, Settings } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import type { AgentTile } from "@/components/dashboard/agents-card";
 import { EmptyState } from "@/components/empty-state";
+import { entityCardChassisClass } from "@/components/entity-card";
 import { SettingsSection } from "@/components/settings-section";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -14,10 +14,12 @@ import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import type { StatusTone } from "@/components/ui/status-badge";
-import type { ComputeSubscriptionListItem } from "@/hosted/billing/contracts";
+import type { ComputePlanSlug, ComputeSubscriptionListItem } from "@/hosted/billing/contracts";
 import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
 import {
 	useCancelSubscription,
+	useHostedDeployments,
+	usePlans,
 	useResumeSubscription,
 	useSubscriptions,
 } from "@/hosted/billing/hooks";
@@ -26,6 +28,11 @@ import {
 	computeSubscriptionCardView,
 	computeSubscriptionPlanLabel,
 } from "@/hosted/billing/subscription/compute-subscription-card";
+import { activePlanChangeOperationName } from "@/hosted/billing/subscription/plan-change.logic";
+import {
+	PlanChangeController,
+	type PlanChangeTarget,
+} from "@/hosted/billing/subscription/plan-change-controller";
 import {
 	canCancelAccountSubscription,
 	canResumeAccountSubscription,
@@ -55,10 +62,12 @@ function subscriptionScheduleVerb(status: ComputeSubscriptionListItem["status"])
 
 function SubscriptionActions({
 	subscription,
-	manageHref,
+	canManage,
+	onManage,
 }: {
 	subscription: ComputeSubscriptionListItem;
-	manageHref: string | null;
+	canManage: boolean;
+	onManage: () => void;
 }) {
 	const cancelSubscription = useCancelSubscription();
 	const resumeSubscription = useResumeSubscription();
@@ -96,20 +105,14 @@ function SubscriptionActions({
 		}
 	}
 
-	if (!manageHref && !canCancel && !canResume) {
+	if (!canManage && !canCancel && !canResume) {
 		return null;
 	}
 
 	return (
 		<>
-			{manageHref ? (
-				<Button
-					render={<Link to={manageHref} />}
-					nativeButton={false}
-					type="button"
-					variant="outline"
-					size="sm"
-				>
+			{canManage ? (
+				<Button type="button" variant="outline" size="sm" onClick={onManage}>
 					<Settings data-icon="inline-start" />
 					Manage
 				</Button>
@@ -152,13 +155,58 @@ function SubscriptionActions({
 	);
 }
 
-function subscriptionManageHref(subscription: ComputeSubscriptionListItem): string | null {
+function subscriptionAgentHref(subscription: ComputeSubscriptionListItem): string | null {
 	if (subscription.is_orphan || !subscription.deployment_id || !subscription.agent_name)
 		return null;
 	return agentSectionHref(subscription.deployment_id, "settings", {
 		source: "on-clawdi",
 		settings: "billing-plan",
 	});
+}
+
+function computePlanSlug(value: string): ComputePlanSlug | null {
+	return value === "compute_basic" || value === "compute_performance" ? value : null;
+}
+
+export function canManageAccountSubscription(subscription: ComputeSubscriptionListItem): boolean {
+	return (
+		!subscription.is_orphan &&
+		Boolean(subscription.deployment_id?.trim()) &&
+		!subscription.cancel_at_period_end &&
+		(subscription.status === "active" || subscription.status === "past_due") &&
+		computePlanSlug(subscription.plan_slug) !== null &&
+		(subscription.funding_source === "stripe" || subscription.funding_source === "wallet")
+	);
+}
+
+function accountPlanChangeTarget(
+	subscription: ComputeSubscriptionListItem,
+	projectedOperationName: string | null,
+): PlanChangeTarget | null {
+	const deploymentId = subscription.deployment_id?.trim();
+	const planSlug = computePlanSlug(subscription.plan_slug);
+	const fundingSource = subscription.funding_source;
+	if (
+		!canManageAccountSubscription(subscription) ||
+		!deploymentId ||
+		!planSlug ||
+		(fundingSource !== "stripe" && fundingSource !== "wallet")
+	) {
+		return null;
+	}
+	return {
+		deploymentId,
+		currentPlanSlug: planSlug,
+		initialPlanSlug: planSlug,
+		currentBillingTermMonths: subscription.billing_term_months,
+		currentFundingSource: fundingSource,
+		status: subscription.status,
+		paymentSourceOnly: subscription.status === "past_due",
+		cancelAtPeriodEnd: subscription.cancel_at_period_end,
+		isPaidCompute: true,
+		allowCombinedChange: false,
+		projectedOperationName,
+	};
 }
 
 export function SubscriptionLoadMore({
@@ -180,24 +228,27 @@ export function SubscriptionLoadMore({
 function SubscriptionRow({
 	subscription,
 	agentTile,
+	onManage,
 }: {
 	subscription: ComputeSubscriptionListItem;
 	agentTile?: AgentTile;
+	onManage: (subscription: ComputeSubscriptionListItem) => void;
 }) {
 	const status = STATUS_PRESENTATION[subscription.status];
-	const manageHref = subscriptionManageHref(subscription);
+	const agentHref = subscriptionAgentHref(subscription);
+	const canManage = canManageAccountSubscription(subscription);
 	const hasActions =
-		manageHref !== null ||
+		canManage ||
 		canCancelAccountSubscription(subscription) ||
 		canResumeAccountSubscription(subscription);
 	const view = computeSubscriptionCardView({
-		identity: manageHref
+		identity: agentHref
 			? {
 					kind: "agent",
 					name: agentTile?.name ?? subscription.agent_name ?? "Agent",
 					agentType: agentTile?.agentType ?? null,
 					avatarUrl: agentTile?.avatarUrl,
-					href: manageHref,
+					href: agentHref,
 				}
 			: { kind: "unavailable", label: "Deleted agent" },
 		status,
@@ -218,7 +269,11 @@ function SubscriptionRow({
 				badges={subscription.is_orphan ? <Badge variant="outline">Orphaned</Badge> : null}
 				actions={
 					hasActions ? (
-						<SubscriptionActions subscription={subscription} manageHref={manageHref} />
+						<SubscriptionActions
+							subscription={subscription}
+							canManage={canManage}
+							onManage={() => onManage(subscription)}
+						/>
 					) : null
 				}
 			/>
@@ -251,20 +306,21 @@ function SubscriptionListSkeleton() {
 		<div className="grid gap-3 lg:grid-cols-2" role="status">
 			<span className="sr-only">Loading subscriptions</span>
 			{Array.from({ length: 3 }, (_, index) => `subscription-skeleton-${index}`).map((key) => (
-				<div key={key} className="overflow-hidden rounded-lg border bg-card">
-					<div className="flex items-start justify-between gap-3 p-4">
-						<Skeleton className="h-5 w-36" />
+				<div key={key} className={entityCardChassisClass({ variant: "compact" })}>
+					<div className="flex items-start justify-between gap-3">
+						<div className="flex min-w-0 items-center gap-3">
+							<Skeleton className="size-8 shrink-0 rounded-md" />
+							<Skeleton className="h-5 w-36 max-w-full" />
+						</div>
 						<Skeleton className="h-5 w-16" />
 					</div>
-					<div className="grid grid-cols-2 gap-4 border-t px-4 py-3">
-						{Array.from({ length: 4 }, (_, detailIndex) => `${key}-${detailIndex}`).map(
-							(detailKey) => (
-								<div key={detailKey} className="space-y-1.5">
-									<Skeleton className="h-3 w-12" />
-									<Skeleton className="h-4 w-20 max-w-full" />
-								</div>
-							),
-						)}
+					<div className="space-y-2.5">
+						<Skeleton className="h-5 w-28" />
+						<div className="flex flex-wrap gap-x-4 gap-y-1.5">
+							<Skeleton className="h-4 w-12" />
+							<Skeleton className="h-4 w-20" />
+							<Skeleton className="h-4 w-24" />
+						</div>
 					</div>
 				</div>
 			))}
@@ -274,8 +330,13 @@ function SubscriptionListSkeleton() {
 
 export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly AgentTile[] }) {
 	const subscriptions = useSubscriptions();
+	const plans = usePlans();
+	const deployments = useHostedDeployments();
 	const [showHistory, setShowHistory] = useState(false);
 	const [historyCutoffMs] = useState(Date.now);
+	const [selectedSubscription, setSelectedSubscription] =
+		useState<ComputeSubscriptionListItem | null>(null);
+	const [planChangeOpen, setPlanChangeOpen] = useState(false);
 	const rows = subscriptions.data?.pages.flatMap((page) => page.items ?? []) ?? [];
 	const orderedRows = sortLoadedSubscriptions(rows);
 	const agentTilesByDeploymentId = new Map(
@@ -293,92 +354,122 @@ export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly Agen
 			);
 	const canLoadMore = subscriptions.hasNextPage && !subscriptions.isFetchNextPageError;
 	const historyControlVisible = endedRows.length > 0 || showHistory;
+	const selectedDeployment = selectedSubscription?.deployment_id
+		? deployments.data?.find(
+				(deployment) =>
+					deployment.resource.id.toLowerCase() ===
+					selectedSubscription.deployment_id?.toLowerCase(),
+			)
+		: undefined;
+	const selectedTarget = selectedSubscription
+		? accountPlanChangeTarget(
+				selectedSubscription,
+				selectedDeployment ? activePlanChangeOperationName(selectedDeployment) : null,
+			)
+		: null;
+
+	function manageSubscription(subscription: ComputeSubscriptionListItem) {
+		if (!canManageAccountSubscription(subscription)) return;
+		setSelectedSubscription(subscription);
+		setPlanChangeOpen(true);
+	}
 
 	return (
-		<SettingsSection
-			data-hosted="true"
-			headingLevel={3}
-			title="Your subscriptions"
-			description="Manage every compute subscription in one place."
-		>
-			{subscriptions.isLoading ? (
-				<SubscriptionListSkeleton />
-			) : shouldBlockQueryError(subscriptions.error, subscriptions.data) ? (
-				<ApiErrorPanel
-					normalizer={billingErrorNormalizer}
-					error={subscriptions.error}
-					onRetry={() => void subscriptions.refetch()}
-					title="Couldn't load subscriptions"
+		<>
+			{selectedTarget ? (
+				<PlanChangeController
+					open={planChangeOpen}
+					onOpenChange={setPlanChangeOpen}
+					target={selectedTarget}
+					plans={plans.data ?? []}
 				/>
-			) : rows.length || subscriptions.hasNextPage ? (
-				<>
-					{historyControlVisible ? (
-						<div className="flex justify-end">
-							<Button
-								type="button"
-								variant="ghost"
-								size="sm"
-								aria-pressed={showHistory}
-								onClick={() => setShowHistory((current) => !current)}
-							>
-								<History />
-								{showHistory
-									? "Hide history"
-									: `Show history${endedRows.length ? ` (${endedRows.length})` : ""}`}
-							</Button>
-						</div>
-					) : null}
-					{visibleRows.length ? (
-						<ul className="grid gap-3 lg:grid-cols-2">
-							{visibleRows.map((subscription) => (
-								<SubscriptionRow
-									key={subscription.subscription_id}
-									subscription={subscription}
-									agentTile={
-										subscription.deployment_id
-											? agentTilesByDeploymentId.get(subscription.deployment_id.toLowerCase())
-											: undefined
-									}
-								/>
-							))}
-						</ul>
-					) : (
-						<EmptyState
-							variant="inset"
-							icon={CreditCard}
-							title="No current subscriptions"
-							description={
-								endedRows.length
-									? "Ended subscriptions are hidden. Show history to view them."
-									: "Load more records to find current subscriptions."
-							}
-							className="py-8 md:p-8"
-						/>
-					)}
-					{canLoadMore ? (
-						<SubscriptionLoadMore
-							isLoading={subscriptions.isFetchingNextPage}
-							onLoadMore={() => void subscriptions.fetchNextPage()}
-						/>
-					) : null}
-					{subscriptions.isFetchNextPageError ? (
-						<ApiErrorPanel
-							normalizer={billingErrorNormalizer}
-							error={subscriptions.error}
-							onRetry={() => void subscriptions.fetchNextPage()}
-							title="Couldn't load more subscriptions"
-						/>
-					) : null}
-				</>
-			) : (
-				<EmptyState
-					variant="inset"
-					icon={CreditCard}
-					title="No compute subscriptions"
-					description="Compute subscriptions will appear here when you start a hosted agent."
-					className="py-8 md:p-8"
-				/>
-			)}
-		</SettingsSection>
+			) : null}
+			<SettingsSection
+				data-hosted="true"
+				headingLevel={3}
+				title="Your subscriptions"
+				description="Manage every compute subscription in one place."
+			>
+				{subscriptions.isLoading ? (
+					<SubscriptionListSkeleton />
+				) : shouldBlockQueryError(subscriptions.error, subscriptions.data) ? (
+					<ApiErrorPanel
+						normalizer={billingErrorNormalizer}
+						error={subscriptions.error}
+						onRetry={() => void subscriptions.refetch()}
+						title="Couldn't load subscriptions"
+					/>
+				) : rows.length || subscriptions.hasNextPage ? (
+					<>
+						{historyControlVisible ? (
+							<div className="flex justify-end">
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									aria-pressed={showHistory}
+									onClick={() => setShowHistory((current) => !current)}
+								>
+									<History />
+									{showHistory
+										? "Hide history"
+										: `Show history${endedRows.length ? ` (${endedRows.length})` : ""}`}
+								</Button>
+							</div>
+						) : null}
+						{visibleRows.length ? (
+							<ul className="grid gap-3 lg:grid-cols-2">
+								{visibleRows.map((subscription) => (
+									<SubscriptionRow
+										key={subscription.subscription_id}
+										subscription={subscription}
+										agentTile={
+											subscription.deployment_id
+												? agentTilesByDeploymentId.get(subscription.deployment_id.toLowerCase())
+												: undefined
+										}
+										onManage={manageSubscription}
+									/>
+								))}
+							</ul>
+						) : (
+							<EmptyState
+								variant="inset"
+								icon={CreditCard}
+								title="No current subscriptions"
+								description={
+									endedRows.length
+										? "Ended subscriptions are hidden. Show history to view them."
+										: "Load more records to find current subscriptions."
+								}
+								className="py-8 md:p-8"
+							/>
+						)}
+						{canLoadMore ? (
+							<SubscriptionLoadMore
+								isLoading={subscriptions.isFetchingNextPage}
+								onLoadMore={() => void subscriptions.fetchNextPage()}
+							/>
+						) : null}
+						{subscriptions.isFetchNextPageError ? (
+							<ApiErrorPanel
+								normalizer={billingErrorNormalizer}
+								error={subscriptions.error}
+								onRetry={() => void subscriptions.fetchNextPage()}
+								title="Couldn't load more subscriptions"
+							/>
+						) : null}
+					</>
+				) : (
+					<EmptyState
+						variant="inset"
+						icon={CreditCard}
+						title="No compute subscriptions"
+						description="Compute subscriptions will appear here when you start a hosted agent."
+						className="py-8 md:p-8"
+					/>
+				)}
+			</SettingsSection>
+		</>
 	);
 }

--- a/apps/web/src/hosted/sensitive-boundaries.test.ts
+++ b/apps/web/src/hosted/sensitive-boundaries.test.ts
@@ -216,7 +216,7 @@ describe("structural secret boundaries without the denylist", () => {
 			"hosted/billing/subscription/welcome-wallet-card.tsx",
 			"hosted/billing/subscription/subscription-create-dialog.tsx",
 			"hosted/billing/components/compute-dunning-banner.tsx",
-			"hosted/agents/hosted-agent-detail.tsx",
+			"hosted/billing/subscription/plan-change-controller.tsx",
 		];
 		for (const path of walletConsumers) {
 			expect(source(path)).toContain("useWalletSnapshot");

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1244,7 +1244,9 @@ export interface components {
         /** V2ComputePlanChangeQuoteRequest */
         V2ComputePlanChangeQuoteRequest: {
             /** Subscription Id */
-            subscription_id: number;
+            subscription_id?: number | null;
+            /** Deployment Id */
+            deployment_id?: string | null;
             /**
              * Target Plan Slug
              * @enum {string}


### PR DESCRIPTION
## Summary
- redesign compute subscription cards around canonical Agent identity and quiet, wrapping metadata without internal dividers
- share one deployment-targeted plan-change controller between Account Settings and Agent Settings
- open Account Settings Manage in place while preserving subscription history, pagination, URL, and recovery state
- restrict Account Manage to current manageable paid subscriptions and keep canceled, canceling, orphaned, and pending-cancellation records fail closed
- regenerate the deploy client for the additive Hosted plan-change `deployment_id` quote target

## Verification
- `bun test apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts apps/web/src/hosted/billing/subscription/plan-change-dialog.test.tsx apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx apps/web/src/hosted/billing/subscription/subscription-utils.test.ts`
- `bun run --cwd apps/web typecheck`
- `bunx biome check apps/web/src`
- `git diff --check origin/main..HEAD`
- `bun run --cwd apps/web e2e:hosted -- hosted-subscriptions.pw.ts` (network-change startup flake rerun unchanged; all three cases passed)
- `bun run --cwd apps/web e2e:hosted -- hosted-smoke.pw.ts --grep "paid card subscription|accepted plan change"` (dynamic-import startup flake rerun unchanged; all three scoped cases passed)