### PR TITLE
feat(web): overhaul agent plugins UX

### DIFF
--- a/apps/web/e2e/hosted-agent-plugins.pw.ts
+++ b/apps/web/e2e/hosted-agent-plugins.pw.ts
@@ -100,7 +100,8 @@ test("Agent Plugins opens and installs with the per-user capability", async ({ p
 	await expect(page.getByText("OpenClaw", { exact: true })).toHaveCount(0);
 	await expect(page.getByText("Hermes", { exact: true })).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Remove", exact: true })).toBeVisible();
-	await page.getByRole("button", { name: "Back to Plugins", exact: true }).click();
+	await page.getByTestId("app-sidebar").getByRole("link", { name: "Plugins", exact: true }).click();
+	await expect(page.getByRole("heading", { name: "Plugins" })).toBeVisible();
 	await page.getByRole("button", { name: "Remove", exact: true }).click();
 	await page.getByRole("button", { name: "Remove plugin", exact: true }).click();
 	await expect(page.getByRole("button", { name: "Install", exact: true })).toBeVisible();

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -652,11 +652,7 @@ export function HostedAgentDetail({
 						)
 					) : null}
 					{activeTab === "plugins" ? (
-						<AgentPluginsSurface
-							agentId={environmentId}
-							runtime={runtime}
-							routeSearch={routeSearch}
-						/>
+						<AgentPluginsSurface agentId={environmentId} runtime={runtime} />
 					) : null}
 					{deploymentStatus.known && activeTab === "ai" ? (
 						<AiProviderTab

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -652,7 +652,11 @@ export function HostedAgentDetail({
 						)
 					) : null}
 					{activeTab === "plugins" ? (
-						<AgentPluginsSurface agentId={environmentId} runtime={runtime} />
+						<AgentPluginsSurface
+							agentId={environmentId}
+							runtime={runtime}
+							routeSearch={routeSearch}
+						/>
 					) : null}
 					{deploymentStatus.known && activeTab === "ai" ? (
 						<AiProviderTab

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-card.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-card.tsx
@@ -19,7 +19,7 @@ import {
 	pluginVersion,
 } from "./agent-plugin-model";
 
-export type AgentPluginPendingAction = "install" | "remove" | null;
+export type AgentPluginPendingAction = "install" | "remove" | "retry" | null;
 
 export function AgentPluginCard({
 	item,
@@ -29,6 +29,7 @@ export function AgentPluginCard({
 	onOpen,
 	onInstall,
 	onRemove,
+	onRetry,
 }: {
 	item: AgentPluginInventoryItem;
 	runtime: HostedRuntime;
@@ -37,14 +38,21 @@ export function AgentPluginCard({
 	onOpen: (name: string) => void;
 	onInstall: (item: AgentPluginInventoryItem) => Promise<unknown>;
 	onRemove: (item: AgentPluginInventoryItem) => Promise<unknown>;
+	onRetry: (item: AgentPluginInventoryItem) => Promise<unknown>;
 }) {
 	const title = pluginDisplayName(item);
 	const status = item.desired ? agentPluginStatusPresentation(item.desired) : null;
 	const installability = item.catalog ? agentPluginInstallability(item.catalog, runtime) : null;
 	const hasUpdate = pluginHasUpdate(item);
+	const installFailed = item.desired?.convergence === "failed";
+	const canRetry = Boolean(installFailed && item.catalog && installability?.installable);
 	const canInstall = Boolean(
-		item.catalog && installability?.installable && (!item.desired || hasUpdate),
+		item.catalog && installability?.installable && !installFailed && (!item.desired || hasUpdate),
 	);
+	const version =
+		hasUpdate && item.desired && item.catalog
+			? `v${item.desired.version} → v${item.catalog.version}`
+			: `v${pluginVersion(item)}`;
 
 	return (
 		<div data-hosted="true" data-v2="true" className="contents">
@@ -59,16 +67,21 @@ export function AgentPluginCard({
 				}
 				title={title}
 				badges={
-					status ? (
-						<StatusBadge status={status.tone} withDot>
-							{status.label}
-						</StatusBadge>
+					status || hasUpdate ? (
+						<>
+							{status ? (
+								<StatusBadge status={status.tone} withDot>
+									{status.label}
+								</StatusBadge>
+							) : null}
+							{hasUpdate ? <StatusBadge status="info">Update available</StatusBadge> : null}
+						</>
 					) : undefined
 				}
 				description={
 					item.catalog?.description ?? "This plugin is no longer available in the Store."
 				}
-				footer={[item.catalog?.publisher, `v${pluginVersion(item)}`]}
+				footer={[item.catalog?.publisher, version]}
 				footerClassName="mt-0"
 			>
 				<div className="mt-auto flex min-w-0 flex-wrap items-center justify-between gap-x-3 gap-y-2">
@@ -119,6 +132,16 @@ export function AgentPluginCard({
 								title={installability.reason ?? undefined}
 							>
 								{installability.label}
+							</Button>
+						) : null}
+						{canRetry ? (
+							<Button
+								size="sm"
+								disabled={mutationsBlocked}
+								onClick={() => void onRetry(item).catch(() => undefined)}
+							>
+								{pendingAction === "retry" ? <Spinner /> : <RefreshCw />}
+								{pendingAction === "retry" ? "Retrying…" : "Retry"}
 							</Button>
 						) : null}
 					</div>

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-detail.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-detail.tsx
@@ -79,7 +79,7 @@ export function AgentPluginDetail({
 
 	return (
 		<div data-hosted="true" data-v2="true" className="space-y-6">
-			<Button variant="ghost" size="sm" className="w-fit" onClick={onBack}>
+			<Button variant="ghost" size="sm" className="w-fit sm:hidden" onClick={onBack}>
 				<ArrowLeft />
 				Back to Plugins
 			</Button>

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-detail.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-detail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+	AlertCircle,
 	ArrowLeft,
 	Blocks,
 	BookOpen,
@@ -16,7 +17,7 @@ import { DetailMeta, DetailPanel, DetailStats } from "@/components/detail/layout
 import { IconChip } from "@/components/icon-chip";
 import { Stat } from "@/components/meta/stat";
 import { PageHeader } from "@/components/page-header";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Alert, AlertAction, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Spinner } from "@/components/ui/spinner";
@@ -38,29 +39,43 @@ export function AgentPluginDetail({
 	item,
 	runtime,
 	catalogError,
+	desiredStateError,
+	desiredStateRetrying,
 	pendingAction,
 	onBack,
 	onInstall,
 	onRemove,
+	onRetry,
 	onRetryCatalog,
+	onRetryDesired,
 }: {
 	item: AgentPluginInventoryItem;
 	runtime: HostedRuntime;
 	catalogError: unknown | null;
+	desiredStateError: boolean;
+	desiredStateRetrying: boolean;
 	pendingAction: AgentPluginPendingAction;
 	onBack: () => void;
 	onInstall: (item: AgentPluginInventoryItem) => Promise<unknown>;
 	onRemove: (item: AgentPluginInventoryItem) => Promise<unknown>;
+	onRetry: (item: AgentPluginInventoryItem) => Promise<unknown>;
 	onRetryCatalog: () => void;
+	onRetryDesired: () => void;
 }) {
 	const title = pluginDisplayName(item);
 	const status = item.desired ? agentPluginStatusPresentation(item.desired) : null;
 	const installability = item.catalog ? agentPluginInstallability(item.catalog, runtime) : null;
 	const hasUpdate = pluginHasUpdate(item);
+	const installFailed = item.desired?.convergence === "failed";
+	const canRetry = Boolean(installFailed && item.catalog && installability?.installable);
 	const canInstall = Boolean(
-		item.catalog && installability?.installable && (!item.desired || hasUpdate),
+		item.catalog && installability?.installable && !installFailed && (!item.desired || hasUpdate),
 	);
 	const showCompatibilityWarning = Boolean(installability?.reason && (!item.desired || hasUpdate));
+	const version =
+		hasUpdate && item.desired && item.catalog
+			? `v${item.desired.version} → v${item.catalog.version}`
+			: `v${pluginVersion(item)}`;
 
 	return (
 		<div data-hosted="true" data-v2="true" className="space-y-6">
@@ -75,6 +90,24 @@ export function AgentPluginDetail({
 					title="Store details unavailable"
 				/>
 			) : null}
+			{desiredStateError ? (
+				<Alert>
+					<AlertCircle />
+					<AlertTitle>Couldn't load installed plugins</AlertTitle>
+					<AlertDescription>Showing Store details without installed status.</AlertDescription>
+					<AlertAction>
+						<Button
+							size="sm"
+							variant="outline"
+							disabled={desiredStateRetrying}
+							onClick={onRetryDesired}
+						>
+							{desiredStateRetrying ? <Spinner /> : <RefreshCw />}
+							Retry
+						</Button>
+					</AlertAction>
+				</Alert>
+			) : null}
 			<PageHeader
 				title={title}
 				icon={
@@ -86,10 +119,15 @@ export function AgentPluginDetail({
 					item.catalog?.description ?? "This plugin is no longer available in the Store."
 				}
 				titleAdornment={
-					status && item.desired?.convergence === "installed" ? (
-						<StatusBadge status={status.tone} withDot>
-							{status.label}
-						</StatusBadge>
+					(status && item.desired?.convergence === "installed") || hasUpdate ? (
+						<>
+							{status && item.desired?.convergence === "installed" ? (
+								<StatusBadge status={status.tone} withDot>
+									{status.label}
+								</StatusBadge>
+							) : null}
+							{hasUpdate ? <StatusBadge status="info">Update available</StatusBadge> : null}
+						</>
 					) : undefined
 				}
 				status={
@@ -99,10 +137,12 @@ export function AgentPluginDetail({
 					<PluginDetailActions
 						item={item}
 						canInstall={canInstall}
+						canRetry={canRetry}
 						installability={installability}
 						pendingAction={pendingAction}
 						onInstall={onInstall}
 						onRemove={onRemove}
+						onRetry={onRetry}
 					/>
 				}
 			/>
@@ -120,7 +160,7 @@ export function AgentPluginDetail({
 				</Alert>
 			) : null}
 			<DetailStats>
-				<Stat icon={Tag} label={`v${pluginVersion(item)}`} />
+				<Stat icon={Tag} label={version} />
 				{item.catalog ? (
 					<>
 						<Stat
@@ -142,17 +182,21 @@ export function AgentPluginDetail({
 function PluginDetailActions({
 	item,
 	canInstall,
+	canRetry,
 	installability,
 	pendingAction,
 	onInstall,
 	onRemove,
+	onRetry,
 }: {
 	item: AgentPluginInventoryItem;
 	canInstall: boolean;
+	canRetry: boolean;
 	installability: ReturnType<typeof agentPluginInstallability> | null;
 	pendingAction: AgentPluginPendingAction;
 	onInstall: (item: AgentPluginInventoryItem) => Promise<unknown>;
 	onRemove: (item: AgentPluginInventoryItem) => Promise<unknown>;
+	onRetry: (item: AgentPluginInventoryItem) => Promise<unknown>;
 }) {
 	const updating = pluginHasUpdate(item);
 	return (
@@ -176,6 +220,16 @@ function PluginDetailActions({
 			) : !item.desired && installability ? (
 				<Button size="sm" variant="outline" disabled title={installability.reason ?? undefined}>
 					{installability.label}
+				</Button>
+			) : null}
+			{canRetry ? (
+				<Button
+					size="sm"
+					disabled={pendingAction !== null}
+					onClick={() => void onRetry(item).catch(() => undefined)}
+				>
+					{pendingAction === "retry" ? <Spinner /> : <RefreshCw />}
+					{pendingAction === "retry" ? "Retrying…" : "Retry"}
 				</Button>
 			) : null}
 			{item.desired ? (

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-detail.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-detail.tsx
@@ -266,20 +266,21 @@ function PluginDetailsPanel({ entry }: { entry: AgentPluginCatalogEntry | null }
 			</DetailPanel>
 		);
 	}
-	const servers = Object.entries(entry.components.mcpServers).sort(([left], [right]) =>
+	const skills = entry.components.skills;
+	const servers = Object.keys(entry.components.mcpServers).sort((left, right) =>
 		left.localeCompare(right),
 	);
 	return (
 		<DetailPanel className="space-y-4">
 			<PanelHeading />
-			<div className="divide-y">
-				{entry.components.skills.map((skill) => (
-					<ComponentRow key={`skill:${skill}`} icon={BookOpen} label="Skill" name={skill} />
-				))}
-				{servers.map(([name]) => (
-					<ComponentRow key={`mcp:${name}`} icon={Server} label="MCP server" name={name} />
-				))}
-			</div>
+			{skills.length === 0 && servers.length === 0 ? (
+				<p className="text-sm text-muted-foreground">This plugin has no listed components.</p>
+			) : (
+				<>
+					<ComponentGroup icon={BookOpen} label="Skills" names={skills} />
+					<ComponentGroup icon={Server} label="MCP servers" names={servers} />
+				</>
+			)}
 		</DetailPanel>
 	);
 }
@@ -293,21 +294,28 @@ function PanelHeading() {
 	);
 }
 
-function ComponentRow({
+function ComponentGroup({
 	icon: Icon,
 	label,
-	name,
+	names,
 }: {
 	icon: typeof BookOpen;
 	label: string;
-	name: string;
+	names: readonly string[];
 }) {
+	if (names.length === 0) return null;
 	return (
-		<div className="flex min-w-0 items-start gap-3 py-3 first:pt-0 last:pb-0">
-			<Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-			<div className="min-w-0 flex-1">
-				<div className="text-xs text-muted-foreground">{label}</div>
-				<code className="mt-0.5 block break-all text-sm">{name}</code>
+		<div className="space-y-2">
+			<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+				<Icon className="size-3.5" />
+				{label}
+			</div>
+			<div className="grid gap-x-6 gap-y-1.5 sm:grid-cols-2">
+				{names.map((name) => (
+					<code key={name} className="min-w-0 break-all text-sm">
+						{name}
+					</code>
+				))}
 			</div>
 		</div>
 	);

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.test.ts
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.test.ts
@@ -3,6 +3,7 @@ import type { AgentPluginCatalogEntry, AgentPluginDesiredState } from "./agent-p
 import {
 	agentPluginInstallability,
 	agentPluginStatusPresentation,
+	assignAgentPluginGroups,
 	buildAgentPluginInventory,
 	pluginHasUpdate,
 } from "./agent-plugin-model";
@@ -57,6 +58,26 @@ describe("Agent Plugin model", () => {
 		expect(inventory.map((item) => item.name)).toEqual(["cetus", "legacy", "sui"]);
 		expect(inventory[1]?.catalog).toBeNull();
 		expect(pluginHasUpdate(inventory[2])).toBe(true);
+	});
+
+	test("keeps each plugin in its first observed group", () => {
+		const initialInventory = buildAgentPluginInventory(
+			[catalogEntry("cetus"), catalogEntry("sui")],
+			[desired("sui")],
+		);
+		const initial = assignAgentPluginGroups(new Map(), initialInventory);
+		const changedInventory = buildAgentPluginInventory(
+			[catalogEntry("cetus"), catalogEntry("move"), catalogEntry("sui")],
+			[desired("cetus"), desired("move")],
+		);
+		const changed = assignAgentPluginGroups(initial, changedInventory);
+
+		expect(Object.fromEntries(initial)).toEqual({ cetus: "available", sui: "installed" });
+		expect(Object.fromEntries(changed)).toEqual({
+			cetus: "available",
+			move: "installed",
+			sui: "installed",
+		});
 	});
 
 	test("maps the three observed convergence states without mutation-only states", () => {

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.ts
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.ts
@@ -11,6 +11,8 @@ export type AgentPluginInventoryItem = {
 	desired: AgentPluginDesiredState | null;
 };
 
+export type AgentPluginGroup = "installed" | "available";
+
 export type AgentPluginInstallability = {
 	installable: boolean;
 	label: string;
@@ -32,6 +34,19 @@ export function buildAgentPluginInventory(
 			desired: desiredByName.get(name) ?? null,
 		}))
 		.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function assignAgentPluginGroups(
+	previous: ReadonlyMap<string, AgentPluginGroup>,
+	inventory: readonly AgentPluginInventoryItem[],
+): Map<string, AgentPluginGroup> {
+	const next = new Map(previous);
+	for (const item of inventory) {
+		if (!next.has(item.name)) {
+			next.set(item.name, item.desired ? "installed" : "available");
+		}
+	}
+	return next;
 }
 
 export function pluginDisplayName(item: AgentPluginInventoryItem): string {

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "@tanstack/react-router";
+import { useLocation, useRouter } from "@tanstack/react-router";
 import { AlertCircle, Blocks, RefreshCw } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -18,7 +18,7 @@ import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/search-input";
 import { Spinner } from "@/components/ui/spinner";
 import type { HostedRuntime } from "@/hosted/runtimes";
-import type { AgentRouteSearch } from "@/lib/agent-routes";
+import { agentPluginDetailHref, agentSectionHref, parseAgentPathname } from "@/lib/agent-routes";
 import { useOpenApi } from "@/lib/api";
 import { normalizeApiError } from "@/lib/api-errors";
 import { shouldBlockQueryError } from "@/lib/query-state";
@@ -44,15 +44,15 @@ type PendingPluginMutation = {
 export function AgentPluginsSurface({
 	agentId,
 	runtime,
-	routeSearch,
 }: {
 	agentId: string;
 	runtime: HostedRuntime;
-	routeSearch: AgentRouteSearch;
 }) {
 	const api = useOpenApi();
 	const queryClient = useQueryClient();
 	const router = useRouter();
+	const pathname = useLocation({ select: (location) => location.pathname });
+	const selectedPlugin = parseAgentPathname(pathname)?.pluginName ?? null;
 	const mutationLock = useRef(false);
 	const [pending, setPending] = useState<PendingPluginMutation>(null);
 	const [query, setQuery] = useState("");
@@ -94,23 +94,15 @@ export function AgentPluginsSurface({
 	);
 
 	const refreshDesired = () => queryClient.invalidateQueries({ queryKey: DESIRED_QUERY_KEY });
-	const navigateToPlugin = (plugin: string | undefined, replace = false) =>
-		router.navigate({
-			to: ".",
-			search: (current) => {
-				const next = { ...current };
-				if (plugin) next.plugin = plugin;
-				else delete next.plugin;
-				return next;
-			},
-			replace,
-			resetScroll: false,
-		});
 	const openPlugin = (name: string) => {
-		void navigateToPlugin(name).catch(() => toast.error("Couldn't open plugin details"));
+		void router
+			.navigate({ href: agentPluginDetailHref(agentId, name), resetScroll: false })
+			.catch(() => toast.error("Couldn't open plugin details"));
 	};
 	const closePlugin = () => {
-		void navigateToPlugin(undefined, true).catch(() => toast.error("Couldn't return to plugins"));
+		void router
+			.navigate({ href: agentSectionHref(agentId, "plugins"), replace: true, resetScroll: false })
+			.catch(() => toast.error("Couldn't return to plugins"));
 	};
 	const install = async (item: AgentPluginInventoryItem) => {
 		if (!item.catalog || mutationLock.current) return;
@@ -144,7 +136,7 @@ export function AgentPluginsSurface({
 			});
 			await refreshDesired();
 			toast.success("Plugin removal started");
-			if (routeSearch.plugin === item.name) closePlugin();
+			if (selectedPlugin === item.name) closePlugin();
 		} catch (error) {
 			toast.error("Couldn't remove plugin", { description: normalizeApiError(error) });
 			throw error;
@@ -208,8 +200,8 @@ export function AgentPluginsSurface({
 		);
 	}
 	const selectedItem =
-		!initialLoading && routeSearch.plugin
-			? inventory.find((item) => item.name === routeSearch.plugin)
+		!initialLoading && selectedPlugin
+			? inventory.find((item) => item.name === selectedPlugin)
 			: null;
 	const categories = useMemo(
 		() =>

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
@@ -3,7 +3,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import { AlertCircle, Blocks, RefreshCw } from "lucide-react";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EmptyState } from "@/components/empty-state";
@@ -63,6 +63,13 @@ export function AgentPluginsSurface({
 	}>({ agentId, assignments: new Map() });
 	if (groupState.current.agentId !== agentId) {
 		groupState.current = { agentId, assignments: new Map() };
+	}
+	const convergenceLog = useRef<{ agentId: string; seen: Map<string, string> }>({
+		agentId,
+		seen: new Map(),
+	});
+	if (convergenceLog.current.agentId !== agentId) {
+		convergenceLog.current = { agentId, seen: new Map() };
 	}
 	const catalogQuery = api.useQuery("get", "/v1/plugin-catalog", {});
 	const desiredQuery = api.useQuery(
@@ -214,6 +221,32 @@ export function AgentPluginsSurface({
 		[catalogQuery.data?.plugins],
 	);
 	const selectedCategory = category === "all" || categories.includes(category) ? category : "all";
+
+	useEffect(() => {
+		const plugins = desiredQuery.data?.plugins;
+		if (!plugins) return;
+		const seen = convergenceLog.current.seen;
+		const live = new Set<string>();
+		for (const plugin of plugins) {
+			live.add(plugin.installation_id);
+			const previous = seen.get(plugin.installation_id);
+			seen.set(plugin.installation_id, plugin.convergence);
+			if (previous !== "not_observed" || plugin.convergence === "not_observed") continue;
+			const title =
+				catalogQuery.data?.plugins.find((entry) => entry.name === plugin.plugin_name)
+					?.display_name ?? plugin.plugin_name;
+			if (plugin.convergence === "installed") {
+				toast.success(`${title} is ready to use`);
+			} else {
+				toast.error(`${title} installation failed`, {
+					description: "Open the plugin to retry or remove it.",
+				});
+			}
+		}
+		for (const id of seen.keys()) {
+			if (!live.has(id)) seen.delete(id);
+		}
+	}, [desiredQuery.data, catalogQuery.data]);
 
 	return (
 		<div data-hosted="true" data-v2="true" className="space-y-6">

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
@@ -180,7 +180,9 @@ export function AgentPluginsSurface({
 	const catalogError = shouldBlockQueryError(catalogQuery.error, catalogQuery.data)
 		? catalogQuery.error
 		: null;
-	const desiredError = desiredQuery.error ?? null;
+	const desiredError = shouldBlockQueryError(desiredQuery.error, desiredQuery.data)
+		? desiredQuery.error
+		: null;
 	const inventory = useMemo(
 		() =>
 			buildAgentPluginInventory(

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
@@ -1,25 +1,35 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { Blocks } from "lucide-react";
+import { useRouter } from "@tanstack/react-router";
+import { AlertCircle, Blocks, RefreshCw } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EmptyState } from "@/components/empty-state";
 import { HERO_GRID_CLASS, HeroCardSkeleton } from "@/components/entity-card";
+import { FilterChip } from "@/components/filter-chip";
 import { IconChip } from "@/components/icon-chip";
 import { ListToolbar } from "@/components/list-toolbar";
 import { PageHeader } from "@/components/page-header";
+import { SectionLabel } from "@/components/section-label";
+import { Alert, AlertAction, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/search-input";
+import { Spinner } from "@/components/ui/spinner";
 import type { HostedRuntime } from "@/hosted/runtimes";
+import type { AgentRouteSearch } from "@/lib/agent-routes";
 import { useOpenApi } from "@/lib/api";
 import { normalizeApiError } from "@/lib/api-errors";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import { AgentPluginCard, type AgentPluginPendingAction } from "./agent-plugin-card";
 import { AgentPluginDetail } from "./agent-plugin-detail";
 import {
+	type AgentPluginGroup,
 	type AgentPluginInventoryItem,
+	agentPluginInstallability,
 	agentPluginMatches,
+	assignAgentPluginGroups,
 	buildAgentPluginInventory,
 	pluginHasUpdate,
 } from "./agent-plugin-model";
@@ -34,16 +44,26 @@ type PendingPluginMutation = {
 export function AgentPluginsSurface({
 	agentId,
 	runtime,
+	routeSearch,
 }: {
 	agentId: string;
 	runtime: HostedRuntime;
+	routeSearch: AgentRouteSearch;
 }) {
 	const api = useOpenApi();
 	const queryClient = useQueryClient();
+	const router = useRouter();
 	const mutationLock = useRef(false);
 	const [pending, setPending] = useState<PendingPluginMutation>(null);
-	const [selectedName, setSelectedName] = useState<string | null>(null);
 	const [query, setQuery] = useState("");
+	const [category, setCategory] = useState("all");
+	const groupState = useRef<{
+		agentId: string;
+		assignments: ReadonlyMap<string, AgentPluginGroup>;
+	}>({ agentId, assignments: new Map() });
+	if (groupState.current.agentId !== agentId) {
+		groupState.current = { agentId, assignments: new Map() };
+	}
 	const catalogQuery = api.useQuery("get", "/v1/plugin-catalog", {});
 	const desiredQuery = api.useQuery(
 		"get",
@@ -67,6 +87,24 @@ export function AgentPluginsSurface({
 	);
 
 	const refreshDesired = () => queryClient.invalidateQueries({ queryKey: DESIRED_QUERY_KEY });
+	const navigateToPlugin = (plugin: string | undefined, replace = false) =>
+		router.navigate({
+			to: ".",
+			search: (current) => {
+				const next = { ...current };
+				if (plugin) next.plugin = plugin;
+				else delete next.plugin;
+				return next;
+			},
+			replace,
+			resetScroll: false,
+		});
+	const openPlugin = (name: string) => {
+		void navigateToPlugin(name).catch(() => toast.error("Couldn't open plugin details"));
+	};
+	const closePlugin = () => {
+		void navigateToPlugin(undefined, true).catch(() => toast.error("Couldn't return to plugins"));
+	};
 	const install = async (item: AgentPluginInventoryItem) => {
 		if (!item.catalog || mutationLock.current) return;
 		mutationLock.current = true;
@@ -98,10 +136,40 @@ export function AgentPluginsSurface({
 				params: { path: { agent_id: agentId, plugin_name: item.name } },
 			});
 			await refreshDesired();
-			setSelectedName(null);
 			toast.success("Plugin removal started");
+			if (routeSearch.plugin === item.name) closePlugin();
 		} catch (error) {
 			toast.error("Couldn't remove plugin", { description: normalizeApiError(error) });
+			throw error;
+		} finally {
+			mutationLock.current = false;
+			setPending(null);
+		}
+	};
+	const retry = async (item: AgentPluginInventoryItem) => {
+		if (
+			!item.catalog ||
+			item.desired?.convergence !== "failed" ||
+			!agentPluginInstallability(item.catalog, runtime).installable ||
+			mutationLock.current
+		) {
+			return;
+		}
+		mutationLock.current = true;
+		setPending({ name: item.name, action: "retry" });
+		try {
+			await removeMutation.mutateAsync({
+				params: { path: { agent_id: agentId, plugin_name: item.name } },
+			});
+			await installMutation.mutateAsync({
+				params: { path: { agent_id: agentId, plugin_name: item.name } },
+				body: { version: item.catalog.version },
+			});
+			await refreshDesired();
+			toast.success("Plugin retry started");
+		} catch (error) {
+			toast.error("Couldn't retry plugin", { description: normalizeApiError(error) });
+			void refreshDesired();
 			throw error;
 		} finally {
 			mutationLock.current = false;
@@ -112,18 +180,38 @@ export function AgentPluginsSurface({
 	const catalogError = shouldBlockQueryError(catalogQuery.error, catalogQuery.data)
 		? catalogQuery.error
 		: null;
-	const desiredError = shouldBlockQueryError(desiredQuery.error, desiredQuery.data)
-		? desiredQuery.error
-		: null;
+	const desiredError = desiredQuery.error ?? null;
 	const inventory = useMemo(
 		() =>
-			buildAgentPluginInventory(catalogQuery.data?.plugins ?? [], desiredQuery.data?.plugins ?? []),
-		[catalogQuery.data?.plugins, desiredQuery.data?.plugins],
+			buildAgentPluginInventory(
+				catalogQuery.data?.plugins ?? [],
+				desiredError ? [] : (desiredQuery.data?.plugins ?? []),
+			),
+		[catalogQuery.data?.plugins, desiredError, desiredQuery.data?.plugins],
 	);
-	const selectedItem = selectedName ? inventory.find((item) => item.name === selectedName) : null;
 	const initialLoading =
 		(desiredQuery.data === undefined && !desiredError) ||
 		(catalogQuery.data === undefined && !catalogError);
+	if (!initialLoading) {
+		groupState.current.assignments = assignAgentPluginGroups(
+			groupState.current.assignments,
+			inventory,
+		);
+	}
+	const selectedItem =
+		!initialLoading && routeSearch.plugin
+			? inventory.find((item) => item.name === routeSearch.plugin)
+			: null;
+	const categories = useMemo(
+		() =>
+			[
+				...new Set(
+					(catalogQuery.data?.plugins ?? []).map((entry) => entry.category).filter(Boolean),
+				),
+			].sort((left, right) => left.localeCompare(right)),
+		[catalogQuery.data?.plugins],
+	);
+	const selectedCategory = category === "all" || categories.includes(category) ? category : "all";
 
 	return (
 		<div data-hosted="true" data-v2="true" className="space-y-6">
@@ -133,10 +221,14 @@ export function AgentPluginsSurface({
 					runtime={runtime}
 					catalogError={catalogError}
 					pendingAction={pending?.name === selectedItem.name ? pending.action : null}
-					onBack={() => setSelectedName(null)}
+					desiredStateError={desiredError !== null}
+					desiredStateRetrying={desiredQuery.isFetching}
+					onBack={closePlugin}
 					onInstall={install}
 					onRemove={remove}
+					onRetry={retry}
 					onRetryCatalog={() => void catalogQuery.refetch()}
+					onRetryDesired={() => void desiredQuery.refetch()}
 				/>
 			) : (
 				<>
@@ -149,26 +241,28 @@ export function AgentPluginsSurface({
 							</IconChip>
 						}
 					/>
-					{desiredError ? (
-						<ApiErrorPanel
-							error={desiredError}
-							onRetry={() => void desiredQuery.refetch()}
-							title="Couldn't load installed plugins"
-						/>
-					) : initialLoading ? (
+					{initialLoading ? (
 						<AgentPluginGridSkeleton />
 					) : (
 						<AgentPluginCatalog
 							inventory={inventory}
 							runtime={runtime}
 							catalogError={catalogError}
+							desiredError={desiredError}
+							desiredRetrying={desiredQuery.isFetching}
 							pending={pending}
 							query={query}
+							categories={categories}
+							category={selectedCategory}
+							groupAssignments={groupState.current.assignments}
 							onQueryChange={setQuery}
-							onOpen={setSelectedName}
+							onCategoryChange={setCategory}
+							onOpen={openPlugin}
 							onInstall={install}
 							onRemove={remove}
+							onRetry={retry}
 							onRetryCatalog={() => void catalogQuery.refetch()}
+							onRetryDesired={() => void desiredQuery.refetch()}
 						/>
 					)}
 				</>
@@ -181,27 +275,59 @@ function AgentPluginCatalog({
 	inventory,
 	runtime,
 	catalogError,
+	desiredError,
+	desiredRetrying,
 	pending,
 	query,
+	categories,
+	category,
+	groupAssignments,
 	onQueryChange,
+	onCategoryChange,
 	onOpen,
 	onInstall,
 	onRemove,
+	onRetry,
 	onRetryCatalog,
+	onRetryDesired,
 }: {
 	inventory: AgentPluginInventoryItem[];
 	runtime: HostedRuntime;
 	catalogError: unknown | null;
+	desiredError: unknown | null;
+	desiredRetrying: boolean;
 	pending: PendingPluginMutation;
 	query: string;
+	categories: string[];
+	category: string;
+	groupAssignments: ReadonlyMap<string, AgentPluginGroup>;
 	onQueryChange: (query: string) => void;
+	onCategoryChange: (category: string) => void;
 	onOpen: (name: string) => void;
 	onInstall: (item: AgentPluginInventoryItem) => Promise<unknown>;
 	onRemove: (item: AgentPluginInventoryItem) => Promise<unknown>;
+	onRetry: (item: AgentPluginInventoryItem) => Promise<unknown>;
 	onRetryCatalog: () => void;
+	onRetryDesired: () => void;
 }) {
-	const items = inventory.filter((item) => agentPluginMatches(item, query));
-	const noMatches = Boolean(query.trim()) && items.length === 0;
+	const items = inventory.filter(
+		(item) =>
+			(category === "all" || item.catalog?.category === category) &&
+			agentPluginMatches(item, query),
+	);
+	const groups = [
+		{
+			id: "installed" as const,
+			label: "Installed",
+			items: items.filter((item) => groupAssignments.get(item.name) === "installed"),
+		},
+		{
+			id: "available" as const,
+			label: "Available",
+			items: items.filter((item) => groupAssignments.get(item.name) === "available"),
+		},
+	];
+	const noMatches = (Boolean(query.trim()) || category !== "all") && items.length === 0;
 
 	if (inventory.length === 0) {
 		return catalogError ? (
@@ -209,6 +335,12 @@ function AgentPluginCatalog({
 				error={catalogError}
 				onRetry={onRetryCatalog}
 				title="Couldn't load available plugins"
+			/>
+		) : desiredError ? (
+			<ApiErrorPanel
+				error={desiredError}
+				onRetry={onRetryDesired}
+				title="Couldn't load installed plugins"
 			/>
 		) : (
 			<EmptyState icon={Blocks} title="No plugins available" />
@@ -226,7 +358,30 @@ function AgentPluginCatalog({
 						ariaLabel="Search plugins"
 					/>
 				}
+				filters={
+					<>
+						<FilterChip active={category === "all"} onClick={() => onCategoryChange("all")}>
+							All
+							<span className="text-muted-foreground tabular-nums">{inventory.length}</span>
+						</FilterChip>
+						{categories.map((value) => (
+							<FilterChip
+								key={value}
+								active={category === value}
+								onClick={() => onCategoryChange(value)}
+							>
+								{value}
+								<span className="text-muted-foreground tabular-nums">
+									{inventory.filter((item) => item.catalog?.category === value).length}
+								</span>
+							</FilterChip>
+						))}
+					</>
+				}
 			/>
+			{desiredError ? (
+				<DesiredStateErrorAlert isRetrying={desiredRetrying} onRetry={onRetryDesired} />
+			) : null}
 			{catalogError ? (
 				<ApiErrorPanel
 					error={catalogError}
@@ -234,30 +389,58 @@ function AgentPluginCatalog({
 					title="Couldn't load available plugins"
 				/>
 			) : null}
-			{items.length > 0 ? (
-				<div className={HERO_GRID_CLASS}>
-					{items.map((item) => (
-						<AgentPluginCard
-							key={item.name}
-							item={item}
-							runtime={runtime}
-							pendingAction={pending?.name === item.name ? pending.action : null}
-							mutationsBlocked={pending !== null}
-							onOpen={onOpen}
-							onInstall={onInstall}
-							onRemove={onRemove}
-						/>
-					))}
-				</div>
-			) : null}
+			{groups.map((group) =>
+				group.items.length > 0 ? (
+					<section key={group.id} className="space-y-3">
+						<SectionLabel count={group.items.length}>{group.label}</SectionLabel>
+						<div className={HERO_GRID_CLASS}>
+							{group.items.map((item) => (
+								<AgentPluginCard
+									key={item.name}
+									item={item}
+									runtime={runtime}
+									pendingAction={pending?.name === item.name ? pending.action : null}
+									mutationsBlocked={pending !== null}
+									onOpen={onOpen}
+									onInstall={onInstall}
+									onRemove={onRemove}
+									onRetry={onRetry}
+								/>
+							))}
+						</div>
+					</section>
+				) : null,
+			)}
 			{noMatches ? (
 				<EmptyState
 					variant="inset"
 					title="No plugins found"
-					description="Try a different search."
+					description="Try a different search or category."
 				/>
 			) : null}
 		</div>
+	);
+}
+
+function DesiredStateErrorAlert({
+	isRetrying,
+	onRetry,
+}: {
+	isRetrying: boolean;
+	onRetry: () => void;
+}) {
+	return (
+		<Alert>
+			<AlertCircle />
+			<AlertTitle>Couldn't load installed plugins</AlertTitle>
+			<AlertDescription>Showing Store plugins without installed status.</AlertDescription>
+			<AlertAction>
+				<Button size="sm" variant="outline" disabled={isRetrying} onClick={onRetry}>
+					{isRetrying ? <Spinner /> : <RefreshCw />}
+					Retry
+				</Button>
+			</AlertAction>
+		</Alert>
 	);
 }
 

--- a/apps/web/src/lib/agent-routes.test.ts
+++ b/apps/web/src/lib/agent-routes.test.ts
@@ -142,6 +142,7 @@ describe("agent routes", () => {
 		expect(
 			agentRouteOwnsSection("/agents/agent-1/connectors/github", "agent-1", "connectors"),
 		).toBe(false);
+		expect(agentRouteOwnsSection("/agents/agent-1/plugins/sui", "agent-1", "plugins")).toBe(false);
 		expect(agentRouteOwnsSection("/agents/agent-1/skills", "agent-1", "overview")).toBe(false);
 	});
 
@@ -253,13 +254,11 @@ describe("agent routes", () => {
 				tab: "sessions",
 				project: "project 1",
 				vault: 42,
-				plugin: "sui",
 				future: "kept",
 			}),
 		).toEqual({
 			tab: "sessions",
 			project: "project 1",
-			plugin: "sui",
 			future: "kept",
 		});
 	});
@@ -327,6 +326,13 @@ describe("agent routes", () => {
 			sessionId: undefined,
 			skillKey: undefined,
 			connectorName: "google drive",
+		});
+		expect(parseAgentPathname("/agents/agent%201/plugins/sui%20agent")).toEqual({
+			agentId: "agent 1",
+			section: "plugins",
+			sessionId: undefined,
+			skillKey: undefined,
+			pluginName: "sui agent",
 		});
 		expect(parseAgentPathname("/agents/agent%201/vaults")).toEqual({
 			agentId: "agent 1",

--- a/apps/web/src/lib/agent-routes.test.ts
+++ b/apps/web/src/lib/agent-routes.test.ts
@@ -253,11 +253,13 @@ describe("agent routes", () => {
 				tab: "sessions",
 				project: "project 1",
 				vault: 42,
+				plugin: "sui",
 				future: "kept",
 			}),
 		).toEqual({
 			tab: "sessions",
 			project: "project 1",
+			plugin: "sui",
 			future: "kept",
 		});
 	});

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -9,7 +9,6 @@ export type AgentRouteSearch = Record<string, unknown> & {
 	tab?: string;
 	project?: string;
 	vault?: string;
-	plugin?: string;
 	subscription_action?: "start_new";
 };
 
@@ -46,6 +45,7 @@ export type ParsedAgentPathname = {
 	vaultSlug?: string;
 	memoryId?: string;
 	connectorName?: string;
+	pluginName?: string;
 };
 
 export type AgentProjectResourceSection = "skills" | "vaults";
@@ -81,11 +81,14 @@ export function parseAgentPathname(pathname: string): ParsedAgentPathname | null
 	if (section === "sessions" && parts.length > 4) return null;
 	if (
 		section !== "overview" &&
-		!["sessions", "skills", "projects", "vaults", "memories", "connectors"].includes(section)
+		!["sessions", "skills", "projects", "vaults", "memories", "connectors", "plugins"].includes(
+			section,
+		)
 	) {
 		if (parts.length !== 3) return null;
 	}
-	if (["vaults", "memories", "connectors"].includes(section) && parts.length > 4) return null;
+	if (["vaults", "memories", "connectors", "plugins"].includes(section) && parts.length > 4)
+		return null;
 	if (section === "projects" && parts.length > 5) return null;
 	const sessionId =
 		section === "sessions" && parts[3] ? safeDecodeURIComponent(parts[3]) : undefined;
@@ -105,6 +108,8 @@ export function parseAgentPathname(pathname: string): ParsedAgentPathname | null
 		section === "memories" && parts[3] ? safeDecodeURIComponent(parts[3]) : undefined;
 	const connectorName =
 		section === "connectors" && parts[3] ? safeDecodeURIComponent(parts[3]) : undefined;
+	const pluginName =
+		section === "plugins" && parts[3] ? safeDecodeURIComponent(parts[3]) : undefined;
 	return {
 		agentId,
 		section,
@@ -115,6 +120,7 @@ export function parseAgentPathname(pathname: string): ParsedAgentPathname | null
 		...(vaultSlug ? { vaultSlug } : {}),
 		...(memoryId ? { memoryId } : {}),
 		...(connectorName ? { connectorName } : {}),
+		...(pluginName ? { pluginName } : {}),
 	};
 }
 
@@ -147,7 +153,8 @@ export function agentRouteOwnsSection(
 		!route.projectResource &&
 		!route.vaultSlug &&
 		!route.memoryId &&
-		!route.connectorName
+		!route.connectorName &&
+		!route.pluginName
 	);
 }
 
@@ -162,7 +169,7 @@ function subscriptionAction(value: unknown): AgentRouteSearch["subscription_acti
 /** Validate the shared agent-route search boundary while retaining additive query state. */
 export function validateAgentRouteSearch(search: Record<string, unknown>): AgentRouteSearch {
 	const validated: AgentRouteSearch = { ...search };
-	for (const key of ["tab", "project", "vault", "plugin"] as const) {
+	for (const key of ["tab", "project", "vault"] as const) {
 		const value = optionalSearchString(search[key]);
 		if (value === undefined) delete validated[key];
 		else validated[key] = value;
@@ -374,6 +381,18 @@ export function agentConnectorDetailLink(agentId: string, connectorName: string)
 	return linkOptions({
 		to: "/agents/$id/connectors/$name",
 		params: { id: agentId, name: connectorName },
+	});
+}
+
+export function agentPluginDetailHref(agentId: string, pluginName: string): string {
+	return `${agentSectionHref(agentId, "plugins")}/${encodeURIComponent(pluginName)}`;
+}
+
+/** Typed TanStack Router options for a Plugin viewed in the Agent shell. */
+export function agentPluginDetailLink(agentId: string, pluginName: string) {
+	return linkOptions({
+		to: "/agents/$id/plugins/$pluginName",
+		params: { id: agentId, pluginName },
 	});
 }
 

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -9,6 +9,7 @@ export type AgentRouteSearch = Record<string, unknown> & {
 	tab?: string;
 	project?: string;
 	vault?: string;
+	plugin?: string;
 	subscription_action?: "start_new";
 };
 
@@ -161,7 +162,7 @@ function subscriptionAction(value: unknown): AgentRouteSearch["subscription_acti
 /** Validate the shared agent-route search boundary while retaining additive query state. */
 export function validateAgentRouteSearch(search: Record<string, unknown>): AgentRouteSearch {
 	const validated: AgentRouteSearch = { ...search };
-	for (const key of ["tab", "project", "vault"] as const) {
+	for (const key of ["tab", "project", "vault", "plugin"] as const) {
 		const value = optionalSearchString(search[key]);
 		if (value === undefined) delete validated[key];
 		else validated[key] = value;

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -46,6 +46,7 @@ import { Route as ProtectedDashboardAgentsIdIndexRouteImport } from './routes/_p
 import { Route as ProtectedDashboardAgentsIdSectionRouteImport } from './routes/_protected/_dashboard/agents/$id/$section'
 import { Route as ProtectedDashboardAgentsIdConnectorsNameRouteImport } from './routes/_protected/_dashboard/agents/$id/connectors/$name'
 import { Route as ProtectedDashboardAgentsIdMemoriesMemoryIdRouteImport } from './routes/_protected/_dashboard/agents/$id/memories/$memoryId'
+import { Route as ProtectedDashboardAgentsIdPluginsPluginNameRouteImport } from './routes/_protected/_dashboard/agents/$id/plugins/$pluginName'
 import { Route as ProtectedDashboardAgentsIdProjectAccessProjectIdRouteImport } from './routes/_protected/_dashboard/agents/$id/project-access/$projectId'
 import { Route as ProtectedDashboardAgentsIdSessionsSessionIdRouteImport } from './routes/_protected/_dashboard/agents/$id/sessions/$sessionId'
 import { Route as ProtectedDashboardAgentsIdSkillsIndexRouteImport } from './routes/_protected/_dashboard/agents/$id/skills/index'
@@ -264,6 +265,12 @@ const ProtectedDashboardAgentsIdMemoriesMemoryIdRoute =
     path: '/memories/$memoryId',
     getParentRoute: () => ProtectedDashboardAgentsIdRoute,
   } as any)
+const ProtectedDashboardAgentsIdPluginsPluginNameRoute =
+  ProtectedDashboardAgentsIdPluginsPluginNameRouteImport.update({
+    id: '/plugins/$pluginName',
+    path: '/plugins/$pluginName',
+    getParentRoute: () => ProtectedDashboardAgentsIdRoute,
+  } as any)
 const ProtectedDashboardAgentsIdProjectAccessProjectIdRoute =
   ProtectedDashboardAgentsIdProjectAccessProjectIdRouteImport.update({
     id: '/project-access/$projectId',
@@ -349,6 +356,7 @@ export interface FileRoutesByFullPath {
   '/agents/$id/': typeof ProtectedDashboardAgentsIdIndexRoute
   '/agents/$id/connectors/$name': typeof ProtectedDashboardAgentsIdConnectorsNameRoute
   '/agents/$id/memories/$memoryId': typeof ProtectedDashboardAgentsIdMemoriesMemoryIdRoute
+  '/agents/$id/plugins/$pluginName': typeof ProtectedDashboardAgentsIdPluginsPluginNameRoute
   '/agents/$id/project-access/$projectId': typeof ProtectedDashboardAgentsIdProjectAccessProjectIdRouteWithChildren
   '/agents/$id/sessions/$sessionId': typeof ProtectedDashboardAgentsIdSessionsSessionIdRoute
   '/agents/$id/skills/$': typeof ProtectedDashboardAgentsIdSkillsSplatRoute
@@ -393,6 +401,7 @@ export interface FileRoutesByTo {
   '/agents/$id': typeof ProtectedDashboardAgentsIdIndexRoute
   '/agents/$id/connectors/$name': typeof ProtectedDashboardAgentsIdConnectorsNameRoute
   '/agents/$id/memories/$memoryId': typeof ProtectedDashboardAgentsIdMemoriesMemoryIdRoute
+  '/agents/$id/plugins/$pluginName': typeof ProtectedDashboardAgentsIdPluginsPluginNameRoute
   '/agents/$id/sessions/$sessionId': typeof ProtectedDashboardAgentsIdSessionsSessionIdRoute
   '/agents/$id/skills/$': typeof ProtectedDashboardAgentsIdSkillsSplatRoute
   '/agents/$id/vaults/$slug': typeof ProtectedDashboardAgentsIdVaultsSlugRoute
@@ -440,6 +449,7 @@ export interface FileRoutesById {
   '/_protected/_dashboard/agents/$id/': typeof ProtectedDashboardAgentsIdIndexRoute
   '/_protected/_dashboard/agents/$id/connectors/$name': typeof ProtectedDashboardAgentsIdConnectorsNameRoute
   '/_protected/_dashboard/agents/$id/memories/$memoryId': typeof ProtectedDashboardAgentsIdMemoriesMemoryIdRoute
+  '/_protected/_dashboard/agents/$id/plugins/$pluginName': typeof ProtectedDashboardAgentsIdPluginsPluginNameRoute
   '/_protected/_dashboard/agents/$id/project-access/$projectId': typeof ProtectedDashboardAgentsIdProjectAccessProjectIdRouteWithChildren
   '/_protected/_dashboard/agents/$id/sessions/$sessionId': typeof ProtectedDashboardAgentsIdSessionsSessionIdRoute
   '/_protected/_dashboard/agents/$id/skills/$': typeof ProtectedDashboardAgentsIdSkillsSplatRoute
@@ -487,6 +497,7 @@ export interface FileRouteTypes {
     | '/agents/$id/'
     | '/agents/$id/connectors/$name'
     | '/agents/$id/memories/$memoryId'
+    | '/agents/$id/plugins/$pluginName'
     | '/agents/$id/project-access/$projectId'
     | '/agents/$id/sessions/$sessionId'
     | '/agents/$id/skills/$'
@@ -531,6 +542,7 @@ export interface FileRouteTypes {
     | '/agents/$id'
     | '/agents/$id/connectors/$name'
     | '/agents/$id/memories/$memoryId'
+    | '/agents/$id/plugins/$pluginName'
     | '/agents/$id/sessions/$sessionId'
     | '/agents/$id/skills/$'
     | '/agents/$id/vaults/$slug'
@@ -577,6 +589,7 @@ export interface FileRouteTypes {
     | '/_protected/_dashboard/agents/$id/'
     | '/_protected/_dashboard/agents/$id/connectors/$name'
     | '/_protected/_dashboard/agents/$id/memories/$memoryId'
+    | '/_protected/_dashboard/agents/$id/plugins/$pluginName'
     | '/_protected/_dashboard/agents/$id/project-access/$projectId'
     | '/_protected/_dashboard/agents/$id/sessions/$sessionId'
     | '/_protected/_dashboard/agents/$id/skills/$'
@@ -858,6 +871,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProtectedDashboardAgentsIdMemoriesMemoryIdRouteImport
       parentRoute: typeof ProtectedDashboardAgentsIdRoute
     }
+    '/_protected/_dashboard/agents/$id/plugins/$pluginName': {
+      id: '/_protected/_dashboard/agents/$id/plugins/$pluginName'
+      path: '/plugins/$pluginName'
+      fullPath: '/agents/$id/plugins/$pluginName'
+      preLoaderRoute: typeof ProtectedDashboardAgentsIdPluginsPluginNameRouteImport
+      parentRoute: typeof ProtectedDashboardAgentsIdRoute
+    }
     '/_protected/_dashboard/agents/$id/project-access/$projectId': {
       id: '/_protected/_dashboard/agents/$id/project-access/$projectId'
       path: '/project-access/$projectId'
@@ -943,6 +963,7 @@ interface ProtectedDashboardAgentsIdRouteChildren {
   ProtectedDashboardAgentsIdIndexRoute: typeof ProtectedDashboardAgentsIdIndexRoute
   ProtectedDashboardAgentsIdConnectorsNameRoute: typeof ProtectedDashboardAgentsIdConnectorsNameRoute
   ProtectedDashboardAgentsIdMemoriesMemoryIdRoute: typeof ProtectedDashboardAgentsIdMemoriesMemoryIdRoute
+  ProtectedDashboardAgentsIdPluginsPluginNameRoute: typeof ProtectedDashboardAgentsIdPluginsPluginNameRoute
   ProtectedDashboardAgentsIdProjectAccessProjectIdRoute: typeof ProtectedDashboardAgentsIdProjectAccessProjectIdRouteWithChildren
   ProtectedDashboardAgentsIdSessionsSessionIdRoute: typeof ProtectedDashboardAgentsIdSessionsSessionIdRoute
   ProtectedDashboardAgentsIdSkillsSplatRoute: typeof ProtectedDashboardAgentsIdSkillsSplatRoute
@@ -959,6 +980,8 @@ const ProtectedDashboardAgentsIdRouteChildren: ProtectedDashboardAgentsIdRouteCh
       ProtectedDashboardAgentsIdConnectorsNameRoute,
     ProtectedDashboardAgentsIdMemoriesMemoryIdRoute:
       ProtectedDashboardAgentsIdMemoriesMemoryIdRoute,
+    ProtectedDashboardAgentsIdPluginsPluginNameRoute:
+      ProtectedDashboardAgentsIdPluginsPluginNameRoute,
     ProtectedDashboardAgentsIdProjectAccessProjectIdRoute:
       ProtectedDashboardAgentsIdProjectAccessProjectIdRouteWithChildren,
     ProtectedDashboardAgentsIdSessionsSessionIdRoute:

--- a/apps/web/src/routes/_protected/_dashboard/agents/$id/plugins/$pluginName.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/agents/$id/plugins/$pluginName.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { agentSectionLink } from "@/lib/agent-routes";
+import { routeHeadTitle } from "@/lib/document-title";
+import { AgentDetailClient } from "@/pages/dashboard/agents/agent-detail-client";
+
+const IS_HOSTED_BUILD = import.meta.env.VITE_CLAWDI_HOSTED === "true";
+
+export const Route = createFileRoute("/_protected/_dashboard/agents/$id/plugins/$pluginName")({
+	beforeLoad: ({ params }) => {
+		if (!IS_HOSTED_BUILD) {
+			throw redirect({ ...agentSectionLink(params.id, "overview"), replace: true });
+		}
+	},
+	head: () => routeHeadTitle("Plugin"),
+	component: AgentPluginDetailRoute,
+});
+
+function AgentPluginDetailRoute() {
+	const { id } = Route.useParams();
+	const search = Route.useSearch();
+	return <AgentDetailClient environmentId={id} section="plugins" routeSearch={search} />;
+}


### PR DESCRIPTION
## Summary

User-facing overhaul of the v2 agent Plugins page (`/agents/:id/plugins`):

- **Retry for failed installs** — failed plugins now offer a one-click Retry (DELETE → PUT, since re-PUTting the same version is a backend no-op) on both card and detail views.
- **Installed / Available grouping with stable positions** — cards are grouped under section headers with counts; group assignment is sticky per page session (pure, tested `assignAgentPluginGroups`), so clicking Install updates a card in place instead of making it jump between sections.
- **Update availability** — `Update available` badge plus `v{installed} → v{latest}` version display on card and detail.
- **Routable detail view** — plugin detail now lives at `?plugin=<name>` (validated via `validateAgentRouteSearch`, preserves other search params), so refresh / deep-link / browser back work.
- **Desired-state error degradation** — when the catalog loads but installed-state fails with no cache, the page degrades to a retryable alert banner instead of blocking the whole page; stale desired data survives transient background refetch failures (`shouldBlockQueryError`).
- **Category filter** — single-select category chips (derived from catalog entries, with counts) in the list toolbar, combined with search.

## Verification

- `bun run --cwd apps/web test:internal` (agent-plugin-model + agent-routes): 16 passed
- `bun run --cwd apps/web typecheck`: pass
- Biome on changed files: clean
- `bun run --cwd apps/web e2e:hosted e2e/hosted-agent-plugins.pw.ts`: 2 passed