### PR TITLE
fix(cli): disable Hermes WhatsApp after unbind

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.80",
+      "version": "0.13.81",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.80",
+	"version": "0.13.81",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/lib/hermes-config-merge.ts
+++ b/packages/cli/src/lib/hermes-config-merge.ts
@@ -104,7 +104,10 @@ export function renderHermesChannelConfig(content: string, patch: Record<string,
 				applyHermesChannelNestedPatch(document, [platform], config);
 			} else {
 				for (const [nestedPlatform, nestedConfig] of Object.entries(config)) {
-					if (nestedPlatform === "telegram" && isPlainRecord(nestedConfig)) {
+					if (
+						(nestedPlatform === "telegram" || nestedPlatform === "whatsapp") &&
+						isPlainRecord(nestedConfig)
+					) {
 						applyHermesChannelNestedPatch(document, [platform, nestedPlatform], nestedConfig);
 						const updated = valueAtPath(document.toJS(), [platform, nestedPlatform]);
 						if (isPlainRecord(updated) && Object.keys(updated).length === 0) {
@@ -119,6 +122,14 @@ export function renderHermesChannelConfig(content: string, patch: Record<string,
 			if (isPlainRecord(updated) && Object.keys(updated).length === 0) {
 				document.delete(platform);
 			}
+			continue;
+		}
+		if (platform === "whatsapp" && isPlainRecord(config)) {
+			const root = document.toJS();
+			if (!isPlainRecord(root) || !isPlainRecord(root.whatsapp)) {
+				document.set(platform, document.createNode({}));
+			}
+			applyHermesChannelNestedPatch(document, [platform], config);
 			continue;
 		}
 		if (config === null) {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -3197,9 +3197,12 @@ function applyHostedChannelProjection(
 	if (name === "hermes") {
 		const configPath = join(home, ".hermes", "config.yaml");
 		withRuntimeUserFileAccess(() => {
+			const configContent = existsSync(configPath) ? readFileSync(configPath, "utf8") : "";
 			mergeHermesChannelConfig(
 				configPath,
-				hermesManagedChannelsPatch(channels, manifest.projection?.channelCredentials),
+				hermesManagedChannelsPatch(channels, manifest.projection?.channelCredentials, {
+					cleanupWhatsApp: hermesManagedWhatsAppProjectionOwned(configContent, home),
+				}),
 			);
 			makeRuntimeUserOwned(configPath);
 		});
@@ -3243,6 +3246,7 @@ function installHostedChannelProjectionDependencies(
 function hermesManagedChannelsPatch(
 	channels: Record<string, unknown>,
 	channelCredentials: unknown,
+	options: { cleanupWhatsApp?: boolean } = {},
 ): Record<string, unknown> {
 	const telegramEnabled = channelHasAccounts(channels.telegram);
 	const discordEnabled = channelHasAccounts(channels.discord);
@@ -3253,6 +3257,50 @@ function hermesManagedChannelsPatch(
 	if (whatsappEnabled && !whatsappSessionPath) {
 		throw new Error("managed Hermes WhatsApp projection is missing its auth directory");
 	}
+	const whatsapp = whatsappEnabled
+		? {
+				enabled: true,
+				dm_policy: "allowlist",
+				group_policy: "open",
+				allow_from: ["*"],
+				group_allow_from: ["*"],
+			}
+		: options.cleanupWhatsApp !== false
+			? {
+					enabled: false,
+					dm_policy: null,
+					group_policy: null,
+					allow_from: null,
+					group_allow_from: null,
+				}
+			: null;
+	const whatsappPlatform = whatsappEnabled
+		? {
+				enabled: true,
+				extra: {
+					session_path: whatsappSessionPath,
+					dm_policy: "allowlist",
+					group_policy: "open",
+					allow_from: ["*"],
+					group_allow_from: ["*"],
+					group_sessions_per_user: false,
+					thread_sessions_per_user: false,
+				},
+			}
+		: options.cleanupWhatsApp !== false
+			? {
+					enabled: false,
+					extra: {
+						session_path: null,
+						dm_policy: null,
+						group_policy: null,
+						allow_from: null,
+						group_allow_from: null,
+						group_sessions_per_user: null,
+						thread_sessions_per_user: null,
+					},
+				}
+			: null;
 	const sharedChannelSessionsEnabled = telegramEnabled || discordEnabled || whatsappEnabled;
 	return {
 		telegram: telegramEnabled
@@ -3280,17 +3328,7 @@ function hermesManagedChannelsPatch(
 					bots_require_inline_mention: false,
 				}
 			: { enabled: false },
-		...(whatsappEnabled
-			? {
-					whatsapp: {
-						enabled: true,
-						dm_policy: "allowlist",
-						group_policy: "open",
-						allow_from: ["*"],
-						group_allow_from: ["*"],
-					},
-				}
-			: {}),
+		...(whatsapp ? { whatsapp } : {}),
 		group_sessions_per_user: sharedChannelSessionsEnabled ? false : null,
 		thread_sessions_per_user: sharedChannelSessionsEnabled ? false : null,
 		platforms: {
@@ -3300,22 +3338,7 @@ function hermesManagedChannelsPatch(
 					thread_sessions_per_user: telegramEnabled ? false : null,
 				},
 			},
-			...(whatsappEnabled
-				? {
-						whatsapp: {
-							enabled: true,
-							extra: {
-								session_path: whatsappSessionPath,
-								dm_policy: "allowlist",
-								group_policy: "open",
-								allow_from: ["*"],
-								group_allow_from: ["*"],
-								group_sessions_per_user: false,
-								thread_sessions_per_user: false,
-							},
-						},
-					}
-				: {}),
+			...(whatsappPlatform ? { whatsapp: whatsappPlatform } : {}),
 		},
 		display: {
 			platforms: {
@@ -3325,6 +3348,18 @@ function hermesManagedChannelsPatch(
 			},
 		},
 	};
+}
+
+function hermesManagedWhatsAppProjectionOwned(configContent: string, home: string): boolean {
+	try {
+		const root = recordValue(parseYaml(configContent));
+		const platforms = recordValue(root?.platforms);
+		const whatsapp = recordValue(platforms?.whatsapp);
+		const extra = recordValue(whatsapp?.extra);
+		return extra?.session_path === managedWhatsAppAuthRoot(home, "hermes");
+	} catch {
+		return false;
+	}
 }
 
 function hermesManagedWhatsAppSessionPath(channelCredentials: unknown): string | null {
@@ -5253,7 +5288,9 @@ function validateRuntimeProjectionPlan(input: {
 		if (channels && name === "hermes" && runtime.enabled) {
 			hermesConfig = renderHermesChannelConfig(
 				hermesConfig,
-				hermesManagedChannelsPatch(channels, manifest.projection?.channelCredentials),
+				hermesManagedChannelsPatch(channels, manifest.projection?.channelCredentials, {
+					cleanupWhatsApp: hermesManagedWhatsAppProjectionOwned(hermesConfig, home),
+				}),
 			);
 		}
 	}

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -13659,8 +13659,25 @@ exit 64
 			me: { id: "15551234567:1@s.whatsapp.net" },
 		};
 		mkdirSync(dirname(hermesBin), { recursive: true });
+		mkdirSync(join(home, ".hermes"), { recursive: true });
 		mkdirSync(workspace, { recursive: true });
 		writeFileSync(hermesBin, "#!/usr/bin/env bash\nexit 0\n");
+		writeFileSync(
+			join(home, ".hermes", "config.yaml"),
+			[
+				"custom_root: keep",
+				"whatsapp:",
+				"  user_owned: keep-whatsapp",
+				"platforms:",
+				"  matrix:",
+				"    custom: keep-matrix",
+				"  whatsapp:",
+				"    custom: keep-platform",
+				"    extra:",
+				"      custom_extra: keep-extra",
+				"",
+			].join("\n"),
+		);
 		chmodSync(hermesBin, 0o700);
 		seedHermesManagedBaileys(home);
 		seedOpenClawBinary(home);
@@ -13915,32 +13932,30 @@ exit 64
 		expect(removedConvergence.installErrors).toEqual([]);
 		expect(existsSync(paths.egressProfileBundle)).toBe(false);
 		expect(existsSync(sessionDir)).toBe(false);
+		const removedHermesConfig = readHermesConfigYaml(home);
+		expect(removedHermesConfig).toHaveProperty("whatsapp", {
+			user_owned: "keep-whatsapp",
+			enabled: false,
+		});
+		expect(removedHermesConfig).toHaveProperty("platforms.whatsapp", {
+			custom: "keep-platform",
+			enabled: false,
+			extra: { custom_extra: "keep-extra" },
+		});
+		expect(removedHermesConfig).toMatchObject({
+			custom_root: "keep",
+			platforms: { matrix: { custom: "keep-matrix" } },
+		});
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_MODE).toBeUndefined();
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ALLOWED_USERS).toBeUndefined();
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ALLOW_ALL_USERS).toBeUndefined();
-	});
 
-	it("clears managed Hermes channels without touching user-owned WhatsApp settings", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const workspace = join(home, "clawdi");
-		const hermesBin = join(home, ".local", "bin", "hermes");
-		mkdirSync(dirname(hermesBin), { recursive: true });
-		mkdirSync(join(home, ".hermes"), { recursive: true });
-		mkdirSync(workspace, { recursive: true });
-		writeFileSync(hermesBin, "#!/usr/bin/env bash\nexit 0\n");
 		writeFileSync(
 			join(home, ".hermes", "config.yaml"),
 			[
-				"telegram:",
-				"  enabled: true",
-				"discord:",
-				"  enabled: true",
-				"  stale: should-be-removed",
 				"whatsapp:",
 				"  enabled: true",
-				"  user_owned: keep",
+				"  user_owned: manual",
 				"platforms:",
 				"  whatsapp:",
 				"    enabled: true",
@@ -13949,115 +13964,11 @@ exit 64
 				"",
 			].join("\n"),
 		);
-		chmodSync(hermesBin, 0o700);
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_SYSTEMD_APPLY = "0";
-
-		const load: RuntimeManifestLoad = {
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				runtime: "hermes",
-				deploymentId: "dep_hermes_channel_clear",
-				environmentId: "env_hermes_channel_clear",
-				instanceId: "iid_hermes_channel_clear",
-				generation: 13,
-				issuedAt: "2026-07-07T00:00:00Z",
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					hermes: {
-						enabled: true,
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://hermes-agent.nousresearch.com/install.sh",
-							home,
-							args: [],
-						},
-						run: {
-							args: ["gateway", "run", "--replace"],
-							env: {
-								HERMES_EXISTING_ENV: "kept",
-								TELEGRAM_ALLOW_ALL_USERS: "true",
-								DISCORD_ALLOW_ALL_USERS: "true",
-								WHATSAPP_ENABLED: "true",
-								WHATSAPP_MODE: "bot",
-								WHATSAPP_ALLOWED_USERS: "*",
-								WHATSAPP_ALLOW_ALL_USERS: "true",
-							},
-							secretEnv: {
-								TELEGRAM_BOT_TOKEN: "secret://channels/telegram/clawdi_stale/agent-token",
-								DISCORD_BOT_TOKEN: "secret://channels/discord/clawdi_stale/agent-token",
-								HERMES_WA_CREDS_JSON:
-									"secret://channels/whatsapp/clawdi_stale/credentials/stale/creds-json",
-							},
-							prependPath: [],
-						},
-						services: {},
-					},
-				},
-				projection: {
-					system: { home, workspace },
-				},
-				recovery: {},
-			},
-			source: "remote-datasource",
-			sourcePath: "test://hermes-channel-clear",
-			offline: false,
-			secretValues: {
-				"secret://channels/whatsapp/clawdi_stale/credentials/stale/creds-json":
-					'{"me":"user-owned"}',
-			},
-			channelBindings: [],
-		};
-		const projected = applyRuntimeBundleChannelsToManifestLoad(load);
-
-		const convergence = convergeRuntimeManifest(projected, getRuntimePaths());
-
-		expect(convergence.installErrors).toEqual([]);
-		const hermesConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf-8");
-		expect(hermesConfig).toContain("telegram:");
-		expect(hermesConfig).toContain("discord:");
-		expect(hermesConfig).toContain("whatsapp:");
-		expect(hermesConfig).toContain("enabled: true");
-		expect(hermesConfig).toContain("user_owned: keep");
-		expect(hermesConfig).toContain("/user/session");
-		expect(hermesConfig).not.toContain("stale: should-be-removed");
-		const clearedChannelsConfig = readHermesConfigYaml(home);
-		expect(clearedChannelsConfig).not.toHaveProperty("display");
-		expect(clearedChannelsConfig).not.toHaveProperty("group_sessions_per_user");
-		expect(clearedChannelsConfig).not.toHaveProperty("thread_sessions_per_user");
-		expect(clearedChannelsConfig).not.toHaveProperty("platforms.telegram");
-		expect(clearedChannelsConfig).not.toHaveProperty(
-			"platforms.telegram.extra.thread_sessions_per_user",
-		);
-		expect(clearedChannelsConfig).not.toHaveProperty("streaming.enabled");
-		expect(clearedChannelsConfig).not.toHaveProperty("streaming.transport");
-		const runConfig = JSON.parse(
-			readFileSync(join(getRuntimePaths().runConfigRoot, "hermes.json"), "utf-8"),
-		);
-		expect(runConfig.env.HERMES_EXISTING_ENV).toBe("kept");
-		expect(runConfig.env.TELEGRAM_ALLOW_ALL_USERS).toBeUndefined();
-		expect(runConfig.env.DISCORD_ALLOW_ALL_USERS).toBeUndefined();
-		expect(runConfig.env.WHATSAPP_ENABLED).toBe("true");
-		expect(runConfig.env.WHATSAPP_MODE).toBeUndefined();
-		expect(runConfig.env.WHATSAPP_ALLOWED_USERS).toBeUndefined();
-		expect(runConfig.env.WHATSAPP_ALLOW_ALL_USERS).toBeUndefined();
-		expect(runConfig.secretEnv.TELEGRAM_BOT_TOKEN).toBeUndefined();
-		expect(runConfig.secretEnv.DISCORD_BOT_TOKEN).toBeUndefined();
-		expect(runConfig.secretEnv.HERMES_WA_CREDS_JSON).toBe(
-			"secret://channels/whatsapp/clawdi_stale/credentials/stale/creds-json",
-		);
-		const hermesEnv = readSystemdEnvFile(getRuntimePaths(), "hermes-gateway");
-		expect(hermesEnv).not.toContain("TELEGRAM_BOT_TOKEN");
-		expect(hermesEnv).not.toContain("DISCORD_BOT_TOKEN");
-		expect(hermesEnv).toContain("HERMES_WA_CREDS_JSON");
-		expect(hermesEnv).toContain("WHATSAPP_ENABLED");
-		expect(hermesEnv).not.toContain("WHATSAPP_MODE");
-		expect(hermesEnv).not.toContain("WHATSAPP_ALLOWED_USERS");
-		expect(hermesEnv).not.toContain("WHATSAPP_ALLOW_ALL_USERS");
+		expect(convergeRuntimeManifest(removed, paths).installErrors).toEqual([]);
+		expect(readHermesConfigYaml(home)).toMatchObject({
+			whatsapp: { enabled: true, user_owned: "manual" },
+			platforms: { whatsapp: { enabled: true, extra: { session_path: "/user/session" } } },
+		});
 	});
 
 	it("isolates OpenClaw WhatsApp DMs and clears stale managed config", () => {


### PR DESCRIPTION
## Summary

- disable both Hermes WhatsApp config paths when a previously managed Hosted binding is removed
- clear only Clawdi-managed WhatsApp policy/session fields, preserving unrelated and user-owned Hermes configuration
- leave never-managed user WhatsApp configuration untouched
- release the fix as `clawdi@0.13.80`

## Root cause

Hermes config uses merge semantics. Telegram and Discord projected `enabled=false` when unbound, but WhatsApp omitted its patch entirely, so a previously paired deployment retained `enabled=true` and the gateway exited with WhatsApp enabled but not paired.

Cleanup is now gated by the exact Clawdi-managed Hermes `session_path`; an unrelated manual WhatsApp setup is not claimed or disabled.

## Verification

- focused managed bind -> unbind -> manual config regression: 1 passed, 44 assertions
- Docker clean CLI gate: 1705 passed, 4 skipped, 0 failed
- CLI typecheck and frozen lock install
- publish manifest gate
- Biome and `git diff --check`

## Release impact

This PR bumps the CLI package from `0.13.79` to `0.13.80`. It does not change the runtime image, database schema, or tenant-specific configuration. Existing affected deployments converge through the normal exact-CLI rollout; no force restart is required.