### PR TITLE
fix(web): refine plugin card status placement and group pinning

### DIFF
--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-card.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-card.tsx
@@ -53,22 +53,20 @@ export function AgentPluginCard({
 					</IconChip>
 				}
 				title={title}
-				badges={
-					status || hasUpdate ? (
-						<>
-							{status ? (
-								<StatusBadge status={status.tone} withDot>
-									{status.label}
-								</StatusBadge>
-							) : null}
-							{hasUpdate ? <StatusBadge status="info">Update available</StatusBadge> : null}
-						</>
-					) : undefined
-				}
 				description={
 					item.catalog?.description ?? "This plugin is no longer available in the Store."
 				}
 				footer={[
+					status ? (
+						<StatusBadge key="status" status={status.tone} withDot>
+							{status.label}
+						</StatusBadge>
+					) : null,
+					hasUpdate ? (
+						<StatusBadge key="update" status="info">
+							Update available
+						</StatusBadge>
+					) : null,
 					item.catalog?.publisher,
 					version,
 					item.catalog ? agentPluginComponentSummary(item.catalog) : null,

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.test.ts
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.test.ts
@@ -60,24 +60,36 @@ describe("Agent Plugin model", () => {
 		expect(pluginHasUpdate(inventory[2])).toBe(true);
 	});
 
-	test("keeps each plugin in its first observed group", () => {
-		const initialInventory = buildAgentPluginInventory(
-			[catalogEntry("cetus"), catalogEntry("sui")],
-			[desired("sui")],
+	test("pins a card to Available only while its install is in flight", () => {
+		const initial = assignAgentPluginGroups(
+			new Map(),
+			buildAgentPluginInventory([catalogEntry("cetus"), catalogEntry("sui")], [desired("sui")]),
 		);
-		const initial = assignAgentPluginGroups(new Map(), initialInventory);
-		const changedInventory = buildAgentPluginInventory(
-			[catalogEntry("cetus"), catalogEntry("move"), catalogEntry("sui")],
-			[desired("cetus"), desired("move")],
-		);
-		const changed = assignAgentPluginGroups(initial, changedInventory);
-
 		expect(Object.fromEntries(initial)).toEqual({ cetus: "available", sui: "installed" });
-		expect(Object.fromEntries(changed)).toEqual({
-			cetus: "available",
-			move: "installed",
-			sui: "installed",
-		});
+
+		const installing = assignAgentPluginGroups(
+			initial,
+			buildAgentPluginInventory(
+				[catalogEntry("cetus"), catalogEntry("sui")],
+				[desired("sui"), desired("cetus", { convergence: "not_observed" })],
+			),
+		);
+		expect(installing.get("cetus")).toBe("available");
+
+		const settled = assignAgentPluginGroups(
+			installing,
+			buildAgentPluginInventory(
+				[catalogEntry("cetus"), catalogEntry("sui")],
+				[desired("sui"), desired("cetus")],
+			),
+		);
+		expect(settled.get("cetus")).toBe("installed");
+
+		const removed = assignAgentPluginGroups(
+			settled,
+			buildAgentPluginInventory([catalogEntry("cetus"), catalogEntry("sui")], [desired("sui")]),
+		);
+		expect(removed.get("cetus")).toBe("available");
 	});
 
 	test("maps the three observed convergence states without mutation-only states", () => {

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.ts
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.ts
@@ -85,15 +85,21 @@ export function buildAgentPluginInventory(
 		.sort((left, right) => left.name.localeCompare(right.name));
 }
 
+/**
+ * Group assignment follows live state, with one exception: a card the user
+ * just clicked Install/Update on stays in Available while the install is in
+ * flight (`not_observed`), so the grid never reshuffles mid-action. Once the
+ * install reaches a terminal state (or the plugin is removed) the card regroups.
+ */
 export function assignAgentPluginGroups(
 	previous: ReadonlyMap<string, AgentPluginGroup>,
 	inventory: readonly AgentPluginInventoryItem[],
 ): Map<string, AgentPluginGroup> {
-	const next = new Map(previous);
+	const next = new Map<string, AgentPluginGroup>();
 	for (const item of inventory) {
-		if (!next.has(item.name)) {
-			next.set(item.name, item.desired ? "installed" : "available");
-		}
+		const pinned =
+			previous.get(item.name) === "available" && item.desired?.convergence === "not_observed";
+		next.set(item.name, pinned ? "available" : item.desired ? "installed" : "available");
 	}
 	return next;
 }


### PR DESCRIPTION
## Summary

- **Status badges move from the title row to the meta line** — "Installed" / "Update available" previously crowded the card title (truncating it); they now lead the footer meta line, matching the Channels card convention (identity pills at the title, status pills in meta).
- **Group pinning narrowed to in-flight installs** — a card clicked Install stays in Available only while convergence is `not_observed`; once it reaches a terminal state (installed/failed) or is removed, it regroups. Previously an installed plugin lingered in Available with an Installed badge until the next navigation.

## Verification

- unit: agent-plugin-model 6 passed (pinning semantics rewritten: in-flight pin, terminal regroup, remove regroup)
- typecheck, Biome, e2e hosted-agent-plugins 2 passed
