### PR TITLE
test(cli): widen timeouts on two near-5s converge tests

### DIFF
--- a/packages/cli/src/runtime/platform-root-modes.test.ts
+++ b/packages/cli/src/runtime/platform-root-modes.test.ts
@@ -154,4 +154,4 @@ exit 0
 		}
 		Object.assign(process.env, originalEnv);
 	}
-});
+}, 30_000);

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -4438,7 +4438,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		);
 		expect(readFileSync(configPath, "utf-8")).not.toMatch(/^model\s*=|model_catalog_json|models/m);
 		expect(readFileSync(configPath, "utf-8")).not.toMatch(/managed/i);
-	});
+	}, 30_000);
 
 	it("migrates the legacy Codex shim before bootstrapping the user npm prefix", () => {
 		const home = join(root, "home", "clawdi");


### PR DESCRIPTION
The two long-documented CI flakes — `never chmods the four platform roots that child writes touch` and `writes Codex managed provider config from hosted runtime converge` — run 4–5s on a healthy machine and intermittently cross bun's 5s default under CI load (they just failed #1130's verify at 5039ms/5183ms and pass on rerun).

Give both the repo's existing `30_000` per-test timeout. Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)