### PR TITLE
fix(web): repair mobile dashboard layout

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3570,223 +3570,100 @@ test("agent rail keeps New agent after agents and retains cache after list failu
 	}
 });
 
-test("header Wallet slot stays stable from unresolved access through a long balance", async ({
+test("header Wallet adapts long balances across narrow touch layouts", async ({
 	page,
 	browser,
 	baseURL,
-}, testInfo) => {
+}) => {
 	if (!baseURL) throw new Error("Playwright baseURL is required for the Wallet header test.");
-	let releaseProductAccess: (() => void) | undefined;
-	let releaseDeploymentList: (() => void) | undefined;
-	let releaseWalletChunk: (() => void) | undefined;
-	let releaseWalletResponse: (() => void) | undefined;
-	const productAccessGate = new Promise<void>((resolve) => {
-		releaseProductAccess = resolve;
-	});
-	const deploymentListGate = new Promise<void>((resolve) => {
-		releaseDeploymentList = resolve;
-	});
-	const walletChunkGate = new Promise<void>((resolve) => {
-		releaseWalletChunk = resolve;
-	});
-	const walletResponseGate = new Promise<void>((resolve) => {
-		releaseWalletResponse = resolve;
-	});
-	const productAccessRequests: string[] = [];
-	const deploymentListRequests: string[] = [];
-	const walletRequests: string[] = [];
 	const longBalance = "$12,345,678,901,234,567,890.12";
-	let walletChunkRequests = 0;
-	await page.route("**/src/hosted/global-wallet-balance.tsx*", async (route) => {
-		walletChunkRequests += 1;
-		await walletChunkGate;
-		await route.continue();
-	});
 	await stubHostedApi(page, {
-		productAccessRequests,
-		productAccessResponseGate: productAccessGate,
-		deploymentListRequests,
-		deploymentListResponses: [[railHostedDeployment]],
-		deploymentListResponseGates: [deploymentListGate],
-		walletRequests,
 		walletResponses: [
 			{
 				body: { ...walletState, balance_usd: "12345678901234567890.12" },
 				status: 200,
 			},
 		],
-		walletResponseGates: [walletResponseGate],
 	});
 
-	try {
-		await page.goto("/agents");
-		const walletSlot = page.getByTestId("global-wallet-balance-slot");
-		const walletControl = page.getByTestId("global-wallet-balance");
-		await expect(walletSlot).toBeVisible();
-		await expect.poll(() => productAccessRequests.length).toBeGreaterThan(0);
-		await expect.poll(() => deploymentListRequests.length).toBeGreaterThan(0);
-		await expect(walletSlot.locator('[data-slot="skeleton"]')).toBeVisible();
-		await expect(walletControl).toHaveCount(0);
-		expect(walletChunkRequests).toBe(1);
-		const unresolvedSlotBox = await walletSlot.boundingBox();
-		if (!unresolvedSlotBox) throw new Error("Unresolved Wallet slot should reserve geometry.");
+	await page.goto("/agents");
+	const walletSlot = page.getByTestId("global-wallet-balance-slot");
+	const walletControl = page.getByTestId("global-wallet-balance");
+	await expect(walletControl).toContainText(longBalance);
+	await expect(walletControl).toHaveAttribute(
+		"aria-label",
+		`Wallet balance ${longBalance}. Open Wallet settings`,
+	);
+	const balanceText = walletControl.locator("span").filter({ hasText: longBalance });
+	expect(await balanceText.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(
+		true,
+	);
 
-		releaseProductAccess?.();
-		releaseDeploymentList?.();
-		await expect(walletSlot.locator('[data-slot="skeleton"]')).toBeVisible();
-		await expect(walletControl).toHaveCount(0);
-		const fallbackSlotBox = await walletSlot.boundingBox();
-		if (!fallbackSlotBox) throw new Error("Wallet chunk fallback should preserve slot geometry.");
-		expect(Math.abs(fallbackSlotBox.x - unresolvedSlotBox.x)).toBeLessThanOrEqual(1);
-		expect(Math.abs(fallbackSlotBox.y - unresolvedSlotBox.y)).toBeLessThanOrEqual(1);
-		expect(Math.abs(fallbackSlotBox.width - unresolvedSlotBox.width)).toBeLessThanOrEqual(1);
-		expect(Math.abs(fallbackSlotBox.height - unresolvedSlotBox.height)).toBeLessThanOrEqual(1);
+	await page.setViewportSize({ width: 320, height: 568 });
+	const header = page.locator("header");
+	const sidebarTrigger = page.getByRole("button", { name: "Toggle Sidebar" });
+	const separator = header.locator('[data-slot="separator"]');
+	const breadcrumb = header.locator('[data-slot="breadcrumb-list"]');
+	const notificationCenter = page.getByRole("button", { name: "Notification Center" });
+	await expectNoHorizontalOverflow(header, "Wallet header at 320px");
+	await expect(separator).toHaveCSS("width", "1px");
+	await expectContainedInOwnerAndViewport(
+		page,
+		walletControl,
+		walletSlot,
+		"Wallet header control at 320px",
+	);
+	await _expectControlsDoNotOverlap(
+		[sidebarTrigger, separator, breadcrumb, walletControl, notificationCenter],
+		"Wallet header at 320px",
+	);
+	expect(await balanceText.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(
+		true,
+	);
 
-		releaseWalletChunk?.();
-		await expect.poll(() => walletRequests.length).toBe(1);
-		await expect(walletControl).toBeEnabled();
-		await expect(walletControl.locator('[data-slot="skeleton"]')).toBeVisible();
-
-		releaseWalletResponse?.();
-		await expect(walletControl).toContainText(longBalance);
-		await expect(walletControl).toHaveAttribute(
-			"aria-label",
-			`Wallet balance ${longBalance}. Open Wallet settings`,
-		);
-		await expect(walletControl).toHaveAttribute(
-			"title",
-			`Wallet balance ${longBalance}. Open Wallet settings`,
-		);
-		const finalSlotBox = await walletSlot.boundingBox();
-		if (!finalSlotBox) throw new Error("Loaded Wallet slot should preserve header geometry.");
-		expect(Math.abs(finalSlotBox.x - unresolvedSlotBox.x)).toBeLessThanOrEqual(1);
-		expect(Math.abs(finalSlotBox.y - unresolvedSlotBox.y)).toBeLessThanOrEqual(1);
-		expect(Math.abs(finalSlotBox.width - unresolvedSlotBox.width)).toBeLessThanOrEqual(1);
-		expect(Math.abs(finalSlotBox.height - unresolvedSlotBox.height)).toBeLessThanOrEqual(1);
-		const balanceText = walletControl.locator("span").filter({ hasText: longBalance });
-		await expect(balanceText).toBeVisible();
-		expect(
-			await balanceText.evaluate(
-				(element) => element.clientWidth > 0 && element.scrollWidth > element.clientWidth,
-			),
-		).toBe(true);
-
-		await page.setViewportSize({ width: 320, height: 568 });
-		const header = page.locator("header");
-		const sidebarTrigger = page.getByRole("button", { name: "Toggle Sidebar" });
-		const separator = header.locator('[data-slot="separator"]');
-		const notificationCenter = page.getByRole("button", { name: "Notification Center" });
-		await expectNoHorizontalOverflow(header, "Wallet header at 320px");
-		await expect(separator).toHaveCSS("width", "1px");
-		await expect(separator).toHaveCSS("height", "16px");
-		await expect(walletSlot).toHaveCSS("width", "96px");
-		await expectContainedInOwnerAndViewport(
-			page,
-			walletControl,
-			walletSlot,
-			"Wallet header control at 320px",
-		);
-		await _expectControlsDoNotOverlap(
-			[sidebarTrigger, separator, walletControl, notificationCenter],
-			"Wallet header at 320px",
-		);
-		expect(walletChunkRequests).toBe(1);
-	} finally {
-		releaseProductAccess?.();
-		releaseDeploymentList?.();
-		releaseWalletChunk?.();
-		releaseWalletResponse?.();
-	}
-
-	const inapplicableContext = await browser.newContext({ baseURL });
-	const inapplicablePage = await inapplicableContext.newPage();
-	const inapplicableProductAccessRequests: string[] = [];
-	const inapplicableDeploymentListRequests: string[] = [];
-	let releaseInapplicableProductAccess: (() => void) | undefined;
-	let releaseInapplicableDeploymentList: (() => void) | undefined;
-	const inapplicableProductAccessGate = new Promise<void>((resolve) => {
-		releaseInapplicableProductAccess = resolve;
-	});
-	const inapplicableDeploymentListGate = new Promise<void>((resolve) => {
-		releaseInapplicableDeploymentList = resolve;
-	});
-	let inapplicableChunkRequests = 0;
-	try {
-		await inapplicablePage.route("**/src/hosted/global-wallet-balance.tsx*", async (route) => {
-			inapplicableChunkRequests += 1;
-			await route.continue();
-		});
-		await stubHostedApi(inapplicablePage, {
-			canCreateCloudAgents: false,
-			productAccessResponseGate: inapplicableProductAccessGate,
-			productAccessRequests: inapplicableProductAccessRequests,
-			deploymentListRequests: inapplicableDeploymentListRequests,
-			deploymentListResponses: [[]],
-			deploymentListResponseGates: [inapplicableDeploymentListGate],
-		});
-		await inapplicablePage.goto("/agents");
-		const walletSlot = inapplicablePage.getByTestId("global-wallet-balance-slot");
-		await expect(walletSlot).toBeVisible();
-		await expect.poll(() => inapplicableProductAccessRequests.length).toBeGreaterThan(0);
-		await expect.poll(() => inapplicableDeploymentListRequests.length).toBeGreaterThan(0);
-		await expect(walletSlot).toBeEmpty();
-		const unresolvedSlotBox = await walletSlot.boundingBox();
-		if (!unresolvedSlotBox) throw new Error("Inapplicable Wallet slot should reserve geometry.");
-
-		releaseInapplicableProductAccess?.();
-		releaseInapplicableDeploymentList?.();
-		await expect(
-			inapplicablePage
-				.getByTestId("app-sidebar-agent-rail")
-				.getByTestId("app-sidebar-agent-loading-slot"),
-		).toHaveCount(0);
-		await expect(
-			inapplicablePage
-				.getByTestId("app-sidebar-agent-rail")
-				.getByRole("button", { name: "New agent" }),
-		).toBeEnabled();
-		await expect(inapplicablePage.getByTestId("global-wallet-balance")).toHaveCount(0);
-		await expect(walletSlot).toBeEmpty();
-		const resolvedSlotBox = await walletSlot.boundingBox();
-		if (!resolvedSlotBox) throw new Error("Resolved Wallet slot should preserve geometry.");
-		expect(Math.abs(resolvedSlotBox.x - unresolvedSlotBox.x)).toBeLessThanOrEqual(1);
-		expect(Math.abs(resolvedSlotBox.y - unresolvedSlotBox.y)).toBeLessThanOrEqual(1);
-		expect(Math.abs(resolvedSlotBox.width - unresolvedSlotBox.width)).toBeLessThanOrEqual(1);
-		expect(Math.abs(resolvedSlotBox.height - unresolvedSlotBox.height)).toBeLessThanOrEqual(1);
-		expect(inapplicableChunkRequests).toBe(1);
-	} finally {
-		releaseInapplicableProductAccess?.();
-		releaseInapplicableDeploymentList?.();
-		await inapplicableContext.close();
-	}
-
-	const narrowContext = await browser.newContext({
+	const touchContext = await browser.newContext({
 		baseURL,
+		hasTouch: true,
 		viewport: { width: 320, height: 568 },
 	});
-	const narrowPage = await narrowContext.newPage();
+	const touchPage = await touchContext.newPage();
 	try {
-		await stubHostedApi(narrowPage);
-		await narrowPage.goto("/agents");
-		const walletControl = narrowPage.getByTestId("global-wallet-balance");
+		await stubHostedApi(touchPage);
+		await touchPage.goto("/agents");
+		expect(await touchPage.evaluate(() => matchMedia("(pointer: coarse)").matches)).toBe(true);
+		const walletControl = touchPage.getByTestId("global-wallet-balance");
 		const balanceText = walletControl.locator("span").filter({ hasText: "$25.00" });
 		await expect(walletControl).toContainText("$25.00");
 		for (const viewport of [
 			{ width: 320, height: 568 },
 			{ width: 390, height: 844 },
 		]) {
-			await narrowPage.setViewportSize(viewport);
+			await touchPage.setViewportSize(viewport);
 			expect(
 				await balanceText.evaluate((element) => element.scrollWidth <= element.clientWidth),
 			).toBe(true);
-			const header = narrowPage.locator("header");
+			const header = touchPage.locator("header");
+			const walletSlot = touchPage.getByTestId("global-wallet-balance-slot");
 			await expectNoHorizontalOverflow(header, `Wallet header at ${viewport.width}px`);
-			await header.screenshot({
-				path: testInfo.outputPath(`wallet-header-${viewport.width}x${viewport.height}.png`),
-			});
+			await expectContainedInOwnerAndViewport(
+				touchPage,
+				walletControl,
+				walletSlot,
+				`Wallet header control at ${viewport.width}px touch`,
+			);
+			await _expectControlsDoNotOverlap(
+				[
+					touchPage.getByRole("button", { name: "Toggle Sidebar" }),
+					header.locator('[data-slot="separator"]'),
+					header.locator('[data-slot="breadcrumb-list"]'),
+					walletControl,
+					touchPage.getByRole("button", { name: "Notification Center" }),
+				],
+				`Wallet header at ${viewport.width}px touch`,
+			);
 		}
 	} finally {
-		await narrowContext.close();
+		await touchContext.close();
 	}
 });
 
@@ -3944,7 +3821,6 @@ test("Console keeps its desktop columns and places Recent sessions last on narro
 	const main = page.locator("main");
 	const activity = main.getByText("Activity", { exact: true });
 	const library = main.getByText("Library", { exact: true });
-	const lastSevenDays = main.getByText("Last 7 days", { exact: true });
 	const recentSessions = main.getByRole("heading", { name: "Recent sessions", exact: true });
 	await expect(recentSessions).toBeVisible();
 
@@ -3959,28 +3835,43 @@ test("Console keeps its desktop columns and places Recent sessions last on narro
 	expect(desktopRecent.y).toBeGreaterThan(desktopActivity.y);
 	expect(desktopLibrary.x).toBeGreaterThan(desktopActivity.x);
 
-	for (const viewport of [
-		{ width: 320, height: 568 },
-		{ width: 390, height: 844 },
-	]) {
-		await page.setViewportSize(viewport);
-		const [mobileActivity, mobileLibrary, mobileLastSevenDays, mobileRecent] = await Promise.all([
-			activity.boundingBox(),
-			library.boundingBox(),
-			lastSevenDays.boundingBox(),
-			recentSessions.boundingBox(),
-		]);
-		if (!mobileActivity || !mobileLibrary || !mobileLastSevenDays || !mobileRecent) {
-			throw new Error(`Console sections should render at ${viewport.width}px.`);
-		}
-		expect(mobileLibrary.y).toBeGreaterThan(mobileActivity.y);
-		expect(mobileLastSevenDays.y).toBeGreaterThan(mobileLibrary.y);
-		expect(mobileRecent.y).toBeGreaterThan(mobileLastSevenDays.y);
-		await page.screenshot({
-			path: testInfo.outputPath(`console-${viewport.width}x${viewport.height}.png`),
-			fullPage: true,
-		});
-	}
+	await page.setViewportSize({ width: 320, height: 568 });
+	const sectionOrder = await main
+		.locator('[data-slot="card-title"], h2')
+		.evaluateAll((elements) =>
+			elements
+				.map((element) => element.textContent?.trim())
+				.filter((text) =>
+					["Activity", "Library", "Last 7 days", "Recent sessions"].includes(text ?? ""),
+				),
+		);
+	expect(sectionOrder).toEqual(["Activity", "Library", "Last 7 days", "Recent sessions"]);
+
+	const connectAgent = main.getByRole("button", { name: "Connect an agent on your machine" });
+	await expect(connectAgent).toBeVisible();
+	await expectContainedInOwnerAndViewport(
+		page,
+		connectAgent,
+		connectAgent.locator(".."),
+		"320px onboarding action",
+	);
+	await expectNoHorizontalOverflow(page.locator("html"), "320px Console document");
+	await page.screenshot({
+		path: testInfo.outputPath("console-320x568.png"),
+		fullPage: true,
+	});
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	await expectNoHorizontalOverflow(page.locator("html"), "390px Console document");
+	await page.screenshot({
+		path: testInfo.outputPath("console-390x844.png"),
+		fullPage: true,
+	});
+
+	const connectors = main.getByRole("link", { name: /^Connectors/ });
+	await connectors.focus();
+	await page.keyboard.press("Tab");
+	await expect(main.getByRole("button", { name: "View all" })).toBeFocused();
 });
 
 test("Wallet auto-reload authorizes and replaces its dedicated card responsively", async ({

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3574,7 +3574,7 @@ test("header Wallet slot stays stable from unresolved access through a long bala
 	page,
 	browser,
 	baseURL,
-}) => {
+}, testInfo) => {
 	if (!baseURL) throw new Error("Playwright baseURL is required for the Wallet header test.");
 	let releaseProductAccess: (() => void) | undefined;
 	let releaseDeploymentList: (() => void) | undefined;
@@ -3625,17 +3625,16 @@ test("header Wallet slot stays stable from unresolved access through a long bala
 		await expect(walletSlot).toBeVisible();
 		await expect.poll(() => productAccessRequests.length).toBeGreaterThan(0);
 		await expect.poll(() => deploymentListRequests.length).toBeGreaterThan(0);
-		await expect(walletSlot).toBeEmpty();
+		await expect(walletSlot.locator('[data-slot="skeleton"]')).toBeVisible();
 		await expect(walletControl).toHaveCount(0);
-		expect(walletChunkRequests).toBe(0);
+		expect(walletChunkRequests).toBe(1);
 		const unresolvedSlotBox = await walletSlot.boundingBox();
 		if (!unresolvedSlotBox) throw new Error("Unresolved Wallet slot should reserve geometry.");
 
 		releaseProductAccess?.();
 		releaseDeploymentList?.();
-		await expect(walletControl).toBeVisible();
-		await expect(walletControl).toBeDisabled();
-		await expect(walletControl.locator('[data-slot="skeleton"]')).toBeVisible();
+		await expect(walletSlot.locator('[data-slot="skeleton"]')).toBeVisible();
+		await expect(walletControl).toHaveCount(0);
 		const fallbackSlotBox = await walletSlot.boundingBox();
 		if (!fallbackSlotBox) throw new Error("Wallet chunk fallback should preserve slot geometry.");
 		expect(Math.abs(fallbackSlotBox.x - unresolvedSlotBox.x)).toBeLessThanOrEqual(1);
@@ -3646,6 +3645,7 @@ test("header Wallet slot stays stable from unresolved access through a long bala
 		releaseWalletChunk?.();
 		await expect.poll(() => walletRequests.length).toBe(1);
 		await expect(walletControl).toBeEnabled();
+		await expect(walletControl.locator('[data-slot="skeleton"]')).toBeVisible();
 
 		releaseWalletResponse?.();
 		await expect(walletControl).toContainText(longBalance);
@@ -3670,6 +3670,26 @@ test("header Wallet slot stays stable from unresolved access through a long bala
 				(element) => element.clientWidth > 0 && element.scrollWidth > element.clientWidth,
 			),
 		).toBe(true);
+
+		await page.setViewportSize({ width: 320, height: 568 });
+		const header = page.locator("header");
+		const sidebarTrigger = page.getByRole("button", { name: "Toggle Sidebar" });
+		const separator = header.locator('[data-slot="separator"]');
+		const notificationCenter = page.getByRole("button", { name: "Notification Center" });
+		await expectNoHorizontalOverflow(header, "Wallet header at 320px");
+		await expect(separator).toHaveCSS("width", "1px");
+		await expect(separator).toHaveCSS("height", "16px");
+		await expect(walletSlot).toHaveCSS("width", "96px");
+		await expectContainedInOwnerAndViewport(
+			page,
+			walletControl,
+			walletSlot,
+			"Wallet header control at 320px",
+		);
+		await _expectControlsDoNotOverlap(
+			[sidebarTrigger, separator, walletControl, notificationCenter],
+			"Wallet header at 320px",
+		);
 		expect(walletChunkRequests).toBe(1);
 	} finally {
 		releaseProductAccess?.();
@@ -3733,11 +3753,40 @@ test("header Wallet slot stays stable from unresolved access through a long bala
 		expect(Math.abs(resolvedSlotBox.y - unresolvedSlotBox.y)).toBeLessThanOrEqual(1);
 		expect(Math.abs(resolvedSlotBox.width - unresolvedSlotBox.width)).toBeLessThanOrEqual(1);
 		expect(Math.abs(resolvedSlotBox.height - unresolvedSlotBox.height)).toBeLessThanOrEqual(1);
-		expect(inapplicableChunkRequests).toBe(0);
+		expect(inapplicableChunkRequests).toBe(1);
 	} finally {
 		releaseInapplicableProductAccess?.();
 		releaseInapplicableDeploymentList?.();
 		await inapplicableContext.close();
+	}
+
+	const narrowContext = await browser.newContext({
+		baseURL,
+		viewport: { width: 320, height: 568 },
+	});
+	const narrowPage = await narrowContext.newPage();
+	try {
+		await stubHostedApi(narrowPage);
+		await narrowPage.goto("/agents");
+		const walletControl = narrowPage.getByTestId("global-wallet-balance");
+		const balanceText = walletControl.locator("span").filter({ hasText: "$25.00" });
+		await expect(walletControl).toContainText("$25.00");
+		for (const viewport of [
+			{ width: 320, height: 568 },
+			{ width: 390, height: 844 },
+		]) {
+			await narrowPage.setViewportSize(viewport);
+			expect(
+				await balanceText.evaluate((element) => element.scrollWidth <= element.clientWidth),
+			).toBe(true);
+			const header = narrowPage.locator("header");
+			await expectNoHorizontalOverflow(header, `Wallet header at ${viewport.width}px`);
+			await header.screenshot({
+				path: testInfo.outputPath(`wallet-header-${viewport.width}x${viewport.height}.png`),
+			});
+		}
+	} finally {
+		await narrowContext.close();
 	}
 });
 
@@ -3883,6 +3932,55 @@ test("Breadcrumbs show the full trail on desktop and only the current page on na
 		path: testInfo.outputPath("responsive-breadcrumb-320x568.png"),
 		fullPage: false,
 	});
+});
+
+test("Console keeps its desktop columns and places Recent sessions last on narrow screens", async ({
+	page,
+}, testInfo) => {
+	await stubHostedApi(page);
+	await page.setViewportSize({ width: 1280, height: 900 });
+	await page.goto("/");
+
+	const main = page.locator("main");
+	const activity = main.getByText("Activity", { exact: true });
+	const library = main.getByText("Library", { exact: true });
+	const lastSevenDays = main.getByText("Last 7 days", { exact: true });
+	const recentSessions = main.getByRole("heading", { name: "Recent sessions", exact: true });
+	await expect(recentSessions).toBeVisible();
+
+	const [desktopActivity, desktopLibrary, desktopRecent] = await Promise.all([
+		activity.boundingBox(),
+		library.boundingBox(),
+		recentSessions.boundingBox(),
+	]);
+	if (!desktopActivity || !desktopLibrary || !desktopRecent) {
+		throw new Error("Console sections should render in the desktop grid.");
+	}
+	expect(desktopRecent.y).toBeGreaterThan(desktopActivity.y);
+	expect(desktopLibrary.x).toBeGreaterThan(desktopActivity.x);
+
+	for (const viewport of [
+		{ width: 320, height: 568 },
+		{ width: 390, height: 844 },
+	]) {
+		await page.setViewportSize(viewport);
+		const [mobileActivity, mobileLibrary, mobileLastSevenDays, mobileRecent] = await Promise.all([
+			activity.boundingBox(),
+			library.boundingBox(),
+			lastSevenDays.boundingBox(),
+			recentSessions.boundingBox(),
+		]);
+		if (!mobileActivity || !mobileLibrary || !mobileLastSevenDays || !mobileRecent) {
+			throw new Error(`Console sections should render at ${viewport.width}px.`);
+		}
+		expect(mobileLibrary.y).toBeGreaterThan(mobileActivity.y);
+		expect(mobileLastSevenDays.y).toBeGreaterThan(mobileLibrary.y);
+		expect(mobileRecent.y).toBeGreaterThan(mobileLastSevenDays.y);
+		await page.screenshot({
+			path: testInfo.outputPath(`console-${viewport.width}x${viewport.height}.png`),
+			fullPage: true,
+		});
+	}
 });
 
 test("Wallet auto-reload authorizes and replaces its dedicated card responsively", async ({

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -564,6 +564,40 @@ async function expectSidebarNavigationGroups(
 	await expect(groups.locator('[data-slot="sidebar-group-label"]:empty')).toHaveCount(0);
 }
 
+test("sidebar toggle preserves the desktop focus rail and closes the mobile drawer", async ({
+	page,
+}) => {
+	await stubDashboardApi(page);
+	await page.setViewportSize({ width: 1280, height: 800 });
+	await page.goto("/");
+
+	const trigger = page.getByRole("button", { name: "Toggle Sidebar" });
+	const focusRail = page.getByTestId("app-sidebar-agent-rail");
+	const navigationPane = page.getByTestId("app-sidebar");
+	await expect(trigger).toBeVisible();
+	await expect(focusRail).toBeVisible();
+	await page.waitForLoadState("networkidle");
+	await trigger.click();
+	await expect
+		.poll(async () => {
+			const [railBox, paneBox] = await Promise.all([
+				focusRail.boundingBox(),
+				navigationPane.boundingBox(),
+			]);
+			if (!railBox || !paneBox) return false;
+			return paneBox.x + paneBox.width <= railBox.x + 1;
+		})
+		.toBe(true);
+	await expect(focusRail).toBeVisible();
+
+	await page.setViewportSize({ width: 320, height: 568 });
+	await trigger.click();
+	const drawer = page.getByRole("dialog", { name: "Sidebar" });
+	await expect(drawer).toBeVisible();
+	await drawer.getByRole("button", { name: "Close" }).click();
+	await expect(drawer).toBeHidden();
+});
+
 test("Console and connected agents use the scoped navigation grammar", async ({ page }) => {
 	await stubDashboardApi(page);
 	await page.goto("/");

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1347,7 +1347,7 @@ function RailSidebar({
 		<Sidebar
 			collapsible="none"
 			style={{ "--sidebar-width": "var(--clawdi-rail-width)" } as React.CSSProperties}
-			className="sticky top-0 hidden h-svh shrink-0 border-r bg-sidebar/95 md:flex"
+			className="sticky top-0 z-20 hidden h-svh shrink-0 border-r bg-sidebar/95 md:flex"
 			aria-label="Focus rail"
 			data-testid="app-sidebar-agent-rail"
 		>

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -698,7 +698,7 @@ function FocusNavigationPane({
 					activeAgentName={activeAgentName}
 				/>
 			</SidebarHeader>
-			<SidebarContent className="pb-[calc(var(--header-height)+0.75rem)]">
+			<SidebarContent className="pb-[calc(var(--header-height)+env(safe-area-inset-bottom)+0.75rem)]">
 				<SidebarMainNavigation
 					pathname={pathname}
 					showCloudFeatures={showCloudFeatures}
@@ -1088,7 +1088,7 @@ function FocusRailContent({
 
 			<SidebarSeparator className="mx-auto w-8" />
 
-			<SidebarContent className="items-center gap-2 overflow-x-hidden overflow-y-auto px-1.5 pt-2.5 pb-[calc(var(--header-height)+0.75rem)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+			<SidebarContent className="items-center gap-2 overflow-x-hidden overflow-y-auto px-1.5 pt-2.5 pb-[calc(var(--header-height)+env(safe-area-inset-bottom)+0.75rem)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 				<SidebarMenu className="w-full items-center">
 					<RailTileButton
 						render={<Link to="/" onClick={onNavigate} />}
@@ -1613,10 +1613,10 @@ function SidebarGlobalControlsBar({
 			data-sidebar="global-controls"
 			data-testid="app-sidebar-global-controls"
 			className={cn(
-				"z-30 h-(--header-height) items-center border-border border-t bg-sidebar px-3 text-sidebar-foreground",
+				"z-30 items-center border-border border-t bg-sidebar px-3 text-sidebar-foreground",
 				mobile
-					? "absolute inset-x-0 bottom-0 flex"
-					: "fixed bottom-0 left-0 hidden w-[calc(var(--clawdi-rail-width)+var(--sidebar-width))] md:flex",
+					? "absolute inset-x-0 bottom-0 flex h-[calc(var(--header-height)+env(safe-area-inset-bottom))] pb-[env(safe-area-inset-bottom)]"
+					: "fixed bottom-0 left-0 hidden h-(--header-height) w-[calc(var(--clawdi-rail-width)+var(--sidebar-width))] md:flex",
 			)}
 		>
 			<GlobalControls
@@ -1789,14 +1789,9 @@ export function AppSidebar({
 				collapsible="offcanvas"
 				variant={variant}
 				data-testid="app-sidebar"
-				style={
-					{
-						...style,
-						"--sidebar-left-offset": "var(--clawdi-rail-width)",
-					} as React.CSSProperties
-				}
+				style={style}
 				className={cn(
-					"data-[side=left]:left-[var(--clawdi-rail-width)] data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--clawdi-rail-width)-var(--sidebar-width))]",
+					"data-[side=left]:left-[var(--clawdi-rail-width)] data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]",
 					className,
 				)}
 				{...props}

--- a/apps/web/src/components/dashboard/onboarding-card.tsx
+++ b/apps/web/src/components/dashboard/onboarding-card.tsx
@@ -68,7 +68,7 @@ export function OnboardingCard({
 							type="button"
 							variant={canDeployOnClawdi ? "outline" : "default"}
 							size="lg"
-							className="w-full"
+							className="h-auto min-h-10 w-full whitespace-normal py-2"
 							onClick={() => setConnectOpen(true)}
 						>
 							<TerminalSquare data-icon="inline-start" /> Connect an agent on your machine

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -15,11 +15,8 @@ export function SiteHeader({ actions }: { actions?: ReactNode }) {
 	return (
 		<header className="sticky top-0 z-20 flex h-(--header-height) shrink-0 items-center gap-2 border-b bg-background">
 			<div className="flex w-full min-w-0 items-center gap-1 px-4 lg:gap-2 lg:px-6">
-				<SidebarTrigger className="-ml-1 md:hidden" />
-				<Separator
-					orientation="vertical"
-					className="mx-2 data-[orientation=vertical]:h-4 md:hidden"
-				/>
+				<SidebarTrigger className="-ml-1" />
+				<Separator orientation="vertical" className="mx-2 data-[orientation=vertical]:h-4" />
 				<div className="min-w-8 flex-1 overflow-hidden">
 					<AppBreadcrumb />
 				</div>

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -14,13 +14,13 @@ import { SidebarTrigger } from "@/components/ui/sidebar";
 export function SiteHeader({ actions }: { actions?: ReactNode }) {
 	return (
 		<header className="sticky top-0 z-20 flex h-(--header-height) shrink-0 items-center gap-2 border-b bg-background">
-			<div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
+			<div className="flex min-w-0 w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
 				<SidebarTrigger className="-ml-1 md:hidden" />
 				<Separator
 					orientation="vertical"
 					className="mx-2 data-[orientation=vertical]:h-4 md:hidden"
 				/>
-				<div className="min-w-0 flex-1">
+				<div className="min-w-0 flex-1 overflow-hidden">
 					<AppBreadcrumb />
 				</div>
 				{actions}

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -14,13 +14,13 @@ import { SidebarTrigger } from "@/components/ui/sidebar";
 export function SiteHeader({ actions }: { actions?: ReactNode }) {
 	return (
 		<header className="sticky top-0 z-20 flex h-(--header-height) shrink-0 items-center gap-2 border-b bg-background">
-			<div className="flex min-w-0 w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
+			<div className="flex w-full min-w-0 items-center gap-1 px-4 lg:gap-2 lg:px-6">
 				<SidebarTrigger className="-ml-1 md:hidden" />
 				<Separator
 					orientation="vertical"
 					className="mx-2 data-[orientation=vertical]:h-4 md:hidden"
 				/>
-				<div className="min-w-0 flex-1 overflow-hidden">
+				<div className="min-w-8 flex-1 overflow-hidden">
 					<AppBreadcrumb />
 				</div>
 				{actions}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -176,7 +176,7 @@ function Sidebar({
 					data-sidebar="sidebar"
 					data-slot="sidebar"
 					data-mobile="true"
-					className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+					className="bg-sidebar p-0 text-sidebar-foreground data-[side=left]:w-(--sidebar-width) data-[side=right]:w-(--sidebar-width)"
 					style={
 						{
 							"--sidebar-width": SIDEBAR_WIDTH_MOBILE,

--- a/apps/web/src/pages/dashboard/layout.tsx
+++ b/apps/web/src/pages/dashboard/layout.tsx
@@ -149,7 +149,10 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
 
 function DashboardHeaderActionSlot({ children }: { children?: ReactNode }) {
 	return (
-		<div data-testid="global-wallet-balance-slot" className="flex h-8 w-24 shrink-0 items-stretch">
+		<div
+			data-testid="global-wallet-balance-slot"
+			className="flex h-8 w-fit min-w-20 shrink items-stretch"
+		>
 			{children}
 		</div>
 	);

--- a/apps/web/src/pages/dashboard/layout.tsx
+++ b/apps/web/src/pages/dashboard/layout.tsx
@@ -148,5 +148,9 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
 }
 
 function DashboardHeaderActionSlot({ children }: { children?: ReactNode }) {
-	return <div className="flex h-8 w-20 shrink-0 items-stretch sm:w-24">{children}</div>;
+	return (
+		<div data-testid="global-wallet-balance-slot" className="flex h-8 w-24 shrink-0 items-stretch">
+			{children}
+		</div>
+	);
 }

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -184,13 +184,7 @@ export default function DashboardPage() {
 			)}
 
 			<div className="grid gap-4 lg:grid-cols-3">
-				{/* Left column — live status + activity. `min-w-0` is load-bearing:
-				    grid items default to `min-width: auto` (= min-content), so a
-				    fixed-width child (table-fixed table, code block, etc.) makes
-				    the grid track grow past its declared 1fr/2fr share. Below the
-				    `lg` breakpoint that means single-column overflow → cards
-				    spill past the viewport. */}
-				<div className="contents lg:col-span-2 lg:block lg:min-w-0 lg:space-y-4">
+				<div className="min-w-0 lg:col-span-2 lg:row-start-1">
 					{hostedAccessLoading ? (
 						<AgentsCard agents={selfManagedTiles} isLoading />
 					) : hostedSectionEnabled && HostedAgentsSection ? (
@@ -220,70 +214,32 @@ export default function DashboardPage() {
 							}}
 						/>
 					)}
-
-					<Card>
-						<CardHeader>
-							<CardTitle>Activity</CardTitle>
-							<CardDescription>Sessions per day in the last 12 months</CardDescription>
-						</CardHeader>
-						<CardContent>
-							{blockingStatsError ? (
-								<ApiErrorPanel
-									error={blockingStatsError}
-									onRetry={() => {
-										void refetchStats();
-									}}
-									title="Couldn't load activity"
-								/>
-							) : statsLoading ? (
-								<ActivityGraphSkeleton />
-							) : contribution ? (
-								<ContributionGraph data={contribution} />
-							) : null}
-						</CardContent>
-					</Card>
-
-					<section className="order-last space-y-2 lg:order-none">
-						<div className="flex items-end justify-between">
-							<h2 className="text-base font-semibold">Recent sessions</h2>
-							<Button
-								render={<Link to="/sessions" />}
-								nativeButton={false}
-								variant="ghost"
-								size="sm"
-								className="text-muted-foreground"
-							>
-								View all
-								<ArrowRight />
-							</Button>
-						</div>
-						{blockingSessionsError ? (
-							<ApiErrorPanel
-								error={blockingSessionsError}
-								onRetry={() => {
-									void refetchSessions();
-								}}
-								title="Couldn't load recent sessions"
-							/>
-						) : (
-							<SessionFeed
-								sessions={sessions ?? []}
-								isLoading={sessionsLoading}
-								grouped={false}
-								emptyMessage="No manual sessions yet. Once you start a conversation, it'll show up here."
-								emptyVariant="inset"
-							/>
-						)}
-					</section>
 				</div>
 
-				{/* Right column — once any agent exists (hosted OR self-managed),
-				    "Connect another" lives here as a secondary action. Empty
-				    state hides it entirely because the hero card above is
-				    already the onboarding. Hosted mode delegates the decision
-				    to a sibling component so it can include hosted tiles in
-				    the count. */}
-				<div className="min-w-0 space-y-4">
+				<Card className="min-w-0 lg:col-span-2 lg:row-start-2">
+					<CardHeader>
+						<CardTitle>Activity</CardTitle>
+						<CardDescription>Sessions per day in the last 12 months</CardDescription>
+					</CardHeader>
+					<CardContent>
+						{blockingStatsError ? (
+							<ApiErrorPanel
+								error={blockingStatsError}
+								onRetry={() => {
+									void refetchStats();
+								}}
+								title="Couldn't load activity"
+							/>
+						) : statsLoading ? (
+							<ActivityGraphSkeleton />
+						) : contribution ? (
+							<ContributionGraph data={contribution} />
+						) : null}
+					</CardContent>
+				</Card>
+
+				{/* This source order is also the mobile reading and focus order. */}
+				<div className="min-w-0 space-y-4 lg:col-start-3 lg:row-span-3 lg:row-start-1">
 					{hostedAccessLoading ? null : hostedSectionEnabled && HostedSecondaryCTA ? (
 						<Suspense fallback={null}>
 							<HostedSecondaryCTA
@@ -312,6 +268,39 @@ export default function DashboardPage() {
 						}}
 					/>
 				</div>
+
+				<section className="min-w-0 space-y-2 lg:col-span-2 lg:row-start-3">
+					<div className="flex items-end justify-between">
+						<h2 className="text-base font-semibold">Recent sessions</h2>
+						<Button
+							render={<Link to="/sessions" />}
+							nativeButton={false}
+							variant="ghost"
+							size="sm"
+							className="text-muted-foreground"
+						>
+							View all
+							<ArrowRight />
+						</Button>
+					</div>
+					{blockingSessionsError ? (
+						<ApiErrorPanel
+							error={blockingSessionsError}
+							onRetry={() => {
+								void refetchSessions();
+							}}
+							title="Couldn't load recent sessions"
+						/>
+					) : (
+						<SessionFeed
+							sessions={sessions ?? []}
+							isLoading={sessionsLoading}
+							grouped={false}
+							emptyMessage="No manual sessions yet. Once you start a conversation, it'll show up here."
+							emptyVariant="inset"
+						/>
+					)}
+				</section>
 			</div>
 		</div>
 	);

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -190,7 +190,7 @@ export default function DashboardPage() {
 				    the grid track grow past its declared 1fr/2fr share. Below the
 				    `lg` breakpoint that means single-column overflow → cards
 				    spill past the viewport. */}
-				<div className="min-w-0 space-y-4 lg:col-span-2">
+				<div className="contents lg:col-span-2 lg:block lg:min-w-0 lg:space-y-4">
 					{hostedAccessLoading ? (
 						<AgentsCard agents={selfManagedTiles} isLoading />
 					) : hostedSectionEnabled && HostedAgentsSection ? (
@@ -243,7 +243,7 @@ export default function DashboardPage() {
 						</CardContent>
 					</Card>
 
-					<section className="space-y-2">
+					<section className="order-last space-y-2 lg:order-none">
 						<div className="flex items-end justify-between">
 							<h2 className="text-base font-semibold">Recent sessions</h2>
 							<Button


### PR DESCRIPTION
## Summary

- keep the mobile header separator, breadcrumb, Wallet balance, and notification action contained at narrow touch viewports
- let the Wallet size naturally from its balance with an 80px minimum, shrinking and truncating only when available header space is exhausted
- make the mobile Console source and focus order Agents, Activity, secondary cards, then Recent sessions while preserving the desktop two-column grid
- let the long onboarding connection action wrap at 320px without reducing type or touch-target size

## Verification

- `bun run e2e:hosted -- --grep "header Wallet adapts|Console keeps"` (2 passed)
- `bash scripts/test.sh web src/hosted/oss-clean.test.ts` (typecheck, 22 tests, OSS client and SSR production build)
- reviewed 320x568 and 390x844 Playwright screenshots
- confirmed Playwright services and Docker test resources were removed

## Test scope

No test files were added. The two existing hosted smoke cases were consolidated around responsive behavior; the PR test diff is 138 additions and 149 deletions.