### PR TITLE
fix(cli): fully drop hosted runtime command privileges

### DIFF
--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1498,11 +1498,13 @@ function nextManagedLocaleFileContent(
 }
 
 function updateManagedLocaleFile(path: string, block: string): string {
-	const { existing, next } = nextManagedLocaleFileContent(path, block);
-	if (next === existing) return path;
-	writePrivateFileAtomic(path, next, { mode: 0o600, dirMode: 0o700 });
-	makeRuntimeUserOwned(path);
-	return path;
+	return withRuntimeUserFileAccess(() => {
+		const { existing, next } = nextManagedLocaleFileContent(path, block);
+		if (next === existing) return path;
+		writePrivateFileAtomic(path, next, { mode: 0o600, dirMode: 0o700 });
+		makeRuntimeUserOwned(path);
+		return path;
+	});
 }
 
 function hermesConfigContext(
@@ -2781,14 +2783,12 @@ function applyHostedAiProviderProjection(
 		return { path: null, revision: null, providerIds: [...previousProviderIds] };
 	}
 	if (name === "hermes") {
-		return withRuntimeUserFileAccess(() =>
-			applyHostedHermesAiProviderProjection(
-				observation,
-				projectionInput,
-				previousProviderIds,
-				home,
-				workspaceRoot,
-			),
+		return applyHostedHermesAiProviderProjection(
+			observation,
+			projectionInput,
+			previousProviderIds,
+			home,
+			workspaceRoot,
 		);
 	}
 	if (name === "openclaw") {
@@ -3180,7 +3180,9 @@ function legacyHermesModelProviderPluginDir(home: string): string {
 }
 
 function removeLegacyHermesModelProviderPlugin(home: string): void {
-	rmSync(legacyHermesModelProviderPluginDir(home), { recursive: true, force: true });
+	withRuntimeUserFileAccess(() =>
+		rmSync(legacyHermesModelProviderPluginDir(home), { recursive: true, force: true }),
+	);
 }
 
 export interface OpenClawHostedProviderPatch {
@@ -7104,15 +7106,13 @@ export function convergeRuntimeManifest(
 				}
 			}
 			try {
-				const localeFile = withRuntimeUserFileAccess(() =>
-					applyHostedRuntimeConfigProjection(
-						name,
-						observation,
-						manifest,
-						projectionHome,
-						openClawWorkspaceRoot,
-						workspaceRoot,
-					),
+				const localeFile = applyHostedRuntimeConfigProjection(
+					name,
+					observation,
+					manifest,
+					projectionHome,
+					openClawWorkspaceRoot,
+					workspaceRoot,
 				);
 				if (localeFile) managedLocaleFiles.push(localeFile);
 			} catch (error) {

--- a/packages/cli/src/runtime/runtime-user-command.test.ts
+++ b/packages/cli/src/runtime/runtime-user-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -9,7 +9,9 @@ import {
 	commandExists,
 	createPrivilegeDropResolver,
 	runRuntimeUserCommand,
+	runtimeUserUid,
 	spawnRuntimeUserCommand,
+	withRuntimeUserFileAccess,
 } from "./runtime-user-command";
 
 test("command existence follows shell resolution", () => {
@@ -296,4 +298,27 @@ describe("runtime user command timeout", () => {
 		expect(result.status).toBeNull();
 		expect(result.error?.message).toContain("ETIMEDOUT");
 	});
+});
+
+test("fully drops root identity when spawned during runtime-user file access", () => {
+	if (process.geteuid?.() !== 0 || !commandExists(NUMERIC_PRIVILEGE_TOOL)) return;
+	const root = mkdtempSync(join(tmpdir(), "runtime-user-spawn-identity-"));
+	const command = join(root, "identity-probe");
+	const output = join(root, "uid");
+	const previousRuntimeUser = process.env.CLAWDI_RUNTIME_USER;
+	try {
+		chmodSync(root, 0o777);
+		writeFileSync(command, '#!/usr/bin/env bash\nid -u > "$1"\n', { mode: 0o755 });
+		process.env.CLAWDI_RUNTIME_USER = "nobody";
+		const result = withRuntimeUserFileAccess(() =>
+			spawnRuntimeUserCommand(command, [output], root, root),
+		);
+		expect(result.status).toBe(0);
+		expect(readFileSync(output, "utf8").trim()).toBe(String(runtimeUserUid("nobody")));
+		expect(statSync(output).uid).toBe(runtimeUserUid("nobody"));
+	} finally {
+		if (previousRuntimeUser === undefined) delete process.env.CLAWDI_RUNTIME_USER;
+		else process.env.CLAWDI_RUNTIME_USER = previousRuntimeUser;
+		rmSync(root, { recursive: true, force: true });
+	}
 });

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -139,7 +139,7 @@ export function buildRuntimeUserCommand(
 	];
 	const runtimeUid = options.runtimeUid ?? runtimeUserUid(runtimeUser);
 	const mechanism = (options.resolver ?? privilegeDropResolver).resolve({
-		currentUid: options.currentUid ?? effectiveUid(),
+		currentUid: options.currentUid ?? privilegeSourceUid(),
 		targetUid: runtimeUid,
 		targetUser: runtimeUser,
 		targetKind: "named",
@@ -195,7 +195,7 @@ export function buildNumericUserCommand(
 		throw new Error(`cannot drop privileges to ${targetUser}: target identity must be non-root`);
 	}
 	const mechanism = (options.resolver ?? privilegeDropResolver).resolve({
-		currentUid: options.currentUid ?? effectiveUid(),
+		currentUid: options.currentUid ?? privilegeSourceUid(),
 		targetUid: uid,
 		targetUser,
 		targetKind: "numeric",
@@ -214,8 +214,15 @@ export function runningAsRoot(): boolean {
 	return typeof process.geteuid === "function" && process.geteuid() === 0;
 }
 
-function effectiveUid(): number | undefined {
-	return process.geteuid?.() ?? process.getuid?.();
+function privilegeSourceUid(): number | undefined {
+	const realUid = process.getuid?.();
+	const effectiveUid = process.geteuid?.();
+	// A shell child can restore a root real UID when only the effective UID was lowered.
+	if (realUid === 0 || effectiveUid === 0) return 0;
+	if (realUid !== undefined && effectiveUid !== undefined && realUid !== effectiveUid) {
+		return undefined;
+	}
+	return effectiveUid ?? realUid;
 }
 
 export function runtimeUserUid(runtimeUser: string): number {


### PR DESCRIPTION
## Summary

- detect retained root real/effective credentials before spawning runtime-user commands
- keep effective filesystem identity scopes limited to direct file mutations
- cover the real-root/effective-runtime-user spawn regression without adding a test matrix

## Verification

- CLI typecheck
- 232 focused runtime tests
- 18 root identity tests
- focused Biome and diff checks
- paired local Hosted runtime smoke