### PR TITLE
fix(cli): tighten Hermes hosted runtime hygiene

### DIFF
--- a/packages/cli/docs/managed-baileys-compat-upgrade.md
+++ b/packages/cli/docs/managed-baileys-compat-upgrade.md
@@ -1,0 +1,68 @@
+# Managed Baileys Compatibility Upgrade
+
+Use this runbook when an OpenClaw or Hermes upgrade changes the bundled Baileys
+artifact audited by
+[`managed-baileys-compat.ts`](../src/runtime/managed-baileys-compat.ts).
+
+## Patch Contract
+
+The compatibility layer has three ordered safeguards:
+
+1. `auditPristineSha256` identifies each accepted, unmodified upstream file.
+2. Exact `before` and `after` hunks classify and patch only known source layouts.
+3. A durable ownership receipt records the hunks Clawdi applied so rollback removes
+   only Clawdi-owned changes.
+
+The audited targets are:
+
+| Target | Current pristine SHA-256 |
+| --- | --- |
+| `lib/Socket/socket.js` | `ab9b68888e123ad683dbc26555fc928400c1526c93ec6b66853f2ba30f8177a9` |
+| `lib/Utils/noise-handler.js` | `970f9526ce0e5a6bebf937328b3d835966a9282c0d232f31b5c0bb283531afe8` |
+| `lib/Utils/noise-handler.d.ts` | `a556ca0b67c3448769ad5ed0d59acbf566a21115fa107cd582b1dcb28c4fd516` |
+
+The current patch revision is `clawdi.managedBaileysCompat.v3`; the current
+receipt schema is `clawdi.managedBaileysPatchReceipt.v4`.
+
+## Retarget The Patch
+
+1. Update the OpenClaw and Hermes fixture pins, integrity values, and downloaded
+   artifacts for the intended runtime versions.
+2. Extract or install each new artifact without running Clawdi reconciliation.
+   Copy the three pristine target files to a separate scratch directory.
+3. Compute each audit hash from those pristine files:
+
+   ```bash
+   sha256sum lib/Socket/socket.js lib/Utils/noise-handler.js lib/Utils/noise-handler.d.ts
+   ```
+
+4. Update each `auditPristineSha256` and retarget its exact `before`/`after`
+   hunks. Keep a hunk ID when its semantic transformation is unchanged; increment
+   the hunk ID and patch revision when owned behavior changes. Increment the
+   receipt schema only when the serialized receipt layout changes.
+5. Confirm every `before` and `after` string occurs exactly once in its target and
+   that a target cannot classify as both states.
+
+Do not derive audit hashes from a previously patched installation. The qualified
+rc14 fixture in `managed-baileys-compat.test.ts` currently has socket hash
+`ff8b19ff02491fa080ee371f066d49c94acb903207dd0d9fdb5548e5a594fb4a`; it is a
+fixture assertion, not a replacement for hashing the new pristine runtime
+artifact.
+
+## Verify
+
+Run the focused compatibility suite from the repository root:
+
+```bash
+bun test packages/cli/src/runtime/managed-baileys-compat.test.ts
+bun run --cwd packages/cli typecheck
+bunx biome check packages/cli/src/runtime/managed-baileys-compat.ts packages/cli/src/runtime/managed-baileys-compat.test.ts packages/cli/docs/managed-baileys-compat-upgrade.md
+```
+
+The suite must cover pristine apply, repeated reconciliation, owned rollback,
+artifact version replacement, recognized mixed state, and unknown-state refusal.
+Run the managed WhatsApp native fixture E2E separately when qualifying a real
+runtime upgrade.
+
+Done: all focused commands exit 0, and the compatibility suite passes without
+weakening mixed-state or unknown-state refusal.

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -337,11 +337,15 @@ export class HermesAdapter implements AgentAdapter {
 		ownerHandle: string,
 		tarGzBytes: Buffer,
 	): Promise<void> {
+		const root = this.getSkillsRootDir();
+		const sharedRoot = join(root, "shared");
 		await replaceSkillArchiveTarGz(
 			key,
-			this.getSkillsRootDir(),
+			root,
 			this.getSharedSkillPath(key, ownerHandle),
 			tarGzBytes,
+			undefined,
+			(mutation) => mutateUserSkillTarget(sharedRoot, "shared", mutation),
 		);
 	}
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -762,20 +762,12 @@ runtimeCmd
 	.requiredOption("--ready-file <path>")
 	.requiredOption("--result-file <path>")
 	.requiredOption("--nonce <nonce>")
-	.requiredOption("--success-token <token>")
-	.action(
-		async (opts: {
-			readyFile: string;
-			resultFile: string;
-			nonce: string;
-			successToken: string;
-		}) => {
-			const { runHermesAgentPluginCanaryController } = await import(
-				"./runtime/hermes-agent-plugin-canary-controller.js"
-			);
-			await runHermesAgentPluginCanaryController(opts);
-		},
-	);
+	.action(async (opts: { readyFile: string; resultFile: string; nonce: string }) => {
+		const { runHermesAgentPluginCanaryController } = await import(
+			"./runtime/hermes-agent-plugin-canary-controller.js"
+		);
+		await runHermesAgentPluginCanaryController(opts);
+	});
 
 runtimeCmd
 	.command("status", { hidden: true })

--- a/packages/cli/src/runtime/hermes-agent-plugin-canary-client.ts
+++ b/packages/cli/src/runtime/hermes-agent-plugin-canary-client.ts
@@ -19,14 +19,8 @@ const HERMES_CANARY_PROVIDER = "clawdi-agent-plugin-canary";
 const hermesCanaryReadySchema = z.object({ port: z.number().int().min(1).max(65_535) }).strict();
 const hermesCanaryEvidenceSchema = z
 	.object({
-		mcpHeader: z.literal(true),
-		mcpInitialize: z.literal(true),
-		mcpInitialized: z.literal(true),
 		mcpToolsList: z.literal(true),
 		mcpToolCall: z.literal(true),
-		inferenceSawTool: z.literal(true),
-		inferenceSawToolResult: z.literal(true),
-		completed: z.literal(true),
 		error: z.never().optional(),
 	})
 	.passthrough();
@@ -146,7 +140,6 @@ function stopCanaryController(child: ChildProcess): void {
 export function runHermesAgentPluginCanary(input: HermesAgentPluginCanaryInput): void {
 	const nonce = randomBytes(16).toString("hex");
 	const name = `clawdi-capability-${nonce.slice(0, 16)}`;
-	const successToken = `CLAWDI_AGENT_PLUGIN_CANARY_OK_${nonce}`;
 	const readyFile = join(input.home, "canary-ready.json");
 	const resultFile = join(input.home, "canary-result.json");
 	const invocation = resolveCurrentCliInvocation([
@@ -158,8 +151,6 @@ export function runHermesAgentPluginCanary(input: HermesAgentPluginCanaryInput):
 		resultFile,
 		"--nonce",
 		nonce,
-		"--success-token",
-		successToken,
 	]);
 	const controller = spawn(invocation.command, invocation.args, {
 		cwd: input.home,
@@ -212,10 +203,10 @@ export function runHermesAgentPluginCanary(input: HermesAgentPluginCanaryInput):
 			),
 		);
 		input.withEnabledCanary(canary, () => {
-			const result = input.runOneShot({
+			input.runOneShot({
 				args: [
 					"-z",
-					"Call the Clawdi capability canary tool exactly once, then return its success result.",
+					"Run the Clawdi Agent Plugin capability probe.",
 					"--model",
 					"clawdi-agent-plugin-canary",
 					"--provider",
@@ -236,7 +227,6 @@ export function runHermesAgentPluginCanary(input: HermesAgentPluginCanaryInput):
 				},
 				timeoutMs: HERMES_REMOTE_PROBE_TIMEOUT_MS,
 			});
-			if (result.status !== 0 || result.stdout.trim() !== successToken) throw new Error();
 			waitForJsonFile(resultFile, hermesCanaryEvidenceSchema, 1_000);
 		});
 	} finally {

--- a/packages/cli/src/runtime/hermes-agent-plugin-canary-controller.test.ts
+++ b/packages/cli/src/runtime/hermes-agent-plugin-canary-controller.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+async function waitForReady(path: string): Promise<{ port: number }> {
+	const deadline = Date.now() + 5_000;
+	while (Date.now() < deadline) {
+		if (existsSync(path)) return JSON.parse(readFileSync(path, "utf8")) as { port: number };
+		await Bun.sleep(20);
+	}
+	throw new Error("canary controller did not become ready");
+}
+
+test("records MCP list and call evidence without inference assertions", async () => {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-hermes-canary-controller-"));
+	const readyFile = join(root, "ready.json");
+	const resultFile = join(root, "result.json");
+	const nonce = "a".repeat(32);
+	const child = Bun.spawn(
+		[
+			"bun",
+			join(import.meta.dir, "..", "index.ts"),
+			"runtime",
+			"agent-plugin-canary",
+			"--ready-file",
+			readyFile,
+			"--result-file",
+			resultFile,
+			"--nonce",
+			nonce,
+		],
+		{
+			cwd: root,
+			env: { ...process.env, CLAWDI_NO_UPDATE_CHECK: "1", CLAWDI_NO_AUTO_UPDATE: "1" },
+			stdout: "ignore",
+			stderr: "pipe",
+		},
+	);
+	let client: Client | null = null;
+	try {
+		const { port } = await waitForReady(readyFile);
+		const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), {
+			requestInit: { headers: { "X-Clawdi-Agent-Plugin-Canary": `clawdi-${nonce}` } },
+		});
+		client = new Client({ name: "clawdi-canary-test", version: "1.0.0" });
+		await client.connect(transport);
+		const tools = await client.listTools();
+		expect(tools.tools.map((tool) => tool.name)).toEqual(["clawdi_agent_plugin_canary"]);
+		const call = await client.callTool({ name: "clawdi_agent_plugin_canary", arguments: {} });
+		expect(JSON.stringify(call)).toContain(nonce);
+		expect(JSON.parse(readFileSync(resultFile, "utf8"))).toEqual({
+			mcpToolsList: true,
+			mcpToolCall: true,
+		});
+	} finally {
+		await client?.close();
+		child.kill("SIGTERM");
+		await child.exited;
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/packages/cli/src/runtime/hermes-agent-plugin-canary-controller.ts
+++ b/packages/cli/src/runtime/hermes-agent-plugin-canary-controller.ts
@@ -13,18 +13,11 @@ export interface HermesAgentPluginCanaryControllerOptions {
 	readyFile: string;
 	resultFile: string;
 	nonce: string;
-	successToken: string;
 }
 
 interface CanaryEvidence {
-	mcpHeader: boolean;
-	mcpInitialize: boolean;
-	mcpInitialized: boolean;
 	mcpToolsList: boolean;
 	mcpToolCall: boolean;
-	inferenceSawTool: boolean;
-	inferenceSawToolResult: boolean;
-	completed: boolean;
 	error?: string;
 }
 
@@ -101,7 +94,12 @@ function writeChatStream(
 	response.end("data: [DONE]\n\n");
 }
 
-function writeChatCompletion(response: ServerResponse, model: string, content: string): void {
+function writeChatCompletion(
+	response: ServerResponse,
+	model: string,
+	message: Record<string, unknown>,
+	finishReason: "stop" | "tool_calls",
+): void {
 	writeJson(response, 200, {
 		id: "chatcmpl-clawdi-agent-plugin-canary",
 		object: "chat.completion",
@@ -110,8 +108,8 @@ function writeChatCompletion(response: ServerResponse, model: string, content: s
 		choices: [
 			{
 				index: 0,
-				message: { role: "assistant", content },
-				finish_reason: "stop",
+				message,
+				finish_reason: finishReason,
 			},
 		],
 		usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
@@ -133,31 +131,18 @@ function requestMethods(body: Record<string, unknown>): string[] {
 	});
 }
 
-function advertisedCanaryTool(body: Record<string, unknown>, description: string): string | null {
-	if (!Array.isArray(body.tools) || body.tools.length !== 1) return null;
-	const tool = body.tools[0];
-	if (typeof tool !== "object" || tool === null || !("function" in tool)) return null;
-	const fn = tool.function;
-	if (typeof fn !== "object" || fn === null) return null;
-	if (!("name" in fn) || typeof fn.name !== "string") return null;
-	if (!("description" in fn) || fn.description !== description) return null;
-	if (!/^mcp__[A-Za-z0-9_]+__clawdi_agent_plugin_canary$/.test(fn.name)) return null;
-	return fn.name;
-}
-
-function hasExpectedToolResult(
-	body: Record<string, unknown>,
-	callId: string,
-	nonce: string,
-): boolean {
-	if (!Array.isArray(body.messages)) return false;
-	return body.messages.some((message) => {
-		if (typeof message !== "object" || message === null) return false;
-		if (!("role" in message) || message.role !== "tool") return false;
-		if (!("tool_call_id" in message) || message.tool_call_id !== callId) return false;
-		if (!("content" in message)) return false;
-		return typeof message.content === "string" && message.content.includes(nonce);
+function advertisedCanaryTool(body: Record<string, unknown>): string | null {
+	if (!Array.isArray(body.tools)) return null;
+	const matches = body.tools.flatMap((tool) => {
+		if (typeof tool !== "object" || tool === null || !("function" in tool)) return [];
+		const fn = tool.function;
+		if (typeof fn !== "object" || fn === null || !("name" in fn)) return [];
+		return typeof fn.name === "string" &&
+			/^mcp__[A-Za-z0-9_]+__clawdi_agent_plugin_canary$/.test(fn.name)
+			? [fn.name]
+			: [];
 	});
+	return matches.length === 1 ? (matches[0] ?? null) : null;
 }
 
 function assertControllerOptions(options: HermesAgentPluginCanaryControllerOptions): void {
@@ -165,9 +150,6 @@ function assertControllerOptions(options: HermesAgentPluginCanaryControllerOptio
 		throw new Error("canary controller paths must be absolute");
 	}
 	if (!/^[a-f0-9]{32}$/.test(options.nonce)) throw new Error("invalid canary nonce");
-	if (!/^CLAWDI_AGENT_PLUGIN_CANARY_OK_[a-f0-9]{32}$/.test(options.successToken)) {
-		throw new Error("invalid canary success token");
-	}
 }
 
 export async function runHermesAgentPluginCanaryController(
@@ -175,14 +157,8 @@ export async function runHermesAgentPluginCanaryController(
 ): Promise<void> {
 	assertControllerOptions(options);
 	const evidence: CanaryEvidence = {
-		mcpHeader: false,
-		mcpInitialize: false,
-		mcpInitialized: false,
 		mcpToolsList: false,
 		mcpToolCall: false,
-		inferenceSawTool: false,
-		inferenceSawToolResult: false,
-		completed: false,
 	};
 	const persistEvidence = () => {
 		writeJsonAtomic(options.resultFile, evidence, options.nonce);
@@ -195,8 +171,6 @@ export async function runHermesAgentPluginCanaryController(
 	const model = "clawdi-agent-plugin-canary";
 	const callId = `call_${options.nonce}`;
 	const toolDescription = `Return the isolated Clawdi Agent Plugin capability nonce ${options.nonce}`;
-	let canaryTool: string | null = null;
-	let inferenceCalls = 0;
 	const server = createServer(async (request, response) => {
 		try {
 			const pathname = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
@@ -210,8 +184,6 @@ export async function runHermesAgentPluginCanaryController(
 					});
 					return;
 				}
-				evidence.mcpHeader = true;
-				persistEvidence();
 				if (request.method === "HEAD") {
 					writeJson(response, 405, { error: "POST required" });
 					return;
@@ -219,8 +191,6 @@ export async function runHermesAgentPluginCanaryController(
 				if (request.method === "POST") {
 					const body = parseJsonObject(await readRequestBody(request));
 					for (const method of requestMethods(body)) {
-						if (method === "initialize") evidence.mcpInitialize = true;
-						if (method === "notifications/initialized") evidence.mcpInitialized = true;
 						if (method === "tools/list") evidence.mcpToolsList = true;
 					}
 					persistEvidence();
@@ -285,72 +255,34 @@ export async function runHermesAgentPluginCanaryController(
 				});
 				return;
 			}
-			if (!Array.isArray(body.tools) || body.tools.length === 0) {
+			const canaryTool = advertisedCanaryTool(body);
+			if (!canaryTool || evidence.mcpToolCall) {
 				if (body.stream === true) writeEmptyChatStream(response, model);
-				else writeChatCompletion(response, model, "");
+				else writeChatCompletion(response, model, { role: "assistant", content: "" }, "stop");
 				return;
 			}
+			const toolCall = {
+				id: callId,
+				type: "function",
+				function: { name: canaryTool, arguments: "{}" },
+			};
 			if (body.stream !== true) {
-				fail("canary inference request did not use the streaming path");
-				writeJson(response, 400, {
-					error: { message: "invalid canary request", type: "invalid_request_error" },
-				});
+				writeChatCompletion(
+					response,
+					model,
+					{ role: "assistant", content: null, tool_calls: [toolCall] },
+					"tool_calls",
+				);
 				return;
 			}
-			inferenceCalls += 1;
-			if (inferenceCalls === 1) {
-				canaryTool = advertisedCanaryTool(body, toolDescription);
-				if (!canaryTool) {
-					fail("portable Agent Plugin canary tool was not advertised to inference");
-					writeJson(response, 400, {
-						error: { message: "canary tool missing", type: "invalid_request_error" },
-					});
-					return;
-				}
-				evidence.inferenceSawTool = true;
-				persistEvidence();
-				writeChatStream(response, [
-					chatChunk({
-						model,
-						delta: {
-							role: "assistant",
-							tool_calls: [
-								{
-									index: 0,
-									id: callId,
-									type: "function",
-									function: { name: canaryTool, arguments: "{}" },
-								},
-							],
-						},
-						finishReason: null,
-					}),
-					chatChunk({ model, delta: {}, finishReason: "tool_calls" }),
-				]);
-				return;
-			}
-			if (
-				inferenceCalls === 2 &&
-				advertisedCanaryTool(body, toolDescription) === canaryTool &&
-				hasExpectedToolResult(body, callId, options.nonce)
-			) {
-				evidence.inferenceSawToolResult = true;
-				evidence.completed = true;
-				persistEvidence();
-				writeChatStream(response, [
-					chatChunk({
-						model,
-						delta: { role: "assistant", content: options.successToken },
-						finishReason: null,
-					}),
-					chatChunk({ model, delta: {}, finishReason: "stop" }),
-				]);
-				return;
-			}
-			fail("inference did not receive the exact canary MCP tool result");
-			writeJson(response, 400, {
-				error: { message: "canary result missing", type: "invalid_request_error" },
-			});
+			writeChatStream(response, [
+				chatChunk({
+					model,
+					delta: { role: "assistant", tool_calls: [{ index: 0, ...toolCall }] },
+					finishReason: null,
+				}),
+				chatChunk({ model, delta: {}, finishReason: "tool_calls" }),
+			]);
 		} catch (error) {
 			fail(error instanceof Error ? error.message : String(error));
 			if (!response.headersSent) {

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
@@ -1,6 +1,14 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -36,6 +44,7 @@ afterAll(() => rmSync(runtimeTestRoot, { recursive: true, force: true }));
 class FakeNativeRunner implements HostedAgentPluginCommandRunner {
 	readonly calls: CommandInput[] = [];
 	readonly states = new Map<string, FakePluginState>();
+	readonly hermesScanPolicies = new Map<string, boolean>();
 	availableResult = true;
 	failProbeInstallName: string | null = null;
 	failLiveHermesScanPolicy = false;
@@ -112,6 +121,17 @@ class FakeNativeRunner implements HostedAgentPluginCommandRunner {
 		return this.states.get(`${this.liveHome}\0${runtime}\0${name}`);
 	}
 
+	setHermesScanPolicy(value: boolean): void {
+		this.hermesScanPolicies.set(this.liveHome, value);
+		const stateRoot = join(this.liveHome, ".hermes");
+		mkdirSync(stateRoot, { recursive: true });
+		writeFileSync(join(stateRoot, "config.yaml"), `plugins:\n  scan_on_install: ${value}\n`);
+	}
+
+	hermesScanPolicy(): boolean {
+		return this.hermesScanPolicies.get(this.liveHome) ?? true;
+	}
+
 	private pluginFromSource(path: string): {
 		name: string;
 		version: string;
@@ -158,14 +178,30 @@ class FakeNativeRunner implements HostedAgentPluginCommandRunner {
 		const args = input.args;
 		if (
 			runtime === "hermes" &&
-			args.join("\0") ===
-				["config", "set", "--force", "plugins.scan_on_install", "false"].join("\0")
+			args.join("\0") === ["config", "get", "plugins.scan_on_install", "--json"].join("\0")
 		) {
-			if (input.home === this.liveHome && this.failLiveHermesScanPolicy) {
+			return {
+				status: 0,
+				stdout: JSON.stringify(this.hermesScanPolicies.get(input.home) ?? true),
+				stderr: "",
+			};
+		}
+		if (
+			runtime === "hermes" &&
+			args.slice(0, 4).join("\0") ===
+				["config", "set", "--force", "plugins.scan_on_install"].join("\0") &&
+			(args[4] === "true" || args[4] === "false")
+		) {
+			if (input.home === this.liveHome && args[4] === "false" && this.failLiveHermesScanPolicy) {
 				return { status: 44, stdout: "", stderr: "scan policy failure" };
 			}
+			const value = args[4] === "true";
+			this.hermesScanPolicies.set(input.home, value);
 			mkdirSync(expectedStateRoot, { recursive: true });
-			writeFileSync(join(expectedStateRoot, "config.yaml"), "plugins:\n  scan_on_install: false\n");
+			writeFileSync(
+				join(expectedStateRoot, "config.yaml"),
+				`plugins:\n  scan_on_install: ${value}\n`,
+			);
 			return { status: 0, stdout: "", stderr: "" };
 		}
 		if (args[0] !== "plugins") return { status: 2, stdout: "", stderr: "" };
@@ -615,24 +651,32 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 		const installIndex = runner.calls.findIndex(
 			(call) => call.home === runner.liveHome && call.args[1] === "install",
 		);
-		const scanPolicyIndex = runner.calls.findIndex(
+		const liveConfigCalls = runner.calls.filter(
 			(call) => call.home === runner.liveHome && call.args[0] === "config",
 		);
+		const disableIndex = runner.calls.findIndex(
+			(call) => call.home === runner.liveHome && call.args.at(-1) === "false",
+		);
+		const restoreIndex = runner.calls.findIndex(
+			(call) => call.home === runner.liveHome && call.args.at(-1) === "true",
+		);
 		const install = runner.calls[installIndex];
-		const scanPolicy = runner.calls[scanPolicyIndex];
-		expect(scanPolicy?.args).toEqual([
-			"config",
-			"set",
-			"--force",
-			"plugins.scan_on_install",
-			"false",
+		expect(liveConfigCalls.map((call) => call.args)).toEqual([
+			["config", "get", "plugins.scan_on_install", "--json"],
+			["config", "set", "--force", "plugins.scan_on_install", "false"],
+			["config", "get", "plugins.scan_on_install", "--json"],
+			["config", "set", "--force", "plugins.scan_on_install", "true"],
 		]);
-		expect(scanPolicyIndex).toBeGreaterThanOrEqual(0);
-		expect(scanPolicyIndex).toBeLessThan(installIndex);
+		expect(disableIndex).toBeGreaterThanOrEqual(0);
+		expect(disableIndex).toBeLessThan(installIndex);
+		expect(restoreIndex).toBeGreaterThan(installIndex);
 		expect(install?.args[2]?.startsWith("file://")).toBe(true);
 		expect(install?.args.join(" ")).not.toContain("github.com");
 		expect(readFileSync(join(runner.liveHome, ".hermes", "config.yaml"), "utf-8")).toContain(
-			"scan_on_install: false",
+			"scan_on_install: true",
+		);
+		expect(existsSync(join(runner.liveHome, ".hermes", ".clawdi-plugin-scan-guard.json"))).toBe(
+			false,
 		);
 		expect(install?.environmentOverrides).toEqual({
 			OPENCLAW_HOME: undefined,
@@ -683,6 +727,58 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 				(call) => call.home === failingRunner.liveHome && call.args[1] === "install",
 			),
 		).toBe(false);
+	});
+
+	test("preserves a tenant-disabled Hermes install scan without writing a guard", () => {
+		const runner = new FakeNativeRunner();
+		runner.setHermesScanPolicy(false);
+		const desired = plugin("acme.tools", "1.2.3", "9".repeat(64));
+		const transaction = prepareTransaction(desiredState("hermes", desired), runner);
+
+		transaction.apply();
+
+		const liveConfigCalls = runner.calls.filter(
+			(call) => call.home === runner.liveHome && call.args[0] === "config",
+		);
+		expect(liveConfigCalls.map((call) => call.args)).toEqual([
+			["config", "get", "plugins.scan_on_install", "--json"],
+		]);
+		expect(runner.hermesScanPolicy()).toBe(false);
+		expect(existsSync(join(runner.liveHome, ".hermes", ".clawdi-plugin-scan-guard.json"))).toBe(
+			false,
+		);
+	});
+
+	test("restores the Hermes install scan after install failure and after an interrupted guard", () => {
+		const runner = new FakeNativeRunner();
+		const desired = plugin("acme.tools", "1.2.3", "8".repeat(64));
+		const prepared = desiredState("hermes", desired);
+		const capabilityProof = proveHostedAgentPluginCapabilities({ prepared, commands, runner });
+		const guardPath = join(runner.liveHome, ".hermes", ".clawdi-plugin-scan-guard.json");
+		runner.setHermesScanPolicy(false);
+		writeFileSync(
+			guardPath,
+			`${JSON.stringify({
+				schemaVersion: "clawdi.hermesPluginScanGuard.v1",
+				previousValue: true,
+			})}\n`,
+			{ mode: 0o600 },
+		);
+
+		const transaction = prepareHostedAgentPluginTransaction({
+			prepared,
+			home: runner.liveHome,
+			commands,
+			capabilityProof,
+			runner,
+		});
+		expect(runner.hermesScanPolicy()).toBe(true);
+		expect(existsSync(guardPath)).toBe(false);
+
+		runner.failLiveInstallVersion = desired.installation.version;
+		expect(() => transaction.apply()).toThrow("Hermes native Agent Plugin install failed");
+		expect(runner.hermesScanPolicy()).toBe(true);
+		expect(existsSync(guardPath)).toBe(false);
 	});
 
 	test("requires the Hermes one-shot remote behavior proof before live mutation", () => {

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
@@ -1,8 +1,9 @@
-import { lstatSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { z } from "zod";
+import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "../lib/private-file";
 import { runHermesAgentPluginCanary } from "./hermes-agent-plugin-canary-client";
 import {
 	type HostedAgentPluginReceipt,
@@ -22,6 +23,7 @@ import {
 	commandResolvable,
 	makeRuntimeUserOwned,
 	spawnRuntimeUserCommand,
+	withRuntimeUserFileAccess,
 } from "./runtime-user-command";
 
 const COMMAND_TIMEOUT_MS = 120_000;
@@ -102,6 +104,15 @@ class OpenClawAgentPluginNotObservedError extends Error {}
 const OPENCLAW_AGENT_PLUGIN_STANDARD_UNSUPPORTED_ERROR =
 	"OpenClaw installed the package but did not report it as an Agent Plugins 1.0.0 bundle; standards-native installation is unsupported";
 const AGENT_PLUGIN_CAPABILITY_CANARY_NAME = "clawdi-capability-canary";
+const HERMES_PLUGIN_SCAN_POLICY_KEY = "plugins.scan_on_install";
+const HERMES_PLUGIN_SCAN_GUARD_SCHEMA = "clawdi.hermesPluginScanGuard.v1";
+const HERMES_PLUGIN_SCAN_GUARD_FILE = ".clawdi-plugin-scan-guard.json";
+const hermesPluginScanGuardSchema = z
+	.object({
+		schemaVersion: z.literal(HERMES_PLUGIN_SCAN_GUARD_SCHEMA),
+		previousValue: z.boolean(),
+	})
+	.strict();
 
 export type HermesRemoteCapabilityProbe = (input: {
 	command: string;
@@ -438,6 +449,131 @@ function initializeLocalGitTransport(
 	}
 }
 
+function hermesPluginScanGuardPath(home: string): string {
+	return join(home, ".hermes", HERMES_PLUGIN_SCAN_GUARD_FILE);
+}
+
+function readHermesPluginScanGuard(
+	home: string,
+): z.infer<typeof hermesPluginScanGuardSchema> | null {
+	const path = hermesPluginScanGuardPath(home);
+	try {
+		return withRuntimeUserFileAccess(() => {
+			const stat = lstatSync(path);
+			if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 4 * 1024) {
+				throw new Error("Hermes Agent Plugin scan guard receipt is unsafe");
+			}
+			if ((stat.mode & 0o777) !== PRIVATE_FILE_MODE) {
+				throw new Error("Hermes Agent Plugin scan guard receipt is not private");
+			}
+			const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+			return hermesPluginScanGuardSchema.parse(parsed);
+		});
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+		if (error instanceof Error && error.message.startsWith("Hermes Agent Plugin scan guard")) {
+			throw error;
+		}
+		throw new Error("Hermes Agent Plugin scan guard receipt is invalid");
+	}
+}
+
+function writeHermesPluginScanGuard(home: string, previousValue: boolean): void {
+	const path = hermesPluginScanGuardPath(home);
+	withRuntimeUserFileAccess(() =>
+		writePrivateFileAtomic(
+			path,
+			`${JSON.stringify({
+				schemaVersion: HERMES_PLUGIN_SCAN_GUARD_SCHEMA,
+				previousValue,
+			})}\n`,
+			{ mode: PRIVATE_FILE_MODE, dirMode: PRIVATE_DIR_MODE },
+		),
+	);
+}
+
+function clearHermesPluginScanGuard(home: string): void {
+	withRuntimeUserFileAccess(() => rmSync(hermesPluginScanGuardPath(home), { force: true }));
+}
+
+type HermesNativeCommand = (args: string[]) => AgentPluginCommandResult;
+
+function readHermesPluginScanPolicy(run: HermesNativeCommand): boolean {
+	const result = run(["config", "get", HERMES_PLUGIN_SCAN_POLICY_KEY, "--json"]);
+	if (result.status !== 0) {
+		throw nativeCommandFailure("Hermes Agent Plugin scan policy read failed", result);
+	}
+	try {
+		return z.boolean().parse(JSON.parse(result.stdout));
+	} catch {
+		throw new Error("Hermes Agent Plugin scan policy is not a boolean");
+	}
+}
+
+function setHermesPluginScanPolicy(
+	run: HermesNativeCommand,
+	value: boolean,
+	operation: "update" | "restoration",
+): void {
+	const result = run(["config", "set", "--force", HERMES_PLUGIN_SCAN_POLICY_KEY, String(value)]);
+	if (result.status !== 0) {
+		throw nativeCommandFailure(`Hermes Agent Plugin scan policy ${operation} failed`, result);
+	}
+}
+
+function restoreHermesPluginScanPolicy(home: string, run: HermesNativeCommand): void {
+	const guard = readHermesPluginScanGuard(home);
+	if (!guard) return;
+	if (readHermesPluginScanPolicy(run) !== guard.previousValue) {
+		setHermesPluginScanPolicy(run, guard.previousValue, "restoration");
+	}
+	clearHermesPluginScanGuard(home);
+}
+
+function withHermesPluginScanDisabled<T>(
+	home: string,
+	run: HermesNativeCommand,
+	install: () => T,
+): T {
+	const previousValue = readHermesPluginScanPolicy(run);
+	if (!previousValue) return install();
+
+	// Temporary until NousResearch/hermes-agent#89704 ships in the supported
+	// Hermes release; then use its immutable-ref --no-scan install exemption.
+	writeHermesPluginScanGuard(home, previousValue);
+	let installOutcome: { ok: true; value: T } | { ok: false; error: unknown };
+	try {
+		setHermesPluginScanPolicy(run, false, "update");
+		installOutcome = { ok: true, value: install() };
+	} catch (error) {
+		installOutcome = { ok: false, error };
+	}
+	let restoreOutcome: { ok: true } | { ok: false; error: unknown };
+	try {
+		restoreHermesPluginScanPolicy(home, run);
+		restoreOutcome = { ok: true };
+	} catch (error) {
+		restoreOutcome = { ok: false, error };
+	}
+	if (!restoreOutcome.ok) {
+		if (installOutcome.ok) throw restoreOutcome.error;
+		const installMessage =
+			installOutcome.error instanceof Error
+				? installOutcome.error.message
+				: String(installOutcome.error);
+		const restoreMessage =
+			restoreOutcome.error instanceof Error
+				? restoreOutcome.error.message
+				: String(restoreOutcome.error);
+		throw new Error(
+			`Hermes Agent Plugin install failed: ${installMessage}; scan policy restoration failed: ${restoreMessage}`,
+			{ cause: installOutcome.error },
+		);
+	}
+	if (!installOutcome.ok) throw installOutcome.error;
+	return installOutcome.value;
+}
+
 function createHermesDriver(input: {
 	command: string;
 	home: string;
@@ -486,25 +622,26 @@ function createHermesDriver(input: {
 	return {
 		runtime: "hermes",
 		installTarget: (nativeId) => nativeInstallTarget(input.home, "hermes", nativeId),
-		mutationStateTargets: () => [join(input.home, ".hermes", "config.yaml")],
+		mutationStateTargets: () => [
+			join(input.home, ".hermes", "config.yaml"),
+			hermesPluginScanGuardPath(input.home),
+		],
 		observe,
 		install(prepared) {
 			withPreparedAgentPluginDirectory(prepared, (sourceDir) => {
-				const scanPolicy = run(["config", "set", "--force", "plugins.scan_on_install", "false"]);
-				if (scanPolicy.status !== 0) {
-					throw nativeCommandFailure("Hermes Agent Plugin scan policy update failed", scanPolicy);
-				}
 				initializeLocalGitTransport(input.runner, "hermes", input.home, sourceDir);
-				const result = run([
-					"plugins",
-					"install",
-					pathToFileURL(sourceDir).href,
-					"--force",
-					"--no-enable",
-				]);
-				if (result.status !== 0) {
-					throw nativeCommandFailure("Hermes native Agent Plugin install failed", result);
-				}
+				withHermesPluginScanDisabled(input.home, run, () => {
+					const result = run([
+						"plugins",
+						"install",
+						pathToFileURL(sourceDir).href,
+						"--force",
+						"--no-enable",
+					]);
+					if (result.status !== 0) {
+						throw nativeCommandFailure("Hermes native Agent Plugin install failed", result);
+					}
+				});
 			});
 			const installed = observe(prepared.name);
 			if (!installed) throw new Error("Hermes did not report the installed Agent Plugin");
@@ -954,6 +1091,15 @@ export function prepareHostedAgentPluginTransaction(input: {
 		runner,
 		proof: input.capabilityProof,
 	});
+	restoreHermesPluginScanPolicy(input.home, (args) =>
+		runNative(runner, {
+			runtime: "hermes",
+			command: input.commands.hermes,
+			args,
+			home: input.home,
+			cwd: input.home,
+		}),
+	);
 	const drivers = new Map<HostedAgentPluginRuntime, NativeAgentPluginDriver>();
 	const driverFor = (runtime: HostedAgentPluginRuntime): NativeAgentPluginDriver => {
 		const existing = drivers.get(runtime);

--- a/packages/cli/src/runtime/managed-baileys-compat.ts
+++ b/packages/cli/src/runtime/managed-baileys-compat.ts
@@ -1,3 +1,4 @@
+// Upgrade procedure: packages/cli/docs/managed-baileys-compat-upgrade.md
 import { createHash, randomUUID } from "node:crypto";
 import {
 	chmodSync,

--- a/packages/cli/tests/adapters/hermes.test.ts
+++ b/packages/cli/tests/adapters/hermes.test.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { HermesAdapter } from "../../src/adapters/hermes";
 import { tarSkillDir } from "../../src/lib/tar";
+import { reserveManagedSkill } from "../../src/runtime/managed-skill-reservation";
 import {
 	type AgentHomeOverrideSnapshot,
 	restoreAgentHomeOverrides,
@@ -178,6 +179,28 @@ describe("HermesAdapter.writeSkillArchive + getSkillPath", () => {
 		const extracted = join(tmpHome, ".hermes", "skills", "demo", "SKILL.md");
 		expect(existsSync(extracted)).toBe(true);
 		expect(readFileSync(extracted, "utf-8")).toContain("description: A nested demo skill");
+	});
+
+	it("refuses to write shared content through a managed shared namespace", async () => {
+		const skillsRoot = join(tmpHome, ".hermes", "skills");
+		const sharedRoot = join(skillsRoot, "shared");
+		mkdirSync(sharedRoot, { recursive: true });
+		writeFileSync(join(sharedRoot, "SKILL.md"), "# Managed shared namespace\n");
+		reserveManagedSkill({
+			targetDir: sharedRoot,
+			id: "shared",
+			version: 1,
+			digest: "a".repeat(64),
+			manager: "local-setup",
+		});
+		const tarBytes = await tarSkillDir(join(skillsRoot, "core", "demo"));
+
+		const adapter = new HermesAdapter();
+		await expect(adapter.writeSharedSkillArchive("demo", "owner", tarBytes)).rejects.toThrow(
+			"Skill shared is reserved by a managed Skill owner",
+		);
+		expect(readFileSync(join(sharedRoot, "SKILL.md"), "utf8")).toBe("# Managed shared namespace\n");
+		expect(existsSync(join(sharedRoot, "demo__owner"))).toBe(false);
 	});
 
 	it("getSkillPath returns the canonical SKILL.md anchor under skills/", () => {


### PR DESCRIPTION
## 1. Guard the Hermes shared Skill namespace

**Symptom:** Hermes shared Skill delivery replaced archives under `skills/shared/<key>__<owner>` without the managed Skill commit boundary. A managed Skill whose ID is `shared` could therefore reserve `skills/shared` while shared synchronization still wrote through that owned tree, permanently invalidating its receipt fingerprint.

**Fix:** Route the shared archive commit through `mutateUserSkillTarget` for the exact `skills/shared` target and managed ID `shared`. Archive preparation remains outside the lock; only the filesystem commit is serialized and checked against managed ownership.

**Tests:** Added an adapter regression that reserves the `shared` target, attempts shared delivery, and verifies rejection plus zero mutation. The focused managed reservation suite also remains green.

## 2. Scope the Hermes plugin scan bypass to install

**Symptom:** Every managed Hermes plugin install persistently set `plugins.scan_on_install` to `false`. The setting survived managed plugin removal and also disabled scanning for tenant-initiated installs.

**Fix:** Use the transient critical-section design (design A). After local Git transport preparation, read the current boolean policy. When it is `true`, atomically write a private recovery receipt, set it to `false` only for the single native `plugins install`, then restore the original value on both success and failure and remove the receipt. When the tenant value is already `false`, Clawdi performs no policy write and preserves that explicit choice. A subsequent plugin transaction repairs an interrupted receipt before any live plugin mutation.

Hermes 0.20 reads `plugins.scan_on_install` at the install-time scan decision, so the transient setting is equivalent for the managed install. The Clawdi convergence lock serializes Clawdi transactions but cannot lock a tenant's separate Hermes CLI process. Preparing the local Git source before disabling scanning minimizes that residual window; at worst, one concurrently initiated tenant install can skip its content scan. No persistent bypass remains after a healthy process completes.

The workaround is documented against `NousResearch/hermes-agent#89704`. Once that change ships in the supported Hermes release, this guard should be replaced with the explicit immutable-ref `--no-scan` exemption.

**Tests:** Added regressions for transient disable/restore from `true`, preserving an explicit tenant `false`, restoration after install failure, and recovery from an interrupted guard receipt.

## 3. Narrow the Hermes plugin canary evidence

**Symptom:** The canary required a full two-round streaming inference exchange and asserted that the Hermes agent loop returned a tool result to the model. That exceeded the evidence needed to prove that the plugin MCP server was mounted and made convergence sensitive to upstream loop and prompt behavior.

**Fix:** Retain the isolated loopback controller, nonce/authentication boundary, timeout, HOME isolation, and child lifecycle, but accept only observed `mcpToolsList` and `mcpToolCall` evidence. The fake provider issues one deterministic tool call and no longer asserts a second inference round, tool-result replay, stdout token, or completion policy.

**Tests:** Added a controller-level MCP SDK regression that lists and calls the canary tool directly and verifies the narrowed evidence payload. Hosted plugin runtime tests remain green.

## 4. Document managed Baileys compatibility upgrades

**Symptom:** The byte-exact Baileys 7.x compatibility patch pins three pristine hashes without documenting how those hashes, strict hunks, patch revisions, and ownership receipts must be retargeted during an upgrade.

**Fix:** Added a command-first runbook covering the pristine SHA-256 -> exact hunk -> ownership receipt contract, all three audited targets, retagging steps, revision/schema rules, fixture-hash caveats, and focused verification. Linked it from the compatibility source header without changing runtime behavior.

**Tests:** Ran the 54-test managed Baileys compatibility suite, including apply, idempotence, rollback, version replacement, mixed-state handling, and unknown-state refusal.

## Verification

- `bun run --cwd packages/cli typecheck`
- `bunx biome check` on every changed TypeScript file
- `bun test packages/cli/tests/adapters/hermes.test.ts packages/cli/src/runtime/managed-skill-reservation.test.ts packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts packages/cli/src/runtime/hermes-agent-plugin-canary-controller.test.ts packages/cli/src/runtime/managed-baileys-compat.test.ts` (102 pass, 0 fail)

Heavy E2E suites were intentionally not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

