### PR TITLE
Release stable CLI 0.13.97

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.96",
+      "version": "0.13.97",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.96",
+	"version": "0.13.97",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary
- publish the Hermes gateway authentication fix from #1099
- bump the stable CLI version from `0.13.96` to `0.13.97`

This has no prerelease suffix, so the release workflow publishes to npm `latest`, not `beta`. No tenant image changes are included.

## Verification
- #1099 CI fully green, including privileged systemd E2E and clean runner
- focused runtime service suite: 30 passed
- CLI typecheck passed
- frozen lockfile install passed