### PR TITLE
fix(cli): avoid restarts for managed catalog updates

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.71",
+      "version": "0.13.72",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.71",
+	"version": "0.13.72",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -2474,7 +2474,11 @@ function previewHostedAiProviderProjectionRevision(
 		}
 		return runtimeImpactRevision({
 			openClawProviderProjection: "json-patch",
-			patch: providerPatch.content,
+			patch: providerProjectionProgramImpact(
+				"openclaw",
+				JSON.parse(providerPatch.content) as unknown,
+				projectionInput,
+			),
 		});
 	}
 	return applyHostedHermesAiProviderProjection(
@@ -2484,6 +2488,37 @@ function previewHostedAiProviderProjectionRevision(
 		home,
 		false,
 	).revision;
+}
+
+function providerProjectionProgramImpact(
+	runtime: "openclaw" | "hermes",
+	patch: unknown,
+	projectionInput: HostedAiProviderProjectionInput,
+): unknown {
+	const root = recordValue(patch);
+	const managedProviderIds = new Set(
+		projectionInput.catalog.providers
+			.filter((provider) => provider.managed_by === "clawdi")
+			.map((provider) => provider.id),
+	);
+	if (!root || managedProviderIds.size === 0) return patch;
+
+	const providerContainer = runtime === "openclaw" ? recordValue(root.models) : root;
+	if (!providerContainer) return patch;
+	const providers = recordValue(providerContainer.providers);
+	if (!providers) return patch;
+	const programProviders = Object.fromEntries(
+		Object.entries(providers).map(([providerId, provider]) => {
+			const providerConfig = recordValue(provider);
+			if (!managedProviderIds.has(providerId) || !providerConfig) return [providerId, provider];
+			const { models: _models, ...programConfig } = providerConfig;
+			return [providerId, programConfig];
+		}),
+	);
+	if (runtime === "openclaw") {
+		return { ...root, models: { ...providerContainer, providers: programProviders } };
+	}
+	return { ...root, providers: programProviders };
 }
 
 function applyHostedCodexManagedProviderProjection(
@@ -2732,7 +2767,7 @@ function applyHostedHermesAiProviderProjection(
 		providerIds: activeProviderIds,
 		revision: runtimeImpactRevision({
 			hermesProviderProjection: "yaml-merge",
-			patch: patchContent,
+			patch: providerProjectionProgramImpact("hermes", parseYaml(patchContent), projectionInput),
 		}),
 	};
 }

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1244,6 +1244,71 @@ exit 0
 	chmodSync(openclawBin, 0o700);
 }
 
+function writeOpenClawConfigMutationFixture(
+	home: string,
+	initialConfig: Record<string, unknown> = {},
+): { configPath: string; commandLog: string; mutationLog: string } {
+	const commandPath = join(home, ".local", "bin", "openclaw");
+	const packageRoot = join(home, ".local", "lib", "node_modules", "openclaw");
+	const configPath = join(home, ".openclaw", "openclaw.json");
+	const commandLog = join(home, ".openclaw-test-commands.log");
+	const mutationLog = join(home, ".openclaw-test-mutation.json");
+	mkdirSync(dirname(commandPath), { recursive: true });
+	mkdirSync(packageRoot, { recursive: true });
+	mkdirSync(dirname(configPath), { recursive: true });
+	writeFileSync(configPath, `${JSON.stringify(initialConfig, null, 2)}\n`);
+	writeFileSync(commandLog, "");
+	writeFileSync(
+		commandPath,
+		`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> '${commandLog}'
+if [ "\${1:-}" = "--version" ]; then printf 'openclaw test-version\n'; exit 0; fi
+if [ "$*" = "agents list --json" ]; then printf '[{"id":"main","workspace":"${home}/.openclaw/workspace"}]\n'; exit 0; fi
+if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then cat >/dev/null; fi
+exit 0
+`,
+	);
+	chmodSync(commandPath, 0o700);
+	writeFileSync(
+		join(packageRoot, "package.json"),
+		JSON.stringify({
+			name: "openclaw",
+			type: "module",
+			exports: { "./plugin-sdk/config-mutation": "./config-mutation.mjs" },
+		}),
+	);
+	writeFileSync(
+		join(packageRoot, "config-mutation.mjs"),
+		`import { readFileSync, writeFileSync } from "node:fs";
+export async function mutateConfigFile(options) {
+  if (options.base !== "source") throw new Error("expected source config mutation");
+  if (options.afterWrite?.mode !== "none") throw new Error("expected no SDK-owned restart");
+  const before = JSON.parse(readFileSync(${JSON.stringify(configPath)}, "utf8"));
+  const draft = structuredClone(before);
+  await options.mutate(draft, { snapshot: {}, previousHash: null, attempt: 1 });
+  const next = JSON.stringify(draft, null, 2) + "\\n";
+  const beforeBytes = Buffer.byteLength(JSON.stringify(before, null, 2) + "\\n");
+  const nextBytes = Buffer.byteLength(next);
+  if (nextBytes < Math.floor(beforeBytes * 0.5) && options.writeOptions?.allowConfigSizeDrop !== true) {
+    throw new Error(\`size-drop:\${beforeBytes}->\${nextBytes}\`);
+  }
+  writeFileSync(${JSON.stringify(configPath)}, next);
+  writeFileSync(${JSON.stringify(mutationLog)}, JSON.stringify({
+    base: options.base,
+    afterWrite: options.afterWrite,
+    allowConfigSizeDrop: options.writeOptions?.allowConfigSizeDrop,
+    explicitSetPaths: options.writeOptions?.explicitSetPaths,
+    unsetPaths: options.writeOptions?.unsetPaths,
+    beforeBytes,
+    nextBytes,
+  }));
+}
+`,
+	);
+	return { configPath, commandLog, mutationLog };
+}
+
 function openClawDiscordPluginInspectFixture(pluginSource: string): Record<string, unknown> {
 	return {
 		plugin: {
@@ -3667,12 +3732,6 @@ chmod +x "$HOME/.local/bin/hermes"
 		const home = join(root, "model-switch", "home", "clawdi");
 		const state = join(root, "model-switch", "var", "lib", "clawdi");
 		const run = join(root, "model-switch", "run", "clawdi");
-		const openclawBin = join(home, ".local", "bin", "openclaw");
-		const openclawPackage = join(home, ".local", "lib", "node_modules", "openclaw");
-		const openclawConfig = join(home, ".openclaw", "openclaw.json");
-		const commandLog = join(root, "openclaw-model-switch-command.txt");
-		const mutationLog = join(root, "openclaw-model-switch-mutation.json");
-		const configMutationSdk = join(openclawPackage, "config-mutation.mjs");
 		const legacyModels = Array.from({ length: 24 }, (_, index) => ({
 			id: `legacy-${index}`,
 			name: `Legacy managed model ${index}`,
@@ -3682,12 +3741,11 @@ chmod +x "$HOME/.local/bin/hermes"
 			contextWindow: 200_000,
 			maxTokens: 64_000,
 		}));
-		mkdirSync(dirname(openclawBin), { recursive: true });
-		mkdirSync(openclawPackage, { recursive: true });
-		mkdirSync(dirname(openclawConfig), { recursive: true });
-		writeFileSync(
-			openclawConfig,
-			`${JSON.stringify({
+		const {
+			configPath: openclawConfig,
+			commandLog,
+			mutationLog,
+		} = writeOpenClawConfigMutationFixture(home, {
 				gateway: { mode: "local", port: 19_001 },
 				logging: { level: "debug" },
 				models: {
@@ -3705,54 +3763,7 @@ chmod +x "$HOME/.local/bin/hermes"
 						},
 					},
 				},
-			})}\n`,
-		);
-		writeFileSync(commandLog, "");
-		writeFileSync(
-			openclawBin,
-			`#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\n' "$*" >> '${commandLog}'
-exit 0
-`,
-		);
-		chmodSync(openclawBin, 0o700);
-		writeFileSync(
-			join(openclawPackage, "package.json"),
-			JSON.stringify({
-				name: "openclaw",
-				type: "module",
-				exports: { "./plugin-sdk/config-mutation": "./config-mutation.mjs" },
-			}),
-		);
-		writeFileSync(
-			configMutationSdk,
-			`import { readFileSync, writeFileSync } from "node:fs";
-export async function mutateConfigFile(options) {
-  if (options.base !== "source") throw new Error("expected source config mutation");
-  if (options.afterWrite?.mode !== "none") throw new Error("expected no SDK-owned restart");
-  const before = JSON.parse(readFileSync(${JSON.stringify(openclawConfig)}, "utf8"));
-  const draft = structuredClone(before);
-  await options.mutate(draft, { snapshot: {}, previousHash: null, attempt: 1 });
-  const next = JSON.stringify(draft, null, 2) + "\\n";
-  const beforeBytes = Buffer.byteLength(JSON.stringify(before, null, 2) + "\\n");
-  const nextBytes = Buffer.byteLength(next);
-  if (nextBytes < Math.floor(beforeBytes * 0.5) && options.writeOptions?.allowConfigSizeDrop !== true) {
-    throw new Error(\`size-drop:\${beforeBytes}->\${nextBytes}\`);
-  }
-  writeFileSync(${JSON.stringify(openclawConfig)}, next);
-  writeFileSync(${JSON.stringify(mutationLog)}, JSON.stringify({
-    base: options.base,
-    afterWrite: options.afterWrite,
-    allowConfigSizeDrop: options.writeOptions?.allowConfigSizeDrop,
-    explicitSetPaths: options.writeOptions?.explicitSetPaths,
-    unsetPaths: options.writeOptions?.unsetPaths,
-    beforeBytes,
-    nextBytes,
-  }));
-}
-`,
-		);
+		});
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
@@ -5790,6 +5801,154 @@ cp '${sdkSource}' '${sdkTarget}'
 		expect(hermesProvider.discover_models).toBe(false);
 		expect(hermesProvider.models).toEqual({ "gpt-5.5": {} });
 	});
+
+	it.each(["openclaw", "hermes"] as const)(
+		"replaces the managed %s model catalog without restarting its active runtime",
+		(runtimeName) => {
+			const caseRoot = join(root, runtimeName);
+			const home = join(caseRoot, "home", "clawdi");
+			const state = join(caseRoot, "var", "lib", "clawdi");
+			const run = join(caseRoot, "run", "clawdi");
+			const systemctlLog = join(caseRoot, "systemctl.log");
+			const systemctlStateRoot = join(caseRoot, "systemctl-state");
+			let openclawConfig: string | null = null;
+			mkdirSync(home, { recursive: true });
+			if (runtimeName === "openclaw") {
+				openclawConfig = writeOpenClawConfigMutationFixture(home).configPath;
+			} else {
+				writeHermesVersionBinary(home, "0.19.1");
+			}
+			writeFakeSystemdManager({
+				path: join(caseRoot, "bin", "systemctl"),
+				logPath: systemctlLog,
+				stateRoot: systemctlStateRoot,
+				environmentRoot: join(run, "systemd", "env"),
+			});
+			process.env.HOME = home;
+			process.env.CLAWDI_RUNTIME_MODE = "hosted";
+			process.env.CLAWDI_SERVICE_STATE_DIR = state;
+			process.env.CLAWDI_RUN_DIR = run;
+			process.env.CLAWDI_SYSTEMCTL_PATH = join(caseRoot, "bin", "systemctl");
+			process.env.CLAWDI_SYSTEMD_APPLY = "1";
+			process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
+
+			const previous = hostedSingleProviderModeLoad(home, runtimeName, "configured", 1);
+			const next = hostedSingleProviderModeLoad(home, runtimeName, "configured", 1);
+			const previousProvider = expectRecord(
+				previous.manifest.projection?.providers?.["clawdi-managed"],
+				"previous managed provider",
+			);
+			const nextProvider = expectRecord(
+				next.manifest.projection?.providers?.["clawdi-managed"],
+				"next managed provider",
+			);
+			previousProvider.models = [
+				{ id: "gpt-5.5", label: "GPT-5.5 old", context_window: 128_000 },
+				{ id: "stale-model", label: "Stale model" },
+			];
+			nextProvider.models = [
+				{
+					id: "gpt-5.5",
+					label: "GPT-5.5 refreshed",
+					context_window: 512_000,
+					max_tokens: 64_000,
+					supports_vision: true,
+				},
+				{ id: "new-model", label: "New model" },
+			];
+
+			const paths = getRuntimePaths();
+			const first = convergeRuntimeManifest(previous, paths);
+			expect(first.installErrors).toEqual([]);
+			writeTestRuntimeAppliedState(paths, previous, first);
+			const before = readSystemdUnitSnapshot(paths);
+			seedFakeSystemdSnapshotProcesses(paths, systemctlStateRoot, before);
+			for (const unit of before.user.keys()) {
+				writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "enabled"), "\n");
+			}
+			const runtimeUnit = runtimeName === "openclaw" ? "openclaw-gateway" : "hermes-gateway";
+			const initialRevision = systemdEnvRevision(readSystemdEnvFile(paths, runtimeUnit));
+			const transaction = new SystemdRuntimeTransaction();
+			writeFileSync(systemctlLog, "");
+
+			const second = convergeRuntimeManifest(next, paths);
+			expect(second.installErrors).toEqual([]);
+			const activation = applySystemdRuntimeUpdate(paths, before, readSystemdUnitSnapshot(paths), {
+				transaction,
+				stage: "final-activation",
+			});
+
+			expect(activation).toEqual({
+				applied: true,
+				systemUnitsChanged: [],
+				userUnitsChanged: [],
+			});
+			expect(
+				systemdEnvRevision(readSystemdEnvFile(paths, runtimeUnit)),
+			).toBe(initialRevision);
+			const systemctlCalls = readFileSync(systemctlLog, "utf-8");
+			expect(systemctlCalls).toContain(`--user show ${runtimeUnit}.service`);
+			expect(systemctlCalls).not.toMatch(
+				/(?:^|\s)(?:start|restart|stop|enable|disable|reset-failed)(?:\s|$)/m,
+			);
+
+			if (runtimeName === "openclaw") {
+				if (!openclawConfig) throw new Error("OpenClaw config fixture is missing");
+				const config = expectRecord(
+					JSON.parse(readFileSync(openclawConfig, "utf-8")),
+					"OpenClaw config",
+				);
+				const models = expectRecord(config.models, "OpenClaw models");
+				const providers = expectRecord(models.providers, "OpenClaw providers");
+				const provider = expectRecord(
+					providers["clawdi-managed"],
+					"OpenClaw managed provider",
+				);
+				expect(provider.models).toEqual([
+					expect.objectContaining({
+						id: "gpt-5.5",
+						name: "GPT-5.5 refreshed",
+						contextWindow: 512_000,
+						maxTokens: 64_000,
+						input: ["text", "image"],
+					}),
+					expect.objectContaining({ id: "new-model", name: "New model" }),
+				]);
+				expect(JSON.stringify(provider)).not.toContain("stale-model");
+			} else {
+				const provider = expectRecord(
+					expectRecord(readHermesConfigYaml(home).providers, "Hermes providers")[
+						"clawdi-managed"
+					],
+					"Hermes managed provider",
+				);
+				expect(provider.models).toEqual({
+					"gpt-5.5": {
+						context_length: 512_000,
+						max_tokens: 64_000,
+						supports_vision: true,
+					},
+					"new-model": {},
+				});
+			}
+
+			const beforeBaseUrlChange = readSystemdUnitSnapshot(paths);
+			nextProvider.baseUrl = "https://replacement.provider.example.test/v1";
+			writeFileSync(systemctlLog, "");
+			const third = convergeRuntimeManifest(next, paths);
+			expect(third.installErrors).toEqual([]);
+			const baseUrlActivation = applySystemdRuntimeUpdate(
+				paths,
+				beforeBaseUrlChange,
+				readSystemdUnitSnapshot(paths),
+				{ transaction, stage: "final-activation" },
+			);
+			expect(baseUrlActivation.userUnitsChanged).toEqual([`${runtimeUnit}.service`]);
+			expect(readFileSync(systemctlLog, "utf-8")).toContain(
+				`--user restart ${runtimeUnit}.service`,
+			);
+		},
+	);
 
 	it("uses the same native Hermes projection before and after 0.18.0", () => {
 		const home = join(root, "home", "clawdi");

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -3746,23 +3746,23 @@ chmod +x "$HOME/.local/bin/hermes"
 			commandLog,
 			mutationLog,
 		} = writeOpenClawConfigMutationFixture(home, {
-				gateway: { mode: "local", port: 19_001 },
-				logging: { level: "debug" },
-				models: {
-					providers: {
-						"user-owned": {
-							baseUrl: "https://user.provider.example.test/v1",
-							api: "openai-completions",
-							models: [{ id: "user-model", name: "User model" }],
-						},
-						clawdi: {
-							baseUrl: "https://managed.provider.example.test/v1",
-							api: "openai-responses",
-							apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-							models: legacyModels,
-						},
+			gateway: { mode: "local", port: 19_001 },
+			logging: { level: "debug" },
+			models: {
+				providers: {
+					"user-owned": {
+						baseUrl: "https://user.provider.example.test/v1",
+						api: "openai-completions",
+						models: [{ id: "user-model", name: "User model" }],
+					},
+					clawdi: {
+						baseUrl: "https://managed.provider.example.test/v1",
+						api: "openai-responses",
+						apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+						models: legacyModels,
 					},
 				},
+			},
 		});
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
@@ -5802,153 +5802,144 @@ cp '${sdkSource}' '${sdkTarget}'
 		expect(hermesProvider.models).toEqual({ "gpt-5.5": {} });
 	});
 
-	it.each(["openclaw", "hermes"] as const)(
-		"replaces the managed %s model catalog without restarting its active runtime",
-		(runtimeName) => {
-			const caseRoot = join(root, runtimeName);
-			const home = join(caseRoot, "home", "clawdi");
-			const state = join(caseRoot, "var", "lib", "clawdi");
-			const run = join(caseRoot, "run", "clawdi");
-			const systemctlLog = join(caseRoot, "systemctl.log");
-			const systemctlStateRoot = join(caseRoot, "systemctl-state");
-			let openclawConfig: string | null = null;
-			mkdirSync(home, { recursive: true });
-			if (runtimeName === "openclaw") {
-				openclawConfig = writeOpenClawConfigMutationFixture(home).configPath;
-			} else {
-				writeHermesVersionBinary(home, "0.19.1");
-			}
-			writeFakeSystemdManager({
-				path: join(caseRoot, "bin", "systemctl"),
-				logPath: systemctlLog,
-				stateRoot: systemctlStateRoot,
-				environmentRoot: join(run, "systemd", "env"),
-			});
-			process.env.HOME = home;
-			process.env.CLAWDI_RUNTIME_MODE = "hosted";
-			process.env.CLAWDI_SERVICE_STATE_DIR = state;
-			process.env.CLAWDI_RUN_DIR = run;
-			process.env.CLAWDI_SYSTEMCTL_PATH = join(caseRoot, "bin", "systemctl");
-			process.env.CLAWDI_SYSTEMD_APPLY = "1";
-			process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
+	it.each([
+		"openclaw",
+		"hermes",
+	] as const)("replaces the managed %s model catalog without restarting its active runtime", (runtimeName) => {
+		const caseRoot = join(root, runtimeName);
+		const home = join(caseRoot, "home", "clawdi");
+		const state = join(caseRoot, "var", "lib", "clawdi");
+		const run = join(caseRoot, "run", "clawdi");
+		const systemctlLog = join(caseRoot, "systemctl.log");
+		const systemctlStateRoot = join(caseRoot, "systemctl-state");
+		let openclawConfig: string | null = null;
+		mkdirSync(home, { recursive: true });
+		if (runtimeName === "openclaw") {
+			openclawConfig = writeOpenClawConfigMutationFixture(home).configPath;
+		} else {
+			writeHermesVersionBinary(home, "0.19.1");
+		}
+		writeFakeSystemdManager({
+			path: join(caseRoot, "bin", "systemctl"),
+			logPath: systemctlLog,
+			stateRoot: systemctlStateRoot,
+			environmentRoot: join(run, "systemd", "env"),
+		});
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_SYSTEMCTL_PATH = join(caseRoot, "bin", "systemctl");
+		process.env.CLAWDI_SYSTEMD_APPLY = "1";
+		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
 
-			const previous = hostedSingleProviderModeLoad(home, runtimeName, "configured", 1);
-			const next = hostedSingleProviderModeLoad(home, runtimeName, "configured", 1);
-			const previousProvider = expectRecord(
-				previous.manifest.projection?.providers?.["clawdi-managed"],
-				"previous managed provider",
+		const previous = hostedSingleProviderModeLoad(home, runtimeName, "configured", 1);
+		const next = hostedSingleProviderModeLoad(home, runtimeName, "configured", 1);
+		const previousProvider = expectRecord(
+			previous.manifest.projection?.providers?.["clawdi-managed"],
+			"previous managed provider",
+		);
+		const nextProvider = expectRecord(
+			next.manifest.projection?.providers?.["clawdi-managed"],
+			"next managed provider",
+		);
+		previousProvider.models = [
+			{ id: "gpt-5.5", label: "GPT-5.5 old", context_window: 128_000 },
+			{ id: "stale-model", label: "Stale model" },
+		];
+		nextProvider.models = [
+			{
+				id: "gpt-5.5",
+				label: "GPT-5.5 refreshed",
+				context_window: 512_000,
+				max_tokens: 64_000,
+				supports_vision: true,
+			},
+			{ id: "new-model", label: "New model" },
+		];
+
+		const paths = getRuntimePaths();
+		const first = convergeRuntimeManifest(previous, paths);
+		expect(first.installErrors).toEqual([]);
+		writeTestRuntimeAppliedState(paths, previous, first);
+		const before = readSystemdUnitSnapshot(paths);
+		seedFakeSystemdSnapshotProcesses(paths, systemctlStateRoot, before);
+		for (const unit of before.user.keys()) {
+			writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "enabled"), "\n");
+		}
+		const runtimeUnit = runtimeName === "openclaw" ? "openclaw-gateway" : "hermes-gateway";
+		const initialRevision = systemdEnvRevision(readSystemdEnvFile(paths, runtimeUnit));
+		const transaction = new SystemdRuntimeTransaction();
+		writeFileSync(systemctlLog, "");
+
+		const second = convergeRuntimeManifest(next, paths);
+		expect(second.installErrors).toEqual([]);
+		const activation = applySystemdRuntimeUpdate(paths, before, readSystemdUnitSnapshot(paths), {
+			transaction,
+			stage: "final-activation",
+		});
+
+		expect(activation).toEqual({
+			applied: true,
+			systemUnitsChanged: [],
+			userUnitsChanged: [],
+		});
+		expect(systemdEnvRevision(readSystemdEnvFile(paths, runtimeUnit))).toBe(initialRevision);
+		const systemctlCalls = readFileSync(systemctlLog, "utf-8");
+		expect(systemctlCalls).toContain(`--user show ${runtimeUnit}.service`);
+		expect(systemctlCalls).not.toMatch(
+			/(?:^|\s)(?:start|restart|stop|enable|disable|reset-failed)(?:\s|$)/m,
+		);
+
+		if (runtimeName === "openclaw") {
+			if (!openclawConfig) throw new Error("OpenClaw config fixture is missing");
+			const config = expectRecord(
+				JSON.parse(readFileSync(openclawConfig, "utf-8")),
+				"OpenClaw config",
 			);
-			const nextProvider = expectRecord(
-				next.manifest.projection?.providers?.["clawdi-managed"],
-				"next managed provider",
-			);
-			previousProvider.models = [
-				{ id: "gpt-5.5", label: "GPT-5.5 old", context_window: 128_000 },
-				{ id: "stale-model", label: "Stale model" },
-			];
-			nextProvider.models = [
-				{
+			const models = expectRecord(config.models, "OpenClaw models");
+			const providers = expectRecord(models.providers, "OpenClaw providers");
+			const provider = expectRecord(providers["clawdi-managed"], "OpenClaw managed provider");
+			expect(provider.models).toEqual([
+				expect.objectContaining({
 					id: "gpt-5.5",
-					label: "GPT-5.5 refreshed",
-					context_window: 512_000,
+					name: "GPT-5.5 refreshed",
+					contextWindow: 512_000,
+					maxTokens: 64_000,
+					input: ["text", "image"],
+				}),
+				expect.objectContaining({ id: "new-model", name: "New model" }),
+			]);
+			expect(JSON.stringify(provider)).not.toContain("stale-model");
+		} else {
+			const provider = expectRecord(
+				expectRecord(readHermesConfigYaml(home).providers, "Hermes providers")["clawdi-managed"],
+				"Hermes managed provider",
+			);
+			expect(provider.models).toEqual({
+				"gpt-5.5": {
+					context_length: 512_000,
 					max_tokens: 64_000,
 					supports_vision: true,
 				},
-				{ id: "new-model", label: "New model" },
-			];
-
-			const paths = getRuntimePaths();
-			const first = convergeRuntimeManifest(previous, paths);
-			expect(first.installErrors).toEqual([]);
-			writeTestRuntimeAppliedState(paths, previous, first);
-			const before = readSystemdUnitSnapshot(paths);
-			seedFakeSystemdSnapshotProcesses(paths, systemctlStateRoot, before);
-			for (const unit of before.user.keys()) {
-				writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "enabled"), "\n");
-			}
-			const runtimeUnit = runtimeName === "openclaw" ? "openclaw-gateway" : "hermes-gateway";
-			const initialRevision = systemdEnvRevision(readSystemdEnvFile(paths, runtimeUnit));
-			const transaction = new SystemdRuntimeTransaction();
-			writeFileSync(systemctlLog, "");
-
-			const second = convergeRuntimeManifest(next, paths);
-			expect(second.installErrors).toEqual([]);
-			const activation = applySystemdRuntimeUpdate(paths, before, readSystemdUnitSnapshot(paths), {
-				transaction,
-				stage: "final-activation",
+				"new-model": {},
 			});
+		}
 
-			expect(activation).toEqual({
-				applied: true,
-				systemUnitsChanged: [],
-				userUnitsChanged: [],
-			});
-			expect(
-				systemdEnvRevision(readSystemdEnvFile(paths, runtimeUnit)),
-			).toBe(initialRevision);
-			const systemctlCalls = readFileSync(systemctlLog, "utf-8");
-			expect(systemctlCalls).toContain(`--user show ${runtimeUnit}.service`);
-			expect(systemctlCalls).not.toMatch(
-				/(?:^|\s)(?:start|restart|stop|enable|disable|reset-failed)(?:\s|$)/m,
-			);
-
-			if (runtimeName === "openclaw") {
-				if (!openclawConfig) throw new Error("OpenClaw config fixture is missing");
-				const config = expectRecord(
-					JSON.parse(readFileSync(openclawConfig, "utf-8")),
-					"OpenClaw config",
-				);
-				const models = expectRecord(config.models, "OpenClaw models");
-				const providers = expectRecord(models.providers, "OpenClaw providers");
-				const provider = expectRecord(
-					providers["clawdi-managed"],
-					"OpenClaw managed provider",
-				);
-				expect(provider.models).toEqual([
-					expect.objectContaining({
-						id: "gpt-5.5",
-						name: "GPT-5.5 refreshed",
-						contextWindow: 512_000,
-						maxTokens: 64_000,
-						input: ["text", "image"],
-					}),
-					expect.objectContaining({ id: "new-model", name: "New model" }),
-				]);
-				expect(JSON.stringify(provider)).not.toContain("stale-model");
-			} else {
-				const provider = expectRecord(
-					expectRecord(readHermesConfigYaml(home).providers, "Hermes providers")[
-						"clawdi-managed"
-					],
-					"Hermes managed provider",
-				);
-				expect(provider.models).toEqual({
-					"gpt-5.5": {
-						context_length: 512_000,
-						max_tokens: 64_000,
-						supports_vision: true,
-					},
-					"new-model": {},
-				});
-			}
-
-			const beforeBaseUrlChange = readSystemdUnitSnapshot(paths);
-			nextProvider.baseUrl = "https://replacement.provider.example.test/v1";
-			writeFileSync(systemctlLog, "");
-			const third = convergeRuntimeManifest(next, paths);
-			expect(third.installErrors).toEqual([]);
-			const baseUrlActivation = applySystemdRuntimeUpdate(
-				paths,
-				beforeBaseUrlChange,
-				readSystemdUnitSnapshot(paths),
-				{ transaction, stage: "final-activation" },
-			);
-			expect(baseUrlActivation.userUnitsChanged).toEqual([`${runtimeUnit}.service`]);
-			expect(readFileSync(systemctlLog, "utf-8")).toContain(
-				`--user restart ${runtimeUnit}.service`,
-			);
-		},
-	);
+		const beforeBaseUrlChange = readSystemdUnitSnapshot(paths);
+		nextProvider.baseUrl = "https://replacement.provider.example.test/v1";
+		writeFileSync(systemctlLog, "");
+		const third = convergeRuntimeManifest(next, paths);
+		expect(third.installErrors).toEqual([]);
+		const baseUrlActivation = applySystemdRuntimeUpdate(
+			paths,
+			beforeBaseUrlChange,
+			readSystemdUnitSnapshot(paths),
+			{ transaction, stage: "final-activation" },
+		);
+		expect(baseUrlActivation.userUnitsChanged).toEqual([`${runtimeUnit}.service`]);
+		expect(readFileSync(systemctlLog, "utf-8")).toContain(`--user restart ${runtimeUnit}.service`);
+	});
 
 	it("uses the same native Hermes projection before and after 0.18.0", () => {
 		const home = join(root, "home", "clawdi");


### PR DESCRIPTION
## Summary

- keep replacing the complete managed Hermes/OpenClaw provider projection from each accepted manifest
- exclude only Clawdi-managed provider `models` fields from the Hermes/OpenClaw systemd process-impact revision
- preserve restart impact for provider selection/default model, base URL, auth/key env/API mode, runtime/service program settings, secrets, gateway/channels/locale/MCP/skills, and every non-managed/BYOK provider field
- bump the CLI package and workspace lock identity from `0.13.71` to the unpublished patch `0.13.72`

Codex is unchanged: its managed projection remains model/catalog-free and keeps the native Codex default-model behavior. The existing CLI-only daemon handoff remains unchanged.

## Upstream runtime evidence

OpenClaw is pinned to `openclaw@2026.7.1-2`, source commit [`0790d9f`](https://github.com/openclaw/openclaw/commit/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c):

- [`config-reload-plan.ts` lines 91-107](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/gateway/config-reload-plan.ts#L91-L107) classifies `models` as hot reload; only `models.pricing` requires restart.
- [`config-reload.ts` lines 271-324](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/gateway/config-reload.ts#L271-L324) sends non-restart plans through `onHotReload`.
- [`config-reload.ts` lines 379-444](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/gateway/config-reload.ts#L379-L444) shows external file-watcher events re-read the snapshot without an in-process `afterWrite` intent, so the separately spawned Clawdi SDK helper's `afterWrite: none` does not suppress the active gateway's watcher path.
- [`server-reload-handlers.ts` lines 113-117](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/gateway/server-reload-handlers.ts#L113-L117), [362-368](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/gateway/server-reload-handlers.ts#L362-L368), and [805-848](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/gateway/server-reload-handlers.ts#L805-L848) clear model/auth caches and activate the new runtime config on hot reload.
- [`models-config.plan.ts` lines 115-120](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/agents/models-config.plan.ts#L115-L120) makes `models.mode=replace` authoritative by skipping implicit provider discovery.

Hermes is pinned to `0.19.1`, source commit [`cc4cab2f`](https://github.com/NousResearch/hermes-agent/tree/cc4cab2f592e60a197e796506de9168f74baf3ea):

- [`config.py` lines 235-260](https://github.com/NousResearch/hermes-agent/blob/cc4cab2f592e60a197e796506de9168f74baf3ea/hermes_cli/config.py#L235-L260) caches config by mtime/size and documents that atomic writes produce a fresh inode, causing the next load to repopulate automatically.
- [`runtime_provider.py` lines 281-288](https://github.com/NousResearch/hermes-agent/blob/cc4cab2f592e60a197e796506de9168f74baf3ea/hermes_cli/runtime_provider.py#L281-L288) and [674-723](https://github.com/NousResearch/hermes-agent/blob/cc4cab2f592e60a197e796506de9168f74baf3ea/hermes_cli/runtime_provider.py#L674-L723) reload model/provider config during runtime resolution.
- [`gateway/run.py` lines 2339-2407](https://github.com/NousResearch/hermes-agent/blob/cc4cab2f592e60a197e796506de9168f74baf3ea/gateway/run.py#L2339-L2407) and [4115-4124](https://github.com/NousResearch/hermes-agent/blob/cc4cab2f592e60a197e796506de9168f74baf3ea/gateway/run.py#L4115-L4124) resolve that runtime config for each turn.

No reload field or private runtime behavior is invented here.

## Regression boundary

The parameterized Hermes/OpenClaw regression uses previous/next manifests with the same generation and identical runtime/provider inputs except managed model catalog metadata. It:

- reads the actual OpenClaw JSON/Hermes YAML after convergence and proves stale models are gone while the complete new model metadata is present
- seeds active fake-systemd processes with their current `CLAWDI_RUNTIME_REV`
- calls the real `applySystemdRuntimeUpdate` transaction and observes `systemctl show`
- proves catalog-only replacement leaves the runtime revision stable and emits no start/restart/stop/enable/disable/reset-failed operation
- then changes only the provider base URL and proves the same runtime unit is restarted, guarding against broad provider suppression

Existing runtime coverage continues to exercise credentials/secrets, runtime settings, service programs, channels, locale, MCP, skills, and CLI-only handoff behavior.

## Verification

- `scripts/test.sh cli tests/runtime.test.ts -t "replaces the managed"` (2 passed, 172 filtered, 28 assertions; includes CLI typecheck)
- `scripts/test.sh cli tests/runtime.test.ts` (174 passed, 1832 assertions; includes CLI typecheck)
- `bunx @biomejs/biome@2.5.2 ci packages/cli/src/runtime/manifest.ts packages/cli/tests/runtime.test.ts packages/cli/package.json bun.lock`
- `git diff --check origin/main..HEAD`
- `npm view clawdi@0.13.72 version --json` returns registry `E404`, confirming the patch identity is unpublished

## Release and Hosted follow-up

Merging this PR changes `packages/cli/package.json`, so the Clawdi CLI publish workflow should build and publish immutable `clawdi@0.13.72` from this PR's merge commit. Do not reuse `0.13.70` or `0.13.71`.

Hosted desired-version selection is deliberately outside this repository and this PR. After `clawdi@0.13.72` is published and its integrity/provenance are verified, a separate cross-repository Hosted PR must update the exact desired package version to `clawdi@0.13.72` and run the Hosted image/CLI pairing verification. This PR does not modify or operate Hosted infrastructure.