### PR TITLE
feat(platform): expose runtime source authority

### DIFF
--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -4,14 +4,15 @@ from datetime import UTC, datetime
 from typing import Annotated, Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import invalidate_api_key_auth_cache
-from app.core.database import get_session
+from app.core.config import settings
+from app.core.database import get_session, runtime_snapshot_session
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.session import AgentEnvironment
@@ -28,6 +29,7 @@ from app.schemas.platform import (
     PlatformOwner,
     PlatformRuntimeStateResponse,
     PlatformRuntimeStateUpsert,
+    RuntimeSourceAuthorityResponse,
 )
 from app.schemas.platform_oauth import PlatformOAuthErrorResponse, PlatformOAuthTokenResponse
 from app.schemas.session import EnvironmentCreatedResponse
@@ -87,6 +89,14 @@ from app.services.runtime_generation import (
 from app.services.runtime_manifest_resources import (
     enabled_runtime_manifest_skill_ids,
     lock_runtime_manifest_skill_reservations,
+)
+from app.services.runtime_source import (
+    RuntimeSourceError,
+    RuntimeSourceNotFoundError,
+    expected_runtime_bundle_v2_etag,
+    load_runtime_source_batch,
+    render_runtime_source,
+    vault_key_identity,
 )
 from app.services.sync_events import (
     queue_environment_runtime_manifest_changed,
@@ -576,6 +586,42 @@ async def _load_owned_key(
     raise AssertionError("unreachable")
 
 
+async def _resolve_runtime_source_authority_owner_id(
+    db: AsyncSession,
+    owner: PlatformOwner,
+) -> UUID:
+    try:
+        if owner.kind == PRINCIPAL_KIND_CLERK:
+            issuer = await resolve_clerk_owner_issuer(db, subject=owner.ref)
+            resolved = await load_clerk_user_for_issuer(
+                db,
+                issuer=issuer,
+                subject=owner.ref,
+                bind_legacy=False,
+            )
+        else:
+            resolved = (
+                await db.execute(
+                    select(User).where(
+                        User.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT,
+                        User.partner_tenant_ref == owner.ref,
+                        User.clerk_id.is_(None),
+                    )
+                )
+            ).scalar_one_or_none()
+        if resolved is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "Runtime source not found")
+        await assert_user_authority_active(db, resolved.id)
+    except (PrincipalIdentityConflictError, PrincipalTerminatedError):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Runtime source not found") from None
+    except PrincipalLifecycleConfigurationError:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Owner authority is unavailable",
+        ) from None
+    return resolved.id
+
+
 async def _next_agent_sort_order(db: AsyncSession, user_id: UUID) -> int:
     value = await db.scalar(
         select(func.coalesce(func.max(AgentEnvironment.sort_order), -1) + 1).where(
@@ -758,6 +804,53 @@ async def platform_delete_agent(
     for key_id in revoked_key_ids:
         invalidate_api_key_auth_cache(key_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get(
+    "/agents/{agent_id}/runtime-state",
+    response_model=RuntimeSourceAuthorityResponse,
+)
+async def platform_get_runtime_source_authority(
+    agent_id: UUID,
+    owner: Annotated[PlatformOwner, Query()],
+    _auth: PlatformMutationAuth = Depends(
+        require_platform_mutation_auth("platform:runtime-state:write")
+    ),
+    db: AsyncSession = Depends(get_session),
+) -> RuntimeSourceAuthorityResponse:
+    owner_user_id = await _resolve_runtime_source_authority_owner_id(db, owner)
+    async with runtime_snapshot_session() as source_db:
+        batch = await load_runtime_source_batch(
+            source_db,
+            environment_ids=[agent_id],
+            owner_user_id=owner_user_id,
+        )
+        try:
+            source = render_runtime_source(
+                batch,
+                environment_id=agent_id,
+                public_api_url=settings.public_api_url,
+                vault_key_identity=vault_key_identity(settings.vault_encryption_key),
+                decrypt_secrets=False,
+            )
+        except RuntimeSourceNotFoundError:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "Runtime source not found") from None
+        except RuntimeSourceError:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "Runtime source is invalid",
+            ) from None
+        row = batch.rows[agent_id]
+        state = row.state
+        if state is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "Runtime source not found")
+        return RuntimeSourceAuthorityResponse(
+            environmentId=row.environment.id,
+            deploymentId=state.deployment_id,
+            instanceId=state.instance_id,
+            sourceRevision=source.source_revision,
+            etag=expected_runtime_bundle_v2_etag(source.source_revision),
+        )
 
 
 @router.put(

--- a/backend/app/schemas/platform.py
+++ b/backend/app/schemas/platform.py
@@ -142,3 +142,13 @@ class PlatformRuntimeStateResponse(BaseModel):
     instance_id: str
     generation: int
     apply_generation: int | None = None
+
+
+class RuntimeSourceAuthorityResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, strict=True)
+
+    environment_id: UUID = Field(alias="environmentId")
+    deployment_id: str = Field(alias="deploymentId", min_length=1, max_length=200)
+    instance_id: str = Field(alias="instanceId", min_length=1, max_length=200)
+    source_revision: str = Field(alias="sourceRevision", pattern=r"^[0-9a-f]{64}$")
+    etag: str = Field(pattern=r'^"sha256:[0-9a-f]{64}"$')

--- a/backend/tests/test_platform_endpoints.py
+++ b/backend/tests/test_platform_endpoints.py
@@ -24,7 +24,12 @@ from app.models.user import PRINCIPAL_KIND_PARTNER_TENANT, User
 from app.schemas.platform import PLATFORM_RUNTIME_KEY_SCOPES, PlatformRuntimeStateUpsert
 from app.services.hosted_runtime_secrets import runtime_secret_values_idempotency_identity
 from app.services.platform_contract import platform_request_hash, store_platform_response
-from app.services.runtime_source import load_runtime_source_batch, render_runtime_source
+from app.services.runtime_source import (
+    expected_runtime_bundle_v2_etag,
+    load_runtime_source_batch,
+    render_runtime_source,
+    vault_key_identity,
+)
 from app.services.user_provisioning import lazy_create_partner_user_with_personal_project
 from app.services.vault_crypto import decrypt
 from tests.conftest import create_env_with_project
@@ -557,6 +562,7 @@ async def test_platform_runtime_state_accepts_and_projects_filebrowser_companion
 
 
 @pytest.mark.asyncio
+@pytest.mark.committed_db
 async def test_platform_runtime_secret_upsert_preserves_ciphertext_and_source_revision(
     platform_client,
     db_session,
@@ -596,10 +602,30 @@ async def test_platform_runtime_secret_upsert_preserves_ciphertext_and_source_re
     first_source = render_runtime_source(
         batch,
         environment_id=agent_id,
-        public_api_url="https://cloud.test",
-        vault_key_identity="test-key-version",
+        public_api_url=settings.public_api_url,
+        vault_key_identity=vault_key_identity(settings.vault_encryption_key),
         decrypt_secrets=False,
     )
+    source_authority = await platform_client.get(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_ADMIN_AUTH,
+        params=owner,
+    )
+    assert source_authority.status_code == 200, source_authority.text
+    assert set(source_authority.json()) == {
+        "environmentId",
+        "deploymentId",
+        "instanceId",
+        "sourceRevision",
+        "etag",
+    }
+    assert source_authority.json() == {
+        "environmentId": str(agent_id),
+        "deploymentId": "deployment-1",
+        "instanceId": "instance-1",
+        "sourceRevision": first_source.source_revision,
+        "etag": expected_runtime_bundle_v2_etag(first_source.source_revision),
+    }
 
     second = await platform_client.put(
         f"/v1/platform/agents/{agent_id}/runtime-state",
@@ -625,8 +651,8 @@ async def test_platform_runtime_secret_upsert_preserves_ciphertext_and_source_re
     repeated_source = render_runtime_source(
         repeated_batch,
         environment_id=agent_id,
-        public_api_url="https://cloud.test",
-        vault_key_identity="test-key-version",
+        public_api_url=settings.public_api_url,
+        vault_key_identity=vault_key_identity(settings.vault_encryption_key),
         decrypt_secrets=False,
     )
     assert repeated_source.secret_values == {}
@@ -1067,6 +1093,14 @@ async def test_platform_existing_resources_reject_owner_mismatch(
     await db_session.refresh(other_key)
     owner = _clerk_owner(seed_user)
     try:
+        cross_owner_read = await platform_client.get(
+            f"/v1/platform/agents/{other_agent.id}/runtime-state",
+            headers=_ADMIN_AUTH,
+            params=owner,
+        )
+        assert cross_owner_read.status_code == 404, cross_owner_read.text
+        assert cross_owner_read.json() == {"detail": "Runtime source not found"}
+
         calls = [
             (
                 "POST",
@@ -1415,7 +1449,11 @@ async def test_platform_routes_are_canonical_and_exposed_in_openapi(platform_cli
         "/v1/platform/oauth/token",
     }
     assert all(not path.startswith("/api/platform") for path in paths)
-    assert set(paths["/v1/platform/agents/{agent_id}/runtime-state"]) == {"put", "delete"}
+    assert set(paths["/v1/platform/agents/{agent_id}/runtime-state"]) == {
+        "get",
+        "put",
+        "delete",
+    }
     companions_schema = response.json()["components"]["schemas"]["PlatformRuntimeStateUpsert"][
         "properties"
     ]["companions"]

--- a/backend/tests/test_platform_workload_oauth.py
+++ b/backend/tests/test_platform_workload_oauth.py
@@ -1168,6 +1168,24 @@ async def test_workload_resource_auth_enforces_scope_status_version_and_revocati
 ):
     owner = _owner(seed_user)
     token = await _access_token(workload_harness, "platform:agents:create")
+    runtime_source_id = uuid.uuid4()
+    runtime_source_token = await _access_token(
+        workload_harness,
+        "platform:runtime-state:write",
+    )
+    authorized_read = await workload_harness.client.get(
+        f"/v1/platform/agents/{runtime_source_id}/runtime-state",
+        headers={"Authorization": f"Bearer {runtime_source_token}"},
+        params=owner,
+    )
+    assert authorized_read.status_code == 404, authorized_read.text
+
+    wrong_scope_read = await workload_harness.client.get(
+        f"/v1/platform/agents/{runtime_source_id}/runtime-state",
+        headers={"Authorization": f"Bearer {token}"},
+        params=owner,
+    )
+    assert wrong_scope_read.status_code == 403, wrong_scope_read.text
 
     wrong_scope = await workload_harness.client.request(
         "DELETE",

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -2125,7 +2125,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /** Platform Get Runtime Source Authority */
+        get: operations["platform_get_runtime_source_authority_v1_platform_agents__agent_id__runtime_state_get"];
         /** Platform Upsert Runtime State */
         put: operations["platform_upsert_runtime_state_v1_platform_agents__agent_id__runtime_state_put"];
         post?: never;
@@ -6829,6 +6830,22 @@ export interface components {
             bootSessionId: string;
             /** Sequence */
             sequence: number;
+        };
+        /** RuntimeSourceAuthorityResponse */
+        RuntimeSourceAuthorityResponse: {
+            /**
+             * Environmentid
+             * Format: uuid
+             */
+            environmentId: string;
+            /** Deploymentid */
+            deploymentId: string;
+            /** Instanceid */
+            instanceId: string;
+            /** Sourcerevision */
+            sourceRevision: string;
+            /** Etag */
+            etag: string;
         };
         /** SearchHit */
         SearchHit: {
@@ -11922,6 +11939,43 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    platform_get_runtime_source_authority_v1_platform_agents__agent_id__runtime_state_get: {
+        parameters: {
+            query: {
+                kind: "clerk" | "partner_tenant";
+                ref: string;
+            };
+            header?: {
+                "X-Admin-Key"?: string | null;
+                Authorization?: string | null;
+            };
+            path: {
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RuntimeSourceAuthorityResponse"];
+                };
             };
             /** @description Validation Error */
             422: {


### PR DESCRIPTION
## Summary
- add an owner-scoped platform GET for authoritative desired runtime source authority
- return only environmentId, deploymentId, instanceId, sourceRevision, and the existing strong runtime bundle ETag
- fail closed for missing, terminated, archived, and cross-owner resources without read-side mutation or audit state
- regenerate the shared OpenAPI client

## Contract
- auth: existing platform:runtime-state:write workload/admin boundary
- owner: strict PlatformOwner query fields kind/ref
- source: runtime_snapshot_session + load_runtime_source_batch(owner_user_id=...) + render_runtime_source(decrypt_secrets=False)
- no Idempotency-Key, request body, runtime bundle, manifest, providers, models, credentials, secret refs/values, or internal database identities

## Verification
- scripts/test.sh backend tests/test_platform_endpoints.py::test_platform_runtime_secret_upsert_preserves_ciphertext_and_source_revision tests/test_platform_endpoints.py::test_platform_existing_resources_reject_owner_mismatch tests/test_platform_endpoints.py::test_platform_routes_are_canonical_and_exposed_in_openapi tests/test_platform_workload_oauth.py::test_workload_resource_auth_enforces_scope_status_version_and_revocation (4 passed)
- scripts/test.sh shared (typecheck + 72 passed)
- uv run ruff check app/routes/platform.py app/schemas/platform.py tests/test_platform_endpoints.py tests/test_platform_workload_oauth.py
- uv run ruff format --check app/routes/platform.py app/schemas/platform.py tests/test_platform_endpoints.py tests/test_platform_workload_oauth.py
- uv run basedpyright app/routes/platform.py app/schemas/platform.py (0 errors)
- uv run python scripts/type_governance.py owned (188 files, 0 errors/warnings)
- uv run python scripts/check_generated_api.py
- git diff --check origin/main..HEAD

No production operations, deployment, or merge performed.