### PR TITLE
fix(web): preserve Kimi icon contrast

### DIFF
--- a/apps/web/src/components/entity-brand-icons.ts
+++ b/apps/web/src/components/entity-brand-icons.ts
@@ -57,7 +57,7 @@ const PROVIDER_BRAND_ICON_DEFINITIONS = {
 	gemini: { icon: Gemini, label: "Gemini" },
 	grok: { icon: Grok, label: "Grok" },
 	groq: { icon: Groq, label: "Groq" },
-	kimi: { icon: Kimi, label: "Kimi" },
+	kimi: { icon: Kimi, label: "Kimi", tileClassName: "bg-black" },
 	minimax: { icon: Minimax, label: "MiniMax" },
 	mistral: { icon: Mistral, label: "Mistral AI" },
 	openai: { icon: OpenAI, label: "OpenAI" },

--- a/apps/web/src/components/entity-icon.test.tsx
+++ b/apps/web/src/components/entity-icon.test.tsx
@@ -42,6 +42,15 @@ describe("EntityIcon LobeHub brands", () => {
 			expect(markup).toContain("text-black");
 		}
 	});
+
+	test("keeps the official Kimi color mark visible on a black tile", () => {
+		const markup = renderToStaticMarkup(<EntityIcon kind="provider" id="kimi" />);
+		expect({
+			blackTile: markup.includes("bg-black"),
+			blueAccent: /<path[^>]*fill="#1783ff"/i.test(markup),
+			whiteMark: /<path[^>]*fill="#fff"/i.test(markup),
+		}).toEqual({ blackTile: true, blueAccent: true, whiteMark: true });
+	});
 });
 
 describe("EntityIcon channels", () => {


### PR DESCRIPTION
## Summary

- keep the official Kimi color mark
- give Kimi its official black tile treatment so the white mark remains visible in light and dark themes
- cover the Kimi tile and white/blue mark contract with one focused regression test

## Verification

- CLAWDI_TEST_COMPOSE_PROJECT_NAME=clawdi-kimi-icon-verify scripts/test.sh web src/components/entity-icon.test.tsx
  - Docker-isolated web typecheck passed
  - entity icon tests: 5 passed, 0 failed
  - OSS web build passed
- temporary Playwright hosted mock check passed in light and dark themes; computed tile background was rgb(0, 0, 0) in both
- bunx biome check apps/web/src/components/entity-brand-icons.ts apps/web/src/components/entity-icon.test.tsx
- git diff --check