### PR TITLE
fix(cli): make hosted runtime observations self-healing

### DIFF
--- a/backend/app/schemas/runtime_observation.py
+++ b/backend/app/schemas/runtime_observation.py
@@ -170,7 +170,7 @@ class RuntimeObservationEventV2(RuntimeObservationRequestModel):
     )
     error: str | None = Field(default=None, max_length=4000)
     converge_error: str | None = Field(alias="convergeError", default=None, max_length=4000)
-    truncated: Literal[False] | None = None
+    truncated: bool | None = None
     generation: int | None = Field(default=None, ge=1, le=9_007_199_254_740_991)
     manifest_etag: str | None = Field(
         alias="manifestETag",
@@ -227,6 +227,12 @@ class RuntimeObservationEventV2(RuntimeObservationRequestModel):
             raise ValueError("predecessorBootSessionId must differ from bootSessionId")
         if self.successor_boot_session_id == self.boot_session_id:
             raise ValueError("successorBootSessionId must differ from bootSessionId")
+        if (
+            self.systemd is not None
+            and self.systemd.unit_count > len(self.systemd.units)
+            and self.truncated is not True
+        ):
+            raise ValueError("truncated must be true when systemd units are omitted")
         if self.agent_plugins is not None:
             self.agent_plugins.validate_applied_identity(self.applied)
         return self

--- a/backend/app/schemas/runtime_observed.py
+++ b/backend/app/schemas/runtime_observed.py
@@ -52,8 +52,14 @@ class HostedRuntimeObservedSystemdUnitV1(_StrictObservedWireModel):
 
 class HostedRuntimeObservedSystemdV1(_StrictObservedWireModel):
     status: RuntimeObservedStatus
-    unit_count: int = Field(alias="unitCount", ge=0, le=30)
+    unit_count: int = Field(alias="unitCount", ge=0, le=9_007_199_254_740_991)
     units: list[HostedRuntimeObservedSystemdUnitV1] = Field(max_length=30)
+
+    @model_validator(mode="after")
+    def validate_unit_count(self) -> HostedRuntimeObservedSystemdV1:
+        if self.unit_count < len(self.units):
+            raise ValueError("unitCount must include every reported systemd unit")
+        return self
 
 
 class HostedRuntimeObservedSupervisorProgramV1(_StrictObservedWireModel):

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -178,6 +178,33 @@ def test_runtime_observation_identity_envelope_is_additive_and_consistent() -> N
         RuntimeObservationEventV2.model_validate({**payload, "generation": 2})
 
 
+def test_runtime_observation_accepts_explicitly_truncated_systemd_summary() -> None:
+    payload = _payload().model_dump(mode="json", by_alias=True)
+    systemd = {
+        "status": "ok",
+        "unitCount": 62,
+        "units": [
+            {
+                "scope": "system",
+                "name": "clawdi-runtime-watch.service",
+                "activeState": "active",
+                "subState": "running",
+                "status": "ok",
+            }
+        ],
+    }
+
+    observed = RuntimeObservationEventV2.model_validate(
+        {**payload, "systemd": systemd, "truncated": True}
+    )
+
+    assert observed.systemd is not None
+    assert observed.systemd.unit_count == 62
+    assert observed.truncated is True
+    with pytest.raises(ValueError, match="truncated must be true"):
+        RuntimeObservationEventV2.model_validate({**payload, "systemd": systemd})
+
+
 def test_agent_plugin_observation_rejects_stale_or_unfenced_apply_identity() -> None:
     payload = _payload(generation=2).model_dump(mode="json", by_alias=True)
     installation = {

--- a/packages/cli/src/runtime/heartbeat-observation.test.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.test.ts
@@ -4,6 +4,7 @@ import {
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
+	readdirSync,
 	readFileSync,
 	rmSync,
 	statSync,
@@ -396,7 +397,7 @@ describe("hosted runtime heartbeat observation", () => {
 		expect(durable).toMatchObject({ lastCapturedAt: "2026-07-16T05:00:00.000Z" });
 	});
 
-	test("retires only the matching terminally stale buffered event", () => {
+	test("retires only the matching rejected buffered event", () => {
 		const paths = tempRuntimePaths();
 		writeRuntimeAppliedState(companionAppliedState(7), paths);
 		const session = new HostedRuntimeHeartbeatSession({
@@ -407,10 +408,49 @@ describe("hosted runtime heartbeat observation", () => {
 		});
 		const stale = session.nextEvent();
 		if (!stale) throw new Error("expected stale buffered event");
-		expect(session.retireTerminallyStale("different-event")).toBe(false);
+		expect(session.retireRejected("different-event")).toBe(false);
 		expect(session.nextEvent()).toEqual(stale);
-		expect(session.retireTerminallyStale(stale.event.eventId)).toBe(true);
+		expect(session.retireRejected(stale.event.eventId)).toBe(true);
 		expect(session.nextEvent()).not.toEqual(stale);
+	});
+
+	test.each([
+		["invalid JSON", "{not-json"],
+		[
+			"unknown schema",
+			JSON.stringify({ schemaVersion: "clawdi.runtimeHeartbeatObservation.v999" }),
+		],
+	] as const)("quarantines %s state and starts fresh", (_name, corruptedState) => {
+		const paths = tempRuntimePaths();
+		writeRuntimeAppliedState(companionAppliedState(7), paths);
+		const statePath = runtimeHeartbeatObservationStatePath(paths, "env_corrupt_state");
+		mkdirSync(dirname(statePath), { recursive: true });
+		writeFileSync(statePath, corruptedState);
+
+		const session = new HostedRuntimeHeartbeatSession({
+			environmentId: "env_corrupt_state",
+			paths,
+			now: () => new Date("2026-07-16T06:00:00.000Z"),
+			createId: idSequence(["fresh-boot-session", "fresh-event-000001"]),
+		});
+		const event = session.nextEvent();
+
+		expect(event?.event).toMatchObject({
+			bootSessionId: "fresh-boot-session",
+			sequence: 1,
+			eventId: "fresh-event-000001",
+		});
+		const quarantineNames = readdirSync(dirname(statePath)).filter((name) =>
+			name.startsWith(`${basename(statePath)}.corrupt-`),
+		);
+		expect(quarantineNames).toHaveLength(1);
+		const quarantineName = quarantineNames[0];
+		if (!quarantineName) throw new Error("expected quarantined heartbeat state");
+		expect(readFileSync(join(dirname(statePath), quarantineName), "utf-8")).toBe(corruptedState);
+		expect(JSON.parse(readFileSync(statePath, "utf-8"))).toMatchObject({
+			schemaVersion: "clawdi.runtimeHeartbeatObservation.v2",
+			nextSequence: 2,
+		});
 	});
 
 	test("does not advance in-memory sequence when buffering fails to persist", () => {

--- a/packages/cli/src/runtime/heartbeat-observation.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.ts
@@ -1,9 +1,10 @@
 import { createHash, randomUUID } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync, renameSync } from "node:fs";
 import { join } from "node:path";
 import type { components } from "@clawdi/shared/api";
 import { z } from "zod";
 import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE } from "../lib/private-file";
+import { log, toErrorMessage } from "../serve/log";
 import {
 	type RuntimeAppliedState,
 	readRuntimeAppliedState,
@@ -72,10 +73,19 @@ const observedSystemdUnitSchema = z
 const observedSystemdSchema = z
 	.object({
 		status: z.enum(["ok", "error", "unknown"]),
-		unitCount: z.number().int().nonnegative(),
+		unitCount: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
 		units: z.array(observedSystemdUnitSchema),
 	})
-	.strict();
+	.strict()
+	.superRefine((systemd, ctx) => {
+		if (systemd.unitCount < systemd.units.length) {
+			ctx.addIssue({
+				code: "custom",
+				message: "unitCount must include every reported systemd unit",
+				path: ["unitCount"],
+			});
+		}
+	});
 
 const observedSupervisorProgramSchema = z
 	.object({
@@ -114,7 +124,7 @@ const hostedRuntimeObservedEventSchema: z.ZodType<HostedRuntimeObservedEvent> = 
 		agentPlugins: agentPluginsObservationSchema.nullable().optional(),
 		error: z.string().nullable().optional(),
 		convergeError: z.string().nullable().optional(),
-		truncated: z.literal(false).nullable().optional(),
+		truncated: z.boolean().nullable().optional(),
 		generation: positiveSafeIntegerSchema,
 		manifestETag: z.string().min(1).max(128),
 		applyReceiptId: z.string().min(16).max(128),
@@ -133,6 +143,17 @@ const hostedRuntimeObservedEventSchema: z.ZodType<HostedRuntimeObservedEvent> = 
 				code: "custom",
 				message: "reportedAt must equal the original capturedAt for companion events",
 				path: ["reportedAt"],
+			});
+		}
+		if (
+			event.systemd &&
+			event.systemd.unitCount > event.systemd.units.length &&
+			event.truncated !== true
+		) {
+			ctx.addIssue({
+				code: "custom",
+				message: "truncated must be true when systemd units are omitted",
+				path: ["truncated"],
 			});
 		}
 		if (event.predecessorBootSessionId === event.bootSessionId) {
@@ -241,10 +262,8 @@ export class HostedRuntimeHeartbeatSession {
 		this.createId = options.createId ?? randomUUID;
 		this.createSuccessorId = options.createSuccessorId ?? randomUUID;
 		this.statePath = runtimeHeartbeatObservationStatePath(this.paths, options.environmentId);
-		const persisted = this.paths.mode === "hosted" ? readState(this.statePath) : null;
-		if (persisted && persisted.environmentId !== options.environmentId) {
-			throw new Error("runtime heartbeat state environment binding does not match");
-		}
+		const persisted =
+			this.paths.mode === "hosted" ? readState(this.statePath, options.environmentId) : null;
 		this.state = null;
 		this.initializeAppliedState(persisted);
 	}
@@ -433,7 +452,7 @@ export class HostedRuntimeHeartbeatSession {
 		return true;
 	}
 
-	retireTerminallyStale(eventId: string): boolean {
+	retireRejected(eventId: string): boolean {
 		return this.clearPending(eventId);
 	}
 
@@ -460,18 +479,50 @@ export function runtimeHeartbeatObservationStatePath(
 	return join(paths.runtimeHeartbeatRoot, `${environmentKey}.json`);
 }
 
-function readState(path: string): PersistedHeartbeatState | LegacyHeartbeatState | null {
-	if (!existsSync(path)) return null;
+function readState(
+	path: string,
+	environmentId: string,
+): PersistedHeartbeatState | LegacyHeartbeatState | null {
+	let serialized: string;
 	try {
-		const raw: unknown = JSON.parse(readFileSync(path, "utf-8"));
-		return z.union([heartbeatStateSchema, legacyHeartbeatStateSchema]).parse(raw);
+		serialized = readFileSync(path, "utf-8");
 	} catch (error) {
+		if (hasErrorCode(error, "ENOENT")) return null;
 		throw new Error(
-			`invalid durable runtime heartbeat state at ${path}: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
+			`unable to read durable runtime heartbeat state at ${path}: ${toErrorMessage(error)}`,
 		);
 	}
+
+	try {
+		const raw: unknown = JSON.parse(serialized);
+		const state = z.union([heartbeatStateSchema, legacyHeartbeatStateSchema]).parse(raw);
+		if (state.environmentId !== environmentId) {
+			throw new Error("runtime heartbeat state environment binding does not match");
+		}
+		if (state.pending) decodePendingEvent(state.pending);
+		return state;
+	} catch (error) {
+		const quarantinePath = `${path}.corrupt-${Date.now()}-${randomUUID()}`;
+		try {
+			renameSync(path, quarantinePath);
+		} catch (quarantineError) {
+			throw new Error(
+				`invalid durable runtime heartbeat state at ${path}: ${toErrorMessage(
+					error,
+				)}; quarantine failed: ${toErrorMessage(quarantineError)}`,
+			);
+		}
+		log.warn("daemon.runtime_heartbeat_state_quarantined", {
+			path,
+			quarantine_path: quarantinePath,
+			error: error instanceof z.ZodError ? "state schema validation failed" : toErrorMessage(error),
+		});
+		return null;
+	}
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+	return typeof error === "object" && error !== null && "code" in error && error.code === code;
 }
 
 function writeState(paths: RuntimePaths, path: string, state: PersistedHeartbeatState): void {

--- a/packages/cli/src/runtime/observation-producer.test.ts
+++ b/packages/cli/src/runtime/observation-producer.test.ts
@@ -7,6 +7,7 @@ import { type RuntimeAppliedStateV2, writeRuntimeAppliedState } from "./applied-
 import { HostedRuntimeHeartbeatSession } from "./heartbeat-observation";
 import {
 	HostedRuntimeObservationProducer,
+	isPermanentRuntimeObservationRejection,
 	runRuntimeObservationProducer,
 } from "./observation-producer";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
@@ -335,6 +336,47 @@ describe("hosted runtime observation producer", () => {
 		});
 	});
 
+	test("retires a permanently rejected event and captures a fresh observation", async () => {
+		const paths = tempRuntimePaths();
+		writeApplyIdentityFile(paths, 1);
+		writeRuntimeAppliedState(appliedState(1), paths);
+		const submitted: components["schemas"]["RuntimeObservationEventV2"][] = [];
+		const ids = ["boot-session-0001", "rejected-event-0001", "fresh-event-000002"];
+		const times = [new Date("2026-07-22T00:01:00.000Z"), new Date("2026-07-22T00:02:00.000Z")];
+		const producer = new HostedRuntimeObservationProducer({
+			abort: new AbortController().signal,
+			paths,
+			contextPath: runtimeContextPath(paths),
+			submit: async (_environmentId, event) => {
+				submitted.push(event);
+				return submitted.length === 1 ? "terminal-rejected" : "accepted";
+			},
+			sessionFactory: (environmentId, sessionPaths) =>
+				new HostedRuntimeHeartbeatSession({
+					environmentId,
+					paths: sessionPaths,
+					createId: () => {
+						const id = ids.shift();
+						if (!id) throw new Error("test ID sequence exhausted");
+						return id;
+					},
+					now: () => {
+						const time = times.shift();
+						if (!time) throw new Error("test clock sequence exhausted");
+						return time;
+					},
+				}),
+		});
+
+		expect(await producer.sendOnce()).toEqual({ outcome: "sent" });
+		expect(await producer.sendOnce()).toEqual({ outcome: "accepted", status: "unknown" });
+		expect(submitted.map((event) => event.eventId)).toEqual([
+			"rejected-event-0001",
+			"fresh-event-000002",
+		]);
+		expect(submitted[1]?.sequence).toBe(2);
+	});
+
 	test("does not let an unresolved old-tuple request block rotation", async () => {
 		const paths = tempRuntimePaths();
 		writeApplyIdentityFile(paths, 1);
@@ -374,6 +416,73 @@ describe("hosted runtime observation producer", () => {
 
 		expect(submitted.map((event) => event.applied.generation)).toEqual([1, 2]);
 		expect(submitted[1]).toMatchObject({ sequence: 1, applied: { generation: 2 } });
+	});
+
+	test("forgets retired identity schedules and in-flight attempts", async () => {
+		const paths = tempRuntimePaths();
+		writeApplyIdentityFile(paths, 1);
+		writeRuntimeAppliedState(appliedState(1), paths);
+		const abort = new AbortController();
+		const submitted: number[] = [];
+		let firstGenerationOneResolve: ((result: "accepted") => void) | null = null;
+		let generationOneAttempts = 0;
+		let delayCalls = 0;
+		let clock = 0;
+
+		await runRuntimeObservationProducer({
+			abort: abort.signal,
+			paths,
+			contextPath: runtimeContextPath(paths),
+			submit: async (_environmentId, event) => {
+				submitted.push(event.applied.generation);
+				if (event.applied.generation !== 1) return "accepted";
+				generationOneAttempts += 1;
+				if (generationOneAttempts === 1) {
+					return await new Promise<"accepted">((resolve) => {
+						firstGenerationOneResolve = resolve;
+					});
+				}
+				return await new Promise<"accepted">(() => {});
+			},
+			now: () => clock,
+			delay: async (ms) => {
+				delayCalls += 1;
+				clock += ms;
+				await Promise.resolve();
+				await Promise.resolve();
+				await Promise.resolve();
+				if (delayCalls === 1) {
+					writeApplyIdentityFile(paths, 2);
+					writeRuntimeAppliedState(appliedState(2), paths);
+					firstGenerationOneResolve?.("accepted");
+					await Promise.resolve();
+					await Promise.resolve();
+				} else if (delayCalls === 2 || delayCalls === 4) {
+					writeApplyIdentityFile(paths, 1);
+					writeRuntimeAppliedState(appliedState(1), paths);
+				} else if (delayCalls === 3) {
+					writeApplyIdentityFile(paths, 2);
+					writeRuntimeAppliedState(appliedState(2), paths);
+				} else if (generationOneAttempts === 3 || delayCalls >= 8) {
+					abort.abort();
+				}
+			},
+		});
+
+		expect(submitted).toEqual([1, 2, 1, 2, 1]);
+	});
+
+	test.each([
+		[400, true],
+		[401, true],
+		[403, true],
+		[404, true],
+		[409, true],
+		[422, true],
+		[429, false],
+		[500, false],
+	] as const)("classifies HTTP %i permanent rejection as %s", (status, expected) => {
+		expect(isPermanentRuntimeObservationRejection({ response: { status } })).toBe(expected);
 	});
 
 	test("reports a non-ok to ok transition within five seconds", async () => {

--- a/packages/cli/src/runtime/observation-producer.ts
+++ b/packages/cli/src/runtime/observation-producer.ts
@@ -26,7 +26,7 @@ const runtimeInstanceIdentitySchema = z
 	})
 	.passthrough();
 
-type ObservationSubmitResult = "accepted" | "terminal-stale";
+type ObservationSubmitResult = "accepted" | "terminal-rejected";
 type RuntimeObservedStatus = HostedRuntimeObservedEvent["status"];
 
 type ObservationSendResult =
@@ -66,6 +66,7 @@ export class HostedRuntimeObservationProducer {
 	private readonly sessionFactory: NonNullable<RuntimeObservationProducerOptions["sessionFactory"]>;
 	private session: HostedRuntimeHeartbeatSession | null = null;
 	private environmentId: string | null = null;
+	private lastAttestationError: string | null = null;
 
 	constructor(options: RuntimeObservationProducerOptions) {
 		this.paths = options.paths ?? getRuntimePaths();
@@ -82,7 +83,7 @@ export class HostedRuntimeObservationProducer {
 					params: { path: { environment_id: environmentId } },
 					body: event,
 				});
-				if (isSafelyTerminalRuntimeObservationFailure(response)) return "terminal-stale";
+				if (isPermanentRuntimeObservationRejection(response)) return "terminal-rejected";
 				unwrap(response);
 				return "accepted";
 			};
@@ -111,11 +112,11 @@ export class HostedRuntimeObservationProducer {
 			if (this.currentAttestedIdentityKey() !== context.identityKey) {
 				return { outcome: "sent" };
 			}
-			if (result === "terminal-stale") {
-				if (!this.session.retireTerminallyStale(buffered.event.eventId)) {
-					throw new Error("terminally stale runtime observation did not match buffered event");
+			if (result === "terminal-rejected") {
+				if (!this.session.retireRejected(buffered.event.eventId)) {
+					throw new Error("rejected runtime observation did not match buffered event");
 				}
-				log.warn("daemon.runtime_observation_retired_stale", {
+				log.warn("daemon.runtime_observation_retired_rejected", {
 					event_id: buffered.event.eventId,
 					captured_at: buffered.event.capturedAt,
 				});
@@ -135,7 +136,18 @@ export class HostedRuntimeObservationProducer {
 	}
 
 	currentAttestedIdentityKey(): string | null {
-		return this.readAttestedContext()?.identityKey ?? null;
+		try {
+			const identityKey = this.readAttestedContext()?.identityKey ?? null;
+			this.lastAttestationError = null;
+			return identityKey;
+		} catch (error) {
+			const message = toErrorMessage(error);
+			if (message !== this.lastAttestationError) {
+				log.warn("daemon.runtime_observation_attestation_invalid", { error: message });
+				this.lastAttestationError = message;
+			}
+			return null;
+		}
 	}
 
 	private readAttestedContext(): AttestedRuntimeObservationContext | null {
@@ -174,6 +186,8 @@ export async function runRuntimeObservationProducer(
 	while (!options.abort.aborted) {
 		try {
 			const identityKey = producer.currentAttestedIdentityKey();
+			pruneRetiredIdentityEntries(activeAttempts, identityKey);
+			pruneRetiredIdentityEntries(schedules, identityKey);
 			if (identityKey && !activeAttempts.has(identityKey)) {
 				const schedule = schedules.get(identityKey) ?? {
 					nextAttemptAt: 0,
@@ -199,7 +213,9 @@ export async function runRuntimeObservationProducer(
 						}
 						schedule.nextAttemptAt =
 							completedAt + (result.outcome === "idle" ? IDLE_RETRY_INTERVAL_MS : interval);
-						activeAttempts.delete(identityKey);
+						if (activeAttempts.get(identityKey) === attempt) {
+							activeAttempts.delete(identityKey);
+						}
 					});
 					activeAttempts.set(identityKey, attempt);
 				}
@@ -239,6 +255,20 @@ export function isSafelyTerminalRuntimeObservationFailure(result: {
 	if (result.response.status !== 422 || !isUnknownRecord(result.error)) return false;
 	const detail = result.error.detail;
 	return isUnknownRecord(detail) && detail.code === "runtime_observation_captured_at_too_old";
+}
+
+export function isPermanentRuntimeObservationRejection(result: {
+	response: { status: number };
+}): boolean {
+	return (
+		result.response.status >= 400 && result.response.status < 500 && result.response.status !== 429
+	);
+}
+
+function pruneRetiredIdentityEntries<T>(entries: Map<string, T>, identityKey: string | null): void {
+	for (const key of entries.keys()) {
+		if (key !== identityKey) entries.delete(key);
+	}
 }
 
 function abortableDelay(ms: number, abort: AbortSignal): Promise<void> {

--- a/packages/cli/src/runtime/observed-v2.test.ts
+++ b/packages/cli/src/runtime/observed-v2.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir, userInfo } from "node:os";
 import { dirname, join } from "node:path";
 import { getCliVersion } from "../lib/version";
 import { writeRuntimeAppliedState } from "./applied-state";
@@ -163,5 +163,35 @@ describe("hosted runtime observed v2", () => {
 		const observed = readHostedRuntimeObserved(paths);
 		expect(observed?.status).toBe("error");
 		expect(observed?.convergeError).toBe("runtime apply failed");
+	});
+
+	test("reports complete systemd counts with representative scoped truncation", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-observed-v2-truncation-"));
+		roots.push(root);
+		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+		process.env.CLAWDI_RUN_DIR = join(root, "run");
+		process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
+		process.env.CLAWDI_RUNTIME_USER = userInfo().username;
+		const paths = getRuntimePaths({ mode: "hosted" });
+		mkdirSync(paths.serviceStateRoot, { recursive: true });
+		mkdirSync(paths.systemdSystemRoot, { recursive: true });
+		mkdirSync(paths.systemdUserRoot, { recursive: true });
+		const systemctl = join(root, "systemctl");
+		writeFileSync(systemctl, "#!/bin/sh\nprintf 'ActiveState=active\\nSubState=running\\n'\n");
+		chmodSync(systemctl, 0o700);
+		process.env.CLAWDI_SYSTEMCTL_PATH = systemctl;
+		for (let index = 0; index < 31; index += 1) {
+			const suffix = index.toString().padStart(2, "0");
+			writeFileSync(join(paths.systemdSystemRoot, `clawdi-system-${suffix}.service`), "");
+			writeFileSync(join(paths.systemdUserRoot, `clawdi-user-${suffix}.service`), "");
+		}
+
+		const observed = readHostedRuntimeObserved(paths);
+
+		expect(observed?.truncated).toBe(true);
+		expect(observed?.systemd?.unitCount).toBe(62);
+		expect(observed?.systemd?.units).toHaveLength(30);
+		expect(observed?.systemd?.units.filter((unit) => unit.scope === "system")).toHaveLength(15);
+		expect(observed?.systemd?.units.filter((unit) => unit.scope === "user")).toHaveLength(15);
 	});
 });

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -28,6 +28,7 @@ type HostedRuntimeObservedSystemdUnit = components["schemas"]["HostedRuntimeObse
 
 const SYSTEMD_STATUS_TIMEOUT_MS = 1_000;
 const SYSTEMD_FAILURE_EVIDENCE_MAX_LENGTH = 500;
+const SYSTEMD_OBSERVED_UNIT_LIMIT = 30;
 const SENSITIVE_FAILURE_EVIDENCE =
 	/(?:^|[^a-z0-9])(?:api[_-]?key|key|token|secret|password|passwd|credential|authorization|bearer)(?:[^a-z0-9]|$)|(?:^|\s)[A-Z][A-Z0-9_]{1,}=|(?:^|[^a-z0-9])(?:sk-|gh[pousr]_|clawdi_)[a-z0-9_-]+/i;
 
@@ -67,7 +68,10 @@ export function readHostedRuntimeObserved(
 		boot: boot.status ? summarizeBootStatus(boot.status) : null,
 		cli: summarizeCliBootstrap(cliBootstrap),
 	};
-	if (systemd) observed.systemd = systemd;
+	if (systemd) {
+		observed.systemd = systemd;
+		if (systemd.unitCount > systemd.units.length) observed.truncated = true;
+	}
 	if (providers) observed.providers = providers;
 	if (appliedState && options.includeAgentPlugins) {
 		const agentPlugins = readHostedAgentPluginsObservation({
@@ -248,13 +252,24 @@ function readSystemdObserved(paths: RuntimePaths): HostedRuntimeObservedSystemd 
 	const userUnits = managedSystemdUnitNames(paths.systemdUserRoot).map((unit) =>
 		systemdUnitStatus("user", unit, paths),
 	);
-	const units = [...systemUnits, ...userUnits].slice(0, 30);
-	if (units.length === 0) return null;
+	const allUnits = [...systemUnits, ...userUnits];
+	if (allUnits.length === 0) return null;
+	const units = representativeSystemdUnits(systemUnits, userUnits);
 	return {
-		status: systemdUnitsStatus(units),
-		unitCount: units.length,
+		status: systemdUnitsStatus(allUnits),
+		unitCount: allUnits.length,
 		units,
 	};
+}
+
+function representativeSystemdUnits(
+	systemUnits: HostedRuntimeObservedSystemdUnit[],
+	userUnits: HostedRuntimeObservedSystemdUnit[],
+): HostedRuntimeObservedSystemdUnit[] {
+	const reservedForUser = Math.min(userUnits.length, SYSTEMD_OBSERVED_UNIT_LIMIT / 2);
+	const systemLimit = Math.min(systemUnits.length, SYSTEMD_OBSERVED_UNIT_LIMIT - reservedForUser);
+	const userLimit = Math.min(userUnits.length, SYSTEMD_OBSERVED_UNIT_LIMIT - systemLimit);
+	return [...systemUnits.slice(0, systemLimit), ...userUnits.slice(0, userLimit)];
 }
 
 function managedSystemdUnitNames(root: string): string[] {

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -6917,7 +6917,7 @@ export interface components {
             /** Convergeerror */
             convergeError?: string | null;
             /** Truncated */
-            truncated?: false | null;
+            truncated?: boolean | null;
             /** Generation */
             generation?: number | null;
             /** Manifestetag */


### PR DESCRIPTION
## Summary

### Permanent observation rejection recovery

**Symptom:** A durable heartbeat event rejected with 401, 403, 404, conflict, or a non-stale 422 remained pending forever. The producer retried the same payload every minute and stopped capturing current observations.

**Fix:** Treat every non-429 4xx response as a permanent rejection of that event, retire only the matching pending event, and keep the observation channel active. Network errors, 429 responses, and 5xx responses remain retryable.

**Test:** Added response classification coverage and an end-to-end producer regression proving that a rejected event is retired and followed by a newly captured event.

### Corrupt durable heartbeat recovery

**Symptom:** Invalid JSON, an unknown schema, a mismatched environment binding, or a corrupt pending payload caused session construction to fail on every producer tick.

**Fix:** Validate the complete durable state, atomically rename invalid state to a unique `.corrupt-*` quarantine file, emit a structured warning, and initialize fresh state. Read or quarantine I/O failures still fail closed so evidence is never overwritten.

**Test:** Added invalid JSON and unknown-schema regressions that verify the original bytes remain quarantined and a fresh sequence-one boot session is created.

### Accurate scoped systemd observations

**Symptom:** `unitCount` reported only the sliced count and system-first ordering could remove every user unit without a truncation signal.

**Fix:** Report the complete count and status, cap the wire list at 30, reserve representative capacity for both system and user scopes, and set top-level `truncated=true` when units are omitted. Backend validation now accepts the additive truncation signal, keeps the 30-unit wire bound, and rejects inconsistent summaries.

**Test:** Added a 62-unit CLI regression that verifies the true count, 30-item bound, truncation marker, and 15/15 scope representation, plus backend schema coverage.

### Identity scheduler lifecycle

**Symptom:** Per-identity schedules and in-flight Promise references accumulated across rollouts, while malformed `CLAWDI_ENVIRONMENT_ID` values emitted the same warning every second.

**Fix:** Prune retired identity entries on each loop, guard Promise cleanup against same-key replacement races, and deduplicate attestation warnings until the error changes or recovers.

**Test:** Added an identity churn regression covering both stale schedules and unresolved attempts across identity exit and re-entry.

## Deployment order

1. Deploy the backend schema relaxation first. Existing CLI payloads remain valid.
2. Roll out the updated CLI after the backend accepts `truncated=true` and `unitCount > 30`.

Deploying the CLI first can cause truncated observations to receive 422 responses from an older backend; the new producer will safely retire those individual events, but scoped truncation data will not be ingested until the backend is upgraded.

## Verification

- `bun run --cwd packages/cli typecheck`
- `bun test` for observation producer, heartbeat observation, and observed v2: 39 passed
- Filtered legacy runtime observed tests: 6 passed
- Biome check for all changed CLI files
- Focused backend schema pytest: 2 passed
- Ruff check and format check
- `uv run python scripts/check_generated_api.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)