### PR TITLE
release(cli): 0.13.108-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.13.108-beta.0
+
+Package: `clawdi@0.13.108-beta.0`
+
+### Fixed
+
+- Hosted Hermes commands now fully drop root credentials before starting, so
+  first-boot runtime files remain owned by the runtime user.
+
 ## Clawdi CLI v0.13.107
 
 Package: `clawdi@0.13.107`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.107",
+      "version": "0.13.108-beta.0",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.107",
+	"version": "0.13.108-beta.0",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -36,7 +36,7 @@ const manifestContract = readFileSync(
 );
 const cliPackage = JSON.parse(
 	readFileSync(resolve(import.meta.dir, "../package.json"), "utf8"),
-) as { version: string; publishConfig?: { access?: string; tag?: unknown } };
+) as { publishConfig?: { access?: string; tag?: unknown } };
 
 describe("CLI publish workflow contract", () => {
 	test("keeps current-run release decisions inside the protected publish topology", () => {
@@ -126,7 +126,8 @@ describe("CLI publish workflow contract", () => {
 		expect(workflow).toContain(
 			'npm publish "./release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag "$NPM_TAG"',
 		);
-		expect(cliPackage.version).not.toContain("-");
+		expect(workflow).toContain("*-*) npm_tag=beta ;;");
+		expect(workflow).toContain("*) npm_tag=latest ;;");
 		expect(cliPackage.publishConfig).toEqual({ access: "public" });
 		expect(publishManifestChecker).toContain(
 			'Object.hasOwn(packageJson.publishConfig ?? {}, "tag")',

--- a/packages/cli/tests/commands/update.test.ts
+++ b/packages/cli/tests/commands/update.test.ts
@@ -28,6 +28,7 @@ import {
 	type NativeTarget,
 	nativeAssetName,
 } from "../../src/lib/native-release-manifest";
+import { getCliVersion } from "../../src/lib/version";
 import {
 	createRestartCoordination,
 	type RestartCoordination,
@@ -329,7 +330,6 @@ describe("update --json", () => {
 
 		// Read the current version from package.json via fetch indirection — the registry returns it.
 		// getCliVersion() reads from disk; we match it by echoing the same value.
-		const { getCliVersion } = await import("../../src/lib/version");
 		const current = getCliVersion();
 
 		const { restore } = mockFetch([
@@ -490,7 +490,7 @@ describe("update install", () => {
 			{
 				method: "GET",
 				path: "/clawdi",
-				response: () => jsonResponse({ "dist-tags": { latest: "99.0.0" } }),
+				response: () => jsonResponse({ "dist-tags": releaseTags("99.0.0") }),
 			},
 		]);
 		process.env.CLAWDI_NATIVE_PROBE_LOG = probeLog;
@@ -539,7 +539,7 @@ describe("update install", () => {
 			{
 				method: "GET",
 				path: "/clawdi",
-				response: () => jsonResponse({ "dist-tags": { latest: "99.0.0" } }),
+				response: () => jsonResponse({ "dist-tags": releaseTags("99.0.0") }),
 			},
 		]);
 		try {
@@ -584,7 +584,7 @@ describe("update install", () => {
 			{
 				method: "GET",
 				path: "/clawdi",
-				response: () => jsonResponse({ "dist-tags": { latest: "99.0.0" } }),
+				response: () => jsonResponse({ "dist-tags": releaseTags("99.0.0") }),
 			},
 		]);
 		try {
@@ -616,7 +616,7 @@ describe("update install", () => {
 			{
 				method: "GET",
 				path: "/clawdi",
-				response: () => jsonResponse({ "dist-tags": { latest: "99.0.0" } }),
+				response: () => jsonResponse({ "dist-tags": releaseTags("99.0.0") }),
 			},
 		]);
 		try {
@@ -657,7 +657,7 @@ describe("update install", () => {
 			{
 				method: "GET",
 				path: "/clawdi",
-				response: () => jsonResponse({ "dist-tags": { latest: "99.0.0" } }),
+				response: () => jsonResponse({ "dist-tags": releaseTags("99.0.0") }),
 			},
 		]);
 		try {
@@ -1134,7 +1134,7 @@ describe("maybeAutoUpdate", () => {
 		expect(fetches).toHaveLength(0);
 		expect(workers).toHaveLength(1);
 		expect(workers[0]?.latest).toBeUndefined();
-		expect(workers[0]?.channel).toBe("latest");
+		expect(workers[0]?.channel).toBe(getCliVersion().includes("-") ? "beta" : "latest");
 	});
 
 	it("prints `Updated clawdi to vX` when last-version differs from current", async () => {
@@ -1368,7 +1368,7 @@ async function runNativeForegroundFailure(
 		{
 			method: "GET",
 			path: "/clawdi",
-			response: () => jsonResponse({ "dist-tags": { latest: "99.0.0" } }),
+			response: () => jsonResponse({ "dist-tags": releaseTags("99.0.0") }),
 		},
 	]);
 	try {
@@ -1406,6 +1406,10 @@ function testFetcher(
 	implementation: (...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>,
 ): typeof fetch {
 	return Object.assign(implementation, { preconnect: fetch.preconnect });
+}
+
+function releaseTags(version: string): { latest: string; beta: string } {
+	return { latest: version, beta: version };
 }
 
 function writeDaemonHealth(agent: string, version: string): void {


### PR DESCRIPTION
## Summary

- publish the Hosted Hermes runtime-user fix as clawdi@0.13.108-beta.0
- keep npm latest unchanged; prerelease workflow targets beta only
- limit production validation to the Kingsley cohort

## Verification

- frozen Bun 1.3.14 install in an isolated Docker copy
- Biome check
- CLI typecheck
- CLI publish manifest check
- git diff/check and pre-commit hook