### PR TITLE
release(cli): 0.13.93

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.92",
+      "version": "0.13.93",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.92",
+	"version": "0.13.93",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
CLI 0.13.93 — ships #1087 (agent plugin failure observability end-to-end, native stderr tails, hermes --no-scan with fallback) and #1072–#1089 plugins UI/UX overhaul.