### PR TITLE
feat(auth): add reversible platform suspensions

### DIFF
--- a/backend/alembic/versions/2e6a9c4f1b7d_clerk_principal_suspension.py
+++ b/backend/alembic/versions/2e6a9c4f1b7d_clerk_principal_suspension.py
@@ -1,0 +1,72 @@
+"""Add the independent reversible Clerk principal suspension fence.
+
+Revision ID: 2e6a9c4f1b7d
+Revises: d1a4e7c9b2f6
+Create Date: 2026-08-21 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "2e6a9c4f1b7d"
+down_revision: str | Sequence[str] | None = "d1a4e7c9b2f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "clerk_principal_suspensions",
+        sa.Column("issuer", sa.String(length=255), nullable=False),
+        sa.Column("subject", sa.String(length=200), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("suspended_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("reason", sa.String(length=191), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("issuer", "subject"),
+        sa.UniqueConstraint(
+            "user_id",
+            name="uq_clerk_principal_suspensions_user_id",
+        ),
+    )
+    op.create_index(
+        "ix_clerk_principal_suspensions_user_id",
+        "clerk_principal_suspensions",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    uncovered = bind.execute(
+        sa.text(
+            "SELECT count(*) FROM clerk_principal_suspensions AS suspension "
+            "WHERE NOT EXISTS ("
+            "SELECT 1 FROM principal_lifecycles AS lifecycle "
+            "WHERE lifecycle.issuer = suspension.issuer "
+            "AND lifecycle.subject = suspension.subject)"
+        )
+    ).scalar_one()
+    if uncovered:
+        raise RuntimeError("cannot downgrade while platform suspensions are active")
+    op.drop_index(
+        "ix_clerk_principal_suspensions_user_id",
+        table_name="clerk_principal_suspensions",
+    )
+    op.drop_table("clerk_principal_suspensions")

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -29,6 +29,7 @@ from app.services.clerk_backend import clerk_backend_headers, clerk_user_url
 from app.services.clerk_cli_oauth_settings import ClerkCliOAuthSetting
 from app.services.principal_lifecycle import (
     PrincipalIdentityConflictError,
+    PrincipalSuspendedError,
     PrincipalTerminatedError,
     assert_clerk_principal_active,
     assert_user_authority_active,
@@ -221,6 +222,9 @@ def invalidate_user_api_key_auth_cache(user_id: UUID) -> None:
 async def _assert_active_user_or_401(db: AsyncSession, user_id: UUID) -> None:
     try:
         await assert_user_authority_active(db, user_id)
+    except PrincipalSuspendedError:
+        invalidate_user_api_key_auth_cache(user_id)
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account is suspended") from None
     except PrincipalTerminatedError:
         invalidate_user_api_key_auth_cache(user_id)
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated") from None
@@ -366,6 +370,8 @@ async def _auth_via_dev_bypass(token: str, db: AsyncSession) -> AuthContext | No
     clerk_id = settings.dev_auth_clerk_id
     try:
         issuer = await assert_clerk_principal_active(db, subject=clerk_id)
+    except PrincipalSuspendedError:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account is suspended") from None
     except PrincipalTerminatedError:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated") from None
     if issuer is None:
@@ -679,6 +685,8 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
                     )
                 )
             ).scalar_one_or_none()
+    except PrincipalSuspendedError:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account is suspended") from None
     except PrincipalTerminatedError:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated") from None
     except PrincipalIdentityConflictError:
@@ -901,6 +909,8 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
             subject=clerk_id,
             issuer=issuer or None,
         )
+    except PrincipalSuspendedError:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account is suspended") from None
     except PrincipalTerminatedError:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated") from None
     await _assert_active_user_or_401(db, user.id)

--- a/backend/app/models/principal_lifecycle.py
+++ b/backend/app/models/principal_lifecycle.py
@@ -126,3 +126,25 @@ class ClerkPrincipalAuthority(Base, TimestampMixin):
     authority_updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     message_id: Mapped[str] = mapped_column(String(191), nullable=False)
     payload_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+
+
+class ClerkPrincipalSuspension(Base, TimestampMixin):
+    """Reversible platform suspension independent of Clerk plan features."""
+
+    __tablename__ = "clerk_principal_suspensions"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            name="uq_clerk_principal_suspensions_user_id",
+        ),
+    )
+
+    issuer: Mapped[str] = mapped_column(String(255), primary_key=True)
+    subject: Mapped[str] = mapped_column(String(200), primary_key=True)
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        index=True,
+    )
+    suspended_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    reason: Mapped[str] = mapped_column(String(191), nullable=False)

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -39,7 +39,11 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
-from app.core.auth import invalidate_api_key_auth_cache, require_admin_api_key
+from app.core.auth import (
+    invalidate_api_key_auth_cache,
+    invalidate_user_api_key_auth_cache,
+    require_admin_api_key,
+)
 from app.core.database import get_session
 from app.models.ai_provider import AiProvider, AiProviderAuthPayload
 from app.models.api_key import ApiKey
@@ -86,6 +90,8 @@ from app.schemas.admin import (
     AdminManagedAiProviderResponse,
     AdminManagedAiProviderUpsert,
     AdminPlatformWhatsAppPairingSessionCreate,
+    AdminPrincipalSuspensionResponse,
+    AdminPrincipalSuspensionUpdate,
     AdminRuntimeStateResponse,
     AdminRuntimeStateUpsert,
 )
@@ -192,6 +198,7 @@ from app.services.principal_lifecycle import (
     configured_clerk_issuer,
     load_clerk_user_for_issuer,
     resolve_clerk_owner_issuer,
+    set_clerk_principal_suspension,
 )
 from app.services.project_runtime_skills import (
     assert_agent_workspace_skill_write_compatible,
@@ -266,6 +273,68 @@ def _setting_enabled(value: JsonValue | None) -> bool | None:
         if isinstance(enabled, bool):
             return enabled
     return None
+
+
+@router.put(
+    "/auth/suspensions",
+    response_model=AdminPrincipalSuspensionResponse,
+)
+async def admin_set_principal_suspension(
+    body: AdminPrincipalSuspensionUpdate,
+    response: Response,
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+) -> AdminPrincipalSuspensionResponse:
+    """Idempotently set or clear the platform-owned authentication fence."""
+
+    _no_store(response)
+    try:
+        issuer = configured_clerk_issuer()
+        result = await set_clerk_principal_suspension(
+            db,
+            issuer=issuer,
+            subject=body.target_clerk_id,
+            suspended=body.suspended,
+            reason=body.reason,
+        )
+    except PrincipalLifecycleConfigurationError:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "Clerk principal issuer is not configured",
+        ) from None
+    except PrincipalTerminatedError:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "Principal has been terminated",
+        ) from None
+
+    record_control_plane_audit(
+        db,
+        actor_type="admin",
+        action=("principal.suspend" if body.suspended else "principal.unsuspend"),
+        resource_type="clerk_principal",
+        resource_id=body.target_clerk_id,
+        target_user_id=result.user_id,
+        source="api.admin",
+        details={
+            "issuer": issuer,
+            "reason": body.reason,
+            "changed": result.changed,
+        },
+    )
+    try:
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    if result.user_id is not None:
+        invalidate_user_api_key_auth_cache(result.user_id)
+    return AdminPrincipalSuspensionResponse(
+        target_clerk_id=body.target_clerk_id,
+        suspended=result.suspended,
+        suspended_at=result.suspended_at,
+        changed=result.changed,
+    )
 
 
 @router.get("/settings", response_model=AdminAppSettingListResponse)

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -133,6 +133,30 @@ class AdminApiKeyCreate(BaseModel):
     managed: bool = False
 
 
+class AdminPrincipalSuspensionUpdate(BaseModel):
+    """Set or clear the platform-owned Clerk principal fence."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_clerk_id: AdminClerkId
+    suspended: bool
+    reason: str = Field(min_length=1, max_length=191)
+
+    @field_validator("reason")
+    @classmethod
+    def _validate_reason(cls, value: str) -> str:
+        if value != value.strip() or not value.isprintable():
+            raise ValueError("reason must be a printable canonical value")
+        return value
+
+
+class AdminPrincipalSuspensionResponse(BaseModel):
+    target_clerk_id: AdminClerkId
+    suspended: bool
+    suspended_at: datetime | None
+    changed: bool
+
+
 class AdminRuntimeStateUpsert(BaseModel):
     """Hosted runtime desired state written by the SaaS deploy orchestrator.
 

--- a/backend/app/services/principal_lifecycle.py
+++ b/backend/app/services/principal_lifecycle.py
@@ -31,6 +31,7 @@ from app.models.device_authorization import DeviceAuthorization
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.principal_lifecycle import (
     ClerkPrincipalAuthority,
+    ClerkPrincipalSuspension,
     ClerkWebhookEventReceipt,
     PrincipalLifecycle,
 )
@@ -55,6 +56,10 @@ from app.services.runtime_observation import retire_runtime_environment
 
 
 class PrincipalTerminatedError(RuntimeError):
+    pass
+
+
+class PrincipalSuspendedError(PrincipalTerminatedError):
     pass
 
 
@@ -106,6 +111,14 @@ class ClaimedPrincipalCleanup:
     lifecycle_id: UUID
     claim_id: str
     attempt_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class PrincipalSuspensionResult:
+    user_id: UUID | None
+    suspended: bool
+    suspended_at: datetime | None
+    changed: bool
 
 
 def configured_clerk_issuer() -> str:
@@ -171,7 +184,7 @@ async def assert_clerk_principal_active(
         # compatibility path, but a configuration change must never hide a
         # fence that was already persisted under a previously configured
         # issuer.
-        lifecycle = (
+        lifecycle_issuer = (
             await db.execute(
                 select(PrincipalLifecycle.issuer)
                 .where(
@@ -181,14 +194,30 @@ async def assert_clerk_principal_active(
                 .limit(1)
             )
         ).scalar_one_or_none()
-        if lifecycle is not None:
+        if lifecycle_issuer is not None:
             if lock:
                 await lock_clerk_principal_shared(
                     db,
-                    issuer=lifecycle,
+                    issuer=lifecycle_issuer,
                     subject=subject,
                 )
             raise PrincipalTerminatedError("principal has been terminated")
+        suspension_issuer = (
+            await db.execute(
+                select(ClerkPrincipalSuspension.issuer)
+                .where(ClerkPrincipalSuspension.subject == subject)
+                .order_by(ClerkPrincipalSuspension.issuer)
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if suspension_issuer is not None:
+            if lock:
+                await lock_clerk_principal_shared(
+                    db,
+                    issuer=suspension_issuer,
+                    subject=subject,
+                )
+            raise PrincipalSuspendedError("principal is suspended")
         return None
     if lock:
         await lock_clerk_principal_shared(db, issuer=resolved_issuer, subject=subject)
@@ -200,6 +229,14 @@ async def assert_clerk_principal_active(
     )
     if lifecycle_id is not None:
         raise PrincipalTerminatedError("principal has been terminated")
+    suspended = await db.scalar(
+        select(ClerkPrincipalSuspension.subject).where(
+            ClerkPrincipalSuspension.issuer == resolved_issuer,
+            ClerkPrincipalSuspension.subject == subject,
+        )
+    )
+    if suspended is not None:
+        raise PrincipalSuspendedError("principal is suspended")
     banned = await db.scalar(
         select(ClerkPrincipalAuthority.banned).where(
             ClerkPrincipalAuthority.issuer == resolved_issuer,
@@ -207,7 +244,7 @@ async def assert_clerk_principal_active(
         )
     )
     if banned is True:
-        raise PrincipalTerminatedError("principal is suspended")
+        raise PrincipalSuspendedError("principal is suspended")
     return resolved_issuer
 
 
@@ -276,9 +313,36 @@ async def assert_user_authority_active(
                 ClerkPrincipalAuthority.banned.is_(True),
             )
             .exists(),
+            ~select(ClerkPrincipalSuspension.subject)
+            .where(
+                or_(
+                    ClerkPrincipalSuspension.user_id == User.id,
+                    and_(
+                        ClerkPrincipalSuspension.issuer == User.clerk_issuer,
+                        ClerkPrincipalSuspension.subject == User.clerk_id,
+                    ),
+                )
+            )
+            .exists(),
         )
     )
     if active_id is None:
+        suspended = await db.scalar(
+            select(ClerkPrincipalSuspension.subject)
+            .join(
+                User,
+                or_(
+                    ClerkPrincipalSuspension.user_id == User.id,
+                    and_(
+                        ClerkPrincipalSuspension.issuer == User.clerk_issuer,
+                        ClerkPrincipalSuspension.subject == User.clerk_id,
+                    ),
+                ),
+            )
+            .where(User.id == user_id)
+        )
+        if suspended is not None:
+            raise PrincipalSuspendedError("user authority is suspended")
         raise PrincipalTerminatedError("user authority is disabled")
 
 
@@ -386,6 +450,124 @@ async def load_clerk_user_for_issuer(
     if bind_legacy and user.clerk_issuer is None:
         user.clerk_issuer = issuer
     return user
+
+
+def _validate_suspension_reason(reason: str) -> None:
+    if not reason or len(reason) > 191 or reason != reason.strip() or not reason.isprintable():
+        raise ValueError("suspension reason must be a printable canonical value")
+
+
+async def set_clerk_principal_suspension(
+    db: AsyncSession,
+    *,
+    issuer: str,
+    subject: str,
+    suspended: bool,
+    reason: str,
+    now: datetime | None = None,
+) -> PrincipalSuspensionResult:
+    """Set the independent platform fence without provisioning or cleanup."""
+
+    if issuer != configured_clerk_issuer():
+        raise PrincipalIdentityConflictError("principal issuer is not accepted")
+    _validate_suspension_reason(reason)
+    current_time = now or datetime.now(UTC)
+    if current_time.tzinfo is None or current_time.utcoffset() is None:
+        raise ValueError("suspension timestamp must be timezone-aware")
+
+    await lock_clerk_principal(db, issuer=issuer, subject=subject)
+    terminated = await db.scalar(
+        select(PrincipalLifecycle.id).where(
+            PrincipalLifecycle.issuer == issuer,
+            PrincipalLifecycle.subject == subject,
+        )
+    )
+    if terminated is not None and suspended:
+        raise PrincipalTerminatedError("principal has been terminated")
+
+    record = (
+        await db.execute(
+            select(ClerkPrincipalSuspension)
+            .where(
+                ClerkPrincipalSuspension.issuer == issuer,
+                ClerkPrincipalSuspension.subject == subject,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+
+    if not suspended:
+        if record is None:
+            return PrincipalSuspensionResult(
+                user_id=None,
+                suspended=False,
+                suspended_at=None,
+                changed=False,
+            )
+        user_id = record.user_id
+        if user_id is None:
+            user = await load_clerk_user_for_issuer(
+                db,
+                issuer=issuer,
+                subject=subject,
+                bind_legacy=False,
+                allow_issuer_mismatch=True,
+            )
+            user_id = user.id if user is not None else None
+        if user_id is not None:
+            await lock_user_authority(db, user_id)
+        await db.delete(record)
+        await db.flush()
+        return PrincipalSuspensionResult(
+            user_id=user_id,
+            suspended=False,
+            suspended_at=None,
+            changed=True,
+        )
+
+    user = await load_clerk_user_for_issuer(
+        db,
+        issuer=issuer,
+        subject=subject,
+        bind_legacy=False,
+        allow_issuer_mismatch=True,
+    )
+    user_id = user.id if user is not None else None
+    authority_user_ids: set[UUID] = set()
+    if record is not None and record.user_id is not None:
+        authority_user_ids.add(record.user_id)
+    if user_id is not None:
+        authority_user_ids.add(user_id)
+    for authority_user_id in sorted(authority_user_ids, key=str):
+        await lock_user_authority(db, authority_user_id)
+    if record is None:
+        record = ClerkPrincipalSuspension(
+            issuer=issuer,
+            subject=subject,
+            user_id=user_id,
+            suspended_at=current_time,
+            reason=reason,
+        )
+        db.add(record)
+        await db.flush()
+        return PrincipalSuspensionResult(
+            user_id=user_id,
+            suspended=True,
+            suspended_at=current_time,
+            changed=True,
+        )
+
+    changed = record.reason != reason or record.user_id != user_id
+    record.reason = reason
+    record.user_id = user_id
+    if changed:
+        await db.flush()
+    return PrincipalSuspensionResult(
+        user_id=user_id,
+        suspended=True,
+        suspended_at=record.suspended_at,
+        changed=changed,
+    )
 
 
 async def fence_clerk_user_deleted(
@@ -943,6 +1125,8 @@ __all__ = [
     "PrincipalDeletionReceipt",
     "PrincipalIdentityConflictError",
     "PrincipalLifecycleConfigurationError",
+    "PrincipalSuspendedError",
+    "PrincipalSuspensionResult",
     "PrincipalTerminatedError",
     "PrincipalWebhookConflictError",
     "assert_clerk_principal_active",
@@ -957,4 +1141,5 @@ __all__ = [
     "project_clerk_user_authority",
     "resolve_clerk_owner_issuer",
     "record_principal_cleanup_failure",
+    "set_clerk_principal_suspension",
 ]

--- a/backend/tests/test_principal_suspension.py
+++ b/backend/tests/test_principal_suspension.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import func, select
+
+from app.core.config import settings
+from app.models.api_key import ApiKey
+from app.models.audit import ControlPlaneAuditEvent
+from app.models.principal_lifecycle import (
+    ClerkPrincipalAuthority,
+    ClerkPrincipalSuspension,
+    PrincipalLifecycle,
+)
+from app.models.session import AgentEnvironment
+from app.models.user import User
+from app.services.api_key import mint_api_key
+from app.services.principal_lifecycle import (
+    PrincipalSuspendedError,
+    PrincipalTerminatedError,
+    assert_clerk_principal_active,
+    assert_user_authority_active,
+    fence_clerk_user_deleted,
+    project_clerk_user_authority,
+    set_clerk_principal_suspension,
+)
+from app.services.user_provisioning import lazy_create_user_with_personal_project
+from tests.conftest import create_env_with_project, create_test_hosted_runtime_state
+
+pytestmark = pytest.mark.asyncio
+
+_ISSUER = "https://platform-suspension.clerk.example.test"
+_ADMIN_KEY = "platform-suspension-admin-test"
+_AUTH = {"X-Admin-Key": _ADMIN_KEY}
+
+
+@pytest.fixture(autouse=True)
+def _suspension_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "clerk_jwt_issuer", _ISSUER)
+    monkeypatch.setattr(settings, "admin_api_key", _ADMIN_KEY)
+
+
+async def _set_suspension(
+    client,
+    *,
+    subject: str,
+    suspended: bool,
+    reason: str,
+):
+    return await client.put(
+        "/v1/admin/auth/suspensions",
+        headers=_AUTH,
+        json={
+            "target_clerk_id": subject,
+            "suspended": suspended,
+            "reason": reason,
+        },
+    )
+
+
+async def test_api_keys_are_denied_and_recover_without_credential_mutation(
+    anon_client,
+    db_session,
+    seed_user,
+) -> None:
+    environment = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"suspension-runtime-{uuid.uuid4().hex}",
+        machine_name="Suspension runtime",
+    )
+    runtime_state = await create_test_hosted_runtime_state(
+        db_session,
+        environment,
+        runtime_name="openclaw",
+    )
+    normal_key = await mint_api_key(
+        db_session,
+        user_id=seed_user.id,
+        label="suspension-normal",
+        commit=True,
+    )
+    runtime_key = await mint_api_key(
+        db_session,
+        user_id=seed_user.id,
+        label="suspension-runtime",
+        environment_id=environment.id,
+        runtime_deployment_id=runtime_state.deployment_id,
+        managed=True,
+        commit=True,
+    )
+    keys = (normal_key, runtime_key)
+    for key in keys:
+        response = await anon_client.get(
+            "/v1/auth/me",
+            headers={"Authorization": f"Bearer {key.raw_key}"},
+        )
+        assert response.status_code == 200, response.text
+
+    suspended = await _set_suspension(
+        anon_client,
+        subject=seed_user.clerk_id,
+        suspended=True,
+        reason="security_review",
+    )
+    assert suspended.status_code == 200, suspended.text
+    assert suspended.headers["cache-control"] == "no-store, private"
+    assert suspended.json()["changed"] is True
+    for key in keys:
+        response = await anon_client.get(
+            "/v1/auth/me",
+            headers={"Authorization": f"Bearer {key.raw_key}"},
+        )
+        assert response.status_code == 401, response.text
+        assert response.json() == {"detail": "Account is suspended"}
+
+    persisted_keys = list(
+        await db_session.scalars(select(ApiKey).where(ApiKey.user_id == seed_user.id))
+    )
+    assert {key.id for key in persisted_keys} >= {
+        normal_key.api_key.id,
+        runtime_key.api_key.id,
+    }
+    assert all(key.revoked_at is None for key in persisted_keys)
+    assert await db_session.get(User, seed_user.id) is not None
+    assert await db_session.get(AgentEnvironment, environment.id) is not None
+
+    restored = await _set_suspension(
+        anon_client,
+        subject=seed_user.clerk_id,
+        suspended=False,
+        reason="security_review_complete",
+    )
+    assert restored.status_code == 200, restored.text
+    assert restored.headers["cache-control"] == "no-store, private"
+    assert restored.json() == {
+        "target_clerk_id": seed_user.clerk_id,
+        "suspended": False,
+        "suspended_at": None,
+        "changed": True,
+    }
+    for key in keys:
+        response = await anon_client.get(
+            "/v1/auth/me",
+            headers={"Authorization": f"Bearer {key.raw_key}"},
+        )
+        assert response.status_code == 200, response.text
+
+    audit_events = list(
+        await db_session.scalars(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.resource_type == "clerk_principal",
+                ControlPlaneAuditEvent.resource_id == seed_user.clerk_id,
+            )
+        )
+    )
+    events_by_action = {event.action: event for event in audit_events}
+    assert set(events_by_action) == {"principal.suspend", "principal.unsuspend"}
+    assert events_by_action["principal.suspend"].details["reason"] == "security_review"
+    assert events_by_action["principal.unsuspend"].details["reason"] == "security_review_complete"
+    assert all(event.target_user_id == seed_user.id for event in audit_events)
+
+
+async def test_prelogin_subject_fence_is_idempotent_and_never_provisions_user(
+    anon_client,
+    db_session,
+) -> None:
+    subject = f"prelogin_{uuid.uuid4().hex}"
+    first = await _set_suspension(
+        anon_client,
+        subject=subject,
+        suspended=True,
+        reason="prelogin_review",
+    )
+    repeated = await _set_suspension(
+        anon_client,
+        subject=subject,
+        suspended=True,
+        reason="prelogin_review",
+    )
+    assert first.status_code == repeated.status_code == 200
+    assert first.json()["changed"] is True
+    assert repeated.json()["changed"] is False
+    assert repeated.json()["suspended_at"] == first.json()["suspended_at"]
+    assert (
+        await db_session.scalar(
+            select(func.count(ClerkPrincipalSuspension.subject)).where(
+                ClerkPrincipalSuspension.issuer == _ISSUER,
+                ClerkPrincipalSuspension.subject == subject,
+            )
+        )
+        == 1
+    )
+    assert await db_session.scalar(select(User.id).where(User.clerk_id == subject)) is None
+
+    with pytest.raises(HTTPException) as error:
+        await lazy_create_user_with_personal_project(
+            db_session,
+            clerk_id=subject,
+            clerk_issuer=_ISSUER,
+            email=None,
+            name=None,
+            race_loser_status=500,
+        )
+    assert error.value.status_code == 403
+    await db_session.rollback()
+
+    invalid = await _set_suspension(
+        anon_client,
+        subject=f"invalid_{uuid.uuid4().hex}",
+        suspended=True,
+        reason=" padded ",
+    )
+    assert invalid.status_code == 422
+
+    cleared = await _set_suspension(
+        anon_client,
+        subject=subject,
+        suspended=False,
+        reason="prelogin_review_complete",
+    )
+    repeated_clear = await _set_suspension(
+        anon_client,
+        subject=subject,
+        suspended=False,
+        reason="prelogin_review_complete",
+    )
+    assert cleared.status_code == repeated_clear.status_code == 200
+    assert cleared.json()["changed"] is True
+    assert repeated_clear.json()["changed"] is False
+    assert await db_session.get(ClerkPrincipalSuspension, (_ISSUER, subject)) is None
+    assert await db_session.scalar(select(User.id).where(User.clerk_id == subject)) is None
+
+
+async def test_clerk_unban_projection_cannot_clear_platform_suspension(
+    db_session,
+    seed_user,
+) -> None:
+    user_id = seed_user.id
+    await set_clerk_principal_suspension(
+        db_session,
+        issuer=_ISSUER,
+        subject=seed_user.clerk_id,
+        suspended=True,
+        reason="independent_projection",
+    )
+    observed_at = datetime(2026, 8, 21, tzinfo=UTC)
+    await project_clerk_user_authority(
+        db_session,
+        issuer=_ISSUER,
+        subject=seed_user.clerk_id,
+        banned=True,
+        authority_updated_at=observed_at,
+        message_id=f"msg_{uuid.uuid4().hex}",
+        payload_sha256="a" * 64,
+    )
+    await project_clerk_user_authority(
+        db_session,
+        issuer=_ISSUER,
+        subject=seed_user.clerk_id,
+        banned=False,
+        authority_updated_at=observed_at + timedelta(seconds=1),
+        message_id=f"msg_{uuid.uuid4().hex}",
+        payload_sha256="b" * 64,
+    )
+    await db_session.commit()
+
+    projection = await db_session.scalar(
+        select(ClerkPrincipalAuthority).where(
+            ClerkPrincipalAuthority.issuer == _ISSUER,
+            ClerkPrincipalAuthority.subject == seed_user.clerk_id,
+        )
+    )
+    assert projection is not None and projection.banned is False
+    assert (
+        await db_session.get(
+            ClerkPrincipalSuspension,
+            (_ISSUER, seed_user.clerk_id),
+        )
+        is not None
+    )
+    with pytest.raises(PrincipalSuspendedError):
+        await assert_clerk_principal_active(
+            db_session,
+            issuer=_ISSUER,
+            subject=seed_user.clerk_id,
+        )
+    await db_session.rollback()
+    with pytest.raises(PrincipalSuspendedError):
+        await assert_user_authority_active(db_session, user_id)
+
+
+async def test_deletion_dominates_suspension_and_unban_only_removes_fence(
+    anon_client,
+    db_session,
+) -> None:
+    subject = f"deleted_{uuid.uuid4().hex}"
+    assert (
+        await _set_suspension(
+            anon_client,
+            subject=subject,
+            suspended=True,
+            reason="pending_deletion",
+        )
+    ).status_code == 200
+    receipt = await fence_clerk_user_deleted(
+        db_session,
+        issuer=_ISSUER,
+        subject=subject,
+        message_id=f"msg_{uuid.uuid4().hex}",
+        payload_sha256="c" * 64,
+        event_occurred_at=datetime.now(UTC),
+    )
+    await db_session.commit()
+    assert receipt.user_id is None
+
+    cleared = await _set_suspension(
+        anon_client,
+        subject=subject,
+        suspended=False,
+        reason="deletion_is_authoritative",
+    )
+    assert cleared.status_code == 200, cleared.text
+    assert cleared.json()["changed"] is True
+    assert await db_session.get(ClerkPrincipalSuspension, (_ISSUER, subject)) is None
+    assert await db_session.scalar(select(User.id).where(User.clerk_id == subject)) is None
+    assert (
+        await db_session.scalar(
+            select(PrincipalLifecycle.id).where(
+                PrincipalLifecycle.issuer == _ISSUER,
+                PrincipalLifecycle.subject == subject,
+            )
+        )
+        is not None
+    )
+
+    with pytest.raises(PrincipalTerminatedError) as error:
+        await assert_clerk_principal_active(
+            db_session,
+            issuer=_ISSUER,
+            subject=subject,
+        )
+    assert type(error.value) is PrincipalTerminatedError
+    await db_session.rollback()
+
+    rejected = await _set_suspension(
+        anon_client,
+        subject=subject,
+        suspended=True,
+        reason="must_not_resurrect",
+    )
+    assert rejected.status_code == 409
+    assert await db_session.get(ClerkPrincipalSuspension, (_ISSUER, subject)) is None
+    assert await db_session.scalar(select(User.id).where(User.clerk_id == subject)) is None

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -13,6 +13,12 @@ and reversibly gates all Clawdi authentication, including API keys;
 `user.deleted` remains an irreversible tombstone followed by cleanup. Session,
 organization, messaging, and billing webhooks are intentionally unsupported.
 
+The platform-owned `PUT /v1/admin/auth/suspensions` fence is independent of
+that Clerk `banned` projection. It accepts a Clerk subject before first login,
+preserves all account resources and credentials, and clearing it only removes
+the platform fence; it neither changes Clerk authority nor recreates a deleted
+principal.
+
 Set `CLERK_WEBHOOK_SIGNING_SECRET`, `CLERK_SECRET_KEY`, and
 `CLERK_JWT_ISSUER`. Backend API calls use the pinned Clerk API version
 `2026-05-12`.


### PR DESCRIPTION
## Summary

- add an issuer-scoped, reversible platform suspension fence independent of Clerk plan features
- reject suspended principals across Clerk JWT, CLI OAuth, normal API keys, and runtime API keys
- add an idempotent, audited admin API to suspend or unsuspend without deleting users, credentials, sessions, agents, or data
- keep irreversible Clerk deletion tombstones dominant and prevent Clerk `banned=false` projections from clearing platform suspensions

## Verification

- `TEST_RUNNER_IMAGE=clawdi-admin-suspension-check scripts/test.sh backend tests/test_principal_suspension.py tests/test_clerk_webhook.py tests/test_auth_keys.py tests/test_cli_oauth_auth.py` (67 passed)
- post-rebase: `TEST_RUNNER_IMAGE=clawdi-admin-suspension-check CLAWDI_TEST_RUNNER_SKIP_BUILD=1 scripts/test.sh backend tests/test_principal_suspension.py` (4 passed)
- fresh PostgreSQL migration reaches Alembic head `2e6a9c4f1b7d`
- Docker Ruff, format check, BasedPyright, compileall, and `git diff --check` passed

## Release impact

Backend migration and runtime image deployment required. The migration is additive. Unsuspending removes only the platform fence; it does not restore deleted resources or mutate credentials.
