### PR TITLE
fix(cli): bootstrap OpenClaw auth marker before doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.13.99
+
+Package: `clawdi@0.13.99`
+
+### Fixed
+
+- Hosted v2 OpenClaw recovery now registers the managed API-key environment
+  marker before repairing legacy config, so existing deployments can converge
+  without persisting the marker as a local credential.
+
 ## Clawdi CLI v0.13.98
 
 Package: `clawdi@0.13.98`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.98",
+      "version": "0.13.99",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.98",
+	"version": "0.13.99",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -178,9 +178,11 @@ import {
 import {
 	ensureManagedOpenClawProviderPlugin,
 	managedOpenClawConfigPath,
+	managedOpenClawProviderPluginInstallDir,
 	managedOpenClawProviderPluginMutationTargets,
 	managedOpenClawStateDir,
 	openClawProviderEnvVarsSdkPath,
+	stageManagedOpenClawProviderMarker,
 } from "./openclaw-managed-provider-plugin";
 import { openClawPluginInspectSchema } from "./openclaw-plugin-observation";
 import { normalizeSecretValues, runtimeSecretValue } from "./secret-values";
@@ -5840,11 +5842,11 @@ function runtimeColdInstallMutationPlan(
 	};
 }
 
-function excludeColdInstallSnapshotCoverage(
+function excludeRuntimeSnapshotCoverage(
 	plan: RuntimeManagedMutationPlan,
-	coldInstallPlan: RuntimeManagedMutationPlan,
+	coveragePlan: RuntimeManagedMutationPlan,
 ): RuntimeManagedMutationPlan {
-	const contentRoots = coldInstallPlan.runtimeUserTargets.map((path) => resolve(path));
+	const contentRoots = coveragePlan.runtimeUserTargets.map((path) => resolve(path));
 	const coveredByContentRoot = (path: string): boolean => {
 		const candidate = resolve(path);
 		return contentRoots.some((root) => {
@@ -5852,7 +5854,7 @@ function excludeColdInstallSnapshotCoverage(
 			return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
 		});
 	};
-	const coldMetadata = new Set(coldInstallPlan.metadataTargets.map((path) => resolve(path)));
+	const coveredMetadata = new Set(coveragePlan.metadataTargets.map((path) => resolve(path)));
 	return {
 		...plan,
 		runtimeUserTargets: plan.runtimeUserTargets.filter((path) => !coveredByContentRoot(path)),
@@ -5860,8 +5862,27 @@ function excludeColdInstallSnapshotCoverage(
 			(path) => !coveredByContentRoot(path),
 		),
 		metadataTargets: plan.metadataTargets.filter(
-			(path) => !coveredByContentRoot(path) && !coldMetadata.has(resolve(path)),
+			(path) => !coveredByContentRoot(path) && !coveredMetadata.has(resolve(path)),
 		),
+	};
+}
+
+function managedOpenClawMarkerBootstrapMutationPlan(
+	manifest: RuntimeManifest,
+	paths: RuntimePaths,
+): RuntimeManagedMutationPlan | null {
+	if (!hasManagedClawdiOpenClawApiKeyProjection(manifest)) return null;
+	const target = managedOpenClawProviderPluginInstallDir(
+		hostedRuntimeProjectionHome(manifest, paths),
+	);
+	const runtimeUserTrustedRoots = [paths.userHome, paths.clawdiHome];
+	return {
+		rootTargets: [],
+		trustedRootDirectories: [],
+		runtimeUserTargets: [target],
+		runtimeUserTrustedRoots,
+		runtimeUserSymlinkTargets: [],
+		metadataTargets: mutationAncestorMetadataTargets([target], runtimeUserTrustedRoots),
 	};
 }
 
@@ -6319,6 +6340,8 @@ export function convergeRuntimeManifest(
 	const coldInstallSnapshot = coldInstallPlan
 		? captureRuntimeLiveSnapshot(coldInstallPlan.snapshot)
 		: null;
+	const markerBootstrapPlan = managedOpenClawMarkerBootstrapMutationPlan(manifest, paths);
+	let markerBootstrapSnapshot: RuntimeLiveSnapshot | null = null;
 	try {
 		if (coldInstallPlan) {
 			hostedRuntimeContract.assertPlatformRoots();
@@ -6341,7 +6364,34 @@ export function convergeRuntimeManifest(
 			}
 		}
 		if (installErrors.length > 0) throw new Error(installErrors.join("; "));
+		if (markerBootstrapPlan) {
+			markerBootstrapSnapshot = captureRuntimeLiveSnapshot(markerBootstrapPlan);
+			ensureRuntimeUserOwnershipBoundaries([
+				...markerBootstrapPlan.metadataTargets,
+				...markerBootstrapPlan.runtimeUserTargets,
+			]);
+			const observation = observations.get("openclaw");
+			if (!observation?.commandPath) {
+				throw new Error("OpenClaw managed provider marker requires an installed runtime");
+			}
+			stageManagedOpenClawProviderMarker({
+				home: projectionHome,
+				commandPath: observation.commandPath,
+				appRoot: observation.appRoot,
+			});
+		}
 	} catch (error) {
+		if (markerBootstrapSnapshot) {
+			try {
+				restoreRuntimeLiveSnapshot(markerBootstrapSnapshot);
+			} catch (rollbackError) {
+				installErrors.push(
+					`OpenClaw managed provider marker rollback failed: ${
+						rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+					}`,
+				);
+			}
+		}
 		if (coldInstallSnapshot) {
 			try {
 				restoreRuntimeLiveSnapshot(coldInstallSnapshot);
@@ -6354,7 +6404,7 @@ export function convergeRuntimeManifest(
 			}
 		}
 		const message = error instanceof Error ? error.message : String(error);
-		if (installErrors.length === 0) installErrors.push(message);
+		if (!installErrors.includes(message)) installErrors.unshift(message);
 		return runtimeConvergenceWithoutApply({
 			load,
 			paths,
@@ -6439,10 +6489,12 @@ export function convergeRuntimeManifest(
 			observations,
 		});
 	} catch (error) {
+		if (markerBootstrapSnapshot) restoreRuntimeLiveSnapshot(markerBootstrapSnapshot);
 		if (coldInstallSnapshot) restoreRuntimeLiveSnapshot(coldInstallSnapshot);
 		throw error;
 	}
 	if (mutationPlan.systemdDriftErrors.length > 0) {
+		if (markerBootstrapSnapshot) restoreRuntimeLiveSnapshot(markerBootstrapSnapshot);
 		if (coldInstallSnapshot) restoreRuntimeLiveSnapshot(coldInstallSnapshot);
 		installErrors.push(...mutationPlan.systemdDriftErrors);
 		return runtimeConvergenceWithoutApply({
@@ -6462,17 +6514,22 @@ export function convergeRuntimeManifest(
 	const workspaceExistedBeforeApply = existsSync(workspaceRoot);
 	let liveSnapshot: ReturnType<typeof captureRuntimeLiveSnapshot>;
 	try {
-		liveSnapshot = captureRuntimeLiveSnapshot(
-			coldInstallPlan
-				? excludeColdInstallSnapshotCoverage(mutationPlan.snapshot, coldInstallPlan.snapshot)
-				: mutationPlan.snapshot,
-		);
-		if (coldInstallSnapshot) {
-			for (const [path, node] of coldInstallSnapshot.entries) {
-				liveSnapshot.entries.set(path, node);
+		let snapshotPlan = mutationPlan.snapshot;
+		if (coldInstallPlan) {
+			snapshotPlan = excludeRuntimeSnapshotCoverage(snapshotPlan, coldInstallPlan.snapshot);
+		}
+		if (markerBootstrapPlan) {
+			snapshotPlan = excludeRuntimeSnapshotCoverage(snapshotPlan, markerBootstrapPlan);
+		}
+		liveSnapshot = captureRuntimeLiveSnapshot(snapshotPlan);
+		for (const earlierSnapshot of [coldInstallSnapshot, markerBootstrapSnapshot]) {
+			if (!earlierSnapshot) continue;
+			for (const [path, node] of earlierSnapshot.entries) {
+				if (!liveSnapshot.entries.has(path)) liveSnapshot.entries.set(path, node);
 			}
 		}
 	} catch (error) {
+		if (markerBootstrapSnapshot) restoreRuntimeLiveSnapshot(markerBootstrapSnapshot);
 		if (coldInstallSnapshot) restoreRuntimeLiveSnapshot(coldInstallSnapshot);
 		throw error;
 	}

--- a/packages/cli/src/runtime/openclaw-managed-provider-plugin.ts
+++ b/packages/cli/src/runtime/openclaw-managed-provider-plugin.ts
@@ -110,16 +110,16 @@ export function managedOpenClawProviderPluginMutationTargets(home: string): stri
 	];
 }
 
-function sourceIsCurrent(sourceDir: string): boolean {
+function pluginDirectoryIsCurrent(directory: string): boolean {
 	try {
-		const stat = lstatSync(sourceDir);
+		const stat = lstatSync(directory);
 		if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
-		const entries = readdirSync(sourceDir).sort();
+		const entries = readdirSync(directory).sort();
 		if (entries.length !== pluginFiles.size) return false;
 		return entries.every((entry) => {
 			const expected = pluginFiles.get(entry);
 			if (expected === undefined) return false;
-			const path = join(sourceDir, entry);
+			const path = join(directory, entry);
 			const file = lstatSync(path);
 			return file.isFile() && !file.isSymbolicLink() && readFileSync(path, "utf8") === expected;
 		});
@@ -129,17 +129,20 @@ function sourceIsCurrent(sourceDir: string): boolean {
 	}
 }
 
-function materializePluginSource(home: string): string {
-	const sourceDir = managedOpenClawProviderPluginSourceDir(home);
-	if (sourceIsCurrent(sourceDir)) return sourceDir;
+function materializePluginDirectory(directory: string): string {
+	if (pluginDirectoryIsCurrent(directory)) return directory;
 	withRuntimeUserFileAccess(() => {
-		rmSync(sourceDir, { recursive: true, force: true });
-		mkdirSync(sourceDir, { recursive: true, mode: 0o700 });
+		rmSync(directory, { recursive: true, force: true });
+		mkdirSync(directory, { recursive: true, mode: 0o700 });
 		for (const [name, content] of pluginFiles) {
-			writeFileSync(join(sourceDir, name), content, { mode: 0o600 });
+			writeFileSync(join(directory, name), content, { mode: 0o600 });
 		}
 	});
-	return sourceDir;
+	return directory;
+}
+
+function materializePluginSource(home: string): string {
+	return materializePluginDirectory(managedOpenClawProviderPluginSourceDir(home));
 }
 
 type PluginInspect = ReturnType<typeof managedOpenClawPluginInspectSchema.parse>;
@@ -287,6 +290,15 @@ export function requireManagedOpenClawProviderMarker(input: {
 	if (result.status !== 0) {
 		throw commandFailure("OpenClaw managed provider env marker verification failed", result);
 	}
+}
+
+export function stageManagedOpenClawProviderMarker(input: {
+	home: string;
+	commandPath?: string | null;
+	appRoot?: string | null;
+}): void {
+	materializePluginDirectory(managedOpenClawProviderPluginInstallDir(input.home));
+	requireManagedOpenClawProviderMarker(input);
 }
 
 export function ensureManagedOpenClawProviderPlugin(input: {

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -180,6 +180,7 @@ state_dir="\${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
 plugin_root="$state_dir/extensions/clawdi-managed-provider"
 if [ "$*" = "plugins inspect clawdi-managed-provider --json" ]; then
   test -f "$plugin_root/openclaw.plugin.json" || exit 1
+  test -f "$plugin_root/.source-path" || exit 1
   enabled=false
   status=disabled
   if [ -f "$plugin_root/.enabled" ]; then enabled=true; status=loaded; fi

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -573,6 +573,22 @@ test("projects a large OpenClaw provider model-list reduction through the public
 		expect(beforeBytes).toBeGreaterThan(5_000);
 		expect(rejectedBytes).toBeLessThan(Math.floor(beforeBytes * 0.5));
 		expect(readFileSync(configPath, "utf8")).toBe(originalConfig);
+		writeFileSync(
+			configPath,
+			`${JSON.stringify(
+				{
+					...existingConfig,
+					agents: {
+						...existingConfig.agents,
+						list: [{ id: "main", workspace: null }],
+					},
+				},
+				null,
+				2,
+			)}\n`,
+			{ mode: 0o600 },
+		);
+		chownSync(configPath, runtimeUid, runtimeGid);
 
 		const convergence = convergeRuntimeManifest(load, paths, { cacheLastGood: false });
 		expect(convergence.installErrors).toEqual([]);
@@ -672,6 +688,7 @@ test("projects a large OpenClaw provider model-list reduction through the public
 			auth: { mode: "token", token: "size-drop-gateway-token" },
 		});
 		expect(appliedConfig.logging).toEqual(existingConfig.logging);
+		expect(appliedConfig.agents.list).toEqual([{ id: "main" }]);
 		expect(appliedConfig.auth).toEqual({
 			profiles: { "openai:user": { provider: "openai", mode: "api_key" } },
 			order: { openai: ["openai:user"] },

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1233,6 +1233,7 @@ state_dir="\${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
 plugin_root="$state_dir/extensions/clawdi-managed-provider"
 if [ "$*" = "plugins inspect clawdi-managed-provider --json" ]; then
   test -f "$plugin_root/openclaw.plugin.json" || exit 1
+  test -f "$plugin_root/.source-path" || exit 1
   enabled=false
   status=disabled
   if [ -f "$plugin_root/.enabled" ]; then enabled=true; status=loaded; fi
@@ -1310,7 +1311,20 @@ function writeOpenClawConfigMutationFixture(
 set -euo pipefail
 printf '%s\n' "$*" >> '${commandLog}'
 if [ "\${1:-}" = "--version" ]; then printf 'openclaw test-version\n'; exit 0; fi
-if [ "$*" = "agents list --json" ]; then printf '[{"id":"main","workspace":"${home}/.openclaw/workspace"}]\n'; exit 0; fi
+if [ "$*" = "agents list --json" ]; then
+  if grep -q 'legacyInvalidConfig' '${configPath}' 2>/dev/null; then exit 1; fi
+  printf '[{"id":"main","workspace":"${home}/.openclaw/workspace"}]\n'
+  exit 0
+fi
+if [ "$*" = "config validate --json" ] && grep -q 'legacyInvalidConfig' '${configPath}' 2>/dev/null; then
+  printf '{"valid":false,"path":"${configPath}","issues":[{"path":"meta","message":"Invalid input"},{"path":"agents","message":"Invalid input"}]}\n'
+  exit 1
+fi
+if [ "$*" = "doctor --fix --non-interactive" ]; then
+  grep -q 'CLAWDI_AI_API_KEY' "$HOME/.openclaw/extensions/clawdi-managed-provider/openclaw.plugin.json"
+  printf '{}\n' > '${configPath}'
+  exit 0
+fi
 ${fakeManagedOpenClawProviderPluginCommands()}
 if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then cat >/dev/null; fi
 exit 0
@@ -2435,6 +2449,37 @@ function hostedSingleProviderModeLoad(
 			recovery: { cacheManifest: true, allowOfflineBoot: true },
 		},
 	};
+}
+
+function hostedManagedOpenClawV2Load(home: string, generation: number): RuntimeManifestLoad {
+	const load = hostedSingleProviderModeLoad(home, "openclaw", "configured", generation, {
+		hostedV2: true,
+	});
+	const providerId = "clawdi-v2-deployment-42";
+	const providers = {
+		[providerId]: {
+			...load.manifest.projection?.providers?.["clawdi-managed"],
+			model: "sol",
+			models: [{ id: "sol" }],
+			apiMode: "openai_chat",
+		},
+	};
+	load.manifest = {
+		...load.manifest,
+		runtimes: {
+			openclaw: {
+				...load.manifest.runtimes.openclaw,
+				provider_ids: [providerId],
+				primary_model: { provider_id: providerId, model: "sol" },
+			},
+		},
+		projection: { ...load.manifest.projection, providers },
+		egressProfiles: hostedManifestEgressProfiles({
+			providers,
+			terminalTooling: load.manifest.projection?.terminalTooling,
+		}),
+	};
+	return load;
 }
 
 function writeTestRuntimeAppliedState(
@@ -3986,6 +4031,43 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		expect(JSON.stringify(runConfig)).not.toContain("sk-runtime-provider");
 	});
 
+	it("stages the managed provider marker before repairing invalid OpenClaw config", () => {
+		const home = join(root, "invalid-openclaw-config", "home", "clawdi");
+		const state = join(root, "invalid-openclaw-config", "var", "lib", "clawdi");
+		const run = join(root, "invalid-openclaw-config", "run", "clawdi");
+		const { configPath, commandLog } = writeOpenClawConfigMutationFixture(home, {
+			legacyInvalidConfig: true,
+			meta: "legacy",
+			agents: [],
+		});
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
+		process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_PROVIDER_AUTH_SDK = writeFakeOpenClawProviderAuthSdk(
+			join(root, "invalid-openclaw-config", "provider-auth"),
+			join(root, "invalid-openclaw-config", "provider-auth-calls.log"),
+		);
+		const paths = getRuntimePaths();
+		const loaded = hostedManagedOpenClawV2Load(home, 1);
+		loaded.manifest.egressEngine = seedMitmproxyCache(paths);
+
+		const convergence = convergeRuntimeManifest(loaded, paths, {
+			hostedOpenClawSkillDriver,
+		});
+
+		expect(convergence.installErrors).toEqual([]);
+		const commands = readFileSync(commandLog, "utf8").trim().split("\n");
+		const doctorIndex = commands.indexOf("doctor --fix --non-interactive");
+		const installIndex = commands.findIndex(
+			(command) => command.startsWith("plugins install ") && command.endsWith(" --force"),
+		);
+		expect(doctorIndex, commands.join(" | ")).toBeGreaterThan(-1);
+		expect(installIndex).toBeGreaterThan(doctorIndex);
+		expect(JSON.parse(readFileSync(configPath, "utf8"))).not.toHaveProperty("legacyInvalidConfig");
+	});
+
 	it("removes reserved OpenClaw provider auth from every store only for managed env projection", () => {
 		const home = join(root, "model-switch", "home", "clawdi");
 		const state = join(root, "model-switch", "var", "lib", "clawdi");
@@ -4142,37 +4224,8 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		}
 
 		const paths = getRuntimePaths();
-		const loaded = hostedSingleProviderModeLoad(home, "openclaw", "configured", 2, {
-			hostedV2: true,
-		});
+		const loaded = hostedManagedOpenClawV2Load(home, 2);
 		loaded.manifest.egressEngine = seedMitmproxyCache(paths);
-		const providerId = "clawdi-v2-deployment-42";
-		const providers = {
-			[providerId]: {
-				...loaded.manifest.projection?.providers?.["clawdi-managed"],
-				model: "sol",
-				models: [{ id: "sol" }],
-				apiMode: "openai_chat",
-			},
-		};
-		loaded.manifest = {
-			...loaded.manifest,
-			runtimes: {
-				openclaw: {
-					...loaded.manifest.runtimes.openclaw,
-					provider_ids: [providerId],
-					primary_model: { provider_id: providerId, model: "sol" },
-				},
-			},
-			projection: {
-				...loaded.manifest.projection,
-				providers,
-			},
-			egressProfiles: hostedManifestEgressProfiles({
-				providers,
-				terminalTooling: loaded.manifest.projection?.terminalTooling,
-			}),
-		};
 
 		const beforeFailedConfig = readFileSync(openclawConfig, "utf8");
 		const beforeFailedStores = new Map(


### PR DESCRIPTION
## Summary

- stage the Hosted v2 managed-provider metadata before OpenClaw repairs legacy config
- verify the canonical provider env marker through the public OpenClaw SDK
- retain the official plugin install/enable lifecycle and exact rollback coverage
- release as clawdi 0.13.99

## Scope

Hosted v2 managed OpenClaw only. No v1, public logs, Sub2API, IP matching, or tenant-state changes.

## Verification

- isolated CLI typecheck and focused runtime suites: 222 pass, 0 fail
- privileged official OpenClaw/systemd E2E: 4 pass, 0 fail, 201 assertions
- Biome: 1041 files, no findings
- git diff --check