### PR TITLE
fix(cli): never reinstall present runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.13.105
+
+Package: `clawdi@0.13.105`
+
+### Fixed
+
+- Hosted v2 installs OpenClaw or Hermes only when its runtime executable is
+  missing. An installed runtime that lacks a required Hosted capability now
+  fails convergence without automatically reinstalling or upgrading it.
+
 ## Clawdi CLI v0.13.104
 
 Package: `clawdi@0.13.104`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.104",
+      "version": "0.13.105",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.104",
+	"version": "0.13.105",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -5065,7 +5065,7 @@ echo spawned > '${installerLog}'
 					["hermes", { status: "present" as const }],
 				]),
 			).sort(),
-		).toEqual([join(home, ".local", "bin", "openclaw"), join(home, ".local", "tools")].sort());
+		).toEqual([]);
 	});
 
 	test("runs the official latest OpenClaw installer with a sanitized environment", () => {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1228,11 +1228,7 @@ function materializeInstaller(
 	return { path, cleanup: dir };
 }
 
-function runOfficialInstaller(
-	name: string,
-	install: RuntimeInstall,
-	options: { force?: boolean } = {},
-): RuntimeInstallObservation {
+function runOfficialInstaller(name: string, install: RuntimeInstall): RuntimeInstallObservation {
 	const installStartedAt = new Date().toISOString();
 	const installStartedMs = Date.now();
 	const finish = (
@@ -1265,7 +1261,7 @@ function runOfficialInstaller(
 			error: `unsupported runtime ${name}`,
 		});
 	}
-	if (executableExists(commandPath) && !options.force) {
+	if (executableExists(commandPath)) {
 		return finish({
 			runtime: name,
 			enabled: true,
@@ -1338,7 +1334,6 @@ function observeRuntimeInstall(
 	name: string,
 	runtime: RuntimeManifest["runtimes"][string],
 	home: string,
-	planned?: RuntimeInstallObservation,
 ) {
 	if (!runtime.enabled) {
 		return {
@@ -1396,15 +1391,7 @@ function observeRuntimeInstall(
 			error: `runtime ${name} is enabled but missing install metadata`,
 		} satisfies RuntimeInstallObservation;
 	}
-	const commandPath = runtimeCommandPath(name, runtime.install.home);
-	const repairDashboardCapability =
-		name === "hermes" &&
-		Boolean(runtime.services?.dashboard) &&
-		Boolean(commandPath && executableExists(commandPath)) &&
-		planned?.status === "configured";
-	const observation = runOfficialInstaller(name, runtime.install, {
-		force: repairDashboardCapability,
-	});
+	const observation = runOfficialInstaller(name, runtime.install);
 	if (observation.error) return observation;
 	const capabilityError = hermesDashboardCapabilityError(name, runtime);
 	return capabilityError
@@ -1421,12 +1408,10 @@ function planRuntimeInstallObservation(
 	if (!runtime.enabled) return observeRuntimeInstall(name, runtime, home);
 	const commandPath = runtimeCommandPath(name, runtime.install.home);
 	const appRoot = runtimeAppRoot(name, runtime.install.home);
-	const capabilityError = hermesDashboardCapabilityError(name, runtime);
 	return {
 		runtime: name,
 		enabled: true,
-		status:
-			commandPath && executableExists(commandPath) && !capabilityError ? "present" : "configured",
+		status: commandPath && executableExists(commandPath) ? "present" : "configured",
 		executionUser: null,
 		commandPath,
 		appRoot,
@@ -2001,24 +1986,6 @@ function hostedRuntimeOAuthCredentials(
 	});
 }
 
-function hostedRuntimeOAuthDeclared(
-	manifest: RuntimeManifest,
-	runtime: "hermes" | "openclaw",
-): boolean {
-	if (manifest.runtimes[runtime]?.enabled !== true) return false;
-	const providers = recordValue(manifest.projection?.providers);
-	if (!providers) return false;
-	return (manifest.runtimes[runtime]?.provider_ids ?? []).some((providerId) => {
-		const auth = recordValue(recordValue(providers[providerId])?.auth);
-		return (
-			auth?.type === "agent_profile" &&
-			auth.tool === "codex" &&
-			typeof auth.credentialSecretRef === "string" &&
-			typeof auth.credentialRevision === "string"
-		);
-	});
-}
-
 function hermesAuthPath(home: string): string {
 	return join(home, ".hermes", "auth.json");
 }
@@ -2293,28 +2260,12 @@ function ensureHostedOpenClawProviderAuthCapability(input: {
 		requireCapabilities(input.observation);
 		return input.observation;
 	} catch (initialError) {
-		const install = input.manifest.runtimes.openclaw?.install;
-		if (!install) {
-			throw new Error(
-				`${requirement} requires the public OpenClaw SDK, and no official installer repair is authorized: ${
-					initialError instanceof Error ? initialError.message : String(initialError)
-				}`,
-			);
-		}
-		const repaired = runOfficialInstaller("openclaw", install, { force: true });
-		if (repaired.error) {
-			throw new Error(`OpenClaw provider-auth capability repair failed: ${repaired.error}`);
-		}
-		try {
-			requireCapabilities(repaired);
-		} catch (repairError) {
-			throw new Error(
-				`OpenClaw provider-auth capability remains unavailable after official installer repair: ${
-					repairError instanceof Error ? repairError.message : String(repairError)
-				}`,
-			);
-		}
-		return repaired;
+		const detail = initialError instanceof Error ? initialError.message : String(initialError);
+		throw new Error(
+			`${requirement} requires the public OpenClaw SDK; automatic runtime reinstall is disabled: ${
+				tail(detail) ?? "capability probe failed"
+			}`,
+		);
 	}
 }
 
@@ -5815,15 +5766,13 @@ export function runtimeInstallerMutationTargets(
 	manifest: RuntimeManifest,
 	home: string,
 	observations: ReadonlyMap<string, Pick<RuntimeInstallObservation, "status">>,
-	options: { includeOAuthRefresh?: boolean } = {},
 ): string[] {
 	const targets = new Set<string>();
 	const openclawObservation = observations.get("openclaw");
 	if (
 		manifest.runtimes.openclaw?.enabled &&
 		manifest.runtimes.openclaw.install &&
-		(openclawObservation?.status !== "present" ||
-			(options.includeOAuthRefresh !== false && hostedRuntimeOAuthDeclared(manifest, "openclaw")))
+		openclawObservation?.status !== "present"
 	) {
 		targets.add(join(home, ".local", "bin", "openclaw"));
 		targets.add(join(home, ".local", "tools"));
@@ -5879,9 +5828,7 @@ function runtimeColdInstallMutationPlan(
 	});
 	if (!pending) return null;
 	const home = hostedRuntimeProjectionHome(manifest, paths);
-	const runtimeUserTargets = runtimeInstallerMutationTargets(manifest, home, observations, {
-		includeOAuthRefresh: false,
-	}).sort();
+	const runtimeUserTargets = runtimeInstallerMutationTargets(manifest, home, observations).sort();
 	if (runtimeUserTargets.length === 0) return null;
 	const runtimeUserTrustedRoots = [paths.userHome, paths.clawdiHome];
 	const metadataTargets = [
@@ -6450,12 +6397,7 @@ export function convergeRuntimeManifest(
 			ensureRuntimeUserOwnershipBoundaries(coldInstallPlan.runtimeUserOwnershipTargets);
 		}
 		for (const [name, runtime] of runtimeEntries) {
-			const observation = observeRuntimeInstall(
-				name,
-				runtime,
-				projectionHome,
-				observations.get(name),
-			);
+			const observation = observeRuntimeInstall(name, runtime, projectionHome);
 			observations.set(name, observation);
 			if (observation.error) installErrors.push(observation.error);
 			if (name === "openclaw" && observation.enabled && observation.commandPath) {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -3601,13 +3601,12 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		}
 	});
 
-	it("repairs Hermes dashboard runtime drift once and rolls back an incompatible repair", () => {
+	it("does not reinstall Hermes for dashboard capability drift but preserves cold install", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const installer = join(root, "install-hermes.sh");
 		const installerCalls = join(root, "install-hermes.calls");
-		const incompatibleRepair = join(root, "incompatible-repair");
 		const appMarker = join(home, ".hermes", "hermes-agent", "repair-marker");
 		const skillMarker = join(home, ".hermes", "skills", "user-skill", "content.txt");
 		const command = writeHermesVersionBinary(home, "0.20.1");
@@ -3636,11 +3635,7 @@ SH
 chmod +x "$HOME/.local/bin/hermes"
 printf '%s\\n' installer-mutated > "$HOME/.hermes/hermes-agent/repair-marker"
 printf '%s\\n' installer-mutated > "$HOME/.hermes/skills/user-skill/content.txt"
-if [ -f '${incompatibleRepair}' ]; then
-  printf '%s\\n' '#!/usr/bin/env bash' 'exit 1' > "$HOME/.hermes/hermes-agent/venv/bin/python"
-else
-  printf '%s\\n' '#!/usr/bin/env bash' 'exit 0' > "$HOME/.hermes/hermes-agent/venv/bin/python"
-fi
+printf '%s\\n' '#!/usr/bin/env bash' 'exit 0' > "$HOME/.hermes/hermes-agent/venv/bin/python"
 chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 `,
 		);
@@ -3654,28 +3649,18 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		const paths = getRuntimePaths();
 		const load = hostedHermesDashboardCapabilityLoad(home);
 
-		const repaired = convergeRuntimeManifest(load, paths);
-		expect(repaired.installErrors).toEqual([]);
-		expect(readFileSync(installerCalls, "utf8").trim().split("\n")).toEqual(["install"]);
-
-		const unchanged = convergeRuntimeManifest(load, paths);
-		expect(unchanged.installErrors).toEqual([]);
-		expect(readFileSync(installerCalls, "utf8").trim().split("\n")).toEqual(["install"]);
-
-		writeFileSync(appMarker, "stable-app\n");
-		writeFileSync(skillMarker, "stable-user-skill\n");
-		const stableCommand = readFileSync(command, "utf8");
-		writeHermesDashboardPython(home, false);
-		writeFileSync(incompatibleRepair, "1\n");
 		const rejected = convergeRuntimeManifest(load, paths);
-
 		expect(rejected.installErrors.join("\n")).toContain(
-			"uvicorn.Server.capture_signals is unavailable",
+			"Hermes dashboard runtime is incompatible: missing capture_signals",
 		);
-		expect(readFileSync(installerCalls, "utf8").trim().split("\n")).toEqual(["install", "install"]);
-		expect(readFileSync(appMarker, "utf8")).toBe("stable-app\n");
-		expect(readFileSync(skillMarker, "utf8")).toBe("stable-user-skill\n");
-		expect(readFileSync(command, "utf8")).toBe(stableCommand);
+		expect(existsSync(installerCalls)).toBe(false);
+		expect(readFileSync(appMarker, "utf8")).toBe("before-repair\n");
+		expect(readFileSync(skillMarker, "utf8")).toBe("user-skill-before-repair\n");
+
+		rmSync(command);
+		const installed = convergeRuntimeManifest(load, paths);
+		expect(installed.installErrors).toEqual([]);
+		expect(readFileSync(installerCalls, "utf8").trim().split("\n")).toEqual(["install"]);
 	});
 
 	it("keeps explicit OpenAI chat providers on direct provider projection", async () => {
@@ -6104,7 +6089,7 @@ exit 0
 		expect(calls).toContain("update ");
 	});
 
-	it("repairs an installed OpenClaw missing provider-auth capability before OAuth apply", () => {
+	it("does not reinstall an installed OpenClaw missing provider-auth capability", () => {
 		const testRoot = join(root, "oauth-openclaw-capability-repair");
 		const home = join(testRoot, "home", "clawdi");
 		const state = join(testRoot, "var", "lib", "clawdi");
@@ -6146,18 +6131,15 @@ cp '${sdkSource}' '${sdkTarget}'
 		});
 		const result = convergeRuntimeManifest(loaded, getRuntimePaths());
 
-		expect(result.installErrors).toEqual([]);
-		expect(readFileSync(installerLog, "utf8").trim()).toBe("--json --no-onboard");
-		expect(readFileSync(installerLog, "utf8")).not.toContain("--version");
-		const profileId = nativeOAuthProfileId("openclaw", "openai-codex");
+		expect(result.installErrors.join("\n")).toContain(
+			"OpenClaw OAuth requires the public OpenClaw SDK; automatic runtime reinstall is disabled",
+		);
+		expect(existsSync(installerLog)).toBe(false);
 		const storePath = join(home, ".openclaw", "agents", "main", "agent", "openclaw-agent.sqlite");
-		expect(JSON.parse(readFileSync(storePath, "utf8")).profiles[profileId]).toMatchObject({
-			access: "repair-access",
-			refresh: "repair-refresh",
-		});
+		expect(existsSync(storePath)).toBe(false);
 	});
 
-	it("fails closed before config or credential mutation when OpenClaw capability repair fails", () => {
+	it("fails closed before config or credential mutation when OpenClaw capability is unavailable", () => {
 		const testRoot = join(root, "oauth-openclaw-capability-repair-failure");
 		const home = join(testRoot, "home", "clawdi");
 		const state = join(testRoot, "var", "lib", "clawdi");
@@ -6197,9 +6179,7 @@ cp '${sdkSource}' '${sdkTarget}'
 
 		const result = convergeRuntimeManifest(loaded, getRuntimePaths());
 
-		expect(result.installErrors.join("\n")).toContain(
-			"OpenClaw provider-auth capability repair failed",
-		);
+		expect(result.installErrors.join("\n")).toContain("automatic runtime reinstall is disabled");
 		expect(readFileSync(configPath, "utf8")).toBe(originalConfig);
 		expect(readFileSync(storePath, "utf8")).toBe(originalStore);
 		expect(existsSync(join(getRuntimePaths().oauthCredentialRoot, "openclaw"))).toBe(false);


### PR DESCRIPTION
## Summary

- treat an existing Hermes or OpenClaw executable as installed and never rerun its runtime installer
- fail convergence when an installed runtime lacks a required Hosted capability
- keep first-time installs on the official latest installer without version or channel arguments
- remove installed runtime trees from installer rollback snapshots

## Verification

- Docker-isolated CLI typecheck
- 5 focused runtime tests: present-runtime zero installer calls, capability failure without mutation, and cold install behavior
- Docker-isolated Biome check
- git diff --check

## Scope

V2 runtime convergence only. This does not publish clawdi 0.13.105 or deploy any Hosted runtime.