### PR TITLE
fix(cli): preserve hosted runtime timezone

### DIFF
--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -2089,7 +2089,10 @@ chmod 0755 '${commandPath}'
 		);
 		chmodSync(openclawBin, 0o700);
 
-		const legacy = hostedOpenClawV2ManifestFixture({}, LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS);
+		const legacy = hostedOpenClawV2ManifestFixture(
+			{ locale: { language: "es", timezone: "Europe/Madrid" } },
+			LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS,
+		);
 		const hosted = hostedRuntimeBundleV2ManifestSchema.parse(legacy);
 		const projected = hostedManifestToRuntimeManifest(hosted);
 		expect(projected.runtimes.openclaw.run?.args).toEqual(["gateway", "run"]);
@@ -2139,6 +2142,7 @@ chmod 0755 '${commandPath}'
 			join(paths.systemdEnvRoot, "openclaw-gateway.service.env"),
 			"utf8",
 		);
+		expect(gatewayEnv).toContain('TZ="Europe/Madrid"');
 		expect(gatewayEnv).not.toContain("OPENCLAW_GATEWAY_TOKEN");
 		expect(gatewayEnv).not.toContain("gateway-token");
 		const gatewayDropIn = readFileSync(

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -1480,6 +1480,7 @@ function writeRuntimeSystemdUserProgram(input: {
 				CLAWDI_HOME: input.paths.clawdiHome,
 				CLAWDI_RUNTIME_REV: revision,
 			};
+	if (input.manifest.locale) env.TZ = input.manifest.locale.timezone;
 	if (officialRuntimeServiceInstallArgs(program)) {
 		return writeSystemdUserEnvironmentDropIn({
 			paths: input.paths,


### PR DESCRIPTION
## Summary

- preserve the manifest timezone when projecting the official Hosted OpenClaw systemd environment
- cover the final environment file in the existing hosted reconciliation test

## Verification

- focused Biome check
- CLI typecheck in Docker
- runtime reconciliation tests: 213 pass, 0 fail
- git diff --check