### PR TITLE
fix(web): avoid session delete transition error

### DIFF
--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -95,10 +95,14 @@ export function SessionDetailContent({
 				queryKey: ["get", "/v1/dashboard/stats"],
 				refetchType: "none",
 			});
-			queryClient.removeQueries({ queryKey: sessionDetailQueryKey(sessionId), exact: true });
-			queryClient.removeQueries({ queryKey: ["session-messages", sessionId] });
-			queryClient.removeQueries({ queryKey: ["session-permissions", sessionId] });
-			void router.navigate({ href: sessionsHref });
+			void router.navigate({ href: sessionsHref, replace: true }).then(
+				() => {
+					queryClient.removeQueries({ queryKey: sessionDetailQueryKey(sessionId), exact: true });
+					queryClient.removeQueries({ queryKey: ["session-messages", sessionId] });
+					queryClient.removeQueries({ queryKey: ["session-permissions", sessionId] });
+				},
+				() => window.location.replace(sessionsHref),
+			);
 		},
 		onError: (error) => {
 			toast.error("Couldn't delete session", { description: normalizeApiError(error) });


### PR DESCRIPTION
## Summary
- keep the active Session detail query intact until collection navigation commits
- replace the deleted detail history entry
- fall back to a document-level replace if client navigation fails

## Verification
- scripts/test.sh web
- Biome check for the changed page
- git diff --check