### PR TITLE
fix(cli): use official latest runtime installers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.13.104
+
+Package: `clawdi@0.13.104`
+
+### Fixed
+
+- Hosted v2 OpenClaw deployments no longer inherit an exact OpenClaw version
+  from the Clawdi CLI. OpenClaw and Hermes now both use their official
+  installers' default latest release without a version argument.
+
 ## Clawdi CLI v0.13.103
 
 Package: `clawdi@0.13.103`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.103",
+      "version": "0.13.104",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/ai-provider-agent-contract-audit.md
+++ b/docs/ai-provider-agent-contract-audit.md
@@ -152,9 +152,9 @@ Clawdi-owned metadata plugin declaring
 provider projection and cleanup. Convergence verifies the effective marker via
 the public provider-env-vars SDK and fails closed if OpenClaw did not register
 it. This contract does not depend on a legacy plugin. The audited `8f382a2`
-source is provenance evidence, while the selected Clawdi release owns the
-Hosted-v2 exact package pin `openclaw@2026.8.1-beta.2` behind the unchanged
-official-installer selector.
+source is provenance evidence. Hosted v2 uses OpenClaw's official installer
+without a version argument, while convergence capability-gates the public SDK
+surface it consumes.
 
 Hosted v2 convergence:
 

--- a/docs/ai-providers.md
+++ b/docs/ai-providers.md
@@ -235,8 +235,8 @@ patch --stdin`.
 The repository regression-audits these public SDK and projection mechanics with
 `openclaw@2026.7.1-2`, official source commit
 [`0790d9f`](https://github.com/openclaw/openclaw/commit/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c).
-That artifact remains an API audit sample. The selected Clawdi release owns the
-Hosted-v2 runtime pin `openclaw@2026.8.1-beta.2`; convergence also
+That artifact remains an API audit sample, not a Hosted install pin. Hosted v2
+uses OpenClaw's official installer without a version argument; convergence
 capability-gates the APIs it uses.
 The discovery skip is implemented in
 [`models-config.plan.ts`](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/agents/models-config.plan.ts#L115-L120).
@@ -266,8 +266,7 @@ projection or cleanup. It then verifies `CLAWDI_AI_API_KEY` through the public
 `openclaw/plugin-sdk/provider-env-vars` export and fails closed if the marker is
 not registered. Explicit `auth: "api-key"` remains necessary for execution
 precedence but is not the doctor prevention mechanism. Commit `8f382a2` is
-source provenance for this contract; the Clawdi release owns the exact Hosted-v2
-artifact `openclaw@2026.8.1-beta.2`.
+source provenance for this contract, not a Hosted install pin.
 
 When the accepted Hosted v2 manifest proves that exact managed projection,
 root-owned convergence uses OpenClaw's public config-mutation and provider-auth

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -577,7 +577,7 @@ Normalization maps hosted fields into the internal shape:
 | `clawdiCli.packageSpec` | Required exact `clawdi@<semver>` without build metadata, at most 200 characters; remote Hosted manifests never select an npm dist-tag or local path |
 | `clawdiCli.registry` | Required literal `https://registry.npmjs.org`; Hosted does not use npm registry defaults or overrides |
 | `runtimes.<name>.enabled` | Run config and systemd unit state |
-| `runtimes.<name>.install` | Required strict `{source: "official"}` selector; Hosted cannot select a version, channel, commit, digest, or custom installer. The selected Clawdi release owns the official installer contract and the audited exact Hosted-v2 OpenClaw package. |
+| `runtimes.<name>.install` | Required strict `{source: "official"}` selector; Hosted cannot select a version, channel, commit, digest, or custom installer. Both supported runtimes use the official installer's default latest release. |
 | `runtimes.<name>.run` | Exact official gateway argv; only OpenClaw may carry its single gateway-token secret reference. Hosted rejects custom commands, cwd, env, and PATH projection. |
 | `runtimes.<name>.providerMode` | Required runtime-provider ownership discriminator: `configured` or `unmanaged` |
 | `runtimes.<name>.provider_ids` | Core Hosted configured mode requires exactly one provider; unmanaged mode requires an exact empty list. Selection is replacement-only, with no fallback or secondary pool. |
@@ -595,14 +595,11 @@ Normalization maps hosted fields into the internal shape:
 | `egressProfiles` | Explicit generic local sidecar profiles; Agent Plugin packages, Store metadata, and public installation APIs cannot declare them |
 | `recovery.{cacheManifest,allowOfflineBoot}` | Required explicit manifest cache and offline-boot behavior |
 
-The outer Hosted selector remains unchanged for reader-first CLI upgrades. A
-new Clawdi release normalizes Hosted-v2 OpenClaw to its internal exact install
-version, currently `openclaw@2026.8.1-beta.2`; Hermes and generic manifests keep
-their existing installer behavior. OpenClaw convergence probes the installed
-CLI, reruns the official installer on drift, passes `meta.lastTouchedVersion`
-through upstream `--compatible-with`, and accepts the result only when the
-installed version exactly matches. It does not compare versions independently
-or rewrite OpenClaw config fields.
+The outer Hosted selector remains unchanged for reader-first CLI upgrades.
+Hosted v2 normalizes both OpenClaw and Hermes to their official installers
+without a version or channel argument. Convergence runs the installer when the
+runtime executable is absent; it does not resolve, compare, or rewrite upstream
+versions independently.
 
 Hosted parsing does not accept camel-case runtime binding aliases, snake-case
 provider transport aliases, or string `primary_model` values. Provider model
@@ -1228,19 +1225,13 @@ The stable release tag
 [`v2026.7.1`](https://github.com/openclaw/openclaw/releases/tag/v2026.7.1),
 resolves to release commit
 [`2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4`](https://github.com/openclaw/openclaw/commit/2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4).
-Exact package metadata and official installer argument support were revalidated
-on 2026-08-19.
-The Hosted-v2 install target is `openclaw@2026.8.1-beta.2` with npm integrity
-`sha512-k4cwlyFOuXN5wN6NOH/gqxupGuvMkOr5OV2Eh7MJmmGFh86wvWSTrGBkL4XkNTg/kszWzGbotI8wKlZ468EjsQ==`.
-The exact spec resolves through the official installer `--version
-2026.8.1-beta.2` contract. Its npm manifest does not publish `gitHead`, so the
-package spec and registry integrity remain the auditable artifact identity;
-the same-version official source tag resolves to commit
-[`8f382a202ff1e15833394b481615dcdda99b04d7`](https://github.com/openclaw/openclaw/commit/8f382a202ff1e15833394b481615dcdda99b04d7)
-and corroborates the CLI and service contracts below without being treated as
-a cryptographic identity for the npm tarball.
+Official installer behavior was revalidated on 2026-08-20. Hosted v2 passes no
+`--version`; the installer defaults `OPENCLAW_VERSION` to npm's `latest`
+dist-tag. At verification time `latest` resolved to stable
+`openclaw@2026.7.1-2`, while beta remained a separate dist-tag. That resolved
+package is observed runtime state, not desired state owned by a Clawdi release.
 
-The separately retained `2026.7.1-2` service-integration audit remains anchored
+The `2026.7.1-2` service-integration audit is anchored
 to source commit `0790d9f`; it verifies the gateway transaction used by Clawdi,
 not the current Hosted package identity:
 

--- a/packages/cli/docs/openclaw-v2-model-projection.md
+++ b/packages/cli/docs/openclaw-v2-model-projection.md
@@ -67,10 +67,9 @@ Clawdi-owned OpenClaw plugin whose setup metadata declares:
 Convergence verifies the effective marker through the public provider-env-vars
 SDK and fails closed before projection or cleanup if it is absent. Explicit
 `auth: "api-key"` controls execution precedence but does not replace this
-doctor prevention. The Clawdi release pins Hosted-v2 OpenClaw to the audited
-exact package `openclaw@2026.8.1-beta.2`; the unchanged outer Hosted installer
-selector carries no version. No legacy Hosted plugin participates in this
-contract.
+doctor prevention. Hosted v2 uses OpenClaw's official installer without a
+version argument; audited packages remain compatibility evidence rather than
+install pins. No legacy Hosted plugin participates in this contract.
 
 During every proven managed v2 `clawdi` env projection, convergence uses the
 public config-mutation SDK to remove normalized `clawdi` entries from

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.103",
+	"version": "0.13.104",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest-contract.test.ts
+++ b/packages/cli/src/runtime/manifest-contract.test.ts
@@ -2,32 +2,23 @@ import { describe, expect, test } from "bun:test";
 import { officialInstallArgs } from "./manifest-contract";
 
 describe("official runtime installer arguments", () => {
-	test("keeps new Hermes installs on the upstream bundled-Skill defaults", () => {
+	test("keeps Hermes on the official installer's latest release", () => {
 		expect(officialInstallArgs("hermes", "/home/clawdi")).toEqual([
 			"--skip-setup",
 			"--skip-browser",
 			"--non-interactive",
 		]);
 		expect(officialInstallArgs("hermes", "/home/clawdi")).not.toContain("--no-skills");
+		expect(officialInstallArgs("hermes", "/home/clawdi")).not.toContain("--version");
 	});
 
-	test("places the official OpenClaw launcher in the runtime user's local bin", () => {
+	test("keeps OpenClaw on the official installer's latest release", () => {
 		expect(officialInstallArgs("openclaw", "/srv/tenant")).toEqual([
 			"--json",
 			"--no-onboard",
 			"--prefix",
 			"/srv/tenant/.local",
 		]);
-	});
-
-	test("passes an exact OpenClaw version through the official installer", () => {
-		expect(officialInstallArgs("openclaw", "/srv/tenant", "2026.8.1-beta.2")).toEqual([
-			"--json",
-			"--no-onboard",
-			"--prefix",
-			"/srv/tenant/.local",
-			"--version",
-			"2026.8.1-beta.2",
-		]);
+		expect(officialInstallArgs("openclaw", "/srv/tenant")).not.toContain("--version");
 	});
 });

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -84,9 +84,7 @@ const OFFICIAL_INSTALL_ARGS: Record<string, string[]> = {
 
 export function officialInstallArgs(runtime: string, home: string): string[] {
 	const args = [...(OFFICIAL_INSTALL_ARGS[runtime] ?? [])];
-	return runtime === "openclaw"
-		? [...args, "--prefix", join(home, ".local")]
-		: args;
+	return runtime === "openclaw" ? [...args, "--prefix", join(home, ".local")] : args;
 }
 
 const hostedRuntimeChoiceSchema = z.enum(["openclaw", "hermes"]);

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -15,8 +15,6 @@ import {
 import { canonicalSecretRefName, canonicalSecretRefSchema } from "./secret-values";
 
 export const RUNTIME_DESIRED_STATE_SCHEMA_VERSION = "clawdi.runtimeDesiredState.v1";
-export const HOSTED_V2_OPENCLAW_PACKAGE_SPEC = "openclaw@2026.8.1-beta.2";
-export const HOSTED_V2_OPENCLAW_VERSION = HOSTED_V2_OPENCLAW_PACKAGE_SPEC.slice("openclaw@".length);
 
 // Temporary v1 read compatibility. Runtime providers and generated config stay canonical-only.
 export const LEGACY_HOSTED_CODEX_MANAGED_RUNTIME_ENV = "OPENAI_API_KEY";
@@ -84,15 +82,10 @@ const OFFICIAL_INSTALL_ARGS: Record<string, string[]> = {
 	hermes: ["--skip-setup", "--skip-browser", "--non-interactive"],
 };
 
-export function officialInstallArgs(runtime: string, home: string, version?: string): string[] {
+export function officialInstallArgs(runtime: string, home: string): string[] {
 	const args = [...(OFFICIAL_INSTALL_ARGS[runtime] ?? [])];
 	return runtime === "openclaw"
-		? [
-				...args,
-				"--prefix",
-				join(home, ".local"),
-				...(version === undefined ? [] : ["--version", version]),
-			]
+		? [...args, "--prefix", join(home, ".local")]
 		: args;
 }
 
@@ -184,7 +177,6 @@ const installSchema = z.object({
 	url: z.string().url(),
 	home: z.string().min(1),
 	args: z.array(z.string()).default([]),
-	version: z.string().refine(isHostedExactSemver, "must be an exact semver").optional(),
 });
 
 const runtimeSchema = z.object({

--- a/packages/cli/src/runtime/manifest-mutation-parity.test.ts
+++ b/packages/cli/src/runtime/manifest-mutation-parity.test.ts
@@ -4,7 +4,6 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import type { RuntimeManagedMutationPlan } from "./live-state-snapshot";
 import * as actualSnapshot from "./live-state-snapshot";
-import { HOSTED_V2_OPENCLAW_VERSION } from "./manifest-contract";
 
 const fsOriginals = {
 	chmodSync: realFs.chmodSync,
@@ -132,7 +131,7 @@ test("keeps real Hosted converge mutations inside its exact root and runtime-use
 if [ "$*" = "agents list --json" ]; then
   printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace"
 elif [ "\${1:-}" = "--version" ]; then
-  printf '%s\\n' '${HOSTED_V2_OPENCLAW_VERSION}'
+  printf '%s\\n' 'OpenClaw test-version'
 fi
 exit 0
 `,

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -63,7 +63,6 @@ import {
 	AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR,
 	AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR,
 	fileBrowserCompanionSchema,
-	HOSTED_V2_OPENCLAW_VERSION,
 	hostedRuntimeBundleV2ManifestSchema,
 	hostedRuntimeManifestFixtureResponseSchema,
 	hostedRuntimeManifestResponseSchema,
@@ -639,7 +638,7 @@ function writeFakeGatewayCli(input: {
 set -euo pipefail
 case "$*" in
 	"--version")
-		printf '%s\\n' '${input.runtime === "openclaw" ? `OpenClaw ${HOSTED_V2_OPENCLAW_VERSION}` : "Hermes test-version"}'
+		printf '%s\\n' '${input.runtime === "openclaw" ? "OpenClaw test-version" : "Hermes test-version"}'
 		;;
 	"config patch --stdin"*)
 		${input.configPatchPath ? `cat > '${input.configPatchPath}'` : "cat >/dev/null"}
@@ -1117,7 +1116,7 @@ if [[ "$plugin_enabled" == true ]]; then plugin_status=loaded; fi
 
 case "\${1:-}" in
   --version)
-    printf '%s\\n' 'OpenClaw ${HOSTED_V2_OPENCLAW_VERSION}'
+    printf '%s\\n' 'OpenClaw test-version'
     ;;
   agents)
     [[ "\${2:-}" == list && "\${3:-}" == --json ]] || exit 2
@@ -1753,7 +1752,7 @@ chmod 0755 '${commandPath}'
 		});
 
 		expect(parsed.runtimes.custom.install?.args).toEqual([]);
-		expect(parsed.runtimes.custom.install?.version).toBeUndefined();
+		expect("version" in (parsed.runtimes.custom.install ?? {})).toBe(false);
 		expect(parsed.runtimes.custom.updateChannel).toBe("stable");
 		expect(parsed.projection?.providers?.default).toEqual({ model: "legacy-model" });
 	});
@@ -1989,7 +1988,7 @@ chmod 0755 '${commandPath}'
 			[
 				"#!/bin/sh",
 				'if [ "$1" = "--version" ]; then',
-				`  printf '%s\\n' 'OpenClaw ${HOSTED_V2_OPENCLAW_VERSION}'`,
+				`  printf '%s\\n' 'OpenClaw test-version'`,
 				"  exit 0",
 				"fi",
 				'if [ "$1 $2 $3" = "agents list --json" ]; then',
@@ -2073,7 +2072,7 @@ chmod 0755 '${commandPath}'
 			[
 				"#!/bin/sh",
 				'if [ "$1" = "--version" ]; then',
-				`  printf '%s\\n' 'OpenClaw ${HOSTED_V2_OPENCLAW_VERSION}'`,
+				`  printf '%s\\n' 'OpenClaw test-version'`,
 				"  exit 0",
 				"fi",
 				'if [ "$1 $2 $3" = "agents list --json" ]; then',
@@ -2450,12 +2449,9 @@ chmod 0755 '${commandPath}'
 		expect(normalized.manifest.runtimes.openclaw.enabled).toBe(true);
 		expect(normalized.manifest.runtimes.openclaw.updateChannel).toBeUndefined();
 		const install = normalized.manifest.runtimes.openclaw.install;
-		const expectedOpenClawVersion = HOSTED_V2_OPENCLAW_VERSION;
 		expect(install?.url).toBe(OFFICIAL_INSTALL_URLS.openclaw);
-		expect(install?.version).toBe(expectedOpenClawVersion);
-		expect(install?.args).toEqual(
-			officialInstallArgs("openclaw", install?.home ?? "", expectedOpenClawVersion),
-		);
+		expect(install?.args).toEqual(officialInstallArgs("openclaw", install?.home ?? ""));
+		expect(install?.args).not.toContain("--version");
 		expect(normalized.manifest.runtimes.openclaw.run?.args).toEqual(["gateway", "run"]);
 		expect(normalized.manifest.runtimes.openclaw.run?.secretEnv).toEqual({
 			OPENCLAW_GATEWAY_TOKEN: "secret://runtime/openclaw/gateway-token",
@@ -5072,18 +5068,19 @@ echo spawned > '${installerLog}'
 		).toEqual([join(home, ".local", "bin", "openclaw"), join(home, ".local", "tools")].sort());
 	});
 
-	test("passes historical config writer versions unchanged to the exact OpenClaw installer", () => {
+	test("runs the official latest OpenClaw installer with a sanitized environment", () => {
 		const paths = tempRuntimePaths();
 		const home = paths.userHome;
 		const commandPath = join(home, ".local", "bin", "openclaw");
 		const configPath = join(home, ".openclaw", "openclaw.json");
 		const installedVersionPath = join(home, ".openclaw", "installed-version");
 		const fixtureRoot = dirname(paths.serviceStateRoot);
+		const commandFixturePath = join(fixtureRoot, "openclaw");
 		const installerPath = join(fixtureRoot, "install-openclaw.sh");
 		const installerResultPath = join(fixtureRoot, "installer-result");
 		const installerLog = join(fixtureRoot, "installer.log");
 		const installerEnvironmentLog = join(fixtureRoot, "installer-environment.log");
-		const desiredVersion = HOSTED_V2_OPENCLAW_VERSION;
+		const installedVersion = "2026.7.1-2";
 		const configWriterVersion = "2026.8.1.beta.1";
 		const openClawInstallerOverrides = [
 			"OPENCLAW_HOME",
@@ -5105,10 +5102,10 @@ echo spawned > '${installerLog}'
 
 		mkdirSync(dirname(commandPath), { recursive: true });
 		mkdirSync(dirname(configPath), { recursive: true });
-		writeFileSync(installedVersionPath, "2026.7.1-2\n");
+		writeFileSync(installedVersionPath, `${installedVersion}\n`);
 		writeFileSync(configPath, `${JSON.stringify(config)}\n`);
 		writeFileSync(
-			commandPath,
+			commandFixturePath,
 			`#!/usr/bin/env bash
 set -euo pipefail
 case "$*" in
@@ -5118,7 +5115,7 @@ case "$*" in
 esac
 `,
 		);
-		chmodSync(commandPath, 0o700);
+		chmodSync(commandFixturePath, 0o700);
 		writeFileSync(
 			installerPath,
 			`#!/usr/bin/env bash
@@ -5129,6 +5126,7 @@ for name in ${openClawInstallerOverrides.join(" ")}; do
   if [ "\${!name+x}" = x ]; then printf '%s\n' "$name" >> '${installerEnvironmentLog}'; fi
 done
 cp '${installerResultPath}' '${installedVersionPath}'
+cp '${commandFixturePath}' '${commandPath}'
 `,
 		);
 		chmodSync(installerPath, 0o700);
@@ -5150,8 +5148,7 @@ cp '${installerResultPath}' '${installedVersionPath}'
 			method: "official-installer" as const,
 			url: OFFICIAL_INSTALL_URLS.openclaw,
 			home,
-			args: officialInstallArgs("openclaw", home, desiredVersion),
-			version: desiredVersion,
+			args: officialInstallArgs("openclaw", home),
 		};
 		const load = manifestLoad(
 			baseManifest(paths, {
@@ -5162,38 +5159,25 @@ cp '${installerResultPath}' '${installedVersionPath}'
 					services: {},
 				},
 			}),
-			"hosted-v2-openclaw-exact-version",
+			"hosted-v2-openclaw-official-latest",
 		);
 
-		writeFileSync(installerResultPath, "2026.8.1-beta.1\n");
-		const mismatched = convergeRuntimeManifest(load, paths, {
-			executeOfficialServiceInstallers: false,
-		});
-		expect(mismatched.installErrors).toContain(
-			`runtime openclaw installer did not produce exact version ${desiredVersion}`,
-		);
-
-		writeFileSync(installerResultPath, `${desiredVersion}\n`);
+		writeFileSync(installerResultPath, `${installedVersion}\n`);
 		const converged = convergeRuntimeManifest(load, paths, {
 			executeOfficialServiceInstallers: false,
 		});
 		expect(converged.installErrors).toEqual([]);
 		expect(execFileSync(commandPath, ["--version"], { encoding: "utf8" }).trim()).toBe(
-			`OpenClaw ${desiredVersion}`,
+			`OpenClaw ${installedVersion}`,
 		);
 		expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual(config);
 		expect(readFileSync(installerEnvironmentLog, "utf8").trim().split("\n")).toEqual([home]);
-		const expectedArgs = [
-			...officialInstallArgs("openclaw", home, desiredVersion),
-			"--compatible-with",
-			configWriterVersion,
-		];
+		const expectedArgs = officialInstallArgs("openclaw", home);
 		expect(readFileSync(installerLog, "utf8").trim().split("\n")).toEqual([
 			String(expectedArgs.length),
 			...expectedArgs,
-			String(expectedArgs.length),
-			...expectedArgs,
 		]);
+		expect(expectedArgs).not.toContain("--version");
 	});
 
 	test("accepts an installed runtime command symlink as an exact transaction target", () => {

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -19,7 +19,6 @@ import {
 } from "./hosted-egress-profiles";
 import {
 	AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR,
-	HOSTED_V2_OPENCLAW_VERSION,
 	type HostedRuntimeBundleV2Manifest,
 	type HostedRuntimeManifest,
 	hasUnsupportedAgentPluginInstallations,
@@ -456,7 +455,6 @@ export function hostedManifestToRuntimeManifest(
 	const paths = getRuntimePaths({ mode: "hosted" });
 	const selectedRuntime = hosted.runtime;
 	const runtime = hosted.runtimes[selectedRuntime];
-	const installVersion = selectedRuntime === "openclaw" ? HOSTED_V2_OPENCLAW_VERSION : undefined;
 	return {
 		schemaVersion: RUNTIME_DESIRED_STATE_SCHEMA_VERSION,
 		deploymentId: hosted.deploymentId,
@@ -483,8 +481,7 @@ export function hostedManifestToRuntimeManifest(
 					method: "official-installer" as const,
 					url: OFFICIAL_INSTALL_URLS[selectedRuntime],
 					home: paths.userHome,
-					args: officialInstallArgs(selectedRuntime, paths.userHome, installVersion),
-					...(installVersion === undefined ? {} : { version: installVersion }),
+					args: officialInstallArgs(selectedRuntime, paths.userHome),
 				},
 				run: hostedRuntimeRunSettings(selectedRuntime, runtime.run),
 				services: Object.fromEntries(
@@ -668,12 +665,6 @@ function validateManifestSemantics(
 		}
 	}
 	for (const [name, runtime] of Object.entries(manifest.runtimes)) {
-		if (
-			runtime.install?.version !== undefined &&
-			(!isHostedV2 || name !== "openclaw" || runtime.install.version !== HOSTED_V2_OPENCLAW_VERSION)
-		) {
-			errors.push(`runtime ${name} exact install version is reserved for Hosted-v2 OpenClaw`);
-		}
 		if (!runtime.enabled) continue;
 		const runCommand = runtime.run?.command?.trim();
 		if (!isSupportedRuntimeName(name)) {
@@ -707,20 +698,17 @@ function validateManifestSemantics(
 		if (runtime.install.args.includes("--dir")) {
 			errors.push(`runtime ${name} install args must not include --dir`);
 		}
-		if (runtime.install.version !== undefined) {
-			const expectedArgs = officialInstallArgs(name, runtime.install.home, runtime.install.version);
-			if (
-				runtime.install.args.length !== expectedArgs.length ||
-				runtime.install.args.some((arg, index) => arg !== expectedArgs[index])
-			) {
-				errors.push(`runtime ${name} exact install version must use canonical official args`);
-			}
+		const expectedArgs = officialInstallArgs(name, runtime.install.home);
+		if (
+			runtime.install.args.length !== expectedArgs.length ||
+			runtime.install.args.some((arg, index) => arg !== expectedArgs[index])
+		) {
+			errors.push(`runtime ${name} install must use canonical official args`);
 		}
 		const prefixIndexes = runtime.install.args.flatMap((arg, index) =>
 			arg === "--prefix" ? [index] : [],
 		);
 		if (prefixIndexes.length > 0) {
-			const expectedArgs = officialInstallArgs(name, runtime.install.home);
 			const expectedPrefixIndex = expectedArgs.indexOf("--prefix");
 			const expectedPrefix =
 				expectedPrefixIndex >= 0 ? expectedArgs[expectedPrefixIndex + 1] : undefined;

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1426,9 +1426,7 @@ function planRuntimeInstallObservation(
 		runtime: name,
 		enabled: true,
 		status:
-			commandPath && executableExists(commandPath) && !capabilityError
-				? "present"
-				: "configured",
+			commandPath && executableExists(commandPath) && !capabilityError ? "present" : "configured",
 		executionUser: null,
 		commandPath,
 		appRoot,

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1228,58 +1228,6 @@ function materializeInstaller(
 	return { path, cleanup: dir };
 }
 
-function reportedRuntimeVersion(output: string): string | null {
-	for (const match of output.matchAll(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?/g)) {
-		if (isValidSemver(match[0])) return match[0];
-	}
-	return null;
-}
-
-function installedOpenClawVersion(command: string, home: string): string | null {
-	try {
-		const result = spawnRuntimeUserCommand(command, ["--version"], home, home, {
-			timeoutMs: 10_000,
-			maxBufferBytes: 64 * 1024,
-		});
-		if (result.status !== 0) return null;
-		return reportedRuntimeVersion(`${String(result.stdout)}\n${String(result.stderr)}`);
-	} catch {
-		return null;
-	}
-}
-
-function openClawConfigWriterVersion(home: string): string | null {
-	const path = managedOpenClawConfigPath(home);
-	if (!existsSync(path)) return null;
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(readFileSync(path, "utf-8"));
-	} catch {
-		throw new Error("OpenClaw config is invalid before exact-version installation");
-	}
-	if (!isPlainRecord(parsed)) {
-		throw new Error("OpenClaw config must be an object before exact-version installation");
-	}
-	const meta = parsed.meta;
-	if (meta === undefined) return null;
-	if (!isPlainRecord(meta)) {
-		throw new Error("OpenClaw config meta must be an object before exact-version installation");
-	}
-	const version = meta.lastTouchedVersion;
-	if (version === undefined) return null;
-	if (
-		typeof version !== "string" ||
-		version.length === 0 ||
-		version.length > 128 ||
-		version.trim() !== version
-	) {
-		throw new Error(
-			"OpenClaw config meta.lastTouchedVersion must be a non-empty trimmed string of at most 128 characters",
-		);
-	}
-	return version;
-}
-
 function runOfficialInstaller(
 	name: string,
 	install: RuntimeInstall,
@@ -1317,16 +1265,7 @@ function runOfficialInstaller(
 			error: `unsupported runtime ${name}`,
 		});
 	}
-	const expectedVersion = name === "openclaw" ? install.version : undefined;
-	const observedVersion =
-		expectedVersion === undefined || !executableExists(commandPath)
-			? null
-			: installedOpenClawVersion(commandPath, install.home);
-	if (
-		executableExists(commandPath) &&
-		!options.force &&
-		(expectedVersion === undefined || observedVersion === expectedVersion)
-	) {
+	if (executableExists(commandPath) && !options.force) {
 		return finish({
 			runtime: name,
 			enabled: true,
@@ -1348,14 +1287,7 @@ function runOfficialInstaller(
 	const url = executionInstallerUrl(name, install.url);
 	const materialized = materializeInstaller(name, url);
 	try {
-		const configWriterVersion =
-			expectedVersion === undefined ? null : openClawConfigWriterVersion(install.home);
-		const execution = runtimeInstallerExecution(
-			name,
-			install,
-			materialized.path,
-			configWriterVersion === null ? [] : ["--compatible-with", configWriterVersion],
-		);
+		const execution = runtimeInstallerExecution(name, install, materialized.path);
 		const result = spawnSync(execution.command, execution.args, {
 			cwd: install.home,
 			env: execution.env,
@@ -1363,14 +1295,7 @@ function runOfficialInstaller(
 			timeout: Number.parseInt(process.env.CLAWDI_RUNTIME_INSTALL_TIMEOUT ?? "1800000", 10),
 		});
 		const exitCode = result.status ?? 1;
-		const installedVersion =
-			exitCode === 0 && expectedVersion !== undefined && executableExists(commandPath)
-				? installedOpenClawVersion(commandPath, install.home)
-				: null;
-		const installed =
-			exitCode === 0 &&
-			executableExists(commandPath) &&
-			(expectedVersion === undefined || installedVersion === expectedVersion);
+		const installed = exitCode === 0 && executableExists(commandPath);
 		return finish({
 			runtime: name,
 			enabled: true,
@@ -1386,9 +1311,7 @@ function runOfficialInstaller(
 			stderrTail: tail(result.stderr),
 			error: installed
 				? null
-				: expectedVersion !== undefined && exitCode === 0
-					? `runtime ${name} installer did not produce exact version ${expectedVersion}`
-					: `runtime ${name} installer exited ${exitCode} or did not create ${commandPath}`,
+				: `runtime ${name} installer exited ${exitCode} or did not create ${commandPath}`,
 		});
 	} catch (error) {
 		return finish({
@@ -1499,16 +1422,11 @@ function planRuntimeInstallObservation(
 	const commandPath = runtimeCommandPath(name, runtime.install.home);
 	const appRoot = runtimeAppRoot(name, runtime.install.home);
 	const capabilityError = hermesDashboardCapabilityError(name, runtime);
-	const exactVersionPresent =
-		name !== "openclaw" ||
-		runtime.install.version === undefined ||
-		(commandPath !== null &&
-			installedOpenClawVersion(commandPath, runtime.install.home) === runtime.install.version);
 	return {
 		runtime: name,
 		enabled: true,
 		status:
-			commandPath && executableExists(commandPath) && !capabilityError && exactVersionPresent
+			commandPath && executableExists(commandPath) && !capabilityError
 				? "present"
 				: "configured",
 		executionUser: null,

--- a/packages/cli/src/runtime/platform-root-modes.test.ts
+++ b/packages/cli/src/runtime/platform-root-modes.test.ts
@@ -11,7 +11,6 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { cacheRuntimeLastGoodManifest, convergeRuntimeManifest } from "./manifest";
-import { HOSTED_V2_OPENCLAW_VERSION } from "./manifest-contract";
 import { normalizeHostedRuntimeBundleV2 } from "./manifest-source";
 import type { RuntimePaths } from "./paths";
 import { ensureRuntimeStateDirs } from "./state";
@@ -48,7 +47,7 @@ test("never chmods the four platform roots that child writes touch", async () =>
 if [ "$*" = "agents list --json" ]; then
   printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace"
 elif [ "\${1:-}" = "--version" ]; then
-  printf '%s\\n' '${HOSTED_V2_OPENCLAW_VERSION}'
+  printf '%s\\n' 'OpenClaw test-version'
 fi
 exit 0
 `,

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -32,7 +32,6 @@ import {
 	cacheRuntimeLastGoodManifest,
 	convergeRuntimeManifest as convergeRuntimeManifestWithContract,
 } from "./manifest";
-import { HOSTED_V2_OPENCLAW_VERSION } from "./manifest-contract";
 import {
 	HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
 	loadRemoteRuntimeManifest,
@@ -744,7 +743,7 @@ describe("hosted runtime bundle v2", () => {
 			[
 				"#!/usr/bin/env bash",
 				"set -euo pipefail",
-				`if [[ "$1" == "--version" ]]; then printf '%s\\n' '${HOSTED_V2_OPENCLAW_VERSION}'; exit 0; fi`,
+				`if [[ "$1" == "--version" ]]; then printf '%s\\n' 'OpenClaw test-version'; exit 0; fi`,
 				'if [[ "$1 $2 $3" == "agents list --json" ]]; then',
 				'  printf \'[{"id":"main","workspace":"%s"}]\\n\' "$HOME/.openclaw/workspace"',
 				'elif [[ "$1 $2 $3" == "config patch --stdin" ]]; then',
@@ -1548,7 +1547,7 @@ describe("hosted runtime bundle v2", () => {
 			openclawBin,
 			`#!/usr/bin/env sh
 if [ "$*" = "--version" ]; then
-  printf '%s\\n' '${HOSTED_V2_OPENCLAW_VERSION}'
+  printf '%s\\n' 'OpenClaw test-version'
   exit 0
 fi
 if [ "$*" = "agents list --json" ]; then

--- a/packages/cli/tests/egress-handoff-access-contract.test.ts
+++ b/packages/cli/tests/egress-handoff-access-contract.test.ts
@@ -15,7 +15,6 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { convergeRuntimeManifest } from "../src/runtime/manifest";
-import { HOSTED_V2_OPENCLAW_VERSION } from "../src/runtime/manifest-contract";
 import { normalizeHostedRuntimeBundleV2 } from "../src/runtime/manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "../src/runtime/paths";
 import { ensureRuntimeStateDirs } from "../src/runtime/state";
@@ -181,7 +180,7 @@ function convergeHostedEgressFixture(): { paths: RuntimePaths; root: string } {
 		openclaw,
 		`#!/bin/sh
 case "$*" in
-  "--version") printf '%s\\n' '${HOSTED_V2_OPENCLAW_VERSION}' ;;
+  "--version") printf '%s\\n' 'OpenClaw test-version' ;;
   "agents list --json") printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace" ;;
 esac
 `,

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -72,7 +72,6 @@ import {
 	type RuntimeManifest,
 } from "../src/runtime/manifest";
 import {
-	HOSTED_V2_OPENCLAW_VERSION,
 	hostedRuntimeManifestResponseSchema,
 	manifestSchema,
 	officialInstallArgs,
@@ -1268,7 +1267,7 @@ function seedOpenClawBinary(home: string): void {
 		openclawBin,
 		`#!/bin/sh
 if [ "\${1:-}" = "--version" ]; then
-  printf 'openclaw ${HOSTED_V2_OPENCLAW_VERSION}\n'
+  printf 'openclaw test-version\n'
   exit 0
 fi
 if [ "$*" = "agents list --json" ]; then
@@ -1311,7 +1310,7 @@ function writeOpenClawConfigMutationFixture(
 		`#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> '${commandLog}'
-if [ "\${1:-}" = "--version" ]; then printf 'openclaw ${HOSTED_V2_OPENCLAW_VERSION}\n'; exit 0; fi
+if [ "\${1:-}" = "--version" ]; then printf 'openclaw test-version\n'; exit 0; fi
 if [ "$*" = "agents list --json" ]; then
   if grep -q 'legacyInvalidConfig' '${configPath}' 2>/dev/null; then exit 1; fi
   printf '[{"id":"main","workspace":"${home}/.openclaw/workspace"}]\n'
@@ -1439,7 +1438,7 @@ function seedOfficialOpenClawServiceInstaller(home: string): void {
 		`#!/usr/bin/env bash
 set -euo pipefail
 if [ "\${1:-}" = "--version" ]; then
-  printf 'openclaw ${HOSTED_V2_OPENCLAW_VERSION}\\n'
+  printf 'openclaw test-version\\n'
   exit 0
 fi
 if [ "$*" = "agents list --json" ]; then
@@ -3327,7 +3326,7 @@ describe("runtime manifest datasource", () => {
 			);
 			expect(loaded.manifest.runtimes.openclaw.install?.home).toBe(home);
 			expect(loaded.manifest.runtimes.openclaw.install?.args).toEqual(
-				officialInstallArgs("openclaw", home, HOSTED_V2_OPENCLAW_VERSION),
+				officialInstallArgs("openclaw", home),
 			);
 			expectProviderEgressProfileUsesSecretRef(
 				loaded.manifest.egressProfiles?.profiles,
@@ -8225,7 +8224,7 @@ exit 64
 			`#!/usr/bin/env bash
 set -euo pipefail
 if [ "\${1:-}" = "--version" ]; then
-  printf 'openclaw ${HOSTED_V2_OPENCLAW_VERSION}\\n'
+  printf 'openclaw test-version\\n'
   exit 0
 fi
 if [ "$*" = "agents list --json" ]; then
@@ -9036,7 +9035,7 @@ fi
 			`#!/usr/bin/env bash
 set -euo pipefail
 if [ "\${1:-}" = "--version" ]; then
-  printf 'openclaw ${HOSTED_V2_OPENCLAW_VERSION}\\n'
+  printf 'openclaw test-version\\n'
   exit 0
 fi
 ${fakeManagedOpenClawProviderPluginCommands()}
@@ -10663,7 +10662,7 @@ chmod +x "$prefix/bin/clawdi"
 set -euo pipefail
 printf '%s\n' "$*" >> '${installerLog}'
 if [ "$*" = "--version" ]; then
-  printf '%s\n' '${runtime === "openclaw" ? HOSTED_V2_OPENCLAW_VERSION : `${runtime}-test-version`}'
+  printf '%s\n' '${runtime}-test-version'
 elif [ "$*" = "agents list --json" ]; then
   printf '[{"id":"main","workspace":"${join(home, ".openclaw", "workspace")}"}]\n'
 elif [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ]; then
@@ -13631,7 +13630,7 @@ chmod +x "$prefix/bin/clawdi"
 			`#!/usr/bin/env bash
 set -euo pipefail
 if [ "\${1:-}" = "--version" ]; then
-  printf 'openclaw ${HOSTED_V2_OPENCLAW_VERSION}\\n'
+  printf 'openclaw test-version\\n'
   exit 0
 fi
 if [ "$*" = "agents list --json" ]; then


### PR DESCRIPTION
## Summary

- remove the Clawdi-owned exact OpenClaw package/version pin
- normalize both Hosted runtimes to their official installer defaults without version/channel args
- reject non-canonical versioned installer args and retain runtime installer environment isolation
- release the stable CLI as `clawdi@0.13.104`

## Verification

- `./scripts/test.sh cli src/runtime/manifest-contract.test.ts src/runtime/manifest-reconciliation.test.ts src/runtime/manifest-mutation-parity.test.ts src/runtime/platform-root-modes.test.ts src/runtime/runtime-bundle-v2.test.ts tests/egress-handoff-access-contract.test.ts`
- 235 passed, 0 failed
- `git diff --check`