### PR TITLE
fix(cli): isolate runtime resource projection failures

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -396,12 +396,13 @@ native runtime contracts: Hermes receives the signed `SKILL.md` URL through
 invalidates the signed file lookup.
 
 Hermes URL delivery follows the upstream native adapter verified at
-[`NousResearch/hermes-agent@aec331899e4748739927fddf02a54327e64419a0`](https://github.com/NousResearch/hermes-agent/blob/aec331899e4748739927fddf02a54327e64419a0/tools/skills_hub.py#L1425-L1558):
+[`NousResearch/hermes-agent@a77ee88ce29c4f1d89f8d60e5b662322645072d8`](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/tools/skills_hub.py#L1428-L1564):
 it installs `SKILL.md` plus explicitly referenced files from the supported
 Skill directories and runs Hermes' normal quarantine and security scan. The
-CLI compares the native result with that exact projection; an older Hermes
-that only installs one file fails closed and rolls back instead of silently
-accepting incomplete Skill bytes.
+URL adapter decodes `SKILL.md` as HTTP text and writes it as UTF-8 while support
+files remain byte payloads, so the CLI compares against that same native
+projection. An older Hermes that only installs one file fails closed and rolls
+back instead of silently accepting incomplete Skill bytes.
 
 OpenClaw directory delivery follows the upstream native CLI verified at
 [`openclaw/openclaw@74014c286d36a4fd8ec16d451333a17e8776fcfe`](https://github.com/openclaw/openclaw/blob/74014c286d36a4fd8ec16d451333a17e8776fcfe/src/cli/skills-cli.ts#L615-L695).

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Status | Public runtime contract |
-| Last updated | 2026-08-15 |
+| Last updated | 2026-08-20 |
 | Owner | CLI runtime and cloud-api layers |
 
 This document describes the public Clawdi CLI and dashboard contract for managed
@@ -907,19 +907,22 @@ affected runtime user units are quiesced; the adapter then captures the exact
 native package directories, runtime plugin configuration, receipt, and
 OpenClaw SQLite/WAL/SHM preimage before applying any native mutation. Any
 package change forces those units through final restart and readiness even when
-their unit/config revision did not change. If native mutation or a later
-installer fails before final activation, compensation runs native rollback,
-filesystem and database snapshot restoration, then systemd rollback and unit
-restart while the affected units remain stopped. Unrelated units are not
-globally quiesced when systemd remains pristine. Native rollback errors remain
-visible, and authority commits only after native state and receipt converge.
+their unit/config revision did not change. A package mutation or receipt failure
+runs native compensation and restores that resource preimage while the affected
+units remain stopped; successful compensation lets core config, official
+services, and final readiness continue. If compensation itself fails, or a
+later core step fails after package success, the outer filesystem/systemd
+transaction restores the whole candidate. Unrelated units are not globally
+quiesced when systemd remains pristine. The plugin receipt advances only with
+native state; native rollback errors remain core failures.
 
 Online preparation stores verified archives in private ownership-keyed cache
-entries. Failed convergence removes entries first created by that attempt while
-retaining the previously committed rollback set. After authority commits, GC
-keeps only receipt-owned archives and ignores unknown or symlink entries.
-Offline convergence never fetches: it revalidates the retained archive and
-fails repair explicitly when that cache is missing or corrupt.
+entries. Failed preparation removes entries first created by that attempt.
+Recoverable projection failure retains the verified desired and rollback
+archives for retry; after native state and receipt converge, GC keeps only
+receipt-owned archives and ignores unknown or symlink entries. Offline
+convergence never fetches: it revalidates the retained archive and reports the
+resource unavailable when that cache is missing or corrupt.
 
 The bundled `clawdi` Skill is platform infrastructure. Hosted constructs its
 private `skills.entries` runtime state internally, and capable CLIs reconcile
@@ -966,6 +969,12 @@ disable releases its ownership without importing or resurrecting a stale
 projection. No reservation or managed target is projected into user Skill
 inventory.
 
+Hosted Skill recovery, ownership validation, native delivery, target trees,
+Hermes `.hub` state, and the reservation ledger form one bounded resource
+transaction. Preparation failure skips that transaction. The first live
+failure stops later Skill commands and restores its exact preimage; a failed
+restore is promoted to a core Apply failure.
+
 MCP remains independent of Skills and has no user declaration or mutation
 contract in this release. The dashboard therefore exposes no MCP page. The safe
 inventory API treats a valid empty or platform-only runtime state as an
@@ -983,12 +992,19 @@ as the desired intent sequence and the ETag as effective content identity. A
 generation-only control-plane bump therefore produces a new ETag so `runtime
 watch` converges immediately.
 
-Reconciliation validates and plans projections before live mutation, completes
-required installers before Apply, and commits last-good, remote ETags, and
+Core reconciliation validates and plans its projections before live mutation,
+completes required installers before Apply, and commits last-good, remote ETags, and
 root-owned `0600` `status/runtime-applied.json` only after managed files and
 systemd state apply successfully. A recoverable Apply failure restores the
 previous Clawdi-owned files and systemd declaration and leaves those authority
 records unchanged.
+
+Skill and Agent Plugin delivery are retryable resource projections outside that
+core commit gate. A resource-only failure leaves no partial resource state,
+does not roll back a successful CLI upgrade, and does not reject the manifest
+generation. `runtime watch` reports `healthImpact=resource_projection` and
+retries with bounded backoff while runtime readiness continues to use the
+committed core authority.
 The last-good manifest and scoped secret cache are each replaced atomically,
 then `runtime-applied.json` is replaced atomically as the final commit record.
 After a crash, strict-v2 offline load requires that final record to match the
@@ -1662,8 +1678,9 @@ fallback for environments that reject custom WebSocket subprotocols.
 
 ## Recovery Rules
 
-- Cache only manifests that validate and converge without install/projection
-  errors.
+- Cache only manifests that validate and converge without core install or
+  projection errors. A retryable Skill or Agent Plugin error may cache the
+  committed core desired state after its resource preimage is restored.
 - Use ETags for remote refreshes where the datasource supports them.
 - Offline boot is allowed only when `recovery.allowOfflineBoot` is true and the
   cached manifest does not require missing secret values. Its root-only secret

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -69,6 +69,7 @@ import {
 	convergeRuntimeManifest,
 	loadRuntimeManifest,
 	type RuntimePrivateAppliedAuthority,
+	type RuntimeResourcePreparationFailures,
 	runtimeRecoverableSecretValues,
 } from "../runtime/manifest";
 import { manifestSchema as runtimeDesiredStateSchema } from "../runtime/manifest-contract";
@@ -203,23 +204,6 @@ interface RuntimeWatchTickOptions {
 	now: number;
 	applyContext?: RuntimeApplyContext;
 	hostedRuntimeContract?: HostedRuntimeContractOptions;
-}
-
-class RuntimeResourceProjectionReconcileError extends Error {
-	constructor(error: unknown) {
-		super(error instanceof Error ? error.message : String(error), { cause: error });
-		this.name = "RuntimeResourceProjectionReconcileError";
-	}
-}
-
-class RuntimeAgentPluginReconcileError extends RuntimeResourceProjectionReconcileError {
-	constructor(
-		readonly installationNames: readonly string[],
-		error: unknown,
-	) {
-		super(error);
-		this.name = "RuntimeAgentPluginReconcileError";
-	}
 }
 
 function writable(path: string): boolean {
@@ -1995,23 +1979,26 @@ async function runtimeInitLocked(
 		}
 		const { convergence } = applyResult;
 		const runtimeErrors = [...convergence.installErrors];
-		const installOk = runtimeErrors.length === 0;
-		if (installOk) completePendingRuntimeCliUpgrade(paths, getCliVersion());
+		const runtimeReady = runtimeErrors.length === 0;
+		if (runtimeReady) completePendingRuntimeCliUpgrade(paths, getCliVersion());
 		const activeAppliedState = readRuntimeAppliedState(paths);
 		const status = buildRuntimeBootStatus(
 			{
 				mode: convergence.mode,
-				status: installOk ? "ok" : "error",
+				status: runtimeReady ? "ok" : "error",
 				stage: "final",
 				bootId,
 				runtimeMode: mode,
 				activeGeneration: activeAppliedState?.generation ?? null,
-				rejectedGeneration: installOk ? null : convergence.manifest.generation,
+				rejectedGeneration: runtimeReady ? null : convergence.manifest.generation,
 				instanceId: activeAppliedState?.instanceId ?? null,
 				enabledRuntimes: convergence.enabledRuntimes,
 				error: runtimeErrors[0],
 				errors: runtimeErrors,
-				exitCode: installOk ? 0 : 23,
+				...(convergence.resourceProjectionErrors.length > 0
+					? { resourceProjectionErrors: convergence.resourceProjectionErrors }
+					: {}),
+				exitCode: runtimeReady ? 0 : 23,
 				datasource: "RuntimeSource",
 				hostPolicy: hostPolicySummary(hostPolicy),
 				manifestSource: {
@@ -2034,7 +2021,7 @@ async function runtimeInitLocked(
 			);
 			console.log(chalk.gray(`  status: ${paths.bootStatus}`));
 		}
-		process.exitCode = installOk ? 0 : 23;
+		process.exitCode = runtimeReady ? 0 : 23;
 		return;
 	}
 
@@ -2120,7 +2107,6 @@ async function runtimeWatchTickAfterCliReconciliation(
 	const activeAppliedState = readRuntimeAppliedState(paths);
 	let failureEtag: string | null = null;
 	let agentPluginFailure: ReturnType<typeof failedHostedAgentPluginsObservation> = null;
-	let resourceProjectionFailure = false;
 	const retryDeferred =
 		opts.failureBackoff !== undefined && opts.now < opts.failureBackoff.nextRetryAt;
 	const manifestEtag =
@@ -2195,41 +2181,28 @@ async function runtimeWatchTickAfterCliReconciliation(
 			paths,
 		);
 		const applyIdentity = loaded.applyContext?.identity ?? null;
-		let applyResult: RuntimeApplyResult;
-		try {
-			applyResult = await applyRuntimeDesiredState(loaded, paths, {
-				authorityCommit: (convergence, authority) =>
-					commitRuntimeAppliedState({
-						load: loaded,
-						paths,
-						etag: bundleEtag,
-						sourceRevision,
-						convergence,
-						applyIdentity,
-						daemonAuthTokenRevision: authority.daemonAuthTokenRevision,
-						daemonProgramRevision: authority.daemonProgramRevision,
-						egressSidecarSecretRevision: authority.egressSidecarSecretRevision,
-						userProcessRevisionAliases: authority.userProcessRevisionAliases,
-					}),
-				continueOnCliUpdateError: true,
-				deferCliInstall: opts.deferCliInstall,
-				deferCliInstallReason: opts.deferCliInstallReason,
-				manifestIdentity,
-				recoverFailedSystemdUnits: opts.recoverFailedSystemdUnits,
-				requireSystemdApplied: applyIdentity !== null,
-				hostedRuntimeContract: opts.hostedRuntimeContract,
-			});
-		} catch (error) {
-			if (error instanceof RuntimeAgentPluginReconcileError) {
-				agentPluginFailure = failedHostedAgentPluginsObservation(
-					loaded.manifest,
+		const applyResult = await applyRuntimeDesiredState(loaded, paths, {
+			authorityCommit: (convergence, authority) =>
+				commitRuntimeAppliedState({
+					load: loaded,
+					paths,
+					etag: bundleEtag,
 					sourceRevision,
-					error.installationNames,
-				);
-			}
-			resourceProjectionFailure = error instanceof RuntimeResourceProjectionReconcileError;
-			throw error;
-		}
+					convergence,
+					applyIdentity,
+					daemonAuthTokenRevision: authority.daemonAuthTokenRevision,
+					daemonProgramRevision: authority.daemonProgramRevision,
+					egressSidecarSecretRevision: authority.egressSidecarSecretRevision,
+					userProcessRevisionAliases: authority.userProcessRevisionAliases,
+				}),
+			continueOnCliUpdateError: true,
+			deferCliInstall: opts.deferCliInstall,
+			deferCliInstallReason: opts.deferCliInstallReason,
+			manifestIdentity,
+			recoverFailedSystemdUnits: opts.recoverFailedSystemdUnits,
+			requireSystemdApplied: applyIdentity !== null,
+			hostedRuntimeContract: opts.hostedRuntimeContract,
+		});
 		if (applyResult.kind === "cli_handoff") {
 			const activeAppliedState = readRuntimeAppliedState(paths);
 			return {
@@ -2276,7 +2249,14 @@ async function runtimeWatchTickAfterCliReconciliation(
 		const { convergence, cliUpdate, systemdApply: systemdApplyResult } = applyResult;
 		const cliUpdateError =
 			cliUpdate.status === "error" ? (cliUpdate.error ?? "CLI update failed") : null;
-		const errors = [...(cliUpdateError ? [cliUpdateError] : []), ...convergence.installErrors];
+		const runtimeErrors = [
+			...(cliUpdateError ? [cliUpdateError] : []),
+			...convergence.installErrors,
+		];
+		const resourceProjectionErrors = [...convergence.resourceProjectionErrors];
+		const errors = [...runtimeErrors, ...resourceProjectionErrors];
+		const resourceProjectionOnly =
+			runtimeErrors.length === 0 && resourceProjectionErrors.length > 0;
 		let selfReexec = cliUpdate.selfReexec;
 		const systemdUnitsChanged =
 			systemdApplyResult.systemUnitsChanged.length > 0 ||
@@ -2287,8 +2267,14 @@ async function runtimeWatchTickAfterCliReconciliation(
 				sourceRevision,
 				convergence.agentPluginFailedNames,
 			);
-			const cliRollback = maybeRollbackFailedCliUpgrade(paths, errors);
-			if (cliRollback.status === "rolled_back") selfReexec = true;
+			const cliRollback = resourceProjectionOnly
+				? null
+				: maybeRollbackFailedCliUpgrade(paths, errors);
+			if (cliRollback?.status === "rolled_back") selfReexec = true;
+			if (resourceProjectionOnly) {
+				const completion = completePendingRuntimeCliUpgrade(paths, getCliVersion());
+				selfReexec = selfReexec || completion.selfReexec;
+			}
 			const activeAppliedState = readRuntimeAppliedState(paths);
 			return {
 				schemaVersion: "clawdi.runtimeWatchEvent.v1",
@@ -2297,20 +2283,16 @@ async function runtimeWatchTickAfterCliReconciliation(
 				errors,
 				error: errors[0],
 				activeGeneration: activeAppliedState?.generation ?? null,
-				rejectedGeneration: convergence.manifest.generation,
+				rejectedGeneration: resourceProjectionOnly ? null : convergence.manifest.generation,
 				instanceId: activeAppliedState?.instanceId ?? null,
 				etag: bundleEtag,
 				cliUpdate,
-				cliRollback,
+				...(cliRollback ? { cliRollback } : {}),
 				selfReexec,
 				systemdUnitsChanged,
 				systemdApply: systemdApplyResult,
 				convergence: convergence.outputs,
-				...(cliUpdateError === null &&
-				convergence.failureHealthImpact === "resource_projection" &&
-				cliRollback.status !== "error"
-					? { healthImpact: "resource_projection" }
-					: {}),
+				...(resourceProjectionOnly ? { healthImpact: "resource_projection" } : {}),
 				...(agentPluginFailure ? { agentPlugins: agentPluginFailure } : {}),
 			};
 		}
@@ -2340,7 +2322,6 @@ async function runtimeWatchTickAfterCliReconciliation(
 			errors: [message],
 			error: message,
 			...(failureEtag ? { etag: failureEtag } : {}),
-			...(resourceProjectionFailure ? { healthImpact: "resource_projection" } : {}),
 			...(agentPluginFailure ? { agentPlugins: agentPluginFailure } : {}),
 		};
 	}
@@ -2382,6 +2363,7 @@ async function applyRuntimeDesiredState(
 	opts: RuntimeApplyOptions = {},
 ): Promise<RuntimeApplyResult> {
 	let preparedHostedAgentPlugins = opts.preparedHostedAgentPlugins;
+	const resourcePreparationFailures: RuntimeResourcePreparationFailures = {};
 	let preservePreparedAgentPluginArchives = false;
 	try {
 		let cliUpdate: RuntimeCliUpdateResult;
@@ -2409,10 +2391,14 @@ async function applyRuntimeDesiredState(
 					offline: load.offline,
 				});
 			} catch (error) {
-				throw new RuntimeAgentPluginReconcileError(
-					Object.keys(load.manifest.projection?.agentPlugins?.installations ?? {}).sort(),
-					error,
-				);
+				resourcePreparationFailures.agentPlugins = {
+					error: `runtime Agent Plugin package preparation failed: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+					installationNames: Object.keys(
+						load.manifest.projection?.agentPlugins?.installations ?? {},
+					).sort(),
+				};
 			}
 		}
 		let preparedHostedSourcedSkills = opts.preparedHostedSourcedSkills;
@@ -2426,7 +2412,9 @@ async function applyRuntimeDesiredState(
 					},
 				);
 			} catch (error) {
-				throw new RuntimeResourceProjectionReconcileError(error);
+				resourcePreparationFailures.sourcedSkills = `runtime sourced Skill archive preparation failed: ${
+					error instanceof Error ? error.message : String(error)
+				}`;
 			}
 		}
 		const previousSystemdUnits = readSystemdUnitSnapshot(paths);
@@ -2447,6 +2435,9 @@ async function applyRuntimeDesiredState(
 			hostedRuntimeContract: opts.hostedRuntimeContract,
 			preparedHostedSourcedSkills,
 			...(preparedHostedAgentPlugins ? { preparedHostedAgentPlugins } : {}),
+			...(Object.keys(resourcePreparationFailures).length > 0
+				? { resourcePreparationFailures }
+				: {}),
 			...(opts.hostedAgentPluginCommandRunner
 				? { hostedAgentPluginCommandRunner: opts.hostedAgentPluginCommandRunner }
 				: {}),

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
@@ -610,6 +610,7 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 		const runner = new FakeNativeRunner();
 		const desired = plugin("acme.tools", "1.2.3", "b".repeat(64));
 		const transaction = prepareTransaction(desiredState("hermes", desired), runner);
+		expect(transaction.snapshotTargets).toContain(join(runner.liveHome, ".hermes", "config.yaml"));
 		transaction.apply();
 		const installIndex = runner.calls.findIndex(
 			(call) => call.home === runner.liveHome && call.args[1] === "install",

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
@@ -366,7 +366,12 @@ function createOpenClawDriver(input: {
 		installTarget: (nativeId) => nativeInstallTarget(input.home, "openclaw", nativeId),
 		mutationStateTargets() {
 			const database = join(input.home, ".openclaw", "state", "openclaw.sqlite");
-			return [database, `${database}-wal`, `${database}-shm`];
+			return [
+				join(input.home, ".openclaw", "openclaw.json"),
+				database,
+				`${database}-wal`,
+				`${database}-shm`,
+			];
 		},
 		observe,
 		install(prepared) {
@@ -481,7 +486,7 @@ function createHermesDriver(input: {
 	return {
 		runtime: "hermes",
 		installTarget: (nativeId) => nativeInstallTarget(input.home, "hermes", nativeId),
-		mutationStateTargets: () => [],
+		mutationStateTargets: () => [join(input.home, ".hermes", "config.yaml")],
 		observe,
 		install(prepared) {
 			withPreparedAgentPluginDirectory(prepared, (sourceDir) => {

--- a/packages/cli/src/runtime/hosted-hermes-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.test.ts
@@ -45,7 +45,8 @@ if sys.argv[1:3] == ["skills", "install"]:
     shutil.rmtree(target, ignore_errors=True)
     target.parent.mkdir(parents=True, exist_ok=True)
     target.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(Path(os.environ["FAKE_HERMES_SOURCE"]) / "SKILL.md", target / "SKILL.md")
+    source_skill = Path(os.environ["FAKE_HERMES_SOURCE"]) / "SKILL.md"
+    (target / "SKILL.md").write_text(source_skill.read_bytes().decode("utf-8", errors="replace"), encoding="utf-8")
     support = Path(os.environ["FAKE_HERMES_SOURCE"]) / "references" / "guide.md"
     if support.exists() and os.environ.get("FAKE_HERMES_OMIT_SUPPORT") != "1":
         (target / "references").mkdir(parents=True, exist_ok=True)
@@ -134,7 +135,9 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		mkdirSync(sourceDir, { recursive: true });
 		const skillV1 = "# Review PR\n\n[Guide](references/guide.md)\n";
 		const skillV2 = "# Review PR v2\n\n[Guide](references/guide.md)\n";
-		writeFileSync(join(sourceDir, "SKILL.md"), skillV1);
+		const skillV1Source = Buffer.concat([Buffer.from(skillV1), Buffer.from([0xff])]);
+		const skillV1Native = Buffer.from(skillV1Source.toString("utf8"), "utf8");
+		writeFileSync(join(sourceDir, "SKILL.md"), skillV1Source);
 		mkdirSync(join(sourceDir, "references"), { recursive: true });
 		writeFileSync(join(sourceDir, "references", "guide.md"), "Pinned guide\n");
 		writeFileSync(join(sourceDir, "skill.json"), '{"catalog_only":true}\n');
@@ -168,7 +171,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		).toBe("installed");
 		const target = join(home, ".hermes", "skills", "review-pr");
 		const receipt = join(home, ".hermes", "skills", ".clawdi-manifest-receipts", "review-pr.json");
-		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe(skillV1);
+		expect(readFileSync(join(target, "SKILL.md"))).toEqual(skillV1Native);
 		expect(readFileSync(join(target, "references", "guide.md"), "utf8")).toBe("Pinned guide\n");
 		expect(existsSync(join(target, "skill.json"))).toBe(false);
 		expect(readFileSync(commandLog, "utf8")).not.toContain("--force");
@@ -182,7 +185,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 
 		writeFileSync(join(target, "SKILL.md"), "forged user bytes\n");
 		expect(hostedHermesSkillExactSourceDriver.verifyOwned(input)).toBe(false);
-		writeFileSync(join(target, "SKILL.md"), skillV1);
+		writeFileSync(join(target, "SKILL.md"), skillV1Native);
 		expect(hostedHermesSkillExactSourceDriver.verifyOwned(input)).toBe(true);
 		expect(existsSync(join(root, "wrong-profile", "skills", "review-pr"))).toBe(false);
 

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -89,7 +89,7 @@ const HERMES_SUPPORT_DIRS = new Set(["references", "templates", "scripts", "asse
 const HERMES_SUPPORT_REFERENCE =
 	/(?:\]\(|`|(?:^|[\s"']))((?:references|templates|scripts|assets|examples)\/[^\s)`"'<>]+)/gm;
 
-/** Mirrors Hermes UrlSource at NousResearch/hermes-agent@aec331899e4748739927fddf02a54327e64419a0. */
+/** Mirrors Hermes UrlSource at NousResearch/hermes-agent@a77ee88ce29c4f1d89f8d60e5b662322645072d8. */
 function expectedHermesNativeTree(sourceDir: string) {
 	const catalogTree = collectManagedSkillTree(sourceDir);
 	const skillMd = catalogTree?.get("SKILL.md");
@@ -99,7 +99,11 @@ function expectedHermesNativeTree(sourceDir: string) {
 		/(?:references|templates|scripts|assets|examples)\/(?:[^\s)`"'<>]*\/)?\.\.(?:\/|$)/m.test(text)
 	)
 		return null;
-	const expected = new Map<string, Buffer>([["SKILL.md", skillMd]]);
+	// UrlSource fetches SKILL.md as HTTP text and quarantine_bundle writes that
+	// text as UTF-8. Support files stay byte-for-byte HTTP payloads.
+	const expected = new Map<string, Buffer>([
+		["SKILL.md", Buffer.from(skillMd.toString("utf8"), "utf8")],
+	]);
 	for (const match of text.matchAll(HERMES_SUPPORT_REFERENCE)) {
 		let relative: string;
 		try {

--- a/packages/cli/src/runtime/live-state-snapshot.ts
+++ b/packages/cli/src/runtime/live-state-snapshot.ts
@@ -13,7 +13,6 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { hostedAgentPluginReceiptsPath } from "./hosted-agent-plugin-package";
 import { runtimeInstallReceiptsPath } from "./install-receipts";
 import type { RuntimeManifest } from "./manifest-contract";
 import type { RuntimePaths } from "./paths";
@@ -61,7 +60,6 @@ export function runtimeRootLiveMutationTargets(
 		paths.appliedState,
 		paths.oauthCredentialRoot,
 		runtimeInstallReceiptsPath(paths),
-		hostedAgentPluginReceiptsPath(paths),
 		paths.runConfigRoot,
 		paths.egressProfileBundle,
 		paths.installInventory,

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -74,6 +74,10 @@ function ledgerPath(): string {
 	return join(getClawdiDir(), "managed-resources", LEDGER_FILE);
 }
 
+export function managedSkillReservationLedgerPath(): string {
+	return ledgerPath();
+}
+
 function legacyHostedLedgerPath(path: string): string | null {
 	const runtimePaths = getRuntimePaths({ mode: "hosted" });
 	return path === join(runtimePaths.managedResourceRoot, LEDGER_FILE)

--- a/packages/cli/src/runtime/manifest-mutation-parity.test.ts
+++ b/packages/cli/src/runtime/manifest-mutation-parity.test.ts
@@ -24,7 +24,7 @@ const fsOriginals = {
 };
 const captureRuntimeLiveSnapshotOriginal = actualSnapshot.captureRuntimeLiveSnapshot;
 const mutations: string[] = [];
-let capturedPlan: RuntimeManagedMutationPlan | null = null;
+const capturedPlans: RuntimeManagedMutationPlan[] = [];
 let recording = false;
 
 function record(path: realFs.PathOrFileDescriptor): void {
@@ -96,7 +96,7 @@ mock.module("node:fs", () => ({
 mock.module("./live-state-snapshot", () => ({
 	...actualSnapshot,
 	captureRuntimeLiveSnapshot: (plan: RuntimeManagedMutationPlan) => {
-		capturedPlan = plan;
+		capturedPlans.push(plan);
 		return captureRuntimeLiveSnapshotOriginal(plan);
 	},
 }));
@@ -205,6 +205,7 @@ exit 0
 		fsOriginals.writeFileSync(egressEngineBinary, "#!/bin/sh\nexit 0\n");
 		fsOriginals.chmodSync(egressEngineBinary, 0o755);
 		ensureRuntimeStateDirs(paths);
+		capturedPlans.length = 0;
 		recording = true;
 		const result = convergeRuntimeManifest(load, paths, {
 			cacheLastGood: false,
@@ -220,12 +221,17 @@ exit 0
 		});
 		recording = false;
 		expect(result.installErrors).toEqual([]);
-		expect(capturedPlan).not.toBeNull();
-		if (!capturedPlan) throw new Error("runtime mutation plan was not captured");
+		expect(capturedPlans.length).toBeGreaterThan(0);
 
-		const rootTargets = capturedPlan.rootTargets.map((path) => resolve(path));
-		const runtimeUserTargets = capturedPlan.runtimeUserTargets.map((path) => resolve(path));
-		const metadataTargets = capturedPlan.metadataTargets.map((path) => resolve(path));
+		const rootTargets = capturedPlans.flatMap((plan) =>
+			plan.rootTargets.map((path) => resolve(path)),
+		);
+		const runtimeUserTargets = capturedPlans.flatMap((plan) =>
+			plan.runtimeUserTargets.map((path) => resolve(path)),
+		);
+		const metadataTargets = capturedPlans.flatMap((plan) =>
+			plan.metadataTargets.map((path) => resolve(path)),
+		);
 		expect(rootTargets.filter((target) => runtimeUserTargets.includes(target))).toEqual([]);
 
 		const scopedMutations = [...new Set(mutations.map(atomicTarget))].filter((path) =>

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -1290,6 +1290,37 @@ chmod 0755 '${commandPath}'
 				agentPlugins: testAgentPluginDesiredState(desired),
 			},
 		};
+		let isolatedAuthorityCommits = 0;
+		let isolatedActivations = 0;
+		const isolated = convergeRuntimeManifest(
+			manifestLoad(nextManifest, "agent-plugin-isolated-failure"),
+			paths,
+			{
+				cacheLastGood: false,
+				preparedHostedAgentPlugins: preparedTestAgentPluginState(desired, previous),
+				commitAuthority: () => isolatedAuthorityCommits++,
+				systemdApply: {
+					activateEgressPrerequisite: successfulPrerequisiteActivation,
+					activate: () => {
+						isolatedActivations += 1;
+						return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
+					},
+					quiesce: () => undefined,
+					rollback: () => {
+						throw new Error("isolated Agent Plugin failure must not roll back core");
+					},
+				},
+			},
+		);
+		expect(isolated.installErrors).toEqual([]);
+		expect(isolated.resourceProjectionErrors.join("\n")).toContain(
+			"OpenClaw native Agent Plugin state change failed",
+		);
+		expect(isolated.agentPluginFailedNames).toEqual(["acme.tools"]);
+		expect(isolatedAuthorityCommits).toBe(1);
+		expect(isolatedActivations).toBe(1);
+		for (const [path, content] of preimage) expect(readFileSync(path)).toEqual(content);
+
 		writeFileSync(eventLog, "");
 		writeFileSync(join(paths.userHome, ".openclaw", "fail-rollback"), "1\n");
 		const rollbackLifecycle: string[] = [];
@@ -4357,16 +4388,22 @@ echo spawned > '${installerLog}'
 		const userOwnedSibling = join(paths.userHome, ".hermes", "skills", "user-owned");
 		mkdirSync(skillDir, { recursive: true });
 		writeFileSync(join(skillDir, "SKILL.md"), "user-owned collision\n");
-		expect(() =>
-			convergeRuntimeManifest(manifestLoad(desiredManifest, "catalog-collision"), paths, {
+		const collision = convergeRuntimeManifest(
+			manifestLoad(desiredManifest, "catalog-collision"),
+			paths,
+			{
 				preparedHostedSourcedSkills: new Map([[prepared.skillId, prepared]]),
 				hostedHermesSkillExactSourceDriver: {
 					install: () => "installed",
 					verifyOwned: () => false,
 					uninstall: () => "removed",
 				},
-			}),
-		).toThrow(`refusing to replace unmanaged review-pr skill at ${skillDir}`);
+			},
+		);
+		expect(collision.installErrors).toEqual([]);
+		expect(collision.resourceProjectionErrors.join("\n")).toContain(
+			`refusing to replace unmanaged review-pr skill at ${skillDir}`,
+		);
 		expect(shouldIgnoreUserSkill(skillDir, "review-pr")).toBe(false);
 		rmSync(skillDir, { recursive: true, force: true });
 		mkdirSync(userOwnedSibling, { recursive: true });
@@ -4402,26 +4439,32 @@ echo spawned > '${installerLog}'
 			preparedHostedSourcedSkills: new Map([[prepared.skillId, prepared]]),
 			hostedHermesSkillExactSourceDriver: nativeReconciler,
 		};
+		let authorityCommits = 0;
 		const lostResponse = convergeRuntimeManifest(
 			manifestLoad(desiredManifest, "catalog-lost-native-response"),
 			paths,
-			options,
+			{ ...options, commitAuthority: () => authorityCommits++ },
 		);
-		expect(lostResponse.installErrors.join("\n")).toContain("lost native install response");
-		expect(lostResponse.failureHealthImpact).toBe("resource_projection");
+		expect(lostResponse.installErrors).toEqual([]);
+		expect(lostResponse.resourceProjectionErrors.join("\n")).toContain(
+			"lost native install response",
+		);
+		expect(authorityCommits).toBe(1);
 		expect(installs).toEqual([false]);
 		expect(shouldIgnoreUserSkill(skillDir, "review-pr")).toBe(false);
 		expect(existsSync(skillDir)).toBe(false);
 
 		mkdirSync(skillDir, { recursive: true });
 		writeFileSync(join(skillDir, "SKILL.md"), "forged user bytes\n");
-		expect(() =>
-			convergeRuntimeManifest(
-				manifestLoad(desiredManifest, "catalog-forged-partial-commit"),
-				paths,
-				options,
-			),
-		).toThrow(`refusing to replace unmanaged review-pr skill at ${skillDir}`);
+		const forged = convergeRuntimeManifest(
+			manifestLoad(desiredManifest, "catalog-forged-partial-commit"),
+			paths,
+			options,
+		);
+		expect(forged.installErrors).toEqual([]);
+		expect(forged.resourceProjectionErrors.join("\n")).toContain(
+			`refusing to replace unmanaged review-pr skill at ${skillDir}`,
+		);
 		expect(verifyCalls).toBe(1);
 		expect(shouldIgnoreUserSkill(skillDir, "review-pr")).toBe(false);
 
@@ -4664,7 +4707,7 @@ echo spawned > '${installerLog}'
 			},
 		});
 		expect(result.installErrors.join("\n")).toContain("injected systemd activation failure");
-		expect(result.failureHealthImpact).toBe("runtime");
+		expect(result.resourceProjectionErrors).toEqual([]);
 		for (const path of rootManagedPaths) {
 			const expected = previous.get(path);
 			if (!expected) throw new Error(`missing preserved fixture for ${path}`);
@@ -4805,7 +4848,6 @@ echo spawned > '${installerLog}'
 				paths.appliedState,
 				paths.oauthCredentialRoot,
 				paths.installReceipts,
-				hostedAgentPluginReceiptsPath(paths),
 				paths.runConfigRoot,
 				paths.egressProfileBundle,
 				paths.installInventory,

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -89,6 +89,7 @@ import {
 	reconcileHermesConfigValue,
 } from "./hermes-config";
 import {
+	hostedAgentPluginReceiptsPath,
 	type PreparedHostedAgentPlugins,
 	writeHostedAgentPluginReceipt,
 } from "./hosted-agent-plugin-package";
@@ -156,6 +157,7 @@ import {
 } from "./managed-channel-reconciliation";
 import {
 	installReservedManagedSkill,
+	managedSkillReservationLedgerPath,
 	managedSkillReservationOwner,
 	managedSkillReservations,
 	releaseManagedSkill,
@@ -172,7 +174,6 @@ import {
 } from "./manifest-contract";
 import {
 	type HostedMcpServerDesiredState,
-	type HostedSkillSource,
 	hostedMcpDesiredStateSchema,
 } from "./manifest-resources";
 import {
@@ -290,7 +291,7 @@ export interface RuntimeConvergenceResult {
 	mode: "normal" | "degraded-offline";
 	enabledRuntimes: string[];
 	installErrors: string[];
-	failureHealthImpact: "runtime" | "resource_projection" | null;
+	resourceProjectionErrors: string[];
 	projectedProviderIds: Record<string, string[]>;
 	agentPluginFailedNames: string[];
 	outputs: {
@@ -322,11 +323,12 @@ export interface RuntimeConvergenceResult {
 	};
 }
 
-class RuntimeResourceProjectionError extends Error {
-	constructor(error: unknown) {
-		super(error instanceof Error ? error.message : String(error), { cause: error });
-		this.name = "RuntimeResourceProjectionError";
-	}
+export interface RuntimeResourcePreparationFailures {
+	agentPlugins?: {
+		error: string;
+		installationNames: readonly string[];
+	};
+	sourcedSkills?: string;
 }
 
 export function planHostedAgentPluginConvergence(input: {
@@ -4609,29 +4611,85 @@ function applyHostedOpenClawSourcedSkills(
 	return ids.map((id) => join(skillsRoot, id));
 }
 
-type HostedSkillProjectionEntry =
-	| { id: string; version: number; digest: string }
-	| { id: string; source: HostedSkillSource };
-
-function hostedSkillProjection(
-	manifest: RuntimeManifest,
-	runtime: string,
-): HostedSkillProjectionEntry[] | null {
-	if (runtime !== "openclaw" && runtime !== "hermes") return null;
-	if (manifest.runtimes[runtime]?.enabled !== true) return [];
-	const projection: HostedSkillProjectionEntry[] = [];
-	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {}).sort(
-		([left], [right]) => left.localeCompare(right),
-	)) {
-		if (desired.enabled !== true) continue;
-		if ("source" in desired) {
-			projection.push({ id: skillId, source: desired.source });
-			continue;
-		}
-		const bundled = resolveHostedBundledSkill(skillId, desired.version);
-		projection.push({ id: bundled.id, version: bundled.version, digest: bundled.digest });
+function runHostedSkillProjectionStep(label: string, step: () => void): void {
+	try {
+		step();
+	} catch (error) {
+		throw new Error(`${label}: ${error instanceof Error ? error.message : String(error)}`, {
+			cause: error,
+		});
 	}
-	return projection;
+}
+
+function reconcileHostedSkillProjection(input: {
+	manifest: RuntimeManifest;
+	observations: ReadonlyMap<string, RuntimeInstallObservation>;
+	home: string;
+	openClawWorkspaceRoot: string | null;
+	preparedSourcedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>;
+	hermesDriver: HostedHermesSkillExactSourceDriver;
+	openClawDriver: HostedOpenClawSkillDriver;
+}): void {
+	const {
+		manifest,
+		observations,
+		home,
+		openClawWorkspaceRoot,
+		preparedSourcedSkills,
+		hermesDriver,
+		openClawDriver,
+	} = input;
+	runHostedSkillProjectionStep("runtime Skill projection planning failed", () => {
+		recoverHostedSourcedSkillReservations(manifest, home, preparedSourcedSkills, hermesDriver);
+		if (openClawWorkspaceRoot) {
+			recoverHostedOpenClawBundledSkillReservations(
+				manifest,
+				openClawWorkspaceRoot,
+				openClawDriver,
+			);
+			recoverHostedOpenClawSourcedSkillReservations(
+				manifest,
+				openClawWorkspaceRoot,
+				preparedSourcedSkills,
+				openClawDriver,
+			);
+		}
+		for (const name of HOSTED_RUNTIME_TARGETS) {
+			validateHostedSkillsPlan(name, manifest, home, openClawWorkspaceRoot, preparedSourcedSkills);
+		}
+	});
+	for (const name of HOSTED_RUNTIME_TARGETS) {
+		runHostedSkillProjectionStep(`runtime ${name} skill projection failed`, () => {
+			applyHostedBundledSkills(
+				name,
+				observations.get(name),
+				manifest,
+				home,
+				openClawWorkspaceRoot,
+				openClawDriver,
+			);
+		});
+	}
+	runHostedSkillProjectionStep("runtime hermes sourced Skill projection failed", () => {
+		applyHostedSourcedSkills(
+			observations.get("hermes"),
+			manifest,
+			home,
+			preparedSourcedSkills,
+			hermesDriver,
+		);
+	});
+	if (!openClawWorkspaceRoot) return;
+	runHostedSkillProjectionStep("runtime openclaw sourced Skill delivery failed", () => {
+		applyHostedOpenClawSourcedSkills(
+			observations.get("openclaw"),
+			manifest,
+			home,
+			openClawWorkspaceRoot,
+			preparedSourcedSkills,
+			openClawDriver,
+		);
+	});
 }
 
 function applyHostedMcpProjections(
@@ -5445,7 +5503,6 @@ function runtimeProgramRevisionForManifest(
 					: (manifest.locale?.timezone ?? null),
 			mcp: hostedTarget ? hostedMcpIntent(manifest) : null,
 			provider: providerProjectionRevision,
-			skills: hostedSkillProjection(manifest, runtime),
 		},
 		desiredRuntime,
 		secretValues: scopedSecretValues(secretValues, runtimeSecretRefs),
@@ -5466,12 +5523,8 @@ function validateRuntimeManifestPlan(
 	manifest: RuntimeManifest,
 	paths: RuntimePaths,
 	openClawWorkspaceRoot: string | null,
-	preparedSourcedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
 ): void {
 	const home = hostedRuntimeProjectionHome(manifest, paths);
-	for (const name of HOSTED_RUNTIME_TARGETS) {
-		validateHostedSkillsPlan(name, manifest, home, openClawWorkspaceRoot, preparedSourcedSkills);
-	}
 	for (const [name, runtime] of Object.entries(manifest.runtimes)) {
 		const runtimeName = runtimeNameSchema.parse(name);
 		const providerEnvironment = runtime.enabled
@@ -5676,7 +5729,6 @@ function runtimeConvergenceWithoutApply(input: {
 	workspaceRoot: string;
 	enabledRuntimes: string[];
 	installErrors: string[];
-	failureHealthImpact?: "runtime" | "resource_projection";
 	projectedProviderIds: Record<string, string[]>;
 	agentPluginFailedNames?: string[];
 }): RuntimeConvergenceResult {
@@ -5689,7 +5741,7 @@ function runtimeConvergenceWithoutApply(input: {
 		mode: input.load.offline ? "degraded-offline" : "normal",
 		enabledRuntimes: input.enabledRuntimes,
 		installErrors: input.installErrors,
-		failureHealthImpact: input.failureHealthImpact ?? "runtime",
+		resourceProjectionErrors: [],
 		projectedProviderIds: input.projectedProviderIds,
 		agentPluginFailedNames: input.agentPluginFailedNames ?? [],
 		outputs: {
@@ -6096,6 +6148,15 @@ export function runtimeUserMutationTargets(
 	for (const agentType of MANAGED_LIVE_SYNC_AGENTS) {
 		targets.add(join(paths.localEnvironments, `${agentType}.json`));
 	}
+	return [...targets].sort();
+}
+
+function hostedSkillMutationTargets(
+	manifest: RuntimeManifest,
+	home: string,
+	openClawWorkspaceRoot: string | null,
+): string[] {
+	const targets = new Set<string>();
 	for (const runtime of HOSTED_RUNTIME_TARGETS) {
 		for (const skillId of hostedBundledSkillIds()) {
 			const target = hostedBundledSkillTargetDir(
@@ -6309,6 +6370,7 @@ export function convergeRuntimeManifest(
 		fileBrowserReadinessProbe?: (url: string) => boolean;
 		preparedHostedSourcedSkills?: ReadonlyMap<string, PreparedHostedSourcedSkill>;
 		preparedHostedAgentPlugins?: PreparedHostedAgentPlugins;
+		resourcePreparationFailures?: RuntimeResourcePreparationFailures;
 		hostedAgentPluginCommandRunner?: HostedAgentPluginCommandRunner;
 		hostedHermesSkillExactSourceDriver?: HostedHermesSkillExactSourceDriver;
 		hostedOpenClawSkillDriver?: HostedOpenClawSkillDriver;
@@ -6322,7 +6384,11 @@ export function convergeRuntimeManifest(
 	) {
 		throw new Error(AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR);
 	}
-	if (hasUnsupportedAgentPluginInstallations(manifest) && !opts.preparedHostedAgentPlugins) {
+	if (
+		hasUnsupportedAgentPluginInstallations(manifest) &&
+		!opts.preparedHostedAgentPlugins &&
+		!opts.resourcePreparationFailures?.agentPlugins
+	) {
 		throw new Error(AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR);
 	}
 	const secretValues = runtimeSecretValues(load);
@@ -6354,6 +6420,7 @@ export function convergeRuntimeManifest(
 	let agentPluginTransaction: HostedAgentPluginTransaction | null = null;
 	const agentPluginFailedNames = new Set<string>();
 	let agentPluginSnapshot: RuntimeLiveSnapshot | null = null;
+	let skillProjectionSnapshot: RuntimeLiveSnapshot | null = null;
 	let agentPluginQuiesceAttempted = false;
 	let agentPluginUnitsQuiesced = false;
 	let agentPluginMutationAttempted = false;
@@ -6384,6 +6451,7 @@ export function convergeRuntimeManifest(
 	const runConfigs: string[] = [];
 	const runtimeSystemdUserPrograms: RuntimeSystemdUserProgram[] = [];
 	const installErrors: string[] = [];
+	const resourceProjectionErrors: string[] = [];
 	const appliedState = readRuntimeAppliedState(paths);
 	let previousInstallReceipts: RuntimeInstallReceipts | null = null;
 	const installReceiptTargets: RuntimeInstallReceiptTargets = {
@@ -6399,6 +6467,16 @@ export function convergeRuntimeManifest(
 	let openClawManagedAuthAgentDirs: string[] = [];
 
 	const preparedHostedSourcedSkills = opts.preparedHostedSourcedSkills ?? new Map();
+	const sourcedSkillsPrepared = opts.resourcePreparationFailures?.sourcedSkills === undefined;
+	if (opts.resourcePreparationFailures?.sourcedSkills) {
+		resourceProjectionErrors.push(opts.resourcePreparationFailures.sourcedSkills);
+	}
+	if (opts.resourcePreparationFailures?.agentPlugins) {
+		resourceProjectionErrors.push(opts.resourcePreparationFailures.agentPlugins.error);
+		for (const name of opts.resourcePreparationFailures.agentPlugins.installationNames) {
+			agentPluginFailedNames.add(name);
+		}
+	}
 	const hermesSkillNativeReconciler =
 		opts.hostedHermesSkillExactSourceDriver ?? hostedHermesSkillExactSourceDriver;
 	const openClawSkillDriver = opts.hostedOpenClawSkillDriver ?? hostedOpenClawSkillDriver;
@@ -6540,31 +6618,7 @@ export function convergeRuntimeManifest(
 						manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2",
 				})
 			: null;
-		recoverHostedSourcedSkillReservations(
-			manifest,
-			projectionHome,
-			preparedHostedSourcedSkills,
-			hermesSkillNativeReconciler,
-		);
-		if (openClawWorkspaceRoot) {
-			recoverHostedOpenClawBundledSkillReservations(
-				manifest,
-				openClawWorkspaceRoot,
-				openClawSkillDriver,
-			);
-			recoverHostedOpenClawSourcedSkillReservations(
-				manifest,
-				openClawWorkspaceRoot,
-				preparedHostedSourcedSkills,
-				openClawSkillDriver,
-			);
-		}
-		validateRuntimeManifestPlan(
-			manifest,
-			paths,
-			openClawWorkspaceRoot,
-			preparedHostedSourcedSkills,
-		);
+		validateRuntimeManifestPlan(manifest, paths, openClawWorkspaceRoot);
 		validateRuntimeProjectionPlan({
 			manifest,
 			paths,
@@ -6743,7 +6797,12 @@ export function convergeRuntimeManifest(
 				for (const name of opts.preparedHostedAgentPlugins.desired.keys()) {
 					agentPluginFailedNames.add(name);
 				}
-				throw new RuntimeResourceProjectionError(error);
+				resourceProjectionErrors.push(
+					`runtime Agent Plugin projection planning failed: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+				planned = { transaction: null };
 			}
 			agentPluginTransaction = planned.transaction;
 			if (agentPluginTransaction?.hasMutations && !opts.systemdApply) {
@@ -7051,54 +7110,46 @@ export function convergeRuntimeManifest(
 		if (installErrors.length > 0) {
 			throw new Error(installErrors.join("; "));
 		}
-		const skillProjectionErrors: string[] = [];
-		for (const name of HOSTED_RUNTIME_TARGETS) {
+		if (sourcedSkillsPrepared) {
 			try {
-				applyHostedBundledSkills(
-					name,
-					observations.get(name),
+				const skillMutationTargets = hostedSkillMutationTargets(
 					manifest,
 					projectionHome,
 					openClawWorkspaceRoot,
-					openClawSkillDriver,
 				);
-			} catch (error) {
-				skillProjectionErrors.push(
-					`runtime ${name} skill projection failed: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
-				);
-			}
-		}
-		try {
-			applyHostedSourcedSkills(
-				observations.get("hermes"),
-				manifest,
-				projectionHome,
-				preparedHostedSourcedSkills,
-				hermesSkillNativeReconciler,
-			);
-		} catch (error) {
-			skillProjectionErrors.push(
-				`runtime hermes sourced Skill projection failed: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
-			);
-		}
-		if (openClawWorkspaceRoot) {
-			try {
-				applyHostedOpenClawSourcedSkills(
-					observations.get("openclaw"),
+				skillProjectionSnapshot = captureRuntimeLiveSnapshot({
+					rootTargets: [managedSkillReservationLedgerPath()],
+					trustedRootDirectories: [paths.managedResourceRoot],
+					runtimeUserTargets: skillMutationTargets,
+					runtimeUserTrustedRoots: [paths.userHome, paths.clawdiHome],
+					runtimeUserSymlinkTargets: [],
+					metadataTargets: mutationAncestorMetadataTargets(skillMutationTargets, [
+						paths.userHome,
+						paths.clawdiHome,
+					]),
+				});
+				reconcileHostedSkillProjection({
 					manifest,
-					projectionHome,
+					observations,
+					home: projectionHome,
 					openClawWorkspaceRoot,
-					preparedHostedSourcedSkills,
-					openClawSkillDriver,
-				);
+					preparedSourcedSkills: preparedHostedSourcedSkills,
+					hermesDriver: hermesSkillNativeReconciler,
+					openClawDriver: openClawSkillDriver,
+				});
 			} catch (error) {
-				skillProjectionErrors.push(
-					`runtime openclaw sourced Skill delivery failed: ${error instanceof Error ? error.message : String(error)}`,
-				);
+				const projectionError = error instanceof Error ? error.message : String(error);
+				try {
+					if (skillProjectionSnapshot) restoreRuntimeLiveSnapshot(skillProjectionSnapshot);
+				} catch (rollbackError) {
+					throw new Error(
+						`runtime Skill projection failed and could not be rolled back: ${projectionError}; ${
+							rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+						}`,
+					);
+				}
+				skillProjectionSnapshot = null;
+				resourceProjectionErrors.push(projectionError);
 			}
 		}
 		try {
@@ -7108,13 +7159,8 @@ export function convergeRuntimeManifest(
 				`runtime MCP projection failed: ${error instanceof Error ? error.message : String(error)}`,
 			);
 		}
-		installErrors.push(...skillProjectionErrors);
 		if (installErrors.length > 0) {
-			const error = new Error(installErrors.join("; "));
-			if (installErrors.length === skillProjectionErrors.length) {
-				throw new RuntimeResourceProjectionError(error);
-			}
-			throw error;
+			throw new Error(installErrors.join("; "));
 		}
 
 		for (const runtime of ["hermes", "openclaw"] as const) {
@@ -7350,10 +7396,14 @@ export function convergeRuntimeManifest(
 			agentPluginQuiesceAttempted = true;
 			opts.systemdApply?.quiesce(agentPluginQuiesceUserUnits);
 			agentPluginUnitsQuiesced = true;
-			if (appliedAgentPluginTransaction.snapshotTargets.length > 0) {
+			agentPluginMutationAttempted = true;
+		}
+		let agentPluginApplyCompleted = false;
+		try {
+			if (appliedAgentPluginTransaction) {
 				agentPluginSnapshot = captureRuntimeLiveSnapshot({
-					rootTargets: [],
-					trustedRootDirectories: [],
+					rootTargets: [hostedAgentPluginReceiptsPath(paths)],
+					trustedRootDirectories: [paths.statusRoot],
 					runtimeUserTargets: [...appliedAgentPluginTransaction.snapshotTargets],
 					runtimeUserTrustedRoots: [projectionHome],
 					runtimeUserSymlinkTargets: [],
@@ -7363,12 +7413,44 @@ export function convergeRuntimeManifest(
 					),
 				});
 			}
-			agentPluginMutationAttempted = true;
-		}
-		try {
 			appliedAgentPluginTransaction?.apply();
+			agentPluginApplyCompleted = true;
+			if (appliedAgentPluginTransaction) {
+				writeHostedAgentPluginReceipt(appliedAgentPluginTransaction.nextReceipt, paths);
+			}
 		} catch (error) {
-			throw new RuntimeResourceProjectionError(error);
+			const failedNames = agentPluginApplyCompleted
+				? opts.preparedHostedAgentPlugins?.desired.keys()
+				: appliedAgentPluginTransaction?.mutationNames;
+			for (const name of failedNames ?? []) {
+				agentPluginFailedNames.add(name);
+			}
+			const rollbackErrors = appliedAgentPluginTransaction?.rollback() ?? [];
+			try {
+				if (agentPluginSnapshot) restoreRuntimeLiveSnapshot(agentPluginSnapshot);
+			} catch (rollbackError) {
+				rollbackErrors.push(
+					`runtime Agent Plugin snapshot rollback failed: ${
+						rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+					}`,
+				);
+			}
+			if (rollbackErrors.length > 0) {
+				throw new Error(
+					`runtime Agent Plugin projection failed and could not be rolled back: ${[
+						error instanceof Error ? error.message : String(error),
+						...rollbackErrors,
+					].join("; ")}`,
+				);
+			}
+			resourceProjectionErrors.push(
+				`runtime Agent Plugin projection failed: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			agentPluginTransaction = null;
+			agentPluginSnapshot = null;
+			agentPluginMutationAttempted = false;
 		}
 		if (
 			officialServicePlan.pending.length > 0 &&
@@ -7438,9 +7520,9 @@ export function convergeRuntimeManifest(
 			mode: load.offline ? "degraded-offline" : "normal",
 			enabledRuntimes,
 			installErrors,
-			failureHealthImpact: null,
+			resourceProjectionErrors,
 			projectedProviderIds,
-			agentPluginFailedNames: [],
+			agentPluginFailedNames: [...agentPluginFailedNames].sort(),
 			outputs: {
 				processManager: "systemd",
 				workspaceRoot,
@@ -7484,16 +7566,6 @@ export function convergeRuntimeManifest(
 				force: true,
 			});
 			commitRuntimeInstallReceipts(installReceiptTargets, paths);
-			if (agentPluginTransaction) {
-				try {
-					writeHostedAgentPluginReceipt(agentPluginTransaction.nextReceipt, paths);
-				} catch (error) {
-					for (const name of opts.preparedHostedAgentPlugins?.desired.keys() ?? []) {
-						agentPluginFailedNames.add(name);
-					}
-					throw new RuntimeResourceProjectionError(error);
-				}
-			}
 			opts.commitAuthority?.(convergence, {
 				...(desiredDaemonAuthTokenRevision !== undefined &&
 				(systemdActivationApplied || daemonAuthTokenRevisionPreviouslyCommitted)
@@ -7539,14 +7611,12 @@ export function convergeRuntimeManifest(
 		}
 		return convergence;
 	} catch (error) {
-		const resourceProjectionFailure = error instanceof RuntimeResourceProjectionError;
 		if (agentPluginMutationAttempted) {
 			for (const name of agentPluginTransaction?.mutationNames ?? []) {
 				agentPluginFailedNames.add(name);
 			}
 		}
 		const applyError = error instanceof Error ? error.message : String(error);
-		const installErrorCountBeforeRollback = installErrors.length;
 		const systemdMutated = opts.systemdApply?.transactionState() === "mutated";
 		const rollbackRequiresQuiesce =
 			systemdMutated || agentPluginQuiesceAttempted || agentPluginMutationAttempted;
@@ -7566,14 +7636,26 @@ export function convergeRuntimeManifest(
 		let filesystemRollbackSucceeded = false;
 		if (candidateQuiesced) {
 			if (agentPluginTransaction) installErrors.push(...agentPluginTransaction.rollback());
-			let pluginFilesystemRollbackSucceeded = true;
+			let resourceFilesystemRollbackSucceeded = true;
 			if (agentPluginSnapshot) {
 				try {
 					restoreRuntimeLiveSnapshot(agentPluginSnapshot);
 				} catch (rollbackError) {
-					pluginFilesystemRollbackSucceeded = false;
+					resourceFilesystemRollbackSucceeded = false;
 					installErrors.push(
 						`runtime Agent Plugin filesystem rollback failed: ${
+							rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+						}`,
+					);
+				}
+			}
+			if (skillProjectionSnapshot) {
+				try {
+					restoreRuntimeLiveSnapshot(skillProjectionSnapshot);
+				} catch (rollbackError) {
+					resourceFilesystemRollbackSucceeded = false;
+					installErrors.push(
+						`runtime Skill filesystem rollback failed: ${
 							rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
 						}`,
 					);
@@ -7595,7 +7677,7 @@ export function convergeRuntimeManifest(
 				} else if (!egressRollbackAuthorityVerified) {
 					rmSync(egressSecretFilePath(paths), { force: true });
 				}
-				filesystemRollbackSucceeded = pluginFilesystemRollbackSucceeded;
+				filesystemRollbackSucceeded = resourceFilesystemRollbackSucceeded;
 			} catch (rollbackError) {
 				installErrors.push(
 					`runtime filesystem rollback failed: ${
@@ -7662,7 +7744,6 @@ export function convergeRuntimeManifest(
 				"runtime egress sidecar stopped because committed secret rollback authority could not be verified",
 			);
 		}
-		const rollbackPreservedRuntimeHealth = installErrors.length === installErrorCountBeforeRollback;
 		installErrors.unshift(`runtime apply failed: ${applyError}`);
 		return runtimeConvergenceWithoutApply({
 			load,
@@ -7670,10 +7751,6 @@ export function convergeRuntimeManifest(
 			workspaceRoot,
 			enabledRuntimes,
 			installErrors,
-			failureHealthImpact:
-				resourceProjectionFailure && rollbackPreservedRuntimeHealth
-					? "resource_projection"
-					: "runtime",
 			projectedProviderIds: Object.fromEntries(
 				Object.entries(previousProjectedProviderIds).map(([runtime, providerIds]) => [
 					runtime,

--- a/packages/cli/src/runtime/runtime-impact-revision.test.ts
+++ b/packages/cli/src/runtime/runtime-impact-revision.test.ts
@@ -26,7 +26,6 @@ describe("runtime impact revisions", () => {
 				locale: null,
 				mcp: null,
 				provider: null,
-				skills: null,
 			},
 			desiredRuntime: { enabled: true, services: {} },
 			secretValues: { TOKEN: "one" },

--- a/packages/cli/src/runtime/runtime-impact-revision.ts
+++ b/packages/cli/src/runtime/runtime-impact-revision.ts
@@ -10,7 +10,6 @@ export interface RuntimeProgramRevisionInput {
 		locale: unknown;
 		mcp: unknown;
 		provider: string | null;
-		skills: unknown;
 	};
 	desiredRuntime: RuntimeManifest["runtimes"][string] | undefined;
 	secretValues: Record<string, string>;

--- a/packages/cli/src/runtime/state.ts
+++ b/packages/cli/src/runtime/state.ts
@@ -61,6 +61,7 @@ export interface RuntimeBootStatus {
 	};
 	error?: string;
 	errors: string[];
+	resourceProjectionErrors?: string[];
 	exitCode: number;
 	datasource: "RuntimeSource";
 	hostPolicy: {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -12431,16 +12431,16 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
-	it("runtime watch never enters a failing projection after CLI activation", async () => {
+	it("runtime watch commits core after CLI activation when Agent Plugin preparation fails", async () => {
 		setRuntimeApplyGeneration(16);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const bin = join(root, "bin");
-		const openclawInstaller = join(root, "install-openclaw.sh");
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
+		const currentVersion = getCliVersion();
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
@@ -12462,7 +12462,7 @@ install -d "$prefix/bin"
 cat > "$prefix/bin/clawdi" <<'SH'
 #!/usr/bin/env bash
 if [ "\${1:-}" = "--version" ]; then
-  echo "1.3.0-test.1"
+  echo "${currentVersion}"
   exit 0
 fi
 if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
@@ -12475,34 +12475,11 @@ chmod +x "$prefix/bin/clawdi"
 `,
 		);
 		chmodSync(join(bin, "npm"), 0o700);
-		writeFileSync(
-			openclawInstaller,
-			`#!/usr/bin/env bash
-set -euo pipefail
-install -d "$HOME/.local/bin"
-cat > "$HOME/.local/bin/openclaw" <<'SH'
-#!/usr/bin/env bash
-if [ "\${1:-} \${2:-} \${3:-}" = "config patch --stdin" ]; then
-  echo "projection boom" >&2
-  exit 73
-fi
-if [ "\${1:-}" = "plugins" ] && [ "\${2:-}" = "install" ]; then
-  exit 0
-fi
-printf 'unexpected openclaw command: %s\\n' "$*" >&2
-exit 64
-SH
-chmod +x "$HOME/.local/bin/openclaw"
-`,
-		);
-		chmodSync(openclawInstaller, 0o700);
 		process.env.PATH = `${bin}:${previousPath ?? ""}`;
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
-		process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER = openclawInstaller;
 		process.exitCode = undefined;
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
@@ -12529,7 +12506,7 @@ chmod +x "$HOME/.local/bin/openclaw"
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
-									packageSpec: "clawdi@1.3.0-test.1",
+									packageSpec: `clawdi@${currentVersion}`,
 									registry: "https://registry.npmjs.org",
 								},
 								agentPlugins: {
@@ -12588,6 +12565,43 @@ chmod +x "$HOME/.local/bin/openclaw"
 			expect(existsSync(join(home, ".local", "bin", "openclaw"))).toBe(false);
 			expect(existsSync(join(state, "cache", "manifest.etag"))).toBe(false);
 			expect(existsSync(getRuntimePaths().appliedState)).toBe(false);
+
+			seedOpenClawBinary(home);
+			installSuccessfulSystemctlFixture();
+			logs.length = 0;
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode).toBe(1);
+			const failedProjection = JSON.parse(logs[0]);
+			expect(failedProjection).toMatchObject({
+				status: "error",
+				stage: "final",
+				healthImpact: "resource_projection",
+				activeGeneration: 16,
+				rejectedGeneration: null,
+				cliUpdate: { status: "current" },
+			});
+			expect(failedProjection.errors.join("\n")).toContain(
+				"Agent Plugin package preparation failed",
+			);
+			expect(failedProjection.cliRollback).toBeUndefined();
+			expect(readRuntimeAppliedState(getRuntimePaths())).toMatchObject({ generation: 16 });
+			expect(JSON.parse(readFileSync(getRuntimePaths().cliUpgradeState, "utf-8"))).toMatchObject({
+				transaction: null,
+				badVersions: [],
+			});
+
+			logs.length = 0;
+			process.exitCode = undefined;
+			await runtimeInit({ nonInteractive: true, json: true });
+
+			expect(process.exitCode).toBe(0);
+			const bootStatus = JSON.parse(logs[0]);
+			expect(bootStatus).toMatchObject({ status: "ok", activeGeneration: 16, errors: [] });
+			expect(bootStatus.resourceProjectionErrors.join("\n")).toContain(
+				"Agent Plugin package preparation failed",
+			);
 		} finally {
 			restore();
 			console.log = previousLog;
@@ -15658,19 +15672,26 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			};
 		};
 
-		expect(() =>
-			convergeRuntimeManifest(
-				loadWithSkillEntry("unknown", { enabled: true, version: 1 }),
-				getRuntimePaths(),
-			),
-		).toThrow("no bundled hosted skill is registered for unknown");
-		expect(() =>
-			convergeRuntimeManifest(
-				loadWithSkillEntry("clawdi", { enabled: true, version: 2 }),
-				getRuntimePaths(),
-			),
-		).toThrow("no bundled hosted skill clawdi version 2 is registered");
-		expect(existsSync(ledgerPath)).toBe(false);
+		const unknownSkill = convergeRuntimeManifest(
+			loadWithSkillEntry("unknown", { enabled: true, version: 1 }),
+			getRuntimePaths(),
+		);
+		expect(unknownSkill.installErrors).toEqual([]);
+		expect(unknownSkill.resourceProjectionErrors.join("\n")).toContain(
+			"no bundled hosted skill is registered for unknown",
+		);
+		const unknownSkillVersion = convergeRuntimeManifest(
+			loadWithSkillEntry("clawdi", { enabled: true, version: 2 }),
+			getRuntimePaths(),
+		);
+		expect(unknownSkillVersion.installErrors).toEqual([]);
+		expect(unknownSkillVersion.resourceProjectionErrors.join("\n")).toContain(
+			"no bundled hosted skill clawdi version 2 is registered",
+		);
+		expect(JSON.parse(readFileSync(ledgerPath, "utf-8"))).toEqual({
+			schemaVersion: "clawdi.hostedManagedMcpServers.v2",
+			runtimes: { openclaw: ["clawdi", "search.proxy"] },
+		});
 
 		const openclawSkill = join(home, ".openclaw", "workspace", "skills", "clawdi");
 		mkdirSync(openclawSkill, { recursive: true });
@@ -15682,11 +15703,15 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			digest: "a".repeat(64),
 			manager: "local-setup",
 		});
-		expect(() =>
-			convergeRuntimeManifest(load(1, "openclaw", initialServers), getRuntimePaths()),
-		).toThrow(`refusing to replace unmanaged clawdi skill at ${openclawSkill}`);
+		const collision = convergeRuntimeManifest(
+			load(1, "openclaw", initialServers),
+			getRuntimePaths(),
+		);
+		expect(collision.installErrors).toEqual([]);
+		expect(collision.resourceProjectionErrors.join("\n")).toContain(
+			`refusing to replace unmanaged clawdi skill at ${openclawSkill}`,
+		);
 		expect(readFileSync(join(openclawSkill, "SKILL.md"), "utf-8")).toBe("local setup skill\n");
-		expect(existsSync(ledgerPath)).toBe(false);
 		releaseManagedSkill({
 			targetDir: openclawSkill,
 			id: "clawdi",


### PR DESCRIPTION
## Summary

- commit core runtime state and CLI upgrades when Skill or Agent Plugin projection fails after exact local rollback
- isolate Skill and Agent Plugin filesystem, receipt, config, and native lifecycle compensation from the core transaction
- preserve official OpenClaw and Hermes gateway lifecycle and avoid Skill-driven gateway restarts
- match Hermes native URL Skill text decoding and keep retryable failures visible without blocking runtime readiness

## Verification

- Head SHA: `4991364256c73ea829002b387cb7872fa3f9387c`
- `bash scripts/test.sh cli`: 1714 passed, 4 skipped, 0 failed
- CLI typecheck passed in the isolated suite
- Biome passed for every changed TypeScript file
- `git diff --check` passed
- GitHub required checks passed

## Release impact

- User-facing Hosted runtime reliability fix
- No schema, migration, public manifest, official gateway lifecycle, or tenant-specific behavior changes
- Does not publish by itself; a separate stable patch-version PR will trigger the immutable CLI release workflow