### PR TITLE
feat: redispatch failed agent plugin installs on reaffirm

### DIFF
--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
@@ -166,9 +166,6 @@ export function AgentPluginsSurface({
 		mutationLock.current = true;
 		setPending({ name: item.name, action: "retry" });
 		try {
-			await removeMutation.mutateAsync({
-				params: { path: { agent_id: agentId, plugin_name: item.name } },
-			});
 			await installMutation.mutateAsync({
 				params: { path: { agent_id: agentId, plugin_name: item.name } },
 				body: { version: item.catalog.version },

--- a/backend/app/routes/plugin_catalog.py
+++ b/backend/app/routes/plugin_catalog.py
@@ -340,6 +340,16 @@ async def put_agent_plugin_desired_state(
         row.agent_plugins_schema = entry.agent_plugins_schema
         row.source = entry.source
         row.content_digest = entry.content_digest
+    if not changed:
+        assert row is not None
+        observations, observed_at, received_at = await _latest_agent_plugin_observations(
+            db, agent_id=agent_id
+        )
+        if _desired_response(row, observations, observed_at, received_at).convergence == "failed":
+            # Reaffirming an identical desire whose last convergence failed is a
+            # retry: bump the staleness anchor so the next observation counts.
+            row.updated_at = datetime.now(UTC)
+            changed = True
     if changed:
         queue_runtime_manifest_changed(db, auth.user_id, agent_id)
     await db.flush()

--- a/backend/tests/test_agent_plugin_catalog_routes.py
+++ b/backend/tests/test_agent_plugin_catalog_routes.py
@@ -224,8 +224,8 @@ async def test_agent_plugin_desired_state_projects_only_exact_observed_identity(
                 "status": "ok" if plugin_status == "installed" else "error",
                 "activeCliVersion": "1.2.3-test",
                 "applied": {
-                    "etag": f'"sha256:{"a" * 64}"',
-                    "sourceRevision": "a" * 64,
+                    "etag": f'"sha256:{digest_character * 64}"',
+                    "sourceRevision": digest_character * 64,
                     "generation": 1,
                     "instanceId": state.instance_id,
                     "appliedProviderIds": [],
@@ -265,6 +265,7 @@ async def test_agent_plugin_desired_state_projects_only_exact_observed_identity(
     assert stale.status_code == 200, stale.text
     assert stale.json()["convergence"] == "not_observed"
 
+    installed_at = datetime.now(UTC)
     await ingest_runtime_observation(
         db_session,
         environment_id=channel_agent.id,
@@ -274,8 +275,9 @@ async def test_agent_plugin_desired_state_projects_only_exact_observed_identity(
             version="1.0.0",
             digest_character="a",
             plugin_status="installed",
+            event_captured=installed_at,
         ),
-        received_at=captured + timedelta(seconds=1),
+        received_at=installed_at,
     )
     await db_session.commit()
     installed = await client.get(
@@ -295,6 +297,7 @@ async def test_agent_plugin_desired_state_projects_only_exact_observed_identity(
     assert updated.json()["convergence"] == "not_observed"
     assert updated.json()["observed_at"] is None
 
+    failed_at = datetime.now(UTC)
     await ingest_runtime_observation(
         db_session,
         environment_id=channel_agent.id,
@@ -305,8 +308,9 @@ async def test_agent_plugin_desired_state_projects_only_exact_observed_identity(
             digest_character="b",
             plugin_status="failed",
             error_code="reconcile_failed",
+            event_captured=failed_at,
         ),
-        received_at=captured + timedelta(seconds=3),
+        received_at=failed_at,
     )
     await db_session.commit()
     failed = await client.get(
@@ -315,6 +319,34 @@ async def test_agent_plugin_desired_state_projects_only_exact_observed_identity(
     assert failed.status_code == 200, failed.text
     assert failed.json()["convergence"] == "failed"
     assert failed.json()["observation_error_code"] == "reconcile_failed"
+
+    retried = await client.put(
+        f"/v1/agents/{channel_agent.id}/agent-plugins/{THIRD_PARTY_PLUGIN_NAME}",
+        json={"version": "1.1.0"},
+    )
+    assert retried.status_code == 202, retried.text
+    assert retried.json()["convergence"] == "not_observed"
+
+    recovered_at = datetime.now(UTC)
+    await ingest_runtime_observation(
+        db_session,
+        environment_id=channel_agent.id,
+        credential_deployment_id=state.deployment_id,
+        value=observation(
+            sequence=4,
+            version="1.1.0",
+            digest_character="b",
+            plugin_status="installed",
+            event_captured=recovered_at,
+        ),
+        received_at=recovered_at,
+    )
+    await db_session.commit()
+    recovered = await client.get(
+        f"/v1/agents/{channel_agent.id}/agent-plugins/{THIRD_PARTY_PLUGIN_NAME}"
+    )
+    assert recovered.status_code == 200, recovered.text
+    assert recovered.json()["convergence"] == "installed"
 
     await _activate_catalog(db_session, version="1.0.0", digest_character="a")
     restored = await client.put(


### PR DESCRIPTION
## Summary

Re-PUTting an identical desired plugin version was a no-op, so a failed install could never be retried without a client-side DELETE+PUT dance.

- **Backend** (`clawdi`): when the desired state is unchanged but the latest matching observation converged to `failed`, the PUT now bumps the installation's `updated_at` staleness anchor and re-queues the runtime manifest — the old failure observation is invalidated and the next one counts. Response returns `not_observed`, so clients see a fresh install cycle.
- **Frontend**: plugin Retry simplifies to a single PUT (no more sequential DELETE+PUT).

## Verification

- backend: `scripts/test.sh backend tests/test_agent_plugin_catalog_routes.py tests/test_agent_plugins_runtime_contract.py tests/test_agent_plugin_catalog_migration.py` — 15 passed (Docker, incl. new failed→retry→recovered lifecycle assertions); ruff check + format clean
- web: typecheck, Biome, `hosted-agent-plugins.pw.ts` 2 passed