### PR TITLE
fix(skills): accept deep legacy hidden paths

### DIFF
--- a/backend/app/core/skill_key.py
+++ b/backend/app/core/skill_key.py
@@ -41,13 +41,14 @@ def is_valid_skill_key(skill_key: str) -> bool:
 
 
 def is_legacy_hidden_skill_key(skill_key: str) -> bool:
-    """Accept only otherwise-valid keys with dot-prefixed components."""
+    """Accept safe dot-prefixed metadata paths without the stored-key depth cap."""
     parts = skill_key.split("/")
     visible_key = "/".join(part.removeprefix(".") for part in parts)
     return (
         len(skill_key) <= MAX_SKILL_KEY_LEN
         and visible_key != skill_key
-        and is_valid_skill_key(visible_key)
+        and all(is_valid_skill_key(part.removeprefix(".")) for part in parts)
+        and not has_reserved_skill_key_suffix(visible_key)
     )
 
 

--- a/backend/tests/test_skill_authority.py
+++ b/backend/tests/test_skill_authority.py
@@ -343,7 +343,10 @@ async def test_legacy_hidden_project_upload_requires_authentication(
 ):
     response = await anon_client.post(
         f"/api/projects/{environment_project.id}/skills/upload",
-        data={"skill_key": "archive/.system/tool", "content_hash": "a" * 64},
+        data={
+            "skill_key": ".archive/curator/mlops/inference/llama-cpp",
+            "content_hash": "a" * 64,
+        },
         files={"file": ("metadata.tar.gz", b"not materializable", "application/gzip")},
     )
 
@@ -358,7 +361,7 @@ async def test_generic_agent_project_upload_truthfully_ignores_legacy_hidden_met
     seed_project: Project,
     environment_project,
 ):
-    skill_key = "archive/.system/tool"
+    skill_key = ".archive/curator/mlops/inference/llama-cpp"
     data = {"skill_key": skill_key, "content_hash": "a" * 64}
     files = {"file": ("metadata.tar.gz", b"not materializable", "application/gzip")}
 


### PR DESCRIPTION
## Summary
- validate legacy hidden metadata keys component by component
- preserve the 200-character limit, route suffix protection, and canonical Skill depth cap
- cover the deep `.archive/...` path shape emitted by legacy Hosted V1 runtimes

## Verification
- isolated Docker/PostgreSQL: 51 focused tests passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`
