### PR TITLE
perf(channels): replace message polling with push wakeups

### DIFF
--- a/backend/app/routes/channel_routers/whatsapp.py
+++ b/backend/app/routes/channel_routers/whatsapp.py
@@ -30,6 +30,7 @@ from app.routes.channel_routers.shared import (
     optional_str,
 )
 from app.services.channel_debug_events import record_channel_debug_event
+from app.services.channel_wakeups import channel_inbound_messages_enqueued
 from app.services.channels import (
     get_active_channel_account,
     resolve_channel_agent_by_identity,
@@ -594,39 +595,50 @@ async def _wait_whatsapp_websocket_inbox(
     timeout = max(0.0, min(settings.channel_long_poll_max_seconds, 30.0))
     poll_interval = max(0.001, settings.channel_long_poll_interval_seconds)
     deadline = asyncio.get_running_loop().time() + timeout
-    while True:
-        async with async_session_factory() as db:
-            result = await db.execute(
-                select(ChannelMessage)
-                .where(
-                    ChannelMessage.account_id == account_id,
-                    ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
-                    ChannelMessage.binding_id.is_not(None),
-                    ChannelMessage.delivered_at.is_(None),
-                    ChannelMessage.inbox_sequence > after_sequence,
-                    ChannelMessage.bot_agent_link_id == bot_agent_link_id,
+    notified = channel_inbound_messages_enqueued.subscribe()
+    try:
+        while True:
+            notified.clear()
+            async with async_session_factory() as db:
+                result = await db.execute(
+                    select(ChannelMessage)
+                    .where(
+                        ChannelMessage.account_id == account_id,
+                        ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
+                        ChannelMessage.binding_id.is_not(None),
+                        ChannelMessage.delivered_at.is_(None),
+                        ChannelMessage.inbox_sequence > after_sequence,
+                        ChannelMessage.bot_agent_link_id == bot_agent_link_id,
+                    )
+                    .order_by(ChannelMessage.inbox_sequence, ChannelMessage.created_at)
+                    .limit(max(0, limit))
                 )
-                .order_by(ChannelMessage.inbox_sequence, ChannelMessage.created_at)
-                .limit(max(0, limit))
-            )
-            messages = list(result.scalars().all())
-        if messages or timeout == 0 or asyncio.get_running_loop().time() >= deadline:
-            return [
-                WhatsAppInboxPumpEvent(
-                    sequence=message.inbox_sequence,
-                    external_chat_id=message.external_chat_id,
-                    payload=message.payload if isinstance(message.payload, dict) else {},
-                    provider_message_id=message.provider_message_id,
-                    text=message.text,
+                messages = list(result.scalars().all())
+            if messages or timeout == 0 or asyncio.get_running_loop().time() >= deadline:
+                return [
+                    WhatsAppInboxPumpEvent(
+                        sequence=message.inbox_sequence,
+                        external_chat_id=message.external_chat_id,
+                        payload=message.payload if isinstance(message.payload, dict) else {},
+                        provider_message_id=message.provider_message_id,
+                        text=message.text,
+                    )
+                    for message in messages
+                ]
+            if notified.is_set():
+                continue
+            try:
+                await asyncio.wait_for(
+                    notified.wait(),
+                    timeout=min(
+                        poll_interval,
+                        max(0.0, deadline - asyncio.get_running_loop().time()),
+                    ),
                 )
-                for message in messages
-            ]
-        await asyncio.sleep(
-            min(
-                poll_interval,
-                max(0.0, deadline - asyncio.get_running_loop().time()),
-            )
-        )
+            except TimeoutError:
+                pass
+    finally:
+        channel_inbound_messages_enqueued.unsubscribe(notified)
 
 
 async def _ack_whatsapp_websocket_inbox(

--- a/backend/app/services/channel_delivery_worker.py
+++ b/backend/app/services/channel_delivery_worker.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from app.services.channel_wakeups import ChannelWakeup, channel_deliveries_enqueued
 from app.services.channels import claim_next_channel_delivery, deliver_channel_delivery
 
 log = logging.getLogger(__name__)
@@ -19,10 +20,12 @@ class ChannelDeliveryWorker:
         *,
         worker_id: str | None = None,
         poll_interval_seconds: float = 1.0,
+        wakeup: ChannelWakeup = channel_deliveries_enqueued,
     ) -> None:
         self._sessionmaker = sessionmaker
         self._worker_id = worker_id or f"channel-delivery-{uuid.uuid4()}"
         self._poll_interval_seconds = poll_interval_seconds
+        self._wakeup = wakeup
 
     async def run_once(self) -> UUID | None:
         async with self._sessionmaker() as db:
@@ -37,16 +40,34 @@ class ChannelDeliveryWorker:
 
     async def run_forever(self, stop: asyncio.Event | None = None) -> None:
         stop_event = stop or asyncio.Event()
-        while not stop_event.is_set():
-            try:
-                delivery_id = await self.run_once()
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:  # noqa: BLE001 - worker must keep polling after one bad job.
-                log.exception("channel delivery worker failed: %s", exc)
-                delivery_id = None
-            if delivery_id is None:
+        notified = self._wakeup.subscribe()
+        try:
+            while not stop_event.is_set():
+                notified.clear()
                 try:
-                    await asyncio.wait_for(stop_event.wait(), timeout=self._poll_interval_seconds)
-                except TimeoutError:
-                    pass
+                    delivery_id = await self.run_once()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:  # noqa: BLE001 - worker must keep polling after one bad job.
+                    log.exception("channel delivery worker failed: %s", exc)
+                    delivery_id = None
+                if delivery_id is None and not notified.is_set():
+                    stop_task = asyncio.create_task(stop_event.wait())
+                    wake_task = asyncio.create_task(notified.wait())
+                    try:
+                        await asyncio.wait_for(
+                            asyncio.wait(
+                                {stop_task, wake_task},
+                                return_when=asyncio.FIRST_COMPLETED,
+                            ),
+                            timeout=self._poll_interval_seconds,
+                        )
+                    except TimeoutError:
+                        pass
+                    finally:
+                        for task in (stop_task, wake_task):
+                            if not task.done():
+                                task.cancel()
+                        await asyncio.gather(stop_task, wake_task, return_exceptions=True)
+        finally:
+            self._wakeup.unsubscribe(notified)

--- a/backend/app/services/channel_wakeups.py
+++ b/backend/app/services/channel_wakeups.py
@@ -1,0 +1,51 @@
+"""Signal-only wakeups for committed channel work."""
+
+from __future__ import annotations
+
+import asyncio
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+CHANNEL_DELIVERIES_ENQUEUED = "channel_deliveries_enqueued"
+CHANNEL_INBOUND_MESSAGES_ENQUEUED = "channel_inbound_messages_enqueued"
+
+
+class ChannelWakeup:
+    """Process-local broadcast subscription for PostgreSQL notifications."""
+
+    def __init__(self) -> None:
+        self._waiters: set[asyncio.Event] = set()
+
+    def subscribe(self) -> asyncio.Event:
+        waiter = asyncio.Event()
+        self._waiters.add(waiter)
+        return waiter
+
+    def unsubscribe(self, waiter: asyncio.Event) -> None:
+        self._waiters.discard(waiter)
+
+    def signal(self) -> None:
+        for waiter in self._waiters:
+            waiter.set()
+
+
+channel_deliveries_enqueued = ChannelWakeup()
+channel_inbound_messages_enqueued = ChannelWakeup()
+
+
+async def notify_channel_delivery_enqueued(db: AsyncSession) -> None:
+    """Wake delivery workers after the surrounding transaction commits."""
+    await _notify_channel_work_enqueued(db, CHANNEL_DELIVERIES_ENQUEUED)
+
+
+async def notify_channel_inbound_message_enqueued(db: AsyncSession) -> None:
+    """Wake inbox consumers after the surrounding transaction commits."""
+    await _notify_channel_work_enqueued(db, CHANNEL_INBOUND_MESSAGES_ENQUEUED)
+
+
+async def _notify_channel_work_enqueued(db: AsyncSession, channel: str) -> None:
+    await db.execute(
+        text("SELECT pg_notify(:channel, '')"),
+        {"channel": channel},
+    )

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -74,6 +74,10 @@ from app.services.channel_config import (
     validate_required_discord_interactions_config,
 )
 from app.services.channel_debug_events import record_channel_debug_event
+from app.services.channel_wakeups import (
+    notify_channel_delivery_enqueued,
+    notify_channel_inbound_message_enqueued,
+)
 from app.services.discord_rate_limiter import discord_rate_limiter
 from app.services.metrics import (
     inbound_messages,
@@ -3039,6 +3043,7 @@ async def _record_inbound_message_with_status(
         if existing is not None:
             return existing, False
         raise
+    await notify_channel_inbound_message_enqueued(db)
     inbound_messages.labels(channel=account.provider).inc()
     return message, True
 
@@ -4648,6 +4653,7 @@ async def enqueue_channel_outbound_message(
     )
     db.add(delivery)
     await db.flush()
+    await notify_channel_delivery_enqueued(db)
     return message, delivery
 
 

--- a/backend/app/services/postgres_listener.py
+++ b/backend/app/services/postgres_listener.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 import asyncpg
 
@@ -21,12 +21,10 @@ class PostgresListener:
     def __init__(
         self,
         connection: asyncpg.Connection,
-        channel: str,
-        callback: _AsyncpgNotificationCallback,
+        listeners: Mapping[str, _AsyncpgNotificationCallback],
     ) -> None:
         self._connection = connection
-        self._channel = channel
-        self._callback = callback
+        self._listeners = dict(listeners)
 
     def is_closed(self) -> bool:
         return self._connection.is_closed()
@@ -34,7 +32,8 @@ class PostgresListener:
     async def close(self) -> None:
         try:
             try:
-                await self._connection.remove_listener(self._channel, self._callback)
+                for channel, callback in self._listeners.items():
+                    await self._connection.remove_listener(channel, callback)
             finally:
                 await self._connection.close(timeout=5)
         except (asyncpg.PostgresError, OSError, TimeoutError) as exc:
@@ -43,8 +42,7 @@ class PostgresListener:
 
 async def connect_postgres_listener(
     dsn: str,
-    channel: str,
-    notification: NotificationCallback,
+    channels: Mapping[str, NotificationCallback],
     terminated: Callable[[], None],
 ) -> PostgresListener:
     try:
@@ -52,21 +50,27 @@ async def connect_postgres_listener(
     except (asyncpg.PostgresError, OSError, TimeoutError) as exc:
         raise PostgresListenerError("PostgreSQL listener connection failed") from exc
 
-    def on_notification(
-        _connection: object,
-        pid: int,
-        received_channel: str,
-        payload: object,
-    ) -> None:
-        if not isinstance(payload, str):
-            raise PostgresListenerError("PostgreSQL notification payload is invalid")
-        notification(pid, received_channel, payload)
-
     def on_termination(_connection: object) -> None:
         terminated()
 
+    listeners: dict[str, _AsyncpgNotificationCallback] = {}
     try:
-        await connection.add_listener(channel, on_notification)
+        for channel, notification in channels.items():
+
+            def on_notification(
+                _connection: object,
+                pid: int,
+                received_channel: str,
+                payload: object,
+                *,
+                callback: NotificationCallback = notification,
+            ) -> None:
+                if not isinstance(payload, str):
+                    raise PostgresListenerError("PostgreSQL notification payload is invalid")
+                callback(pid, received_channel, payload)
+
+            listeners[channel] = on_notification
+            await connection.add_listener(channel, on_notification)
         connection.add_termination_listener(on_termination)
     except (asyncpg.PostgresError, OSError, TimeoutError) as exc:
         try:
@@ -74,4 +78,4 @@ async def connect_postgres_listener(
         except (asyncpg.PostgresError, OSError, TimeoutError):
             pass
         raise PostgresListenerError("PostgreSQL listener registration failed") from exc
-    return PostgresListener(connection, channel, on_notification)
+    return PostgresListener(connection, listeners)

--- a/backend/app/services/sync_events.py
+++ b/backend/app/services/sync_events.py
@@ -78,6 +78,12 @@ from app.models.project_membership import ProjectMembership
 from app.models.session import AgentEnvironment
 from app.models.user import User
 from app.schemas.runtime import HostedRuntimeTools, validate_hosted_runtime_desired_state
+from app.services.channel_wakeups import (
+    CHANNEL_DELIVERIES_ENQUEUED,
+    CHANNEL_INBOUND_MESSAGES_ENQUEUED,
+    channel_deliveries_enqueued,
+    channel_inbound_messages_enqueued,
+)
 from app.services.managed_ai_provider import (
     CLAWDI_MANAGED_PROVIDER_ID,
     is_v2_deployment_managed_provider_id,
@@ -628,8 +634,11 @@ async def _postgres_listener_loop(
         try:
             active_connection = await connect_postgres_listener(
                 _asyncpg_dsn(),
-                _POSTGRES_CHANNEL,
-                _on_postgres_notification,
+                {
+                    _POSTGRES_CHANNEL: _on_postgres_notification,
+                    CHANNEL_DELIVERIES_ENQUEUED: _on_channel_delivery_enqueued,
+                    CHANNEL_INBOUND_MESSAGES_ENQUEUED: _on_channel_inbound_message_enqueued,
+                },
                 terminated.set,
             )
             connection = active_connection
@@ -692,6 +701,14 @@ def _on_postgres_notification(
         log.warning("ignored invalid PostgreSQL sync event: %s", exc)
         return
     _broadcast(envelope.user_id, envelope.event)
+
+
+def _on_channel_delivery_enqueued(_pid: int, _channel: str, _payload: str) -> None:
+    channel_deliveries_enqueued.signal()
+
+
+def _on_channel_inbound_message_enqueued(_pid: int, _channel: str, _payload: str) -> None:
+    channel_inbound_messages_enqueued.signal()
 
 
 async def get_skills_revision(db: AsyncSession, user_id: UUID) -> int:

--- a/backend/app/services/whatsapp_native_transport.py
+++ b/backend/app/services/whatsapp_native_transport.py
@@ -32,6 +32,8 @@ _RAW_NODE_PATH = "/v1/raw-node"
 _QUERY_IQ_PATH = "/v1/query-iq"
 _PROVIDER_EVENTS_PATH = "/v1/provider-events"
 _PROVIDER_EVENTS_ACK_PATH = "/v1/provider-events/ack"
+_PROVIDER_EVENTS_MAX_WAIT_MS = 8_000
+_PROVIDER_EVENTS_READ_TIMEOUT_SECONDS = 10.0
 _JSON_VALUE_ADAPTER: TypeAdapter[JsonValue] = TypeAdapter(JsonValue)
 
 type _NativeNodeValue = (
@@ -408,8 +410,20 @@ class WhatsAppBaileysSidecarClient:
             decoded_node[key] = value
         return decoded_node
 
-    async def provider_events(self, *, limit: int = 100) -> list[WhatsAppProviderMessageEvent]:
-        response = await self._request("GET", _PROVIDER_EVENTS_PATH, params={"limit": limit})
+    async def provider_events(
+        self,
+        *,
+        limit: int = 100,
+        wait_ms: int = 0,
+    ) -> list[WhatsAppProviderMessageEvent]:
+        if not 0 <= wait_ms <= _PROVIDER_EVENTS_MAX_WAIT_MS:
+            raise ValueError("baileys provider events wait must be between 0 and 8000 milliseconds")
+        response = await self._request(
+            "GET",
+            _PROVIDER_EVENTS_PATH,
+            params={"limit": limit, "waitMs": wait_ms},
+            timeout=httpx.Timeout(_PROVIDER_EVENTS_READ_TIMEOUT_SECONDS),
+        )
         data = _response_json(response)
         if not isinstance(data, dict):
             raise ValueError("baileys provider events response must contain an event list")
@@ -433,18 +447,21 @@ class WhatsAppBaileysSidecarClient:
         json_body: JsonValue = None,
         params: Mapping[str, str | int] | None = None,
         session_scoped: bool = True,
+        timeout: httpx.Timeout | float | None = None,
     ) -> httpx.Response:
         headers = {"Authorization": f"Bearer {self._api_token}"}
         request_path = self._session_path(path) if session_scoped else path
         try:
             if self._config.unix_socket_path is not None:
                 _assert_whatsapp_sidecar_unix_socket_ready(self._config.unix_socket_path)
+            request_timeout = self._client.timeout if timeout is None else timeout
             if json_body is None:
                 response = await self._client.request(
                     method,
                     request_path,
                     headers=headers,
                     params=params,
+                    timeout=request_timeout,
                 )
             else:
                 response = await self._client.request(
@@ -453,6 +470,7 @@ class WhatsAppBaileysSidecarClient:
                     headers=headers,
                     json=json_body,
                     params=params,
+                    timeout=request_timeout,
                 )
         except WhatsAppSidecarUnavailableError:
             self._connected = False

--- a/backend/app/services/whatsapp_sidecar_registry.py
+++ b/backend/app/services/whatsapp_sidecar_registry.py
@@ -50,6 +50,7 @@ _UNRELEASED_STATES = (
     "scanned",
     WHATSAPP_ONBOARDING_STATE_ERROR,
 )
+_PROVIDER_EVENTS_WAIT_MS = 8_000
 
 
 class WhatsAppSidecarClient(WhatsAppNativeUpstreamClient, Protocol):
@@ -59,7 +60,12 @@ class WhatsAppSidecarClient(WhatsAppNativeUpstreamClient, Protocol):
 
     async def refresh_health(self) -> bool: ...
 
-    async def provider_events(self, *, limit: int = 100) -> list[WhatsAppProviderMessageEvent]: ...
+    async def provider_events(
+        self,
+        *,
+        limit: int = 100,
+        wait_ms: int = 0,
+    ) -> list[WhatsAppProviderMessageEvent]: ...
 
     async def acknowledge_provider_events(self, *, through_sequence: int) -> None: ...
 
@@ -574,9 +580,14 @@ class ConfiguredWhatsAppSidecarRegistry:
     ) -> None:
         while True:
             try:
-                events = await client.provider_events(limit=100)
+                events = await client.provider_events(
+                    limit=100,
+                    wait_ms=_PROVIDER_EVENTS_WAIT_MS,
+                )
                 if not events:
-                    await asyncio.sleep(0.25)
+                    # A compatible older endpoint may ignore wait_ms and return
+                    # immediately. Yield without reintroducing timed polling.
+                    await asyncio.sleep(0)
                     continue
                 for event in events:
                     async with async_session_factory() as db:

--- a/backend/app/workers/channels.py
+++ b/backend/app/workers/channels.py
@@ -20,6 +20,7 @@ from app.services.discord_gateway_worker import DiscordGatewayWorker
 from app.services.metrics import metrics_content_type, render_metrics
 from app.services.principal_lifecycle_cleanup_worker import PrincipalLifecycleCleanupWorker
 from app.services.runtime_observation_retention_worker import RuntimeObservationRetentionWorker
+from app.services.sync_events import start_postgres_listener, stop_postgres_listener
 
 configure_application_logging()
 log = logging.getLogger(__name__)
@@ -162,10 +163,14 @@ async def run_channel_workers(
     stop: asyncio.Event,
     health: ChannelWorkerHealth | None = None,
 ) -> None:
-    workers = build_channel_workers()
-    if health is not None:
-        health.ready = True
-    await asyncio.gather(*(worker.run_forever(stop) for worker in workers))
+    await start_postgres_listener()
+    try:
+        workers = build_channel_workers()
+        if health is not None:
+            health.ready = True
+        await asyncio.gather(*(worker.run_forever(stop) for worker in workers))
+    finally:
+        await stop_postgres_listener()
 
 
 async def main() -> None:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -239,6 +239,7 @@ strict = [
     "app/services/channel_debug_events.py",
     "app/services/channel_delivery_worker.py",
     "app/services/channel_message_retention_worker.py",
+    "app/services/channel_wakeups.py",
     "app/services/channel_webhook_delivery_worker.py",
     "app/services/channel_webhooks.py",
     "app/services/channels.py",

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -126,7 +126,7 @@ class _ManagedOnboardingSidecar:
         self.stopped = True
         return WhatsAppSidecarPairingStatus(status="stopped", registered=False)
 
-    async def provider_events(self, *, limit=100):
+    async def provider_events(self, *, limit=100, wait_ms=0):
         return []
 
     async def acknowledge_provider_events(self, *, through_sequence):

--- a/backend/tests/test_channel_workers.py
+++ b/backend/tests/test_channel_workers.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
+from uuid import UUID
 
 import pytest
 
+from app.core.config import settings
+from app.routes.channel_routers.whatsapp import _wait_whatsapp_websocket_inbox
 from app.services.ai_provider_oauth_revoke_worker import AiProviderOAuthRevokeWorker
 from app.services.channel_delivery_worker import ChannelDeliveryWorker
 from app.services.channel_message_retention_worker import ChannelMessageRetentionWorker
+from app.services.channel_wakeups import ChannelWakeup
 from app.services.channel_webhook_delivery_worker import ChannelWebhookDeliveryWorker
 from app.services.channels import ChannelRetentionBatch
 from app.services.discord_command_reconciliation_worker import (
@@ -15,7 +20,12 @@ from app.services.discord_command_reconciliation_worker import (
 from app.services.discord_gateway_worker import DiscordGatewayWorker
 from app.services.principal_lifecycle_cleanup_worker import PrincipalLifecycleCleanupWorker
 from app.services.runtime_observation_retention_worker import RuntimeObservationRetentionWorker
-from app.workers.channels import ChannelWorkerHealth, _handle_health_request, build_channel_workers
+from app.workers.channels import (
+    ChannelWorkerHealth,
+    _handle_health_request,
+    build_channel_workers,
+    run_channel_workers,
+)
 
 pytestmark = pytest.mark.committed_db
 
@@ -33,6 +43,141 @@ def test_channel_worker_stack_runs_revoke_delivery_webhook_gateway_and_retention
         ChannelMessageRetentionWorker,
         RuntimeObservationRetentionWorker,
     )
+
+
+@pytest.mark.asyncio
+async def test_channel_worker_process_owns_postgres_listener(monkeypatch):
+    import app.workers.channels as channel_workers
+
+    calls: list[str] = []
+
+    class Worker:
+        async def run_forever(self, _stop):
+            calls.append("worker")
+
+    async def start_listener():
+        calls.append("start-listener")
+
+    async def stop_listener():
+        calls.append("stop-listener")
+
+    monkeypatch.setattr(channel_workers, "start_postgres_listener", start_listener)
+    monkeypatch.setattr(channel_workers, "stop_postgres_listener", stop_listener)
+    monkeypatch.setattr(channel_workers, "build_channel_workers", lambda: (Worker(),))
+
+    await run_channel_workers(asyncio.Event())
+
+    assert calls == ["start-listener", "worker", "stop-listener"]
+
+
+@pytest.mark.asyncio
+async def test_channel_delivery_worker_wakes_on_enqueue_signal(monkeypatch):
+    wakeup = ChannelWakeup()
+    stop = asyncio.Event()
+    idle = asyncio.Event()
+    awakened = asyncio.Event()
+    calls = 0
+    worker = ChannelDeliveryWorker(None, poll_interval_seconds=60, wakeup=wakeup)
+
+    async def fake_run_once():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            idle.set()
+            return None
+        awakened.set()
+        stop.set()
+        return None
+
+    monkeypatch.setattr(worker, "run_once", fake_run_once)
+    task = asyncio.create_task(worker.run_forever(stop))
+    await idle.wait()
+
+    wakeup.signal()
+
+    await asyncio.wait_for(awakened.wait(), timeout=1)
+    await asyncio.wait_for(task, timeout=1)
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_channel_delivery_worker_polls_when_listener_is_disabled(monkeypatch):
+    stop = asyncio.Event()
+    calls = 0
+    worker = ChannelDeliveryWorker(None, poll_interval_seconds=0, wakeup=ChannelWakeup())
+
+    async def fake_run_once():
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            stop.set()
+        return None
+
+    monkeypatch.setattr(worker, "run_once", fake_run_once)
+
+    await asyncio.wait_for(worker.run_forever(stop), timeout=1)
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_websocket_inbox_wakes_on_inbound_signal(monkeypatch):
+    import app.routes.channel_routers.whatsapp as whatsapp_routes
+
+    wakeup = ChannelWakeup()
+    first_query_complete = asyncio.Event()
+    query_count = 0
+    message = SimpleNamespace(
+        inbox_sequence=1,
+        external_chat_id="15551110000@s.whatsapp.net",
+        payload={},
+        provider_message_id="message-1",
+        text="hello",
+    )
+
+    class Result:
+        def __init__(self, values):
+            self._values = values
+
+        def scalars(self):
+            return self
+
+        def all(self):
+            return self._values
+
+    class Session:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        async def execute(self, _statement):
+            nonlocal query_count
+            query_count += 1
+            if query_count == 1:
+                first_query_complete.set()
+                return Result([])
+            return Result([message])
+
+    monkeypatch.setattr(whatsapp_routes, "async_session_factory", Session)
+    monkeypatch.setattr(whatsapp_routes, "channel_inbound_messages_enqueued", wakeup)
+    monkeypatch.setattr(settings, "channel_long_poll_max_seconds", 60)
+    monkeypatch.setattr(settings, "channel_long_poll_interval_seconds", 60)
+    waiting = asyncio.create_task(
+        _wait_whatsapp_websocket_inbox(
+            account_id=UUID("00000000-0000-4000-8000-000000000906"),
+            bot_agent_link_id=UUID("00000000-0000-4000-8000-000000000907"),
+            after_sequence=0,
+            limit=100,
+        )
+    )
+    await first_query_complete.wait()
+
+    wakeup.signal()
+
+    events = await asyncio.wait_for(waiting, timeout=1)
+    assert [event.provider_message_id for event in events] == ["message-1"]
+    assert query_count == 2
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sync_events.py
+++ b/backend/tests/test_sync_events.py
@@ -39,6 +39,12 @@ from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.user import User
 from app.services import sync_events
+from app.services.channel_wakeups import (
+    channel_deliveries_enqueued,
+    channel_inbound_messages_enqueued,
+    notify_channel_delivery_enqueued,
+    notify_channel_inbound_message_enqueued,
+)
 from app.services.managed_ai_provider import (
     CLAWDI_MANAGED_PROVIDER_ID,
     V2_LEGACY_MANAGED_AI_PROVIDER_ID,
@@ -712,12 +718,34 @@ async def test_postgres_listener_ignores_malformed_notification_before_valid_eve
 
 
 @pytest.mark.asyncio
+async def test_postgres_listener_wakes_channel_consumers(db_session: AsyncSession):
+    delivery_waiter = channel_deliveries_enqueued.subscribe()
+    inbound_waiter = channel_inbound_messages_enqueued.subscribe()
+    await sync_events.start_postgres_listener()
+    try:
+        await notify_channel_delivery_enqueued(db_session)
+        await notify_channel_inbound_message_enqueued(db_session)
+        await asyncio.sleep(0)
+        assert not delivery_waiter.is_set()
+        assert not inbound_waiter.is_set()
+
+        await db_session.commit()
+
+        await asyncio.wait_for(delivery_waiter.wait(), timeout=2)
+        await asyncio.wait_for(inbound_waiter.wait(), timeout=2)
+    finally:
+        await sync_events.stop_postgres_listener()
+        channel_deliveries_enqueued.unsubscribe(delivery_waiter)
+        channel_inbound_messages_enqueued.unsubscribe(inbound_waiter)
+
+
+@pytest.mark.asyncio
 async def test_postgres_listener_start_failure_allows_clean_restart(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """A failed first connection leaves the public lifecycle restartable."""
 
-    async def fail_connect(_dsn, _channel, _notification, _terminated):
+    async def fail_connect(_dsn, _channels, _terminated):
         raise RuntimeError("listener failed")
 
     with monkeypatch.context() as failed_connection:

--- a/backend/tests/test_whatsapp_custom_onboarding.py
+++ b/backend/tests/test_whatsapp_custom_onboarding.py
@@ -173,7 +173,7 @@ class FakeCustomSidecar:
     async def query(self, _node, _timeout_ms):
         return None
 
-    async def provider_events(self, *, limit: int = 100):
+    async def provider_events(self, *, limit: int = 100, wait_ms: int = 0):
         return self.provider_event_queue[:limit]
 
     async def acknowledge_provider_events(self, *, through_sequence: int) -> None:

--- a/backend/tests/test_whatsapp_managed_onboarding.py
+++ b/backend/tests/test_whatsapp_managed_onboarding.py
@@ -122,7 +122,7 @@ class FakeManagedSidecar:
         self.stopped = True
         return WhatsAppSidecarPairingStatus(status="stopped", registered=False)
 
-    async def provider_events(self, *, limit: int = 100):
+    async def provider_events(self, *, limit: int = 100, wait_ms: int = 0):
         return []
 
     async def acknowledge_provider_events(self, *, through_sequence: int) -> None:

--- a/backend/tests/test_whatsapp_native_transport.py
+++ b/backend/tests/test_whatsapp_native_transport.py
@@ -231,7 +231,8 @@ async def test_whatsapp_baileys_sidecar_client_uses_internal_contract():
                 },
             )
         if request.url.path == f"{SESSION_PREFIX}/provider-events":
-            assert dict(request.url.params) == {"limit": "25"}
+            assert dict(request.url.params) == {"limit": "25", "waitMs": "8000"}
+            assert request.extensions["timeout"]["read"] == 10.0
             return httpx.Response(
                 200,
                 json={
@@ -303,7 +304,7 @@ async def test_whatsapp_baileys_sidecar_client_uses_internal_contract():
         {"tag": "iq", "attrs": {"id": "query", "type": "get"}},
         15_000,
     )
-    events = await client.provider_events(limit=25)
+    events = await client.provider_events(limit=25, wait_ms=8_000)
     await client.acknowledge_provider_events(through_sequence=events[0].sequence)
 
     await http_client.aclose()

--- a/backend/tests/test_whatsapp_sidecar_registry.py
+++ b/backend/tests/test_whatsapp_sidecar_registry.py
@@ -30,8 +30,9 @@ class _FakeSidecarClient:
     async def aclose(self) -> None:
         self.closed = True
 
-    async def provider_events(self, *, limit: int = 100):
+    async def provider_events(self, *, limit: int = 100, wait_ms: int = 0):
         assert limit == 100
+        assert wait_ms in {0, 8_000}
         return []
 
     async def acknowledge_provider_events(self, *, through_sequence: int):
@@ -177,8 +178,9 @@ async def test_provider_ingress_ack_waits_until_persistence_returns(monkeypatch)
         def __init__(self) -> None:
             self._first_poll = True
 
-        async def provider_events(self, *, limit: int = 100):
+        async def provider_events(self, *, limit: int = 100, wait_ms: int = 0):
             assert limit == 100
+            assert wait_ms == 8_000
             if self._first_poll:
                 self._first_poll = False
                 return [event]
@@ -203,6 +205,36 @@ async def test_provider_ingress_ack_waits_until_persistence_returns(monkeypatch)
             "persistence-returned-after-commit",
             "acknowledged",
         ]
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_provider_ingress_reissues_long_poll_without_idle_sleep():
+    account_id = UUID("00000000-0000-4000-8000-000000000905")
+    second_request = asyncio.Event()
+    calls = 0
+
+    class PumpClient:
+        async def provider_events(self, *, limit: int = 100, wait_ms: int = 0):
+            nonlocal calls
+            calls += 1
+            assert limit == 100
+            assert wait_ms == 8_000
+            if calls == 2:
+                second_request.set()
+                await asyncio.Future()
+            return []
+
+        async def acknowledge_provider_events(self, *, through_sequence: int):
+            raise AssertionError(through_sequence)
+
+    registry = ConfiguredWhatsAppSidecarRegistry("")
+    task = asyncio.create_task(registry._pump_provider_ingress(account_id, PumpClient()))
+    try:
+        await asyncio.wait_for(second_request.wait(), timeout=1)
+        assert calls == 2
     finally:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)
@@ -250,7 +282,8 @@ async def test_terminal_ingress_releases_local_owner_and_can_reattach(
     class PumpClient:
         connected = True
 
-        async def provider_events(self, *, limit=100):
+        async def provider_events(self, *, limit=100, wait_ms=0):
+            assert wait_ms == 8_000
             assert limit == 100
             return [event]
 

--- a/docs/designs/whatsapp-baileys-sidecar-runtime.md
+++ b/docs/designs/whatsapp-baileys-sidecar-runtime.md
@@ -142,7 +142,7 @@ must use HTTPS.
 | `POST` | `/v1/sessions/{id}/relay-message` | Relay an authorized Baileys message proto with its message id and attributes. |
 | `POST` | `/v1/sessions/{id}/raw-node` | Send an ownership-checked receipt or other allowed BinaryNode. |
 | `POST` | `/v1/sessions/{id}/query-iq` | Forward the bounded IQ subset required by the synthetic Noise session. |
-| `GET` | `/v1/sessions/{id}/provider-events` | Read ordered physical `messages.upsert` proto events after synchronous SQLite persistence. |
+| `GET` | `/v1/sessions/{id}/provider-events` | Read ordered physical `messages.upsert` proto events after synchronous SQLite persistence; optional `waitMs` long-polls for up to 8000ms, paired with the backend's explicit 10s read timeout. |
 | `POST` | `/v1/sessions/{id}/provider-events/ack` | Delete physical events only after FastAPI commits them. |
 
 These are provider-transport operations behind an internal bearer, not a

--- a/packages/whatsapp-baileys-sidecar/src/index.ts
+++ b/packages/whatsapp-baileys-sidecar/src/index.ts
@@ -99,8 +99,12 @@ const shutdown = createSharedShutdown(async (signal: "SIGINT" | "SIGTERM"): Prom
 			signal,
 		}),
 	);
-	await new Promise<void>((resolve) => server.close(() => resolve()));
-	await supervisor.stop();
+	const serverClosed = new Promise<void>((resolve) => server.close(() => resolve()));
+	try {
+		await supervisor.stop();
+	} finally {
+		await serverClosed;
+	}
 });
 
 for (const signal of ["SIGINT", "SIGTERM"] as const) {

--- a/packages/whatsapp-baileys-sidecar/src/runtime.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/runtime.test.ts
@@ -637,6 +637,9 @@ function createHarness(options: HarnessOptions = {}) {
 		providerEvents() {
 			return [];
 		},
+		async waitForProviderEvents() {
+			return [];
+		},
 		acknowledgeProviderEvents() {},
 		resetPhysicalAuth() {
 			physicalAuthResets += 1;

--- a/packages/whatsapp-baileys-sidecar/src/runtime.ts
+++ b/packages/whatsapp-baileys-sidecar/src/runtime.ts
@@ -82,6 +82,7 @@ type ProviderState = {
 	): proto.IMessage | undefined;
 	appendProviderEvents(events: readonly ProviderMessageEventInput[]): void;
 	providerEvents(limit: number): ProviderMessageEvent[];
+	waitForProviderEvents(limit: number, waitMs: number): Promise<ProviderMessageEvent[]>;
 	acknowledgeProviderEvents(throughSequence: number): void;
 	resetPhysicalAuth(): void;
 	close(): void;
@@ -400,6 +401,15 @@ export class BaileysSocketRuntime implements BaileysRuntime {
 	providerEvents(limit: number): ProviderMessageEvent[] {
 		try {
 			return this.providerState.providerEvents(limit);
+		} catch (error: unknown) {
+			this.markFatal("provider_inbox_persistence_failed", asError(error));
+			throw error;
+		}
+	}
+
+	async waitForProviderEvents(limit: number, waitMs: number): Promise<ProviderMessageEvent[]> {
+		try {
+			return await this.providerState.waitForProviderEvents(limit, waitMs);
 		} catch (error: unknown) {
 			this.markFatal("provider_inbox_persistence_failed", asError(error));
 			throw error;

--- a/packages/whatsapp-baileys-sidecar/src/server.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/server.test.ts
@@ -110,6 +110,10 @@ class FakeRuntime implements BaileysRuntime {
 		return this.providerInbox.slice(0, limit);
 	}
 
+	async waitForProviderEvents(limit: number, _waitMs: number): Promise<ProviderMessageEvent[]> {
+		return this.providerEvents(limit);
+	}
+
 	acknowledgeProviderEvents(throughSequence: number): void {
 		this.providerInbox = this.providerInbox.filter((event) => event.sequence > throughSequence);
 	}
@@ -372,7 +376,9 @@ describe("sidecar HTTP contract", () => {
 		];
 		const { url } = await startTestServer(runtime);
 
-		const listed = await authedFetch(`${url}${SESSION_PREFIX}/provider-events?limit=10`);
+		const listed = await authedFetch(
+			`${url}${SESSION_PREFIX}/provider-events?limit=10&waitMs=8000`,
+		);
 		const listedBody = await listed.json();
 		const acknowledged = await authedFetch(`${url}${SESSION_PREFIX}/provider-events/ack`, {
 			method: "POST",
@@ -395,6 +401,20 @@ describe("sidecar HTTP contract", () => {
 		expect(acknowledged.status).toBe(200);
 		expect(await acknowledged.json()).toEqual({ ok: true, throughSequence: 1 });
 		expect(runtime.providerInbox).toEqual([]);
+	});
+
+	it.each([
+		"-1",
+		"1.5",
+		"invalid",
+		"8001",
+	])("rejects invalid provider event wait %s", async (waitMs) => {
+		const { url } = await startTestServer(new FakeRuntime());
+
+		const response = await authedFetch(`${url}${SESSION_PREFIX}/provider-events?waitMs=${waitMs}`);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({ error: "waitMs_must_be_0_to_8000" });
 	});
 });
 

--- a/packages/whatsapp-baileys-sidecar/src/server.ts
+++ b/packages/whatsapp-baileys-sidecar/src/server.ts
@@ -133,8 +133,8 @@ export function createSidecarServer(
 				return;
 			}
 			if (method === "GET" && path === "/v1/provider-events") {
-				const limit = parseEventLimit(request.url);
-				writeJson(response, 200, { events: runtime.providerEvents(limit) });
+				const { limit, waitMs } = parseProviderEventsQuery(request.url);
+				writeJson(response, 200, { events: await runtime.waitForProviderEvents(limit, waitMs) });
 				return;
 			}
 			if (method === "POST" && path === "/v1/provider-events/ack") {
@@ -278,13 +278,18 @@ function parseQueryBody(body: unknown) {
 	};
 }
 
-function parseEventLimit(rawUrl: string | undefined): number {
-	const raw = new URL(rawUrl ?? "/", "http://127.0.0.1").searchParams.get("limit") ?? "100";
+function parseProviderEventsQuery(rawUrl: string | undefined): { limit: number; waitMs: number } {
+	const params = new URL(rawUrl ?? "/", "http://127.0.0.1").searchParams;
+	const raw = params.get("limit") ?? "100";
 	const limit = Number(raw);
 	if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
 		throw new HttpError(400, "limit_must_be_1_to_100");
 	}
-	return limit;
+	const waitMs = Number(params.get("waitMs") ?? "0");
+	if (!Number.isInteger(waitMs) || waitMs < 0 || waitMs > 8_000) {
+		throw new HttpError(400, "waitMs_must_be_0_to_8000");
+	}
+	return { limit, waitMs };
 }
 
 function parseEventAckBody(body: unknown): number {

--- a/packages/whatsapp-baileys-sidecar/src/session-supervisor.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/session-supervisor.test.ts
@@ -87,6 +87,10 @@ class FakeRuntime implements BaileysRuntime {
 		return [];
 	}
 
+	async waitForProviderEvents(): Promise<[]> {
+		return [];
+	}
+
 	acknowledgeProviderEvents(): void {}
 }
 

--- a/packages/whatsapp-baileys-sidecar/src/sqlite-state.test.ts
+++ b/packages/whatsapp-baileys-sidecar/src/sqlite-state.test.ts
@@ -10,7 +10,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type AuthenticationCreds, BufferJSON, proto } from "baileys";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { parseAuditedWhatsAppWebVersion } from "./audited-version.js";
 import { Database } from "./sqlite-database.js";
@@ -29,6 +29,7 @@ const WEB_VERSION = parseAuditedWhatsAppWebVersion("2.3000.1043857760");
 const temporaryDirectories: string[] = [];
 
 afterEach(() => {
+	vi.useRealTimers();
 	for (const directory of temporaryDirectories.splice(0)) {
 		try {
 			const database = new Database(join(directory, "provider-state.sqlite"));
@@ -300,6 +301,49 @@ describe("SQLite provider state", () => {
 		second.appendProviderEvents([providerEvent("second")]);
 		expect(second.providerEvents(100)[0]?.sequence).toBe(2);
 		second.close();
+	});
+
+	it("returns pending provider events without waiting", async () => {
+		const state = makeState(makeDirectory());
+		state.appendProviderEvents([providerEvent("pending")]);
+
+		expect(await state.waitForProviderEvents(100, 8_000)).toEqual(state.providerEvents(100));
+		state.close();
+	});
+
+	it("wakes every provider event waiter when events are appended", async () => {
+		const state = makeState(makeDirectory());
+		const first = state.waitForProviderEvents(100, 8_000);
+		const second = state.waitForProviderEvents(100, 8_000);
+
+		state.appendProviderEvents([providerEvent("appended")]);
+
+		const results = await Promise.all([first, second]);
+		expect(results.map((events) => events.map((event) => event.messageId))).toEqual([
+			["appended"],
+			["appended"],
+		]);
+		state.close();
+	});
+
+	it("returns an empty provider event batch when the wait expires", async () => {
+		vi.useFakeTimers();
+		const state = makeState(makeDirectory());
+		const waiting = state.waitForProviderEvents(100, 8_000);
+
+		await vi.advanceTimersByTimeAsync(8_000);
+
+		await expect(waiting).resolves.toEqual([]);
+		state.close();
+	});
+
+	it("resolves provider event waiters when the state closes", async () => {
+		const state = makeState(makeDirectory());
+		const waiting = state.waitForProviderEvents(100, 8_000);
+
+		state.close();
+
+		await expect(waiting).resolves.toEqual([]);
 	});
 
 	it("atomically clears physical auth, Signal, retry, and inbox state across restart", async () => {

--- a/packages/whatsapp-baileys-sidecar/src/sqlite-state.ts
+++ b/packages/whatsapp-baileys-sidecar/src/sqlite-state.ts
@@ -102,6 +102,7 @@ export class SQLiteProviderState {
 
 	private readonly db: Database;
 	private readonly creds: AuthenticationCreds;
+	private readonly providerEventWaiters = new Set<() => void>();
 	private closed = false;
 
 	constructor(
@@ -237,6 +238,7 @@ export class SQLiteProviderState {
 				for (const event of prepared) insert.run(event.value, event.byteCount, createdAt);
 			});
 		});
+		this.signalProviderEventWaiters();
 	}
 
 	providerEvents(limit: number): ProviderMessageEvent[] {
@@ -260,6 +262,29 @@ export class SQLiteProviderState {
 				return parseProviderMessageEvent(row.event_json, row.sequence);
 			});
 		});
+	}
+
+	async waitForProviderEvents(limit: number, waitMs: number): Promise<ProviderMessageEvent[]> {
+		if (!Number.isInteger(waitMs) || waitMs < 0 || waitMs > 8_000) {
+			throw new Error("provider inbox wait must be between 0 and 8000 milliseconds");
+		}
+		if (this.closed) return [];
+		const pending = this.providerEvents(limit);
+		if (pending.length > 0 || waitMs === 0) return pending;
+
+		await new Promise<void>((resolve) => {
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			const finish = () => {
+				if (!this.providerEventWaiters.delete(finish)) return;
+				if (timer !== undefined) clearTimeout(timer);
+				resolve();
+			};
+			this.providerEventWaiters.add(finish);
+			timer = setTimeout(finish, waitMs);
+			if (this.closed) finish();
+		});
+
+		return this.closed ? [] : this.providerEvents(limit);
 	}
 
 	acknowledgeProviderEvents(throughSequence: number): void {
@@ -361,11 +386,16 @@ export class SQLiteProviderState {
 	close(): void {
 		if (this.closed) return;
 		this.closed = true;
+		this.signalProviderEventWaiters();
 		try {
 			this.db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
 		} finally {
 			this.db.close();
 		}
+	}
+
+	private signalProviderEventWaiters(): void {
+		for (const resolve of [...this.providerEventWaiters]) resolve();
 	}
 
 	getRetryCounter<T>(key: string): T | undefined {

--- a/packages/whatsapp-baileys-sidecar/src/types.ts
+++ b/packages/whatsapp-baileys-sidecar/src/types.ts
@@ -75,6 +75,7 @@ export type BaileysRuntime = {
 	sendNode(node: BinaryNode): Promise<void>;
 	query(node: BinaryNode, timeoutMs: number): Promise<BinaryNode | null>;
 	providerEvents(limit: number): ProviderMessageEvent[];
+	waitForProviderEvents(limit: number, waitMs: number): Promise<ProviderMessageEvent[]>;
 	acknowledgeProviderEvents(throughSequence: number): void;
 };
 


### PR DESCRIPTION
## Summary

- replace the measured 250ms backend-to-sidecar provider-event idle poll with sidecar long-polling
- wake channel delivery workers immediately through the existing PostgreSQL listener infrastructure
- wake the Hermes WhatsApp inbox DB reader on committed inbound messages

## Design

The previous chain could add 0.25s at provider ingress and up to 1s at an idle delivery worker before processing new work.

The sidecar provider-events endpoint now accepts `waitMs` from 0 through 8000. Pending events return immediately; otherwise the request waits for an append, timeout, or runtime shutdown. The backend pairs `waitMs=8000` with an explicit 10s read timeout.

Outbound delivery and inbound inbox inserts call `pg_notify` inside their existing database transaction, so PostgreSQL publishes the signal only after commit. The existing listener now subscribes to those channels in both web and channel-worker processes and broadcasts process-local wakeups.

NOTIFY remains only a wake signal: PostgreSQL rows are still the source of truth. Lost notifications, a disabled listener, and scheduled delivery retries continue to rely on the existing bounded polling intervals. Ordering, acknowledgement, at-least-once delivery, and retry/backoff semantics are unchanged.

Hermes inbox delivery was DB-polled before this change; it now follows subscribe/query/recheck/wait ordering to avoid missed wakeups while keeping the prior bounded fallback. The managed native E2E fixture does not implement the provider-events endpoint, so no fixture query compatibility change was required.

## Verification

- focused backend PostgreSQL suites after rebasing: 213 passed
- broader channels/WhatsApp/backend suites during implementation: 727 passed, 6 skipped
- channel suite during implementation: 407 passed
- sidecar: 81 passed across 9 files
- managed WhatsApp native E2E: OpenClaw and Hermes passed
- workspace TypeScript typecheck: 4 packages passed
- sidecar TypeScript typecheck and Biome: passed
- Ruff lint, focused Ruff format, compileall: passed
- BasedPyright: 186 files, 0 errors and 0 warnings

Not merged; ready for orchestrator review.