### PR TITLE
fix(runtime): clean retired desired state

### DIFF
--- a/backend/alembic/versions/e5c8a1d7f2b9_runtime_state_retirement_cleanup.py
+++ b/backend/alembic/versions/e5c8a1d7f2b9_runtime_state_retirement_cleanup.py
@@ -1,0 +1,85 @@
+"""Add durable retired runtime-state cleanup receipts.
+
+Revision ID: e5c8a1d7f2b9
+Revises: b7e1c4a9d2f6
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "e5c8a1d7f2b9"
+down_revision: str | Sequence[str] | None = "b7e1c4a9d2f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "v2_runtime_environment_fences",
+        sa.Column("runtime_state_cleanup_id", sa.String(length=200), nullable=True),
+    )
+    op.add_column(
+        "v2_runtime_environment_fences",
+        sa.Column(
+            "runtime_state_cleanup_receipt",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+    op.create_check_constraint(
+        "ck_v2_runtime_environment_fences_runtime_state_cleanup",
+        "v2_runtime_environment_fences",
+        "(runtime_state_cleanup_id IS NULL AND runtime_state_cleanup_receipt IS NULL) "
+        "OR (state = 'retired' AND runtime_state_cleanup_id IS NOT NULL "
+        "AND runtime_state_cleanup_receipt IS NOT NULL "
+        "AND jsonb_typeof(runtime_state_cleanup_receipt) = 'object')",
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE FUNCTION enforce_v2_runtime_state_cleanup_immutability()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF OLD.runtime_state_cleanup_id IS NOT NULL
+                   AND (OLD.runtime_state_cleanup_id
+                            IS DISTINCT FROM NEW.runtime_state_cleanup_id
+                        OR OLD.runtime_state_cleanup_receipt
+                            IS DISTINCT FROM NEW.runtime_state_cleanup_receipt) THEN
+                    RAISE EXCEPTION
+                        'v2 runtime state cleanup identity and receipt are immutable';
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+
+            CREATE TRIGGER trg_v2_runtime_state_cleanup_immutability
+            BEFORE UPDATE ON v2_runtime_environment_fences
+            FOR EACH ROW EXECUTE FUNCTION enforce_v2_runtime_state_cleanup_immutability();
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            DROP TRIGGER IF EXISTS trg_v2_runtime_state_cleanup_immutability
+                ON v2_runtime_environment_fences;
+            DROP FUNCTION IF EXISTS enforce_v2_runtime_state_cleanup_immutability();
+            """
+        )
+    )
+    op.drop_constraint(
+        "ck_v2_runtime_environment_fences_runtime_state_cleanup",
+        "v2_runtime_environment_fences",
+        type_="check",
+    )
+    op.drop_column("v2_runtime_environment_fences", "runtime_state_cleanup_receipt")
+    op.drop_column("v2_runtime_environment_fences", "runtime_state_cleanup_id")

--- a/backend/app/models/runtime_observation.py
+++ b/backend/app/models/runtime_observation.py
@@ -70,6 +70,13 @@ class V2RuntimeEnvironmentFence(Base, TimestampMixin):
             "AND final_session_high_waters IS NOT NULL)",
             name="ck_v2_runtime_environment_fences_retirement",
         ),
+        CheckConstraint(
+            "(runtime_state_cleanup_id IS NULL AND runtime_state_cleanup_receipt IS NULL) "
+            "OR (state = 'retired' AND runtime_state_cleanup_id IS NOT NULL "
+            "AND runtime_state_cleanup_receipt IS NOT NULL "
+            "AND jsonb_typeof(runtime_state_cleanup_receipt) = 'object')",
+            name="ck_v2_runtime_environment_fences_runtime_state_cleanup",
+        ),
     )
 
     environment_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
@@ -107,6 +114,10 @@ class V2RuntimeEnvironmentFence(Base, TimestampMixin):
     final_cursor: Mapped[str | None] = mapped_column(String(2000))
     final_stream_position: Mapped[int | None] = mapped_column(BigInteger)
     final_session_high_waters: Mapped[dict[str, int] | None] = mapped_column(
+        JSONB(none_as_null=True)
+    )
+    runtime_state_cleanup_id: Mapped[str | None] = mapped_column(String(200))
+    runtime_state_cleanup_receipt: Mapped[JsonValue | None] = mapped_column(
         JSONB(none_as_null=True)
     )
 

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -186,6 +186,8 @@ from app.services.runtime_manifest_resources import (
     enabled_runtime_manifest_skill_ids,
     lock_runtime_manifest_skill_reservations,
 )
+from app.services.runtime_observation import RuntimeObservationProtocolError
+from app.services.runtime_state_cleanup import lock_runtime_state_write_fence
 from app.services.sync_events import (
     queue_environment_runtime_manifest_changed,
     queue_provider_runtime_manifest_changed,
@@ -1936,6 +1938,16 @@ async def _admin_upsert_runtime_state(
         target_clerk_id=body.target_clerk_id,
     )
     await lock_ai_provider_owner(db, target_user_id)
+    try:
+        await lock_runtime_state_write_fence(
+            db,
+            environment_id=environment_id,
+            owner_id=target_user_id,
+            deployment_id=body.deployment_id,
+        )
+    except RuntimeObservationProtocolError as exc:
+        await db.rollback()
+        raise HTTPException(exc.status_code, exc.detail()) from exc
     env = (
         await db.execute(
             select(AgentEnvironment)

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -90,6 +90,7 @@ from app.services.runtime_manifest_resources import (
     enabled_runtime_manifest_skill_ids,
     lock_runtime_manifest_skill_reservations,
 )
+from app.services.runtime_observation import RuntimeObservationProtocolError
 from app.services.runtime_source import (
     RuntimeSourceError,
     RuntimeSourceNotFoundError,
@@ -98,6 +99,7 @@ from app.services.runtime_source import (
     render_runtime_source,
     vault_key_identity,
 )
+from app.services.runtime_state_cleanup import lock_runtime_state_write_fence
 from app.services.sync_events import (
     queue_environment_runtime_manifest_changed,
     queue_runtime_manifest_changed,
@@ -895,6 +897,29 @@ async def platform_upsert_runtime_state(
     )
     if replay is not None:
         return _replay_response(replay)
+    try:
+        await lock_runtime_state_write_fence(
+            db,
+            environment_id=agent_id,
+            owner_id=owner.id,
+            deployment_id=body.deployment_id,
+        )
+    except RuntimeObservationProtocolError as exc:
+        await _reject(
+            db,
+            status_code=exc.status_code,
+            detail=exc.detail(),
+            result=exc.code,
+            owner=body.owner,
+            owner_user_id=owner.id,
+            resource_type="hosted_runtime_state",
+            resource_id=str(agent_id),
+            action=action,
+            request=request,
+            idempotency_key=idempotency_key,
+            environment_id=agent_id,
+        )
+        raise AssertionError("unreachable")
     agent = await _load_owned_agent(
         db,
         agent_id=agent_id,

--- a/backend/app/routes/runtime_observation_v2.py
+++ b/backend/app/routes/runtime_observation_v2.py
@@ -35,6 +35,8 @@ from app.schemas.runtime_observation import (
     RuntimeObservationIngestResponse,
     RuntimeObservationReadRequest,
     RuntimeObservationReadResponse,
+    RuntimeStateCleanupReceipt,
+    RuntimeStateCleanupRequest,
 )
 from app.services.api_key import mint_api_key
 from app.services.audit import record_control_plane_audit
@@ -44,6 +46,10 @@ from app.services.platform_contract import (
     platform_request_hash,
     read_platform_replay,
     store_platform_response,
+)
+from app.services.platform_workload_auth import (
+    PlatformMutationAuth,
+    require_platform_mutation_auth,
 )
 from app.services.principal_lifecycle import (
     PrincipalIdentityConflictError,
@@ -64,6 +70,7 @@ from app.services.runtime_observation import (
     reset_runtime_observation_consumer,
     retire_runtime_environment,
 )
+from app.services.runtime_state_cleanup import cleanup_retired_runtime_state
 
 router = APIRouter(prefix="/v2/runtime", tags=["v2-runtime-observations"])
 _JSON_OBJECT_ADAPTER: TypeAdapter[dict[str, JsonValue]] = TypeAdapter(dict[str, JsonValue])
@@ -322,6 +329,42 @@ def _record_cursor_expiry_audit(
     )
 
 
+def _record_runtime_state_cleanup_audit(
+    db: AsyncSession,
+    *,
+    auth: PlatformMutationAuth,
+    action: str,
+    environment_id: UUID,
+    body: RuntimeStateCleanupRequest,
+    outcome: str,
+    runtime_state_deleted: bool | None = None,
+) -> None:
+    details: dict[str, Any] = {
+        "auth_method": "workload_token" if auth.kind == "workload" else "x_admin_key",
+        "workload_client_id": auth.client_id,
+        "credential_id": str(auth.credential_id) if auth.credential_id is not None else None,
+        "token_jti": auth.token_jti,
+        "environment_id": str(environment_id),
+        "deployment_id": body.expected_deployment_binding,
+        "retirement_id": body.retirement_id,
+        "cleanup_id": body.cleanup_id,
+        "outcome": outcome,
+    }
+    if runtime_state_deleted is not None:
+        details["runtime_state_deleted"] = runtime_state_deleted
+    record_control_plane_audit(
+        db,
+        actor_type="platform",
+        target_user_id=None,
+        source="api.v2.runtime",
+        action=action,
+        resource_type="hosted_runtime_state",
+        resource_id=str(environment_id),
+        environment_id=None,
+        details=details,
+    )
+
+
 def _raise_protocol_error(exc: RuntimeObservationProtocolError) -> NoReturn:
     raise HTTPException(exc.status_code, exc.detail()) from exc
 
@@ -575,6 +618,72 @@ async def retire_runtime_environment_endpoint(
                 deployment_id=body.expected_deployment_binding,
                 outcome=exc.code,
                 details={"retirement_id": body.retirement_id},
+            )
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+        _raise_protocol_error(exc)
+    except Exception:
+        await db.rollback()
+        raise
+    return _CanonicalJSONResponse(status_code=status.HTTP_200_OK, content=response_body)
+
+
+@router.post(
+    "/environments/{environment_id}/runtime-state/cleanup",
+    response_model=RuntimeStateCleanupReceipt,
+)
+async def cleanup_retired_runtime_state_endpoint(
+    environment_id: UUID,
+    body: RuntimeStateCleanupRequest,
+    idempotency_key: IdempotencyKey,
+    auth: PlatformMutationAuth = Depends(
+        require_platform_mutation_auth("platform:runtime-environments:retire")
+    ),
+    db: AsyncSession = Depends(get_session),
+) -> JSONResponse:
+    try:
+        if body.environment_reference != environment_id:
+            raise RuntimeObservationProtocolError(
+                status.HTTP_409_CONFLICT,
+                "runtime_state_cleanup_environment_conflict",
+                "path and body environment references do not match",
+            )
+        if idempotency_key != body.cleanup_id:
+            raise RuntimeObservationProtocolError(
+                status.HTTP_409_CONFLICT,
+                "runtime_state_cleanup_idempotency_conflict",
+                "idempotency key and cleanup identity do not match",
+            )
+        receipt, receipt_created, runtime_state_deleted = await cleanup_retired_runtime_state(
+            db,
+            environment_id=environment_id,
+            expected_deployment_binding=body.expected_deployment_binding,
+            retirement_id=body.retirement_id,
+            cleanup_id=body.cleanup_id,
+        )
+        response_body = _canonical_response_body(receipt)
+        _record_runtime_state_cleanup_audit(
+            db,
+            auth=auth,
+            action=("runtime_state.cleanup" if receipt_created else "runtime_state.cleanup_replay"),
+            environment_id=environment_id,
+            body=body,
+            outcome="cleaned" if receipt_created else "replayed",
+            runtime_state_deleted=runtime_state_deleted,
+        )
+        await db.commit()
+    except RuntimeObservationProtocolError as exc:
+        await db.rollback()
+        try:
+            _record_runtime_state_cleanup_audit(
+                db,
+                auth=auth,
+                action="runtime_state.cleanup",
+                environment_id=environment_id,
+                body=body,
+                outcome=exc.code,
             )
             await db.commit()
         except Exception:

--- a/backend/app/schemas/runtime_observation.py
+++ b/backend/app/schemas/runtime_observation.py
@@ -129,6 +129,17 @@ class RuntimeEnvironmentRetireRequest(RuntimeObservationRequestModel):
     retirement_id: str = Field(alias="retirementId", min_length=1, max_length=200)
 
 
+class RuntimeStateCleanupRequest(RuntimeObservationRequestModel):
+    environment_reference: UUID = Field(alias="environmentReference")
+    expected_deployment_binding: str = Field(
+        alias="expectedDeploymentBinding",
+        min_length=1,
+        max_length=200,
+    )
+    retirement_id: str = Field(alias="retirementId", min_length=1, max_length=200)
+    cleanup_id: str = Field(alias="cleanupId", min_length=1, max_length=200)
+
+
 class RuntimeObservationConsumerRequest(RuntimeObservationRequestModel):
     pass
 
@@ -246,6 +257,16 @@ class RuntimeEnvironmentRetirementReceipt(RuntimeObservationResponseModel):
     final_session_high_water_marks: list[RuntimeSessionHighWaterMark] = Field(
         alias="finalSessionHighWaterMarks"
     )
+
+
+class RuntimeStateCleanupReceipt(RuntimeObservationResponseModel):
+    schema_version: Literal["clawdi.runtimeStateCleanupReceipt.v1"] = Field(alias="schemaVersion")
+    environment_reference: UUID = Field(alias="environmentReference")
+    expected_deployment_binding: str = Field(alias="expectedDeploymentBinding")
+    retirement_id: str = Field(alias="retirementId")
+    cleanup_id: str = Field(alias="cleanupId")
+    runtime_state_status: Literal["absent"] = Field(alias="runtimeStateStatus")
+    cleaned_at: datetime = Field(alias="cleanedAt")
 
 
 class RuntimeSessionHighWaterMark(RuntimeObservationResponseModel):

--- a/backend/app/services/runtime_state_cleanup.py
+++ b/backend/app/services/runtime_state_cleanup.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.hosted_runtime import HostedRuntimeState
+from app.models.runtime_observation import (
+    RUNTIME_ENVIRONMENT_ACTIVE,
+    RUNTIME_ENVIRONMENT_RETIRED,
+    V2RuntimeEnvironmentFence,
+)
+from app.models.user import User
+from app.schemas.runtime_observation import RuntimeStateCleanupReceipt
+from app.services.ai_provider_credentials import release_runtime_oauth_claims
+from app.services.runtime_observation import RuntimeObservationProtocolError
+
+
+async def lock_runtime_state_write_fence(
+    db: AsyncSession,
+    *,
+    environment_id: UUID,
+    owner_id: UUID,
+    deployment_id: str,
+) -> None:
+    """Fence v2 desired-state writes while preserving unfenced v1 behavior."""
+
+    fence = await db.scalar(
+        select(V2RuntimeEnvironmentFence)
+        .where(V2RuntimeEnvironmentFence.environment_id == environment_id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
+    if fence is None:
+        return
+    if fence.owner_id != owner_id or fence.deployment_id != deployment_id:
+        raise RuntimeObservationProtocolError(
+            409,
+            "runtime_environment_binding_conflict",
+            "runtime environment binding does not match desired state",
+        )
+    if fence.state != RUNTIME_ENVIRONMENT_ACTIVE:
+        raise RuntimeObservationProtocolError(
+            409,
+            "runtime_environment_retired",
+            "runtime environment is retired",
+        )
+
+
+async def cleanup_retired_runtime_state(
+    db: AsyncSession,
+    *,
+    environment_id: UUID,
+    expected_deployment_binding: str,
+    retirement_id: str,
+    cleanup_id: str,
+    cleaned_at: datetime | None = None,
+) -> tuple[RuntimeStateCleanupReceipt, bool, bool]:
+    """Delete the exact retired desired state and persist its permanent receipt."""
+
+    observed = await db.get(V2RuntimeEnvironmentFence, environment_id)
+    if observed is None:
+        raise _conflict(
+            "runtime_environment_fence_missing",
+            "runtime environment fence does not exist",
+        )
+
+    # User is the established parent lock for runtime state and OAuth claims.
+    # It can be absent after principal cleanup; its dependent state is then
+    # already absent through existing FK/lifecycle cleanup.
+    owner_exists = (
+        await db.scalar(select(User.id).where(User.id == observed.owner_id).with_for_update())
+        is not None
+    )
+    fence = await db.scalar(
+        select(V2RuntimeEnvironmentFence)
+        .where(V2RuntimeEnvironmentFence.environment_id == environment_id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
+    if fence is None:
+        raise _conflict(
+            "runtime_environment_fence_missing",
+            "runtime environment fence does not exist",
+        )
+    _validate_retirement_identity(
+        fence,
+        expected_deployment_binding=expected_deployment_binding,
+        retirement_id=retirement_id,
+    )
+
+    if fence.runtime_state_cleanup_id is not None:
+        if fence.runtime_state_cleanup_id != cleanup_id:
+            raise _conflict(
+                "runtime_state_cleanup_conflict",
+                "retired runtime state was cleaned by another obligation",
+            )
+        receipt = validate_runtime_state_cleanup_receipt(fence, cleanup_id=cleanup_id)
+        return receipt, False, False
+
+    runtime_state = await db.scalar(
+        select(HostedRuntimeState)
+        .where(HostedRuntimeState.environment_id == environment_id)
+        .with_for_update()
+    )
+    runtime_state_deleted = runtime_state is not None
+    if runtime_state is not None:
+        if runtime_state.deployment_id != expected_deployment_binding:
+            raise _conflict(
+                "runtime_state_deployment_binding_conflict",
+                "hosted runtime state deployment binding does not match",
+            )
+        await db.delete(runtime_state)
+    if owner_exists:
+        await release_runtime_oauth_claims(
+            db,
+            owner_user_id=fence.owner_id,
+            environment_id=environment_id,
+        )
+
+    receipt = RuntimeStateCleanupReceipt(
+        schemaVersion="clawdi.runtimeStateCleanupReceipt.v1",
+        environmentReference=environment_id,
+        expectedDeploymentBinding=expected_deployment_binding,
+        retirementId=retirement_id,
+        cleanupId=cleanup_id,
+        runtimeStateStatus="absent",
+        cleanedAt=cleaned_at or datetime.now(UTC),
+    )
+    fence.runtime_state_cleanup_id = cleanup_id
+    fence.runtime_state_cleanup_receipt = receipt.model_dump(mode="json", by_alias=True)
+    await db.flush()
+    return receipt, True, runtime_state_deleted
+
+
+def _validate_retirement_identity(
+    fence: V2RuntimeEnvironmentFence,
+    *,
+    expected_deployment_binding: str,
+    retirement_id: str,
+) -> None:
+    if fence.state != RUNTIME_ENVIRONMENT_RETIRED:
+        raise _conflict(
+            "runtime_environment_not_retired",
+            "runtime environment is not retired",
+        )
+    if fence.deployment_id != expected_deployment_binding or fence.retirement_id != retirement_id:
+        raise _conflict(
+            "runtime_environment_retirement_conflict",
+            "runtime environment retirement identity does not match",
+        )
+
+
+def validate_runtime_state_cleanup_receipt(
+    fence: V2RuntimeEnvironmentFence,
+    *,
+    cleanup_id: str,
+) -> RuntimeStateCleanupReceipt:
+    try:
+        receipt = RuntimeStateCleanupReceipt.model_validate(fence.runtime_state_cleanup_receipt)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("persisted runtime state cleanup receipt is invalid") from exc
+    if receipt.cleaned_at.tzinfo is None or receipt.cleaned_at.utcoffset() is None:
+        raise RuntimeError("persisted runtime state cleanup receipt is invalid")
+    if (
+        receipt.environment_reference != fence.environment_id
+        or receipt.expected_deployment_binding != fence.deployment_id
+        or receipt.retirement_id != fence.retirement_id
+        or receipt.cleanup_id != cleanup_id
+    ):
+        raise RuntimeError("persisted runtime state cleanup receipt identity is invalid")
+    return receipt
+
+
+def _conflict(code: str, message: str) -> RuntimeObservationProtocolError:
+    return RuntimeObservationProtocolError(409, code, message)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -275,6 +275,7 @@ strict = [
     "app/services/runtime_observation.py",
     "app/services/runtime_observation_retention_worker.py",
     "app/services/runtime_source.py",
+    "app/services/runtime_state_cleanup.py",
     "app/services/safe_public_http.py",
     "app/services/secret_detection.py",
     "app/services/session_content.py",

--- a/backend/tests/test_platform_endpoints.py
+++ b/backend/tests/test_platform_endpoints.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
 import uuid
@@ -462,6 +463,118 @@ async def test_platform_clerk_owner_full_lifecycle_and_audit(
         assert event.details["credential_id"] is None
         assert event.details["token_jti"] is None
         assert all(secret not in str(event.details) for secret in _TEST_SECRET_VALUES.values())
+
+
+@pytest.mark.committed_db
+@pytest.mark.asyncio
+async def test_retirement_fences_late_runtime_state_writes_and_old_replay(
+    platform_client,
+    engine,
+    db_session,
+    seed_user,
+):
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from app.services.runtime_observation import (
+        provision_runtime_environment_fence,
+        retire_runtime_environment,
+    )
+    from app.services.runtime_state_cleanup import cleanup_retired_runtime_state
+
+    owner = _clerk_owner(seed_user)
+    agent = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"retired-write-{uuid.uuid4().hex}",
+        machine_name="retired-write-agent",
+        agent_type="openclaw",
+        os="linux",
+    )
+    provider_id = CANONICAL_CODEX_TOOL_PROVIDER_ID
+    await ensure_canonical_codex_tool_provider(db_session, seed_user)
+    await db_session.commit()
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def _fresh_session():
+        async with session_factory() as session:
+            yield session
+
+    previous_session_override = app.dependency_overrides[get_session]
+    app.dependency_overrides[get_session] = _fresh_session
+    try:
+        client = platform_client
+        body = _runtime_body(owner, agent.id, provider_id=provider_id)
+        initial_headers = _headers("retired-write-initial")
+        initial = await client.put(
+            f"/v1/platform/agents/{agent.id}/runtime-state",
+            headers=initial_headers,
+            json=body,
+        )
+        assert initial.status_code == 200, initial.text
+
+        deployment_id = str(body["deployment_id"])
+        async with session_factory() as setup_session:
+            await provision_runtime_environment_fence(
+                setup_session,
+                environment_id=agent.id,
+                owner_id=seed_user.id,
+                deployment_id=deployment_id,
+            )
+            await setup_session.commit()
+
+        retirement_id = f"retirement-{agent.id}"
+        async with session_factory() as retirement_session:
+            await retire_runtime_environment(
+                retirement_session,
+                environment_id=agent.id,
+                expected_deployment_id=deployment_id,
+                retirement_id=retirement_id,
+                owner_id=seed_user.id,
+            )
+            late_body = {**body, "generation": 2}
+            late_put = asyncio.create_task(
+                client.put(
+                    f"/v1/platform/agents/{agent.id}/runtime-state",
+                    headers=_headers("retired-write-late"),
+                    json=late_body,
+                )
+            )
+            await asyncio.sleep(0.05)
+            assert not late_put.done()
+            await retirement_session.commit()
+            late = await asyncio.wait_for(late_put, timeout=5)
+
+        assert late.status_code == 409, late.text
+        assert late.json()["detail"]["code"] == "runtime_environment_retired"
+        async with session_factory() as cleanup_session:
+            await cleanup_retired_runtime_state(
+                cleanup_session,
+                environment_id=agent.id,
+                expected_deployment_binding=deployment_id,
+                retirement_id=retirement_id,
+                cleanup_id=f"cleanup-{agent.id}",
+            )
+            await cleanup_session.commit()
+
+        old_replay = await client.put(
+            f"/v1/platform/agents/{agent.id}/runtime-state",
+            headers=initial_headers,
+            json=body,
+        )
+        assert old_replay.status_code == 200, old_replay.text
+        async with session_factory() as assertion_session:
+            assert await assertion_session.get(HostedRuntimeState, agent.id) is None
+
+        admin_body = {key: value for key, value in body.items() if key != "owner"}
+        admin = await client.put(
+            f"/v1/admin/agents/{agent.id}/runtime-state",
+            headers=_ADMIN_AUTH,
+            json=admin_body,
+        )
+        assert admin.status_code == 409, admin.text
+        assert admin.json()["detail"]["code"] == "runtime_environment_retired"
+    finally:
+        app.dependency_overrides[get_session] = previous_session_override
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_platform_workload_oauth.py
+++ b/backend/tests/test_platform_workload_oauth.py
@@ -22,6 +22,7 @@ from app.main import app
 from app.models.ai_provider import AiProviderAuthPayload
 from app.models.api_key import RUNTIME_DEPLOYMENT_KEY_SCOPES, ApiKey
 from app.models.audit import ControlPlaneAuditEvent
+from app.models.hosted_runtime import HostedRuntimeState
 from app.models.platform_workload_auth import (
     PLATFORM_WORKLOAD_CLIENT_ACTIVE,
     PLATFORM_WORKLOAD_CLIENT_DISABLED,
@@ -45,6 +46,7 @@ from app.services.platform_workload_auth import (
     canonical_platform_workload_token_endpoint,
     get_platform_workload_key_resolver,
 )
+from app.services.runtime_observation import retire_runtime_environment
 from app.services.vault_crypto import encrypt
 
 _ADMIN_KEY = "test-platform-admin-secret"
@@ -1158,6 +1160,167 @@ async def test_platform_agent_archive_preserves_runtime_oauth_claim(
     await db_session.refresh(payload)
     assert payload.consumer_environment_id == agent_id
     assert payload.consumer_runtime == "openclaw"
+
+
+@pytest.mark.asyncio
+async def test_retired_runtime_state_cleanup_works_for_archived_agent(
+    workload_harness,
+    db_session,
+    seed_user,
+):
+    from tests.conftest import create_env_with_project, create_test_hosted_runtime_state
+
+    environment = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"cleanup-{uuid.uuid4().hex}",
+        machine_name="cleanup-archived-agent",
+        agent_type="openclaw",
+        os="linux",
+    )
+    state = await create_test_hosted_runtime_state(
+        db_session,
+        environment,
+        runtime_name="openclaw",
+    )
+    encrypted, nonce = encrypt('{"kind":"cleanup-test"}')
+    payload = AiProviderAuthPayload(
+        owner_user_id=seed_user.id,
+        provider_id=f"cleanup-{uuid.uuid4().hex}",
+        auth_profile="default",
+        kind="agent_profile",
+        source="test",
+        encrypted_payload=encrypted,
+        nonce=nonce,
+        consumer_environment_id=environment.id,
+        consumer_runtime="openclaw",
+    )
+    db_session.add(payload)
+    retirement_id = f"retirement-{environment.id}"
+    await retire_runtime_environment(
+        db_session,
+        environment_id=environment.id,
+        expected_deployment_id=state.deployment_id,
+        retirement_id=retirement_id,
+        owner_id=seed_user.id,
+    )
+    environment.archived_at = datetime.now(UTC)
+    await db_session.commit()
+
+    token = await _access_token(
+        workload_harness,
+        "platform:runtime-environments:retire",
+    )
+    cleanup_id = f"cleanup-{environment.id}"
+    response = await workload_harness.client.post(
+        f"/v2/runtime/environments/{environment.id}/runtime-state/cleanup",
+        headers=_workload_headers(token, cleanup_id),
+        json={
+            "environmentReference": str(environment.id),
+            "expectedDeploymentBinding": state.deployment_id,
+            "retirementId": retirement_id,
+            "cleanupId": cleanup_id,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "schemaVersion": "clawdi.runtimeStateCleanupReceipt.v1",
+        "environmentReference": str(environment.id),
+        "expectedDeploymentBinding": state.deployment_id,
+        "retirementId": retirement_id,
+        "cleanupId": cleanup_id,
+        "runtimeStateStatus": "absent",
+        "cleanedAt": response.json()["cleanedAt"],
+    }
+    assert await db_session.get(HostedRuntimeState, environment.id) is None
+    await db_session.refresh(payload)
+    assert payload.consumer_environment_id is None
+    assert payload.consumer_runtime is None
+
+
+@pytest.mark.asyncio
+async def test_retired_runtime_state_cleanup_replays_absence_and_rejects_conflicts(
+    workload_harness,
+    db_session,
+    seed_user,
+):
+    from app.services.runtime_observation import provision_runtime_environment_fence
+    from tests.conftest import create_env_with_project
+
+    environment = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"cleanup-absent-{uuid.uuid4().hex}",
+        machine_name="cleanup-absent-agent",
+        agent_type="openclaw",
+        os="linux",
+    )
+    deployment_id = f"deployment-{environment.id}"
+    retirement_id = f"retirement-{environment.id}"
+    await provision_runtime_environment_fence(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=deployment_id,
+    )
+    await retire_runtime_environment(
+        db_session,
+        environment_id=environment.id,
+        expected_deployment_id=deployment_id,
+        retirement_id=retirement_id,
+        owner_id=seed_user.id,
+    )
+    await db_session.commit()
+
+    token = await _access_token(
+        workload_harness,
+        "platform:runtime-environments:retire",
+    )
+    path = f"/v2/runtime/environments/{environment.id}/runtime-state/cleanup"
+    body = {
+        "environmentReference": str(environment.id),
+        "expectedDeploymentBinding": deployment_id,
+        "retirementId": retirement_id,
+        "cleanupId": f"cleanup-{environment.id}",
+    }
+    first = await workload_harness.client.post(
+        path,
+        headers=_workload_headers(token, str(body["cleanupId"])),
+        json=body,
+    )
+    replay = await workload_harness.client.post(
+        path,
+        headers=_workload_headers(token, str(body["cleanupId"])),
+        json=body,
+    )
+    conflict = await workload_harness.client.post(
+        path,
+        headers=_workload_headers(token, f"different-{body['environmentReference']}"),
+        json={**body, "cleanupId": f"different-{body['environmentReference']}"},
+    )
+    path_conflict = await workload_harness.client.post(
+        path,
+        headers=_workload_headers(token, str(body["cleanupId"])),
+        json={**body, "environmentReference": str(uuid.uuid4())},
+    )
+    header_conflict = await workload_harness.client.post(
+        path,
+        headers=_workload_headers(token, f"different-{body['environmentReference']}"),
+        json=body,
+    )
+
+    assert first.status_code == replay.status_code == 200
+    assert first.content == replay.content
+    assert first.json()["runtimeStateStatus"] == "absent"
+    assert conflict.status_code == 409
+    assert conflict.json()["detail"]["code"] == "runtime_state_cleanup_conflict"
+    assert path_conflict.status_code == 409
+    assert path_conflict.json()["detail"]["code"] == "runtime_state_cleanup_environment_conflict"
+    assert header_conflict.status_code == 409
+    assert header_conflict.json()["detail"]["code"] == (
+        "runtime_state_cleanup_idempotency_conflict"
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime_state_cleanup.py
+++ b/backend/tests/test_runtime_state_cleanup.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.models.runtime_observation import V2RuntimeEnvironmentFence
+from app.services.runtime_state_cleanup import validate_runtime_state_cleanup_receipt
+
+
+def test_persisted_runtime_state_cleanup_receipt_fails_closed() -> None:
+    environment_id = uuid.uuid4()
+    cleanup_id = "cleanup-receipt-validation"
+    fence = V2RuntimeEnvironmentFence(
+        environment_id=environment_id,
+        owner_id=uuid.uuid4(),
+        deployment_id="deployment-receipt-validation",
+        state="retired",
+        retirement_id="retirement-receipt-validation",
+        runtime_state_cleanup_id=cleanup_id,
+        runtime_state_cleanup_receipt={
+            "schemaVersion": "wrong",
+            "environmentReference": str(environment_id),
+            "expectedDeploymentBinding": "deployment-receipt-validation",
+            "retirementId": "retirement-receipt-validation",
+            "cleanupId": cleanup_id,
+            "runtimeStateStatus": "already_absent",
+            "cleanedAt": "not-a-timestamp",
+        },
+    )
+    with pytest.raises(RuntimeError, match="receipt is invalid"):
+        validate_runtime_state_cleanup_receipt(fence, cleanup_id=cleanup_id)
+
+    fence.runtime_state_cleanup_receipt = {
+        "schemaVersion": "clawdi.runtimeStateCleanupReceipt.v1",
+        "environmentReference": str(environment_id),
+        "expectedDeploymentBinding": fence.deployment_id,
+        "retirementId": fence.retirement_id,
+        "cleanupId": cleanup_id,
+        "runtimeStateStatus": "absent",
+        "cleanedAt": "2026-08-13T00:00:00",
+    }
+    with pytest.raises(RuntimeError, match="receipt is invalid"):
+        validate_runtime_state_cleanup_receipt(fence, cleanup_id=cleanup_id)
+
+    fence.runtime_state_cleanup_receipt = {
+        "schemaVersion": "clawdi.runtimeStateCleanupReceipt.v1",
+        "environmentReference": str(uuid.uuid4()),
+        "expectedDeploymentBinding": fence.deployment_id,
+        "retirementId": fence.retirement_id,
+        "cleanupId": cleanup_id,
+        "runtimeStateStatus": "absent",
+        "cleanedAt": "2026-08-13T00:00:00Z",
+    }
+    with pytest.raises(RuntimeError, match="receipt identity is invalid"):
+        validate_runtime_state_cleanup_receipt(fence, cleanup_id=cleanup_id)

--- a/backend/tests/test_runtime_state_cleanup_migration.py
+++ b/backend/tests/test_runtime_state_cleanup_migration.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import URL, make_url
+from sqlalchemy.exc import DBAPIError
+
+from app.core.config import settings
+
+PREVIOUS_HEAD_REVISION = "b7e1c4a9d2f6"
+CLEANUP_REVISION = "e5c8a1d7f2b9"
+BACKEND_DIR = Path(__file__).parents[1]
+
+
+def _sync_url(url: URL, *, database: str) -> URL:
+    return url.set(drivername="postgresql+psycopg2", database=database)
+
+
+def _run_alembic(database_url: URL, *args: str) -> None:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url.render_as_string(hide_password=False)
+    subprocess.run(
+        [str(Path(sys.executable).with_name("alembic")), *args],
+        cwd=BACKEND_DIR,
+        env=env,
+        check=True,
+    )
+
+
+def test_runtime_state_cleanup_migration_extends_retired_fence_once() -> None:
+    source_url = make_url(os.getenv("DATABASE_URL", settings.database_url))
+    database_name = f"clawdi_runtime_cleanup_{uuid.uuid4().hex}"
+    admin_engine = create_engine(
+        _sync_url(source_url, database="postgres"),
+        isolation_level="AUTOCOMMIT",
+    )
+    database_url = source_url.set(database=database_name)
+    database_engine = create_engine(_sync_url(source_url, database=database_name))
+    environment_id = uuid.uuid4()
+    cleanup_id = f"cleanup-{environment_id}"
+
+    with admin_engine.connect() as connection:
+        connection.execute(text(f'CREATE DATABASE "{database_name}"'))
+    try:
+        _run_alembic(database_url, "upgrade", PREVIOUS_HEAD_REVISION)
+        with database_engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO v2_runtime_environment_fences (
+                        environment_id, owner_id, deployment_id, state,
+                        retirement_id, retirement_receipt_id, retirement_receipt,
+                        retired_at, final_cursor, final_stream_position,
+                        final_session_high_waters
+                    ) VALUES (
+                        :environment_id, :owner_id, 'deployment-cleanup', 'retired',
+                        'retirement-cleanup', :receipt_id, '{}'::jsonb,
+                        now(), 'final-cursor', 0, '{}'::jsonb
+                    )
+                    """
+                ),
+                {
+                    "environment_id": environment_id,
+                    "owner_id": uuid.uuid4(),
+                    "receipt_id": uuid.uuid4(),
+                },
+            )
+
+        _run_alembic(database_url, "upgrade", CLEANUP_REVISION)
+        receipt = {
+            "schemaVersion": "clawdi.runtimeStateCleanupReceipt.v1",
+            "environmentReference": str(environment_id),
+            "expectedDeploymentBinding": "deployment-cleanup",
+            "retirementId": "retirement-cleanup",
+            "cleanupId": cleanup_id,
+            "runtimeStateStatus": "absent",
+            "cleanedAt": "2026-08-13T00:00:00Z",
+        }
+        with database_engine.begin() as connection:
+            connection.execute(
+                text(
+                    "UPDATE v2_runtime_environment_fences "
+                    "SET runtime_state_cleanup_id = :cleanup_id, "
+                    "runtime_state_cleanup_receipt = CAST(:receipt AS jsonb) "
+                    "WHERE environment_id = :environment_id"
+                ),
+                {
+                    "cleanup_id": cleanup_id,
+                    "receipt": json.dumps(receipt),
+                    "environment_id": environment_id,
+                },
+            )
+        with pytest.raises(DBAPIError, match="cleanup identity and receipt are immutable"):
+            with database_engine.begin() as connection:
+                connection.execute(
+                    text(
+                        "UPDATE v2_runtime_environment_fences "
+                        "SET runtime_state_cleanup_id = 'different-cleanup' "
+                        "WHERE environment_id = :environment_id"
+                    ),
+                    {"environment_id": environment_id},
+                )
+
+        _run_alembic(database_url, "downgrade", PREVIOUS_HEAD_REVISION)
+        columns = {
+            column["name"]
+            for column in inspect(database_engine).get_columns("v2_runtime_environment_fences")
+        }
+        assert "runtime_state_cleanup_id" not in columns
+        assert "runtime_state_cleanup_receipt" not in columns
+
+        _run_alembic(database_url, "upgrade", CLEANUP_REVISION)
+        fresh_columns = {
+            column["name"]
+            for column in inspect(database_engine).get_columns("v2_runtime_environment_fences")
+        }
+        assert "runtime_state_cleanup_id" in fresh_columns
+        assert "runtime_state_cleanup_receipt" in fresh_columns
+        _run_alembic(database_url, "downgrade", PREVIOUS_HEAD_REVISION)
+    finally:
+        database_engine.dispose()
+        with admin_engine.connect() as connection:
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)'))
+        admin_engine.dispose()

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -69,8 +69,8 @@ Cloud-api reuses these existing runtime primitives:
   `runtime_deployment_id` identity binding;
 - the first-party `X-Admin-Key` gate, mutation idempotency, and control-plane
   audit events for Hosted-facing provisioning and retirement calls;
-- PostgreSQL transactions and `FOR UPDATE` locks for ingestion and retirement
-  serialization.
+- PostgreSQL transactions and `FOR UPDATE` locks for ingestion, retirement,
+  desired-state cleanup, and late-write serialization.
 
 `POST /v1/agents/{agent_id}/sync-heartbeat` remains the frozen v1 liveness and
 latest-observation transport. It neither accepts strict-v2 identity fields nor
@@ -82,7 +82,7 @@ Four PostgreSQL tables form the additive companion boundary:
 
 | Table | Contract |
 | --- | --- |
-| `v2_runtime_environment_fences` | Permanent environment/owner/deployment binding, active or retired state, replay floor, and immutable final retirement receipt/high-waters. |
+| `v2_runtime_environment_fences` | Permanent environment/owner/deployment binding, active or retired state, replay floor, immutable final retirement receipt/high-waters, and the durable runtime-state cleanup receipt. |
 | `v2_runtime_observation_inbox` | Immutable accepted identities with the five-field boot identity, boot-scoped sequence, global event id, timestamps, payload hash, and health. Private diagnostic payloads may be compacted in place after retention eligibility, while identity and hash columns remain permanently unique. |
 | `v2_runtime_observation_heads` | One immutable boot-session binding with non-regressing accepted sequence, stream position, capture time, and freshness; retirement compacts it to a tombstone. |
 | `v2_runtime_observation_consumer_cursors` | Environment-and-consumer ACK state, replay horizon, and explicit fail-closed expiry/reset boundary used by safe prefix retention. |
@@ -100,7 +100,9 @@ separately requires its scope. The database constrains only the identity
 binding, while the issuer and migration own the canonical authorization bundle.
 
 Hosted-facing `/v2` registration, read, acknowledgement, reset, retirement, and
-provisioning calls all require the first-party `X-Admin-Key`. The server binds
+provisioning calls require the first-party `X-Admin-Key`. Retired runtime-state
+cleanup also accepts a platform workload token with the existing
+`platform:runtime-environments:retire` scope. The server binds
 observation cursors to its fixed Hosted controller identity, and immutable
 owner/deployment authority is resolved from the environment fence rather than
 caller-selected request data, so opaque cursors cannot cross consumers or
@@ -116,8 +118,15 @@ heads atomically. Replaying the same retirement ID returns the persisted
 receipt; a different ID or deployment binding conflicts. V1 agent deletion and
 key revocation retain their pre-companion behavior and do not consult the v2
 fence. Trusted Hosted controller ordering obtains the retirement receipt before
-using those existing teardown surfaces; the permanent fence itself is never
-deleted.
+requesting `POST /v2/runtime/environments/{environment_id}/runtime-state/cleanup`
+with the exact environment, deployment, retirement, and stable cleanup
+identities. Cleanup derives owner authority from the permanent fence, removes
+only matching desired state, releases its OAuth claims, and stores an immutable
+versioned absence receipt. Exact retries return that receipt; identity reuse or
+mismatch conflicts. Runtime-state writers lock `User`, then the fence, then
+subordinate state and OAuth rows. A retired fence rejects new writes, including
+legacy admin v2 writers, while old successful platform idempotency replays do
+not execute a write. The permanent fence itself is never deleted.
 
 Retention advances the replay floor only across a contiguous per-environment
 stream prefix. Every row in a normal replay-horizon prefix must be old enough

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -2962,6 +2962,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v2/runtime/environments/{environment_id}/runtime-state/cleanup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Cleanup Retired Runtime State Endpoint */
+        post: operations["cleanup_retired_runtime_state_endpoint_v2_runtime_environments__environment_id__runtime_state_cleanup_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v2/runtime/environments/{environment_id}/observation-consumers/register": {
         parameters: {
             query?: never;
@@ -6850,6 +6867,49 @@ export interface components {
             sourceRevision: string;
             /** Etag */
             etag: string;
+        };
+        /** RuntimeStateCleanupReceipt */
+        RuntimeStateCleanupReceipt: {
+            /**
+             * Schemaversion
+             * @constant
+             */
+            schemaVersion: "clawdi.runtimeStateCleanupReceipt.v1";
+            /**
+             * Environmentreference
+             * Format: uuid
+             */
+            environmentReference: string;
+            /** Expecteddeploymentbinding */
+            expectedDeploymentBinding: string;
+            /** Retirementid */
+            retirementId: string;
+            /** Cleanupid */
+            cleanupId: string;
+            /**
+             * Runtimestatestatus
+             * @constant
+             */
+            runtimeStateStatus: "absent";
+            /**
+             * Cleanedat
+             * Format: date-time
+             */
+            cleanedAt: string;
+        };
+        /** RuntimeStateCleanupRequest */
+        RuntimeStateCleanupRequest: {
+            /**
+             * Environmentreference
+             * Format: uuid
+             */
+            environmentReference: string;
+            /** Expecteddeploymentbinding */
+            expectedDeploymentBinding: string;
+            /** Retirementid */
+            retirementId: string;
+            /** Cleanupid */
+            cleanupId: string;
         };
         /** SearchHit */
         SearchHit: {
@@ -13624,6 +13684,45 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RuntimeEnvironmentRetirementReceipt"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cleanup_retired_runtime_state_endpoint_v2_runtime_environments__environment_id__runtime_state_cleanup_post: {
+        parameters: {
+            query?: never;
+            header: {
+                "Idempotency-Key": string;
+                "X-Admin-Key"?: string | null;
+                Authorization?: string | null;
+            };
+            path: {
+                environment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RuntimeStateCleanupRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RuntimeStateCleanupReceipt"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary

- add an idempotent retired-environment runtime-state cleanup RPC
- persist an immutable exact cleanup receipt on the permanent retirement fence
- fence late runtime-state writes while preserving exact successful idempotency replays
- release runtime OAuth claims after desired state is absent

## Safety

The RPC requires the existing retirement scope plus exact environment, deployment, retirement, cleanup, and Idempotency-Key identity. Active or mismatched environments fail closed. It supports archived Agents and already-absent state without inferring absence from Agent lifecycle.

## Verification

- full `scripts/test.sh all`: passed
- backend: 2295 passed, 12 skipped
- focused cleanup: 5 passed
- OpenAPI generation, Ruff lint, deptry, BasedPyright, Biome: passed
- isolated compileall: passed

Release this Cloud change before the dependent Hosted consumer.