### PR TITLE
fix(web): reuse OpenClaw browser sessions

### DIFF
--- a/apps/web/src/components/dialog-exit-lifecycle.test.ts
+++ b/apps/web/src/components/dialog-exit-lifecycle.test.ts
@@ -61,9 +61,8 @@ describe("dialog exit lifecycle", () => {
 
 		const runtime = source("hosted/agents/hosted-agent-detail.tsx");
 		const identityClose = runtime.indexOf("if (open) credentialExit.beginClose()");
-		const clearAfterIdentity = runtime.indexOf("clearSensitiveState();", identityClose);
 		expect(identityClose).toBeGreaterThan(-1);
-		expect(clearAfterIdentity).toBeGreaterThan(identityClose);
+		expect(runtime).toContain("clearCredentials();");
 	});
 
 	test("invalidates stale async writes independently from visual cleanup", () => {

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -676,14 +676,16 @@ describe("hosted agent customer language", () => {
 		expect(detailSource).toContain('allow="clipboard-read; clipboard-write"');
 		expect(detailSource).toContain("Open in new window");
 		expect(detailSource).toContain('<RuntimeUiCredentialRow label="Username"');
-		expect(detailSource).toContain('<RuntimeUiCredentialRow label="Password"');
-		expect(detailSource).toContain(
-			'<RuntimeUiCredentialRow label="Token" value={renderedCredentials.token} secret />',
-		);
+		expect(detailSource).toContain('label="Password"');
+		expect(detailSource).not.toContain('<RuntimeUiCredentialRow label="Token"');
+		expect(detailSource).toContain("hasOpenClawBootstrapAttempt");
+		expect(detailSource).toContain("rememberOpenClawBootstrapAttempt");
+		expect(detailSource).toContain("Reconnect");
 		expect(detailSource).toContain("Sign in to Hermes");
 		expect(detailSource).toContain("Get your Hermes username and password from Access.");
 		expect(detailSource).toContain("clawdi.hermes-access-hint.dismissed");
-		expect(detailSource).toContain('runtime === "hermes" && accessHintOpen');
+		expect(detailSource).toContain('runtime === "hermes" ? (');
+		expect(detailSource).not.toContain("Open Access to retry");
 		expect(detailSource).not.toContain("reconciliationRequired");
 	});
 });

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -123,8 +123,10 @@ import {
 	type HostedTerminalStatus,
 } from "@/hosted/agents/hosted-terminal-panel";
 import {
-	loadRuntimeUiLaunchCredentials,
+	forgetOpenClawBootstrapAttempt,
+	hasOpenClawBootstrapAttempt,
 	openSecureRuntimeWindow,
+	rememberOpenClawBootstrapAttempt,
 	resolveRuntimeUiCredentials,
 	runtimeUiLaunchTarget,
 } from "@/hosted/agents/runtime-ui-credentials";
@@ -1372,13 +1374,14 @@ function hermesAccessHintStorageKey(deploymentId: string): string {
 
 function useRuntimeUiCredentialRequest(
 	deployment: HostedDeployment,
-	endpointUrl: string,
+	endpointUrl: string | null,
 	runtime: Runtime,
 ): () => Promise<RuntimeUiCredentials> {
 	const client = useBillingClient();
 	const deploymentId = deployment.resource.id;
 	const resourceVersion = deployment.resource.metadata.resourceVersion;
 	return useCallback(async () => {
+		if (!endpointUrl) throw new Error("Runtime UI endpoint is unavailable");
 		const credentials = await client.getRuntimeUiCredentials(deploymentId, resourceVersion);
 		const resolved = resolveRuntimeUiCredentials(credentials, endpointUrl, resourceVersion);
 		if (!resolved || resolved.runtime !== runtime) {
@@ -1412,9 +1415,83 @@ function ConsoleTab({
 	const browserUiLabel = runtimeBrowserUiLabel(runtime);
 	const url = runtimeConsoleUrl(deployment, runtime);
 	const [credentials, setCredentials] = useState<RuntimeUiCredentials | null>(null);
+	const [credentialError, setCredentialError] = useState<Error | null>(null);
+	const [isCredentialLoading, setIsCredentialLoading] = useState(false);
+	const [isOpenClawBootstrapPending, setIsOpenClawBootstrapPending] = useState(false);
 	const [credentialLoadState, setCredentialLoadState] = useState<"loading" | "ready" | "error">(
 		runtime === "openclaw" ? "loading" : "ready",
 	);
+	const requestCredentials = useRuntimeUiCredentialRequest(deployment, url, runtime);
+	const requestVersionRef = useRef(0);
+	const loadedCredentialIdentityRef = useRef<string | null>(null);
+	const credentialIdentity = `${deployment.resource.id}\0${deployment.resource.metadata.resourceVersion}\0${runtime}\0${url ?? ""}\0${isRunning}`;
+
+	const loadCredentials = useCallback(
+		async ({ allowDirectOpenOnFailure = false } = {}): Promise<RuntimeUiCredentials | null> => {
+			const requestVersion = requestVersionRef.current + 1;
+			requestVersionRef.current = requestVersion;
+			setIsCredentialLoading(true);
+			setCredentialError(null);
+			setCredentialLoadState("loading");
+			try {
+				const resolved = await requestCredentials();
+				if (requestVersionRef.current !== requestVersion) return null;
+				setCredentials(resolved);
+				setCredentialLoadState("ready");
+				return resolved;
+			} catch (error) {
+				if (requestVersionRef.current === requestVersion) {
+					setCredentialError(
+						error instanceof Error ? error : new Error("Runtime UI credential request failed"),
+					);
+					setCredentialLoadState(
+						runtime === "openclaw" && allowDirectOpenOnFailure ? "ready" : "error",
+					);
+					if (!allowDirectOpenOnFailure) setIsOpenClawBootstrapPending(false);
+				}
+				return null;
+			} finally {
+				if (requestVersionRef.current === requestVersion) setIsCredentialLoading(false);
+			}
+		},
+		[requestCredentials, runtime],
+	);
+
+	const clearCredentials = useCallback(() => {
+		requestVersionRef.current += 1;
+		setCredentials(null);
+		setCredentialError(null);
+		setIsCredentialLoading(false);
+		setIsOpenClawBootstrapPending(false);
+		setCredentialLoadState(runtime === "openclaw" ? "loading" : "ready");
+	}, [runtime]);
+
+	const reconnectOpenClaw = useCallback(() => {
+		forgetOpenClawBootstrapAttempt(window.localStorage, deployment.resource.id);
+		setIsOpenClawBootstrapPending(true);
+		return loadCredentials();
+	}, [deployment.resource.id, loadCredentials]);
+
+	useEffect(() => {
+		if (loadedCredentialIdentityRef.current === credentialIdentity) return;
+		loadedCredentialIdentityRef.current = credentialIdentity;
+		clearCredentials();
+		if (runtime !== "openclaw" || !isRunning || !url) return;
+		if (hasOpenClawBootstrapAttempt(window.localStorage, deployment.resource.id, url)) {
+			setCredentialLoadState("ready");
+			return;
+		}
+		setIsOpenClawBootstrapPending(true);
+		void loadCredentials({ allowDirectOpenOnFailure: true });
+	}, [
+		clearCredentials,
+		credentialIdentity,
+		deployment.resource.id,
+		isRunning,
+		loadCredentials,
+		runtime,
+		url,
+	]);
 
 	if (status.kind === "stopped") {
 		return <StoppedAgentState deployment={deployment} />;
@@ -1514,7 +1591,9 @@ function ConsoleTab({
 		runtime === "openclaw"
 			? credentials?.runtime === "openclaw"
 				? runtimeUiLaunchTarget(credentials)
-				: "about:blank"
+				: credentialLoadState === "ready"
+					? url
+					: "about:blank"
 			: url;
 
 	return (
@@ -1527,17 +1606,37 @@ function ConsoleTab({
 					endpointUrl={url}
 					runtime={runtime}
 					credentials={credentials}
-					onCredentialsChange={setCredentials}
-					onCredentialLoadStateChange={setCredentialLoadState}
+					credentialError={credentialError}
+					isCredentialLoading={isCredentialLoading}
+					isOpenClawBootstrapPending={isOpenClawBootstrapPending}
+					onLoadCredentials={loadCredentials}
+					onClearCredentials={clearCredentials}
+					onReconnectOpenClaw={reconnectOpenClaw}
 				/>
 			}
 		>
-			{runtime === "openclaw" && !credentials ? (
+			{runtime === "openclaw" && credentialLoadState !== "ready" ? (
 				credentialLoadState === "error" ? (
 					<EmptyState
 						icon={AlertCircle}
 						title={`${browserUiLabel} could not be opened`}
-						description="Runtime UI access could not be loaded. Open Access to retry."
+						description="Clawdi couldn't establish this browser session."
+						action={
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								disabled={isCredentialLoading}
+								onClick={() => void reconnectOpenClaw()}
+							>
+								{isCredentialLoading ? (
+									<Spinner className="size-3.5" />
+								) : (
+									<RefreshCw className="size-3.5" />
+								)}
+								Retry
+							</Button>
+						}
 					/>
 				) : (
 					<div role="status" className="flex min-h-[420px] flex-1">
@@ -1555,6 +1654,18 @@ function ConsoleTab({
 					title={browserUiLabel}
 					className="min-h-[420px] flex-1 border-0 bg-background"
 					allow="clipboard-read; clipboard-write"
+					onLoad={
+						runtime === "openclaw"
+							? () => {
+									rememberOpenClawBootstrapAttempt(
+										window.localStorage,
+										deployment.resource.id,
+										url,
+									);
+									setIsOpenClawBootstrapPending(false);
+								}
+							: undefined
+					}
 				/>
 			)}
 		</LiveToolFrame>
@@ -1686,25 +1797,27 @@ function RuntimeUiAccessDialog({
 	endpointUrl,
 	runtime,
 	credentials,
-	onCredentialsChange,
-	onCredentialLoadStateChange,
+	credentialError,
+	isCredentialLoading,
+	isOpenClawBootstrapPending,
+	onLoadCredentials,
+	onClearCredentials,
+	onReconnectOpenClaw,
 }: {
 	deployment: HostedDeployment;
 	endpointUrl: string;
 	runtime: Runtime;
 	credentials: RuntimeUiCredentials | null;
-	onCredentialsChange: (credentials: RuntimeUiCredentials | null) => void;
-	onCredentialLoadStateChange: (state: "loading" | "ready" | "error") => void;
+	credentialError: Error | null;
+	isCredentialLoading: boolean;
+	isOpenClawBootstrapPending: boolean;
+	onLoadCredentials: () => Promise<RuntimeUiCredentials | null>;
+	onClearCredentials: () => void;
+	onReconnectOpenClaw: () => Promise<RuntimeUiCredentials | null>;
 }) {
 	const label = runtimeBrowserUiLabel(runtime);
-	const requestCredentials = useRuntimeUiCredentialRequest(deployment, endpointUrl, runtime);
 	const reset = useResetRuntimeUiAccess();
 	const [open, setOpen] = useState(false);
-	const [credentialError, setCredentialError] = useState<Error | null>(null);
-	const [isLoading, setIsLoading] = useState(false);
-	const [isLaunching, setIsLaunching] = useState(false);
-	const launchingRef = useRef(false);
-	const requestVersionRef = useRef(0);
 	const loadedIdentityRef = useRef<string | null>(null);
 	const triggerRef = useRef<HTMLButtonElement>(null);
 	const [accessHintOpen, setAccessHintOpen] = useState(false);
@@ -1712,6 +1825,7 @@ function RuntimeUiAccessDialog({
 	const renderedCredentials = credentialExit.renderedValue;
 	const identity = `${deployment.resource.id}\0${deployment.resource.metadata.resourceVersion}\0${runtime}\0${endpointUrl}`;
 	const accessHintStorageKey = hermesAccessHintStorageKey(deployment.resource.id);
+	const isOpenClawOpening = runtime === "openclaw" && isOpenClawBootstrapPending;
 
 	const dismissAccessHint = useCallback(() => {
 		setAccessHintOpen(false);
@@ -1722,47 +1836,12 @@ function RuntimeUiAccessDialog({
 		}
 	}, [accessHintStorageKey]);
 
-	const clearSensitiveState = useCallback(() => {
-		requestVersionRef.current += 1;
-		onCredentialsChange(null);
-		setCredentialError(null);
-		setIsLoading(false);
-		onCredentialLoadStateChange(runtime === "openclaw" ? "loading" : "ready");
-	}, [onCredentialLoadStateChange, onCredentialsChange, runtime]);
-
-	const loadCredentials = useCallback(async (): Promise<RuntimeUiCredentials | null> => {
-		const requestVersion = requestVersionRef.current + 1;
-		requestVersionRef.current = requestVersion;
-		setIsLoading(true);
-		setCredentialError(null);
-		onCredentialLoadStateChange("loading");
-		try {
-			const resolved = await requestCredentials();
-			if (requestVersionRef.current !== requestVersion) return null;
-			onCredentialsChange(resolved);
-			onCredentialLoadStateChange("ready");
-			return resolved;
-		} catch (error) {
-			if (requestVersionRef.current === requestVersion) {
-				setCredentialError(
-					error instanceof Error ? error : new Error("Runtime UI credential request failed"),
-				);
-				onCredentialLoadStateChange("error");
-			}
-			return null;
-		} finally {
-			if (requestVersionRef.current === requestVersion) setIsLoading(false);
-		}
-	}, [onCredentialLoadStateChange, onCredentialsChange, requestCredentials]);
-
 	useEffect(() => {
 		if (loadedIdentityRef.current === identity) return;
 		loadedIdentityRef.current = identity;
 		if (open) credentialExit.beginClose();
-		clearSensitiveState();
 		setOpen(false);
-		if (runtime === "openclaw") void loadCredentials();
-	}, [clearSensitiveState, credentialExit.beginClose, identity, loadCredentials, open, runtime]);
+	}, [credentialExit.beginClose, identity, open]);
 
 	useEffect(() => {
 		if (runtime !== "hermes") {
@@ -1781,23 +1860,21 @@ function RuntimeUiAccessDialog({
 			if (nextOpen) credentialExit.beginOpen();
 			else credentialExit.beginClose();
 			setOpen(nextOpen);
-			if (nextOpen && runtime === "hermes") dismissAccessHint();
-			if (nextOpen && !credentials && !isLoading) void loadCredentials();
+			if (nextOpen) dismissAccessHint();
+			if (nextOpen && !credentials && !isCredentialLoading) void onLoadCredentials();
 		},
 		[
 			credentialExit.beginClose,
 			credentialExit.beginOpen,
 			credentials,
 			dismissAccessHint,
-			isLoading,
-			loadCredentials,
-			runtime,
+			isCredentialLoading,
+			onLoadCredentials,
 		],
 	);
 
-	const openRuntime = useCallback(async () => {
-		if (launchingRef.current) return;
-		const popup = openSecureRuntimeWindow(window.open.bind(window));
+	const openRuntime = useCallback(() => {
+		const popup = openSecureRuntimeWindow(window.open.bind(window), endpointUrl);
 		if (!popup) {
 			toast.error(`Couldn't open ${label}`, {
 				id: RUNTIME_UI_LAUNCH_TOAST_ID,
@@ -1806,196 +1883,176 @@ function RuntimeUiAccessDialog({
 			});
 			return;
 		}
-		launchingRef.current = true;
-		setIsLaunching(true);
-
-		try {
-			let launchCredentials: RuntimeUiCredentials;
-			try {
-				launchCredentials = await loadRuntimeUiLaunchCredentials(
-					runtime,
-					credentials,
-					requestCredentials,
-				);
-			} catch {
-				try {
-					popup.close();
-				} catch {
-					// Browser isolation may have severed the WindowProxy.
-				}
-				toast.error(`Couldn't open ${label}`, {
-					id: RUNTIME_UI_LAUNCH_TOAST_ID,
-					description: "Runtime UI access couldn't be loaded. Open Access to retry.",
-				});
-				return;
-			}
-
-			try {
-				popup.location.replace(runtimeUiLaunchTarget(launchCredentials));
-				trackRuntimeWindow(deployment.resource.id, popup);
-			} catch {
-				try {
-					popup.close();
-				} catch {
-					// Browser isolation may have severed the WindowProxy.
-				}
-				toast.error(`Couldn't open ${label}`, {
-					id: RUNTIME_UI_LAUNCH_TOAST_ID,
-					description: "The new window couldn't be connected. Try again.",
-				});
-			}
-		} finally {
-			launchingRef.current = false;
-			setIsLaunching(false);
-		}
-	}, [credentials, deployment.resource.id, label, requestCredentials, runtime]);
+		trackRuntimeWindow(deployment.resource.id, popup);
+	}, [deployment.resource.id, endpointUrl, label]);
 
 	const acceptReset = useCallback(async () => {
 		await reset.mutateAsync({ id: deployment.resource.id });
 		credentialExit.beginClose();
-		clearSensitiveState();
+		onClearCredentials();
 		setOpen(false);
-	}, [clearSensitiveState, credentialExit.beginClose, deployment.resource.id, reset]);
+	}, [credentialExit.beginClose, deployment.resource.id, onClearCredentials, reset]);
 
 	return (
 		<Dialog
-			open={open}
+			open={runtime === "hermes" && open}
 			onOpenChange={handleOpenChange}
 			onOpenChangeComplete={(nextOpen) => {
 				if (!nextOpen) credentialExit.completeClose();
 			}}
 		>
 			<div className="flex items-center gap-1.5">
-				<Popover
-					open={runtime === "hermes" && accessHintOpen}
-					onOpenChange={(nextOpen) => {
-						if (!nextOpen) dismissAccessHint();
-					}}
-				>
-					<PopoverTrigger
-						render={
-							<Button
-								ref={triggerRef}
-								type="button"
-								variant="outline"
-								size="sm"
-								onClick={() => handleOpenChange(true)}
-								aria-label={`Access ${label}`}
-							/>
-						}
+				{runtime === "hermes" ? (
+					<Popover
+						open={accessHintOpen}
+						onOpenChange={(nextOpen) => {
+							if (!nextOpen) dismissAccessHint();
+						}}
 					>
-						Access
-					</PopoverTrigger>
-					<PopoverContent side="bottom" align="end" className="w-72 gap-2">
-						<div className="flex items-start justify-between gap-3">
-							<PopoverHeader>
-								<PopoverTitle>Sign in to Hermes</PopoverTitle>
-								<PopoverDescription>
-									Get your Hermes username and password from Access.
-								</PopoverDescription>
-							</PopoverHeader>
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon-xs"
-								onClick={dismissAccessHint}
-								aria-label="Dismiss Hermes sign-in hint"
-							>
-								<X />
-							</Button>
-						</div>
-					</PopoverContent>
-				</Popover>
+						<PopoverTrigger
+							render={
+								<Button
+									ref={triggerRef}
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={() => handleOpenChange(true)}
+									aria-label={`Access ${label}`}
+								/>
+							}
+						>
+							Access
+						</PopoverTrigger>
+						<PopoverContent side="bottom" align="end" className="w-72 gap-2">
+							<div className="flex items-start justify-between gap-3">
+								<PopoverHeader>
+									<PopoverTitle>Sign in to Hermes</PopoverTitle>
+									<PopoverDescription>
+										Get your Hermes username and password from Access.
+									</PopoverDescription>
+								</PopoverHeader>
+								<Button
+									type="button"
+									variant="ghost"
+									size="icon-xs"
+									onClick={dismissAccessHint}
+									aria-label="Dismiss Hermes sign-in hint"
+								>
+									<X />
+								</Button>
+							</div>
+						</PopoverContent>
+					</Popover>
+				) : (
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						disabled={isCredentialLoading || isOpenClawOpening}
+						onClick={() => void onReconnectOpenClaw()}
+					>
+						{isCredentialLoading || isOpenClawOpening ? (
+							<Spinner className="size-3.5" />
+						) : (
+							<RefreshCw className="size-3.5" />
+						)}
+						Reconnect
+					</Button>
+				)}
 				<Button
 					type="button"
 					variant="outline"
 					size="sm"
-					disabled={isLaunching}
-					onClick={() => void openRuntime()}
+					disabled={isOpenClawOpening}
+					onClick={openRuntime}
 					aria-label={`Open ${label} in new window`}
 				>
-					{isLaunching ? <Spinner className="size-3.5" /> : <ExternalLink className="size-3.5" />}
+					{isOpenClawOpening ? (
+						<Spinner className="size-3.5" />
+					) : (
+						<ExternalLink className="size-3.5" />
+					)}
 					<span className="hidden sm:inline">
-						{isLaunching ? "Opening…" : "Open in new window"}
+						{isOpenClawOpening ? "Opening…" : "Open in new window"}
 					</span>
-					<span className="sm:hidden">{isLaunching ? "Opening…" : "Open"}</span>
+					<span className="sm:hidden">{isOpenClawOpening ? "Opening…" : "Open"}</span>
 				</Button>
 			</div>
-			<DialogContent
-				data-hosted="true"
-				data-v2="true"
-				className="sm:max-w-md"
-				finalFocus={triggerRef}
-			>
-				<DialogHeader>
-					<DialogTitle>Runtime UI access</DialogTitle>
-					<DialogDescription>
-						View or copy the current {label} access details. Reset rotates the same access material
-						through the normal agent rollout.
-					</DialogDescription>
-				</DialogHeader>
+			{runtime === "hermes" ? (
+				<DialogContent
+					data-hosted="true"
+					data-v2="true"
+					className="sm:max-w-md"
+					finalFocus={triggerRef}
+				>
+					<DialogHeader>
+						<DialogTitle>Runtime UI access</DialogTitle>
+						<DialogDescription>
+							View or copy the current {label} access details. Reset rotates the same access
+							material through the normal agent rollout.
+						</DialogDescription>
+					</DialogHeader>
 
-				{isLoading ? (
-					<div
-						role="status"
-						className="flex items-center gap-2 rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground"
-					>
-						<Spinner className="size-4" />
-						Loading Runtime UI access…
-					</div>
-				) : null}
+					{isCredentialLoading ? (
+						<div
+							role="status"
+							className="flex items-center gap-2 rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground"
+						>
+							<Spinner className="size-4" />
+							Loading Runtime UI access…
+						</div>
+					) : null}
 
-				{credentialError ? (
-					<ApiErrorPanel
-						error={credentialError}
-						onRetry={() => void loadCredentials()}
-						normalizer={billingErrorNormalizer}
-						title={`Couldn't load ${label} access`}
-					/>
-				) : null}
+					{credentialError ? (
+						<ApiErrorPanel
+							error={credentialError}
+							onRetry={() => void onLoadCredentials()}
+							normalizer={billingErrorNormalizer}
+							title={`Couldn't load ${label} access`}
+						/>
+					) : null}
 
-				{renderedCredentials?.runtime === "hermes" ? (
-					<div className="overflow-hidden rounded-lg border bg-card/60">
-						<RuntimeUiCredentialRow label="Username" value={renderedCredentials.username} />
-						<Separator />
-						<RuntimeUiCredentialRow label="Password" value={renderedCredentials.password} secret />
-					</div>
-				) : null}
+					{renderedCredentials?.runtime === "hermes" ? (
+						<div className="overflow-hidden rounded-lg border bg-card/60">
+							<RuntimeUiCredentialRow label="Username" value={renderedCredentials.username} />
+							<Separator />
+							<RuntimeUiCredentialRow
+								label="Password"
+								value={renderedCredentials.password}
+								secret
+							/>
+						</div>
+					) : null}
 
-				{renderedCredentials?.runtime === "openclaw" ? (
-					<div className="overflow-hidden rounded-lg border bg-card/60">
-						<RuntimeUiCredentialRow label="Token" value={renderedCredentials.token} secret />
-					</div>
-				) : null}
-
-				<div className="flex flex-wrap justify-end gap-2">
-					<ConfirmAction
-						title="Reset Runtime UI access?"
-						description={
-							<p>
-								This rotates the {runtime === "hermes" ? "Hermes credentials" : "OpenClaw token"}
-								and restarts the agent through its normal rollout.
-							</p>
-						}
-						confirmLabel="Reset access"
-						destructive
-						onConfirm={acceptReset}
-					>
-						<Button type="button" variant="outline" disabled={isLoading || reset.isPending}>
-							{reset.isPending ? <Spinner className="size-3.5" /> : null}
-							Reset access
+					<div className="flex flex-wrap justify-end gap-2">
+						<ConfirmAction
+							title="Reset Runtime UI access?"
+							description={
+								<p>
+									This rotates the Hermes credentials and restarts the agent through its normal
+									rollout.
+								</p>
+							}
+							confirmLabel="Reset access"
+							destructive
+							onConfirm={acceptReset}
+						>
+							<Button
+								type="button"
+								variant="outline"
+								disabled={isCredentialLoading || reset.isPending}
+							>
+								{reset.isPending ? <Spinner className="size-3.5" /> : null}
+								Reset access
+							</Button>
+						</ConfirmAction>
+						<Button type="button" disabled={reset.isPending} onClick={openRuntime}>
+							<ExternalLink className="size-3.5" />
+							Open in new window
 						</Button>
-					</ConfirmAction>
-					<Button
-						type="button"
-						disabled={isLaunching || reset.isPending}
-						onClick={() => void openRuntime()}
-					>
-						{isLaunching ? <Spinner className="size-3.5" /> : <ExternalLink className="size-3.5" />}
-						{isLaunching ? "Opening…" : "Open in new window"}
-					</Button>
-				</div>
-			</DialogContent>
+					</div>
+				</DialogContent>
+			) : null}
 		</Dialog>
 	);
 }

--- a/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { RuntimeUiCredentials } from "@clawdi/shared/api";
 import {
-	loadRuntimeUiLaunchCredentials,
+	forgetOpenClawBootstrapAttempt,
+	hasOpenClawBootstrapAttempt,
 	openSecureRuntimeWindow,
+	rememberOpenClawBootstrapAttempt,
 	resolveRuntimeUiCredentials,
 	runtimeUiLaunchTarget,
 } from "@/hosted/agents/runtime-ui-credentials";
@@ -12,14 +14,21 @@ describe("runtime UI credential targeting", () => {
 		const calls: unknown[][] = [];
 		const popup = {
 			close() {},
-			location: { replace() {} },
+			location: {
+				replace(url: string | URL) {
+					calls.push(["replace", url]);
+				},
+			},
 			opener: { unsafe: true },
 		};
 		const opened = openSecureRuntimeWindow((...args) => {
 			calls.push(args);
 			return popup;
-		});
-		expect(calls).toEqual([["about:blank", "_blank"]]);
+		}, "https://runtime.example/openclaw/");
+		expect(calls).toEqual([
+			["about:blank", "_blank"],
+			["replace", "https://runtime.example/openclaw/"],
+		]);
 		expect(opened?.opener).toBeNull();
 	});
 
@@ -107,46 +116,30 @@ describe("runtime UI credential targeting", () => {
 		).toBeNull();
 	});
 
-	test("requests a fresh single-use handoff for every OpenClaw window", async () => {
-		const embedded: RuntimeUiCredentials = {
-			runtime: "openclaw",
-			auth_mode: "openclaw_token",
-			url: "https://runtime.example/openclaw/",
-			deployment_resource_version: "rv-current",
-			token: "deployment-token",
-			handoff_url:
-				"https://runtime.example/openclaw/#bootstrapToken=embedded-token&bootstrapProfile=owner",
-		};
-		const fresh: RuntimeUiCredentials = {
-			...embedded,
-			handoff_url:
-				"https://runtime.example/openclaw/#bootstrapToken=fresh-token&bootstrapProfile=owner",
-		};
-		let requests = 0;
-
-		const resolved = await loadRuntimeUiLaunchCredentials("openclaw", embedded, async () => {
-			requests += 1;
-			return fresh;
-		});
-
-		expect(requests).toBe(1);
-		expect(resolved).toBe(fresh);
-	});
-
-	test("reuses non-single-use Hermes credentials", async () => {
-		const current: RuntimeUiCredentials = {
-			runtime: "hermes",
-			auth_mode: "password",
-			url: "https://runtime.example/hermes",
-			deployment_resource_version: "rv-current",
-			username: "admin",
-			password: "deployment-password",
+	test("remembers only that this browser attempted OpenClaw bootstrap", () => {
+		const values = new Map<string, string>();
+		const storage = {
+			getItem: (key: string) => values.get(key) ?? null,
+			setItem: (key: string, value: string) => values.set(key, value),
+			removeItem: (key: string) => values.delete(key),
 		};
 
-		const resolved = await loadRuntimeUiLaunchCredentials("hermes", current, async () => {
-			throw new Error("Hermes credentials should not be requested again");
-		});
-
-		expect(resolved).toBe(current);
+		expect(
+			hasOpenClawBootstrapAttempt(storage, "hdep_one", "https://one.runtime.example/"),
+		).toBeFalse();
+		rememberOpenClawBootstrapAttempt(storage, "hdep_one", "https://one.runtime.example/");
+		expect(
+			hasOpenClawBootstrapAttempt(storage, "hdep_one", "https://one.runtime.example/"),
+		).toBeTrue();
+		expect(
+			hasOpenClawBootstrapAttempt(storage, "hdep_one", "https://moved.runtime.example/"),
+		).toBeFalse();
+		expect(
+			hasOpenClawBootstrapAttempt(storage, "hdep_two", "https://one.runtime.example/"),
+		).toBeFalse();
+		forgetOpenClawBootstrapAttempt(storage, "hdep_one");
+		expect(
+			hasOpenClawBootstrapAttempt(storage, "hdep_one", "https://one.runtime.example/"),
+		).toBeFalse();
 	});
 });

--- a/apps/web/src/hosted/agents/runtime-ui-credentials.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-credentials.ts
@@ -11,12 +11,66 @@ type OpenRuntimeWindow = (
 	features?: string,
 ) => RuntimeWindow | null;
 
-export function openSecureRuntimeWindow(openWindow: OpenRuntimeWindow): RuntimeWindow | null {
-	// `noopener` may intentionally make window.open return null even when the
-	// browser opened the tab, which would leave an async token handoff unable
-	// to navigate it. Detach the synchronously opened placeholder immediately.
+type RuntimeUiBootstrapStorage = Pick<Storage, "getItem" | "removeItem" | "setItem">;
+
+const OPENCLAW_BOOTSTRAP_STORAGE_PREFIX = "clawdi.openclaw-bootstrap-attempted";
+
+function openClawBootstrapStorageKey(deploymentId: string): string {
+	return `${OPENCLAW_BOOTSTRAP_STORAGE_PREFIX}.${deploymentId}`;
+}
+
+export function hasOpenClawBootstrapAttempt(
+	storage: RuntimeUiBootstrapStorage,
+	deploymentId: string,
+	endpointUrl: string,
+): boolean {
+	try {
+		return storage.getItem(openClawBootstrapStorageKey(deploymentId)) === endpointUrl;
+	} catch {
+		return false;
+	}
+}
+
+export function rememberOpenClawBootstrapAttempt(
+	storage: RuntimeUiBootstrapStorage,
+	deploymentId: string,
+	endpointUrl: string,
+): void {
+	try {
+		storage.setItem(openClawBootstrapStorageKey(deploymentId), endpointUrl);
+	} catch {
+		// Browser storage is only an optimization; OpenClaw remains authoritative.
+	}
+}
+
+export function forgetOpenClawBootstrapAttempt(
+	storage: RuntimeUiBootstrapStorage,
+	deploymentId: string,
+): void {
+	try {
+		storage.removeItem(openClawBootstrapStorageKey(deploymentId));
+	} catch {
+		// A fresh handoff can still proceed when browser storage is unavailable.
+	}
+}
+
+export function openSecureRuntimeWindow(
+	openWindow: OpenRuntimeWindow,
+	url = "about:blank",
+): RuntimeWindow | null {
 	const popup = openWindow("about:blank", "_blank");
-	if (popup) popup.opener = null;
+	if (!popup) return null;
+	popup.opener = null;
+	try {
+		if (url !== "about:blank") popup.location.replace(url);
+	} catch {
+		try {
+			popup.close();
+		} catch {
+			// Browser isolation may have severed the WindowProxy.
+		}
+		return null;
+	}
 	return popup;
 }
 
@@ -61,15 +115,4 @@ export function resolveRuntimeUiCredentials(
 
 export function runtimeUiLaunchTarget(credentials: RuntimeUiCredentials): string {
 	return credentials.runtime === "openclaw" ? credentials.handoff_url : credentials.url;
-}
-
-export async function loadRuntimeUiLaunchCredentials(
-	runtime: RuntimeUiCredentials["runtime"],
-	currentCredentials: RuntimeUiCredentials | null,
-	requestCredentials: () => Promise<RuntimeUiCredentials>,
-): Promise<RuntimeUiCredentials> {
-	// OpenClaw handoffs are single-use. The embedded UI and each new window
-	// must receive different credentials.
-	if (runtime === "openclaw") return requestCredentials();
-	return currentCredentials?.runtime === "hermes" ? currentCredentials : requestCredentials();
 }

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -178,16 +178,12 @@ describe("deploy wizard product copy and flow", () => {
 });
 
 describe("hosted agent security and copy", () => {
-	test("shows the Hermes username and masks Hermes and OpenClaw secrets", () => {
+	test("shows and masks the Hermes credentials without exposing OpenClaw tokens", () => {
 		expect(agentDetailSource).toContain(
 			'<RuntimeUiCredentialRow label="Username" value={renderedCredentials.username} />',
 		);
-		expect(agentDetailSource).toContain(
-			'<RuntimeUiCredentialRow label="Password" value={renderedCredentials.password} secret />',
-		);
-		expect(agentDetailSource).toContain(
-			'<RuntimeUiCredentialRow label="Token" value={renderedCredentials.token} secret />',
-		);
+		expect(agentDetailSource).toContain("value={renderedCredentials.password}");
+		expect(agentDetailSource).not.toContain('<RuntimeUiCredentialRow label="Token"');
 		expect(agentDetailSource).not.toContain("hermes-password-");
 		expect(agentDetailSource).not.toContain("openclaw-token-");
 	});

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1137,6 +1137,16 @@ installed binary cannot issue that handoff, Hosted preserves the existing exact
 own device-auth policy. This fallback neither disables device auth nor approves
 pending devices, and Clawdi implements no parallel device-auth protocol.
 
+OpenClaw persists the issued device credential in its own browser origin and
+reuses it when that browser later opens the clean dashboard URL. Clawdi records
+only that a bootstrap was attempted for the deployment and published endpoint,
+so returning to Agent Interface and opening a new window do not request another
+single-use handoff. An endpoint change requires a new bootstrap.
+The embedding page cannot inspect OpenClaw's cross-origin storage or connection
+state, and an iframe load is not treated as authentication proof. `Reconnect`
+explicitly requests a fresh native handoff when the OpenClaw UI reports that its
+stored session is no longer usable.
+
 Hermes direct exposure requires `hermes-basic-auth-v1`, a stable HTTPS public
 URL (including any path prefix), exact `0.0.0.0:9119` service args, and the
 official Basic password/session environment secret references. Hosted derives


### PR DESCRIPTION
## Summary

- bootstrap OpenClaw once per browser, deployment, and published endpoint
- reuse OpenClaw's own persisted device session for the embedded UI and new windows
- replace OpenClaw Access/token controls with bounded Reconnect and direct new-window actions
- show explicit opening state and fall back to the clean dashboard URL when handoff issuance is unavailable

## Design

The Clawdi page cannot inspect a cross-origin OpenClaw iframe's storage, DOM, or authenticated WebSocket state, and OpenClaw does not publish an auth-ready postMessage contract. The browser hint therefore records only that bootstrap was attempted; OpenClaw remains the sole session authority. Reconnect explicitly requests a fresh official handoff.

A new window navigates synchronously to the clean endpoint and never requests another single-use handoff. During initial handoff consumption, Reconnect and new-window actions are disabled to prevent a second token race. Hermes keeps the existing Access username/password flow.

## Verification

- Docker clean Web typecheck
- full Web test suite
- focused Runtime UI suite: 73 passed
- OSS production build
- touched-file Biome
- git diff --check

The first full-suite attempt stopped during dependency installation because npm returned simultaneous tarball integrity/extraction errors. A clean retry installed the same frozen lockfile and passed.
