### PR TITLE
refactor: share plugin action state and record truthful audit convergence

### DIFF
--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-card.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-card.tsx
@@ -11,12 +11,9 @@ import type { HostedRuntime } from "@/hosted/runtimes";
 import { identityFor } from "@/lib/identity";
 import {
 	type AgentPluginInventoryItem,
+	agentPluginActionState,
 	agentPluginComponentSummary,
-	agentPluginInstallability,
-	agentPluginStatusPresentation,
 	pluginDisplayName,
-	pluginHasUpdate,
-	pluginVersion,
 } from "./agent-plugin-model";
 
 export type AgentPluginPendingAction = "install" | "remove" | "retry" | null;
@@ -41,18 +38,8 @@ export function AgentPluginCard({
 	onRetry: (item: AgentPluginInventoryItem) => Promise<unknown>;
 }) {
 	const title = pluginDisplayName(item);
-	const status = item.desired ? agentPluginStatusPresentation(item.desired) : null;
-	const installability = item.catalog ? agentPluginInstallability(item.catalog, runtime) : null;
-	const hasUpdate = pluginHasUpdate(item);
-	const installFailed = item.desired?.convergence === "failed";
-	const canRetry = Boolean(installFailed && item.catalog && installability?.installable);
-	const canInstall = Boolean(
-		item.catalog && installability?.installable && !installFailed && (!item.desired || hasUpdate),
-	);
-	const version =
-		hasUpdate && item.desired && item.catalog
-			? `v${item.desired.version} → v${item.catalog.version}`
-			: `v${pluginVersion(item)}`;
+	const { status, installability, hasUpdate, canInstall, canRetry, version } =
+		agentPluginActionState(item, runtime);
 
 	return (
 		<div data-hosted="true" data-v2="true" className="contents">

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-detail.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-detail.tsx
@@ -26,13 +26,11 @@ import type { HostedRuntime } from "@/hosted/runtimes";
 import { identityFor } from "@/lib/identity";
 import type { AgentPluginPendingAction } from "./agent-plugin-card";
 import {
+	type AgentPluginActionState,
 	type AgentPluginCatalogEntry,
 	type AgentPluginInventoryItem,
-	agentPluginInstallability,
-	agentPluginStatusPresentation,
+	agentPluginActionState,
 	pluginDisplayName,
-	pluginHasUpdate,
-	pluginVersion,
 } from "./agent-plugin-model";
 
 export function AgentPluginDetail({
@@ -42,6 +40,7 @@ export function AgentPluginDetail({
 	desiredStateError,
 	desiredStateRetrying,
 	pendingAction,
+	mutationsBlocked,
 	onBack,
 	onInstall,
 	onRemove,
@@ -55,6 +54,7 @@ export function AgentPluginDetail({
 	desiredStateError: boolean;
 	desiredStateRetrying: boolean;
 	pendingAction: AgentPluginPendingAction;
+	mutationsBlocked: boolean;
 	onBack: () => void;
 	onInstall: (item: AgentPluginInventoryItem) => Promise<unknown>;
 	onRemove: (item: AgentPluginInventoryItem) => Promise<unknown>;
@@ -63,19 +63,9 @@ export function AgentPluginDetail({
 	onRetryDesired: () => void;
 }) {
 	const title = pluginDisplayName(item);
-	const status = item.desired ? agentPluginStatusPresentation(item.desired) : null;
-	const installability = item.catalog ? agentPluginInstallability(item.catalog, runtime) : null;
-	const hasUpdate = pluginHasUpdate(item);
-	const installFailed = item.desired?.convergence === "failed";
-	const canRetry = Boolean(installFailed && item.catalog && installability?.installable);
-	const canInstall = Boolean(
-		item.catalog && installability?.installable && !installFailed && (!item.desired || hasUpdate),
-	);
+	const actionState = agentPluginActionState(item, runtime);
+	const { status, installability, hasUpdate, version } = actionState;
 	const showCompatibilityWarning = Boolean(installability?.reason && (!item.desired || hasUpdate));
-	const version =
-		hasUpdate && item.desired && item.catalog
-			? `v${item.desired.version} → v${item.catalog.version}`
-			: `v${pluginVersion(item)}`;
 
 	return (
 		<div data-hosted="true" data-v2="true" className="space-y-6">
@@ -136,10 +126,9 @@ export function AgentPluginDetail({
 				actions={
 					<PluginDetailActions
 						item={item}
-						canInstall={canInstall}
-						canRetry={canRetry}
-						installability={installability}
+						state={actionState}
 						pendingAction={pendingAction}
+						mutationsBlocked={mutationsBlocked}
 						onInstall={onInstall}
 						onRemove={onRemove}
 						onRetry={onRetry}
@@ -148,7 +137,7 @@ export function AgentPluginDetail({
 			/>
 			{status && item.desired?.convergence !== "installed" ? (
 				<Alert variant={status.tone === "destructive" ? "destructive" : "default"}>
-					<RefreshCw />
+					{status.tone === "destructive" ? <AlertCircle /> : <RefreshCw />}
 					<AlertTitle>{status.label}</AlertTitle>
 					<AlertDescription>{status.description}</AlertDescription>
 				</Alert>
@@ -181,31 +170,29 @@ export function AgentPluginDetail({
 
 function PluginDetailActions({
 	item,
-	canInstall,
-	canRetry,
-	installability,
+	state,
 	pendingAction,
+	mutationsBlocked,
 	onInstall,
 	onRemove,
 	onRetry,
 }: {
 	item: AgentPluginInventoryItem;
-	canInstall: boolean;
-	canRetry: boolean;
-	installability: ReturnType<typeof agentPluginInstallability> | null;
+	state: AgentPluginActionState;
 	pendingAction: AgentPluginPendingAction;
+	mutationsBlocked: boolean;
 	onInstall: (item: AgentPluginInventoryItem) => Promise<unknown>;
 	onRemove: (item: AgentPluginInventoryItem) => Promise<unknown>;
 	onRetry: (item: AgentPluginInventoryItem) => Promise<unknown>;
 }) {
-	const updating = pluginHasUpdate(item);
+	const { canInstall, canRetry, installability, hasUpdate: updating } = state;
 	return (
 		<>
 			{canInstall ? (
 				<Button
 					size="sm"
 					variant={updating ? "outline" : "default"}
-					disabled={pendingAction !== null}
+					disabled={mutationsBlocked}
 					onClick={() => void onInstall(item).catch(() => undefined)}
 				>
 					{pendingAction === "install" ? <Spinner /> : updating ? <RefreshCw /> : <Plus />}
@@ -225,7 +212,7 @@ function PluginDetailActions({
 			{canRetry ? (
 				<Button
 					size="sm"
-					disabled={pendingAction !== null}
+					disabled={mutationsBlocked}
 					onClick={() => void onRetry(item).catch(() => undefined)}
 				>
 					{pendingAction === "retry" ? <Spinner /> : <RefreshCw />}
@@ -243,7 +230,7 @@ function PluginDetailActions({
 					<Button
 						variant="outline"
 						size="sm"
-						disabled={pendingAction !== null}
+						disabled={mutationsBlocked}
 						className="text-destructive hover:text-destructive"
 					>
 						{pendingAction === "remove" ? <Spinner /> : <Trash2 />}

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.ts
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.ts
@@ -23,7 +23,7 @@ const EXACT_SEMVER_PATTERN =
 	/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
 /** SemVer precedence; null when either side is not exact SemVer. */
-export function compareAgentPluginVersions(left: string, right: string): number | null {
+function compareAgentPluginVersions(left: string, right: string): number | null {
 	const a = EXACT_SEMVER_PATTERN.exec(left);
 	const b = EXACT_SEMVER_PATTERN.exec(right);
 	if (!a || !b) return null;
@@ -113,7 +113,7 @@ export function pluginHasUpdate(item: AgentPluginInventoryItem): boolean {
 }
 
 /** After this long without an observation, the agent — not the install — is the holdup. */
-export const AGENT_PLUGIN_STALL_THRESHOLD_MS = 10 * 60 * 1000;
+const AGENT_PLUGIN_STALL_THRESHOLD_MS = 10 * 60 * 1000;
 
 export function agentPluginIsStalled(
 	desired: AgentPluginDesiredState,
@@ -199,8 +199,40 @@ export function agentPluginStatusPresentation(
 	}
 }
 
-export function agentPluginComponentSummary(entry: AgentPluginCatalogEntry | null): string {
-	if (!entry) return "Component details unavailable";
+export type AgentPluginActionState = {
+	status: ReturnType<typeof agentPluginStatusPresentation> | null;
+	installability: AgentPluginInstallability | null;
+	hasUpdate: boolean;
+	canInstall: boolean;
+	canRetry: boolean;
+	version: string;
+};
+
+/** Shared card/detail action derivation — keep the two surfaces from drifting. */
+export function agentPluginActionState(
+	item: AgentPluginInventoryItem,
+	runtime: HostedRuntime,
+): AgentPluginActionState {
+	const status = item.desired ? agentPluginStatusPresentation(item.desired) : null;
+	const installability = item.catalog ? agentPluginInstallability(item.catalog, runtime) : null;
+	const hasUpdate = pluginHasUpdate(item);
+	const installFailed = item.desired?.convergence === "failed";
+	return {
+		status,
+		installability,
+		hasUpdate,
+		canRetry: Boolean(installFailed && item.catalog && installability?.installable),
+		canInstall: Boolean(
+			item.catalog && installability?.installable && !installFailed && (!item.desired || hasUpdate),
+		),
+		version:
+			hasUpdate && item.desired && item.catalog
+				? `v${item.desired.version} → v${item.catalog.version}`
+				: `v${pluginVersion(item)}`,
+	};
+}
+
+export function agentPluginComponentSummary(entry: AgentPluginCatalogEntry): string {
 	const skills = entry.components.skills.length;
 	const servers = Object.keys(entry.components.mcpServers).length;
 	return [

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
@@ -38,6 +38,8 @@ import {
 } from "./agent-plugin-model";
 
 const DESIRED_QUERY_KEY = ["get", "/v1/agents/{agent_id}/agent-plugins"] as const;
+const ACTIVE_INSTALL_POLL_MS = 5_000;
+const STALLED_INSTALL_POLL_MS = 60_000;
 
 type PendingPluginMutation = {
 	name: string;
@@ -87,8 +89,8 @@ export function AgentPluginsSurface({
 				return plugins.some(
 					(plugin) => plugin.convergence === "not_observed" && !agentPluginIsStalled(plugin, now),
 				)
-					? 5_000
-					: 60_000;
+					? ACTIVE_INSTALL_POLL_MS
+					: STALLED_INSTALL_POLL_MS;
 			},
 			refetchIntervalInBackground: false,
 		},
@@ -174,7 +176,6 @@ export function AgentPluginsSurface({
 			toast.success("Plugin retry started");
 		} catch (error) {
 			toast.error("Couldn't retry plugin", { description: normalizeApiError(error) });
-			void refreshDesired();
 			throw error;
 		} finally {
 			mutationLock.current = false;
@@ -260,6 +261,7 @@ export function AgentPluginsSurface({
 					pendingAction={pending?.name === selectedItem.name ? pending.action : null}
 					desiredStateError={desiredError !== null}
 					desiredStateRetrying={desiredQuery.isFetching}
+					mutationsBlocked={pending !== null}
 					onBack={closePlugin}
 					onInstall={install}
 					onRemove={remove}

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -388,14 +388,6 @@ export function agentPluginDetailHref(agentId: string, pluginName: string): stri
 	return `${agentSectionHref(agentId, "plugins")}/${encodeURIComponent(pluginName)}`;
 }
 
-/** Typed TanStack Router options for a Plugin viewed in the Agent shell. */
-export function agentPluginDetailLink(agentId: string, pluginName: string) {
-	return linkOptions({
-		to: "/agents/$id/plugins/$pluginName",
-		params: { id: agentId, pluginName },
-	});
-}
-
 function safeDecodeURIComponent(value: string): string {
 	try {
 		return decodeURIComponent(value);

--- a/backend/app/routes/plugin_catalog.py
+++ b/backend/app/routes/plugin_catalog.py
@@ -353,9 +353,11 @@ async def put_agent_plugin_desired_state(
     if changed:
         queue_runtime_manifest_changed(db, auth.user_id, agent_id)
     await db.flush()
+    await db.refresh(row)
     observations, observed_at, received_at = await _latest_agent_plugin_observations(
         db, agent_id=agent_id
     )
+    response = _desired_response(row, observations, observed_at, received_at)
     record_control_plane_audit(
         db,
         actor_type="user",
@@ -371,12 +373,11 @@ async def put_agent_plugin_desired_state(
             "version": entry.version,
             "catalog_revision": catalog_revision,
             "changed": changed,
-            "convergence": "not_observed",
+            "convergence": response.convergence,
         },
     )
     await db.commit()
-    await db.refresh(row)
-    return _desired_response(row, observations, observed_at, received_at)
+    return response
 
 
 @router.delete(


### PR DESCRIPTION
## Summary

Final polish pass over the agent plugins feature (audit-driven):

- **Shared action state** — card and detail derived status / installability / hasUpdate / canInstall / canRetry / version via copy-pasted logic that had already drifted; both now consume `agentPluginActionState(item, runtime)` from the model.
- **Detail buttons respect in-flight mutations** — the detail page previously kept buttons enabled while another plugin's mutation ran, and clicks were silently swallowed by the mutation lock; it now receives `mutationsBlocked` like the card.
- **Truthful audit** — the PUT audit record wrote a hardcoded `convergence: not_observed` even for unchanged, already-installed plugins; it now records the computed response convergence (computed once after flush/refresh and reused as the return value).
- **Nits** — failed-status alert uses AlertCircle instead of RefreshCw; poll intervals named; retry error path symmetric with install/remove; dropped the unused `agentPluginDetailLink` export and the unreachable component-summary null branch; unexported internal helpers.

## Verification

- web: typecheck, Biome, 18 unit tests, hosted-agent-plugins.pw.ts 2 passed
- backend: Docker test suite (catalog routes + runtime contract) 13 passed; ruff check + format clean
