### PR TITLE
fix(cli): respect official runtime service ownership

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1510,16 +1510,18 @@ OpenClaw gateway token is not part of that environment:
 ConditionPathExists=/run/clawdi/systemd/env/openclaw-gateway.service.env
 
 [Service]
-Environment="XDG_RUNTIME_DIR=%t"
-Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus"
+UnsetEnvironment=CLAWDI_AUTH_TOKEN
 EnvironmentFile=/run/clawdi/systemd/env/openclaw-gateway.service.env
 ```
 
 `ExecStart` and `WorkingDirectory` remain solely in the official base unit and
 are deliberately absent from the Clawdi-owned drop-in.
 
-The generated environment file includes
-`CLAWDI_HOME=/var/lib/clawdi-user`; it never points into the tenant home.
+The gateway environment file contains only desired runtime/provider
+environment, any required CA trust variables, and `CLAWDI_RUNTIME_REV`. It does
+not add `HOME`, `PATH`, `TZ`, `CLAWDI_HOME`, or `CLAWDI_AUTH_TOKEN`; the
+OpenClaw gateway token is also absent because the official config and installer
+own it.
 
 When egress profiles are enabled, systemd runs the Clawdi sidecar. Egress
 interception uses a runtime-fetched `mitmdump` (mitmproxy) transparent gateway

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1190,8 +1190,13 @@ URL (including any path prefix), exact `0.0.0.0:9119` service args, and the
 official Basic password/session environment secret references. Hosted derives
 the password and an independent session-signing secret from the gateway token
 and durable Runtime UI access revision. The CLI projects non-secret settings to
-`dashboard.basic_auth` and secrets to the official
-`HERMES_DASHBOARD_BASIC_AUTH_*` environment variables.
+the official `dashboard.basic_auth` and `dashboard.public_url` config keys, and
+projects only the password and session-signing secret through the official
+`HERMES_DASHBOARD_BASIC_AUTH_*` environment variables. Hosted also writes its
+workspace to the official `terminal.cwd` key; it does not replace the gateway
+unit's upstream-owned working directory. Runtime processes keep the system UTC
+timezone, while the agent's business timezone uses the official OpenClaw
+`agents.defaults.userTimezone` or Hermes `timezone` config key.
 
 The dashboard consumes generated discriminated deployment metadata; it does not
 infer auth from the runtime name or fall back to legacy `native_url` fields.
@@ -1207,11 +1212,12 @@ rotates the existing encrypted gateway credential and advances the durable
 access revision through the ordinary generation, manifest, reconcile, and LRO
 completion path; restart and ordinary updates do not rotate it.
 
-The Hermes contract was verified against NousResearch/hermes-agent commit
-[`8208fc52701332f213e6c51ebc0b610be00300de`](https://github.com/NousResearch/hermes-agent/tree/8208fc52701332f213e6c51ebc0b610be00300de),
-specifically `cli-config.yaml.example`,
-`plugins/dashboard_auth/self_hosted/__init__.py`,
-`hermes_cli/dashboard_auth/public_paths.py`, and `hermes_cli/web_server.py`.
+The Hermes contract was verified against Hermes Agent 0.20.4 commit
+[`a72c9ca248a051b8c7e8a69ff422c7be5066cdc4`](https://github.com/NousResearch/hermes-agent/tree/a72c9ca248a051b8c7e8a69ff422c7be5066cdc4),
+specifically `hermes_cli/subcommands/dashboard.py`,
+`plugins/dashboard_auth/basic/__init__.py`,
+`hermes_cli/dashboard_auth/prefix.py`, `hermes_cli/web_server.py`, and
+`hermes_cli/gateway.py`.
 
 ### Official OpenClaw evidence
 

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -578,13 +578,13 @@ Normalization maps hosted fields into the internal shape:
 | `clawdiCli.registry` | Required literal `https://registry.npmjs.org`; Hosted does not use npm registry defaults or overrides |
 | `runtimes.<name>.enabled` | Run config and systemd unit state |
 | `runtimes.<name>.install` | Required strict `{source: "official"}` selector; Hosted cannot select a version, channel, commit, digest, or custom installer. The selected Clawdi release owns the official installer contract and the audited exact Hosted-v2 OpenClaw package. |
-| `runtimes.<name>.run` | Command, args, cwd, env, and PATH projection |
+| `runtimes.<name>.run` | Exact official gateway argv; only OpenClaw may carry its single gateway-token secret reference. Hosted rejects custom commands, cwd, env, and PATH projection. |
 | `runtimes.<name>.providerMode` | Required runtime-provider ownership discriminator: `configured` or `unmanaged` |
 | `runtimes.<name>.provider_ids` | Core Hosted configured mode requires exactly one provider; unmanaged mode requires an exact empty list. Selection is replacement-only, with no fallback or secondary pool. |
 | `runtimes.<name>.primary_model.{provider_id,model}` | Required only in configured mode and its provider must belong to `provider_ids`; absent in unmanaged mode |
-| Hosted filesystem defaults | Derived locally from Hosted `RuntimePaths`: HOME, workspace, persistence root, installer home, and explicit process/service cwd use `userHome`; obsolete external `system`/runtime path fields are rejected |
+| Hosted filesystem defaults | Derived locally from Hosted `RuntimePaths`: HOME, workspace, persistence root, and installer home use `userHome`; Hosted rejects external path and cwd overrides. |
 | `providers.<id>` | Canonical Hosted provider projection: `kind` is exactly `openai-compatible`; normal entries also require `type` and `baseUrl`, while `provider_not_found` is the only reduced error entry |
-| `runtimes.<name>.services` | Runtime-owned auxiliary processes, such as a browser dashboard, managed without user command shims |
+| `runtimes.<name>.services` | Empty for OpenClaw; exactly the fixed official `hermes dashboard` argv for Hermes. Hosted rejects every other runtime-owned process. |
 | `providers` | Required runtime-scoped AI provider projections whose keys exactly match selected `provider_ids`; `{}` in unmanaged mode |
 | `terminalTooling.codex` | Required typed Hosted terminal-tool projection with the selected model plus minimal Clawdi-managed endpoint/secret metadata; it has no provider model catalog and is independent of runtime providers |
 | `mcp.servers` | Required canonical map for generic named stdio or remote HTTP server declarations; invalid stored MCP state fails closed with `409` |
@@ -1124,10 +1124,12 @@ enabled.
 
 ## Runtime UI Authentication
 
-Strict-v2 OpenClaw binds the official gateway directly to the pod network with
-`gateway run --allow-unconfigured --port 18789 --bind lan --force`. Before the
-official service installer runs, Clawdi uses the official `openclaw config patch
---stdin` flow to persist the managed token at `gateway.auth.token`, and passes
+Strict-v2 OpenClaw does not render a gateway `ExecStart`. The manifest's
+canonical `["gateway", "run"]` argv identifies the official gateway service;
+the official installer resolves the configured port and writes its own Node
+entrypoint argv. Before that installer runs, Clawdi uses the official
+`openclaw config patch --stdin` flow to persist the managed token at
+`gateway.auth.token`, and passes
 that same value to the installer through its `OPENCLAW_GATEWAY_TOKEN`
 environment. The token never appears in installer argv. OpenClaw's installer
 resolves configured tokens before its environment fallback and only persists a
@@ -1213,9 +1215,9 @@ specifically `cli-config.yaml.example`,
 
 ### Official OpenClaw evidence
 
-Gateway/source research was refreshed on 2026-08-02. The official `main`
+Gateway/source research was refreshed on 2026-08-20. The official `main`
 commit at that time was
-[`1e9a620a28d6d8f8a0ba165f2004718a79030460`](https://github.com/openclaw/openclaw/commit/1e9a620a28d6d8f8a0ba165f2004718a79030460).
+[`916eef4e996008d387207c53044afd8cf02dcc30`](https://github.com/openclaw/openclaw/commit/916eef4e996008d387207c53044afd8cf02dcc30).
 The stable release tag
 [`v2026.7.1`](https://github.com/openclaw/openclaw/releases/tag/v2026.7.1),
 resolves to release commit
@@ -1226,8 +1228,11 @@ The Hosted-v2 install target is `openclaw@2026.8.1-beta.2` with npm integrity
 `sha512-k4cwlyFOuXN5wN6NOH/gqxupGuvMkOr5OV2Eh7MJmmGFh86wvWSTrGBkL4XkNTg/kszWzGbotI8wKlZ468EjsQ==`.
 The exact spec resolves through the official installer `--version
 2026.8.1-beta.2` contract. Its npm manifest does not publish `gitHead`, so the
-package spec and registry integrity, rather than an inferred source commit, are
-the auditable artifact identity.
+package spec and registry integrity remain the auditable artifact identity;
+the same-version official source tag resolves to commit
+[`8f382a202ff1e15833394b481615dcdda99b04d7`](https://github.com/openclaw/openclaw/commit/8f382a202ff1e15833394b481615dcdda99b04d7)
+and corroborates the CLI and service contracts below without being treated as
+a cryptographic identity for the npm tarball.
 
 The separately retained `2026.7.1-2` service-integration audit remains anchored
 to source commit `0790d9f`; it verifies the gateway transaction used by Clawdi,
@@ -1251,20 +1256,20 @@ inventing a success path:
 scripts/test-runtime-official-installer-systemd.sh
 ```
 
-Done: the command exits 0 and reports `1 pass`.
+Done: the command exits 0 and reports `4 pass`.
 
-The Runtime UI behavior evidence below was refreshed against exact official
-commit
-[`f7a86382823d2b30dca8af578f717a4fa87670f5`](https://github.com/openclaw/openclaw/commit/f7a86382823d2b30dca8af578f717a4fa87670f5).
+The Runtime UI behavior evidence below was refreshed against the same-version
+official source commit
+[`8f382a202ff1e15833394b481615dcdda99b04d7`](https://github.com/openclaw/openclaw/commit/8f382a202ff1e15833394b481615dcdda99b04d7).
 
 | Requirement | Official line evidence | Contract consequence |
 | --- | --- | --- |
-| Gateway bind, port, auth, and token | [`docs/cli/gateway.md`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/docs/cli/gateway.md), [`configuration-reference.md`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/docs/gateway/configuration-reference.md) | Use native `18789`, container-reachable `lan`, required token auth, and explicit public `allowedOrigins`. |
-| Browser handoff command | [`docs/cli/dashboard.md`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/docs/cli/dashboard.md), [`src/commands/dashboard.ts`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/src/commands/dashboard.ts) | `dashboard --json` is the official machine-readable integration surface. Against a running gateway it returns `browserUrl` plus its expiry without opening a browser. |
-| Owner bootstrap contract | [`control-ui-handoff.ts`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/src/commands/control-ui-handoff.ts), [`control-ui-contract.ts`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/src/gateway/control-ui-contract.ts), [`device-bootstrap-profile.ts`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/src/shared/device-bootstrap-profile.ts) | The fragment contains a single-use `bootstrapToken` and the closed `bootstrapProfile=owner` hint; the host-issued profile grants the browser owner credential through OpenClaw's native device flow. |
-| Gateway health surfaces | [`docs/gateway/embedding.md`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/docs/gateway/embedding.md), [`docs/gateway/index.md`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/docs/gateway/index.md) | The CLI commit proof is the required systemd units reaching active/enabled. The workload platform separately gates Service exposure with loopback startup/readiness probes against the official `/healthz` and `/readyz` surfaces. Hermes additionally requires readiness metadata asserting `auth_required` with provider `basic`. |
-| Base path/prefix | [`docs/web/control-ui.md`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/docs/web/control-ui.md) | Configure official `gateway.controlUi.basePath`; rebind only the verified origin while preserving the official path and fragment. |
-| Service lifecycle | [`docs/cli/daemon.md`](https://github.com/openclaw/openclaw/blob/f7a86382823d2b30dca8af578f717a4fa87670f5/docs/cli/daemon.md) | Use official gateway install/start/stop/restart/status lifecycle and keep Clawdi ownership limited to its hosted drop-in/env. |
+| Gateway bind, port, auth, and token | [`docs/cli/gateway.md`](https://github.com/openclaw/openclaw/blob/8f382a202ff1e15833394b481615dcdda99b04d7/docs/cli/gateway.md), [`configuration-reference.md`](https://github.com/openclaw/openclaw/blob/8f382a202ff1e15833394b481615dcdda99b04d7/docs/gateway/configuration-reference.md) | Use native `18789`, container-reachable `lan`, required token auth, and explicit public `allowedOrigins`. |
+| Browser handoff command | [`docs/cli/dashboard.md`](https://github.com/openclaw/openclaw/blob/8f382a202ff1e15833394b481615dcdda99b04d7/docs/cli/dashboard.md), [`src/commands/dashboard.ts`](https://github.com/openclaw/openclaw/blob/8f382a202ff1e15833394b481615dcdda99b04d7/src/commands/dashboard.ts) | `dashboard --json` is the official machine-readable integration surface. Against a running gateway it returns `browserUrl` plus its expiry without opening a browser. |
+| Owner bootstrap contract | [`control-ui-handoff.ts`](https://github.com/openclaw/openclaw/blob/8f382a202ff1e15833394b481615dcdda99b04d7/src/commands/control-ui-handoff.ts), [`control-ui-contract.ts`](https://github.com/openclaw/openclaw/blob/8f382a202ff1e15833394b481615dcdda99b04d7/src/gateway/control-ui-contract.ts), [`device-bootstrap-profile.ts`](https://github.com/openclaw/openclaw/blob/8f382a202ff1e15833394b481615dcdda99b04d7/src/shared/device-bootstrap-profile.ts) | The fragment contains a single-use `bootstrapToken` and the closed `bootstrapProfile=owner` hint; the host-issued profile grants the browser owner credential through OpenClaw's native device flow. |
+| Gateway health surfaces | [`docs/gateway/embedding.md`](https://github.com/openclaw/openclaw/blob/8f382a202ff1e15833394b481615dcdda99b04d7/docs/gateway/embedding.md), [`docs/gateway/index.md`](https://github.com/openclaw/openclaw/blob/8f382a202ff1e15833394b481615dcdda99b04d7/docs/gateway/index.md) | The CLI commit proof is the required systemd units reaching active/enabled. The workload platform separately gates Service exposure with loopback startup/readiness probes against the official `/healthz` and `/readyz` surfaces. Hermes additionally requires readiness metadata asserting `auth_required` with provider `basic`. |
+| Base path/prefix | [`docs/web/control-ui.md`](https://github.com/openclaw/openclaw/blob/8f382a202ff1e15833394b481615dcdda99b04d7/docs/web/control-ui.md) | Configure official `gateway.controlUi.basePath`; rebind only the verified origin while preserving the official path and fragment. |
+| Service lifecycle | [`docs/cli/daemon.md`](https://github.com/openclaw/openclaw/blob/8f382a202ff1e15833394b481615dcdda99b04d7/docs/cli/daemon.md) | Use official gateway install/start/stop/restart/status lifecycle and keep Clawdi ownership limited to its hosted drop-in/env. |
 
 ## Desired State Boundary
 
@@ -1428,6 +1433,11 @@ without ledger ownership fails closed. Native absence already satisfies a
 managed deletion. The convergence transaction snapshots both complete native
 configs and the ledger, preserves unrelated entries, writes the ledger last,
 and restores the exact previous files and metadata if any later mutation fails.
+Hermes' `mcp add` and `mcp remove` flows are interactive and perform live
+discovery, while `mcp list` has no machine-readable output and does not expose
+the complete native map. Hosted therefore resolves the official config path
+with `hermes config path` and atomically reconciles only `mcp_servers`; it does
+not scrape CLI output or inject answers into interactive prompts.
 These paths and transports are pinned to official fixed-commit sources:
 OpenClaw's
 [`mcp-config.ts` read path](https://github.com/openclaw/openclaw/blob/2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4/src/config/mcp-config.ts#L51-L65),
@@ -1537,12 +1547,19 @@ official dashboard installer or claim the compatibility unit is upstream-owned.
 Strict-v2 OpenClaw uses the official gateway directly on native port `18789`.
 Clawdi patches `gateway.port=18789`, `gateway.bind=lan`, and
 `gateway.auth.mode=token` with the managed token. The service receives no token
-environment entry, and the launch command does not pass a conflicting `--auth`
-override:
+environment entry, and the launch command carries no Hosted-owned network or
+authentication overrides. The manifest identity is:
 
-```bash
-openclaw gateway run --allow-unconfigured --port 18789 --bind lan --force
+```json
+{"args": ["gateway", "run"]}
 ```
+
+The reader still accepts the previous producer argv containing
+`--allow-unconfigured --port 18789 --bind lan --force` long enough for an old
+CLI to self-upgrade, then normalizes it before matching the official service.
+The exact pinned OpenClaw installer currently writes an absolute Node/CLI
+entrypoint with `gateway --port 18789`; that upstream argv is deliberately not
+duplicated or overridden by Clawdi.
 
 The strict manifest references the token only as
 `secret://runtime/openclaw/gateway-token`; its value comes only from the fetched
@@ -1564,8 +1581,8 @@ boots a real `systemd --user` manager for the runtime user:
 - `openclaw`, `hermes`, and their update subcommands are not shadowed by
   Clawdi wrappers or PATH shims;
 - `clawdi run` is used only when explicitly requested by a caller;
-- OpenClaw receives `OPENCLAW_SYSTEMD_UNIT=openclaw-gateway.service` and can use
-  `systemd-run --user --scope --collect` for managed update handoff;
+- OpenClaw's official base unit provides
+  `OPENCLAW_SYSTEMD_UNIT=openclaw-gateway.service` for managed update handoff;
 - after an updater replaces files, the process manager restarts the relevant
   official programs, or autorestart picks them up when they exit.
 

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -44,6 +44,14 @@ const LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS = [
 	"--force",
 ] as const;
 const LEGACY_HOSTED_HERMES_GATEWAY_RUN_ARGS = ["gateway", "run", "--replace"] as const;
+const HOSTED_HERMES_DASHBOARD_ARGS = [
+	"dashboard",
+	"--host",
+	"0.0.0.0",
+	"--port",
+	"9119",
+	"--no-open",
+] as const;
 
 function exactStringArray(value: unknown, expected: readonly string[]): boolean {
 	return (
@@ -65,6 +73,10 @@ export function isHostedGatewayRunArgs(runtime: "openclaw" | "hermes", value: un
 				: LEGACY_HOSTED_HERMES_GATEWAY_RUN_ARGS,
 		)
 	);
+}
+
+export function isHostedHermesDashboardArgs(value: unknown): boolean {
+	return exactStringArray(value, HOSTED_HERMES_DASHBOARD_ARGS);
 }
 
 const OFFICIAL_INSTALL_ARGS: Record<string, string[]> = {
@@ -473,51 +485,23 @@ const hostedControlPlaneSchema = z
 	})
 	.strict();
 
-const hostedRuntimeRunSettingsSchema = runtimeRunSettingsSchema.strict();
-type HostedRuntimeRunSettings = z.infer<typeof hostedRuntimeRunSettingsSchema>;
+const hostedGatewayRunSettingsSchema = z
+	.object({
+		args: z.array(z.string()),
+		secretEnv: z
+			.object({
+				OPENCLAW_GATEWAY_TOKEN: z.literal("secret://runtime/openclaw/gateway-token"),
+			})
+			.strict()
+			.optional(),
+	})
+	.strict();
 
-function validateUnmanagedRunSettings(
-	location: string,
-	settings: HostedRuntimeRunSettings | undefined,
-	ctx: z.RefinementCtx,
-): void {
-	if (!settings) return;
-	const env = settings.env ?? {};
-	const secretEnv = settings.secretEnv ?? {};
-	for (const envName of ["CLAWDI_AI_API_KEY", "OPENAI_API_KEY"]) {
-		if (envName in env || envName in secretEnv) {
-			ctx.addIssue({
-				code: "custom",
-				message: `unmanaged ${location} must not include provider env`,
-				path: [location, envName in env ? "env" : "secretEnv", envName],
-			});
-		}
-	}
-	for (const [envName, value] of Object.entries(env)) {
-		if (value === "clawdi-egress-placeholder") {
-			ctx.addIssue({
-				code: "custom",
-				message: `unmanaged ${location} must not include provider placeholder env`,
-				path: [location, "env", envName],
-			});
-		}
-	}
-	for (const [source, values] of [
-		["env", env],
-		["secretEnv", secretEnv],
-	] as const) {
-		for (const [envName, value] of Object.entries(values)) {
-			const secretRef = canonicalSecretRefName(value);
-			if (secretRef?.startsWith("provider.")) {
-				ctx.addIssue({
-					code: "custom",
-					message: `unmanaged ${location} must not include provider secret refs`,
-					path: [location, source, envName],
-				});
-			}
-		}
-	}
-}
+const hostedServiceRunSettingsSchema = z
+	.object({
+		args: z.array(z.string()),
+	})
+	.strict();
 
 const urlOriginSchema = z.string().refine((value) => {
 	try {
@@ -546,8 +530,8 @@ const hostedProviderIdsSchema = z.array(z.string().min(1)).min(1).max(1);
 const hostedRuntimeEntryBaseShape = {
 	enabled: z.boolean(),
 	install: hostedRuntimeInstallSchema,
-	run: hostedRuntimeRunSettingsSchema.optional(),
-	services: z.record(runtimeServiceNameSchema, hostedRuntimeRunSettingsSchema).default({}),
+	run: hostedGatewayRunSettingsSchema,
+	services: z.record(runtimeServiceNameSchema, hostedServiceRunSettingsSchema).default({}),
 };
 
 const hostedConfiguredRuntimeEntrySchema = z
@@ -577,13 +561,7 @@ const hostedUnmanagedRuntimeEntrySchema = z
 		providerMode: z.literal("unmanaged"),
 		provider_ids: z.array(z.string()).length(0),
 	})
-	.strict()
-	.superRefine((runtime, ctx) => {
-		validateUnmanagedRunSettings("run", runtime.run, ctx);
-		for (const [name, service] of Object.entries(runtime.services)) {
-			validateUnmanagedRunSettings(`services.${name}`, service, ctx);
-		}
-	});
+	.strict();
 
 const hostedRuntimeEntrySchema = z.discriminatedUnion("providerMode", [
 	hostedConfiguredRuntimeEntrySchema,
@@ -882,6 +860,7 @@ function validateHostedRuntimeManifest(
 		}
 	}
 	if (manifest.runtime === "hermes") {
+		const runtime = manifest.runtimes.hermes;
 		if (!manifest.system.hermesDashboardAuth) {
 			ctx.addIssue({
 				code: "custom",
@@ -896,11 +875,29 @@ function validateHostedRuntimeManifest(
 				path: ["system", "hermesDashboardAuth", "activation", "enabled"],
 			});
 		}
-		const dashboardArgs = manifest.runtimes.hermes?.services.dashboard?.args;
-		if (
-			JSON.stringify(dashboardArgs) !==
-			JSON.stringify(["dashboard", "--host", "0.0.0.0", "--port", "9119", "--no-open"])
-		) {
+		if (runtime && !isHostedGatewayRunArgs("hermes", runtime.run.args)) {
+			ctx.addIssue({
+				code: "custom",
+				message: "Hermes gateway must use the official gateway run command",
+				path: ["runtimes", "hermes", "run", "args"],
+			});
+		}
+		if (runtime?.run.secretEnv) {
+			ctx.addIssue({
+				code: "custom",
+				message: "Hermes gateway must not declare OpenClaw gateway credentials",
+				path: ["runtimes", "hermes", "run", "secretEnv"],
+			});
+		}
+		const serviceNames = Object.keys(runtime?.services ?? {});
+		if (serviceNames.length !== 1 || serviceNames[0] !== "dashboard") {
+			ctx.addIssue({
+				code: "custom",
+				message: "Hermes must declare only its official dashboard command",
+				path: ["runtimes", "hermes", "services"],
+			});
+		}
+		if (!isHostedHermesDashboardArgs(runtime?.services.dashboard?.args)) {
 			ctx.addIssue({
 				code: "custom",
 				message: "hermes dashboard must bind directly to 0.0.0.0:9119",
@@ -968,25 +965,12 @@ function validateHostedRuntimeManifestV2(
 			path: ["runtimes", "openclaw", "run", "secretEnv", "OPENCLAW_GATEWAY_TOKEN"],
 		});
 	}
-	if (run?.env?.OPENCLAW_GATEWAY_TOKEN !== undefined) {
+	if (Object.keys(manifest.runtimes.openclaw?.services ?? {}).length > 0) {
 		ctx.addIssue({
 			code: "custom",
-			message: "OpenClaw v2 gateway token must not be embedded in manifest env",
-			path: ["runtimes", "openclaw", "run", "env", "OPENCLAW_GATEWAY_TOKEN"],
+			message: "OpenClaw hosted runtime must not declare auxiliary services",
+			path: ["runtimes", "openclaw", "services"],
 		});
-	}
-	for (const [serviceName, service] of Object.entries(manifest.runtimes.openclaw?.services ?? {})) {
-		for (const source of ["env", "secretEnv"] as const) {
-			for (const envName of Object.keys(service[source] ?? {})) {
-				if (envName === "OPENCLAW_GATEWAY_TOKEN") {
-					ctx.addIssue({
-						code: "custom",
-						message: "OpenClaw v2 gateway token must be scoped to the gateway run secretEnv",
-						path: ["runtimes", "openclaw", "services", serviceName, source, envName],
-					});
-				}
-			}
-		}
 	}
 	for (const [providerId, provider] of Object.entries(manifest.providers)) {
 		const envName = provider.runtimeEnvName;

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -553,7 +553,7 @@ function hostedRuntimeFixture(overrides: Record<string, unknown> = {}): Record<s
 
 function hostedHermesManifestFixture(
 	overrides: Record<string, unknown> = {},
-	gatewayArgs?: string[],
+	gatewayArgs: string[] = ["gateway", "run"],
 ): Record<string, unknown> {
 	return hostedManifestFixture({
 		runtime: "hermes",
@@ -574,7 +574,7 @@ function hostedHermesManifestFixture(
 		},
 		runtimes: {
 			hermes: hostedRuntimeFixture({
-				run: gatewayArgs === undefined ? undefined : { args: gatewayArgs },
+				run: { args: gatewayArgs },
 				services: {
 					dashboard: {
 						args: ["dashboard", "--host", "0.0.0.0", "--port", "9119", "--no-open"],
@@ -613,13 +613,10 @@ function hostedOpenClawV2ManifestFixture(
 		runtimes: {
 			openclaw: hostedRuntimeFixture({
 				run: {
-					command: "openclaw",
 					args: gatewayArgs,
-					env: {},
 					secretEnv: {
 						OPENCLAW_GATEWAY_TOKEN: "secret://runtime/openclaw/gateway-token",
 					},
-					prependPath: [],
 				},
 			}),
 		},
@@ -851,21 +848,50 @@ describe("runtime manifest reconciliation invariants", () => {
 			mismatchedOrigin.system as { openclawControlUiAllowedOrigins: string[] }
 		).openclawControlUiAllowedOrigins = ["https://other.example.test"];
 		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(mismatchedOrigin).success).toBe(true);
-
-		const serviceGatewayTokenEnvironment = structuredClone(valid);
-		(
-			serviceGatewayTokenEnvironment.runtimes as {
-				openclaw: { services: Record<string, unknown> };
-			}
-		).openclaw.services = {
-			helper: {
-				secretEnv: { OPENCLAW_GATEWAY_TOKEN: "secret://runtime/openclaw/gateway-token" },
-			},
-		};
-		expect(
-			hostedRuntimeBundleV2ManifestSchema.safeParse(serviceGatewayTokenEnvironment).success,
-		).toBe(false);
 	});
+
+	test("keeps hosted runtime process ownership on the exact upstream commands", () => {
+		for (const manifest of [hostedOpenClawV2ManifestFixture(), hostedHermesManifestFixture()]) {
+			const runtime = manifest.runtime as "openclaw" | "hermes";
+			delete (manifest.runtimes as Record<string, { run?: unknown }>)[runtime].run;
+			expect(hostedRuntimeBundleV2ManifestSchema.safeParse(manifest).success).toBe(false);
+		}
+
+		for (const [field, value] of [
+			["command", "openclaw"],
+			["cwd", "/home/clawdi"],
+			["env", { EXTRA: "value" }],
+			["prependPath", ["/custom/bin"]],
+		] as const) {
+			const manifest = hostedOpenClawV2ManifestFixture();
+			const run = (manifest.runtimes as { openclaw: { run: Record<string, unknown> } }).openclaw
+				.run;
+			run[field] = value;
+			expect(hostedRuntimeBundleV2ManifestSchema.safeParse(manifest).success).toBe(false);
+		}
+
+		const openClawService = hostedOpenClawV2ManifestFixture();
+		(
+			openClawService.runtimes as { openclaw: { services: Record<string, unknown> } }
+		).openclaw.services = { helper: { args: ["helper"] } };
+		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(openClawService).success).toBe(false);
+
+		const hermesService = hostedHermesManifestFixture();
+		(
+			hermesService.runtimes as { hermes: { services: Record<string, unknown> } }
+		).hermes.services.helper = { args: ["helper"] };
+		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(hermesService).success).toBe(false);
+
+		const hermesDashboardEnv = hostedHermesManifestFixture();
+		const dashboard = (
+			hermesDashboardEnv.runtimes as {
+				hermes: { services: { dashboard: Record<string, unknown> } };
+			}
+		).hermes.services.dashboard;
+		dashboard.env = { EXTRA: "value" };
+		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(hermesDashboardEnv).success).toBe(false);
+	});
+
 	test("normalizes previous gateway args during the official-unit rollout", () => {
 		const legacy = hostedOpenClawV2ManifestFixture({}, LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS);
 		expect(hostedRuntimeManifestSchema.safeParse(legacy).success).toBe(true);
@@ -881,6 +907,7 @@ describe("runtime manifest reconciliation invariants", () => {
 		const unsupported = hostedOpenClawV2ManifestFixture({}, ["gateway", "run", "--force"]);
 		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(unsupported).success).toBe(false);
 	});
+
 	test("requires official Basic auth and direct 9119 exposure for hosted Hermes v2", () => {
 		const valid = hostedHermesManifestFixture();
 		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(valid).success).toBe(true);
@@ -1589,46 +1616,6 @@ chmod 0755 '${commandPath}'
 				hostedManifestFixture({ runtimes: { openclaw: runtime } }),
 			).success,
 		).toBe(false);
-	});
-
-	test.each([
-		["run provider env", { run: { env: { OPENAI_API_KEY: "configured" } } }],
-		["run placeholder", { run: { env: { TOKEN: "clawdi-egress-placeholder" } } }],
-		[
-			"run provider secret ref",
-			{ run: { secretEnv: { OPENAI_API_KEY: "secret://provider.clawdi-managed-v2.apiKey" } } },
-		],
-		[
-			"service provider secret ref",
-			{ services: { helper: { secretEnv: { TOKEN: "secret://provider.runtime.apiKey" } } } },
-		],
-	])("rejects unmanaged runtime %s", (_name, overrides) => {
-		const runtime = hostedRuntimeFixture({
-			providerMode: "unmanaged",
-			provider_ids: [],
-			primary_model: undefined,
-			...overrides,
-		});
-		expect(
-			hostedRuntimeManifestSchema.safeParse(
-				hostedManifestFixture({ providers: {}, runtimes: { openclaw: runtime } }),
-			).success,
-		).toBe(false);
-	});
-
-	test("allows an explicit user Vault-backed service secret ref in unmanaged mode", () => {
-		const runtime = hostedRuntimeFixture({
-			providerMode: "unmanaged",
-			provider_ids: [],
-			services: { helper: { secretEnv: { TOKEN: "secret://vault/default/key" } } },
-		});
-		delete runtime.primary_model;
-
-		expect(
-			hostedRuntimeManifestSchema.safeParse(
-				hostedManifestFixture({ providers: {}, runtimes: { openclaw: runtime } }),
-			).success,
-		).toBe(true);
 	});
 
 	test("rejects the terminal Codex env name for managed runtime providers", () => {
@@ -2393,13 +2380,10 @@ chmod 0755 '${commandPath}'
 						primary_model: { provider_id: "default", model: "gpt-test" },
 						install: { source: "official" },
 						run: {
-							command: "openclaw",
 							args: ["gateway", "run"],
-							env: { OPENCLAW_TEST: "1" },
 							secretEnv: {
 								OPENCLAW_GATEWAY_TOKEN: "secret://runtime/openclaw/gateway-token",
 							},
-							prependPath: [],
 						},
 					},
 				},
@@ -2645,7 +2629,13 @@ chmod 0755 '${commandPath}'
 						providerMode: "configured",
 						provider_ids: ["default"],
 						primary_model: { provider_id: "default", model: "gpt-test" },
-						run: { command: "openclaw", args: ["gateway", "run"] },
+						run: {
+							args: ["gateway", "run"],
+							secretEnv: {
+								OPENCLAW_GATEWAY_TOKEN: "secret://runtime/openclaw/gateway-token",
+							},
+						},
+						services: {},
 					},
 					hermes: {
 						enabled: true,
@@ -2653,7 +2643,12 @@ chmod 0755 '${commandPath}'
 						providerMode: "configured",
 						provider_ids: ["default"],
 						primary_model: { provider_id: "default", model: "gpt-test" },
-						run: { command: "hermes", args: ["gateway", "run"] },
+						run: { args: ["gateway", "run"] },
+						services: {
+							dashboard: {
+								args: ["dashboard", "--host", "0.0.0.0", "--port", "9119", "--no-open"],
+							},
+						},
 					},
 				},
 			}),

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -5082,8 +5082,19 @@ echo spawned > '${installerLog}'
 		const installerPath = join(fixtureRoot, "install-openclaw.sh");
 		const installerResultPath = join(fixtureRoot, "installer-result");
 		const installerLog = join(fixtureRoot, "installer.log");
+		const installerEnvironmentLog = join(fixtureRoot, "installer-environment.log");
 		const desiredVersion = HOSTED_V2_OPENCLAW_VERSION;
 		const configWriterVersion = "2026.8.1.beta.1";
+		const openClawInstallerOverrides = [
+			"OPENCLAW_HOME",
+			"OPENCLAW_STATE_DIR",
+			"OPENCLAW_CONFIG_PATH",
+			"OPENCLAW_PREFIX",
+			"OPENCLAW_VERSION",
+			"OPENCLAW_INSTALL_METHOD",
+			"OPENCLAW_GIT_DIR",
+			"OPENCLAW_GIT_UPDATE",
+		] as const;
 		const config = {
 			meta: {
 				lastTouchedVersion: configWriterVersion,
@@ -5113,10 +5124,24 @@ esac
 			`#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$#" "$@" >> '${installerLog}'
+printf '%s\n' "$HOME" > '${installerEnvironmentLog}'
+for name in ${openClawInstallerOverrides.join(" ")}; do
+  if [ "\${!name+x}" = x ]; then printf '%s\n' "$name" >> '${installerEnvironmentLog}'; fi
+done
 cp '${installerResultPath}' '${installedVersionPath}'
 `,
 		);
 		chmodSync(installerPath, 0o700);
+		Object.assign(process.env, {
+			OPENCLAW_HOME: "stale-openclaw-home",
+			OPENCLAW_STATE_DIR: dirname(configPath),
+			OPENCLAW_CONFIG_PATH: configPath,
+			OPENCLAW_PREFIX: "stale-openclaw-prefix",
+			OPENCLAW_VERSION: "stale-openclaw-version",
+			OPENCLAW_INSTALL_METHOD: "stale-openclaw-install-method",
+			OPENCLAW_GIT_DIR: "stale-openclaw-git-dir",
+			OPENCLAW_GIT_UPDATE: "stale-openclaw-git-update",
+		});
 		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
 		process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER = `file://${installerPath}`;
 
@@ -5157,6 +5182,7 @@ cp '${installerResultPath}' '${installedVersionPath}'
 			`OpenClaw ${desiredVersion}`,
 		);
 		expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual(config);
+		expect(readFileSync(installerEnvironmentLog, "utf8").trim().split("\n")).toEqual([home]);
 		const expectedArgs = [
 			...officialInstallArgs("openclaw", home, desiredVersion),
 			"--compatible-with",

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -112,6 +112,19 @@ function readUserServiceConfig(paths: RuntimePaths, name: string): string {
 	].join("\n");
 }
 
+function readSystemdEnvironment(paths: RuntimePaths, name: string): Record<string, string> {
+	const content = readFileSync(join(paths.systemdEnvRoot, `${name}.service.env`), "utf8");
+	return Object.fromEntries(
+		content
+			.split(/\r?\n/)
+			.filter((line) => line && !line.startsWith("#"))
+			.map((line) => {
+				const separator = line.indexOf("=");
+				return [line.slice(0, separator), JSON.parse(line.slice(separator + 1)) as string];
+			}),
+	);
+}
+
 function writeFakeGatewayCli(input: {
 	path: string;
 	logPath: string;
@@ -552,6 +565,7 @@ describe("runtime manifest services", () => {
 		const hermesUnit = readUserServiceConfig(paths, "hermes-gateway");
 		expect(hermesUnit).not.toContain("\nExecStart=");
 		expect(hermesUnit).not.toContain("\nWorkingDirectory=");
+		expect(hermesUnit).toContain("UnsetEnvironment=CLAWDI_AUTH_TOKEN");
 		const dashboardUnit = readFileSync(
 			join(paths.systemdUserRoot, "clawdi-hermes-dashboard.service"),
 			"utf8",
@@ -560,9 +574,8 @@ describe("runtime manifest services", () => {
 			'ExecStart="hermes" "dashboard" "--host" "127.0.0.1" "--port" "9119" "--no-open"',
 		);
 		expect(dashboardUnit).not.toContain("--skip-build");
+		expect(dashboardUnit).toContain("UnsetEnvironment=CLAWDI_AUTH_TOKEN");
 		const openclawUnit = readUserServiceConfig(paths, "openclaw-gateway");
-		expect(openclawUnit).toContain('Environment="XDG_RUNTIME_DIR=%t"');
-		expect(openclawUnit).toContain('Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus"');
 		expect(openclawUnit).toContain(
 			`EnvironmentFile=${join(paths.systemdEnvRoot, "openclaw-gateway.service.env")}`,
 		);
@@ -571,6 +584,7 @@ describe("runtime manifest services", () => {
 		);
 		expect(openclawUnit).not.toContain("\nExecStart=");
 		expect(openclawUnit).not.toContain("\nWorkingDirectory=");
+		expect(openclawUnit).toContain("UnsetEnvironment=CLAWDI_AUTH_TOKEN");
 		expect(hermesUnit).toContain(
 			`ConditionPathExists=${join(paths.systemdEnvRoot, "hermes-gateway.service.env")}`,
 		);
@@ -609,17 +623,21 @@ describe("runtime manifest services", () => {
 			expect(unit).not.toContain("supervisord");
 			expect(unit).not.toContain("test-token");
 		}
-		const openclawEnv = readFileSync(
-			join(paths.systemdEnvRoot, "openclaw-gateway.service.env"),
-			"utf8",
-		);
-		expect(openclawEnv).not.toContain("OPENCLAW_SYSTEMD_UNIT");
-		expect(openclawEnv).toContain('CLAWDI_AUTH_TOKEN=""');
-		for (const name of ["openclaw-gateway", "hermes-gateway", "clawdi-hermes-dashboard"]) {
-			const env = readFileSync(join(paths.systemdEnvRoot, `${name}.service.env`), "utf8");
-			expect(env).toContain(`CLAWDI_HOME="${paths.clawdiHome}"`);
-			expect(env).not.toContain(dirname(paths.cliManagedBin));
-		}
+		const revision = expect.stringMatching(/^[a-f0-9]{32}$/);
+		expect(readSystemdEnvironment(paths, "openclaw-gateway")).toEqual({
+			BYOK_RUNTIME_SECRET: "runtime-byok-value",
+			CLAWDI_RUNTIME_REV: revision,
+			NON_SECRET_RUNTIME_SETTING: "public-value",
+		});
+		expect(readSystemdEnvironment(paths, "hermes-gateway")).toEqual({
+			CLAWDI_RUNTIME_REV: revision,
+		});
+		expect(readSystemdEnvironment(paths, "clawdi-hermes-dashboard")).toEqual({
+			BYOK_SERVICE_SECRET: "service-byok-value",
+			CLAWDI_RUNTIME_REV: revision,
+			HOME: paths.userHome,
+			PATH: expect.any(String),
+		});
 		expect(runtimeWatchEnv).toContain(`CLAWDI_HOME="${paths.clawdiHome}"`);
 
 		const serviceConfig = JSON.parse(
@@ -770,14 +788,8 @@ describe("runtime manifest services", () => {
 			`ExecStart="${hermesCommand}" "dashboard" "--host" "0.0.0.0" "--port" "9119" "--no-open"`,
 		);
 		expect(dashboardUnit).not.toContain("--skip-build");
-		const dashboardEnv = readFileSync(
-			join(paths.systemdEnvRoot, "clawdi-hermes-dashboard.service.env"),
-			"utf8",
-		);
-		const gatewayEnv = readFileSync(
-			join(paths.systemdEnvRoot, "hermes-gateway.service.env"),
-			"utf8",
-		);
+		const dashboardEnv = readSystemdEnvironment(paths, "clawdi-hermes-dashboard");
+		const gatewayEnv = readSystemdEnvironment(paths, "hermes-gateway");
 		const watchEnv = readFileSync(
 			join(paths.systemdEnvRoot, "clawdi-runtime-watch.service.env"),
 			"utf8",
@@ -787,35 +799,27 @@ describe("runtime manifest services", () => {
 		const gatewayUnit = readUserServiceConfig(paths, "hermes-gateway");
 		const watchEnvPath = join(paths.systemdEnvRoot, "clawdi-runtime-watch.service.env");
 		const watchEnvStat = statSync(watchEnvPath);
-		expect(dashboardEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_USERNAME="admin"');
-		expect(dashboardEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="opaque-password-value"');
-		expect(dashboardEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_SECRET="opaque-session-value"');
-		expect(dashboardEnv).toContain(
-			'HERMES_DASHBOARD_PUBLIC_URL="https://agent.example.test/hermes"',
-		);
+		const revision = expect.stringMatching(/^[a-f0-9]{32}$/);
+		expect(dashboardEnv).toEqual({
+			CLAWDI_RUNTIME_REV: revision,
+			HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "opaque-password-value",
+			HERMES_DASHBOARD_BASIC_AUTH_SECRET: "opaque-session-value",
+			HOME: paths.userHome,
+			PATH: expect.any(String),
+		});
+		expect(gatewayEnv).toEqual({
+			CLAWDI_RUNTIME_REV: revision,
+			RUNTIME_BUNDLE_TOKEN: "bundle-runtime-token",
+			RUNTIME_TARGET_TOKEN: "runtime-source-token",
+		});
 		const dashboardRunConfig = JSON.parse(
 			readFileSync(runtimeRunConfigPath("hermes", paths, "dashboard"), "utf8"),
 		) as { env?: Record<string, string>; secretEnv?: Record<string, string> };
-		expect(dashboardRunConfig.env).toMatchObject({
-			HERMES_DASHBOARD_BASIC_AUTH_USERNAME: "admin",
-			HERMES_DASHBOARD_BASIC_AUTH_TTL_SECONDS: "43200",
-			HERMES_DASHBOARD_PUBLIC_URL: "https://agent.example.test/hermes",
-		});
-		expect(dashboardRunConfig.secretEnv).toMatchObject({
+		expect(dashboardRunConfig.env).toEqual({});
+		expect(dashboardRunConfig.secretEnv).toEqual({
 			HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "secret://runtime/hermes/dashboard-password",
 			HERMES_DASHBOARD_BASIC_AUTH_SECRET: "secret://runtime/hermes/dashboard-session-secret",
 		});
-		for (const name of [
-			"HERMES_DASHBOARD_BASIC_AUTH_USERNAME",
-			"HERMES_DASHBOARD_BASIC_AUTH_PASSWORD",
-			"HERMES_DASHBOARD_BASIC_AUTH_SECRET",
-			"HERMES_DASHBOARD_BASIC_AUTH_TTL_SECONDS",
-			"HERMES_DASHBOARD_PUBLIC_URL",
-		]) {
-			expect(gatewayEnv).not.toContain(name);
-		}
-		expect(gatewayEnv).toContain('RUNTIME_TARGET_TOKEN="runtime-source-token"');
-		expect(gatewayEnv).toContain('RUNTIME_BUNDLE_TOKEN="bundle-runtime-token"');
 		expect(watchEnv).not.toContain("opaque-password-value");
 		expect(watchEnv).not.toContain("opaque-session-value");
 		expect(watchEnv).not.toContain("runtime-source-token");
@@ -864,6 +868,7 @@ describe("runtime manifest services", () => {
 		expect(hermesConfig).toContain("basic_auth:");
 		expect(hermesConfig).toContain("username: admin");
 		expect(hermesConfig).toContain("session_ttl_seconds: 43200");
+		expect(hermesConfig).toContain("public_url: https://agent.example.test/hermes");
 		expect(hermesConfig).toContain("dashboard_auth/nous");
 		expect(hermesConfig).toContain("dashboard_auth/self_hosted");
 		expect(hermesConfig).not.toContain("dashboard_auth/basic\n");

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -613,7 +613,7 @@ describe("runtime manifest services", () => {
 			join(paths.systemdEnvRoot, "openclaw-gateway.service.env"),
 			"utf8",
 		);
-		expect(openclawEnv).toContain('OPENCLAW_SYSTEMD_UNIT="openclaw-gateway.service"');
+		expect(openclawEnv).not.toContain("OPENCLAW_SYSTEMD_UNIT");
 		expect(openclawEnv).toContain('CLAWDI_AUTH_TOKEN=""');
 		for (const name of ["openclaw-gateway", "hermes-gateway", "clawdi-hermes-dashboard"]) {
 			const env = readFileSync(join(paths.systemdEnvRoot, `${name}.service.env`), "utf8");
@@ -805,9 +805,15 @@ describe("runtime manifest services", () => {
 			HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "secret://runtime/hermes/dashboard-password",
 			HERMES_DASHBOARD_BASIC_AUTH_SECRET: "secret://runtime/hermes/dashboard-session-secret",
 		});
-		expect(gatewayEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_USERNAME="admin"');
-		expect(gatewayEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_PASSWORD="opaque-password-value"');
-		expect(gatewayEnv).toContain('HERMES_DASHBOARD_BASIC_AUTH_SECRET="opaque-session-value"');
+		for (const name of [
+			"HERMES_DASHBOARD_BASIC_AUTH_USERNAME",
+			"HERMES_DASHBOARD_BASIC_AUTH_PASSWORD",
+			"HERMES_DASHBOARD_BASIC_AUTH_SECRET",
+			"HERMES_DASHBOARD_BASIC_AUTH_TTL_SECONDS",
+			"HERMES_DASHBOARD_PUBLIC_URL",
+		]) {
+			expect(gatewayEnv).not.toContain(name);
+		}
 		expect(gatewayEnv).toContain('RUNTIME_TARGET_TOKEN="runtime-source-token"');
 		expect(gatewayEnv).toContain('RUNTIME_BUNDLE_TOKEN="bundle-runtime-token"');
 		expect(watchEnv).not.toContain("opaque-password-value");
@@ -890,7 +896,7 @@ describe("runtime manifest services", () => {
 		const rotatedWatchUnit = readFileSync(watchUnitPath, "utf8");
 		expect(rotatedWatchEnv).toBe(watchEnv);
 		expect(rotatedDashboardUnit).not.toBe(dashboardUnit);
-		expect(rotatedGatewayUnit).not.toBe(gatewayUnit);
+		expect(rotatedGatewayUnit).toBe(gatewayUnit);
 		// The root watcher reloads the apply-context file on each tick, so neither
 		// its environment nor its unit needs secret bytes.
 		expect(rotatedWatchUnit).toBe(watchUnit);

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -26,6 +26,7 @@ import {
 	hostedCliPayloadPolicySchema,
 	hostedRuntimeBundleV2ManifestSchema,
 	isHostedGatewayRunArgs,
+	isHostedHermesDashboardArgs,
 	manifestSchema,
 	OFFICIAL_INSTALL_URLS,
 	officialInstallArgs,
@@ -446,6 +447,7 @@ function runtimeFetchFailureStage(error: unknown): "network" | "auth" {
 
 type NormalizableHostedRuntimeManifest = HostedRuntimeManifest &
 	Partial<Pick<HostedRuntimeBundleV2Manifest, "agentPlugins">>;
+type HostedRuntimeRunSettings = NormalizableHostedRuntimeManifest["runtimes"][string]["run"];
 
 export function hostedManifestToRuntimeManifest(
 	hosted: NormalizableHostedRuntimeManifest,
@@ -527,25 +529,22 @@ function hostedRuntimeProviderBinding(
 
 function hostedRuntimeRunSettings(
 	runtime: NormalizableHostedRuntimeManifest["runtime"],
-	run: RuntimeRunSettings | undefined,
+	run: HostedRuntimeRunSettings,
 ): RuntimeRunSettings {
 	const settings = copyHostedRuntimeRunSettings(run);
-	if (isHostedGatewayRunArgs(runtime, run?.args)) {
+	if (isHostedGatewayRunArgs(runtime, run.args)) {
 		settings.args = ["gateway", "run"];
 	}
 	return settings;
 }
 
-function copyHostedRuntimeRunSettings(run: RuntimeRunSettings | undefined): RuntimeRunSettings {
-	const settings: RuntimeRunSettings = {
-		env: run?.env ?? {},
-		prependPath: run?.prependPath ?? [],
+function copyHostedRuntimeRunSettings(run: HostedRuntimeRunSettings): RuntimeRunSettings {
+	return {
+		args: [...run.args],
+		env: {},
+		prependPath: [],
+		...(run.secretEnv === undefined ? {} : { secretEnv: { ...run.secretEnv } }),
 	};
-	if (run?.command !== undefined) settings.command = run.command;
-	if (run?.args !== undefined) settings.args = run.args;
-	if (run?.secretEnv !== undefined) settings.secretEnv = run.secretEnv;
-	if (run?.cwd !== undefined) settings.cwd = run.cwd;
-	return settings;
 }
 
 function loadExistingState(paths: RuntimePaths): ExistingManifestState {
@@ -660,10 +659,10 @@ function validateManifestSemantics(
 			if (manifest.openclawGatewayAuth) {
 				errors.push("OpenClaw gateway auth is only valid for the OpenClaw runtime");
 			}
-			if (
-				JSON.stringify(manifest.runtimes.hermes?.services.dashboard?.args) !==
-				JSON.stringify(["dashboard", "--host", "0.0.0.0", "--port", "9119", "--no-open"])
-			) {
+			if (!isHostedGatewayRunArgs("hermes", manifest.runtimes.hermes?.run?.args)) {
+				errors.push("Hermes gateway must use the official gateway run command");
+			}
+			if (!isHostedHermesDashboardArgs(manifest.runtimes.hermes?.services.dashboard?.args)) {
 				errors.push("hermes dashboard must bind directly to 0.0.0.0:9119");
 			}
 		}

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1674,13 +1674,11 @@ function resolvedRuntimeServiceSettings(
 }
 
 function resolvedRuntimeSettings(
-	manifest: RuntimeManifest,
 	runtime: string,
 	settings: RuntimeRunSettings | undefined,
 	providerEnv: Record<string, string>,
 ): RuntimeRunSettings | undefined {
-	const merged = mergeRuntimeEnvWithProviderPlaceholders(runtime, settings, providerEnv);
-	return runtime === "hermes" ? withHermesDashboardAuthEnvironment(manifest, merged) : merged;
+	return mergeRuntimeEnvWithProviderPlaceholders(runtime, settings, providerEnv);
 }
 
 function mergeRuntimeSecretEnv(
@@ -5457,12 +5455,7 @@ function runtimeProgramRevisionForManifest(
 		? hostedProviderEnvironment(manifest, runtime)
 		: { placeholderEnv: {}, secretEnv: {} };
 	const runtimeSettings = desiredRuntime
-		? resolvedRuntimeSettings(
-				manifest,
-				runtime,
-				desiredRuntime.run,
-				providerEnvironment.placeholderEnv,
-			)
+		? resolvedRuntimeSettings(runtime, desiredRuntime.run, providerEnvironment.placeholderEnv)
 		: undefined;
 	const runtimeSecretRefs = desiredRuntime
 		? [
@@ -5533,7 +5526,6 @@ function validateRuntimeManifestPlan(
 		const { placeholderEnv: providerPlaceholderEnv, secretEnv: providerSecretEnv } =
 			providerEnvironment;
 		const runtimeSettings = resolvedRuntimeSettings(
-			manifest,
 			runtimeName,
 			runtime.run,
 			providerPlaceholderEnv,
@@ -5669,7 +5661,6 @@ function resolveRuntimeRunConfigs(input: {
 	const { placeholderEnv: providerPlaceholderEnv, secretEnv: providerSecretEnv } =
 		providerEnvironment;
 	const runtimeRunSettings = resolvedRuntimeSettings(
-		input.manifest,
 		runtimeName,
 		input.runtime.run,
 		providerPlaceholderEnv,
@@ -5827,7 +5818,6 @@ function validateRuntimeProjectionPlan(input: {
 		const { placeholderEnv: providerPlaceholderEnv, secretEnv: providerSecretEnv } =
 			providerEnvironment;
 		const runtimeSettings = resolvedRuntimeSettings(
-			manifest,
 			runtimeName,
 			runtime.run,
 			providerPlaceholderEnv,

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1109,6 +1109,7 @@ const liveSyncEnvironmentIndexSchema = z
 	.strict();
 
 function runtimeInstallerExecution(
+	runtime: string,
 	install: RuntimeInstall,
 	installerPath: string,
 	extraArgs: string[] = [],
@@ -1119,7 +1120,7 @@ function runtimeInstallerExecution(
 	executionUser: string | null;
 } {
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
-	const env = runtimeInstallerEnv(install);
+	const env = runtimeInstallerEnv(runtime, install);
 	if (!runtimeUser || runtimeUser === "root") {
 		return {
 			command: "bash",
@@ -1142,13 +1143,27 @@ function runtimeInstallerExecution(
 	};
 }
 
-function runtimeInstallerEnv(install: RuntimeInstall): NodeJS.ProcessEnv {
+function runtimeInstallerEnv(runtime: string, install: RuntimeInstall): NodeJS.ProcessEnv {
 	const env: NodeJS.ProcessEnv = {
 		...process.env,
 		HOME: install.home,
 		PATH: [join(install.home, ".local", "bin"), process.env.PATH].filter(Boolean).join(":"),
 	};
 	clearTenantToolLocationOverrides(env);
+	if (runtime === "openclaw") {
+		for (const key of [
+			"OPENCLAW_HOME",
+			"OPENCLAW_STATE_DIR",
+			"OPENCLAW_CONFIG_PATH",
+			"OPENCLAW_PREFIX",
+			"OPENCLAW_VERSION",
+			"OPENCLAW_INSTALL_METHOD",
+			"OPENCLAW_GIT_DIR",
+			"OPENCLAW_GIT_UPDATE",
+		] as const) {
+			delete env[key];
+		}
+	}
 	env.SSL_CERT_FILE = SYSTEM_CA_BUNDLE;
 	env.NODE_EXTRA_CA_CERTS = SYSTEM_CA_BUNDLE;
 	env.REQUESTS_CA_BUNDLE = SYSTEM_CA_BUNDLE;
@@ -1336,6 +1351,7 @@ function runOfficialInstaller(
 		const configWriterVersion =
 			expectedVersion === undefined ? null : openClawConfigWriterVersion(install.home);
 		const execution = runtimeInstallerExecution(
+			name,
 			install,
 			materialized.path,
 			configWriterVersion === null ? [] : ["--compatible-with", configWriterVersion],
@@ -1607,6 +1623,7 @@ function applyHermesDashboardConfig(
 		username: auth.username,
 		session_ttl_seconds: auth.sessionTtlSeconds,
 	});
+	reconcileHermesConfigValue(context, "dashboard.public_url", auth.publicUrl);
 	const currentDisabled = getHermesRawConfigValue(context, "plugins.disabled");
 	if (
 		currentDisabled.exists &&
@@ -1625,7 +1642,7 @@ function applyHermesDashboardConfig(
 	reconcileHermesConfigValue(context, "plugins.disabled", [...disabled].sort());
 }
 
-function applyHostedLocaleProjection(
+function applyHostedRuntimeConfigProjection(
 	runtime: string,
 	observation: RuntimeInstallObservation,
 	manifest: RuntimeManifest,
@@ -1643,9 +1660,12 @@ function applyHostedLocaleProjection(
 	}
 	if (runtime === "hermes") {
 		const auth = manifest.hermesDashboardAuth;
-		if (!auth && !locale) return null;
+		const managesWorkspace =
+			manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2";
+		if (!auth && !locale && !managesWorkspace) return null;
 		const context = hermesConfigContext(observation, home, workspaceRoot);
 		const hermesHome = join(home, ".hermes");
+		if (managesWorkspace) reconcileHermesConfigValue(context, "terminal.cwd", workspaceRoot);
 		if (auth) applyHermesDashboardConfig(context, auth);
 		if (locale) reconcileHermesConfigValue(context, "timezone", locale.timezone);
 		return locale
@@ -5530,9 +5550,7 @@ function validateRuntimeManifestPlan(
 			runtime.run,
 			providerPlaceholderEnv,
 		);
-		const secretEnv = runtime.enabled
-			? mergeRuntimeSecretEnv(name, runtimeSettings, providerSecretEnv)
-			: {};
+		if (runtime.enabled) mergeRuntimeSecretEnv(name, runtimeSettings, providerSecretEnv);
 		for (const [serviceName, serviceSettings] of Object.entries(runtime.services ?? {})) {
 			const service = runtimeServiceNameSchema.parse(serviceName);
 			const settings = resolvedRuntimeServiceSettings(
@@ -5542,7 +5560,7 @@ function validateRuntimeManifestPlan(
 				serviceSettings,
 				providerPlaceholderEnv,
 			);
-			if (runtime.enabled) mergeRuntimeServiceSecretEnv(name, service, settings, secretEnv);
+			if (runtime.enabled) mergeRuntimeServiceSecretEnv(name, service, settings, providerSecretEnv);
 		}
 		if (!runtime.enabled || !manifest.locale) continue;
 		const block = managedLocaleBlock(manifest.locale);
@@ -5622,12 +5640,7 @@ function withHermesDashboardAuthEnvironment(
 	return {
 		...(settings ?? {}),
 		prependPath: settings?.prependPath ?? [],
-		env: {
-			...(settings?.env ?? {}),
-			HERMES_DASHBOARD_BASIC_AUTH_USERNAME: auth.username,
-			HERMES_DASHBOARD_BASIC_AUTH_TTL_SECONDS: String(auth.sessionTtlSeconds),
-			HERMES_DASHBOARD_PUBLIC_URL: auth.publicUrl,
-		},
+		env: settings?.env ?? {},
 		secretEnv: {
 			...(settings?.secretEnv ?? {}),
 			HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: auth.passwordSecretRef,
@@ -5707,7 +5720,7 @@ function resolveRuntimeRunConfigs(input: {
 				settings,
 				secretFilePath: null,
 				secretEnv: input.runtime.enabled
-					? mergeRuntimeServiceSecretEnv(input.name, service, settings, secretEnv)
+					? mergeRuntimeServiceSecretEnv(input.name, service, settings, providerSecretEnv)
 					: {},
 			});
 		});
@@ -5835,7 +5848,7 @@ function validateRuntimeProjectionPlan(input: {
 				serviceSettings,
 				providerPlaceholderEnv,
 			);
-			mergeRuntimeServiceSecretEnv(name, service, settings, secretEnv);
+			mergeRuntimeServiceSecretEnv(name, service, settings, providerSecretEnv);
 		}
 
 		const projectionInput = agentTargetProjectionInput(hostedAiProviderCatalog(manifest, name));
@@ -7234,7 +7247,7 @@ export function convergeRuntimeManifest(
 			}
 			try {
 				const localeFile = withRuntimeUserFileAccess(() =>
-					applyHostedLocaleProjection(
+					applyHostedRuntimeConfigProjection(
 						name,
 						observation,
 						manifest,
@@ -7246,7 +7259,7 @@ export function convergeRuntimeManifest(
 				if (localeFile) managedLocaleFiles.push(localeFile);
 			} catch (error) {
 				installErrors.push(
-					`runtime ${name} locale projection failed: ${
+					`runtime ${name} config projection failed: ${
 						error instanceof Error ? error.message : String(error)
 					}`,
 				);

--- a/packages/cli/src/runtime/platform-root-modes.test.ts
+++ b/packages/cli/src/runtime/platform-root-modes.test.ts
@@ -16,8 +16,6 @@ import { normalizeHostedRuntimeBundleV2 } from "./manifest-source";
 import type { RuntimePaths } from "./paths";
 import { ensureRuntimeStateDirs } from "./state";
 
-const ROOT_MODE_TEST_SECRET_REF = "secret://runtime/root-modes/test-secret";
-
 const roots: string[] = [];
 
 function tempRoot(): string {
@@ -83,21 +81,12 @@ exit 0
 		delete openclawRuntime.primary_model;
 		manifest.providers = {};
 		manifest.skills = { entries: {} };
-		// A recoverable secret ensures writeLastGoodSecretValues persists the
-		// cache file directly inside the cache platform root.
-		const openclawRun = openclawRuntime.run as Record<string, unknown>;
-		openclawRuntime.run = {
-			...openclawRun,
-			secretEnv: {
-				...(openclawRun.secretEnv as Record<string, unknown>),
-				ROOT_MODE_TEST_SECRET: ROOT_MODE_TEST_SECRET_REF,
-			},
-		};
+		// The canonical Codex secret ensures writeLastGoodSecretValues persists
+		// the cache file directly inside the cache platform root.
 		fixture.secretValues = {
 			"secret://clawdi/auth-token": "runtime-auth-token-root-modes",
 			"secret://runtime/openclaw/gateway-token": "gateway-token-root-modes",
 			"secret://tool.codex.apiKey": "codex-provider-key-root-modes",
-			[ROOT_MODE_TEST_SECRET_REF]: "root-modes-secret-value",
 		};
 
 		const { getRuntimePaths } = await import("./paths");

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -880,6 +880,8 @@ describe("hosted runtime bundle v2", () => {
 			join(paths.systemdEnvRoot, "openclaw-gateway.service.env"),
 			"utf-8",
 		);
+		expect(gatewayEnv).not.toMatch(/^HOME=/m);
+		expect(gatewayEnv).not.toMatch(/^PATH=/m);
 		expect(gatewayEnv).not.toContain("OPENCLAW_GATEWAY_TOKEN");
 		expect(gatewayEnv).not.toContain("openclaw-gateway-token-golden");
 		const persistentLastGood = [

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -763,6 +763,7 @@ function writeSystemdUnit(input: {
 	directoryKind?: "platform" | "file-browser";
 	extraUnitLines?: string[];
 	extraServiceLines?: string[];
+	unsetEnvironment?: readonly string[];
 	wantedBy: "multi-user.target" | "default.target";
 }): string {
 	const path = join(input.root, systemdUnitFileName(input.name));
@@ -810,6 +811,9 @@ function writeSystemdUnit(input: {
 					]
 				: []),
 		...(input.unitEnv ? systemdUnitEnvironmentLines(input.unitEnv) : []),
+		...(input.unsetEnvironment?.length
+			? [`UnsetEnvironment=${input.unsetEnvironment.join(" ")}`]
+			: []),
 		...(input.extraServiceLines ?? []),
 		`EnvironmentFile=${systemdPath(envFile)}`,
 		`ExecStart=${input.execStart ?? systemdExec(input.command, input.args)}`,
@@ -857,11 +861,6 @@ function writeSystemdUserUnit(
 		...input,
 		root: input.paths.systemdUserRoot,
 		owner: "runtime-user",
-		extraServiceLines: [
-			'Environment="XDG_RUNTIME_DIR=%t"',
-			'Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus"',
-			...(input.extraServiceLines ?? []),
-		],
 		wantedBy: "default.target",
 	});
 }
@@ -870,6 +869,7 @@ function writeSystemdUserEnvironmentDropIn(input: {
 	paths: RuntimePaths;
 	name: string;
 	env: Record<string, string>;
+	unsetEnvironment?: readonly string[];
 }): string {
 	const unitName = systemdUnitFileName(input.name);
 	const { envFile, envRevision } = writeSystemdProgramEnvironment({
@@ -889,8 +889,9 @@ function writeSystemdUserEnvironmentDropIn(input: {
 		"",
 		"[Service]",
 		`# ClawdiEnvironmentRevision=${envRevision}`,
-		'Environment="XDG_RUNTIME_DIR=%t"',
-		'Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus"',
+		...(input.unsetEnvironment?.length
+			? [`UnsetEnvironment=${input.unsetEnvironment.join(" ")}`]
+			: []),
 		`EnvironmentFile=${systemdPath(envFile)}`,
 		"",
 	];
@@ -1034,6 +1035,14 @@ function installOfficialRuntimeUserService(
 		);
 		const result = spawnRuntimeUserCommand(program.command, args, paths.userHome, program.cwd, {
 			environment,
+			environmentOverrides:
+				descriptor.runtime === "openclaw"
+					? {
+							OPENCLAW_HOME: undefined,
+							OPENCLAW_STATE_DIR: undefined,
+							OPENCLAW_CONFIG_PATH: undefined,
+						}
+					: undefined,
 			maxBufferBytes: OFFICIAL_INSTALLER_MAX_BUFFER_BYTES,
 			timeoutMs: OFFICIAL_SERVICE_INSTALL_TIMEOUT_MS,
 		});
@@ -1438,6 +1447,7 @@ function writeRuntimeSystemdUserProgram(input: {
 	const name = runtimeSystemdProgramName(program);
 	const runtimeEnv = { ...program.env };
 	const descriptor = officialRuntimeServiceDescriptorForProgram(program);
+	const isHermesDashboard = program.runtime === "hermes" && program.service === "dashboard";
 	const installerOnlySecretEnv =
 		descriptor?.runtime === "openclaw" &&
 		input.manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2" &&
@@ -1447,34 +1457,35 @@ function writeRuntimeSystemdUserProgram(input: {
 	for (const envName of installerOnlySecretEnv) {
 		delete runtimeEnv[envName];
 	}
-	const env: Record<string, string> = {
-		...input.commonEnvironment,
-		...runtimeEnv,
-		...(input.manifest.locale ? { TZ: input.manifest.locale.timezone } : {}),
-		CLAWDI_AUTH_TOKEN: "",
-		CLAWDI_HOME: input.paths.clawdiHome,
-		CLAWDI_RUNTIME_REV: runtimeSystemdProgramRevision(
-			input.manifest,
-			program,
-			input.secretValues,
-			input.providerProjectionRevisions,
-			input.runtimeRevision,
-		),
-	};
-	if (
-		descriptor &&
-		input.manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2"
-	) {
-		// The official installer owns the gateway's process environment baseline
-		// along with ExecStart and WorkingDirectory.
-		delete env.HOME;
-		delete env.PATH;
-	}
+	if (descriptor) delete runtimeEnv.PATH;
+	if (descriptor || isHermesDashboard) delete runtimeEnv.CLAWDI_AUTH_TOKEN;
+	const revision = runtimeSystemdProgramRevision(
+		input.manifest,
+		program,
+		input.secretValues,
+		input.providerProjectionRevisions,
+		input.runtimeRevision,
+	);
+	const isNativeRuntimeService = descriptor !== null || isHermesDashboard;
+	const env: Record<string, string> = isNativeRuntimeService
+		? {
+				...(isHermesDashboard ? { HOME: input.paths.userHome } : {}),
+				...runtimeEnv,
+				CLAWDI_RUNTIME_REV: revision,
+			}
+		: {
+				...input.commonEnvironment,
+				...runtimeEnv,
+				CLAWDI_AUTH_TOKEN: "",
+				CLAWDI_HOME: input.paths.clawdiHome,
+				CLAWDI_RUNTIME_REV: revision,
+			};
 	if (officialRuntimeServiceInstallArgs(program)) {
 		return writeSystemdUserEnvironmentDropIn({
 			paths: input.paths,
 			name,
 			env,
+			unsetEnvironment: ["CLAWDI_AUTH_TOKEN"],
 		});
 	}
 	return writeSystemdUserUnit({
@@ -1485,6 +1496,7 @@ function writeRuntimeSystemdUserProgram(input: {
 		args: program.args,
 		cwd: program.cwd,
 		env,
+		unsetEnvironment: isHermesDashboard ? ["CLAWDI_AUTH_TOKEN"] : undefined,
 	});
 }
 

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -413,8 +413,6 @@ type OfficialRuntimeServiceDescriptor = {
 	// Manifest `services` key the official unit corresponds to; used for
 	// program naming even when such an entry is not official for the runtime.
 	service: string;
-	// Extra env projected into the unit's environment file.
-	unitEnv?: (unitName: string) => Record<string, string>;
 	// Which desired programs the official unit covers. Deliberately
 	// asymmetric: openclaw's default program is its gateway, while hermes may
 	// express the gateway as the default program or an explicit
@@ -431,7 +429,6 @@ const OFFICIAL_RUNTIME_SERVICE_DESCRIPTORS: OfficialRuntimeServiceDescriptor[] =
 		uninstallArgs: ["gateway", "uninstall"],
 		installSecretEnv: ["OPENCLAW_GATEWAY_TOKEN"],
 		service: "gateway",
-		unitEnv: (unitName) => ({ OPENCLAW_SYSTEMD_UNIT: unitName }),
 		matchesProgram: (program) => !program.service,
 	},
 	{
@@ -1439,7 +1436,6 @@ function writeRuntimeSystemdUserProgram(input: {
 }): string {
 	const { program } = input;
 	const name = runtimeSystemdProgramName(program);
-	const unitName = systemdUnitFileName(name);
 	const runtimeEnv = { ...program.env };
 	const descriptor = officialRuntimeServiceDescriptorForProgram(program);
 	const installerOnlySecretEnv =
@@ -1451,7 +1447,7 @@ function writeRuntimeSystemdUserProgram(input: {
 	for (const envName of installerOnlySecretEnv) {
 		delete runtimeEnv[envName];
 	}
-	const env = {
+	const env: Record<string, string> = {
 		...input.commonEnvironment,
 		...runtimeEnv,
 		...(input.manifest.locale ? { TZ: input.manifest.locale.timezone } : {}),
@@ -1464,8 +1460,16 @@ function writeRuntimeSystemdUserProgram(input: {
 			input.providerProjectionRevisions,
 			input.runtimeRevision,
 		),
-		...(descriptor?.unitEnv?.(unitName) ?? {}),
 	};
+	if (
+		descriptor &&
+		input.manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2"
+	) {
+		// The official installer owns the gateway's process environment baseline
+		// along with ExecStart and WorkingDirectory.
+		delete env.HOME;
+		delete env.PATH;
+	}
 	if (officialRuntimeServiceInstallArgs(program)) {
 		return writeSystemdUserEnvironmentDropIn({
 			paths: input.paths,

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -795,6 +795,8 @@ test("persists and serves the managed token through the real official OpenClaw g
 	rmSync(dropInRoot, { recursive: true, force: true });
 	rmSync(enablementPath, { force: true });
 	const workspaceRoot = join(runtimeHome, ".openclaw", "workspace");
+	mkdirSync(dirname(openClawConfig), { recursive: true, mode: 0o700 });
+	chownSync(dirname(openClawConfig), runtimeUid, runtimeGid);
 	writeFileSync(
 		openClawConfig,
 		`${JSON.stringify({
@@ -931,7 +933,7 @@ test("persists and serves the managed token through the real official OpenClaw g
 		rmSync(dropInRoot, { recursive: true, force: true });
 		rmSync(enablementPath, { force: true });
 	}
-}, 60_000);
+}, 120_000);
 
 test("runs Files as the tenant while preserving platform isolation", () => {
 	if (process.env[REAL_SYSTEMD_GATE] !== "1") return;

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1575,12 +1575,8 @@ function seedMitmproxyCache(paths = getRuntimePaths()): typeof TEST_EGRESS_ENGIN
 }
 
 type HostedRunFixture = {
-	command?: string;
 	args?: string[];
-	env?: Record<string, string>;
 	secretEnv?: Record<string, string>;
-	cwd?: string;
-	prependPath?: string[];
 };
 
 type HostedRuntimeFixtureEntry = {
@@ -1610,11 +1606,9 @@ function hostedOpenClawRuntime(
 		primary_model,
 		run: {
 			args: ["gateway", "run"],
-			env: {},
 			secretEnv: {
 				OPENCLAW_GATEWAY_TOKEN: "secret://runtime/openclaw/gateway-token",
 			},
-			prependPath: [],
 		},
 		services: {},
 		...entryOverrides,
@@ -1637,14 +1631,10 @@ function hostedHermesRuntime(
 		primary_model,
 		run: {
 			args: ["gateway", "run"],
-			env: {},
-			prependPath: [],
 		},
 		services: {
 			dashboard: {
 				args: ["dashboard", "--host", "0.0.0.0", "--port", "9119", "--no-open"],
-				env: {},
-				prependPath: [],
 			},
 		},
 		...entryOverrides,
@@ -7081,13 +7071,7 @@ exit 64
 					},
 					runtimes: {
 						openclaw: hostedOpenClawRuntime(),
-						hermes: {
-							enabled: false,
-							install: { source: "official" },
-							providerMode: "configured",
-							provider_ids: ["default"],
-							primary_model: { provider_id: "default", model: "gpt-test" },
-						},
+						hermes: hostedHermesRuntime({ enabled: false }),
 					},
 				},
 				secretValues: {},

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -15298,6 +15298,9 @@ exit 64
 			expect(convergence.outputs.workspaceRoot).toBe(workspace);
 			expect(existsSync(workspace)).toBe(true);
 			expect(hermesRunConfig.cwd).toBe(workspace);
+			expect(expectRecord(readHermesConfigYaml(home).terminal, "Hermes terminal config").cwd).toBe(
+				workspace,
+			);
 			expect(convergence.outputs.processManager).toBe("systemd");
 			expect(readSystemdSystemUnit(getRuntimePaths(), "clawdi-runtime-watch")).toContain(
 				`WorkingDirectory=${workspace}`,
@@ -16851,7 +16854,6 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 
 		converge(manifestFor("en", "UTC"));
 		const initialRevision = systemdEnvRevision(readSystemdEnvFile(paths, "openclaw-gateway"));
-		expect(readSystemdEnvFile(paths, "openclaw-gateway")).toContain('TZ="UTC"');
 
 		converge(manifestFor("fr", "Europe/Paris"));
 		const soul = readFileSync(soulPath, "utf-8");
@@ -16861,7 +16863,6 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		expect(soul).toContain("`Europe/Paris`");
 		expect(readFileSync(userPath, "utf-8")).toBe("User profile stays untouched.\n");
 		const updatedEnv = readSystemdEnvFile(paths, "openclaw-gateway");
-		expect(updatedEnv).toContain('TZ="Europe/Paris"');
 		expect(systemdEnvRevision(updatedEnv)).not.toBe(initialRevision);
 		converge(manifestFor("fr", "Europe/Paris"));
 		expect(readFileSync(soulPath, "utf-8")).toBe(soul);
@@ -16920,7 +16921,6 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		const config = readHermesConfigYaml(home);
 		expect(config.custom_setting).toBe("keep");
 		expect(config.timezone).toBe("Asia/Taipei");
-		expect(readSystemdEnvFile(paths, "hermes-gateway")).toContain('TZ="Asia/Taipei"');
 	});
 
 	it("runtime program revisions ignore unrelated control-plane and sibling runtime changes", () => {


### PR DESCRIPTION
## Summary

- restrict Hosted runtime manifests to official OpenClaw/Hermes gateway identities and the one supported Hermes dashboard command
- leave gateway ExecStart, WorkingDirectory, HOME, PATH, and OpenClaw systemd identity under the official installers while removing legacy Hosted overrides during reconciliation
- keep Hermes dashboard authentication and lifecycle scoped to the compatibility dashboard unit, with upstream-owned dashboard builds

## Compatibility

- accepts the previous Hosted OpenClaw and Hermes gateway argv during fleet self-upgrade, then normalizes to `gateway run`
- verified against integrity-pinned official `openclaw@2026.7.1-2` with its real config mutation, gateway installer, user systemd service, auth, and health flow
- contains no version-specific runtime branch or unit-shape patch

## Verification

- `scripts/test-runtime-official-installer-systemd.sh`: 4 pass, 0 fail, 201 expect
- focused CLI runtime suite: 260 pass, 0 fail, 1776 expect
- full CLI suite: 1710 pass, 4 skip, 0 fail, 9389 expect
- Biome CI and `git diff --check`: pass
