### PR TITLE
fix(runtime): surface agent plugin install failures end to end

### DIFF
--- a/backend/app/schemas/runtime_observation.py
+++ b/backend/app/schemas/runtime_observation.py
@@ -127,9 +127,13 @@ class HostedRuntimeObservedAgentPluginsV1(RuntimeObservationRequestModel):
     def validate_applied_identity(self, applied: HostedRuntimeObservedAppliedV2) -> None:
         for installation in self.installations:
             if installation.status == "failed":
+                # A failed apply never becomes the applied state, so a failure
+                # naming the exact applied identity is a replay; a same-generation
+                # attempt with a *different* revision is a newer (e.g. plugin-only)
+                # manifest that did not bump the runtime generation.
                 if installation.generation < applied.generation or (
                     installation.generation == applied.generation
-                    and installation.source_revision != applied.source_revision
+                    and installation.source_revision == applied.source_revision
                 ):
                     raise ValueError("failed Agent Plugin observation is stale")
                 continue

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -209,6 +209,30 @@ def test_agent_plugin_observation_rejects_stale_or_unfenced_apply_identity() -> 
             }
         )
 
+    with pytest.raises(ValueError, match="failed Agent Plugin observation is stale"):
+        RuntimeObservationEventV2.model_validate(
+            {
+                **payload,
+                "agentPlugins": {
+                    "schemaVersion": 1,
+                    "installations": [
+                        {**installation, "generation": 2, "sourceRevision": "a" * 64}
+                    ],
+                },
+            }
+        )
+
+    same_generation_new_revision = RuntimeObservationEventV2.model_validate(
+        {
+            **payload,
+            "agentPlugins": {
+                "schemaVersion": 1,
+                "installations": [{**installation, "generation": 2}],
+            },
+        }
+    )
+    assert same_generation_new_revision.agent_plugins is not None
+
     with pytest.raises(ValueError, match="must match applied identity"):
         RuntimeObservationEventV2.model_validate(
             {

--- a/packages/cli/src/runtime/hosted-agent-plugin-observation.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-observation.test.ts
@@ -214,6 +214,32 @@ describe("hosted Agent Plugin heartbeat observation", () => {
 		]);
 	});
 
+	test("reports a failed attempt at the applied generation with a newer revision", () => {
+		const paths = tempPaths();
+		const desired = installation("1.0.0", "d");
+		writeAppliedManifest(paths, desired);
+		writeReceipt(paths, desired);
+
+		const observed = readHostedAgentPluginsObservation({
+			paths,
+			applied: appliedState(),
+			watchStatus: failedWatchStatus(desired, 7),
+		});
+
+		expect(observed?.installations).toEqual([
+			{
+				installationId,
+				name: "clawdi",
+				version: "1.0.0",
+				contentDigest: `sha256-tree-v1:${"d".repeat(64)}`,
+				sourceRevision: "1".repeat(64),
+				generation: 7,
+				status: "failed",
+				errorCode: "reconcile_failed",
+			},
+		]);
+	});
+
 	test("keeps heartbeat readable and reports unknown when the receipt is corrupt", () => {
 		const paths = tempPaths();
 		const desired = installation("1.0.0", "d");

--- a/packages/cli/src/runtime/hosted-agent-plugin-observation.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-observation.ts
@@ -252,8 +252,10 @@ export function readHostedAgentPluginsObservation(input: {
 	const currentFailures = failed.installations.filter(
 		(observation) =>
 			observation.generation > appliedGeneration ||
+			// Plugin-only manifest changes do not bump the runtime generation, so a
+			// failed attempt at the same generation carries a newer revision.
 			(observation.generation === appliedGeneration &&
-				observation.sourceRevision === input.applied.sourceRevision),
+				observation.sourceRevision !== input.applied.sourceRevision),
 	);
 	if (currentFailures.length === 0) return applied;
 	const failedNames = new Set(currentFailures.map((observation) => observation.name));

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
@@ -37,6 +37,7 @@ class FakeNativeRunner implements HostedAgentPluginCommandRunner {
 	readonly calls: CommandInput[] = [];
 	readonly states = new Map<string, FakePluginState>();
 	availableResult = true;
+	rejectNoScan = false;
 	failProbeInstallName: string | null = null;
 	failLiveEnableVersion: string | null = null;
 	failLiveInstallVersion: string | null = null;
@@ -233,6 +234,9 @@ class FakeNativeRunner implements HostedAgentPluginCommandRunner {
 			};
 		}
 		if (args[1] === "install") {
+			if (this.rejectNoScan && args.includes("--no-scan")) {
+				return { status: 2, stdout: "", stderr: "error: unrecognized arguments: --no-scan" };
+			}
 			const source = runtime === "hermes" ? fileURLToPath(args[2] ?? "") : (args[2] ?? "");
 			const manifest = this.pluginFromSource(source);
 			if (input.home !== this.liveHome && manifest.name === this.failProbeInstallName) {
@@ -602,6 +606,7 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 			(call) => call.home === runner.liveHome && call.args[1] === "install",
 		);
 		expect(install?.args[2]?.startsWith("file://")).toBe(true);
+		expect(install?.args).toContain("--no-scan");
 		expect(install?.args.join(" ")).not.toContain("github.com");
 		expect(install?.environmentOverrides).toEqual({
 			OPENCLAW_HOME: undefined,
@@ -639,6 +644,19 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 					call.command === "git" && call.args.includes("add") && call.args.includes("--force"),
 			),
 		).toBe(true);
+		expect(runner.get("hermes", desired.name)?.enabled).toBe(true);
+	});
+
+	test("falls back when the native Hermes does not support --no-scan", () => {
+		const runner = new FakeNativeRunner();
+		runner.rejectNoScan = true;
+		const desired = plugin("acme.tools", "1.2.3", "b".repeat(64));
+		const transaction = prepareTransaction(desiredState("hermes", desired), runner);
+		transaction.apply();
+		const installs = runner.calls.filter(
+			(call) => call.home === runner.liveHome && call.args[1] === "install",
+		);
+		expect(installs.map((call) => call.args.includes("--no-scan"))).toEqual([true, false]);
 		expect(runner.get("hermes", desired.name)?.enabled).toBe(true);
 	});
 

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
@@ -227,6 +227,17 @@ function runNative(
 	});
 }
 
+/** Native CLIs explain failures on stderr; keep a tail so apply errors are diagnosable. */
+function nativeCommandFailure(prefix: string, result: AgentPluginCommandResult): Error {
+	const detail = (result.stderr.trim() || result.stdout.trim())
+		.split("\n")
+		.map((line) => line.trimEnd())
+		.filter((line) => line.length > 0)
+		.slice(-8)
+		.join("\n");
+	return new Error(detail ? `${prefix}: ${detail}` : prefix);
+}
+
 function assertNativeId(nativeId: string): void {
 	if (nativeId.length > 128 || !/^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/.test(nativeId)) {
 		throw new Error("native Agent Plugin identity is unsafe");
@@ -361,7 +372,9 @@ function createOpenClawDriver(input: {
 		install(prepared) {
 			withPreparedAgentPluginDirectory(prepared, (sourceDir) => {
 				const result = run(["plugins", "install", sourceDir, "--force"]);
-				if (result.status !== 0) throw new Error("OpenClaw native Agent Plugin install failed");
+				if (result.status !== 0) {
+					throw nativeCommandFailure("OpenClaw native Agent Plugin install failed", result);
+				}
 			});
 			const installed = observe(prepared.name);
 			if (!installed) {
@@ -373,7 +386,9 @@ function createOpenClawDriver(input: {
 		},
 		setEnabled(observation, enabled) {
 			const result = run(["plugins", enabled ? "enable" : "disable", observation.nativeId]);
-			if (result.status !== 0) throw new Error("OpenClaw native Agent Plugin state change failed");
+			if (result.status !== 0) {
+				throw nativeCommandFailure("OpenClaw native Agent Plugin state change failed", result);
+			}
 		},
 		remove(observation) {
 			if (!observation.compatible) {
@@ -381,7 +396,9 @@ function createOpenClawDriver(input: {
 			}
 			if (observation.enabled) this.setEnabled(observation, false);
 			const result = run(["plugins", "uninstall", observation.nativeId, "--force"]);
-			if (result.status !== 0) throw new Error("OpenClaw native Agent Plugin uninstall failed");
+			if (result.status !== 0) {
+				throw nativeCommandFailure("OpenClaw native Agent Plugin uninstall failed", result);
+			}
 		},
 	};
 }
@@ -469,14 +486,22 @@ function createHermesDriver(input: {
 		install(prepared) {
 			withPreparedAgentPluginDirectory(prepared, (sourceDir) => {
 				initializeLocalGitTransport(input.runner, "hermes", input.home, sourceDir);
-				const result = run([
+				const args = [
 					"plugins",
 					"install",
 					pathToFileURL(sourceDir).href,
 					"--force",
 					"--no-enable",
-				]);
-				if (result.status !== 0) throw new Error("Hermes native Agent Plugin install failed");
+				];
+				// Store plugins are digest-verified by the control plane, so the native
+				// community-plugin security scan is skipped when the runtime supports it.
+				let result = run([...args, "--no-scan"]);
+				if (result.status !== 0 && result.stderr.includes("unrecognized arguments")) {
+					result = run(args);
+				}
+				if (result.status !== 0) {
+					throw nativeCommandFailure("Hermes native Agent Plugin install failed", result);
+				}
 			});
 			const installed = observe(prepared.name);
 			if (!installed) throw new Error("Hermes did not report the installed Agent Plugin");
@@ -486,13 +511,17 @@ function createHermesDriver(input: {
 			const args = ["plugins", enabled ? "enable" : "disable", observation.nativeId];
 			if (enabled) args.push("--no-allow-tool-override");
 			const result = run(args);
-			if (result.status !== 0) throw new Error("Hermes native Agent Plugin state change failed");
+			if (result.status !== 0) {
+				throw nativeCommandFailure("Hermes native Agent Plugin state change failed", result);
+			}
 		},
 		remove(observation) {
 			if (!observation.compatible) throw new Error("refusing to remove an unmanaged Hermes plugin");
 			if (observation.enabled) this.setEnabled(observation, false);
 			const result = run(["plugins", "remove", observation.nativeId]);
-			if (result.status !== 0) throw new Error("Hermes native Agent Plugin remove failed");
+			if (result.status !== 0) {
+				throw nativeCommandFailure("Hermes native Agent Plugin remove failed", result);
+			}
 		},
 	};
 }


### PR DESCRIPTION
## Summary

Production root-cause: a hosted agent was stuck on "Installing" forever because a plugin-only manifest change reuses the runtime generation, and the failed-install evidence was dropped by *both* sides of the observation protocol:

- **CLI merge filter** dropped failed observations whose generation equals the applied generation but whose source revision is newer — exactly the plugin-only shape.
- **Backend ingest validator** rejected those same observations as "stale" (the revision arm was inverted: it rejected `!= applied` instead of `== applied`). The two rules were complementary opposites, so no same-generation failure could ever surface.

Also in the CLI driver:

- Native install/state/remove failures now carry an 8-line stderr tail — "Hermes native Agent Plugin install failed" previously discarded the actual reason (in prod: hermes' new community-plugin security scanner hard-blocked a Store plugin; Store plugins are digest-verified by the control plane and don't need it).
- Hermes installs pass `--no-scan` (upstream PR: NousResearch/hermes-agent adding the flag), falling back when the native CLI doesn't recognize it yet.

## Verification

- CLI: bun test runtime plugin suites — 21 passed (new: same-generation/newer-revision failure is reported; `--no-scan` fallback)
- Backend (Docker): test_runtime_observation_companion + test_agent_plugin_catalog_routes — 38 passed (new: same-generation different-revision failure accepted, exact-identity replay still stale)
- Biome / ruff clean
