### PR TITLE
fix(web): reuse OpenClaw browser handoffs

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1,5 +1,12 @@
 import type { DeployComponents, DeploymentRead } from "@clawdi/shared/api";
-import { expect, type Locator, type Page, type Route, test } from "@playwright/test";
+import {
+	type BrowserContext,
+	expect,
+	type Locator,
+	type Page,
+	type Route,
+	test,
+} from "@playwright/test";
 import type { ManagedModelCatalogItem, WalletState } from "../src/hosted/billing/contracts";
 import type { AiProvider } from "../src/hosted/v2/ai-providers/types";
 import {
@@ -709,7 +716,7 @@ const paidBasicDeployment: DeploymentMutationFixture = {
 	},
 };
 
-const _openClawIncludedDeployment: DeploymentMutationFixture = {
+const openClawIncludedDeployment: DeploymentMutationFixture = {
 	...includedBasicDeployment,
 	id: "hdep_openclaw_included",
 	name: "OpenClaw included Basic",
@@ -2909,6 +2916,82 @@ async function gotoHostedAgentSettings(
 	}
 }
 
+const openClawRuntimeEndpoint = "https://runtime.example/openclaw/";
+const openClawRuntimeToken = "test-deployment-token";
+
+async function stubOpenClawRuntime(page: Page, context: BrowserContext, handoffUrl: string) {
+	type FrameGate = { signalStarted: () => void; released: Promise<void> };
+	let nextFrameGate: FrameGate | null = null;
+	const pauseNextIframe = () => {
+		if (nextFrameGate) throw new Error("An OpenClaw iframe gate is already pending.");
+		let started = false;
+		let release: () => void = () => undefined;
+		const released = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		nextFrameGate = {
+			signalStarted: () => {
+				started = true;
+			},
+			released,
+		};
+		return { isStarted: () => started, release };
+	};
+
+	await context.route("https://runtime.example/**", async (route) => {
+		if (route.request().frame().parentFrame()) {
+			const gate = nextFrameGate;
+			nextFrameGate = null;
+			if (gate) {
+				gate.signalStarted();
+				await gate.released;
+			}
+		}
+		await route.fulfill({
+			status: 200,
+			contentType: "text/html",
+			body: "<!doctype html><title>Mock OpenClaw</title><main>Mock OpenClaw</main>",
+		});
+	});
+
+	const credentialRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [openClawIncludedDeployment],
+		runtimeUiRedemptionRequests: credentialRequests,
+		runtimeUiRedemptionResponses: [
+			{
+				status: 200,
+				body: {
+					runtime: "openclaw",
+					auth_mode: "openclaw_token",
+					url: openClawRuntimeEndpoint,
+					deployment_resource_version: `rv_${openClawIncludedDeployment.id}`,
+					token: openClawRuntimeToken,
+					handoff_url: handoffUrl,
+				},
+			},
+		],
+	});
+
+	return {
+		agentId: fixtureAgentId(openClawIncludedDeployment),
+		credentialRequests,
+		pauseNextIframe,
+	};
+}
+
+async function expectOpenClawWindow(
+	context: BrowserContext,
+	openButton: Locator,
+	expectedUrl: string,
+) {
+	const popupPromise = context.waitForEvent("page");
+	await openButton.click();
+	const popup = await popupPromise;
+	await expect(popup).toHaveURL(expectedUrl);
+	await popup.close();
+}
+
 async function _gotoHostedSettingsDialog(page: Page, section: string) {
 	for (let attempt = 0; attempt < 2; attempt += 1) {
 		await page.goto(`/channels?settings=${section}`);
@@ -3496,6 +3579,68 @@ test("cold hosted live-tool routes keep full-bleed loading geometry", async ({ p
 	} finally {
 		releaseDeploymentList?.();
 	}
+});
+
+test("native OpenClaw windows wait for the handoff iframe load and reuse the clean endpoint", async ({
+	page,
+	context,
+}) => {
+	const nativeHandoff = `${openClawRuntimeEndpoint}#bootstrapToken=one-time-token&bootstrapProfile=owner`;
+	const runtime = await stubOpenClawRuntime(page, context, nativeHandoff);
+	const initialFrame = runtime.pauseNextIframe();
+
+	await page.goto(`/agents/${runtime.agentId}/console`, { waitUntil: "domcontentloaded" });
+	await expect.poll(() => runtime.credentialRequests.length).toBe(1);
+	await expect.poll(initialFrame.isStarted).toBe(true);
+	const openButton = page.getByRole("button", {
+		name: "Open OpenClaw Control UI in new window",
+	});
+	const iframe = page.locator('iframe[title="OpenClaw Control UI"]');
+	await expect(openButton).toBeDisabled();
+	await expect(openButton).toContainText("Open in new window");
+	await expect(page.getByRole("button", { name: "Reconnect" })).toBeEnabled();
+	await expect(iframe).toHaveAttribute("src", nativeHandoff);
+	expect(runtime.credentialRequests).toHaveLength(1);
+
+	initialFrame.release();
+	await expect(openButton).toBeEnabled();
+	await expectOpenClawWindow(context, openButton, openClawRuntimeEndpoint);
+	expect(runtime.credentialRequests).toHaveLength(1);
+
+	const remountedFrame = runtime.pauseNextIframe();
+	await page.reload({ waitUntil: "domcontentloaded" });
+	await expect.poll(remountedFrame.isStarted).toBe(true);
+	await expect(openButton).toBeDisabled();
+	await expect(iframe).toHaveAttribute("src", openClawRuntimeEndpoint);
+	expect(runtime.credentialRequests).toHaveLength(1);
+
+	remountedFrame.release();
+	await expect(openButton).toBeEnabled();
+	await expectOpenClawWindow(context, openButton, openClawRuntimeEndpoint);
+	expect(runtime.credentialRequests).toHaveLength(1);
+});
+
+test("legacy OpenClaw windows reuse the exact token handoff", async ({ page, context }) => {
+	const legacyHandoff = `${openClawRuntimeEndpoint}#token=${openClawRuntimeToken}`;
+	const runtime = await stubOpenClawRuntime(page, context, legacyHandoff);
+	const frame = runtime.pauseNextIframe();
+
+	await page.goto(`/agents/${runtime.agentId}/console`, { waitUntil: "domcontentloaded" });
+	await expect.poll(() => runtime.credentialRequests.length).toBe(1);
+	const iframe = page.locator('iframe[title="OpenClaw Control UI"]');
+	await expect(iframe).toHaveAttribute("src", legacyHandoff);
+	await expect.poll(frame.isStarted).toBe(true);
+	const openButton = page.getByRole("button", {
+		name: "Open OpenClaw Control UI in new window",
+	});
+	await expect(openButton).toBeDisabled();
+	await expect(openButton).toContainText("Open in new window");
+	expect(runtime.credentialRequests).toHaveLength(1);
+
+	frame.release();
+	await expect(openButton).toBeEnabled();
+	await expectOpenClawWindow(context, openButton, legacyHandoff);
+	expect(runtime.credentialRequests).toHaveLength(1);
 });
 
 test("agent rail keeps New agent after agents and retains cache after list failure", async ({

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -673,12 +673,9 @@ describe("hosted agent customer language", () => {
 		expect(detailSource).toContain("Runtime UI access");
 		expect(detailSource).toContain("<iframe");
 		expect(detailSource).toContain('allow="clipboard-read; clipboard-write"');
-		expect(detailSource).toContain("loadRuntimeUiWindowTarget");
 		expect(detailSource).toContain('<RuntimeUiCredentialRow label="Username"');
 		expect(detailSource).toContain('label="Password"');
 		expect(detailSource).not.toContain('<RuntimeUiCredentialRow label="Token"');
-		expect(detailSource).toContain("hasOpenClawBootstrapAttempt");
-		expect(detailSource).toContain("rememberOpenClawBootstrapAttempt");
 		expect(detailSource).toContain("Reconnect");
 		expect(detailSource).toContain("Sign in to Hermes");
 		expect(detailSource).toContain("Get your Hermes username and password from Access.");

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -122,13 +122,14 @@ import {
 	type HostedTerminalStatus,
 } from "@/hosted/agents/hosted-terminal-panel";
 import {
-	forgetOpenClawNativeReady,
-	hasOpenClawNativeReady,
+	forgetOpenClawNativeHandoffLoaded,
+	hasOpenClawNativeHandoffLoaded,
+	markOpenClawNativeHandoffLoaded,
 	openClawRuntimeUiWindowTarget,
 	openSecureRuntimeWindow,
-	rememberOpenClawNativeReady,
 	resolveRuntimeUiCredentials,
 	runtimeUiLaunchTarget,
+	runtimeUiLocalStorage,
 } from "@/hosted/agents/runtime-ui-credentials";
 import { trackRuntimeWindow } from "@/hosted/agents/runtime-window-lifecycle";
 import {
@@ -1417,8 +1418,8 @@ function ConsoleTab({
 	const [credentialLoadState, setCredentialLoadState] = useState<"loading" | "ready" | "error">(
 		runtime === "openclaw" ? "loading" : "ready",
 	);
-	const [openClawNativeReady, setOpenClawNativeReady] = useState(false);
-	const [openClawFrameReady, setOpenClawFrameReady] = useState(false);
+	const [openClawNativeHandoffLoaded, setOpenClawNativeHandoffLoaded] = useState(false);
+	const [openClawFrameLoaded, setOpenClawFrameLoaded] = useState(false);
 	const requestCredentials = useRuntimeUiCredentialRequest(deployment, url, runtime);
 	const requestVersionRef = useRef(0);
 	const loadedCredentialIdentityRef = useRef<string | null>(null);
@@ -1432,8 +1433,8 @@ function ConsoleTab({
 		setCredentialLoadState("loading");
 		if (runtime === "openclaw") {
 			setCredentials(null);
-			setOpenClawNativeReady(false);
-			setOpenClawFrameReady(false);
+			setOpenClawNativeHandoffLoaded(false);
+			setOpenClawFrameLoaded(false);
 		}
 		try {
 			const resolved = await requestCredentials();
@@ -1460,12 +1461,12 @@ function ConsoleTab({
 		setCredentialError(null);
 		setIsCredentialLoading(false);
 		setCredentialLoadState(runtime === "openclaw" ? "loading" : "ready");
-		setOpenClawNativeReady(false);
-		setOpenClawFrameReady(false);
+		setOpenClawNativeHandoffLoaded(false);
+		setOpenClawFrameLoaded(false);
 	}, [runtime]);
 
 	const reconnectOpenClaw = useCallback(() => {
-		forgetOpenClawNativeReady(window.localStorage, deployment.resource.id);
+		forgetOpenClawNativeHandoffLoaded(runtimeUiLocalStorage(), deployment.resource.id);
 		return loadCredentials();
 	}, [deployment.resource.id, loadCredentials]);
 
@@ -1474,8 +1475,8 @@ function ConsoleTab({
 		loadedCredentialIdentityRef.current = credentialIdentity;
 		clearCredentials();
 		if (runtime !== "openclaw" || !isRunning || !url) return;
-		if (hasOpenClawNativeReady(window.localStorage, deployment.resource.id, url)) {
-			setOpenClawNativeReady(true);
+		if (hasOpenClawNativeHandoffLoaded(runtimeUiLocalStorage(), deployment.resource.id, url)) {
+			setOpenClawNativeHandoffLoaded(true);
 			setCredentialLoadState("ready");
 			return;
 		}
@@ -1590,12 +1591,13 @@ function ConsoleTab({
 	const openClawCredentials =
 		currentCredentials?.runtime === "openclaw" ? currentCredentials : null;
 	const openClawFrameCanLoad =
-		credentialLoadState === "ready" && (openClawCredentials !== null || openClawNativeReady);
+		credentialLoadState === "ready" &&
+		(openClawCredentials !== null || openClawNativeHandoffLoaded);
 	const iframeUrl =
 		runtime === "openclaw"
 			? openClawCredentials
 				? runtimeUiLaunchTarget(openClawCredentials)
-				: openClawNativeReady
+				: openClawNativeHandoffLoaded
 					? url
 					: "about:blank"
 			: url;
@@ -1604,8 +1606,8 @@ function ConsoleTab({
 			? openClawRuntimeUiWindowTarget(
 					openClawCredentials,
 					url,
-					openClawNativeReady,
-					openClawFrameReady,
+					openClawNativeHandoffLoaded,
+					openClawFrameLoaded,
 				)
 			: url;
 
@@ -1671,16 +1673,16 @@ function ConsoleTab({
 						runtime === "openclaw"
 							? () => {
 									if (
-										rememberOpenClawNativeReady(
-											window.localStorage,
+										markOpenClawNativeHandoffLoaded(
+											runtimeUiLocalStorage(),
 											deployment.resource.id,
 											url,
 											openClawCredentials,
 										)
 									) {
-										setOpenClawNativeReady(true);
+										setOpenClawNativeHandoffLoaded(true);
 									}
-									setOpenClawFrameReady(true);
+									setOpenClawFrameLoaded(true);
 								}
 							: undefined
 					}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -122,11 +122,11 @@ import {
 	type HostedTerminalStatus,
 } from "@/hosted/agents/hosted-terminal-panel";
 import {
-	forgetOpenClawBootstrapAttempt,
-	hasOpenClawBootstrapAttempt,
-	loadRuntimeUiWindowTarget,
+	forgetOpenClawNativeReady,
+	hasOpenClawNativeReady,
+	openClawRuntimeUiWindowTarget,
 	openSecureRuntimeWindow,
-	rememberOpenClawBootstrapAttempt,
+	rememberOpenClawNativeReady,
 	resolveRuntimeUiCredentials,
 	runtimeUiLaunchTarget,
 } from "@/hosted/agents/runtime-ui-credentials";
@@ -1417,6 +1417,8 @@ function ConsoleTab({
 	const [credentialLoadState, setCredentialLoadState] = useState<"loading" | "ready" | "error">(
 		runtime === "openclaw" ? "loading" : "ready",
 	);
+	const [openClawNativeReady, setOpenClawNativeReady] = useState(false);
+	const [openClawFrameReady, setOpenClawFrameReady] = useState(false);
 	const requestCredentials = useRuntimeUiCredentialRequest(deployment, url, runtime);
 	const requestVersionRef = useRef(0);
 	const loadedCredentialIdentityRef = useRef<string | null>(null);
@@ -1428,6 +1430,11 @@ function ConsoleTab({
 		setIsCredentialLoading(true);
 		setCredentialError(null);
 		setCredentialLoadState("loading");
+		if (runtime === "openclaw") {
+			setCredentials(null);
+			setOpenClawNativeReady(false);
+			setOpenClawFrameReady(false);
+		}
 		try {
 			const resolved = await requestCredentials();
 			if (requestVersionRef.current !== requestVersion) return null;
@@ -1445,7 +1452,7 @@ function ConsoleTab({
 		} finally {
 			if (requestVersionRef.current === requestVersion) setIsCredentialLoading(false);
 		}
-	}, [requestCredentials]);
+	}, [requestCredentials, runtime]);
 
 	const clearCredentials = useCallback(() => {
 		requestVersionRef.current += 1;
@@ -1453,10 +1460,12 @@ function ConsoleTab({
 		setCredentialError(null);
 		setIsCredentialLoading(false);
 		setCredentialLoadState(runtime === "openclaw" ? "loading" : "ready");
+		setOpenClawNativeReady(false);
+		setOpenClawFrameReady(false);
 	}, [runtime]);
 
 	const reconnectOpenClaw = useCallback(() => {
-		forgetOpenClawBootstrapAttempt(window.localStorage, deployment.resource.id);
+		forgetOpenClawNativeReady(window.localStorage, deployment.resource.id);
 		return loadCredentials();
 	}, [deployment.resource.id, loadCredentials]);
 
@@ -1465,7 +1474,8 @@ function ConsoleTab({
 		loadedCredentialIdentityRef.current = credentialIdentity;
 		clearCredentials();
 		if (runtime !== "openclaw" || !isRunning || !url) return;
-		if (hasOpenClawBootstrapAttempt(window.localStorage, deployment.resource.id, url)) {
+		if (hasOpenClawNativeReady(window.localStorage, deployment.resource.id, url)) {
+			setOpenClawNativeReady(true);
 			setCredentialLoadState("ready");
 			return;
 		}
@@ -1574,13 +1584,29 @@ function ConsoleTab({
 			/>
 		);
 	}
+	const currentCredentials = credentials
+		? resolveRuntimeUiCredentials(credentials, url, deployment.resource.metadata.resourceVersion)
+		: null;
+	const openClawCredentials =
+		currentCredentials?.runtime === "openclaw" ? currentCredentials : null;
+	const openClawFrameCanLoad =
+		credentialLoadState === "ready" && (openClawCredentials !== null || openClawNativeReady);
 	const iframeUrl =
 		runtime === "openclaw"
-			? credentials?.runtime === "openclaw"
-				? runtimeUiLaunchTarget(credentials)
-				: credentialLoadState === "ready"
+			? openClawCredentials
+				? runtimeUiLaunchTarget(openClawCredentials)
+				: openClawNativeReady
 					? url
 					: "about:blank"
+			: url;
+	const windowTarget =
+		runtime === "openclaw"
+			? openClawRuntimeUiWindowTarget(
+					openClawCredentials,
+					url,
+					openClawNativeReady,
+					openClawFrameReady,
+				)
 			: url;
 
 	return (
@@ -1591,18 +1617,18 @@ function ConsoleTab({
 				<RuntimeUiAccessDialog
 					deployment={deployment}
 					endpointUrl={url}
+					windowTarget={windowTarget}
 					runtime={runtime}
-					credentials={credentials}
+					credentials={currentCredentials}
 					credentialError={credentialError}
 					isCredentialLoading={isCredentialLoading}
 					onLoadCredentials={loadCredentials}
-					onRequestCredentials={requestCredentials}
 					onClearCredentials={clearCredentials}
 					onReconnectOpenClaw={reconnectOpenClaw}
 				/>
 			}
 		>
-			{runtime === "openclaw" && credentialLoadState !== "ready" ? (
+			{runtime === "openclaw" && !openClawFrameCanLoad ? (
 				credentialLoadState === "error" ? (
 					<EmptyState
 						icon={AlertCircle}
@@ -1644,11 +1670,17 @@ function ConsoleTab({
 					onLoad={
 						runtime === "openclaw"
 							? () => {
-									rememberOpenClawBootstrapAttempt(
-										window.localStorage,
-										deployment.resource.id,
-										url,
-									);
+									if (
+										rememberOpenClawNativeReady(
+											window.localStorage,
+											deployment.resource.id,
+											url,
+											openClawCredentials,
+										)
+									) {
+										setOpenClawNativeReady(true);
+									}
+									setOpenClawFrameReady(true);
 								}
 							: undefined
 					}
@@ -1781,31 +1813,29 @@ function RuntimeUiCredentialRow({
 function RuntimeUiAccessDialog({
 	deployment,
 	endpointUrl,
+	windowTarget,
 	runtime,
 	credentials,
 	credentialError,
 	isCredentialLoading,
 	onLoadCredentials,
-	onRequestCredentials,
 	onClearCredentials,
 	onReconnectOpenClaw,
 }: {
 	deployment: HostedDeployment;
 	endpointUrl: string;
+	windowTarget: string | null;
 	runtime: Runtime;
 	credentials: RuntimeUiCredentials | null;
 	credentialError: Error | null;
 	isCredentialLoading: boolean;
 	onLoadCredentials: () => Promise<RuntimeUiCredentials | null>;
-	onRequestCredentials: () => Promise<RuntimeUiCredentials>;
 	onClearCredentials: () => void;
 	onReconnectOpenClaw: () => Promise<RuntimeUiCredentials | null>;
 }) {
 	const label = runtimeBrowserUiLabel(runtime);
 	const reset = useResetRuntimeUiAccess();
 	const [open, setOpen] = useState(false);
-	const [isWindowOpening, setIsWindowOpening] = useState(false);
-	const windowOpeningRef = useRef(false);
 	const loadedIdentityRef = useRef<string | null>(null);
 	const triggerRef = useRef<HTMLButtonElement>(null);
 	const [accessHintOpen, setAccessHintOpen] = useState(false);
@@ -1860,9 +1890,9 @@ function RuntimeUiAccessDialog({
 		],
 	);
 
-	const openRuntime = useCallback(async () => {
-		if (windowOpeningRef.current) return;
-		const popup = openSecureRuntimeWindow(window.open.bind(window));
+	const openRuntime = useCallback(() => {
+		if (!windowTarget) return;
+		const popup = openSecureRuntimeWindow(window.open.bind(window), windowTarget);
 		if (!popup) {
 			toast.error(`Couldn't open ${label}`, {
 				id: RUNTIME_UI_LAUNCH_TOAST_ID,
@@ -1870,28 +1900,8 @@ function RuntimeUiAccessDialog({
 			});
 			return;
 		}
-
-		windowOpeningRef.current = true;
-		setIsWindowOpening(true);
-		try {
-			const target = await loadRuntimeUiWindowTarget(runtime, endpointUrl, onRequestCredentials);
-			popup.location.replace(target);
-			trackRuntimeWindow(deployment.resource.id, popup);
-		} catch {
-			try {
-				popup.close();
-			} catch {
-				// Browser isolation may have severed the WindowProxy.
-			}
-			toast.error(`Couldn't open ${label}`, {
-				id: RUNTIME_UI_LAUNCH_TOAST_ID,
-				description: "Access failed. Try again.",
-			});
-		} finally {
-			windowOpeningRef.current = false;
-			setIsWindowOpening(false);
-		}
-	}, [deployment.resource.id, endpointUrl, label, onRequestCredentials, runtime]);
+		trackRuntimeWindow(deployment.resource.id, popup);
+	}, [deployment.resource.id, label, windowTarget]);
 
 	const acceptReset = useCallback(async () => {
 		await reset.mutateAsync({ id: deployment.resource.id });
@@ -1970,16 +1980,12 @@ function RuntimeUiAccessDialog({
 					type="button"
 					variant="outline"
 					size="sm"
-					disabled={isWindowOpening}
-					onClick={() => void openRuntime()}
+					disabled={!windowTarget}
+					onClick={openRuntime}
 					aria-label={`Open ${label} in new window`}
 				>
-					{isWindowOpening ? (
-						<Spinner className="size-3.5" />
-					) : (
-						<ExternalLink className="size-3.5" />
-					)}
-					{isWindowOpening ? "Opening…" : "Open"}
+					<ExternalLink className="size-3.5" />
+					<span className="hidden sm:inline">Open in new window</span>
 				</Button>
 			</div>
 			{runtime === "hermes" ? (
@@ -2052,16 +2058,12 @@ function RuntimeUiAccessDialog({
 						</ConfirmAction>
 						<Button
 							type="button"
-							disabled={isWindowOpening || reset.isPending}
-							onClick={() => void openRuntime()}
+							disabled={!windowTarget || reset.isPending}
+							onClick={openRuntime}
 							aria-label={`Open ${label} in new window`}
 						>
-							{isWindowOpening ? (
-								<Spinner className="size-3.5" />
-							) : (
-								<ExternalLink className="size-3.5" />
-							)}
-							{isWindowOpening ? "Opening…" : "Open"}
+							<ExternalLink className="size-3.5" />
+							<span className="hidden sm:inline">Open in new window</span>
 						</Button>
 					</div>
 				</DialogContent>

--- a/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import type { RuntimeUiCredentials } from "@clawdi/shared/api";
 import {
-	forgetOpenClawNativeReady,
-	hasOpenClawNativeReady,
+	forgetOpenClawNativeHandoffLoaded,
+	hasOpenClawNativeHandoffLoaded,
+	markOpenClawNativeHandoffLoaded,
 	openClawRuntimeUiWindowTarget,
 	openSecureRuntimeWindow,
-	rememberOpenClawNativeReady,
 	resolveRuntimeUiCredentials,
 	runtimeUiLaunchTarget,
+	runtimeUiLocalStorage,
 } from "@/hosted/agents/runtime-ui-credentials";
 
 describe("runtime UI credential targeting", () => {
@@ -178,7 +179,7 @@ describe("runtime UI credential targeting", () => {
 		expect(openClawRuntimeUiWindowTarget(null, native.url, true, true)).toBe(native.url);
 	});
 
-	test("persists only completed native bootstrap for the deployment endpoint", () => {
+	test("marks native handoff loads with a best-effort non-secret marker", () => {
 		const values = new Map<string, string>();
 		const storage = {
 			getItem: (key: string) => values.get(key) ?? null,
@@ -200,17 +201,29 @@ describe("runtime UI credential targeting", () => {
 		};
 		values.set("clawdi.openclaw-bootstrap-attempted.hdep_one", endpointUrl);
 
-		expect(hasOpenClawNativeReady(storage, "hdep_one", endpointUrl)).toBeFalse();
+		expect(hasOpenClawNativeHandoffLoaded(storage, "hdep_one", endpointUrl)).toBeFalse();
 		expect(values.has("clawdi.openclaw-bootstrap-attempted.hdep_one")).toBeFalse();
-		expect(rememberOpenClawNativeReady(storage, "hdep_one", endpointUrl, legacy)).toBeFalse();
-		expect(hasOpenClawNativeReady(storage, "hdep_one", endpointUrl)).toBeFalse();
-		expect(rememberOpenClawNativeReady(storage, "hdep_one", endpointUrl, native)).toBeTrue();
-		expect(hasOpenClawNativeReady(storage, "hdep_one", endpointUrl)).toBeTrue();
+		expect(markOpenClawNativeHandoffLoaded(storage, "hdep_one", endpointUrl, legacy)).toBeFalse();
+		expect(hasOpenClawNativeHandoffLoaded(storage, "hdep_one", endpointUrl)).toBeFalse();
+		expect(markOpenClawNativeHandoffLoaded(storage, "hdep_one", endpointUrl, native)).toBeTrue();
+		expect(hasOpenClawNativeHandoffLoaded(storage, "hdep_one", endpointUrl)).toBeTrue();
+		expect(markOpenClawNativeHandoffLoaded(null, "hdep_one", endpointUrl, native)).toBeTrue();
+		expect(hasOpenClawNativeHandoffLoaded(null, "hdep_one", endpointUrl)).toBeFalse();
 		expect(
-			hasOpenClawNativeReady(storage, "hdep_one", "https://moved.runtime.example/"),
+			hasOpenClawNativeHandoffLoaded(storage, "hdep_one", "https://moved.runtime.example/"),
 		).toBeFalse();
-		expect(hasOpenClawNativeReady(storage, "hdep_two", endpointUrl)).toBeFalse();
-		forgetOpenClawNativeReady(storage, "hdep_one");
-		expect(hasOpenClawNativeReady(storage, "hdep_one", endpointUrl)).toBeFalse();
+		expect(hasOpenClawNativeHandoffLoaded(storage, "hdep_two", endpointUrl)).toBeFalse();
+		forgetOpenClawNativeHandoffLoaded(storage, "hdep_one");
+		expect(hasOpenClawNativeHandoffLoaded(storage, "hdep_one", endpointUrl)).toBeFalse();
+	});
+
+	test("treats an unavailable localStorage getter as missing storage", () => {
+		const browserWindow = {
+			get localStorage(): Storage {
+				throw new Error("Storage is unavailable");
+			},
+		};
+
+		expect(runtimeUiLocalStorage(browserWindow)).toBeNull();
 	});
 });

--- a/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
@@ -1,18 +1,19 @@
 import { describe, expect, test } from "bun:test";
 import type { RuntimeUiCredentials } from "@clawdi/shared/api";
 import {
-	forgetOpenClawBootstrapAttempt,
-	hasOpenClawBootstrapAttempt,
-	loadRuntimeUiWindowTarget,
+	forgetOpenClawNativeReady,
+	hasOpenClawNativeReady,
+	openClawRuntimeUiWindowTarget,
 	openSecureRuntimeWindow,
-	rememberOpenClawBootstrapAttempt,
+	rememberOpenClawNativeReady,
 	resolveRuntimeUiCredentials,
 	runtimeUiLaunchTarget,
 } from "@/hosted/agents/runtime-ui-credentials";
 
 describe("runtime UI credential targeting", () => {
-	test("opens top-level runtime UIs without an opener", () => {
+	test("opens the selected runtime target synchronously without an opener", () => {
 		const calls: unknown[][] = [];
+		const target = "https://runtime.example/openclaw/#token=deployment-token";
 		const popup = {
 			close() {},
 			location: {
@@ -25,12 +26,49 @@ describe("runtime UI credential targeting", () => {
 		const opened = openSecureRuntimeWindow((...args) => {
 			calls.push(args);
 			return popup;
-		}, "https://runtime.example/openclaw/");
+		}, target);
 		expect(calls).toEqual([
 			["about:blank", "_blank"],
-			["replace", "https://runtime.example/openclaw/"],
+			["replace", target],
 		]);
 		expect(opened?.opener).toBeNull();
+	});
+
+	test("closes the placeholder when target navigation cannot start", () => {
+		let closed = false;
+		const popup = {
+			close() {
+				closed = true;
+			},
+			location: {
+				replace() {
+					throw new Error("navigation denied");
+				},
+			},
+			opener: { unsafe: true },
+		};
+
+		expect(openSecureRuntimeWindow(() => popup, "https://runtime.example/openclaw/")).toBeNull();
+		expect(closed).toBeTrue();
+	});
+
+	test("closes the placeholder when the browser refuses opener isolation", () => {
+		let closed = false;
+		const popup = {
+			close() {
+				closed = true;
+			},
+			location: { replace() {} },
+			get opener() {
+				return null;
+			},
+			set opener(_value: unknown) {
+				throw new Error("opener isolation denied");
+			},
+		};
+
+		expect(openSecureRuntimeWindow(() => popup, "https://runtime.example/openclaw/")).toBeNull();
+		expect(closed).toBeTrue();
 	});
 
 	test("keeps Hermes credentials separate from its secret-free URL", () => {
@@ -117,71 +155,62 @@ describe("runtime UI credential targeting", () => {
 		).toBeNull();
 	});
 
-	test("requests a fresh single-use handoff for every OpenClaw window", async () => {
-		const embedded: RuntimeUiCredentials = {
+	test("enables new-window launch after the current iframe load boundary", () => {
+		const native: RuntimeUiCredentials = {
 			runtime: "openclaw",
 			auth_mode: "openclaw_token",
 			url: "https://runtime.example/openclaw/",
 			deployment_resource_version: "rv-current",
 			token: "deployment-token",
 			handoff_url:
-				"https://runtime.example/openclaw/#bootstrapToken=embedded-token&bootstrapProfile=owner",
+				"https://runtime.example/openclaw/#bootstrapToken=one-time-token&bootstrapProfile=owner",
 		};
-		let requests = 0;
-		const requestCredentials = async () => {
-			requests += 1;
-			return {
-				...embedded,
-				handoff_url: `https://runtime.example/openclaw/#bootstrapToken=fresh-${requests}&bootstrapProfile=owner`,
-			};
+		const legacy: RuntimeUiCredentials = {
+			...native,
+			handoff_url: "https://runtime.example/openclaw/#token=deployment-token",
 		};
 
-		const endpointUrl = "https://runtime.example/openclaw/";
-		const first = await loadRuntimeUiWindowTarget("openclaw", endpointUrl, requestCredentials);
-		const second = await loadRuntimeUiWindowTarget("openclaw", endpointUrl, requestCredentials);
-
-		expect(requests).toBe(2);
-		expect(first).toBe(
-			"https://runtime.example/openclaw/#bootstrapToken=fresh-1&bootstrapProfile=owner",
-		);
-		expect(second).toBe(
-			"https://runtime.example/openclaw/#bootstrapToken=fresh-2&bootstrapProfile=owner",
-		);
+		expect(openClawRuntimeUiWindowTarget(native, native.url, false, false)).toBeNull();
+		expect(openClawRuntimeUiWindowTarget(native, native.url, false, true)).toBe(native.url);
+		expect(openClawRuntimeUiWindowTarget(legacy, legacy.url, false, false)).toBeNull();
+		expect(openClawRuntimeUiWindowTarget(legacy, legacy.url, false, true)).toBe(legacy.handoff_url);
+		expect(openClawRuntimeUiWindowTarget(null, native.url, true, false)).toBeNull();
+		expect(openClawRuntimeUiWindowTarget(null, native.url, true, true)).toBe(native.url);
 	});
 
-	test("returns the Hermes endpoint without requesting credentials", async () => {
-		const endpointUrl = "https://runtime.example/hermes";
-		const target = await loadRuntimeUiWindowTarget("hermes", endpointUrl, async () => {
-			throw new Error("Hermes credentials should not be requested again");
-		});
-
-		expect(target).toBe(endpointUrl);
-	});
-
-	test("remembers only that this browser attempted OpenClaw bootstrap", () => {
+	test("persists only completed native bootstrap for the deployment endpoint", () => {
 		const values = new Map<string, string>();
 		const storage = {
 			getItem: (key: string) => values.get(key) ?? null,
 			setItem: (key: string, value: string) => values.set(key, value),
 			removeItem: (key: string) => values.delete(key),
 		};
+		const endpointUrl = "https://one.runtime.example/";
+		const native: RuntimeUiCredentials = {
+			runtime: "openclaw",
+			auth_mode: "openclaw_token",
+			url: endpointUrl,
+			deployment_resource_version: "rv-current",
+			token: "deployment-token",
+			handoff_url: `${endpointUrl}#bootstrapToken=one-time-token&bootstrapProfile=owner`,
+		};
+		const legacy: RuntimeUiCredentials = {
+			...native,
+			handoff_url: `${endpointUrl}#token=deployment-token`,
+		};
+		values.set("clawdi.openclaw-bootstrap-attempted.hdep_one", endpointUrl);
 
+		expect(hasOpenClawNativeReady(storage, "hdep_one", endpointUrl)).toBeFalse();
+		expect(values.has("clawdi.openclaw-bootstrap-attempted.hdep_one")).toBeFalse();
+		expect(rememberOpenClawNativeReady(storage, "hdep_one", endpointUrl, legacy)).toBeFalse();
+		expect(hasOpenClawNativeReady(storage, "hdep_one", endpointUrl)).toBeFalse();
+		expect(rememberOpenClawNativeReady(storage, "hdep_one", endpointUrl, native)).toBeTrue();
+		expect(hasOpenClawNativeReady(storage, "hdep_one", endpointUrl)).toBeTrue();
 		expect(
-			hasOpenClawBootstrapAttempt(storage, "hdep_one", "https://one.runtime.example/"),
+			hasOpenClawNativeReady(storage, "hdep_one", "https://moved.runtime.example/"),
 		).toBeFalse();
-		rememberOpenClawBootstrapAttempt(storage, "hdep_one", "https://one.runtime.example/");
-		expect(
-			hasOpenClawBootstrapAttempt(storage, "hdep_one", "https://one.runtime.example/"),
-		).toBeTrue();
-		expect(
-			hasOpenClawBootstrapAttempt(storage, "hdep_one", "https://moved.runtime.example/"),
-		).toBeFalse();
-		expect(
-			hasOpenClawBootstrapAttempt(storage, "hdep_two", "https://one.runtime.example/"),
-		).toBeFalse();
-		forgetOpenClawBootstrapAttempt(storage, "hdep_one");
-		expect(
-			hasOpenClawBootstrapAttempt(storage, "hdep_one", "https://one.runtime.example/"),
-		).toBeFalse();
+		expect(hasOpenClawNativeReady(storage, "hdep_two", endpointUrl)).toBeFalse();
+		forgetOpenClawNativeReady(storage, "hdep_one");
+		expect(hasOpenClawNativeReady(storage, "hdep_one", endpointUrl)).toBeFalse();
 	});
 });

--- a/apps/web/src/hosted/agents/runtime-ui-credentials.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-credentials.ts
@@ -13,45 +13,60 @@ type OpenRuntimeWindow = (
 
 type RuntimeUiBootstrapStorage = Pick<Storage, "getItem" | "removeItem" | "setItem">;
 
-const OPENCLAW_BOOTSTRAP_STORAGE_PREFIX = "clawdi.openclaw-bootstrap-attempted";
+const LEGACY_OPENCLAW_BOOTSTRAP_STORAGE_PREFIX = "clawdi.openclaw-bootstrap-attempted";
+const OPENCLAW_NATIVE_READY_STORAGE_PREFIX = "clawdi.openclaw-native-ready.v1";
 
-function openClawBootstrapStorageKey(deploymentId: string): string {
-	return `${OPENCLAW_BOOTSTRAP_STORAGE_PREFIX}.${deploymentId}`;
+function legacyOpenClawBootstrapStorageKey(deploymentId: string): string {
+	return `${LEGACY_OPENCLAW_BOOTSTRAP_STORAGE_PREFIX}.${deploymentId}`;
 }
 
-export function hasOpenClawBootstrapAttempt(
-	storage: RuntimeUiBootstrapStorage,
-	deploymentId: string,
-	endpointUrl: string,
-): boolean {
-	try {
-		return storage.getItem(openClawBootstrapStorageKey(deploymentId)) === endpointUrl;
-	} catch {
-		return false;
-	}
+function openClawNativeReadyStorageKey(deploymentId: string): string {
+	return `${OPENCLAW_NATIVE_READY_STORAGE_PREFIX}.${deploymentId}`;
 }
 
-export function rememberOpenClawBootstrapAttempt(
-	storage: RuntimeUiBootstrapStorage,
-	deploymentId: string,
-	endpointUrl: string,
-): void {
+function removeStorageItem(storage: RuntimeUiBootstrapStorage, key: string): void {
 	try {
-		storage.setItem(openClawBootstrapStorageKey(deploymentId), endpointUrl);
+		storage.removeItem(key);
 	} catch {
 		// Browser storage is only an optimization; OpenClaw remains authoritative.
 	}
 }
 
-export function forgetOpenClawBootstrapAttempt(
+export function hasOpenClawNativeReady(
+	storage: RuntimeUiBootstrapStorage,
+	deploymentId: string,
+	endpointUrl: string,
+): boolean {
+	removeStorageItem(storage, legacyOpenClawBootstrapStorageKey(deploymentId));
+	try {
+		return storage.getItem(openClawNativeReadyStorageKey(deploymentId)) === endpointUrl;
+	} catch {
+		return false;
+	}
+}
+
+export function rememberOpenClawNativeReady(
+	storage: RuntimeUiBootstrapStorage,
+	deploymentId: string,
+	endpointUrl: string,
+	credentials: RuntimeUiCredentials | null,
+): boolean {
+	if (openClawHandoffMode(credentials) !== "native") return false;
+	removeStorageItem(storage, legacyOpenClawBootstrapStorageKey(deploymentId));
+	try {
+		storage.setItem(openClawNativeReadyStorageKey(deploymentId), endpointUrl);
+	} catch {
+		// Browser storage is only an optimization; OpenClaw remains authoritative.
+	}
+	return true;
+}
+
+export function forgetOpenClawNativeReady(
 	storage: RuntimeUiBootstrapStorage,
 	deploymentId: string,
 ): void {
-	try {
-		storage.removeItem(openClawBootstrapStorageKey(deploymentId));
-	} catch {
-		// A fresh handoff can still proceed when browser storage is unavailable.
-	}
+	removeStorageItem(storage, legacyOpenClawBootstrapStorageKey(deploymentId));
+	removeStorageItem(storage, openClawNativeReadyStorageKey(deploymentId));
 }
 
 export function openSecureRuntimeWindow(
@@ -60,8 +75,8 @@ export function openSecureRuntimeWindow(
 ): RuntimeWindow | null {
 	const popup = openWindow("about:blank", "_blank");
 	if (!popup) return null;
-	popup.opener = null;
 	try {
+		popup.opener = null;
 		if (url !== "about:blank") popup.location.replace(url);
 	} catch {
 		try {
@@ -117,11 +132,34 @@ export function runtimeUiLaunchTarget(credentials: RuntimeUiCredentials): string
 	return credentials.runtime === "openclaw" ? credentials.handoff_url : credentials.url;
 }
 
-export async function loadRuntimeUiWindowTarget(
-	runtime: RuntimeUiCredentials["runtime"],
+export function openClawHandoffMode(
+	credentials: RuntimeUiCredentials | null,
+): "legacy" | "native" | null {
+	if (credentials?.runtime !== "openclaw") return null;
+	try {
+		const fragment = new URL(credentials.handoff_url).hash.slice(1);
+		const params = new URLSearchParams(fragment);
+		if (params.has("bootstrapToken")) return "native";
+		if (params.has("token")) return "legacy";
+	} catch {
+		// The credential response validator remains authoritative for malformed handoffs.
+	}
+	return null;
+}
+
+export function openClawRuntimeUiWindowTarget(
+	credentials: RuntimeUiCredentials | null,
 	endpointUrl: string,
-	requestCredentials: () => Promise<RuntimeUiCredentials>,
-): Promise<string> {
-	if (runtime === "hermes") return endpointUrl;
-	return runtimeUiLaunchTarget(await requestCredentials());
+	nativeReady: boolean,
+	frameReady: boolean,
+): string | null {
+	if (!frameReady) return null;
+	const handoffMode = openClawHandoffMode(credentials);
+	if (handoffMode === "legacy" && credentials?.runtime === "openclaw") {
+		return credentials.handoff_url;
+	}
+	if (handoffMode === "native" && credentials?.runtime === "openclaw") {
+		return credentials.url;
+	}
+	return nativeReady ? endpointUrl : null;
 }

--- a/apps/web/src/hosted/agents/runtime-ui-credentials.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-credentials.ts
@@ -14,17 +14,28 @@ type OpenRuntimeWindow = (
 type RuntimeUiBootstrapStorage = Pick<Storage, "getItem" | "removeItem" | "setItem">;
 
 const LEGACY_OPENCLAW_BOOTSTRAP_STORAGE_PREFIX = "clawdi.openclaw-bootstrap-attempted";
-const OPENCLAW_NATIVE_READY_STORAGE_PREFIX = "clawdi.openclaw-native-ready.v1";
+const OPENCLAW_NATIVE_HANDOFF_LOADED_STORAGE_PREFIX = "clawdi.openclaw-native-handoff-loaded.v1";
 
 function legacyOpenClawBootstrapStorageKey(deploymentId: string): string {
 	return `${LEGACY_OPENCLAW_BOOTSTRAP_STORAGE_PREFIX}.${deploymentId}`;
 }
 
-function openClawNativeReadyStorageKey(deploymentId: string): string {
-	return `${OPENCLAW_NATIVE_READY_STORAGE_PREFIX}.${deploymentId}`;
+function openClawNativeHandoffLoadedStorageKey(deploymentId: string): string {
+	return `${OPENCLAW_NATIVE_HANDOFF_LOADED_STORAGE_PREFIX}.${deploymentId}`;
 }
 
-function removeStorageItem(storage: RuntimeUiBootstrapStorage, key: string): void {
+export function runtimeUiLocalStorage(
+	browserWindow: { readonly localStorage: Storage } = window,
+): Storage | null {
+	try {
+		return browserWindow.localStorage;
+	} catch {
+		return null;
+	}
+}
+
+function removeStorageItem(storage: RuntimeUiBootstrapStorage | null, key: string): void {
+	if (!storage) return;
 	try {
 		storage.removeItem(key);
 	} catch {
@@ -32,41 +43,43 @@ function removeStorageItem(storage: RuntimeUiBootstrapStorage, key: string): voi
 	}
 }
 
-export function hasOpenClawNativeReady(
-	storage: RuntimeUiBootstrapStorage,
+export function hasOpenClawNativeHandoffLoaded(
+	storage: RuntimeUiBootstrapStorage | null,
 	deploymentId: string,
 	endpointUrl: string,
 ): boolean {
 	removeStorageItem(storage, legacyOpenClawBootstrapStorageKey(deploymentId));
+	if (!storage) return false;
 	try {
-		return storage.getItem(openClawNativeReadyStorageKey(deploymentId)) === endpointUrl;
+		return storage.getItem(openClawNativeHandoffLoadedStorageKey(deploymentId)) === endpointUrl;
 	} catch {
 		return false;
 	}
 }
 
-export function rememberOpenClawNativeReady(
-	storage: RuntimeUiBootstrapStorage,
+export function markOpenClawNativeHandoffLoaded(
+	storage: RuntimeUiBootstrapStorage | null,
 	deploymentId: string,
 	endpointUrl: string,
 	credentials: RuntimeUiCredentials | null,
 ): boolean {
 	if (openClawHandoffMode(credentials) !== "native") return false;
 	removeStorageItem(storage, legacyOpenClawBootstrapStorageKey(deploymentId));
+	if (!storage) return true;
 	try {
-		storage.setItem(openClawNativeReadyStorageKey(deploymentId), endpointUrl);
+		storage.setItem(openClawNativeHandoffLoadedStorageKey(deploymentId), endpointUrl);
 	} catch {
 		// Browser storage is only an optimization; OpenClaw remains authoritative.
 	}
 	return true;
 }
 
-export function forgetOpenClawNativeReady(
-	storage: RuntimeUiBootstrapStorage,
+export function forgetOpenClawNativeHandoffLoaded(
+	storage: RuntimeUiBootstrapStorage | null,
 	deploymentId: string,
 ): void {
 	removeStorageItem(storage, legacyOpenClawBootstrapStorageKey(deploymentId));
-	removeStorageItem(storage, openClawNativeReadyStorageKey(deploymentId));
+	removeStorageItem(storage, openClawNativeHandoffLoadedStorageKey(deploymentId));
 }
 
 export function openSecureRuntimeWindow(
@@ -150,10 +163,10 @@ export function openClawHandoffMode(
 export function openClawRuntimeUiWindowTarget(
 	credentials: RuntimeUiCredentials | null,
 	endpointUrl: string,
-	nativeReady: boolean,
-	frameReady: boolean,
+	nativeHandoffLoaded: boolean,
+	frameLoaded: boolean,
 ): string | null {
-	if (!frameReady) return null;
+	if (!frameLoaded) return null;
 	const handoffMode = openClawHandoffMode(credentials);
 	if (handoffMode === "legacy" && credentials?.runtime === "openclaw") {
 		return credentials.handoff_url;
@@ -161,5 +174,5 @@ export function openClawRuntimeUiWindowTarget(
 	if (handoffMode === "native" && credentials?.runtime === "openclaw") {
 		return credentials.url;
 	}
-	return nativeReady ? endpointUrl : null;
+	return nativeHandoffLoaded ? endpointUrl : null;
 }

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1154,12 +1154,13 @@ protocol.
 
 OpenClaw persists the issued device credential in its own browser origin and
 may reuse it when the embedded UI revisits the clean dashboard URL. Clawdi
-records only that a bootstrap was attempted for the deployment and published
-endpoint. Every explicit new-window launch requests a fresh official handoff
-because iframe and top-level storage may be partitioned; `Reconnect` also
-requests a fresh handoff. The embedding page cannot inspect OpenClaw's
-cross-origin storage or connection state, and an iframe load is not treated as
-authentication proof.
+records a versioned, non-secret native-ready marker only after the native
+handoff iframe loads, allowing later Console mounts to use the clean endpoint.
+New-window access stays disabled until the current iframe loads; it then opens
+the clean endpoint for native access or the exact reusable legacy `#token=` URL.
+It never requests another handoff. `Reconnect` clears the marker and requests a
+fresh iframe handoff. The load event is only a browser boundary; Clawdi cannot
+inspect OpenClaw's cross-origin authentication state.
 
 Hermes direct exposure requires `hermes-basic-auth-v1`, a stable HTTPS public
 URL (including any path prefix), exact `0.0.0.0:9119` service args, and the

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1154,8 +1154,9 @@ protocol.
 
 OpenClaw persists the issued device credential in its own browser origin and
 may reuse it when the embedded UI revisits the clean dashboard URL. Clawdi
-records a versioned, non-secret native-ready marker only after the native
-handoff iframe loads, allowing later Console mounts to use the clean endpoint.
+records a versioned, non-secret native-handoff-loaded marker only after the
+native handoff document triggers the iframe load event, allowing later Console
+mounts to use the clean endpoint.
 New-window access stays disabled until the current iframe loads; it then opens
 the clean endpoint for native access or the exact reusable legacy `#token=` URL.
 It never requests another handoff. `Reconnect` clears the marker and requests a


### PR DESCRIPTION
## Summary

- consume one OpenClaw handoff per browser and deployment endpoint instead of issuing another credential when Open is clicked
- open the clean endpoint for native handoffs and preserve the exact reusable `#token=` URL for legacy OpenClaw
- keep `Open in new window` disabled until the current iframe load boundary, with synchronous popup navigation and no Open loading state
- clear the versioned, non-secret handoff-loaded marker on Reconnect and fetch a new iframe handoff only then

## Contract

This replaces the fresh-per-window behavior introduced in #1067. The marker records only that the native handoff document loaded; it is not proof that Clawdi observed cross-origin OpenClaw authentication. No launcher route, generic 409 retry, or token persistence was added.

## Verification

- full Docker Web gate: typecheck, complete Bun test suite, OSS production build
- Hosted Playwright: native clean-window reuse across reload and exact legacy token handoff, 2/2 passed
- Hosted production build
- Biome check
- `git diff origin/main..HEAD --check`
