### PR TITLE
fix(web): align agent settings management

### DIFF
--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -7,6 +7,7 @@ import {
 	collectBrowserErrors,
 	gotoHostedAgentSettings,
 	gotoHostedSettingsDialog,
+	includedBasicDeployment,
 	paidBasicDeployment,
 	performancePlan,
 	planChangeQuoteResponse,
@@ -162,6 +163,41 @@ async function expectNoHorizontalOverflow(page: Page) {
 		scrollWidth: document.documentElement.scrollWidth,
 	}));
 	expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth);
+}
+
+async function expectAgentSettingsSectionsAligned(page: Page, maxWidth: number) {
+	const main = page.locator("main");
+	const sectionNames = ["Name", "Language & timezone", "Compute plan", "Lifecycle", "Danger zone"];
+	const boxes = await Promise.all(
+		sectionNames.map(async (name) => {
+			const section = main
+				.getByRole("heading", { name, exact: true })
+				.locator("xpath=ancestor::section[1]");
+			await expect(section).toBeVisible();
+			const box = await section.boundingBox();
+			if (!box) throw new Error(`${name} settings section has no layout box`);
+			const overflow = await section.evaluate((element) => ({
+				clientWidth: element.clientWidth,
+				scrollWidth: element.scrollWidth,
+			}));
+			expect(overflow.scrollWidth, `${name} section overflow`).toBeLessThanOrEqual(
+				overflow.clientWidth + 1,
+			);
+			return box;
+		}),
+	);
+
+	const [reference] = boxes;
+	if (!reference) throw new Error("Expected Agent Settings section boxes");
+	expect(reference.width).toBeLessThanOrEqual(maxWidth + 1);
+	for (const box of boxes.slice(1)) {
+		expect(Math.abs(box.x - reference.x), "section left edge").toBeLessThanOrEqual(1);
+		expect(Math.abs(box.width - reference.width), "section width").toBeLessThanOrEqual(1);
+		expect(
+			Math.abs(box.x + box.width / 2 - (reference.x + reference.width / 2)),
+			"section center axis",
+		).toBeLessThanOrEqual(1);
+	}
 }
 
 async function openSubscriptions(page: Page) {
@@ -359,14 +395,28 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 
 	const accountSettingsUrl = page.url();
 	await activeCard.getByRole("button", { name: "Manage", exact: true }).click();
-	const fullManagementDialog = page.getByRole("dialog", { name: "Change compute subscription" });
+	const fullManagementDialog = page.getByRole("dialog", { name: "Manage compute subscription" });
 	await expect(fullManagementDialog).toBeVisible();
 	await expect(dialog).toBeVisible();
 	expect(page.url()).toBe(accountSettingsUrl);
+	await expect(
+		fullManagementDialog.getByRole("group", { name: "Subscription management mode" }),
+	).toBeVisible();
+	await expect(
+		fullManagementDialog.getByRole("button", { name: "Plan & billing", exact: true }),
+	).toHaveAttribute("aria-pressed", "true");
+	await expect(fullManagementDialog.getByLabel("Payment source")).toHaveCount(0);
 	await expect(fullManagementDialog.getByLabel("Compute plan")).toHaveText(/Performance/);
 	await fullManagementDialog.getByLabel("Compute plan").click();
 	await page.getByRole("option", { name: "Basic", exact: true }).click();
 	await expect(fullManagementDialog.getByLabel("Compute plan")).toHaveText(/Basic/);
+	await fullManagementDialog.getByRole("button", { name: "Payment source", exact: true }).click();
+	await expect(fullManagementDialog.getByLabel("Compute plan")).toHaveCount(0);
+	await expect(fullManagementDialog.getByText("Current plan", { exact: true })).toBeVisible();
+	await expect(fullManagementDialog.getByLabel("Payment source")).toBeVisible();
+	await fullManagementDialog.getByRole("button", { name: "Plan & billing", exact: true }).click();
+	await expect(fullManagementDialog.getByLabel("Compute plan")).toHaveText(/Performance/);
+	await expect(fullManagementDialog.getByLabel("Payment source")).toHaveCount(0);
 	await fullManagementDialog.getByRole("button", { name: "Cancel", exact: true }).click();
 	await expect(fullManagementDialog).toBeHidden();
 	await expect(dialog).toBeVisible();
@@ -379,6 +429,9 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(paymentSourceDialog).toBeVisible();
 	await expect(dialog).toBeVisible();
 	expect(page.url()).toBe(accountSettingsUrl);
+	await expect(
+		paymentSourceDialog.getByRole("group", { name: "Subscription management mode" }),
+	).toHaveCount(0);
 	await expect(paymentSourceDialog.getByText("Current plan", { exact: true })).toBeVisible();
 	await expect(paymentSourceDialog.getByText("Basic", { exact: true })).toBeVisible();
 	await expect(paymentSourceDialog.getByText("Monthly", { exact: true })).toBeVisible();
@@ -477,6 +530,7 @@ test("agent settings uses the subscription card without changing plan actions", 
 				},
 			},
 			terminalFallbackDeployment,
+			includedBasicDeployment,
 		],
 		plans: [basicPlan, performancePlan],
 	});
@@ -500,9 +554,11 @@ test("agent settings uses the subscription card without changing plan actions", 
 	const activeCardWidth = await activeCard.evaluate((card) => card.getBoundingClientRect().width);
 	expect(activeCardWidth).toBeLessThanOrEqual(672);
 	await expectCardsFit(page.locator("body"));
+	await expectAgentSettingsSectionsAligned(page, 896);
 
 	await page.setViewportSize({ width: 320, height: 568 });
 	await expectCardsFit(page.locator("body"));
+	await expectAgentSettingsSectionsAligned(page, 320);
 	await expectNoHorizontalOverflow(page);
 	await expect(activeCard.getByRole("button", { name: "Manage", exact: true })).toBeVisible();
 	await expect(activeCard.getByRole("button", { name: "Cancel subscription" })).toBeVisible();
@@ -559,6 +615,18 @@ test("agent settings uses the subscription card without changing plan actions", 
 	await expect(fallbackCard.getByText("Payment", { exact: true })).toBeVisible();
 	await expect(fallbackCard.getByText("Included", { exact: true })).toBeVisible();
 	await expect(fallbackCard.getByRole("button", { name: "Choose a subscription" })).toBeVisible();
+
+	await gotoHostedAgentSettings(page, "hdep_included", "Basic");
+	await page.getByRole("button", { name: "Upgrade to Performance", exact: true }).click();
+	const includedUpgradeDialog = page.getByRole("dialog", { name: "Change compute subscription" });
+	await expect(includedUpgradeDialog).toBeVisible();
+	await expect(
+		includedUpgradeDialog.getByRole("group", { name: "Subscription management mode" }),
+	).toHaveCount(0);
+	await expect(includedUpgradeDialog.getByLabel("Compute plan")).toBeVisible();
+	await expect(includedUpgradeDialog.getByLabel("Payment source")).toBeVisible();
+	await expectNoHorizontalOverflow(page);
+	await includedUpgradeDialog.getByRole("button", { name: "Cancel", exact: true }).click();
 	expect(errors, `agent subscription cards: ${errors.join(" | ")}`).toEqual([]);
 });
 

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -3407,7 +3407,7 @@ function HostedAgentSettingsTab({
 }) {
 	return (
 		<UnsavedNavigationBoundary description="Your agent settings will return to the last values saved on the server.">
-			<div className="flex flex-col gap-8">
+			<div className="mx-auto flex w-full max-w-4xl flex-col gap-8">
 				{agent ? (
 					<AgentSettingsPanel environmentId={environmentId} />
 				) : (

--- a/apps/web/src/hosted/billing/subscription/plan-change-dialog.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-change-dialog.tsx
@@ -59,6 +59,8 @@ const PLAN_ITEMS = [
 	{ value: "compute_performance", label: "Performance" },
 ] as const;
 
+type ManagementMode = "plan-billing" | "payment-source";
+
 function planSlug(value: string | null): ComputePlanSlug | null {
 	return value === "compute_basic" || value === "compute_performance" ? value : null;
 }
@@ -204,6 +206,9 @@ export function PlanChangeDialog({
 		[currentBillingTermMonths, currentFundingSource, currentPlanSlug, initialPlanSlug],
 	);
 	const [selection, setSelection] = useState(initialSelection);
+	const [managementMode, setManagementMode] = useState<ManagementMode>(
+		paymentSourceOnly ? "payment-source" : "plan-billing",
+	);
 	const exit = useDialogExitLifecycle({ open, value: quote, emptyValue: null });
 	const displayedQuote = exit.renderedValue;
 	const step = planChangeDialogStep({
@@ -260,10 +265,27 @@ export function PlanChangeDialog({
 	const walletReady =
 		!planChangeNeedsWalletBalance(selection, currentPlanSlug, currentBillingTermMonths) ||
 		walletBalanceUsd !== null;
+	const hasManagementModes = !allowCombinedChange && !paymentSourceOnly;
+	const paymentSourceMode = paymentSourceOnly || managementMode === "payment-source";
 
 	useEffect(() => {
-		if (open) setSelection(initialSelection);
-	}, [initialSelection, open]);
+		if (!open) return;
+		setSelection(initialSelection);
+		setManagementMode(paymentSourceOnly ? "payment-source" : "plan-billing");
+	}, [initialSelection, open, paymentSourceOnly]);
+
+	function updateManagementMode(nextMode: ManagementMode) {
+		setManagementMode(nextMode);
+		setSelection(
+			nextMode === "payment-source"
+				? {
+						target_plan_slug: currentPlanSlug,
+						target_billing_term_months: currentBillingTermMonths,
+						funding_source: currentFundingSource,
+					}
+				: initialSelection,
+		);
+	}
 
 	function updatePlan(value: string | null) {
 		const nextPlanSlug = planSlug(value);
@@ -340,7 +362,9 @@ export function PlanChangeDialog({
 									? quoteTitle
 									: paymentSourceOnly
 										? "Change payment source"
-										: "Change compute subscription"}
+										: hasManagementModes
+											? "Manage compute subscription"
+											: "Change compute subscription"}
 					</DialogTitle>
 					<DialogDescription>
 						{step === "pending"
@@ -353,9 +377,11 @@ export function PlanChangeDialog({
 										: displayedQuote.change_kind === "immediate_upgrade"
 											? "The quoted proration is charged now. Compute changes after payment is confirmed."
 											: `The current plan remains active until ${formatShortDate(displayedQuote.effective_at)}.`
-									: paymentSourceOnly
+									: paymentSourceMode
 										? "Choose a new payment source. Your plan and billing term stay the same; eligibility is verified before the change is applied."
-										: "Choose a compute plan, billing term, and payment source, then review the exact price and timing."}
+										: allowCombinedChange
+											? "Choose a compute plan, billing term, and payment source, then review the exact price and timing."
+											: "Choose a compute plan and billing term. Your payment source stays the same."}
 					</DialogDescription>
 				</DialogHeader>
 
@@ -515,7 +541,29 @@ export function PlanChangeDialog({
 					</div>
 				) : (
 					<div className="flex flex-col gap-5">
-						{paymentSourceOnly ? (
+						{hasManagementModes ? (
+							<ToggleGroup
+								value={[managementMode]}
+								onValueChange={(value) => {
+									const nextMode = value[0];
+									if (nextMode === "plan-billing" || nextMode === "payment-source") {
+										updateManagementMode(nextMode);
+									}
+								}}
+								variant="outline"
+								size="sm"
+								className="grid w-full grid-cols-2"
+								aria-label="Subscription management mode"
+							>
+								<ToggleGroupItem value="plan-billing" className="min-w-0 px-2">
+									Plan &amp; billing
+								</ToggleGroupItem>
+								<ToggleGroupItem value="payment-source" className="min-w-0 px-2">
+									Payment source
+								</ToggleGroupItem>
+							</ToggleGroup>
+						) : null}
+						{paymentSourceMode ? (
 							<div className="grid gap-3 border-y py-3 sm:grid-cols-2">
 								<dl>
 									<dt className="text-xs text-muted-foreground">Current plan</dt>
@@ -569,42 +617,44 @@ export function PlanChangeDialog({
 								</div>
 							</div>
 						)}
-						<div className="flex flex-col gap-1.5">
-							<Label id="plan-change-funding-label">Payment source</Label>
-							<ToggleGroup
-								value={[selection.funding_source]}
-								onValueChange={(value) => {
-									const next = value[0];
-									if (next === "stripe" || next === "wallet") {
-										setSelection((current) =>
-											selectPlanChangeFundingSource(
-												current,
-												next,
-												currentPlanSlug,
-												currentBillingTermMonths,
-												allowCombinedChange,
-											),
-										);
-									}
-								}}
-								variant="outline"
-								className="grid w-full grid-cols-2"
-								aria-labelledby="plan-change-funding-label"
-							>
-								<ToggleGroupItem value="stripe">
-									<CreditCard data-icon="inline-start" /> Card
-								</ToggleGroupItem>
-								<ToggleGroupItem value="wallet">
-									<WalletCards data-icon="inline-start" /> Wallet
-								</ToggleGroupItem>
-							</ToggleGroup>
-						</div>
+						{allowCombinedChange || paymentSourceMode ? (
+							<div className="flex flex-col gap-1.5">
+								<Label id="plan-change-funding-label">Payment source</Label>
+								<ToggleGroup
+									value={[selection.funding_source]}
+									onValueChange={(value) => {
+										const next = value[0];
+										if (next === "stripe" || next === "wallet") {
+											setSelection((current) =>
+												selectPlanChangeFundingSource(
+													current,
+													next,
+													currentPlanSlug,
+													currentBillingTermMonths,
+													allowCombinedChange,
+												),
+											);
+										}
+									}}
+									variant="outline"
+									className="grid w-full grid-cols-2"
+									aria-labelledby="plan-change-funding-label"
+								>
+									<ToggleGroupItem value="stripe">
+										<CreditCard data-icon="inline-start" /> Card
+									</ToggleGroupItem>
+									<ToggleGroupItem value="wallet">
+										<WalletCards data-icon="inline-start" /> Wallet
+									</ToggleGroupItem>
+								</ToggleGroup>
+							</div>
+						) : null}
 						{selection.funding_source === "wallet" && !walletReady ? (
 							<p className="text-sm text-muted-foreground" role="status">
 								Loading Wallet balance…
 							</p>
 						) : null}
-						{selectedOffer ? (
+						{selectedOffer && !paymentSourceMode ? (
 							<p className="text-sm text-muted-foreground">
 								Listed recurring price {formatCents(selectedOffer.price_cents)}
 								{selectedOffer.billing_term_months === 1 ? "/month" : "/year"}


### PR DESCRIPTION
## Summary

- center Hosted Agent Settings sections on one shared `max-w-4xl` content axis without changing the reusable `SettingsSection` primitive
- split paid compute management into mutually exclusive `Plan & billing` and `Payment source` modes while preserving the server-side single-change boundary
- keep past-due subscriptions payment-source-only and Included Basic upgrades on the existing combined first-upgrade flow

## Verification

- `bun test apps/web/src/hosted/billing/subscription/plan-change-dialog.test.tsx apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts apps/web/src/hosted/agents/hosted-agent-detail.test.ts` (30 passed)
- `bun run --cwd apps/web typecheck`
- `./node_modules/.bin/biome check apps/web/src/hosted/agents/hosted-agent-detail.tsx apps/web/src/hosted/billing/subscription/plan-change-dialog.tsx apps/web/e2e/hosted-subscriptions.pw.ts`
- `bun run --cwd apps/web build:oss`
- focused hosted Playwright: 2 passed, covering paid/past-due/Included Basic management and aligned section geometry at 1440px and 320px
- inspected full-page and dialog screenshots at 1440x900 and 320x568; no overflow, clipping, overlap, or content-axis drift
