### PR TITLE
fix(cli): scope systemd activation rollback

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -21,6 +21,7 @@ on:
       - "scripts/test-kamal-whatsapp-sidecar-render.sh"
       - "scripts/deploy-whatsapp-sidecar.sh"
       - "scripts/whatsapp-sidecar-deployment-revision.ts"
+      - "scripts/clawdi-image-release-plan.ts"
       - "scripts/test-deploy-whatsapp-sidecar.sh"
       - "scripts/check_postgres_image_parity.py"
       - "tools/openapi-typescript/**"
@@ -48,6 +49,7 @@ on:
       - "scripts/test-kamal-whatsapp-sidecar-render.sh"
       - "scripts/deploy-whatsapp-sidecar.sh"
       - "scripts/whatsapp-sidecar-deployment-revision.ts"
+      - "scripts/clawdi-image-release-plan.ts"
       - "scripts/test-deploy-whatsapp-sidecar.sh"
       - "scripts/check_postgres_image_parity.py"
       - "tools/openapi-typescript/**"
@@ -100,6 +102,7 @@ jobs:
               - "scripts/test-kamal-whatsapp-sidecar-render.sh"
               - "scripts/deploy-whatsapp-sidecar.sh"
               - "scripts/whatsapp-sidecar-deployment-revision.ts"
+              - "scripts/clawdi-image-release-plan.ts"
               - "scripts/test-deploy-whatsapp-sidecar.sh"
               - "scripts/check_postgres_image_parity.py"
               - "config/deploy.yml"
@@ -124,6 +127,7 @@ jobs:
               - "scripts/test-kamal-whatsapp-sidecar-render.sh"
               - "scripts/deploy-whatsapp-sidecar.sh"
               - "scripts/whatsapp-sidecar-deployment-revision.ts"
+              - "scripts/clawdi-image-release-plan.ts"
               - "scripts/test-deploy-whatsapp-sidecar.sh"
               - "config/deploy.yml"
               - "package.json"
@@ -133,7 +137,6 @@ jobs:
               - ".github/actions/setup-bun-ci/**"
               - ".github/workflows/backend-ci.yml"
               - ".github/workflows/clawdi-image-release.yml"
-
   lint-and-typecheck:
     needs: changes
     if: needs.changes.outputs.any == 'true'

--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -103,7 +103,7 @@ jobs:
                 { ...context.repo, run_id: run.id, filter: "latest", per_page: 100 },
               );
               const deployJobs = jobs.filter(
-                (job) => job.name === "deploy-vps" || /^deploy-vps [0-9a-f]{40}$/.test(job.name),
+                (job) => job.name === "deploy-vps" || job.name.startsWith("deploy-vps "),
               );
               if (deployJobs.length > 1) {
                 core.setFailed(`Release run ${run.id} has ambiguous deploy-vps history`);
@@ -112,7 +112,13 @@ jobs:
               const deploy = deployJobs[0];
               if (!deploy || deploy.conclusion !== "success") continue;
               const namedSha = /^deploy-vps ([0-9a-f]{40})$/.exec(deploy.name)?.[1];
-              const deployedSha = namedSha ?? (run.event === "workflow_run" ? run.head_sha : "");
+              if (deploy.name !== "deploy-vps" && !namedSha) {
+                core.setFailed(`Release run ${run.id} has invalid named deployment authority`);
+                return;
+              }
+              const legacyAutomaticSha = run.event === "workflow_run" ? run.head_sha : undefined;
+              if (!namedSha && legacyAutomaticSha === undefined) continue;
+              const deployedSha = namedSha ?? legacyAutomaticSha;
               if (!/^[0-9a-f]{40}$/.test(deployedSha) || !deploy.completed_at) {
                 core.setFailed(`Release run ${run.id} has invalid deployment authority metadata`);
                 return;

--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -28,6 +28,7 @@ on:
         default: "http://localhost:50021"
 
 permissions:
+  actions: read
   contents: read
   packages: write
 
@@ -54,7 +55,8 @@ jobs:
     timeout-minutes: 30
     outputs:
       image_tag: ${{ steps.rev.outputs.sha }}
-      sidecar_revision: ${{ steps.sidecar-revision.outputs.revision }}
+      release_required: ${{ steps.release-plan.outputs.release_required }}
+      sidecar_revision: ${{ steps.release-plan.outputs.sidecar_revision }}
     steps:
       - name: Resolve source ref
         id: source-ref
@@ -72,7 +74,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ steps.source-ref.outputs.ref }}
-          fetch-depth: 2
+          fetch-depth: 0
 
       - id: rev
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
@@ -81,16 +83,91 @@ jobs:
         with:
           bun-version: "1.3.14"
 
-      - name: Resolve WhatsApp sidecar deployment revision
-        id: sidecar-revision
+      - name: Resolve last successful deployment authority
+        id: deployment-authority
+        if: github.event_name == 'workflow_run'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              ...context.repo,
+              workflow_id: "clawdi-image-release.yml",
+              status: "completed",
+              per_page: 100,
+            });
+            const deployed = [];
+            for (const run of runs) {
+              if (run.id === context.runId || run.conclusion !== "success") continue;
+              const jobs = await github.paginate(
+                github.rest.actions.listJobsForWorkflowRun,
+                { ...context.repo, run_id: run.id, filter: "latest", per_page: 100 },
+              );
+              const deployJobs = jobs.filter(
+                (job) => job.name === "deploy-vps" || /^deploy-vps [0-9a-f]{40}$/.test(job.name),
+              );
+              if (deployJobs.length > 1) {
+                core.setFailed(`Release run ${run.id} has ambiguous deploy-vps history`);
+                return;
+              }
+              const deploy = deployJobs[0];
+              if (!deploy || deploy.conclusion !== "success") continue;
+              const namedSha = /^deploy-vps ([0-9a-f]{40})$/.exec(deploy.name)?.[1];
+              const deployedSha = namedSha ?? (run.event === "workflow_run" ? run.head_sha : "");
+              if (!/^[0-9a-f]{40}$/.test(deployedSha) || !deploy.completed_at) {
+                core.setFailed(`Release run ${run.id} has invalid deployment authority metadata`);
+                return;
+              }
+              deployed.push({ completedAt: deploy.completed_at, sha: deployedSha });
+            }
+            deployed.sort((left, right) => right.completedAt.localeCompare(left.completedAt));
+            if (deployed.length > 1 && deployed[0].completedAt === deployed[1].completedAt) {
+              core.setFailed("Latest successful deploy-vps authority is ambiguous");
+              return;
+            }
+            if (deployed.length > 0) {
+              core.setOutput("found", "true");
+              core.setOutput("base_sha", deployed[0].sha);
+              return;
+            }
+            core.setOutput("found", "false");
+
+      - name: Resolve image release plan
+        id: release-plan
+        env:
+          AUTHORITY_FOUND: ${{ steps.deployment-authority.outputs.found }}
+          BASE_SHA: ${{ steps.deployment-authority.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.rev.outputs.sha }}
         run: |
-          revision="$(bun run scripts/whatsapp-sidecar-deployment-revision.ts)"
-          test "${#revision}" = 64
-          echo "revision=${revision}" >> "$GITHUB_OUTPUT"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_run" ]; then
+            if [ "$AUTHORITY_FOUND" != true ]; then
+              echo "No unambiguous successful deployment authority was found" >&2
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "$BASE_SHA" "$HEAD_SHA"; then
+              echo "Last deployed image authority is not an ancestor of release HEAD" >&2
+              exit 1
+            fi
+            plan="$(mktemp)"
+            trap 'rm -f "$plan"' EXIT
+            bun run scripts/clawdi-image-release-plan.ts "$BASE_SHA" "$HEAD_SHA" > "$plan"
+            test "$(jq -r .baseSha "$plan")" = "$BASE_SHA"
+            test "$(jq -r .headSha "$plan")" = "$HEAD_SHA"
+            release_required="$(jq -r .releaseRequired "$plan")"
+            sidecar_revision="$(jq -r .head.sidecar "$plan")"
+          else
+            release_required=true
+            sidecar_revision="$(bun run scripts/whatsapp-sidecar-deployment-revision.ts)"
+          fi
+          test "$release_required" = true -o "$release_required" = false
+          test "${#sidecar_revision}" = 64
+          echo "release_required=$release_required" >> "$GITHUB_OUTPUT"
+          echo "sidecar_revision=$sidecar_revision" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v4
+        if: steps.release-plan.outputs.release_required == 'true'
 
       - uses: docker/login-action@v4
+        if: steps.release-plan.outputs.release_required == 'true'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -98,6 +175,7 @@ jobs:
 
       - name: Resolve OCI label metadata
         id: labels
+        if: steps.release-plan.outputs.release_required == 'true'
         run: |
           created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           {
@@ -105,6 +183,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Build and push backend image
+        if: steps.release-plan.outputs.release_required == 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -124,6 +203,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=clawdi-backend-image
 
       - name: Build and push WhatsApp sidecar image
+        if: steps.release-plan.outputs.release_required == 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -138,13 +218,13 @@ jobs:
             org.opencontainers.image.created=${{ steps.labels.outputs.created }}
             org.opencontainers.image.title=Clawdi WhatsApp Baileys Sidecar
             org.opencontainers.image.description=Multiplexed physical WhatsApp transport for Clawdi.
-            io.clawdi.whatsapp-sidecar.deployment-revision=${{ steps.sidecar-revision.outputs.revision }}
+            io.clawdi.whatsapp-sidecar.deployment-revision=${{ steps.release-plan.outputs.sidecar_revision }}
           provenance: false
           cache-from: type=gha,scope=clawdi-whatsapp-sidecar-image
           cache-to: type=gha,mode=max,scope=clawdi-whatsapp-sidecar-image
 
       - name: Validate web image inputs
-        if: inputs.build_web
+        if: steps.release-plan.outputs.release_required == 'true' && inputs.build_web
         env:
           WEB_CLERK_PUBLISHABLE_KEY: ${{ inputs.web_clerk_publishable_key }}
         run: |
@@ -154,7 +234,7 @@ jobs:
           fi
 
       - name: Build and push web image
-        if: inputs.build_web
+        if: steps.release-plan.outputs.release_required == 'true' && inputs.build_web
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -179,12 +259,13 @@ jobs:
           cache-to: type=gha,mode=max,scope=clawdi-web-image
 
       - name: Print image summary
+        if: steps.release-plan.outputs.release_required == 'true'
         run: |
           echo "### Clawdi Images" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Backend: \`${{ env.BACKEND_IMAGE_NAME }}:${{ steps.rev.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- WhatsApp sidecar: \`${{ env.SIDECAR_IMAGE_NAME }}:${{ steps.rev.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- WhatsApp sidecar deployment revision: \`${{ steps.sidecar-revision.outputs.revision }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- WhatsApp sidecar deployment revision: \`${{ steps.release-plan.outputs.sidecar_revision }}\`" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ inputs.build_web }}" = "true" ]; then
             echo "- Web: \`${{ env.WEB_IMAGE_NAME }}:${{ steps.rev.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
           else
@@ -192,7 +273,9 @@ jobs:
           fi
 
   deploy-vps:
+    name: deploy-vps ${{ needs.build.outputs.image_tag }}
     needs: build
+    if: needs.build.outputs.release_required == 'true'
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     steps:

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.70",
+      "version": "0.13.71",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.70",
+	"version": "0.13.71",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -507,6 +507,35 @@ export interface SystemdUnitSnapshot {
 	user: Map<string, string>;
 }
 
+type SystemdRuntimeScope = "system" | "user";
+
+type SystemdRuntimeMutationStage =
+	| "egress-prerequisite"
+	| "official-installer"
+	| "final-activation"
+	| "quiesce"
+	| "rollback";
+
+type SystemdRuntimeMutationAction =
+	| "daemon-reload"
+	| "disable"
+	| "enable"
+	| "enable-and-start"
+	| "install"
+	| "reset-failed"
+	| "restart"
+	| "start"
+	| "stop";
+
+export interface SystemdRuntimeMutationJournalEntry {
+	sequence: number;
+	stage: SystemdRuntimeMutationStage;
+	scope: SystemdRuntimeScope;
+	action: SystemdRuntimeMutationAction;
+	units: string[];
+	outcome: "pending" | "succeeded" | "failed";
+}
+
 interface SystemdUnitManagerState {
 	loadState: string;
 	activeState: string;
@@ -526,6 +555,69 @@ const RUNTIME_WATCH_SYSTEM_UNIT = "clawdi-runtime-watch.service";
 const RUNTIME_DAEMON_SYSTEM_UNIT = "clawdi-daemon.service";
 const RUNTIME_SIDECAR_SYSTEM_UNIT = "clawdi-runtime-sidecar.service";
 const RUNTIME_REVISION_RE = /^[a-f0-9]{32}$/;
+
+const SYSTEMD_ACTIVATION_STAGES = new Set<SystemdRuntimeMutationStage>([
+	"egress-prerequisite",
+	"official-installer",
+	"final-activation",
+]);
+
+const systemdRuntimeTransactionInitialStates = new WeakMap<
+	SystemdRuntimeTransaction,
+	{ system: Map<string, SystemdUnitManagerState>; user: Map<string, SystemdUnitManagerState> }
+>();
+
+export class SystemdRuntimeTransaction {
+	// Journal entries contain only systemd unit names and command outcomes. Command
+	// output, environment, process metadata, and secret material never enter it.
+	readonly journal: SystemdRuntimeMutationJournalEntry[] = [];
+
+	constructor() {
+		systemdRuntimeTransactionInitialStates.set(this, {
+			system: new Map(),
+			user: new Map(),
+		});
+	}
+
+	get state(): "pristine" | "mutated" {
+		return this.journal.some((entry) => SYSTEMD_ACTIVATION_STAGES.has(entry.stage))
+			? "mutated"
+			: "pristine";
+	}
+
+	installOfficialService(
+		paths: ReturnType<typeof getRuntimePaths>,
+		unit: string,
+		install: () => string | null,
+	): string | null {
+		return runSystemdRuntimeOfficialInstaller(paths, this, unit, install);
+	}
+
+	quiesce(paths: ReturnType<typeof getRuntimePaths>): void {
+		quiesceSystemdRuntimeCandidate(paths, this);
+	}
+
+	rollback(paths: ReturnType<typeof getRuntimePaths>): void {
+		rollbackSystemdRuntimeTransaction(paths, this);
+	}
+}
+
+function systemdRuntimeTransactionTouchedUnits(transaction: SystemdRuntimeTransaction): {
+	systemUnits: string[];
+	userUnits: string[];
+} {
+	const systemUnits = new Set<string>();
+	const userUnits = new Set<string>();
+	for (const entry of transaction.journal) {
+		if (!SYSTEMD_ACTIVATION_STAGES.has(entry.stage) || entry.action === "daemon-reload") continue;
+		const target = entry.scope === "system" ? systemUnits : userUnits;
+		for (const unit of entry.units) target.add(unit);
+	}
+	return {
+		systemUnits: [...systemUnits].sort(),
+		userUnits: [...userUnits].sort(),
+	};
+}
 
 export function readSystemdUnitSnapshot(
 	paths: ReturnType<typeof getRuntimePaths>,
@@ -604,6 +696,8 @@ export function applySystemdRuntimeUpdate(
 	before: SystemdUnitSnapshot,
 	after: SystemdUnitSnapshot,
 	opts: {
+		transaction: SystemdRuntimeTransaction;
+		stage: Extract<SystemdRuntimeMutationStage, "egress-prerequisite" | "final-activation">;
 		forceRestartSystemUnits?: readonly string[];
 		forceStopSystemUnits?: readonly string[];
 		recoverFailedUnits?: boolean;
@@ -613,8 +707,9 @@ export function applySystemdRuntimeUpdate(
 		};
 		preserveActiveUnits?: boolean;
 		skipActivatedSystemUnits?: readonly string[];
-	} = {},
+	},
 ): { applied: boolean; systemUnitsChanged: string[]; userUnitsChanged: string[] } {
+	const { transaction, stage } = opts;
 	const allSystem = changedSystemdUnits(before.system, after.system);
 	const allUser = changedSystemdUnits(before.user, after.user);
 	const filterChanges = (
@@ -661,37 +756,59 @@ export function applySystemdRuntimeUpdate(
 			userUnitsChanged: [...userUnitsChanged].sort(),
 		};
 	}
+	const systemStates = preflightSystemdRuntimeUnits(paths, transaction, "system", [
+		...system.present,
+		...system.removed,
+		...forcedSystemStops,
+	]);
+	const userStates = preflightSystemdRuntimeUnits(paths, transaction, "user", [
+		...user.present,
+		...user.removed,
+	]);
 	const systemManagerNeedsReload = new Set(
-		system.present.filter(
-			(unit) => systemdUnitManagerState(paths, "system", unit).needDaemonReload,
-		),
+		system.present.filter((unit) => systemStates.get(unit)?.needDaemonReload),
 	);
 	const userManagerNeedsReload = new Set(
-		user.present.filter((unit) => systemdUnitManagerState(paths, "user", unit).needDaemonReload),
+		user.present.filter((unit) => userStates.get(unit)?.needDaemonReload),
 	);
 	const changedSystemUnits = new Set(system.changed);
 	const changedUserUnits = new Set(user.changed);
 	const userProcessRevisionDrift = new Set(
 		user.present.filter((unit) => {
-			const state = systemdUnitManagerState(paths, "user", unit);
-			return state.activeState === "active" && !systemdProcessRevisionMatches(paths, unit, state);
+			const state = requiredSystemdUnitState(userStates, "user", unit);
+			if (state.activeState !== "active") return false;
+			return !systemdProcessRevisionMatches(paths, unit, state);
 		}),
 	);
 
 	for (const unit of system.removed) {
-		const state = systemdUnitManagerState(paths, "system", unit);
+		const state = requiredSystemdUnitState(systemStates, "system", unit);
 		if (unit === RUNTIME_WATCH_SYSTEM_UNIT && !systemdUnitAbsentOrInactive(state)) continue;
-		if (!systemdUnitAbsentOrInactive(state)) systemctl(["stop", unit]);
+		if (!systemdUnitAbsentOrInactive(state)) {
+			runJournaledSystemdMutation(transaction, stage, "system", "stop", [unit], () =>
+				systemctl(["stop", unit]),
+			);
+		}
 	}
 	for (const unit of user.removed) {
-		const state = systemdUnitManagerState(paths, "user", unit);
-		if (!systemdUnitAbsentOrInactive(state)) runtimeUserSystemctl(paths, ["stop", unit]);
-		if (!systemdUnitAbsentOrDisabled(state)) runtimeUserSystemctl(paths, ["disable", unit]);
+		const state = requiredSystemdUnitState(userStates, "user", unit);
+		if (!systemdUnitAbsentOrInactive(state)) {
+			runJournaledSystemdMutation(transaction, stage, "user", "stop", [unit], () =>
+				runtimeUserSystemctl(paths, ["stop", unit]),
+			);
+		}
+		if (!systemdUnitAbsentOrDisabled(state)) {
+			runJournaledSystemdMutation(transaction, stage, "user", "disable", [unit], () =>
+				runtimeUserSystemctl(paths, ["disable", unit]),
+			);
+		}
 	}
 	for (const unit of forcedSystemStops) {
-		const state = systemdUnitManagerState(paths, "system", unit);
+		const state = requiredSystemdUnitState(systemStates, "system", unit);
 		if (!systemdUnitAbsentOrInactive(state)) {
-			systemctl(["stop", unit]);
+			runJournaledSystemdMutation(transaction, stage, "system", "stop", [unit], () =>
+				systemctl(["stop", unit]),
+			);
 			systemUnitsChanged.add(unit);
 		}
 	}
@@ -702,7 +819,9 @@ export function applySystemdRuntimeUpdate(
 		system.removed.length > 0 ||
 		systemManagerNeedsReload.size > 0
 	) {
-		systemctl(["daemon-reload"]);
+		runJournaledSystemdMutation(transaction, stage, "system", "daemon-reload", [], () =>
+			systemctl(["daemon-reload"]),
+		);
 	}
 	if (
 		user.added.length > 0 ||
@@ -710,7 +829,9 @@ export function applySystemdRuntimeUpdate(
 		user.removed.length > 0 ||
 		userManagerNeedsReload.size > 0
 	) {
-		runtimeUserSystemctl(paths, ["daemon-reload"]);
+		runJournaledSystemdMutation(transaction, stage, "user", "daemon-reload", [], () =>
+			runtimeUserSystemctl(paths, ["daemon-reload"]),
+		);
 	}
 
 	const addedSystemUnits = new Set(system.added);
@@ -721,7 +842,7 @@ export function applySystemdRuntimeUpdate(
 	const startSystemUnits: string[] = [];
 	const restartSystemUnits: string[] = [];
 	for (const unit of system.present) {
-		const state = systemdUnitManagerState(paths, "system", unit);
+		const state = requiredSystemdUnitState(systemStates, "system", unit);
 		if (forcedStopUnits.has(unit)) continue;
 		if (skipActivatedSystemUnits.has(unit)) continue;
 		if (state.activeState === "failed" && recoverFailedUnits) {
@@ -748,9 +869,26 @@ export function applySystemdRuntimeUpdate(
 	}
 	// Each reconciliation makes at most one recovery attempt per failed unit.
 	// Transitional units remain untouched and fail final proof below.
-	if (resetFailedSystemUnits.length > 0) systemctl(["reset-failed", ...resetFailedSystemUnits]);
-	if (startSystemUnits.length > 0) systemctl(["start", ...startSystemUnits]);
-	if (restartSystemUnits.length > 0) systemctl(["restart", ...restartSystemUnits]);
+	if (resetFailedSystemUnits.length > 0) {
+		runJournaledSystemdMutation(
+			transaction,
+			stage,
+			"system",
+			"reset-failed",
+			resetFailedSystemUnits,
+			() => systemctl(["reset-failed", ...resetFailedSystemUnits]),
+		);
+	}
+	if (startSystemUnits.length > 0) {
+		runJournaledSystemdMutation(transaction, stage, "system", "start", startSystemUnits, () =>
+			systemctl(["start", ...startSystemUnits]),
+		);
+	}
+	if (restartSystemUnits.length > 0) {
+		runJournaledSystemdMutation(transaction, stage, "system", "restart", restartSystemUnits, () =>
+			systemctl(["restart", ...restartSystemUnits]),
+		);
+	}
 
 	const resetFailedUserUnits: string[] = [];
 	const startUserUnits: string[] = [];
@@ -758,7 +896,7 @@ export function applySystemdRuntimeUpdate(
 	const enableAndStartUserUnits: string[] = [];
 	const restartUserUnits: string[] = [];
 	for (const unit of user.present) {
-		const state = systemdUnitManagerState(paths, "user", unit);
+		const state = requiredSystemdUnitState(userStates, "user", unit);
 		const enabled = systemdUnitEnabled(state);
 		if (state.activeState === "failed" && recoverFailedUnits) {
 			resetFailedUserUnits.push(unit);
@@ -787,14 +925,40 @@ export function applySystemdRuntimeUpdate(
 		}
 	}
 	if (resetFailedUserUnits.length > 0) {
-		runtimeUserSystemctl(paths, ["reset-failed", ...resetFailedUserUnits]);
+		runJournaledSystemdMutation(
+			transaction,
+			stage,
+			"user",
+			"reset-failed",
+			resetFailedUserUnits,
+			() => runtimeUserSystemctl(paths, ["reset-failed", ...resetFailedUserUnits]),
+		);
 	}
 	if (enableAndStartUserUnits.length > 0) {
-		runtimeUserSystemctl(paths, ["enable", "--now", ...enableAndStartUserUnits]);
+		runJournaledSystemdMutation(
+			transaction,
+			stage,
+			"user",
+			"enable-and-start",
+			enableAndStartUserUnits,
+			() => runtimeUserSystemctl(paths, ["enable", "--now", ...enableAndStartUserUnits]),
+		);
 	}
-	if (enableUserUnits.length > 0) runtimeUserSystemctl(paths, ["enable", ...enableUserUnits]);
-	if (startUserUnits.length > 0) runtimeUserSystemctl(paths, ["start", ...startUserUnits]);
-	if (restartUserUnits.length > 0) runtimeUserSystemctl(paths, ["restart", ...restartUserUnits]);
+	if (enableUserUnits.length > 0) {
+		runJournaledSystemdMutation(transaction, stage, "user", "enable", enableUserUnits, () =>
+			runtimeUserSystemctl(paths, ["enable", ...enableUserUnits]),
+		);
+	}
+	if (startUserUnits.length > 0) {
+		runJournaledSystemdMutation(transaction, stage, "user", "start", startUserUnits, () =>
+			runtimeUserSystemctl(paths, ["start", ...startUserUnits]),
+		);
+	}
+	if (restartUserUnits.length > 0) {
+		runJournaledSystemdMutation(transaction, stage, "user", "restart", restartUserUnits, () =>
+			runtimeUserSystemctl(paths, ["restart", ...restartUserUnits]),
+		);
+	}
 
 	const systemConverged = system.present.every((unit) => {
 		const state = systemdUnitManagerState(paths, "system", unit);
@@ -805,13 +969,15 @@ export function applySystemdRuntimeUpdate(
 	});
 	const userConverged = user.present.every((unit) => {
 		const state = systemdUnitManagerState(paths, "user", unit);
-		return (
-			state.loadState !== "not-found" &&
-			state.activeState === "active" &&
-			!state.needDaemonReload &&
-			systemdUnitEnabled(state) &&
-			systemdProcessRevisionMatches(paths, unit, state)
-		);
+		if (
+			state.loadState === "not-found" ||
+			state.activeState !== "active" ||
+			state.needDaemonReload ||
+			!systemdUnitEnabled(state)
+		) {
+			return false;
+		}
+		return systemdProcessRevisionMatches(paths, unit, state);
 	});
 	const removedSystemConverged = system.removed.every(
 		(unit) =>
@@ -829,19 +995,220 @@ export function applySystemdRuntimeUpdate(
 	};
 }
 
-export function quiesceSystemdRuntimeCandidate(
+function quiesceSystemdRuntimeCandidate(
 	paths: ReturnType<typeof getRuntimePaths>,
-	candidate: SystemdUnitSnapshot,
+	transaction: SystemdRuntimeTransaction,
 ): void {
 	if (!shouldApplySystemdRuntimeUpdate(paths)) return;
-	const userUnits = [...candidate.user.keys()]
+	const candidateUnits = systemdRuntimeCandidateUnits(transaction);
+	const userUnits = [...candidateUnits.user]
 		.filter((unit) => unit !== RUNTIME_WATCH_SYSTEM_UNIT)
 		.sort();
-	if (userUnits.length > 0) runtimeUserSystemctl(paths, ["stop", ...userUnits]);
-	const systemUnits = [...candidate.system.keys()]
+	for (const unit of userUnits) {
+		const state = systemdUnitManagerState(paths, "user", unit);
+		if (systemdUnitAbsentOrInactive(state)) continue;
+		runJournaledSystemdMutation(transaction, "quiesce", "user", "stop", [unit], () =>
+			runtimeUserSystemctl(paths, ["stop", unit]),
+		);
+	}
+	const systemUnits = [...candidateUnits.system]
 		.filter((unit) => unit !== RUNTIME_WATCH_SYSTEM_UNIT)
 		.sort();
-	if (systemUnits.length > 0) systemctl(["stop", ...systemUnits]);
+	for (const unit of systemUnits) {
+		const state = systemdUnitManagerState(paths, "system", unit);
+		if (systemdUnitAbsentOrInactive(state)) continue;
+		runJournaledSystemdMutation(transaction, "quiesce", "system", "stop", [unit], () =>
+			systemctl(["stop", unit]),
+		);
+	}
+}
+
+function systemdRuntimeCandidateUnits(transaction: SystemdRuntimeTransaction): {
+	system: Set<string>;
+	user: Set<string>;
+} {
+	const candidateActions = new Set<SystemdRuntimeMutationAction>([
+		"enable-and-start",
+		"install",
+		"restart",
+		"start",
+	]);
+	const candidateUnits = { system: new Set<string>(), user: new Set<string>() };
+	for (const entry of transaction.journal) {
+		if (!SYSTEMD_ACTIVATION_STAGES.has(entry.stage) || !candidateActions.has(entry.action)) {
+			continue;
+		}
+		for (const unit of entry.units) candidateUnits[entry.scope].add(unit);
+	}
+	return candidateUnits;
+}
+
+function rollbackSystemdRuntimeTransaction(
+	paths: ReturnType<typeof getRuntimePaths>,
+	transaction: SystemdRuntimeTransaction,
+): void {
+	const activationJournal = transaction.journal.filter((entry) =>
+		SYSTEMD_ACTIVATION_STAGES.has(entry.stage),
+	);
+	const touched = systemdRuntimeTransactionTouchedUnits(transaction);
+	const reloadSystem = activationJournal.some(
+		(entry) => entry.scope === "system" && entry.action === "daemon-reload",
+	);
+	const reloadUser = activationJournal.some(
+		(entry) =>
+			entry.scope === "user" && (entry.action === "daemon-reload" || entry.action === "install"),
+	);
+	if (reloadSystem) {
+		runJournaledSystemdMutation(transaction, "rollback", "system", "daemon-reload", [], () =>
+			systemctl(["daemon-reload"]),
+		);
+	}
+	if (reloadUser) {
+		runJournaledSystemdMutation(transaction, "rollback", "user", "daemon-reload", [], () =>
+			runtimeUserSystemctl(paths, ["daemon-reload"]),
+		);
+	}
+	for (const unit of touched.systemUnits) {
+		const initial = systemdRuntimeTransactionStates(transaction).system.get(unit);
+		if (!initial || initial.loadState === "not-found" || initial.activeState !== "active") continue;
+		restoreActiveSystemdUnit(paths, transaction, "system", unit);
+	}
+	for (const unit of touched.userUnits) {
+		const initial = systemdRuntimeTransactionStates(transaction).user.get(unit);
+		if (!initial || initial.loadState === "not-found") continue;
+		const initiallyEnabled = systemdUnitEnabled(initial);
+		const currentlyEnabled = systemdUnitEnabled(systemdUnitManagerState(paths, "user", unit));
+		if (initiallyEnabled !== currentlyEnabled) {
+			const action = initiallyEnabled ? "enable" : "disable";
+			runJournaledSystemdMutation(transaction, "rollback", "user", action, [unit], () =>
+				runtimeUserSystemctl(paths, [action, unit]),
+			);
+		}
+		if (initial.activeState !== "active") continue;
+		restoreActiveSystemdUnit(paths, transaction, "user", unit);
+		const restored = systemdUnitManagerState(paths, "user", unit);
+		if (systemdUnitEnabled(restored) !== initiallyEnabled) {
+			throw new Error(`systemd rollback did not restore user unit ${unit} enablement`);
+		}
+		if (!systemdProcessRevisionMatches(paths, unit, restored)) {
+			throw new Error(`systemd rollback restored stale runtime revision for ${unit}`);
+		}
+	}
+}
+
+function restoreActiveSystemdUnit(
+	paths: ReturnType<typeof getRuntimePaths>,
+	transaction: SystemdRuntimeTransaction,
+	scope: SystemdRuntimeScope,
+	unit: string,
+): void {
+	let current = systemdUnitManagerState(paths, scope, unit);
+	const mutate = (
+		action: Extract<SystemdRuntimeMutationAction, "reset-failed" | "start" | "stop">,
+	) =>
+		runJournaledSystemdMutation(transaction, "rollback", scope, action, [unit], () =>
+			scope === "system" ? systemctl([action, unit]) : runtimeUserSystemctl(paths, [action, unit]),
+		);
+	if (current.activeState === "failed") {
+		mutate("reset-failed");
+		current = systemdUnitManagerState(paths, scope, unit);
+	}
+	if (current.activeState !== "active") {
+		if (current.activeState !== "inactive") {
+			throw new Error(
+				`systemd rollback could not restore ${scope} unit ${unit} from ${current.activeState}`,
+			);
+		}
+		mutate("start");
+		current = systemdUnitManagerState(paths, scope, unit);
+	}
+	if (current.activeState !== "active") {
+		throw new Error(`systemd rollback did not restore ${scope} unit ${unit} activity`);
+	}
+}
+
+function runSystemdRuntimeOfficialInstaller(
+	paths: ReturnType<typeof getRuntimePaths>,
+	transaction: SystemdRuntimeTransaction,
+	unit: string,
+	install: () => string | null,
+): string | null {
+	const states = preflightSystemdRuntimeUnits(paths, transaction, "user", [unit]);
+	const state = requiredSystemdUnitState(states, "user", unit);
+	if (state.activeState === "active") {
+		systemdProcessRevisionMatches(paths, unit, state);
+	}
+	return runJournaledSystemdMutation(
+		transaction,
+		"official-installer",
+		"user",
+		"install",
+		[unit],
+		install,
+		(error) => error !== null,
+	);
+}
+
+function preflightSystemdRuntimeUnits(
+	paths: ReturnType<typeof getRuntimePaths>,
+	transaction: SystemdRuntimeTransaction,
+	scope: SystemdRuntimeScope,
+	units: readonly string[],
+): Map<string, SystemdUnitManagerState> {
+	const states = new Map<string, SystemdUnitManagerState>();
+	const initialStates = systemdRuntimeTransactionStates(transaction)[scope];
+	for (const unit of [...new Set(units)].sort()) {
+		const state = systemdUnitManagerState(paths, scope, unit);
+		states.set(unit, state);
+		if (!initialStates.has(unit)) initialStates.set(unit, state);
+	}
+	return states;
+}
+
+function systemdRuntimeTransactionStates(transaction: SystemdRuntimeTransaction): {
+	system: Map<string, SystemdUnitManagerState>;
+	user: Map<string, SystemdUnitManagerState>;
+} {
+	const states = systemdRuntimeTransactionInitialStates.get(transaction);
+	if (!states) throw new Error("systemd runtime transaction is not initialized");
+	return states;
+}
+function requiredSystemdUnitState(
+	states: ReadonlyMap<string, SystemdUnitManagerState>,
+	scope: SystemdRuntimeScope,
+	unit: string,
+): SystemdUnitManagerState {
+	const state = states.get(unit);
+	if (!state) throw new Error(`systemd ${scope} unit ${unit} was not preflighted`);
+	return state;
+}
+
+function runJournaledSystemdMutation<T>(
+	transaction: SystemdRuntimeTransaction,
+	stage: SystemdRuntimeMutationStage,
+	scope: SystemdRuntimeScope,
+	action: SystemdRuntimeMutationAction,
+	units: readonly string[],
+	mutation: () => T,
+	failed: (result: T) => boolean = () => false,
+): T {
+	const entry: SystemdRuntimeMutationJournalEntry = {
+		sequence: transaction.journal.length + 1,
+		stage,
+		scope,
+		action,
+		units: [...new Set(units)].sort(),
+		outcome: "pending",
+	};
+	transaction.journal.push(entry);
+	try {
+		const result = mutation();
+		entry.outcome = failed(result) ? "failed" : "succeeded";
+		return result;
+	} catch (error) {
+		entry.outcome = "failed";
+		throw error;
+	}
 }
 
 function systemdUnitManagerState(
@@ -1899,7 +2266,7 @@ async function applyRuntimeDesiredState(
 			authToken: load.applyContext?.manifestSource.auth.token,
 		}));
 	const previousSystemdUnits = readSystemdUnitSnapshot(paths);
-	let failedSystemdUnits: SystemdUnitSnapshot | null = null;
+	const systemdTransaction = new SystemdRuntimeTransaction();
 	let systemdApply = {
 		applied: false,
 		systemUnitsChanged: [] as string[],
@@ -1918,14 +2285,19 @@ async function applyRuntimeDesiredState(
 			opts.authorityCommit?.(committedConvergence, authority);
 		},
 		systemdApply: {
+			transactionState: () => systemdTransaction.state,
+			installOfficialService: (unit, install) =>
+				systemdTransaction.installOfficialService(paths, unit, install),
 			activateEgressPrerequisite: ({ restartEgressSidecar }) => {
-				failedSystemdUnits = readSystemdUnitSnapshot(paths);
+				const candidateSystemdUnits = readSystemdUnitSnapshot(paths);
 				try {
 					const prerequisite = applySystemdRuntimeUpdate(
 						paths,
 						previousSystemdUnits,
-						failedSystemdUnits,
+						candidateSystemdUnits,
 						{
+							transaction: systemdTransaction,
+							stage: "egress-prerequisite",
 							activationScope: {
 								systemUnits: [RUNTIME_SIDECAR_SYSTEM_UNIT],
 								userUnits: [],
@@ -1952,10 +2324,10 @@ async function applyRuntimeDesiredState(
 			activate: ({ restartDaemon, restartEgressSidecar, staleSystemUnits, staleUserUnits }) => {
 				// Official installers run after the prerequisite phase and add their
 				// base units, so final reconciliation must observe a fresh rendered state.
-				failedSystemdUnits = readSystemdUnitSnapshot(paths);
+				const candidateSystemdUnits = readSystemdUnitSnapshot(paths);
 				try {
 					const activationTarget = withoutStaleSystemdUnits(
-						failedSystemdUnits,
+						candidateSystemdUnits,
 						staleSystemUnits,
 						staleUserUnits,
 					);
@@ -1964,6 +2336,8 @@ async function applyRuntimeDesiredState(
 						previousSystemdUnits,
 						activationTarget,
 						{
+							transaction: systemdTransaction,
+							stage: "final-activation",
 							forceRestartSystemUnits: [
 								...(restartDaemon ? [RUNTIME_DAEMON_SYSTEM_UNIT] : []),
 								...(restartEgressSidecar ? [RUNTIME_SIDECAR_SYSTEM_UNIT] : []),
@@ -1997,36 +2371,8 @@ async function applyRuntimeDesiredState(
 					);
 				}
 			},
-			quiesce: () => {
-				quiesceSystemdRuntimeCandidate(paths, readSystemdUnitSnapshot(paths));
-			},
-			rollback: ({
-				restartDaemon,
-				restartEgressSidecar,
-				stopEgressSidecar,
-				reconcileUserUnits,
-				staleSystemUnits,
-			}) => {
-				const restoredSystemdUnits = readSystemdUnitSnapshot(paths);
-				const rollbackSource = failedSystemdUnits ?? {
-					system: new Map(previousSystemdUnits.system),
-					user: new Map(previousSystemdUnits.user),
-				};
-				for (const unit of reconcileUserUnits) {
-					if (!rollbackSource.user.has(unit)) {
-						rollbackSource.user.set(unit, "# failed runtime apply candidate\n");
-					}
-				}
-				applySystemdRuntimeUpdate(paths, rollbackSource, restoredSystemdUnits, {
-					forceRestartSystemUnits: [
-						...(restartDaemon ? [RUNTIME_DAEMON_SYSTEM_UNIT] : []),
-						...(restartEgressSidecar ? [RUNTIME_SIDECAR_SYSTEM_UNIT] : []),
-						...staleSystemUnits,
-					],
-					forceStopSystemUnits: stopEgressSidecar ? [RUNTIME_SIDECAR_SYSTEM_UNIT] : [],
-					recoverFailedUnits: false,
-				});
-			},
+			quiesce: () => systemdTransaction.quiesce(paths),
+			rollback: () => systemdTransaction.rollback(paths),
 		},
 	});
 	return { kind: "converged", cliUpdate, convergence, systemdApply };

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -20,6 +20,10 @@ import { dirname, join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { commitRuntimeAppliedState } from "../commands/runtime";
 import {
+	type TestConvergeOptions,
+	withTestSystemdTransaction,
+} from "../test-support/systemd-apply";
+import {
 	readRuntimeAppliedState,
 	runtimeContentSha256,
 	writeRuntimeAppliedState,
@@ -145,11 +149,12 @@ function tempRuntimePaths(): RuntimePaths {
 function convergeRuntimeManifest(
 	load: RuntimeManifestLoad,
 	paths: RuntimePaths,
-	opts: Parameters<typeof convergeRuntimeManifestWithContract>[2] = {},
+	opts: TestConvergeOptions = {},
 ) {
 	ensureRuntimeStateDirs(paths);
 	return convergeRuntimeManifestWithContract(load, paths, {
 		...opts,
+		systemdApply: opts.systemdApply ? withTestSystemdTransaction(opts.systemdApply) : undefined,
 		hostedRuntimeContract: opts.hostedRuntimeContract ?? {
 			expectedIdentity: {
 				home: paths.userHome,

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -12,6 +12,10 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import {
+	type TestConvergeOptions,
+	withTestSystemdTransaction,
+} from "../test-support/systemd-apply";
 import { hostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
 import {
 	readRuntimeInstallReceipts,
@@ -41,7 +45,7 @@ const TEST_RUNTIME_USER = String(TEST_PROCESS_UID);
 function convergeRuntimeManifest(
 	load: RuntimeManifestLoad,
 	paths: RuntimePaths,
-	opts?: Parameters<typeof convergeRuntimeManifestWithContext>[2],
+	opts: TestConvergeOptions = {},
 ) {
 	ensureRuntimeStateDirs(paths);
 	return convergeRuntimeManifestWithContext(
@@ -67,6 +71,7 @@ function convergeRuntimeManifest(
 		paths,
 		{
 			...opts,
+			systemdApply: opts.systemdApply ? withTestSystemdTransaction(opts.systemdApply) : undefined,
 			hostedOpenClawSkillDriver: opts?.hostedOpenClawSkillDriver ?? {
 				...hostedOpenClawSkillDriver,
 				resolveWorkspace: () => join(paths.userHome, ".openclaw", "workspace"),

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -306,6 +306,8 @@ interface RuntimeSystemdApplySignal {
 interface RuntimeSystemdApplyHooks {
 	activateEgressPrerequisite: (signal: RuntimeSystemdApplySignal) => RuntimeSystemdApplyResult;
 	activate: (signal: RuntimeSystemdApplySignal) => RuntimeSystemdApplyResult;
+	transactionState: () => "pristine" | "mutated";
+	installOfficialService: (unit: string, install: () => string | null) => string | null;
 	quiesce: () => void;
 	rollback: (signal: RuntimeSystemdApplySignal) => void;
 }
@@ -5877,7 +5879,6 @@ export function convergeRuntimeManifest(
 		throw error;
 	}
 	let systemdActivationApplied = false;
-	let systemdActivationAttempted = false;
 	let restartDaemon = false;
 	let desiredDaemonAuthTokenRevision: string | undefined;
 	let desiredDaemonProgramRevision: string | undefined;
@@ -6498,7 +6499,6 @@ export function convergeRuntimeManifest(
 			systemdUnits.egressSidecarActive &&
 			opts.systemdApply
 		) {
-			systemdActivationAttempted = true;
 			const prerequisite = opts.systemdApply.activateEgressPrerequisite({
 				restartDaemon,
 				restartEgressSidecar,
@@ -6514,7 +6514,10 @@ export function convergeRuntimeManifest(
 
 		for (const item of officialServicePlan.pending) {
 			hostedRuntimeContract.assertPlatformRoots();
-			const error = installOfficialRuntimeService(item, paths);
+			const install = () => installOfficialRuntimeService(item, paths);
+			const error = opts.systemdApply
+				? opts.systemdApply.installOfficialService(item.unitName, install)
+				: install();
 			if (error) throw new Error(error);
 		}
 		const artifactError = prepareHermesDashboardArtifact(
@@ -6528,7 +6531,6 @@ export function convergeRuntimeManifest(
 		const bootFinished = join(instanceRoot, "boot-finished");
 		writeRuntimePrivateFileAtomic(paths, bootFinished, `${generatedAt}\n`);
 		if (opts.systemdApply) {
-			systemdActivationAttempted = true;
 			const activation = opts.systemdApply.activate({
 				restartDaemon,
 				restartEgressSidecar,
@@ -6647,8 +6649,9 @@ export function convergeRuntimeManifest(
 		return convergence;
 	} catch (error) {
 		const applyError = error instanceof Error ? error.message : String(error);
-		let candidateQuiesced = !systemdActivationAttempted;
-		if (systemdActivationAttempted) {
+		const systemdMutated = opts.systemdApply?.transactionState() === "mutated";
+		let candidateQuiesced = !systemdMutated;
+		if (systemdMutated) {
 			try {
 				opts.systemdApply?.quiesce();
 				candidateQuiesced = true;
@@ -6711,7 +6714,7 @@ export function convergeRuntimeManifest(
 				);
 			}
 		}
-		if (opts.systemdApply && filesystemRollbackSucceeded) {
+		if (opts.systemdApply && filesystemRollbackSucceeded && systemdMutated) {
 			try {
 				opts.systemdApply.rollback({
 					restartDaemon,
@@ -6728,11 +6731,11 @@ export function convergeRuntimeManifest(
 					}`,
 				);
 			}
-		} else if (opts.systemdApply && candidateQuiesced) {
+		} else if (opts.systemdApply && systemdMutated && candidateQuiesced) {
 			installErrors.push(
 				"runtime systemd rollback skipped because filesystem authority restoration failed",
 			);
-		} else if (opts.systemdApply) {
+		} else if (opts.systemdApply && systemdMutated) {
 			installErrors.push(
 				"runtime systemd reconciliation skipped because candidate services did not quiesce",
 			);

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -97,7 +97,11 @@ export interface RuntimeInstallReceiptTarget {
 
 export interface OfficialRuntimeServicePlan {
 	targets: Map<string, RuntimeInstallReceiptTarget>;
-	pending: Array<{ program: RuntimeSystemdUserProgram; target: RuntimeInstallReceiptTarget }>;
+	pending: Array<{
+		unitName: string;
+		program: RuntimeSystemdUserProgram;
+		target: RuntimeInstallReceiptTarget;
+	}>;
 }
 
 export interface HermesDashboardArtifactPlan {
@@ -552,7 +556,7 @@ export function planOfficialRuntimeServices(
 		);
 		const target = { desiredRevision, currentRevision, expectedCurrentRevision };
 		targets.set(key, target);
-		if (expectedCurrentRevision === null) pending.push({ program, target });
+		if (expectedCurrentRevision === null) pending.push({ unitName: key, program, target });
 	}
 	return { targets, pending };
 }

--- a/packages/cli/src/test-support/systemd-apply.ts
+++ b/packages/cli/src/test-support/systemd-apply.ts
@@ -1,0 +1,33 @@
+import type { convergeRuntimeManifest } from "../runtime/manifest";
+
+type ConvergeOptions = NonNullable<Parameters<typeof convergeRuntimeManifest>[2]>;
+type SystemdApplyHooks = NonNullable<ConvergeOptions["systemdApply"]>;
+
+export type TestSystemdApplyHooks = Omit<
+	SystemdApplyHooks,
+	"installOfficialService" | "transactionState"
+>;
+
+export type TestConvergeOptions = Omit<ConvergeOptions, "systemdApply"> & {
+	systemdApply?: TestSystemdApplyHooks;
+};
+
+export function withTestSystemdTransaction(hooks: TestSystemdApplyHooks): SystemdApplyHooks {
+	let mutated = false;
+	return {
+		...hooks,
+		transactionState: () => (mutated ? "mutated" : "pristine"),
+		installOfficialService: (_unit, install) => {
+			mutated = true;
+			return install();
+		},
+		activateEgressPrerequisite: (signal) => {
+			mutated = true;
+			return hooks.activateEgressPrerequisite(signal);
+		},
+		activate: (signal) => {
+			mutated = true;
+			return hooks.activate(signal);
+		},
+	};
+}

--- a/packages/cli/tests/clawdi-image-release-workflow.test.ts
+++ b/packages/cli/tests/clawdi-image-release-workflow.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { parse } from "yaml";
+import {
+	calculateClawdiImageRevisions,
+	classifyClawdiImageRelease,
+} from "../../../scripts/clawdi-image-release-plan";
 
 interface WorkflowStep {
 	id?: string;
@@ -15,7 +19,9 @@ interface WorkflowStep {
 interface WorkflowJob {
 	concurrency?: unknown;
 	if?: string;
+	name?: string;
 	needs?: string;
+	outputs?: Record<string, string>;
 	steps?: WorkflowStep[];
 }
 
@@ -49,6 +55,14 @@ const backendMainSource = readFileSync(
 	resolve(import.meta.dir, "../../../backend/app/main.py"),
 	"utf8",
 );
+const backendPackageSource = readFileSync(
+	resolve(import.meta.dir, "../../../backend/pyproject.toml"),
+	"utf8",
+);
+const backendTestSource = readFileSync(
+	resolve(import.meta.dir, "../../../backend/tests/test_smoke.py"),
+	"utf8",
+);
 const channelWorkerSource = readFileSync(
 	resolve(import.meta.dir, "../../../backend/app/workers/channels.py"),
 	"utf8",
@@ -59,6 +73,14 @@ const deployConfigSource = readFileSync(
 );
 const releaseRunbook = readFileSync(
 	resolve(import.meta.dir, "../../../docs/runbooks/release.md"),
+	"utf8",
+);
+const repoRoot = resolve(import.meta.dir, "../../..");
+const lockfileSource = readFileSync(resolve(repoRoot, "bun.lock"), "utf8");
+const cliPackageSource = readFileSync(resolve(repoRoot, "packages/cli/package.json"), "utf8");
+const cliVersion = (JSON.parse(cliPackageSource) as { version: string }).version;
+const releaseClassifierSource = readFileSync(
+	resolve(repoRoot, "scripts/clawdi-image-release-plan.ts"),
 	"utf8",
 );
 
@@ -84,7 +106,7 @@ describe("backend image release workflow contract", () => {
 		expect(backendCi.concurrency?.["cancel-in-progress"]).toBe(true);
 	});
 
-	test("builds a started release from its exact successful Backend CI head SHA", () => {
+	test("compares the exact Backend CI head against cumulative successful deployment authority", () => {
 		expect(imageRelease.on?.workflow_run).toEqual({
 			workflows: ["Backend CI"],
 			types: ["completed"],
@@ -108,17 +130,29 @@ describe("backend image release workflow contract", () => {
 		expect(imageRelease.jobs.build?.steps?.find((step) => step.id === "rev")?.run).toContain(
 			"git rev-parse HEAD",
 		);
-		expect(imageReleaseSource).not.toContain("git diff-tree");
-		expect(imageReleaseSource).not.toContain("git ls-tree -r --full-tree");
-		expect(imageReleaseSource).not.toContain("runtime-changes");
-		expect(imageReleaseSource).not.toContain("build_required");
-		const sidecarRevision = imageRelease.jobs.build?.steps?.find(
-			(step) => step.name === "Resolve WhatsApp sidecar deployment revision",
+		const authority = imageRelease.jobs.build?.steps?.find(
+			(step) => step.name === "Resolve last successful deployment authority",
 		);
-		expect(sidecarRevision?.run).toContain(
-			"bun run scripts/whatsapp-sidecar-deployment-revision.ts",
+		expect(authority?.uses).toBe("actions/github-script@v8");
+		const authorityScript = String(authority?.with?.script ?? "");
+		expect(authorityScript).toContain("listWorkflowRuns");
+		expect(authorityScript).toContain("listJobsForWorkflowRun");
+		expect(authorityScript).toContain("/^deploy-vps [0-9a-f]{40}$/.test(job.name)");
+		expect(authorityScript).toContain('deploy.conclusion !== "success"');
+		expect(authorityScript).toContain('run.event === "workflow_run" ? run.head_sha : ""');
+		expect(authorityScript).toContain("right.completedAt.localeCompare(left.completedAt)");
+		expect(authorityScript).toContain('core.setOutput("base_sha", deployed[0].sha)');
+		expect(authorityScript).not.toContain("github.event.before");
+		const releasePlan = imageRelease.jobs.build?.steps?.find(
+			(step) => step.name === "Resolve image release plan",
 		);
-		const revisionStepIndex = imageRelease.jobs.build?.steps?.indexOf(sidecarRevision ?? {});
+		expect(releasePlan?.run).toContain("bun run scripts/whatsapp-sidecar-deployment-revision.ts");
+		expect(releasePlan?.run).toContain('test "$(jq -r .headSha "$plan")"');
+		expect(releasePlan?.run).toContain('git merge-base --is-ancestor "$BASE_SHA" "$HEAD_SHA"');
+		expect(releasePlan?.run).toContain('if [ "$AUTHORITY_FOUND" != true ]');
+		expect(releasePlan?.run).toContain("No unambiguous successful deployment authority was found");
+		expect(releasePlan?.run).toContain("release_required=true");
+		const revisionStepIndex = imageRelease.jobs.build?.steps?.indexOf(releasePlan ?? {});
 		const setupBunIndex = imageRelease.jobs.build?.steps?.findIndex(
 			(step) => step.uses === "oven-sh/setup-bun@v2",
 		);
@@ -128,13 +162,16 @@ describe("backend image release workflow contract", () => {
 		const backendBuild = imageRelease.jobs.build?.steps?.find(
 			(step) => step.name === "Build and push backend image",
 		);
-		expect(backendBuild?.if).toBeUndefined();
+		expect(backendBuild?.if).toBe("steps.release-plan.outputs.release_required == 'true'");
 		expect(imageReleaseSource).toContain(
 			`tags: \${{ env.BACKEND_IMAGE_NAME }}:\${{ steps.rev.outputs.sha }}`,
 		);
 
 		const deployCheckout = imageRelease.jobs["deploy-vps"]?.steps?.find(
 			(step) => step.uses === "actions/checkout@v7",
+		);
+		expect(imageRelease.jobs["deploy-vps"]?.name).toBe(
+			`deploy-vps \${{ needs.build.outputs.image_tag }}`,
 		);
 		expect(deployCheckout?.with?.ref).toBe(`\${{ needs.build.outputs.image_tag }}`);
 		expect(imageReleaseSource).toContain(
@@ -143,6 +180,127 @@ describe("backend image release workflow contract", () => {
 		expect(releaseRunbook).toContain("commit-addressed OCI image tag");
 		expect(releaseRunbook).toContain("tags remain mutable");
 		expect(releaseRunbook).not.toContain("immutable OCI image tag");
+	});
+
+	test("keeps CLI and release orchestration outside every automatic image release input", () => {
+		const baseline = calculateClawdiImageRevisions(repoRoot);
+		const probeVersion = `${cliVersion}-image-release-probe`;
+		const head = calculateClawdiImageRevisions(
+			repoRoot,
+			new Map([
+				[
+					"packages/cli/package.json",
+					replaceOnce(
+						cliPackageSource,
+						`"version": "${cliVersion}"`,
+						`"version": "${probeVersion}"`,
+					),
+				],
+				[
+					"bun.lock",
+					replaceOnce(lockfileSource, `"version": "${cliVersion}"`, `"version": "${probeVersion}"`),
+				],
+				[
+					".github/workflows/clawdi-image-release.yml",
+					replaceOnce(
+						imageReleaseSource,
+						'workflow_id: "clawdi-image-release.yml"',
+						'workflow_id: "clawdi-image-release-probe.yml"',
+					),
+				],
+				["scripts/clawdi-image-release-plan.ts", `${releaseClassifierSource}\n// probe\n`],
+			]),
+		);
+		const plan = classifyClawdiImageRelease({
+			base: baseline,
+			baseSha: "a".repeat(40),
+			head,
+			headSha: "b".repeat(40),
+		});
+
+		expect(head).toEqual(baseline);
+		expect(plan.changed).toEqual({ backend: false, deployment: false, sidecar: false });
+		expect(plan.releaseRequired).toBe(false);
+
+		const releaseGate = "steps.release-plan.outputs.release_required == 'true'";
+		for (const name of [
+			"Build and push backend image",
+			"Build and push WhatsApp sidecar image",
+			"Resolve OCI label metadata",
+		]) {
+			expect(imageRelease.jobs.build?.steps?.find((step) => step.name === name)?.if).toBe(
+				releaseGate,
+			);
+		}
+		expect(imageRelease.jobs["deploy-vps"]?.if).toBe(
+			"needs.build.outputs.release_required == 'true'",
+		);
+	});
+
+	test("classifies the deploy-vps execution contract without circular release authority", () => {
+		const baseline = calculateClawdiImageRevisions(repoRoot);
+		const changedCommand = calculateClawdiImageRevisions(
+			repoRoot,
+			new Map([
+				[
+					".github/workflows/clawdi-image-release.yml",
+					replaceOnce(
+						imageReleaseSource,
+						"kamal deploy -P --version",
+						"kamal deploy --verbose -P --version",
+					),
+				],
+			]),
+		);
+
+		expect(changedCommand.backend).toBe(baseline.backend);
+		expect(changedCommand.sidecar).toBe(baseline.sidecar);
+		expect(changedCommand.deployment).not.toBe(baseline.deployment);
+		expect(
+			imageRelease.jobs["deploy-vps"]?.steps?.some(
+				(step) => step.uses === "./.github/actions/setup-bun-ci",
+			),
+		).toBe(true);
+	});
+
+	test("matches the explicit backend Docker COPY and ignore contract", () => {
+		const baseline = calculateClawdiImageRevisions(repoRoot);
+		const ignored = calculateClawdiImageRevisions(
+			repoRoot,
+			new Map([
+				["package.json", `${readFileSync(resolve(repoRoot, "package.json"), "utf8")}\n`],
+				["bun.lock", `${lockfileSource}\n`],
+				["backend/tests/test_smoke.py", `${backendTestSource}\n# probe\n`],
+			]),
+		);
+		expect(ignored.backend).toBe(baseline.backend);
+
+		for (const [path, source] of [
+			["backend/Dockerfile", backendDockerfile],
+			["backend/pyproject.toml", backendPackageSource],
+			["backend/app/main.py", backendMainSource],
+		] as const) {
+			const changed = calculateClawdiImageRevisions(
+				repoRoot,
+				new Map([[path, `${source}\n# image-input-probe\n`]]),
+			);
+			expect(changed.backend).not.toBe(baseline.backend);
+		}
+		expect(() =>
+			calculateClawdiImageRevisions(
+				repoRoot,
+				new Map([
+					[
+						"backend/Dockerfile",
+						replaceOnce(
+							backendDockerfile,
+							"COPY backend/pyproject.toml",
+							"COPY package.json /tmp/package.json\nCOPY backend/pyproject.toml",
+						),
+					],
+				]),
+			),
+		).toThrow("backend Docker COPY contract changed");
 	});
 
 	test("admits privileged workflow_run releases only from same-repository pushes", () => {
@@ -173,7 +331,9 @@ describe("backend image release workflow contract", () => {
 			expect(job.concurrency).toBeUndefined();
 		}
 		expect(imageRelease.jobs["deploy-vps"]?.needs).toBe("build");
-		expect(imageRelease.jobs["deploy-vps"]?.if).toBeUndefined();
+		expect(imageRelease.jobs["deploy-vps"]?.if).toBe(
+			"needs.build.outputs.release_required == 'true'",
+		);
 		expect(imageRelease.on?.workflow_dispatch?.inputs?.ref?.description).toContain(
 			"Do not use an older ref while an automatic release is running or pending.",
 		);
@@ -267,3 +427,11 @@ describe("backend image release workflow contract", () => {
 		expect(releaseRunbook).toContain("expand/contract sequence");
 	});
 });
+
+function replaceOnce(source: string, current: string, replacement: string): string {
+	const first = source.indexOf(current);
+	if (first < 0 || source.indexOf(current, first + current.length) >= 0) {
+		throw new Error(`expected one image release fixture occurrence of ${current}`);
+	}
+	return `${source.slice(0, first)}${replacement}${source.slice(first + current.length)}`;
+}

--- a/packages/cli/tests/clawdi-image-release-workflow.test.ts
+++ b/packages/cli/tests/clawdi-image-release-workflow.test.ts
@@ -137,9 +137,13 @@ describe("backend image release workflow contract", () => {
 		const authorityScript = String(authority?.with?.script ?? "");
 		expect(authorityScript).toContain("listWorkflowRuns");
 		expect(authorityScript).toContain("listJobsForWorkflowRun");
-		expect(authorityScript).toContain("/^deploy-vps [0-9a-f]{40}$/.test(job.name)");
+		expect(authorityScript).toContain('job.name.startsWith("deploy-vps ")');
 		expect(authorityScript).toContain('deploy.conclusion !== "success"');
-		expect(authorityScript).toContain('run.event === "workflow_run" ? run.head_sha : ""');
+		expect(authorityScript).toContain('run.event === "workflow_run" ? run.head_sha : undefined');
+		expect(authorityScript).toContain(
+			"if (!namedSha && legacyAutomaticSha === undefined) continue",
+		);
+		expect(authorityScript).toContain('deploy.name !== "deploy-vps" && !namedSha');
 		expect(authorityScript).toContain("right.completedAt.localeCompare(left.completedAt)");
 		expect(authorityScript).toContain('core.setOutput("base_sha", deployed[0].sha)');
 		expect(authorityScript).not.toContain("github.event.before");

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -19,8 +19,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
 	applySystemdRuntimeUpdate,
-	quiesceSystemdRuntimeCandidate,
 	readSystemdUnitSnapshot,
+	SystemdRuntimeTransaction,
 } from "../../src/commands/runtime";
 import { hostedAiProviderCatalog } from "../../src/runtime/hosted-provider-resolution";
 import {
@@ -915,30 +915,28 @@ http.createServer((request, response) => {
 	};
 	const converge = () => {
 		const before = readSystemdUnitSnapshot(paths);
-		let failed = before;
+		const transaction = new SystemdRuntimeTransaction();
 		return convergeRuntimeManifest(load, paths, {
 			fileBrowserInstallOptions: {
 				download: (_url, destination) => writeFileSync(destination, binary),
 			},
 			systemdApply: {
-				quiesce: () => {
-					failed = readSystemdUnitSnapshot(paths);
-					quiesceSystemdRuntimeCandidate(paths, failed);
-				},
+				transactionState: () => transaction.state,
+				installOfficialService: (unit, install) =>
+					transaction.installOfficialService(paths, unit, install),
+				quiesce: () => transaction.quiesce(paths),
 				activateEgressPrerequisite: () => ({
 					applied: true,
 					systemUnitsChanged: [],
 					userUnitsChanged: [],
 				}),
 				activate: () => {
-					failed = readSystemdUnitSnapshot(paths);
-					return applySystemdRuntimeUpdate(paths, before, failed);
-				},
-				rollback: () => {
-					applySystemdRuntimeUpdate(paths, failed, readSystemdUnitSnapshot(paths), {
-						recoverFailedUnits: false,
+					return applySystemdRuntimeUpdate(paths, before, readSystemdUnitSnapshot(paths), {
+						transaction,
+						stage: "final-activation",
 					});
 				},
+				rollback: () => transaction.rollback(paths),
 			},
 		});
 	};
@@ -1084,6 +1082,8 @@ http.createServer((request, response) => {
 	const activeUnits = readSystemdUnitSnapshot(paths);
 	expect(
 		applySystemdRuntimeUpdate(paths, activeUnits, activeUnits, {
+			transaction: new SystemdRuntimeTransaction(),
+			stage: "final-activation",
 			activationScope: { systemUnits: [], userUnits: ["openclaw-gateway.service"] },
 		}),
 	).toEqual({ applied: true, systemUnitsChanged: [], userUnitsChanged: [] });

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -21,13 +21,13 @@ import { parse as parseYaml } from "yaml";
 import {
 	applySystemdRuntimeUpdate,
 	commitRuntimeAppliedState,
-	quiesceSystemdRuntimeCandidate,
 	readSystemdUnitSnapshot,
 	runtimeAppliedContentIdentity,
 	runtimeInit as runtimeInitWithContext,
 	runtimeOnlyChangesCliPackage,
 	runtimePublicContentRevision,
 	runtimeWatch as runtimeWatchWithContext,
+	SystemdRuntimeTransaction,
 } from "../src/commands/runtime";
 import {
 	nativeOAuthProfileId,
@@ -95,6 +95,10 @@ import {
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "../src/runtime/systemd-user";
 import { TRANSPARENT_EGRESS_PORT } from "../src/runtime/transparent-egress";
 import { getDaemonControlTokenPath } from "../src/serve/paths";
+import {
+	type TestConvergeOptions,
+	withTestSystemdTransaction,
+} from "../src/test-support/systemd-apply";
 import { mockFetch } from "./commands/helpers";
 
 const TEST_PROCESS_USER = String(process.getuid?.() ?? 0);
@@ -211,7 +215,7 @@ function loadRuntimeManifest(
 function convergeRuntimeManifest(
 	load: RuntimeManifestLoad,
 	paths: RuntimePaths,
-	opts?: Parameters<typeof convergeRuntimeManifestWithContext>[2],
+	opts: TestConvergeOptions = {},
 ) {
 	if (!process.env.CLAWDI_RUNTIME_MODE) process.env.CLAWDI_RUNTIME_MODE = "hosted";
 	if (!process.env.CLAWDI_RUNTIME_USER) process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
@@ -231,6 +235,7 @@ function convergeRuntimeManifest(
 		paths,
 		{
 			...opts,
+			systemdApply: opts.systemdApply ? withTestSystemdTransaction(opts.systemdApply) : undefined,
 			hostedOpenClawSkillDriver: opts?.hostedOpenClawSkillDriver ?? {
 				...hostedOpenClawSkillDriver,
 				resolveWorkspace: () => join(paths.userHome, ".openclaw", "workspace"),
@@ -383,6 +388,7 @@ function writeFakeSystemdManager(input: {
 	logPath: string;
 	stateRoot: string;
 	environmentRoot: string;
+	failNextGatewayRestart?: string;
 	failNextSidecarRestart?: string;
 	sidecarReadyPath?: string;
 }): void {
@@ -456,8 +462,19 @@ case "$command" in
     done
     ;;
   restart)
+    if [ "$scope" = user ] && [ "$*" = "openclaw-gateway.service" ] && [ -n '${input.failNextGatewayRestart ?? ""}' ] && [ -f '${input.failNextGatewayRestart ?? ""}' ]; then
+      rm -f '${input.failNextGatewayRestart ?? ""}'
+      rm -f "$(state_path "openclaw-gateway.service" failed)" "$(state_path "openclaw-gateway.service" not-found)"
+      touch "$(state_path "openclaw-gateway.service" active)"
+      start_process "openclaw-gateway.service"
+      printf 'injected gateway restart failure\n' >&2
+      exit 42
+    fi
     if [ "$*" = "clawdi-runtime-sidecar.service" ] && [ -n '${input.failNextSidecarRestart ?? ""}' ] && [ -f '${input.failNextSidecarRestart ?? ""}' ]; then
       rm -f '${input.failNextSidecarRestart ?? ""}'
+      rm -f "$(state_path "clawdi-runtime-sidecar.service" failed)" "$(state_path "clawdi-runtime-sidecar.service" not-found)"
+      touch "$(state_path "clawdi-runtime-sidecar.service" active)"
+      start_process "clawdi-runtime-sidecar.service"
       printf 'injected sidecar restart failure\\n' >&2
       exit 42
     fi
@@ -472,7 +489,6 @@ case "$command" in
     for unit in "$@"; do
       if [ -f "$(state_path "$unit" pid)" ]; then kill "$(cat "$(state_path "$unit" pid)")" 2>/dev/null || true; fi
       rm -f "$(state_path "$unit" active)" "$(state_path "$unit" failed)" "$(state_path "$unit" pid)"
-      touch "$(state_path "$unit" not-found)"
     done
     ;;
   enable)
@@ -530,7 +546,7 @@ afterEach(() => {
 	for (const [key, value] of Object.entries(originalEnv)) {
 		process.env[key as EnvKey] = value;
 	}
-	process.exitCode = undefined;
+	process.exitCode = 0;
 	rmSync(root, { recursive: true, force: true });
 });
 
@@ -7038,6 +7054,147 @@ exit 64
 		}
 	});
 
+	it("restores rendered state without systemd mutation when process revision preflight races PID exit", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const bin = join(root, "bin");
+		const systemctlLog = join(root, "systemctl-preflight-race.log");
+		const systemctlStateRoot = join(root, "systemctl-preflight-race-state");
+		const previousExitCode = process.exitCode;
+		const previousLog = console.log;
+		const logs: string[] = [];
+		writeFakeSystemdManager({
+			path: join(bin, "systemctl"),
+			logPath: systemctlLog,
+			stateRoot: systemctlStateRoot,
+			environmentRoot: join(run, "systemd", "env"),
+			sidecarReadyPath: join(run, "egress", "systemd", "ca.pem"),
+		});
+		process.env.CLAWDI_SYSTEMD_APPLY = "1";
+		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
+		const paths = seedRuntimeWatchLocaleBaseline(home, state, run);
+		const baselineUnits = readSystemdUnitSnapshot(paths);
+		seedFakeSystemdSnapshotProcesses(paths, systemctlStateRoot, baselineUnits);
+		for (const unit of baselineUnits.user.keys()) {
+			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "enabled"), "\n");
+		}
+		console.log = (value?: unknown) => logs.push(String(value));
+		process.exitCode = undefined;
+		setRuntimeApplyGeneration(2, CANONICAL_TEST_CONTEXT);
+		const warmupFetch = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/runtime/manifest",
+				response: () =>
+					hostedRuntimeBundleResponse(hostedRuntimeWatchLocalePayload(home, 2), {
+						etag: testBundleEtag("manifest-preflight-race-2"),
+					}),
+			},
+		]);
+		try {
+			await runtimeWatch({ once: true, json: true });
+		} finally {
+			warmupFetch.restore();
+		}
+		if (process.exitCode !== undefined && process.exitCode !== 0) {
+			throw new Error(logs.join("\n"));
+		}
+		const activeUnits = readSystemdUnitSnapshot(paths);
+		writeFileSync(
+			fakeSystemdStatePath(systemctlStateRoot, "system", "clawdi-files.service", "active"),
+			"\n",
+		);
+		const gatewayPidPath = fakeSystemdStatePath(
+			systemctlStateRoot,
+			"user",
+			"openclaw-gateway.service",
+			"pid",
+		);
+		const gatewayPid = Number(readFileSync(gatewayPidPath, "utf8").trim());
+		process.kill(gatewayPid, "SIGTERM");
+		writeFileSync(gatewayPidPath, "2147483647\n");
+
+		const transaction = new SystemdRuntimeTransaction();
+		expect(() =>
+			applySystemdRuntimeUpdate(paths, activeUnits, activeUnits, {
+				transaction,
+				stage: "final-activation",
+			}),
+		).toThrow(
+			"could not prove active runtime revision for managed systemd unit openclaw-gateway.service",
+		);
+		expect(transaction.journal).toEqual([]);
+
+		const gatewayEnvPath = join(paths.systemdEnvRoot, "openclaw-gateway.service.env");
+		const gatewayDropInPath = join(
+			paths.systemdUserRoot,
+			"openclaw-gateway.service.d",
+			"10-clawdi-hosted.conf",
+		);
+		const preImage = {
+			managedConfig: readFileSync(paths.managedConfig, "utf8"),
+			gatewayEnv: readFileSync(gatewayEnvPath, "utf8"),
+			gatewayDropIn: readFileSync(gatewayDropInPath, "utf8"),
+			appliedState: readFileSync(paths.appliedState, "utf8"),
+			managerState: Object.fromEntries(
+				readdirSync(systemctlStateRoot)
+					.sort()
+					.map((entry) => [entry, readFileSync(join(systemctlStateRoot, entry), "utf8")]),
+			),
+		};
+		writeFileSync(systemctlLog, "");
+		logs.length = 0;
+		process.exitCode = undefined;
+		setRuntimeApplyGeneration(3, CANONICAL_TEST_CONTEXT);
+		const fetchMock = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/runtime/manifest",
+				response: () =>
+					hostedRuntimeBundleResponse(hostedRuntimeWatchLocalePayload(home, 3, "en"), {
+						etag: testBundleEtag("manifest-preflight-race-3"),
+					}),
+			},
+		]);
+		try {
+			await runtimeWatch({ once: true, json: true });
+		} finally {
+			fetchMock.restore();
+			console.log = previousLog;
+			process.exitCode = previousExitCode;
+		}
+
+		const event = JSON.parse(logs.at(-1) ?? "{}");
+		expect(event.status).toBe("error");
+		expect(event.error).toContain(
+			"could not prove active runtime revision for managed systemd unit openclaw-gateway.service",
+		);
+		expect(readFileSync(paths.managedConfig, "utf8")).toBe(preImage.managedConfig);
+		expect(readFileSync(gatewayEnvPath, "utf8")).toBe(preImage.gatewayEnv);
+		expect(readFileSync(gatewayDropInPath, "utf8")).toBe(preImage.gatewayDropIn);
+		expect(readFileSync(paths.appliedState, "utf8")).toBe(preImage.appliedState);
+		expect(systemdEnvRevision(readFileSync(gatewayEnvPath, "utf8"))).toBe(
+			systemdEnvRevision(preImage.gatewayEnv),
+		);
+		expect(
+			Object.fromEntries(
+				readdirSync(systemctlStateRoot)
+					.sort()
+					.map((entry) => [entry, readFileSync(join(systemctlStateRoot, entry), "utf8")]),
+			),
+		).toEqual(preImage.managerState);
+		const mutationCalls = readFileSync(systemctlLog, "utf8")
+			.trim()
+			.split("\n")
+			.filter((call) =>
+				/^(?:--user )?(?:daemon-reload|disable|enable|reset-failed|restart|start|stop)(?: |$)/.test(
+					call,
+				),
+			);
+		expect(mutationCalls).toEqual([]);
+	});
+
 	it("runtime watch keeps polling after SSE authentication failure", async () => {
 		installSuccessfulSystemctlFixture();
 		const home = join(root, "home", "clawdi");
@@ -9101,6 +9258,8 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		writeFileSync(systemctlLog, "");
 
 		const applied = applySystemdRuntimeUpdate(paths, before, after, {
+			transaction: new SystemdRuntimeTransaction(),
+			stage: "final-activation",
 			forceRestartSystemUnits: ["clawdi-daemon.service"],
 			preserveActiveUnits: true,
 		});
@@ -9135,6 +9294,8 @@ printf 'ActiveState=active\\nSubState=running\\n'
 
 		expect(
 			applySystemdRuntimeUpdate(paths, driftedUnits, driftedUnits, {
+				transaction: new SystemdRuntimeTransaction(),
+				stage: "final-activation",
 				preserveActiveUnits: true,
 			}),
 		).toEqual({
@@ -9146,6 +9307,92 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		expect(driftRepairCalls).not.toContain("daemon-reload");
 		expect(driftRepairCalls).toContain("--user restart hermes-gateway.service");
 		expect(driftRepairCalls).not.toContain("restart clawdi-runtime-watch.service");
+	});
+
+	it("rolls back a manager reload without attributing or stopping business units", () => {
+		const home = join(root, "home", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const systemctlPath = join(root, "bin", "systemctl");
+		const systemctlLog = join(root, "systemctl-reload-only.log");
+		const systemctlStateRoot = join(root, "systemctl-reload-only-state");
+		writeFakeSystemdManager({
+			path: systemctlPath,
+			logPath: systemctlLog,
+			stateRoot: systemctlStateRoot,
+			environmentRoot: join(run, "systemd", "env"),
+		});
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlPath;
+		process.env.CLAWDI_SYSTEMD_APPLY = "1";
+		const paths = getRuntimePaths();
+		const units = {
+			system: new Map<string, string>(),
+			user: new Map([["openclaw-gateway.service", "gateway"]]),
+		};
+		mkdirSync(paths.systemdEnvRoot, { recursive: true });
+		writeFileSync(
+			join(paths.systemdEnvRoot, "openclaw-gateway.service.env"),
+			`CLAWDI_RUNTIME_REV="${"a".repeat(32)}"\n`,
+		);
+		seedFakeSystemdSnapshotProcesses(paths, systemctlStateRoot, units);
+		writeFileSync(
+			fakeSystemdStatePath(systemctlStateRoot, "user", "openclaw-gateway.service", "enabled"),
+			"\n",
+		);
+		writeFileSync(
+			fakeSystemdStatePath(systemctlStateRoot, "user", "openclaw-gateway.service", "reload"),
+			"\n",
+		);
+		writeFileSync(
+			fakeSystemdStatePath(systemctlStateRoot, "system", "clawdi-files.service", "active"),
+			"\n",
+		);
+		writeFileSync(systemctlLog, "");
+		const transaction = new SystemdRuntimeTransaction();
+
+		expect(
+			applySystemdRuntimeUpdate(paths, units, units, {
+				transaction,
+				stage: "final-activation",
+			}),
+		).toEqual({ applied: true, systemUnitsChanged: [], userUnitsChanged: [] });
+		transaction.quiesce(paths);
+		transaction.rollback(paths);
+
+		expect(transaction.journal).toEqual([
+			{
+				sequence: 1,
+				stage: "final-activation",
+				scope: "user",
+				action: "daemon-reload",
+				units: [],
+				outcome: "succeeded",
+			},
+			{
+				sequence: 2,
+				stage: "rollback",
+				scope: "user",
+				action: "daemon-reload",
+				units: [],
+				outcome: "succeeded",
+			},
+		]);
+		expect(readFileSync(systemctlLog, "utf8").trim().split("\n")).toEqual([
+			"--user show openclaw-gateway.service --property=LoadState --property=ActiveState --property=MainPID --property=NeedDaemonReload",
+			"--user is-enabled openclaw-gateway.service",
+			"--user daemon-reload",
+			"--user show openclaw-gateway.service --property=LoadState --property=ActiveState --property=MainPID --property=NeedDaemonReload",
+			"--user is-enabled openclaw-gateway.service",
+			"--user daemon-reload",
+		]);
+		expect(
+			existsSync(
+				fakeSystemdStatePath(systemctlStateRoot, "system", "clawdi-files.service", "active"),
+			),
+		).toBe(true);
 	});
 
 	it("stops the egress sidecar while proving independent system units ready", () => {
@@ -9191,6 +9438,8 @@ fi
 		};
 
 		const applied = applySystemdRuntimeUpdate(paths, units, units, {
+			transaction: new SystemdRuntimeTransaction(),
+			stage: "final-activation",
 			forceRestartSystemUnits: ["clawdi-daemon.service"],
 			forceStopSystemUnits: ["clawdi-runtime-sidecar.service"],
 		});
@@ -9206,53 +9455,6 @@ fi
 		expect(calls).not.toContain("start clawdi-runtime-sidecar.service");
 		expect(calls).not.toContain("restart clawdi-runtime-sidecar.service");
 		expect(readFileSync(sidecarState, "utf-8")).toBe("inactive\n");
-	});
-
-	it("quiesces candidate services before their transparent-egress handoff is removed", () => {
-		const home = join(root, "home", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const systemctlPath = join(root, "bin", "systemctl");
-		const systemctlLog = join(root, "systemctl-quiesce.log");
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
-		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlPath;
-		process.env.CLAWDI_SYSTEMD_APPLY = "1";
-		const paths = getRuntimePaths();
-		mkdirSync(dirname(systemctlPath), { recursive: true });
-		mkdirSync(dirname(paths.egressTransparentEnv), { recursive: true });
-		writeFileSync(paths.egressTransparentEnv, "CLAWDI_EGRESS_TRANSPARENT_PORT=27212\n");
-		writeFileSync(
-			systemctlPath,
-			`#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\n' "$*" >> '${systemctlLog}'
-if [ "\${1:-}" = "stop" ] && [[ " $* " = *" clawdi-runtime-sidecar.service "* ]]; then
-  test -f '${paths.egressTransparentEnv}'
-  printf 'sidecar-env-present\\n' >> '${systemctlLog}'
-fi
-`,
-		);
-		chmodSync(systemctlPath, 0o700);
-		const candidate: Parameters<typeof quiesceSystemdRuntimeCandidate>[1] = {
-			system: new Map([
-				["clawdi-runtime-watch.service", "watch"],
-				["clawdi-daemon.service", "daemon"],
-				["clawdi-runtime-sidecar.service", "sidecar"],
-				["clawdi-files.service", "files"],
-			]),
-			user: new Map([["openclaw-gateway.service", "gateway"]]),
-		};
-
-		quiesceSystemdRuntimeCandidate(paths, candidate);
-		rmSync(paths.egressTransparentEnv);
-
-		expect(readFileSync(systemctlLog, "utf-8").trim().split("\n")).toEqual([
-			"--user stop openclaw-gateway.service",
-			"stop clawdi-daemon.service clawdi-files.service clawdi-runtime-sidecar.service",
-			"sidecar-env-present",
-		]);
 	});
 
 	it("hands off a CLI-only checkpoint by restarting only the daemon once", async () => {
@@ -9742,7 +9944,7 @@ fi
 		const bin = join(root, "bin");
 		const systemctlLog = join(root, "systemctl-egress-rotation.log");
 		const systemctlStateRoot = join(root, "systemctl-egress-state");
-		const failNextSidecarRestart = join(root, "fail-next-sidecar-restart");
+		const failNextGatewayRestart = join(root, "fail-next-gateway-restart");
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const logs: string[] = [];
@@ -9754,7 +9956,7 @@ fi
 			logPath: systemctlLog,
 			stateRoot: systemctlStateRoot,
 			environmentRoot: join(run, "systemd", "env"),
-			failNextSidecarRestart,
+			failNextGatewayRestart,
 			sidecarReadyPath: join(run, "egress", "systemd", "ca.pem"),
 		});
 		writeFileSync(
@@ -9975,7 +10177,29 @@ fi
 			);
 			chmodSync(egressSecretFile, 0o600);
 			writeFileSync(systemctlLog, "");
-			writeFileSync(failNextSidecarRestart, "fail\n");
+			writeFileSync(failNextGatewayRestart, "fail\n");
+			writeFileSync(
+				fakeSystemdStatePath(systemctlStateRoot, "system", "clawdi-files.service", "active"),
+				"active\n",
+			);
+			writeFileSync(
+				fakeSystemdStatePath(systemctlStateRoot, "system", "clawdi-unrelated.service", "failed"),
+				"failed\n",
+			);
+			rmSync(
+				fakeSystemdStatePath(systemctlStateRoot, "system", "clawdi-daemon.service", "active"),
+				{ force: true },
+			);
+			rmSync(
+				fakeSystemdStatePath(systemctlStateRoot, "user", "openclaw-gateway.service", "enabled"),
+				{ force: true },
+			);
+			seedFakeSystemdProcess(
+				systemctlStateRoot,
+				"user",
+				"openclaw-gateway.service",
+				"0".repeat(32),
+			);
 			logs.length = 0;
 			process.exitCode = undefined;
 			const rejectedFetch = mockFetch([
@@ -10022,23 +10246,48 @@ fi
 			expect(readFileSync(paths.managedSecretCacheFile, "utf-8")).toBe(committedSecretCache);
 			const rollbackSystemctlCalls = readFileSync(systemctlLog, "utf-8").trim().split("\n");
 			expect(rollbackSystemctlCalls).not.toContain("official openclaw installer");
-			expect(rollbackSystemctlCalls).not.toContain("restart openclaw-gateway.service");
-			expect(rollbackSystemctlCalls).not.toContain("restart clawdi-daemon.service");
-			const failedRestart = rollbackSystemctlCalls.indexOf(
+			const rollbackMutations = rollbackSystemctlCalls.filter((call) =>
+				/^(?:--user )?(?:daemon-reload|disable|enable|reset-failed|restart|start|stop)(?: |$)/.test(
+					call,
+				),
+			);
+			expect(rollbackMutations).toEqual([
+				"start clawdi-daemon.service",
 				"restart clawdi-runtime-sidecar.service",
-			);
-			const quiesce = rollbackSystemctlCalls.findIndex(
-				(call) => call.startsWith("stop ") && call.includes("clawdi-runtime-sidecar.service"),
-			);
-			const priorStart = rollbackSystemctlCalls.findIndex(
-				(call, index) =>
-					index > quiesce &&
-					(call.startsWith("start ") || call.startsWith("restart ")) &&
-					call.includes("clawdi-runtime-sidecar.service"),
-			);
-			expect(failedRestart).toBeGreaterThanOrEqual(0);
-			expect(quiesce).toBeGreaterThan(failedRestart);
-			expect(priorStart).toBeGreaterThan(quiesce);
+				"--user enable openclaw-gateway.service",
+				"--user restart openclaw-gateway.service",
+				"--user stop openclaw-gateway.service",
+				"stop clawdi-daemon.service",
+				"stop clawdi-runtime-sidecar.service",
+				"start clawdi-runtime-sidecar.service",
+				"--user disable openclaw-gateway.service",
+				"--user start openclaw-gateway.service",
+			]);
+			expect(
+				existsSync(
+					fakeSystemdStatePath(systemctlStateRoot, "system", "clawdi-daemon.service", "active"),
+				),
+			).toBe(false);
+			expect(
+				existsSync(
+					fakeSystemdStatePath(systemctlStateRoot, "user", "openclaw-gateway.service", "active"),
+				),
+			).toBe(true);
+			expect(
+				existsSync(
+					fakeSystemdStatePath(systemctlStateRoot, "user", "openclaw-gateway.service", "enabled"),
+				),
+			).toBe(false);
+			expect(
+				existsSync(
+					fakeSystemdStatePath(systemctlStateRoot, "system", "clawdi-files.service", "active"),
+				),
+			).toBe(true);
+			expect(
+				existsSync(
+					fakeSystemdStatePath(systemctlStateRoot, "system", "clawdi-unrelated.service", "failed"),
+				),
+			).toBe(true);
 
 			writeFileSync(systemctlLog, "");
 			logs.length = 0;
@@ -13299,11 +13548,12 @@ exit 64
 		expect(unrelatedSecret.installErrors).toEqual([]);
 		expect(statSync(hermesDropIn).ino).toBe(initialHermesDropInInode);
 		process.env.CLAWDI_SYSTEMD_APPLY = "1";
-		expect(applySystemdRuntimeUpdate(paths, initialUnits, readSystemdUnitSnapshot(paths))).toEqual({
-			applied: true,
-			systemUnitsChanged: [],
-			userUnitsChanged: [],
-		});
+		expect(
+			applySystemdRuntimeUpdate(paths, initialUnits, readSystemdUnitSnapshot(paths), {
+				transaction: new SystemdRuntimeTransaction(),
+				stage: "final-activation",
+			}),
+		).toEqual({ applied: true, systemUnitsChanged: [], userUnitsChanged: [] });
 		expect(systemdEnvRevision(readSystemdEnvFile(paths, "hermes-gateway"))).toBe(
 			initialHermesRevision,
 		);
@@ -13347,6 +13597,8 @@ exit 64
 		process.env.CLAWDI_SYSTEMD_APPLY = "1";
 		expect(
 			applySystemdRuntimeUpdate(paths, beforeCredentialChange, readSystemdUnitSnapshot(paths), {
+				transaction: new SystemdRuntimeTransaction(),
+				stage: "final-activation",
 				preserveActiveUnits,
 			}),
 		).toEqual({

--- a/scripts/clawdi-image-release-plan.ts
+++ b/scripts/clawdi-image-release-plan.ts
@@ -1,0 +1,208 @@
+#!/usr/bin/env bun
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	calculateWhatsAppSidecarDeploymentRevisionFromSnapshot,
+	type RevisionSnapshot,
+} from "./whatsapp-sidecar-deployment-revision";
+
+const BACKEND_ROOT = "backend";
+const IMAGE_RELEASE_WORKFLOW = ".github/workflows/clawdi-image-release.yml";
+const DEPLOYMENT_FILE_INPUTS = [
+	".github/actions/setup-bun-ci/action.yml",
+	"config/deploy.yml",
+	"scripts/deploy-whatsapp-sidecar.sh",
+] as const;
+
+export interface ClawdiImageRevisions {
+	backend: string;
+	deployment: string;
+	sidecar: string;
+}
+
+export interface ClawdiImageReleasePlan {
+	base: ClawdiImageRevisions;
+	baseSha: string;
+	changed: { backend: boolean; deployment: boolean; sidecar: boolean };
+	head: ClawdiImageRevisions;
+	headSha: string;
+	releaseRequired: boolean;
+}
+
+export function calculateClawdiImageRevisions(
+	repositoryRoot: string,
+	overrides: ReadonlyMap<string, string> = new Map(),
+): ClawdiImageRevisions {
+	return calculateClawdiImageRevisionsFromSnapshot({
+		listFiles: (root) => filesystemFiles(repositoryRoot, root),
+		readText: (path) => overrides.get(path) ?? readFileSync(join(repositoryRoot, path), "utf8"),
+	});
+}
+
+export function calculateClawdiImageRevisionsFromSnapshot(
+	snapshot: RevisionSnapshot,
+): ClawdiImageRevisions {
+	const dockerignore = snapshot.readText(".dockerignore");
+	assertBackendDockerInputContract(snapshot.readText("backend/Dockerfile"), dockerignore);
+	const backendInputs = new Map<string, string>([[".dockerignore", dockerignore]]);
+	for (const path of snapshot.listFiles(BACKEND_ROOT)) {
+		if (path.startsWith("backend/tests/")) continue;
+		backendInputs.set(path, snapshot.readText(path));
+	}
+	const deploymentInputs = new Map<string, string>([
+		[
+			`${IMAGE_RELEASE_WORKFLOW}#jobs.deploy-vps.steps`,
+			extractDeployVpsExecutionContract(snapshot.readText(IMAGE_RELEASE_WORKFLOW)),
+		],
+	]);
+	for (const path of DEPLOYMENT_FILE_INPUTS) {
+		deploymentInputs.set(path, snapshot.readText(path));
+	}
+	return {
+		backend: hashInputs(backendInputs),
+		deployment: hashInputs(deploymentInputs),
+		sidecar: calculateWhatsAppSidecarDeploymentRevisionFromSnapshot(snapshot),
+	};
+}
+
+function assertBackendDockerInputContract(dockerfile: string, dockerignore: string): void {
+	const copyInstructions = dockerfile
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter((line) => line.startsWith("COPY "));
+	const expectedCopies = [
+		"COPY backend/pyproject.toml backend/uv.lock backend/alembic.ini ./",
+		"COPY --chown=app:app backend/ /app/backend/",
+	];
+	if (stableStringify(copyInstructions) !== stableStringify(expectedCopies)) {
+		throw new Error("backend Docker COPY contract changed; update the image revision inputs");
+	}
+	const ignoreRules = new Set(
+		dockerignore
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter(Boolean),
+	);
+	for (const rule of ["backend/.venv", "backend/data", "backend/tests"]) {
+		if (!ignoreRules.has(rule)) {
+			throw new Error(`backend Docker ignore contract is missing ${rule}`);
+		}
+	}
+}
+
+function extractDeployVpsExecutionContract(workflowSource: string): string {
+	// The durable deployment authority covers the executable deploy job and the
+	// repository files it invokes. Release gating/authority orchestration stays
+	// outside this contract, so changing the classifier cannot trigger itself.
+	const workflow = Bun.YAML.parse(workflowSource) as {
+		jobs?: {
+			"deploy-vps"?: {
+				steps?: Array<{
+					env?: Record<string, unknown>;
+					run?: string;
+					uses?: string;
+					with?: Record<string, unknown>;
+				}>;
+			};
+		};
+	};
+	const steps = workflow.jobs?.["deploy-vps"]?.steps;
+	if (!Array.isArray(steps) || steps.length === 0) {
+		throw new Error("image release workflow must define deploy-vps execution steps");
+	}
+	return stableStringify(
+		steps.map(({ env, run, uses, with: inputs }) => ({
+			...(uses === undefined ? {} : { uses }),
+			...(inputs === undefined ? {} : { with: inputs }),
+			...(env === undefined ? {} : { env }),
+			...(run === undefined ? {} : { run }),
+		})),
+	);
+}
+
+export function classifyClawdiImageRelease(input: {
+	base: ClawdiImageRevisions;
+	baseSha: string;
+	head: ClawdiImageRevisions;
+	headSha: string;
+}): ClawdiImageReleasePlan {
+	const changed = {
+		backend: input.base.backend !== input.head.backend,
+		deployment: input.base.deployment !== input.head.deployment,
+		sidecar: input.base.sidecar !== input.head.sidecar,
+	};
+	return { ...input, changed, releaseRequired: Object.values(changed).some(Boolean) };
+}
+
+function gitSnapshot(repositoryRoot: string, revision: string): RevisionSnapshot {
+	if (!/^[a-f0-9]{40}$/.test(revision)) throw new Error(`invalid Git revision: ${revision}`);
+	return {
+		listFiles: (root) =>
+			git(repositoryRoot, ["ls-tree", "-r", "--name-only", revision, "--", root])
+				.split("\n")
+				.filter(Boolean)
+				.sort(),
+		readText: (path) => git(repositoryRoot, ["show", `${revision}:${path}`]),
+	};
+}
+
+function git(repositoryRoot: string, args: string[]): string {
+	const result = spawnSync("git", args, { cwd: repositoryRoot, encoding: "utf8" });
+	if (result.status !== 0 || result.error) {
+		throw new Error(`git ${args[0]} failed: ${result.stderr.trim() || result.error?.message}`);
+	}
+	return result.stdout;
+}
+
+function filesystemFiles(repositoryRoot: string, root: string): string[] {
+	const absoluteRoot = join(repositoryRoot, root);
+	return readdirSync(absoluteRoot, { recursive: true, withFileTypes: true })
+		.filter((entry) => entry.isFile())
+		.map((entry) => relative(repositoryRoot, join(entry.parentPath, entry.name)))
+		.sort();
+}
+
+function hashInputs(inputs: ReadonlyMap<string, string>): string {
+	const hash = createHash("sha256");
+	for (const [name, value] of [...inputs].sort(([left], [right]) => left.localeCompare(right))) {
+		hash.update(`${Buffer.byteLength(name)}:${name}:${Buffer.byteLength(value)}:`);
+		hash.update(value);
+	}
+	return hash.digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+	if (value === null || typeof value !== "object") {
+		const serialized = JSON.stringify(value);
+		if (serialized === undefined) throw new Error("deployment contract is not serializable");
+		return serialized;
+	}
+	if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+	return `{${Object.entries(value)
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
+		.join(",")}}`;
+}
+
+if (import.meta.main) {
+	const [baseSha, headSha] = process.argv.slice(2);
+	if (!baseSha || !headSha) {
+		throw new Error("usage: clawdi-image-release-plan.ts <base-sha> <head-sha>");
+	}
+	const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+	const repositoryRoot = resolve(scriptDirectory, "..");
+	console.log(
+		JSON.stringify(
+			classifyClawdiImageRelease({
+				base: calculateClawdiImageRevisionsFromSnapshot(gitSnapshot(repositoryRoot, baseSha)),
+				baseSha,
+				head: calculateClawdiImageRevisionsFromSnapshot(gitSnapshot(repositoryRoot, headSha)),
+				headSha,
+			}),
+		),
+	);
+}

--- a/scripts/whatsapp-sidecar-deployment-revision.ts
+++ b/scripts/whatsapp-sidecar-deployment-revision.ts
@@ -34,27 +34,41 @@ const DIRECT_FILE_INPUTS = [
 	`${SIDECAR_ROOT}/tsconfig.build.json`,
 ] as const;
 
+export interface RevisionSnapshot {
+	listFiles(root: string): string[];
+	readText(path: string): string;
+}
+
 type TextOverrides = ReadonlyMap<string, string>;
 
 export function calculateWhatsAppSidecarDeploymentRevision(
 	repositoryRoot: string,
 	overrides: TextOverrides = new Map(),
 ): string {
-	const readText = (path: string): string =>
-		overrides.get(path) ?? readFileSync(join(repositoryRoot, path), "utf8");
-	const dockerfile = readText(`${SIDECAR_ROOT}/Dockerfile`);
-	assertDockerInputContract(dockerfile, readText(".dockerignore"));
+	return calculateWhatsAppSidecarDeploymentRevisionFromSnapshot({
+		listFiles: (root) => filesystemFiles(repositoryRoot, root),
+		readText: (path) => overrides.get(path) ?? readFileSync(join(repositoryRoot, path), "utf8"),
+	});
+}
+
+export function calculateWhatsAppSidecarDeploymentRevisionFromSnapshot(
+	snapshot: RevisionSnapshot,
+): string {
+	const dockerfile = snapshot.readText(`${SIDECAR_ROOT}/Dockerfile`);
+	assertDockerInputContract(dockerfile, snapshot.readText(".dockerignore"));
 
 	const inputs = new Map<string, string>();
-	for (const path of DIRECT_FILE_INPUTS) inputs.set(path, readText(path));
-	for (const path of runtimeSourceFiles(repositoryRoot)) inputs.set(path, readText(path));
+	for (const path of DIRECT_FILE_INPUTS) inputs.set(path, snapshot.readText(path));
+	for (const path of snapshot.listFiles(SIDECAR_SOURCE_ROOT)) {
+		if (!path.endsWith(".test.ts")) inputs.set(path, snapshot.readText(path));
+	}
 	inputs.set(
 		"bun.lock#whatsapp-sidecar-dependency-closure",
-		stableStringify(sidecarDependencyClosure(readText("bun.lock"))),
+		stableStringify(sidecarDependencyClosure(snapshot.readText("bun.lock"))),
 	);
 	inputs.set(
 		"config/deploy.yml#accessories.whatsapp-baileys",
-		extractWhatsAppSidecarAccessory(readText("config/deploy.yml")),
+		extractWhatsAppSidecarAccessory(snapshot.readText("config/deploy.yml")),
 	);
 
 	const hash = createHash("sha256");
@@ -174,10 +188,10 @@ function platformMatches(constraint: unknown, target: string): boolean {
 	return !denied && (allowed.length === 0 || allowed.includes(target));
 }
 
-function runtimeSourceFiles(repositoryRoot: string): string[] {
-	const absoluteRoot = join(repositoryRoot, SIDECAR_SOURCE_ROOT);
+function filesystemFiles(repositoryRoot: string, root: string): string[] {
+	const absoluteRoot = join(repositoryRoot, root);
 	return readdirSync(absoluteRoot, { recursive: true, withFileTypes: true })
-		.filter((entry) => entry.isFile() && !entry.name.endsWith(".test.ts"))
+		.filter((entry) => entry.isFile())
 		.map((entry) => relative(repositoryRoot, join(entry.parentPath, entry.name)))
 		.sort();
 }


### PR DESCRIPTION
## Summary
- journal systemd mutations and skip systemd rollback when failure occurs during preflight before any mutation
- restore only transaction-touched units, including exact active/disabled state
- classify cumulative backend/sidecar image inputs so a CLI-only merge does not build or deploy service images
- publish `clawdi@0.13.71` through the protected CLI workflow

## Root cause
A `/proc/<MainPID>/environ` PID race happened before any systemd mutation, but the previous catch path treated entering the activation hook as mutation authority and quiesced unrelated runtime services.

## Verification
- full CLI clean runner: 1650 passed, 4 skipped, 0 failed
- release focused: 19 passed
- official installer focused: 4 passed
- workspace typecheck: 4/4
- Biome: 999 files
- frozen lock and publish manifest passed
- image release plan from deployed-compatible base to this head: backend=false, sidecar=false, deployment=false, releaseRequired=false

## Release impact
Merging publishes only the new CLI package. The automatic image workflow must classify this merge as `releaseRequired=false`; it must not build or deploy backend, web, or WhatsApp sidecar images.