### PR TITLE
fix(web): clarify ended subscription history

### DIFF
--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -319,6 +319,7 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 						agent_name: "Former deleted agent",
 						deployment_id: null,
 						is_orphan: true,
+						recovery_action: "start_new",
 					}),
 				],
 				has_more: true,
@@ -350,7 +351,8 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 						agent_name: "Canceling agent",
 					}),
 					subscription("ended_second", "canceled", {
-						current_period_end: "2024-08-12T12:00:00Z",
+						current_period_end: "2099-09-11T12:00:00Z",
+						recovery_action: "start_new",
 					}),
 				],
 				has_more: false,
@@ -433,18 +435,11 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await dialog.getByRole("button", { name: "Show history (2)" }).click();
 	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(6);
 	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(6);
-	await expect(dialog.getByText("Canceled", { exact: true })).toHaveCount(2);
+	await expect(dialog.getByText("Ended", { exact: true })).toHaveCount(2);
 	const visibleStatuses = await dialog
 		.locator('[data-slot="compute-subscription-card"]')
 		.evaluateAll((cards) => cards.map((card) => card.getAttribute("data-subscription-status")));
-	expect(visibleStatuses).toEqual([
-		"active",
-		"active",
-		"past-due",
-		"canceling",
-		"canceled",
-		"canceled",
-	]);
+	expect(visibleStatuses).toEqual(["active", "active", "past-due", "canceling", "ended", "ended"]);
 	const orphanCard = dialog
 		.locator('[data-slot="compute-subscription-card"]')
 		.filter({ hasText: "Deleted agent" });
@@ -455,10 +450,13 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(orphanCard.getByText("No linked agent", { exact: true })).toHaveCount(0);
 	await expect(dialog.getByText("ended_second", { exact: true })).toBeVisible();
 	await expect(orphanCard.getByRole("button", { name: "Manage", exact: true })).toHaveCount(0);
-	const canceledCards = dialog
-		.locator('[data-slot="compute-subscription-card"]')
-		.filter({ hasText: "Canceled" });
-	await expect(canceledCards.getByRole("button", { name: "Manage", exact: true })).toHaveCount(0);
+	await expect(orphanCard.locator('[data-slot="compute-subscription-notice"]')).toHaveCount(0);
+	const endedCards = dialog.locator('[data-subscription-status="ended"]');
+	await expect(endedCards.getByRole("button", { name: "Manage", exact: true })).toHaveCount(0);
+	await expect(endedCards.getByText("Schedule", { exact: true })).toHaveCount(0);
+	await expect(endedCards.getByText(/(Aug 12, 2025|Sep 11, 2099)/)).toHaveCount(0);
+	await expect(dialog.getByText("Start a new subscription from Agent settings.")).toHaveCount(1);
+	await expect(dialog.getByText(/This subscription ended\./)).toHaveCount(0);
 	await expectCardsFit(dialog);
 
 	const accountSettingsUrl = page.url();

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
@@ -45,6 +45,7 @@ export function computeSubscriptionCardView({
 	scheduleVerb,
 	scheduleAt,
 	scheduleFallback,
+	includeSchedule = true,
 }: {
 	status: ComputeSubscriptionCardView["status"];
 	planSlug: string;
@@ -55,6 +56,7 @@ export function computeSubscriptionCardView({
 	scheduleVerb: string | null;
 	scheduleAt: string | null | undefined;
 	scheduleFallback?: string;
+	includeSchedule?: boolean;
 }): ComputeSubscriptionCardView {
 	const included = fundingSource === "included";
 	const schedule =
@@ -83,7 +85,7 @@ export function computeSubscriptionCardView({
 									? "Card"
 									: "Unavailable",
 					},
-					{ label: "Schedule", value: schedule },
+					...(includeSchedule ? [{ label: "Schedule", value: schedule }] : []),
 				],
 	};
 }

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -15,7 +15,7 @@ import {
 	isComputeSubscriptionCancelable,
 	isComputeSubscriptionRenewing,
 	isComputeSubscriptionTermChangeable,
-	isEndedAccountSubscription,
+	isHistoricalAccountSubscription,
 	isIncludedBasicSubscription,
 	pendingComputePlanSlug,
 	pendingPlanScheduleCopy,
@@ -303,27 +303,15 @@ describe("commonExplicitBillingOffers", () => {
 });
 
 describe("compute subscription action status gates", () => {
-	test("hides only canceled subscriptions whose service period has ended", () => {
-		const nowMs = Date.parse("2026-08-12T12:00:00Z");
+	test("treats terminal canceled status as history regardless of service period", () => {
 		const ended = {
 			status: "canceled" as const,
 			cancel_at_period_end: false,
-			current_period_end: "2026-08-12T12:00:00Z",
+			current_period_end: "2099-08-12T12:00:00Z",
 		};
 
-		expect(isEndedAccountSubscription(ended, nowMs)).toBe(true);
-		expect(
-			isEndedAccountSubscription(
-				{ ...ended, current_period_end: "2026-08-12T12:00:00.001Z" },
-				nowMs,
-			),
-		).toBe(false);
-		expect(isEndedAccountSubscription({ ...ended, status: "canceling" }, nowMs)).toBe(false);
-		expect(isEndedAccountSubscription({ ...ended, cancel_at_period_end: true }, nowMs)).toBe(true);
-		expect(isEndedAccountSubscription({ ...ended, current_period_end: null }, nowMs)).toBe(false);
-		expect(isEndedAccountSubscription({ ...ended, current_period_end: "not-a-date" }, nowMs)).toBe(
-			false,
-		);
+		expect(isHistoricalAccountSubscription(ended)).toBe(true);
+		expect(isHistoricalAccountSubscription({ ...ended, status: "canceling" })).toBe(false);
 	});
 
 	test("matches the backend cancel and resume status set", () => {
@@ -440,8 +428,9 @@ describe("compute subscription lifecycle presentation", () => {
 			{ badgeLabel: "Setup incomplete", renews: false },
 		);
 		expect(computeSubscriptionLifecycle({ ...subscription(), status: "canceled" })).toMatchObject({
-			badgeLabel: "Canceled",
-			dateVerb: "Canceled",
+			badgeLabel: "Ended",
+			dateAt: null,
+			dateVerb: null,
 			renews: false,
 		});
 		expect(computeSubscriptionLifecycle({ ...subscription(), status: "expired" })).toMatchObject({

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -64,17 +64,10 @@ export function canResumeAccountSubscription(
 	);
 }
 
-export function isEndedAccountSubscription(
-	subscription: Pick<
-		ComputeSubscriptionListItem,
-		"cancel_at_period_end" | "current_period_end" | "status"
-	>,
-	nowMs: number,
+export function isHistoricalAccountSubscription(
+	subscription: Pick<ComputeSubscriptionListItem, "status">,
 ): boolean {
-	if (subscription.status !== "canceled") return false;
-	if (!subscription.current_period_end) return false;
-	const periodEndMs = Date.parse(subscription.current_period_end);
-	return Number.isFinite(periodEndMs) && periodEndMs <= nowMs;
+	return subscription.status === "canceled";
 }
 
 export function resolveBasicPlan(plans: Plan[] | undefined): Plan | undefined {
@@ -274,10 +267,10 @@ export function computeSubscriptionLifecycle(
 	}
 	if (status === "canceled") {
 		return {
-			badgeLabel: "Canceled",
+			badgeLabel: "Ended",
 			badgeTone: "neutral",
-			dateAt: canceledAt,
-			dateVerb: "Canceled",
+			dateAt: null,
+			dateVerb: null,
 			renews: false,
 		};
 	}

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -52,7 +52,7 @@ import {
 	canResumeAccountSubscription,
 	computeFundingSource,
 	computeSubscriptionLifecycle,
-	isEndedAccountSubscription,
+	isHistoricalAccountSubscription,
 	pendingPlanScheduleCopy,
 	resolvePerformancePlan,
 } from "@/hosted/billing/subscription/subscription-utils";
@@ -334,9 +334,7 @@ function SubscriptionRow({
 			case "fix_payment":
 				return "Resolve the open invoice before managing this subscription.";
 			case "start_new":
-				return agentHref
-					? "This subscription ended. Start a new subscription from Agent settings."
-					: "This subscription ended.";
+				return agentHref ? "Start a new subscription from Agent settings." : null;
 			case undefined:
 				return null;
 		}
@@ -366,6 +364,7 @@ function SubscriptionRow({
 		scheduleVerb: recovery.schedule?.verb ?? lifecycle.dateVerb,
 		scheduleAt: recovery.schedule?.at ?? lifecycle.dateAt,
 		scheduleFallback: recovery.schedule?.fallback ?? undefined,
+		includeSchedule: !isHistoricalAccountSubscription(subscription),
 	});
 
 	return (
@@ -471,7 +470,6 @@ export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly Agen
 	const deployments = useHostedDeployments();
 	const hostedAccess = useHostedProductAccess();
 	const [showHistory, setShowHistory] = useState(false);
-	const [historyCutoffMs] = useState(Date.now);
 	const [selectedSubscription, setSelectedSubscription] =
 		useState<ComputeSubscriptionListItem | null>(null);
 	const [planChangeOpen, setPlanChangeOpen] = useState(false);
@@ -482,14 +480,10 @@ export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly Agen
 			.filter((tile) => tile.source === "on-clawdi")
 			.map((tile) => [tile.id.toLowerCase(), tile] as const),
 	);
-	const endedRows = rows.filter((subscription) =>
-		isEndedAccountSubscription(subscription, historyCutoffMs),
-	);
+	const endedRows = rows.filter(isHistoricalAccountSubscription);
 	const visibleRows = showHistory
 		? orderedRows
-		: orderedRows.filter(
-				(subscription) => !isEndedAccountSubscription(subscription, historyCutoffMs),
-			);
+		: orderedRows.filter((subscription) => !isHistoricalAccountSubscription(subscription));
 	const canLoadMore = subscriptions.hasNextPage && !subscriptions.isFetchNextPageError;
 	const historyControlVisible = endedRows.length > 0 || showHistory;
 	const blockingPlansError = shouldBlockQueryError(plans.error, plans.data) ? plans.error : null;


### PR DESCRIPTION
## Summary

- classify the server-projected `canceled` terminal state as subscription history regardless of `current_period_end`
- hide ended subscriptions by default and reveal them only through Show history
- present terminal history as `Ended` without an unverified date or duplicate ended notice
- preserve only actionable start-new guidance for subscriptions linked to a live agent

## State model

- `Active`: current and renewing
- `Canceling`: current, still usable, and shows `Ends <date>`
- `Past due`: current and recoverable
- `Ended`: terminal history, hidden by default, with no inferred schedule date

## Verification

- isolated Web typecheck
- 29 focused tests
- OSS build
- isolated Biome check
- targeted Hosted Playwright scenario (1 passed)
- `git diff --check`