### PR TITLE
fix(cli): clean generated egress profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.13.78
+
+Package: `clawdi@0.13.78`
+
+### Fixed
+
+- Hosted agents no longer retain redundant installer egress profiles or
+  intercept WhatsApp traffic when no managed WhatsApp Link is configured.
+
 ## Clawdi CLI v0.13.65
 
 Package: `clawdi@0.13.65`

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.77",
+      "version": "0.13.78",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.77",
+	"version": "0.13.78",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/hosted-egress-profiles.ts
+++ b/packages/cli/src/runtime/hosted-egress-profiles.ts
@@ -29,7 +29,6 @@ export function hostedManifestEgressProfiles(
 			? egressProfileInputBundleSchema.parse(hosted.egressProfiles)
 			: { profiles: [] };
 	return mergeGeneratedProfiles(explicit, [
-		...runtimeInstallerEgressProfiles(),
 		...managedProviderEgressProfiles(hosted),
 		...managedMcpEgressProfiles(hosted),
 	]);
@@ -104,95 +103,6 @@ export function managedMcpHeaderPlaceholder(serverName: string, headerName: stri
 		.digest("hex")
 		.slice(0, 16);
 	return `${MANAGED_EGRESS_PLACEHOLDER_VALUE}-mcp-${suffix}`;
-}
-
-export function runtimeInstallerEgressProfiles(): HostedEgressProfile[] {
-	const profile = (
-		id: string,
-		host: string,
-		pathPrefix: string,
-		description: string,
-	): HostedEgressProfile => ({
-		id,
-		enabled: true,
-		kind: "passthrough",
-		match: {
-			scheme: "https",
-			host,
-			pathPrefix,
-			headers: {},
-			query: {},
-		},
-		logging: { redactHeaders: [], redactUrlPatterns: [] },
-		priority: 200,
-		owner: "runtime-installer",
-		description,
-	});
-	return [
-		profile(
-			"runtime-installer-openclaw-install",
-			"openclaw.ai",
-			"/install-cli.sh",
-			"OpenClaw official installer script.",
-		),
-		profile(
-			"runtime-installer-nodejs-dist",
-			"nodejs.org",
-			"/dist/",
-			"Node.js release artifacts used by the OpenClaw official installer.",
-		),
-		profile(
-			"runtime-installer-npm-registry",
-			"registry.npmjs.org",
-			"/",
-			"npm package metadata and tarballs used by the OpenClaw official installer.",
-		),
-		profile(
-			"runtime-installer-hermes-install",
-			"hermes-agent.nousresearch.com",
-			"/install.sh",
-			"Hermes official installer script.",
-		),
-		profile("runtime-installer-uv", "astral.sh", "/uv/", "uv installer bootstrap."),
-		profile(
-			"runtime-installer-uv-releases",
-			"releases.astral.sh",
-			"/installers/uv/",
-			"uv installer release script.",
-		),
-		profile("runtime-installer-github", "github.com", "/", "Installer release metadata."),
-		profile(
-			"runtime-installer-github-api",
-			"api.github.com",
-			"/",
-			"Installer release metadata API.",
-		),
-		profile(
-			"runtime-installer-github-raw",
-			"raw.githubusercontent.com",
-			"/",
-			"Installer release script assets.",
-		),
-		profile(
-			"runtime-installer-github-objects",
-			"objects.githubusercontent.com",
-			"/",
-			"Installer release binary assets.",
-		),
-		profile(
-			"runtime-installer-github-release-assets",
-			"release-assets.githubusercontent.com",
-			"/",
-			"Installer release binary assets.",
-		),
-		profile("runtime-installer-pypi", "pypi.org", "/simple/", "Hermes Python package index."),
-		profile(
-			"runtime-installer-pythonhosted",
-			"files.pythonhosted.org",
-			"/",
-			"Hermes Python package artifacts.",
-		),
-	];
 }
 
 function providerUsesManagedEgressProfile(apiMode: string | null): boolean {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -6119,17 +6119,16 @@ export function convergeRuntimeManifest(
 				...(observation?.appRoot ? { appRoot: observation.appRoot } : {}),
 				paths,
 			});
-			if (managedWhatsAppRuntime && compatibility.status === "rollback-refused") {
+			if (compatibility.status === "rollback-refused") {
 				throw new Error(compatibility.errors.join(", "));
 			}
 		} catch (error) {
-			if (managedWhatsAppRuntime) {
-				installErrors.push(
-					`runtime ${managedWhatsAppRuntime} managed WhatsApp compatibility failed: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
-				);
-			}
+			const operation = managedWhatsAppRuntime
+				? `runtime ${managedWhatsAppRuntime} managed WhatsApp compatibility`
+				: "runtime managed WhatsApp compatibility cleanup";
+			installErrors.push(
+				`${operation} failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
 		}
 		if (installErrors.length > 0) throw new Error(installErrors.join("; "));
 

--- a/packages/cli/src/runtime/whatsapp-egress.ts
+++ b/packages/cli/src/runtime/whatsapp-egress.ts
@@ -20,6 +20,7 @@ export function buildManagedWhatsAppEgressProfiles(input: {
 	controlPlaneApiUrl: string;
 	links: ManagedWhatsAppEgressLink[];
 }): EgressProfile[] {
+	if (input.links.length === 0) return [];
 	const upstreamBaseUrl = managedWhatsAppWebSocketUrl(input.controlPlaneApiUrl);
 	const profiles = [...input.links]
 		.sort((left, right) => left.linkId.localeCompare(right.linkId))

--- a/packages/cli/tests/runtime-egress-profiles.test.ts
+++ b/packages/cli/tests/runtime-egress-profiles.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { egressProfileSchema, secretRefSchema } from "../src/runtime/egress-profiles";
-import {
-	hostedManifestEgressProfiles,
-	runtimeInstallerEgressProfiles,
-} from "../src/runtime/hosted-egress-profiles";
+import { hostedManifestEgressProfiles } from "../src/runtime/hosted-egress-profiles";
 
 const providerProfiles = (profiles: ReturnType<typeof hostedManifestEgressProfiles>["profiles"]) =>
 	profiles.filter((profile) => profile.owner === "provider-projection");
@@ -207,7 +204,6 @@ describe("runtime egress profile schema", () => {
 			},
 		});
 
-		expect(bundle.profiles.map((profile) => profile.id)).toContain("runtime-installer-nodejs-dist");
 		expect(providerProfiles(bundle.profiles)).toEqual([
 			{
 				id: "managed-provider",
@@ -263,88 +259,8 @@ describe("runtime egress profile schema", () => {
 		);
 	});
 
-	it("adds explicit runtime installer passthrough allowlist profiles", () => {
-		const profiles = runtimeInstallerEgressProfiles();
-		expect(profiles).toContainEqual(
-			expect.objectContaining({
-				id: "runtime-installer-openclaw-install",
-				kind: "passthrough",
-				match: expect.objectContaining({
-					scheme: "https",
-					host: "openclaw.ai",
-					pathPrefix: "/install-cli.sh",
-				}),
-				owner: "runtime-installer",
-			}),
-		);
-		expect(profiles).toContainEqual(
-			expect.objectContaining({
-				id: "runtime-installer-nodejs-dist",
-				kind: "passthrough",
-				match: expect.objectContaining({
-					scheme: "https",
-					host: "nodejs.org",
-					pathPrefix: "/dist/",
-				}),
-				owner: "runtime-installer",
-			}),
-		);
-		expect(profiles).toContainEqual(
-			expect.objectContaining({
-				id: "runtime-installer-npm-registry",
-				kind: "passthrough",
-				match: expect.objectContaining({
-					scheme: "https",
-					host: "registry.npmjs.org",
-					pathPrefix: "/",
-				}),
-				owner: "runtime-installer",
-			}),
-		);
-		expect(profiles).toContainEqual(
-			expect.objectContaining({
-				id: "runtime-installer-hermes-install",
-				kind: "passthrough",
-				match: expect.objectContaining({
-					scheme: "https",
-					host: "hermes-agent.nousresearch.com",
-					pathPrefix: "/install.sh",
-				}),
-				owner: "runtime-installer",
-			}),
-		);
-		expect(profiles).toContainEqual(
-			expect.objectContaining({
-				id: "runtime-installer-uv-releases",
-				kind: "passthrough",
-				match: expect.objectContaining({
-					scheme: "https",
-					host: "releases.astral.sh",
-					pathPrefix: "/installers/uv/",
-				}),
-				owner: "runtime-installer",
-			}),
-		);
-		expect(profiles).toEqual(
-			expect.arrayContaining([
-				{
-					id: "runtime-installer-pythonhosted",
-					enabled: true,
-					kind: "passthrough",
-					match: {
-						scheme: "https",
-						host: "files.pythonhosted.org",
-						pathPrefix: "/",
-						headers: {},
-						query: {},
-					},
-					logging: { redactHeaders: [], redactUrlPatterns: [] },
-					priority: 200,
-					owner: "runtime-installer",
-					description: "Hermes Python package artifacts.",
-				},
-			]),
-		);
+	it("does not generate egress profiles without managed inputs", () => {
+		expect(hostedManifestEgressProfiles({}).profiles).toEqual([]);
 	});
 
 	it("builds managed provider profiles for runtime-scoped providers", () => {
@@ -479,8 +395,7 @@ describe("runtime egress profile schema", () => {
 			},
 		});
 
-		expect(providerProfiles(bundle.profiles)).toEqual([]);
-		expect(bundle.profiles.every((profile) => profile.owner === "runtime-installer")).toBe(true);
+		expect(bundle.profiles).toEqual([]);
 	});
 
 	it("does not derive provider egress profiles for BYOK providers", () => {
@@ -495,8 +410,7 @@ describe("runtime egress profile schema", () => {
 			},
 		});
 
-		expect(providerProfiles(bundle.profiles)).toEqual([]);
-		expect(bundle.profiles.every((profile) => profile.owner === "runtime-installer")).toBe(true);
+		expect(bundle.profiles).toEqual([]);
 	});
 
 	it("does not derive provider egress profiles for unsupported provider API modes", () => {
@@ -511,7 +425,6 @@ describe("runtime egress profile schema", () => {
 			},
 		});
 
-		expect(providerProfiles(bundle.profiles)).toEqual([]);
-		expect(bundle.profiles.every((profile) => profile.owner === "runtime-installer")).toBe(true);
+		expect(bundle.profiles).toEqual([]);
 	});
 });

--- a/packages/cli/tests/runtime-whatsapp-egress.test.ts
+++ b/packages/cli/tests/runtime-whatsapp-egress.test.ts
@@ -111,23 +111,13 @@ describe("native WhatsApp egress contract", () => {
 		expect(profiles.at(-1)?.match.path).toBeUndefined();
 	});
 
-	it("retains the stale-marker deny rule after every managed Link is removed", () => {
+	it("does not intercept WhatsApp without a managed Link", () => {
 		const profiles = buildManagedWhatsAppEgressProfiles({
 			controlPlaneApiUrl: "https://control-plane.test",
 			links: [],
 		});
 
-		expect(profiles).toHaveLength(1);
-		expect(profiles[0]).toMatchObject({
-			id: "native-whatsapp-baileys-invalid-capability",
-			kind: "deny",
-			match: {
-				host: "web.whatsapp.com",
-				headers: {
-					[CLAWDI_WHATSAPP_LINK_CAPABILITY_HEADER]: { type: "exists" },
-				},
-			},
-		});
+		expect(profiles).toEqual([]);
 	});
 
 	it("qualifies the pinned rc14 physical sidecar artifact", () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -242,13 +242,26 @@ function convergeRuntimeManifest(
 	);
 }
 
+function hermesManagedBaileysRoot(home: string): string {
+	return join(
+		home,
+		".hermes",
+		"hermes-agent",
+		"scripts",
+		"whatsapp-bridge",
+		"node_modules",
+		"@whiskeysockets",
+		"baileys",
+	);
+}
+
 function seedHermesManagedBaileys(home: string): void {
 	const sourceRoot = resolve(
 		import.meta.dir,
 		"../../whatsapp-baileys-sidecar/node_modules/baileys",
 	);
 	const bridgeRoot = join(home, ".hermes", "hermes-agent", "scripts", "whatsapp-bridge");
-	const baileysRoot = join(bridgeRoot, "node_modules", "@whiskeysockets", "baileys");
+	const baileysRoot = hermesManagedBaileysRoot(home);
 	for (const relativePath of [
 		"package.json",
 		...MANAGED_BAILEYS_STATIC_PATCH_TARGETS.map((target) => target.relativePath),
@@ -6906,18 +6919,13 @@ exit 64
 		expect(active.manifest.projection?.channels).toMatchObject({
 			telegram: { defaultAccount: accountKey, accounts: { [accountKey]: { enabled: true } } },
 		});
-		expect(active.manifest.egressProfiles?.profiles).toHaveLength(3);
+		expect(active.manifest.egressProfiles?.profiles).toHaveLength(2);
 		expect(JSON.stringify(active.manifest)).not.toContain("agent-token-v1");
 		expect(JSON.stringify(active)).not.toContain("provider-token");
 		expect(rotated.sourceRevision).toBe("b".repeat(64));
 		expect(rotated.secretValues?.[agentRef]).toBe("agent-token-v2");
 		expect(removed.manifest.projection?.channels).toEqual({});
-		expect(removed.manifest.egressProfiles?.profiles).toEqual([
-			expect.objectContaining({
-				id: "native-whatsapp-baileys-invalid-capability",
-				kind: "deny",
-			}),
-		]);
+		expect(removed.manifest.egressProfiles?.profiles).toEqual([]);
 		expect(removed.manifest.runtimes.openclaw?.run?.secretEnv ?? {}).toEqual({});
 		expect(removed.secretValues).toEqual({});
 	});
@@ -7011,7 +7019,6 @@ exit 64
 
 		expect(projected.manifest.egressProfiles?.profiles.map((profile) => profile.id)).toEqual([
 			"explicit-provider-profile",
-			"native-whatsapp-baileys-invalid-capability",
 		]);
 	});
 
@@ -7071,7 +7078,6 @@ exit 64
 		expect(projected.manifest.egressProfiles?.profiles.map((profile) => profile.id)).toEqual([
 			"native-telegram-clawdi_accttelegram-managed",
 			"native-telegram-clawdi_accttelegram-file-managed",
-			"native-whatsapp-baileys-invalid-capability",
 		]);
 	});
 
@@ -13642,6 +13648,7 @@ exit 64
 			.digest("hex")
 			.slice(0, 32)}`;
 		const sessionDir = join(home, ".hermes", "platforms", "whatsapp", "session");
+		const baileysSocket = join(hermesManagedBaileysRoot(home), "lib", "Socket", "socket.js");
 		const legacySessionDir = join(home, ".hermes", "whatsapp", "session");
 		const legacySentinel = join(legacySessionDir, "unmanaged-session-sentinel");
 		const systemctlPath = join(root, "bin", "systemctl");
@@ -13887,7 +13894,26 @@ exit 64
 			{ ...load, channelBindings: [], secretValues: {} },
 			paths,
 		);
-		materializeHostedChannelCredentials(removed.manifest, removed.secretValues, home);
+		const patchedSocket = readFileSync(baileysSocket, "utf8");
+		writeFileSync(
+			baileysSocket,
+			patchedSocket.replace(
+				"DEFAULT_CONNECTION_CONFIG.waWebSocketUrl",
+				"DRIFTED_CONNECTION_CONFIG.waWebSocketUrl",
+			),
+		);
+		const blockedRemoval = convergeRuntimeManifest(removed, paths);
+		expect(blockedRemoval.installErrors.join("\n")).toContain(
+			"runtime managed WhatsApp compatibility cleanup failed",
+		);
+		expect(readFileSync(paths.egressProfileBundle, "utf8")).toContain(
+			"native-whatsapp-baileys-invalid-capability",
+		);
+
+		writeFileSync(baileysSocket, patchedSocket);
+		const removedConvergence = convergeRuntimeManifest(removed, paths);
+		expect(removedConvergence.installErrors).toEqual([]);
+		expect(existsSync(paths.egressProfileBundle)).toBe(false);
 		expect(existsSync(sessionDir)).toBe(false);
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_MODE).toBeUndefined();
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ALLOWED_USERS).toBeUndefined();


### PR DESCRIPTION
## Summary

- Remove the 13 generated runtime-installer-* passthrough profiles.
- Emit native-whatsapp-baileys-invalid-capability only while at least one managed WhatsApp Link exists.
- Fail closed when Link removal cannot safely roll back the owned Hermes Baileys patch, preserving the last-good egress bundle.
- Prepare the immutable clawdi@0.13.78 CLI release.

## Rationale

Unmatched egress is allowed by default, and passthrough-only hosts are excluded from TLS interception, so the installer profiles changed no routing behavior.

The WhatsApp deny profile is meaningful only alongside active managed Link routes. Keeping it without a Link caused unrelated WhatsApp traffic carrying the historical marker to be intercepted. Removal now stays transactional: if patch ownership drift prevents rollback, convergence fails and retains the prior deny instead of creating a half-removed state.

Managed provider, managed MCP, Telegram, and active managed WhatsApp behavior are unchanged.

## Existing agents

On the first successful hosted convergence with clawdi@0.13.78, profiles.json is atomically regenerated from desired state. Redundant installer profiles disappear automatically. The WhatsApp deny disappears only after the owned Baileys patch is safely rolled back when the final managed Link is removed.

Publishing the npm package alone does not upgrade existing agents; Hosted must roll the exact CLI package spec to clawdi@0.13.78.

## Validation

- Focused Docker CLI runner: typecheck passed; 180 passed, 0 failed
- Full Docker CLI runner: typecheck passed; 1700 passed, 4 skipped, 0 failed
- Full Biome check: 1013 files passed
- Workspace typecheck: 4 of 4 packages passed
- CLI publish manifest, build, version smoke, and npm pack passed
- clawdi --version returned exactly 0.13.78
- git diff --check passed
- Test containers, networks, and temporary images were cleaned

## Release

The package version change triggers the protected CLI publish workflow after merge. Do not roll Hosted to clawdi@0.13.78 until that workflow publishes and verifies the immutable artifact.