### PR TITLE
test(cli): raise the internal suite timeout to 30s

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,7 @@
 		"check:native-release": "bun run scripts/check-native-release.mjs",
 		"typecheck": "tsc --noEmit",
 		"test": "../../scripts/test.sh cli",
-		"test:internal": "bun test --isolate --max-concurrency=1",
+		"test:internal": "bun test --isolate --max-concurrency=1 --timeout=30000",
 		"test:e2e": "../../scripts/test.sh cli tests/e2e",
 		"test:native-linux-lifecycle:internal": "CLAWDI_NATIVE_BINARY=${CLAWDI_NATIVE_BINARY:-dist-native/linux-x64/clawdi} bun test tests/e2e/native-installer.e2e.test.ts tests/e2e/native-daemon.e2e.test.ts",
 		"test:watch:local": "bun test --watch",

--- a/packages/cli/tests/clean-test-runner.test.ts
+++ b/packages/cli/tests/clean-test-runner.test.ts
@@ -155,7 +155,7 @@ describe("clean runner suite contract", () => {
 		});
 		expect(cliScripts).toMatchObject({
 			test: "../../scripts/test.sh cli",
-			"test:internal": "bun test --isolate --max-concurrency=1",
+			"test:internal": "bun test --isolate --max-concurrency=1 --timeout=30000",
 			"test:e2e": "../../scripts/test.sh cli tests/e2e",
 			"test:watch:local": "bun test --watch",
 		});


### PR DESCRIPTION
Supersedes #1133 (which only patched two tests).

The CLI suite runs on a self-hosted runner sharing the box with other load. A whole batch of converge-heavy tests legitimately take 4–6s and brush bun's 5s default, flaking under load — not just the two long-known ones. Rather than annotate individual tests (whack-a-mole), set a single global `--timeout=30000` on `test:internal`, matching the `30_000` per-test convention already scattered across the suite.

Verified: 182 tests across the two previously-flaky files pass under the new timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)