### PR TITLE
fix(runtime): make Hosted Codex user-owned

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.89",
+      "version": "0.13.90",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/ai-provider-agent-contract-audit.md
+++ b/docs/ai-provider-agent-contract-audit.md
@@ -47,7 +47,9 @@ also accepts legacy terminal-Codex `OPENAI_API_KEY` and provider `models` on
 read, strips the latter, and always writes `CLAWDI_AI_API_KEY` locally. Runtime
 provider and BYOK schemas do not receive this compatibility allowance.
 
-The dedicated Hosted install pins `@openai/codex` `0.146.0`. In that version,
+The Hosted bootstrap uses audited `@openai/codex` `0.146.0` only when Codex is
+missing or damaged. A healthy tenant-owned install is not pinned or rolled
+back. In the bootstrap version,
 [`ModelProviderInfo`](https://github.com/openai/codex/blob/rust-v0.146.0/codex-rs/model-provider-info/src/lib.rs#L86-L144)
 defaults `name` to the empty display value and `wire_api` to `responses`, but
 [`validate_model_providers`](https://github.com/openai/codex/blob/rust-v0.146.0/codex-rs/config/src/config_toml.rs#L924-L946)
@@ -73,7 +75,7 @@ A manually written or stale ChatGPT backend auth file can therefore satisfy the
 endpoint's
 [`uses_codex_backend`](https://github.com/openai/codex/blob/rust-v0.146.0/codex-rs/model-provider/src/models_endpoint.rs#L68-L72)
 gate. Codex exposes no OpenClaw/Hermes-style discovery-off setting, and Clawdi
-does not invent one. In the locked catalog,
+does not invent one. In the bootstrap catalog,
 [`gpt-5.6-sol`](https://github.com/openai/codex/blob/rust-v0.146.0/codex-rs/models-manager/models.json#L3-L11)
 is the first picker-visible model after
 [`priority` sorting](https://github.com/openai/codex/blob/rust-v0.146.0/codex-rs/models-manager/src/manager.rs#L122-L134),

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1025,11 +1025,12 @@ binaries and do not add any platform install directory to `PATH`. Tenant tools
 use their normal home locations and inherited npm/XDG location overrides are
 cleared before official installers run. Unlike the root-owned, exactly managed
 Clawdi CLI above, Hosted Codex is user-version-owned: Clawdi bootstraps Codex
-into the tenant-owned `~/.local/share/npm` prefix only when its package metadata
-or executable is missing or damaged. A healthy installed Codex version is owned
-by the user and is never rolled back by Clawdi. `~/.local/bin/codex` remains the
-transparent-egress wrapper, while the shared npm prefix is excluded from Clawdi
-snapshot, ownership, and rollback targets.
+into the standard tenant-owned `~/.local` npm prefix only when its package
+metadata or executable is missing or damaged. A healthy installed Codex version
+is owned by the user and is never rolled back by Clawdi. Hosted terminal
+sessions provide the public egress placeholder and Codex CA through environment
+variables; the shared npm prefix remains outside Clawdi snapshot, ownership,
+and rollback targets.
 
 The hosted image's bootstrap package may expose
 `/usr/local/bin/clawdi -> ../lib/node_modules/clawdi/bin/clawdi.mjs` while root

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -641,12 +641,14 @@ materialized under `terminalTooling.codex` from the same repeatable-read batch a
 runtime providers. When both consumers use the same provider, Cloud resolves
 and decrypts that provider auth payload once. The CLI uses the terminal-tool
 reference to own exactly one Hosted Codex default configuration at
-`$CODEX_HOME/config.toml` (default `~/.codex/config.toml`) and a managed command
-shim. The shim exports the process-scoped egress placeholder and executes the
-real Codex with the original arguments; it never adds `--profile`. Managed,
-BYOK, Codex OAuth, and unmanaged runtime-provider modes all receive the same
-terminal Codex default. Unmanaged OpenClaw or Hermes units receive no provider
-environment.
+`$CODEX_HOME/config.toml` (default `~/.codex/config.toml`). When Codex is absent
+or damaged, the CLI bootstraps the audited package into the tenant's standard
+`~/.local` npm prefix. It does not wrap, pin, or roll back a healthy user-owned
+Codex install. The Hosted instance environment supplies the public egress
+placeholder, standard CA trust variables, and npm prefix to terminal commands.
+Managed, BYOK, Codex OAuth, and unmanaged runtime-provider modes all receive the
+same terminal Codex default. Unmanaged OpenClaw or Hermes units receive no
+provider environment.
 
 For a Clawdi-managed provider, the CLI gives OpenClaw, Hermes, and terminal
 Codex the same reserved local placeholder name: `CLAWDI_AI_API_KEY`. Each
@@ -660,8 +662,8 @@ custom provider selection, endpoint, canonical env key, and Responses transport.
 On the normal Clawdi-provisioned path, the plain `env_key`, fresh managed home,
 and absence of command or Codex-backend auth leave remote refresh disabled, so
 Codex selects its own default from its bundled catalog (`gpt-5.6-sol` in the
-locked `0.146.0` catalog). A manually written or stale ChatGPT backend auth file
-can satisfy Codex's upstream refresh gate. Codex has no native discovery-off
+bootstrap `0.146.0` catalog). A manually written or stale ChatGPT backend auth
+file can satisfy Codex's upstream refresh gate. Codex has no native discovery-off
 setting analogous to OpenClaw or Hermes, and Clawdi does not invent one or
 encode a model choice. Manifest v1 `primary_model` remains required only
 because strict parsing precedes a `clawdiCli.packageSpec` self-upgrade; the new
@@ -1028,9 +1030,10 @@ Clawdi CLI above, Hosted Codex is user-version-owned: Clawdi bootstraps Codex
 into the standard tenant-owned `~/.local` npm prefix only when its package
 metadata or executable is missing or damaged. A healthy installed Codex version
 is owned by the user and is never rolled back by Clawdi. The hosted execution
-environment provides the public egress placeholder, Codex CA, and user npm
-prefix without exposing the real provider credential; the shared npm prefix
-remains outside Clawdi snapshot, ownership, and rollback targets.
+environment provides the public egress placeholder, standard per-tool CA trust
+variables, and user npm prefix without exposing the real provider credential;
+the shared npm prefix remains outside Clawdi snapshot, ownership, and rollback
+targets.
 
 The hosted image's bootstrap package may expose
 `/usr/local/bin/clawdi -> ../lib/node_modules/clawdi/bin/clawdi.mjs` while root

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1027,10 +1027,10 @@ cleared before official installers run. Unlike the root-owned, exactly managed
 Clawdi CLI above, Hosted Codex is user-version-owned: Clawdi bootstraps Codex
 into the standard tenant-owned `~/.local` npm prefix only when its package
 metadata or executable is missing or damaged. A healthy installed Codex version
-is owned by the user and is never rolled back by Clawdi. Hosted terminal
-sessions provide the public egress placeholder and Codex CA through environment
-variables; the shared npm prefix remains outside Clawdi snapshot, ownership,
-and rollback targets.
+is owned by the user and is never rolled back by Clawdi. The hosted execution
+environment provides the public egress placeholder, Codex CA, and user npm
+prefix without exposing the real provider credential; the shared npm prefix
+remains outside Clawdi snapshot, ownership, and rollback targets.
 
 The hosted image's bootstrap package may expose
 `/usr/local/bin/clawdi -> ../lib/node_modules/clawdi/bin/clawdi.mjs` while root

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1023,11 +1023,13 @@ Root system services use the absolute managed CLI path for watch, daemon, and
 sidecar commands. OpenClaw and Hermes user services execute their official
 binaries and do not add any platform install directory to `PATH`. Tenant tools
 use their normal home locations and inherited npm/XDG location overrides are
-cleared before official installers run. Hosted Codex is the narrow exception:
-its exact managed package is isolated under
-`~/.local/share/clawdi/codex` so the stable `~/.local/bin/codex` transparent-
-egress wrapper can delegate to it without replacing the tenant's general npm
-global tree.
+cleared before official installers run. Unlike the root-owned, exactly managed
+Clawdi CLI above, Hosted Codex is user-version-owned: Clawdi bootstraps Codex
+into the tenant-owned `~/.local/share/npm` prefix only when its package metadata
+or executable is missing or damaged. A healthy installed Codex version is owned
+by the user and is never rolled back by Clawdi. `~/.local/bin/codex` remains the
+transparent-egress wrapper, while the shared npm prefix is excluded from Clawdi
+snapshot, ownership, and rollback targets.
 
 The hosted image's bootstrap package may expose
 `/usr/local/bin/clawdi -> ../lib/node_modules/clawdi/bin/clawdi.mjs` while root

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -229,8 +229,8 @@ discoverable from account state and should be reconciled separately with
    bootstrap handoff matches the manifest, installs that exact package, and
    re-execs before applying the manifest when the CLI changes.
 
-   Hosted Codex is a CLI-owned tool-plane dependency pinned by the immutable
-   Clawdi CLI release. Verify its audited exact package and executable before
+   Hosted Codex has an audited bootstrap package selected by the immutable
+   Clawdi CLI release. Verify that exact package and executable before
    activating Hosted:
 
    ```bash
@@ -238,9 +238,9 @@ discoverable from account state and should be reconciled separately with
    npx --yes @openai/codex@0.146.0 --version | grep -F '0.146.0'
    ```
 
-   A Hosted Codex version change therefore requires a new exact Clawdi CLI
-   release and the same registry/pairing smoke gate; it is not an image,
-   manifest, environment override, or npm dist-tag setting.
+   Changing the bootstrap version requires a new exact Clawdi CLI release and
+   the same registry/pairing smoke gate. The bootstrap applies only when Codex
+   is missing or damaged; users own subsequent upgrades and healthy versions.
 
    The backend terminal Codex environment-name cutover may deploy after
    `clawdi@0.13.69` is published. Existing deployments do not need to converge

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.89",
+	"version": "0.13.90",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -2708,15 +2708,17 @@ function hostedCodexManagedConfigToml(provider: HostedCodexManagedProvider): str
 
 function ensureHostedCodexCli(paths: RuntimePaths): Record<string, string> | null {
 	if (process.env.CLAWDI_CODEX_INSTALL_DISABLED === "1") return null;
-	// Codex owns its version after Clawdi bootstraps a healthy installation.
-	// ~/.local/bin/codex remains the transparent-egress wrapper.
 	const npmPrefix = paths.userNpmPrefix;
 	const realBin = join(npmPrefix, "bin", "codex");
-	const commandPath = paths.codexCommand;
 	let installedVersion = hostedCodexInstalledVersion(npmPrefix);
 	const bootstrapRequired = installedVersion === null || !executableExists(realBin);
 	if (bootstrapRequired) {
-		installHostedCodexBootstrap(CODEX_BOOTSTRAP_PACKAGE_SPEC, npmPrefix, paths);
+		installHostedCodexBootstrap(
+			CODEX_BOOTSTRAP_PACKAGE_SPEC,
+			npmPrefix,
+			paths,
+			isLegacyHostedCodexCommandShim(realBin, paths.userHome),
+		);
 		installedVersion = hostedCodexInstalledVersion(npmPrefix);
 		if (installedVersion !== CODEX_BOOTSTRAP_PACKAGE_VERSION) {
 			throw new Error(
@@ -2728,16 +2730,8 @@ function ensureHostedCodexCli(paths: RuntimePaths): Record<string, string> | nul
 		}
 	}
 	if (installedVersion === null) throw new Error("Codex package metadata is unavailable");
-	withRuntimeUserFileAccess(() =>
-		writeHostedCodexCommandShim(
-			commandPath,
-			realBin,
-			paths.egressSystemCaFile,
-			paths.userNpmPrefix,
-		),
-	);
 	return {
-		commandPath,
+		commandPath: realBin,
 		npmPrefix,
 		bootstrapPackageSpec: CODEX_BOOTSTRAP_PACKAGE_SPEC,
 		installedVersion,
@@ -2769,6 +2763,7 @@ function installHostedCodexBootstrap(
 	packageSpec: string,
 	npmPrefix: string,
 	paths: RuntimePaths,
+	replaceLegacyShim: boolean,
 ): void {
 	if (!commandExists("npm")) {
 		throw new Error("Codex bootstrap requires npm on PATH");
@@ -2781,6 +2776,7 @@ function installHostedCodexBootstrap(
 			"-g",
 			"--prefix",
 			npmPrefix,
+			...(replaceLegacyShim ? ["--force"] : []),
 			"--ignore-scripts",
 			"--fetch-retries",
 			"2",
@@ -2807,33 +2803,22 @@ function installHostedCodexBootstrap(
 	}
 }
 
-function writeHostedCodexCommandShim(
-	commandPath: string,
-	realBin: string,
-	caFile: string,
-	npmPrefix: string,
-): void {
-	const binDir = dirname(commandPath);
-	mkdirSync(binDir, { recursive: true });
-	writePrivateFileAtomic(
-		commandPath,
-		[
-			"#!/usr/bin/env sh",
-			`export ${MANAGED_AI_PROVIDER_RUNTIME_ENV}=${shellQuote(MANAGED_EGRESS_PLACEHOLDER_VALUE)}`,
-			`export CODEX_CA_CERTIFICATE=${shellQuote(caFile)}`,
-			`export NPM_CONFIG_PREFIX=${shellQuote(npmPrefix)}`,
-			`exec ${shellQuote(realBin)} "$@"`,
-			"",
-		].join("\n"),
-		{
-			mode: 0o755,
-			dirMode: 0o755,
-		},
-	);
-}
-
-function shellQuote(value: string): string {
-	return `'${value.replace(/'/g, "'\\''")}'`;
+function isLegacyHostedCodexCommandShim(commandPath: string, home: string): boolean {
+	try {
+		const content = readFileSync(commandPath, "utf8");
+		const legacyRealBin = join(home, ".local", "share", "clawdi", "codex", "bin", "codex");
+		return (
+			content ===
+			[
+				"#!/usr/bin/env sh",
+				`export ${MANAGED_AI_PROVIDER_RUNTIME_ENV}='${MANAGED_EGRESS_PLACEHOLDER_VALUE}'`,
+				`exec '${legacyRealBin}' "$@"`,
+				"",
+			].join("\n")
+		);
+	} catch {
+		return false;
+	}
 }
 
 function applyHostedHermesAiProviderProjection(
@@ -5459,14 +5444,6 @@ export function runtimeUserMutationTargets(
 		...channelPluginTargets,
 	]);
 	if (openClawWorkspaceRoot) targets.add(join(openClawWorkspaceRoot, "SOUL.md"));
-	if (
-		hostedCodexManagedProvider(manifest) ||
-		manifest.projection?.sourceSchemaVersion === "clawdi.hosted-runtime.manifest.v1"
-	) {
-		// The user npm prefix is shared state and must remain outside Clawdi's
-		// snapshot, ownership, and rollback boundary.
-		targets.add(paths.codexCommand);
-	}
 	for (const name of HOSTED_RUNTIME_TARGETS) {
 		if (manifest.runtimes[name]?.enabled !== true) continue;
 		const commandPath = runtimeCommandPath(name, home);
@@ -6106,9 +6083,7 @@ export function convergeRuntimeManifest(
 				codexCli = ensureHostedCodexCli(paths);
 			} catch (error) {
 				installErrors.push(
-					`runtime codex setup failed: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
+					`runtime codex setup failed: ${error instanceof Error ? error.message : String(error)}`,
 				);
 			}
 		}

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -70,6 +70,7 @@ import {
 	writeOAuthCredentialLedger,
 } from "../lib/oauth-credential-ledger";
 import { writePrivateFileAtomic } from "../lib/private-file";
+import { isValidSemver } from "../lib/semver";
 import {
 	type RuntimeUserProcessRevisionAliases,
 	readRuntimeAppliedState,
@@ -1734,8 +1735,8 @@ interface HostedAiProviderProjectionResult {
 
 const CODEX_MANAGED_PROVIDER_ID = "clawdi";
 const CODEX_MANAGED_PROVIDER_CONFIG_FILE = "config.toml";
-const CODEX_NPM_PACKAGE_VERSION = "0.146.0";
-const CODEX_NPM_PACKAGE_SPEC = `@openai/codex@${CODEX_NPM_PACKAGE_VERSION}`;
+const CODEX_BOOTSTRAP_PACKAGE_VERSION = "0.146.0";
+const CODEX_BOOTSTRAP_PACKAGE_SPEC = `@openai/codex@${CODEX_BOOTSTRAP_PACKAGE_VERSION}`;
 
 interface HostedCodexManagedProvider {
 	baseUrl: string;
@@ -2707,31 +2708,39 @@ function hostedCodexManagedConfigToml(provider: HostedCodexManagedProvider): str
 
 function ensureHostedCodexCli(paths: RuntimePaths): Record<string, string> | null {
 	if (process.env.CLAWDI_CODEX_INSTALL_DISABLED === "1") return null;
-	// Keep the exact managed package separate from the tenant's global npm tree:
-	// ~/.local/bin/codex is the transparent-egress wrapper, while this XDG data
-	// location holds the executable that the wrapper delegates to.
-	const npmPrefix = paths.codexInstallRoot;
+	// Codex owns its version after Clawdi bootstraps a healthy installation.
+	// ~/.local/bin/codex remains the transparent-egress wrapper.
+	const npmPrefix = paths.userNpmPrefix;
 	const realBin = join(npmPrefix, "bin", "codex");
 	const commandPath = paths.codexCommand;
 	let installedVersion = hostedCodexInstalledVersion(npmPrefix);
-	if (installedVersion !== CODEX_NPM_PACKAGE_VERSION || !executableExists(realBin)) {
-		installHostedCodexCli(CODEX_NPM_PACKAGE_SPEC, npmPrefix, paths);
+	const bootstrapRequired = installedVersion === null || !executableExists(realBin);
+	if (bootstrapRequired) {
+		installHostedCodexBootstrap(CODEX_BOOTSTRAP_PACKAGE_SPEC, npmPrefix, paths);
 		installedVersion = hostedCodexInstalledVersion(npmPrefix);
+		if (installedVersion !== CODEX_BOOTSTRAP_PACKAGE_VERSION) {
+			throw new Error(
+				`Codex bootstrap installed version ${installedVersion ?? "unknown"}; expected ${CODEX_BOOTSTRAP_PACKAGE_VERSION}`,
+			);
+		}
+		if (!executableExists(realBin)) {
+			throw new Error(`Codex bootstrap did not create ${realBin}`);
+		}
 	}
-	if (installedVersion !== CODEX_NPM_PACKAGE_VERSION) {
-		throw new Error(
-			`Codex npm install produced version ${installedVersion ?? "unknown"}; expected ${CODEX_NPM_PACKAGE_VERSION}`,
-		);
-	}
-	if (!executableExists(realBin)) {
-		throw new Error(`Codex npm install did not create ${realBin}`);
-	}
-	withRuntimeUserFileAccess(() => writeHostedCodexCommandShim(commandPath, realBin));
+	if (installedVersion === null) throw new Error("Codex package metadata is unavailable");
+	withRuntimeUserFileAccess(() =>
+		writeHostedCodexCommandShim(
+			commandPath,
+			realBin,
+			paths.egressSystemCaFile,
+			paths.userNpmPrefix,
+		),
+	);
 	return {
 		commandPath,
 		npmPrefix,
-		packageSpec: CODEX_NPM_PACKAGE_SPEC,
-		packageVersion: installedVersion,
+		bootstrapPackageSpec: CODEX_BOOTSTRAP_PACKAGE_SPEC,
+		installedVersion,
 		realBin,
 	};
 }
@@ -2748,15 +2757,21 @@ function hostedCodexInstalledVersion(npmPrefix: string): string | null {
 	try {
 		const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as unknown;
 		if (!parsed || typeof parsed !== "object" || !("version" in parsed)) return null;
-		return typeof parsed.version === "string" ? parsed.version : null;
+		return typeof parsed.version === "string" && isValidSemver(parsed.version)
+			? parsed.version
+			: null;
 	} catch {
 		return null;
 	}
 }
 
-function installHostedCodexCli(packageSpec: string, npmPrefix: string, paths: RuntimePaths): void {
+function installHostedCodexBootstrap(
+	packageSpec: string,
+	npmPrefix: string,
+	paths: RuntimePaths,
+): void {
 	if (!commandExists("npm")) {
-		throw new Error("Codex runtime add-on install requires npm on PATH");
+		throw new Error("Codex bootstrap requires npm on PATH");
 	}
 	withRuntimeUserFileAccess(() => mkdirSync(npmPrefix, { recursive: true }));
 	const result = spawnRuntimeUserCommand(
@@ -2787,12 +2802,17 @@ function installHostedCodexCli(packageSpec: string, npmPrefix: string, paths: Ru
 	);
 	if (result.status !== 0) {
 		throw new Error(
-			`Codex runtime add-on install failed: ${tail(result.stderr?.toString()) ?? tail(result.stdout?.toString()) ?? "npm failed"}`,
+			`Codex bootstrap failed: ${tail(result.stderr?.toString()) ?? tail(result.stdout?.toString()) ?? "npm failed"}`,
 		);
 	}
 }
 
-function writeHostedCodexCommandShim(commandPath: string, realBin: string): void {
+function writeHostedCodexCommandShim(
+	commandPath: string,
+	realBin: string,
+	caFile: string,
+	npmPrefix: string,
+): void {
 	const binDir = dirname(commandPath);
 	mkdirSync(binDir, { recursive: true });
 	writePrivateFileAtomic(
@@ -2800,6 +2820,8 @@ function writeHostedCodexCommandShim(commandPath: string, realBin: string): void
 		[
 			"#!/usr/bin/env sh",
 			`export ${MANAGED_AI_PROVIDER_RUNTIME_ENV}=${shellQuote(MANAGED_EGRESS_PLACEHOLDER_VALUE)}`,
+			`export CODEX_CA_CERTIFICATE=${shellQuote(caFile)}`,
+			`export NPM_CONFIG_PREFIX=${shellQuote(npmPrefix)}`,
 			`exec ${shellQuote(realBin)} "$@"`,
 			"",
 		].join("\n"),
@@ -5441,7 +5463,8 @@ export function runtimeUserMutationTargets(
 		hostedCodexManagedProvider(manifest) ||
 		manifest.projection?.sourceSchemaVersion === "clawdi.hosted-runtime.manifest.v1"
 	) {
-		targets.add(paths.codexInstallRoot);
+		// The user npm prefix is shared state and must remain outside Clawdi's
+		// snapshot, ownership, and rollback boundary.
 		targets.add(paths.codexCommand);
 	}
 	for (const name of HOSTED_RUNTIME_TARGETS) {
@@ -6083,7 +6106,7 @@ export function convergeRuntimeManifest(
 				codexCli = ensureHostedCodexCli(paths);
 			} catch (error) {
 				installErrors.push(
-					`runtime codex add-on install failed: ${
+					`runtime codex setup failed: ${
 						error instanceof Error ? error.message : String(error)
 					}`,
 				);

--- a/packages/cli/src/runtime/paths.test.ts
+++ b/packages/cli/src/runtime/paths.test.ts
@@ -36,7 +36,7 @@ describe("runtime paths", () => {
 		expect(paths.fileBrowserStateRoot).toBe("/var/lib/clawdi-files");
 		expect(paths.egressServiceBinary).toBe("/run/clawdi/egress/systemd/mitmdump");
 		expect(paths.fileBrowserServiceBinary).toBe("/run/clawdi-files/filebrowser");
-		expect(paths.codexInstallRoot).toBe("/home/clawdi/.local/share/clawdi/codex");
+		expect(paths.userNpmPrefix).toBe("/home/clawdi/.local/share/npm");
 		expect(paths.codexCommand).toBe("/home/clawdi/.local/bin/codex");
 	});
 

--- a/packages/cli/src/runtime/paths.test.ts
+++ b/packages/cli/src/runtime/paths.test.ts
@@ -36,8 +36,7 @@ describe("runtime paths", () => {
 		expect(paths.fileBrowserStateRoot).toBe("/var/lib/clawdi-files");
 		expect(paths.egressServiceBinary).toBe("/run/clawdi/egress/systemd/mitmdump");
 		expect(paths.fileBrowserServiceBinary).toBe("/run/clawdi-files/filebrowser");
-		expect(paths.userNpmPrefix).toBe("/home/clawdi/.local/share/npm");
-		expect(paths.codexCommand).toBe("/home/clawdi/.local/bin/codex");
+		expect(paths.userNpmPrefix).toBe("/home/clawdi/.local");
 	});
 
 	test("derives isolated config and cache roots from a service-state fixture", () => {

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -39,7 +39,7 @@ export interface RuntimePaths {
 	cliManagedBin: string;
 	cliNpmPrefix: string;
 	cliNpmCache: string;
-	codexInstallRoot: string;
+	userNpmPrefix: string;
 	codexCommand: string;
 	cliBootstrapStatus: string;
 	cliUpgradeState: string;
@@ -174,7 +174,7 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 	const maintainedRoot = join(serviceStateRoot, "maintained");
 	const managedCliRoot = join(maintainedRoot, "clawdi");
 	const npmRoot = join(managedCliRoot, "npm");
-	const codexInstallRoot = join(userDataRoot, "clawdi", "codex");
+	const userNpmPrefix = join(userDataRoot, "npm");
 	const instanceRoot = join(serviceStateRoot, "instances");
 
 	return {
@@ -200,7 +200,7 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 		cliManagedBin: join(managedCliRoot, "bin", "clawdi"),
 		cliNpmPrefix: npmRoot,
 		cliNpmCache: join(cacheRoot, "npm"),
-		codexInstallRoot,
+		userNpmPrefix,
 		codexCommand: join(userLocalBin, "codex"),
 		cliBootstrapStatus: join(statusRoot, "cli-bootstrap.json"),
 		cliUpgradeState: join(statusRoot, "cli-upgrade-state.json"),

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -40,7 +40,6 @@ export interface RuntimePaths {
 	cliNpmPrefix: string;
 	cliNpmCache: string;
 	userNpmPrefix: string;
-	codexCommand: string;
 	cliBootstrapStatus: string;
 	cliUpgradeState: string;
 	providerHealthStatus: string;
@@ -161,7 +160,6 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 	const clawdiHome = defaultClawdiHome(mode, serviceStateRoot);
 	const userLocalRoot = join(userHome, ".local");
 	const userLocalBin = join(userLocalRoot, "bin");
-	const userDataRoot = join(userLocalRoot, "share");
 	const configurationRoot = derivedPlatformRoot(
 		serviceStateRoot,
 		DEFAULT_CONFIGURATION_ROOT,
@@ -174,7 +172,6 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 	const maintainedRoot = join(serviceStateRoot, "maintained");
 	const managedCliRoot = join(maintainedRoot, "clawdi");
 	const npmRoot = join(managedCliRoot, "npm");
-	const userNpmPrefix = join(userDataRoot, "npm");
 	const instanceRoot = join(serviceStateRoot, "instances");
 
 	return {
@@ -200,8 +197,7 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 		cliManagedBin: join(managedCliRoot, "bin", "clawdi"),
 		cliNpmPrefix: npmRoot,
 		cliNpmCache: join(cacheRoot, "npm"),
-		userNpmPrefix,
-		codexCommand: join(userLocalBin, "codex"),
+		userNpmPrefix: userLocalRoot,
 		cliBootstrapStatus: join(statusRoot, "cli-bootstrap.json"),
 		cliUpgradeState: join(statusRoot, "cli-upgrade-state.json"),
 		providerHealthStatus: join(statusRoot, "provider-health.json"),

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -67,7 +67,6 @@ import {
 	convergeRuntimeManifest as convergeRuntimeManifestWithContext,
 	loadRuntimeManifest as loadRuntimeManifestFromContext,
 	materializeHostedChannelCredentials,
-	runtimeUserMutationTargets,
 	type RuntimeConvergenceResult,
 	type RuntimeManifest,
 } from "../src/runtime/manifest";
@@ -1404,7 +1403,7 @@ function seedHostedCodexPackage(
 	version: string,
 	options: { executable?: boolean; validPackageJson?: boolean } = {},
 ): { packageJson: string; realBin: string } {
-	const npmPrefix = join(home, ".local", "share", "npm");
+	const npmPrefix = join(home, ".local");
 	const packageJson = join(npmPrefix, "lib", "node_modules", "@openai", "codex", "package.json");
 	const realBin = join(npmPrefix, "bin", "codex");
 	mkdirSync(dirname(packageJson), { recursive: true });
@@ -4042,14 +4041,27 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		const npmArgsPath = join(root, "npm-args.txt");
 		const userCodexConfig = join(home, ".codex", "config.toml");
 		const legacyCodexMarker = join(home, ".local", "share", "clawdi", "codex", "user-data");
+		const legacyCodexCommand = join(home, ".local", "bin", "codex");
+		const legacyCodexRealBin = join(home, ".local", "share", "clawdi", "codex", "bin", "codex");
 		const userConfigBytes = Buffer.from('# user config\nmodel = "user-model"\n');
 		const previousPath = process.env.PATH;
 		const previousUmask = process.umask(0o077);
 		mkdirSync(binDir, { recursive: true });
 		mkdirSync(dirname(userCodexConfig), { recursive: true });
 		mkdirSync(dirname(legacyCodexMarker), { recursive: true });
+		mkdirSync(dirname(legacyCodexCommand), { recursive: true });
 		writeFileSync(userCodexConfig, userConfigBytes);
 		writeFileSync(legacyCodexMarker, "preserve\n");
+		writeFileSync(
+			legacyCodexCommand,
+			[
+				"#!/usr/bin/env sh",
+				"export CLAWDI_AI_API_KEY='clawdi-egress-placeholder'",
+				`exec '${legacyCodexRealBin}' "$@"`,
+				"",
+			].join("\n"),
+		);
+		chmodSync(legacyCodexCommand, 0o755);
 		writeFileSync(
 			join(binDir, "npm"),
 			[
@@ -4072,9 +4084,6 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 				`printf '%s\\n' '{"version":"0.146.0"}' > "$prefix/lib/node_modules/@openai/codex/package.json"`,
 				"cat > \"$prefix/bin/codex\" <<'SH'",
 				"#!/usr/bin/env sh",
-				"printf 'env=<%s>\\n' \"$" + '{CLAWDI_AI_API_KEY-unset}"',
-				"printf 'ca=<%s>\\n' \"$" + '{CODEX_CA_CERTIFICATE-unset}"',
-				"printf 'npm_prefix=<%s>\\n' \"$" + '{NPM_CONFIG_PREFIX-unset}"',
 				'for arg in "$@"; do printf \'arg=<%s>\\n\' "$arg"; done',
 				"SH",
 				'chmod 755 "$prefix/bin/codex"',
@@ -4091,55 +4100,51 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		const paths = getRuntimePaths();
 
 		try {
-			const codexLoad: RuntimeManifestLoad = {
-				source: "remote-datasource",
-				sourcePath: "https://runtime-source.test/desired-state",
-				offline: false,
-				manifest: {
-					schemaVersion: "clawdi.runtimeDesiredState.v1",
-					deploymentId: "dep_codex_addon",
-					environmentId: "env_codex_addon",
-					instanceId: "iid_codex_addon",
-					generation: 1,
-					issuedAt: "2026-07-10T00:00:00Z",
-					workspaceRoot: join(home, "clawdi"),
-					controlPlane: { apiUrl: "https://cloud-api.test" },
-					runtimes: {
-						openclaw: { enabled: false },
-					},
-					projection: {
-						system: { home },
-						providers: {},
-						terminalTooling: {
-							codex: {
-								enabled: true,
-								provider_id: "codex-managed",
-								primary_model: { provider_id: "codex-managed", model: "gpt-5.5" },
-								provider: {
-									kind: "openai-compatible",
-									baseUrl: "https://managed-provider.example.test/v1",
-									apiMode: "openai_responses",
-									managed_by: "clawdi",
-									runtimeEnvName: "OPENAI_API_KEY",
-									apiKeySecretRef: "secret://tool.codex.apiKey",
+			const convergence = convergeRuntimeManifest(
+				{
+					source: "remote-datasource",
+					sourcePath: "https://runtime-source.test/desired-state",
+					offline: false,
+					manifest: {
+						schemaVersion: "clawdi.runtimeDesiredState.v1",
+						deploymentId: "dep_codex_addon",
+						environmentId: "env_codex_addon",
+						instanceId: "iid_codex_addon",
+						generation: 1,
+						issuedAt: "2026-07-10T00:00:00Z",
+						workspaceRoot: join(home, "clawdi"),
+						controlPlane: { apiUrl: "https://cloud-api.test" },
+						runtimes: {
+							openclaw: { enabled: false },
+						},
+						projection: {
+							system: { home },
+							providers: {},
+							terminalTooling: {
+								codex: {
+									enabled: true,
+									provider_id: "codex-managed",
+									primary_model: {
+										provider_id: "codex-managed",
+										model: "gpt-5.5",
+									},
+									provider: {
+										kind: "openai-compatible",
+										baseUrl: "https://managed-provider.example.test/v1",
+										apiMode: "openai_responses",
+										managed_by: "clawdi",
+										runtimeEnvName: "OPENAI_API_KEY",
+										apiKeySecretRef: "secret://tool.codex.apiKey",
+									},
 								},
 							},
 						},
+						egressProfiles: { profiles: [] },
+						recovery: { cacheManifest: true, allowOfflineBoot: true },
 					},
-					egressProfiles: { profiles: [] },
-					recovery: { cacheManifest: true, allowOfflineBoot: true },
 				},
-			};
-			const mutationTargets = runtimeUserMutationTargets(
-				codexLoad.manifest,
 				paths,
-				null,
-				new Map(),
 			);
-			expect(mutationTargets).toContain(userCodexConfig);
-			expect(mutationTargets).toContain(paths.codexCommand);
-			expect(mutationTargets).not.toContain(paths.userNpmPrefix);
-			const convergence = convergeRuntimeManifest(codexLoad, paths);
 
 			expect(convergence.installErrors).toEqual([]);
 		} finally {
@@ -4152,36 +4157,25 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		const npmArgs = readFileSync(npmArgsPath, "utf-8");
 		expect(npmArgs).toContain("@openai/codex@0.146.0");
 		expect(npmArgs).toContain(`${paths.userNpmPrefix}\n`);
+		expect(npmArgs).toContain("--force\n");
 		expect(npmArgs).not.toContain("--cache\n");
 		const realBin = join(paths.userNpmPrefix, "bin", "codex");
 		const packageJson = join(paths.userNpmPrefix, "lib/node_modules/@openai/codex/package.json");
-		const commandShim = paths.codexCommand;
 		expect(statSync(paths.userNpmPrefix).mode & 0o777).toBe(0o700);
 		expect(statSync(dirname(realBin)).mode & 0o777).toBe(0o700);
 		expect(statSync(realBin).mode & 0o777).toBe(0o755);
 		expect(statSync(packageJson).mode & 0o777).toBe(0o600);
-		expect(statSync(commandShim).mode & 0o777).toBe(0o755);
-		expect(readFileSync(commandShim, "utf8")).not.toContain("--profile");
-		expect(readFileSync(userCodexConfig, "utf8")).toContain('model_provider = "clawdi"');
+		expect(readFileSync(userCodexConfig, "utf8")).toContain('env_key = "CLAWDI_AI_API_KEY"');
 		expect(readFileSync(legacyCodexMarker, "utf8")).toBe("preserve\n");
 
-		const runShim = (args: string[]) => {
-			const result = spawnSync(commandShim, args, {
+		const runCodex = (args: string[]) => {
+			const result = spawnSync(realBin, args, {
 				encoding: "utf8",
-				env: {
-					...process.env,
-					CLAWDI_AI_API_KEY: "user-existing-key",
-					CODEX_CA_CERTIFICATE: "/parent/ca-must-be-overridden.pem",
-					NPM_CONFIG_PREFIX: "/parent/npm-prefix-must-be-overridden",
-				},
 			});
 			expect(result.status).toBe(0);
 			return result.stdout.trimEnd().split("\n");
 		};
-		expect(runShim(["exec", "quoted arg", ""])).toEqual([
-			"env=<clawdi-egress-placeholder>",
-			`ca=<${paths.egressSystemCaFile}>`,
-			`npm_prefix=<${paths.userNpmPrefix}>`,
+		expect(runCodex(["exec", "quoted arg", ""])).toEqual([
 			"arg=<exec>",
 			"arg=<quoted arg>",
 			"arg=<>",
@@ -4190,12 +4184,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 			["resume", "session id", "--flag=value"],
 			["exec", "", "'quoted'", '"double quoted"'],
 		]) {
-			expect(runShim(args)).toEqual([
-				"env=<clawdi-egress-placeholder>",
-				`ca=<${paths.egressSystemCaFile}>`,
-				`npm_prefix=<${paths.userNpmPrefix}>`,
-				...args.map((arg) => `arg=<${arg}>`),
-			]);
+			expect(runCodex(args)).toEqual(args.map((arg) => `arg=<${arg}>`));
 		}
 	});
 
@@ -4234,7 +4223,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		expect(readFileSync(join(home, ".codex", "config.toml"), "utf8")).toContain(
 			'model_provider = "clawdi"',
 		);
-		expect(readFileSync(getRuntimePaths().codexCommand, "utf8")).not.toContain("--profile");
+		expect(existsSync(join(getRuntimePaths().userNpmPrefix, "bin", "codex"))).toBe(true);
 	});
 
 	it("bootstraps missing or damaged Hosted Codex packages", () => {
@@ -4279,10 +4268,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 				expect(
 					JSON.parse(
 						readFileSync(
-							join(
-								getRuntimePaths().userNpmPrefix,
-								"lib/node_modules/@openai/codex/package.json",
-							),
+							join(getRuntimePaths().userNpmPrefix, "lib/node_modules/@openai/codex/package.json"),
 							"utf8",
 						),
 					).version,

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -67,6 +67,7 @@ import {
 	convergeRuntimeManifest as convergeRuntimeManifestWithContext,
 	loadRuntimeManifest as loadRuntimeManifestFromContext,
 	materializeHostedChannelCredentials,
+	runtimeUserMutationTargets,
 	type RuntimeConvergenceResult,
 	type RuntimeManifest,
 } from "../src/runtime/manifest";
@@ -1403,7 +1404,7 @@ function seedHostedCodexPackage(
 	version: string,
 	options: { executable?: boolean; validPackageJson?: boolean } = {},
 ): { packageJson: string; realBin: string } {
-	const npmPrefix = join(home, ".local", "share", "clawdi", "codex");
+	const npmPrefix = join(home, ".local", "share", "npm");
 	const packageJson = join(npmPrefix, "lib", "node_modules", "@openai", "codex", "package.json");
 	const realBin = join(npmPrefix, "bin", "codex");
 	mkdirSync(dirname(packageJson), { recursive: true });
@@ -4033,19 +4034,22 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		expect(readFileSync(configPath, "utf-8")).not.toMatch(/managed/i);
 	});
 
-	it("installs the Codex runtime add-on through npm when managed config is projected", () => {
+	it("bootstraps Codex through the user npm prefix when managed config is projected", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const binDir = join(root, "fake-bin");
 		const npmArgsPath = join(root, "npm-args.txt");
 		const userCodexConfig = join(home, ".codex", "config.toml");
+		const legacyCodexMarker = join(home, ".local", "share", "clawdi", "codex", "user-data");
 		const userConfigBytes = Buffer.from('# user config\nmodel = "user-model"\n');
 		const previousPath = process.env.PATH;
 		const previousUmask = process.umask(0o077);
 		mkdirSync(binDir, { recursive: true });
 		mkdirSync(dirname(userCodexConfig), { recursive: true });
+		mkdirSync(dirname(legacyCodexMarker), { recursive: true });
 		writeFileSync(userCodexConfig, userConfigBytes);
+		writeFileSync(legacyCodexMarker, "preserve\n");
 		writeFileSync(
 			join(binDir, "npm"),
 			[
@@ -4069,6 +4073,8 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 				"cat > \"$prefix/bin/codex\" <<'SH'",
 				"#!/usr/bin/env sh",
 				"printf 'env=<%s>\\n' \"$" + '{CLAWDI_AI_API_KEY-unset}"',
+				"printf 'ca=<%s>\\n' \"$" + '{CODEX_CA_CERTIFICATE-unset}"',
+				"printf 'npm_prefix=<%s>\\n' \"$" + '{NPM_CONFIG_PREFIX-unset}"',
 				'for arg in "$@"; do printf \'arg=<%s>\\n\' "$arg"; done',
 				"SH",
 				'chmod 755 "$prefix/bin/codex"',
@@ -4085,48 +4091,55 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		const paths = getRuntimePaths();
 
 		try {
-			const convergence = convergeRuntimeManifest(
-				{
-					source: "remote-datasource",
-					sourcePath: "https://runtime-source.test/desired-state",
-					offline: false,
-					manifest: {
-						schemaVersion: "clawdi.runtimeDesiredState.v1",
-						deploymentId: "dep_codex_addon",
-						environmentId: "env_codex_addon",
-						instanceId: "iid_codex_addon",
-						generation: 1,
-						issuedAt: "2026-07-10T00:00:00Z",
-						workspaceRoot: join(home, "clawdi"),
-						controlPlane: { apiUrl: "https://cloud-api.test" },
-						runtimes: {
-							openclaw: { enabled: false },
-						},
-						projection: {
-							system: { home },
-							providers: {},
-							terminalTooling: {
-								codex: {
-									enabled: true,
-									provider_id: "codex-managed",
-									primary_model: { provider_id: "codex-managed", model: "gpt-5.5" },
-									provider: {
-										kind: "openai-compatible",
-										baseUrl: "https://managed-provider.example.test/v1",
-										apiMode: "openai_responses",
-										managed_by: "clawdi",
-										runtimeEnvName: "OPENAI_API_KEY",
-										apiKeySecretRef: "secret://tool.codex.apiKey",
-									},
+			const codexLoad: RuntimeManifestLoad = {
+				source: "remote-datasource",
+				sourcePath: "https://runtime-source.test/desired-state",
+				offline: false,
+				manifest: {
+					schemaVersion: "clawdi.runtimeDesiredState.v1",
+					deploymentId: "dep_codex_addon",
+					environmentId: "env_codex_addon",
+					instanceId: "iid_codex_addon",
+					generation: 1,
+					issuedAt: "2026-07-10T00:00:00Z",
+					workspaceRoot: join(home, "clawdi"),
+					controlPlane: { apiUrl: "https://cloud-api.test" },
+					runtimes: {
+						openclaw: { enabled: false },
+					},
+					projection: {
+						system: { home },
+						providers: {},
+						terminalTooling: {
+							codex: {
+								enabled: true,
+								provider_id: "codex-managed",
+								primary_model: { provider_id: "codex-managed", model: "gpt-5.5" },
+								provider: {
+									kind: "openai-compatible",
+									baseUrl: "https://managed-provider.example.test/v1",
+									apiMode: "openai_responses",
+									managed_by: "clawdi",
+									runtimeEnvName: "OPENAI_API_KEY",
+									apiKeySecretRef: "secret://tool.codex.apiKey",
 								},
 							},
 						},
-						egressProfiles: { profiles: [] },
-						recovery: { cacheManifest: true, allowOfflineBoot: true },
 					},
+					egressProfiles: { profiles: [] },
+					recovery: { cacheManifest: true, allowOfflineBoot: true },
 				},
+			};
+			const mutationTargets = runtimeUserMutationTargets(
+				codexLoad.manifest,
 				paths,
+				null,
+				new Map(),
 			);
+			expect(mutationTargets).toContain(userCodexConfig);
+			expect(mutationTargets).toContain(paths.codexCommand);
+			expect(mutationTargets).not.toContain(paths.userNpmPrefix);
+			const convergence = convergeRuntimeManifest(codexLoad, paths);
 
 			expect(convergence.installErrors).toEqual([]);
 		} finally {
@@ -4138,29 +4151,37 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 
 		const npmArgs = readFileSync(npmArgsPath, "utf-8");
 		expect(npmArgs).toContain("@openai/codex@0.146.0");
-		expect(npmArgs).toContain(`${paths.codexInstallRoot}\n`);
+		expect(npmArgs).toContain(`${paths.userNpmPrefix}\n`);
 		expect(npmArgs).not.toContain("--cache\n");
-		const realBin = join(paths.codexInstallRoot, "bin", "codex");
-		const packageJson = join(paths.codexInstallRoot, "lib/node_modules/@openai/codex/package.json");
+		const realBin = join(paths.userNpmPrefix, "bin", "codex");
+		const packageJson = join(paths.userNpmPrefix, "lib/node_modules/@openai/codex/package.json");
 		const commandShim = paths.codexCommand;
-		expect(statSync(paths.codexInstallRoot).mode & 0o777).toBe(0o700);
+		expect(statSync(paths.userNpmPrefix).mode & 0o777).toBe(0o700);
 		expect(statSync(dirname(realBin)).mode & 0o777).toBe(0o700);
 		expect(statSync(realBin).mode & 0o777).toBe(0o755);
 		expect(statSync(packageJson).mode & 0o777).toBe(0o600);
 		expect(statSync(commandShim).mode & 0o777).toBe(0o755);
 		expect(readFileSync(commandShim, "utf8")).not.toContain("--profile");
 		expect(readFileSync(userCodexConfig, "utf8")).toContain('model_provider = "clawdi"');
+		expect(readFileSync(legacyCodexMarker, "utf8")).toBe("preserve\n");
 
 		const runShim = (args: string[]) => {
 			const result = spawnSync(commandShim, args, {
 				encoding: "utf8",
-				env: { ...process.env, CLAWDI_AI_API_KEY: "user-existing-key" },
+				env: {
+					...process.env,
+					CLAWDI_AI_API_KEY: "user-existing-key",
+					CODEX_CA_CERTIFICATE: "/parent/ca-must-be-overridden.pem",
+					NPM_CONFIG_PREFIX: "/parent/npm-prefix-must-be-overridden",
+				},
 			});
 			expect(result.status).toBe(0);
 			return result.stdout.trimEnd().split("\n");
 		};
 		expect(runShim(["exec", "quoted arg", ""])).toEqual([
 			"env=<clawdi-egress-placeholder>",
+			`ca=<${paths.egressSystemCaFile}>`,
+			`npm_prefix=<${paths.userNpmPrefix}>`,
 			"arg=<exec>",
 			"arg=<quoted arg>",
 			"arg=<>",
@@ -4171,20 +4192,22 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		]) {
 			expect(runShim(args)).toEqual([
 				"env=<clawdi-egress-placeholder>",
+				`ca=<${paths.egressSystemCaFile}>`,
+				`npm_prefix=<${paths.userNpmPrefix}>`,
 				...args.map((arg) => `arg=<${arg}>`),
 			]);
 		}
 	});
 
-	it("does not reinstall the exact executable Hosted Codex package", () => {
-		const home = join(root, "codex-exact", "home", "clawdi");
-		const state = join(root, "codex-exact", "var", "lib", "clawdi");
-		const run = join(root, "codex-exact", "run", "clawdi");
-		const binDir = join(root, "codex-exact", "fake-bin");
-		const installMarker = join(root, "codex-exact", "npm-install.txt");
+	it("preserves a healthy user-upgraded Hosted Codex package", () => {
+		const home = join(root, "codex-user-upgraded", "home", "clawdi");
+		const state = join(root, "codex-user-upgraded", "var", "lib", "clawdi");
+		const run = join(root, "codex-user-upgraded", "run", "clawdi");
+		const binDir = join(root, "codex-user-upgraded", "fake-bin");
+		const installMarker = join(root, "codex-user-upgraded", "npm-install.txt");
 		const previousPath = process.env.PATH;
 		seedOpenClawBinary(home);
-		seedHostedCodexPackage(home, "0.146.0");
+		const { packageJson } = seedHostedCodexPackage(home, "0.147.0");
 		writeHostedCodexNpmInstaller(binDir, installMarker, "0.146.0");
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
@@ -4207,17 +4230,17 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		}
 
 		expect(existsSync(installMarker)).toBe(false);
+		expect(JSON.parse(readFileSync(packageJson, "utf8")).version).toBe("0.147.0");
 		expect(readFileSync(join(home, ".codex", "config.toml"), "utf8")).toContain(
 			'model_provider = "clawdi"',
 		);
 		expect(readFileSync(getRuntimePaths().codexCommand, "utf8")).not.toContain("--profile");
 	});
 
-	it("reinstalls missing, damaged, or old Hosted Codex packages to the exact version", () => {
+	it("bootstraps missing or damaged Hosted Codex packages", () => {
 		const previousPath = process.env.PATH;
 		const cases = [
 			{ name: "missing" },
-			{ name: "old", version: "0.145.0" },
 			{ name: "damaged", version: "0.146.0", validPackageJson: false },
 			{ name: "non-executable", version: "0.146.0", executable: false },
 		] as const;
@@ -4257,7 +4280,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 					JSON.parse(
 						readFileSync(
 							join(
-								getRuntimePaths().codexInstallRoot,
+								getRuntimePaths().userNpmPrefix,
 								"lib/node_modules/@openai/codex/package.json",
 							),
 							"utf8",
@@ -4272,7 +4295,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		}
 	});
 
-	it("fails closed when npm installs the wrong Hosted Codex version", () => {
+	it("fails closed when npm installs the wrong Codex bootstrap version", () => {
 		const home = join(root, "codex-wrong-version", "home", "clawdi");
 		const state = join(root, "codex-wrong-version", "var", "lib", "clawdi");
 		const run = join(root, "codex-wrong-version", "run", "clawdi");
@@ -4295,7 +4318,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 				getRuntimePaths(),
 			);
 			expect(convergence.installErrors.join("\n")).toContain(
-				"Codex npm install produced version 0.145.0; expected 0.146.0",
+				"Codex bootstrap installed version 0.145.0; expected 0.146.0",
 			);
 			expect(existsSync(join(home, ".codex", "config.toml"))).toBe(false);
 		} finally {
@@ -4305,7 +4328,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		}
 	});
 
-	it("does not mutate live config when the Codex runtime add-on install fails", () => {
+	it("does not mutate live config when Codex bootstrap fails", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -4344,7 +4367,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 				paths,
 			);
 
-			expect(convergence.installErrors.join("\n")).toContain("runtime codex add-on install failed");
+			expect(convergence.installErrors.join("\n")).toContain("runtime codex setup failed");
 			expect(convergence.outputs.systemdSystemUnits).toEqual([]);
 			expect(convergence.outputs.systemdUserUnits).toEqual([]);
 			for (const [path, content] of Object.entries(previousLiveSnapshot)) {


### PR DESCRIPTION
## Summary

- keep Codex provider auth on the standard `env_key = "CLAWDI_AI_API_KEY"` contract
- bootstrap the official Codex npm package into the tenant-owned `~/.local` prefix only when missing or damaged
- preserve healthy user-selected Codex versions and remove the long-lived Clawdi command wrapper
- migrate only the exact legacy Clawdi wrapper, without overwriting arbitrary user files
- keep the shared npm prefix outside Clawdi snapshot, ownership, and rollback targets

## Verification

- CLI typecheck passed
- 19 focused runtime path and Codex tests passed
- Biome checks passed for all changed TypeScript files

## Paired Change

- Clawdi-AI/clawdi-hosted#1769 configures the public placeholder, Codex CA path, and standard user npm prefix as the Incus instance exec environment.
- Existing instances are updated in place; no tenant image change or image migration is required.