### PR TITLE
fix(runtime): preserve observation evidence identity

### DIFF
--- a/backend/app/services/runtime_observation.py
+++ b/backend/app/services/runtime_observation.py
@@ -1185,6 +1185,16 @@ async def read_runtime_observations(
         .scalars()
         .all()
     )
+    event_evidence_references = {
+        event.event_id: _evidence_reference(
+            event_id=event.event_id,
+            environment_id=environment_id,
+            consumer_id=consumer_id,
+            cursor_epoch=cursor.cursor_epoch,
+            stream_position=event.id,
+        )
+        for event in page
+    }
     event_payloads = [
         {
             "runtimeIdentity": _identity_payload(
@@ -1198,13 +1208,7 @@ async def read_runtime_observations(
             "capturedAt": _utc(event.captured_at).isoformat(),
             "receivedAt": _utc(event.received_at).isoformat(),
             "freshnessDeadline": _utc(event.freshness_deadline).isoformat(),
-            "evidenceReference": _evidence_reference(
-                event_id=event.event_id,
-                environment_id=environment_id,
-                consumer_id=consumer_id,
-                cursor_epoch=cursor.cursor_epoch,
-                stream_position=event.id,
-            ),
+            "evidenceReference": event_evidence_references[event.event_id],
             "payloadHash": event.payload_hash,
             "health": event.health,
             "diagnostics": event.diagnostics,
@@ -1229,7 +1233,8 @@ async def read_runtime_observations(
                 if head.freshness_deadline is not None
                 else None
             ),
-            "evidenceReference": _evidence_reference(
+            "evidenceReference": event_evidence_references.get(head.latest_event_id)
+            or _evidence_reference(
                 event_id=head.latest_event_id,
                 environment_id=environment_id,
                 consumer_id=consumer_id,

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -2127,6 +2127,9 @@ async def test_snapshot_and_high_water_share_one_repeatable_read_snapshot(
         )
     assert [event["sequence"] for event in incremental["events"]] == [2]
     assert [head["sequence"] for head in incremental["heads"]] == [2]
+    assert incremental["heads"][0]["evidenceReference"] == (
+        incremental["events"][0]["evidenceReference"]
+    )
     assert first.stream_position < second.stream_position
     assert incremental["events"][0]["runtimeIdentity"]["bootSessionId"] == ("boot-session-0001")
     assert (


### PR DESCRIPTION
## Summary

- generate each paged runtime observation evidence reference once
- reuse that exact reference when the active head points at the same event
- preserve the existing fallback when a head event is outside the current page

## Why

Evidence cursors use randomized authenticated encryption. Re-encoding the same logical event produces a different cursor string, which made the hosted controller correctly reject the head as a changed event identity.

## Test plan

- `bash scripts/test.sh backend tests/test_runtime_observation_companion.py` (32 passed)