### PR TITLE
fix(runtime): probe standards-native Agent Plugins

### DIFF
--- a/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
@@ -53,7 +53,8 @@ describe("runtime UI credential targeting", () => {
 			url: "https://other.example/openclaw/",
 			deployment_resource_version: "rv-current",
 			token: "deployment-token",
-			handoff_url: "https://other.example/openclaw/#token=deployment-token",
+			handoff_url:
+				"https://other.example/openclaw/#bootstrapToken=one-time-token&bootstrapProfile=owner",
 		};
 		expect(
 			resolveRuntimeUiCredentials(hermes, "https://runtime.example/hermes", "rv-current"),
@@ -63,14 +64,15 @@ describe("runtime UI credential targeting", () => {
 		).toBeNull();
 	});
 
-	test("preserves the exact official OpenClaw token fragment URL", () => {
+	test("preserves the exact official OpenClaw browser handoff URL", () => {
 		const credentials: RuntimeUiCredentials = {
 			runtime: "openclaw",
 			auth_mode: "openclaw_token",
 			url: "https://runtime.example/openclaw/",
 			deployment_resource_version: "rv-current",
 			token: "deployment-token",
-			handoff_url: "https://runtime.example/openclaw/#token=deployment-token",
+			handoff_url:
+				"https://runtime.example/openclaw/#bootstrapToken=one-time-token&bootstrapProfile=owner",
 		};
 		expect(
 			resolveRuntimeUiCredentials(credentials, "https://runtime.example/openclaw/", "rv-current"),
@@ -79,19 +81,22 @@ describe("runtime UI credential targeting", () => {
 		expect(runtimeUiLaunchTarget(credentials)).not.toBe(credentials.url);
 	});
 
-	test("rejects a stale rollout or a handoff without the exact token fragment", () => {
+	test("rejects a stale rollout or a noncanonical browser handoff", () => {
 		const credentials: RuntimeUiCredentials = {
 			runtime: "openclaw",
 			auth_mode: "openclaw_token",
 			url: "https://runtime.example/openclaw/",
 			deployment_resource_version: "rv-current",
 			token: "deployment-token",
-			handoff_url: "https://runtime.example/openclaw/#token=wrong-token",
+			handoff_url: "https://runtime.example/openclaw/#token=deployment-token",
 		};
 		expect(resolveRuntimeUiCredentials(credentials, credentials.url, "rv-current")).toBeNull();
 		expect(
 			resolveRuntimeUiCredentials(
-				{ ...credentials, handoff_url: `${credentials.url}#token=deployment-token` },
+				{
+					...credentials,
+					handoff_url: `${credentials.url}#bootstrapToken=one-time-token&bootstrapProfile=owner`,
+				},
 				credentials.url,
 				"rv-new",
 			),

--- a/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
@@ -81,7 +81,7 @@ describe("runtime UI credential targeting", () => {
 		expect(runtimeUiLaunchTarget(credentials)).not.toBe(credentials.url);
 	});
 
-	test("rejects a stale rollout or a noncanonical browser handoff", () => {
+	test("opens the exact legacy fallback and rejects a stale rollout", () => {
 		const credentials: RuntimeUiCredentials = {
 			runtime: "openclaw",
 			auth_mode: "openclaw_token",
@@ -90,7 +90,10 @@ describe("runtime UI credential targeting", () => {
 			token: "deployment-token",
 			handoff_url: "https://runtime.example/openclaw/#token=deployment-token",
 		};
-		expect(resolveRuntimeUiCredentials(credentials, credentials.url, "rv-current")).toBeNull();
+		expect(resolveRuntimeUiCredentials(credentials, credentials.url, "rv-current")).toEqual(
+			credentials,
+		);
+		expect(runtimeUiLaunchTarget(credentials)).toBe(credentials.handoff_url);
 		expect(
 			resolveRuntimeUiCredentials(
 				{

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -769,7 +769,8 @@ describe("declarative deployment mutations", () => {
 				url: "https://runtime.example/openclaw/",
 				deployment_resource_version: "rv-runtime-ui",
 				token: "gateway-token",
-				handoff_url: "https://runtime.example/openclaw/#token=gateway-token",
+				handoff_url:
+					"https://runtime.example/openclaw/#bootstrapToken=one-time-token&bootstrapProfile=owner",
 			});
 		});
 

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.88",
+      "version": "0.13.89",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1109,10 +1109,11 @@ patch is required for caller-selected tokens:
 [`auth-token-resolution.ts` lines 38-60](https://github.com/openclaw/openclaw/blob/2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4/src/gateway/auth-token-resolution.ts#L38-L60),
 and the official [`config patch --stdin` contract](https://github.com/openclaw/openclaw/blob/2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4/docs/cli/config.md#L249-L263).
 
-The local config patch also sets official shared-token auth, intentionally sets
-`dangerouslyDisableDeviceAuth: true` for the managed v2 product, disables
-insecure and Host-header fallback modes, derives `gateway.controlUi.basePath`
-from the clean public URL, and includes that URL's origin in `allowedOrigins`.
+The local config patch also sets official shared-token auth, disables insecure
+and Host-header fallback modes, derives `gateway.controlUi.basePath` from the
+clean public URL, and includes that URL's origin in `allowedOrigins`. Device
+authentication remains on its official default; Clawdi does not project the
+retired `dangerouslyDisableDeviceAuth` setting.
 The managed backend value, transient installer environment, and
 `openclaw.json` token must remain identical. The gateway unit does not receive
 an `OPENCLAW_GATEWAY_TOKEN` environment entry because runtime auth resolves the
@@ -1125,10 +1126,13 @@ Direct OpenClaw exposure remains fail closed behind the typed
 `openclaw-native-auth-v1` capability and an available
 managed gateway token. Hosted returns a clean endpoint plus an explicit token
 and `handoff_url` through an owner-checked, no-store credential endpoint. The
-handoff carries exactly one official `#token=` fragment. In hosted mode that
-managed token is the authentication, so device pairing is intentionally
-disabled to avoid an additional approval step in the iframe or new-window
-handoff. OpenClaw retains its normal device-auth behavior outside hosted mode.
+backend executes the fixed official `openclaw dashboard --json` command in the
+currently receipted runtime instance and returns its single-use, ten-minute
+`browserUrl` after binding it to the deployment's clean HTTPS endpoint. The
+browser consumes the official `bootstrapToken` and `bootstrapProfile=owner`
+fragment, creates its signed device identity, and receives the durable owner
+credential without a manual pairing step. Clawdi never approves pending devices
+or implements a parallel device-auth protocol.
 
 Hermes direct exposure requires `hermes-basic-auth-v1`, a stable HTTPS public
 URL (including any path prefix), exact `0.0.0.0:9119` service args, and the
@@ -1143,8 +1147,9 @@ infer auth from the runtime name or fall back to legacy `native_url` fields.
 Both runtimes declare `browser_mode: embedded_and_top_level` and remain embedded
 in the Console. Public endpoint URLs contain no secret. The owner-checked
 credential response carries the Hermes username/password or the OpenClaw token
-and exact `handoff_url`, never a query token. Credentials fail closed unless the
-displayed resource version is the exact converged current Ready rollout.
+and exact one-time `handoff_url`, never a query token. Credentials fail closed
+unless the displayed resource version is the exact converged current Ready
+rollout.
 
 Both runtimes use the same Runtime UI Access dialog and declarative reset. Reset
 rotates the existing encrypted gateway credential and advances the durable
@@ -1194,20 +1199,18 @@ scripts/test-runtime-official-installer-systemd.sh
 
 Done: the command exits 0 and reports `1 pass`.
 
-The Runtime UI behavior evidence below remains pinned to exact official commit
-[`ba467fbd3efa9ab109e620c4e42cfe92388171c5`](https://github.com/openclaw/openclaw/commit/ba467fbd3efa9ab109e620c4e42cfe92388171c5).
+The Runtime UI behavior evidence below was refreshed against exact official
+commit
+[`f7a86382823d2b30dca8af578f717a4fa87670f5`](https://github.com/openclaw/openclaw/commit/f7a86382823d2b30dca8af578f717a4fa87670f5).
 
 | Requirement | Official line evidence | Contract consequence |
 | --- | --- | --- |
-| Gateway bind, port, auth, and token | [`docs/cli/gateway.md` lines 26-85](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/docs/cli/gateway.md#L26-L85), [`configuration-reference.md` lines 629-661](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/docs/gateway/configuration-reference.md#L629-L661) | Use native `18789`, container-reachable `lan`, required token auth, and explicit public `allowedOrigins`. |
-| Control UI auth | [`docs/web/control-ui.md` lines 33-69](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/docs/web/control-ui.md#L33-L69) | Token is sent in `connect.params.auth.token`; managed v2 uses this shared-token path without device pairing. |
-| Device-auth policy | [`docs/web/control-ui.md` lines 588-632](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/docs/web/control-ui.md#L588-L632) | `dangerouslyDisableDeviceAuth: true` is an intentional managed-product policy tradeoff, not an inferred security default. |
-| Dashboard URL discovery | [`docs/cli/dashboard.md` lines 20-42](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/docs/cli/dashboard.md#L20-L42), [`src/commands/dashboard.ts` lines 33-118](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/src/commands/dashboard.ts#L33-L118) | Official JSON discovery reports resolved HTTP/WS URLs; the official handoff uses `#token=`, not a query token. |
-| Fragment browser handoff | [`ui/src/app/startup-settings.ts` lines 91-172](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/ui/src/app/startup-settings.ts#L91-L172), [`docs/web/control-ui.md` lines 742-754](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/docs/web/control-ui.md#L742-L754) | Query tokens are legacy, warned, and stripped; Clawdi loads the clean URL plus the official `#token=` handoff in its embedded iframe and optional top-level window. |
-| WebSocket auth | [`docs/concepts/architecture.md` lines 75-112](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/docs/concepts/architecture.md#L75-L112) | The first frame is `connect`; managed v2 supplies the shared token and does not initiate a device-pairing flow. |
-| Gateway health surfaces | [`docs/gateway/embedding.md` lines 91-107](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/docs/gateway/embedding.md#L91-L107), [`docs/gateway/index.md` lines 40-49](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/docs/gateway/index.md#L40-L49) | The CLI commit proof is the required systemd units reaching active/enabled. The workload platform separately gates Service exposure with loopback startup/readiness probes against the official `/healthz` and `/readyz` surfaces; it does not claim an authenticated WebSocket or `gateway status --require-rpc` proof. Hermes additionally requires readiness metadata asserting `auth_required` with provider `basic`. |
-| Base path/prefix | [`docs/web/control-ui.md` lines 10-15](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/docs/web/control-ui.md#L10-L15) | Configure official `gateway.controlUi.basePath`; do not inject or rewrite browser paths. |
-| Service lifecycle | [`docs/cli/daemon.md` lines 13-47](https://github.com/openclaw/openclaw/blob/ba467fbd3efa9ab109e620c4e42cfe92388171c5/docs/cli/daemon.md#L13-L47) | Use official gateway install/start/stop/restart/status lifecycle and keep Clawdi ownership limited to its hosted drop-in/env. |
+| Gateway bind, port, auth, and token | [`docs/cli/gateway.md`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/docs/cli/gateway.md), [`configuration-reference.md`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/docs/gateway/configuration-reference.md) | Use native `18789`, container-reachable `lan`, required token auth, and explicit public `allowedOrigins`. |
+| Browser handoff command | [`docs/cli/dashboard.md`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/docs/cli/dashboard.md), [`src/commands/dashboard.ts`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/src/commands/dashboard.ts) | `dashboard --json` is the official machine-readable integration surface. Against a running gateway it returns `browserUrl` plus its expiry without opening a browser. |
+| Owner bootstrap contract | [`control-ui-handoff.ts`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/src/commands/control-ui-handoff.ts), [`control-ui-contract.ts`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/src/gateway/control-ui-contract.ts), [`device-bootstrap-profile.ts`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/src/shared/device-bootstrap-profile.ts) | The fragment contains a single-use `bootstrapToken` and the closed `bootstrapProfile=owner` hint; the host-issued profile grants the browser owner credential through OpenClaw's native device flow. |
+| Gateway health surfaces | [`docs/gateway/embedding.md`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/docs/gateway/embedding.md), [`docs/gateway/index.md`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/docs/gateway/index.md) | The CLI commit proof is the required systemd units reaching active/enabled. The workload platform separately gates Service exposure with loopback startup/readiness probes against the official `/healthz` and `/readyz` surfaces. Hermes additionally requires readiness metadata asserting `auth_required` with provider `basic`. |
+| Base path/prefix | [`docs/web/control-ui.md`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/docs/web/control-ui.md) | Configure official `gateway.controlUi.basePath`; rebind only the verified origin while preserving the official path and fragment. |
+| Service lifecycle | [`docs/cli/daemon.md`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/docs/cli/daemon.md) | Use official gateway install/start/stop/restart/status lifecycle and keep Clawdi ownership limited to its hosted drop-in/env. |
 
 ## Desired State Boundary
 

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1126,13 +1126,16 @@ Direct OpenClaw exposure remains fail closed behind the typed
 `openclaw-native-auth-v1` capability and an available
 managed gateway token. Hosted returns a clean endpoint plus an explicit token
 and `handoff_url` through an owner-checked, no-store credential endpoint. The
-backend executes the fixed official `openclaw dashboard --json` command in the
-currently receipted runtime instance and returns its single-use, ten-minute
-`browserUrl` after binding it to the deployment's clean HTTPS endpoint. The
-browser consumes the official `bootstrapToken` and `bootstrapProfile=owner`
-fragment, creates its signed device identity, and receives the durable owner
-credential without a manual pairing step. Clawdi never approves pending devices
-or implements a parallel device-auth protocol.
+backend first executes the fixed official `openclaw dashboard --json` command
+in the currently receipted runtime instance. When supported, it returns the
+single-use, ten-minute `browserUrl` after binding it to the deployment's clean
+HTTPS endpoint. The browser consumes the official `bootstrapToken` and
+`bootstrapProfile=owner` fragment, creates its signed device identity, and
+receives the durable owner credential without a manual pairing step. If the
+installed binary cannot issue that handoff, Hosted preserves the existing exact
+`#token=` launch for older deployments; OpenClaw then enforces that deployment's
+own device-auth policy. This fallback neither disables device auth nor approves
+pending devices, and Clawdi implements no parallel device-auth protocol.
 
 Hermes direct exposure requires `hermes-basic-auth-v1`, a stable HTTPS public
 URL (including any path prefix), exact `0.0.0.0:9119` service args, and the
@@ -1606,10 +1609,11 @@ fallback for environments that reject custom WebSocket subprotocols.
   channel descriptors, filesystem paths, and process launch arguments.
 - Remove `CLAWDI_AUTH_TOKEN` from agent child process environments unless that
   process is explicitly the Clawdi daemon or runtime reconciler.
-- Disable OpenClaw device auth only for hosted strict v2, where the managed
-  shared token authenticates the dashboard handoff without an additional
-  pairing approval. Keep device auth enabled outside hosted mode, and never
-  enable insecure or Host-header fallback modes.
+- Keep OpenClaw device auth at its native default and use the official owner
+  bootstrap when available. Older hosted deployments may temporarily retain
+  their existing shared-token launch until their runtime and CLI are upgraded
+  together; do not project the retired device-auth disable setting into new
+  desired state, and never enable insecure or Host-header fallback modes.
 - Prefer WebSocket subprotocol auth for Terminal sessions so bearer tokens do
   not normally appear in URLs or proxy access logs.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.88",
+	"version": "0.13.89",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/hermes-agent-plugin-canary-client.ts
+++ b/packages/cli/src/runtime/hermes-agent-plugin-canary-client.ts
@@ -4,7 +4,10 @@ import { lstatSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { z } from "zod";
 import { resolveCurrentCliInvocation } from "../lib/current-cli-invocation";
-import type { PreparedHostedAgentPlugin } from "./hosted-agent-plugin-package";
+import {
+	hostedAgentPluginTreeDigest,
+	type PreparedHostedAgentPlugin,
+} from "./hosted-agent-plugin-package";
 import { makeRuntimeUserOwned, withRuntimeUserFileAccess } from "./runtime-user-command";
 
 const HERMES_REMOTE_PROBE_TIMEOUT_MS = 30_000;
@@ -71,20 +74,6 @@ function waitForJsonFile<T>(path: string, schema: z.ZodType<T>, timeoutMs: numbe
 	throw new Error("Hermes Agent Plugin canary did not become ready");
 }
 
-function preparedTreeDigest(tree: PreparedHostedAgentPlugin["tree"]): string {
-	const digest = createHash("sha256");
-	for (const file of [...tree].sort((left, right) =>
-		Buffer.compare(Buffer.from(left.path, "utf8"), Buffer.from(right.path, "utf8")),
-	)) {
-		const fileDigest = createHash("sha256").update(file.bytes).digest("hex");
-		digest.update(
-			`${file.mode.toString(8)}\0${file.path}\0${file.bytes.length}\0${fileDigest}\n`,
-			"utf8",
-		);
-	}
-	return `sha256-tree-v1:${digest.digest("hex")}`;
-}
-
 function hermesCanaryPackage(input: {
 	name: string;
 	nonce: string;
@@ -134,7 +123,7 @@ function hermesCanaryPackage(input: {
 				path: "",
 				commit: input.nonce.padEnd(40, "0"),
 			},
-			contentDigest: preparedTreeDigest(tree),
+			contentDigest: hostedAgentPluginTreeDigest(tree),
 			ownershipIdentity: createHash("sha256").update(`canary:${input.nonce}`).digest("hex"),
 		},
 		receiptNativeId: null,

--- a/packages/cli/src/runtime/hosted-agent-plugin-package.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-package.ts
@@ -96,6 +96,19 @@ export interface PreparedAgentPluginTreeFile {
 	bytes: Buffer;
 }
 
+export function hostedAgentPluginTreeDigest(tree: readonly PreparedAgentPluginTreeFile[]): string {
+	const digest = createHash("sha256");
+	for (const file of [...tree].sort((left, right) =>
+		Buffer.compare(Buffer.from(left.path, "utf8"), Buffer.from(right.path, "utf8")),
+	)) {
+		digest.update(
+			`${file.mode.toString(8)}\0${file.path}\0${file.bytes.length}\0${sha256(file.bytes)}\n`,
+			"utf8",
+		);
+	}
+	return `sha256-tree-v1:${digest.digest("hex")}`;
+}
+
 export interface PreparedHostedAgentPlugin {
 	name: string;
 	installation: PreparedHostedAgentPluginInstallation;
@@ -673,14 +686,7 @@ function collectPackageTree(
 	tree.sort((left, right) =>
 		Buffer.compare(Buffer.from(left.path, "utf8"), Buffer.from(right.path, "utf8")),
 	);
-	const digest = createHash("sha256");
-	for (const file of tree) {
-		digest.update(
-			`${file.mode.toString(8)}\0${file.path}\0${file.bytes.length}\0${sha256(file.bytes)}\n`,
-			"utf8",
-		);
-	}
-	return { digest: `sha256-tree-v1:${digest.digest("hex")}`, tree };
+	return { digest: hostedAgentPluginTreeDigest(tree), tree };
 }
 
 export function hostedAgentPluginDirectoryDigest(
@@ -1228,7 +1234,7 @@ export async function prepareHostedAgentPluginPackages(
 }
 
 export function withPreparedAgentPluginDirectory<T>(
-	prepared: PreparedHostedAgentPlugin,
+	prepared: Pick<PreparedHostedAgentPlugin, "tree">,
 	operation: (sourceDir: string) => T,
 ): T {
 	const root = mkdtempSync(join(tmpdir(), "clawdi-agent-plugin-stage-"));

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
@@ -48,6 +48,7 @@ class FakeNativeRunner implements HostedAgentPluginCommandRunner {
 	openClawDiagnostics: Array<{ level: "warn" | "error"; message: string }> = [];
 	omitOpenClawComponentObservation = false;
 	openClawInstallSource: "path" | "npm" = "path";
+	openClawFaultPackageName = "acme.tools";
 	omitOpenClawInstalledPluginObservation: "probe" | "live" | null = null;
 	retainProbeRemoval = false;
 	readonly liveHome: string;
@@ -196,6 +197,7 @@ class FakeNativeRunner implements HostedAgentPluginCommandRunner {
 				.map(([, value]) => value)
 				.find((value) => value.nativeId === args[2]);
 			if (!plugin) return { status: 1, stdout: "", stderr: "" };
+			const applyPackageFaults = plugin.name === this.openClawFaultPackageName;
 			return {
 				status: 0,
 				stdout: JSON.stringify({
@@ -211,20 +213,20 @@ class FakeNativeRunner implements HostedAgentPluginCommandRunner {
 						bundleFormat: plugin.compatible ? "agent" : undefined,
 					},
 					install: {
-						source: this.openClawInstallSource,
+						source: applyPackageFaults ? this.openClawInstallSource : "path",
 						version: plugin.version,
 						installPath: this.installPath(input.home, runtime, plugin.nativeId),
 					},
-					...(this.omitOpenClawComponentObservation
+					...(applyPackageFaults && this.omitOpenClawComponentObservation
 						? {}
 						: {
 								mcpServers:
-									this.openClawMcpServersOverride ??
+									(applyPackageFaults ? this.openClawMcpServersOverride : null) ??
 									(plugin.mcpServerNames ?? []).map((name) => ({
 										name,
 										hasStdioTransport: true,
 									})),
-								diagnostics: this.openClawDiagnostics,
+								diagnostics: applyPackageFaults ? this.openClawDiagnostics : [],
 							}),
 				}),
 				stderr: "",
@@ -469,7 +471,7 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 		expect(runner.liveMutations()).toHaveLength(liveMutations);
 	});
 
-	test("classifies only explicit OpenClaw capability absence as unsupported", () => {
+	test("separates OpenClaw capability absence from package incompatibility", () => {
 		const desired = plugin("acme.tools", "1.2.3", "f".repeat(64), ["alpha", "zeta"]);
 		const prepared = desiredState("openclaw", desired);
 		expect(() =>
@@ -485,9 +487,18 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 			{ name: "alpha", hasStdioTransport: true },
 			{ name: "zeta", hasStdioTransport: false, unsupported: true },
 		];
-		expect(() =>
-			proveHostedAgentPluginCapabilities({ prepared, commands, runner: unsupportedRunner }),
-		).toThrow(HostedAgentPluginCapabilityUnsupportedError);
+		let packageError: unknown;
+		try {
+			proveHostedAgentPluginCapabilities({ prepared, commands, runner: unsupportedRunner });
+		} catch (error) {
+			packageError = error;
+		}
+		expect(packageError).toBeInstanceOf(Error);
+		expect(packageError).not.toBeInstanceOf(HostedAgentPluginCapabilityUnsupportedError);
+		expect(packageError).toHaveProperty(
+			"message",
+			"Agent Plugin package is not supported by the selected native runtime",
+		);
 
 		const oldOpenClawRunner = new FakeNativeRunner();
 		oldOpenClawRunner.omitOpenClawInstalledPluginObservation = "probe";

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
@@ -8,6 +8,7 @@ import {
 	type HostedAgentPluginReceipt,
 	type HostedAgentPluginRuntime,
 	hostedAgentPluginDirectoryDigest,
+	hostedAgentPluginTreeDigest,
 	type PreparedHostedAgentPlugin,
 	type PreparedHostedAgentPlugins,
 	withPreparedAgentPluginDirectory,
@@ -100,6 +101,7 @@ class OpenClawAgentPluginNotObservedError extends Error {}
 
 const OPENCLAW_AGENT_PLUGIN_STANDARD_UNSUPPORTED_ERROR =
 	"OpenClaw installed the package but did not report it as an Agent Plugins 1.0.0 bundle; standards-native installation is unsupported";
+const AGENT_PLUGIN_CAPABILITY_CANARY_NAME = "clawdi-capability-canary";
 
 export type HermesRemoteCapabilityProbe = (input: {
 	command: string;
@@ -150,12 +152,32 @@ interface NativePluginObservation {
 	contentDigest: string | null;
 }
 
+interface NativeAgentPluginPackage {
+	name: string;
+	version: string;
+	contentDigest: string;
+	mcpServerNames: readonly string[];
+	hasStreamableHttpMcp: boolean;
+	tree: PreparedHostedAgentPlugin["tree"];
+}
+
+function nativePackage(prepared: PreparedHostedAgentPlugin): NativeAgentPluginPackage {
+	return {
+		name: prepared.name,
+		version: prepared.installation.version,
+		contentDigest: prepared.installation.contentDigest,
+		mcpServerNames: prepared.mcpServerNames,
+		hasStreamableHttpMcp: prepared.hasStreamableHttpMcp,
+		tree: prepared.tree,
+	};
+}
+
 interface NativeAgentPluginDriver {
 	runtime: HostedAgentPluginRuntime;
 	installTarget(nativeId: string): string;
 	mutationStateTargets(): readonly string[];
 	observe(name: string, nativeId?: string): NativePluginObservation | null;
-	install(prepared: PreparedHostedAgentPlugin): NativePluginObservation;
+	install(prepared: NativeAgentPluginPackage): NativePluginObservation;
 	setEnabled(observation: NativePluginObservation, enabled: boolean): void;
 	remove(observation: NativePluginObservation): void;
 }
@@ -505,7 +527,7 @@ const defaultHermesRemoteCapabilityProbe: HermesRemoteCapabilityProbe = (input) 
 			}),
 		withEnabledCanary: (canary, prove) => {
 			const driver = createHermesDriver(input);
-			const installed = driver.install(canary);
+			const installed = driver.install(nativePackage(canary));
 			try {
 				driver.setEnabled(installed, true);
 				prove();
@@ -525,6 +547,45 @@ const defaultHermesRemoteCapabilityProbe: HermesRemoteCapabilityProbe = (input) 
 interface CapabilityProbePackage {
 	runtime: HostedAgentPluginRuntime;
 	prepared: PreparedHostedAgentPlugin;
+}
+
+function capabilityCanaryPackage(): NativeAgentPluginPackage {
+	const tree: PreparedHostedAgentPlugin["tree"] = [
+		{
+			path: "plugin.json",
+			mode: 0o100644,
+			bytes: Buffer.from(
+				JSON.stringify({
+					$schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+					name: AGENT_PLUGIN_CAPABILITY_CANARY_NAME,
+					version: "1.0.0",
+				}),
+			),
+		},
+		{
+			path: "skills/clawdi-capability/SKILL.md",
+			mode: 0o100644,
+			bytes: Buffer.from(
+				[
+					"---",
+					"name: clawdi-capability",
+					"description: Verify standards-native Agent Plugin lifecycle support.",
+					"---",
+					"",
+					"# Clawdi capability canary",
+					"",
+				].join("\n"),
+			),
+		},
+	];
+	return {
+		name: AGENT_PLUGIN_CAPABILITY_CANARY_NAME,
+		version: "1.0.0",
+		contentDigest: hostedAgentPluginTreeDigest(tree),
+		mcpServerNames: [],
+		hasStreamableHttpMcp: false,
+		tree,
+	};
 }
 
 function capabilityProbePackages(prepared: PreparedHostedAgentPlugins): CapabilityProbePackage[] {
@@ -597,25 +658,25 @@ function observationUnchanged(
 	);
 }
 
-type NativeCapabilityProbeResult =
+type NativePackageProbeResult =
 	| { kind: "supported"; nativeId: string }
 	| { kind: "unsupported"; message?: string };
 
 function probeObservationCapability(
 	observation: NativePluginObservation,
-	prepared: PreparedHostedAgentPlugin,
+	prepared: NativeAgentPluginPackage,
 	expectedNativeId?: string,
 ): "supported" | "unsupported" {
 	if (
 		observation.name !== prepared.name ||
-		observation.version !== prepared.installation.version ||
+		observation.version !== prepared.version ||
 		(expectedNativeId !== undefined && observation.nativeId !== expectedNativeId)
 	) {
 		throw new Error("native Agent Plugin probe observed an unexpected package identity");
 	}
 	if (!observation.compatible)
 		throw new Error("native Agent Plugin probe observed an unexpected package source");
-	if (observation.contentDigest !== prepared.installation.contentDigest) {
+	if (observation.contentDigest !== prepared.contentDigest) {
 		throw new Error("native Agent Plugin probe observed unexpected package bytes");
 	}
 	if (observation.runtime === "openclaw") {
@@ -631,13 +692,13 @@ function probeObservationCapability(
 	return "supported";
 }
 
-function probeNativeCapability(input: {
+function probeNativePackage(input: {
 	runtime: HostedAgentPluginRuntime;
 	command: string;
-	prepared: PreparedHostedAgentPlugin;
+	prepared: NativeAgentPluginPackage;
 	runner: HostedAgentPluginCommandRunner;
 	hermesRemoteCapabilityProbe: HermesRemoteCapabilityProbe;
-}): NativeCapabilityProbeResult {
+}): NativePackageProbeResult {
 	if (!isAbsolute(input.command)) {
 		throw new Error("Agent Plugin capability probe requires an absolute runtime command");
 	}
@@ -721,12 +782,26 @@ export function proveHostedAgentPluginCapabilities(input: {
 	const runner = input.runner ?? defaultCommandRunner;
 	const packages = new Map<string, HostedAgentPluginPackageProof>();
 	let hermesRemoteProven = false;
-	for (const item of capabilityProbePackages(input.prepared)) {
+	const probePackages = capabilityProbePackages(input.prepared);
+	const runtimes = [...new Set(probePackages.map((item) => item.runtime))].sort();
+	for (const runtime of runtimes) {
+		const probe = probeNativePackage({
+			runtime,
+			command: input.commands[runtime],
+			prepared: capabilityCanaryPackage(),
+			runner,
+			hermesRemoteCapabilityProbe: () => undefined,
+		});
+		if (probe.kind === "unsupported") {
+			throw new HostedAgentPluginCapabilityUnsupportedError(probe.message);
+		}
+	}
+	for (const item of probePackages) {
 		const command = input.commands[item.runtime];
-		const probe = probeNativeCapability({
+		const probe = probeNativePackage({
 			runtime: item.runtime,
 			command,
-			prepared: item.prepared,
+			prepared: nativePackage(item.prepared),
 			runner,
 			hermesRemoteCapabilityProbe: (probeInput) => {
 				if (hermesRemoteProven) return;
@@ -735,7 +810,7 @@ export function proveHostedAgentPluginCapabilities(input: {
 			},
 		});
 		if (probe.kind === "unsupported") {
-			throw new HostedAgentPluginCapabilityUnsupportedError(probe.message);
+			throw new Error("Agent Plugin package is not supported by the selected native runtime");
 		}
 		const proof = {
 			runtime: item.runtime,
@@ -958,7 +1033,7 @@ export function prepareHostedAgentPluginTransaction(input: {
 				}
 				if (mutation.action === "install" || mutation.action === "replace") {
 					if (!mutation.desired) throw new Error("Agent Plugin mutation plan is invalid");
-					const installed = mutation.driver.install(mutation.desired);
+					const installed = mutation.driver.install(nativePackage(mutation.desired));
 					if (!observationMatches(installed, mutation.desired, mutation.nativeId)) {
 						throw new Error("native Agent Plugin installed an unexpected identity or package");
 					}
@@ -1003,7 +1078,7 @@ export function prepareHostedAgentPluginTransaction(input: {
 							}
 							mutation.driver.remove(current);
 						}
-						const restored = mutation.driver.install(mutation.previous);
+						const restored = mutation.driver.install(nativePackage(mutation.previous));
 						if (!observationMatches(restored, mutation.previous, mutation.nativeId)) {
 							throw new Error("native Agent Plugin rollback restored an unexpected package");
 						}

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -1057,7 +1057,17 @@ mkdir -p '${dirname(commandPath)}'
 cat > '${commandPath}' <<'CLI'
 #!/usr/bin/env bash
 set -euo pipefail
-plugin_root="$HOME/.openclaw/extensions/acme-tools"
+plugin_root=""
+for plugin_file in "$HOME"/.openclaw/extensions/*/plugin.json; do
+  [[ -f "$plugin_file" ]] || continue
+  plugin_root="\${plugin_file%/plugin.json}"
+  break
+done
+plugin_native_id="\${plugin_root##*/}"
+plugin_name=""
+if [[ -n "$plugin_root" ]]; then
+  plugin_name=$(sed -n 's/.*"name":"\\([^"]*\\)".*/\\1/p' "$plugin_root/plugin.json")
+fi
 plugin_config="$HOME/.openclaw/openclaw.json"
 plugin_database="$HOME/.openclaw/state/openclaw.sqlite"
 plugin_enabled=false
@@ -1091,20 +1101,23 @@ case "\${1:-}" in
     case "\${2:-}" in
       list)
         [[ "\${3:-}" == --json ]] || exit 2
-        if [[ ! -f "$plugin_root/plugin.json" ]]; then
+	        if [[ -z "$plugin_root" || ! -f "$plugin_root/plugin.json" ]]; then
           printf '%s\\n' '{"plugins":[]}'
           exit 0
         fi
         version=$(sed -n 's/.*"version":"\\([^"]*\\)".*/\\1/p' "$plugin_root/plugin.json")
-        printf '{"plugins":[{"id":"acme-tools","name":"acme.tools","version":"%s","enabled":%s,"status":"%s","format":"bundle","bundleFormat":"agent"}]}\\n' "$version" "$plugin_enabled" "$plugin_status"
+	        printf '{"plugins":[{"id":"%s","name":"%s","version":"%s","enabled":%s,"status":"%s","format":"bundle","bundleFormat":"agent"}]}\\n' "$plugin_native_id" "$plugin_name" "$version" "$plugin_enabled" "$plugin_status"
         ;;
       inspect)
-        [[ "\${3:-}" == acme-tools && "\${4:-}" == --json && -f "$plugin_root/plugin.json" ]] || exit 2
+	        [[ "\${3:-}" == "$plugin_native_id" && "\${4:-}" == --json && -f "$plugin_root/plugin.json" ]] || exit 2
         version=$(sed -n 's/.*"version":"\\([^"]*\\)".*/\\1/p' "$plugin_root/plugin.json")
-	        printf '{"plugin":{"id":"acme-tools","name":"acme.tools","source":"test","origin":"config","status":"%s","version":"%s","enabled":%s,"format":"bundle","bundleFormat":"agent"},"mcpServers":[],"diagnostics":[],"install":{"source":"path","installPath":"%s","resolvedVersion":"%s"}}\\n' "$plugin_status" "$version" "$plugin_enabled" "$plugin_root" "$version"
+	        printf '{"plugin":{"id":"%s","name":"%s","source":"test","origin":"config","status":"%s","version":"%s","enabled":%s,"format":"bundle","bundleFormat":"agent"},"mcpServers":[],"diagnostics":[],"install":{"source":"path","installPath":"%s","resolvedVersion":"%s"}}\\n' "$plugin_native_id" "$plugin_name" "$plugin_status" "$version" "$plugin_enabled" "$plugin_root" "$version"
         ;;
 	      install)
 	        [[ "\${4:-}" == --force && -f "\${3:-}/plugin.json" ]] || exit 2
+	        plugin_name=$(sed -n 's/.*"name":"\\([^"]*\\)".*/\\1/p' "$3/plugin.json")
+	        plugin_native_id="\${plugin_name//./-}"
+	        plugin_root="$HOME/.openclaw/extensions/$plugin_native_id"
 	        version=$(sed -n 's/.*"version":"\\([^"]*\\)".*/\\1/p' "$3/plugin.json")
 	        if [[ "$HOME" == '${paths.userHome}' ]]; then
 	          if [[ -f "$HOME/.openclaw/fail-rollback" && "$version" == 1.0.0 ]]; then
@@ -1119,17 +1132,17 @@ case "\${1:-}" in
         mkdir -p "$(dirname "$plugin_root")"
         cp -R "$3" "$plugin_root"
         mkdir -p "$(dirname "$plugin_config")"
-        printf '%s\\n' '{"plugins":{"entries":{"acme-tools":{"enabled":false}}}}' > "$plugin_config"
+	        printf '{"plugins":{"entries":{"%s":{"enabled":false}}}}\\n' "$plugin_native_id" > "$plugin_config"
         mkdir -p "$(dirname "$plugin_database")"
         printf 'installed:%s\\n' "$version" > "$plugin_database"
         printf 'wal:%s\\n' "$version" > "$plugin_database-wal"
         printf 'shm:%s\\n' "$version" > "$plugin_database-shm"
         ;;
 	      enable|disable)
-	        [[ "\${3:-}" == acme-tools && -f "$plugin_root/plugin.json" ]] || exit 2
+	        [[ "\${3:-}" == "$plugin_native_id" && -f "$plugin_root/plugin.json" ]] || exit 2
 	        enabled=false
 	        if [[ "$2" == enable ]]; then enabled=true; fi
-	        printf '{"plugins":{"entries":{"acme-tools":{"enabled":%s}}}}\\n' "$enabled" > "$plugin_config"
+	        printf '{"plugins":{"entries":{"%s":{"enabled":%s}}}}\\n' "$plugin_native_id" "$enabled" > "$plugin_config"
 	        version=$(sed -n 's/.*"version":"\\([^"]*\\)".*/\\1/p' "$plugin_root/plugin.json")
 	        if [[ "$HOME" == '${paths.userHome}' && "$2" == enable && "$version" == 2.0.0 ]]; then
 	          printf '%s\\n' enable-failed > "$plugin_database"
@@ -1140,7 +1153,7 @@ case "\${1:-}" in
 	        fi
 	        ;;
       uninstall)
-        [[ "\${3:-}" == acme-tools && "\${4:-}" == --force ]] || exit 2
+	        [[ "\${3:-}" == "$plugin_native_id" && "\${4:-}" == --force ]] || exit 2
         rm -rf "$plugin_root"
         printf '%s\\n' '{}' > "$plugin_config"
         printf '%s\\n' uninstalled > "$plugin_database"
@@ -1210,6 +1223,7 @@ chmod 0755 '${commandPath}'
 		expect(first.installErrors).toEqual([]);
 		expect(readFileSync(eventLog, "utf8").trim().split("\n")).toEqual([
 			"binary-install",
+			"probe-install:1.0.0",
 			"probe-install:1.0.0",
 			"quiesce",
 			"plugin-apply:1.0.0",
@@ -1307,6 +1321,7 @@ chmod 0755 '${commandPath}'
 		expect(failed.agentPluginFailedNames).toEqual(["acme.tools"]);
 		expect(rollbackLifecycle).toEqual(["quiesce", "systemd rollback"]);
 		expect(readFileSync(eventLog, "utf8").trim().split("\n")).toEqual([
+			"probe-install:1.0.0",
 			"probe-install:1.0.0",
 			"probe-install:2.0.0",
 			"quiesce",
@@ -1987,13 +2002,12 @@ chmod 0755 '${commandPath}'
 				controlUi: {
 					allowedOrigins,
 					dangerouslyAllowHostHeaderOriginFallback: false,
-					dangerouslyDisableDeviceAuth: true,
 				},
 			},
 		});
 	});
 
-	test("projects hosted OpenClaw v2 direct token auth with device auth disabled", () => {
+	test("projects hosted OpenClaw v2 direct token auth", () => {
 		const paths = tempRuntimePaths();
 		const openclawBin = join(paths.userHome, ".local", "bin", "openclaw");
 		const patchPath = join(paths.serviceStateRoot, "openclaw-native-auth-patch.json");
@@ -2055,7 +2069,6 @@ chmod 0755 '${commandPath}'
 					basePath: "/control",
 					allowedOrigins: ["https://agent.example.test"],
 					dangerouslyAllowHostHeaderOriginFallback: false,
-					dangerouslyDisableDeviceAuth: true,
 				},
 			},
 		});

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -3183,9 +3183,8 @@ function openClawGatewayHostedPatch(
 											? {
 													basePath: openClawControlUiBasePath(manifest),
 													dangerouslyAllowHostHeaderOriginFallback: false,
-													dangerouslyDisableDeviceAuth: true,
 												}
-											: { dangerouslyDisableDeviceAuth: true }),
+											: {}),
 									},
 								}
 							: {}),

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -3800,7 +3800,6 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 				},
 				controlUi: {
 					allowedOrigins: ["https://app-v2-18789.k3s.example.test"],
-					dangerouslyDisableDeviceAuth: true,
 				},
 			},
 		});
@@ -4956,7 +4955,6 @@ exit 0
 					basePath: "/",
 					allowedOrigins: ["https://app-v2-18789.k3s.example.test"],
 					dangerouslyAllowHostHeaderOriginFallback: false,
-					dangerouslyDisableDeviceAuth: true,
 				},
 			},
 		});

--- a/packages/shared/src/api/deploy.test.ts
+++ b/packages/shared/src/api/deploy.test.ts
@@ -115,7 +115,7 @@ describe("Runtime UI access contracts", () => {
 		).toBe(true);
 	});
 
-	test("rejects shared-token and mismatched OpenClaw handoffs", () => {
+	test("accepts the exact legacy token fallback and rejects mismatched handoffs", () => {
 		const credential = {
 			runtime: "openclaw",
 			auth_mode: "openclaw_token",
@@ -124,7 +124,13 @@ describe("Runtime UI access contracts", () => {
 			token: "gateway-token",
 			handoff_url: "https://runtime.example/openclaw/#token=gateway-token",
 		};
-		expect(isRuntimeUiCredentials(credential)).toBe(false);
+		expect(isRuntimeUiCredentials(credential)).toBe(true);
+		expect(
+			isRuntimeUiCredentials({
+				...credential,
+				handoff_url: "https://runtime.example/openclaw/#token=other-token",
+			}),
+		).toBe(false);
 		expect(
 			isRuntimeUiCredentials({
 				...credential,

--- a/packages/shared/src/api/deploy.test.ts
+++ b/packages/shared/src/api/deploy.test.ts
@@ -92,7 +92,7 @@ describe("deployment list response split", () => {
 });
 
 describe("Runtime UI access contracts", () => {
-	test("accepts embedded endpoints and the explicit OpenClaw fragment handoff", () => {
+	test("accepts embedded endpoints and the official OpenClaw browser handoff", () => {
 		expect(
 			isRuntimeUiEndpointInfo({
 				runtime: "openclaw",
@@ -109,21 +109,29 @@ describe("Runtime UI access contracts", () => {
 				url: "https://runtime.example/openclaw/",
 				deployment_resource_version: "rv-current",
 				token: "gateway-token",
-				handoff_url: "https://runtime.example/openclaw/#token=gateway-token",
+				handoff_url:
+					"https://runtime.example/openclaw/#bootstrapToken=one-time-token&bootstrapProfile=owner",
 			}),
 		).toBe(true);
 	});
 
-	test("rejects token query parameters and mismatched OpenClaw handoffs", () => {
+	test("rejects shared-token and mismatched OpenClaw handoffs", () => {
 		const credential = {
 			runtime: "openclaw",
 			auth_mode: "openclaw_token",
-			url: "https://runtime.example/openclaw/?token=gateway-token",
+			url: "https://runtime.example/openclaw/",
 			deployment_resource_version: "rv-current",
 			token: "gateway-token",
-			handoff_url: "https://runtime.example/openclaw/#token=other-token",
+			handoff_url: "https://runtime.example/openclaw/#token=gateway-token",
 		};
 		expect(isRuntimeUiCredentials(credential)).toBe(false);
+		expect(
+			isRuntimeUiCredentials({
+				...credential,
+				handoff_url:
+					"https://other.example/openclaw/#bootstrapToken=one-time-token&bootstrapProfile=owner",
+			}),
+		).toBe(false);
 	});
 });
 

--- a/packages/shared/src/api/deploy.ts
+++ b/packages/shared/src/api/deploy.ts
@@ -81,12 +81,13 @@ export function isRuntimeUiCredentials(value: unknown): value is RuntimeUiCreden
 		typeof value.token === "string" &&
 		Boolean(value.token) &&
 		typeof value.handoff_url === "string" &&
-		isOpenClawBrowserHandoff(value.handoff_url, value.url) &&
+		isOpenClawLaunchHandoff(value.handoff_url, value.url, value.token) &&
 		isCleanRuntimeUiUrl(value.url)
 	);
 }
 
-function isOpenClawBrowserHandoff(handoff: string, endpoint: string): boolean {
+function isOpenClawLaunchHandoff(handoff: string, endpoint: string, token: string): boolean {
+	if (handoff === `${endpoint}#token=${encodeURIComponent(token)}`) return true;
 	try {
 		const target = new URL(handoff);
 		const cleanEndpoint = new URL(endpoint);

--- a/packages/shared/src/api/deploy.ts
+++ b/packages/shared/src/api/deploy.ts
@@ -81,9 +81,29 @@ export function isRuntimeUiCredentials(value: unknown): value is RuntimeUiCreden
 		typeof value.token === "string" &&
 		Boolean(value.token) &&
 		typeof value.handoff_url === "string" &&
-		value.handoff_url === `${value.url}#token=${encodeURIComponent(value.token)}` &&
+		isOpenClawBrowserHandoff(value.handoff_url, value.url) &&
 		isCleanRuntimeUiUrl(value.url)
 	);
+}
+
+function isOpenClawBrowserHandoff(handoff: string, endpoint: string): boolean {
+	try {
+		const target = new URL(handoff);
+		const cleanEndpoint = new URL(endpoint);
+		const fragment = new URLSearchParams(target.hash.slice(1));
+		const entries = [...fragment.entries()];
+		target.hash = "";
+		return (
+			target.href === cleanEndpoint.href &&
+			entries.length === 2 &&
+			new Set(entries.map(([key]) => key)).size === 2 &&
+			typeof fragment.get("bootstrapToken") === "string" &&
+			Boolean(fragment.get("bootstrapToken")) &&
+			fragment.get("bootstrapProfile") === "owner"
+		);
+	} catch {
+		return false;
+	}
 }
 
 function isCleanRuntimeUiUrl(value: string): boolean {


### PR DESCRIPTION
## Summary

- prove Agent Plugins 1.0.0 support with an isolated native lifecycle canary instead of a version, SHA, command-presence, or stderr heuristic
- require OpenClaw to report `format=bundle` and `bundleFormat=agent`, separating runtime capability absence from desired-package incompatibility
- keep Hermes on the same verified tree digest path
- remove the retired device-auth-disable projection and validate the official owner bootstrap handoff shape
- accept only that official bootstrap or the exact existing shared-token launch fallback bound to the current endpoint and token
- bump the CLI package to the unused `0.13.89`

Hosted control-plane counterpart: https://github.com/Clawdi-AI/clawdi-hosted/pull/1766

## Verification

- Docker workspace typecheck: 4/4
- prior full clean suites: Web 1042, Shared 76, Sidecar 81, CLI 1707 passed with 4 existing skips
- post-refactor focused Docker suite: 374 passed
- fallback follow-up: Shared typecheck and 76 tests; Web typecheck, 5 focused tests, and OSS build
- touched-file Biome and publish-manifest checks passed
- real OpenClaw binary matrix:
  - `2026.7.1-2` misclassified the Agent Plugin canary as `bundleFormat=claude` and is rejected
  - `2026.8.1-beta.2` completed the Agent Plugin lifecycle and issued the official browser owner bootstrap
- `git diff --check` passed

No production or tenant operation was performed.