### PR TITLE
fix(runtime): disable hermes plugin install scanning via managed config

### DIFF
--- a/packages/cli/src/lib/hermes-config-merge.ts
+++ b/packages/cli/src/lib/hermes-config-merge.ts
@@ -182,6 +182,28 @@ function valueAtPath(value: unknown, path: readonly string[]): unknown {
 	return current;
 }
 
+/**
+ * Hosted agents receive Agent Plugins only through the Store's digest-verified
+ * channel, where the upstream community install scanner false-positive blocks
+ * delivery, so the managed config disables that heuristic scan.
+ */
+export function mergeHermesPluginScanPolicy(configPath: string): void {
+	writeHermesConfig(configPath, renderHermesPluginScanPolicy(readHermesConfigContent(configPath)));
+}
+
+export function renderHermesPluginScanPolicy(content: string): string {
+	const document = parseHermesConfig(content, "Hermes config");
+	const root = document.toJS();
+	if (isPlainRecord(root) && root.plugins !== undefined && !isPlainRecord(root.plugins)) {
+		throw new Error("Hermes config field plugins must be a YAML object.");
+	}
+	if (!isPlainRecord(root) || !isPlainRecord(root.plugins)) {
+		document.set("plugins", document.createNode({}));
+	}
+	document.setIn(["plugins", "scan_on_install"], false);
+	return String(document);
+}
+
 export function mergeHermesRuntimeLocale(configPath: string, timezone: string): void {
 	writeHermesConfig(
 		configPath,

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
@@ -37,7 +37,6 @@ class FakeNativeRunner implements HostedAgentPluginCommandRunner {
 	readonly calls: CommandInput[] = [];
 	readonly states = new Map<string, FakePluginState>();
 	availableResult = true;
-	rejectNoScan = false;
 	failProbeInstallName: string | null = null;
 	failLiveEnableVersion: string | null = null;
 	failLiveInstallVersion: string | null = null;
@@ -234,9 +233,6 @@ class FakeNativeRunner implements HostedAgentPluginCommandRunner {
 			};
 		}
 		if (args[1] === "install") {
-			if (this.rejectNoScan && args.includes("--no-scan")) {
-				return { status: 2, stdout: "", stderr: "error: unrecognized arguments: --no-scan" };
-			}
 			const source = runtime === "hermes" ? fileURLToPath(args[2] ?? "") : (args[2] ?? "");
 			const manifest = this.pluginFromSource(source);
 			if (input.home !== this.liveHome && manifest.name === this.failProbeInstallName) {
@@ -606,8 +602,10 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 			(call) => call.home === runner.liveHome && call.args[1] === "install",
 		);
 		expect(install?.args[2]?.startsWith("file://")).toBe(true);
-		expect(install?.args).toContain("--no-scan");
 		expect(install?.args.join(" ")).not.toContain("github.com");
+		expect(readFileSync(join(runner.liveHome, ".hermes", "config.yaml"), "utf-8")).toContain(
+			"scan_on_install: false",
+		);
 		expect(install?.environmentOverrides).toEqual({
 			OPENCLAW_HOME: undefined,
 			OPENCLAW_PROFILE: undefined,
@@ -644,19 +642,6 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 					call.command === "git" && call.args.includes("add") && call.args.includes("--force"),
 			),
 		).toBe(true);
-		expect(runner.get("hermes", desired.name)?.enabled).toBe(true);
-	});
-
-	test("falls back when the native Hermes does not support --no-scan", () => {
-		const runner = new FakeNativeRunner();
-		runner.rejectNoScan = true;
-		const desired = plugin("acme.tools", "1.2.3", "b".repeat(64));
-		const transaction = prepareTransaction(desiredState("hermes", desired), runner);
-		transaction.apply();
-		const installs = runner.calls.filter(
-			(call) => call.home === runner.liveHome && call.args[1] === "install",
-		);
-		expect(installs.map((call) => call.args.includes("--no-scan"))).toEqual([true, false]);
 		expect(runner.get("hermes", desired.name)?.enabled).toBe(true);
 	});
 

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { z } from "zod";
+import { mergeHermesPluginScanPolicy } from "../lib/hermes-config-merge";
 import { runHermesAgentPluginCanary } from "./hermes-agent-plugin-canary-client";
 import {
 	type HostedAgentPluginReceipt,
@@ -485,20 +486,15 @@ function createHermesDriver(input: {
 		observe,
 		install(prepared) {
 			withPreparedAgentPluginDirectory(prepared, (sourceDir) => {
+				mergeHermesPluginScanPolicy(join(input.home, ".hermes", "config.yaml"));
 				initializeLocalGitTransport(input.runner, "hermes", input.home, sourceDir);
-				const args = [
+				const result = run([
 					"plugins",
 					"install",
 					pathToFileURL(sourceDir).href,
 					"--force",
 					"--no-enable",
-				];
-				// Store plugins are digest-verified by the control plane, so the native
-				// community-plugin security scan is skipped when the runtime supports it.
-				let result = run([...args, "--no-scan"]);
-				if (result.status !== 0 && result.stderr.includes("unrecognized arguments")) {
-					result = run(args);
-				}
+				]);
 				if (result.status !== 0) {
 					throw nativeCommandFailure("Hermes native Agent Plugin install failed", result);
 				}


### PR DESCRIPTION
## Summary

Root cause of hosted Hermes agents stuck on "Installing": upstream Hermes' install-time community-plugin scanner hard-blocks Store plugins on heuristic false positives (docs snippets like "generate an AGENTS.md" trip persistence/supply-chain rules), and `dangerous` verdicts cannot be overridden.

Store plugins are already digest-verified by the control plane, so this drops the speculative `--no-scan` flag passing (unsupported upstream) and instead writes `plugins.scan_on_install: false` into the Hermes config through the managed-config surface the runtime already owns — the same mechanism used for dashboard auth and locale. Native stderr tails from #1087 stay, so any remaining native failure still surfaces with its reason.

## Verification

- bun test runtime plugin suites: 14 passed (asserts the managed config write and the plain native install invocation)
- full `packages/cli/src/runtime` suite matches main (one pre-existing `hosted-hermes-skill` failure also fails on main, unrelated)
- Biome, tsc clean
