### PR TITLE
fix(runtime): preserve retired heads during environment retirement

### DIFF
--- a/backend/app/services/runtime_observation.py
+++ b/backend/app/services/runtime_observation.py
@@ -689,7 +689,8 @@ async def retire_runtime_environment(
     fence.final_stream_position = final_position
     fence.final_session_high_waters = high_waters
     for head in heads:
-        _retire_runtime_observation_head(head, tombstoned_at=now)
+        if head.state == RUNTIME_OBSERVATION_HEAD_ACTIVE:
+            _retire_runtime_observation_head(head, tombstoned_at=now)
     await db.flush()
     return RuntimeEnvironmentRetirementResult(
         receipt=receipt,

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -386,6 +386,25 @@ async def test_authorized_successor_atomically_tombstones_predecessor(
         )
     assert late_predecessor.value.code == "runtime_environment_retired"
 
+    predecessor_tombstone = heads["boot-session-predecessor"].tombstoned_at
+    receipt = await retire_runtime_environment(
+        db_session,
+        environment_id=environment.id,
+        expected_deployment_id=_DEPLOYMENT_ID,
+        retirement_id="handoff-environment-retirement",
+        owner_id=owner_id,
+    )
+    await db_session.commit()
+
+    await db_session.refresh(heads["boot-session-predecessor"])
+    await db_session.refresh(heads["boot-session-successor"])
+    assert heads["boot-session-predecessor"].tombstoned_at == predecessor_tombstone
+    assert heads["boot-session-successor"].state == "retired"
+    assert receipt["finalSessionHighWaterMarks"] == [
+        {"bootSessionId": "boot-session-predecessor", "sequence": 1},
+        {"bootSessionId": "boot-session-successor", "sequence": 1},
+    ]
+
 
 @pytest.mark.asyncio
 async def test_handoff_cannot_hide_an_unauthorized_active_head(


### PR DESCRIPTION
## Summary\n\n- preserve immutable boot-session predecessor tombstones during whole-environment retirement\n- retire only active observation heads while retaining every session final high-water in the receipt\n- extend the existing clean handoff regression to cover environment retirement\n\n## Root cause\n\nPR #942 introduced permanent retired predecessor heads for clean CLI handoffs. The environment retirement path still iterated every historical head and unconditionally reapplied the tombstone mutation, so PostgreSQL correctly rejected the write with: retired v2 runtime observation head is immutable.\n\n## Verification\n\n- focused PostgreSQL regression: 2 passed\n- full backend: 2289 passed, 12 skipped\n- Ruff lint and format: passed\n- compileall: passed\n- git diff --check: passed