### PR TITLE
fix(admin): replay legacy managed provider metadata

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -162,6 +162,7 @@ from app.services.managed_ai_provider import (
     V2_MANAGED_AI_PROVIDER_IDS,
     archive_clawdi_managed_provider,
     find_clawdi_managed_provider,
+    is_supported_deployment_managed_provider_contract,
     is_v2_deployment_managed_provider_id,
     lock_deployment_managed_provider_mutation,
     replace_deployment_managed_provider_metadata,
@@ -463,15 +464,7 @@ async def _resolve_or_create_admin_owner(
 
 
 def _require_managed_provider_contract(provider: AiProvider) -> None:
-    if (
-        provider.type != MANAGED_AI_PROVIDER_TYPE
-        or provider.api_mode != MANAGED_AI_PROVIDER_API_MODE
-        or provider.auth_type != "api_key"
-        or provider.auth_ref is not None
-        or (provider.auth_metadata or {}).get("source") != "managed"
-        or provider.managed_by != "clawdi"
-        or provider.runtime_env_name != MANAGED_AI_PROVIDER_RUNTIME_ENV
-    ):
+    if not is_supported_deployment_managed_provider_contract(provider):
         raise HTTPException(
             status.HTTP_409_CONFLICT,
             "Stored managed AI provider contract is invalid",
@@ -519,10 +512,10 @@ async def _admin_deployment_managed_provider_response(
         scope=MANAGED_AI_PROVIDER_SCOPE,
         type=MANAGED_AI_PROVIDER_TYPE,
         label=provider.label or MANAGED_AI_PROVIDER_LABEL,
-        api_mode=provider.api_mode or "",
+        api_mode=MANAGED_AI_PROVIDER_API_MODE,
         auth=auth,
         managed_by="clawdi",
-        runtime_env_name=provider.runtime_env_name or "",
+        runtime_env_name=MANAGED_AI_PROVIDER_RUNTIME_ENV,
         base_url=provider.base_url,
         capabilities=provider.capabilities,
         models=provider.models,

--- a/backend/app/services/managed_ai_provider.py
+++ b/backend/app/services/managed_ai_provider.py
@@ -53,6 +53,16 @@ MANAGED_AI_PROVIDER_PROFILE = "default"
 MANAGED_AI_PROVIDER_SCOPE = "account_global"
 MANAGED_AI_PROVIDER_PROVENANCE_CAPABILITY = "clawdi_provisioning_discovery_key"
 
+_LEGACY_MANAGED_AI_PROVIDER_RUNTIME_ENV = "CLAWDI_MANAGED_OPENAI_API_KEY"
+# Keep the exact pairings emitted by released admin upserts, not two independent allowlists.
+_SUPPORTED_DEPLOYMENT_MANAGED_PROVIDER_CONTRACTS = frozenset(
+    {
+        ("openai_chat", _LEGACY_MANAGED_AI_PROVIDER_RUNTIME_ENV),
+        ("openai_chat", MANAGED_AI_PROVIDER_RUNTIME_ENV),
+        (MANAGED_AI_PROVIDER_API_MODE, MANAGED_AI_PROVIDER_RUNTIME_ENV),
+    }
+)
+
 _V2_DEPLOYMENT_ID_RE = re.compile(r"^[1-9][0-9]*$")
 
 
@@ -116,6 +126,21 @@ def validate_managed_provider_base_url(base_url: str) -> None:
         validate_public_https_url(base_url, label="base_url")
     except UnsafePublicHttpsUrlError as exc:
         raise ValueError(str(exc)) from exc
+
+
+def is_supported_deployment_managed_provider_contract(provider: AiProvider) -> bool:
+    """Return whether a stored deployment provider matches a released contract."""
+
+    return (
+        is_v2_deployment_managed_provider_id(provider.provider_id)
+        and provider.type == MANAGED_AI_PROVIDER_TYPE
+        and (provider.api_mode, provider.runtime_env_name)
+        in _SUPPORTED_DEPLOYMENT_MANAGED_PROVIDER_CONTRACTS
+        and provider.auth_type == "api_key"
+        and provider.auth_ref is None
+        and (provider.auth_metadata or {}).get("source") == "managed"
+        and provider.managed_by == "clawdi"
+    )
 
 
 async def lock_deployment_managed_provider_mutation(
@@ -222,8 +247,19 @@ def replace_deployment_managed_provider_metadata(
         raise ValueError("unsupported deployment managed provider id")
     validate_managed_provider_base_url(base_url)
     normalized_base_url = base_url.strip()
-    if provider.base_url == normalized_base_url and provider.models == models:
+    if (
+        provider.type == MANAGED_AI_PROVIDER_TYPE
+        and provider.api_mode == MANAGED_AI_PROVIDER_API_MODE
+        and provider.managed_by == "clawdi"
+        and provider.runtime_env_name == MANAGED_AI_PROVIDER_RUNTIME_ENV
+        and provider.base_url == normalized_base_url
+        and provider.models == models
+    ):
         return False
+    provider.type = MANAGED_AI_PROVIDER_TYPE
+    provider.api_mode = MANAGED_AI_PROVIDER_API_MODE
+    provider.managed_by = "clawdi"
+    provider.runtime_env_name = MANAGED_AI_PROVIDER_RUNTIME_ENV
     provider.base_url = normalized_base_url
     provider.models = models
     return True

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -25,7 +25,9 @@ from app.core.config import settings
 from app.core.database import get_session
 from app.main import app
 from app.services.managed_ai_provider import (
+    MANAGED_AI_PROVIDER_API_MODE,
     MANAGED_AI_PROVIDER_PROVENANCE_CAPABILITY,
+    MANAGED_AI_PROVIDER_RUNTIME_ENV,
     V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX,
     V2_LEGACY_MANAGED_AI_PROVIDER_ID,
     V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
@@ -1391,10 +1393,15 @@ async def test_admin_deployment_managed_ai_provider_lifecycle_is_owner_scoped_an
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "legacy_runtime_env",
+    ["CLAWDI_MANAGED_OPENAI_API_KEY", MANAGED_AI_PROVIDER_RUNTIME_ENV],
+)
 async def test_admin_deployment_provider_invalidates_only_bound_runtime_on_manifest_changes(
     admin_client,
     db_session,
     seed_user,
+    legacy_runtime_env: str,
 ):
     from sqlalchemy import select
 
@@ -1512,24 +1519,88 @@ async def test_admin_deployment_provider_invalidates_only_bound_runtime_on_manif
         )
         assert provider is not None and payload is not None
 
-        def auth_storage():
+        provider.api_mode = "openai_chat"
+        provider.runtime_env_name = legacy_runtime_env
+        payload.payload_metadata = {"runtime_env_name": legacy_runtime_env}
+        await db_session.commit()
+        await db_session.refresh(provider)
+        await db_session.refresh(payload)
+
+        def preserved_storage():
             return (
+                provider.id,
+                provider.owner_user_id,
+                provider.provider_id,
                 provider.auth_type,
                 provider.auth_ref,
                 provider.auth_metadata,
                 provider.label,
                 provider.capabilities,
+                payload.id,
+                payload.owner_user_id,
+                payload.provider_id,
+                payload.auth_profile,
                 payload.encrypted_payload,
                 payload.nonce,
                 payload.credential_revision,
                 payload.kind,
                 payload.source,
                 payload.payload_metadata,
+                payload.consumer_environment_id,
+                payload.consumer_runtime,
                 payload.archived_at,
+                payload.created_at,
                 payload.updated_at,
             )
 
-        preserved = auth_storage()
+        preserved = preserved_storage()
+        readback = await admin_client.get(
+            f"/v1/admin/ai-providers/{provider_id}", headers=_AUTH, params=owner
+        )
+        assert readback.status_code == 200, readback.text
+        assert readback.json()["api_mode"] == MANAGED_AI_PROVIDER_API_MODE
+        assert readback.json()["runtime_env_name"] == MANAGED_AI_PROVIDER_RUNTIME_ENV
+        assert readback.json()["base_url"] == request_body["base_url"]
+        assert readback.json()["models"] == request_body["models"]
+        await db_session.refresh(provider)
+        assert provider.api_mode == "openai_chat"
+        assert provider.runtime_env_name == legacy_runtime_env
+        assert all(queue.empty() for queue in queues)
+
+        legacy_metadata = {
+            "owner": owner,
+            "base_url": request_body["base_url"],
+            "models": request_body["models"],
+        }
+        upgraded = await _replace_managed_provider_runtime_metadata(
+            admin_client, provider_id, legacy_metadata
+        )
+        assert upgraded.status_code == 200, upgraded.text
+        assert upgraded.json()["api_mode"] == MANAGED_AI_PROVIDER_API_MODE
+        assert upgraded.json()["runtime_env_name"] == MANAGED_AI_PROVIDER_RUNTIME_ENV
+        assert_only_bound_event()
+        await db_session.refresh(provider)
+        await db_session.refresh(payload)
+        assert provider.type == "custom_openai_compatible"
+        assert provider.api_mode == MANAGED_AI_PROVIDER_API_MODE
+        assert provider.managed_by == "clawdi"
+        assert provider.runtime_env_name == MANAGED_AI_PROVIDER_RUNTIME_ENV
+        assert provider.base_url == legacy_metadata["base_url"]
+        assert provider.models == legacy_metadata["models"]
+        assert preserved_storage() == preserved
+
+        unchanged_at = datetime.now(UTC) - timedelta(days=1)
+        provider.updated_at = unchanged_at
+        await db_session.commit()
+        replay = await _replace_managed_provider_runtime_metadata(
+            admin_client, provider_id, legacy_metadata
+        )
+        assert replay.status_code == 200, replay.text
+        assert replay.json() == upgraded.json()
+        await db_session.refresh(provider)
+        assert provider.updated_at == unchanged_at
+        assert all(queue.empty() for queue in queues)
+
         metadata = {
             "owner": owner,
             "base_url": "https://catalog-gateway.example.test/v1",
@@ -1555,20 +1626,28 @@ async def test_admin_deployment_provider_invalidates_only_bound_runtime_on_manif
         assert_only_bound_event()
         await db_session.refresh(provider)
         await db_session.refresh(payload)
-        assert auth_storage() == preserved
-        unchanged_at = datetime.now(UTC) - timedelta(days=1)
-        provider.updated_at = unchanged_at
-        await db_session.commit()
+        assert preserved_storage() == preserved
 
-        replay = await _replace_managed_provider_runtime_metadata(
+        provider.runtime_env_name = "CLAWDI_MANAGED_OPENAI_API_KEY"
+        await db_session.commit()
+        invalid_readback = await admin_client.get(
+            f"/v1/admin/ai-providers/{provider_id}", headers=_AUTH, params=owner
+        )
+        assert invalid_readback.status_code == 409, invalid_readback.text
+        invalid_replay = await _replace_managed_provider_runtime_metadata(
             admin_client, provider_id, metadata
         )
-        assert replay.status_code == 200, replay.text
-        assert replay.json() == changed.json()
+        assert invalid_replay.status_code == 409, invalid_replay.text
         await db_session.refresh(provider)
-        assert provider.updated_at == unchanged_at
+        await db_session.refresh(payload)
+        assert provider.runtime_env_name == "CLAWDI_MANAGED_OPENAI_API_KEY"
+        assert provider.base_url == metadata["base_url"]
+        assert provider.models == metadata["models"]
+        assert preserved_storage() == preserved
         assert all(queue.empty() for queue in queues)
 
+        provider.runtime_env_name = MANAGED_AI_PROVIDER_RUNTIME_ENV
+        await db_session.commit()
         cleared = await _replace_managed_provider_runtime_metadata(
             admin_client, provider_id, {**metadata, "models": None}
         )


### PR DESCRIPTION
## Summary
- accept only the three managed provider api mode/runtime env pairings emitted by released admin upserts
- return canonical managed invariants from deployment-provider GET without mutating storage
- atomically canonicalize fixed non-auth fields plus requested base URL and ordered models during metadata replay
- preserve provider identity, label, capabilities, and every auth/credential field

## Verification
- isolated Docker: scripts/test.sh backend tests/test_admin_endpoints.py::test_admin_deployment_provider_invalidates_only_bound_runtime_on_manifest_changes (2 passed)
- production owned BasedPyright: 190 files, 0 diagnostics
- Ruff check and format check on touched files
- Python compileall for backend app
- git diff --check

## Residual risk
A legacy row whose base URL and ordered model catalog already match Hosted desired state may remain legacy in storage because canonical GET projection gives Hosted no reason to call metadata PUT. This Cloud-only fix keeps GET read-only; healing that case would require a Hosted replay contract change or a read mutation.