### PR TITLE
fix(cli): resume partial draft release assets

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -238,7 +238,7 @@ jobs:
             fi
           fi
           release_action=create-draft
-          if existing_release=$(gh release view "$tag" --json isDraft,targetCommitish 2>/dev/null); then
+          if existing_release=$(gh release view "$tag" --json assets,isDraft,targetCommitish 2>/dev/null); then
             release_action=$(RELEASE_JSON="$existing_release" EXPECTED_COMMIT="$GITHUB_SHA" node - <<'NODE'
           const release = JSON.parse(process.env.RELEASE_JSON);
           if (release.targetCommitish !== process.env.EXPECTED_COMMIT) {
@@ -267,11 +267,40 @@ jobs:
           EOF
           )
           if [ "$release_action" = "resume-draft" ]; then
-            gh release upload "$tag" \
-              release/clawdi-cli-*.tar.gz \
-              release/clawdi-cli-manifest.txt \
-              release/install.sh \
-              --clobber
+            assets=(
+              release/clawdi-cli-*.tar.gz
+              release/clawdi-cli-manifest.txt
+              release/install.sh
+            )
+            missing_assets=$(RELEASE_JSON="$existing_release" node - "${assets[@]}" <<'NODE'
+          const { createHash } = require("node:crypto");
+          const { readFileSync, statSync } = require("node:fs");
+          const { basename } = require("node:path");
+          const remoteAssets = JSON.parse(process.env.RELEASE_JSON).assets;
+          for (const localPath of process.argv.slice(2)) {
+            const name = basename(localPath);
+            const matches = remoteAssets.filter((asset) => asset.name === name);
+            if (matches.length > 1) {
+              console.error(`GitHub release has duplicate assets named ${name}`);
+              process.exit(65);
+            }
+            if (matches.length === 0) {
+              console.log(localPath);
+              continue;
+            }
+            const digest = `sha256:${createHash("sha256").update(readFileSync(localPath)).digest("hex")}`;
+            const size = statSync(localPath).size;
+            if (matches[0].digest !== digest || matches[0].size !== size) {
+              console.error(`GitHub release asset ${name} does not match this workflow artifact`);
+              process.exit(65);
+            }
+          }
+          NODE
+            )
+            if [ -n "$missing_assets" ]; then
+              mapfile -t assets_to_upload <<< "$missing_assets"
+              gh release upload "$tag" "${assets_to_upload[@]}"
+            fi
             gh release edit "$tag" --draft=false
             exit 0
           fi

--- a/packages/cli/tests/clawdi-image-release-workflow.test.ts
+++ b/packages/cli/tests/clawdi-image-release-workflow.test.ts
@@ -47,6 +47,10 @@ const imageReleaseSource = readFileSync(
 	"utf8",
 );
 const imageRelease = parse(imageReleaseSource) as WorkflowDocument;
+const cliPublishSource = readFileSync(
+	resolve(import.meta.dir, "../../../.github/workflows/cli-publish.yml"),
+	"utf8",
+);
 const backendDockerfile = readFileSync(
 	resolve(import.meta.dir, "../../../backend/Dockerfile"),
 	"utf8",
@@ -239,6 +243,15 @@ describe("backend image release workflow contract", () => {
 		expect(imageRelease.jobs["deploy-vps"]?.if).toBe(
 			"needs.build.outputs.release_required == 'true'",
 		);
+	});
+
+	test("resumes partial CLI drafts without replacing verified assets", () => {
+		expect(cliPublishSource).toContain("--json assets,isDraft,targetCommitish");
+		expect(cliPublishSource).toContain('createHash("sha256")');
+		expect(cliPublishSource).toContain("matches[0].digest !== digest || matches[0].size !== size");
+		expect(cliPublishSource).toContain('if [ -n "$missing_assets" ]; then');
+		expect(cliPublishSource).toContain(`gh release upload "$tag" "\${assets_to_upload[@]}"`);
+		expect(cliPublishSource).not.toContain("--clobber");
 	});
 
 	test("classifies the deploy-vps execution contract without circular release authority", () => {

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -194,7 +194,6 @@ describe("CLI publish workflow contract", () => {
 		expect(workflow).toContain("release.targetCommitish !== process.env.EXPECTED_COMMIT");
 		expect(workflow).toContain('console.log(release.isDraft ? "resume-draft" : "none")');
 		expect(workflow).toContain('gh release upload "$tag"');
-		expect(workflow).toContain("--clobber");
 		expect(workflow).toContain('--target "$GITHUB_SHA"');
 		expect(workflow).toContain("--draft");
 		expect(workflow).toContain('gh release edit "$tag" --draft=false');


### PR DESCRIPTION
## Summary

- verify an existing draft release asset by SHA-256 digest and byte size before skipping it
- upload only assets missing from a partial draft and fail closed on duplicate names or mismatched content
- preserve the existing first-create, npm immutability, tag, and target fences

## Verification

- `bun run --cwd packages/cli test -- tests/cli-publish-workflow.test.ts tests/clawdi-image-release-workflow.test.ts` (Docker-isolated; 17 passed)
- `docker run --rm -v "$PWD:/repo:ro" -w /repo oven/bun:1.3.14 bunx --bun @biomejs/biome@2.5.2 check packages/cli/tests/cli-publish-workflow.test.ts packages/cli/tests/clawdi-image-release-workflow.test.ts`
- extracted workflow release script: `bash -n`
- `git diff --check`

## Release impact

This changes only rerun recovery for an existing same-commit draft CLI release. It does not publish npm, modify a completed release, delete or replace release assets, or change first-run release creation.