### PR TITLE
fix(web): unify compute subscription recovery

### DIFF
--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -10,7 +10,6 @@ import {
 	includedBasicDeployment,
 	paidBasicDeployment,
 	performancePlan,
-	planChangeQuoteResponse,
 	sharedLegacyCloudAgent,
 	stubHostedApi,
 	terminalFallbackDeployment,
@@ -99,6 +98,11 @@ function subscription(
 		deployment_id: `hdep_${subscriptionId}`,
 		agent_name: subscriptionId,
 		is_orphan: false,
+		payment_state: "ok",
+		latest_failed_invoice_hosted_url: null,
+		next_payment_attempt_at: null,
+		recovery_action: null,
+		pending_plan_slug: null,
 		...overrides,
 	};
 }
@@ -165,9 +169,19 @@ async function expectNoHorizontalOverflow(page: Page) {
 	expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth);
 }
 
-async function expectAgentSettingsSectionsAligned(page: Page, maxWidth: number) {
+async function expectAgentSettingsSectionsAligned(
+	page: Page,
+	width: { min?: number; max?: number },
+) {
 	const main = page.locator("main");
-	const sectionNames = ["Name", "Language & timezone", "Compute plan", "Lifecycle", "Danger zone"];
+	const sectionNames = [
+		"Name",
+		"Avatar",
+		"Language & timezone",
+		"Compute plan",
+		"Lifecycle",
+		"Danger zone",
+	];
 	const boxes = await Promise.all(
 		sectionNames.map(async (name) => {
 			const section = main
@@ -189,7 +203,8 @@ async function expectAgentSettingsSectionsAligned(page: Page, maxWidth: number) 
 
 	const [reference] = boxes;
 	if (!reference) throw new Error("Expected Agent Settings section boxes");
-	expect(reference.width).toBeLessThanOrEqual(maxWidth + 1);
+	if (width.min !== undefined) expect(reference.width).toBeGreaterThanOrEqual(width.min - 1);
+	if (width.max !== undefined) expect(reference.width).toBeLessThanOrEqual(width.max + 1);
 	for (const box of boxes.slice(1)) {
 		expect(Math.abs(box.x - reference.x), "section left edge").toBeLessThanOrEqual(1);
 		expect(Math.abs(box.width - reference.width), "section width").toBeLessThanOrEqual(1);
@@ -254,26 +269,9 @@ async function expectSourceDialogGeometry(
 test("subscription cards preserve pagination and reveal loaded history", async ({ page }) => {
 	await page.setViewportSize({ width: 1440, height: 900 });
 	const errors = collectBrowserErrors(page);
-	const planQuoteRequests: string[] = [];
 	await stubHostedApi(page, {
 		deployments: [accountActiveDeployment, accountPastDueDeployment, accountCancelingDeployment],
 		cloudAgents: accountCloudAgents,
-		planQuoteRequests,
-		planQuoteResponses: [
-			planChangeQuoteResponse({
-				operationId: "op_account_past_due_to_card",
-				subscriptionId: 42,
-				fundingSource: "stripe",
-				currentPlanSlug: "compute_basic",
-				targetPlanSlug: "compute_basic",
-				currentBillingTermMonths: 1,
-				targetBillingTermMonths: 1,
-				changeKind: "funding_source_switch",
-				effectiveAt: "2026-07-16T00:00:00Z",
-				amountCents: 0,
-				amountUsd: "0.00",
-			}),
-		],
 		plans: [basicPlan, performancePlan],
 		subscriptionPages: {
 			initial: {
@@ -302,6 +300,9 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 						price_cents: 900,
 						billing_term_months: 1,
 						agent_name: "Past due agent",
+						payment_state: "past_due",
+						next_payment_attempt_at: "2099-08-10T12:00:00Z",
+						recovery_action: "top_up",
 					}),
 					subscription("canceling", "canceling", {
 						cancel_at_period_end: true,
@@ -336,7 +337,7 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(dialog.getByText("Active", { exact: true })).toBeVisible();
 	await expect(dialog.getByText("Canceling", { exact: true })).toBeVisible();
 	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(3);
-	await expect(dialog.getByRole("button", { name: "Manage", exact: true })).toHaveCount(2);
+	await expect(dialog.getByRole("button", { name: "Manage", exact: true })).toHaveCount(1);
 	await expect(dialog.getByRole("button", { name: "Resume subscription" })).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Show history (2)" })).toBeVisible();
 	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(3);
@@ -352,7 +353,9 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(activeCard.getByText("Card", { exact: true })).toBeVisible();
 	await expect(activeCard.getByText("$190.00/yr", { exact: true })).toBeVisible();
 	await expect(pastDueCard.getByText("Past due", { exact: true })).toBeVisible();
-	await expect(pastDueCard.getByText("Due Aug 12, 2099", { exact: true })).toBeVisible();
+	await expect(pastDueCard.getByText("Retries Aug 10, 2099", { exact: true })).toBeVisible();
+	await expect(pastDueCard.getByRole("button", { name: "Manage", exact: true })).toHaveCount(0);
+	await expect(pastDueCard.getByRole("button", { name: "Top up", exact: true })).toBeVisible();
 	await expect(cancelingCard.getByRole("button", { name: "Manage", exact: true })).toHaveCount(0);
 	const currentStatuses = await currentCards.evaluateAll((cards) =>
 		cards.map((card) => card.getAttribute("data-subscription-status")),
@@ -424,36 +427,11 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(5);
 	expect(page.url()).toBe(accountSettingsUrl);
 
-	await pastDueCard.getByRole("button", { name: "Manage", exact: true }).click();
-	const paymentSourceDialog = page.getByRole("dialog", { name: "Change payment source" });
-	await expect(paymentSourceDialog).toBeVisible();
-	await expect(dialog).toBeVisible();
-	expect(page.url()).toBe(accountSettingsUrl);
-	await expect(
-		paymentSourceDialog.getByRole("group", { name: "Subscription management mode" }),
-	).toHaveCount(0);
-	await expect(paymentSourceDialog.getByText("Current plan", { exact: true })).toBeVisible();
-	await expect(paymentSourceDialog.getByText("Basic", { exact: true })).toBeVisible();
-	await expect(paymentSourceDialog.getByText("Monthly", { exact: true })).toBeVisible();
-	await expect(paymentSourceDialog.getByLabel("Compute plan")).toHaveCount(0);
-	await expect(
-		paymentSourceDialog.getByRole("button", { name: "Wallet", exact: true }),
-	).toHaveAttribute("aria-pressed", "true");
-	await paymentSourceDialog.getByRole("button", { name: "Card", exact: true }).click();
-	await paymentSourceDialog.getByRole("button", { name: "Review change" }).click();
-	await expect.poll(() => planQuoteRequests.length).toBe(1);
-	expect(JSON.parse(planQuoteRequests[0] ?? "{}")).toEqual({
-		deployment_id: "hdep_past_due",
-		target_plan_slug: "compute_basic",
-		target_billing_term_months: 1,
-		funding_source: "stripe",
-	});
-	const confirmPaymentSourceDialog = page.getByRole("dialog", {
-		name: "Confirm payment source change",
-	});
-	await expect(confirmPaymentSourceDialog).toBeVisible();
-	await confirmPaymentSourceDialog.getByRole("button", { name: "Back", exact: true }).click();
-	await expect(paymentSourceDialog).toBeHidden();
+	await pastDueCard.getByRole("button", { name: "Top up", exact: true }).click();
+	const topUpDialog = page.getByRole("dialog", { name: "Top up Wallet", exact: true });
+	await expect(topUpDialog).toBeVisible();
+	await page.keyboard.press("Escape");
+	await expect(topUpDialog).toBeHidden();
 	await expect(dialog).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Hide history" })).toBeVisible();
 	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(5);
@@ -517,16 +495,18 @@ test("agent settings uses the subscription card without changing plan actions", 
 				name: "Card authentication required",
 				compute_subscription: {
 					...paidBasicDeployment.compute_subscription,
+					status: "past_due",
 					payment_state: "requires_action",
 					latest_failed_invoice_id: "in_card_action_required",
 					latest_failed_invoice_hosted_url: "https://billing.example/invoice/action-required",
+					recovery_action: "fix_payment",
 				},
 			},
 			{
 				...cardPastDueDeployment,
 				compute_subscription: {
 					...cardPastDueDeployment.compute_subscription,
-					status: "active",
+					recovery_action: "fix_payment",
 				},
 			},
 			terminalFallbackDeployment,
@@ -552,13 +532,13 @@ test("agent settings uses the subscription card without changing plan actions", 
 	await expect(agentManage.locator("svg.lucide-settings")).toHaveCount(1);
 	await expect(activeCard.getByRole("button", { name: "Cancel subscription" })).toBeVisible();
 	const activeCardWidth = await activeCard.evaluate((card) => card.getBoundingClientRect().width);
-	expect(activeCardWidth).toBeLessThanOrEqual(672);
+	expect(activeCardWidth).toBeGreaterThan(896);
 	await expectCardsFit(page.locator("body"));
-	await expectAgentSettingsSectionsAligned(page, 896);
+	await expectAgentSettingsSectionsAligned(page, { min: 896 });
 
 	await page.setViewportSize({ width: 320, height: 568 });
 	await expectCardsFit(page.locator("body"));
-	await expectAgentSettingsSectionsAligned(page, 320);
+	await expectAgentSettingsSectionsAligned(page, { max: 320 });
 	await expectNoHorizontalOverflow(page);
 	await expect(activeCard.getByRole("button", { name: "Manage", exact: true })).toBeVisible();
 	await expect(activeCard.getByRole("button", { name: "Cancel subscription" })).toBeVisible();
@@ -571,7 +551,7 @@ test("agent settings uses the subscription card without changing plan actions", 
 		"data-status",
 		"warning",
 	);
-	await expect(cancelingCard.getByRole("button", { name: "Manage", exact: true })).toBeDisabled();
+	await expect(cancelingCard.getByRole("button", { name: "Manage", exact: true })).toHaveCount(0);
 	await expect(cancelingCard.getByRole("button", { name: "Resume subscription" })).toBeVisible();
 	await expectCardsFit(page.locator("body"));
 
@@ -583,13 +563,8 @@ test("agent settings uses the subscription card without changing plan actions", 
 		"data-status",
 		"destructive",
 	);
-	await expect(pastDueCard.getByRole("button", { name: "Manage", exact: true })).toBeVisible();
-	await pastDueCard.getByRole("button", { name: "Manage", exact: true }).click();
-	const paymentSourceDialog = page.getByRole("dialog", { name: "Change payment source" });
-	await expect(paymentSourceDialog).toBeVisible();
-	await expect(paymentSourceDialog.getByLabel("Compute plan")).toHaveCount(0);
-	await expect(paymentSourceDialog.getByText("Current plan", { exact: true })).toBeVisible();
-	await paymentSourceDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+	await expect(pastDueCard.getByText("Retries Jul 16, 2026", { exact: true })).toBeVisible();
+	await expect(pastDueCard.getByRole("button", { name: "Manage", exact: true })).toHaveCount(0);
 	await expectCardsFit(page.locator("body"));
 
 	await gotoHostedAgentSettings(page, "hdep_card_action_required", "Basic");
@@ -599,9 +574,9 @@ test("agent settings uses the subscription card without changing plan actions", 
 	await expect(
 		actionRequiredCard.getByText("Payment action required", { exact: true }),
 	).toHaveAttribute("data-status", "warning");
-	await expect(
-		actionRequiredCard.getByRole("button", { name: "Manage", exact: true }),
-	).toBeVisible();
+	await expect(actionRequiredCard.getByRole("button", { name: "Manage", exact: true })).toHaveCount(
+		0,
+	);
 	await expectCardsFit(page.locator("body"));
 
 	await gotoHostedAgentSettings(page, "hdep_terminal_fallback", "Basic");

--- a/apps/web/src/components/dashboard/agent-settings-panel.tsx
+++ b/apps/web/src/components/dashboard/agent-settings-panel.tsx
@@ -250,7 +250,7 @@ export function AgentSettingsPanel({
 				title="Name"
 				description="Use a short name that distinguishes this agent from others."
 			>
-				<div className="flex max-w-2xl flex-col gap-3">
+				<div className="flex w-full flex-col gap-3">
 					<div className="flex flex-col gap-2 lg:flex-row">
 						<Label htmlFor="agent-display-name" className="sr-only">
 							Agent name

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -166,6 +166,7 @@ import {
 	ComputeSubscriptionCard,
 	computeSubscriptionCardView,
 } from "@/hosted/billing/subscription/compute-subscription-card";
+import { computeSubscriptionRecoveryPresentation } from "@/hosted/billing/subscription/compute-subscription-recovery";
 import {
 	activePlanChangeOperationName,
 	performanceUpgradeUnavailableReason,
@@ -3407,7 +3408,7 @@ function HostedAgentSettingsTab({
 }) {
 	return (
 		<UnsavedNavigationBoundary description="Your agent settings will return to the last values saved on the server.">
-			<div className="mx-auto flex w-full max-w-4xl flex-col gap-8">
+			<div className="flex w-full flex-col gap-8">
 				{agent ? (
 					<AgentSettingsPanel environmentId={environmentId} />
 				) : (
@@ -3458,7 +3459,7 @@ function LanguageTimezoneSettingsSection({ deployment }: { deployment: HostedDep
 			title="Language & timezone"
 			description="Language and time zone used by this agent."
 		>
-			<div className="flex max-w-2xl flex-col gap-4">
+			<div className="flex w-full flex-col gap-4">
 				<LiveNote>Changes apply to this agent.</LiveNote>
 				<div className="grid gap-4 sm:grid-cols-2">
 					<div className="flex flex-col gap-1.5">
@@ -3635,42 +3636,28 @@ function ComputeSettingsSections({
 		? computeSubscriptionLifecycle(currentSubscription)
 		: null;
 	const currentSubscriptionStatus = currentSubscription?.status.toLowerCase();
-	const computePlanStatusTone: StatusTone =
-		currentSubscriptionStatus === "past_due" ||
-		currentSubscriptionStatus === "unpaid" ||
-		currentSubscription?.payment_state === "past_due" ||
-		currentSubscription?.payment_state === "unpaid"
-			? "destructive"
-			: currentSubscriptionStatus === "canceling" ||
-					currentSubscription?.payment_state === "requires_action" ||
-					subscriptionCancelPending ||
-					pendingPlanSlug
+	const lifecycleStatus: { label: string; tone: StatusTone } = {
+		label:
+			fundingMode === "unknown"
+				? "Unavailable"
+				: !isPaidCompute || !subscriptionLifecycle
+					? "Current"
+					: currentSubscriptionStatus === "canceling" || subscriptionCancelPending
+						? "Canceling"
+						: subscriptionLifecycle.badgeLabel,
+		tone:
+			currentSubscriptionStatus === "canceling" || subscriptionCancelPending || pendingPlanSlug
 				? "warning"
 				: isIncludedBasic ||
 						currentSubscriptionStatus === "active" ||
 						currentSubscriptionStatus === "trialing"
 					? "success"
-					: "neutral";
-	const computePlanStatusLabel =
-		fundingMode === "unknown"
-			? "Unavailable"
-			: !isPaidCompute || !subscriptionLifecycle
-				? "Current"
-				: currentSubscriptionStatus === "past_due" ||
-						currentSubscription?.payment_state === "past_due"
-					? "Past due"
-					: currentSubscriptionStatus === "unpaid" ||
-							currentSubscription?.payment_state === "unpaid"
-						? "Unpaid"
-						: currentSubscription?.payment_state === "requires_action"
-							? "Payment action required"
-							: currentSubscriptionStatus === "canceling" || subscriptionCancelPending
-								? "Canceling"
-								: subscriptionLifecycle.badgeLabel;
-	const computePlanStatus = {
-		label: computePlanStatusLabel,
-		tone: computePlanStatusTone,
+					: "neutral",
 	};
+	const computeRecovery = computeSubscriptionRecoveryPresentation(
+		currentSubscription,
+		lifecycleStatus,
+	);
 	const computeCardView = computeSubscriptionCardView({
 		identity: {
 			kind: "agent",
@@ -3683,7 +3670,7 @@ function ComputeSettingsSections({
 			agentType: deployment.resource.spec.runtime,
 			avatarUrl: agent?.avatar_url,
 		},
-		status: computePlanStatus,
+		status: computeRecovery.status,
 		planSlug: computePlanSlug ?? rawComputePlanSlug,
 		fundingSource: isIncludedBasic
 			? "included"
@@ -3695,8 +3682,9 @@ function ComputeSettingsSections({
 		priceCents: currentPriceCents,
 		currency: currentSubscription?.currency ?? "usd",
 		billingTermMonths: currentBillingTerm,
-		scheduleVerb: subscriptionLifecycle?.dateVerb ?? null,
-		scheduleAt: subscriptionLifecycle?.dateAt,
+		scheduleVerb: computeRecovery.schedule?.verb ?? subscriptionLifecycle?.dateVerb ?? null,
+		scheduleAt: computeRecovery.schedule?.at ?? subscriptionLifecycle?.dateAt,
+		scheduleFallback: computeRecovery.schedule?.fallback ?? undefined,
 	});
 	const pendingPlanCopy = pendingPlanSlug
 		? pendingPlanScheduleCopy(
@@ -3835,7 +3823,7 @@ function ComputeSettingsSections({
 				<ComputeSubscriptionCard
 					headingLevel={3}
 					view={computeCardView}
-					className="max-w-2xl"
+					className="w-full"
 					badges={
 						hasWalletFallback ? (
 							<Badge variant="outline" className="font-normal text-muted-foreground">
@@ -3906,52 +3894,46 @@ function ComputeSettingsSections({
 									</>
 								) : isPaidCompute && currentSubscription ? (
 									subscriptionCancelPending ? (
-										<>
-											<Button
-												type="button"
-												variant="outline"
-												size="sm"
-												disabled
-												title={planChangeUnavailable ?? undefined}
-											>
-												<Settings data-icon="inline-start" />
-												Manage
-											</Button>
-											<Button
-												type="button"
-												variant="outline"
-												size="sm"
-												disabled={resumeSubscription.isPending || !subscriptionCancelable}
-												onClick={() =>
-													void runAction(resumeComputeSubscription).catch(() => undefined)
-												}
-											>
-												{resumeSubscription.isPending ? (
-													<Spinner data-icon="inline-start" />
-												) : (
-													<RefreshCw data-icon="inline-start" />
-												)}
-												Resume subscription
-											</Button>
-											<p className="basis-full text-right text-xs text-muted-foreground">
-												{planChangeUnavailable}
-											</p>
-										</>
+										<Button
+											type="button"
+											variant="outline"
+											size="sm"
+											disabled={resumeSubscription.isPending || !subscriptionCancelable}
+											onClick={() =>
+												void runAction(resumeComputeSubscription).catch(() => undefined)
+											}
+										>
+											{resumeSubscription.isPending ? (
+												<Spinner data-icon="inline-start" />
+											) : (
+												<RefreshCw data-icon="inline-start" />
+											)}
+											Resume subscription
+										</Button>
 									) : (
 										<>
-											<Button
-												type="button"
-												variant="outline"
-												size="sm"
-												disabled={
-													!hasPendingPlanChange &&
-													(planChangeUnavailable !== null || !!pendingPlanSlug)
-												}
-												onClick={() => setPlanChangeOpen(true)}
-											>
-												<Settings data-icon="inline-start" />
-												Manage
-											</Button>
+											{hasPendingPlanChange ? (
+												<Button
+													type="button"
+													variant="outline"
+													size="sm"
+													onClick={() => setPlanChangeOpen(true)}
+												>
+													<RefreshCw data-icon="inline-start" />
+													Check change status
+												</Button>
+											) : computeRecovery.hasPaymentIssue || pendingPlanSlug ? null : (
+												<Button
+													type="button"
+													variant="outline"
+													size="sm"
+													disabled={planChangeUnavailable !== null}
+													onClick={() => setPlanChangeOpen(true)}
+												>
+													<Settings data-icon="inline-start" />
+													Manage
+												</Button>
+											)}
 											<ConfirmAction
 												title={`Cancel ${tierLabel} subscription?`}
 												description={

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
@@ -50,6 +50,7 @@ export function computeSubscriptionCardView({
 	billingTermMonths,
 	scheduleVerb,
 	scheduleAt,
+	scheduleFallback,
 }: {
 	identity: ComputeSubscriptionIdentity;
 	status: ComputeSubscriptionCardView["status"];
@@ -60,6 +61,7 @@ export function computeSubscriptionCardView({
 	billingTermMonths: number;
 	scheduleVerb: string | null;
 	scheduleAt: string | null | undefined;
+	scheduleFallback?: string;
 }): ComputeSubscriptionCardView {
 	const included = fundingSource === "included";
 	return {
@@ -92,9 +94,11 @@ export function computeSubscriptionCardView({
 				value:
 					scheduleVerb && scheduleAt
 						? `${scheduleVerb} ${formatShortDate(scheduleAt)}`
-						: included
-							? "Current"
-							: "Unavailable",
+						: scheduleFallback
+							? scheduleFallback
+							: included
+								? "Current"
+								: "Unavailable",
 			},
 		],
 	};

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { computeSubscriptionRecoveryPresentation } from "./compute-subscription-recovery";
+
+const active = { label: "Active", tone: "success" } as const;
+
+describe("computeSubscriptionRecoveryPresentation", () => {
+	test("prioritizes authoritative payment state over coarse lifecycle status", () => {
+		expect(
+			computeSubscriptionRecoveryPresentation(
+				{
+					payment_state: "requires_action",
+					recovery_action: "fix_payment",
+					latest_failed_invoice_hosted_url: "https://billing.example/invoice/open",
+					next_payment_attempt_at: null,
+				},
+				{ label: "Past due", tone: "destructive" },
+			),
+		).toEqual({
+			status: { label: "Payment action required", tone: "warning" },
+			hasPaymentIssue: true,
+			recoveryTarget: {
+				kind: "invoice",
+				action: "fix_payment",
+				url: "https://billing.example/invoice/open",
+			},
+			schedule: { verb: null, at: null, fallback: "Payment needs attention" },
+		});
+	});
+
+	test("projects wallet, card, terminal, and healthy actions", () => {
+		expect(
+			computeSubscriptionRecoveryPresentation(
+				{
+					payment_state: "past_due",
+					recovery_action: "top_up",
+					latest_failed_invoice_hosted_url: null,
+					next_payment_attempt_at: "2026-08-20T00:00:00Z",
+				},
+				active,
+			),
+		).toMatchObject({
+			recoveryTarget: { kind: "top_up", action: "top_up" },
+			schedule: { verb: "Retries", at: "2026-08-20T00:00:00Z", fallback: null },
+		});
+		expect(
+			computeSubscriptionRecoveryPresentation(
+				{
+					payment_state: "past_due",
+					recovery_action: "fix_payment",
+					latest_failed_invoice_hosted_url: null,
+					next_payment_attempt_at: null,
+				},
+				active,
+			).recoveryTarget,
+		).toEqual({ kind: "fix_payment", action: "fix_payment" });
+		expect(
+			computeSubscriptionRecoveryPresentation(
+				{
+					payment_state: "unpaid",
+					recovery_action: "start_new",
+					latest_failed_invoice_hosted_url: null,
+					next_payment_attempt_at: null,
+				},
+				active,
+			),
+		).toEqual({
+			status: { label: "Unpaid", tone: "destructive" },
+			hasPaymentIssue: true,
+			recoveryTarget: { kind: "start_new", action: "start_new" },
+			schedule: null,
+		});
+		expect(
+			computeSubscriptionRecoveryPresentation(
+				{
+					payment_state: "ok",
+					recovery_action: null,
+					latest_failed_invoice_hosted_url: null,
+					next_payment_attempt_at: null,
+				},
+				active,
+			),
+		).toEqual({
+			status: active,
+			hasPaymentIssue: false,
+			recoveryTarget: null,
+			schedule: null,
+		});
+	});
+});

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.ts
@@ -1,0 +1,96 @@
+import type { StatusTone } from "@/components/ui/status-badge";
+import type {
+	ComputeSubscriptionListItem,
+	HostedComputeSubscription,
+} from "@/hosted/billing/contracts";
+
+type RecoveryFields =
+	| Pick<
+			ComputeSubscriptionListItem,
+			| "latest_failed_invoice_hosted_url"
+			| "next_payment_attempt_at"
+			| "payment_state"
+			| "recovery_action"
+	  >
+	| Pick<
+			HostedComputeSubscription,
+			| "latest_failed_invoice_hosted_url"
+			| "next_payment_attempt_at"
+			| "payment_state"
+			| "recovery_action"
+	  >;
+
+export type ComputeRecoveryTarget =
+	| { kind: "invoice"; action: "fix_payment"; url: string }
+	| { kind: "fix_payment"; action: "fix_payment" }
+	| { kind: "top_up"; action: "top_up" }
+	| { kind: "start_new"; action: "start_new" };
+
+export type ComputeSubscriptionRecoveryPresentation = {
+	status: { label: string; tone: StatusTone };
+	hasPaymentIssue: boolean;
+	recoveryTarget: ComputeRecoveryTarget | null;
+	schedule:
+		| { verb: "Retries"; at: string; fallback: null }
+		| { verb: null; at: null; fallback: "Payment needs attention" }
+		| null;
+};
+
+function recoveryTarget(subscription: RecoveryFields): ComputeRecoveryTarget | null {
+	const action = subscription.recovery_action;
+	if (action === "top_up") return { kind: "top_up", action };
+	if (action === "start_new") return { kind: "start_new", action };
+	if (action === "fix_payment") {
+		const invoiceUrl = subscription.latest_failed_invoice_hosted_url?.trim();
+		return invoiceUrl
+			? { kind: "invoice", action, url: invoiceUrl }
+			: { kind: "fix_payment", action };
+	}
+	return null;
+}
+
+export function computeSubscriptionRecoveryPresentation(
+	subscription: RecoveryFields | null | undefined,
+	lifecycleStatus: ComputeSubscriptionRecoveryPresentation["status"],
+): ComputeSubscriptionRecoveryPresentation {
+	if (!subscription) {
+		return {
+			status: lifecycleStatus,
+			hasPaymentIssue: false,
+			recoveryTarget: null,
+			schedule: null,
+		};
+	}
+
+	const paymentStatus = (() => {
+		switch (subscription.payment_state) {
+			case "unpaid":
+				return { label: "Unpaid", tone: "destructive" } as const;
+			case "requires_action":
+				return { label: "Payment action required", tone: "warning" } as const;
+			case "past_due":
+				return { label: "Past due", tone: "destructive" } as const;
+			case "ok":
+				return null;
+			default:
+				return null;
+		}
+	})();
+	const target = recoveryTarget(subscription);
+
+	return {
+		status: paymentStatus ?? lifecycleStatus,
+		hasPaymentIssue: paymentStatus !== null || target !== null,
+		recoveryTarget: target,
+		schedule:
+			subscription.payment_state === "past_due" || subscription.payment_state === "requires_action"
+				? subscription.next_payment_attempt_at
+					? {
+							verb: "Retries",
+							at: subscription.next_payment_attempt_at,
+							fallback: null,
+						}
+					: { verb: null, at: null, fallback: "Payment needs attention" }
+				: null,
+	};
+}

--- a/apps/web/src/hosted/billing/subscription/plan-change-controller.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-change-controller.tsx
@@ -24,6 +24,7 @@ import {
 	type PlanChangeSelection,
 	planChangeUnavailableReason,
 	shouldRecoverWalletToCardSwitch,
+	shouldResetUnacceptedPlanChangeQuote,
 	visiblePlanChangeOperationName,
 } from "@/hosted/billing/subscription/plan-change.logic";
 import { PlanChangeDialog } from "@/hosted/billing/subscription/plan-change-dialog";
@@ -310,6 +311,14 @@ function PlanChangeControllerState({
 				setPaymentMethodRequired(true);
 				return;
 			}
+		}
+		if (shouldResetUnacceptedPlanChangeQuote(error)) {
+			setQuote(null);
+			setPaymentMethodRequired(false);
+			toast.error("Subscription quote is no longer current", {
+				description: "Review the latest choices and request a fresh quote.",
+			});
+			return;
 		}
 		if (walletTopUp.handleFundingError(error)) return;
 		toast.error("Couldn’t update subscription", {

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts
@@ -18,11 +18,21 @@ import {
 	selectPlanChangeFundingSource,
 	selectPlanChangeOffer,
 	shouldRecoverWalletToCardSwitch,
+	shouldResetUnacceptedPlanChangeQuote,
 	visiblePlanChangeOperationName,
 	walletBalanceAfterDebit,
 } from "./plan-change.logic";
 
 describe("plan change recovery", () => {
+	test("resets only direct quote conflicts before an operation is accepted", () => {
+		expect(shouldResetUnacceptedPlanChangeQuote(new BillingApiError(409, "quote expired"))).toBe(
+			true,
+		);
+		expect(shouldResetUnacceptedPlanChangeQuote(new BillingApiError(422, "invalid"))).toBe(false);
+		expect(
+			shouldResetUnacceptedPlanChangeQuote(new BillingApiError(409, "operation conflict")),
+		).toBe(false);
+	});
 	type AcceptedOperation = NonNullable<HostedDeployment["accepted_operation"]>;
 	const acceptedPlanChange: AcceptedOperation = {
 		name: "operations/plan-change-pending",

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
@@ -4,7 +4,11 @@ import type {
 	ComputePlanSlug,
 	HostedDeployment,
 } from "@/hosted/billing/contracts";
-import { isPaymentMethodRequiredError } from "@/hosted/billing/errors";
+import {
+	BillingApiError,
+	isPaymentMethodRequiredError,
+	PlanChangeTerminalError,
+} from "@/hosted/billing/errors";
 import { COMPUTE_BASIC_SLUG, COMPUTE_PERFORMANCE_SLUG } from "./subscription-utils";
 
 export type PlanChangeSelection = Omit<
@@ -66,6 +70,15 @@ export function visiblePlanChangeOperationName(
 	return projectedOperationName !== null && ignoredOperationNames.includes(projectedOperationName)
 		? null
 		: projectedOperationName;
+}
+
+export function shouldResetUnacceptedPlanChangeQuote(error: unknown): boolean {
+	return (
+		error instanceof BillingApiError &&
+		error.status === 409 &&
+		!(error instanceof PlanChangeTerminalError) &&
+		/quote.*expired|expired.*quote/i.test(error.detail)
+	);
 }
 
 function isHostedComputeUpgradeIneligibilityReason(

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
@@ -33,6 +33,11 @@ function subscription(
 		deployment_id: `hdep_${subscriptionId}`,
 		agent_name: subscriptionId,
 		is_orphan: false,
+		payment_state: "ok",
+		latest_failed_invoice_hosted_url: null,
+		next_payment_attempt_at: null,
+		recovery_action: null,
+		pending_plan_slug: null,
 	};
 }
 
@@ -71,9 +76,13 @@ describe("SubscriptionsSection", () => {
 		const active = subscription("active", "active");
 
 		expect(canManageAccountSubscription(active)).toBe(true);
-		expect(canManageAccountSubscription(subscription("past-due", "past_due"))).toBe(true);
+		expect(canManageAccountSubscription(subscription("past-due", "past_due"))).toBe(false);
 		expect(canManageAccountSubscription(subscription("canceling", "canceling"))).toBe(false);
 		expect(canManageAccountSubscription(subscription("canceled", "canceled"))).toBe(false);
+		expect(canManageAccountSubscription({ ...active, recovery_action: "fix_payment" })).toBe(false);
+		expect(
+			canManageAccountSubscription({ ...active, pending_plan_slug: "compute_performance" }),
+		).toBe(false);
 		expect(canManageAccountSubscription({ ...active, is_orphan: true })).toBe(false);
 		expect(canManageAccountSubscription({ ...active, deployment_id: null })).toBe(false);
 		expect(canManageAccountSubscription({ ...active, cancel_at_period_end: true })).toBe(false);

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { CreditCard, History, Link2Off, RefreshCw, Settings } from "lucide-react";
+import {
+	CreditCard,
+	ExternalLink,
+	History,
+	Link2Off,
+	RefreshCw,
+	Settings,
+	WalletCards,
+} from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -13,7 +21,6 @@ import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
-import type { StatusTone } from "@/components/ui/status-badge";
 import type { ComputePlanSlug, ComputeSubscriptionListItem } from "@/hosted/billing/contracts";
 import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
 import {
@@ -23,11 +30,16 @@ import {
 	useResumeSubscription,
 	useSubscriptions,
 } from "@/hosted/billing/hooks";
+import { useSensitiveFixPayment } from "@/hosted/billing/sensitive-actions";
 import {
 	ComputeSubscriptionCard,
 	computeSubscriptionCardView,
 	computeSubscriptionPlanLabel,
 } from "@/hosted/billing/subscription/compute-subscription-card";
+import {
+	type ComputeRecoveryTarget,
+	computeSubscriptionRecoveryPresentation,
+} from "@/hosted/billing/subscription/compute-subscription-recovery";
 import { activePlanChangeOperationName } from "@/hosted/billing/subscription/plan-change.logic";
 import {
 	PlanChangeController,
@@ -37,26 +49,25 @@ import {
 	canCancelAccountSubscription,
 	canResumeAccountSubscription,
 	isEndedAccountSubscription,
+	pendingPlanScheduleCopy,
 } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
+import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
+import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { formatShortDate } from "@/lib/format";
 import { shouldBlockQueryError } from "@/lib/query-state";
 
-const STATUS_PRESENTATION: Record<
-	ComputeSubscriptionListItem["status"],
-	{ label: string; tone: StatusTone }
-> = {
+const STATUS_PRESENTATION = {
 	active: { label: "Active", tone: "success" },
 	canceling: { label: "Canceling", tone: "warning" },
 	past_due: { label: "Past due", tone: "destructive" },
 	canceled: { label: "Canceled", tone: "neutral" },
-};
+} as const;
 
 function subscriptionScheduleVerb(status: ComputeSubscriptionListItem["status"]): string {
 	if (status === "canceling") return "Ends";
 	if (status === "canceled") return "Ended";
-	if (status === "past_due") return "Due";
 	return "Renews";
 }
 
@@ -155,6 +166,79 @@ function SubscriptionActions({
 	);
 }
 
+function SubscriptionRecoveryAction({
+	target,
+	deploymentId,
+	agentHref,
+}: {
+	target: ComputeRecoveryTarget;
+	deploymentId: string | null;
+	agentHref: string | null;
+}) {
+	const fixPayment = useSensitiveFixPayment();
+	const runAction = useActionLock();
+	const wallet = useWalletSnapshot({ enabled: target.kind === "top_up" });
+	const [topUpOpen, setTopUpOpen] = useState(false);
+
+	async function openPaymentRecovery() {
+		if (target.kind === "invoice") {
+			window.location.href = target.url;
+			return;
+		}
+		if (target.kind !== "fix_payment") return;
+		try {
+			const result = await fixPayment.execute({ deployment_id: deploymentId });
+			const url = result.url || result.portal_url;
+			if (url) {
+				window.location.href = url;
+				return;
+			}
+			toast.message("Payment update unavailable", {
+				description: "Refresh this page and try again in a moment.",
+			});
+		} catch (error) {
+			toast.error("Couldn't open payment settings", {
+				description: normalizeBillingError(error),
+			});
+		}
+	}
+
+	if (target.kind === "top_up") {
+		return (
+			<>
+				<Button type="button" size="sm" onClick={() => setTopUpOpen(true)} disabled={!wallet.data}>
+					<WalletCards data-icon="inline-start" />
+					Top up
+				</Button>
+				{wallet.data ? <TopUpDialog open={topUpOpen} onOpenChange={setTopUpOpen} /> : null}
+			</>
+		);
+	}
+	if (target.kind === "start_new") {
+		return agentHref ? (
+			<Button render={<a href={agentHref} />} nativeButton={false} type="button" size="sm">
+				<Settings data-icon="inline-start" />
+				Open Agent settings
+			</Button>
+		) : null;
+	}
+	return (
+		<Button
+			type="button"
+			size="sm"
+			onClick={() => void runAction(openPaymentRecovery)}
+			disabled={fixPayment.isPending}
+		>
+			{target.kind === "invoice" ? (
+				<ExternalLink data-icon="inline-start" />
+			) : (
+				<CreditCard data-icon="inline-start" />
+			)}
+			Fix payment
+		</Button>
+	);
+}
+
 function subscriptionAgentHref(subscription: ComputeSubscriptionListItem): string | null {
 	if (subscription.is_orphan || !subscription.deployment_id || !subscription.agent_name)
 		return null;
@@ -173,7 +257,10 @@ export function canManageAccountSubscription(subscription: ComputeSubscriptionLi
 		!subscription.is_orphan &&
 		Boolean(subscription.deployment_id?.trim()) &&
 		!subscription.cancel_at_period_end &&
-		(subscription.status === "active" || subscription.status === "past_due") &&
+		subscription.status === "active" &&
+		subscription.payment_state === "ok" &&
+		subscription.recovery_action === null &&
+		subscription.pending_plan_slug === null &&
 		computePlanSlug(subscription.plan_slug) !== null &&
 		(subscription.funding_source === "stripe" || subscription.funding_source === "wallet")
 	);
@@ -201,7 +288,7 @@ function accountPlanChangeTarget(
 		currentBillingTermMonths: subscription.billing_term_months,
 		currentFundingSource: fundingSource,
 		status: subscription.status,
-		paymentSourceOnly: subscription.status === "past_due",
+		paymentSourceOnly: false,
 		cancelAtPeriodEnd: subscription.cancel_at_period_end,
 		isPaidCompute: true,
 		allowCombinedChange: false,
@@ -234,11 +321,41 @@ function SubscriptionRow({
 	agentTile?: AgentTile;
 	onManage: (subscription: ComputeSubscriptionListItem) => void;
 }) {
-	const status = STATUS_PRESENTATION[subscription.status];
+	const recovery = computeSubscriptionRecoveryPresentation(
+		subscription,
+		STATUS_PRESENTATION[subscription.status],
+	);
 	const agentHref = subscriptionAgentHref(subscription);
 	const canManage = canManageAccountSubscription(subscription);
+	const pendingPlanSlug = computePlanSlug(subscription.pending_plan_slug ?? "");
+	const pendingPlanCopy = pendingPlanSlug
+		? pendingPlanScheduleCopy(
+				pendingPlanSlug,
+				subscription.current_period_end,
+				formatShortDate(subscription.current_period_end),
+			)
+		: null;
+	const recoveryActionAvailable =
+		recovery.recoveryTarget !== null &&
+		(recovery.recoveryTarget.kind !== "start_new" || agentHref !== null);
+	const recoveryNotice = (() => {
+		switch (recovery.recoveryTarget?.kind) {
+			case "top_up":
+				return "Top up Wallet before managing this subscription.";
+			case "invoice":
+			case "fix_payment":
+				return "Resolve the open invoice before managing this subscription.";
+			case "start_new":
+				return agentHref
+					? "This subscription ended. Start a new subscription from Agent settings."
+					: "This subscription ended.";
+			case undefined:
+				return null;
+		}
+	})();
 	const hasActions =
 		canManage ||
+		recoveryActionAvailable ||
 		canCancelAccountSubscription(subscription) ||
 		canResumeAccountSubscription(subscription);
 	const view = computeSubscriptionCardView({
@@ -251,14 +368,15 @@ function SubscriptionRow({
 					href: agentHref,
 				}
 			: { kind: "unavailable", label: "Deleted agent" },
-		status,
+		status: recovery.status,
 		planSlug: subscription.plan_slug,
 		fundingSource: subscription.funding_source === null ? "included" : subscription.funding_source,
 		priceCents: subscription.price_cents,
 		currency: subscription.currency,
 		billingTermMonths: subscription.billing_term_months,
-		scheduleVerb: subscriptionScheduleVerb(subscription.status),
-		scheduleAt: subscription.current_period_end,
+		scheduleVerb: recovery.schedule?.verb ?? subscriptionScheduleVerb(subscription.status),
+		scheduleAt: recovery.schedule?.at ?? subscription.current_period_end,
+		scheduleFallback: recovery.schedule?.fallback ?? undefined,
 	});
 
 	return (
@@ -267,13 +385,32 @@ function SubscriptionRow({
 				headingLevel={4}
 				view={view}
 				badges={subscription.is_orphan ? <Badge variant="outline">Orphaned</Badge> : null}
+				notice={
+					recoveryNotice || pendingPlanCopy ? (
+						<div className="flex flex-col gap-1.5 text-xs text-muted-foreground">
+							{recoveryNotice ? <p>{recoveryNotice}</p> : null}
+							{pendingPlanCopy ? (
+								<p className="font-medium text-warning-muted-foreground">{pendingPlanCopy}</p>
+							) : null}
+						</div>
+					) : null
+				}
 				actions={
 					hasActions ? (
-						<SubscriptionActions
-							subscription={subscription}
-							canManage={canManage}
-							onManage={() => onManage(subscription)}
-						/>
+						<>
+							{recoveryActionAvailable && recovery.recoveryTarget ? (
+								<SubscriptionRecoveryAction
+									target={recovery.recoveryTarget}
+									deploymentId={subscription.deployment_id ?? null}
+									agentHref={agentHref}
+								/>
+							) : null}
+							<SubscriptionActions
+								subscription={subscription}
+								canManage={canManage}
+								onManage={() => onManage(subscription)}
+							/>
+						</>
 					) : null
 				}
 			/>

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts
@@ -29,6 +29,7 @@ function queryClientWithWalletData(): QueryClient {
 		term_price_cents: 1_500,
 	});
 	qc.setQueryData(billingKeys.deployments, []);
+	qc.setQueryData(billingKeys.subscriptions, { pages: [], pageParams: [] });
 	qc.setQueryData(["get", "/v1/agents"], []);
 	return qc;
 }
@@ -74,6 +75,7 @@ describe("handleTopupStartResult", () => {
 				?.isInvalidated,
 		).toBe(true);
 		expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(true);
+		expect(qc.getQueryState(billingKeys.subscriptions)?.isInvalidated).toBe(true);
 		expect(qc.getQueryState(["get", "/v1/agents"])?.isInvalidated).toBe(true);
 		expect(setup.resetAttempt).toHaveBeenCalledTimes(1);
 		expect(setup.closeDialog).toHaveBeenCalledTimes(1);
@@ -121,6 +123,7 @@ describe("handleTopupStartResult", () => {
 				?.isInvalidated,
 		).toBe(false);
 		expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(false);
+		expect(qc.getQueryState(billingKeys.subscriptions)?.isInvalidated).toBe(false);
 		expect(setup.closeDialog).not.toHaveBeenCalled();
 		expect(setup.resetAttempt).not.toHaveBeenCalled();
 		expect(setup.toastInfo).not.toHaveBeenCalled();

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
@@ -55,6 +55,7 @@ export function invalidateWalletData(queryClient: QueryClient): void {
 	queryClient.invalidateQueries({ queryKey: billingKeys.transactions });
 	queryClient.invalidateQueries({ queryKey: billingKeys.subscriptionCreateQuotes });
 	queryClient.invalidateQueries({ queryKey: billingKeys.deployments });
+	queryClient.invalidateQueries({ queryKey: billingKeys.subscriptions });
 	queryClient.invalidateQueries({ queryKey: ["get", "/v1/agents"] });
 }
 

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1456,6 +1456,19 @@ export interface components {
             agent_name: string | null;
             /** Is Orphan */
             is_orphan: boolean;
+            /**
+             * Payment State
+             * @enum {string}
+             */
+            payment_state: "ok" | "past_due" | "requires_action" | "unpaid";
+            /** Latest Failed Invoice Hosted Url */
+            latest_failed_invoice_hosted_url: string | null;
+            /** Next Payment Attempt At */
+            next_payment_attempt_at: string | null;
+            /** Recovery Action */
+            recovery_action: ("top_up" | "fix_payment" | "start_new") | null;
+            /** Pending Plan Slug */
+            pending_plan_slug: string | null;
         };
         /** V2ComputeSubscriptionListResponse */
         V2ComputeSubscriptionListResponse: {


### PR DESCRIPTION
## Summary

- remove the Agent Settings inner max-width and align every settings section to the page content track
- share compute payment-state presentation between Account Settings and Agent Settings
- replace invalid Manage actions with the matching invoice, card, Wallet, resume, or new-subscription recovery path
- refresh subscription inventory after Wallet top-ups and recover expired plan-change quotes in place

## Validation

- Docker clean-runner Web suite (typecheck, full Web tests, OSS production build)
- Hosted Playwright: account subscription recovery, Agent Settings desktop/320px layout, reusable subscription selection
- focused billing tests: 33 passed
- Biome and git diff check
- generated deploy client is byte-identical after regeneration from Hosted commit 8f547a85a0153615a499ec7ccec2d5cbfa579770

## Dependency

Requires Clawdi-AI/clawdi-hosted#1716 to be deployed before this Web change. Keep this PR open until that rollout is complete.