### PR TITLE
fix: make Project-Agent links additive and batchable

### DIFF
--- a/apps/web/e2e/project-agent-linking.pw.ts
+++ b/apps/web/e2e/project-agent-linking.pw.ts
@@ -1,0 +1,122 @@
+import { expect, type Route, test } from "@playwright/test";
+
+const now = "2026-08-18T12:00:00Z";
+const projectId = "11111111-1111-4111-8111-111111111111";
+const linkedAgentId = "22222222-2222-4222-8222-222222222222";
+const buildAgentId = "33333333-3333-4333-8333-333333333333";
+const deployAgentId = "44444444-4444-4444-8444-444444444444";
+
+function agent(id: string, displayName: string) {
+	return {
+		id,
+		name: displayName.toLowerCase().replaceAll(" ", "-"),
+		default_name: displayName,
+		display_name: displayName,
+		machine_name: `${displayName.toLowerCase().replaceAll(" ", "-")}.local`,
+		agent_type: "openclaw",
+		agent_version: "1.0.0",
+		os: "linux",
+		last_seen_at: now,
+		last_sync_at: now,
+		last_sync_error: null,
+		last_revision_seen: 1,
+		queue_depth_high_water: 0,
+		dropped_count: 0,
+		sync_enabled: true,
+		explicit_identity: true,
+		default_project_id: `${id.slice(0, -1)}9`,
+	};
+}
+
+async function fulfill(route: Route, body: unknown) {
+	await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+}
+
+test("Project link dialog adds multiple Agents without replacing existing links", async ({
+	page,
+}) => {
+	const linkedAgent = agent(linkedAgentId, "Review Agent");
+	const buildAgent = agent(buildAgentId, "Build Agent");
+	const deployAgent = agent(deployAgentId, "Deploy Agent");
+	let availableAgentsLinked = false;
+	const linkBodies: unknown[] = [];
+	let projectDetailReads = 0;
+	let filteredAgentReads = 0;
+	const project = () => ({
+		id: projectId,
+		name: "Client Review",
+		slug: "client-review",
+		kind: "workspace",
+		description: "Shared review resources.",
+		origin_environment_id: null,
+		archived_at: null,
+		created_at: now,
+		is_owner: true,
+		owner_display: "Dev User",
+		owner_handle: "dev-user",
+		skill_count: 0,
+		vault_count: 0,
+		agent_count: availableAgentsLinked ? 3 : 1,
+		member_count: 0,
+	});
+
+	await page.route("**/v1/**", async (route) => {
+		const request = route.request();
+		const url = new URL(request.url());
+		const path = url.pathname;
+		if (path === `/v1/projects/${projectId}/agents` && request.method() === "POST") {
+			linkBodies.push(request.postDataJSON());
+			availableAgentsLinked = true;
+			return fulfill(route, {
+				project_id: projectId,
+				bound_agent_ids: [buildAgentId, deployAgentId],
+			});
+		}
+		if (path === `/v1/projects/${projectId}`) {
+			projectDetailReads += 1;
+			return fulfill(route, project());
+		}
+		if (path === "/v1/projects") return fulfill(route, [project()]);
+		if (path === "/v1/agents") {
+			if (url.searchParams.get("project_id") === projectId) {
+				filteredAgentReads += 1;
+				return fulfill(
+					route,
+					availableAgentsLinked ? [linkedAgent, buildAgent, deployAgent] : [linkedAgent],
+				);
+			}
+			return fulfill(route, [linkedAgent, buildAgent, deployAgent]);
+		}
+		if (path === `/v1/projects/${projectId}/members`) return fulfill(route, []);
+		if (path === "/v1/dashboard/stats") return fulfill(route, {});
+		if (path === "/v1/auth/keys") return fulfill(route, []);
+		return fulfill(route, {});
+	});
+
+	await page.goto(`/projects/${projectId}?tab=agents`);
+	await expect(page.getByRole("heading", { name: "Client Review" })).toBeVisible({
+		timeout: 15_000,
+	});
+	const agentsSection = page.locator("#agents");
+	await expect(agentsSection.getByText("Review Agent", { exact: true })).toBeVisible();
+
+	await page.getByRole("button", { name: "Link project" }).click();
+	const dialog = page.getByRole("dialog", { name: "Link project to Agents" });
+	const linkedCheckbox = dialog.getByRole("checkbox", { name: "Review Agent already linked" });
+	await expect(linkedCheckbox).toBeChecked();
+	await expect(linkedCheckbox).toBeDisabled();
+	await expect(dialog.getByText("Linked", { exact: true })).toBeVisible();
+
+	await dialog.getByRole("checkbox", { name: "Link Build Agent" }).click();
+	await dialog.getByRole("checkbox", { name: "Link Deploy Agent" }).click();
+	await dialog.getByRole("button", { name: "Link 2 Agents" }).click();
+
+	await expect.poll(() => linkBodies).toEqual([{ agent_ids: [buildAgentId, deployAgentId] }]);
+	await expect(dialog).toHaveCount(0);
+	await expect(agentsSection.getByText("3", { exact: true })).toBeVisible();
+	await expect(agentsSection.getByText("Review Agent", { exact: true })).toBeVisible();
+	await expect(agentsSection.getByText("Build Agent", { exact: true })).toBeVisible();
+	await expect(agentsSection.getByText("Deploy Agent", { exact: true })).toBeVisible();
+	await expect.poll(() => projectDetailReads).toBeGreaterThan(1);
+	await expect.poll(() => filteredAgentReads).toBeGreaterThan(1);
+});

--- a/apps/web/e2e/project-detail.pw.ts
+++ b/apps/web/e2e/project-detail.pw.ts
@@ -47,9 +47,7 @@ async function expectNoHorizontalOverflow(page: Page) {
 	expect(widths.content).toBeLessThanOrEqual(widths.viewport + 1);
 }
 
-test("Project detail uses explicit local pages and whole-bundle Link at mobile and desktop", async ({
-	page,
-}) => {
+test("Project detail uses explicit local pages at mobile and desktop", async ({ page }) => {
 	let project = {
 		id: projectId,
 		name: "Client Review",
@@ -69,7 +67,6 @@ test("Project detail uses explicit local pages and whole-bundle Link at mobile a
 	};
 	const projectResourceRequests: string[] = [];
 	const boundedAgentRequests: string[] = [];
-	const linkedBodies: unknown[] = [];
 	const updateBodies: unknown[] = [];
 	const vaultCreateRequests: Array<{ url: URL; body: unknown }> = [];
 
@@ -105,18 +102,6 @@ test("Project detail uses explicit local pages and whole-bundle Link at mobile a
 					created_at: now,
 				},
 			]);
-		}
-		if (path === `/v1/agents/${agentId}/project-bindings/context`) {
-			linkedBodies.push(request.postDataJSON());
-			return fulfill(route, {
-				id: "55555555-5555-4555-8555-555555555555",
-				agent_id: agentId,
-				project_id: projectId,
-				binding_type: "context",
-				priority: 1,
-				default_write_enabled: false,
-				created_at: now,
-			});
 		}
 		if (path === "/v1/skills") {
 			projectResourceRequests.push(request.url());
@@ -253,12 +238,6 @@ test("Project detail uses explicit local pages and whole-bundle Link at mobile a
 
 	await page.setViewportSize({ width: 1280, height: 900 });
 	await expectNoHorizontalOverflow(page);
-	await page.getByRole("button", { name: "Link project" }).click();
-	const linkDialog = page.getByRole("dialog", { name: "Link project to Agent" });
-	await expect(linkDialog).toContainText("Skills and attached Vaults as one bundle");
-	await linkDialog.getByRole("button", { name: "Link project" }).click();
-	await expect.poll(() => linkedBodies).toEqual([{ project_id: projectId }]);
-
 	await page
 		.getByRole("tablist", { name: "Project pages" })
 		.getByRole("tab", { name: "Access" })

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -314,18 +314,13 @@ async function stubDashboardApi(
 			return;
 		}
 		if (
-			url.pathname === "/v1/agents/11111111-1111-4111-8111-111111111111/project-bindings/context" &&
+			url.pathname === "/v1/agents/11111111-1111-4111-8111-111111111111/projects" &&
 			route.request().method() === "POST"
 		) {
 			options.projectLinkBodies?.push(route.request().postDataJSON());
 			await fulfillJson(route, {
-				id: "binding-created-context",
 				agent_id: "11111111-1111-4111-8111-111111111111",
-				project_id: "project-unrelated",
-				binding_type: "context",
-				priority: 3,
-				default_write_enabled: false,
-				created_at: now.toISOString(),
+				bound_project_ids: ["project-batch-second", "project-unrelated"],
 			});
 			return;
 		}
@@ -834,6 +829,8 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	const vaultRequests: string[] = [];
 	const projectCreateBodies: unknown[] = [];
 	const projectLinkBodies: unknown[] = [];
+	const projectBindingRequests: string[] = [];
+	const projectRequests: string[] = [];
 	const longContextProjectName =
 		"Automation Library for exceptionally long production workflow names across several teams";
 	const longContextProjectSlug =
@@ -883,6 +880,19 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 			name: longContextProjectName,
 			slug: longContextProjectSlug,
 			description: longContextProjectDescription,
+			kind: "workspace",
+			origin_environment_id: null,
+			archived_at: null,
+			created_at: now.toISOString(),
+			is_owner: true,
+			owner_display: "Dev User",
+			owner_handle: "dev-user",
+		},
+		{
+			id: "project-batch-second",
+			name: "Release Project",
+			slug: "release-project",
+			description: "Release checklists and protected Vault access",
 			kind: "workspace",
 			origin_environment_id: null,
 			archived_at: null,
@@ -947,6 +957,8 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 		vaultItems: projectAccessVaults,
 		projectCreateBodies,
 		projectLinkBodies,
+		projectBindingRequests,
+		projectRequests,
 	});
 
 	await page.setViewportSize({ width: 1280, height: 900 });
@@ -1042,25 +1054,36 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	});
 	await page.goBack();
 	await expect(page).toHaveURL(/\/agents\/11111111-1111-4111-8111-111111111111\/project-access$/);
+	const bindingReadsBeforeLink = projectBindingRequests.length;
+	const projectReadsBeforeLink = projectRequests.length;
 	const addProjectTrigger = projectStack.getByRole("button", {
-		name: "Link project",
+		name: "Link projects",
 		exact: true,
 	});
 	await expect(addProjectTrigger).toBeVisible();
 	await addProjectTrigger.click();
 	const addProjectDialog = page.getByTestId("agent-project-add-dialog");
 	await expect(addProjectDialog).toBeVisible();
-	await expect(addProjectDialog.getByRole("heading", { name: "Link project" })).toBeVisible();
-	const compactProjectPicker = addProjectDialog.getByLabel("Project to link");
-	await expect(compactProjectPicker).toBeVisible();
-	await compactProjectPicker.click();
-	await page.getByRole("option", { name: /Unrelated Project/ }).click();
 	await expect(
-		addProjectDialog.getByRole("button", { name: "Link project", exact: true }),
+		addProjectDialog.getByRole("heading", { name: "Link projects to Agent" }),
+	).toBeVisible();
+	const linkedProject = addProjectDialog.getByRole("checkbox", {
+		name: "Team Knowledge already linked",
+	});
+	await expect(linkedProject).toBeChecked();
+	await expect(linkedProject).toBeDisabled();
+	await addProjectDialog.getByRole("checkbox", { name: "Link Release Project" }).click();
+	await addProjectDialog.getByRole("checkbox", { name: "Link Unrelated Project" }).click();
+	await expect(
+		addProjectDialog.getByRole("button", { name: "Link 2 Projects", exact: true }),
 	).toBeEnabled();
-	await addProjectDialog.getByRole("button", { name: "Link project", exact: true }).click();
+	await addProjectDialog.getByRole("button", { name: "Link 2 Projects", exact: true }).click();
 	await expect(addProjectDialog).toHaveCount(0);
-	await expect.poll(() => projectLinkBodies).toEqual([{ project_id: "project-unrelated" }]);
+	await expect
+		.poll(() => projectLinkBodies)
+		.toEqual([{ project_ids: ["project-batch-second", "project-unrelated"] }]);
+	await expect.poll(() => projectBindingRequests.length).toBeGreaterThan(bindingReadsBeforeLink);
+	await expect.poll(() => projectRequests.length).toBeGreaterThan(projectReadsBeforeLink);
 
 	await projectStack.screenshot({
 		path: testInfo.outputPath("connected-agent-projects-desktop.png"),

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -988,14 +988,11 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 		await expect(card.locator(":scope > div")).toHaveCSS("border-top-width", "1px");
 	}
 	await expect(projectCards.nth(0)).toContainText("Team Knowledge");
-	await expect(projectCards.nth(0)).toContainText("Project order 1");
 	await expect(projectCards.nth(0)).toContainText("Viewer");
 	await expect(projectCards.nth(1)).toContainText(longContextProjectName);
-	await expect(projectCards.nth(1)).toContainText("Project order 2");
 	await projectCards.nth(0).hover();
-	await expect(
-		projectCards.nth(0).getByRole("button", { name: "Move Team Knowledge up" }),
-	).toBeDisabled();
+	await expect(projectStack.getByText(/Project order/)).toHaveCount(0);
+	await expect(projectStack.getByRole("button", { name: /Move .* (up|down)/ })).toHaveCount(0);
 	await expect(
 		projectCards.nth(0).getByRole("button", { name: "Unlink Team Knowledge" }),
 	).toBeVisible();

--- a/apps/web/src/components/dashboard/agent-projects-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-projects-tab.tsx
@@ -18,16 +18,19 @@ import { EmptyState } from "@/components/empty-state";
 import { HERO_GRID_CLASS } from "@/components/entity-card";
 import { PageHeader } from "@/components/page-header";
 import {
+	compareProjectsForUse,
 	displayProjectName,
 	isCustomProject,
-	ProjectCompactPicker,
+	ProjectIdentity,
 } from "@/components/projects/project-metadata";
 import {
 	ProjectResourceCard,
 	ProjectResourceCardSkeleton,
 	UnavailableProjectResourceCard,
 } from "@/components/projects/project-resource-card";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import {
 	Dialog,
@@ -77,6 +80,17 @@ export function AgentProjectsTab({
 		},
 	);
 	const bindings = useAgentProjectBindings(agentId, { enabled });
+	const refresh = async () => {
+		await Promise.all([
+			queryClient.invalidateQueries({ queryKey: agentProjectBindingsQueryKey(agentId) }),
+			queryClient.invalidateQueries({ queryKey: ["get", "/v1/projects"] }),
+			queryClient.invalidateQueries({ queryKey: ["get", "/v1/projects/{project_id}"] }),
+			queryClient.invalidateQueries({ queryKey: ["get", "/v1/agents"] }),
+			queryClient.invalidateQueries({ queryKey: ["get", "/v1/vault"] }),
+			queryClient.invalidateQueries({ queryKey: ["skills"] }),
+			queryClient.invalidateQueries({ queryKey: ["vaults"] }),
+		]);
+	};
 
 	const navigationScope = agentResourceScope(agentId);
 	return (
@@ -96,10 +110,7 @@ export function AgentProjectsTab({
 			navigationScope={navigationScope}
 			headerIcon={headerIcon}
 			headerAdornment={headerAdornment}
-			onChanged={() => {
-				void queryClient.invalidateQueries({ queryKey: agentProjectBindingsQueryKey(agentId) });
-				void queryClient.invalidateQueries({ queryKey: ["get", "/v1/projects"] });
-			}}
+			onChanged={refresh}
 		/>
 	);
 }
@@ -129,11 +140,11 @@ function AgentProjectsPanel({
 	navigationScope: ResourceNavigationScope;
 	headerIcon?: ReactNode;
 	headerAdornment?: ReactNode;
-	onChanged: () => void;
+	onChanged: () => Promise<void>;
 }) {
 	const api = useApi();
 	const router = useRouter();
-	const [contextProjectId, setContextProjectId] = useState("");
+	const [selectedProjectIds, setSelectedProjectIds] = useState<Set<string>>(() => new Set());
 	const [linkOpen, setLinkOpen] = useState(false);
 	const [createOpen, setCreateOpen] = useState(false);
 	const [newProjectName, setNewProjectName] = useState("");
@@ -149,28 +160,35 @@ function AgentProjectsPanel({
 		() => new Map(projects.map((project) => [project.id, project])),
 		[projects],
 	);
-	const contextChoices = projects.filter(
-		(project) =>
-			isCustomProject(project) && !bindings.some((binding) => binding.project_id === project.id),
+	const linkProjects = useMemo(
+		() => projects.filter(isCustomProject).sort(compareProjectsForUse),
+		[projects],
+	);
+	const linkedProjectIds = useMemo(
+		() => new Set(bindings.map((binding) => binding.project_id)),
+		[bindings],
+	);
+	const selectedProjects = linkProjects.filter(
+		(project) => selectedProjectIds.has(project.id) && !linkedProjectIds.has(project.id),
 	);
 
-	const linkContext = useMutation({
-		mutationFn: async (projectId: string) => {
-			await unwrap(
-				await api.POST("/v1/agents/{agent_id}/project-bindings/context", {
+	const linkContexts = useMutation({
+		mutationFn: async (projectIds: string[]) => {
+			return unwrap(
+				await api.POST("/v1/agents/{agent_id}/projects", {
 					params: { path: { agent_id: agentId } },
-					body: { project_id: projectId },
+					body: { project_ids: projectIds },
 				}),
 			);
 		},
-		onSuccess: () => {
-			setContextProjectId("");
+		onSuccess: async (_response, projectIds) => {
+			await onChanged();
+			setSelectedProjectIds(new Set());
 			setLinkOpen(false);
-			onChanged();
-			toast.success("Project linked");
+			toast.success(projectIds.length === 1 ? "Project linked" : "Projects linked");
 		},
 		onError: (error) =>
-			toast.error("Couldn't link project", { description: normalizeApiError(error) }),
+			toast.error("Couldn't link Projects", { description: normalizeApiError(error) }),
 		onSettled: () => {
 			linkExistingLockedRef.current = false;
 		},
@@ -178,11 +196,11 @@ function AgentProjectsPanel({
 
 	const createProject = useMutation({
 		mutationFn: async (body: ProjectCreate) => unwrap(await api.POST("/v1/projects", { body })),
-		onSuccess: (project) => {
+		onSuccess: async (project) => {
+			await onChanged();
 			setNewProjectName("");
 			setNewProjectDescription("");
 			setCreateOpen(false);
-			onChanged();
 			const returnTarget = resourceCollectionTarget(navigationScope, "projects");
 			const openHref = `${projectDetailHref(project.id)}?from=${encodeURIComponent(returnTarget.href)}`;
 			toast.success("Project created", {
@@ -200,10 +218,11 @@ function AgentProjectsPanel({
 		},
 	});
 
-	const submitExistingProjectLink = () => {
-		if (!contextProjectId || linkExistingLockedRef.current) return;
+	const submitExistingProjectLinks = () => {
+		const projectIds = selectedProjects.map((project) => project.id);
+		if (projectIds.length === 0 || linkExistingLockedRef.current) return;
 		linkExistingLockedRef.current = true;
-		linkContext.mutate(contextProjectId);
+		linkContexts.mutate(projectIds);
 	};
 
 	const submitCreateProject = () => {
@@ -224,8 +243,8 @@ function AgentProjectsPanel({
 				}),
 			);
 		},
-		onSuccess: () => {
-			onChanged();
+		onSuccess: async () => {
+			await onChanged();
 			toast.success("Project unlinked");
 		},
 		onError: (error) =>
@@ -254,12 +273,12 @@ function AgentProjectsPanel({
 						size="sm"
 						disabled={actionsDisabled}
 						onClick={() => {
-							setContextProjectId("");
+							setSelectedProjectIds(new Set());
 							setLinkOpen(true);
 						}}
 					>
 						<Link2 className="size-3.5" />
-						Link project
+						Link projects
 					</Button>
 				</>
 			}
@@ -380,32 +399,66 @@ function AgentProjectsPanel({
 				open={linkOpen}
 				onOpenChange={setLinkOpen}
 				onOpenChangeComplete={(open) => {
-					if (!open) setContextProjectId("");
+					if (!open) setSelectedProjectIds(new Set());
 				}}
 			>
-				<DialogContent className="sm:max-w-md" data-testid="agent-project-add-dialog">
+				<DialogContent className="sm:max-w-lg" data-testid="agent-project-add-dialog">
 					<DialogHeader>
-						<DialogTitle>Link project</DialogTitle>
+						<DialogTitle>Link projects to Agent</DialogTitle>
 						<DialogDescription>
-							Choose a Project. This Agent will use its Skills and attached Vaults together.
+							Select Projects to add. Existing links stay in place.
 						</DialogDescription>
 					</DialogHeader>
 					<form
 						className="space-y-4"
 						onSubmit={(event) => {
 							event.preventDefault();
-							submitExistingProjectLink();
+							submitExistingProjectLinks();
 						}}
 					>
-						{contextChoices.length > 0 ? (
-							<ProjectCompactPicker
-								projects={contextChoices}
-								value={contextProjectId}
-								onValueChange={setContextProjectId}
-								placeholder="Choose a Project…"
-								ariaLabel="Project to link"
-								disabled={linkContext.isPending}
-							/>
+						{linkProjects.length > 0 ? (
+							<div className="max-h-80 divide-y overflow-y-auto rounded-md border">
+								{linkProjects.map((project) => {
+									const name = displayProjectName(project);
+									const checkboxId = `agent-project-${project.id}`;
+									const isLinked = linkedProjectIds.has(project.id);
+									const isSelected = selectedProjectIds.has(project.id);
+									return (
+										<label
+											key={project.id}
+											htmlFor={checkboxId}
+											className={
+												isLinked
+													? "flex items-center gap-3 bg-muted/30 px-3 py-3"
+													: "flex cursor-pointer items-center gap-3 px-3 py-3 hover:bg-muted/20"
+											}
+										>
+											<Checkbox
+												id={checkboxId}
+												checked={isLinked || isSelected}
+												disabled={isLinked || linkContexts.isPending}
+												aria-label={isLinked ? `${name} already linked` : `Link ${name}`}
+												onCheckedChange={(checked) => {
+													setSelectedProjectIds((current) => {
+														const next = new Set(current);
+														if (checked === true) next.add(project.id);
+														else next.delete(project.id);
+														return next;
+													});
+												}}
+											/>
+											<ProjectIdentity
+												project={project}
+												showKind={false}
+												className="min-w-0 flex-1"
+											/>
+											<Badge variant={isLinked ? "secondary" : "outline"} className="shrink-0">
+												{isLinked ? "Linked" : "Available"}
+											</Badge>
+										</label>
+									);
+								})}
+							</div>
 						) : (
 							<p className="text-sm text-muted-foreground">No Projects are available to link.</p>
 						)}
@@ -413,13 +466,18 @@ function AgentProjectsPanel({
 							<Button type="button" variant="ghost" onClick={() => setLinkOpen(false)}>
 								Cancel
 							</Button>
-							<Button type="submit" disabled={!contextProjectId || linkContext.isPending}>
-								{linkContext.isPending ? (
+							<Button
+								type="submit"
+								disabled={selectedProjects.length === 0 || linkContexts.isPending}
+							>
+								{linkContexts.isPending ? (
 									<Spinner className="size-3.5" />
 								) : (
 									<Plus className="size-3.5" />
 								)}
-								Link project
+								{linkContexts.isPending
+									? "Linking…"
+									: `Link ${selectedProjects.length} ${selectedProjects.length === 1 ? "Project" : "Projects"}`}
 							</Button>
 						</DialogFooter>
 					</form>

--- a/apps/web/src/components/dashboard/agent-projects-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-projects-tab.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
-import { ArrowDown, ArrowUp, Link2, Plus, Trash2 } from "lucide-react";
+import { Link2, Plus, Trash2 } from "lucide-react";
 import { type ReactNode, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -232,35 +232,6 @@ function AgentProjectsPanel({
 			toast.error("Couldn't unlink project", { description: normalizeApiError(error) }),
 	});
 
-	const reorder = useMutation({
-		mutationFn: async (items: Array<{ binding_id: string; priority: number }>) => {
-			await unwrap(
-				await api.PATCH("/v1/agents/{agent_id}/project-bindings/context/reorder", {
-					params: { path: { agent_id: agentId } },
-					body: { items },
-				}),
-			);
-		},
-		onSuccess: () => {
-			onChanged();
-			toast.success("Project order updated");
-		},
-		onError: (error) =>
-			toast.error("Couldn't update Project order", {
-				description: normalizeApiError(error),
-			}),
-	});
-
-	const moveContext = (bindingId: string, direction: -1 | 1) => {
-		const index = contexts.findIndex((binding) => binding.id === bindingId);
-		const targetIndex = index + direction;
-		if (index < 0 || targetIndex < 0 || targetIndex >= contexts.length) return;
-		const next = contexts.slice();
-		const [item] = next.splice(index, 1);
-		if (!item) return;
-		next.splice(targetIndex, 0, item);
-		reorder.mutate(next.map((binding, idx) => ({ binding_id: binding.id, priority: idx + 1 })));
-	};
 	const actionsDisabled = !primary || isLoading || Boolean(bindingsError || projectsError);
 	const header = (
 		<PageHeader
@@ -348,10 +319,10 @@ function AgentProjectsPanel({
 			) : (
 				<ol
 					className={HERO_GRID_CLASS}
-					aria-label="Linked Projects in use order"
+					aria-label="Linked Projects"
 					data-testid="agent-project-grid"
 				>
-					{contexts.map((binding, position) => {
+					{contexts.map((binding) => {
 						const project = projectsById.get(binding.project_id);
 						const projectName = project ? displayProjectName(project) : "Unavailable Project";
 						const isRemoving = removeBinding.isPending && removeBinding.variables === binding.id;
@@ -364,30 +335,9 @@ function AgentProjectsPanel({
 							>
 								<AgentProjectCard
 									project={project}
-									position={position}
 									navigationScope={navigationScope}
 									actions={
-										<div className="flex items-center gap-0.5">
-											<Button
-												variant="ghost"
-												size="icon-sm"
-												disabled={position === 0 || reorder.isPending}
-												onClick={() => moveContext(binding.id, -1)}
-												title="Move up"
-												aria-label={`Move ${projectName} up`}
-											>
-												<ArrowUp className="size-3.5" />
-											</Button>
-											<Button
-												variant="ghost"
-												size="icon-sm"
-												disabled={position === contexts.length - 1 || reorder.isPending}
-												onClick={() => moveContext(binding.id, 1)}
-												title="Move down"
-												aria-label={`Move ${projectName} down`}
-											>
-												<ArrowDown className="size-3.5" />
-											</Button>
+										<div>
 											<ConfirmAction
 												title="Unlink this Project?"
 												description={
@@ -544,25 +494,17 @@ function AgentProjectsPanel({
 
 function AgentProjectCard({
 	project,
-	position,
 	navigationScope,
 	actions,
 }: {
 	project: ProjectRow | undefined;
-	position: number;
 	navigationScope: ResourceNavigationScope;
 	actions?: ReactNode;
 }) {
-	const footer = [`Project order ${position + 1}`];
 	if (!project) {
-		return <UnavailableProjectResourceCard footer={footer} actions={actions} />;
+		return <UnavailableProjectResourceCard actions={actions} />;
 	}
 	return (
-		<ProjectResourceCard
-			project={project}
-			footer={footer}
-			actions={actions}
-			navigationScope={navigationScope}
-		/>
+		<ProjectResourceCard project={project} actions={actions} navigationScope={navigationScope} />
 	);
 }

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -71,6 +71,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import {
 	Dialog,
@@ -383,7 +384,7 @@ export default function ProjectDetailPage({
 		"get",
 		"/v1/agents",
 		{ params: { query: { project_id: projectId } } },
-		{ enabled: !isAgentScope && !!project && localTab === "agents" },
+		{ enabled: !isAgentScope && !!project && (localTab === "agents" || useWithAgentOpen) },
 	);
 
 	const refresh = () => {
@@ -611,6 +612,9 @@ export default function ProjectDetailPage({
 	const blockingBoundAgentsError = shouldBlockQueryError(boundAgents.error, boundAgents.data)
 		? boundAgents.error
 		: null;
+	const blockingEnvironmentsError = shouldBlockQueryError(environments.error, environments.data)
+		? environments.error
+		: null;
 	const skillCount: CountValue | undefined = isAgentScope
 		? isWorkspace || project.kind === "environment"
 			? undefined
@@ -630,7 +634,13 @@ export default function ProjectDetailPage({
 		<UseProjectWithAgentDialog
 			project={project}
 			environments={environments.data ?? []}
-			isLoadingEnvironments={environments.isLoading}
+			linkedEnvironments={boundAgents.data ?? []}
+			isLoadingAgents={environments.isLoading || boundAgents.isLoading}
+			agentsError={blockingEnvironmentsError ?? blockingBoundAgentsError}
+			onRetryAgents={() => {
+				void environments.refetch();
+				void boundAgents.refetch();
+			}}
 			open={useWithAgentOpen}
 			onOpenChange={handleUseWithAgentOpenChange}
 		>
@@ -1561,69 +1571,69 @@ function SharedAccessPanel({
 function UseProjectWithAgentDialog({
 	project,
 	environments,
-	isLoadingEnvironments,
+	linkedEnvironments,
+	isLoadingAgents,
+	agentsError,
+	onRetryAgents,
 	open,
 	onOpenChange,
 	children,
 }: {
 	project: ProjectRow;
 	environments: Env[];
-	isLoadingEnvironments: boolean;
+	linkedEnvironments: Env[];
+	isLoadingAgents: boolean;
+	agentsError?: unknown;
+	onRetryAgents: () => void;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	children: ReactElement;
 }) {
 	const api = useApi();
 	const qc = useQueryClient();
-	const router = useRouter();
 	const projectName = displayProjectName(project);
-	const [selectedAgentId, setSelectedAgentId] = useState("");
+	const [selectedAgentIds, setSelectedAgentIds] = useState<Set<string>>(() => new Set());
 	const orderedEnvironments = useMemo(
 		() => [...environments].sort(compareAgentEnvironments),
 		[environments],
 	);
-	const agentItems = orderedEnvironments.map((env) => ({
-		value: env.id,
-		label: agentDisplayName(env),
-	}));
-	const selectedEnv = orderedEnvironments.find((env) => env.id === selectedAgentId) ?? null;
-	const projectIsHome = selectedEnv?.default_project_id === project.id;
-	const selectedBindings = useAgentProjectBindings(selectedAgentId, { enabled: open });
-	const blockingSelectedBindingsError = shouldBlockQueryError(
-		selectedBindings.error,
-		selectedBindings.data,
+	const linkedAgentIds = useMemo(
+		() => new Set(linkedEnvironments.map((environment) => environment.id)),
+		[linkedEnvironments],
 	);
-	const existingBinding =
-		selectedBindings.data?.find((binding) => binding.project_id === project.id) ?? null;
-	const projectIsAlreadyAvailable = projectIsHome || !!existingBinding;
+	const selectedAgents = orderedEnvironments.filter(
+		(environment) => selectedAgentIds.has(environment.id) && !linkedAgentIds.has(environment.id),
+	);
 
 	useEffect(() => {
-		if (!open) return;
-		if (selectedAgentId && orderedEnvironments.some((env) => env.id === selectedAgentId)) return;
-		setSelectedAgentId(orderedEnvironments[0]?.id ?? "");
-	}, [open, orderedEnvironments, selectedAgentId]);
+		if (!open) setSelectedAgentIds(new Set());
+	}, [open]);
 
-	const addProjectToAgent = useMutation({
-		mutationFn: async () => {
-			if (!selectedAgentId) throw new Error("Choose an agent first");
+	const addProjectToAgents = useMutation({
+		mutationFn: async (agentIds: string[]) => {
+			if (agentIds.length === 0) throw new Error("Choose at least one agent");
 			return unwrap(
-				await api.POST("/v1/agents/{agent_id}/project-bindings/context", {
-					params: { path: { agent_id: selectedAgentId } },
-					body: { project_id: project.id },
+				await api.POST("/v1/projects/{project_id}/agents", {
+					params: { path: { project_id: project.id } },
+					body: { agent_ids: agentIds },
 				}),
 			);
 		},
-		onSuccess: () => {
-			const agentName = selectedEnv ? agentDisplayName(selectedEnv) : "the agent";
-			qc.invalidateQueries({ queryKey: agentProjectBindingsQueryKey(selectedAgentId) });
-			qc.invalidateQueries({ queryKey: ["get", "/v1/vault"] });
+		onSuccess: async (_response, agentIds) => {
+			await Promise.all([
+				qc.invalidateQueries({ queryKey: ["get", "/v1/projects"] }),
+				qc.invalidateQueries({ queryKey: ["get", "/v1/projects/{project_id}"] }),
+				qc.invalidateQueries({ queryKey: ["get", "/v1/agents"] }),
+				qc.invalidateQueries({ queryKey: ["get", "/v1/vault"] }),
+				qc.invalidateQueries({ queryKey: ["skills"] }),
+				qc.invalidateQueries({ queryKey: ["vaults"] }),
+				...agentIds.map((agentId) =>
+					qc.invalidateQueries({ queryKey: agentProjectBindingsQueryKey(agentId) }),
+				),
+			]);
+			setSelectedAgentIds(new Set());
 			toast.success("Project linked", {
-				description: `${agentName} can now use ${projectName}'s Skills and attached Vaults.`,
-				action: {
-					label: "Open agent",
-					onClick: () =>
-						void router.navigate({ href: agentSectionHref(selectedAgentId, "projects") }),
-				},
+				description: `${agentIds.length} ${agentIds.length === 1 ? "Agent can" : "Agents can"} now use ${projectName}'s Skills and attached Vaults.`,
 			});
 			onOpenChange(false);
 		},
@@ -1639,14 +1649,14 @@ function UseProjectWithAgentDialog({
 			<DialogTrigger render={children} />
 			<DialogContent className="sm:max-w-lg">
 				<DialogHeader>
-					<DialogTitle>Link project to Agent</DialogTitle>
-					<DialogDescription>
-						The Agent will use {projectName}&apos;s Skills and attached Vaults as one bundle.
-					</DialogDescription>
+					<DialogTitle>Link project to Agents</DialogTitle>
+					<DialogDescription>Select Agents to add. Existing links stay in place.</DialogDescription>
 				</DialogHeader>
 
-				{isLoadingEnvironments ? (
+				{isLoadingAgents ? (
 					<Skeleton className="h-24 w-full" />
+				) : agentsError ? (
+					<ApiErrorPanel error={agentsError} onRetry={onRetryAgents} title="Couldn't load Agents" />
 				) : orderedEnvironments.length === 0 ? (
 					<Alert>
 						<Bot className="size-4" />
@@ -1658,142 +1668,73 @@ function UseProjectWithAgentDialog({
 					</Alert>
 				) : (
 					<div className="space-y-4">
-						<div className="space-y-2">
-							<div className="text-sm font-medium">Agent</div>
-							<Select
-								items={agentItems}
-								value={selectedAgentId}
-								onValueChange={(value) => {
-									if (value !== null) setSelectedAgentId(value);
-								}}
-							>
-								<SelectTrigger
-									aria-label="Agent to link this Project to"
-									className="h-auto min-h-9 w-full justify-between py-2"
-								>
-									{selectedEnv ? (
+						<div className="max-h-80 divide-y overflow-y-auto rounded-md border">
+							{orderedEnvironments.map((environment) => {
+								const name = agentDisplayName(environment);
+								const checkboxId = `project-agent-${environment.id}`;
+								const isLinked = linkedAgentIds.has(environment.id);
+								const isSelected = selectedAgentIds.has(environment.id);
+								return (
+									<label
+										key={environment.id}
+										htmlFor={checkboxId}
+										className={cn(
+											"flex items-center gap-3 px-3 py-3",
+											isLinked ? "bg-muted/30" : "cursor-pointer hover:bg-muted/20",
+										)}
+									>
+										<Checkbox
+											id={checkboxId}
+											checked={isLinked || isSelected}
+											disabled={isLinked || addProjectToAgents.isPending}
+											aria-label={isLinked ? `${name} already linked` : `Link ${name}`}
+											onCheckedChange={(checked) => {
+												setSelectedAgentIds((current) => {
+													const next = new Set(current);
+													if (checked === true) next.add(environment.id);
+													else next.delete(environment.id);
+													return next;
+												});
+											}}
+										/>
 										<AgentLabel
-											machineName={selectedEnv.machine_name}
-											displayName={selectedEnv.display_name}
-											defaultName={selectedEnv.default_name}
-											type={selectedEnv.agent_type}
-											avatarUrl={selectedEnv.avatar_url}
+											machineName={environment.machine_name}
+											displayName={environment.display_name}
+											defaultName={environment.default_name}
+											type={environment.agent_type}
+											avatarUrl={environment.avatar_url}
 											size="sm"
-											titleAdornment={<AgentSourceBadgeForEnvironment env={selectedEnv} compact />}
+											primary="machine"
+											titleAdornment={<AgentSourceBadgeForEnvironment env={environment} compact />}
+											meta={[
+												environment.last_sync_at
+													? `synced ${formatShortDate(environment.last_sync_at, { includeYear: false })}`
+													: "not synced yet",
+											]}
 											className="min-w-0 flex-1"
 										/>
-									) : (
-										<SelectValue placeholder="Choose an agent…" />
-									)}
-								</SelectTrigger>
-								<SelectContent align="start" alignItemWithTrigger={false}>
-									{orderedEnvironments.map((env) => (
-										<SelectItem
-											key={env.id}
-											value={env.id}
-											label={agentDisplayName(env)}
-											className="py-2"
-										>
-											<AgentLabel
-												machineName={env.machine_name}
-												displayName={env.display_name}
-												defaultName={env.default_name}
-												type={env.agent_type}
-												avatarUrl={env.avatar_url}
-												size="sm"
-												primary="machine"
-												titleAdornment={<AgentSourceBadgeForEnvironment env={env} compact />}
-												meta={[
-													env.last_sync_at
-														? `synced ${formatShortDate(env.last_sync_at, { includeYear: false })}`
-														: "not synced yet",
-												]}
-											/>
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
+										<Badge variant={isLinked ? "secondary" : "outline"} className="shrink-0">
+											{isLinked ? "Linked" : "Available"}
+										</Badge>
+									</label>
+								);
+							})}
 						</div>
 
-						<div className="rounded-md border bg-muted/30 p-3 text-sm">
-							{projectIsHome ? (
-								<div className="flex items-start gap-2">
-									<CheckCircle2 className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-									<div>
-										<div className="font-medium">This is the Agent&apos;s Workspace</div>
-										<p className="mt-1 text-xs text-muted-foreground">
-											No extra Project link is needed. Edit Workspace Skills and Vaults from the
-											Agent&apos;s Workspace section.
-										</p>
-									</div>
-								</div>
-							) : existingBinding ? (
-								<div className="flex items-start gap-2">
-									<CheckCircle2 className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-									<div>
-										<div className="font-medium">Already linked</div>
-										<p className="mt-1 text-xs text-muted-foreground">
-											Open the Agent&apos;s {AGENT_PROJECTS_SECTION_LABEL} section to review its
-											Project order or unlink it.
-										</p>
-									</div>
-								</div>
-							) : (
-								<div className="flex items-start gap-2">
-									<Bot className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-									<div>
-										<div className="font-medium">Link project</div>
-										<p className="mt-1 text-xs text-muted-foreground">
-											The selected Agent will use this Project&apos;s Skills and attached Vaults
-											together.
-										</p>
-									</div>
-								</div>
-							)}
-						</div>
-
-						{blockingSelectedBindingsError ? (
-							<ApiErrorPanel
-								error={selectedBindings.error}
-								onRetry={() => {
-									void selectedBindings.refetch();
-								}}
-								title="Couldn't check this agent's Project list"
-							/>
-						) : null}
-
-						<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+						<DialogFooter>
 							<Button variant="ghost" onClick={() => onOpenChange(false)}>
 								Cancel
 							</Button>
-							{projectIsAlreadyAvailable && selectedEnv ? (
-								<Button
-									render={
-										<Link
-											to="/agents/$id/$section"
-											params={{ id: selectedEnv.id, section: "project-access" }}
-										/>
-									}
-									nativeButton={false}
-								>
-									Open projects
-								</Button>
-							) : (
-								<Button
-									onClick={() => addProjectToAgent.mutate()}
-									disabled={
-										!selectedAgentId ||
-										addProjectToAgent.isPending ||
-										selectedBindings.isLoading ||
-										blockingSelectedBindingsError ||
-										projectIsAlreadyAvailable
-									}
-								>
-									{addProjectToAgent.isPending ? <Spinner /> : <Plus className="mr-1.5 size-3.5" />}
-									{addProjectToAgent.isPending ? "Linking…" : "Link project"}
-								</Button>
-							)}
-						</div>
+							<Button
+								onClick={() => addProjectToAgents.mutate(selectedAgents.map((agent) => agent.id))}
+								disabled={selectedAgents.length === 0 || addProjectToAgents.isPending}
+							>
+								{addProjectToAgents.isPending ? <Spinner /> : <Plus className="mr-1.5 size-3.5" />}
+								{addProjectToAgents.isPending
+									? "Linking…"
+									: `Link ${selectedAgents.length} ${selectedAgents.length === 1 ? "Agent" : "Agents"}`}
+							</Button>
+						</DialogFooter>
 					</div>
 				)}
 			</DialogContent>

--- a/apps/web/src/pages/dashboard/projects/project-navigation-copy.test.ts
+++ b/apps/web/src/pages/dashboard/projects/project-navigation-copy.test.ts
@@ -10,7 +10,7 @@ describe("Project navigation instructions", () => {
 		expect(projectDetailSource).toContain(
 			'const AGENT_PROJECTS_SECTION_LABEL = agentSectionLabel("projects");',
 		);
-		expect(projectDetailSource.match(/\{AGENT_PROJECTS_SECTION_LABEL\}/g)).toHaveLength(2);
+		expect(projectDetailSource.match(/\{AGENT_PROJECTS_SECTION_LABEL\}/g)).toHaveLength(1);
 		expect(projectDetailSource).not.toContain("Project Access section");
 	});
 });

--- a/backend/app/routes/agent_project_bindings.py
+++ b/backend/app/routes/agent_project_bindings.py
@@ -184,7 +184,7 @@ async def add_context_project_binding(
         if priority_conflict is not None:
             raise HTTPException(
                 status.HTTP_409_CONFLICT,
-                "Project order is already in use",
+                "Vault resolution priority is already in use",
             )
     binding = await ensure_context_binding(
         db,
@@ -218,7 +218,7 @@ async def reorder_context_project_bindings(
     if len({item.binding_id for item in body.items}) != len(body.items):
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "duplicate binding_id")
     if len({item.priority for item in body.items}) != len(body.items):
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, "duplicate Project order")
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "duplicate Vault resolution priority")
 
     current_context_rows = (
         (
@@ -246,7 +246,7 @@ async def reorder_context_project_bindings(
         if item.priority < 1:
             raise HTTPException(
                 status.HTTP_400_BAD_REQUEST,
-                "Project order must be >= 1",
+                "Vault resolution priority must be >= 1",
             )
         requested.append((binding, item.priority))
 
@@ -256,10 +256,11 @@ async def reorder_context_project_bindings(
         if binding.id not in requested_ids and binding.priority in requested_priorities:
             raise HTTPException(
                 status.HTTP_409_CONFLICT,
-                "Project order is already in use",
+                "Vault resolution priority is already in use",
             )
 
-    if requested:
+    changed = any(binding.priority != priority for binding, priority in requested)
+    if changed:
         max_priority = max([binding.priority for binding in current_context_rows] + [0])
         temp_base = max_priority + len(requested) + 1000
         for offset, (binding, _priority) in enumerate(requested, start=1):
@@ -268,6 +269,7 @@ async def reorder_context_project_bindings(
 
         for binding, priority in requested:
             binding.priority = priority
+        await queue_environment_runtime_manifest_changed(db, auth.user_id, agent_id)
 
     await db.commit()
     return BindingReorderResponse(status="reordered")

--- a/backend/app/routes/agent_project_bindings.py
+++ b/backend/app/routes/agent_project_bindings.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
 from sqlalchemy import case, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -12,7 +13,6 @@ from app.core.auth import AuthContext, require_user_auth_unbound
 from app.core.database import get_session
 from app.core.project import project_ids_visible_to
 from app.models.agent_project_binding import AgentProjectBinding
-from app.models.project import PROJECT_KIND_WORKSPACE
 from app.schemas.sharing import (
     AgentProjectBindingResponse,
     BindingCreate,
@@ -21,7 +21,8 @@ from app.schemas.sharing import (
     BindingReorderResponse,
 )
 from app.services.agent_bindings import (
-    assert_project_visible_to_user,
+    assert_project_linkable_to_agent,
+    attach_projects_to_owned_agent,
     ensure_agent_primary_binding,
     ensure_context_binding,
     get_owned_agent_or_404,
@@ -34,6 +35,15 @@ from app.services.project_runtime_skills import (
 from app.services.sync_events import queue_environment_runtime_manifest_changed
 
 router = APIRouter(prefix="/agents", tags=["agent-project-bindings"])
+
+
+class AgentProjectLinkBody(BaseModel):
+    project_ids: list[str] = Field(min_length=1, max_length=200)
+
+
+class AgentProjectLinkResponse(BaseModel):
+    agent_id: str
+    bound_project_ids: list[str]
 
 
 def _to_response(binding: AgentProjectBinding) -> AgentProjectBindingResponse:
@@ -120,6 +130,26 @@ async def list_project_bindings(
     return [_to_response(row) for row in rows]
 
 
+@router.post("/{agent_id}/projects", response_model=AgentProjectLinkResponse)
+async def link_agent_projects(
+    agent_id: UUID,
+    body: AgentProjectLinkBody,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> AgentProjectLinkResponse:
+    bound_project_ids = await attach_projects_to_owned_agent(
+        db,
+        user_id=auth.user_id,
+        agent_id=agent_id,
+        raw_project_ids=body.project_ids,
+    )
+    await db.commit()
+    return AgentProjectLinkResponse(
+        agent_id=str(agent_id),
+        bound_project_ids=bound_project_ids,
+    )
+
+
 @router.post(
     "/{agent_id}/project-bindings/context",
     response_model=AgentProjectBindingResponse,
@@ -141,30 +171,21 @@ async def add_context_project_binding(
     except ValueError as err:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "invalid project_id") from err
 
-    project = await assert_project_visible_to_user(db, user_id=auth.user_id, project_id=project_id)
-    if project_id == agent.default_project_id:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST,
-            "This Project is already the Agent Workspace",
-        )
-    if project.kind != PROJECT_KIND_WORKSPACE:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST,
-            "Only Projects you create or that are shared with you can be linked",
-        )
+    await assert_project_linkable_to_agent(
+        db,
+        user_id=auth.user_id,
+        agent=agent,
+        project_id=project_id,
+    )
     await lock_project_binding_change(db, project_id=project_id, agent_id=agent_id)
     # Archive/unshare can race the initial picker read. Access and Project kind
     # must still be valid at the serialized Link boundary.
-    project = await assert_project_visible_to_user(
+    await assert_project_linkable_to_agent(
         db,
         user_id=auth.user_id,
+        agent=agent,
         project_id=project_id,
     )
-    if project.kind != PROJECT_KIND_WORKSPACE:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST,
-            "Only Projects you create or that are shared with you can be linked",
-        )
     await assert_project_link_compatible(
         db,
         agent_id=agent_id,

--- a/backend/app/routes/projects.py
+++ b/backend/app/routes/projects.py
@@ -25,6 +25,7 @@ from app.models.session import AgentEnvironment
 from app.models.skill import Skill
 from app.models.user import User
 from app.models.vault import VaultProjectAttachment
+from app.services.agent_bindings import attach_project_to_owned_agents
 from app.services.agent_lifecycle import active_project_filter
 from app.services.project_runtime_skills import (
     lock_project_change,
@@ -123,6 +124,15 @@ class ProjectUpdate(BaseModel):
 class ProjectArchiveResponse(BaseModel):
     status: str = "archived"
     unlinked_agent_count: int
+
+
+class ProjectAgentLinkBody(BaseModel):
+    agent_ids: list[str] = Field(min_length=1, max_length=200)
+
+
+class ProjectAgentLinkResponse(BaseModel):
+    project_id: str
+    bound_agent_ids: list[str]
 
 
 def _project_response(
@@ -431,6 +441,26 @@ async def update_project(
         vault_count=counts.vault_count,
         agent_count=counts.agent_count,
         member_count=counts.member_count,
+    )
+
+
+@router.post("/{project_id}/agents", response_model=ProjectAgentLinkResponse)
+async def link_project_agents(
+    project_id: UUID,
+    body: ProjectAgentLinkBody,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> ProjectAgentLinkResponse:
+    bound_agent_ids = await attach_project_to_owned_agents(
+        db,
+        user_id=auth.user_id,
+        project_id=project_id,
+        raw_agent_ids=body.agent_ids,
+    )
+    await db.commit()
+    return ProjectAgentLinkResponse(
+        project_id=str(project_id),
+        bound_agent_ids=bound_agent_ids,
     )
 
 

--- a/backend/app/routes/vault.py
+++ b/backend/app/routes/vault.py
@@ -1149,7 +1149,9 @@ async def resolve_vault(
     ),
     agent_id: UUID | None = Query(
         default=None,
-        description="Resolve through an Agent Project and attached Project order.",
+        description=(
+            "Resolve through an Agent Project and linked Project Vault resolution priority."
+        ),
     ),
     allow_conflicts: bool = Query(
         default=False,

--- a/backend/app/routes/vault.py
+++ b/backend/app/routes/vault.py
@@ -1007,7 +1007,8 @@ def _resolve_exact_vault_reference_from_index(
                 "reference": reference,
                 "message": (
                     "Vault reference exists in multiple attached Projects; "
-                    "pass allow_conflicts=true to use the first Project in Agent order."
+                    "pass allow_conflicts=true to use the first Project by "
+                    "Vault resolution priority."
                 ),
                 "winner": {
                     "source_project_id": winner["source_project_id"],
@@ -1295,7 +1296,8 @@ async def resolve_vault(
                     "key": key,
                     "message": (
                         "Vault key exists in multiple attached Projects; "
-                        "pass allow_conflicts=true to use the first Project in Agent order."
+                        "pass allow_conflicts=true to use the first Project by "
+                        "Vault resolution priority."
                     ),
                     "winner": {
                         "source_project_id": winner["source_project_id"],
@@ -1363,7 +1365,8 @@ async def resolve_vault(
                     "code": "vault_conflicts_blocked",
                     "message": (
                         "Vault keys conflict across attached Projects; "
-                        "pass allow_conflicts=true to use the first Project in Agent order."
+                        "pass allow_conflicts=true to use the first Project by "
+                        "Vault resolution priority."
                     ),
                     "conflicts": conflicts,
                 },

--- a/backend/app/services/agent_bindings.py
+++ b/backend/app/services/agent_bindings.py
@@ -10,7 +10,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.agent_project_binding import AgentProjectBinding
-from app.models.project import Project
+from app.models.project import PROJECT_KIND_WORKSPACE, Project
 from app.models.project_membership import ProjectMembership
 from app.models.session import AgentEnvironment
 from app.services.agent_lifecycle import active_agent_filter, active_project_filter
@@ -180,7 +180,7 @@ async def ensure_context_binding(
     if priority < 1:
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,
-            "Project order must be >= 1",
+            "Vault resolution priority must be >= 1",
         )
 
     binding = AgentProjectBinding(
@@ -222,7 +222,12 @@ async def attach_project_to_owned_agents(
 
     if not agent_ids:
         return []
-    await assert_project_visible_to_user(db, user_id=user_id, project_id=project_id)
+    project = await assert_project_visible_to_user(db, user_id=user_id, project_id=project_id)
+    if project.kind != PROJECT_KIND_WORKSPACE:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Only Projects you create or that are shared with you can be linked",
+        )
     await lock_project_agent_binding_changes(
         db,
         project_id=project_id,
@@ -230,7 +235,12 @@ async def attach_project_to_owned_agents(
     )
     # Re-check access after acquiring the Project graph lock so archive,
     # unshare, and explicit Link cannot cross at the write boundary.
-    await assert_project_visible_to_user(db, user_id=user_id, project_id=project_id)
+    project = await assert_project_visible_to_user(db, user_id=user_id, project_id=project_id)
+    if project.kind != PROJECT_KIND_WORKSPACE:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Only Projects you create or that are shared with you can be linked",
+        )
     for agent_id in sorted(agent_ids, key=str):
         await assert_project_link_compatible(
             db,

--- a/backend/app/services/agent_bindings.py
+++ b/backend/app/services/agent_bindings.py
@@ -82,6 +82,31 @@ async def assert_project_writable_by_user(
     return project
 
 
+async def assert_project_linkable_to_agent(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    agent: AgentEnvironment,
+    project_id: UUID,
+) -> Project:
+    project = await assert_project_visible_to_user(
+        db,
+        user_id=user_id,
+        project_id=project_id,
+    )
+    if project_id == agent.default_project_id:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "This Project is already the Agent Workspace",
+        )
+    if project.kind != PROJECT_KIND_WORKSPACE:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Only Projects you create or that are shared with you can be linked",
+        )
+    return project
+
+
 async def delete_project_bindings_for_users(
     db: AsyncSession,
     *,
@@ -259,6 +284,95 @@ async def attach_project_to_owned_agents(
         await queue_environment_runtime_manifest_changed(db, user_id, agent_id)
         bound_agent_ids.append(str(agent_id))
     return bound_agent_ids
+
+
+async def attach_projects_to_owned_agent(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    agent_id: UUID,
+    raw_project_ids: list[str] | None,
+) -> list[str]:
+    """Attach visible Projects to one owned Agent in a single transaction."""
+    from app.services.project_runtime_skills import (
+        assert_project_link_compatible,
+        lock_project_binding_set_change,
+    )
+    from app.services.sync_events import queue_environment_runtime_manifest_changed
+
+    agent = await get_owned_agent_or_404(db, user_id=user_id, agent_id=agent_id)
+    project_ids: list[UUID] = []
+    for raw_project_id in raw_project_ids or []:
+        try:
+            project_id = UUID(raw_project_id)
+        except ValueError as err:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, "invalid project id") from err
+        if project_id not in project_ids:
+            project_ids.append(project_id)
+
+    if not project_ids:
+        return []
+    for project_id in project_ids:
+        await assert_project_linkable_to_agent(
+            db,
+            user_id=user_id,
+            agent=agent,
+            project_id=project_id,
+        )
+
+    await lock_project_binding_set_change(
+        db,
+        project_ids=project_ids,
+        agent_id=agent_id,
+    )
+    # Re-check the full selection after locking so archive or unshare cannot
+    # leave a partially applied batch.
+    for project_id in project_ids:
+        await assert_project_linkable_to_agent(
+            db,
+            user_id=user_id,
+            agent=agent,
+            project_id=project_id,
+        )
+
+    await ensure_agent_primary_binding(
+        db,
+        agent=agent,
+        created_by_user_id=user_id,
+    )
+    existing_project_ids = set(
+        (
+            await db.execute(
+                select(AgentProjectBinding.project_id).where(
+                    AgentProjectBinding.agent_id == agent_id,
+                )
+            )
+        ).scalars()
+    )
+
+    changed = False
+    for project_id in project_ids:
+        if project_id in existing_project_ids:
+            continue
+        # Each inserted binding is flushed before the next compatibility
+        # check, so conflicts within the submitted batch also fail atomically.
+        await assert_project_link_compatible(
+            db,
+            agent_id=agent_id,
+            project_id=project_id,
+        )
+        await ensure_context_binding(
+            db,
+            agent_id=agent_id,
+            project_id=project_id,
+            created_by_user_id=user_id,
+        )
+        existing_project_ids.add(project_id)
+        changed = True
+
+    if changed:
+        await queue_environment_runtime_manifest_changed(db, user_id, agent_id)
+    return [str(project_id) for project_id in project_ids]
 
 
 async def ensure_agent_primary_binding(

--- a/backend/tests/test_agent_project_bindings_routes.py
+++ b/backend/tests/test_agent_project_bindings_routes.py
@@ -8,6 +8,7 @@ def test_agent_project_binding_routes_registered():
 
     paths = {route.path for route in iter_route_contexts(app.routes)}
     assert "/v1/projects/{project_id}/agents" in paths
+    assert "/v1/agents/{agent_id}/projects" in paths
     assert "/v1/agents/{agent_id}/project-bindings" in paths
     assert "/v1/agents/{agent_id}/project-bindings/context" in paths
     assert "/v1/agents/{agent_id}/project-bindings/context/reorder" in paths

--- a/backend/tests/test_agent_project_bindings_routes.py
+++ b/backend/tests/test_agent_project_bindings_routes.py
@@ -7,6 +7,7 @@ def test_agent_project_binding_routes_registered():
     from app.main import app
 
     paths = {route.path for route in iter_route_contexts(app.routes)}
+    assert "/v1/projects/{project_id}/agents" in paths
     assert "/v1/agents/{agent_id}/project-bindings" in paths
     assert "/v1/agents/{agent_id}/project-bindings/context" in paths
     assert "/v1/agents/{agent_id}/project-bindings/context/reorder" in paths

--- a/backend/tests/test_project_agent_role_paths.py
+++ b/backend/tests/test_project_agent_role_paths.py
@@ -633,15 +633,23 @@ async def test_context_reorder_can_swap_priorities(client, db_session, seed_user
         bindings.append(row)
     await db_session.commit()
 
-    response = await client.patch(
-        f"/v1/agents/{env.id}/project-bindings/context/reorder",
-        json={
-            "items": [
-                {"binding_id": str(bindings[0].id), "priority": 2},
-                {"binding_id": str(bindings[1].id), "priority": 1},
-            ]
-        },
-    )
+    queue = sync_events.subscribe(seed_user.id, frozenset(), environment_id=env.id)
+    try:
+        response = await client.patch(
+            f"/v1/agents/{env.id}/project-bindings/context/reorder",
+            json={
+                "items": [
+                    {"binding_id": str(bindings[0].id), "priority": 2},
+                    {"binding_id": str(bindings[1].id), "priority": 1},
+                ]
+            },
+        )
+        assert queue.get_nowait() == {
+            "type": "runtime_manifest_changed",
+            "environment_id": str(env.id),
+        }
+    finally:
+        sync_events.unsubscribe(seed_user.id, queue)
     assert response.status_code == 200, response.text
 
     rows = (

--- a/backend/tests/test_project_agent_role_paths.py
+++ b/backend/tests/test_project_agent_role_paths.py
@@ -298,6 +298,74 @@ async def test_agent_binding_attach_repairs_stale_primary_before_returning_conte
     assert [row.project_id for row in primary_rows] == [env.default_project_id]
 
 
+async def test_agent_batch_link_adds_projects_without_replacing_existing_links(
+    client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"batch-link-{uuid.uuid4().hex[:8]}",
+        machine_name="forge",
+    )
+    projects = [
+        Project(
+            user_id=seed_user.id,
+            name=name,
+            slug=f"{slug}-{uuid.uuid4().hex[:8]}",
+            kind=PROJECT_KIND_WORKSPACE,
+        )
+        for name, slug in (
+            ("Existing Context", "existing-context"),
+            ("Build Context", "build-context"),
+            ("Deploy Context", "deploy-context"),
+        )
+    ]
+    db_session.add_all(projects)
+    await db_session.commit()
+
+    existing = await client.post(
+        f"/v1/agents/{env.id}/project-bindings/context",
+        json={"project_id": str(projects[0].id)},
+    )
+    assert existing.status_code == 200, existing.text
+
+    queue = sync_events.subscribe(seed_user.id, frozenset(), environment_id=env.id)
+    try:
+        linked = await client.post(
+            f"/v1/agents/{env.id}/projects",
+            json={"project_ids": [str(projects[1].id), str(projects[2].id)]},
+        )
+        assert linked.status_code == 200, linked.text
+        assert linked.json() == {
+            "agent_id": str(env.id),
+            "bound_project_ids": [str(projects[1].id), str(projects[2].id)],
+        }
+        assert queue.get_nowait() == {
+            "type": "runtime_manifest_changed",
+            "environment_id": str(env.id),
+        }
+        assert queue.empty()
+    finally:
+        sync_events.unsubscribe(seed_user.id, queue)
+
+    bindings = (
+        (
+            await db_session.execute(
+                select(AgentProjectBinding).where(
+                    AgentProjectBinding.agent_id == env.id,
+                    AgentProjectBinding.binding_type == "context",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {binding.project_id for binding in bindings} == {project.id for project in projects}
+    assert sorted(binding.priority for binding in bindings) == [1, 2, 3]
+
+
 async def test_agent_context_attach_rejects_managed_projects(
     client,
     db_session,

--- a/backend/tests/test_projects_routes.py
+++ b/backend/tests/test_projects_routes.py
@@ -224,21 +224,27 @@ async def test_agents_project_filter_is_explicit_and_bounded(
     assert [agent["id"] for agent in response.json()] == [str(channel_agent.id)]
 
 
-async def test_project_batch_link_is_additive_for_two_owned_agents(
+async def test_project_batch_link_preserves_an_existing_owned_agent(
     client,
     db_session,
     workspace_project,
     channel_agent,
     second_channel_agent,
 ):
+    first_link = await client.post(
+        f"/v1/agents/{channel_agent.id}/project-bindings/context",
+        json={"project_id": str(workspace_project.id)},
+    )
+    assert first_link.status_code == 200, first_link.text
+
     linked = await client.post(
         f"/v1/projects/{workspace_project.id}/agents",
-        json={"agent_ids": [str(channel_agent.id), str(second_channel_agent.id)]},
+        json={"agent_ids": [str(second_channel_agent.id)]},
     )
     assert linked.status_code == 200, linked.text
     assert linked.json() == {
         "project_id": str(workspace_project.id),
-        "bound_agent_ids": [str(channel_agent.id), str(second_channel_agent.id)],
+        "bound_agent_ids": [str(second_channel_agent.id)],
     }
 
     bindings = (

--- a/backend/tests/test_projects_routes.py
+++ b/backend/tests/test_projects_routes.py
@@ -224,6 +224,52 @@ async def test_agents_project_filter_is_explicit_and_bounded(
     assert [agent["id"] for agent in response.json()] == [str(channel_agent.id)]
 
 
+async def test_project_batch_link_is_additive_for_two_owned_agents(
+    client,
+    db_session,
+    workspace_project,
+    channel_agent,
+    second_channel_agent,
+):
+    linked = await client.post(
+        f"/v1/projects/{workspace_project.id}/agents",
+        json={"agent_ids": [str(channel_agent.id), str(second_channel_agent.id)]},
+    )
+    assert linked.status_code == 200, linked.text
+    assert linked.json() == {
+        "project_id": str(workspace_project.id),
+        "bound_agent_ids": [str(channel_agent.id), str(second_channel_agent.id)],
+    }
+
+    bindings = (
+        (
+            await db_session.execute(
+                select(AgentProjectBinding).where(
+                    AgentProjectBinding.project_id == workspace_project.id,
+                    AgentProjectBinding.binding_type == "context",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {binding.agent_id for binding in bindings} == {
+        channel_agent.id,
+        second_channel_agent.id,
+    }
+
+    detail = await client.get(f"/v1/projects/{workspace_project.id}")
+    assert detail.status_code == 200, detail.text
+    assert detail.json()["agent_count"] == 2
+
+    filtered = await client.get("/v1/agents", params={"project_id": str(workspace_project.id)})
+    assert filtered.status_code == 200, filtered.text
+    assert {agent["id"] for agent in filtered.json()} == {
+        str(channel_agent.id),
+        str(second_channel_agent.id),
+    }
+
+
 async def test_global_search_finds_projects_by_name_and_slug(client):
     created = await client.post("/v1/projects", json={"name": "Redpill Launch"})
     assert created.status_code == 201, created.text
@@ -232,9 +278,7 @@ async def test_global_search_finds_projects_by_name_and_slug(client):
     by_name = await client.get("/v1/search", params={"q": "redpill"})
     assert by_name.status_code == 200, by_name.text
     project_hits = [h for h in by_name.json()["results"] if h["type"] == "project"]
-    assert [(h["id"], h["href"]) for h in project_hits] == [
-        (project_id, f"/projects/{project_id}")
-    ]
+    assert [(h["id"], h["href"]) for h in project_hits] == [(project_id, f"/projects/{project_id}")]
 
     by_slug = await client.get("/v1/search", params={"q": "redpill-launch"})
     slug_hits = [h for h in by_slug.json()["results"] if h["type"] == "project"]

--- a/docs/scenarios/project-sharing-agent-bindings-demo.md
+++ b/docs/scenarios/project-sharing-agent-bindings-demo.md
@@ -263,7 +263,7 @@ clawdi vault resolve OPENAI_API_KEY --agent <atlas-id> --debug --json
 Expected default behavior:
 
 - The command fails with `vault_conflicts_blocked`.
-- The response shows Project order, winning candidate metadata, and conflicts.
+- The response shows Vault resolution priority, winning candidate metadata, and conflicts.
 - The blocked response does not include plaintext.
 
 Explicit allow branch:
@@ -274,8 +274,8 @@ clawdi vault resolve OPENAI_API_KEY --agent <atlas-id> --allow-conflicts --debug
 
 Expected:
 
-- First match wins according to the Agent's Project order.
-- Provenance shows the source project, order, vault slug, section, and item name.
+- First match wins according to the Agent's Vault resolution priority.
+- Provenance shows the source project, Vault resolution priority, vault slug, section, and item name.
 
 Security branch:
 

--- a/docs/scenarios/project-sharing-agent-bindings-demo.md
+++ b/docs/scenarios/project-sharing-agent-bindings-demo.md
@@ -25,7 +25,7 @@
 - Alice owns project `engineering`.
 - Bob receives viewer access and uses `engineering` with Agent `atlas`.
 - Carol accepts an invitation, then declines a later one.
-- Dana operates multiple agents and changes attachment order.
+- Dana operates multiple agents and changes advanced Vault resolution priority.
 - Evan is removed during cleanup.
 
 CLI examples assume:
@@ -69,9 +69,9 @@ to the separate web PR. Folder links are CLI-only local preferences:
 | --- | --- | --- | --- |
 | Project owner human | Share `engineering`, inspect who has access, and revoke access without controlling recipients' agents. | `clawdi project share`, `invite`, `members --remove`, `unshare`; dashboard equivalent in web PR. | Sharing grants Project membership only; it never attaches the Project to an Agent unless the recipient or operator explicitly asks. |
 | Recipient human | Accept, decline, or leave shared Project access, then decide whether an Agent should use it. | `clawdi inbox accept`, `decline`, `project leave`, optional `inbox accept --agent` or later `agent projects attach`; dashboard equivalent in web PR. | Accepting without an explicit Agent leaves all Agents unchanged; viewer access cannot become the Agent Project. |
-| Agent operator human | See Agent Project and attachments. | `clawdi agent projects list`, `attach`, `detach`, `move`; dashboard equivalent in web PR. | Agent Project handles default writes; attachments are ordered read sources. |
+| Agent operator human | See Agent Project and attachments. | `clawdi agent projects list`, `attach`, `detach`, `move`; dashboard equivalent in web PR. | Agent Project handles default writes; Vault resolution priority is an advanced CLI concern. |
 | Local operator human using `clawdi run` | Run a local command with vault env from an explicit or linked Project. | CLI only; `clawdi run --project`, `clawdi project folder link/status/unlink`, `clawdi run --no-project-folder`. | Folder links are local selection hints for `run`; they do not grant membership, change cloud state, or attach Projects to Agents. |
-| Agent runtime / automation consumer | Resolve reads deterministically, write to the right default Project, and debug provenance/conflicts. | Agent Project APIs; `clawdi vault resolve --agent --debug --json`, future agent runtime calls. | Precedence is the Agent Project first, then attached Projects by explicit order; conflicts block by default and include provenance without leaking plaintext. |
+| Agent runtime / automation consumer | Resolve reads deterministically, write to the right default Project, and debug provenance/conflicts. | Agent Project APIs; `clawdi vault resolve --agent --debug --json`, future agent runtime calls. | Precedence is the Agent Project first, then attached Projects by Vault resolution priority; conflicts block by default and include provenance without leaking plaintext. |
 | Security/admin revocation perspective | Stop future access and downstream Agent use when membership changes. | Project member removal, recipient leave, owner unshare, audit/admin views. | Project membership gates access; revocation removes affected attached Projects while preserving owner data and rejecting sharing changes from Agent API keys. |
 
 ## Flow 1: Owner Creates And Shares
@@ -194,7 +194,7 @@ Expected:
 
 ## Flow 5: Agent Operator Manages Projects
 
-Dana reviews Agent Project and attachments, then changes read order.
+Dana reviews Agent Project and attachments, then changes advanced Vault resolution priority.
 
 ```bash
 clawdi agent projects list <atlas-id> --json
@@ -207,11 +207,12 @@ clawdi agent projects detach <atlas-id> --project @alice/engineering
 Expected:
 
 - Agent Project is always visible and fixed.
-- Attachment order is explicit and stable.
+- Vault resolution priority is explicit and stable.
 - Detaching a Project stops that Agent from using the Project but does not remove membership.
 
-Web PR follow-up: Agent detail should show the fixed Agent Project plus
-ordered attached Projects with attach, move, and detach actions.
+The Agent detail shows the fixed Agent Project plus linked Projects with attach
+and detach actions. Advanced Vault resolution priority remains available in the
+CLI and API.
 
 ## Flow 6: Local Project Folder Selection For Run
 

--- a/packages/cli/src/commands/vault-resolve.ts
+++ b/packages/cli/src/commands/vault-resolve.ts
@@ -110,7 +110,9 @@ export async function vaultResolveCommand(
 				);
 			} else {
 				console.error(
-					chalk.gray("Re-run with --allow-conflicts to use the first project in agent order."),
+					chalk.gray(
+						"Re-run with --allow-conflicts to use the first project by Vault resolution priority.",
+					),
 				);
 			}
 		} else {

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1555,6 +1555,23 @@ export interface paths {
         patch: operations["update_project_v1_projects__project_id__patch"];
         trace?: never;
     };
+    "/v1/projects/{project_id}/agents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Link Project Agents */
+        post: operations["link_project_agents_v1_projects__project_id__agents_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/runtime/manifest": {
         parameters: {
             query?: never;
@@ -6430,6 +6447,18 @@ export interface components {
             /** Plugins */
             plugins: components["schemas"]["PluginCatalogEntryResponse"][];
         };
+        /** ProjectAgentLinkBody */
+        ProjectAgentLinkBody: {
+            /** Agent Ids */
+            agent_ids: string[];
+        };
+        /** ProjectAgentLinkResponse */
+        ProjectAgentLinkResponse: {
+            /** Project Id */
+            project_id: string;
+            /** Bound Agent Ids */
+            bound_agent_ids: string[];
+        };
         /** ProjectArchiveResponse */
         ProjectArchiveResponse: {
             /**
@@ -11284,6 +11313,41 @@ export interface operations {
             };
         };
     };
+    link_project_agents_v1_projects__project_id__agents_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProjectAgentLinkBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectAgentLinkResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_runtime_manifest_v1_runtime_manifest_get: {
         parameters: {
             query?: {
@@ -13082,7 +13146,7 @@ export interface operations {
                 field?: string | null;
                 /** @description Project to resolve from (default: caller write project). */
                 project_id?: string | null;
-                /** @description Resolve through an Agent Project and attached Project order. */
+                /** @description Resolve through an Agent Project and linked Project Vault resolution priority. */
                 agent_id?: string | null;
                 /** @description Allow first-match wins when attached Projects contain the same key. */
                 allow_conflicts?: boolean;

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -2948,6 +2948,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/agents/{agent_id}/projects": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Link Agent Projects */
+        post: operations["link_agent_projects_v1_agents__agent_id__projects_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/agents/{agent_id}/project-bindings/context": {
         parameters: {
             query?: never;
@@ -3296,6 +3313,18 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
+        };
+        /** AgentProjectLinkBody */
+        AgentProjectLinkBody: {
+            /** Project Ids */
+            project_ids: string[];
+        };
+        /** AgentProjectLinkResponse */
+        AgentProjectLinkResponse: {
+            /** Agent Id */
+            agent_id: string;
+            /** Bound Project Ids */
+            bound_project_ids: string[];
         };
         /** AgentProjectSkillDesiredItem */
         AgentProjectSkillDesiredItem: {
@@ -14002,6 +14031,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AgentProjectBindingResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    link_agent_projects_v1_agents__agent_id__projects_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AgentProjectLinkBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentProjectLinkResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary

- make Project-to-Agent and Agent-to-Project linking additive and support selecting multiple new relationships at once
- preserve existing links, validate each batch atomically, and notify affected runtimes only when bindings change
- refresh Project counts, Agent filters, bindings, Skills, and Vault state after linking
- remove ordinary Project ordering controls and label the retained API/CLI behavior as Vault resolution priority
- notify managed runtimes when Vault resolution priority actually changes

## Test Plan

- Docker backend focused suite: 26 passed
- Docker CLI focused suite: 19 passed
- Docker Web clean suite: typecheck, 1049 unit tests, and OSS production build passed
- Docker Chromium Playwright: bidirectional multi-select linking, 2 passed
- Ruff lint/format, Python compileall, Biome, generated API consistency, and git diff check passed