### PR TITLE
fix(web): refine Compute subscription cards

### DIFF
--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -28,6 +28,7 @@ const activeEnvironmentId = "11111111-1111-4111-8111-111111111111";
 const cancelingEnvironmentId = "22222222-2222-4222-8222-222222222222";
 const paidEnvironmentId = "33333333-3333-4333-8333-333333333333";
 const pastDueEnvironmentId = "44444444-4444-4444-8444-444444444444";
+const includedEnvironmentId = "55555555-5555-4555-8555-555555555555";
 const accountActiveDeployment = {
 	...paidBasicDeployment,
 	id: "hdep_active",
@@ -55,6 +56,13 @@ const accountPastDueDeployment = {
 		clawdi_cloud_environments: { hermes: pastDueEnvironmentId },
 	},
 };
+const accountIncludedDeployment = {
+	...includedBasicDeployment,
+	config_info: {
+		...includedBasicDeployment.config_info,
+		clawdi_cloud_environments: { hermes: includedEnvironmentId },
+	},
+};
 const accountCloudAgents = [
 	{
 		...sharedLegacyCloudAgent,
@@ -76,6 +84,13 @@ const accountCloudAgents = [
 		id: pastDueEnvironmentId,
 		name: "account-past-due",
 		default_name: "Past due agent",
+		display_name: null,
+	},
+	{
+		...sharedLegacyCloudAgent,
+		id: includedEnvironmentId,
+		name: "account-included",
+		default_name: "Included agent",
 		display_name: null,
 	},
 ];
@@ -270,7 +285,12 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await page.setViewportSize({ width: 1440, height: 900 });
 	const errors = collectBrowserErrors(page);
 	await stubHostedApi(page, {
-		deployments: [accountActiveDeployment, accountPastDueDeployment, accountCancelingDeployment],
+		deployments: [
+			accountActiveDeployment,
+			accountIncludedDeployment,
+			accountPastDueDeployment,
+			accountCancelingDeployment,
+		],
 		cloudAgents: accountCloudAgents,
 		plans: [basicPlan, performancePlan],
 		subscriptionPages: {
@@ -294,6 +314,13 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 			"current-page": {
 				items: [
 					subscription("active", "active", { agent_name: longAgentName }),
+					subscription("included", "active", {
+						plan_slug: "compute_basic",
+						funding_source: null,
+						price_cents: 0,
+						billing_term_months: 1,
+						agent_name: "Included agent",
+					}),
 					subscription("past_due", "past_due", {
 						plan_slug: "compute_basic",
 						funding_source: "wallet",
@@ -334,24 +361,34 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await dialog.getByRole("button", { name: "Load more" }).click();
 	await expect(dialog.getByText(longAgentName, { exact: true })).toBeVisible();
 	await expect(dialog.getByText("Canceling agent", { exact: true })).toBeVisible();
-	await expect(dialog.getByText("Active", { exact: true })).toBeVisible();
+	await expect(dialog.getByText("Active", { exact: true })).toHaveCount(2);
 	await expect(dialog.getByText("Canceling", { exact: true })).toBeVisible();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(3);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(4);
 	await expect(dialog.getByRole("button", { name: "Manage", exact: true })).toHaveCount(1);
 	await expect(dialog.getByRole("button", { name: "Resume subscription" })).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Show history (2)" })).toBeVisible();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(3);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(4);
 	const currentCards = dialog.locator('[data-slot="compute-subscription-card"]');
 	const activeCard = currentCards.nth(0);
-	const pastDueCard = currentCards.nth(1);
-	const cancelingCard = currentCards.nth(2);
+	const includedCard = currentCards.nth(1);
+	const pastDueCard = currentCards.nth(2);
+	const cancelingCard = currentCards.nth(3);
 	await expect(activeCard.getByRole("button", { name: "Cancel subscription" })).toBeVisible();
-	await expect(activeCard.locator("h4")).toHaveText(`${longAgentName}: Performance compute`);
+	await expect(activeCard.locator("h4")).toHaveText("Performance compute");
+	await expect(activeCard.getByText("Used by", { exact: true })).toBeVisible();
 	await expect(activeCard.getByText(longAgentName, { exact: true })).toBeVisible();
 	await expect(activeCard.locator("img")).toHaveCount(1);
-	await expect(activeCard.getByText("Performance compute", { exact: true })).toBeVisible();
+	await expect(activeCard.locator('[data-slot="compute-subscription-identity"] a')).toHaveAttribute(
+		"href",
+		/\/agents\/hdep_active\/settings\?.*settings=billing-plan/,
+	);
 	await expect(activeCard.getByText("Card", { exact: true })).toBeVisible();
 	await expect(activeCard.getByText("$190.00/yr", { exact: true })).toBeVisible();
+	await expect(includedCard.locator("h4")).toHaveText("Basic compute");
+	await expect(includedCard.getByText("Free", { exact: true })).toBeVisible();
+	await expect(includedCard.getByText("Included agent", { exact: true })).toBeVisible();
+	await expect(includedCard.getByRole("button", { name: "Cancel subscription" })).toHaveCount(0);
+	await expect(includedCard.locator('[data-slot="compute-subscription-actions"]')).toHaveCount(0);
 	await expect(pastDueCard.getByText("Past due", { exact: true })).toBeVisible();
 	await expect(pastDueCard.getByText("Retries Aug 10, 2099", { exact: true })).toBeVisible();
 	await expect(pastDueCard.getByRole("button", { name: "Manage", exact: true })).toHaveCount(0);
@@ -360,7 +397,7 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	const currentStatuses = await currentCards.evaluateAll((cards) =>
 		cards.map((card) => card.getAttribute("data-subscription-status")),
 	);
-	expect(currentStatuses).toEqual(["active", "past-due", "canceling"]);
+	expect(currentStatuses).toEqual(["active", "active", "past-due", "canceling"]);
 	const desktopCardBoxes = await currentCards.evaluateAll((cards) =>
 		cards.map((card) => card.getBoundingClientRect().toJSON()),
 	);
@@ -373,13 +410,20 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expectCardsFit(dialog);
 
 	await dialog.getByRole("button", { name: "Show history (2)" }).click();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(5);
-	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(5);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(6);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(6);
 	await expect(dialog.getByText("Canceled", { exact: true })).toHaveCount(2);
 	const visibleStatuses = await dialog
 		.locator('[data-slot="compute-subscription-card"]')
 		.evaluateAll((cards) => cards.map((card) => card.getAttribute("data-subscription-status")));
-	expect(visibleStatuses).toEqual(["active", "past-due", "canceling", "canceled", "canceled"]);
+	expect(visibleStatuses).toEqual([
+		"active",
+		"active",
+		"past-due",
+		"canceling",
+		"canceled",
+		"canceled",
+	]);
 	const orphanCard = dialog
 		.locator('[data-slot="compute-subscription-card"]')
 		.filter({ hasText: "Deleted agent" });
@@ -424,7 +468,7 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(fullManagementDialog).toBeHidden();
 	await expect(dialog).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Hide history" })).toBeVisible();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(5);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(6);
 	expect(page.url()).toBe(accountSettingsUrl);
 
 	await pastDueCard.getByRole("button", { name: "Top up", exact: true }).click();
@@ -434,11 +478,11 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(topUpDialog).toBeHidden();
 	await expect(dialog).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Hide history" })).toBeVisible();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(5);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(6);
 	expect(page.url()).toBe(accountSettingsUrl);
 
 	await dialog.getByRole("button", { name: "Hide history" }).click();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(3);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(4);
 	await expect(dialog.getByText("ended_first", { exact: true })).toHaveCount(0);
 
 	await page.setViewportSize({ width: 320, height: 568 });
@@ -524,9 +568,10 @@ test("agent settings uses the subscription card without changing plan actions", 
 		"data-status",
 		"success",
 	);
-	await expect(activeCard.locator("h3")).toHaveText("Paid research agent: Basic compute");
-	await expect(activeCard.getByText("Paid research agent", { exact: true })).toBeVisible();
-	await expect(activeCard.locator("img")).toHaveCount(1);
+	await expect(activeCard.locator("h3")).toHaveText("Basic compute");
+	await expect(activeCard.getByText("Paid research agent", { exact: true })).toHaveCount(0);
+	await expect(activeCard.locator("img")).toHaveCount(0);
+	await expect(activeCard.locator('[data-slot="compute-subscription-identity"]')).toHaveCount(0);
 	const agentManage = activeCard.getByRole("button", { name: "Manage", exact: true });
 	await expect(agentManage).toBeVisible();
 	await expect(agentManage.locator("svg.lucide-settings")).toHaveCount(1);
@@ -587,8 +632,7 @@ test("agent settings uses the subscription card without changing plan actions", 
 		"data-status",
 		"success",
 	);
-	await expect(fallbackCard.getByText("Payment", { exact: true })).toBeVisible();
-	await expect(fallbackCard.getByText("Included", { exact: true })).toBeVisible();
+	await expect(fallbackCard.getByText("Free", { exact: true })).toBeVisible();
 	await expect(fallbackCard.getByRole("button", { name: "Choose a subscription" })).toBeVisible();
 
 	await gotoHostedAgentSettings(page, "hdep_included", "Basic");

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -3415,11 +3415,7 @@ function HostedAgentSettingsTab({
 					<ProjectionDependentUnavailable label="Profile settings" />
 				)}
 				<LanguageTimezoneSettingsSection deployment={deployment} />
-				<ComputeSettingsSections
-					deployment={deployment}
-					agent={agent}
-					onDeleteAccepted={onDeleteAccepted}
-				/>
+				<ComputeSettingsSections deployment={deployment} onDeleteAccepted={onDeleteAccepted} />
 			</div>
 		</UnsavedNavigationBoundary>
 	);
@@ -3516,11 +3512,9 @@ function LanguageTimezoneSettingsSection({ deployment }: { deployment: HostedDep
 
 function ComputeSettingsSections({
 	deployment,
-	agent,
 	onDeleteAccepted,
 }: {
 	deployment: HostedDeployment;
-	agent: components["schemas"]["AgentResponse"] | null;
 	onDeleteAccepted: (deploymentId: string) => Promise<void> | void;
 }) {
 	const router = useRouter();
@@ -3659,17 +3653,6 @@ function ComputeSettingsSections({
 		lifecycleStatus,
 	);
 	const computeCardView = computeSubscriptionCardView({
-		identity: {
-			kind: "agent",
-			name: agent
-				? agentDisplayName(agent)
-				: agentDisplayName({
-						default_name: deployment.resource.name,
-						agent_type: deployment.resource.spec.runtime,
-					}),
-			agentType: deployment.resource.spec.runtime,
-			avatarUrl: agent?.avatar_url,
-		},
 		status: computeRecovery.status,
 		planSlug: computePlanSlug ?? rawComputePlanSlug,
 		fundingSource: isIncludedBasic

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
@@ -1,7 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { UserRoundX } from "lucide-react";
 import type { ReactNode } from "react";
-import { AgentIcon } from "@/components/dashboard/agent-icon";
 import { AgentLabel } from "@/components/dashboard/agent-label";
 import { entityCardChassisClass } from "@/components/entity-card";
 import { StatusBadge, type StatusTone } from "@/components/ui/status-badge";
@@ -21,14 +20,9 @@ export type ComputeSubscriptionIdentity =
 	| { kind: "unavailable"; label: string };
 
 export type ComputeSubscriptionCardView = {
-	identity: ComputeSubscriptionIdentity;
 	status: { label: string; tone: StatusTone };
-	facts: readonly [
-		{ label: "Plan"; value: string },
-		{ label: "Payment"; value: string },
-		{ label: "Price"; value: string },
-		{ label: "Schedule"; value: string },
-	];
+	plan: string;
+	commercialFacts: readonly { label: string; value: string; emphasis?: boolean }[];
 };
 
 export type ComputeSubscriptionPaymentSource = "included" | "stripe" | "wallet" | "unavailable";
@@ -41,7 +35,6 @@ export function computeSubscriptionPlanLabel(planSlug: string): string {
 }
 
 export function computeSubscriptionCardView({
-	identity,
 	status,
 	planSlug,
 	fundingSource,
@@ -52,7 +45,6 @@ export function computeSubscriptionCardView({
 	scheduleAt,
 	scheduleFallback,
 }: {
-	identity: ComputeSubscriptionIdentity;
 	status: ComputeSubscriptionCardView["status"];
 	planSlug: string;
 	fundingSource: ComputeSubscriptionPaymentSource;
@@ -64,43 +56,34 @@ export function computeSubscriptionCardView({
 	scheduleFallback?: string;
 }): ComputeSubscriptionCardView {
 	const included = fundingSource === "included";
+	const schedule =
+		scheduleVerb && scheduleAt
+			? `${scheduleVerb} ${formatShortDate(scheduleAt)}`
+			: scheduleFallback || "Unavailable";
 	return {
-		identity,
 		status,
-		facts: [
-			{ label: "Plan", value: computeSubscriptionPlanLabel(planSlug) },
-			{
-				label: "Payment",
-				value:
-					fundingSource === "included"
-						? "Included"
-						: fundingSource === "wallet"
-							? "Wallet"
-							: fundingSource === "stripe"
-								? "Card"
-								: "Unavailable",
-			},
-			{
-				label: "Price",
-				value:
-					included || priceCents === 0
-						? "No charge"
-						: priceCents == null
-							? "Unavailable"
-							: `${formatCurrencyCents(priceCents, currency)}${billingTermSuffix(billingTermMonths)}`,
-			},
-			{
-				label: "Schedule",
-				value:
-					scheduleVerb && scheduleAt
-						? `${scheduleVerb} ${formatShortDate(scheduleAt)}`
-						: scheduleFallback
-							? scheduleFallback
-							: included
-								? "Current"
-								: "Unavailable",
-			},
-		],
+		plan: computeSubscriptionPlanLabel(planSlug),
+		commercialFacts: included
+			? [{ label: "Price", value: "Free", emphasis: true }]
+			: [
+					{
+						label: "Price",
+						value:
+							priceCents == null
+								? "Unavailable"
+								: `${formatCurrencyCents(priceCents, currency)}${billingTermSuffix(billingTermMonths)}`,
+					},
+					{
+						label: "Payment",
+						value:
+							fundingSource === "wallet"
+								? "Wallet"
+								: fundingSource === "stripe"
+									? "Card"
+									: "Unavailable",
+					},
+					{ label: "Schedule", value: schedule },
+				],
 	};
 }
 
@@ -118,7 +101,7 @@ function SubscriptionIdentity({ identity }: { identity: ComputeSubscriptionIdent
 		);
 	}
 
-	const label = identity.agentType ? (
+	const label = (
 		<AgentLabel
 			name={identity.name}
 			machineName={null}
@@ -127,13 +110,6 @@ function SubscriptionIdentity({ identity }: { identity: ComputeSubscriptionIdent
 			size="md"
 			className={cn("min-w-0", identity.href && "transition-opacity hover:opacity-80")}
 		/>
-	) : (
-		<div className="flex min-w-0 items-center gap-3">
-			<AgentIcon agent={null} size="md" avatarUrl={identity.avatarUrl} />
-			<span className="truncate text-sm font-medium" title={identity.name}>
-				{identity.name}
-			</span>
-		</div>
 	);
 
 	return identity.href ? (
@@ -150,6 +126,7 @@ function SubscriptionIdentity({ identity }: { identity: ComputeSubscriptionIdent
 
 export function ComputeSubscriptionCard({
 	view,
+	identity,
 	badges,
 	notice,
 	actions,
@@ -157,6 +134,7 @@ export function ComputeSubscriptionCard({
 	className,
 }: {
 	view: ComputeSubscriptionCardView;
+	identity?: ComputeSubscriptionIdentity;
 	badges?: ReactNode;
 	notice?: ReactNode;
 	actions?: ReactNode;
@@ -164,12 +142,6 @@ export function ComputeSubscriptionCard({
 	className?: string;
 }) {
 	const Heading = headingLevel === 4 ? "h4" : "h3";
-	const [plan, payment, price] = view.facts;
-	const hideIncludedPrice = payment.value === "Included" && price.value === "No charge";
-	const visibleMetadataFacts = view.facts
-		.slice(1)
-		.filter((fact) => !(fact.label === "Price" && hideIncludedPrice));
-	const identityLabel = view.identity.kind === "agent" ? view.identity.name : view.identity.label;
 
 	return (
 		<article
@@ -181,9 +153,10 @@ export function ComputeSubscriptionCard({
 				className: cn("flex h-full min-w-0 flex-col gap-4", className),
 			})}
 		>
-			<Heading className="sr-only">{`${identityLabel}: ${plan.value}`}</Heading>
 			<header className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
-				<SubscriptionIdentity identity={view.identity} />
+				<Heading className="min-w-0 text-base font-semibold leading-6 [overflow-wrap:anywhere]">
+					{view.plan}
+				</Heading>
 				<div className="flex min-w-0 flex-wrap justify-end gap-1.5">
 					<StatusBadge status={view.status.tone} withDot>
 						{view.status.label}
@@ -193,19 +166,29 @@ export function ComputeSubscriptionCard({
 			</header>
 
 			<dl className="flex min-w-0 flex-wrap items-baseline gap-x-4 gap-y-1.5">
-				<div className="min-w-0 basis-full">
-					<dt className="sr-only">{plan.label}</dt>
-					<dd className="min-w-0 text-base font-semibold leading-6 [overflow-wrap:anywhere]">
-						{plan.value}
-					</dd>
-				</div>
-				{visibleMetadataFacts.map((fact) => (
+				{view.commercialFacts.map((fact) => (
 					<div key={fact.label} className="min-w-0 text-xs text-muted-foreground">
 						<dt className="sr-only">{fact.label}</dt>
-						<dd className="[overflow-wrap:anywhere]">{fact.value}</dd>
+						<dd
+							className={cn(
+								"[overflow-wrap:anywhere]",
+								fact.emphasis && "text-sm font-semibold text-foreground",
+							)}
+						>
+							{fact.value}
+						</dd>
 					</div>
 				))}
 			</dl>
+
+			{identity ? (
+				<div data-slot="compute-subscription-identity" className="flex min-w-0 items-center gap-3">
+					<span className="shrink-0 text-xs text-muted-foreground">Used by</span>
+					<div className="min-w-0 flex-1">
+						<SubscriptionIdentity identity={identity} />
+					</div>
+				</div>
+			) : null}
 
 			{notice ? (
 				<div data-slot="compute-subscription-notice" className="min-w-0 pt-1">

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -371,6 +371,7 @@ describe("compute subscription action status gates", () => {
 			status: "active" as const,
 			cancel_at_period_end: false,
 			deployment_id: null,
+			funding_source: "stripe" as const,
 			is_orphan: true,
 		};
 
@@ -378,6 +379,18 @@ describe("compute subscription action status gates", () => {
 		expect(canCancelAccountSubscription({ ...orphan, cancel_at_period_end: true })).toBe(false);
 		expect(canCancelAccountSubscription({ ...orphan, status: "canceling" })).toBe(false);
 		expect(canCancelAccountSubscription({ ...orphan, status: "canceled" })).toBe(false);
+	});
+
+	test("never offers cancellation for an included free subscription", () => {
+		expect(
+			canCancelAccountSubscription({
+				status: "active",
+				cancel_at_period_end: false,
+				deployment_id: "hdep_included",
+				funding_source: null,
+				is_orphan: false,
+			}),
+		).toBe(false);
 	});
 });
 

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -41,10 +41,17 @@ type AccountSubscriptionActionState = Pick<
 	"cancel_at_period_end" | "deployment_id" | "is_orphan" | "status"
 >;
 
+type AccountSubscriptionCancelState = AccountSubscriptionActionState &
+	Pick<ComputeSubscriptionListItem, "funding_source">;
+
 export function canCancelAccountSubscription(
-	subscription: AccountSubscriptionActionState,
+	subscription: AccountSubscriptionCancelState,
 ): boolean {
-	return !subscription.cancel_at_period_end && isComputeSubscriptionCancelable(subscription);
+	return (
+		(subscription.funding_source === "stripe" || subscription.funding_source === "wallet") &&
+		!subscription.cancel_at_period_end &&
+		isComputeSubscriptionCancelable(subscription)
+	);
 }
 
 export function canResumeAccountSubscription(

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -359,15 +359,6 @@ function SubscriptionRow({
 		canCancelAccountSubscription(subscription) ||
 		canResumeAccountSubscription(subscription);
 	const view = computeSubscriptionCardView({
-		identity: agentHref
-			? {
-					kind: "agent",
-					name: agentTile?.name ?? subscription.agent_name ?? "Agent",
-					agentType: agentTile?.agentType ?? null,
-					avatarUrl: agentTile?.avatarUrl,
-					href: agentHref,
-				}
-			: { kind: "unavailable", label: "Deleted agent" },
 		status: recovery.status,
 		planSlug: subscription.plan_slug,
 		fundingSource: subscription.funding_source === null ? "included" : subscription.funding_source,
@@ -384,6 +375,17 @@ function SubscriptionRow({
 			<ComputeSubscriptionCard
 				headingLevel={4}
 				view={view}
+				identity={
+					agentHref
+						? {
+								kind: "agent",
+								name: agentTile?.name ?? subscription.agent_name ?? "Agent",
+								agentType: agentTile?.agentType ?? null,
+								avatarUrl: agentTile?.avatarUrl,
+								href: agentHref,
+							}
+						: { kind: "unavailable", label: "Deleted agent" }
+				}
 				badges={subscription.is_orphan ? <Badge variant="outline">Orphaned</Badge> : null}
 				notice={
 					recoveryNotice || pendingPlanCopy ? (
@@ -445,19 +447,18 @@ function SubscriptionListSkeleton() {
 			{Array.from({ length: 3 }, (_, index) => `subscription-skeleton-${index}`).map((key) => (
 				<div key={key} className={entityCardChassisClass({ variant: "compact" })}>
 					<div className="flex items-start justify-between gap-3">
-						<div className="flex min-w-0 items-center gap-3">
-							<Skeleton className="size-8 shrink-0 rounded-md" />
-							<Skeleton className="h-5 w-36 max-w-full" />
-						</div>
+						<Skeleton className="h-5 w-36 max-w-full" />
 						<Skeleton className="h-5 w-16" />
 					</div>
-					<div className="space-y-2.5">
-						<Skeleton className="h-5 w-28" />
-						<div className="flex flex-wrap gap-x-4 gap-y-1.5">
-							<Skeleton className="h-4 w-12" />
-							<Skeleton className="h-4 w-20" />
-							<Skeleton className="h-4 w-24" />
-						</div>
+					<div className="flex flex-wrap gap-x-4 gap-y-1.5">
+						<Skeleton className="h-4 w-16" />
+						<Skeleton className="h-4 w-12" />
+						<Skeleton className="h-4 w-24" />
+					</div>
+					<div className="flex items-center gap-3">
+						<Skeleton className="h-4 w-12" />
+						<Skeleton className="size-6 shrink-0 rounded-md" />
+						<Skeleton className="h-4 w-28 max-w-full" />
 					</div>
 				</div>
 			))}


### PR DESCRIPTION
## Summary

- lead Compute subscription cards with plan identity and clean commercial facts, including explicit Free presentation
- show canonical linked Agent identity only in account subscription inventory while omitting redundant identity in Agent Settings
- prevent Included Basic subscriptions from ever exposing account cancellation
- preserve in-place management, recovery, pending, history, and responsive behavior

## Verification

- `bun test src/hosted/billing/subscription/subscription-utils.test.ts src/hosted/billing/subscription/subscriptions-section.test.tsx` (31 passed)
- `bun run typecheck`
- `bunx biome check apps/web/src`
- `bun run build:oss`
- `bunx playwright test --config=playwright.hosted.config.ts e2e/hosted-subscriptions.pw.ts` (account inventory and terminal fallback passed; Agent Settings product/geometry assertions passed, but the runner collected an environment `net::ERR_NETWORK_CHANGED` during external Stripe/Vite module loading)
- visually inspected account inventory and Agent Settings at desktop and 320px; no overlap or horizontal overflow