### PR TITLE
refactor(cli): consolidate hosted systemd management

### DIFF
--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1,19 +1,8 @@
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import {
-	accessSync,
-	chmodSync,
-	chownSync,
-	constants,
-	existsSync,
-	readdirSync,
-	readFileSync,
-	statSync,
-} from "node:fs";
-import { join } from "node:path";
+import { accessSync, chmodSync, chownSync, constants, existsSync, readFileSync } from "node:fs";
 import chalk from "chalk";
 import { z } from "zod";
-import { parseDotenv } from "../lib/dotenv";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { getCliVersion } from "../lib/version";
 import {
@@ -43,7 +32,6 @@ import {
 	rollbackPendingRuntimeCliUpgrade,
 } from "../runtime/cli-update";
 import { withRuntimeConvergeLockAsync } from "../runtime/converge-lock";
-import { withEffectiveFilesystemIdentity } from "../runtime/effective-identity";
 import { buildEgressEngineEnv, SYSTEM_CA_BUNDLE } from "../runtime/egress-env";
 import { readHostPolicy } from "../runtime/host-policy";
 import { failedHostedAgentPluginsObservation } from "../runtime/hosted-agent-plugin-observation";
@@ -80,27 +68,28 @@ import {
 	type RuntimeManifestLoad,
 } from "../runtime/manifest-source";
 import { detectRuntimeMode, getRuntimePaths, type RuntimePaths } from "../runtime/paths";
-import { systemdEnvironmentFilePath } from "../runtime/runtime-systemd-reconciliation";
-import {
-	buildNumericUserCommand,
-	buildRuntimeUserCommand,
-	runtimeUserUid,
-} from "../runtime/runtime-user-command";
+import { buildNumericUserCommand } from "../runtime/runtime-user-command";
 import {
 	assertRuntimePlatformRoots,
 	buildRuntimeBootStatus,
 	ensureRuntimeStateDirs,
 	hostPolicySummary,
 	type RuntimeBootStage,
+	type RuntimeBootStatus,
 	readRuntimeBootStatus,
 	writeRuntimeBootStatus,
 	writeRuntimeWatchStatus,
 } from "../runtime/state";
 import {
-	isGeneratedRuntimeSystemdFile,
-	runtimeUserName,
-	runtimeUserSystemdEnvironment,
-} from "../runtime/systemd-user";
+	applySystemdRuntimeUpdate,
+	assertRuntimeUserCanRead,
+	RUNTIME_DAEMON_SYSTEM_UNIT,
+	RUNTIME_SIDECAR_SYSTEM_UNIT,
+	readSystemdUnitSnapshot,
+	readSystemdUserDesiredRevisions,
+	SystemdRuntimeTransaction,
+	withoutStaleSystemdUnits,
+} from "../runtime/systemd-transaction";
 import {
 	applyTransparentEgressNftRulesFromEnv,
 	cleanupTransparentEgressNftRulesFromEnv,
@@ -515,1049 +504,6 @@ function ensureRuntimeWatchNotificationSubscription(
 	return subscription;
 }
 
-function readFileIfExists(path: string): string | null {
-	if (!existsSync(path)) return null;
-	return readFileSync(path, "utf-8");
-}
-
-export interface SystemdUnitSnapshot {
-	system: Map<string, string>;
-	user: Map<string, string>;
-}
-
-type SystemdRuntimeScope = "system" | "user";
-
-type SystemdRuntimeMutationStage =
-	| "egress-prerequisite"
-	| "official-installer"
-	| "final-activation"
-	| "quiesce"
-	| "rollback";
-
-type SystemdRuntimeMutationAction =
-	| "daemon-reload"
-	| "disable"
-	| "enable"
-	| "enable-and-start"
-	| "install"
-	| "reset-failed"
-	| "restart"
-	| "start"
-	| "stop";
-
-export interface SystemdRuntimeMutationJournalEntry {
-	sequence: number;
-	stage: SystemdRuntimeMutationStage;
-	scope: SystemdRuntimeScope;
-	action: SystemdRuntimeMutationAction;
-	units: string[];
-	outcome: "pending" | "succeeded" | "failed";
-}
-
-interface SystemdUnitManagerState {
-	loadState: string;
-	activeState: string;
-	mainPid: number;
-	needDaemonReload: boolean;
-	enabledState?: string;
-}
-
-interface CommandResult {
-	status: number | null;
-	stdout: string;
-	stderr: string;
-	error?: Error;
-}
-
-const RUNTIME_WATCH_SYSTEM_UNIT = "clawdi-runtime-watch.service";
-const RUNTIME_DAEMON_SYSTEM_UNIT = "clawdi-daemon.service";
-const RUNTIME_SIDECAR_SYSTEM_UNIT = "clawdi-runtime-sidecar.service";
-const RUNTIME_REVISION_RE = /^[a-f0-9]{32}$/;
-
-const SYSTEMD_ACTIVATION_STAGES = new Set<SystemdRuntimeMutationStage>([
-	"egress-prerequisite",
-	"official-installer",
-	"final-activation",
-]);
-
-const systemdRuntimeTransactionInitialStates = new WeakMap<
-	SystemdRuntimeTransaction,
-	{ system: Map<string, SystemdUnitManagerState>; user: Map<string, SystemdUnitManagerState> }
->();
-
-export class SystemdRuntimeTransaction {
-	// Journal entries contain only systemd unit names and command outcomes. Command
-	// output, environment, process metadata, and secret material never enter it.
-	readonly journal: SystemdRuntimeMutationJournalEntry[] = [];
-
-	constructor() {
-		systemdRuntimeTransactionInitialStates.set(this, {
-			system: new Map(),
-			user: new Map(),
-		});
-	}
-
-	get state(): "pristine" | "mutated" {
-		return this.journal.some((entry) => SYSTEMD_ACTIVATION_STAGES.has(entry.stage))
-			? "mutated"
-			: "pristine";
-	}
-
-	installOfficialService(
-		paths: ReturnType<typeof getRuntimePaths>,
-		unit: string,
-		install: () => string | null,
-	): string | null {
-		return runSystemdRuntimeOfficialInstaller(paths, this, unit, install);
-	}
-
-	quiesce(
-		paths: ReturnType<typeof getRuntimePaths>,
-		affectedUserUnits: readonly string[] = [],
-	): void {
-		quiesceSystemdRuntimeCandidate(paths, this, affectedUserUnits);
-	}
-
-	rollback(paths: ReturnType<typeof getRuntimePaths>): void {
-		rollbackSystemdRuntimeTransaction(paths, this);
-	}
-}
-
-function systemdRuntimeTransactionTouchedUnits(transaction: SystemdRuntimeTransaction): {
-	systemUnits: string[];
-	userUnits: string[];
-} {
-	const systemUnits = new Set<string>();
-	const userUnits = new Set<string>();
-	for (const entry of transaction.journal) {
-		const restoresUnit =
-			SYSTEMD_ACTIVATION_STAGES.has(entry.stage) ||
-			(entry.stage === "quiesce" && entry.action === "stop");
-		if (!restoresUnit || entry.action === "daemon-reload") continue;
-		const target = entry.scope === "system" ? systemUnits : userUnits;
-		for (const unit of entry.units) target.add(unit);
-	}
-	return {
-		systemUnits: [...systemUnits].sort(),
-		userUnits: [...userUnits].sort(),
-	};
-}
-
-export function readSystemdUnitSnapshot(
-	paths: ReturnType<typeof getRuntimePaths>,
-): SystemdUnitSnapshot {
-	return {
-		system: readManagedSystemdUnits(paths.systemdSystemRoot),
-		user: readManagedSystemdUnits(paths.systemdUserRoot),
-	};
-}
-
-function systemdDesiredProgramRevision(
-	paths: ReturnType<typeof getRuntimePaths>,
-	unit: string,
-): string {
-	if (!unit.endsWith(".service")) {
-		throw new Error(`managed systemd unit has invalid name: ${unit}`);
-	}
-	const programName = unit.slice(0, -".service".length);
-	const content = readFileSync(systemdEnvironmentFilePath(paths, programName), "utf8");
-	const parsed = parseDotenv(content).filter(([key]) => key === "CLAWDI_RUNTIME_REV");
-	const declarations = content
-		.split(/\r?\n/)
-		.filter((line) => line.startsWith("CLAWDI_RUNTIME_REV="));
-	const match = /^CLAWDI_RUNTIME_REV="([a-f0-9]{32})"$/.exec(declarations[0] ?? "");
-	if (parsed.length !== 1 || declarations.length !== 1 || !match) {
-		throw new Error("invalid revision declaration");
-	}
-	return match[1];
-}
-
-function readSystemdUserDesiredRevisions(
-	paths: ReturnType<typeof getRuntimePaths>,
-	units: Iterable<string>,
-): ReadonlyMap<string, string> {
-	const revisions = new Map<string, string>();
-	for (const unit of units) {
-		try {
-			revisions.set(unit, systemdDesiredProgramRevision(paths, unit));
-		} catch {
-			// Missing or malformed predecessor authority is not eligible for adoption.
-		}
-	}
-	return revisions;
-}
-
-function readManagedSystemdUnits(root: string): Map<string, string> {
-	const units = new Map<string, string>();
-	if (!existsSync(root)) return units;
-	for (const entry of readdirSync(root)) {
-		if (entry.endsWith(".service")) {
-			const path = join(root, entry);
-			const contents = readFileIfExists(path);
-			if (
-				contents === null ||
-				(!entry.startsWith("clawdi-") && !isGeneratedRuntimeSystemdFile(contents))
-			) {
-				continue;
-			}
-			units.set(entry, contents);
-			continue;
-		}
-		if (!entry.endsWith(".service.d")) {
-			continue;
-		}
-		const unitName = entry.slice(0, -".d".length);
-		const dropInPath = join(root, entry, "10-clawdi-hosted.conf");
-		const dropIn = readFileIfExists(dropInPath);
-		if (!dropIn || !isGeneratedRuntimeSystemdFile(dropIn)) continue;
-		const base = readFileIfExists(join(root, unitName)) ?? "";
-		units.set(unitName, `${base}\n${dropIn}`);
-	}
-	return units;
-}
-
-function changedSystemdUnits(
-	before: Map<string, string>,
-	after: Map<string, string>,
-): { added: string[]; changed: string[]; removed: string[]; present: string[] } {
-	const added: string[] = [];
-	const changed: string[] = [];
-	const removed: string[] = [];
-	for (const [name, contents] of after) {
-		if (!before.has(name)) added.push(name);
-		else if (before.get(name) !== contents) changed.push(name);
-	}
-	for (const name of before.keys()) {
-		if (!after.has(name)) removed.push(name);
-	}
-	return {
-		added: added.sort(),
-		changed: changed.sort(),
-		removed: removed.sort(),
-		present: [...after.keys()].sort(),
-	};
-}
-
-function withoutStaleSystemdUnits(
-	snapshot: SystemdUnitSnapshot,
-	staleSystemUnits: readonly string[],
-	staleUserUnits: readonly string[],
-): SystemdUnitSnapshot {
-	const system = new Map(snapshot.system);
-	const user = new Map(snapshot.user);
-	for (const unit of staleSystemUnits) system.delete(unit);
-	for (const unit of staleUserUnits) user.delete(unit);
-	return { system, user };
-}
-
-export function applySystemdRuntimeUpdate(
-	paths: ReturnType<typeof getRuntimePaths>,
-	before: SystemdUnitSnapshot,
-	after: SystemdUnitSnapshot,
-	opts: {
-		transaction: SystemdRuntimeTransaction;
-		stage: Extract<SystemdRuntimeMutationStage, "egress-prerequisite" | "final-activation">;
-		forceRestartSystemUnits?: readonly string[];
-		forceStopSystemUnits?: readonly string[];
-		forceRestartUserUnits?: readonly string[];
-		recoverFailedUnits?: boolean;
-		activationScope?: {
-			systemUnits: readonly string[];
-			userUnits: readonly string[];
-		};
-		preserveActiveUnits?: boolean;
-		previousUserDesiredRevisions?: ReadonlyMap<string, string>;
-		onUserProcessRevisionAliases?: (aliases: RuntimeUserProcessRevisionAliases) => void;
-		skipActivatedSystemUnits?: readonly string[];
-	},
-): { applied: boolean; systemUnitsChanged: string[]; userUnitsChanged: string[] } {
-	const { transaction, stage } = opts;
-	const allSystem = changedSystemdUnits(before.system, after.system);
-	const allUser = changedSystemdUnits(before.user, after.user);
-	const filterChanges = (
-		changes: ReturnType<typeof changedSystemdUnits>,
-		units: readonly string[],
-	): ReturnType<typeof changedSystemdUnits> => {
-		const selected = new Set(units);
-		return {
-			added: changes.added.filter((unit) => selected.has(unit)),
-			changed: changes.changed.filter((unit) => selected.has(unit)),
-			removed: changes.removed.filter((unit) => selected.has(unit)),
-			present: changes.present.filter((unit) => selected.has(unit)),
-		};
-	};
-	const system = opts.activationScope
-		? filterChanges(allSystem, opts.activationScope.systemUnits)
-		: allSystem;
-	const user = opts.activationScope
-		? filterChanges(allUser, opts.activationScope.userUnits)
-		: allUser;
-	const systemUnitsChanged = new Set([...system.added, ...system.removed]);
-	const userUnitsChanged = new Set([...user.added, ...user.removed]);
-	const scopedSystemUnits = opts.activationScope ? new Set(opts.activationScope.systemUnits) : null;
-	const forcedSystemRestarts = (opts.forceRestartSystemUnits ?? []).filter(
-		(unit) => after.system.has(unit) && (!scopedSystemUnits || scopedSystemUnits.has(unit)),
-	);
-	const forcedSystemStops = (opts.forceStopSystemUnits ?? []).filter(
-		(unit) => after.system.has(unit) && (!scopedSystemUnits || scopedSystemUnits.has(unit)),
-	);
-	const scopedUserUnits = opts.activationScope ? new Set(opts.activationScope.userUnits) : null;
-	const forcedUserRestarts = (opts.forceRestartUserUnits ?? []).filter(
-		(unit) => after.user.has(unit) && (!scopedUserUnits || scopedUserUnits.has(unit)),
-	);
-	const recoverFailedUnits = opts.recoverFailedUnits !== false;
-	const activationChanged =
-		system.added.length > 0 ||
-		system.changed.length > 0 ||
-		system.removed.length > 0 ||
-		user.added.length > 0 ||
-		user.changed.length > 0 ||
-		user.removed.length > 0 ||
-		forcedSystemRestarts.length > 0 ||
-		forcedSystemStops.length > 0 ||
-		forcedUserRestarts.length > 0;
-	if (!shouldApplySystemdRuntimeUpdate(paths)) {
-		return {
-			applied: !activationChanged,
-			systemUnitsChanged: [...systemUnitsChanged].sort(),
-			userUnitsChanged: [...userUnitsChanged].sort(),
-		};
-	}
-	const systemStates = preflightSystemdRuntimeUnits(paths, transaction, "system", [
-		...system.present,
-		...system.removed,
-		...forcedSystemStops,
-	]);
-	const userStates = preflightSystemdRuntimeUnits(paths, transaction, "user", [
-		...user.present,
-		...user.removed,
-	]);
-	const systemManagerNeedsReload = new Set(
-		system.present.filter((unit) => systemStates.get(unit)?.needDaemonReload),
-	);
-	const userManagerNeedsReload = new Set(
-		user.present.filter((unit) => userStates.get(unit)?.needDaemonReload),
-	);
-	const changedSystemUnits = new Set(system.changed);
-	const changedUserUnits = new Set(user.changed);
-	const committedAliases = readRuntimeAppliedState(paths)?.userProcessRevisionAliases ?? {};
-	const userProcessRevisionAliases: RuntimeUserProcessRevisionAliases = {};
-	const userProcessRevisionDrift = new Set<string>();
-	for (const unit of user.present) {
-		const state = requiredSystemdUnitState(userStates, "user", unit);
-		if (state.activeState !== "active") continue;
-		const revisions = systemdProcessRevisions(paths, unit, state);
-		if (revisions.processRevision === revisions.desiredRevision) continue;
-		const committedAlias = committedAliases[unit];
-		if (
-			committedAlias?.desiredRevision === revisions.desiredRevision &&
-			committedAlias.processRevision === revisions.processRevision
-		) {
-			userProcessRevisionAliases[unit] = committedAlias;
-			continue;
-		}
-		if (
-			opts.preserveActiveUnits &&
-			opts.previousUserDesiredRevisions?.get(unit) === revisions.processRevision
-		) {
-			userProcessRevisionAliases[unit] = revisions;
-			continue;
-		}
-		userProcessRevisionDrift.add(unit);
-	}
-
-	for (const unit of system.removed) {
-		const state = requiredSystemdUnitState(systemStates, "system", unit);
-		if (unit === RUNTIME_WATCH_SYSTEM_UNIT && !systemdUnitAbsentOrInactive(state)) continue;
-		if (!systemdUnitAbsentOrInactive(state)) {
-			runJournaledSystemdMutation(transaction, stage, "system", "stop", [unit], () =>
-				systemctl(["stop", unit]),
-			);
-		}
-	}
-	for (const unit of user.removed) {
-		const state = requiredSystemdUnitState(userStates, "user", unit);
-		if (!systemdUnitAbsentOrInactive(state)) {
-			runJournaledSystemdMutation(transaction, stage, "user", "stop", [unit], () =>
-				runtimeUserSystemctl(paths, ["stop", unit]),
-			);
-		}
-		if (!systemdUnitAbsentOrDisabled(state)) {
-			runJournaledSystemdMutation(transaction, stage, "user", "disable", [unit], () =>
-				runtimeUserSystemctl(paths, ["disable", unit]),
-			);
-		}
-	}
-	for (const unit of forcedSystemStops) {
-		const state = requiredSystemdUnitState(systemStates, "system", unit);
-		if (!systemdUnitAbsentOrInactive(state)) {
-			runJournaledSystemdMutation(transaction, stage, "system", "stop", [unit], () =>
-				systemctl(["stop", unit]),
-			);
-			systemUnitsChanged.add(unit);
-		}
-	}
-
-	if (
-		system.added.length > 0 ||
-		system.changed.length > 0 ||
-		system.removed.length > 0 ||
-		systemManagerNeedsReload.size > 0
-	) {
-		runJournaledSystemdMutation(transaction, stage, "system", "daemon-reload", [], () =>
-			systemctl(["daemon-reload"]),
-		);
-	}
-	if (
-		user.added.length > 0 ||
-		user.changed.length > 0 ||
-		user.removed.length > 0 ||
-		userManagerNeedsReload.size > 0
-	) {
-		runJournaledSystemdMutation(transaction, stage, "user", "daemon-reload", [], () =>
-			runtimeUserSystemctl(paths, ["daemon-reload"]),
-		);
-	}
-
-	const addedSystemUnits = new Set(system.added);
-	const forcedRestartUnits = new Set(forcedSystemRestarts);
-	const forcedStopUnits = new Set(forcedSystemStops);
-	const skipActivatedSystemUnits = new Set(opts.skipActivatedSystemUnits ?? []);
-	const resetFailedSystemUnits: string[] = [];
-	const startSystemUnits: string[] = [];
-	const restartSystemUnits: string[] = [];
-	for (const unit of system.present) {
-		const state = requiredSystemdUnitState(systemStates, "system", unit);
-		if (forcedStopUnits.has(unit)) continue;
-		if (skipActivatedSystemUnits.has(unit)) continue;
-		if (state.activeState === "failed" && recoverFailedUnits) {
-			resetFailedSystemUnits.push(unit);
-			startSystemUnits.push(unit);
-			systemUnitsChanged.add(unit);
-			continue;
-		}
-		if (state.activeState === "inactive") {
-			startSystemUnits.push(unit);
-			systemUnitsChanged.add(unit);
-			continue;
-		}
-		if (
-			state.activeState === "active" &&
-			unit !== RUNTIME_WATCH_SYSTEM_UNIT &&
-			((changedSystemUnits.has(unit) && !opts.preserveActiveUnits) ||
-				(forcedRestartUnits.has(unit) &&
-					(!addedSystemUnits.has(unit) || unit === RUNTIME_SIDECAR_SYSTEM_UNIT)))
-		) {
-			restartSystemUnits.push(unit);
-			systemUnitsChanged.add(unit);
-		}
-	}
-	// Each reconciliation makes at most one recovery attempt per failed unit.
-	// Transitional units remain untouched and fail final proof below.
-	if (resetFailedSystemUnits.length > 0) {
-		runJournaledSystemdMutation(
-			transaction,
-			stage,
-			"system",
-			"reset-failed",
-			resetFailedSystemUnits,
-			() => systemctl(["reset-failed", ...resetFailedSystemUnits]),
-		);
-	}
-	if (startSystemUnits.length > 0) {
-		runJournaledSystemdMutation(transaction, stage, "system", "start", startSystemUnits, () =>
-			systemctl(["start", ...startSystemUnits]),
-		);
-	}
-	if (restartSystemUnits.length > 0) {
-		runJournaledSystemdMutation(transaction, stage, "system", "restart", restartSystemUnits, () =>
-			systemctl(["restart", ...restartSystemUnits]),
-		);
-	}
-
-	const resetFailedUserUnits: string[] = [];
-	const forcedRestartUserUnits = new Set(forcedUserRestarts);
-	const startUserUnits: string[] = [];
-	const enableUserUnits: string[] = [];
-	const enableAndStartUserUnits: string[] = [];
-	const restartUserUnits: string[] = [];
-	for (const unit of user.present) {
-		const state = requiredSystemdUnitState(userStates, "user", unit);
-		const enabled = systemdUnitEnabled(state);
-		if (state.activeState === "failed" && recoverFailedUnits) {
-			resetFailedUserUnits.push(unit);
-			userUnitsChanged.add(unit);
-		}
-		if (
-			state.activeState === "inactive" ||
-			(state.activeState === "failed" && recoverFailedUnits)
-		) {
-			if (enabled) startUserUnits.push(unit);
-			else enableAndStartUserUnits.push(unit);
-			userUnitsChanged.add(unit);
-			continue;
-		}
-		if (state.activeState !== "active") continue;
-		if (!enabled) {
-			enableUserUnits.push(unit);
-			userUnitsChanged.add(unit);
-		}
-		if (
-			userProcessRevisionDrift.has(unit) ||
-			(changedUserUnits.has(unit) && !opts.preserveActiveUnits) ||
-			forcedRestartUserUnits.has(unit)
-		) {
-			restartUserUnits.push(unit);
-			userUnitsChanged.add(unit);
-		}
-	}
-	for (const unit of restartUserUnits) delete userProcessRevisionAliases[unit];
-	if (resetFailedUserUnits.length > 0) {
-		runJournaledSystemdMutation(
-			transaction,
-			stage,
-			"user",
-			"reset-failed",
-			resetFailedUserUnits,
-			() => runtimeUserSystemctl(paths, ["reset-failed", ...resetFailedUserUnits]),
-		);
-	}
-	if (enableAndStartUserUnits.length > 0) {
-		runJournaledSystemdMutation(
-			transaction,
-			stage,
-			"user",
-			"enable-and-start",
-			enableAndStartUserUnits,
-			() => runtimeUserSystemctl(paths, ["enable", "--now", ...enableAndStartUserUnits]),
-		);
-	}
-	if (enableUserUnits.length > 0) {
-		runJournaledSystemdMutation(transaction, stage, "user", "enable", enableUserUnits, () =>
-			runtimeUserSystemctl(paths, ["enable", ...enableUserUnits]),
-		);
-	}
-	if (startUserUnits.length > 0) {
-		runJournaledSystemdMutation(transaction, stage, "user", "start", startUserUnits, () =>
-			runtimeUserSystemctl(paths, ["start", ...startUserUnits]),
-		);
-	}
-	if (restartUserUnits.length > 0) {
-		runJournaledSystemdMutation(transaction, stage, "user", "restart", restartUserUnits, () =>
-			runtimeUserSystemctl(paths, ["restart", ...restartUserUnits]),
-		);
-	}
-
-	const systemConverged = system.present.every((unit) => {
-		const state = systemdUnitManagerState(paths, "system", unit);
-		if (forcedStopUnits.has(unit)) return systemdUnitAbsentOrInactive(state);
-		return (
-			state.loadState !== "not-found" && state.activeState === "active" && !state.needDaemonReload
-		);
-	});
-	const userConverged = user.present.every((unit) => {
-		const state = systemdUnitManagerState(paths, "user", unit);
-		if (
-			state.loadState === "not-found" ||
-			state.activeState !== "active" ||
-			state.needDaemonReload ||
-			!systemdUnitEnabled(state)
-		) {
-			return false;
-		}
-		const revisions = systemdProcessRevisions(paths, unit, state);
-		const alias = userProcessRevisionAliases[unit];
-		return (
-			revisions.processRevision === revisions.desiredRevision ||
-			(alias?.desiredRevision === revisions.desiredRevision &&
-				alias.processRevision === revisions.processRevision)
-		);
-	});
-	const removedSystemConverged = system.removed.every(
-		(unit) =>
-			unit === RUNTIME_WATCH_SYSTEM_UNIT ||
-			systemdUnitAbsentOrInactive(systemdUnitManagerState(paths, "system", unit)),
-	);
-	const removedUserConverged = user.removed.every((unit) => {
-		const state = systemdUnitManagerState(paths, "user", unit);
-		return systemdUnitAbsentOrInactive(state) && systemdUnitAbsentOrDisabled(state);
-	});
-	const applied =
-		systemConverged && userConverged && removedSystemConverged && removedUserConverged;
-	if (applied) opts.onUserProcessRevisionAliases?.(userProcessRevisionAliases);
-	return {
-		applied,
-		systemUnitsChanged: [...systemUnitsChanged].sort(),
-		userUnitsChanged: [...userUnitsChanged].sort(),
-	};
-}
-
-function quiesceSystemdRuntimeCandidate(
-	paths: ReturnType<typeof getRuntimePaths>,
-	transaction: SystemdRuntimeTransaction,
-	affectedUserUnits: readonly string[],
-): void {
-	if (!shouldApplySystemdRuntimeUpdate(paths)) return;
-	const candidateUnits = systemdRuntimeCandidateUnits(transaction);
-	const userUnits = [...new Set([...candidateUnits.user, ...affectedUserUnits])]
-		.filter((unit) => unit !== RUNTIME_WATCH_SYSTEM_UNIT)
-		.sort();
-	const userStates = preflightSystemdRuntimeUnits(paths, transaction, "user", userUnits);
-	for (const unit of userUnits) {
-		const state = requiredSystemdUnitState(userStates, "user", unit);
-		if (systemdUnitAbsentOrInactive(state)) continue;
-		runJournaledSystemdMutation(transaction, "quiesce", "user", "stop", [unit], () =>
-			runtimeUserSystemctl(paths, ["stop", unit]),
-		);
-	}
-	const systemUnits = [...candidateUnits.system]
-		.filter((unit) => unit !== RUNTIME_WATCH_SYSTEM_UNIT)
-		.sort();
-	for (const unit of systemUnits) {
-		const state = systemdUnitManagerState(paths, "system", unit);
-		if (systemdUnitAbsentOrInactive(state)) continue;
-		runJournaledSystemdMutation(transaction, "quiesce", "system", "stop", [unit], () =>
-			systemctl(["stop", unit]),
-		);
-	}
-}
-
-function systemdRuntimeCandidateUnits(transaction: SystemdRuntimeTransaction): {
-	system: Set<string>;
-	user: Set<string>;
-} {
-	const candidateActions = new Set<SystemdRuntimeMutationAction>([
-		"enable-and-start",
-		"install",
-		"restart",
-		"start",
-	]);
-	const candidateUnits = { system: new Set<string>(), user: new Set<string>() };
-	for (const entry of transaction.journal) {
-		if (!SYSTEMD_ACTIVATION_STAGES.has(entry.stage) || !candidateActions.has(entry.action)) {
-			continue;
-		}
-		for (const unit of entry.units) candidateUnits[entry.scope].add(unit);
-	}
-	return candidateUnits;
-}
-
-function rollbackSystemdRuntimeTransaction(
-	paths: ReturnType<typeof getRuntimePaths>,
-	transaction: SystemdRuntimeTransaction,
-): void {
-	const activationJournal = transaction.journal.filter((entry) =>
-		SYSTEMD_ACTIVATION_STAGES.has(entry.stage),
-	);
-	const touched = systemdRuntimeTransactionTouchedUnits(transaction);
-	const reloadSystem = activationJournal.some(
-		(entry) => entry.scope === "system" && entry.action === "daemon-reload",
-	);
-	const reloadUser = activationJournal.some(
-		(entry) =>
-			entry.scope === "user" && (entry.action === "daemon-reload" || entry.action === "install"),
-	);
-	if (reloadSystem) {
-		runJournaledSystemdMutation(transaction, "rollback", "system", "daemon-reload", [], () =>
-			systemctl(["daemon-reload"]),
-		);
-	}
-	if (reloadUser) {
-		runJournaledSystemdMutation(transaction, "rollback", "user", "daemon-reload", [], () =>
-			runtimeUserSystemctl(paths, ["daemon-reload"]),
-		);
-	}
-	for (const unit of touched.systemUnits) {
-		const initial = systemdRuntimeTransactionStates(transaction).system.get(unit);
-		if (!initial || initial.loadState === "not-found" || initial.activeState !== "active") continue;
-		restoreActiveSystemdUnit(paths, transaction, "system", unit);
-	}
-	for (const unit of touched.userUnits) {
-		const initial = systemdRuntimeTransactionStates(transaction).user.get(unit);
-		if (!initial || initial.loadState === "not-found") continue;
-		const initiallyEnabled = systemdUnitEnabled(initial);
-		const currentlyEnabled = systemdUnitEnabled(systemdUnitManagerState(paths, "user", unit));
-		if (initiallyEnabled !== currentlyEnabled) {
-			const action = initiallyEnabled ? "enable" : "disable";
-			runJournaledSystemdMutation(transaction, "rollback", "user", action, [unit], () =>
-				runtimeUserSystemctl(paths, [action, unit]),
-			);
-		}
-		if (initial.activeState !== "active") continue;
-		restoreActiveSystemdUnit(paths, transaction, "user", unit);
-		const restored = systemdUnitManagerState(paths, "user", unit);
-		if (systemdUnitEnabled(restored) !== initiallyEnabled) {
-			throw new Error(`systemd rollback did not restore user unit ${unit} enablement`);
-		}
-		if (!systemdProcessRevisionMatches(paths, unit, restored)) {
-			throw new Error(`systemd rollback restored stale runtime revision for ${unit}`);
-		}
-	}
-}
-
-function restoreActiveSystemdUnit(
-	paths: ReturnType<typeof getRuntimePaths>,
-	transaction: SystemdRuntimeTransaction,
-	scope: SystemdRuntimeScope,
-	unit: string,
-): void {
-	let current = systemdUnitManagerState(paths, scope, unit);
-	const mutate = (
-		action: Extract<SystemdRuntimeMutationAction, "reset-failed" | "start" | "stop">,
-	) =>
-		runJournaledSystemdMutation(transaction, "rollback", scope, action, [unit], () =>
-			scope === "system" ? systemctl([action, unit]) : runtimeUserSystemctl(paths, [action, unit]),
-		);
-	if (current.activeState === "failed") {
-		mutate("reset-failed");
-		current = systemdUnitManagerState(paths, scope, unit);
-	}
-	if (current.activeState !== "active") {
-		if (current.activeState !== "inactive") {
-			throw new Error(
-				`systemd rollback could not restore ${scope} unit ${unit} from ${current.activeState}`,
-			);
-		}
-		mutate("start");
-		current = systemdUnitManagerState(paths, scope, unit);
-	}
-	if (current.activeState !== "active") {
-		throw new Error(`systemd rollback did not restore ${scope} unit ${unit} activity`);
-	}
-}
-
-function runSystemdRuntimeOfficialInstaller(
-	paths: ReturnType<typeof getRuntimePaths>,
-	transaction: SystemdRuntimeTransaction,
-	unit: string,
-	install: () => string | null,
-): string | null {
-	const states = preflightSystemdRuntimeUnits(paths, transaction, "user", [unit]);
-	const state = requiredSystemdUnitState(states, "user", unit);
-	if (state.activeState === "active") {
-		systemdProcessRevisionMatches(paths, unit, state);
-	}
-	return runJournaledSystemdMutation(
-		transaction,
-		"official-installer",
-		"user",
-		"install",
-		[unit],
-		install,
-		(error) => error !== null,
-	);
-}
-
-function preflightSystemdRuntimeUnits(
-	paths: ReturnType<typeof getRuntimePaths>,
-	transaction: SystemdRuntimeTransaction,
-	scope: SystemdRuntimeScope,
-	units: readonly string[],
-): Map<string, SystemdUnitManagerState> {
-	const states = new Map<string, SystemdUnitManagerState>();
-	const initialStates = systemdRuntimeTransactionStates(transaction)[scope];
-	for (const unit of [...new Set(units)].sort()) {
-		const state = systemdUnitManagerState(paths, scope, unit);
-		states.set(unit, state);
-		if (!initialStates.has(unit)) initialStates.set(unit, state);
-	}
-	return states;
-}
-
-function systemdRuntimeTransactionStates(transaction: SystemdRuntimeTransaction): {
-	system: Map<string, SystemdUnitManagerState>;
-	user: Map<string, SystemdUnitManagerState>;
-} {
-	const states = systemdRuntimeTransactionInitialStates.get(transaction);
-	if (!states) throw new Error("systemd runtime transaction is not initialized");
-	return states;
-}
-function requiredSystemdUnitState(
-	states: ReadonlyMap<string, SystemdUnitManagerState>,
-	scope: SystemdRuntimeScope,
-	unit: string,
-): SystemdUnitManagerState {
-	const state = states.get(unit);
-	if (!state) throw new Error(`systemd ${scope} unit ${unit} was not preflighted`);
-	return state;
-}
-
-function runJournaledSystemdMutation<T>(
-	transaction: SystemdRuntimeTransaction,
-	stage: SystemdRuntimeMutationStage,
-	scope: SystemdRuntimeScope,
-	action: SystemdRuntimeMutationAction,
-	units: readonly string[],
-	mutation: () => T,
-	failed: (result: T) => boolean = () => false,
-): T {
-	const entry: SystemdRuntimeMutationJournalEntry = {
-		sequence: transaction.journal.length + 1,
-		stage,
-		scope,
-		action,
-		units: [...new Set(units)].sort(),
-		outcome: "pending",
-	};
-	transaction.journal.push(entry);
-	try {
-		const result = mutation();
-		entry.outcome = failed(result) ? "failed" : "succeeded";
-		return result;
-	} catch (error) {
-		entry.outcome = "failed";
-		throw error;
-	}
-}
-
-function systemdUnitManagerState(
-	paths: ReturnType<typeof getRuntimePaths>,
-	scope: "system" | "user",
-	unit: string,
-): SystemdUnitManagerState {
-	const showArgs = [
-		"show",
-		unit,
-		"--property=LoadState",
-		"--property=ActiveState",
-		"--property=MainPID",
-		"--property=NeedDaemonReload",
-	];
-	const show =
-		scope === "system" ? systemctlResult(showArgs) : runtimeUserSystemctlResult(paths, showArgs);
-	assertCommandSucceeded(scope === "system" ? systemctlPath() : "systemctl --user", showArgs, show);
-	const properties = Object.fromEntries(
-		show.stdout
-			.split("\n")
-			.map((line) => line.trim())
-			.filter(Boolean)
-			.map((line) => {
-				const separator = line.indexOf("=");
-				return separator < 0 ? [line, ""] : [line.slice(0, separator), line.slice(separator + 1)];
-			}),
-	);
-	const loadState = properties.LoadState;
-	const activeState = properties.ActiveState;
-	const mainPidValue = properties.MainPID;
-	const needDaemonReload = properties.NeedDaemonReload;
-	if (!loadState || !activeState || mainPidValue === undefined || !needDaemonReload) {
-		throw new Error(`systemd ${scope} unit ${unit} returned incomplete manager state`);
-	}
-	if (!/^(0|[1-9]\d*)$/.test(mainPidValue)) {
-		throw new Error(`systemd ${scope} unit ${unit} returned invalid MainPID`);
-	}
-	const mainPid = Number(mainPidValue);
-	if (!Number.isSafeInteger(mainPid)) {
-		throw new Error(`systemd ${scope} unit ${unit} returned invalid MainPID`);
-	}
-	if (needDaemonReload !== "yes" && needDaemonReload !== "no") {
-		throw new Error(
-			`systemd ${scope} unit ${unit} returned invalid NeedDaemonReload: ${needDaemonReload}`,
-		);
-	}
-	const managerState = {
-		loadState,
-		activeState,
-		mainPid,
-		needDaemonReload: needDaemonReload === "yes",
-	};
-	if (scope === "system") return managerState;
-
-	const enabledArgs = ["is-enabled", unit];
-	const enabled = runtimeUserSystemctlResult(paths, enabledArgs);
-	const enabledState = enabled.stdout.trim().split(/\s+/)[0] ?? "";
-	if (!SYSTEMD_ENABLED_STATES.has(enabledState) && !SYSTEMD_DISABLED_STATES.has(enabledState)) {
-		assertCommandSucceeded("systemctl --user", enabledArgs, enabled);
-		throw new Error(`systemd user unit ${unit} returned unknown enabled state: ${enabledState}`);
-	}
-	return { ...managerState, enabledState };
-}
-
-function systemdProcessRevisionMatches(
-	paths: ReturnType<typeof getRuntimePaths>,
-	unit: string,
-	state: SystemdUnitManagerState,
-): boolean {
-	const revisions = systemdProcessRevisions(paths, unit, state);
-	return revisions.processRevision === revisions.desiredRevision;
-}
-
-function systemdProcessRevisions(
-	paths: ReturnType<typeof getRuntimePaths>,
-	unit: string,
-	state: SystemdUnitManagerState,
-): { desiredRevision: string; processRevision: string } {
-	if (state.mainPid === 0) {
-		throw new Error(`active managed systemd unit ${unit} has no MainPID`);
-	}
-	let desiredRevision: string;
-	try {
-		desiredRevision = systemdDesiredProgramRevision(paths, unit);
-	} catch (error) {
-		throw new Error(`could not prove desired runtime revision for managed systemd unit ${unit}`, {
-			cause: error,
-		});
-	}
-
-	let processRevision: string;
-	try {
-		const procDir = `/proc/${state.mainPid}`;
-		const owner = statSync(procDir);
-		const readEnvironment = () => readFileSync(join(procDir, "environ"));
-		let environment: Buffer;
-		try {
-			environment = readEnvironment();
-		} catch (error) {
-			const code = (error as NodeJS.ErrnoException).code;
-			if (owner.uid === 0 || (code !== "EACCES" && code !== "EPERM")) throw error;
-			environment = withEffectiveFilesystemIdentity(
-				{ uid: owner.uid, gid: owner.gid },
-				readEnvironment,
-			);
-		}
-		processRevision = runtimeRevisionFromProcessEnvironment(environment);
-	} catch (error) {
-		throw new Error(`could not prove active runtime revision for managed systemd unit ${unit}`, {
-			cause: error,
-		});
-	}
-	return { desiredRevision, processRevision };
-}
-
-function runtimeRevisionFromProcessEnvironment(environment: Buffer): string {
-	const prefix = Buffer.from("CLAWDI_RUNTIME_REV=");
-	const revisions: string[] = [];
-	for (let start = 0; start < environment.length; ) {
-		const separator = environment.indexOf(0, start);
-		const end = separator < 0 ? environment.length : separator;
-		const entry = environment.subarray(start, end);
-		if (entry.subarray(0, prefix.length).equals(prefix)) {
-			revisions.push(entry.subarray(prefix.length).toString("ascii"));
-		}
-		start = end + 1;
-	}
-	if (revisions.length !== 1 || !RUNTIME_REVISION_RE.test(revisions[0])) {
-		throw new Error("invalid revision entry");
-	}
-	return revisions[0];
-}
-
-const SYSTEMD_ENABLED_STATES = new Set([
-	"enabled",
-	"enabled-runtime",
-	"linked",
-	"linked-runtime",
-	"alias",
-]);
-const SYSTEMD_DISABLED_STATES = new Set([
-	"disabled",
-	"not-found",
-	"static",
-	"indirect",
-	"masked",
-	"generated",
-	"transient",
-]);
-
-function systemdUnitEnabled(state: SystemdUnitManagerState): boolean {
-	return state.enabledState !== undefined && SYSTEMD_ENABLED_STATES.has(state.enabledState);
-}
-
-function systemdUnitAbsentOrInactive(state: SystemdUnitManagerState): boolean {
-	return state.loadState === "not-found" || state.activeState === "inactive";
-}
-
-function systemdUnitAbsentOrDisabled(state: SystemdUnitManagerState): boolean {
-	return (
-		state.loadState === "not-found" ||
-		state.enabledState === "not-found" ||
-		state.enabledState === "disabled"
-	);
-}
-
-function shouldApplySystemdRuntimeUpdate(paths: ReturnType<typeof getRuntimePaths>): boolean {
-	const override = process.env.CLAWDI_SYSTEMD_APPLY?.trim().toLowerCase();
-	if (override === "1" || override === "true") return true;
-	if (override === "0" || override === "false") return false;
-	return paths.systemdSystemRoot === "/run/systemd/system";
-}
-
-function systemctl(args: string[]): string {
-	return runCommand(systemctlPath(), args);
-}
-
-function systemctlResult(args: string[]): CommandResult {
-	return runCommandResult(systemctlPath(), args);
-}
-
-function systemctlPath(): string {
-	return process.env.CLAWDI_SYSTEMCTL_PATH?.trim() || "systemctl";
-}
-
-function runtimeUserSystemctl(paths: ReturnType<typeof getRuntimePaths>, args: string[]): string {
-	const result = runtimeUserSystemctlResult(paths, args);
-	assertCommandSucceeded("systemctl --user", args, result);
-	return [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
-}
-
-function runtimeUserSystemctlResult(
-	paths: ReturnType<typeof getRuntimePaths>,
-	args: string[],
-): CommandResult {
-	const runtimeUser = runtimeUserName();
-	if (runtimeUser !== "root") {
-		const uid = String(runtimeUserUid(runtimeUser));
-		const child = buildRuntimeUserCommand(
-			runtimeUser,
-			paths.userHome,
-			systemctlPath(),
-			["--user", ...args],
-			{ environment: runtimeUserSystemdEnvironment(uid) },
-		);
-		return runCommandResult(child.command, child.args, child.env);
-	}
-	return runCommandResult(systemctlPath(), ["--user", ...args]);
-}
-
-function assertRuntimeUserCanRead(path: string, home: string): void {
-	const runtimeUser = runtimeUserName();
-	const proof = buildRuntimeUserCommand(runtimeUser, home, "test", ["-r", path]);
-	runCommand(proof.command, proof.args, proof.env);
-}
-
-function runCommand(command: string, args: string[], env?: Record<string, string>): string {
-	const result = runCommandResult(command, args, env);
-	assertCommandSucceeded(command, args, result);
-	return [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
-}
-
-function runCommandResult(
-	command: string,
-	args: string[],
-	env?: Record<string, string>,
-): CommandResult {
-	const result = spawnSync(command, args, {
-		encoding: "utf8",
-		...(env ? { env: { ...process.env, ...env } } : {}),
-	});
-	return {
-		status: result.status,
-		stdout: result.stdout ?? "",
-		stderr: result.stderr ?? "",
-		...(result.error ? { error: result.error } : {}),
-	};
-}
-
-function assertCommandSucceeded(command: string, args: string[], result: CommandResult): void {
-	if (result.status === 0) return;
-	const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
-	throw new Error(
-		`${command} ${args.join(" ")} failed${result.status === null ? "" : ` (${result.status})`}${
-			result.error ? `: ${result.error.message}` : ""
-		}${output ? `: ${output.slice(0, 1000)}` : ""}`,
-	);
-}
-
 function emitRuntimeWatchEvent(value: unknown, json: boolean | undefined): void {
 	if (json) {
 		console.log(JSON.stringify(value));
@@ -1583,34 +529,51 @@ function emitRuntimeWatchEvent(value: unknown, json: boolean | undefined): void 
 	}
 }
 
-function repairStatus(
-	input: {
-		bootId: string;
-		stage: RuntimeBootStage;
-		runtimeMode: "local" | "hosted";
-		errors: string[];
-		exitCode: number;
+function emitRuntimeInitStatus(input: {
+	opts: RuntimeInitOptions;
+	paths: RuntimePaths;
+	status: Parameters<typeof buildRuntimeBootStatus>[0];
+	persist?: boolean;
+	jsonExtras?: Record<string, unknown>;
+	render?: (status: RuntimeBootStatus) => void;
+}): void {
+	const status = buildRuntimeBootStatus(input.status, input.paths);
+	if (input.persist !== false) writeRuntimeBootStatus(status, input.paths);
+	if (input.opts.json || !process.stdout.isTTY) {
+		console.log(
+			JSON.stringify(input.jsonExtras ? { ...status, ...input.jsonExtras } : status, null, 2),
+		);
+	} else {
+		input.render?.(status);
+	}
+	process.exitCode = status.exitCode;
+}
+
+function emitRuntimeInitRepair(
+	input: Pick<RuntimeBootStatus, "bootId" | "stage" | "runtimeMode" | "errors" | "exitCode"> & {
+		opts: RuntimeInitOptions;
+		paths: RuntimePaths;
+		persist?: boolean;
+		render?: (status: RuntimeBootStatus) => void;
 	},
-	paths = getRuntimePaths(),
-) {
-	const policy = readHostPolicy(paths.hostPolicy);
-	return buildRuntimeBootStatus(
-		{
+): void {
+	const { opts, paths, persist, render, ...repair } = input;
+	emitRuntimeInitStatus({
+		opts,
+		paths,
+		status: {
+			...repair,
 			mode: "repair",
 			status: "error",
-			stage: input.stage,
-			bootId: input.bootId,
-			runtimeMode: input.runtimeMode,
 			activeGeneration: null,
 			enabledRuntimes: [],
-			error: input.errors[0],
-			errors: input.errors,
-			exitCode: input.exitCode,
+			error: repair.errors[0],
 			datasource: "RuntimeSource",
-			hostPolicy: hostPolicySummary(policy),
+			hostPolicy: hostPolicySummary(readHostPolicy(paths.hostPolicy)),
 		},
-		paths,
-	);
+		persist,
+		render,
+	});
 }
 
 function finishRuntimeInitCliHandoff(input: {
@@ -1625,8 +588,10 @@ function finishRuntimeInitCliHandoff(input: {
 		| { reconciliation: RuntimeCliReconciliationResult };
 }): void {
 	const activeAppliedState = readRuntimeAppliedState(input.paths);
-	const status = buildRuntimeBootStatus(
-		{
+	emitRuntimeInitStatus({
+		opts: input.opts,
+		paths: input.paths,
+		status: {
 			mode: input.manifestLoad?.offline ? "degraded-offline" : "normal",
 			status: "ok",
 			stage: "config",
@@ -1650,28 +615,17 @@ function finishRuntimeInitCliHandoff(input: {
 					}
 				: {}),
 		},
-		input.paths,
-	);
-	writeRuntimeBootStatus(status, input.paths);
-	if (input.opts.json || !process.stdout.isTTY) {
-		console.log(
-			JSON.stringify(
-				{
-					...status,
-					handoff: "cli_reexec",
-					...input.detail,
-					selfReexec: true,
-				},
-				null,
-				2,
-			),
-		);
-	} else {
-		console.log(chalk.bold("clawdi runtime init"));
-		console.log(chalk.green("  CLI activated; restarting under the managed binary"));
-		console.log(chalk.gray(`  status: ${input.paths.bootStatus}`));
-	}
-	process.exitCode = RUNTIME_INIT_CLI_HANDOFF_EXIT_CODE;
+		jsonExtras: {
+			handoff: "cli_reexec",
+			...input.detail,
+			selfReexec: true,
+		},
+		render: () => {
+			console.log(chalk.bold("clawdi runtime init"));
+			console.log(chalk.green("  CLI activated; restarting under the managed binary"));
+			console.log(chalk.gray(`  status: ${input.paths.bootStatus}`));
+		},
+	});
 }
 
 export async function runtimeVerify(opts: RuntimeVerifyOptions = {}) {
@@ -1718,24 +672,20 @@ export async function runtimeInit(opts: RuntimeInitOptions = {}) {
 	const bootId = randomUUID();
 
 	if (mode !== "hosted") {
-		const status = repairStatus(
-			{
-				bootId,
-				runtimeMode: mode,
-				stage: "detect",
-				exitCode: 2,
-				errors: [
-					"runtime init requires CLAWDI_RUNTIME_MODE=hosted explicitly; host policy files do not select runtime mode",
-				],
-			},
+		emitRuntimeInitRepair({
+			opts,
 			paths,
-		);
-		if (opts.json || !process.stdout.isTTY) {
-			console.log(JSON.stringify(status, null, 2));
-		} else {
-			console.log(chalk.red("runtime init is only available in hosted runtime mode."));
-		}
-		process.exitCode = 2;
+			bootId,
+			runtimeMode: mode,
+			stage: "detect",
+			exitCode: 2,
+			errors: [
+				"runtime init requires CLAWDI_RUNTIME_MODE=hosted explicitly; host policy files do not select runtime mode",
+			],
+			persist: false,
+			render: () =>
+				console.log(chalk.red("runtime init is only available in hosted runtime mode.")),
+		});
 		return;
 	}
 	let applyContext: RuntimeApplyContext;
@@ -1747,41 +697,37 @@ export async function runtimeInit(opts: RuntimeInitOptions = {}) {
 		});
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		const status = repairStatus(
-			{
-				bootId,
-				runtimeMode: mode,
-				stage: "detect",
-				exitCode: 20,
-				errors: [message],
-			},
+		emitRuntimeInitRepair({
+			opts,
 			paths,
-		);
-		if (opts.json || !process.stdout.isTTY) console.log(JSON.stringify(status, null, 2));
-		else console.log(chalk.red(message));
-		process.exitCode = 20;
+			bootId,
+			runtimeMode: mode,
+			stage: "detect",
+			exitCode: 20,
+			errors: [message],
+			persist: false,
+			render: () => console.log(chalk.red(message)),
+		});
 		return;
 	}
 	try {
 		ensureRuntimeStateDirs(paths);
 	} catch (error) {
-		const status = repairStatus(
-			{
-				bootId,
-				runtimeMode: mode,
-				stage: "detect",
-				exitCode: 20,
-				errors: [
-					`could not create runtime state directories: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
-				],
-			},
+		emitRuntimeInitRepair({
+			opts,
 			paths,
-		);
-		if (opts.json || !process.stdout.isTTY) console.log(JSON.stringify(status, null, 2));
-		else console.log(chalk.red(status.error));
-		process.exitCode = 20;
+			bootId,
+			runtimeMode: mode,
+			stage: "detect",
+			exitCode: 20,
+			errors: [
+				`could not create runtime state directories: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			],
+			persist: false,
+			render: (status) => console.log(chalk.red(status.error)),
+		});
 		return;
 	}
 	return withRuntimeConvergeLockAsync(paths, () =>
@@ -1811,20 +757,16 @@ async function runtimeInitLocked(
 		}
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		const status = repairStatus(
-			{
-				bootId,
-				runtimeMode: mode,
-				stage: "local",
-				exitCode: 23,
-				errors: [message],
-			},
+		emitRuntimeInitRepair({
+			opts,
 			paths,
-		);
-		writeRuntimeBootStatus(status, paths);
-		if (opts.json || !process.stdout.isTTY) console.log(JSON.stringify(status, null, 2));
-		else console.log(chalk.red(message));
-		process.exitCode = 23;
+			bootId,
+			runtimeMode: mode,
+			stage: "local",
+			exitCode: 23,
+			errors: [message],
+			render: () => console.log(chalk.red(message)),
+		});
 		return;
 	}
 
@@ -1842,8 +784,10 @@ async function runtimeInitLocked(
 			stage = loaded.stage;
 			exitCode = loaded.mode === "manifest-rejected" ? 22 : 21;
 			errors.push(...loaded.errors);
-			const status = buildRuntimeBootStatus(
-				{
+			emitRuntimeInitStatus({
+				opts,
+				paths,
+				status: {
 					mode: loaded.mode,
 					status: "error",
 					stage,
@@ -1858,18 +802,12 @@ async function runtimeInitLocked(
 					datasource: "RuntimeSource",
 					hostPolicy: hostPolicySummary(hostPolicy),
 				},
-				paths,
-			);
-			writeRuntimeBootStatus(status, paths);
-
-			if (opts.json || !process.stdout.isTTY) {
-				console.log(JSON.stringify(status, null, 2));
-			} else {
-				console.log(chalk.bold("clawdi runtime init"));
-				console.log(chalk.yellow(`  ${loaded.mode}: ${errors[0]}`));
-				console.log(chalk.gray(`  status: ${paths.bootStatus}`));
-			}
-			process.exitCode = exitCode;
+				render: () => {
+					console.log(chalk.bold("clawdi runtime init"));
+					console.log(chalk.yellow(`  ${loaded.mode}: ${errors[0]}`));
+					console.log(chalk.gray(`  status: ${paths.bootStatus}`));
+				},
+			});
 			return;
 		}
 
@@ -1903,8 +841,10 @@ async function runtimeInitLocked(
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			const activeAppliedState = readRuntimeAppliedState(paths);
-			const status = buildRuntimeBootStatus(
-				{
+			emitRuntimeInitStatus({
+				opts,
+				paths,
+				status: {
 					mode: "repair",
 					status: "error",
 					stage: "final",
@@ -1925,24 +865,21 @@ async function runtimeInitLocked(
 						offline: convergenceLoad.offline,
 					},
 				},
-				paths,
-			);
-			writeRuntimeBootStatus(status, paths);
-			if (opts.json || !process.stdout.isTTY) {
-				console.log(JSON.stringify(status, null, 2));
-			} else {
-				console.log(chalk.bold("clawdi runtime init"));
-				console.log(chalk.red(`  repair: ${message}`));
-				console.log(chalk.gray(`  status: ${paths.bootStatus}`));
-			}
-			process.exitCode = 23;
+				render: () => {
+					console.log(chalk.bold("clawdi runtime init"));
+					console.log(chalk.red(`  repair: ${message}`));
+					console.log(chalk.gray(`  status: ${paths.bootStatus}`));
+				},
+			});
 			return;
 		}
 		if (applyResult.kind === "cli_update_failed") {
 			const message = applyResult.cliUpdate.error ?? "CLI update failed";
 			const activeAppliedState = readRuntimeAppliedState(paths);
-			const status = buildRuntimeBootStatus(
-				{
+			emitRuntimeInitStatus({
+				opts,
+				paths,
+				status: {
 					mode: "repair",
 					status: "error",
 					stage: "config",
@@ -1958,11 +895,7 @@ async function runtimeInitLocked(
 					datasource: "RuntimeSource",
 					hostPolicy: hostPolicySummary(hostPolicy),
 				},
-				paths,
-			);
-			writeRuntimeBootStatus(status, paths);
-			if (opts.json || !process.stdout.isTTY) console.log(JSON.stringify(status, null, 2));
-			process.exitCode = 23;
+			});
 			return;
 		}
 		if (applyResult.kind === "cli_handoff") {
@@ -1982,8 +915,10 @@ async function runtimeInitLocked(
 		const runtimeReady = runtimeErrors.length === 0;
 		if (runtimeReady) completePendingRuntimeCliUpgrade(paths, getCliVersion());
 		const activeAppliedState = readRuntimeAppliedState(paths);
-		const status = buildRuntimeBootStatus(
-			{
+		emitRuntimeInitStatus({
+			opts,
+			paths,
+			status: {
 				mode: convergence.mode,
 				status: runtimeReady ? "ok" : "error",
 				stage: "final",
@@ -2008,25 +943,21 @@ async function runtimeInitLocked(
 				},
 				convergence: convergence.outputs,
 			},
-			paths,
-		);
-		writeRuntimeBootStatus(status, paths);
-
-		if (opts.json || !process.stdout.isTTY) {
-			console.log(JSON.stringify(status, null, 2));
-		} else {
-			console.log(chalk.bold("clawdi runtime init"));
-			console.log(
-				chalk.green(`  ${convergence.mode}: generation ${convergence.manifest.generation}`),
-			);
-			console.log(chalk.gray(`  status: ${paths.bootStatus}`));
-		}
-		process.exitCode = runtimeReady ? 0 : 23;
+			render: () => {
+				console.log(chalk.bold("clawdi runtime init"));
+				console.log(
+					chalk.green(`  ${convergence.mode}: generation ${convergence.manifest.generation}`),
+				);
+				console.log(chalk.gray(`  status: ${paths.bootStatus}`));
+			},
+		});
 		return;
 	}
 
-	const status = buildRuntimeBootStatus(
-		{
+	emitRuntimeInitStatus({
+		opts,
+		paths,
+		status: {
 			mode: "repair",
 			status: "error",
 			stage,
@@ -2040,18 +971,12 @@ async function runtimeInitLocked(
 			datasource: "RuntimeSource",
 			hostPolicy: hostPolicySummary(hostPolicy),
 		},
-		paths,
-	);
-	writeRuntimeBootStatus(status, paths);
-
-	if (opts.json || !process.stdout.isTTY) {
-		console.log(JSON.stringify(status, null, 2));
-	} else {
-		console.log(chalk.bold("clawdi runtime init"));
-		console.log(chalk.yellow(`  repair: ${errors[0]}`));
-		console.log(chalk.gray(`  status: ${paths.bootStatus}`));
-	}
-	process.exitCode = exitCode;
+		render: () => {
+			console.log(chalk.bold("clawdi runtime init"));
+			console.log(chalk.yellow(`  repair: ${errors[0]}`));
+			console.log(chalk.gray(`  status: ${paths.bootStatus}`));
+		},
+	});
 }
 
 async function runtimeWatchTick(

--- a/packages/cli/src/runtime/heartbeat-observation.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.ts
@@ -9,7 +9,11 @@ import {
 	readRuntimeAppliedState,
 	runtimeAppliedApplyIdentity,
 } from "./applied-state";
-import { type RuntimeApplyIdentity, runtimeApplyIdentitySchema } from "./apply-identity";
+import {
+	type RuntimeApplyIdentity,
+	runtimeApplyIdentitiesEqual,
+	runtimeApplyIdentitySchema,
+} from "./apply-identity";
 import { agentPluginsObservationSchema } from "./hosted-agent-plugin-observation";
 import { assertRuntimeBundleAuthority } from "./manifest-source";
 import { readHostedRuntimeObserved } from "./observed";
@@ -253,7 +257,10 @@ export class HostedRuntimeHeartbeatSession {
 			this.currentBootIdentity = null;
 			return false;
 		}
-		if (this.currentBootIdentity && sameApplyIdentity(this.currentBootIdentity, applyIdentity)) {
+		if (
+			this.currentBootIdentity &&
+			runtimeApplyIdentitiesEqual(this.currentBootIdentity, applyIdentity)
+		) {
 			this.capturedAppliedState = appliedState;
 			return false;
 		}
@@ -274,7 +281,7 @@ export class HostedRuntimeHeartbeatSession {
 		if (!appliedState || !applyIdentity) return;
 
 		let candidate: PersistedHeartbeatState;
-		if (persisted && sameApplyIdentity(persisted.bootIdentity, applyIdentity)) {
+		if (persisted && runtimeApplyIdentitiesEqual(persisted.bootIdentity, applyIdentity)) {
 			if (persisted.schemaVersion === "clawdi.runtimeHeartbeatObservation.v1") {
 				candidate = {
 					schemaVersion: "clawdi.runtimeHeartbeatObservation.v2",
@@ -516,16 +523,4 @@ function nonEmptyId(value: string, name: string): string {
 	const normalized = value.trim();
 	if (!normalized) throw new Error(`${name} must not be empty`);
 	return normalized;
-}
-
-function sameApplyIdentity(
-	left: Pick<PersistedBootIdentity, keyof RuntimeApplyIdentity>,
-	right: RuntimeApplyIdentity,
-): boolean {
-	return (
-		left.generation === right.generation &&
-		left.manifestETag === right.manifestETag &&
-		left.applyReceiptId === right.applyReceiptId &&
-		left.bootNonce === right.bootNonce
-	);
 }

--- a/packages/cli/src/runtime/live-state-snapshot.ts
+++ b/packages/cli/src/runtime/live-state-snapshot.ts
@@ -17,7 +17,7 @@ import { runtimeInstallReceiptsPath } from "./install-receipts";
 import type { RuntimeManifest } from "./manifest-contract";
 import type { RuntimePaths } from "./paths";
 import { runningAsRoot } from "./runtime-user-command";
-import { isGeneratedRuntimeSystemdFile } from "./systemd-user";
+import { managedRuntimeSystemdUnitEntries, RUNTIME_SYSTEMD_DROP_IN_FILE } from "./systemd";
 
 type RuntimeLiveSnapshotNode =
 	| { kind: "missing" }
@@ -240,26 +240,8 @@ export function restoreRuntimeLiveSnapshot(snapshot: RuntimeLiveSnapshot): void 
 }
 
 function addExistingManagedSystemdSystemPaths(paths: RuntimePaths, result: Set<string>): void {
-	if (!existsSync(paths.systemdSystemRoot)) return;
-	for (const entry of readdirSync(paths.systemdSystemRoot)) {
-		const path = join(paths.systemdSystemRoot, entry);
-		if (
-			entry.endsWith(".service") &&
-			(entry.startsWith("clawdi-") || isGeneratedSystemdFile(path))
-		) {
-			result.add(path);
-		}
-		if (!entry.endsWith(".service.d")) continue;
-		const dropIn = join(path, "10-clawdi-hosted.conf");
-		if (isGeneratedSystemdFile(dropIn)) result.add(dropIn);
-	}
-}
-
-function isGeneratedSystemdFile(path: string): boolean {
-	try {
-		return isGeneratedRuntimeSystemdFile(readFileSync(path, "utf-8"));
-	} catch {
-		return false;
+	for (const entry of managedRuntimeSystemdUnitEntries(paths.systemdSystemRoot)) {
+		result.add(entry.path);
 	}
 }
 
@@ -267,7 +249,7 @@ function runtimeLiveSnapshotMetadataPaths(snapshotPaths: readonly string[]): str
 	return [
 		...new Set(
 			snapshotPaths
-				.filter((path) => basename(path) === "10-clawdi-hosted.conf")
+				.filter((path) => basename(path) === RUNTIME_SYSTEMD_DROP_IN_FILE)
 				.map((path) => dirname(path)),
 		),
 	].sort();

--- a/packages/cli/src/runtime/observation-producer.ts
+++ b/packages/cli/src/runtime/observation-producer.ts
@@ -3,7 +3,11 @@ import { z } from "zod";
 import { ApiClient, unwrap } from "../lib/api-client";
 import { log, toErrorMessage } from "../serve/log";
 import { readRuntimeAppliedState, runtimeAppliedApplyIdentity } from "./applied-state";
-import { type RuntimeApplyIdentity, readRuntimeApplyIdentity } from "./apply-identity";
+import {
+	type RuntimeApplyIdentity,
+	readRuntimeApplyIdentity,
+	runtimeApplyIdentitiesEqual,
+} from "./apply-identity";
 import {
 	HostedRuntimeHeartbeatSession,
 	type HostedRuntimeObservedEvent,
@@ -100,7 +104,7 @@ export class HostedRuntimeObservationProducer {
 
 			buffered = this.session.nextEvent();
 			if (!buffered) return { outcome: "idle" };
-			if (!eventMatchesApplyIdentity(buffered.event, expectedApplyIdentity)) {
+			if (!runtimeApplyIdentitiesEqual(buffered.event, expectedApplyIdentity)) {
 				return { outcome: "idle" };
 			}
 			const result = await this.submit(environmentId, buffered.event);
@@ -138,7 +142,7 @@ export class HostedRuntimeObservationProducer {
 		const expectedApplyIdentity = readRuntimeApplyIdentity(this.contextPath);
 		const appliedState = readRuntimeAppliedState(this.paths);
 		const appliedIdentity = appliedState ? runtimeAppliedApplyIdentity(appliedState) : null;
-		if (!appliedIdentity || !sameApplyIdentity(appliedIdentity, expectedApplyIdentity)) {
+		if (!runtimeApplyIdentitiesEqual(appliedIdentity, expectedApplyIdentity)) {
 			return null;
 		}
 		const environmentId = readRuntimeObservationEnvironmentId(this.paths);
@@ -226,27 +230,6 @@ export function readRuntimeObservationEnvironmentId(paths: RuntimePaths): string
 
 function isUnknownRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function sameApplyIdentity(left: RuntimeApplyIdentity, right: RuntimeApplyIdentity): boolean {
-	return (
-		left.generation === right.generation &&
-		left.manifestETag === right.manifestETag &&
-		left.applyReceiptId === right.applyReceiptId &&
-		left.bootNonce === right.bootNonce
-	);
-}
-
-function eventMatchesApplyIdentity(
-	event: HostedRuntimeObservedEvent,
-	identity: RuntimeApplyIdentity,
-): boolean {
-	return (
-		event.generation === identity.generation &&
-		event.manifestETag === identity.manifestETag &&
-		event.applyReceiptId === identity.applyReceiptId &&
-		event.bootNonce === identity.bootNonce
-	);
 }
 
 export function isSafelyTerminalRuntimeObservationFailure(result: {

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { components } from "@clawdi/shared/api";
 import { safeTruncate, sanitizeMetadata } from "../lib/sanitize";
@@ -11,7 +11,8 @@ import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { spawnRuntimeUserCommand } from "./runtime-user-command";
 import { runtimeSecretValue } from "./secret-values";
 import { type RuntimeBootStatus, readRuntimeBootStatus } from "./state";
-import { isGeneratedRuntimeSystemdFile, runtimeUserName } from "./systemd-user";
+import { managedRuntimeSystemdUnitEntries, parseSystemctlShow, systemctlPath } from "./systemd";
+import { runtimeUserName } from "./systemd-user";
 
 type JsonRecord = Record<string, unknown>;
 type ObservedStatus = "ok" | "error" | "unknown";
@@ -257,30 +258,7 @@ function readSystemdObserved(paths: RuntimePaths): HostedRuntimeObservedSystemd 
 }
 
 function managedSystemdUnitNames(root: string): string[] {
-	if (!existsSync(root)) return [];
-	const units = new Set<string>();
-	for (const entry of readdirSync(root)) {
-		if (entry.endsWith(".service")) {
-			if (entry.startsWith("clawdi-") || isGeneratedSystemdPath(join(root, entry))) {
-				units.add(entry);
-			}
-			continue;
-		}
-		if (!entry.endsWith(".service.d")) continue;
-		const unitName = entry.slice(0, -".d".length);
-		if (isGeneratedSystemdPath(join(root, entry, "10-clawdi-hosted.conf"))) {
-			units.add(unitName);
-		}
-	}
-	return [...units].sort();
-}
-
-function isGeneratedSystemdPath(path: string): boolean {
-	try {
-		return isGeneratedRuntimeSystemdFile(readFileSync(path, "utf-8"));
-	} catch {
-		return false;
-	}
+	return [...new Set(managedRuntimeSystemdUnitEntries(root).map((entry) => entry.unitName))].sort();
 }
 
 function systemdUnitStatus(
@@ -421,23 +399,6 @@ function runRuntimeUserSystemctl(
 			output: error instanceof Error ? error.message : String(error),
 		};
 	}
-}
-
-function systemctlPath(): string {
-	return process.env.CLAWDI_SYSTEMCTL_PATH?.trim() || "systemctl";
-}
-
-function parseSystemctlShow(output: string): Record<string, string> {
-	return Object.fromEntries(
-		output
-			.split(/\r?\n/)
-			.map((line) => line.trim())
-			.filter(Boolean)
-			.map((line) => {
-				const index = line.indexOf("=");
-				return index === -1 ? [line, ""] : [line.slice(0, index), line.slice(index + 1)];
-			}),
-	);
 }
 
 function systemdUnitsStatus(units: HostedRuntimeObservedSystemdUnit[]): ObservedStatus {

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -57,6 +57,12 @@ import {
 } from "./runtime-user-command";
 import { runtimeSecretValue } from "./secret-values";
 import {
+	isGeneratedRuntimeSystemdPath,
+	managedRuntimeSystemdUnitEntries,
+	RUNTIME_SYSTEMD_DROP_IN_FILE,
+	systemctlPath,
+} from "./systemd";
+import {
 	GENERATED_RUNTIME_SYSTEMD_FILE_HEADER,
 	isGeneratedRuntimeSystemdFile,
 } from "./systemd-user";
@@ -337,7 +343,6 @@ export function planRuntimeMutationSystemdUserUnits(input: {
 	return { quiesceUserUnits, restartUserUnits };
 }
 
-const RUNTIME_SYSTEMD_DROP_IN_FILE = "10-clawdi-hosted.conf";
 function systemdDropInFilePath(paths: RuntimePaths, unitName: string): string {
 	return join(
 		paths.systemdUserRoot,
@@ -913,7 +918,7 @@ function writeSystemdUserEnvironmentDropIn(input: {
 
 function removeGeneratedRuntimeBaseUnit(paths: RuntimePaths, unitName: string): void {
 	const path = join(paths.systemdUserRoot, unitName);
-	if (!isGeneratedSystemdFile(path)) return;
+	if (!isGeneratedRuntimeSystemdPath(path)) return;
 	rmSync(path, { force: true });
 }
 
@@ -1082,7 +1087,7 @@ export function installOfficialRuntimeService(
 function resetFailedRuntimeUserService(name: string, paths: RuntimePaths, cwd: string): void {
 	try {
 		runRuntimeUserCommand(
-			process.env.CLAWDI_SYSTEMCTL_PATH?.trim() || "systemctl",
+			systemctlPath(),
 			["--user", "reset-failed", systemdUnitFileName(name)],
 			"",
 			paths.userHome,
@@ -1096,14 +1101,9 @@ function resetFailedRuntimeUserService(name: string, paths: RuntimePaths, cwd: s
 
 function reloadRuntimeUserManager(paths: RuntimePaths, cwd: string): void {
 	try {
-		runRuntimeUserCommand(
-			process.env.CLAWDI_SYSTEMCTL_PATH?.trim() || "systemctl",
-			["--user", "daemon-reload"],
-			"",
-			paths.userHome,
-			cwd,
-			{ timeoutMs: RUNTIME_SYSTEMCTL_MAINTENANCE_TIMEOUT_MS },
-		);
+		runRuntimeUserCommand(systemctlPath(), ["--user", "daemon-reload"], "", paths.userHome, cwd, {
+			timeoutMs: RUNTIME_SYSTEMCTL_MAINTENANCE_TIMEOUT_MS,
+		});
 	} catch {
 		// Best-effort: environments without a reachable user manager (unit tests,
 		// non-hosted hosts) must not fail convergence, and official installers
@@ -1189,9 +1189,9 @@ function staleOfficialRuntimeUserServices(paths: RuntimePaths, writtenUnits: str
 		if (writtenNames.has(unitName)) continue;
 		if (!officialRuntimeServiceDescriptorForUnit(unitName)) continue;
 		const dropInPath = join(paths.systemdUserRoot, entry, RUNTIME_SYSTEMD_DROP_IN_FILE);
-		if (!isGeneratedSystemdFile(dropInPath)) continue;
+		if (!isGeneratedRuntimeSystemdPath(dropInPath)) continue;
 		const baseUnitPath = join(paths.systemdUserRoot, unitName);
-		if (!existsSync(baseUnitPath) || isGeneratedSystemdFile(baseUnitPath)) continue;
+		if (!existsSync(baseUnitPath) || isGeneratedRuntimeSystemdPath(baseUnitPath)) continue;
 		stale.push(unitName);
 	}
 	return stale.sort();
@@ -1259,40 +1259,23 @@ export function planRuntimeSystemdUserMutations(
 		})
 		.filter((path): path is string => path !== null);
 
-	if (existsSync(paths.systemdUserRoot)) {
-		const writtenNames = new Set(writtenUnits.map(systemdUnitNameFromPath));
-		for (const entry of readdirSync(paths.systemdUserRoot)) {
-			if (entry.endsWith(".service")) {
-				const path = join(paths.systemdUserRoot, entry);
-				if (
-					(entry.startsWith("clawdi-") || isGeneratedSystemdFile(path)) &&
-					!writtenNames.has(entry)
-				) {
-					targets.add(path);
-					const enablementPath = join(paths.systemdUserRoot, "default.target.wants", entry);
-					targets.add(enablementPath);
-					symlinkTargets.add(enablementPath);
-					unitNames.add(entry);
-				}
-				continue;
-			}
-			if (!entry.endsWith(".service.d")) continue;
-			const unitName = entry.slice(0, -".d".length);
-			const dropInPath = join(paths.systemdUserRoot, entry, RUNTIME_SYSTEMD_DROP_IN_FILE);
-			if (!isGeneratedSystemdFile(dropInPath) || writtenNames.has(unitName)) continue;
-			targets.add(dropInPath);
-			const enablementPath = join(paths.systemdUserRoot, "default.target.wants", unitName);
-			targets.add(enablementPath);
-			symlinkTargets.add(enablementPath);
-			metadataTargets.add(dirname(dropInPath));
-			unitNames.add(unitName);
+	const writtenNames = new Set(writtenUnits.map(systemdUnitNameFromPath));
+	for (const entry of managedRuntimeSystemdUnitEntries(paths.systemdUserRoot)) {
+		if (writtenNames.has(entry.unitName)) continue;
+		targets.add(entry.path);
+		const enablementPath = join(paths.systemdUserRoot, "default.target.wants", entry.unitName);
+		targets.add(enablementPath);
+		symlinkTargets.add(enablementPath);
+		unitNames.add(entry.unitName);
+		if (entry.kind === "hosted-drop-in") {
+			metadataTargets.add(dirname(entry.path));
 		}
 	}
 	if (existsSync(paths.systemdEnvRoot)) {
 		for (const entry of readdirSync(paths.systemdEnvRoot)) {
 			if (!entry.endsWith(".service.env")) continue;
 			const path = join(paths.systemdEnvRoot, entry);
-			if (entry.startsWith("clawdi-") || isGeneratedSystemdFile(path)) {
+			if (entry.startsWith("clawdi-") || isGeneratedRuntimeSystemdPath(path)) {
 				environmentTargets.add(path);
 			}
 		}
@@ -1308,14 +1291,6 @@ export function planRuntimeSystemdUserMutations(
 		staleOfficialUnits,
 		driftErrors: officialRuntimeSystemdUserDropInDriftErrors(programs, paths),
 	};
-}
-
-function isGeneratedSystemdFile(path: string): boolean {
-	try {
-		return isGeneratedRuntimeSystemdFile(readFileSync(path, "utf-8"));
-	} catch {
-		return false;
-	}
 }
 
 function planStaleRuntimeSystemdFiles(
@@ -1341,25 +1316,11 @@ function planStaleRuntimeSystemdFiles(
 			systemUnits.add(entry);
 		}
 	}
-	if (existsSync(paths.systemdUserRoot)) {
-		for (const entry of readdirSync(paths.systemdUserRoot)) {
-			if (entry.endsWith(".service")) {
-				const path = join(paths.systemdUserRoot, entry);
-				if (desiredUser.has(entry)) continue;
-				if (!entry.startsWith("clawdi-") && !isGeneratedSystemdFile(path)) continue;
-				files.add(path);
-				files.add(join(paths.systemdUserRoot, "default.target.wants", entry));
-				userUnits.add(entry);
-				continue;
-			}
-			if (!entry.endsWith(".service.d")) continue;
-			const unitName = entry.slice(0, -".d".length);
-			const dropIn = join(paths.systemdUserRoot, entry, RUNTIME_SYSTEMD_DROP_IN_FILE);
-			if (desiredUser.has(unitName) || !isGeneratedSystemdFile(dropIn)) continue;
-			files.add(dropIn);
-			files.add(join(paths.systemdUserRoot, "default.target.wants", unitName));
-			userUnits.add(unitName);
-		}
+	for (const entry of managedRuntimeSystemdUnitEntries(paths.systemdUserRoot)) {
+		if (desiredUser.has(entry.unitName)) continue;
+		files.add(entry.path);
+		files.add(join(paths.systemdUserRoot, "default.target.wants", entry.unitName));
+		userUnits.add(entry.unitName);
 	}
 	const desiredEnvironmentFiles = new Set(
 		[...desiredSystem, ...desiredUser].map((unit) => `${unit}.env`),
@@ -1368,7 +1329,7 @@ function planStaleRuntimeSystemdFiles(
 		for (const entry of readdirSync(paths.systemdEnvRoot)) {
 			if (!entry.endsWith(".service.env") || desiredEnvironmentFiles.has(entry)) continue;
 			const path = join(paths.systemdEnvRoot, entry);
-			if (!entry.startsWith("clawdi-") && !isGeneratedSystemdFile(path)) continue;
+			if (!entry.startsWith("clawdi-") && !isGeneratedRuntimeSystemdPath(path)) continue;
 			files.add(path);
 		}
 	}
@@ -1394,7 +1355,7 @@ export function removeStaleRuntimeSystemdFiles(
 			errors.push(error instanceof Error ? error.message : String(error));
 		}
 	}
-	const systemctl = process.env.CLAWDI_SYSTEMCTL_PATH?.trim() || "systemctl";
+	const systemctl = systemctlPath();
 	if (plan.systemUnits.length > 0) {
 		const result = spawnSync(systemctl, ["daemon-reload"], { encoding: "utf8" });
 		if (result.status !== 0) errors.push("system systemd daemon-reload failed after stale file GC");

--- a/packages/cli/src/runtime/systemd-transaction.ts
+++ b/packages/cli/src/runtime/systemd-transaction.ts
@@ -1,0 +1,1026 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { parseDotenv } from "../lib/dotenv";
+import { type RuntimeUserProcessRevisionAliases, readRuntimeAppliedState } from "./applied-state";
+import { withEffectiveFilesystemIdentity } from "./effective-identity";
+import type { getRuntimePaths } from "./paths";
+import { systemdEnvironmentFilePath } from "./runtime-systemd-reconciliation";
+import { buildRuntimeUserCommand, runtimeUserUid } from "./runtime-user-command";
+import { managedRuntimeSystemdUnitEntries, parseSystemctlShow, systemctlPath } from "./systemd";
+import { runtimeUserName, runtimeUserSystemdEnvironment } from "./systemd-user";
+
+function readFileIfExists(path: string): string | null {
+	if (!existsSync(path)) return null;
+	return readFileSync(path, "utf-8");
+}
+
+export interface SystemdUnitSnapshot {
+	system: Map<string, string>;
+	user: Map<string, string>;
+}
+
+type SystemdRuntimeScope = "system" | "user";
+
+type SystemdRuntimeMutationStage =
+	| "egress-prerequisite"
+	| "official-installer"
+	| "final-activation"
+	| "quiesce"
+	| "rollback";
+
+type SystemdRuntimeMutationAction =
+	| "daemon-reload"
+	| "disable"
+	| "enable"
+	| "enable-and-start"
+	| "install"
+	| "reset-failed"
+	| "restart"
+	| "start"
+	| "stop";
+
+export interface SystemdRuntimeMutationJournalEntry {
+	sequence: number;
+	stage: SystemdRuntimeMutationStage;
+	scope: SystemdRuntimeScope;
+	action: SystemdRuntimeMutationAction;
+	units: string[];
+	outcome: "pending" | "succeeded" | "failed";
+}
+
+interface SystemdUnitManagerState {
+	loadState: string;
+	activeState: string;
+	mainPid: number;
+	needDaemonReload: boolean;
+	enabledState?: string;
+}
+
+interface CommandResult {
+	status: number | null;
+	stdout: string;
+	stderr: string;
+	error?: Error;
+}
+
+export const RUNTIME_WATCH_SYSTEM_UNIT = "clawdi-runtime-watch.service";
+export const RUNTIME_DAEMON_SYSTEM_UNIT = "clawdi-daemon.service";
+export const RUNTIME_SIDECAR_SYSTEM_UNIT = "clawdi-runtime-sidecar.service";
+const RUNTIME_REVISION_RE = /^[a-f0-9]{32}$/;
+
+const SYSTEMD_ACTIVATION_STAGES = new Set<SystemdRuntimeMutationStage>([
+	"egress-prerequisite",
+	"official-installer",
+	"final-activation",
+]);
+
+const systemdRuntimeTransactionInitialStates = new WeakMap<
+	SystemdRuntimeTransaction,
+	{ system: Map<string, SystemdUnitManagerState>; user: Map<string, SystemdUnitManagerState> }
+>();
+
+export class SystemdRuntimeTransaction {
+	// Journal entries contain only systemd unit names and command outcomes. Command
+	// output, environment, process metadata, and secret material never enter it.
+	readonly journal: SystemdRuntimeMutationJournalEntry[] = [];
+
+	constructor() {
+		systemdRuntimeTransactionInitialStates.set(this, {
+			system: new Map(),
+			user: new Map(),
+		});
+	}
+
+	get state(): "pristine" | "mutated" {
+		return this.journal.some((entry) => SYSTEMD_ACTIVATION_STAGES.has(entry.stage))
+			? "mutated"
+			: "pristine";
+	}
+
+	installOfficialService(
+		paths: ReturnType<typeof getRuntimePaths>,
+		unit: string,
+		install: () => string | null,
+	): string | null {
+		return runSystemdRuntimeOfficialInstaller(paths, this, unit, install);
+	}
+
+	quiesce(
+		paths: ReturnType<typeof getRuntimePaths>,
+		affectedUserUnits: readonly string[] = [],
+	): void {
+		quiesceSystemdRuntimeCandidate(paths, this, affectedUserUnits);
+	}
+
+	rollback(paths: ReturnType<typeof getRuntimePaths>): void {
+		rollbackSystemdRuntimeTransaction(paths, this);
+	}
+}
+
+function systemdRuntimeTransactionTouchedUnits(transaction: SystemdRuntimeTransaction): {
+	systemUnits: string[];
+	userUnits: string[];
+} {
+	const systemUnits = new Set<string>();
+	const userUnits = new Set<string>();
+	for (const entry of transaction.journal) {
+		const restoresUnit =
+			SYSTEMD_ACTIVATION_STAGES.has(entry.stage) ||
+			(entry.stage === "quiesce" && entry.action === "stop");
+		if (!restoresUnit || entry.action === "daemon-reload") continue;
+		const target = entry.scope === "system" ? systemUnits : userUnits;
+		for (const unit of entry.units) target.add(unit);
+	}
+	return {
+		systemUnits: [...systemUnits].sort(),
+		userUnits: [...userUnits].sort(),
+	};
+}
+
+export function readSystemdUnitSnapshot(
+	paths: ReturnType<typeof getRuntimePaths>,
+): SystemdUnitSnapshot {
+	return {
+		system: readManagedSystemdUnits(paths.systemdSystemRoot),
+		user: readManagedSystemdUnits(paths.systemdUserRoot),
+	};
+}
+
+function systemdDesiredProgramRevision(
+	paths: ReturnType<typeof getRuntimePaths>,
+	unit: string,
+): string {
+	if (!unit.endsWith(".service")) {
+		throw new Error(`managed systemd unit has invalid name: ${unit}`);
+	}
+	const programName = unit.slice(0, -".service".length);
+	const content = readFileSync(systemdEnvironmentFilePath(paths, programName), "utf8");
+	const parsed = parseDotenv(content).filter(([key]) => key === "CLAWDI_RUNTIME_REV");
+	const declarations = content
+		.split(/\r?\n/)
+		.filter((line) => line.startsWith("CLAWDI_RUNTIME_REV="));
+	const match = /^CLAWDI_RUNTIME_REV="([a-f0-9]{32})"$/.exec(declarations[0] ?? "");
+	if (parsed.length !== 1 || declarations.length !== 1 || !match) {
+		throw new Error("invalid revision declaration");
+	}
+	return match[1];
+}
+
+export function readSystemdUserDesiredRevisions(
+	paths: ReturnType<typeof getRuntimePaths>,
+	units: Iterable<string>,
+): ReadonlyMap<string, string> {
+	const revisions = new Map<string, string>();
+	for (const unit of units) {
+		try {
+			revisions.set(unit, systemdDesiredProgramRevision(paths, unit));
+		} catch {
+			// Missing or malformed predecessor authority is not eligible for adoption.
+		}
+	}
+	return revisions;
+}
+
+function readManagedSystemdUnits(root: string): Map<string, string> {
+	const units = new Map<string, string>();
+	for (const entry of managedRuntimeSystemdUnitEntries(root, readFileIfExists)) {
+		if (entry.kind === "base-unit") {
+			const contents = entry.generatedContents ?? readFileIfExists(entry.path);
+			if (contents !== null) units.set(entry.unitName, contents);
+			continue;
+		}
+		const base = readFileIfExists(join(root, entry.unitName)) ?? "";
+		units.set(entry.unitName, `${base}\n${entry.generatedContents}`);
+	}
+	return units;
+}
+
+function changedSystemdUnits(
+	before: Map<string, string>,
+	after: Map<string, string>,
+): { added: string[]; changed: string[]; removed: string[]; present: string[] } {
+	const added: string[] = [];
+	const changed: string[] = [];
+	const removed: string[] = [];
+	for (const [name, contents] of after) {
+		if (!before.has(name)) added.push(name);
+		else if (before.get(name) !== contents) changed.push(name);
+	}
+	for (const name of before.keys()) {
+		if (!after.has(name)) removed.push(name);
+	}
+	return {
+		added: added.sort(),
+		changed: changed.sort(),
+		removed: removed.sort(),
+		present: [...after.keys()].sort(),
+	};
+}
+
+export function withoutStaleSystemdUnits(
+	snapshot: SystemdUnitSnapshot,
+	staleSystemUnits: readonly string[],
+	staleUserUnits: readonly string[],
+): SystemdUnitSnapshot {
+	const system = new Map(snapshot.system);
+	const user = new Map(snapshot.user);
+	for (const unit of staleSystemUnits) system.delete(unit);
+	for (const unit of staleUserUnits) user.delete(unit);
+	return { system, user };
+}
+
+export function applySystemdRuntimeUpdate(
+	paths: ReturnType<typeof getRuntimePaths>,
+	before: SystemdUnitSnapshot,
+	after: SystemdUnitSnapshot,
+	opts: {
+		transaction: SystemdRuntimeTransaction;
+		stage: Extract<SystemdRuntimeMutationStage, "egress-prerequisite" | "final-activation">;
+		forceRestartSystemUnits?: readonly string[];
+		forceStopSystemUnits?: readonly string[];
+		forceRestartUserUnits?: readonly string[];
+		recoverFailedUnits?: boolean;
+		activationScope?: {
+			systemUnits: readonly string[];
+			userUnits: readonly string[];
+		};
+		preserveActiveUnits?: boolean;
+		previousUserDesiredRevisions?: ReadonlyMap<string, string>;
+		onUserProcessRevisionAliases?: (aliases: RuntimeUserProcessRevisionAliases) => void;
+		skipActivatedSystemUnits?: readonly string[];
+	},
+): { applied: boolean; systemUnitsChanged: string[]; userUnitsChanged: string[] } {
+	const { transaction, stage } = opts;
+	const allSystem = changedSystemdUnits(before.system, after.system);
+	const allUser = changedSystemdUnits(before.user, after.user);
+	const filterChanges = (
+		changes: ReturnType<typeof changedSystemdUnits>,
+		units: readonly string[],
+	): ReturnType<typeof changedSystemdUnits> => {
+		const selected = new Set(units);
+		return {
+			added: changes.added.filter((unit) => selected.has(unit)),
+			changed: changes.changed.filter((unit) => selected.has(unit)),
+			removed: changes.removed.filter((unit) => selected.has(unit)),
+			present: changes.present.filter((unit) => selected.has(unit)),
+		};
+	};
+	const system = opts.activationScope
+		? filterChanges(allSystem, opts.activationScope.systemUnits)
+		: allSystem;
+	const user = opts.activationScope
+		? filterChanges(allUser, opts.activationScope.userUnits)
+		: allUser;
+	const systemUnitsChanged = new Set([...system.added, ...system.removed]);
+	const userUnitsChanged = new Set([...user.added, ...user.removed]);
+	const scopedSystemUnits = opts.activationScope ? new Set(opts.activationScope.systemUnits) : null;
+	const forcedSystemRestarts = (opts.forceRestartSystemUnits ?? []).filter(
+		(unit) => after.system.has(unit) && (!scopedSystemUnits || scopedSystemUnits.has(unit)),
+	);
+	const forcedSystemStops = (opts.forceStopSystemUnits ?? []).filter(
+		(unit) => after.system.has(unit) && (!scopedSystemUnits || scopedSystemUnits.has(unit)),
+	);
+	const scopedUserUnits = opts.activationScope ? new Set(opts.activationScope.userUnits) : null;
+	const forcedUserRestarts = (opts.forceRestartUserUnits ?? []).filter(
+		(unit) => after.user.has(unit) && (!scopedUserUnits || scopedUserUnits.has(unit)),
+	);
+	const recoverFailedUnits = opts.recoverFailedUnits !== false;
+	const activationChanged =
+		system.added.length > 0 ||
+		system.changed.length > 0 ||
+		system.removed.length > 0 ||
+		user.added.length > 0 ||
+		user.changed.length > 0 ||
+		user.removed.length > 0 ||
+		forcedSystemRestarts.length > 0 ||
+		forcedSystemStops.length > 0 ||
+		forcedUserRestarts.length > 0;
+	if (!shouldApplySystemdRuntimeUpdate(paths)) {
+		return {
+			applied: !activationChanged,
+			systemUnitsChanged: [...systemUnitsChanged].sort(),
+			userUnitsChanged: [...userUnitsChanged].sort(),
+		};
+	}
+	const systemStates = preflightSystemdRuntimeUnits(paths, transaction, "system", [
+		...system.present,
+		...system.removed,
+		...forcedSystemStops,
+	]);
+	const userStates = preflightSystemdRuntimeUnits(paths, transaction, "user", [
+		...user.present,
+		...user.removed,
+	]);
+	const systemManagerNeedsReload = new Set(
+		system.present.filter((unit) => systemStates.get(unit)?.needDaemonReload),
+	);
+	const userManagerNeedsReload = new Set(
+		user.present.filter((unit) => userStates.get(unit)?.needDaemonReload),
+	);
+	const changedSystemUnits = new Set(system.changed);
+	const changedUserUnits = new Set(user.changed);
+	const committedAliases = readRuntimeAppliedState(paths)?.userProcessRevisionAliases ?? {};
+	const userProcessRevisionAliases: RuntimeUserProcessRevisionAliases = {};
+	const userProcessRevisionDrift = new Set<string>();
+	for (const unit of user.present) {
+		const state = requiredSystemdUnitState(userStates, "user", unit);
+		if (state.activeState !== "active") continue;
+		const revisions = systemdProcessRevisions(paths, unit, state);
+		if (revisions.processRevision === revisions.desiredRevision) continue;
+		const committedAlias = committedAliases[unit];
+		if (
+			committedAlias?.desiredRevision === revisions.desiredRevision &&
+			committedAlias.processRevision === revisions.processRevision
+		) {
+			userProcessRevisionAliases[unit] = committedAlias;
+			continue;
+		}
+		if (
+			opts.preserveActiveUnits &&
+			opts.previousUserDesiredRevisions?.get(unit) === revisions.processRevision
+		) {
+			userProcessRevisionAliases[unit] = revisions;
+			continue;
+		}
+		userProcessRevisionDrift.add(unit);
+	}
+
+	for (const unit of system.removed) {
+		const state = requiredSystemdUnitState(systemStates, "system", unit);
+		if (unit === RUNTIME_WATCH_SYSTEM_UNIT && !systemdUnitAbsentOrInactive(state)) continue;
+		if (!systemdUnitAbsentOrInactive(state)) {
+			runJournaledSystemdMutation(transaction, stage, "system", "stop", [unit], () =>
+				systemctl(["stop", unit]),
+			);
+		}
+	}
+	for (const unit of user.removed) {
+		const state = requiredSystemdUnitState(userStates, "user", unit);
+		if (!systemdUnitAbsentOrInactive(state)) {
+			runJournaledSystemdMutation(transaction, stage, "user", "stop", [unit], () =>
+				runtimeUserSystemctl(paths, ["stop", unit]),
+			);
+		}
+		if (!systemdUnitAbsentOrDisabled(state)) {
+			runJournaledSystemdMutation(transaction, stage, "user", "disable", [unit], () =>
+				runtimeUserSystemctl(paths, ["disable", unit]),
+			);
+		}
+	}
+	for (const unit of forcedSystemStops) {
+		const state = requiredSystemdUnitState(systemStates, "system", unit);
+		if (!systemdUnitAbsentOrInactive(state)) {
+			runJournaledSystemdMutation(transaction, stage, "system", "stop", [unit], () =>
+				systemctl(["stop", unit]),
+			);
+			systemUnitsChanged.add(unit);
+		}
+	}
+
+	if (
+		system.added.length > 0 ||
+		system.changed.length > 0 ||
+		system.removed.length > 0 ||
+		systemManagerNeedsReload.size > 0
+	) {
+		runJournaledSystemdMutation(transaction, stage, "system", "daemon-reload", [], () =>
+			systemctl(["daemon-reload"]),
+		);
+	}
+	if (
+		user.added.length > 0 ||
+		user.changed.length > 0 ||
+		user.removed.length > 0 ||
+		userManagerNeedsReload.size > 0
+	) {
+		runJournaledSystemdMutation(transaction, stage, "user", "daemon-reload", [], () =>
+			runtimeUserSystemctl(paths, ["daemon-reload"]),
+		);
+	}
+
+	const addedSystemUnits = new Set(system.added);
+	const forcedRestartUnits = new Set(forcedSystemRestarts);
+	const forcedStopUnits = new Set(forcedSystemStops);
+	const skipActivatedSystemUnits = new Set(opts.skipActivatedSystemUnits ?? []);
+	const resetFailedSystemUnits: string[] = [];
+	const startSystemUnits: string[] = [];
+	const restartSystemUnits: string[] = [];
+	for (const unit of system.present) {
+		const state = requiredSystemdUnitState(systemStates, "system", unit);
+		if (forcedStopUnits.has(unit)) continue;
+		if (skipActivatedSystemUnits.has(unit)) continue;
+		if (state.activeState === "failed" && recoverFailedUnits) {
+			resetFailedSystemUnits.push(unit);
+			startSystemUnits.push(unit);
+			systemUnitsChanged.add(unit);
+			continue;
+		}
+		if (state.activeState === "inactive") {
+			startSystemUnits.push(unit);
+			systemUnitsChanged.add(unit);
+			continue;
+		}
+		if (
+			state.activeState === "active" &&
+			unit !== RUNTIME_WATCH_SYSTEM_UNIT &&
+			((changedSystemUnits.has(unit) && !opts.preserveActiveUnits) ||
+				(forcedRestartUnits.has(unit) &&
+					(!addedSystemUnits.has(unit) || unit === RUNTIME_SIDECAR_SYSTEM_UNIT)))
+		) {
+			restartSystemUnits.push(unit);
+			systemUnitsChanged.add(unit);
+		}
+	}
+	// Each reconciliation makes at most one recovery attempt per failed unit.
+	// Transitional units remain untouched and fail final proof below.
+	if (resetFailedSystemUnits.length > 0) {
+		runJournaledSystemdMutation(
+			transaction,
+			stage,
+			"system",
+			"reset-failed",
+			resetFailedSystemUnits,
+			() => systemctl(["reset-failed", ...resetFailedSystemUnits]),
+		);
+	}
+	if (startSystemUnits.length > 0) {
+		runJournaledSystemdMutation(transaction, stage, "system", "start", startSystemUnits, () =>
+			systemctl(["start", ...startSystemUnits]),
+		);
+	}
+	if (restartSystemUnits.length > 0) {
+		runJournaledSystemdMutation(transaction, stage, "system", "restart", restartSystemUnits, () =>
+			systemctl(["restart", ...restartSystemUnits]),
+		);
+	}
+
+	const resetFailedUserUnits: string[] = [];
+	const forcedRestartUserUnits = new Set(forcedUserRestarts);
+	const startUserUnits: string[] = [];
+	const enableUserUnits: string[] = [];
+	const enableAndStartUserUnits: string[] = [];
+	const restartUserUnits: string[] = [];
+	for (const unit of user.present) {
+		const state = requiredSystemdUnitState(userStates, "user", unit);
+		const enabled = systemdUnitEnabled(state);
+		if (state.activeState === "failed" && recoverFailedUnits) {
+			resetFailedUserUnits.push(unit);
+			userUnitsChanged.add(unit);
+		}
+		if (
+			state.activeState === "inactive" ||
+			(state.activeState === "failed" && recoverFailedUnits)
+		) {
+			if (enabled) startUserUnits.push(unit);
+			else enableAndStartUserUnits.push(unit);
+			userUnitsChanged.add(unit);
+			continue;
+		}
+		if (state.activeState !== "active") continue;
+		if (!enabled) {
+			enableUserUnits.push(unit);
+			userUnitsChanged.add(unit);
+		}
+		if (
+			userProcessRevisionDrift.has(unit) ||
+			(changedUserUnits.has(unit) && !opts.preserveActiveUnits) ||
+			forcedRestartUserUnits.has(unit)
+		) {
+			restartUserUnits.push(unit);
+			userUnitsChanged.add(unit);
+		}
+	}
+	for (const unit of restartUserUnits) delete userProcessRevisionAliases[unit];
+	if (resetFailedUserUnits.length > 0) {
+		runJournaledSystemdMutation(
+			transaction,
+			stage,
+			"user",
+			"reset-failed",
+			resetFailedUserUnits,
+			() => runtimeUserSystemctl(paths, ["reset-failed", ...resetFailedUserUnits]),
+		);
+	}
+	if (enableAndStartUserUnits.length > 0) {
+		runJournaledSystemdMutation(
+			transaction,
+			stage,
+			"user",
+			"enable-and-start",
+			enableAndStartUserUnits,
+			() => runtimeUserSystemctl(paths, ["enable", "--now", ...enableAndStartUserUnits]),
+		);
+	}
+	if (enableUserUnits.length > 0) {
+		runJournaledSystemdMutation(transaction, stage, "user", "enable", enableUserUnits, () =>
+			runtimeUserSystemctl(paths, ["enable", ...enableUserUnits]),
+		);
+	}
+	if (startUserUnits.length > 0) {
+		runJournaledSystemdMutation(transaction, stage, "user", "start", startUserUnits, () =>
+			runtimeUserSystemctl(paths, ["start", ...startUserUnits]),
+		);
+	}
+	if (restartUserUnits.length > 0) {
+		runJournaledSystemdMutation(transaction, stage, "user", "restart", restartUserUnits, () =>
+			runtimeUserSystemctl(paths, ["restart", ...restartUserUnits]),
+		);
+	}
+
+	const systemConverged = system.present.every((unit) => {
+		const state = systemdUnitManagerState(paths, "system", unit);
+		if (forcedStopUnits.has(unit)) return systemdUnitAbsentOrInactive(state);
+		return (
+			state.loadState !== "not-found" && state.activeState === "active" && !state.needDaemonReload
+		);
+	});
+	const userConverged = user.present.every((unit) => {
+		const state = systemdUnitManagerState(paths, "user", unit);
+		if (
+			state.loadState === "not-found" ||
+			state.activeState !== "active" ||
+			state.needDaemonReload ||
+			!systemdUnitEnabled(state)
+		) {
+			return false;
+		}
+		const revisions = systemdProcessRevisions(paths, unit, state);
+		const alias = userProcessRevisionAliases[unit];
+		return (
+			revisions.processRevision === revisions.desiredRevision ||
+			(alias?.desiredRevision === revisions.desiredRevision &&
+				alias.processRevision === revisions.processRevision)
+		);
+	});
+	const removedSystemConverged = system.removed.every(
+		(unit) =>
+			unit === RUNTIME_WATCH_SYSTEM_UNIT ||
+			systemdUnitAbsentOrInactive(systemdUnitManagerState(paths, "system", unit)),
+	);
+	const removedUserConverged = user.removed.every((unit) => {
+		const state = systemdUnitManagerState(paths, "user", unit);
+		return systemdUnitAbsentOrInactive(state) && systemdUnitAbsentOrDisabled(state);
+	});
+	const applied =
+		systemConverged && userConverged && removedSystemConverged && removedUserConverged;
+	if (applied) opts.onUserProcessRevisionAliases?.(userProcessRevisionAliases);
+	return {
+		applied,
+		systemUnitsChanged: [...systemUnitsChanged].sort(),
+		userUnitsChanged: [...userUnitsChanged].sort(),
+	};
+}
+
+function quiesceSystemdRuntimeCandidate(
+	paths: ReturnType<typeof getRuntimePaths>,
+	transaction: SystemdRuntimeTransaction,
+	affectedUserUnits: readonly string[],
+): void {
+	if (!shouldApplySystemdRuntimeUpdate(paths)) return;
+	const candidateUnits = systemdRuntimeCandidateUnits(transaction);
+	const userUnits = [...new Set([...candidateUnits.user, ...affectedUserUnits])]
+		.filter((unit) => unit !== RUNTIME_WATCH_SYSTEM_UNIT)
+		.sort();
+	const userStates = preflightSystemdRuntimeUnits(paths, transaction, "user", userUnits);
+	for (const unit of userUnits) {
+		const state = requiredSystemdUnitState(userStates, "user", unit);
+		if (systemdUnitAbsentOrInactive(state)) continue;
+		runJournaledSystemdMutation(transaction, "quiesce", "user", "stop", [unit], () =>
+			runtimeUserSystemctl(paths, ["stop", unit]),
+		);
+	}
+	const systemUnits = [...candidateUnits.system]
+		.filter((unit) => unit !== RUNTIME_WATCH_SYSTEM_UNIT)
+		.sort();
+	for (const unit of systemUnits) {
+		const state = systemdUnitManagerState(paths, "system", unit);
+		if (systemdUnitAbsentOrInactive(state)) continue;
+		runJournaledSystemdMutation(transaction, "quiesce", "system", "stop", [unit], () =>
+			systemctl(["stop", unit]),
+		);
+	}
+}
+
+function systemdRuntimeCandidateUnits(transaction: SystemdRuntimeTransaction): {
+	system: Set<string>;
+	user: Set<string>;
+} {
+	const candidateActions = new Set<SystemdRuntimeMutationAction>([
+		"enable-and-start",
+		"install",
+		"restart",
+		"start",
+	]);
+	const candidateUnits = { system: new Set<string>(), user: new Set<string>() };
+	for (const entry of transaction.journal) {
+		if (!SYSTEMD_ACTIVATION_STAGES.has(entry.stage) || !candidateActions.has(entry.action)) {
+			continue;
+		}
+		for (const unit of entry.units) candidateUnits[entry.scope].add(unit);
+	}
+	return candidateUnits;
+}
+
+function rollbackSystemdRuntimeTransaction(
+	paths: ReturnType<typeof getRuntimePaths>,
+	transaction: SystemdRuntimeTransaction,
+): void {
+	const activationJournal = transaction.journal.filter((entry) =>
+		SYSTEMD_ACTIVATION_STAGES.has(entry.stage),
+	);
+	const touched = systemdRuntimeTransactionTouchedUnits(transaction);
+	const reloadSystem = activationJournal.some(
+		(entry) => entry.scope === "system" && entry.action === "daemon-reload",
+	);
+	const reloadUser = activationJournal.some(
+		(entry) =>
+			entry.scope === "user" && (entry.action === "daemon-reload" || entry.action === "install"),
+	);
+	if (reloadSystem) {
+		runJournaledSystemdMutation(transaction, "rollback", "system", "daemon-reload", [], () =>
+			systemctl(["daemon-reload"]),
+		);
+	}
+	if (reloadUser) {
+		runJournaledSystemdMutation(transaction, "rollback", "user", "daemon-reload", [], () =>
+			runtimeUserSystemctl(paths, ["daemon-reload"]),
+		);
+	}
+	for (const unit of touched.systemUnits) {
+		const initial = systemdRuntimeTransactionStates(transaction).system.get(unit);
+		if (!initial || initial.loadState === "not-found" || initial.activeState !== "active") continue;
+		restoreActiveSystemdUnit(paths, transaction, "system", unit);
+	}
+	for (const unit of touched.userUnits) {
+		const initial = systemdRuntimeTransactionStates(transaction).user.get(unit);
+		if (!initial || initial.loadState === "not-found") continue;
+		const initiallyEnabled = systemdUnitEnabled(initial);
+		const currentlyEnabled = systemdUnitEnabled(systemdUnitManagerState(paths, "user", unit));
+		if (initiallyEnabled !== currentlyEnabled) {
+			const action = initiallyEnabled ? "enable" : "disable";
+			runJournaledSystemdMutation(transaction, "rollback", "user", action, [unit], () =>
+				runtimeUserSystemctl(paths, [action, unit]),
+			);
+		}
+		if (initial.activeState !== "active") continue;
+		restoreActiveSystemdUnit(paths, transaction, "user", unit);
+		const restored = systemdUnitManagerState(paths, "user", unit);
+		if (systemdUnitEnabled(restored) !== initiallyEnabled) {
+			throw new Error(`systemd rollback did not restore user unit ${unit} enablement`);
+		}
+		if (!systemdProcessRevisionMatches(paths, unit, restored)) {
+			throw new Error(`systemd rollback restored stale runtime revision for ${unit}`);
+		}
+	}
+}
+
+function restoreActiveSystemdUnit(
+	paths: ReturnType<typeof getRuntimePaths>,
+	transaction: SystemdRuntimeTransaction,
+	scope: SystemdRuntimeScope,
+	unit: string,
+): void {
+	let current = systemdUnitManagerState(paths, scope, unit);
+	const mutate = (
+		action: Extract<SystemdRuntimeMutationAction, "reset-failed" | "start" | "stop">,
+	) =>
+		runJournaledSystemdMutation(transaction, "rollback", scope, action, [unit], () =>
+			scope === "system" ? systemctl([action, unit]) : runtimeUserSystemctl(paths, [action, unit]),
+		);
+	if (current.activeState === "failed") {
+		mutate("reset-failed");
+		current = systemdUnitManagerState(paths, scope, unit);
+	}
+	if (current.activeState !== "active") {
+		if (current.activeState !== "inactive") {
+			throw new Error(
+				`systemd rollback could not restore ${scope} unit ${unit} from ${current.activeState}`,
+			);
+		}
+		mutate("start");
+		current = systemdUnitManagerState(paths, scope, unit);
+	}
+	if (current.activeState !== "active") {
+		throw new Error(`systemd rollback did not restore ${scope} unit ${unit} activity`);
+	}
+}
+
+function runSystemdRuntimeOfficialInstaller(
+	paths: ReturnType<typeof getRuntimePaths>,
+	transaction: SystemdRuntimeTransaction,
+	unit: string,
+	install: () => string | null,
+): string | null {
+	const states = preflightSystemdRuntimeUnits(paths, transaction, "user", [unit]);
+	const state = requiredSystemdUnitState(states, "user", unit);
+	if (state.activeState === "active") {
+		systemdProcessRevisionMatches(paths, unit, state);
+	}
+	return runJournaledSystemdMutation(
+		transaction,
+		"official-installer",
+		"user",
+		"install",
+		[unit],
+		install,
+		(error) => error !== null,
+	);
+}
+
+function preflightSystemdRuntimeUnits(
+	paths: ReturnType<typeof getRuntimePaths>,
+	transaction: SystemdRuntimeTransaction,
+	scope: SystemdRuntimeScope,
+	units: readonly string[],
+): Map<string, SystemdUnitManagerState> {
+	const states = new Map<string, SystemdUnitManagerState>();
+	const initialStates = systemdRuntimeTransactionStates(transaction)[scope];
+	for (const unit of [...new Set(units)].sort()) {
+		const state = systemdUnitManagerState(paths, scope, unit);
+		states.set(unit, state);
+		if (!initialStates.has(unit)) initialStates.set(unit, state);
+	}
+	return states;
+}
+
+function systemdRuntimeTransactionStates(transaction: SystemdRuntimeTransaction): {
+	system: Map<string, SystemdUnitManagerState>;
+	user: Map<string, SystemdUnitManagerState>;
+} {
+	const states = systemdRuntimeTransactionInitialStates.get(transaction);
+	if (!states) throw new Error("systemd runtime transaction is not initialized");
+	return states;
+}
+function requiredSystemdUnitState(
+	states: ReadonlyMap<string, SystemdUnitManagerState>,
+	scope: SystemdRuntimeScope,
+	unit: string,
+): SystemdUnitManagerState {
+	const state = states.get(unit);
+	if (!state) throw new Error(`systemd ${scope} unit ${unit} was not preflighted`);
+	return state;
+}
+
+function runJournaledSystemdMutation<T>(
+	transaction: SystemdRuntimeTransaction,
+	stage: SystemdRuntimeMutationStage,
+	scope: SystemdRuntimeScope,
+	action: SystemdRuntimeMutationAction,
+	units: readonly string[],
+	mutation: () => T,
+	failed: (result: T) => boolean = () => false,
+): T {
+	const entry: SystemdRuntimeMutationJournalEntry = {
+		sequence: transaction.journal.length + 1,
+		stage,
+		scope,
+		action,
+		units: [...new Set(units)].sort(),
+		outcome: "pending",
+	};
+	transaction.journal.push(entry);
+	try {
+		const result = mutation();
+		entry.outcome = failed(result) ? "failed" : "succeeded";
+		return result;
+	} catch (error) {
+		entry.outcome = "failed";
+		throw error;
+	}
+}
+
+function systemdUnitManagerState(
+	paths: ReturnType<typeof getRuntimePaths>,
+	scope: "system" | "user",
+	unit: string,
+): SystemdUnitManagerState {
+	const showArgs = [
+		"show",
+		unit,
+		"--property=LoadState",
+		"--property=ActiveState",
+		"--property=MainPID",
+		"--property=NeedDaemonReload",
+	];
+	const show =
+		scope === "system" ? systemctlResult(showArgs) : runtimeUserSystemctlResult(paths, showArgs);
+	assertCommandSucceeded(scope === "system" ? systemctlPath() : "systemctl --user", showArgs, show);
+	const properties = parseSystemctlShow(show.stdout);
+	const loadState = properties.LoadState;
+	const activeState = properties.ActiveState;
+	const mainPidValue = properties.MainPID;
+	const needDaemonReload = properties.NeedDaemonReload;
+	if (!loadState || !activeState || mainPidValue === undefined || !needDaemonReload) {
+		throw new Error(`systemd ${scope} unit ${unit} returned incomplete manager state`);
+	}
+	if (!/^(0|[1-9]\d*)$/.test(mainPidValue)) {
+		throw new Error(`systemd ${scope} unit ${unit} returned invalid MainPID`);
+	}
+	const mainPid = Number(mainPidValue);
+	if (!Number.isSafeInteger(mainPid)) {
+		throw new Error(`systemd ${scope} unit ${unit} returned invalid MainPID`);
+	}
+	if (needDaemonReload !== "yes" && needDaemonReload !== "no") {
+		throw new Error(
+			`systemd ${scope} unit ${unit} returned invalid NeedDaemonReload: ${needDaemonReload}`,
+		);
+	}
+	const managerState = {
+		loadState,
+		activeState,
+		mainPid,
+		needDaemonReload: needDaemonReload === "yes",
+	};
+	if (scope === "system") return managerState;
+
+	const enabledArgs = ["is-enabled", unit];
+	const enabled = runtimeUserSystemctlResult(paths, enabledArgs);
+	const enabledState = enabled.stdout.trim().split(/\s+/)[0] ?? "";
+	if (!SYSTEMD_ENABLED_STATES.has(enabledState) && !SYSTEMD_DISABLED_STATES.has(enabledState)) {
+		assertCommandSucceeded("systemctl --user", enabledArgs, enabled);
+		throw new Error(`systemd user unit ${unit} returned unknown enabled state: ${enabledState}`);
+	}
+	return { ...managerState, enabledState };
+}
+
+function systemdProcessRevisionMatches(
+	paths: ReturnType<typeof getRuntimePaths>,
+	unit: string,
+	state: SystemdUnitManagerState,
+): boolean {
+	const revisions = systemdProcessRevisions(paths, unit, state);
+	return revisions.processRevision === revisions.desiredRevision;
+}
+
+function systemdProcessRevisions(
+	paths: ReturnType<typeof getRuntimePaths>,
+	unit: string,
+	state: SystemdUnitManagerState,
+): { desiredRevision: string; processRevision: string } {
+	if (state.mainPid === 0) {
+		throw new Error(`active managed systemd unit ${unit} has no MainPID`);
+	}
+	let desiredRevision: string;
+	try {
+		desiredRevision = systemdDesiredProgramRevision(paths, unit);
+	} catch (error) {
+		throw new Error(`could not prove desired runtime revision for managed systemd unit ${unit}`, {
+			cause: error,
+		});
+	}
+
+	let processRevision: string;
+	try {
+		const procDir = `/proc/${state.mainPid}`;
+		const owner = statSync(procDir);
+		const readEnvironment = () => readFileSync(join(procDir, "environ"));
+		let environment: Buffer;
+		try {
+			environment = readEnvironment();
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code;
+			if (owner.uid === 0 || (code !== "EACCES" && code !== "EPERM")) throw error;
+			environment = withEffectiveFilesystemIdentity(
+				{ uid: owner.uid, gid: owner.gid },
+				readEnvironment,
+			);
+		}
+		processRevision = runtimeRevisionFromProcessEnvironment(environment);
+	} catch (error) {
+		throw new Error(`could not prove active runtime revision for managed systemd unit ${unit}`, {
+			cause: error,
+		});
+	}
+	return { desiredRevision, processRevision };
+}
+
+function runtimeRevisionFromProcessEnvironment(environment: Buffer): string {
+	const prefix = Buffer.from("CLAWDI_RUNTIME_REV=");
+	const revisions: string[] = [];
+	for (let start = 0; start < environment.length; ) {
+		const separator = environment.indexOf(0, start);
+		const end = separator < 0 ? environment.length : separator;
+		const entry = environment.subarray(start, end);
+		if (entry.subarray(0, prefix.length).equals(prefix)) {
+			revisions.push(entry.subarray(prefix.length).toString("ascii"));
+		}
+		start = end + 1;
+	}
+	if (revisions.length !== 1 || !RUNTIME_REVISION_RE.test(revisions[0])) {
+		throw new Error("invalid revision entry");
+	}
+	return revisions[0];
+}
+
+const SYSTEMD_ENABLED_STATES = new Set([
+	"enabled",
+	"enabled-runtime",
+	"linked",
+	"linked-runtime",
+	"alias",
+]);
+const SYSTEMD_DISABLED_STATES = new Set([
+	"disabled",
+	"not-found",
+	"static",
+	"indirect",
+	"masked",
+	"generated",
+	"transient",
+]);
+
+function systemdUnitEnabled(state: SystemdUnitManagerState): boolean {
+	return state.enabledState !== undefined && SYSTEMD_ENABLED_STATES.has(state.enabledState);
+}
+
+function systemdUnitAbsentOrInactive(state: SystemdUnitManagerState): boolean {
+	return state.loadState === "not-found" || state.activeState === "inactive";
+}
+
+function systemdUnitAbsentOrDisabled(state: SystemdUnitManagerState): boolean {
+	return (
+		state.loadState === "not-found" ||
+		state.enabledState === "not-found" ||
+		state.enabledState === "disabled"
+	);
+}
+
+function shouldApplySystemdRuntimeUpdate(paths: ReturnType<typeof getRuntimePaths>): boolean {
+	const override = process.env.CLAWDI_SYSTEMD_APPLY?.trim().toLowerCase();
+	if (override === "1" || override === "true") return true;
+	if (override === "0" || override === "false") return false;
+	return paths.systemdSystemRoot === "/run/systemd/system";
+}
+
+function systemctl(args: string[]): string {
+	return runCommand(systemctlPath(), args);
+}
+
+function systemctlResult(args: string[]): CommandResult {
+	return runCommandResult(systemctlPath(), args);
+}
+
+function runtimeUserSystemctl(paths: ReturnType<typeof getRuntimePaths>, args: string[]): string {
+	const result = runtimeUserSystemctlResult(paths, args);
+	assertCommandSucceeded("systemctl --user", args, result);
+	return [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+}
+
+function runtimeUserSystemctlResult(
+	paths: ReturnType<typeof getRuntimePaths>,
+	args: string[],
+): CommandResult {
+	const runtimeUser = runtimeUserName();
+	if (runtimeUser !== "root") {
+		const uid = String(runtimeUserUid(runtimeUser));
+		const child = buildRuntimeUserCommand(
+			runtimeUser,
+			paths.userHome,
+			systemctlPath(),
+			["--user", ...args],
+			{ environment: runtimeUserSystemdEnvironment(uid) },
+		);
+		return runCommandResult(child.command, child.args, child.env);
+	}
+	return runCommandResult(systemctlPath(), ["--user", ...args]);
+}
+
+export function assertRuntimeUserCanRead(path: string, home: string): void {
+	const runtimeUser = runtimeUserName();
+	const proof = buildRuntimeUserCommand(runtimeUser, home, "test", ["-r", path]);
+	runCommand(proof.command, proof.args, proof.env);
+}
+
+function runCommand(command: string, args: string[], env?: Record<string, string>): string {
+	const result = runCommandResult(command, args, env);
+	assertCommandSucceeded(command, args, result);
+	return [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+}
+
+function runCommandResult(
+	command: string,
+	args: string[],
+	env?: Record<string, string>,
+): CommandResult {
+	const result = spawnSync(command, args, {
+		encoding: "utf8",
+		...(env ? { env: { ...process.env, ...env } } : {}),
+	});
+	return {
+		status: result.status,
+		stdout: result.stdout ?? "",
+		stderr: result.stderr ?? "",
+		...(result.error ? { error: result.error } : {}),
+	};
+}
+
+function assertCommandSucceeded(command: string, args: string[], result: CommandResult): void {
+	if (result.status === 0) return;
+	const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+	throw new Error(
+		`${command} ${args.join(" ")} failed${result.status === null ? "" : ` (${result.status})`}${
+			result.error ? `: ${result.error.message}` : ""
+		}${output ? `: ${output.slice(0, 1000)}` : ""}`,
+	);
+}

--- a/packages/cli/src/runtime/systemd.test.ts
+++ b/packages/cli/src/runtime/systemd.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { managedRuntimeSystemdUnitEntries, RUNTIME_SYSTEMD_DROP_IN_FILE } from "./systemd";
+import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "./systemd-user";
+
+const roots: string[] = [];
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function writeFixture(root: string, path: string, contents: string): void {
+	const target = join(root, path);
+	mkdirSync(dirname(target), { recursive: true });
+	writeFileSync(target, contents);
+}
+
+describe("managed runtime systemd unit classification", () => {
+	test("classifies only prefixed, generated, and exact generated drop-in units", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-systemd-classification-"));
+		roots.push(root);
+		const generated = `${GENERATED_RUNTIME_SYSTEMD_FILE_HEADER}\n`;
+		const dropIn = RUNTIME_SYSTEMD_DROP_IN_FILE;
+		writeFixture(root, "clawdi-prefix.service", "foreign");
+		writeFixture(root, "generated.service", generated);
+		writeFixture(root, "foreign.service", "foreign");
+		writeFixture(root, join("official.service.d", dropIn), generated);
+		writeFixture(root, join("official.service.d", "20-foreign.conf"), generated);
+		writeFixture(root, join("foreign.service.d", dropIn), "foreign");
+
+		const classified = managedRuntimeSystemdUnitEntries(root)
+			.map(({ kind, unitName }) => [kind, unitName])
+			.sort((left, right) => left[1].localeCompare(right[1]));
+		expect(classified).toEqual([
+			["base-unit", "clawdi-prefix.service"],
+			["base-unit", "generated.service"],
+			["hosted-drop-in", "official.service"],
+		]);
+	});
+
+	test("returns no units for a missing root", () => {
+		const root = join(tmpdir(), `clawdi-systemd-missing-${crypto.randomUUID()}`);
+		expect(managedRuntimeSystemdUnitEntries(root)).toEqual([]);
+	});
+});

--- a/packages/cli/src/runtime/systemd.ts
+++ b/packages/cli/src/runtime/systemd.ts
@@ -1,0 +1,83 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { isGeneratedRuntimeSystemdFile } from "./systemd-user";
+
+export const RUNTIME_SYSTEMD_DROP_IN_FILE = "10-clawdi-hosted.conf";
+
+export type ManagedRuntimeSystemdUnitEntry = {
+	unitName: string;
+	path: string;
+} & (
+	| { kind: "base-unit"; generatedContents?: string }
+	| { kind: "hosted-drop-in"; generatedContents: string }
+);
+
+export function managedRuntimeSystemdUnitEntries(
+	root: string,
+	readContents: (path: string) => string | null = readRuntimeSystemdContents,
+): ManagedRuntimeSystemdUnitEntry[] {
+	if (!existsSync(root)) return [];
+	const managed: ManagedRuntimeSystemdUnitEntry[] = [];
+	for (const entry of readdirSync(root)) {
+		if (entry.endsWith(".service")) {
+			const path = join(root, entry);
+			if (entry.startsWith("clawdi-")) {
+				managed.push({ kind: "base-unit", unitName: entry, path });
+			} else {
+				const generatedContents = generatedRuntimeSystemdContents(path, readContents);
+				if (generatedContents !== null) {
+					managed.push({ kind: "base-unit", unitName: entry, path, generatedContents });
+				}
+			}
+			continue;
+		}
+		if (!entry.endsWith(".service.d")) continue;
+		const path = join(root, entry, RUNTIME_SYSTEMD_DROP_IN_FILE);
+		const generatedContents = generatedRuntimeSystemdContents(path, readContents);
+		if (generatedContents === null) continue;
+		managed.push({
+			kind: "hosted-drop-in",
+			unitName: entry.slice(0, -".d".length),
+			path,
+			generatedContents,
+		});
+	}
+	return managed;
+}
+
+export function isGeneratedRuntimeSystemdPath(path: string): boolean {
+	return generatedRuntimeSystemdContents(path, readRuntimeSystemdContents) !== null;
+}
+
+function readRuntimeSystemdContents(path: string): string | null {
+	try {
+		return readFileSync(path, "utf-8");
+	} catch {
+		return null;
+	}
+}
+
+function generatedRuntimeSystemdContents(
+	path: string,
+	readContents: (path: string) => string | null,
+): string | null {
+	const contents = readContents(path);
+	return contents !== null && isGeneratedRuntimeSystemdFile(contents) ? contents : null;
+}
+
+export function systemctlPath(): string {
+	return process.env.CLAWDI_SYSTEMCTL_PATH?.trim() || "systemctl";
+}
+
+export function parseSystemctlShow(output: string): Record<string, string> {
+	return Object.fromEntries(
+		output
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter(Boolean)
+			.map((line) => {
+				const separator = line.indexOf("=");
+				return separator < 0 ? [line, ""] : [line.slice(0, separator), line.slice(separator + 1)];
+			}),
+	);
+}

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -20,11 +20,6 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
-	applySystemdRuntimeUpdate,
-	readSystemdUnitSnapshot,
-	SystemdRuntimeTransaction,
-} from "../../src/commands/runtime";
-import {
 	resolveOpenClawProviderAuthSdkExport,
 	resolveOpenClawProviderEnvVarsSdkExport,
 } from "../../src/lib/codex-oauth-native-store";
@@ -38,6 +33,11 @@ import type { RuntimeManifestLoad } from "../../src/runtime/manifest-source";
 import { CLAWDI_MANAGED_OPENCLAW_PROVIDER_PLUGIN_ID } from "../../src/runtime/openclaw-managed-provider-plugin";
 import { getRuntimePaths } from "../../src/runtime/paths";
 import { ensureRuntimeStateDirs } from "../../src/runtime/state";
+import {
+	applySystemdRuntimeUpdate,
+	readSystemdUnitSnapshot,
+	SystemdRuntimeTransaction,
+} from "../../src/runtime/systemd-transaction";
 
 const REAL_SYSTEMD_GATE = "CLAWDI_TEST_REAL_OPENCLAW_SYSTEMD";
 const FILE_BROWSER_VERSION = "v1.5.0-stable";

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -20,15 +20,12 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 import {
-	applySystemdRuntimeUpdate,
 	commitRuntimeAppliedState,
-	readSystemdUnitSnapshot,
 	runtimeAppliedContentIdentity,
 	runtimeInit as runtimeInitWithContext,
 	runtimeOnlyChangesCliPackage,
 	runtimePublicContentRevision,
 	runtimeWatch as runtimeWatchWithContext,
-	SystemdRuntimeTransaction,
 } from "../src/commands/runtime";
 import {
 	nativeOAuthProfileId,
@@ -94,6 +91,11 @@ import {
 	writeRuntimeBootStatus,
 	writeRuntimeWatchStatus,
 } from "../src/runtime/state";
+import {
+	applySystemdRuntimeUpdate,
+	readSystemdUnitSnapshot,
+	SystemdRuntimeTransaction,
+} from "../src/runtime/systemd-transaction";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "../src/runtime/systemd-user";
 import { TRANSPARENT_EGRESS_PORT } from "../src/runtime/transparent-egress";
 import { getDaemonControlTokenPath } from "../src/serve/paths";


### PR DESCRIPTION
## Summary

- centralize managed systemd unit classification, the hosted drop-in filename, generated-file probing, `systemctl` resolution, and `systemctl show` parsing
- move the systemd transaction, activation, quiesce, rollback, preflight, and process-revision proof library from `commands/runtime.ts` to `runtime/systemd-transaction.ts`
- reuse the canonical apply-identity comparator and consolidate runtime-init status emission while preserving branch-specific persistence, output, and exit behavior
- add focused unit coverage for prefixed units, generated units, the exact hosted drop-in, foreign files, and missing roots
- reduce the total diff by 35 lines: 1,380 additions and 1,415 deletions, including the new tests

## Behavior verification

- manually edited generated units are still compared by current contents and rewritten during convergence
- official base-unit drift still invalidates the install receipt and triggers the official reinstall path
- foreign drop-ins still fail closed before the platform override is reconciled
- unmarked, non-`clawdi-` units remain untouched
- active user services still prove `CLAWDI_RUNTIME_REV` from `/proc/<pid>/environ`, including the existing privilege fallback and alias rules

## Verification

- `bun run --cwd packages/cli typecheck`
- `bunx biome check packages/cli/src packages/cli/tests`
- 417 focused systemd/runtime/observed tests across 7 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)