### PR TITLE
feat(runtime): expose admin source authority

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -90,7 +90,7 @@ from app.schemas.channel import (
     ChannelCommandSyncResponse,
     ChannelWhatsAppOnboardingSessionResponse,
 )
-from app.schemas.platform import PlatformOwner
+from app.schemas.platform import PlatformOwner, RuntimeSourceAuthorityResponse
 from app.schemas.session import EnvironmentCreatedResponse
 from app.services.agent_environments import (
     AgentEnvironmentIdConflict,
@@ -187,6 +187,8 @@ from app.services.runtime_manifest_resources import (
     lock_runtime_manifest_skill_reservations,
 )
 from app.services.runtime_observation import RuntimeObservationProtocolError
+from app.services.runtime_source import RuntimeSourceError, RuntimeSourceNotFoundError
+from app.services.runtime_source_authority import load_runtime_source_authority
 from app.services.runtime_state_cleanup import lock_runtime_state_write_fence
 from app.services.sync_events import (
     queue_environment_runtime_manifest_changed,
@@ -2153,6 +2155,39 @@ async def _admin_upsert_runtime_state(
         instance_id=body.instance_id,
         generation=body.generation,
         apply_generation=apply_generation,
+    )
+
+
+@router.get(
+    "/agents/{agent_id}/runtime-state",
+    response_model=RuntimeSourceAuthorityResponse,
+    include_in_schema=False,
+)
+async def admin_get_runtime_source_authority(
+    agent_id: UUID,
+    owner: Annotated[PlatformOwner, Query()],
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+) -> RuntimeSourceAuthorityResponse:
+    target = await _find_admin_owner(db, owner)
+    try:
+        authority = await load_runtime_source_authority(
+            environment_id=agent_id,
+            owner_user_id=target.id,
+        )
+    except RuntimeSourceNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Runtime source not found") from None
+    except RuntimeSourceError:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "Runtime source is invalid",
+        ) from None
+    return RuntimeSourceAuthorityResponse(
+        environmentId=authority.environment_id,
+        deploymentId=authority.deployment_id,
+        instanceId=authority.instance_id,
+        sourceRevision=authority.source_revision,
+        etag=authority.etag,
     )
 
 

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -11,8 +11,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import invalidate_api_key_auth_cache
-from app.core.config import settings
-from app.core.database import get_session, runtime_snapshot_session
+from app.core.database import get_session
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.session import AgentEnvironment
@@ -91,14 +90,8 @@ from app.services.runtime_manifest_resources import (
     lock_runtime_manifest_skill_reservations,
 )
 from app.services.runtime_observation import RuntimeObservationProtocolError
-from app.services.runtime_source import (
-    RuntimeSourceError,
-    RuntimeSourceNotFoundError,
-    expected_runtime_bundle_v2_etag,
-    load_runtime_source_batch,
-    render_runtime_source,
-    vault_key_identity,
-)
+from app.services.runtime_source import RuntimeSourceError, RuntimeSourceNotFoundError
+from app.services.runtime_source_authority import load_runtime_source_authority
 from app.services.runtime_state_cleanup import lock_runtime_state_write_fence
 from app.services.sync_events import (
     queue_environment_runtime_manifest_changed,
@@ -821,38 +814,25 @@ async def platform_get_runtime_source_authority(
     db: AsyncSession = Depends(get_session),
 ) -> RuntimeSourceAuthorityResponse:
     owner_user_id = await _resolve_runtime_source_authority_owner_id(db, owner)
-    async with runtime_snapshot_session() as source_db:
-        batch = await load_runtime_source_batch(
-            source_db,
-            environment_ids=[agent_id],
+    try:
+        authority = await load_runtime_source_authority(
+            environment_id=agent_id,
             owner_user_id=owner_user_id,
         )
-        try:
-            source = render_runtime_source(
-                batch,
-                environment_id=agent_id,
-                public_api_url=settings.public_api_url,
-                vault_key_identity=vault_key_identity(settings.vault_encryption_key),
-                decrypt_secrets=False,
-            )
-        except RuntimeSourceNotFoundError:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, "Runtime source not found") from None
-        except RuntimeSourceError:
-            raise HTTPException(
-                status.HTTP_409_CONFLICT,
-                "Runtime source is invalid",
-            ) from None
-        row = batch.rows[agent_id]
-        state = row.state
-        if state is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, "Runtime source not found")
-        return RuntimeSourceAuthorityResponse(
-            environmentId=row.environment.id,
-            deploymentId=state.deployment_id,
-            instanceId=state.instance_id,
-            sourceRevision=source.source_revision,
-            etag=expected_runtime_bundle_v2_etag(source.source_revision),
-        )
+    except RuntimeSourceNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Runtime source not found") from None
+    except RuntimeSourceError:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "Runtime source is invalid",
+        ) from None
+    return RuntimeSourceAuthorityResponse(
+        environmentId=authority.environment_id,
+        deploymentId=authority.deployment_id,
+        instanceId=authority.instance_id,
+        sourceRevision=authority.source_revision,
+        etag=authority.etag,
+    )
 
 
 @router.put(

--- a/backend/app/services/runtime_source_authority.py
+++ b/backend/app/services/runtime_source_authority.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from app.core.config import settings
+from app.core.database import runtime_snapshot_session
+from app.services.runtime_source import (
+    RuntimeSourceNotFoundError,
+    expected_runtime_bundle_v2_etag,
+    load_runtime_source_batch,
+    render_runtime_source,
+    vault_key_identity,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeSourceAuthority:
+    environment_id: UUID
+    deployment_id: str
+    instance_id: str
+    source_revision: str
+    etag: str
+
+
+async def load_runtime_source_authority(
+    *,
+    environment_id: UUID,
+    owner_user_id: UUID,
+) -> RuntimeSourceAuthority:
+    """Render the non-secret authority for one exact owner/environment binding."""
+
+    async with runtime_snapshot_session() as source_db:
+        batch = await load_runtime_source_batch(
+            source_db,
+            environment_ids=[environment_id],
+            owner_user_id=owner_user_id,
+        )
+        source = render_runtime_source(
+            batch,
+            environment_id=environment_id,
+            public_api_url=settings.public_api_url,
+            vault_key_identity=vault_key_identity(settings.vault_encryption_key),
+            decrypt_secrets=False,
+        )
+        row = batch.rows[environment_id]
+        state = row.state
+        if state is None:
+            raise RuntimeSourceNotFoundError("Runtime source not found")
+        return RuntimeSourceAuthority(
+            environment_id=row.environment.id,
+            deployment_id=state.deployment_id,
+            instance_id=state.instance_id,
+            source_revision=source.source_revision,
+            etag=expected_runtime_bundle_v2_etag(source.source_revision),
+        )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -275,6 +275,7 @@ strict = [
     "app/services/runtime_observation.py",
     "app/services/runtime_observation_retention_worker.py",
     "app/services/runtime_source.py",
+    "app/services/runtime_source_authority.py",
     "app/services/runtime_state_cleanup.py",
     "app/services/safe_public_http.py",
     "app/services/secret_detection.py",

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -2553,14 +2553,21 @@ async def test_admin_register_env_rejects_default_name_request_field(admin_clien
 
 
 @pytest.mark.asyncio
+@pytest.mark.committed_db
 async def test_admin_agents_alias_registers_with_agent_id_and_runtime_state(
     admin_client, db_session, seed_user
 ):
     from sqlalchemy import select
 
+    from app.core.config import settings
     from app.models.hosted_runtime import HostedRuntimeSecret, HostedRuntimeState
     from app.models.session import AgentEnvironment
-    from app.services.runtime_source import load_runtime_source_batch, render_runtime_source
+    from app.services.runtime_source import (
+        expected_runtime_bundle_v2_etag,
+        load_runtime_source_batch,
+        render_runtime_source,
+        vault_key_identity,
+    )
     from app.services.vault_crypto import decrypt
     from tests.hosted_runtime_fixtures import (
         CANONICAL_CODEX_TOOL_PROVIDER_ID,
@@ -2681,6 +2688,33 @@ async def test_admin_agents_alias_registers_with_agent_id_and_runtime_state(
     )
     assert first_source.manifest["runtimes"]["openclaw"]["provider_ids"] == ["clawdi"]
     assert first_source.manifest["terminalTooling"]["codex"]["provider_id"] == "clawdi"
+
+    authority_source = render_runtime_source(
+        first_batch,
+        environment_id=agent_id,
+        public_api_url=settings.public_api_url,
+        vault_key_identity=vault_key_identity(settings.vault_encryption_key),
+        decrypt_secrets=False,
+    )
+    authority = await admin_client.get(
+        f"/v1/admin/agents/{agent_id}/runtime-state",
+        headers=_AUTH,
+        params={"kind": "clerk", "ref": seed_user.clerk_id},
+    )
+    assert authority.status_code == 200, authority.text
+    assert authority.json() == {
+        "environmentId": str(agent_id),
+        "deploymentId": "dep-admin-agent-alias",
+        "instanceId": "iid-admin-agent-alias",
+        "sourceRevision": authority_source.source_revision,
+        "etag": expected_runtime_bundle_v2_etag(authority_source.source_revision),
+    }
+    cross_owner = await admin_client.get(
+        f"/v1/admin/agents/{agent_id}/runtime-state",
+        headers=_AUTH,
+        params={"kind": "clerk", "ref": "user_another_owner"},
+    )
+    assert cross_owner.status_code == 404, cross_owner.text
 
     repeated = await admin_client.put(
         f"/v1/admin/agents/{agent_id}/runtime-state",


### PR DESCRIPTION
## Summary

- share one non-secret runtime source authority renderer across auth surfaces
- expose a hidden owner-scoped admin read for legacy Hosted cohorts
- return only environment, deployment, instance, source revision, and bundle ETag
- preserve the existing workload-auth platform endpoint behavior

## Safety

- no bundle, model payload, secret, credential, or mutation is exposed
- missing and cross-owner bindings remain 404
- invalid source state remains 409
- no schema or migration change

## Verification

- isolated Docker backend suite: 2299 passed, 12 skipped
- git diff --check passed

This is the Cloud prerequisite for the Hosted online managed-catalog replay.