### PR TITLE
fix: render Kamal config under ASCII locale

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -11,7 +11,9 @@
 # role, and drains on SIGTERM — no command overrides needed.
 <%
 require "json"
-clawdi_cli_version = JSON.parse(File.read("packages/cli/package.json")).fetch("version")
+clawdi_cli_version = JSON.parse(
+  File.read("packages/cli/package.json", encoding: Encoding::UTF_8)
+).fetch("version")
 %>
 
 service: clawdi

--- a/scripts/test-kamal-whatsapp-sidecar-render.sh
+++ b/scripts/test-kamal-whatsapp-sidecar-render.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export LC_ALL=C
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 render_root="$(mktemp -d)"
@@ -12,6 +13,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
+test "$(ruby -e 'print Encoding.default_external.name')" = "US-ASCII"
 test "$(kamal version)" = "2.12.0"
 mkdir -p "${render_root}/config" "${render_root}/.kamal"
 cp "${repo_root}/config/deploy.yml" "${render_root}/config/deploy.yml"
@@ -140,7 +142,9 @@ config = Kamal::Configuration.create_from(
 expected_logging_args = [ "--log-driver", '"journald"' ]
 
 raise "top-level logging did not render journald" unless config.logging_args == expected_logging_args
-cli_version = JSON.parse(File.read("packages/cli/package.json")).fetch("version")
+cli_version = JSON.parse(
+  File.read("packages/cli/package.json", encoding: Encoding::UTF_8)
+).fetch("version")
 expected_project_skill_specs = [ "clawdi@#{cli_version}" ].to_json
 unless config.raw_config.dig("env", "clear", "PROJECT_SKILL_HOSTED_CLI_PACKAGE_SPECS") == expected_project_skill_specs
   raise "Project Skill Hosted CLI package specs drifted from packages/cli/package.json"


### PR DESCRIPTION
## Summary

- read the CLI package manifest explicitly as UTF-8 when rendering Kamal config
- run the existing Kamal render contract under the production runner's ASCII locale

## Verification

- Docker Ruby 3.4.10 + Kamal 2.12 render and deployment contract
- `git diff --check`
- `bash -n scripts/test-kamal-whatsapp-sidecar-render.sh`