### PR TITLE
fix(web): keep compute subscriptions in two columns

### DIFF
--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -587,7 +587,12 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 		"canceling",
 	]);
 	await expectSubscriptionCardRowAligned(activeCard, includedCard);
-	await expectSubscriptionCardRowAligned(activeCard, availableCard);
+	const desktopCardBoxes = await currentCards.evaluateAll((cards) =>
+		cards.map((card) => card.getBoundingClientRect().toJSON()),
+	);
+	expect(desktopCardBoxes[2]?.y ?? 0).toBeGreaterThanOrEqual(
+		Math.max(desktopCardBoxes[0]?.bottom ?? 0, desktopCardBoxes[1]?.bottom ?? 0) - 1,
+	);
 	await expectCardsFit(dialog);
 	await activeCard.evaluate((element) => element.scrollIntoView({ block: "start" }));
 	await dialog.screenshot({ path: testInfo.outputPath("account-compute-plans-desktop.png") });
@@ -708,10 +713,7 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	const tabletCardBoxes = await dialog
 		.locator('[data-slot="compute-subscription-card"]')
 		.evaluateAll((cards) => cards.map((card) => card.getBoundingClientRect().toJSON()));
-	expect(Math.abs((tabletCardBoxes[0]?.y ?? 0) - (tabletCardBoxes[1]?.y ?? 1))).toBeLessThanOrEqual(
-		1,
-	);
-	expect(tabletCardBoxes[2]?.y ?? 0).toBeGreaterThanOrEqual(tabletCardBoxes[0]?.bottom ?? 0);
+	expect(tabletCardBoxes[1]?.y ?? 0).toBeGreaterThanOrEqual((tabletCardBoxes[0]?.bottom ?? 0) - 1);
 
 	await page.setViewportSize({ width: 320, height: 1000 });
 	await expect(dialog).toBeVisible();

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import type { AgentTile } from "@/components/dashboard/agents-card";
 import { EmptyState } from "@/components/empty-state";
-import { ENTITY_CARD_GRID_CLASS, entityCardChassisClass } from "@/components/entity-card";
+import { entityCardChassisClass } from "@/components/entity-card";
 import { SettingsSection } from "@/components/settings-section";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -318,9 +318,11 @@ export function reusableInventoryState(
 	return data === undefined ? "loading" : "ready";
 }
 
+const SUBSCRIPTION_CARD_GRID_CLASS = "grid gap-3 lg:grid-cols-2";
+
 function SubscriptionListSkeleton({ label = "Loading subscriptions" }: { label?: string }) {
 	return (
-		<div className={ENTITY_CARD_GRID_CLASS.compact} role="status">
+		<div className={SUBSCRIPTION_CARD_GRID_CLASS} role="status">
 			<span className="sr-only">{label}</span>
 			{Array.from({ length: 3 }, (_, index) => `subscription-skeleton-${index}`).map((key) => (
 				<div key={key} className={entityCardChassisClass({ variant: "compact" })}>
@@ -456,7 +458,7 @@ export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly Agen
 							</div>
 						) : null}
 						{visibleRows.length ? (
-							<ul className={ENTITY_CARD_GRID_CLASS.compact}>
+							<ul className={SUBSCRIPTION_CARD_GRID_CLASS}>
 								{visibleRows.map((subscription) => {
 									const deployment = subscription.deployment_id
 										? deploymentsById.get(subscription.deployment_id.toLowerCase())


### PR DESCRIPTION
## Summary

- keep the Compute subscription surface in a domain-specific two-column desktop grid
- use the same layout for loading skeletons and loaded cards
- verify two desktop columns and single-column tablet/mobile geometry in the existing hosted subscription E2E

## Verification

- isolated Docker web typecheck
- focused subscription unit tests
- OSS production build
- isolated Playwright hosted subscription flow at 1440, 800, and 320 px: 1 passed
- scoped Biome check and git diff check