### PR TITLE
fix(skills): quiesce legacy hidden metadata uploads

### DIFF
--- a/backend/app/core/skill_key.py
+++ b/backend/app/core/skill_key.py
@@ -40,6 +40,17 @@ def is_valid_skill_key(skill_key: str) -> bool:
     )
 
 
+def is_legacy_hidden_skill_key(skill_key: str) -> bool:
+    """Accept only otherwise-valid keys with dot-prefixed components."""
+    parts = skill_key.split("/")
+    visible_key = "/".join(part.removeprefix(".") for part in parts)
+    return (
+        len(skill_key) <= MAX_SKILL_KEY_LEN
+        and visible_key != skill_key
+        and is_valid_skill_key(visible_key)
+    )
+
+
 def validate_derived_skill_key(skill_key: str) -> str:
     """Validate a server-derived skill_key before storage.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -59,6 +59,7 @@ from app.routes.settings import router as settings_router
 from app.routes.share_redeem import router as share_redeem_router
 from app.routes.sharing import router as sharing_router
 from app.routes.skills import agent_router as skills_agent_router
+from app.routes.skills import legacy_project_upload_router as skills_legacy_project_upload_router
 from app.routes.skills import project_router as skills_project_router
 from app.routes.skills import router as skills_router
 from app.routes.skills import scope_router as skills_scope_router
@@ -387,6 +388,13 @@ _VERSIONED_ROUTERS = (
     sharing_router,
     me_router,
     agent_project_bindings_router,
+)
+# This released /api upload adapter must precede the generic /api project
+# router; it is intentionally absent from /v1 and OpenAPI.
+app.include_router(
+    skills_legacy_project_upload_router,
+    prefix="/api",
+    include_in_schema=False,
 )
 for _router in _VERSIONED_ROUTERS:
     app.include_router(_router, prefix="/v1")

--- a/backend/app/middleware/skill_upload_preflight.py
+++ b/backend/app/middleware/skill_upload_preflight.py
@@ -19,6 +19,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from app.core.skill_key import (
     RESERVED_SKILL_KEY_SUFFIXES,
     has_reserved_skill_key_suffix,
+    is_legacy_hidden_skill_key,
     is_valid_skill_key,
 )
 
@@ -57,6 +58,9 @@ class SkillUploadPreflightMiddleware:
                     if has_reserved_skill_key_suffix(skill_key):
                         await _send_reserved_skill_key(send)
                         return
+                    path = str(scope.get("path", ""))
+                    if path.startswith("/api/projects/") and is_legacy_hidden_skill_key(skill_key):
+                        break
                     if not is_valid_skill_key(skill_key):
                         await _send_invalid_skill_key(send)
                         return

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -38,6 +38,8 @@ from app.core.skill_key import (
     SKILL_KEY_PATTERN,
     SkillKeyValidationError,
     has_reserved_skill_key_suffix,
+    is_legacy_hidden_skill_key,
+    is_valid_skill_key,
     validate_derived_skill_key,
 )
 from app.core.skill_sync_protocol import (
@@ -103,6 +105,13 @@ router = APIRouter(prefix="/skills", tags=["skills"])
 # callers migrate, the legacy write paths return 410 (see step 3
 # of phase 2).
 project_router = APIRouter(prefix="/projects/{project_id}/skills", tags=["skills"])
+
+# Narrow compatibility adapter for legacy Agent uploads. This is mounted only
+# under /api and before project_router so canonical /v1 validation stays strict.
+legacy_project_upload_router = APIRouter(
+    prefix="/projects/{project_id}/skills",
+    include_in_schema=False,
+)
 
 # Agent-authoritative filesystem projection. Unlike project routes, these
 # endpoints derive current project authority from the authenticated Agent
@@ -1005,6 +1014,40 @@ async def _project_upload_authority(
     return SKILL_AUTHORITY_AGENT_SYNC, agent_id
 
 
+async def _upload_skill_project(
+    *,
+    db: AsyncSession,
+    auth: AuthContext,
+    project_id: UUID,
+    skill_key: str,
+    file: UploadFile,
+    create_only: bool,
+    content_hash: str | None,
+    skill_sync_protocol: str | None,
+) -> SkillUploadResponse:
+    authority, authority_agent_id = await _project_upload_authority(
+        db,
+        auth,
+        project_id,
+        allow_agent_alias=True,
+        skill_sync_protocol=skill_sync_protocol,
+    )
+    # Do not hold an idle transaction while reading a bounded multipart body.
+    await db.commit()
+    data = await _read_bounded_skill_upload(file)
+    return await _do_upload_skill(
+        db=db,
+        auth=auth,
+        project_id=project_id,
+        skill_key=skill_key,
+        data=data,
+        content_hash=content_hash,
+        create_only=create_only,
+        authority=authority,
+        authority_agent_id=authority_agent_id,
+    )
+
+
 @agent_router.post("/sync/upload")
 async def upload_agent_synced_skill(
     agent_id: UUID,
@@ -1064,45 +1107,66 @@ async def upload_skill_project(
     `_do_upload_skill`, which serializes mutations with a per-Skill advisory
     lock. SSE is an invalidation hint only for Agent projections.
     """
-    authority, authority_agent_id = await _project_upload_authority(
-        db,
-        auth,
-        project_id,
-        allow_agent_alias=True,
-        skill_sync_protocol=skill_sync_protocol,
-    )
-    await db.commit()
-    # Stream the upload in bounded chunks, refusing once we cross
-    # the cap. `await file.read()` would otherwise pull the whole
-    # body into memory before any check fires — the global
-    # `BodySizeLimitMiddleware` only catches requests that declare
-    # Content-Length, so chunked-transfer clients (HTTP/1.1 +
-    # `Transfer-Encoding: chunked`, HTTP/2 streamed) bypass it.
-    chunks: list[bytes] = []
-    total = 0
-    chunk_size = 1024 * 1024  # 1 MB
-    while True:
-        chunk = await file.read(chunk_size)
-        if not chunk:
-            break
-        total += len(chunk)
-        if total > _MAX_SKILL_TAR_BYTES:
-            raise HTTPException(
-                status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                f"Skill tarball exceeds {_MAX_SKILL_TAR_BYTES} bytes",
-            )
-        chunks.append(chunk)
-    data = b"".join(chunks)
-    return await _do_upload_skill(
+    return await _upload_skill_project(
         db=db,
         auth=auth,
         project_id=project_id,
         skill_key=skill_key,
-        data=data,
-        content_hash=content_hash,
+        file=file,
         create_only=create_only,
-        authority=authority,
-        authority_agent_id=authority_agent_id,
+        content_hash=content_hash,
+        skill_sync_protocol=skill_sync_protocol,
+    )
+
+
+@legacy_project_upload_router.post("/upload", response_model=None)
+async def upload_skill_project_legacy(
+    project_id: UUID = Path(...),
+    skill_key: str = Form(..., max_length=MAX_SKILL_KEY_LEN),
+    file: UploadFile = File(...),
+    create_only: bool = Form(
+        False,
+        description="Reject the upload if this Project already has an active Skill with this key.",
+    ),
+    content_hash: str | None = Form(
+        None,
+        min_length=64,
+        max_length=64,
+        pattern=r"^[a-f0-9]{64}$",
+    ),
+    skill_sync_protocol: str | None = Header(default=None, alias=SKILL_SYNC_PROTOCOL_HEADER),
+    auth: AuthContext = Depends(require_scope_short_session("skills:write")),
+    db: AsyncSession = Depends(get_session),
+) -> SkillUploadResponse | dict[str, bool]:
+    """Preserve the released /api upload contract for legacy Agent scanners."""
+    if has_reserved_skill_key_suffix(skill_key):
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"skill_key cannot end with reserved suffix "
+            f"({', '.join(sorted(RESERVED_SKILL_KEY_SUFFIXES))})",
+        )
+    if is_legacy_hidden_skill_key(skill_key):
+        authority, _ = await _project_upload_authority(
+            db,
+            auth,
+            project_id,
+            allow_agent_alias=True,
+            skill_sync_protocol=skill_sync_protocol,
+        )
+        if authority != SKILL_AUTHORITY_AGENT_SYNC:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, "Invalid skill_key")
+        return {"ignored": True}
+    if not is_valid_skill_key(skill_key):
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, "Invalid skill_key")
+    return await _upload_skill_project(
+        db=db,
+        auth=auth,
+        project_id=project_id,
+        skill_key=skill_key,
+        file=file,
+        create_only=create_only,
+        content_hash=content_hash,
+        skill_sync_protocol=skill_sync_protocol,
     )
 
 

--- a/backend/tests/test_skill_authority.py
+++ b/backend/tests/test_skill_authority.py
@@ -337,6 +337,65 @@ async def test_generic_agent_project_upload_and_delete_support_mixed_cli_version
 
 
 @pytest.mark.asyncio
+async def test_legacy_hidden_project_upload_requires_authentication(
+    anon_client: httpx.AsyncClient,
+    environment_project,
+):
+    response = await anon_client.post(
+        f"/api/projects/{environment_project.id}/skills/upload",
+        data={"skill_key": "archive/.system/tool", "content_hash": "a" * 64},
+        files={"file": ("metadata.tar.gz", b"not materializable", "application/gzip")},
+    )
+
+    assert response.status_code == 401, response.text
+
+
+@pytest.mark.asyncio
+async def test_generic_agent_project_upload_truthfully_ignores_legacy_hidden_metadata(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user: User,
+    seed_project: Project,
+    environment_project,
+):
+    skill_key = "archive/.system/tool"
+    data = {"skill_key": skill_key, "content_hash": "a" * 64}
+    files = {"file": ("metadata.tar.gz", b"not materializable", "application/gzip")}
+
+    _set_auth(_api_key_auth(seed_user))
+    canonical = await client.post(
+        f"/v1/projects/{environment_project.id}/skills/upload",
+        data=data,
+        files=files,
+    )
+    assert canonical.status_code == 422, canonical.text
+
+    cloud = await client.post(
+        f"/api/projects/{seed_project.id}/skills/upload",
+        data=data,
+        files=files,
+    )
+    assert cloud.status_code == 422, cloud.text
+
+    ignored = await client.post(
+        f"/api/projects/{environment_project.id}/skills/upload",
+        data=data,
+        files=files,
+    )
+    assert ignored.status_code == 200, ignored.text
+    assert ignored.json() == {"ignored": True}
+    assert (
+        await db_session.execute(
+            select(Skill).where(
+                Skill.project_id == environment_project.id,
+                Skill.skill_key == skill_key,
+                Skill.is_active,
+            )
+        )
+    ).scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("protocol", "expected_status", "expected_code"),
     [

--- a/backend/tests/test_skill_upload_preflight.py
+++ b/backend/tests/test_skill_upload_preflight.py
@@ -33,7 +33,14 @@ def _multipart_body(*, skill_key: str | None) -> tuple[bytes, str]:
 
 
 @pytest.mark.asyncio
-async def test_skill_upload_preflight_rejects_invalid_key_before_inner_app():
+@pytest.mark.parametrize(
+    ("skill_key", "expected_status"),
+    [("../system", 422), ("team/install", 400)],
+)
+async def test_skill_upload_preflight_rejects_unsafe_legacy_project_keys_before_inner_app(
+    skill_key: str,
+    expected_status: int,
+):
     called = False
 
     async def inner_app(_scope: Scope, _receive: Receive, _send: Send) -> None:
@@ -42,19 +49,22 @@ async def test_skill_upload_preflight_rejects_invalid_key_before_inner_app():
         raise AssertionError("inner app should not receive invalid skill uploads")
 
     app = SkillUploadPreflightMiddleware(inner_app)
-    body, content_type = _multipart_body(skill_key=".system")
+    body, content_type = _multipart_body(skill_key=skill_key)
 
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
         response = await client.post(
-            "/v1/projects/00000000-0000-0000-0000-000000000000/skills/upload",
+            "/api/projects/00000000-0000-0000-0000-000000000000/skills/upload",
             content=body,
             headers={"Content-Type": content_type},
         )
 
-    assert response.status_code == 422
-    assert response.json() == {"detail": "Invalid skill_key"}
+    assert response.status_code == expected_status
+    if expected_status == 422:
+        assert response.json() == {"detail": "Invalid skill_key"}
+    else:
+        assert "reserved suffix" in response.json()["detail"]
     assert called is False
 
 

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -1554,7 +1554,7 @@ async def test_project_explicit_upload_targets_named_project(
 
     # Upload to workspace A explicitly via the project-scoped route.
     r = await client.post(
-        f"/v1/projects/{project_a.id}/skills/upload",
+        f"/api/projects/{project_a.id}/skills/upload",
         data={"skill_key": "projected"},
         files=files,
     )


### PR DESCRIPTION
## Summary

- recognize legacy Skill keys whose dot-prefixed components become a valid key when the leading dots are removed
- allow only the hidden /api project upload adapter to acknowledge those keys after normal authentication and Agent Project authority checks
- return {"ignored": true} without reading the archive or writing database/object-storage state

The normal /api upload path and canonical /v1 upload share the same bounded persistence helper.

## Compatibility

- backend-only; no CLI upgrade, Hosted change, migration, flag, version selector, or allowlist
- canonical /v1 validation and the public SkillUploadResponse/OpenAPI schema remain unchanged
- traversal, empty segments, reserved route suffixes, normal invalid keys, and Cloud Project uploads remain rejected
- real valid-key 409 authority/ownership conflicts, 413 oversized uploads, and project_skill_delivery_update_required remain fail-closed

A small /api-only router is necessary because the normal project router is mounted under both /v1 and /api. Reusing it for the broad legacy input would either loosen the public /v1 schema or require hand-written OpenAPI behavior.

Older clients require a 2xx response containing parseable JSON. After that response they persist their locally computed hash and remove the queue item; they do not runtime-validate SkillUploadResponse.

## Verification

- Docker/PostgreSQL focused backend regression: 10 passed
- uv run ruff check .
- uv run ruff format --check .
- uv run python scripts/check_generated_api.py
- canonical /v1 multipart schema still exposes SKILL_KEY_PATTERN
- git diff --check