### PR TITLE
fix(web): compact compute subscription cards

### DIFF
--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -180,12 +180,25 @@ async function expectCardsFit(container: Locator) {
 				const metaItemBoxes = Array.from(meta?.children ?? []).map((item) =>
 					item.getBoundingClientRect().toJSON(),
 				);
-				const actionBox = action?.getBoundingClientRect();
+				const actionRect = action?.getBoundingClientRect();
+				const actionBox = actionRect && actionRect.height > 0 ? actionRect : null;
 				const actionItemBoxes = Array.from(
 					card.querySelectorAll<HTMLElement>(
 						'[data-slot="compute-subscription-actions"] button, [data-slot="compute-subscription-actions"] a',
 					),
 				).map((item) => item.getBoundingClientRect().toJSON());
+				const sectionBoxes = [
+					"compute-subscription-header",
+					"compute-subscription-meta",
+					"compute-subscription-identity",
+					"compute-subscription-notice",
+					"compute-subscription-actions",
+				]
+					.map((slot) =>
+						card.querySelector<HTMLElement>(`[data-slot="${slot}"]`)?.getBoundingClientRect(),
+					)
+					.filter((section): section is DOMRect => Boolean(section && section.height > 0))
+					.map((section) => section.toJSON());
 				return {
 					clientWidth: card.clientWidth,
 					scrollWidth: card.scrollWidth,
@@ -195,6 +208,7 @@ async function expectCardsFit(container: Locator) {
 					metaItemBoxes,
 					actionBox: actionBox?.toJSON() ?? null,
 					actionItemBoxes,
+					sectionBoxes,
 				};
 			}),
 		);
@@ -203,6 +217,13 @@ async function expectCardsFit(container: Locator) {
 	for (const metric of metrics) {
 		expect(metric.scrollWidth).toBeLessThanOrEqual(metric.clientWidth + 1);
 		if (metric.headingBox) expect(metric.headingBox.height).toBeLessThanOrEqual(49);
+		for (let index = 1; index < metric.sectionBoxes.length; index += 1) {
+			const previous = metric.sectionBoxes[index - 1];
+			const current = metric.sectionBoxes[index];
+			if (!previous || !current) continue;
+			expect(current.y).toBeGreaterThanOrEqual(previous.bottom - 1);
+			expect(current.y - previous.bottom).toBeLessThanOrEqual(48);
+		}
 		if (metric.metaBox) {
 			for (const itemBox of metric.metaItemBoxes) {
 				expect(itemBox.x).toBeGreaterThanOrEqual(metric.metaBox.x - 1);
@@ -590,6 +611,7 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 	const desktopCardBoxes = await currentCards.evaluateAll((cards) =>
 		cards.map((card) => card.getBoundingClientRect().toJSON()),
 	);
+	expect(desktopCardBoxes[0]?.height ?? Number.POSITIVE_INFINITY).toBeLessThan(200);
 	expect(desktopCardBoxes[2]?.y ?? 0).toBeGreaterThanOrEqual(
 		Math.max(desktopCardBoxes[0]?.bottom ?? 0, desktopCardBoxes[1]?.bottom ?? 0) - 1,
 	);
@@ -714,6 +736,8 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 		.locator('[data-slot="compute-subscription-card"]')
 		.evaluateAll((cards) => cards.map((card) => card.getBoundingClientRect().toJSON()));
 	expect(tabletCardBoxes[1]?.y ?? 0).toBeGreaterThanOrEqual((tabletCardBoxes[0]?.bottom ?? 0) - 1);
+	await currentCards.nth(0).scrollIntoViewIfNeeded();
+	await dialog.screenshot({ path: testInfo.outputPath("account-compute-plans-tablet-800.png") });
 
 	await page.setViewportSize({ width: 320, height: 1000 });
 	await expect(dialog).toBeVisible();

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-card.tsx
@@ -189,77 +189,70 @@ export function ComputeSubscriptionCard({
 			data-subscription-status={view.status.label.toLowerCase().replaceAll(" ", "-")}
 			className={entityCardChassisClass({
 				variant: "compact",
-				className: cn("@container/subscription flex h-full min-w-0 flex-col gap-3", className),
+				className: cn("grid min-w-0 gap-2", className),
 			})}
 		>
-			<div className="flex min-w-0 flex-1 flex-col gap-1.5">
-				<header
-					data-slot="compute-subscription-header"
-					className="flex min-h-6 min-w-0 flex-wrap items-start gap-x-3 gap-y-1.5 sm:min-h-12 @md/subscription:min-h-6"
-				>
-					<Heading className="min-w-28 flex-1 basis-28 text-base font-semibold leading-6 [overflow-wrap:anywhere]">
-						{view.plan}
-					</Heading>
-					<div className="ml-auto flex max-w-full shrink-0 flex-wrap justify-end gap-1.5">
-						<StatusBadge status={view.status.tone} withDot>
-							{view.status.label}
-						</StatusBadge>
-						{badges}
-					</div>
-				</header>
-
-				<dl
-					data-slot="compute-subscription-meta"
-					className="flex min-h-5 min-w-0 flex-wrap items-baseline gap-x-4 gap-y-1.5 sm:min-h-12 @md/subscription:min-h-5"
-				>
-					{view.commercialFacts.map((fact) => (
-						<div key={fact.label} className="min-w-0 text-xs leading-5 text-muted-foreground">
-							<dt className="sr-only">{fact.label}</dt>
-							<dd
-								className={cn(
-									"[overflow-wrap:anywhere]",
-									fact.emphasis && "font-semibold text-foreground",
-								)}
-							>
-								{fact.value}
-							</dd>
-						</div>
-					))}
-				</dl>
-
-				<div
-					data-slot="compute-subscription-identity"
-					className="flex min-h-5 min-w-0 items-center gap-3"
-				>
-					{identity ? (
-						<>
-							{identity.kind === "agent" ? (
-								<span className="shrink-0 text-xs text-muted-foreground">Used by</span>
-							) : null}
-							<div className="min-w-0 flex-1">
-								<SubscriptionIdentity identity={identity} />
-							</div>
-						</>
-					) : null}
+			<header
+				data-slot="compute-subscription-header"
+				className="flex min-w-0 flex-wrap items-start gap-x-3 gap-y-1.5"
+			>
+				<Heading className="min-w-28 flex-1 basis-28 text-base font-semibold leading-6 [overflow-wrap:anywhere]">
+					{view.plan}
+				</Heading>
+				<div className="ml-auto flex max-w-full shrink-0 flex-wrap justify-end gap-1.5">
+					<StatusBadge status={view.status.tone} withDot>
+						{view.status.label}
+					</StatusBadge>
+					{badges}
 				</div>
-			</div>
+			</header>
+
+			<dl
+				data-slot="compute-subscription-meta"
+				className="flex min-w-0 flex-wrap items-baseline gap-x-4 gap-y-1.5 empty:hidden"
+			>
+				{view.commercialFacts.map((fact) => (
+					<div key={fact.label} className="min-w-0 text-xs leading-5 text-muted-foreground">
+						<dt className="sr-only">{fact.label}</dt>
+						<dd
+							className={cn(
+								"[overflow-wrap:anywhere]",
+								fact.emphasis && "font-semibold text-foreground",
+							)}
+						>
+							{fact.value}
+						</dd>
+					</div>
+				))}
+			</dl>
 
 			<div
-				data-slot="compute-subscription-footer"
-				className="mt-auto flex min-w-0 flex-col items-start gap-1.5 pt-1 sm:items-end"
+				data-slot="compute-subscription-identity"
+				className="flex min-w-0 items-center gap-3 empty:hidden"
 			>
-				{notice ? (
-					<div data-slot="compute-subscription-notice" className="min-w-0 sm:text-right">
-						{notice}
-					</div>
+				{identity ? (
+					<>
+						{identity.kind === "agent" ? (
+							<span className="shrink-0 text-xs text-muted-foreground">Used by</span>
+						) : null}
+						<div className="min-w-0 flex-1">
+							<SubscriptionIdentity identity={identity} />
+						</div>
+					</>
 				) : null}
-				<div
-					id={actionsId}
-					data-slot="compute-subscription-actions"
-					className="flex min-h-8 min-w-0 w-full flex-wrap items-center gap-2 sm:justify-end max-sm:[&_[data-slot=button]]:h-auto max-sm:[&_[data-slot=button]]:min-h-8 max-sm:[&_[data-slot=button]]:max-w-full max-sm:[&_[data-slot=button]]:whitespace-normal"
-				>
-					{actions}
+			</div>
+
+			{notice ? (
+				<div data-slot="compute-subscription-notice" className="min-w-0 sm:text-right">
+					{notice}
 				</div>
+			) : null}
+			<div
+				id={actionsId}
+				data-slot="compute-subscription-actions"
+				className="flex min-w-0 w-full flex-wrap items-center gap-2 empty:hidden sm:justify-end max-sm:[&_[data-slot=button]]:h-auto max-sm:[&_[data-slot=button]]:min-h-8 max-sm:[&_[data-slot=button]]:max-w-full max-sm:[&_[data-slot=button]]:whitespace-normal"
+			>
+				{actions}
 			</div>
 		</article>
 	);

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -225,11 +225,12 @@ function SubscriptionRow({
 				: { kind: "unavailable", label: "Deleted agent" };
 
 	return (
-		<li className="min-w-0">
+		<li className="grid min-w-0 lg:row-span-5 lg:grid-rows-subgrid">
 			<ComputeSubscriptionCard
 				headingLevel={4}
 				view={view}
 				identity={identity}
+				className="lg:row-span-full lg:grid-rows-subgrid lg:[&>[data-slot=compute-subscription-actions]]:row-start-5"
 				notice={
 					recoveryNotice || pendingPlanCopy || managementReason ? (
 						<div className="flex flex-col gap-1.5 text-xs text-muted-foreground">
@@ -318,7 +319,7 @@ export function reusableInventoryState(
 	return data === undefined ? "loading" : "ready";
 }
 
-const SUBSCRIPTION_CARD_GRID_CLASS = "grid gap-3 lg:grid-cols-2";
+const SUBSCRIPTION_CARD_GRID_CLASS = "grid gap-2 lg:grid-cols-2";
 
 function SubscriptionListSkeleton({ label = "Loading subscriptions" }: { label?: string }) {
 	return (


### PR DESCRIPTION
## Summary\n\n- remove flex-grow and minimum-height rules that stretched compute subscription cards\n- align desktop card sections with a five-row CSS subgrid while preserving the two-column layout\n- keep tablet and mobile cards in a compact natural flow with wrapping actions\n- strengthen the existing subscription E2E geometry checks without adding test files\n\n## Verification\n\n- isolated Docker web typecheck\n- 4 focused subscription tests\n- OSS production build\n- Playwright Chromium: hosted subscriptions 3/3 at 1440, 800, and 320 px\n- root visual review of all three screenshots\n- \n