### PR TITLE
fix(runtime): write hermes plugin scan policy as the runtime user

### DIFF
--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
@@ -23,6 +23,7 @@ import {
 	commandResolvable,
 	makeRuntimeUserOwned,
 	spawnRuntimeUserCommand,
+	withRuntimeUserFileAccess,
 } from "./runtime-user-command";
 
 const COMMAND_TIMEOUT_MS = 120_000;
@@ -486,7 +487,10 @@ function createHermesDriver(input: {
 		observe,
 		install(prepared) {
 			withPreparedAgentPluginDirectory(prepared, (sourceDir) => {
-				mergeHermesPluginScanPolicy(join(input.home, ".hermes", "config.yaml"));
+				// Written as the runtime user so the native CLI can traverse its own home.
+				withRuntimeUserFileAccess(() =>
+					mergeHermesPluginScanPolicy(join(input.home, ".hermes", "config.yaml")),
+				);
 				initializeLocalGitTransport(input.runner, "hermes", input.home, sourceDir);
 				const result = run([
 					"plugins",


### PR DESCRIPTION
## Summary

Fixes a regression from #1094 found in production: `mergeHermesPluginScanPolicy` ran with the root-process filesystem identity, so inside a freshly created probe home it produced a root-owned `0700` `.hermes/` — the native Hermes subprocess (running as the runtime user) then died with `PermissionError` reading `.env`. Writing through `withRuntimeUserFileAccess` matches how the rest of the driver stages plugin files.

Also note the diagnosis this unblocks: the pre-existing probe-home failure mode meant the scan policy must be present in the *probe* home, which this path now does correctly.

## Verification

- bun test runtime plugin suites: 14 passed
- Biome, tsc clean
