### PR TITLE
fix(web): separate Free compute from reusable subscriptions

### DIFF
--- a/apps/web/e2e/hosted-deploy-flow.pw.ts
+++ b/apps/web/e2e/hosted-deploy-flow.pw.ts
@@ -87,5 +87,9 @@ test("deploy wizard creates one selected runtime and renders mock status transit
 	await expect(page.getByRole("button", { name: /New paid subscription/ })).toHaveCount(0);
 	await expect(page.getByText("Payment method", { exact: true })).toBeVisible();
 	await expect(page.getByRole("button", { name: /Card subscription/ })).toBeVisible();
+
+	await page.getByRole("button", { name: "Settings", exact: true }).click();
+	await expect(page.getByTestId("settings-dialog")).toBeVisible();
+	await expect(page.getByRole("alertdialog", { name: "Discard unsaved changes?" })).toHaveCount(0);
 	expect(errors, `deploy flow: ${errors.join(" | ")}`).toEqual([]);
 });

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4192,6 +4192,7 @@ test("paid checkout navigates on deployment acceptance without LRO convergence",
 test("accepted detail delete dismisses immediately while teardown finishes in the background", async ({
 	page,
 }) => {
+	const deleteRequestBodies: string[] = [];
 	const deleteRequests: string[] = [];
 	const deploymentListRequests: string[] = [];
 	const completedDeleteIds = new Set<string>();
@@ -4199,6 +4200,7 @@ test("accepted detail delete dismisses immediately while teardown finishes in th
 		deployments: [includedBasicDeployment],
 		plans: [basicPlan, performancePlan],
 		completedDeleteIds,
+		deleteRequestBodies,
 		deleteRequests,
 		deploymentListRequests,
 	});
@@ -4222,6 +4224,9 @@ test("accepted detail delete dismisses immediately while teardown finishes in th
 		.click();
 
 	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_included"]);
+	await expect
+		.poll(() => deleteRequestBodies.map((body) => JSON.parse(body)))
+		.toEqual([{ subscription_choice: "cancel_subscription" }]);
 	await expect.poll(() => new URL(page.url()).pathname).toBe("/");
 	await expect
 		.poll(() => page.evaluate(() => window.history.length))

--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -609,6 +609,17 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 		"payment-action-required",
 		"canceling",
 	]);
+	const desktopGrid = await activeCard.evaluate((card) => {
+		const grid = card.closest("ul");
+		if (!grid) throw new Error("Subscription card grid is missing");
+		const style = getComputedStyle(grid);
+		return {
+			columns: style.gridTemplateColumns.split(" ").filter(Boolean).length,
+			columnGap: style.columnGap,
+			rowGap: style.rowGap,
+		};
+	});
+	expect(desktopGrid).toEqual({ columns: 2, columnGap: "8px", rowGap: "8px" });
 	await expectSubscriptionCardRowAligned(activeCard, includedCard);
 	const desktopCardBoxes = await currentCards.evaluateAll((cards) =>
 		cards.map((card) => card.getBoundingClientRect().toJSON()),

--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -126,6 +126,7 @@ function subscription(
 ): Subscription {
 	return {
 		subscription_id: subscriptionId,
+		subscription_kind: "paid",
 		plan_slug: "compute_performance",
 		funding_source: "stripe",
 		status,
@@ -460,6 +461,7 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 				items: [
 					subscription("active", "active", { agent_name: longAgentName }),
 					subscription("included", "active", {
+						subscription_kind: "included_basic",
 						plan_slug: "compute_basic",
 						funding_source: null,
 						price_cents: 0,

--- a/apps/web/src/hosted/agents/deployment-delete-action.tsx
+++ b/apps/web/src/hosted/agents/deployment-delete-action.tsx
@@ -44,6 +44,8 @@ export function HostedDeploymentDeleteAction({
 	const [pending, setPending] = useState(false);
 	const locked = useRef(false);
 	const subscription = deployment.commercial_display?.compute_subscription;
+	const includedBasic =
+		computeFundingMode(deployment.current_plan_slug, subscription) === "included_basic";
 	const offerChoice =
 		computeFundingMode(deployment.current_plan_slug, subscription) === "subscription" &&
 		isComputeSubscriptionRenewing(subscription);
@@ -63,7 +65,11 @@ export function HostedDeploymentDeleteAction({
 					id: deployment.resource.id,
 					resourceVersion: deployment.resource.metadata.resourceVersion,
 					request: {
-						subscription_choice: offerChoice ? choice : "keep_subscription",
+						subscription_choice: offerChoice
+							? choice
+							: includedBasic
+								? "cancel_subscription"
+								: "keep_subscription",
 					},
 				});
 			} catch {

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -749,6 +749,7 @@ describe("deployment mutation settlement", () => {
 		queryClient.setQueryData(billingKeys.deployments, []);
 		queryClient.setQueryData(["get", "/v1/agents"], []);
 		queryClient.setQueryData(billingKeys.subscriptions, []);
+		queryClient.setQueryData(billingKeys.includedBasicAvailability, { available_slots: 0 });
 		queryClient.setQueryData(billingKeys.reusableSubscriptions, []);
 
 		if (!invalidateSnapshots || !invalidateDeleteSnapshots) {
@@ -759,10 +760,16 @@ describe("deployment mutation settlement", () => {
 		expect(queryClient.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(true);
 		expect(queryClient.getQueryState(["get", "/v1/agents"])?.isInvalidated).toBe(true);
 		expect(queryClient.getQueryState(billingKeys.subscriptions)?.isInvalidated).toBe(false);
+		expect(queryClient.getQueryState(billingKeys.includedBasicAvailability)?.isInvalidated).toBe(
+			false,
+		);
 		expect(queryClient.getQueryState(billingKeys.reusableSubscriptions)?.isInvalidated).toBe(false);
 
 		invalidateDeleteSnapshots(queryClient);
 		expect(queryClient.getQueryState(billingKeys.subscriptions)?.isInvalidated).toBe(true);
+		expect(queryClient.getQueryState(billingKeys.includedBasicAvailability)?.isInvalidated).toBe(
+			true,
+		);
 		expect(queryClient.getQueryState(billingKeys.reusableSubscriptions)?.isInvalidated).toBe(true);
 	});
 

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -56,6 +56,7 @@ export function invalidateDeploymentSnapshots(qc: QueryClient) {
 export function invalidateDeploymentDeleteSnapshots(qc: QueryClient) {
 	invalidateDeploymentSnapshots(qc);
 	void qc.invalidateQueries({ queryKey: billingKeys.subscriptions });
+	void qc.invalidateQueries({ queryKey: billingKeys.includedBasicAvailability });
 	void qc.invalidateQueries({ queryKey: billingKeys.reusableSubscriptions });
 }
 

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -828,6 +828,8 @@ export function createBillingClient(
 					params: { query: { limit, cursor } },
 				}),
 			),
+		getIncludedBasicAvailability: async () =>
+			unwrapDeploy(await api.GET("/v2/subscriptions/included-basic", {})),
 		getReusableSubscriptions: async (limit = 100, cursor?: string | null) =>
 			unwrapDeploy(
 				await api.GET("/v2/subscriptions/reusable", {

--- a/apps/web/src/hosted/billing/contracts.ts
+++ b/apps/web/src/hosted/billing/contracts.ts
@@ -16,6 +16,7 @@ export type ComputeCancelScheduledPlanChangeRequest =
 	Schemas["V2ComputeCancelScheduledPlanChangeRequest"];
 export type ComputeSubscriptionCancelRequest = Schemas["V2ComputeSubscriptionCancelRequest"];
 export type ComputeSubscriptionListItem = Schemas["V2ComputeSubscriptionListItem"];
+export type IncludedBasicAvailability = Schemas["V2ComputeIncludedBasicAvailabilityResponse"];
 export type ComputeFixPaymentRequest = Schemas["V2ComputeFixPaymentRequest"];
 export type ComputePlanChangeRequest = Schemas["V2ComputePlanChangeRequest"];
 export type ComputePlanChangeProgress = Schemas["ComputePlanChangeProgress"];

--- a/apps/web/src/hosted/billing/deploy/deploy-model.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-model.test.ts
@@ -1,63 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import type {
-	ComputePlanSlug,
-	HostedComputeSubscription,
-	HostedDeploymentStatus,
-	Plan,
-} from "@/hosted/billing/contracts";
-import {
-	resolveBasicDeploySelection,
-	usesActiveIncludedBasicSlot,
-} from "@/hosted/billing/deploy/deploy-model";
-import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
-
-function subscription(): HostedComputeSubscription {
-	return {
-		status: "active",
-		funding_source: "stripe",
-		payment_state: "ok",
-		billing_term_months: 1,
-		price_cents: 900,
-		currency: "usd",
-		cancel_at_period_end: false,
-	};
-}
-
-function includedSubscription(): HostedComputeSubscription {
-	return {
-		subscription_id: 7,
-		status: "active",
-		funding_source: null,
-		payment_state: "ok",
-		billing_term_months: 1,
-		price_cents: 0,
-		currency: "usd",
-		cancel_at_period_end: false,
-	};
-}
-
-function deployment({
-	status,
-	computePlanSlug = "compute_basic",
-	computeSubscription = includedSubscription(),
-	occupiesSlot = true,
-}: {
-	status: HostedDeploymentStatus["summary_state"];
-	computePlanSlug?: ComputePlanSlug;
-	computeSubscription?: HostedComputeSubscription;
-	occupiesSlot?: boolean;
-}) {
-	return hostedDeploymentFixture({
-		id: `hdep_${status}_${computePlanSlug}`,
-		name: "Test agent",
-		status,
-		createdAt: "2026-06-24T00:00:00Z",
-		currentPlanSlug: computePlanSlug,
-		computeSubscription,
-		fundingFact: null,
-		occupiesSlot,
-	});
-}
+import type { Plan } from "@/hosted/billing/contracts";
+import { resolveBasicDeploySelection } from "@/hosted/billing/deploy/deploy-model";
 
 function plan(priceCents: number): Plan {
 	return {
@@ -78,40 +21,6 @@ function plan(priceCents: number): Plan {
 		],
 	};
 }
-
-describe("usesActiveIncludedBasicSlot", () => {
-	test("uses current_plan_slug and slot occupancy without a funding fact", () => {
-		expect(usesActiveIncludedBasicSlot([deployment({ status: "running" })])).toBe(true);
-		expect(
-			usesActiveIncludedBasicSlot([deployment({ status: "running", occupiesSlot: false })]),
-		).toBe(false);
-	});
-
-	test("ignores paid-funded Basic and Performance deployments", () => {
-		expect(
-			usesActiveIncludedBasicSlot([
-				deployment({ status: "running", computeSubscription: subscription() }),
-			]),
-		).toBe(false);
-		expect(
-			usesActiveIncludedBasicSlot([
-				deployment({ status: "running", computePlanSlug: "compute_performance" }),
-			]),
-		).toBe(false);
-	});
-
-	test("does not assume a free Basic slot when occupancy is unavailable", () => {
-		expect(
-			usesActiveIncludedBasicSlot([
-				hostedDeploymentFixture({
-					status: "running",
-					computeSubscription: includedSubscription(),
-					computeSlotOccupancy: null,
-				}),
-			]),
-		).toBeNull();
-	});
-});
 
 describe("resolveBasicDeploySelection", () => {
 	const basic = plan(900);

--- a/apps/web/src/hosted/billing/deploy/deploy-model.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-model.ts
@@ -1,8 +1,5 @@
-import {
-	resolveHostedDeployIncludedBasicSelection,
-	usesHostedDeployIncludedBasicSlot,
-} from "@clawdi/shared/api";
-import type { HostedDeployment, Plan } from "@/hosted/billing/contracts";
+import { resolveHostedDeployIncludedBasicSelection } from "@clawdi/shared/api";
+import type { Plan } from "@/hosted/billing/contracts";
 import type { COMPUTE_BASIC_SLUG } from "@/hosted/billing/subscription/subscription-utils";
 
 export type BasicDeploySelection =
@@ -23,12 +20,6 @@ export type BasicDeploySelection =
 			reason: "plan_missing" | "offers_missing" | "inventory_unavailable";
 	  };
 
-export function usesActiveIncludedBasicSlot(
-	deployments: HostedDeployment[] | undefined,
-): boolean | null {
-	return usesHostedDeployIncludedBasicSlot(deployments);
-}
-
 export function resolveBasicDeploySelection({
 	basicPlan,
 	billingTermMonths,
@@ -36,7 +27,7 @@ export function resolveBasicDeploySelection({
 }: {
 	basicPlan: Plan | undefined;
 	billingTermMonths: number;
-	/** `null` means deployment inventory or included-slot occupancy is unavailable. */
+	/** `null` means included Basic capacity is unavailable. */
 	includedSlotAvailable: boolean | null;
 }): BasicDeploySelection {
 	return resolveHostedDeployIncludedBasicSelection({

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -333,14 +333,14 @@ describe("AI provider usability gate", () => {
 
 describe("billing-read gates", () => {
 	test("keeps deploy disabled until inventory resolves and offers scoped retries", () => {
-		expect(wizardSource).toContain("const deploymentsResolved = deployments.data !== undefined;");
-		expect(wizardSource).toContain("shouldBlockQueryError(deployments.error, deployments.data)");
-		expect(wizardSource).toContain("activeIncludedBasicSlot === null");
-		expect(wizardSource).toContain("Free compute availability is unknown");
+		expect(wizardSource).toContain("useIncludedBasicAvailability()");
+		expect(wizardSource).toContain(
+			"shouldBlockQueryError(includedBasic.error, includedBasic.data)",
+		);
+		expect(wizardSource).toContain("includedBasic.data.available_slots > 0");
 		expect(wizardSource).toContain('title="Couldn\'t check free compute availability"');
-		expect(wizardSource).toContain("onRetry={() => void deployments.refetch()}");
-		expect(wizardSource).toContain("disabled={checkingDeployments}");
-		expect(wizardSource).toContain("onClick={() => void checkDeploymentsAgain()}");
+		expect(wizardSource).toContain("onRetry={() => void includedBasic.refetch()}");
+		expect(wizardSource).not.toContain("usesActiveIncludedBasicSlot");
 		expect(wizardSource).toContain('title="Couldn\'t load compute plans"');
 		expect(wizardSource).toContain("async function retryWalletQuote()");
 		expect(wizardSource).toContain('toast.error("Couldn’t refresh Wallet quote"');

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -79,7 +79,6 @@ import {
 	type DeployWizardDirtyState,
 	deployWizardDraftIsDirty,
 } from "@/hosted/billing/deploy/deploy-dirty-state";
-import { usesActiveIncludedBasicSlot } from "@/hosted/billing/deploy/deploy-model";
 import {
 	type ComputePricePresentation,
 	cardDeployAmountPresentation,
@@ -111,7 +110,7 @@ import {
 } from "@/hosted/billing/errors";
 import { billingTermLabel, formatCents } from "@/hosted/billing/format";
 import {
-	useHostedDeployments,
+	useIncludedBasicAvailability,
 	useManagedModelCatalog,
 	usePlans,
 	useResolveDeploymentRequest,
@@ -321,6 +320,9 @@ export function DeployWizard() {
 						onAccepted: () => {
 							setDeploymentCommitted(true);
 							clearCheckoutAttempt(target.deployRequestId);
+							void queryClient.invalidateQueries({
+								queryKey: billingKeys.includedBasicAvailability,
+							});
 						},
 						resolveDeploymentRequest,
 					});
@@ -391,7 +393,7 @@ export function DeployWizard() {
 		onNavigate: navigateCheckoutReturn,
 	});
 	const plans = usePlans();
-	const deployments = useHostedDeployments();
+	const includedBasic = useIncludedBasicAvailability();
 	const reusableSubscriptions = useReusableSubscriptions(billingClient);
 	const managedModelCatalog = useManagedModelCatalog();
 	const aiProviders = useUserAiProviders();
@@ -404,6 +406,14 @@ export function DeployWizard() {
 	const reusableSubscriptionInventory = blockingReusableSubscriptionsError
 		? undefined
 		: reusableSubscriptions.data;
+	const blockingIncludedBasicError = shouldBlockQueryError(includedBasic.error, includedBasic.data)
+		? includedBasic.error
+		: null;
+	const includedBasicAvailable = blockingIncludedBasicError
+		? undefined
+		: includedBasic.data
+			? includedBasic.data.available_slots > 0
+			: undefined;
 	const createSubscription = useSensitiveCreateSubscription();
 	const runAction = useActionLock();
 	const walletCreateAttemptRef = useRef<IdempotencyAttempt | null>(null);
@@ -424,21 +434,7 @@ export function DeployWizard() {
 	const [selectedSubscriptionSource, setSubscriptionSource] = useState<SubscriptionSource | null>(
 		null,
 	);
-	const [checkingDeployments, setCheckingDeployments] = useState(false);
 	const walletTopUp = useWalletTopUpDialog(SUBSCRIPTION_WALLET_FUNDING_ERROR_COPY);
-	const deploymentsResolved = deployments.data !== undefined;
-	const blockingDeploymentsError = shouldBlockQueryError(deployments.error, deployments.data)
-		? deployments.error
-		: null;
-	const checkDeploymentsAgain = async () => {
-		if (checkingDeployments) return;
-		setCheckingDeployments(true);
-		try {
-			await deployments.refetch();
-		} finally {
-			setCheckingDeployments(false);
-		}
-	};
 
 	// Keep the first client render on the same deterministic fallback as SSR,
 	// then adopt runtime IANA data and best-effort browser defaults after mount.
@@ -460,30 +456,14 @@ export function DeployWizard() {
 		() => (basicPlan ? selectExplicitOfferForTerm(basicPlan, term) : null),
 		[basicPlan, term],
 	);
-	const activeIncludedBasicSlot = useMemo(
-		() => (deploymentsResolved ? usesActiveIncludedBasicSlot(deployments.data ?? []) : null),
-		[deployments.data, deploymentsResolved],
-	);
-	const includedBasicAvailability =
-		!deploymentsResolved || activeIncludedBasicSlot === null
-			? "unknown"
-			: activeIncludedBasicSlot
-				? "unavailable"
-				: "available";
 	const subscriptionSource = resolveSubscriptionSource({
 		selected: selectedSubscriptionSource,
-		includedAvailable:
-			includedBasicAvailability === "unknown"
-				? undefined
-				: includedBasicAvailability === "available",
+		includedAvailable: includedBasicAvailable,
 		reusableSubscriptions: reusableSubscriptionInventory,
 	});
 	const defaultSubscriptionSource = resolveSubscriptionSource({
 		selected: null,
-		includedAvailable:
-			includedBasicAvailability === "unknown"
-				? undefined
-				: includedBasicAvailability === "available",
+		includedAvailable: includedBasicAvailable,
 		reusableSubscriptions: reusableSubscriptionInventory,
 	});
 	const perfOfferSelection = useMemo(
@@ -620,12 +600,12 @@ export function DeployWizard() {
 		if (personaError) return personaError;
 		if (!subscriptionSource) return "Choose a subscription source.";
 		if (subscriptionSource.mode === "included") {
-			if (!deploymentsResolved) {
-				return blockingDeploymentsError
+			if (includedBasicAvailable === undefined) {
+				return blockingIncludedBasicError
 					? "Retry the free compute availability check above."
 					: "Checking your free compute availability.";
 			}
-			if (includedBasicAvailability !== "available") return "Free compute is unavailable.";
+			if (!includedBasicAvailable) return "Free compute is unavailable.";
 		} else {
 			if (reusableSubscriptions.isFetching) return "Checking reusable subscriptions.";
 			if (blockingReusableSubscriptionsError || reusableSubscriptionInventory === undefined) {
@@ -1263,46 +1243,20 @@ export function DeployWizard() {
 						<SubscriptionSourcePicker
 							value={subscriptionSource}
 							onChange={setSubscriptionSource}
-							showIncluded={includedBasicAvailability === "available"}
+							showIncluded={includedBasicAvailable === true}
 							reusableSubscriptions={reusableSubscriptionInventory ?? []}
-							isLoading={reusableSubscriptions.isFetching}
+							isLoading={reusableSubscriptions.isFetching || includedBasic.isFetching}
 							error={blockingReusableSubscriptionsError}
 							onRetry={() => void reusableSubscriptions.refetch()}
 							disabled={submitting}
 						/>
-						{blockingDeploymentsError ? (
+						{blockingIncludedBasicError ? (
 							<ApiErrorPanel
 								normalizer={billingErrorNormalizer}
-								error={blockingDeploymentsError}
-								onRetry={() => void deployments.refetch()}
+								error={blockingIncludedBasicError}
+								onRetry={() => void includedBasic.refetch()}
 								title="Couldn't check free compute availability"
 							/>
-						) : null}
-						{deploymentsResolved && activeIncludedBasicSlot === null ? (
-							<Alert data-hosted="true">
-								<TriangleAlert />
-								<AlertTitle>Free compute availability is unknown</AlertTitle>
-								<AlertDescription className="flex flex-col gap-3 @2xl/main:flex-row @2xl/main:items-center @2xl/main:justify-between">
-									<span>
-										We can’t determine whether an existing agent is already using your free compute
-										entitlement.
-									</span>
-									<Button
-										type="button"
-										variant="outline"
-										size="sm"
-										disabled={checkingDeployments}
-										onClick={() => void checkDeploymentsAgain()}
-									>
-										{checkingDeployments ? (
-											<Spinner className="size-3.5" />
-										) : (
-											<RefreshCw className="size-3.5" />
-										)}
-										Check again
-									</Button>
-								</AlertDescription>
-							</Alert>
 						) : null}
 						{subscriptionSource?.mode === "new" && plansLoadError ? (
 							<ApiErrorPanel

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -165,6 +165,7 @@ describe("applySubscriptionActionSuccess", () => {
 		const qc = new QueryClient();
 		qc.setQueryData(billingKeys.deployments, { current: true });
 		qc.setQueryData(billingKeys.subscriptions, { current: true });
+		qc.setQueryData(billingKeys.includedBasicAvailability, { available_slots: 0 });
 		qc.setQueryData(billingKeys.reusableSubscriptions, { current: true });
 
 		await applySubscriptionActionSuccess(
@@ -175,6 +176,7 @@ describe("applySubscriptionActionSuccess", () => {
 
 		expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(true);
 		expect(qc.getQueryState(billingKeys.subscriptions)?.isInvalidated).toBe(true);
+		expect(qc.getQueryState(billingKeys.includedBasicAvailability)?.isInvalidated).toBe(true);
 		expect(qc.getQueryState(billingKeys.reusableSubscriptions)?.isInvalidated).toBe(true);
 	});
 
@@ -184,6 +186,7 @@ describe("applySubscriptionActionSuccess", () => {
 		for (const queryKey of [
 			billingKeys.deployments,
 			billingKeys.subscriptions,
+			billingKeys.includedBasicAvailability,
 			billingKeys.reusableSubscriptions,
 		]) {
 			const key = JSON.stringify(queryKey);
@@ -201,6 +204,7 @@ describe("applySubscriptionActionSuccess", () => {
 		for (const queryKey of [
 			billingKeys.deployments,
 			billingKeys.subscriptions,
+			billingKeys.includedBasicAvailability,
 			billingKeys.reusableSubscriptions,
 		]) {
 			expect(fetches.get(JSON.stringify(queryKey))).toBe(2);

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -112,9 +112,12 @@ export async function invalidateComputeSubscriptionInventory(
 	refetchType: "active" | "all" = "active",
 ): Promise<void> {
 	await Promise.all(
-		[billingKeys.deployments, billingKeys.subscriptions, billingKeys.reusableSubscriptions].map(
-			(queryKey) => qc.invalidateQueries({ queryKey, refetchType }),
-		),
+		[
+			billingKeys.deployments,
+			billingKeys.subscriptions,
+			billingKeys.includedBasicAvailability,
+			billingKeys.reusableSubscriptions,
+		].map((queryKey) => qc.invalidateQueries({ queryKey, refetchType })),
 	);
 }
 
@@ -204,6 +207,14 @@ export function useSubscriptions() {
 	});
 }
 
+export function useIncludedBasicAvailability() {
+	const client = useBillingClient();
+	return useBillingQuery({
+		queryKey: billingKeys.includedBasicAvailability,
+		queryFn: () => client.getIncludedBasicAvailability(),
+	});
+}
+
 export function useSubscriptionCreateQuote(
 	selection: SubscriptionCreateSelection | null,
 	{ enabled = true }: { enabled?: boolean } = {},
@@ -241,6 +252,7 @@ export function invalidatePlanChangeQueries(qc: QueryClient): void {
 	qc.invalidateQueries({ queryKey: billingKeys.wallet });
 	qc.invalidateQueries({ queryKey: billingKeys.transactions });
 	qc.invalidateQueries({ queryKey: billingKeys.subscriptions });
+	qc.invalidateQueries({ queryKey: billingKeys.includedBasicAvailability });
 }
 
 export function invalidateSettledPlanChangeQueries(qc: QueryClient, error: Error | null): void {

--- a/apps/web/src/hosted/billing/query-keys.ts
+++ b/apps/web/src/hosted/billing/query-keys.ts
@@ -12,6 +12,7 @@ export const billingKeys = {
 		[...subscriptionCreateQuotes, planSlug, billingTermMonths, fundingSource] as const,
 	plans: ["billing", "plans"] as const,
 	subscriptions: ["billing", "subscriptions"] as const,
+	includedBasicAvailability: ["billing", "included-basic-availability"] as const,
 	reusableSubscriptions: ["billing", "reusable-subscriptions"] as const,
 	deployments: ["billing", "deployments"] as const,
 	workspaceSkills: (deploymentId: string) =>

--- a/apps/web/src/hosted/billing/sensitive-actions.ts
+++ b/apps/web/src/hosted/billing/sensitive-actions.ts
@@ -23,6 +23,7 @@ function useInvalidateBillingAfterCheckout() {
 	return () => {
 		queryClient.invalidateQueries({ queryKey: billingKeys.deployments });
 		queryClient.invalidateQueries({ queryKey: billingKeys.subscriptions });
+		queryClient.invalidateQueries({ queryKey: billingKeys.includedBasicAvailability });
 		queryClient.invalidateQueries({ queryKey: billingKeys.wallet });
 		queryClient.invalidateQueries({ queryKey: billingKeys.transactions });
 		queryClient.invalidateQueries({ queryKey: billingKeys.reusableSubscriptions });

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-actions.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-actions.ts
@@ -29,6 +29,7 @@ export type ComputeSubscriptionAction =
 	| ComputeSubscriptionRecoveryAction;
 
 export type ComputeSubscriptionActionEntitlement = {
+	subscriptionKind?: "included_basic" | "paid";
 	deploymentId: string | null | undefined;
 	planSlug: string | null | undefined;
 	fundingSource: "stripe" | "wallet" | null | undefined;
@@ -95,7 +96,10 @@ export function resolveComputeSubscriptionActions({
 		funding_source: entitlement.fundingSource,
 		price_cents: entitlement.priceCents,
 	});
-	const paid = fundingSource === "stripe" || fundingSource === "wallet";
+	const paid =
+		entitlement.subscriptionKind === "paid" ||
+		(entitlement.subscriptionKind === undefined &&
+			(fundingSource === "stripe" || fundingSource === "wallet"));
 	const canCancel = paid && !entitlement.cancelAtPeriodEnd && CANCELABLE_STATUSES.has(status);
 	const cancel = canCancel ? action("cancel") : null;
 

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-management.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-management.ts
@@ -20,6 +20,7 @@ import {
 } from "./subscription-utils";
 
 export type ComputeSubscriptionEntitlement = {
+	subscriptionKind?: "included_basic" | "paid";
 	deploymentId: string | null | undefined;
 	planSlug: string | null | undefined;
 	fundingSource: "stripe" | "wallet" | null | undefined;
@@ -96,8 +97,13 @@ export function computeSubscriptionManagement({
 		funding_source: entitlement.fundingSource,
 		price_cents: entitlement.priceCents,
 	});
-	const includedBasic = fundingSource === "included_basic";
-	const paid = fundingSource === "stripe" || fundingSource === "wallet";
+	const includedBasic =
+		entitlement.subscriptionKind === "included_basic" ||
+		(entitlement.subscriptionKind === undefined && fundingSource === "included_basic");
+	const paid =
+		entitlement.subscriptionKind === "paid" ||
+		(entitlement.subscriptionKind === undefined &&
+			(fundingSource === "stripe" || fundingSource === "wallet"));
 	if (!includedBasic && !paid) {
 		return { action: "hidden", target: null, unavailableReason: null };
 	}

--- a/apps/web/src/hosted/billing/subscription/subscription-source-picker.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-source-picker.tsx
@@ -90,7 +90,7 @@ export function SubscriptionSourcePicker({
 			</div>
 			{isLoading ? (
 				<p className="flex items-center gap-2 text-sm text-muted-foreground" role="status">
-					<Spinner className="size-3.5" /> Checking reusable subscriptions…
+					<Spinner className="size-3.5" /> Checking compute availability…
 				</p>
 			) : error != null ? (
 				<ApiErrorPanel

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
@@ -8,6 +8,8 @@ let sortLoadedSubscriptions: SubscriptionsSectionModule["sortLoadedSubscriptions
 let computeSubscriptionAssignment:
 	| SubscriptionsSectionModule["computeSubscriptionAssignment"]
 	| null = null;
+let computeSubscriptionIdentity: SubscriptionsSectionModule["computeSubscriptionIdentity"] | null =
+	null;
 let reusableInventoryState: SubscriptionsSectionModule["reusableInventoryState"] | null = null;
 
 beforeAll(async () => {
@@ -17,6 +19,7 @@ beforeAll(async () => {
 	const module = await import("@/hosted/billing/subscription/subscriptions-section");
 	sortLoadedSubscriptions = module.sortLoadedSubscriptions;
 	computeSubscriptionAssignment = module.computeSubscriptionAssignment;
+	computeSubscriptionIdentity = module.computeSubscriptionIdentity;
 	reusableInventoryState = module.reusableInventoryState;
 });
 
@@ -80,6 +83,22 @@ describe("SubscriptionsSection", () => {
 		).toBe("unavailable");
 		expect(computeSubscriptionAssignment(staleAssigned, new Set())).toBe("assigned");
 		expect(computeSubscriptionAssignment(staleOrphan, new Set())).toBe("unavailable");
+
+		if (!computeSubscriptionIdentity) throw new Error("Subscriptions helpers were not loaded");
+		expect(computeSubscriptionIdentity(staleAssigned, "assigned", undefined, null)).toMatchObject({
+			kind: "agent",
+			name: "reusable",
+		});
+		expect(
+			computeSubscriptionIdentity(staleOrphan, "unavailable", undefined, null, true),
+		).toBeUndefined();
+		expect(computeSubscriptionIdentity(staleOrphan, "unavailable", undefined, null)).toEqual({
+			kind: "unavailable",
+			label: "Deleted agent",
+		});
+		expect(
+			computeSubscriptionIdentity(staleIncluded, "unavailable", undefined, null),
+		).toBeUndefined();
 	});
 
 	test("stably prioritizes loaded current subscriptions without mutating query data", () => {

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.test.tsx
@@ -26,6 +26,7 @@ function subscription(
 ): ComputeSubscriptionListItem {
 	return {
 		subscription_id: subscriptionId,
+		subscription_kind: "paid",
 		plan_slug: "compute_basic",
 		funding_source: "stripe",
 		status,
@@ -69,6 +70,14 @@ describe("SubscriptionsSection", () => {
 		expect(computeSubscriptionAssignment(staleOrphan, new Set([staleOrphan.subscription_id]))).toBe(
 			"available",
 		);
+		const staleIncluded = {
+			...staleOrphan,
+			subscription_kind: "included_basic" as const,
+			funding_source: null,
+		};
+		expect(
+			computeSubscriptionAssignment(staleIncluded, new Set([staleIncluded.subscription_id])),
+		).toBe("unavailable");
 		expect(computeSubscriptionAssignment(staleAssigned, new Set())).toBe("assigned");
 		expect(computeSubscriptionAssignment(staleOrphan, new Set())).toBe("unavailable");
 	});

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -77,6 +77,7 @@ function subscriptionManagement(
 ): ComputeSubscriptionManagementResult {
 	return computeSubscriptionManagement({
 		entitlement: {
+			subscriptionKind: subscription.subscription_kind,
 			deploymentId: subscription.deployment_id,
 			planSlug: subscription.plan_slug,
 			fundingSource: subscription.funding_source,
@@ -99,10 +100,13 @@ function subscriptionManagement(
 export function computeSubscriptionAssignment(
 	subscription: Pick<
 		ComputeSubscriptionListItem,
-		"deployment_id" | "is_orphan" | "subscription_id"
+		"deployment_id" | "is_orphan" | "subscription_id" | "subscription_kind"
 	>,
 	reusableSubscriptionIds: ReadonlySet<string>,
 ): "available" | "assigned" | "unavailable" {
+	if (subscription.subscription_kind === "included_basic") {
+		return subscription.deployment_id && !subscription.is_orphan ? "assigned" : "unavailable";
+	}
 	if (reusableSubscriptionIds.has(subscription.subscription_id)) return "available";
 	return subscription.deployment_id && !subscription.is_orphan ? "assigned" : "unavailable";
 }
@@ -154,6 +158,7 @@ function SubscriptionRow({
 	const pendingPlanSlug = pendingComputePlanSlug(subscription);
 	const actions = resolveComputeSubscriptionActions({
 		entitlement: {
+			subscriptionKind: subscription.subscription_kind,
 			deploymentId: subscription.deployment_id,
 			planSlug: subscription.plan_slug,
 			fundingSource: subscription.funding_source,
@@ -190,7 +195,10 @@ function SubscriptionRow({
 	})();
 	const hasActions =
 		actions.some((candidate) => candidate.kind !== "start_new") || startNewHref !== null;
-	const fundingSource = computeFundingSource(subscription.plan_slug, subscription);
+	const fundingSource =
+		subscription.subscription_kind === "included_basic"
+			? "included_basic"
+			: computeFundingSource(subscription.plan_slug, subscription);
 	const managementReason =
 		actions.find((candidate) => candidate.kind === "upgrade" || candidate.kind === "manage")
 			?.disabledReason ?? null;
@@ -212,17 +220,25 @@ function SubscriptionRow({
 		includeSchedule: !isHistoricalAccountSubscription(subscription),
 	});
 	const identity: ComputeSubscriptionIdentity =
-		assignment === "available"
-			? { kind: "available", label: "Available for a new agent" }
-			: assignment === "assigned" && agentHref
-				? {
-						kind: "agent",
-						name: agentTile?.name ?? subscription.agent_name ?? "Agent",
-						agentType: agentTile?.agentType ?? null,
-						avatarUrl: agentTile?.avatarUrl,
-						href: agentHref,
-					}
-				: { kind: "unavailable", label: "Deleted agent" };
+		subscription.subscription_kind === "included_basic"
+			? {
+					kind: "agent",
+					name: agentTile?.name ?? subscription.agent_name ?? "Agent",
+					agentType: agentTile?.agentType ?? null,
+					avatarUrl: agentTile?.avatarUrl,
+					href: agentHref ?? undefined,
+				}
+			: assignment === "available"
+				? { kind: "available", label: "Available for a new agent" }
+				: assignment === "assigned" && agentHref
+					? {
+							kind: "agent",
+							name: agentTile?.name ?? subscription.agent_name ?? "Agent",
+							agentType: agentTile?.agentType ?? null,
+							avatarUrl: agentTile?.avatarUrl,
+							href: agentHref,
+						}
+					: { kind: "unavailable", label: "Deleted agent" };
 
 	return (
 		<li className="grid min-w-0 lg:row-span-5 lg:grid-rows-subgrid">

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -111,6 +111,32 @@ export function computeSubscriptionAssignment(
 	return subscription.deployment_id && !subscription.is_orphan ? "assigned" : "unavailable";
 }
 
+export function computeSubscriptionIdentity(
+	subscription: Pick<ComputeSubscriptionListItem, "agent_name" | "subscription_kind">,
+	assignment: "available" | "assigned" | "unavailable",
+	agentTile: AgentTile | undefined,
+	href: string | null,
+	inventoryUncertain = false,
+): ComputeSubscriptionIdentity | undefined {
+	if (subscription.subscription_kind === "included_basic" && assignment !== "assigned") {
+		return undefined;
+	}
+	if (assignment === "available") {
+		return { kind: "available", label: "Available for a new agent" };
+	}
+	if (assignment === "unavailable") {
+		if (inventoryUncertain) return undefined;
+		return { kind: "unavailable", label: "Deleted agent" };
+	}
+	return {
+		kind: "agent",
+		name: agentTile?.name ?? subscription.agent_name ?? "Agent",
+		agentType: agentTile?.agentType ?? null,
+		avatarUrl: agentTile?.avatarUrl,
+		href: href ?? undefined,
+	};
+}
+
 export function SubscriptionLoadMore({
 	isLoading,
 	onLoadMore,
@@ -134,6 +160,7 @@ function SubscriptionRow({
 	management,
 	onPlanChange,
 	reusableSubscriptionIds,
+	reusableInventoryUncertain,
 }: {
 	subscription: ComputeSubscriptionListItem;
 	deployment?: HostedDeployment;
@@ -141,6 +168,7 @@ function SubscriptionRow({
 	management: ComputeSubscriptionManagementResult;
 	onPlanChange: (subscription: ComputeSubscriptionListItem) => void;
 	reusableSubscriptionIds: ReadonlySet<string>;
+	reusableInventoryUncertain: boolean;
 }) {
 	const lifecycle = computeSubscriptionLifecycle(subscription);
 	const recovery = computeSubscriptionRecoveryPresentation(subscription, {
@@ -219,26 +247,13 @@ function SubscriptionRow({
 		scheduleFallback: recovery.schedule?.fallback ?? undefined,
 		includeSchedule: !isHistoricalAccountSubscription(subscription),
 	});
-	const identity: ComputeSubscriptionIdentity =
-		subscription.subscription_kind === "included_basic"
-			? {
-					kind: "agent",
-					name: agentTile?.name ?? subscription.agent_name ?? "Agent",
-					agentType: agentTile?.agentType ?? null,
-					avatarUrl: agentTile?.avatarUrl,
-					href: agentHref ?? undefined,
-				}
-			: assignment === "available"
-				? { kind: "available", label: "Available for a new agent" }
-				: assignment === "assigned" && agentHref
-					? {
-							kind: "agent",
-							name: agentTile?.name ?? subscription.agent_name ?? "Agent",
-							agentType: agentTile?.agentType ?? null,
-							avatarUrl: agentTile?.avatarUrl,
-							href: agentHref,
-						}
-					: { kind: "unavailable", label: "Deleted agent" };
+	const identity = computeSubscriptionIdentity(
+		subscription,
+		assignment,
+		agentTile,
+		agentHref,
+		reusableInventoryUncertain,
+	);
 
 	return (
 		<li className="grid min-w-0 lg:row-span-5 lg:grid-rows-subgrid">
@@ -497,6 +512,9 @@ export function SubscriptionsSection({ agentTiles }: { agentTiles: readonly Agen
 											)}
 											onPlanChange={openPlanChange}
 											reusableSubscriptionIds={reusableSubscriptionIds}
+											reusableInventoryUncertain={
+												reusableSubscriptions.isFetching || reusableSubscriptions.error != null
+											}
 										/>
 									);
 								})}

--- a/backend/scripts/mock_deploy_api.py
+++ b/backend/scripts/mock_deploy_api.py
@@ -951,6 +951,25 @@ async def plans() -> list[dict[str, Any]]:
     ]
 
 
+@app.get("/v2/subscriptions/included-basic")
+async def included_basic_availability() -> dict[str, int]:
+    used_slots = sum(
+        1
+        for deployment in DEPLOYMENTS.values()
+        if deployment["status"] != "deleted"
+        and deployment["config_info"].get("compute_plan_slug") == "compute_basic"
+        and isinstance((subscription := deployment.get("compute_subscription")), dict)
+        and subscription.get("funding_source") is None
+        and subscription.get("price_cents") == 0
+    )
+    total_slots = 1
+    return {
+        "total_slots": total_slots,
+        "used_slots": used_slots,
+        "available_slots": max(0, total_slots - used_slots),
+    }
+
+
 @app.post("/v2/subscription/checkout")
 async def checkout(request: Request) -> dict[str, Any]:
     body = await request.json()

--- a/backend/tests/test_mock_deploy_api.py
+++ b/backend/tests/test_mock_deploy_api.py
@@ -87,6 +87,33 @@ def test_mock_v2_create_projects_only_the_resource_name() -> None:
             mock_deploy_api.DEPLOYMENTS.pop(deployment_id, None)
 
 
+def test_mock_included_basic_availability_is_deployment_scoped() -> None:
+    deployment = mock_deploy_api._create_deployment_record(
+        {"runtime": "hermes", "compute_plan_slug": "compute_basic"}
+    )
+    deployment["compute_subscription"] = {
+        "funding_source": None,
+        "price_cents": 0,
+    }
+    deployment_id = deployment["id"]
+    try:
+        with TestClient(mock_deploy_api.app) as client:
+            assert client.get("/v2/subscriptions/included-basic").json() == {
+                "total_slots": 1,
+                "used_slots": 1,
+                "available_slots": 0,
+            }
+
+            deployment["status"] = "deleted"
+            assert client.get("/v2/subscriptions/included-basic").json() == {
+                "total_slots": 1,
+                "used_slots": 0,
+                "available_slots": 1,
+            }
+    finally:
+        mock_deploy_api.DEPLOYMENTS.pop(deployment_id, None)
+
+
 def test_mock_v2_rejects_retired_names_and_updates_runtime_configuration() -> None:
     deployment = mock_deploy_api._create_deployment_record(
         {"name": "Stable resource name", "runtime": "hermes"}

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -12,7 +12,6 @@ import {
 	HOSTED_DEPLOY_LANGUAGE_OPTIONS,
 	type HostedDeployCheckoutRequest,
 	type HostedDeployComputePlanSlug,
-	type HostedDeployDeployment,
 	type HostedDeployManagedModel,
 	type HostedDeployOperation,
 	type HostedDeployPlan,
@@ -21,6 +20,7 @@ import {
 	type HostedDeployRuntime,
 	type HostedDeploySubscriptionQuote,
 	type HostedDeploySubscriptionQuoteRequest,
+	type HostedIncludedBasicAvailability,
 	type HostedSavedAiProvider,
 	hostedAiProviderAvailabilityIssue,
 	hostedDeployRuntimeLabel,
@@ -31,7 +31,6 @@ import {
 	projectHostedDeployRequest,
 	resolveHostedDeployIncludedBasicSelection,
 	selectHostedDeployOfferForTerm,
-	usesHostedDeployIncludedBasicSlot,
 	validateAndBuildHostedDeployRequest,
 } from "@clawdi/shared/api";
 import chalk from "chalk";
@@ -216,7 +215,7 @@ export function parseDeployCommandOptions(options: DeployCommandOptions): Parsed
 export interface HostedDeployGateway {
 	supportsPaidCheckout(): boolean;
 	getPlans(): Promise<HostedDeployPlan[]>;
-	listDeployments(): Promise<HostedDeployDeployment[]>;
+	getIncludedBasicAvailability(): Promise<HostedIncludedBasicAvailability>;
 	getManagedModels(): Promise<HostedDeployManagedModel[]>;
 	getSavedAiProviders(): Promise<HostedSavedAiProvider[]>;
 	quoteSubscription(
@@ -639,12 +638,13 @@ export async function runDeployFlow(
 				return [];
 			})
 		: Promise.resolve([]);
-	const [plans, deployments, managedModels, savedProviderInventory] = await Promise.all([
-		dependencies.client.getPlans(),
-		dependencies.client.listDeployments(),
-		needsManagedModels ? dependencies.client.getManagedModels() : Promise.resolve([]),
-		savedProvidersPromise,
-	]);
+	const [plans, includedBasicAvailability, managedModels, savedProviderInventory] =
+		await Promise.all([
+			dependencies.client.getPlans(),
+			dependencies.client.getIncludedBasicAvailability(),
+			needsManagedModels ? dependencies.client.getManagedModels() : Promise.resolve([]),
+			savedProvidersPromise,
+		]);
 	const savedProviders = projectUserSelectableAiProviders(savedProviderInventory);
 
 	let runtime = parsed.runtime ?? DEFAULT_HOSTED_DEPLOY_RUNTIME;
@@ -798,15 +798,11 @@ export async function runDeployFlow(
 	let term = parsed.billingTermMonths ?? DEFAULT_HOSTED_DEPLOY_BILLING_TERM;
 	const basicPlan = plans.find((plan) => plan.slug === "compute_basic");
 	const performancePlan = plans.find((plan) => plan.slug === "compute_performance");
-	const includedSlotUsage = usesHostedDeployIncludedBasicSlot(deployments);
 	let basicSelection = resolveHostedDeployIncludedBasicSelection({
 		basicPlan,
 		billingTermMonths: term,
-		includedSlotAvailable: existingBasicCreateRequest
-			? true
-			: includedSlotUsage === null
-				? null
-				: !includedSlotUsage,
+		includedSlotAvailable:
+			existingBasicCreateRequest || includedBasicAvailability.available_slots > 0,
 	});
 	let performanceSelection = performancePlan
 		? selectHostedDeployOfferForTerm(performancePlan, term)
@@ -899,11 +895,8 @@ export async function runDeployFlow(
 		basicSelection = resolveHostedDeployIncludedBasicSelection({
 			basicPlan,
 			billingTermMonths: term,
-			includedSlotAvailable: existingBasicCreateRequest
-				? true
-				: includedSlotUsage === null
-					? null
-					: !includedSlotUsage,
+			includedSlotAvailable:
+				existingBasicCreateRequest || includedBasicAvailability.available_slots > 0,
 		});
 		performanceSelection = performancePlan
 			? selectHostedDeployOfferForTerm(performancePlan, term)

--- a/packages/cli/src/lib/hosted-deploy-client.ts
+++ b/packages/cli/src/lib/hosted-deploy-client.ts
@@ -4,7 +4,6 @@ import {
 	type DeployPaths,
 	extractApiDetail,
 	type HostedDeployCheckoutRequest,
-	type HostedDeployDeployment,
 	type HostedDeployManagedModel,
 	type HostedDeployOperation,
 	type HostedDeployPlan,
@@ -13,10 +12,10 @@ import {
 	type HostedDeploySubscriptionQuote,
 	type HostedDeploySubscriptionQuoteRequest,
 	type HostedDeployWallet,
+	type HostedIncludedBasicAvailability,
 	type HostedSavedAiProvider,
 	type HostedWalletBinding,
 	type paths,
-	unwrapDeploymentList,
 } from "@clawdi/shared/api";
 import createClient, { type Client, type Middleware } from "openapi-fetch";
 import {
@@ -153,8 +152,8 @@ export class HostedDeployClient {
 		return unwrapHosted(await this.client.GET("/v2/subscription/plans"));
 	}
 
-	async listDeployments(): Promise<HostedDeployDeployment[]> {
-		return unwrapDeploymentList(unwrapHosted(await this.client.GET("/v2/deployments")));
+	async getIncludedBasicAvailability(): Promise<HostedIncludedBasicAvailability> {
+		return unwrapHosted(await this.client.GET("/v2/subscriptions/included-basic", {}));
 	}
 
 	async getManagedModels(): Promise<HostedDeployManagedModel[]> {

--- a/packages/cli/tests/commands/deploy.test.ts
+++ b/packages/cli/tests/commands/deploy.test.ts
@@ -9,13 +9,13 @@ import {
 } from "@clawdi/shared";
 import type {
 	HostedDeployCheckoutRequest,
-	HostedDeployDeployment,
 	HostedDeployOperation,
 	HostedDeployPlan,
 	HostedDeployRequest,
 	HostedDeployRequestStatus,
 	HostedDeploySubscriptionQuote,
 	HostedDeploySubscriptionQuoteRequest,
+	HostedIncludedBasicAvailability,
 	HostedSavedAiProvider,
 } from "@clawdi/shared/api";
 import {
@@ -114,14 +114,18 @@ function savedProvider(
 
 class FakeDeployGateway implements HostedDeployGateway {
 	plans: HostedDeployPlan[] = [plan("compute_basic", 900), plan("compute_performance", 2_900)];
-	deployments: HostedDeployDeployment[] = [];
+	includedBasicAvailability: HostedIncludedBasicAvailability = {
+		total_slots: 1,
+		used_slots: 0,
+		available_slots: 1,
+	};
 	savedProviders: HostedSavedAiProvider[] = [];
 	paidCheckoutSupported = true;
 	created: { body: HostedDeployRequest; idempotencyKey: string } | null = null;
 	quoted: HostedDeploySubscriptionQuoteRequest | null = null;
 	checkoutCalls: { body: HostedDeployCheckoutRequest; idempotencyKey: string }[] = [];
 	planReads = 0;
-	deploymentReads = 0;
+	availabilityReads = 0;
 	managedModelReads = 0;
 	savedProviderReads = 0;
 	calls: string[] = [];
@@ -178,10 +182,10 @@ class FakeDeployGateway implements HostedDeployGateway {
 		return this.plans;
 	}
 
-	async listDeployments() {
-		this.calls.push("deployments");
-		this.deploymentReads += 1;
-		return this.deployments;
+	async getIncludedBasicAvailability() {
+		this.calls.push("included-basic-availability");
+		this.availabilityReads += 1;
+		return this.includedBasicAvailability;
 	}
 
 	async getManagedModels() {
@@ -798,7 +802,7 @@ describe("deploy orchestration", () => {
 		expect(freeClient.quoted).toBeNull();
 		expect(freeClient.checkoutCalls).toHaveLength(0);
 		expect(freeClient.planReads).toBe(0);
-		expect(freeClient.deploymentReads).toBe(0);
+		expect(freeClient.availabilityReads).toBe(0);
 		expect(freeClient.managedModelReads).toBe(0);
 		expect(freeClient.savedProviderReads).toBe(0);
 		expect(freeClient.requestPolls).toBe(0);
@@ -853,7 +857,7 @@ describe("deploy orchestration", () => {
 			});
 			expect(client.calls[0]).toBe("request");
 			expect(client.planReads).toBe(1);
-			expect(client.deploymentReads).toBe(1);
+			expect(client.availabilityReads).toBe(1);
 			expect(client.created).toMatchObject({
 				idempotencyKey: "123e4567-e89b-42d3-a456-426614174099",
 				body: { compute_plan_slug: "compute_basic" },

--- a/packages/shared/src/api/deploy-wizard.test.ts
+++ b/packages/shared/src/api/deploy-wizard.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type {
 	HostedDeployCheckoutUiMode,
-	HostedDeployDeployment,
 	HostedDeployPlan,
 	HostedDeployRequestStatus,
 } from "./deploy-wizard";
@@ -13,7 +12,6 @@ import {
 	projectHostedDeployRequest,
 	resolveHostedDeployIncludedBasicSelection,
 	selectHostedDeployOfferForTerm,
-	usesHostedDeployIncludedBasicSlot,
 	validateAndBuildHostedDeployRequest,
 } from "./deploy-wizard";
 
@@ -58,89 +56,6 @@ function plan(
 		ram_gb: 4,
 		disk_size: 20,
 		offers,
-	};
-}
-
-function includedDeployment(occupiesSlot: boolean | null): HostedDeployDeployment {
-	return {
-		resource: {
-			id: "hdep_test",
-			name: "Hermes",
-			commercial_revision: 0,
-			deployment_target: "test",
-			metadata: {
-				generation: 1,
-				manifestETag: "manifest-1",
-				resourceVersion: "1",
-				createdAt: "2026-07-28T00:00:00Z",
-				updatedAt: "2026-07-28T00:00:00Z",
-			},
-			spec: {
-				schema_version: 1,
-				desired_lifecycle: "running",
-				runtime: "hermes",
-				runtime_version: "test",
-				resources: { vcpu: 2, memory_mib: 4096, disk_gib: 20 },
-				agents: [],
-				ports: [],
-				runtime_configuration: { providers: [], features: [] },
-				rollout_nonce: 0,
-				secret_references: [],
-			},
-			status: {
-				summary_state: "running",
-				observedGeneration: 1,
-				conditions: [],
-				driver_acknowledged_generation: 1,
-				driver_applied_generation: 1,
-				driver_observation_sequence: 1,
-				endpoints: [],
-			},
-		},
-		agent_id: "11111111-1111-4111-8111-111111111111",
-		clawdi_cloud_environments: {},
-		ai_provider_auth_kinds: { hermes: "managed" },
-		accepted_operation: null,
-		commercial_display: {
-			compute_subscription: {
-				status: "active",
-				funding_source: null,
-				payment_state: "ok",
-				billing_term_months: 1,
-				price_cents: 0,
-				currency: "usd",
-				cancel_at_period_end: false,
-			},
-			latest_funding_fact: null,
-		},
-		current_plan_slug: "compute_basic",
-		upgrade_available: true,
-		upgrade_eligibility: { eligible: true, reason: null },
-		compute_slot_occupancy:
-			occupiesSlot === null
-				? null
-				: {
-						occupies_slot: occupiesSlot,
-						backing_infra: occupiesSlot ? "present" : "absent",
-						reason: occupiesSlot ? "backing_infra_present" : "authoritative_absence",
-					},
-	};
-}
-
-function acceptedDeleteOperation(): NonNullable<HostedDeployDeployment["accepted_operation"]> {
-	return {
-		name: "operations/delete-hdep_test",
-		metadata: {
-			"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
-			deploymentId: "hdep_test",
-			verb: "delete",
-			targetGeneration: 2,
-			manifestETag: "manifest-delete",
-			createTime: "2026-07-28T00:01:00Z",
-			updateTime: "2026-07-28T00:01:00Z",
-		},
-		done: false,
-		response: null,
 	};
 }
 
@@ -253,48 +168,6 @@ describe("hosted deploy request contract", () => {
 describe("hosted deploy compute and payment contract", () => {
 	test("keeps every product checkout mode in the generated narrow union", () => {
 		expect(checkoutModeIsExact).toBe(true);
-	});
-
-	test("distinguishes an occupied, available, and unknown included Basic slot", () => {
-		expect(usesHostedDeployIncludedBasicSlot([includedDeployment(true)])).toBe(true);
-		expect(usesHostedDeployIncludedBasicSlot([includedDeployment(false)])).toBe(false);
-		expect(usesHostedDeployIncludedBasicSlot([includedDeployment(null)])).toBeNull();
-	});
-
-	test("honors delete_accepted occupancy while backing infrastructure remains", () => {
-		const deleting = includedDeployment(false);
-		deleting.compute_slot_occupancy = {
-			occupies_slot: false,
-			backing_infra: "present",
-			reason: "delete_accepted",
-		};
-
-		expect(usesHostedDeployIncludedBasicSlot([deleting])).toBe(false);
-	});
-
-	test("optimistically releases the included Basic slot as soon as delete is accepted", () => {
-		const deleting = includedDeployment(true);
-		deleting.accepted_operation = acceptedDeleteOperation();
-
-		expect(usesHostedDeployIncludedBasicSlot([deleting])).toBe(false);
-		expect(usesHostedDeployIncludedBasicSlot([deleting, includedDeployment(true)])).toBe(true);
-	});
-
-	test("restores included Basic occupancy when an accepted delete is cancelled", () => {
-		const restored = includedDeployment(true);
-		const acceptedDelete = acceptedDeleteOperation();
-		restored.accepted_operation = {
-			...acceptedDelete,
-			done: true,
-			error: {
-				code: 1,
-				message: "Delete was cancelled before teardown.",
-				details: [],
-			},
-			response: null,
-		};
-
-		expect(usesHostedDeployIncludedBasicSlot([restored])).toBe(true);
 	});
 
 	test("requires an explicit Basic offer once the free slot is occupied", () => {

--- a/packages/shared/src/api/deploy-wizard.ts
+++ b/packages/shared/src/api/deploy-wizard.ts
@@ -15,8 +15,8 @@ export type HostedDeployComputePlanSlug = HostedDeployRequest["compute_plan_slug
 export type HostedDeployRuntime = HostedDeployRequest["runtime"];
 export type HostedDeployLanguage = NonNullable<HostedDeployRequest["language"]>;
 export type HostedDeployPlan = Schemas["V2PlanResponse"];
+export type HostedIncludedBasicAvailability = Schemas["V2ComputeIncludedBasicAvailabilityResponse"];
 export type HostedDeployBillingOffer = Schemas["V2BillingOfferResponse"];
-export type HostedDeployDeployment = Schemas["V2HostedDeploymentReadResponse"];
 export type HostedDeployManagedModel = Schemas["V2ManagedModelCatalogItem"];
 export type HostedDeploySubscriptionQuote = Schemas["V2ComputeSubscriptionQuoteResponse-Output"];
 export type HostedDeploySubscriptionQuoteRequest = Schemas["V2ComputeSubscriptionQuoteRequest"];
@@ -262,39 +262,6 @@ export type IncludedBasicDeploySelection =
 			mode: "unavailable";
 			reason: "plan_missing" | "offers_missing" | "inventory_unavailable";
 	  };
-
-function hasIncludedBasicSubscription(deployment: HostedDeployDeployment): boolean {
-	const subscription = deployment.commercial_display?.compute_subscription;
-	return (
-		deployment.current_plan_slug === "compute_basic" &&
-		subscription != null &&
-		subscription.funding_source == null &&
-		subscription.price_cents === 0
-	);
-}
-
-export function usesHostedDeployIncludedBasicSlot(
-	deployments: readonly HostedDeployDeployment[] | undefined,
-): boolean | null {
-	let occupancyUnavailable = false;
-	for (const deployment of deployments ?? []) {
-		if (!hasIncludedBasicSubscription(deployment)) continue;
-		const acceptedOperation = deployment.accepted_operation;
-		if (
-			(acceptedOperation?.metadata.verb === "delete" && !acceptedOperation.done) ||
-			deployment.compute_slot_occupancy?.reason === "delete_accepted"
-		) {
-			continue;
-		}
-		const occupancy = deployment.compute_slot_occupancy;
-		if (occupancy === null) {
-			occupancyUnavailable = true;
-			continue;
-		}
-		if (occupancy.occupies_slot) return true;
-	}
-	return occupancyUnavailable ? null : false;
-}
 
 export function selectHostedDeployOfferForTerm(
 	plan: HostedDeployPlan,

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -501,6 +501,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v2/subscriptions/included-basic": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get V2 Included Basic Availability */
+        get: operations["get_v2_included_basic_availability_v2_subscriptions_included_basic_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v2/subscriptions/reusable": {
         parameters: {
             query?: never;
@@ -1437,6 +1454,15 @@ export interface components {
             /** Deployment Id */
             deployment_id?: string | null;
         };
+        /** V2ComputeIncludedBasicAvailabilityResponse */
+        V2ComputeIncludedBasicAvailabilityResponse: {
+            /** Total Slots */
+            total_slots: number;
+            /** Used Slots */
+            used_slots: number;
+            /** Available Slots */
+            available_slots: number;
+        };
         /** V2ComputePlanChangeQuoteRequest */
         V2ComputePlanChangeQuoteRequest: {
             /** Subscription Id */
@@ -1625,6 +1651,11 @@ export interface components {
              * @example csub_K8fJ3pQm
              */
             subscription_id: string;
+            /**
+             * Subscription Kind
+             * @enum {string}
+             */
+            subscription_kind: "included_basic" | "paid";
             /** Plan Slug */
             plan_slug: string;
             /** Funding Source */
@@ -4215,6 +4246,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_v2_included_basic_availability_v2_subscriptions_included_basic_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["V2ComputeIncludedBasicAvailabilityResponse"];
                 };
             };
         };

--- a/scripts/filter-deploy-openapi.py
+++ b/scripts/filter-deploy-openapi.py
@@ -79,6 +79,7 @@ KEEP_OPERATIONS_BY_PATH: dict[str, set[str]] = {
     "/v2/subscription/quote": {"post"},
     "/v2/subscription/resume": {"post"},
     "/v2/subscriptions": {"get"},
+    "/v2/subscriptions/included-basic": {"get"},
     "/v2/subscriptions/reusable": {"get"},
     "/v2/usage": {"get"},
     "/v2/wallet": {"get"},


### PR DESCRIPTION
## Summary\n\n- use the hosted included Basic capacity endpoint instead of scanning deployments\n- present Free as a fresh Basic entitlement, never as a reusable subscription\n- remove Free from available/deleted/orphan subscription states while keeping active Free visible with its Agent\n- invalidate authoritative capacity after create, delete, checkout, and plan changes\n- keep Compute cards compact in two columns with gap-2 spacing\n- align CLI deployment selection with the same server-owned capacity contract\n\n## Verification\n\n- GitHub verify passed\n- deploy contract drift check passed\n- web end-to-end suite passed\n- Vercel preview passed\n- generated deploy client and focused Web/CLI tests are included in verify\n\n## Dependency\n\nRequires Clawdi-AI/clawdi-hosted#1806.