### PR TITLE
fix(runtime): adopt authoritative retirement receipts

### DIFF
--- a/backend/app/routes/runtime_observation_v2.py
+++ b/backend/app/routes/runtime_observation_v2.py
@@ -573,6 +573,8 @@ async def retire_runtime_environment_endpoint(
                 outcome="transitioned",
                 details={
                     "retirement_id": body.retirement_id,
+                    "requested_retirement_id": body.retirement_id,
+                    "authoritative_retirement_id": receipt.retirement_id,
                     "retirement_receipt_id": str(binding.retirement_receipt_id),
                     "previous_state": "active",
                     "new_state": "retired",
@@ -582,7 +584,7 @@ async def retire_runtime_environment_endpoint(
                     "final_session_high_water_marks": result.final_session_high_waters,
                 },
             )
-        else:
+        elif receipt.retirement_id == body.retirement_id:
             _record_admin_audit(
                 db,
                 action="runtime_environment.retire_replay",
@@ -592,6 +594,22 @@ async def retire_runtime_environment_endpoint(
                 outcome="replayed",
                 details={
                     "retirement_id": body.retirement_id,
+                    "requested_retirement_id": body.retirement_id,
+                    "authoritative_retirement_id": receipt.retirement_id,
+                    "retirement_receipt_id": str(binding.retirement_receipt_id),
+                },
+            )
+        else:
+            _record_admin_audit(
+                db,
+                action="runtime_environment.retire_adopted",
+                target_user_id=binding_owner_id,
+                environment_id=environment_id,
+                deployment_id=body.expected_deployment_binding,
+                outcome="adopted",
+                details={
+                    "requested_retirement_id": body.retirement_id,
+                    "authoritative_retirement_id": receipt.retirement_id,
                     "retirement_receipt_id": str(binding.retirement_receipt_id),
                 },
             )
@@ -617,7 +635,10 @@ async def retire_runtime_environment_endpoint(
                 environment_id=environment_id,
                 deployment_id=body.expected_deployment_binding,
                 outcome=exc.code,
-                details={"retirement_id": body.retirement_id},
+                details={
+                    "retirement_id": body.retirement_id,
+                    "requested_retirement_id": body.retirement_id,
+                },
             )
             await db.commit()
         except Exception:

--- a/backend/app/services/runtime_observation.py
+++ b/backend/app/services/runtime_observation.py
@@ -31,6 +31,7 @@ from app.models.runtime_observation import (
 )
 from app.models.session import AgentEnvironment
 from app.schemas.runtime_observation import (
+    RuntimeEnvironmentRetirementReceipt,
     RuntimeObservationEventV2,
     RuntimeObservationIngestOutcome,
 )
@@ -597,6 +598,44 @@ async def _load_session_high_waters(
     return _session_high_waters(heads)
 
 
+def _validated_retirement_receipt(
+    fence: V2RuntimeEnvironmentFence,
+) -> dict[str, Any]:
+    try:
+        receipt = RuntimeEnvironmentRetirementReceipt.model_validate_json(
+            json.dumps(fence.retirement_receipt, separators=(",", ":"), ensure_ascii=True),
+            strict=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("persisted runtime retirement receipt is invalid") from exc
+
+    high_waters = {
+        item.boot_session_id: item.sequence for item in receipt.final_session_high_water_marks
+    }
+    if (
+        fence.retirement_id is None
+        or fence.retired_at is None
+        or fence.final_cursor is None
+        or fence.final_session_high_waters is None
+        or not receipt.retirement_id
+        or len(receipt.retirement_id) > 200
+        or receipt.retired_at.tzinfo is None
+        or receipt.retired_at.utcoffset() is None
+        or receipt.environment_reference != str(fence.environment_id)
+        or receipt.expected_deployment_binding != fence.deployment_id
+        or receipt.retirement_id != fence.retirement_id
+        or _utc(receipt.retired_at) != _utc(fence.retired_at)
+        or receipt.final_cursor != fence.final_cursor
+        or len(high_waters) != len(receipt.final_session_high_water_marks)
+        or high_waters != fence.final_session_high_waters
+        or any(
+            not boot_session_id or sequence < 0 for boot_session_id, sequence in high_waters.items()
+        )
+    ):
+        raise RuntimeError("persisted runtime retirement receipt identity is invalid")
+    return receipt.model_dump(mode="json", by_alias=True)
+
+
 async def retire_runtime_environment(
     db: AsyncSession,
     *,
@@ -636,17 +675,11 @@ async def retire_runtime_environment(
             "runtime environment deployment binding does not match",
         )
     if fence.state == RUNTIME_ENVIRONMENT_RETIRED:
-        if fence.retirement_id == retirement_id and isinstance(fence.retirement_receipt, dict):
-            return RuntimeEnvironmentRetirementResult(
-                receipt=fence.retirement_receipt,
-                transitioned=False,
-                final_stream_position=fence.final_stream_position or 0,
-                final_session_high_waters=dict(fence.final_session_high_waters or {}),
-            )
-        raise RuntimeObservationProtocolError(
-            409,
-            "runtime_environment_retirement_conflict",
-            "runtime environment was retired by another obligation",
+        return RuntimeEnvironmentRetirementResult(
+            receipt=_validated_retirement_receipt(fence),
+            transitioned=False,
+            final_stream_position=fence.final_stream_position or 0,
+            final_session_high_waters=dict(fence.final_session_high_waters or {}),
         )
 
     heads = (

--- a/backend/tests/test_platform_workload_oauth.py
+++ b/backend/tests/test_platform_workload_oauth.py
@@ -889,29 +889,47 @@ async def test_v2_provision_precedes_scoped_deploy_key_and_retirement_replays_ex
     assert transition.details["previous_state"] == "active"
     assert transition.details["new_state"] == "retired"
 
-    conflicting = await workload_harness.client.post(
+    adopted_request_id = f"other-{environment_id}"
+    adopted = await workload_harness.client.post(
         path,
         headers={
             "X-Admin-Key": _ADMIN_KEY,
-            "Idempotency-Key": f"retire-conflict-{environment_id}",
+            "Idempotency-Key": f"retire-adopt-{environment_id}",
         },
-        json={**body, "retirementId": f"other-{environment_id}"},
+        json={**body, "retirementId": adopted_request_id},
     )
-    assert conflicting.status_code == 409, conflicting.text
-    assert conflicting.json()["detail"]["code"] == "runtime_environment_retirement_conflict"
-    rejection_audit = (
+    assert adopted.status_code == 200, adopted.text
+    assert adopted.content == first.content
+    adoption_audit = (
         await db_session.execute(
             select(ControlPlaneAuditEvent).where(
                 ControlPlaneAuditEvent.source == "api.v2.runtime",
-                ControlPlaneAuditEvent.action == "runtime_environment.retire",
+                ControlPlaneAuditEvent.action == "runtime_environment.retire_adopted",
                 ControlPlaneAuditEvent.resource_id == str(environment_id),
-                ControlPlaneAuditEvent.details["outcome"].astext
-                == "runtime_environment_retirement_conflict",
             )
         )
     ).scalar_one()
-    assert rejection_audit.actor_type == "admin"
-    assert rejection_audit.details["auth_method"] == "x_admin_key"
+    assert adoption_audit.actor_type == "admin"
+    assert adoption_audit.details["auth_method"] == "x_admin_key"
+    assert adoption_audit.details["requested_retirement_id"] == adopted_request_id
+    assert adoption_audit.details["authoritative_retirement_id"] == body["retirementId"]
+    await db_session.refresh(fence)
+    assert fence.retirement_id == body["retirementId"]
+    assert fence.retirement_receipt == first.json()
+
+    mismatched_binding = await workload_harness.client.post(
+        path,
+        headers={
+            "X-Admin-Key": _ADMIN_KEY,
+            "Idempotency-Key": f"retire-binding-conflict-{environment_id}",
+        },
+        json={
+            "expectedDeploymentBinding": f"other-{deployment_id}",
+            "retirementId": f"binding-conflict-{environment_id}",
+        },
+    )
+    assert mismatched_binding.status_code == 409, mismatched_binding.text
+    assert mismatched_binding.json()["detail"]["code"] == ("runtime_environment_binding_conflict")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -603,6 +603,79 @@ async def test_ingestion_and_retirement_serialize_on_the_environment_fence(
 
 @pytest.mark.committed_db
 @pytest.mark.asyncio
+async def test_competing_retirements_adopt_the_first_authoritative_receipt(
+    engine,
+    db_session: AsyncSession,
+    seed_user,
+):
+    environment, _ = await _provision_environment(db_session, seed_user)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with session_factory() as principal_session:
+        principal = await _retire_runtime_environment(
+            principal_session,
+            environment_id=environment.id,
+            expected_deployment_id=_DEPLOYMENT_ID,
+            retirement_id="principal-termination:lifecycle-1",
+            owner_id=seed_user.id,
+        )
+
+        async def retire_from_hosted():
+            async with session_factory() as hosted_session:
+                result = await _retire_runtime_environment(
+                    hosted_session,
+                    environment_id=environment.id,
+                    expected_deployment_id=_DEPLOYMENT_ID,
+                    retirement_id="runtime-retirement:deployment-delete-1",
+                    owner_id=seed_user.id,
+                )
+                await hosted_session.commit()
+                return result
+
+        hosted_retirement = asyncio.create_task(retire_from_hosted())
+        await asyncio.sleep(0.05)
+        assert not hosted_retirement.done()
+        await principal_session.commit()
+        adopted = await asyncio.wait_for(hosted_retirement, timeout=5)
+
+    assert principal.transitioned
+    assert not adopted.transitioned
+    assert adopted.receipt == principal.receipt
+    assert adopted.receipt["retirementId"] == "principal-termination:lifecycle-1"
+
+    fence = await db_session.get(V2RuntimeEnvironmentFence, environment.id)
+    assert fence is not None
+    await db_session.refresh(fence)
+    assert fence.retirement_id == "principal-termination:lifecycle-1"
+    assert fence.retirement_receipt == principal.receipt
+
+    fence.retirement_receipt = {
+        **principal.receipt,
+        "expectedDeploymentBinding": "another-deployment",
+    }
+    with pytest.raises(
+        RuntimeError,
+        match="persisted runtime retirement receipt identity is invalid",
+    ):
+        runtime_observation_service._validated_retirement_receipt(fence)
+
+    fence.final_session_high_waters = {"boot-session-malformed": 1}
+    fence.retirement_receipt = {
+        **principal.receipt,
+        "finalSessionHighWaterMarks": [
+            {"bootSessionId": "boot-session-malformed", "sequence": "1"}
+        ],
+    }
+    with pytest.raises(
+        RuntimeError,
+        match="persisted runtime retirement receipt is invalid",
+    ):
+        runtime_observation_service._validated_retirement_receipt(fence)
+    await db_session.rollback()
+
+
+@pytest.mark.committed_db
+@pytest.mark.asyncio
 async def test_retirement_first_rejects_delayed_new_session(
     engine,
     db_session: AsyncSession,


### PR DESCRIPTION
## Summary

- return the existing immutable retirement receipt when another legitimate lifecycle obligation already retired the same exact environment/deployment binding
- preserve the first retirement identity and validate the complete persisted receipt before adoption
- record requested and authoritative retirement IDs separately in control-plane audit events

## Safety

Owner and deployment binding checks remain fail-closed before adoption. Malformed, non-strict, or identity-inconsistent persisted receipts are rejected. No schema, migration, generated client, tenant, or deployment-specific logic.

## Verification

- focused competing-retirement and endpoint contracts: 2 passed
- `bash scripts/test.sh backend`: 2329 passed, 12 skipped
- Ruff checks and `git diff --check`: passed

Hosted consumer PR follows and must be released only after this Cloud change is live.
