### PR TITLE
fix(cli): reject unpersistable skill text

### DIFF
--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -7,6 +7,7 @@ import { type AgentType, adapterRegistry } from "../adapters/registry";
 import { ApiClient, ApiError, unwrap } from "../lib/api-client";
 import { isLoggedIn } from "../lib/config";
 import { errMessage } from "../lib/errors";
+import { SkillTextValidationError } from "../lib/frontmatter";
 import { sha256Hex } from "../lib/hash";
 import { parseModules } from "../lib/prompts";
 import {
@@ -628,7 +629,7 @@ async function uploadOneAgent(
 		const skillSpinner = p.spinner();
 		skillSpinner.start(`Uploading ${skills.length} skill${skills.length === 1 ? "" : "s"}...`);
 		let pushed = 0;
-		const skipped: { key: string; reason: string }[] = [];
+		const skipped: { key: string; reason: string; category: "too large" | "invalid text" }[] = [];
 		try {
 			for (const skill of skills) {
 				// Pass skill_key so nested Hermes layouts archive
@@ -674,15 +675,25 @@ async function uploadOneAgent(
 						(e.status === 413 ||
 							(typeof e.body === "string" &&
 								/(?:^|[^0-9])413(?:[^0-9]|$)|payload too large/i.test(e.body)));
-					if (!is413) throw e;
-					const mb = (snapshot.archive.length / 1024 / 1024).toFixed(1);
-					skipped.push({ key: skill.skillKey, reason: `${mb} MB exceeds upload limit` });
+					if (e instanceof SkillTextValidationError) {
+						skipped.push({ key: skill.skillKey, reason: e.message, category: "invalid text" });
+					} else {
+						if (!is413) throw e;
+						const mb = (snapshot.archive.length / 1024 / 1024).toFixed(1);
+						skipped.push({
+							key: skill.skillKey,
+							reason: `${mb} MB exceeds upload limit`,
+							category: "too large",
+						});
+					}
 				}
 				skillSpinner.message(`Uploading skills (${pushed + skipped.length}/${skills.length})...`);
 			}
 			const summary = [`Pushed ${pushed} skill${pushed === 1 ? "" : "s"}`];
 			if (skipped.length > 0) {
-				summary.push(`skipped ${skipped.length} (too large)`);
+				summary.push(
+					`skipped ${skipped.length} (${[...new Set(skipped.map((item) => item.category))].join(", ")})`,
+				);
 			}
 			skillSpinner.stop(summary.join(", "));
 			for (const s of skipped) {

--- a/packages/cli/src/lib/api-client.test.ts
+++ b/packages/cli/src/lib/api-client.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { ApiClient } from "./api-client";
+import { tarSingleFile } from "./tar";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
 
 describe("ApiClient.uploadSkill", () => {
 	it("rejects invalid skill_key before building a multipart request", async () => {
@@ -13,5 +20,37 @@ describe("ApiClient.uploadSkill", () => {
 				".system.tar.gz",
 			),
 		).rejects.toThrow('Invalid skill_key: ".system"');
+	});
+
+	it("rejects literal and YAML-decoded NUL text before sending multipart", async () => {
+		let fetchCalls = 0;
+		globalThis.fetch = Object.assign(
+			async () => {
+				fetchCalls++;
+				return new Response("unexpected");
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+
+		const api = new ApiClient({ requireAuth: false });
+		const cases = [
+			{ key: "literal-nul", raw: "# Body\0\n" },
+			{
+				key: "decoded-nul",
+				raw: '---\nname: "invalid\\0name"\ndescription: metadata\n---\n# Body\n',
+			},
+		];
+		expect(Buffer.from(cases[1]?.raw ?? "").includes(0)).toBe(false);
+		for (const { key, raw } of cases) {
+			await expect(
+				api.uploadSkill(
+					"00000000-0000-0000-0000-000000000000",
+					key,
+					await tarSingleFile(key, raw),
+					"skill.tar.gz",
+				),
+			).rejects.toThrow("SKILL.md must not contain NUL characters");
+		}
+		expect(fetchCalls).toBe(0);
 	});
 });

--- a/packages/cli/src/lib/api-client.test.ts
+++ b/packages/cli/src/lib/api-client.test.ts
@@ -53,4 +53,29 @@ describe("ApiClient.uploadSkill", () => {
 		}
 		expect(fetchCalls).toBe(0);
 	});
+
+	it("skips decoded-NUL inspection above the server frontmatter limit", async () => {
+		let fetchCalls = 0;
+		globalThis.fetch = Object.assign(
+			async () => {
+				fetchCalls++;
+				return Response.json({ skill_key: "oversized-frontmatter", version: 1, file_count: 1 });
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+
+		const frontmatter = `name: valid\ndescription: "${"a".repeat(64 * 1024)}\\0"`;
+		const raw = `---\n${frontmatter}\n---\n# Body\n`;
+		expect(Buffer.byteLength(frontmatter, "utf8")).toBeGreaterThan(64 * 1024);
+		expect(Buffer.from(raw).includes(0)).toBe(false);
+
+		const api = new ApiClient({ requireAuth: false });
+		await api.uploadSkill(
+			"00000000-0000-0000-0000-000000000000",
+			"oversized-frontmatter",
+			await tarSingleFile("oversized-frontmatter", raw),
+			"skill.tar.gz",
+		);
+		expect(fetchCalls).toBe(1);
+	});
 });

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -10,6 +10,7 @@ import {
 	SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
 	SKILL_SYNC_PROTOCOL_HEADER,
 } from "./skill-sync-protocol";
+import { assertUploadableSkillArchive } from "./tar";
 import { getCliVersion } from "./version";
 
 type SkillUploadResponse = components["schemas"]["SkillUploadResponse"];
@@ -362,6 +363,7 @@ export class ApiClient {
 		contentHash?: string,
 	): Promise<SkillUploadResponse> {
 		assertValidSkillKey(skillKey);
+		await assertUploadableSkillArchive(file, skillKey);
 		// `content_hash` is optional server-side for legacy clients. Omit the
 		// field entirely when the caller doesn't have one — server falls
 		// back to computing it from the uploaded tar.
@@ -392,6 +394,7 @@ export class ApiClient {
 		contentHash?: string,
 	): Promise<SkillUploadResponse> {
 		assertValidSkillKey(skillKey);
+		await assertUploadableSkillArchive(file, skillKey);
 		const fields: Record<string, string> = { skill_key: skillKey };
 		if (contentHash) fields.content_hash = contentHash;
 		try {

--- a/packages/cli/src/lib/frontmatter.ts
+++ b/packages/cli/src/lib/frontmatter.ts
@@ -1,5 +1,7 @@
 import { parse as parseYaml } from "yaml";
 
+const FRONTMATTER_BYTES_MAX = 64 * 1024;
+
 export class SkillTextValidationError extends Error {
 	constructor() {
 		super("SKILL.md must not contain NUL characters, including YAML-decoded escapes.");
@@ -13,10 +15,12 @@ export function assertUploadableSkillText(raw: string): void {
 
 	const match = raw.match(/^---\s*\n(.*?)\n---\s*\n/s);
 	if (!match) return;
+	const frontmatter = match[1] ?? "";
+	if (Buffer.byteLength(frontmatter, "utf8") > FRONTMATTER_BYTES_MAX) return;
 
 	let parsed: unknown;
 	try {
-		parsed = parseYaml(match[1] ?? "", { mapAsMap: true, merge: true, uniqueKeys: false });
+		parsed = parseYaml(frontmatter, { mapAsMap: true, merge: true, uniqueKeys: false });
 	} catch {
 		// The server accepts malformed frontmatter as an empty metadata block.
 		return;

--- a/packages/cli/src/lib/frontmatter.ts
+++ b/packages/cli/src/lib/frontmatter.ts
@@ -1,3 +1,35 @@
+import { parse as parseYaml } from "yaml";
+
+export class SkillTextValidationError extends Error {
+	constructor() {
+		super("SKILL.md must not contain NUL characters, including YAML-decoded escapes.");
+		this.name = "SkillTextValidationError";
+	}
+}
+
+/** Reject text that the server cannot persist without changing its content. */
+export function assertUploadableSkillText(raw: string): void {
+	if (raw.includes("\0")) throw new SkillTextValidationError();
+
+	const match = raw.match(/^---\s*\n(.*?)\n---\s*\n/s);
+	if (!match) return;
+
+	let parsed: unknown;
+	try {
+		parsed = parseYaml(match[1] ?? "", { mapAsMap: true, merge: true, uniqueKeys: false });
+	} catch {
+		// The server accepts malformed frontmatter as an empty metadata block.
+		return;
+	}
+	if (!(parsed instanceof Map)) return;
+
+	for (const [key, value] of parsed) {
+		if (typeof key !== "string") continue;
+		if (key.includes("\0")) throw new SkillTextValidationError();
+		if (typeof value === "string" && value.includes("\0")) throw new SkillTextValidationError();
+	}
+}
+
 /**
  * Minimal SKILL.md frontmatter parser.
  *

--- a/packages/cli/src/lib/tar.ts
+++ b/packages/cli/src/lib/tar.ts
@@ -13,6 +13,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve } from "node:pat
 import { createGunzip } from "node:zlib";
 import * as tar from "tar";
 import { isReservedSkillArchivePath } from "../runtime/managed-skill-reservation";
+import { assertUploadableSkillText } from "./frontmatter";
 import { assertValidSkillKey } from "./skill-key";
 
 /**
@@ -85,6 +86,32 @@ export const SKILL_ARCHIVE_EXTRACTION_LIMITS = Object.freeze({
 
 function isRegularArchiveFile(type: string | undefined): boolean {
 	return type === "File" || type === "OldFile" || type === "ContiguousFile";
+}
+
+/** Validate the exact SKILL.md bytes about to cross the upload boundary. */
+export async function assertUploadableSkillArchive(bytes: Buffer, skillKey: string): Promise<void> {
+	const expectedPath = `${skillKey}/SKILL.md`;
+	const reads: Array<Promise<void>> = [];
+	const stream = tar.list({
+		gzip: true,
+		onReadEntry: (entry) => {
+			if (entry.path !== expectedPath || !isRegularArchiveFile(entry.type)) {
+				entry.resume();
+				return;
+			}
+			reads.push(
+				entry.concat().then((content) => {
+					assertUploadableSkillText(Buffer.from(content).toString("utf-8"));
+				}),
+			);
+		},
+	});
+	await new Promise<void>((resolvePromise, reject) => {
+		stream.on("end", resolvePromise);
+		stream.on("error", reject);
+		stream.end(bytes);
+	});
+	await Promise.all(reads);
 }
 
 function isAllowedArchiveEntry(type: string | undefined): boolean {

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -232,6 +232,20 @@ describe("Agent filesystem projection reconcile", () => {
 		});
 	});
 
+	it("does not queue a skill whose YAML metadata decodes to NUL", async () => {
+		await withProjectionCase(async ({ root, queue, keys, reconcile }) => {
+			const local = join(root, "decoded-nul");
+			mkdirSync(local, { recursive: true });
+			const skillMd = '---\nname: "invalid\\0name"\ndescription: metadata\n---\n# Body\n';
+			expect(Buffer.from(skillMd).includes(0)).toBe(false);
+			writeFileSync(join(local, "SKILL.md"), skillMd);
+			keys.add("decoded-nul");
+
+			await reconcile(new Map());
+			expect(queue.depth).toBe(0);
+		});
+	});
+
 	it("treats a current Agent-Project SSE key as an absence or local reproject hint", async () => {
 		await withProjectionCase(async ({ root, queue, keys, reconcile }) => {
 			await reconcile(new Map(), new Set(["legacy-absent"]));

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -35,12 +35,13 @@
  */
 
 import { createHash } from "node:crypto";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { components } from "@clawdi/shared/api";
 import type { AgentAdapter, CollectSessionsResult } from "../adapters/base";
 import { AgentSkillSyncNotFoundError, ApiClient, ApiError, unwrap } from "../lib/api-client";
+import { assertUploadableSkillText, SkillTextValidationError } from "../lib/frontmatter";
 import { computeLastActivityIso } from "../lib/session-activity";
 import { cacheKey, readSessionsLock, writeSessionsLock } from "../lib/sessions-lock";
 import { isValidSkillKey, SkillKeyValidationError } from "../lib/skill-key";
@@ -1022,9 +1023,9 @@ async function enqueueIfChanged(
 		});
 		return;
 	}
-	let hash: string;
+	let hash: string | null;
 	try {
-		hash = await computeSkillFolderHash(dir, undefined, skillKey);
+		hash = await computeUploadableSkillFolderHash(dir, skillKey);
 	} catch (e) {
 		// The path can disappear between the existence check and hash walk.
 		// Preserve the exact claim and enqueue its durable absence report.
@@ -1043,6 +1044,7 @@ async function enqueueIfChanged(
 		}
 		throw e;
 	}
+	if (hash === null) return;
 	if (lastPushedHash.get(skillKey) === hash) {
 		// No-op local touch; the exact projection claim already matches.
 		log.debug("engine.skill_unchanged", { skill_key: skillKey });
@@ -1070,6 +1072,20 @@ async function enqueueIfChanged(
 		version,
 		queue_depth: queue.depth,
 	});
+}
+
+async function computeUploadableSkillFolderHash(
+	dir: string,
+	skillKey: string,
+): Promise<string | null> {
+	try {
+		assertUploadableSkillText(readFileSync(join(dir, "SKILL.md"), "utf-8"));
+		return await computeSkillFolderHash(dir, undefined, skillKey);
+	} catch (error) {
+		if (!(error instanceof SkillTextValidationError)) throw error;
+		log.warn("engine.invalid_skill_text_skipped", { skill_key: skillKey, error: error.message });
+		return null;
+	}
 }
 
 /** Auth failure on projection/listing: not "permanent for this item"
@@ -1111,6 +1127,7 @@ export function classifyHeartbeatFailure(consecutiveFailures: number): FailureCl
  */
 export function isPermanentUploadError(e: unknown): boolean {
 	if (e instanceof SkillKeyValidationError) return true;
+	if (e instanceof SkillTextValidationError) return true;
 	// A dedicated Agent sync 404 is deliberately ambiguous between an older
 	// backend without the route and a current backend hiding an unproven Agent
 	// identity. Never redirect it to a generic Project write, release a claim,
@@ -1985,7 +2002,8 @@ export async function reconcileAgentSkillProjection(input: {
 			continue;
 		}
 
-		const hash = await computeSkillFolderHash(join(rootDir, skillKey), undefined, skillKey);
+		const hash = await computeUploadableSkillFolderHash(join(rootDir, skillKey), skillKey);
+		if (hash === null) continue;
 		const pendingOperation = queue
 			.all()
 			.find(

--- a/packages/cli/tests/commands/push.test.ts
+++ b/packages/cli/tests/commands/push.test.ts
@@ -192,6 +192,33 @@ describe("push — Hermes fixture", () => {
 		expect(uploads).toHaveLength(1);
 	});
 
+	it("skips YAML-decoded NUL metadata while preserving valid skills", async () => {
+		setup("hermes");
+		const invalidDir = join(tmpHome, ".hermes", "skills", "decoded-nul");
+		mkdirSync(invalidDir, { recursive: true });
+		const skillMd = '---\nname: "invalid\\0name"\ndescription: metadata\n---\n# Body\n';
+		expect(Buffer.from(skillMd).includes(0)).toBe(false);
+		writeFileSync(join(invalidDir, "SKILL.md"), skillMd);
+
+		const { captured, restore } = mockFetch([
+			okEnvironmentProbe(),
+			{
+				method: "POST",
+				path: "/v1/agents/env-test/skills/sync/upload",
+				response: () => jsonResponse({ skill_key: "core/demo", version: 1, file_count: 1 }),
+			},
+		]);
+		try {
+			await push({ agent: "hermes", modules: "skills", all: true });
+		} finally {
+			restore();
+		}
+
+		const uploads = captured.filter((c) => c.path === "/v1/agents/env-test/skills/sync/upload");
+		expect(uploads).toHaveLength(1);
+		expect(uploads[0]?.multipartFields?.skill_key).toBe("core/demo");
+	});
+
 	it("a skill already in the skills-lock is skipped on the next push", async () => {
 		setup("hermes");
 		const { captured, restore } = mockFetch([


### PR DESCRIPTION
## Summary

- reject literal NUL and NUL materialized by structured YAML frontmatter parsing before a Skill archive crosses either upload route
- skip invalid Skill text explicitly in manual batch push while preserving valid Skills, and keep daemon-invalid text out of the durable queue
- retain the existing current CLI `skill_key` boundary unchanged: Hermes discovery already skips dot directories such as `.archive` at every depth and validates relative keys before returning them

## Boundary rationale

- `frontmatter.ts` owns the one text rule and uses the CLI's existing `yaml` dependency; it does not copy server whitespace, truncation, or field-cap behavior
- `ApiClient` validates the exact tar bytes immediately before multipart upload, covering all callers and filesystem-change races
- daemon reconciliation validates before durable enqueue because permanently invalid work must not enter or churn the retry queue
- manual `push` catches the final boundary error per Skill so one invalid Skill does not discard valid uploads in the same batch

No compatibility behavior was added for legacy v1, and this PR does not change release, deployment, image, or rollout configuration.

## Evidence

Current-main invalid-key coverage:

- `HermesAdapter.collectSkills > skips archived dot-directories and invalid skill keys at every depth` constructs both `skills/.archive/old-skill/SKILL.md` and nested `skills/apple/.archive/old-reminders/SKILL.md`, then asserts both `collectSkills()` and daemon-facing `listSkillKeys()` return only `core/demo`
- daemon tests prove watcher paths with any dot-prefixed component resolve to no Skill, and adapter-listed invalid keys are filtered before reconciliation
- history: PR #199 / commit `0a1288bf8` added Hermes dot-directory skipping; PR #148 / commit `229be9e2b` unified generated keys; PR #213 / commit `7fa061455` added daemon/API key validation

NUL regression coverage:

- raw `SKILL.md` bytes are asserted NUL-free while YAML `"invalid\\0name"` decodes to NUL
- API upload rejects literal and decoded NUL before `fetch`
- daemon reconciliation does not enqueue decoded-NUL content
- manual Hermes push skips decoded-NUL content and still uploads the valid Skill

## Verification

```text
bun run --cwd packages/cli test \
  tests/adapters/hermes.test.ts \
  src/lib/api-client.test.ts \
  src/serve/sync-engine.test.ts \
  tests/commands/push.test.ts \
  tests/api-client.test.ts

CLI typecheck: passed
Tests: 117 passed, 0 failed
Biome: passed on all changed files and the existing Hermes discovery evidence test
git diff --check: passed
```
