### PR TITLE
fix(release): bound deployment authority lookup

### DIFF
--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -88,20 +88,22 @@ jobs:
         if: github.event_name == 'workflow_run'
         uses: actions/github-script@v8
         with:
+          retries: 3
           script: |
-            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+            const { data: { workflow_runs: runs } } = await github.rest.actions.listWorkflowRuns({
               ...context.repo,
               workflow_id: "clawdi-image-release.yml",
-              status: "completed",
-              per_page: 100,
+              status: "success",
+              per_page: 20,
             });
             const deployed = [];
             for (const run of runs) {
-              if (run.id === context.runId || run.conclusion !== "success") continue;
-              const jobs = await github.paginate(
-                github.rest.actions.listJobsForWorkflowRun,
-                { ...context.repo, run_id: run.id, filter: "latest", per_page: 100 },
-              );
+              const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
+                ...context.repo,
+                run_id: run.id,
+                filter: "latest",
+                per_page: 100,
+              });
               const deployJobs = jobs.filter(
                 (job) => job.name === "deploy-vps" || job.name.startsWith("deploy-vps "),
               );

--- a/packages/cli/tests/clawdi-image-release-workflow.test.ts
+++ b/packages/cli/tests/clawdi-image-release-workflow.test.ts
@@ -185,8 +185,12 @@ describe("backend image release workflow contract", () => {
 			(step) => step.name === "Resolve last successful deployment authority",
 		);
 		expect(authority?.uses).toBe("actions/github-script@v8");
+		expect(authority?.with?.retries).toBe(3);
 		const authorityScript = String(authority?.with?.script ?? "");
 		expect(authorityScript).toContain("listWorkflowRuns");
+		expect(authorityScript).toContain('status: "success"');
+		expect(authorityScript).toContain("per_page: 20");
+		expect(authorityScript).not.toContain("github.paginate");
 		expect(authorityScript).toContain("listJobsForWorkflowRun");
 		expect(authorityScript).toContain('job.name.startsWith("deploy-vps ")');
 		expect(authorityScript).toContain('deploy.conclusion !== "success"');


### PR DESCRIPTION
## Summary

- inspect only the 20 most recent successful image-release runs
- preserve exact selection by deploy job completion time
- retry transient GitHub API failures three times

## Why

The release workflow paginated the full history and fetched every successful run's jobs. A single transient `502` among hundreds of requests blocked production deployment and consumed nearly 1,000 API calls per attempt.

The bounded window remains fail-closed when no unambiguous deployment authority is found.

## Verification

- isolated CLI typecheck
- `tests/clawdi-image-release-workflow.test.ts`: 13 passed
- live API check resolves the latest successful deploy authority to `224ed00b34347515d7114605c2e0e3ccd22db581`
- `git diff --check`