### PR TITLE
fix(runtime): hand off daemon to active CLI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.69",
+      "version": "0.13.70",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.69",
+	"version": "0.13.70",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -296,6 +296,7 @@ export function commitRuntimeAppliedState(input: {
 	convergence: ReturnType<typeof convergeRuntimeManifest>;
 	applyIdentity: RuntimeApplyIdentity | null;
 	daemonAuthTokenRevision?: string;
+	daemonProgramRevision?: string;
 	egressSidecarSecretRevision?: string;
 }): void {
 	if (
@@ -331,6 +332,9 @@ export function commitRuntimeAppliedState(input: {
 			contentIdentity: runtimeAppliedContentIdentity(input.load),
 			...(input.daemonAuthTokenRevision
 				? { daemonAuthTokenRevision: input.daemonAuthTokenRevision }
+				: {}),
+			...(input.daemonProgramRevision
+				? { daemonProgramRevision: input.daemonProgramRevision }
 				: {}),
 			...(input.egressSidecarSecretRevision
 				? { egressSidecarSecretRevision: input.egressSidecarSecretRevision }
@@ -1424,6 +1428,7 @@ async function runtimeInitLocked(
 						convergence,
 						applyIdentity,
 						daemonAuthTokenRevision: authority.daemonAuthTokenRevision,
+						daemonProgramRevision: authority.daemonProgramRevision,
 						egressSidecarSecretRevision: authority.egressSidecarSecretRevision,
 					}),
 				manifestIdentity: {
@@ -1720,6 +1725,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 					convergence,
 					applyIdentity,
 					daemonAuthTokenRevision: authority.daemonAuthTokenRevision,
+					daemonProgramRevision: authority.daemonProgramRevision,
 					egressSidecarSecretRevision: authority.egressSidecarSecretRevision,
 				}),
 			continueOnCliUpdateError: true,

--- a/packages/cli/src/runtime/applied-state.test.ts
+++ b/packages/cli/src/runtime/applied-state.test.ts
@@ -92,6 +92,18 @@ describe("runtime applied state", () => {
 				daemonAuthTokenRevision: "not-a-private-revision",
 			}).success,
 		).toBe(false);
+		expect(
+			runtimeAppliedStateSchema.safeParse({
+				...state,
+				daemonProgramRevision: "d".repeat(32),
+			}).success,
+		).toBe(true);
+		expect(
+			runtimeAppliedStateSchema.safeParse({
+				...state,
+				daemonProgramRevision: "not-a-private-revision",
+			}).success,
+		).toBe(false);
 	});
 
 	test("reads old state through the named fallback and preserves explicit apply generation", () => {

--- a/packages/cli/src/runtime/applied-state.ts
+++ b/packages/cli/src/runtime/applied-state.ts
@@ -50,6 +50,10 @@ export const runtimeAppliedStateSchema = z
 			.string()
 			.regex(/^[a-f0-9]{64}$/)
 			.optional(),
+		daemonProgramRevision: z
+			.string()
+			.regex(/^[a-f0-9]{32}$/)
+			.optional(),
 		providerIds: providerIdsSchema,
 		projectedProviderIds: projectedProviderIdsSchema,
 	})

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -39,6 +39,7 @@ import {
 	cacheRuntimeLastGoodManifest,
 	convergeRuntimeManifest as convergeRuntimeManifestWithContract,
 	type RuntimeManifest,
+	type RuntimePrivateAppliedAuthority,
 	runtimeInstallerMutationTargets,
 	runtimeRecoverableSecretValues,
 	runtimeUserMutationTargets,
@@ -362,7 +363,7 @@ function commitTestRuntimeAuthority(
 	load: RuntimeManifestLoad,
 	paths: RuntimePaths,
 	convergence: ReturnType<typeof convergeRuntimeManifest>,
-	authority: { egressSidecarSecretRevision?: string },
+	authority: RuntimePrivateAppliedAuthority,
 ): void {
 	commitRuntimeAppliedState({
 		load,
@@ -371,6 +372,8 @@ function commitTestRuntimeAuthority(
 		sourceRevision: runtimeContentSha256({ generation: load.manifest.generation }),
 		convergence,
 		applyIdentity: null,
+		daemonAuthTokenRevision: authority.daemonAuthTokenRevision,
+		daemonProgramRevision: authority.daemonProgramRevision,
 		egressSidecarSecretRevision: authority.egressSidecarSecretRevision,
 	});
 }

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -191,7 +191,11 @@ import {
 	runtimeServiceNameSchema,
 	writeRuntimeRunConfig,
 } from "./run-config";
-import { runtimeImpactRevision, runtimeProgramRevision } from "./runtime-impact-revision";
+import {
+	daemonProgramRevision,
+	runtimeImpactRevision,
+	runtimeProgramRevision,
+} from "./runtime-impact-revision";
 import {
 	buildRuntimeSystemdUserProgram,
 	installOfficialRuntimeService,
@@ -307,9 +311,10 @@ interface RuntimeSystemdApplyHooks {
 }
 
 export interface RuntimePrivateAppliedAuthority {
-	// These are secret-dependent verifiers and may only be persisted in the
-	// root-owned 0600 applied-state authority.
+	// These private activation verifiers may only be persisted in the root-owned
+	// 0600 applied-state authority.
 	daemonAuthTokenRevision?: string;
+	daemonProgramRevision?: string;
 	egressSidecarSecretRevision?: string;
 }
 
@@ -5875,6 +5880,7 @@ export function convergeRuntimeManifest(
 	let systemdActivationAttempted = false;
 	let restartDaemon = false;
 	let desiredDaemonAuthTokenRevision: string | undefined;
+	let desiredDaemonProgramRevision: string | undefined;
 	let restartEgressSidecar = false;
 	let desiredEgressSidecarSecretRevision: string | undefined;
 	let rollbackEgressSecretOverride: RuntimeEgressSecretMaterial | undefined;
@@ -6104,7 +6110,10 @@ export function convergeRuntimeManifest(
 		const runtimeAuthToken = daemonAuthTokenFile ? readRuntimeAuthToken(paths) : null;
 		if (runtimeAuthToken) {
 			desiredDaemonAuthTokenRevision = daemonAuthTokenRevision(runtimeAuthToken);
-			restartDaemon = desiredDaemonAuthTokenRevision !== appliedState?.daemonAuthTokenRevision;
+			desiredDaemonProgramRevision = daemonProgramRevision(manifest);
+			restartDaemon =
+				desiredDaemonAuthTokenRevision !== appliedState?.daemonAuthTokenRevision ||
+				desiredDaemonProgramRevision !== appliedState?.daemonProgramRevision;
 		}
 		try {
 			withRuntimeUserFileAccess(() =>
@@ -6582,17 +6591,24 @@ export function convergeRuntimeManifest(
 		};
 		if (installErrors.length === 0) {
 			hostedRuntimeContract.assertPlatformRoots();
-			const daemonRevisionPreviouslyCommitted =
+			const daemonAuthTokenRevisionPreviouslyCommitted =
 				desiredDaemonAuthTokenRevision !== undefined &&
 				desiredDaemonAuthTokenRevision === appliedState?.daemonAuthTokenRevision;
+			const daemonProgramRevisionPreviouslyCommitted =
+				desiredDaemonProgramRevision !== undefined &&
+				desiredDaemonProgramRevision === appliedState?.daemonProgramRevision;
 			const egressRevisionPreviouslyCommitted =
 				desiredEgressSidecarSecretRevision !== undefined &&
 				desiredEgressSidecarSecretRevision === appliedState?.egressSidecarSecretRevision;
 			commitRuntimeInstallReceipts(installReceiptTargets, paths);
 			opts.commitAuthority?.(convergence, {
 				...(desiredDaemonAuthTokenRevision !== undefined &&
-				(systemdActivationApplied || daemonRevisionPreviouslyCommitted)
+				(systemdActivationApplied || daemonAuthTokenRevisionPreviouslyCommitted)
 					? { daemonAuthTokenRevision: desiredDaemonAuthTokenRevision }
+					: {}),
+				...(desiredDaemonProgramRevision !== undefined &&
+				(systemdActivationApplied || daemonProgramRevisionPreviouslyCommitted)
+					? { daemonProgramRevision: desiredDaemonProgramRevision }
 					: {}),
 				...(desiredEgressSidecarSecretRevision !== undefined &&
 				(systemdActivationApplied || egressRevisionPreviouslyCommitted)

--- a/packages/cli/src/runtime/runtime-impact-revision.test.ts
+++ b/packages/cli/src/runtime/runtime-impact-revision.test.ts
@@ -7,6 +7,7 @@ import {
 } from "./runtime-impact-revision";
 
 const daemonManifest = {
+	clawdiCli: { packageSpec: "clawdi@1.2.3" },
 	controlPlane: { apiUrl: "https://cloud.test" },
 	liveSync: { enabled: false, agents: [] },
 };
@@ -55,7 +56,7 @@ describe("runtime impact revisions", () => {
 			...daemonManifest,
 			clawdiCli: { packageSpec: "clawdi@2.0.0" },
 		};
-		expect(daemonProgramRevision(cliOnlyChange)).toBe(daemonProgramRevision(daemonManifest));
+		expect(daemonProgramRevision(cliOnlyChange)).not.toBe(daemonProgramRevision(daemonManifest));
 		expect(
 			daemonProgramRevision({
 				...daemonManifest,

--- a/packages/cli/src/runtime/runtime-impact-revision.ts
+++ b/packages/cli/src/runtime/runtime-impact-revision.ts
@@ -85,9 +85,10 @@ export function runtimeServiceProgramRevision(program: RuntimeServiceProgramImpa
 }
 
 export function daemonProgramRevision(
-	manifest: Pick<RuntimeManifest, "controlPlane" | "liveSync">,
+	manifest: Pick<RuntimeManifest, "clawdiCli" | "controlPlane" | "liveSync">,
 ): string {
 	return runtimeImpactRevision({
+		cliPackageSpec: manifest.clawdiCli?.packageSpec ?? null,
 		controlPlane: manifest.controlPlane,
 		liveSync: manifest.liveSync ?? null,
 	});

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -6523,6 +6523,7 @@ exit 64
 							convergence,
 							applyIdentity: load.applyContext?.identity ?? null,
 							daemonAuthTokenRevision: authority.daemonAuthTokenRevision,
+							daemonProgramRevision: authority.daemonProgramRevision,
 							egressSidecarSecretRevision: authority.egressSidecarSecretRevision,
 						});
 					},
@@ -9013,7 +9014,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		).toBe(false);
 	});
 
-	it("does not restart runtime units when only the bootstrap CLI package pin changes", () => {
+	it("force-restarts only the daemon for a CLI-only checkpoint", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -9054,6 +9055,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 			).installErrors,
 		).toEqual([]);
 		const before = readSystemdUnitSnapshot(paths);
+		before.user.set("hermes-gateway.service", "legacy");
 		const unchangedUnitInodes = [
 			join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"),
 			join(paths.systemdUserRoot, "openclaw-gateway.service.d", "10-clawdi-hosted.conf"),
@@ -9085,58 +9087,36 @@ printf 'ActiveState=active\\nSubState=running\\n'
 				join(paths.systemdUserRoot, "openclaw-gateway.service.d", "10-clawdi-hosted.conf"),
 			].map((path) => statSync(path).ino),
 		).toEqual(unchangedUnitInodes);
+		const after = readSystemdUnitSnapshot(paths);
+		after.user.set("hermes-gateway.service", "current");
+		const currentRevision = "a".repeat(32);
+		writeFileSync(
+			join(paths.systemdEnvRoot, "hermes-gateway.service.env"),
+			`CLAWDI_RUNTIME_REV="${currentRevision}"\n`,
+		);
 		seedFakeSystemdSnapshotProcesses(paths, systemctlStateRoot, before);
 		for (const unit of before.user.keys()) {
 			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "enabled"), "\n");
 		}
 		writeFileSync(systemctlLog, "");
 
-		const applied = applySystemdRuntimeUpdate(paths, before, readSystemdUnitSnapshot(paths));
+		const applied = applySystemdRuntimeUpdate(paths, before, after, {
+			forceRestartSystemUnits: ["clawdi-daemon.service"],
+			preserveActiveUnits: true,
+		});
 
 		expect(applied).toEqual({
 			applied: true,
-			systemUnitsChanged: [],
+			systemUnitsChanged: ["clawdi-daemon.service"],
 			userUnitsChanged: [],
 		});
 		const calls = readFileSync(systemctlLog, "utf-8");
-		expect(calls).not.toContain("daemon-reload");
-		expect(calls).not.toContain("restart clawdi-daemon.service");
+		expect(calls).toContain("daemon-reload");
+		expect(calls).toContain("restart clawdi-daemon.service");
+		expect(calls).not.toContain("restart clawdi-runtime-watch.service");
+		expect(calls).not.toContain("restart hermes-gateway.service");
 		expect(calls).not.toContain("restart openclaw-gateway.service");
 		expect(calls).not.toContain("restart clawdi-runtime-sidecar.service");
-
-		const currentCheckpointUnits = {
-			system: new Map<string, string>(),
-			user: new Map([["hermes-gateway.service", "current"]]),
-		};
-		const currentRevision = "a".repeat(32);
-		writeFileSync(
-			join(paths.systemdEnvRoot, "hermes-gateway.service.env"),
-			`CLAWDI_RUNTIME_REV="${currentRevision}"\n`,
-		);
-		seedFakeSystemdProcess(systemctlStateRoot, "user", "hermes-gateway.service", currentRevision);
-		writeFileSync(
-			fakeSystemdStatePath(systemctlStateRoot, "user", "hermes-gateway.service", "enabled"),
-			"\n",
-		);
-		writeFileSync(
-			fakeSystemdStatePath(systemctlStateRoot, "user", "hermes-gateway.service", "reload"),
-			"\n",
-		);
-		writeFileSync(systemctlLog, "");
-		expect(
-			applySystemdRuntimeUpdate(
-				paths,
-				{
-					system: new Map<string, string>(),
-					user: new Map([["hermes-gateway.service", "legacy"]]),
-				},
-				currentCheckpointUnits,
-				{ preserveActiveUnits: true },
-			),
-		).toEqual({ applied: true, systemUnitsChanged: [], userUnitsChanged: [] });
-		const currentCheckpointCalls = readFileSync(systemctlLog, "utf-8");
-		expect(currentCheckpointCalls).toContain("--user daemon-reload");
-		expect(currentCheckpointCalls).not.toContain("restart hermes-gateway.service");
 
 		const driftedUnits = {
 			system: new Map([["clawdi-runtime-watch.service", "watch"]]),
@@ -9275,7 +9255,7 @@ fi
 		]);
 	});
 
-	it("preserves active units across a CLI-only checkpoint with legacy renderer drift", async () => {
+	it("hands off a CLI-only checkpoint by restarting only the daemon once", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -9349,8 +9329,12 @@ chmod +x "$prefix/bin/clawdi"
 			{
 				method: "GET",
 				path: "/v1/runtime/manifest",
-				response: () =>
-					hostedRuntimeBundleResponse(
+				response: (request) => {
+					const etag = testBundleEtag(`${runtimeGeneration}:${desiredCliPackageSpec}`);
+					if (request.headers["if-none-match"] === etag) {
+						return new Response(null, { status: 304, headers: { etag } });
+					}
+					return hostedRuntimeBundleResponse(
 						{
 							manifest: {
 								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
@@ -9377,9 +9361,10 @@ chmod +x "$prefix/bin/clawdi"
 						},
 						{
 							applyGeneration: 13,
-							etag: testBundleEtag(`${runtimeGeneration}:${desiredCliPackageSpec}`),
+							etag,
 						},
-					),
+					);
+				},
 			},
 		]);
 
@@ -9397,6 +9382,8 @@ chmod +x "$prefix/bin/clawdi"
 			);
 			expect(existsSync(join(paths.systemdUserRoot, "openclaw-gateway.service"))).toBe(true);
 			expect(existsSync(paths.daemonAuthToken)).toBe(true);
+			const initialAppliedState = readRuntimeAppliedState(paths);
+			expect(initialAppliedState?.daemonProgramRevision).toMatch(/^[a-f0-9]{32}$/);
 			const legacyUnitPaths = [
 				...readdirSync(paths.systemdSystemRoot)
 					.filter((entry) => entry.endsWith(".service"))
@@ -9460,6 +9447,7 @@ chmod +x "$prefix/bin/clawdi"
 				generation: 13,
 				applyGeneration: 13,
 			});
+			const appliedBeforeDaemonHandoff = readFileSync(paths.appliedState, "utf-8");
 			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
 				transaction: { phase: "activated" },
 				badVersions: [],
@@ -9475,16 +9463,21 @@ chmod +x "$prefix/bin/clawdi"
 			expect(completedEvent.status).toBe("applied");
 			expect(completedEvent.selfReexec).toBe(false);
 			expect(completedEvent.cliUpdate.status).toBe("current");
-			expect(completedEvent.systemdUnitsChanged).toBe(false);
+			expect(completedEvent.systemdUnitsChanged).toBe(true);
 			expect(completedEvent.systemdApply).toEqual({
 				applied: true,
-				systemUnitsChanged: [],
+				systemUnitsChanged: ["clawdi-daemon.service"],
 				userUnitsChanged: [],
 			});
-			expect(readRuntimeAppliedState(paths)).toMatchObject({
+			const completedAppliedState = readRuntimeAppliedState(paths);
+			expect(completedAppliedState).toMatchObject({
 				generation: 14,
 				applyGeneration: 13,
 			});
+			expect(completedAppliedState?.daemonProgramRevision).toMatch(/^[a-f0-9]{32}$/);
+			expect(completedAppliedState?.daemonProgramRevision).not.toBe(
+				initialAppliedState?.daemonProgramRevision,
+			);
 			expect(JSON.stringify(currentTestApplyContext)).toBe(runtimeContextBefore);
 			const activationCalls = readFileSync(systemctlLog, "utf-8")
 				.trim()
@@ -9494,11 +9487,59 @@ chmod +x "$prefix/bin/clawdi"
 						call,
 					),
 				);
-			expect(activationCalls).toEqual(["daemon-reload", "--user daemon-reload"]);
+			expect(activationCalls).toEqual([
+				"daemon-reload",
+				"--user daemon-reload",
+				"restart clawdi-daemon.service",
+			]);
+			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
+				"restart clawdi-runtime-watch.service",
+			);
+			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
+				"restart clawdi-runtime-sidecar.service",
+			);
+			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
+				"--user restart openclaw-gateway.service",
+			);
 			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
 				transaction: null,
 				badVersions: [],
 			});
+
+			// Model a crash after the cache write but before the applied-state commit.
+			writeFileSync(paths.appliedState, appliedBeforeDaemonHandoff);
+			logs.length = 0;
+			writeFileSync(systemctlLog, "");
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode ?? 0).toBe(0);
+			expect(captured).toHaveLength(4);
+			expect(JSON.parse(logs[0]).systemdApply).toEqual({
+				applied: true,
+				systemUnitsChanged: ["clawdi-daemon.service"],
+				userUnitsChanged: [],
+			});
+			const retryCalls = readFileSync(systemctlLog, "utf-8");
+			expect(retryCalls.match(/^restart clawdi-daemon\.service$/gm)).toHaveLength(1);
+			expect(retryCalls).not.toContain("restart clawdi-runtime-watch.service");
+			expect(retryCalls).not.toContain("restart clawdi-runtime-sidecar.service");
+			expect(retryCalls).not.toContain("--user restart openclaw-gateway.service");
+			expect(readRuntimeAppliedState(paths)?.daemonProgramRevision).toBe(
+				completedAppliedState?.daemonProgramRevision,
+			);
+
+			const committedAfterRetry = readFileSync(paths.appliedState, "utf-8");
+			logs.length = 0;
+			writeFileSync(systemctlLog, "");
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode ?? 0).toBe(0);
+			expect(captured).toHaveLength(5);
+			expect(JSON.parse(logs[0])).toMatchObject({ status: "not_modified" });
+			expect(readFileSync(systemctlLog, "utf-8")).toBe("");
+			expect(readFileSync(paths.appliedState, "utf-8")).toBe(committedAfterRetry);
 		} finally {
 			restore();
 			console.log = previousLog;


### PR DESCRIPTION
## Summary

- include the exact Cloud manifest `clawdiCli.packageSpec` in the daemon program revision
- persist that private activation revision only after successful systemd activation, so a crash before commit retries the daemon handoff while a committed checkpoint is a no-op
- keep CLI-only checkpoints on `preserveActiveUnits: true` and force-restart only `clawdi-daemon.service`
- bump the CLI package and workspace lock entry to unpublished `0.13.70`

## Handoff semantics

This is a daemon process handoff, not a deployment, VM, Incus instance, or whole-runtime restart. The Cloud manifest remains the unique desired CLI authority. The existing watcher installs and activates the exact manifest package, then hands off through its existing self-reexec path. The successor watcher applies the same committed Cloud checkpoint and restarts only `clawdi-daemon.service`; the watcher, Hermes, OpenClaw, and runtime sidecar are not restarted. Rollout remains `force_restart:false`, and active evidence still comes from the successor daemon reporting its actual `activeCliVersion`.

This PR depends on the Hosted exact ACK/catalog replay counterpart for end-to-end rollout convergence.

## Verification

- Docker clean runner focused suite: 4 pass, 173 filtered, 0 fail, 90 assertions
- Docker clean runner full CLI suite: 1646 pass, 4 skip, 0 fail, 8942 assertions
- CLI `tsc --noEmit` in the clean runner
- focused Biome check
- `git diff --check`
- npm registry confirms `clawdi@0.13.70` is unpublished (`E404`)
