### PR TITLE
fix(runtime): keep Codex cold boot wire compatible

### DIFF
--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -50,12 +50,10 @@ from app.schemas.runtime import (
     HostedRuntimeTools,
     PersistedHostedRuntimeSkills,
     is_canonical_secret_ref,
-    parse_exact_semver,
     validate_clawdi_cli_package_spec,
     validate_hosted_runtime_desired_state,
     validate_hosted_runtime_mcp_desired_state,
 )
-from app.schemas.runtime_observed import HostedRuntimeObservedV2
 from app.services.channels import (
     HOSTED_RUNTIME_SINGLE_ACCOUNT_PROVIDERS,
     channel_runtime_account_key,
@@ -76,7 +74,6 @@ from app.services.project_runtime_skills import (
     agent_supports_project_skills,
     project_skill_file_signature,
 )
-from app.services.runtime_generation import resolve_runtime_apply_generation
 from app.services.url_security import UnsafePublicHttpsUrlError, validate_public_https_url
 from app.services.vault_crypto import decrypt
 from app.services.whatsapp_baileys import (
@@ -90,8 +87,7 @@ RUNTIME_BUNDLE_V2_MEDIA_TYPE = "application/vnd.clawdi.runtime-bundle.v2+json"
 RUNTIME_BUNDLE_V2_SCHEMA_VERSION = "clawdi.hosted-runtime.bundle.v2"
 _SUPPORTED_RUNTIMES = {"hermes", "openclaw"}
 _MANAGED_PROVIDER_RUNTIME_ENV = "CLAWDI_AI_API_KEY"
-_CODEX_TOOL_LEGACY_RUNTIME_ENV = "OPENAI_API_KEY"
-_CODEX_TOOL_CANONICAL_ENV_MINIMUM_CLI_VERSION = (0, 13, 69)
+_CODEX_TOOL_RUNTIME_ENV = "OPENAI_API_KEY"
 _CODEX_TOOL_SECRET_REF = "secret://tool.codex.apiKey"
 _CODEX_TOOL_API_MODE = "openai_responses"
 _CODEX_PROVIDER_SOURCE_API_MODES = {"openai_chat", "openai_responses"}
@@ -111,47 +107,6 @@ def expected_runtime_bundle_v2_etag(source_revision: str) -> str:
     if not re.fullmatch(r"[0-9a-f]{64}", source_revision):
         raise ValueError("runtime bundle source revision must be a SHA-256 digest")
     return f'"sha256:{source_revision}"'
-
-
-def _codex_tool_runtime_env(
-    state: HostedRuntimeState,
-    observation: HostedRuntimeConfigObservation | None,
-) -> str:
-    desired_version = state.cli_package_spec.removeprefix("clawdi@")
-    parsed_version = parse_exact_semver(desired_version)
-    if parsed_version is None or (
-        parsed_version[:3] < _CODEX_TOOL_CANONICAL_ENV_MINIMUM_CLI_VERSION
-        or (
-            parsed_version[:3] == _CODEX_TOOL_CANONICAL_ENV_MINIMUM_CLI_VERSION
-            and parsed_version[3]
-        )
-    ):
-        return _CODEX_TOOL_LEGACY_RUNTIME_ENV
-    if observation is None:
-        return _CODEX_TOOL_LEGACY_RUNTIME_ENV
-    try:
-        observed = HostedRuntimeObservedV2.model_validate(observation.diagnostics)
-    except ValidationError:
-        return _CODEX_TOOL_LEGACY_RUNTIME_ENV
-    expected_generation = resolve_runtime_apply_generation(
-        generation=state.generation,
-        apply_generation=state.apply_generation,
-    )
-    # The env-name change creates the next source revision, so gate only on the
-    # last applied record's internal identity instead of this render's revision.
-    if not (
-        observed.status == "ok"
-        and observed.converge_error is None
-        and observed.active_cli_version == desired_version
-        and observed.applied is not None
-        and observed.applied.instance_id == state.instance_id
-        and observed.applied.generation == expected_generation
-        and observation.observed_config_generation == expected_generation
-        and observation.observed_manifest_etag == observed.applied.etag
-        and observation.observed_source_revision == observed.applied.source_revision
-    ):
-        return _CODEX_TOOL_LEGACY_RUNTIME_ENV
-    return _MANAGED_PROVIDER_RUNTIME_ENV
 
 
 @dataclass(frozen=True)
@@ -780,7 +735,7 @@ def render_runtime_source(
         "baseUrl": codex_provider_material.get("baseUrl"),
         "apiMode": _CODEX_TOOL_API_MODE,
         "managed_by": codex_provider_material.get("managed_by"),
-        "runtimeEnvName": _codex_tool_runtime_env(state, row.observation),
+        "runtimeEnvName": _CODEX_TOOL_RUNTIME_ENV,
         "apiKeySecretRef": codex_provider_material.get("apiKeySecretRef"),
     }
     try:

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -313,19 +313,16 @@ def _render(batch: RuntimeSourceBatch):
 
 def _set_healthy_cli_observation(
     batch: RuntimeSourceBatch,
-    *,
-    desired: str,
-    active: str | None = None,
-    source_revision: str = "a" * 64,
-) -> HostedRuntimeConfigObservation:
+) -> None:
     row = batch.rows[ENV_ID]
     assert row.state is not None
-    row.state.cli_package_spec = desired
+    row.state.cli_package_spec = "clawdi@0.13.69"
     expected_generation = (
         row.state.apply_generation
         if row.state.apply_generation is not None
         else row.state.generation
     )
+    source_revision = "a" * 64
     etag = expected_runtime_bundle_v2_etag(source_revision)
     observation = HostedRuntimeConfigObservation(
         environment_id=ENV_ID,
@@ -337,7 +334,7 @@ def _set_healthy_cli_observation(
             "reportedAt": "2026-07-13T00:00:00Z",
             "runtimeMode": "hosted",
             "status": "ok",
-            "activeCliVersion": active or desired.removeprefix("clawdi@"),
+            "activeCliVersion": "0.13.69",
             "applied": {
                 "etag": etag,
                 "sourceRevision": source_revision,
@@ -351,11 +348,6 @@ def _set_healthy_cli_observation(
         },
     )
     batch.rows[ENV_ID] = RuntimeSourceRow(row.environment, row.state, observation)
-    return observation
-
-
-def _codex_runtime_env(batch: RuntimeSourceBatch) -> str:
-    return _render(batch).manifest["terminalTooling"]["codex"]["provider"]["runtimeEnvName"]
 
 
 def test_runtime_source_revision_uses_only_projected_descriptor_and_secret_sources() -> None:
@@ -756,127 +748,12 @@ def test_codex_tool_projection_rejects_invalid_fixed_fields(field: str, value: s
         HostedCodexProviderProjection.model_validate(projection)
 
 
-@pytest.mark.parametrize(
-    ("desired", "active", "expected"),
-    [
-        ("0.13.68", "0.13.68", "OPENAI_API_KEY"),
-        ("0.13.69-rc.1", "0.13.69-rc.1", "OPENAI_API_KEY"),
-        ("0.13.69", "0.13.68", "OPENAI_API_KEY"),
-        ("0.13.69", "0.13.69", "CLAWDI_AI_API_KEY"),
-        ("0.14.0-rc.1", "0.14.0-rc.1", "CLAWDI_AI_API_KEY"),
-        ("0.13.68", "0.14.0", "OPENAI_API_KEY"),
-    ],
-)
-def test_codex_tool_env_respects_cli_version_boundary(
-    desired: str,
-    active: str,
-    expected: str,
-) -> None:
+def test_codex_tool_env_stays_bootstrap_compatible_after_managed_cli_converges() -> None:
     batch = _batch()
-    _set_healthy_cli_observation(
-        batch,
-        desired=f"clawdi@{desired}",
-        active=active,
-    )
+    _set_healthy_cli_observation(batch)
 
-    assert _codex_runtime_env(batch) == expected
-
-
-def test_codex_tool_env_rejects_compatible_installed_cli_until_it_is_running() -> None:
-    batch = _batch()
-    observation = _set_healthy_cli_observation(
-        batch,
-        desired="clawdi@0.13.69",
-        active="0.13.68",
-    )
-    assert isinstance(observation.diagnostics, dict)
-    observation.diagnostics["cli"] = {
-        "status": "installed",
-        "source": "npm",
-        "packageSpec": "clawdi@0.13.69",
-        "registry": "https://registry.npmjs.org",
-        "activePath": "/test/managed/clawdi",
-        "activeTarget": "/test/managed/packages/0.13.69/clawdi",
-        "version": "0.13.69",
-    }
-
-    assert observation.diagnostics["activeCliVersion"] == "0.13.68"
-    assert _codex_runtime_env(batch) == "OPENAI_API_KEY"
-
-
-def test_codex_tool_env_stays_legacy_until_new_cli_is_observed() -> None:
-    missing = _batch()
-    assert missing.rows[ENV_ID].state is not None
-    missing.rows[ENV_ID].state.cli_package_spec = "clawdi@0.13.69"
-    invalid = _batch()
-    invalid_observation = _set_healthy_cli_observation(invalid, desired="clawdi@0.13.69")
-    invalid_observation.diagnostics = {"schemaVersion": "clawdi.hostedRuntimeObserved.v2"}
-
-    assert [_codex_runtime_env(batch) for batch in (missing, invalid)] == [
-        "OPENAI_API_KEY",
-        "OPENAI_API_KEY",
-    ]
-
-
-@pytest.mark.parametrize(
-    ("diagnostics_update", "applied_update", "observation_update"),
-    [
-        ({"status": "error"}, {}, {}),
-        ({"convergeError": "apply failed"}, {}, {}),
-        ({"applied": None}, {}, {}),
-        ({}, {"instanceId": "hri_previous"}, {}),
-        ({}, {"generation": 0}, {}),
-        ({}, {}, {"observed_config_generation": 0}),
-        ({}, {}, {"observed_manifest_etag": expected_runtime_bundle_v2_etag("b" * 64)}),
-        ({}, {}, {"observed_source_revision": "b" * 64}),
-    ],
-)
-def test_codex_tool_env_rejects_unhealthy_or_inconsistent_observations(
-    diagnostics_update: dict[str, object],
-    applied_update: dict[str, object],
-    observation_update: dict[str, object],
-) -> None:
-    batch = _batch()
-    observation = _set_healthy_cli_observation(batch, desired="clawdi@0.13.69")
-    assert isinstance(observation.diagnostics, dict)
-    applied = observation.diagnostics["applied"]
-    observation.diagnostics.update(diagnostics_update)
-    if applied_update:
-        assert isinstance(applied, dict)
-        applied.update(applied_update)
-    for field, value in observation_update.items():
-        setattr(observation, field, value)
-
-    assert _codex_runtime_env(batch) == "OPENAI_API_KEY"
-
-
-def test_codex_tool_env_cutover_reaches_a_stable_source_revision() -> None:
-    batch = _batch()
-    assert batch.rows[ENV_ID].state is not None
-    batch.rows[ENV_ID].state.cli_package_spec = "clawdi@0.13.69"
-    legacy = _render(batch)
-    assert _codex_runtime_env(batch) == "OPENAI_API_KEY"
-
-    observation = _set_healthy_cli_observation(
-        batch,
-        desired="clawdi@0.13.69",
-        source_revision=legacy.source_revision,
-    )
-    canonical = _render(batch)
-    assert canonical.source_revision != legacy.source_revision
-    assert observation.observed_source_revision == legacy.source_revision
-    assert observation.observed_source_revision != canonical.source_revision
-    assert _codex_runtime_env(batch) == "CLAWDI_AI_API_KEY"
-    assert _render(batch).source_revision == canonical.source_revision
-
-    assert isinstance(observation.diagnostics, dict)
-    applied = observation.diagnostics["applied"]
-    assert isinstance(applied, dict)
-    canonical_etag = expected_runtime_bundle_v2_etag(canonical.source_revision)
-    applied.update({"etag": canonical_etag, "sourceRevision": canonical.source_revision})
-    observation.observed_manifest_etag = canonical_etag
-    observation.observed_source_revision = canonical.source_revision
-    assert _render(batch).source_revision == canonical.source_revision
+    provider = _render(batch).manifest["terminalTooling"]["codex"]["provider"]
+    assert provider["runtimeEnvName"] == "OPENAI_API_KEY"
 
 
 def test_shared_managed_provider_material_has_distinct_codex_wire_mode() -> None:

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -574,23 +574,6 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
         applied_generation=4,
         applied_instance_id="iid-observed-api",
     )
-    heartbeat = await client.post(
-        f"/v1/agents/{env_id}/sync-heartbeat",
-        json={"queue_depth": 1, "runtime_observed": observed},
-    )
-    assert heartbeat.status_code == 204, heartbeat.text
-
-    transitioning = (await client.get(f"/v1/environments/{env_id}/runtime-observed")).json()
-    canonical_source_revision = transitioning["desired"]["desired_source_revision"]
-    assert canonical_source_revision != desired_source_revision
-    assert transitioning["health"]["status"] == "unknown"
-
-    observed = _runtime_observed(
-        source_revision=canonical_source_revision,
-        active_cli_version="1.2.5-test",
-        applied_generation=4,
-        applied_instance_id="iid-observed-api",
-    )
     received_at_lower_bound = datetime.now(UTC)
     heartbeat = await client.post(
         f"/v1/agents/{env_id}/sync-heartbeat",
@@ -632,9 +615,9 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
     ) == datetime.fromisoformat(observed["reportedAt"])
     assert payload["observed"]["observed_config_generation"] == 4
     assert payload["observed"]["observed_manifest_etag"] == expected_runtime_bundle_v2_etag(
-        canonical_source_revision
+        desired_source_revision
     )
-    assert payload["observed"]["observed_source_revision"] == canonical_source_revision
+    assert payload["observed"]["observed_source_revision"] == desired_source_revision
     assert payload["observed"]["diagnostics"]["schemaVersion"] == (
         "clawdi.hostedRuntimeObserved.v2"
     )

--- a/docs/ai-provider-agent-contract-audit.md
+++ b/docs/ai-provider-agent-contract-audit.md
@@ -80,14 +80,11 @@ is the first picker-visible model after
 so it is the current upstream-owned default. Clawdi does not encode that model
 choice.
 
-Deployment is two-stage. Phase A publishes the dual-read/canonical-write
-`clawdi@0.13.69`; the backend continues to emit legacy `OPENAI_API_KEY`. Phase B
-is a separate backend change gated on the exact CLI being published, desired
-package specs advancing, and `activeCliVersion` proving that the current running
-CLI is that exact version. Installed CLI diagnostics are not execution authority.
-The current flow parses the strict manifest before `applyRuntimeCliDesiredState`,
-so enabling canonical backend emission earlier would strand an older CLI before
-self-upgrade.
+The backend always emits terminal-Codex `OPENAI_API_KEY`; the CLI accepts that
+v1 compatibility input and writes `CLAWDI_AI_API_KEY` locally. The immutable
+image bootstrap CLI parses the strict manifest before a managed CLI can upgrade
+or start, so desired package specs and managed observations cannot authorize a
+wire-name change. That requires an explicit immutable bootstrap capability.
 
 ## Hermes
 

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -648,25 +648,13 @@ setting analogous to OpenClaw or Hermes, and Clawdi does not invent one or
 encode a model choice. Manifest v1 `primary_model` remains required only
 because strict parsing precedes a `clawdiCli.packageSpec` self-upgrade; the new
 CLI validates and ignores it.
-Legacy terminal-Codex `OPENAI_API_KEY` and provider `models` are also read-only
-v1 compatibility inputs; local output always uses `CLAWDI_AI_API_KEY` and
-remains catalog-free. Removing those wire fields needs a new schema after older
-CLIs can reach this compatibility release.
-
-This change is Phase A: publish `clawdi@0.13.69`, which reads both legacy and
-canonical terminal-Codex env names while writing only the canonical local env.
-Phase B keeps backend emission deployment-scoped: terminal Codex receives
-`CLAWDI_AI_API_KEY` only when the desired CLI is `clawdi@0.13.69` or later and
-strict v2 `activeCliVersion` proves the current running CLI is the exact desired
-version, along with the current apply generation and instance. Installed CLI
-diagnostics do not satisfy this gate. Observation generation, ETag, and source
-revision must agree with that applied record. Every missing, invalid, stale, or
-mismatched state retains `OPENAI_API_KEY`, including upgrades and rollbacks.
-Phase B may therefore deploy before the fleet upgrades: each deployment remains
-on the legacy env name until its own CLI and observation have converged.
-The gate does not compare that last applied revision with the revision currently
-being rendered: changing the env name creates a new revision, and the internally
-consistent applied record keeps the canonical projection stable while it catches up.
+Terminal-Codex `OPENAI_API_KEY` and provider `models` remain v1 compatibility
+inputs; local output always uses `CLAWDI_AI_API_KEY` and remains catalog-free.
+Cloud always emits `OPENAI_API_KEY` for terminal Codex because the immutable
+image bootstrap CLI parses the manifest before the managed CLI can upgrade or
+start. Desired versions and managed CLI observations cannot prove that cold-boot
+parser capability. A future wire-name change requires an explicit immutable
+bootstrap capability; it must not be inferred from managed CLI state.
 
 This mode controls default configuration ownership, not pod-wide network
 isolation. Egress matching is domain based, so another pod process could call a

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -242,14 +242,11 @@ discoverable from account state and should be reconciled separately with
    release and the same registry/pairing smoke gate; it is not an image,
    manifest, environment override, or npm dist-tag setting.
 
-   The backend terminal Codex environment-name cutover may deploy after
-   `clawdi@0.13.69` is published. Existing deployments do not need to converge
-   first: each deployment switches to `CLAWDI_AI_API_KEY` only when its desired
-   version is at least `0.13.69` and strict v2 diagnostics report that exact
-   desired version plus the current apply generation and instance. Observation
-   generation, ETag, and source revision must agree with that applied record;
-   every older, upgrading, stale, or unhealthy deployment continues to receive
-   `OPENAI_API_KEY`.
+   The backend always emits terminal Codex `OPENAI_API_KEY`. The immutable image
+   bootstrap CLI parses the manifest before a managed CLI can upgrade or start,
+   so desired versions and managed observations are not cold-boot compatibility
+   evidence. Do not change this wire name without an explicit immutable
+   bootstrap capability.
 
    Managed provider egress rewrites require the public
    `Bearer clawdi-egress-placeholder` authorization value as an explicit intent


### PR DESCRIPTION
## Summary

- always project terminal Codex `runtimeEnvName` as the v1-compatible `OPENAI_API_KEY` wire input
- remove desired/observed managed CLI version gating and its heuristic-only tests
- keep one regression proving a healthy `clawdi@0.13.69` observation still renders the cold-boot-compatible env name
- update the directly affected runtime and release documentation

## Root cause

The immutable image bootstrap CLI parses the manifest before the managed CLI can upgrade or start. Desired managed CLI state and a healthy prior observation therefore cannot prove cold-boot parser capability.

## Verification

- `scripts/test.sh backend tests/test_runtime_source.py` (37 passed)
- `scripts/test.sh backend tests/test_sync_heartbeat.py::test_runtime_observed_endpoint_returns_desired_observed_health` (1 passed)
- Ruff check and format check for all changed Python files
- `python scripts/type_governance.py owned` with the locked `mem0` extra (188 files, 0 errors, 0 warnings)
- `scripts/test.sh backend` (2273 passed, 12 skipped)
- `git diff --check origin/main..HEAD`

All tests used the repository clean Docker runner or task-owned one-shot containers and databases. No production, tenant, Hosted checkout, deployment, restart, or merge operation was performed.

## Rollout

After review and merge, the Cloud backend still requires its normal deliberate rollout before production manifests change. No CLI or image rollout is included in this PR.