### PR TITLE
fix(runtime): preserve current agent plugin failures end to end

### DIFF
--- a/backend/app/schemas/runtime_observation.py
+++ b/backend/app/schemas/runtime_observation.py
@@ -127,14 +127,9 @@ class HostedRuntimeObservedAgentPluginsV1(RuntimeObservationRequestModel):
     def validate_applied_identity(self, applied: HostedRuntimeObservedAppliedV2) -> None:
         for installation in self.installations:
             if installation.status == "failed":
-                # A failed apply never becomes the applied state, so a failure
-                # naming the exact applied identity is a replay; a same-generation
-                # attempt with a *different* revision is a newer (e.g. plugin-only)
-                # manifest that did not bump the runtime generation.
-                if installation.generation < applied.generation or (
-                    installation.generation == applied.generation
-                    and installation.source_revision == applied.source_revision
-                ):
+                # Resource projection failures can still commit the manifest's
+                # apply identity, so only failures from an older generation are stale.
+                if installation.generation < applied.generation:
                     raise ValueError("failed Agent Plugin observation is stale")
                 continue
             if (

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -209,18 +209,16 @@ def test_agent_plugin_observation_rejects_stale_or_unfenced_apply_identity() -> 
             }
         )
 
-    with pytest.raises(ValueError, match="failed Agent Plugin observation is stale"):
-        RuntimeObservationEventV2.model_validate(
-            {
-                **payload,
-                "agentPlugins": {
-                    "schemaVersion": 1,
-                    "installations": [
-                        {**installation, "generation": 2, "sourceRevision": "a" * 64}
-                    ],
-                },
-            }
-        )
+    same_applied_identity = RuntimeObservationEventV2.model_validate(
+        {
+            **payload,
+            "agentPlugins": {
+                "schemaVersion": 1,
+                "installations": [{**installation, "generation": 2, "sourceRevision": "a" * 64}],
+            },
+        }
+    )
+    assert same_applied_identity.agent_plugins is not None
 
     same_generation_new_revision = RuntimeObservationEventV2.model_validate(
         {

--- a/packages/cli/src/runtime/hosted-agent-plugin-observation.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-observation.test.ts
@@ -103,7 +103,11 @@ function writeReceipt(paths: RuntimePaths, desired: ReturnType<typeof installati
 	);
 }
 
-function failedWatchStatus(desired: ReturnType<typeof installation>, generation: number) {
+function failedWatchStatus(
+	desired: ReturnType<typeof installation>,
+	generation: number,
+	revision = "1".repeat(64),
+) {
 	return {
 		event: {
 			status: "error",
@@ -115,7 +119,7 @@ function failedWatchStatus(desired: ReturnType<typeof installation>, generation:
 						name: "clawdi",
 						version: desired.version,
 						contentDigest: desired.contentDigest,
-						sourceRevision: "1".repeat(64),
+						sourceRevision: revision,
 						generation,
 						status: "failed",
 						errorCode: "reconcile_failed",
@@ -233,6 +237,32 @@ describe("hosted Agent Plugin heartbeat observation", () => {
 				version: "1.0.0",
 				contentDigest: `sha256-tree-v1:${"d".repeat(64)}`,
 				sourceRevision: "1".repeat(64),
+				generation: 7,
+				status: "failed",
+				errorCode: "reconcile_failed",
+			},
+		]);
+	});
+
+	test("reports a failed reconvergence at the applied identity", () => {
+		const paths = tempPaths();
+		const desired = installation("1.0.0", "d");
+		writeAppliedManifest(paths, desired);
+		writeReceipt(paths, desired);
+
+		const observed = readHostedAgentPluginsObservation({
+			paths,
+			applied: appliedState(),
+			watchStatus: failedWatchStatus(desired, 7, sourceRevision),
+		});
+
+		expect(observed?.installations).toEqual([
+			{
+				installationId,
+				name: "clawdi",
+				version: "1.0.0",
+				contentDigest: `sha256-tree-v1:${"d".repeat(64)}`,
+				sourceRevision,
 				generation: 7,
 				status: "failed",
 				errorCode: "reconcile_failed",

--- a/packages/cli/src/runtime/hosted-agent-plugin-observation.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-observation.ts
@@ -250,14 +250,7 @@ export function readHostedAgentPluginsObservation(input: {
 
 	const appliedGeneration = resolveRuntimeApplyGeneration(input.applied);
 	const currentFailures = failed.installations.filter(
-		(observation) =>
-			observation.generation > appliedGeneration ||
-			// Plugin-only attempts share a generation. Keep both a different revision
-			// and a failed retry of the currently applied installation identity.
-			(observation.generation === appliedGeneration &&
-				(observation.sourceRevision !== input.applied.sourceRevision ||
-					applied?.installations.some((installation) => sameIdentity(observation, installation)) ===
-						true)),
+		(observation) => observation.generation >= appliedGeneration,
 	);
 	if (currentFailures.length === 0) return applied;
 	const failedNames = new Set(currentFailures.map((observation) => observation.name));

--- a/packages/cli/src/runtime/hosted-agent-plugin-observation.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-observation.ts
@@ -252,10 +252,12 @@ export function readHostedAgentPluginsObservation(input: {
 	const currentFailures = failed.installations.filter(
 		(observation) =>
 			observation.generation > appliedGeneration ||
-			// Plugin-only manifest changes do not bump the runtime generation, so a
-			// failed attempt at the same generation carries a newer revision.
+			// Plugin-only attempts share a generation. Keep both a different revision
+			// and a failed retry of the currently applied installation identity.
 			(observation.generation === appliedGeneration &&
-				observation.sourceRevision !== input.applied.sourceRevision),
+				(observation.sourceRevision !== input.applied.sourceRevision ||
+					applied?.installations.some((installation) => sameIdentity(observation, installation)) ===
+						true)),
 	);
 	if (currentFailures.length === 0) return applied;
 	const failedNames = new Set(currentFailures.map((observation) => observation.name));


### PR DESCRIPTION
## Summary

- preserve current-generation Agent Plugin reconciliation failures in steady-state heartbeats
- align the CLI producer fence and backend ingest validator so both reject only failures from older generations
- cover unchanged-manifest reconvergence failures and the updated backend identity contract

## Root cause

The previous contract assumed: "A failed apply never becomes the applied state, so a failure naming the exact applied identity is a replay."

That assumption no longer holds for Agent Plugin projection. Native plugin installation failures are recorded in `resourceProjectionErrors`, not `installErrors`. Runtime authority commit is gated by `installErrors`, so the manifest whose plugin projection failed can still commit its `generation` and `sourceRevision` as the applied identity. A same-generation, same-revision failure is therefore commonly the real current state after a native install failure and clean rollback, not a replay.

The steady-state CLI heartbeat filtered that failure out, while the backend validator independently rejected the same identity. The control plane consequently saw receipt-derived `installed`/`unknown` state instead of `reconcile_failed`.

## Fix

Both sides now use the same minimal generation fence:

- failures with `generation < applied.generation` remain stale and are discarded/rejected
- failures with `generation == applied.generation`, including an equal `sourceRevision`, are accepted as current
- failures from a newer generation remain accepted
- non-failure observations must still match the complete applied identity

This preserves the stale-generation protection introduced in #1087 without relying on source revision equality to distinguish replay from current projection state.

No attempt or event identity is added. Runtime observation heads already advance only when sequence increases and `captured_at` does not regress, and Agent Plugin reads join the head's `latest_inbox_id`. A later successful heartbeat therefore replaces a same-identity failure, while delayed historical events cannot replace the compact head.

## Deployment order

The backend must deploy before the new CLI rolls out. An old backend rejects a same-generation, same-revision failure with 422, causing the producer to retry the observation. In practice the repository's backend deploys continuously from `main`, while the CLI requires an explicit release and rollout, so the normal delivery sequence satisfies this requirement.

## Verification

- `bun run --cwd packages/cli typecheck`
- `bun test packages/cli/src/runtime/hosted-agent-plugin-observation.test.ts` (7 passed)
- `bunx biome check packages/cli/src/runtime/hosted-agent-plugin-observation.ts packages/cli/src/runtime/hosted-agent-plugin-observation.test.ts`
- `uvx --from ruff==0.16.3 ruff check backend/app/schemas/runtime_observation.py backend/tests/test_runtime_observation_companion.py`
- `uvx --from ruff==0.16.3 ruff format --check backend/app/schemas/runtime_observation.py backend/tests/test_runtime_observation_companion.py`
- `scripts/test.sh backend tests/test_runtime_observation_companion.py -k agent_plugin_observation_rejects_stale_or_unfenced_apply_identity` (1 passed, 33 deselected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
