### PR TITLE
perf(ci): remove bounded test delay

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -59,7 +59,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 concurrency:
   group: backend-ci-${{ github.workflow }}-${{ github.ref }}
@@ -77,9 +76,16 @@ jobs:
       sidecar: ${{ steps.filter.outputs.sidecar }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
       - id: filter
         uses: dorny/paths-filter@v4
         with:
+          # Use the exact event endpoints so path routing stays on the bounded
+          # git fallback instead of the pull-request files API.
+          token: ""
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          ref: ${{ github.event_name == 'push' && github.sha || '' }}
           filters: |
             backend:
               - "backend/**/*.py"

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -55,7 +55,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 concurrency:
   group: client-ci-${{ github.workflow }}-${{ github.ref }}
@@ -77,9 +76,16 @@ jobs:
       whatsapp_native_e2e: ${{ steps.filter.outputs.whatsapp_native_e2e }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
       - id: filter
         uses: dorny/paths-filter@v4
         with:
+          # Use the exact event endpoints so path routing stays on the bounded
+          # git fallback instead of the pull-request files API.
+          token: ""
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          ref: ${{ github.event_name == 'push' && github.sha || '' }}
           filters: |
             client:
               - "apps/web/**"

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -3849,6 +3849,7 @@ async def test_admin_platform_whatsapp_qr_promotes_only_after_connected_and_logo
     admin_client, db_session, seed_user, channel_agent, monkeypatch
 ):
     import app.routes.admin as admin_routes
+    import app.services.whatsapp_device_onboarding as whatsapp_onboarding
     from app.models.channel import (
         ChannelAccount,
         ChannelBotAgentLink,
@@ -3921,10 +3922,12 @@ async def test_admin_platform_whatsapp_qr_promotes_only_after_connected_and_logo
             frozenset(),
             environment_id=channel_agent.id,
         )
+        monkeypatch.setattr(whatsapp_onboarding, "_LOGOUT_RECOVERY_TTL_SECONDS", 0.01)
         fake.logout_fails = True
         assert (
             await admin_client.delete(f"/v1/admin/channels/{account_id}", headers=_AUTH)
         ).status_code == 503
+        assert fake.logout_calls == 1
         await db_session.refresh(account)
         assert account.archived_at is None
         assert queue.empty()

--- a/packages/cli/tests/clawdi-image-release-workflow.test.ts
+++ b/packages/cli/tests/clawdi-image-release-workflow.test.ts
@@ -28,6 +28,7 @@ interface WorkflowJob {
 interface WorkflowDocument {
 	concurrency?: Record<string, unknown>;
 	jobs: Record<string, WorkflowJob>;
+	permissions?: Record<string, string>;
 	on?: {
 		push?: { branches?: string[]; paths?: string[] };
 		workflow_run?: { branches?: string[]; types?: string[]; workflows?: string[] };
@@ -89,6 +90,20 @@ const releaseClassifierSource = readFileSync(
 );
 
 describe("backend image release workflow contract", () => {
+	test("routes changes through the bounded git fallback", () => {
+		const steps = backendCi.jobs.changes?.steps ?? [];
+
+		expect(backendCi.permissions).toEqual({ contents: "read" });
+		expect(steps.find((step) => step.uses === "actions/checkout@v7")?.with).toEqual({
+			"fetch-depth": 1,
+		});
+		expect(steps.find((step) => step.id === "filter")?.with).toMatchObject({
+			token: "",
+			base: `\${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}`,
+			ref: `\${{ github.event_name == 'push' && github.sha || '' }}`,
+		});
+	});
+
 	test("keeps Python governance out of sidecar-only changes", () => {
 		const filterStep = backendCi.jobs.changes?.steps?.find((step) => step.id === "filter");
 		const filters = String(filterStep?.with?.filters);

--- a/packages/cli/tests/clean-test-runner.test.ts
+++ b/packages/cli/tests/clean-test-runner.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { parse } from "yaml";
+
+interface WorkflowStep {
+	uses?: string;
+	with?: Record<string, unknown>;
+}
+
+interface WorkflowDocument {
+	permissions?: Record<string, string>;
+	jobs?: Record<string, { steps?: WorkflowStep[] }>;
+}
 
 const repoRoot = resolve(import.meta.dir, "../../..");
 const repoPath = (path: string): string => resolve(repoRoot, path);
@@ -9,6 +20,7 @@ const readPackageScripts = (path: string): Record<string, string> =>
 	JSON.parse(readRepoFile(path)).scripts;
 
 const clientWorkflow = readRepoFile(".github/workflows/client-ci.yml");
+const clientWorkflowDocument = parse(clientWorkflow) as WorkflowDocument;
 const cleanRunnerWorkflow = readRepoFile(".github/workflows/clean-test-runner-ci.yml");
 const setupBunAction = readRepoFile(".github/actions/setup-bun-ci/action.yml");
 const runner = readRepoFile("scripts/test.sh");
@@ -75,6 +87,16 @@ describe("client workflow contract", () => {
 		expect(clientWorkflow).toContain(
 			`cancel-in-progress: \${{ github.event_name == 'pull_request' }}`,
 		);
+		const changeSteps = clientWorkflowDocument.jobs?.changes?.steps ?? [];
+		expect(clientWorkflowDocument.permissions).toEqual({ contents: "read" });
+		expect(changeSteps.find((step) => step.uses === "actions/checkout@v7")?.with).toEqual({
+			"fetch-depth": 1,
+		});
+		expect(changeSteps.find((step) => step.uses === "dorny/paths-filter@v4")?.with).toMatchObject({
+			token: "",
+			base: `\${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}`,
+			ref: `\${{ github.event_name == 'push' && github.sha || '' }}`,
+		});
 
 		const typecheckTask = section(turboConfig, '\t\t"typecheck": {\n', '\t\t"lint": {\n');
 		expect(typecheckTask).toContain('"outputs": []');


### PR DESCRIPTION
## Summary

- route Client and Backend change detection through the bounded git fallback using exact event SHAs and contents-only permissions
- shorten the production 10-second logout recovery window only inside the fail-closed admin test
- assert the failing delete still attempts pairing logout before returning 503
- add parsed workflow contracts for both routing configurations

## Performance

- focused test call: 10.99s -> 1.21s (9.78s deterministic reduction)
- full backend pytest observation: 305.83s -> 275.27s with identical 2346 passed / 12 skipped coverage
- only the fixed 9.78s reduction is claimed; the remaining full-suite difference is treated as host-load variance

## Verification

- hermetic CLI typecheck and workflow contracts: 21 passed, 263 assertions
- hermetic PostgreSQL focused test: 1 passed in 2.36s
- full hermetic backend comparison: 2346 passed, 12 skipped before and after
- Ruff lint and format, Biome, and git diff --check passed
- temporary containers, networks, volumes, and review images removed

## Deliberately unchanged

- no pytest xdist without worker-isolated databases
- no additional Playwright workers without a stability soak
- no WhatsApp sharding or Buildx driver changes without reliable bottleneck attribution