### PR TITLE
ci: streamline test routing and builds

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -63,13 +63,16 @@ permissions:
 
 concurrency:
   group: backend-ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  DOCKER_BUILD_RECORD_UPLOAD: "false"
 
 jobs:
   changes:
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     outputs:
-      any: ${{ steps.filter.outputs.any }}
+      backend: ${{ steps.filter.outputs.backend }}
       test: ${{ steps.filter.outputs.test }}
       sidecar: ${{ steps.filter.outputs.sidecar }}
     steps:
@@ -78,32 +81,19 @@ jobs:
         uses: dorny/paths-filter@v4
         with:
           filters: |
-            any:
+            backend:
               - "backend/**/*.py"
               - "backend/pyproject.toml"
               - "backend/uv.lock"
               - "backend/alembic.ini"
               - "backend/Dockerfile"
-              - "deploy/self-host/**"
-              - "apps/web/Dockerfile"
-              - ".dockerignore"
               - "packages/shared/src/api/api.generated.ts"
               - "package.json"
               - "bun.lock"
-              - "patches/libsignal@6.0.0.patch"
               - "scripts/openapi-typescript.sh"
               - "tools/openapi-typescript/**"
               - ".github/actions/setup-bun-ci/**"
               - ".github/workflows/backend-ci.yml"
-              - ".github/workflows/clawdi-image-release.yml"
-              - "packages/whatsapp-baileys-sidecar/**"
-              - "packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts"
-              - "packages/cli/tests/clawdi-image-release-workflow.test.ts"
-              - "scripts/test-kamal-whatsapp-sidecar-render.sh"
-              - "scripts/deploy-whatsapp-sidecar.sh"
-              - "scripts/whatsapp-sidecar-deployment-revision.ts"
-              - "scripts/clawdi-image-release-plan.ts"
-              - "scripts/test-deploy-whatsapp-sidecar.sh"
               - "scripts/check_postgres_image_parity.py"
               - "config/deploy.yml"
               - "config/postgres-image.txt"
@@ -139,7 +129,7 @@ jobs:
               - ".github/workflows/clawdi-image-release.yml"
   lint-and-typecheck:
     needs: changes
-    if: needs.changes.outputs.any == 'true'
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     defaults:
@@ -284,9 +274,14 @@ jobs:
           RUN gem install kamal -v '2.12.0' --no-document
           RUN scripts/test-kamal-whatsapp-sidecar-render.sh && scripts/test-deploy-whatsapp-sidecar.sh
           DOCKERFILE
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Build production sidecar image
-        run: >-
-          docker build
-          --file packages/whatsapp-baileys-sidecar/Dockerfile
-          --tag clawdi-whatsapp-baileys-sidecar:ci
-          .
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: packages/whatsapp-baileys-sidecar/Dockerfile
+          tags: clawdi-whatsapp-baileys-sidecar:ci
+          load: true
+          cache-from: type=gha,scope=clawdi-whatsapp-sidecar-ci
+          cache-to: type=gha,mode=max,scope=clawdi-whatsapp-sidecar-ci

--- a/.github/workflows/clean-test-runner-ci.yml
+++ b/.github/workflows/clean-test-runner-ci.yml
@@ -88,7 +88,7 @@ permissions:
 
 concurrency:
   group: clean-test-runner-ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   DOCKER_BUILD_RECORD_UPLOAD: "false"

--- a/.github/workflows/cli-systemd-e2e.yml
+++ b/.github/workflows/cli-systemd-e2e.yml
@@ -14,7 +14,7 @@ permissions:
 
 concurrency:
   group: cli-systemd-e2e-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   privileged-systemd-e2e:

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -264,6 +264,7 @@ jobs:
         env:
           E2E_ARTIFACT_DIR: ${{ runner.temp }}/managed-whatsapp-native-e2e-artifacts
         with:
+          source: .
           files: packages/cli/tests/fixtures/managed-whatsapp-native-e2e/docker-bake.hcl
           targets: openclaw,hermes
           load: true

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -59,7 +59,7 @@ permissions:
 
 concurrency:
   group: client-ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   BUN_VERSION: "1.3.14"
@@ -72,6 +72,7 @@ jobs:
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     outputs:
       client: ${{ steps.filter.outputs.client }}
+      web_e2e: ${{ steps.filter.outputs.web_e2e }}
       deploy_contract: ${{ steps.filter.outputs.deploy_contract }}
       whatsapp_native_e2e: ${{ steps.filter.outputs.whatsapp_native_e2e }}
     steps:
@@ -89,6 +90,16 @@ jobs:
               - "package.json"
               - "bun.lock"
               - "patches/libsignal@6.0.0.patch"
+              - "turbo.json"
+              - "tsconfig.base.json"
+              - "biome.json"
+              - ".github/actions/setup-bun-ci/**"
+              - ".github/workflows/client-ci.yml"
+            web_e2e:
+              - "apps/web/**"
+              - "packages/shared/**"
+              - "package.json"
+              - "bun.lock"
               - "turbo.json"
               - "tsconfig.base.json"
               - "biome.json"
@@ -196,7 +207,7 @@ jobs:
     needs: changes
     if: >-
       github.event_name != 'schedule' &&
-      needs.changes.outputs.client == 'true'
+      needs.changes.outputs.web_e2e == 'true'
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 25
     env:
@@ -248,30 +259,19 @@ jobs:
           path: ${{ runner.temp }}/managed-whatsapp-native-e2e-artifacts
           key: managed-whatsapp-native-e2e-artifacts-v1-${{ hashFiles('packages/cli/tests/fixtures/managed-whatsapp-native-e2e/versions.env') }}
       - uses: docker/setup-buildx-action@v4
-      - name: Build stock OpenClaw WhatsApp E2E image
-        uses: docker/build-push-action@v7
+      - name: Build stock OpenClaw and Hermes WhatsApp E2E images
+        uses: docker/bake-action@v7
+        env:
+          E2E_ARTIFACT_DIR: ${{ runner.temp }}/managed-whatsapp-native-e2e-artifacts
         with:
-          context: .
-          file: packages/cli/tests/fixtures/managed-whatsapp-native-e2e/Dockerfile
-          target: openclaw
-          tags: clawdi-managed-whatsapp-native-e2e:openclaw-local
+          files: packages/cli/tests/fixtures/managed-whatsapp-native-e2e/docker-bake.hcl
+          targets: openclaw,hermes
           load: true
-          build-contexts: |
-            e2e_artifacts=${{ runner.temp }}/managed-whatsapp-native-e2e-artifacts
-          cache-from: type=gha,scope=managed-whatsapp-native-e2e-openclaw
-          cache-to: type=gha,mode=max,scope=managed-whatsapp-native-e2e-openclaw
-      - name: Build stock Hermes WhatsApp E2E image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: packages/cli/tests/fixtures/managed-whatsapp-native-e2e/Dockerfile
-          target: hermes
-          tags: clawdi-managed-whatsapp-native-e2e:hermes-local
-          load: true
-          build-contexts: |
-            e2e_artifacts=${{ runner.temp }}/managed-whatsapp-native-e2e-artifacts
-          cache-from: type=gha,scope=managed-whatsapp-native-e2e-hermes
-          cache-to: type=gha,mode=max,scope=managed-whatsapp-native-e2e-hermes
+          set: |
+            openclaw.cache-from=type=gha,scope=managed-whatsapp-native-e2e-openclaw
+            openclaw.cache-to=type=gha,mode=max,scope=managed-whatsapp-native-e2e-openclaw
+            hermes.cache-from=type=gha,scope=managed-whatsapp-native-e2e-hermes
+            hermes.cache-to=type=gha,mode=max,scope=managed-whatsapp-native-e2e-hermes
       - name: Test stock OpenClaw and Hermes WhatsApp plugins
         run: scripts/test-managed-whatsapp-native-e2e.sh --run-only
       - name: Remove loaded E2E images

--- a/packages/cli/src/runtime/manifest-mutation-parity.test.ts
+++ b/packages/cli/src/runtime/manifest-mutation-parity.test.ts
@@ -158,6 +158,7 @@ exit 0
 		) as Record<string, unknown>;
 		const manifest = fixture.manifest as Record<string, unknown>;
 		const runtimes = manifest.runtimes as Record<string, Record<string, unknown>>;
+		const egressEngine = manifest.egressEngine as { sha256: string; version: string };
 		const openclawRuntime = runtimes.openclaw;
 		openclawRuntime.providerMode = "unmanaged";
 		openclawRuntime.provider_ids = [];
@@ -193,6 +194,15 @@ exit 0
 		};
 
 		const paths = getRuntimePaths();
+		const egressEngineBinary = join(
+			paths.egressEngineMaintainedRoot,
+			egressEngine.version,
+			egressEngine.sha256,
+			"mitmdump",
+		);
+		fsOriginals.mkdirSync(dirname(egressEngineBinary), { recursive: true });
+		fsOriginals.writeFileSync(egressEngineBinary, "#!/bin/sh\nexit 0\n");
+		fsOriginals.chmodSync(egressEngineBinary, 0o755);
 		ensureRuntimeStateDirs(paths);
 		recording = true;
 		const result = convergeRuntimeManifest(load, paths, {

--- a/packages/cli/tests/clawdi-image-release-workflow.test.ts
+++ b/packages/cli/tests/clawdi-image-release-workflow.test.ts
@@ -92,10 +92,7 @@ describe("backend image release workflow contract", () => {
 	test("keeps Python governance out of sidecar-only changes", () => {
 		const filterStep = backendCi.jobs.changes?.steps?.find((step) => step.id === "filter");
 		const filters = String(filterStep?.with?.filters);
-		const backendFilter = filters.slice(
-			filters.indexOf("backend:\n"),
-			filters.indexOf("test:\n"),
-		);
+		const backendFilter = filters.slice(filters.indexOf("backend:\n"), filters.indexOf("test:\n"));
 
 		expect(backendCi.jobs["lint-and-typecheck"]?.if).toBe(
 			"needs.changes.outputs.backend == 'true'",
@@ -136,7 +133,7 @@ describe("backend image release workflow contract", () => {
 		expect(backendCi.on?.push?.paths).not.toContain("**");
 		expect(backendCi.on?.push?.paths).not.toContain("apps/web/src/**");
 		expect(backendCi.concurrency?.["cancel-in-progress"]).toBe(
-			"${{ github.event_name == 'pull_request' }}",
+			`\${{ github.event_name == 'pull_request' }}`,
 		);
 	});
 

--- a/packages/cli/tests/clawdi-image-release-workflow.test.ts
+++ b/packages/cli/tests/clawdi-image-release-workflow.test.ts
@@ -89,6 +89,34 @@ const releaseClassifierSource = readFileSync(
 );
 
 describe("backend image release workflow contract", () => {
+	test("keeps Python governance out of sidecar-only changes", () => {
+		const filterStep = backendCi.jobs.changes?.steps?.find((step) => step.id === "filter");
+		const filters = String(filterStep?.with?.filters);
+		const backendFilter = filters.slice(
+			filters.indexOf("backend:\n"),
+			filters.indexOf("test:\n"),
+		);
+
+		expect(backendCi.jobs["lint-and-typecheck"]?.if).toBe(
+			"needs.changes.outputs.backend == 'true'",
+		);
+		for (const path of [
+			"backend/**/*.py",
+			"packages/shared/src/api/api.generated.ts",
+			"scripts/openapi-typescript.sh",
+			"config/deploy.yml",
+			"tools/openapi-typescript/**",
+		]) {
+			expect(backendFilter).toContain(`- "${path}"`);
+		}
+		for (const path of [
+			"packages/whatsapp-baileys-sidecar/**",
+			"scripts/deploy-whatsapp-sidecar.sh",
+		]) {
+			expect(backendFilter).not.toContain(`- "${path}"`);
+		}
+	});
+
 	test("coalesces main Backend CI only inside its image-input path gate", () => {
 		expect(backendCi.on?.push?.branches).toEqual(["main"]);
 		expect(backendCi.on?.push?.paths).toEqual(
@@ -107,7 +135,9 @@ describe("backend image release workflow contract", () => {
 		);
 		expect(backendCi.on?.push?.paths).not.toContain("**");
 		expect(backendCi.on?.push?.paths).not.toContain("apps/web/src/**");
-		expect(backendCi.concurrency?.["cancel-in-progress"]).toBe(true);
+		expect(backendCi.concurrency?.["cancel-in-progress"]).toBe(
+			"${{ github.event_name == 'pull_request' }}",
+		);
 	});
 
 	test("compares the exact Backend CI head against cumulative successful deployment authority", () => {

--- a/packages/cli/tests/clean-test-runner.test.ts
+++ b/packages/cli/tests/clean-test-runner.test.ts
@@ -38,8 +38,11 @@ describe("client workflow contract", () => {
 	test("uses truthful change routing and verifies every client package in one job", () => {
 		const changesJob = section(clientWorkflow, "  changes:\n", "  # Lint");
 		const verifyJob = section(clientWorkflow, "  verify:\n", "  deploy-contract-drift:\n");
+		const webE2eFilter = section(changesJob, "            web_e2e:\n", "            deploy_contract:\n");
+		const webE2eJob = section(clientWorkflow, "  web-e2e:\n", "  whatsapp-native-e2e:\n");
 
 		expect(changesJob).toContain(`client: \${{ steps.filter.outputs.client }}`);
+		expect(changesJob).toContain(`web_e2e: \${{ steps.filter.outputs.web_e2e }}`);
 		expect(changesJob).toContain(`deploy_contract: \${{ steps.filter.outputs.deploy_contract }}`);
 		for (const path of [
 			"apps/web/**",
@@ -55,9 +58,19 @@ describe("client workflow contract", () => {
 			);
 		}
 		expect(verifyJob).toContain("needs.changes.outputs.client == 'true'");
+		expect(webE2eJob).toContain("needs.changes.outputs.web_e2e == 'true'");
+		for (const path of ["apps/web/**", "packages/shared/**", "package.json", "bun.lock"]) {
+			expect(webE2eFilter).toContain(`- "${path}"`);
+		}
+		for (const path of ["packages/cli/**", "packages/whatsapp-baileys-sidecar/**"]) {
+			expect(webE2eFilter).not.toContain(`- "${path}"`);
+		}
 		expect(verifyJob).not.toContain("matrix:");
 		expect(clientWorkflow).not.toContain("actions/upload-artifact");
 		expect(clientWorkflow).not.toContain("actions/download-artifact");
+		expect(clientWorkflow).toContain(
+			"cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+		);
 
 		const typecheckTask = section(turboConfig, '\t\t"typecheck": {\n', '\t\t"lint": {\n');
 		expect(typecheckTask).toContain('"outputs": []');
@@ -175,6 +188,9 @@ describe("clean runner suite contract", () => {
 	});
 
 	test("runs focused CI routinely and exposes full all as a manual gate", () => {
+		expect(cleanRunnerWorkflow).toContain(
+			"cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+		);
 		expect(cleanRunnerWorkflow).toContain('description: "Clean runner suite to execute"');
 		expect(cleanRunnerWorkflow).toContain("default: ci");
 		expect(cleanRunnerWorkflow).toContain("          - ci\n          - all");

--- a/packages/cli/tests/clean-test-runner.test.ts
+++ b/packages/cli/tests/clean-test-runner.test.ts
@@ -38,7 +38,11 @@ describe("client workflow contract", () => {
 	test("uses truthful change routing and verifies every client package in one job", () => {
 		const changesJob = section(clientWorkflow, "  changes:\n", "  # Lint");
 		const verifyJob = section(clientWorkflow, "  verify:\n", "  deploy-contract-drift:\n");
-		const webE2eFilter = section(changesJob, "            web_e2e:\n", "            deploy_contract:\n");
+		const webE2eFilter = section(
+			changesJob,
+			"            web_e2e:\n",
+			"            deploy_contract:\n",
+		);
 		const webE2eJob = section(clientWorkflow, "  web-e2e:\n", "  whatsapp-native-e2e:\n");
 
 		expect(changesJob).toContain(`client: \${{ steps.filter.outputs.client }}`);
@@ -69,7 +73,7 @@ describe("client workflow contract", () => {
 		expect(clientWorkflow).not.toContain("actions/upload-artifact");
 		expect(clientWorkflow).not.toContain("actions/download-artifact");
 		expect(clientWorkflow).toContain(
-			"cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+			`cancel-in-progress: \${{ github.event_name == 'pull_request' }}`,
 		);
 
 		const typecheckTask = section(turboConfig, '\t\t"typecheck": {\n', '\t\t"lint": {\n');
@@ -189,7 +193,7 @@ describe("clean runner suite contract", () => {
 
 	test("runs focused CI routinely and exposes full all as a manual gate", () => {
 		expect(cleanRunnerWorkflow).toContain(
-			"cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+			`cancel-in-progress: \${{ github.event_name == 'pull_request' }}`,
 		);
 		expect(cleanRunnerWorkflow).toContain('description: "Clean runner suite to execute"');
 		expect(cleanRunnerWorkflow).toContain("default: ci");

--- a/packages/cli/tests/docker-build-workflows.test.ts
+++ b/packages/cli/tests/docker-build-workflows.test.ts
@@ -22,10 +22,7 @@ const backendWorkflow = parse(
 	readFileSync(resolve(workflowsDirectory, "backend-ci.yml"), "utf8"),
 ) as WorkflowDocument;
 const nativeE2eBake = readFileSync(
-	resolve(
-		import.meta.dir,
-		"fixtures/managed-whatsapp-native-e2e/docker-bake.hcl",
-	),
+	resolve(import.meta.dir, "fixtures/managed-whatsapp-native-e2e/docker-bake.hcl"),
 	"utf8",
 );
 const nativeE2eScript = readFileSync(
@@ -51,9 +48,7 @@ describe("Docker build workflow contract", () => {
 				) as WorkflowDocument,
 			}))
 			.filter(({ workflow }) =>
-				Object.values(workflow.jobs ?? {}).some((job) =>
-					job.steps?.some(isDockerBuildAction),
-				),
+				Object.values(workflow.jobs ?? {}).some((job) => job.steps?.some(isDockerBuildAction)),
 			);
 
 		expect(buildWorkflows.length).toBeGreaterThan(0);
@@ -102,7 +97,7 @@ describe("Docker build workflow contract", () => {
 		expect(nativeE2eBake).toContain('group "default" {\n  targets = ["openclaw", "hermes"]');
 		expect(nativeE2eBake).toContain('target "_common" {');
 		expect(nativeE2eScript).toContain(
-			'docker buildx bake --file "${FIXTURE_ROOT}/docker-bake.hcl" --load',
+			`docker buildx bake --file "\${FIXTURE_ROOT}/docker-bake.hcl" --load`,
 		);
 		expect(nativeE2eScript).not.toContain("docker buildx build");
 	});

--- a/packages/cli/tests/docker-build-workflows.test.ts
+++ b/packages/cli/tests/docker-build-workflows.test.ts
@@ -5,13 +5,43 @@ import { parse } from "yaml";
 
 interface WorkflowDocument {
 	env?: Record<string, unknown>;
-	jobs?: Record<string, { steps?: Array<{ uses?: string }> }>;
+	jobs?: Record<string, { steps?: WorkflowStep[] }>;
+}
+
+interface WorkflowStep {
+	name?: string;
+	uses?: string;
+	with?: Record<string, unknown>;
 }
 
 const workflowsDirectory = resolve(import.meta.dir, "../../../.github/workflows");
+const clientWorkflow = parse(
+	readFileSync(resolve(workflowsDirectory, "client-ci.yml"), "utf8"),
+) as WorkflowDocument;
+const backendWorkflow = parse(
+	readFileSync(resolve(workflowsDirectory, "backend-ci.yml"), "utf8"),
+) as WorkflowDocument;
+const nativeE2eBake = readFileSync(
+	resolve(
+		import.meta.dir,
+		"fixtures/managed-whatsapp-native-e2e/docker-bake.hcl",
+	),
+	"utf8",
+);
+const nativeE2eScript = readFileSync(
+	resolve(import.meta.dir, "../../../scripts/test-managed-whatsapp-native-e2e.sh"),
+	"utf8",
+);
+
+function isDockerBuildAction(step: WorkflowStep): boolean {
+	return (
+		step.uses?.startsWith("docker/build-push-action@") === true ||
+		step.uses?.startsWith("docker/bake-action@") === true
+	);
+}
 
 describe("Docker build workflow contract", () => {
-	test("disables build record artifact uploads for every build-push action", () => {
+	test("disables build record artifact uploads for every Docker build action", () => {
 		const buildWorkflows = readdirSync(workflowsDirectory)
 			.filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
 			.map((name) => ({
@@ -22,7 +52,7 @@ describe("Docker build workflow contract", () => {
 			}))
 			.filter(({ workflow }) =>
 				Object.values(workflow.jobs ?? {}).some((job) =>
-					job.steps?.some((step) => step.uses?.startsWith("docker/build-push-action@")),
+					job.steps?.some(isDockerBuildAction),
 				),
 			);
 
@@ -30,5 +60,50 @@ describe("Docker build workflow contract", () => {
 		for (const { name, workflow } of buildWorkflows) {
 			expect(workflow.env?.DOCKER_BUILD_RECORD_UPLOAD, name).toBe("false");
 		}
+	});
+
+	test("builds and loads the production sidecar through cached Buildx", () => {
+		const steps = backendWorkflow.jobs?.sidecar?.steps ?? [];
+		const buildStep = steps.find((step) => step.name === "Build production sidecar image");
+
+		expect(steps.some((step) => step.uses === "docker/setup-buildx-action@v4")).toBe(true);
+		expect(buildStep?.uses).toBe("docker/build-push-action@v7");
+		expect(buildStep?.with).toEqual({
+			context: ".",
+			file: "packages/whatsapp-baileys-sidecar/Dockerfile",
+			tags: "clawdi-whatsapp-baileys-sidecar:ci",
+			load: true,
+			"cache-from": "type=gha,scope=clawdi-whatsapp-sidecar-ci",
+			"cache-to": "type=gha,mode=max,scope=clawdi-whatsapp-sidecar-ci",
+		});
+	});
+
+	test("builds both native WhatsApp E2E targets in one loaded Bake graph", () => {
+		const steps = clientWorkflow.jobs?.["whatsapp-native-e2e"]?.steps ?? [];
+		const bakeSteps = steps.filter((step) => step.uses?.startsWith("docker/bake-action@"));
+
+		expect(bakeSteps).toHaveLength(1);
+		expect(bakeSteps[0]?.with).toMatchObject({
+			files: "packages/cli/tests/fixtures/managed-whatsapp-native-e2e/docker-bake.hcl",
+			load: true,
+			targets: "openclaw,hermes",
+		});
+		const settings = String(bakeSteps[0]?.with?.set);
+		for (const runtime of ["openclaw", "hermes"]) {
+			expect(settings).toContain(
+				`${runtime}.cache-from=type=gha,scope=managed-whatsapp-native-e2e-${runtime}`,
+			);
+			expect(settings).toContain(
+				`${runtime}.cache-to=type=gha,mode=max,scope=managed-whatsapp-native-e2e-${runtime}`,
+			);
+			expect(nativeE2eBake).toContain(`target "${runtime}" {`);
+			expect(nativeE2eBake).toContain(`tags     = ["\${E2E_IMAGE_PREFIX}:${runtime}-local"]`);
+		}
+		expect(nativeE2eBake).toContain('group "default" {\n  targets = ["openclaw", "hermes"]');
+		expect(nativeE2eBake).toContain('target "_common" {');
+		expect(nativeE2eScript).toContain(
+			'docker buildx bake --file "${FIXTURE_ROOT}/docker-bake.hcl" --load',
+		);
+		expect(nativeE2eScript).not.toContain("docker buildx build");
 	});
 });

--- a/packages/cli/tests/docker-build-workflows.test.ts
+++ b/packages/cli/tests/docker-build-workflows.test.ts
@@ -79,6 +79,7 @@ describe("Docker build workflow contract", () => {
 
 		expect(bakeSteps).toHaveLength(1);
 		expect(bakeSteps[0]?.with).toMatchObject({
+			source: ".",
 			files: "packages/cli/tests/fixtures/managed-whatsapp-native-e2e/docker-bake.hcl",
 			load: true,
 			targets: "openclaw,hermes",

--- a/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/docker-bake.hcl
+++ b/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/docker-bake.hcl
@@ -1,0 +1,31 @@
+variable "E2E_ARTIFACT_DIR" {
+  default = ""
+}
+
+variable "E2E_IMAGE_PREFIX" {
+  default = "clawdi-managed-whatsapp-native-e2e"
+}
+
+group "default" {
+  targets = ["openclaw", "hermes"]
+}
+
+target "_common" {
+  context    = "."
+  dockerfile = "packages/cli/tests/fixtures/managed-whatsapp-native-e2e/Dockerfile"
+  contexts = {
+    e2e_artifacts = E2E_ARTIFACT_DIR
+  }
+}
+
+target "openclaw" {
+  inherits = ["_common"]
+  target   = "openclaw"
+  tags     = ["${E2E_IMAGE_PREFIX}:openclaw-local"]
+}
+
+target "hermes" {
+  inherits = ["_common"]
+  target   = "hermes"
+  tags     = ["${E2E_IMAGE_PREFIX}:hermes-local"]
+}

--- a/scripts/test-managed-whatsapp-native-e2e.sh
+++ b/scripts/test-managed-whatsapp-native-e2e.sh
@@ -61,15 +61,11 @@ if [[ "${MODE}" == "--fetch-only" ]]; then
 fi
 
 if [[ "${MODE}" != "--run-only" ]]; then
-	for runtime in "${RUNTIMES[@]}"; do
-		docker buildx build \
-			--file "${FIXTURE_ROOT}/Dockerfile" \
-			--target "${runtime}" \
-			--tag "${IMAGE_PREFIX}:${runtime}-local" \
-			--build-context "e2e_artifacts=${artifact_root}" \
-			--load \
-			"${REPO_ROOT}"
-	done
+	(
+		cd "${REPO_ROOT}"
+		E2E_ARTIFACT_DIR="${artifact_root}" E2E_IMAGE_PREFIX="${IMAGE_PREFIX}" \
+			docker buildx bake --file "${FIXTURE_ROOT}/docker-bake.hcl" --load
+	)
 fi
 
 if [[ "${MODE}" == "--build-only" ]]; then


### PR DESCRIPTION
## Summary

- make runtime mutation parity hermetic by seeding the exact pinned mitmproxy cache path
- route web E2E and backend governance only from their real dependency inputs while preserving cross-boundary PostgreSQL parity inputs
- replace serial WhatsApp image builds with one loaded Buildx Bake graph and add cached Buildx for the production sidecar
- cancel superseded PR runs without canceling main validation

## Expected impact

- pure CLI and sidecar changes avoid the roughly four-minute web E2E lane
- OpenClaw and Hermes fixtures can build concurrently and share graph work
- repeated sidecar builds can reuse scoped GHA cache
- main runs complete deterministically for downstream release authority

## Verification

- Docker-isolated focused CLI suite: 24 passed, including CLI typecheck
- docker buildx bake --print
- PostgreSQL image parity check
- bash syntax and git diff checks

The full pinned-upstream WhatsApp image build is left to CI to avoid duplicating large artifact downloads locally.