### PR TITLE
fix(web): semver-aware plugin updates and stalled-install presentation

### DIFF
--- a/apps/web/e2e/hosted-agent-plugins.pw.ts
+++ b/apps/web/e2e/hosted-agent-plugins.pw.ts
@@ -40,7 +40,7 @@ test("Agent Plugins opens and installs with the per-user capability", async ({ p
 		observation_error_code: null,
 		observed_at: null,
 		created_at: "2026-08-17T00:00:00Z",
-		updated_at: "2026-08-17T00:00:00Z",
+		updated_at: new Date().toISOString(),
 	};
 	await stubHostedApi(page, {
 		canUseAgentPluginsUI: true,

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.test.ts
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.test.ts
@@ -81,9 +81,10 @@ describe("Agent Plugin model", () => {
 	});
 
 	test("maps the three observed convergence states without mutation-only states", () => {
-		expect(agentPluginStatusPresentation(desired("sui")).label).toBe("Installed");
+		const now = new Date("2026-08-16T00:00:30Z");
+		expect(agentPluginStatusPresentation(desired("sui"), now).label).toBe("Installed");
 		expect(
-			agentPluginStatusPresentation(desired("sui", { convergence: "not_observed" })).label,
+			agentPluginStatusPresentation(desired("sui", { convergence: "not_observed" }), now).label,
 		).toBe("Installing");
 		expect(
 			agentPluginStatusPresentation(
@@ -91,11 +92,38 @@ describe("Agent Plugin model", () => {
 					convergence: "failed",
 					observation_error_code: "receipt_mismatch",
 				}),
+				now,
 			),
 		).toMatchObject({
 			label: "Install failed",
 			description: "The installed plugin does not match the requested version.",
 		});
+	});
+
+	test("distinguishes a stalled install from an active one", () => {
+		const pending = desired("sui", { convergence: "not_observed" });
+		expect(agentPluginStatusPresentation(pending, new Date("2026-08-16T00:05:00Z")).label).toBe(
+			"Installing",
+		);
+		expect(agentPluginStatusPresentation(pending, new Date("2026-08-16T00:11:00Z")).label).toBe(
+			"Waiting for agent",
+		);
+	});
+
+	test("keeps the latest catalog version and only flags real upgrades", () => {
+		const inventory = buildAgentPluginInventory(
+			[catalogEntry("sui", { version: "2.0.0" }), catalogEntry("sui", { version: "10.0.0" })],
+			[desired("sui", { version: "2.0.0" })],
+		);
+		expect(inventory).toHaveLength(1);
+		expect(inventory[0]?.catalog?.version).toBe("10.0.0");
+		expect(pluginHasUpdate(inventory[0])).toBe(true);
+
+		const downgraded = buildAgentPluginInventory(
+			[catalogEntry("sui", { version: "1.0.0" })],
+			[desired("sui", { version: "2.0.0" })],
+		);
+		expect(pluginHasUpdate(downgraded[0])).toBe(false);
 	});
 
 	test("combines catalog installability with the selected hosted runtime", () => {

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.ts
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.ts
@@ -19,11 +19,60 @@ export type AgentPluginInstallability = {
 	reason: string | null;
 };
 
+const EXACT_SEMVER_PATTERN =
+	/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+/** SemVer precedence; null when either side is not exact SemVer. */
+export function compareAgentPluginVersions(left: string, right: string): number | null {
+	const a = EXACT_SEMVER_PATTERN.exec(left);
+	const b = EXACT_SEMVER_PATTERN.exec(right);
+	if (!a || !b) return null;
+	for (let i = 1; i <= 3; i++) {
+		const diff = Number(a[i]) - Number(b[i]);
+		if (diff !== 0) return diff < 0 ? -1 : 1;
+	}
+	const preLeft = a[4];
+	const preRight = b[4];
+	if (!preLeft && !preRight) return 0;
+	if (!preLeft) return 1;
+	if (!preRight) return -1;
+	const idsLeft = preLeft.split(".");
+	const idsRight = preRight.split(".");
+	for (let i = 0; i < Math.max(idsLeft.length, idsRight.length); i++) {
+		const x = idsLeft[i];
+		const y = idsRight[i];
+		if (x === undefined) return -1;
+		if (y === undefined) return 1;
+		const numericX = /^\d+$/.test(x);
+		const numericY = /^\d+$/.test(y);
+		if (numericX && numericY) {
+			const diff = Number(x) - Number(y);
+			if (diff !== 0) return diff < 0 ? -1 : 1;
+		} else if (numericX !== numericY) {
+			return numericX ? -1 : 1;
+		} else if (x !== y) {
+			return x < y ? -1 : 1;
+		}
+	}
+	return 0;
+}
+
 export function buildAgentPluginInventory(
 	catalog: readonly AgentPluginCatalogEntry[],
 	desired: readonly AgentPluginDesiredState[],
 ): AgentPluginInventoryItem[] {
-	const catalogByName = new Map(catalog.map((entry) => [entry.name, entry]));
+	const catalogByName = new Map<string, AgentPluginCatalogEntry>();
+	for (const entry of catalog) {
+		const existing = catalogByName.get(entry.name);
+		if (!existing) {
+			catalogByName.set(entry.name, entry);
+			continue;
+		}
+		// Unparseable versions fall back to last-write-wins.
+		if ((compareAgentPluginVersions(entry.version, existing.version) ?? 1) > 0) {
+			catalogByName.set(entry.name, entry);
+		}
+	}
 	const desiredByName = new Map(desired.map((entry) => [entry.plugin_name, entry]));
 	const names = new Set([...catalogByName.keys(), ...desiredByName.keys()]);
 
@@ -58,7 +107,22 @@ export function pluginVersion(item: AgentPluginInventoryItem): string {
 }
 
 export function pluginHasUpdate(item: AgentPluginInventoryItem): boolean {
-	return Boolean(item.catalog && item.desired && item.catalog.version !== item.desired.version);
+	if (!item.catalog || !item.desired) return false;
+	const comparison = compareAgentPluginVersions(item.catalog.version, item.desired.version);
+	return comparison === null ? item.catalog.version !== item.desired.version : comparison > 0;
+}
+
+/** After this long without an observation, the agent — not the install — is the holdup. */
+export const AGENT_PLUGIN_STALL_THRESHOLD_MS = 10 * 60 * 1000;
+
+export function agentPluginIsStalled(
+	desired: AgentPluginDesiredState,
+	now: Date = new Date(),
+): boolean {
+	return (
+		desired.convergence === "not_observed" &&
+		now.getTime() - new Date(desired.updated_at).getTime() > AGENT_PLUGIN_STALL_THRESHOLD_MS
+	);
 }
 
 export function agentPluginInstallability(
@@ -97,7 +161,10 @@ export function agentPluginInstallability(
 	return { installable: true, label: "Install", reason: null };
 }
 
-export function agentPluginStatusPresentation(desired: AgentPluginDesiredState): {
+export function agentPluginStatusPresentation(
+	desired: AgentPluginDesiredState,
+	now: Date = new Date(),
+): {
 	label: string;
 	tone: StatusTone;
 	description: string;
@@ -116,11 +183,19 @@ export function agentPluginStatusPresentation(desired: AgentPluginDesiredState):
 				description: observationErrorDescription(desired.observation_error_code),
 			};
 		case "not_observed":
-			return {
-				label: "Installing",
-				tone: "warning",
-				description: "This plugin is being installed. You can leave this page while it finishes.",
-			};
+			return agentPluginIsStalled(desired, now)
+				? {
+						label: "Waiting for agent",
+						tone: "warning",
+						description:
+							"The agent has not picked this up yet. It will finish once the agent is back online.",
+					}
+				: {
+						label: "Installing",
+						tone: "warning",
+						description:
+							"This plugin is being installed. You can leave this page while it finishes.",
+					};
 	}
 }
 

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
@@ -29,6 +29,7 @@ import {
 	type AgentPluginGroup,
 	type AgentPluginInventoryItem,
 	agentPluginInstallability,
+	agentPluginIsStalled,
 	agentPluginMatches,
 	assignAgentPluginGroups,
 	buildAgentPluginInventory,
@@ -79,10 +80,16 @@ export function AgentPluginsSurface({
 		"/v1/agents/{agent_id}/agent-plugins",
 		{ params: { path: { agent_id: agentId } } },
 		{
-			refetchInterval: (query) =>
-				query.state.data?.plugins.some((plugin) => plugin.convergence === "not_observed")
+			refetchInterval: (query) => {
+				const plugins = query.state.data?.plugins;
+				if (!plugins?.some((plugin) => plugin.convergence === "not_observed")) return false;
+				const now = new Date();
+				return plugins.some(
+					(plugin) => plugin.convergence === "not_observed" && !agentPluginIsStalled(plugin, now),
+				)
 					? 5_000
-					: false,
+					: 60_000;
+			},
 			refetchIntervalInBackground: false,
 		},
 	);


### PR DESCRIPTION
## Summary

- **SemVer-aware update detection** — `compareAgentPluginVersions` implements SemVer precedence; `pluginHasUpdate` now only flags real upgrades (a Store rollback no longer masquerades as "Update available"), and `buildAgentPluginInventory` picks the latest version per plugin name instead of the last row (latent bug: the catalog list is version-descending, so the Map last-write-wins dedup would have surfaced the *oldest* version once a plugin publishes two versions).
- **Stalled-install presentation** — a desired install unobserved for over 10 minutes now reads "Waiting for agent" ("it will finish once the agent is back online") instead of spinning "Installing" forever, and polling backs off from 5s to 60s in that state; active installs keep the 5s cadence.

## Verification

- typecheck, Biome: pass
- unit: agent-plugin-model 6 passed (new cases: stall threshold, latest-version dedup, downgrade not an update)
- e2e: `hosted-agent-plugins.pw.ts` 2 passed (stub fixture now uses a fresh `updated_at`, matching an active install)