### PR TITLE
refactor(cli): deduplicate manifest contract validation

### DIFF
--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -800,32 +800,166 @@ const hostedRuntimeManifestBaseSchema = z
 
 type HostedRuntimeManifestBase = z.infer<typeof hostedRuntimeManifestBaseSchema>;
 
+interface HostedRuntimeSemanticRun {
+	args?: readonly string[];
+	secretEnv?: Readonly<Record<string, string>>;
+}
+
+interface HostedRuntimeSemanticEntry {
+	enabled?: boolean;
+	run?: HostedRuntimeSemanticRun;
+	services?: Readonly<Record<string, HostedRuntimeSemanticRun>>;
+}
+
+export interface HostedRuntimeSemanticView {
+	hostedV2: boolean;
+	runtime: string;
+	runtimes: Readonly<Record<string, HostedRuntimeSemanticEntry | undefined>>;
+	openclawGatewayAuth?: {
+		tokenRef?: string;
+		activation: { enabled?: boolean };
+	};
+	hermesDashboardAuth?: { activation: { enabled?: boolean } };
+	openclawControlUiAllowedOrigins?: unknown;
+	providers?: Readonly<Record<string, unknown>>;
+}
+
+export interface HostedRuntimeSemanticIssue {
+	message: string;
+	path: string[];
+}
+
+export function hostedRuntimeSemanticIssues(
+	view: HostedRuntimeSemanticView,
+): HostedRuntimeSemanticIssue[] {
+	const issues: HostedRuntimeSemanticIssue[] = [];
+	const addIssue = (message: string, path: string[]): void => {
+		issues.push({ message, path });
+	};
+	const systemPath = (...path: string[]): string[] => ["system", ...path];
+	const runtimePath = (...path: string[]): string[] => ["runtimes", view.runtime, ...path];
+	const runtimeKeys = Object.keys(view.runtimes);
+	const selectedRuntime = view.runtimes[view.runtime];
+	if (!selectedRuntime) {
+		addIssue(`runtimes.${view.runtime} must be present for selected runtime`, [
+			"runtimes",
+			view.runtime,
+		]);
+	}
+	for (const key of runtimeKeys) {
+		if (key === view.runtime) continue;
+		addIssue("hosted runtime manifests must declare exactly one selected runtime", [
+			"runtimes",
+			key,
+		]);
+	}
+	if (selectedRuntime?.enabled !== true) {
+		addIssue("selected runtime must be enabled", ["runtimes", view.runtime, "enabled"]);
+	}
+	if (!view.hostedV2) return issues;
+
+	if (view.runtime === "openclaw") {
+		const auth = view.openclawGatewayAuth;
+		if (!auth) {
+			addIssue(
+				"OpenClaw v2 native Control UI requires official gateway token authentication",
+				systemPath("openclawGatewayAuth"),
+			);
+		} else if (auth.activation.enabled !== true) {
+			addIssue(
+				"OpenClaw native auth activation must be explicitly enabled",
+				systemPath("openclawGatewayAuth", "activation", "enabled"),
+			);
+		}
+		if (
+			!Array.isArray(view.openclawControlUiAllowedOrigins) ||
+			view.openclawControlUiAllowedOrigins.length === 0
+		) {
+			addIssue(
+				"OpenClaw v2 native Control UI requires an explicit public allowed origin",
+				systemPath("openclawControlUiAllowedOrigins"),
+			);
+		}
+		const run = view.runtimes.openclaw?.run;
+		if (!isHostedGatewayRunArgs("openclaw", run?.args)) {
+			addIssue(
+				"OpenClaw v2 gateway must use the official gateway run command",
+				runtimePath("run", "args"),
+			);
+		}
+		if (run?.secretEnv?.OPENCLAW_GATEWAY_TOKEN !== auth?.tokenRef) {
+			addIssue(
+				"OpenClaw v2 gateway token must use the declared environment secret reference",
+				runtimePath("run", "secretEnv", "OPENCLAW_GATEWAY_TOKEN"),
+			);
+		}
+		for (const [providerId, provider] of Object.entries(view.providers ?? {})) {
+			if (!provider || typeof provider !== "object" || Array.isArray(provider)) continue;
+			if ((provider as Record<string, unknown>).runtimeEnvName === "OPENCLAW_GATEWAY_TOKEN") {
+				addIssue("OpenClaw v2 provider environment must not target native auth controls", [
+					"providers",
+					providerId,
+					"runtimeEnvName",
+				]);
+			}
+		}
+	}
+
+	if (view.runtime === "hermes") {
+		if (!view.hermesDashboardAuth) {
+			addIssue(
+				"hermes direct dashboard requires official password authentication",
+				systemPath("hermesDashboardAuth"),
+			);
+		}
+		if (view.hermesDashboardAuth?.activation.enabled !== true) {
+			addIssue(
+				"hermes password authentication must be explicitly enabled",
+				systemPath("hermesDashboardAuth", "activation", "enabled"),
+			);
+		}
+		if (view.openclawGatewayAuth) {
+			addIssue(
+				"OpenClaw gateway auth is only valid for the OpenClaw runtime",
+				systemPath("openclawGatewayAuth"),
+			);
+		}
+		if (!isHostedGatewayRunArgs("hermes", view.runtimes.hermes?.run?.args)) {
+			addIssue(
+				"Hermes gateway must use the official gateway run command",
+				runtimePath("run", "args"),
+			);
+		}
+		if (!isHostedHermesDashboardArgs(view.runtimes.hermes?.services?.dashboard?.args)) {
+			addIssue(
+				"hermes dashboard must bind directly to 0.0.0.0:9119",
+				runtimePath("services", "dashboard", "args"),
+			);
+		}
+	}
+	return issues;
+}
+
+function hostedRuntimeManifestSemanticView(
+	manifest: HostedRuntimeManifestBase,
+): HostedRuntimeSemanticView {
+	return {
+		hostedV2: true,
+		runtime: manifest.runtime,
+		runtimes: manifest.runtimes,
+		openclawGatewayAuth: manifest.system.openclawGatewayAuth,
+		hermesDashboardAuth: manifest.system.hermesDashboardAuth,
+		openclawControlUiAllowedOrigins: manifest.system.openclawControlUiAllowedOrigins,
+		providers: manifest.providers,
+	};
+}
+
 function validateHostedRuntimeManifest(
 	manifest: HostedRuntimeManifestBase,
 	ctx: z.RefinementCtx,
 ): void {
-	const runtimeKeys = Object.keys(manifest.runtimes);
-	const unexpectedRuntimeKeys = runtimeKeys.filter((runtime) => runtime !== manifest.runtime);
-	if (!manifest.runtimes[manifest.runtime]) {
-		ctx.addIssue({
-			code: "custom",
-			message: `runtimes.${manifest.runtime} must be present for selected runtime`,
-			path: ["runtimes", manifest.runtime],
-		});
-	}
-	for (const key of unexpectedRuntimeKeys) {
-		ctx.addIssue({
-			code: "custom",
-			message: "hosted runtime manifests must declare exactly one selected runtime",
-			path: ["runtimes", key],
-		});
-	}
-	if (manifest.runtimes[manifest.runtime]?.enabled !== true) {
-		ctx.addIssue({
-			code: "custom",
-			message: "selected runtime must be enabled",
-			path: ["runtimes", manifest.runtime, "enabled"],
-		});
+	for (const issue of hostedRuntimeSemanticIssues(hostedRuntimeManifestSemanticView(manifest))) {
+		ctx.addIssue({ code: "custom", message: issue.message, path: issue.path });
 	}
 	const selectedRuntime = manifest.runtimes[manifest.runtime];
 	if (selectedRuntime) {
@@ -851,27 +985,6 @@ function validateHostedRuntimeManifest(
 	}
 	if (manifest.runtime === "hermes") {
 		const runtime = manifest.runtimes.hermes;
-		if (!manifest.system.hermesDashboardAuth) {
-			ctx.addIssue({
-				code: "custom",
-				message: "hermes direct dashboard requires official password authentication",
-				path: ["system", "hermesDashboardAuth"],
-			});
-		}
-		if (manifest.system.hermesDashboardAuth?.activation.enabled !== true) {
-			ctx.addIssue({
-				code: "custom",
-				message: "hermes password authentication must be explicitly enabled",
-				path: ["system", "hermesDashboardAuth", "activation", "enabled"],
-			});
-		}
-		if (runtime && !isHostedGatewayRunArgs("hermes", runtime.run.args)) {
-			ctx.addIssue({
-				code: "custom",
-				message: "Hermes gateway must use the official gateway run command",
-				path: ["runtimes", "hermes", "run", "args"],
-			});
-		}
 		if (runtime?.run.secretEnv) {
 			ctx.addIssue({
 				code: "custom",
@@ -887,13 +1000,6 @@ function validateHostedRuntimeManifest(
 				path: ["runtimes", "hermes", "services"],
 			});
 		}
-		if (!isHostedHermesDashboardArgs(runtime?.services.dashboard?.args)) {
-			ctx.addIssue({
-				code: "custom",
-				message: "hermes dashboard must bind directly to 0.0.0.0:9119",
-				path: ["runtimes", "hermes", "services", "dashboard", "args"],
-			});
-		}
 	} else if (manifest.system.hermesDashboardAuth) {
 		ctx.addIssue({
 			code: "custom",
@@ -901,76 +1007,15 @@ function validateHostedRuntimeManifest(
 			path: ["system", "hermesDashboardAuth"],
 		});
 	}
-	if (manifest.runtime !== "openclaw" && manifest.system.openclawGatewayAuth) {
-		ctx.addIssue({
-			code: "custom",
-			message: "OpenClaw gateway auth is only valid for the OpenClaw runtime",
-			path: ["system", "openclawGatewayAuth"],
-		});
-	}
-	validateHostedRuntimeManifestV2(manifest, ctx);
-}
-
-function validateHostedRuntimeManifestV2(
-	manifest: HostedRuntimeManifestBase,
-	ctx: z.RefinementCtx,
-): void {
-	if (manifest.runtime !== "openclaw") return;
-	const auth = manifest.system.openclawGatewayAuth;
-	if (!manifest.system.openclawGatewayAuth) {
-		ctx.addIssue({
-			code: "custom",
-			message: "OpenClaw v2 native Control UI requires official gateway token authentication",
-			path: ["system", "openclawGatewayAuth"],
-		});
-	}
-	if (auth?.activation.enabled !== true) {
-		ctx.addIssue({
-			code: "custom",
-			message: "OpenClaw native auth activation must be explicitly enabled",
-			path: ["system", "openclawGatewayAuth", "activation", "enabled"],
-		});
-	}
-	const allowedOrigins = manifest.system.openclawControlUiAllowedOrigins ?? [];
-	if (allowedOrigins.length === 0) {
-		ctx.addIssue({
-			code: "custom",
-			message: "OpenClaw v2 native Control UI requires an explicit public allowed origin",
-			path: ["system", "openclawControlUiAllowedOrigins"],
-		});
-	}
-	const run = manifest.runtimes.openclaw?.run;
-	const gatewayArgs = run?.args;
-	if (!isHostedGatewayRunArgs("openclaw", gatewayArgs)) {
-		ctx.addIssue({
-			code: "custom",
-			message: "OpenClaw v2 gateway must use the official gateway run command",
-			path: ["runtimes", "openclaw", "run", "args"],
-		});
-	}
-	if (run?.secretEnv?.OPENCLAW_GATEWAY_TOKEN !== auth?.tokenRef) {
-		ctx.addIssue({
-			code: "custom",
-			message: "OpenClaw v2 gateway token must use the declared environment secret reference",
-			path: ["runtimes", "openclaw", "run", "secretEnv", "OPENCLAW_GATEWAY_TOKEN"],
-		});
-	}
-	if (Object.keys(manifest.runtimes.openclaw?.services ?? {}).length > 0) {
+	if (
+		manifest.runtime === "openclaw" &&
+		Object.keys(manifest.runtimes.openclaw?.services ?? {}).length > 0
+	) {
 		ctx.addIssue({
 			code: "custom",
 			message: "OpenClaw hosted runtime must not declare auxiliary services",
 			path: ["runtimes", "openclaw", "services"],
 		});
-	}
-	for (const [providerId, provider] of Object.entries(manifest.providers)) {
-		const envName = provider.runtimeEnvName;
-		if (envName === "OPENCLAW_GATEWAY_TOKEN") {
-			ctx.addIssue({
-				code: "custom",
-				message: "OpenClaw v2 provider environment must not target native auth controls",
-				path: ["providers", providerId, "runtimeEnvName"],
-			});
-		}
 	}
 }
 
@@ -990,43 +1035,33 @@ export const hostedRuntimeBundleV2ManifestSchema = hostedRuntimeManifestBaseSche
 	})
 	.strict()
 	.superRefine(validateHostedRuntimeManifest);
-export const hostedRuntimeManifestResponseSchema = z
-	.object({
-		manifest: hostedRuntimeManifestSchema,
-		secretValues: z.record(canonicalSecretRefSchema, z.string()).default({}),
-	})
-	.strict()
-	.superRefine((response, ctx) => {
-		const runtime = response.manifest.runtimes[response.manifest.runtime];
-		if (runtime?.providerMode !== "unmanaged") return;
-		const codexSecretRef = canonicalSecretRefName(
-			response.manifest.terminalTooling?.codex.provider.apiKeySecretRef,
-		);
-		for (const rawSecretRef of Object.keys(response.secretValues)) {
-			const secretRef = canonicalSecretRefName(rawSecretRef);
-			if (!secretRef?.startsWith("provider.") || secretRef === codexSecretRef) continue;
-			ctx.addIssue({
-				code: "custom",
-				message: "unmanaged provider mode must not include provider secret values",
-				path: ["secretValues", rawSecretRef],
-			});
-		}
-	});
 
-const hostedRuntimeManifestFixtureSchema = hostedRuntimeManifestBaseSchema
-	.safeExtend({
-		schemaVersion: z.literal("clawdi.hosted-runtime.manifest.v1"),
-		clawdiCli: hostedFixtureCliPayloadPolicySchema,
-	})
-	.strict()
-	.superRefine(validateHostedRuntimeManifest);
-
-export const hostedRuntimeManifestFixtureResponseSchema = z
-	.object({
-		manifest: hostedRuntimeManifestFixtureSchema,
-		secretValues: z.record(canonicalSecretRefSchema, z.string()).default({}),
-	})
-	.strict();
+export function validateUnmanagedProviderSecretValues(
+	response: {
+		manifest: {
+			runtime: string;
+			runtimes: Readonly<Record<string, { providerMode?: "configured" | "unmanaged" } | undefined>>;
+			terminalTooling?: { codex: { provider: { apiKeySecretRef?: string | null } } };
+		};
+		secretValues: Readonly<Record<string, string>>;
+	},
+	ctx: z.RefinementCtx,
+): void {
+	const runtime = response.manifest.runtimes[response.manifest.runtime];
+	if (runtime?.providerMode !== "unmanaged") return;
+	const codexSecretRef = canonicalSecretRefName(
+		response.manifest.terminalTooling?.codex.provider.apiKeySecretRef,
+	);
+	for (const rawSecretRef of Object.keys(response.secretValues)) {
+		const secretRef = canonicalSecretRefName(rawSecretRef);
+		if (!secretRef?.startsWith("provider.") || secretRef === codexSecretRef) continue;
+		ctx.addIssue({
+			code: "custom",
+			message: "unmanaged provider mode must not include provider secret values",
+			path: ["secretValues", rawSecretRef],
+		});
+	}
+}
 
 export type RuntimeManifest = z.output<typeof manifestSchema>;
 export type RuntimeInstall = z.infer<typeof installSchema>;

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -19,6 +19,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
+import { z } from "zod";
 import { commitRuntimeAppliedState } from "../commands/runtime";
 import {
 	type TestConvergeOptions,
@@ -66,9 +67,8 @@ import {
 	AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR,
 	AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR,
 	fileBrowserCompanionSchema,
+	hostedFixtureCliPayloadPolicySchema,
 	hostedRuntimeBundleV2ManifestSchema,
-	hostedRuntimeManifestFixtureResponseSchema,
-	hostedRuntimeManifestResponseSchema,
 	hostedRuntimeManifestSchema,
 	manifestSchema,
 	OFFICIAL_INSTALL_URLS,
@@ -81,12 +81,17 @@ import {
 import {
 	hostedManifestToRuntimeManifest,
 	loadCommittedRuntimeManifest,
+	normalizeHostedRuntimeBundleV2,
 	type RuntimeManifestLoad,
 } from "./manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
 import { planRuntimeMutationSystemdUserUnits } from "./runtime-systemd-reconciliation";
-import { normalizeSecretValues, runtimeSecretValue } from "./secret-values";
+import {
+	canonicalSecretRefSchema,
+	normalizeSecretValues,
+	runtimeSecretValue,
+} from "./secret-values";
 import { ensureRuntimeStateDirs } from "./state";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "./systemd-user";
 
@@ -113,6 +118,9 @@ const FILE_BROWSER_AMD64_SHA256 =
 	"8d51d1718d576d22e73e1f41a5194b451d152ddab0df97697cabe839cf59524e";
 const FILE_BROWSER_ARM64_SHA256 =
 	"3e18838ae33750a25da434dc6156a359968bf7935e01bdd884711f47f08ad92f";
+const hostedRuntimeManifestFixtureSchema = hostedRuntimeManifestSchema.safeExtend({
+	clawdiCli: hostedFixtureCliPayloadPolicySchema,
+});
 const TEST_HOSTED_SECRET_VALUES = {
 	"secret://clawdi/auth-token": "test-auth-token",
 	"secret://runtime/openclaw/gateway-token": "gateway-token",
@@ -626,6 +634,19 @@ function hostedOpenClawV2ManifestFixture(
 	});
 }
 
+function normalizeHostedBundleFixture(
+	manifest: Record<string, unknown>,
+	secretValues: Record<string, string>,
+): RuntimeManifestLoad {
+	return normalizeHostedRuntimeBundleV2({
+		schemaVersion: "clawdi.hosted-runtime.bundle.v2",
+		sourceRevision: "a".repeat(64),
+		manifest,
+		channelBindings: [],
+		secretValues,
+	});
+}
+
 function writeFakeGatewayCli(input: {
 	path: string;
 	runtime: "openclaw" | "hermes";
@@ -825,12 +846,6 @@ describe("runtime manifest reconciliation invariants", () => {
 			const withBridge = { ...valid, bridge: {} };
 			expect(hostedRuntimeManifestSchema.safeParse(withBridge).success).toBe(false);
 			expect(hostedRuntimeBundleV2ManifestSchema.safeParse(withBridge).success).toBe(false);
-			expect(
-				hostedRuntimeManifestResponseSchema.safeParse({
-					manifest: withBridge,
-					secretValues: {},
-				}).success,
-			).toBe(false);
 		},
 	);
 
@@ -840,7 +855,13 @@ describe("runtime manifest reconciliation invariants", () => {
 
 		const missingAuth = structuredClone(valid);
 		delete (missingAuth.system as { openclawGatewayAuth?: unknown }).openclawGatewayAuth;
-		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(missingAuth).success).toBe(false);
+		const missingAuthResult = hostedRuntimeBundleV2ManifestSchema.safeParse(missingAuth);
+		expect(missingAuthResult.success).toBe(false);
+		expect(
+			missingAuthResult.error?.issues.some(
+				(issue) => issue.message === "OpenClaw native auth activation must be explicitly enabled",
+			),
+		).toBe(false);
 
 		const inactive = structuredClone(valid);
 		(
@@ -853,6 +874,11 @@ describe("runtime manifest reconciliation invariants", () => {
 			mismatchedOrigin.system as { openclawControlUiAllowedOrigins: string[] }
 		).openclawControlUiAllowedOrigins = ["https://other.example.test"];
 		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(mismatchedOrigin).success).toBe(true);
+		const missingOrigin = structuredClone(valid);
+		(
+			missingOrigin.system as { openclawControlUiAllowedOrigins: string[] }
+		).openclawControlUiAllowedOrigins = [];
+		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(missingOrigin).success).toBe(false);
 	});
 
 	test("keeps hosted runtime process ownership on the exact upstream commands", () => {
@@ -1660,7 +1686,7 @@ chmod 0755 '${commandPath}'
 		expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(false);
 	});
 
-	test.each(["secret://provider.stale.apiKey", "secret://provider.stale.apiKey"])(
+	test.each(["secret://provider.stale.apiKey", "secret://provider.other.apiKey"])(
 		"rejects provider secret value %s in unmanaged mode",
 		(secretRef) => {
 			const runtime = hostedRuntimeFixture({
@@ -1672,12 +1698,9 @@ chmod 0755 '${commandPath}'
 				providers: {},
 				runtimes: { openclaw: runtime },
 			});
-			expect(
-				hostedRuntimeManifestResponseSchema.safeParse({
-					manifest,
-					secretValues: { [secretRef]: "secret" },
-				}).success,
-			).toBe(false);
+			expect(() => normalizeHostedBundleFixture(manifest, { [secretRef]: "secret" })).toThrow(
+				"unmanaged provider mode must not include provider secret values",
+			);
 		},
 	);
 
@@ -1688,12 +1711,7 @@ chmod 0755 '${commandPath}'
 		const codexRef = TEST_HOSTED_CODEX_TOOLING.codex.provider.apiKeySecretRef;
 		expect(codexRef).toBeDefined();
 		for (const secretRef of [codexRef, `secret://${codexRef}`]) {
-			expect(
-				hostedRuntimeManifestResponseSchema.safeParse({
-					manifest,
-					secretValues: { [secretRef]: "secret" },
-				}).success,
-			).toBe(true);
+			expect(() => normalizeHostedBundleFixture(manifest, { [secretRef]: "secret" })).not.toThrow();
 		}
 	});
 
@@ -2159,20 +2177,17 @@ chmod 0755 '${commandPath}'
 
 	test("rejects hosted manifests without an explicit CLI package policy", () => {
 		expect(() =>
-			hostedRuntimeManifestResponseSchema.parse({
-				manifest: {
-					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
-					runtime: "openclaw",
-					deploymentId: "hdep_missing_cli_policy",
-					environmentId: "env_missing_cli_policy",
-					instanceId: "hri_missing_cli_policy",
-					generation: 1,
-					issuedAt: "2026-07-11T00:00:00.000Z",
-					locale: TEST_HOSTED_LOCALE,
-					controlPlane: { cloudApiUrl: "https://cloud-api.example.test" },
-					runtimes: { openclaw: { enabled: true } },
-				},
-				secretValues: {},
+			hostedRuntimeManifestSchema.parse({
+				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				runtime: "openclaw",
+				deploymentId: "hdep_missing_cli_policy",
+				environmentId: "env_missing_cli_policy",
+				instanceId: "hri_missing_cli_policy",
+				generation: 1,
+				issuedAt: "2026-07-11T00:00:00.000Z",
+				locale: TEST_HOSTED_LOCALE,
+				controlPlane: { cloudApiUrl: "https://cloud-api.example.test" },
+				runtimes: { openclaw: { enabled: true } },
 			}),
 		).toThrow(/clawdiCli/);
 	});
@@ -2253,21 +2268,18 @@ chmod 0755 '${commandPath}'
 		},
 	])("rejects hosted CLI policy with $name", ({ clawdiCli }) => {
 		expect(() =>
-			hostedRuntimeManifestResponseSchema.parse({
-				manifest: {
-					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
-					runtime: "openclaw",
-					deploymentId: "hdep_invalid_cli_policy",
-					environmentId: "env_invalid_cli_policy",
-					instanceId: "hri_invalid_cli_policy",
-					generation: 1,
-					issuedAt: "2026-07-11T00:00:00.000Z",
-					locale: TEST_HOSTED_LOCALE,
-					controlPlane: { cloudApiUrl: "https://cloud-api.example.test" },
-					clawdiCli,
-					runtimes: { openclaw: { enabled: true } },
-				},
-				secretValues: {},
+			hostedRuntimeManifestSchema.parse({
+				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				runtime: "openclaw",
+				deploymentId: "hdep_invalid_cli_policy",
+				environmentId: "env_invalid_cli_policy",
+				instanceId: "hri_invalid_cli_policy",
+				generation: 1,
+				issuedAt: "2026-07-11T00:00:00.000Z",
+				locale: TEST_HOSTED_LOCALE,
+				controlPlane: { cloudApiUrl: "https://cloud-api.example.test" },
+				clawdiCli,
+				runtimes: { openclaw: { enabled: true } },
 			}),
 		).toThrow();
 	});
@@ -2305,20 +2317,14 @@ chmod 0755 '${commandPath}'
 			});
 			const expected = packageSpec === atLimit;
 			expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(expected);
-			expect(
-				hostedRuntimeManifestFixtureResponseSchema.safeParse({
-					manifest,
-					secretValues: {},
-				}).success,
-			).toBe(expected);
+			expect(hostedRuntimeManifestFixtureSchema.safeParse(manifest).success).toBe(expected);
 		}
 	});
 
 	test("rejects raw secretValues keys in the Hosted fixture contract", () => {
 		expect(
-			hostedRuntimeManifestFixtureResponseSchema.safeParse({
-				manifest: hostedManifestFixture(),
-				secretValues: { "tool.codex.apiKey": "must-be-rejected" },
+			z.record(canonicalSecretRefSchema, z.string()).safeParse({
+				"tool.codex.apiKey": "must-be-rejected",
 			}).success,
 		).toBe(false);
 	});
@@ -2441,11 +2447,10 @@ chmod 0755 '${commandPath}'
 			},
 		};
 
-		const parsedResponse = hostedRuntimeManifestResponseSchema.parse(hostedResponse);
-		const hostedManifest = hostedRuntimeManifestSchema.parse(parsedResponse.manifest);
+		const hostedManifest = hostedRuntimeManifestSchema.parse(hostedResponse.manifest);
 		const normalized = {
 			manifest: hostedManifestToRuntimeManifest(hostedManifest),
-			secretValues: normalizeSecretValues(parsedResponse.secretValues),
+			secretValues: normalizeSecretValues(hostedResponse.secretValues),
 		};
 		expect(normalized.manifest.schemaVersion).toBe("clawdi.runtimeDesiredState.v1");
 		expect(normalized.manifest.runtime).toBe("openclaw");

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -24,18 +24,18 @@ import {
 	hasUnsupportedAgentPluginInstallations,
 	hostedCliPayloadPolicySchema,
 	hostedRuntimeBundleV2ManifestSchema,
+	hostedRuntimeSemanticIssues,
 	isHostedGatewayRunArgs,
-	isHostedHermesDashboardArgs,
 	manifestSchema,
 	OFFICIAL_INSTALL_URLS,
 	officialInstallArgs,
 	RUNTIME_DESIRED_STATE_SCHEMA_VERSION,
 	type RuntimeManifest,
+	validateUnmanagedProviderSecretValues,
 } from "./manifest-contract";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { isSupportedRuntimeName, type RuntimeRunSettings } from "./run-config";
 import {
-	canonicalSecretRefName,
 	canonicalSecretRefSchema,
 	normalizeSecretValues,
 	runtimeSecretValue,
@@ -119,22 +119,7 @@ const hostedRuntimeBundleV2Schema = z
 		secretValues: z.record(canonicalSecretRefSchema, z.string()),
 	})
 	.strict()
-	.superRefine((bundle, ctx) => {
-		const runtime = bundle.manifest.runtimes[bundle.manifest.runtime];
-		if (runtime?.providerMode !== "unmanaged") return;
-		const codexSecretRef = canonicalSecretRefName(
-			bundle.manifest.terminalTooling?.codex.provider.apiKeySecretRef,
-		);
-		for (const rawSecretRef of Object.keys(bundle.secretValues)) {
-			const secretRef = canonicalSecretRefName(rawSecretRef);
-			if (!secretRef?.startsWith("provider.") || secretRef === codexSecretRef) continue;
-			ctx.addIssue({
-				code: "custom",
-				message: "unmanaged provider mode must not include provider secret values",
-				path: ["secretValues", rawSecretRef],
-			});
-		}
-	});
+	.superRefine(validateUnmanagedProviderSecretValues);
 
 export function normalizeHostedRuntimeBundleV2(value: unknown): RuntimeManifestLoad {
 	const bundle = hostedRuntimeBundleV2Schema.parse(value);
@@ -323,7 +308,7 @@ type RemoteRuntimeManifestResult =
 	| RuntimeManifestFailure
 	| RuntimeManifestNotModified;
 
-async function loadRemoteRuntimeManifestPipeline(
+export async function loadRemoteRuntimeManifest(
 	paths: RuntimePaths,
 	opts: { ifNoneMatch?: string; applyContext?: RuntimeApplyContext } = {},
 ): Promise<RemoteRuntimeManifestResult> {
@@ -354,7 +339,7 @@ async function loadRemoteRuntimeManifestPipeline(
 			sourcePath: fetched.url,
 			notModified: true,
 			etag: fetched.etag ?? opts.ifNoneMatch,
-			...runtimeApplyContextLoadFields(applyContext),
+			applyContext,
 		};
 	}
 
@@ -388,15 +373,8 @@ async function loadRemoteRuntimeManifestPipeline(
 	return {
 		...loaded,
 		etag: fetched.etag,
-		...runtimeApplyContextLoadFields(applyContext),
+		applyContext,
 	};
-}
-
-export async function loadRemoteRuntimeManifest(
-	paths: RuntimePaths,
-	opts: { ifNoneMatch?: string; applyContext?: RuntimeApplyContext } = {},
-): Promise<RemoteRuntimeManifestResult> {
-	return loadRemoteRuntimeManifestPipeline(paths, opts);
 }
 
 function runtimeApplyContextFailure(error: unknown): RuntimeManifestFailure {
@@ -405,12 +383,6 @@ function runtimeApplyContextFailure(error: unknown): RuntimeManifestFailure {
 		stage: "local",
 		errors: [error instanceof Error ? error.message : String(error)],
 	};
-}
-
-function runtimeApplyContextLoadFields(applyContext: RuntimeApplyContext): {
-	applyContext: RuntimeApplyContext;
-} {
-	return { applyContext };
 }
 
 function assertRuntimeApplyIdentityMatchesManifest(
@@ -591,41 +563,20 @@ function validateManifestSemantics(
 	}
 	if (manifest.runtime) {
 		const runtime = manifest.runtime;
-		const runtimeKeys = Object.keys(manifest.runtimes);
-		if (!runtimeKeys.includes(runtime)) {
-			errors.push(`manifest runtime ${runtime} must have a matching runtimes.${runtime} entry`);
-		}
-		for (const key of runtimeKeys) {
-			if (key !== runtime) {
-				errors.push(`single-runtime manifest must not declare runtimes.${key}`);
-			}
-		}
-		if (manifest.runtimes[runtime]?.enabled !== true) {
-			errors.push(`manifest runtime ${runtime} must be enabled`);
-		}
+		const system = plainRecord(manifest.projection?.system);
+		errors.push(
+			...hostedRuntimeSemanticIssues({
+				hostedV2: isHostedV2,
+				runtime,
+				runtimes: manifest.runtimes,
+				openclawGatewayAuth: manifest.openclawGatewayAuth,
+				hermesDashboardAuth: manifest.hermesDashboardAuth,
+				openclawControlUiAllowedOrigins: system?.openclawControlUiAllowedOrigins,
+				providers: manifest.projection?.providers,
+			}).map((issue) => issue.message),
+		);
 		if (runtime === "openclaw" && isHostedV2) {
-			const auth = manifest.openclawGatewayAuth;
-			if (!auth) {
-				errors.push("OpenClaw v2 native Control UI requires official gateway token authentication");
-			}
-			if (auth?.activation.enabled !== true) {
-				errors.push("OpenClaw native auth activation must be explicitly enabled");
-			}
-			const system = manifest.projection?.system;
-			const origins =
-				typeof system === "object" && system !== null && !Array.isArray(system)
-					? (system as Record<string, unknown>).openclawControlUiAllowedOrigins
-					: null;
-			if (!Array.isArray(origins) || origins.length === 0) {
-				errors.push("OpenClaw v2 native Control UI requires an explicit public allowed origin");
-			}
 			const run = manifest.runtimes.openclaw?.run;
-			if (!isHostedGatewayRunArgs("openclaw", run?.args)) {
-				errors.push("OpenClaw v2 gateway must use the official gateway run command");
-			}
-			if (run?.secretEnv?.OPENCLAW_GATEWAY_TOKEN !== auth?.tokenRef) {
-				errors.push("OpenClaw v2 gateway token must use the declared environment secret reference");
-			}
 			if (run?.env?.OPENCLAW_GATEWAY_TOKEN !== undefined) {
 				errors.push("OpenClaw v2 gateway token must not be embedded in manifest env");
 			}
@@ -637,30 +588,6 @@ function validateManifestSemantics(
 						}
 					}
 				}
-			}
-			for (const provider of Object.values(manifest.projection?.providers ?? {})) {
-				if (!provider || typeof provider !== "object" || Array.isArray(provider)) continue;
-				const envName = (provider as Record<string, unknown>).runtimeEnvName;
-				if (envName === "OPENCLAW_GATEWAY_TOKEN") {
-					errors.push("OpenClaw v2 provider environment must not target native auth controls");
-				}
-			}
-		}
-		if (runtime === "hermes" && isHostedV2) {
-			if (!manifest.hermesDashboardAuth) {
-				errors.push("hermes direct dashboard requires official password authentication");
-			}
-			if (manifest.hermesDashboardAuth?.activation.enabled !== true) {
-				errors.push("hermes password authentication must be explicitly enabled");
-			}
-			if (manifest.openclawGatewayAuth) {
-				errors.push("OpenClaw gateway auth is only valid for the OpenClaw runtime");
-			}
-			if (!isHostedGatewayRunArgs("hermes", manifest.runtimes.hermes?.run?.args)) {
-				errors.push("Hermes gateway must use the official gateway run command");
-			}
-			if (!isHostedHermesDashboardArgs(manifest.runtimes.hermes?.services.dashboard?.args)) {
-				errors.push("hermes dashboard must bind directly to 0.0.0.0:9119");
 			}
 		}
 	}
@@ -733,7 +660,7 @@ export async function loadRuntimeManifest(
 	} catch (error) {
 		return runtimeApplyContextFailure(error);
 	}
-	const remote = await loadRemoteRuntimeManifestPipeline(paths, { applyContext });
+	const remote = await loadRemoteRuntimeManifest(paths, { applyContext });
 	const fetchFailed =
 		"errors" in remote &&
 		remote.mode === "repair" &&
@@ -871,7 +798,7 @@ function loadLastGoodManifest(
 				sourcePath: paths.manifestLastGood,
 				offline: true,
 				secretValues: cached.secretValues,
-				...runtimeApplyContextLoadFields(applyContext),
+				applyContext,
 			};
 		}
 		return {
@@ -879,7 +806,7 @@ function loadLastGoodManifest(
 			source: "last-good-cache",
 			sourcePath: paths.manifestLastGood,
 			offline: true,
-			...runtimeApplyContextLoadFields(applyContext),
+			applyContext,
 		};
 	} catch (error) {
 		return {

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -1466,7 +1466,7 @@ describe("hosted runtime bundle v2", () => {
 		);
 	});
 
-	test("caches the effective projected manifest and complete active secret union", () => {
+	test("caches the complete active secret union and revalidates shared semantics", async () => {
 		const root = mkdtempSync(join(tmpdir(), "clawdi-runtime-bundle-cache-"));
 		roots.push(root);
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
@@ -1495,6 +1495,23 @@ describe("hosted runtime bundle v2", () => {
 			expect(cacheStat.uid).toBe(0);
 			expect(cacheStat.gid).toBe(0);
 		}
+		const applyContext = setRuntimeApplyIdentityFile(root, {
+			generation: 1,
+			manifestETag: '"bundle-golden"',
+			applyReceiptId: "apply-receipt-golden-0001",
+			bootNonce: "boot-nonce-golden-000001",
+		});
+		if (!projected.manifest.projection) throw new Error("golden bundle projection is unavailable");
+		projected.manifest.projection.system = { openclawControlUiAllowedOrigins: [] };
+		cacheRuntimeLastGoodManifest(projected.manifest, paths, projected.secretValues);
+		globalThis.fetch = Object.assign(async () => Promise.reject(new Error("offline")), {
+			preconnect: () => undefined,
+		});
+
+		const loaded = await loadRuntimeManifest(paths, { applyContext });
+		expect("errors" in loaded ? loaded.errors.join("\n") : "").toContain(
+			"cached OpenClaw v2 native Control UI requires an explicit public allowed origin",
+		);
 	});
 
 	test("rebuilds the exact active egress secret file from the golden bundle offline", async () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -19,6 +19,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
+import { z } from "zod";
 import {
 	commitRuntimeAppliedState,
 	runtimeAppliedContentIdentity,
@@ -69,9 +70,10 @@ import {
 	type RuntimeManifest,
 } from "../src/runtime/manifest";
 import {
-	hostedRuntimeManifestResponseSchema,
+	hostedRuntimeManifestSchema,
 	manifestSchema,
 	officialInstallArgs,
+	validateUnmanagedProviderSecretValues,
 } from "../src/runtime/manifest-contract";
 import {
 	HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
@@ -84,7 +86,7 @@ import {
 import { readHostedRuntimeObserved } from "../src/runtime/observed";
 import { detectRuntimeMode, getRuntimePaths, type RuntimePaths } from "../src/runtime/paths";
 import { buildRuntimeRunConfig } from "../src/runtime/run-config";
-import { normalizeSecretValues } from "../src/runtime/secret-values";
+import { canonicalSecretRefSchema, normalizeSecretValues } from "../src/runtime/secret-values";
 import {
 	buildRuntimeBootStatus,
 	ensureRuntimeStateDirs,
@@ -147,6 +149,14 @@ function explicitTestApplyContext(
 		},
 	};
 }
+
+const hostedRuntimeManifestResponseSchema = z
+	.object({
+		manifest: hostedRuntimeManifestSchema,
+		secretValues: z.record(canonicalSecretRefSchema, z.string()).default({}),
+	})
+	.strict()
+	.superRefine(validateUnmanagedProviderSecretValues);
 
 function normalizeHostedManifestFixture(value: unknown): {
 	manifest: RuntimeManifest;


### PR DESCRIPTION
## Duplicate inventory

- Hosted v2 single-runtime, OpenClaw auth, Hermes auth, gateway command, dashboard command, origin, token-ref, and provider-env semantics were implemented independently in the wire schema and projected-manifest revalidation.
- Unmanaged provider `secretValues` filtering was duplicated between hosted response fixtures and bundle parsing.
- Hosted response schemas were production exports with test-only consumers.
- Remote loading and apply-context projection each had a pure forwarding helper.

## Consolidation

- Added one normalized hosted semantic view and issue generator shared by strict wire parsing and last-good-cache revalidation.
- Kept wire-only structural checks and projected-manifest tamper checks at their existing boundaries.
- Centralized unmanaged provider secret refinement and exercised it through the real bundle normalizer.
- Moved response fixture composition to tests and removed both test-only production response schema exports.
- Inlined the remote loader and apply-context forwarding helpers.
- Kept `hostedRuntimeManifestSchema` and `hostedRuntimeBundleV2ManifestSchema` separate because combining them would allow optional `agentPlugins` on the strict legacy manifest contract.
- Kept `updateChannel`: on current `main`, `manifest.ts` still consumes it in two runtime status projections and the generic manifest contract has an explicit preservation test, so deleting it inside the allowed file scope would weaken behavior or fail typecheck.

## Net deletion

- 306 additions, 312 deletions: **6 net lines removed** across production and regression tests.

## Rejection parity

- Strict wire schemas remain strict and still reject all existing OpenClaw/Hermes fixture mutations.
- Missing OpenClaw auth now emits the required-auth issue without the redundant activation issue.
- Last-good-cache loading still revalidates projected hosted v2 semantics; a cache mutation regression proves an empty Control UI origin list fails closed.
- Unmanaged provider bundles still reject non-Codex provider secrets while accepting both Codex secret-ref aliases.
- `markHostedRuntimeBundleV2` and the hosted-v2 trust marker are unchanged.

## Verification

- `bun run --cwd packages/cli test` in the repository Bun 1.4.0 clean runner: 1729 passed, 4 skipped, 0 failed across 134 files; CLI typecheck passed in the same runner.
- Focused manifest contract, reconciliation, and bundle tests: 231 passed, 0 failed.
- Biome check on all five changed files passed.
- Rebasing onto current `origin/main` completed without conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)