### PR TITLE
fix(cli): classify unsupported OpenClaw Agent Plugins

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.85",
+      "version": "0.13.86",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.85",
+	"version": "0.13.86",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
@@ -48,6 +48,7 @@ class FakeNativeRunner implements HostedAgentPluginCommandRunner {
 	openClawDiagnostics: Array<{ level: "warn" | "error"; message: string }> = [];
 	omitOpenClawComponentObservation = false;
 	openClawInstallSource: "path" | "npm" = "path";
+	omitOpenClawInstalledPluginObservation: "probe" | "live" | null = null;
 	retainProbeRemoval = false;
 	readonly liveHome: string;
 
@@ -244,6 +245,14 @@ class FakeNativeRunner implements HostedAgentPluginCommandRunner {
 			rmSync(target, { recursive: true, force: true });
 			mkdirSync(join(target, ".."), { recursive: true });
 			cpSync(source, target, { recursive: true });
+			const installContext = input.home === this.liveHome ? "live" : "probe";
+			if (
+				runtime === "openclaw" &&
+				this.omitOpenClawInstalledPluginObservation === installContext
+			) {
+				if (installContext === "live") this.omitOpenClawInstalledPluginObservation = null;
+				return { status: 0, stdout: "", stderr: "" };
+			}
 			this.states.set(this.key(input, manifest.name), {
 				name: manifest.name,
 				nativeId,
@@ -480,6 +489,21 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 			proveHostedAgentPluginCapabilities({ prepared, commands, runner: unsupportedRunner }),
 		).toThrow(HostedAgentPluginCapabilityUnsupportedError);
 
+		const oldOpenClawRunner = new FakeNativeRunner();
+		oldOpenClawRunner.omitOpenClawInstalledPluginObservation = "probe";
+		let capabilityError: unknown;
+		try {
+			proveHostedAgentPluginCapabilities({ prepared, commands, runner: oldOpenClawRunner });
+		} catch (error) {
+			capabilityError = error;
+		}
+		expect(capabilityError).toBeInstanceOf(HostedAgentPluginCapabilityUnsupportedError);
+		expect(capabilityError).toHaveProperty(
+			"message",
+			"OpenClaw installed the package but did not report it as an Agent Plugins 1.0.0 bundle; standards-native installation is unsupported",
+		);
+		expect(oldOpenClawRunner.liveMutations()).toEqual([]);
+
 		const malformedRunner = new FakeNativeRunner();
 		malformedRunner.omitOpenClawComponentObservation = true;
 		expect(() =>
@@ -518,6 +542,44 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 				message,
 			);
 		}
+
+		const liveRunner = new FakeNativeRunner();
+		const previous = plugin("acme.tools", "1.2.2", "e".repeat(64), ["alpha", "zeta"]);
+		liveRunner.seed(
+			"openclaw",
+			{
+				name: previous.name,
+				nativeId: "acme-tools",
+				version: previous.installation.version,
+				enabled: true,
+				compatible: true,
+				mcpServerNames: [...previous.mcpServerNames],
+			},
+			previous,
+		);
+		const livePrepared = desiredState("openclaw", desired, {
+			runtime: "openclaw",
+			plugin: previous,
+		});
+		const liveTransaction = prepareTransaction(livePrepared, liveRunner);
+		liveRunner.omitOpenClawInstalledPluginObservation = "live";
+		let liveError: unknown;
+		try {
+			liveTransaction.apply();
+		} catch (error) {
+			liveError = error;
+		}
+		expect(liveError).toBeInstanceOf(Error);
+		expect(liveError).not.toBeInstanceOf(HostedAgentPluginCapabilityUnsupportedError);
+		expect(liveError).toHaveProperty(
+			"message",
+			"OpenClaw did not report the installed Agent Plugin",
+		);
+		expect(liveTransaction.rollback()).toEqual([]);
+		expect(liveRunner.get("openclaw", previous.name)).toMatchObject({
+			version: previous.installation.version,
+			enabled: true,
+		});
 	});
 
 	test("installs the Hermes stdio-capable package from a local file Git transport", () => {

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
@@ -90,11 +90,16 @@ export interface HostedAgentPluginCapabilityProof {
 }
 
 export class HostedAgentPluginCapabilityUnsupportedError extends Error {
-	constructor() {
-		super(AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR);
+	constructor(message = AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR) {
+		super(message);
 		this.name = "HostedAgentPluginCapabilityUnsupportedError";
 	}
 }
+
+class OpenClawAgentPluginNotObservedError extends Error {}
+
+const OPENCLAW_AGENT_PLUGIN_STANDARD_UNSUPPORTED_ERROR =
+	"OpenClaw installed the package but did not report it as an Agent Plugins 1.0.0 bundle; standards-native installation is unsupported";
 
 export type HermesRemoteCapabilityProbe = (input: {
 	command: string;
@@ -337,7 +342,11 @@ function createOpenClawDriver(input: {
 				if (result.status !== 0) throw new Error("OpenClaw native Agent Plugin install failed");
 			});
 			const installed = observe(prepared.name);
-			if (!installed) throw new Error("OpenClaw did not report the installed Agent Plugin");
+			if (!installed) {
+				throw new OpenClawAgentPluginNotObservedError(
+					"OpenClaw did not report the installed Agent Plugin",
+				);
+			}
 			return installed;
 		},
 		setEnabled(observation, enabled) {
@@ -590,7 +599,7 @@ function observationUnchanged(
 
 type NativeCapabilityProbeResult =
 	| { kind: "supported"; nativeId: string }
-	| { kind: "unsupported" };
+	| { kind: "unsupported"; message?: string };
 
 function probeObservationCapability(
 	observation: NativePluginObservation,
@@ -647,7 +656,15 @@ function probeNativeCapability(input: {
 			home,
 			runner: input.runner,
 		});
-		const installed = driver.install(input.prepared);
+		let installed: NativePluginObservation;
+		try {
+			installed = driver.install(input.prepared);
+		} catch (error) {
+			if (input.runtime === "openclaw" && error instanceof OpenClawAgentPluginNotObservedError) {
+				return { kind: "unsupported", message: OPENCLAW_AGENT_PLUGIN_STANDARD_UNSUPPORTED_ERROR };
+			}
+			throw error;
+		}
 		if (probeObservationCapability(installed, input.prepared) === "unsupported") {
 			return { kind: "unsupported" };
 		}
@@ -718,7 +735,7 @@ export function proveHostedAgentPluginCapabilities(input: {
 			},
 		});
 		if (probe.kind === "unsupported") {
-			throw new HostedAgentPluginCapabilityUnsupportedError();
+			throw new HostedAgentPluginCapabilityUnsupportedError(probe.message);
 		}
 		const proof = {
 			runtime: item.runtime,


### PR DESCRIPTION
## Summary

- classify an OpenClaw install that cannot observe the standards-native bundle as typed capability absence during the isolated probe
- keep live mutation fail-closed with rollback and preserve hard failures for malformed output, identity, digest, I/O, permissions, and cleanup
- bump the CLI package to 0.13.86

## Verification

- CLI typecheck
- 14 focused Agent Plugin runtime tests
- Biome and publish-manifest checks
- real OpenClaw 2026.8.1-beta.2 lifecycle with the immutable Cetus 0.1.0 release asset

No OpenClaw version or commit gate is used; support remains behavior-probed.