### PR TITLE
fix(web): keep billing dialogs within viewport

### DIFF
--- a/apps/web/src/hosted/billing/subscription/plan-change-dialog.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-change-dialog.tsx
@@ -378,7 +378,11 @@ export function PlanChangeDialog({
 				}
 			}}
 		>
-			<DialogContent data-hosted="true" className="sm:max-w-lg" showCloseButton={!blocksClose}>
+			<DialogContent
+				data-hosted="true"
+				className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-lg"
+				showCloseButton={!blocksClose}
+			>
 				<DialogHeader>
 					<DialogTitle>
 						{step === "pending"

--- a/apps/web/src/hosted/billing/wallet/auto-reload-setup-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-setup-dialog.tsx
@@ -210,7 +210,7 @@ export function AutoReloadSetupDialog({
 		>
 			<DialogContent
 				data-hosted="true"
-				className="max-h-[calc(100vh-2rem)] overflow-y-auto sm:max-w-lg"
+				className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-lg"
 			>
 				<DialogHeader>
 					<div className="flex items-center gap-3">

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
@@ -275,7 +275,7 @@ export function TopUpDialog({
 			}}
 		>
 			<DialogContent
-				className="sm:max-w-md"
+				className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-md"
 				data-hosted="true"
 				showCloseButton={!topUp.isPending && !paymentSubmitting}
 			>


### PR DESCRIPTION
## Summary
- bound Top up Wallet and subscription-change dialogs to the dynamic viewport and allow vertical scrolling
- use `dvh` for the existing auto-reload dialog guard so mobile browser chrome cannot hide actions
- preserve current desktop sizing and avoid changing the shared Dialog primitive

## Root cause
The fixed, centered Dialog popup had no viewport height boundary. Stripe Payment Element can expand as payment methods and fields render, so the popup extended beyond small screens while neither the page nor popup could scroll.

## Verification
- `bunx biome check` on the three changed files
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web build:oss`
- focused wallet top-up logic tests: 7 passed
- `git diff --check origin/main..HEAD`

All build and test commands ran in a disposable Bun 1.3.14 container. No production or tenant operations were performed.