### PR TITLE
fix(cli): repair hosted OpenClaw state ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.13.102
+
+Package: `clawdi@0.13.102`
+
+### Fixed
+
+- Hosted v2 OpenClaw deployments now repair private runtime state-directory
+  ownership before official installer and config-repair commands run, allowing
+  existing deployments with legacy ownership drift to converge normally.
+
 ## Clawdi CLI v0.13.101
 
 Package: `clawdi@0.13.101`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.101",
+      "version": "0.13.102",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.101",
+	"version": "0.13.102",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -975,6 +975,24 @@ function makeRuntimeUserPrivateDir(path: string, home: string): void {
 	}
 }
 
+function ensureHostedOpenClawStateDirectories(manifest: RuntimeManifest, home: string): void {
+	if (
+		manifest.projection?.sourceBundleVersion !== "clawdi.hosted-runtime.bundle.v2" ||
+		manifest.runtimes.openclaw?.enabled !== true
+	)
+		return;
+	const stateRoot = join(home, ".openclaw");
+	for (const path of [stateRoot, join(stateRoot, "tmp")]) {
+		if (existsSync(path)) {
+			const node = lstatSync(path);
+			if (!node.isDirectory() || node.isSymbolicLink()) {
+				throw new Error(`hosted OpenClaw state path must be a real directory: ${path}`);
+			}
+		}
+		makeRuntimeUserPrivateDir(path, home);
+	}
+}
+
 function ensureRuntimeUserCliStateRoot(path: string, identity: { uid: number; gid: number }): void {
 	mkdirSync(path, { recursive: true });
 	let node = lstatSync(path);
@@ -6318,6 +6336,9 @@ export function convergeRuntimeManifest(
 		opts.hostedRuntimeContract,
 	);
 	const projectionHome = hostedRuntimeProjectionHome(manifest, paths);
+	// Runtime-user state ownership is a platform invariant, not a manifest
+	// mutation: repair it before snapshots so rollback cannot restore drift.
+	ensureHostedOpenClawStateDirectories(manifest, projectionHome);
 	const hermesWhatsAppAuthDir = managedHermesWhatsAppAuthDir(manifest, projectionHome);
 	removeHostedCliPathExposure(paths);
 	removeLegacyTenantClawdiState(paths);

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1322,6 +1322,7 @@ if [ "$*" = "config validate --json" ] && grep -q 'legacyInvalidConfig' '${confi
   exit 1
 fi
 if [ "$*" = "doctor --fix --non-interactive" ]; then
+	if [ -d "$HOME/.openclaw/tmp" ]; then test "$(stat -c %a "$HOME/.openclaw/tmp")" = 700; fi
   grep -q 'CLAWDI_AI_API_KEY' "$HOME/.openclaw/extensions/clawdi-managed-provider/openclaw.plugin.json"
   printf '{}\n' > '${configPath}'
   exit 0
@@ -4033,11 +4034,14 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		const home = join(root, "invalid-openclaw-config", "home", "clawdi");
 		const state = join(root, "invalid-openclaw-config", "var", "lib", "clawdi");
 		const run = join(root, "invalid-openclaw-config", "run", "clawdi");
+		const openClawTmp = join(home, ".openclaw", "tmp");
 		const { configPath, commandLog } = writeOpenClawConfigMutationFixture(home, {
 			legacyInvalidConfig: true,
 			meta: "legacy",
 			agents: [],
 		});
+		mkdirSync(openClawTmp, { recursive: true });
+		chmodSync(openClawTmp, 0o500);
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
@@ -4064,6 +4068,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		expect(doctorIndex, commands.join(" | ")).toBeGreaterThan(-1);
 		expect(installIndex).toBeGreaterThan(doctorIndex);
 		expect(JSON.parse(readFileSync(configPath, "utf8"))).not.toHaveProperty("legacyInvalidConfig");
+		expect(statSync(openClawTmp).mode & 0o777).toBe(0o700);
 	});
 
 	it("removes reserved OpenClaw provider auth from every store only for managed env projection", () => {


### PR DESCRIPTION
## Summary
- repair Hosted v2 OpenClaw state and scratch directory ownership before official runtime commands run
- fail closed when either managed state path is not a real directory
- keep the repair outside runtime manifest rollback so bad ownership cannot be restored

## Verification
- CLI typecheck
- focused runtime regression: 1 pass, 0 fail
- full isolated CLI suite: 1714 pass, 4 skip, 0 fail
- Biome and git diff check
