### PR TITLE
fix(admin): prove exact managed provider cleanup

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -55,6 +55,7 @@ from app.models.channel import (
     ChannelBotAgentLink,
 )
 from app.models.hosted_runtime import HostedRuntimeState
+from app.models.principal_lifecycle import PrincipalLifecycle
 from app.models.session import AgentEnvironment
 from app.models.user import (
     PRINCIPAL_KIND_CLERK,
@@ -73,6 +74,8 @@ from app.schemas.admin import (
     AdminChannelUpdate,
     AdminChannelVisibility,
     AdminChannelWebhookSecretResponse,
+    AdminDeploymentManagedAiProviderCleanup,
+    AdminDeploymentManagedAiProviderCleanupReceipt,
     AdminDeploymentManagedAiProviderResponse,
     AdminDeploymentManagedAiProviderRuntimeMetadataReplace,
     AdminDeploymentManagedAiProviderUpsert,
@@ -160,7 +163,10 @@ from app.services.managed_ai_provider import (
     MANAGED_AI_PROVIDER_TYPE,
     V2_MANAGED_AI_PROVIDER_ID,
     V2_MANAGED_AI_PROVIDER_IDS,
+    DeploymentManagedProviderCleanupInvariantError,
+    DeploymentManagedProviderCleanupMismatchError,
     archive_clawdi_managed_provider,
+    cleanup_deployment_managed_provider,
     find_clawdi_managed_provider,
     is_supported_deployment_managed_provider_contract,
     is_v2_deployment_managed_provider_id,
@@ -173,6 +179,7 @@ from app.services.principal_lifecycle import (
     PrincipalLifecycleConfigurationError,
     PrincipalTerminatedError,
     assert_user_authority_active,
+    configured_clerk_issuer,
     load_clerk_user_for_issuer,
     resolve_clerk_owner_issuer,
 )
@@ -574,6 +581,60 @@ async def _find_deployment_managed_provider_owner(
         )
         await db.commit()
         raise
+
+
+async def _find_deployment_managed_provider_cleanup_owner(
+    db: AsyncSession,
+    *,
+    owner: PlatformOwner,
+    provider_id: str,
+    action: str,
+) -> tuple[User, datetime | None]:
+    """Resolve active authority or an exact completed Clerk cleanup fence."""
+
+    try:
+        return await _find_admin_owner(db, owner), None
+    except HTTPException as exc:
+        if owner.kind != PRINCIPAL_KIND_CLERK or exc.status_code != status.HTTP_403_FORBIDDEN:
+            _record_deployment_managed_provider_audit(
+                db,
+                action=action,
+                owner=owner,
+                owner_user_id=None,
+                provider_id=provider_id,
+                outcome="failed",
+            )
+            await db.commit()
+            raise
+
+        issuer = configured_clerk_issuer()
+        row = (
+            await db.execute(
+                select(User, PrincipalLifecycle.cleanup_completed_at)
+                .join(PrincipalLifecycle, PrincipalLifecycle.user_id == User.id)
+                .where(
+                    User.principal_kind == PRINCIPAL_KIND_CLERK,
+                    User.clerk_id == owner.ref,
+                    User.clerk_issuer == issuer,
+                    PrincipalLifecycle.issuer == issuer,
+                    PrincipalLifecycle.subject == owner.ref,
+                    PrincipalLifecycle.cleanup_completed_at.is_not(None),
+                )
+            )
+        ).one_or_none()
+        if row is None:
+            _record_deployment_managed_provider_audit(
+                db,
+                action=action,
+                owner=owner,
+                owner_user_id=None,
+                provider_id=provider_id,
+                outcome="failed",
+            )
+            await db.commit()
+            raise
+        target, cleanup_completed_at = row
+        return target, cleanup_completed_at
 
 
 async def _raise_deployment_managed_provider_scope_denied(
@@ -1154,6 +1215,104 @@ async def admin_replace_deployment_managed_ai_provider_metadata(
         provider=provider,
         owner=owner,
         target=target,
+    )
+
+
+@router.post(
+    "/ai-providers/{provider_id}/cleanup",
+    response_model=AdminDeploymentManagedAiProviderCleanupReceipt,
+)
+async def admin_cleanup_deployment_managed_ai_provider(
+    provider_id: str,
+    body: AdminDeploymentManagedAiProviderCleanup,
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+) -> AdminDeploymentManagedAiProviderCleanupReceipt:
+    """Archive or prove one exact deployment-scoped managed provider."""
+
+    if not is_v2_deployment_managed_provider_id(provider_id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
+    owner = body.owner
+    action = "ai_provider.managed.cleanup"
+    target, principal_cleanup_completed_at = await _find_deployment_managed_provider_cleanup_owner(
+        db,
+        owner=owner,
+        provider_id=provider_id,
+        action=action,
+    )
+    authority = (
+        "active_owner" if principal_cleanup_completed_at is None else "completed_principal_cleanup"
+    )
+    try:
+        result = await cleanup_deployment_managed_provider(
+            db,
+            owner_user_id=target.id,
+            provider_id=provider_id,
+            expected_provider_uuid=body.expected_provider_uuid,
+            provisioning_discovery_key=body.provisioning_discovery_key,
+            authority=authority,
+        )
+    except DeploymentManagedProviderCleanupMismatchError as exc:
+        _record_deployment_managed_provider_audit(
+            db,
+            action=action,
+            owner=owner,
+            owner_user_id=target.id,
+            provider_id=provider_id,
+            outcome="identity_mismatch",
+        )
+        await db.commit()
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "Managed AI provider cleanup identity did not match",
+        ) from exc
+    except DeploymentManagedProviderCleanupInvariantError as exc:
+        _record_deployment_managed_provider_audit(
+            db,
+            action=action,
+            owner=owner,
+            owner_user_id=target.id,
+            provider_id=provider_id,
+            outcome="invariant_violation",
+        )
+        await db.commit()
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "Managed AI provider cleanup invariant did not hold",
+        ) from exc
+    if result is None:
+        await _raise_deployment_managed_provider_scope_denied(
+            db,
+            action=action,
+            owner=owner,
+            owner_user_id=target.id,
+            provider_id=provider_id,
+        )
+
+    provider = result.provider
+    if result.status == "archived":
+        await queue_provider_runtime_manifest_changed(db, target.id, provider_id)
+    _record_deployment_managed_provider_audit(
+        db,
+        action=action,
+        owner=owner,
+        owner_user_id=target.id,
+        provider_id=provider_id,
+        provider_uuid=provider.id,
+        outcome=result.status,
+    )
+    await db.commit()
+    if provider.archived_at is None:
+        raise RuntimeError("managed AI provider cleanup did not archive provider")
+    return AdminDeploymentManagedAiProviderCleanupReceipt(
+        status=result.status,
+        authority=authority,
+        owner=owner,
+        provider_id=provider.provider_id,
+        provider_uuid=provider.id,
+        provisioning_discovery_key=body.provisioning_discovery_key,
+        archived_at=provider.archived_at,
+        principal_cleanup_completed_at=principal_cleanup_completed_at,
     )
 
 

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -246,6 +246,45 @@ class AdminDeploymentManagedAiProviderRuntimeMetadataReplace(BaseModel):
     models: list[AiProviderModel] | None
 
 
+class AdminDeploymentManagedAiProviderCleanup(BaseModel):
+    """Archive or prove one exact deployment-scoped managed provider."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    owner: PlatformOwner
+    expected_provider_uuid: UUID
+    provisioning_discovery_key: str = Field(min_length=1, max_length=191)
+
+    @field_validator("provisioning_discovery_key")
+    @classmethod
+    def _validate_discovery_key(cls, value: str) -> str:
+        if value != value.strip():
+            raise ValueError("provisioning_discovery_key must be canonical")
+        return value
+
+
+class AdminDeploymentManagedAiProviderCleanupReceipt(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["archived", "already_archived"]
+    authority: Literal["active_owner", "completed_principal_cleanup"]
+    owner: PlatformOwner
+    provider_id: str
+    provider_uuid: UUID
+    provisioning_discovery_key: str
+    archived_at: datetime
+    principal_cleanup_completed_at: datetime | None = None
+
+    @model_validator(mode="after")
+    def _validate_authority_receipt(self) -> AdminDeploymentManagedAiProviderCleanupReceipt:
+        completed = self.principal_cleanup_completed_at is not None
+        if completed != (self.authority == "completed_principal_cleanup"):
+            raise ValueError("cleanup authority receipt is inconsistent")
+        if completed and self.status != "already_archived":
+            raise ValueError("completed principal cleanup can only prove an archived provider")
+        return self
+
+
 class AdminDeploymentManagedAiProviderResponse(BaseModel):
     id: UUID
     owner: PlatformOwner

--- a/backend/app/services/managed_ai_provider.py
+++ b/backend/app/services/managed_ai_provider.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
+from typing import Literal
 from uuid import UUID
 
 from pydantic import JsonValue
@@ -64,6 +66,20 @@ _SUPPORTED_DEPLOYMENT_MANAGED_PROVIDER_CONTRACTS = frozenset(
 )
 
 _V2_DEPLOYMENT_ID_RE = re.compile(r"^[1-9][0-9]*$")
+
+
+class DeploymentManagedProviderCleanupMismatchError(ValueError):
+    pass
+
+
+class DeploymentManagedProviderCleanupInvariantError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class DeploymentManagedProviderCleanupResult:
+    provider: AiProvider
+    status: Literal["archived", "already_archived"]
 
 
 def is_v2_deployment_managed_provider_id(provider_id: str) -> bool:
@@ -317,3 +333,61 @@ async def archive_clawdi_managed_provider(
         archive_provider=True,
     )
     return provider
+
+
+async def cleanup_deployment_managed_provider(
+    db: AsyncSession,
+    *,
+    owner_user_id: UUID,
+    provider_id: str,
+    expected_provider_uuid: UUID,
+    provisioning_discovery_key: str,
+    authority: Literal["active_owner", "completed_principal_cleanup"],
+) -> DeploymentManagedProviderCleanupResult | None:
+    """Atomically archive or prove the exact retained managed provider."""
+
+    await lock_deployment_managed_provider_mutation(
+        db,
+        owner_user_id=owner_user_id,
+        provider_id=provider_id,
+    )
+    provider = (
+        await db.execute(
+            select(AiProvider)
+            .where(
+                AiProvider.owner_user_id == owner_user_id,
+                AiProvider.provider_id == provider_id,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if provider is None:
+        return None
+    if (
+        not is_supported_deployment_managed_provider_contract(provider)
+        or provider.id != expected_provider_uuid
+        or (provider.capabilities or {}).get(MANAGED_AI_PROVIDER_PROVENANCE_CAPABILITY)
+        != provisioning_discovery_key
+    ):
+        raise DeploymentManagedProviderCleanupMismatchError(
+            "managed AI provider cleanup identity did not match"
+        )
+    if provider.archived_at is not None:
+        return DeploymentManagedProviderCleanupResult(
+            provider=provider,
+            status="already_archived",
+        )
+    if authority == "completed_principal_cleanup":
+        raise DeploymentManagedProviderCleanupInvariantError(
+            "completed principal cleanup retained an active managed AI provider"
+        )
+    await transition_ai_provider_auth(
+        db,
+        owner_user_id=owner_user_id,
+        provider=provider,
+        auth_type=provider.auth_type,
+        auth_ref=provider.auth_ref,
+        auth_metadata=provider.auth_metadata,
+        archive_provider=True,
+    )
+    return DeploymentManagedProviderCleanupResult(provider=provider, status="archived")

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -1393,6 +1393,239 @@ async def test_admin_deployment_managed_ai_provider_lifecycle_is_owner_scoped_an
 
 
 @pytest.mark.asyncio
+async def test_admin_cleanup_deployment_managed_provider_archives_exact_identity_idempotently(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    from sqlalchemy import select
+
+    from app.models.ai_provider import AiProvider, AiProviderAuthPayload
+
+    provider_id = f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}5901"
+    marker = "a" * 64
+    owner = {"kind": "clerk", "ref": seed_user.clerk_id}
+    created = await admin_client.put(
+        f"/v1/admin/ai-providers/{provider_id}",
+        headers=_AUTH,
+        json={
+            "owner": owner,
+            "base_url": "https://ai-gateway.clawdi.ai/v1",
+            "api_key": "sk-cleanup-active",
+            "capabilities": {MANAGED_AI_PROVIDER_PROVENANCE_CAPABILITY: marker},
+        },
+    )
+    assert created.status_code == 200, created.text
+    provider_uuid = created.json()["id"]
+    request = {
+        "owner": owner,
+        "expected_provider_uuid": provider_uuid,
+        "provisioning_discovery_key": marker,
+    }
+
+    archived = await admin_client.post(
+        f"/v1/admin/ai-providers/{provider_id}/cleanup",
+        headers=_AUTH,
+        json=request,
+    )
+    assert archived.status_code == 200, archived.text
+    receipt = archived.json()
+    assert receipt == {
+        "status": "archived",
+        "authority": "active_owner",
+        "owner": owner,
+        "provider_id": provider_id,
+        "provider_uuid": provider_uuid,
+        "provisioning_discovery_key": marker,
+        "archived_at": receipt["archived_at"],
+        "principal_cleanup_completed_at": None,
+    }
+
+    replayed = await admin_client.post(
+        f"/v1/admin/ai-providers/{provider_id}/cleanup",
+        headers=_AUTH,
+        json=request,
+    )
+    assert replayed.status_code == 200, replayed.text
+    assert replayed.json() == {
+        **receipt,
+        "status": "already_archived",
+    }
+    provider = await db_session.get(AiProvider, UUID(provider_uuid))
+    assert provider is not None and provider.archived_at is not None
+    payload = (
+        await db_session.execute(
+            select(AiProviderAuthPayload).where(
+                AiProviderAuthPayload.owner_user_id == seed_user.id,
+                AiProviderAuthPayload.provider_id == provider_id,
+            )
+        )
+    ).scalar_one()
+    assert payload.archived_at is not None
+
+
+@pytest.mark.asyncio
+async def test_admin_cleanup_proves_exact_provider_archived_by_completed_principal_cleanup(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    from app.models.ai_provider import AiProvider
+    from app.models.principal_lifecycle import PrincipalLifecycle
+    from app.services.principal_lifecycle import complete_principal_cleanup
+
+    provider_id = f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}59"
+    marker = "b" * 64
+    owner = {"kind": "clerk", "ref": seed_user.clerk_id}
+    created = await admin_client.put(
+        f"/v1/admin/ai-providers/{provider_id}",
+        headers=_AUTH,
+        json={
+            "owner": owner,
+            "base_url": "https://ai-gateway.clawdi.ai/v1",
+            "api_key": "sk-cleanup-terminated",
+            "capabilities": {MANAGED_AI_PROVIDER_PROVENANCE_CAPABILITY: marker},
+        },
+    )
+    assert created.status_code == 200, created.text
+    provider_uuid = created.json()["id"]
+    now = datetime.now(UTC)
+    seed_user.clerk_issuer = _CLERK_ISSUER
+    lifecycle = PrincipalLifecycle(
+        issuer=_CLERK_ISSUER,
+        subject=seed_user.clerk_id,
+        user_id=seed_user.id,
+        terminated_at=now,
+        next_cleanup_attempt_at=now,
+    )
+    db_session.add(lifecycle)
+    await db_session.flush()
+    await complete_principal_cleanup(db_session, lifecycle_id=lifecycle.id, now=now)
+    await db_session.commit()
+
+    ordinary_read = await admin_client.get(
+        f"/v1/admin/ai-providers/{provider_id}",
+        headers=_AUTH,
+        params=owner,
+    )
+    assert ordinary_read.status_code == 403, ordinary_read.text
+    ordinary_metadata_write = await _replace_managed_provider_runtime_metadata(
+        admin_client,
+        provider_id,
+        {
+            "owner": owner,
+            "base_url": "https://ai-gateway.clawdi.ai/v1",
+            "models": None,
+        },
+    )
+    assert ordinary_metadata_write.status_code == 403, ordinary_metadata_write.text
+
+    proved = await admin_client.post(
+        f"/v1/admin/ai-providers/{provider_id}/cleanup",
+        headers=_AUTH,
+        json={
+            "owner": owner,
+            "expected_provider_uuid": provider_uuid,
+            "provisioning_discovery_key": marker,
+        },
+    )
+    assert proved.status_code == 200, proved.text
+    receipt = proved.json()
+    assert receipt == {
+        "status": "already_archived",
+        "authority": "completed_principal_cleanup",
+        "owner": owner,
+        "provider_id": provider_id,
+        "provider_uuid": provider_uuid,
+        "provisioning_discovery_key": marker,
+        "archived_at": receipt["archived_at"],
+        "principal_cleanup_completed_at": receipt["principal_cleanup_completed_at"],
+    }
+    await db_session.refresh(lifecycle)
+    provider = await db_session.get(AiProvider, UUID(provider_uuid))
+    assert provider is not None and provider.archived_at is not None
+    assert lifecycle.cleanup_completed_at is not None
+    assert lifecycle.cleanup_attempts == 1
+    assert datetime.fromisoformat(receipt["archived_at"]) == provider.archived_at
+    assert (
+        datetime.fromisoformat(receipt["principal_cleanup_completed_at"])
+        == lifecycle.cleanup_completed_at
+    )
+
+
+@pytest.mark.asyncio
+async def test_admin_cleanup_deployment_managed_provider_rejects_mismatch_and_pending_cleanup(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    from app.models.ai_provider import AiProvider
+    from app.models.principal_lifecycle import PrincipalLifecycle
+
+    provider_id = f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}5902"
+    marker = "c" * 64
+    owner = {"kind": "clerk", "ref": seed_user.clerk_id}
+    created = await admin_client.put(
+        f"/v1/admin/ai-providers/{provider_id}",
+        headers=_AUTH,
+        json={
+            "owner": owner,
+            "base_url": "https://ai-gateway.clawdi.ai/v1",
+            "api_key": "sk-cleanup-mismatch",
+            "capabilities": {MANAGED_AI_PROVIDER_PROVENANCE_CAPABILITY: marker},
+        },
+    )
+    assert created.status_code == 200, created.text
+    provider_uuid = created.json()["id"]
+    request = {
+        "owner": owner,
+        "expected_provider_uuid": provider_uuid,
+        "provisioning_discovery_key": marker,
+    }
+
+    for mismatch in (
+        {**request, "expected_provider_uuid": str(uuid.uuid4())},
+        {**request, "provisioning_discovery_key": "d" * 64},
+    ):
+        rejected = await admin_client.post(
+            f"/v1/admin/ai-providers/{provider_id}/cleanup",
+            headers=_AUTH,
+            json=mismatch,
+        )
+        assert rejected.status_code == 409, rejected.text
+
+    now = datetime.now(UTC)
+    seed_user.clerk_issuer = _CLERK_ISSUER
+    lifecycle = PrincipalLifecycle(
+        issuer=_CLERK_ISSUER,
+        subject=seed_user.clerk_id,
+        user_id=seed_user.id,
+        terminated_at=now,
+        next_cleanup_attempt_at=now,
+    )
+    db_session.add(lifecycle)
+    await db_session.commit()
+    pending = await admin_client.post(
+        f"/v1/admin/ai-providers/{provider_id}/cleanup",
+        headers=_AUTH,
+        json=request,
+    )
+    assert pending.status_code == 403, pending.text
+    lifecycle.cleanup_attempts = 1
+    lifecycle.cleanup_completed_at = now
+    lifecycle.next_cleanup_attempt_at = None
+    await db_session.commit()
+    inconsistent = await admin_client.post(
+        f"/v1/admin/ai-providers/{provider_id}/cleanup",
+        headers=_AUTH,
+        json=request,
+    )
+    assert inconsistent.status_code == 409, inconsistent.text
+    provider = await db_session.get(AiProvider, UUID(provider_uuid))
+    assert provider is not None and provider.archived_at is None
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "legacy_runtime_env",
     ["CLAWDI_MANAGED_OPENAI_API_KEY", MANAGED_AI_PROVIDER_RUNTIME_ENV],


### PR DESCRIPTION
## Summary

- add an atomic admin cleanup-or-prove-archived contract for deployment-scoped managed providers
- require exact owner, provider ID, provider UUID, and provisioning discovery key
- allow active owners to archive while terminated owners can only prove an already-archived provider after completed principal cleanup
- keep ordinary provider reads and writes fail-closed for terminated owners

## Verification

- focused incident contract: 3 passed
- full hermetic backend: 2332 passed, 12 skipped
- Ruff, format, compileall, and Python type governance passed

## Rollout

Deploy this Cloud contract before the corresponding Hosted consumer.