### PR TITLE
refactor(runtime): centralize hosted runtime authority

### DIFF
--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -46,6 +46,7 @@ from app.models.session_permission import (
 )
 from app.schemas.common import Paginated
 from app.schemas.runtime import (
+    HostedRuntimePlatformMcpServer,
     HostedRuntimeStdioMcpServer,
     PersistedHostedRuntimeBundledSkillEntry,
     PersistedHostedRuntimeMcp,
@@ -1200,7 +1201,7 @@ def _is_platform_only_mcp(persisted: PersistedHostedRuntimeMcp) -> bool:
     if set(persisted.servers) != {"clawdi"}:
         return False
     server = persisted.servers["clawdi"]
-    return (
+    return isinstance(server, HostedRuntimePlatformMcpServer) or (
         isinstance(server, HostedRuntimeStdioMcpServer)
         and server.command == "clawdi"
         and server.args == ["mcp"]

--- a/backend/app/schemas/runtime.py
+++ b/backend/app/schemas/runtime.py
@@ -28,11 +28,6 @@ HostedRuntimeLanguage = Literal[
 ]
 HostedRuntimeName = Literal["openclaw", "hermes"]
 
-FILE_BROWSER_VERSION = "v1.5.0-stable"
-FILE_BROWSER_COMMIT = "79552f8adb27c3e29934c4001660eb98f4aab5d6"
-FILE_BROWSER_AMD64_SHA256 = "8d51d1718d576d22e73e1f41a5194b451d152ddab0df97697cabe839cf59524e"
-FILE_BROWSER_ARM64_SHA256 = "3e18838ae33750a25da434dc6156a359968bf7935e01bdd884711f47f08ad92f"
-
 
 class ProjectSkillCapabilityReport(BaseModel):
     """Current Connected Agent observation, separate from deployment generations."""
@@ -92,21 +87,6 @@ class HostedFileBrowserAssets(BaseModel):
     amd64: HostedFileBrowserAsset
     arm64: HostedFileBrowserAsset
 
-    @model_validator(mode="after")
-    def validate_pins(self) -> "HostedFileBrowserAssets":
-        release = (
-            f"https://github.com/gtsteffaniak/filebrowser/releases/download/{FILE_BROWSER_VERSION}"
-        )
-        expected = {
-            "amd64": (f"{release}/linux-amd64-filebrowser", FILE_BROWSER_AMD64_SHA256),
-            "arm64": (f"{release}/linux-arm64-filebrowser", FILE_BROWSER_ARM64_SHA256),
-        }
-        for arch, asset in (("amd64", self.amd64), ("arm64", self.arm64)):
-            url, digest = expected[arch]
-            if asset.url != url or asset.sha256 != digest:
-                raise ValueError(f"Files {arch} artifact must match the pinned release")
-        return self
-
 
 class HostedFileBrowserAuth(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -139,8 +119,8 @@ class HostedFileBrowserAuth(BaseModel):
 class HostedFileBrowserCompanion(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    version: Literal["v1.5.0-stable"]
-    commit: Literal["79552f8adb27c3e29934c4001660eb98f4aab5d6"]
+    version: str = Field(pattern=r"^v[0-9A-Za-z][0-9A-Za-z._-]{0,63}$")
+    commit: str = Field(pattern=_GIT_COMMIT_PATTERN.pattern)
     listen: Literal["0.0.0.0"]
     port: Literal[9120]
     baseURL: Literal["/"]
@@ -148,6 +128,34 @@ class HostedFileBrowserCompanion(BaseModel):
     sourceRoot: Literal["/home/clawdi"]
     assets: HostedFileBrowserAssets
     auth: HostedFileBrowserAuth
+
+    @model_validator(mode="after")
+    def validate_assets(self) -> "HostedFileBrowserCompanion":
+        for architecture, asset in (
+            ("amd64", self.assets.amd64),
+            ("arm64", self.assets.arm64),
+        ):
+            path = (
+                f"/gtsteffaniak/filebrowser/releases/download/{self.version}"
+                f"/linux-{architecture}-filebrowser"
+            )
+            try:
+                parsed = urlsplit(asset.url)
+                parsed.port
+            except ValueError as exc:
+                raise ValueError("Files artifact URL must be canonical") from exc
+            if (
+                parsed.scheme != "https"
+                or parsed.hostname != "github.com"
+                or parsed.username is not None
+                or parsed.password is not None
+                or parsed.query
+                or parsed.fragment
+                or parsed.path != path
+                or asset.url != f"https://github.com{path}"
+            ):
+                raise ValueError("Files artifact URL must match its release and architecture")
+        return self
 
 
 class HostedRuntimeCompanions(BaseModel):
@@ -720,6 +728,22 @@ def _is_mcp_credential_header(name: str) -> bool:
     )
 
 
+def _validate_mcp_headers(
+    value: dict[str, str | HostedRuntimeMcpSecretHeader],
+) -> dict[str, str | HostedRuntimeMcpSecretHeader]:
+    if any(_EGRESS_HEADER_NAME_PATTERN.fullmatch(name) is None for name in value):
+        raise ValueError("MCP header names must be canonical")
+    normalized = [name.lower() for name in value]
+    if len(normalized) != len(set(normalized)):
+        raise ValueError("MCP header names must be unique case-insensitively")
+    if any(
+        isinstance(header_value, str) and _is_mcp_credential_header(name)
+        for name, header_value in value.items()
+    ):
+        raise ValueError("credential-bearing MCP headers must use secretRef")
+    return value
+
+
 class HostedRuntimeRemoteMcpServer(_StrictHostedWireModel):
     url: str = Field(min_length=1, max_length=2000)
     transport: Literal["streamable-http", "sse"]
@@ -747,20 +771,25 @@ class HostedRuntimeRemoteMcpServer(_StrictHostedWireModel):
     def _validate_headers(
         cls, value: dict[str, str | HostedRuntimeMcpSecretHeader]
     ) -> dict[str, str | HostedRuntimeMcpSecretHeader]:
-        if any(_EGRESS_HEADER_NAME_PATTERN.fullmatch(name) is None for name in value):
-            raise ValueError("MCP header names must be canonical")
-        normalized = [name.lower() for name in value]
-        if len(normalized) != len(set(normalized)):
-            raise ValueError("MCP header names must be unique case-insensitively")
-        if any(
-            isinstance(header_value, str) and _is_mcp_credential_header(name)
-            for name, header_value in value.items()
-        ):
-            raise ValueError("credential-bearing MCP headers must use secretRef")
-        return value
+        return _validate_mcp_headers(value)
 
 
-HostedRuntimeMcpServer = HostedRuntimeStdioMcpServer | HostedRuntimeRemoteMcpServer
+class HostedRuntimePlatformMcpServer(_StrictHostedWireModel):
+    platform: Literal["clawdi"]
+    transport: Literal["streamable-http"]
+    headers: dict[str, str | HostedRuntimeMcpSecretHeader] = Field(default_factory=dict)
+
+    @field_validator("headers")
+    @classmethod
+    def _validate_headers(
+        cls, value: dict[str, str | HostedRuntimeMcpSecretHeader]
+    ) -> dict[str, str | HostedRuntimeMcpSecretHeader]:
+        return _validate_mcp_headers(value)
+
+
+HostedRuntimeMcpServer = (
+    HostedRuntimeStdioMcpServer | HostedRuntimeRemoteMcpServer | HostedRuntimePlatformMcpServer
+)
 
 
 class HostedRuntimeMcp(_StrictHostedWireModel):

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -44,8 +44,11 @@ from app.schemas.runtime import (
     HostedRuntimeCompanions,
     HostedRuntimeLiveSync,
     HostedRuntimeLocale,
+    HostedRuntimeMcp,
     HostedRuntimeName,
+    HostedRuntimePlatformMcpServer,
     HostedRuntimeRecovery,
+    HostedRuntimeRemoteMcpServer,
     HostedRuntimeSystem,
     HostedRuntimeTools,
     PersistedHostedRuntimeSkills,
@@ -53,7 +56,6 @@ from app.schemas.runtime import (
     parse_exact_semver,
     validate_clawdi_cli_package_spec,
     validate_hosted_runtime_desired_state,
-    validate_hosted_runtime_mcp_desired_state,
 )
 from app.schemas.runtime_observed import HostedRuntimeObservedV2
 from app.services.channels import (
@@ -582,7 +584,7 @@ def render_runtime_source(
     except ValidationError as exc:
         raise RuntimeSourceError("Hosted runtime tools state is invalid") from exc
     try:
-        mcp = validate_hosted_runtime_mcp_desired_state(state.mcp)
+        mcp_document = HostedRuntimeMcp.model_validate(state.mcp) if state.mcp is not None else None
         workspace_skills = (
             PersistedHostedRuntimeSkills.model_validate(state.skills).model_dump(
                 exclude_none=True,
@@ -594,6 +596,20 @@ def render_runtime_source(
         )
     except (ValidationError, ValueError) as exc:
         raise RuntimeSourceError("Hosted runtime MCP or skills state is invalid") from exc
+    if mcp_document is None:
+        mcp = None
+    else:
+        clawdi_mcp = mcp_document.servers.get("clawdi")
+        public_clawdi_mcp_url = f"{public_api_url.rstrip('/')}/v1/mcp/clawdi"
+        if isinstance(clawdi_mcp, HostedRuntimePlatformMcpServer):
+            mcp_document.servers["clawdi"] = HostedRuntimeRemoteMcpServer(
+                url=public_clawdi_mcp_url,
+                transport=clawdi_mcp.transport,
+                headers=clawdi_mcp.headers,
+            )
+        elif isinstance(clawdi_mcp, HostedRuntimeRemoteMcpServer):
+            clawdi_mcp.url = public_clawdi_mcp_url
+        mcp = mcp_document.model_dump(mode="json")
     skills = _project_runtime_skills(
         workspace_skills,
         batch.project_skills.get(environment_id, ()),

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -149,7 +149,7 @@ TEST_HERMES_DASHBOARD_AUTH = {
 }
 
 
-def test_hosted_filebrowser_companion_enforces_pins_and_auth_binding() -> None:
+def test_hosted_filebrowser_companion_enforces_source_and_auth_binding() -> None:
     files_deployment_id = "hdep_files_contract"
     companion = _filebrowser_companion(files_deployment_id)
     body = _runtime_state_body(
@@ -183,10 +183,25 @@ def test_hosted_filebrowser_companion_enforces_pins_and_auth_binding() -> None:
         with pytest.raises(ValidationError, match="Files authentication fields must reference"):
             AdminRuntimeStateUpsert.model_validate(invalid)
 
-    unpinned = json.loads(json.dumps(body))
-    unpinned["companions"]["filebrowser"]["assets"]["amd64"]["sha256"] = "d" * 64
-    with pytest.raises(ValidationError, match="pinned release"):
-        AdminRuntimeStateUpsert.model_validate(unpinned)
+    next_release = json.loads(json.dumps(body))
+    next_release["companions"]["filebrowser"]["version"] = "v1.6.0-stable"
+    next_release["companions"]["filebrowser"]["commit"] = "c" * 40
+    for architecture in ("amd64", "arm64"):
+        asset = next_release["companions"]["filebrowser"]["assets"][architecture]
+        asset["url"] = (
+            "https://github.com/gtsteffaniak/filebrowser/releases/download/"
+            f"v1.6.0-stable/linux-{architecture}-filebrowser"
+        )
+        asset["sha256"] = "d" * 64
+    AdminRuntimeStateUpsert.model_validate(next_release)
+
+    mismatched = json.loads(json.dumps(next_release))
+    mismatched["companions"]["filebrowser"]["assets"]["amd64"]["url"] = (
+        "https://github.com/gtsteffaniak/filebrowser/releases/download/"
+        "v1.5.0-stable/linux-amd64-filebrowser"
+    )
+    with pytest.raises(ValidationError, match="must match its release"):
+        AdminRuntimeStateUpsert.model_validate(mismatched)
 
 
 def test_hosted_runtime_skills_retain_exact_repository_root_source() -> None:
@@ -331,6 +346,23 @@ def test_hosted_mcp_accepts_public_literals_and_secret_ref_credentials() -> None
             }
         }
     )
+
+
+def test_hosted_platform_mcp_keeps_secret_ref_header_boundary() -> None:
+    server = {
+        "platform": "clawdi",
+        "transport": "streamable-http",
+        "headers": {
+            "Authorization": {
+                "secretRef": "secret://clawdi/auth-token",
+                "prefix": "Bearer ",
+            }
+        },
+    }
+    HostedRuntimeMcp.model_validate({"servers": {"clawdi": server}})
+    server["headers"] = {"Authorization": "literal-token"}
+    with pytest.raises(ValidationError, match="must use secretRef"):
+        HostedRuntimeMcp.model_validate({"servers": {"clawdi": server}})
 
 
 async def _create_bundle_runtime(admin_client, db_session, seed_user):

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -381,6 +381,55 @@ def test_runtime_source_revision_uses_only_projected_descriptor_and_secret_sourc
     ]
 
 
+def test_runtime_source_owns_the_public_clawdi_mcp_url() -> None:
+    first = _batch()
+    second = _batch()
+    for batch in (first, second):
+        state = batch.rows[ENV_ID].state
+        assert state is not None
+        state.mcp = {
+            "servers": {
+                "clawdi": {
+                    "platform": "clawdi",
+                    "transport": "streamable-http",
+                    "headers": {
+                        "Authorization": {
+                            "secretRef": "secret://clawdi/auth-token",
+                            "prefix": "Bearer ",
+                        }
+                    },
+                }
+            }
+        }
+    second_state = second.rows[ENV_ID].state
+    assert second_state is not None
+    second_state.mcp["servers"]["clawdi"] = {
+        **second_state.mcp["servers"]["clawdi"],
+        "url": "https://stale-hosted.example/v1/mcp/clawdi",
+    }
+    del second_state.mcp["servers"]["clawdi"]["platform"]
+
+    first_render = _render(first)
+    second_render = _render(second)
+
+    assert first_render.manifest["mcp"]["servers"]["clawdi"]["url"] == (
+        "https://cloud.test/v1/mcp/clawdi"
+    )
+    assert first_render.source_revision == second_render.source_revision
+    first_state = first.rows[ENV_ID].state
+    assert first_state is not None
+    assert first_state.mcp["servers"]["clawdi"] == {
+        "platform": "clawdi",
+        "transport": "streamable-http",
+        "headers": {
+            "Authorization": {
+                "secretRef": "secret://clawdi/auth-token",
+                "prefix": "Bearer ",
+            }
+        },
+    }
+
+
 def test_runtime_source_binds_whatsapp_capability_and_revision_to_link_credential_and_cert(
     monkeypatch,
 ) -> None:

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.75",
+      "version": "0.13.76",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -148,10 +148,11 @@ boundary.
 
 The primary hosted runtime model is a Linux-like runtime host. The host image
 provides the OS envelope, a runtime user, a root-only `clawdi` bootstrap path,
-official Hermes/OpenClaw installs, and a process manager. Runtime behavior
-comes from the manifest and official runtime binaries, not from per-agent
-wrappers. The managed Clawdi CLI is an administrator capability: the runtime
-user, model tools, and browser terminal cannot resolve, read, or execute it.
+the prerequisites for official Hermes/OpenClaw installers, and a process
+manager. Runtime behavior comes from the manifest and official runtime
+binaries, not from per-agent wrappers. The managed Clawdi CLI is an
+administrator capability: the runtime user, model tools, and browser terminal
+cannot resolve, read, or execute it.
 
 ```mermaid
 flowchart TB
@@ -262,8 +263,8 @@ already-existing root. If a root disappears after preflight, no child writer
 recursively recreates it; convergence fails and leaves root restoration to the
 systemd/image boundary that owns it.
 
-That entrypoint reads the exact managed CLI pin from the canonical runtime
-context, installs it under a root-only versioned npm prefix, atomically activates
+That entrypoint reads the exact managed CLI pin from the authenticated Cloud
+manifest, installs it under a root-only versioned npm prefix, atomically activates
 `/var/lib/clawdi/maintained/clawdi/bin/clawdi`, and runs
 `runtime init --non-interactive`. `runtime init` is the local administrator
 convergence step. It invokes official non-interactive service installers for
@@ -574,7 +575,7 @@ Normalization maps hosted fields into the internal shape:
 | `clawdiCli.packageSpec` | Required exact `clawdi@<semver>` without build metadata, at most 200 characters; remote Hosted manifests never select an npm dist-tag or local path |
 | `clawdiCli.registry` | Required literal `https://registry.npmjs.org`; Hosted does not use npm registry defaults or overrides |
 | `runtimes.<name>.enabled` | Run config and systemd unit state |
-| `runtimes.<name>.install` | Required strict `{source: "official"}` selector; CLI owns installer URL and args |
+| `runtimes.<name>.install` | Required strict `{source: "official"}` selector; CLI owns the official installer URL and non-version arguments, and Hosted cannot select a version, channel, commit, digest, or custom installer |
 | `runtimes.<name>.run` | Command, args, cwd, env, and PATH projection |
 | `runtimes.<name>.providerMode` | Required runtime-provider ownership discriminator: `configured` or `unmanaged` |
 | `runtimes.<name>.provider_ids` | Core Hosted configured mode requires exactly one provider; unmanaged mode requires an exact empty list. Selection is replacement-only, with no fallback or secondary pool. |
@@ -590,6 +591,11 @@ Normalization maps hosted fields into the internal shape:
 | `liveSync.{enabled,agents}` | Required explicit daemon sync configuration; Hosted does not infer it from agent metadata |
 | `egressProfiles` | Explicit local sidecar profiles |
 | `recovery.{cacheManifest,allowOfflineBoot}` | Required explicit manifest cache and offline-boot behavior |
+
+When an OpenClaw or Hermes installation is missing or requires repair, the CLI
+invokes the official installer without a version selector, so the installer
+chooses its current upstream release. A healthy installed runtime is not
+reinstalled merely to poll for a newer release.
 
 Hosted parsing does not accept camel-case runtime binding aliases, snake-case
 provider transport aliases, or string `primary_model` values. Provider model
@@ -1092,9 +1098,9 @@ fields such as desired or observed replica generation.
 
 Strict-v2 workloads provide their bootstrap and apply authority through the
 single fixed file `/etc/clawdi/runtime-context.json`. The file
-is a strict `clawdi.runtimeContext.v2` object containing an `apply` tuple
+is a strict `clawdi.runtimeContext.v3` object containing an `apply` tuple
 (`generation`, `manifestETag`, `applyReceiptId`, and `bootNonce`), an exact
-`backend: "incus"` attestation, the exact bootstrap `cliPackageSpec`, and a typed HTTP
+`backend: "incus"` attestation, and a typed HTTP
 `manifestSource` with bearer auth. `backend` is required for every Hosted v2
 context and is validated by the common precondition gate before convergence.
 Business secrets are not bootstrap context: the fetched bundle's `secretValues`
@@ -1104,10 +1110,11 @@ process environment are not duplicated in the context. A missing or malformed
 context
 fails closed, and no field falls back to ambient process environment. The
 applied generation must match the fetched manifest before CLI installation,
-systemd mutation, or applied-authority commit can occur. The context package is
-validated as bootstrap identity but is not desired-state authority and need not
-match a later exact package selected by the manifest. The paired-image local
-tarball exception exists only when the explicit test-installer gate is enabled.
+systemd mutation, or applied-authority commit can occur. The CLI package is
+selected only by manifest `clawdiCli.packageSpec`. RuntimeContext v2 remains a
+read-only compatibility input; its legacy `cliPackageSpec` is ignored and new
+contexts never write it. The paired-image local tarball exception exists only
+in manifest fixtures when the explicit test-installer gate is enabled.
 `manifestETag` names the
 Hosted control-plane snapshot and is persisted separately from the fetched
 bundle's HTTP ETag, which remains the strong validator derived from

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.75",
+	"version": "0.13.76",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/apply-identity.test.ts
+++ b/packages/cli/src/runtime/apply-identity.test.ts
@@ -32,7 +32,7 @@ function contextFile(root: string): string {
 	writeFileSync(
 		path,
 		JSON.stringify({
-			schemaVersion: "clawdi.runtimeContext.v2",
+			schemaVersion: "clawdi.runtimeContext.v3",
 			backend: "incus",
 			apply: {
 				generation: 8,
@@ -40,7 +40,6 @@ function contextFile(root: string): string {
 				applyReceiptId: "apply-receipt-0008",
 				bootNonce: "boot-nonce-000008",
 			},
-			cliPackageSpec: "clawdi@1.2.3",
 			manifestSource: {
 				type: "http",
 				url: "https://runtime.test/v1/runtime/manifest?environment_id=env-test",
@@ -88,7 +87,6 @@ describe("runtime apply identity", () => {
 				applyReceiptId: "apply-receipt-0008",
 				bootNonce: "boot-nonce-000008",
 			},
-			cliPackageSpec: "clawdi@1.2.3",
 			manifestSource: {
 				type: "http",
 				url: "https://runtime.test/v1/runtime/manifest?environment_id=env-test",
@@ -111,18 +109,17 @@ describe("runtime apply identity", () => {
 		expect(() => readRuntimeApplyContext()).toThrow(/canonical absolute path/);
 	});
 
-	test("accepts the fixed paired-image CLI fixture path only behind the test gate", () => {
+	test("reads legacy v2 context without treating its CLI field as authority", () => {
 		const root = mkdtempSync(join(tmpdir(), "clawdi-paired-cli-fixture-"));
 		roots.push(root);
 		const path = contextFile(root);
 		const parsed: Record<string, unknown> = JSON.parse(readFileSync(path, "utf-8"));
+		parsed.schemaVersion = "clawdi.runtimeContext.v2";
 		parsed.cliPackageSpec = "/usr/local/share/clawdi/bootstrap/clawdi-local.tgz";
 		writeFileSync(path, JSON.stringify(parsed));
 		expect(() => readRuntimeApplyContext(path)).toThrow(/CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS=1/);
 		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
-		expect(readRuntimeApplyContext(path).cliPackageSpec).toBe(
-			"/usr/local/share/clawdi/bootstrap/clawdi-local.tgz",
-		);
+		expect(readRuntimeApplyContext(path).identity.generation).toBe(8);
 
 		parsed.cliPackageSpec = "/tmp/clawdi-local.tgz";
 		writeFileSync(path, JSON.stringify(parsed));
@@ -144,7 +141,7 @@ describe("runtime apply identity", () => {
 		expect(() => readRuntimeApplyContext(legacy)).toThrow(/invalid runtime context file/);
 	});
 
-	test("requires the attested Incus backend in every v2 runtime context", () => {
+	test("requires the attested Incus backend in every runtime context", () => {
 		const root = mkdtempSync(join(tmpdir(), "clawdi-missing-runtime-backend-"));
 		roots.push(root);
 		const path = contextFile(root);

--- a/packages/cli/src/runtime/apply-identity.ts
+++ b/packages/cli/src/runtime/apply-identity.ts
@@ -80,7 +80,7 @@ export const runtimeManifestSourceSchema = z
 
 export type RuntimeManifestSource = z.infer<typeof runtimeManifestSourceSchema>;
 
-const runtimeContextFileSchema = z
+const runtimeContextV2FileSchema = z
 	.object({
 		schemaVersion: z.literal("clawdi.runtimeContext.v2"),
 		backend: z.literal("incus"),
@@ -92,13 +92,26 @@ const runtimeContextFileSchema = z
 	})
 	.strict();
 
+const runtimeContextV3FileSchema = z
+	.object({
+		schemaVersion: z.literal("clawdi.runtimeContext.v3"),
+		backend: z.literal("incus"),
+		apply: runtimeApplyIdentitySchema,
+		manifestSource: runtimeManifestSourceSchema,
+	})
+	.strict();
+
+const runtimeContextFileSchema = z.discriminatedUnion("schemaVersion", [
+	runtimeContextV2FileSchema,
+	runtimeContextV3FileSchema,
+]);
+
 type RuntimeContextFile = z.infer<typeof runtimeContextFileSchema>;
 
 export interface RuntimeApplyContext {
 	kind: "context-file";
 	backend: "incus";
 	identity: RuntimeApplyIdentity;
-	cliPackageSpec: string;
 	manifestSource: RuntimeManifestSource;
 }
 
@@ -116,7 +129,6 @@ export function readRuntimeApplyContext(
 		kind: "context-file",
 		backend: parsed.backend,
 		identity: parsed.apply,
-		cliPackageSpec: parsed.cliPackageSpec,
 		manifestSource: parsed.manifestSource,
 	};
 }
@@ -155,6 +167,7 @@ function readRuntimeContextFile(contextPath: string): RuntimeContextFile {
 		);
 	}
 	if (
+		parsed.data.schemaVersion === "clawdi.runtimeContext.v2" &&
 		parsed.data.cliPackageSpec === HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE &&
 		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS !== "1"
 	) {

--- a/packages/cli/src/runtime/hosted-runtime-contract.test.ts
+++ b/packages/cli/src/runtime/hosted-runtime-contract.test.ts
@@ -13,7 +13,6 @@ const applyContext: RuntimeApplyContext = {
 		applyReceiptId: "test-apply-receipt",
 		bootNonce: "test-boot-nonce",
 	},
-	cliPackageSpec: "clawdi@1.2.3",
 	manifestSource: {
 		type: "http",
 		url: "https://runtime.test/v1/runtime/manifest",

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -205,13 +205,12 @@ export const hostedFixtureCliPayloadPolicySchema = hostedCliPayloadPolicySchema.
 
 const sha256Schema = z.string().regex(/^[a-fA-F0-9]{64}$/);
 
-export const FILE_BROWSER_VERSION = "v1.5.0-stable";
-export const FILE_BROWSER_COMMIT = "79552f8adb27c3e29934c4001660eb98f4aab5d6";
 export const FILE_BROWSER_PORT = 9120;
-export const FILE_BROWSER_AMD64_SHA256 =
-	"8d51d1718d576d22e73e1f41a5194b451d152ddab0df97697cabe839cf59524e";
-export const FILE_BROWSER_ARM64_SHA256 =
-	"3e18838ae33750a25da434dc6156a359968bf7935e01bdd884711f47f08ad92f";
+
+const fileBrowserVersionSchema = z
+	.string()
+	.regex(/^v[0-9A-Za-z][0-9A-Za-z._-]{0,63}$/, "must be a canonical release tag");
+const fileBrowserCommitSchema = z.string().regex(/^[a-f0-9]{40}$/);
 
 const fileBrowserAssetSchema = z
 	.object({
@@ -221,6 +220,29 @@ const fileBrowserAssetSchema = z
 	.strict();
 
 const FILE_BROWSER_AUDIENCE_PREFIX = "clawdi-files:";
+
+function isCanonicalFileBrowserAssetUrl(
+	url: string,
+	version: string,
+	architecture: string,
+): boolean {
+	try {
+		const parsed = new URL(url);
+		return (
+			parsed.protocol === "https:" &&
+			parsed.hostname === "github.com" &&
+			parsed.port === "" &&
+			parsed.username === "" &&
+			parsed.password === "" &&
+			parsed.search === "" &&
+			parsed.hash === "" &&
+			parsed.pathname ===
+				`/gtsteffaniak/filebrowser/releases/download/${version}/linux-${architecture}-filebrowser`
+		);
+	} catch {
+		return false;
+	}
+}
 
 const fileBrowserAuthSchema = z
 	.object({
@@ -258,8 +280,8 @@ const fileBrowserAuthSchema = z
 
 export const fileBrowserCompanionSchema = z
 	.object({
-		version: z.literal(FILE_BROWSER_VERSION),
-		commit: z.literal(FILE_BROWSER_COMMIT),
+		version: fileBrowserVersionSchema,
+		commit: fileBrowserCommitSchema,
 		listen: z.literal("0.0.0.0"),
 		port: z.literal(FILE_BROWSER_PORT),
 		baseURL: z.literal("/"),
@@ -267,23 +289,30 @@ export const fileBrowserCompanionSchema = z
 		sourceRoot: z.literal("/home/clawdi"),
 		assets: z
 			.object({
-				amd64: fileBrowserAssetSchema.extend({
-					url: z.literal(
-						`https://github.com/gtsteffaniak/filebrowser/releases/download/${FILE_BROWSER_VERSION}/linux-amd64-filebrowser`,
-					),
-					sha256: z.literal(FILE_BROWSER_AMD64_SHA256),
-				}),
-				arm64: fileBrowserAssetSchema.extend({
-					url: z.literal(
-						`https://github.com/gtsteffaniak/filebrowser/releases/download/${FILE_BROWSER_VERSION}/linux-arm64-filebrowser`,
-					),
-					sha256: z.literal(FILE_BROWSER_ARM64_SHA256),
-				}),
+				amd64: fileBrowserAssetSchema,
+				arm64: fileBrowserAssetSchema,
 			})
 			.strict(),
 		auth: fileBrowserAuthSchema,
 	})
-	.strict();
+	.strict()
+	.superRefine((companion, ctx) => {
+		for (const architecture of ["amd64", "arm64"] as const) {
+			if (
+				!isCanonicalFileBrowserAssetUrl(
+					companion.assets[architecture].url,
+					companion.version,
+					architecture,
+				)
+			) {
+				ctx.addIssue({
+					code: "custom",
+					message: "Files asset URL must match its declared release and architecture",
+					path: ["assets", architecture, "url"],
+				});
+			}
+		}
+	});
 
 const runtimeCompanionsSchema = z
 	.object({

--- a/packages/cli/src/runtime/manifest-mutation-parity.test.ts
+++ b/packages/cli/src/runtime/manifest-mutation-parity.test.ts
@@ -185,7 +185,6 @@ exit 0
 				applyReceiptId: "apply-receipt-parity-0001",
 				bootNonce: "boot-nonce-parity-0000001",
 			},
-			cliPackageSpec: "clawdi@1.2.3-test",
 			manifestSource: {
 				type: "http",
 				url: "https://runtime.test/v1/runtime/manifest",

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -49,10 +49,6 @@ import {
 	runtimeUserMutationTargets,
 } from "./manifest";
 import {
-	FILE_BROWSER_AMD64_SHA256,
-	FILE_BROWSER_ARM64_SHA256,
-	FILE_BROWSER_COMMIT,
-	FILE_BROWSER_VERSION,
 	fileBrowserCompanionSchema,
 	hostedRuntimeBundleV2ManifestSchema,
 	hostedRuntimeManifestFixtureResponseSchema,
@@ -86,6 +82,12 @@ const TEST_HOSTED_HOME = "/home/clawdi";
 const TEST_PROCESS_UID = process.getuid?.() ?? 1_000;
 const TEST_PROCESS_GID = process.getgid?.() ?? 1_000;
 const TEST_RUNTIME_USER = String(TEST_PROCESS_UID);
+const FILE_BROWSER_VERSION = "v1.5.0-stable";
+const FILE_BROWSER_COMMIT = "79552f8adb27c3e29934c4001660eb98f4aab5d6";
+const FILE_BROWSER_AMD64_SHA256 =
+	"8d51d1718d576d22e73e1f41a5194b451d152ddab0df97697cabe839cf59524e";
+const FILE_BROWSER_ARM64_SHA256 =
+	"3e18838ae33750a25da434dc6156a359968bf7935e01bdd884711f47f08ad92f";
 const TEST_HOSTED_SECRET_VALUES = {
 	"secret://clawdi/auth-token": "test-auth-token",
 	"secret://runtime/openclaw/gateway-token": "gateway-token",
@@ -191,7 +193,6 @@ function manifestLoad(
 				applyReceiptId: "test-apply-receipt",
 				bootNonce: "test-boot-nonce",
 			},
-			cliPackageSpec: "clawdi@1.2.3",
 			manifestSource: {
 				type: "http",
 				url: "https://runtime.test/v1/runtime/manifest?environment_id=env-test",
@@ -5393,6 +5394,22 @@ exit 42
 			false,
 		);
 		expect(fileBrowserCompanionSchema.safeParse({ ...pinned, port: 9000 }).success).toBe(false);
+		const nextRelease = {
+			...pinned,
+			version: "v1.6.0-stable",
+			commit: "b".repeat(40),
+			assets: {
+				amd64: {
+					url: "https://github.com/gtsteffaniak/filebrowser/releases/download/v1.6.0-stable/linux-amd64-filebrowser",
+					sha256: "c".repeat(64),
+				},
+				arm64: {
+					url: "https://github.com/gtsteffaniak/filebrowser/releases/download/v1.6.0-stable/linux-arm64-filebrowser",
+					sha256: "d".repeat(64),
+				},
+			},
+		};
+		expect(fileBrowserCompanionSchema.safeParse(nextRelease).success).toBe(true);
 		expect(
 			fileBrowserCompanionSchema.safeParse({
 				...pinned,
@@ -5404,7 +5421,10 @@ exit 42
 				...pinned,
 				assets: {
 					...pinned.assets,
-					amd64: { ...pinned.assets.amd64, sha256: "d".repeat(64) },
+					amd64: {
+						...pinned.assets.amd64,
+						url: "https://github.com/gtsteffaniak/filebrowser/releases/download/v1.6.0-stable/linux-amd64-filebrowser",
+					},
 				},
 			}).success,
 		).toBe(false);

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -60,7 +60,6 @@ function convergeRuntimeManifest(
 					applyReceiptId: "test-apply-receipt",
 					bootNonce: "test-boot-nonce",
 				},
-				cliPackageSpec: "clawdi@1.2.3",
 				manifestSource: {
 					type: "http",
 					url: "https://runtime.test/v1/runtime/manifest?environment_id=env-test",
@@ -713,7 +712,6 @@ describe("runtime manifest services", () => {
 				applyReceiptId: "apply-receipt-0001",
 				bootNonce: "boot-nonce-000001",
 			},
-			cliPackageSpec: "clawdi@1.2.3",
 			manifestSource: {
 				type: "http" as const,
 				url: "https://runtime.test/v1/runtime/manifest?environment_id=env-test",

--- a/packages/cli/src/runtime/observation-producer.test.ts
+++ b/packages/cli/src/runtime/observation-producer.test.ts
@@ -62,7 +62,7 @@ function writeApplyIdentityFile(paths: RuntimePaths, generation: number): void {
 	writeFileSync(
 		path,
 		JSON.stringify({
-			schemaVersion: "clawdi.runtimeContext.v2",
+			schemaVersion: "clawdi.runtimeContext.v3",
 			backend: "incus",
 			apply: {
 				generation,
@@ -70,7 +70,6 @@ function writeApplyIdentityFile(paths: RuntimePaths, generation: number): void {
 				applyReceiptId: `apply-receipt-000${generation}`,
 				bootNonce: "boot-nonce-000001",
 			},
-			cliPackageSpec: "clawdi@1.2.3",
 			manifestSource: {
 				type: "http",
 				url: "https://runtime.test/v1/runtime/manifest?environment_id=env_producer",

--- a/packages/cli/src/runtime/platform-root-modes.test.ts
+++ b/packages/cli/src/runtime/platform-root-modes.test.ts
@@ -127,7 +127,6 @@ exit 0
 				applyReceiptId: "apply-receipt-root-modes-0001",
 				bootNonce: "boot-nonce-root-modes-0000001",
 			},
-			cliPackageSpec: "clawdi@1.2.3-test",
 			manifestSource: {
 				type: "http",
 				url: "https://runtime.test/v1/runtime/manifest",

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -90,7 +90,6 @@ function applyRuntimeBundleChannelsToManifestLoad(load: RuntimeManifestLoad): Ru
 				applyReceiptId: "test-apply-receipt",
 				bootNonce: "test-boot-nonce",
 			},
-			cliPackageSpec: "clawdi@1.2.3",
 			manifestSource: {
 				type: "http",
 				url: "https://runtime.test/v1/runtime/manifest?environment_id=env-test",
@@ -115,16 +114,14 @@ function readFileTree(root: string): string {
 function setRuntimeApplyIdentityFile(
 	root: string,
 	identity: { generation: number; manifestETag: string; applyReceiptId: string; bootNonce: string },
-	cliPackageSpec = "clawdi@1.2.3",
 ): RuntimeApplyContext {
 	const path = join(root, "runtime-context.json");
 	writeFileSync(
 		path,
 		JSON.stringify({
-			schemaVersion: "clawdi.runtimeContext.v2",
+			schemaVersion: "clawdi.runtimeContext.v3",
 			backend: "incus",
 			apply: identity,
-			cliPackageSpec,
 			manifestSource: {
 				type: "http",
 				url: "https://runtime.test/v1/runtime/manifest?environment_id=env-test",
@@ -1180,16 +1177,12 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
 		process.env.CLAWDI_RUN_DIR = join(root, "run");
 		process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
-		const applyContext = setRuntimeApplyIdentityFile(
-			root,
-			{
-				generation: 1,
-				manifestETag: '"bundle-golden"',
-				applyReceiptId: "apply-receipt-golden-0001",
-				bootNonce: "boot-nonce-golden-000001",
-			},
-			"clawdi@1.2.3-test",
-		);
+		const applyContext = setRuntimeApplyIdentityFile(root, {
+			generation: 1,
+			manifestETag: '"bundle-golden"',
+			applyReceiptId: "apply-receipt-golden-0001",
+			bootNonce: "boot-nonce-golden-000001",
+		});
 		const paths = getRuntimePaths({ mode: "hosted" });
 		globalThis.fetch = Object.assign(
 			async () =>
@@ -1213,16 +1206,12 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
 		process.env.CLAWDI_RUN_DIR = join(root, "run");
 		process.env.CLAWDI_RUNTIME_HOME = "/home/clawdi";
-		const applyContext = setRuntimeApplyIdentityFile(
-			root,
-			{
-				generation: 1,
-				manifestETag: '"bundle-golden"',
-				applyReceiptId: "apply-receipt-golden-0001",
-				bootNonce: "boot-nonce-golden-000001",
-			},
-			"clawdi@1.2.3-test",
-		);
+		const applyContext = setRuntimeApplyIdentityFile(root, {
+			generation: 1,
+			manifestETag: '"bundle-golden"',
+			applyReceiptId: "apply-receipt-golden-0001",
+			bootNonce: "boot-nonce-golden-000001",
+		});
 		const paths = getRuntimePaths({ mode: "hosted" });
 		globalThis.fetch = Object.assign(
 			async () =>
@@ -1243,22 +1232,18 @@ describe("hosted runtime bundle v2", () => {
 		expect(loaded.channelBindings).toHaveLength(1);
 	});
 
-	test("takes the desired CLI package from the runtime manifest", async () => {
+	test("takes the desired CLI package only from the runtime manifest", async () => {
 		const root = mkdtempSync(join(tmpdir(), "clawdi-runtime-bundle-cli-update-"));
 		roots.push(root);
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
 		process.env.CLAWDI_RUN_DIR = join(root, "run");
 		process.env.CLAWDI_RUNTIME_HOME = "/home/clawdi";
-		const applyContext = setRuntimeApplyIdentityFile(
-			root,
-			{
-				generation: 1,
-				manifestETag: '"bundle-golden"',
-				applyReceiptId: "apply-receipt-golden-0001",
-				bootNonce: "boot-nonce-golden-000001",
-			},
-			"clawdi@1.2.2-test",
-		);
+		const applyContext = setRuntimeApplyIdentityFile(root, {
+			generation: 1,
+			manifestETag: '"bundle-golden"',
+			applyReceiptId: "apply-receipt-golden-0001",
+			bootNonce: "boot-nonce-golden-000001",
+		});
 		globalThis.fetch = Object.assign(
 			async () =>
 				new Response(readFileSync(goldenPath, "utf-8"), {
@@ -1276,7 +1261,6 @@ describe("hosted runtime bundle v2", () => {
 		});
 
 		if (!("manifest" in loaded)) throw new Error(JSON.stringify(loaded));
-		expect(applyContext.cliPackageSpec).toBe("clawdi@1.2.2-test");
 		expect(loaded.manifest.clawdiCli?.packageSpec).toBe("clawdi@1.2.3-test");
 	});
 
@@ -1286,16 +1270,12 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
 		process.env.CLAWDI_RUN_DIR = join(root, "run");
 		process.env.CLAWDI_RUNTIME_HOME = "/home/clawdi";
-		const applyContext = setRuntimeApplyIdentityFile(
-			root,
-			{
-				generation: 1,
-				manifestETag: '"bundle-golden"',
-				applyReceiptId: "apply-receipt-golden-0001",
-				bootNonce: "boot-nonce-golden-000001",
-			},
-			"clawdi@1.2.3-test",
-		);
+		const applyContext = setRuntimeApplyIdentityFile(root, {
+			generation: 1,
+			manifestETag: '"bundle-golden"',
+			applyReceiptId: "apply-receipt-golden-0001",
+			bootNonce: "boot-nonce-golden-000001",
+		});
 		globalThis.fetch = Object.assign(
 			async () =>
 				new Response(readFileSync(goldenPath, "utf-8"), {
@@ -1366,16 +1346,12 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_EGRESS_UID = "10002";
 		process.env.CLAWDI_EGRESS_GID = "10002";
 		process.env.OPENCLAW_GATEWAY_TOKEN = "gateway-token";
-		const applyContext = setRuntimeApplyIdentityFile(
-			root,
-			{
-				generation: 1,
-				manifestETag: '"bundle-golden"',
-				applyReceiptId: "apply-receipt-golden-0001",
-				bootNonce: "boot-nonce-golden-000001",
-			},
-			"clawdi@1.2.3-test",
-		);
+		const applyContext = setRuntimeApplyIdentityFile(root, {
+			generation: 1,
+			manifestETag: '"bundle-golden"',
+			applyReceiptId: "apply-receipt-golden-0001",
+			bootNonce: "boot-nonce-golden-000001",
+		});
 		const paths = getRuntimePaths({ mode: "hosted" });
 		const goldenRaw = JSON.parse(readFileSync(goldenPath, "utf-8")) as {
 			sourceRevision: string;

--- a/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
+++ b/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
@@ -339,7 +339,7 @@ function cliEnv(fixture: Fixture, runtimeMode: "local" | "hosted"): Record<strin
 	writeFileSync(
 		fixture.contextPath,
 		`${JSON.stringify({
-			schemaVersion: "clawdi.runtimeContext.v2",
+			schemaVersion: "clawdi.runtimeContext.v3",
 			backend: "incus",
 			apply: {
 				generation: 1,
@@ -347,7 +347,6 @@ function cliEnv(fixture: Fixture, runtimeMode: "local" | "hosted"): Record<strin
 				applyReceiptId: "apply-receipt-daemon-rpc",
 				bootNonce: "boot-nonce-daemon-rpc-01",
 			},
-			cliPackageSpec: "clawdi@1.2.3-test",
 			manifestSource: {
 				type: "http",
 				url: `${server.url.origin}/v1/runtime/manifest`,

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -27,18 +27,18 @@ import {
 	buildOpenClawHostedProviderPatch,
 	convergeRuntimeManifest,
 } from "../../src/runtime/manifest";
-import {
-	FILE_BROWSER_AMD64_SHA256,
-	FILE_BROWSER_ARM64_SHA256,
-	FILE_BROWSER_COMMIT,
-	FILE_BROWSER_VERSION,
-	type RuntimeManifest,
-} from "../../src/runtime/manifest-contract";
+import type { RuntimeManifest } from "../../src/runtime/manifest-contract";
 import type { RuntimeManifestLoad } from "../../src/runtime/manifest-source";
 import { getRuntimePaths } from "../../src/runtime/paths";
 import { ensureRuntimeStateDirs } from "../../src/runtime/state";
 
 const REAL_SYSTEMD_GATE = "CLAWDI_TEST_REAL_OPENCLAW_SYSTEMD";
+const FILE_BROWSER_VERSION = "v1.5.0-stable";
+const FILE_BROWSER_COMMIT = "79552f8adb27c3e29934c4001660eb98f4aab5d6";
+const FILE_BROWSER_AMD64_SHA256 =
+	"8d51d1718d576d22e73e1f41a5194b451d152ddab0df97697cabe839cf59524e";
+const FILE_BROWSER_ARM64_SHA256 =
+	"3e18838ae33750a25da434dc6156a359968bf7935e01bdd884711f47f08ad92f";
 
 test("propagates the real official OpenClaw installer failure and rolls back as UID 10001", () => {
 	if (process.env[REAL_SYSTEMD_GATE] !== "1") return;
@@ -187,7 +187,6 @@ test("propagates the real official OpenClaw installer failure and rolls back as 
 				applyReceiptId: "real-systemd-test-receipt",
 				bootNonce: "real-systemd-test-boot",
 			},
-			cliPackageSpec: "clawdi@1.2.3",
 			manifestSource: {
 				type: "http",
 				url: "https://runtime.test/v1/runtime/manifest?environment_id=env_real_openclaw_systemd",
@@ -386,7 +385,6 @@ test("projects a large OpenClaw provider model-list reduction through the public
 				applyReceiptId: "real-size-drop-test-receipt",
 				bootNonce: "real-size-drop-test-boot",
 			},
-			cliPackageSpec: "clawdi@1.2.3",
 			manifestSource: {
 				type: "http",
 				url: "https://runtime.test/v1/runtime/manifest?environment_id=env_real_openclaw_size_drop",
@@ -591,7 +589,6 @@ test("persists and serves the managed token through the real official OpenClaw g
 				applyReceiptId: "real-token-test-receipt",
 				bootNonce: "real-token-test-boot",
 			},
-			cliPackageSpec: "clawdi@1.2.3",
 			manifestSource: {
 				type: "http",
 				url: "https://runtime.test/v1/runtime/manifest?environment_id=env_real_openclaw_token",
@@ -905,7 +902,6 @@ http.createServer((request, response) => {
 				applyReceiptId: "real-filebrowser-systemd-test-receipt",
 				bootNonce: "real-filebrowser-systemd-test-boot",
 			},
-			cliPackageSpec: "clawdi@1.2.3",
 			manifestSource: {
 				type: "http",
 				url: "https://runtime.test/v1/runtime/manifest?environment_id=env_real_filebrowser_systemd",

--- a/packages/cli/tests/egress-handoff-access-contract.test.ts
+++ b/packages/cli/tests/egress-handoff-access-contract.test.ts
@@ -276,7 +276,6 @@ esac
 				applyReceiptId: "apply-receipt-handoff-access-0001",
 				bootNonce: "boot-nonce-handoff-access-0000001",
 			},
-			cliPackageSpec: "clawdi@1.2.3-test",
 			manifestSource: {
 				type: "http",
 				url: "https://runtime.test/v1/runtime/manifest",

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -134,7 +134,6 @@ function explicitTestApplyContext(
 			applyReceiptId: "test-apply-receipt",
 			bootNonce: "test-boot-nonce-0001",
 		},
-		cliPackageSpec: "clawdi@1.2.3-test",
 		manifestSource: {
 			type: "http" as const,
 			url: "https://runtime.test/v1/runtime/manifest",
@@ -175,9 +174,6 @@ function liveTestApplyContext(): RuntimeApplyContext {
 		},
 		get identity() {
 			return currentTestApplyContext.identity;
-		},
-		get cliPackageSpec() {
-			return currentTestApplyContext.cliPackageSpec;
 		},
 		get manifestSource() {
 			return currentTestApplyContext.manifestSource;
@@ -614,7 +610,6 @@ function setRuntimeApplyContextFixture(
 	contextOverrides: Partial<TestRuntimeContextFixture> = {},
 ): void {
 	const contextValues: TestRuntimeContextFixture = {
-		cliPackageSpec: "clawdi@1.2.3-test",
 		manifestSourceUrl: "https://runtime.test/v1/runtime/manifest",
 		bootstrapBearer: "file-runtime-token",
 		...contextOverrides,
@@ -623,7 +618,6 @@ function setRuntimeApplyContextFixture(
 		kind: "context-file",
 		backend: "incus",
 		identity,
-		cliPackageSpec: contextValues.cliPackageSpec,
 		manifestSource: {
 			type: "http",
 			url: contextValues.manifestSourceUrl,
@@ -2318,13 +2312,11 @@ const OFFLINE_RUNTIME_APPLY_IDENTITY = {
 };
 
 interface TestRuntimeContextFixture {
-	cliPackageSpec: string;
 	manifestSourceUrl: string;
 	bootstrapBearer: string;
 }
 
 const CANONICAL_TEST_CONTEXT: TestRuntimeContextFixture = {
-	cliPackageSpec: "clawdi@1.2.3-test",
 	manifestSourceUrl: "https://runtime.test/v1/runtime/manifest",
 	bootstrapBearer: "file-runtime-token",
 };
@@ -2336,7 +2328,6 @@ function writeCanonicalApplyContext(
 		kind: "context-file",
 		backend: "incus",
 		identity,
-		cliPackageSpec: context.cliPackageSpec,
 		manifestSource: {
 			type: "http",
 			url: context.manifestSourceUrl,
@@ -9737,11 +9728,7 @@ fi
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
 		const currentVersion = getCliVersion();
-		const cliContext = {
-			...CANONICAL_TEST_CONTEXT,
-			cliPackageSpec: "clawdi@1.2.3-test",
-		};
-		setRuntimeApplyGeneration(13, cliContext);
+		setRuntimeApplyGeneration(13);
 		const runtimeContextBefore = JSON.stringify(currentTestApplyContext);
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
@@ -10619,11 +10606,7 @@ fi
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
 		const currentVersion = getCliVersion();
-		const cliContext = {
-			...CANONICAL_TEST_CONTEXT,
-			cliPackageSpec: `clawdi@${currentVersion}`,
-		};
-		setRuntimeApplyGeneration(1, cliContext);
+		setRuntimeApplyGeneration(1);
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
@@ -10807,7 +10790,7 @@ chmod +x "$prefix/bin/clawdi"
 		]);
 
 		try {
-			setRuntimeApplyGeneration(2, cliContext);
+			setRuntimeApplyGeneration(2);
 			await runtimeWatch({ once: true, json: true });
 
 			if (process.exitCode !== undefined && process.exitCode !== 0) {
@@ -11862,10 +11845,7 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("runtime watch never enters a failing projection after CLI activation", async () => {
-		setRuntimeApplyGeneration(16, {
-			...CANONICAL_TEST_CONTEXT,
-			cliPackageSpec: "clawdi@1.3.0-test.1",
-		});
+		setRuntimeApplyGeneration(16);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -12022,10 +12002,7 @@ chmod +x "$HOME/.local/bin/openclaw"
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
 		const currentVersion = getCliVersion();
-		setRuntimeApplyGeneration(18, {
-			...CANONICAL_TEST_CONTEXT,
-			cliPackageSpec: `clawdi@${currentVersion}`,
-		});
+		setRuntimeApplyGeneration(18);
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
@@ -12213,10 +12190,7 @@ chmod +x "$prefix/bin/clawdi"
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
 		const currentVersion = getCliVersion();
-		setRuntimeApplyGeneration(17, {
-			...CANONICAL_TEST_CONTEXT,
-			cliPackageSpec: `clawdi@${currentVersion}`,
-		});
+		setRuntimeApplyGeneration(17);
 		const firstAttempt = join(root, "npm-etarget-first-attempt");
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
@@ -12913,11 +12887,7 @@ chmod +x "$prefix/bin/clawdi"
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
 		const currentVersion = getCliVersion();
-		const cliContext = {
-			...CANONICAL_TEST_CONTEXT,
-			cliPackageSpec: `clawdi@${currentVersion}`,
-		};
-		setRuntimeApplyGeneration(1, cliContext);
+		setRuntimeApplyGeneration(1);
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(dirname(policyPath), { recursive: true });
@@ -13008,7 +12978,7 @@ chmod +x "$prefix/bin/clawdi"
 
 			logs.length = 0;
 			process.exitCode = undefined;
-			setRuntimeApplyGeneration(1, cliContext);
+			setRuntimeApplyGeneration(1);
 			await runtimeInit({ nonInteractive: true, json: true });
 
 			if (process.exitCode !== undefined && process.exitCode !== 0) {
@@ -13320,10 +13290,7 @@ exit 64
 			channelBindings: bundle.channelBindings,
 			secretValues: bundle.secretValues,
 		});
-		setRuntimeApplyGeneration(bundle.applyGeneration, {
-			...CANONICAL_TEST_CONTEXT,
-			cliPackageSpec: bundle.manifest.clawdiCli.packageSpec,
-		});
+		setRuntimeApplyGeneration(bundle.applyGeneration);
 
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(dirname(policyPath), { recursive: true });

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -16,7 +16,7 @@ function writeRuntimeContext(
 	writeFileSync(
 		path,
 		`${JSON.stringify({
-			schemaVersion: "clawdi.runtimeContext.v2",
+			schemaVersion: "clawdi.runtimeContext.v3",
 			backend: "incus",
 			apply: {
 				generation: 1,
@@ -24,7 +24,6 @@ function writeRuntimeContext(
 				applyReceiptId: "smoke-apply-receipt-0001",
 				bootNonce: "smoke-boot-nonce-000001",
 			},
-			cliPackageSpec: "clawdi@1.2.3-test",
 			manifestSource: {
 				type: "http",
 				url: options.manifestUrl ?? "https://runtime.test/v1/runtime/manifest",

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -5338,16 +5338,10 @@ export interface components {
         };
         /** HostedFileBrowserCompanion */
         HostedFileBrowserCompanion: {
-            /**
-             * Version
-             * @constant
-             */
-            version: "v1.5.0-stable";
-            /**
-             * Commit
-             * @constant
-             */
-            commit: "79552f8adb27c3e29934c4001660eb98f4aab5d6";
+            /** Version */
+            version: string;
+            /** Commit */
+            commit: string;
             /**
              * Listen
              * @constant
@@ -5526,7 +5520,7 @@ export interface components {
         HostedRuntimeMcp: {
             /** Servers */
             servers: {
-                [key: string]: components["schemas"]["HostedRuntimeStdioMcpServer"] | components["schemas"]["HostedRuntimeRemoteMcpServer"];
+                [key: string]: components["schemas"]["HostedRuntimeStdioMcpServer"] | components["schemas"]["HostedRuntimeRemoteMcpServer"] | components["schemas"]["HostedRuntimePlatformMcpServer"];
             };
         };
         /** HostedRuntimeMcpSecretHeader */
@@ -5691,6 +5685,23 @@ export interface components {
             convergeError?: string | null;
             /** Truncated */
             truncated?: boolean | null;
+        };
+        /** HostedRuntimePlatformMcpServer */
+        HostedRuntimePlatformMcpServer: {
+            /**
+             * Platform
+             * @constant
+             */
+            platform: "clawdi";
+            /**
+             * Transport
+             * @constant
+             */
+            transport: "streamable-http";
+            /** Headers */
+            headers?: {
+                [key: string]: string | components["schemas"]["HostedRuntimeMcpSecretHeader"];
+            };
         };
         /** HostedRuntimePrimaryModel */
         HostedRuntimePrimaryModel: {


### PR DESCRIPTION
## Summary

- make Hosted runtime install intent a strict official-source selector; Cloud CLI owns official OpenClaw/Hermes installer URLs and non-version arguments
- accept runtimeContext v3 without a duplicate CLI package field while retaining strict read-only v2 compatibility
- keep the exact managed Clawdi CLI selection in the authenticated Cloud manifest
- move File Browser release pins out of the Cloud receiver and add the logical platform MCP receiver shape

## Behavior

- missing or repair-required OpenClaw/Hermes installs run the official installer without a version selector, so upstream selects its current release
- healthy installed runtimes are not periodically reinstalled to chase releases
- no tenant, deployment, fallback, or custom-installer exception was added

## Verification

- bash scripts/test.sh cli: 1655 passed, 4 skipped, 0 failed
- bash scripts/test.sh backend: 2301 passed, 12 skipped
- workspace typecheck: 4/4 packages
- Biome: 1003 files
- focused Ruff lint and format: passed
- git diff --check origin/main..HEAD: passed

## Rollout

Cloud receiver/renderer must deploy before the Hosted runtimeContext v3 producer. This PR does not deploy, release, or mutate production.