### PR TITLE
release(cli): 0.13.103

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.13.103
+
+Package: `clawdi@0.13.103`
+
+### Fixed
+
+- Hosted v2 deployments now keep core runtime convergence and CLI upgrades
+  healthy when a Skill or Agent Plugin cannot be projected after exact local
+  rollback. Resource delivery remains visible and retryable without blocking
+  the agent or its browser interface.
+
 ## Clawdi CLI v0.13.102
 
 Package: `clawdi@0.13.102`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.102",
+      "version": "0.13.103",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.102",
+	"version": "0.13.103",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary

- release stable `clawdi@0.13.103`
- document the Hosted runtime resource-projection reliability fix from PR #1105
- keep the release change limited to package identity, lockfile identity, and changelog

## Verification

- Head SHA: `a3ec93c95`
- publish manifest contract passed
- package and workspace lock versions both resolve to `0.13.103`
- `clawdi@0.13.103` and tag `clawdi-cli-v0.13.103` are not yet published
- `git diff --check` passed
- implementation suite on PR #1105: 1714 passed, 4 skipped, 0 failed

## Release impact

Merging changes `packages/cli/package.json`, so the stable immutable CLI workflow will publish `clawdi@0.13.103` to npm tag `latest` and create `clawdi-cli-v0.13.103` with native assets. No beta or Hosted tenant image is involved.