### PR TITLE
fix: make project agent links fully manageable

### DIFF
--- a/apps/web/e2e/project-agent-linking.pw.ts
+++ b/apps/web/e2e/project-agent-linking.pw.ts
@@ -32,14 +32,12 @@ async function fulfill(route: Route, body: unknown) {
 	await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
 }
 
-test("Project link dialog adds multiple Agents without replacing existing links", async ({
-	page,
-}) => {
+test("Project Agent manager saves additions and removals as one delta", async ({ page }) => {
 	const linkedAgent = agent(linkedAgentId, "Review Agent");
 	const buildAgent = agent(buildAgentId, "Build Agent");
 	const deployAgent = agent(deployAgentId, "Deploy Agent");
-	let availableAgentsLinked = false;
-	const linkBodies: unknown[] = [];
+	const managedAgentIds = new Set([linkedAgentId]);
+	const deltaBodies: unknown[] = [];
 	let projectDetailReads = 0;
 	let filteredAgentReads = 0;
 	const project = () => ({
@@ -56,7 +54,7 @@ test("Project link dialog adds multiple Agents without replacing existing links"
 		owner_handle: "dev-user",
 		skill_count: 0,
 		vault_count: 0,
-		agent_count: availableAgentsLinked ? 3 : 1,
+		agent_count: managedAgentIds.size,
 		member_count: 0,
 	});
 
@@ -64,12 +62,18 @@ test("Project link dialog adds multiple Agents without replacing existing links"
 		const request = route.request();
 		const url = new URL(request.url());
 		const path = url.pathname;
-		if (path === `/v1/projects/${projectId}/agents` && request.method() === "POST") {
-			linkBodies.push(request.postDataJSON());
-			availableAgentsLinked = true;
+		if (path === `/v1/projects/${projectId}/agents` && request.method() === "PATCH") {
+			const body = request.postDataJSON() as {
+				add_agent_ids: string[];
+				remove_agent_ids: string[];
+			};
+			deltaBodies.push(body);
+			for (const agentId of body.remove_agent_ids) managedAgentIds.delete(agentId);
+			for (const agentId of body.add_agent_ids) managedAgentIds.add(agentId);
 			return fulfill(route, {
 				project_id: projectId,
-				bound_agent_ids: [buildAgentId, deployAgentId],
+				added_agent_ids: body.add_agent_ids,
+				removed_agent_ids: body.remove_agent_ids,
 			});
 		}
 		if (path === `/v1/projects/${projectId}`) {
@@ -82,7 +86,7 @@ test("Project link dialog adds multiple Agents without replacing existing links"
 				filteredAgentReads += 1;
 				return fulfill(
 					route,
-					availableAgentsLinked ? [linkedAgent, buildAgent, deployAgent] : [linkedAgent],
+					[linkedAgent, buildAgent, deployAgent].filter((agent) => managedAgentIds.has(agent.id)),
 				);
 			}
 			return fulfill(route, [linkedAgent, buildAgent, deployAgent]);
@@ -100,23 +104,28 @@ test("Project link dialog adds multiple Agents without replacing existing links"
 	const agentsSection = page.locator("#agents");
 	await expect(agentsSection.getByText("Review Agent", { exact: true })).toBeVisible();
 
-	await page.getByRole("button", { name: "Link project" }).click();
-	const dialog = page.getByRole("dialog", { name: "Link project to Agents" });
-	const linkedCheckbox = dialog.getByRole("checkbox", { name: "Review Agent already linked" });
+	await page.getByRole("button", { name: "Manage agents" }).click();
+	const dialog = page.getByRole("dialog", { name: "Manage agents" });
+	const linkedCheckbox = dialog.getByRole("checkbox", { name: "Review Agent access" });
 	await expect(linkedCheckbox).toBeChecked();
-	await expect(linkedCheckbox).toBeDisabled();
-	await expect(dialog.getByText("Linked", { exact: true })).toBeVisible();
+	await expect(linkedCheckbox).toBeEnabled();
+	await expect(dialog.getByText("Linked", { exact: true })).toHaveCount(0);
+	await expect(dialog.getByText("Available", { exact: true })).toHaveCount(0);
 
-	await dialog.getByRole("checkbox", { name: "Link Build Agent" }).click();
-	await dialog.getByRole("checkbox", { name: "Link Deploy Agent" }).click();
-	await dialog.getByRole("button", { name: "Link 2 Agents" }).click();
+	await linkedCheckbox.click();
+	await expect(linkedCheckbox).not.toBeChecked();
+	const buildCheckbox = dialog.getByRole("checkbox", { name: "Build Agent access" });
+	await expect(buildCheckbox).not.toBeChecked();
+	await buildCheckbox.click();
+	await dialog.getByRole("button", { name: "Save changes" }).click();
 
-	await expect.poll(() => linkBodies).toEqual([{ agent_ids: [buildAgentId, deployAgentId] }]);
+	await expect
+		.poll(() => deltaBodies)
+		.toEqual([{ add_agent_ids: [buildAgentId], remove_agent_ids: [linkedAgentId] }]);
 	await expect(dialog).toHaveCount(0);
-	await expect(agentsSection.getByText("3", { exact: true })).toBeVisible();
-	await expect(agentsSection.getByText("Review Agent", { exact: true })).toBeVisible();
+	await expect(agentsSection.getByText("Review Agent", { exact: true })).toHaveCount(0);
 	await expect(agentsSection.getByText("Build Agent", { exact: true })).toBeVisible();
-	await expect(agentsSection.getByText("Deploy Agent", { exact: true })).toBeVisible();
+	await expect(agentsSection.getByText("Deploy Agent", { exact: true })).toHaveCount(0);
 	await expect.poll(() => projectDetailReads).toBeGreaterThan(1);
 	await expect.poll(() => filteredAgentReads).toBeGreaterThan(1);
 });

--- a/apps/web/e2e/project-agent-linking.pw.ts
+++ b/apps/web/e2e/project-agent-linking.pw.ts
@@ -103,6 +103,7 @@ test("Project Agent manager saves additions and removals as one delta", async ({
 	});
 	const agentsSection = page.locator("#agents");
 	await expect(agentsSection.getByText("Review Agent", { exact: true })).toBeVisible();
+	await expect(agentsSection.getByText("Linked", { exact: true })).toHaveCount(0);
 
 	await page.getByRole("button", { name: "Manage agents" }).click();
 	const dialog = page.getByRole("dialog", { name: "Manage agents" });

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -1010,24 +1010,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	await projectCards.nth(0).hover();
 	await expect(projectStack.getByText(/Project order/)).toHaveCount(0);
 	await expect(projectStack.getByRole("button", { name: /Move .* (up|down)/ })).toHaveCount(0);
-	await expect(
-		projectCards.nth(0).getByRole("button", { name: "Unlink Team Knowledge" }),
-	).toBeVisible();
-	await expect
-		.poll(() =>
-			projectCards
-				.nth(0)
-				.getByRole("button", { name: "Unlink Team Knowledge" })
-				.evaluate((element) => getComputedStyle(element.parentElement ?? element).opacity),
-		)
-		.toBe("1");
-	await projectCards.nth(0).getByRole("button", { name: "Unlink Team Knowledge" }).click();
-	await expect(page).toHaveURL(/\/agents\/11111111-1111-4111-8111-111111111111\/project-access$/);
-	const removeProjectDialog = page.getByRole("alertdialog", { name: "Unlink this Project?" });
-	await expect(removeProjectDialog).toContainText(
-		"This Agent will stop using Team Knowledge's Skills and attached Vaults.",
-	);
-	await removeProjectDialog.getByRole("button", { name: "Cancel" }).click();
+	await expect(projectCards.nth(0).getByRole("button", { name: /Unlink/ })).toHaveCount(0);
 	await expect(projectStack.getByLabel("Project to link")).toHaveCount(0);
 	await expect(
 		projectStack.getByRole("button", { name: "Create project", exact: true }),
@@ -1118,14 +1101,6 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 			(element) => getComputedStyle(element).gridTemplateColumns.split(" ").length,
 		),
 	).toBe(1);
-	await expect
-		.poll(() =>
-			projectCards
-				.nth(0)
-				.getByRole("button", { name: "Unlink Team Knowledge" })
-				.evaluate((element) => getComputedStyle(element.parentElement ?? element).opacity),
-		)
-		.toBe("1");
 	const longTitle = projectCards.nth(1).getByRole("heading", { name: longContextProjectName });
 	const longDescription = projectCards.nth(1).getByText(longContextProjectDescription, {
 		exact: true,

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -235,7 +235,7 @@ type DashboardApiStubOptions = {
 	memoryDetailGate?: Promise<void>;
 	memoryDetailResponse?: { body: unknown; status: number };
 	projectBindingRequests?: string[];
-	projectLinkBodies?: unknown[];
+	projectLinkDeltaBodies?: unknown[];
 	projectRequests?: string[];
 	projectCreateBodies?: unknown[];
 	projectBindings?: readonly unknown[];
@@ -315,12 +315,17 @@ async function stubDashboardApi(
 		}
 		if (
 			url.pathname === "/v1/agents/11111111-1111-4111-8111-111111111111/projects" &&
-			route.request().method() === "POST"
+			route.request().method() === "PATCH"
 		) {
-			options.projectLinkBodies?.push(route.request().postDataJSON());
+			const body = route.request().postDataJSON() as {
+				add_project_ids: string[];
+				remove_project_ids: string[];
+			};
+			options.projectLinkDeltaBodies?.push(body);
 			await fulfillJson(route, {
 				agent_id: "11111111-1111-4111-8111-111111111111",
-				bound_project_ids: ["project-batch-second", "project-unrelated"],
+				added_project_ids: body.add_project_ids,
+				removed_project_ids: body.remove_project_ids,
 			});
 			return;
 		}
@@ -828,7 +833,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	const skillRequests: string[] = [];
 	const vaultRequests: string[] = [];
 	const projectCreateBodies: unknown[] = [];
-	const projectLinkBodies: unknown[] = [];
+	const projectLinkDeltaBodies: unknown[] = [];
 	const projectBindingRequests: string[] = [];
 	const projectRequests: string[] = [];
 	const longContextProjectName =
@@ -956,7 +961,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 		vaultRequests,
 		vaultItems: projectAccessVaults,
 		projectCreateBodies,
-		projectLinkBodies,
+		projectLinkDeltaBodies,
 		projectBindingRequests,
 		projectRequests,
 	});
@@ -1043,7 +1048,7 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 				description: "Review instructions and protected Vault access",
 			},
 		]);
-	expect(projectLinkBodies).toEqual([]);
+	expect(projectLinkDeltaBodies).toEqual([]);
 	const createdToast = page.locator("[data-sonner-toast]").filter({ hasText: "Project created" });
 	await createdToast.getByRole("button", { name: "Open project" }).click();
 	await expect(page).toHaveURL((url) => {
@@ -1057,31 +1062,37 @@ test("connected agent resources select Projects before scoped Skills and Vaults"
 	const bindingReadsBeforeLink = projectBindingRequests.length;
 	const projectReadsBeforeLink = projectRequests.length;
 	const addProjectTrigger = projectStack.getByRole("button", {
-		name: "Link projects",
+		name: "Manage projects",
 		exact: true,
 	});
 	await expect(addProjectTrigger).toBeVisible();
 	await addProjectTrigger.click();
 	const addProjectDialog = page.getByTestId("agent-project-add-dialog");
 	await expect(addProjectDialog).toBeVisible();
-	await expect(
-		addProjectDialog.getByRole("heading", { name: "Link projects to Agent" }),
-	).toBeVisible();
+	await expect(addProjectDialog.getByRole("heading", { name: "Manage projects" })).toBeVisible();
 	const linkedProject = addProjectDialog.getByRole("checkbox", {
-		name: "Team Knowledge already linked",
+		name: "Team Knowledge access",
 	});
 	await expect(linkedProject).toBeChecked();
-	await expect(linkedProject).toBeDisabled();
-	await addProjectDialog.getByRole("checkbox", { name: "Link Release Project" }).click();
-	await addProjectDialog.getByRole("checkbox", { name: "Link Unrelated Project" }).click();
-	await expect(
-		addProjectDialog.getByRole("button", { name: "Link 2 Projects", exact: true }),
-	).toBeEnabled();
-	await addProjectDialog.getByRole("button", { name: "Link 2 Projects", exact: true }).click();
+	await expect(linkedProject).toBeEnabled();
+	await expect(addProjectDialog.getByText("Linked", { exact: true })).toHaveCount(0);
+	await expect(addProjectDialog.getByText("Available", { exact: true })).toHaveCount(0);
+	await linkedProject.click();
+	await expect(linkedProject).not.toBeChecked();
+	const releaseProject = addProjectDialog.getByRole("checkbox", { name: "Release Project access" });
+	await expect(releaseProject).not.toBeChecked();
+	await releaseProject.click();
+	await expect(addProjectDialog.getByRole("button", { name: "Save changes" })).toBeEnabled();
+	await addProjectDialog.getByRole("button", { name: "Save changes" }).click();
 	await expect(addProjectDialog).toHaveCount(0);
 	await expect
-		.poll(() => projectLinkBodies)
-		.toEqual([{ project_ids: ["project-batch-second", "project-unrelated"] }]);
+		.poll(() => projectLinkDeltaBodies)
+		.toEqual([
+			{
+				add_project_ids: ["project-batch-second"],
+				remove_project_ids: ["project-context-first"],
+			},
+		]);
 	await expect.poll(() => projectBindingRequests.length).toBeGreaterThan(bindingReadsBeforeLink);
 	await expect.poll(() => projectRequests.length).toBeGreaterThan(projectReadsBeforeLink);
 

--- a/apps/web/src/components/dashboard/agent-projects-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-projects-tab.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
-import { Link2, Plus, Save, Trash2 } from "lucide-react";
+import { Link2, Plus, Save } from "lucide-react";
 import { type ReactNode, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -30,7 +30,6 @@ import {
 } from "@/components/projects/project-resource-card";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { ConfirmAction } from "@/components/ui/confirm-action";
 import {
 	Dialog,
 	DialogContent,
@@ -253,22 +252,6 @@ function AgentProjectsPanel({
 		});
 	};
 
-	const removeBinding = useMutation({
-		mutationFn: async (bindingId: string) => {
-			await unwrap(
-				await api.DELETE("/v1/agents/{agent_id}/project-bindings/{binding_id}", {
-					params: { path: { agent_id: agentId, binding_id: bindingId } },
-				}),
-			);
-		},
-		onSuccess: async () => {
-			await onChanged();
-			toast.success("Project unlinked");
-		},
-		onError: (error) =>
-			toast.error("Couldn't unlink project", { description: normalizeApiError(error) }),
-	});
-
 	const actionsDisabled = !primary || isLoading || Boolean(bindingsError || projectsError);
 	const header = (
 		<PageHeader
@@ -361,8 +344,6 @@ function AgentProjectsPanel({
 				>
 					{contexts.map((binding) => {
 						const project = projectsById.get(binding.project_id);
-						const projectName = project ? displayProjectName(project) : "Unavailable Project";
-						const isRemoving = removeBinding.isPending && removeBinding.variables === binding.id;
 						return (
 							<li
 								key={binding.id}
@@ -370,43 +351,11 @@ function AgentProjectsPanel({
 								data-binding-type={binding.binding_type}
 								data-testid="agent-project-card"
 							>
-								<AgentProjectCard
-									project={project}
-									navigationScope={navigationScope}
-									actions={
-										<div>
-											<ConfirmAction
-												title="Unlink this Project?"
-												description={
-													<>
-														<p>
-															This Agent will stop using {projectName}&apos;s Skills and attached
-															Vaults.
-														</p>
-														<p>The Project and its resources remain unchanged.</p>
-													</>
-												}
-												confirmLabel="Unlink project"
-												destructive
-												onConfirm={() => removeBinding.mutateAsync(binding.id)}
-											>
-												<Button
-													variant="ghost"
-													size="icon-sm"
-													disabled={isRemoving}
-													title="Unlink project"
-													aria-label={`Unlink ${projectName}`}
-												>
-													{isRemoving ? (
-														<Spinner className="size-3.5" />
-													) : (
-														<Trash2 className="size-3.5 text-destructive" />
-													)}
-												</Button>
-											</ConfirmAction>
-										</div>
-									}
-								/>
+								{project ? (
+									<ProjectResourceCard project={project} navigationScope={navigationScope} />
+								) : (
+									<UnavailableProjectResourceCard />
+								)}
 							</li>
 						);
 					})}
@@ -550,22 +499,5 @@ function AgentProjectsPanel({
 				</DialogContent>
 			</Dialog>
 		</div>
-	);
-}
-
-function AgentProjectCard({
-	project,
-	navigationScope,
-	actions,
-}: {
-	project: ProjectRow | undefined;
-	navigationScope: ResourceNavigationScope;
-	actions?: ReactNode;
-}) {
-	if (!project) {
-		return <UnavailableProjectResourceCard actions={actions} />;
-	}
-	return (
-		<ProjectResourceCard project={project} actions={actions} navigationScope={navigationScope} />
 	);
 }

--- a/apps/web/src/components/dashboard/agent-projects-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-projects-tab.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
-import { Link2, Plus, Trash2 } from "lucide-react";
+import { Link2, Plus, Save, Trash2 } from "lucide-react";
 import { type ReactNode, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -28,7 +28,6 @@ import {
 	ProjectResourceCardSkeleton,
 	UnavailableProjectResourceCard,
 } from "@/components/projects/project-resource-card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ConfirmAction } from "@/components/ui/confirm-action";
@@ -86,6 +85,9 @@ export function AgentProjectsTab({
 			queryClient.invalidateQueries({ queryKey: ["get", "/v1/projects"] }),
 			queryClient.invalidateQueries({ queryKey: ["get", "/v1/projects/{project_id}"] }),
 			queryClient.invalidateQueries({ queryKey: ["get", "/v1/agents"] }),
+			queryClient.invalidateQueries({
+				queryKey: ["get", "/v1/agents/{agent_id}", { params: { path: { agent_id: agentId } } }],
+			}),
 			queryClient.invalidateQueries({ queryKey: ["get", "/v1/vault"] }),
 			queryClient.invalidateQueries({ queryKey: ["skills"] }),
 			queryClient.invalidateQueries({ queryKey: ["vaults"] }),
@@ -144,14 +146,14 @@ function AgentProjectsPanel({
 }) {
 	const api = useApi();
 	const router = useRouter();
-	const [selectedProjectIds, setSelectedProjectIds] = useState<Set<string>>(() => new Set());
-	const [linkOpen, setLinkOpen] = useState(false);
+	const [managedProjectIds, setManagedProjectIds] = useState<Set<string>>(() => new Set());
+	const [manageOpen, setManageOpen] = useState(false);
 	const [createOpen, setCreateOpen] = useState(false);
 	const [newProjectName, setNewProjectName] = useState("");
 	const [newProjectDescription, setNewProjectDescription] = useState("");
 	// React Query pending state is post-render. These refs reject a second
 	// submit synchronously, before another mutation can queue in the same frame.
-	const linkExistingLockedRef = useRef(false);
+	const manageProjectsLockedRef = useRef(false);
 	const createProjectLockedRef = useRef(false);
 	const orderedBindings = orderedAgentProjectBindings(bindings);
 	const primary = orderedBindings.find((binding) => binding.binding_type === "primary") ?? null;
@@ -160,7 +162,7 @@ function AgentProjectsPanel({
 		() => new Map(projects.map((project) => [project.id, project])),
 		[projects],
 	);
-	const linkProjects = useMemo(
+	const manageableProjects = useMemo(
 		() => projects.filter(isCustomProject).sort(compareProjectsForUse),
 		[projects],
 	);
@@ -168,29 +170,43 @@ function AgentProjectsPanel({
 		() => new Set(bindings.map((binding) => binding.project_id)),
 		[bindings],
 	);
-	const selectedProjects = linkProjects.filter(
-		(project) => selectedProjectIds.has(project.id) && !linkedProjectIds.has(project.id),
-	);
+	const projectIdsToAdd = manageableProjects
+		.filter((project) => managedProjectIds.has(project.id) && !linkedProjectIds.has(project.id))
+		.map((project) => project.id);
+	const projectIdsToRemove = manageableProjects
+		.filter((project) => linkedProjectIds.has(project.id) && !managedProjectIds.has(project.id))
+		.map((project) => project.id);
+	const hasProjectChanges = projectIdsToAdd.length > 0 || projectIdsToRemove.length > 0;
 
-	const linkContexts = useMutation({
-		mutationFn: async (projectIds: string[]) => {
+	const updateProjectLinks = useMutation({
+		mutationFn: async ({
+			addProjectIds,
+			removeProjectIds,
+		}: {
+			addProjectIds: string[];
+			removeProjectIds: string[];
+		}) => {
 			return unwrap(
-				await api.POST("/v1/agents/{agent_id}/projects", {
+				await api.PATCH("/v1/agents/{agent_id}/projects", {
 					params: { path: { agent_id: agentId } },
-					body: { project_ids: projectIds },
+					body: {
+						add_project_ids: addProjectIds,
+						remove_project_ids: removeProjectIds,
+					},
 				}),
 			);
 		},
-		onSuccess: async (_response, projectIds) => {
+		onSuccess: async () => {
 			await onChanged();
-			setSelectedProjectIds(new Set());
-			setLinkOpen(false);
-			toast.success(projectIds.length === 1 ? "Project linked" : "Projects linked");
+			setManageOpen(false);
+			toast.success("Project access updated");
 		},
 		onError: (error) =>
-			toast.error("Couldn't link Projects", { description: normalizeApiError(error) }),
+			toast.error("Couldn't update Project access", {
+				description: normalizeApiError(error),
+			}),
 		onSettled: () => {
-			linkExistingLockedRef.current = false;
+			manageProjectsLockedRef.current = false;
 		},
 	});
 
@@ -218,11 +234,13 @@ function AgentProjectsPanel({
 		},
 	});
 
-	const submitExistingProjectLinks = () => {
-		const projectIds = selectedProjects.map((project) => project.id);
-		if (projectIds.length === 0 || linkExistingLockedRef.current) return;
-		linkExistingLockedRef.current = true;
-		linkContexts.mutate(projectIds);
+	const submitProjectChanges = () => {
+		if (!hasProjectChanges || manageProjectsLockedRef.current) return;
+		manageProjectsLockedRef.current = true;
+		updateProjectLinks.mutate({
+			addProjectIds: projectIdsToAdd,
+			removeProjectIds: projectIdsToRemove,
+		});
 	};
 
 	const submitCreateProject = () => {
@@ -273,12 +291,12 @@ function AgentProjectsPanel({
 						size="sm"
 						disabled={actionsDisabled}
 						onClick={() => {
-							setSelectedProjectIds(new Set());
-							setLinkOpen(true);
+							setManagedProjectIds(new Set(contexts.map((binding) => binding.project_id)));
+							setManageOpen(true);
 						}}
 					>
 						<Link2 className="size-3.5" />
-						Link projects
+						Manage projects
 					</Button>
 				</>
 			}
@@ -396,50 +414,43 @@ function AgentProjectsPanel({
 			)}
 
 			<Dialog
-				open={linkOpen}
-				onOpenChange={setLinkOpen}
+				open={manageOpen}
+				onOpenChange={setManageOpen}
 				onOpenChangeComplete={(open) => {
-					if (!open) setSelectedProjectIds(new Set());
+					if (!open) setManagedProjectIds(new Set());
 				}}
 			>
 				<DialogContent className="sm:max-w-lg" data-testid="agent-project-add-dialog">
 					<DialogHeader>
-						<DialogTitle>Link projects to Agent</DialogTitle>
-						<DialogDescription>
-							Select Projects to add. Existing links stay in place.
-						</DialogDescription>
+						<DialogTitle>Manage projects</DialogTitle>
+						<DialogDescription>Choose which Projects this Agent can use.</DialogDescription>
 					</DialogHeader>
 					<form
 						className="space-y-4"
 						onSubmit={(event) => {
 							event.preventDefault();
-							submitExistingProjectLinks();
+							submitProjectChanges();
 						}}
 					>
-						{linkProjects.length > 0 ? (
+						{manageableProjects.length > 0 ? (
 							<div className="max-h-80 divide-y overflow-y-auto rounded-md border">
-								{linkProjects.map((project) => {
+								{manageableProjects.map((project) => {
 									const name = displayProjectName(project);
 									const checkboxId = `agent-project-${project.id}`;
-									const isLinked = linkedProjectIds.has(project.id);
-									const isSelected = selectedProjectIds.has(project.id);
+									const isSelected = managedProjectIds.has(project.id);
 									return (
 										<label
 											key={project.id}
 											htmlFor={checkboxId}
-											className={
-												isLinked
-													? "flex items-center gap-3 bg-muted/30 px-3 py-3"
-													: "flex cursor-pointer items-center gap-3 px-3 py-3 hover:bg-muted/20"
-											}
+											className="flex cursor-pointer items-center gap-3 px-3 py-2.5 hover:bg-muted/20"
 										>
 											<Checkbox
 												id={checkboxId}
-												checked={isLinked || isSelected}
-												disabled={isLinked || linkContexts.isPending}
-												aria-label={isLinked ? `${name} already linked` : `Link ${name}`}
+												checked={isSelected}
+												disabled={updateProjectLinks.isPending}
+												aria-label={`${name} access`}
 												onCheckedChange={(checked) => {
-													setSelectedProjectIds((current) => {
+													setManagedProjectIds((current) => {
 														const next = new Set(current);
 														if (checked === true) next.add(project.id);
 														else next.delete(project.id);
@@ -452,32 +463,24 @@ function AgentProjectsPanel({
 												showKind={false}
 												className="min-w-0 flex-1"
 											/>
-											<Badge variant={isLinked ? "secondary" : "outline"} className="shrink-0">
-												{isLinked ? "Linked" : "Available"}
-											</Badge>
 										</label>
 									);
 								})}
 							</div>
 						) : (
-							<p className="text-sm text-muted-foreground">No Projects are available to link.</p>
+							<p className="text-sm text-muted-foreground">No Projects are available.</p>
 						)}
 						<DialogFooter>
-							<Button type="button" variant="ghost" onClick={() => setLinkOpen(false)}>
+							<Button type="button" variant="ghost" onClick={() => setManageOpen(false)}>
 								Cancel
 							</Button>
-							<Button
-								type="submit"
-								disabled={selectedProjects.length === 0 || linkContexts.isPending}
-							>
-								{linkContexts.isPending ? (
+							<Button type="submit" disabled={!hasProjectChanges || updateProjectLinks.isPending}>
+								{updateProjectLinks.isPending ? (
 									<Spinner className="size-3.5" />
 								) : (
-									<Plus className="size-3.5" />
+									<Save className="size-3.5" />
 								)}
-								{linkContexts.isPending
-									? "Linking…"
-									: `Link ${selectedProjects.length} ${selectedProjects.length === 1 ? "Project" : "Projects"}`}
+								Save changes
 							</Button>
 						</DialogFooter>
 					</form>

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
 	LogOut,
 	Pencil,
 	Plus,
+	Save,
 	Share2,
 	Trash2,
 } from "lucide-react";
@@ -23,6 +24,7 @@ import {
 	Suspense,
 	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from "react";
 import { toast } from "sonner";
@@ -630,8 +632,8 @@ export default function ProjectDetailPage({
 	const peopleCount: CountValue | undefined = project.member_count + 1;
 	const agentCount: CountValue | undefined = project.agent_count;
 
-	const addToAgentDialog = (trigger: ReactElement) => (
-		<UseProjectWithAgentDialog
+	const manageAgentsDialog = (trigger: ReactElement) => (
+		<ManageProjectAgentsDialog
 			project={project}
 			environments={environments.data ?? []}
 			linkedEnvironments={boundAgents.data ?? []}
@@ -645,7 +647,7 @@ export default function ProjectDetailPage({
 			onOpenChange={handleUseWithAgentOpenChange}
 		>
 			{trigger}
-		</UseProjectWithAgentDialog>
+		</ManageProjectAgentsDialog>
 	);
 	const projectIdentity = identityFor(displayProjectName(project));
 	const workspaceIdentity = identityFor("Workspace");
@@ -751,10 +753,10 @@ export default function ProjectDetailPage({
 						) : !focus && !isAgentScope && isShareableProject ? (
 							<>
 								{!joinedFromShare
-									? addToAgentDialog(
+									? manageAgentsDialog(
 											<Button size="sm">
 												<Bot className="mr-1.5 size-3.5" />
-												Link project
+												Manage agents
 											</Button>,
 										)
 									: null}
@@ -786,7 +788,7 @@ export default function ProjectDetailPage({
 						</span>
 						<Button type="button" size="sm" onClick={() => setUseWithAgentOpen(true)}>
 							<Bot className="mr-1.5 size-3.5" />
-							Link project
+							Manage agents
 						</Button>
 					</AlertDescription>
 				</Alert>
@@ -1568,7 +1570,7 @@ function SharedAccessPanel({
 	);
 }
 
-function UseProjectWithAgentDialog({
+function ManageProjectAgentsDialog({
 	project,
 	environments,
 	linkedEnvironments,
@@ -1591,8 +1593,8 @@ function UseProjectWithAgentDialog({
 }) {
 	const api = useApi();
 	const qc = useQueryClient();
-	const projectName = displayProjectName(project);
-	const [selectedAgentIds, setSelectedAgentIds] = useState<Set<string>>(() => new Set());
+	const [managedAgentIds, setManagedAgentIds] = useState<Set<string>>(() => new Set());
+	const updateAgentsLockedRef = useRef(false);
 	const orderedEnvironments = useMemo(
 		() => [...environments].sort(compareAgentEnvironments),
 		[environments],
@@ -1601,25 +1603,42 @@ function UseProjectWithAgentDialog({
 		() => new Set(linkedEnvironments.map((environment) => environment.id)),
 		[linkedEnvironments],
 	);
-	const selectedAgents = orderedEnvironments.filter(
-		(environment) => selectedAgentIds.has(environment.id) && !linkedAgentIds.has(environment.id),
-	);
+	const agentIdsToAdd = orderedEnvironments
+		.filter(
+			(environment) => managedAgentIds.has(environment.id) && !linkedAgentIds.has(environment.id),
+		)
+		.map((environment) => environment.id);
+	const agentIdsToRemove = orderedEnvironments
+		.filter(
+			(environment) => linkedAgentIds.has(environment.id) && !managedAgentIds.has(environment.id),
+		)
+		.map((environment) => environment.id);
+	const hasAgentChanges = agentIdsToAdd.length > 0 || agentIdsToRemove.length > 0;
 
 	useEffect(() => {
-		if (!open) setSelectedAgentIds(new Set());
-	}, [open]);
+		setManagedAgentIds(open ? new Set(linkedAgentIds) : new Set());
+	}, [open, linkedAgentIds]);
 
-	const addProjectToAgents = useMutation({
-		mutationFn: async (agentIds: string[]) => {
-			if (agentIds.length === 0) throw new Error("Choose at least one agent");
+	const updateProjectAgents = useMutation({
+		mutationFn: async ({
+			addAgentIds,
+			removeAgentIds,
+		}: {
+			addAgentIds: string[];
+			removeAgentIds: string[];
+		}) => {
 			return unwrap(
-				await api.POST("/v1/projects/{project_id}/agents", {
+				await api.PATCH("/v1/projects/{project_id}/agents", {
 					params: { path: { project_id: project.id } },
-					body: { agent_ids: agentIds },
+					body: {
+						add_agent_ids: addAgentIds,
+						remove_agent_ids: removeAgentIds,
+					},
 				}),
 			);
 		},
-		onSuccess: async (_response, agentIds) => {
+		onSuccess: async (response) => {
+			const changedAgentIds = [...response.added_agent_ids, ...response.removed_agent_ids];
 			await Promise.all([
 				qc.invalidateQueries({ queryKey: ["get", "/v1/projects"] }),
 				qc.invalidateQueries({ queryKey: ["get", "/v1/projects/{project_id}"] }),
@@ -1627,30 +1646,41 @@ function UseProjectWithAgentDialog({
 				qc.invalidateQueries({ queryKey: ["get", "/v1/vault"] }),
 				qc.invalidateQueries({ queryKey: ["skills"] }),
 				qc.invalidateQueries({ queryKey: ["vaults"] }),
-				...agentIds.map((agentId) =>
+				...changedAgentIds.flatMap((agentId) => [
 					qc.invalidateQueries({ queryKey: agentProjectBindingsQueryKey(agentId) }),
-				),
+					qc.invalidateQueries({
+						queryKey: ["get", "/v1/agents/{agent_id}", { params: { path: { agent_id: agentId } } }],
+					}),
+				]),
 			]);
-			setSelectedAgentIds(new Set());
-			toast.success("Project linked", {
-				description: `${agentIds.length} ${agentIds.length === 1 ? "Agent can" : "Agents can"} now use ${projectName}'s Skills and attached Vaults.`,
-			});
+			toast.success("Agent access updated");
 			onOpenChange(false);
 		},
 		onError: (error) => {
-			toast.error("Couldn't link project", {
+			toast.error("Couldn't update Agent access", {
 				description: normalizeApiError(error),
 			});
 		},
+		onSettled: () => {
+			updateAgentsLockedRef.current = false;
+		},
 	});
+	const submitAgentChanges = () => {
+		if (!hasAgentChanges || updateAgentsLockedRef.current) return;
+		updateAgentsLockedRef.current = true;
+		updateProjectAgents.mutate({
+			addAgentIds: agentIdsToAdd,
+			removeAgentIds: agentIdsToRemove,
+		});
+	};
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogTrigger render={children} />
 			<DialogContent className="sm:max-w-lg">
 				<DialogHeader>
-					<DialogTitle>Link project to Agents</DialogTitle>
-					<DialogDescription>Select Agents to add. Existing links stay in place.</DialogDescription>
+					<DialogTitle>Manage agents</DialogTitle>
+					<DialogDescription>Choose which Agents can use this Project.</DialogDescription>
 				</DialogHeader>
 
 				{isLoadingAgents ? (
@@ -1667,29 +1697,31 @@ function UseProjectWithAgentDialog({
 						</AlertDescription>
 					</Alert>
 				) : (
-					<div className="space-y-4">
+					<form
+						className="space-y-4"
+						onSubmit={(event) => {
+							event.preventDefault();
+							submitAgentChanges();
+						}}
+					>
 						<div className="max-h-80 divide-y overflow-y-auto rounded-md border">
 							{orderedEnvironments.map((environment) => {
 								const name = agentDisplayName(environment);
 								const checkboxId = `project-agent-${environment.id}`;
-								const isLinked = linkedAgentIds.has(environment.id);
-								const isSelected = selectedAgentIds.has(environment.id);
+								const isSelected = managedAgentIds.has(environment.id);
 								return (
 									<label
 										key={environment.id}
 										htmlFor={checkboxId}
-										className={cn(
-											"flex items-center gap-3 px-3 py-3",
-											isLinked ? "bg-muted/30" : "cursor-pointer hover:bg-muted/20",
-										)}
+										className="flex cursor-pointer items-center gap-3 px-3 py-2.5 hover:bg-muted/20"
 									>
 										<Checkbox
 											id={checkboxId}
-											checked={isLinked || isSelected}
-											disabled={isLinked || addProjectToAgents.isPending}
-											aria-label={isLinked ? `${name} already linked` : `Link ${name}`}
+											checked={isSelected}
+											disabled={updateProjectAgents.isPending}
+											aria-label={`${name} access`}
 											onCheckedChange={(checked) => {
-												setSelectedAgentIds((current) => {
+												setManagedAgentIds((current) => {
 													const next = new Set(current);
 													if (checked === true) next.add(environment.id);
 													else next.delete(environment.id);
@@ -1713,29 +1745,21 @@ function UseProjectWithAgentDialog({
 											]}
 											className="min-w-0 flex-1"
 										/>
-										<Badge variant={isLinked ? "secondary" : "outline"} className="shrink-0">
-											{isLinked ? "Linked" : "Available"}
-										</Badge>
 									</label>
 								);
 							})}
 						</div>
 
 						<DialogFooter>
-							<Button variant="ghost" onClick={() => onOpenChange(false)}>
+							<Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
 								Cancel
 							</Button>
-							<Button
-								onClick={() => addProjectToAgents.mutate(selectedAgents.map((agent) => agent.id))}
-								disabled={selectedAgents.length === 0 || addProjectToAgents.isPending}
-							>
-								{addProjectToAgents.isPending ? <Spinner /> : <Plus className="mr-1.5 size-3.5" />}
-								{addProjectToAgents.isPending
-									? "Linking…"
-									: `Link ${selectedAgents.length} ${selectedAgents.length === 1 ? "Agent" : "Agents"}`}
+							<Button type="submit" disabled={!hasAgentChanges || updateProjectAgents.isPending}>
+								{updateProjectAgents.isPending ? <Spinner /> : <Save className="size-3.5" />}
+								Save changes
 							</Button>
 						</DialogFooter>
-					</div>
+					</form>
 				)}
 			</DialogContent>
 		</Dialog>

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -1183,11 +1183,7 @@ export default function ProjectDetailPage({
 										<Badge variant="secondary" className="shrink-0">
 											Workspace
 										</Badge>
-									) : (
-										<Badge variant="outline" className="shrink-0">
-											Linked
-										</Badge>
-									)}
+									) : null}
 									<Link
 										{...agentSectionLink(env.id, "projects")}
 										className="absolute inset-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/backend/app/routes/agent_project_bindings.py
+++ b/backend/app/routes/agent_project_bindings.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from sqlalchemy import case, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -26,6 +26,7 @@ from app.services.agent_bindings import (
     ensure_agent_primary_binding,
     ensure_context_binding,
     get_owned_agent_or_404,
+    update_owned_agent_project_links,
 )
 from app.services.project_runtime_skills import (
     assert_project_link_compatible,
@@ -44,6 +45,23 @@ class AgentProjectLinkBody(BaseModel):
 class AgentProjectLinkResponse(BaseModel):
     agent_id: str
     bound_project_ids: list[str]
+
+
+class AgentProjectDeltaBody(BaseModel):
+    add_project_ids: list[UUID] = Field(default_factory=list, max_length=200)
+    remove_project_ids: list[UUID] = Field(default_factory=list, max_length=200)
+
+    @model_validator(mode="after")
+    def validate_disjoint_ids(self) -> AgentProjectDeltaBody:
+        if set(self.add_project_ids) & set(self.remove_project_ids):
+            raise ValueError("Project ids to add and remove must be disjoint")
+        return self
+
+
+class AgentProjectDeltaResponse(BaseModel):
+    agent_id: str
+    added_project_ids: list[str]
+    removed_project_ids: list[str]
 
 
 def _to_response(binding: AgentProjectBinding) -> AgentProjectBindingResponse:
@@ -147,6 +165,28 @@ async def link_agent_projects(
     return AgentProjectLinkResponse(
         agent_id=str(agent_id),
         bound_project_ids=bound_project_ids,
+    )
+
+
+@router.patch("/{agent_id}/projects", response_model=AgentProjectDeltaResponse)
+async def update_agent_projects(
+    agent_id: UUID,
+    body: AgentProjectDeltaBody,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> AgentProjectDeltaResponse:
+    result = await update_owned_agent_project_links(
+        db,
+        user_id=auth.user_id,
+        agent_id=agent_id,
+        add_project_ids=body.add_project_ids,
+        remove_project_ids=body.remove_project_ids,
+    )
+    await db.commit()
+    return AgentProjectDeltaResponse(
+        agent_id=str(agent_id),
+        added_project_ids=[str(project_id) for project_id in result.added_ids],
+        removed_project_ids=[str(project_id) for project_id in result.removed_ids],
     )
 
 

--- a/backend/app/routes/projects.py
+++ b/backend/app/routes/projects.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy import and_, delete, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,7 +25,10 @@ from app.models.session import AgentEnvironment
 from app.models.skill import Skill
 from app.models.user import User
 from app.models.vault import VaultProjectAttachment
-from app.services.agent_bindings import attach_project_to_owned_agents
+from app.services.agent_bindings import (
+    attach_project_to_owned_agents,
+    update_project_owned_agent_links,
+)
 from app.services.agent_lifecycle import active_project_filter
 from app.services.project_runtime_skills import (
     lock_project_change,
@@ -133,6 +136,23 @@ class ProjectAgentLinkBody(BaseModel):
 class ProjectAgentLinkResponse(BaseModel):
     project_id: str
     bound_agent_ids: list[str]
+
+
+class ProjectAgentDeltaBody(BaseModel):
+    add_agent_ids: list[UUID] = Field(default_factory=list, max_length=200)
+    remove_agent_ids: list[UUID] = Field(default_factory=list, max_length=200)
+
+    @model_validator(mode="after")
+    def validate_disjoint_ids(self) -> ProjectAgentDeltaBody:
+        if set(self.add_agent_ids) & set(self.remove_agent_ids):
+            raise ValueError("Agent ids to add and remove must be disjoint")
+        return self
+
+
+class ProjectAgentDeltaResponse(BaseModel):
+    project_id: str
+    added_agent_ids: list[str]
+    removed_agent_ids: list[str]
 
 
 def _project_response(
@@ -461,6 +481,28 @@ async def link_project_agents(
     return ProjectAgentLinkResponse(
         project_id=str(project_id),
         bound_agent_ids=bound_agent_ids,
+    )
+
+
+@router.patch("/{project_id}/agents", response_model=ProjectAgentDeltaResponse)
+async def update_project_agents(
+    project_id: UUID,
+    body: ProjectAgentDeltaBody,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> ProjectAgentDeltaResponse:
+    result = await update_project_owned_agent_links(
+        db,
+        user_id=auth.user_id,
+        project_id=project_id,
+        add_agent_ids=body.add_agent_ids,
+        remove_agent_ids=body.remove_agent_ids,
+    )
+    await db.commit()
+    return ProjectAgentDeltaResponse(
+        project_id=str(project_id),
+        added_agent_ids=[str(agent_id) for agent_id in result.added_ids],
+        removed_agent_ids=[str(agent_id) for agent_id in result.removed_ids],
     )
 
 

--- a/backend/app/services/agent_bindings.py
+++ b/backend/app/services/agent_bindings.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from dataclasses import dataclass
 from uuid import UUID
 
 from fastapi import HTTPException, status
@@ -14,6 +16,37 @@ from app.models.project import PROJECT_KIND_WORKSPACE, Project
 from app.models.project_membership import ProjectMembership
 from app.models.session import AgentEnvironment
 from app.services.agent_lifecycle import active_agent_filter, active_project_filter
+
+
+@dataclass(frozen=True)
+class BindingDeltaResult:
+    added_ids: tuple[UUID, ...]
+    removed_ids: tuple[UUID, ...]
+
+
+def _unique_ids(values: Iterable[UUID]) -> list[UUID]:
+    return list(dict.fromkeys(values))
+
+
+def _validate_disjoint_delta(
+    *,
+    add_ids: list[UUID],
+    remove_ids: list[UUID],
+    resource_name: str,
+) -> None:
+    if set(add_ids) & set(remove_ids):
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"{resource_name} ids to add and remove must be disjoint",
+        )
+
+
+def _assert_context_binding(binding: AgentProjectBinding) -> None:
+    if binding.binding_type != "context":
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Workspace bindings cannot be changed here",
+        )
 
 
 async def get_owned_agent_or_404(
@@ -373,6 +406,225 @@ async def attach_projects_to_owned_agent(
     if changed:
         await queue_environment_runtime_manifest_changed(db, user_id, agent_id)
     return [str(project_id) for project_id in project_ids]
+
+
+async def update_owned_agent_project_links(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    agent_id: UUID,
+    add_project_ids: Iterable[UUID],
+    remove_project_ids: Iterable[UUID],
+) -> BindingDeltaResult:
+    """Atomically add and remove one owned Agent's context Projects."""
+    from app.services.project_runtime_skills import (
+        assert_project_link_compatible,
+        lock_project_binding_set_change,
+    )
+    from app.services.sync_events import queue_environment_runtime_manifest_changed
+
+    agent = await get_owned_agent_or_404(db, user_id=user_id, agent_id=agent_id)
+    add_ids = _unique_ids(add_project_ids)
+    remove_ids = _unique_ids(remove_project_ids)
+    _validate_disjoint_delta(
+        add_ids=add_ids,
+        remove_ids=remove_ids,
+        resource_name="Project",
+    )
+    target_ids = _unique_ids([*add_ids, *remove_ids])
+
+    if agent.default_project_id in remove_ids:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Workspace cannot be unlinked",
+        )
+    for project_id in add_ids:
+        await assert_project_linkable_to_agent(
+            db,
+            user_id=user_id,
+            agent=agent,
+            project_id=project_id,
+        )
+    if not target_ids:
+        return BindingDeltaResult(added_ids=(), removed_ids=())
+
+    await lock_project_binding_set_change(
+        db,
+        project_ids=target_ids,
+        agent_id=agent_id,
+    )
+    agent = await get_owned_agent_or_404(db, user_id=user_id, agent_id=agent_id)
+    if agent.default_project_id in remove_ids:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Workspace cannot be unlinked",
+        )
+    for project_id in add_ids:
+        await assert_project_linkable_to_agent(
+            db,
+            user_id=user_id,
+            agent=agent,
+            project_id=project_id,
+        )
+
+    bindings = (
+        (
+            await db.execute(
+                select(AgentProjectBinding).where(
+                    AgentProjectBinding.agent_id == agent_id,
+                    AgentProjectBinding.project_id.in_(target_ids),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    bindings_by_project_id = {binding.project_id: binding for binding in bindings}
+    for binding in bindings:
+        _assert_context_binding(binding)
+
+    removed_ids: list[UUID] = []
+    for project_id in remove_ids:
+        binding = bindings_by_project_id.get(project_id)
+        if binding is None:
+            continue
+        await db.delete(binding)
+        removed_ids.append(project_id)
+    if removed_ids:
+        await db.flush()
+
+    added_ids: list[UUID] = []
+    for project_id in add_ids:
+        if project_id in bindings_by_project_id:
+            continue
+        await assert_project_link_compatible(
+            db,
+            agent_id=agent_id,
+            project_id=project_id,
+        )
+        await ensure_context_binding(
+            db,
+            agent_id=agent_id,
+            project_id=project_id,
+            created_by_user_id=user_id,
+        )
+        added_ids.append(project_id)
+
+    if added_ids or removed_ids:
+        await queue_environment_runtime_manifest_changed(db, user_id, agent_id)
+    return BindingDeltaResult(
+        added_ids=tuple(added_ids),
+        removed_ids=tuple(removed_ids),
+    )
+
+
+async def update_project_owned_agent_links(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    project_id: UUID,
+    add_agent_ids: Iterable[UUID],
+    remove_agent_ids: Iterable[UUID],
+) -> BindingDeltaResult:
+    """Atomically add and remove owned Agents for one visible Project."""
+    from app.services.project_runtime_skills import (
+        assert_project_link_compatible,
+        lock_project_agent_binding_changes,
+    )
+    from app.services.sync_events import queue_environment_runtime_manifest_changed
+
+    add_ids = _unique_ids(add_agent_ids)
+    remove_ids = _unique_ids(remove_agent_ids)
+    _validate_disjoint_delta(
+        add_ids=add_ids,
+        remove_ids=remove_ids,
+        resource_name="Agent",
+    )
+    target_ids = _unique_ids([*add_ids, *remove_ids])
+
+    project = await assert_project_visible_to_user(
+        db,
+        user_id=user_id,
+        project_id=project_id,
+    )
+    if project.kind != PROJECT_KIND_WORKSPACE:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Only Projects you create or that are shared with you can be linked",
+        )
+    for agent_id in target_ids:
+        await get_owned_agent_or_404(db, user_id=user_id, agent_id=agent_id)
+    if not target_ids:
+        return BindingDeltaResult(added_ids=(), removed_ids=())
+
+    await lock_project_agent_binding_changes(
+        db,
+        project_id=project_id,
+        agent_ids=target_ids,
+    )
+    project = await assert_project_visible_to_user(
+        db,
+        user_id=user_id,
+        project_id=project_id,
+    )
+    if project.kind != PROJECT_KIND_WORKSPACE:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Only Projects you create or that are shared with you can be linked",
+        )
+    for agent_id in target_ids:
+        await get_owned_agent_or_404(db, user_id=user_id, agent_id=agent_id)
+
+    bindings = (
+        (
+            await db.execute(
+                select(AgentProjectBinding).where(
+                    AgentProjectBinding.project_id == project_id,
+                    AgentProjectBinding.agent_id.in_(target_ids),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    bindings_by_agent_id = {binding.agent_id: binding for binding in bindings}
+    for binding in bindings:
+        _assert_context_binding(binding)
+
+    removed_ids: list[UUID] = []
+    for agent_id in remove_ids:
+        binding = bindings_by_agent_id.get(agent_id)
+        if binding is None:
+            continue
+        await db.delete(binding)
+        removed_ids.append(agent_id)
+    if removed_ids:
+        await db.flush()
+
+    added_ids: list[UUID] = []
+    for agent_id in add_ids:
+        if agent_id in bindings_by_agent_id:
+            continue
+        await assert_project_link_compatible(
+            db,
+            agent_id=agent_id,
+            project_id=project_id,
+        )
+        await ensure_context_binding(
+            db,
+            agent_id=agent_id,
+            project_id=project_id,
+            created_by_user_id=user_id,
+        )
+        added_ids.append(agent_id)
+
+    changed_agent_ids = {*added_ids, *removed_ids}
+    for agent_id in sorted(changed_agent_ids, key=str):
+        await queue_environment_runtime_manifest_changed(db, user_id, agent_id)
+    return BindingDeltaResult(
+        added_ids=tuple(added_ids),
+        removed_ids=tuple(removed_ids),
+    )
 
 
 async def ensure_agent_primary_binding(

--- a/backend/tests/test_project_agent_role_paths.py
+++ b/backend/tests/test_project_agent_role_paths.py
@@ -14,6 +14,7 @@ from app.core.auth import AuthContext, get_auth
 from app.core.database import get_session
 from app.main import app
 from app.models.agent_project_binding import AgentProjectBinding
+from app.models.hosted_runtime import HostedRuntimeState
 from app.models.project import PROJECT_KIND_WORKSPACE, Project
 from app.models.project_invitation import ProjectInvitation
 from app.models.project_membership import ProjectMembership
@@ -364,6 +365,129 @@ async def test_agent_batch_link_adds_projects_without_replacing_existing_links(
     )
     assert {binding.project_id for binding in bindings} == {project.id for project in projects}
     assert sorted(binding.priority for binding in bindings) == [1, 2, 3]
+
+
+async def test_agent_project_delta_is_atomic_and_skips_noop_notifications(
+    client,
+    db_session,
+    seed_user,
+    channel_agent,
+):
+    projects = [
+        Project(
+            user_id=seed_user.id,
+            name=name,
+            slug=f"{slug}-{uuid.uuid4().hex[:8]}",
+            kind=PROJECT_KIND_WORKSPACE,
+        )
+        for name, slug in (
+            ("Old Context", "old-context"),
+            ("New Context", "new-context"),
+            ("Conflicting Context", "conflicting-context"),
+        )
+    ]
+    db_session.add_all(projects)
+    await db_session.flush()
+    db_session.add(
+        Skill(
+            user_id=seed_user.id,
+            project_id=projects[2].id,
+            skill_key="duplicate",
+            name="Duplicate",
+            description="Conflicts with the Agent Workspace",
+            content_hash="c" * 64,
+            authority=SKILL_AUTHORITY_CLOUD,
+        )
+    )
+    state = await db_session.get(HostedRuntimeState, channel_agent.id)
+    assert state is not None
+    state.skills = {"entries": {"duplicate": {"enabled": False, "version": 1}}}
+    await db_session.commit()
+    user_id = seed_user.id
+    agent_id = channel_agent.id
+    default_project_id = channel_agent.default_project_id
+    project_ids = [project.id for project in projects]
+
+    existing = await client.post(
+        f"/v1/agents/{agent_id}/project-bindings/context",
+        json={"project_id": str(project_ids[0])},
+    )
+    assert existing.status_code == 200, existing.text
+    projects[0].archived_at = datetime.now(UTC)
+    await db_session.commit()
+
+    queue = sync_events.subscribe(user_id, frozenset(), environment_id=agent_id)
+    try:
+        changed = await client.patch(
+            f"/v1/agents/{agent_id}/projects",
+            json={
+                "add_project_ids": [str(project_ids[1])],
+                "remove_project_ids": [str(project_ids[0])],
+            },
+        )
+        assert changed.status_code == 200, changed.text
+        assert changed.json() == {
+            "agent_id": str(agent_id),
+            "added_project_ids": [str(project_ids[1])],
+            "removed_project_ids": [str(project_ids[0])],
+        }
+        assert queue.get_nowait() == {
+            "type": "runtime_manifest_changed",
+            "environment_id": str(agent_id),
+        }
+        assert queue.empty()
+
+        noop = await client.patch(
+            f"/v1/agents/{agent_id}/projects",
+            json={
+                "add_project_ids": [str(project_ids[1])],
+                "remove_project_ids": [str(project_ids[0])],
+            },
+        )
+        assert noop.status_code == 200, noop.text
+        assert noop.json()["added_project_ids"] == []
+        assert noop.json()["removed_project_ids"] == []
+        assert queue.empty()
+
+        primary_removal = await client.patch(
+            f"/v1/agents/{agent_id}/projects",
+            json={
+                "add_project_ids": [],
+                "remove_project_ids": [str(default_project_id)],
+            },
+        )
+        assert primary_removal.status_code == 400, primary_removal.text
+        assert queue.empty()
+
+        conflict = await client.patch(
+            f"/v1/agents/{agent_id}/projects",
+            json={
+                "add_project_ids": [str(project_ids[2])],
+                "remove_project_ids": [str(project_ids[1])],
+            },
+        )
+        assert conflict.status_code == 409, conflict.text
+        assert conflict.json()["detail"]["code"] == "project_skill_name_conflict"
+        await db_session.rollback()
+
+        bindings = (
+            (
+                await db_session.execute(
+                    select(AgentProjectBinding).where(AgentProjectBinding.agent_id == agent_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert {
+            binding.project_id for binding in bindings if binding.binding_type == "context"
+        } == {project_ids[1]}
+        assert [
+            binding.project_id for binding in bindings if binding.binding_type == "primary"
+        ] == [default_project_id]
+        assert queue.empty()
+    finally:
+        sync_events.unsubscribe(user_id, queue)
 
 
 async def test_agent_context_attach_rejects_managed_projects(

--- a/backend/tests/test_projects_routes.py
+++ b/backend/tests/test_projects_routes.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import UTC, datetime
 
 import pytest
@@ -9,7 +10,7 @@ from app.models.skill import SKILL_AUTHORITY_CLOUD, Skill
 from app.models.user import User
 from app.models.vault import Vault, VaultProjectAttachment
 from app.services import sync_events
-from tests.conftest import create_env_with_project
+from tests.conftest import create_env_with_project, create_test_hosted_runtime_state
 
 pytestmark = pytest.mark.asyncio
 
@@ -274,6 +275,136 @@ async def test_project_batch_link_preserves_an_existing_owned_agent(
         str(channel_agent.id),
         str(second_channel_agent.id),
     }
+
+
+async def test_project_agent_delta_is_atomic_and_skips_noop_notifications(
+    client,
+    db_session,
+    seed_user,
+    workspace_project,
+    channel_agent,
+    second_channel_agent,
+):
+    conflicting_agent = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"project-delta-conflict-{uuid.uuid4().hex[:8]}",
+        machine_name="Conflict Agent",
+        agent_type="openclaw",
+    )
+    conflicting_state = await create_test_hosted_runtime_state(
+        db_session,
+        conflicting_agent,
+        runtime_name="openclaw",
+    )
+    conflicting_state.skills = {"entries": {"duplicate": {"enabled": False, "version": 1}}}
+    db_session.add(
+        Skill(
+            user_id=seed_user.id,
+            project_id=workspace_project.id,
+            skill_key="duplicate",
+            name="Duplicate",
+            description="Conflicts with one Agent Workspace",
+            content_hash="d" * 64,
+            authority=SKILL_AUTHORITY_CLOUD,
+        )
+    )
+    await db_session.commit()
+    user_id = seed_user.id
+    project_id = workspace_project.id
+    first_agent_id = channel_agent.id
+    second_agent_id = second_channel_agent.id
+    conflicting_agent_id = conflicting_agent.id
+
+    existing = await client.post(
+        f"/v1/agents/{first_agent_id}/project-bindings/context",
+        json={"project_id": str(project_id)},
+    )
+    assert existing.status_code == 200, existing.text
+
+    first_queue = sync_events.subscribe(
+        user_id,
+        frozenset(),
+        environment_id=first_agent_id,
+    )
+    second_queue = sync_events.subscribe(
+        user_id,
+        frozenset(),
+        environment_id=second_agent_id,
+    )
+    conflict_queue = sync_events.subscribe(
+        user_id,
+        frozenset(),
+        environment_id=conflicting_agent_id,
+    )
+    try:
+        changed = await client.patch(
+            f"/v1/projects/{project_id}/agents",
+            json={
+                "add_agent_ids": [str(second_agent_id)],
+                "remove_agent_ids": [str(first_agent_id)],
+            },
+        )
+        assert changed.status_code == 200, changed.text
+        assert changed.json() == {
+            "project_id": str(project_id),
+            "added_agent_ids": [str(second_agent_id)],
+            "removed_agent_ids": [str(first_agent_id)],
+        }
+        for queue, agent_id in (
+            (first_queue, first_agent_id),
+            (second_queue, second_agent_id),
+        ):
+            assert queue.get_nowait() == {
+                "type": "runtime_manifest_changed",
+                "environment_id": str(agent_id),
+            }
+            assert queue.empty()
+        assert conflict_queue.empty()
+
+        noop = await client.patch(
+            f"/v1/projects/{project_id}/agents",
+            json={
+                "add_agent_ids": [str(second_agent_id)],
+                "remove_agent_ids": [str(first_agent_id)],
+            },
+        )
+        assert noop.status_code == 200, noop.text
+        assert noop.json()["added_agent_ids"] == []
+        assert noop.json()["removed_agent_ids"] == []
+        assert first_queue.empty()
+        assert second_queue.empty()
+        assert conflict_queue.empty()
+
+        conflict = await client.patch(
+            f"/v1/projects/{project_id}/agents",
+            json={
+                "add_agent_ids": [str(conflicting_agent_id)],
+                "remove_agent_ids": [str(second_agent_id)],
+            },
+        )
+        assert conflict.status_code == 409, conflict.text
+        assert conflict.json()["detail"]["code"] == "project_skill_name_conflict"
+        await db_session.rollback()
+
+        linked_agent_ids = set(
+            (
+                await db_session.execute(
+                    select(AgentProjectBinding.agent_id).where(
+                        AgentProjectBinding.project_id == project_id,
+                        AgentProjectBinding.binding_type == "context",
+                    )
+                )
+            ).scalars()
+        )
+        assert linked_agent_ids == {second_agent_id}
+        assert first_queue.empty()
+        assert second_queue.empty()
+        assert conflict_queue.empty()
+    finally:
+        sync_events.unsubscribe(user_id, first_queue)
+        sync_events.unsubscribe(user_id, second_queue)
+        sync_events.unsubscribe(user_id, conflict_queue)
 
 
 async def test_global_search_finds_projects_by_name_and_slug(client):

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1569,7 +1569,8 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
+        /** Update Project Agents */
+        patch: operations["update_project_agents_v1_projects__project_id__agents_patch"];
         trace?: never;
     };
     "/v1/runtime/manifest": {
@@ -2962,7 +2963,8 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
+        /** Update Agent Projects */
+        patch: operations["update_agent_projects_v1_agents__agent_id__projects_patch"];
         trace?: never;
     };
     "/v1/agents/{agent_id}/project-bindings/context": {
@@ -3313,6 +3315,22 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
+        };
+        /** AgentProjectDeltaBody */
+        AgentProjectDeltaBody: {
+            /** Add Project Ids */
+            add_project_ids?: string[];
+            /** Remove Project Ids */
+            remove_project_ids?: string[];
+        };
+        /** AgentProjectDeltaResponse */
+        AgentProjectDeltaResponse: {
+            /** Agent Id */
+            agent_id: string;
+            /** Added Project Ids */
+            added_project_ids: string[];
+            /** Removed Project Ids */
+            removed_project_ids: string[];
         };
         /** AgentProjectLinkBody */
         AgentProjectLinkBody: {
@@ -6475,6 +6493,22 @@ export interface components {
             synced_at: string;
             /** Plugins */
             plugins: components["schemas"]["PluginCatalogEntryResponse"][];
+        };
+        /** ProjectAgentDeltaBody */
+        ProjectAgentDeltaBody: {
+            /** Add Agent Ids */
+            add_agent_ids?: string[];
+            /** Remove Agent Ids */
+            remove_agent_ids?: string[];
+        };
+        /** ProjectAgentDeltaResponse */
+        ProjectAgentDeltaResponse: {
+            /** Project Id */
+            project_id: string;
+            /** Added Agent Ids */
+            added_agent_ids: string[];
+            /** Removed Agent Ids */
+            removed_agent_ids: string[];
         };
         /** ProjectAgentLinkBody */
         ProjectAgentLinkBody: {
@@ -11377,6 +11411,41 @@ export interface operations {
             };
         };
     };
+    update_project_agents_v1_projects__project_id__agents_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProjectAgentDeltaBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectAgentDeltaResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_runtime_manifest_v1_runtime_manifest_get: {
         parameters: {
             query?: {
@@ -14066,6 +14135,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AgentProjectLinkResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_agent_projects_v1_agents__agent_id__projects_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AgentProjectDeltaBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentProjectDeltaResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary

- make Agent-to-Project and Project-to-Agent dialogs true multi-select management surfaces
- allow linked items to be unchecked and remove redundant Linked/Available badges
- apply additions and removals atomically while preserving Workspace and runtime consistency
- keep the existing additive endpoints compatible

## Verification

- backend atomic delta tests: 2 passed
- Chromium Playwright related suites: 12 passed
- web typecheck, OSS tests, and OSS production build
- full Biome check, Ruff lint/format, generated API consistency, and git diff check