### PR TITLE
fix(cli): retain Hermes WhatsApp cleanup authority

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.81",
+      "version": "0.13.82",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.81",
+	"version": "0.13.82",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/managed-channel-reconciliation.ts
+++ b/packages/cli/src/runtime/managed-channel-reconciliation.ts
@@ -50,7 +50,7 @@ export function planManagedHermesWhatsApp(input: {
 }): ManagedHermesWhatsAppPlan {
 	const desired = desiredHermesWhatsAppReceipt(input.manifest, input.home);
 	const stored = readManagedHermesWhatsAppReceipt(input.paths);
-	if (stored) assertReceiptScope(stored, input.manifest);
+	if (stored) assertReceiptAuthority(stored, input.manifest, input.home);
 	const commit =
 		input.manifest.runtimes.hermes?.enabled === true &&
 		input.manifest.projection !== undefined &&
@@ -248,7 +248,7 @@ function desiredHermesWhatsAppReceipt(
 		throw new Error("managed Hermes WhatsApp projection is missing its Link identity");
 	}
 	const authDir = resolve(credential.authDir);
-	const expectedAuthDir = resolve(home, ".hermes", "platforms", "whatsapp", "session");
+	const expectedAuthDir = managedHermesWhatsAppAuthDir(home);
 	if (authDir !== expectedAuthDir) {
 		throw new Error(`managed Hermes WhatsApp auth directory must be ${expectedAuthDir}`);
 	}
@@ -304,9 +304,10 @@ function readManagedHermesWhatsAppReceipt(
 	}
 }
 
-function assertReceiptScope(
+function assertReceiptAuthority(
 	receipt: ManagedHermesWhatsAppReceipt,
 	manifest: RuntimeManifest,
+	home: string,
 ): void {
 	if (
 		receipt.deploymentId !== manifest.deploymentId ||
@@ -315,6 +316,14 @@ function assertReceiptScope(
 	) {
 		throw new Error("managed Hermes WhatsApp receipt belongs to another runtime identity");
 	}
+	const expectedAuthDir = managedHermesWhatsAppAuthDir(home);
+	if (receipt.authDir !== expectedAuthDir) {
+		throw new Error(`managed Hermes WhatsApp receipt auth directory must be ${expectedAuthDir}`);
+	}
+}
+
+function managedHermesWhatsAppAuthDir(home: string): string {
+	return resolve(home, ".hermes", "platforms", "whatsapp", "session");
 }
 
 function hermesWhatsAppConfigCleanupAuthorized(

--- a/packages/cli/src/runtime/managed-channel-reconciliation.ts
+++ b/packages/cli/src/runtime/managed-channel-reconciliation.ts
@@ -1,0 +1,348 @@
+import { existsSync, lstatSync, readFileSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+import type { RuntimeApplyContext } from "./apply-identity";
+import type { RuntimeManifest } from "./manifest-contract";
+import { loadCommittedRuntimeManifest } from "./manifest-source";
+import type { RuntimePaths } from "./paths";
+import { writeRuntimePlatformFileAtomic } from "./state";
+import { managedWhatsAppAuthCredentials } from "./whatsapp-credential-projection";
+
+const RECEIPT_FILE = "hermes-whatsapp.json";
+const receiptSchema = z
+	.object({
+		schemaVersion: z.literal("clawdi.managedHermesWhatsApp.v1"),
+		deploymentId: z.string().min(1),
+		environmentId: z.string().min(1),
+		instanceId: z.string().min(1),
+		runtime: z.literal("hermes"),
+		provider: z.literal("whatsapp"),
+		accountKey: z.string().min(1),
+		linkId: z.string().uuid(),
+		credentialId: z.string().uuid(),
+		authDir: z.string().min(1),
+	})
+	.strict()
+	.refine((receipt) => resolve(receipt.authDir) === receipt.authDir, {
+		message: "managed Hermes WhatsApp auth directory must be absolute",
+		path: ["authDir"],
+	});
+
+export type ManagedHermesWhatsAppReceipt = z.infer<typeof receiptSchema>;
+
+export interface ManagedHermesWhatsAppPlan {
+	previous: ManagedHermesWhatsAppReceipt | null;
+	desired: ManagedHermesWhatsAppReceipt | null;
+	cleanupAuthorized: boolean;
+	commit: boolean;
+}
+
+export function managedHermesWhatsAppReceiptPath(paths: RuntimePaths): string {
+	return join(paths.managedResourceRoot, RECEIPT_FILE);
+}
+
+export function planManagedHermesWhatsApp(input: {
+	manifest: RuntimeManifest;
+	paths: RuntimePaths;
+	applyContext: RuntimeApplyContext;
+	home: string;
+}): ManagedHermesWhatsAppPlan {
+	const desired = desiredHermesWhatsAppReceipt(input.manifest, input.home);
+	const stored = readManagedHermesWhatsAppReceipt(input.paths);
+	if (stored) assertReceiptScope(stored, input.manifest);
+	const commit =
+		input.manifest.runtimes.hermes?.enabled === true &&
+		input.manifest.projection !== undefined &&
+		Object.hasOwn(input.manifest.projection, "channels");
+	const previous =
+		stored ??
+		(desired === null && commit
+			? recoverCommittedHermesWhatsAppReceipt(
+					input.manifest,
+					input.paths,
+					input.applyContext,
+					input.home,
+				)
+			: null);
+	return {
+		previous,
+		desired,
+		cleanupAuthorized: commit && desired === null && previous !== null,
+		commit,
+	};
+}
+
+export function buildHermesManagedChannelsPatch(
+	channels: Record<string, unknown>,
+	plan: ManagedHermesWhatsAppPlan,
+	currentConfig: string,
+): Record<string, unknown> {
+	return hermesManagedChannelsPatch(
+		channels,
+		plan.desired,
+		hermesWhatsAppConfigCleanupAuthorized(plan, currentConfig),
+	);
+}
+
+export function buildHermesManagedChannelsRevision(
+	channels: Record<string, unknown>,
+	plan: ManagedHermesWhatsAppPlan,
+): Record<string, unknown> {
+	return hermesManagedChannelsPatch(channels, plan.desired, false);
+}
+
+function hermesManagedChannelsPatch(
+	channels: Record<string, unknown>,
+	desiredWhatsApp: ManagedHermesWhatsAppReceipt | null,
+	cleanupWhatsApp: boolean,
+): Record<string, unknown> {
+	const telegramEnabled = managedChannelHasAccounts(channels.telegram);
+	const discordEnabled = managedChannelHasAccounts(channels.discord);
+	const whatsappEnabled = managedChannelHasAccounts(channels.whatsapp);
+	if (whatsappEnabled && !desiredWhatsApp) {
+		throw new Error("managed Hermes WhatsApp projection is missing its exact ownership identity");
+	}
+	const whatsapp = whatsappEnabled
+		? {
+				enabled: true,
+				dm_policy: "allowlist",
+				group_policy: "open",
+				allow_from: ["*"],
+				group_allow_from: ["*"],
+			}
+		: cleanupWhatsApp
+			? {
+					enabled: false,
+					dm_policy: null,
+					group_policy: null,
+					allow_from: null,
+					group_allow_from: null,
+				}
+			: null;
+	const whatsappPlatform = whatsappEnabled
+		? {
+				enabled: true,
+				extra: {
+					session_path: desiredWhatsApp?.authDir,
+					dm_policy: "allowlist",
+					group_policy: "open",
+					allow_from: ["*"],
+					group_allow_from: ["*"],
+					group_sessions_per_user: false,
+					thread_sessions_per_user: false,
+				},
+			}
+		: cleanupWhatsApp
+			? {
+					enabled: false,
+					extra: {
+						session_path: null,
+						dm_policy: null,
+						group_policy: null,
+						allow_from: null,
+						group_allow_from: null,
+						group_sessions_per_user: null,
+						thread_sessions_per_user: null,
+					},
+				}
+			: null;
+	const sharedChannelSessionsEnabled = telegramEnabled || discordEnabled || whatsappEnabled;
+	return {
+		telegram: telegramEnabled
+			? {
+					enabled: true,
+					dm_policy: "open",
+					group_policy: "open",
+					allow_from: ["*"],
+					group_allow_from: ["*"],
+					group_allowed_chats: ["*"],
+					require_mention: false,
+					extra: {
+						base_url: "https://api.telegram.org/bot",
+						base_file_url: "https://api.telegram.org/file/bot",
+					},
+				}
+			: { enabled: false },
+		discord: discordEnabled
+			? {
+					enabled: true,
+					dm_policy: "open",
+					group_policy: "open",
+					require_mention: false,
+					thread_require_mention: false,
+					bots_require_inline_mention: false,
+				}
+			: { enabled: false },
+		...(whatsapp ? { whatsapp } : {}),
+		group_sessions_per_user: sharedChannelSessionsEnabled ? false : null,
+		thread_sessions_per_user: sharedChannelSessionsEnabled ? false : null,
+		platforms: {
+			telegram: {
+				extra: {
+					group_sessions_per_user: telegramEnabled ? false : null,
+					thread_sessions_per_user: telegramEnabled ? false : null,
+				},
+			},
+			...(whatsappPlatform ? { whatsapp: whatsappPlatform } : {}),
+		},
+		display: {
+			platforms: {
+				telegram: {
+					streaming: telegramEnabled ? true : null,
+				},
+			},
+		},
+	};
+}
+
+export function managedChannelHasAccounts(channel: unknown): boolean {
+	const record = plainRecord(channel);
+	const accounts = plainRecord(record?.accounts);
+	return accounts !== null && Object.keys(accounts).length > 0;
+}
+
+export function commitManagedHermesWhatsApp(
+	plan: ManagedHermesWhatsAppPlan,
+	paths: RuntimePaths,
+): void {
+	if (!plan.commit) return;
+	const path = managedHermesWhatsAppReceiptPath(paths);
+	if (!plan.desired) {
+		rmSync(path, { force: true });
+		return;
+	}
+	writeRuntimePlatformFileAtomic(paths, path, `${JSON.stringify(plan.desired, null, 2)}\n`, {
+		mode: 0o600,
+		dirMode: 0o755,
+	});
+	const persisted = readManagedHermesWhatsAppReceipt(paths);
+	if (!persisted || JSON.stringify(persisted) !== JSON.stringify(plan.desired)) {
+		throw new Error("managed Hermes WhatsApp receipt did not pass post-write verification");
+	}
+}
+
+function desiredHermesWhatsAppReceipt(
+	manifest: RuntimeManifest,
+	home: string,
+): ManagedHermesWhatsAppReceipt | null {
+	if (manifest.runtimes.hermes?.enabled !== true) return null;
+	const channels = plainRecord(manifest.projection?.channels);
+	const whatsapp = plainRecord(channels?.whatsapp);
+	const accounts = plainRecord(whatsapp?.accounts);
+	if (!accounts || Object.keys(accounts).length === 0) return null;
+	const accountKeys = Object.keys(accounts).sort();
+	if (accountKeys.length !== 1) {
+		throw new Error("managed Hermes WhatsApp projection must contain exactly one account");
+	}
+	const [accountKey] = accountKeys;
+	if (!accountKey) throw new Error("managed Hermes WhatsApp account identity is missing");
+	const credentials = managedWhatsAppAuthCredentials(
+		manifest.projection?.channelCredentials,
+	).filter((credential) => credential.target === "hermes" && credential.accountKey === accountKey);
+	if (credentials.length !== 1) {
+		throw new Error("managed Hermes WhatsApp projection must contain one exact credential");
+	}
+	const credential = credentials[0];
+	if (!credential?.linkId) {
+		throw new Error("managed Hermes WhatsApp projection is missing its Link identity");
+	}
+	const authDir = resolve(credential.authDir);
+	const expectedAuthDir = resolve(home, ".hermes", "platforms", "whatsapp", "session");
+	if (authDir !== expectedAuthDir) {
+		throw new Error(`managed Hermes WhatsApp auth directory must be ${expectedAuthDir}`);
+	}
+	return receiptSchema.parse({
+		schemaVersion: "clawdi.managedHermesWhatsApp.v1",
+		deploymentId: manifest.deploymentId,
+		environmentId: manifest.environmentId,
+		instanceId: manifest.instanceId,
+		runtime: "hermes",
+		provider: "whatsapp",
+		accountKey,
+		linkId: credential.linkId,
+		credentialId: credential.credentialId,
+		authDir,
+	});
+}
+
+function recoverCommittedHermesWhatsAppReceipt(
+	current: RuntimeManifest,
+	paths: RuntimePaths,
+	applyContext: RuntimeApplyContext,
+	home: string,
+): ManagedHermesWhatsAppReceipt | null {
+	const committed = loadCommittedRuntimeManifest(paths, applyContext);
+	if (!("manifest" in committed)) return null;
+	if (
+		committed.manifest.deploymentId !== current.deploymentId ||
+		committed.manifest.environmentId !== current.environmentId ||
+		committed.manifest.instanceId !== current.instanceId
+	) {
+		throw new Error("committed Hermes WhatsApp ownership belongs to another runtime identity");
+	}
+	return desiredHermesWhatsAppReceipt(committed.manifest, home);
+}
+
+function readManagedHermesWhatsAppReceipt(
+	paths: RuntimePaths,
+): ManagedHermesWhatsAppReceipt | null {
+	const path = managedHermesWhatsAppReceiptPath(paths);
+	if (!existsSync(path)) return null;
+	try {
+		const stat = lstatSync(path);
+		if (!stat.isFile() || stat.isSymbolicLink()) throw new Error("not a regular file");
+		if ((stat.mode & 0o777) !== 0o600) throw new Error("permissions are not private");
+		if (typeof process.geteuid === "function" && stat.uid !== process.geteuid()) {
+			throw new Error("owner is unexpected");
+		}
+		return receiptSchema.parse(JSON.parse(readFileSync(path, "utf8")) as unknown);
+	} catch (error) {
+		throw new Error(
+			`managed Hermes WhatsApp receipt is invalid: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
+
+function assertReceiptScope(
+	receipt: ManagedHermesWhatsAppReceipt,
+	manifest: RuntimeManifest,
+): void {
+	if (
+		receipt.deploymentId !== manifest.deploymentId ||
+		receipt.environmentId !== manifest.environmentId ||
+		receipt.instanceId !== manifest.instanceId
+	) {
+		throw new Error("managed Hermes WhatsApp receipt belongs to another runtime identity");
+	}
+}
+
+function hermesWhatsAppConfigCleanupAuthorized(
+	plan: ManagedHermesWhatsAppPlan,
+	content: string,
+): boolean {
+	if (!plan.cleanupAuthorized || !plan.previous) return false;
+	let parsed: unknown;
+	try {
+		parsed = parseYaml(content);
+	} catch (error) {
+		throw new Error(
+			`Hermes config is invalid: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	const root = plainRecord(parsed);
+	const platforms = plainRecord(root?.platforms);
+	const whatsapp = plainRecord(platforms?.whatsapp);
+	const extra = plainRecord(whatsapp?.extra);
+	const sessionPath = extra?.session_path;
+	if (sessionPath !== undefined && sessionPath !== null && sessionPath !== plan.previous.authDir) {
+		throw new Error("refusing to remove user-owned Hermes WhatsApp session configuration");
+	}
+	return true;
+}
+
+function plainRecord(value: unknown): Record<string, unknown> | null {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -5328,10 +5328,7 @@ function hostedChannelCredentialMutationTargets(
 		}
 	}
 	const hermesAuthDir = managedWhatsAppAuthRoot(home, "hermes");
-	if (
-		hermesAuthDir &&
-		hermesWhatsAppPlan?.cleanupAuthorized
-	) {
+	if (hermesAuthDir && hermesWhatsAppPlan?.cleanupAuthorized) {
 		targets.add(hermesAuthDir);
 	}
 	return [...targets];

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -152,6 +152,14 @@ import {
 	reconcileManagedBaileysCompatibility,
 } from "./managed-baileys-compat";
 import {
+	buildHermesManagedChannelsPatch,
+	buildHermesManagedChannelsRevision,
+	commitManagedHermesWhatsApp,
+	type ManagedHermesWhatsAppPlan,
+	managedChannelHasAccounts,
+	planManagedHermesWhatsApp,
+} from "./managed-channel-reconciliation";
+import {
 	installReservedManagedSkill,
 	managedSkillReservationOwner,
 	managedSkillReservations,
@@ -508,9 +516,10 @@ export function materializeHostedChannelCredentials(
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
 	home: string,
+	hermesWhatsAppPlan: ManagedHermesWhatsAppPlan | null = null,
 ): void {
 	if (!hostedChannelCredentialsDeclared(manifest)) {
-		removeStaleManagedWhatsAppAuthDirs(home, new Set<string>());
+		removeStaleManagedWhatsAppAuthDirs(home, new Set<string>(), hermesWhatsAppPlan);
 		return;
 	}
 	const credentials = hostedWhatsAppAuthCredentials(manifest);
@@ -538,7 +547,7 @@ export function materializeHostedChannelCredentials(
 			errors.push(error instanceof Error ? error.message : String(error));
 		}
 	}
-	removeStaleManagedWhatsAppAuthDirs(home, expectedAuthDirs);
+	removeStaleManagedWhatsAppAuthDirs(home, expectedAuthDirs, hermesWhatsAppPlan);
 	if (errors.length > 0) {
 		throw new Error(errors.join("; "));
 	}
@@ -713,14 +722,22 @@ function managedWhatsAppAuthRoot(
 		: resolve(home, ".openclaw", "credentials", "whatsapp");
 }
 
-function readManagedWhatsAppAuthMarker(authDir: string): { credentialId: string } | null {
+interface ManagedWhatsAppAuthMarker {
+	target: string;
+	accountKey: string;
+	credentialId: string;
+}
+
+function readManagedWhatsAppAuthMarker(authDir: string): ManagedWhatsAppAuthMarker | null {
 	const markerPath = join(authDir, MANAGED_WHATSAPP_AUTH_MARKER);
 	try {
 		if (!lstatSync(markerPath).isFile()) return null;
 		const parsed = JSON.parse(readFileSync(markerPath, "utf-8")) as unknown;
 		const record = recordValue(parsed);
+		const target = record ? stringValue(record.target) : null;
+		const accountKey = record ? stringValue(record.accountKey) : null;
 		const credentialId = record ? stringValue(record.credentialId) : null;
-		return credentialId ? { credentialId } : null;
+		return target && accountKey && credentialId ? { target, accountKey, credentialId } : null;
 	} catch {
 		return null;
 	}
@@ -731,13 +748,31 @@ function removeManagedWhatsAppAuthDir(authDir: string): void {
 	rmSync(authDir, { recursive: true, force: true });
 }
 
-function removeStaleManagedWhatsAppAuthDirs(home: string, expected: Set<string>): void {
+function removeStaleManagedWhatsAppAuthDirs(
+	home: string,
+	expected: Set<string>,
+	hermesWhatsAppPlan: ManagedHermesWhatsAppPlan | null,
+): void {
 	const openclawRoot = managedWhatsAppAuthRoot(home, "openclaw");
 	if (openclawRoot && existsSync(openclawRoot)) {
 		removeStaleManagedWhatsAppAuthDirsUnderRoot(openclawRoot, expected);
 	}
 	const hermesAuthDir = managedWhatsAppAuthRoot(home, "hermes");
-	if (hermesAuthDir && !expected.has(hermesAuthDir)) {
+	if (
+		hermesAuthDir &&
+		!expected.has(hermesAuthDir) &&
+		hermesWhatsAppPlan?.cleanupAuthorized &&
+		hermesWhatsAppPlan.previous
+	) {
+		const marker = readManagedWhatsAppAuthMarker(hermesAuthDir);
+		if (
+			marker &&
+			(marker.target !== "hermes" ||
+				marker.accountKey !== hermesWhatsAppPlan.previous.accountKey ||
+				marker.credentialId !== hermesWhatsAppPlan.previous.credentialId)
+		) {
+			throw new Error("managed Hermes WhatsApp session marker does not match its receipt");
+		}
 		removeManagedWhatsAppAuthDir(hermesAuthDir);
 	}
 }
@@ -3186,6 +3221,7 @@ function applyHostedChannelProjection(
 	manifest: RuntimeManifest,
 	home: string,
 	workspaceRoot: string,
+	hermesWhatsAppPlan: ManagedHermesWhatsAppPlan,
 ): string | null {
 	if (name !== "openclaw" && name !== "hermes") return null;
 	if (!observation.enabled || observation.status === "install_failed" || !observation.commandPath) {
@@ -3200,9 +3236,7 @@ function applyHostedChannelProjection(
 			const configContent = existsSync(configPath) ? readFileSync(configPath, "utf8") : "";
 			mergeHermesChannelConfig(
 				configPath,
-				hermesManagedChannelsPatch(channels, manifest.projection?.channelCredentials, {
-					cleanupWhatsApp: hermesManagedWhatsAppProjectionOwned(configContent, home),
-				}),
+				buildHermesManagedChannelsPatch(channels, hermesWhatsAppPlan, configContent),
 			);
 			makeRuntimeUserOwned(configPath);
 		});
@@ -3243,149 +3277,9 @@ function installHostedChannelProjectionDependencies(
 	});
 }
 
-function hermesManagedChannelsPatch(
-	channels: Record<string, unknown>,
-	channelCredentials: unknown,
-	options: { cleanupWhatsApp?: boolean } = {},
-): Record<string, unknown> {
-	const telegramEnabled = channelHasAccounts(channels.telegram);
-	const discordEnabled = channelHasAccounts(channels.discord);
-	const whatsappEnabled = channelHasAccounts(channels.whatsapp);
-	const whatsappSessionPath = whatsappEnabled
-		? hermesManagedWhatsAppSessionPath(channelCredentials)
-		: null;
-	if (whatsappEnabled && !whatsappSessionPath) {
-		throw new Error("managed Hermes WhatsApp projection is missing its auth directory");
-	}
-	const whatsapp = whatsappEnabled
-		? {
-				enabled: true,
-				dm_policy: "allowlist",
-				group_policy: "open",
-				allow_from: ["*"],
-				group_allow_from: ["*"],
-			}
-		: options.cleanupWhatsApp !== false
-			? {
-					enabled: false,
-					dm_policy: null,
-					group_policy: null,
-					allow_from: null,
-					group_allow_from: null,
-				}
-			: null;
-	const whatsappPlatform = whatsappEnabled
-		? {
-				enabled: true,
-				extra: {
-					session_path: whatsappSessionPath,
-					dm_policy: "allowlist",
-					group_policy: "open",
-					allow_from: ["*"],
-					group_allow_from: ["*"],
-					group_sessions_per_user: false,
-					thread_sessions_per_user: false,
-				},
-			}
-		: options.cleanupWhatsApp !== false
-			? {
-					enabled: false,
-					extra: {
-						session_path: null,
-						dm_policy: null,
-						group_policy: null,
-						allow_from: null,
-						group_allow_from: null,
-						group_sessions_per_user: null,
-						thread_sessions_per_user: null,
-					},
-				}
-			: null;
-	const sharedChannelSessionsEnabled = telegramEnabled || discordEnabled || whatsappEnabled;
-	return {
-		telegram: telegramEnabled
-			? {
-					enabled: true,
-					dm_policy: "open",
-					group_policy: "open",
-					allow_from: ["*"],
-					group_allow_from: ["*"],
-					group_allowed_chats: ["*"],
-					require_mention: false,
-					extra: {
-						base_url: "https://api.telegram.org/bot",
-						base_file_url: "https://api.telegram.org/file/bot",
-					},
-				}
-			: { enabled: false },
-		discord: discordEnabled
-			? {
-					enabled: true,
-					dm_policy: "open",
-					group_policy: "open",
-					require_mention: false,
-					thread_require_mention: false,
-					bots_require_inline_mention: false,
-				}
-			: { enabled: false },
-		...(whatsapp ? { whatsapp } : {}),
-		group_sessions_per_user: sharedChannelSessionsEnabled ? false : null,
-		thread_sessions_per_user: sharedChannelSessionsEnabled ? false : null,
-		platforms: {
-			telegram: {
-				extra: {
-					group_sessions_per_user: telegramEnabled ? false : null,
-					thread_sessions_per_user: telegramEnabled ? false : null,
-				},
-			},
-			...(whatsappPlatform ? { whatsapp: whatsappPlatform } : {}),
-		},
-		display: {
-			platforms: {
-				telegram: {
-					streaming: telegramEnabled ? true : null,
-				},
-			},
-		},
-	};
-}
-
-function hermesManagedWhatsAppProjectionOwned(configContent: string, home: string): boolean {
-	try {
-		const root = recordValue(parseYaml(configContent));
-		const platforms = recordValue(root?.platforms);
-		const whatsapp = recordValue(platforms?.whatsapp);
-		const extra = recordValue(whatsapp?.extra);
-		return extra?.session_path === managedWhatsAppAuthRoot(home, "hermes");
-	} catch {
-		return false;
-	}
-}
-
-function hermesManagedWhatsAppSessionPath(channelCredentials: unknown): string | null {
-	if (!Array.isArray(channelCredentials)) return null;
-	for (const value of channelCredentials) {
-		const credential = recordValue(value);
-		if (credential?.provider !== "whatsapp" || credential.kind !== "whatsapp_baileys_auth_state") {
-			continue;
-		}
-		const targets = recordValue(credential.targets);
-		const hermes = recordValue(targets?.hermes);
-		const authDir = stringValue(hermes?.authDir);
-		if (authDir) return authDir;
-	}
-	return null;
-}
-
-function channelHasAccounts(channel: unknown): boolean {
-	if (!isPlainRecord(channel)) return false;
-	const accounts = channel.accounts;
-	return isPlainRecord(accounts) && Object.keys(accounts).length > 0;
-}
-
 function openClawManagedChannelUsesEnvSecretRefs(channels: Record<string, unknown>): boolean {
 	return ["telegram", "discord", "whatsapp"].some((channel) =>
-		channelHasAccounts(channels[channel]),
+		managedChannelHasAccounts(channels[channel]),
 	);
 }
 
@@ -3393,9 +3287,9 @@ function openClawManagedChannelsPatch(channels: Record<string, unknown>): Record
 	const deleteEntries = openClawManagedChannelDeletes();
 	const usesEnvSecretRefs = openClawManagedChannelUsesEnvSecretRefs(channels);
 	const isolatesManagedDms =
-		channelHasAccounts(channels.telegram) ||
-		channelHasAccounts(channels.discord) ||
-		channelHasAccounts(channels.whatsapp);
+		managedChannelHasAccounts(channels.telegram) ||
+		managedChannelHasAccounts(channels.discord) ||
+		managedChannelHasAccounts(channels.whatsapp);
 	return {
 		channels: {
 			...deleteEntries,
@@ -4860,7 +4754,8 @@ function runtimeProgramRevisionForManifest(
 	manifest: RuntimeManifest,
 	runtime: string,
 	secretValues: Record<string, string> | undefined,
-	providerProjectionRevision: string | null = null,
+	providerProjectionRevision: string | null,
+	hermesWhatsAppPlan: ManagedHermesWhatsAppPlan,
 ): string {
 	const desiredRuntime = manifest.runtimes[runtime];
 	const runtimeSecretRefs = desiredRuntime
@@ -4887,10 +4782,7 @@ function runtimeProgramRevisionForManifest(
 	if (channels && runtime === "openclaw") {
 		channelProjection = openClawManagedChannelsPatch(channels);
 	} else if (channels && runtime === "hermes" && desiredRuntime?.enabled) {
-		channelProjection = hermesManagedChannelsPatch(
-			channels,
-			manifest.projection?.channelCredentials,
-		);
+		channelProjection = buildHermesManagedChannelsRevision(channels, hermesWhatsAppPlan);
 	}
 	return runtimeProgramRevision({
 		renderedProjection: {
@@ -5180,6 +5072,7 @@ function validateRuntimeProjectionPlan(input: {
 	secretValues: Record<string, string> | undefined;
 	observations: Map<string, RuntimeInstallObservation>;
 	previousProjectedProviderIds: Record<string, string[]>;
+	hermesWhatsAppPlan: ManagedHermesWhatsAppPlan;
 }): void {
 	const {
 		manifest,
@@ -5188,6 +5081,7 @@ function validateRuntimeProjectionPlan(input: {
 		secretValues,
 		observations,
 		previousProjectedProviderIds,
+		hermesWhatsAppPlan,
 	} = input;
 	const home = hostedRuntimeProjectionHome(manifest, paths);
 	const localeBlock = manifest.locale ? managedLocaleBlock(manifest.locale) : null;
@@ -5288,9 +5182,7 @@ function validateRuntimeProjectionPlan(input: {
 		if (channels && name === "hermes" && runtime.enabled) {
 			hermesConfig = renderHermesChannelConfig(
 				hermesConfig,
-				hermesManagedChannelsPatch(channels, manifest.projection?.channelCredentials, {
-					cleanupWhatsApp: hermesManagedWhatsAppProjectionOwned(hermesConfig, home),
-				}),
+				buildHermesManagedChannelsPatch(channels, hermesWhatsAppPlan, hermesConfig),
 			);
 		}
 	}
@@ -5382,7 +5274,11 @@ function runtimeColdInstallMutationPlan(
 	};
 }
 
-function hostedChannelCredentialMutationTargets(manifest: RuntimeManifest, home: string): string[] {
+function hostedChannelCredentialMutationTargets(
+	manifest: RuntimeManifest,
+	home: string,
+	hermesWhatsAppPlan: ManagedHermesWhatsAppPlan | null,
+): string[] {
 	const targets = new Set(
 		hostedChannelCredentialsDeclared(manifest)
 			? hostedWhatsAppAuthCredentials(manifest).map((entry) => entry.authDir)
@@ -5396,7 +5292,13 @@ function hostedChannelCredentialMutationTargets(manifest: RuntimeManifest, home:
 		}
 	}
 	const hermesAuthDir = managedWhatsAppAuthRoot(home, "hermes");
-	if (hermesAuthDir && readManagedWhatsAppAuthMarker(hermesAuthDir)) targets.add(hermesAuthDir);
+	if (
+		hermesAuthDir &&
+		hermesWhatsAppPlan?.cleanupAuthorized &&
+		readManagedWhatsAppAuthMarker(hermesAuthDir)
+	) {
+		targets.add(hermesAuthDir);
+	}
 	return [...targets];
 }
 
@@ -5418,6 +5320,7 @@ export function runtimeUserMutationTargets(
 	paths: RuntimePaths,
 	openClawWorkspaceRoot: string | null,
 	observations: ReadonlyMap<string, Pick<RuntimeInstallObservation, "status">>,
+	hermesWhatsAppPlan: ManagedHermesWhatsAppPlan | null = null,
 ): string[] {
 	const home = hostedRuntimeProjectionHome(manifest, paths);
 	const installerTargets = runtimeInstallerMutationTargets(manifest, home, observations);
@@ -5442,7 +5345,7 @@ export function runtimeUserMutationTargets(
 		join(hostedCodexHome(home), CODEX_MANAGED_PROVIDER_CONFIG_FILE),
 		legacyHermesModelProviderPluginDir(home),
 		...installerTargets,
-		...hostedChannelCredentialMutationTargets(manifest, home),
+		...hostedChannelCredentialMutationTargets(manifest, home, hermesWhatsAppPlan),
 		...channelPluginTargets,
 	]);
 	if (openClawWorkspaceRoot) targets.add(join(openClawWorkspaceRoot, "SOUL.md"));
@@ -5578,6 +5481,7 @@ function runtimeManagedMutationPlan(input: {
 	openClawWorkspaceRoot: string | null;
 	programs: RuntimeSystemdUserProgram[];
 	observations: ReadonlyMap<string, RuntimeInstallObservation>;
+	hermesWhatsAppPlan: ManagedHermesWhatsAppPlan;
 }): {
 	snapshot: RuntimeManagedMutationPlan;
 	runtimeUserOwnershipTargets: string[];
@@ -5612,6 +5516,7 @@ function runtimeManagedMutationPlan(input: {
 				input.paths,
 				input.openClawWorkspaceRoot,
 				input.observations,
+				input.hermesWhatsAppPlan,
 			),
 			...systemd.targets,
 		]),
@@ -5742,6 +5647,13 @@ export function convergeRuntimeManifest(
 		applyContext,
 		opts.hostedRuntimeContract,
 	);
+	const projectionHome = hostedRuntimeProjectionHome(manifest, paths);
+	const hermesWhatsAppPlan = planManagedHermesWhatsApp({
+		manifest,
+		paths,
+		applyContext,
+		home: projectionHome,
+	});
 	removeHostedCliPathExposure(paths);
 	removeLegacyTenantClawdiState(paths);
 	if (manifest.companions?.filebrowser) {
@@ -5752,7 +5664,6 @@ export function convergeRuntimeManifest(
 			throw new Error("Files companion requires systemd apply and readiness hooks");
 		}
 	}
-	const projectionHome = hostedRuntimeProjectionHome(manifest, paths);
 	const workspaceRoot = runtimeWorkspaceRoot(manifest, paths);
 	let agentPluginTransaction: HostedAgentPluginTransaction | null = null;
 	const agentPluginFailedNames = new Set<string>();
@@ -5928,6 +5839,7 @@ export function convergeRuntimeManifest(
 			secretValues,
 			observations,
 			previousProjectedProviderIds,
+			hermesWhatsAppPlan,
 		});
 		plannedRuntimePrograms = planRuntimeSystemdUserPrograms({
 			manifest,
@@ -5946,6 +5858,7 @@ export function convergeRuntimeManifest(
 			openClawWorkspaceRoot,
 			programs: plannedRuntimePrograms,
 			observations,
+			hermesWhatsAppPlan,
 		});
 	} catch (error) {
 		if (coldInstallSnapshot) restoreRuntimeLiveSnapshot(coldInstallSnapshot);
@@ -6243,7 +6156,12 @@ export function convergeRuntimeManifest(
 		}
 		try {
 			withRuntimeUserFileAccess(() =>
-				materializeHostedChannelCredentials(manifest, secretValues, projectionHome),
+				materializeHostedChannelCredentials(
+					manifest,
+					secretValues,
+					projectionHome,
+					hermesWhatsAppPlan,
+				),
 			);
 		} catch (error) {
 			installErrors.push(
@@ -6337,6 +6255,7 @@ export function convergeRuntimeManifest(
 			secretValues,
 			observations,
 			previousProjectedProviderIds,
+			hermesWhatsAppPlan,
 		});
 		const providerProjectionRevisions: Partial<Record<string, string | null>> = {};
 		for (const [name] of runtimeEntries) {
@@ -6536,7 +6455,14 @@ export function convergeRuntimeManifest(
 				);
 			}
 			try {
-				applyHostedChannelProjection(name, observation, manifest, projectionHome, workspaceRoot);
+				applyHostedChannelProjection(
+					name,
+					observation,
+					manifest,
+					projectionHome,
+					workspaceRoot,
+					hermesWhatsAppPlan,
+				);
 			} catch (error) {
 				installErrors.push(
 					`runtime ${name} channel projection failed: ${
@@ -6594,7 +6520,14 @@ export function convergeRuntimeManifest(
 			daemonAuthTokenFile,
 			secretValues,
 			providerProjectionRevisions,
-			runtimeRevision: runtimeProgramRevisionForManifest,
+			runtimeRevision: (desired, runtime, secrets, providerRevision) =>
+				runtimeProgramRevisionForManifest(
+					desired,
+					runtime,
+					secrets,
+					providerRevision,
+					hermesWhatsAppPlan,
+				),
 			commonEnvironment: commonSystemdEnvironment,
 		});
 		staleSystemdFiles = systemdUnits.staleFiles;
@@ -6763,6 +6696,7 @@ export function convergeRuntimeManifest(
 			const egressRevisionPreviouslyCommitted =
 				desiredEgressSidecarSecretRevision !== undefined &&
 				desiredEgressSidecarSecretRevision === appliedState?.egressSidecarSecretRevision;
+			commitManagedHermesWhatsApp(hermesWhatsAppPlan, paths);
 			commitRuntimeInstallReceipts(installReceiptTargets, paths);
 			if (agentPluginTransaction) {
 				try {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -723,7 +723,9 @@ function managedWhatsAppAuthRoot(
 }
 
 interface ManagedWhatsAppAuthMarker {
-	target: string;
+	schemaVersion: "clawdi.managedWhatsAppAuth.v1";
+	provider: "whatsapp";
+	target: ManagedWhatsAppAuthCredential["target"];
 	accountKey: string;
 	credentialId: string;
 }
@@ -737,7 +739,22 @@ function readManagedWhatsAppAuthMarker(authDir: string): ManagedWhatsAppAuthMark
 		const target = record ? stringValue(record.target) : null;
 		const accountKey = record ? stringValue(record.accountKey) : null;
 		const credentialId = record ? stringValue(record.credentialId) : null;
-		return target && accountKey && credentialId ? { target, accountKey, credentialId } : null;
+		if (
+			record?.schemaVersion !== "clawdi.managedWhatsAppAuth.v1" ||
+			record.provider !== "whatsapp" ||
+			(target !== "openclaw" && target !== "hermes" && target !== "legacy") ||
+			!accountKey ||
+			!credentialId
+		) {
+			return null;
+		}
+		return {
+			schemaVersion: "clawdi.managedWhatsAppAuth.v1",
+			provider: "whatsapp",
+			target,
+			accountKey,
+			credentialId,
+		};
 	} catch {
 		return null;
 	}
@@ -745,6 +762,34 @@ function readManagedWhatsAppAuthMarker(authDir: string): ManagedWhatsAppAuthMark
 
 function removeManagedWhatsAppAuthDir(authDir: string): void {
 	if (!readManagedWhatsAppAuthMarker(authDir)) return;
+	rmSync(authDir, { recursive: true, force: true });
+}
+
+function removeManagedHermesWhatsAppAuthDir(
+	authDir: string,
+	expected: Pick<ManagedWhatsAppAuthMarker, "accountKey" | "credentialId">,
+): void {
+	let stat: ReturnType<typeof lstatSync>;
+	try {
+		stat = lstatSync(authDir);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
+	if (!stat.isDirectory() || stat.isSymbolicLink()) {
+		throw new Error("managed Hermes WhatsApp session path is not a trusted directory");
+	}
+	const marker = readManagedWhatsAppAuthMarker(authDir);
+	if (!marker) {
+		throw new Error("managed Hermes WhatsApp session marker is missing or invalid");
+	}
+	if (
+		marker.target !== "hermes" ||
+		marker.accountKey !== expected.accountKey ||
+		marker.credentialId !== expected.credentialId
+	) {
+		throw new Error("managed Hermes WhatsApp session marker does not match its receipt");
+	}
 	rmSync(authDir, { recursive: true, force: true });
 }
 
@@ -764,16 +809,7 @@ function removeStaleManagedWhatsAppAuthDirs(
 		hermesWhatsAppPlan?.cleanupAuthorized &&
 		hermesWhatsAppPlan.previous
 	) {
-		const marker = readManagedWhatsAppAuthMarker(hermesAuthDir);
-		if (
-			marker &&
-			(marker.target !== "hermes" ||
-				marker.accountKey !== hermesWhatsAppPlan.previous.accountKey ||
-				marker.credentialId !== hermesWhatsAppPlan.previous.credentialId)
-		) {
-			throw new Error("managed Hermes WhatsApp session marker does not match its receipt");
-		}
-		removeManagedWhatsAppAuthDir(hermesAuthDir);
+		removeManagedHermesWhatsAppAuthDir(hermesAuthDir, hermesWhatsAppPlan.previous);
 	}
 }
 
@@ -5294,8 +5330,7 @@ function hostedChannelCredentialMutationTargets(
 	const hermesAuthDir = managedWhatsAppAuthRoot(home, "hermes");
 	if (
 		hermesAuthDir &&
-		hermesWhatsAppPlan?.cleanupAuthorized &&
-		readManagedWhatsAppAuthMarker(hermesAuthDir)
+		hermesWhatsAppPlan?.cleanupAuthorized
 	) {
 		targets.add(hermesAuthDir);
 	}

--- a/packages/cli/src/runtime/whatsapp-credential-projection.ts
+++ b/packages/cli/src/runtime/whatsapp-credential-projection.ts
@@ -1,5 +1,6 @@
 export interface ManagedWhatsAppAuthCredential {
 	accountKey: string;
+	linkId: string | null;
 	credentialId: string;
 	authDir: string;
 	credsJsonSecretRef: string;
@@ -24,6 +25,7 @@ function parseManagedWhatsAppAuthCredential(value: unknown): ManagedWhatsAppAuth
 	if (!record) return [];
 	if (record.provider !== "whatsapp" || record.kind !== "whatsapp_baileys_auth_state") return [];
 	const accountKey = stringValue(record.accountKey);
+	const linkId = stringValue(record.linkId);
 	const credentialId = stringValue(record.credentialId);
 	const files = Array.isArray(record.files) ? record.files : [];
 	const credsFile = files
@@ -42,6 +44,7 @@ function parseManagedWhatsAppAuthCredential(value: unknown): ManagedWhatsAppAuth
 	if (openclawAuthDir) {
 		credentials.push({
 			accountKey,
+			linkId,
 			credentialId,
 			authDir: openclawAuthDir,
 			credsJsonSecretRef,
@@ -53,6 +56,7 @@ function parseManagedWhatsAppAuthCredential(value: unknown): ManagedWhatsAppAuth
 	if (hermesAuthDir) {
 		credentials.push({
 			accountKey,
+			linkId,
 			credentialId,
 			authDir: hermesAuthDir,
 			credsJsonSecretRef,

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -13938,6 +13938,30 @@ exit 64
 			{ ...load, channelBindings: [], secretValues: {} },
 			paths,
 		);
+		const committedReceipt = readFileSync(hermesWhatsAppReceipt, "utf8");
+		writeFileSync(
+			hermesWhatsAppReceipt,
+			`${JSON.stringify({
+				...(JSON.parse(committedReceipt) as Record<string, unknown>),
+				authDir: join(home, ".hermes", "user-session"),
+			})}\n`,
+		);
+		expect(() => convergeRuntimeManifest(removed, paths)).toThrow(
+			"managed Hermes WhatsApp receipt auth directory must be",
+		);
+		writeFileSync(hermesWhatsAppReceipt, committedReceipt);
+
+		const sessionMarker = join(sessionDir, ".clawdi-managed-whatsapp-auth.json");
+		const committedMarker = readFileSync(sessionMarker, "utf8");
+		writeFileSync(sessionMarker, "{\"schemaVersion\":\"invalid\"}\n");
+		const invalidMarkerRemoval = convergeRuntimeManifest(removed, paths);
+		expect(invalidMarkerRemoval.installErrors.join("\n")).toContain(
+			"managed Hermes WhatsApp session marker is missing or invalid",
+		);
+		expect(existsSync(sessionDir)).toBe(true);
+		expect(readFileSync(hermesWhatsAppReceipt, "utf8")).toBe(committedReceipt);
+		writeFileSync(sessionMarker, committedMarker);
+
 		// Simulate a pre-receipt CLI after Hermes normalized its own config.
 		rmSync(hermesWhatsAppReceipt);
 		const hermesConfigPath = join(home, ".hermes", "config.yaml");

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -13695,6 +13695,7 @@ exit 64
 		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlPath;
 		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
 		const paths = getRuntimePaths();
+		const hermesWhatsAppReceipt = join(paths.managedResourceRoot, "hermes-whatsapp.json");
 		mkdirSync(legacySessionDir, { recursive: true });
 		writeFileSync(legacySentinel, "preserved\n");
 
@@ -13813,6 +13814,24 @@ exit 64
 		});
 		const convergence = convergeRuntimeManifest(projected, paths);
 		expect(convergence.installErrors).toEqual([]);
+		expect(JSON.parse(readFileSync(hermesWhatsAppReceipt, "utf8"))).toMatchObject({
+			schemaVersion: "clawdi.managedHermesWhatsApp.v1",
+			deploymentId: projected.manifest.deploymentId,
+			environmentId: projected.manifest.environmentId,
+			instanceId: projected.manifest.instanceId,
+			accountKey,
+			linkId,
+			credentialId,
+			authDir: sessionDir,
+		});
+		commitRuntimeAppliedState({
+			load: projected,
+			paths,
+			etag: '"hermes-whatsapp-active"',
+			sourceRevision: "a".repeat(64),
+			convergence,
+			applyIdentity: projected.applyContext?.identity ?? null,
+		});
 		expect(existsSync(sessionDir)).toBe(true);
 		expect(readFileSync(legacySentinel, "utf-8")).toBe("preserved\n");
 		expect(readHermesConfigYaml(home)).toHaveProperty(
@@ -13884,6 +13903,14 @@ exit 64
 		expect(preserveActiveUnits).toBe(false);
 		const changedCredential = convergeRuntimeManifest(changedCheckpoint, paths);
 		expect(changedCredential.installErrors).toEqual([]);
+		commitRuntimeAppliedState({
+			load: changedCheckpoint,
+			paths,
+			etag: '"hermes-whatsapp-rotated"',
+			sourceRevision: "b".repeat(64),
+			convergence: changedCredential,
+			applyIdentity: changedCheckpoint.applyContext?.identity ?? null,
+		});
 		expect(systemdEnvRevision(readSystemdEnvFile(paths, "hermes-gateway"))).not.toBe(
 			initialHermesRevision,
 		);
@@ -13911,6 +13938,16 @@ exit 64
 			{ ...load, channelBindings: [], secretValues: {} },
 			paths,
 		);
+		// Simulate a pre-receipt CLI after Hermes normalized its own config.
+		rmSync(hermesWhatsAppReceipt);
+		const hermesConfigPath = join(home, ".hermes", "config.yaml");
+		const hermesConfigBeforeNormalization = readFileSync(hermesConfigPath, "utf8");
+		const hermesConfigAfterNormalization = hermesConfigBeforeNormalization
+			.split("\n")
+			.filter((line) => !line.trimStart().startsWith("session_path:"))
+			.join("\n");
+		expect(hermesConfigAfterNormalization).not.toBe(hermesConfigBeforeNormalization);
+		writeFileSync(hermesConfigPath, hermesConfigAfterNormalization);
 		const patchedSocket = readFileSync(baileysSocket, "utf8");
 		writeFileSync(
 			baileysSocket,
@@ -13932,6 +13969,7 @@ exit 64
 		expect(removedConvergence.installErrors).toEqual([]);
 		expect(existsSync(paths.egressProfileBundle)).toBe(false);
 		expect(existsSync(sessionDir)).toBe(false);
+		expect(existsSync(hermesWhatsAppReceipt)).toBe(false);
 		const removedHermesConfig = readHermesConfigYaml(home);
 		expect(removedHermesConfig).toHaveProperty("whatsapp", {
 			user_owned: "keep-whatsapp",
@@ -13949,6 +13987,7 @@ exit 64
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_MODE).toBeUndefined();
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ALLOWED_USERS).toBeUndefined();
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ALLOW_ALL_USERS).toBeUndefined();
+		const removedHermesRevision = systemdEnvRevision(readSystemdEnvFile(paths, "hermes-gateway"));
 
 		writeFileSync(
 			join(home, ".hermes", "config.yaml"),
@@ -13969,6 +14008,9 @@ exit 64
 			whatsapp: { enabled: true, user_owned: "manual" },
 			platforms: { whatsapp: { enabled: true, extra: { session_path: "/user/session" } } },
 		});
+		expect(systemdEnvRevision(readSystemdEnvFile(paths, "hermes-gateway"))).toBe(
+			removedHermesRevision,
+		);
 	});
 
 	it("isolates OpenClaw WhatsApp DMs and clears stale managed config", () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -13953,7 +13953,7 @@ exit 64
 
 		const sessionMarker = join(sessionDir, ".clawdi-managed-whatsapp-auth.json");
 		const committedMarker = readFileSync(sessionMarker, "utf8");
-		writeFileSync(sessionMarker, "{\"schemaVersion\":\"invalid\"}\n");
+		writeFileSync(sessionMarker, '{"schemaVersion":"invalid"}\n');
 		const invalidMarkerRemoval = convergeRuntimeManifest(removed, paths);
 		expect(invalidMarkerRemoval.installErrors.join("\n")).toContain(
 			"managed Hermes WhatsApp session marker is missing or invalid",


### PR DESCRIPTION
## Summary

- persist exact root-owned Hermes WhatsApp ownership after successful runtime activation
- use that receipt for config and session cleanup, with one-time migration from exact committed last-good/applied authority
- keep stable desired-state revisions separate from one-shot cleanup and move Hermes channel reconciliation out of `manifest.ts`
- release as `clawdi@0.13.82`

## Safety

- no Cloud/Hosted manifest schema, image, tenant, or deployment special cases
- malformed or mismatched receipt/config/session evidence fails closed
- OpenClaw channel reconciliation is unchanged

## Verification

- focused Hermes WhatsApp lifecycle: 1 passed, 50 assertions
- full isolated CLI: 1701 passed, 4 skipped, 0 failed
- CLI TypeScript typecheck
- Biome: 1021 files
- publish manifest and frozen lock checks
- `git diff --check origin/main..HEAD`
