### PR TITLE
fix(cli): pin hosted v2 OpenClaw exactly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
-## Unreleased
+## Clawdi CLI v0.13.100
+
+Package: `clawdi@0.13.100`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Unreleased
+
+### Fixed
+
+- Hosted v2 OpenClaw convergence now installs the audited exact
+  `openclaw@2026.8.1-beta.2` package, repairs existing version drift, verifies
+  the installed version exactly, and delegates downgrade protection to the
+  official installer's config-writer compatibility guard.
+
 ## Clawdi CLI v0.13.99
 
 Package: `clawdi@0.13.99`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.99",
+      "version": "0.13.100",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/ai-provider-agent-contract-audit.md
+++ b/docs/ai-provider-agent-contract-audit.md
@@ -152,8 +152,9 @@ Clawdi-owned metadata plugin declaring
 provider projection and cleanup. Convergence verifies the effective marker via
 the public provider-env-vars SDK and fails closed if OpenClaw did not register
 it. This contract does not depend on a legacy plugin. The audited `8f382a2`
-source is provenance evidence, not a Hosted pin; the v2 official installer
-selects `openclaw@latest`.
+source is provenance evidence, while the selected Clawdi release owns the
+Hosted-v2 exact package pin `openclaw@2026.8.1-beta.2` behind the unchanged
+official-installer selector.
 
 Hosted v2 convergence:
 

--- a/docs/ai-providers.md
+++ b/docs/ai-providers.md
@@ -235,9 +235,9 @@ patch --stdin`.
 The repository regression-audits these public SDK and projection mechanics with
 `openclaw@2026.7.1-2`, official source commit
 [`0790d9f`](https://github.com/openclaw/openclaw/commit/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c).
-That artifact is an audit sample, not the Hosted v2 runtime pin; the official
-installer selects `openclaw@latest` and convergence capability-gates the APIs it
-uses.
+That artifact remains an API audit sample. The selected Clawdi release owns the
+Hosted-v2 runtime pin `openclaw@2026.8.1-beta.2`; convergence also
+capability-gates the APIs it uses.
 The discovery skip is implemented in
 [`models-config.plan.ts`](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/agents/models-config.plan.ts#L115-L120).
 API-key providers use env-backed `apiKey` references and explicitly set
@@ -266,8 +266,8 @@ projection or cleanup. It then verifies `CLAWDI_AI_API_KEY` through the public
 `openclaw/plugin-sdk/provider-env-vars` export and fails closed if the marker is
 not registered. Explicit `auth: "api-key"` remains necessary for execution
 precedence but is not the doctor prevention mechanism. Commit `8f382a2` is
-source provenance for this contract, not a Hosted v2 runtime pin; the official
-installer owns the selected `openclaw@latest` artifact.
+source provenance for this contract; the Clawdi release owns the exact Hosted-v2
+artifact `openclaw@2026.8.1-beta.2`.
 
 When the accepted Hosted v2 manifest proves that exact managed projection,
 root-owned convergence uses OpenClaw's public config-mutation and provider-auth

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -577,7 +577,7 @@ Normalization maps hosted fields into the internal shape:
 | `clawdiCli.packageSpec` | Required exact `clawdi@<semver>` without build metadata, at most 200 characters; remote Hosted manifests never select an npm dist-tag or local path |
 | `clawdiCli.registry` | Required literal `https://registry.npmjs.org`; Hosted does not use npm registry defaults or overrides |
 | `runtimes.<name>.enabled` | Run config and systemd unit state |
-| `runtimes.<name>.install` | Required strict `{source: "official"}` selector; CLI owns the official installer URL and non-version arguments, and Hosted cannot select a version, channel, commit, digest, or custom installer |
+| `runtimes.<name>.install` | Required strict `{source: "official"}` selector; Hosted cannot select a version, channel, commit, digest, or custom installer. The selected Clawdi release owns the official installer contract and the audited exact Hosted-v2 OpenClaw package. |
 | `runtimes.<name>.run` | Command, args, cwd, env, and PATH projection |
 | `runtimes.<name>.providerMode` | Required runtime-provider ownership discriminator: `configured` or `unmanaged` |
 | `runtimes.<name>.provider_ids` | Core Hosted configured mode requires exactly one provider; unmanaged mode requires an exact empty list. Selection is replacement-only, with no fallback or secondary pool. |
@@ -595,10 +595,14 @@ Normalization maps hosted fields into the internal shape:
 | `egressProfiles` | Explicit generic local sidecar profiles; Agent Plugin packages, Store metadata, and public installation APIs cannot declare them |
 | `recovery.{cacheManifest,allowOfflineBoot}` | Required explicit manifest cache and offline-boot behavior |
 
-When an OpenClaw or Hermes installation is missing or requires repair, the CLI
-invokes the official installer without a version selector, so the installer
-chooses its current upstream release. A healthy installed runtime is not
-reinstalled merely to poll for a newer release.
+The outer Hosted selector remains unchanged for reader-first CLI upgrades. A
+new Clawdi release normalizes Hosted-v2 OpenClaw to its internal exact install
+version, currently `openclaw@2026.8.1-beta.2`; Hermes and generic manifests keep
+their existing installer behavior. OpenClaw convergence probes the installed
+CLI, reruns the official installer on drift, passes `meta.lastTouchedVersion`
+through upstream `--compatible-with`, and accepts the result only when the
+installed version exactly matches. It does not compare versions independently
+or rewrite OpenClaw config fields.
 
 Hosted parsing does not accept camel-case runtime binding aliases, snake-case
 provider transport aliases, or string `primary_model` values. Provider model
@@ -1193,20 +1197,25 @@ specifically `cli-config.yaml.example`,
 
 ### Official OpenClaw evidence
 
-Installer research was refreshed on 2026-08-02. The official `main` commit at
-that time was
+Gateway/source research was refreshed on 2026-08-02. The official `main`
+commit at that time was
 [`1e9a620a28d6d8f8a0ba165f2004718a79030460`](https://github.com/openclaw/openclaw/commit/1e9a620a28d6d8f8a0ba165f2004718a79030460).
 The stable release tag
 [`v2026.7.1`](https://github.com/openclaw/openclaw/releases/tag/v2026.7.1),
 resolves to release commit
 [`2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4`](https://github.com/openclaw/openclaw/commit/2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4).
-The immutable integration target is `openclaw@2026.7.1-2` with npm integrity
-`sha512-ycF3yPcbjN6bUPeaUx6Mh6vze1hQWoD3CT/wWcmD7a8xaHHHRUaAlaq+lFxMHf1ssEgODVAwjlzYqp2twkYZ7g==`.
-Its npm manifest omits `gitHead`, while its own `openclaw --version` reports
-`OpenClaw 2026.7.1-2 (0790d9f)`, identifying official source commit
-[`0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c`](https://github.com/openclaw/openclaw/commit/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c).
+Exact package metadata and official installer argument support were revalidated
+on 2026-08-19.
+The Hosted-v2 install target is `openclaw@2026.8.1-beta.2` with npm integrity
+`sha512-k4cwlyFOuXN5wN6NOH/gqxupGuvMkOr5OV2Eh7MJmmGFh86wvWSTrGBkL4XkNTg/kszWzGbotI8wKlZ468EjsQ==`.
+The exact spec resolves through the official installer `--version
+2026.8.1-beta.2` contract. Its npm manifest does not publish `gitHead`, so the
+package spec and registry integrity, rather than an inferred source commit, are
+the auditable artifact identity.
 
-At that published commit, the official installer contract is:
+The separately retained `2026.7.1-2` service-integration audit remains anchored
+to source commit `0790d9f`; it verifies the gateway transaction used by Clawdi,
+not the current Hosted package identity:
 
 | Stage | Official line evidence | Diagnostic consequence |
 | --- | --- | --- |
@@ -1216,7 +1225,7 @@ At that published commit, the official installer contract is:
 | Systemd activation | [`systemd.ts` lines 1101-1147](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/daemon/systemd.ts#L1101-L1147) | `daemon-reload`, enable, and restart are separate failure points after staging. |
 
 Consequently, the absence of gateway process journal entries does not identify
-which installer stage failed. The isolated regression test runs the published
+which installer stage failed. The isolated regression test runs that audited
 package's real `gateway install --force --json` path under a live systemd user
 manager and UID/GID 10001, forces an immutable pre-activation `EISDIR` failure,
 and proves exit/stdout propagation plus exact transaction rollback without

--- a/packages/cli/docs/openclaw-v2-model-projection.md
+++ b/packages/cli/docs/openclaw-v2-model-projection.md
@@ -67,9 +67,10 @@ Clawdi-owned OpenClaw plugin whose setup metadata declares:
 Convergence verifies the effective marker through the public provider-env-vars
 SDK and fails closed before projection or cleanup if it is absent. Explicit
 `auth: "api-key"` controls execution precedence but does not replace this
-doctor prevention. The audited OpenClaw source commit is provenance evidence,
-not a v2 runtime pin; the official installer selects `openclaw@latest`. No
-legacy Hosted plugin participates in this contract.
+doctor prevention. The Clawdi release pins Hosted-v2 OpenClaw to the audited
+exact package `openclaw@2026.8.1-beta.2`; the unchanged outer Hosted installer
+selector carries no version. No legacy Hosted plugin participates in this
+contract.
 
 During every proven managed v2 `clawdi` env projection, convergence uses the
 public config-mutation SDK to remove normalized `clawdi` entries from

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.99",
+	"version": "0.13.100",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest-contract.test.ts
+++ b/packages/cli/src/runtime/manifest-contract.test.ts
@@ -19,4 +19,15 @@ describe("official runtime installer arguments", () => {
 			"/srv/tenant/.local",
 		]);
 	});
+
+	test("passes an exact OpenClaw version through the official installer", () => {
+		expect(officialInstallArgs("openclaw", "/srv/tenant", "2026.8.1-beta.2")).toEqual([
+			"--json",
+			"--no-onboard",
+			"--prefix",
+			"/srv/tenant/.local",
+			"--version",
+			"2026.8.1-beta.2",
+		]);
+	});
 });

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -15,6 +15,8 @@ import {
 import { canonicalSecretRefName, canonicalSecretRefSchema } from "./secret-values";
 
 export const RUNTIME_DESIRED_STATE_SCHEMA_VERSION = "clawdi.runtimeDesiredState.v1";
+export const HOSTED_V2_OPENCLAW_PACKAGE_SPEC = "openclaw@2026.8.1-beta.2";
+export const HOSTED_V2_OPENCLAW_VERSION = HOSTED_V2_OPENCLAW_PACKAGE_SPEC.slice("openclaw@".length);
 
 // Temporary v1 read compatibility. Runtime providers and generated config stay canonical-only.
 export const LEGACY_HOSTED_CODEX_MANAGED_RUNTIME_ENV = "OPENAI_API_KEY";
@@ -70,9 +72,16 @@ const OFFICIAL_INSTALL_ARGS: Record<string, string[]> = {
 	hermes: ["--skip-setup", "--skip-browser", "--non-interactive"],
 };
 
-export function officialInstallArgs(runtime: string, home: string): string[] {
+export function officialInstallArgs(runtime: string, home: string, version?: string): string[] {
 	const args = [...(OFFICIAL_INSTALL_ARGS[runtime] ?? [])];
-	return runtime === "openclaw" ? [...args, "--prefix", join(home, ".local")] : args;
+	return runtime === "openclaw"
+		? [
+				...args,
+				"--prefix",
+				join(home, ".local"),
+				...(version === undefined ? [] : ["--version", version]),
+			]
+		: args;
 }
 
 const hostedRuntimeChoiceSchema = z.enum(["openclaw", "hermes"]);
@@ -163,6 +172,7 @@ const installSchema = z.object({
 	url: z.string().url(),
 	home: z.string().min(1),
 	args: z.array(z.string()).default([]),
+	version: z.string().refine(isHostedExactSemver, "must be an exact semver").optional(),
 });
 
 const runtimeSchema = z.object({

--- a/packages/cli/src/runtime/manifest-mutation-parity.test.ts
+++ b/packages/cli/src/runtime/manifest-mutation-parity.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import type { RuntimeManagedMutationPlan } from "./live-state-snapshot";
 import * as actualSnapshot from "./live-state-snapshot";
+import { HOSTED_V2_OPENCLAW_VERSION } from "./manifest-contract";
 
 const fsOriginals = {
 	chmodSync: realFs.chmodSync,
@@ -131,7 +132,7 @@ test("keeps real Hosted converge mutations inside its exact root and runtime-use
 if [ "$*" = "agents list --json" ]; then
   printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace"
 elif [ "\${1:-}" = "--version" ]; then
-  printf '%s\\n' '2026.7.1'
+  printf '%s\\n' '${HOSTED_V2_OPENCLAW_VERSION}'
 fi
 exit 0
 `,

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -63,6 +63,7 @@ import {
 	AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR,
 	AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR,
 	fileBrowserCompanionSchema,
+	HOSTED_V2_OPENCLAW_VERSION,
 	hostedRuntimeBundleV2ManifestSchema,
 	hostedRuntimeManifestFixtureResponseSchema,
 	hostedRuntimeManifestResponseSchema,
@@ -641,7 +642,7 @@ function writeFakeGatewayCli(input: {
 set -euo pipefail
 case "$*" in
 	"--version")
-		printf '%s\\n' '${input.runtime === "openclaw" ? "OpenClaw test-version" : "Hermes test-version"}'
+		printf '%s\\n' '${input.runtime === "openclaw" ? `OpenClaw ${HOSTED_V2_OPENCLAW_VERSION}` : "Hermes test-version"}'
 		;;
 	"config patch --stdin"*)
 		${input.configPatchPath ? `cat > '${input.configPatchPath}'` : "cat >/dev/null"}
@@ -1089,7 +1090,7 @@ if [[ "$plugin_enabled" == true ]]; then plugin_status=loaded; fi
 
 case "\${1:-}" in
   --version)
-    printf '%s\\n' 'OpenClaw test-version'
+    printf '%s\\n' 'OpenClaw ${HOSTED_V2_OPENCLAW_VERSION}'
     ;;
   agents)
     [[ "\${2:-}" == list && "\${3:-}" == --json ]] || exit 2
@@ -1734,6 +1735,7 @@ chmod 0755 '${commandPath}'
 		});
 
 		expect(parsed.runtimes.custom.install?.args).toEqual([]);
+		expect(parsed.runtimes.custom.install?.version).toBeUndefined();
 		expect(parsed.runtimes.custom.updateChannel).toBe("stable");
 		expect(parsed.projection?.providers?.default).toEqual({ model: "legacy-model" });
 	});
@@ -1968,6 +1970,10 @@ chmod 0755 '${commandPath}'
 			openclawBin,
 			[
 				"#!/bin/sh",
+				'if [ "$1" = "--version" ]; then',
+				`  printf '%s\\n' 'OpenClaw ${HOSTED_V2_OPENCLAW_VERSION}'`,
+				"  exit 0",
+				"fi",
 				'if [ "$1 $2 $3" = "agents list --json" ]; then',
 				'  printf \'[{"id":"main","workspace":"%s"}]\\n\' "$HOME/.openclaw/workspace"',
 				"  exit 0",
@@ -2048,6 +2054,10 @@ chmod 0755 '${commandPath}'
 			openclawBin,
 			[
 				"#!/bin/sh",
+				'if [ "$1" = "--version" ]; then',
+				`  printf '%s\\n' 'OpenClaw ${HOSTED_V2_OPENCLAW_VERSION}'`,
+				"  exit 0",
+				"fi",
 				'if [ "$1 $2 $3" = "agents list --json" ]; then',
 				'  printf \'[{"id":"main","workspace":"%s"}]\\n\' "$HOME/.openclaw/workspace"',
 				"  exit 0",
@@ -2425,8 +2435,12 @@ chmod 0755 '${commandPath}'
 		expect(normalized.manifest.runtimes.openclaw.enabled).toBe(true);
 		expect(normalized.manifest.runtimes.openclaw.updateChannel).toBeUndefined();
 		const install = normalized.manifest.runtimes.openclaw.install;
+		const expectedOpenClawVersion = HOSTED_V2_OPENCLAW_VERSION;
 		expect(install?.url).toBe(OFFICIAL_INSTALL_URLS.openclaw);
-		expect(install?.args).toEqual(officialInstallArgs("openclaw", install?.home ?? ""));
+		expect(install?.version).toBe(expectedOpenClawVersion);
+		expect(install?.args).toEqual(
+			officialInstallArgs("openclaw", install?.home ?? "", expectedOpenClawVersion),
+		);
 		expect(normalized.manifest.runtimes.openclaw.run?.args).toEqual(["gateway", "run"]);
 		expect(normalized.manifest.runtimes.openclaw.run?.secretEnv).toEqual({
 			OPENCLAW_GATEWAY_TOKEN: "secret://runtime/openclaw/gateway-token",
@@ -4891,7 +4905,7 @@ echo spawned > '${installerLog}'
 		).toThrow(`trusted directory path contains a non-directory: ${symlinkPaths.runConfigRoot}`);
 	});
 
-	test("snapshots exact installer targets only when the planned executable is missing", () => {
+	test("snapshots exact installer targets only when installation is planned", () => {
 		const paths = tempRuntimePaths();
 		const home = paths.userHome;
 		const install = (runtime: "openclaw" | "hermes") => ({
@@ -5019,6 +5033,101 @@ echo spawned > '${installerLog}'
 				]),
 			).sort(),
 		).toEqual([join(home, ".local", "bin", "openclaw"), join(home, ".local", "tools")].sort());
+	});
+
+	test("reinstalls hosted v2 OpenClaw exactly and delegates config compatibility to upstream", () => {
+		const paths = tempRuntimePaths();
+		const home = paths.userHome;
+		const commandPath = join(home, ".local", "bin", "openclaw");
+		const configPath = join(home, ".openclaw", "openclaw.json");
+		const installedVersionPath = join(home, ".openclaw", "installed-version");
+		const fixtureRoot = dirname(paths.serviceStateRoot);
+		const installerPath = join(fixtureRoot, "install-openclaw.sh");
+		const installerResultPath = join(fixtureRoot, "installer-result");
+		const installerLog = join(fixtureRoot, "installer.log");
+		const desiredVersion = HOSTED_V2_OPENCLAW_VERSION;
+		const config = {
+			meta: {
+				lastTouchedVersion: desiredVersion,
+				migrations: { applied: ["agents.entries"] },
+			},
+			agents: { entries: [{ id: "main" }] },
+		};
+
+		mkdirSync(dirname(commandPath), { recursive: true });
+		mkdirSync(dirname(configPath), { recursive: true });
+		writeFileSync(installedVersionPath, "2026.7.1-2\n");
+		writeFileSync(configPath, `${JSON.stringify(config)}\n`);
+		writeFileSync(
+			commandPath,
+			`#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  "--version") printf 'OpenClaw %s\n' "$(cat '${installedVersionPath}')" ;;
+  "agents list --json") printf '[{"id":"main","workspace":"%s"}]\n' "$HOME/.openclaw/workspace" ;;
+  *) exit 0 ;;
+esac
+`,
+		);
+		chmodSync(commandPath, 0o700);
+		writeFileSync(
+			installerPath,
+			`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> '${installerLog}'
+cp '${installerResultPath}' '${installedVersionPath}'
+`,
+		);
+		chmodSync(installerPath, 0o700);
+		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
+		process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER = `file://${installerPath}`;
+
+		const install = {
+			authority: "official" as const,
+			method: "official-installer" as const,
+			url: OFFICIAL_INSTALL_URLS.openclaw,
+			home,
+			args: officialInstallArgs("openclaw", home, desiredVersion),
+			version: desiredVersion,
+		};
+		const load = manifestLoad(
+			baseManifest(paths, {
+				openclaw: {
+					enabled: true,
+					install,
+					run: runSettings(commandPath, ["gateway", "run"]),
+					services: {},
+				},
+			}),
+			"hosted-v2-openclaw-exact-version",
+		);
+
+		writeFileSync(installerResultPath, "2026.8.1-beta.1\n");
+		const mismatched = convergeRuntimeManifest(load, paths, {
+			executeOfficialServiceInstallers: false,
+		});
+		expect(mismatched.installErrors).toContain(
+			`runtime openclaw installer did not produce exact version ${desiredVersion}`,
+		);
+
+		writeFileSync(installerResultPath, `${desiredVersion}\n`);
+		const converged = convergeRuntimeManifest(load, paths, {
+			executeOfficialServiceInstallers: false,
+		});
+		expect(converged.installErrors).toEqual([]);
+		expect(execFileSync(commandPath, ["--version"], { encoding: "utf8" }).trim()).toBe(
+			`OpenClaw ${desiredVersion}`,
+		);
+		expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual(config);
+		const expectedArgs = [
+			...officialInstallArgs("openclaw", home, desiredVersion),
+			"--compatible-with",
+			desiredVersion,
+		].join(" ");
+		expect(readFileSync(installerLog, "utf8").trim().split("\n")).toEqual([
+			expectedArgs,
+			expectedArgs,
+		]);
 	});
 
 	test("accepts an installed runtime command symlink as an exact transaction target", () => {

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -5035,7 +5035,7 @@ echo spawned > '${installerLog}'
 		).toEqual([join(home, ".local", "bin", "openclaw"), join(home, ".local", "tools")].sort());
 	});
 
-	test("reinstalls hosted v2 OpenClaw exactly and delegates config compatibility to upstream", () => {
+	test("passes historical config writer versions unchanged to the exact OpenClaw installer", () => {
 		const paths = tempRuntimePaths();
 		const home = paths.userHome;
 		const commandPath = join(home, ".local", "bin", "openclaw");
@@ -5046,9 +5046,10 @@ echo spawned > '${installerLog}'
 		const installerResultPath = join(fixtureRoot, "installer-result");
 		const installerLog = join(fixtureRoot, "installer.log");
 		const desiredVersion = HOSTED_V2_OPENCLAW_VERSION;
+		const configWriterVersion = "2026.8.1.beta.1";
 		const config = {
 			meta: {
-				lastTouchedVersion: desiredVersion,
+				lastTouchedVersion: configWriterVersion,
 				migrations: { applied: ["agents.entries"] },
 			},
 			agents: { entries: [{ id: "main" }] },
@@ -5074,7 +5075,7 @@ esac
 			installerPath,
 			`#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n' "$*" >> '${installerLog}'
+printf '%s\n' "$#" "$@" >> '${installerLog}'
 cp '${installerResultPath}' '${installedVersionPath}'
 `,
 		);
@@ -5122,11 +5123,13 @@ cp '${installerResultPath}' '${installedVersionPath}'
 		const expectedArgs = [
 			...officialInstallArgs("openclaw", home, desiredVersion),
 			"--compatible-with",
-			desiredVersion,
-		].join(" ");
+			configWriterVersion,
+		];
 		expect(readFileSync(installerLog, "utf8").trim().split("\n")).toEqual([
-			expectedArgs,
-			expectedArgs,
+			String(expectedArgs.length),
+			...expectedArgs,
+			String(expectedArgs.length),
+			...expectedArgs,
 		]);
 	});
 

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -19,6 +19,7 @@ import {
 } from "./hosted-egress-profiles";
 import {
 	AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR,
+	HOSTED_V2_OPENCLAW_VERSION,
 	type HostedRuntimeBundleV2Manifest,
 	type HostedRuntimeManifest,
 	hasUnsupportedAgentPluginInstallations,
@@ -453,6 +454,7 @@ export function hostedManifestToRuntimeManifest(
 	const paths = getRuntimePaths({ mode: "hosted" });
 	const selectedRuntime = hosted.runtime;
 	const runtime = hosted.runtimes[selectedRuntime];
+	const installVersion = selectedRuntime === "openclaw" ? HOSTED_V2_OPENCLAW_VERSION : undefined;
 	return {
 		schemaVersion: RUNTIME_DESIRED_STATE_SCHEMA_VERSION,
 		deploymentId: hosted.deploymentId,
@@ -479,7 +481,8 @@ export function hostedManifestToRuntimeManifest(
 					method: "official-installer" as const,
 					url: OFFICIAL_INSTALL_URLS[selectedRuntime],
 					home: paths.userHome,
-					args: officialInstallArgs(selectedRuntime, paths.userHome),
+					args: officialInstallArgs(selectedRuntime, paths.userHome, installVersion),
+					...(installVersion === undefined ? {} : { version: installVersion }),
 				},
 				run: hostedRuntimeRunSettings(selectedRuntime, runtime.run),
 				services: Object.fromEntries(
@@ -666,6 +669,12 @@ function validateManifestSemantics(
 		}
 	}
 	for (const [name, runtime] of Object.entries(manifest.runtimes)) {
+		if (
+			runtime.install?.version !== undefined &&
+			(!isHostedV2 || name !== "openclaw" || runtime.install.version !== HOSTED_V2_OPENCLAW_VERSION)
+		) {
+			errors.push(`runtime ${name} exact install version is reserved for Hosted-v2 OpenClaw`);
+		}
 		if (!runtime.enabled) continue;
 		const runCommand = runtime.run?.command?.trim();
 		if (!isSupportedRuntimeName(name)) {
@@ -698,6 +707,15 @@ function validateManifestSemantics(
 		}
 		if (runtime.install.args.includes("--dir")) {
 			errors.push(`runtime ${name} install args must not include --dir`);
+		}
+		if (runtime.install.version !== undefined) {
+			const expectedArgs = officialInstallArgs(name, runtime.install.home, runtime.install.version);
+			if (
+				runtime.install.args.length !== expectedArgs.length ||
+				runtime.install.args.some((arg, index) => arg !== expectedArgs[index])
+			) {
+				errors.push(`runtime ${name} exact install version must use canonical official args`);
+			}
 		}
 		const prefixIndexes = runtime.install.args.flatMap((arg, index) =>
 			arg === "--prefix" ? [index] : [],

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1232,8 +1232,15 @@ function openClawConfigWriterVersion(home: string): string | null {
 	}
 	const version = meta.lastTouchedVersion;
 	if (version === undefined) return null;
-	if (typeof version !== "string" || !isValidSemver(version)) {
-		throw new Error("OpenClaw config meta.lastTouchedVersion must be valid SemVer");
+	if (
+		typeof version !== "string" ||
+		version.length === 0 ||
+		version.length > 128 ||
+		version.trim() !== version
+	) {
+		throw new Error(
+			"OpenClaw config meta.lastTouchedVersion must be a non-empty trimmed string of at most 128 characters",
+		);
 	}
 	return version;
 }

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1091,6 +1091,7 @@ const liveSyncEnvironmentIndexSchema = z
 function runtimeInstallerExecution(
 	install: RuntimeInstall,
 	installerPath: string,
+	extraArgs: string[] = [],
 ): {
 	command: string;
 	args: string[];
@@ -1102,7 +1103,7 @@ function runtimeInstallerExecution(
 	if (!runtimeUser || runtimeUser === "root") {
 		return {
 			command: "bash",
-			args: [installerPath, ...install.args],
+			args: [installerPath, ...install.args, ...extraArgs],
 			env,
 			executionUser: null,
 		};
@@ -1111,6 +1112,7 @@ function runtimeInstallerExecution(
 	const child = buildRuntimeUserCommand(runtimeUser, install.home, "bash", [
 		installerPath,
 		...install.args,
+		...extraArgs,
 	]);
 	return {
 		command: child.command,
@@ -1191,6 +1193,51 @@ function materializeInstaller(
 	return { path, cleanup: dir };
 }
 
+function reportedRuntimeVersion(output: string): string | null {
+	for (const match of output.matchAll(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?/g)) {
+		if (isValidSemver(match[0])) return match[0];
+	}
+	return null;
+}
+
+function installedOpenClawVersion(command: string, home: string): string | null {
+	try {
+		const result = spawnRuntimeUserCommand(command, ["--version"], home, home, {
+			timeoutMs: 10_000,
+			maxBufferBytes: 64 * 1024,
+		});
+		if (result.status !== 0) return null;
+		return reportedRuntimeVersion(`${String(result.stdout)}\n${String(result.stderr)}`);
+	} catch {
+		return null;
+	}
+}
+
+function openClawConfigWriterVersion(home: string): string | null {
+	const path = managedOpenClawConfigPath(home);
+	if (!existsSync(path)) return null;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(readFileSync(path, "utf-8"));
+	} catch {
+		throw new Error("OpenClaw config is invalid before exact-version installation");
+	}
+	if (!isPlainRecord(parsed)) {
+		throw new Error("OpenClaw config must be an object before exact-version installation");
+	}
+	const meta = parsed.meta;
+	if (meta === undefined) return null;
+	if (!isPlainRecord(meta)) {
+		throw new Error("OpenClaw config meta must be an object before exact-version installation");
+	}
+	const version = meta.lastTouchedVersion;
+	if (version === undefined) return null;
+	if (typeof version !== "string" || !isValidSemver(version)) {
+		throw new Error("OpenClaw config meta.lastTouchedVersion must be valid SemVer");
+	}
+	return version;
+}
+
 function runOfficialInstaller(
 	name: string,
 	install: RuntimeInstall,
@@ -1228,7 +1275,16 @@ function runOfficialInstaller(
 			error: `unsupported runtime ${name}`,
 		});
 	}
-	if (executableExists(commandPath) && !options.force) {
+	const expectedVersion = name === "openclaw" ? install.version : undefined;
+	const observedVersion =
+		expectedVersion === undefined || !executableExists(commandPath)
+			? null
+			: installedOpenClawVersion(commandPath, install.home);
+	if (
+		executableExists(commandPath) &&
+		!options.force &&
+		(expectedVersion === undefined || observedVersion === expectedVersion)
+	) {
 		return finish({
 			runtime: name,
 			enabled: true,
@@ -1250,7 +1306,13 @@ function runOfficialInstaller(
 	const url = executionInstallerUrl(name, install.url);
 	const materialized = materializeInstaller(name, url);
 	try {
-		const execution = runtimeInstallerExecution(install, materialized.path);
+		const configWriterVersion =
+			expectedVersion === undefined ? null : openClawConfigWriterVersion(install.home);
+		const execution = runtimeInstallerExecution(
+			install,
+			materialized.path,
+			configWriterVersion === null ? [] : ["--compatible-with", configWriterVersion],
+		);
 		const result = spawnSync(execution.command, execution.args, {
 			cwd: install.home,
 			env: execution.env,
@@ -1258,7 +1320,14 @@ function runOfficialInstaller(
 			timeout: Number.parseInt(process.env.CLAWDI_RUNTIME_INSTALL_TIMEOUT ?? "1800000", 10),
 		});
 		const exitCode = result.status ?? 1;
-		const installed = exitCode === 0 && executableExists(commandPath);
+		const installedVersion =
+			exitCode === 0 && expectedVersion !== undefined && executableExists(commandPath)
+				? installedOpenClawVersion(commandPath, install.home)
+				: null;
+		const installed =
+			exitCode === 0 &&
+			executableExists(commandPath) &&
+			(expectedVersion === undefined || installedVersion === expectedVersion);
 		return finish({
 			runtime: name,
 			enabled: true,
@@ -1274,7 +1343,9 @@ function runOfficialInstaller(
 			stderrTail: tail(result.stderr),
 			error: installed
 				? null
-				: `runtime ${name} installer exited ${exitCode} or did not create ${commandPath}`,
+				: expectedVersion !== undefined && exitCode === 0
+					? `runtime ${name} installer did not produce exact version ${expectedVersion}`
+					: `runtime ${name} installer exited ${exitCode} or did not create ${commandPath}`,
 		});
 	} catch (error) {
 		return finish({
@@ -1385,11 +1456,18 @@ function planRuntimeInstallObservation(
 	const commandPath = runtimeCommandPath(name, runtime.install.home);
 	const appRoot = runtimeAppRoot(name, runtime.install.home);
 	const capabilityError = hermesDashboardCapabilityError(name, runtime);
+	const exactVersionPresent =
+		name !== "openclaw" ||
+		runtime.install.version === undefined ||
+		(commandPath !== null &&
+			installedOpenClawVersion(commandPath, runtime.install.home) === runtime.install.version);
 	return {
 		runtime: name,
 		enabled: true,
 		status:
-			commandPath && executableExists(commandPath) && !capabilityError ? "present" : "configured",
+			commandPath && executableExists(commandPath) && !capabilityError && exactVersionPresent
+				? "present"
+				: "configured",
 		executionUser: null,
 		commandPath,
 		appRoot,

--- a/packages/cli/src/runtime/platform-root-modes.test.ts
+++ b/packages/cli/src/runtime/platform-root-modes.test.ts
@@ -11,6 +11,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { cacheRuntimeLastGoodManifest, convergeRuntimeManifest } from "./manifest";
+import { HOSTED_V2_OPENCLAW_VERSION } from "./manifest-contract";
 import { normalizeHostedRuntimeBundleV2 } from "./manifest-source";
 import type { RuntimePaths } from "./paths";
 import { ensureRuntimeStateDirs } from "./state";
@@ -49,7 +50,7 @@ test("never chmods the four platform roots that child writes touch", async () =>
 if [ "$*" = "agents list --json" ]; then
   printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace"
 elif [ "\${1:-}" = "--version" ]; then
-  printf '%s\\n' '2026.7.1'
+  printf '%s\\n' '${HOSTED_V2_OPENCLAW_VERSION}'
 fi
 exit 0
 `,

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -32,6 +32,7 @@ import {
 	cacheRuntimeLastGoodManifest,
 	convergeRuntimeManifest as convergeRuntimeManifestWithContract,
 } from "./manifest";
+import { HOSTED_V2_OPENCLAW_VERSION } from "./manifest-contract";
 import {
 	HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
 	loadRemoteRuntimeManifest,
@@ -746,6 +747,7 @@ describe("hosted runtime bundle v2", () => {
 			[
 				"#!/usr/bin/env bash",
 				"set -euo pipefail",
+				`if [[ "$1" == "--version" ]]; then printf '%s\\n' '${HOSTED_V2_OPENCLAW_VERSION}'; exit 0; fi`,
 				'if [[ "$1 $2 $3" == "agents list --json" ]]; then',
 				'  printf \'[{"id":"main","workspace":"%s"}]\\n\' "$HOME/.openclaw/workspace"',
 				'elif [[ "$1 $2 $3" == "config patch --stdin" ]]; then',
@@ -1546,6 +1548,10 @@ describe("hosted runtime bundle v2", () => {
 		writeFileSync(
 			openclawBin,
 			`#!/usr/bin/env sh
+if [ "$*" = "--version" ]; then
+  printf '%s\\n' '${HOSTED_V2_OPENCLAW_VERSION}'
+  exit 0
+fi
 if [ "$*" = "agents list --json" ]; then
   printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace"
   exit 0

--- a/packages/cli/tests/egress-handoff-access-contract.test.ts
+++ b/packages/cli/tests/egress-handoff-access-contract.test.ts
@@ -15,6 +15,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { convergeRuntimeManifest } from "../src/runtime/manifest";
+import { HOSTED_V2_OPENCLAW_VERSION } from "../src/runtime/manifest-contract";
 import { normalizeHostedRuntimeBundleV2 } from "../src/runtime/manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "../src/runtime/paths";
 import { ensureRuntimeStateDirs } from "../src/runtime/state";
@@ -180,7 +181,7 @@ function convergeHostedEgressFixture(): { paths: RuntimePaths; root: string } {
 		openclaw,
 		`#!/bin/sh
 case "$*" in
-  "--version") printf '%s\\n' '2026.7.1' ;;
+  "--version") printf '%s\\n' '${HOSTED_V2_OPENCLAW_VERSION}' ;;
   "agents list --json") printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace" ;;
 esac
 `,

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -72,6 +72,7 @@ import {
 	type RuntimeManifest,
 } from "../src/runtime/manifest";
 import {
+	HOSTED_V2_OPENCLAW_VERSION,
 	hostedRuntimeManifestResponseSchema,
 	manifestSchema,
 	officialInstallArgs,
@@ -1267,7 +1268,7 @@ function seedOpenClawBinary(home: string): void {
 		openclawBin,
 		`#!/bin/sh
 if [ "\${1:-}" = "--version" ]; then
-  printf 'openclaw test-version\n'
+  printf 'openclaw ${HOSTED_V2_OPENCLAW_VERSION}\n'
   exit 0
 fi
 if [ "$*" = "agents list --json" ]; then
@@ -1310,7 +1311,7 @@ function writeOpenClawConfigMutationFixture(
 		`#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> '${commandLog}'
-if [ "\${1:-}" = "--version" ]; then printf 'openclaw test-version\n'; exit 0; fi
+if [ "\${1:-}" = "--version" ]; then printf 'openclaw ${HOSTED_V2_OPENCLAW_VERSION}\n'; exit 0; fi
 if [ "$*" = "agents list --json" ]; then
   if grep -q 'legacyInvalidConfig' '${configPath}' 2>/dev/null; then exit 1; fi
   printf '[{"id":"main","workspace":"${home}/.openclaw/workspace"}]\n'
@@ -1437,7 +1438,7 @@ function seedOfficialOpenClawServiceInstaller(home: string): void {
 		`#!/usr/bin/env bash
 set -euo pipefail
 if [ "\${1:-}" = "--version" ]; then
-  printf 'openclaw test-version\\n'
+  printf 'openclaw ${HOSTED_V2_OPENCLAW_VERSION}\\n'
   exit 0
 fi
 if [ "$*" = "agents list --json" ]; then
@@ -3338,7 +3339,7 @@ describe("runtime manifest datasource", () => {
 			);
 			expect(loaded.manifest.runtimes.openclaw.install?.home).toBe(home);
 			expect(loaded.manifest.runtimes.openclaw.install?.args).toEqual(
-				officialInstallArgs("openclaw", home),
+				officialInstallArgs("openclaw", home, HOSTED_V2_OPENCLAW_VERSION),
 			);
 			expectProviderEgressProfileUsesSecretRef(
 				loaded.manifest.egressProfiles?.profiles,
@@ -8238,7 +8239,7 @@ exit 64
 			`#!/usr/bin/env bash
 set -euo pipefail
 if [ "\${1:-}" = "--version" ]; then
-  printf 'openclaw test-version\\n'
+  printf 'openclaw ${HOSTED_V2_OPENCLAW_VERSION}\\n'
   exit 0
 fi
 if [ "$*" = "agents list --json" ]; then
@@ -9048,6 +9049,10 @@ fi
 			openclawBin,
 			`#!/usr/bin/env bash
 set -euo pipefail
+if [ "\${1:-}" = "--version" ]; then
+  printf 'openclaw ${HOSTED_V2_OPENCLAW_VERSION}\\n'
+  exit 0
+fi
 ${fakeManagedOpenClawProviderPluginCommands()}
 if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
   cat >/dev/null
@@ -10672,7 +10677,7 @@ chmod +x "$prefix/bin/clawdi"
 set -euo pipefail
 printf '%s\n' "$*" >> '${installerLog}'
 if [ "$*" = "--version" ]; then
-  printf '%s\n' '${runtime}-test-version'
+  printf '%s\n' '${runtime === "openclaw" ? HOSTED_V2_OPENCLAW_VERSION : `${runtime}-test-version`}'
 elif [ "$*" = "agents list --json" ]; then
   printf '[{"id":"main","workspace":"${join(home, ".openclaw", "workspace")}"}]\n'
 elif [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ]; then
@@ -13626,7 +13631,7 @@ chmod +x "$prefix/bin/clawdi"
 			`#!/usr/bin/env bash
 set -euo pipefail
 if [ "\${1:-}" = "--version" ]; then
-  printf 'openclaw test-version\\n'
+  printf 'openclaw ${HOSTED_V2_OPENCLAW_VERSION}\\n'
   exit 0
 fi
 if [ "$*" = "agents list --json" ]; then


### PR DESCRIPTION
## Summary

- make the selected Clawdi release the sole Hosted-v2 OpenClaw package authority
- repair installed-version drift through the official installer and verify the resulting version exactly
- pass the existing config writer identity unchanged to the upstream compatibility guard
- release the change as clawdi@0.13.100

## Scope

V2 only. No v1, Hosted image, Sub2API, egress/IP matching, or tenant-data changes.

## Verification

- isolated CLI typecheck
- manifest reconciliation: 187 passed
- full focused hermetic CLI: 190 passed
- Biome
- frozen lockfile install
- git diff --check

## Release impact

Merging changes packages/cli/package.json and automatically starts Publish Agent v2 CLI for clawdi@0.13.100. Existing Hosted deployments remain unchanged until an explicit exact-package controlled rollout.