### PR TITLE
fix(cli): align OpenClaw auth cleanup contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.13.101
+
+Package: `clawdi@0.13.101`
+
+### Fixed
+
+- Hosted v2 OpenClaw recovery now checks only the public SDK exports shipped by
+  the pinned OpenClaw package, allowing existing deployments to upgrade and
+  clean stale managed-provider credentials before gateway activation.
+
 ## Clawdi CLI v0.13.100
 
 Package: `clawdi@0.13.100`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.100",
+      "version": "0.13.101",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.100",
+	"version": "0.13.101",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/lib/codex-oauth-native-store.ts
+++ b/packages/cli/src/lib/codex-oauth-native-store.ts
@@ -392,7 +392,6 @@ if (
   typeof providerAuth.ensureAuthProfileStoreForLocalUpdate !== "function" ||
   typeof providerAuth.listProfilesForProvider !== "function" ||
   typeof providerAuth.removeProviderAuthProfilesWithLock !== "function" ||
-  typeof providerAuth.resolveOpenClawAgentDir !== "function" ||
   typeof configMutation.readConfigFileSnapshotForWrite !== "function" ||
   typeof configMutation.mutateConfigFile !== "function"
 ) {
@@ -410,7 +409,7 @@ const normalizePath = (value) => {
 };
 const stateDir = normalizePath(process.env.OPENCLAW_STATE_DIR?.trim() || join(home, ".openclaw"));
 const defaultAgentDir = join(stateDir, "agents", "main", "agent");
-const agentDirs = new Set([defaultAgentDir, normalizePath(providerAuth.resolveOpenClawAgentDir({}))]);
+const agentDirs = new Set([defaultAgentDir]);
 if (process.env.OPENCLAW_AGENT_DIR?.trim()) {
   agentDirs.add(normalizePath(process.env.OPENCLAW_AGENT_DIR));
 }

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -2249,7 +2249,6 @@ if (
   typeof providerAuth.ensureAuthProfileStoreForLocalUpdate !== "function" ||
   typeof providerAuth.listProfilesForProvider !== "function" ||
   typeof providerAuth.removeProviderAuthProfilesWithLock !== "function" ||
-  typeof providerAuth.resolveOpenClawAgentDir !== "function" ||
   typeof configMutation.readConfigFileSnapshotForWrite !== "function" ||
   typeof configMutation.mutateConfigFile !== "function" ||
   typeof providerEnvVars.listKnownProviderAuthEnvVarNames !== "function"

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -142,9 +142,6 @@ const defaultAgentDir = () => join(
   "main",
   "agent",
 );
-export function resolveOpenClawAgentDir() {
-  return process.env.OPENCLAW_AGENT_DIR || defaultAgentDir();
-}
 export function ensureAuthProfileStoreForLocalUpdate() {
   return { profiles: {}, order: {}, lastGood: {}, usageStats: {} };
 }

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -2045,9 +2045,6 @@ export function ensureAuthProfileStoreForLocalUpdate(agentDir) {
   appendFileSync(callsPath, "ensure " + agentDir + "\\n");
   return readStore(agentDir);
 }
-export function resolveOpenClawAgentDir() {
-  return process.env.OPENCLAW_AGENT_DIR || defaultAgentDir();
-}
 export function listProfilesForProvider(store, provider) {
   appendFileSync(callsPath, "list " + provider + "\\n");
   const providerKey = provider.trim().toLowerCase();


### PR DESCRIPTION
## Summary

- stop requiring the nonexistent resolveOpenClawAgentDir provider-auth export
- preserve complete agent-store discovery through Clawdi-owned state/config sources
- release as clawdi 0.13.101 so Hosted v2 recovery can complete

## Root cause

The pinned openclaw 2026.8.1-beta.2 package exposes every public cleanup API we use except resolveOpenClawAgentDir. The capability probe therefore rejected a compatible installation, causing the runtime transaction to roll back to the old OpenClaw version.

## Verification

- isolated CLI typecheck
- 222 focused tests, 0 failures, 2091 assertions
- real official OpenClaw artifact/systemd E2E: 4 pass, 0 fail, 201 assertions
- Biome on touched product files
- git diff --check

## Release impact

Publishing clawdi 0.13.101 is required. Hosted must then validate that exact package and advance only the selected v2 canary deployment.