### PR TITLE
fix: release hosted project skill capability

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "backend/**"
       - "packages/whatsapp-baileys-sidecar/**"
+      - "packages/cli/package.json"
       - "packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts"
       - "packages/cli/tests/clawdi-image-release-workflow.test.ts"
       - "config/deploy.yml"
@@ -33,6 +34,7 @@ on:
     paths:
       - "backend/**"
       - "packages/whatsapp-baileys-sidecar/**"
+      - "packages/cli/package.json"
       - "packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts"
       - "packages/cli/tests/clawdi-image-release-workflow.test.ts"
       - "config/deploy.yml"
@@ -118,6 +120,7 @@ jobs:
               - ".github/workflows/backend-ci.yml"
             sidecar:
               - "packages/whatsapp-baileys-sidecar/**"
+              - "packages/cli/package.json"
               - "packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts"
               - "packages/cli/tests/clawdi-image-release-workflow.test.ts"
               - "scripts/test-kamal-whatsapp-sidecar-render.sh"

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -274,6 +274,7 @@ jobs:
           FROM ruby:3.4.10-bookworm@sha256:8ff02c55f0467a3d03bc6c41b7500f9f0b30086a1861c601cd4e9dc5b8536a66
           WORKDIR /repo
           COPY config/deploy.yml config/deploy.yml
+          COPY packages/cli/package.json packages/cli/package.json
           COPY scripts/deploy-whatsapp-sidecar.sh scripts/deploy-whatsapp-sidecar.sh
           COPY scripts/test-deploy-whatsapp-sidecar.sh scripts/test-deploy-whatsapp-sidecar.sh
           COPY scripts/test-kamal-whatsapp-sidecar-render.sh scripts/test-kamal-whatsapp-sidecar-render.sh

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -9,6 +9,10 @@
 # runtime shape lives here. The image entrypoint (app.runtime_entrypoint)
 # selects the process via CLAWDI_PROCESS_ROLE, runs migrations for the api
 # role, and drains on SIGTERM — no command overrides needed.
+<%
+require "json"
+clawdi_cli_version = JSON.parse(File.read("packages/cli/package.json")).fetch("version")
+%>
 
 service: clawdi
 image: clawdi-ai/clawdi-backend
@@ -306,6 +310,8 @@ env:
     CORS_ORIGINS: '["https://www.clawdi.ai","https://clawdi.ai","https://api.clawdi.ai","https://cloud.clawdi.ai"]'
     TRUST_FORWARDED_FOR: "true"
     PLUGIN_CATALOG_SYNC_ENABLED: "true"
+    # The CLI package manifest is the version authority; do not duplicate its release pin.
+    PROJECT_SKILL_HOSTED_CLI_PACKAGE_SPECS: '["clawdi@<%= clawdi_cli_version %>"]'
     FILE_STORE_TYPE: s3
     MEMORY_EMBEDDING_MODE: local
     DB_POOL_SIZE: 20

--- a/packages/cli/tests/clawdi-image-release-workflow.test.ts
+++ b/packages/cli/tests/clawdi-image-release-workflow.test.ts
@@ -108,6 +108,7 @@ describe("backend image release workflow contract", () => {
 		const filterStep = backendCi.jobs.changes?.steps?.find((step) => step.id === "filter");
 		const filters = String(filterStep?.with?.filters);
 		const backendFilter = filters.slice(filters.indexOf("backend:\n"), filters.indexOf("test:\n"));
+		const sidecarFilter = filters.slice(filters.indexOf("sidecar:\n"));
 
 		expect(backendCi.jobs["lint-and-typecheck"]?.if).toBe(
 			"needs.changes.outputs.backend == 'true'",
@@ -123,10 +124,12 @@ describe("backend image release workflow contract", () => {
 		}
 		for (const path of [
 			"packages/whatsapp-baileys-sidecar/**",
+			"packages/cli/package.json",
 			"scripts/deploy-whatsapp-sidecar.sh",
 		]) {
 			expect(backendFilter).not.toContain(`- "${path}"`);
 		}
+		expect(sidecarFilter).toContain('- "packages/cli/package.json"');
 	});
 
 	test("coalesces main Backend CI only inside its image-input path gate", () => {
@@ -135,6 +138,7 @@ describe("backend image release workflow contract", () => {
 			expect.arrayContaining([
 				"backend/**",
 				"packages/whatsapp-baileys-sidecar/**",
+				"packages/cli/package.json",
 				"config/deploy.yml",
 				".dockerignore",
 				"packages/shared/src/api/api.generated.ts",
@@ -145,6 +149,7 @@ describe("backend image release workflow contract", () => {
 				".github/workflows/clawdi-image-release.yml",
 			]),
 		);
+		expect(backendCi.on?.pull_request?.paths).toContain("packages/cli/package.json");
 		expect(backendCi.on?.push?.paths).not.toContain("**");
 		expect(backendCi.on?.push?.paths).not.toContain("apps/web/src/**");
 		expect(backendCi.concurrency?.["cancel-in-progress"]).toBe(
@@ -232,10 +237,10 @@ describe("backend image release workflow contract", () => {
 		expect(releaseRunbook).not.toContain("immutable OCI image tag");
 	});
 
-	test("keeps CLI and release orchestration outside every automatic image release input", () => {
+	test("classifies the CLI manifest as deployment-only without circular release inputs", () => {
 		const baseline = calculateClawdiImageRevisions(repoRoot);
 		const probeVersion = `${cliVersion}-image-release-probe`;
-		const head = calculateClawdiImageRevisions(
+		const cliHead = calculateClawdiImageRevisions(
 			repoRoot,
 			new Map([
 				[
@@ -246,6 +251,24 @@ describe("backend image release workflow contract", () => {
 						`"version": "${probeVersion}"`,
 					),
 				],
+			]),
+		);
+		const cliPlan = classifyClawdiImageRelease({
+			base: baseline,
+			baseSha: "a".repeat(40),
+			head: cliHead,
+			headSha: "b".repeat(40),
+		});
+
+		expect(cliHead.backend).toBe(baseline.backend);
+		expect(cliHead.deployment).not.toBe(baseline.deployment);
+		expect(cliHead.sidecar).toBe(baseline.sidecar);
+		expect(cliPlan.changed).toEqual({ backend: false, deployment: true, sidecar: false });
+		expect(cliPlan.releaseRequired).toBe(true);
+
+		const ignoredHead = calculateClawdiImageRevisions(
+			repoRoot,
+			new Map([
 				[
 					"bun.lock",
 					replaceOnce(lockfileSource, `"version": "${cliVersion}"`, `"version": "${probeVersion}"`),
@@ -261,16 +284,16 @@ describe("backend image release workflow contract", () => {
 				["scripts/clawdi-image-release-plan.ts", `${releaseClassifierSource}\n// probe\n`],
 			]),
 		);
-		const plan = classifyClawdiImageRelease({
+		const ignoredPlan = classifyClawdiImageRelease({
 			base: baseline,
 			baseSha: "a".repeat(40),
-			head,
+			head: ignoredHead,
 			headSha: "b".repeat(40),
 		});
 
-		expect(head).toEqual(baseline);
-		expect(plan.changed).toEqual({ backend: false, deployment: false, sidecar: false });
-		expect(plan.releaseRequired).toBe(false);
+		expect(ignoredHead).toEqual(baseline);
+		expect(ignoredPlan.changed).toEqual({ backend: false, deployment: false, sidecar: false });
+		expect(ignoredPlan.releaseRequired).toBe(false);
 
 		const releaseGate = "steps.release-plan.outputs.release_required == 'true'";
 		for (const name of [

--- a/scripts/clawdi-image-release-plan.ts
+++ b/scripts/clawdi-image-release-plan.ts
@@ -15,6 +15,7 @@ const IMAGE_RELEASE_WORKFLOW = ".github/workflows/clawdi-image-release.yml";
 const DEPLOYMENT_FILE_INPUTS = [
 	".github/actions/setup-bun-ci/action.yml",
 	"config/deploy.yml",
+	"packages/cli/package.json",
 	"scripts/deploy-whatsapp-sidecar.sh",
 ] as const;
 

--- a/scripts/test-kamal-whatsapp-sidecar-render.sh
+++ b/scripts/test-kamal-whatsapp-sidecar-render.sh
@@ -15,6 +15,8 @@ trap cleanup EXIT
 test "$(kamal version)" = "2.12.0"
 mkdir -p "${render_root}/config" "${render_root}/.kamal"
 cp "${repo_root}/config/deploy.yml" "${render_root}/config/deploy.yml"
+mkdir -p "${render_root}/packages/cli"
+cp "${repo_root}/packages/cli/package.json" "${render_root}/packages/cli/package.json"
 
 secret_keys=(
 	KAMAL_REGISTRY_USERNAME
@@ -127,6 +129,7 @@ RUBY
 		DEPLOY_IMAGE_VERSION="${expected_version}" \
 		ruby - "${render_root}/config/deploy.yml" "${expected_version}" <<'RUBY'
 require "kamal"
+require "json"
 require "pathname"
 
 config_path, expected_version = ARGV
@@ -137,6 +140,11 @@ config = Kamal::Configuration.create_from(
 expected_logging_args = [ "--log-driver", '"journald"' ]
 
 raise "top-level logging did not render journald" unless config.logging_args == expected_logging_args
+cli_version = JSON.parse(File.read("packages/cli/package.json")).fetch("version")
+expected_project_skill_specs = [ "clawdi@#{cli_version}" ].to_json
+unless config.raw_config.dig("env", "clear", "PROJECT_SKILL_HOSTED_CLI_PACKAGE_SPECS") == expected_project_skill_specs
+  raise "Project Skill Hosted CLI package specs drifted from packages/cli/package.json"
+end
 config.roles.each do |role|
   raise "#{role.name} logging drifted" unless role.logging_args == expected_logging_args
 end


### PR DESCRIPTION
## Summary
- render the Hosted Project Skill CLI allowlist from the canonical CLI package version
- verify the rendered Kamal environment matches that version
- include the CLI manifest in Backend CI routing and deployment revision authority

## Root cause
Production left `PROJECT_SKILL_HOSTED_CLI_PACKAGE_SPECS` unset, so every Hosted Agent failed the Project Skill capability gate even after its runtime had converged.

## Verification
- Docker CLI typecheck
- focused release workflow contract: 13 passed
- Docker Kamal 2.12 render and deployment contracts
- Biome and diff checks
