### PR TITLE
fix(web): preserve exact hosted billing amounts

### DIFF
--- a/apps/web/src/hosted/billing/deploy/deploy-price-presentation.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-price-presentation.ts
@@ -3,7 +3,6 @@ import {
 	billingTermLabel,
 	billingTermSuffix,
 	formatCents,
-	formatUsd,
 	formatUsdExact,
 } from "@/hosted/billing/format";
 import type { WalletDebitSummary } from "@/hosted/billing/wallet/wallet-debit-summary";
@@ -100,6 +99,6 @@ export function walletDeployAmountPresentation({
 		detail:
 			shortfallUsd === null
 				? null
-				: `Available ${formatUsdExact(walletDebit.balanceBeforeUsd)} · short ${formatUsd(shortfallUsd)}`,
+				: `Available ${formatUsdExact(walletDebit.balanceBeforeUsd)} · short ${formatUsdExact(shortfallUsd)}`,
 	};
 }

--- a/apps/web/src/hosted/billing/format.test.ts
+++ b/apps/web/src/hosted/billing/format.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, test } from "bun:test";
-import { formatCents, formatUsd, formatUsdExact } from "@/hosted/billing/format";
+import {
+	addDecimals,
+	canonicalDecimal,
+	compareDecimals,
+	decimalRatioPercent,
+	formatCents,
+	formatUsd,
+	formatUsdExact,
+	negativeDecimalMagnitude,
+	persistedUsdToCents,
+	subtractDecimals,
+	wholeDollarTopUpCents,
+} from "@/hosted/billing/format";
 
 describe("USD formatting", () => {
 	test("formats normal numeric USD with exactly two decimal places", () => {
@@ -34,5 +46,21 @@ describe("USD formatting", () => {
 
 	test("keeps Stripe cents at two decimal places", () => {
 		expect(formatCents(1900)).toBe("$19.00");
+		expect(persistedUsdToCents("5.000000000000000000")).toBe(500);
+		expect(persistedUsdToCents("5.001000000000000000")).toBeNull();
+		expect(persistedUsdToCents("90071992547409.91")).toBe(9_007_199_254_740_991);
+		expect(persistedUsdToCents("90071992547409.92")).toBeNull();
+	});
+
+	test("does exact fixed-point money arithmetic without Number coercion", () => {
+		expect(canonicalDecimal("0009007199254740993.99500")).toBe("9007199254740993.995");
+		expect(canonicalDecimal(Number.POSITIVE_INFINITY)).toBeNull();
+		expect(compareDecimals("9007199254740993.01", "9007199254740993")).toBe(1);
+		expect(subtractDecimals("25", "19.000125")).toBe("5.999875");
+		expect(addDecimals("9007199254740993.01", "0.99")).toBe("9007199254740994");
+		expect(negativeDecimalMagnitude("-1.250500")).toBe("1.2505");
+		expect(decimalRatioPercent("1", "3")).toBe(33.33);
+		expect(decimalRatioPercent("Infinity", "3")).toBe(0);
+		expect(wholeDollarTopUpCents("25.000000000000000001", 1_000, 200_000)).toBe(2_600);
 	});
 });

--- a/apps/web/src/hosted/billing/format.ts
+++ b/apps/web/src/hosted/billing/format.ts
@@ -11,6 +11,92 @@ const DECIMAL_USD = /^([+-]?)(\d+)(?:\.(\d+))?$/;
 const USD_INPUT = /^(?:0|[1-9]\d*)(?:\.(\d{1,2}))?$/;
 const MAX_SAFE_CENTS = BigInt(Number.MAX_SAFE_INTEGER);
 
+type DecimalParts = {
+	units: bigint;
+	scale: number;
+};
+
+function decimalParts(value: string): DecimalParts | null {
+	if (!value || value.length > 64) return null;
+	const match = DECIMAL_USD.exec(value);
+	if (!match) return null;
+	const sign = match[1] === "-" ? -1n : 1n;
+	const whole = match[2] ?? "0";
+	const fraction = match[3] ?? "";
+	return {
+		units: sign * BigInt(`${whole}${fraction}`),
+		scale: fraction.length,
+	};
+}
+
+function scaledUnits(parts: DecimalParts, scale: number): bigint {
+	return parts.units * 10n ** BigInt(scale - parts.scale);
+}
+
+function decimalString(units: bigint, scale: number): string {
+	const negative = units < 0n;
+	const digits = (negative ? -units : units).toString().padStart(scale + 1, "0");
+	const whole = scale === 0 ? digits : digits.slice(0, -scale);
+	const fraction = scale === 0 ? "" : digits.slice(-scale).replace(/0+$/, "");
+	return `${negative ? "-" : ""}${whole}${fraction ? `.${fraction}` : ""}`;
+}
+
+/** Canonicalize a finite fixed-point decimal without converting through Number. */
+export function canonicalDecimal(value: unknown): string | null {
+	if (typeof value !== "string" && typeof value !== "number") return null;
+	if (typeof value === "number" && !Number.isFinite(value)) return null;
+	const parts = decimalParts(String(value));
+	return parts ? decimalString(parts.units, parts.scale) : null;
+}
+
+/** Compare two fixed-point decimals exactly. */
+export function compareDecimals(left: string, right: string): number | null {
+	const leftParts = decimalParts(left);
+	const rightParts = decimalParts(right);
+	if (!leftParts || !rightParts) return null;
+	const scale = Math.max(leftParts.scale, rightParts.scale);
+	const difference = scaledUnits(leftParts, scale) - scaledUnits(rightParts, scale);
+	return difference < 0n ? -1 : difference > 0n ? 1 : 0;
+}
+
+/** Add two fixed-point decimals exactly. */
+export function addDecimals(left: string, right: string): string | null {
+	const leftParts = decimalParts(left);
+	const rightParts = decimalParts(right);
+	if (!leftParts || !rightParts) return null;
+	const scale = Math.max(leftParts.scale, rightParts.scale);
+	return decimalString(scaledUnits(leftParts, scale) + scaledUnits(rightParts, scale), scale);
+}
+
+/** Subtract two fixed-point decimals exactly. */
+export function subtractDecimals(left: string, right: string): string | null {
+	const leftParts = decimalParts(left);
+	const rightParts = decimalParts(right);
+	if (!leftParts || !rightParts) return null;
+	const scale = Math.max(leftParts.scale, rightParts.scale);
+	return decimalString(scaledUnits(leftParts, scale) - scaledUnits(rightParts, scale), scale);
+}
+
+/** Return the exact positive magnitude, or null for zero, positive, or invalid input. */
+export function negativeDecimalMagnitude(value: string): string | null {
+	const parts = decimalParts(value);
+	return parts && parts.units < 0n ? decimalString(-parts.units, parts.scale) : null;
+}
+
+/** Return a bounded percentage for presentation without floating-point money math. */
+export function decimalRatioPercent(value: string, maximum: string): number {
+	const valueParts = decimalParts(value);
+	const maximumParts = decimalParts(maximum);
+	if (!valueParts || !maximumParts || valueParts.units <= 0n || maximumParts.units <= 0n) {
+		return 0;
+	}
+	const scale = Math.max(valueParts.scale, maximumParts.scale);
+	const numerator = scaledUnits(valueParts, scale);
+	const denominator = scaledUnits(maximumParts, scale);
+	const basisPoints = (numerator * 10_000n) / denominator;
+	return Number(basisPoints > 10_000n ? 10_000n : basisPoints) / 100;
+}
+
 function incrementDecimalDigits(digits: string): string {
 	const incremented = [...digits];
 	for (let index = incremented.length - 1; index >= 0; index -= 1) {
@@ -89,6 +175,42 @@ export function usdInputToCents(value: string): number | null {
 	const fraction = (match[1] ?? "").padEnd(2, "0");
 	const cents = BigInt(whole) * 100n + BigInt(fraction);
 	return cents > 0n && cents <= MAX_SAFE_CENTS ? Number(cents) : null;
+}
+
+/** Parse a positive backend USD decimal when all precision beyond cents is zero. */
+export function persistedUsdToCents(value: string): number | null {
+	const parts = decimalParts(value);
+	if (!parts || parts.units <= 0n) return null;
+	let cents: bigint;
+	if (parts.scale <= 2) {
+		cents = parts.units * 10n ** BigInt(2 - parts.scale);
+	} else {
+		const subcentScale = 10n ** BigInt(parts.scale - 2);
+		if (parts.units % subcentScale !== 0n) return null;
+		cents = parts.units / subcentScale;
+	}
+	return cents <= MAX_SAFE_CENTS ? Number(cents) : null;
+}
+
+/** Round a positive exact USD shortfall up to whole dollars and return cents. */
+export function wholeDollarTopUpCents(
+	shortfallUsd: string | null,
+	minimumCents: number,
+	maximumCents: number,
+): number | null {
+	if (shortfallUsd === null) return null;
+	const parts = decimalParts(shortfallUsd);
+	if (!parts || parts.units <= 0n) return null;
+	const divisor = 10n ** BigInt(parts.scale);
+	const wholeDollars = (parts.units + divisor - 1n) / divisor;
+	const cents = wholeDollars * 100n;
+	return Number(
+		cents < BigInt(minimumCents)
+			? BigInt(minimumCents)
+			: cents > BigInt(maximumCents)
+				? BigInt(maximumCents)
+				: cents,
+	);
 }
 
 /** "$57 / 3 mo" style term label. */

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
@@ -9,6 +9,7 @@ import {
 	isPaymentMethodRequiredError,
 	PlanChangeTerminalError,
 } from "@/hosted/billing/errors";
+import { subtractDecimals } from "@/hosted/billing/format";
 import { COMPUTE_BASIC_SLUG, COMPUTE_PERFORMANCE_SLUG } from "./subscription-utils";
 
 export type PlanChangeSelection = Omit<
@@ -17,8 +18,6 @@ export type PlanChangeSelection = Omit<
 > & {
 	funding_source: NonNullable<ComputePlanChangeQuoteRequest["funding_source"]>;
 };
-
-const UNSIGNED_DECIMAL = /^(\d+)(?:\.(\d+))?$/;
 
 type HostedComputeUpgradeIneligibilityReason = NonNullable<
 	HostedDeployment["upgrade_eligibility"]["reason"]
@@ -93,39 +92,13 @@ function performanceUpgradeEligibilityReasonCopy(reason: string | null): string 
 		: UNKNOWN_PERFORMANCE_UPGRADE_UNAVAILABLE_COPY;
 }
 
-function decimalParts(value: string): { units: bigint; scale: number } | null {
-	const match = UNSIGNED_DECIMAL.exec(value.trim());
-	if (!match) return null;
-	const whole = match[1] ?? "0";
-	const fraction = match[2] ?? "";
-	return {
-		units: BigInt(`${whole}${fraction}`),
-		scale: fraction.length,
-	};
-}
-
-function scaledUnits(parts: { units: bigint; scale: number }, scale: number): bigint {
-	return parts.units * 10n ** BigInt(scale - parts.scale);
-}
-
-function decimalString(units: bigint, scale: number): string {
-	const negative = units < 0n;
-	const digits = (negative ? -units : units).toString().padStart(scale + 1, "0");
-	const whole = scale === 0 ? digits : digits.slice(0, -scale);
-	const fraction = scale === 0 ? "" : digits.slice(-scale).replace(/0+$/, "");
-	return `${negative ? "-" : ""}${whole}${fraction ? `.${fraction}` : ""}`;
-}
-
 /** Subtract a decimal-string debit without rounding through a JavaScript number. */
 export function walletBalanceAfterDebit(
 	balanceBeforeUsd: string,
 	debitAmountUsd: string,
 ): string | null {
-	const balance = decimalParts(balanceBeforeUsd);
-	const debit = decimalParts(debitAmountUsd);
-	if (!balance || !debit) return null;
-	const scale = Math.max(balance.scale, debit.scale);
-	return decimalString(scaledUnits(balance, scale) - scaledUnits(debit, scale), scale);
+	if (/^[+-]/.test(balanceBeforeUsd) || /^[+-]/.test(debitAmountUsd)) return null;
+	return subtractDecimals(balanceBeforeUsd, debitAmountUsd);
 }
 
 export function defaultPlanChangeSelection(

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -21,7 +21,12 @@ import { Spinner } from "@/components/ui/spinner";
 import { UsageSkeleton } from "@/hosted/billing/components/state-views";
 import type { HostedUsageSummary, ManagedModelCatalogItem } from "@/hosted/billing/contracts";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
-import { formatUsdExact } from "@/hosted/billing/format";
+import {
+	addDecimals,
+	compareDecimals,
+	decimalRatioPercent,
+	formatUsdExact,
+} from "@/hosted/billing/format";
 import { useManagedModelCatalog, useUsage } from "@/hosted/billing/hooks";
 import { useUserAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { ProviderIcon } from "@/hosted/v2/ai-providers/ai-providers-ui";
@@ -70,23 +75,8 @@ function compareStableText(left: string, right: string): number {
 	return 0;
 }
 
-function decimalUsdParts(value: string): readonly [string, string] {
-	const match = /^\+?(\d+)(?:\.(\d+))?$/.exec(value.trim());
-	if (!match) return ["0", ""];
-	return [(match[1] ?? "0").replace(/^0+(?=\d)/, ""), (match[2] ?? "").replace(/0+$/, "")];
-}
-
 function compareSpendDescending(left: string, right: string): number {
-	const [leftWhole, leftFraction] = decimalUsdParts(left);
-	const [rightWhole, rightFraction] = decimalUsdParts(right);
-	if (leftWhole.length !== rightWhole.length) return rightWhole.length - leftWhole.length;
-	const wholeOrder = compareStableText(leftWhole, rightWhole);
-	if (wholeOrder !== 0) return -wholeOrder;
-	const fractionLength = Math.max(leftFraction.length, rightFraction.length);
-	return -compareStableText(
-		leftFraction.padEnd(fractionLength, "0"),
-		rightFraction.padEnd(fractionLength, "0"),
-	);
+	return -(compareDecimals(left, right) ?? 0);
 }
 
 function sortModelBreakdown(left: ModelBreakdown, right: ModelBreakdown): number {
@@ -569,26 +559,29 @@ export function UsageSummaryView({
 }
 
 function DailyUsageChart({ days }: { days: readonly DayBreakdown[] }) {
-	const amounts = days.map((day) => Number(day.amount_usd));
-	const maxAmount = Math.max(...amounts, 0);
-	const totalAmount = amounts.reduce((total, amount) => total + amount, 0);
+	const maxAmount = days.reduce(
+		(maximum, day) => (compareDecimals(day.amount_usd, maximum) === 1 ? day.amount_usd : maximum),
+		"0",
+	);
+	const totalAmount = days.reduce((total, day) => addDecimals(total, day.amount_usd) ?? total, "0");
 	const firstDay = days[0];
 	const lastDay = days.at(-1);
 
 	return (
 		<div
 			role="img"
-			aria-label={`Daily spend from ${firstDay ? formatUsageDate(firstDay.date) : "the start of the window"} to ${lastDay ? formatUsageDate(lastDay.date) : "the end of the window"}: ${formatUsdExact(String(totalAmount))} total.`}
+			aria-label={`Daily spend from ${firstDay ? formatUsageDate(firstDay.date) : "the start of the window"} to ${lastDay ? formatUsageDate(lastDay.date) : "the end of the window"}: ${formatUsdExact(totalAmount)} total.`}
 		>
 			<div className="mb-3 flex justify-end text-xs text-muted-foreground">
 				<span className="font-medium tabular-nums text-foreground">
-					Peak {formatUsdExact(String(maxAmount))}
+					Peak {formatUsdExact(maxAmount)}
 				</span>
 			</div>
 			<div className="flex h-36 items-end gap-px border-b sm:h-44 sm:gap-1" aria-hidden="true">
-				{days.map((day, index) => {
-					const amount = amounts[index] ?? 0;
-					const height = maxAmount > 0 ? (amount / maxAmount) * 100 : 0;
+				{days.map((day) => {
+					const amount = day.amount_usd;
+					const positive = compareDecimals(amount, "0") === 1;
+					const height = decimalRatioPercent(amount, maxAmount);
 					const label = `${formatUsageDate(day.date)} · ${formatUsdExact(day.amount_usd)}`;
 					return (
 						<div
@@ -598,11 +591,11 @@ function DailyUsageChart({ days }: { days: readonly DayBreakdown[] }) {
 						>
 							<div
 								className={
-									amount > 0
+									positive
 										? "w-full rounded-t-sm bg-primary/75 group-hover:bg-primary"
 										: "h-0.5 w-full bg-muted"
 								}
-								style={amount > 0 ? { height: `${height}%`, minHeight: "2px" } : undefined}
+								style={positive ? { height: `${height}%`, minHeight: "2px" } : undefined}
 							/>
 						</div>
 					);

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.test.ts
@@ -69,7 +69,7 @@ const wallet: WalletState = {
 	auto_reload_amount_policy: "wallet_reload_configured_plus_negative_balance_v1",
 	auto_reload_consent_version: null,
 	auto_reload_consented_at: null,
-	auto_reload_threshold_usd: "5",
+	auto_reload_threshold_usd: "5.000000000000000000",
 	auto_reload_amount_cents: 2_500,
 	auto_reload_monthly_cap_cents: 10_000,
 	auto_reload_monthly_spent_cents: 2_500,
@@ -106,6 +106,7 @@ describe("auto-reload explicit-save state", () => {
 	test("includes all parameters when disabling auto-reload", () => {
 		const draft = autoReloadDraftFromWallet({ ...wallet, auto_reload_enabled: true });
 
+		expect(draft.threshold).toBe("5");
 		expect(autoReloadRequest({ ...draft, enabled: false })).toEqual({
 			auto_reload_enabled: false,
 			auto_reload_threshold_usd: "5",

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.ts
@@ -8,7 +8,7 @@ import {
 	billingErrorDetail,
 	normalizeBillingError,
 } from "@/hosted/billing/errors";
-import { usdInputToCents } from "@/hosted/billing/format";
+import { persistedUsdToCents, usdInputToCents } from "@/hosted/billing/format";
 import type { WalletCacheSnapshot } from "@/hosted/billing/wallet/wallet-cache";
 import {
 	AUTORELOAD_AMOUNT_MAX_CENTS,
@@ -150,10 +150,10 @@ export function autoReloadFormState({
 
 export function autoReloadDraftFromWallet(wallet: WalletCacheSnapshot): AutoReloadDraft {
 	const monthlyLimitEnabled = wallet.auto_reload_monthly_cap_cents !== 0;
-	const thresholdCents = usdInputToCents(wallet.auto_reload_threshold_usd);
+	const thresholdCents = persistedUsdToCents(wallet.auto_reload_threshold_usd);
 	return {
 		enabled: wallet.auto_reload_enabled,
-		threshold: thresholdCents === null ? wallet.auto_reload_threshold_usd : dollars(thresholdCents),
+		threshold: thresholdCents === null ? "" : dollars(thresholdCents),
 		amount: dollars(wallet.auto_reload_amount_cents),
 		cap: dollars(
 			monthlyLimitEnabled ? wallet.auto_reload_monthly_cap_cents : wallet.auto_reload_amount_cents,

--- a/apps/web/src/hosted/billing/wallet/auto-reload-setup-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-setup-dialog.tsx
@@ -18,7 +18,7 @@ import type {
 	WalletState,
 } from "@/hosted/billing/contracts";
 import { normalizeBillingError } from "@/hosted/billing/errors";
-import { formatCents, usdInputToCents } from "@/hosted/billing/format";
+import { formatCents, persistedUsdToCents, usdInputToCents } from "@/hosted/billing/format";
 import {
 	type IdempotencyAttempt,
 	idempotencyAttemptFor,
@@ -54,7 +54,7 @@ function setupResultMatchesRequest(
 		result.currency === "usd" &&
 		result.consent_version === request.consent_version &&
 		result.amount_policy === amountPolicy &&
-		usdInputToCents(result.auto_reload_threshold_usd) ===
+		persistedUsdToCents(result.auto_reload_threshold_usd) ===
 			usdInputToCents(String(request.auto_reload_threshold_usd)) &&
 		result.auto_reload_amount_cents === request.auto_reload_amount_cents &&
 		result.auto_reload_monthly_cap_cents === request.auto_reload_monthly_cap_cents &&

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts
@@ -187,15 +187,16 @@ describe("walletTopupCreditIsApplied", () => {
 
 describe("topUpAmountCentsForUsdShortfall", () => {
 	test("rounds up to whole dollars and clamps to the allowed top-up range", () => {
-		expect(topUpAmountCentsForUsdShortfall(4)).toBe(1_000);
-		expect(topUpAmountCentsForUsdShortfall(14)).toBe(1_400);
-		expect(topUpAmountCentsForUsdShortfall(25.001)).toBe(2_600);
-		expect(topUpAmountCentsForUsdShortfall(2_500)).toBe(200_000);
+		expect(topUpAmountCentsForUsdShortfall("4")).toBe(1_000);
+		expect(topUpAmountCentsForUsdShortfall("14")).toBe(1_400);
+		expect(topUpAmountCentsForUsdShortfall("25.001")).toBe(2_600);
+		expect(topUpAmountCentsForUsdShortfall("25.000000000000000001")).toBe(2_600);
+		expect(topUpAmountCentsForUsdShortfall("2500")).toBe(200_000);
 	});
 
 	test("ignores missing or invalid USD inputs", () => {
 		expect(topUpAmountCentsForUsdShortfall(null)).toBeNull();
-		expect(topUpAmountCentsForUsdShortfall(Number.NaN)).toBeNull();
+		expect(topUpAmountCentsForUsdShortfall("NaN")).toBeNull();
 	});
 });
 

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
@@ -1,5 +1,6 @@
 import type { InfiniteData, QueryClient } from "@tanstack/react-query";
 import type { WalletTopupResult, WalletTransaction } from "@/hosted/billing/contracts";
+import { wholeDollarTopUpCents } from "@/hosted/billing/format";
 import { billingKeys } from "@/hosted/billing/query-keys";
 import {
 	type PaymentIntentClientSecret,
@@ -41,12 +42,8 @@ export function validTopUpAmountCents(amountCents: number): boolean {
 }
 
 /** Convert a USD shortfall into the smallest whole-dollar top-up that covers it. */
-export function topUpAmountCentsForUsdShortfall(shortfallUsd: number | null): number | null {
-	if (shortfallUsd === null || !Number.isFinite(shortfallUsd) || shortfallUsd <= 0) {
-		return null;
-	}
-	const roundedCents = Math.ceil(shortfallUsd) * TOPUP_INCREMENT_CENTS;
-	return Math.min(TOPUP_MAX_CENTS, Math.max(TOPUP_MIN_CENTS, roundedCents));
+export function topUpAmountCentsForUsdShortfall(shortfallUsd: string | null): number | null {
+	return wholeDollarTopUpCents(shortfallUsd, TOPUP_MIN_CENTS, TOPUP_MAX_CENTS);
 }
 
 export function invalidateWalletData(queryClient: QueryClient): void {

--- a/apps/web/src/hosted/billing/wallet/wallet-constants.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-constants.ts
@@ -1,4 +1,4 @@
-import { formatCents } from "@/hosted/billing/format";
+import { compareDecimals, formatCents } from "@/hosted/billing/format";
 
 /**
  * Wallet UI bounds. These mirror the hosted API validation so the form catches
@@ -33,6 +33,5 @@ export const AUTORELOAD_AMOUNT_RANGE_LABEL = amountRangeLabel(
 export const LOW_BALANCE_USD = 2;
 
 export function isLowBalance(balanceUsd: string): boolean {
-	const balance = Number(balanceUsd);
-	return Number.isFinite(balance) && balance < LOW_BALANCE_USD;
+	return compareDecimals(balanceUsd, String(LOW_BALANCE_USD)) === -1;
 }

--- a/apps/web/src/hosted/billing/wallet/wallet-debit-summary.test.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-debit-summary.test.ts
@@ -12,7 +12,10 @@ function summary(overrides: Partial<WalletDebitSummary> = {}): WalletDebitSummar
 
 describe("walletDebitShortfallUsd", () => {
 	test("derives an exact decimal shortfall from the presentation model", () => {
-		expect(walletDebitShortfallUsd(summary({ balanceAfterUsd: "-1.2505" }))).toBe(1.2505);
+		expect(walletDebitShortfallUsd(summary({ balanceAfterUsd: "-1.2505" }))).toBe("1.2505");
+		expect(
+			walletDebitShortfallUsd(summary({ balanceAfterUsd: "-9007199254740993.000000000000000001" })),
+		).toBe("9007199254740993.000000000000000001");
 		expect(walletDebitShortfallUsd(summary())).toBeNull();
 	});
 });

--- a/apps/web/src/hosted/billing/wallet/wallet-debit-summary.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-debit-summary.ts
@@ -1,3 +1,5 @@
+import { negativeDecimalMagnitude } from "@/hosted/billing/format";
+
 export type WalletDebitSummary = {
 	balanceBeforeUsd: string;
 	debitAmountUsd: string;
@@ -6,8 +8,7 @@ export type WalletDebitSummary = {
 
 export function walletDebitShortfallUsd(
 	summary: WalletDebitSummary | null | undefined,
-): number | null {
+): string | null {
 	if (!summary) return null;
-	const balanceAfter = Number(summary.balanceAfterUsd);
-	return Number.isFinite(balanceAfter) && balanceAfter < 0 ? -balanceAfter : null;
+	return negativeDecimalMagnitude(summary.balanceAfterUsd);
 }

--- a/apps/web/src/hosted/billing/wallet/wallet-funding.test.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-funding.test.ts
@@ -13,7 +13,7 @@ describe("classifyWalletFundingError", () => {
 				classifyWalletFundingError(
 					billingError({ code, shortfall_usd: code === "insufficient_balance" ? 12.5 : "12.50" }),
 				),
-			).toEqual({ kind: "insufficient_balance", shortfallUsd: 12.5 });
+			).toEqual({ kind: "insufficient_balance", shortfallUsd: "12.5" });
 		}
 	});
 
@@ -39,8 +39,11 @@ describe("classifyWalletFundingError", () => {
 
 describe("decimalUsd", () => {
 	test("accepts finite non-negative decimal strings and numbers only", () => {
-		expect(decimalUsd("25.01")).toBe(25.01);
-		expect(decimalUsd(0)).toBe(0);
+		expect(decimalUsd("25.0100")).toBe("25.01");
+		expect(decimalUsd("9007199254740993.000000000000000001")).toBe(
+			"9007199254740993.000000000000000001",
+		);
+		expect(decimalUsd(0)).toBe("0");
 		expect(decimalUsd(-1)).toBeNull();
 		expect(decimalUsd(Number.NaN)).toBeNull();
 		expect(decimalUsd(null)).toBeNull();

--- a/apps/web/src/hosted/billing/wallet/wallet-funding.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-funding.ts
@@ -3,10 +3,11 @@
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { billingErrorDetail } from "@/hosted/billing/errors";
+import { canonicalDecimal, compareDecimals } from "@/hosted/billing/format";
 import { topUpAmountCentsForUsdShortfall } from "@/hosted/billing/wallet/top-up-dialog.logic";
 
 export type WalletFundingError =
-	| { kind: "insufficient_balance"; shortfallUsd: number | null }
+	| { kind: "insufficient_balance"; shortfallUsd: string | null }
 	| { kind: "open_refund_debt"; shortfallUsd: null }
 	| { kind: "other"; shortfallUsd: null };
 
@@ -20,10 +21,9 @@ export const SUBSCRIPTION_WALLET_FUNDING_ERROR_COPY: WalletFundingErrorCopy = {
 	refundDebt: "Top up before starting this wallet subscription.",
 };
 
-export function decimalUsd(value: unknown): number | null {
-	if (typeof value !== "string" && typeof value !== "number") return null;
-	const parsed = Number(value);
-	return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+export function decimalUsd(value: unknown): string | null {
+	const parsed = canonicalDecimal(value);
+	return parsed !== null && compareDecimals(parsed, "0") !== -1 ? parsed : null;
 }
 
 export function classifyWalletFundingError(error: unknown): WalletFundingError {
@@ -49,7 +49,7 @@ export function useWalletTopUpDialog(errorCopy: WalletFundingErrorCopy) {
 		(nextOpen: boolean) => (nextOpen ? setOpen(true) : reset()),
 		[reset],
 	);
-	const show = useCallback((shortfallUsd: number | null = null) => {
+	const show = useCallback((shortfallUsd: string | null = null) => {
 		setInitialAmountCents(topUpAmountCentsForUsdShortfall(shortfallUsd));
 		setOpen(true);
 	}, []);


### PR DESCRIPTION
## Summary
- centralize exact fixed-point decimal operations for Hosted billing UI
- display canonical wallet thresholds instead of database scale padding such as `5.000000000000000000`
- remove JavaScript Number coercion from usage totals, wallet shortfalls, low-balance checks, plan changes, and top-up suggestions
- reject malformed persisted auto-reload thresholds instead of echoing invalid values

## Scope
Hosted v2 billing surfaces only. No v1/legacy UI or generated client changes.

## Verification
- `bash scripts/test.sh web`: passed after rebase, including TypeScript, full Web tests, Biome, and production build
- generated deploy client and `bun.lock`: zero diff
- `git diff --check`: passed