### PR TITLE
fix(cli): quarantine corrupt upgrade state

### DIFF
--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -1,5 +1,5 @@
 import { type SpawnSyncReturns, spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
 	accessSync,
 	constants,
@@ -18,6 +18,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { z } from "zod";
+import { log, toErrorMessage } from "../serve/log";
 import { HOSTED_RUNTIME_HOME, HOSTED_RUNTIME_USER } from "./hosted-runtime-contract";
 import {
 	HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE,
@@ -1028,9 +1029,14 @@ function reconcileCliUpgradeTransaction(
 	paths: RuntimePaths,
 	opts: RuntimeCliReconciliationOptions = {},
 ): RuntimeCliReconciliationResult {
+	const hadUpgradeState = existsSync(paths.cliUpgradeState);
 	const state = readCliUpgradeState(paths);
 	const transaction = state.transaction ?? null;
-	if (!transaction) return { status: "unchanged", selfReexec: false };
+	if (!transaction) {
+		return hadUpgradeState && !existsSync(paths.cliUpgradeState)
+			? cliReconciliationResult(paths, "unchanged", opts.runningVersion)
+			: { status: "unchanged", selfReexec: false };
+	}
 	if (transaction.rollback) {
 		finishCliRollback(paths, transaction);
 		return cliReconciliationResult(paths, "rolled_back", opts.runningVersion);
@@ -1162,30 +1168,8 @@ function cliInstallIdentitiesMatch(
 
 function verifiedActiveBootstrapIdentity(paths: RuntimePaths): RuntimeCliInstallIdentity | null {
 	const status = readBootstrapStatus(paths.cliBootstrapStatus);
-	const activeTarget = activeLinkTarget(paths.cliManagedBin);
-	if (
-		status?.schemaVersion !== "clawdi.cliNpmBootstrapStatus.v1" ||
-		status.status !== "installed" ||
-		status.source !== "npm" ||
-		status.error !== null ||
-		status.activePath !== paths.cliManagedBin ||
-		status.activeTarget !== activeTarget ||
-		status.npmCache !== paths.cliNpmCache ||
-		typeof status.packageSpec !== "string" ||
-		(status.registry !== null && typeof status.registry !== "string") ||
-		typeof status.npmPrefix !== "string" ||
-		typeof status.activeTarget !== "string" ||
-		typeof status.version !== "string"
-	) {
-		return null;
-	}
-	const identity: RuntimeCliInstallIdentity = {
-		packageSpec: status.packageSpec,
-		registry: status.registry,
-		npmPrefix: status.npmPrefix,
-		activeTarget: status.activeTarget,
-		version: status.version,
-	};
+	const identity = cliBootstrapIdentity(paths, status);
+	if (!identity || activeLinkTarget(paths.cliManagedBin) !== identity.activeTarget) return null;
 	if (!verifyStoredCliIdentity(paths, identity)) return null;
 	const currentStatus = readBootstrapStatus(paths.cliBootstrapStatus);
 	return activeLinkTarget(paths.cliManagedBin) === identity.activeTarget &&
@@ -1195,6 +1179,34 @@ function verifiedActiveBootstrapIdentity(paths: RuntimePaths): RuntimeCliInstall
 		currentStatus.npmCache === paths.cliNpmCache
 		? identity
 		: null;
+}
+
+function cliBootstrapIdentity(
+	paths: RuntimePaths,
+	status: RuntimeCliBootstrapStatus | null,
+): RuntimeCliInstallIdentity | null {
+	if (
+		status?.schemaVersion !== "clawdi.cliNpmBootstrapStatus.v1" ||
+		status.status !== "installed" ||
+		status.source !== "npm" ||
+		status.error !== null ||
+		status.activePath !== paths.cliManagedBin ||
+		status.npmCache !== paths.cliNpmCache ||
+		typeof status.packageSpec !== "string" ||
+		(status.registry !== null && typeof status.registry !== "string") ||
+		typeof status.npmPrefix !== "string" ||
+		typeof status.activeTarget !== "string" ||
+		typeof status.version !== "string"
+	) {
+		return null;
+	}
+	return {
+		packageSpec: status.packageSpec,
+		registry: status.registry,
+		npmPrefix: status.npmPrefix,
+		activeTarget: status.activeTarget,
+		version: status.version,
+	};
 }
 
 function cliReconciliationResult(
@@ -1374,22 +1386,82 @@ function readCliUpgradeState(paths: RuntimePaths): RuntimeCliUpgradeState {
 	try {
 		parsed = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8")) as unknown;
 	} catch (error) {
-		throw new Error(
-			`invalid clawdi CLI upgrade transaction JSON: ${error instanceof Error ? error.message : String(error)}`,
-		);
+		return quarantineInvalidCliUpgradeState(paths, `invalid JSON: ${toErrorMessage(error)}`);
 	}
-	const schemaVersion =
-		typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
-			? (parsed as Record<string, unknown>).schemaVersion
-			: undefined;
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		return quarantineInvalidCliUpgradeState(paths, "state must be a JSON object");
+	}
+	const schemaVersion = (parsed as Record<string, unknown>).schemaVersion;
 	if (schemaVersion === "clawdi.cliUpgradeState.v2") {
 		const result = cliUpgradeStateV2Schema.safeParse(parsed);
 		if (!result.success) {
-			throw new Error(`invalid clawdi CLI upgrade transaction: ${result.error.issues[0]?.message}`);
+			return quarantineInvalidCliUpgradeState(
+				paths,
+				`invalid v2 state: ${result.error.issues[0]?.message ?? "schema validation failed"}`,
+			);
 		}
 		return result.data;
 	}
+	if (typeof schemaVersion !== "string") {
+		return quarantineInvalidCliUpgradeState(paths, "schemaVersion must be a string");
+	}
 	throw new Error(`unsupported clawdi CLI upgrade transaction schema: ${String(schemaVersion)}`);
+}
+
+function quarantineInvalidCliUpgradeState(
+	paths: RuntimePaths,
+	reason: string,
+): RuntimeCliUpgradeState {
+	try {
+		repairCliInstallAfterInvalidUpgradeState(paths);
+	} catch (error) {
+		throw new Error(
+			`invalid clawdi CLI upgrade state: ${reason}; disk recovery failed: ${toErrorMessage(error)}`,
+		);
+	}
+	const quarantinePath = `${paths.cliUpgradeState}.corrupt-${Date.now()}-${randomUUID()}`;
+	try {
+		renameSync(paths.cliUpgradeState, quarantinePath);
+	} catch (error) {
+		throw new Error(
+			`invalid clawdi CLI upgrade state: ${reason}; quarantine failed: ${toErrorMessage(error)}`,
+		);
+	}
+	log.warn("runtime.cli_upgrade_state_quarantined", {
+		path: paths.cliUpgradeState,
+		quarantine_path: quarantinePath,
+		error: reason,
+	});
+	return emptyCliUpgradeState();
+}
+
+function repairCliInstallAfterInvalidUpgradeState(paths: RuntimePaths): void {
+	const status = readBootstrapStatus(paths.cliBootstrapStatus);
+	const activeIdentity = verifiedActiveCliIdentity(paths, status);
+	if (activeIdentity) {
+		const verification = verifyStoredCliIdentity(paths, activeIdentity);
+		if (!verification) {
+			throw new Error("invalid clawdi CLI upgrade state has an unverifiable active CLI target");
+		}
+		writeCliBootstrapStatus(paths, activeIdentity, verification);
+		return;
+	}
+
+	const bootstrapIdentity = cliBootstrapIdentity(paths, status);
+	if (bootstrapIdentity) {
+		const verification = verifyStoredCliIdentity(paths, bootstrapIdentity);
+		if (verification) {
+			swapActiveCli(paths.cliManagedBin, bootstrapIdentity.activeTarget);
+			writeCliBootstrapStatus(paths, bootstrapIdentity, verification);
+			return;
+		}
+	}
+
+	if (activeLinkTarget(paths.cliManagedBin) === null && !existsSync(paths.cliBootstrapStatus))
+		return;
+	throw new Error(
+		"invalid clawdi CLI upgrade state cannot be quarantined because the active CLI installation is not recoverable",
+	);
 }
 
 function writeCliUpgradeState(paths: RuntimePaths, state: RuntimeCliUpgradeState): void {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -769,6 +769,12 @@ function writeCliTransactionFixture(
 	);
 }
 
+function cliUpgradeQuarantineFiles(paths: RuntimePaths): string[] {
+	return readdirSync(dirname(paths.cliUpgradeState))
+		.filter((name) => name.startsWith("cli-upgrade-state.json.corrupt-"))
+		.map((name) => join(dirname(paths.cliUpgradeState), name));
+}
+
 function seedCliRecoveryFixture(state: string, run: string) {
 	process.env.CLAWDI_RUNTIME_MODE = "hosted";
 	process.env.CLAWDI_SERVICE_STATE_DIR = state;
@@ -11973,27 +11979,129 @@ exit 64
 		}
 	});
 
-	it("fails closed on a corrupt CLI transaction journal before install or prune", () => {
+	it("quarantines corrupt CLI state and continues with the requested upgrade", () => {
 		const state = join(root, "state-cli-corrupt-journal");
 		const run = join(root, "run-cli-corrupt-journal");
+		const bin = join(root, "bin-cli-corrupt-journal");
+		const previousPath = process.env.PATH;
+		mkdirSync(bin, { recursive: true });
+		writeFileSync(
+			join(bin, "npm"),
+			`#!/usr/bin/env bash
+set -euo pipefail
+prefix=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--prefix" ]; then
+    prefix="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+test -n "$prefix"
+install -d "$prefix/bin"
+cat > "$prefix/bin/clawdi" <<'SH'
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then echo '1.2.4'; exit 0; fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
+exit 64
+SH
+chmod +x "$prefix/bin/clawdi"
+`,
+		);
+		chmodSync(join(bin, "npm"), 0o700);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		seedCurrentCliInstall(state, "clawdi@1.2.3", "1.2.3");
 		const paths = getRuntimePaths();
-		const activeTarget = readlinkSync(paths.cliManagedBin);
-		const lastGood = join(paths.cliNpmPrefix, "packages", "1.2.2", "bin", "clawdi");
-		mkdirSync(dirname(lastGood), { recursive: true });
-		writeFileSync(lastGood, "#!/usr/bin/env bash\nexit 0\n");
-		chmodSync(lastGood, 0o700);
 		writeFileSync(paths.cliUpgradeState, "{broken journal");
 
-		expect(() => applyRuntimeCliDesiredState(cliManifest("1.2.4"), paths)).toThrow(
-			/invalid clawdi CLI upgrade transaction JSON/,
+		try {
+			const result = applyRuntimeCliDesiredState(cliManifest("1.2.4"), paths);
+			const quarantined = cliUpgradeQuarantineFiles(paths);
+
+			expect(result.status).toBe("installed");
+			expect(result.version).toBe("1.2.4");
+			expect(result.selfReexec).toBe(true);
+			expect(quarantined).toHaveLength(1);
+			expect(readFileSync(quarantined[0], "utf-8")).toBe("{broken journal");
+			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
+				transaction: { phase: "activated", newIdentity: { version: "1.2.4" } },
+			});
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
+	it("repairs an interrupted activation before discarding corrupt CLI state", () => {
+		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(
+			join(root, "state-cli-corrupt-half-activation"),
+			join(root, "run-cli-corrupt-half-activation"),
 		);
-		expect(readlinkSync(paths.cliManagedBin)).toBe(activeTarget);
-		expect(existsSync(lastGood)).toBe(true);
-		expect(readFileSync(paths.cliUpgradeState, "utf-8")).toBe("{broken journal");
+		pointManagedCliAt(paths, newIdentity);
+		writeFileSync(paths.cliUpgradeState, "{broken journal");
+
+		const recovered = reconcilePendingRuntimeCliUpgrade(paths, previousIdentity.version);
+		const bootstrap = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+
+		expect(recovered).toEqual({ status: "unchanged", selfReexec: true });
+		expect(readlinkSync(paths.cliManagedBin)).toBe(newIdentity.activeTarget);
+		expect(bootstrap).toMatchObject({
+			activeTarget: newIdentity.activeTarget,
+			version: newIdentity.version,
+		});
+		expect(cliUpgradeQuarantineFiles(paths)).toHaveLength(1);
+		expect(
+			applyRuntimeCliDesiredState(cliManifest(newIdentity.version), paths, {
+				runningVersion: newIdentity.version,
+			}).status,
+		).toBe("current");
+	});
+
+	it("quarantines structurally invalid state for the current CLI upgrade schema", () => {
+		const state = join(root, "state-cli-invalid-current-schema");
+		const run = join(root, "run-cli-invalid-current-schema");
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, "clawdi@1.2.3", "1.2.3");
+		const paths = getRuntimePaths();
+		writeFileSync(
+			paths.cliUpgradeState,
+			`${JSON.stringify({ schemaVersion: "clawdi.cliUpgradeState.v2", transaction: null })}\n`,
+		);
+
+		expect(applyRuntimeCliDesiredState(cliManifest("1.2.3"), paths).status).toBe("current");
+		expect(cliUpgradeQuarantineFiles(paths)).toHaveLength(1);
+		expect(existsSync(paths.cliUpgradeState)).toBe(false);
+	});
+
+	it("preserves and rejects CLI upgrade state from a future schema", () => {
+		const state = join(root, "state-cli-future-schema");
+		const run = join(root, "run-cli-future-schema");
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, "clawdi@1.2.3", "1.2.3");
+		const paths = getRuntimePaths();
+		const futureState = `${JSON.stringify({
+			schemaVersion: "clawdi.cliUpgradeState.v3",
+			transaction: null,
+			badVersions: [],
+		})}\n`;
+		writeFileSync(paths.cliUpgradeState, futureState);
+
+		expect(() => applyRuntimeCliDesiredState(cliManifest("1.2.3"), paths)).toThrow(
+			"unsupported clawdi CLI upgrade transaction schema: clawdi.cliUpgradeState.v3",
+		);
+		expect(readFileSync(paths.cliUpgradeState, "utf-8")).toBe(futureState);
+		expect(cliUpgradeQuarantineFiles(paths)).toHaveLength(0);
 	});
 
 	it("recovers an exact CLI install when matching bootstrap status has no version", () => {


### PR DESCRIPTION
## Symptom

Malformed or structurally invalid `cli-upgrade-state.json` made every CLI reconcile throw before recovery or installation. Runtime watch then failed at `stage=cli-update` every tick without entering failure backoff, while runtime init exited immediately. Both paths stayed blocked until an operator deleted the journal.

## Safety analysis

The journal carries prepared or activated transaction identities and rolled-back version cooldowns, so corrupted bytes cannot be treated as trustworthy recovery data. Before discarding them, the CLI now reconciles independently verifiable disk state:

- A valid active managed CLI is smoke-tested and runtime-verified, then bootstrap status is repaired to that identity.
- If the active target is invalid but the recorded bootstrap identity still verifies, the active symlink is restored to that target.
- If neither identity is recoverable, the original invalid journal remains in place and reconciliation fails closed with explicit recovery context.

The code deliberately does not reconstruct transaction direction from an active/status mismatch. That mismatch can represent either interrupted activation or interrupted rollback, so inventing previous/new identities could reverse a rollback. Corruption can therefore lose rollback history and `badVersions`, but only after disk state is independently verified or repaired. A repaired active version also preserves the re-exec fence before runtime convergence continues.

Unsupported string schema versions remain untouched and fail closed. This protects a newer journal when an older CLI runs after a downgrade; only malformed JSON, non-object values, missing/non-string schema versions, and structurally invalid current-schema state are quarantined.

## Fix

- Rename recoverable invalid state to a unique `.corrupt-<timestamp>-<uuid>` file and emit a structured warning with the original and quarantine paths.
- Continue from empty transaction state after quarantine so the current tick can converge and later upgrades can create a fresh journal.
- Reuse verified bootstrap identity parsing for active-state repair.
- Align quarantine naming and failure handling with the durable heartbeat state precedent in #1128.

## Tests

- Corrupt JSON is preserved in quarantine and the requested upgrade completes with a fresh activated journal.
- An interrupted activation with a corrupt journal repairs bootstrap state, requests re-exec, and converges as current under the repaired version.
- Structurally invalid v2 state is quarantined.
- Future v3 state is preserved and rejected without quarantine.
- `bun run --cwd packages/cli typecheck`
- `bunx biome check packages/cli/src/runtime/cli-update.ts packages/cli/tests/runtime.test.ts`
- `bun run --cwd packages/cli test tests/runtime.test.ts` (`181 pass`, Docker clean runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
