### PR TITLE
refactor(cli): consolidate hosted skill delivery

### DIFF
--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -9,7 +9,7 @@ import { managedSkillDirectoryDigest } from "../runtime/hosted-bundled-skill";
 import {
 	collectManagedSkillTree,
 	managedSkillTreesEqual,
-	withTargetTreeRollback,
+	withManagedTargetRollback,
 } from "../runtime/managed-skill-delivery";
 import {
 	migrateLegacyLocalSetupSkill,
@@ -505,7 +505,7 @@ export class OpenClawAdapter implements AgentAdapter {
 			if (!existsSync(join(sourceDir, "SKILL.md")))
 				throw new Error("Skill archive is missing SKILL.md");
 			mutateUserSkillTarget(targetDir, installedSlug, () =>
-				withTargetTreeRollback({
+				withManagedTargetRollback({
 					target: targetDir,
 					operation: () => {
 						const result = spawnSync(

--- a/packages/cli/src/runtime/hosted-bundled-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.test.ts
@@ -1,11 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
 	chmodSync,
 	cpSync,
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
-	readdirSync,
 	readFileSync,
 	rmSync,
 	statSync,
@@ -16,284 +15,100 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import {
 	adoptableLegacyHostedBundledSkill,
-	loadHostedBundledSkill,
-	reconcileHostedBundledSkill,
+	assertHostedBundledSkillCatalogDigest,
 	resolveHostedBundledSkill,
-	withStagedHostedBundledSkill,
 } from "./hosted-bundled-skill";
-import {
-	installReservedManagedSkill,
-	managedSkillReservationState,
-} from "./managed-skill-reservation";
+import { prepareHostedBundledSkillArchive } from "./hosted-sourced-skill-archive";
+import { withStagedManagedSkill } from "./managed-skill-delivery";
 
 const catalogEntry = resolveHostedBundledSkill("clawdi", 1);
 const bundledSourceDir = resolve(import.meta.dir, "../../skills/hosted-versions/1/clawdi");
-const originalRuntimeMode = process.env.CLAWDI_RUNTIME_MODE;
-const originalServiceStateDir = process.env.CLAWDI_SERVICE_STATE_DIR;
+let root = "";
 
-describe("hosted bundled skill reconciliation", () => {
-	let root: string;
-	let targetDir: string;
+afterEach(() => {
+	if (root) rmSync(root, { recursive: true, force: true });
+	root = "";
+});
 
-	beforeEach(() => {
-		root = mkdtempSync(join(tmpdir(), "clawdi-hosted-bundled-skill-"));
-		targetDir = join(root, "target", "clawdi");
-	});
-
-	afterEach(() => {
-		rmSync(root, { recursive: true, force: true });
-		if (originalRuntimeMode === undefined) delete process.env.CLAWDI_RUNTIME_MODE;
-		else process.env.CLAWDI_RUNTIME_MODE = originalRuntimeMode;
-		if (originalServiceStateDir === undefined) delete process.env.CLAWDI_SERVICE_STATE_DIR;
-		else process.env.CLAWDI_SERVICE_STATE_DIR = originalServiceStateDir;
-	});
-
-	function reconcile(
-		sourceDir = bundledSourceDir,
-		activation?: Parameters<typeof reconcileHostedBundledSkill>[0]["activation"],
-	) {
-		return reconcileHostedBundledSkill({
-			bundle: loadHostedBundledSkill("clawdi", 1, sourceDir),
-			targetDir,
-			activation,
-		});
-	}
-
-	it("does not write when id, version, digest, and actual target content are unchanged", () => {
-		expect(reconcile()).toBe("replaced");
-		const markerPath = join(targetDir, ".clawdi-managed.json");
-		expect(JSON.parse(readFileSync(markerPath, "utf-8"))).toEqual({
-			schema: "clawdi.hostedBundledSkillMarker.v1",
-			owner: "clawdi runtime init",
-			id: "clawdi",
+describe("hosted bundled Skill preparation", () => {
+	test("captures the immutable catalog tree as a prepared bundled source", () => {
+		const prepared = prepareHostedBundledSkillArchive("clawdi", 1);
+		expect(prepared.source).toEqual({
+			type: "bundled",
 			version: 1,
 			digest: catalogEntry.digest,
+			assetDirectory: catalogEntry.assetDirectory,
 		});
-		const targetInode = statSync(targetDir).ino;
-		const skillInode = statSync(join(targetDir, "SKILL.md")).ino;
-		const markerInode = statSync(markerPath).ino;
-		const markerBytes = readFileSync(markerPath);
+		expect(prepared.sourceIdentity).toBe(`content-sha256\0${catalogEntry.digest}`);
+		expect(prepared.archiveSha256).toMatch(/^[a-f0-9]{64}$/);
 
-		expect(reconcile()).toBe("unchanged");
-		expect(statSync(targetDir).ino).toBe(targetInode);
-		expect(statSync(join(targetDir, "SKILL.md")).ino).toBe(skillInode);
-		expect(statSync(markerPath).ino).toBe(markerInode);
-		expect(readFileSync(markerPath)).toEqual(markerBytes);
-	});
-
-	it("atomically replaces drift, a different marker version, and a legacy ownership marker", () => {
-		expect(reconcile()).toBe("replaced");
-		const markerPath = join(targetDir, ".clawdi-managed.json");
-		const initialTargetInode = statSync(targetDir).ino;
-		writeFileSync(join(targetDir, "SKILL.md"), "tampered\n");
-		writeFileSync(join(targetDir, "unexpected.txt"), "tampered\n");
-
-		expect(reconcile()).toBe("replaced");
-		expect(readFileSync(join(targetDir, "SKILL.md"))).toEqual(
-			readFileSync(join(bundledSourceDir, "SKILL.md")),
-		);
-		expect(existsSync(join(targetDir, "unexpected.txt"))).toBe(false);
-		expect(statSync(targetDir).ino).not.toBe(initialTargetInode);
-
-		const currentMarker = JSON.parse(readFileSync(markerPath, "utf-8"));
-		writeFileSync(markerPath, `${JSON.stringify({ ...currentMarker, version: 2 })}\n`);
-		expect(reconcile()).toBe("replaced");
-		expect(JSON.parse(readFileSync(markerPath, "utf-8")).version).toBe(1);
-
-		writeFileSync(
-			markerPath,
-			`${JSON.stringify({ managedBy: "clawdi runtime init", skillName: "clawdi" })}\n`,
-		);
-		expect(reconcile()).toBe("replaced");
-		expect(JSON.parse(readFileSync(markerPath, "utf-8"))).toEqual({
-			schema: "clawdi.hostedBundledSkillMarker.v1",
-			owner: "clawdi runtime init",
-			id: "clawdi",
-			version: 1,
-			digest: catalogEntry.digest,
-		});
-		expect(readdirSync(join(root, "target"))).toEqual(["clawdi"]);
-	});
-
-	it("treats activation as committed before best-effort previous-target cleanup", () => {
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
-		mkdirSync(join(root, "state"));
-		const install = (
-			activation?: Parameters<typeof reconcileHostedBundledSkill>[0]["activation"],
-		) =>
-			installReservedManagedSkill(
-				{
-					targetDir,
-					id: "clawdi",
-					version: 1,
-					digest: catalogEntry.digest,
-					manager: "hosted-manifest",
-				},
-				() => reconcile(bundledSourceDir, activation),
-			);
-		expect(install()).toBe("replaced");
-		writeFileSync(join(targetDir, "SKILL.md"), "tampered\n");
-
+		let stagingRoot = "";
 		expect(
-			install({
-				beforeCleanup: () => {
-					throw new Error("cleanup failed");
-				},
-			}),
-		).toBe("replaced");
-		expect(readFileSync(join(targetDir, "SKILL.md"))).toEqual(
-			readFileSync(join(bundledSourceDir, "SKILL.md")),
-		);
-		expect(managedSkillReservationState(targetDir, "clawdi")).toBe("reserved");
-		expect(readdirSync(join(root, "target")).some((entry) => entry.includes("-trash-"))).toBe(true);
-	});
-
-	it("adopts an old marker only when catalog identity and live content match exactly", () => {
-		expect(reconcile()).toBe("replaced");
-		writeFileSync(
-			join(targetDir, ".clawdi-managed.json"),
-			`${JSON.stringify({ managedBy: "clawdi runtime init", skillName: "clawdi" })}\n`,
-		);
-		expect(adoptableLegacyHostedBundledSkill(targetDir, "clawdi")).toEqual(catalogEntry);
-		writeFileSync(join(targetDir, "SKILL.md"), "tampered\n");
-		expect(adoptableLegacyHostedBundledSkill(targetDir, "clawdi")).toBeNull();
-	});
-
-	it("detects target symlink tampering without following or modifying its destination", () => {
-		expect(reconcile()).toBe("replaced");
-		const outside = join(root, "outside.txt");
-		writeFileSync(outside, "outside\n");
-		rmSync(join(targetDir, "SKILL.md"));
-		symlinkSync(outside, join(targetDir, "SKILL.md"));
-
-		expect(reconcile()).toBe("replaced");
-		expect(readFileSync(outside, "utf-8")).toBe("outside\n");
-		expect(statSync(join(targetDir, "SKILL.md")).isFile()).toBe(true);
-		expect(readFileSync(join(targetDir, "SKILL.md"))).toEqual(
-			readFileSync(join(bundledSourceDir, "SKILL.md")),
-		);
-	});
-
-	it("repairs target group-write drift to the canonical mode", () => {
-		expect(reconcile()).toBe("replaced");
-		const targetSkill = join(targetDir, "SKILL.md");
-		chmodSync(targetSkill, 0o664);
-
-		expect(reconcile()).toBe("replaced");
-		expect(statSync(targetSkill).mode & 0o777).toBe(0o644);
-	});
-
-	it("repairs target directory permission drift to the canonical mode", () => {
-		expect(reconcile()).toBe("replaced");
-		chmodSync(targetDir, 0o700);
-
-		expect(reconcile()).toBe("replaced");
-		expect(statSync(targetDir).mode & 0o777).toBe(0o755);
-	});
-
-	it("normalizes source group-write mode without changing bundle identity", () => {
-		const copiedSource = join(root, "group-write-source");
-		cpSync(bundledSourceDir, copiedSource, { recursive: true });
-		chmodSync(join(copiedSource, "SKILL.md"), 0o664);
-
-		expect(reconcile(copiedSource)).toBe("replaced");
-		expect(statSync(join(targetDir, "SKILL.md")).mode & 0o777).toBe(0o644);
-		expect(JSON.parse(readFileSync(join(targetDir, ".clawdi-managed.json"), "utf-8")).digest).toBe(
-			catalogEntry.digest,
-		);
-	});
-
-	it("fails closed when source regular-file permissions differ from the catalog", () => {
-		const copiedSource = join(root, "mode-drift-source");
-		cpSync(bundledSourceDir, copiedSource, { recursive: true });
-		const copiedSkill = join(copiedSource, "SKILL.md");
-		const sourceMode = statSync(copiedSkill).mode & 0o777;
-		chmodSync(copiedSkill, sourceMode === 0o755 ? 0o644 : 0o755);
-
-		expect(() => reconcile(copiedSource)).toThrow("catalog digest mismatch");
-		expect(existsSync(targetDir)).toBe(false);
-	});
-
-	it("fails closed for source symlinks and catalog digest mismatch", () => {
-		const copiedSource = join(root, "source");
-		cpSync(bundledSourceDir, copiedSource, { recursive: true });
-		const outside = join(root, "outside.txt");
-		writeFileSync(outside, "outside\n");
-		symlinkSync(outside, join(copiedSource, "linked.txt"));
-		expect(() => reconcile(copiedSource)).toThrow("symbolic links are not supported");
-		expect(existsSync(targetDir)).toBe(false);
-
-		rmSync(join(copiedSource, "linked.txt"));
-		writeFileSync(join(copiedSource, "SKILL.md"), "catalog drift\n");
-		expect(() => reconcile(copiedSource)).toThrow("catalog digest mismatch");
-		expect(existsSync(targetDir)).toBe(false);
-	});
-
-	it("materializes only from the verified in-memory bundle", () => {
-		const copiedSource = join(root, "captured-source");
-		cpSync(bundledSourceDir, copiedSource, { recursive: true });
-		const bundle = loadHostedBundledSkill("clawdi", 1, copiedSource);
-		rmSync(copiedSource, { recursive: true });
-
-		expect(
-			reconcileHostedBundledSkill({
-				bundle,
-				targetDir,
-			}),
-		).toBe("replaced");
-		expect(readFileSync(join(targetDir, "SKILL.md"))).toEqual(
-			readFileSync(join(bundledSourceDir, "SKILL.md")),
-		);
-	});
-
-	it("stages exact captured bytes with canonical readable modes and always cleans up", () => {
-		const protectedRoot = join(root, "root-private");
-		const copiedSource = join(protectedRoot, "clawdi");
-		mkdirSync(protectedRoot, { mode: 0o700 });
-		cpSync(bundledSourceDir, copiedSource, { recursive: true });
-		chmodSync(protectedRoot, 0o700);
-		const expectedSkill = readFileSync(join(copiedSource, "SKILL.md"));
-		const bundle = loadHostedBundledSkill("clawdi", 1, copiedSource);
-		rmSync(copiedSource, { recursive: true });
-
-		let successfulStagingRoot = "";
-		expect(
-			withStagedHostedBundledSkill(bundle, (sourceDir) => {
-				successfulStagingRoot = dirname(sourceDir);
-				expect(sourceDir).not.toBe(copiedSource);
-				expect(statSync(successfulStagingRoot).mode & 0o777).toBe(0o755);
+			withStagedManagedSkill(prepared, (sourceDir) => {
+				stagingRoot = dirname(sourceDir);
+				expect(readFileSync(join(sourceDir, "SKILL.md"))).toEqual(
+					readFileSync(join(bundledSourceDir, "SKILL.md")),
+				);
 				expect(statSync(sourceDir).mode & 0o777).toBe(0o755);
 				expect(statSync(join(sourceDir, "SKILL.md")).mode & 0o777).toBe(0o644);
-				expect(readFileSync(join(sourceDir, "SKILL.md"))).toEqual(expectedSkill);
-				return "installed";
+				expect(existsSync(join(sourceDir, ".clawdi-managed.json"))).toBe(false);
+				return "staged" as const;
 			}),
-		).toBe("installed");
-		expect(existsSync(successfulStagingRoot)).toBe(false);
-
-		let failedStagingRoot = "";
-		expect(() =>
-			withStagedHostedBundledSkill(bundle, (sourceDir) => {
-				failedStagingRoot = dirname(sourceDir);
-				throw new Error("official installer failed");
-			}),
-		).toThrow("official installer failed");
-		expect(existsSync(failedStagingRoot)).toBe(false);
-		expect(statSync(protectedRoot).mode & 0o777).toBe(0o700);
+		).toBe("staged");
+		expect(existsSync(stagingRoot)).toBe(false);
 	});
 
-	it("fails closed for unknown ids, unknown versions, and unmanaged targets", () => {
-		expect(() => loadHostedBundledSkill("unknown", 1, bundledSourceDir)).toThrow(
+	test("fails closed for unknown catalog entries and source drift", () => {
+		expect(() => resolveHostedBundledSkill("unknown", 1)).toThrow(
 			"no bundled hosted skill is registered for unknown",
 		);
-		expect(() => loadHostedBundledSkill("clawdi", 2, bundledSourceDir)).toThrow(
+		expect(() => resolveHostedBundledSkill("clawdi", 2)).toThrow(
 			"no bundled hosted skill clawdi version 2 is registered",
 		);
 
-		mkdirSync(targetDir, { recursive: true });
-		writeFileSync(join(targetDir, "SKILL.md"), "user owned\n");
-		expect(() => reconcile()).toThrow(`refusing to replace unmanaged clawdi skill at ${targetDir}`);
-		expect(readFileSync(join(targetDir, "SKILL.md"), "utf-8")).toBe("user owned\n");
-		expect(existsSync(join(targetDir, ".clawdi-managed.json"))).toBe(false);
+		root = mkdtempSync(join(tmpdir(), "hosted-bundled-source-"));
+		const copied = join(root, "clawdi");
+		cpSync(bundledSourceDir, copied, { recursive: true });
+		writeFileSync(join(copied, "SKILL.md"), "catalog drift\n");
+		expect(() => assertHostedBundledSkillCatalogDigest(catalogEntry, copied)).toThrow(
+			"catalog digest mismatch",
+		);
+
+		cpSync(bundledSourceDir, copied, { recursive: true, force: true });
+		const outside = join(root, "outside");
+		writeFileSync(outside, "outside\n");
+		symlinkSync(outside, join(copied, "linked"));
+		expect(() => assertHostedBundledSkillCatalogDigest(catalogEntry, copied)).toThrow(
+			"symbolic links are not supported",
+		);
+	});
+
+	test("adopts legacy tree markers only while identity and bytes match exactly", () => {
+		root = mkdtempSync(join(tmpdir(), "hosted-bundled-legacy-"));
+		const target = join(root, "skills", "clawdi");
+		mkdirSync(dirname(target), { recursive: true });
+		cpSync(bundledSourceDir, target, { recursive: true });
+		chmodSync(target, 0o755);
+		chmodSync(join(target, "SKILL.md"), 0o644);
+		const marker = join(target, ".clawdi-managed.json");
+		writeFileSync(
+			marker,
+			`${JSON.stringify({ managedBy: "clawdi runtime init", skillName: "clawdi" })}\n`,
+		);
+		expect(adoptableLegacyHostedBundledSkill(target, "clawdi")).toEqual(catalogEntry);
+
+		writeFileSync(
+			marker,
+			`${JSON.stringify({
+				schema: "clawdi.hostedBundledSkillMarker.v1",
+				owner: "clawdi runtime init",
+				id: "clawdi",
+				version: 1,
+				digest: catalogEntry.digest,
+			})}\n`,
+		);
+		expect(adoptableLegacyHostedBundledSkill(target, "clawdi")).toEqual(catalogEntry);
+		writeFileSync(join(target, "SKILL.md"), "tenant bytes\n");
+		expect(adoptableLegacyHostedBundledSkill(target, "clawdi")).toBeNull();
 	});
 });

--- a/packages/cli/src/runtime/hosted-bundled-skill.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.ts
@@ -1,39 +1,14 @@
-import { randomUUID } from "node:crypto";
-import {
-	chmodSync,
-	existsSync,
-	lstatSync,
-	mkdirSync,
-	mkdtempSync,
-	readdirSync,
-	readFileSync,
-	rmSync,
-	writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { lstatSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
 	canonicalManagedBundleFileMode,
 	computeManagedBundleHash,
 	type ManagedBundleHashEntry,
 } from "./managed-bundle-hash";
-import {
-	activateManagedSkillDirectory,
-	type ManagedSkillDirectoryActivationOptions,
-} from "./managed-skill-reservation";
 
-const HOSTED_BUNDLED_SKILL_MARKER = ".clawdi-managed.json";
-const HOSTED_BUNDLED_SKILL_MARKER_SCHEMA = "clawdi.hostedBundledSkillMarker.v1";
-const HOSTED_BUNDLED_SKILL_OWNER = "clawdi runtime init";
-const HOSTED_BUNDLED_SKILL_DIRECTORY_MODE = 0o755;
-
-interface HostedBundledSkillMarker {
-	schema: typeof HOSTED_BUNDLED_SKILL_MARKER_SCHEMA;
-	owner: typeof HOSTED_BUNDLED_SKILL_OWNER;
-	id: string;
-	version: number;
-	digest: string;
-}
+const LEGACY_MARKER = ".clawdi-managed.json";
+const LEGACY_MARKER_SCHEMA = "clawdi.hostedBundledSkillMarker.v1";
+const LEGACY_MARKER_OWNER = "clawdi runtime init";
 
 export interface HostedBundledSkillCatalogEntry {
 	id: string;
@@ -62,194 +37,68 @@ const HOSTED_BUNDLED_SKILL_CATALOG = new Map<
 	],
 ]);
 
-export interface ReconcileHostedBundledSkillInput {
-	bundle: HostedBundledSkillBundle;
-	targetDir: string;
-	/** A root-owned reservation for this exact target authorizes replacement. */
-	reserved?: boolean;
-	/** Deterministic failure hooks for the shared activation contract. */
-	activation?: ManagedSkillDirectoryActivationOptions;
-}
-
-interface HostedBundledSkillFile {
-	readonly relativePath: string;
-	readonly mode: 0o644 | 0o755;
-	/** Base64 keeps the captured bytes immutable across the privilege boundary. */
-	readonly contentBase64: string;
-}
-
-export interface HostedBundledSkillBundle {
-	readonly catalogEntry: HostedBundledSkillCatalogEntry;
-	readonly files: readonly HostedBundledSkillFile[];
-}
-
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-function readHostedBundledSkillMarker(targetDir: string): Record<string, unknown> | null {
-	const markerPath = join(targetDir, HOSTED_BUNDLED_SKILL_MARKER);
-	try {
-		if (!lstatSync(markerPath).isFile()) return null;
-		const marker = JSON.parse(readFileSync(markerPath, "utf-8")) as unknown;
-		return isPlainRecord(marker) ? marker : null;
-	} catch {
-		return null;
-	}
-}
-
-function isCurrentManagedMarker(marker: Record<string, unknown>, skillId: string): boolean {
-	return (
-		marker.schema === HOSTED_BUNDLED_SKILL_MARKER_SCHEMA &&
-		marker.owner === HOSTED_BUNDLED_SKILL_OWNER &&
-		marker.id === skillId &&
-		typeof marker.version === "number" &&
-		Number.isSafeInteger(marker.version) &&
-		marker.version > 0 &&
-		typeof marker.digest === "string" &&
-		/^[a-f0-9]{64}$/.test(marker.digest)
-	);
-}
-
-function isLegacyManagedMarker(marker: Record<string, unknown>, skillId: string): boolean {
-	return marker.managedBy === HOSTED_BUNDLED_SKILL_OWNER && marker.skillName === skillId;
-}
-
-export function isManagedHostedBundledSkill(targetDir: string, skillId: string): boolean {
-	try {
-		if (!lstatSync(targetDir).isDirectory()) return false;
-	} catch {
-		return false;
-	}
-	const marker = readHostedBundledSkillMarker(targetDir);
-	return Boolean(
-		marker && (isCurrentManagedMarker(marker, skillId) || isLegacyManagedMarker(marker, skillId)),
-	);
-}
-
-function collectHostedBundledSkillFiles(
-	currentDir: string,
-	relativeDir: string,
-	excludeMarker: boolean,
-	requireCanonicalModes: boolean,
+function collectDirectoryEntries(
+	directory: string,
+	prefix: string,
+	options: { excludeLegacyMarker: boolean; requireCanonicalModes: boolean },
 	files: ManagedBundleHashEntry[],
 ): void {
-	const entries = readdirSync(currentDir, { withFileTypes: true }).sort((left, right) =>
-		left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+	const entries = readdirSync(directory, { withFileTypes: true }).sort((left, right) =>
+		left.name.localeCompare(right.name),
 	);
 	for (const entry of entries) {
-		const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
-		if (excludeMarker && relativePath === HOSTED_BUNDLED_SKILL_MARKER) continue;
-		const path = join(currentDir, entry.name);
+		const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+		if (options.excludeLegacyMarker && relativePath === LEGACY_MARKER) continue;
+		const path = join(directory, entry.name);
 		const stat = lstatSync(path);
 		if (stat.isSymbolicLink()) {
-			throw new Error(`symbolic links are not supported in bundled hosted skills: ${path}`);
+			throw new Error(`symbolic links are not supported in managed skills: ${path}`);
 		}
 		if (stat.isDirectory()) {
-			if (requireCanonicalModes && (stat.mode & 0o777) !== HOSTED_BUNDLED_SKILL_DIRECTORY_MODE) {
-				throw new Error(`bundled hosted skill directory mode is not canonical: ${path}`);
+			if (options.requireCanonicalModes && (stat.mode & 0o777) !== 0o755) {
+				throw new Error(`managed skill directory mode is not canonical: ${path}`);
 			}
-			collectHostedBundledSkillFiles(
-				path,
-				relativePath,
-				excludeMarker,
-				requireCanonicalModes,
-				files,
-			);
+			collectDirectoryEntries(path, relativePath, options, files);
 			continue;
 		}
 		if (stat.isFile()) {
 			const mode = stat.mode & 0o777;
-			if (requireCanonicalModes && mode !== canonicalManagedBundleFileMode(mode)) {
-				throw new Error(`bundled hosted skill file mode is not canonical: ${path}`);
+			if (options.requireCanonicalModes && mode !== canonicalManagedBundleFileMode(mode)) {
+				throw new Error(`managed skill file mode is not canonical: ${path}`);
 			}
 			files.push({ relativePath, mode, content: readFileSync(path) });
 			continue;
 		}
-		throw new Error(`unsupported file type in bundled hosted skill: ${path}`);
+		throw new Error(`unsupported entry in managed skill: ${path}`);
 	}
 }
 
-function hostedBundledSkillDigest(
+function directoryDigest(
 	directory: string,
-	excludeMarker: boolean,
-	requireCanonicalModes = false,
+	options: { excludeLegacyMarker?: boolean; requireCanonicalModes?: boolean } = {},
 ): string {
 	const stat = lstatSync(directory);
-	if (!stat.isDirectory()) {
-		throw new Error(`bundled hosted skill path is not a directory: ${directory}`);
+	if (stat.isSymbolicLink() || !stat.isDirectory()) {
+		throw new Error(`managed skill path is not a directory: ${directory}`);
 	}
-	if (requireCanonicalModes && (stat.mode & 0o777) !== HOSTED_BUNDLED_SKILL_DIRECTORY_MODE) {
-		throw new Error(`bundled hosted skill directory mode is not canonical: ${directory}`);
+	if (options.requireCanonicalModes && (stat.mode & 0o777) !== 0o755) {
+		throw new Error(`managed skill directory mode is not canonical: ${directory}`);
 	}
 	const files: ManagedBundleHashEntry[] = [];
-	collectHostedBundledSkillFiles(directory, "", excludeMarker, requireCanonicalModes, files);
+	collectDirectoryEntries(
+		directory,
+		"",
+		{
+			excludeLegacyMarker: options.excludeLegacyMarker ?? false,
+			requireCanonicalModes: options.requireCanonicalModes ?? false,
+		},
+		files,
+	);
 	return computeManagedBundleHash(files);
 }
 
 export function managedSkillDirectoryDigest(directory: string): string {
-	return hostedBundledSkillDigest(directory, false);
-}
-
-export function adoptableLegacyHostedBundledSkill(
-	targetDir: string,
-	skillId: string,
-): HostedBundledSkillCatalogEntry | null {
-	const marker = readHostedBundledSkillMarker(targetDir);
-	if (!marker) return null;
-	const current = isCurrentManagedMarker(marker, skillId);
-	const legacy = isLegacyManagedMarker(marker, skillId);
-	if (!current && !legacy) return null;
-	const version = current ? (marker.version as number) : 1;
-	let catalogEntry: HostedBundledSkillCatalogEntry;
-	try {
-		catalogEntry = resolveHostedBundledSkill(skillId, version);
-	} catch {
-		return null;
-	}
-	if (current && marker.digest !== catalogEntry.digest) return null;
-	try {
-		return hostedBundledSkillDigest(targetDir, true, true) === catalogEntry.digest
-			? catalogEntry
-			: null;
-	} catch {
-		return null;
-	}
-}
-
-function normalizeHostedBundledSkillModes(currentDir: string): void {
-	chmodSync(currentDir, HOSTED_BUNDLED_SKILL_DIRECTORY_MODE);
-	for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
-		const path = join(currentDir, entry.name);
-		const stat = lstatSync(path);
-		if (stat.isSymbolicLink()) {
-			throw new Error(`symbolic links are not supported in bundled hosted skills: ${path}`);
-		}
-		if (stat.isDirectory()) {
-			normalizeHostedBundledSkillModes(path);
-			continue;
-		}
-		if (stat.isFile()) {
-			chmodSync(path, canonicalManagedBundleFileMode(stat.mode & 0o777));
-			continue;
-		}
-		throw new Error(`unsupported file type in bundled hosted skill: ${path}`);
-	}
-}
-
-function markerMatches(
-	marker: Record<string, unknown> | null,
-	expected: HostedBundledSkillMarker,
-): boolean {
-	return Boolean(
-		marker &&
-			Object.keys(marker).length === 5 &&
-			marker.schema === expected.schema &&
-			marker.owner === expected.owner &&
-			marker.id === expected.id &&
-			marker.version === expected.version &&
-			marker.digest === expected.digest,
-	);
+	return directoryDigest(directory);
 }
 
 export function hostedBundledSkillIds(): string[] {
@@ -273,124 +122,62 @@ export function assertHostedBundledSkillCatalogDigest(
 	catalogEntry: HostedBundledSkillCatalogEntry,
 	sourceDir: string,
 ): void {
-	const actualDigest = hostedBundledSkillDigest(sourceDir, false);
-	if (actualDigest !== catalogEntry.digest) {
+	if (directoryDigest(sourceDir) !== catalogEntry.digest) {
 		throw new Error(
 			`bundled hosted skill catalog digest mismatch for ${catalogEntry.id} version ${catalogEntry.version}`,
 		);
 	}
 }
 
-export function loadHostedBundledSkill(
+function readLegacyMarker(targetDir: string): Record<string, unknown> | null {
+	try {
+		const path = join(targetDir, LEGACY_MARKER);
+		if (!lstatSync(path).isFile()) return null;
+		const value: unknown = JSON.parse(readFileSync(path, "utf8"));
+		return value && typeof value === "object" && !Array.isArray(value)
+			? (value as Record<string, unknown>)
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * One-time migration shim for pre-ledger hosted bundles. Remove only after all
+ * supported hosted CLI versions have written reservation-backed receipts and
+ * the oldest pre-ledger runtime image is outside the supported upgrade window.
+ */
+export function adoptableLegacyHostedBundledSkill(
+	targetDir: string,
 	skillId: string,
-	version: number,
-	sourceDir: string,
-): HostedBundledSkillBundle {
-	const catalogEntry = resolveHostedBundledSkill(skillId, version);
-	const sourceFiles: ManagedBundleHashEntry[] = [];
-	const stat = lstatSync(sourceDir);
-	if (!stat.isDirectory()) {
-		throw new Error(`bundled hosted skill path is not a directory: ${sourceDir}`);
-	}
-	collectHostedBundledSkillFiles(sourceDir, "", false, false, sourceFiles);
-	if (computeManagedBundleHash(sourceFiles) !== catalogEntry.digest) {
-		throw new Error(
-			`bundled hosted skill catalog digest mismatch for ${catalogEntry.id} version ${catalogEntry.version}`,
-		);
-	}
-	const files = sourceFiles.map((file) =>
-		Object.freeze({
-			relativePath: file.relativePath,
-			mode: canonicalManagedBundleFileMode(file.mode),
-			contentBase64: Buffer.from(file.content).toString("base64"),
-		}),
-	);
-	return Object.freeze({ catalogEntry, files: Object.freeze(files) });
-}
-
-function materializeHostedBundledSkill(bundle: HostedBundledSkillBundle, targetDir: string): void {
-	mkdirSync(targetDir, { recursive: true, mode: HOSTED_BUNDLED_SKILL_DIRECTORY_MODE });
-	for (const file of bundle.files) {
-		const path = join(targetDir, file.relativePath);
-		mkdirSync(dirname(path), { recursive: true, mode: HOSTED_BUNDLED_SKILL_DIRECTORY_MODE });
-		writeFileSync(path, Buffer.from(file.contentBase64, "base64"), { mode: file.mode });
-	}
-}
-
-export function withStagedHostedBundledSkill<T>(
-	bundle: HostedBundledSkillBundle,
-	operation: (sourceDir: string) => T,
-): T {
-	const stagingRoot = mkdtempSync(join(tmpdir(), "clawdi-hosted-bundled-skill-"));
-	const sourceDir = join(stagingRoot, bundle.catalogEntry.id);
+): HostedBundledSkillCatalogEntry | null {
+	const marker = readLegacyMarker(targetDir);
+	if (!marker) return null;
+	const current =
+		marker.schema === LEGACY_MARKER_SCHEMA &&
+		marker.owner === LEGACY_MARKER_OWNER &&
+		marker.id === skillId &&
+		typeof marker.version === "number" &&
+		Number.isSafeInteger(marker.version) &&
+		marker.version > 0 &&
+		typeof marker.digest === "string";
+	const legacy = marker.managedBy === LEGACY_MARKER_OWNER && marker.skillName === skillId;
+	if (!current && !legacy) return null;
+	let catalogEntry: HostedBundledSkillCatalogEntry;
 	try {
-		materializeHostedBundledSkill(bundle, sourceDir);
-		normalizeHostedBundledSkillModes(stagingRoot);
-		if (hostedBundledSkillDigest(sourceDir, false, true) !== bundle.catalogEntry.digest) {
-			throw new Error(
-				`bundled hosted skill catalog digest mismatch for ${bundle.catalogEntry.id} version ${bundle.catalogEntry.version}`,
-			);
-		}
-		return operation(sourceDir);
-	} finally {
-		rmSync(stagingRoot, { recursive: true, force: true });
+		catalogEntry = resolveHostedBundledSkill(skillId, current ? (marker.version as number) : 1);
+	} catch {
+		return null;
 	}
-}
-
-export function reconcileHostedBundledSkill(
-	input: ReconcileHostedBundledSkillInput,
-): "unchanged" | "replaced" {
-	const catalogEntry = input.bundle.catalogEntry;
-	const marker: HostedBundledSkillMarker = {
-		schema: HOSTED_BUNDLED_SKILL_MARKER_SCHEMA,
-		owner: HOSTED_BUNDLED_SKILL_OWNER,
-		id: catalogEntry.id,
-		version: catalogEntry.version,
-		digest: catalogEntry.digest,
-	};
-	const targetExists = existsSync(input.targetDir);
-	if (
-		targetExists &&
-		!input.reserved &&
-		!isManagedHostedBundledSkill(input.targetDir, catalogEntry.id)
-	) {
-		throw new Error(`refusing to replace unmanaged ${catalogEntry.id} skill at ${input.targetDir}`);
-	}
-	if (targetExists && markerMatches(readHostedBundledSkillMarker(input.targetDir), marker)) {
-		try {
-			if (hostedBundledSkillDigest(input.targetDir, true, true) === marker.digest)
-				return "unchanged";
-		} catch {
-			// A recognized managed target with tampered content is replaced below.
-		}
-	}
-
-	const parent = dirname(input.targetDir);
-	mkdirSync(parent, { recursive: true });
-	const stagingRoot = mkdtempSync(join(parent, `.${basename(input.targetDir)}-stage-`));
-	const stagedTarget = join(stagingRoot, basename(input.targetDir));
-	const trash = join(parent, `.${basename(input.targetDir)}-trash-${process.pid}-${randomUUID()}`);
+	if (current && marker.digest !== catalogEntry.digest) return null;
 	try {
-		materializeHostedBundledSkill(input.bundle, stagedTarget);
-		normalizeHostedBundledSkillModes(stagedTarget);
-		if (hostedBundledSkillDigest(stagedTarget, false, true) !== catalogEntry.digest) {
-			throw new Error(
-				`bundled hosted skill catalog digest mismatch for ${catalogEntry.id} version ${catalogEntry.version}`,
-			);
-		}
-		writeFileSync(
-			join(stagedTarget, HOSTED_BUNDLED_SKILL_MARKER),
-			`${JSON.stringify(marker, null, 2)}\n`,
-			{ mode: 0o600 },
-		);
-		activateManagedSkillDirectory({
-			stagedTarget,
-			targetDir: input.targetDir,
-			previousTarget: trash,
-			options: input.activation,
-		});
-	} finally {
-		rmSync(stagingRoot, { recursive: true, force: true });
+		return directoryDigest(targetDir, {
+			excludeLegacyMarker: true,
+			requireCanonicalModes: true,
+		}) === catalogEntry.digest
+			? catalogEntry
+			: null;
+	} catch {
+		return null;
 	}
-	return "replaced";
 }

--- a/packages/cli/src/runtime/hosted-hermes-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
 	chmodSync,
 	existsSync,
@@ -16,6 +17,14 @@ import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive"
 
 const originalEnv = { ...process.env };
 let root = "";
+
+function preparedArchive(path: string): { archiveSha256: string; tarBytes: Buffer } {
+	const tarBytes = readFileSync(path);
+	return {
+		archiveSha256: createHash("sha256").update(tarBytes).digest("hex"),
+		tarBytes,
+	};
+}
 
 afterEach(() => {
 	if (root) rmSync(root, { recursive: true, force: true });
@@ -105,8 +114,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 				"22222222-2222-4222-8222-222222222222",
 				"a".repeat(64),
 			].join("\0"),
-			archiveSha256: "b".repeat(64),
-			tarBytes: readFileSync(archive),
+			...preparedArchive(archive),
 		};
 		process.env.FAKE_HERMES_INSTALL_NOOP = "1";
 
@@ -157,8 +165,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 			skillId: "review-pr",
 			source,
 			sourceIdentity: `github\0review-pr\0https://github.com/Clawdi-AI/store\0\0${"a".repeat(40)}`,
-			archiveSha256: "b".repeat(64),
-			tarBytes: readFileSync(archive),
+			...preparedArchive(archive),
 		};
 		const input = {
 			home,
@@ -178,14 +185,31 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		expect(readFileSync(commandLog, "utf8")).toContain(`/${source.commit}/SKILL.md`);
 		expect(readFileSync(commandLog, "utf8")).not.toContain(`/${source.commit}//SKILL.md`);
 		expect(hostedHermesSkillExactSourceDriver.verifyOwned(input)).toBe(true);
+		expect(
+			hostedHermesSkillExactSourceDriver.hasOwnershipReceipt({
+				home,
+				skillId: "review-pr",
+				ownershipIdentity: skill.sourceIdentity,
+			}),
+		).toBe(true);
+		expect(
+			hostedHermesSkillExactSourceDriver.hasOwnershipReceipt({
+				home,
+				skillId: "review-pr",
+				ownershipIdentity: `${skill.sourceIdentity}-other`,
+			}),
+		).toBe(false);
 		const receiptBytes = readFileSync(receipt);
 		rmSync(receipt);
 		expect(hostedHermesSkillExactSourceDriver.verifyOwned(input)).toBe(false);
-		writeFileSync(receipt, receiptBytes);
+		writeFileSync(receipt, receiptBytes, { mode: 0o600 });
 
 		writeFileSync(join(target, "SKILL.md"), "forged user bytes\n");
 		expect(hostedHermesSkillExactSourceDriver.verifyOwned(input)).toBe(false);
-		writeFileSync(join(target, "SKILL.md"), skillV1Native);
+		expect(hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: true })).toBe(
+			"installed",
+		);
+		expect(readFileSync(join(target, "SKILL.md"))).toEqual(skillV1Native);
 		expect(hostedHermesSkillExactSourceDriver.verifyOwned(input)).toBe(true);
 		expect(existsSync(join(root, "wrong-profile", "skills", "review-pr"))).toBe(false);
 
@@ -211,8 +235,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 			sourceIdentity:
 				"github\0review-pr\0https://github.com/Clawdi-AI/store\0skills/review-pr\0" +
 				"c".repeat(40),
-			archiveSha256: "c".repeat(64),
-			tarBytes: readFileSync(updateArchive),
+			...preparedArchive(updateArchive),
 		};
 		expect(
 			hostedHermesSkillExactSourceDriver.install({
@@ -245,7 +268,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		const failingSkill = {
 			...updatedSkill,
 			sourceIdentity: `${updatedSkill.sourceIdentity}-failure-test`,
-			tarBytes: readFileSync(failingArchive),
+			...preparedArchive(failingArchive),
 		};
 		expect(() =>
 			hostedHermesSkillExactSourceDriver.install({

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -3,14 +3,19 @@ import { join } from "node:path";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import {
 	collectManagedSkillTree,
+	managedSkillMarkerMatchesIdentity,
 	managedSkillReceiptMatchesIdentity,
-	managedSkillReceiptOwnsTarget,
 	managedSkillTreesEqual,
 	withManagedTargetRollback,
 	withStagedManagedSkill,
 	writeManagedSkillReceipt,
 } from "./managed-skill-delivery";
-import { executableExists, spawnRuntimeUserCommand } from "./runtime-user-command";
+import { replaceManagedSkillDirectoryAtomic } from "./managed-skill-reservation";
+import {
+	executableExists,
+	spawnRuntimeUserCommand,
+	withRuntimeUserFileAccess,
+} from "./runtime-user-command";
 
 const RECEIPT_SCHEMA = "clawdi.hermesManifestSkillReceipt.v2";
 
@@ -22,9 +27,15 @@ export interface HostedHermesSkillExactSourceDriver {
 		previouslyReserved: boolean;
 	}): "installed" | "unchanged";
 	verifyOwned(input: { home: string; appRoot: string; skill: PreparedHostedSourcedSkill }): boolean;
+	hasOwnershipReceipt(input: { home: string; skillId: string; ownershipIdentity: string }): boolean;
 	uninstall(input: {
 		home: string;
 		appRoot: string;
+		skillId: string;
+		ownershipIdentity: string;
+	}): "absent" | "removed";
+	cleanupManifestOwned(input: {
+		home: string;
 		skillId: string;
 		ownershipIdentity: string;
 	}): "absent" | "removed";
@@ -54,6 +65,9 @@ function receiptInput(home: string, skillId: string, ownershipIdentity: string) 
 
 function rawSkillUrl(skill: PreparedHostedSourcedSkill): string {
 	if (skill.source.type === "project") return skill.source.installUrl;
+	if (skill.source.type === "bundled") {
+		throw new Error("bundled Hermes Skills do not have a remote install URL");
+	}
 	const repository = new URL(skill.source.url);
 	const [owner, repo] = repository.pathname.slice(1).split("/");
 	if (!owner || !repo)
@@ -126,9 +140,15 @@ function expectedHermesNativeTree(sourceDir: string) {
 	return expected;
 }
 
-function nativeResultMatches(sourceDir: string, target: string): boolean {
+function nativeResultMatches(
+	skill: PreparedHostedSourcedSkill,
+	sourceDir: string,
+	target: string,
+): boolean {
 	return managedSkillTreesEqual(
-		expectedHermesNativeTree(sourceDir),
+		skill.source.type === "bundled"
+			? collectManagedSkillTree(sourceDir)
+			: expectedHermesNativeTree(sourceDir),
 		collectManagedSkillTree(target),
 	);
 }
@@ -141,16 +161,23 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 			const hadTarget = existsSync(target);
 			if (hadTarget && !input.previouslyReserved)
 				throw new Error("Hermes Skill target is not paired with a manifest reservation");
-			if (nativeResultMatches(sourceDir, target) && managedSkillReceiptMatchesIdentity(receipt))
+			if (
+				nativeResultMatches(input.skill, sourceDir, target) &&
+				managedSkillReceiptMatchesIdentity(receipt)
+			)
 				return "unchanged";
-			if (hadTarget && !managedSkillReceiptOwnsTarget(receipt))
-				throw new Error(
-					"refusing to replace a Hermes Skill without a matching Clawdi ownership receipt",
-				);
 			return withManagedTargetRollback({
 				target,
 				receipt: receipt.path,
 				operation: () => {
+					if (input.skill.source.type === "bundled") {
+						withRuntimeUserFileAccess(() => replaceManagedSkillDirectoryAtomic(sourceDir, target));
+						if (!nativeResultMatches(input.skill, sourceDir, target)) {
+							throw new Error("Hermes bundled Skill activation changed exact source bytes");
+						}
+						writeManagedSkillReceipt(receipt);
+						return "installed" as const;
+					}
 					const args = [
 						"skills",
 						"install",
@@ -165,7 +192,7 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 						throw new Error(
 							`Hermes official Skill install failed: ${String(result.stderr || result.stdout).trim() || "unknown error"}`,
 						);
-					if (!nativeResultMatches(sourceDir, target)) {
+					if (!nativeResultMatches(input.skill, sourceDir, target)) {
 						if (!hadTarget && existsSync(target)) {
 							const rollback = runHermesUninstall(input, input.skill.skillId);
 							if (rollback.status !== 0 || existsSync(target))
@@ -187,10 +214,15 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 		return withStagedManagedSkill(
 			input.skill,
 			(sourceDir) =>
-				nativeResultMatches(sourceDir, targetDir(input.home, input.skill.skillId)) &&
+				nativeResultMatches(input.skill, sourceDir, targetDir(input.home, input.skill.skillId)) &&
 				managedSkillReceiptMatchesIdentity(
 					receiptInput(input.home, input.skill.skillId, input.skill.sourceIdentity),
 				),
+		);
+	},
+	hasOwnershipReceipt(input) {
+		return managedSkillMarkerMatchesIdentity(
+			receiptInput(input.home, input.skillId, input.ownershipIdentity),
 		);
 	},
 	uninstall(input) {
@@ -215,6 +247,20 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 			);
 		if (existsSync(target))
 			throw new Error("Hermes official Skill uninstall did not remove the Skill target");
+		rmSync(receipt.path, { force: true });
+		return "removed";
+	},
+	cleanupManifestOwned(input) {
+		const target = targetDir(input.home, input.skillId);
+		const receipt = receiptInput(input.home, input.skillId, input.ownershipIdentity);
+		if (!existsSync(target)) {
+			rmSync(receipt.path, { force: true });
+			return "absent";
+		}
+		if (!managedSkillReceiptMatchesIdentity(receipt)) {
+			throw new Error("Hermes Skill bytes no longer match the manifest ownership receipt");
+		}
+		withRuntimeUserFileAccess(() => rmSync(target, { recursive: true }));
 		rmSync(receipt.path, { force: true });
 		return "removed";
 	},

--- a/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
 	chmodSync,
 	existsSync,
@@ -213,6 +214,7 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 	const archive = join(root, "review-pr.tar.gz");
 	const packed = spawnSync("tar", ["-czf", archive, "-C", dirname(sourceDir), "review-pr"]);
 	if (packed.status !== 0) throw new Error("test tar creation failed");
+	const tarBytes = readFileSync(archive);
 	const skill = {
 		skillId: "review-pr",
 		source: {
@@ -222,8 +224,8 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 			commit: "a".repeat(40),
 		},
 		sourceIdentity: `github\0review-pr\0https://github.com/Clawdi-AI/store\0skills/review-pr\0${"a".repeat(40)}`,
-		archiveSha256: "b".repeat(64),
-		tarBytes: readFileSync(archive),
+		archiveSha256: createHash("sha256").update(tarBytes).digest("hex"),
+		tarBytes,
 	};
 
 	expect(existsSync(workspaceRoot)).toBe(false);

--- a/packages/cli/src/runtime/hosted-openclaw-skill.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.ts
@@ -30,11 +30,13 @@ export interface HostedOpenClawSkillDriver {
 		skillId: string;
 		sourceDir: string;
 		ownershipIdentity: string;
+		previouslyReserved?: boolean;
 	}): "installed" | "unchanged";
 	install(input: {
 		home: string;
 		workspaceRoot: string;
 		skill: PreparedHostedSourcedSkill;
+		previouslyReserved?: boolean;
 	}): "installed" | "unchanged";
 	hasOwnershipReceipt(input: {
 		workspaceRoot: string;
@@ -191,7 +193,7 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 		const receipt = receiptInput(input.workspaceRoot, input.skillId, input.ownershipIdentity);
 		if (nativeResultMatches(input.sourceDir, target) && managedSkillReceiptMatchesIdentity(receipt))
 			return "unchanged";
-		if (existsSync(target) && !managedSkillMarkerOwnsTarget(receipt))
+		if (existsSync(target) && !input.previouslyReserved && !managedSkillMarkerOwnsTarget(receipt))
 			throw new Error(
 				"refusing to replace an OpenClaw Skill without a matching Clawdi ownership receipt",
 			);
@@ -239,6 +241,7 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 				skillId: input.skill.skillId,
 				sourceDir,
 				ownershipIdentity: input.skill.sourceIdentity,
+				previouslyReserved: input.previouslyReserved,
 			}),
 		);
 	},

--- a/packages/cli/src/runtime/hosted-sourced-skill-archive.ts
+++ b/packages/cli/src/runtime/hosted-sourced-skill-archive.ts
@@ -1,7 +1,9 @@
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, lstatSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
+import { resolveCurrentCliResourceRoot } from "../lib/current-cli-invocation";
 import type { GithubArchiveFetcher } from "../lib/github-skill-archive";
 import {
 	fetchGithubSkillArchive,
@@ -9,6 +11,10 @@ import {
 	readBoundedResponseBytes,
 } from "../lib/github-skill-archive";
 import { extractTarGz, snapshotSkillArchive } from "../lib/tar";
+import {
+	assertHostedBundledSkillCatalogDigest,
+	resolveHostedBundledSkill,
+} from "./hosted-bundled-skill";
 import type { RuntimeManifest } from "./manifest-contract";
 import type { HostedSkillSource } from "./manifest-resources";
 import type { RuntimePaths } from "./paths";
@@ -28,7 +34,9 @@ interface HostedSourcedSkillArchiveReceipt {
 
 export interface PreparedHostedSourcedSkill {
 	skillId: string;
-	source: HostedSkillSource;
+	source:
+		| HostedSkillSource
+		| { type: "bundled"; version: number; digest: string; assetDirectory: string };
 	/** Stable canonical ownership identity; independent of tar encoding and cache lifetime. */
 	sourceIdentity: string;
 	/** Byte hash used only to detect corruption in the local archive cache. */
@@ -44,6 +52,38 @@ function sourceIdentity(skillId: string, source: HostedSkillSource): string {
 	return source.type === "github"
 		? ["github", skillId, source.url, source.path, source.commit].join("\0")
 		: ["project", skillId, source.projectId, source.contentHash].join("\0");
+}
+
+export function prepareHostedBundledSkillArchive(
+	skillId: string,
+	version: number,
+): PreparedHostedSourcedSkill {
+	const catalogEntry = resolveHostedBundledSkill(skillId, version);
+	const sourceDir = resolve(resolveCurrentCliResourceRoot(), "skills", catalogEntry.assetDirectory);
+	if (basename(sourceDir) !== skillId || !existsSync(join(sourceDir, "SKILL.md"))) {
+		throw new Error(`bundled hosted skill asset ${catalogEntry.assetDirectory} is unavailable`);
+	}
+	assertHostedBundledSkillCatalogDigest(catalogEntry, sourceDir);
+	const packed = spawnSync("tar", ["-czf", "-", "-C", dirname(sourceDir), skillId], {
+		stdio: ["ignore", "pipe", "pipe"],
+		maxBuffer: MAX_CACHED_ARCHIVE_BYTES,
+	});
+	if (packed.status !== 0 || !Buffer.isBuffer(packed.stdout)) {
+		throw new Error(`bundled hosted skill ${skillId} could not be archived`);
+	}
+	const tarBytes = packed.stdout;
+	return {
+		skillId,
+		source: {
+			type: "bundled",
+			version,
+			digest: catalogEntry.digest,
+			assetDirectory: catalogEntry.assetDirectory,
+		},
+		sourceIdentity: `content-sha256\0${catalogEntry.digest}`,
+		archiveSha256: sha256(tarBytes),
+		tarBytes,
+	};
 }
 
 function cachePaths(paths: RuntimePaths, skillId: string, source: HostedSkillSource) {
@@ -230,7 +270,11 @@ export async function prepareHostedSourcedSkillArchives(
 	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {}).sort(
 		([left], [right]) => left.localeCompare(right),
 	)) {
-		if (!desired.enabled || !("source" in desired)) continue;
+		if (!desired.enabled) continue;
+		if (!("source" in desired)) {
+			prepared.set(skillId, prepareHostedBundledSkillArchive(skillId, desired.version));
+			continue;
+		}
 		if (desired.source.type === "project") {
 			assertProjectSkillEndpoints(manifest, skillId, desired.source);
 		}

--- a/packages/cli/src/runtime/managed-skill-delivery.test.ts
+++ b/packages/cli/src/runtime/managed-skill-delivery.test.ts
@@ -69,3 +69,35 @@ test("never treats a null fingerprint as ownership of an absent target", () => {
 		rmSync(root, { recursive: true, force: true });
 	}
 });
+
+test("treats backup cleanup failure as GC after the operation commits", () => {
+	const root = mkdtempSync(join(tmpdir(), "managed-skill-commit-"));
+	try {
+		const target = join(root, "skills", "review-pr");
+		const receipt = join(root, "receipts", "review-pr.json");
+		mkdirSync(target, { recursive: true });
+		mkdirSync(join(root, "receipts"), { recursive: true });
+		writeFileSync(join(target, "SKILL.md"), "previous\n");
+		writeFileSync(receipt, "previous receipt\n");
+
+		expect(
+			withManagedTargetRollback({
+				target,
+				receipt,
+				operation: () => {
+					mkdirSync(target, { recursive: true });
+					writeFileSync(join(target, "SKILL.md"), "committed\n");
+					writeFileSync(receipt, "committed receipt\n");
+					return "installed" as const;
+				},
+				remove: () => {
+					throw new Error("injected backup cleanup failure");
+				},
+			}),
+		).toBe("installed");
+		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("committed\n");
+		expect(readFileSync(receipt, "utf8")).toBe("committed receipt\n");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/packages/cli/src/runtime/managed-skill-delivery.ts
+++ b/packages/cli/src/runtime/managed-skill-delivery.ts
@@ -11,8 +11,9 @@ import {
 	rmSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { writePrivateFileAtomic } from "../lib/private-file";
+import { managedSkillDirectoryDigest } from "./hosted-bundled-skill";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 
 const MAX_ENTRIES = 1024;
@@ -199,6 +200,9 @@ export function withStagedManagedSkill<T>(
 	skill: PreparedHostedSourcedSkill,
 	operation: (sourceDir: string) => T,
 ): T {
+	if (createHash("sha256").update(skill.tarBytes).digest("hex") !== skill.archiveSha256) {
+		throw new Error("prepared Skill archive digest mismatch");
+	}
 	const root = mkdtempSync(join(tmpdir(), "clawdi-managed-skill-"));
 	try {
 		const extracted = spawnSync("tar", ["-xzf", "-", "-C", root], {
@@ -218,6 +222,12 @@ export function withStagedManagedSkill<T>(
 			} else chmodSync(path, node.mode & 0o111 ? 0o755 : 0o644);
 		};
 		makeReadable(root);
+		if (
+			skill.source.type === "bundled" &&
+			managedSkillDirectoryDigest(sourceDir) !== skill.source.digest
+		) {
+			throw new Error("prepared bundled Skill tree digest mismatch");
+		}
 		return operation(sourceDir);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
@@ -226,16 +236,23 @@ export function withStagedManagedSkill<T>(
 
 export function withManagedTargetRollback<T>(input: {
 	target: string;
-	receipt: string;
+	receipt?: string;
 	operation: () => T;
 	rename?: typeof renameSync;
+	remove?: typeof rmSync;
 }): T {
 	const rename = input.rename ?? renameSync;
+	const remove = input.remove ?? rmSync;
 	const suffix = randomBytes(8).toString("hex");
-	const targetBackup = `${input.target}.clawdi-rollback-${suffix}`;
-	const receiptBackup = `${input.receipt}.clawdi-rollback-${suffix}`;
+	const targetBackup = join(
+		dirname(input.target),
+		`.${basename(input.target)}-clawdi-rollback-${suffix}`,
+	);
+	const receiptBackup = input.receipt
+		? join(dirname(input.receipt), `.${basename(input.receipt)}-clawdi-rollback-${suffix}`)
+		: undefined;
 	const hadTarget = existsSync(input.target);
-	const hadReceipt = existsSync(input.receipt);
+	const hadReceipt = input.receipt !== undefined && existsSync(input.receipt);
 	let targetMoved = false;
 	let receiptMoved = false;
 	try {
@@ -243,40 +260,30 @@ export function withManagedTargetRollback<T>(input: {
 			rename(input.target, targetBackup);
 			targetMoved = true;
 		}
-		if (hadReceipt) {
+		if (hadReceipt && input.receipt && receiptBackup) {
 			rename(input.receipt, receiptBackup);
 			receiptMoved = true;
 		}
 	} catch (error) {
-		if (receiptMoved) rename(receiptBackup, input.receipt);
+		if (receiptMoved && input.receipt && receiptBackup) rename(receiptBackup, input.receipt);
 		if (targetMoved) rename(targetBackup, input.target);
 		throw error;
 	}
+	let result: T;
 	try {
-		const result = input.operation();
-		rmSync(targetBackup, { recursive: true, force: true });
-		rmSync(receiptBackup, { force: true });
-		return result;
+		result = input.operation();
 	} catch (error) {
-		rmSync(input.target, { recursive: true, force: true });
-		rmSync(input.receipt, { force: true });
+		remove(input.target, { recursive: true, force: true });
+		if (input.receipt) remove(input.receipt, { force: true });
 		if (hadTarget) rename(targetBackup, input.target);
-		if (hadReceipt) rename(receiptBackup, input.receipt);
+		if (hadReceipt && input.receipt && receiptBackup) rename(receiptBackup, input.receipt);
 		throw error;
 	}
-}
-
-export function withTargetTreeRollback<T>(input: { target: string; operation: () => T }): T {
-	const backup = `${input.target}.clawdi-rollback-${randomBytes(8).toString("hex")}`;
-	const hadTarget = existsSync(input.target);
-	if (hadTarget) renameSync(input.target, backup);
+	// The operation returning is the commit point. Backup cleanup is GC and
+	// must never roll back a live target or its ownership receipt.
 	try {
-		const result = input.operation();
-		rmSync(backup, { recursive: true, force: true });
-		return result;
-	} catch (error) {
-		rmSync(input.target, { recursive: true, force: true });
-		if (hadTarget) renameSync(backup, input.target);
-		throw error;
-	}
+		remove(targetBackup, { recursive: true, force: true });
+		if (receiptBackup) remove(receiptBackup, { force: true });
+	} catch {}
+	return result;
 }

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -39,7 +39,10 @@ import {
 	type HostedAgentPluginCommandRunner,
 	hostedAgentPluginCommands,
 } from "./hosted-agent-plugin-runtime";
-import { loadHostedBundledSkill, reconcileHostedBundledSkill } from "./hosted-bundled-skill";
+import {
+	assertHostedBundledSkillCatalogDigest,
+	resolveHostedBundledSkill,
+} from "./hosted-bundled-skill";
 import { hostedAiProviderCatalog } from "./hosted-provider-resolution";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import { readRuntimeInstallReceipts } from "./install-receipts";
@@ -4268,9 +4271,9 @@ echo spawned > '${installerLog}'
 		const driftedSource = join(fixtureRoot, "drifted-skill-source");
 		cpSync(skillSource, driftedSource, { recursive: true });
 		writeFileSync(join(driftedSource, "SKILL.md"), "catalog drift\n");
-		expect(() => loadHostedBundledSkill("clawdi", 1, driftedSource)).toThrow(
-			"catalog digest mismatch",
-		);
+		expect(() =>
+			assertHostedBundledSkillCatalogDigest(resolveHostedBundledSkill("clawdi", 1), driftedSource),
+		).toThrow("catalog digest mismatch");
 
 		for (const path of protectedSourceAncestors) chmodSync(path, 0o700);
 		const accountPrivilegeTool = ["run", "user"].join("");
@@ -4387,8 +4390,10 @@ echo spawned > '${installerLog}'
 				preparedHostedSourcedSkills: new Map([[prepared.skillId, prepared]]),
 				hostedHermesSkillExactSourceDriver: {
 					install: () => "installed",
+					hasOwnershipReceipt: () => false,
 					verifyOwned: () => false,
 					uninstall: () => "removed",
+					cleanupManifestOwned: () => "removed",
 				},
 			},
 		);
@@ -4412,20 +4417,21 @@ echo spawned > '${installerLog}'
 				if (installs.length === 1) throw new Error("lost native install response");
 				return "unchanged" as const;
 			},
-			verifyOwned: (input: { skill: PreparedHostedSourcedSkill }) => {
+			hasOwnershipReceipt: (input: { ownershipIdentity: string }) => {
 				verifyCalls += 1;
 				return (
-					input.skill.sourceIdentity === prepared.sourceIdentity &&
-					JSON.stringify(input.skill.source) === JSON.stringify(prepared.source) &&
+					input.ownershipIdentity === prepared.sourceIdentity &&
 					existsSync(join(skillDir, "SKILL.md")) &&
 					readFileSync(join(skillDir, "SKILL.md"), "utf8") === "manifest-owned\n"
 				);
 			},
+			verifyOwned: () => false,
 			uninstall: () => {
 				uninstalls += 1;
 				rmSync(skillDir, { recursive: true, force: true });
 				return "removed" as const;
 			},
+			cleanupManifestOwned: () => "removed" as const,
 		};
 		const options = {
 			preparedHostedSourcedSkills: new Map([[prepared.skillId, prepared]]),
@@ -4529,11 +4535,12 @@ echo spawned > '${installerLog}'
 		expect(result.installErrors).toEqual([]);
 		const stagedSource = readFileSync(sourceLog, "utf8").trim();
 		expect(stagedSource).not.toBe(packageSource);
-		expect(stagedSource.startsWith(join(tmpdir(), "clawdi-hosted-bundled-skill-"))).toBe(true);
+		expect(stagedSource.startsWith(join(tmpdir(), "clawdi-managed-skill-"))).toBe(true);
 		expect(existsSync(stagedSource)).toBe(false);
 		expect(readFileSync(join(target, "SKILL.md"))).toEqual(
 			readFileSync(join(packageSource, "SKILL.md")),
 		);
+		expect(existsSync(join(target, ".clawdi-managed.json"))).toBe(false);
 		expect(
 			existsSync(
 				join(
@@ -4573,8 +4580,14 @@ echo spawned > '${installerLog}'
 		const openClawWorkspaceRoot = join(paths.userHome, ".openclaw", "workspace");
 		const target = join(openClawWorkspaceRoot, "skills", "clawdi");
 		const source = resolve(import.meta.dir, "../..", "skills", "hosted-versions", "1", "clawdi");
-		const bundle = loadHostedBundledSkill("clawdi", 1, source);
-		reconcileHostedBundledSkill({ bundle, targetDir: target, reserved: true });
+		mkdirSync(dirname(target), { recursive: true });
+		cpSync(source, target, { recursive: true });
+		chmodSync(target, 0o755);
+		chmodSync(join(target, "SKILL.md"), 0o644);
+		writeFileSync(
+			join(target, ".clawdi-managed.json"),
+			`${JSON.stringify({ managedBy: "clawdi runtime init", skillName: "clawdi" })}\n`,
+		);
 		const manifest = baseManifest(
 			paths,
 			{ openclaw: { enabled: true, run: runSettings(command, ["gateway"]), services: {} } },

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -28,7 +28,6 @@ import {
 } from "@clawdi/shared";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { z } from "zod";
-import { agentSkillTargetDir } from "../adapters/registry";
 import { type AgentPrimaryModel, buildAgentTargetProjection } from "../lib/ai-provider-projection";
 import {
 	decideChatGptOAuthCredentialReconciliation,
@@ -103,12 +102,8 @@ import {
 } from "./hosted-agent-plugin-runtime";
 import {
 	adoptableLegacyHostedBundledSkill,
-	assertHostedBundledSkillCatalogDigest,
 	hostedBundledSkillIds,
-	loadHostedBundledSkill,
-	reconcileHostedBundledSkill,
 	resolveHostedBundledSkill,
-	withStagedHostedBundledSkill,
 } from "./hosted-bundled-skill";
 import { managedMcpHeaderPlaceholder, normalizeSecretRef } from "./hosted-egress-profiles";
 import {
@@ -127,7 +122,10 @@ import {
 	assertHostedRuntimeContract,
 	type HostedRuntimeContractOptions,
 } from "./hosted-runtime-contract";
-import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
+import {
+	type PreparedHostedSourcedSkill,
+	prepareHostedBundledSkillArchive,
+} from "./hosted-sourced-skill-archive";
 import {
 	emptyRuntimeInstallReceipts,
 	type RuntimeInstallReceiptEntry,
@@ -157,6 +155,7 @@ import {
 } from "./managed-channel-reconciliation";
 import {
 	installReservedManagedSkill,
+	type ManagedSkillReservationSnapshot,
 	managedSkillReservationLedgerPath,
 	managedSkillReservationOwner,
 	managedSkillReservations,
@@ -174,6 +173,7 @@ import {
 } from "./manifest-contract";
 import {
 	type HostedMcpServerDesiredState,
+	type HostedSkillSource,
 	hostedMcpDesiredStateSchema,
 } from "./manifest-resources";
 import {
@@ -4053,362 +4053,288 @@ function hostedBundledSkillsEnabled(): boolean {
 	return detectRuntimeMode() === "hosted";
 }
 
-function hostedBundledSkillSourceDir(assetDirectory: string): string {
-	const sourceDir = resolve(resolveCurrentCliResourceRoot(), "skills", assetDirectory);
-	if (!existsSync(join(sourceDir, "SKILL.md"))) {
-		throw new Error(`bundled hosted skill asset ${assetDirectory} is unavailable`);
-	}
-	return sourceDir;
+type HostedSkillDesired =
+	| { enabled: boolean; version: number }
+	| { enabled: boolean; source: HostedSkillSource };
+
+interface HostedSkillProjectionDriver {
+	name: "hermes" | "openclaw";
+	enabled: boolean;
+	skillsRoot: string | null;
+	install(
+		skill: PreparedHostedSourcedSkill,
+		previouslyReserved: boolean,
+	): "installed" | "unchanged";
+	hasOwnershipReceipt(skill: PreparedHostedSourcedSkill): boolean;
+	remove(reservation: ManagedSkillReservationSnapshot, legacy: boolean): void;
 }
 
-function hostedBundledSkillTargetDir(
-	name: string,
-	skillName: string,
-	home: string,
-	openClawWorkspaceRoot?: string,
-): string | null {
-	if (name !== "openclaw" && name !== "hermes") return null;
-	if (name === "openclaw") {
-		return openClawWorkspaceRoot ? join(openClawWorkspaceRoot, "skills", skillName) : null;
+function preparedSkillMatchesDesired(
+	prepared: PreparedHostedSourcedSkill | undefined,
+	desired: HostedSkillDesired,
+	skillId: string,
+): prepared is PreparedHostedSourcedSkill {
+	if (!prepared || prepared.skillId !== skillId) return false;
+	if ("source" in desired) {
+		return JSON.stringify(prepared.source) === JSON.stringify(desired.source);
 	}
-	return agentSkillTargetDir(name, skillName, join(home, ".hermes"));
-}
-
-function managedSkillReservationDigest(targetDir: string, skillId: string): string {
-	const reservation = managedSkillReservations("hosted-manifest").find(
-		(entry) => entry.targetDir === targetDir && entry.id === skillId,
+	const catalogEntry = resolveHostedBundledSkill(skillId, desired.version);
+	return (
+		prepared.source.type === "bundled" &&
+		prepared.source.version === desired.version &&
+		prepared.source.digest === catalogEntry.digest &&
+		prepared.source.assetDirectory === catalogEntry.assetDirectory
 	);
-	if (!reservation) throw new Error(`managed Skill ${skillId} has no matching ownership receipt`);
-	if (!reservation.digest) throw new Error(`managed Skill ${skillId} has no content digest`);
-	return reservation.digest;
 }
 
-function managedSkillReservationSourceIdentity(targetDir: string, skillId: string): string {
-	const reservation = managedSkillReservations("hosted-manifest").find(
-		(entry) => entry.targetDir === targetDir && entry.id === skillId,
-	);
-	if (!reservation?.sourceIdentity)
-		throw new Error(`managed Skill ${skillId} has no canonical source identity`);
-	return reservation.sourceIdentity;
-}
-
-function validateHostedSkillsPlan(
-	name: string,
+function completePreparedHostedSkills(
 	manifest: RuntimeManifest,
-	home: string,
-	openClawWorkspaceRoot: string | null,
-	preparedSourcedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
-): void {
-	if (!hostedBundledSkillsEnabled()) return;
-	if (name === "openclaw" && !openClawWorkspaceRoot) {
-		if (manifest.runtimes.openclaw?.enabled === true) {
-			throw new Error("OpenClaw official agent workspace is unavailable");
-		}
-		return;
+	prepared: ReadonlyMap<string, PreparedHostedSourcedSkill>,
+): ReadonlyMap<string, PreparedHostedSourcedSkill> {
+	if (!hostedBundledSkillsEnabled()) return prepared;
+	const complete = new Map(prepared);
+	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
+		if (!desired.enabled || "source" in desired) continue;
+		const existing = complete.get(skillId);
+		if (preparedSkillMatchesDesired(existing, desired, skillId)) continue;
+		complete.set(skillId, prepareHostedBundledSkillArchive(skillId, desired.version));
 	}
-	for (const [skillName, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
-		const targetDir = hostedBundledSkillTargetDir(
-			name,
-			skillName,
-			home,
-			openClawWorkspaceRoot ?? undefined,
-		);
-		const runtimeEnabled = manifest.runtimes[name]?.enabled === true;
-		if ("source" in desired) {
-			if (hostedBundledSkillIds().includes(skillName)) {
-				throw new Error(`bundled hosted Skill ${skillName} must not declare a catalog source`);
-			}
-			if (
-				(name !== "hermes" && name !== "openclaw") ||
-				!targetDir ||
-				!runtimeEnabled ||
-				desired.enabled !== true
-			)
-				continue;
-			const prepared = preparedSourcedSkills.get(skillName);
-			if (!prepared || JSON.stringify(prepared.source) !== JSON.stringify(desired.source)) {
-				throw new Error(`pinned archive for hosted Skill ${skillName} is unavailable`);
-			}
-			const reservationOwner = managedSkillReservationOwner(targetDir, skillName);
-			if (existsSync(targetDir) && reservationOwner !== "hosted-manifest") {
-				throw new Error(`refusing to replace unmanaged ${skillName} skill at ${targetDir}`);
-			}
-			continue;
-		}
-		const bundled = resolveHostedBundledSkill(skillName, desired.version);
-		if (!targetDir || !runtimeEnabled || desired.enabled !== true) continue;
-		const sourceDir = hostedBundledSkillSourceDir(bundled.assetDirectory);
-		assertHostedBundledSkillCatalogDigest(bundled, sourceDir);
-		const reservationOwner = managedSkillReservationOwner(targetDir, skillName);
-		if (
-			existsSync(targetDir) &&
-			reservationOwner !== "hosted-manifest" &&
-			!adoptableLegacyHostedBundledSkill(targetDir, skillName)
-		) {
-			throw new Error(`refusing to replace unmanaged ${skillName} skill at ${targetDir}`);
-		}
-	}
+	return complete;
 }
 
-function recoverHostedSourcedSkillReservations(
+function preparedReservationIdentity(skill: PreparedHostedSourcedSkill): {
+	version?: number;
+	digest?: string;
+	sourceIdentity?: string;
+} {
+	return skill.source.type === "bundled"
+		? { version: skill.source.version, digest: skill.source.digest }
+		: { sourceIdentity: skill.sourceIdentity };
+}
+
+function reservationOwnershipIdentity(reservation: ManagedSkillReservationSnapshot): string {
+	if (reservation.sourceIdentity) return reservation.sourceIdentity;
+	if (reservation.digest) return `content-sha256\0${reservation.digest}`;
+	throw new Error(`managed Skill ${reservation.id} has no ownership identity`);
+}
+
+function hostedSkillProjectionDrivers(input: {
+	manifest: RuntimeManifest;
+	home: string;
+	openClawWorkspaceRoot: string | null;
+	hermesDriver: HostedHermesSkillExactSourceDriver;
+	openClawDriver: HostedOpenClawSkillDriver;
+}): HostedSkillProjectionDriver[] {
+	const appRoot = join(input.home, ".hermes", "hermes-agent");
+	const hermesSkillsRoot = join(input.home, ".hermes", "skills");
+	const openClawSkillsRoot = input.openClawWorkspaceRoot
+		? join(input.openClawWorkspaceRoot, "skills")
+		: null;
+	return [
+		{
+			name: "hermes",
+			enabled: input.manifest.runtimes.hermes?.enabled === true,
+			skillsRoot: hermesSkillsRoot,
+			install: (skill, previouslyReserved) =>
+				input.hermesDriver.install({
+					home: input.home,
+					appRoot,
+					skill,
+					previouslyReserved,
+				}),
+			hasOwnershipReceipt: (skill) =>
+				input.hermesDriver.hasOwnershipReceipt({
+					home: input.home,
+					skillId: skill.skillId,
+					ownershipIdentity: skill.sourceIdentity,
+				}),
+			remove: (reservation, legacy) => {
+				if (legacy) {
+					withRuntimeUserFileAccess(() =>
+						rmSync(reservation.targetDir, { recursive: true, force: true }),
+					);
+					return;
+				}
+				const ownershipIdentity = reservationOwnershipIdentity(reservation);
+				if (reservation.digest) {
+					input.hermesDriver.cleanupManifestOwned({
+						home: input.home,
+						skillId: reservation.id,
+						ownershipIdentity,
+					});
+					return;
+				}
+				input.hermesDriver.uninstall({
+					home: input.home,
+					appRoot,
+					skillId: reservation.id,
+					ownershipIdentity,
+				});
+			},
+		},
+		{
+			name: "openclaw",
+			enabled: input.manifest.runtimes.openclaw?.enabled === true,
+			skillsRoot: openClawSkillsRoot,
+			install: (skill, previouslyReserved) => {
+				if (!input.openClawWorkspaceRoot) {
+					throw new Error("OpenClaw official agent workspace is unavailable");
+				}
+				return input.openClawDriver.install({
+					home: input.home,
+					workspaceRoot: input.openClawWorkspaceRoot,
+					skill,
+					previouslyReserved,
+				});
+			},
+			hasOwnershipReceipt: (skill) => {
+				if (!input.openClawWorkspaceRoot) return false;
+				return input.openClawDriver.hasOwnershipReceipt({
+					workspaceRoot: input.openClawWorkspaceRoot,
+					skillId: skill.skillId,
+					ownershipIdentity: skill.sourceIdentity,
+				});
+			},
+			remove: (reservation, legacy) => {
+				if (!input.openClawWorkspaceRoot) {
+					throw new Error("OpenClaw official agent workspace is unavailable");
+				}
+				if (legacy) {
+					withRuntimeUserFileAccess(() =>
+						rmSync(reservation.targetDir, { recursive: true, force: true }),
+					);
+					return;
+				}
+				input.openClawDriver.cleanupManifestOwned({
+					workspaceRoot: input.openClawWorkspaceRoot,
+					skillId: reservation.id,
+					ownershipIdentity: reservationOwnershipIdentity(reservation),
+				});
+			},
+		},
+	];
+}
+
+function recoverHostedSkillReservations(
+	driver: HostedSkillProjectionDriver,
 	manifest: RuntimeManifest,
-	home: string,
-	preparedSourcedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
-	nativeReconciler: HostedHermesSkillExactSourceDriver,
+	preparedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
 ): void {
-	if (!hostedBundledSkillsEnabled() || manifest.runtimes.hermes?.enabled !== true) return;
-	const appRoot = join(home, ".hermes", "hermes-agent");
-	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {}).sort(
-		([left], [right]) => left.localeCompare(right),
-	)) {
+	if (!hostedBundledSkillsEnabled() || !driver.skillsRoot) return;
+	const desiredEntries = manifest.projection?.skills?.entries ?? {};
+	const skillIds = new Set([...Object.keys(desiredEntries), ...hostedBundledSkillIds()]);
+	for (const skillId of [...skillIds].sort()) {
+		const targetDir = join(driver.skillsRoot, skillId);
 		if (
-			desired.enabled !== true ||
-			!("source" in desired) ||
-			hostedBundledSkillIds().includes(skillId)
-		) {
-			continue;
-		}
-		const targetDir = hostedBundledSkillTargetDir("hermes", skillId, home);
-		if (
-			!targetDir ||
 			!existsSync(targetDir) ||
 			managedSkillReservationOwner(targetDir, skillId) !== "unreserved"
 		) {
 			continue;
 		}
-		const prepared = preparedSourcedSkills.get(skillId);
-		if (!prepared || JSON.stringify(prepared.source) !== JSON.stringify(desired.source)) {
-			continue;
-		}
-		if (!nativeReconciler.verifyOwned({ home, appRoot, skill: prepared })) continue;
-		reserveManagedSkill({
-			targetDir,
-			id: skillId,
-			manager: "hosted-manifest",
-			sourceIdentity: prepared.sourceIdentity,
-		});
-	}
-}
-
-function recoverHostedOpenClawSourcedSkillReservations(
-	manifest: RuntimeManifest,
-	openClawWorkspaceRoot: string,
-	prepared: ReadonlyMap<string, PreparedHostedSourcedSkill>,
-	driver: HostedOpenClawSkillDriver,
-): void {
-	if (!hostedBundledSkillsEnabled() || manifest.runtimes.openclaw?.enabled !== true) return;
-	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
-		if (
-			desired.enabled !== true ||
-			!("source" in desired) ||
-			hostedBundledSkillIds().includes(skillId)
-		)
-			continue;
-		const targetDir = join(openClawWorkspaceRoot, "skills", skillId);
-		if (!existsSync(targetDir) || managedSkillReservationOwner(targetDir, skillId) !== "unreserved")
-			continue;
-		const skill = prepared.get(skillId);
-		if (
-			!skill ||
-			JSON.stringify(skill.source) !== JSON.stringify(desired.source) ||
-			!driver.verifyOwned({ workspaceRoot: openClawWorkspaceRoot, skill })
-		)
-			continue;
-		reserveManagedSkill({
-			targetDir,
-			id: skillId,
-			manager: "hosted-manifest",
-			sourceIdentity: skill.sourceIdentity,
-		});
-	}
-}
-
-function recoverHostedOpenClawBundledSkillReservations(
-	manifest: RuntimeManifest,
-	openClawWorkspaceRoot: string,
-	driver: HostedOpenClawSkillDriver,
-): void {
-	if (!hostedBundledSkillsEnabled() || manifest.runtimes.openclaw?.enabled !== true) return;
-	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
-		if (desired.enabled !== true || "source" in desired) continue;
-		const targetDir = join(openClawWorkspaceRoot, "skills", skillId);
-		if (!existsSync(targetDir) || managedSkillReservationOwner(targetDir, skillId) !== "unreserved")
-			continue;
-		const bundled = resolveHostedBundledSkill(skillId, desired.version);
-		if (
-			!driver.hasOwnershipReceipt({
-				workspaceRoot: openClawWorkspaceRoot,
-				skillId,
-				ownershipIdentity: `content-sha256\0${bundled.digest}`,
-			})
-		)
-			continue;
-		reserveManagedSkill({
-			targetDir,
-			id: skillId,
-			manager: "hosted-manifest",
-			version: bundled.version,
-			digest: bundled.digest,
-		});
-	}
-}
-
-function applyHostedBundledSkills(
-	name: string,
-	observation: RuntimeInstallObservation | undefined,
-	manifest: RuntimeManifest,
-	home: string,
-	openClawWorkspaceRoot: string | null,
-	openClawDriver: HostedOpenClawSkillDriver,
-): string[] {
-	// Reservation state is root-authoritative. Drop privilege only inside the
-	// callbacks that mutate runtime-user-owned Skill trees.
-	const installEnabled = hostedBundledSkillsEnabled();
-	if (name === "openclaw" && !openClawWorkspaceRoot) return [];
-	const requireOpenClawWorkspace = (): string => {
-		if (!openClawWorkspaceRoot) throw new Error("OpenClaw official agent workspace is unavailable");
-		return openClawWorkspaceRoot;
-	};
-	const targets: string[] = [];
-	for (const skillName of hostedBundledSkillIds()) {
-		const targetDir = hostedBundledSkillTargetDir(
-			name,
-			skillName,
-			home,
-			openClawWorkspaceRoot ?? undefined,
-		);
-		if (!targetDir) continue;
-		targets.push(targetDir);
-		const desired = manifest.projection?.skills?.entries[skillName];
-		const runtimeEnabled = manifest.runtimes[name]?.enabled === true;
-		if (desired && "source" in desired) {
-			throw new Error(`bundled hosted Skill ${skillName} must not declare a catalog source`);
-		}
-		if (!installEnabled || !runtimeEnabled || desired?.enabled !== true) {
-			const reservationOwner = managedSkillReservationOwner(targetDir, skillName);
-			const legacy = adoptableLegacyHostedBundledSkill(targetDir, skillName);
-			const legacyAdopted = Boolean(legacy && reservationOwner === "unreserved");
-			if (reservationOwner === "local-setup") continue;
-			if (!installEnabled && reservationOwner === "unreserved" && !legacy) continue;
-			if (legacy && reservationOwner === "unreserved") {
-				reserveManagedSkill({
-					targetDir,
-					id: skillName,
-					manager: "hosted-manifest",
-					version: legacy.version,
-					digest: legacy.digest,
-				});
-			}
-			releaseManagedSkill({
+		const legacy = adoptableLegacyHostedBundledSkill(targetDir, skillId);
+		if (legacy) {
+			reserveManagedSkill({
 				targetDir,
-				id: skillName,
+				id: skillId,
 				manager: "hosted-manifest",
-				removeTarget: () =>
-					name === "openclaw" && !legacyAdopted
-						? openClawDriver.cleanupManifestOwned({
-								workspaceRoot: requireOpenClawWorkspace(),
-								skillId: skillName,
-								ownershipIdentity: `content-sha256\0${managedSkillReservationDigest(targetDir, skillName)}`,
-							})
-						: withRuntimeUserFileAccess(() => rmSync(targetDir, { recursive: true, force: true })),
+				version: legacy.version,
+				digest: legacy.digest,
 			});
 			continue;
 		}
-		if (!observation?.enabled || observation.status === "install_failed") continue;
-		const catalogEntry = resolveHostedBundledSkill(skillName, desired.version);
-		const reservationOwner = managedSkillReservationOwner(targetDir, skillName);
+		const desired = desiredEntries[skillId];
+		if (!driver.enabled || desired?.enabled !== true) continue;
+		const prepared = preparedSkills.get(skillId);
 		if (
-			existsSync(targetDir) &&
-			reservationOwner !== "hosted-manifest" &&
-			!adoptableLegacyHostedBundledSkill(targetDir, skillName)
+			!preparedSkillMatchesDesired(prepared, desired, skillId) ||
+			!driver.hasOwnershipReceipt(prepared)
 		) {
-			throw new Error(`refusing to replace unmanaged ${skillName} skill at ${targetDir}`);
+			continue;
 		}
-		const bundled = catalogEntry;
-		const sourceDir = hostedBundledSkillSourceDir(bundled.assetDirectory);
-		// Root captures and verifies the source before the callback drops to the
-		// runtime identity. The callback can only mutate the target from bytes.
-		const bundle = loadHostedBundledSkill(skillName, desired.version, sourceDir);
-		const result = installReservedManagedSkill(
-			{
-				targetDir,
-				id: skillName,
-				manager: "hosted-manifest",
-				version: desired.version,
-				digest: bundled.digest,
-			},
-			() =>
-				name === "openclaw"
-					? withStagedHostedBundledSkill(bundle, (stagedSourceDir) =>
-							openClawDriver.installDirectory({
-								home,
-								workspaceRoot: requireOpenClawWorkspace(),
-								skillId: skillName,
-								sourceDir: stagedSourceDir,
-								ownershipIdentity: `content-sha256\0${bundled.digest}`,
-							}),
-						)
-					: withRuntimeUserFileAccess(() =>
-							reconcileHostedBundledSkill({ bundle, targetDir, reserved: true }),
-						),
-		);
-		if (result === "unchanged") continue;
+		reserveManagedSkill({
+			targetDir,
+			id: skillId,
+			manager: "hosted-manifest",
+			...preparedReservationIdentity(prepared),
+		});
 	}
-	return targets;
 }
 
-function applyHostedSourcedSkills(
+function validateHostedSkillsPlan(
+	driver: HostedSkillProjectionDriver,
+	manifest: RuntimeManifest,
+	preparedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
+): void {
+	if (!hostedBundledSkillsEnabled()) return;
+	if (driver.enabled && !driver.skillsRoot) {
+		throw new Error("OpenClaw official agent workspace is unavailable");
+	}
+	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
+		if ("source" in desired && hostedBundledSkillIds().includes(skillId)) {
+			throw new Error(`bundled hosted Skill ${skillId} must not declare a catalog source`);
+		}
+		if (!("source" in desired)) resolveHostedBundledSkill(skillId, desired.version);
+		if (!driver.enabled || !driver.skillsRoot || !desired.enabled) continue;
+		const prepared = preparedSkills.get(skillId);
+		if (!preparedSkillMatchesDesired(prepared, desired, skillId)) {
+			throw new Error(`pinned archive for hosted Skill ${skillId} is unavailable`);
+		}
+		const targetDir = join(driver.skillsRoot, skillId);
+		if (
+			existsSync(targetDir) &&
+			managedSkillReservationOwner(targetDir, skillId) !== "hosted-manifest"
+		) {
+			throw new Error(`refusing to replace unmanaged ${skillId} skill at ${targetDir}`);
+		}
+	}
+}
+
+function applyHostedSkills(
+	driver: HostedSkillProjectionDriver,
 	observation: RuntimeInstallObservation | undefined,
 	manifest: RuntimeManifest,
-	home: string,
-	preparedSourcedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
-	nativeReconciler: HostedHermesSkillExactSourceDriver,
-): string[] {
-	const skillsRoot = join(home, ".hermes", "skills");
+	preparedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
+): void {
+	if (!hostedBundledSkillsEnabled() || !driver.skillsRoot) return;
 	const desiredEntries = manifest.projection?.skills?.entries ?? {};
-	const desiredCatalogIds = Object.entries(desiredEntries).flatMap(([skillId, desired]) =>
-		"source" in desired ? [skillId] : [],
+	const reservations = managedSkillReservations("hosted-manifest").filter(
+		(reservation) => dirname(reservation.targetDir) === driver.skillsRoot,
 	);
-	const previouslyManagedIds = managedSkillReservations("hosted-manifest").flatMap((reservation) =>
-		dirname(reservation.targetDir) === skillsRoot &&
-		!hostedBundledSkillIds().includes(reservation.id)
-			? [reservation.id]
-			: [],
-	);
-	const skillIds = [...new Set([...desiredCatalogIds, ...previouslyManagedIds])].sort(
-		(left, right) => left.localeCompare(right),
-	);
-	const appRoot = join(home, ".hermes", "hermes-agent");
-	const runtimeEnabled = manifest.runtimes.hermes?.enabled === true;
-	const targets: string[] = [];
-	for (const skillId of skillIds) {
-		const targetDir = hostedBundledSkillTargetDir("hermes", skillId, home);
-		if (!targetDir) continue;
-		targets.push(targetDir);
+	const skillIds = new Set([
+		...Object.keys(desiredEntries),
+		...reservations.map((reservation) => reservation.id),
+		...hostedBundledSkillIds(),
+	]);
+	for (const skillId of [...skillIds].sort()) {
+		const targetDir = join(driver.skillsRoot, skillId);
 		const desired = desiredEntries[skillId];
-		if (!runtimeEnabled || desired?.enabled !== true || !("source" in desired)) {
+		if (!driver.enabled || desired?.enabled !== true) {
 			const owner = managedSkillReservationOwner(targetDir, skillId);
-			if (owner === "unreserved") continue;
+			if (owner === "unreserved" || owner === "local-setup") continue;
 			if (owner !== "hosted-manifest") {
 				throw new Error(`managed Skill ${skillId} is owned by a different manager`);
 			}
+			const reservation = managedSkillReservations("hosted-manifest").find(
+				(entry) => entry.targetDir === targetDir && entry.id === skillId,
+			);
+			if (!reservation) throw new Error(`managed Skill ${skillId} has no ownership reservation`);
 			releaseManagedSkill({
 				targetDir,
 				id: skillId,
 				manager: "hosted-manifest",
 				removeTarget: () =>
-					nativeReconciler.uninstall({
-						home,
-						appRoot,
-						skillId,
-						ownershipIdentity: managedSkillReservationSourceIdentity(targetDir, skillId),
-					}),
+					driver.remove(
+						reservation,
+						adoptableLegacyHostedBundledSkill(targetDir, skillId) !== null,
+					),
 			});
 			continue;
 		}
 		if (!observation?.enabled || observation.status === "install_failed") continue;
-		const prepared = preparedSourcedSkills.get(skillId);
-		if (!prepared) throw new Error(`pinned archive for hosted Skill ${skillId} is unavailable`);
+		const prepared = preparedSkills.get(skillId);
+		if (!preparedSkillMatchesDesired(prepared, desired, skillId)) {
+			throw new Error(`pinned archive for hosted Skill ${skillId} is unavailable`);
+		}
 		const owner = managedSkillReservationOwner(targetDir, skillId);
 		if (existsSync(targetDir) && owner !== "hosted-manifest") {
 			throw new Error(`refusing to replace unmanaged ${skillId} skill at ${targetDir}`);
@@ -4418,84 +4344,11 @@ function applyHostedSourcedSkills(
 				targetDir,
 				id: skillId,
 				manager: "hosted-manifest",
-				sourceIdentity: prepared.sourceIdentity,
+				...preparedReservationIdentity(prepared),
 			},
-			() =>
-				nativeReconciler.install({
-					home,
-					appRoot,
-					skill: prepared,
-					previouslyReserved: owner === "hosted-manifest",
-				}),
+			() => driver.install(prepared, owner === "hosted-manifest"),
 		);
 	}
-	return targets;
-}
-
-function applyHostedOpenClawSourcedSkills(
-	observation: RuntimeInstallObservation | undefined,
-	manifest: RuntimeManifest,
-	home: string,
-	openClawWorkspaceRoot: string,
-	preparedSourcedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
-	driver: HostedOpenClawSkillDriver,
-): string[] {
-	const skillsRoot = join(openClawWorkspaceRoot, "skills");
-	const desiredEntries = manifest.projection?.skills?.entries ?? {};
-	const desiredIds = Object.entries(desiredEntries).flatMap(([id, desired]) =>
-		"source" in desired ? [id] : [],
-	);
-	const managedIds = managedSkillReservations("hosted-manifest").flatMap((reservation) =>
-		dirname(reservation.targetDir) === skillsRoot &&
-		!hostedBundledSkillIds().includes(reservation.id)
-			? [reservation.id]
-			: [],
-	);
-	const ids = [...new Set([...desiredIds, ...managedIds])].sort((left, right) =>
-		left.localeCompare(right),
-	);
-	for (const skillId of ids) {
-		const targetDir = join(skillsRoot, skillId);
-		const desired = desiredEntries[skillId];
-		if (
-			manifest.runtimes.openclaw?.enabled !== true ||
-			desired?.enabled !== true ||
-			!("source" in desired)
-		) {
-			const owner = managedSkillReservationOwner(targetDir, skillId);
-			if (owner === "unreserved") continue;
-			if (owner !== "hosted-manifest")
-				throw new Error(`managed Skill ${skillId} is owned by a different manager`);
-			releaseManagedSkill({
-				targetDir,
-				id: skillId,
-				manager: "hosted-manifest",
-				removeTarget: () =>
-					driver.cleanupManifestOwned({
-						workspaceRoot: openClawWorkspaceRoot,
-						skillId,
-						ownershipIdentity: managedSkillReservationSourceIdentity(targetDir, skillId),
-					}),
-			});
-			continue;
-		}
-		if (!observation?.enabled || observation.status === "install_failed") continue;
-		const prepared = preparedSourcedSkills.get(skillId);
-		if (!prepared) throw new Error(`pinned archive for hosted Skill ${skillId} is unavailable`);
-		const owner = managedSkillReservationOwner(targetDir, skillId);
-		if (existsSync(targetDir) && owner !== "hosted-manifest")
-			throw new Error(`refusing to replace unmanaged ${skillId} skill at ${targetDir}`);
-		installReservedManagedSkill(
-			{
-				targetDir,
-				id: skillId,
-				manager: "hosted-manifest",
-				sourceIdentity: prepared.sourceIdentity,
-			},
-			() => driver.install({ home, workspaceRoot: openClawWorkspaceRoot, skill: prepared }),
-		);
-	}
-	return ids.map((id) => join(skillsRoot, id));
 }
 
 function runHostedSkillProjectionStep(label: string, step: () => void): void {
@@ -4526,57 +4379,25 @@ function reconcileHostedSkillProjection(input: {
 		hermesDriver,
 		openClawDriver,
 	} = input;
+	const preparedSkills = completePreparedHostedSkills(manifest, preparedSourcedSkills);
+	const drivers = hostedSkillProjectionDrivers({
+		manifest,
+		home,
+		openClawWorkspaceRoot,
+		hermesDriver,
+		openClawDriver,
+	});
 	runHostedSkillProjectionStep("runtime Skill projection planning failed", () => {
-		recoverHostedSourcedSkillReservations(manifest, home, preparedSourcedSkills, hermesDriver);
-		if (openClawWorkspaceRoot) {
-			recoverHostedOpenClawBundledSkillReservations(
-				manifest,
-				openClawWorkspaceRoot,
-				openClawDriver,
-			);
-			recoverHostedOpenClawSourcedSkillReservations(
-				manifest,
-				openClawWorkspaceRoot,
-				preparedSourcedSkills,
-				openClawDriver,
-			);
-		}
-		for (const name of HOSTED_RUNTIME_TARGETS) {
-			validateHostedSkillsPlan(name, manifest, home, openClawWorkspaceRoot, preparedSourcedSkills);
+		for (const driver of drivers) {
+			recoverHostedSkillReservations(driver, manifest, preparedSkills);
+			validateHostedSkillsPlan(driver, manifest, preparedSkills);
 		}
 	});
-	for (const name of HOSTED_RUNTIME_TARGETS) {
-		runHostedSkillProjectionStep(`runtime ${name} skill projection failed`, () => {
-			applyHostedBundledSkills(
-				name,
-				observations.get(name),
-				manifest,
-				home,
-				openClawWorkspaceRoot,
-				openClawDriver,
-			);
+	for (const driver of drivers) {
+		runHostedSkillProjectionStep(`runtime ${driver.name} Skill projection failed`, () => {
+			applyHostedSkills(driver, observations.get(driver.name), manifest, preparedSkills);
 		});
 	}
-	runHostedSkillProjectionStep("runtime hermes sourced Skill projection failed", () => {
-		applyHostedSourcedSkills(
-			observations.get("hermes"),
-			manifest,
-			home,
-			preparedSourcedSkills,
-			hermesDriver,
-		);
-	});
-	if (!openClawWorkspaceRoot) return;
-	runHostedSkillProjectionStep("runtime openclaw sourced Skill delivery failed", () => {
-		applyHostedOpenClawSourcedSkills(
-			observations.get("openclaw"),
-			manifest,
-			home,
-			openClawWorkspaceRoot,
-			preparedSourcedSkills,
-			openClawDriver,
-		);
-	});
 }
 
 function applyHostedMcpProjections(
@@ -6025,43 +5846,28 @@ function hostedSkillMutationTargets(
 	openClawWorkspaceRoot: string | null,
 ): string[] {
 	const targets = new Set<string>();
-	for (const runtime of HOSTED_RUNTIME_TARGETS) {
-		for (const skillId of hostedBundledSkillIds()) {
-			const target = hostedBundledSkillTargetDir(
-				runtime,
-				skillId,
-				home,
-				openClawWorkspaceRoot ?? undefined,
-			);
-			if (target) targets.add(target);
-		}
-	}
 	const hermesSkillsRoot = join(home, ".hermes", "skills");
 	const openClawSkillsRoot = openClawWorkspaceRoot ? join(openClawWorkspaceRoot, "skills") : null;
 	let managesHermesSourcedSkill = false;
 	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
-		if (!("source" in desired)) continue;
-		if (manifest.runtimes.hermes?.enabled === true) {
+		targets.add(join(hermesSkillsRoot, skillId));
+		if (openClawSkillsRoot) targets.add(join(openClawSkillsRoot, skillId));
+		if ("source" in desired && manifest.runtimes.hermes?.enabled === true) {
 			managesHermesSourcedSkill = true;
-			targets.add(join(hermesSkillsRoot, skillId));
 		}
-		if (manifest.runtimes.openclaw?.enabled === true && openClawSkillsRoot)
-			targets.add(join(openClawSkillsRoot, skillId));
+	}
+	for (const skillId of hostedBundledSkillIds()) {
+		targets.add(join(hermesSkillsRoot, skillId));
+		if (openClawSkillsRoot) targets.add(join(openClawSkillsRoot, skillId));
 	}
 	for (const reservation of managedSkillReservations("hosted-manifest")) {
-		if (
-			dirname(reservation.targetDir) === hermesSkillsRoot &&
-			!hostedBundledSkillIds().includes(reservation.id)
-		) {
-			managesHermesSourcedSkill = true;
+		if (dirname(reservation.targetDir) === hermesSkillsRoot) {
+			if (reservation.sourceIdentity) managesHermesSourcedSkill = true;
 			targets.add(reservation.targetDir);
 		}
-		if (
-			openClawSkillsRoot &&
-			dirname(reservation.targetDir) === openClawSkillsRoot &&
-			!hostedBundledSkillIds().includes(reservation.id)
-		)
+		if (openClawSkillsRoot && dirname(reservation.targetDir) === openClawSkillsRoot) {
 			targets.add(reservation.targetDir);
+		}
 	}
 	if (managesHermesSourcedSkill) targets.add(join(hermesSkillsRoot, ".hub"));
 	return [...targets].sort();

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -15758,7 +15758,15 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			hermes: ["clawdi", "search.proxy"],
 		});
 		const hermesSkill = join(home, ".hermes", "skills", "clawdi");
-		expect(existsSync(join(hermesSkill, ".clawdi-managed.json"))).toBe(true);
+		const hermesSkillReceipt = JSON.parse(
+			readFileSync(join(dirname(hermesSkill), ".clawdi-manifest-receipts", "clawdi.json"), "utf-8"),
+		);
+		expect(hermesSkillReceipt).toEqual({
+			schemaVersion: "clawdi.hermesManifestSkillReceipt.v2",
+			skillId: "clawdi",
+			ownershipIdentity: expect.stringMatching(/^content-sha256\0[a-f0-9]{64}$/),
+			treeFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+		});
 		process.env.CLAWDI_RUNTIME_MODE = "local";
 		expect(() =>
 			convergeRuntimeManifest(load(4, "hermes", updatedServers, true), getRuntimePaths()),


### PR DESCRIPTION
## Summary

- Treat a successful managed Skill install as the commit point. Backup cleanup is best-effort GC and can no longer roll back a live target or receipt.
- Let an existing root-authoritative reservation authorize Hermes repair after tenant byte drift, matching OpenClaw while still refusing unmanaged collisions.
- Model bundled Skills as `source.type === "bundled"` prepared archives and send them through the shared reservation, driver, staging, digest, and receipt pipeline.
- Replace the bundled/sourced and Hermes/OpenClaw apply loops plus three recovery loops with one driver-table reconciliation flow.
- Retain legacy tree-marker adoption only as a read-only migration shim with an explicit removal condition. New installs never write the marker.

## Ownership and integrity

- Root-owned reservation state remains authoritative and is committed before runtime-user tree mutation.
- Prepared archive SHA-256 is checked before extraction; bundled catalog identity is checked at source and staging; drivers verify the final native target before writing a receipt.
- Receipt validation remains fail-closed for schema, Skill identity, ownership identity, mode, owner UID, and target shape.
- Unmanaged targets are never replaced. Tampered managed targets are repaired only with an existing reservation or a secure matching receipt used to recover that reservation.
- Rollback artifacts are hidden sibling paths, and post-commit cleanup failures leave the committed installation intact.

The official Hermes and OpenClaw installers still mutate fixed live paths and do not expose a safe hidden staging destination. Their single target-plus-receipt rollback wrapper is retained with the corrected commit point; the second tree-only rollback implementation was removed. Direct bundled activation continues to use `activateManagedSkillDirectory`.

## Size

`git diff --shortstat` reports 653 insertions and 1,067 deletions: net 414 lines removed. The seven delivery modules moved from 9,568 to 9,261 lines, with 213 lines removed from the bundled implementation and 194 from the manifest implementation.

## Verification

- `bun run --cwd packages/cli typecheck`
- `bunx biome check packages/cli` (326 files)
- `bun test tests/runtime.test.ts` (176 passed, 1,892 assertions)
- All Skill-focused unit tests plus `manifest-reconciliation.test.ts` (262 passed, 1,579 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
