### PR TITLE
feat(admin): replace managed provider runtime metadata

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -1084,7 +1084,6 @@ async def admin_replace_deployment_managed_ai_provider_metadata(
         )
     try:
         _require_managed_provider_contract(provider)
-        previous_non_auth_signature = runtime_manifest_provider_non_auth_signature(provider)
         changed = replace_deployment_managed_provider_metadata(
             provider,
             base_url=body.base_url,
@@ -1110,8 +1109,7 @@ async def admin_replace_deployment_managed_ai_provider_metadata(
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, str(exc)) from exc
     if changed:
         await db.flush()
-        if previous_non_auth_signature != runtime_manifest_provider_non_auth_signature(provider):
-            await queue_provider_runtime_manifest_changed(db, target.id, provider_id)
+        await queue_provider_runtime_manifest_changed(db, target.id, provider_id)
     _record_deployment_managed_provider_audit(
         db,
         action=action,

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -74,6 +74,7 @@ from app.schemas.admin import (
     AdminChannelVisibility,
     AdminChannelWebhookSecretResponse,
     AdminDeploymentManagedAiProviderResponse,
+    AdminDeploymentManagedAiProviderRuntimeMetadataReplace,
     AdminDeploymentManagedAiProviderUpsert,
     AdminEnvironmentCreate,
     AdminManagedAiProviderResponse,
@@ -163,6 +164,7 @@ from app.services.managed_ai_provider import (
     find_clawdi_managed_provider,
     is_v2_deployment_managed_provider_id,
     lock_deployment_managed_provider_mutation,
+    replace_deployment_managed_provider_metadata,
     upsert_clawdi_managed_provider,
 )
 from app.services.principal_lifecycle import (
@@ -1032,6 +1034,95 @@ async def admin_upsert_clawdi_managed_ai_provider(
         owner.ref,
         provider.provider_id,
     )
+    return await _admin_deployment_managed_provider_response(
+        db,
+        provider=provider,
+        owner=owner,
+        target=target,
+    )
+
+
+@router.put(
+    "/ai-providers/{provider_id}/runtime-metadata",
+    response_model=AdminDeploymentManagedAiProviderResponse,
+)
+async def admin_replace_deployment_managed_ai_provider_metadata(
+    provider_id: str,
+    body: AdminDeploymentManagedAiProviderRuntimeMetadataReplace,
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+) -> AdminDeploymentManagedAiProviderResponse:
+    """Replace deployment-managed runtime metadata without changing auth state."""
+
+    if not is_v2_deployment_managed_provider_id(provider_id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
+    owner = body.owner
+    action = "ai_provider.managed.runtime_metadata.replace"
+    target = await _find_deployment_managed_provider_owner(
+        db,
+        owner=owner,
+        provider_id=provider_id,
+        action=action,
+    )
+    await lock_deployment_managed_provider_mutation(
+        db,
+        owner_user_id=target.id,
+        provider_id=provider_id,
+    )
+    provider = await find_clawdi_managed_provider(
+        db,
+        owner_user_id=target.id,
+        provider_id=provider_id,
+    )
+    if provider is None:
+        await _raise_deployment_managed_provider_scope_denied(
+            db,
+            action=action,
+            owner=owner,
+            owner_user_id=target.id,
+            provider_id=provider_id,
+        )
+    try:
+        _require_managed_provider_contract(provider)
+        previous_non_auth_signature = runtime_manifest_provider_non_auth_signature(provider)
+        changed = replace_deployment_managed_provider_metadata(
+            provider,
+            base_url=body.base_url,
+            models=(
+                [model.model_dump(exclude_none=True) for model in body.models]
+                if body.models is not None
+                else None
+            ),
+        )
+    except (HTTPException, ValueError) as exc:
+        _record_deployment_managed_provider_audit(
+            db,
+            action=action,
+            owner=owner,
+            owner_user_id=target.id,
+            provider_id=provider_id,
+            provider_uuid=provider.id,
+            outcome="failed",
+        )
+        await db.commit()
+        if isinstance(exc, HTTPException):
+            raise
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, str(exc)) from exc
+    if changed:
+        await db.flush()
+        if previous_non_auth_signature != runtime_manifest_provider_non_auth_signature(provider):
+            await queue_provider_runtime_manifest_changed(db, target.id, provider_id)
+    _record_deployment_managed_provider_audit(
+        db,
+        action=action,
+        owner=owner,
+        owner_user_id=target.id,
+        provider_id=provider_id,
+        provider_uuid=provider.id,
+        outcome="success",
+    )
+    await db.commit()
+    await db.refresh(provider)
     return await _admin_deployment_managed_provider_response(
         db,
         provider=provider,

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -236,6 +236,16 @@ class AdminDeploymentManagedAiProviderUpsert(BaseModel):
     capabilities: dict[str, Any] | None = None
 
 
+class AdminDeploymentManagedAiProviderRuntimeMetadataReplace(BaseModel):
+    """Replace runtime metadata without changing managed credentials."""
+
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
+
+    owner: PlatformOwner
+    base_url: str = Field(min_length=1, max_length=1000)
+    models: list[AiProviderModel] | None
+
+
 class AdminDeploymentManagedAiProviderResponse(BaseModel):
     id: UUID
     owner: PlatformOwner

--- a/backend/app/services/managed_ai_provider.py
+++ b/backend/app/services/managed_ai_provider.py
@@ -197,6 +197,25 @@ async def upsert_clawdi_managed_provider(
     return provider
 
 
+def replace_deployment_managed_provider_metadata(
+    provider: AiProvider,
+    *,
+    base_url: str,
+    models: list[dict[str, JsonValue]] | None,
+) -> bool:
+    """Replace runtime metadata without touching provider auth state."""
+
+    if not is_v2_deployment_managed_provider_id(provider.provider_id):
+        raise ValueError("unsupported deployment managed provider id")
+    validate_managed_provider_base_url(base_url)
+    normalized_base_url = base_url.strip()
+    if provider.base_url == normalized_base_url and provider.models == models:
+        return False
+    provider.base_url = normalized_base_url
+    provider.models = models
+    return True
+
+
 async def find_clawdi_managed_provider(
     db: AsyncSession,
     *,

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -194,6 +194,18 @@ async def _isolated_admin_client(engine) -> AsyncIterator[httpx.AsyncClient]:
         settings.admin_api_key = original_admin_key
 
 
+async def _replace_managed_provider_runtime_metadata(
+    client: httpx.AsyncClient,
+    provider_id: str,
+    body: dict,
+) -> httpx.Response:
+    return await client.put(
+        f"/v1/admin/ai-providers/{provider_id}/runtime-metadata",
+        headers=_AUTH,
+        json=body,
+    )
+
+
 @pytest.mark.asyncio
 async def test_admin_mint_requires_admin_key(admin_client, seed_user):
     """Without the X-Admin-Key header, endpoint returns 401."""
@@ -1253,6 +1265,13 @@ async def test_admin_deployment_managed_ai_provider_lifecycle_is_owner_scoped_an
         params=other_owner,
     )
     assert cross_owner_delete.status_code == 404, cross_owner_delete.text
+    metadata = {"owner": owner, "base_url": "https://gateway.example.test/v1", "models": None}
+    cross_owner_replace = await _replace_managed_provider_runtime_metadata(
+        admin_client,
+        provider_id,
+        {**metadata, "owner": other_owner},
+    )
+    assert cross_owner_replace.status_code == 404, cross_owner_replace.text
 
     still_active = (
         await db_session.execute(
@@ -1316,6 +1335,7 @@ async def test_admin_deployment_managed_ai_provider_lifecycle_is_owner_scoped_an
             ("ai_provider.managed.read", "success", seed_user.id),
             ("ai_provider.managed.read", "cross_owner_denied", other.id),
             ("ai_provider.managed.delete", "cross_owner_denied", other.id),
+            ("ai_provider.managed.runtime_metadata.replace", "cross_owner_denied", other.id),
             ("ai_provider.managed.delete", "success", seed_user.id),
             ("ai_provider.managed.credential.archive", "success", seed_user.id),
         ]
@@ -1333,6 +1353,42 @@ async def test_admin_deployment_managed_ai_provider_lifecycle_is_owner_scoped_an
         assert event.details["owner_user_id"] == str(event.target_user_id)
         assert event.details["provider_id"] == provider_id
 
+    for rejected_provider_id, body, expected_status in (
+        (V2_MANAGED_AI_PROVIDER_ID, metadata, 404),
+        ("ordinary-provider", metadata, 404),
+        (f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}404", metadata, 404),
+        (
+            provider_id,
+            {
+                **metadata,
+                "api_key": "not-accepted",
+                "auth": {"type": "none"},
+                "credential": {"type": "api_key"},
+                "label": "not-accepted",
+                "capabilities": {},
+                "default_model": "not-accepted",
+            },
+            422,
+        ),
+        (provider_id, {"owner": owner, "models": None}, 422),
+        (provider_id, {"owner": owner, "base_url": metadata["base_url"]}, 422),
+    ):
+        response = await _replace_managed_provider_runtime_metadata(
+            admin_client, rejected_provider_id, body
+        )
+        assert response.status_code == expected_status, response.text
+        if "api_key" in body:
+            assert {error["loc"][-1] for error in response.json()["detail"]} == {
+                "api_key",
+                "auth",
+                "credential",
+                "label",
+                "capabilities",
+                "default_model",
+            }
+    archived = await _replace_managed_provider_runtime_metadata(admin_client, provider_id, metadata)
+    assert archived.status_code == 404, archived.text
+
 
 @pytest.mark.asyncio
 async def test_admin_deployment_provider_invalidates_only_bound_runtime_on_manifest_changes(
@@ -1340,6 +1396,9 @@ async def test_admin_deployment_provider_invalidates_only_bound_runtime_on_manif
     db_session,
     seed_user,
 ):
+    from sqlalchemy import select
+
+    from app.models.ai_provider import AiProvider, AiProviderAuthPayload
     from app.models.hosted_runtime import HostedRuntimeState
     from app.models.user import User
     from app.services import sync_events
@@ -1411,21 +1470,25 @@ async def test_admin_deployment_provider_invalidates_only_bound_runtime_on_manif
         "owner": owner,
         "base_url": "https://ai-gateway.clawdi.ai/v1",
         "api_key": "sk-initial",
+        "label": "Hosted catalog",
+        "capabilities": {MANAGED_AI_PROVIDER_PROVENANCE_CAPABILITY: "deployment-8403"},
         "models": [{"id": "gpt-5.5"}],
     }
     expected_event = {
         "type": "runtime_manifest_changed",
         "environment_id": str(environments[0][1].id),
     }
+
+    def assert_only_bound_event() -> None:
+        assert queues[0].get_nowait() == expected_event
+        assert all(queue.empty() for queue in queues)
+
     try:
         created = await admin_client.put(
             f"/v1/admin/ai-providers/{provider_id}", headers=_AUTH, json=request_body
         )
         assert created.status_code == 200, created.text
-        assert queues[0].get_nowait() == expected_event
-        assert queues[0].empty()
-        assert queues[1].empty()
-        assert queues[2].empty()
+        assert_only_bound_event()
 
         credential_only = await admin_client.put(
             f"/v1/admin/ai-providers/{provider_id}",
@@ -1433,41 +1496,91 @@ async def test_admin_deployment_provider_invalidates_only_bound_runtime_on_manif
             json={**request_body, "api_key": "sk-rotated"},
         )
         assert credential_only.status_code == 200, credential_only.text
-        assert queues[0].get_nowait() == expected_event
-        assert queues[0].empty()
-        assert queues[1].empty()
-        assert queues[2].empty()
+        assert_only_bound_event()
 
-        replayed_write = await admin_client.put(
-            f"/v1/admin/ai-providers/{provider_id}",
-            headers=_AUTH,
-            json={**request_body, "api_key": "sk-rotated"},
+        provider = await db_session.scalar(
+            select(AiProvider).where(
+                AiProvider.owner_user_id == seed_user.id,
+                AiProvider.provider_id == provider_id,
+            )
         )
-        assert replayed_write.status_code == 200, replayed_write.text
-        assert queues[0].get_nowait() == expected_event
-        assert queues[0].empty()
-        assert queues[1].empty()
-        assert queues[2].empty()
+        payload = await db_session.scalar(
+            select(AiProviderAuthPayload).where(
+                AiProviderAuthPayload.owner_user_id == seed_user.id,
+                AiProviderAuthPayload.provider_id == provider_id,
+            )
+        )
+        assert provider is not None and payload is not None
 
-        catalog_changed = await admin_client.put(
-            f"/v1/admin/ai-providers/{provider_id}",
-            headers=_AUTH,
-            json={**request_body, "api_key": "sk-rotated", "models": [{"id": "gpt-5.6"}]},
+        def auth_storage():
+            return (
+                provider.auth_type,
+                provider.auth_ref,
+                provider.auth_metadata,
+                provider.label,
+                provider.capabilities,
+                payload.encrypted_payload,
+                payload.nonce,
+                payload.credential_revision,
+                payload.kind,
+                payload.source,
+                payload.payload_metadata,
+                payload.archived_at,
+                payload.updated_at,
+            )
+
+        preserved = auth_storage()
+        metadata = {
+            "owner": owner,
+            "base_url": "https://catalog-gateway.example.test/v1",
+            "models": [
+                {
+                    "id": "hermes-primary",
+                    "supports_tools": True,
+                    "compat": {"supportsDeveloperRole": True},
+                },
+                {
+                    "id": "openclaw-fallback",
+                    "alias": "fallback",
+                    "compat": {"maxTokensField": "max_completion_tokens"},
+                },
+            ],
+        }
+        changed = await _replace_managed_provider_runtime_metadata(
+            admin_client, provider_id, metadata
         )
-        assert catalog_changed.status_code == 200, catalog_changed.text
-        assert queues[0].get_nowait() == expected_event
-        assert queues[0].empty()
-        assert queues[1].empty()
-        assert queues[2].empty()
+        assert changed.status_code == 200, changed.text
+        assert changed.json()["base_url"] == metadata["base_url"]
+        assert changed.json()["models"] == metadata["models"]
+        assert_only_bound_event()
+        await db_session.refresh(provider)
+        await db_session.refresh(payload)
+        assert auth_storage() == preserved
+        unchanged_at = datetime.now(UTC) - timedelta(days=1)
+        provider.updated_at = unchanged_at
+        await db_session.commit()
+
+        replay = await _replace_managed_provider_runtime_metadata(
+            admin_client, provider_id, metadata
+        )
+        assert replay.status_code == 200, replay.text
+        assert replay.json() == changed.json()
+        await db_session.refresh(provider)
+        assert provider.updated_at == unchanged_at
+        assert all(queue.empty() for queue in queues)
+
+        cleared = await _replace_managed_provider_runtime_metadata(
+            admin_client, provider_id, {**metadata, "models": None}
+        )
+        assert cleared.status_code == 200, cleared.text
+        assert cleared.json()["models"] is None
+        assert_only_bound_event()
 
         deleted = await admin_client.delete(
             f"/v1/admin/ai-providers/{provider_id}", headers=_AUTH, params=owner
         )
         assert deleted.status_code == 200, deleted.text
-        assert queues[0].get_nowait() == expected_event
-        assert queues[0].empty()
-        assert queues[1].empty()
-        assert queues[2].empty()
+        assert_only_bound_event()
     finally:
         for (user, _), queue in zip(environments, queues, strict=True):
             sync_events.unsubscribe(user.id, queue)


### PR DESCRIPTION
## Summary
- add an admin-only full replacement endpoint for deployment-scoped managed provider runtime metadata
- require explicit owner, base URL, and required-nullable ordered model projection while preserving label, capabilities, and all credential/auth storage
- make identical projection replay a strict provider-row no-op and emit the existing runtime manifest invalidation only once when the projection changes

## Contract
- `PUT /v1/admin/ai-providers/{provider_id}/runtime-metadata`
- accepts only exact v2 deployment-scoped managed provider IDs
- rejects fixed, ordinary, missing, archived, and cross-owner providers fail closed
- `models` omitted returns 422; `models: null` clears legacy model metadata
- response reuses the complete admin provider readback for response-loss convergence
- no idempotency table/header, schema migration, or generated client churn

## Verification
- isolated Docker/PostgreSQL focused suite: 6 passed (managed provider lifecycle/scope, ordered replace + null cleanup + no-op notification semantics, existing credential rotation, ordinary user GET/PATCH/DELETE isolation)
- BasedPyright governance: owned 188 files, strict 186 files, 0 diagnostics
- Ruff focused lint and format: passed
- `git diff --check`: passed

## Note
- full backend Ruff lint passed; full-tree Ruff format check is blocked by a pre-existing unrelated formatting delta in `backend/tests/test_projects_routes.py`.