### PR TITLE
release(cli): 0.13.108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
-## Clawdi CLI v0.13.108-beta.0
+## Clawdi CLI v0.13.108
 
-Package: `clawdi@0.13.108-beta.0`
+Package: `clawdi@0.13.108`
 
 ### Fixed
 

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.108-beta.0",
+      "version": "0.13.108",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.108-beta.0",
+	"version": "0.13.108",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary

- promote the validated `0.13.108-beta.0` CLI contents to stable `0.13.108`
- update package and lockfile release identity
- finalize the CLI changelog entry

## Verification

- Docker-backed CLI typecheck
- focused release workflow contracts: 27 passed
- Biome CI: 1045 files checked
- CLI publish manifest validation
- `git diff --check`

## Rollout scope

After the immutable npm/GitHub release succeeds, roll out only Kingsley's three deployments, verify health, then remove Kingsley's temporary CLI package override. Global Hosted CLI settings remain unchanged.