### PR TITLE
refactor(cli): unify session scan contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.13.106
+
+Package: `clawdi@0.13.106`
+
+### Improved
+
+- Multi-agent Session sync now uses targeted local scans for faster updates,
+  while cloud Session metadata can be searched and read across agents.
+
 ## Clawdi CLI v0.13.105
 
 Package: `clawdi@0.13.105`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.105",
+      "version": "0.13.106",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/designs/cli-agent-adapter-capabilities.md
+++ b/docs/designs/cli-agent-adapter-capabilities.md
@@ -2,15 +2,15 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed for owner review; not implemented |
+| Status | PR-A implemented in Clawdi CLI 0.13.106; PR-B deferred |
 | Last updated | 2026-08-20 |
 | Owner | CLI sync layer |
 | Prerequisite | [PR #1109](https://github.com/Clawdi-AI/clawdi/pull/1109), including [`8b571e756`](https://github.com/Clawdi-AI/clawdi/commit/8b571e75678b5684d0a300312e8b2718d1bdb687) |
 
-This document defines two deliberately separate adapter changes. Immediate
-PR-A is a behavior-preserving cleanup of the Session contract introduced by PR
-#1109. Later PR-B separates `SkillStore` immediately before the first real
-session-only adapter needs that boundary.
+This document defines two deliberately separate adapter changes. PR-A was
+implemented in Clawdi CLI 0.13.106 as a behavior-preserving cleanup of the
+Session contract introduced by PR #1109. PR-B remains deferred until
+immediately before the first real session-only adapter needs `SkillStore`.
 
 Neither PR changes the fact that Session support is mandatory for every
 `AgentAdapter`. Do not turn the adapter into a bag of optional capabilities.
@@ -33,7 +33,7 @@ Neither PR changes the fact that Session support is mandatory for every
    Hosted runtime path. They are not local Session drivers and do not justify
    optional Session methods on `AgentAdapter`.
 
-PR-A follows PR #1109 and must not include a new adapter.
+PR-A followed PR #1109 and included no new adapter.
 
 ## PR-A Session Contract
 
@@ -61,8 +61,8 @@ export interface AgentAdapter {
 }
 ```
 
-Session methods are required. Skill methods remain directly on `AgentAdapter`
-in PR-A and remain required for all four registered adapters.
+Session methods are required. PR-A kept Skill methods directly on
+`AgentAdapter`, required for all four registered adapters.
 
 ### Collection And Coverage
 
@@ -98,9 +98,9 @@ canonical Session that should be uploaded now.
 The Codex active-to-archive absence bug is already fixed in PR #1109 commit
 `8b571e756`. That commit removes the stale complete-inventory early return and
 adds coverage for moving a learned Session from `sessions/` to
-`archived_sessions/`. PR-A preserves that behavior; it only removes the
+`archived_sessions/`. PR-A preserved that behavior and removed only the
 residual optional-resolution fallback and completeness plumbing from the
-engine. Do not duplicate the fix or its regression test.
+engine. It did not duplicate the fix or its regression test.
 
 ### Watcher And Engine Flow
 
@@ -134,14 +134,14 @@ sha256(JSON.stringify(session.messages))
 
 ### Path Containment And Dead API
 
-Replace the repeated Claude Code, Codex, and OpenClaw containment logic with one
+The repeated Claude Code, Codex, and OpenClaw containment logic now lives in one
 small shared helper. It validates that a resolved candidate path is inside one
 of the adapter's declared roots. File extensions, existence checks, storage
 layout, and parsing remain adapter-specific.
 
-`buildRunCommand` has no caller. Remove it from `AgentAdapter`, all four
-implementations, and the tests that only assert command-prefix construction.
-Do not replace it with a runner abstraction without a real caller.
+`buildRunCommand` had no caller and was removed from `AgentAdapter`, all four
+implementations, and the tests that only asserted command-prefix construction.
+No runner abstraction replaced it.
 
 ## Deferred PR-B
 
@@ -210,28 +210,29 @@ compatibility migration when no format changes. Follow
 [`api-compatibility.md`](../api-compatibility.md) for any separately authorized
 wire change.
 
-## PR-A Implementation Order
+## PR-A Implementation
 
-1. Add the unified request/result types, explicit coverage, mandatory
-   `resolveSession`, and watcher event union. Leave Skill methods in place.
-2. Adapt all four Session implementations, add the shared containment helper,
-   and remove `buildRunCommand`.
-3. Make the watcher emit `SessionWatchEvent` and make the engine consume one
+1. Added the unified request/result types, explicit coverage, mandatory
+   `resolveSession`, and watcher event union while keeping Skill methods in
+   place.
+2. Adapted all four Session implementations, added the shared containment
+   helper, and removed `buildRunCommand`.
+3. Changed the watcher to emit `SessionWatchEvent` and the engine to consume one
    request/result path with no optional probes or side completeness flag.
-4. Make queue drain call `resolveSession` directly and preserve the current
-   hash-before-upload behavior.
-5. Remove obsolete fallback plumbing and stale comments. Do not change public
-   behavior, persistence, APIs, Skill workflows, or runtime boundaries.
+4. Changed queue drain to call `resolveSession` directly while preserving the
+   existing hash-before-upload behavior.
+5. Removed obsolete fallback plumbing and stale comments without changing
+   public behavior, persistence, APIs, Skill workflows, or runtime boundaries.
 
 Done: the PR contains no new adapter, Skill capability split, Agent Plugin
 change, wire change, persisted-state migration, or duplicate regression test.
 
 ## Verification
 
-Preserve PR #1109's existing coverage for bounded and ambiguous watcher
+PR-A preserved PR #1109's existing coverage for bounded and ambiguous watcher
 changes, periodic complete scans, queue-time re-reads, and Codex
-active-to-archive resolution. Update fixtures only as required by the contract
-rename. Do not add tests for TypeScript declarations, a fake session-only
+active-to-archive resolution. Fixtures changed only as required by the contract
+rename. It added no tests for TypeScript declarations, a fake session-only
 adapter, or the already-covered Codex move.
 
 ```bash

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.105",
+	"version": "0.13.106",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/adapters/base.ts
+++ b/packages/cli/src/adapters/base.ts
@@ -27,20 +27,9 @@ export interface RawSession {
 	contentHash?: string;
 }
 
-/**
- * Options for `AgentAdapter.collectSessions`.
- *
- * `projectFilter` restricts to sessions whose stored `cwd` / project path
- * equals or is under the given absolute path. Hermes ignores this — its
- * data model has no project linkage.
- *
- * Adapters always do a full scan and return every session that matches
- * the project filter. Whether to actually push a session to the server
- * is decided in `pushOneAgent` against `~/.clawdi/sessions-lock.json`.
- */
-export interface CollectSessionsOptions {
-	projectFilter?: string;
-}
+export type SessionScanRequest =
+	| { kind: "complete"; projectFilter?: string }
+	| { kind: "paths"; paths: readonly string[]; projectFilter?: string };
 
 /**
  * Return shape of `AgentAdapter.collectSessions`.
@@ -52,9 +41,10 @@ export interface CollectSessionsOptions {
  * their storage formats don't produce cross-file duplication (e.g. Codex
  * keeps long-conversation history in-file via `compacted` entries).
  */
-export interface CollectSessionsResult {
+export interface SessionScanResult {
 	sessions: RawSession[];
 	dedupedCount: number;
+	coverage: "complete" | "partial";
 }
 
 export interface RawSkill {
@@ -75,24 +65,8 @@ export interface AgentAdapter {
 	detect(): Promise<boolean>;
 	getVersion(): Promise<string | null>;
 
-	collectSessions(opts?: CollectSessionsOptions): Promise<CollectSessionsResult>;
-	/**
-	 * Re-read one session from its current backing store, when supported.
-	 * Implementations must not return a cached transcript payload.
-	 */
-	collectSession?(localSessionId: string): Promise<RawSession | null>;
-	/**
-	 * Parse only sessions represented by concrete watcher paths.
-	 *
-	 * Returns `null` when any path cannot be resolved safely to a bounded
-	 * session set. The daemon then falls back to `collectSessions()`. The
-	 * result is a partial inventory, so callers must not infer deletion of
-	 * sessions omitted from it.
-	 */
-	collectSessionsForPaths?(
-		paths: readonly string[],
-		opts?: CollectSessionsOptions,
-	): Promise<CollectSessionsResult | null>;
+	collectSessions(request: SessionScanRequest): Promise<SessionScanResult>;
+	resolveSession(localSessionId: string): Promise<RawSession | null>;
 	collectSkills(): Promise<RawSkill[]>;
 	/** Enumerate skill_keys present on disk WITHOUT reading SKILL.md
 	 * content. Used by the daemon's hot-path rescan / boot listing
@@ -129,10 +103,7 @@ export interface AgentAdapter {
 	getSharedSkillPath(skillKey: string, ownerHandle: string): string;
 	/** Path(s) `clawdi daemon` should watch for session changes. May
 	 * be directories (Claude Code, Codex, OpenClaw all dump JSONL
-	 * files there) or database/sidecar files (Hermes uses SQLite). The
-	 * daemon passes concrete changed paths to `collectSessionsForPaths`
-	 * when the platform provides them, with `collectSessions` as the safe
-	 * fallback for ambiguous events and shared data stores.
+	 * files there) or database/sidecar files (Hermes uses SQLite).
 	 *
 	 * Returning paths that don't exist yet is fine — the watcher
 	 * skips missing roots and reattaches when `mkdir` lands. The
@@ -155,6 +126,4 @@ export interface AgentAdapter {
 	 * inventory reconciliation does so with its durable materialization receipt.
 	 * An already absent target is handled idempotently. */
 	removeLocalSkill(key: string): Promise<void>;
-
-	buildRunCommand(args: string[], env: Record<string, string>): string[];
 }

--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
-import { basename, isAbsolute, join, relative } from "node:path";
+import { basename, join, relative, resolve } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import { replaceSkillArchiveTarGz } from "../lib/tar";
@@ -11,13 +11,13 @@ import {
 } from "../runtime/managed-skill-reservation";
 import type {
 	AgentAdapter,
-	CollectSessionsOptions,
-	CollectSessionsResult,
 	RawSession,
 	RawSkill,
 	SessionMessage,
+	SessionScanRequest,
+	SessionScanResult,
 } from "./base";
-import { getClaudeHome, SKIP_DIRS } from "./paths";
+import { getClaudeHome, isPathWithinRoots, SKIP_DIRS } from "./paths";
 import { readCommandVersion } from "./version";
 
 function claudeDir() {
@@ -89,19 +89,38 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 		return absPath.replace(/\//g, "-");
 	}
 
-	async collectSessions(opts: CollectSessionsOptions = {}): Promise<CollectSessionsResult> {
-		if (!existsSync(projectsDir())) return { sessions: [], dedupedCount: 0 };
+	async collectSessions(request: SessionScanRequest): Promise<SessionScanResult> {
+		if (!existsSync(projectsDir())) {
+			return { sessions: [], dedupedCount: 0, coverage: "complete" };
+		}
 
-		const { projectFilter } = opts;
+		const { projectFilter } = request;
+		const absFilter = projectFilter ? resolve(projectFilter) : null;
+		if (request.kind === "paths") {
+			const root = resolve(projectsDir());
+			const projectDirNames = new Set<string>();
+			for (const candidate of request.paths) {
+				const path = resolve(candidate);
+				const parts = relative(root, path).split(/[\\/]/);
+				if (
+					!isPathWithinRoots(path, [root]) ||
+					parts.length !== 2 ||
+					!parts[1].endsWith(".jsonl")
+				) {
+					return this.collectSessions({ kind: "complete", projectFilter });
+				}
+				projectDirNames.add(parts[0]);
+			}
+			if (projectDirNames.size > 0) {
+				return this.collectProjectSessions([...projectDirNames], absFilter, "partial");
+			}
+		}
 
 		let projectDirs = readdirSync(projectsDir(), { withFileTypes: true }).filter((d) =>
 			d.isDirectory(),
 		);
 
-		let absFilter: string | null = null;
-		if (projectFilter) {
-			const { resolve } = await import("node:path");
-			absFilter = resolve(projectFilter);
+		if (absFilter) {
 			const targetDir = this.pathToProjectDir(absFilter);
 			// Coarse pre-filter on the encoded dir name: keep the target and any
 			// dir whose name starts with "target-". Because "/" and in-segment "-"
@@ -116,10 +135,11 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 		return this.collectProjectSessions(
 			projectDirs.map((projectDir) => projectDir.name),
 			absFilter,
+			"complete",
 		);
 	}
 
-	async collectSession(localSessionId: string): Promise<RawSession | null> {
+	async resolveSession(localSessionId: string): Promise<RawSession | null> {
 		if (!existsSync(projectsDir()) || basename(localSessionId) !== localSessionId) return null;
 		const matches: Array<{ filePath: string; projectDirName: string }> = [];
 		for (const projectDir of readdirSync(projectsDir(), { withFileTypes: true })) {
@@ -130,48 +150,23 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 		if (matches.length !== 1) {
 			if (matches.length === 0) return null;
 			return (
-				(await this.collectSessions()).sessions.find(
+				(await this.collectSessions({ kind: "complete" })).sessions.find(
 					(session) => session.localSessionId === localSessionId,
 				) ?? null
 			);
 		}
 		return (
-			this.collectProjectSessions([matches[0].projectDirName], null).sessions.find(
+			this.collectProjectSessions([matches[0].projectDirName], null, "partial").sessions.find(
 				(session) => session.localSessionId === localSessionId,
 			) ?? null
 		);
 	}
 
-	async collectSessionsForPaths(
-		paths: readonly string[],
-		opts: CollectSessionsOptions = {},
-	): Promise<CollectSessionsResult | null> {
-		const projectDirNames = new Set<string>();
-		for (const path of paths) {
-			const fromRoot = relative(projectsDir(), path);
-			const parts = fromRoot.split(/[\\/]/);
-			if (
-				isAbsolute(fromRoot) ||
-				fromRoot.startsWith("..") ||
-				parts.length !== 2 ||
-				!parts[1].endsWith(".jsonl")
-			) {
-				return null;
-			}
-			projectDirNames.add(parts[0]);
-		}
-		if (projectDirNames.size === 0) return null;
-
-		const absFilter = opts.projectFilter
-			? (await import("node:path")).resolve(opts.projectFilter)
-			: null;
-		return this.collectProjectSessions([...projectDirNames], absFilter);
-	}
-
 	private collectProjectSessions(
 		projectDirNames: readonly string[],
 		absFilter: string | null,
-	): CollectSessionsResult {
+		coverage: SessionScanResult["coverage"],
+	): SessionScanResult {
 		const sessions: RawSession[] = [];
 		const uuidsBySession = new Map<RawSession, Set<string>>();
 		for (const projectDirName of projectDirNames) {
@@ -192,7 +187,7 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 				}
 			}
 		}
-		return dedupeResumeChains(sessions, uuidsBySession);
+		return dedupeResumeChains(sessions, uuidsBySession, coverage);
 	}
 
 	private parseRawSession(
@@ -427,10 +422,6 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 			tarGzBytes,
 		);
 	}
-
-	buildRunCommand(args: string[], _env: Record<string, string>): string[] {
-		return ["claude", ...args];
-	}
 }
 
 /**
@@ -450,7 +441,8 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 function dedupeResumeChains(
 	sessions: RawSession[],
 	uuids: Map<RawSession, Set<string>>,
-): CollectSessionsResult {
+	coverage: SessionScanResult["coverage"],
+): SessionScanResult {
 	// Group by projectPath — resume chains are always within a single cwd.
 	const byProject = new Map<string, RawSession[]>();
 	for (const s of sessions) {
@@ -496,5 +488,6 @@ function dedupeResumeChains(
 	return {
 		sessions: sessions.filter((s) => !dedupedIds.has(s.localSessionId)),
 		dedupedCount: dedupedIds.size,
+		coverage,
 	};
 }

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -1,5 +1,5 @@
 import { type Dirent, existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import { replaceSkillArchiveTarGz } from "../lib/tar";
@@ -11,13 +11,13 @@ import {
 } from "../runtime/managed-skill-reservation";
 import type {
 	AgentAdapter,
-	CollectSessionsOptions,
-	CollectSessionsResult,
 	RawSession,
 	RawSkill,
 	SessionMessage,
+	SessionScanRequest,
+	SessionScanResult,
 } from "./base";
-import { getCodexHome, SKIP_DIRS } from "./paths";
+import { getCodexHome, isPathWithinRoots, SKIP_DIRS } from "./paths";
 import { readCommandVersion } from "./version";
 
 function codexDir() {
@@ -98,13 +98,6 @@ function collectJsonlFiles(root: string): string[] {
 
 	walk(root);
 	return results;
-}
-
-function isWithinSessionRoot(path: string): boolean {
-	return sessionRoots().some((root) => {
-		const fromRoot = relative(root, path);
-		return fromRoot === "" || (!fromRoot.startsWith("..") && !isAbsolute(fromRoot));
-	});
 }
 
 function resolveProjectFilter(projectFilter?: string): string | null {
@@ -238,10 +231,36 @@ export class CodexAdapter implements AgentAdapter {
 		return readCommandVersion("codex", ["--version"]);
 	}
 
-	async collectSessions(opts: CollectSessionsOptions = {}): Promise<CollectSessionsResult> {
+	async collectSessions(request: SessionScanRequest): Promise<SessionScanResult> {
+		const absFilter = resolveProjectFilter(request.projectFilter);
+		if (request.kind === "paths") {
+			if (request.paths.length === 0) {
+				return this.collectSessions({ kind: "complete", projectFilter: request.projectFilter });
+			}
+			const roots = sessionRoots().map((root) => resolve(root));
+			const files = new Set<string>();
+			for (const path of request.paths.map((candidate) => resolve(candidate))) {
+				if (!isPathWithinRoots(path, roots) || !path.endsWith(".jsonl")) {
+					return this.collectSessions({ kind: "complete", projectFilter: request.projectFilter });
+				}
+				for (const [sessionId, knownPath] of this.sessionPaths) {
+					if (knownPath === path && !existsSync(path)) this.sessionPaths.delete(sessionId);
+				}
+				if (existsSync(path)) files.add(path);
+			}
+			const sessionsById = new Map<string, RawSession>();
+			for (const filePath of files) {
+				const session = parseSessionFile(filePath, absFilter);
+				if (session) {
+					sessionsById.set(session.localSessionId, session);
+					this.sessionPaths.set(session.localSessionId, filePath);
+				}
+			}
+			return { sessions: [...sessionsById.values()], dedupedCount: 0, coverage: "partial" };
+		}
+
 		const sessionsById = new Map<string, RawSession>();
 		const pathsById = new Map<string, string>();
-		const absFilter = resolveProjectFilter(opts.projectFilter);
 		for (const root of sessionRoots()) {
 			for (const filePath of collectJsonlFiles(root)) {
 				const session = parseSessionFile(filePath, absFilter);
@@ -251,7 +270,7 @@ export class CodexAdapter implements AgentAdapter {
 				}
 			}
 		}
-		if (opts.projectFilter) {
+		if (request.projectFilter) {
 			for (const [sessionId, path] of pathsById) this.sessionPaths.set(sessionId, path);
 		} else {
 			this.sessionPaths = pathsById;
@@ -260,10 +279,10 @@ export class CodexAdapter implements AgentAdapter {
 		// Codex stores long-conversation history via in-file `compacted`
 		// entries rather than spawning new sessionId files, so it cannot
 		// produce the resume-chain duplication that ClaudeCodeAdapter dedupes.
-		return { sessions: [...sessionsById.values()], dedupedCount: 0 };
+		return { sessions: [...sessionsById.values()], dedupedCount: 0, coverage: "complete" };
 	}
 
-	async collectSession(localSessionId: string): Promise<RawSession | null> {
+	async resolveSession(localSessionId: string): Promise<RawSession | null> {
 		const knownPath = this.sessionPaths.get(localSessionId);
 		if (knownPath) {
 			const current = parseSessionFile(knownPath, null);
@@ -271,34 +290,10 @@ export class CodexAdapter implements AgentAdapter {
 			this.sessionPaths.delete(localSessionId);
 		}
 		return (
-			(await this.collectSessions()).sessions.find(
+			(await this.collectSessions({ kind: "complete" })).sessions.find(
 				(session) => session.localSessionId === localSessionId,
 			) ?? null
 		);
-	}
-
-	async collectSessionsForPaths(
-		paths: readonly string[],
-		opts: CollectSessionsOptions = {},
-	): Promise<CollectSessionsResult | null> {
-		const files = new Set<string>();
-		for (const path of paths.map((candidate) => resolve(candidate))) {
-			if (!isWithinSessionRoot(path) || !path.endsWith(".jsonl")) return null;
-			for (const [sessionId, knownPath] of this.sessionPaths) {
-				if (knownPath === path && !existsSync(path)) this.sessionPaths.delete(sessionId);
-			}
-			if (existsSync(path)) files.add(path);
-		}
-		const sessionsById = new Map<string, RawSession>();
-		const absFilter = resolveProjectFilter(opts.projectFilter);
-		for (const filePath of files) {
-			const session = parseSessionFile(filePath, absFilter);
-			if (session) {
-				sessionsById.set(session.localSessionId, session);
-				this.sessionPaths.set(session.localSessionId, filePath);
-			}
-		}
-		return { sessions: [...sessionsById.values()], dedupedCount: 0 };
 	}
 
 	async collectSkills(): Promise<RawSkill[]> {
@@ -402,9 +397,5 @@ export class CodexAdapter implements AgentAdapter {
 			this.getSharedSkillPath(key, ownerHandle),
 			tarGzBytes,
 		);
-	}
-
-	buildRunCommand(args: string[], _env: Record<string, string>): string[] {
-		return ["codex", ...args];
 	}
 }

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -12,11 +12,11 @@ import {
 } from "../runtime/managed-skill-reservation";
 import type {
 	AgentAdapter,
-	CollectSessionsOptions,
-	CollectSessionsResult,
 	RawSession,
 	RawSkill,
 	SessionMessage,
+	SessionScanRequest,
+	SessionScanResult,
 } from "./base";
 import { getHermesHome, SKIP_DIRS } from "./paths";
 import { readCommandVersion } from "./version";
@@ -124,15 +124,15 @@ export class HermesAdapter implements AgentAdapter {
 		return readCommandVersion("hermes", ["--version"]);
 	}
 
-	async collectSessions(_opts: CollectSessionsOptions = {}): Promise<CollectSessionsResult> {
+	async collectSessions(_request: SessionScanRequest): Promise<SessionScanResult> {
 		// Hermes' SQLite is a single file with no per-row stat info, so we
 		// always scan the whole `sessions` table. Cost is negligible
 		// (dozens to hundreds of rows). `projectFilter` has no analogue
 		// in Hermes' data model and is silently ignored.
-		return { sessions: await this.collectCurrentSessions(), dedupedCount: 0 };
+		return { sessions: await this.collectCurrentSessions(), dedupedCount: 0, coverage: "complete" };
 	}
 
-	async collectSession(localSessionId: string): Promise<RawSession | null> {
+	async resolveSession(localSessionId: string): Promise<RawSession | null> {
 		return (await this.collectCurrentSessions(localSessionId))[0] ?? null;
 	}
 
@@ -343,9 +343,5 @@ export class HermesAdapter implements AgentAdapter {
 			this.getSharedSkillPath(key, ownerHandle),
 			tarGzBytes,
 		);
-	}
-
-	buildRunCommand(args: string[], _env: Record<string, string>): string[] {
-		return ["hermes", ...args];
 	}
 }

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, isAbsolute, join, relative, resolve } from "node:path";
+import { basename, isAbsolute, join, resolve } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
 import { durationSecondsBetween } from "../lib/session-duration";
 import { extractTarGz } from "../lib/tar";
@@ -18,18 +18,18 @@ import {
 } from "../runtime/managed-skill-reservation";
 import type {
 	AgentAdapter,
-	CollectSessionsOptions,
-	CollectSessionsResult,
 	RawSession,
 	RawSkill,
 	SessionMessage,
+	SessionScanRequest,
+	SessionScanResult,
 } from "./base";
 import {
 	listOpenClawAgentWorkspaces,
 	openClawAgentId,
 	resolveOpenClawAgentWorkspace,
 } from "./openclaw-workspace";
-import { getOpenClawHome, SKIP_DIRS } from "./paths";
+import { getOpenClawHome, isPathWithinRoots, SKIP_DIRS } from "./paths";
 import { readCommandVersion } from "./version";
 
 function openclawDir() {
@@ -89,11 +89,6 @@ function listAgentDirs(): string[] {
 		);
 		return [];
 	}
-}
-
-function isWithin(path: string, root: string): boolean {
-	const fromRoot = relative(root, path);
-	return fromRoot === "" || (!fromRoot.startsWith("..") && !isAbsolute(fromRoot));
 }
 
 interface SessionEntry {
@@ -168,44 +163,49 @@ export class OpenClawAdapter implements AgentAdapter {
 		);
 	}
 
-	async collectSessions(opts: CollectSessionsOptions = {}): Promise<CollectSessionsResult> {
-		return (await this.collectSessionsMatching(opts)).result;
+	async collectSessions(request: SessionScanRequest): Promise<SessionScanResult> {
+		if (request.kind === "complete") {
+			const { result } = await this.collectSessionsMatching(request);
+			return { ...result, coverage: "complete" };
+		}
+		if (request.paths.length === 0) {
+			return this.collectSessions({ kind: "complete", projectFilter: request.projectFilter });
+		}
+		const sessionRoots = listAgentDirs().map((dir) => resolve(dir, "sessions"));
+		const transcriptPaths = new Set<string>();
+		for (const path of request.paths) {
+			const normalized = resolve(path);
+			if (
+				!isPathWithinRoots(normalized, sessionRoots) ||
+				basename(normalized) === "sessions.json" ||
+				!normalized.endsWith(".jsonl")
+			) {
+				return this.collectSessions({ kind: "complete", projectFilter: request.projectFilter });
+			}
+			transcriptPaths.add(normalized);
+		}
+
+		const collection = await this.collectSessionsMatching(request, transcriptPaths);
+		for (const path of transcriptPaths) {
+			if (existsSync(path) && !collection.matchedTranscriptPaths.has(path)) {
+				return this.collectSessions({ kind: "complete", projectFilter: request.projectFilter });
+			}
+		}
+		return { ...collection.result, coverage: "partial" };
 	}
 
-	async collectSession(localSessionId: string): Promise<RawSession | null> {
+	async resolveSession(localSessionId: string): Promise<RawSession | null> {
 		return (
 			(await this.collectSessionsMatching({}, undefined, localSessionId)).result.sessions[0] ?? null
 		);
 	}
 
-	async collectSessionsForPaths(
-		paths: readonly string[],
-		opts: CollectSessionsOptions = {},
-	): Promise<CollectSessionsResult | null> {
-		const sessionRoots = listAgentDirs().map((dir) => resolve(dir, "sessions"));
-		const transcriptPaths = new Set<string>();
-		for (const path of paths) {
-			const normalized = resolve(path);
-			if (!sessionRoots.some((root) => isWithin(normalized, root))) return null;
-			if (basename(normalized) === "sessions.json") return null;
-			if (!normalized.endsWith(".jsonl")) return null;
-			transcriptPaths.add(normalized);
-		}
-		if (transcriptPaths.size === 0) return null;
-
-		const collection = await this.collectSessionsMatching(opts, transcriptPaths);
-		for (const path of transcriptPaths) {
-			if (existsSync(path) && !collection.matchedTranscriptPaths.has(path)) return null;
-		}
-		return collection.result;
-	}
-
 	private async collectSessionsMatching(
-		opts: CollectSessionsOptions,
+		opts: { projectFilter?: string },
 		transcriptPaths?: ReadonlySet<string>,
 		localSessionId?: string,
 	): Promise<{
-		result: CollectSessionsResult;
+		result: Pick<SessionScanResult, "sessions" | "dedupedCount">;
 		matchedTranscriptPaths: Set<string>;
 	}> {
 		const agentDirs = listAgentDirs();
@@ -556,9 +556,5 @@ export class OpenClawAdapter implements AgentAdapter {
 		tarGzBytes: Buffer,
 	): Promise<void> {
 		await this.installOfficialSkillArchive(key, `${key}__${ownerHandle}`, tarGzBytes);
-	}
-
-	buildRunCommand(args: string[], _env: Record<string, string>): string[] {
-		return ["openclaw", ...args];
 	}
 }

--- a/packages/cli/src/adapters/paths.ts
+++ b/packages/cli/src/adapters/paths.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join, relative } from "node:path";
 
 /**
  * Directory names to skip when scanning for skills. Applied by every adapter's
@@ -8,6 +8,13 @@ import { join } from "node:path";
  * registry.ts already imports every adapter.
  */
 export const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build", "__pycache__"]);
+
+export function isPathWithinRoots(path: string, roots: readonly string[]): boolean {
+	return roots.some((root) => {
+		const fromRoot = relative(root, path);
+		return fromRoot === "" || (!fromRoot.startsWith("..") && !isAbsolute(fromRoot));
+	});
+}
 
 // All getters compute lazily. Module-level constants would freeze the path at
 // import time and ignore env changes (and break per-test HOME overrides).

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -348,7 +348,7 @@ async function scanOneAgent(
 		// `collectSessions` also reports a `dedupedCount` (resume chains it
 		// collapsed). That's internal housekeeping — not actionable and not
 		// perceptible to the user — so it isn't surfaced.
-		sessions = (await adapter.collectSessions({ projectFilter })).sessions;
+		sessions = (await adapter.collectSessions({ kind: "complete", projectFilter })).sessions;
 	}
 	if (modules.includes("skills")) {
 		// Always route local Skills through the authenticated Agent claim

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -61,7 +61,7 @@ export async function sessionList(opts: SessionListOpts) {
 			// `list` command silently benefits from dedupe — no user-facing
 			// counter needed since the listing project itself is dedupe's
 			// purpose (don't show users two near-identical rows).
-			const result = await adapter.collectSessions({ projectFilter });
+			const result = await adapter.collectSessions({ kind: "complete", projectFilter });
 			sessions = result.sessions;
 		} catch {
 			continue;

--- a/packages/cli/src/serve/sessions-watcher.test.ts
+++ b/packages/cli/src/serve/sessions-watcher.test.ts
@@ -9,6 +9,7 @@ import {
 	pollSessionPaths,
 	SESSION_IDLE_POLL_INTERVAL_MS,
 	SESSION_STABLE_AFTER_MS,
+	type SessionWatchEvent,
 	sessionPathSignature,
 	sessionPathSnapshot,
 	sleepForSessionPoll,
@@ -76,7 +77,7 @@ describe("pollSessionPaths", () => {
 		const abort = new AbortController();
 		let now = 0;
 		const sessionPath = "/sessions/changed.jsonl";
-		const changes: Array<{ paths: string[]; requiresFullScan: boolean }> = [];
+		const changes: SessionWatchEvent[] = [];
 
 		await pollSessionPaths(
 			{
@@ -102,7 +103,7 @@ describe("pollSessionPaths", () => {
 			},
 		);
 
-		expect(changes).toEqual([{ paths: [sessionPath], requiresFullScan: false }]);
+		expect(changes).toEqual([{ kind: "paths", paths: [sessionPath] }]);
 	});
 
 	test("bounds tracked entries and requests a full scan when the cap is exceeded", async () => {
@@ -110,7 +111,7 @@ describe("pollSessionPaths", () => {
 		const abort = new AbortController();
 		let now = 0;
 		let sleepCalls = 0;
-		const changes: Array<{ paths: string[]; requiresFullScan: boolean }> = [];
+		const changes: SessionWatchEvent[] = [];
 		try {
 			writeFileSync(join(root, "first.jsonl"), "first");
 			writeFileSync(join(root, "second.jsonl"), "second");
@@ -137,7 +138,7 @@ describe("pollSessionPaths", () => {
 				},
 			);
 
-			expect(changes).toEqual([{ paths: [], requiresFullScan: true }]);
+			expect(changes).toEqual([{ kind: "rescan" }]);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}
@@ -382,7 +383,7 @@ test("debounces rapid fs events into one concrete changed-path batch", async () 
 	const abort = new AbortController();
 	let onChange: (eventType?: string, filename?: string | Buffer | null) => void = () => {};
 	let fireStable = () => {};
-	const changes: Array<{ paths: string[]; requiresFullScan: boolean }> = [];
+	const changes: SessionWatchEvent[] = [];
 	try {
 		const running = watchSessions(
 			{
@@ -414,10 +415,10 @@ test("debounces rapid fs events into one concrete changed-path batch", async () 
 
 		expect(changes).toEqual([
 			{
+				kind: "paths",
 				paths: [join(root, "first.jsonl"), join(root, "archived/second.jsonl")],
-				requiresFullScan: false,
 			},
-			{ paths: [], requiresFullScan: true },
+			{ kind: "rescan" },
 		]);
 		abort.abort();
 		await running;

--- a/packages/cli/src/serve/sessions-watcher.ts
+++ b/packages/cli/src/serve/sessions-watcher.ts
@@ -11,7 +11,7 @@
  * OpenClaw) or SQLite database/sidecar files (Hermes). Any change
  * resets the adapter-wide quiescence timer. Concrete filenames are
  * accumulated across the window and handed to the adapter once stable;
- * ambiguous platform events retain an explicit full-scan fallback.
+ * ambiguous platform events request a complete rescan.
  *
  * Two modes mirror the skill watcher:
  *
@@ -29,14 +29,11 @@ import { log, toErrorMessage } from "./log";
 export interface SessionWatcherOptions {
 	paths: string[];
 	abort: AbortSignal;
-	onPathStable: (change: SessionWatchChange) => void;
+	onPathStable: (event: SessionWatchEvent) => void;
 	forcePoll?: boolean;
 }
 
-export interface SessionWatchChange {
-	paths: string[];
-	requiresFullScan: boolean;
-}
+export type SessionWatchEvent = { kind: "rescan" } | { kind: "paths"; paths: string[] };
 
 interface SessionFsWatcher {
 	close: () => void;
@@ -111,7 +108,7 @@ async function fsWatchLoop(
 ): Promise<void> {
 	const watchers: SessionFsWatcher[] = [];
 	const pendingPaths = new Set<string>();
-	let requiresFullScan = false;
+	let pendingRescan = false;
 	let cancelStableTimer: (() => void) | null = null;
 	let cleaned = false;
 	let settled = false;
@@ -157,18 +154,17 @@ async function fsWatchLoop(
 	const armStable = (path?: string) => {
 		if (settled || opts.abort.aborted) return;
 		if (path) pendingPaths.add(path);
-		else requiresFullScan = true;
+		else pendingRescan = true;
 		cancelStableTimer?.();
 		cancelStableTimer = dependencies.stableTimer.schedule(() => {
 			cancelStableTimer = null;
 			if (settled || opts.abort.aborted) return;
-			const change = {
-				paths: [...pendingPaths],
-				requiresFullScan,
-			};
+			const event: SessionWatchEvent = pendingRescan
+				? { kind: "rescan" }
+				: { kind: "paths", paths: [...pendingPaths] };
 			pendingPaths.clear();
-			requiresFullScan = false;
-			opts.onPathStable(change);
+			pendingRescan = false;
+			opts.onPathStable(event);
 		}, SESSION_STABLE_AFTER_MS);
 	};
 
@@ -282,7 +278,7 @@ export async function pollSessionPaths(
 
 	let stableDeadline: number | null = null;
 	const pendingPaths = new Set<string>();
-	let requiresFullScan = false;
+	let pendingRescan = false;
 	while (!opts.abort.aborted) {
 		const now = dependencies.now();
 		const delayMs =
@@ -303,7 +299,7 @@ export async function pollSessionPaths(
 				anyChanged = true;
 				const changedPaths = diffSnapshotEntries(prev.entries, cur.entries);
 				if (changedPaths === null || changedPaths.length === 0) {
-					requiresFullScan = true;
+					pendingRescan = true;
 				} else {
 					for (const changedPath of changedPaths) pendingPaths.add(changedPath);
 				}
@@ -317,13 +313,12 @@ export async function pollSessionPaths(
 		if (stableDeadline !== null && observedAt >= stableDeadline) {
 			stableDeadline = null;
 			if (opts.abort.aborted) return;
-			const change = {
-				paths: [...pendingPaths],
-				requiresFullScan,
-			};
+			const event: SessionWatchEvent = pendingRescan
+				? { kind: "rescan" }
+				: { kind: "paths", paths: [...pendingPaths] };
 			pendingPaths.clear();
-			requiresFullScan = false;
-			opts.onPathStable(change);
+			pendingRescan = false;
+			opts.onPathStable(event);
 		}
 	}
 }

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -11,7 +11,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import type { CollectSessionsResult, RawSession } from "../adapters/base";
+import type { RawSession } from "../adapters/base";
 import { adapterRegistry } from "../adapters/registry";
 import { AgentSkillSyncNotFoundError, ApiClient, ApiError } from "../lib/api-client";
 import { cacheKey, readSessionsLock } from "../lib/sessions-lock";
@@ -49,24 +49,13 @@ import {
 } from "./sync-engine";
 
 describe("stable session enqueue abort fence", () => {
-	it("does not enqueue after collection resolves into an abort", async () => {
+	it("does not enqueue after collection finishes into an abort", async () => {
 		const abort = new AbortController();
-		let resolveCollection: ((result: CollectSessionsResult) => void) | undefined;
-		const collection = new Promise<CollectSessionsResult>((resolve) => {
-			resolveCollection = resolve;
-		});
 		const queued: unknown[] = [];
 		const inFlight = new Map<string, string>();
-		const running = enqueueChangedSessionsAfterStability({
-			abort: abort.signal,
-			collectSessions: () => collection,
-			queue: { enqueue: (item: unknown) => queued.push(item) },
-			lastPushedHash: new Map(),
-			inFlightHash: inFlight,
-		});
-
 		abort.abort();
-		resolveCollection?.({
+		const enqueued = await enqueueChangedSessionsAfterStability({
+			abort: abort.signal,
 			sessions: [
 				{
 					localSessionId: "session-1",
@@ -85,10 +74,12 @@ describe("stable session enqueue abort fence", () => {
 					rawFilePath: "/sessions/1.jsonl",
 				},
 			],
-			dedupedCount: 0,
+			queue: { enqueue: (item: unknown) => queued.push(item) },
+			lastPushedHash: new Map(),
+			inFlightHash: inFlight,
 		});
 
-		expect(await running).toBe(0);
+		expect(enqueued).toBe(0);
 		expect(queued).toEqual([]);
 		expect(inFlight.size).toBe(0);
 	});
@@ -124,8 +115,7 @@ describe("Session deletion convergence", () => {
 				rawFilePath: "/sessions/deleted-session.jsonl",
 			};
 			const adapter = adapterRegistry.hermes.create();
-			adapter.collectSessions = async () => ({ sessions: [session], dedupedCount: 0 });
-			adapter.collectSession = async () => session;
+			adapter.resolveSession = async () => session;
 			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
 				const request = input instanceof Request ? input : new Request(input, init);
 				const path = new URL(request.url).pathname;
@@ -207,10 +197,7 @@ describe("Session deletion convergence", () => {
 		}
 	});
 
-	it.each([
-		"exact",
-		"fallback",
-	] as const)("re-reads newer session content at drain via the %s collector", async (mode) => {
+	it("re-reads newer session content at drain", async () => {
 		const root = mkdtempSync(join(tmpdir(), "session-current-drain-"));
 		const originalHome = process.env.HOME;
 		const originalState = process.env.CLAWDI_STATE_DIR;
@@ -220,7 +207,7 @@ describe("Session deletion convergence", () => {
 			process.env.HOME = root;
 			process.env.CLAWDI_STATE_DIR = join(root, "serve");
 			const enqueuedSession: RawSession = {
-				localSessionId: `current-session-${mode}`,
+				localSessionId: "current-session",
 				projectPath: "/project",
 				startedAt: new Date(0),
 				endedAt: new Date(1_000),
@@ -233,7 +220,7 @@ describe("Session deletion convergence", () => {
 				durationSeconds: 1,
 				summary: "current content",
 				messages: [{ role: "user", content: "before enqueue" }],
-				rawFilePath: `/sessions/current-session-${mode}.jsonl`,
+				rawFilePath: "/sessions/current-session.jsonl",
 			};
 			const currentSession: RawSession = {
 				...enqueuedSession,
@@ -250,20 +237,11 @@ describe("Session deletion convergence", () => {
 				.update(JSON.stringify(currentSession.messages))
 				.digest("hex");
 			const adapter = adapterRegistry.hermes.create();
-			let collectionCalls = 0;
-			adapter.collectSessions = async () => {
-				collectionCalls += 1;
-				return { sessions: [currentSession], dedupedCount: 0 };
+			let resolveCalls = 0;
+			adapter.resolveSession = async () => {
+				resolveCalls += 1;
+				return currentSession;
 			};
-			let exactCalls = 0;
-			if (mode === "exact") {
-				adapter.collectSession = async () => {
-					exactCalls += 1;
-					return currentSession;
-				};
-			} else {
-				Object.defineProperty(adapter, "collectSession", { value: undefined });
-			}
 			let sentMetadata: Record<string, unknown> | undefined;
 			let sentMessages: unknown;
 			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -323,8 +301,7 @@ describe("Session deletion convergence", () => {
 			);
 
 			expect(outcome).toBe("applied");
-			expect(exactCalls).toBe(mode === "exact" ? 1 : 0);
-			expect(collectionCalls).toBe(mode === "fallback" ? 1 : 0);
+			expect(resolveCalls).toBe(1);
 			expect(sentMetadata).toMatchObject({
 				content_hash: currentHash,
 				message_count: 2,

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -39,7 +39,7 @@ import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { components } from "@clawdi/shared/api";
-import type { AgentAdapter, CollectSessionsResult, RawSession } from "../adapters/base";
+import type { AgentAdapter, RawSession, SessionScanRequest } from "../adapters/base";
 import { AgentSkillSyncNotFoundError, ApiClient, ApiError, unwrap } from "../lib/api-client";
 import { computeLastActivityIso } from "../lib/session-activity";
 import { cacheKey, readSessionsLock, writeSessionsLock } from "../lib/sessions-lock";
@@ -63,7 +63,7 @@ import { log, toErrorMessage } from "./log";
 import { getServeStateDir } from "./paths";
 import { reconcileConnectedProjectSkills } from "./project-skill-reconcile";
 import { type QueueItem, RetryQueue } from "./queue";
-import { type SessionWatchChange, watchSessions } from "./sessions-watcher";
+import { type SessionWatchEvent, watchSessions } from "./sessions-watcher";
 import {
 	consumeSse,
 	type ServerEvent,
@@ -242,11 +242,10 @@ export class SyncHealth {
 
 interface StableSessionEnqueueOptions {
 	abort: AbortSignal;
-	collectSessions: () => Promise<CollectSessionsResult>;
+	sessions: readonly RawSession[];
 	queue: Pick<RetryQueue, "enqueue">;
 	lastPushedHash: ReadonlyMap<string, string>;
 	inFlightHash: Map<string, string>;
-	onPresentSessions?: (resources: ReadonlySet<string>) => void;
 }
 
 function sessionContentHash(session: RawSession): string {
@@ -257,11 +256,8 @@ export async function enqueueChangedSessionsAfterStability(
 	opts: StableSessionEnqueueOptions,
 ): Promise<number> {
 	if (opts.abort.aborted) return 0;
-	const { sessions } = await opts.collectSessions();
-	if (opts.abort.aborted) return 0;
-	opts.onPresentSessions?.(new Set(sessions.map((session) => `session:${session.localSessionId}`)));
 	let enqueued = 0;
-	for (const session of sessions) {
+	for (const session of opts.sessions) {
 		if (opts.abort.aborted) return enqueued;
 		const hash = sessionContentHash(session);
 		if (opts.lastPushedHash.get(session.localSessionId) === hash) continue;
@@ -782,39 +778,26 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 		}
 	};
 
-	// Prefer an adapter's bounded path collector for concrete watcher events.
-	// Ambiguous events and the periodic safety scan retain the complete scan.
-	const onSessionsStable = async (change?: SessionWatchChange) => {
+	const onSessionsStable = async (event?: SessionWatchEvent) => {
 		if (opts.abort.aborted) return;
 		try {
-			let completeInventory = true;
-			const collectSessions = async (): Promise<CollectSessionsResult> => {
-				if (
-					change &&
-					!change.requiresFullScan &&
-					change.paths.length > 0 &&
-					opts.adapter.collectSessionsForPaths
-				) {
-					const targeted = await opts.adapter.collectSessionsForPaths(change.paths);
-					if (targeted !== null) {
-						completeInventory = false;
-						return targeted;
-					}
-				}
-				const complete = await opts.adapter.collectSessions();
-				return complete;
-			};
+			const request: SessionScanRequest = event?.kind === "paths" ? event : { kind: "complete" };
+			const result = await opts.adapter.collectSessions(request);
 			const enqueued = await enqueueChangedSessionsAfterStability({
 				abort: opts.abort,
-				collectSessions,
+				sessions: result.sessions,
 				queue,
 				lastPushedHash: lastPushedSessionHash,
 				inFlightHash: inFlightSessionHash,
-				onPresentSessions: (resources) => {
-					if (completeInventory) syncHealth.clearAbsent("push", "session:", resources);
-				},
 			});
 			if (opts.abort.aborted) return;
+			if (result.coverage === "complete") {
+				syncHealth.clearAbsent(
+					"push",
+					"session:",
+					new Set(result.sessions.map((session) => `session:${session.localSessionId}`)),
+				);
+			}
 			syncHealth.clear("push", "session_scan");
 			if (enqueued > 0) {
 				log.info("engine.sessions_enqueued", { count: enqueued });
@@ -1558,15 +1541,6 @@ export async function processQueueItem(
 	return "not_applied";
 }
 
-async function resolveQueuedSession(
-	adapter: AgentAdapter,
-	localSessionId: string,
-): Promise<RawSession | null> {
-	if (adapter.collectSession) return adapter.collectSession(localSessionId);
-	const { sessions } = await adapter.collectSessions();
-	return sessions.find((session) => session.localSessionId === localSessionId) ?? null;
-}
-
 /** Upload a single session via the same two-step `clawdi push`
  * uses: POST /api/sessions/batch (metadata) → POST
  * /api/sessions/{id}/upload (content) when the server says it
@@ -1585,7 +1559,7 @@ async function uploadSessionFromQueue(
 ): Promise<
 	{ outcome: "applied"; actualHash: string } | { outcome: "absent" } | { outcome: "not_applied" }
 > {
-	const session = await resolveQueuedSession(opts.adapter, item.local_session_id);
+	const session = await opts.adapter.resolveSession(item.local_session_id);
 	if (!session) {
 		log.info("engine.session_gone", { local_session_id: item.local_session_id });
 		return { outcome: "absent" };

--- a/packages/cli/tests/adapters/claude-code.test.ts
+++ b/packages/cli/tests/adapters/claude-code.test.ts
@@ -76,7 +76,7 @@ describe("ClaudeCodeAdapter.detect", () => {
 describe("ClaudeCodeAdapter.collectSessions", () => {
 	it("parses the fixture session with correct tokens and model", async () => {
 		const a = new ClaudeCodeAdapter();
-		const { sessions, dedupedCount } = await a.collectSessions();
+		const { sessions, dedupedCount } = await a.collectSessions({ kind: "complete" });
 		expect(sessions).toHaveLength(1);
 		expect(dedupedCount).toBe(0);
 		const s = sessions[0]!;
@@ -97,16 +97,22 @@ describe("ClaudeCodeAdapter.collectSessions", () => {
 
 	it("extracts text from array content blocks (type:text)", async () => {
 		const a = new ClaudeCodeAdapter();
-		const { sessions } = await a.collectSessions();
+		const { sessions } = await a.collectSessions({ kind: "complete" });
 		const texts = sessions[0]?.messages.map((m) => m.content);
 		expect(texts).toEqual(["hello", "world", "one more", "done"]);
 	});
 
 	it("filters by projectFilter (matching cwd → encoded dir)", async () => {
 		const a = new ClaudeCodeAdapter();
-		const matched = await a.collectSessions({ projectFilter: "/Users/fixture/project" });
+		const matched = await a.collectSessions({
+			kind: "complete",
+			projectFilter: "/Users/fixture/project",
+		});
 		expect(matched.sessions).toHaveLength(1);
-		const notMatched = await a.collectSessions({ projectFilter: "/Users/other/project" });
+		const notMatched = await a.collectSessions({
+			kind: "complete",
+			projectFilter: "/Users/other/project",
+		});
 		expect(notMatched.sessions).toHaveLength(0);
 	});
 
@@ -114,14 +120,14 @@ describe("ClaudeCodeAdapter.collectSessions", () => {
 		const shortPath = join(tmpHome, ".claude", "projects", "-Users-fixture-project", "short.jsonl");
 		writeFileSync(shortPath, `${JSON.stringify({ timestamp: "2026-04-20T10:00:00Z" })}\n`);
 		const a = new ClaudeCodeAdapter();
-		const { sessions } = await a.collectSessions();
+		const { sessions } = await a.collectSessions({ kind: "complete" });
 		// original long session still counts, short file is skipped
 		expect(sessions).toHaveLength(1);
 	});
 
 	it("first user message populates the summary (capped at 200 chars)", async () => {
 		const a = new ClaudeCodeAdapter();
-		const s = (await a.collectSessions()).sessions[0]!;
+		const s = (await a.collectSessions({ kind: "complete" })).sessions[0]!;
 		expect(s.summary).toBe("hello");
 	});
 
@@ -138,8 +144,12 @@ describe("ClaudeCodeAdapter.collectSessions", () => {
 			"-Users-fixture-project",
 			"11111111-2222-3333-4444-555555555555.jsonl",
 		);
-		const result = await new ClaudeCodeAdapter().collectSessionsForPaths([changedPath]);
-		expect(result?.sessions.map((session) => session.localSessionId)).toEqual([
+		const result = await new ClaudeCodeAdapter().collectSessions({
+			kind: "paths",
+			paths: [changedPath],
+		});
+		expect(result.coverage).toBe("partial");
+		expect(result.sessions.map((session) => session.localSessionId)).toEqual([
 			"11111111-2222-3333-4444-555555555555",
 		]);
 	});
@@ -210,7 +220,7 @@ describe("ClaudeCodeAdapter dedupeResumeChains", () => {
 		const predecessorUuids = uuidRange("queued", 12);
 		writeResumeSessionFile({ cwd, sessionId: "queued-predecessor", uuids: predecessorUuids });
 		const adapter = new ClaudeCodeAdapter();
-		expect(await adapter.collectSession("queued-predecessor")).not.toBeNull();
+		expect(await adapter.resolveSession("queued-predecessor")).not.toBeNull();
 
 		writeResumeSessionFile({
 			cwd,
@@ -218,8 +228,8 @@ describe("ClaudeCodeAdapter dedupeResumeChains", () => {
 			uuids: [...predecessorUuids, ...uuidRange("new", 4)],
 		});
 
-		expect(await adapter.collectSession("queued-predecessor")).toBeNull();
-		expect((await adapter.collectSession("new-successor"))?.localSessionId).toBe("new-successor");
+		expect(await adapter.resolveSession("queued-predecessor")).toBeNull();
+		expect((await adapter.resolveSession("new-successor"))?.localSessionId).toBe("new-successor");
 	});
 
 	it("dedupes A when A.uuids ⊂ B.uuids in the same project (resume chain)", async () => {
@@ -236,7 +246,7 @@ describe("ClaudeCodeAdapter dedupeResumeChains", () => {
 		});
 
 		const adapter = new ClaudeCodeAdapter();
-		const result = await adapter.collectSessions({ projectFilter: cwd });
+		const result = await adapter.collectSessions({ kind: "complete", projectFilter: cwd });
 
 		expect(result.dedupedCount).toBe(1);
 		expect(result.sessions.map((s) => s.localSessionId)).toEqual(["bbbb-bbbb"]);
@@ -253,7 +263,7 @@ describe("ClaudeCodeAdapter dedupeResumeChains", () => {
 		writeResumeSessionFile({ cwd, sessionId: "cccc-cccc", uuids: cUuids });
 
 		const adapter = new ClaudeCodeAdapter();
-		const result = await adapter.collectSessions({ projectFilter: cwd });
+		const result = await adapter.collectSessions({ kind: "complete", projectFilter: cwd });
 
 		expect(result.dedupedCount).toBe(2);
 		expect(result.sessions.map((s) => s.localSessionId)).toEqual(["cccc-cccc"]);
@@ -275,7 +285,7 @@ describe("ClaudeCodeAdapter dedupeResumeChains", () => {
 		});
 
 		const adapter = new ClaudeCodeAdapter();
-		const result = await adapter.collectSessions();
+		const result = await adapter.collectSessions({ kind: "complete" });
 		// project to just the two we wrote — the fixture's pre-existing session
 		// would otherwise pad the result count
 		const ours = result.sessions.filter((s) =>
@@ -296,7 +306,7 @@ describe("ClaudeCodeAdapter dedupeResumeChains", () => {
 		writeResumeSessionFile({ cwd, sessionId: "bbbb-bbbb", uuids: bUuids });
 
 		const adapter = new ClaudeCodeAdapter();
-		const result = await adapter.collectSessions({ projectFilter: cwd });
+		const result = await adapter.collectSessions({ kind: "complete", projectFilter: cwd });
 
 		expect(result.dedupedCount).toBe(0);
 		expect(result.sessions.map((s) => s.localSessionId).sort()).toEqual(["aaaa-aaaa", "bbbb-bbbb"]);
@@ -311,7 +321,7 @@ describe("ClaudeCodeAdapter dedupeResumeChains", () => {
 		writeResumeSessionFile({ cwd, sessionId: "bbbb-bbbb", uuids: bUuids });
 
 		const adapter = new ClaudeCodeAdapter();
-		const result = await adapter.collectSessions({ projectFilter: cwd });
+		const result = await adapter.collectSessions({ kind: "complete", projectFilter: cwd });
 
 		expect(result.dedupedCount).toBe(0);
 		expect(result.sessions.map((s) => s.localSessionId).sort()).toEqual(["aaaa-aaaa", "bbbb-bbbb"]);
@@ -322,7 +332,7 @@ describe("ClaudeCodeAdapter dedupeResumeChains", () => {
 		writeResumeSessionFile({ cwd, sessionId: "aaaa-aaaa", uuids: uuidRange("u", 15) });
 
 		const adapter = new ClaudeCodeAdapter();
-		const result = await adapter.collectSessions({ projectFilter: cwd });
+		const result = await adapter.collectSessions({ kind: "complete", projectFilter: cwd });
 
 		expect(result.dedupedCount).toBe(0);
 		expect(result.sessions).toHaveLength(1);
@@ -429,12 +439,5 @@ describe("ClaudeCodeAdapter.writeSkillArchive + getSkillPath", () => {
 	it("getSkillPath returns skills/<key>/SKILL.md under Claude home", () => {
 		const a = new ClaudeCodeAdapter();
 		expect(a.getSkillPath("xyz")).toBe(join(tmpHome, ".claude", "skills", "xyz", "SKILL.md"));
-	});
-});
-
-describe("ClaudeCodeAdapter.buildRunCommand", () => {
-	it("prefixes args with claude", () => {
-		const a = new ClaudeCodeAdapter();
-		expect(a.buildRunCommand(["--help"], {})).toEqual(["claude", "--help"]);
 	});
 });

--- a/packages/cli/tests/adapters/codex.test.ts
+++ b/packages/cli/tests/adapters/codex.test.ts
@@ -48,7 +48,7 @@ describe("CodexAdapter.collectSessions", () => {
 
 	it("parses the fixture session with session_meta + turn_context + messages + token_count", async () => {
 		const a = new CodexAdapter();
-		const { sessions } = await a.collectSessions();
+		const { sessions } = await a.collectSessions({ kind: "complete" });
 		expect(sessions).toHaveLength(1);
 		const s = sessions[0]!;
 		expect(s).toMatchObject({
@@ -73,22 +73,24 @@ describe("CodexAdapter.collectSessions", () => {
 	it("filters by projectFilter", async () => {
 		const a = new CodexAdapter();
 		expect(
-			(await a.collectSessions({ projectFilter: "/Users/fixture/project" })).sessions,
+			(await a.collectSessions({ kind: "complete", projectFilter: "/Users/fixture/project" }))
+				.sessions,
 		).toHaveLength(1);
 		expect(
-			(await a.collectSessions({ projectFilter: "/Users/other/project" })).sessions,
+			(await a.collectSessions({ kind: "complete", projectFilter: "/Users/other/project" }))
+				.sessions,
 		).toHaveLength(0);
 	});
 
 	it("returns empty when sessions dir is missing", async () => {
 		rmSync(join(tmpHome, ".codex", "sessions"), { recursive: true, force: true });
 		const a = new CodexAdapter();
-		expect((await a.collectSessions()).sessions).toEqual([]);
+		expect((await a.collectSessions({ kind: "complete" })).sessions).toEqual([]);
 	});
 
 	it("summary skips <environment_context> prefix user messages", async () => {
 		const a = new CodexAdapter();
-		const s = (await a.collectSessions()).sessions[0]!;
+		const s = (await a.collectSessions({ kind: "complete" })).sessions[0]!;
 		// First non-environment_context user message is "hello"
 		expect(s.summary).toBe("hello");
 	});
@@ -116,14 +118,16 @@ describe("CodexAdapter.collectSessions", () => {
 
 		const adapter = new CodexAdapter();
 		expect(
-			(await adapter.collectSessions()).sessions.map((session) => session.localSessionId),
+			(await adapter.collectSessions({ kind: "complete" })).sessions.map(
+				(session) => session.localSessionId,
+			),
 		).toEqual(["019ae46c-52d9-7e51-9527-1b105eb42d1b", "019ae46c-52d9-7e51-9527-1b105eb42d2c"]);
 		expect(adapter.getSessionsWatchPaths()).toEqual([
 			join(tmpHome, ".codex", "sessions"),
 			archivedRoot,
 		]);
 		expect(
-			(await adapter.collectSessionsForPaths([archivedPath]))?.sessions.map(
+			(await adapter.collectSessions({ kind: "paths", paths: [archivedPath] })).sessions.map(
 				(session) => session.localSessionId,
 			),
 		).toEqual(["019ae46c-52d9-7e51-9527-1b105eb42d2c"]);
@@ -135,12 +139,12 @@ describe("CodexAdapter.collectSessions", () => {
 		mkdirSync(join(tmpHome, ".codex", "archived_sessions"), { recursive: true });
 
 		const adapter = new CodexAdapter();
-		const learned = (await adapter.collectSessions()).sessions[0];
+		const learned = (await adapter.collectSessions({ kind: "complete" })).sessions[0];
 		if (!learned) throw new Error("expected Codex session fixture");
 		expect(learned.localSessionId).toBe(sessionId);
 		renameSync(learned.rawFilePath, archivedPath);
 
-		expect(await adapter.collectSession(sessionId)).toMatchObject({
+		expect(await adapter.resolveSession(sessionId)).toMatchObject({
 			localSessionId: sessionId,
 			rawFilePath: archivedPath,
 		});
@@ -168,12 +172,5 @@ describe("CodexAdapter.writeSkillArchive + getSkillPath", () => {
 		const extracted = join(tmpHome, ".codex", "skills", "demo", "SKILL.md");
 		expect(existsSync(extracted)).toBe(true);
 		expect(readFileSync(extracted, "utf-8")).toContain("name: demo");
-	});
-});
-
-describe("CodexAdapter.buildRunCommand", () => {
-	it("prefixes args with codex", () => {
-		const a = new CodexAdapter();
-		expect(a.buildRunCommand(["exec"], {})).toEqual(["codex", "exec"]);
 	});
 });

--- a/packages/cli/tests/adapters/hermes.test.ts
+++ b/packages/cli/tests/adapters/hermes.test.ts
@@ -46,7 +46,7 @@ describe("HermesAdapter.detect", () => {
 describe("HermesAdapter.collectSessions", () => {
 	it("returns the plain-string-model session with correct token counters", async () => {
 		const a = new HermesAdapter();
-		const { sessions } = await a.collectSessions();
+		const { sessions } = await a.collectSessions({ kind: "complete" });
 		const plain = sessions.find((s) => s.localSessionId === "s-plain");
 		expect(plain).toBeDefined();
 		expect(plain).toMatchObject({
@@ -63,13 +63,13 @@ describe("HermesAdapter.collectSessions", () => {
 		expect(plain?.messages[0]?.content).toBe("hello");
 		expect(plain?.messages[1]?.role).toBe("assistant");
 		expect(plain?.messages[1]?.model).toBe("claude-opus-4-7");
-		expect((await a.collectSession("s-plain"))?.messages).toEqual(plain?.messages);
-		expect(await a.collectSession("missing-session")).toBeNull();
+		expect((await a.resolveSession("s-plain"))?.messages).toEqual(plain?.messages);
+		expect(await a.resolveSession("missing-session")).toBeNull();
 	});
 
 	it("parses a JSON-blob model field via parseModelField", async () => {
 		const a = new HermesAdapter();
-		const { sessions } = await a.collectSessions();
+		const { sessions } = await a.collectSessions({ kind: "complete" });
 		const json = sessions.find((s) => s.localSessionId === "s-json");
 		expect(json).toBeDefined();
 		expect(json?.model).toBe("gpt-5.3-codex");
@@ -86,7 +86,7 @@ describe("HermesAdapter.collectSessions", () => {
 		db.close();
 
 		const a = new HermesAdapter();
-		const { sessions } = await a.collectSessions();
+		const { sessions } = await a.collectSessions({ kind: "complete" });
 		const json = sessions.find((s) => s.localSessionId === "s-json");
 		expect(json?.model).toBe("gpt-5.3-codex");
 		expect(json?.modelsUsed).toEqual(["gpt-5.3-codex"]);
@@ -94,26 +94,26 @@ describe("HermesAdapter.collectSessions", () => {
 
 	it("skips sessions with no extractable messages", async () => {
 		const a = new HermesAdapter();
-		const { sessions } = await a.collectSessions();
+		const { sessions } = await a.collectSessions({ kind: "complete" });
 		expect(sessions.find((s) => s.localSessionId === "s-empty")).toBeUndefined();
 	});
 
 	it("orders sessions by started_at DESC", async () => {
 		const a = new HermesAdapter();
-		const { sessions } = await a.collectSessions();
+		const { sessions } = await a.collectSessions({ kind: "complete" });
 		// s-json started later than s-plain; s-empty is filtered out
 		expect(sessions.map((s) => s.localSessionId)).toEqual(["s-json", "s-plain"]);
 	});
 
 	it("projectPath is null for every Hermes session (by design)", async () => {
 		const a = new HermesAdapter();
-		const { sessions } = await a.collectSessions();
+		const { sessions } = await a.collectSessions({ kind: "complete" });
 		for (const s of sessions) expect(s.projectPath).toBeNull();
 	});
 
 	it("rawFilePath includes the session id anchor", async () => {
 		const a = new HermesAdapter();
-		const { sessions } = await a.collectSessions();
+		const { sessions } = await a.collectSessions({ kind: "complete" });
 		expect(sessions[0]?.rawFilePath).toContain("state.db#");
 	});
 });
@@ -184,12 +184,5 @@ describe("HermesAdapter.writeSkillArchive + getSkillPath", () => {
 		const a = new HermesAdapter();
 		const p = a.getSkillPath("foo");
 		expect(p).toBe(join(tmpHome, ".hermes", "skills", "foo", "SKILL.md"));
-	});
-});
-
-describe("HermesAdapter.buildRunCommand", () => {
-	it("prefixes arguments with the hermes binary", () => {
-		const a = new HermesAdapter();
-		expect(a.buildRunCommand(["hello", "world"], {})).toEqual(["hermes", "hello", "world"]);
 	});
 });

--- a/packages/cli/tests/adapters/openclaw.test.ts
+++ b/packages/cli/tests/adapters/openclaw.test.ts
@@ -135,7 +135,7 @@ describe("OpenClawAdapter.detect", () => {
 describe("OpenClawAdapter.collectSessions", () => {
 	it("parses the fixture session with index metadata + transcript messages", async () => {
 		const a = new OpenClawAdapter();
-		const { sessions, dedupedCount } = await a.collectSessions();
+		const { sessions, dedupedCount } = await a.collectSessions({ kind: "complete" });
 		expect(sessions).toHaveLength(1);
 		expect(dedupedCount).toBe(0);
 		const s = sessions[0]!;
@@ -159,17 +159,19 @@ describe("OpenClawAdapter.collectSessions", () => {
 
 	it("uses displayName as summary", async () => {
 		const a = new OpenClawAdapter();
-		const s = (await a.collectSessions()).sessions[0]!;
+		const s = (await a.collectSessions({ kind: "complete" })).sessions[0]!;
 		expect(s.summary).toBe("Fixture session");
 	});
 
 	it("filters by projectFilter matching acp.cwd", async () => {
 		const a = new OpenClawAdapter();
 		expect(
-			(await a.collectSessions({ projectFilter: "/Users/fixture/project" })).sessions,
+			(await a.collectSessions({ kind: "complete", projectFilter: "/Users/fixture/project" }))
+				.sessions,
 		).toHaveLength(1);
 		expect(
-			(await a.collectSessions({ projectFilter: "/Users/other/project" })).sessions,
+			(await a.collectSessions({ kind: "complete", projectFilter: "/Users/other/project" }))
+				.sessions,
 		).toHaveLength(0);
 	});
 
@@ -182,7 +184,7 @@ describe("OpenClawAdapter.collectSessions", () => {
 		// accident.)
 		rmSync(join(tmpHome, ".openclaw", "agents", "main"), { recursive: true, force: true });
 		const a = new OpenClawAdapter();
-		expect((await a.collectSessions()).sessions).toEqual([]);
+		expect((await a.collectSessions({ kind: "complete" })).sessions).toEqual([]);
 	});
 
 	it("scans every agents/<id>/ subdir (issue #28)", async () => {
@@ -190,7 +192,7 @@ describe("OpenClawAdapter.collectSessions", () => {
 		// are picked up without setting OPENCLAW_AGENT_ID.
 		addFinancialAgent(join(tmpHome, ".openclaw"));
 		const a = new OpenClawAdapter();
-		const { sessions } = await a.collectSessions();
+		const { sessions } = await a.collectSessions({ kind: "complete" });
 		const ids = sessions.map((s) => s.localSessionId).sort();
 		expect(ids).toEqual(["oc-financial-001", "oc-session-001"]);
 	});
@@ -203,17 +205,24 @@ describe("OpenClawAdapter.collectSessions", () => {
 		expect(adapter.getSessionsWatchPaths().sort()).toEqual(
 			[mainSessions, financialSessions].sort(),
 		);
-		expect(
-			(
-				await adapter.collectSessionsForPaths([join(financialSessions, "oc-financial-001.jsonl")])
-			)?.sessions.map((session) => session.localSessionId),
-		).toEqual(["oc-financial-001"]);
-		expect(
-			await adapter.collectSessionsForPaths([
+		const bounded = await adapter.collectSessions({
+			kind: "paths",
+			paths: [join(financialSessions, "oc-financial-001.jsonl")],
+		});
+		expect(bounded.coverage).toBe("partial");
+		expect(bounded.sessions.map((session) => session.localSessionId)).toEqual(["oc-financial-001"]);
+		const ambiguous = await adapter.collectSessions({
+			kind: "paths",
+			paths: [
 				join(financialSessions, "sessions.json"),
 				join(financialSessions, "oc-financial-001.jsonl"),
-			]),
-		).toBeNull();
+			],
+		});
+		expect(ambiguous.coverage).toBe("complete");
+		expect(ambiguous.sessions.map((session) => session.localSessionId).sort()).toEqual([
+			"oc-financial-001",
+			"oc-session-001",
+		]);
 	});
 
 	it("handles production schema: composite index keys + absolute sessionFile", async () => {
@@ -259,7 +268,7 @@ describe("OpenClawAdapter.collectSessions", () => {
 		);
 
 		const a = new OpenClawAdapter();
-		const { sessions } = await a.collectSessions();
+		const { sessions } = await a.collectSessions({ kind: "complete" });
 		expect(sessions).toHaveLength(1);
 		const s = sessions[0]!;
 		// localSessionId must be the UUID, not the composite index key.
@@ -272,7 +281,7 @@ describe("OpenClawAdapter.collectSessions", () => {
 		addFinancialAgent(join(tmpHome, ".openclaw"));
 		process.env.OPENCLAW_AGENT_ID = "financial";
 		const a = new OpenClawAdapter();
-		const { sessions } = await a.collectSessions();
+		const { sessions } = await a.collectSessions({ kind: "complete" });
 		expect(sessions.map((s) => s.localSessionId)).toEqual(["oc-financial-001"]);
 	});
 });
@@ -322,12 +331,5 @@ describe("OpenClawAdapter.writeSkillArchive + getSkillPath", () => {
 		const extracted = join(tmpHome, ".openclaw", "agents", "main", "skills", "demo", "SKILL.md");
 		expect(existsSync(extracted)).toBe(true);
 		expect(readFileSync(extracted, "utf-8")).toContain("name: demo");
-	});
-});
-
-describe("OpenClawAdapter.buildRunCommand", () => {
-	it("prefixes args with openclaw", () => {
-		const a = new OpenClawAdapter();
-		expect(a.buildRunCommand(["run"], {})).toEqual(["openclaw", "run"]);
 	});
 });


### PR DESCRIPTION
## Summary

- Replace the optional Session collector/fallback protocol with one mandatory `collectSessions(request)` contract and explicit `complete | partial` coverage.
- Make watcher events discriminated, queue-time Session resolution mandatory, and the engine path straight-line while preserving adapter-owned safe full-scan fallback.
- Remove dead `buildRunCommand` code and its prefix-only tests, and share the small path-containment helper used by Claude Code, Codex, and OpenClaw.
- Keep Skill behavior mandatory and unchanged; the deferred `SkillStore` boundary still waits for the first real session-only adapter.

The implementation and affected tests are net `-106` lines. No compatibility shim or fake capability matrix was added.

## Compatibility

- Session message hashing remains byte-for-byte `sha256(JSON.stringify(session.messages))`.
- API payloads, queue/lock formats, CLI commands/output, Agent types, Skill workflows, and Hosted/Connected ownership boundaries are unchanged.
- Claude resume-chain suppression, Codex active/archive recovery, OpenClaw personality discovery, Hermes lookup, and the periodic complete recovery scan are preserved.

## Release

- Bump the CLI package and lockfile to `clawdi@0.13.106`.
- The changelog includes the still-unreleased Session scan/search/read work from #1109.
- Merging this PR triggers the existing immutable CLI publish workflow for npm `latest` and `clawdi-cli-v0.13.106`.

## Verification

- `bun run check`: passed (1045 files).
- `bun run typecheck`: passed (4/4 workspace tasks).
- CLI publish manifest and CLI typecheck: passed.
- Full CLI suite: `1718 pass / 4 skip / 0 fail`.
- `git diff --check origin/main...HEAD`: passed.
- The root JavaScript test stage passed. The full backend stage reported only `test_runtime_bundle_matches_shared_golden`; the same failure reproduces unchanged on clean `origin/main`, and this PR changes no backend or fixture files.