### PR TITLE
fix(web): restore mobile-only header trigger

### DIFF
--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -564,7 +564,7 @@ async function expectSidebarNavigationGroups(
 	await expect(groups.locator('[data-slot="sidebar-group-label"]:empty')).toHaveCount(0);
 }
 
-test("sidebar toggle preserves the desktop focus rail and closes the mobile drawer", async ({
+test("sidebar shortcut preserves the desktop focus rail and the mobile trigger closes the drawer", async ({
 	page,
 }) => {
 	await stubDashboardApi(page);
@@ -572,12 +572,17 @@ test("sidebar toggle preserves the desktop focus rail and closes the mobile draw
 	await page.goto("/");
 
 	const trigger = page.getByRole("button", { name: "Toggle Sidebar" });
+	const separator = page.locator('header [data-slot="separator"]');
 	const focusRail = page.getByTestId("app-sidebar-agent-rail");
 	const navigationPane = page.getByTestId("app-sidebar");
-	await expect(trigger).toBeVisible();
+	const desktopSidebar = page.locator('[data-slot="sidebar"][data-state]');
+	await expect(trigger).toBeHidden();
+	await expect(separator).toBeHidden();
 	await expect(focusRail).toBeVisible();
-	await page.waitForLoadState("networkidle");
-	await trigger.click();
+	await expect(desktopSidebar).toHaveAttribute("data-state", "expanded");
+	await expect(page.getByTestId("app-sidebar-agent-tile")).toHaveCount(2);
+	await page.keyboard.press("ControlOrMeta+b");
+	await expect(desktopSidebar).toHaveAttribute("data-state", "collapsed");
 	await expect
 		.poll(async () => {
 			const [railBox, paneBox] = await Promise.all([
@@ -591,6 +596,10 @@ test("sidebar toggle preserves the desktop focus rail and closes the mobile draw
 	await expect(focusRail).toBeVisible();
 
 	await page.setViewportSize({ width: 320, height: 568 });
+	await expect(trigger).toBeVisible();
+	await expect(separator).toBeVisible();
+	await expect(separator).toHaveCSS("width", "1px");
+	await expect(separator).toHaveCSS("height", "16px");
 	await trigger.click();
 	const drawer = page.getByRole("dialog", { name: "Sidebar" });
 	await expect(drawer).toBeVisible();

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -15,8 +15,11 @@ export function SiteHeader({ actions }: { actions?: ReactNode }) {
 	return (
 		<header className="sticky top-0 z-20 flex h-(--header-height) shrink-0 items-center gap-2 border-b bg-background">
 			<div className="flex w-full min-w-0 items-center gap-1 px-4 lg:gap-2 lg:px-6">
-				<SidebarTrigger className="-ml-1" />
-				<Separator orientation="vertical" className="mx-2 data-[orientation=vertical]:h-4" />
+				<SidebarTrigger className="-ml-1 md:hidden" />
+				<Separator
+					orientation="vertical"
+					className="mx-2 h-4 data-vertical:self-center md:hidden"
+				/>
 				<div className="min-w-8 flex-1 overflow-hidden">
 					<AppBreadcrumb />
 				</div>


### PR DESCRIPTION
## Summary
- hide the sidebar trigger and its separator on desktop
- constrain the mobile separator to 1x16px and center it correctly
- update the existing sidebar smoke to use the desktop keyboard shortcut and verify mobile geometry

## Verification
- Biome on the two touched files
- focused sidebar Playwright smoke
- focused hosted Wallet Playwright smoke at 320px and 390px
- Docker-isolated web typecheck, OSS boundary tests, and OSS build

No new tests or test files were added.