### PR TITLE
feat(web): unify plugin card actions and flatten detail includes

### DIFF
--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -388,6 +388,7 @@ export function HeroCard({
 	description,
 	footer,
 	actions,
+	actionsVisibility = "responsive",
 	link,
 	onClick,
 	ariaLabel,
@@ -403,6 +404,8 @@ export function HeroCard({
 	description?: ReactNode;
 	footer?: ReactNode | ReactNode[];
 	actions?: ReactNode;
+	/** Action visibility rhythm; `responsive` recedes until hover/focus on desktop. */
+	actionsVisibility?: "responsive" | "always";
 	link?: EntityCardLinkOptions;
 	/** Whole-card button for state-driven detail views. Ignored when `link` is set. */
 	onClick?: () => void;
@@ -422,7 +425,9 @@ export function HeroCard({
 			{icon || actions ? (
 				<div className="flex items-start justify-between gap-2">
 					{icon ? <div className="shrink-0">{icon}</div> : <span aria-hidden />}
-					{actions ? <EntityCardActions>{actions}</EntityCardActions> : null}
+					{actions ? (
+						<EntityCardActions visibility={actionsVisibility}>{actions}</EntityCardActions>
+					) : null}
 				</div>
 			) : null}
 			<div className="min-w-0">

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-card.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-card.tsx
@@ -81,14 +81,14 @@ export function AgentPluginCard({
 				description={
 					item.catalog?.description ?? "This plugin is no longer available in the Store."
 				}
-				footer={[item.catalog?.publisher, version]}
-				footerClassName="mt-0"
-			>
-				<div className="mt-auto flex min-w-0 flex-wrap items-center justify-between gap-x-3 gap-y-2">
-					<span className="min-w-0 text-xs text-muted-foreground">
-						{agentPluginComponentSummary(item.catalog)}
-					</span>
-					<div className="relative z-10 flex shrink-0 items-center gap-1.5">
+				footer={[
+					item.catalog?.publisher,
+					version,
+					item.catalog ? agentPluginComponentSummary(item.catalog) : null,
+				]}
+				actionsVisibility="always"
+				actions={
+					<>
 						{item.desired ? (
 							<ConfirmAction
 								title={`Remove ${title}?`}
@@ -98,10 +98,10 @@ export function AgentPluginCard({
 								onConfirm={() => onRemove(item)}
 							>
 								<Button
-									variant="outline"
+									variant="ghost"
 									size="sm"
 									disabled={mutationsBlocked}
-									className="text-destructive hover:text-destructive"
+									className="text-muted-foreground hover:text-destructive"
 								>
 									{pendingAction === "remove" ? <Spinner /> : <Trash2 />}
 									{pendingAction === "remove" ? "Removing…" : "Remove"}
@@ -144,9 +144,9 @@ export function AgentPluginCard({
 								{pendingAction === "retry" ? "Retrying…" : "Retry"}
 							</Button>
 						) : null}
-					</div>
-				</div>
-			</HeroCard>
+					</>
+				}
+			/>
 		</div>
 	);
 }

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-detail.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-detail.tsx
@@ -13,7 +13,7 @@ import {
 	Trash2,
 } from "lucide-react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
-import { DetailMeta, DetailPanel, DetailStats } from "@/components/detail/layout";
+import { DetailMeta, DetailStats } from "@/components/detail/layout";
 import { IconChip } from "@/components/icon-chip";
 import { Stat } from "@/components/meta/stat";
 import { PageHeader } from "@/components/page-header";
@@ -258,12 +258,12 @@ function PluginDetailActions({
 function PluginDetailsPanel({ entry }: { entry: AgentPluginCatalogEntry | null }) {
 	if (!entry) {
 		return (
-			<DetailPanel className="space-y-3">
+			<section className="space-y-3">
 				<PanelHeading />
 				<p className="text-sm text-muted-foreground">
 					Details are no longer available for this plugin.
 				</p>
-			</DetailPanel>
+			</section>
 		);
 	}
 	const skills = entry.components.skills;
@@ -271,7 +271,7 @@ function PluginDetailsPanel({ entry }: { entry: AgentPluginCatalogEntry | null }
 		left.localeCompare(right),
 	);
 	return (
-		<DetailPanel className="space-y-4">
+		<section className="space-y-4">
 			<PanelHeading />
 			{skills.length === 0 && servers.length === 0 ? (
 				<p className="text-sm text-muted-foreground">This plugin has no listed components.</p>
@@ -281,7 +281,7 @@ function PluginDetailsPanel({ entry }: { entry: AgentPluginCatalogEntry | null }
 					<ComponentGroup icon={Server} label="MCP servers" names={servers} />
 				</>
 			)}
-		</DetailPanel>
+		</section>
 	);
 }
 


### PR DESCRIPTION
## Summary

- **List cards**: action buttons (Install / Update / Retry / Remove) move from the custom bottom row into the shared HeroCard top-right `actions` slot — the same position other entity cards use. `HeroCard` gains an `actionsVisibility` prop (default `responsive` = hover-reveal, unchanged for existing callers); plugin cards use `always` so the primary CTA stays visible. Remove becomes a ghost destructive button matching the Channels card. The component summary ("3 Skills · 2 MCP servers") joins the middot footer meta line.
- **Detail page**: the Includes section drops its outer DetailPanel big card — group headings + small component cards render directly.

## Verification

- typecheck, Biome: pass
- e2e: `hosted-agent-plugins.pw.ts` 2 passed