### PR TITLE
fix(cli): use manifest as Hermes WhatsApp authority

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.84",
+      "version": "0.13.85",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.84",
+	"version": "0.13.85",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/lib/hermes-config-merge.ts
+++ b/packages/cli/src/lib/hermes-config-merge.ts
@@ -79,11 +79,15 @@ export function renderHermesMcpServer(
 	return String(document);
 }
 
-export function mergeHermesChannelConfig(configPath: string, patch: Record<string, unknown>): void {
-	writeHermesConfig(
-		configPath,
-		renderHermesChannelConfig(readHermesConfigContent(configPath), patch),
-	);
+export function mergeHermesChannelConfig(
+	configPath: string,
+	patch: Record<string, unknown>,
+): boolean {
+	const current = readHermesConfigContent(configPath);
+	const rendered = renderHermesChannelConfig(current, patch);
+	if (rendered === current) return false;
+	writeHermesConfig(configPath, rendered);
+	return true;
 }
 
 export function renderHermesChannelConfig(content: string, patch: Record<string, unknown>): string {

--- a/packages/cli/src/runtime/managed-channel-reconciliation.ts
+++ b/packages/cli/src/runtime/managed-channel-reconciliation.ts
@@ -1,107 +1,54 @@
-import { existsSync, lstatSync, readFileSync, rmSync } from "node:fs";
-import { join, resolve } from "node:path";
-import { parse as parseYaml } from "yaml";
+import { resolve } from "node:path";
 import { z } from "zod";
-import type { RuntimeApplyContext } from "./apply-identity";
 import type { RuntimeManifest } from "./manifest-contract";
-import { loadCommittedRuntimeManifest } from "./manifest-source";
-import type { RuntimePaths } from "./paths";
-import { writeRuntimePlatformFileAtomic } from "./state";
 import { managedWhatsAppAuthCredentials } from "./whatsapp-credential-projection";
 
-const RECEIPT_FILE = "hermes-whatsapp.json";
-const receiptSchema = z
-	.object({
-		schemaVersion: z.literal("clawdi.managedHermesWhatsApp.v1"),
-		deploymentId: z.string().min(1),
-		environmentId: z.string().min(1),
-		instanceId: z.string().min(1),
-		runtime: z.literal("hermes"),
-		provider: z.literal("whatsapp"),
-		accountKey: z.string().min(1),
-		linkId: z.string().uuid(),
-		credentialId: z.string().uuid(),
-		authDir: z.string().min(1),
-	})
-	.strict()
-	.refine((receipt) => resolve(receipt.authDir) === receipt.authDir, {
-		message: "managed Hermes WhatsApp auth directory must be absolute",
-		path: ["authDir"],
-	});
+const uuidSchema = z.string().uuid();
 
-export type ManagedHermesWhatsAppReceipt = z.infer<typeof receiptSchema>;
-
-export interface ManagedHermesWhatsAppPlan {
-	previous: ManagedHermesWhatsAppReceipt | null;
-	desired: ManagedHermesWhatsAppReceipt | null;
-	cleanupAuthorized: boolean;
-	commit: boolean;
-}
-
-export function managedHermesWhatsAppReceiptPath(paths: RuntimePaths): string {
-	return join(paths.managedResourceRoot, RECEIPT_FILE);
-}
-
-export function planManagedHermesWhatsApp(input: {
-	manifest: RuntimeManifest;
-	paths: RuntimePaths;
-	applyContext: RuntimeApplyContext;
-	home: string;
-}): ManagedHermesWhatsAppPlan {
-	const desired = desiredHermesWhatsAppReceipt(input.manifest, input.home);
-	const stored = readManagedHermesWhatsAppReceipt(input.paths);
-	if (stored) assertReceiptAuthority(stored, input.manifest, input.home);
-	const commit =
-		input.manifest.runtimes.hermes?.enabled === true &&
-		input.manifest.projection !== undefined &&
-		Object.hasOwn(input.manifest.projection, "channels");
-	const previous =
-		stored ??
-		(desired === null && commit
-			? recoverCommittedHermesWhatsAppReceipt(
-					input.manifest,
-					input.paths,
-					input.applyContext,
-					input.home,
-				)
-			: null);
-	return {
-		previous,
-		desired,
-		cleanupAuthorized: commit && desired === null && previous !== null,
-		commit,
-	};
+export function managedHermesWhatsAppAuthDir(
+	manifest: RuntimeManifest,
+	home: string,
+): string | null {
+	if (manifest.runtimes.hermes?.enabled !== true) return null;
+	const channels = plainRecord(manifest.projection?.channels);
+	const whatsapp = plainRecord(channels?.whatsapp);
+	const accounts = plainRecord(whatsapp?.accounts);
+	if (!accounts || Object.keys(accounts).length === 0) return null;
+	const accountKeys = Object.keys(accounts).sort();
+	if (accountKeys.length !== 1) {
+		throw new Error("managed Hermes WhatsApp projection must contain exactly one account");
+	}
+	const [accountKey] = accountKeys;
+	if (!accountKey) throw new Error("managed Hermes WhatsApp account identity is missing");
+	const credentials = managedWhatsAppAuthCredentials(
+		manifest.projection?.channelCredentials,
+	).filter((credential) => credential.target === "hermes" && credential.accountKey === accountKey);
+	if (credentials.length !== 1) {
+		throw new Error("managed Hermes WhatsApp projection must contain one exact credential");
+	}
+	const credential = credentials[0];
+	if (!credential?.linkId) {
+		throw new Error("managed Hermes WhatsApp projection is missing its Link identity");
+	}
+	uuidSchema.parse(credential.linkId);
+	uuidSchema.parse(credential.credentialId);
+	const authDir = resolve(credential.authDir);
+	const expectedAuthDir = resolve(home, ".hermes", "platforms", "whatsapp", "session");
+	if (authDir !== expectedAuthDir) {
+		throw new Error(`managed Hermes WhatsApp auth directory must be ${expectedAuthDir}`);
+	}
+	return authDir;
 }
 
 export function buildHermesManagedChannelsPatch(
 	channels: Record<string, unknown>,
-	plan: ManagedHermesWhatsAppPlan,
-	currentConfig: string,
-): Record<string, unknown> {
-	return hermesManagedChannelsPatch(
-		channels,
-		plan.desired,
-		hermesWhatsAppConfigCleanupAuthorized(plan, currentConfig),
-	);
-}
-
-export function buildHermesManagedChannelsRevision(
-	channels: Record<string, unknown>,
-	plan: ManagedHermesWhatsAppPlan,
-): Record<string, unknown> {
-	return hermesManagedChannelsPatch(channels, plan.desired, false);
-}
-
-function hermesManagedChannelsPatch(
-	channels: Record<string, unknown>,
-	desiredWhatsApp: ManagedHermesWhatsAppReceipt | null,
-	cleanupWhatsApp: boolean,
+	whatsappAuthDir: string | null,
 ): Record<string, unknown> {
 	const telegramEnabled = managedChannelHasAccounts(channels.telegram);
 	const discordEnabled = managedChannelHasAccounts(channels.discord);
 	const whatsappEnabled = managedChannelHasAccounts(channels.whatsapp);
-	if (whatsappEnabled && !desiredWhatsApp) {
-		throw new Error("managed Hermes WhatsApp projection is missing its exact ownership identity");
+	if (whatsappEnabled && !whatsappAuthDir) {
+		throw new Error("managed Hermes WhatsApp projection is missing its exact auth directory");
 	}
 	const whatsapp = whatsappEnabled
 		? {
@@ -111,20 +58,18 @@ function hermesManagedChannelsPatch(
 				allow_from: ["*"],
 				group_allow_from: ["*"],
 			}
-		: cleanupWhatsApp
-			? {
-					enabled: false,
-					dm_policy: null,
-					group_policy: null,
-					allow_from: null,
-					group_allow_from: null,
-				}
-			: null;
+		: {
+				enabled: false,
+				dm_policy: null,
+				group_policy: null,
+				allow_from: null,
+				group_allow_from: null,
+			};
 	const whatsappPlatform = whatsappEnabled
 		? {
 				enabled: true,
 				extra: {
-					session_path: desiredWhatsApp?.authDir,
+					session_path: whatsappAuthDir,
 					dm_policy: "allowlist",
 					group_policy: "open",
 					allow_from: ["*"],
@@ -133,20 +78,18 @@ function hermesManagedChannelsPatch(
 					thread_sessions_per_user: false,
 				},
 			}
-		: cleanupWhatsApp
-			? {
-					enabled: false,
-					extra: {
-						session_path: null,
-						dm_policy: null,
-						group_policy: null,
-						allow_from: null,
-						group_allow_from: null,
-						group_sessions_per_user: null,
-						thread_sessions_per_user: null,
-					},
-				}
-			: null;
+		: {
+				enabled: false,
+				extra: {
+					session_path: null,
+					dm_policy: null,
+					group_policy: null,
+					allow_from: null,
+					group_allow_from: null,
+					group_sessions_per_user: null,
+					thread_sessions_per_user: null,
+				},
+			};
 	const sharedChannelSessionsEnabled = telegramEnabled || discordEnabled || whatsappEnabled;
 	return {
 		telegram: telegramEnabled
@@ -174,7 +117,7 @@ function hermesManagedChannelsPatch(
 					bots_require_inline_mention: false,
 				}
 			: { enabled: false },
-		...(whatsapp ? { whatsapp } : {}),
+		whatsapp,
 		group_sessions_per_user: sharedChannelSessionsEnabled ? false : null,
 		thread_sessions_per_user: sharedChannelSessionsEnabled ? false : null,
 		platforms: {
@@ -184,7 +127,7 @@ function hermesManagedChannelsPatch(
 					thread_sessions_per_user: telegramEnabled ? false : null,
 				},
 			},
-			...(whatsappPlatform ? { whatsapp: whatsappPlatform } : {}),
+			whatsapp: whatsappPlatform,
 		},
 		display: {
 			platforms: {
@@ -200,154 +143,6 @@ export function managedChannelHasAccounts(channel: unknown): boolean {
 	const record = plainRecord(channel);
 	const accounts = plainRecord(record?.accounts);
 	return accounts !== null && Object.keys(accounts).length > 0;
-}
-
-export function commitManagedHermesWhatsApp(
-	plan: ManagedHermesWhatsAppPlan,
-	paths: RuntimePaths,
-): void {
-	if (!plan.commit) return;
-	const path = managedHermesWhatsAppReceiptPath(paths);
-	if (!plan.desired) {
-		rmSync(path, { force: true });
-		return;
-	}
-	writeRuntimePlatformFileAtomic(paths, path, `${JSON.stringify(plan.desired, null, 2)}\n`, {
-		mode: 0o600,
-		dirMode: 0o755,
-	});
-	const persisted = readManagedHermesWhatsAppReceipt(paths);
-	if (!persisted || JSON.stringify(persisted) !== JSON.stringify(plan.desired)) {
-		throw new Error("managed Hermes WhatsApp receipt did not pass post-write verification");
-	}
-}
-
-function desiredHermesWhatsAppReceipt(
-	manifest: RuntimeManifest,
-	home: string,
-): ManagedHermesWhatsAppReceipt | null {
-	if (manifest.runtimes.hermes?.enabled !== true) return null;
-	const channels = plainRecord(manifest.projection?.channels);
-	const whatsapp = plainRecord(channels?.whatsapp);
-	const accounts = plainRecord(whatsapp?.accounts);
-	if (!accounts || Object.keys(accounts).length === 0) return null;
-	const accountKeys = Object.keys(accounts).sort();
-	if (accountKeys.length !== 1) {
-		throw new Error("managed Hermes WhatsApp projection must contain exactly one account");
-	}
-	const [accountKey] = accountKeys;
-	if (!accountKey) throw new Error("managed Hermes WhatsApp account identity is missing");
-	const credentials = managedWhatsAppAuthCredentials(
-		manifest.projection?.channelCredentials,
-	).filter((credential) => credential.target === "hermes" && credential.accountKey === accountKey);
-	if (credentials.length !== 1) {
-		throw new Error("managed Hermes WhatsApp projection must contain one exact credential");
-	}
-	const credential = credentials[0];
-	if (!credential?.linkId) {
-		throw new Error("managed Hermes WhatsApp projection is missing its Link identity");
-	}
-	const authDir = resolve(credential.authDir);
-	const expectedAuthDir = managedHermesWhatsAppAuthDir(home);
-	if (authDir !== expectedAuthDir) {
-		throw new Error(`managed Hermes WhatsApp auth directory must be ${expectedAuthDir}`);
-	}
-	return receiptSchema.parse({
-		schemaVersion: "clawdi.managedHermesWhatsApp.v1",
-		deploymentId: manifest.deploymentId,
-		environmentId: manifest.environmentId,
-		instanceId: manifest.instanceId,
-		runtime: "hermes",
-		provider: "whatsapp",
-		accountKey,
-		linkId: credential.linkId,
-		credentialId: credential.credentialId,
-		authDir,
-	});
-}
-
-function recoverCommittedHermesWhatsAppReceipt(
-	current: RuntimeManifest,
-	paths: RuntimePaths,
-	applyContext: RuntimeApplyContext,
-	home: string,
-): ManagedHermesWhatsAppReceipt | null {
-	const committed = loadCommittedRuntimeManifest(paths, applyContext);
-	if (!("manifest" in committed)) return null;
-	if (
-		committed.manifest.deploymentId !== current.deploymentId ||
-		committed.manifest.environmentId !== current.environmentId ||
-		committed.manifest.instanceId !== current.instanceId
-	) {
-		throw new Error("committed Hermes WhatsApp ownership belongs to another runtime identity");
-	}
-	return desiredHermesWhatsAppReceipt(committed.manifest, home);
-}
-
-function readManagedHermesWhatsAppReceipt(
-	paths: RuntimePaths,
-): ManagedHermesWhatsAppReceipt | null {
-	const path = managedHermesWhatsAppReceiptPath(paths);
-	if (!existsSync(path)) return null;
-	try {
-		const stat = lstatSync(path);
-		if (!stat.isFile() || stat.isSymbolicLink()) throw new Error("not a regular file");
-		if ((stat.mode & 0o777) !== 0o600) throw new Error("permissions are not private");
-		if (typeof process.geteuid === "function" && stat.uid !== process.geteuid()) {
-			throw new Error("owner is unexpected");
-		}
-		return receiptSchema.parse(JSON.parse(readFileSync(path, "utf8")) as unknown);
-	} catch (error) {
-		throw new Error(
-			`managed Hermes WhatsApp receipt is invalid: ${error instanceof Error ? error.message : String(error)}`,
-		);
-	}
-}
-
-function assertReceiptAuthority(
-	receipt: ManagedHermesWhatsAppReceipt,
-	manifest: RuntimeManifest,
-	home: string,
-): void {
-	if (
-		receipt.deploymentId !== manifest.deploymentId ||
-		receipt.environmentId !== manifest.environmentId ||
-		receipt.instanceId !== manifest.instanceId
-	) {
-		throw new Error("managed Hermes WhatsApp receipt belongs to another runtime identity");
-	}
-	const expectedAuthDir = managedHermesWhatsAppAuthDir(home);
-	if (receipt.authDir !== expectedAuthDir) {
-		throw new Error(`managed Hermes WhatsApp receipt auth directory must be ${expectedAuthDir}`);
-	}
-}
-
-function managedHermesWhatsAppAuthDir(home: string): string {
-	return resolve(home, ".hermes", "platforms", "whatsapp", "session");
-}
-
-function hermesWhatsAppConfigCleanupAuthorized(
-	plan: ManagedHermesWhatsAppPlan,
-	content: string,
-): boolean {
-	if (!plan.cleanupAuthorized || !plan.previous) return false;
-	let parsed: unknown;
-	try {
-		parsed = parseYaml(content);
-	} catch (error) {
-		throw new Error(
-			`Hermes config is invalid: ${error instanceof Error ? error.message : String(error)}`,
-		);
-	}
-	const root = plainRecord(parsed);
-	const platforms = plainRecord(root?.platforms);
-	const whatsapp = plainRecord(platforms?.whatsapp);
-	const extra = plainRecord(whatsapp?.extra);
-	const sessionPath = extra?.session_path;
-	if (sessionPath !== undefined && sessionPath !== null && sessionPath !== plan.previous.authDir) {
-		throw new Error("refusing to remove user-owned Hermes WhatsApp session configuration");
-	}
-	return true;
 }
 
 function plainRecord(value: unknown): Record<string, unknown> | null {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -153,11 +153,8 @@ import {
 } from "./managed-baileys-compat";
 import {
 	buildHermesManagedChannelsPatch,
-	buildHermesManagedChannelsRevision,
-	commitManagedHermesWhatsApp,
-	type ManagedHermesWhatsAppPlan,
 	managedChannelHasAccounts,
-	planManagedHermesWhatsApp,
+	managedHermesWhatsAppAuthDir,
 } from "./managed-channel-reconciliation";
 import {
 	installReservedManagedSkill,
@@ -240,6 +237,7 @@ import {
 	removeStaleRuntimeSystemdFiles,
 	resolveRuntimeSystemdIdentity,
 	runtimeSystemdCommonEnvironment,
+	runtimeSystemdUserUnitName,
 	uninstallStaleOfficialRuntimeServices,
 	validateRuntimeSystemdPlan,
 	writeRuntimeSystemdState,
@@ -511,15 +509,15 @@ function omitSecretRefs(
 }
 
 const MANAGED_WHATSAPP_AUTH_MARKER = ".clawdi-managed-whatsapp-auth.json";
+const RETIRED_MANAGED_HERMES_WHATSAPP_RECEIPT = "hermes-whatsapp.json";
 
 export function materializeHostedChannelCredentials(
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
 	home: string,
-	hermesWhatsAppPlan: ManagedHermesWhatsAppPlan | null = null,
 ): void {
 	if (!hostedChannelCredentialsDeclared(manifest)) {
-		removeStaleManagedWhatsAppAuthDirs(home, new Set<string>(), hermesWhatsAppPlan);
+		removeStaleManagedWhatsAppAuthDirs(home, new Set<string>());
 		return;
 	}
 	const credentials = hostedWhatsAppAuthCredentials(manifest);
@@ -547,7 +545,7 @@ export function materializeHostedChannelCredentials(
 			errors.push(error instanceof Error ? error.message : String(error));
 		}
 	}
-	removeStaleManagedWhatsAppAuthDirs(home, expectedAuthDirs, hermesWhatsAppPlan);
+	removeStaleManagedWhatsAppAuthDirs(home, expectedAuthDirs);
 	if (errors.length > 0) {
 		throw new Error(errors.join("; "));
 	}
@@ -765,51 +763,20 @@ function removeManagedWhatsAppAuthDir(authDir: string): void {
 	rmSync(authDir, { recursive: true, force: true });
 }
 
-function removeManagedHermesWhatsAppAuthDir(
-	authDir: string,
-	expected: Pick<ManagedWhatsAppAuthMarker, "accountKey" | "credentialId">,
-): void {
-	let stat: ReturnType<typeof lstatSync>;
-	try {
-		stat = lstatSync(authDir);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-		throw error;
-	}
-	if (!stat.isDirectory() || stat.isSymbolicLink()) {
-		throw new Error("managed Hermes WhatsApp session path is not a trusted directory");
-	}
+function removeManagedHermesWhatsAppAuthDir(authDir: string): void {
 	const marker = readManagedWhatsAppAuthMarker(authDir);
-	if (!marker) {
-		throw new Error("managed Hermes WhatsApp session marker is missing or invalid");
-	}
-	if (
-		marker.target !== "hermes" ||
-		marker.accountKey !== expected.accountKey ||
-		marker.credentialId !== expected.credentialId
-	) {
-		throw new Error("managed Hermes WhatsApp session marker does not match its receipt");
-	}
+	if (marker?.target !== "hermes") return;
 	rmSync(authDir, { recursive: true, force: true });
 }
 
-function removeStaleManagedWhatsAppAuthDirs(
-	home: string,
-	expected: Set<string>,
-	hermesWhatsAppPlan: ManagedHermesWhatsAppPlan | null,
-): void {
+function removeStaleManagedWhatsAppAuthDirs(home: string, expected: Set<string>): void {
 	const openclawRoot = managedWhatsAppAuthRoot(home, "openclaw");
 	if (openclawRoot && existsSync(openclawRoot)) {
 		removeStaleManagedWhatsAppAuthDirsUnderRoot(openclawRoot, expected);
 	}
 	const hermesAuthDir = managedWhatsAppAuthRoot(home, "hermes");
-	if (
-		hermesAuthDir &&
-		!expected.has(hermesAuthDir) &&
-		hermesWhatsAppPlan?.cleanupAuthorized &&
-		hermesWhatsAppPlan.previous
-	) {
-		removeManagedHermesWhatsAppAuthDir(hermesAuthDir, hermesWhatsAppPlan.previous);
+	if (hermesAuthDir && !expected.has(hermesAuthDir)) {
+		removeManagedHermesWhatsAppAuthDir(hermesAuthDir);
 	}
 }
 
@@ -3257,26 +3224,25 @@ function applyHostedChannelProjection(
 	manifest: RuntimeManifest,
 	home: string,
 	workspaceRoot: string,
-	hermesWhatsAppPlan: ManagedHermesWhatsAppPlan,
-): string | null {
-	if (name !== "openclaw" && name !== "hermes") return null;
+	hermesWhatsAppAuthDir: string | null,
+): boolean {
+	if (name !== "openclaw" && name !== "hermes") return false;
 	if (!observation.enabled || observation.status === "install_failed" || !observation.commandPath) {
-		return null;
+		return false;
 	}
 	const channels = hostedChannelProjection(manifest);
-	if (!channels) return null;
+	if (!channels) return false;
 
 	if (name === "hermes") {
 		const configPath = join(home, ".hermes", "config.yaml");
-		withRuntimeUserFileAccess(() => {
-			const configContent = existsSync(configPath) ? readFileSync(configPath, "utf8") : "";
-			mergeHermesChannelConfig(
+		return withRuntimeUserFileAccess(() => {
+			const changed = mergeHermesChannelConfig(
 				configPath,
-				buildHermesManagedChannelsPatch(channels, hermesWhatsAppPlan, configContent),
+				buildHermesManagedChannelsPatch(channels, hermesWhatsAppAuthDir),
 			);
 			makeRuntimeUserOwned(configPath);
+			return changed;
 		});
-		return configPath;
 	}
 	runRuntimeUserCommand(
 		observation.commandPath,
@@ -3285,7 +3251,7 @@ function applyHostedChannelProjection(
 		home,
 		workspaceRoot,
 	);
-	return observation.commandPath;
+	return false;
 }
 
 function installHostedChannelProjectionDependencies(
@@ -4791,7 +4757,7 @@ function runtimeProgramRevisionForManifest(
 	runtime: string,
 	secretValues: Record<string, string> | undefined,
 	providerProjectionRevision: string | null,
-	hermesWhatsAppPlan: ManagedHermesWhatsAppPlan,
+	hermesWhatsAppAuthDir: string | null,
 ): string {
 	const desiredRuntime = manifest.runtimes[runtime];
 	const runtimeSecretRefs = desiredRuntime
@@ -4818,7 +4784,7 @@ function runtimeProgramRevisionForManifest(
 	if (channels && runtime === "openclaw") {
 		channelProjection = openClawManagedChannelsPatch(channels);
 	} else if (channels && runtime === "hermes" && desiredRuntime?.enabled) {
-		channelProjection = buildHermesManagedChannelsRevision(channels, hermesWhatsAppPlan);
+		channelProjection = buildHermesManagedChannelsPatch(channels, hermesWhatsAppAuthDir);
 	}
 	return runtimeProgramRevision({
 		renderedProjection: {
@@ -5108,7 +5074,7 @@ function validateRuntimeProjectionPlan(input: {
 	secretValues: Record<string, string> | undefined;
 	observations: Map<string, RuntimeInstallObservation>;
 	previousProjectedProviderIds: Record<string, string[]>;
-	hermesWhatsAppPlan: ManagedHermesWhatsAppPlan;
+	hermesWhatsAppAuthDir: string | null;
 }): void {
 	const {
 		manifest,
@@ -5117,7 +5083,7 @@ function validateRuntimeProjectionPlan(input: {
 		secretValues,
 		observations,
 		previousProjectedProviderIds,
-		hermesWhatsAppPlan,
+		hermesWhatsAppAuthDir,
 	} = input;
 	const home = hostedRuntimeProjectionHome(manifest, paths);
 	const localeBlock = manifest.locale ? managedLocaleBlock(manifest.locale) : null;
@@ -5218,7 +5184,7 @@ function validateRuntimeProjectionPlan(input: {
 		if (channels && name === "hermes" && runtime.enabled) {
 			hermesConfig = renderHermesChannelConfig(
 				hermesConfig,
-				buildHermesManagedChannelsPatch(channels, hermesWhatsAppPlan, hermesConfig),
+				buildHermesManagedChannelsPatch(channels, hermesWhatsAppAuthDir),
 			);
 		}
 	}
@@ -5310,11 +5276,7 @@ function runtimeColdInstallMutationPlan(
 	};
 }
 
-function hostedChannelCredentialMutationTargets(
-	manifest: RuntimeManifest,
-	home: string,
-	hermesWhatsAppPlan: ManagedHermesWhatsAppPlan | null,
-): string[] {
+function hostedChannelCredentialMutationTargets(manifest: RuntimeManifest, home: string): string[] {
 	const targets = new Set(
 		hostedChannelCredentialsDeclared(manifest)
 			? hostedWhatsAppAuthCredentials(manifest).map((entry) => entry.authDir)
@@ -5328,7 +5290,7 @@ function hostedChannelCredentialMutationTargets(
 		}
 	}
 	const hermesAuthDir = managedWhatsAppAuthRoot(home, "hermes");
-	if (hermesAuthDir && hermesWhatsAppPlan?.cleanupAuthorized) {
+	if (hermesAuthDir && readManagedWhatsAppAuthMarker(hermesAuthDir)?.target === "hermes") {
 		targets.add(hermesAuthDir);
 	}
 	return [...targets];
@@ -5352,7 +5314,6 @@ export function runtimeUserMutationTargets(
 	paths: RuntimePaths,
 	openClawWorkspaceRoot: string | null,
 	observations: ReadonlyMap<string, Pick<RuntimeInstallObservation, "status">>,
-	hermesWhatsAppPlan: ManagedHermesWhatsAppPlan | null = null,
 ): string[] {
 	const home = hostedRuntimeProjectionHome(manifest, paths);
 	const installerTargets = runtimeInstallerMutationTargets(manifest, home, observations);
@@ -5377,7 +5338,7 @@ export function runtimeUserMutationTargets(
 		join(hostedCodexHome(home), CODEX_MANAGED_PROVIDER_CONFIG_FILE),
 		legacyHermesModelProviderPluginDir(home),
 		...installerTargets,
-		...hostedChannelCredentialMutationTargets(manifest, home, hermesWhatsAppPlan),
+		...hostedChannelCredentialMutationTargets(manifest, home),
 		...channelPluginTargets,
 	]);
 	if (openClawWorkspaceRoot) targets.add(join(openClawWorkspaceRoot, "SOUL.md"));
@@ -5513,7 +5474,6 @@ function runtimeManagedMutationPlan(input: {
 	openClawWorkspaceRoot: string | null;
 	programs: RuntimeSystemdUserProgram[];
 	observations: ReadonlyMap<string, RuntimeInstallObservation>;
-	hermesWhatsAppPlan: ManagedHermesWhatsAppPlan;
 }): {
 	snapshot: RuntimeManagedMutationPlan;
 	runtimeUserOwnershipTargets: string[];
@@ -5548,7 +5508,6 @@ function runtimeManagedMutationPlan(input: {
 				input.paths,
 				input.openClawWorkspaceRoot,
 				input.observations,
-				input.hermesWhatsAppPlan,
 			),
 			...systemd.targets,
 		]),
@@ -5680,12 +5639,7 @@ export function convergeRuntimeManifest(
 		opts.hostedRuntimeContract,
 	);
 	const projectionHome = hostedRuntimeProjectionHome(manifest, paths);
-	const hermesWhatsAppPlan = planManagedHermesWhatsApp({
-		manifest,
-		paths,
-		applyContext,
-		home: projectionHome,
-	});
+	const hermesWhatsAppAuthDir = managedHermesWhatsAppAuthDir(manifest, projectionHome);
 	removeHostedCliPathExposure(paths);
 	removeLegacyTenantClawdiState(paths);
 	if (manifest.companions?.filebrowser) {
@@ -5705,6 +5659,8 @@ export function convergeRuntimeManifest(
 	let agentPluginMutationAttempted = false;
 	let agentPluginQuiesceUserUnits: string[] = [];
 	let agentPluginRestartUserUnits: string[] = [];
+	const runtimeProjectionMutationRuntimes = new Set<string>();
+	let runtimeProjectionRestartUserUnits: string[] = [];
 	const enabledRuntimes = Object.entries(manifest.runtimes)
 		.filter(([, runtime]) => runtime.enabled)
 		.map(([name]) => name)
@@ -5871,7 +5827,7 @@ export function convergeRuntimeManifest(
 			secretValues,
 			observations,
 			previousProjectedProviderIds,
-			hermesWhatsAppPlan,
+			hermesWhatsAppAuthDir,
 		});
 		plannedRuntimePrograms = planRuntimeSystemdUserPrograms({
 			manifest,
@@ -5890,7 +5846,6 @@ export function convergeRuntimeManifest(
 			openClawWorkspaceRoot,
 			programs: plannedRuntimePrograms,
 			observations,
-			hermesWhatsAppPlan,
 		});
 	} catch (error) {
 		if (coldInstallSnapshot) restoreRuntimeLiveSnapshot(coldInstallSnapshot);
@@ -6188,12 +6143,7 @@ export function convergeRuntimeManifest(
 		}
 		try {
 			withRuntimeUserFileAccess(() =>
-				materializeHostedChannelCredentials(
-					manifest,
-					secretValues,
-					projectionHome,
-					hermesWhatsAppPlan,
-				),
+				materializeHostedChannelCredentials(manifest, secretValues, projectionHome),
 			);
 		} catch (error) {
 			installErrors.push(
@@ -6287,7 +6237,7 @@ export function convergeRuntimeManifest(
 			secretValues,
 			observations,
 			previousProjectedProviderIds,
-			hermesWhatsAppPlan,
+			hermesWhatsAppAuthDir,
 		});
 		const providerProjectionRevisions: Partial<Record<string, string | null>> = {};
 		for (const [name] of runtimeEntries) {
@@ -6487,14 +6437,15 @@ export function convergeRuntimeManifest(
 				);
 			}
 			try {
-				applyHostedChannelProjection(
+				const channelConfigChanged = applyHostedChannelProjection(
 					name,
 					observation,
 					manifest,
 					projectionHome,
 					workspaceRoot,
-					hermesWhatsAppPlan,
+					hermesWhatsAppAuthDir,
 				);
+				if (channelConfigChanged) runtimeProjectionMutationRuntimes.add(name);
 			} catch (error) {
 				installErrors.push(
 					`runtime ${name} channel projection failed: ${
@@ -6558,7 +6509,7 @@ export function convergeRuntimeManifest(
 					runtime,
 					secrets,
 					providerRevision,
-					hermesWhatsAppPlan,
+					hermesWhatsAppAuthDir,
 				),
 			commonEnvironment: commonSystemdEnvironment,
 		});
@@ -6569,6 +6520,21 @@ export function convergeRuntimeManifest(
 			previousInstallReceipts,
 			opts.systemdApply !== undefined || opts.executeOfficialServiceInstallers === true,
 		);
+		const pendingOfficialUnits = new Set(officialServicePlan.pending.map((item) => item.unitName));
+		runtimeProjectionRestartUserUnits = [
+			...new Set(
+				runtimeSystemdUserPrograms
+					.filter(
+						(program) =>
+							program.programKind === "runtime" &&
+							program.service === null &&
+							runtimeProjectionMutationRuntimes.has(program.runtime),
+					)
+					.map(runtimeSystemdUserUnitName),
+			),
+		]
+			.filter((unitName) => !pendingOfficialUnits.has(unitName))
+			.sort();
 		installReceiptTargets.officialServices = officialServicePlan.targets;
 		const hermesDashboardArtifactPlan = planHermesDashboardArtifact(
 			runtimeSystemdUserPrograms,
@@ -6660,7 +6626,9 @@ export function convergeRuntimeManifest(
 				restartEgressSidecar,
 				stopEgressSidecar: false,
 				reconcileUserUnits: mutationPlan.systemdUserUnits,
-				restartUserUnits: agentPluginRestartUserUnits,
+				restartUserUnits: [
+					...new Set([...agentPluginRestartUserUnits, ...runtimeProjectionRestartUserUnits]),
+				].sort(),
 				staleSystemUnits: staleSystemdFiles.systemUnits,
 				staleUserUnits: staleSystemdFiles.userUnits,
 			});
@@ -6728,7 +6696,9 @@ export function convergeRuntimeManifest(
 			const egressRevisionPreviouslyCommitted =
 				desiredEgressSidecarSecretRevision !== undefined &&
 				desiredEgressSidecarSecretRevision === appliedState?.egressSidecarSecretRevision;
-			commitManagedHermesWhatsApp(hermesWhatsAppPlan, paths);
+			rmSync(join(paths.managedResourceRoot, RETIRED_MANAGED_HERMES_WHATSAPP_RECEIPT), {
+				force: true,
+			});
 			commitRuntimeInstallReceipts(installReceiptTargets, paths);
 			if (agentPluginTransaction) {
 				try {
@@ -6879,7 +6849,9 @@ export function convergeRuntimeManifest(
 					restartEgressSidecar: restartEgressSidecar && egressRollbackAuthorityVerified,
 					stopEgressSidecar: restartEgressSidecar && !egressRollbackAuthorityVerified,
 					reconcileUserUnits: mutationPlan.systemdUserUnits,
-					restartUserUnits: agentPluginRestartUserUnits,
+					restartUserUnits: [
+						...new Set([...agentPluginRestartUserUnits, ...runtimeProjectionRestartUserUnits]),
+					].sort(),
 					staleSystemUnits: staleSystemdFiles.systemUnits,
 					staleUserUnits: staleSystemdFiles.userUnits,
 				});

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -13698,7 +13698,6 @@ exit 64
 		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlPath;
 		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
 		const paths = getRuntimePaths();
-		const hermesWhatsAppReceipt = join(paths.managedResourceRoot, "hermes-whatsapp.json");
 		mkdirSync(legacySessionDir, { recursive: true });
 		writeFileSync(legacySentinel, "preserved\n");
 
@@ -13819,24 +13818,6 @@ exit 64
 		expect(convergence.installErrors).toEqual([]);
 		expect(projected.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ENABLED).toBeUndefined();
 		expect(readSystemdEnvFile(paths, "hermes-gateway")).not.toContain("WHATSAPP_ENABLED");
-		expect(JSON.parse(readFileSync(hermesWhatsAppReceipt, "utf8"))).toMatchObject({
-			schemaVersion: "clawdi.managedHermesWhatsApp.v1",
-			deploymentId: projected.manifest.deploymentId,
-			environmentId: projected.manifest.environmentId,
-			instanceId: projected.manifest.instanceId,
-			accountKey,
-			linkId,
-			credentialId,
-			authDir: sessionDir,
-		});
-		commitRuntimeAppliedState({
-			load: projected,
-			paths,
-			etag: '"hermes-whatsapp-active"',
-			sourceRevision: "a".repeat(64),
-			convergence,
-			applyIdentity: projected.applyContext?.identity ?? null,
-		});
 		expect(existsSync(sessionDir)).toBe(true);
 		expect(readFileSync(legacySentinel, "utf-8")).toBe("preserved\n");
 		expect(readHermesConfigYaml(home)).toHaveProperty(
@@ -13908,14 +13889,6 @@ exit 64
 		expect(preserveActiveUnits).toBe(false);
 		const changedCredential = convergeRuntimeManifest(changedCheckpoint, paths);
 		expect(changedCredential.installErrors).toEqual([]);
-		commitRuntimeAppliedState({
-			load: changedCheckpoint,
-			paths,
-			etag: '"hermes-whatsapp-rotated"',
-			sourceRevision: "b".repeat(64),
-			convergence: changedCredential,
-			applyIdentity: changedCheckpoint.applyContext?.identity ?? null,
-		});
 		expect(systemdEnvRevision(readSystemdEnvFile(paths, "hermes-gateway"))).not.toBe(
 			initialHermesRevision,
 		);
@@ -13943,40 +13916,6 @@ exit 64
 			{ ...load, channelBindings: [], secretValues: {} },
 			paths,
 		);
-		const committedReceipt = readFileSync(hermesWhatsAppReceipt, "utf8");
-		writeFileSync(
-			hermesWhatsAppReceipt,
-			`${JSON.stringify({
-				...(JSON.parse(committedReceipt) as Record<string, unknown>),
-				authDir: join(home, ".hermes", "user-session"),
-			})}\n`,
-		);
-		expect(() => convergeRuntimeManifest(removed, paths)).toThrow(
-			"managed Hermes WhatsApp receipt auth directory must be",
-		);
-		writeFileSync(hermesWhatsAppReceipt, committedReceipt);
-
-		const sessionMarker = join(sessionDir, ".clawdi-managed-whatsapp-auth.json");
-		const committedMarker = readFileSync(sessionMarker, "utf8");
-		writeFileSync(sessionMarker, '{"schemaVersion":"invalid"}\n');
-		const invalidMarkerRemoval = convergeRuntimeManifest(removed, paths);
-		expect(invalidMarkerRemoval.installErrors.join("\n")).toContain(
-			"managed Hermes WhatsApp session marker is missing or invalid",
-		);
-		expect(existsSync(sessionDir)).toBe(true);
-		expect(readFileSync(hermesWhatsAppReceipt, "utf8")).toBe(committedReceipt);
-		writeFileSync(sessionMarker, committedMarker);
-
-		// Simulate a pre-receipt CLI after Hermes normalized its own config.
-		rmSync(hermesWhatsAppReceipt);
-		const hermesConfigPath = join(home, ".hermes", "config.yaml");
-		const hermesConfigBeforeNormalization = readFileSync(hermesConfigPath, "utf8");
-		const hermesConfigAfterNormalization = hermesConfigBeforeNormalization
-			.split("\n")
-			.filter((line) => !line.trimStart().startsWith("session_path:"))
-			.join("\n");
-		expect(hermesConfigAfterNormalization).not.toBe(hermesConfigBeforeNormalization);
-		writeFileSync(hermesConfigPath, hermesConfigAfterNormalization);
 		const patchedSocket = readFileSync(baileysSocket, "utf8");
 		writeFileSync(
 			baileysSocket,
@@ -13994,11 +13933,18 @@ exit 64
 		);
 
 		writeFileSync(baileysSocket, patchedSocket);
+		const sessionMarker = join(sessionDir, ".clawdi-managed-whatsapp-auth.json");
+		const committedMarker = readFileSync(sessionMarker, "utf8");
+		writeFileSync(sessionMarker, '{"schemaVersion":"invalid"}\n');
+		const invalidMarkerRemoval = convergeRuntimeManifest(removed, paths);
+		expect(invalidMarkerRemoval.installErrors).toEqual([]);
+		expect(existsSync(sessionDir)).toBe(true);
+		writeFileSync(sessionMarker, committedMarker);
+
 		const removedConvergence = convergeRuntimeManifest(removed, paths);
 		expect(removedConvergence.installErrors).toEqual([]);
 		expect(existsSync(paths.egressProfileBundle)).toBe(false);
 		expect(existsSync(sessionDir)).toBe(false);
-		expect(existsSync(hermesWhatsAppReceipt)).toBe(false);
 		const removedHermesConfig = readHermesConfigYaml(home);
 		expect(removedHermesConfig).toHaveProperty("whatsapp", {
 			user_owned: "keep-whatsapp",
@@ -14034,14 +13980,19 @@ exit 64
 				"",
 			].join("\n"),
 		);
-		expect(convergeRuntimeManifest(removed, paths).installErrors).toEqual([]);
+		const driftRepair = convergeRuntimeManifest(removed, paths);
+		expect(driftRepair.installErrors).toEqual([]);
 		expect(readHermesConfigYaml(home)).toMatchObject({
-			whatsapp: { enabled: true, user_owned: "manual" },
-			platforms: { whatsapp: { enabled: true, extra: { session_path: "/user/session" } } },
+			whatsapp: { enabled: false, user_owned: "manual" },
+			platforms: { whatsapp: { enabled: false } },
 		});
+		expect(readHermesConfigYaml(home)).not.toHaveProperty("platforms.whatsapp.extra.session_path");
 		expect(systemdEnvRevision(readSystemdEnvFile(paths, "hermes-gateway"))).toBe(
 			removedHermesRevision,
 		);
+		const repairedConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf8");
+		expect(convergeRuntimeManifest(removed, paths).installErrors).toEqual([]);
+		expect(readFileSync(join(home, ".hermes", "config.yaml"), "utf8")).toBe(repairedConfig);
 	});
 
 	it("isolates OpenClaw WhatsApp DMs and clears stale managed config", () => {


### PR DESCRIPTION
Root cause: Hermes WhatsApp enablement was split between the Cloud manifest and a local ownership receipt. A missing receipt could leave stale enabled YAML after unlink.\n\nThis change removes the receipt as configuration authority, always reconciles the managed Hermes WhatsApp keys from the current manifest, preserves unrelated user config, and uses the existing marker only to authorize session-directory deletion. Managed config drift triggers the existing systemd activation and rollback transaction; cold official installs are not restarted twice. The retired receipt is removed after successful convergence.\n\nCLI version: 0.13.85\n\nVerification:\n- bash scripts/test.sh cli: 1702 passed, 4 skipped, 0 failed\n- publish manifest check passed\n- Biome and git diff --check passed