### PR TITLE
feat: delete synced sessions

### DIFF
--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -76,8 +76,8 @@ export function SessionDetailContent({
 		: "/sessions";
 	const deleteSession = $api.useMutation("delete", "/v1/sessions/{session_id}", {
 		onSuccess: () => {
-			toast.success("Session deleted", {
-				description: "The cloud copy and share link were removed.",
+			toast.success("Cloud Session permanently deleted", {
+				description: "Local data and extracted Memories remain. This Session will not sync again.",
 			});
 			void queryClient.invalidateQueries({
 				queryKey: ["get", "/v1/sessions"],
@@ -370,18 +370,20 @@ export function SessionDetailContent({
 					<div className="flex items-center gap-2">
 						<SessionShareControls sessionId={session.id} isShared={session.is_shared ?? false} />
 						<ConfirmAction
-							title="Delete this synced session?"
+							title="Permanently delete this cloud Session?"
 							description={
 								<>
-									<p>This removes the cloud copy and its share link.</p>
-									<p>Memories extracted from this session will remain.</p>
 									<p>
-										If the session still exists locally, <code>clawdi push</code> can sync it again
-										later.
+										This permanently deletes the cloud Session, its history, and all sharing access.
+									</p>
+									<p>Local agent files remain untouched, but this Session will never sync again.</p>
+									<p>
+										Extracted account-level Memories remain, with this Session&apos;s provenance
+										removed.
 									</p>
 								</>
 							}
-							confirmLabel="Delete session"
+							confirmLabel="Permanently delete"
 							destructive
 							onConfirm={onDelete}
 						>

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -96,8 +96,7 @@ export function SessionDetailContent({
 			toast.error("Couldn't delete session", { description: normalizeApiError(error) });
 		},
 	});
-	const onDelete = () =>
-		deleteSession.mutateAsync({ params: { path: { session_id: sessionId } } });
+	const onDelete = () => deleteSession.mutateAsync({ params: { path: { session_id: sessionId } } });
 
 	const {
 		data: session,
@@ -369,35 +368,32 @@ export function SessionDetailContent({
 				}
 				actions={
 					<div className="flex items-center gap-2">
-						<SessionShareControls
-							sessionId={session.id}
-							isShared={session.is_shared ?? false}
-						/>
+						<SessionShareControls sessionId={session.id} isShared={session.is_shared ?? false} />
 						<ConfirmAction
-								title="Delete this synced session?"
-								description={
-									<>
-										<p>This removes the cloud copy and its share link.</p>
-										<p>Memories extracted from this session will remain.</p>
-										<p>
-											If the session still exists locally, a future local <code>clawdi push</code> can
-											sync it again.
-										</p>
-									</>
-								}
-								confirmLabel="Delete session"
-								destructive
-								onConfirm={onDelete}
+							title="Delete this synced session?"
+							description={
+								<>
+									<p>This removes the cloud copy and its share link.</p>
+									<p>Memories extracted from this session will remain.</p>
+									<p>
+										If the session still exists locally, <code>clawdi push</code> can sync it again
+										later.
+									</p>
+								</>
+							}
+							confirmLabel="Delete session"
+							destructive
+							onConfirm={onDelete}
+						>
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={deleteSession.isPending}
+								className="w-fit shrink-0 text-destructive hover:text-destructive"
 							>
-								<Button
-									variant="outline"
-									size="sm"
-									disabled={deleteSession.isPending}
-									className="w-fit shrink-0 text-destructive hover:text-destructive"
-								>
-									<Trash2 />
-									Delete
-								</Button>
+								<Trash2 />
+								Delete
+							</Button>
 						</ConfirmAction>
 					</div>
 				}

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "@tanstack/react-router";
 import {
 	ArrowDown,
 	ArrowDownNarrowWide,
@@ -8,9 +9,11 @@ import {
 	Clock,
 	Hash,
 	MessageSquare,
+	Trash2,
 	Zap,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { AgentInline } from "@/components/dashboard/agent-label";
@@ -27,11 +30,12 @@ import { SessionSidebar } from "@/components/sessions/session-sidebar";
 import { SessionShareControls } from "@/components/sessions/share-controls";
 import { TimeTooltip } from "@/components/time-tooltip";
 import { Button } from "@/components/ui/button";
+import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { agentDeploymentRouteQuery, agentSectionHref } from "@/lib/agent-routes";
 import { ApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
-import { isApiNotFoundError } from "@/lib/api-errors";
+import { isApiNotFoundError, normalizeApiError } from "@/lib/api-errors";
 import type { SessionMessage } from "@/lib/api-schemas";
 import { useCurrentUser } from "@/lib/auth-client";
 import { formatDuration } from "@/lib/format";
@@ -41,6 +45,7 @@ import {
 	SESSION_DETAIL_STALE_MS,
 	SESSION_MESSAGES_GC_MS,
 	SESSION_MESSAGES_STALE_MS,
+	sessionDetailQueryKey,
 } from "@/lib/session-queries";
 import { useCommittedLocation } from "@/lib/use-committed-location";
 import { useIsomorphicLayoutEffect } from "@/lib/use-isomorphic-layout-effect";
@@ -59,6 +64,8 @@ export function SessionDetailContent({
 }) {
 	const api = useApi();
 	const $api = useOpenApi();
+	const queryClient = useQueryClient();
+	const router = useRouter();
 	const { user } = useCurrentUser();
 	// Committed-match search, not the pending target: this page stays mounted
 	// while an outgoing navigation loads, and its links must keep pointing at
@@ -67,6 +74,30 @@ export function SessionDetailContent({
 	const sessionsHref = agentId
 		? agentSectionHref(agentId, "sessions", agentDeploymentRouteQuery(routeSearch))
 		: "/sessions";
+	const deleteSession = $api.useMutation("delete", "/v1/sessions/{session_id}", {
+		onSuccess: () => {
+			toast.success("Session deleted", {
+				description: "The cloud copy and share link were removed.",
+			});
+			void queryClient.invalidateQueries({
+				queryKey: ["get", "/v1/sessions"],
+				refetchType: "none",
+			});
+			void queryClient.invalidateQueries({
+				queryKey: ["get", "/v1/dashboard/stats"],
+				refetchType: "none",
+			});
+			queryClient.removeQueries({ queryKey: sessionDetailQueryKey(sessionId), exact: true });
+			queryClient.removeQueries({ queryKey: ["session-messages", sessionId] });
+			queryClient.removeQueries({ queryKey: ["session-permissions", sessionId] });
+			void router.navigate({ href: sessionsHref });
+		},
+		onError: (error) => {
+			toast.error("Couldn't delete session", { description: normalizeApiError(error) });
+		},
+	});
+	const onDelete = () =>
+		deleteSession.mutateAsync({ params: { path: { session_id: sessionId } } });
 
 	const {
 		data: session,
@@ -337,7 +368,38 @@ export function SessionDetailContent({
 					</DetailMeta>
 				}
 				actions={
-					<SessionShareControls sessionId={session.id} isShared={session.is_shared ?? false} />
+					<div className="flex items-center gap-2">
+						<SessionShareControls
+							sessionId={session.id}
+							isShared={session.is_shared ?? false}
+						/>
+						<ConfirmAction
+								title="Delete this synced session?"
+								description={
+									<>
+										<p>This removes the cloud copy and its share link.</p>
+										<p>Memories extracted from this session will remain.</p>
+										<p>
+											If the session still exists locally, a future local <code>clawdi push</code> can
+											sync it again.
+										</p>
+									</>
+								}
+								confirmLabel="Delete session"
+								destructive
+								onConfirm={onDelete}
+							>
+								<Button
+									variant="outline"
+									size="sm"
+									disabled={deleteSession.isPending}
+									className="w-fit shrink-0 text-destructive hover:text-destructive"
+								>
+									<Trash2 />
+									Delete
+								</Button>
+						</ConfirmAction>
+					</div>
 				}
 			/>
 

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -80,6 +80,14 @@ export function SessionDetailContent({
 				description: "Local data and extracted Memories remain. This Session will not sync again.",
 			});
 			void queryClient.invalidateQueries({
+				queryKey: ["get", "/v1/memories"],
+				refetchType: "none",
+			});
+			void queryClient.invalidateQueries({
+				queryKey: ["get", "/v1/memories/{memory_id}"],
+				refetchType: "none",
+			});
+			void queryClient.invalidateQueries({
 				queryKey: ["get", "/v1/sessions"],
 				refetchType: "none",
 			});

--- a/backend/alembic/versions/d1a4e7c9b2f6_add_session_sync_suppressions.py
+++ b/backend/alembic/versions/d1a4e7c9b2f6_add_session_sync_suppressions.py
@@ -1,0 +1,39 @@
+"""Add durable Session sync suppressions.
+
+Revision ID: d1a4e7c9b2f6
+Revises: c3e8f1a6d2b9
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "d1a4e7c9b2f6"
+down_revision: str | Sequence[str] | None = "c3e8f1a6d2b9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "session_sync_suppressions",
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("local_session_id", sa.String(length=200), nullable=False),
+        sa.PrimaryKeyConstraint(
+            "user_id",
+            "local_session_id",
+            name="pk_session_sync_suppressions",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("session_sync_suppressions")

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -136,6 +136,17 @@ class AgentEnvironment(Base, TimestampMixin):
     )
 
 
+class SessionSyncSuppression(Base):
+    __tablename__ = "session_sync_suppressions"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    local_session_id: Mapped[str] = mapped_column(String(200), primary_key=True)
+
+
 class Session(Base, TimestampMixin):
     __tablename__ = "sessions"
     __table_args__ = (

--- a/backend/app/routes/memories.py
+++ b/backend/app/routes/memories.py
@@ -62,11 +62,13 @@ async def attach_source_machines(
                 pass
         raw_session_id = item.get("source_session_id")
         if not isinstance(raw_session_id, str):
+            if raw_session_id is not None:
+                item["source_session_id"] = None
             continue
         try:
             sids.add(UUID(raw_session_id))
         except ValueError:
-            continue
+            item["source_session_id"] = None
     if not environment_ids and not sids:
         return items
     machine_by_environment: dict[UUID, str | None] = {}
@@ -102,6 +104,20 @@ async def attach_source_machines(
             for session_id, environment_id, machine_name in session_rows
         }
     for item in items:
+        source_session: tuple[UUID | None, str | None] | None = None
+        raw_session_id = item.get("source_session_id")
+        if isinstance(raw_session_id, str):
+            try:
+                session_id = UUID(raw_session_id)
+            except ValueError:
+                item["source_session_id"] = None
+            else:
+                source_session = by_session.get(session_id)
+                if source_session is None:
+                    item["source_session_id"] = None
+                else:
+                    item["source_session_id"] = str(session_id)
+
         raw_environment_id = item.get("source_environment_id")
         if isinstance(raw_environment_id, str):
             try:
@@ -112,16 +128,12 @@ async def attach_source_machines(
                 item["source_environment_id"] = str(environment_id)
                 item["source_machine_name"] = machine_by_environment[environment_id]
                 continue
-        raw_session_id = item.get("source_session_id")
-        if not isinstance(raw_session_id, str):
-            continue
-        try:
-            session_id = UUID(raw_session_id)
-        except ValueError:
-            continue
-        environment_id, machine_name = by_session.get(session_id, (None, None))
-        item["source_environment_id"] = str(environment_id) if environment_id is not None else None
-        item["source_machine_name"] = machine_name
+        if source_session is not None:
+            environment_id, machine_name = source_session
+            item["source_environment_id"] = (
+                str(environment_id) if environment_id is not None else None
+            )
+            item["source_machine_name"] = machine_name
     return items
 
 

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -20,7 +20,7 @@ from fastapi import (
     status,
 )
 from pydantic import BaseModel, Field, JsonValue, TypeAdapter, ValidationError, field_validator
-from sqlalchemy import case, func, or_, select, text
+from sqlalchemy import case, func, or_, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -38,6 +38,7 @@ from app.core.database import get_session, runtime_snapshot_session
 from app.models.agent_project_binding import AgentProjectBinding
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
+from app.models.memory import Memory
 from app.models.session import AgentEnvironment, Session
 from app.models.session_permission import (
     PERMISSION_KIND_LINK,
@@ -130,6 +131,8 @@ _MAX_RUNTIME_OBSERVED_BYTES = 64 * 1024
 _MAX_AGENT_AVATAR_BYTES = 2 * 1024 * 1024
 _AGENT_AVATAR_PREFIX = "agent-avatars/"
 _AGENT_AVATAR_KEY_RE = re.compile(r"^agent-avatars/[0-9a-f]{32}\.(png|jpg|webp)$")
+_SESSION_LOCAL_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._\-]{0,199}$"
+_SESSION_LOCAL_ID_RE = re.compile(_SESSION_LOCAL_ID_PATTERN)
 _RUNTIME_OBSERVED_STALE_AFTER = timedelta(seconds=90)
 _HEARTBEAT_FRESHNESS_WRITE_INTERVAL = timedelta(seconds=40)
 _AGENT_DISCONNECTED_ERROR_CODE = "agent_disconnected"
@@ -1332,6 +1335,38 @@ async def _delete_managed_avatar_key_best_effort(key: str | None) -> None:
         await file_store.delete(key)
     except Exception:
         log.warning("agent_avatar_delete_failed key=%s", key, exc_info=True)
+
+
+async def _delete_session_content_best_effort(key: str | None) -> None:
+    if not key:
+        return
+    try:
+        await file_store.delete(key)
+    except Exception:
+        log.warning("session_content_delete_failed file_key=%s", key, exc_info=True)
+
+
+def _session_generation_file_key(session: Session) -> str:
+    return f"sessions/{session.user_id}/{session.id}.json"
+
+
+def _session_content_cleanup_keys(session: Session) -> set[str]:
+    """Return only exact object keys owned by this Session generation."""
+    keys = {_session_generation_file_key(session)}
+    if _SESSION_LOCAL_ID_RE.fullmatch(session.local_session_id):
+        keys.add(f"sessions/{session.user_id}/{session.local_session_id}.json")
+    if session.file_key and session.file_key not in keys:
+        log.warning(
+            "session_content_cleanup_skipped_unrecognized file_key=%s session_id=%s",
+            session.file_key,
+            session.id,
+        )
+    return keys
+
+
+async def _delete_session_content_keys_best_effort(keys: set[str]) -> None:
+    for key in sorted(keys):
+        await _delete_session_content_best_effort(key)
 
 
 async def _next_environment_sort_order(db: AsyncSession, user_id: UUID) -> int:
@@ -2722,11 +2757,46 @@ async def get_session_detail(
     )
 
 
+@router.delete("/sessions/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_session(
+    session_id: UUID,
+    auth: AuthContext = Depends(require_web_auth),
+    db: AsyncSession = Depends(get_session),
+) -> None:
+    session = (
+        await db.execute(
+            select(Session)
+            .where(
+                Session.id == session_id,
+                Session.user_id == auth.user_id,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if session is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
+
+    content_keys = _session_content_cleanup_keys(session)
+    await db.execute(
+        update(Memory)
+        .where(
+            Memory.user_id == auth.user_id,
+            Memory.source_session_id == session.id,
+        )
+        .values(source_session_id=None)
+    )
+    await db.delete(session)
+    await db.commit()
+
+    await _delete_session_content_keys_best_effort(content_keys)
+
+
 @router.post("/sessions/{local_session_id}/upload")
 async def upload_session_content(
-    # Constrained to safe filename chars so it cannot escape the
-    # `sessions/{user_id}/` prefix in the file-store key below.
-    local_session_id: str = Path(..., pattern=r"^[A-Za-z0-9][A-Za-z0-9._\-]{0,199}$"),
+    # Constrained to the legacy object-name alphabet. Session.id owns new
+    # object keys; local_session_id remains a lookup key and a safely derived
+    # legacy cleanup candidate.
+    local_session_id: str = Path(..., pattern=_SESSION_LOCAL_ID_PATTERN),
     file: UploadFile = File(...),
     auth: AuthContext = Depends(require_scope("sessions:write")),
     db: AsyncSession = Depends(get_session),
@@ -2743,7 +2813,7 @@ async def upload_session_content(
         # treated as "not yours" — without this an orphaned
         # session would be a silent shared write target.
         stmt = stmt.where(Session.environment_id == bound_env)
-    result = await db.execute(stmt)
+    result = await db.execute(stmt.with_for_update())
     session = result.scalar_one_or_none()
     if not session:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
@@ -2778,7 +2848,12 @@ async def upload_session_content(
     # hash on disk matches the hash in the row.
     content_hash = hashlib.sha256(data).hexdigest()
 
-    fk = f"sessions/{auth.user_id}/{local_session_id}.json"
+    # The row id is the storage generation. Recreating the same local_session_id
+    # gets a new row id, so delayed cleanup from dashboard deletion cannot touch
+    # the recreated session's content.
+    fk = _session_generation_file_key(session)
+    old_file_key = session.file_key
+    old_cleanup_keys = _session_content_cleanup_keys(session) - {fk}
     await file_store.put(fk, data)
 
     session.file_key = fk
@@ -2803,7 +2878,14 @@ async def upload_session_content(
             local_session_id,
         )
 
-    await db.commit()
+    try:
+        await db.commit()
+    except Exception:
+        if old_file_key != fk:
+            await _delete_session_content_best_effort(fk)
+        raise
+
+    await _delete_session_content_keys_best_effort(old_cleanup_keys)
 
     return SessionUploadResponse(status="uploaded", file_key=fk, content_hash=content_hash)
 

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -39,7 +39,7 @@ from app.models.agent_project_binding import AgentProjectBinding
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
 from app.models.memory import Memory
-from app.models.session import AgentEnvironment, Session
+from app.models.session import AgentEnvironment, Session, SessionSyncSuppression
 from app.models.session_permission import (
     PERMISSION_KIND_LINK,
     PERMISSION_KINDS,
@@ -132,7 +132,6 @@ _MAX_AGENT_AVATAR_BYTES = 2 * 1024 * 1024
 _AGENT_AVATAR_PREFIX = "agent-avatars/"
 _AGENT_AVATAR_KEY_RE = re.compile(r"^agent-avatars/[0-9a-f]{32}\.(png|jpg|webp)$")
 _SESSION_LOCAL_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._\-]{0,199}$"
-_SESSION_LOCAL_ID_RE = re.compile(_SESSION_LOCAL_ID_PATTERN)
 _RUNTIME_OBSERVED_STALE_AFTER = timedelta(seconds=90)
 _HEARTBEAT_FRESHNESS_WRITE_INTERVAL = timedelta(seconds=40)
 _AGENT_DISCONNECTED_ERROR_CODE = "agent_disconnected"
@@ -1337,36 +1336,8 @@ async def _delete_managed_avatar_key_best_effort(key: str | None) -> None:
         log.warning("agent_avatar_delete_failed key=%s", key, exc_info=True)
 
 
-async def _delete_session_content_best_effort(key: str | None) -> None:
-    if not key:
-        return
-    try:
-        await file_store.delete(key)
-    except Exception:
-        log.warning("session_content_delete_failed file_key=%s", key, exc_info=True)
-
-
-def _session_generation_file_key(session: Session) -> str:
-    return f"sessions/{session.user_id}/{session.id}.json"
-
-
-def _session_content_cleanup_keys(session: Session) -> set[str]:
-    """Return only exact object keys owned by this Session generation."""
-    keys = {_session_generation_file_key(session)}
-    if _SESSION_LOCAL_ID_RE.fullmatch(session.local_session_id):
-        keys.add(f"sessions/{session.user_id}/{session.local_session_id}.json")
-    if session.file_key and session.file_key not in keys:
-        log.warning(
-            "session_content_cleanup_skipped_unrecognized file_key=%s session_id=%s",
-            session.file_key,
-            session.id,
-        )
-    return keys
-
-
-async def _delete_session_content_keys_best_effort(keys: set[str]) -> None:
-    for key in sorted(keys):
-        await _delete_session_content_best_effort(key)
+def _session_content_key(session: Session) -> str:
+    return f"sessions/{session.user_id}/{session.local_session_id}.json"
 
 
 async def _next_environment_sort_order(db: AsyncSession, user_id: UUID) -> int:
@@ -2078,7 +2049,12 @@ async def batch_create_sessions(
     """
     if not body.sessions:
         return SessionBatchResponse(
-            created=0, updated=0, unchanged=0, needs_content=[], rejected=[]
+            created=0,
+            updated=0,
+            unchanged=0,
+            needs_content=[],
+            rejected=[],
+            suppressed=[],
         )
 
     clamped_duration_ids = [
@@ -2172,7 +2148,7 @@ async def batch_create_sessions(
     # then the upsert overwrites again. Locking the rows for the rest
     # of this transaction makes the (read, check, write) sequence
     # atomic from the perspective of any other writer.
-    incoming_ids = [s.local_session_id for s in body.sessions]
+    incoming_ids = list(dict.fromkeys(s.local_session_id for s in body.sessions))
     existing_rows = (
         await db.execute(
             select(
@@ -2185,10 +2161,39 @@ async def batch_create_sessions(
                 Session.user_id == auth.user_id,
                 Session.local_session_id.in_(incoming_ids),
             )
+            .order_by(Session.local_session_id)
             .with_for_update()
         )
     ).all()
-    existing_by_id = {row.local_session_id: row for row in existing_rows}
+    suppressed_ids = set(
+        (
+            await db.execute(
+                select(SessionSyncSuppression.local_session_id).where(
+                    SessionSyncSuppression.user_id == auth.user_id,
+                    SessionSyncSuppression.local_session_id.in_(incoming_ids),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    suppressed = [local_id for local_id in incoming_ids if local_id in suppressed_ids]
+    active_sessions = [s for s in body.sessions if s.local_session_id not in suppressed_ids]
+    active_existing_rows = [
+        row for row in existing_rows if row.local_session_id not in suppressed_ids
+    ]
+    if not active_sessions:
+        await db.commit()
+        return SessionBatchResponse(
+            created=0,
+            updated=0,
+            unchanged=0,
+            needs_content=[],
+            rejected=[],
+            suppressed=suppressed,
+        )
+
+    existing_by_id = {row.local_session_id: row for row in active_existing_rows}
 
     # Bound-key cross-env steal guard. Reject if any pre-existing row
     # belongs to an env other than the one the caller is bound to.
@@ -2196,7 +2201,7 @@ async def batch_create_sessions(
         bound = auth.api_key.environment_id
         stolen = [
             row.local_session_id
-            for row in existing_rows
+            for row in active_existing_rows
             if row.environment_id is not None and row.environment_id != bound
         ]
         if stolen:
@@ -2225,10 +2230,10 @@ async def batch_create_sessions(
     # to `/v1/sessions/{local_session_id}/upload`, which resolves
     # the row by `local_session_id` alone and stamps the new bytes
     # onto the OTHER env's row. Cross-env data corruption.
-    incoming_env_by_id = {s.local_session_id: s.environment_id for s in body.sessions}
+    incoming_env_by_id = {s.local_session_id: s.environment_id for s in active_sessions}
     mismatched = [
         row.local_session_id
-        for row in existing_rows
+        for row in active_existing_rows
         if (
             row.environment_id is not None
             and incoming_env_by_id.get(row.local_session_id) is not None
@@ -2272,7 +2277,7 @@ async def batch_create_sessions(
             "status": s.status,
             "content_hash": s.content_hash,
         }
-        for s in body.sessions
+        for s in active_sessions
     ]
 
     insert_stmt = pg_insert(Session).values(rows)
@@ -2410,7 +2415,7 @@ async def batch_create_sessions(
     needs_content: list[str] = []
     rejected: list[str] = []
     upserted_ids = {row[0] for row in upserted_id_rows}
-    for s in body.sessions:
+    for s in active_sessions:
         if s.local_session_id not in upserted_ids:
             # Upsert filtered this row out at the conflict-WHERE
             # step (cross-env race window: pre-fetch saw no row,
@@ -2446,6 +2451,7 @@ async def batch_create_sessions(
         unchanged=unchanged,
         needs_content=needs_content,
         rejected=rejected,
+        suppressed=suppressed,
     )
 
 
@@ -2776,26 +2782,41 @@ async def delete_session(
     if session is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
 
-    content_keys = _session_content_cleanup_keys(session)
-    await db.execute(
-        update(Memory)
-        .where(
-            Memory.user_id == auth.user_id,
-            Memory.source_session_id == session.id,
-        )
-        .values(source_session_id=None)
-    )
-    await db.delete(session)
-    await db.commit()
+    try:
+        await file_store.delete(_session_content_key(session))
+    except Exception:
+        log.exception("session_content_delete_failed session_id=%s", session.id)
+        await db.rollback()
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Session storage is temporarily unavailable. Please retry.",
+        ) from None
 
-    await _delete_session_content_keys_best_effort(content_keys)
+    try:
+        suppression = pg_insert(SessionSyncSuppression).values(
+            user_id=auth.user_id,
+            local_session_id=session.local_session_id,
+        )
+        await db.execute(suppression.on_conflict_do_nothing())
+        await db.execute(
+            update(Memory)
+            .where(
+                Memory.user_id == auth.user_id,
+                Memory.source_session_id == session.id,
+            )
+            .values(source_session_id=None)
+        )
+        await db.delete(session)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
 
 
 @router.post("/sessions/{local_session_id}/upload")
 async def upload_session_content(
-    # Constrained to the legacy object-name alphabet. Session.id owns new
-    # object keys; local_session_id remains a lookup key and a safely derived
-    # legacy cleanup candidate.
+    # Constrained to safe filename chars so the legacy object key remains
+    # inside the user's Session prefix.
     local_session_id: str = Path(..., pattern=_SESSION_LOCAL_ID_PATTERN),
     file: UploadFile = File(...),
     auth: AuthContext = Depends(require_scope("sessions:write")),
@@ -2848,12 +2869,7 @@ async def upload_session_content(
     # hash on disk matches the hash in the row.
     content_hash = hashlib.sha256(data).hexdigest()
 
-    # The row id is the storage generation. Recreating the same local_session_id
-    # gets a new row id, so delayed cleanup from dashboard deletion cannot touch
-    # the recreated session's content.
-    fk = _session_generation_file_key(session)
-    old_file_key = session.file_key
-    old_cleanup_keys = _session_content_cleanup_keys(session) - {fk}
+    fk = _session_content_key(session)
     await file_store.put(fk, data)
 
     session.file_key = fk
@@ -2878,14 +2894,7 @@ async def upload_session_content(
             local_session_id,
         )
 
-    try:
-        await db.commit()
-    except Exception:
-        if old_file_key != fk:
-            await _delete_session_content_best_effort(fk)
-        raise
-
-    await _delete_session_content_keys_best_effort(old_cleanup_keys)
+    await db.commit()
 
     return SessionUploadResponse(status="uploaded", file_key=fk, content_hash=content_hash)
 

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -2141,7 +2141,9 @@ async def batch_create_sessions(
     # env-A), and the upsert's ON CONFLICT path then overwrites
     # environment_id from B to A. Bound key effectively steals the row.
     #
-    # `with_for_update()` closes the TOCTOU between the env-binding
+    # Lock in deterministic id order so concurrent batches do not deadlock.
+    # `with_for_update()` also serializes this read with Session upload/delete
+    # and closes the TOCTOU between the env-binding
     # check below and the upsert that follows. Without the row lock,
     # a concurrent JWT (dashboard) write could rebind environment_id
     # in the gap; the bound-key check would pass on the stale read,

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -445,6 +445,9 @@ class SessionBatchResponse(BaseModel):
     # client treated "id not in needs_content" as success and
     # wrote a stale lock — the loser never retried.
     rejected: list[str] = []
+    # Durable dashboard deletions. Callers must not upload content for
+    # these ids, but should cache the current local hash as converged.
+    suppressed: list[str] = []
 
 
 class SessionListItemResponse(BaseModel):

--- a/backend/tests/test_session_deletion.py
+++ b/backend/tests/test_session_deletion.py
@@ -11,7 +11,9 @@ from fastapi import Request
 from sqlalchemy import event, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from app.core.auth import AuthContext
+from app.core.auth import AuthContext, get_auth
+from app.main import app
+from app.models.api_key import ApiKey
 from app.models.memory import Memory
 from app.models.session import Session, SessionSyncSuppression
 from app.models.session_permission import PERMISSION_KIND_LINK, SessionPermission
@@ -148,6 +150,17 @@ async def test_delete_session_is_durable_and_preserves_memories(
     permission_id = permission.id
     memory_id = memory.id
     assert (await anon_client.get(f"/v1/public/sessions/{session_id}")).status_code == 200
+
+    dashboard_auth = app.dependency_overrides[get_auth]
+
+    async def cli_auth() -> AuthContext:
+        return AuthContext(user=seed_user, api_key=ApiKey(user_id=seed_user.id))
+
+    app.dependency_overrides[get_auth] = cli_auth
+    try:
+        assert (await client.delete(f"/v1/sessions/{session_id}")).status_code == 403
+    finally:
+        app.dependency_overrides[get_auth] = dashboard_auth
 
     response = await client.delete(f"/v1/sessions/{session_id}")
 

--- a/backend/tests/test_session_deletion.py
+++ b/backend/tests/test_session_deletion.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from datetime import UTC, datetime
+from io import BytesIO
+
+import httpx
+import pytest
+from fastapi import UploadFile
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.auth import AuthContext, get_auth
+from app.main import app
+from app.models.api_key import ApiKey
+from app.models.memory import Memory
+from app.models.session import Session
+from app.models.session_permission import PERMISSION_KIND_LINK, SessionPermission
+from app.routes.memories import attach_source_machines
+from app.services.file_store import FileStore
+
+
+class _DeleteTrackingFileStore:
+    def __init__(self, delegate: FileStore, *, fail_delete: bool = False) -> None:
+        self._delegate = delegate
+        self._fail_delete = fail_delete
+        self.deleted: list[str] = []
+
+    async def put(self, key: str, data: bytes, content_type: str | None = None) -> None:
+        await self._delegate.put(key, data, content_type)
+
+    async def get(self, key: str) -> bytes:
+        return await self._delegate.get(key)
+
+    async def delete(self, key: str) -> None:
+        self.deleted.append(key)
+        if self._fail_delete:
+            raise RuntimeError("test file-store delete failure")
+        await self._delegate.delete(key)
+
+    async def exists(self, key: str) -> bool:
+        return await self._delegate.exists(key)
+
+
+class _BlockingPutFileStore(_DeleteTrackingFileStore):
+    def __init__(
+        self,
+        delegate: FileStore,
+        *,
+        put_started: asyncio.Event,
+        release_put: asyncio.Event,
+    ) -> None:
+        super().__init__(delegate)
+        self._put_started = put_started
+        self._release_put = release_put
+
+    async def put(self, key: str, data: bytes, content_type: str | None = None) -> None:
+        self._put_started.set()
+        await self._release_put.wait()
+        await super().put(key, data, content_type)
+
+
+async def _create_session(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    local_session_id: str,
+    file_key: str | None = None,
+) -> Session:
+    now = datetime.now(UTC)
+    session = Session(
+        user_id=user_id,
+        local_session_id=local_session_id,
+        started_at=now,
+        last_activity_at=now,
+        file_key=file_key,
+    )
+    db.add(session)
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def _register_env(client: httpx.AsyncClient) -> str:
+    response = await client.post(
+        "/v1/environments",
+        json={
+            "machine_id": f"session-delete-{uuid.uuid4().hex}",
+            "machine_name": "Session deletion test",
+            "agent_type": "claude-code",
+            "agent_version": "test",
+            "os": "linux",
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_delete_session_requires_dashboard_owner_and_hides_visibility(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+) -> None:
+    owned = await _create_session(
+        db_session,
+        user_id=seed_user.id,
+        local_session_id=f"owned-{uuid.uuid4().hex}",
+    )
+    foreign = await _create_session(
+        db_session,
+        user_id=uuid.uuid4(),
+        local_session_id=f"foreign-{uuid.uuid4().hex}",
+    )
+
+    previous_auth = app.dependency_overrides[get_auth]
+
+    async def cli_auth() -> AuthContext:
+        return AuthContext(user=seed_user, api_key=ApiKey(user_id=seed_user.id))
+
+    app.dependency_overrides[get_auth] = cli_auth
+    try:
+        cli_response = await client.delete(f"/v1/sessions/{owned.id}")
+    finally:
+        app.dependency_overrides[get_auth] = previous_auth
+
+    assert cli_response.status_code == 403
+    assert await db_session.get(Session, owned.id) is not None
+    assert (await client.delete(f"/v1/sessions/{foreign.id}")).status_code == 404
+    assert (await client.delete(f"/v1/sessions/{uuid.uuid4()}")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_session_cascades_permission_clears_memory_and_deletes_content(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+) -> None:
+    from app.routes import sessions as sessions_route
+
+    local_session_id = f"delete-{uuid.uuid4().hex}"
+    file_key = f"sessions/{seed_user.id}/{local_session_id}.json"
+    await sessions_route.file_store.put(file_key, b"[]")
+    session = await _create_session(
+        db_session,
+        user_id=seed_user.id,
+        local_session_id=local_session_id,
+        file_key=file_key,
+    )
+    permission = SessionPermission(
+        session_id=session.id,
+        kind=PERMISSION_KIND_LINK,
+        role="viewer",
+        invited_by=seed_user.id,
+        accepted_at=datetime.now(UTC),
+    )
+    memory = Memory(
+        user_id=seed_user.id,
+        content="Keep this extracted memory",
+        source="session",
+        source_session_id=session.id,
+    )
+    db_session.add_all([permission, memory])
+    await db_session.commit()
+    permission_id = permission.id
+    memory_id = memory.id
+
+    response = await client.delete(f"/v1/sessions/{session.id}")
+
+    assert response.status_code == 204
+    assert response.content == b""
+    assert await db_session.get(Session, session.id) is None
+    assert (
+        await db_session.scalar(
+            select(SessionPermission.id).where(SessionPermission.id == permission_id)
+        )
+        is None
+    )
+    preserved_memory = (
+        await db_session.execute(
+            select(Memory.content, Memory.source_session_id).where(Memory.id == memory_id)
+        )
+    ).one()
+    assert preserved_memory == ("Keep this extracted memory", None)
+    assert not await sessions_route.file_store.exists(file_key)
+
+
+@pytest.mark.asyncio
+async def test_delete_session_commits_when_content_cleanup_fails(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from app.routes import sessions as sessions_route
+
+    local_session_id = f"cleanup-failure-{uuid.uuid4().hex}"
+    file_key = f"sessions/{seed_user.id}/{local_session_id}.json"
+    session = await _create_session(
+        db_session,
+        user_id=seed_user.id,
+        local_session_id=local_session_id,
+        file_key=file_key,
+    )
+    store = _DeleteTrackingFileStore(sessions_route.file_store, fail_delete=True)
+    monkeypatch.setattr(sessions_route, "file_store", store)
+    caplog.set_level(logging.WARNING, logger="app.routes.sessions")
+
+    response = await client.delete(f"/v1/sessions/{session.id}")
+
+    assert response.status_code == 204
+    assert await db_session.get(Session, session.id) is None
+    assert set(store.deleted) == {
+        file_key,
+        f"sessions/{seed_user.id}/{session.id}.json",
+    }
+    assert "session_content_delete_failed" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_upload_keys_do_not_reuse_deleted_session_generation(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    engine,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.routes import sessions as sessions_route
+
+    environment_id = await _register_env(client)
+    local_session_id = f"generation-{uuid.uuid4().hex}"
+    started_at = datetime.now(UTC).isoformat()
+    batch = await client.post(
+        "/v1/sessions/batch",
+        json={
+            "sessions": [
+                {
+                    "environment_id": environment_id,
+                    "local_session_id": local_session_id,
+                    "started_at": started_at,
+                    "message_count": 1,
+                    "content_hash": "a" * 64,
+                }
+            ]
+        },
+    )
+    assert batch.status_code == 200, batch.text
+    first = await db_session.scalar(
+        select(Session).where(
+            Session.user_id == seed_user.id,
+            Session.local_session_id == local_session_id,
+        )
+    )
+    assert first is not None
+    legacy_key = f"sessions/{seed_user.id}/{local_session_id}.json"
+    await sessions_route.file_store.put(legacy_key, b"old")
+    first.file_key = legacy_key
+    await db_session.commit()
+    store = _DeleteTrackingFileStore(sessions_route.file_store)
+    monkeypatch.setattr(sessions_route, "file_store", store)
+    first_content = b'[{"role":"user","content":"first"}]'
+
+    first_upload = await client.post(
+        f"/v1/sessions/{local_session_id}/upload",
+        files={"file": ("session.json", first_content, "application/json")},
+    )
+
+    assert first_upload.status_code == 200, first_upload.text
+    first_key = first_upload.json()["file_key"]
+    assert first_key == f"sessions/{seed_user.id}/{first.id}.json"
+    assert store.deleted == [legacy_key]
+    assert not await store.exists(legacy_key)
+
+    hash_change = await client.post(
+        "/v1/sessions/batch",
+        json={
+            "sessions": [
+                {
+                    "environment_id": environment_id,
+                    "local_session_id": local_session_id,
+                    "started_at": started_at,
+                    "message_count": 2,
+                    "content_hash": "f" * 64,
+                }
+            ]
+        },
+    )
+    assert hash_change.status_code == 200, hash_change.text
+    assert await db_session.scalar(select(Session.file_key).where(Session.id == first.id)) is None
+    assert await store.exists(first_key)
+    assert (await client.delete(f"/v1/sessions/{first.id}")).status_code == 204
+    recreate = await client.post(
+        "/v1/sessions/batch",
+        json={
+            "sessions": [
+                {
+                    "environment_id": environment_id,
+                    "local_session_id": local_session_id,
+                    "started_at": started_at,
+                    "message_count": 1,
+                    "content_hash": "b" * 64,
+                }
+            ]
+        },
+    )
+    assert recreate.status_code == 200, recreate.text
+    second = await db_session.scalar(
+        select(Session).where(
+            Session.user_id == seed_user.id,
+            Session.local_session_id == local_session_id,
+        )
+    )
+    assert second is not None
+    second_content = b'[{"role":"user","content":"second"}]'
+    second_upload = await client.post(
+        f"/v1/sessions/{local_session_id}/upload",
+        files={"file": ("session.json", second_content, "application/json")},
+    )
+    assert second_upload.status_code == 200, second_upload.text
+    second_key = second_upload.json()["file_key"]
+    assert second.id != first.id
+    assert second_key != first_key
+
+    # Simulate delayed cleanup from the first deletion after recreation.
+    await store.delete(first_key)
+    assert await store.exists(second_key)
+
+    put_started = asyncio.Event()
+    release_put = asyncio.Event()
+    blocking_store = _BlockingPutFileStore(
+        store,
+        put_started=put_started,
+        release_put=release_put,
+    )
+    monkeypatch.setattr(sessions_route, "file_store", blocking_store)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    auth = AuthContext(user=seed_user)
+
+    async def reupload() -> str:
+        async with session_factory() as upload_db:
+            result = await sessions_route.upload_session_content(
+                local_session_id=local_session_id,
+                file=UploadFile(
+                    file=BytesIO(b'[{"role":"user","content":"replacement"}]'),
+                    filename="session.json",
+                ),
+                auth=auth,
+                db=upload_db,
+            )
+            return result.file_key
+
+    async def delete_during_upload() -> None:
+        async with session_factory() as delete_db:
+            await sessions_route.delete_session(second.id, auth=auth, db=delete_db)
+
+    upload_task = asyncio.create_task(reupload())
+    await asyncio.wait_for(put_started.wait(), timeout=5)
+    delete_task = asyncio.create_task(delete_during_upload())
+    await asyncio.sleep(0.05)
+    delete_waited_for_upload = not delete_task.done()
+    release_put.set()
+    uploaded_key, _ = await asyncio.wait_for(
+        asyncio.gather(upload_task, delete_task),
+        timeout=10,
+    )
+
+    assert delete_waited_for_upload
+    assert uploaded_key == second_key
+    async with session_factory() as verify_db:
+        assert await verify_db.get(Session, second.id) is None
+    assert not await blocking_store.exists(second_key)
+
+
+@pytest.mark.asyncio
+async def test_memory_enrichment_clears_unresolvable_external_session_provenance(
+    db_session: AsyncSession,
+    seed_user,
+) -> None:
+    stale_session_id = uuid.uuid4()
+    item = {
+        "id": "mem0-memory",
+        "content": "External memory",
+        "category": "fact",
+        "source": "mem0",
+        "source_session_id": str(stale_session_id),
+        "source_environment_id": None,
+    }
+
+    enriched = await attach_source_machines(db_session, AuthContext(user=seed_user), [item])
+
+    assert enriched[0]["source_session_id"] is None
+    assert enriched[0]["content"] == "External memory"

--- a/backend/tests/test_session_deletion.py
+++ b/backend/tests/test_session_deletion.py
@@ -17,6 +17,7 @@ from app.models.api_key import ApiKey
 from app.models.memory import Memory
 from app.models.session import Session, SessionSyncSuppression
 from app.models.session_permission import PERMISSION_KIND_LINK, SessionPermission
+from app.models.user import User
 from app.routes.memories import attach_source_machines
 from app.schemas.session import SessionBatchRequest
 from app.services.file_store import FileStore
@@ -146,11 +147,23 @@ async def test_delete_session_is_durable_and_preserves_memories(
 
     dashboard_auth = app.dependency_overrides[get_auth]
 
+    other_user = User(
+        id=uuid.uuid4(),
+        clerk_id=f"session-delete-other-{uuid.uuid4().hex}",
+        email="session-delete-other@example.test",
+        name="Other Session User",
+    )
+
+    async def other_user_auth() -> AuthContext:
+        return AuthContext(user=other_user)
+
     async def cli_auth() -> AuthContext:
         return AuthContext(user=seed_user, api_key=ApiKey(user_id=seed_user.id))
 
-    app.dependency_overrides[get_auth] = cli_auth
     try:
+        app.dependency_overrides[get_auth] = other_user_auth
+        assert (await client.delete(f"/v1/sessions/{session_id}")).status_code == 404
+        app.dependency_overrides[get_auth] = cli_auth
         assert (await client.delete(f"/v1/sessions/{session_id}")).status_code == 403
     finally:
         app.dependency_overrides[get_auth] = dashboard_auth
@@ -277,28 +290,27 @@ async def test_delete_serializes_batch_before_suppression_check(
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
     auth = AuthContext(user=seed_user)
     async with session_factory() as delete_db, session_factory() as batch_db:
-        delete_task = asyncio.create_task(
-            sessions_route.delete_session(session.id, auth=auth, db=delete_db)
-        )
-        await asyncio.wait_for(delete_started.wait(), timeout=5)
-        event.listen(engine.sync_engine, "before_cursor_execute", observe_lock_statement)
-        try:
-            batch_task = asyncio.create_task(
-                sessions_route.batch_create_sessions(
-                    _batch_body(environment_id, [local_session_id]),
-                    Request({"type": "http", "headers": []}),
-                    auth=auth,
-                    db=batch_db,
+        async with asyncio.TaskGroup() as tasks:
+            tasks.create_task(sessions_route.delete_session(session.id, auth=auth, db=delete_db))
+            await asyncio.wait_for(delete_started.wait(), timeout=5)
+            event.listen(engine.sync_engine, "before_cursor_execute", observe_lock_statement)
+            try:
+                batch_task = tasks.create_task(
+                    sessions_route.batch_create_sessions(
+                        _batch_body(environment_id, [local_session_id]),
+                        Request({"type": "http", "headers": []}),
+                        auth=auth,
+                        db=batch_db,
+                    )
                 )
-            )
-            await asyncio.wait_for(batch_lock_started.wait(), timeout=5)
-            assert not batch_task.done()
-            release_delete.set()
-            await delete_task
-            batch_result = await batch_task
-        finally:
-            release_delete.set()
-            event.remove(engine.sync_engine, "before_cursor_execute", observe_lock_statement)
+                await asyncio.wait_for(batch_lock_started.wait(), timeout=5)
+                assert not batch_task.done()
+                release_delete.set()
+            finally:
+                release_delete.set()
+                event.remove(engine.sync_engine, "before_cursor_execute", observe_lock_statement)
+
+        batch_result = batch_task.result()
 
     assert batch_result.suppressed == [local_session_id]
     assert batch_result.created == 0

--- a/backend/tests/test_session_deletion.py
+++ b/backend/tests/test_session_deletion.py
@@ -10,6 +10,7 @@ import httpx
 import pytest
 from fastapi import UploadFile
 from sqlalchemy import select
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.auth import AuthContext, get_auth
@@ -357,18 +358,24 @@ async def test_upload_keys_do_not_reuse_deleted_session_generation(
         async with session_factory() as delete_db:
             await sessions_route.delete_session(second.id, auth=auth, db=delete_db)
 
-    upload_task = asyncio.create_task(reupload())
-    await asyncio.wait_for(put_started.wait(), timeout=5)
-    delete_task = asyncio.create_task(delete_during_upload())
-    await asyncio.sleep(0.05)
-    delete_waited_for_upload = not delete_task.done()
-    release_put.set()
-    uploaded_key, _ = await asyncio.wait_for(
-        asyncio.gather(upload_task, delete_task),
-        timeout=10,
-    )
+    async with asyncio.TaskGroup() as tasks:
+        upload_task = tasks.create_task(reupload())
+        await asyncio.wait_for(put_started.wait(), timeout=5)
+        try:
+            async with session_factory() as lock_probe_db:
+                with pytest.raises(DBAPIError) as lock_error:
+                    await lock_probe_db.execute(
+                        select(Session.id)
+                        .where(Session.id == second.id)
+                        .with_for_update(nowait=True)
+                    )
+                assert getattr(lock_error.value.orig, "sqlstate", None) == "55P03"
+                await lock_probe_db.rollback()
+            tasks.create_task(delete_during_upload())
+        finally:
+            release_put.set()
 
-    assert delete_waited_for_upload
+    uploaded_key = upload_task.result()
     assert uploaded_key == second_key
     async with session_factory() as verify_db:
         assert await verify_db.get(Session, second.id) is None

--- a/backend/tests/test_session_deletion.py
+++ b/backend/tests/test_session_deletion.py
@@ -35,16 +35,8 @@ class _ControlledDeleteFileStore:
         self._fail = fail
         self._started = started
         self._release = release
-        self.deleted: list[str] = []
-
-    async def put(self, key: str, data: bytes, content_type: str | None = None) -> None:
-        await self._delegate.put(key, data, content_type)
-
-    async def get(self, key: str) -> bytes:
-        return await self._delegate.get(key)
 
     async def delete(self, key: str) -> None:
-        self.deleted.append(key)
         if self._started is not None:
             self._started.set()
         if self._release is not None:
@@ -52,9 +44,6 @@ class _ControlledDeleteFileStore:
         if self._fail:
             raise RuntimeError("test storage failure")
         await self._delegate.delete(key)
-
-    async def exists(self, key: str) -> bool:
-        return await self._delegate.exists(key)
 
 
 async def _create_session(
@@ -78,6 +67,10 @@ async def _create_session(
     await db.commit()
     await db.refresh(session)
     return session
+
+
+async def _is_suppressed(db: AsyncSession, user_id: uuid.UUID, local_id: str) -> bool:
+    return await db.get(SessionSyncSuppression, (user_id, local_id)) is not None
 
 
 async def _register_env(client: httpx.AsyncClient) -> uuid.UUID:
@@ -166,7 +159,6 @@ async def test_delete_session_is_durable_and_preserves_memories(
 
     assert response.status_code == 204
     assert not await sessions_route.file_store.exists(content_key)
-    assert await db_session.get(Session, session_id) is None
     assert (
         await db_session.scalar(
             select(SessionPermission.id).where(SessionPermission.id == permission_id)
@@ -179,13 +171,7 @@ async def test_delete_session_is_durable_and_preserves_memories(
         )
     ).one()
     assert preserved_memory == ("Keep this extracted memory", None)
-    assert (
-        await db_session.get(
-            SessionSyncSuppression,
-            (seed_user.id, local_session_id),
-        )
-        is not None
-    )
+    assert await _is_suppressed(db_session, seed_user.id, local_session_id)
     assert (await anon_client.get(f"/v1/public/sessions/{session_id}")).status_code == 404
 
     second_suppressed_id = f"a-delete-{uuid.uuid4().hex}"
@@ -213,20 +199,7 @@ async def test_delete_session_is_durable_and_preserves_memories(
         "rejected": [],
         "suppressed": [local_session_id, second_suppressed_id],
     }
-    assert (
-        await db_session.scalar(
-            select(Session.id).where(
-                Session.user_id == seed_user.id,
-                Session.local_session_id == local_session_id,
-            )
-        )
-        is None
-    )
-    upload = await client.post(
-        f"/v1/sessions/{local_session_id}/upload",
-        files={"file": ("session.json", b"[]", "application/json")},
-    )
-    assert upload.status_code == 404
+    assert await db_session.get(Session, session_id) is None
 
 
 @pytest.mark.asyncio
@@ -242,14 +215,15 @@ async def test_delete_session_storage_failure_is_retryable(
     user_id = seed_user.id
     local_session_id = f"cleanup-failure-{uuid.uuid4().hex}"
     content_key = f"sessions/{user_id}/{local_session_id}.json"
-    await sessions_route.file_store.put(content_key, b"private transcript")
+    file_store = sessions_route.file_store
+    await file_store.put(content_key, b"private transcript")
     session = await _create_session(
         db_session,
         user_id=user_id,
         local_session_id=local_session_id,
         file_key=content_key,
     )
-    store = _ControlledDeleteFileStore(sessions_route.file_store, fail=True)
+    store = _ControlledDeleteFileStore(file_store, fail=True)
     monkeypatch.setattr(sessions_route, "file_store", store)
     caplog.set_level(logging.ERROR, logger="app.routes.sessions")
 
@@ -263,14 +237,8 @@ async def test_delete_session_storage_failure_is_retryable(
     assert "test storage failure" not in response.text
     assert "session_content_delete_failed" in caplog.text
     assert await db_session.scalar(select(Session.id).where(Session.id == session_id)) == session_id
-    assert (
-        await db_session.get(
-            SessionSyncSuppression,
-            (user_id, local_session_id),
-        )
-        is None
-    )
-    assert await store.exists(content_key)
+    assert not await _is_suppressed(db_session, user_id, local_session_id)
+    assert await file_store.exists(content_key)
 
 
 @pytest.mark.asyncio
@@ -302,14 +270,7 @@ async def test_delete_serializes_batch_before_suppression_check(
     )
     monkeypatch.setattr(sessions_route, "file_store", store)
 
-    def observe_lock_statement(
-        _connection,
-        _cursor,
-        statement: str,
-        _parameters,
-        _context,
-        _executemany,
-    ) -> None:
+    def observe_lock_statement(_connection, _cursor, statement: str, *_args) -> None:
         if "FROM sessions" in statement and "FOR UPDATE" in statement:
             batch_lock_started.set()
 
@@ -343,13 +304,7 @@ async def test_delete_serializes_batch_before_suppression_check(
     assert batch_result.created == 0
     async with session_factory() as verify_db:
         assert await verify_db.get(Session, session.id) is None
-        assert (
-            await verify_db.get(
-                SessionSyncSuppression,
-                (seed_user.id, local_session_id),
-            )
-            is not None
-        )
+        assert await _is_suppressed(verify_db, seed_user.id, local_session_id)
 
 
 @pytest.mark.asyncio
@@ -359,10 +314,7 @@ async def test_memory_enrichment_clears_unresolvable_external_session_provenance
 ) -> None:
     stale_session_id = uuid.uuid4()
     item = {
-        "id": "mem0-memory",
         "content": "External memory",
-        "category": "fact",
-        "source": "mem0",
         "source_session_id": str(stale_session_id),
         "source_environment_id": None,
     }

--- a/backend/tests/test_session_deletion.py
+++ b/backend/tests/test_session_deletion.py
@@ -4,29 +4,35 @@ import asyncio
 import logging
 import uuid
 from datetime import UTC, datetime
-from io import BytesIO
 
 import httpx
 import pytest
-from fastapi import UploadFile
-from sqlalchemy import select
-from sqlalchemy.exc import DBAPIError
+from fastapi import Request
+from sqlalchemy import event, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from app.core.auth import AuthContext, get_auth
-from app.main import app
-from app.models.api_key import ApiKey
+from app.core.auth import AuthContext
 from app.models.memory import Memory
-from app.models.session import Session
+from app.models.session import Session, SessionSyncSuppression
 from app.models.session_permission import PERMISSION_KIND_LINK, SessionPermission
 from app.routes.memories import attach_source_machines
+from app.schemas.session import SessionBatchRequest
 from app.services.file_store import FileStore
 
 
-class _DeleteTrackingFileStore:
-    def __init__(self, delegate: FileStore, *, fail_delete: bool = False) -> None:
+class _ControlledDeleteFileStore:
+    def __init__(
+        self,
+        delegate: FileStore,
+        *,
+        fail: bool = False,
+        started: asyncio.Event | None = None,
+        release: asyncio.Event | None = None,
+    ) -> None:
         self._delegate = delegate
-        self._fail_delete = fail_delete
+        self._fail = fail
+        self._started = started
+        self._release = release
         self.deleted: list[str] = []
 
     async def put(self, key: str, data: bytes, content_type: str | None = None) -> None:
@@ -37,30 +43,16 @@ class _DeleteTrackingFileStore:
 
     async def delete(self, key: str) -> None:
         self.deleted.append(key)
-        if self._fail_delete:
-            raise RuntimeError("test file-store delete failure")
+        if self._started is not None:
+            self._started.set()
+        if self._release is not None:
+            await self._release.wait()
+        if self._fail:
+            raise RuntimeError("test storage failure")
         await self._delegate.delete(key)
 
     async def exists(self, key: str) -> bool:
         return await self._delegate.exists(key)
-
-
-class _BlockingPutFileStore(_DeleteTrackingFileStore):
-    def __init__(
-        self,
-        delegate: FileStore,
-        *,
-        put_started: asyncio.Event,
-        release_put: asyncio.Event,
-    ) -> None:
-        super().__init__(delegate)
-        self._put_started = put_started
-        self._release_put = release_put
-
-    async def put(self, key: str, data: bytes, content_type: str | None = None) -> None:
-        self._put_started.set()
-        await self._release_put.wait()
-        await super().put(key, data, content_type)
 
 
 async def _create_session(
@@ -68,11 +60,13 @@ async def _create_session(
     *,
     user_id: uuid.UUID,
     local_session_id: str,
+    environment_id: uuid.UUID | None = None,
     file_key: str | None = None,
 ) -> Session:
     now = datetime.now(UTC)
     session = Session(
         user_id=user_id,
+        environment_id=environment_id,
         local_session_id=local_session_id,
         started_at=now,
         last_activity_at=now,
@@ -84,7 +78,7 @@ async def _create_session(
     return session
 
 
-async def _register_env(client: httpx.AsyncClient) -> str:
+async def _register_env(client: httpx.AsyncClient) -> uuid.UUID:
     response = await client.post(
         "/v1/environments",
         json={
@@ -96,59 +90,44 @@ async def _register_env(client: httpx.AsyncClient) -> str:
         },
     )
     assert response.status_code == 200, response.text
-    return response.json()["id"]
+    return uuid.UUID(response.json()["id"])
+
+
+def _batch_body(environment_id: uuid.UUID, local_session_ids: list[str]) -> SessionBatchRequest:
+    now = datetime.now(UTC)
+    return SessionBatchRequest(
+        sessions=[
+            {
+                "environment_id": environment_id,
+                "local_session_id": local_session_id,
+                "started_at": now,
+                "message_count": 1,
+                "content_hash": chr(97 + index) * 64,
+            }
+            for index, local_session_id in enumerate(local_session_ids)
+        ]
+    )
 
 
 @pytest.mark.asyncio
-async def test_delete_session_requires_dashboard_owner_and_hides_visibility(
+async def test_delete_session_is_durable_and_preserves_memories(
     client: httpx.AsyncClient,
-    db_session: AsyncSession,
-    seed_user,
-) -> None:
-    owned = await _create_session(
-        db_session,
-        user_id=seed_user.id,
-        local_session_id=f"owned-{uuid.uuid4().hex}",
-    )
-    foreign = await _create_session(
-        db_session,
-        user_id=uuid.uuid4(),
-        local_session_id=f"foreign-{uuid.uuid4().hex}",
-    )
-
-    previous_auth = app.dependency_overrides[get_auth]
-
-    async def cli_auth() -> AuthContext:
-        return AuthContext(user=seed_user, api_key=ApiKey(user_id=seed_user.id))
-
-    app.dependency_overrides[get_auth] = cli_auth
-    try:
-        cli_response = await client.delete(f"/v1/sessions/{owned.id}")
-    finally:
-        app.dependency_overrides[get_auth] = previous_auth
-
-    assert cli_response.status_code == 403
-    assert await db_session.get(Session, owned.id) is not None
-    assert (await client.delete(f"/v1/sessions/{foreign.id}")).status_code == 404
-    assert (await client.delete(f"/v1/sessions/{uuid.uuid4()}")).status_code == 404
-
-
-@pytest.mark.asyncio
-async def test_delete_session_cascades_permission_clears_memory_and_deletes_content(
-    client: httpx.AsyncClient,
+    anon_client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user,
 ) -> None:
     from app.routes import sessions as sessions_route
 
-    local_session_id = f"delete-{uuid.uuid4().hex}"
-    file_key = f"sessions/{seed_user.id}/{local_session_id}.json"
-    await sessions_route.file_store.put(file_key, b"[]")
+    environment_id = await _register_env(client)
+    local_session_id = f"z-delete-{uuid.uuid4().hex}"
+    content_key = f"sessions/{seed_user.id}/{local_session_id}.json"
+    await sessions_route.file_store.put(content_key, b"[]")
     session = await _create_session(
         db_session,
         user_id=seed_user.id,
+        environment_id=environment_id,
         local_session_id=local_session_id,
-        file_key=file_key,
+        file_key=None,
     )
     permission = SessionPermission(
         session_id=session.id,
@@ -165,14 +144,16 @@ async def test_delete_session_cascades_permission_clears_memory_and_deletes_cont
     )
     db_session.add_all([permission, memory])
     await db_session.commit()
+    session_id = session.id
     permission_id = permission.id
     memory_id = memory.id
+    assert (await anon_client.get(f"/v1/public/sessions/{session_id}")).status_code == 200
 
-    response = await client.delete(f"/v1/sessions/{session.id}")
+    response = await client.delete(f"/v1/sessions/{session_id}")
 
     assert response.status_code == 204
-    assert response.content == b""
-    assert await db_session.get(Session, session.id) is None
+    assert not await sessions_route.file_store.exists(content_key)
+    assert await db_session.get(Session, session_id) is None
     assert (
         await db_session.scalar(
             select(SessionPermission.id).where(SessionPermission.id == permission_id)
@@ -185,11 +166,58 @@ async def test_delete_session_cascades_permission_clears_memory_and_deletes_cont
         )
     ).one()
     assert preserved_memory == ("Keep this extracted memory", None)
-    assert not await sessions_route.file_store.exists(file_key)
+    assert (
+        await db_session.get(
+            SessionSyncSuppression,
+            (seed_user.id, local_session_id),
+        )
+        is not None
+    )
+    assert (await anon_client.get(f"/v1/public/sessions/{session_id}")).status_code == 404
+
+    second_suppressed_id = f"a-delete-{uuid.uuid4().hex}"
+    db_session.add(
+        SessionSyncSuppression(
+            user_id=seed_user.id,
+            local_session_id=second_suppressed_id,
+        )
+    )
+    await db_session.commit()
+
+    batch = await client.post(
+        "/v1/sessions/batch",
+        json=_batch_body(
+            environment_id,
+            [local_session_id, second_suppressed_id, local_session_id],
+        ).model_dump(mode="json"),
+    )
+    assert batch.status_code == 200, batch.text
+    assert batch.json() == {
+        "created": 0,
+        "updated": 0,
+        "unchanged": 0,
+        "needs_content": [],
+        "rejected": [],
+        "suppressed": [local_session_id, second_suppressed_id],
+    }
+    assert (
+        await db_session.scalar(
+            select(Session.id).where(
+                Session.user_id == seed_user.id,
+                Session.local_session_id == local_session_id,
+            )
+        )
+        is None
+    )
+    upload = await client.post(
+        f"/v1/sessions/{local_session_id}/upload",
+        files={"file": ("session.json", b"[]", "application/json")},
+    )
+    assert upload.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_delete_session_commits_when_content_cleanup_fails(
+async def test_delete_session_storage_failure_is_retryable(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user,
@@ -198,32 +226,43 @@ async def test_delete_session_commits_when_content_cleanup_fails(
 ) -> None:
     from app.routes import sessions as sessions_route
 
+    user_id = seed_user.id
     local_session_id = f"cleanup-failure-{uuid.uuid4().hex}"
-    file_key = f"sessions/{seed_user.id}/{local_session_id}.json"
+    content_key = f"sessions/{user_id}/{local_session_id}.json"
+    await sessions_route.file_store.put(content_key, b"private transcript")
     session = await _create_session(
         db_session,
-        user_id=seed_user.id,
+        user_id=user_id,
         local_session_id=local_session_id,
-        file_key=file_key,
+        file_key=content_key,
     )
-    store = _DeleteTrackingFileStore(sessions_route.file_store, fail_delete=True)
+    store = _ControlledDeleteFileStore(sessions_route.file_store, fail=True)
     monkeypatch.setattr(sessions_route, "file_store", store)
-    caplog.set_level(logging.WARNING, logger="app.routes.sessions")
+    caplog.set_level(logging.ERROR, logger="app.routes.sessions")
 
-    response = await client.delete(f"/v1/sessions/{session.id}")
+    session_id = session.id
+    response = await client.delete(f"/v1/sessions/{session_id}")
 
-    assert response.status_code == 204
-    assert await db_session.get(Session, session.id) is None
-    assert set(store.deleted) == {
-        file_key,
-        f"sessions/{seed_user.id}/{session.id}.json",
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": "Session storage is temporarily unavailable. Please retry."
     }
+    assert "test storage failure" not in response.text
     assert "session_content_delete_failed" in caplog.text
+    assert await db_session.scalar(select(Session.id).where(Session.id == session_id)) == session_id
+    assert (
+        await db_session.get(
+            SessionSyncSuppression,
+            (user_id, local_session_id),
+        )
+        is None
+    )
+    assert await store.exists(content_key)
 
 
 @pytest.mark.asyncio
 @pytest.mark.committed_db
-async def test_upload_keys_do_not_reuse_deleted_session_generation(
+async def test_delete_serializes_batch_before_suppression_check(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     engine,
@@ -233,153 +272,71 @@ async def test_upload_keys_do_not_reuse_deleted_session_generation(
     from app.routes import sessions as sessions_route
 
     environment_id = await _register_env(client)
-    local_session_id = f"generation-{uuid.uuid4().hex}"
-    started_at = datetime.now(UTC).isoformat()
-    batch = await client.post(
-        "/v1/sessions/batch",
-        json={
-            "sessions": [
-                {
-                    "environment_id": environment_id,
-                    "local_session_id": local_session_id,
-                    "started_at": started_at,
-                    "message_count": 1,
-                    "content_hash": "a" * 64,
-                }
-            ]
-        },
+    local_session_id = f"concurrent-{uuid.uuid4().hex}"
+    session = await _create_session(
+        db_session,
+        user_id=seed_user.id,
+        environment_id=environment_id,
+        local_session_id=local_session_id,
     )
-    assert batch.status_code == 200, batch.text
-    first = await db_session.scalar(
-        select(Session).where(
-            Session.user_id == seed_user.id,
-            Session.local_session_id == local_session_id,
-        )
+    delete_started = asyncio.Event()
+    release_delete = asyncio.Event()
+    batch_lock_started = asyncio.Event()
+    store = _ControlledDeleteFileStore(
+        sessions_route.file_store,
+        started=delete_started,
+        release=release_delete,
     )
-    assert first is not None
-    legacy_key = f"sessions/{seed_user.id}/{local_session_id}.json"
-    await sessions_route.file_store.put(legacy_key, b"old")
-    first.file_key = legacy_key
-    await db_session.commit()
-    store = _DeleteTrackingFileStore(sessions_route.file_store)
     monkeypatch.setattr(sessions_route, "file_store", store)
-    first_content = b'[{"role":"user","content":"first"}]'
 
-    first_upload = await client.post(
-        f"/v1/sessions/{local_session_id}/upload",
-        files={"file": ("session.json", first_content, "application/json")},
-    )
+    def observe_lock_statement(
+        _connection,
+        _cursor,
+        statement: str,
+        _parameters,
+        _context,
+        _executemany,
+    ) -> None:
+        if "FROM sessions" in statement and "FOR UPDATE" in statement:
+            batch_lock_started.set()
 
-    assert first_upload.status_code == 200, first_upload.text
-    first_key = first_upload.json()["file_key"]
-    assert first_key == f"sessions/{seed_user.id}/{first.id}.json"
-    assert store.deleted == [legacy_key]
-    assert not await store.exists(legacy_key)
-
-    hash_change = await client.post(
-        "/v1/sessions/batch",
-        json={
-            "sessions": [
-                {
-                    "environment_id": environment_id,
-                    "local_session_id": local_session_id,
-                    "started_at": started_at,
-                    "message_count": 2,
-                    "content_hash": "f" * 64,
-                }
-            ]
-        },
-    )
-    assert hash_change.status_code == 200, hash_change.text
-    assert await db_session.scalar(select(Session.file_key).where(Session.id == first.id)) is None
-    assert await store.exists(first_key)
-    assert (await client.delete(f"/v1/sessions/{first.id}")).status_code == 204
-    recreate = await client.post(
-        "/v1/sessions/batch",
-        json={
-            "sessions": [
-                {
-                    "environment_id": environment_id,
-                    "local_session_id": local_session_id,
-                    "started_at": started_at,
-                    "message_count": 1,
-                    "content_hash": "b" * 64,
-                }
-            ]
-        },
-    )
-    assert recreate.status_code == 200, recreate.text
-    second = await db_session.scalar(
-        select(Session).where(
-            Session.user_id == seed_user.id,
-            Session.local_session_id == local_session_id,
-        )
-    )
-    assert second is not None
-    second_content = b'[{"role":"user","content":"second"}]'
-    second_upload = await client.post(
-        f"/v1/sessions/{local_session_id}/upload",
-        files={"file": ("session.json", second_content, "application/json")},
-    )
-    assert second_upload.status_code == 200, second_upload.text
-    second_key = second_upload.json()["file_key"]
-    assert second.id != first.id
-    assert second_key != first_key
-
-    # Simulate delayed cleanup from the first deletion after recreation.
-    await store.delete(first_key)
-    assert await store.exists(second_key)
-
-    put_started = asyncio.Event()
-    release_put = asyncio.Event()
-    blocking_store = _BlockingPutFileStore(
-        store,
-        put_started=put_started,
-        release_put=release_put,
-    )
-    monkeypatch.setattr(sessions_route, "file_store", blocking_store)
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
     auth = AuthContext(user=seed_user)
-
-    async def reupload() -> str:
-        async with session_factory() as upload_db:
-            result = await sessions_route.upload_session_content(
-                local_session_id=local_session_id,
-                file=UploadFile(
-                    file=BytesIO(b'[{"role":"user","content":"replacement"}]'),
-                    filename="session.json",
-                ),
-                auth=auth,
-                db=upload_db,
-            )
-            return result.file_key
-
-    async def delete_during_upload() -> None:
-        async with session_factory() as delete_db:
-            await sessions_route.delete_session(second.id, auth=auth, db=delete_db)
-
-    async with asyncio.TaskGroup() as tasks:
-        upload_task = tasks.create_task(reupload())
-        await asyncio.wait_for(put_started.wait(), timeout=5)
+    async with session_factory() as delete_db, session_factory() as batch_db:
+        delete_task = asyncio.create_task(
+            sessions_route.delete_session(session.id, auth=auth, db=delete_db)
+        )
+        await asyncio.wait_for(delete_started.wait(), timeout=5)
+        event.listen(engine.sync_engine, "before_cursor_execute", observe_lock_statement)
         try:
-            async with session_factory() as lock_probe_db:
-                with pytest.raises(DBAPIError) as lock_error:
-                    await lock_probe_db.execute(
-                        select(Session.id)
-                        .where(Session.id == second.id)
-                        .with_for_update(nowait=True)
-                    )
-                assert getattr(lock_error.value.orig, "sqlstate", None) == "55P03"
-                await lock_probe_db.rollback()
-            tasks.create_task(delete_during_upload())
+            batch_task = asyncio.create_task(
+                sessions_route.batch_create_sessions(
+                    _batch_body(environment_id, [local_session_id]),
+                    Request({"type": "http", "headers": []}),
+                    auth=auth,
+                    db=batch_db,
+                )
+            )
+            await asyncio.wait_for(batch_lock_started.wait(), timeout=5)
+            assert not batch_task.done()
+            release_delete.set()
+            await delete_task
+            batch_result = await batch_task
         finally:
-            release_put.set()
+            release_delete.set()
+            event.remove(engine.sync_engine, "before_cursor_execute", observe_lock_statement)
 
-    uploaded_key = upload_task.result()
-    assert uploaded_key == second_key
+    assert batch_result.suppressed == [local_session_id]
+    assert batch_result.created == 0
     async with session_factory() as verify_db:
-        assert await verify_db.get(Session, second.id) is None
-    assert not await blocking_store.exists(second_key)
+        assert await verify_db.get(Session, session.id) is None
+        assert (
+            await verify_db.get(
+                SessionSyncSuppression,
+                (seed_user.id, local_session_id),
+            )
+            is not None
+        )
 
 
 @pytest.mark.asyncio

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -52,6 +52,7 @@ interface AgentUploadResult {
 	sessionsCreated: number;
 	sessionsUpdated: number;
 	sessionsUnchanged: number;
+	sessionsSuppressed: number;
 	contentUploaded: number;
 	skillsPushed: number;
 }
@@ -206,6 +207,7 @@ export async function push(opts: PushOpts) {
 		created: 0,
 		updated: 0,
 		unchanged: 0,
+		suppressed: 0,
 		content: 0,
 		skillsCacheSkipped: 0,
 		skills: 0,
@@ -230,6 +232,7 @@ export async function push(opts: PushOpts) {
 		totals.created += result.sessionsCreated;
 		totals.updated += result.sessionsUpdated;
 		totals.unchanged += result.sessionsUnchanged;
+		totals.suppressed += result.sessionsSuppressed;
 		totals.content += result.contentUploaded;
 		totals.skills += result.skillsPushed;
 	}
@@ -254,6 +257,11 @@ export async function push(opts: PushOpts) {
 		// internal perf metric and only confuses non-technical users.
 		const unchangedTotal = totals.cacheSkipped + totals.unchanged;
 		parts.push(`${totals.created} new, ${totals.updated} updated, ${unchangedTotal} unchanged`);
+		if (totals.suppressed > 0) {
+			parts.push(
+				`${totals.suppressed} cloud Session${totals.suppressed === 1 ? "" : "s"} kept deleted`,
+			);
+		}
 		parts.push(`${totals.content} content upload${totals.content === 1 ? "" : "s"}`);
 	}
 	if (modules.includes("skills")) {
@@ -478,6 +486,7 @@ async function uploadOneAgent(
 	let sessionsCreated = 0;
 	let sessionsUpdated = 0;
 	let sessionsUnchanged = 0;
+	let sessionsSuppressed = 0;
 	let contentUploaded = 0;
 	let skillsPushed = 0;
 
@@ -488,6 +497,7 @@ async function uploadOneAgent(
 		);
 		const needsContent: Set<string> = new Set();
 		const rejectedIds: Set<string> = new Set();
+		const suppressedIds: Set<string> = new Set();
 		// Chunk sessions into batches that fit under PostgreSQL's
 		// 32767 bound-parameters-per-query limit. The server upsert
 		// builds a single multi-VALUES INSERT with ~17 columns per
@@ -526,9 +536,11 @@ async function uploadOneAgent(
 					}),
 				);
 				for (const id of result.needs_content) needsContent.add(id);
+				for (const id of result.suppressed ?? []) suppressedIds.add(id);
 				sessionsCreated += result.created;
 				sessionsUpdated += result.updated;
 				sessionsUnchanged += result.unchanged;
+				sessionsSuppressed += result.suppressed?.length ?? 0;
 				// Server flagged these ids as cross-env race casualties
 				// (see SessionBatchResponse.rejected). They are NOT
 				// synced; the caller must skip the lock-write step
@@ -537,13 +549,16 @@ async function uploadOneAgent(
 				// wrote a stale lock.
 				for (const id of result.rejected ?? []) rejectedIds.add(id);
 			}
+			for (const id of suppressedIds) needsContent.delete(id);
 			if (rejectedIds.size > 0) {
 				p.log.warn(
 					`${rejectedIds.size} session${rejectedIds.size === 1 ? "" : "s"} rejected by server (cross-env race) — will retry on next push`,
 				);
 			}
+			const suppressedSummary =
+				sessionsSuppressed > 0 ? `, ${sessionsSuppressed} kept deleted` : "";
 			sessionSpinner.stop(
-				`Metadata: ${sessionsCreated} new, ${sessionsUpdated} updated, ${sessionsUnchanged} unchanged`,
+				`Metadata: ${sessionsCreated} new, ${sessionsUpdated} updated, ${sessionsUnchanged} unchanged${suppressedSummary}`,
 			);
 		} catch (e) {
 			sessionSpinner.stop("Session metadata upload failed.");
@@ -600,6 +615,10 @@ async function uploadOneAgent(
 			if (!s.contentHash) continue;
 			const id = s.localSessionId;
 			if (rejectedIds.has(id)) continue;
+			if (suppressedIds.has(id)) {
+				sessionsLock.sessions[cacheKey(agentType, id)] = { hash: s.contentHash };
+				continue;
+			}
 			if (needsContent.has(id) && !uploadedIds.has(id)) continue;
 			sessionsLock.sessions[cacheKey(agentType, id)] = { hash: s.contentHash };
 		}
@@ -700,6 +719,7 @@ async function uploadOneAgent(
 		sessionsCreated,
 		sessionsUpdated,
 		sessionsUnchanged,
+		sessionsSuppressed,
 		contentUploaded,
 		skillsPushed,
 	};

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
 import {
 	existsSync,
 	mkdirSync,
@@ -10,9 +11,10 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import type { CollectSessionsResult } from "../adapters/base";
+import type { CollectSessionsResult, RawSession } from "../adapters/base";
 import { adapterRegistry } from "../adapters/registry";
 import { AgentSkillSyncNotFoundError, ApiClient, ApiError } from "../lib/api-client";
+import { cacheKey, readSessionsLock } from "../lib/sessions-lock";
 import {
 	computeSkillFolderHash,
 	readSkillProjectionClaimsForAgent,
@@ -89,6 +91,119 @@ describe("stable session enqueue abort fence", () => {
 		expect(await running).toBe(0);
 		expect(queued).toEqual([]);
 		expect(inFlight.size).toBe(0);
+	});
+});
+
+describe("Session deletion convergence", () => {
+	it("caches server suppression without uploading and refreshes after local changes", async () => {
+		const root = mkdtempSync(join(tmpdir(), "session-suppression-"));
+		const originalHome = process.env.HOME;
+		const originalState = process.env.CLAWDI_STATE_DIR;
+		const originalFetch = globalThis.fetch;
+		const originalWrite = process.stderr.write;
+		const requests: string[] = [];
+		const logs: string[] = [];
+		let queue: RetryQueue | undefined;
+		try {
+			process.env.HOME = root;
+			process.env.CLAWDI_STATE_DIR = join(root, "serve");
+			const session: RawSession = {
+				localSessionId: "deleted-session",
+				projectPath: "/project",
+				startedAt: new Date(0),
+				endedAt: null,
+				messageCount: 1,
+				inputTokens: 0,
+				outputTokens: 0,
+				cacheReadTokens: 0,
+				model: null,
+				modelsUsed: [],
+				durationSeconds: null,
+				summary: null,
+				messages: [{ role: "user", content: "first" }],
+				rawFilePath: "/sessions/deleted-session.jsonl",
+			};
+			const adapter = adapterRegistry.hermes.create();
+			adapter.collectSessions = async () => ({ sessions: [session], dedupedCount: 0 });
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const request = input instanceof Request ? input : new Request(input, init);
+				const path = new URL(request.url).pathname;
+				requests.push(path);
+				if (path === "/v1/sessions/batch") {
+					return new Response(
+						JSON.stringify({
+							created: 0,
+							updated: 0,
+							unchanged: 0,
+							needs_content: [session.localSessionId],
+							rejected: [],
+							suppressed: [session.localSessionId],
+						}),
+						{ headers: { "content-type": "application/json" } },
+					);
+				}
+				return new Response("unexpected content upload", { status: 500 });
+			}) as typeof fetch;
+			process.stderr.write = ((chunk: string | Uint8Array) => {
+				logs.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+				return true;
+			}) as typeof process.stderr.write;
+
+			const retryQueue = new RetryQueue({ agentType: "hermes" });
+			queue = retryQueue;
+			const lastPushedSessionHash = new Map<string, string>();
+			const abortController = new AbortController();
+			const processCurrent = async () => {
+				const hash = createHash("sha256").update(JSON.stringify(session.messages)).digest("hex");
+				retryQueue.enqueue({
+					kind: "session_push",
+					local_session_id: session.localSessionId,
+					content_hash: hash,
+					enqueued_at: new Date().toISOString(),
+					attempts: 0,
+				});
+				const item = retryQueue.peek();
+				if (!item) throw new Error("expected queued Session");
+				const outcome = await processQueueItem(
+					{
+						environmentId: "agent-1",
+						adapter,
+						abort: abortController.signal,
+						abortController,
+					},
+					new ApiClient({ requireAuth: false }),
+					retryQueue,
+					item,
+					new Map(),
+					lastPushedSessionHash,
+					new Map(),
+					"project-1",
+				);
+				expect(outcome).toBe("applied");
+				expect(lastPushedSessionHash.get(session.localSessionId)).toBe(hash);
+				expect(readSessionsLock().sessions[cacheKey("hermes", session.localSessionId)]?.hash).toBe(
+					hash,
+				);
+			};
+
+			await processCurrent();
+			session.messages.push({ role: "assistant", content: "changed" });
+			session.messageCount = 2;
+			await processCurrent();
+
+			expect(requests).toEqual(["/v1/sessions/batch", "/v1/sessions/batch"]);
+			expect(logs.join("")).toContain('"event":"engine.session_sync_suppressed"');
+			expect(logs.join("")).not.toContain('"event":"engine.session_pushed"');
+		} finally {
+			await queue?.flushPersist();
+			globalThis.fetch = originalFetch;
+			process.stderr.write = originalWrite;
+			if (originalHome === undefined) delete process.env.HOME;
+			else process.env.HOME = originalHome;
+			if (originalState === undefined) delete process.env.CLAWDI_STATE_DIR;
+			else process.env.CLAWDI_STATE_DIR = originalState;
+			rmSync(root, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -1628,7 +1628,12 @@ async function uploadSessionFromQueue(
 		return { outcome: "not_applied" };
 	}
 
-	if (result.needs_content.includes(session.localSessionId) && session.messages.length > 0) {
+	const suppressed = result.suppressed?.includes(session.localSessionId) ?? false;
+	if (
+		!suppressed &&
+		result.needs_content.includes(session.localSessionId) &&
+		session.messages.length > 0
+	) {
 		const contentBuf = Buffer.from(JSON.stringify(session.messages), "utf-8");
 		await api.uploadSessionContent(
 			session.localSessionId,
@@ -1651,11 +1656,18 @@ async function uploadSessionFromQueue(
 	};
 	writeSessionsLock(lock);
 
-	log.info("engine.session_pushed", {
-		local_session_id: session.localSessionId,
-		message_count: session.messageCount,
-		uploaded_content: result.needs_content.includes(session.localSessionId),
-	});
+	if (suppressed) {
+		log.info("engine.session_sync_suppressed", {
+			local_session_id: session.localSessionId,
+			desired_state: "cloud_deleted",
+		});
+	} else {
+		log.info("engine.session_pushed", {
+			local_session_id: session.localSessionId,
+			message_count: session.messageCount,
+			uploaded_content: result.needs_content.includes(session.localSessionId),
+		});
+	}
 	return { outcome: "applied", actualHash };
 }
 

--- a/packages/cli/tests/commands/push.test.ts
+++ b/packages/cli/tests/commands/push.test.ts
@@ -20,6 +20,7 @@ import {
 interface BatchSession {
 	environment_id: string;
 	local_session_id: string;
+	content_hash?: string | null;
 	input_tokens?: number;
 	cache_read_tokens?: number;
 	project_path?: string | null;
@@ -273,6 +274,45 @@ describe("push — Claude Code fixture", () => {
 		expect(sessions[0]?.input_tokens).toBe(30);
 		expect(sessions[0]?.output_tokens).toBe(8);
 		expect(sessions[0]?.project_path).toBe("/Users/fixture/project");
+	});
+
+	it("keeps a cloud-deleted Session deleted and caches the current hash", async () => {
+		setup("claude_code");
+		const localSessionId = "11111111-2222-3333-4444-555555555555";
+		const { captured, restore } = mockFetch([
+			okEnvironmentProbe(),
+			{
+				method: "POST",
+				path: "/v1/sessions/batch",
+				response: () =>
+					jsonResponse({
+						created: 0,
+						updated: 0,
+						unchanged: 0,
+						needs_content: [localSessionId],
+						rejected: [],
+						suppressed: [localSessionId],
+					}),
+			},
+		]);
+		try {
+			await push({ agent: "claude_code", modules: "sessions", all: true });
+			await push({ agent: "claude_code", modules: "sessions", all: true });
+		} finally {
+			restore();
+		}
+
+		const batches = captured.filter((request) => request.path === "/v1/sessions/batch");
+		expect(batches).toHaveLength(1);
+		const submitted = batchSessions(batches[0]);
+		expect(submitted).toHaveLength(1);
+		expect(
+			captured.filter((request) => request.path.endsWith(`/${localSessionId}/upload`)),
+		).toHaveLength(0);
+		const lock = JSON.parse(
+			readFileSync(join(tmpHome, ".clawdi", "sessions-lock.json"), "utf-8"),
+		) as { sessions: Record<string, { hash: string }> };
+		expect(lock.sessions[`claude_code:${localSessionId}`]?.hash).toBe(submitted[0]?.content_hash);
 	});
 });
 

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1155,7 +1155,8 @@ export interface paths {
         get: operations["get_session_detail_v1_sessions__session_id__get"];
         put?: never;
         post?: never;
-        delete?: never;
+        /** Delete Session */
+        delete: operations["delete_session_v1_sessions__session_id__delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -10617,6 +10618,35 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SessionDetailResponse"];
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_session_v1_sessions__session_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -7201,6 +7201,11 @@ export interface components {
              * @default []
              */
             rejected: string[];
+            /**
+             * Suppressed
+             * @default []
+             */
+            suppressed: string[];
         };
         /** SessionCreate */
         SessionCreate: {


### PR DESCRIPTION
## Summary

- Add owner-only `DELETE /v1/sessions/{session_id}` and a destructive Session detail action.
- Permanently record `(user_id, local_session_id)` suppressions so normal push, `--all`, daemon sync, and another machine cannot recreate a deleted Session.
- Serialize batch, content upload, and deletion with Session row locks; storage deletion failure returns a sanitized retryable `503` without committing the suppression or metadata deletion.
- Delete cloud history and sharing access, preserve account-level Memories while clearing Session provenance, and make old share links return `404`.
- Teach CLI and daemon clients to treat `suppressed` as converged without uploading content, while remaining compatible with older servers.
- Regenerate the OpenAPI TypeScript client.

## User behavior

Deleting a Session permanently removes its cloud metadata, message history, and sharing access. Local Agent files remain untouched. Extracted account-level Memories remain, but no longer link back to the deleted Session.

The deletion is durable across clients and machines: later automatic or manual sync keeps that Session deleted. This change intentionally provides no recovery entry or restore API.

## Verification

- Backend Docker: `tests/test_session_deletion.py tests/test_sessions.py` — 51 passed
- Backend focused Docker after final review fixes: 4 passed
- CLI Docker: focused push and daemon suites — 78 passed; typecheck passed
- Shared Docker: 76 passed; typecheck passed
- Web Docker: route generation, typecheck, 1044 tests, and OSS build passed
- Alembic: `d1a4e7c9b2f6 (head)`
- Generated API consistency passed
- Ruff lint, touched-file formatting, compileall, Biome, and `git diff --check` passed
- `bun.lock` unchanged

## Operations

No production or tenant-impacting operations were performed. `clawdi-hosted` was not changed.