### PR TITLE
fix(cli): isolate resource projection failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.13.96
+
+Package: `clawdi@0.13.96`
+
+### Fixed
+
+- Hosted runtime dashboards remain available when only managed Skill or Agent
+  Plugin projection fails, while core runtime failures continue to report an
+  error and fail closed.
+- Hermes Skill removal and failed-install recovery now follow the native CLI's
+  confirmation and ownership contracts.
+- OpenClaw Agent Plugin repair now uses its supported overwrite mode and
+  verifies the installed package from structured provenance records.
+
 ## Clawdi CLI v0.13.78
 
 Package: `clawdi@0.13.78`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.95",
+      "version": "0.13.96",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -396,7 +396,7 @@ native runtime contracts: Hermes receives the signed `SKILL.md` URL through
 invalidates the signed file lookup.
 
 Hermes URL delivery follows the upstream native adapter verified at
-[`NousResearch/hermes-agent@e624e9fde561e1add9388384012b295fde669ade`](https://github.com/NousResearch/hermes-agent/blob/e624e9fde561e1add9388384012b295fde669ade/tools/skills_hub.py#L1431-L1528):
+[`NousResearch/hermes-agent@aec331899e4748739927fddf02a54327e64419a0`](https://github.com/NousResearch/hermes-agent/blob/aec331899e4748739927fddf02a54327e64419a0/tools/skills_hub.py#L1425-L1558):
 it installs `SKILL.md` plus explicitly referenced files from the supported
 Skill directories and runs Hermes' normal quarantine and security scan. The
 CLI compares the native result with that exact projection; an older Hermes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -396,7 +396,7 @@ native runtime contracts: Hermes receives the signed `SKILL.md` URL through
 invalidates the signed file lookup.
 
 Hermes URL delivery follows the upstream native adapter verified at
-[`NousResearch/hermes-agent@aec331899e4748739927fddf02a54327e64419a0`](https://github.com/NousResearch/hermes-agent/blob/aec331899e4748739927fddf02a54327e64419a0/tools/skills_hub.py#L1425-L1558):
+[`NousResearch/hermes-agent@e624e9fde561e1add9388384012b295fde669ade`](https://github.com/NousResearch/hermes-agent/blob/e624e9fde561e1add9388384012b295fde669ade/tools/skills_hub.py#L1431-L1528):
 it installs `SKILL.md` plus explicitly referenced files from the supported
 Skill directories and runs Hermes' normal quarantine and security scan. The
 CLI compares the native result with that exact projection; an older Hermes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.95",
+	"version": "0.13.96",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -215,6 +215,13 @@ class RuntimeAgentPluginReconcileError extends Error {
 	}
 }
 
+class RuntimeSkillProjectionReconcileError extends Error {
+	constructor(error: unknown) {
+		super(error instanceof Error ? error.message : String(error), { cause: error });
+		this.name = "RuntimeSkillProjectionReconcileError";
+	}
+}
+
 function writable(path: string): boolean {
 	try {
 		accessSync(path, constants.W_OK);
@@ -2113,6 +2120,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 	const activeAppliedState = readRuntimeAppliedState(paths);
 	let failureEtag: string | null = null;
 	let agentPluginFailure: ReturnType<typeof failedHostedAgentPluginsObservation> = null;
+	let resourceProjectionFailure = false;
 	const retryDeferred =
 		opts.failureBackoff !== undefined && opts.now < opts.failureBackoff.nextRetryAt;
 	const manifestEtag =
@@ -2219,6 +2227,9 @@ async function runtimeWatchTickAfterCliReconciliation(
 					error.installationNames,
 				);
 			}
+			resourceProjectionFailure =
+				error instanceof RuntimeAgentPluginReconcileError ||
+				error instanceof RuntimeSkillProjectionReconcileError;
 			throw error;
 		}
 		if (applyResult.kind === "cli_handoff") {
@@ -2297,6 +2308,11 @@ async function runtimeWatchTickAfterCliReconciliation(
 				systemdUnitsChanged,
 				systemdApply: systemdApplyResult,
 				convergence: convergence.outputs,
+				...(cliUpdateError === null &&
+				convergence.failureHealthImpact === "resource_projection" &&
+				cliRollback.status !== "error"
+					? { healthImpact: "resource_projection" }
+					: {}),
 				...(agentPluginFailure ? { agentPlugins: agentPluginFailure } : {}),
 			};
 		}
@@ -2326,6 +2342,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 			errors: [message],
 			error: message,
 			...(failureEtag ? { etag: failureEtag } : {}),
+			...(resourceProjectionFailure ? { healthImpact: "resource_projection" } : {}),
 			...(agentPluginFailure ? { agentPlugins: agentPluginFailure } : {}),
 		};
 	}
@@ -2400,11 +2417,20 @@ async function applyRuntimeDesiredState(
 				);
 			}
 		}
-		const preparedHostedSourcedSkills =
-			opts.preparedHostedSourcedSkills ??
-			(await prepareHostedSourcedSkillArchives(load.manifest, paths, {
-				authToken: load.applyContext?.manifestSource.auth.token,
-			}));
+		let preparedHostedSourcedSkills = opts.preparedHostedSourcedSkills;
+		if (preparedHostedSourcedSkills === undefined) {
+			try {
+				preparedHostedSourcedSkills = await prepareHostedSourcedSkillArchives(
+					load.manifest,
+					paths,
+					{
+						authToken: load.applyContext?.manifestSource.auth.token,
+					},
+				);
+			} catch (error) {
+				throw new RuntimeSkillProjectionReconcileError(error);
+			}
+		}
 		const previousSystemdUnits = readSystemdUnitSnapshot(paths);
 		const previousUserDesiredRevisions = preserveActiveUnits
 			? readSystemdUserDesiredRevisions(paths, previousSystemdUnits.user.keys())

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -205,20 +205,20 @@ interface RuntimeWatchTickOptions {
 	hostedRuntimeContract?: HostedRuntimeContractOptions;
 }
 
-class RuntimeAgentPluginReconcileError extends Error {
+class RuntimeResourceProjectionReconcileError extends Error {
+	constructor(error: unknown) {
+		super(error instanceof Error ? error.message : String(error), { cause: error });
+		this.name = "RuntimeResourceProjectionReconcileError";
+	}
+}
+
+class RuntimeAgentPluginReconcileError extends RuntimeResourceProjectionReconcileError {
 	constructor(
 		readonly installationNames: readonly string[],
 		error: unknown,
 	) {
-		super(error instanceof Error ? error.message : String(error), { cause: error });
+		super(error);
 		this.name = "RuntimeAgentPluginReconcileError";
-	}
-}
-
-class RuntimeSkillProjectionReconcileError extends Error {
-	constructor(error: unknown) {
-		super(error instanceof Error ? error.message : String(error), { cause: error });
-		this.name = "RuntimeSkillProjectionReconcileError";
 	}
 }
 
@@ -2227,9 +2227,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 					error.installationNames,
 				);
 			}
-			resourceProjectionFailure =
-				error instanceof RuntimeAgentPluginReconcileError ||
-				error instanceof RuntimeSkillProjectionReconcileError;
+			resourceProjectionFailure = error instanceof RuntimeResourceProjectionReconcileError;
 			throw error;
 		}
 		if (applyResult.kind === "cli_handoff") {
@@ -2428,7 +2426,7 @@ async function applyRuntimeDesiredState(
 					},
 				);
 			} catch (error) {
-				throw new RuntimeSkillProjectionReconcileError(error);
+				throw new RuntimeResourceProjectionReconcileError(error);
 			}
 		}
 		const previousSystemdUnits = readSystemdUnitSnapshot(paths);

--- a/packages/cli/src/runtime/hosted-hermes-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.test.ts
@@ -38,6 +38,9 @@ with Path(os.environ["FAKE_HERMES_LOG"]).open("a") as log:
 if sys.argv[1:3] == ["skills", "install"]:
     assert "--yes" in sys.argv and "--name" in sys.argv
     name = sys.argv[sys.argv.index("--name") + 1]
+    if os.environ.get("FAKE_HERMES_INSTALL_BLOCK") == "1":
+        print("Installation blocked: Blocked by the native security policy.")
+        raise SystemExit(0)
     target = root / name
     marker = root / ".native-installed" / name
     shutil.rmtree(target, ignore_errors=True)
@@ -50,8 +53,6 @@ if sys.argv[1:3] == ["skills", "install"]:
         shutil.copy2(support, target / "references" / "guide.md")
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.write_text("installed")
-    if os.environ.get("FAKE_HERMES_INSTALL_FAIL_AFTER_WRITE") == "1":
-        raise SystemExit(44)
 elif sys.argv[1:3] == ["skills", "uninstall"]:
     if len(sys.argv) != 4:
         print("hermes skills uninstall: error: unrecognized arguments: " + " ".join(sys.argv[4:]), file=sys.stderr)
@@ -72,7 +73,7 @@ else:
 }
 
 describe("Hermes exact-source Workspace Skill driver", () => {
-	test("rolls back invalid Project Skill bytes through the Hermes uninstall contract", () => {
+	test("rejects a native false success without running a fake rollback", () => {
 		root = mkdtempSync(join(tmpdir(), "hosted-hermes-project-skill-"));
 		delete process.env.CLAWDI_RUNTIME_USER;
 		const home = join(root, "home");
@@ -107,10 +108,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 			archiveSha256: "b".repeat(64),
 			tarBytes: readFileSync(archive),
 		};
-		const invalidSourceDir = join(root, "invalid-source", "review-pr");
-		mkdirSync(invalidSourceDir, { recursive: true });
-		writeFileSync(join(invalidSourceDir, "SKILL.md"), "# Wrong bytes\n");
-		process.env.FAKE_HERMES_SOURCE = invalidSourceDir;
+		process.env.FAKE_HERMES_INSTALL_BLOCK = "1";
 
 		expect(() =>
 			hostedHermesSkillExactSourceDriver.install({
@@ -119,12 +117,14 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 				skill,
 				previouslyReserved: false,
 			}),
-		).toThrow("did not preserve the exact native catalog projection");
-		expect(readFileSync(commandLog, "utf8").trim().split("\n")).toEqual([
+		).toThrow(
+			"did not preserve the exact native catalog projection: Installation blocked: Blocked by the native security policy.",
+		);
+		expect(readFileSync(commandLog, "utf8").trim()).toBe(
 			`skills install ${installUrl} --name review-pr --yes`,
-			"skills uninstall review-pr",
-		]);
+		);
 		expect(existsSync(join(home, ".hermes", "skills", "review-pr"))).toBe(false);
+		delete process.env.FAKE_HERMES_INSTALL_BLOCK;
 	});
 
 	test("requires paired ownership and uses Hermes install and uninstall semantics", async () => {
@@ -232,7 +232,6 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		writeFileSync(join(wrongSource, "SKILL.md"), "wrong bytes\n");
 		process.env.FAKE_HERMES_SOURCE = wrongSource;
 		const nativeMarker = join(home, ".hermes", "skills", ".native-installed", "review-pr");
-		process.env.FAKE_HERMES_INSTALL_FAIL_AFTER_WRITE = "1";
 		writeFileSync(join(sourceDir, "SKILL.md"), "# Review PR v3\n\n[Guide](references/guide.md)\n");
 		const failingArchive = join(root, "review-pr-failing.tar.gz");
 		const failingPacked = spawnSync("tar", [
@@ -255,12 +254,12 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 				skill: failingSkill,
 				previouslyReserved: true,
 			}),
-		).toThrow("official Skill install failed");
+		).toThrow("did not preserve the exact native catalog projection");
 		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe(skillV2);
 		expect(
 			hostedHermesSkillExactSourceDriver.verifyOwned({ home, appRoot, skill: updatedSkill }),
 		).toBe(true);
-		delete process.env.FAKE_HERMES_INSTALL_FAIL_AFTER_WRITE;
+		expect(existsSync(nativeMarker)).toBe(true);
 		writeFileSync(join(sourceDir, "SKILL.md"), skillV2);
 		process.env.FAKE_HERMES_SOURCE = sourceDir;
 		expect(

--- a/packages/cli/src/runtime/hosted-hermes-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.test.ts
@@ -38,8 +38,7 @@ with Path(os.environ["FAKE_HERMES_LOG"]).open("a") as log:
 if sys.argv[1:3] == ["skills", "install"]:
     assert "--yes" in sys.argv and "--name" in sys.argv
     name = sys.argv[sys.argv.index("--name") + 1]
-    if os.environ.get("FAKE_HERMES_INSTALL_BLOCK") == "1":
-        print("Installation blocked: Blocked by the native security policy.")
+    if os.environ.get("FAKE_HERMES_INSTALL_NOOP") == "1":
         raise SystemExit(0)
     target = root / name
     marker = root / ".native-installed" / name
@@ -108,7 +107,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 			archiveSha256: "b".repeat(64),
 			tarBytes: readFileSync(archive),
 		};
-		process.env.FAKE_HERMES_INSTALL_BLOCK = "1";
+		process.env.FAKE_HERMES_INSTALL_NOOP = "1";
 
 		expect(() =>
 			hostedHermesSkillExactSourceDriver.install({
@@ -117,14 +116,12 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 				skill,
 				previouslyReserved: false,
 			}),
-		).toThrow(
-			"did not preserve the exact native catalog projection: Installation blocked: Blocked by the native security policy.",
-		);
+		).toThrow("did not preserve the exact native catalog projection");
 		expect(readFileSync(commandLog, "utf8").trim()).toBe(
 			`skills install ${installUrl} --name review-pr --yes`,
 		);
 		expect(existsSync(join(home, ".hermes", "skills", "review-pr"))).toBe(false);
-		delete process.env.FAKE_HERMES_INSTALL_BLOCK;
+		delete process.env.FAKE_HERMES_INSTALL_NOOP;
 	});
 
 	test("requires paired ownership and uses Hermes install and uninstall semantics", async () => {

--- a/packages/cli/src/runtime/hosted-hermes-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.test.ts
@@ -53,7 +53,12 @@ if sys.argv[1:3] == ["skills", "install"]:
     if os.environ.get("FAKE_HERMES_INSTALL_FAIL_AFTER_WRITE") == "1":
         raise SystemExit(44)
 elif sys.argv[1:3] == ["skills", "uninstall"]:
-    assert sys.argv[-1] == "--yes"
+    if len(sys.argv) != 4:
+        print("hermes skills uninstall: error: unrecognized arguments: " + " ".join(sys.argv[4:]), file=sys.stderr)
+        raise SystemExit(2)
+    if sys.stdin.readline().strip().lower() not in {"y", "yes"}:
+        print("Cancelled.")
+        raise SystemExit(0)
     if os.environ.get("FAKE_HERMES_UNINSTALL_FAIL") == "1":
         raise SystemExit(43)
     shutil.rmtree(root / sys.argv[3])
@@ -67,7 +72,7 @@ else:
 }
 
 describe("Hermes exact-source Workspace Skill driver", () => {
-	test("passes the signed Project Skill URL to Hermes native install", () => {
+	test("rolls back invalid Project Skill bytes through the Hermes uninstall contract", () => {
 		root = mkdtempSync(join(tmpdir(), "hosted-hermes-project-skill-"));
 		delete process.env.CLAWDI_RUNTIME_USER;
 		const home = join(root, "home");
@@ -102,16 +107,24 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 			archiveSha256: "b".repeat(64),
 			tarBytes: readFileSync(archive),
 		};
+		const invalidSourceDir = join(root, "invalid-source", "review-pr");
+		mkdirSync(invalidSourceDir, { recursive: true });
+		writeFileSync(join(invalidSourceDir, "SKILL.md"), "# Wrong bytes\n");
+		process.env.FAKE_HERMES_SOURCE = invalidSourceDir;
 
-		expect(
+		expect(() =>
 			hostedHermesSkillExactSourceDriver.install({
 				home,
 				appRoot,
 				skill,
 				previouslyReserved: false,
 			}),
-		).toBe("installed");
-		expect(readFileSync(commandLog, "utf8")).toContain(`skills install ${installUrl}`);
+		).toThrow("did not preserve the exact native catalog projection");
+		expect(readFileSync(commandLog, "utf8").trim().split("\n")).toEqual([
+			`skills install ${installUrl} --name review-pr --yes`,
+			"skills uninstall review-pr",
+		]);
+		expect(existsSync(join(home, ".hermes", "skills", "review-pr"))).toBe(false);
 	});
 
 	test("requires paired ownership and uses Hermes install and uninstall semantics", async () => {

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -66,24 +66,33 @@ function rawSkillUrl(skill: PreparedHostedSourcedSkill): string {
 	return `https://raw.githubusercontent.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${skill.source.commit}/${skillPath}`;
 }
 
-function runHermes(input: { home: string; appRoot: string }, args: string[]) {
+function runHermes(input: { home: string; appRoot: string }, args: string[], stdin?: string) {
 	return spawnRuntimeUserCommand(
 		commandPath(input.home, input.appRoot),
 		args,
 		input.home,
 		input.appRoot,
 		{
+			input: stdin,
 			timeoutMs: 120_000,
 			maxBufferBytes: 1024 * 1024,
 		},
 	);
 }
 
+function runHermesUninstall(
+	input: { home: string; appRoot: string },
+	skillId: string,
+) {
+	// Hermes exposes no --yes flag for this subcommand; its confirmation reads stdin.
+	return runHermes(input, ["skills", "uninstall", skillId], "y\n");
+}
+
 const HERMES_SUPPORT_DIRS = new Set(["references", "templates", "scripts", "assets", "examples"]);
 const HERMES_SUPPORT_REFERENCE =
 	/(?:\]\(|`|(?:^|[\s"']))((?:references|templates|scripts|assets|examples)\/[^\s)`"'<>]+)/gm;
 
-/** Mirrors Hermes UrlSource at NousResearch/hermes-agent@aec331899e4748739927fddf02a54327e64419a0. */
+/** Mirrors Hermes UrlSource at NousResearch/hermes-agent@e624e9fde561e1add9388384012b295fde669ade. */
 function expectedHermesNativeTree(sourceDir: string) {
 	const catalogTree = collectManagedSkillTree(sourceDir);
 	const skillMd = catalogTree?.get("SKILL.md");
@@ -157,15 +166,10 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 						);
 					if (!nativeResultMatches(sourceDir, target)) {
 						if (!hadTarget) {
-							const rollback = runHermes(input, [
-								"skills",
-								"uninstall",
-								input.skill.skillId,
-								"--yes",
-							]);
-							if (rollback.status !== 0)
+							const rollback = runHermesUninstall(input, input.skill.skillId);
+							if (rollback.status !== 0 || existsSync(target))
 								throw new Error(
-									`Hermes official install produced invalid Skill bytes and native rollback failed: ${String(rollback.stderr || rollback.stdout).trim() || "unknown error"}`,
+									`Hermes official install produced invalid Skill bytes and native rollback failed: ${String(rollback.stderr || rollback.stdout).trim() || (existsSync(target) ? "Skill target still exists" : "unknown error")}`,
 								);
 						}
 						throw new Error(
@@ -203,11 +207,13 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 		}
 		if (!managedSkillReceiptMatchesIdentity(receipt))
 			throw new Error("Hermes Skill bytes no longer match the manifest ownership receipt");
-		const result = runHermes(input, ["skills", "uninstall", input.skillId, "--yes"]);
+		const result = runHermesUninstall(input, input.skillId);
 		if (result.status !== 0)
 			throw new Error(
 				`Hermes official Skill uninstall failed: ${String(result.stderr || result.stdout).trim() || "unknown error"}`,
 			);
+		if (existsSync(target))
+			throw new Error("Hermes official Skill uninstall did not remove the Skill target");
 		rmSync(receipt.path, { force: true });
 		return "removed";
 	},

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -1,6 +1,5 @@
 import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { safeTruncate, sanitizeMetadata } from "../lib/sanitize";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import {
 	collectManagedSkillTree,
@@ -86,18 +85,11 @@ function runHermesUninstall(input: { home: string; appRoot: string }, skillId: s
 	return runHermes(input, ["skills", "uninstall", skillId], "y\n");
 }
 
-function installFailureDiagnostic(result: ReturnType<typeof runHermes>): string | null {
-	const output = sanitizeMetadata(String(result.stderr || result.stdout));
-	const marker = "Installation blocked:";
-	const markerIndex = output.lastIndexOf(marker);
-	return markerIndex === -1 ? null : safeTruncate(output.slice(markerIndex), 500);
-}
-
 const HERMES_SUPPORT_DIRS = new Set(["references", "templates", "scripts", "assets", "examples"]);
 const HERMES_SUPPORT_REFERENCE =
 	/(?:\]\(|`|(?:^|[\s"']))((?:references|templates|scripts|assets|examples)\/[^\s)`"'<>]+)/gm;
 
-/** Mirrors Hermes UrlSource at NousResearch/hermes-agent@e624e9fde561e1add9388384012b295fde669ade. */
+/** Mirrors Hermes UrlSource at NousResearch/hermes-agent@aec331899e4748739927fddf02a54327e64419a0. */
 function expectedHermesNativeTree(sourceDir: string) {
 	const catalogTree = collectManagedSkillTree(sourceDir);
 	const skillMd = catalogTree?.get("SKILL.md");
@@ -177,9 +169,8 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 									`Hermes official install produced invalid Skill bytes and native rollback failed: ${String(rollback.stderr || rollback.stdout).trim() || (existsSync(target) ? "Skill target still exists" : "unknown error")}`,
 								);
 						}
-						const diagnostic = installFailureDiagnostic(result);
 						throw new Error(
-							`Hermes official install did not preserve the exact native catalog projection${diagnostic ? `: ${diagnostic}` : ""}`,
+							"Hermes official install did not preserve the exact native catalog projection",
 						);
 					}
 					writeManagedSkillReceipt(receipt);

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -1,5 +1,6 @@
 import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { safeTruncate, sanitizeMetadata } from "../lib/sanitize";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import {
 	collectManagedSkillTree,
@@ -80,12 +81,16 @@ function runHermes(input: { home: string; appRoot: string }, args: string[], std
 	);
 }
 
-function runHermesUninstall(
-	input: { home: string; appRoot: string },
-	skillId: string,
-) {
+function runHermesUninstall(input: { home: string; appRoot: string }, skillId: string) {
 	// Hermes exposes no --yes flag for this subcommand; its confirmation reads stdin.
 	return runHermes(input, ["skills", "uninstall", skillId], "y\n");
+}
+
+function installFailureDiagnostic(result: ReturnType<typeof runHermes>): string | null {
+	const output = sanitizeMetadata(String(result.stderr || result.stdout));
+	const marker = "Installation blocked:";
+	const markerIndex = output.lastIndexOf(marker);
+	return markerIndex === -1 ? null : safeTruncate(output.slice(markerIndex), 500);
 }
 
 const HERMES_SUPPORT_DIRS = new Set(["references", "templates", "scripts", "assets", "examples"]);
@@ -165,15 +170,16 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 							`Hermes official Skill install failed: ${String(result.stderr || result.stdout).trim() || "unknown error"}`,
 						);
 					if (!nativeResultMatches(sourceDir, target)) {
-						if (!hadTarget) {
+						if (!hadTarget && existsSync(target)) {
 							const rollback = runHermesUninstall(input, input.skill.skillId);
 							if (rollback.status !== 0 || existsSync(target))
 								throw new Error(
 									`Hermes official install produced invalid Skill bytes and native rollback failed: ${String(rollback.stderr || rollback.stdout).trim() || (existsSync(target) ? "Skill target still exists" : "unknown error")}`,
 								);
 						}
+						const diagnostic = installFailureDiagnostic(result);
 						throw new Error(
-							"Hermes official install did not preserve the exact native catalog projection",
+							`Hermes official install did not preserve the exact native catalog projection${diagnostic ? `: ${diagnostic}` : ""}`,
 						);
 					}
 					writeManagedSkillReceipt(receipt);

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -4394,6 +4394,7 @@ echo spawned > '${installerLog}'
 			options,
 		);
 		expect(lostResponse.installErrors.join("\n")).toContain("lost native install response");
+		expect(lostResponse.failureHealthImpact).toBe("resource_projection");
 		expect(installs).toEqual([false]);
 		expect(shouldIgnoreUserSkill(skillDir, "review-pr")).toBe(false);
 		expect(existsSync(skillDir)).toBe(false);
@@ -4649,6 +4650,7 @@ echo spawned > '${installerLog}'
 			},
 		});
 		expect(result.installErrors.join("\n")).toContain("injected systemd activation failure");
+		expect(result.failureHealthImpact).toBe("runtime");
 		for (const path of rootManagedPaths) {
 			const expected = previous.get(path);
 			if (!expected) throw new Error(`missing preserved fixture for ${path}`);

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -253,14 +253,21 @@ set -euo pipefail
 case "$*" in
 	  "--version") printf '%s\\n' '${input.version ?? "OpenClaw 2026.7.29"}' ;;
   "plugins inspect discord --json") cat '${input.inspectStatePath}' ;;
-  "plugins install @openclaw/discord")
+  "plugins install @openclaw/discord --force")
 	mkdir -p '${dirname(input.inspectStatePath)}'
-	printf '%s\\n' '@openclaw/discord' >> '${input.installLogPath}'
+	printf '%s\\n' 'plugins install @openclaw/discord --force' >> '${input.installLogPath}'
 	[ ! -f '${input.failInstallMarker}' ] || exit 73
 	mkdir -p '${dirname(input.pluginSourcePath)}'
 	printf '%s\\n' 'export const discordPlugin = true;' > '${input.pluginSourcePath}'
 	chmod 0644 '${input.pluginSourcePath}'
 	printf '%s\\n' '${JSON.stringify(pluginInspectFixture(input.pluginSourcePath))}' > '${input.inspectStatePath}'
+	;;
+  "plugins install @openclaw/discord")
+	if [ -f '${input.pluginSourcePath}' ]; then
+	  printf 'plugin already exists: %s\\n' '${input.pluginSourcePath}' >&2
+	  exit 1
+	fi
+	exit 64
 	;;
   "config patch --stdin") cat >/dev/null ;;
   *) exit 64 ;;

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -263,11 +263,7 @@ case "$*" in
 	printf '%s\\n' '${JSON.stringify(pluginInspectFixture(input.pluginSourcePath))}' > '${input.inspectStatePath}'
 	;;
   "plugins install @openclaw/discord")
-	if [ -f '${input.pluginSourcePath}' ]; then
-	  printf 'plugin already exists: %s\\n' '${input.pluginSourcePath}' >&2
-	  exit 1
-	fi
-	exit 64
+	exit 1
 	;;
   "config patch --stdin") cat >/dev/null ;;
   *) exit 64 ;;

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -280,6 +280,7 @@ export interface RuntimeConvergenceResult {
 	mode: "normal" | "degraded-offline";
 	enabledRuntimes: string[];
 	installErrors: string[];
+	failureHealthImpact: "runtime" | "resource_projection" | null;
 	projectedProviderIds: Record<string, string[]>;
 	agentPluginFailedNames: string[];
 	outputs: {
@@ -309,6 +310,13 @@ export interface RuntimeConvergenceResult {
 		instanceSemaphores: string[];
 		bootFinished: string;
 	};
+}
+
+class RuntimeResourceProjectionError extends Error {
+	constructor(error: unknown) {
+		super(error instanceof Error ? error.message : String(error), { cause: error });
+		this.name = "RuntimeResourceProjectionError";
+	}
 }
 
 export function planHostedAgentPluginConvergence(input: {
@@ -3649,6 +3657,7 @@ function installOpenClawChannelPlugins(input: {
 		const currentRevision = () =>
 			channelPluginCurrentRevision({
 				channel,
+				specs,
 				commandPath: input.commandPath,
 				home: input.home,
 				workspaceRoot: input.workspaceRoot,
@@ -3683,31 +3692,20 @@ function runPluginInstallWithFallback(
 	let lastError: unknown = null;
 	for (const spec of specs) {
 		try {
-			runRuntimeUserCommand(commandPath, ["plugins", "install", spec], "", home, workspaceRoot);
+			runRuntimeUserCommand(
+				commandPath,
+				["plugins", "install", spec, "--force"],
+				"",
+				home,
+				workspaceRoot,
+			);
 			return;
 		} catch (error) {
-			if (isOpenClawPluginAlreadyInstalledError(error)) return;
 			lastError = error;
 		}
 	}
 	if (lastError instanceof Error) throw lastError;
 	throw new Error(`OpenClaw plugin install failed for ${specs.join(" or ")}`);
-}
-
-function isOpenClawPluginAlreadyInstalledError(error: unknown): boolean {
-	const text = commandErrorText(error).toLowerCase();
-	return text.includes("plugin already exists:");
-}
-
-function commandErrorText(error: unknown): string {
-	if (typeof error !== "object" || error === null) return String(error);
-	const parts: string[] = [];
-	const output = error as { message?: unknown; stdout?: unknown; stderr?: unknown };
-	for (const value of [output.message, output.stdout, output.stderr]) {
-		if (typeof value === "string") parts.push(value);
-		else if (Buffer.isBuffer(value)) parts.push(value.toString("utf8"));
-	}
-	return parts.join("\n");
 }
 
 function channelPluginEntries(
@@ -4595,13 +4593,14 @@ function channelPluginDesiredRevision(input: {
 	return runtimeContentSha256({
 		runtime: "openclaw",
 		pluginIdentity: input.channel,
-		installerCommand: ["plugins", "install"],
+		installerCommand: ["plugins", "install", "--force"],
 		specs: input.specs,
 	});
 }
 
 function channelPluginCurrentRevision(input: {
 	channel: string;
+	specs: readonly string[];
 	commandPath: string;
 	home: string;
 	workspaceRoot: string;
@@ -4630,6 +4629,7 @@ function channelPluginCurrentRevision(input: {
 		const sourceRevision = runtimeFileCurrentRevision(plugin.source);
 		if (
 			plugin.id !== input.channel ||
+			!input.specs.some((spec) => openClawPluginInstallMatchesSpec(install, spec)) ||
 			plugin.status !== "loaded" ||
 			!plugin.enabled ||
 			!version ||
@@ -4670,6 +4670,16 @@ function channelPluginCurrentRevision(input: {
 	} catch {
 		return null;
 	}
+}
+
+function openClawPluginInstallMatchesSpec(
+	install: z.infer<typeof openClawPluginInspectSchema>["install"],
+	spec: string,
+): boolean {
+	if (spec.startsWith("clawhub:")) {
+		return install.source === "clawhub" && install.clawhubPackage === spec.slice("clawhub:".length);
+	}
+	return install.spec === spec || install.resolvedSpec === spec;
 }
 
 function verifiedReceiptCurrentRevision(
@@ -5330,6 +5340,7 @@ function runtimeConvergenceWithoutApply(input: {
 	workspaceRoot: string;
 	enabledRuntimes: string[];
 	installErrors: string[];
+	failureHealthImpact?: "runtime" | "resource_projection";
 	projectedProviderIds: Record<string, string[]>;
 	agentPluginFailedNames?: string[];
 }): RuntimeConvergenceResult {
@@ -5342,6 +5353,7 @@ function runtimeConvergenceWithoutApply(input: {
 		mode: input.load.offline ? "degraded-offline" : "normal",
 		enabledRuntimes: input.enabledRuntimes,
 		installErrors: input.installErrors,
+		failureHealthImpact: input.failureHealthImpact ?? "runtime",
 		projectedProviderIds: input.projectedProviderIds,
 		agentPluginFailedNames: input.agentPluginFailedNames ?? [],
 		outputs: {
@@ -6307,7 +6319,7 @@ export function convergeRuntimeManifest(
 				for (const name of opts.preparedHostedAgentPlugins.desired.keys()) {
 					agentPluginFailedNames.add(name);
 				}
-				throw error;
+				throw new RuntimeResourceProjectionError(error);
 			}
 			agentPluginTransaction = planned.transaction;
 			if (agentPluginTransaction?.hasMutations && !opts.systemdApply) {
@@ -6615,6 +6627,7 @@ export function convergeRuntimeManifest(
 		if (installErrors.length > 0) {
 			throw new Error(installErrors.join("; "));
 		}
+		const skillProjectionErrors: string[] = [];
 		for (const name of HOSTED_RUNTIME_TARGETS) {
 			try {
 				applyHostedBundledSkills(
@@ -6626,7 +6639,7 @@ export function convergeRuntimeManifest(
 					openClawSkillDriver,
 				);
 			} catch (error) {
-				installErrors.push(
+				skillProjectionErrors.push(
 					`runtime ${name} skill projection failed: ${
 						error instanceof Error ? error.message : String(error)
 					}`,
@@ -6642,7 +6655,7 @@ export function convergeRuntimeManifest(
 				hermesSkillNativeReconciler,
 			);
 		} catch (error) {
-			installErrors.push(
+			skillProjectionErrors.push(
 				`runtime hermes sourced Skill projection failed: ${
 					error instanceof Error ? error.message : String(error)
 				}`,
@@ -6659,7 +6672,7 @@ export function convergeRuntimeManifest(
 					openClawSkillDriver,
 				);
 			} catch (error) {
-				installErrors.push(
+				skillProjectionErrors.push(
 					`runtime openclaw sourced Skill delivery failed: ${error instanceof Error ? error.message : String(error)}`,
 				);
 			}
@@ -6671,8 +6684,13 @@ export function convergeRuntimeManifest(
 				`runtime MCP projection failed: ${error instanceof Error ? error.message : String(error)}`,
 			);
 		}
+		installErrors.push(...skillProjectionErrors);
 		if (installErrors.length > 0) {
-			throw new Error(installErrors.join("; "));
+			const error = new Error(installErrors.join("; "));
+			if (installErrors.length === skillProjectionErrors.length) {
+				throw new RuntimeResourceProjectionError(error);
+			}
+			throw error;
 		}
 
 		for (const runtime of ["hermes", "openclaw"] as const) {
@@ -6922,7 +6940,11 @@ export function convergeRuntimeManifest(
 			}
 			agentPluginMutationAttempted = true;
 		}
-		appliedAgentPluginTransaction?.apply();
+		try {
+			appliedAgentPluginTransaction?.apply();
+		} catch (error) {
+			throw new RuntimeResourceProjectionError(error);
+		}
 		if (
 			officialServicePlan.pending.length > 0 &&
 			systemdUnits.egressSidecarActive &&
@@ -6991,6 +7013,7 @@ export function convergeRuntimeManifest(
 			mode: load.offline ? "degraded-offline" : "normal",
 			enabledRuntimes,
 			installErrors,
+			failureHealthImpact: null,
 			projectedProviderIds,
 			agentPluginFailedNames: [],
 			outputs: {
@@ -7043,7 +7066,7 @@ export function convergeRuntimeManifest(
 					for (const name of opts.preparedHostedAgentPlugins?.desired.keys() ?? []) {
 						agentPluginFailedNames.add(name);
 					}
-					throw error;
+					throw new RuntimeResourceProjectionError(error);
 				}
 			}
 			opts.commitAuthority?.(convergence, {
@@ -7091,12 +7114,14 @@ export function convergeRuntimeManifest(
 		}
 		return convergence;
 	} catch (error) {
+		const resourceProjectionFailure = error instanceof RuntimeResourceProjectionError;
 		if (agentPluginMutationAttempted) {
 			for (const name of agentPluginTransaction?.mutationNames ?? []) {
 				agentPluginFailedNames.add(name);
 			}
 		}
 		const applyError = error instanceof Error ? error.message : String(error);
+		const installErrorCountBeforeRollback = installErrors.length;
 		const systemdMutated = opts.systemdApply?.transactionState() === "mutated";
 		const rollbackRequiresQuiesce =
 			systemdMutated || agentPluginQuiesceAttempted || agentPluginMutationAttempted;
@@ -7219,6 +7244,10 @@ export function convergeRuntimeManifest(
 			workspaceRoot,
 			enabledRuntimes,
 			installErrors,
+			failureHealthImpact:
+				resourceProjectionFailure && installErrors.length === installErrorCountBeforeRollback + 1
+					? "resource_projection"
+					: "runtime",
 			projectedProviderIds: Object.fromEntries(
 				Object.entries(previousProjectedProviderIds).map(([runtime, providerIds]) => [
 					runtime,

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -4676,10 +4676,11 @@ function openClawPluginInstallMatchesSpec(
 	install: z.infer<typeof openClawPluginInspectSchema>["install"],
 	spec: string,
 ): boolean {
-	if (spec.startsWith("clawhub:")) {
-		return install.source === "clawhub" && install.clawhubPackage === spec.slice("clawhub:".length);
+	const recordedSpecs = [install.spec, install.resolvedSpec];
+	if (install.source === "clawhub" && install.clawhubPackage) {
+		recordedSpecs.push(`clawhub:${install.clawhubPackage}`);
 	}
-	return install.spec === spec || install.resolvedSpec === spec;
+	return recordedSpecs.includes(spec);
 }
 
 function verifiedReceiptCurrentRevision(
@@ -7237,6 +7238,7 @@ export function convergeRuntimeManifest(
 				"runtime egress sidecar stopped because committed secret rollback authority could not be verified",
 			);
 		}
+		const rollbackPreservedRuntimeHealth = installErrors.length === installErrorCountBeforeRollback;
 		installErrors.unshift(`runtime apply failed: ${applyError}`);
 		return runtimeConvergenceWithoutApply({
 			load,
@@ -7245,7 +7247,7 @@ export function convergeRuntimeManifest(
 			enabledRuntimes,
 			installErrors,
 			failureHealthImpact:
-				resourceProjectionFailure && installErrors.length === installErrorCountBeforeRollback + 1
+				resourceProjectionFailure && rollbackPreservedRuntimeHealth
 					? "resource_projection"
 					: "runtime",
 			projectedProviderIds: Object.fromEntries(

--- a/packages/cli/src/runtime/observed-v2.test.ts
+++ b/packages/cli/src/runtime/observed-v2.test.ts
@@ -6,6 +6,7 @@ import { getCliVersion } from "../lib/version";
 import { writeRuntimeAppliedState } from "./applied-state";
 import { readHostedRuntimeObserved } from "./observed";
 import { getRuntimePaths } from "./paths";
+import { buildRuntimeBootStatus, writeRuntimeBootStatus, writeRuntimeWatchStatus } from "./state";
 
 const originalEnv = { ...process.env };
 const roots: string[] = [];
@@ -14,6 +15,64 @@ afterEach(() => {
 	process.env = { ...originalEnv };
 	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
+
+function healthyAppliedRuntimePaths() {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-observed-v2-watch-error-"));
+	roots.push(root);
+	process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+	process.env.CLAWDI_RUN_DIR = join(root, "run");
+	process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
+	const paths = getRuntimePaths({ mode: "hosted" });
+	mkdirSync(paths.serviceStateRoot);
+	writeRuntimeAppliedState(
+		{
+			schemaVersion: "clawdi.runtimeAppliedState.v2",
+			appliedAt: "2026-08-19T00:00:00.000Z",
+			instanceId: "hri_watch_error",
+			etag: '"bundle-applied"',
+			manifestETag: '"manifest-applied"',
+			applyReceiptId: "apply-receipt-watch-error",
+			bootNonce: "boot-nonce-watch-error",
+			sourceRevision: "d".repeat(64),
+			generation: 1,
+			contentIdentity: {
+				sourcePath: "https://runtime.test/v1/runtime/manifest",
+				sha256: "e".repeat(64),
+			},
+			providerIds: [],
+			projectedProviderIds: {},
+		},
+		paths,
+	);
+	writeRuntimeBootStatus(
+		buildRuntimeBootStatus(
+			{
+				mode: "normal",
+				status: "ok",
+				stage: "final",
+				bootId: "boot-watch-error",
+				runtimeMode: "hosted",
+				activeGeneration: 1,
+				instanceId: "hri_watch_error",
+				enabledRuntimes: ["hermes"],
+				errors: [],
+				exitCode: 0,
+				datasource: "RuntimeSource",
+				hostPolicy: {
+					source: "file",
+					path: paths.hostPolicy,
+					exists: true,
+					valid: true,
+					mode: "hosted",
+				},
+				timestamp: "2026-08-19T00:00:00.000Z",
+			},
+			paths,
+		),
+		paths,
+	);
+	return paths;
+}
 
 describe("hosted runtime observed v2", () => {
 	test("reports authority only from applied state and the active process version", () => {
@@ -71,5 +130,38 @@ describe("hosted runtime observed v2", () => {
 		const observed = readHostedRuntimeObserved(getRuntimePaths({ mode: "hosted" }));
 		expect(observed?.applied).toBeNull();
 		expect(observed?.status).toBe("unknown");
+	});
+
+	test("keeps last-good runtime healthy when a desired projection fails", () => {
+		const paths = healthyAppliedRuntimePaths();
+		writeRuntimeWatchStatus(
+			{
+				status: "error",
+				stage: "final",
+				error: "runtime hermes sourced Skill projection failed",
+				healthImpact: "resource_projection",
+			},
+			paths,
+		);
+
+		const observed = readHostedRuntimeObserved(paths);
+		expect(observed?.status).toBe("ok");
+		expect(observed?.convergeError).toBe("runtime hermes sourced Skill projection failed");
+	});
+
+	test("reports an untyped watch apply failure as unhealthy", () => {
+		const paths = healthyAppliedRuntimePaths();
+		writeRuntimeWatchStatus(
+			{
+				status: "error",
+				stage: "final",
+				error: "runtime apply failed",
+			},
+			paths,
+		);
+
+		const observed = readHostedRuntimeObserved(paths);
+		expect(observed?.status).toBe("error");
+		expect(observed?.convergeError).toBe("runtime apply failed");
 	});
 });

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -100,10 +100,15 @@ function observedStatus(
 	hasAppliedAuthority: boolean,
 ): ObservedStatus {
 	const watchEvent = recordValue(watchStatus?.event);
-	if (watchEvent?.status === "error") return "error";
 	if (bootStatus?.status === "error") return "error";
 	if (systemd?.status === "error") return "error";
 	if (providers && Object.values(providers).some((provider) => provider.status === "error")) {
+		return "error";
+	}
+	if (
+		watchEvent?.status === "error" &&
+		(!hasAppliedAuthority || watchEvent.healthImpact !== "resource_projection")
+	) {
 		return "error";
 	}
 	if (!hasAppliedAuthority) return "unknown";

--- a/packages/cli/src/runtime/openclaw-plugin-observation.ts
+++ b/packages/cli/src/runtime/openclaw-plugin-observation.ts
@@ -36,6 +36,7 @@ export const openClawPluginInspectSchema = z
 				gitUrl: z.string().min(1).optional(),
 				gitRef: z.string().min(1).optional(),
 				gitCommit: z.string().min(1).optional(),
+				clawhubPackage: z.string().min(1).optional(),
 			})
 			.passthrough(),
 	})

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1354,7 +1354,7 @@ function openClawWhatsAppPluginInspectFixture(pluginSource: string): Record<stri
 		},
 		install: {
 			source: "clawhub",
-			spec: "clawhub:@openclaw/whatsapp",
+			clawhubPackage: "@openclaw/whatsapp",
 			installPath: dirname(pluginSource),
 			version: "2026.7.1",
 			integrity: "sha256-test",
@@ -13183,8 +13183,8 @@ if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin
   printf '\\n---\\n' >> '${openclawPatch}'
   exit 0
 fi
-if [ "\${1:-}" = "plugins" ] && [ "\${2:-}" = "install" ]; then
-  printf '%s\\n' "\${3:-}" >> '${openclawPluginInstalls}'
+if [ "$*" = "plugins install @openclaw/discord --force" ]; then
+  printf '%s\\n' "$*" >> '${openclawPluginInstalls}'
   mkdir -p '${dirname(openclawPluginSource)}'
   printf '%s\\n' 'export const discordPlugin = true;' > '${openclawPluginSource}'
   exit 0
@@ -13333,7 +13333,9 @@ exit 64
 					resetTriggers: ["/new"],
 				});
 			}
-			expect(readFileSync(openclawPluginInstalls, "utf-8")).toBe("@openclaw/discord\n");
+			expect(readFileSync(openclawPluginInstalls, "utf-8")).toBe(
+				"plugins install @openclaw/discord --force\n",
+			);
 			const openclawRunConfig = JSON.parse(
 				readFileSync(join(getRuntimePaths().runConfigRoot, "openclaw.json"), "utf-8"),
 			);
@@ -14122,7 +14124,7 @@ if [ "\${1:-}" = "--version" ]; then
   printf 'openclaw 2026.7.1\\n'
   exit 0
 fi
-if [ "\${1:-}" = "plugins" ] && [ "\${2:-}" = "install" ]; then
+if [ "$*" = "plugins install clawhub:@openclaw/whatsapp --force" ]; then
   mkdir -p '${dirname(openclawPluginSource)}'
   printf 'export const whatsappPlugin = true;\\n' > '${openclawPluginSource}'
   exit 0
@@ -14223,7 +14225,7 @@ exit 0
 			openclawBin,
 			`#!/usr/bin/env bash
 set -euo pipefail
-if [ "\${1:-}" = "plugins" ] && [ "\${2:-}" = "install" ]; then
+if [ "$*" = "plugins install @openclaw/discord --force" ]; then
   echo "plugin install failed" >&2
   exit 73
 fi
@@ -14489,8 +14491,8 @@ if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin
   printf '\\n---\\n' >> '${openclawPatch}'
   exit 0
 fi
-if [ "\${1:-}" = "plugins" ] && [ "\${2:-}" = "install" ]; then
-  printf '%s\\n' "\${3:-}" >> '${openclawPluginInstalls}'
+if [ "$*" = "plugins install clawhub:@openclaw/whatsapp --force" ]; then
+  printf '%s\\n' "$*" >> '${openclawPluginInstalls}'
   exit 0
 fi
 printf 'unexpected openclaw command: %s\\n' "$*" >&2
@@ -14591,8 +14593,8 @@ if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin
   printf '\\n---\\n' >> '${openclawPatch}'
   exit 0
 fi
-if [ "\${1:-}" = "plugins" ] && [ "\${2:-}" = "install" ]; then
-  printf '%s\\n' "\${3:-}" >> '${openclawPluginInstalls}'
+if [ "$*" = "plugins install @openclaw/discord --force" ]; then
+  printf '%s\\n' "$*" >> '${openclawPluginInstalls}'
   mkdir -p '${dirname(openclawPluginSource)}'
   printf '%s\\n' 'export const discordPlugin = true;' > '${openclawPluginSource}'
   exit 0
@@ -14683,10 +14685,12 @@ exit 64
 		expect(patches[1].channels.telegram).toEqual(telegramChannel);
 		expect(patches[2].session).toEqual({ dmScope: null });
 		expect(patches[2].channels.telegram).toBeNull();
-		expect(readFileSync(openclawPluginInstalls, "utf-8")).toBe("@openclaw/discord\n");
+		expect(readFileSync(openclawPluginInstalls, "utf-8")).toBe(
+			"plugins install @openclaw/discord --force\n",
+		);
 	});
 
-	it("treats already-installed OpenClaw channel plugins as converged", () => {
+	it("reconciles an already-installed OpenClaw channel plugin with forced provenance", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -14710,11 +14714,10 @@ if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin
   cat > '${openclawPatch}'
   exit 0
 fi
-if [ "\${1:-}" = "plugins" ] && [ "\${2:-}" = "install" ]; then
-  printf '%s\\n' "\${3:-}" >> '${openclawPluginInstalls}'
-  printf 'plugin already exists: %s\\n' "$HOME/.openclaw/npm/projects/openclaw-discord/node_modules/\${3:-}" >&2
-  printf 'Use openclaw plugins update to upgrade the tracked plugin.\\n' >&2
-  exit 1
+if [ "$*" = "plugins install @openclaw/discord --force" ]; then
+  printf '%s\\n' "$*" >> '${openclawPluginInstalls}'
+  printf '%s\\n' 'export const discordPlugin = true;' > '${openclawPluginSource}'
+  exit 0
 fi
 if [ "$*" = "plugins inspect discord --json" ]; then
   printf '%s\\n' '${JSON.stringify(openClawDiscordPluginInspectFixture(openclawPluginSource))}'
@@ -14771,7 +14774,9 @@ exit 64
 		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
 
 		expect(convergence.installErrors).toEqual([]);
-		expect(readFileSync(openclawPluginInstalls, "utf-8")).toBe("@openclaw/discord\n");
+		expect(readFileSync(openclawPluginInstalls, "utf-8")).toBe(
+			"plugins install @openclaw/discord --force\n",
+		);
 		const patchText = readFileSync(openclawPatch, "utf-8");
 		expect(patchText).toContain('"discord"');
 		expect(patchText).toContain('"plugins"');


### PR DESCRIPTION
## Summary

- keep last-good runtime/UI readiness for explicitly typed Skill and Agent Plugin projection failures while preserving convergence and plugin diagnostics
- keep core apply, systemd, installer, provider, channel, and rollback failures fail-closed
- align Hermes Skill install/uninstall and rollback behavior with the native CLI contract
- repair OpenClaw channel plugins with `plugins install <spec> --force` and verify structured inspect provenance before accepting convergence
- release the fix as exact package `clawdi@0.13.96`

## Verification

- Docker CLI TypeScript typecheck
- 211 Docker tests across observed-v2, Hermes Skill delivery, manifest services, and repo-wide runtime behavior
- earlier 19 focused Docker tests covering the changed contracts
- Biome on the 10 touched TypeScript test/source files
- `git diff --check origin/main..HEAD`

## Release impact

- head SHA: `e3f943b2823f6fd5afbef6f6bfdafce7ce4afaf5`
- changing `packages/cli/package.json` triggers the immutable CLI publish workflow after merge and publishes stable `0.13.96` to npm `latest`
- no database migration
- Hosted rollout remains a separate exact-version promotion using `clawdi@0.13.96`
