### PR TITLE
test(runtime): refresh observation freeze baseline

### DIFF
--- a/backend/tests/fixtures/v1_runtime_observation_baseline.json
+++ b/backend/tests/fixtures/v1_runtime_observation_baseline.json
@@ -44,7 +44,7 @@
 			}
 		},
 		"backend/app/schemas/runtime_observed.py": {
-			"whole_file_sha256": "7272efb1be898bf83d704a5bb8c40c65ce9fb61fb6bbfb1c1698a325a0e1c5d2"
+			"whole_file_sha256": "cc515ac8b1d3daf548d3ff1c7e4c6aa8f9d760362b15076d0c00865ea8d20288"
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- refresh the byte-freeze hash after the intentional runtime observation schema change in #1128

## Verification
- `scripts/test.sh backend tests/test_v1_runtime_observation_byte_freeze.py::test_v1_runtime_observation_production_bytes_match_repository_baseline`
- `git diff --check`