### PR TITLE
fix(cli): restore forward-upgrade rollback gate

### DIFF
--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -163,19 +163,12 @@ interface RuntimeApplyOptions {
 	continueOnCliUpdateError?: boolean;
 	deferCliInstall?: boolean;
 	deferCliInstallReason?: string;
-	manifestIdentity?: RuntimeManifestIdentity;
 	recoverFailedSystemdUnits?: boolean;
 	requireSystemdApplied?: boolean;
 	preparedHostedSourcedSkills?: ReadonlyMap<string, PreparedHostedSourcedSkill>;
 	preparedHostedAgentPlugins?: PreparedHostedAgentPlugins | null;
 	hostedAgentPluginCommandRunner?: HostedAgentPluginCommandRunner;
 	hostedRuntimeContract?: HostedRuntimeContractOptions;
-}
-
-interface RuntimeManifestIdentity {
-	generation?: number | null;
-	etag?: string | null;
-	previouslyApplied?: boolean;
 }
 
 interface RuntimeWatchFailureBackoff {
@@ -831,10 +824,6 @@ async function runtimeInitLocked(
 						egressSidecarSecretRevision: authority.egressSidecarSecretRevision,
 						userProcessRevisionAliases: authority.userProcessRevisionAliases,
 					}),
-				manifestIdentity: {
-					generation: convergenceLoad.manifest.generation,
-					etag: loaded.etag ?? null,
-				},
 				requireSystemdApplied: applyIdentity !== null,
 				hostedRuntimeContract: opts.hostedRuntimeContract,
 			});
@@ -913,7 +902,11 @@ async function runtimeInitLocked(
 		const { convergence } = applyResult;
 		const runtimeErrors = [...convergence.installErrors];
 		const runtimeReady = runtimeErrors.length === 0;
-		if (runtimeReady) completePendingRuntimeCliUpgrade(paths, getCliVersion());
+		if (runtimeReady) {
+			completePendingRuntimeCliUpgrade(paths, getCliVersion());
+		} else {
+			maybeRollbackFailedCliUpgrade(paths, runtimeErrors);
+		}
 		const activeAppliedState = readRuntimeAppliedState(paths);
 		emitRuntimeInitStatus({
 			opts,
@@ -1100,11 +1093,6 @@ async function runtimeWatchTickAfterCliReconciliation(
 			throw new Error("runtime bundle is missing applied authority identity");
 		}
 		failureEtag = bundleEtag;
-		const manifestIdentity = runtimeManifestIdentityForWatch(
-			loaded.manifest.generation,
-			bundleEtag,
-			paths,
-		);
 		const applyIdentity = loaded.applyContext?.identity ?? null;
 		const applyResult = await applyRuntimeDesiredState(loaded, paths, {
 			authorityCommit: (convergence, authority) =>
@@ -1123,7 +1111,6 @@ async function runtimeWatchTickAfterCliReconciliation(
 			continueOnCliUpdateError: true,
 			deferCliInstall: opts.deferCliInstall,
 			deferCliInstallReason: opts.deferCliInstallReason,
-			manifestIdentity,
 			recoverFailedSystemdUnits: opts.recoverFailedSystemdUnits,
 			requireSystemdApplied: applyIdentity !== null,
 			hostedRuntimeContract: opts.hostedRuntimeContract,
@@ -1296,7 +1283,6 @@ async function applyRuntimeDesiredState(
 			cliUpdate = applyRuntimeCliDesiredState(load.manifest, paths, {
 				deferInstall: opts.deferCliInstall,
 				deferReason: opts.deferCliInstallReason,
-				rollbackEligible: opts.manifestIdentity?.previouslyApplied,
 				runningVersion: getCliVersion(),
 			});
 		} catch (error) {
@@ -1522,19 +1508,6 @@ function runtimeCliUpdateError(
 		version: null,
 		selfReexec: false,
 		error: error instanceof Error ? error.message : String(error),
-	};
-}
-
-function runtimeManifestIdentityForWatch(
-	generation: number,
-	observedManifestEtag: string | null,
-	paths: RuntimePaths,
-): RuntimeManifestIdentity {
-	const appliedState = readRuntimeAppliedState(paths);
-	return {
-		generation,
-		etag: observedManifestEtag,
-		previouslyApplied: appliedState?.etag === observedManifestEtag,
 	};
 }
 

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -197,7 +197,6 @@ export function applyRuntimeCliDesiredState(
 	opts: {
 		deferInstall?: boolean;
 		deferReason?: string;
-		rollbackEligible?: boolean;
 		runningVersion?: string;
 	} = {},
 ): RuntimeCliUpdateResult {
@@ -298,7 +297,6 @@ export function applyRuntimeCliDesiredState(
 			version: installed.version,
 		},
 		previousIdentity,
-		rollbackEligible: opts.rollbackEligible === true && previousIdentity !== null,
 	});
 	swapActiveCli(paths.cliManagedBin, installed.activeTarget);
 	writeCliBootstrapStatus(
@@ -517,7 +515,6 @@ function lastGoodCliIdentity(
 	if (
 		transaction?.phase !== "activated" ||
 		transaction.rollback ||
-		!transaction.rollbackEligible ||
 		!transaction.previousIdentity ||
 		transaction.newIdentity.activeTarget !== activeIdentity.activeTarget
 	) {
@@ -913,13 +910,13 @@ export function rollbackPendingRuntimeCliUpgrade(
 			previousActiveTarget: null,
 		};
 	}
-	if (!transaction.rollbackEligible || !transaction.previousIdentity) {
+	if (!transaction.previousIdentity) {
 		return {
 			status: "not_pending",
 			version: transaction.newIdentity.version,
-			previousVersion: transaction.previousIdentity?.version ?? null,
+			previousVersion: null,
 			activeTarget: transaction.newIdentity.activeTarget,
-			previousActiveTarget: transaction.previousIdentity?.activeTarget ?? null,
+			previousActiveTarget: null,
 		};
 	}
 	if (!verifyStoredCliIdentity(paths, transaction.previousIdentity)) {
@@ -997,7 +994,6 @@ function prepareCliUpgradeTransaction(
 	input: {
 		newIdentity: RuntimeCliInstallIdentity;
 		previousIdentity: RuntimeCliInstallIdentity | null;
-		rollbackEligible: boolean;
 	},
 ): void {
 	const state = normalizeCliUpgradeState(readCliUpgradeState(paths));
@@ -1005,7 +1001,7 @@ function prepareCliUpgradeTransaction(
 		phase: "prepared",
 		previousIdentity: input.previousIdentity,
 		newIdentity: input.newIdentity,
-		rollbackEligible: input.rollbackEligible,
+		rollbackEligible: input.previousIdentity !== null,
 		installedAt: new Date().toISOString(),
 		rollback: null,
 	};

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -70,7 +70,7 @@ interface RuntimeCliBadVersion {
 	registry: string | null;
 	version: string;
 	reason: string;
-	markedAt: string;
+	markedAt?: string;
 }
 
 interface RuntimeCliVerification {
@@ -109,6 +109,7 @@ const NPM_INSTALL_TIMEOUT_MS = 180_000;
 const VERSION_SMOKE_TIMEOUT_MS = 20_000;
 const RUNTIME_VERIFY_TIMEOUT_MS = 20_000;
 const CLI_VERIFY_CACHE_MAX_AGE_MS = 300_000;
+const CLI_BAD_VERSION_TTL_MS = 60 * 60 * 1000;
 const HOSTED_TENANT_PATH_CLI = "/usr/local/bin/clawdi";
 const HOSTED_SYSTEM_NPM_CLI = "/usr/local/lib/node_modules/clawdi/bin/clawdi.mjs";
 
@@ -165,7 +166,7 @@ const cliBadVersionStateSchema = z
 		registry: z.string().min(1).nullable(),
 		version: z.string().min(1),
 		reason: z.string(),
-		markedAt: z.string().min(1),
+		markedAt: z.string().min(1).optional(),
 	})
 	.strict();
 
@@ -576,7 +577,7 @@ function installCliPackage(
 	const installPlan = cliInstallPlan(paths, packageSpec, registry);
 	if (isBadCliVersion(paths, packageSpec, registry, installPlan.version)) {
 		throw new Error(
-			`clawdi CLI ${installPlan.version} is marked bad after rollback; waiting for a newer resolved version`,
+			`clawdi CLI ${installPlan.version} is marked bad after rollback; retry deferred until the rollback cooldown expires`,
 		);
 	}
 	const npmPrefix = installPlan.npmPrefix;
@@ -1349,12 +1350,22 @@ function isBadCliVersion(
 	version: string,
 ): boolean {
 	const state = readCliUpgradeState(paths);
+	const now = Date.now();
 	return (state.badVersions ?? []).some(
 		(entry) =>
 			entry.packageSpec === packageSpec &&
 			(entry.registry ?? null) === registry &&
-			entry.version === version,
+			entry.version === version &&
+			badVersionIsActive(entry, now),
 	);
+}
+
+function badVersionIsActive(entry: RuntimeCliBadVersion, now: number): boolean {
+	if (!entry.markedAt) return false;
+	const markedAt = Date.parse(entry.markedAt);
+	if (!Number.isFinite(markedAt)) return false;
+	const ageMs = now - markedAt;
+	return ageMs >= 0 && ageMs < CLI_BAD_VERSION_TTL_MS;
 }
 
 function readCliUpgradeState(paths: RuntimePaths): RuntimeCliUpgradeState {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -12584,25 +12584,28 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
-	it("rolls back a CLI upgrade when first converge fails for an already-applied manifest", async () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const bin = join(root, "bin");
-		const npmLog = join(root, "npm.log");
-		const openclawInstaller = join(root, "install-openclaw.sh");
-		const previousExitCode = process.exitCode;
-		const previousLog = console.log;
-		const previousPath = process.env.PATH;
-		const currentVersion = getCliVersion();
-		setRuntimeApplyGeneration(18);
-		const logs: string[] = [];
-		mkdirSync(join(run, "secrets"), { recursive: true });
-		mkdirSync(bin, { recursive: true });
-		mkdirSync(home, { recursive: true });
-		writeFileSync(
-			join(bin, "npm"),
-			`#!/usr/bin/env bash
+	it.each(["runtime watch", "runtime init"] as const)(
+		"%s rolls back a forward CLI upgrade on first converge failure",
+		async (command) => {
+			const home = join(root, "home", "clawdi");
+			const state = join(root, "var", "lib", "clawdi");
+			const run = join(root, "run", "clawdi");
+			const bin = join(root, "bin");
+			const npmLog = join(root, "npm.log");
+			const openclawInstaller = join(root, "install-openclaw.sh");
+			const previousExitCode = process.exitCode;
+			const previousLog = console.log;
+			const previousPath = process.env.PATH;
+			const currentVersion = getCliVersion();
+			const previousVersion = "0.13.107";
+			setRuntimeApplyGeneration(18);
+			const logs: string[] = [];
+			mkdirSync(join(run, "secrets"), { recursive: true });
+			mkdirSync(bin, { recursive: true });
+			mkdirSync(home, { recursive: true });
+			writeFileSync(
+				join(bin, "npm"),
+				`#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\\n' "$*" >> '${npmLog}'
 if [ "\${1:-}" = "view" ]; then
@@ -12633,146 +12636,163 @@ echo "fake clawdi"
 SH
 chmod +x "$prefix/bin/clawdi"
 `,
-		);
-		chmodSync(join(bin, "npm"), 0o700);
-		writeFileSync(openclawInstaller, "#!/usr/bin/env bash\necho install failed >&2\nexit 73\n");
-		chmodSync(openclawInstaller, 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
-		process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER = openclawInstaller;
-		process.exitCode = undefined;
-		console.log = (value?: unknown) => {
-			logs.push(String(value));
-		};
-		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
-		seedCurrentCliInstall(state, `clawdi@${currentVersion}`, currentVersion);
-		const paths = getRuntimePaths();
-		const oldTarget = readlinkSync(paths.cliManagedBin);
-		const manifest = {
-			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
-			runtime: "openclaw",
-			deploymentId: "dep_cli_rollback",
-			environmentId: "env_cli_rollback",
-			...hostedRequiredState(),
-			instanceId: "iid_cli_rollback",
-			generation: 18,
-			issuedAt: "2026-06-06T00:00:00Z",
-			locale: TEST_HOSTED_LOCALE,
-			system: hostedSystemFixture(home),
-			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
-			clawdiCli: {
-				source: "npm:clawdi",
-				packageSpec: `clawdi@${currentVersion}`,
-				registry: "https://registry.npmjs.org",
-			},
-			runtimes: {
-				openclaw: hostedOpenClawRuntime({}),
-			},
-		};
-		writeRuntimeAppliedState(
-			{
-				schemaVersion: "clawdi.runtimeAppliedState.v2",
-				appliedAt: "2026-07-13T05:00:00.000Z",
-				instanceId: "iid_cli_rollback",
-				etag: testBundleEtag("etag-cli-rollback"),
-				sourceRevision: "a".repeat(64),
-				generation: 18,
-				contentIdentity: {
-					sourcePath: "https://runtime.test/v1/runtime/manifest",
-					sha256: "b".repeat(64),
-				},
-				providerIds: ["default"],
-				projectedProviderIds: {},
-			},
-			paths,
-		);
-		const { restore } = mockFetch([
-			{
-				method: "GET",
-				path: "/v1/runtime/manifest",
-				response: () =>
-					hostedRuntimeBundleResponse(
-						{
-							manifest,
-							secretValues: {},
-						},
-						{ etag: testBundleEtag("etag-cli-rollback") },
-					),
-			},
-		]);
-
-		try {
-			await runtimeWatch({ once: true, json: true });
-
-			expect(process.exitCode).toBe(0);
-			const handoffEvent = JSON.parse(logs[0]);
-			expect(handoffEvent.status).toBe("cli_handoff");
-			expect(handoffEvent.cliUpdate.status).toBe("installed");
-			expect(handoffEvent.cliRollback).toBeUndefined();
-			expect(readlinkSync(paths.cliManagedBin)).not.toBe(oldTarget);
-			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
-				transaction: { phase: "activated", newIdentity: { version: currentVersion } },
-				badVersions: [],
-			});
-
-			logs.length = 0;
+			);
+			chmodSync(join(bin, "npm"), 0o700);
+			writeFileSync(openclawInstaller, "#!/usr/bin/env bash\necho install failed >&2\nexit 73\n");
+			chmodSync(openclawInstaller, 0o700);
+			process.env.PATH = `${bin}:${previousPath ?? ""}`;
+			process.env.HOME = home;
+			process.env.CLAWDI_RUNTIME_MODE = "hosted";
+			process.env.CLAWDI_SERVICE_STATE_DIR = state;
+			process.env.CLAWDI_RUN_DIR = run;
+			process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
+			process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER = openclawInstaller;
 			process.exitCode = undefined;
-			await runtimeWatch({ once: true, json: true });
-
-			expect(process.exitCode).toBe(1);
-			const event = JSON.parse(logs[0]);
-			expect(event.status).toBe("error");
-			expect(event.cliUpdate.status).toBe("current");
-			expect(event.cliRollback.status).toBe("rolled_back");
-			expect(event.cliRollback.version).toBe(currentVersion);
-			expect(event.selfReexec).toBe(true);
-			expect(readlinkSync(paths.cliManagedBin)).toBe(oldTarget);
-			const upgradeState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-			expect(upgradeState.transaction).toBeNull();
-			expect(upgradeState.badVersions).toContainEqual(
-				expect.objectContaining({
+			console.log = (value?: unknown) => {
+				logs.push(String(value));
+			};
+			writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
+			seedCurrentCliInstall(state, `clawdi@${previousVersion}`, previousVersion);
+			const paths = getRuntimePaths();
+			const oldTarget = readlinkSync(paths.cliManagedBin);
+			const manifest = {
+				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				runtime: "openclaw",
+				deploymentId: "dep_cli_rollback",
+				environmentId: "env_cli_rollback",
+				...hostedRequiredState(),
+				instanceId: "iid_cli_rollback",
+				generation: 18,
+				issuedAt: "2026-06-06T00:00:00Z",
+				locale: TEST_HOSTED_LOCALE,
+				system: hostedSystemFixture(home),
+				controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+				clawdiCli: {
+					source: "npm:clawdi",
 					packageSpec: `clawdi@${currentVersion}`,
-					version: currentVersion,
-				}),
-			);
-			const beforeRetryLog = readFileSync(npmLog, "utf-8");
-			expect(() =>
-				applyRuntimeCliDesiredState(
-					{
-						schemaVersion: "clawdi.runtimeDesiredState.v1",
-						deploymentId: "dep_cli_rollback",
-						environmentId: "env_cli_rollback",
-						instanceId: "iid_cli_rollback",
-						generation: 18,
-						issuedAt: "2026-06-06T00:00:00Z",
-						controlPlane: { apiUrl: "https://cloud-api.test" },
-						clawdiCli: {
-							source: "npm:clawdi",
-							packageSpec: `clawdi@${currentVersion}`,
-							registry: "https://registry.npmjs.org",
-						},
-						runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
-						recovery: {},
+					registry: "https://registry.npmjs.org",
+				},
+				runtimes: {
+					openclaw: hostedOpenClawRuntime({}),
+				},
+			};
+			writeRuntimeAppliedState(
+				{
+					schemaVersion: "clawdi.runtimeAppliedState.v2",
+					appliedAt: "2026-07-13T05:00:00.000Z",
+					instanceId: "iid_cli_rollback",
+					etag: testBundleEtag("etag-cli-rollback-previous"),
+					sourceRevision: "a".repeat(64),
+					generation: 18,
+					contentIdentity: {
+						sourcePath: "https://runtime.test/v1/runtime/manifest",
+						sha256: "b".repeat(64),
 					},
-					paths,
-				),
-			).toThrow(/marked bad/);
-			const afterRetryLog = readFileSync(npmLog, "utf-8");
-			expect(afterRetryLog.split("\n").filter((line) => line.startsWith("install ")).length).toBe(
-				beforeRetryLog.split("\n").filter((line) => line.startsWith("install ")).length,
+					providerIds: ["default"],
+					projectedProviderIds: {},
+				},
+				paths,
 			);
-		} finally {
-			restore();
-			console.log = previousLog;
-			process.exitCode = previousExitCode;
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
+			const { restore } = mockFetch([
+				{
+					method: "GET",
+					path: "/v1/runtime/manifest",
+					response: () =>
+						hostedRuntimeBundleResponse(
+							{
+								manifest,
+								secretValues: {},
+							},
+							{ etag: testBundleEtag("etag-cli-rollback") },
+						),
+				},
+			]);
+
+			try {
+				if (command === "runtime watch") {
+					await runtimeWatch({ once: true, json: true });
+				} else {
+					await runtimeInit({ nonInteractive: true, json: true });
+				}
+
+				expect(process.exitCode ?? 0).toBe(command === "runtime watch" ? 0 : 75);
+				const handoffEvent = JSON.parse(logs[0]);
+				expect(handoffEvent.status).toBe(command === "runtime watch" ? "cli_handoff" : "ok");
+				expect(handoffEvent.cliUpdate.status).toBe("installed");
+				expect(handoffEvent.cliRollback).toBeUndefined();
+				expect(readlinkSync(paths.cliManagedBin)).not.toBe(oldTarget);
+				expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
+					transaction: {
+						phase: "activated",
+						previousIdentity: { version: previousVersion },
+						newIdentity: { version: currentVersion },
+						rollbackEligible: true,
+					},
+					badVersions: [],
+				});
+
+				logs.length = 0;
+				process.exitCode = undefined;
+				if (command === "runtime watch") {
+					await runtimeWatch({ once: true, json: true });
+				} else {
+					await runtimeInit({ nonInteractive: true, json: true });
+				}
+
+				expect(process.exitCode).toBe(command === "runtime watch" ? 1 : 23);
+				const event = JSON.parse(logs[0]);
+				expect(event.status).toBe("error");
+				if (command === "runtime watch") {
+					expect(event.cliUpdate.status).toBe("current");
+					expect(event.cliRollback.status).toBe("rolled_back");
+					expect(event.cliRollback.version).toBe(currentVersion);
+					expect(event.selfReexec).toBe(true);
+				}
+				expect(event.errors.join("\n")).toContain("rolled back clawdi CLI");
+				expect(readlinkSync(paths.cliManagedBin)).toBe(oldTarget);
+				const upgradeState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
+				expect(upgradeState.transaction).toBeNull();
+				expect(upgradeState.badVersions).toContainEqual(
+					expect.objectContaining({
+						packageSpec: `clawdi@${currentVersion}`,
+						version: currentVersion,
+					}),
+				);
+				const beforeRetryLog = readFileSync(npmLog, "utf-8");
+				expect(() =>
+					applyRuntimeCliDesiredState(
+						{
+							schemaVersion: "clawdi.runtimeDesiredState.v1",
+							deploymentId: "dep_cli_rollback",
+							environmentId: "env_cli_rollback",
+							instanceId: "iid_cli_rollback",
+							generation: 18,
+							issuedAt: "2026-06-06T00:00:00Z",
+							controlPlane: { apiUrl: "https://cloud-api.test" },
+							clawdiCli: {
+								source: "npm:clawdi",
+								packageSpec: `clawdi@${currentVersion}`,
+								registry: "https://registry.npmjs.org",
+							},
+							runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
+							recovery: {},
+						},
+						paths,
+					),
+				).toThrow(/marked bad/);
+				const afterRetryLog = readFileSync(npmLog, "utf-8");
+				expect(afterRetryLog.split("\n").filter((line) => line.startsWith("install ")).length).toBe(
+					beforeRetryLog.split("\n").filter((line) => line.startsWith("install ")).length,
+				);
+			} finally {
+				restore();
+				console.log = previousLog;
+				process.exitCode = previousExitCode;
+				if (previousPath === undefined) delete process.env.PATH;
+				else process.env.PATH = previousPath;
+			}
+		},
+	);
 
 	it("runtime watch keeps npm ETARGET retryable without converging or marking the version bad", async () => {
 		const home = join(root, "home", "clawdi");
@@ -13313,11 +13333,6 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		const paths = getRuntimePaths();
-		const manifestIdentity = {
-			generation: 1,
-			etag: testBundleEtag("etag-cli-rollback-lifecycle"),
-			previouslyApplied: true,
-		};
 		const manifestFor = (version: string): RuntimeManifest => ({
 			schemaVersion: "clawdi.runtimeDesiredState.v1",
 			deploymentId: "dep_cli_rollback_lifecycle",
@@ -13332,9 +13347,7 @@ chmod +x "$prefix/bin/clawdi"
 		});
 
 		try {
-			const first = applyRuntimeCliDesiredState(manifestFor("1.2.20-test.1"), paths, {
-				rollbackEligible: manifestIdentity.previouslyApplied,
-			});
+			const first = applyRuntimeCliDesiredState(manifestFor("1.2.20-test.1"), paths);
 			if (!first.activeTarget) throw new Error("first CLI install has no active target");
 			const lastGoodTarget = first.activeTarget;
 			const lastGoodPrefix = first.npmPrefix;
@@ -13342,9 +13355,7 @@ chmod +x "$prefix/bin/clawdi"
 			expect(firstState.transaction.rollbackEligible).toBe(false);
 
 			rmSync(paths.cliBootstrapStatus, { force: true });
-			const failed = applyRuntimeCliDesiredState(manifestFor("1.2.20-test.2"), paths, {
-				rollbackEligible: manifestIdentity.previouslyApplied,
-			});
+			const failed = applyRuntimeCliDesiredState(manifestFor("1.2.20-test.2"), paths);
 			if (!failed.activeTarget) throw new Error("failed CLI install has no active target");
 			const failedTarget = failed.activeTarget;
 			const failedState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
@@ -13372,9 +13383,7 @@ chmod +x "$prefix/bin/clawdi"
 				version: "1.2.20-test.1",
 			});
 
-			applyRuntimeCliDesiredState(manifestFor("1.2.20-test.3"), paths, {
-				rollbackEligible: manifestIdentity.previouslyApplied,
-			});
+			applyRuntimeCliDesiredState(manifestFor("1.2.20-test.3"), paths);
 			const secondState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
 			expect(secondState.transaction.previousIdentity.activeTarget).toBe(lastGoodTarget);
 			expect(secondState.transaction.previousIdentity.activeTarget).not.toBe(failedTarget);

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -11555,6 +11555,28 @@ chmod +x "$prefix/bin/clawdi"
 		});
 	});
 
+	it("reads legacy CLI journals whose bad-version entries have no timestamp", () => {
+		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(
+			join(root, "state-cli-legacy-bad-version"),
+			join(root, "run-cli-legacy-bad-version"),
+		);
+		pointManagedCliAt(paths, newIdentity);
+		writeCliBootstrapFixture(paths, newIdentity);
+		writeCliTransactionFixture(paths, {
+			phase: "activated",
+			previousIdentity,
+			newIdentity,
+			badVersions: [{ version: newIdentity.version, reason: "legacy rollback" }],
+		});
+		const legacyState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
+		delete legacyState.badVersions[0].markedAt;
+		writeFileSync(paths.cliUpgradeState, `${JSON.stringify(legacyState)}\n`);
+
+		const recovered = reconcilePendingRuntimeCliUpgrade(paths, newIdentity.version);
+
+		expect(recovered).toEqual({ status: "unchanged", selfReexec: false });
+	});
+
 	it("accepts a verified external bootstrap that supersedes a stale activated transaction", () => {
 		const { paths, previousIdentity, newIdentity, bootstrapIdentity } =
 			seedExternalCliBootstrapRecoveryFixture(
@@ -12758,31 +12780,39 @@ chmod +x "$prefix/bin/clawdi"
 						version: currentVersion,
 					}),
 				);
+				const retryManifest: RuntimeManifest = {
+					schemaVersion: "clawdi.runtimeDesiredState.v1",
+					deploymentId: "dep_cli_rollback",
+					environmentId: "env_cli_rollback",
+					instanceId: "iid_cli_rollback",
+					generation: 18,
+					issuedAt: "2026-06-06T00:00:00Z",
+					controlPlane: { apiUrl: "https://cloud-api.test" },
+					clawdiCli: {
+						source: "npm:clawdi",
+						packageSpec: `clawdi@${currentVersion}`,
+						registry: "https://registry.npmjs.org",
+					},
+					runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
+					recovery: {},
+				};
 				const beforeRetryLog = readFileSync(npmLog, "utf-8");
-				expect(() =>
-					applyRuntimeCliDesiredState(
-						{
-							schemaVersion: "clawdi.runtimeDesiredState.v1",
-							deploymentId: "dep_cli_rollback",
-							environmentId: "env_cli_rollback",
-							instanceId: "iid_cli_rollback",
-							generation: 18,
-							issuedAt: "2026-06-06T00:00:00Z",
-							controlPlane: { apiUrl: "https://cloud-api.test" },
-							clawdiCli: {
-								source: "npm:clawdi",
-								packageSpec: `clawdi@${currentVersion}`,
-								registry: "https://registry.npmjs.org",
-							},
-							runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
-							recovery: {},
-						},
-						paths,
-					),
-				).toThrow(/marked bad/);
+				expect(() => applyRuntimeCliDesiredState(retryManifest, paths)).toThrow(/marked bad/);
 				const afterRetryLog = readFileSync(npmLog, "utf-8");
 				expect(afterRetryLog.split("\n").filter((line) => line.startsWith("install ")).length).toBe(
 					beforeRetryLog.split("\n").filter((line) => line.startsWith("install ")).length,
+				);
+
+				upgradeState.badVersions[0].markedAt = new Date(
+					Date.now() - 60 * 60 * 1000 - 1_000,
+				).toISOString();
+				writeFileSync(paths.cliUpgradeState, `${JSON.stringify(upgradeState)}\n`);
+
+				const retried = applyRuntimeCliDesiredState(retryManifest, paths);
+				expect(retried.status).toBe("installed");
+				const afterTtlLog = readFileSync(npmLog, "utf-8");
+				expect(afterTtlLog.split("\n").filter((line) => line.startsWith("install ")).length).toBe(
+					beforeRetryLog.split("\n").filter((line) => line.startsWith("install ")).length + 1,
 				);
 			} finally {
 				restore();


### PR DESCRIPTION
## Summary

- derive failed-converge rollback eligibility from a verified previous CLI identity instead of manifest history
- run the existing failed-converge rollback path from both runtime watch and runtime init
- expire rollback-generated bad-version blocks after 60 minutes so the control-plane pin can self-heal
- accept legacy v2 journal entries without `markedAt` and treat them as already expired

## Why both fixes must ship together

The watch path treated `appliedState.etag === observedManifestEtag` as a prerequisite for rollback and passed that value through `manifestIdentity.previouslyApplied` into the CLI upgrade transaction. Runtime init omitted the flag, which had the same false result.

A real forward upgrade changes `clawdiCli.packageSpec`, which changes the bundle ETag. Its first convergence therefore cannot be previously applied, so the transaction was marked ineligible. If the new CLI executed successfully but its first convergence failed, `rollbackPendingRuntimeCliUpgrade` returned `not_pending` and left the unproven CLI active.

Fixing that gate makes failed-converge rollback reachable. That exposes an existing interaction: every successful rollback writes the candidate to `badVersions`, and the old install gate rejected that package spec forever. A transient first-converge failure could therefore roll back safely but permanently pin the node to the old CLI while the control plane continued serving the same valid spec.

The eligibility fix and bounded bad-version lifetime must land atomically. The former restores safe rollback; the latter preserves eventual retry and fleet self-healing after transient failures.

## Fix

The manifest-history flag and its parameter chain are removed. New transactions derive their persisted rollback eligibility directly from `previousIdentity !== null`, and failed-converge rollback checks and verifies the previous identity before restoring it. Runtime init now invokes the same rollback helper as runtime watch when runtime convergence fails.

Rollback entries retain their existing `markedAt` timestamp, but they only block the exact package spec, registry, and version for 60 minutes. Missing, invalid, or future timestamps are treated as expired, preventing legacy or clock-anomalous entries from creating a permanent block. Expired entries remain in the journal for history and are refreshed by the existing upsert if that version rolls back again.

Interrupted-install recovery remains unchanged. No transient/permanent error classifier is introduced.

## Regression coverage

The parameterized watch/init regression now exercises the full interaction:

1. seed an applied old bundle ETag and a verified previous CLI version
2. return a control-plane manifest with a new package spec and new ETag
3. install and hand off to the new CLI
4. fail its first runtime convergence and roll back to the previous identity
5. verify the same spec is rejected during the 60-minute cooldown
6. advance the persisted timestamp beyond the TTL and verify the same spec installs again

A separate compatibility test reads a legacy v2 journal whose bad-version entry has no `markedAt` field.

## Verification

- `bun run --cwd packages/cli typecheck`
- `bunx biome check packages/cli/src/commands/runtime.ts packages/cli/src/runtime/cli-update.ts packages/cli/tests/runtime.test.ts`
- `bun test packages/cli/tests/runtime.test.ts packages/cli/tests/commands/runtime.test.ts` (182 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
