### PR TITLE
feat(web): gate Agent Plugins UI per user

### DIFF
--- a/apps/web/e2e/hosted-agent-plugins.pw.ts
+++ b/apps/web/e2e/hosted-agent-plugins.pw.ts
@@ -4,23 +4,94 @@ import { includedBasicDeployment, stubHostedApi } from "./hosted-stub-api";
 const AGENT_ID = "11111111-1111-4111-8111-111111111111";
 const DEPLOYMENT_ID = "hdep_agent_plugins_closed";
 
-test("Agent Plugins has no product entry while closed", async ({ page }) => {
+const deployment = {
+	...includedBasicDeployment,
+	id: DEPLOYMENT_ID,
+	config_info: {
+		...includedBasicDeployment.config_info,
+		clawdi_cloud_environments: { hermes: AGENT_ID },
+	},
+};
+
+test("Agent Plugins stays closed without the per-user capability", async ({ page }) => {
 	await stubHostedApi(page, {
-		deployments: [
-			{
-				...includedBasicDeployment,
-				id: DEPLOYMENT_ID,
-				config_info: {
-					...includedBasicDeployment.config_info,
-					clawdi_cloud_environments: { hermes: AGENT_ID },
-				},
-			},
-		],
+		deployments: [deployment],
 	});
 
 	await page.goto(`/agents/${AGENT_ID}?source=on-clawdi&d=${DEPLOYMENT_ID}`);
 	await expect(page.getByRole("link", { name: "Plugins", exact: true })).toHaveCount(0);
 
 	await page.goto(`/agents/${AGENT_ID}/plugins?source=on-clawdi&d=${DEPLOYMENT_ID}`);
-	await expect(page.getByRole("heading", { name: "Page not found" })).toBeVisible();
+	await expect(page).toHaveURL(new RegExp(`/agents/${AGENT_ID}\\?`));
+	await expect(page.getByRole("link", { name: "Plugins", exact: true })).toHaveCount(0);
+});
+
+test("Agent Plugins opens and installs with the per-user capability", async ({ page }) => {
+	let installed = false;
+	const desired = {
+		installation_id: "22222222-2222-4222-8222-222222222222",
+		agent_id: AGENT_ID,
+		plugin_name: "sui",
+		version: "1.0.0",
+		catalog_revision: "a".repeat(40),
+		desired_state: "present",
+		convergence: "not_observed",
+		observation_error_code: null,
+		observed_at: null,
+		created_at: "2026-08-17T00:00:00Z",
+		updated_at: "2026-08-17T00:00:00Z",
+	};
+	await stubHostedApi(page, {
+		canUseAgentPluginsUI: true,
+		deployments: [deployment],
+	});
+	await page.route("http://127.0.0.1:8000/v1/plugin-catalog", async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({
+				plugins: [
+					{
+						name: "sui",
+						version: "1.0.0",
+						display_name: "Sui Agent",
+						description: "Official Sui knowledge and tools.",
+						publisher: "Mysten Labs",
+						category: "developer-tools",
+						keywords: ["sui"],
+						languages: ["en"],
+						runtimes: ["openclaw", "hermes"],
+						components: { skills: ["sui"], mcpServers: { sui: "streamable-http" } },
+						installable: true,
+					},
+				],
+			}),
+		});
+	});
+	await page.route(`http://127.0.0.1:8000/v1/agents/${AGENT_ID}/agent-plugins`, async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({ plugins: installed ? [desired] : [] }),
+		});
+	});
+	await page.route(
+		`http://127.0.0.1:8000/v1/agents/${AGENT_ID}/agent-plugins/**`,
+		async (route) => {
+			installed = true;
+			await route.fulfill({
+				status: 202,
+				contentType: "application/json",
+				body: JSON.stringify(desired),
+			});
+		},
+	);
+
+	await page.goto(`/agents/${AGENT_ID}?source=on-clawdi&d=${DEPLOYMENT_ID}`);
+	await page.getByRole("link", { name: "Plugins", exact: true }).click();
+	await expect(page.getByRole("heading", { name: "Plugins" })).toBeVisible();
+	await expect(page.getByText("Sui Agent", { exact: true })).toBeVisible();
+
+	await page.getByRole("button", { name: "Install", exact: true }).click();
+	await expect(page.getByText("Not observed", { exact: true })).toBeVisible();
 });

--- a/apps/web/e2e/hosted-stub-api.ts
+++ b/apps/web/e2e/hosted-stub-api.ts
@@ -266,11 +266,12 @@ export function readDeploymentFixture(value: unknown): unknown {
 // own modules live under /src/hosted/v2/... and a path glob would intercept
 // them and break module loading.
 
-function hostedUser(canUsePlanCBilling = true) {
+function hostedUser(canUsePlanCBilling = true, canUseAgentPluginsUI = false) {
 	return {
 		capabilities: {
 			can_use_v1: false,
 			can_use_v2: true,
+			can_use_agent_plugins_ui: canUseAgentPluginsUI,
 			can_use_plan_c_billing: canUsePlanCBilling,
 		},
 	};
@@ -760,6 +761,7 @@ export type HostedApiStubOptions = {
 	autoReloadRequests?: string[];
 	autoReloadResponses?: StubResponse[];
 	canUsePlanCBilling?: boolean;
+	canUseAgentPluginsUI?: boolean;
 	planBillingCapability?: { enabled: boolean };
 	productAccessRequests?: string[];
 	cancelRequests?: string[];
@@ -823,7 +825,10 @@ export async function stubHostedApi(page: Page, options: HostedApiStubOptions = 
 			options.productAccessRequests?.push(`DEPLOY ${p}`);
 			return fulfillJson(
 				r,
-				hostedUser(options.planBillingCapability?.enabled ?? options.canUsePlanCBilling ?? true),
+				hostedUser(
+					options.planBillingCapability?.enabled ?? options.canUsePlanCBilling ?? true,
+					options.canUseAgentPluginsUI,
+				),
 			);
 		}
 		if (p === "/v2/subscription/plans") return fulfillJson(r, plans);
@@ -1092,7 +1097,10 @@ export async function stubHostedApi(page: Page, options: HostedApiStubOptions = 
 			options.productAccessRequests?.push(`CLOUD ${p}`);
 			return fulfillJson(
 				r,
-				hostedUser(options.planBillingCapability?.enabled ?? options.canUsePlanCBilling ?? true),
+				hostedUser(
+					options.planBillingCapability?.enabled ?? options.canUsePlanCBilling ?? true,
+					options.canUseAgentPluginsUI,
+				),
 			);
 		}
 		if (p === "/v1/agents") {

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -486,7 +486,7 @@ function AgentFocusSections({
 	primaryProject?: AgentPrimaryProjectNavigation | null;
 	onNavigate?: () => void;
 }) {
-	const { legacyDashboardUrl } = useProductAccess();
+	const { legacyDashboardUrl, canUseAgentPluginsUI } = useProductAccess();
 	const legacyDashboardHref = kind === "legacy" ? legacyDashboardUrl : null;
 	const extraPrimaryItems: SidebarNavItem[] = legacyDashboardHref
 		? [
@@ -507,7 +507,9 @@ function AgentFocusSections({
 			agentId={agentId}
 			variant={kind === "cloud" ? "hosted" : "connected"}
 			visibleSectionIds={
-				kind === "cloud" ? hostedAgentVisibleSectionIds(filesAvailable === true) : undefined
+				kind === "cloud"
+					? hostedAgentVisibleSectionIds(filesAvailable === true, canUseAgentPluginsUI)
+					: undefined
 			}
 			activeSection={activeSection}
 			primaryProject={primaryProject}

--- a/apps/web/src/hosted/access/product-access-model.test.ts
+++ b/apps/web/src/hosted/access/product-access-model.test.ts
@@ -11,6 +11,7 @@ describe("hostedProductAccessFromProfile", () => {
 			legacyHostedAccessStatus: "unresolved",
 			canCreateCloudAgents: false,
 			canUseCloudAgents: false,
+			canUseAgentPluginsUI: false,
 		});
 	});
 
@@ -24,6 +25,7 @@ describe("hostedProductAccessFromProfile", () => {
 			legacyHostedAccessStatus: "disabled",
 			canCreateCloudAgents: true,
 			canUseCloudAgents: true,
+			canUseAgentPluginsUI: false,
 		});
 	});
 
@@ -37,6 +39,7 @@ describe("hostedProductAccessFromProfile", () => {
 			legacyHostedAccessStatus: "enabled",
 			canCreateCloudAgents: false,
 			canUseCloudAgents: false,
+			canUseAgentPluginsUI: false,
 		});
 	});
 
@@ -46,6 +49,7 @@ describe("hostedProductAccessFromProfile", () => {
 				capabilities: {
 					can_use_v1: false,
 					can_use_v2: false,
+					can_use_agent_plugins_ui: true,
 				},
 			}),
 		).toEqual({
@@ -53,6 +57,7 @@ describe("hostedProductAccessFromProfile", () => {
 			legacyHostedAccessStatus: "disabled",
 			canCreateCloudAgents: false,
 			canUseCloudAgents: false,
+			canUseAgentPluginsUI: true,
 		});
 	});
 });

--- a/apps/web/src/hosted/access/product-access-model.ts
+++ b/apps/web/src/hosted/access/product-access-model.ts
@@ -1,7 +1,8 @@
-export interface HostedProductCapabilities {
-	can_use_v1?: boolean;
-	can_use_v2?: boolean;
-}
+import type { DeployComponents } from "@clawdi/shared/api";
+
+type HostedProductCapabilities = Partial<
+	DeployComponents["schemas"]["V1UserProductCapabilities"]
+>;
 
 export interface HostedProductAccessProfile {
 	capabilities?: HostedProductCapabilities | null;
@@ -14,6 +15,7 @@ export interface HostedProductAccess {
 	canUseLegacyHostedDashboard: boolean;
 	legacyHostedAccessStatus: LegacyHostedAccessStatus;
 	canCreateCloudAgents: boolean;
+	canUseAgentPluginsUI: boolean;
 	/**
 	 * Back-compat alias for the rollout flag. New code should choose the
 	 * narrower `canCreateCloudAgents` name so existing deployment management
@@ -62,5 +64,6 @@ export function hostedProductAccessFromProfile(
 		legacyHostedAccessStatus,
 		canCreateCloudAgents,
 		canUseCloudAgents: canCreateCloudAgents,
+		canUseAgentPluginsUI: capabilities?.can_use_agent_plugins_ui === true,
 	};
 }

--- a/apps/web/src/hosted/access/product-access-model.ts
+++ b/apps/web/src/hosted/access/product-access-model.ts
@@ -1,8 +1,6 @@
 import type { DeployComponents } from "@clawdi/shared/api";
 
-type HostedProductCapabilities = Partial<
-	DeployComponents["schemas"]["V1UserProductCapabilities"]
->;
+type HostedProductCapabilities = Partial<DeployComponents["schemas"]["V1UserProductCapabilities"]>;
 
 export interface HostedProductAccessProfile {
 	capabilities?: HostedProductCapabilities | null;

--- a/apps/web/src/hosted/access/product-access-projection.ts
+++ b/apps/web/src/hosted/access/product-access-projection.ts
@@ -7,6 +7,7 @@ function sameProductAccess(left: ProductAccess, right: ProductAccess): boolean {
 		left.legacyDashboardUrl === right.legacyDashboardUrl &&
 		left.canCreateCloudAgents === right.canCreateCloudAgents &&
 		left.canUseCloudAgents === right.canUseCloudAgents &&
+		left.canUseAgentPluginsUI === right.canUseAgentPluginsUI &&
 		left.status === right.status &&
 		left.isLoading === right.isLoading &&
 		left.isError === right.isError &&

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/lib/agent-routes";
 import { formatShortDate } from "@/lib/format";
 import { hostedAgentVisibleSectionIds } from "@/lib/navigation-model";
+import { useProductAccess } from "@/lib/product-access";
 import { cn } from "@/lib/utils";
 
 const UNRESOLVED_HOSTED_AGENT_REFETCH_INTERVAL_MS = 5_000;
@@ -79,6 +80,7 @@ export function AgentHome({
 	routeSearch: AgentRouteSearch;
 }) {
 	const router = useRouter();
+	const { canUseAgentPluginsUI, isLoading: productAccessLoading } = useProductAccess();
 	const pathname = useLocation({ select: (location) => location.pathname });
 	const deploymentSelector = agentDeploymentSelector(routeSearch);
 	const {
@@ -111,9 +113,11 @@ export function AgentHome({
 	const [manualChecking, setManualChecking] = useState(false);
 	const ownsCurrentSection = agentRouteOwnsSection(pathname, environmentId, section);
 	const hostedSectionIds = deployment
-		? hostedAgentVisibleSectionIds(deploymentFilesUrl(deployment) !== null)
+		? hostedAgentVisibleSectionIds(deploymentFilesUrl(deployment) !== null, canUseAgentPluginsUI)
 		: HOSTED_AGENT_SECTION_IDS;
-	const hostedSection = hostedSectionIds.some((candidate) => candidate === section);
+	const agentPluginsAccessPending = section === "plugins" && productAccessLoading;
+	const hostedSection =
+		agentPluginsAccessPending || hostedSectionIds.some((candidate) => candidate === section);
 	const connectedSection = CONNECTED_AGENT_SECTION_IDS.some((candidate) => candidate === section);
 
 	// Hosted membership is asynchronous, so it cannot be resolved in beforeLoad.
@@ -271,6 +275,9 @@ export function AgentHome({
 	}
 
 	if (deployment) {
+		if (agentPluginsAccessPending) {
+			return <ConnectedAgentDetailSkeleton hosted section={section} />;
+		}
 		// Scope the detail to a single runtime. Prefer the env's matched runtime;
 		// fall back to the deployment default when the route used a deployment id.
 		const runtime =

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -40,6 +40,7 @@ const ACCEPTED_OPERATION_TRANSITIONS = {
 	restart: "restarting",
 	reset_runtime_ui_access: "restarting",
 	update: "updating",
+	migrate_runtime_context: "updating",
 	plan_change: "updating",
 	runtime_switch: "updating",
 	migrate_image: "updating",

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -219,6 +219,7 @@ import {
 	runtimeConsoleUrl,
 	runtimeDisplayName,
 } from "@/hosted/runtimes";
+import { AgentPluginsSurface } from "@/hosted/v2/agent-plugins/agent-plugins-surface";
 import { AddProviderDialog } from "@/hosted/v2/ai-providers/add-provider-dialog";
 import {
 	aiBindingBuildErrorCopy,
@@ -318,6 +319,7 @@ type HostedAgentTab =
 	| "projects"
 	| "ai"
 	| "channels"
+	| "plugins"
 	| "settings";
 function parseHostedAgentTab(value: AgentSectionId | string | null): HostedAgentTab | null {
 	if (!value) return null;
@@ -448,6 +450,7 @@ export function HostedAgentDetail({
 	onCheckDeploymentAgain: () => void;
 }) {
 	const $api = useOpenApi();
+	const { canUseAgentPluginsUI } = useProductAccess();
 	const [isCheckingProjection, setIsCheckingProjection] = useState(false);
 	const deploymentStatus = deploymentStatusFromResource(deployment.resource.status);
 	const deploymentFailure = deploymentFailurePresentation(deployment);
@@ -490,7 +493,8 @@ export function HostedAgentDetail({
 	const availableAgentTitle = agent
 		? agentDisplayName(agent)
 		: agentDisplayName({ default_name: deployment.resource.name, agent_type: runtime });
-	const requestedTab = parseHostedAgentTab(section) ?? "overview";
+	const parsedTab = parseHostedAgentTab(section) ?? "overview";
+	const requestedTab = parsedTab === "plugins" && !canUseAgentPluginsUI ? "overview" : parsedTab;
 	const filesUrl = deploymentFilesUrl(deployment);
 	const activeTab = requestedTab === "files" && filesUrl === null ? "overview" : requestedTab;
 	useSetBreadcrumbTitle(
@@ -534,7 +538,9 @@ export function HostedAgentDetail({
 		>
 			{isLiveToolTab ? <h1 className="sr-only">{availableAgentTitle}</h1> : null}
 			<section className={isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : "flex flex-col gap-6"}>
-				{isLiveToolTab || (activeTab === "projects" && projection.status === "resolved") ? null : (
+				{isLiveToolTab ||
+				activeTab === "plugins" ||
+				(activeTab === "projects" && projection.status === "resolved") ? null : (
 					<PageHeader
 						title={activeTab === "overview" ? availableAgentTitle : activeTabLabel}
 						titleAdornment={
@@ -644,6 +650,9 @@ export function HostedAgentDetail({
 						) : (
 							<ProjectionDependentUnavailable label="Projects" />
 						)
+					) : null}
+					{activeTab === "plugins" ? (
+						<AgentPluginsSurface agentId={environmentId} runtime={runtime} />
 					) : null}
 					{deploymentStatus.known && activeTab === "ai" ? (
 						<AiProviderTab

--- a/apps/web/src/hosted/deployment-failure.ts
+++ b/apps/web/src/hosted/deployment-failure.ts
@@ -108,6 +108,7 @@ export function deploymentOperationLabel(verb: DeploymentOperationVerb | null): 
 		case "reset_runtime_ui_access":
 			return "Runtime UI access reset";
 		case "update":
+		case "migrate_runtime_context":
 			return "Agent update";
 		case "runtime_switch":
 			return "Agent software change";
@@ -224,6 +225,7 @@ export function deploymentFailurePresentation(
 			};
 		case "stop":
 		case "update":
+		case "migrate_runtime_context":
 		case "reset_runtime_ui_access":
 		case "runtime_switch":
 		case "migrate_image":

--- a/apps/web/src/lib/agent-routes.test.ts
+++ b/apps/web/src/lib/agent-routes.test.ts
@@ -41,6 +41,7 @@ describe("agent routes", () => {
 		expect(agentSectionHref("agent 1", "connectors")).toBe("/agents/agent%201/connectors");
 		expect(agentSectionHref("agent 1", "ai")).toBe("/agents/agent%201/model-provider");
 		expect(agentSectionHref("agent 1", "channels")).toBe("/agents/agent%201/channel-links");
+		expect(agentSectionHref("agent 1", "plugins")).toBe("/agents/agent%201/plugins");
 		expect(agentSectionHref("agent 1", "files")).toBe("/agents/agent%201/files");
 		expect(agentSectionHref("agent 1", "settings")).toBe("/agents/agent%201/settings");
 		expect(agentSessionDetailHref("agent 1", "session 1")).toBe(

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -37,6 +37,7 @@ const AGENT_SECTION_SEGMENTS = {
 	connectors: "connectors",
 	ai: "model-provider",
 	channels: "channel-links",
+	plugins: "plugins",
 	settings: "settings",
 } as const satisfies Record<AgentSectionId, string>;
 

--- a/apps/web/src/lib/navigation-model.test.ts
+++ b/apps/web/src/lib/navigation-model.test.ts
@@ -153,7 +153,10 @@ describe("sidebar navigation model", () => {
 				id: "workspace",
 				label: "Workspace",
 				separated: false,
-				items: [{ id: "projects", label: "Projects" }],
+				items: [
+					{ id: "projects", label: "Projects" },
+					{ id: "plugins", label: "Plugins" },
+				],
 			},
 			{
 				id: "shared",
@@ -197,6 +200,7 @@ describe("sidebar navigation model", () => {
 			"overview",
 			"sessions",
 			"projects",
+			"plugins",
 			"memories",
 			"connectors",
 			"console",
@@ -208,6 +212,8 @@ describe("sidebar navigation model", () => {
 		]);
 		expect(hostedAgentVisibleSectionIds(false)).not.toContain("files");
 		expect(hostedAgentVisibleSectionIds(true)).toContain("files");
+		expect(hostedAgentVisibleSectionIds(true)).not.toContain("plugins");
+		expect(hostedAgentVisibleSectionIds(true, true)).toContain("plugins");
 
 		expect(groupShape(agentNavigationGroups("hosted", ["overview"]))).toEqual([
 			{

--- a/apps/web/src/lib/navigation-model.ts
+++ b/apps/web/src/lib/navigation-model.ts
@@ -1,4 +1,5 @@
 import {
+	Blocks,
 	FolderOpen,
 	LayoutDashboard,
 	type LucideIcon,
@@ -29,6 +30,7 @@ export type AgentSectionId =
 	| "connectors"
 	| "ai"
 	| "channels"
+	| "plugins"
 	| "settings";
 
 export type AgentNavigationVariant = "connected" | "hosted";
@@ -373,6 +375,15 @@ export const AGENT_SECTION_NAVIGATION_ITEMS: Record<AgentSectionId, AgentNavigat
 		tooltip: "Channels linked to this agent",
 		variants: ["hosted"],
 	},
+	plugins: {
+		id: "plugins",
+		label: "Plugins",
+		icon: Blocks,
+		tint: "bg-identity-7-bg text-identity-7-fg",
+		description: "Install Skills and MCP servers for this agent.",
+		tooltip: "Install plugins for this agent",
+		variants: ["hosted"],
+	},
 	settings: {
 		id: "settings",
 		...CANONICAL_NAVIGATION_IDENTITIES.settings,
@@ -385,6 +396,7 @@ export const AGENT_SECTION_NAVIGATION_ITEMS: Record<AgentSectionId, AgentNavigat
 
 export const AGENT_WORKSPACE_SECTION_IDS = [
 	"projects",
+	"plugins",
 ] as const satisfies readonly AgentSectionId[];
 
 export const AGENT_SHARED_SECTION_IDS = [
@@ -449,10 +461,14 @@ export const CONNECTED_AGENT_SECTION_IDS: readonly AgentSectionId[] =
 export const HOSTED_AGENT_SECTION_IDS: readonly AgentSectionId[] =
 	agentNavigationSectionIds("hosted");
 
-export function hostedAgentVisibleSectionIds(filesAvailable: boolean): AgentSectionId[] {
-	return filesAvailable
-		? [...HOSTED_AGENT_SECTION_IDS]
-		: HOSTED_AGENT_SECTION_IDS.filter((section) => section !== "files");
+export function hostedAgentVisibleSectionIds(
+	filesAvailable: boolean,
+	agentPluginsEnabled = false,
+): AgentSectionId[] {
+	return HOSTED_AGENT_SECTION_IDS.filter(
+		(section) =>
+			(filesAvailable || section !== "files") && (agentPluginsEnabled || section !== "plugins"),
+	);
 }
 
 export function agentNavigationGroups(

--- a/apps/web/src/lib/product-access.ts
+++ b/apps/web/src/lib/product-access.ts
@@ -11,6 +11,7 @@ export type ProductAccess = {
 	legacyDashboardUrl: string | null;
 	canCreateCloudAgents: boolean;
 	canUseCloudAgents: boolean;
+	canUseAgentPluginsUI: boolean;
 	status: ProductAccessStatus;
 	isLoading: boolean;
 	isError: boolean;
@@ -31,6 +32,7 @@ export const UNAVAILABLE_PRODUCT_ACCESS: ProductAccess = {
 	legacyDashboardUrl: null,
 	canCreateCloudAgents: false,
 	canUseCloudAgents: false,
+	canUseAgentPluginsUI: false,
 	status: "unavailable",
 	isLoading: false,
 	isError: false,

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -835,7 +835,7 @@ export interface components {
              * Verb
              * @enum {string}
              */
-            verb: "create" | "plan_change" | "start" | "stop" | "restart" | "update" | "rename" | "delete" | "reset_runtime_ui_access" | "migrate_image" | "rollback_image";
+            verb: "create" | "plan_change" | "start" | "stop" | "restart" | "update" | "migrate_runtime_context" | "rename" | "delete" | "reset_runtime_ui_access" | "migrate_image" | "rollback_image";
             /** Targetgeneration */
             targetGeneration: number;
             /** Manifestetag */
@@ -1238,6 +1238,11 @@ export interface components {
              * @default false
              */
             can_use_v2: boolean;
+            /**
+             * Can Use Agent Plugins Ui
+             * @default false
+             */
+            can_use_agent_plugins_ui: boolean;
         };
         /** V1UserResponse */
         V1UserResponse: {


### PR DESCRIPTION
## Summary
- read the Agent Plugins UI capability from the Hosted `/v1/me` contract
- expose the existing Plugins surface only for authorized hosted users
- fail closed for loading errors, direct URLs, OSS, connected agents, and all users without the capability
- keep the global rollout default off; App Settings email overrides remain the rollout authority

## Dependency
- requires Clawdi-AI/clawdi-hosted#1772 to deploy `can_use_agent_plugins_ui`

## Verification
- Web typecheck
- 76 focused Web tests
- generated Deploy API from the Hosted PR OpenAPI
- `git diff --check`
- hosted Playwright covers denied direct access and authorized install flow