### PR TITLE
fix(backend): allow cleanup after owner termination

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -651,6 +651,37 @@ async def _assert_admin_target_owns_environment(
     return target.id
 
 
+async def _assert_admin_cleanup_target_owns_environment(
+    db: AsyncSession,
+    *,
+    env: AgentEnvironment,
+    target_clerk_id: str | None,
+) -> UUID:
+    """Verify retained ownership without requiring an active principal."""
+
+    if target_clerk_id is None:
+        return env.user_id
+
+    target_user_id = await db.scalar(
+        select(User.id).where(
+            User.principal_kind == PRINCIPAL_KIND_CLERK,
+            User.clerk_id == target_clerk_id,
+        )
+    )
+    if target_user_id is None or env.user_id != target_user_id:
+        logger.warning(
+            "admin_environment_owner_rejected target_clerk_id=%s env_id=%s owner_user_id=%s",
+            target_clerk_id,
+            env.id,
+            env.user_id,
+        )
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            "Agent environment is not owned by target user",
+        )
+    return target_user_id
+
+
 @router.post("/auth/keys", response_model=ApiKeyCreated)
 async def admin_mint_api_key(
     body: AdminApiKeyCreate,
@@ -1827,7 +1858,7 @@ async def _admin_delete_environment(
     ).scalar_one_or_none()
     if env is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
-    target_user_id = await _assert_admin_target_owns_environment(
+    target_user_id = await _assert_admin_cleanup_target_owns_environment(
         db,
         env=env,
         target_clerk_id=target_clerk_id,
@@ -2162,7 +2193,7 @@ async def _admin_delete_runtime_state(
     ).scalar_one_or_none()
     if env is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent environment not found")
-    target_user_id = await _assert_admin_target_owns_environment(
+    target_user_id = await _assert_admin_cleanup_target_owns_environment(
         db,
         env=env,
         target_clerk_id=target_clerk_id,

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -3147,6 +3147,45 @@ async def test_admin_delete_environment_accepts_matching_optional_owner(
 
 
 @pytest.mark.asyncio
+async def test_admin_delete_agent_accepts_matching_terminated_owner(
+    admin_client, db_session, seed_user
+):
+    from app.models.principal_lifecycle import PrincipalLifecycle
+    from app.models.session import AgentEnvironment
+    from tests.conftest import create_env_with_project
+
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"delete-terminated-owner-{uuid.uuid4().hex[:8]}",
+        machine_name="delete-terminated-owner",
+        agent_type="codex",
+    )
+    now = datetime.now(UTC)
+    db_session.add(
+        PrincipalLifecycle(
+            issuer=_CLERK_ISSUER,
+            subject=seed_user.clerk_id,
+            user_id=seed_user.id,
+            terminated_at=now,
+            next_cleanup_attempt_at=now,
+        )
+    )
+    await db_session.commit()
+
+    response = await admin_client.delete(
+        f"/api/admin/agents/{env.id}",
+        headers=_AUTH,
+        params={"target_clerk_id": seed_user.clerk_id},
+    )
+
+    assert response.status_code == 204, response.text
+    archived = await db_session.get(AgentEnvironment, env.id)
+    assert archived is not None
+    assert archived.archived_at is not None
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "path_template",
     ["/v1/admin/agents/{env_id}", "/v1/admin/environments/{env_id}"],


### PR DESCRIPTION
## Root cause

Admin Agent/runtime-state cleanup reused the active-principal owner resolver. After a verified `user.deleted` fence, an exact owner match was rejected with HTTP 403, so Hosted could not finish deleting a retired v2 deployment.

## Fix

- Verify cleanup ownership against the retained Clerk ID to User mapping without requiring active principal authority.
- Keep create/update owner checks active-only.
- Keep cross-owner cleanup fail-closed.
- Cover the exact terminated-owner cleanup boundary on the production `/api/admin/agents` alias.

## Verification

- Focused PostgreSQL: 5 passed
- Full backend: 2296 passed, 12 skipped
- Ruff lint/format: passed
- Owned Python type governance: 189 files, 0 diagnostics
- `git diff --check`: passed