### PR TITLE
fix(web): hide unavailable free compute source

### DIFF
--- a/apps/web/e2e/hosted-deploy-flow.pw.ts
+++ b/apps/web/e2e/hosted-deploy-flow.pw.ts
@@ -63,7 +63,7 @@ test("deploy wizard creates one selected runtime and renders mock status transit
 		"aria-pressed",
 		"false",
 	);
-	const includedBasic = page.getByRole("button", { name: /Included Basic/ });
+	const includedBasic = page.getByRole("button", { name: /Basic compute/ });
 	await expect(includedBasic).toBeVisible();
 	await includedBasic.click();
 	await expect(includedBasic).toHaveAttribute("aria-pressed", "true");
@@ -78,5 +78,12 @@ test("deploy wizard creates one selected runtime and renders mock status transit
 
 	await expect(page).toHaveURL(/\/agents\/hdep_dev_/);
 	await expect(page.getByText("Starting").first()).toBeVisible();
+
+	await page.goto("/deploy");
+	await expect(page.getByRole("heading", { name: "Deploy an Agent" })).toBeVisible();
+	await expect(page.getByRole("button", { name: /Basic compute/ })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: /New paid subscription/ })).toHaveCount(0);
+	await expect(page.getByText("Payment method", { exact: true })).toBeVisible();
+	await expect(page.getByRole("button", { name: /Card subscription/ })).toBeVisible();
 	expect(errors, `deploy flow: ${errors.join(" | ")}`).toEqual([]);
 });

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -3812,14 +3812,14 @@ function ComputeSettingsSections({
 								description: (
 									<p>
 										Cancellation takes effect {subscriptionPeriodLabel}. The agent then falls back
-										to included Basic funding if available; otherwise, it stops.
+										to free compute if available; otherwise, it stops.
 									</p>
 								),
 								confirmLabel: "Cancel at period end",
 								successDescription: (result) =>
 									result.current_period_end
-										? `Cancellation takes effect ${formatShortDate(result.current_period_end)}. The agent then falls back to included Basic funding if available; otherwise, it stops.`
-										: "The agent falls back to included Basic funding if available when cancellation takes effect; otherwise, it stops.",
+										? `Cancellation takes effect ${formatShortDate(result.current_period_end)}. The agent then falls back to free compute if available; otherwise, it stops.`
+										: "The agent falls back to free compute if available when cancellation takes effect; otherwise, it stops.",
 							}}
 						/>
 					}

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
@@ -188,7 +188,7 @@ describe("computeDunningState", () => {
 			recoveryPlanSlug: "compute_performance",
 		});
 		expect(running?.fallbackOccurredAt).not.toBe("2026-07-18T12:05:00Z");
-		expect(running?.description).toContain("now using included Basic");
+		expect(running?.description).toContain("now using free compute");
 
 		const stopped = computeDunningState(
 			deployment({
@@ -197,7 +197,7 @@ describe("computeDunningState", () => {
 				status: "stopped",
 			}),
 		);
-		expect(stopped?.description).toContain("No included Basic slot was available");
+		expect(stopped?.description).toContain("No free compute slot was available");
 
 		const unavailable = computeDunningState(
 			deployment({
@@ -207,9 +207,9 @@ describe("computeDunningState", () => {
 			}),
 		);
 		expect(unavailable?.description).toContain(
-			"can’t determine whether this agent stopped or is using included Basic",
+			"can’t determine whether this agent stopped or is using free compute",
 		);
-		expect(unavailable?.description).not.toContain("is now using included Basic");
+		expect(unavailable?.description).not.toContain("is now using free compute");
 	});
 
 	test("does not recover a detached or already recovered subscription", () => {

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
@@ -117,10 +117,10 @@ function detachedFallbackState(deployment: DunningDeployment): ComputeDunningSta
 		fundingSource: fallback.funding_source,
 		recoveryTarget: { kind: "start_new", action: "start_new" },
 		description: statusUnavailable
-			? "We can’t determine whether this agent stopped or is using included Basic because its current status is unavailable. Start a new subscription to restore paid compute."
+			? "We can’t determine whether this agent stopped or is using free compute because its current status is unavailable. Start a new subscription to restore paid compute."
 			: stopped
-				? "No included Basic slot was available, so this agent stopped. Start a new subscription to restore paid compute."
-				: "This agent is now using included Basic. Start a new subscription to restore paid compute.",
+				? "No free compute slot was available, so this agent stopped. Start a new subscription to restore paid compute."
+				: "This agent is now using free compute. Start a new subscription to restore paid compute.",
 		fallbackOccurredAt: fallback.occurred_at,
 		fallbackPlanLabel,
 		fallbackReason: fallback.reason,

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -348,8 +348,8 @@ describe("billing-read gates", () => {
 		expect(wizardSource).toContain("const deploymentsResolved = deployments.data !== undefined;");
 		expect(wizardSource).toContain("shouldBlockQueryError(deployments.error, deployments.data)");
 		expect(wizardSource).toContain("activeIncludedBasicSlot === null");
-		expect(wizardSource).toContain("Included Basic availability is unknown");
-		expect(wizardSource).toContain('title="Couldn\'t check Included Basic availability"');
+		expect(wizardSource).toContain("Free compute availability is unknown");
+		expect(wizardSource).toContain('title="Couldn\'t check free compute availability"');
 		expect(wizardSource).toContain("onRetry={() => void deployments.refetch()}");
 		expect(wizardSource).toContain("disabled={checkingDeployments}");
 		expect(wizardSource).toContain("onClick={() => void checkDeploymentsAgain()}");

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -128,6 +128,7 @@ import type { CheckoutSessionClientSecret } from "@/hosted/billing/stripe-client
 import { useReusableSubscriptions } from "@/hosted/billing/subscription/reusable-subscriptions-query";
 import {
 	existingSubscriptionCreateSelection,
+	resolveSubscriptionSource,
 	type SubscriptionCreateSelection,
 	type SubscriptionSource,
 	supportedBillingTerm,
@@ -466,7 +467,9 @@ export function DeployWizard() {
 		"Agent creation is still starting. Keep this page open; we’ll take you to your agent as soon as its page is available.",
 	);
 	const [paymentMethod, setPaymentMethod] = useState<DeployPaymentMethod>("card");
-	const [subscriptionSource, setSubscriptionSource] = useState<SubscriptionSource | null>(null);
+	const [selectedSubscriptionSource, setSubscriptionSource] = useState<SubscriptionSource | null>(
+		null,
+	);
 	const [checkingDeployments, setCheckingDeployments] = useState(false);
 	const walletTopUp = useWalletTopUpDialog(SUBSCRIPTION_WALLET_FUNDING_ERROR_COPY);
 	const deploymentsResolved = deployments.data !== undefined;
@@ -516,6 +519,12 @@ export function DeployWizard() {
 			: activeIncludedBasicSlot
 				? "unavailable"
 				: "available";
+	const subscriptionSource = resolveSubscriptionSource({
+		selected: selectedSubscriptionSource,
+		includedAvailable: includedBasicAvailability === "available",
+		reusableSubscriptions:
+			reusableSubscriptions.error == null ? reusableSubscriptions.data : undefined,
+	});
 	const perfOfferSelection = useMemo(
 		() => (perfPlan ? selectOfferForTerm(perfPlan, term) : null),
 		[perfPlan, term],
@@ -652,10 +661,10 @@ export function DeployWizard() {
 		if (subscriptionSource.mode === "included") {
 			if (!deploymentsResolved) {
 				return blockingDeploymentsError
-					? "Retry the Included Basic availability check above."
-					: "Checking your Included Basic availability.";
+					? "Retry the free compute availability check above."
+					: "Checking your free compute availability.";
 			}
-			if (includedBasicAvailability !== "available") return "Included Basic is unavailable.";
+			if (includedBasicAvailability !== "available") return "Free compute is unavailable.";
 		} else {
 			if (reusableSubscriptions.isFetching) return "Checking reusable subscriptions.";
 			if (reusableSubscriptions.error != null || reusableSubscriptions.data === undefined) {
@@ -1160,7 +1169,7 @@ export function DeployWizard() {
 		language !== "" ||
 		timezone !== "" ||
 		term !== 1 ||
-		subscriptionSource !== null ||
+		selectedSubscriptionSource !== null ||
 		checkoutSession !== null;
 
 	return (
@@ -1296,32 +1305,29 @@ export function DeployWizard() {
 						<SubscriptionSourcePicker
 							value={subscriptionSource}
 							onChange={setSubscriptionSource}
-							showIncluded
-							includedAvailability={includedBasicAvailability}
+							showIncluded={includedBasicAvailability === "available"}
 							reusableSubscriptions={reusableSubscriptions.data ?? []}
 							isLoading={reusableSubscriptions.isFetching}
 							error={reusableSubscriptions.error}
 							onRetry={() => void reusableSubscriptions.refetch()}
 							disabled={submitting}
 						/>
-						{subscriptionSource?.mode === "included" && blockingDeploymentsError ? (
+						{blockingDeploymentsError ? (
 							<ApiErrorPanel
 								normalizer={billingErrorNormalizer}
 								error={blockingDeploymentsError}
 								onRetry={() => void deployments.refetch()}
-								title="Couldn't check Included Basic availability"
+								title="Couldn't check free compute availability"
 							/>
 						) : null}
-						{subscriptionSource?.mode === "included" &&
-						deploymentsResolved &&
-						activeIncludedBasicSlot === null ? (
+						{deploymentsResolved && activeIncludedBasicSlot === null ? (
 							<Alert data-hosted="true">
 								<TriangleAlert />
-								<AlertTitle>Included Basic availability is unknown</AlertTitle>
+								<AlertTitle>Free compute availability is unknown</AlertTitle>
 								<AlertDescription className="flex flex-col gap-3 @2xl/main:flex-row @2xl/main:items-center @2xl/main:justify-between">
 									<span>
-										We can’t determine whether an existing agent is already using your included
-										Basic entitlement.
+										We can’t determine whether an existing agent is already using your free compute
+										entitlement.
 									</span>
 									<Button
 										type="button"

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -521,7 +521,10 @@ export function DeployWizard() {
 				: "available";
 	const subscriptionSource = resolveSubscriptionSource({
 		selected: selectedSubscriptionSource,
-		includedAvailable: includedBasicAvailability === "available",
+		includedAvailable:
+			includedBasicAvailability === "unknown"
+				? undefined
+				: includedBasicAvailability === "available",
 		reusableSubscriptions:
 			reusableSubscriptions.error == null ? reusableSubscriptions.data : undefined,
 	});

--- a/apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts
@@ -53,6 +53,13 @@ describe("subscription creation adapter", () => {
 		expect(
 			resolveSubscriptionSource({
 				selected: null,
+				includedAvailable: undefined,
+				reusableSubscriptions: [],
+			}),
+		).toBeNull();
+		expect(
+			resolveSubscriptionSource({
+				selected: null,
 				includedAvailable: false,
 				reusableSubscriptions: undefined,
 			}),

--- a/apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { CheckoutOperationResult } from "@/hosted/billing/billing-client";
 import type { ComputeSubscriptionQuoteResponse, DeployRequest } from "@/hosted/billing/contracts";
 import {
+	resolveSubscriptionSource,
 	type SubscriptionCreateRequestView,
 	subscriptionCreateOutcome,
 	subscriptionCreateQuoteRequest,
@@ -48,6 +49,37 @@ function createRequest(
 }
 
 describe("subscription creation adapter", () => {
+	test("selects the sole new-subscription source only after inventory resolves", () => {
+		expect(
+			resolveSubscriptionSource({
+				selected: null,
+				includedAvailable: false,
+				reusableSubscriptions: undefined,
+			}),
+		).toBeNull();
+		expect(
+			resolveSubscriptionSource({
+				selected: null,
+				includedAvailable: false,
+				reusableSubscriptions: [],
+			}),
+		).toEqual({ mode: "new" });
+		expect(
+			resolveSubscriptionSource({
+				selected: { mode: "included" },
+				includedAvailable: false,
+				reusableSubscriptions: [],
+			}),
+		).toEqual({ mode: "new" });
+		expect(
+			resolveSubscriptionSource({
+				selected: null,
+				includedAvailable: true,
+				reusableSubscriptions: [],
+			}),
+		).toBeNull();
+	});
+
 	test("presents the exact annual wallet quote and post-debit balance", () => {
 		const selection = createRequest().selection;
 		expect(subscriptionCreateQuoteRequest(selection)).toEqual({

--- a/apps/web/src/hosted/billing/subscription/subscription-create-adapter.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-adapter.ts
@@ -46,11 +46,11 @@ export function resolveSubscriptionSource({
 	reusableSubscriptions,
 	selected,
 }: {
-	includedAvailable: boolean;
+	includedAvailable: boolean | undefined;
 	reusableSubscriptions: readonly ReusableSubscription[] | undefined;
 	selected: SubscriptionSource | null;
 }): SubscriptionSource | null {
-	if (reusableSubscriptions === undefined) return selected;
+	if (includedAvailable === undefined || reusableSubscriptions === undefined) return selected;
 	if (selected?.mode === "included" && !includedAvailable) selected = null;
 	if (selected?.mode === "existing") {
 		const subscriptionId = selected.subscriptionId;

--- a/apps/web/src/hosted/billing/subscription/subscription-create-adapter.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-adapter.ts
@@ -39,6 +39,31 @@ export type SubscriptionSource =
 	| { mode: "existing"; subscriptionId: string }
 	| { mode: "new" };
 
+const NEW_SUBSCRIPTION_SOURCE: SubscriptionSource = { mode: "new" };
+
+export function resolveSubscriptionSource({
+	includedAvailable,
+	reusableSubscriptions,
+	selected,
+}: {
+	includedAvailable: boolean;
+	reusableSubscriptions: readonly ReusableSubscription[] | undefined;
+	selected: SubscriptionSource | null;
+}): SubscriptionSource | null {
+	if (reusableSubscriptions === undefined) return selected;
+	if (selected?.mode === "included" && !includedAvailable) selected = null;
+	if (selected?.mode === "existing") {
+		const subscriptionId = selected.subscriptionId;
+		if (
+			!reusableSubscriptions.some((subscription) => subscription.subscription_id === subscriptionId)
+		) {
+			selected = null;
+		}
+	}
+	if (selected) return selected;
+	return !includedAvailable && reusableSubscriptions.length === 0 ? NEW_SUBSCRIPTION_SOURCE : null;
+}
+
 /** Presentation model plus the exact server assertion used at confirmation. */
 export type SubscriptionCreateQuoteView = {
 	selection: SubscriptionCreateSelection;

--- a/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
@@ -51,6 +51,7 @@ import { useSensitiveCreateSubscription } from "@/hosted/billing/sensitive-actio
 import { useReusableSubscriptions } from "@/hosted/billing/subscription/reusable-subscriptions-query";
 import {
 	existingSubscriptionCreateSelection,
+	resolveSubscriptionSource,
 	type SubscriptionCreateSelection,
 	type SubscriptionFundingSource,
 	type SubscriptionSource,
@@ -119,11 +120,17 @@ export function SubscriptionCreateDialog({
 	const [planSlug, setPlanSlug] = useState(initialPlanSlug);
 	const [billingTermMonths, setBillingTermMonths] = useState(initialBillingTermMonths);
 	const [fundingSource, setFundingSource] = useState<SubscriptionFundingSource>("stripe");
-	const [source, setSource] = useState<SubscriptionSource | null>(null);
+	const [selectedSource, setSource] = useState<SubscriptionSource | null>(null);
 	const reusableSubscriptions = useReusableSubscriptions(
 		billingClient,
 		open && hostedAccess.canCreateCloudAgents,
 	);
+	const source = resolveSubscriptionSource({
+		selected: selectedSource,
+		includedAvailable: false,
+		reusableSubscriptions:
+			reusableSubscriptions.error == null ? reusableSubscriptions.data : undefined,
+	});
 	const selectedReusableSubscription =
 		source?.mode === "existing"
 			? (reusableSubscriptions.data?.find(

--- a/apps/web/src/hosted/billing/subscription/subscription-source-picker.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-source-picker.tsx
@@ -15,7 +15,6 @@ import { formatShortDate } from "@/lib/format";
 export function SubscriptionSourcePicker({
 	disabled = false,
 	error,
-	includedAvailability = "unknown",
 	isLoading,
 	onChange,
 	onRetry,
@@ -25,7 +24,6 @@ export function SubscriptionSourcePicker({
 }: {
 	disabled?: boolean;
 	error: unknown;
-	includedAvailability?: "available" | "unavailable" | "unknown";
 	isLoading: boolean;
 	onChange: (source: SubscriptionSource) => void;
 	onRetry: () => void;
@@ -33,31 +31,33 @@ export function SubscriptionSourcePicker({
 	showIncluded?: boolean;
 	value: SubscriptionSource | null;
 }) {
+	const onlyNewSubscription =
+		value?.mode === "new" &&
+		!isLoading &&
+		error == null &&
+		!showIncluded &&
+		reusableSubscriptions.length === 0;
+
+	if (onlyNewSubscription) return null;
+
 	const paidDisabled = disabled || error != null || isLoading;
-	const includedAvailable = includedAvailability === "available";
 	return (
 		<div data-hosted="true" className="flex min-w-0 flex-col gap-3">
 			<div className="grid min-w-0 gap-2 lg:grid-cols-2">
 				{showIncluded ? (
 					<EntityChoiceCard
 						selected={value?.mode === "included"}
-						onClick={includedAvailable ? () => onChange({ mode: "included" }) : undefined}
-						disabled={disabled || !includedAvailable}
+						onClick={disabled ? undefined : () => onChange({ mode: "included" })}
+						disabled={disabled}
 						icon={
 							<IconChip size="sm" tint="bg-identity-3-bg text-identity-3-fg">
 								<Cpu />
 							</IconChip>
 						}
-						title="Included Basic"
-						description={
-							includedAvailable
-								? "Use your included Basic entitlement."
-								: includedAvailability === "unavailable"
-									? "Your included Basic entitlement is currently in use."
-									: "Included Basic availability hasn’t been confirmed yet."
-						}
+						title="Basic compute"
+						description="Use your free compute entitlement."
 						details={<span className="text-xs font-medium text-foreground">$0 due now</span>}
-						badge={includedAvailable ? <Badge variant="secondary">Included</Badge> : undefined}
+						badge={<Badge variant="secondary">Free</Badge>}
 						className="items-start p-3"
 					/>
 				) : null}

--- a/backend/scripts/mock_deploy_api.py
+++ b/backend/scripts/mock_deploy_api.py
@@ -556,6 +556,18 @@ async def create_deployment(request: Request) -> dict[str, Any]:
     body = await request.json()
     idempotency_key = request.headers.get("Idempotency-Key") or uuid.uuid4().hex
     created = _create_deployment_record(body)
+    if created["config_info"]["compute_plan_slug"] == "compute_basic":
+        created["compute_subscription"] = {
+            "subscription_id": len(DEPLOYMENTS),
+            "status": "active",
+            "funding_source": None,
+            "payment_state": "ok",
+            "billing_term_months": 1,
+            "price_cents": 0,
+            "currency": "usd",
+            "cancel_at_period_end": False,
+            "current_period_end": _iso(_now() + timedelta(days=30)),
+        }
     return _accept_operation(created, verb="create", idempotency_key=idempotency_key)
 
 


### PR DESCRIPTION
## Summary

- render Basic compute / Free only while the account free entitlement is available
- derive source selection from authoritative inventory and discard stale Free or reusable selections
- skip the source picker and enter new-subscription plan/payment setup when New is the sole source
- keep free-compute terminology consistent in fallback and recovery copy
- make the local deploy mock project the canonical Free subscription fact used by the browser test

## Verification

- 40 focused tests
- Web typecheck
- Biome
- Ruff
- Hosted Playwright: deploy with Free, return with Free occupied, enter new plan/payment directly
- git diff --check