### PR TITLE
chore(cli): remove dead hosted runtime code

### DIFF
--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -680,10 +680,6 @@ function validateManifestSemantics(
 			}
 			continue;
 		}
-		if (!runtime.install && !runCommand && !isSupportedRuntimeName(name)) {
-			errors.push(`runtime ${name} is enabled but missing install metadata`);
-			continue;
-		}
 		if (!runtime.install) continue;
 		const expectedUrl = OFFICIAL_INSTALL_URLS[name];
 		if (runtime.install.url !== expectedUrl) {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -318,7 +318,6 @@ export interface RuntimeConvergenceResult {
 		egressAddon: string | null;
 		liveSyncEnvironments: string[];
 		daemonAuthTokenFile: string | null;
-		instanceSemaphores: string[];
 		bootFinished: string;
 	};
 }
@@ -5641,7 +5640,6 @@ function runtimeConvergenceWithoutApply(input: {
 			egressAddon: null,
 			liveSyncEnvironments: [],
 			daemonAuthTokenFile: null,
-			instanceSemaphores: [],
 			bootFinished: join(instanceRoot, "boot-finished"),
 		},
 	};
@@ -6311,8 +6309,6 @@ export function convergeRuntimeManifest(
 		? paths.egressProfileBundle
 		: null;
 	const instanceRoot = join(paths.instanceRoot, manifest.instanceId);
-	const semRoot = join(instanceRoot, "sem");
-	const instanceSemaphores: string[] = [];
 	const installInventory: string[] = [];
 	const projections: string[] = [];
 	const managedLocaleFiles: string[] = [];
@@ -6742,7 +6738,7 @@ export function convergeRuntimeManifest(
 			mkdirSync(workspaceRoot, { recursive: true });
 			makeRuntimeUserOwned(workspaceRoot);
 		});
-		for (const directory of [paths.installInventory, paths.projectionRoot, instanceRoot, semRoot]) {
+		for (const directory of [paths.installInventory, paths.projectionRoot, instanceRoot]) {
 			ensureRuntimePlatformDirectory(paths, directory, { mode: 0o755 });
 		}
 		ensureRuntimePlatformDirectory(paths, paths.managedSecretRoot);
@@ -7183,12 +7179,6 @@ export function convergeRuntimeManifest(
 					runtimeRunConfigId(serviceRunConfig.runtime, serviceRunConfig.service),
 				);
 			}
-
-			const semaphorePath = join(semRoot, `${name}.enabled`);
-			if (runtime.enabled) {
-				writeRuntimePrivateFileAtomic(paths, semaphorePath, `${generatedAt}\n`);
-				instanceSemaphores.push(semaphorePath);
-			}
 		}
 
 		const mcpProjection = join(paths.projectionRoot, "clawdi-mcp.json");
@@ -7408,7 +7398,6 @@ export function convergeRuntimeManifest(
 				egressAddon: egressAddon?.path ?? null,
 				liveSyncEnvironments,
 				daemonAuthTokenFile,
-				instanceSemaphores,
 				bootFinished,
 			},
 		};

--- a/packages/cli/src/runtime/run-config.ts
+++ b/packages/cli/src/runtime/run-config.ts
@@ -225,9 +225,6 @@ export function buildRuntimeRunInvocation(
 		...baseEnv,
 		...read.config.env,
 		...runtimeSecretEnv(read.config.secretFilePath, read.config.secretEnv),
-		...(read.config.secretFilePath && read.config.egressProfileBundlePath
-			? { CLAWDI_EGRESS_SECRET_FILE: read.config.secretFilePath }
-			: {}),
 		PATH: pathPrefix ? [pathPrefix, currentPath].filter(Boolean).join(":") : currentPath,
 	};
 	if (read.config.egressProfileBundlePath) {

--- a/packages/cli/src/runtime/state.ts
+++ b/packages/cli/src/runtime/state.ts
@@ -56,7 +56,6 @@ export interface RuntimeBootStatus {
 		egressAddon: string | null;
 		liveSyncEnvironments: string[];
 		daemonAuthTokenFile: string | null;
-		instanceSemaphores: string[];
 		bootFinished: string;
 	};
 	error?: string;


### PR DESCRIPTION
Three verified dead-code removals in the hosted runtime path (net −19 lines):

- **Runtime semaphores** (`sem/<runtime>.enabled`): written on every converge, never deleted on disable, and — verified across both this repo and the hosted repo (image, incus-image, platform scripts) — **zero consumers**. Removes the write, the directory provisioning, the `instanceSemaphores` convergence output, and the state field.
- **Guaranteed-dead egress env assignment** (`run-config.ts`): the conditional `CLAWDI_EGRESS_SECRET_FILE` assignment required `egressProfileBundlePath`, and the very next block on the same condition calls `applyEgressTransparentRuntimeEnv`, which strips it. Provably unreachable in effect.
- **Unreachable validation branch** (`manifest-source.ts`): unsupported runtime names `continue` earlier in the loop, so the "missing install metadata" branch could never fire.

Verified on the final tree: CLI typecheck, Biome, and 230 targeted tests (run-config / runtime-bundle-v2 / manifest-reconciliation) all green; zero remaining references to the semaphore protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)