### PR TITLE
fix(cli): isolate hosted runtime user secrets

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -28,6 +28,7 @@ import {
 } from "../lib/vault-errors";
 import { applyEgressTransparentRuntimeEnv } from "../runtime/egress-env";
 import { detectRuntimeMode, getRuntimePaths } from "../runtime/paths";
+import { clearPlatformCredentialEnv } from "../runtime/platform-credential-env";
 import {
 	buildRuntimeRunInvocation,
 	type RuntimeRunConfigRead,
@@ -335,7 +336,7 @@ async function spawnRuntimeInvocation(
 	invocation: RuntimeRunInvocation,
 	spawnImpl: SpawnFn,
 ): Promise<void> {
-	delete invocation.env.CLAWDI_AUTH_TOKEN;
+	clearPlatformCredentialEnv(invocation.env);
 	let childSpawn: RuntimeChildSpawn;
 	try {
 		childSpawn = buildRuntimeChildSpawn(invocation);
@@ -388,8 +389,7 @@ function runtimeChildEnv(
 	runtimeUser: string | undefined,
 ): NodeJS.ProcessEnv {
 	const childEnv = { ...env };
-	delete childEnv.CLAWDI_AUTH_TOKEN;
-	delete childEnv.CLAWDI_EGRESS_SECRET_FILE;
+	clearPlatformCredentialEnv(childEnv);
 	if (runtimeUser && runtimeUser !== "root") {
 		childEnv.HOME ||= `/home/${runtimeUser}`;
 	}

--- a/packages/cli/src/runtime/platform-credential-env.ts
+++ b/packages/cli/src/runtime/platform-credential-env.ts
@@ -1,0 +1,9 @@
+const PLATFORM_CREDENTIAL_ENV_KEYS = [
+	"CLAWDI_AUTH_TOKEN",
+	"CLAWDI_DAEMON_RPC_TOKEN",
+	"CLAWDI_EGRESS_SECRET_FILE",
+] as const;
+
+export function clearPlatformCredentialEnv(env: NodeJS.ProcessEnv): void {
+	for (const key of PLATFORM_CREDENTIAL_ENV_KEYS) delete env[key];
+}

--- a/packages/cli/src/runtime/runtime-user-command.test.ts
+++ b/packages/cli/src/runtime/runtime-user-command.test.ts
@@ -46,6 +46,48 @@ test("tenant tools inherit HOME but not platform location overrides", () => {
 	});
 });
 
+test("runtime-user commands exclude platform credentials and tenant-writable PATH entries", () => {
+	const previousPath = process.env.PATH;
+	const previousAuthToken = process.env.CLAWDI_AUTH_TOKEN;
+	const previousDaemonToken = process.env.CLAWDI_DAEMON_RPC_TOKEN;
+	const previousEgressSecretFile = process.env.CLAWDI_EGRESS_SECRET_FILE;
+	const home = "/home/clawdi";
+	try {
+		process.env.PATH = `${join(home, ".local", "bin")}:${join(home, ".openclaw", "bin")}:/usr/local/bin:/usr/bin`;
+		process.env.CLAWDI_AUTH_TOKEN = "platform-auth-token";
+		process.env.CLAWDI_DAEMON_RPC_TOKEN = "platform-daemon-token";
+		process.env.CLAWDI_EGRESS_SECRET_FILE = "/run/clawdi/egress-secrets.json";
+
+		const result = spawnRuntimeUserCommand(
+			process.execPath,
+			["-e", "process.stdout.write(JSON.stringify(process.env))"],
+			home,
+			tmpdir(),
+			{
+				runtimeUser: "clawdi",
+				runtimeUid: 10_001,
+				resolver: { resolve: () => "none" },
+			},
+		);
+		const env = JSON.parse(String(result.stdout)) as NodeJS.ProcessEnv;
+
+		expect(result.status).toBe(0);
+		expect(env.CLAWDI_AUTH_TOKEN).toBeUndefined();
+		expect(env.CLAWDI_DAEMON_RPC_TOKEN).toBeUndefined();
+		expect(env.CLAWDI_EGRESS_SECRET_FILE).toBeUndefined();
+		expect(env.PATH).toBe("/usr/local/bin:/usr/bin");
+	} finally {
+		if (previousPath === undefined) delete process.env.PATH;
+		else process.env.PATH = previousPath;
+		if (previousAuthToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;
+		else process.env.CLAWDI_AUTH_TOKEN = previousAuthToken;
+		if (previousDaemonToken === undefined) delete process.env.CLAWDI_DAEMON_RPC_TOKEN;
+		else process.env.CLAWDI_DAEMON_RPC_TOKEN = previousDaemonToken;
+		if (previousEgressSecretFile === undefined) delete process.env.CLAWDI_EGRESS_SECRET_FILE;
+		else process.env.CLAWDI_EGRESS_SECRET_FILE = previousEgressSecretFile;
+	}
+});
+
 test("isolated runtime commands override and clear native state locations", () => {
 	const root = mkdtempSync(join(tmpdir(), "runtime-user-isolation-"));
 	const output = join(root, "environment.json");

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -3,9 +3,11 @@ import { accessSync, chownSync, constants } from "node:fs";
 import { isAbsolute, join } from "node:path";
 import { withEffectiveFilesystemIdentity } from "./effective-identity";
 import { applyEgressTransparentRuntimeEnv } from "./egress-env";
+import { clearPlatformCredentialEnv } from "./platform-credential-env";
 import { parsePositiveLinuxId } from "./transparent-egress";
 
 const RUNTIME_IDENTITY_PROBE_TIMEOUT_MS = 5_000;
+const DEFAULT_SYSTEM_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 
 export interface RuntimeUserIdentity {
 	uid: number;
@@ -283,12 +285,14 @@ function runtimeUserCommandEnv(
 	} = {},
 ): NodeJS.ProcessEnv {
 	const runtimeDir = runtimeUid === null ? null : `/run/user/${runtimeUid}`;
+	const tenantBinPaths = [join(home, ".local", "bin"), join(home, ".openclaw", "bin")];
 	const env: NodeJS.ProcessEnv = {
 		...process.env,
 		HOME: home,
-		PATH: [join(home, ".local", "bin"), join(home, ".openclaw", "bin"), process.env.PATH]
-			.filter(Boolean)
-			.join(":"),
+		PATH:
+			runtimeUid === null
+				? [...tenantBinPaths, process.env.PATH].filter(Boolean).join(":")
+				: runtimeUserSystemPath(tenantBinPaths),
 		...(runtimeDir
 			? {
 					XDG_RUNTIME_DIR: runtimeDir,
@@ -304,7 +308,17 @@ function runtimeUserCommandEnv(
 	if (options.egressSystemCaFile) {
 		applyEgressTransparentRuntimeEnv(env, { caFile: options.egressSystemCaFile });
 	}
+	clearPlatformCredentialEnv(env);
 	return env;
+}
+
+function runtimeUserSystemPath(tenantBinPaths: readonly string[]): string {
+	const inheritedPath = process.env.PATH || DEFAULT_SYSTEM_PATH;
+	const path = inheritedPath
+		.split(":")
+		.filter((entry) => entry && !tenantBinPaths.includes(entry))
+		.join(":");
+	return path || DEFAULT_SYSTEM_PATH;
 }
 
 export function clearTenantToolLocationOverrides(env: NodeJS.ProcessEnv): void {
@@ -411,12 +425,14 @@ export function spawnRuntimeUserCommand(
 				resolver: options.resolver,
 			})
 		: { command, args, env: {} };
+	const env = {
+		...runtimeUserCommandEnv(home, runtimeUid, options),
+		...child.env,
+		...options.environment,
+	};
+	clearPlatformCredentialEnv(env);
 	return spawnSync(child.command, child.args, {
-		env: {
-			...runtimeUserCommandEnv(home, runtimeUid, options),
-			...child.env,
-			...options.environment,
-		},
+		env,
 		cwd,
 		encoding: "utf8",
 		input: options.input,


### PR DESCRIPTION
## Vulnerability

The hosted root daemon loads the platform `CLAWDI_AUTH_TOKEN` into `process.env`, then periodically drops privileges to the tenant runtime user for observation and reconciliation commands. `runtimeUserCommandEnv` inherited the full daemon environment and prepended tenant-writable `~/.local/bin` and `~/.openclaw/bin` directories to `PATH`. A tenant-controlled executable such as `~/.local/bin/systemctl` could therefore be selected by a root-initiated observation command and exfiltrate the inherited platform token.

## Fix

- Centralize platform credential environment cleanup for `CLAWDI_AUTH_TOKEN`, `CLAWDI_DAEMON_RPC_TOKEN`, and `CLAWDI_EGRESS_SECRET_FILE`, and reuse it in both runtime-user commands and `clawdi run`.
- Clear credentials after the final runtime-user environment merge so explicit overrides cannot reintroduce them.
- Remove tenant-writable bin directories from `PATH` when spawning a command for a dropped runtime UID. Managed OpenClaw and Hermes tools continue to use their resolved absolute command paths, while trusted platform commands resolve from the inherited system path.
- Preserve the existing tenant tool location override cleanup.

## Tests

- `bun run --cwd packages/cli typecheck`
- `bunx biome check packages/cli`
- `bun test packages/cli/src/runtime/runtime-user-command.test.ts packages/cli/tests/commands/run.test.ts --max-concurrency=1` (45 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)