### PR TITLE
Fix Hermes gateway dashboard authentication

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.95",
+      "version": "0.13.96",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.95",
+	"version": "0.13.96",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -802,6 +802,9 @@ describe("runtime manifest services", () => {
 			HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "secret://runtime/hermes/dashboard-password",
 			HERMES_DASHBOARD_BASIC_AUTH_SECRET: "secret://runtime/hermes/dashboard-session-secret",
 		});
+		expect(gatewayEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_USERNAME="admin"');
+		expect(gatewayEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="opaque-password-value"');
+		expect(gatewayEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_SECRET="opaque-session-value"');
 		expect(gatewayEnv).toContain('RUNTIME_TARGET_TOKEN="runtime-source-token"');
 		expect(gatewayEnv).toContain('RUNTIME_BUNDLE_TOKEN="bundle-runtime-token"');
 		expect(watchEnv).not.toContain("opaque-password-value");
@@ -884,7 +887,7 @@ describe("runtime manifest services", () => {
 		const rotatedWatchUnit = readFileSync(watchUnitPath, "utf8");
 		expect(rotatedWatchEnv).toBe(watchEnv);
 		expect(rotatedDashboardUnit).not.toBe(dashboardUnit);
-		expect(rotatedGatewayUnit).toBe(gatewayUnit);
+		expect(rotatedGatewayUnit).not.toBe(gatewayUnit);
 		// The root watcher reloads the apply-context file on each tick, so neither
 		// its environment nor its unit needs secret bytes.
 		expect(rotatedWatchUnit).toBe(watchUnit);

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1539,21 +1539,34 @@ function resolvedRuntimeServiceSettings(
 	settings: RuntimeRunSettings,
 	providerEnv: Record<string, string>,
 ): RuntimeRunSettings {
-	return mergeRuntimeServiceEnvWithProviderPlaceholders(
+	const merged = mergeRuntimeServiceEnvWithProviderPlaceholders(
 		runtime,
 		service,
-		hermesDashboardServiceSettings(manifest, runtime, service, settings),
+		settings,
 		providerEnv,
 	);
+	return runtime === "hermes" && service === "dashboard"
+		? (withHermesDashboardAuthEnvironment(manifest, merged) ?? merged)
+		: merged;
+}
+
+function resolvedRuntimeSettings(
+	manifest: RuntimeManifest,
+	runtime: string,
+	settings: RuntimeRunSettings | undefined,
+	providerEnv: Record<string, string>,
+): RuntimeRunSettings | undefined {
+	const merged = mergeRuntimeEnvWithProviderPlaceholders(runtime, settings, providerEnv);
+	return runtime === "hermes" ? withHermesDashboardAuthEnvironment(manifest, merged) : merged;
 }
 
 function mergeRuntimeSecretEnv(
 	runtimeName: string,
-	runtime: RuntimeManifest["runtimes"][string],
+	settings: RuntimeRunSettings | undefined,
 	providerSecretEnv: Record<string, string>,
 ): Record<string, string> {
 	const merged = { ...providerSecretEnv };
-	const runtimeSecretEnv = runtime.run?.secretEnv ?? {};
+	const runtimeSecretEnv = settings?.secretEnv ?? {};
 	for (const [envName, ref] of Object.entries(runtimeSecretEnv)) {
 		const existing = merged[envName];
 		if (existing !== undefined && existing !== ref) {
@@ -1563,7 +1576,7 @@ function mergeRuntimeSecretEnv(
 		}
 		merged[envName] = ref;
 	}
-	for (const envName of Object.keys(runtime.run?.env ?? {})) {
+	for (const envName of Object.keys(settings?.env ?? {})) {
 		if (merged[envName] !== undefined) {
 			throw new Error(`runtime ${runtimeName} defines ${envName} in both env and secretEnv`);
 		}
@@ -5060,14 +5073,21 @@ function runtimeProgramRevisionForManifest(
 	openClawOwnerBrowserBootstrapSupported: boolean,
 ): string {
 	const desiredRuntime = manifest.runtimes[runtime];
+	const providerEnvironment = desiredRuntime
+		? hostedProviderEnvironment(manifest, runtime)
+		: { placeholderEnv: {}, secretEnv: {} };
+	const runtimeSettings = desiredRuntime
+		? resolvedRuntimeSettings(
+				manifest,
+				runtime,
+				desiredRuntime.run,
+				providerEnvironment.placeholderEnv,
+			)
+		: undefined;
 	const runtimeSecretRefs = desiredRuntime
 		? [
 				...Object.values(
-					mergeRuntimeSecretEnv(
-						runtime,
-						desiredRuntime,
-						hostedProviderEnvironment(manifest, runtime).secretEnv,
-					),
+					mergeRuntimeSecretEnv(runtime, runtimeSettings, providerEnvironment.secretEnv),
 				),
 				...hostedWhatsAppAuthCredentials(manifest)
 					.filter(
@@ -5137,9 +5157,14 @@ function validateRuntimeManifestPlan(
 			: { placeholderEnv: {}, secretEnv: {} };
 		const { placeholderEnv: providerPlaceholderEnv, secretEnv: providerSecretEnv } =
 			providerEnvironment;
-		mergeRuntimeEnvWithProviderPlaceholders(name, runtime.run, providerPlaceholderEnv);
+		const runtimeSettings = resolvedRuntimeSettings(
+			manifest,
+			runtimeName,
+			runtime.run,
+			providerPlaceholderEnv,
+		);
 		const secretEnv = runtime.enabled
-			? mergeRuntimeSecretEnv(name, runtime, providerSecretEnv)
+			? mergeRuntimeSecretEnv(name, runtimeSettings, providerSecretEnv)
 			: {};
 		for (const [serviceName, serviceSettings] of Object.entries(runtime.services ?? {})) {
 			const service = runtimeServiceNameSchema.parse(serviceName);
@@ -5218,20 +5243,18 @@ function planRuntimeSystemdUserPrograms(input: {
 	return programs;
 }
 
-function hermesDashboardServiceSettings(
+function withHermesDashboardAuthEnvironment(
 	manifest: RuntimeManifest,
-	runtime: RuntimeName,
-	service: RuntimeServiceName,
-	settings: RuntimeRunSettings,
-): RuntimeRunSettings {
-	if (runtime !== "hermes" || service !== "dashboard") return settings;
+	settings: RuntimeRunSettings | undefined,
+): RuntimeRunSettings | undefined {
 	const auth = manifest.hermesDashboardAuth;
 	if (!auth) return settings;
 	if (!auth.activation.enabled) {
 		throw new Error("Hermes password authentication is disabled");
 	}
 	return {
-		...settings,
+		...(settings ?? {}),
+		prependPath: settings?.prependPath ?? [],
 		env: {
 			...(settings?.env ?? {}),
 			HERMES_DASHBOARD_BASIC_AUTH_USERNAME: auth.username,
@@ -5270,13 +5293,14 @@ function resolveRuntimeRunConfigs(input: {
 		: { placeholderEnv: {}, secretEnv: {} };
 	const { placeholderEnv: providerPlaceholderEnv, secretEnv: providerSecretEnv } =
 		providerEnvironment;
-	const runtimeRunSettings = mergeRuntimeEnvWithProviderPlaceholders(
-		input.name,
+	const runtimeRunSettings = resolvedRuntimeSettings(
+		input.manifest,
+		runtimeName,
 		input.runtime.run,
 		providerPlaceholderEnv,
 	);
 	const secretEnv = input.runtime.enabled
-		? mergeRuntimeSecretEnv(input.name, input.runtime, providerSecretEnv)
+		? mergeRuntimeSecretEnv(input.name, runtimeRunSettings, providerSecretEnv)
 		: {};
 	const secretFilePath = null;
 	const runtime = buildRuntimeRunConfig({
@@ -5426,9 +5450,14 @@ function validateRuntimeProjectionPlan(input: {
 			: { placeholderEnv: {}, secretEnv: {} };
 		const { placeholderEnv: providerPlaceholderEnv, secretEnv: providerSecretEnv } =
 			providerEnvironment;
-		mergeRuntimeEnvWithProviderPlaceholders(name, runtime.run, providerPlaceholderEnv);
+		const runtimeSettings = resolvedRuntimeSettings(
+			manifest,
+			runtimeName,
+			runtime.run,
+			providerPlaceholderEnv,
+		);
 		const secretEnv = runtime.enabled
-			? mergeRuntimeSecretEnv(name, runtime, providerSecretEnv)
+			? mergeRuntimeSecretEnv(name, runtimeSettings, providerSecretEnv)
 			: {};
 		scopedSecretValues(secretValues, Object.values(secretEnv));
 		for (const [serviceName, serviceSettings] of Object.entries(runtime.services ?? {})) {


### PR DESCRIPTION
## Summary
- project Hermes Basic Auth environment into both the official Hermes gateway and the dashboard service
- include gateway auth secret rotation in runtime reconciliation
- release the stable CLI patch as `0.13.96`

## Verification
- `scripts/test.sh cli src/runtime/manifest-contract.test.ts src/runtime/manifest-reconciliation.test.ts src/runtime/manifest-services.test.ts` (218 passed)
- focused runtime service suite (30 passed)
- Biome CI on all changed files
- official Hermes installer completed on the existing tenant image digest

No tenant image changes are included.