### PR TITLE
fix(web): refresh OpenClaw window handoffs

### DIFF
--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -673,7 +673,7 @@ describe("hosted agent customer language", () => {
 		expect(detailSource).toContain("Runtime UI access");
 		expect(detailSource).toContain("<iframe");
 		expect(detailSource).toContain('allow="clipboard-read; clipboard-write"');
-		expect(detailSource).toContain("Open in new window");
+		expect(detailSource).toContain("loadRuntimeUiWindowTarget");
 		expect(detailSource).toContain('<RuntimeUiCredentialRow label="Username"');
 		expect(detailSource).toContain('label="Password"');
 		expect(detailSource).not.toContain('<RuntimeUiCredentialRow label="Token"');

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -124,6 +124,7 @@ import {
 import {
 	forgetOpenClawBootstrapAttempt,
 	hasOpenClawBootstrapAttempt,
+	loadRuntimeUiWindowTarget,
 	openSecureRuntimeWindow,
 	rememberOpenClawBootstrapAttempt,
 	resolveRuntimeUiCredentials,
@@ -1413,7 +1414,6 @@ function ConsoleTab({
 	const [credentials, setCredentials] = useState<RuntimeUiCredentials | null>(null);
 	const [credentialError, setCredentialError] = useState<Error | null>(null);
 	const [isCredentialLoading, setIsCredentialLoading] = useState(false);
-	const [isOpenClawBootstrapPending, setIsOpenClawBootstrapPending] = useState(false);
 	const [credentialLoadState, setCredentialLoadState] = useState<"loading" | "ready" | "error">(
 		runtime === "openclaw" ? "loading" : "ready",
 	);
@@ -1440,7 +1440,6 @@ function ConsoleTab({
 					error instanceof Error ? error : new Error("Runtime UI credential request failed"),
 				);
 				setCredentialLoadState("error");
-				setIsOpenClawBootstrapPending(false);
 			}
 			return null;
 		} finally {
@@ -1453,13 +1452,11 @@ function ConsoleTab({
 		setCredentials(null);
 		setCredentialError(null);
 		setIsCredentialLoading(false);
-		setIsOpenClawBootstrapPending(false);
 		setCredentialLoadState(runtime === "openclaw" ? "loading" : "ready");
 	}, [runtime]);
 
 	const reconnectOpenClaw = useCallback(() => {
 		forgetOpenClawBootstrapAttempt(window.localStorage, deployment.resource.id);
-		setIsOpenClawBootstrapPending(true);
 		return loadCredentials();
 	}, [deployment.resource.id, loadCredentials]);
 
@@ -1472,7 +1469,6 @@ function ConsoleTab({
 			setCredentialLoadState("ready");
 			return;
 		}
-		setIsOpenClawBootstrapPending(true);
 		void loadCredentials();
 	}, [
 		clearCredentials,
@@ -1599,8 +1595,8 @@ function ConsoleTab({
 					credentials={credentials}
 					credentialError={credentialError}
 					isCredentialLoading={isCredentialLoading}
-					isOpenClawBootstrapPending={isOpenClawBootstrapPending}
 					onLoadCredentials={loadCredentials}
+					onRequestCredentials={requestCredentials}
 					onClearCredentials={clearCredentials}
 					onReconnectOpenClaw={reconnectOpenClaw}
 				/>
@@ -1653,7 +1649,6 @@ function ConsoleTab({
 										deployment.resource.id,
 										url,
 									);
-									setIsOpenClawBootstrapPending(false);
 								}
 							: undefined
 					}
@@ -1790,8 +1785,8 @@ function RuntimeUiAccessDialog({
 	credentials,
 	credentialError,
 	isCredentialLoading,
-	isOpenClawBootstrapPending,
 	onLoadCredentials,
+	onRequestCredentials,
 	onClearCredentials,
 	onReconnectOpenClaw,
 }: {
@@ -1801,14 +1796,16 @@ function RuntimeUiAccessDialog({
 	credentials: RuntimeUiCredentials | null;
 	credentialError: Error | null;
 	isCredentialLoading: boolean;
-	isOpenClawBootstrapPending: boolean;
 	onLoadCredentials: () => Promise<RuntimeUiCredentials | null>;
+	onRequestCredentials: () => Promise<RuntimeUiCredentials>;
 	onClearCredentials: () => void;
 	onReconnectOpenClaw: () => Promise<RuntimeUiCredentials | null>;
 }) {
 	const label = runtimeBrowserUiLabel(runtime);
 	const reset = useResetRuntimeUiAccess();
 	const [open, setOpen] = useState(false);
+	const [isWindowOpening, setIsWindowOpening] = useState(false);
+	const windowOpeningRef = useRef(false);
 	const loadedIdentityRef = useRef<string | null>(null);
 	const triggerRef = useRef<HTMLButtonElement>(null);
 	const [accessHintOpen, setAccessHintOpen] = useState(false);
@@ -1816,8 +1813,6 @@ function RuntimeUiAccessDialog({
 	const renderedCredentials = credentialExit.renderedValue;
 	const identity = `${deployment.resource.id}\0${deployment.resource.metadata.resourceVersion}\0${runtime}\0${endpointUrl}`;
 	const accessHintStorageKey = hermesAccessHintStorageKey(deployment.resource.id);
-	const isOpenClawOpening = runtime === "openclaw" && isOpenClawBootstrapPending;
-	const isOpenClawUnavailable = runtime === "openclaw" && credentialError !== null;
 
 	const dismissAccessHint = useCallback(() => {
 		setAccessHintOpen(false);
@@ -1865,18 +1860,38 @@ function RuntimeUiAccessDialog({
 		],
 	);
 
-	const openRuntime = useCallback(() => {
-		const popup = openSecureRuntimeWindow(window.open.bind(window), endpointUrl);
+	const openRuntime = useCallback(async () => {
+		if (windowOpeningRef.current) return;
+		const popup = openSecureRuntimeWindow(window.open.bind(window));
 		if (!popup) {
 			toast.error(`Couldn't open ${label}`, {
 				id: RUNTIME_UI_LAUNCH_TOAST_ID,
-				description:
-					"Your browser blocked the new window. Allow pop-ups for Clawdi, then try again.",
+				description: "Allow pop-ups, then try again.",
 			});
 			return;
 		}
-		trackRuntimeWindow(deployment.resource.id, popup);
-	}, [deployment.resource.id, endpointUrl, label]);
+
+		windowOpeningRef.current = true;
+		setIsWindowOpening(true);
+		try {
+			const target = await loadRuntimeUiWindowTarget(runtime, endpointUrl, onRequestCredentials);
+			popup.location.replace(target);
+			trackRuntimeWindow(deployment.resource.id, popup);
+		} catch {
+			try {
+				popup.close();
+			} catch {
+				// Browser isolation may have severed the WindowProxy.
+			}
+			toast.error(`Couldn't open ${label}`, {
+				id: RUNTIME_UI_LAUNCH_TOAST_ID,
+				description: "Access failed. Try again.",
+			});
+		} finally {
+			windowOpeningRef.current = false;
+			setIsWindowOpening(false);
+		}
+	}, [deployment.resource.id, endpointUrl, label, onRequestCredentials, runtime]);
 
 	const acceptReset = useCallback(async () => {
 		await reset.mutateAsync({ id: deployment.resource.id });
@@ -1940,10 +1955,10 @@ function RuntimeUiAccessDialog({
 						type="button"
 						variant="outline"
 						size="sm"
-						disabled={isCredentialLoading || isOpenClawOpening}
+						disabled={isCredentialLoading}
 						onClick={() => void onReconnectOpenClaw()}
 					>
-						{isCredentialLoading || isOpenClawOpening ? (
+						{isCredentialLoading ? (
 							<Spinner className="size-3.5" />
 						) : (
 							<RefreshCw className="size-3.5" />
@@ -1955,19 +1970,16 @@ function RuntimeUiAccessDialog({
 					type="button"
 					variant="outline"
 					size="sm"
-					disabled={isOpenClawOpening || isOpenClawUnavailable}
-					onClick={openRuntime}
+					disabled={isWindowOpening}
+					onClick={() => void openRuntime()}
 					aria-label={`Open ${label} in new window`}
 				>
-					{isOpenClawOpening ? (
+					{isWindowOpening ? (
 						<Spinner className="size-3.5" />
 					) : (
 						<ExternalLink className="size-3.5" />
 					)}
-					<span className="hidden sm:inline">
-						{isOpenClawOpening ? "Opening…" : "Open in new window"}
-					</span>
-					<span className="sm:hidden">{isOpenClawOpening ? "Opening…" : "Open"}</span>
+					{isWindowOpening ? "Opening…" : "Open"}
 				</Button>
 			</div>
 			{runtime === "hermes" ? (
@@ -2038,9 +2050,18 @@ function RuntimeUiAccessDialog({
 								Reset access
 							</Button>
 						</ConfirmAction>
-						<Button type="button" disabled={reset.isPending} onClick={openRuntime}>
-							<ExternalLink className="size-3.5" />
-							Open in new window
+						<Button
+							type="button"
+							disabled={isWindowOpening || reset.isPending}
+							onClick={() => void openRuntime()}
+							aria-label={`Open ${label} in new window`}
+						>
+							{isWindowOpening ? (
+								<Spinner className="size-3.5" />
+							) : (
+								<ExternalLink className="size-3.5" />
+							)}
+							{isWindowOpening ? "Opening…" : "Open"}
 						</Button>
 					</div>
 				</DialogContent>

--- a/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
@@ -3,6 +3,7 @@ import type { RuntimeUiCredentials } from "@clawdi/shared/api";
 import {
 	forgetOpenClawBootstrapAttempt,
 	hasOpenClawBootstrapAttempt,
+	loadRuntimeUiWindowTarget,
 	openSecureRuntimeWindow,
 	rememberOpenClawBootstrapAttempt,
 	resolveRuntimeUiCredentials,
@@ -114,6 +115,47 @@ describe("runtime UI credential targeting", () => {
 				"rv-new",
 			),
 		).toBeNull();
+	});
+
+	test("requests a fresh single-use handoff for every OpenClaw window", async () => {
+		const embedded: RuntimeUiCredentials = {
+			runtime: "openclaw",
+			auth_mode: "openclaw_token",
+			url: "https://runtime.example/openclaw/",
+			deployment_resource_version: "rv-current",
+			token: "deployment-token",
+			handoff_url:
+				"https://runtime.example/openclaw/#bootstrapToken=embedded-token&bootstrapProfile=owner",
+		};
+		let requests = 0;
+		const requestCredentials = async () => {
+			requests += 1;
+			return {
+				...embedded,
+				handoff_url: `https://runtime.example/openclaw/#bootstrapToken=fresh-${requests}&bootstrapProfile=owner`,
+			};
+		};
+
+		const endpointUrl = "https://runtime.example/openclaw/";
+		const first = await loadRuntimeUiWindowTarget("openclaw", endpointUrl, requestCredentials);
+		const second = await loadRuntimeUiWindowTarget("openclaw", endpointUrl, requestCredentials);
+
+		expect(requests).toBe(2);
+		expect(first).toBe(
+			"https://runtime.example/openclaw/#bootstrapToken=fresh-1&bootstrapProfile=owner",
+		);
+		expect(second).toBe(
+			"https://runtime.example/openclaw/#bootstrapToken=fresh-2&bootstrapProfile=owner",
+		);
+	});
+
+	test("returns the Hermes endpoint without requesting credentials", async () => {
+		const endpointUrl = "https://runtime.example/hermes";
+		const target = await loadRuntimeUiWindowTarget("hermes", endpointUrl, async () => {
+			throw new Error("Hermes credentials should not be requested again");
+		});
+
+		expect(target).toBe(endpointUrl);
 	});
 
 	test("remembers only that this browser attempted OpenClaw bootstrap", () => {

--- a/apps/web/src/hosted/agents/runtime-ui-credentials.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-credentials.ts
@@ -116,3 +116,12 @@ export function resolveRuntimeUiCredentials(
 export function runtimeUiLaunchTarget(credentials: RuntimeUiCredentials): string {
 	return credentials.runtime === "openclaw" ? credentials.handoff_url : credentials.url;
 }
+
+export async function loadRuntimeUiWindowTarget(
+	runtime: RuntimeUiCredentials["runtime"],
+	endpointUrl: string,
+	requestCredentials: () => Promise<RuntimeUiCredentials>,
+): Promise<string> {
+	if (runtime === "hermes") return endpointUrl;
+	return runtimeUiLaunchTarget(await requestCredentials());
+}

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1143,22 +1143,23 @@ in the currently receipted runtime instance. When supported, it returns the
 single-use, ten-minute `browserUrl` after binding it to the deployment's clean
 HTTPS endpoint. The browser consumes the official `bootstrapToken` and
 `bootstrapProfile=owner` fragment, creates its signed device identity, and
-receives the durable owner credential without a manual pairing step. If the
-installed binary explicitly lacks `dashboard --json`, or returns the validated
-legacy JSON shape, Hosted preserves the exact `#token=` launch while the CLI's
-legacy patch disables device authentication. Other command, JSON, and handoff
-errors fail closed with no bare-URL fallback. Clawdi implements no parallel
-device-auth or device-approval protocol.
+receives the durable owner credential without a manual pairing step. OpenClaw
+removes the handoff fragment before authentication, so the visible address
+remains the clean endpoint. If the installed binary explicitly lacks
+`dashboard --json`, or returns the validated legacy JSON shape, Hosted preserves
+the exact `#token=` launch while the CLI's legacy patch disables device
+authentication. Other command, JSON, and handoff errors fail closed with no
+bare-URL fallback. Clawdi implements no parallel device-auth or device-approval
+protocol.
 
 OpenClaw persists the issued device credential in its own browser origin and
-reuses it when that browser later opens the clean dashboard URL. Clawdi records
-only that a bootstrap was attempted for the deployment and published endpoint,
-so returning to Agent Interface and opening a new window do not request another
-single-use handoff. An endpoint change requires a new bootstrap.
-The embedding page cannot inspect OpenClaw's cross-origin storage or connection
-state, and an iframe load is not treated as authentication proof. `Reconnect`
-explicitly requests a fresh native handoff when the OpenClaw UI reports that its
-stored session is no longer usable.
+may reuse it when the embedded UI revisits the clean dashboard URL. Clawdi
+records only that a bootstrap was attempted for the deployment and published
+endpoint. Every explicit new-window launch requests a fresh official handoff
+because iframe and top-level storage may be partitioned; `Reconnect` also
+requests a fresh handoff. The embedding page cannot inspect OpenClaw's
+cross-origin storage or connection state, and an iframe load is not treated as
+authentication proof.
 
 Hermes direct exposure requires `hermes-basic-auth-v1`, a stable HTTPS public
 URL (including any path prefix), exact `0.0.0.0:9119` service args, and the


### PR DESCRIPTION
## Summary

- request a fresh official OpenClaw handoff for every explicit top-level launch while keeping Hermes on its clean endpoint
- isolate Open and Reconnect pending states and shorten the visible action label to Open
- document that OpenClaw removes the one-time fragment before authentication, leaving the visible URL clean

## Verification

- Docker Web typecheck
- full Docker Web test suite
- Docker OSS client and SSR production build
- 43 focused Runtime UI tests
- Docker Biome
- git diff --check

## Behavior

Cross-site iframe storage cannot be assumed to exist in a top-level window. The launch starts from a synchronous blank popup to avoid popup blocking, navigates with a fresh single-use handoff, and OpenClaw immediately strips the fragment. Only the clicked Open action shows pending state.