### PR TITLE
feat(web): plugin detail breadcrumbs and component cards

### DIFF
--- a/apps/web/src/components/app-breadcrumb-model.ts
+++ b/apps/web/src/components/app-breadcrumb-model.ts
@@ -1,6 +1,7 @@
 import type { BreadcrumbSegmentTitles } from "@/components/breadcrumb-title";
 import {
 	type AgentRouteSearch,
+	agentPluginDetailHref,
 	agentProjectDetailHref,
 	agentProjectResourceHref,
 	agentSectionHref,
@@ -115,6 +116,11 @@ function buildAgentBreadcrumbTrail(
 
 	const sectionLabel = agentSectionLabel(route.section);
 	const sectionHref = agentSectionHref(route.agentId, route.section);
+	if (route.pluginName) {
+		const detailHref = agentPluginDetailHref(route.agentId, route.pluginName);
+		trail.push({ key: route.section, label: sectionLabel, href: sectionHref });
+		return finishTrail(trail, segmentTitle(segmentTitles, detailHref) ?? route.pluginName);
+	}
 	const detailTitle =
 		route.sessionId || route.memoryId || route.connectorName ? overrideTitle : null;
 	if (route.sessionId || route.memoryId || route.connectorName) {

--- a/apps/web/src/components/app-breadcrumb.test.ts
+++ b/apps/web/src/components/app-breadcrumb.test.ts
@@ -104,6 +104,18 @@ describe("AppBreadcrumb semantic trail", () => {
 			"Connectors",
 			"GitHub",
 		]);
+		expect(
+			labels(`/agents/${agentId}/plugins/sui-agent`, {
+				segmentTitles: {
+					[`/agents/${agentId}/plugins/sui-agent`]: { title: "Sui Agent" },
+				},
+			}),
+		).toEqual(["e2e-2", "Plugins", "Sui Agent"]);
+		expect(labels(`/agents/${agentId}/plugins/sui-agent`)).toEqual([
+			"e2e-2",
+			"Plugins",
+			"sui-agent",
+		]);
 	});
 
 	test("keeps every Agent parent link clean while reading explicit detail context", () => {

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-detail.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-detail.tsx
@@ -310,11 +310,17 @@ function ComponentGroup({
 				<Icon className="size-3.5" />
 				{label}
 			</div>
-			<div className="grid gap-x-6 gap-y-1.5 sm:grid-cols-2">
+			<div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
 				{names.map((name) => (
-					<code key={name} className="min-w-0 break-all text-sm">
-						{name}
-					</code>
+					<div
+						key={name}
+						className="flex min-w-0 items-center gap-2 rounded-lg border bg-muted/30 px-3 py-2"
+					>
+						<Icon className="size-4 shrink-0 text-muted-foreground" />
+						<code title={name} className="min-w-0 truncate text-sm">
+							{name}
+						</code>
+					</div>
 				))}
 			</div>
 		</div>

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
@@ -6,6 +6,7 @@ import { AlertCircle, Blocks, RefreshCw } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
+import { useSetBreadcrumbSegmentTitle } from "@/components/breadcrumb-title";
 import { EmptyState } from "@/components/empty-state";
 import { HERO_GRID_CLASS, HeroCardSkeleton } from "@/components/entity-card";
 import { FilterChip } from "@/components/filter-chip";
@@ -31,6 +32,7 @@ import {
 	agentPluginMatches,
 	assignAgentPluginGroups,
 	buildAgentPluginInventory,
+	pluginDisplayName,
 	pluginHasUpdate,
 } from "./agent-plugin-model";
 
@@ -203,6 +205,10 @@ export function AgentPluginsSurface({
 		!initialLoading && selectedPlugin
 			? inventory.find((item) => item.name === selectedPlugin)
 			: null;
+	useSetBreadcrumbSegmentTitle(
+		selectedItem ? agentPluginDetailHref(agentId, selectedItem.name) : null,
+		selectedItem ? pluginDisplayName(selectedItem) : null,
+	);
 	const categories = useMemo(
 		() =>
 			[


### PR DESCRIPTION
## Summary

Follow-up polish to #1072 for the agent Plugins detail page (`/agents/:id/plugins/:pluginName`):

- **Breadcrumb adapts to plugin details** — the trail now reads `Agent / Plugins / Sui Agent` (Plugins crumb links back to the list). The surface registers the display name via `useSetBreadcrumbSegmentTitle` (multi-writer-safe, keyed by href); while data loads it falls back to the decoded plugin name slug.
- **Includes panel as small cards** — Skills / MCP servers render as individual cards in a 3-column grid (2 cols on small screens, 1 on mobile) instead of bare rows inside one big panel; long names truncate with a title tooltip.

## Verification

- typecheck, Biome: pass
- unit: app-breadcrumb + agent-routes 19 passed
- e2e: `hosted-agent-plugins.pw.ts` 2 passed