### PR TITLE
fix(runtime): restore active CLI env gate

### DIFF
--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -95,7 +95,6 @@ _CODEX_TOOL_CANONICAL_ENV_MINIMUM_CLI_VERSION = (0, 13, 69)
 _CODEX_TOOL_SECRET_REF = "secret://tool.codex.apiKey"
 _CODEX_TOOL_API_MODE = "openai_responses"
 _CODEX_PROVIDER_SOURCE_API_MODES = {"openai_chat", "openai_responses"}
-_HOSTED_CLI_NPM_REGISTRY = "https://registry.npmjs.org"
 _AI_PROVIDER_MODELS_ADAPTER: TypeAdapter[list[AiProviderModel]] = TypeAdapter(list[AiProviderModel])
 
 
@@ -112,29 +111,6 @@ def expected_runtime_bundle_v2_etag(source_revision: str) -> str:
     if not re.fullmatch(r"[0-9a-f]{64}", source_revision):
         raise ValueError("runtime bundle source revision must be a SHA-256 digest")
     return f'"sha256:{source_revision}"'
-
-
-def _has_exact_active_cli_evidence(
-    diagnostics: HostedRuntimeObservedV2,
-    package_spec: str,
-) -> bool:
-    prefix = "clawdi@"
-    if not package_spec.startswith(prefix):
-        return False
-    version = package_spec.removeprefix(prefix)
-    if parse_exact_semver(version) is None:
-        return False
-    cli = diagnostics.cli
-    return bool(
-        cli is not None
-        and cli.status == "installed"
-        and cli.source == "npm"
-        and cli.package_spec == package_spec
-        and cli.registry == _HOSTED_CLI_NPM_REGISTRY
-        and cli.active_path
-        and cli.active_target
-        and cli.version == version
-    )
 
 
 def _codex_tool_runtime_env(
@@ -166,7 +142,7 @@ def _codex_tool_runtime_env(
     if not (
         observed.status == "ok"
         and observed.converge_error is None
-        and _has_exact_active_cli_evidence(observed, state.cli_package_spec)
+        and observed.active_cli_version == desired_version
         and observed.applied is not None
         and observed.applied.instance_id == state.instance_id
         and observed.applied.generation == expected_generation
@@ -836,7 +812,7 @@ def render_runtime_source(
         "clawdiCli": {
             "source": "npm:clawdi",
             "packageSpec": cli_package_spec,
-            "registry": _HOSTED_CLI_NPM_REGISTRY,
+            "registry": "https://registry.npmjs.org",
         },
         "runtimes": {runtime_name: runtime},
         "providers": providers,

--- a/backend/tests/hosted_runtime_fixtures.py
+++ b/backend/tests/hosted_runtime_fixtures.py
@@ -24,19 +24,6 @@ CANONICAL_CODEX_TOOLS = {
 }
 
 
-def active_cli_diagnostics(package_spec: str) -> dict[str, str]:
-    version = package_spec.removeprefix("clawdi@")
-    return {
-        "status": "installed",
-        "source": "npm",
-        "packageSpec": package_spec,
-        "registry": "https://registry.npmjs.org",
-        "activePath": "/test/managed/clawdi",
-        "activeTarget": f"/test/managed/packages/{version}/clawdi",
-        "version": version,
-    }
-
-
 def filebrowser_companion(deployment_id: str, access_revision: str = "a" * 64) -> dict[str, Any]:
     audience = f"clawdi-files:{deployment_id}"
     release = "https://github.com/gtsteffaniak/filebrowser/releases/download/v1.5.0-stable"

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -36,10 +36,7 @@ from app.services.runtime_source import (
     render_runtime_bundle,
     render_runtime_source,
 )
-from tests.hosted_runtime_fixtures import (
-    CANONICAL_CODEX_TOOL_PROVIDER_ID,
-    active_cli_diagnostics,
-)
+from tests.hosted_runtime_fixtures import CANONICAL_CODEX_TOOL_PROVIDER_ID
 
 USER_ID = UUID("10000000-0000-0000-0000-000000000001")
 ENV_ID = UUID("20000000-0000-0000-0000-000000000002")
@@ -318,7 +315,7 @@ def _set_healthy_cli_observation(
     batch: RuntimeSourceBatch,
     *,
     desired: str,
-    daemon_version: str = "0.13.68",
+    active: str | None = None,
     source_revision: str = "a" * 64,
 ) -> HostedRuntimeConfigObservation:
     row = batch.rows[ENV_ID]
@@ -340,7 +337,7 @@ def _set_healthy_cli_observation(
             "reportedAt": "2026-07-13T00:00:00Z",
             "runtimeMode": "hosted",
             "status": "ok",
-            "activeCliVersion": daemon_version,
+            "activeCliVersion": active or desired.removeprefix("clawdi@"),
             "applied": {
                 "etag": etag,
                 "sourceRevision": source_revision,
@@ -349,7 +346,7 @@ def _set_healthy_cli_observation(
                 "appliedProviderIds": ["managed"],
             },
             "boot": None,
-            "cli": active_cli_diagnostics(desired),
+            "cli": None,
             "convergeError": None,
         },
     )
@@ -760,34 +757,51 @@ def test_codex_tool_projection_rejects_invalid_fixed_fields(field: str, value: s
 
 
 @pytest.mark.parametrize(
-    ("desired", "expected"),
+    ("desired", "active", "expected"),
     [
-        ("0.13.68", "OPENAI_API_KEY"),
-        ("0.13.69-rc.1", "OPENAI_API_KEY"),
-        ("0.13.69", "CLAWDI_AI_API_KEY"),
-        ("0.14.0-rc.1", "CLAWDI_AI_API_KEY"),
+        ("0.13.68", "0.13.68", "OPENAI_API_KEY"),
+        ("0.13.69-rc.1", "0.13.69-rc.1", "OPENAI_API_KEY"),
+        ("0.13.69", "0.13.68", "OPENAI_API_KEY"),
+        ("0.13.69", "0.13.69", "CLAWDI_AI_API_KEY"),
+        ("0.14.0-rc.1", "0.14.0-rc.1", "CLAWDI_AI_API_KEY"),
+        ("0.13.68", "0.14.0", "OPENAI_API_KEY"),
     ],
 )
 def test_codex_tool_env_respects_cli_version_boundary(
     desired: str,
+    active: str,
     expected: str,
 ) -> None:
     batch = _batch()
-    _set_healthy_cli_observation(batch, desired=f"clawdi@{desired}")
+    _set_healthy_cli_observation(
+        batch,
+        desired=f"clawdi@{desired}",
+        active=active,
+    )
 
     assert _codex_runtime_env(batch) == expected
 
 
-def test_codex_tool_env_accepts_current_cli_diagnostics_from_old_daemon() -> None:
+def test_codex_tool_env_rejects_compatible_installed_cli_until_it_is_running() -> None:
     batch = _batch()
     observation = _set_healthy_cli_observation(
         batch,
         desired="clawdi@0.13.69",
-        daemon_version="0.13.68",
+        active="0.13.68",
     )
+    assert isinstance(observation.diagnostics, dict)
+    observation.diagnostics["cli"] = {
+        "status": "installed",
+        "source": "npm",
+        "packageSpec": "clawdi@0.13.69",
+        "registry": "https://registry.npmjs.org",
+        "activePath": "/test/managed/clawdi",
+        "activeTarget": "/test/managed/packages/0.13.69/clawdi",
+        "version": "0.13.69",
+    }
 
     assert observation.diagnostics["activeCliVersion"] == "0.13.68"
-    assert _codex_runtime_env(batch) == "CLAWDI_AI_API_KEY"
+    assert _codex_runtime_env(batch) == "OPENAI_API_KEY"
 
 
 def test_codex_tool_env_stays_legacy_until_new_cli_is_observed() -> None:
@@ -802,45 +816,6 @@ def test_codex_tool_env_stays_legacy_until_new_cli_is_observed() -> None:
         "OPENAI_API_KEY",
         "OPENAI_API_KEY",
     ]
-
-
-@pytest.mark.parametrize(
-    "cli_update",
-    [
-        pytest.param(None, id="missing"),
-        pytest.param({"status": "deferred"}, id="not-installed"),
-        pytest.param(
-            {
-                "packageSpec": "clawdi@0.13.68",
-                "activeTarget": (
-                    "/var/lib/clawdi/maintained/clawdi/npm/packages/0.13.68/bin/clawdi"
-                ),
-                "version": "0.13.68",
-            },
-            id="stale",
-        ),
-        pytest.param({"source": "fixture"}, id="source-mismatch"),
-        pytest.param({"packageSpec": "clawdi@0.13.70"}, id="package-mismatch"),
-        pytest.param({"registry": "https://registry.test"}, id="registry-mismatch"),
-        pytest.param({"activePath": None}, id="active-path-missing"),
-        pytest.param({"activeTarget": None}, id="active-target-missing"),
-        pytest.param({"version": "0.13.70"}, id="version-mismatch"),
-    ],
-)
-def test_codex_tool_env_rejects_inexact_cli_diagnostics(
-    cli_update: dict[str, object] | None,
-) -> None:
-    batch = _batch()
-    observation = _set_healthy_cli_observation(batch, desired="clawdi@0.13.69")
-    assert isinstance(observation.diagnostics, dict)
-    cli = observation.diagnostics["cli"]
-    if cli_update is None:
-        observation.diagnostics["cli"] = None
-    else:
-        assert isinstance(cli, dict)
-        cli.update(cli_update)
-
-    assert _codex_runtime_env(batch) == "OPENAI_API_KEY"
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -39,7 +39,6 @@ from app.services.runtime_source import expected_runtime_bundle_v2_etag
 from tests.conftest import create_env_with_project
 from tests.hosted_runtime_fixtures import (
     CANONICAL_CODEX_TOOLS,
-    active_cli_diagnostics,
     canonical_hosted_runtime_state,
     ensure_canonical_codex_tool_provider,
 )
@@ -575,7 +574,6 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
         applied_generation=4,
         applied_instance_id="iid-observed-api",
     )
-    observed["cli"] = active_cli_diagnostics(_TEST_HOSTED_INTEGRATIONS_CLI_PACKAGE_SPEC)
     heartbeat = await client.post(
         f"/v1/agents/{env_id}/sync-heartbeat",
         json={"queue_depth": 1, "runtime_observed": observed},
@@ -593,7 +591,6 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
         applied_generation=4,
         applied_instance_id="iid-observed-api",
     )
-    observed["cli"] = active_cli_diagnostics(_TEST_HOSTED_INTEGRATIONS_CLI_PACKAGE_SPEC)
     received_at_lower_bound = datetime.now(UTC)
     heartbeat = await client.post(
         f"/v1/agents/{env_id}/sync-heartbeat",

--- a/docs/ai-provider-agent-contract-audit.md
+++ b/docs/ai-provider-agent-contract-audit.md
@@ -83,9 +83,8 @@ choice.
 Deployment is two-stage. Phase A publishes the dual-read/canonical-write
 `clawdi@0.13.69`; the backend continues to emit legacy `OPENAI_API_KEY`. Phase B
 is a separate backend change gated on the exact CLI being published, desired
-package specs advancing, and strict `diagnostics.cli` evidence proving that exact
-package is installed and active. An in-place update preserves the long-running
-daemon, so `activeCliVersion` may correctly remain its older running version.
+package specs advancing, and `activeCliVersion` proving that the current running
+CLI is that exact version. Installed CLI diagnostics are not execution authority.
 The current flow parses the strict manifest before `applyRuntimeCliDesiredState`,
 so enabling canonical backend emission earlier would strand an older CLI before
 self-upgrade.

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -657,12 +657,11 @@ This change is Phase A: publish `clawdi@0.13.69`, which reads both legacy and
 canonical terminal-Codex env names while writing only the canonical local env.
 Phase B keeps backend emission deployment-scoped: terminal Codex receives
 `CLAWDI_AI_API_KEY` only when the desired CLI is `clawdi@0.13.69` or later and
-strict v2 `diagnostics.cli` proves the exact desired package is installed and
-active, along with the current apply generation and instance. An in-place update
-preserves the daemon process, so its `activeCliVersion` may remain the older
-running version. Observation generation, ETag, and source revision must agree
-with that applied record. Every missing, invalid, stale, or mismatched state
-retains `OPENAI_API_KEY`, including upgrades and rollbacks.
+strict v2 `activeCliVersion` proves the current running CLI is the exact desired
+version, along with the current apply generation and instance. Installed CLI
+diagnostics do not satisfy this gate. Observation generation, ETag, and source
+revision must agree with that applied record. Every missing, invalid, stale, or
+mismatched state retains `OPENAI_API_KEY`, including upgrades and rollbacks.
 Phase B may therefore deploy before the fleet upgrades: each deployment remains
 on the legacy env name until its own CLI and observation have converged.
 The gate does not compare that last applied revision with the revision currently


### PR DESCRIPTION
## Summary

- restore the running CLI version as the terminal Codex env cutover authority
- keep legacy `OPENAI_API_KEY` while the desired CLI is installed but the active daemon is still older
- remove the redundant installed-diagnostics fixture matrix introduced by #988

## Root cause

#988 treated on-disk CLI diagnostics as active execution authority. During in-place handoff the installed package can be new while the long-running daemon remains old; emitting the new env contract at that point makes reboot bootstrap unparsable by the old active CLI.

## Verification

- focused: 53 passed
- related hermetic: 333 passed
- full hermetic: Web 1023, Shared 72, Sidecar 81, CLI 1646, Backend 2289; 0 failures
- workspace typecheck 4/4
- Biome 989 files
- targeted Ruff lint/format