### PR TITLE
fix(cli): preserve user runtimes across revision migrations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.73",
+      "version": "0.13.74",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.73",
+	"version": "0.13.74",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -18,6 +18,7 @@ import { writePrivateFileAtomic } from "../lib/private-file";
 import { getCliVersion } from "../lib/version";
 import {
 	type RuntimeAppliedContentIdentity,
+	type RuntimeUserProcessRevisionAliases,
 	readRuntimeAppliedState,
 	runtimeAppliedApplyIdentity,
 	runtimeContentSha256,
@@ -298,6 +299,7 @@ export function commitRuntimeAppliedState(input: {
 	daemonAuthTokenRevision?: string;
 	daemonProgramRevision?: string;
 	egressSidecarSecretRevision?: string;
+	userProcessRevisionAliases?: RuntimeUserProcessRevisionAliases;
 }): void {
 	if (
 		input.applyIdentity &&
@@ -338,6 +340,10 @@ export function commitRuntimeAppliedState(input: {
 				: {}),
 			...(input.egressSidecarSecretRevision
 				? { egressSidecarSecretRevision: input.egressSidecarSecretRevision }
+				: {}),
+			...(input.userProcessRevisionAliases &&
+			Object.keys(input.userProcessRevisionAliases).length > 0
+				? { userProcessRevisionAliases: input.userProcessRevisionAliases }
 				: {}),
 			providerIds,
 			projectedProviderIds: input.convergence.projectedProviderIds,
@@ -628,6 +634,41 @@ export function readSystemdUnitSnapshot(
 	};
 }
 
+function systemdDesiredProgramRevision(
+	paths: ReturnType<typeof getRuntimePaths>,
+	unit: string,
+): string {
+	if (!unit.endsWith(".service")) {
+		throw new Error(`managed systemd unit has invalid name: ${unit}`);
+	}
+	const programName = unit.slice(0, -".service".length);
+	const content = readFileSync(systemdEnvironmentFilePath(paths, programName), "utf8");
+	const parsed = parseDotenv(content).filter(([key]) => key === "CLAWDI_RUNTIME_REV");
+	const declarations = content
+		.split(/\r?\n/)
+		.filter((line) => line.startsWith("CLAWDI_RUNTIME_REV="));
+	const match = /^CLAWDI_RUNTIME_REV="([a-f0-9]{32})"$/.exec(declarations[0] ?? "");
+	if (parsed.length !== 1 || declarations.length !== 1 || !match) {
+		throw new Error("invalid revision declaration");
+	}
+	return match[1];
+}
+
+function readSystemdUserDesiredRevisions(
+	paths: ReturnType<typeof getRuntimePaths>,
+	units: Iterable<string>,
+): ReadonlyMap<string, string> {
+	const revisions = new Map<string, string>();
+	for (const unit of units) {
+		try {
+			revisions.set(unit, systemdDesiredProgramRevision(paths, unit));
+		} catch {
+			// Missing or malformed predecessor authority is not eligible for adoption.
+		}
+	}
+	return revisions;
+}
+
 function readManagedSystemdUnits(root: string): Map<string, string> {
 	const units = new Map<string, string>();
 	if (!existsSync(root)) return units;
@@ -706,6 +747,8 @@ export function applySystemdRuntimeUpdate(
 			userUnits: readonly string[];
 		};
 		preserveActiveUnits?: boolean;
+		previousUserDesiredRevisions?: ReadonlyMap<string, string>;
+		onUserProcessRevisionAliases?: (aliases: RuntimeUserProcessRevisionAliases) => void;
 		skipActivatedSystemUnits?: readonly string[];
 	},
 ): { applied: boolean; systemUnitsChanged: string[]; userUnitsChanged: string[] } {
@@ -773,13 +816,31 @@ export function applySystemdRuntimeUpdate(
 	);
 	const changedSystemUnits = new Set(system.changed);
 	const changedUserUnits = new Set(user.changed);
-	const userProcessRevisionDrift = new Set(
-		user.present.filter((unit) => {
-			const state = requiredSystemdUnitState(userStates, "user", unit);
-			if (state.activeState !== "active") return false;
-			return !systemdProcessRevisionMatches(paths, unit, state);
-		}),
-	);
+	const committedAliases = readRuntimeAppliedState(paths)?.userProcessRevisionAliases ?? {};
+	const userProcessRevisionAliases: RuntimeUserProcessRevisionAliases = {};
+	const userProcessRevisionDrift = new Set<string>();
+	for (const unit of user.present) {
+		const state = requiredSystemdUnitState(userStates, "user", unit);
+		if (state.activeState !== "active") continue;
+		const revisions = systemdProcessRevisions(paths, unit, state);
+		if (revisions.processRevision === revisions.desiredRevision) continue;
+		const committedAlias = committedAliases[unit];
+		if (
+			committedAlias?.desiredRevision === revisions.desiredRevision &&
+			committedAlias.processRevision === revisions.processRevision
+		) {
+			userProcessRevisionAliases[unit] = committedAlias;
+			continue;
+		}
+		if (
+			opts.preserveActiveUnits &&
+			opts.previousUserDesiredRevisions?.get(unit) === revisions.processRevision
+		) {
+			userProcessRevisionAliases[unit] = revisions;
+			continue;
+		}
+		userProcessRevisionDrift.add(unit);
+	}
 
 	for (const unit of system.removed) {
 		const state = requiredSystemdUnitState(systemStates, "system", unit);
@@ -924,6 +985,7 @@ export function applySystemdRuntimeUpdate(
 			userUnitsChanged.add(unit);
 		}
 	}
+	for (const unit of restartUserUnits) delete userProcessRevisionAliases[unit];
 	if (resetFailedUserUnits.length > 0) {
 		runJournaledSystemdMutation(
 			transaction,
@@ -977,7 +1039,13 @@ export function applySystemdRuntimeUpdate(
 		) {
 			return false;
 		}
-		return systemdProcessRevisionMatches(paths, unit, state);
+		const revisions = systemdProcessRevisions(paths, unit, state);
+		const alias = userProcessRevisionAliases[unit];
+		return (
+			revisions.processRevision === revisions.desiredRevision ||
+			(alias?.desiredRevision === revisions.desiredRevision &&
+				alias.processRevision === revisions.processRevision)
+		);
 	});
 	const removedSystemConverged = system.removed.every(
 		(unit) =>
@@ -988,8 +1056,11 @@ export function applySystemdRuntimeUpdate(
 		const state = systemdUnitManagerState(paths, "user", unit);
 		return systemdUnitAbsentOrInactive(state) && systemdUnitAbsentOrDisabled(state);
 	});
+	const applied =
+		systemConverged && userConverged && removedSystemConverged && removedUserConverged;
+	if (applied) opts.onUserProcessRevisionAliases?.(userProcessRevisionAliases);
 	return {
-		applied: systemConverged && userConverged && removedSystemConverged && removedUserConverged,
+		applied,
 		systemUnitsChanged: [...systemUnitsChanged].sort(),
 		userUnitsChanged: [...userUnitsChanged].sort(),
 	};
@@ -1279,26 +1350,21 @@ function systemdProcessRevisionMatches(
 	unit: string,
 	state: SystemdUnitManagerState,
 ): boolean {
+	const revisions = systemdProcessRevisions(paths, unit, state);
+	return revisions.processRevision === revisions.desiredRevision;
+}
+
+function systemdProcessRevisions(
+	paths: ReturnType<typeof getRuntimePaths>,
+	unit: string,
+	state: SystemdUnitManagerState,
+): { desiredRevision: string; processRevision: string } {
 	if (state.mainPid === 0) {
 		throw new Error(`active managed systemd unit ${unit} has no MainPID`);
 	}
-	if (!unit.endsWith(".service")) {
-		throw new Error(`managed systemd unit has invalid name: ${unit}`);
-	}
-	const programName = unit.slice(0, -".service".length);
-	const envPath = systemdEnvironmentFilePath(paths, programName);
 	let desiredRevision: string;
 	try {
-		const content = readFileSync(envPath, "utf8");
-		const parsed = parseDotenv(content).filter(([key]) => key === "CLAWDI_RUNTIME_REV");
-		const declarations = content
-			.split(/\r?\n/)
-			.filter((line) => line.startsWith("CLAWDI_RUNTIME_REV="));
-		const match = /^CLAWDI_RUNTIME_REV="([a-f0-9]{32})"$/.exec(declarations[0] ?? "");
-		if (parsed.length !== 1 || declarations.length !== 1 || !match) {
-			throw new Error("invalid revision declaration");
-		}
-		desiredRevision = match[1];
+		desiredRevision = systemdDesiredProgramRevision(paths, unit);
 	} catch (error) {
 		throw new Error(`could not prove desired runtime revision for managed systemd unit ${unit}`, {
 			cause: error,
@@ -1327,7 +1393,7 @@ function systemdProcessRevisionMatches(
 			cause: error,
 		});
 	}
-	return processRevision === desiredRevision;
+	return { desiredRevision, processRevision };
 }
 
 function runtimeRevisionFromProcessEnvironment(environment: Buffer): string {
@@ -1797,6 +1863,7 @@ async function runtimeInitLocked(
 						daemonAuthTokenRevision: authority.daemonAuthTokenRevision,
 						daemonProgramRevision: authority.daemonProgramRevision,
 						egressSidecarSecretRevision: authority.egressSidecarSecretRevision,
+						userProcessRevisionAliases: authority.userProcessRevisionAliases,
 					}),
 				manifestIdentity: {
 					generation: convergenceLoad.manifest.generation,
@@ -2094,6 +2161,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 					daemonAuthTokenRevision: authority.daemonAuthTokenRevision,
 					daemonProgramRevision: authority.daemonProgramRevision,
 					egressSidecarSecretRevision: authority.egressSidecarSecretRevision,
+					userProcessRevisionAliases: authority.userProcessRevisionAliases,
 				}),
 			continueOnCliUpdateError: true,
 			deferCliInstall: opts.deferCliInstall,
@@ -2266,7 +2334,11 @@ async function applyRuntimeDesiredState(
 			authToken: load.applyContext?.manifestSource.auth.token,
 		}));
 	const previousSystemdUnits = readSystemdUnitSnapshot(paths);
+	const previousUserDesiredRevisions = preserveActiveUnits
+		? readSystemdUserDesiredRevisions(paths, previousSystemdUnits.user.keys())
+		: new Map<string, string>();
 	const systemdTransaction = new SystemdRuntimeTransaction();
+	let userProcessRevisionAliases: RuntimeUserProcessRevisionAliases = {};
 	let systemdApply = {
 		applied: false,
 		systemUnitsChanged: [] as string[],
@@ -2282,7 +2354,12 @@ async function applyRuntimeDesiredState(
 			if (opts.requireSystemdApplied && !systemdApply.applied) {
 				throw new Error("systemd apply did not activate the rendered runtime manifest");
 			}
-			opts.authorityCommit?.(committedConvergence, authority);
+			opts.authorityCommit?.(committedConvergence, {
+				...authority,
+				...(Object.keys(userProcessRevisionAliases).length > 0
+					? { userProcessRevisionAliases }
+					: {}),
+			});
 		},
 		systemdApply: {
 			transactionState: () => systemdTransaction.state,
@@ -2343,6 +2420,10 @@ async function applyRuntimeDesiredState(
 								...(restartEgressSidecar ? [RUNTIME_SIDECAR_SYSTEM_UNIT] : []),
 							],
 							preserveActiveUnits,
+							previousUserDesiredRevisions,
+							onUserProcessRevisionAliases: (aliases) => {
+								userProcessRevisionAliases = aliases;
+							},
 							recoverFailedUnits: opts.recoverFailedSystemdUnits,
 							skipActivatedSystemUnits: egressPrerequisiteActivated
 								? [RUNTIME_SIDECAR_SYSTEM_UNIT]

--- a/packages/cli/src/runtime/applied-state.test.ts
+++ b/packages/cli/src/runtime/applied-state.test.ts
@@ -104,6 +104,29 @@ describe("runtime applied state", () => {
 				daemonProgramRevision: "not-a-private-revision",
 			}).success,
 		).toBe(false);
+		const revisionAlias = {
+			"openclaw-gateway.service": {
+				desiredRevision: "d".repeat(32),
+				processRevision: "a".repeat(32),
+			},
+		};
+		expect(
+			runtimeAppliedStateSchema.safeParse({
+				...state,
+				userProcessRevisionAliases: revisionAlias,
+			}).success,
+		).toBe(true);
+		expect(
+			runtimeAppliedStateSchema.safeParse({
+				...state,
+				userProcessRevisionAliases: {
+					"openclaw-gateway.service": {
+						desiredRevision: "d".repeat(32),
+						processRevision: "d".repeat(32),
+					},
+				},
+			}).success,
+		).toBe(false);
 	});
 
 	test("reads old state through the named fallback and preserves explicit apply generation", () => {

--- a/packages/cli/src/runtime/applied-state.ts
+++ b/packages/cli/src/runtime/applied-state.ts
@@ -29,6 +29,21 @@ const providerIdsSchema = z
 		message: "provider IDs must be unique",
 	});
 
+const runtimeRevisionSchema = z.string().regex(/^[a-f0-9]{32}$/);
+
+const userProcessRevisionAliasesSchema = z.record(
+	z.string().regex(/^[A-Za-z0-9_.@-]+\.service$/),
+	z
+		.object({
+			desiredRevision: runtimeRevisionSchema,
+			processRevision: runtimeRevisionSchema,
+		})
+		.strict()
+		.refine((alias) => alias.desiredRevision !== alias.processRevision, {
+			message: "revision alias must describe distinct desired and process revisions",
+		}),
+);
+
 export const runtimeAppliedStateSchema = z
 	.object({
 		schemaVersion: z.literal("clawdi.runtimeAppliedState.v2"),
@@ -54,6 +69,7 @@ export const runtimeAppliedStateSchema = z
 			.string()
 			.regex(/^[a-f0-9]{32}$/)
 			.optional(),
+		userProcessRevisionAliases: userProcessRevisionAliasesSchema.optional(),
 		providerIds: providerIdsSchema,
 		projectedProviderIds: projectedProviderIdsSchema,
 	})
@@ -79,6 +95,7 @@ export const runtimeAppliedStateSchema = z
 
 export type RuntimeAppliedState = z.infer<typeof runtimeAppliedStateSchema>;
 export type RuntimeAppliedStateV2 = RuntimeAppliedState;
+export type RuntimeUserProcessRevisionAliases = z.infer<typeof userProcessRevisionAliasesSchema>;
 export type RuntimeAppliedContentSource = z.infer<typeof appliedContentSourceSchema>;
 export type RuntimeAppliedContentIdentity = RuntimeAppliedContentSource;
 

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -69,7 +69,11 @@ import {
 	writeOAuthCredentialLedger,
 } from "../lib/oauth-credential-ledger";
 import { writePrivateFileAtomic } from "../lib/private-file";
-import { readRuntimeAppliedState, runtimeContentSha256 } from "./applied-state";
+import {
+	type RuntimeUserProcessRevisionAliases,
+	readRuntimeAppliedState,
+	runtimeContentSha256,
+} from "./applied-state";
 import type { RuntimeApplyContext } from "./apply-identity";
 import {
 	ensureRuntimeAuthTokenFile,
@@ -318,6 +322,7 @@ export interface RuntimePrivateAppliedAuthority {
 	daemonAuthTokenRevision?: string;
 	daemonProgramRevision?: string;
 	egressSidecarSecretRevision?: string;
+	userProcessRevisionAliases?: RuntimeUserProcessRevisionAliases;
 }
 
 interface RuntimeInstallObservation {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -35,6 +35,7 @@ import {
 } from "../src/lib/codex-oauth-native-store";
 import { getCliVersion } from "../src/lib/version";
 import {
+	type RuntimeUserProcessRevisionAliases,
 	readRuntimeAppliedState,
 	runtimeContentSha256,
 	writeRuntimeAppliedState,
@@ -9457,6 +9458,123 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		expect(driftRepairCalls).not.toContain("daemon-reload");
 		expect(driftRepairCalls).toContain("--user restart hermes-gateway.service");
 		expect(driftRepairCalls).not.toContain("restart clawdi-runtime-watch.service");
+	});
+
+	it("adopts a cross-version user revision only until its desired program changes", () => {
+		const home = join(root, "revision-alias", "home", "clawdi");
+		const state = join(root, "revision-alias", "var", "lib", "clawdi");
+		const run = join(root, "revision-alias", "run", "clawdi");
+		const systemctlPath = join(root, "revision-alias", "bin", "systemctl");
+		const systemctlLog = join(root, "revision-alias", "systemctl.log");
+		const systemctlStateRoot = join(root, "revision-alias", "systemctl-state");
+		writeFakeSystemdManager({
+			path: systemctlPath,
+			logPath: systemctlLog,
+			stateRoot: systemctlStateRoot,
+			environmentRoot: join(run, "systemd", "env"),
+		});
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlPath;
+		process.env.CLAWDI_SYSTEMD_APPLY = "1";
+		const paths = getRuntimePaths();
+		const unit = "hermes-gateway.service";
+		const oldRevision = "a".repeat(32);
+		const migratedRevision = "b".repeat(32);
+		const changedRevision = "c".repeat(32);
+		const before = { system: new Map<string, string>(), user: new Map([[unit, "old"]]) };
+		const migrated = {
+			system: new Map<string, string>(),
+			user: new Map([[unit, "migrated"]]),
+		};
+		mkdirSync(paths.systemdEnvRoot, { recursive: true });
+		writeFileSync(
+			join(paths.systemdEnvRoot, `${unit}.env`),
+			`CLAWDI_RUNTIME_REV="${migratedRevision}"\n`,
+		);
+		seedFakeSystemdProcess(systemctlStateRoot, "user", unit, oldRevision);
+		writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "enabled"), "\n");
+		let aliases: RuntimeUserProcessRevisionAliases = {};
+
+		const adopted = applySystemdRuntimeUpdate(paths, before, migrated, {
+			transaction: new SystemdRuntimeTransaction(),
+			stage: "final-activation",
+			preserveActiveUnits: true,
+			previousUserDesiredRevisions: new Map([[unit, oldRevision]]),
+			onUserProcessRevisionAliases: (value) => {
+				aliases = value;
+			},
+		});
+
+		expect(adopted).toEqual({ applied: true, systemUnitsChanged: [], userUnitsChanged: [] });
+		expect(aliases).toEqual({
+			[unit]: { desiredRevision: migratedRevision, processRevision: oldRevision },
+		});
+		expect(readFileSync(systemctlLog, "utf-8")).not.toContain(`--user restart ${unit}`);
+		mkdirSync(dirname(paths.appliedState), { recursive: true });
+		writeRuntimeAppliedState(
+			{
+				schemaVersion: "clawdi.runtimeAppliedState.v2",
+				appliedAt: "2026-08-14T04:02:30.000Z",
+				instanceId: "iid_revision_alias",
+				etag: `"sha256:${"d".repeat(64)}"`,
+				sourceRevision: "d".repeat(64),
+				generation: 1,
+				contentIdentity: { sourcePath: "test://revision-alias", sha256: "e".repeat(64) },
+				userProcessRevisionAliases: aliases,
+				providerIds: [],
+				projectedProviderIds: {},
+			},
+			paths,
+		);
+
+		aliases = {};
+		writeFileSync(systemctlLog, "");
+		expect(
+			applySystemdRuntimeUpdate(paths, migrated, migrated, {
+				transaction: new SystemdRuntimeTransaction(),
+				stage: "final-activation",
+				onUserProcessRevisionAliases: (value) => {
+					aliases = value;
+				},
+			}),
+		).toEqual({ applied: true, systemUnitsChanged: [], userUnitsChanged: [] });
+		expect(aliases[unit]).toEqual({
+			desiredRevision: migratedRevision,
+			processRevision: oldRevision,
+		});
+		expect(readFileSync(systemctlLog, "utf-8")).not.toMatch(
+			/(?:^|\s)(?:daemon-reload|start|restart|stop|enable|disable|reset-failed)(?:\s|$)/m,
+		);
+
+		const changed = {
+			system: new Map<string, string>(),
+			user: new Map([[unit, "changed"]]),
+		};
+		writeFileSync(
+			join(paths.systemdEnvRoot, `${unit}.env`),
+			`CLAWDI_RUNTIME_REV="${changedRevision}"\n`,
+		);
+		aliases = {};
+		writeFileSync(systemctlLog, "");
+		expect(
+			applySystemdRuntimeUpdate(paths, migrated, changed, {
+				transaction: new SystemdRuntimeTransaction(),
+				stage: "final-activation",
+				onUserProcessRevisionAliases: (value) => {
+					aliases = value;
+				},
+			}),
+		).toEqual({
+			applied: true,
+			systemUnitsChanged: [],
+			userUnitsChanged: [unit],
+		});
+		expect(aliases).toEqual({});
+		expect(readFileSync(systemctlLog, "utf-8")).toContain(`--user restart ${unit}`);
 	});
 
 	it("rolls back a manager reload without attributing or stopping business units", () => {


### PR DESCRIPTION
Root cause: a CLI-only upgrade can change the runtime revision algorithm. The newly active CLI then compares the old process revision with the newly rendered desired revision and incorrectly restarts healthy user services.

This change captures the pre-upgrade desired revision, adopts a revision alias only when the live process exactly matches that prior authority, and stores the alias in the root-owned private applied state. Existing drift remains fail-closed, and any later desired program change invalidates the alias and performs the normal restart.

No deployment, tenant, Hermes, OpenClaw, provider, image, or release special case is included. The source version is reserved as clawdi@0.13.74; this PR does not publish or deploy it.

Verification:
- focused runtime/applied-state tests: 179 passed
- full CLI suite: 1655 passed, 4 skipped
- version/smoke tests after version bump: 19 passed
- workspace typecheck: 4/4 packages
- Biome: 1003 files
- git diff --check