### PR TITLE
fix(skills): separate source and runtime identities

### DIFF
--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -35,7 +35,9 @@ from app.services.project_runtime_skills import (
     MAX_AGENT_PROJECT_SKILLS,
     agent_supports_project_skills,
     assert_agent_project_skill_total,
+    assert_project_skill_runtime_identity,
     project_skill_file_signature,
+    project_skill_runtime_identity,
 )
 from app.services.runtime_source import (
     RUNTIME_AGENT_PLUGIN_GITHUB_RELEASE_SOURCE_CAPABILITY,
@@ -53,7 +55,7 @@ from app.services.runtime_source import (
     runtime_whatsapp_credential_repair_link_ids,
     vault_key_identity,
 )
-from app.services.tar_utils import tar_from_content
+from app.services.tar_utils import reroot_skill_archive, tar_from_content
 
 router = APIRouter(prefix="/runtime", tags=["runtime"])
 _RUNTIME_MANIFEST_CACHE_CONTROL = "no-store, no-transform"
@@ -299,20 +301,26 @@ async def get_agent_project_skills(
         .all()
     )
     assert_agent_project_skill_total(len(rows))
-    seen_keys: set[str] = set()
+    seen_local_keys: set[str] = set()
     for skill in rows:
-        if skill.skill_key in seen_keys:
+        identity = project_skill_runtime_identity(skill.skill_key, skill.name)
+        assert_project_skill_runtime_identity(identity)
+        if identity.local_skill_key in seen_local_keys:
             raise HTTPException(
                 status.HTTP_409_CONFLICT,
-                f'Skill "{skill.skill_key}" comes from more than one linked Project. '
+                f'Skill "{identity.local_skill_key}" comes from more than one linked Project. '
                 "Unlink one Project.",
             )
-        seen_keys.add(skill.skill_key)
+        seen_local_keys.add(identity.local_skill_key)
 
     base_url = settings.public_api_url.rstrip("/")
     signing_key = vault_key_identity(settings.vault_encryption_key)
     skills: list[AgentProjectSkillDesiredItem] = []
     for skill in rows:
+        local_skill_key = project_skill_runtime_identity(
+            skill.skill_key,
+            skill.name,
+        ).local_skill_key
         signature = project_skill_file_signature(
             signing_key=signing_key,
             agent_id=agent_id,
@@ -323,12 +331,12 @@ async def get_agent_project_skills(
             AgentProjectSkillDesiredItem(
                 project_id=str(skill.project_id),
                 skill_id=str(skill.id),
-                skill_key=skill.skill_key,
+                skill_key=local_skill_key,
                 content_hash=skill.content_hash,
                 archive_url=(
                     f"{base_url}/v1/runtime/project-skill-archives/{agent_id}/"
                     f"{skill.project_id}/{skill.id}/{skill.content_hash}/{signature}/"
-                    f"{quote(skill.skill_key, safe='')}.tar.gz"
+                    f"{quote(local_skill_key, safe='')}.tar.gz"
                 ),
             )
         )
@@ -359,14 +367,20 @@ async def get_project_skill_archive(
         project_id=project_id,
         skill_id=skill_id,
         content_hash=content_hash,
-        skill_key=skill_key,
+        local_skill_key=skill_key,
     )
     if not skill.file_key:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Skill archive not found")
+    local_skill_key = project_skill_runtime_identity(
+        skill.skill_key,
+        skill.name,
+    ).local_skill_key
     try:
         stored = await file_store.get(skill.file_key)
         if skill.file_key.endswith(".md"):
-            stored, _file_count = tar_from_content(skill.skill_key, stored.decode("utf-8"))
+            stored, _file_count = tar_from_content(local_skill_key, stored.decode("utf-8"))
+        else:
+            stored = reroot_skill_archive(stored, skill.skill_key, local_skill_key)
     except Exception:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Skill archive not found") from None
     if len(stored) > _MAX_PROJECT_SKILL_ARCHIVE_BYTES:
@@ -447,7 +461,7 @@ async def _linked_project_skill(
     skill_id: UUID,
     content_hash: str,
     project_id: UUID | None = None,
-    skill_key: str | None = None,
+    local_skill_key: str | None = None,
 ) -> Skill:
     membership = ProjectMembership.__table__.alias("signed_project_skill_membership")
     filters = [
@@ -463,8 +477,6 @@ async def _linked_project_skill(
     ]
     if project_id is not None:
         filters.append(Project.id == project_id)
-    if skill_key is not None:
-        filters.append(Skill.skill_key == skill_key)
     skill = (
         await db.execute(
             select(Skill)
@@ -483,7 +495,14 @@ async def _linked_project_skill(
             .where(*filters)
         )
     ).scalar_one_or_none()
-    if skill is None:
+    if skill is None or (
+        local_skill_key is not None
+        and project_skill_runtime_identity(
+            skill.skill_key,
+            skill.name,
+        ).local_skill_key
+        != local_skill_key
+    ):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Skill file not found")
     return skill
 

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -1387,6 +1387,7 @@ async def _do_upload_skill(
             db,
             project_id=project_id,
             skill_key=skill_key,
+            local_skill_key=name,
         )
         # Project archive can cross the initial authorization read while the
         # archive is being validated. Re-check after the Project graph lock.
@@ -2201,6 +2202,7 @@ async def _do_install_skill(
         db,
         project_id=project_id,
         skill_key=skill_key,
+        local_skill_key=fetched.name,
     )
     await _project_upload_authority(db, auth, project_id, allow_agent_alias=False)
     await db.commit()
@@ -2214,6 +2216,7 @@ async def _do_install_skill(
         db,
         project_id=project_id,
         skill_key=skill_key,
+        local_skill_key=fetched.name,
     )
     lock_key = project_skill_advisory_lock_key(auth.user_id, project_id, skill_key)
     await db.execute(text("SELECT pg_advisory_xact_lock(:k)"), {"k": lock_key})

--- a/backend/app/services/project_runtime_skills.py
+++ b/backend/app/services/project_runtime_skills.py
@@ -11,6 +11,7 @@ import hashlib
 import hmac
 import re
 from collections.abc import Iterable
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
@@ -32,15 +33,21 @@ from app.services.runtime_generation import resolve_runtime_apply_generation
 from app.services.sync_events import queue_runtime_manifest_changed
 
 # OpenClaw's native `skills install --as` contract accepts this slug shape.
-# Keeping Project-delivered keys inside the strictest native runtime contract
-# prevents a desired manifest from succeeding but failing during installation.
-RUNTIME_PROJECT_SKILL_KEY_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
+# Source keys may be namespaced. The SKILL.md name is the local install identity
+# and must fit the strictest native runtime contract.
+RUNTIME_PROJECT_SKILL_LOCAL_KEY_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
 PROJECT_SKILL_RECONCILE_VERSION = 1
 # The Connected daemon renews every four to six minutes. Ten minutes provides
 # normal retry margin while still closing stale or downgraded Agents promptly.
 CONNECTED_PROJECT_SKILL_CAPABILITY_TTL = timedelta(minutes=10)
 MAX_AGENT_PROJECT_SKILLS = 1000
 _CONNECTED_PROJECT_SKILL_AGENT_TYPES = frozenset({"claude_code", "codex", "hermes", "openclaw"})
+
+
+@dataclass(frozen=True)
+class ProjectSkillRuntimeIdentity:
+    source_skill_key: str
+    local_skill_key: str
 
 
 def _advisory_key(namespace: str, value: UUID) -> int:
@@ -163,41 +170,62 @@ async def _connected_workspace_skill_keys(
     return set(rows.scalars())
 
 
-def _assert_runtime_skill_key(skill_key: str) -> None:
-    if RUNTIME_PROJECT_SKILL_KEY_PATTERN.fullmatch(skill_key) is not None:
+def assert_project_skill_runtime_identity(identity: ProjectSkillRuntimeIdentity) -> None:
+    if RUNTIME_PROJECT_SKILL_LOCAL_KEY_PATTERN.fullmatch(identity.local_skill_key) is not None:
         return
     raise HTTPException(
         status.HTTP_409_CONFLICT,
         detail={
             "code": "project_skill_name_incompatible",
             "message": (
-                f'Skill "{skill_key}" cannot be linked to an Agent. Rename it using '
-                "lowercase letters, numbers, or inner hyphens (up to 64 characters)."
+                f'Skill "{identity.source_skill_key}" cannot be linked to an Agent. '
+                "Update its SKILL.md name to use lowercase letters, numbers, or inner "
+                "hyphens (up to 64 characters)."
             ),
-            "skill_key": skill_key,
+            "skill_key": identity.source_skill_key,
         },
     )
 
 
-async def _project_skill_keys(db: AsyncSession, project_id: UUID) -> set[str]:
+def project_skill_runtime_identity(
+    source_skill_key: str,
+    declared_name: str,
+) -> ProjectSkillRuntimeIdentity:
+    """Resolve the runtime identity while preserving legacy flat-key Skills."""
+    local_skill_key = declared_name
+    if (
+        RUNTIME_PROJECT_SKILL_LOCAL_KEY_PATTERN.fullmatch(local_skill_key) is None
+        and RUNTIME_PROJECT_SKILL_LOCAL_KEY_PATTERN.fullmatch(source_skill_key) is not None
+    ):
+        local_skill_key = source_skill_key
+    return ProjectSkillRuntimeIdentity(
+        source_skill_key=source_skill_key,
+        local_skill_key=local_skill_key,
+    )
+
+
+async def _project_skill_identities(
+    db: AsyncSession,
+    project_id: UUID,
+) -> tuple[ProjectSkillRuntimeIdentity, ...]:
     rows = await db.execute(
-        select(Skill.skill_key).where(
+        select(Skill.skill_key, Skill.name).where(
             Skill.project_id == project_id,
             Skill.authority == SKILL_AUTHORITY_CLOUD,
             Skill.is_active,
         )
     )
-    return set(rows.scalars())
+    return tuple(project_skill_runtime_identity(skill_key, name) for skill_key, name in rows)
 
 
-async def _other_project_skill_keys(
+async def _other_project_local_skill_keys(
     db: AsyncSession,
     *,
     agent_id: UUID,
     project_id: UUID,
 ) -> set[str]:
     rows = await db.execute(
-        select(Skill.skill_key)
+        select(Skill.skill_key, Skill.name)
         .join(
             AgentProjectBinding,
             AgentProjectBinding.project_id == Skill.project_id,
@@ -213,7 +241,9 @@ async def _other_project_skill_keys(
             Skill.is_active,
         )
     )
-    return set(rows.scalars())
+    return {
+        project_skill_runtime_identity(skill_key, name).local_skill_key for skill_key, name in rows
+    }
 
 
 async def _linked_project_skill_count(db: AsyncSession, *, agent_id: UUID) -> int:
@@ -318,12 +348,22 @@ async def _assert_agent_accepts_project_skills(
     *,
     agent_id: UUID,
     project_id: UUID,
-    skill_keys: set[str],
+    skill_identities: Iterable[ProjectSkillRuntimeIdentity],
 ) -> None:
-    if not skill_keys:
+    identities = tuple(skill_identities)
+    if not identities:
         return
-    for skill_key in sorted(skill_keys):
-        _assert_runtime_skill_key(skill_key)
+    for identity in sorted(identities, key=lambda value: value.source_skill_key):
+        assert_project_skill_runtime_identity(identity)
+
+    local_owners: dict[str, list[str]] = {}
+    for identity in identities:
+        local_owners.setdefault(identity.local_skill_key, []).append(identity.source_skill_key)
+    duplicate_local_keys = {
+        local_skill_key
+        for local_skill_key, source_skill_keys in local_owners.items()
+        if len(source_skill_keys) > 1
+    }
 
     agent, state, observation, has_environment_bound_key = await _agent_runtime_delivery_evidence(
         db, agent_id=agent_id
@@ -340,13 +380,14 @@ async def _assert_agent_accepts_project_skills(
         if state is not None
         else await _connected_workspace_skill_keys(db, agent=agent)
     )
-    workspace_conflicts = skill_keys & workspace_skill_keys
-    project_conflicts = skill_keys & await _other_project_skill_keys(
+    local_skill_keys = set(local_owners)
+    workspace_conflicts = local_skill_keys & workspace_skill_keys
+    project_conflicts = local_skill_keys & await _other_project_local_skill_keys(
         db,
         agent_id=agent_id,
         project_id=project_id,
     )
-    conflicts = sorted(workspace_conflicts | project_conflicts)
+    conflicts = sorted(duplicate_local_keys | workspace_conflicts | project_conflicts)
     if not conflicts:
         return
     skill_key = conflicts[0]
@@ -360,6 +401,22 @@ async def _assert_agent_accepts_project_skills(
             ),
             "skill_key": skill_key,
         },
+    )
+
+
+async def _assert_agent_project_skill_delivery_supported(
+    db: AsyncSession,
+    *,
+    agent_id: UUID,
+) -> None:
+    agent, state, observation, has_environment_bound_key = await _agent_runtime_delivery_evidence(
+        db, agent_id=agent_id
+    )
+    _assert_agent_supports_project_skills(
+        agent,
+        state,
+        observation,
+        has_environment_bound_key=has_environment_bound_key,
     )
 
 
@@ -514,7 +571,7 @@ async def assert_project_link_compatible(
         db,
         agent_id=agent_id,
         project_id=project_id,
-        skill_keys=await _project_skill_keys(db, project_id),
+        skill_identities=await _project_skill_identities(db, project_id),
     )
     await _assert_project_link_skill_capacity(
         db,
@@ -528,16 +585,27 @@ async def assert_project_skill_write_compatible(
     *,
     project_id: UUID,
     skill_key: str,
+    local_skill_key: str | None = None,
     enforce_total_limit: bool = True,
 ) -> list[UUID]:
     """Lock the graph and prove a Cloud Skill write has one runtime owner."""
     agent_ids = await lock_project_runtime_graph(db, project_id)
+    proposed_identities: tuple[ProjectSkillRuntimeIdentity, ...] = ()
+    if local_skill_key is not None:
+        proposed_identities = tuple(
+            identity
+            for identity in await _project_skill_identities(db, project_id)
+            if identity.source_skill_key != skill_key
+        ) + (project_skill_runtime_identity(skill_key, local_skill_key),)
     for agent_id in agent_ids:
+        if local_skill_key is None:
+            await _assert_agent_project_skill_delivery_supported(db, agent_id=agent_id)
+            continue
         await _assert_agent_accepts_project_skills(
             db,
             agent_id=agent_id,
             project_id=project_id,
-            skill_keys={skill_key},
+            skill_identities=proposed_identities,
         )
     if enforce_total_limit:
         await _assert_project_skill_write_capacity(
@@ -560,7 +628,7 @@ async def assert_agent_workspace_skill_write_compatible(
     if not skill_keys:
         return
     rows = await db.execute(
-        select(Skill.skill_key)
+        select(Skill.skill_key, Skill.name)
         .join(
             AgentProjectBinding,
             AgentProjectBinding.project_id == Skill.project_id,
@@ -575,8 +643,10 @@ async def assert_agent_workspace_skill_write_compatible(
             Skill.is_active,
         )
     )
-    project_skill_keys = set(rows.scalars())
-    conflicts = sorted(skill_keys & project_skill_keys)
+    project_local_skill_keys = {
+        project_skill_runtime_identity(skill_key, name).local_skill_key for skill_key, name in rows
+    }
+    conflicts = sorted(skill_keys & project_local_skill_keys)
     if conflicts:
         skill_key = conflicts[0]
         raise HTTPException(
@@ -590,7 +660,7 @@ async def assert_agent_workspace_skill_write_compatible(
                 "skill_key": skill_key,
             },
         )
-    if project_skill_keys:
+    if project_local_skill_keys:
         (
             agent,
             state,

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -77,9 +77,10 @@ from app.services.managed_ai_provider import (
     runtime_managed_provider_id,
 )
 from app.services.project_runtime_skills import (
-    RUNTIME_PROJECT_SKILL_KEY_PATTERN,
+    RUNTIME_PROJECT_SKILL_LOCAL_KEY_PATTERN,
     agent_supports_project_skills,
     project_skill_file_signature,
+    project_skill_runtime_identity,
 )
 from app.services.runtime_generation import resolve_runtime_apply_generation
 from app.services.url_security import UnsafePublicHttpsUrlError, validate_public_https_url
@@ -175,6 +176,7 @@ class RuntimeProjectSkill:
     id: UUID
     project_id: UUID
     skill_key: str
+    local_skill_key: str
     content_hash: str
 
 
@@ -417,6 +419,10 @@ async def load_runtime_source_batch(
                 id=skill.id,
                 project_id=skill.project_id,
                 skill_key=skill.skill_key,
+                local_skill_key=project_skill_runtime_identity(
+                    skill.skill_key,
+                    skill.name,
+                ).local_skill_key,
                 content_hash=skill.content_hash,
             )
         )
@@ -512,28 +518,29 @@ def _project_runtime_skills(
     base_url = public_api_url.rstrip("/")
     owners: dict[str, UUID] = {}
     for skill in project_skills:
-        if RUNTIME_PROJECT_SKILL_KEY_PATTERN.fullmatch(skill.skill_key) is None:
+        if RUNTIME_PROJECT_SKILL_LOCAL_KEY_PATTERN.fullmatch(skill.local_skill_key) is None:
             raise RuntimeSourceError(
-                f'Project Skill "{skill.skill_key}" is not compatible with managed Agent delivery'
+                f'Project Skill "{skill.skill_key}" has an incompatible SKILL.md name'
             )
-        if skill.skill_key in entries:
+        if skill.local_skill_key in entries:
             raise RuntimeSourceError(
-                f'Project Skill "{skill.skill_key}" conflicts with this Agent\'s Workspace'
+                f'Project Skill "{skill.local_skill_key}" conflicts with this Agent\'s Workspace'
             )
-        existing_project = owners.get(skill.skill_key)
+        existing_project = owners.get(skill.local_skill_key)
         if existing_project is not None:
             raise RuntimeSourceError(
-                f'Project Skill "{skill.skill_key}" is provided by more than one linked Project'
+                f'Project Skill "{skill.local_skill_key}" is provided by more than one linked '
+                "Project"
             )
-        owners[skill.skill_key] = skill.project_id
+        owners[skill.local_skill_key] = skill.project_id
         signature = project_skill_file_signature(
             signing_key=signing_key,
             agent_id=environment_id,
             skill_id=skill.id,
             content_hash=skill.content_hash,
         )
-        encoded_key = quote(skill.skill_key, safe="")
-        entries[skill.skill_key] = {
+        encoded_key = quote(skill.local_skill_key, safe="")
+        entries[skill.local_skill_key] = {
             "enabled": True,
             "source": {
                 "type": "project",

--- a/backend/app/services/tar_utils.py
+++ b/backend/app/services/tar_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import re
 import tarfile
+from copy import copy
 from pathlib import Path, PurePosixPath
 from typing import TypeGuard
 
@@ -173,6 +174,54 @@ def tar_from_content(skill_key: str, content: str) -> tuple[bytes, int]:
         tf.addfile(info, io.BytesIO(encoded))
 
     return buf.getvalue(), 1
+
+
+def reroot_skill_archive(data: bytes, source_skill_key: str, local_skill_key: str) -> bytes:
+    """Repackage a validated Skill under its runtime-local directory name."""
+    if source_skill_key == local_skill_key:
+        return data
+    validate_tar(data)
+    source_parts = PurePosixPath(source_skill_key).parts
+    local_parts = PurePosixPath(local_skill_key).parts
+    if not source_parts or not local_parts:
+        raise TarValidationError("Skill archive identity is invalid")
+
+    output = io.BytesIO()
+    try:
+        with (
+            tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as source,
+            tarfile.open(fileobj=output, mode="w:gz") as target,
+        ):
+            for member in source:
+                member_parts = PurePosixPath(member.name).parts
+                if not member_parts:
+                    raise TarValidationError("Skill archive contains an invalid path")
+                if (
+                    len(member_parts) < len(source_parts)
+                    and member_parts == source_parts[: len(member_parts)]
+                ):
+                    if not member.isdir():
+                        raise TarValidationError("Skill archive root is invalid")
+                    continue
+                if member_parts[: len(source_parts)] != source_parts:
+                    raise TarValidationError(
+                        "Skill archive root does not match its source identity"
+                    )
+
+                rewritten = copy(member)
+                rewritten.name = "/".join((*local_parts, *member_parts[len(source_parts) :]))
+                if "path" in rewritten.pax_headers:
+                    rewritten.pax_headers = {**rewritten.pax_headers, "path": rewritten.name}
+                if member.isfile():
+                    extracted = source.extractfile(member)
+                    if extracted is None:
+                        raise TarValidationError("Archive file could not be read")
+                    target.addfile(rewritten, extracted)
+                else:
+                    target.addfile(rewritten)
+    except tarfile.TarError as exc:
+        raise TarValidationError("Invalid tar archive") from exc
+    return output.getvalue()
 
 
 def replace_skill_md(data: bytes, skill_key: str, content: str) -> tuple[bytes, int]:

--- a/backend/tests/test_project_runtime_skills.py
+++ b/backend/tests/test_project_runtime_skills.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import io
+import tarfile
 import uuid
 from datetime import UTC, datetime, timedelta
 from urllib.parse import urlsplit
@@ -36,8 +38,16 @@ from tests.hosted_runtime_fixtures import (
 )
 
 
-def _skill_archive(skill_key: str, marker: str = "Project runtime") -> bytes:
-    content = f"---\nname: {skill_key}\ndescription: Project runtime test\n---\n# {marker}\n"
+def _skill_archive(
+    skill_key: str,
+    marker: str = "Project runtime",
+    *,
+    local_skill_key: str | None = None,
+) -> bytes:
+    content = (
+        f"---\nname: {local_skill_key or skill_key}\n"
+        f"description: Project runtime test\n---\n# {marker}\n"
+    )
     archive, _ = tar_from_content(skill_key, content)
     return archive
 
@@ -47,6 +57,8 @@ async def _upload_project_skill(
     project_id: uuid.UUID,
     skill_key: str,
     marker: str = "Project runtime",
+    *,
+    local_skill_key: str | None = None,
 ) -> httpx.Response:
     return await client.post(
         f"/v1/projects/{project_id}/skills/upload",
@@ -54,7 +66,7 @@ async def _upload_project_skill(
         files={
             "file": (
                 f"{skill_key}.tar.gz",
-                _skill_archive(skill_key, marker),
+                _skill_archive(skill_key, marker, local_skill_key=local_skill_key),
                 "application/gzip",
             )
         },
@@ -150,7 +162,14 @@ async def test_linked_project_skill_is_composed_into_managed_runtime_manifest(
     workspace_project: Project,
     channel_agent,
 ):
-    uploaded = await _upload_project_skill(client, workspace_project.id, "project-review")
+    source_skill_key = "devops/phala-cloud-admin-ops"
+    local_skill_key = "phala-cloud-admin-ops"
+    uploaded = await _upload_project_skill(
+        client,
+        workspace_project.id,
+        source_skill_key,
+        local_skill_key=local_skill_key,
+    )
     assert uploaded.status_code == 200, uploaded.text
     linked = await _link(
         client,
@@ -178,13 +197,59 @@ async def test_linked_project_skill_is_composed_into_managed_runtime_manifest(
         decrypt_secrets=False,
     )
 
-    entry = rendered.manifest["skills"]["entries"]["project-review"]
+    entry = rendered.manifest["skills"]["entries"][local_skill_key]
     assert entry["enabled"] is True
     assert entry["source"]["type"] == "project"
     assert entry["source"]["projectId"] == str(workspace_project.id)
     assert entry["source"]["contentHash"] == uploaded.json()["content_hash"]
-    assert urlsplit(entry["source"]["archiveUrl"]).path.endswith("/project-review.tar.gz")
+    archive_path = urlsplit(entry["source"]["archiveUrl"]).path
+    assert archive_path.endswith(f"/{local_skill_key}.tar.gz")
     assert urlsplit(entry["source"]["installUrl"]).path.endswith("/SKILL.md")
+
+    archive = await client.get(archive_path)
+    assert archive.status_code == 200, archive.text
+    with tarfile.open(fileobj=io.BytesIO(archive.content), mode="r:gz") as result:
+        assert result.getnames() == [f"{local_skill_key}/SKILL.md"]
+
+
+@pytest.mark.asyncio
+async def test_connected_project_skill_desired_inventory_uses_local_name(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user: User,
+    workspace_project: Project,
+    environment_project: Project,
+):
+    agent_id = environment_project.origin_environment_id
+    assert agent_id is not None
+    uploaded = await _upload_project_skill(
+        client,
+        workspace_project.id,
+        "devops/phala-cloud-admin-ops",
+        local_skill_key="phala-cloud-admin-ops",
+    )
+    assert uploaded.status_code == 200, uploaded.text
+    capability = await _report_connected_project_skill_capability(
+        client,
+        db_session,
+        user=seed_user,
+        agent_id=agent_id,
+    )
+    assert capability.status_code == 204, capability.text
+    linked = await _link(client, agent_id=agent_id, project_id=workspace_project.id)
+    assert linked.status_code == 200, linked.text
+
+    _set_auth(_connected_agent_auth(seed_user))
+    try:
+        desired = await client.get(
+            "/v1/runtime/project-skills",
+            params={"environment_id": str(agent_id)},
+        )
+    finally:
+        _set_auth(AuthContext(user=seed_user))
+    assert desired.status_code == 200, desired.text
+    assert desired.json()["skills"][0]["skill_key"] == "phala-cloud-admin-ops"
+    assert desired.json()["skills"][0]["archive_url"].endswith("/phala-cloud-admin-ops.tar.gz")
 
 
 @pytest.mark.asyncio
@@ -203,7 +268,7 @@ async def test_link_fails_closed_for_workspace_and_sibling_project_skill_conflic
             user_id=seed_user.id,
             project_id=workspace_project.id,
             skill_key="duplicate",
-            name="Duplicate",
+            name="duplicate",
             description="Conflicts with the Agent Workspace",
             content_hash="1" * 64,
             authority=SKILL_AUTHORITY_CLOUD,
@@ -241,8 +306,8 @@ async def test_link_fails_closed_for_workspace_and_sibling_project_skill_conflic
         Skill(
             user_id=seed_user.id,
             project_id=sibling.id,
-            skill_key="duplicate",
-            name="Duplicate",
+            skill_key="team/duplicate",
+            name="duplicate",
             description="Conflicts with the first linked Project",
             content_hash="2" * 64,
             authority=SKILL_AUTHORITY_CLOUD,
@@ -278,7 +343,7 @@ async def test_connected_agent_and_project_skill_write_fail_before_mutation(
             user_id=seed_user.id,
             project_id=workspace_project.id,
             skill_key="managed-only",
-            name="Managed only",
+            name="managed-only",
             description="Requires managed delivery",
             content_hash="3" * 64,
             authority=SKILL_AUTHORITY_CLOUD,
@@ -318,7 +383,7 @@ async def test_connected_agent_and_project_skill_write_fail_before_mutation(
                 user_id=seed_user.id,
                 project_id=environment_project.id,
                 skill_key="connected-local",
-                name="Connected local",
+                name="connected-local",
                 description="Observed Agent Workspace projection",
                 content_hash="5" * 64,
                 authority=SKILL_AUTHORITY_AGENT_SYNC,
@@ -327,8 +392,8 @@ async def test_connected_agent_and_project_skill_write_fail_before_mutation(
             Skill(
                 user_id=seed_user.id,
                 project_id=connected_workspace_conflict.id,
-                skill_key="connected-local",
-                name="Connected local",
+                skill_key="team/connected-local",
+                name="connected-local",
                 description="Conflicts with the Agent Workspace",
                 content_hash="6" * 64,
                 authority=SKILL_AUTHORITY_CLOUD,
@@ -358,6 +423,15 @@ async def test_connected_agent_and_project_skill_write_fail_before_mutation(
         project_id=workspace_project.id,
     )
     assert connected_link.status_code == 200, connected_link.text
+
+    duplicate_local_name = await _upload_project_skill(
+        client,
+        workspace_project.id,
+        "devops/managed-only",
+        local_skill_key="managed-only",
+    )
+    assert duplicate_local_name.status_code == 409, duplicate_local_name.text
+    assert duplicate_local_name.json()["detail"]["code"] == "project_skill_name_conflict"
 
     # A downgraded Connected Agent still emits the byte-frozen heartbeat contract,
     # but it cannot renew the separate Project Skill lease. Once that observation
@@ -688,7 +762,12 @@ async def test_agent_workspace_upload_rejects_linked_project_key_before_projecti
 ):
     agent_id = environment_project.origin_environment_id
     assert agent_id is not None
-    uploaded = await _upload_project_skill(client, workspace_project.id, "shared-key")
+    uploaded = await _upload_project_skill(
+        client,
+        workspace_project.id,
+        "team/shared-key",
+        local_skill_key="shared-key",
+    )
     assert uploaded.status_code == 200, uploaded.text
     capability = await _report_connected_project_skill_capability(
         client,
@@ -756,7 +835,7 @@ async def test_link_rejects_project_skill_name_outside_native_runtime_contract(
         Skill(
             user_id=seed_user.id,
             project_id=workspace_project.id,
-            skill_key="not_openclaw_safe",
+            skill_key="devops/not_openclaw_safe",
             name="Not OpenClaw safe",
             description="The desired state must be installable by the native CLI",
             content_hash="4" * 64,

--- a/backend/tests/test_tar_utils.py
+++ b/backend/tests/test_tar_utils.py
@@ -48,6 +48,28 @@ def test_validate_tar_preserves_total_expanded_limit(
         )
 
 
+def test_reroot_skill_archive_preserves_the_file_tree() -> None:
+    source_key = "devops/phala-cloud-admin-ops"
+    local_key = "phala-cloud-admin-ops"
+    source = _archive(
+        (
+            (f"{source_key}/SKILL.md", b"---\nname: phala-cloud-admin-ops\n---\n"),
+            (f"{source_key}/references/runbook.md", b"runbook\n"),
+        )
+    )
+
+    rerooted = tar_utils.reroot_skill_archive(source, source_key, local_key)
+
+    with tarfile.open(fileobj=io.BytesIO(rerooted), mode="r:gz") as archive:
+        assert sorted(archive.getnames()) == [
+            f"{local_key}/SKILL.md",
+            f"{local_key}/references/runbook.md",
+        ]
+    assert _compute_file_tree_hash(source, source_key) == _compute_file_tree_hash(
+        rerooted, local_key
+    )
+
+
 def test_unicode_tree_hash_matches_typescript_archive_fixture() -> None:
     fixture = Path(__file__).parents[2] / "test-fixtures" / "skill-hash" / "unicode-tree.tar.gz.b64"
     archive = b64decode(fixture.read_text(encoding="ascii"))


### PR DESCRIPTION
## Summary

- keep the cloud `skill_key` as the immutable source identity and use the `SKILL.md` frontmatter `name` as the Agent-local install identity
- preserve existing flat-key Skills whose historical `name` is display text by retaining their already-valid source key as the local identity
- render the existing Hosted manifest and Connected desired inventory with the resolved local install name
- repackage stored source-root archives under the local runtime root when they are downloaded
- detect Workspace, sibling Project, and same-Project conflicts by local install name

## Compatibility

- backend-only fix
- no configuration flag or rollout allowlist
- no database migration or stored Skill rewrite
- no reconcile protocol or API schema change; Connected reconciliation remains v1
- no Hosted or Connected CLI release required

## Verification

- `scripts/test.sh backend <three legacy compatibility cases> tests/test_project_runtime_skills.py tests/test_tar_utils.py tests/test_skills.py` (60 passed)
- Ruff format and check
- `git diff --check`