### PR TITLE
fix(web): show reusable subscriptions as available

### DIFF
--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -1031,10 +1031,8 @@ test("terminal fallback selects reusable subscriptions and keeps the long dialog
 			.getByRole("button", { name: "Choose a subscription" })
 			.click();
 		await expect(sourceDialog).toBeVisible();
-		await expect(sourceDialog.getByRole("button", { name: /Basic subscription/ })).toBeVisible();
-		await expect(
-			sourceDialog.getByRole("button", { name: /Performance subscription/ }),
-		).toBeVisible();
+		await expect(sourceDialog.getByRole("button", { name: /^Basic\b/ })).toBeVisible();
+		await expect(sourceDialog.getByRole("button", { name: /^Performance\b/ })).toBeVisible();
 		return sourceDialog;
 	};
 	const closeSourceDialog = async () => {
@@ -1059,8 +1057,8 @@ test("terminal fallback selects reusable subscriptions and keeps the long dialog
 	dialog = await openSourceDialog(mobile320);
 	await expectSourceDialogGeometry(dialog, mobile320, true);
 
-	const active = dialog.getByRole("button", { name: /Basic subscription/ });
-	const canceling = dialog.getByRole("button", { name: /Performance subscription/ });
+	const active = dialog.getByRole("button", { name: /^Basic\b/ });
+	const canceling = dialog.getByRole("button", { name: /^Performance\b/ });
 	await active.click();
 	await expect(active).toHaveAttribute("aria-pressed", "true");
 	await canceling.click();

--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -644,9 +644,17 @@ export function EntityChoiceCard({
 				) : null}
 			</div>
 			{selected ? (
-				<Check className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden />
-			) : detailsPlacement === "trailing" || detailsPlacement === "responsive" ? (
+				<Check
+					className={cn(
+						"mt-0.5 size-4 shrink-0 text-primary",
+						detailsPlacement === "responsive" && "hidden @md/choice:block",
+					)}
+					aria-hidden
+				/>
+			) : detailsPlacement === "trailing" ? (
 				<span className="size-4 shrink-0" aria-hidden />
+			) : detailsPlacement === "responsive" ? (
+				<span className="hidden size-4 shrink-0 @md/choice:block" aria-hidden />
 			) : null}
 		</>
 	);

--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -176,6 +176,7 @@ export function EntityCardLink({
 }
 
 type EntityChoiceCardVariant = "card" | "compact";
+type EntityChoiceDetailsPlacement = "stacked" | "trailing" | "responsive";
 
 export function entityChoiceCardClass({
 	variant = "card",
@@ -579,7 +580,7 @@ export function EntityChoiceCard({
 	/** Optional detail block below the description (for example, pricing). */
 	details?: ReactNode;
 	/** Keep dense, comparable details beside the main copy when space allows. */
-	detailsPlacement?: "stacked" | "trailing";
+	detailsPlacement?: EntityChoiceDetailsPlacement;
 	/** Trailing badge in the title row (e.g. "Default", an auth chip). */
 	badge?: ReactNode;
 	selected?: boolean;
@@ -599,6 +600,9 @@ export function EntityChoiceCard({
 				className={cn(
 					"min-w-0 flex-1",
 					details && detailsPlacement === "trailing" && "flex items-start gap-3",
+					details &&
+						detailsPlacement === "responsive" &&
+						"flex flex-col gap-2 @md/choice:flex-row @md/choice:items-start @md/choice:gap-3",
 				)}
 			>
 				<div className="min-w-0 flex-1">
@@ -628,7 +632,11 @@ export function EntityChoiceCard({
 					<div
 						className={cn(
 							"min-w-0",
-							detailsPlacement === "trailing" ? "max-w-[45%] shrink-0" : "mt-2",
+							detailsPlacement === "trailing"
+								? "max-w-[45%] shrink-0"
+								: detailsPlacement === "responsive"
+									? "w-full @md/choice:w-auto @md/choice:max-w-[52%] @md/choice:shrink-0"
+									: "mt-2",
 						)}
 					>
 						{details}
@@ -637,7 +645,7 @@ export function EntityChoiceCard({
 			</div>
 			{selected ? (
 				<Check className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden />
-			) : detailsPlacement === "trailing" ? (
+			) : detailsPlacement === "trailing" || detailsPlacement === "responsive" ? (
 				<span className="size-4 shrink-0" aria-hidden />
 			) : null}
 		</>
@@ -647,7 +655,7 @@ export function EntityChoiceCard({
 		selected,
 		interactive: Boolean(onClick || href),
 		disabled,
-		className,
+		className: cn(detailsPlacement === "responsive" && "@container/choice", className),
 	});
 	if (href) {
 		return (

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -748,10 +748,11 @@ function successfulOperation(
 }
 
 describe("deployment mutation settlement", () => {
-	test("keeps reusable subscriptions scoped to delete snapshot invalidation", () => {
+	test("keeps subscription assignment inventories scoped to delete snapshot invalidation", () => {
 		const queryClient = new QueryClient();
 		queryClient.setQueryData(billingKeys.deployments, []);
 		queryClient.setQueryData(["get", "/v1/agents"], []);
+		queryClient.setQueryData(billingKeys.subscriptions, []);
 		queryClient.setQueryData(billingKeys.reusableSubscriptions, []);
 
 		if (!invalidateSnapshots || !invalidateDeleteSnapshots) {
@@ -761,9 +762,11 @@ describe("deployment mutation settlement", () => {
 
 		expect(queryClient.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(true);
 		expect(queryClient.getQueryState(["get", "/v1/agents"])?.isInvalidated).toBe(true);
+		expect(queryClient.getQueryState(billingKeys.subscriptions)?.isInvalidated).toBe(false);
 		expect(queryClient.getQueryState(billingKeys.reusableSubscriptions)?.isInvalidated).toBe(false);
 
 		invalidateDeleteSnapshots(queryClient);
+		expect(queryClient.getQueryState(billingKeys.subscriptions)?.isInvalidated).toBe(true);
 		expect(queryClient.getQueryState(billingKeys.reusableSubscriptions)?.isInvalidated).toBe(true);
 	});
 

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -56,6 +56,7 @@ export function invalidateDeploymentSnapshots(qc: QueryClient) {
 
 export function invalidateDeploymentDeleteSnapshots(qc: QueryClient) {
 	invalidateDeploymentSnapshots(qc);
+	void qc.invalidateQueries({ queryKey: billingKeys.subscriptions });
 	void qc.invalidateQueries({ queryKey: billingKeys.reusableSubscriptions });
 }
 

--- a/apps/web/src/hosted/billing/deploy/deploy-dirty-state.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-dirty-state.test.ts
@@ -5,8 +5,8 @@ import {
 	DEFAULT_DEPLOY_RUNTIME,
 } from "@/hosted/billing/deploy/deploy-defaults";
 import {
-	deployWizardDraftIsDirty,
 	type DeployWizardDirtyState,
+	deployWizardDraftIsDirty,
 } from "@/hosted/billing/deploy/deploy-dirty-state";
 import { runtimeDisplayName } from "@/hosted/runtimes";
 

--- a/apps/web/src/hosted/billing/deploy/deploy-dirty-state.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-dirty-state.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import {
+	DEFAULT_DEPLOY_AI_ACCESS_MODE,
+	DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
+	DEFAULT_DEPLOY_RUNTIME,
+} from "@/hosted/billing/deploy/deploy-defaults";
+import {
+	deployWizardDraftIsDirty,
+	type DeployWizardDirtyState,
+} from "@/hosted/billing/deploy/deploy-dirty-state";
+import { runtimeDisplayName } from "@/hosted/runtimes";
+
+const baseline: DeployWizardDirtyState = {
+	runtime: DEFAULT_DEPLOY_RUNTIME,
+	agentName: runtimeDisplayName(DEFAULT_DEPLOY_RUNTIME),
+	compute: "basic",
+	language: "en",
+	timezone: "America/Los_Angeles",
+	term: 1,
+	paymentMethod: "card",
+	subscriptionSource: { mode: "new" },
+	aiBindingDraft: {
+		bindingMode: DEFAULT_DEPLOY_AI_ACCESS_MODE,
+		primaryProviderChoice: DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
+		primaryModel: "managed-default",
+	},
+	checkoutOpen: false,
+};
+
+describe("deploy wizard dirty state", () => {
+	test("keeps browser, inventory, and managed-model hydration clean", () => {
+		const beforeManagedModelEffect = {
+			...baseline,
+			aiBindingDraft: { ...baseline.aiBindingDraft, primaryModel: "" },
+		};
+
+		expect(deployWizardDraftIsDirty(beforeManagedModelEffect, baseline)).toBe(false);
+		expect(deployWizardDraftIsDirty(baseline, baseline)).toBe(false);
+	});
+
+	test("blocks real edits until the deployment is committed", () => {
+		const edited = {
+			...baseline,
+			language: "fr",
+			aiBindingDraft: { ...baseline.aiBindingDraft, primaryModel: "another-model" },
+		};
+
+		expect(deployWizardDraftIsDirty(edited, baseline)).toBe(true);
+		expect(deployWizardDraftIsDirty(edited, baseline, true)).toBe(false);
+	});
+});

--- a/apps/web/src/hosted/billing/deploy/deploy-dirty-state.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-dirty-state.ts
@@ -1,0 +1,62 @@
+import type { SubscriptionSource } from "@/hosted/billing/subscription/subscription-create-adapter";
+import type { HostedRuntime } from "@/hosted/runtimes";
+import type { AiProviderBindingDraft } from "@/hosted/v2/ai-providers/ai-provider-binding";
+
+export type DeployWizardDirtyState = {
+	runtime: HostedRuntime;
+	agentName: string;
+	compute: "basic" | "performance";
+	language: string;
+	timezone: string;
+	term: number;
+	paymentMethod: "card" | "wallet";
+	subscriptionSource: SubscriptionSource | null;
+	aiBindingDraft: AiProviderBindingDraft;
+	checkoutOpen: boolean;
+};
+
+function subscriptionSourceEquals(
+	left: SubscriptionSource | null,
+	right: SubscriptionSource | null,
+): boolean {
+	if (left?.mode !== right?.mode) return false;
+	if (left?.mode !== "existing" || right?.mode !== "existing") return true;
+	return left.subscriptionId === right.subscriptionId;
+}
+
+function aiBindingEquals(
+	current: AiProviderBindingDraft,
+	baseline: AiProviderBindingDraft,
+): boolean {
+	if (
+		current.bindingMode !== baseline.bindingMode ||
+		current.primaryProviderChoice !== baseline.primaryProviderChoice
+	) {
+		return false;
+	}
+
+	// The managed catalog fills an initially empty model after the first render.
+	// Treat that pre-effect value as equivalent to the hydrated default.
+	const currentModel = current.primaryModel.trim() || baseline.primaryModel.trim();
+	return currentModel === baseline.primaryModel.trim();
+}
+
+export function deployWizardDraftIsDirty(
+	current: DeployWizardDirtyState,
+	baseline: DeployWizardDirtyState,
+	committed = false,
+): boolean {
+	if (committed) return false;
+	return (
+		current.runtime !== baseline.runtime ||
+		current.agentName !== baseline.agentName ||
+		current.compute !== baseline.compute ||
+		current.language !== baseline.language ||
+		current.timezone !== baseline.timezone ||
+		current.term !== baseline.term ||
+		current.paymentMethod !== baseline.paymentMethod ||
+		!subscriptionSourceEquals(current.subscriptionSource, baseline.subscriptionSource) ||
+		!aiBindingEquals(current.aiBindingDraft, baseline.aiBindingDraft) ||
+		current.checkoutOpen !== baseline.checkoutOpen
+	);
+}

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -77,8 +77,8 @@ import {
 	deployAgentNameAfterRuntimeChange,
 } from "@/hosted/billing/deploy/deploy-defaults";
 import {
-	deployWizardDraftIsDirty,
 	type DeployWizardDirtyState,
+	deployWizardDraftIsDirty,
 } from "@/hosted/billing/deploy/deploy-dirty-state";
 import { usesActiveIncludedBasicSlot } from "@/hosted/billing/deploy/deploy-model";
 import {
@@ -166,10 +166,10 @@ import { useUserAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks"
 import { AuthBadge, ProviderIcon } from "@/hosted/v2/ai-providers/ai-providers-ui";
 import { authCardLabel } from "@/hosted/v2/ai-providers/auth-card-label";
 import {
+	firstModelForProvider,
 	MANAGED_AI_CHOICE,
 	MANAGED_PROVIDER_ID,
 	MANAGED_PROVIDER_LABEL,
-	firstModelForProvider,
 	modelDisplayName,
 	modelOptionsForProvider,
 	providerAvailabilityIssue,
@@ -1194,11 +1194,7 @@ export function DeployWizard() {
 
 	const defaultPrimaryModel =
 		DEFAULT_DEPLOY_PRIMARY_MODEL ||
-		firstModelForProvider(
-			DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
-			providerList,
-			managedModels,
-		);
+		firstModelForProvider(DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE, providerList, managedModels);
 	const defaultBillingTerm = basicPlan
 		? (selectExplicitOfferForTerm(basicPlan, 1)?.billingTermMonths ?? 1)
 		: 1;

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -76,6 +76,10 @@ import {
 	DEFAULT_DEPLOY_RUNTIME,
 	deployAgentNameAfterRuntimeChange,
 } from "@/hosted/billing/deploy/deploy-defaults";
+import {
+	deployWizardDraftIsDirty,
+	type DeployWizardDirtyState,
+} from "@/hosted/billing/deploy/deploy-dirty-state";
 import { usesActiveIncludedBasicSlot } from "@/hosted/billing/deploy/deploy-model";
 import {
 	type ComputePricePresentation,
@@ -165,6 +169,7 @@ import {
 	MANAGED_AI_CHOICE,
 	MANAGED_PROVIDER_ID,
 	MANAGED_PROVIDER_LABEL,
+	firstModelForProvider,
 	modelDisplayName,
 	modelOptionsForProvider,
 	providerAvailabilityIssue,
@@ -336,6 +341,7 @@ export function DeployWizard() {
 	}, []);
 	const [acceptedDeploymentRecovery, setAcceptedDeploymentRecovery] =
 		useState<AcceptedDeploymentRecovery | null>(null);
+	const [deploymentCommitted, setDeploymentCommitted] = useState(false);
 	const acceptanceNavigatingRef = useRef(false);
 	const acceptDeployment = useCallback(
 		async (
@@ -344,6 +350,7 @@ export function DeployWizard() {
 			requestProgress: DeploymentRequestProgress = DEFAULT_DEPLOYMENT_REQUEST_PROGRESS,
 		): Promise<boolean> => {
 			setAcceptedDeploymentRecovery(null);
+			if (target.kind === "deployment") setDeploymentCommitted(true);
 			setSubmitBusyLabel(
 				target.kind === "deploy_request" ? requestProgress.busyLabel : "Loading agent details…",
 			);
@@ -365,6 +372,7 @@ export function DeployWizard() {
 						...navigation,
 						deployRequestId: target.deployRequestId,
 						onAccepted: () => {
+							setDeploymentCommitted(true);
 							clearCheckoutAttempt(target.deployRequestId);
 							setSubmitBusyLabel("Loading agent details…");
 							setSubmitTakingLongCopy(null);
@@ -446,6 +454,15 @@ export function DeployWizard() {
 	const reusableSubscriptions = useReusableSubscriptions(billingClient);
 	const managedModelCatalog = useManagedModelCatalog();
 	const aiProviders = useUserAiProviders();
+	const blockingReusableSubscriptionsError = shouldBlockQueryError(
+		reusableSubscriptions.error,
+		reusableSubscriptions.data,
+	)
+		? reusableSubscriptions.error
+		: null;
+	const reusableSubscriptionInventory = blockingReusableSubscriptionsError
+		? undefined
+		: reusableSubscriptions.data;
 	const createSubscription = useSensitiveCreateSubscription();
 	const runAction = useActionLock();
 	const walletCreateAttemptRef = useRef<IdempotencyAttempt | null>(null);
@@ -456,6 +473,7 @@ export function DeployWizard() {
 	const [compute, setCompute] = useState<Compute>("basic");
 	const [language, setLanguage] = useState("");
 	const [timezone, setTimezone] = useState("");
+	const [personaDefaults, setPersonaDefaults] = useState({ language: "", timezone: "" });
 	const [timezoneOptions, setTimezoneOptions] = useState(fallbackTimezones);
 	const [addProviderOpen, setAddProviderOpen] = useState(false);
 	const [checkoutSession, setCheckoutSession] = useState<NativeDeployCheckout | null>(null);
@@ -490,9 +508,11 @@ export function DeployWizard() {
 	// then adopt runtime IANA data and best-effort browser defaults after mount.
 	useEffect(() => {
 		const browserTimezoneValue = browserTimezone();
+		const browserLanguageValue = browserLanguage();
 		setTimezone((current) => current || browserTimezoneValue);
 		setTimezoneOptions(supportedTimezones(browserTimezoneValue ? [browserTimezoneValue] : []));
-		setLanguage((lang) => lang || browserLanguage());
+		setLanguage((current) => current || browserLanguageValue);
+		setPersonaDefaults({ language: browserLanguageValue, timezone: browserTimezoneValue });
 	}, []);
 	useEffect(() => {
 		if (!submitting) return;
@@ -525,8 +545,15 @@ export function DeployWizard() {
 			includedBasicAvailability === "unknown"
 				? undefined
 				: includedBasicAvailability === "available",
-		reusableSubscriptions:
-			reusableSubscriptions.error == null ? reusableSubscriptions.data : undefined,
+		reusableSubscriptions: reusableSubscriptionInventory,
+	});
+	const defaultSubscriptionSource = resolveSubscriptionSource({
+		selected: null,
+		includedAvailable:
+			includedBasicAvailability === "unknown"
+				? undefined
+				: includedBasicAvailability === "available",
+		reusableSubscriptions: reusableSubscriptionInventory,
 	});
 	const perfOfferSelection = useMemo(
 		() => (perfPlan ? selectOfferForTerm(perfPlan, term) : null),
@@ -580,7 +607,7 @@ export function DeployWizard() {
 			: null;
 	const selectedReusableSubscription =
 		subscriptionSource?.mode === "existing"
-			? (reusableSubscriptions.data?.find(
+			? (reusableSubscriptionInventory?.find(
 					(subscription) => subscription.subscription_id === subscriptionSource.subscriptionId,
 				) ?? null)
 			: null;
@@ -670,7 +697,7 @@ export function DeployWizard() {
 			if (includedBasicAvailability !== "available") return "Free compute is unavailable.";
 		} else {
 			if (reusableSubscriptions.isFetching) return "Checking reusable subscriptions.";
-			if (reusableSubscriptions.error != null || reusableSubscriptions.data === undefined) {
+			if (blockingReusableSubscriptionsError || reusableSubscriptionInventory === undefined) {
 				return "Retry loading reusable subscriptions above.";
 			}
 			if (subscriptionSource.mode === "existing" && !selectedReusableSubscription) {
@@ -1165,15 +1192,51 @@ export function DeployWizard() {
 			? new Error("The billing service returned no compute plans. Try loading plans again.")
 			: null);
 
-	const deployDirty =
-		runtime !== DEFAULT_DEPLOY_RUNTIME ||
-		agentName !== runtimeDisplayName(runtime) ||
-		compute !== "basic" ||
-		language !== "" ||
-		timezone !== "" ||
-		term !== 1 ||
-		selectedSubscriptionSource !== null ||
-		checkoutSession !== null;
+	const defaultPrimaryModel =
+		DEFAULT_DEPLOY_PRIMARY_MODEL ||
+		firstModelForProvider(
+			DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
+			providerList,
+			managedModels,
+		);
+	const defaultBillingTerm = basicPlan
+		? (selectExplicitOfferForTerm(basicPlan, 1)?.billingTermMonths ?? 1)
+		: 1;
+	const effectiveBillingTerm =
+		(compute === "performance" ? perfOfferSelection : basicOfferSelection)?.billingTermMonths ??
+		term;
+	const deployBaseline: DeployWizardDirtyState = {
+		runtime: DEFAULT_DEPLOY_RUNTIME,
+		agentName: runtimeDisplayName(DEFAULT_DEPLOY_RUNTIME),
+		compute: "basic",
+		language: personaDefaults.language,
+		timezone: personaDefaults.timezone,
+		term: defaultBillingTerm,
+		paymentMethod: "card",
+		subscriptionSource: defaultSubscriptionSource,
+		aiBindingDraft: {
+			bindingMode: DEFAULT_DEPLOY_AI_ACCESS_MODE,
+			primaryProviderChoice: DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
+			primaryModel: defaultPrimaryModel,
+		},
+		checkoutOpen: false,
+	};
+	const deployDirty = deployWizardDraftIsDirty(
+		{
+			runtime,
+			agentName,
+			compute,
+			language,
+			timezone,
+			term: effectiveBillingTerm,
+			paymentMethod,
+			subscriptionSource,
+			aiBindingDraft,
+			checkoutOpen: checkoutSession !== null,
+		},
+		deployBaseline,
+		deploymentCommitted,
+	);
 
 	return (
 		<div data-hosted="true" data-v2="true" className={DEPLOY_PAGE_CLASS}>
@@ -1309,9 +1372,9 @@ export function DeployWizard() {
 							value={subscriptionSource}
 							onChange={setSubscriptionSource}
 							showIncluded={includedBasicAvailability === "available"}
-							reusableSubscriptions={reusableSubscriptions.data ?? []}
+							reusableSubscriptions={reusableSubscriptionInventory ?? []}
 							isLoading={reusableSubscriptions.isFetching}
-							error={reusableSubscriptions.error}
+							error={blockingReusableSubscriptionsError}
 							onRetry={() => void reusableSubscriptions.refetch()}
 							disabled={submitting}
 						/>

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-card.test.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-card.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ComputeSubscriptionCard } from "./compute-subscription-card";
+
+describe("ComputeSubscriptionCard", () => {
+	test("labels reusable compute as available without stale assignment copy", () => {
+		const markup = renderToStaticMarkup(
+			<ComputeSubscriptionCard
+				view={{
+					status: { label: "Active", tone: "success" },
+					plan: "Performance compute",
+					commercialFacts: [],
+				}}
+				identity={{ kind: "available", label: "Available for a new agent" }}
+			/>,
+		);
+
+		expect(markup).toContain("Available for a new agent");
+		expect(markup).not.toContain("Used by");
+		expect(markup).not.toContain("Deleted agent");
+		expect(markup).not.toContain("Orphaned");
+	});
+});

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { ArrowUp, Settings, UserRoundX } from "lucide-react";
+import { ArrowUp, CircleCheck, Settings, UserRoundX } from "lucide-react";
 import type { ReactNode } from "react";
 import { AgentLabel } from "@/components/dashboard/agent-label";
 import { entityCardChassisClass } from "@/components/entity-card";
@@ -18,6 +18,7 @@ export type ComputeSubscriptionIdentity =
 			avatarUrl?: string | null;
 			href?: string;
 	  }
+	| { kind: "available"; label: string }
 	| { kind: "unavailable"; label: string };
 
 export type ComputeSubscriptionCardView = {
@@ -91,6 +92,18 @@ export function computeSubscriptionCardView({
 }
 
 function SubscriptionIdentity({ identity }: { identity: ComputeSubscriptionIdentity }) {
+	if (identity.kind === "available") {
+		return (
+			<div className="flex min-w-0 items-center gap-3 text-success-muted-foreground">
+				<span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-success-muted">
+					<CircleCheck className="size-3.5" aria-hidden />
+				</span>
+				<span className="truncate text-sm font-medium" title={identity.label}>
+					{identity.label}
+				</span>
+			</div>
+		);
+	}
 	if (identity.kind === "unavailable") {
 		return (
 			<div className="flex min-w-0 items-center gap-3 text-muted-foreground">
@@ -213,7 +226,9 @@ export function ComputeSubscriptionCard({
 						data-slot="compute-subscription-identity"
 						className="flex min-w-0 items-center gap-3"
 					>
-						<span className="shrink-0 text-xs text-muted-foreground">Used by</span>
+						{identity.kind === "agent" ? (
+							<span className="shrink-0 text-xs text-muted-foreground">Used by</span>
+						) : null}
 						<div className="min-w-0 flex-1">
 							<SubscriptionIdentity identity={identity} />
 						</div>

--- a/apps/web/src/hosted/billing/subscription/subscription-source-picker.test.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-source-picker.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { ReusableSubscription } from "@/hosted/billing/contracts";
+import { SubscriptionSourcePicker } from "@/hosted/billing/subscription/subscription-source-picker";
+
+const reusableSubscription: ReusableSubscription = {
+	subscription_id: "csub_reusable",
+	plan_slug: "compute_basic",
+	billing_term_months: 1,
+	funding_source: "wallet",
+	status: "active",
+	currency: "usd",
+	price_cents: 1_000,
+	current_period_end: "2026-09-17T00:00:00Z",
+	entitled_until: "2026-09-17T00:00:00Z",
+	cancel_at_period_end: false,
+};
+
+describe("SubscriptionSourcePicker", () => {
+	test("keeps reusable compute compact and readable at card-local breakpoints", () => {
+		const markup = renderToStaticMarkup(
+			<SubscriptionSourcePicker
+				value={{ mode: "existing", subscriptionId: reusableSubscription.subscription_id }}
+				onChange={() => undefined}
+				reusableSubscriptions={[reusableSubscription]}
+				isLoading={false}
+				error={null}
+				onRetry={() => undefined}
+			/>,
+		);
+
+		expect(markup).toContain("@container/subscription-source");
+		expect(markup).toContain("items-start gap-2 @3xl/subscription-source:grid-cols-2");
+		expect(markup).toContain("@container/choice");
+		expect(markup).toContain("@md/choice:flex-row");
+		expect(markup).toContain('aria-pressed="true"');
+		expect(markup).toContain("Basic subscription");
+		expect(markup).toContain("Plan price");
+	});
+});

--- a/apps/web/src/hosted/billing/subscription/subscription-source-picker.test.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-source-picker.test.tsx
@@ -34,7 +34,7 @@ describe("SubscriptionSourcePicker", () => {
 		expect(markup).toContain("@container/choice");
 		expect(markup).toContain("@md/choice:flex-row");
 		expect(markup).toContain('aria-pressed="true"');
-		expect(markup).toContain("Basic subscription");
+		expect(markup).toContain('title="Basic">Basic</span>');
 		expect(markup).toContain("Plan price");
 	});
 });

--- a/apps/web/src/hosted/billing/subscription/subscription-source-picker.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-source-picker.tsx
@@ -146,15 +146,15 @@ function ExistingSubscriptionChoice({
 					{subscription.plan_slug === "compute_performance" ? <Zap /> : <Cpu />}
 				</IconChip>
 			}
-			title={`${computeTierLabel(subscription.plan_slug)} subscription`}
+			title={computeTierLabel(subscription.plan_slug)}
 			description="$0 due now"
 			badge={statusBadge}
 			detailsPlacement="responsive"
 			details={
-				<dl className="grid min-w-0 grid-cols-2 gap-x-3 gap-y-1 text-xs">
+				<dl className="grid min-w-0 grid-cols-2 gap-x-2 gap-y-1 text-[11px] @md/choice:gap-x-3 @md/choice:text-xs">
 					<div className="min-w-0">
 						<dt className="text-muted-foreground">Term</dt>
-						<dd className="truncate text-foreground">
+						<dd className="whitespace-nowrap text-foreground">
 							{billingTermLabel(subscription.billing_term_months)}
 						</dd>
 					</div>
@@ -166,17 +166,17 @@ function ExistingSubscriptionChoice({
 							) : (
 								<CreditCard className="size-3 shrink-0" />
 							)}
-							<span className="truncate">{paymentLabel}</span>
+							<span className="whitespace-nowrap">{paymentLabel}</span>
 						</dd>
 					</div>
 					<div className="min-w-0">
 						<dt className="text-muted-foreground">{canceling ? "Ends" : "Renews"}</dt>
-						<dd className="truncate text-foreground">{dateLabel}</dd>
+						<dd className="whitespace-nowrap text-foreground">{dateLabel}</dd>
 					</div>
 					{priceLabel ? (
 						<div className="min-w-0">
 							<dt className="text-muted-foreground">Plan price</dt>
-							<dd className="truncate text-foreground tabular-nums">{priceLabel}</dd>
+							<dd className="whitespace-nowrap text-foreground tabular-nums">{priceLabel}</dd>
 						</div>
 					) : null}
 				</dl>

--- a/apps/web/src/hosted/billing/subscription/subscription-source-picker.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-source-picker.tsx
@@ -42,8 +42,11 @@ export function SubscriptionSourcePicker({
 
 	const paidDisabled = disabled || error != null || isLoading;
 	return (
-		<div data-hosted="true" className="flex min-w-0 flex-col gap-3">
-			<div className="grid min-w-0 gap-2 lg:grid-cols-2">
+		<div
+			data-hosted="true"
+			className="@container/subscription-source flex min-w-0 flex-col gap-3"
+		>
+			<div className="grid min-w-0 items-start gap-2 @3xl/subscription-source:grid-cols-2">
 				{showIncluded ? (
 					<EntityChoiceCard
 						selected={value?.mode === "included"}
@@ -149,6 +152,7 @@ function ExistingSubscriptionChoice({
 			title={`${computeTierLabel(subscription.plan_slug)} subscription`}
 			description="$0 due now"
 			badge={statusBadge}
+			detailsPlacement="responsive"
 			details={
 				<dl className="grid min-w-0 grid-cols-2 gap-x-3 gap-y-1 text-xs">
 					<div className="min-w-0">

--- a/apps/web/src/hosted/billing/subscription/subscription-source-picker.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-source-picker.tsx
@@ -42,10 +42,7 @@ export function SubscriptionSourcePicker({
 
 	const paidDisabled = disabled || error != null || isLoading;
 	return (
-		<div
-			data-hosted="true"
-			className="@container/subscription-source flex min-w-0 flex-col gap-3"
-		>
+		<div data-hosted="true" className="@container/subscription-source flex min-w-0 flex-col gap-3">
 			<div className="grid min-w-0 items-start gap-2 @3xl/subscription-source:grid-cols-2">
 				{showIncluded ? (
 					<EntityChoiceCard

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
@@ -5,6 +5,8 @@ type SubscriptionsSectionModule =
 	typeof import("@/hosted/billing/subscription/subscriptions-section");
 
 let sortLoadedSubscriptions: SubscriptionsSectionModule["sortLoadedSubscriptions"] | null = null;
+let computeSubscriptionAssignment: SubscriptionsSectionModule["computeSubscriptionAssignment"] | null =
+	null;
 
 beforeAll(async () => {
 	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
@@ -12,6 +14,7 @@ beforeAll(async () => {
 	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
 	const module = await import("@/hosted/billing/subscription/subscriptions-section");
 	sortLoadedSubscriptions = module.sortLoadedSubscriptions;
+	computeSubscriptionAssignment = module.computeSubscriptionAssignment;
 });
 
 function subscription(
@@ -38,6 +41,25 @@ function subscription(
 }
 
 describe("SubscriptionsSection", () => {
+	test("lets canonical reusable inventory override stale deployment and orphan projections", () => {
+		if (!computeSubscriptionAssignment) throw new Error("Subscriptions helpers were not loaded");
+		const staleAssigned = subscription("reusable", "active");
+		const staleOrphan = {
+			...subscription("orphan", "active"),
+			deployment_id: null,
+			is_orphan: true,
+		};
+
+		expect(
+			computeSubscriptionAssignment(staleAssigned, new Set([staleAssigned.subscription_id])),
+		).toBe("available");
+		expect(
+			computeSubscriptionAssignment(staleOrphan, new Set([staleOrphan.subscription_id])),
+		).toBe("available");
+		expect(computeSubscriptionAssignment(staleAssigned, new Set())).toBe("assigned");
+		expect(computeSubscriptionAssignment(staleOrphan, new Set())).toBe("unavailable");
+	});
+
 	test("stably prioritizes loaded current subscriptions without mutating query data", () => {
 		if (!sortLoadedSubscriptions) throw new Error("Subscriptions helpers were not loaded");
 		const loaded = [

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
@@ -7,6 +7,7 @@ type SubscriptionsSectionModule =
 let sortLoadedSubscriptions: SubscriptionsSectionModule["sortLoadedSubscriptions"] | null = null;
 let computeSubscriptionAssignment: SubscriptionsSectionModule["computeSubscriptionAssignment"] | null =
 	null;
+let reusableInventoryState: SubscriptionsSectionModule["reusableInventoryState"] | null = null;
 
 beforeAll(async () => {
 	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
@@ -15,6 +16,7 @@ beforeAll(async () => {
 	const module = await import("@/hosted/billing/subscription/subscriptions-section");
 	sortLoadedSubscriptions = module.sortLoadedSubscriptions;
 	computeSubscriptionAssignment = module.computeSubscriptionAssignment;
+	reusableInventoryState = module.reusableInventoryState;
 });
 
 function subscription(
@@ -41,6 +43,16 @@ function subscription(
 }
 
 describe("SubscriptionsSection", () => {
+	test("waits for canonical availability and only blocks errors without cached data", () => {
+		if (!reusableInventoryState) throw new Error("Subscriptions helpers were not loaded");
+		expect([
+			reusableInventoryState(null, undefined),
+			reusableInventoryState(new Error("offline"), undefined),
+			reusableInventoryState(null, []),
+			reusableInventoryState(new Error("background refresh failed"), []),
+		]).toEqual(["loading", "error", "ready", "ready"]);
+	});
+
 	test("lets canonical reusable inventory override stale deployment and orphan projections", () => {
 		if (!computeSubscriptionAssignment) throw new Error("Subscriptions helpers were not loaded");
 		const staleAssigned = subscription("reusable", "active");

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
@@ -5,8 +5,9 @@ type SubscriptionsSectionModule =
 	typeof import("@/hosted/billing/subscription/subscriptions-section");
 
 let sortLoadedSubscriptions: SubscriptionsSectionModule["sortLoadedSubscriptions"] | null = null;
-let computeSubscriptionAssignment: SubscriptionsSectionModule["computeSubscriptionAssignment"] | null =
-	null;
+let computeSubscriptionAssignment:
+	| SubscriptionsSectionModule["computeSubscriptionAssignment"]
+	| null = null;
 let reusableInventoryState: SubscriptionsSectionModule["reusableInventoryState"] | null = null;
 
 beforeAll(async () => {
@@ -65,9 +66,9 @@ describe("SubscriptionsSection", () => {
 		expect(
 			computeSubscriptionAssignment(staleAssigned, new Set([staleAssigned.subscription_id])),
 		).toBe("available");
-		expect(
-			computeSubscriptionAssignment(staleOrphan, new Set([staleOrphan.subscription_id])),
-		).toBe("available");
+		expect(computeSubscriptionAssignment(staleOrphan, new Set([staleOrphan.subscription_id]))).toBe(
+			"available",
+		);
 		expect(computeSubscriptionAssignment(staleAssigned, new Set())).toBe("assigned");
 		expect(computeSubscriptionAssignment(staleOrphan, new Set())).toBe("unavailable");
 	});

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -18,9 +18,9 @@ import { ComputeSubscriptionActionList } from "@/hosted/billing/subscription/com
 import { resolveComputeSubscriptionActions } from "@/hosted/billing/subscription/compute-subscription-actions";
 import {
 	ComputeSubscriptionCard,
+	type ComputeSubscriptionIdentity,
 	computeSubscriptionCardView,
 	computeSubscriptionPlanLabel,
-	type ComputeSubscriptionIdentity,
 } from "@/hosted/billing/subscription/compute-subscription-card";
 import {
 	type ComputeSubscriptionManagementResult,
@@ -94,7 +94,10 @@ function subscriptionManagement(
 }
 
 export function computeSubscriptionAssignment(
-	subscription: Pick<ComputeSubscriptionListItem, "deployment_id" | "is_orphan" | "subscription_id">,
+	subscription: Pick<
+		ComputeSubscriptionListItem,
+		"deployment_id" | "is_orphan" | "subscription_id"
+	>,
 	reusableSubscriptionIds: ReadonlySet<string>,
 ): "available" | "assigned" | "unavailable" {
 	if (reusableSubscriptionIds.has(subscription.subscription_id)) return "available";

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -10,6 +10,7 @@ import { SettingsSection } from "@/components/settings-section";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useBillingClient } from "@/hosted/billing/billing-client";
 import type { ComputeSubscriptionListItem, HostedDeployment } from "@/hosted/billing/contracts";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { useHostedDeployments, usePlans, useSubscriptions } from "@/hosted/billing/hooks";
@@ -19,6 +20,7 @@ import {
 	ComputeSubscriptionCard,
 	computeSubscriptionCardView,
 	computeSubscriptionPlanLabel,
+	type ComputeSubscriptionIdentity,
 } from "@/hosted/billing/subscription/compute-subscription-card";
 import {
 	type ComputeSubscriptionManagementResult,
@@ -26,6 +28,7 @@ import {
 } from "@/hosted/billing/subscription/compute-subscription-management";
 import { computeSubscriptionRecoveryPresentation } from "@/hosted/billing/subscription/compute-subscription-recovery";
 import { PlanChangeController } from "@/hosted/billing/subscription/plan-change-controller";
+import { useReusableSubscriptions } from "@/hosted/billing/subscription/reusable-subscriptions-query";
 import {
 	computeFundingSource,
 	computeSubscriptionLifecycle,
@@ -90,6 +93,14 @@ function subscriptionManagement(
 	});
 }
 
+export function computeSubscriptionAssignment(
+	subscription: Pick<ComputeSubscriptionListItem, "deployment_id" | "is_orphan" | "subscription_id">,
+	reusableSubscriptionIds: ReadonlySet<string>,
+): "available" | "assigned" | "unavailable" {
+	if (reusableSubscriptionIds.has(subscription.subscription_id)) return "available";
+	return subscription.deployment_id && !subscription.is_orphan ? "assigned" : "unavailable";
+}
+
 export function SubscriptionLoadMore({
 	isLoading,
 	onLoadMore,
@@ -111,11 +122,13 @@ function SubscriptionRow({
 	agentTile,
 	management,
 	onPlanChange,
+	reusableSubscriptionIds,
 }: {
 	subscription: ComputeSubscriptionListItem;
 	agentTile?: AgentTile;
 	management: ComputeSubscriptionManagementResult;
 	onPlanChange: (subscription: ComputeSubscriptionListItem) => void;
+	reusableSubscriptionIds: ReadonlySet<string>;
 }) {
 	const lifecycle = computeSubscriptionLifecycle(subscription);
 	const recovery = computeSubscriptionRecoveryPresentation(subscription, {
@@ -184,24 +197,31 @@ function SubscriptionRow({
 		scheduleFallback: recovery.schedule?.fallback ?? undefined,
 		includeSchedule: !isHistoricalAccountSubscription(subscription),
 	});
+	const assignment = computeSubscriptionAssignment(subscription, reusableSubscriptionIds);
+	const identity: ComputeSubscriptionIdentity =
+		assignment === "available"
+			? { kind: "available", label: "Available for a new agent" }
+			: assignment === "assigned" && agentHref
+				? {
+						kind: "agent",
+						name: agentTile?.name ?? subscription.agent_name ?? "Agent",
+						agentType: agentTile?.agentType ?? null,
+						avatarUrl: agentTile?.avatarUrl,
+						href: agentHref,
+					}
+				: { kind: "unavailable", label: "Deleted agent" };
 
 	return (
 		<li className="min-w-0">
 			<ComputeSubscriptionCard
 				headingLevel={4}
 				view={view}
-				identity={
-					agentHref
-						? {
-								kind: "agent",
-								name: agentTile?.name ?? subscription.agent_name ?? "Agent",
-								agentType: agentTile?.agentType ?? null,
-								avatarUrl: agentTile?.avatarUrl,
-								href: agentHref,
-							}
-						: { kind: "unavailable", label: "Deleted agent" }
+				identity={identity}
+				badges={
+					assignment === "unavailable" && subscription.is_orphan ? (
+						<Badge variant="outline">Orphaned</Badge>
+					) : null
 				}
-				badges={subscription.is_orphan ? <Badge variant="outline">Orphaned</Badge> : null}
 				notice={
 					recoveryNotice || pendingPlanCopy || managementReason ? (
 						<div className="flex flex-col gap-1.5 text-xs text-muted-foreground">
@@ -309,7 +329,9 @@ function SubscriptionListSkeleton() {
 }
 
 export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly AgentTile[] }) {
+	const billingClient = useBillingClient();
 	const subscriptions = useSubscriptions();
+	const reusableSubscriptions = useReusableSubscriptions(billingClient);
 	const plans = usePlans();
 	const deployments = useHostedDeployments();
 	const hostedAccess = useProductAccess();
@@ -323,6 +345,9 @@ export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly Agen
 		agentTiles
 			.filter((tile) => tile.source === "on-clawdi")
 			.map((tile) => [tile.id.toLowerCase(), tile] as const),
+	);
+	const reusableSubscriptionIds = new Set(
+		(reusableSubscriptions.data ?? []).map((subscription) => subscription.subscription_id),
 	);
 	const endedRows = rows.filter(isHistoricalAccountSubscription);
 	const visibleRows = showHistory
@@ -420,6 +445,7 @@ export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly Agen
 											managementOptions,
 										)}
 										onPlanChange={openPlanChange}
+										reusableSubscriptionIds={reusableSubscriptionIds}
 									/>
 								))}
 							</ul>

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -302,10 +302,18 @@ export function sortLoadedSubscriptions(
 		.map(({ subscription }) => subscription);
 }
 
-function SubscriptionListSkeleton() {
+export function reusableInventoryState(
+	error: unknown,
+	data: readonly unknown[] | undefined,
+): "loading" | "error" | "ready" {
+	if (shouldBlockQueryError(error, data)) return "error";
+	return data === undefined ? "loading" : "ready";
+}
+
+function SubscriptionListSkeleton({ label = "Loading subscriptions" }: { label?: string }) {
 	return (
 		<div className="grid gap-3 lg:grid-cols-2" role="status">
-			<span className="sr-only">Loading subscriptions</span>
+			<span className="sr-only">{label}</span>
 			{Array.from({ length: 3 }, (_, index) => `subscription-skeleton-${index}`).map((key) => (
 				<div key={key} className={entityCardChassisClass({ variant: "compact" })}>
 					<div className="flex items-start justify-between gap-3">
@@ -340,6 +348,10 @@ export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly Agen
 		useState<ComputeSubscriptionListItem | null>(null);
 	const [planChangeOpen, setPlanChangeOpen] = useState(false);
 	const rows = subscriptions.data?.pages.flatMap((page) => page.items ?? []) ?? [];
+	const availabilityState = reusableInventoryState(
+		reusableSubscriptions.error,
+		reusableSubscriptions.data,
+	);
 	const orderedRows = sortLoadedSubscriptions(rows);
 	const agentTilesByDeploymentId = new Map(
 		agentTiles
@@ -407,6 +419,15 @@ export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly Agen
 						error={subscriptions.error}
 						onRetry={() => void subscriptions.refetch()}
 						title="Couldn't load subscriptions"
+					/>
+				) : availabilityState === "loading" ? (
+					<SubscriptionListSkeleton label="Loading subscription availability" />
+				) : availabilityState === "error" ? (
+					<ApiErrorPanel
+						normalizer={billingErrorNormalizer}
+						error={reusableSubscriptions.error}
+						onRetry={() => void reusableSubscriptions.refetch()}
+						title="Couldn't load subscription availability"
 					/>
 				) : rows.length || subscriptions.hasNextPage ? (
 					<>


### PR DESCRIPTION
## Summary

- use the reusable subscription inventory as the canonical assignment state in Compute
- refresh subscription inventories after deletion so Create Agent can reuse capacity immediately
- compact the reusable subscription choice card with card-local responsive layout
- compare Deploy dirty state against hydrated semantic defaults to avoid false unsaved-change prompts

## Verification

- focused web tests (`41 passed`)
- web TypeScript check
- OSS production build
- `git diff --check origin/main..HEAD`

## Related

- Backend counterpart: https://github.com/Clawdi-AI/clawdi-hosted/pull/1792