### PR TITLE
fix(runtime): bind hermes plugin installs to the verified commit

### DIFF
--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
@@ -145,7 +145,12 @@ class FakeNativeRunner implements HostedAgentPluginCommandRunner {
 
 	run(input: CommandInput) {
 		this.calls.push(input);
-		if (input.command === "git") return { status: 0, stdout: "", stderr: "" };
+		if (input.command === "git") {
+			if (input.args.includes("rev-parse")) {
+				return { status: 0, stdout: `${"9".repeat(40)}\n`, stderr: "" };
+			}
+			return { status: 0, stdout: "", stderr: "" };
+		}
 		const runtime = this.runtime(input);
 		const expectedStateRoot = join(input.home, runtime === "openclaw" ? ".openclaw" : ".hermes");
 		const actualStateRoot =
@@ -607,6 +612,7 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 		);
 		expect(install?.args[2]?.startsWith("file://")).toBe(true);
 		expect(install?.args).toContain("--no-scan");
+		expect(install?.args.slice(install.args.indexOf("--ref") + 1)[0]).toBe("9".repeat(40));
 		expect(install?.args.join(" ")).not.toContain("github.com");
 		expect(install?.environmentOverrides).toEqual({
 			OPENCLAW_HOME: undefined,

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
@@ -408,7 +408,7 @@ function initializeLocalGitTransport(
 	runtime: HostedAgentPluginRuntime,
 	home: string,
 	sourceDir: string,
-): void {
+): string {
 	const gitEnvironment = {
 		...isolatedNativeEnvironment(runtime, home),
 		...isolatedGitEnvironment,
@@ -431,6 +431,18 @@ function initializeLocalGitTransport(
 		});
 		if (result.status !== 0) throw new Error("Hermes local Agent Plugin transport failed");
 	}
+	const head = runner.run({
+		command: "git",
+		args: ["-C", sourceDir, "rev-parse", "HEAD"],
+		home,
+		cwd: sourceDir,
+		environmentOverrides: gitEnvironment,
+	});
+	const revision = head.status === 0 ? head.stdout.trim() : "";
+	if (!/^[0-9a-f]{40}$/.test(revision)) {
+		throw new Error("Hermes local Agent Plugin transport returned no revision");
+	}
+	return revision;
 }
 
 function createHermesDriver(input: {
@@ -485,19 +497,23 @@ function createHermesDriver(input: {
 		observe,
 		install(prepared) {
 			withPreparedAgentPluginDirectory(prepared, (sourceDir) => {
-				initializeLocalGitTransport(input.runner, "hermes", input.home, sourceDir);
+				const revision = initializeLocalGitTransport(input.runner, "hermes", input.home, sourceDir);
+				// Store plugins are digest-verified by the control plane, so bind the
+				// native install to the verified commit and skip the community-plugin
+				// content scan when the runtime supports it.
 				const args = [
 					"plugins",
 					"install",
 					pathToFileURL(sourceDir).href,
 					"--force",
 					"--no-enable",
+					"--ref",
+					revision,
+					"--no-scan",
 				];
-				// Store plugins are digest-verified by the control plane, so the native
-				// community-plugin security scan is skipped when the runtime supports it.
-				let result = run([...args, "--no-scan"]);
+				let result = run(args);
 				if (result.status !== 0 && result.stderr.includes("unrecognized arguments")) {
-					result = run(args);
+					result = run(args.filter((arg) => arg !== "--no-scan"));
 				}
 				if (result.status !== 0) {
 					throw nativeCommandFailure("Hermes native Agent Plugin install failed", result);


### PR DESCRIPTION
## Summary

Follow-up to #1087, aligning with the revised upstream interface (NousResearch/hermes-agent#89704 v2): `--no-scan` there requires an immutable `--ref`, so the local git transport now returns the prepared commit SHA and the Hermes install binds to it:

- `initializeLocalGitTransport` resolves and returns `rev-parse HEAD` (fail-closed if git reports no revision)
- Hermes install passes `--ref <sha> --no-scan`; runtimes without the flag fall back to a plain install as before

## Verification

- bun test runtime plugin suites: 21 passed (asserts `--ref` carries the prepared commit and the fallback drops only `--no-scan`)
- Biome, tsc clean
