### PR TITLE
feat(cli): optimize session sync and add cloud search

### DIFF
--- a/packages/cli/src/adapters/base.ts
+++ b/packages/cli/src/adapters/base.ts
@@ -76,6 +76,23 @@ export interface AgentAdapter {
 	getVersion(): Promise<string | null>;
 
 	collectSessions(opts?: CollectSessionsOptions): Promise<CollectSessionsResult>;
+	/**
+	 * Re-read one session from its current backing store, when supported.
+	 * Implementations must not return a cached transcript payload.
+	 */
+	collectSession?(localSessionId: string): Promise<RawSession | null>;
+	/**
+	 * Parse only sessions represented by concrete watcher paths.
+	 *
+	 * Returns `null` when any path cannot be resolved safely to a bounded
+	 * session set. The daemon then falls back to `collectSessions()`. The
+	 * result is a partial inventory, so callers must not infer deletion of
+	 * sessions omitted from it.
+	 */
+	collectSessionsForPaths?(
+		paths: readonly string[],
+		opts?: CollectSessionsOptions,
+	): Promise<CollectSessionsResult | null>;
 	collectSkills(): Promise<RawSkill[]>;
 	/** Enumerate skill_keys present on disk WITHOUT reading SKILL.md
 	 * content. Used by the daemon's hot-path rescan / boot listing
@@ -113,8 +130,9 @@ export interface AgentAdapter {
 	/** Path(s) `clawdi daemon` should watch for session changes. May
 	 * be directories (Claude Code, Codex, OpenClaw all dump JSONL
 	 * files there) or database/sidecar files (Hermes uses SQLite). The
-	 * daemon walks each path on a change event, then runs
-	 * `collectSessions` to enumerate what's actually there.
+	 * daemon passes concrete changed paths to `collectSessionsForPaths`
+	 * when the platform provides them, with `collectSessions` as the safe
+	 * fallback for ambiguous events and shared data stores.
 	 *
 	 * Returning paths that don't exist yet is fine — the watcher
 	 * skips missing roots and reattaches when `mkdir` lands. The

--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
-import { basename, join } from "node:path";
+import { basename, isAbsolute, join, relative } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import { replaceSkillArchiveTarGz } from "../lib/tar";
@@ -94,8 +94,6 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 
 		const { projectFilter } = opts;
 
-		const sessions: RawSession[] = [];
-		const uuidsBySession = new Map<RawSession, Set<string>>();
 		let projectDirs = readdirSync(projectsDir(), { withFileTypes: true }).filter((d) =>
 			d.isDirectory(),
 		);
@@ -115,42 +113,103 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 			);
 		}
 
-		for (const projectDir of projectDirs) {
-			const projectPath = join(projectsDir(), projectDir.name);
-			const jsonlFiles = readdirSync(projectPath).filter((f) => f.endsWith(".jsonl"));
+		return this.collectProjectSessions(
+			projectDirs.map((projectDir) => projectDir.name),
+			absFilter,
+		);
+	}
 
-			for (const file of jsonlFiles) {
-				const filePath = join(projectPath, file);
-				const sessionId = basename(file, ".jsonl");
+	async collectSession(localSessionId: string): Promise<RawSession | null> {
+		if (!existsSync(projectsDir()) || basename(localSessionId) !== localSessionId) return null;
+		const matches: Array<{ filePath: string; projectDirName: string }> = [];
+		for (const projectDir of readdirSync(projectsDir(), { withFileTypes: true })) {
+			if (!projectDir.isDirectory()) continue;
+			const filePath = join(projectsDir(), projectDir.name, `${localSessionId}.jsonl`);
+			if (existsSync(filePath)) matches.push({ filePath, projectDirName: projectDir.name });
+		}
+		if (matches.length !== 1) {
+			if (matches.length === 0) return null;
+			return (
+				(await this.collectSessions()).sessions.find(
+					(session) => session.localSessionId === localSessionId,
+				) ?? null
+			);
+		}
+		return (
+			this.collectProjectSessions([matches[0].projectDirName], null).sessions.find(
+				(session) => session.localSessionId === localSessionId,
+			) ?? null
+		);
+	}
 
+	async collectSessionsForPaths(
+		paths: readonly string[],
+		opts: CollectSessionsOptions = {},
+	): Promise<CollectSessionsResult | null> {
+		const projectDirNames = new Set<string>();
+		for (const path of paths) {
+			const fromRoot = relative(projectsDir(), path);
+			const parts = fromRoot.split(/[\\/]/);
+			if (
+				isAbsolute(fromRoot) ||
+				fromRoot.startsWith("..") ||
+				parts.length !== 2 ||
+				!parts[1].endsWith(".jsonl")
+			) {
+				return null;
+			}
+			projectDirNames.add(parts[0]);
+		}
+		if (projectDirNames.size === 0) return null;
+
+		const absFilter = opts.projectFilter
+			? (await import("node:path")).resolve(opts.projectFilter)
+			: null;
+		return this.collectProjectSessions([...projectDirNames], absFilter);
+	}
+
+	private collectProjectSessions(
+		projectDirNames: readonly string[],
+		absFilter: string | null,
+	): CollectSessionsResult {
+		const sessions: RawSession[] = [];
+		const uuidsBySession = new Map<RawSession, Set<string>>();
+		for (const projectDirName of projectDirNames) {
+			const projectPath = join(projectsDir(), projectDirName);
+			if (!existsSync(projectPath)) continue;
+			for (const file of readdirSync(projectPath).filter((name) => name.endsWith(".jsonl"))) {
 				try {
-					const parsed = this.parseSessionJsonl(filePath, projectDir.name);
+					const parsed = this.parseRawSession(join(projectPath, file), projectDirName);
 					if (!parsed) continue;
-
-					if (absFilter) {
-						const cwd = parsed.projectPath;
-						if (!cwd) continue;
-						if (cwd !== absFilter && !cwd.startsWith(`${absFilter}/`)) continue;
+					const cwd = parsed.session.projectPath;
+					if (absFilter && (!cwd || (cwd !== absFilter && !cwd.startsWith(`${absFilter}/`)))) {
+						continue;
 					}
-
-					const { uuidSet, ...sessionFields } = parsed;
-					const session: RawSession = {
-						...sessionFields,
-						localSessionId: sessionId,
-						rawFilePath: filePath,
-					};
-					sessions.push(session);
-					uuidsBySession.set(session, uuidSet);
+					sessions.push(parsed.session);
+					uuidsBySession.set(parsed.session, parsed.uuidSet);
 				} catch {
-					// Skip unparseable sessions
+					// Skip files that disappear or become unreadable during collection.
 				}
 			}
 		}
-
-		// Dedupe resume chains. The Map is local to this module — it goes out of
-		// use when this function returns and is GC'd, so uuid data never
-		// leaks into RawSession or anywhere downstream.
 		return dedupeResumeChains(sessions, uuidsBySession);
+	}
+
+	private parseRawSession(
+		filePath: string,
+		projectDirName: string,
+	): { session: RawSession; uuidSet: Set<string> } | null {
+		const parsed = this.parseSessionJsonl(filePath, projectDirName);
+		if (!parsed) return null;
+		const { uuidSet, ...sessionFields } = parsed;
+		return {
+			session: {
+				...sessionFields,
+				localSessionId: basename(filePath, ".jsonl"),
+				rawFilePath: filePath,
+			},
+			uuidSet,
+		};
 	}
 
 	private parseSessionJsonl(filePath: string, _projectDirName: string): ParsedSession | null {

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -1,5 +1,5 @@
 import { type Dirent, existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import { replaceSkillArchiveTarGz } from "../lib/tar";
@@ -25,6 +25,12 @@ function codexDir() {
 }
 function sessionsDir() {
 	return join(codexDir(), "sessions");
+}
+function archivedSessionsDir() {
+	return join(codexDir(), "archived_sessions");
+}
+function sessionRoots() {
+	return [sessionsDir(), archivedSessionsDir()];
 }
 function skillsDir() {
 	return join(codexDir(), "skills");
@@ -68,9 +74,9 @@ function collectJsonlFiles(root: string): string[] {
 	const results: string[] = [];
 	if (!existsSync(root)) return results;
 
-	// Directory layout: YYYY/MM/DD/rollout-*.jsonl. Full walk every push —
-	// the content-hash cache in `lib/sessions-lock.ts` decides which files
-	// to actually upload, so there's no point pruning at the FS level.
+	// Directory layout: YYYY/MM/DD/rollout-*.jsonl. Complete inventory
+	// collection walks every file; watcher and queue paths use the bounded
+	// collectors below.
 	const walk = (dir: string) => {
 		let entries: Dirent[];
 		try {
@@ -94,15 +100,139 @@ function collectJsonlFiles(root: string): string[] {
 	return results;
 }
 
+function isWithinSessionRoot(path: string): boolean {
+	return sessionRoots().some((root) => {
+		const fromRoot = relative(root, path);
+		return fromRoot === "" || (!fromRoot.startsWith("..") && !isAbsolute(fromRoot));
+	});
+}
+
+function resolveProjectFilter(projectFilter?: string): string | null {
+	return projectFilter ? resolve(projectFilter) : null;
+}
+
+function parseSessionFile(filePath: string, absFilter: string | null): RawSession | null {
+	let content: string;
+	try {
+		content = readFileSync(filePath, "utf-8");
+	} catch {
+		return null;
+	}
+	const lines = content.split("\n").filter(Boolean);
+	if (lines.length === 0) return null;
+
+	let sessionId: string | null = null;
+	let projectPath: string | null = null;
+	let startedAt: Date | null = null;
+	let endedAt: Date | null = null;
+	let lastModel: string | null = null;
+	const modelsUsed = new Set<string>();
+	const messages: SessionMessage[] = [];
+	let inputTokens = 0;
+	let outputTokens = 0;
+	let cacheReadTokens = 0;
+
+	for (const line of lines) {
+		let parsed: SessionLine;
+		try {
+			parsed = JSON.parse(line);
+		} catch {
+			continue;
+		}
+
+		const ts = parsed.timestamp ? new Date(parsed.timestamp) : null;
+		if (ts && !Number.isNaN(ts.getTime())) {
+			if (!startedAt) startedAt = ts;
+			endedAt = ts;
+		}
+
+		if (parsed.type === "session_meta") {
+			sessionId = parsed.payload?.id ?? sessionId;
+			projectPath = parsed.payload?.cwd ?? projectPath;
+			if (parsed.payload?.timestamp) {
+				const headerTs = new Date(parsed.payload.timestamp);
+				if (!Number.isNaN(headerTs.getTime())) startedAt = headerTs;
+			}
+			continue;
+		}
+
+		if (parsed.type === "turn_context") {
+			const model = parsed.payload?.model;
+			if (model) {
+				lastModel = model;
+				modelsUsed.add(model);
+			}
+			continue;
+		}
+
+		if (parsed.type === "event_msg" && parsed.payload?.type === "token_count") {
+			const total = parsed.payload.info?.total_token_usage;
+			if (total) {
+				inputTokens = total.input_tokens ?? inputTokens;
+				outputTokens = total.output_tokens ?? outputTokens;
+				cacheReadTokens = total.cached_input_tokens ?? cacheReadTokens;
+			}
+			continue;
+		}
+
+		if (parsed.type === "response_item" && parsed.payload?.type === "message") {
+			const role = parsed.payload.role;
+			if (role !== "user" && role !== "assistant") continue;
+			const text = extractMessageText(parsed.payload.content);
+			if (!text) continue;
+			messages.push({
+				role,
+				content: text,
+				model: role === "assistant" ? (lastModel ?? undefined) : undefined,
+				timestamp: ts?.toISOString(),
+			});
+		}
+	}
+
+	if (!sessionId || messages.length === 0 || !startedAt) return null;
+	if (absFilter) {
+		if (!projectPath) return null;
+		if (projectPath !== absFilter && !projectPath.startsWith(`${absFilter}/`)) return null;
+	}
+
+	endedAt ??= startedAt;
+	const firstRealUser = messages.find(
+		(message) => message.role === "user" && !message.content.startsWith("<environment_context>"),
+	);
+
+	return {
+		localSessionId: sessionId,
+		projectPath,
+		startedAt,
+		endedAt,
+		messageCount: messages.length,
+		inputTokens,
+		outputTokens,
+		cacheReadTokens,
+		model: lastModel,
+		modelsUsed: [...modelsUsed],
+		durationSeconds: durationSecondsBetween(startedAt, endedAt),
+		summary: firstRealUser ? safeTruncate(firstRealUser.content, 200) : null,
+		messages,
+		rawFilePath: filePath,
+	};
+}
+
 export class CodexAdapter implements AgentAdapter {
 	readonly agentType = "codex" as const;
+	private sessionPaths = new Map<string, string>();
+	private hasCompleteSessionPathInventory = false;
 
 	async detect(): Promise<boolean> {
 		// Bare `~/.codex/` could be a leftover. Require either the sessions
 		// dir (created on first `codex` run) or `config.toml` (created when
 		// the user edits codex config).
 		if (!existsSync(codexDir())) return false;
-		return existsSync(sessionsDir()) || existsSync(join(codexDir(), "config.toml"));
+		return (
+			existsSync(sessionsDir()) ||
+			existsSync(archivedSessionsDir()) ||
+			existsSync(join(codexDir(), "config.toml"))
+		);
 	}
 
 	async getVersion(): Promise<string | null> {
@@ -110,134 +240,68 @@ export class CodexAdapter implements AgentAdapter {
 	}
 
 	async collectSessions(opts: CollectSessionsOptions = {}): Promise<CollectSessionsResult> {
-		if (!existsSync(sessionsDir())) return { sessions: [], dedupedCount: 0 };
-
-		const { projectFilter } = opts;
-
-		let absFilter: string | null = null;
-		if (projectFilter) {
-			const { resolve } = await import("node:path");
-			absFilter = resolve(projectFilter);
+		const sessionsById = new Map<string, RawSession>();
+		const pathsById = new Map<string, string>();
+		const absFilter = resolveProjectFilter(opts.projectFilter);
+		for (const root of sessionRoots()) {
+			for (const filePath of collectJsonlFiles(root)) {
+				const session = parseSessionFile(filePath, absFilter);
+				if (session && !sessionsById.has(session.localSessionId)) {
+					sessionsById.set(session.localSessionId, session);
+					pathsById.set(session.localSessionId, filePath);
+				}
+			}
 		}
-
-		const files = collectJsonlFiles(sessionsDir());
-		const sessions: RawSession[] = [];
-
-		for (const filePath of files) {
-			let content: string;
-			try {
-				content = readFileSync(filePath, "utf-8");
-			} catch {
-				continue;
-			}
-			const lines = content.split("\n").filter(Boolean);
-			if (lines.length === 0) continue;
-
-			let sessionId: string | null = null;
-			let projectPath: string | null = null;
-			let startedAt: Date | null = null;
-			let endedAt: Date | null = null;
-			let lastModel: string | null = null;
-			const modelsUsed = new Set<string>();
-			const messages: SessionMessage[] = [];
-			let inputTokens = 0;
-			let outputTokens = 0;
-			let cacheReadTokens = 0;
-
-			for (const line of lines) {
-				let parsed: SessionLine;
-				try {
-					parsed = JSON.parse(line);
-				} catch {
-					continue;
-				}
-
-				const ts = parsed.timestamp ? new Date(parsed.timestamp) : null;
-				if (ts && !Number.isNaN(ts.getTime())) {
-					if (!startedAt) startedAt = ts;
-					endedAt = ts;
-				}
-
-				if (parsed.type === "session_meta") {
-					sessionId = parsed.payload?.id ?? sessionId;
-					projectPath = parsed.payload?.cwd ?? projectPath;
-					if (parsed.payload?.timestamp) {
-						const headerTs = new Date(parsed.payload.timestamp);
-						if (!Number.isNaN(headerTs.getTime())) startedAt = headerTs;
-					}
-					continue;
-				}
-
-				if (parsed.type === "turn_context") {
-					const m = parsed.payload?.model;
-					if (m) {
-						lastModel = m;
-						modelsUsed.add(m);
-					}
-					continue;
-				}
-
-				if (parsed.type === "event_msg" && parsed.payload?.type === "token_count") {
-					const total = parsed.payload.info?.total_token_usage;
-					if (total) {
-						inputTokens = total.input_tokens ?? inputTokens;
-						outputTokens = total.output_tokens ?? outputTokens;
-						cacheReadTokens = total.cached_input_tokens ?? cacheReadTokens;
-					}
-					continue;
-				}
-
-				if (parsed.type === "response_item" && parsed.payload?.type === "message") {
-					const role = parsed.payload.role;
-					if (role !== "user" && role !== "assistant") continue;
-					const text = extractMessageText(parsed.payload.content);
-					if (!text) continue;
-					messages.push({
-						role,
-						content: text,
-						model: role === "assistant" ? (lastModel ?? undefined) : undefined,
-						timestamp: ts?.toISOString(),
-					});
-				}
-			}
-
-			if (!sessionId || messages.length === 0 || !startedAt) continue;
-
-			if (absFilter) {
-				if (!projectPath) continue;
-				if (projectPath !== absFilter && !projectPath.startsWith(`${absFilter}/`)) continue;
-			}
-
-			if (!endedAt) endedAt = startedAt;
-			const durationSeconds = durationSecondsBetween(startedAt, endedAt);
-
-			const firstRealUser = messages.find(
-				(m) => m.role === "user" && !m.content.startsWith("<environment_context>"),
-			);
-			const summary = firstRealUser ? safeTruncate(firstRealUser.content, 200) : null;
-
-			sessions.push({
-				localSessionId: sessionId,
-				projectPath,
-				startedAt,
-				endedAt,
-				messageCount: messages.length,
-				inputTokens,
-				outputTokens,
-				cacheReadTokens,
-				model: lastModel,
-				modelsUsed: [...modelsUsed],
-				durationSeconds,
-				summary,
-				messages,
-				rawFilePath: filePath,
-			});
+		if (opts.projectFilter) {
+			for (const [sessionId, path] of pathsById) this.sessionPaths.set(sessionId, path);
+		} else {
+			this.sessionPaths = pathsById;
+			this.hasCompleteSessionPathInventory = true;
 		}
 
 		// Codex stores long-conversation history via in-file `compacted`
 		// entries rather than spawning new sessionId files, so it cannot
 		// produce the resume-chain duplication that ClaudeCodeAdapter dedupes.
-		return { sessions, dedupedCount: 0 };
+		return { sessions: [...sessionsById.values()], dedupedCount: 0 };
+	}
+
+	async collectSession(localSessionId: string): Promise<RawSession | null> {
+		const knownPath = this.sessionPaths.get(localSessionId);
+		if (knownPath) {
+			const current = parseSessionFile(knownPath, null);
+			if (current?.localSessionId === localSessionId) return current;
+			this.sessionPaths.delete(localSessionId);
+		}
+		if (this.hasCompleteSessionPathInventory) return null;
+		return (
+			(await this.collectSessions()).sessions.find(
+				(session) => session.localSessionId === localSessionId,
+			) ?? null
+		);
+	}
+
+	async collectSessionsForPaths(
+		paths: readonly string[],
+		opts: CollectSessionsOptions = {},
+	): Promise<CollectSessionsResult | null> {
+		const files = new Set<string>();
+		for (const path of paths.map((candidate) => resolve(candidate))) {
+			if (!isWithinSessionRoot(path) || !path.endsWith(".jsonl")) return null;
+			for (const [sessionId, knownPath] of this.sessionPaths) {
+				if (knownPath === path && !existsSync(path)) this.sessionPaths.delete(sessionId);
+			}
+			if (existsSync(path)) files.add(path);
+		}
+		const sessionsById = new Map<string, RawSession>();
+		const absFilter = resolveProjectFilter(opts.projectFilter);
+		for (const filePath of files) {
+			const session = parseSessionFile(filePath, absFilter);
+			if (session) {
+				sessionsById.set(session.localSessionId, session);
+				this.sessionPaths.set(session.localSessionId, filePath);
+			}
+		}
+		return { sessions: [...sessionsById.values()], dedupedCount: 0 };
 	}
 
 	async collectSkills(): Promise<RawSkill[]> {
@@ -311,10 +375,8 @@ export class CodexAdapter implements AgentAdapter {
 	}
 
 	getSessionsWatchPaths(): string[] {
-		// Codex dumps every session under `~/.codex/sessions/`. We
-		// watch the root recursively and let `collectSessions`
-		// re-enumerate on change.
-		return [sessionsDir()];
+		const existingRoots = sessionRoots().filter((root) => existsSync(root));
+		return existingRoots.length > 0 ? existingRoots : [sessionsDir()];
 	}
 
 	async removeLocalSkill(key: string): Promise<void> {

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -221,7 +221,6 @@ function parseSessionFile(filePath: string, absFilter: string | null): RawSessio
 export class CodexAdapter implements AgentAdapter {
 	readonly agentType = "codex" as const;
 	private sessionPaths = new Map<string, string>();
-	private hasCompleteSessionPathInventory = false;
 
 	async detect(): Promise<boolean> {
 		// Bare `~/.codex/` could be a leftover. Require either the sessions
@@ -256,7 +255,6 @@ export class CodexAdapter implements AgentAdapter {
 			for (const [sessionId, path] of pathsById) this.sessionPaths.set(sessionId, path);
 		} else {
 			this.sessionPaths = pathsById;
-			this.hasCompleteSessionPathInventory = true;
 		}
 
 		// Codex stores long-conversation history via in-file `compacted`
@@ -272,7 +270,6 @@ export class CodexAdapter implements AgentAdapter {
 			if (current?.localSessionId === localSessionId) return current;
 			this.sessionPaths.delete(localSessionId);
 		}
-		if (this.hasCompleteSessionPathInventory) return null;
 		return (
 			(await this.collectSessions()).sessions.find(
 				(session) => session.localSessionId === localSessionId,

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -33,6 +33,25 @@ interface SqliteDatabase {
 	close(): void;
 }
 
+interface SessionRow {
+	id: string;
+	source: string | null;
+	model: string | null;
+	title: string | null;
+	started_at: number;
+	ended_at: number | null;
+	message_count: number | null;
+	input_tokens: number | null;
+	output_tokens: number | null;
+	cache_read_tokens: number | null;
+}
+
+interface MessageRow {
+	role: string;
+	content: string;
+	timestamp: number;
+}
+
 /**
  * Open a Hermes SQLite db using the runtime's built-in binding:
  * - Under Bun: `bun:sqlite` (built-in, the dev/test default).
@@ -110,37 +129,27 @@ export class HermesAdapter implements AgentAdapter {
 		// always scan the whole `sessions` table. Cost is negligible
 		// (dozens to hundreds of rows). `projectFilter` has no analogue
 		// in Hermes' data model and is silently ignored.
-		if (!existsSync(stateDbPath())) return { sessions: [], dedupedCount: 0 };
+		return { sessions: await this.collectCurrentSessions(), dedupedCount: 0 };
+	}
 
+	async collectSession(localSessionId: string): Promise<RawSession | null> {
+		return (await this.collectCurrentSessions(localSessionId))[0] ?? null;
+	}
+
+	private async collectCurrentSessions(localSessionId?: string): Promise<RawSession[]> {
+		if (!existsSync(stateDbPath())) return [];
 		const db = await openHermesDb(stateDbPath());
 		try {
-			interface SessionRow {
-				id: string;
-				source: string | null;
-				model: string | null;
-				title: string | null;
-				started_at: number;
-				ended_at: number | null;
-				message_count: number | null;
-				input_tokens: number | null;
-				output_tokens: number | null;
-				cache_read_tokens: number | null;
-			}
-			interface MessageRow {
-				role: string;
-				content: string;
-				timestamp: number;
-			}
-
+			const selectSessions = `
+				SELECT id, source, model, title, started_at, ended_at,
+				       message_count, input_tokens, output_tokens, cache_read_tokens
+				FROM sessions
+				${localSessionId === undefined ? "" : "WHERE id = ?"}
+				ORDER BY started_at DESC
+			`;
 			const rows = db
-				.prepare(`
-					SELECT id, source, model, title, started_at, ended_at,
-					       message_count, input_tokens, output_tokens, cache_read_tokens
-					FROM sessions
-					ORDER BY started_at DESC
-				`)
-				.all() as SessionRow[];
-
+				.prepare(selectSessions)
+				.all(...(localSessionId === undefined ? [] : [localSessionId])) as SessionRow[];
 			const msgStmt = db.prepare(`
 				SELECT role, content, timestamp
 				FROM messages
@@ -196,9 +205,7 @@ export class HermesAdapter implements AgentAdapter {
 				});
 			}
 
-			// Hermes stores one row per session with a stable id — no resume-
-			// chain duplication to dedupe.
-			return { sessions, dedupedCount: 0 };
+			return sessions;
 		} finally {
 			db.close();
 		}

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { isAbsolute, join } from "node:path";
+import { basename, isAbsolute, join, relative, resolve } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import { extractTarGz } from "../lib/tar";
@@ -91,6 +91,11 @@ function listAgentDirs(): string[] {
 	}
 }
 
+function isWithin(path: string, root: string): boolean {
+	const fromRoot = relative(root, path);
+	return fromRoot === "" || (!fromRoot.startsWith("..") && !isAbsolute(fromRoot));
+}
+
 interface SessionEntry {
 	// Real openclaw indexes key entries by composite strings like
 	// `agent:main:main` or `agent:main:telegram:group:-100…:topic:1`, with
@@ -164,8 +169,52 @@ export class OpenClawAdapter implements AgentAdapter {
 	}
 
 	async collectSessions(opts: CollectSessionsOptions = {}): Promise<CollectSessionsResult> {
+		return (await this.collectSessionsMatching(opts)).result;
+	}
+
+	async collectSession(localSessionId: string): Promise<RawSession | null> {
+		return (
+			(await this.collectSessionsMatching({}, undefined, localSessionId)).result.sessions[0] ?? null
+		);
+	}
+
+	async collectSessionsForPaths(
+		paths: readonly string[],
+		opts: CollectSessionsOptions = {},
+	): Promise<CollectSessionsResult | null> {
+		const sessionRoots = listAgentDirs().map((dir) => resolve(dir, "sessions"));
+		const transcriptPaths = new Set<string>();
+		for (const path of paths) {
+			const normalized = resolve(path);
+			if (!sessionRoots.some((root) => isWithin(normalized, root))) return null;
+			if (basename(normalized) === "sessions.json") return null;
+			if (!normalized.endsWith(".jsonl")) return null;
+			transcriptPaths.add(normalized);
+		}
+		if (transcriptPaths.size === 0) return null;
+
+		const collection = await this.collectSessionsMatching(opts, transcriptPaths);
+		for (const path of transcriptPaths) {
+			if (existsSync(path) && !collection.matchedTranscriptPaths.has(path)) return null;
+		}
+		return collection.result;
+	}
+
+	private async collectSessionsMatching(
+		opts: CollectSessionsOptions,
+		transcriptPaths?: ReadonlySet<string>,
+		localSessionId?: string,
+	): Promise<{
+		result: CollectSessionsResult;
+		matchedTranscriptPaths: Set<string>;
+	}> {
 		const agentDirs = listAgentDirs();
-		if (agentDirs.length === 0) return { sessions: [], dedupedCount: 0 };
+		if (agentDirs.length === 0) {
+			return {
+				result: { sessions: [], dedupedCount: 0 },
+				matchedTranscriptPaths: new Set(),
+			};
+		}
 
 		const { projectFilter } = opts;
 		let absFilter: string | null = null;
@@ -175,6 +224,7 @@ export class OpenClawAdapter implements AgentAdapter {
 		}
 
 		const sessions: RawSession[] = [];
+		const matchedTranscriptPaths = new Set<string>();
 
 		for (const agentRoot of agentDirs) {
 			const sessionsDirForAgent = join(agentRoot, "sessions");
@@ -193,6 +243,7 @@ export class OpenClawAdapter implements AgentAdapter {
 				// the index key only for legacy fixtures that use the UUID as
 				// the key directly.
 				const sessionId = entry.sessionId ?? indexKey;
+				if (localSessionId !== undefined && sessionId !== localSessionId) continue;
 				const updatedAt = entry.updatedAt ?? entry.acp?.lastActivityAt;
 				if (!updatedAt) continue;
 
@@ -207,6 +258,9 @@ export class OpenClawAdapter implements AgentAdapter {
 						? entry.sessionFile
 						: join(sessionsDirForAgent, entry.sessionFile)
 					: join(sessionsDirForAgent, `${sessionId}.jsonl`);
+				const normalizedTranscriptPath = resolve(transcriptPath);
+				if (transcriptPaths && !transcriptPaths.has(normalizedTranscriptPath)) continue;
+				if (transcriptPaths) matchedTranscriptPaths.add(normalizedTranscriptPath);
 
 				const messages: SessionMessage[] = [];
 				let startedAt: Date | null = null;
@@ -307,7 +361,10 @@ export class OpenClawAdapter implements AgentAdapter {
 
 		// OpenClaw stores one session per ACP transcript with stable sessionIds
 		// — no resume-chain duplication to dedupe.
-		return { sessions, dedupedCount: 0 };
+		return {
+			result: { sessions, dedupedCount: 0 },
+			matchedTranscriptPaths,
+		};
 	}
 
 	async collectSkills(): Promise<RawSkill[]> {
@@ -417,11 +474,10 @@ export class OpenClawAdapter implements AgentAdapter {
 	}
 
 	getSessionsWatchPaths(): string[] {
-		// OpenClaw dumps per-agent sessions under
-		// `~/.openclaw/agents/<id>/sessions/`. The root dir holds the
-		// `sessions.json` index plus per-session `.jsonl` files; one
-		// recursive watcher catches both.
-		return [sessionsDir()];
+		const paths = listAgentDirs()
+			.map((dir) => join(dir, "sessions"))
+			.filter((path) => existsSync(path));
+		return paths.length > 0 ? paths : [sessionsDir()];
 	}
 
 	async removeLocalSkill(key: string): Promise<void> {

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -3,7 +3,9 @@ import chalk from "chalk";
 import type { RawSession } from "../adapters/base";
 import { type AgentType, adapterRegistry } from "../adapters/registry";
 import { ApiClient, ApiError, unwrap } from "../lib/api-client";
+import type { SessionDetail, SessionListItem, SessionMessage } from "../lib/api-schemas";
 import { isLoggedIn } from "../lib/config";
+import { sanitizeMetadata, stripTerminalEscapes } from "../lib/sanitize";
 import {
 	adapterForType,
 	listRegisteredAgentTypes,
@@ -164,6 +166,116 @@ function relativeTime(then: Date): string {
 	if (mon < 12) return `${mon}mo ago`;
 	const yr = Math.floor(mon / 12);
 	return `${yr}y ago`;
+}
+
+interface CloudSessionOpts {
+	agent?: string;
+	since?: string;
+	limit?: string;
+	json?: boolean;
+}
+
+function requireCloudSessionAuth(): boolean {
+	if (isLoggedIn()) return true;
+	console.log(chalk.red("Not logged in. Run `clawdi auth login` first."));
+	process.exitCode = 1;
+	return false;
+}
+
+function cloudSessionLimit(value?: string): number {
+	const limit = value === undefined ? 25 : Number(value);
+	if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
+		throw new Error("--limit must be an integer between 1 and 200.");
+	}
+	return limit;
+}
+
+function cloudSessionSince(value?: string): string | undefined {
+	if (!value) return undefined;
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) throw new Error(`Invalid --since date: ${value}`);
+	return parsed.toISOString();
+}
+
+function printCloudSessionRows(sessions: SessionListItem[], total: number): void {
+	for (const session of sessions) {
+		const summary = sanitizeMetadata(session.summary ?? "(untitled)");
+		const project = session.project_path ? sanitizeMetadata(session.project_path) : "-";
+		const agent = sanitizeMetadata(session.agent_type ?? "unknown");
+		console.log(
+			`  ${chalk.dim(session.id)}  ${chalk.white(summary)}  ${chalk.gray(project)}  ${chalk.gray(agent)}  ${chalk.gray(relativeTime(new Date(session.last_activity_at)))}`,
+		);
+	}
+	console.log(
+		chalk.gray(`\n  ${sessions.length} of ${total} metadata match${total === 1 ? "" : "es"}`),
+	);
+}
+
+export async function sessionSearch(query: string, opts: CloudSessionOpts = {}): Promise<void> {
+	if (!requireCloudSessionAuth()) return;
+	const trimmedQuery = query.trim();
+	if (!trimmedQuery) throw new Error("Session metadata search query cannot be empty.");
+
+	const api = new ApiClient();
+	const page = unwrap(
+		await api.GET("/v1/sessions", {
+			params: {
+				query: {
+					q: trimmedQuery,
+					agent: opts.agent || undefined,
+					since: cloudSessionSince(opts.since),
+					page_size: cloudSessionLimit(opts.limit),
+					sort: "relevance",
+					order: "desc",
+				},
+			},
+		}),
+	);
+
+	if (opts.json || !process.stdout.isTTY) {
+		console.log(JSON.stringify(page.items, null, 2));
+		return;
+	}
+	if (page.items.length === 0) {
+		console.log(chalk.gray(`No uploaded session metadata matching "${sanitizeMetadata(query)}".`));
+		return;
+	}
+	printCloudSessionRows(page.items, page.total);
+}
+
+export async function sessionRead(sessionId: string, opts: { json?: boolean } = {}): Promise<void> {
+	if (!requireCloudSessionAuth()) return;
+	const api = new ApiClient();
+	const detail: SessionDetail = unwrap(
+		await api.GET("/v1/sessions/{session_id}", {
+			params: { path: { session_id: sessionId } },
+		}),
+	);
+	const messages: SessionMessage[] = detail.has_content
+		? unwrap(
+				await api.GET("/v1/sessions/{session_id}/content", {
+					params: { path: { session_id: sessionId } },
+				}),
+			)
+		: [];
+
+	if (opts.json || !process.stdout.isTTY) {
+		console.log(JSON.stringify({ session: detail, messages }, null, 2));
+		return;
+	}
+
+	console.log(chalk.bold(sanitizeMetadata(detail.summary ?? detail.local_session_id)));
+	console.log(
+		chalk.gray(
+			`${sanitizeMetadata(detail.agent_type ?? "unknown")} | ${sanitizeMetadata(detail.project_path ?? "no project")} | ${messages.length} messages`,
+		),
+	);
+	console.log();
+	for (const message of messages) {
+		const role = message.role === "user" ? chalk.cyan("user") : chalk.green("assistant");
+		console.log(`${role}: ${stripTerminalEscapes(message.content)}`);
+		console.log();
+	}
 }
 
 interface SessionExtractOpts {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1091,7 +1091,9 @@ skillCmd
 // ─────────────────────────────────────────────────────────────
 // session
 // ─────────────────────────────────────────────────────────────
-const sessionCmd = program.command("session").description("Inspect local agent sessions");
+const sessionCmd = program
+	.command("session")
+	.description("Inspect local and uploaded agent sessions");
 
 sessionCmd
 	.command("list")
@@ -1114,6 +1116,32 @@ Examples:
 	.action(async (opts) => {
 		const { sessionList } = await import("./commands/session.js");
 		await sessionList(opts);
+	});
+
+sessionCmd
+	.command("search <query>")
+	.description("Search uploaded session metadata (summary, project, and IDs; not message text)")
+	.option("--agent <type>", "Filter by agent type")
+	.option("--since <date>", "Only sessions active after this date")
+	.option("--limit <n>", "Cap results (1-200)", "25")
+	.option("--json", "Output as JSON")
+	.addHelpText(
+		"after",
+		'\nExamples:\n  $ clawdi session search authentication\n  $ clawdi session search "workspace setup" --agent codex --limit 10',
+	)
+	.action(async (query, opts) => {
+		const { sessionSearch } = await import("./commands/session.js");
+		await sessionSearch(query, opts);
+	});
+
+sessionCmd
+	.command("read <session-id>")
+	.description("Read one uploaded session and its message content")
+	.option("--json", "Output metadata and messages as JSON")
+	.addHelpText("after", "\nUse the cloud session UUID printed by `clawdi session search`.")
+	.action(async (sessionId, opts) => {
+		const { sessionRead } = await import("./commands/session.js");
+		await sessionRead(sessionId, opts);
 	});
 
 sessionCmd

--- a/packages/cli/src/lib/api-schemas.ts
+++ b/packages/cli/src/lib/api-schemas.ts
@@ -9,6 +9,8 @@ type Schemas = components["schemas"];
 export type Memory = Schemas["MemoryResponse"];
 export type SkillSummary = Schemas["SkillSummaryResponse"];
 export type SessionListItem = Schemas["SessionListItemResponse"];
+export type SessionDetail = Schemas["SessionDetailResponse"];
+export type SessionMessage = Schemas["SessionMessageResponse"];
 
 // ── Write responses ───────────────────────────────────────────────────────
 // `/v1/vault/resolve` has richer single-reference/debug shapes in OpenAPI.

--- a/packages/cli/src/serve/sessions-watcher.test.ts
+++ b/packages/cli/src/serve/sessions-watcher.test.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { HermesAdapter } from "../adapters/hermes";
@@ -10,6 +10,7 @@ import {
 	SESSION_IDLE_POLL_INTERVAL_MS,
 	SESSION_STABLE_AFTER_MS,
 	sessionPathSignature,
+	sessionPathSnapshot,
 	sleepForSessionPoll,
 	watchSessions,
 } from "./sessions-watcher";
@@ -69,6 +70,77 @@ describe("pollSessionPaths", () => {
 
 		expect(delays).toEqual([SESSION_IDLE_POLL_INTERVAL_MS, SESSION_STABLE_AFTER_MS]);
 		expect(stableAt).toEqual([SESSION_IDLE_POLL_INTERVAL_MS + SESSION_STABLE_AFTER_MS]);
+	});
+
+	test("reports concrete changed files from production-style poll snapshots", async () => {
+		const abort = new AbortController();
+		let now = 0;
+		const sessionPath = "/sessions/changed.jsonl";
+		const changes: Array<{ paths: string[]; requiresFullScan: boolean }> = [];
+
+		await pollSessionPaths(
+			{
+				paths: ["/sessions"],
+				abort: abort.signal,
+				onPathStable: (change) => {
+					changes.push(change);
+					abort.abort();
+				},
+			},
+			{
+				now: () => now,
+				pathSignature: async () => {
+					throw new Error("pathSnapshot should provide the production poll state");
+				},
+				pathSnapshot: async () => ({
+					signature: now === 0 ? "initial" : "changed",
+					entries: new Map([[sessionPath, now === 0 ? "1:10" : "2:20"]]),
+				}),
+				sleep: async (delayMs) => {
+					now += delayMs;
+				},
+			},
+		);
+
+		expect(changes).toEqual([{ paths: [sessionPath], requiresFullScan: false }]);
+	});
+
+	test("bounds tracked entries and requests a full scan when the cap is exceeded", async () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-session-snapshot-cap-"));
+		const abort = new AbortController();
+		let now = 0;
+		let sleepCalls = 0;
+		const changes: Array<{ paths: string[]; requiresFullScan: boolean }> = [];
+		try {
+			writeFileSync(join(root, "first.jsonl"), "first");
+			writeFileSync(join(root, "second.jsonl"), "second");
+			expect((await sessionPathSnapshot(root, 1)).entries).toBeNull();
+
+			await pollSessionPaths(
+				{
+					paths: [root],
+					abort: abort.signal,
+					onPathStable: (change) => {
+						changes.push(change);
+						abort.abort();
+					},
+				},
+				{
+					now: () => now,
+					pathSignature: async () => "unused",
+					pathSnapshot: (path) => sessionPathSnapshot(path, 1),
+					sleep: async (delayMs) => {
+						now += delayMs;
+						sleepCalls += 1;
+						if (sleepCalls === 1) writeFileSync(join(root, "first.jsonl"), "changed");
+					},
+				},
+			);
+
+			expect(changes).toEqual([{ paths: [], requiresFullScan: true }]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	test("uses the injected monotonic clock rather than wall-clock time", async () => {
@@ -301,6 +373,59 @@ test("watchSessions returns immediately for a pre-aborted real fs watch", async 
 	}
 }, 1_000);
 
+test("debounces rapid fs events into one concrete changed-path batch", async () => {
+	class InjectedWatcher extends EventEmitter {
+		close(): void {}
+	}
+
+	const root = mkdtempSync(join(tmpdir(), "clawdi-session-path-batch-"));
+	const abort = new AbortController();
+	let onChange: (eventType?: string, filename?: string | Buffer | null) => void = () => {};
+	let fireStable = () => {};
+	const changes: Array<{ paths: string[]; requiresFullScan: boolean }> = [];
+	try {
+		const running = watchSessions(
+			{
+				paths: [root],
+				abort: abort.signal,
+				onPathStable: (change) => changes.push(change),
+			},
+			{
+				createWatcher: (_path, _options, callback) => {
+					onChange = callback;
+					return new InjectedWatcher();
+				},
+				poll: async () => {},
+				stableTimer: {
+					schedule: (callback) => {
+						fireStable = callback;
+						return () => {};
+					},
+				},
+			},
+		);
+
+		onChange("change", "first.jsonl");
+		onChange("rename", Buffer.from("archived/second.jsonl"));
+		onChange("change", "first.jsonl");
+		fireStable();
+		onChange("rename", null);
+		fireStable();
+
+		expect(changes).toEqual([
+			{
+				paths: [join(root, "first.jsonl"), join(root, "archived/second.jsonl")],
+				requiresFullScan: false,
+			},
+			{ paths: [], requiresFullScan: true },
+		]);
+		abort.abort();
+		await running;
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("falls back once when an attached fs watcher emits an asynchronous error", async () => {
 	class InjectedWatcher extends EventEmitter {
 		closeCalls = 0;
@@ -316,7 +441,7 @@ test("falls back once when an attached fs watcher emits an asynchronous error", 
 	];
 	const abort = new AbortController();
 	const watchers: InjectedWatcher[] = [];
-	let onChange = () => {};
+	let onChange: (eventType?: string, filename?: string | Buffer | null) => void = () => {};
 	let scheduledStableCallback = () => {};
 	let pendingStableTimers = 0;
 	let stableCalls = 0;

--- a/packages/cli/src/serve/sessions-watcher.ts
+++ b/packages/cli/src/serve/sessions-watcher.ts
@@ -9,14 +9,9 @@
  * One watcher per adapter. Adapters return a list of paths via
  * `getSessionsWatchPaths()` — directories (Claude Code / Codex /
  * OpenClaw) or SQLite database/sidecar files (Hermes). Any change
- * resets the adapter-wide quiescence timer; once the timer fires,
- * `onPathStable` runs and the engine re-enumerates sessions to
- * find what changed.
- *
- * Why path-level (not per-session) debounce: the watcher doesn't
- * know which session a given fs event corresponds to; the
- * adapter does. Letting the adapter re-enumerate on a "stable"
- * tick is simpler and avoids leaking session-id parsing here.
+ * resets the adapter-wide quiescence timer. Concrete filenames are
+ * accumulated across the window and handed to the adapter once stable;
+ * ambiguous platform events retain an explicit full-scan fallback.
  *
  * Two modes mirror the skill watcher:
  *
@@ -34,8 +29,13 @@ import { log, toErrorMessage } from "./log";
 export interface SessionWatcherOptions {
 	paths: string[];
 	abort: AbortSignal;
-	onPathStable: () => void;
+	onPathStable: (change: SessionWatchChange) => void;
 	forcePoll?: boolean;
+}
+
+export interface SessionWatchChange {
+	paths: string[];
+	requiresFullScan: boolean;
 }
 
 interface SessionFsWatcher {
@@ -51,7 +51,7 @@ export interface SessionWatcherDependencies {
 	createWatcher: (
 		path: string,
 		options: { persistent: false; recursive: boolean },
-		onChange: () => void,
+		onChange: (eventType?: string, filename?: string | Buffer | null) => void,
 	) => SessionFsWatcher;
 	poll: (opts: SessionWatcherOptions) => Promise<void>;
 	stableTimer: SessionTimerScheduler;
@@ -110,6 +110,8 @@ async function fsWatchLoop(
 	dependencies: SessionWatcherDependencies,
 ): Promise<void> {
 	const watchers: SessionFsWatcher[] = [];
+	const pendingPaths = new Set<string>();
+	let requiresFullScan = false;
 	let cancelStableTimer: (() => void) | null = null;
 	let cleaned = false;
 	let settled = false;
@@ -152,13 +154,21 @@ async function fsWatchLoop(
 	// Re-check after registration to close the race with a pre-aborted caller.
 	if (opts.abort.aborted) onAbort();
 
-	const armStable = () => {
+	const armStable = (path?: string) => {
 		if (settled || opts.abort.aborted) return;
+		if (path) pendingPaths.add(path);
+		else requiresFullScan = true;
 		cancelStableTimer?.();
 		cancelStableTimer = dependencies.stableTimer.schedule(() => {
 			cancelStableTimer = null;
 			if (settled || opts.abort.aborted) return;
-			opts.onPathStable();
+			const change = {
+				paths: [...pendingPaths],
+				requiresFullScan,
+			};
+			pendingPaths.clear();
+			requiresFullScan = false;
+			opts.onPathStable(change);
 		}, SESSION_STABLE_AFTER_MS);
 	};
 
@@ -177,8 +187,14 @@ async function fsWatchLoop(
 				const watcher = dependencies.createWatcher(
 					p,
 					{ persistent: false, recursive: isDir },
-					() => {
-						if (!opts.abort.aborted) armStable();
+					(_eventType, filename) => {
+						if (opts.abort.aborted) return;
+						if (!isDir) {
+							armStable(p);
+							return;
+						}
+						const relativePath = typeof filename === "string" ? filename : filename?.toString();
+						armStable(relativePath ? join(p, relativePath) : undefined);
 					},
 				);
 				watchers.push(watcher);
@@ -229,12 +245,19 @@ async function fsWatchLoop(
 export interface SessionPollDependencies {
 	now: () => number;
 	pathSignature: (path: string) => Promise<string>;
+	pathSnapshot?: (path: string) => Promise<SessionPathSnapshot>;
 	sleep: (ms: number, signal: AbortSignal) => Promise<void>;
+}
+
+export interface SessionPathSnapshot {
+	signature: string;
+	entries: ReadonlyMap<string, string> | null;
 }
 
 const defaultSessionPollDependencies: SessionPollDependencies = {
 	now: () => performance.now(),
 	pathSignature: sessionPathSignature,
+	pathSnapshot: sessionPathSnapshot,
 	sleep: sleepForSessionPoll,
 };
 
@@ -242,12 +265,12 @@ export async function pollSessionPaths(
 	opts: SessionWatcherOptions,
 	dependencies: SessionPollDependencies = defaultSessionPollDependencies,
 ): Promise<void> {
-	const lastSig = new Map<string, string>();
+	const lastSnapshot = new Map<string, SessionPathSnapshot>();
 	for (const p of opts.paths) {
 		if (opts.abort.aborted) return;
-		const signature = await dependencies.pathSignature(p);
+		const snapshot = await readPollSnapshot(p, dependencies);
 		if (opts.abort.aborted) return;
-		lastSig.set(p, signature);
+		lastSnapshot.set(p, snapshot);
 	}
 
 	log.info("sessions_watcher.mode", {
@@ -258,6 +281,8 @@ export async function pollSessionPaths(
 	});
 
 	let stableDeadline: number | null = null;
+	const pendingPaths = new Set<string>();
+	let requiresFullScan = false;
 	while (!opts.abort.aborted) {
 		const now = dependencies.now();
 		const delayMs =
@@ -270,12 +295,18 @@ export async function pollSessionPaths(
 		let anyChanged = false;
 		for (const p of opts.paths) {
 			if (opts.abort.aborted) return;
-			const cur = await dependencies.pathSignature(p);
+			const cur = await readPollSnapshot(p, dependencies);
 			if (opts.abort.aborted) return;
-			const prev = lastSig.get(p) ?? "";
-			if (cur !== prev) {
-				lastSig.set(p, cur);
+			const prev = lastSnapshot.get(p) ?? { signature: "", entries: null };
+			if (cur.signature !== prev.signature) {
+				lastSnapshot.set(p, cur);
 				anyChanged = true;
+				const changedPaths = diffSnapshotEntries(prev.entries, cur.entries);
+				if (changedPaths === null || changedPaths.length === 0) {
+					requiresFullScan = true;
+				} else {
+					for (const changedPath of changedPaths) pendingPaths.add(changedPath);
+				}
 			}
 		}
 		const observedAt = dependencies.now();
@@ -286,9 +317,38 @@ export async function pollSessionPaths(
 		if (stableDeadline !== null && observedAt >= stableDeadline) {
 			stableDeadline = null;
 			if (opts.abort.aborted) return;
-			opts.onPathStable();
+			const change = {
+				paths: [...pendingPaths],
+				requiresFullScan,
+			};
+			pendingPaths.clear();
+			requiresFullScan = false;
+			opts.onPathStable(change);
 		}
 	}
+}
+
+async function readPollSnapshot(
+	path: string,
+	dependencies: SessionPollDependencies,
+): Promise<SessionPathSnapshot> {
+	if (dependencies.pathSnapshot) return dependencies.pathSnapshot(path);
+	return { signature: await dependencies.pathSignature(path), entries: null };
+}
+
+function diffSnapshotEntries(
+	previous: ReadonlyMap<string, string> | null,
+	current: ReadonlyMap<string, string> | null,
+): string[] | null {
+	if (previous === null || current === null) return null;
+	const changed = new Set<string>();
+	for (const [path, signature] of current) {
+		if (previous.get(path) !== signature) changed.add(path);
+	}
+	for (const path of previous.keys()) {
+		if (!current.has(path)) changed.add(path);
+	}
+	return [...changed];
 }
 
 /** Per-path signature that detects appends to existing files
@@ -302,19 +362,12 @@ export async function pollSessionPaths(
  * stable timer. Container-mode (CLAWDI_SERVE_MODE=container)
  * + active conversation = silently no session push.
  *
- * Now: for files we keep `mtime:size`. For directories we walk
- * up to MAX_ENTRIES top-level + child entries and aggregate
- * `mtime:size` per file, folded into a streaming sha256. The
- * fold is bounded in memory (one hash state regardless of dir
- * size) and content-sensitive at every entry — appending to an
- * existing file changes its mtime+size and therefore the hash.
- *
- * Why a fold rather than a parts list with a cap: the previous
- * cap-and-truncate implementation silently collapsed every state
- * past 4096 entries to the same dir-mtime fallback signature,
- * which the parent dir's mtime didn't bump on file APPEND.
- * Active session dirs with hundreds of files would silently stop
- * detecting transcript writes once they crossed the cap.
+ * For files we keep `mtime:size`. For directories we fold every
+ * file's path, mtime, and size into a sha256 and retain a bounded
+ * metadata map so the poller can identify concrete changes. Once
+ * the cap is exceeded, the complete aggregate remains valid but
+ * path tracking becomes `null`, requesting a safe full scan.
+ * No file content is read.
  */
 // Depth budget for the walk's RECURSION into subdirectories.
 // Files at every depth are statted; only further recursion is
@@ -330,18 +383,28 @@ export async function pollSessionPaths(
 // fit comfortably; the budget just needs to be wide enough for
 // the deepest supported adapter.
 const SIG_MAX_DEPTH = 3;
+export const SESSION_PATH_TRACKED_ENTRY_LIMIT = 4_096;
 
 export async function sessionPathSignature(p: string): Promise<string> {
+	return (await sessionPathSnapshot(p)).signature;
+}
+
+export async function sessionPathSnapshot(
+	p: string,
+	maxTrackedEntries = SESSION_PATH_TRACKED_ENTRY_LIMIT,
+): Promise<SessionPathSnapshot> {
 	try {
 		const s = await stat(p);
 		if (!s.isDirectory()) {
-			return `f:${s.mtimeMs}:${s.size}`;
+			const signature = `f:${s.mtimeMs}:${s.size}`;
+			return { signature, entries: new Map([[p, signature]]) };
 		}
 		// Streaming hash: sorted readdir order at each level so the
 		// same on-disk state always produces the same digest. Files
 		// are stat'd individually; directories recurse up to depth.
 		// No content read — just metadata.
 		const h = createHash("sha256");
+		let entriesByPath: Map<string, string> | null = new Map();
 		let counted = 0;
 		const walk = async (dir: string, depth: number): Promise<void> => {
 			let entries: import("node:fs").Dirent[];
@@ -356,7 +419,12 @@ export async function sessionPathSignature(p: string): Promise<string> {
 				if (e.isFile()) {
 					try {
 						const fs = await stat(full);
-						h.update(`${e.name}:${fs.mtimeMs}:${fs.size};`);
+						const signature = `${fs.mtimeMs}:${fs.size}`;
+						h.update(`${full}:${signature};`);
+						if (entriesByPath) {
+							if (entriesByPath.size < maxTrackedEntries) entriesByPath.set(full, signature);
+							else entriesByPath = null;
+						}
 						counted += 1;
 					} catch {
 						/* race: file vanished between readdir and stat */
@@ -372,12 +440,15 @@ export async function sessionPathSignature(p: string): Promise<string> {
 			}
 		};
 		await walk(p, 0);
-		return `d:${counted}:${h.digest("hex")}`;
+		return {
+			signature: `d:${counted}:${h.digest("hex")}`,
+			entries: entriesByPath,
+		};
 	} catch {
 		// Path missing / permission denied — treat as empty
 		// signature so it shows up as "changed" if the path
 		// later appears.
-		return "";
+		return { signature: "", entries: new Map() };
 	}
 }
 

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -125,6 +125,7 @@ describe("Session deletion convergence", () => {
 			};
 			const adapter = adapterRegistry.hermes.create();
 			adapter.collectSessions = async () => ({ sessions: [session], dedupedCount: 0 });
+			adapter.collectSession = async () => session;
 			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
 				const request = input instanceof Request ? input : new Request(input, init);
 				const path = new URL(request.url).pathname;
@@ -205,6 +206,140 @@ describe("Session deletion convergence", () => {
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
+
+	it.each(["exact", "fallback"] as const)(
+		"re-reads newer session content at drain via the %s collector",
+		async (mode) => {
+			const root = mkdtempSync(join(tmpdir(), "session-current-drain-"));
+			const originalHome = process.env.HOME;
+			const originalState = process.env.CLAWDI_STATE_DIR;
+			const originalFetch = globalThis.fetch;
+			let queue: RetryQueue | undefined;
+			try {
+				process.env.HOME = root;
+				process.env.CLAWDI_STATE_DIR = join(root, "serve");
+				const enqueuedSession: RawSession = {
+					localSessionId: `current-session-${mode}`,
+					projectPath: "/project",
+					startedAt: new Date(0),
+					endedAt: new Date(1_000),
+					messageCount: 1,
+					inputTokens: 1,
+					outputTokens: 0,
+					cacheReadTokens: 0,
+					model: null,
+					modelsUsed: [],
+					durationSeconds: 1,
+					summary: "current content",
+					messages: [{ role: "user", content: "before enqueue" }],
+					rawFilePath: `/sessions/current-session-${mode}.jsonl`,
+				};
+				const currentSession: RawSession = {
+					...enqueuedSession,
+					messageCount: 2,
+					messages: [
+						...enqueuedSession.messages,
+						{ role: "assistant", content: "appended after enqueue" },
+					],
+				};
+				const queuedHash = createHash("sha256")
+					.update(JSON.stringify(enqueuedSession.messages))
+					.digest("hex");
+				const currentHash = createHash("sha256")
+					.update(JSON.stringify(currentSession.messages))
+					.digest("hex");
+				const adapter = adapterRegistry.hermes.create();
+				let collectionCalls = 0;
+				adapter.collectSessions = async () => {
+					collectionCalls += 1;
+					return { sessions: [currentSession], dedupedCount: 0 };
+				};
+				let exactCalls = 0;
+				if (mode === "exact") {
+					adapter.collectSession = async () => {
+						exactCalls += 1;
+						return currentSession;
+					};
+				} else {
+					Object.defineProperty(adapter, "collectSession", { value: undefined });
+				}
+				let sentMetadata: Record<string, unknown> | undefined;
+				let sentMessages: unknown;
+				globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+					const request = input instanceof Request ? input : new Request(input, init);
+					const path = new URL(request.url).pathname;
+					if (path === "/v1/sessions/batch") {
+						const body = (await request.json()) as { sessions: Array<Record<string, unknown>> };
+						sentMetadata = body.sessions[0];
+						return new Response(
+							JSON.stringify({
+								created: 0,
+								updated: 1,
+								unchanged: 0,
+								needs_content: [currentSession.localSessionId],
+								rejected: [],
+								suppressed: [],
+							}),
+							{ headers: { "content-type": "application/json" } },
+						);
+					}
+					if (path === `/v1/sessions/${currentSession.localSessionId}/upload`) {
+						const file = (await request.formData()).get("file");
+						if (!(file instanceof Blob)) return new Response("missing file", { status: 400 });
+						sentMessages = JSON.parse(await file.text());
+						return new Response(JSON.stringify({ uploaded: true }), {
+							headers: { "content-type": "application/json" },
+						});
+					}
+					return new Response("unexpected request", { status: 404 });
+				}) as typeof fetch;
+
+				queue = new RetryQueue({ agentType: "hermes" });
+				queue.enqueue({
+					kind: "session_push",
+					local_session_id: enqueuedSession.localSessionId,
+					content_hash: queuedHash,
+					enqueued_at: new Date().toISOString(),
+					attempts: 0,
+				});
+				const item = queue.peek();
+				if (!item) throw new Error("expected queued session");
+				const abortController = new AbortController();
+				const outcome = await processQueueItem(
+					{
+						environmentId: "agent-1",
+						adapter,
+						abort: abortController.signal,
+						abortController,
+					},
+					new ApiClient({ requireAuth: false }),
+					queue,
+					item,
+					new Map(),
+					new Map(),
+					new Map([[enqueuedSession.localSessionId, queuedHash]]),
+					"project-1",
+				);
+
+				expect(outcome).toBe("applied");
+				expect(exactCalls).toBe(mode === "exact" ? 1 : 0);
+				expect(collectionCalls).toBe(mode === "fallback" ? 1 : 0);
+				expect(sentMetadata).toMatchObject({
+					content_hash: currentHash,
+					message_count: 2,
+				});
+				expect(sentMessages).toEqual(currentSession.messages);
+			} finally {
+				await queue?.flushPersist();
+				globalThis.fetch = originalFetch;
+				if (originalHome === undefined) delete process.env.HOME;
+				else process.env.HOME = originalHome;
+				if (originalState === undefined) delete process.env.CLAWDI_STATE_DIR;
+				else process.env.CLAWDI_STATE_DIR = originalState;
+				rmSync(root, { recursive: true, force: true });
+			}
+		},
+	);
 });
 
 describe("Agent filesystem projection reconcile", () => {
@@ -1043,12 +1178,13 @@ describe("isAuthFailure", () => {
 		expect(isAuthFailure(e)).toBe(true);
 	});
 
-	it.each([
-		400, 404, 408, 429, 500, 502, 503,
-	])("does not treat ApiError(%i) as auth failure", (status) => {
-		const e = new ApiError({ status, body: "", hint: "" });
-		expect(isAuthFailure(e)).toBe(false);
-	});
+	it.each([400, 404, 408, 429, 500, 502, 503])(
+		"does not treat ApiError(%i) as auth failure",
+		(status) => {
+			const e = new ApiError({ status, body: "", hint: "" });
+			expect(isAuthFailure(e)).toBe(false);
+		},
+	);
 
 	it("does not treat plain Error as auth failure", () => {
 		expect(isAuthFailure(new Error("boom"))).toBe(false);

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -207,139 +207,139 @@ describe("Session deletion convergence", () => {
 		}
 	});
 
-	it.each(["exact", "fallback"] as const)(
-		"re-reads newer session content at drain via the %s collector",
-		async (mode) => {
-			const root = mkdtempSync(join(tmpdir(), "session-current-drain-"));
-			const originalHome = process.env.HOME;
-			const originalState = process.env.CLAWDI_STATE_DIR;
-			const originalFetch = globalThis.fetch;
-			let queue: RetryQueue | undefined;
-			try {
-				process.env.HOME = root;
-				process.env.CLAWDI_STATE_DIR = join(root, "serve");
-				const enqueuedSession: RawSession = {
-					localSessionId: `current-session-${mode}`,
-					projectPath: "/project",
-					startedAt: new Date(0),
-					endedAt: new Date(1_000),
-					messageCount: 1,
-					inputTokens: 1,
-					outputTokens: 0,
-					cacheReadTokens: 0,
-					model: null,
-					modelsUsed: [],
-					durationSeconds: 1,
-					summary: "current content",
-					messages: [{ role: "user", content: "before enqueue" }],
-					rawFilePath: `/sessions/current-session-${mode}.jsonl`,
+	it.each([
+		"exact",
+		"fallback",
+	] as const)("re-reads newer session content at drain via the %s collector", async (mode) => {
+		const root = mkdtempSync(join(tmpdir(), "session-current-drain-"));
+		const originalHome = process.env.HOME;
+		const originalState = process.env.CLAWDI_STATE_DIR;
+		const originalFetch = globalThis.fetch;
+		let queue: RetryQueue | undefined;
+		try {
+			process.env.HOME = root;
+			process.env.CLAWDI_STATE_DIR = join(root, "serve");
+			const enqueuedSession: RawSession = {
+				localSessionId: `current-session-${mode}`,
+				projectPath: "/project",
+				startedAt: new Date(0),
+				endedAt: new Date(1_000),
+				messageCount: 1,
+				inputTokens: 1,
+				outputTokens: 0,
+				cacheReadTokens: 0,
+				model: null,
+				modelsUsed: [],
+				durationSeconds: 1,
+				summary: "current content",
+				messages: [{ role: "user", content: "before enqueue" }],
+				rawFilePath: `/sessions/current-session-${mode}.jsonl`,
+			};
+			const currentSession: RawSession = {
+				...enqueuedSession,
+				messageCount: 2,
+				messages: [
+					...enqueuedSession.messages,
+					{ role: "assistant", content: "appended after enqueue" },
+				],
+			};
+			const queuedHash = createHash("sha256")
+				.update(JSON.stringify(enqueuedSession.messages))
+				.digest("hex");
+			const currentHash = createHash("sha256")
+				.update(JSON.stringify(currentSession.messages))
+				.digest("hex");
+			const adapter = adapterRegistry.hermes.create();
+			let collectionCalls = 0;
+			adapter.collectSessions = async () => {
+				collectionCalls += 1;
+				return { sessions: [currentSession], dedupedCount: 0 };
+			};
+			let exactCalls = 0;
+			if (mode === "exact") {
+				adapter.collectSession = async () => {
+					exactCalls += 1;
+					return currentSession;
 				};
-				const currentSession: RawSession = {
-					...enqueuedSession,
-					messageCount: 2,
-					messages: [
-						...enqueuedSession.messages,
-						{ role: "assistant", content: "appended after enqueue" },
-					],
-				};
-				const queuedHash = createHash("sha256")
-					.update(JSON.stringify(enqueuedSession.messages))
-					.digest("hex");
-				const currentHash = createHash("sha256")
-					.update(JSON.stringify(currentSession.messages))
-					.digest("hex");
-				const adapter = adapterRegistry.hermes.create();
-				let collectionCalls = 0;
-				adapter.collectSessions = async () => {
-					collectionCalls += 1;
-					return { sessions: [currentSession], dedupedCount: 0 };
-				};
-				let exactCalls = 0;
-				if (mode === "exact") {
-					adapter.collectSession = async () => {
-						exactCalls += 1;
-						return currentSession;
-					};
-				} else {
-					Object.defineProperty(adapter, "collectSession", { value: undefined });
-				}
-				let sentMetadata: Record<string, unknown> | undefined;
-				let sentMessages: unknown;
-				globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-					const request = input instanceof Request ? input : new Request(input, init);
-					const path = new URL(request.url).pathname;
-					if (path === "/v1/sessions/batch") {
-						const body = (await request.json()) as { sessions: Array<Record<string, unknown>> };
-						sentMetadata = body.sessions[0];
-						return new Response(
-							JSON.stringify({
-								created: 0,
-								updated: 1,
-								unchanged: 0,
-								needs_content: [currentSession.localSessionId],
-								rejected: [],
-								suppressed: [],
-							}),
-							{ headers: { "content-type": "application/json" } },
-						);
-					}
-					if (path === `/v1/sessions/${currentSession.localSessionId}/upload`) {
-						const file = (await request.formData()).get("file");
-						if (!(file instanceof Blob)) return new Response("missing file", { status: 400 });
-						sentMessages = JSON.parse(await file.text());
-						return new Response(JSON.stringify({ uploaded: true }), {
-							headers: { "content-type": "application/json" },
-						});
-					}
-					return new Response("unexpected request", { status: 404 });
-				}) as typeof fetch;
-
-				queue = new RetryQueue({ agentType: "hermes" });
-				queue.enqueue({
-					kind: "session_push",
-					local_session_id: enqueuedSession.localSessionId,
-					content_hash: queuedHash,
-					enqueued_at: new Date().toISOString(),
-					attempts: 0,
-				});
-				const item = queue.peek();
-				if (!item) throw new Error("expected queued session");
-				const abortController = new AbortController();
-				const outcome = await processQueueItem(
-					{
-						environmentId: "agent-1",
-						adapter,
-						abort: abortController.signal,
-						abortController,
-					},
-					new ApiClient({ requireAuth: false }),
-					queue,
-					item,
-					new Map(),
-					new Map(),
-					new Map([[enqueuedSession.localSessionId, queuedHash]]),
-					"project-1",
-				);
-
-				expect(outcome).toBe("applied");
-				expect(exactCalls).toBe(mode === "exact" ? 1 : 0);
-				expect(collectionCalls).toBe(mode === "fallback" ? 1 : 0);
-				expect(sentMetadata).toMatchObject({
-					content_hash: currentHash,
-					message_count: 2,
-				});
-				expect(sentMessages).toEqual(currentSession.messages);
-			} finally {
-				await queue?.flushPersist();
-				globalThis.fetch = originalFetch;
-				if (originalHome === undefined) delete process.env.HOME;
-				else process.env.HOME = originalHome;
-				if (originalState === undefined) delete process.env.CLAWDI_STATE_DIR;
-				else process.env.CLAWDI_STATE_DIR = originalState;
-				rmSync(root, { recursive: true, force: true });
+			} else {
+				Object.defineProperty(adapter, "collectSession", { value: undefined });
 			}
-		},
-	);
+			let sentMetadata: Record<string, unknown> | undefined;
+			let sentMessages: unknown;
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const request = input instanceof Request ? input : new Request(input, init);
+				const path = new URL(request.url).pathname;
+				if (path === "/v1/sessions/batch") {
+					const body = (await request.json()) as { sessions: Array<Record<string, unknown>> };
+					sentMetadata = body.sessions[0];
+					return new Response(
+						JSON.stringify({
+							created: 0,
+							updated: 1,
+							unchanged: 0,
+							needs_content: [currentSession.localSessionId],
+							rejected: [],
+							suppressed: [],
+						}),
+						{ headers: { "content-type": "application/json" } },
+					);
+				}
+				if (path === `/v1/sessions/${currentSession.localSessionId}/upload`) {
+					const file = (await request.formData()).get("file");
+					if (!(file instanceof Blob)) return new Response("missing file", { status: 400 });
+					sentMessages = JSON.parse(await file.text());
+					return new Response(JSON.stringify({ uploaded: true }), {
+						headers: { "content-type": "application/json" },
+					});
+				}
+				return new Response("unexpected request", { status: 404 });
+			}) as typeof fetch;
+
+			queue = new RetryQueue({ agentType: "hermes" });
+			queue.enqueue({
+				kind: "session_push",
+				local_session_id: enqueuedSession.localSessionId,
+				content_hash: queuedHash,
+				enqueued_at: new Date().toISOString(),
+				attempts: 0,
+			});
+			const item = queue.peek();
+			if (!item) throw new Error("expected queued session");
+			const abortController = new AbortController();
+			const outcome = await processQueueItem(
+				{
+					environmentId: "agent-1",
+					adapter,
+					abort: abortController.signal,
+					abortController,
+				},
+				new ApiClient({ requireAuth: false }),
+				queue,
+				item,
+				new Map(),
+				new Map(),
+				new Map([[enqueuedSession.localSessionId, queuedHash]]),
+				"project-1",
+			);
+
+			expect(outcome).toBe("applied");
+			expect(exactCalls).toBe(mode === "exact" ? 1 : 0);
+			expect(collectionCalls).toBe(mode === "fallback" ? 1 : 0);
+			expect(sentMetadata).toMatchObject({
+				content_hash: currentHash,
+				message_count: 2,
+			});
+			expect(sentMessages).toEqual(currentSession.messages);
+		} finally {
+			await queue?.flushPersist();
+			globalThis.fetch = originalFetch;
+			if (originalHome === undefined) delete process.env.HOME;
+			else process.env.HOME = originalHome;
+			if (originalState === undefined) delete process.env.CLAWDI_STATE_DIR;
+			else process.env.CLAWDI_STATE_DIR = originalState;
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
 });
 
 describe("Agent filesystem projection reconcile", () => {
@@ -1178,13 +1178,12 @@ describe("isAuthFailure", () => {
 		expect(isAuthFailure(e)).toBe(true);
 	});
 
-	it.each([400, 404, 408, 429, 500, 502, 503])(
-		"does not treat ApiError(%i) as auth failure",
-		(status) => {
-			const e = new ApiError({ status, body: "", hint: "" });
-			expect(isAuthFailure(e)).toBe(false);
-		},
-	);
+	it.each([
+		400, 404, 408, 429, 500, 502, 503,
+	])("does not treat ApiError(%i) as auth failure", (status) => {
+		const e = new ApiError({ status, body: "", hint: "" });
+		expect(isAuthFailure(e)).toBe(false);
+	});
 
 	it("does not treat plain Error as auth failure", () => {
 		expect(isAuthFailure(new Error("boom"))).toBe(false);

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -39,7 +39,7 @@ import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { components } from "@clawdi/shared/api";
-import type { AgentAdapter, CollectSessionsResult } from "../adapters/base";
+import type { AgentAdapter, CollectSessionsResult, RawSession } from "../adapters/base";
 import { AgentSkillSyncNotFoundError, ApiClient, ApiError, unwrap } from "../lib/api-client";
 import { computeLastActivityIso } from "../lib/session-activity";
 import { cacheKey, readSessionsLock, writeSessionsLock } from "../lib/sessions-lock";
@@ -63,7 +63,7 @@ import { log, toErrorMessage } from "./log";
 import { getServeStateDir } from "./paths";
 import { reconcileConnectedProjectSkills } from "./project-skill-reconcile";
 import { type QueueItem, RetryQueue } from "./queue";
-import { watchSessions } from "./sessions-watcher";
+import { type SessionWatchChange, watchSessions } from "./sessions-watcher";
 import {
 	consumeSse,
 	type ServerEvent,
@@ -249,6 +249,10 @@ interface StableSessionEnqueueOptions {
 	onPresentSessions?: (resources: ReadonlySet<string>) => void;
 }
 
+function sessionContentHash(session: RawSession): string {
+	return createHash("sha256").update(JSON.stringify(session.messages)).digest("hex");
+}
+
 export async function enqueueChangedSessionsAfterStability(
 	opts: StableSessionEnqueueOptions,
 ): Promise<number> {
@@ -259,7 +263,7 @@ export async function enqueueChangedSessionsAfterStability(
 	let enqueued = 0;
 	for (const session of sessions) {
 		if (opts.abort.aborted) return enqueued;
-		const hash = createHash("sha256").update(JSON.stringify(session.messages)).digest("hex");
+		const hash = sessionContentHash(session);
 		if (opts.lastPushedHash.get(session.localSessionId) === hash) continue;
 		if (opts.inFlightHash.get(session.localSessionId) === hash) continue;
 		if (opts.abort.aborted) return enqueued;
@@ -778,23 +782,37 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 		}
 	};
 
-	// Triggered by the sessions watcher after a path has been
-	// quiet for the session watcher's stable window. Re-enumerates the adapter's
-	// sessions, hashes each, and enqueues a `session_push` for any
-	// whose content_hash has changed since we last pushed. The
-	// watcher itself doesn't know which session changed; this
-	// function is the source-of-truth diff against the in-memory
-	// + persisted lock.
-	const onSessionsStable = async () => {
+	// Prefer an adapter's bounded path collector for concrete watcher events.
+	// Ambiguous events and the periodic safety scan retain the complete scan.
+	const onSessionsStable = async (change?: SessionWatchChange) => {
 		if (opts.abort.aborted) return;
 		try {
+			let completeInventory = true;
+			const collectSessions = async (): Promise<CollectSessionsResult> => {
+				if (
+					change &&
+					!change.requiresFullScan &&
+					change.paths.length > 0 &&
+					opts.adapter.collectSessionsForPaths
+				) {
+					const targeted = await opts.adapter.collectSessionsForPaths(change.paths);
+					if (targeted !== null) {
+						completeInventory = false;
+						return targeted;
+					}
+				}
+				const complete = await opts.adapter.collectSessions();
+				return complete;
+			};
 			const enqueued = await enqueueChangedSessionsAfterStability({
 				abort: opts.abort,
-				collectSessions: () => opts.adapter.collectSessions(),
+				collectSessions,
 				queue,
 				lastPushedHash: lastPushedSessionHash,
 				inFlightHash: inFlightSessionHash,
-				onPresentSessions: (resources) => syncHealth.clearAbsent("push", "session:", resources),
+				onPresentSessions: (resources) => {
+					if (completeInventory) syncHealth.clearAbsent("push", "session:", resources);
+				},
 			});
 			if (opts.abort.aborted) return;
 			syncHealth.clear("push", "session_scan");
@@ -842,13 +860,13 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 		watchSessions({
 			paths: opts.adapter.getSessionsWatchPaths(),
 			abort: opts.abort,
-			onPathStable: () => {
+			onPathStable: (change) => {
 				if (opts.abort.aborted) return;
 				// Fire-and-forget — onPathStable is a sync callback
 				// from the watcher, but the enumeration can be slow
 				// (hundreds of JSONLs). Catch errors here so a
 				// transient FS error never breaks the watcher loop.
-				void onSessionsStable();
+				void onSessionsStable(change);
 			},
 			forcePoll: opts.forcePollWatcher,
 		}),
@@ -1540,6 +1558,15 @@ export async function processQueueItem(
 	return "not_applied";
 }
 
+async function resolveQueuedSession(
+	adapter: AgentAdapter,
+	localSessionId: string,
+): Promise<RawSession | null> {
+	if (adapter.collectSession) return adapter.collectSession(localSessionId);
+	const { sessions } = await adapter.collectSessions();
+	return sessions.find((session) => session.localSessionId === localSessionId) ?? null;
+}
+
 /** Upload a single session via the same two-step `clawdi push`
  * uses: POST /api/sessions/batch (metadata) → POST
  * /api/sessions/{id}/upload (content) when the server says it
@@ -1558,12 +1585,7 @@ async function uploadSessionFromQueue(
 ): Promise<
 	{ outcome: "applied"; actualHash: string } | { outcome: "absent" } | { outcome: "not_applied" }
 > {
-	// Re-enumerate via the adapter so we always upload current
-	// content. Filter to the single local_session_id we were asked
-	// to push; if the user deleted the session between enqueue and
-	// drain, we just no-op.
-	const { sessions } = await opts.adapter.collectSessions();
-	const session = sessions.find((s) => s.localSessionId === item.local_session_id);
+	const session = await resolveQueuedSession(opts.adapter, item.local_session_id);
 	if (!session) {
 		log.info("engine.session_gone", { local_session_id: item.local_session_id });
 		return { outcome: "absent" };
@@ -1585,7 +1607,7 @@ async function uploadSessionFromQueue(
 	// short-circuits on the cached hash and never re-uploads. The
 	// skill_push path already follows this pattern (recompute at
 	// upload time); align session_push.
-	const actualHash = createHash("sha256").update(JSON.stringify(session.messages)).digest("hex");
+	const actualHash = sessionContentHash(session);
 
 	const result = unwrap(
 		await api.POST("/v1/sessions/batch", {

--- a/packages/cli/tests/adapters/claude-code.test.ts
+++ b/packages/cli/tests/adapters/claude-code.test.ts
@@ -124,6 +124,25 @@ describe("ClaudeCodeAdapter.collectSessions", () => {
 		const s = (await a.collectSessions()).sessions[0]!;
 		expect(s.summary).toBe("hello");
 	});
+
+	it("limits concrete path collection to the affected project", async () => {
+		writeResumeSessionFile({
+			cwd: "/Users/fixture/other-project",
+			sessionId: "other-project-session",
+			uuids: uuidRange("other", 4),
+		});
+		const changedPath = join(
+			tmpHome,
+			".claude",
+			"projects",
+			"-Users-fixture-project",
+			"11111111-2222-3333-4444-555555555555.jsonl",
+		);
+		const result = await new ClaudeCodeAdapter().collectSessionsForPaths([changedPath]);
+		expect(result?.sessions.map((session) => session.localSessionId)).toEqual([
+			"11111111-2222-3333-4444-555555555555",
+		]);
+	});
 });
 
 /**
@@ -186,6 +205,23 @@ function uuidRange(prefix: string, n: number): string[] {
 }
 
 describe("ClaudeCodeAdapter dedupeResumeChains", () => {
+	it("suppresses a queued predecessor when a successor appears before exact reread", async () => {
+		const cwd = "/Users/fixture/resume-before-drain";
+		const predecessorUuids = uuidRange("queued", 12);
+		writeResumeSessionFile({ cwd, sessionId: "queued-predecessor", uuids: predecessorUuids });
+		const adapter = new ClaudeCodeAdapter();
+		expect(await adapter.collectSession("queued-predecessor")).not.toBeNull();
+
+		writeResumeSessionFile({
+			cwd,
+			sessionId: "new-successor",
+			uuids: [...predecessorUuids, ...uuidRange("new", 4)],
+		});
+
+		expect(await adapter.collectSession("queued-predecessor")).toBeNull();
+		expect((await adapter.collectSession("new-successor"))?.localSessionId).toBe("new-successor");
+	});
+
 	it("dedupes A when A.uuids ⊂ B.uuids in the same project (resume chain)", async () => {
 		const cwd = "/Users/fixture/resume-test";
 		const aUuids = uuidRange("u", 12);

--- a/packages/cli/tests/adapters/codex.test.ts
+++ b/packages/cli/tests/adapters/codex.test.ts
@@ -1,12 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import {
-	existsSync,
-	mkdirSync,
-	readFileSync,
-	renameSync,
-	rmSync,
-	writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { CodexAdapter } from "../../src/adapters/codex";
 import { tarSkillDir } from "../../src/lib/tar";

--- a/packages/cli/tests/adapters/codex.test.ts
+++ b/packages/cli/tests/adapters/codex.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { CodexAdapter } from "../../src/adapters/codex";
 import { tarSkillDir } from "../../src/lib/tar";
@@ -127,6 +134,23 @@ describe("CodexAdapter.collectSessions", () => {
 				(session) => session.localSessionId,
 			),
 		).toEqual(["019ae46c-52d9-7e51-9527-1b105eb42d2c"]);
+	});
+
+	it("finds a learned active session after Codex archives it", async () => {
+		const sessionId = "019ae46c-52d9-7e51-9527-1b105eb42d1b";
+		const archivedPath = join(tmpHome, ".codex", "archived_sessions", "rollout-archived.jsonl");
+		mkdirSync(join(tmpHome, ".codex", "archived_sessions"), { recursive: true });
+
+		const adapter = new CodexAdapter();
+		const learned = (await adapter.collectSessions()).sessions[0];
+		if (!learned) throw new Error("expected Codex session fixture");
+		expect(learned.localSessionId).toBe(sessionId);
+		renameSync(learned.rawFilePath, archivedPath);
+
+		expect(await adapter.collectSession(sessionId)).toMatchObject({
+			localSessionId: sessionId,
+			rawFilePath: archivedPath,
+		});
 	});
 });
 

--- a/packages/cli/tests/adapters/codex.test.ts
+++ b/packages/cli/tests/adapters/codex.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { CodexAdapter } from "../../src/adapters/codex";
 import { tarSkillDir } from "../../src/lib/tar";
@@ -40,6 +40,12 @@ describe("CodexAdapter.detect", () => {
 });
 
 describe("CodexAdapter.collectSessions", () => {
+	it("keeps fs watching on active sessions when archived_sessions is absent", () => {
+		const adapter = new CodexAdapter();
+		expect(existsSync(join(tmpHome, ".codex", "archived_sessions"))).toBe(false);
+		expect(adapter.getSessionsWatchPaths()).toEqual([join(tmpHome, ".codex", "sessions")]);
+	});
+
 	it("parses the fixture session with session_meta + turn_context + messages + token_count", async () => {
 		const a = new CodexAdapter();
 		const { sessions } = await a.collectSessions();
@@ -85,6 +91,42 @@ describe("CodexAdapter.collectSessions", () => {
 		const s = (await a.collectSessions()).sessions[0]!;
 		// First non-environment_context user message is "hello"
 		expect(s.summary).toBe("hello");
+	});
+
+	it("discovers archived sessions and parses only concrete changed transcripts", async () => {
+		const activePath = join(
+			tmpHome,
+			".codex",
+			"sessions",
+			"2026",
+			"04",
+			"20",
+			"rollout-2026-04-20T10-00-00-019ae46c-52d9-7e51-9527-1b105eb42d1b.jsonl",
+		);
+		const archivedRoot = join(tmpHome, ".codex", "archived_sessions");
+		const archivedPath = join(archivedRoot, "rollout-archived.jsonl");
+		mkdirSync(archivedRoot, { recursive: true });
+		writeFileSync(
+			archivedPath,
+			readFileSync(activePath, "utf-8").replaceAll(
+				"019ae46c-52d9-7e51-9527-1b105eb42d1b",
+				"019ae46c-52d9-7e51-9527-1b105eb42d2c",
+			),
+		);
+
+		const adapter = new CodexAdapter();
+		expect(
+			(await adapter.collectSessions()).sessions.map((session) => session.localSessionId),
+		).toEqual(["019ae46c-52d9-7e51-9527-1b105eb42d1b", "019ae46c-52d9-7e51-9527-1b105eb42d2c"]);
+		expect(adapter.getSessionsWatchPaths()).toEqual([
+			join(tmpHome, ".codex", "sessions"),
+			archivedRoot,
+		]);
+		expect(
+			(await adapter.collectSessionsForPaths([archivedPath]))?.sessions.map(
+				(session) => session.localSessionId,
+			),
+		).toEqual(["019ae46c-52d9-7e51-9527-1b105eb42d2c"]);
 	});
 });
 

--- a/packages/cli/tests/adapters/hermes.test.ts
+++ b/packages/cli/tests/adapters/hermes.test.ts
@@ -63,6 +63,8 @@ describe("HermesAdapter.collectSessions", () => {
 		expect(plain?.messages[0]?.content).toBe("hello");
 		expect(plain?.messages[1]?.role).toBe("assistant");
 		expect(plain?.messages[1]?.model).toBe("claude-opus-4-7");
+		expect((await a.collectSession("s-plain"))?.messages).toEqual(plain?.messages);
+		expect(await a.collectSession("missing-session")).toBeNull();
 	});
 
 	it("parses a JSON-blob model field via parseModelField", async () => {

--- a/packages/cli/tests/adapters/openclaw.test.ts
+++ b/packages/cli/tests/adapters/openclaw.test.ts
@@ -195,6 +195,27 @@ describe("OpenClawAdapter.collectSessions", () => {
 		expect(ids).toEqual(["oc-financial-001", "oc-session-001"]);
 	});
 
+	it("watches every personality and narrows concrete transcript changes", async () => {
+		addFinancialAgent(join(tmpHome, ".openclaw"));
+		const adapter = new OpenClawAdapter();
+		const mainSessions = join(tmpHome, ".openclaw", "agents", "main", "sessions");
+		const financialSessions = join(tmpHome, ".openclaw", "agents", "financial", "sessions");
+		expect(adapter.getSessionsWatchPaths().sort()).toEqual(
+			[mainSessions, financialSessions].sort(),
+		);
+		expect(
+			(
+				await adapter.collectSessionsForPaths([join(financialSessions, "oc-financial-001.jsonl")])
+			)?.sessions.map((session) => session.localSessionId),
+		).toEqual(["oc-financial-001"]);
+		expect(
+			await adapter.collectSessionsForPaths([
+				join(financialSessions, "sessions.json"),
+				join(financialSessions, "oc-financial-001.jsonl"),
+			]),
+		).toBeNull();
+	});
+
 	it("handles production schema: composite index keys + absolute sessionFile", async () => {
 		// Mirror what real openclaw writes: index keyed by `agent:main:…`
 		// composite strings, with the UUID in `entry.sessionId` and an

--- a/packages/cli/tests/commands/session.test.ts
+++ b/packages/cli/tests/commands/session.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sessionRead, sessionSearch } from "../../src/commands/session";
+import { jsonResponse, mockFetch, seedAuthAndEnv } from "./helpers";
+
+let tmpHome: string;
+let originalHome: string | undefined;
+let originalApiUrl: string | undefined;
+
+beforeEach(() => {
+	originalHome = process.env.HOME;
+	originalApiUrl = process.env.CLAWDI_API_URL;
+	tmpHome = mkdtempSync(join(tmpdir(), "clawdi-session-command-"));
+	process.env.HOME = tmpHome;
+	process.env.CLAWDI_API_URL = "http://localhost:8000";
+	seedAuthAndEnv(tmpHome, "codex");
+});
+
+afterEach(() => {
+	if (originalHome === undefined) delete process.env.HOME;
+	else process.env.HOME = originalHome;
+	if (originalApiUrl === undefined) delete process.env.CLAWDI_API_URL;
+	else process.env.CLAWDI_API_URL = originalApiUrl;
+	rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("cloud session commands", () => {
+	it("searches only through the existing session metadata query contract", async () => {
+		const { captured, restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/sessions",
+				response: () => jsonResponse({ items: [], total: 0, page: 1, page_size: 7 }),
+			},
+		]);
+		const originalLog = console.log;
+		console.log = () => {};
+		try {
+			await sessionSearch("workspace setup", { agent: "codex", limit: "7", json: true });
+		} finally {
+			console.log = originalLog;
+			restore();
+		}
+
+		expect(captured).toHaveLength(1);
+		const url = new URL(captured[0].url);
+		expect(url.pathname).toBe("/v1/sessions");
+		expect(Object.fromEntries(url.searchParams)).toMatchObject({
+			q: "workspace setup",
+			agent: "codex",
+			page_size: "7",
+			sort: "relevance",
+		});
+	});
+
+	it("reads metadata and message content by cloud session id", async () => {
+		const sessionId = "00000000-0000-0000-0000-000000000123";
+		const { captured, restore } = mockFetch([
+			{
+				method: "GET",
+				path: `/v1/sessions/${sessionId}/content`,
+				response: () => jsonResponse([{ role: "user", content: "hello" }]),
+			},
+			{
+				method: "GET",
+				path: `/v1/sessions/${sessionId}`,
+				response: () =>
+					jsonResponse({
+						id: sessionId,
+						local_session_id: "local-123",
+						summary: "Fixture",
+						agent_type: "codex",
+						project_path: "/workspace",
+						has_content: true,
+					}),
+			},
+		]);
+		const output: string[] = [];
+		const originalLog = console.log;
+		console.log = (value?: unknown) => output.push(String(value));
+		try {
+			await sessionRead(sessionId, { json: true });
+		} finally {
+			console.log = originalLog;
+			restore();
+		}
+
+		expect(captured.map((request) => request.path).sort()).toEqual(
+			[`/v1/sessions/${sessionId}`, `/v1/sessions/${sessionId}/content`].sort(),
+		);
+		expect(JSON.parse(output[0])).toMatchObject({
+			session: { id: sessionId },
+			messages: [{ role: "user", content: "hello" }],
+		});
+	});
+
+	it("reads metadata-only sessions without requesting absent content", async () => {
+		const sessionId = "00000000-0000-0000-0000-000000000124";
+		const { captured, restore } = mockFetch([
+			{
+				method: "GET",
+				path: `/v1/sessions/${sessionId}`,
+				response: () =>
+					jsonResponse({
+						id: sessionId,
+						local_session_id: "local-124",
+						summary: "Metadata only",
+						agent_type: "codex",
+						project_path: "/workspace",
+						has_content: false,
+					}),
+			},
+		]);
+		const output: string[] = [];
+		const originalLog = console.log;
+		console.log = (value?: unknown) => output.push(String(value));
+		try {
+			await sessionRead(sessionId, { json: true });
+		} finally {
+			console.log = originalLog;
+			restore();
+		}
+
+		expect(captured.map((request) => request.path)).toEqual([`/v1/sessions/${sessionId}`]);
+		expect(JSON.parse(output[0])).toMatchObject({
+			session: { id: sessionId, has_content: false },
+			messages: [],
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Preserve concrete filesystem change paths through the session watcher so adapters can parse only affected sessions, with explicit full-scan fallback for ambiguous events.
- Re-read current session content when draining the queue, including Claude resume-chain suppression, parameterized Hermes lookup, Codex archived sessions, and all existing OpenClaw personalities.
- Add `clawdi session search` for uploaded metadata and `clawdi session read` for cloud session content, including metadata-only sessions.
- Bound poll-mode path tracking to 4096 lightweight entries while retaining a complete aggregate signature and safe full scans beyond the cap.

## Compatibility

- New adapter capabilities are optional; existing adapters continue through `collectSessions()`.
- Session upload payloads and persisted queue and lock formats are unchanged.
- Search uses the existing `/v1/sessions` metadata query and clearly excludes message-body search.

## Verification

- Docker CLI runner: TypeScript typecheck plus full CLI suite, 1727 passed, 4 existing conditional skips, 0 failed.
- Biome check passed for all 17 changed files.
- `git diff --check` and `git show --check` passed.

## Follow-up

Message-body search should be implemented separately as a tenant-scoped PostgreSQL projection keyed by `content_hash`, with `tsvector` and a GIN index. Query-time object-store scans are intentionally out of scope.