### PR TITLE
fix(web): align compute subscription cards

### DIFF
--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -398,6 +398,7 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(dialog.getByText("Canceling", { exact: true })).toBeVisible();
 	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(5);
 	await expect(dialog.getByRole("button", { name: "Manage", exact: true })).toHaveCount(2);
+	await expect(dialog.getByRole("button", { name: "Upgrade", exact: true })).toHaveCount(1);
 	await expect(dialog.getByRole("button", { name: "Cancel scheduled change" })).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Show history (2)" })).toBeVisible();
 	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(5);
@@ -422,7 +423,10 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(includedCard.locator("h4")).toHaveText("Basic compute");
 	await expect(includedCard.getByText("Free", { exact: true })).toBeVisible();
 	await expect(includedCard.getByText("Included agent", { exact: true })).toBeVisible();
-	await expect(includedCard.getByRole("button")).toHaveCount(0);
+	const includedUpgrade = includedCard.getByRole("button", { name: "Upgrade", exact: true });
+	await expect(includedUpgrade).toBeEnabled();
+	await expect(includedUpgrade.locator("svg.lucide-arrow-up")).toHaveCount(1);
+	await expect(includedCard.getByRole("button")).toHaveCount(1);
 	await expect(includedCard.getByRole("button", { name: "Cancel subscription" })).toHaveCount(0);
 	await expect(pastDueCard.getByText("Past due", { exact: true })).toBeVisible();
 	await expect(pastDueCard.getByText("Retries Aug 10, 2099", { exact: true })).toBeVisible();
@@ -483,6 +487,17 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expectCardsFit(dialog);
 	await activeCard.evaluate((element) => element.scrollIntoView({ block: "start" }));
 	await dialog.screenshot({ path: testInfo.outputPath("account-compute-plans-desktop.png") });
+	await includedUpgrade.click();
+	const upgradeDialog = page.getByRole("dialog", { name: "Change compute subscription" });
+	await expect(upgradeDialog).toBeVisible();
+	await expect(
+		upgradeDialog.getByRole("group", { name: "Subscription management mode" }),
+	).toHaveCount(0);
+	await expect(upgradeDialog.getByLabel("Compute plan")).toHaveText(/Performance/);
+	await expect(upgradeDialog.getByLabel("Payment source")).toBeVisible();
+	await upgradeDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+	await expect(upgradeDialog).toBeHidden();
+	await expect(dialog).toBeVisible();
 
 	await dialog.getByRole("button", { name: "Show history (2)" }).click();
 	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(7);
@@ -874,11 +889,20 @@ test("agent settings uses compact canonical subscription management", async ({
 	);
 	await expect(includedCard.getByText("Free", { exact: true })).toBeVisible();
 	await expect(includedCard.locator('[data-slot="compute-subscription-identity"]')).toHaveCount(0);
-	await expect(includedCard.getByRole("button")).toHaveCount(0);
+	const agentUpgrade = includedCard.getByRole("button", { name: "Upgrade", exact: true });
+	await expect(agentUpgrade).toBeEnabled();
+	await expect(agentUpgrade.locator("svg.lucide-arrow-up")).toHaveCount(1);
+	await expect(includedCard.getByRole("button")).toHaveCount(1);
 	const desktopIncludedBox = await includedCard.boundingBox();
 	if (!desktopIncludedBox) throw new Error("Included Basic card has no desktop layout box");
-	expect(desktopIncludedBox.height).toBeLessThan(120);
+	expect(desktopIncludedBox.height).toBeLessThan(160);
 	await includedCard.screenshot({ path: testInfo.outputPath("agent-compute-plan-desktop.png") });
+	await agentUpgrade.click();
+	const agentUpgradeDialog = page.getByRole("dialog", { name: "Change compute subscription" });
+	await expect(agentUpgradeDialog).toBeVisible();
+	await expect(agentUpgradeDialog.getByLabel("Compute plan")).toHaveText(/Performance/);
+	await agentUpgradeDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+	await expect(agentUpgradeDialog).toBeHidden();
 	await expectCardsFit(page.locator("body"));
 	await page.setViewportSize({ width: 320, height: 568 });
 	await expect(includedCard).toBeVisible();
@@ -886,14 +910,25 @@ test("agent settings uses compact canonical subscription management", async ({
 	await expectNoHorizontalOverflow(page);
 	const mobileIncludedBox = await includedCard.boundingBox();
 	if (!mobileIncludedBox) throw new Error("Included Basic card has no mobile layout box");
-	expect(mobileIncludedBox.height).toBeLessThan(180);
+	expect(mobileIncludedBox.height).toBeLessThan(200);
 	await includedCard.screenshot({ path: testInfo.outputPath("agent-compute-plan-mobile-320.png") });
 
 	await gotoHostedAgentSettings(page, "hdep_included_ineligible", "Basic");
 	const unavailableCard = page
 		.locator('[data-slot="compute-subscription-card"]')
 		.filter({ hasText: "Basic compute" });
-	await expect(unavailableCard.getByRole("button")).toHaveCount(0);
+	const unavailableUpgrade = unavailableCard.getByRole("button", {
+		name: "Upgrade",
+		exact: true,
+	});
+	await expect(unavailableUpgrade).toBeDisabled();
+	await expect(unavailableCard.getByRole("button")).toHaveCount(1);
+	await expect(
+		unavailableCard.getByText(
+			"Wait until this agent is running or stopped before trying to upgrade again.",
+			{ exact: true },
+		),
+	).toBeVisible();
 	await unavailableCard.screenshot({
 		path: testInfo.outputPath("agent-compute-plan-disabled.png"),
 	});

--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -397,7 +397,7 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(dialog.getByText("Active", { exact: true })).toHaveCount(2);
 	await expect(dialog.getByText("Canceling", { exact: true })).toBeVisible();
 	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(5);
-	await expect(dialog.getByRole("button", { name: "Manage", exact: true })).toHaveCount(3);
+	await expect(dialog.getByRole("button", { name: "Manage", exact: true })).toHaveCount(2);
 	await expect(dialog.getByRole("button", { name: "Cancel scheduled change" })).toBeVisible();
 	await expect(dialog.getByRole("button", { name: "Show history (2)" })).toBeVisible();
 	await expect(dialog.locator('[data-slot="compute-subscription-card"] h4')).toHaveCount(5);
@@ -422,9 +422,7 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(includedCard.locator("h4")).toHaveText("Basic compute");
 	await expect(includedCard.getByText("Free", { exact: true })).toBeVisible();
 	await expect(includedCard.getByText("Included agent", { exact: true })).toBeVisible();
-	const includedManage = includedCard.getByRole("button", { name: "Manage", exact: true });
-	await expect(includedManage).toBeVisible();
-	await expect(includedManage.locator("svg.lucide-settings")).toHaveCount(1);
+	await expect(includedCard.getByRole("button")).toHaveCount(0);
 	await expect(includedCard.getByRole("button", { name: "Cancel subscription" })).toHaveCount(0);
 	await expect(pastDueCard.getByText("Past due", { exact: true })).toBeVisible();
 	await expect(pastDueCard.getByText("Retries Aug 10, 2099", { exact: true })).toBeVisible();
@@ -469,10 +467,21 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	expect(
 		Math.abs((desktopCardBoxes[0]?.y ?? 0) - (desktopCardBoxes[1]?.y ?? 1)),
 	).toBeLessThanOrEqual(1);
+	expect(
+		Math.abs((desktopCardBoxes[0]?.height ?? 0) - (desktopCardBoxes[1]?.height ?? 1)),
+	).toBeLessThanOrEqual(1);
 	expect(Math.abs((desktopCardBoxes[0]?.x ?? 0) - (desktopCardBoxes[1]?.x ?? 0))).toBeGreaterThan(
 		100,
 	);
+	const activeActionsBottomInset = await activeCard.evaluate((card) => {
+		const actions = card.querySelector<HTMLElement>('[data-slot="compute-subscription-actions"]');
+		if (!actions) return null;
+		return card.getBoundingClientRect().bottom - actions.getBoundingClientRect().bottom;
+	});
+	expect(activeActionsBottomInset).toBeGreaterThanOrEqual(12);
+	expect(activeActionsBottomInset).toBeLessThanOrEqual(20);
 	await expectCardsFit(dialog);
+	await activeCard.evaluate((element) => element.scrollIntoView({ block: "start" }));
 	await dialog.screenshot({ path: testInfo.outputPath("account-compute-plans-desktop.png") });
 
 	await dialog.getByRole("button", { name: "Show history (2)" }).click();
@@ -541,23 +550,6 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	await expect(dialog.getByRole("button", { name: "Hide history" })).toBeVisible();
 	await expect(dialog.locator('[data-slot="compute-subscription-card"]')).toHaveCount(7);
 	expect(page.url()).toBe(accountSettingsUrl);
-
-	await includedManage.click();
-	const includedManagementDialog = page.getByRole("dialog", {
-		name: "Change compute subscription",
-	});
-	await expect(includedManagementDialog).toBeVisible();
-	await expect(
-		includedManagementDialog.getByRole("group", { name: "Subscription management mode" }),
-	).toHaveCount(0);
-	await expect(includedManagementDialog.getByLabel("Compute plan")).toHaveText(/Performance/);
-	await expect(includedManagementDialog.getByLabel("Payment source")).toBeVisible();
-	await expect(
-		includedManagementDialog.getByRole("button", { name: "Cancel subscription" }),
-	).toHaveCount(0);
-	await includedManagementDialog.getByRole("button", { name: "Cancel", exact: true }).click();
-	await expect(includedManagementDialog).toBeHidden();
-	await expect(dialog).toBeVisible();
 
 	await pastDueManage.click();
 	const pastDueManagementDialog = page.getByRole("dialog", { name: "Change payment source" });
@@ -882,27 +874,12 @@ test("agent settings uses compact canonical subscription management", async ({
 	);
 	await expect(includedCard.getByText("Free", { exact: true })).toBeVisible();
 	await expect(includedCard.locator('[data-slot="compute-subscription-identity"]')).toHaveCount(0);
-	await expect(includedCard.getByRole("button", { name: "Cancel subscription" })).toHaveCount(0);
-	const includedManage = includedCard.getByRole("button", { name: "Manage", exact: true });
-	await expect(includedManage).toBeEnabled();
-	await expect(includedManage.locator("svg.lucide-settings")).toHaveCount(1);
+	await expect(includedCard.getByRole("button")).toHaveCount(0);
 	const desktopIncludedBox = await includedCard.boundingBox();
 	if (!desktopIncludedBox) throw new Error("Included Basic card has no desktop layout box");
 	expect(desktopIncludedBox.height).toBeLessThan(120);
 	await includedCard.screenshot({ path: testInfo.outputPath("agent-compute-plan-desktop.png") });
 	await expectCardsFit(page.locator("body"));
-	await includedManage.click();
-	const includedManagementDialog = page.getByRole("dialog", {
-		name: "Change compute subscription",
-	});
-	await expect(includedManagementDialog).toBeVisible();
-	await expect(
-		includedManagementDialog.getByRole("group", { name: "Subscription management mode" }),
-	).toHaveCount(0);
-	await expect(includedManagementDialog.getByLabel("Compute plan")).toBeVisible();
-	await expect(includedManagementDialog.getByLabel("Payment source")).toBeVisible();
-	await includedManagementDialog.getByRole("button", { name: "Cancel", exact: true }).click();
-
 	await page.setViewportSize({ width: 320, height: 568 });
 	await expect(includedCard).toBeVisible();
 	await expectCardsFit(page.locator("body"));
@@ -916,31 +893,7 @@ test("agent settings uses compact canonical subscription management", async ({
 	const unavailableCard = page
 		.locator('[data-slot="compute-subscription-card"]')
 		.filter({ hasText: "Basic compute" });
-	const unavailableReason = unavailableCard.getByText(
-		"Wait until this agent is running or stopped before trying to upgrade again.",
-		{ exact: true },
-	);
-	const unavailableManage = unavailableCard.getByRole("button", { name: "Manage", exact: true });
-	await expect(unavailableManage).toBeDisabled();
-	await expect(unavailableReason).toBeVisible();
-	const unavailableLayout = await unavailableCard.evaluate((card) => {
-		const notice = card.querySelector<HTMLElement>('[data-slot="compute-subscription-notice"]');
-		const actions = card.querySelector<HTMLElement>('[data-slot="compute-subscription-actions"]');
-		if (!notice || !actions) return null;
-		const noticeBox = notice.getBoundingClientRect();
-		const actionsBox = actions.getBoundingClientRect();
-		return {
-			gap: actionsBox.top - noticeBox.bottom,
-			scrollWidth: card.scrollWidth,
-			clientWidth: card.clientWidth,
-		};
-	});
-	expect(unavailableLayout).not.toBeNull();
-	expect(unavailableLayout?.gap).toBeGreaterThanOrEqual(0);
-	expect(unavailableLayout?.gap).toBeLessThanOrEqual(12);
-	expect(unavailableLayout?.scrollWidth).toBeLessThanOrEqual(
-		(unavailableLayout?.clientWidth ?? 0) + 1,
-	);
+	await expect(unavailableCard.getByRole("button")).toHaveCount(0);
 	await unavailableCard.screenshot({
 		path: testInfo.outputPath("agent-compute-plan-disabled.png"),
 	});

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -163,7 +163,6 @@ import {
 	computeSubscriptionCardView,
 } from "@/hosted/billing/subscription/compute-subscription-card";
 import {
-	COMPUTE_PLANS_UNAVAILABLE_REASON,
 	type ComputeSubscriptionManagementResult,
 	computeSubscriptionManagement,
 } from "@/hosted/billing/subscription/compute-subscription-management";
@@ -3597,7 +3596,6 @@ function ComputeSettingsSections({
 	const currentBillingTerm = planChangeBillingTerm(currentSubscription?.billing_term_months ?? 1);
 	const basicPlan = useMemo(() => resolveBasicPlan(plans.data), [plans.data]);
 	const perfPlan = useMemo(() => resolvePerformancePlan(plans.data), [plans.data]);
-	const blockingPlansError = shouldBlockQueryError(plans.error, plans.data) ? plans.error : null;
 	const currentPaidPlan =
 		computePlanSlug === COMPUTE_BASIC_SLUG
 			? basicPlan
@@ -3675,21 +3673,13 @@ function ComputeSettingsSections({
 				},
 				deployment,
 				canCreateCloudAgents: hostedAccess.canCreateCloudAgents,
-				plansLoading: plans.isLoading,
-				plansError: blockingPlansError !== null,
-				performancePlanAvailable: Boolean(perfPlan),
 			})
 		: { action: "hidden", target: null, unavailableReason: null };
 	const hasPendingComputeChange =
 		hasPendingPlanChange ||
 		(computeManagement.action === "enabled" &&
 			computeManagement.target.projectedOperationName !== null);
-	const plansErrorBlocksIncluded =
-		blockingPlansError !== null &&
-		computeManagement.unavailableReason === COMPUTE_PLANS_UNAVAILABLE_REASON;
-	const computeManagementReason = plansErrorBlocksIncluded
-		? null
-		: computeManagement.unavailableReason;
+	const computeManagementReason = computeManagement.unavailableReason;
 	const subscriptionCreatePlanSlug = resolveSubscriptionCreatePlanSlug(
 		terminalRecovery?.recoveryPlanSlug ?? pendingPlanSlug ?? computePlanSlug,
 		{
@@ -3782,14 +3772,6 @@ function ComputeSettingsSections({
 			) : null}
 
 			<SettingsSection title="Compute plan" description="Compute resources for this hosted agent.">
-				{plansErrorBlocksIncluded ? (
-					<ApiErrorPanel
-						normalizer={billingErrorNormalizer}
-						error={blockingPlansError}
-						onRetry={() => void plans.refetch()}
-						title="Couldn't load compute plans"
-					/>
-				) : null}
 				<ComputeSubscriptionCard
 					headingLevel={3}
 					view={computeCardView}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -3673,6 +3673,8 @@ function ComputeSettingsSections({
 				},
 				deployment,
 				canCreateCloudAgents: hostedAccess.canCreateCloudAgents,
+				plansLoading: plans.isLoading,
+				performancePlanAvailable: Boolean(perfPlan),
 			})
 		: { action: "hidden", target: null, unavailableReason: null };
 	const hasPendingComputeChange =
@@ -3799,7 +3801,7 @@ function ComputeSettingsSections({
 						<ComputeSubscriptionActionList
 							actions={computeActions}
 							target={{ kind: "deployment", deploymentId: deployment.resource.id }}
-							onManage={() => setPlanChangeOpen(true)}
+							onPlanChange={() => setPlanChangeOpen(true)}
 							onStartNew={{
 								kind: "button",
 								onClick: () => setSubscriptionCreateOpen(true),

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-action-list.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-action-list.tsx
@@ -17,7 +17,7 @@ import {
 	useResumeSubscription,
 } from "@/hosted/billing/hooks";
 import type { ComputeSubscriptionAction } from "@/hosted/billing/subscription/compute-subscription-actions";
-import { ComputeSubscriptionManageAction } from "@/hosted/billing/subscription/compute-subscription-card";
+import { ComputeSubscriptionPlanAction } from "@/hosted/billing/subscription/compute-subscription-card";
 import {
 	ComputeSubscriptionRecoveryAction,
 	type ComputeSubscriptionStartNewAction,
@@ -81,7 +81,7 @@ export function scheduledPlanCancellationNotice(result: ComputeSubscriptionActio
 export function ComputeSubscriptionActionList({
 	actions,
 	target,
-	onManage,
+	onPlanChange,
 	onStartNew,
 	cancelCopy,
 	checkChangeHref,
@@ -90,7 +90,7 @@ export function ComputeSubscriptionActionList({
 }: {
 	actions: readonly ComputeSubscriptionAction[];
 	target: ComputeSubscriptionActionTarget;
-	onManage?: () => void;
+	onPlanChange?: () => void;
 	onStartNew: ComputeSubscriptionStartNewAction | null;
 	cancelCopy?: ComputeSubscriptionCancelCopy;
 	checkChangeHref?: string;
@@ -146,12 +146,14 @@ export function ComputeSubscriptionActionList({
 
 	return actions.map((candidate) => {
 		switch (candidate.kind) {
+			case "upgrade":
 			case "manage":
 				return (
-					<ComputeSubscriptionManageAction
+					<ComputeSubscriptionPlanAction
 						key={candidate.kind}
-						onClick={() => onManage?.()}
-						disabled={!onManage || candidate.disabledReason !== null}
+						action={candidate.kind}
+						onClick={() => onPlanChange?.()}
+						disabled={!onPlanChange || candidate.disabledReason !== null}
 					/>
 				);
 			case "check_change":
@@ -178,8 +180,8 @@ export function ComputeSubscriptionActionList({
 						type="button"
 						variant="outline"
 						size="sm"
-						disabled={!onManage || candidate.disabledReason !== null}
-						onClick={onManage}
+						disabled={!onPlanChange || candidate.disabledReason !== null}
+						onClick={onPlanChange}
 					>
 						<RefreshCw data-icon="inline-start" />
 						Check subscription change status

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-actions.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-actions.test.ts
@@ -75,7 +75,7 @@ describe("resolveComputeSubscriptionActions", () => {
 				{ planSlug: "compute_basic", fundingSource: null, priceCents: 0 },
 				{ management: enabledManagement },
 			),
-		).toEqual(["manage"]);
+		).toEqual([]);
 		expect(kinds({ deploymentId: null, isOrphan: true })).toEqual(["cancel"]);
 	});
 

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-actions.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-actions.test.ts
@@ -75,7 +75,7 @@ describe("resolveComputeSubscriptionActions", () => {
 				{ planSlug: "compute_basic", fundingSource: null, priceCents: 0 },
 				{ management: enabledManagement },
 			),
-		).toEqual([]);
+		).toEqual(["upgrade"]);
 		expect(kinds({ deploymentId: null, isOrphan: true })).toEqual(["cancel"]);
 	});
 

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-actions.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-actions.ts
@@ -130,8 +130,7 @@ export function resolveComputeSubscriptionActions({
 	}
 
 	if (!paid) {
-		const manage = !entitlement.isOrphan ? manageAction(management) : null;
-		return recovery ? [recovery] : manage ? [manage] : [];
+		return recovery ? [recovery] : [];
 	}
 
 	const manage = !entitlement.isOrphan ? manageAction(management) : null;

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-actions.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-actions.ts
@@ -3,6 +3,7 @@ import type { ComputeRecoveryTarget } from "./compute-subscription-recovery";
 import { computeFundingSource } from "./subscription-utils";
 
 export type ComputeSubscriptionActionKind =
+	| "upgrade"
 	| "manage"
 	| "cancel"
 	| "resume"
@@ -55,11 +56,12 @@ function action(
 	return { kind, disabledReason };
 }
 
-function manageAction(
+function planAction(
 	management: ComputeSubscriptionManagementResult,
+	kind: Extract<ComputeSubscriptionActionKind, "manage" | "upgrade"> = "manage",
 ): ComputeSubscriptionAction | null {
 	if (management.action === "hidden") return null;
-	return action("manage", management.action === "disabled" ? management.unavailableReason : null);
+	return action(kind, management.action === "disabled" ? management.unavailableReason : null);
 }
 
 function recoveryAction(target: ComputeRecoveryTarget): ComputeSubscriptionRecoveryAction {
@@ -130,10 +132,11 @@ export function resolveComputeSubscriptionActions({
 	}
 
 	if (!paid) {
-		return recovery ? [recovery] : [];
+		const upgrade = !entitlement.isOrphan ? planAction(management, "upgrade") : null;
+		return recovery ? [recovery] : upgrade ? [upgrade] : [];
 	}
 
-	const manage = !entitlement.isOrphan ? manageAction(management) : null;
+	const manage = !entitlement.isOrphan ? planAction(management) : null;
 	if (recovery) {
 		return [recovery, ...(manage ? [manage] : []), ...(cancel ? [cancel] : [])];
 	}

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
@@ -170,10 +170,10 @@ export function ComputeSubscriptionCard({
 			data-subscription-status={view.status.label.toLowerCase().replaceAll(" ", "-")}
 			className={entityCardChassisClass({
 				variant: "compact",
-				className: cn("flex min-w-0 flex-wrap items-center gap-3", className),
+				className: cn("flex h-full min-w-0 flex-col gap-3", className),
 			})}
 		>
-			<div className="flex min-w-[min(12rem,100%)] flex-1 flex-col gap-1.5">
+			<div className="flex min-w-0 flex-1 flex-col gap-1.5">
 				<header className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
 					<Heading className="min-w-0 text-base font-semibold leading-6 [overflow-wrap:anywhere]">
 						{view.plan}
@@ -216,7 +216,7 @@ export function ComputeSubscriptionCard({
 			</div>
 
 			{notice || actions ? (
-				<div className="ml-auto flex min-w-0 flex-col items-start gap-1.5 sm:items-end">
+				<div className="mt-auto flex min-w-0 flex-col items-start gap-1.5 pt-1 sm:items-end">
 					{notice ? (
 						<div data-slot="compute-subscription-notice" className="min-w-0 sm:text-right">
 							{notice}

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { Settings, UserRoundX } from "lucide-react";
+import { ArrowUp, Settings, UserRoundX } from "lucide-react";
 import type { ReactNode } from "react";
 import { AgentLabel } from "@/components/dashboard/agent-label";
 import { entityCardChassisClass } from "@/components/entity-card";
@@ -127,17 +127,23 @@ function SubscriptionIdentity({ identity }: { identity: ComputeSubscriptionIdent
 	);
 }
 
-export function ComputeSubscriptionManageAction({
+export function ComputeSubscriptionPlanAction({
+	action,
 	onClick,
 	disabled = false,
 }: {
+	action: "upgrade" | "manage";
 	onClick: () => void;
 	disabled?: boolean;
 }) {
 	return (
 		<Button type="button" variant="outline" size="sm" disabled={disabled} onClick={onClick}>
-			<Settings data-icon="inline-start" />
-			Manage
+			{action === "upgrade" ? (
+				<ArrowUp data-icon="inline-start" />
+			) : (
+				<Settings data-icon="inline-start" />
+			)}
+			{action === "upgrade" ? "Upgrade" : "Manage"}
 		</Button>
 	);
 }

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-management.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-management.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 import {
 	type ComputeSubscriptionEntitlement,
@@ -10,10 +9,10 @@ function entitlement(
 	overrides: Partial<ComputeSubscriptionEntitlement> = {},
 ): ComputeSubscriptionEntitlement {
 	return {
-		deploymentId: "hdep_included",
+		deploymentId: "hdep_agent",
 		planSlug: "compute_basic",
-		fundingSource: null,
-		priceCents: 0,
+		fundingSource: "stripe",
+		priceCents: 900,
 		billingTermMonths: 1,
 		status: "active",
 		paymentState: "ok",
@@ -24,106 +23,40 @@ function entitlement(
 	};
 }
 
-function includedDeployment() {
-	return hostedDeploymentFixture({
-		id: "hdep_included",
-		currentPlanSlug: "compute_basic",
-		upgradeAvailable: true,
-		computeSubscription: {
-			subscription_id: 7,
-			status: "active",
-			funding_source: null,
-			payment_state: "ok",
-			billing_term_months: 1,
-			price_cents: 0,
-			currency: "usd",
-			cancel_at_period_end: false,
-		},
-	});
-}
-
-const available = {
-	canCreateCloudAgents: true,
-	plansLoading: false,
-	plansError: false,
-	performancePlanAvailable: true,
-};
+const available = { canCreateCloudAgents: true };
 
 describe("computeSubscriptionManagement", () => {
-	test("maps Included Basic and paid entitlements into the same management target model", () => {
-		const included = computeSubscriptionManagement({
-			entitlement: entitlement(),
-			deployment: includedDeployment(),
-			...available,
-		});
-		const paid = computeSubscriptionManagement({
-			entitlement: entitlement({ fundingSource: "wallet", priceCents: 900 }),
-			...available,
-		});
+	test("keeps stable Included Basic read-only", () => {
+		const included = entitlement({ fundingSource: null, priceCents: 0 });
 
-		expect(included).toMatchObject({
-			action: "enabled",
-			target: {
-				currentPlanSlug: "compute_basic",
-				initialPlanSlug: "compute_performance",
-				currentFundingSource: "stripe",
-				isPaidCompute: false,
-				allowCombinedChange: true,
-			},
-		});
-		expect(paid).toMatchObject({
-			action: "enabled",
-			target: {
-				currentPlanSlug: "compute_basic",
-				initialPlanSlug: "compute_basic",
-				currentFundingSource: "wallet",
-				isPaidCompute: true,
-				allowCombinedChange: false,
-			},
-		});
-	});
-
-	test("limits plans errors to Included upgrades without blocking paid or pending management", () => {
-		expect(
-			computeSubscriptionManagement({
-				entitlement: entitlement({ fundingSource: "stripe", priceCents: 900 }),
-				...available,
-				plansError: true,
-			}),
-		).toMatchObject({ action: "enabled" });
-		expect(
-			computeSubscriptionManagement({
-				entitlement: entitlement(),
-				deployment: includedDeployment(),
-				...available,
-				plansError: true,
-			}),
-		).toMatchObject({
-			action: "disabled",
-			unavailableReason: expect.stringContaining("Retry loading compute plans"),
+		expect(computeSubscriptionManagement({ entitlement: included, ...available })).toEqual({
+			action: "hidden",
+			target: null,
+			unavailableReason: null,
 		});
 		expect(
 			computeSubscriptionManagement({
-				entitlement: entitlement({ fundingSource: null, priceCents: 900 }),
-				...available,
-			}),
-		).toMatchObject({
-			action: "enabled",
-			target: { currentFundingSource: "stripe", isPaidCompute: true },
-		});
-		expect(
-			computeSubscriptionManagement({
-				entitlement: entitlement({ planSlug: "compute_performance", priceCents: 0 }),
+				entitlement: included,
+				deployment: hostedDeploymentFixture({
+					id: "hdep_agent",
+					currentPlanSlug: "compute_basic",
+					upgradeAvailable: true,
+				}),
 				...available,
 			}),
 		).toEqual({ action: "hidden", target: null, unavailableReason: null });
+	});
 
-		const pending = includedDeployment();
-		pending.accepted_operation = {
+	test("keeps an already-started Included Basic change observable", () => {
+		const deployment = hostedDeploymentFixture({
+			id: "hdep_agent",
+			currentPlanSlug: "compute_basic",
+		});
+		deployment.accepted_operation = {
 			name: "operations/pending-plan-change",
 			metadata: {
 				"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
-				deploymentId: "hdep_included",
+				deploymentId: "hdep_agent",
 				verb: "plan_change",
 				targetGeneration: 2,
 				manifestETag: "etag_plan_change",
@@ -132,140 +65,60 @@ describe("computeSubscriptionManagement", () => {
 			},
 			done: false,
 		};
-		expect(
-			computeSubscriptionManagement({
-				entitlement: entitlement(),
-				deployment: pending,
-				...available,
-				plansError: true,
-			}),
-		).toMatchObject({ action: "enabled" });
-	});
 
-	test("keeps paid payment recovery payment-source-only across lifecycle projections", () => {
-		for (const [fundingSource, status, paymentState, recoveryAction] of [
-			["stripe", "active", "requires_action", "fix_payment"],
-			["wallet", "active", "past_due", "top_up"],
-		] as const) {
-			expect(
-				computeSubscriptionManagement({
-					entitlement: entitlement({
-						fundingSource,
-						priceCents: 900,
-						status,
-						paymentState,
-						recoveryAction,
-					}),
-					...available,
-				}),
-			).toMatchObject({
-				action: "enabled",
-				target: { status: "past_due", paymentSourceOnly: true },
-			});
-		}
-	});
-
-	test("keeps Included Basic management disabled until the gated deployment projection is available", () => {
-		expect(
-			computeSubscriptionManagement({ entitlement: entitlement(), ...available }),
-		).toMatchObject({
-			action: "disabled",
-			unavailableReason: expect.stringContaining("compute details finish syncing"),
-		});
 		expect(
 			computeSubscriptionManagement({
-				entitlement: entitlement(),
-				deployment: hostedDeploymentFixture({
-					id: "hdep_included",
-					currentPlanSlug: "compute_basic",
-					upgradeAvailable: false,
-					upgradeEligibility: {
-						eligible: false,
-						reason: "deployment_must_be_running_or_stopped",
-					},
-					computeSubscription: includedDeployment().commercial_display?.compute_subscription,
-				}),
-				...available,
-			}),
-		).toMatchObject({
-			action: "disabled",
-			unavailableReason: expect.stringContaining("running or stopped"),
-		});
-	});
-
-	test("does not present ordinary management for recovery or terminal fallback states", () => {
-		expect(
-			computeSubscriptionManagement({
-				entitlement: entitlement({ recoveryAction: "fix_payment" }),
-				deployment: includedDeployment(),
-				...available,
-			}),
-		).toEqual({ action: "hidden", target: null, unavailableReason: null });
-		const fallback = hostedDeploymentFixture({
-			id: "hdep_included",
-			currentPlanSlug: "compute_basic",
-			upgradeAvailable: false,
-			computeSubscription: includedDeployment().commercial_display?.compute_subscription,
-			fundingFact: {
-				fact_kind: "funding_revoked",
-				commercial_revision: 1,
-				funding_source: "stripe",
-				prior_plan_slug: "compute_performance",
-				occurred_at: "2026-07-16T00:00:00Z",
-				emitted_at: "2026-07-16T00:00:00Z",
-			},
-		});
-		expect(
-			computeSubscriptionManagement({
-				entitlement: entitlement(),
-				deployment: fallback,
-				...available,
-			}),
-		).toMatchObject({
-			action: "hidden",
-			target: { deploymentId: "hdep_included", isPaidCompute: false },
-		});
-
-		const pendingFallback = {
-			...fallback,
-			accepted_operation: {
-				name: "operations/pending-plan-change",
-				metadata: {
-					"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
-					deploymentId: "hdep_included",
-					verb: "plan_change",
-					targetGeneration: 2,
-					manifestETag: "etag_plan_change",
-					createTime: "2026-07-16T00:00:00Z",
-					updateTime: "2026-07-16T00:00:00Z",
-				},
-				done: false,
-			},
-		} satisfies HostedDeployment;
-		expect(
-			computeSubscriptionManagement({
-				entitlement: entitlement(),
-				deployment: pendingFallback,
+				entitlement: entitlement({ fundingSource: null, priceCents: 0 }),
+				deployment,
 				...available,
 			}),
 		).toMatchObject({
 			action: "enabled",
-			target: { projectedOperationName: "operations/pending-plan-change" },
+			target: {
+				isPaidCompute: false,
+				projectedOperationName: "operations/pending-plan-change",
+			},
 		});
+	});
 
-		const pendingPaymentRecovery = computeSubscriptionManagement({
-			entitlement: entitlement({
-				fundingSource: "stripe",
-				priceCents: 900,
-				status: "active",
-				paymentState: "past_due",
+	test("keeps healthy paid management and payment recovery explicit", () => {
+		expect(
+			computeSubscriptionManagement({
+				entitlement: entitlement({ fundingSource: "wallet" }),
+				...available,
 			}),
-			deployment: pendingFallback,
-			...available,
+		).toMatchObject({
+			action: "enabled",
+			target: {
+				currentFundingSource: "wallet",
+				isPaidCompute: true,
+				paymentSourceOnly: false,
+			},
 		});
-		expect(pendingPaymentRecovery).toMatchObject({
+		expect(
+			computeSubscriptionManagement({
+				entitlement: entitlement({
+					paymentState: "requires_action",
+					recoveryAction: "fix_payment",
+				}),
+				...available,
+			}),
+		).toMatchObject({
 			action: "enabled",
 			target: { status: "past_due", paymentSourceOnly: true },
 		});
+	});
+
+	test("hides ordinary management for invalid, canceling, and scheduled targets", () => {
+		for (const overrides of [
+			{ deploymentId: null },
+			{ cancelAtPeriodEnd: true },
+			{ pendingPlanSlug: "compute_performance" },
+			{ status: "canceled" },
+		] satisfies Partial<ComputeSubscriptionEntitlement>[]) {
+			expect(
+				computeSubscriptionManagement({ entitlement: entitlement(overrides), ...available }),
+			).toEqual({ action: "hidden", target: null, unavailableReason: null });
+		}
 	});
 });

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-management.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-management.test.ts
@@ -23,16 +23,21 @@ function entitlement(
 	};
 }
 
-const available = { canCreateCloudAgents: true };
+const available = {
+	canCreateCloudAgents: true,
+	plansLoading: false,
+	performancePlanAvailable: true,
+};
 
 describe("computeSubscriptionManagement", () => {
-	test("keeps stable Included Basic read-only", () => {
+	test("exposes stable Included Basic as an explicit upgrade target", () => {
 		const included = entitlement({ fundingSource: null, priceCents: 0 });
 
 		expect(computeSubscriptionManagement({ entitlement: included, ...available })).toEqual({
-			action: "hidden",
+			action: "disabled",
 			target: null,
-			unavailableReason: null,
+			unavailableReason:
+				"Upgrade availability will appear after this agent’s compute details finish syncing.",
 		});
 		expect(
 			computeSubscriptionManagement({
@@ -44,7 +49,15 @@ describe("computeSubscriptionManagement", () => {
 				}),
 				...available,
 			}),
-		).toEqual({ action: "hidden", target: null, unavailableReason: null });
+		).toMatchObject({
+			action: "enabled",
+			target: {
+				currentPlanSlug: "compute_basic",
+				initialPlanSlug: "compute_performance",
+				isPaidCompute: false,
+				allowCombinedChange: true,
+			},
+		});
 	});
 
 	test("keeps an already-started Included Basic change observable", () => {

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-management.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-management.ts
@@ -3,11 +3,7 @@ import type {
 	HostedComputeSubscription,
 	HostedDeployment,
 } from "@/hosted/billing/contracts";
-import { deploymentStatusFromResource, isRunningStatus } from "@/hosted/deployment-status";
-import {
-	activePlanChangeOperationName,
-	performanceUpgradeUnavailableReason,
-} from "./plan-change.logic";
+import { activePlanChangeOperationName } from "./plan-change.logic";
 import {
 	type PlanChangeTarget,
 	planChangeBillingTerm,
@@ -38,12 +34,6 @@ export type ComputeSubscriptionManagementResult =
 	| { action: "disabled"; target: null; unavailableReason: string }
 	| { action: "enabled"; target: PlanChangeTarget; unavailableReason: null };
 
-export const COMPUTE_PLANS_UNAVAILABLE_REASON =
-	"Retry loading compute plans to manage this subscription.";
-
-const PROJECTION_UNAVAILABLE_REASON =
-	"Subscription changes will be available after this agent’s compute details finish syncing.";
-
 function isComputePlanSlug(value: string | null | undefined): value is ComputePlanSlug {
 	return value === COMPUTE_BASIC_SLUG || value === COMPUTE_PERFORMANCE_SLUG;
 }
@@ -73,60 +63,27 @@ function blocksManagement(entitlement: ComputeSubscriptionEntitlement, paid: boo
 	);
 }
 
-function projectedIncludedBasicEntitlement(
-	deployment: HostedDeployment,
-): ComputeSubscriptionEntitlement | null {
-	const subscription = deployment.commercial_display?.compute_subscription;
-	if (
-		deployment.current_plan_slug !== COMPUTE_BASIC_SLUG ||
-		!subscription ||
-		computeFundingSource(deployment.current_plan_slug, subscription) !== "included_basic"
-	) {
-		return null;
-	}
-	return {
-		deploymentId: deployment.resource.id,
-		planSlug: deployment.current_plan_slug,
-		fundingSource: subscription.funding_source,
-		priceCents: subscription.price_cents,
-		billingTermMonths: subscription.billing_term_months,
-		status: subscription.status,
-		paymentState: subscription.payment_state,
-		cancelAtPeriodEnd: subscription.cancel_at_period_end,
-		recoveryAction: subscription.recovery_action,
-		pendingPlanSlug: subscription.pending_plan_slug,
-	};
-}
-
 export function computeSubscriptionManagement({
-	entitlement: initialEntitlement,
+	entitlement,
 	deployment,
 	canCreateCloudAgents,
-	plansLoading,
-	plansError,
-	performancePlanAvailable,
 }: {
 	entitlement: ComputeSubscriptionEntitlement;
 	deployment?: HostedDeployment | null;
 	canCreateCloudAgents: boolean;
-	plansLoading: boolean;
-	plansError: boolean;
-	performancePlanAvailable: boolean;
 }): ComputeSubscriptionManagementResult {
-	if (initialEntitlement.isOrphan) {
+	if (entitlement.isOrphan) {
 		return { action: "hidden", target: null, unavailableReason: null };
 	}
-	const deploymentId = initialEntitlement.deploymentId?.trim();
-	const planSlug = isComputePlanSlug(initialEntitlement.planSlug)
-		? initialEntitlement.planSlug
-		: null;
+	const deploymentId = entitlement.deploymentId?.trim();
+	const planSlug = isComputePlanSlug(entitlement.planSlug) ? entitlement.planSlug : null;
 	if (!deploymentId || !planSlug) {
 		return { action: "hidden", target: null, unavailableReason: null };
 	}
 
-	const fundingSource = computeFundingSource(initialEntitlement.planSlug, {
-		funding_source: initialEntitlement.fundingSource,
-		price_cents: initialEntitlement.priceCents,
+	const fundingSource = computeFundingSource(entitlement.planSlug, {
+		funding_source: entitlement.fundingSource,
+		price_cents: entitlement.priceCents,
 	});
 	const includedBasic = fundingSource === "included_basic";
 	const paid = fundingSource === "stripe" || fundingSource === "wallet";
@@ -134,25 +91,9 @@ export function computeSubscriptionManagement({
 		return { action: "hidden", target: null, unavailableReason: null };
 	}
 	const projectedOperationName = deployment ? activePlanChangeOperationName(deployment) : null;
-	if (projectedOperationName === null && blocksManagement(initialEntitlement, paid)) {
+	if (includedBasic && projectedOperationName === null) {
 		return { action: "hidden", target: null, unavailableReason: null };
 	}
-
-	let entitlement = initialEntitlement;
-	let terminalFallback = false;
-	if (includedBasic) {
-		if (!deployment || deployment.resource.id.toLowerCase() !== deploymentId.toLowerCase()) {
-			return { action: "disabled", target: null, unavailableReason: PROJECTION_UNAVAILABLE_REASON };
-		}
-		terminalFallback =
-			deployment.commercial_display?.latest_funding_fact?.fact_kind === "funding_revoked";
-		const projectedEntitlement = projectedIncludedBasicEntitlement(deployment);
-		if (!projectedEntitlement) {
-			return { action: "disabled", target: null, unavailableReason: PROJECTION_UNAVAILABLE_REASON };
-		}
-		entitlement = projectedEntitlement;
-	}
-
 	if (projectedOperationName === null && blocksManagement(entitlement, paid)) {
 		return { action: "hidden", target: null, unavailableReason: null };
 	}
@@ -176,45 +117,15 @@ export function computeSubscriptionManagement({
 		allowCombinedChange: includedBasic,
 		projectedOperationName,
 	};
-	if (terminalFallback && projectedOperationName === null) {
-		return { action: "hidden", target, unavailableReason: null };
-	}
-
 	if (projectedOperationName) {
 		return { action: "enabled", target, unavailableReason: null };
-	}
-	if (includedBasic && plansError) {
-		return {
-			action: "disabled",
-			target: null,
-			unavailableReason: COMPUTE_PLANS_UNAVAILABLE_REASON,
-		};
 	}
 
 	const targetUnavailableReason = planChangeTargetUnavailableReason({
 		canCreateCloudAgents,
 		target,
 	});
-	const deploymentStatus = deployment
-		? deploymentStatusFromResource(deployment.resource.status)
-		: null;
-	const unavailableReason = includedBasic
-		? performanceUpgradeUnavailableReason({
-				plansLoading,
-				canCreateCloudAgents,
-				isIncludedBasic: true,
-				performancePlanAvailable,
-				pendingPlanSlug: null,
-				planChangeUnavailable: targetUnavailableReason,
-				deploymentStatusSupportsUpgrade: deploymentStatus
-					? isRunningStatus(deploymentStatus) || deploymentStatus.kind === "stopped"
-					: false,
-				upgradeAvailable: deployment?.upgrade_available ?? false,
-				upgradeEligibilityReason: deployment?.upgrade_eligibility.reason ?? null,
-			})
-		: targetUnavailableReason;
-
-	return unavailableReason
-		? { action: "disabled", target: null, unavailableReason }
+	return targetUnavailableReason
+		? { action: "disabled", target: null, unavailableReason: targetUnavailableReason }
 		: { action: "enabled", target, unavailableReason: null };
 }

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-management.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-management.ts
@@ -3,7 +3,11 @@ import type {
 	HostedComputeSubscription,
 	HostedDeployment,
 } from "@/hosted/billing/contracts";
-import { activePlanChangeOperationName } from "./plan-change.logic";
+import { deploymentStatusFromResource, isRunningStatus } from "@/hosted/deployment-status";
+import {
+	activePlanChangeOperationName,
+	performanceUpgradeUnavailableReason,
+} from "./plan-change.logic";
 import {
 	type PlanChangeTarget,
 	planChangeBillingTerm,
@@ -33,6 +37,9 @@ export type ComputeSubscriptionManagementResult =
 	| { action: "hidden"; target: PlanChangeTarget | null; unavailableReason: null }
 	| { action: "disabled"; target: null; unavailableReason: string }
 	| { action: "enabled"; target: PlanChangeTarget; unavailableReason: null };
+
+const UPGRADE_DETAILS_UNAVAILABLE_REASON =
+	"Upgrade availability will appear after this agent’s compute details finish syncing.";
 
 function isComputePlanSlug(value: string | null | undefined): value is ComputePlanSlug {
 	return value === COMPUTE_BASIC_SLUG || value === COMPUTE_PERFORMANCE_SLUG;
@@ -67,10 +74,14 @@ export function computeSubscriptionManagement({
 	entitlement,
 	deployment,
 	canCreateCloudAgents,
+	plansLoading,
+	performancePlanAvailable,
 }: {
 	entitlement: ComputeSubscriptionEntitlement;
 	deployment?: HostedDeployment | null;
 	canCreateCloudAgents: boolean;
+	plansLoading: boolean;
+	performancePlanAvailable: boolean;
 }): ComputeSubscriptionManagementResult {
 	if (entitlement.isOrphan) {
 		return { action: "hidden", target: null, unavailableReason: null };
@@ -91,9 +102,6 @@ export function computeSubscriptionManagement({
 		return { action: "hidden", target: null, unavailableReason: null };
 	}
 	const projectedOperationName = deployment ? activePlanChangeOperationName(deployment) : null;
-	if (includedBasic && projectedOperationName === null) {
-		return { action: "hidden", target: null, unavailableReason: null };
-	}
 	if (projectedOperationName === null && blocksManagement(entitlement, paid)) {
 		return { action: "hidden", target: null, unavailableReason: null };
 	}
@@ -125,6 +133,33 @@ export function computeSubscriptionManagement({
 		canCreateCloudAgents,
 		target,
 	});
+	if (includedBasic) {
+		if (!deployment || deployment.resource.id.toLowerCase() !== deploymentId.toLowerCase()) {
+			return {
+				action: "disabled",
+				target: null,
+				unavailableReason: UPGRADE_DETAILS_UNAVAILABLE_REASON,
+			};
+		}
+		const deploymentStatus = deploymentStatusFromResource(deployment.resource.status);
+		const unavailableReason = performanceUpgradeUnavailableReason({
+			plansLoading,
+			canCreateCloudAgents,
+			isIncludedBasic: true,
+			performancePlanAvailable,
+			pendingPlanSlug: isComputePlanSlug(entitlement.pendingPlanSlug)
+				? entitlement.pendingPlanSlug
+				: null,
+			planChangeUnavailable: targetUnavailableReason,
+			deploymentStatusSupportsUpgrade:
+				isRunningStatus(deploymentStatus) || deploymentStatus.kind === "stopped",
+			upgradeAvailable: deployment.upgrade_available,
+			upgradeEligibilityReason: deployment.upgrade_eligibility.reason,
+		});
+		return unavailableReason
+			? { action: "disabled", target: null, unavailableReason }
+			: { action: "enabled", target, unavailableReason: null };
+	}
 	return targetUnavailableReason
 		? { action: "disabled", target: null, unavailableReason: targetUnavailableReason }
 		: { action: "enabled", target, unavailableReason: null };

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -32,6 +32,7 @@ import {
 	isHistoricalAccountSubscription,
 	pendingComputePlanSlug,
 	pendingPlanScheduleCopy,
+	resolvePerformancePlan,
 } from "@/hosted/billing/subscription/subscription-utils";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { formatShortDate } from "@/lib/format";
@@ -60,8 +61,12 @@ function subscriptionManagement(
 	deployment: HostedDeployment | undefined,
 	{
 		canCreateCloudAgents,
+		plansLoading,
+		performancePlanAvailable,
 	}: {
 		canCreateCloudAgents: boolean;
+		plansLoading: boolean;
+		performancePlanAvailable: boolean;
 	},
 ): ComputeSubscriptionManagementResult {
 	return computeSubscriptionManagement({
@@ -80,6 +85,8 @@ function subscriptionManagement(
 		},
 		deployment,
 		canCreateCloudAgents,
+		plansLoading,
+		performancePlanAvailable,
 	});
 }
 
@@ -103,12 +110,12 @@ function SubscriptionRow({
 	subscription,
 	agentTile,
 	management,
-	onManage,
+	onPlanChange,
 }: {
 	subscription: ComputeSubscriptionListItem;
 	agentTile?: AgentTile;
 	management: ComputeSubscriptionManagementResult;
-	onManage: (subscription: ComputeSubscriptionListItem) => void;
+	onPlanChange: (subscription: ComputeSubscriptionListItem) => void;
 }) {
 	const lifecycle = computeSubscriptionLifecycle(subscription);
 	const recovery = computeSubscriptionRecoveryPresentation(subscription, {
@@ -158,7 +165,8 @@ function SubscriptionRow({
 		actions.some((candidate) => candidate.kind !== "start_new") || startNewHref !== null;
 	const fundingSource = computeFundingSource(subscription.plan_slug, subscription);
 	const managementReason =
-		actions.find((candidate) => candidate.kind === "manage")?.disabledReason ?? null;
+		actions.find((candidate) => candidate.kind === "upgrade" || candidate.kind === "manage")
+			?.disabledReason ?? null;
 	const view = computeSubscriptionCardView({
 		status: recovery.status,
 		planSlug: subscription.plan_slug,
@@ -214,7 +222,7 @@ function SubscriptionRow({
 								subscriptionId: subscription.subscription_id,
 								deploymentId: subscription.deployment_id ?? null,
 							}}
-							onManage={() => onManage(subscription)}
+							onPlanChange={() => onPlanChange(subscription)}
 							onStartNew={
 								startNewHref
 									? { kind: "link", href: startNewHref, label: "Open Agent settings" }
@@ -330,6 +338,8 @@ export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly Agen
 	);
 	const managementOptions = {
 		canCreateCloudAgents: hostedAccess.canCreateCloudAgents,
+		plansLoading: plans.isLoading,
+		performancePlanAvailable: Boolean(resolvePerformancePlan(plans.data)),
 	};
 	const selectedDeployment = selectedSubscription?.deployment_id
 		? deploymentsById.get(selectedSubscription.deployment_id.toLowerCase())
@@ -338,7 +348,7 @@ export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly Agen
 		? subscriptionManagement(selectedSubscription, selectedDeployment, managementOptions)
 		: null;
 
-	function manageSubscription(subscription: ComputeSubscriptionListItem) {
+	function openPlanChange(subscription: ComputeSubscriptionListItem) {
 		const deployment = subscription.deployment_id
 			? deploymentsById.get(subscription.deployment_id.toLowerCase())
 			: undefined;
@@ -409,7 +419,7 @@ export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly Agen
 												: undefined,
 											managementOptions,
 										)}
-										onManage={manageSubscription}
+										onPlanChange={openPlanChange}
 									/>
 								))}
 							</ul>

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -21,7 +21,6 @@ import {
 	computeSubscriptionPlanLabel,
 } from "@/hosted/billing/subscription/compute-subscription-card";
 import {
-	COMPUTE_PLANS_UNAVAILABLE_REASON,
 	type ComputeSubscriptionManagementResult,
 	computeSubscriptionManagement,
 } from "@/hosted/billing/subscription/compute-subscription-management";
@@ -33,7 +32,6 @@ import {
 	isHistoricalAccountSubscription,
 	pendingComputePlanSlug,
 	pendingPlanScheduleCopy,
-	resolvePerformancePlan,
 } from "@/hosted/billing/subscription/subscription-utils";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { formatShortDate } from "@/lib/format";
@@ -62,14 +60,8 @@ function subscriptionManagement(
 	deployment: HostedDeployment | undefined,
 	{
 		canCreateCloudAgents,
-		plansLoading,
-		plansError,
-		performancePlanAvailable,
 	}: {
 		canCreateCloudAgents: boolean;
-		plansLoading: boolean;
-		plansError: boolean;
-		performancePlanAvailable: boolean;
 	},
 ): ComputeSubscriptionManagementResult {
 	return computeSubscriptionManagement({
@@ -88,9 +80,6 @@ function subscriptionManagement(
 		},
 		deployment,
 		canCreateCloudAgents,
-		plansLoading,
-		plansError,
-		performancePlanAvailable,
 	});
 }
 
@@ -169,10 +158,7 @@ function SubscriptionRow({
 		actions.some((candidate) => candidate.kind !== "start_new") || startNewHref !== null;
 	const fundingSource = computeFundingSource(subscription.plan_slug, subscription);
 	const managementReason =
-		actions.find((candidate) => candidate.kind === "manage")?.disabledReason ===
-		COMPUTE_PLANS_UNAVAILABLE_REASON
-			? null
-			: (actions.find((candidate) => candidate.kind === "manage")?.disabledReason ?? null);
+		actions.find((candidate) => candidate.kind === "manage")?.disabledReason ?? null;
 	const view = computeSubscriptionCardView({
 		status: recovery.status,
 		planSlug: subscription.plan_slug,
@@ -336,7 +322,6 @@ export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly Agen
 		: orderedRows.filter((subscription) => !isHistoricalAccountSubscription(subscription));
 	const canLoadMore = subscriptions.hasNextPage && !subscriptions.isFetchNextPageError;
 	const historyControlVisible = endedRows.length > 0 || showHistory;
-	const blockingPlansError = shouldBlockQueryError(plans.error, plans.data) ? plans.error : null;
 	const deploymentsById = new Map(
 		(deployments.data ?? []).map((deployment) => [
 			deployment.resource.id.toLowerCase(),
@@ -345,9 +330,6 @@ export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly Agen
 	);
 	const managementOptions = {
 		canCreateCloudAgents: hostedAccess.canCreateCloudAgents,
-		plansLoading: plans.isLoading,
-		plansError: blockingPlansError !== null,
-		performancePlanAvailable: Boolean(resolvePerformancePlan(plans.data)),
 	};
 	const selectedDeployment = selectedSubscription?.deployment_id
 		? deploymentsById.get(selectedSubscription.deployment_id.toLowerCase())
@@ -355,17 +337,6 @@ export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly Agen
 	const selectedManagement = selectedSubscription
 		? subscriptionManagement(selectedSubscription, selectedDeployment, managementOptions)
 		: null;
-	const plansErrorBlocksVisibleIncluded =
-		blockingPlansError !== null &&
-		visibleRows.some((subscription) => {
-			const deployment = subscription.deployment_id
-				? deploymentsById.get(subscription.deployment_id.toLowerCase())
-				: undefined;
-			return (
-				subscriptionManagement(subscription, deployment, managementOptions).unavailableReason ===
-				COMPUTE_PLANS_UNAVAILABLE_REASON
-			);
-		});
 
 	function manageSubscription(subscription: ComputeSubscriptionListItem) {
 		const deployment = subscription.deployment_id
@@ -404,14 +375,6 @@ export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly Agen
 					/>
 				) : rows.length || subscriptions.hasNextPage ? (
 					<>
-						{plansErrorBlocksVisibleIncluded ? (
-							<ApiErrorPanel
-								normalizer={billingErrorNormalizer}
-								error={blockingPlansError}
-								onRetry={() => void plans.refetch()}
-								title="Couldn't load compute plans"
-							/>
-						) : null}
 						{historyControlVisible ? (
 							<div className="flex justify-end">
 								<Button


### PR DESCRIPTION
## Summary

- make stable Included Basic read-only with no Manage or Cancel actions
- use one equal-height vertical card layout and pin paid actions to the bottom
- remove obsolete Included Basic upgrade-management gating from both settings surfaces

## Verification

- isolated Docker Web suite: typecheck, full tests, OSS build
- focused subscription tests: 11 passed
- Biome: 8 changed files
- Hosted Playwright: account mixed paid/free cards and Agent Settings, desktop and 320px
- browser geometry: first-row cards equal height, paid actions fixed to the bottom, Free has zero buttons, no horizontal overflow
- git diff --check