### PR TITLE
fix(runtime): report runtime bundle observation ETag

### DIFF
--- a/backend/app/schemas/runtime_observation.py
+++ b/backend/app/schemas/runtime_observation.py
@@ -54,6 +54,13 @@ class RuntimeObservationEventV2(RuntimeObservationRequestModel):
     error: str | None = Field(default=None, max_length=4000)
     converge_error: str | None = Field(alias="convergeError", default=None, max_length=4000)
     truncated: Literal[False] | None = None
+    generation: int | None = Field(default=None, ge=1, le=9_007_199_254_740_991)
+    manifest_etag: str | None = Field(
+        alias="manifestETag",
+        default=None,
+        min_length=1,
+        max_length=128,
+    )
     apply_receipt_id: str = Field(alias="applyReceiptId", min_length=16, max_length=128)
     boot_nonce: str = Field(alias="bootNonce", min_length=16, max_length=128)
     boot_session_id: str = Field(alias="bootSessionId", min_length=1, max_length=128)
@@ -93,6 +100,10 @@ class RuntimeObservationEventV2(RuntimeObservationRequestModel):
     def validate_companion_identity(self) -> RuntimeObservationEventV2:
         if self.applied.generation < 1:
             raise ValueError("runtime observation generation must be at least 1")
+        if (self.generation is None) != (self.manifest_etag is None):
+            raise ValueError("generation and manifestETag must be present together")
+        if self.generation is not None and self.generation != self.applied.generation:
+            raise ValueError("generation must match applied.generation")
         if self.reported_at != self.captured_at:
             raise ValueError("reportedAt must equal capturedAt")
         if self.predecessor_boot_session_id == self.boot_session_id:

--- a/backend/app/services/runtime_observation.py
+++ b/backend/app/services/runtime_observation.py
@@ -291,8 +291,10 @@ def _canonical_observation_payload(value: RuntimeObservationEventV2) -> tuple[di
 
 def _companion_identity(value: RuntimeObservationEventV2) -> RuntimeApplyIdentity:
     return RuntimeApplyIdentity(
-        generation=value.applied.generation,
-        manifest_etag=value.applied.etag,
+        generation=value.generation if value.generation is not None else value.applied.generation,
+        manifest_etag=(
+            value.manifest_etag if value.manifest_etag is not None else value.applied.etag
+        ),
         apply_receipt_id=value.apply_receipt_id,
         boot_nonce=value.boot_nonce,
     )

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -53,6 +53,7 @@ _DEPLOYMENT_ID = "deployment-observation-companion"
 _APPLY_RECEIPT_ID = "apply-receipt-00000001"
 _BOOT_NONCE = "boot-nonce-0000000001"
 _MANIFEST_ETAG = '"manifest-etag-0001"'
+_BUNDLE_ETAG = f'"sha256:{"a" * 64}"'
 
 
 async def ingest_runtime_observation(
@@ -101,7 +102,7 @@ def _payload(
             "status": status,
             "activeCliVersion": "1.2.3-test",
             "applied": {
-                "etag": manifest_etag,
+                "etag": _BUNDLE_ETAG,
                 "sourceRevision": "a" * 64,
                 "generation": generation,
                 "instanceId": "runtime-instance-0001",
@@ -110,6 +111,8 @@ def _payload(
             "boot": None,
             "cli": None,
             "error": error,
+            "generation": generation,
+            "manifestETag": manifest_etag,
             "applyReceiptId": apply_receipt_id,
             "bootNonce": boot_nonce,
             "bootSessionId": boot_session_id,
@@ -146,6 +149,33 @@ def _rotated_identity() -> RuntimeApplyIdentity:
         apply_receipt_id="apply-receipt-00000002",
         boot_nonce="boot-nonce-0000000002",
     )
+
+
+def test_runtime_observation_identity_envelope_is_additive_and_consistent() -> None:
+    payload = _payload().model_dump(mode="json", by_alias=True)
+    assert payload["generation"] == payload["applied"]["generation"]
+    assert payload["manifestETag"] == _MANIFEST_ETAG
+    assert payload["applied"]["etag"] == _BUNDLE_ETAG
+
+    legacy_payload = {
+        key: value
+        for key, value in payload.items()
+        if key
+        not in {
+            "generation",
+            "manifestETag",
+        }
+    }
+    legacy = RuntimeObservationEventV2.model_validate(legacy_payload)
+    assert runtime_observation_service._companion_identity(legacy) == RuntimeApplyIdentity(
+        generation=1,
+        manifest_etag=_BUNDLE_ETAG,
+        apply_receipt_id=_APPLY_RECEIPT_ID,
+        boot_nonce=_BOOT_NONCE,
+    )
+
+    with pytest.raises(ValueError, match="generation must match applied.generation"):
+        RuntimeObservationEventV2.model_validate({**payload, "generation": 2})
 
 
 async def retire_runtime_environment(*args, **kwargs):
@@ -190,6 +220,11 @@ async def test_unique_regressions_enter_inbox_without_regressing_head(
         value=first_payload,
         received_at=base,
     )
+    stored_first = await db_session.get(V2RuntimeObservationInbox, first.stream_position)
+    assert stored_first is not None
+    assert stored_first.manifest_etag == _MANIFEST_ETAG
+    assert stored_first.diagnostics["manifestETag"] == _MANIFEST_ETAG
+    assert stored_first.diagnostics["applied"]["etag"] == _BUNDLE_ETAG
     duplicate = await ingest_runtime_observation(
         db_session,
         environment_id=environment.id,
@@ -2448,6 +2483,8 @@ async def test_short_tuple_filtered_page_does_not_skip_next_tuple_first_event(
 def _legacy_runtime_observed(value: RuntimeObservationEventV2) -> dict:
     payload = value.model_dump(mode="json", by_alias=True)
     for field in (
+        "generation",
+        "manifestETag",
         "applyReceiptId",
         "bootNonce",
         "bootSessionId",

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.72",
+      "version": "0.13.73",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.72",
+	"version": "0.13.73",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/heartbeat-observation.test.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.test.ts
@@ -480,9 +480,7 @@ describe("hosted runtime heartbeat observation", () => {
 		expect(session.hasCompanionIdentity).toBe(false);
 		expect(session.nextEvent()).toBeNull();
 		expect(existsSync(runtimeHeartbeatObservationStatePath(paths, "env_legacy"))).toBe(false);
-		expect(readHostedRuntimeObserved(paths)?.applied?.etag).toBe(
-			`"sha256:${"c".repeat(64)}"`,
-		);
+		expect(readHostedRuntimeObserved(paths)?.applied?.etag).toBe(`"sha256:${"c".repeat(64)}"`);
 	});
 
 	test("rejects a boot session ID outside the frozen 128-character bound", () => {

--- a/packages/cli/src/runtime/heartbeat-observation.test.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.test.ts
@@ -43,12 +43,13 @@ function tempRuntimePaths(): RuntimePaths {
 }
 
 function legacyAppliedState(generation: number): RuntimeAppliedStateV2 {
+	const sourceRevision = (generation === 8 ? "d" : "c").repeat(64);
 	return {
 		schemaVersion: "clawdi.runtimeAppliedState.v2",
 		appliedAt: `2026-07-16T00:00:0${generation}.000Z`,
 		instanceId: "hri_heartbeat",
-		etag: `"transport-bundle-${generation}"`,
-		sourceRevision: (generation === 8 ? "d" : "c").repeat(64),
+		etag: `"sha256:${sourceRevision}"`,
+		sourceRevision,
 		generation,
 		contentIdentity: {
 			sourcePath: "https://runtime.test/v1/runtime/manifest",
@@ -125,6 +126,8 @@ describe("hosted runtime heartbeat observation", () => {
 
 		const event = session.nextEvent()?.event;
 		expect(event).toMatchObject({
+			generation: 1,
+			manifestETag: '"frozen-manifest-1"',
 			applyReceiptId: "apply-receipt-0001",
 			bootNonce: "boot-nonce-000001",
 			bootSessionId: "boot-session-split",
@@ -132,7 +135,8 @@ describe("hosted runtime heartbeat observation", () => {
 			eventId: "event-split-000001",
 			applied: {
 				generation: 1,
-				etag: '"frozen-manifest-1"',
+				etag: `"sha256:${"c".repeat(64)}"`,
+				sourceRevision: "c".repeat(64),
 			},
 		});
 	});
@@ -162,6 +166,8 @@ describe("hosted runtime heartbeat observation", () => {
 		const first = session.nextEvent();
 		if (!first) throw new Error("expected first companion event");
 		expect(first.event).toMatchObject({
+			generation: 7,
+			manifestETag: '"frozen-manifest-7"',
 			applyReceiptId: "apply-receipt-0007",
 			bootNonce: "boot-nonce-000007",
 			bootSessionId: "boot-session-0001",
@@ -171,10 +177,11 @@ describe("hosted runtime heartbeat observation", () => {
 			reportedAt: "2026-07-16T01:00:00.000Z",
 			applied: {
 				generation: 7,
-				etag: '"frozen-manifest-7"',
+				etag: `"sha256:${"c".repeat(64)}"`,
+				sourceRevision: "c".repeat(64),
 			},
 		});
-		expect(first.event.applied?.etag).not.toBe('"transport-bundle-7"');
+		expect(first.event.applied.etag).not.toBe(first.event.manifestETag);
 		expect(first.payloadJson).toBe(JSON.stringify(first.event));
 		expect(first.payloadSha256).toBe(createHash("sha256").update(first.payloadJson).digest("hex"));
 		expect(session.acknowledge(first.event.eventId)).toBe(true);
@@ -183,6 +190,8 @@ describe("hosted runtime heartbeat observation", () => {
 		const second = session.nextEvent();
 		if (!second) throw new Error("expected second companion event");
 		expect(second.event).toMatchObject({
+			generation: 7,
+			manifestETag: '"frozen-manifest-7"',
 			applyReceiptId: "apply-receipt-0007",
 			bootNonce: "boot-nonce-000007",
 			bootSessionId: "boot-session-0001",
@@ -190,7 +199,7 @@ describe("hosted runtime heartbeat observation", () => {
 			eventId: "event-0000000002",
 			applied: {
 				generation: 7,
-				etag: '"frozen-manifest-7"',
+				etag: `"sha256:${"c".repeat(64)}"`,
 			},
 		});
 	});
@@ -218,6 +227,8 @@ describe("hosted runtime heartbeat observation", () => {
 		const rotated = session.nextEvent();
 		if (!rotated) throw new Error("expected rotated tuple event");
 		expect(rotated.event).toMatchObject({
+			generation: 8,
+			manifestETag: '"frozen-manifest-8"',
 			applyReceiptId: "apply-receipt-0008",
 			bootNonce: "boot-nonce-000008",
 			bootSessionId: "boot-session-0002",
@@ -225,7 +236,8 @@ describe("hosted runtime heartbeat observation", () => {
 			eventId: "event-0000000002",
 			applied: {
 				generation: 8,
-				etag: '"frozen-manifest-8"',
+				etag: `"sha256:${"d".repeat(64)}"`,
+				sourceRevision: "d".repeat(64),
 			},
 		});
 	});
@@ -468,7 +480,9 @@ describe("hosted runtime heartbeat observation", () => {
 		expect(session.hasCompanionIdentity).toBe(false);
 		expect(session.nextEvent()).toBeNull();
 		expect(existsSync(runtimeHeartbeatObservationStatePath(paths, "env_legacy"))).toBe(false);
-		expect(readHostedRuntimeObserved(paths)?.applied?.etag).toBe('"transport-bundle-7"');
+		expect(readHostedRuntimeObserved(paths)?.applied?.etag).toBe(
+			`"sha256:${"c".repeat(64)}"`,
+		);
 	});
 
 	test("rejects a boot session ID outside the frozen 128-character bound", () => {

--- a/packages/cli/src/runtime/heartbeat-observation.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.ts
@@ -10,6 +10,7 @@ import {
 	runtimeAppliedApplyIdentity,
 } from "./applied-state";
 import { type RuntimeApplyIdentity, runtimeApplyIdentitySchema } from "./apply-identity";
+import { assertRuntimeBundleAuthority } from "./manifest-source";
 import { readHostedRuntimeObserved } from "./observed";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { writeRuntimePlatformFileAtomic } from "./state";
@@ -87,7 +88,10 @@ const observedSupervisorSchema = z
 	})
 	.strict();
 
-export type HostedRuntimeObservedEvent = components["schemas"]["RuntimeObservationEventV2"];
+export type HostedRuntimeObservedEvent = components["schemas"]["RuntimeObservationEventV2"] & {
+	generation: number;
+	manifestETag: string;
+};
 
 const hostedRuntimeObservedEventSchema: z.ZodType<HostedRuntimeObservedEvent> = z
 	.object({
@@ -105,6 +109,8 @@ const hostedRuntimeObservedEventSchema: z.ZodType<HostedRuntimeObservedEvent> = 
 		error: z.string().nullable().optional(),
 		convergeError: z.string().nullable().optional(),
 		truncated: z.literal(false).nullable().optional(),
+		generation: positiveSafeIntegerSchema,
+		manifestETag: z.string().min(1).max(128),
 		applyReceiptId: z.string().min(16).max(128),
 		bootNonce: z.string().min(16).max(128),
 		bootSessionId: z.string().min(1).max(128),
@@ -351,11 +357,23 @@ export class HostedRuntimeHeartbeatSession {
 		const snapshot = readHostedRuntimeObserved(this.paths, {
 			reportedAt: capturedAt,
 			appliedState: this.capturedAppliedState,
-			etagAuthority: "control-plane",
 		});
 		if (!snapshot) return null;
+		if (!snapshot.applied) {
+			throw new Error("runtime heartbeat snapshot is missing captured applied state");
+		}
+		if (
+			snapshot.applied.generation !== this.currentBootIdentity.generation ||
+			snapshot.applied.etag !== this.capturedAppliedState.etag ||
+			snapshot.applied.sourceRevision !== this.capturedAppliedState.sourceRevision
+		) {
+			throw new Error("runtime heartbeat snapshot does not match captured applied state");
+		}
+		assertRuntimeBundleAuthority(snapshot.applied.sourceRevision, snapshot.applied.etag);
 		const event = hostedRuntimeObservedEventSchema.parse({
 			...snapshot,
+			generation: this.currentBootIdentity.generation,
+			manifestETag: this.currentBootIdentity.manifestETag,
 			applyReceiptId: this.currentBootIdentity.applyReceiptId,
 			bootNonce: this.currentBootIdentity.bootNonce,
 			bootSessionId: this.currentBootIdentity.bootSessionId,

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -353,7 +353,7 @@ async function loadRemoteRuntimeManifestPipeline(
 	};
 	try {
 		normalized = normalizeRemoteManifestPayload(fetched.raw);
-		assertRemoteBundleAuthority(normalized.sourceRevision, fetched.etag);
+		assertRuntimeBundleAuthority(normalized.sourceRevision, fetched.etag);
 		assertRuntimeApplyIdentityMatchesManifest(normalized.manifest, applyContext);
 	} catch (error) {
 		return {
@@ -414,7 +414,7 @@ function assertRuntimeApplyIdentityMatchesManifest(
 	}
 }
 
-function assertRemoteBundleAuthority(
+export function assertRuntimeBundleAuthority(
 	sourceRevision: string | undefined,
 	etag: string | undefined,
 ): void {

--- a/packages/cli/src/runtime/observation-producer.test.ts
+++ b/packages/cli/src/runtime/observation-producer.test.ts
@@ -32,12 +32,13 @@ function tempRuntimePaths(): RuntimePaths {
 }
 
 function appliedState(generation: number): RuntimeAppliedStateV2 {
+	const sourceRevision = (generation === 1 ? "a" : "b").repeat(64);
 	return {
 		schemaVersion: "clawdi.runtimeAppliedState.v2",
 		appliedAt: `2026-07-22T00:00:0${generation}.000Z`,
 		instanceId: "hri_producer",
-		etag: `"transport-${generation}"`,
-		sourceRevision: (generation === 1 ? "a" : "b").repeat(64),
+		etag: `"sha256:${sourceRevision}"`,
+		sourceRevision,
 		generation,
 		manifestETag: `"manifest-${generation}"`,
 		applyReceiptId: `apply-receipt-000${generation}`,
@@ -154,12 +155,18 @@ describe("hosted runtime observation producer", () => {
 
 		expect(await producer.sendOnce()).toEqual({ outcome: "accepted", status: "unknown" });
 		expect(submitted).toMatchObject({
+			generation: 3,
+			manifestETag: '"manifest-3"',
 			bootSessionId: "event-or-boot-identity",
 			sequence: 1,
 			eventId: "event-or-boot-identity",
 			applyReceiptId: "apply-receipt-0003",
 			bootNonce: "boot-nonce-000001",
-			applied: { generation: 3, etag: '"manifest-3"' },
+			applied: {
+				generation: 3,
+				etag: `"sha256:${"b".repeat(64)}"`,
+				sourceRevision: "b".repeat(64),
+			},
 		});
 	});
 
@@ -208,20 +215,24 @@ describe("hosted runtime observation producer", () => {
 
 		expect(events).toHaveLength(2);
 		expect(events[0]).toMatchObject({
+			generation: 1,
+			manifestETag: '"manifest-1"',
 			bootSessionId: "boot-000000000001",
 			sequence: 1,
 			eventId: "event-00000000001",
 			applyReceiptId: "apply-receipt-0001",
 			bootNonce: "boot-nonce-000001",
-			applied: { generation: 1, etag: '"manifest-1"' },
+			applied: { generation: 1, etag: `"sha256:${"a".repeat(64)}"` },
 		});
 		expect(events[1]).toMatchObject({
+			generation: 2,
+			manifestETag: '"manifest-2"',
 			bootSessionId: "boot-000000000002",
 			sequence: 1,
 			eventId: "event-00000000002",
 			applyReceiptId: "apply-receipt-0002",
 			bootNonce: "boot-nonce-000001",
-			applied: { generation: 2, etag: '"manifest-2"' },
+			applied: { generation: 2, etag: `"sha256:${"b".repeat(64)}"` },
 		});
 	});
 
@@ -259,6 +270,25 @@ describe("hosted runtime observation producer", () => {
 		});
 
 		expect(await producer.sendOnce()).toEqual({ outcome: "idle" });
+		expect(submits).toBe(0);
+	});
+
+	test("does not submit diagnostics with an invalid runtime bundle validator", async () => {
+		const paths = tempRuntimePaths();
+		writeApplyIdentityFile(paths, 1);
+		writeRuntimeAppliedState({ ...appliedState(1), etag: `"sha256:${"f".repeat(64)}"` }, paths);
+		let submits = 0;
+		const producer = new HostedRuntimeObservationProducer({
+			abort: new AbortController().signal,
+			paths,
+			contextPath: runtimeContextPath(paths),
+			submit: async () => {
+				submits += 1;
+				return "accepted";
+			},
+		});
+
+		expect(await producer.sendOnce()).toEqual({ outcome: "failed" });
 		expect(submits).toBe(0);
 	});
 

--- a/packages/cli/src/runtime/observation-producer.ts
+++ b/packages/cli/src/runtime/observation-producer.ts
@@ -242,8 +242,8 @@ function eventMatchesApplyIdentity(
 	identity: RuntimeApplyIdentity,
 ): boolean {
 	return (
-		event.applied.generation === identity.generation &&
-		event.applied.etag === identity.manifestETag &&
+		event.generation === identity.generation &&
+		event.manifestETag === identity.manifestETag &&
 		event.applyReceiptId === identity.applyReceiptId &&
 		event.bootNonce === identity.bootNonce
 	);

--- a/packages/cli/src/runtime/observed-v2.test.ts
+++ b/packages/cli/src/runtime/observed-v2.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { getCliVersion } from "../lib/version";
-import { readRuntimeAppliedState, writeRuntimeAppliedState } from "./applied-state";
+import { writeRuntimeAppliedState } from "./applied-state";
 import { readHostedRuntimeObserved } from "./observed";
 import { getRuntimePaths } from "./paths";
 
@@ -53,18 +53,6 @@ describe("hosted runtime observed v2", () => {
 		expect(observed?.activeCliVersion).toBe(getCliVersion());
 		expect(observed?.applied).toEqual({
 			etag: '"bundle-applied"',
-			sourceRevision: "a".repeat(64),
-			generation: 1,
-			instanceId: "hri_observed",
-			appliedProviderIds: ["managed"],
-		});
-		const companion = readHostedRuntimeObserved(paths, {
-			reportedAt: "2026-07-13T06:01:00.000Z",
-			appliedState: readRuntimeAppliedState(paths),
-			etagAuthority: "control-plane",
-		});
-		expect(companion?.applied).toEqual({
-			etag: '"frozen-companion-manifest"',
 			sourceRevision: "a".repeat(64),
 			generation: 1,
 			instanceId: "hri_observed",

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -33,7 +33,6 @@ export function readHostedRuntimeObserved(
 	options: {
 		reportedAt?: string;
 		appliedState?: RuntimeAppliedState | null;
-		etagAuthority?: "bundle" | "control-plane";
 	} = {},
 ): HostedRuntimeObserved | null {
 	if (paths.mode !== "hosted") return null;
@@ -46,10 +45,7 @@ export function readHostedRuntimeObserved(
 	const providers = readProviderObserved(paths);
 	const appliedAuthority = appliedState
 		? {
-				etag:
-					options.etagAuthority === "control-plane"
-						? (appliedState.manifestETag ?? appliedState.etag)
-						: appliedState.etag,
+				etag: appliedState.etag,
 				sourceRevision: appliedState.sourceRevision,
 				generation: resolveRuntimeApplyGeneration(appliedState),
 				instanceId: appliedState.instanceId,

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -6562,6 +6562,10 @@ export interface components {
             convergeError?: string | null;
             /** Truncated */
             truncated?: false | null;
+            /** Generation */
+            generation?: number | null;
+            /** Manifestetag */
+            manifestETag?: string | null;
             /** Applyreceiptid */
             applyReceiptId: string;
             /** Bootnonce */


### PR DESCRIPTION
## Summary

- report `diagnostics.applied.etag` from `RuntimeAppliedState.etag`, preserving the fetched runtime bundle validator and source revision
- carry the exact control-plane ApplyIdentity independently in the v2 event envelope (`generation`, `manifestETag`, `applyReceiptId`, `bootNonce`, `bootSessionId`)
- reuse the existing CLI sourceRevision/bundle validator before buffering an observation, and remove the dual-purpose `etagAuthority` option
- accept the additive envelope fields in Cloud while retaining the released-client fallback when both new fields are absent
- bump the unpublished CLI version to `0.13.73`

## Upstream / source evidence

- Base: `origin/main@a35e546dc298522c85fad575f1e6dec0c39a3550`.
- `backend/app/routes/platform.py:847-852` returns the runtime-state authority ETag through `expected_runtime_bundle_v2_etag(source.source_revision)`.
- `backend/app/services/runtime_source.py:109-113` defines that validator exactly as `"sha256:{sourceRevision}"`.
- `packages/cli/src/runtime/manifest-source.ts:354-357,417-428` validates the fetched ETag against the bundle `sourceRevision`.
- `packages/cli/src/runtime/applied-state.ts:37-43,85-100` stores bundle `etag` separately from the control-plane `manifestETag` ApplyIdentity.

No Cloud hash rendering is copied into the CLI and no dual-use ETag is introduced.

## Compatibility

- The new envelope fields are additive in the backend/OpenAPI contract and are required by the new CLI producer.
- The backend accepts old v2 clients only when both additive fields are absent, deriving their historical identity from `applied.generation` / `applied.etag`.
- Explicit envelope generation must match `diagnostics.applied.generation`.
- No OpenClaw, Hermes, or Codex provider projection files changed. The complete CLI suite includes the existing provider projection and restart-semantics coverage.

## Verification

- `scripts/test.sh cli src/runtime/observed-v2.test.ts src/runtime/heartbeat-observation.test.ts src/runtime/observation-producer.test.ts` (23 passed)
- `scripts/test.sh backend tests/test_runtime_observation_companion.py -k "identity_envelope or unique_regressions"` (2 passed)
- `scripts/test.sh backend tests/test_runtime_observation_companion.py` (32 passed)
- `scripts/test.sh cli` (typecheck; 1654 passed, 4 existing native lifecycle skips, 0 failed)
- `scripts/test.sh shared` (typecheck; 72 passed)
- Biome on changed TS/generated files
- Ruff check/format and Python compileall on changed backend files
- `uv run python scripts/check_generated_api.py`
- `node packages/cli/scripts/check-publish-manifest.mjs`
- `git diff --check`

All task-scoped Docker containers, networks, volumes, and test-runner images were removed by the clean runner.

## Release state

- `npm view clawdi version` reports `0.13.72`.
- `npm view clawdi@0.13.73 version` returns `E404`; `0.13.73` remains unpublished.
- This PR is intentionally unmerged and does not publish or deploy anything.
