### PR TITLE
fix: make project skills desired state

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -5,7 +5,6 @@ on:
     paths:
       - "backend/**"
       - "packages/whatsapp-baileys-sidecar/**"
-      - "packages/cli/package.json"
       - "packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts"
       - "packages/cli/tests/clawdi-image-release-workflow.test.ts"
       - "config/deploy.yml"
@@ -34,7 +33,6 @@ on:
     paths:
       - "backend/**"
       - "packages/whatsapp-baileys-sidecar/**"
-      - "packages/cli/package.json"
       - "packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts"
       - "packages/cli/tests/clawdi-image-release-workflow.test.ts"
       - "config/deploy.yml"
@@ -120,7 +118,6 @@ jobs:
               - ".github/workflows/backend-ci.yml"
             sidecar:
               - "packages/whatsapp-baileys-sidecar/**"
-              - "packages/cli/package.json"
               - "packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts"
               - "packages/cli/tests/clawdi-image-release-workflow.test.ts"
               - "scripts/test-kamal-whatsapp-sidecar-render.sh"
@@ -277,7 +274,6 @@ jobs:
           FROM ruby:3.4.10-bookworm@sha256:8ff02c55f0467a3d03bc6c41b7500f9f0b30086a1861c601cd4e9dc5b8536a66
           WORKDIR /repo
           COPY config/deploy.yml config/deploy.yml
-          COPY packages/cli/package.json packages/cli/package.json
           COPY scripts/deploy-whatsapp-sidecar.sh scripts/deploy-whatsapp-sidecar.sh
           COPY scripts/test-deploy-whatsapp-sidecar.sh scripts/test-deploy-whatsapp-sidecar.sh
           COPY scripts/test-kamal-whatsapp-sidecar-render.sh scripts/test-kamal-whatsapp-sidecar-render.sh

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -269,9 +269,6 @@ class Settings(BaseSettings):
     runtime_observation_replay_horizon_days: Annotated[int, Field(gt=0, le=365)] = 7
     runtime_observation_hard_retention_days: Annotated[int, Field(gt=0, le=3_650)] = 30
     runtime_observation_cleanup_batch_size: Annotated[int, Field(gt=0, le=10_000)] = 500
-    # Exact Hosted CLI package specs permitted to consume linked Project
-    # Skills. Empty is deliberately fail-closed for staged rollout.
-    project_skill_hosted_cli_package_specs: list[str] = []
 
     # Admin endpoints (POST/DELETE /v1/admin/auth/keys) auth.
     # Empty string disables them entirely (returns 503). Set in

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -110,10 +110,8 @@ class AgentEnvironment(Base, TimestampMixin):
     # OAuth CLI or unbound unmanaged API key. Historical ambiguous rows remain
     # NULL; Admin, managed, and environment-bound registration never qualify.
     connected_agent_registered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
-    # Connected Agent-only leased capability observation. Legacy V1 deployments
-    # never use it; Hosted V2 deployments prove readiness through their desired
-    # manifest and same-generation observation. Old Connected daemons cannot
-    # renew observed_at, so a downgrade expires instead of retaining evidence.
+    # Connected Agent-only compatibility observation retained for deployed CLI
+    # clients. Desired-state reads and writes do not depend on these fields.
     project_skill_reconcile_version: Mapped[int | None] = mapped_column(Integer)
     project_skill_reconcile_observed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True)

--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -33,7 +33,6 @@ from app.services.file_store import get_file_store
 from app.services.http_cache import if_none_match_contains
 from app.services.project_runtime_skills import (
     MAX_AGENT_PROJECT_SKILLS,
-    agent_supports_project_skills,
     assert_agent_project_skill_total,
     assert_project_skill_runtime_identity,
     project_skill_file_signature,
@@ -192,6 +191,8 @@ async def report_project_skill_capability(
     require_auth_scopes(auth, "skills:write")
     agent_id = _authorized_environment_id(auth, requested_environment_id)
     agent = await _connected_agent(db, auth=auth, agent_id=agent_id)
+    # Compatibility observation only; desired-state reads and writes never
+    # consult these fields.
     agent.project_skill_reconcile_version = body.project_skill_reconcile_version
     agent.project_skill_reconcile_observed_at = datetime.now(UTC)
     await db.commit()
@@ -251,20 +252,7 @@ async def get_agent_project_skills(
     """Return one Agent's complete linked-Project Skill inventory."""
     require_auth_scopes(auth, "skills:read")
     agent_id = _authorized_environment_id(auth, requested_environment_id)
-    agent = await _connected_agent(db, auth=auth, agent_id=agent_id)
-    if not agent_supports_project_skills(
-        agent,
-        None,
-        None,
-        has_environment_bound_key=False,
-    ):
-        raise HTTPException(
-            status.HTTP_409_CONFLICT,
-            detail={
-                "code": "project_skill_delivery_update_required",
-                "message": "Update this Agent, then try again.",
-            },
-        )
+    await _connected_agent(db, auth=auth, agent_id=agent_id)
     membership = ProjectMembership.__table__.alias("desired_project_skill_membership")
     rows = (
         (

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -275,15 +275,13 @@ async def _register_agent_identity(
         )
         connected_registration = hosted_state is None and environment_bound_key_id is None
     if connected_registration:
-        # This is origin evidence, not capability evidence. A current Connected
-        # Agent must still renew its separate short-lived Project Skill lease.
-        # Existing Hosted V2 state or a Legacy V1 environment-bound key is
-        # positive deployment evidence and prevents an account-level CLI token
-        # from reclassifying that durable Agent identity.
+        # This durable origin evidence authorizes Connected-only runtime APIs.
+        # Existing Hosted V2 state or a Legacy V1 environment-bound key prevents
+        # an account-level CLI token from reclassifying that Agent identity.
         registered.env.connected_agent_registered_at = datetime.now(UTC)
     else:
         # A managed or environment-bound registration is positive evidence
-        # against the Connected runtime shape; do not retain an earlier lease.
+        # against the Connected runtime shape; do not retain its observations.
         clear_connected_agent_registration(registered.env)
     await db.commit()
     return EnvironmentCreatedResponse(id=str(registered.env.id))

--- a/backend/app/services/agent_environments.py
+++ b/backend/app/services/agent_environments.py
@@ -47,7 +47,7 @@ def local_machine_registration_key(machine_id: str, agent_type: str) -> str:
 
 
 def clear_connected_agent_registration(agent: AgentEnvironment) -> None:
-    """Clear Connected-only origin and lease evidence during hosted registration."""
+    """Clear Connected-only origin and observations during hosted registration."""
 
     agent.connected_agent_registered_at = None
     agent.project_skill_reconcile_version = None

--- a/backend/app/services/project_runtime_skills.py
+++ b/backend/app/services/project_runtime_skills.py
@@ -12,36 +12,26 @@ import hmac
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 from fastapi import HTTPException, status
-from sqlalchemy import exists, func, select, text
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
 from app.models.agent_project_binding import AgentProjectBinding
-from app.models.api_key import ApiKey
-from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
+from app.models.hosted_runtime import HostedRuntimeState
 from app.models.project import PROJECT_KIND_WORKSPACE, Project
 from app.models.project_membership import ProjectMembership
 from app.models.session import AgentEnvironment
 from app.models.skill import SKILL_AUTHORITY_AGENT_SYNC, SKILL_AUTHORITY_CLOUD, Skill
 from app.schemas.runtime import PersistedHostedRuntimeSkills
-from app.schemas.runtime_observed import HostedRuntimeObservedV2
-from app.services.runtime_generation import resolve_runtime_apply_generation
 from app.services.sync_events import queue_runtime_manifest_changed
 
 # OpenClaw's native `skills install --as` contract accepts this slug shape.
 # Source keys may be namespaced. The SKILL.md name is the local install identity
 # and must fit the strictest native runtime contract.
 RUNTIME_PROJECT_SKILL_LOCAL_KEY_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
-PROJECT_SKILL_RECONCILE_VERSION = 1
-# The Connected daemon renews every four to six minutes. Ten minutes provides
-# normal retry margin while still closing stale or downgraded Agents promptly.
-CONNECTED_PROJECT_SKILL_CAPABILITY_TTL = timedelta(minutes=10)
 MAX_AGENT_PROJECT_SKILLS = 1000
-_CONNECTED_PROJECT_SKILL_AGENT_TYPES = frozenset({"claude_code", "codex", "hermes", "openclaw"})
 
 
 @dataclass(frozen=True)
@@ -365,15 +355,22 @@ async def _assert_agent_accepts_project_skills(
         if len(source_skill_keys) > 1
     }
 
-    agent, state, observation, has_environment_bound_key = await _agent_runtime_delivery_evidence(
-        db, agent_id=agent_id
-    )
-    _assert_agent_supports_project_skills(
-        agent,
-        state,
-        observation,
-        has_environment_bound_key=has_environment_bound_key,
-    )
+    row = (
+        await db.execute(
+            select(AgentEnvironment, HostedRuntimeState)
+            .outerjoin(
+                HostedRuntimeState,
+                HostedRuntimeState.environment_id == AgentEnvironment.id,
+            )
+            .where(
+                AgentEnvironment.id == agent_id,
+                AgentEnvironment.archived_at.is_(None),
+            )
+        )
+    ).first()
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
+    agent, state = row
 
     workspace_skill_keys = (
         _runtime_state_skill_keys(state)
@@ -401,162 +398,6 @@ async def _assert_agent_accepts_project_skills(
             ),
             "skill_key": skill_key,
         },
-    )
-
-
-async def _assert_agent_project_skill_delivery_supported(
-    db: AsyncSession,
-    *,
-    agent_id: UUID,
-) -> None:
-    agent, state, observation, has_environment_bound_key = await _agent_runtime_delivery_evidence(
-        db, agent_id=agent_id
-    )
-    _assert_agent_supports_project_skills(
-        agent,
-        state,
-        observation,
-        has_environment_bound_key=has_environment_bound_key,
-    )
-
-
-async def _agent_runtime_delivery_evidence(
-    db: AsyncSession,
-    *,
-    agent_id: UUID,
-) -> tuple[
-    AgentEnvironment,
-    HostedRuntimeState | None,
-    HostedRuntimeConfigObservation | None,
-    bool,
-]:
-    has_environment_bound_key = exists().where(
-        ApiKey.environment_id == AgentEnvironment.id,
-    )
-    row = (
-        await db.execute(
-            select(
-                AgentEnvironment,
-                HostedRuntimeState,
-                HostedRuntimeConfigObservation,
-                has_environment_bound_key,
-            )
-            .outerjoin(
-                HostedRuntimeState,
-                HostedRuntimeState.environment_id == AgentEnvironment.id,
-            )
-            .outerjoin(
-                HostedRuntimeConfigObservation,
-                HostedRuntimeConfigObservation.environment_id == AgentEnvironment.id,
-            )
-            .where(
-                AgentEnvironment.id == agent_id,
-                AgentEnvironment.archived_at.is_(None),
-            )
-        )
-    ).first()
-    if row is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
-    return row[0], row[1], row[2], row[3]
-
-
-def _assert_agent_supports_project_skills(
-    agent: AgentEnvironment,
-    state: HostedRuntimeState | None,
-    observation: HostedRuntimeConfigObservation | None,
-    *,
-    has_environment_bound_key: bool,
-) -> None:
-    if not agent_supports_project_skills(
-        agent,
-        state,
-        observation,
-        has_environment_bound_key=has_environment_bound_key,
-    ):
-        raise HTTPException(
-            status.HTTP_409_CONFLICT,
-            detail={
-                "code": "project_skill_delivery_update_required",
-                "message": "Update this Agent, then try again.",
-            },
-        )
-
-
-def agent_supports_project_skills(
-    agent: AgentEnvironment,
-    state: HostedRuntimeState | None,
-    observation: HostedRuntimeConfigObservation | None,
-    *,
-    has_environment_bound_key: bool,
-) -> bool:
-    """Require evidence from exactly one authoritative Agent runtime shape."""
-    if state is not None:
-        if state.cli_package_spec not in settings.project_skill_hosted_cli_package_specs:
-            return False
-        if observation is None or observation.observed_at is None:
-            return False
-        now = datetime.now(UTC)
-        observed_at = observation.observed_at
-        if observed_at.tzinfo is None:
-            observed_at = observed_at.replace(tzinfo=UTC)
-        if now - observed_at > timedelta(seconds=settings.runtime_observation_freshness_seconds):
-            return False
-        if agent.last_sync_at is None or agent.last_sync_error:
-            return False
-        last_sync_at = agent.last_sync_at
-        if last_sync_at.tzinfo is None:
-            last_sync_at = last_sync_at.replace(tzinfo=UTC)
-        if now - last_sync_at > timedelta(seconds=settings.runtime_observation_freshness_seconds):
-            return False
-        try:
-            diagnostics = HostedRuntimeObservedV2.model_validate(observation.diagnostics)
-        except ValueError:
-            return False
-        expected_version = state.cli_package_spec.removeprefix("clawdi@")
-        expected_generation = resolve_runtime_apply_generation(
-            generation=state.generation,
-            apply_generation=state.apply_generation,
-        )
-        return bool(
-            diagnostics.status == "ok"
-            and diagnostics.converge_error is None
-            and diagnostics.active_cli_version == expected_version
-            and diagnostics.applied is not None
-            and diagnostics.applied.instance_id == state.instance_id
-            and diagnostics.applied.generation == expected_generation
-            and observation.observed_config_generation == expected_generation
-            and observation.observed_manifest_etag == diagnostics.applied.etag
-            and observation.observed_source_revision == diagnostics.applied.source_revision
-        )
-
-    # Explicit hosted identities without Hosted V2 state are Legacy V1
-    # deployments (or incomplete provisioning), never Connected fallbacks.
-    if agent.registration_key is None:
-        return False
-
-    # registration_key is necessary but not sufficient: historical Admin
-    # registration without an explicit id created the same key for Legacy V1
-    # Hosted deployments. Only a fresh current self-managed registration writes
-    # this positive Connected origin marker; ambiguous historical rows remain
-    # NULL and fail closed even if old environment-bound keys are later removed.
-    if agent.connected_agent_registered_at is None:
-        return False
-
-    # A persisted environment-bound workload key is independent positive
-    # evidence against the Connected path. Its absence is never used as proof.
-    if has_environment_bound_key:
-        return False
-
-    observed_at = agent.project_skill_reconcile_observed_at
-    if observed_at is None:
-        return False
-    if observed_at.tzinfo is None:
-        observed_at = observed_at.replace(tzinfo=UTC)
-    age = datetime.now(UTC) - observed_at
-    return (
-        agent.agent_type in _CONNECTED_PROJECT_SKILL_AGENT_TYPES
-        and agent.project_skill_reconcile_version == PROJECT_SKILL_RECONCILE_VERSION
-        and timedelta(0) <= age <= CONNECTED_PROJECT_SKILL_CAPABILITY_TTL
     )
 
 
@@ -590,23 +431,19 @@ async def assert_project_skill_write_compatible(
 ) -> list[UUID]:
     """Lock the graph and prove a Cloud Skill write has one runtime owner."""
     agent_ids = await lock_project_runtime_graph(db, project_id)
-    proposed_identities: tuple[ProjectSkillRuntimeIdentity, ...] = ()
     if local_skill_key is not None:
         proposed_identities = tuple(
             identity
             for identity in await _project_skill_identities(db, project_id)
             if identity.source_skill_key != skill_key
         ) + (project_skill_runtime_identity(skill_key, local_skill_key),)
-    for agent_id in agent_ids:
-        if local_skill_key is None:
-            await _assert_agent_project_skill_delivery_supported(db, agent_id=agent_id)
-            continue
-        await _assert_agent_accepts_project_skills(
-            db,
-            agent_id=agent_id,
-            project_id=project_id,
-            skill_identities=proposed_identities,
-        )
+        for agent_id in agent_ids:
+            await _assert_agent_accepts_project_skills(
+                db,
+                agent_id=agent_id,
+                project_id=project_id,
+                skill_identities=proposed_identities,
+            )
     if enforce_total_limit:
         await _assert_project_skill_write_capacity(
             db,

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -78,7 +78,6 @@ from app.services.managed_ai_provider import (
 )
 from app.services.project_runtime_skills import (
     RUNTIME_PROJECT_SKILL_LOCAL_KEY_PATTERN,
-    agent_supports_project_skills,
     project_skill_file_signature,
     project_skill_runtime_identity,
 )
@@ -400,19 +399,7 @@ async def load_runtime_source_batch(
     project_skills: dict[UUID, list[RuntimeProjectSkill]] = {}
     for environment_id, skill in project_skill_rows:
         runtime_row = rows.get(environment_id)
-        if (
-            runtime_row is None
-            or runtime_row.state is None
-            or not agent_supports_project_skills(
-                runtime_row.environment,
-                runtime_row.state,
-                runtime_row.observation,
-                has_environment_bound_key=False,
-            )
-        ):
-            # Existing Vault-only bindings predate Project Skill delivery. Keep
-            # those links usable, but never render the new source shape until
-            # this exact Hosted V2 deployment has proven a compatible, Ready CLI.
+        if runtime_row is None or runtime_row.state is None:
             continue
         project_skills.setdefault(environment_id, []).append(
             RuntimeProjectSkill(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -102,7 +102,6 @@ def _test_runtime_settings():
     prev_channel_long_poll_max = settings.channel_long_poll_max_seconds
     prev_channel_long_poll_interval = settings.channel_long_poll_interval_seconds
     prev_discord_gateway_poll_interval = settings.discord_gateway_poll_interval_seconds
-    prev_project_skill_specs = settings.project_skill_hosted_cli_package_specs
     prev_plugin_catalog_sync_enabled = settings.plugin_catalog_sync_enabled
     settings.vault_encryption_key = secrets.token_hex(32)
     settings.encryption_key = secrets.token_hex(32)
@@ -110,7 +109,6 @@ def _test_runtime_settings():
     settings.channel_long_poll_max_seconds = 0.05
     settings.channel_long_poll_interval_seconds = 0.005
     settings.discord_gateway_poll_interval_seconds = 0.01
-    settings.project_skill_hosted_cli_package_specs = ["clawdi@1.2.3-test"]
     settings.plugin_catalog_sync_enabled = False
     try:
         yield
@@ -121,7 +119,6 @@ def _test_runtime_settings():
         settings.channel_long_poll_max_seconds = prev_channel_long_poll_max
         settings.channel_long_poll_interval_seconds = prev_channel_long_poll_interval
         settings.discord_gateway_poll_interval_seconds = prev_discord_gateway_poll_interval
-        settings.project_skill_hosted_cli_package_specs = prev_project_skill_specs
         settings.plugin_catalog_sync_enabled = prev_plugin_catalog_sync_enabled
 
 

--- a/backend/tests/test_project_runtime_skills.py
+++ b/backend/tests/test_project_runtime_skills.py
@@ -25,7 +25,6 @@ from app.routes import skills as skill_routes
 from app.routes.skills import _compute_file_tree_hash
 from app.services import project_runtime_skills
 from app.services.file_store import get_file_store
-from app.services.project_runtime_skills import CONNECTED_PROJECT_SKILL_CAPABILITY_TTL
 from app.services.runtime_source import (
     load_runtime_source_batch,
     render_runtime_source,
@@ -213,7 +212,7 @@ async def test_linked_project_skill_is_composed_into_managed_runtime_manifest(
 
 
 @pytest.mark.asyncio
-async def test_connected_project_skill_desired_inventory_uses_local_name(
+async def test_connected_project_skill_desired_inventory_ignores_capability_observation(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user: User,
@@ -236,6 +235,11 @@ async def test_connected_project_skill_desired_inventory_uses_local_name(
         agent_id=agent_id,
     )
     assert capability.status_code == 204, capability.text
+    agent = await db_session.get(AgentEnvironment, agent_id)
+    assert agent is not None
+    agent.project_skill_reconcile_version = None
+    agent.project_skill_reconcile_observed_at = None
+    await db_session.commit()
     linked = await _link(client, agent_id=agent_id, project_id=workspace_project.id)
     assert linked.status_code == 200, linked.text
 
@@ -330,7 +334,7 @@ async def test_link_fails_closed_for_workspace_and_sibling_project_skill_conflic
 
 
 @pytest.mark.asyncio
-async def test_connected_agent_and_project_skill_write_fail_before_mutation(
+async def test_connected_desired_state_ignores_capability_lease_but_preserves_conflicts(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user: User,
@@ -350,16 +354,12 @@ async def test_connected_agent_and_project_skill_write_fail_before_mutation(
         )
     )
     await db_session.commit()
-    connected_conflict = await _link(
+    connected_link = await _link(
         client,
         agent_id=environment_project.origin_environment_id,
         project_id=workspace_project.id,
     )
-    assert connected_conflict.status_code == 409, connected_conflict.text
-    assert connected_conflict.json()["detail"] == {
-        "code": "project_skill_delivery_update_required",
-        "message": "Update this Agent, then try again.",
-    }
+    assert connected_link.status_code == 200, connected_link.text
 
     capability = await _report_connected_project_skill_capability(
         client,
@@ -417,13 +417,6 @@ async def test_connected_agent_and_project_skill_write_fail_before_mutation(
         )
     ).scalar_one_or_none() is None
 
-    connected_link = await _link(
-        client,
-        agent_id=environment_project.origin_environment_id,
-        project_id=workspace_project.id,
-    )
-    assert connected_link.status_code == 200, connected_link.text
-
     duplicate_local_name = await _upload_project_skill(
         client,
         workspace_project.id,
@@ -433,10 +426,8 @@ async def test_connected_agent_and_project_skill_write_fail_before_mutation(
     assert duplicate_local_name.status_code == 409, duplicate_local_name.text
     assert duplicate_local_name.json()["detail"]["code"] == "project_skill_name_conflict"
 
-    # A downgraded Connected Agent still emits the byte-frozen heartbeat contract,
-    # but it cannot renew the separate Project Skill lease. Once that observation
-    # is stale, every graph mutation fails closed without disturbing the existing
-    # linked Project or its Vault access.
+    # The capability report remains observable for old clients, but its freshness
+    # is not a precondition for control-plane desired-state changes.
     downgraded = await client.post(
         f"/v1/agents/{environment_project.origin_environment_id}/sync-heartbeat",
         json={},
@@ -449,28 +440,25 @@ async def test_connected_agent_and_project_skill_write_fail_before_mutation(
     assert connected_agent is not None
     assert connected_agent.connected_agent_registered_at is not None
     assert connected_agent.project_skill_reconcile_version == 1
-    connected_agent.project_skill_reconcile_observed_at = (
-        datetime.now(UTC) - CONNECTED_PROJECT_SKILL_CAPABILITY_TTL - timedelta(seconds=1)
-    )
+    connected_agent.project_skill_reconcile_observed_at = datetime.now(UTC) - timedelta(days=1)
     await db_session.commit()
-    rejected_connected_write = await _upload_project_skill(
+    created_with_stale_lease = await _upload_project_skill(
         client,
         workspace_project.id,
         "after-downgrade",
     )
-    assert rejected_connected_write.status_code == 409, rejected_connected_write.text
-    assert rejected_connected_write.json()["detail"] == {
-        "code": "project_skill_delivery_update_required",
-        "message": "Update this Agent, then try again.",
-    }
-    rejected_connected_delete = await client.delete(
+    assert created_with_stale_lease.status_code == 200, created_with_stale_lease.text
+    updated_with_stale_lease = await _upload_project_skill(
+        client,
+        workspace_project.id,
+        "managed-only",
+        marker="Updated with stale lease",
+    )
+    assert updated_with_stale_lease.status_code == 200, updated_with_stale_lease.text
+    deleted_with_stale_lease = await client.delete(
         f"/v1/projects/{workspace_project.id}/skills/managed-only"
     )
-    assert rejected_connected_delete.status_code == 409, rejected_connected_delete.text
-    assert rejected_connected_delete.json()["detail"] == {
-        "code": "project_skill_delivery_update_required",
-        "message": "Update this Agent, then try again.",
-    }
+    assert deleted_with_stale_lease.status_code == 200, deleted_with_stale_lease.text
     assert (
         await db_session.execute(
             select(Skill).where(
@@ -479,7 +467,7 @@ async def test_connected_agent_and_project_skill_write_fail_before_mutation(
                 Skill.is_active,
             )
         )
-    ).scalar_one_or_none() is not None
+    ).scalar_one_or_none() is None
 
     _set_auth(
         AuthContext(
@@ -561,7 +549,7 @@ async def test_connected_capability_report_rejects_hosted_v2_deployment(
 
 
 @pytest.mark.asyncio
-async def test_legacy_v1_hosted_identity_cannot_report_or_read_project_desired(
+async def test_legacy_v1_hosted_identity_cannot_use_connected_runtime_endpoints(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user: User,
@@ -663,29 +651,32 @@ async def test_legacy_v1_hosted_identity_cannot_report_or_read_project_desired(
 
     uploaded = await _upload_project_skill(client, workspace_project.id, "legacy-v1-closed")
     assert uploaded.status_code == 200, uploaded.text
-    rejected_link = await _link(
+    linked = await _link(
         client,
         agent_id=legacy_v1_agent_id,
         project_id=workspace_project.id,
     )
-    assert rejected_link.status_code == 409, rejected_link.text
-    assert rejected_link.json()["detail"]["code"] == "project_skill_delivery_update_required"
+    assert linked.status_code == 200, linked.text
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("unsupported_evidence", ["unobserved", "old-cli"])
-async def test_unsupported_hosted_v2_deployment_rejects_link_and_project_skill_render(
+@pytest.mark.parametrize(
+    "runtime_evidence", ["missing-observation", "stale-observation", "old-cli"]
+)
+async def test_hosted_desired_state_ignores_runtime_evidence(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user: User,
     workspace_project: Project,
     channel_agent,
-    unsupported_evidence: str,
+    runtime_evidence: str,
 ):
     observation = await db_session.get(HostedRuntimeConfigObservation, channel_agent.id)
     assert observation is not None
-    if unsupported_evidence == "unobserved":
+    if runtime_evidence == "missing-observation":
         await db_session.delete(observation)
+    elif runtime_evidence == "stale-observation":
+        observation.observed_at = datetime.now(UTC) - timedelta(days=1)
     else:
         state = await db_session.get(HostedRuntimeState, channel_agent.id)
         assert state is not None
@@ -694,16 +685,12 @@ async def test_unsupported_hosted_v2_deployment_rejects_link_and_project_skill_r
     uploaded = await _upload_project_skill(client, workspace_project.id, "needs-ready-agent")
     assert uploaded.status_code == 200, uploaded.text
 
-    rejected = await _link(
+    linked = await _link(
         client,
         agent_id=channel_agent.id,
         project_id=workspace_project.id,
     )
-    assert rejected.status_code == 409, rejected.text
-    assert rejected.json()["detail"] == {
-        "code": "project_skill_delivery_update_required",
-        "message": "Update this Agent, then try again.",
-    }
+    assert linked.status_code == 200, linked.text
     assert (
         await db_session.execute(
             select(AgentProjectBinding).where(
@@ -711,22 +698,15 @@ async def test_unsupported_hosted_v2_deployment_rejects_link_and_project_skill_r
                 AgentProjectBinding.project_id == workspace_project.id,
             )
         )
-    ).scalar_one_or_none() is None
+    ).scalar_one_or_none() is not None
 
-    # Links created before this source shape existed may already be present.
-    # Preserve their Vault access, but do not expose Project Skill intent to an
-    # old or unobserved Hosted V2 CLI merely because the binding row exists.
-    db_session.add(
-        AgentProjectBinding(
-            agent_id=channel_agent.id,
-            project_id=workspace_project.id,
-            binding_type="context",
-            priority=1,
-            default_write_enabled=False,
-            created_by_user_id=seed_user.id,
-        )
+    updated = await _upload_project_skill(
+        client,
+        workspace_project.id,
+        "needs-ready-agent",
+        marker="Updated desired state",
     )
-    await db_session.commit()
+    assert updated.status_code == 200, updated.text
     await _make_runtime_renderable(
         db_session,
         user=seed_user,
@@ -745,7 +725,7 @@ async def test_unsupported_hosted_v2_deployment_rejects_link_and_project_skill_r
         decrypt_secrets=False,
     )
     entries = rendered.manifest.get("skills", {}).get("entries", {})
-    assert "needs-ready-agent" not in entries
+    assert entries["needs-ready-agent"]["source"]["contentHash"] == updated.json()["content_hash"]
 
 
 @pytest.mark.asyncio

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -9,13 +9,6 @@
 # runtime shape lives here. The image entrypoint (app.runtime_entrypoint)
 # selects the process via CLAWDI_PROCESS_ROLE, runs migrations for the api
 # role, and drains on SIGTERM — no command overrides needed.
-<%
-require "json"
-clawdi_cli_version = JSON.parse(
-  File.read("packages/cli/package.json", encoding: Encoding::UTF_8)
-).fetch("version")
-%>
-
 service: clawdi
 image: clawdi-ai/clawdi-backend
 
@@ -312,8 +305,6 @@ env:
     CORS_ORIGINS: '["https://www.clawdi.ai","https://clawdi.ai","https://api.clawdi.ai","https://cloud.clawdi.ai"]'
     TRUST_FORWARDED_FOR: "true"
     PLUGIN_CATALOG_SYNC_ENABLED: "true"
-    # The CLI package manifest is the version authority; do not duplicate its release pin.
-    PROJECT_SKILL_HOSTED_CLI_PACKAGE_SPECS: '["clawdi@<%= clawdi_cli_version %>"]'
     FILE_STORE_TYPE: s3
     MEMORY_EMBEDDING_MODE: local
     DB_POOL_SIZE: 20

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -215,12 +215,11 @@ invalidate the affected managed Agent desired state.
 Skill keys have no precedence across the Agent Workspace and linked Projects.
 The link or write transaction rejects a duplicate key before changing the
 binding, Skill row, or object-store content and tells the user to remove or
-rename one copy. A connected Agent must advertise the exact Project Skill
-reconcile capability in every heartbeat. Hosted requires an allowlisted exact
-CLI package specification plus a fresh, successful observation of that CLI
-applying the current generation. Missing, stale, or downgraded evidence fails
-closed with an update action before Link or a later Project Skill write. An
-empty Project can still be linked for Vault access.
+rename one copy. Link, unlink, and Project Skill writes change control-plane
+desired state regardless of CLI package version, runtime availability,
+observation freshness, or reconcile lease. Runtime convergence and health are
+reported separately and never gate those changes. An empty Project can still
+be linked for Vault access.
 
 Project owners may rename, edit the description, and archive their Projects.
 Archival removes all Agent links immediately while retaining historical
@@ -420,12 +419,11 @@ and returned by
 before and after installation. Any target or byte mismatch rolls back instead
 of creating a second writer.
 
-Rollout is deliberately capability-first: ship the compatible CLI, wait for
-fresh same-generation readiness observations, configure the exact Hosted CLI
-package-spec allowlist (which defaults empty), and only then permit
-Skill-bearing Project links. Connected daemons advertise the capability only
-after the reconcile implementation is present; older daemons remain
-unavailable. No runtime name or unobserved desired row is capability evidence.
+Hosted manifests render linked Project Skills for every `HostedRuntimeState`;
+Connected inventory returns them after Connected identity and authorization
+validation. Capability reports remain a deployed-client-compatible observation
+only. Runtime reconciliation handles convergence without changing desired-state
+eligibility.
 
 The detailed contract is [`managed-runtime.md`](managed-runtime.md). This
 architecture page should not duplicate that runtime specification.

--- a/packages/cli/tests/clawdi-image-release-workflow.test.ts
+++ b/packages/cli/tests/clawdi-image-release-workflow.test.ts
@@ -108,7 +108,6 @@ describe("backend image release workflow contract", () => {
 		const filterStep = backendCi.jobs.changes?.steps?.find((step) => step.id === "filter");
 		const filters = String(filterStep?.with?.filters);
 		const backendFilter = filters.slice(filters.indexOf("backend:\n"), filters.indexOf("test:\n"));
-		const sidecarFilter = filters.slice(filters.indexOf("sidecar:\n"));
 
 		expect(backendCi.jobs["lint-and-typecheck"]?.if).toBe(
 			"needs.changes.outputs.backend == 'true'",
@@ -124,12 +123,10 @@ describe("backend image release workflow contract", () => {
 		}
 		for (const path of [
 			"packages/whatsapp-baileys-sidecar/**",
-			"packages/cli/package.json",
 			"scripts/deploy-whatsapp-sidecar.sh",
 		]) {
 			expect(backendFilter).not.toContain(`- "${path}"`);
 		}
-		expect(sidecarFilter).toContain('- "packages/cli/package.json"');
 	});
 
 	test("coalesces main Backend CI only inside its image-input path gate", () => {
@@ -138,7 +135,6 @@ describe("backend image release workflow contract", () => {
 			expect.arrayContaining([
 				"backend/**",
 				"packages/whatsapp-baileys-sidecar/**",
-				"packages/cli/package.json",
 				"config/deploy.yml",
 				".dockerignore",
 				"packages/shared/src/api/api.generated.ts",
@@ -149,7 +145,6 @@ describe("backend image release workflow contract", () => {
 				".github/workflows/clawdi-image-release.yml",
 			]),
 		);
-		expect(backendCi.on?.pull_request?.paths).toContain("packages/cli/package.json");
 		expect(backendCi.on?.push?.paths).not.toContain("**");
 		expect(backendCi.on?.push?.paths).not.toContain("apps/web/src/**");
 		expect(backendCi.concurrency?.["cancel-in-progress"]).toBe(
@@ -241,10 +236,10 @@ describe("backend image release workflow contract", () => {
 		expect(releaseRunbook).not.toContain("immutable OCI image tag");
 	});
 
-	test("classifies the CLI manifest as deployment-only without circular release inputs", () => {
+	test("keeps CLI and release orchestration outside every automatic image release input", () => {
 		const baseline = calculateClawdiImageRevisions(repoRoot);
 		const probeVersion = `${cliVersion}-image-release-probe`;
-		const cliHead = calculateClawdiImageRevisions(
+		const head = calculateClawdiImageRevisions(
 			repoRoot,
 			new Map([
 				[
@@ -255,24 +250,6 @@ describe("backend image release workflow contract", () => {
 						`"version": "${probeVersion}"`,
 					),
 				],
-			]),
-		);
-		const cliPlan = classifyClawdiImageRelease({
-			base: baseline,
-			baseSha: "a".repeat(40),
-			head: cliHead,
-			headSha: "b".repeat(40),
-		});
-
-		expect(cliHead.backend).toBe(baseline.backend);
-		expect(cliHead.deployment).not.toBe(baseline.deployment);
-		expect(cliHead.sidecar).toBe(baseline.sidecar);
-		expect(cliPlan.changed).toEqual({ backend: false, deployment: true, sidecar: false });
-		expect(cliPlan.releaseRequired).toBe(true);
-
-		const ignoredHead = calculateClawdiImageRevisions(
-			repoRoot,
-			new Map([
 				[
 					"bun.lock",
 					replaceOnce(lockfileSource, `"version": "${cliVersion}"`, `"version": "${probeVersion}"`),
@@ -288,16 +265,16 @@ describe("backend image release workflow contract", () => {
 				["scripts/clawdi-image-release-plan.ts", `${releaseClassifierSource}\n// probe\n`],
 			]),
 		);
-		const ignoredPlan = classifyClawdiImageRelease({
+		const plan = classifyClawdiImageRelease({
 			base: baseline,
 			baseSha: "a".repeat(40),
-			head: ignoredHead,
+			head,
 			headSha: "b".repeat(40),
 		});
 
-		expect(ignoredHead).toEqual(baseline);
-		expect(ignoredPlan.changed).toEqual({ backend: false, deployment: false, sidecar: false });
-		expect(ignoredPlan.releaseRequired).toBe(false);
+		expect(head).toEqual(baseline);
+		expect(plan.changed).toEqual({ backend: false, deployment: false, sidecar: false });
+		expect(plan.releaseRequired).toBe(false);
 
 		const releaseGate = "steps.release-plan.outputs.release_required == 'true'";
 		for (const name of [

--- a/scripts/clawdi-image-release-plan.ts
+++ b/scripts/clawdi-image-release-plan.ts
@@ -15,7 +15,6 @@ const IMAGE_RELEASE_WORKFLOW = ".github/workflows/clawdi-image-release.yml";
 const DEPLOYMENT_FILE_INPUTS = [
 	".github/actions/setup-bun-ci/action.yml",
 	"config/deploy.yml",
-	"packages/cli/package.json",
 	"scripts/deploy-whatsapp-sidecar.sh",
 ] as const;
 

--- a/scripts/test-kamal-whatsapp-sidecar-render.sh
+++ b/scripts/test-kamal-whatsapp-sidecar-render.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-export LC_ALL=C
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 render_root="$(mktemp -d)"
@@ -13,12 +12,9 @@ cleanup() {
 }
 trap cleanup EXIT
 
-test "$(ruby -e 'print Encoding.default_external.name')" = "US-ASCII"
 test "$(kamal version)" = "2.12.0"
 mkdir -p "${render_root}/config" "${render_root}/.kamal"
 cp "${repo_root}/config/deploy.yml" "${render_root}/config/deploy.yml"
-mkdir -p "${render_root}/packages/cli"
-cp "${repo_root}/packages/cli/package.json" "${render_root}/packages/cli/package.json"
 
 secret_keys=(
 	KAMAL_REGISTRY_USERNAME
@@ -131,7 +127,6 @@ RUBY
 		DEPLOY_IMAGE_VERSION="${expected_version}" \
 		ruby - "${render_root}/config/deploy.yml" "${expected_version}" <<'RUBY'
 require "kamal"
-require "json"
 require "pathname"
 
 config_path, expected_version = ARGV
@@ -142,13 +137,6 @@ config = Kamal::Configuration.create_from(
 expected_logging_args = [ "--log-driver", '"journald"' ]
 
 raise "top-level logging did not render journald" unless config.logging_args == expected_logging_args
-cli_version = JSON.parse(
-  File.read("packages/cli/package.json", encoding: Encoding::UTF_8)
-).fetch("version")
-expected_project_skill_specs = [ "clawdi@#{cli_version}" ].to_json
-unless config.raw_config.dig("env", "clear", "PROJECT_SKILL_HOSTED_CLI_PACKAGE_SPECS") == expected_project_skill_specs
-  raise "Project Skill Hosted CLI package specs drifted from packages/cli/package.json"
-end
 config.roles.each do |role|
   raise "#{role.name} logging drifted" unless role.logging_args == expected_logging_args
 end


### PR DESCRIPTION
## Summary

- treat Project links and Project Skill writes as control-plane desired state, independent of CLI version, runtime readiness, observation freshness, or Connected capability lease
- render linked Project Skills for every Hosted runtime state and return Connected desired inventory after identity and scope checks
- retain the deployed capability observation contract while removing the package-spec allowlist and its deployment/release coupling
- preserve Project Skill name conflicts, capacity limits, graph locking, atomicity, signatures, and runtime invalidation

## Verification

- Docker PostgreSQL Project Skill/link suite: 15 passed
- Docker CLI release workflow contract: 13 passed, 0 failed
- Docker Kamal 2.12 render/deploy contract
- Ruff lint/format, Biome, generated API consistency, and diff checks