### PR TITLE
fix(web): navigate immediately after deploy acceptance

### DIFF
--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -564,6 +564,7 @@ describe("declarative deployment mutations", () => {
 						request_status: "ready",
 						lineage_tail: {
 							deployment_id: "hdep_test",
+							agent_id: "44444444-4444-4444-8444-444444444444",
 							lineage_version: 1,
 							lineage_state: "unaccepted",
 							operation: null,
@@ -596,6 +597,7 @@ describe("declarative deployment mutations", () => {
 		expect(checkout.flow_type).toBe("checkout_session");
 		expect(checkout.checkout_url).toBe("https://checkout.example.com/session");
 		expect(await client.waitForDeploymentRequest(intentKey)).toMatchObject({
+			agentId: "44444444-4444-4444-8444-444444444444",
 			deploymentId: "hdep_test",
 			operation: null,
 		});

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -577,10 +577,13 @@ export function createBillingClient(
 				throw terminalDeployRequestError(status);
 			}
 			if (projection.kind === "operation") {
-				return acceptDeclarativeOperation({
-					operation: projection.operation,
-					deploymentId: projection.deploymentId,
-				});
+				return {
+					...acceptDeclarativeOperation({
+						operation: projection.operation,
+						deploymentId: projection.deploymentId,
+					}),
+					agentId: projection.agentId,
+				};
 			}
 			if (projection.kind === "operation_name") {
 				const remainingMs = deadline - Date.now();
@@ -602,16 +605,22 @@ export function createBillingClient(
 				} finally {
 					globalThis.clearTimeout(operationTimeoutId);
 				}
-				return acceptDeclarativeOperation({
-					operation,
-					deploymentId: projection.deploymentId,
-				});
+				return {
+					...acceptDeclarativeOperation({
+						operation,
+						deploymentId: projection.deploymentId,
+					}),
+					agentId: projection.agentId,
+				};
 			}
 			if (projection.kind === "deployment") {
-				return acceptDeclarativeOperation({
-					deploymentId: projection.deploymentId,
-					operation: null,
-				});
+				return {
+					...acceptDeclarativeOperation({
+						deploymentId: projection.deploymentId,
+						operation: null,
+					}),
+					agentId: projection.agentId,
+				};
 			}
 			if (projection.kind === "invalid_success") {
 				return acceptDeclarativeOperation({ deploymentId: null, operation: null });

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -838,8 +838,8 @@ export function createBillingClient(
 		checkout: async (body: CheckoutRequest, idempotencyKey: string) =>
 			unwrapDeploy(
 				await api.POST("/v2/subscription/checkout", {
+					params: { header: { "Idempotency-Key": idempotencyKey } },
 					body,
-					headers: { "Idempotency-Key": idempotencyKey },
 				}),
 			),
 		quoteSubscription: async (body: ComputeSubscriptionQuoteRequest) =>

--- a/apps/web/src/hosted/billing/checkout-return.ts
+++ b/apps/web/src/hosted/billing/checkout-return.ts
@@ -16,7 +16,7 @@ const MARKER_PARAMS = [
 
 export type CheckoutReturnNavigationTarget =
 	| { kind: "deploy_request"; deployRequestId: string }
-	| { kind: "deployment"; deploymentId: string };
+	| { kind: "deployment"; agentId?: string | null; deploymentId: string };
 
 export function checkoutReturnWasCanceled(searchStr: string): boolean {
 	return new URLSearchParams(searchStr).get("checkout") === "cancel";

--- a/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.test.ts
+++ b/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.test.ts
@@ -18,6 +18,46 @@ function deferred<T>() {
 }
 
 describe("accepted deployment navigation", () => {
+	test("opens the canonical route before deployment hydration settles", async () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const authoritative = hostedDeploymentFixture({
+			id: "hdep_fast_handoff",
+			agentId: "11111111-1111-4111-8111-111111111111",
+			status: "creating",
+		});
+		const hydration = deferred<HostedDeployment>();
+		const events: string[] = [];
+
+		await navigateToAcceptedDeployment({
+			agentId: authoritative.agent_id,
+			deploymentId: authoritative.resource.id,
+			getDeployment: async () => {
+				events.push("hydrate");
+				return hydration.promise;
+			},
+			navigate: async ({ href }) => {
+				events.push(`navigate:${href}`);
+			},
+			queryClient,
+		});
+
+		expect(events).toEqual(["hydrate", "navigate:/agents/11111111-1111-4111-8111-111111111111"]);
+		expect(queryClient.getQueryData(billingKeys.deployments)).toBeUndefined();
+
+		hydration.resolve(authoritative);
+		for (
+			let turn = 0;
+			turn < 10 && !queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments);
+			turn += 1
+		) {
+			await Promise.resolve();
+		}
+		expect(queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments)).toEqual([
+			authoritative,
+		]);
+		queryClient.clear();
+	});
+
 	test("cancels a stale list before authoritative cache handoff and navigation", async () => {
 		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 		const staleList = deferred<HostedDeployment[]>();

--- a/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.ts
+++ b/apps/web/src/hosted/billing/deploy/accepted-deployment-navigation.ts
@@ -1,7 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { billingKeys } from "@/hosted/billing/query-keys";
-import { agentSectionHref, isAgentRouteId } from "@/lib/agent-routes";
+import { agentRouteIdsEqual, agentSectionHref, isAgentRouteId } from "@/lib/agent-routes";
 
 export type AcceptedDeploymentNavigate = (options: {
 	href: string;
@@ -10,7 +10,7 @@ export type AcceptedDeploymentNavigate = (options: {
 
 type AcceptedDeploymentRequestResolver = (
 	deployRequestId: string,
-) => Promise<{ deploymentId: string }>;
+) => Promise<{ agentId?: string | null; deploymentId: string }>;
 
 function upsertAuthoritativeDeployment(
 	deployments: readonly HostedDeployment[] | undefined,
@@ -27,26 +27,26 @@ function upsertAuthoritativeDeployment(
 	);
 }
 
-/** Hydrate committed deployment authority before opening its canonical route. */
-export async function navigateToAcceptedDeployment({
+async function hydrateAcceptedDeployment({
+	agentId,
 	deploymentId,
 	getDeployment,
-	navigate,
 	queryClient,
-	replace = false,
 }: {
+	agentId?: string;
 	deploymentId: string;
 	getDeployment: (deploymentId: string) => Promise<HostedDeployment>;
-	navigate: AcceptedDeploymentNavigate;
 	queryClient: QueryClient;
-	replace?: boolean;
-}): Promise<void> {
+}): Promise<HostedDeployment> {
 	const authoritative = await getDeployment(deploymentId);
 	if (authoritative.resource.id !== deploymentId) {
 		throw new Error("The deployment service returned a different deployment.");
 	}
 	if (!isAgentRouteId(authoritative.agent_id)) {
 		throw new Error("The deployment service returned an invalid Agent identity.");
+	}
+	if (agentId && !agentRouteIdsEqual(authoritative.agent_id, agentId)) {
+		throw new Error("The deployment service returned a different Agent identity.");
 	}
 
 	// A list read that started before acceptance can be older than the committed
@@ -56,6 +56,49 @@ export async function navigateToAcceptedDeployment({
 		upsertAuthoritativeDeployment(deployments, authoritative),
 	);
 	void queryClient.invalidateQueries({ queryKey: ["get", "/v1/agents"] });
+	return authoritative;
+}
+
+/** Open accepted authority immediately when the API already returned its canonical Agent ID. */
+export async function navigateToAcceptedDeployment({
+	agentId,
+	deploymentId,
+	getDeployment,
+	navigate,
+	queryClient,
+	replace = false,
+}: {
+	agentId?: string | null;
+	deploymentId: string;
+	getDeployment: (deploymentId: string) => Promise<HostedDeployment>;
+	navigate: AcceptedDeploymentNavigate;
+	queryClient: QueryClient;
+	replace?: boolean;
+}): Promise<void> {
+	const acceptedAgentId = agentId?.trim() || null;
+	if (acceptedAgentId && !isAgentRouteId(acceptedAgentId)) {
+		throw new Error("The deployment service returned an invalid Agent identity.");
+	}
+
+	if (acceptedAgentId) {
+		const hydration = hydrateAcceptedDeployment({
+			agentId: acceptedAgentId,
+			deploymentId,
+			getDeployment,
+			queryClient,
+		}).catch(() => {
+			void queryClient.invalidateQueries({ queryKey: billingKeys.deployments, exact: true });
+		});
+		await navigate({ href: agentSectionHref(acceptedAgentId), replace });
+		void hydration;
+		return;
+	}
+
+	const authoritative = await hydrateAcceptedDeployment({
+		deploymentId,
+		getDeployment,
+		queryClient,
+	});
 
 	await navigate({
 		href: agentSectionHref(authoritative.agent_id),
@@ -74,7 +117,7 @@ export async function navigateToAcceptedDeploymentRequest({
 	onAccepted?: () => void;
 	resolveDeploymentRequest: AcceptedDeploymentRequestResolver;
 }): Promise<void> {
-	const { deploymentId } = await resolveDeploymentRequest(deployRequestId);
+	const { agentId, deploymentId } = await resolveDeploymentRequest(deployRequestId);
 	onAccepted?.();
-	await navigateToAcceptedDeployment({ ...navigation, deploymentId });
+	await navigateToAcceptedDeployment({ ...navigation, agentId, deploymentId });
 }

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -223,8 +223,7 @@ describe("first Basic agent copy", () => {
 		expect(wizardSource).not.toContain("waitForRuntime");
 		expect(wizardSource).not.toContain("Agent deployment started");
 		expect(wizardSource).not.toContain("agent is getting ready now");
-		expect(wizardSource).toContain('toast.success("Wallet payment confirmed"');
-		expect(wizardSource).toContain("toast.dismiss(WALLET_PAYMENT_TOAST_ID)");
+		expect(wizardSource).not.toContain("Wallet payment confirmed");
 	});
 
 	test("keeps infrastructure vocabulary out of customer copy", () => {
@@ -378,13 +377,11 @@ describe("deploy acceptance", () => {
 		expect(walletBranch).not.toContain("recheckCanCreateCloudAgents");
 	});
 
-	test("shows a scoped honest busy state and reports failures only through actionable toasts", () => {
-		expect(wizardSource).toContain("setSubmitBusyLabel(");
+	test("keeps submit progress inside the action and reports failures through actionable toasts", () => {
 		expect(wizardSource).toContain('"Deploying…"');
-		expect(wizardSource).toContain('"Opening…"');
 		expect(wizardSource).not.toContain("Loading agent details");
-		expect(wizardSource).toContain('"Payment is processing."');
-		expect(wizardSource).toContain('"Waiting for your agent."');
+		expect(wizardSource).not.toContain('"Payment is processing."');
+		expect(wizardSource).not.toContain('"Waiting for your agent."');
 		expect(wizardSource).not.toContain("Keep this page open");
 		expect(wizardSource).not.toContain("Payment and agent creation are still being confirmed.");
 		expect(wizardSource).toContain('<Spinner data-icon="inline-start" />');

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -8,10 +8,6 @@ const deployPageSource = readFileSync(
 	new URL("../../../pages/dashboard/deploy/page.tsx", import.meta.url),
 	"utf8",
 );
-const acceptedNavigationSource = readFileSync(
-	new URL("./accepted-deployment-navigation.ts", import.meta.url),
-	"utf8",
-);
 const planChangeDialogSource = readFileSync(
 	new URL("../subscription/plan-change-dialog.tsx", import.meta.url),
 	"utf8",
@@ -222,10 +218,7 @@ describe("first Basic agent copy", () => {
 		expect(wizardSource).not.toContain("resolveWalletDeploymentId");
 	});
 
-	test("hydrates authoritative Agent identity before accepted-create navigation", () => {
-		expect(acceptedNavigationSource).toContain("getDeployment(deploymentId)");
-		expect(acceptedNavigationSource).toContain("agentSectionHref(authoritative.agent_id)");
-		expect(acceptedNavigationSource).not.toContain("source=on-clawdi");
+	test("keeps post-acceptance waiting out of the customer flow", () => {
 		expect(wizardSource).not.toContain("setup=accepted");
 		expect(wizardSource).not.toContain("waitForRuntime");
 		expect(wizardSource).not.toContain("Agent deployment started");

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -52,7 +52,6 @@ import {
 	checkoutRedirectUrl,
 	checkoutSessionClientSecret,
 	checkoutUiModeForPublishableKey,
-	type StripeCheckoutPaymentStatus,
 } from "@/hosted/billing/components/stripe-checkout.logic";
 import {
 	StripeCheckoutDialog,
@@ -110,7 +109,7 @@ import {
 	isReusableSubscriptionUnavailableError,
 	normalizeBillingError,
 } from "@/hosted/billing/errors";
-import { billingTermLabel, formatCents, formatUsdExact } from "@/hosted/billing/format";
+import { billingTermLabel, formatCents } from "@/hosted/billing/format";
 import {
 	useHostedDeployments,
 	useManagedModelCatalog,
@@ -196,10 +195,6 @@ type AcceptedDeploymentRecovery = {
 	replace: boolean;
 	target: CheckoutReturnNavigationTarget;
 };
-type DeploymentRequestProgress = {
-	busyLabel: string;
-	takingLongCopy: string;
-};
 type PaidDeploySelection = {
 	billingTermMonths: number;
 	computePlanSlug: ComputePlanSlug;
@@ -208,40 +203,6 @@ type PaidDeploySelection = {
 	tierLabel: "Basic" | "Performance";
 };
 const DEPLOY_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
-const WALLET_PAYMENT_TOAST_ID = "agent-create-wallet-payment";
-const WALLET_PAYMENT_TOAST_DURATION_MS = 8_000;
-const DEFAULT_DEPLOYMENT_REQUEST_PROGRESS: DeploymentRequestProgress = {
-	busyLabel: "Opening…",
-	takingLongCopy: "Waiting for your agent.",
-};
-
-function checkoutDeploymentRequestProgress(
-	paymentStatus: StripeCheckoutPaymentStatus,
-): DeploymentRequestProgress {
-	if (paymentStatus === "unpaid") {
-		return {
-			busyLabel: "Opening…",
-			takingLongCopy: "Payment is processing.",
-		};
-	}
-	if (paymentStatus === "no_payment_required") return DEFAULT_DEPLOYMENT_REQUEST_PROGRESS;
-	return {
-		busyLabel: "Opening…",
-		takingLongCopy: "Payment confirmed.",
-	};
-}
-
-function showWalletPaymentConfirmation(amount: string) {
-	toast.success("Wallet payment confirmed", {
-		id: WALLET_PAYMENT_TOAST_ID,
-		description: `${amount} was paid from Wallet.`,
-		duration: Number.POSITIVE_INFINITY,
-	});
-	globalThis.setTimeout(
-		() => toast.dismiss(WALLET_PAYMENT_TOAST_ID),
-		WALLET_PAYMENT_TOAST_DURATION_MS,
-	);
-}
 
 const aiProviderErrorNormalizer: ApiErrorNormalizer = {
 	isAuthError: isApiAuthError,
@@ -344,15 +305,9 @@ export function DeployWizard() {
 		async (
 			target: CheckoutReturnNavigationTarget,
 			replace = false,
-			requestProgress: DeploymentRequestProgress = DEFAULT_DEPLOYMENT_REQUEST_PROGRESS,
 		): Promise<boolean> => {
 			setAcceptedDeploymentRecovery(null);
 			if (target.kind === "deployment") setDeploymentCommitted(true);
-			setSubmitBusyLabel(target.kind === "deploy_request" ? requestProgress.busyLabel : "Opening…");
-			setSubmitTakingLongCopy(
-				target.kind === "deploy_request" ? requestProgress.takingLongCopy : null,
-			);
-			setSubmitTakingLong(false);
 			setSubmitting(true);
 			acceptanceNavigatingRef.current = true;
 			const navigation = {
@@ -369,9 +324,6 @@ export function DeployWizard() {
 						onAccepted: () => {
 							setDeploymentCommitted(true);
 							clearCheckoutAttempt(target.deployRequestId);
-							setSubmitBusyLabel("Opening…");
-							setSubmitTakingLongCopy(null);
-							setSubmitTakingLong(false);
 						},
 						resolveDeploymentRequest,
 					});
@@ -422,7 +374,6 @@ export function DeployWizard() {
 					setAcceptedDeploymentRecovery({ replace, target });
 				}
 				setSubmitting(false);
-				setSubmitTakingLong(false);
 				return false;
 			}
 		},
@@ -472,11 +423,6 @@ export function DeployWizard() {
 	const [checkoutSession, setCheckoutSession] = useState<NativeDeployCheckout | null>(null);
 	const [term, setTerm] = useState(1);
 	const [submitting, setSubmitting] = useState(false);
-	const [submitTakingLong, setSubmitTakingLong] = useState(false);
-	const [submitBusyLabel, setSubmitBusyLabel] = useState("Deploying…");
-	const [submitTakingLongCopy, setSubmitTakingLongCopy] = useState<string | null>(
-		"Waiting for your agent.",
-	);
 	const [paymentMethod, setPaymentMethod] = useState<DeployPaymentMethod>("card");
 	const [selectedSubscriptionSource, setSubscriptionSource] = useState<SubscriptionSource | null>(
 		null,
@@ -507,11 +453,6 @@ export function DeployWizard() {
 		setLanguage((current) => current || browserLanguageValue);
 		setPersonaDefaults({ language: browserLanguageValue, timezone: browserTimezoneValue });
 	}, []);
-	useEffect(() => {
-		if (!submitting) return;
-		const timeout = window.setTimeout(() => setSubmitTakingLong(true), 5_000);
-		return () => window.clearTimeout(timeout);
-	}, [submitting]);
 	const tzOptions = useMemo(() => {
 		return mergeTimezoneOptions(timezoneOptions, timezone ? [timezone] : []);
 	}, [timezone, timezoneOptions]);
@@ -843,16 +784,9 @@ export function DeployWizard() {
 		return false;
 	}
 
-	async function handleCheckoutComplete(
-		requestKey: string,
-		paymentStatus: StripeCheckoutPaymentStatus,
-	) {
+	async function handleCheckoutComplete(requestKey: string) {
 		setCheckoutSession(null);
-		await acceptDeployment(
-			{ kind: "deploy_request", deployRequestId: requestKey },
-			true,
-			checkoutDeploymentRequestProgress(paymentStatus),
-		);
+		await acceptDeployment({ kind: "deploy_request", deployRequestId: requestKey }, true);
 	}
 
 	function handleCheckoutExpired(requestKey: string) {
@@ -887,17 +821,6 @@ export function DeployWizard() {
 
 	async function onDeploy() {
 		if (!canSubmit || !subscriptionSource) return;
-		setSubmitTakingLong(false);
-		setSubmitBusyLabel(paidSelection && paymentMethod === "card" ? "Opening…" : "Deploying…");
-		setSubmitTakingLongCopy(
-			subscriptionSource.mode === "existing"
-				? "Waiting for your agent."
-				: paidSelection
-					? paymentMethod === "wallet"
-						? "Payment is processing."
-						: "Opening checkout."
-					: "Waiting for your agent.",
-		);
 		setSubmitting(true);
 		try {
 			const aiFields = aiDeployFields();
@@ -993,11 +916,6 @@ export function DeployWizard() {
 					}
 					forgetIdempotencyAttempt("subscription-wallet-deploy", fingerprint);
 					walletCreateAttemptRef.current = null;
-					showWalletPaymentConfirmation(
-						walletDebit
-							? formatUsdExact(walletDebit.debitAmountUsd)
-							: formatCents(paidSelection.offer.price_cents),
-					);
 					await acceptDeployment(outcome.target);
 					return;
 				}
@@ -1086,7 +1004,6 @@ export function DeployWizard() {
 			showDeploySubmissionError(e);
 		} finally {
 			setSubmitting(false);
-			setSubmitTakingLong(false);
 		}
 	}
 
@@ -1726,19 +1643,12 @@ export function DeployWizard() {
 										<Rocket data-icon="inline-start" />
 									)}
 									{submitting
-										? submitBusyLabel
+										? "Deploying…"
 										: acceptedDeploymentHydrationFailed
 											? "Retry"
 											: deployLabel}
 								</Button>
-								{submitTakingLong && submitTakingLongCopy ? (
-									<p
-										className="max-w-sm text-xs text-muted-foreground @2xl/main:text-right"
-										role="status"
-									>
-										{submitTakingLongCopy}
-									</p>
-								) : visibleSubmitBlockingReason ? (
+								{visibleSubmitBlockingReason ? (
 									<p
 										id="deploy-blocking-reason"
 										className={cn(
@@ -1779,9 +1689,9 @@ export function DeployWizard() {
 				title={`Complete ${checkoutSession?.tierLabel ?? "compute"} checkout`}
 				description="Enter payment details without leaving this page. Redirect-based payment methods return here after confirmation."
 				summary={checkoutSession?.summary ?? null}
-				onComplete={(paymentStatus) => {
+				onComplete={() => {
 					if (checkoutSession) {
-						void handleCheckoutComplete(checkoutSession.requestKey, paymentStatus);
+						void handleCheckoutComplete(checkoutSession.requestKey);
 					}
 				}}
 				onExpired={() => {

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -302,10 +302,7 @@ export function DeployWizard() {
 	const [deploymentCommitted, setDeploymentCommitted] = useState(false);
 	const acceptanceNavigatingRef = useRef(false);
 	const acceptDeployment = useCallback(
-		async (
-			target: CheckoutReturnNavigationTarget,
-			replace = false,
-		): Promise<boolean> => {
+		async (target: CheckoutReturnNavigationTarget, replace = false): Promise<boolean> => {
 			setAcceptedDeploymentRecovery(null);
 			if (target.kind === "deployment") setDeploymentCommitted(true);
 			setSubmitting(true);

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -378,6 +378,7 @@ export function DeployWizard() {
 				} else {
 					await navigateToAcceptedDeployment({
 						...navigation,
+						agentId: target.agentId,
 						deploymentId: target.deploymentId,
 					});
 				}

--- a/apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts
@@ -177,6 +177,7 @@ describe("subscription creation adapter", () => {
 			checkout_url: "",
 			subscription_id: "csub_contract",
 			invoice_id: null,
+			agent_id: "33333333-3333-4333-8333-333333333333",
 			deploy_request_id: "subscription-create-test",
 			deployment_id: "hdep_created",
 			deployment_name: null,
@@ -189,7 +190,11 @@ describe("subscription creation adapter", () => {
 		};
 		expect(subscriptionCreateOutcome(activation)).toEqual({
 			flowType: "subscription_activation",
-			target: { kind: "deployment", deploymentId: "hdep_created" },
+			target: {
+				kind: "deployment",
+				agentId: "33333333-3333-4333-8333-333333333333",
+				deploymentId: "hdep_created",
+			},
 			currentPeriodEnd: "2027-07-15T00:00:00Z",
 			entitledUntil: "2027-07-16T00:00:00Z",
 		});

--- a/apps/web/src/hosted/billing/subscription/subscription-create-adapter.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-adapter.ts
@@ -93,7 +93,7 @@ export type SubscriptionCreateOutcomeView =
 	| {
 			flowType: "subscription_activation";
 			target:
-				| { kind: "deployment"; deploymentId: string }
+				| { kind: "deployment"; agentId: string | null; deploymentId: string }
 				| { kind: "deploy_request"; deployRequestId: string };
 			currentPeriodEnd: string | null;
 			entitledUntil: string | null;
@@ -174,10 +174,10 @@ export function subscriptionCreateOutcome(
 	const deploymentId = result.deployment_id?.trim();
 	const deployRequestId = result.deploy_request_id?.trim();
 	let target:
-		| { kind: "deployment"; deploymentId: string }
+		| { kind: "deployment"; agentId: string | null; deploymentId: string }
 		| { kind: "deploy_request"; deployRequestId: string };
 	if (deploymentId) {
-		target = { kind: "deployment", deploymentId };
+		target = { kind: "deployment", agentId: result.agent_id?.trim() || null, deploymentId };
 	} else if (deployRequestId) {
 		target = { kind: "deploy_request", deployRequestId };
 	} else {

--- a/packages/cli/src/lib/hosted-deploy-client.ts
+++ b/packages/cli/src/lib/hosted-deploy-client.ts
@@ -197,8 +197,8 @@ export class HostedDeployClient {
 	async checkout(body: HostedDeployCheckoutRequest, idempotencyKey: string) {
 		return unwrapHosted(
 			await this.client.POST("/v2/subscription/checkout", {
+				params: { header: { "Idempotency-Key": idempotencyKey } },
 				body,
-				headers: { "Idempotency-Key": idempotencyKey },
 			}),
 		);
 	}

--- a/packages/shared/src/api/deploy-wizard.test.ts
+++ b/packages/shared/src/api/deploy-wizard.test.ts
@@ -389,13 +389,19 @@ describe("hosted deploy request projection", () => {
 					request_status: "ready",
 					lineage_tail: {
 						deployment_id: "hdep_test",
+						agent_id: "55555555-5555-4555-8555-555555555555",
 						operation_name: "operations/deploy-test",
 						lineage_version: 1,
 						lineage_state: "processing",
 					},
 				}),
 			),
-		).toEqual({ kind: "deployment", completed: false, deploymentId: "hdep_test" });
+		).toEqual({
+			kind: "deployment",
+			agentId: "55555555-5555-4555-8555-555555555555",
+			completed: false,
+			deploymentId: "hdep_test",
+		});
 		expect(
 			projectHostedDeployRequest(
 				requestStatus({
@@ -409,6 +415,7 @@ describe("hosted deploy request projection", () => {
 			),
 		).toEqual({
 			kind: "operation_name",
+			agentId: null,
 			deploymentId: null,
 			operationName: "operations/deploy-test",
 		});
@@ -426,7 +433,12 @@ describe("hosted deploy request projection", () => {
 					},
 				}),
 			),
-		).toEqual({ kind: "deployment", completed: false, deploymentId: "hdep_test" });
+		).toEqual({
+			kind: "deployment",
+			agentId: null,
+			completed: false,
+			deploymentId: "hdep_test",
+		});
 		expect(projectHostedDeployRequest(requestStatus({}))).toEqual({ kind: "wait" });
 		expect(projectHostedDeployRequest(requestStatus({ request_status: "succeeded" }))).toEqual({
 			kind: "invalid_success",

--- a/packages/shared/src/api/deploy-wizard.ts
+++ b/packages/shared/src/api/deploy-wizard.ts
@@ -408,16 +408,19 @@ export type HostedDeployRequestProjection =
 	  }
 	| {
 			kind: "operation";
+			agentId: string | null;
 			deploymentId: string | null;
 			operation: HostedDeployOperation;
 	  }
 	| {
 			kind: "operation_name";
+			agentId: string | null;
 			deploymentId: string | null;
 			operationName: string;
 	  }
 	| {
 			kind: "deployment";
+			agentId: string | null;
 			completed: boolean;
 			deploymentId: string;
 	  }
@@ -436,17 +439,19 @@ export function projectHostedDeployRequest(
 		return { kind: "terminal", requestStatus: status.request_status };
 	}
 	const deploymentId = status.lineage_tail?.deployment_id?.trim() || null;
+	const agentId = status.lineage_tail?.agent_id?.trim() || null;
 	if (deploymentId) {
 		return {
 			kind: "deployment",
+			agentId,
 			completed: status.request_status === "succeeded",
 			deploymentId,
 		};
 	}
 	const operation = status.lineage_tail?.operation ?? null;
-	if (operation) return { kind: "operation", deploymentId, operation };
+	if (operation) return { kind: "operation", agentId, deploymentId, operation };
 	const operationName = status.lineage_tail?.operation_name?.trim() || "";
-	if (operationName) return { kind: "operation_name", deploymentId, operationName };
+	if (operationName) return { kind: "operation_name", agentId, deploymentId, operationName };
 	if (status.request_status === "succeeded") return { kind: "invalid_success" };
 	return { kind: "wait" };
 }

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1363,6 +1363,8 @@ export interface components {
             invoice_id: null;
             /** Deployment Id */
             deployment_id: null;
+            /** Agent Id */
+            agent_id?: null;
             /** Deployment Name */
             deployment_name: null;
             /** Metadata Generation */
@@ -2069,6 +2071,8 @@ export interface components {
         V2HostedDeployRequestLineageTail: {
             /** Deployment Id */
             deployment_id?: string | null;
+            /** Agent Id */
+            agent_id?: string | null;
             deployment_status?: components["schemas"]["HostedDeploymentStatus"] | null;
             /** Operation Name */
             operation_name?: string | null;
@@ -2401,6 +2405,8 @@ export interface components {
             invoice_id: string | null;
             /** Deployment Id */
             deployment_id: string | null;
+            /** Agent Id */
+            agent_id?: string | null;
             /** Deployment Name */
             deployment_name: string | null;
             /** Metadata Generation */

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -3860,8 +3860,8 @@ export interface operations {
     checkout_v2_subscription_v2_subscription_checkout_post: {
         parameters: {
             query?: never;
-            header?: {
-                "Idempotency-Key"?: string | null;
+            header: {
+                "Idempotency-Key": string;
             };
             path?: never;
             cookie?: never;


### PR DESCRIPTION
## Summary\n\n- carry canonical agent_id through Wallet activation and deploy-request resolution\n- navigate to the Agent detail route immediately after server acceptance\n- hydrate deployment data in the background while retaining the legacy read-before-navigation fallback\n- keep pending feedback inside the deploy button and remove non-actionable phase copy and Wallet success toasts\n\nDepends on Clawdi-AI/clawdi-hosted#1803 for the fast-path response field.\n\n## Verification\n\n- Docker web typecheck passed\n- focused deploy wizard and accepted-navigation tests passed\n- OSS production web build passed\n- prior Docker shared typecheck and 76 shared tests passed