### PR TITLE
fix(runtime): migrate legacy Codex npm shim

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.90",
+      "version": "0.13.91",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1029,11 +1029,13 @@ cleared before official installers run. Unlike the root-owned, exactly managed
 Clawdi CLI above, Hosted Codex is user-version-owned: Clawdi bootstraps Codex
 into the standard tenant-owned `~/.local` npm prefix only when its package
 metadata or executable is missing or damaged. A healthy installed Codex version
-is owned by the user and is never rolled back by Clawdi. The hosted execution
-environment provides the public egress placeholder, standard per-tool CA trust
-variables, and user npm prefix without exposing the real provider credential;
-the shared npm prefix remains outside Clawdi snapshot, ownership, and rollback
-targets.
+is owned by the user and is never rolled back by Clawdi. During migration,
+Clawdi removes only its byte-for-byte legacy `~/.local/bin/codex` shim before
+npm installs the package-owned executable; an unrecognized file at that path is
+never overwritten. The hosted execution environment provides the public egress
+placeholder, standard per-tool CA trust variables, and user npm prefix without
+exposing the real provider credential; the shared npm prefix remains outside
+Clawdi snapshot, ownership, and rollback targets.
 
 The hosted image's bootstrap package may expose
 `/usr/local/bin/clawdi -> ../lib/node_modules/clawdi/bin/clawdi.mjs` while root

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.90",
+	"version": "0.13.91",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -2710,15 +2710,11 @@ function ensureHostedCodexCli(paths: RuntimePaths): Record<string, string> | nul
 	if (process.env.CLAWDI_CODEX_INSTALL_DISABLED === "1") return null;
 	const npmPrefix = paths.userNpmPrefix;
 	const realBin = join(npmPrefix, "bin", "codex");
+	removeLegacyHostedCodexCommandShim(realBin, paths.userHome);
 	let installedVersion = hostedCodexInstalledVersion(npmPrefix);
 	const bootstrapRequired = installedVersion === null || !executableExists(realBin);
 	if (bootstrapRequired) {
-		installHostedCodexBootstrap(
-			CODEX_BOOTSTRAP_PACKAGE_SPEC,
-			npmPrefix,
-			paths,
-			isLegacyHostedCodexCommandShim(realBin, paths.userHome),
-		);
+		installHostedCodexBootstrap(CODEX_BOOTSTRAP_PACKAGE_SPEC, npmPrefix, paths);
 		installedVersion = hostedCodexInstalledVersion(npmPrefix);
 		if (installedVersion !== CODEX_BOOTSTRAP_PACKAGE_VERSION) {
 			throw new Error(
@@ -2763,7 +2759,6 @@ function installHostedCodexBootstrap(
 	packageSpec: string,
 	npmPrefix: string,
 	paths: RuntimePaths,
-	replaceLegacyShim: boolean,
 ): void {
 	if (!commandExists("npm")) {
 		throw new Error("Codex bootstrap requires npm on PATH");
@@ -2776,7 +2771,6 @@ function installHostedCodexBootstrap(
 			"-g",
 			"--prefix",
 			npmPrefix,
-			...(replaceLegacyShim ? ["--force"] : []),
 			"--ignore-scripts",
 			"--fetch-retries",
 			"2",
@@ -2803,21 +2797,23 @@ function installHostedCodexBootstrap(
 	}
 }
 
-function isLegacyHostedCodexCommandShim(commandPath: string, home: string): boolean {
+function removeLegacyHostedCodexCommandShim(commandPath: string, home: string): void {
+	let content: string;
 	try {
-		const content = readFileSync(commandPath, "utf8");
-		const legacyRealBin = join(home, ".local", "share", "clawdi", "codex", "bin", "codex");
-		return (
-			content ===
-			[
-				"#!/usr/bin/env sh",
-				`export ${MANAGED_AI_PROVIDER_RUNTIME_ENV}='${MANAGED_EGRESS_PLACEHOLDER_VALUE}'`,
-				`exec '${legacyRealBin}' "$@"`,
-				"",
-			].join("\n")
-		);
+		content = readFileSync(commandPath, "utf8");
 	} catch {
-		return false;
+		// A missing or unreadable command is handled by the normal bootstrap check.
+		return;
+	}
+	const legacyRealBin = join(home, ".local", "share", "clawdi", "codex", "bin", "codex");
+	const expected = [
+		"#!/usr/bin/env sh",
+		`export ${MANAGED_AI_PROVIDER_RUNTIME_ENV}='${MANAGED_EGRESS_PLACEHOLDER_VALUE}'`,
+		`exec '${legacyRealBin}' "$@"`,
+		"",
+	].join("\n");
+	if (content === expected) {
+		withRuntimeUserFileAccess(() => rmSync(commandPath));
 	}
 }
 

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -4033,7 +4033,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		expect(readFileSync(configPath, "utf-8")).not.toMatch(/managed/i);
 	});
 
-	it("bootstraps Codex through the user npm prefix when managed config is projected", () => {
+	it("migrates the legacy Codex shim before bootstrapping the user npm prefix", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -4043,6 +4043,15 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		const legacyCodexMarker = join(home, ".local", "share", "clawdi", "codex", "user-data");
 		const legacyCodexCommand = join(home, ".local", "bin", "codex");
 		const legacyCodexRealBin = join(home, ".local", "share", "clawdi", "codex", "bin", "codex");
+		const partialPackageJson = join(
+			home,
+			".local",
+			"lib",
+			"node_modules",
+			"@openai",
+			"codex",
+			"package.json",
+		);
 		const userConfigBytes = Buffer.from('# user config\nmodel = "user-model"\n');
 		const previousPath = process.env.PATH;
 		const previousUmask = process.umask(0o077);
@@ -4050,8 +4059,10 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		mkdirSync(dirname(userCodexConfig), { recursive: true });
 		mkdirSync(dirname(legacyCodexMarker), { recursive: true });
 		mkdirSync(dirname(legacyCodexCommand), { recursive: true });
+		mkdirSync(dirname(partialPackageJson), { recursive: true });
 		writeFileSync(userCodexConfig, userConfigBytes);
 		writeFileSync(legacyCodexMarker, "preserve\n");
+		writeFileSync(partialPackageJson, '{"version":"0.147.0"}\n');
 		writeFileSync(
 			legacyCodexCommand,
 			[
@@ -4080,6 +4091,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 				"      ;;",
 				"  esac",
 				"done",
+				'test ! -e "$prefix/bin/codex"',
 				'mkdir -p "$prefix/bin" "$prefix/lib/node_modules/@openai/codex"',
 				`printf '%s\\n' '{"version":"0.146.0"}' > "$prefix/lib/node_modules/@openai/codex/package.json"`,
 				"cat > \"$prefix/bin/codex\" <<'SH'",
@@ -4157,7 +4169,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		const npmArgs = readFileSync(npmArgsPath, "utf-8");
 		expect(npmArgs).toContain("@openai/codex@0.146.0");
 		expect(npmArgs).toContain(`${paths.userNpmPrefix}\n`);
-		expect(npmArgs).toContain("--force\n");
+		expect(npmArgs).not.toContain("--force\n");
 		expect(npmArgs).not.toContain("--cache\n");
 		const realBin = join(paths.userNpmPrefix, "bin", "codex");
 		const packageJson = join(paths.userNpmPrefix, "lib/node_modules/@openai/codex/package.json");


### PR DESCRIPTION
## Summary

- remove only the byte-for-byte legacy Clawdi Codex shim before user-prefix bootstrap
- let npm own `~/.local/bin/codex` without `--force` or version rollback
- release the repair as `clawdi@0.13.91`

## Verification

- clean Docker CLI typecheck
- clean Docker `tests/runtime.test.ts`: 175 passed
- `git diff --check`

## Release impact

Publishes `clawdi@0.13.91`. Existing Hosted deployments need the normal exact-version controlled rollout; no runtime image change is required.