### PR TITLE
fix(skills): allow legacy agent local uploads

### DIFF
--- a/backend/app/services/project_runtime_skills.py
+++ b/backend/app/services/project_runtime_skills.py
@@ -623,7 +623,7 @@ async def assert_agent_workspace_skill_write_compatible(
     agent_id: UUID,
     skill_keys: set[str],
 ) -> None:
-    """Fail before Agent Workspace intent would duplicate a linked Project Skill."""
+    """Reject local names that collide with linked Project Skills."""
     await lock_agent_runtime_graph(db, agent_id)
     if not skill_keys:
         return
@@ -659,22 +659,6 @@ async def assert_agent_workspace_skill_write_compatible(
                 ),
                 "skill_key": skill_key,
             },
-        )
-    if project_local_skill_keys:
-        (
-            agent,
-            state,
-            observation,
-            has_environment_bound_key,
-        ) = await _agent_runtime_delivery_evidence(
-            db,
-            agent_id=agent_id,
-        )
-        _assert_agent_supports_project_skills(
-            agent,
-            state,
-            observation,
-            has_environment_bound_key=has_environment_bound_key,
         )
 
 

--- a/backend/tests/test_project_runtime_skills.py
+++ b/backend/tests/test_project_runtime_skills.py
@@ -507,11 +507,7 @@ async def test_connected_agent_and_project_skill_write_fail_before_mutation(
         },
     )
     _set_auth(AuthContext(user=seed_user))
-    assert stale_workspace_write.status_code == 409, stale_workspace_write.text
-    assert stale_workspace_write.json()["detail"] == {
-        "code": "project_skill_delivery_update_required",
-        "message": "Update this Agent, then try again.",
-    }
+    assert stale_workspace_write.status_code == 200, stale_workspace_write.text
 
     empty_project = Project(
         user_id=seed_user.id,


### PR DESCRIPTION
## Summary

- stop requiring Project Skill delivery capability for local Agent Skill uploads
- keep linked Project Skill name-conflict checks fail-closed
- preserve capability enforcement for Project Skill links and mutations

## Why

Legacy Hermes Agents can safely upload their own local Skills even when they cannot prove Project Skill delivery support. The previous upload-time gate rejected unrelated local uploads with `409 project_skill_delivery_update_required`.

## Verification

- `scripts/test.sh backend`: 2355 passed, 12 skipped
- focused runtime Skill tests: 12 passed
- Ruff check and format check
- generated API consistency
- `git diff --check`