### PR TITLE
fix(web): complete compute subscription action states

### DIFF
--- a/apps/web/e2e/hosted-stub-api.ts
+++ b/apps/web/e2e/hosted-stub-api.ts
@@ -780,6 +780,8 @@ export type HostedApiStubOptions = {
 	resumeRequests?: string[];
 	reusableSubscriptionRequests?: string[];
 	reusableSubscriptionPages?: Record<string, ReusableSubscriptionsResponse>;
+	scheduledPlanCancellationRequests?: string[];
+	scheduledPlanCancellationResponses?: StubResponse[];
 	subscriptionPages?: Record<string, SubscriptionListResponse>;
 	subscriptionQuoteRequests?: string[];
 	subscriptionQuoteResponses?: unknown[];
@@ -977,6 +979,24 @@ export async function stubHostedApi(page: Page, options: HostedApiStubOptions = 
 			return isStubResponse(response)
 				? fulfillJson(r, response.body, response.status)
 				: fulfillJson(r, response);
+		}
+		if (p === "/v2/subscription/plan/cancel-scheduled-change" && r.request().method() === "POST") {
+			options.scheduledPlanCancellationRequests?.push(r.request().postData() ?? "");
+			const response = options.scheduledPlanCancellationResponses?.shift() ?? {
+				status: 200,
+				body: {
+					status: "active",
+					funding_source: "stripe",
+					billing_term_months: 12,
+					cancel_at_period_end: false,
+					pending_plan_slug: null,
+					action_state: "removed",
+				},
+			};
+			if (response.delayMs) {
+				await new Promise((resolve) => setTimeout(resolve, response.delayMs));
+			}
+			return fulfillJson(r, response.body, response.status);
 		}
 		if (p === "/v2/wallet/topup" && r.request().method() === "POST") {
 			options.topUpRequests?.push(r.request().postData() ?? "");

--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -8,6 +8,7 @@ import {
 	gotoHostedAgentSettings,
 	gotoHostedSettingsDialog,
 	includedBasicDeployment,
+	mutationDeploymentReadFixture,
 	paidBasicDeployment,
 	performancePlan,
 	sharedLegacyCloudAgent,
@@ -297,6 +298,8 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 }, testInfo) => {
 	await page.setViewportSize({ width: 1440, height: 900 });
 	const errors = collectBrowserErrors(page);
+	const fixPaymentRequests: string[] = [];
+	const scheduledPlanCancellationRequests: string[] = [];
 	await stubHostedApi(page, {
 		deployments: [
 			accountActiveDeployment,
@@ -306,6 +309,8 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 		],
 		cloudAgents: accountCloudAgents,
 		plans: [basicPlan, performancePlan],
+		fixPaymentRequests,
+		scheduledPlanCancellationRequests,
 		subscriptionPages: {
 			initial: {
 				items: [],
@@ -345,10 +350,19 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 						next_payment_attempt_at: "2099-08-10T12:00:00Z",
 						recovery_action: "top_up",
 					}),
-					subscription("canceling", "canceling", {
+					subscription("orphan_past_due", "past_due", {
+						deployment_id: null,
+						agent_name: null,
+						is_orphan: true,
+						payment_state: "requires_action",
+						recovery_action: "fix_payment",
+					}),
+					subscription("csub_canceling", "canceling", {
 						cancel_at_period_end: true,
 						current_period_end: "2025-08-12T12:00:00Z",
+						deployment_id: "hdep_canceling",
 						agent_name: "Canceling agent",
+						pending_plan_slug: "compute_basic",
 					}),
 					subscription("ended_second", "canceled", {
 						current_period_end: "2099-09-11T12:00:00Z",
@@ -382,16 +396,17 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(dialog.getByText("Canceling agent", { exact: true })).toBeVisible();
 	await expect(dialog.getByText("Active", { exact: true })).toHaveCount(2);
 	await expect(dialog.getByText("Canceling", { exact: true })).toBeVisible();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(4);
-	await expect(dialog.getByRole("button", { name: "Manage", exact: true })).toHaveCount(2);
-	await expect(dialog.getByRole("button", { name: "Resume subscription" })).toBeVisible();
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(5);
+	await expect(dialog.getByRole("button", { name: "Manage", exact: true })).toHaveCount(3);
+	await expect(dialog.getByRole("button", { name: "Cancel scheduled change" })).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Show history (2)" })).toBeVisible();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(4);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(5);
 	const currentCards = dialog.locator('[data-slot="compute-subscription-card"]');
 	const activeCard = currentCards.nth(0);
 	const includedCard = currentCards.nth(1);
 	const pastDueCard = currentCards.nth(2);
-	const cancelingCard = currentCards.nth(3);
+	const orphanPastDueCard = currentCards.nth(3);
+	const cancelingCard = currentCards.nth(4);
 	await expect(activeCard.getByRole("button", { name: "Cancel subscription" })).toBeVisible();
 	await expect(activeCard.locator("h4")).toHaveText("Performance compute");
 	await expect(activeCard.getByText("Used by", { exact: true })).toBeVisible();
@@ -413,13 +428,41 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(includedCard.getByRole("button", { name: "Cancel subscription" })).toHaveCount(0);
 	await expect(pastDueCard.getByText("Past due", { exact: true })).toBeVisible();
 	await expect(pastDueCard.getByText("Retries Aug 10, 2099", { exact: true })).toBeVisible();
-	await expect(pastDueCard.getByRole("button", { name: "Manage", exact: true })).toHaveCount(0);
+	const pastDueManage = pastDueCard.getByRole("button", { name: "Manage", exact: true });
+	await expect(pastDueManage).toBeEnabled();
 	await expect(pastDueCard.getByRole("button", { name: "Top up", exact: true })).toBeVisible();
+	await expect(pastDueCard.getByRole("button", { name: "Cancel subscription" })).toBeVisible();
+	await expect(orphanPastDueCard.getByText("Deleted agent", { exact: true })).toBeVisible();
+	const orphanFixPayment = orphanPastDueCard.getByRole("button", { name: "Fix payment" });
+	await expect(orphanFixPayment).toBeEnabled();
+	await orphanFixPayment.click();
+	await expect.poll(() => fixPaymentRequests.map((body) => JSON.parse(body))).toEqual([{}]);
+	await expect(
+		orphanPastDueCard.getByRole("button", { name: "Cancel subscription" }),
+	).toBeVisible();
 	await expect(cancelingCard.getByRole("button", { name: "Manage", exact: true })).toHaveCount(0);
+	const cancelScheduledAccount = cancelingCard.getByRole("button", {
+		name: "Cancel scheduled change",
+	});
+	await expect(cancelScheduledAccount).toBeEnabled();
+	await expect(cancelingCard.getByRole("button", { name: "Resume subscription" })).toHaveCount(0);
+	await cancelScheduledAccount.click();
+	await expect
+		.poll(() => scheduledPlanCancellationRequests.map((body) => JSON.parse(body)))
+		.toEqual([{ subscription_id: "csub_canceling" }]);
+	await expect(
+		page.locator("[data-sonner-toast]").filter({ hasText: "Scheduled plan change canceled" }),
+	).toBeVisible();
 	const currentStatuses = await currentCards.evaluateAll((cards) =>
 		cards.map((card) => card.getAttribute("data-subscription-status")),
 	);
-	expect(currentStatuses).toEqual(["active", "active", "past-due", "canceling"]);
+	expect(currentStatuses).toEqual([
+		"active",
+		"active",
+		"past-due",
+		"payment-action-required",
+		"canceling",
+	]);
 	const desktopCardBoxes = await currentCards.evaluateAll((cards) =>
 		cards.map((card) => card.getBoundingClientRect().toJSON()),
 	);
@@ -433,15 +476,24 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await dialog.screenshot({ path: testInfo.outputPath("account-compute-plans-desktop.png") });
 
 	await dialog.getByRole("button", { name: "Show history (2)" }).click();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(6);
-	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(6);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(7);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(7);
 	await expect(dialog.getByText("Ended", { exact: true })).toHaveCount(2);
 	const visibleStatuses = await dialog
 		.locator('[data-slot="compute-subscription-card"]')
 		.evaluateAll((cards) => cards.map((card) => card.getAttribute("data-subscription-status")));
-	expect(visibleStatuses).toEqual(["active", "active", "past-due", "canceling", "ended", "ended"]);
+	expect(visibleStatuses).toEqual([
+		"active",
+		"active",
+		"past-due",
+		"payment-action-required",
+		"canceling",
+		"ended",
+		"ended",
+	]);
 	const orphanCard = dialog
 		.locator('[data-slot="compute-subscription-card"]')
+		.filter({ hasText: "Ended" })
 		.filter({ hasText: "Deleted agent" });
 	await expect(orphanCard).toBeVisible();
 	await expect(orphanCard.getByText("Orphaned", { exact: true })).toBeVisible();
@@ -487,7 +539,7 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(fullManagementDialog).toBeHidden();
 	await expect(dialog).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Hide history" })).toBeVisible();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(6);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(7);
 	expect(page.url()).toBe(accountSettingsUrl);
 
 	await includedManage.click();
@@ -507,6 +559,18 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(includedManagementDialog).toBeHidden();
 	await expect(dialog).toBeVisible();
 
+	await pastDueManage.click();
+	const pastDueManagementDialog = page.getByRole("dialog", { name: "Change payment source" });
+	await expect(pastDueManagementDialog).toBeVisible();
+	await expect(
+		pastDueManagementDialog.getByRole("group", { name: "Subscription management mode" }),
+	).toHaveCount(0);
+	await expect(pastDueManagementDialog.getByLabel("Compute plan")).toHaveCount(0);
+	await expect(pastDueManagementDialog.getByLabel("Payment source")).toBeVisible();
+	await pastDueManagementDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+	await expect(pastDueManagementDialog).toBeHidden();
+	await expect(dialog).toBeVisible();
+
 	await pastDueCard.getByRole("button", { name: "Top up", exact: true }).click();
 	const topUpDialog = page.getByRole("dialog", { name: "Top up Wallet", exact: true });
 	await expect(topUpDialog).toBeVisible();
@@ -514,11 +578,11 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(topUpDialog).toBeHidden();
 	await expect(dialog).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Hide history" })).toBeVisible();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(6);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(7);
 	expect(page.url()).toBe(accountSettingsUrl);
 
 	await dialog.getByRole("button", { name: "Hide history" }).click();
-	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(4);
+	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(5);
 	await expect(dialog.getByText("ended_first", { exact: true })).toHaveCount(0);
 
 	await page.setViewportSize({ width: 320, height: 1000 });
@@ -556,6 +620,8 @@ test("agent settings uses compact canonical subscription management", async ({
 }, testInfo) => {
 	await page.setViewportSize({ width: 1440, height: 900 });
 	const errors = collectBrowserErrors(page);
+	const planQuoteRequests: string[] = [];
+	const scheduledPlanCancellationRequests: string[] = [];
 	await stubHostedApi(page, {
 		cloudAgentOverrides: {
 			display_name: "Paid research agent",
@@ -576,11 +642,52 @@ test("agent settings uses compact canonical subscription management", async ({
 				name: "Card authentication required",
 				compute_subscription: {
 					...paidBasicDeployment.compute_subscription,
-					status: "past_due",
+					status: "active",
 					payment_state: "requires_action",
 					latest_failed_invoice_id: "in_card_action_required",
 					latest_failed_invoice_hosted_url: "https://billing.example/invoice/action-required",
 					recovery_action: "fix_payment",
+				},
+			},
+			{
+				...mutationDeploymentReadFixture({
+					...paidBasicDeployment,
+					id: "hdep_plan_change_pending",
+					name: "Plan change pending",
+					compute_subscription: {
+						...paidBasicDeployment.compute_subscription,
+						status: "past_due",
+						payment_state: "requires_action",
+						recovery_action: "fix_payment",
+					},
+				}),
+				accepted_operation: {
+					name: "operations/pending-plan-change",
+					metadata: {
+						"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
+						deploymentId: "hdep_plan_change_pending",
+						verb: "plan_change",
+						targetGeneration: 1,
+						manifestETag: "plan-change-pending",
+						createTime: "2026-07-16T00:00:00Z",
+						updateTime: "2026-07-16T00:00:00Z",
+					},
+					done: false,
+					error: null,
+					response: null,
+				},
+			},
+			{
+				...paidBasicDeployment,
+				id: "hdep_scheduled_downgrade",
+				name: "Scheduled downgrade",
+				config_info: {
+					...paidBasicDeployment.config_info,
+					compute_plan_slug: "compute_performance",
+				},
+				compute_subscription: {
+					...paidBasicDeployment.compute_subscription,
+					pending_plan_slug: "compute_basic",
 				},
 			},
 			{
@@ -595,9 +702,28 @@ test("agent settings uses compact canonical subscription management", async ({
 			ineligibleIncludedDeployment,
 		],
 		plans: [basicPlan, performancePlan],
+		planQuoteRequests,
+		scheduledPlanCancellationRequests,
+		scheduledPlanCancellationResponses: [
+			{
+				status: 200,
+				delayMs: 100,
+				body: {
+					status: "active",
+					funding_source: "stripe",
+					billing_term_months: 12,
+					cancel_at_period_end: false,
+					pending_plan_slug: "compute_basic",
+					action_state: "reconciling",
+				},
+			},
+		],
 	});
 
 	await gotoHostedAgentSettings(page, paidEnvironmentId, "Basic", "?source=on-clawdi&d=hdep_paid");
+	await page.goto(`${page.url()}&subscription_action=start_new`);
+	await expect(page.getByRole("dialog", { name: "Choose a paid subscription" })).toHaveCount(0);
+	await expect.poll(() => new URL(page.url()).searchParams.has("subscription_action")).toBe(false);
 	const activeCard = page
 		.locator('[data-slot="compute-subscription-card"]')
 		.filter({ hasText: "Basic compute" });
@@ -635,7 +761,7 @@ test("agent settings uses compact canonical subscription management", async ({
 		"warning",
 	);
 	await expect(cancelingCard.getByRole("button", { name: "Manage", exact: true })).toHaveCount(0);
-	await expect(cancelingCard.getByRole("button", { name: "Resume subscription" })).toBeVisible();
+	await expect(cancelingCard.getByRole("button", { name: "Resume subscription" })).toBeEnabled();
 	await expectCardsFit(page.locator("body"));
 
 	await gotoHostedAgentSettings(page, "hdep_card_due", "Basic");
@@ -647,7 +773,37 @@ test("agent settings uses compact canonical subscription management", async ({
 		"destructive",
 	);
 	await expect(pastDueCard.getByText("Retries Jul 16, 2026", { exact: true })).toBeVisible();
-	await expect(pastDueCard.getByRole("button", { name: "Manage", exact: true })).toHaveCount(0);
+	const pastDueManage = pastDueCard.getByRole("button", { name: "Manage", exact: true });
+	await expect(pastDueManage).toBeEnabled();
+	await expect(pastDueCard.getByRole("button", { name: "Fix payment", exact: true })).toBeVisible();
+	await expect(pastDueCard.getByRole("button", { name: "Cancel subscription" })).toBeVisible();
+	await pastDueManage.click();
+	const pastDueManagementDialog = page.getByRole("dialog", { name: "Change payment source" });
+	await expect(pastDueManagementDialog).toBeVisible();
+	await expect(
+		pastDueManagementDialog.getByRole("group", { name: "Subscription management mode" }),
+	).toHaveCount(0);
+	await expect(pastDueManagementDialog.getByLabel("Compute plan")).toHaveCount(0);
+	await expect(pastDueManagementDialog.getByLabel("Payment source")).toBeVisible();
+	await pastDueManagementDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+	await expect(pastDueManagementDialog).toBeHidden();
+	await expectCardsFit(page.locator("body"));
+
+	await gotoHostedAgentSettings(page, "hdep_scheduled_downgrade", "Performance");
+	const scheduledDowngradeCard = page
+		.locator('[data-slot="compute-subscription-card"]')
+		.filter({ hasText: "Performance compute" });
+	const cancelScheduledAgent = scheduledDowngradeCard.getByRole("button", {
+		name: "Cancel scheduled change",
+	});
+	await cancelScheduledAgent.click();
+	await expect(cancelScheduledAgent).toBeDisabled();
+	await expect
+		.poll(() => scheduledPlanCancellationRequests.map((body) => JSON.parse(body)))
+		.toEqual([{ deployment_id: "hdep_scheduled_downgrade" }]);
+	await expect(
+		page.locator("[data-sonner-toast]").filter({ hasText: "Billing details are reconciling" }),
+	).toBeVisible();
 	await expectCardsFit(page.locator("body"));
 
 	await gotoHostedAgentSettings(page, "hdep_card_action_required", "Basic");
@@ -657,12 +813,54 @@ test("agent settings uses compact canonical subscription management", async ({
 	await expect(
 		actionRequiredCard.getByText("Payment action required", { exact: true }),
 	).toHaveAttribute("data-status", "warning");
-	await expect(actionRequiredCard.getByRole("button", { name: "Manage", exact: true })).toHaveCount(
-		0,
-	);
+	const actionRequiredManage = actionRequiredCard.getByRole("button", {
+		name: "Manage",
+		exact: true,
+	});
+	await expect(actionRequiredManage).toBeEnabled();
+	await expect(actionRequiredCard.getByRole("button", { name: "Fix payment" })).toBeVisible();
+	await expect(
+		actionRequiredCard.getByRole("button", { name: "Cancel subscription" }),
+	).toBeVisible();
+	await actionRequiredManage.click();
+	const actionRequiredManagementDialog = page.getByRole("dialog", {
+		name: "Change payment source",
+	});
+	await expect(actionRequiredManagementDialog).toBeVisible();
+	await expect(
+		actionRequiredManagementDialog.getByRole("group", {
+			name: "Subscription management mode",
+		}),
+	).toHaveCount(0);
+	await expect(actionRequiredManagementDialog.getByLabel("Compute plan")).toHaveCount(0);
+	await expect(actionRequiredManagementDialog.getByLabel("Payment source")).toBeVisible();
+	await actionRequiredManagementDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+	await expect(actionRequiredManagementDialog).toBeHidden();
+	await expectCardsFit(page.locator("body"));
+
+	await gotoHostedAgentSettings(page, "hdep_plan_change_pending", "Basic");
+	const pendingChangeCard = page
+		.locator('[data-slot="compute-subscription-card"]')
+		.filter({ hasText: "Basic compute" });
+	const cardCheckChange = pendingChangeCard.getByRole("button", {
+		name: "Check subscription change status",
+	});
+	await expect(cardCheckChange).toBeVisible();
+	await cardCheckChange.click();
+	await expect(
+		page.getByRole("dialog", { name: "Check subscription change status" }),
+	).toBeVisible();
+	expect(planQuoteRequests).toEqual([]);
+	await page.keyboard.press("Escape");
 	await expectCardsFit(page.locator("body"));
 
 	await gotoHostedAgentSettings(page, "hdep_terminal_fallback", "Basic");
+	await page.goto(`${page.url()}&subscription_action=start_new`);
+	const routedCreateDialog = page.getByRole("dialog", { name: "Choose a paid subscription" });
+	await expect(routedCreateDialog).toBeVisible();
+	await expect.poll(() => new URL(page.url()).searchParams.has("subscription_action")).toBe(false);
+	await page.keyboard.press("Escape");
+	await expect(routedCreateDialog).toBeHidden();
 	const fallbackCard = page
 		.locator('[data-slot="compute-subscription-card"]')
 		.filter({ hasText: "Basic compute" });

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -137,6 +137,7 @@ import {
 	type CheckoutReturnNavigationTarget,
 	useCheckoutReturnHandler,
 } from "@/hosted/billing/checkout-return";
+import { computeDunningState } from "@/hosted/billing/components/compute-dunning.logic";
 import { ComputeDunningBanner } from "@/hosted/billing/components/compute-dunning-banner";
 import type { DeploymentUpdateRequest, HostedDeployment } from "@/hosted/billing/contracts";
 import { navigateToAcceptedDeployment } from "@/hosted/billing/deploy/accepted-deployment-navigation";
@@ -154,16 +155,11 @@ import {
 	billingQueryRetry,
 	normalizeBillingError,
 } from "@/hosted/billing/errors";
-import {
-	billingKeys,
-	useCancelSubscription,
-	useManagedModelCatalog,
-	usePlans,
-	useResumeSubscription,
-} from "@/hosted/billing/hooks";
+import { billingKeys, useManagedModelCatalog, usePlans } from "@/hosted/billing/hooks";
+import { ComputeSubscriptionActionList } from "@/hosted/billing/subscription/compute-subscription-action-list";
+import { resolveComputeSubscriptionActions } from "@/hosted/billing/subscription/compute-subscription-actions";
 import {
 	ComputeSubscriptionCard,
-	ComputeSubscriptionManageAction,
 	computeSubscriptionCardView,
 } from "@/hosted/billing/subscription/compute-subscription-card";
 import {
@@ -180,11 +176,9 @@ import { SubscriptionCreateDialog } from "@/hosted/billing/subscription/subscrip
 import {
 	COMPUTE_BASIC_SLUG,
 	COMPUTE_PERFORMANCE_SLUG,
-	computeFundingMode,
 	computeFundingSource,
 	computeSubscriptionLifecycle,
 	computeTierLabel,
-	isComputeSubscriptionCancelable,
 	pendingComputePlanSlug,
 	pendingPlanScheduleCopy,
 	resolveBasicPlan,
@@ -530,7 +524,10 @@ export function HostedAgentDetail({
 			className={cn(
 				isLiveToolTab
 					? "-my-4 flex min-h-[calc(100svh-var(--header-height))] w-full flex-col md:-my-5 md:min-h-[calc(100svh-var(--header-height)-1rem)]"
-					: cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6"),
+					: cn(
+							activeTab === "settings" ? "w-full" : CENTERED_PAGE_WIDTH_CLASS.page,
+							"flex flex-col gap-6 px-4 lg:px-6",
+						),
 			)}
 		>
 			{isLiveToolTab ? <h1 className="sr-only">{availableAgentTitle}</h1> : null}
@@ -559,7 +556,9 @@ export function HostedAgentDetail({
 						}
 					/>
 				)}
-				{isLiveToolTab ? null : <ComputeDunningBanner deployment={deployment} />}
+				{isLiveToolTab || activeTab === "settings" ? null : (
+					<ComputeDunningBanner deployment={deployment} />
+				)}
 				{!deploymentStatus.known && activeTab !== "overview" ? (
 					<DeploymentStatusUnavailableState
 						deployment={deployment}
@@ -676,6 +675,7 @@ export function HostedAgentDetail({
 							environmentId={environmentId}
 							deployment={deployment}
 							agent={agent}
+							routeSearch={routeSearch}
 							onDeleteAccepted={onDeleteAccepted}
 						/>
 					) : null}
@@ -3398,11 +3398,13 @@ function HostedAgentSettingsTab({
 	environmentId,
 	deployment,
 	agent,
+	routeSearch,
 	onDeleteAccepted,
 }: {
 	environmentId: string;
 	deployment: HostedDeployment;
 	agent: components["schemas"]["AgentResponse"] | null;
+	routeSearch: AgentRouteSearch;
 	onDeleteAccepted: (deploymentId: string) => Promise<void> | void;
 }) {
 	return (
@@ -3414,7 +3416,11 @@ function HostedAgentSettingsTab({
 					<ProjectionDependentUnavailable label="Profile settings" />
 				)}
 				<LanguageTimezoneSettingsSection deployment={deployment} />
-				<ComputeSettingsSections deployment={deployment} onDeleteAccepted={onDeleteAccepted} />
+				<ComputeSettingsSections
+					deployment={deployment}
+					routeSearch={routeSearch}
+					onDeleteAccepted={onDeleteAccepted}
+				/>
 			</div>
 		</UnsavedNavigationBoundary>
 	);
@@ -3511,9 +3517,11 @@ function LanguageTimezoneSettingsSection({ deployment }: { deployment: HostedDep
 
 function ComputeSettingsSections({
 	deployment,
+	routeSearch,
 	onDeleteAccepted,
 }: {
 	deployment: HostedDeployment;
+	routeSearch: AgentRouteSearch;
 	onDeleteAccepted: (deploymentId: string) => Promise<void> | void;
 }) {
 	const router = useRouter();
@@ -3561,8 +3569,6 @@ function ComputeSettingsSections({
 	const [subscriptionCreateOpen, setSubscriptionCreateOpen] = useState(false);
 	const [planChangeOpen, setPlanChangeOpen] = useState(false);
 	const [hasPendingPlanChange, setHasPendingPlanChange] = useState(false);
-	const cancelSubscription = useCancelSubscription();
-	const resumeSubscription = useResumeSubscription();
 	const runAction = useActionLock();
 	const deploymentStatus = deploymentStatusFromResource(deployment.resource.status);
 	const canStop = canStopDeployment(deploymentStatus);
@@ -3576,21 +3582,16 @@ function ComputeSettingsSections({
 			? "stop"
 			: "start";
 	const canRunPrimaryLifecycleAction = primaryLifecycleAction === "stop" ? canStop : canStart;
-	const fundingFact = deployment.commercial_display?.latest_funding_fact;
 	const rawComputePlanSlug = deployment.current_plan_slug;
 	const computePlanSlug =
 		rawComputePlanSlug === COMPUTE_BASIC_SLUG || rawComputePlanSlug === COMPUTE_PERFORMANCE_SLUG
 			? rawComputePlanSlug
 			: undefined;
 	const currentSubscription = deployment.commercial_display?.compute_subscription;
-	const fundingMode = computeFundingMode(computePlanSlug, currentSubscription);
 	const fundingSource = computeFundingSource(computePlanSlug, currentSubscription);
-	const isIncludedBasic = fundingMode === "included_basic";
-	const isPaidCompute = fundingMode === "subscription";
-	const terminalFundingFact =
-		isIncludedBasic && fundingFact?.fact_kind === "funding_revoked" ? fundingFact : null;
-	const hasWalletFallback = terminalFundingFact?.funding_source === "wallet";
-	const hasTerminalFallback = terminalFundingFact !== null;
+	const dunningState = computeDunningState(deployment);
+	const terminalRecovery = dunningState?.recoveryTarget.kind === "start_new" ? dunningState : null;
+	const hasWalletFallback = terminalRecovery?.fundingSource === "wallet";
 	const pendingPlanSlug = pendingComputePlanSlug(currentSubscription);
 	const tierLabel = computeTierLabel(computePlanSlug);
 	const currentBillingTerm = planChangeBillingTerm(currentSubscription?.billing_term_months ?? 1);
@@ -3633,6 +3634,8 @@ function ComputeSettingsSections({
 			? { label: subscriptionLifecycle.badgeLabel, tone: subscriptionLifecycle.badgeTone }
 			: { label: "Unavailable", tone: "neutral" },
 	);
+	const actionRecoveryTarget = terminalRecovery?.recoveryTarget ?? computeRecovery.recoveryTarget;
+	const canOfferStartNew = actionRecoveryTarget?.kind === "start_new";
 	const computeCardView = computeSubscriptionCardView({
 		status: computeRecovery.status,
 		planSlug: computePlanSlug ?? rawComputePlanSlug,
@@ -3656,7 +3659,6 @@ function ComputeSettingsSections({
 				subscriptionPeriodLabel,
 			)
 		: null;
-	const subscriptionCancelable = isComputeSubscriptionCancelable(currentSubscription);
 	const computeManagement: ComputeSubscriptionManagementResult = currentSubscription
 		? computeSubscriptionManagement({
 				entitlement: {
@@ -3688,15 +3690,14 @@ function ComputeSettingsSections({
 	const computeManagementReason = plansErrorBlocksIncluded
 		? null
 		: computeManagement.unavailableReason;
-	const canStartNewSubscription = hostedAccess.canCreateCloudAgents && hasTerminalFallback;
 	const subscriptionCreatePlanSlug = resolveSubscriptionCreatePlanSlug(
-		terminalFundingFact?.prior_plan_slug,
+		terminalRecovery?.recoveryPlanSlug ?? pendingPlanSlug ?? computePlanSlug,
 		{
 			basicAvailable: !!basicPlan,
 			performanceAvailable: !!perfPlan,
 		},
 	);
-	const createUnavailableMessage = !hasTerminalFallback
+	const createUnavailableMessage = !canOfferStartNew
 		? null
 		: plans.isLoading
 			? "Checking paid compute availability…"
@@ -3705,48 +3706,54 @@ function ComputeSettingsSections({
 				: !(basicPlan || perfPlan)
 					? "Paid compute plans are unavailable right now."
 					: null;
-	const pendingComputeChangeAction = hasPendingComputeChange ? (
-		<Button type="button" variant="outline" size="sm" onClick={() => setPlanChangeOpen(true)}>
-			<RefreshCw data-icon="inline-start" />
-			Check subscription change status
-		</Button>
-	) : null;
+	const computeActions = resolveComputeSubscriptionActions({
+		entitlement: {
+			deploymentId: deployment.resource.id,
+			planSlug: computePlanSlug,
+			fundingSource: currentSubscription?.funding_source,
+			priceCents: currentSubscription?.price_cents,
+			status: currentSubscription?.status ?? "unavailable",
+			paymentState: currentSubscription?.payment_state ?? "ok",
+			cancelAtPeriodEnd: subscriptionCancelPending,
+			pendingPlanSlug,
+		},
+		management: computeManagement,
+		recoveryTarget: actionRecoveryTarget,
+		hasPendingOperation: hasPendingComputeChange,
+		startNewUnavailableReason: createUnavailableMessage,
+	});
 	useEffect(() => {
 		if (hostedAccess.isLoading || hostedAccess.canCreateCloudAgents) return;
 		setSubscriptionCreateOpen(false);
 		setPlanChangeOpen(false);
 	}, [hostedAccess.canCreateCloudAgents, hostedAccess.isLoading]);
-
-	async function cancelComputeSubscription() {
-		if (!subscriptionCancelable || subscriptionCancelPending) {
-			return;
+	useEffect(() => {
+		if (routeSearch.subscription_action !== "start_new") return;
+		if (hostedAccess.isLoading || plans.isLoading) return;
+		if (canOfferStartNew && hostedAccess.canCreateCloudAgents && (basicPlan || perfPlan)) {
+			setSubscriptionCreateOpen(true);
 		}
-		try {
-			const res = await cancelSubscription.mutateAsync({ deployment_id: deployment.resource.id });
-			toast.success("Subscription cancellation scheduled", {
-				description: res.current_period_end
-					? `Cancellation takes effect ${formatShortDate(
-							res.current_period_end,
-						)}. The agent then falls back to included Basic funding if available; otherwise, it stops.`
-					: "The agent falls back to included Basic funding if available when cancellation takes effect; otherwise, it stops.",
-			});
-		} catch (error) {
-			toast.error("Couldn’t cancel subscription", { description: normalizeBillingError(error) });
-			throw error;
-		}
-	}
-
-	async function resumeComputeSubscription() {
-		if (!subscriptionCancelable || !subscriptionCancelPending) {
-			return;
-		}
-		try {
-			await resumeSubscription.mutateAsync({ deployment_id: deployment.resource.id });
-			toast.success("Subscription resumed");
-		} catch (error) {
-			toast.error("Couldn’t resume subscription", { description: normalizeBillingError(error) });
-		}
-	}
+		void router.navigate({
+			to: ".",
+			search: (current) => {
+				const next = { ...current };
+				delete next.subscription_action;
+				return next;
+			},
+			hash: true,
+			replace: true,
+			resetScroll: false,
+		});
+	}, [
+		basicPlan,
+		canOfferStartNew,
+		hostedAccess.canCreateCloudAgents,
+		hostedAccess.isLoading,
+		perfPlan,
+		plans.isLoading,
+		routeSearch.subscription_action,
+		router,
+	]);
 
 	async function runLifecycleAction(action: "restart" | "stop" | "start") {
 		await lifecycle.mutateAsync({ id: deployment.resource.id, action });
@@ -3754,7 +3761,7 @@ function ComputeSettingsSections({
 
 	return (
 		<div className="flex flex-col gap-8">
-			{hasTerminalFallback ? (
+			{canOfferStartNew ? (
 				<SubscriptionCreateDialog
 					open={subscriptionCreateOpen}
 					onOpenChange={setSubscriptionCreateOpen}
@@ -3807,80 +3814,30 @@ function ComputeSettingsSections({
 						) : null
 					}
 					actions={
-						hasTerminalFallback || isIncludedBasic || (isPaidCompute && currentSubscription) ? (
-							hasTerminalFallback ? (
-								(pendingComputeChangeAction ?? (
-									<Button
-										size="sm"
-										disabled={!canStartNewSubscription}
-										onClick={() => setSubscriptionCreateOpen(true)}
-									>
-										<Plus data-icon="inline-start" />
-										Choose a subscription
-									</Button>
-								))
-							) : isIncludedBasic ? (
-								(pendingComputeChangeAction ?? (
-									<ComputeSubscriptionManageAction
-										onClick={() => setPlanChangeOpen(true)}
-										disabled={computeManagement.action !== "enabled"}
-									/>
-								))
-							) : isPaidCompute && currentSubscription ? (
-								subscriptionCancelPending ? (
-									<Button
-										type="button"
-										variant="outline"
-										size="sm"
-										disabled={resumeSubscription.isPending || !subscriptionCancelable}
-										onClick={() => void runAction(resumeComputeSubscription).catch(() => undefined)}
-									>
-										{resumeSubscription.isPending ? (
-											<Spinner data-icon="inline-start" />
-										) : (
-											<RefreshCw data-icon="inline-start" />
-										)}
-										Resume subscription
-									</Button>
-								) : (
-									<>
-										{pendingComputeChangeAction ??
-											(computeRecovery.hasPaymentIssue || pendingPlanSlug ? null : (
-												<ComputeSubscriptionManageAction
-													onClick={() => setPlanChangeOpen(true)}
-													disabled={computeManagement.action !== "enabled"}
-												/>
-											))}
-										<ConfirmAction
-											title={`Cancel ${tierLabel} subscription?`}
-											description={
-												<p>
-													Cancellation takes effect {subscriptionPeriodLabel}. The agent then falls
-													back to included Basic funding if available; otherwise, it stops.
-												</p>
-											}
-											confirmLabel="Cancel at period end"
-											destructive
-											onConfirm={() => runAction(cancelComputeSubscription)}
-										>
-											<Button
-												type="button"
-												variant="outline"
-												size="sm"
-												disabled={cancelSubscription.isPending || !subscriptionCancelable}
-											>
-												{cancelSubscription.isPending ? (
-													<Spinner data-icon="inline-start" />
-												) : (
-													<Link2Off data-icon="inline-start" />
-												)}
-												Cancel subscription
-											</Button>
-										</ConfirmAction>
-									</>
-								)
-							) : null
-						) : null
+						<ComputeSubscriptionActionList
+							actions={computeActions}
+							target={{ kind: "deployment", deploymentId: deployment.resource.id }}
+							onManage={() => setPlanChangeOpen(true)}
+							onStartNew={{
+								kind: "button",
+								onClick: () => setSubscriptionCreateOpen(true),
+								label: "Choose a subscription",
+							}}
+							cancelCopy={{
+								title: `Cancel ${tierLabel} subscription?`,
+								description: (
+									<p>
+										Cancellation takes effect {subscriptionPeriodLabel}. The agent then falls back
+										to included Basic funding if available; otherwise, it stops.
+									</p>
+								),
+								confirmLabel: "Cancel at period end",
+								successDescription: (result) =>
+									result.current_period_end
+										? `Cancellation takes effect ${formatShortDate(result.current_period_end)}. The agent then falls back to included Basic funding if available; otherwise, it stops.`
+										: "The agent falls back to included Basic funding if available when cancellation takes effect; otherwise, it stops.",
+							}}
+						/>
 					}
 				/>
 			</SettingsSection>

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -1035,7 +1035,7 @@ describe("declarative deployment mutations", () => {
 });
 
 describe("account compute subscriptions", () => {
-	it("lists subscriptions and targets cancel or resume by subscription id", async () => {
+	it("lists subscriptions and uses the generated subscription action endpoints", async () => {
 		const requests: Request[] = [];
 		const client = testClient(async (request) => {
 			requests.push(request.clone());
@@ -1084,14 +1084,20 @@ describe("account compute subscriptions", () => {
 		});
 		await client.cancelSubscription({ subscription_id: "csub_test" });
 		await client.resumeSubscription({ subscription_id: "csub_test" });
+		await client.cancelScheduledPlanChange({ subscription_id: "csub_test" });
+		await client.cancelScheduledPlanChange({ deployment_id: "hdep_test" });
 
 		expect(requests.map((request) => [request.method, new URL(request.url).pathname])).toEqual([
 			["GET", "/v2/subscriptions"],
 			["POST", "/v2/subscription/cancel"],
 			["POST", "/v2/subscription/resume"],
+			["POST", "/v2/subscription/plan/cancel-scheduled-change"],
+			["POST", "/v2/subscription/plan/cancel-scheduled-change"],
 		]);
 		expect(await requests[1]?.json()).toEqual({ subscription_id: "csub_test" });
 		expect(await requests[2]?.json()).toEqual({ subscription_id: "csub_test" });
+		expect(await requests[3]?.json()).toEqual({ subscription_id: "csub_test" });
+		expect(await requests[4]?.json()).toEqual({ deployment_id: "hdep_test" });
 		expect(new URL(requests[0]?.url ?? "").searchParams).toEqual(
 			new URLSearchParams({ limit: "3", cursor: "cursor-current" }),
 		);

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import { hostedApiBaseUrl } from "@/hosted/billing/billing-url";
 import type {
 	CheckoutRequest,
+	ComputeCancelScheduledPlanChangeRequest,
 	ComputeFixPaymentRequest,
 	ComputePlanChangeProgress,
 	ComputePlanChangeQuoteRequest,
@@ -816,6 +817,8 @@ export function createBillingClient(
 			}),
 		cancelSubscription: async (body: ComputeSubscriptionCancelRequest) =>
 			unwrapDeploy(await api.POST("/v2/subscription/cancel", { body })),
+		cancelScheduledPlanChange: async (body: ComputeCancelScheduledPlanChangeRequest) =>
+			unwrapDeploy(await api.POST("/v2/subscription/plan/cancel-scheduled-change", { body })),
 		fixPayment: async (body: ComputeFixPaymentRequest) =>
 			unwrapDeploy(await api.POST("/v2/subscription/fix-payment", { body })),
 		portal: async (body: PortalRequest) =>

--- a/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
+++ b/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
@@ -1,44 +1,56 @@
 "use client";
 
 import { Link, useSearch } from "@tanstack/react-router";
-import {
-	CreditCard,
-	ExternalLink,
-	History,
-	Info,
-	LifeBuoy,
-	Plus,
-	TriangleAlert,
-	WalletCards,
-} from "lucide-react";
-import { useState } from "react";
-import { toast } from "sonner";
+import { History, Info, LifeBuoy, TriangleAlert } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
-import { normalizeBillingError } from "@/hosted/billing/errors";
-import { useSensitiveFixPayment } from "@/hosted/billing/sensitive-actions";
-import { useActionLock } from "@/hosted/billing/use-action-lock";
-import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
-import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
+import { ComputeSubscriptionActionList } from "@/hosted/billing/subscription/compute-subscription-action-list";
+import { resolveComputeSubscriptionActions } from "@/hosted/billing/subscription/compute-subscription-actions";
+import { activePlanChangeOperationName } from "@/hosted/billing/subscription/plan-change.logic";
+import { pendingComputePlanSlug } from "@/hosted/billing/subscription/subscription-utils";
+import { agentSectionHref } from "@/lib/agent-routes";
 import { formatShortDate } from "@/lib/format";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { computeDunningState, fallbackReasonSentence } from "./compute-dunning.logic";
 
 export function ComputeDunningBanner({ deployment }: { deployment: HostedDeployment }) {
 	const state = computeDunningState(deployment);
+	const subscription = deployment.commercial_display?.compute_subscription;
+	const actions = state
+		? resolveComputeSubscriptionActions({
+				entitlement: {
+					deploymentId: deployment.resource.id,
+					planSlug: deployment.current_plan_slug,
+					fundingSource: subscription?.funding_source ?? state.fundingSource,
+					priceCents: subscription?.price_cents,
+					status: subscription?.status ?? state.paymentState,
+					paymentState: state.paymentState,
+					cancelAtPeriodEnd: subscription?.cancel_at_period_end ?? false,
+					pendingPlanSlug: pendingComputePlanSlug(subscription),
+				},
+				management: { action: "hidden", target: null, unavailableReason: null },
+				recoveryTarget: state.recoveryTarget,
+				hasPendingOperation: activePlanChangeOperationName(deployment) !== null,
+			})
+		: [];
+	const primaryAction = actions[0] ?? null;
 	const hostedAccess = useHostedProductAccess();
-	const fixPayment = useSensitiveFixPayment();
-	const runAction = useActionLock();
-	const wallet = useWalletSnapshot({
-		enabled: state?.ctaTarget === "top_up",
-	});
-	const [topUpOpen, setTopUpOpen] = useState(false);
 	const routeSearch = useSearch({ from: "/_protected/_dashboard" });
 	const transactionsLink = (
 		<Link to="." search={{ ...routeSearch, settings: "billing-wallet" }} hash="transactions" />
 	);
+	const startNewHref = agentSectionHref(deployment.resource.id, "settings", {
+		...routeSearch,
+		source: "on-clawdi",
+		subscription_action: "start_new",
+	});
+	const checkChangeHref = agentSectionHref(deployment.resource.id, "settings", {
+		...routeSearch,
+		source: "on-clawdi",
+		settings: "billing-plan",
+		subscription_action: undefined,
+	});
 
 	if (!state) return null;
 
@@ -56,119 +68,59 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 		.filter(Boolean)
 		.join(" ");
 
-	async function handleFixPayment() {
-		if (!state) return;
-		if (state.ctaTarget === "invoice" && state.invoiceUrl) {
-			window.location.href = state.invoiceUrl;
-			return;
-		}
-		try {
-			const result = await fixPayment.execute({ deployment_id: deployment.resource.id });
-			const url = result.url || result.portal_url;
-			if (url) {
-				window.location.href = url;
-				return;
-			}
-			toast.message("Payment update unavailable", {
-				description: "Refresh this page and try again in a moment.",
-			});
-		} catch (error) {
-			toast.error("Couldn’t open payment settings", {
-				description: normalizeBillingError(error),
-			});
-		}
-	}
-
 	const BannerIcon = state.tone === "neutral" ? Info : TriangleAlert;
 
 	return (
-		<>
-			<Alert
-				data-hosted="true"
-				variant={destructive ? "destructive" : "default"}
-				className={
-					destructive
-						? undefined
-						: state.tone === "warning"
-							? "border-warning/30 bg-warning-muted"
-							: "border-info-muted bg-info-muted text-info-muted-foreground"
-				}
-			>
-				<BannerIcon aria-hidden />
-				<AlertTitle>{state.title}</AlertTitle>
-				<AlertDescription className="flex flex-col items-start gap-3">
-					<span>{bannerDescription}</span>
-					{hostedAccess.isLoading ? null : !hostedAccess.canCreateCloudAgents &&
-						state.ctaTarget === "start_new" ? (
-						<span className="text-xs text-muted-foreground">
-							Starting a new subscription is temporarily unavailable. This agent remains visible and
-							manageable.
-						</span>
-					) : state.ctaTarget === "top_up" ? (
-						<Button
-							size="sm"
-							variant={destructive ? "destructive" : "default"}
-							onClick={() => setTopUpOpen(true)}
-							disabled={!wallet.data}
-						>
-							<WalletCards data-icon="inline-start" /> Top up
-						</Button>
-					) : state.ctaTarget === "start_new" ? (
-						<Button
-							render={<a href="#compute-plan-controls" />}
-							nativeButton={false}
-							size="sm"
-							variant={destructive ? "destructive" : "default"}
-						>
-							<Plus data-icon="inline-start" /> Start a new subscription
-						</Button>
-					) : state.ctaTarget === "transactions" ? (
-						<Button render={transactionsLink} nativeButton={false} size="sm" variant="outline">
-							<History data-icon="inline-start" /> View transactions
-						</Button>
-					) : state.ctaTarget === "support" ? (
-						<Button
-							render={<a href="mailto:support@clawdi.ai" />}
-							nativeButton={false}
-							size="sm"
-							variant="outline"
-						>
-							<LifeBuoy data-icon="inline-start" /> Contact support
-						</Button>
-					) : state.ctaTarget === "invoice" || state.ctaTarget === "fix_payment" ? (
-						<Button
-							size="sm"
-							variant={destructive ? "destructive" : "default"}
-							onClick={() => void runAction(handleFixPayment)}
-							disabled={fixPayment.isPending}
-						>
-							{fixPayment.isPending ? (
-								<Spinner data-icon="inline-start" />
-							) : state.ctaTarget === "invoice" ? (
-								<ExternalLink data-icon="inline-start" />
-							) : (
-								<CreditCard data-icon="inline-start" />
-							)}
-							Fix payment
-						</Button>
-					) : null}
-					{state.secondaryTarget === "transactions" ? (
-						<Button render={transactionsLink} nativeButton={false} size="sm" variant="outline">
-							<History data-icon="inline-start" /> View transactions
-						</Button>
-					) : state.secondaryTarget === "support" ? (
-						<Button
-							render={<a href="mailto:support@clawdi.ai" />}
-							nativeButton={false}
-							size="sm"
-							variant="outline"
-						>
-							<LifeBuoy data-icon="inline-start" /> Contact support
-						</Button>
-					) : null}
-				</AlertDescription>
-			</Alert>
-			{wallet.data ? <TopUpDialog open={topUpOpen} onOpenChange={setTopUpOpen} /> : null}
-		</>
+		<Alert
+			data-hosted="true"
+			variant={destructive ? "destructive" : "default"}
+			className={
+				destructive
+					? undefined
+					: state.tone === "warning"
+						? "border-warning/30 bg-warning-muted"
+						: "border-info-muted bg-info-muted text-info-muted-foreground"
+			}
+		>
+			<BannerIcon aria-hidden />
+			<AlertTitle>{state.title}</AlertTitle>
+			<AlertDescription className="flex flex-col items-start gap-3">
+				<span>{bannerDescription}</span>
+				{hostedAccess.isLoading ? null : !hostedAccess.canCreateCloudAgents &&
+					primaryAction?.kind === "start_new" ? (
+					<span className="text-xs text-muted-foreground">
+						Starting a new subscription is temporarily unavailable. This agent remains visible and
+						manageable.
+					</span>
+				) : primaryAction ? (
+					<ComputeSubscriptionActionList
+						actions={[primaryAction]}
+						target={{ kind: "deployment", deploymentId: deployment.resource.id }}
+						onStartNew={{
+							kind: "link",
+							href: startNewHref,
+							label: "Start a new subscription",
+						}}
+						checkChangeHref={checkChangeHref}
+						startNewIcon="plus"
+						primaryVariant={destructive ? "destructive" : "default"}
+					/>
+				) : null}
+				{state.secondaryTarget === "transactions" ? (
+					<Button render={transactionsLink} nativeButton={false} size="sm" variant="outline">
+						<History data-icon="inline-start" /> View transactions
+					</Button>
+				) : state.secondaryTarget === "support" ? (
+					<Button
+						render={<a href="mailto:support@clawdi.ai" />}
+						nativeButton={false}
+						size="sm"
+						variant="outline"
+					>
+						<LifeBuoy data-icon="inline-start" /> Contact support
+					</Button>
+				) : null}
+			</AlertDescription>
+		</Alert>
 	);
 }

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
@@ -93,8 +93,7 @@ describe("computeDunningState", () => {
 
 		expect(state).toMatchObject({
 			fundingSource: "wallet",
-			recoveryAction: "top_up",
-			ctaTarget: "top_up",
+			recoveryTarget: { kind: "top_up", action: "top_up" },
 		});
 		expect(state?.description).toContain("update automatically");
 		expect(state?.description).not.toMatch(/grace|retry/i);
@@ -105,11 +104,11 @@ describe("computeDunningState", () => {
 	test("routes card past due to payment remediation", () => {
 		const deploymentWithPastDueCard = deployment({
 			computeSubscription: subscription({ status: "past_due", payment_state: "past_due" }),
+			factKind: "funding_revoked",
 		});
 		expect(computeDunningState(deploymentWithPastDueCard)).toMatchObject({
 			fundingSource: "stripe",
-			recoveryAction: "fix_payment",
-			ctaTarget: "fix_payment",
+			recoveryTarget: { kind: "fix_payment", action: "fix_payment" },
 		});
 	});
 
@@ -126,9 +125,11 @@ describe("computeDunningState", () => {
 
 		expect(state).toMatchObject({
 			paymentState: "requires_action",
-			recoveryAction: "fix_payment",
-			ctaTarget: "invoice",
-			invoiceUrl: "https://invoice.stripe.test/action",
+			recoveryTarget: {
+				kind: "invoice",
+				action: "fix_payment",
+				url: "https://invoice.stripe.test/action",
+			},
 		});
 	});
 
@@ -161,8 +162,7 @@ describe("computeDunningState", () => {
 			);
 			expect(state).toMatchObject({
 				fundingSource,
-				recoveryAction: "start_new",
-				ctaTarget: "start_new",
+				recoveryTarget: { kind: "start_new", action: "start_new" },
 				tone: "destructive",
 			});
 			expect(state?.description).toContain("Start a new subscription");
@@ -181,8 +181,7 @@ describe("computeDunningState", () => {
 		expect(running).toMatchObject({
 			paymentState: "unpaid",
 			fundingSource: "wallet",
-			recoveryAction: "start_new",
-			ctaTarget: "start_new",
+			recoveryTarget: { kind: "start_new", action: "start_new" },
 			fallbackOccurredAt: "2026-07-18T12:00:00Z",
 			fallbackPlanLabel: "Performance compute",
 			fallbackReason: "payment_failure",
@@ -265,8 +264,7 @@ describe("computeDunningState", () => {
 			expect(state).toMatchObject({
 				...expected,
 				fallbackReason: reason,
-				ctaTarget: "start_new",
-				recoveryAction: "start_new",
+				recoveryTarget: { kind: "start_new", action: "start_new" },
 			});
 		}
 	});

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
@@ -5,6 +5,10 @@ import type {
 	HostedFundingFact,
 } from "@/hosted/billing/contracts";
 import {
+	type ComputeRecoveryTarget,
+	computeSubscriptionRecoveryTarget,
+} from "@/hosted/billing/subscription/compute-subscription-recovery";
+import {
 	computeTierLabel,
 	isIncludedBasicSubscription,
 	pendingComputePlanSlug,
@@ -21,19 +25,10 @@ type FundingRevocationReason = NonNullable<HostedFundingFact["reason"]>;
 export type ComputeDunningState = {
 	paymentState: Exclude<ComputePaymentState, "ok">;
 	fundingSource: "stripe" | "wallet";
-	recoveryAction: "top_up" | "fix_payment" | "start_new" | null;
+	recoveryTarget: ComputeRecoveryTarget;
 	tone: "neutral" | "warning" | "destructive";
 	title: string;
 	description: string;
-	ctaTarget:
-		| "invoice"
-		| "fix_payment"
-		| "top_up"
-		| "start_new"
-		| "transactions"
-		| "support"
-		| "none";
-	invoiceUrl: string | null;
 	secondaryTarget: "transactions" | "support" | null;
 	fallbackOccurredAt: string | null;
 	fallbackPlanLabel: string | null;
@@ -120,18 +115,16 @@ function detachedFallbackState(deployment: DunningDeployment): ComputeDunningSta
 		...presentation,
 		paymentState: "unpaid",
 		fundingSource: fallback.funding_source,
-		recoveryAction: "start_new",
+		recoveryTarget: { kind: "start_new", action: "start_new" },
 		description: statusUnavailable
 			? "We can’t determine whether this agent stopped or is using included Basic because its current status is unavailable. Start a new subscription to restore paid compute."
 			: stopped
 				? "No included Basic slot was available, so this agent stopped. Start a new subscription to restore paid compute."
 				: "This agent is now using included Basic. Start a new subscription to restore paid compute.",
-		invoiceUrl: null,
 		fallbackOccurredAt: fallback.occurred_at,
 		fallbackPlanLabel,
 		fallbackReason: fallback.reason,
 		recoveryPlanSlug,
-		ctaTarget: "start_new",
 	};
 }
 
@@ -143,6 +136,8 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 	}
 	if (!subscription) return null;
 	if (subscription.payment_state === "ok") return null;
+	const recoveryTarget = computeSubscriptionRecoveryTarget(subscription);
+	if (!recoveryTarget) return null;
 
 	const recoveryPlanSlug = recoveryPlanSlugFor(deployment, subscription);
 	const computeName = recoveryPlanSlug
@@ -151,7 +146,6 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 	const fundingSource = subscription.funding_source ?? "stripe";
 	const common = {
 		fundingSource,
-		invoiceUrl: subscription.latest_failed_invoice_hosted_url ?? null,
 		fallbackOccurredAt: null,
 		fallbackPlanLabel: null,
 		fallbackReason: null,
@@ -163,12 +157,11 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 		return {
 			...common,
 			paymentState: "unpaid",
-			recoveryAction: "start_new",
+			recoveryTarget,
 			tone: "destructive",
 			title: "Compute subscription ended",
 			description:
 				"This paid subscription ended. Start a new subscription for this agent to restore paid compute.",
-			ctaTarget: "start_new",
 		};
 	}
 
@@ -176,11 +169,10 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 		return {
 			...common,
 			paymentState: "requires_action",
-			recoveryAction: "fix_payment",
+			recoveryTarget,
 			tone: "warning",
 			title: "Payment authentication required",
 			description: `Complete the payment authentication to keep ${computeName} active.`,
-			ctaTarget: common.invoiceUrl ? "invoice" : "fix_payment",
 		};
 	}
 
@@ -188,22 +180,20 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 		return {
 			...common,
 			paymentState: "past_due",
-			recoveryAction: "top_up",
+			recoveryTarget,
 			tone: "warning",
 			title: "Wallet payment past due",
 			description:
 				"Top up your Wallet. Stripe will keep the invoice open while funds are short, and billing will update automatically after payment completes.",
-			ctaTarget: "top_up",
 		};
 	}
 
 	return {
 		...common,
 		paymentState: "past_due",
-		recoveryAction: "fix_payment",
+		recoveryTarget,
 		tone: "warning",
 		title: "Payment past due",
 		description: "Update the card payment method for the open invoice.",
-		ctaTarget: "fix_payment",
 	};
 }

--- a/apps/web/src/hosted/billing/contracts.ts
+++ b/apps/web/src/hosted/billing/contracts.ts
@@ -12,6 +12,8 @@ export type BillingOffer = Schemas["V2BillingOfferResponse"];
 export type CheckoutRequest = Schemas["V2ComputeCheckoutRequest"];
 export type ComputePlanSlug = Schemas["V2HostedDeployRequest"]["compute_plan_slug"];
 export type ComputeSubscriptionActionResult = Schemas["V2ComputeSubscriptionActionResponse"];
+export type ComputeCancelScheduledPlanChangeRequest =
+	Schemas["V2ComputeCancelScheduledPlanChangeRequest"];
 export type ComputeSubscriptionCancelRequest = Schemas["V2ComputeSubscriptionCancelRequest"];
 export type ComputeSubscriptionListItem = Schemas["V2ComputeSubscriptionListItem"];
 export type ComputeFixPaymentRequest = Schemas["V2ComputeFixPaymentRequest"];

--- a/apps/web/src/hosted/billing/errors.test.ts
+++ b/apps/web/src/hosted/billing/errors.test.ts
@@ -166,6 +166,20 @@ describe("normalizeBillingError", () => {
 		);
 	});
 
+	test("maps funding authority conflicts by stable code without exposing internals", () => {
+		const error = new BillingApiError(
+			409,
+			"Stripe and local funding-source authority are inconsistent",
+			{ detail: { code: "funding_authority_inconsistent" } },
+		);
+		const message = normalizeBillingError(error);
+		expect(message).toBe(
+			"Subscription billing details need reconciliation. Contact support before changing this subscription.",
+		);
+		expect(message).not.toContain("Stripe");
+		expect(message).not.toContain("authority");
+	});
+
 	test("unknown shapes get a safe message", () => {
 		expect(normalizeBillingError(null)).toMatch(/something went wrong/i);
 	});

--- a/apps/web/src/hosted/billing/errors.ts
+++ b/apps/web/src/hosted/billing/errors.ts
@@ -353,6 +353,7 @@ export function billingQueryRetry(failureCount: number, error: unknown): boolean
  * message text from an upstream gateway.
  */
 export const INSUFFICIENT_WALLET_BALANCE_CODE = "insufficient_wallet_balance";
+export const FUNDING_AUTHORITY_INCONSISTENT_CODE = "funding_authority_inconsistent";
 
 export function isInsufficientBalanceError(error: unknown): boolean {
 	if (!(error instanceof BillingApiError)) return false;
@@ -390,6 +391,9 @@ export function normalizeBillingError(error: unknown): string {
 	}
 	if (error instanceof BillingApiError) {
 		const code = billingErrorDetail(error)?.code;
+		if (code === FUNDING_AUTHORITY_INCONSISTENT_CODE) {
+			return "Subscription billing details need reconciliation. Contact support before changing this subscription.";
+		}
 		if (code === "open_refund_debt") {
 			return "Top up your Wallet to continue. New funds repay refund debt before compute charges.";
 		}

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -20,6 +20,7 @@ import {
 	billingNextPageParam,
 	billingRecoveryRefetchIntervalFor,
 	HOSTED_DEPLOYMENTS_REFRESH_POLICY,
+	invalidateComputeSubscriptionInventory,
 	invalidateSettledPlanChangeQueries,
 	reconcileDeploymentSnapshots,
 	refreshCheckoutReturnQueries,
@@ -160,15 +161,50 @@ describe("applyDeploymentSubscriptionResult", () => {
 });
 
 describe("applySubscriptionActionSuccess", () => {
-	test("invalidates deployments and subscriptions when targeting a subscription id", () => {
+	test("invalidates every compute subscription inventory after an action", async () => {
 		const qc = new QueryClient();
 		qc.setQueryData(billingKeys.deployments, { current: true });
 		qc.setQueryData(billingKeys.subscriptions, { current: true });
+		qc.setQueryData(billingKeys.reusableSubscriptions, { current: true });
 
-		applySubscriptionActionSuccess(qc, { subscription_id: "csub_test" }, subscriptionAction(true));
+		await applySubscriptionActionSuccess(
+			qc,
+			{ subscription_id: "csub_test" },
+			subscriptionAction(true),
+		);
 
 		expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(true);
 		expect(qc.getQueryState(billingKeys.subscriptions)?.isInvalidated).toBe(true);
+		expect(qc.getQueryState(billingKeys.reusableSubscriptions)?.isInvalidated).toBe(true);
+	});
+
+	test("refetches every inventory after scheduled cancellation settles", async () => {
+		const fetches = new Map<string, number>();
+		const qc = new QueryClient();
+		for (const queryKey of [
+			billingKeys.deployments,
+			billingKeys.subscriptions,
+			billingKeys.reusableSubscriptions,
+		]) {
+			const key = JSON.stringify(queryKey);
+			await qc.fetchQuery({
+				queryKey,
+				queryFn: () => {
+					fetches.set(key, (fetches.get(key) ?? 0) + 1);
+					return { current: true };
+				},
+			});
+		}
+
+		await invalidateComputeSubscriptionInventory(qc, "all");
+
+		for (const queryKey of [
+			billingKeys.deployments,
+			billingKeys.subscriptions,
+			billingKeys.reusableSubscriptions,
+		]) {
+			expect(fetches.get(JSON.stringify(queryKey))).toBe(2);
+		}
 	});
 });
 

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -13,6 +13,7 @@ import {
 import { useCallback, useEffect, useRef } from "react";
 import { isDeployApiConfigured, useBillingClient } from "@/hosted/billing/billing-client";
 import type {
+	ComputeCancelScheduledPlanChangeRequest,
 	ComputePlanChangeQuoteRequest,
 	ComputePlanChangeRequest,
 	ComputePlanChangeResult,
@@ -58,6 +59,10 @@ function subscriptionFromAction(
 		billing_term_months: next.billing_term_months,
 		currency: previous?.currency ?? "usd",
 		cancel_at_period_end: next.cancel_at_period_end,
+		pending_plan_slug:
+			next.pending_plan_slug === undefined
+				? (previous?.pending_plan_slug ?? null)
+				: next.pending_plan_slug,
 		current_period_end: next.current_period_end ?? previous?.current_period_end ?? null,
 		cancel_at: next.cancel_at ?? null,
 		latest_failed_invoice_id:
@@ -103,17 +108,26 @@ export function applyDeploymentSubscriptionResult(
 	);
 }
 
-export function applySubscriptionActionSuccess(
+export async function invalidateComputeSubscriptionInventory(
+	qc: QueryClient,
+	refetchType: "active" | "all" = "active",
+): Promise<void> {
+	await Promise.all(
+		[billingKeys.deployments, billingKeys.subscriptions, billingKeys.reusableSubscriptions].map(
+			(queryKey) => qc.invalidateQueries({ queryKey, refetchType }),
+		),
+	);
+}
+
+export async function applySubscriptionActionSuccess(
 	qc: QueryClient,
 	body: ComputeSubscriptionCancelRequest | ComputeSubscriptionResumeRequest,
 	next: ComputeSubscriptionActionResult,
-): void {
+): Promise<void> {
 	if (body.deployment_id) {
 		applyDeploymentSubscriptionResult(qc, body.deployment_id, next);
-	} else if (body.subscription_id) {
-		qc.invalidateQueries({ queryKey: billingKeys.deployments });
 	}
-	qc.invalidateQueries({ queryKey: billingKeys.subscriptions });
+	await invalidateComputeSubscriptionInventory(qc);
 }
 
 /**
@@ -268,6 +282,16 @@ export function useResumeSubscription() {
 	return useMutation({
 		mutationFn: (body: ComputeSubscriptionResumeRequest) => client.resumeSubscription(body),
 		onSuccess: (next, body) => applySubscriptionActionSuccess(qc, body, next),
+	});
+}
+
+export function useCancelScheduledPlanChange() {
+	const client = useBillingClient();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (body: ComputeCancelScheduledPlanChangeRequest) =>
+			client.cancelScheduledPlanChange(body),
+		onSettled: () => invalidateComputeSubscriptionInventory(qc, "all"),
 	});
 }
 

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-action-list.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-action-list.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { CalendarX2, Link2Off, RefreshCw } from "lucide-react";
+import type { ReactNode } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { ConfirmAction } from "@/components/ui/confirm-action";
+import { Spinner } from "@/components/ui/spinner";
+import type {
+	ComputeCancelScheduledPlanChangeRequest,
+	ComputeSubscriptionActionResult,
+} from "@/hosted/billing/contracts";
+import { normalizeBillingError } from "@/hosted/billing/errors";
+import {
+	useCancelScheduledPlanChange,
+	useCancelSubscription,
+	useResumeSubscription,
+} from "@/hosted/billing/hooks";
+import type { ComputeSubscriptionAction } from "@/hosted/billing/subscription/compute-subscription-actions";
+import { ComputeSubscriptionManageAction } from "@/hosted/billing/subscription/compute-subscription-card";
+import {
+	ComputeSubscriptionRecoveryAction,
+	type ComputeSubscriptionStartNewAction,
+} from "@/hosted/billing/subscription/compute-subscription-recovery-action";
+import { useActionLock } from "@/hosted/billing/use-action-lock";
+
+export type ComputeSubscriptionActionTarget =
+	| { kind: "deployment"; deploymentId: string }
+	| { kind: "subscription"; subscriptionId: string; deploymentId: string | null };
+
+export type ComputeSubscriptionCancelCopy = {
+	title: string;
+	description: ReactNode;
+	confirmLabel: string;
+	successDescription?: (result: ComputeSubscriptionActionResult) => string | undefined;
+};
+
+export function computeSubscriptionActionRequest(
+	target: ComputeSubscriptionActionTarget,
+): ComputeCancelScheduledPlanChangeRequest {
+	return target.kind === "deployment"
+		? { deployment_id: target.deploymentId }
+		: { subscription_id: target.subscriptionId };
+}
+
+export function scheduledPlanCancellationNotice(result: ComputeSubscriptionActionResult): {
+	kind: "success" | "info";
+	title: string;
+	description: string;
+} {
+	switch (result.action_state) {
+		case "removed":
+			return {
+				kind: "success",
+				title: "Scheduled plan change canceled",
+				description: "Your current plan will stay in place.",
+			};
+		case "pending":
+			return {
+				kind: "info",
+				title: "Cancellation is still processing",
+				description:
+					"The scheduled plan change is still being removed. Subscription details will refresh automatically.",
+			};
+		case "reconciling":
+			return {
+				kind: "info",
+				title: "Billing details are reconciling",
+				description:
+					"The cancellation was accepted, but subscription details are still reconciling. Refresh in a moment.",
+			};
+		default:
+			return {
+				kind: "info",
+				title: "Cancellation status is still updating",
+				description: "Refresh the subscription details before trying again.",
+			};
+	}
+}
+
+export function ComputeSubscriptionActionList({
+	actions,
+	target,
+	onManage,
+	onStartNew,
+	cancelCopy,
+	checkChangeHref,
+	primaryVariant,
+	startNewIcon,
+}: {
+	actions: readonly ComputeSubscriptionAction[];
+	target: ComputeSubscriptionActionTarget;
+	onManage?: () => void;
+	onStartNew: ComputeSubscriptionStartNewAction | null;
+	cancelCopy?: ComputeSubscriptionCancelCopy;
+	checkChangeHref?: string;
+	primaryVariant?: "default" | "destructive";
+	startNewIcon?: "plus" | "settings";
+}) {
+	const cancelSubscription = useCancelSubscription();
+	const resumeSubscription = useResumeSubscription();
+	const cancelScheduledPlanChange = useCancelScheduledPlanChange();
+	const runAction = useActionLock();
+	const pending =
+		cancelSubscription.isPending ||
+		resumeSubscription.isPending ||
+		cancelScheduledPlanChange.isPending;
+	const actionTarget = computeSubscriptionActionRequest(target);
+	const paymentRecoveryDeploymentId = target.deploymentId;
+
+	async function cancel() {
+		try {
+			const result = await cancelSubscription.mutateAsync(actionTarget);
+			toast.success(
+				result.cancel_at_period_end ? "Cancellation scheduled" : "Subscription canceled",
+				{ description: cancelCopy?.successDescription?.(result) },
+			);
+		} catch (error) {
+			toast.error("Couldn't cancel subscription", { description: normalizeBillingError(error) });
+			throw error;
+		}
+	}
+
+	async function resume() {
+		try {
+			await resumeSubscription.mutateAsync(actionTarget);
+			toast.success("Subscription resumed");
+		} catch (error) {
+			toast.error("Couldn't resume subscription", { description: normalizeBillingError(error) });
+			throw error;
+		}
+	}
+
+	async function cancelScheduledChange() {
+		try {
+			const result = await cancelScheduledPlanChange.mutateAsync(actionTarget);
+			const notice = scheduledPlanCancellationNotice(result);
+			toast[notice.kind](notice.title, { description: notice.description });
+		} catch (error) {
+			toast.error("Couldn't cancel scheduled plan change", {
+				description: normalizeBillingError(error),
+			});
+			throw error;
+		}
+	}
+
+	return actions.map((candidate) => {
+		switch (candidate.kind) {
+			case "manage":
+				return (
+					<ComputeSubscriptionManageAction
+						key={candidate.kind}
+						onClick={() => onManage?.()}
+						disabled={!onManage || candidate.disabledReason !== null}
+					/>
+				);
+			case "check_change":
+				if (checkChangeHref) {
+					return (
+						<Button
+							data-hosted="true"
+							key={candidate.kind}
+							render={<a href={checkChangeHref} />}
+							nativeButton={false}
+							size="sm"
+							variant={primaryVariant ?? "outline"}
+							disabled={candidate.disabledReason !== null}
+						>
+							<RefreshCw data-icon="inline-start" />
+							Check subscription change status
+						</Button>
+					);
+				}
+				return (
+					<Button
+						data-hosted="true"
+						key={candidate.kind}
+						type="button"
+						variant="outline"
+						size="sm"
+						disabled={!onManage || candidate.disabledReason !== null}
+						onClick={onManage}
+					>
+						<RefreshCw data-icon="inline-start" />
+						Check subscription change status
+					</Button>
+				);
+			case "fix_payment":
+			case "top_up":
+			case "start_new":
+				return (
+					<ComputeSubscriptionRecoveryAction
+						key={candidate.kind}
+						target={candidate.recoveryTarget}
+						deploymentId={paymentRecoveryDeploymentId}
+						startNewAction={onStartNew}
+						disabled={candidate.disabledReason !== null}
+						variant={primaryVariant}
+						startNewIcon={startNewIcon}
+					/>
+				);
+			case "resume":
+				return (
+					<Button
+						data-hosted="true"
+						key={candidate.kind}
+						type="button"
+						variant="outline"
+						size="sm"
+						disabled={pending || candidate.disabledReason !== null}
+						onClick={() => void runAction(resume).catch(() => undefined)}
+					>
+						{resumeSubscription.isPending ? <Spinner /> : <RefreshCw />}
+						Resume subscription
+					</Button>
+				);
+			case "cancel":
+				if (!cancelCopy) return null;
+				return (
+					<ConfirmAction
+						key={candidate.kind}
+						title={cancelCopy.title}
+						description={cancelCopy.description}
+						confirmLabel={cancelCopy.confirmLabel}
+						destructive
+						onConfirm={() => runAction(cancel)}
+					>
+						<Button
+							data-hosted="true"
+							type="button"
+							variant="outline"
+							size="sm"
+							disabled={pending || candidate.disabledReason !== null}
+						>
+							{cancelSubscription.isPending ? <Spinner /> : <Link2Off />}
+							Cancel subscription
+						</Button>
+					</ConfirmAction>
+				);
+			case "cancel_scheduled_change":
+				return (
+					<Button
+						data-hosted="true"
+						key={candidate.kind}
+						type="button"
+						variant="outline"
+						size="sm"
+						disabled={pending || candidate.disabledReason !== null}
+						onClick={() => void runAction(cancelScheduledChange).catch(() => undefined)}
+					>
+						{cancelScheduledPlanChange.isPending ? <Spinner /> : <CalendarX2 />}
+						Cancel scheduled change
+					</Button>
+				);
+		}
+		return null;
+	});
+}

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-actions.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-actions.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "bun:test";
+import {
+	computeSubscriptionActionRequest,
+	scheduledPlanCancellationNotice,
+} from "./compute-subscription-action-list";
+import {
+	type ComputeSubscriptionActionEntitlement,
+	resolveComputeSubscriptionActions,
+} from "./compute-subscription-actions";
+import type { ComputeSubscriptionManagementResult } from "./compute-subscription-management";
+
+const enabledManagement: ComputeSubscriptionManagementResult = {
+	action: "enabled",
+	target: {
+		deploymentId: "hdep_agent",
+		currentPlanSlug: "compute_performance",
+		initialPlanSlug: "compute_performance",
+		currentBillingTermMonths: 1,
+		currentFundingSource: "stripe",
+		status: "active",
+		paymentSourceOnly: false,
+		cancelAtPeriodEnd: false,
+		isPaidCompute: true,
+		allowCombinedChange: false,
+		projectedOperationName: null,
+	},
+	unavailableReason: null,
+};
+
+const hiddenManagement: ComputeSubscriptionManagementResult = {
+	action: "hidden",
+	target: null,
+	unavailableReason: null,
+};
+
+function entitlement(
+	overrides: Partial<ComputeSubscriptionActionEntitlement> = {},
+): ComputeSubscriptionActionEntitlement {
+	return {
+		deploymentId: "hdep_agent",
+		planSlug: "compute_performance",
+		fundingSource: "stripe",
+		priceCents: 1_900,
+		status: "active",
+		paymentState: "ok",
+		cancelAtPeriodEnd: false,
+		pendingPlanSlug: null,
+		isOrphan: false,
+		...overrides,
+	};
+}
+
+function kinds(
+	overrides: Partial<ComputeSubscriptionActionEntitlement> = {},
+	options: {
+		management?: ComputeSubscriptionManagementResult;
+		recoveryTarget?: Parameters<typeof resolveComputeSubscriptionActions>[0]["recoveryTarget"];
+		hasPendingOperation?: boolean;
+	} = {},
+) {
+	return resolveComputeSubscriptionActions({
+		entitlement: entitlement(overrides),
+		management: options.management ?? enabledManagement,
+		recoveryTarget: options.recoveryTarget ?? null,
+		hasPendingOperation: options.hasPendingOperation,
+	}).map((candidate) => candidate.kind);
+}
+
+describe("resolveComputeSubscriptionActions", () => {
+	test("covers healthy paid, trial, Included Basic, and orphan entitlements", () => {
+		expect(kinds()).toEqual(["manage", "cancel"]);
+		expect(kinds({ status: "trialing" })).toEqual(["cancel"]);
+		expect(
+			kinds(
+				{ planSlug: "compute_basic", fundingSource: null, priceCents: 0 },
+				{ management: enabledManagement },
+			),
+		).toEqual(["manage"]);
+		expect(kinds({ deploymentId: null, isOrphan: true })).toEqual(["cancel"]);
+	});
+
+	test("keeps paid recovery, payment-source management, and legal cancellation", () => {
+		expect(
+			kinds(
+				{ status: "past_due", paymentState: "requires_action" },
+				{ recoveryTarget: { kind: "fix_payment", action: "fix_payment" } },
+			),
+		).toEqual(["fix_payment", "manage", "cancel"]);
+		expect(
+			kinds(
+				{ status: "past_due", paymentState: "past_due", fundingSource: "wallet" },
+				{ recoveryTarget: { kind: "top_up", action: "top_up" } },
+			),
+		).toEqual(["top_up", "manage", "cancel"]);
+		expect(kinds({ status: "past_due", paymentState: "ok" })).toEqual(["manage", "cancel"]);
+		const orphanCardRecovery = resolveComputeSubscriptionActions({
+			entitlement: entitlement({
+				deploymentId: null,
+				isOrphan: true,
+				status: "past_due",
+				paymentState: "requires_action",
+			}),
+			management: hiddenManagement,
+			recoveryTarget: { kind: "fix_payment", action: "fix_payment" },
+		});
+		expect(orphanCardRecovery.map(({ kind }) => kind)).toEqual(["fix_payment", "cancel"]);
+		expect(orphanCardRecovery[0]?.disabledReason).toBeNull();
+	});
+
+	test("gives pending, canceling, and terminal states exclusive recovery priority", () => {
+		expect(kinds({}, { hasPendingOperation: true })).toEqual(["check_change"]);
+		expect(kinds({ cancelAtPeriodEnd: true })).toEqual(["resume"]);
+		const unpaid = resolveComputeSubscriptionActions({
+			entitlement: entitlement({ status: "unpaid", paymentState: "unpaid" }),
+			management: enabledManagement,
+			recoveryTarget: null,
+		});
+		expect(unpaid.map(({ kind }) => kind)).toEqual(["start_new"]);
+		expect(unpaid[0]).toMatchObject({
+			kind: "start_new",
+			recoveryTarget: { kind: "start_new" },
+		});
+		const terminalRecovery = resolveComputeSubscriptionActions({
+			entitlement: entitlement({ status: "canceled", paymentState: "ok" }),
+			management: enabledManagement,
+			recoveryTarget: { kind: "start_new", action: "start_new" },
+		});
+		expect(terminalRecovery.map(({ kind }) => kind)).toEqual(["start_new"]);
+		expect(terminalRecovery[0]).toMatchObject({
+			kind: "start_new",
+			recoveryTarget: { kind: "start_new" },
+		});
+		expect(kinds({ status: "canceled", paymentState: "unpaid" })).toEqual(["start_new"]);
+		for (const status of ["canceled", "expired", "incomplete", "paused"]) {
+			expect(kinds({ status }, { management: hiddenManagement }), status).toEqual([]);
+		}
+	});
+
+	test("keeps scheduled-downgrade cancellation ahead of subscription cancellation", () => {
+		expect(kinds({ pendingPlanSlug: "compute_basic" })).toEqual([
+			"cancel_scheduled_change",
+			"cancel",
+		]);
+		expect(
+			kinds(
+				{
+					status: "past_due",
+					paymentState: "requires_action",
+					pendingPlanSlug: "compute_basic",
+				},
+				{ recoveryTarget: { kind: "fix_payment", action: "fix_payment" } },
+			),
+		).toEqual(["fix_payment", "cancel_scheduled_change", "cancel"]);
+		expect(
+			kinds({ cancelAtPeriodEnd: true, status: "canceling", pendingPlanSlug: "compute_basic" }),
+		).toEqual(["cancel_scheduled_change"]);
+	});
+
+	test("keeps payment recovery ahead of resuming a canceling subscription", () => {
+		expect(
+			kinds(
+				{ status: "past_due", paymentState: "requires_action", cancelAtPeriodEnd: true },
+				{ recoveryTarget: { kind: "fix_payment", action: "fix_payment" } },
+			),
+		).toEqual(["fix_payment", "resume"]);
+		expect(kinds({ deploymentId: null, isOrphan: true, status: "canceling" })).toEqual([]);
+	});
+});
+
+describe("scheduled plan cancellation execution", () => {
+	test("uses the exact public target and never reports pending work as success", () => {
+		expect(
+			computeSubscriptionActionRequest({ kind: "deployment", deploymentId: "hdep_agent" }),
+		).toEqual({ deployment_id: "hdep_agent" });
+		expect(
+			computeSubscriptionActionRequest({
+				kind: "subscription",
+				subscriptionId: "csub_account",
+				deploymentId: null,
+			}),
+		).toEqual({ subscription_id: "csub_account" });
+
+		const result = {
+			status: "active",
+			billing_term_months: 1,
+			cancel_at_period_end: false,
+		};
+		expect(scheduledPlanCancellationNotice({ ...result, action_state: "removed" })).toMatchObject({
+			kind: "success",
+			title: "Scheduled plan change canceled",
+		});
+		for (const actionState of ["pending", "reconciling"] as const) {
+			expect(
+				scheduledPlanCancellationNotice({ ...result, action_state: actionState }),
+			).toMatchObject({ kind: "info" });
+		}
+	});
+});

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-actions.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-actions.ts
@@ -1,0 +1,149 @@
+import type { ComputeSubscriptionManagementResult } from "./compute-subscription-management";
+import type { ComputeRecoveryTarget } from "./compute-subscription-recovery";
+import { computeFundingSource } from "./subscription-utils";
+
+export type ComputeSubscriptionActionKind =
+	| "manage"
+	| "cancel"
+	| "resume"
+	| "fix_payment"
+	| "top_up"
+	| "start_new"
+	| "check_change"
+	| "cancel_scheduled_change";
+
+type ComputeSubscriptionRecoveryAction = {
+	kind: Extract<ComputeSubscriptionActionKind, "fix_payment" | "top_up" | "start_new">;
+	disabledReason: string | null;
+	recoveryTarget: ComputeRecoveryTarget;
+};
+
+type ComputeSubscriptionDirectAction = {
+	kind: Exclude<ComputeSubscriptionActionKind, ComputeSubscriptionRecoveryAction["kind"]>;
+	disabledReason: string | null;
+};
+
+export type ComputeSubscriptionAction =
+	| ComputeSubscriptionDirectAction
+	| ComputeSubscriptionRecoveryAction;
+
+export type ComputeSubscriptionActionEntitlement = {
+	deploymentId: string | null | undefined;
+	planSlug: string | null | undefined;
+	fundingSource: "stripe" | "wallet" | null | undefined;
+	priceCents: number | null | undefined;
+	status: string;
+	paymentState: string;
+	cancelAtPeriodEnd: boolean;
+	pendingPlanSlug: string | null | undefined;
+	isOrphan?: boolean;
+};
+
+const TERMINAL_STATUSES = new Set([
+	"canceled",
+	"expired",
+	"incomplete",
+	"incomplete_expired",
+	"paused",
+]);
+const CANCELABLE_STATUSES = new Set(["trialing", "active", "past_due"]);
+
+function action(
+	kind: ComputeSubscriptionDirectAction["kind"],
+	disabledReason: string | null = null,
+): ComputeSubscriptionDirectAction {
+	return { kind, disabledReason };
+}
+
+function manageAction(
+	management: ComputeSubscriptionManagementResult,
+): ComputeSubscriptionAction | null {
+	if (management.action === "hidden") return null;
+	return action("manage", management.action === "disabled" ? management.unavailableReason : null);
+}
+
+function recoveryAction(target: ComputeRecoveryTarget): ComputeSubscriptionRecoveryAction {
+	return {
+		kind: target.action,
+		disabledReason: null,
+		recoveryTarget: target,
+	};
+}
+
+/**
+ * Resolves the ordered, mutually compatible actions for one compute entitlement.
+ * Callers own only context-specific execution such as navigation or opening dialogs.
+ */
+export function resolveComputeSubscriptionActions({
+	entitlement,
+	management,
+	recoveryTarget,
+	hasPendingOperation = false,
+	startNewUnavailableReason = null,
+}: {
+	entitlement: ComputeSubscriptionActionEntitlement;
+	management: ComputeSubscriptionManagementResult;
+	recoveryTarget: ComputeRecoveryTarget | null;
+	hasPendingOperation?: boolean;
+	startNewUnavailableReason?: string | null;
+}): readonly ComputeSubscriptionAction[] {
+	const status = entitlement.status.toLowerCase();
+	const deploymentBound = Boolean(entitlement.deploymentId?.trim()) && !entitlement.isOrphan;
+	const fundingSource = computeFundingSource(entitlement.planSlug, {
+		funding_source: entitlement.fundingSource,
+		price_cents: entitlement.priceCents,
+	});
+	const paid = fundingSource === "stripe" || fundingSource === "wallet";
+	const canCancel = paid && !entitlement.cancelAtPeriodEnd && CANCELABLE_STATUSES.has(status);
+	const cancel = canCancel ? action("cancel") : null;
+
+	if (hasPendingOperation) return [action("check_change")];
+
+	if (
+		recoveryTarget?.kind === "start_new" ||
+		entitlement.paymentState === "unpaid" ||
+		status === "unpaid"
+	) {
+		if (!deploymentBound) return [];
+		const startNewTarget: ComputeRecoveryTarget = { kind: "start_new", action: "start_new" };
+		return [
+			{
+				...recoveryAction(recoveryTarget?.kind === "start_new" ? recoveryTarget : startNewTarget),
+				disabledReason: startNewUnavailableReason,
+			},
+		];
+	}
+	if (TERMINAL_STATUSES.has(status)) return [];
+
+	const recovery = recoveryTarget ? recoveryAction(recoveryTarget) : null;
+
+	if (entitlement.pendingPlanSlug != null) {
+		return [
+			...(recovery ? [recovery] : []),
+			action("cancel_scheduled_change"),
+			...(cancel ? [cancel] : []),
+		];
+	}
+
+	if (paid && (entitlement.cancelAtPeriodEnd || status === "canceling")) {
+		return [...(recovery ? [recovery] : []), ...(deploymentBound ? [action("resume")] : [])];
+	}
+
+	if (!paid) {
+		const manage = !entitlement.isOrphan ? manageAction(management) : null;
+		return recovery ? [recovery] : manage ? [manage] : [];
+	}
+
+	const manage = !entitlement.isOrphan ? manageAction(management) : null;
+	if (recovery) {
+		return [recovery, ...(manage ? [manage] : []), ...(cancel ? [cancel] : [])];
+	}
+
+	if (status === "trialing") return cancel ? [cancel] : [];
+
+	if (status === "active" || status === "past_due") {
+		return [...(manage ? [manage] : []), ...(cancel ? [cancel] : [])];
+	}
+
+	return [];
+}

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-management.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-management.test.ts
@@ -142,21 +142,27 @@ describe("computeSubscriptionManagement", () => {
 		).toMatchObject({ action: "enabled" });
 	});
 
-	test("keeps healthy past-due subscriptions available for payment-source-only management", () => {
-		expect(
-			computeSubscriptionManagement({
-				entitlement: entitlement({
-					fundingSource: "stripe",
-					priceCents: 900,
-					status: "past_due",
-					paymentState: "ok",
+	test("keeps paid payment recovery payment-source-only across lifecycle projections", () => {
+		for (const [fundingSource, status, paymentState, recoveryAction] of [
+			["stripe", "active", "requires_action", "fix_payment"],
+			["wallet", "active", "past_due", "top_up"],
+		] as const) {
+			expect(
+				computeSubscriptionManagement({
+					entitlement: entitlement({
+						fundingSource,
+						priceCents: 900,
+						status,
+						paymentState,
+						recoveryAction,
+					}),
+					...available,
 				}),
-				...available,
-			}),
-		).toMatchObject({
-			action: "enabled",
-			target: { status: "past_due", paymentSourceOnly: true },
-		});
+			).toMatchObject({
+				action: "enabled",
+				target: { status: "past_due", paymentSourceOnly: true },
+			});
+		}
 	});
 
 	test("keeps Included Basic management disabled until the gated deployment projection is available", () => {

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-management.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-management.ts
@@ -1,4 +1,8 @@
-import type { ComputePlanSlug, HostedDeployment } from "@/hosted/billing/contracts";
+import type {
+	ComputePlanSlug,
+	HostedComputeSubscription,
+	HostedDeployment,
+} from "@/hosted/billing/contracts";
 import { deploymentStatusFromResource, isRunningStatus } from "@/hosted/deployment-status";
 import {
 	activePlanChangeOperationName,
@@ -22,9 +26,9 @@ export type ComputeSubscriptionEntitlement = {
 	priceCents: number | null | undefined;
 	billingTermMonths: number;
 	status: string;
-	paymentState: string;
+	paymentState: HostedComputeSubscription["payment_state"];
 	cancelAtPeriodEnd: boolean;
-	recoveryAction: string | null | undefined;
+	recoveryAction: HostedComputeSubscription["recovery_action"];
 	pendingPlanSlug: string | null | undefined;
 	isOrphan?: boolean;
 };
@@ -44,12 +48,27 @@ function isComputePlanSlug(value: string | null | undefined): value is ComputePl
 	return value === COMPUTE_BASIC_SLUG || value === COMPUTE_PERFORMANCE_SLUG;
 }
 
-function blocksManagement(entitlement: ComputeSubscriptionEntitlement): boolean {
+function isPaymentSourceOnlyManagement(
+	entitlement: ComputeSubscriptionEntitlement,
+	paid: boolean,
+): boolean {
+	return (
+		paid &&
+		(entitlement.status === "past_due" ||
+			entitlement.paymentState === "past_due" ||
+			entitlement.paymentState === "requires_action") &&
+		entitlement.paymentState !== "unpaid" &&
+		entitlement.recoveryAction !== "start_new"
+	);
+}
+
+function blocksManagement(entitlement: ComputeSubscriptionEntitlement, paid: boolean): boolean {
+	const paymentSourceOnly = isPaymentSourceOnlyManagement(entitlement, paid);
 	return (
 		entitlement.cancelAtPeriodEnd ||
 		(entitlement.status !== "active" && entitlement.status !== "past_due") ||
-		entitlement.paymentState !== "ok" ||
-		entitlement.recoveryAction != null ||
+		(!paymentSourceOnly &&
+			(entitlement.paymentState !== "ok" || entitlement.recoveryAction != null)) ||
 		entitlement.pendingPlanSlug != null
 	);
 }
@@ -115,7 +134,7 @@ export function computeSubscriptionManagement({
 		return { action: "hidden", target: null, unavailableReason: null };
 	}
 	const projectedOperationName = deployment ? activePlanChangeOperationName(deployment) : null;
-	if (projectedOperationName === null && blocksManagement(initialEntitlement)) {
+	if (projectedOperationName === null && blocksManagement(initialEntitlement, paid)) {
 		return { action: "hidden", target: null, unavailableReason: null };
 	}
 
@@ -134,10 +153,11 @@ export function computeSubscriptionManagement({
 		entitlement = projectedEntitlement;
 	}
 
-	if (projectedOperationName === null && blocksManagement(entitlement)) {
+	if (projectedOperationName === null && blocksManagement(entitlement, paid)) {
 		return { action: "hidden", target: null, unavailableReason: null };
 	}
 
+	const paymentSourceOnly = isPaymentSourceOnlyManagement(entitlement, paid);
 	const target: PlanChangeTarget = {
 		deploymentId,
 		currentPlanSlug: planSlug,
@@ -147,10 +167,10 @@ export function computeSubscriptionManagement({
 		status:
 			entitlement.status === "unpaid" || entitlement.paymentState === "unpaid"
 				? "unpaid"
-				: entitlement.status === "past_due" || entitlement.paymentState === "past_due"
+				: paymentSourceOnly
 					? "past_due"
 					: entitlement.status,
-		paymentSourceOnly: entitlement.status === "past_due" || entitlement.paymentState === "past_due",
+		paymentSourceOnly,
 		cancelAtPeriodEnd: entitlement.cancelAtPeriodEnd,
 		isPaidCompute: !includedBasic,
 		allowCombinedChange: includedBasic,

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-recovery-action.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-recovery-action.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { CreditCard, ExternalLink, Plus, Settings, WalletCards } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { normalizeBillingError } from "@/hosted/billing/errors";
+import { useSensitiveFixPayment } from "@/hosted/billing/sensitive-actions";
+import type { ComputeRecoveryTarget } from "@/hosted/billing/subscription/compute-subscription-recovery";
+import { useActionLock } from "@/hosted/billing/use-action-lock";
+import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
+import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
+
+export type ComputeSubscriptionStartNewAction =
+	| { kind: "link"; href: string; label: string }
+	| { kind: "button"; onClick: () => void; label: string };
+
+export function ComputeSubscriptionRecoveryAction({
+	target,
+	deploymentId,
+	startNewAction,
+	disabled = false,
+	variant = "default",
+	startNewIcon = "settings",
+}: {
+	target: ComputeRecoveryTarget;
+	deploymentId: string | null;
+	startNewAction: ComputeSubscriptionStartNewAction | null;
+	disabled?: boolean;
+	variant?: "default" | "destructive";
+	startNewIcon?: "plus" | "settings";
+}) {
+	const fixPayment = useSensitiveFixPayment();
+	const runAction = useActionLock();
+	const wallet = useWalletSnapshot({ enabled: target.kind === "top_up" });
+	const [topUpOpen, setTopUpOpen] = useState(false);
+
+	async function openPaymentRecovery() {
+		if (target.kind === "invoice") {
+			window.location.href = target.url;
+			return;
+		}
+		if (target.kind !== "fix_payment") return;
+		try {
+			const result = await fixPayment.execute(deploymentId ? { deployment_id: deploymentId } : {});
+			const url = result.url || result.portal_url;
+			if (url) {
+				window.location.href = url;
+				return;
+			}
+			toast.message("Payment update unavailable", {
+				description: "Refresh this page and try again in a moment.",
+			});
+		} catch (error) {
+			toast.error("Couldn't open payment settings", {
+				description: normalizeBillingError(error),
+			});
+		}
+	}
+
+	if (target.kind === "top_up") {
+		return (
+			<>
+				<Button
+					data-hosted="true"
+					type="button"
+					size="sm"
+					variant={variant}
+					onClick={() => setTopUpOpen(true)}
+					disabled={disabled || !wallet.data}
+				>
+					<WalletCards data-icon="inline-start" />
+					Top up
+				</Button>
+				{wallet.data ? <TopUpDialog open={topUpOpen} onOpenChange={setTopUpOpen} /> : null}
+			</>
+		);
+	}
+	if (target.kind === "start_new") {
+		if (!startNewAction) return null;
+		const icon =
+			startNewIcon === "plus" ? (
+				<Plus data-icon="inline-start" />
+			) : (
+				<Settings data-icon="inline-start" />
+			);
+		return startNewAction.kind === "link" ? (
+			<Button
+				data-hosted="true"
+				render={<a href={startNewAction.href} />}
+				nativeButton={false}
+				type="button"
+				size="sm"
+				variant={variant}
+				disabled={disabled}
+			>
+				{icon}
+				{startNewAction.label}
+			</Button>
+		) : (
+			<Button
+				data-hosted="true"
+				type="button"
+				size="sm"
+				variant={variant}
+				onClick={startNewAction.onClick}
+				disabled={disabled}
+			>
+				{icon}
+				{startNewAction.label}
+			</Button>
+		);
+	}
+	return (
+		<Button
+			data-hosted="true"
+			type="button"
+			size="sm"
+			variant={variant}
+			onClick={() => void runAction(openPaymentRecovery)}
+			disabled={disabled || fixPayment.isPending}
+		>
+			{fixPayment.isPending ? (
+				<Spinner data-icon="inline-start" />
+			) : target.kind === "invoice" ? (
+				<ExternalLink data-icon="inline-start" />
+			) : (
+				<CreditCard data-icon="inline-start" />
+			)}
+			Fix payment
+		</Button>
+	);
+}

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.ts
@@ -4,21 +4,23 @@ import type {
 	HostedComputeSubscription,
 } from "@/hosted/billing/contracts";
 
-type RecoveryFields =
-	| Pick<
+export type ComputeSubscriptionRecoveryFields =
+	| (Pick<
 			ComputeSubscriptionListItem,
 			| "latest_failed_invoice_hosted_url"
 			| "next_payment_attempt_at"
 			| "payment_state"
 			| "recovery_action"
-	  >
-	| Pick<
+	  > &
+			Partial<Pick<ComputeSubscriptionListItem, "funding_source">>)
+	| (Pick<
 			HostedComputeSubscription,
 			| "latest_failed_invoice_hosted_url"
 			| "next_payment_attempt_at"
 			| "payment_state"
 			| "recovery_action"
-	  >;
+	  > &
+			Partial<Pick<HostedComputeSubscription, "funding_source">>);
 
 export type ComputeRecoveryTarget =
 	| { kind: "invoice"; action: "fix_payment"; url: string }
@@ -36,7 +38,9 @@ export type ComputeSubscriptionRecoveryPresentation = {
 		| null;
 };
 
-function recoveryTarget(subscription: RecoveryFields): ComputeRecoveryTarget | null {
+export function computeSubscriptionRecoveryTarget(
+	subscription: ComputeSubscriptionRecoveryFields,
+): ComputeRecoveryTarget | null {
 	const action = subscription.recovery_action;
 	if (action === "top_up") return { kind: "top_up", action };
 	if (action === "start_new") return { kind: "start_new", action };
@@ -46,11 +50,25 @@ function recoveryTarget(subscription: RecoveryFields): ComputeRecoveryTarget | n
 			? { kind: "invoice", action, url: invoiceUrl }
 			: { kind: "fix_payment", action };
 	}
+	if (subscription.payment_state === "unpaid") {
+		return { kind: "start_new", action: "start_new" };
+	}
+	if (subscription.payment_state === "requires_action") {
+		const invoiceUrl = subscription.latest_failed_invoice_hosted_url?.trim();
+		return invoiceUrl
+			? { kind: "invoice", action: "fix_payment", url: invoiceUrl }
+			: { kind: "fix_payment", action: "fix_payment" };
+	}
+	if (subscription.payment_state === "past_due") {
+		return subscription.funding_source === "wallet"
+			? { kind: "top_up", action: "top_up" }
+			: { kind: "fix_payment", action: "fix_payment" };
+	}
 	return null;
 }
 
 export function computeSubscriptionRecoveryPresentation(
-	subscription: RecoveryFields | null | undefined,
+	subscription: ComputeSubscriptionRecoveryFields | null | undefined,
 	lifecycleStatus: ComputeSubscriptionRecoveryPresentation["status"],
 ): ComputeSubscriptionRecoveryPresentation {
 	if (!subscription) {
@@ -76,7 +94,7 @@ export function computeSubscriptionRecoveryPresentation(
 				return null;
 		}
 	})();
-	const target = recoveryTarget(subscription);
+	const target = computeSubscriptionRecoveryTarget(subscription);
 
 	return {
 		status: paymentStatus ?? lifecycleStatus,

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -3,8 +3,6 @@ import type { BillingOffer, HostedComputeSubscription, Plan } from "@/hosted/bil
 import {
 	COMPUTE_BASIC_SLUG,
 	COMPUTE_PERFORMANCE_SLUG,
-	canCancelAccountSubscription,
-	canResumeAccountSubscription,
 	commonExplicitBillingOffers,
 	computeFundingMode,
 	computeFundingSource,
@@ -12,9 +10,7 @@ import {
 	computeSubscriptionLifecycle,
 	computeTierLabel,
 	isBasicCompute,
-	isComputeSubscriptionCancelable,
 	isComputeSubscriptionRenewing,
-	isComputeSubscriptionTermChangeable,
 	isHistoricalAccountSubscription,
 	isIncludedBasicSubscription,
 	pendingComputePlanSlug,
@@ -302,7 +298,7 @@ describe("commonExplicitBillingOffers", () => {
 	});
 });
 
-describe("compute subscription action status gates", () => {
+describe("account subscription history", () => {
 	test("treats terminal canceled status as history regardless of service period", () => {
 		const ended = {
 			status: "canceled" as const,
@@ -312,73 +308,6 @@ describe("compute subscription action status gates", () => {
 
 		expect(isHistoricalAccountSubscription(ended)).toBe(true);
 		expect(isHistoricalAccountSubscription({ ...ended, status: "canceling" })).toBe(false);
-	});
-
-	test("matches the backend cancel and resume status set", () => {
-		expect(isComputeSubscriptionCancelable({ status: "trialing" })).toBe(true);
-		expect(isComputeSubscriptionCancelable({ status: "active" })).toBe(true);
-		expect(isComputeSubscriptionCancelable({ status: "past_due" })).toBe(true);
-
-		expect(isComputeSubscriptionCancelable({ status: "incomplete" })).toBe(false);
-		expect(isComputeSubscriptionCancelable({ status: "unpaid" })).toBe(false);
-		expect(isComputeSubscriptionCancelable({ status: "canceled" })).toBe(false);
-		expect(isComputeSubscriptionCancelable(null)).toBe(false);
-	});
-
-	test("keeps term changes stricter than cancel or resume", () => {
-		expect(isComputeSubscriptionTermChangeable({ status: "active" })).toBe(true);
-
-		expect(isComputeSubscriptionTermChangeable({ status: "trialing" })).toBe(false);
-		expect(isComputeSubscriptionTermChangeable({ status: "past_due" })).toBe(false);
-		expect(isComputeSubscriptionTermChangeable({ status: "unpaid" })).toBe(false);
-		expect(isComputeSubscriptionTermChangeable(undefined)).toBe(false);
-	});
-
-	test("offers account resume only for a canceling subscription bound to a live agent", () => {
-		const liveCanceling = {
-			status: "canceling" as const,
-			cancel_at_period_end: true,
-			deployment_id: "hdep_live",
-			is_orphan: false,
-		};
-
-		expect(canResumeAccountSubscription(liveCanceling)).toBe(true);
-		expect(canResumeAccountSubscription({ ...liveCanceling, deployment_id: null })).toBe(false);
-		expect(canResumeAccountSubscription({ ...liveCanceling, is_orphan: true })).toBe(false);
-		expect(
-			canResumeAccountSubscription({
-				...liveCanceling,
-				status: "active",
-				cancel_at_period_end: false,
-			}),
-		).toBe(false);
-	});
-
-	test("keeps cancellation available for active orphan subscriptions without repeating it", () => {
-		const orphan = {
-			status: "active" as const,
-			cancel_at_period_end: false,
-			deployment_id: null,
-			funding_source: "stripe" as const,
-			is_orphan: true,
-		};
-
-		expect(canCancelAccountSubscription(orphan)).toBe(true);
-		expect(canCancelAccountSubscription({ ...orphan, cancel_at_period_end: true })).toBe(false);
-		expect(canCancelAccountSubscription({ ...orphan, status: "canceling" })).toBe(false);
-		expect(canCancelAccountSubscription({ ...orphan, status: "canceled" })).toBe(false);
-	});
-
-	test("never offers cancellation for an included free subscription", () => {
-		expect(
-			canCancelAccountSubscription({
-				status: "active",
-				cancel_at_period_end: false,
-				deployment_id: "hdep_included",
-				funding_source: null,
-				is_orphan: false,
-			}),
-		).toBe(false);
 	});
 });
 

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -9,60 +9,11 @@ import {
 } from "@/hosted/billing/contracts";
 
 export { COMPUTE_BASIC_SLUG, COMPUTE_PERFORMANCE_SLUG };
-export const COMPUTE_SUBSCRIPTION_CANCELABLE_STATUSES = new Set(["trialing", "active", "past_due"]);
-export const COMPUTE_SUBSCRIPTION_TERM_CHANGEABLE_STATUSES = new Set(["active"]);
 
 export type ResolvedBillingOffer = {
 	offer: BillingOffer;
 	billingTermMonths: number;
 };
-
-type ComputeSubscriptionStatusInput =
-	| {
-			status?: string | null;
-	  }
-	| null
-	| undefined;
-
-export function isComputeSubscriptionCancelable(
-	subscription: ComputeSubscriptionStatusInput,
-): boolean {
-	return COMPUTE_SUBSCRIPTION_CANCELABLE_STATUSES.has(subscription?.status ?? "");
-}
-
-export function isComputeSubscriptionTermChangeable(
-	subscription: ComputeSubscriptionStatusInput,
-): boolean {
-	return COMPUTE_SUBSCRIPTION_TERM_CHANGEABLE_STATUSES.has(subscription?.status ?? "");
-}
-
-type AccountSubscriptionActionState = Pick<
-	ComputeSubscriptionListItem,
-	"cancel_at_period_end" | "deployment_id" | "is_orphan" | "status"
->;
-
-type AccountSubscriptionCancelState = AccountSubscriptionActionState &
-	Pick<ComputeSubscriptionListItem, "funding_source">;
-
-export function canCancelAccountSubscription(
-	subscription: AccountSubscriptionCancelState,
-): boolean {
-	return (
-		(subscription.funding_source === "stripe" || subscription.funding_source === "wallet") &&
-		!subscription.cancel_at_period_end &&
-		isComputeSubscriptionCancelable(subscription)
-	);
-}
-
-export function canResumeAccountSubscription(
-	subscription: AccountSubscriptionActionState,
-): boolean {
-	return (
-		!subscription.is_orphan &&
-		Boolean(subscription.deployment_id) &&
-		(subscription.cancel_at_period_end || subscription.status === "canceling")
-	);
-}
 
 export function isHistoricalAccountSubscription(
 	subscription: Pick<ComputeSubscriptionListItem, "status">,
@@ -136,7 +87,7 @@ export function computeSubscriptionId(
 }
 
 export function pendingComputePlanSlug(
-	subscription: HostedComputeSubscription | null | undefined,
+	subscription: Pick<HostedComputeSubscription, "pending_plan_slug"> | null | undefined,
 ): ComputePlanSlug | null {
 	if (!subscription) return null;
 	return subscription.pending_plan_slug === COMPUTE_BASIC_SLUG ||

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -1,16 +1,7 @@
 "use client";
 
-import {
-	CreditCard,
-	ExternalLink,
-	History,
-	Link2Off,
-	RefreshCw,
-	Settings,
-	WalletCards,
-} from "lucide-react";
+import { CreditCard, History } from "lucide-react";
 import { useState } from "react";
-import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import type { AgentTile } from "@/components/dashboard/agents-card";
 import { EmptyState } from "@/components/empty-state";
@@ -18,22 +9,14 @@ import { entityCardChassisClass } from "@/components/entity-card";
 import { SettingsSection } from "@/components/settings-section";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Spinner } from "@/components/ui/spinner";
 import type { ComputeSubscriptionListItem, HostedDeployment } from "@/hosted/billing/contracts";
-import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
-import {
-	useCancelSubscription,
-	useHostedDeployments,
-	usePlans,
-	useResumeSubscription,
-	useSubscriptions,
-} from "@/hosted/billing/hooks";
-import { useSensitiveFixPayment } from "@/hosted/billing/sensitive-actions";
+import { billingErrorNormalizer } from "@/hosted/billing/errors";
+import { useHostedDeployments, usePlans, useSubscriptions } from "@/hosted/billing/hooks";
+import { ComputeSubscriptionActionList } from "@/hosted/billing/subscription/compute-subscription-action-list";
+import { resolveComputeSubscriptionActions } from "@/hosted/billing/subscription/compute-subscription-actions";
 import {
 	ComputeSubscriptionCard,
-	ComputeSubscriptionManageAction,
 	computeSubscriptionCardView,
 	computeSubscriptionPlanLabel,
 } from "@/hosted/billing/subscription/compute-subscription-card";
@@ -42,202 +25,35 @@ import {
 	type ComputeSubscriptionManagementResult,
 	computeSubscriptionManagement,
 } from "@/hosted/billing/subscription/compute-subscription-management";
-import {
-	type ComputeRecoveryTarget,
-	computeSubscriptionRecoveryPresentation,
-} from "@/hosted/billing/subscription/compute-subscription-recovery";
+import { computeSubscriptionRecoveryPresentation } from "@/hosted/billing/subscription/compute-subscription-recovery";
 import { PlanChangeController } from "@/hosted/billing/subscription/plan-change-controller";
 import {
-	canCancelAccountSubscription,
-	canResumeAccountSubscription,
 	computeFundingSource,
 	computeSubscriptionLifecycle,
 	isHistoricalAccountSubscription,
+	pendingComputePlanSlug,
 	pendingPlanScheduleCopy,
 	resolvePerformancePlan,
 } from "@/hosted/billing/subscription/subscription-utils";
-import { useActionLock } from "@/hosted/billing/use-action-lock";
-import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
-import { useWalletSnapshot } from "@/hosted/billing/wallet/wallet-query";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { formatShortDate } from "@/lib/format";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { shouldBlockQueryError } from "@/lib/query-state";
 
-function SubscriptionActions({
-	subscription,
-	management,
-	onManage,
-}: {
-	subscription: ComputeSubscriptionListItem;
-	management: ComputeSubscriptionManagementResult;
-	onManage: () => void;
-}) {
-	const cancelSubscription = useCancelSubscription();
-	const resumeSubscription = useResumeSubscription();
-	const runAction = useActionLock();
-	const canCancel = canCancelAccountSubscription(subscription);
-	const canResume = canResumeAccountSubscription(subscription);
-	const pending = cancelSubscription.isPending || resumeSubscription.isPending;
-
-	async function cancel() {
-		try {
-			const result = await cancelSubscription.mutateAsync({
-				subscription_id: subscription.subscription_id,
-			});
-			toast.success(
-				result.cancel_at_period_end ? "Cancellation scheduled" : "Subscription canceled",
-				{
-					description: result.current_period_end
-						? `Access continues through ${formatShortDate(result.current_period_end)}.`
-						: undefined,
-				},
-			);
-		} catch (error) {
-			toast.error("Couldn't cancel subscription", { description: normalizeBillingError(error) });
-			throw error;
-		}
-	}
-
-	async function resume() {
-		try {
-			await resumeSubscription.mutateAsync({ subscription_id: subscription.subscription_id });
-			toast.success("Subscription resumed");
-		} catch (error) {
-			toast.error("Couldn't resume subscription", { description: normalizeBillingError(error) });
-			throw error;
-		}
-	}
-
-	if (management.action === "hidden" && !canCancel && !canResume) {
-		return null;
-	}
-
-	return (
-		<>
-			{management.action !== "hidden" ? (
-				<ComputeSubscriptionManageAction
-					onClick={onManage}
-					disabled={management.action === "disabled"}
-				/>
-			) : null}
-			{canResume ? (
-				<Button
-					type="button"
-					variant="outline"
-					size="sm"
-					disabled={pending}
-					onClick={() => void runAction(resume).catch(() => undefined)}
-				>
-					{resumeSubscription.isPending ? <Spinner /> : <RefreshCw />}
-					Resume subscription
-				</Button>
-			) : null}
-			{canCancel ? (
-				<ConfirmAction
-					title={`Cancel ${computeSubscriptionPlanLabel(subscription.plan_slug)} subscription?`}
-					description={
-						<p>
-							The subscription will stop renewing
-							{subscription.current_period_end
-								? ` and remain active through ${formatShortDate(subscription.current_period_end)}`
-								: ""}
-							. This cannot restore a deleted agent.
-						</p>
-					}
-					confirmLabel="Cancel subscription"
-					destructive
-					onConfirm={() => runAction(cancel)}
-				>
-					<Button type="button" variant="outline" size="sm" disabled={pending}>
-						{cancelSubscription.isPending ? <Spinner /> : <Link2Off />}
-						Cancel subscription
-					</Button>
-				</ConfirmAction>
-			) : null}
-		</>
-	);
-}
-
-function SubscriptionRecoveryAction({
-	target,
-	deploymentId,
-	agentHref,
-}: {
-	target: ComputeRecoveryTarget;
-	deploymentId: string | null;
-	agentHref: string | null;
-}) {
-	const fixPayment = useSensitiveFixPayment();
-	const runAction = useActionLock();
-	const wallet = useWalletSnapshot({ enabled: target.kind === "top_up" });
-	const [topUpOpen, setTopUpOpen] = useState(false);
-
-	async function openPaymentRecovery() {
-		if (target.kind === "invoice") {
-			window.location.href = target.url;
-			return;
-		}
-		if (target.kind !== "fix_payment") return;
-		try {
-			const result = await fixPayment.execute({ deployment_id: deploymentId });
-			const url = result.url || result.portal_url;
-			if (url) {
-				window.location.href = url;
-				return;
-			}
-			toast.message("Payment update unavailable", {
-				description: "Refresh this page and try again in a moment.",
-			});
-		} catch (error) {
-			toast.error("Couldn't open payment settings", {
-				description: normalizeBillingError(error),
-			});
-		}
-	}
-
-	if (target.kind === "top_up") {
-		return (
-			<>
-				<Button type="button" size="sm" onClick={() => setTopUpOpen(true)} disabled={!wallet.data}>
-					<WalletCards data-icon="inline-start" />
-					Top up
-				</Button>
-				{wallet.data ? <TopUpDialog open={topUpOpen} onOpenChange={setTopUpOpen} /> : null}
-			</>
-		);
-	}
-	if (target.kind === "start_new") {
-		return agentHref ? (
-			<Button render={<a href={agentHref} />} nativeButton={false} type="button" size="sm">
-				<Settings data-icon="inline-start" />
-				Open Agent settings
-			</Button>
-		) : null;
-	}
-	return (
-		<Button
-			type="button"
-			size="sm"
-			onClick={() => void runAction(openPaymentRecovery)}
-			disabled={fixPayment.isPending}
-		>
-			{target.kind === "invoice" ? (
-				<ExternalLink data-icon="inline-start" />
-			) : (
-				<CreditCard data-icon="inline-start" />
-			)}
-			Fix payment
-		</Button>
-	);
-}
-
 function subscriptionAgentHref(subscription: ComputeSubscriptionListItem): string | null {
-	if (subscription.is_orphan || !subscription.deployment_id || !subscription.agent_name)
-		return null;
+	if (subscription.is_orphan || !subscription.deployment_id) return null;
 	return agentSectionHref(subscription.deployment_id, "settings", {
 		source: "on-clawdi",
 		settings: "billing-plan",
+	});
+}
+
+function subscriptionStartNewHref(subscription: ComputeSubscriptionListItem): string | null {
+	if (subscription.is_orphan || !subscription.deployment_id) return null;
+	return agentSectionHref(subscription.deployment_id, "settings", {
+		source: "on-clawdi",
+		settings: "billing-plan",
+		subscription_action: "start_new",
 	});
 }
 
@@ -267,7 +83,7 @@ function subscriptionManagement(
 			paymentState: subscription.payment_state,
 			cancelAtPeriodEnd: subscription.cancel_at_period_end,
 			recoveryAction: subscription.recovery_action,
-			pendingPlanSlug: subscription.pending_plan_slug,
+			pendingPlanSlug: pendingComputePlanSlug(subscription),
 			isOrphan: subscription.is_orphan,
 		},
 		deployment,
@@ -311,11 +127,24 @@ function SubscriptionRow({
 		tone: lifecycle.badgeTone,
 	});
 	const agentHref = subscriptionAgentHref(subscription);
-	const pendingPlanSlug =
-		subscription.pending_plan_slug === "compute_basic" ||
-		subscription.pending_plan_slug === "compute_performance"
-			? subscription.pending_plan_slug
-			: null;
+	const startNewHref = subscriptionStartNewHref(subscription);
+	const pendingPlanSlug = pendingComputePlanSlug(subscription);
+	const actions = resolveComputeSubscriptionActions({
+		entitlement: {
+			deploymentId: subscription.deployment_id,
+			planSlug: subscription.plan_slug,
+			fundingSource: subscription.funding_source,
+			priceCents: subscription.price_cents,
+			status: subscription.status,
+			paymentState: subscription.payment_state,
+			cancelAtPeriodEnd: subscription.cancel_at_period_end,
+			pendingPlanSlug,
+			isOrphan: subscription.is_orphan,
+		},
+		management,
+		recoveryTarget: recovery.recoveryTarget,
+		hasPendingOperation: management.target?.projectedOperationName != null,
+	});
 	const pendingPlanCopy = pendingPlanSlug
 		? pendingPlanScheduleCopy(
 				pendingPlanSlug,
@@ -323,32 +152,27 @@ function SubscriptionRow({
 				formatShortDate(subscription.current_period_end),
 			)
 		: null;
-	const recoveryActionAvailable =
-		recovery.recoveryTarget !== null &&
-		(recovery.recoveryTarget.kind !== "start_new" || agentHref !== null);
 	const recoveryNotice = (() => {
 		switch (recovery.recoveryTarget?.kind) {
 			case "top_up":
-				return "Top up Wallet before managing this subscription.";
+				return "Top up Wallet to settle the outstanding balance. Payment source changes apply to future renewals.";
 			case "invoice":
 			case "fix_payment":
-				return "Resolve the open invoice before managing this subscription.";
+				return "Resolve the outstanding payment to restore this subscription. Payment source changes apply to future renewals.";
 			case "start_new":
-				return agentHref ? "Start a new subscription from Agent settings." : null;
+				return startNewHref ? "Start a new subscription from Agent settings." : null;
 			case undefined:
 				return null;
 		}
 	})();
 	const hasActions =
-		management.action !== "hidden" ||
-		recoveryActionAvailable ||
-		canCancelAccountSubscription(subscription) ||
-		canResumeAccountSubscription(subscription);
+		actions.some((candidate) => candidate.kind !== "start_new") || startNewHref !== null;
 	const fundingSource = computeFundingSource(subscription.plan_slug, subscription);
 	const managementReason =
-		management.unavailableReason === COMPUTE_PLANS_UNAVAILABLE_REASON
+		actions.find((candidate) => candidate.kind === "manage")?.disabledReason ===
+		COMPUTE_PLANS_UNAVAILABLE_REASON
 			? null
-			: management.unavailableReason;
+			: (actions.find((candidate) => candidate.kind === "manage")?.disabledReason ?? null);
 	const view = computeSubscriptionCardView({
 		status: recovery.status,
 		planSlug: subscription.plan_slug,
@@ -397,20 +221,37 @@ function SubscriptionRow({
 				}
 				actions={
 					hasActions ? (
-						<>
-							{recoveryActionAvailable && recovery.recoveryTarget ? (
-								<SubscriptionRecoveryAction
-									target={recovery.recoveryTarget}
-									deploymentId={subscription.deployment_id ?? null}
-									agentHref={agentHref}
-								/>
-							) : null}
-							<SubscriptionActions
-								subscription={subscription}
-								management={management}
-								onManage={() => onManage(subscription)}
-							/>
-						</>
+						<ComputeSubscriptionActionList
+							actions={actions}
+							target={{
+								kind: "subscription",
+								subscriptionId: subscription.subscription_id,
+								deploymentId: subscription.deployment_id ?? null,
+							}}
+							onManage={() => onManage(subscription)}
+							onStartNew={
+								startNewHref
+									? { kind: "link", href: startNewHref, label: "Open Agent settings" }
+									: null
+							}
+							cancelCopy={{
+								title: `Cancel ${computeSubscriptionPlanLabel(subscription.plan_slug)} subscription?`,
+								description: (
+									<p>
+										The subscription will stop renewing
+										{subscription.current_period_end
+											? ` and remain active through ${formatShortDate(subscription.current_period_end)}`
+											: ""}
+										. This cannot restore a deleted agent.
+									</p>
+								),
+								confirmLabel: "Cancel subscription",
+								successDescription: (result) =>
+									result.current_period_end
+										? `Access continues through ${formatShortDate(result.current_period_end)}.`
+										: undefined,
+							}}
+						/>
 					) : null
 				}
 			/>
@@ -418,12 +259,21 @@ function SubscriptionRow({
 	);
 }
 
-const SUBSCRIPTION_STATUS_PRIORITY: Record<ComputeSubscriptionListItem["status"], number> = {
-	active: 0,
-	past_due: 1,
-	canceling: 2,
-	canceled: 3,
-};
+function subscriptionStatusPriority(status: string): number {
+	switch (status) {
+		case "trialing":
+		case "active":
+			return 0;
+		case "past_due":
+			return 1;
+		case "canceling":
+			return 2;
+		case "canceled":
+			return 3;
+		default:
+			return 4;
+	}
+}
 
 export function sortLoadedSubscriptions(
 	subscriptions: readonly ComputeSubscriptionListItem[],
@@ -432,8 +282,8 @@ export function sortLoadedSubscriptions(
 		.map((subscription, index) => ({ subscription, index }))
 		.sort(
 			(a, b) =>
-				SUBSCRIPTION_STATUS_PRIORITY[a.subscription.status] -
-					SUBSCRIPTION_STATUS_PRIORITY[b.subscription.status] || a.index - b.index,
+				subscriptionStatusPriority(a.subscription.status) -
+					subscriptionStatusPriority(b.subscription.status) || a.index - b.index,
 		)
 		.map(({ subscription }) => subscription);
 }

--- a/apps/web/src/hosted/sensitive-boundaries.test.ts
+++ b/apps/web/src/hosted/sensitive-boundaries.test.ts
@@ -224,7 +224,7 @@ describe("structural secret boundaries without the denylist", () => {
 			"hosted/billing/wallet/wallet-page.tsx",
 			"hosted/billing/subscription/welcome-wallet-card.tsx",
 			"hosted/billing/subscription/subscription-create-dialog.tsx",
-			"hosted/billing/components/compute-dunning-banner.tsx",
+			"hosted/billing/subscription/compute-subscription-recovery-action.tsx",
 			"hosted/billing/subscription/plan-change-controller.tsx",
 		];
 		for (const path of walletConsumers) {

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -12,6 +12,7 @@ export type AgentRouteSearch = Record<string, unknown> & {
 	tab?: string;
 	project?: string;
 	vault?: string;
+	subscription_action?: "start_new";
 };
 export type AgentRouteQuery =
 	| string
@@ -195,6 +196,10 @@ function optionalSearchString(value: unknown): string | undefined {
 	return typeof value === "string" ? value : undefined;
 }
 
+function subscriptionAction(value: unknown): AgentRouteSearch["subscription_action"] {
+	return value === "start_new" ? value : undefined;
+}
+
 /** Validate the shared agent-route search boundary while retaining additive query state. */
 export function validateAgentRouteSearch(search: Record<string, unknown>): AgentRouteSearch {
 	return {
@@ -204,6 +209,7 @@ export function validateAgentRouteSearch(search: Record<string, unknown>): Agent
 		tab: optionalSearchString(search.tab),
 		project: optionalSearchString(search.project),
 		vault: optionalSearchString(search.vault),
+		subscription_action: subscriptionAction(search.subscription_action),
 	};
 }
 

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -331,6 +331,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v2/subscription/plan/cancel-scheduled-change": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Cancel Scheduled V2 Subscription Plan Change */
+        post: operations["cancel_scheduled_v2_subscription_plan_change_v2_subscription_plan_cancel_scheduled_change_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v2/subscription/plan/change": {
         parameters: {
             query?: never;
@@ -1227,6 +1244,13 @@ export interface components {
             /** Entitled Until */
             entitled_until: null;
         };
+        /** V2ComputeCancelScheduledPlanChangeRequest */
+        V2ComputeCancelScheduledPlanChangeRequest: {
+            /** Deployment Id */
+            deployment_id?: string | null;
+            /** Subscription Id */
+            subscription_id?: string | null;
+        };
         /** V2ComputeCheckoutRequest */
         V2ComputeCheckoutRequest: {
             /**
@@ -1441,6 +1465,10 @@ export interface components {
             invoice_due_at?: string | null;
             /** Recovery Action */
             recovery_action?: ("top_up" | "fix_payment" | "start_new") | null;
+            /** Pending Plan Slug */
+            pending_plan_slug?: string | null;
+            /** Action State */
+            action_state?: ("removed" | "pending" | "reconciling") | null;
             /** Message */
             message?: string | null;
         };
@@ -1467,7 +1495,7 @@ export interface components {
              * Status
              * @enum {string}
              */
-            status: "active" | "canceling" | "past_due" | "canceled";
+            status: "trialing" | "active" | "canceling" | "past_due" | "canceled";
             /** Price Cents */
             price_cents?: number | null;
             /**
@@ -3618,6 +3646,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["V2PortalResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_scheduled_v2_subscription_plan_change_v2_subscription_plan_cancel_scheduled_change_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["V2ComputeCancelScheduledPlanChangeRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["V2ComputeSubscriptionActionResponse"];
                 };
             };
             /** @description Validation Error */

--- a/scripts/filter-deploy-openapi.py
+++ b/scripts/filter-deploy-openapi.py
@@ -69,6 +69,7 @@ KEEP_OPERATIONS_BY_PATH: dict[str, set[str]] = {
     "/v2/subscription/checkout": {"post"},
     "/v2/subscription/cancel": {"post"},
     "/v2/subscription/fix-payment": {"post"},
+    "/v2/subscription/plan/cancel-scheduled-change": {"post"},
     "/v2/subscription/plan/change": {"post"},
     "/v2/subscription/plan/quote": {"post"},
     "/v2/subscription/plans": {"get"},


### PR DESCRIPTION
## Summary

- unify Account Settings, Agent Settings, and Dunning behind one compute subscription resolver, action renderer, and recovery executor
- preserve generated `trialing`, add the generated cancel-scheduled-change contract from Hosted #1728, and refresh subscriptions/deployments/reusable inventory after actions
- allow paid payment-recovery states to manage only their future payment source while keeping plan and billing term changes unavailable
- map structured funding-authority conflicts to actionable product copy without exposing Stripe/internal details

## Action semantics

- Included Basic / Free: Manage only; never Cancel or Resume
- paid active: Manage + Cancel
- trialing: Cancel only
- past due / requires action: recovery + payment-source-only Manage + Cancel
- pending plan operation: Check change only
- scheduled plan change: recovery when applicable + Cancel scheduled change + legal Cancel
- canceling: Resume only when deployment-bound
- unpaid / authoritative fallback: Start new when deployment-bound
- ended without recovery: hidden

Cancel scheduled change sends `{subscription_id}` from Account and `{deployment_id}` from Agent. Only `action_state=removed` reports success; pending/reconciling remains truthful and refetches all compute subscription inventory.

Depends on Hosted #1728.

## Verification

- 134 focused Web/OSS tests
- Web typecheck
- Biome on touched files
- OSS build
- Hosted Playwright subscriptions suite: 3/3, desktop + 320px overflow checks
- generated deploy client freshness against Hosted commit 83d2f4a44
- `git diff --check`
