### PR TITLE
refactor(cli): streamline runtime manifest reconciliation

### DIFF
--- a/packages/cli/src/runtime/hosted-agent-plugin-package.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-package.ts
@@ -24,7 +24,11 @@ import {
 	parseCanonicalGithubRepositoryUrl,
 	readBoundedResponseBytes,
 } from "../lib/github-skill-archive";
-import { AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR, type RuntimeManifest } from "./manifest-contract";
+import {
+	AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR,
+	HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
+	type RuntimeManifest,
+} from "./manifest-contract";
 import {
 	AGENT_PLUGINS_SCHEMA_1_0_0,
 	agentPluginNameSchema,
@@ -1144,7 +1148,8 @@ export async function prepareHostedAgentPluginPackages(
 	options: { fetcher?: GithubArchiveFetcher; offline?: boolean } = {},
 ): Promise<PreparedHostedAgentPlugins | null> {
 	const desiredInstallations = manifest.projection?.agentPlugins?.installations ?? {};
-	const isHostedV2 = manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2";
+	const isHostedV2 =
+		manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION;
 	if (!isHostedV2) {
 		if (Object.keys(desiredInstallations).length > 0) {
 			throw new Error(AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR);

--- a/packages/cli/src/runtime/hosted-openclaw-context.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-context.ts
@@ -9,7 +9,7 @@ import {
 	resolveOpenClawSdkExport,
 } from "../lib/codex-oauth-native-store";
 import { agentTargetProjectionInput, hostedAiProviderCatalog } from "./hosted-provider-resolution";
-import type { RuntimeManifest } from "./manifest-contract";
+import { HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION, type RuntimeManifest } from "./manifest-contract";
 import { runtimeUserDirectoryOwnership } from "./runtime-user-command";
 
 export const CLAWDI_MANAGED_OPENCLAW_PROVIDER_PLUGIN_ID = "clawdi-managed-provider";
@@ -49,7 +49,7 @@ export function createOpenClawHostedContext(manifest: RuntimeManifest, home: str
 	const installDir = statePath("extensions", CLAWDI_MANAGED_OPENCLAW_PROVIDER_PLUGIN_ID);
 	const sdk = resolveSdkExports(home);
 	const ownership =
-		manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2" &&
+		manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION &&
 		manifest.runtimes.openclaw?.enabled === true
 			? [
 					...runtimeUserDirectoryOwnership(home),
@@ -100,7 +100,7 @@ function hasManagedApiKeyProjection(manifest: RuntimeManifest): boolean {
 		(entry) => entry.id === CLAWDI_MANAGED_PROVIDER_ID,
 	);
 	return (
-		manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2" &&
+		manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION &&
 		runtime?.enabled === true &&
 		runtime.providerMode === "configured" &&
 		sourceProvider?.managed_by === "clawdi" &&

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -15,6 +15,7 @@ import {
 import { canonicalSecretRefName, canonicalSecretRefSchema } from "./secret-values";
 
 export const RUNTIME_DESIRED_STATE_SCHEMA_VERSION = "clawdi.runtimeDesiredState.v1";
+export const HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION = "clawdi.hosted-runtime.bundle.v2";
 
 // Temporary v1 read compatibility. Runtime providers and generated config stay canonical-only.
 export const LEGACY_HOSTED_CODEX_MANAGED_RUNTIME_ENV = "OPENAI_API_KEY";
@@ -392,7 +393,7 @@ const liveSyncSchema = z.object({
 
 const runtimeProjectionSchema = z.object({
 	sourceSchemaVersion: z.string().min(1).optional(),
-	sourceBundleVersion: z.literal("clawdi.hosted-runtime.bundle.v2").optional(),
+	sourceBundleVersion: z.literal(HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION).optional(),
 	system: z.unknown().nullable().optional(),
 	providers: z.record(z.string().min(1), z.unknown()).optional(),
 	channels: z.record(z.string().min(1), z.unknown()).optional(),

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -5087,7 +5087,7 @@ echo spawned > '${installerLog}'
 		).toEqual([]);
 	});
 
-	test("runs the official latest OpenClaw installer with a sanitized environment", () => {
+	test("runs the official latest OpenClaw installer with a sanitized environment and timeout", () => {
 		const paths = tempRuntimePaths();
 		const home = paths.userHome;
 		const commandPath = join(home, ".local", "bin", "openclaw");
@@ -5161,6 +5161,7 @@ cp '${commandFixturePath}' '${commandPath}'
 		});
 		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
 		process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER = `file://${installerPath}`;
+		process.env.CLAWDI_RUNTIME_INSTALL_TIMEOUT = "invalid";
 
 		const install = {
 			authority: "official" as const,
@@ -5182,10 +5183,21 @@ cp '${commandFixturePath}' '${commandPath}'
 		);
 
 		writeFileSync(installerResultPath, `${installedVersion}\n`);
-		const converged = convergeRuntimeManifest(load, paths, {
-			executeOfficialServiceInstallers: false,
-		});
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		let converged: ReturnType<typeof convergeRuntimeManifest>;
+		try {
+			console.warn = (message) => warnings.push(String(message));
+			converged = convergeRuntimeManifest(load, paths, {
+				executeOfficialServiceInstallers: false,
+			});
+		} finally {
+			console.warn = originalWarn;
+		}
 		expect(converged.installErrors).toEqual([]);
+		expect(warnings).toEqual([
+			"CLAWDI_RUNTIME_INSTALL_TIMEOUT must be a valid positive integer; using 1800000ms",
+		]);
 		expect(execFileSync(commandPath, ["--version"], { encoding: "utf8" }).trim()).toBe(
 			`OpenClaw ${installedVersion}`,
 		);

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -5208,6 +5208,11 @@ cp '${commandFixturePath}' '${commandPath}'
 			String(expectedArgs.length),
 			...expectedArgs,
 		]);
+		const inventory = JSON.parse(
+			readFileSync(join(paths.installInventory, "openclaw.json"), "utf8"),
+		) as Record<string, unknown>;
+		expect(inventory.installerArgs).toEqual(expectedArgs);
+		expect(inventory).not.toHaveProperty("command");
 		expect(expectedArgs).not.toContain("--version");
 	});
 

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -480,6 +480,87 @@ describe("runtime manifest services", () => {
 		}
 	});
 
+	test("restarts OpenClaw after repairing managed channel config drift", () => {
+		const paths = tempRuntimePaths();
+		const command = join(paths.userHome, ".local", "bin", "openclaw");
+		const configPath = join(paths.userHome, ".openclaw", "openclaw.json");
+		const patchPath = join(paths.runRoot, "openclaw-config-patch.json");
+		const unitPath = join(paths.systemdUserRoot, "openclaw-gateway.service");
+		mkdirSync(dirname(command), { recursive: true });
+		mkdirSync(dirname(configPath), { recursive: true });
+		writeFileSync(configPath, "{}\n");
+		writeFileSync(
+			command,
+			`#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  "--version") printf '%s\n' 'OpenClaw 2026.7.29' ;;
+  "config patch --stdin"*)
+    cat > '${patchPath}'
+    '${process.execPath}' - '${configPath}' '${patchPath}' <<'NODE'
+const fs = require("node:fs");
+const [configPath, patchPath] = process.argv.slice(2);
+const current = JSON.parse(fs.readFileSync(configPath, "utf8"));
+const patch = JSON.parse(fs.readFileSync(patchPath, "utf8"));
+const isRecord = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
+const merge = (currentValue, patchValue) => {
+  if (!isRecord(patchValue)) return patchValue;
+  const next = isRecord(currentValue) ? { ...currentValue } : {};
+  for (const [key, value] of Object.entries(patchValue)) {
+    if (value === null) delete next[key];
+    else next[key] = merge(next[key], value);
+  }
+  return next;
+};
+fs.writeFileSync(configPath, JSON.stringify(merge(current, patch)) + "\\n");
+NODE
+    ;;
+  "gateway install --force --json"|"gateway install --force"|"gateway install")
+    mkdir -p '${dirname(unitPath)}'
+    printf '%s\n' '[Service]' 'ExecStart=openclaw gateway run' > '${unitPath}'
+    ;;
+  *) exit 0 ;;
+esac
+`,
+		);
+		chmodSync(command, 0o700);
+		const manifest = installGateManifest(paths, "openclaw", command);
+		manifest.projection = { channels: { telegram: { enabled: true } } };
+		const load: RuntimeManifestLoad = {
+			manifest,
+			source: "remote-datasource",
+			sourcePath: "inline-openclaw-channel-drift",
+			offline: false,
+		};
+		const restartSignals: string[][] = [];
+		const converge = () =>
+			convergeRuntimeManifest(load, paths, {
+				systemdApply: {
+					activateEgressPrerequisite: () => ({
+						applied: true,
+						systemUnitsChanged: [],
+						userUnitsChanged: [],
+					}),
+					activate: (signal) => {
+						restartSignals.push(signal.restartUserUnits);
+						return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
+					},
+					quiesce: () => undefined,
+					rollback: () => undefined,
+				},
+			});
+
+		expect(converge().installErrors).toEqual([]);
+		expect(converge().installErrors).toEqual([]);
+		expect(restartSignals.at(-1)).toEqual([]);
+		const config = JSON.parse(readFileSync(configPath, "utf8")) as Record<string, unknown>;
+		delete config.channels;
+		writeFileSync(configPath, `${JSON.stringify(config)}\n`);
+
+		expect(converge().installErrors).toEqual([]);
+		expect(restartSignals.at(-1)).toEqual(["openclaw-gateway.service"]);
+	});
+
 	test("renders systemd runtime services without creating user command shims", () => {
 		const paths = tempRuntimePaths();
 		process.env.PATH = `${dirname(paths.cliManagedBin)}:${process.env.PATH ?? ""}`;

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -19,6 +19,7 @@ import {
 } from "./hosted-egress-profiles";
 import {
 	AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR,
+	HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
 	type HostedRuntimeBundleV2Manifest,
 	type HostedRuntimeManifest,
 	hasUnsupportedAgentPluginInstallations,
@@ -111,7 +112,7 @@ export type RuntimeBundleChannelBinding = z.infer<typeof runtimeBundleChannelBin
 
 const hostedRuntimeBundleV2Schema = z
 	.object({
-		schemaVersion: z.literal("clawdi.hosted-runtime.bundle.v2"),
+		schemaVersion: z.literal(HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION),
 		sourceRevision: z.string().regex(/^[a-f0-9]{64}$/),
 		manifest: hostedRuntimeBundleV2ManifestSchema,
 		applyGeneration: z.number().int().positive().safe().optional(),
@@ -141,7 +142,7 @@ function markHostedRuntimeBundleV2(manifest: RuntimeManifest): RuntimeManifest {
 		...manifest,
 		projection: {
 			...(manifest.projection ?? {}),
-			sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
+			sourceBundleVersion: HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
 		},
 	};
 }
@@ -469,7 +470,7 @@ export function hostedManifestToRuntimeManifest(
 		hermesDashboardAuth: hosted.system.hermesDashboardAuth,
 		projection: {
 			sourceSchemaVersion: hosted.schemaVersion,
-			sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
+			sourceBundleVersion: HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
 			system: hosted.system,
 			providers: hosted.providers,
 			...(hosted.mcp === undefined ? {} : { mcp: hosted.mcp }),
@@ -545,7 +546,7 @@ function validateManifestSemantics(
 	const errors: string[] = [];
 	const isHostedV2 =
 		trustDomain === "hosted" &&
-		manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2";
+		manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION;
 	const expiryError = manifestExpiryError(manifest);
 	if (expiryError) errors.push(expiryError);
 	if (!isAbsolute(paths.userHome)) errors.push(`runtime HOME must be absolute: ${paths.userHome}`);
@@ -729,7 +730,7 @@ function loadLastGoodManifest(
 		const appliedState = readRuntimeAppliedState(paths);
 		const cachedApplyIdentity = appliedState ? runtimeAppliedApplyIdentity(appliedState) : null;
 		const strictV2Cache =
-			manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2";
+			manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION;
 		if (
 			opts.requireOfflineBoot &&
 			(strictV2Cache || cachedApplyIdentity !== null) &&

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1050,6 +1050,18 @@ function runtimeAppRoot(name: string, home: string): string | null {
 
 const HERMES_DASHBOARD_CAPABILITY_PROBE =
 	"import uvicorn; assert callable(getattr(uvicorn.Server, 'capture_signals', None))";
+const DEFAULT_RUNTIME_INSTALL_TIMEOUT_MS = 30 * 60 * 1000;
+
+function runtimeInstallTimeoutMs(): number {
+	const raw = process.env.CLAWDI_RUNTIME_INSTALL_TIMEOUT;
+	if (raw === undefined) return DEFAULT_RUNTIME_INSTALL_TIMEOUT_MS;
+	const timeout = Number(raw);
+	if (Number.isSafeInteger(timeout) && timeout > 0 && timeout <= 0x7fffffff) return timeout;
+	console.warn(
+		`CLAWDI_RUNTIME_INSTALL_TIMEOUT must be a valid positive integer; using ${DEFAULT_RUNTIME_INSTALL_TIMEOUT_MS}ms`,
+	);
+	return DEFAULT_RUNTIME_INSTALL_TIMEOUT_MS;
+}
 
 function hermesDashboardCapabilityError(
 	name: string,
@@ -1259,7 +1271,7 @@ function runOfficialInstaller(name: string, install: RuntimeInstall): RuntimeIns
 			cwd: install.home,
 			env: execution.env,
 			encoding: "utf8",
-			timeout: Number.parseInt(process.env.CLAWDI_RUNTIME_INSTALL_TIMEOUT ?? "1800000", 10),
+			timeout: runtimeInstallTimeoutMs(),
 		});
 		const exitCode = result.status ?? 1;
 		const installed = exitCode === 0 && executableExists(commandPath);

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -160,6 +160,7 @@ import {
 import {
 	AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR,
 	AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR,
+	HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
 	hasUnsupportedAgentPluginInstallations,
 	isHostedCodexManagedRuntimeEnv,
 	type LiveSyncAgent,
@@ -1517,7 +1518,7 @@ function applyHostedRuntimeConfigProjection(
 	if (runtime === "hermes") {
 		const auth = manifest.hermesDashboardAuth;
 		const managesWorkspace =
-			manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2";
+			manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION;
 		if (!auth && !locale && !managesWorkspace) return null;
 		const context = hermesConfigContext(observation, home, workspaceRoot);
 		const hermesHome = join(home, ".hermes");
@@ -3154,7 +3155,8 @@ function openClawGatewayHostedPatch(
 	const gatewayToken = manifest.openclawGatewayAuth
 		? runtimeSecretValue(secretValues ?? {}, manifest.openclawGatewayAuth.tokenRef)
 		: null;
-	const isHostedV2 = manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2";
+	const isHostedV2 =
+		manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION;
 	const nativeAuth = isHostedV2 ? manifest.openclawGatewayAuth : undefined;
 	if (isHostedV2 && nativeAuth?.activation.enabled !== true) {
 		throw new Error("OpenClaw native auth capability is unavailable");
@@ -4455,7 +4457,7 @@ function requireV2EgressEngineReady(
 	engine: RuntimeMitmproxyEnsureResult | null,
 ): void {
 	if (
-		manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2" &&
+		manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION &&
 		profileBundlePath &&
 		engine?.status !== "ready"
 	) {
@@ -5637,7 +5639,7 @@ export function convergeRuntimeManifest(
 	const { manifest } = load;
 	if (
 		(hasUnsupportedAgentPluginInstallations(manifest) || opts.preparedHostedAgentPlugins) &&
-		manifest.projection?.sourceBundleVersion !== "clawdi.hosted-runtime.bundle.v2"
+		manifest.projection?.sourceBundleVersion !== HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION
 	) {
 		throw new Error(AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR);
 	}
@@ -5667,7 +5669,7 @@ export function convergeRuntimeManifest(
 	removeHostedCliPathExposure(paths);
 	removeLegacyTenantClawdiState(paths);
 	if (manifest.companions?.filebrowser) {
-		if (manifest.projection?.sourceBundleVersion !== "clawdi.hosted-runtime.bundle.v2") {
+		if (manifest.projection?.sourceBundleVersion !== HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION) {
 			throw new Error("Files companion requires a hosted v2 bundle");
 		}
 		if (!opts.systemdApply) {
@@ -5834,7 +5836,7 @@ export function convergeRuntimeManifest(
 			? openClawSkillDriver.resolveWorkspace({
 					home: projectionHome,
 					repairInvalidConfig:
-						manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2",
+						manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
 				})
 			: null;
 		validateRuntimeProjectionPlan({

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -554,6 +554,7 @@ function omitSecretRefs(
 }
 
 const MANAGED_WHATSAPP_AUTH_MARKER = ".clawdi-managed-whatsapp-auth.json";
+// SUNSET: Remove after every fleet host has converged past the retired Hermes WhatsApp receipt writer.
 const RETIRED_MANAGED_HERMES_WHATSAPP_RECEIPT = "hermes-whatsapp.json";
 
 export function materializeHostedChannelCredentials(
@@ -2815,6 +2816,7 @@ function legacyHermesModelProviderPluginDir(home: string): string {
 	return join(home, ".hermes", "plugins", "model-providers", "clawdi");
 }
 
+// SUNSET: Remove after every fleet host has migrated to native Hermes provider projection.
 function removeLegacyHermesModelProviderPlugin(home: string): void {
 	withRuntimeUserFileAccess(() =>
 		rmSync(legacyHermesModelProviderPluginDir(home), { recursive: true, force: true }),
@@ -3554,6 +3556,7 @@ interface HostedMcpIntent {
 }
 
 const HOSTED_RUNTIME_TARGETS = ["openclaw", "hermes"] as const satisfies readonly RuntimeName[];
+// SUNSET: Remove v1 parsing and the projection-root fallback after every fleet host has written the v2 managed-resource ledger.
 const HOSTED_MCP_LEDGER_V1_SCHEMA_VERSION = "clawdi.hostedManagedMcpServers.v1";
 const HOSTED_MCP_LEDGER_SCHEMA_VERSION = "clawdi.hostedManagedMcpServers.v2";
 const HOSTED_MCP_LEDGER_FILE = "managed-mcp-servers.json";
@@ -4652,6 +4655,7 @@ function writeLiveSyncEnvironmentFiles(manifest: RuntimeManifest, paths: Runtime
 	return written;
 }
 
+// SUNSET: Remove after every fleet host has migrated to the dedicated hosted CLAWDI_HOME.
 function removeLegacyTenantClawdiState(paths: RuntimePaths): void {
 	const legacyRoot = join(paths.userHome, ".clawdi");
 	if (resolve(legacyRoot) === resolve(paths.clawdiHome)) return;

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -2793,12 +2793,12 @@ function applyHostedHermesAiProviderProjection(
 	);
 	const file = projection.files.find((entry) => entry.path.endsWith(".hermes.yaml"));
 	if (!file) throw new Error("Hermes projection did not include a config merge YAML file.");
-	const activeProviderIds = [...hermesProviderIdsFromPatch(file.content)].sort();
+	const activeProviderIds = [...providerIdsFromPatch("hermes", file.content)].sort();
 	const deletedProviderIds = staleProviderIds(
 		new Set(previousProviderIds),
 		new Set(activeProviderIds),
 	);
-	const patchContent = mergeHermesProviderDeletes(file.content, deletedProviderIds);
+	const patchContent = mergeProviderDeletes("hermes", file.content, deletedProviderIds);
 	if (apply) {
 		const patch = parseYaml(file.content) as unknown;
 		const root = recordValue(patch);
@@ -2943,23 +2943,39 @@ export function buildOpenClawHostedProviderPatch(
 	);
 	const file = projection.files.find((entry) => entry.path.endsWith(".openclaw.json"));
 	if (!file) throw new Error("OpenClaw projection did not include a config patch JSON file.");
-	const providerIds = [...openClawProviderIdsFromPatch(file.content)].sort();
+	const providerIds = [...providerIdsFromPatch("openclaw", file.content)].sort();
 	const deletedProviderIds = staleProviderIds(new Set(previousProviderIds), new Set(providerIds));
 	const providerPatchContent =
 		providerIds.length > 0 ? withOpenClawProviderMode(file.content, "replace") : file.content;
 	return {
 		apply: true,
 		args: openClawProviderReplacementArgs(file.content),
-		content: mergeOpenClawProviderDeletes(providerPatchContent, deletedProviderIds),
+		content: mergeProviderDeletes("openclaw", providerPatchContent, deletedProviderIds),
 		providerIds,
 	};
 }
 
-function openClawProviderIdsFromPatch(content: string): Set<string> {
-	const parsed = JSON.parse(content) as unknown;
-	const root = recordValue(parsed);
-	const models = root ? recordValue(root.models) : null;
-	const providers = models ? recordValue(models.providers) : null;
+type ProviderPatchRuntime = "hermes" | "openclaw";
+
+function providerPatchRoot(
+	runtime: ProviderPatchRuntime,
+	content: string,
+): Record<string, unknown> | null {
+	if (runtime === "hermes" && !content.trim()) return null;
+	return recordValue(runtime === "openclaw" ? JSON.parse(content) : parseYaml(content));
+}
+
+function providerPatchProviders(
+	runtime: ProviderPatchRuntime,
+	root: Record<string, unknown>,
+): Record<string, unknown> | null {
+	const container = runtime === "openclaw" ? recordValue(root.models) : root;
+	return container ? recordValue(container.providers) : null;
+}
+
+function providerIdsFromPatch(runtime: ProviderPatchRuntime, content: string): Set<string> {
+	const root = providerPatchRoot(runtime, content);
+	const providers = root ? providerPatchProviders(runtime, root) : null;
 	if (!providers) return new Set();
 	return new Set(
 		Object.entries(providers)
@@ -2990,30 +3006,6 @@ function withOpenClawProviderMode(patchContent: string, mode: "merge" | "replace
 	patch.models = models;
 	return `${JSON.stringify(patch, null, 2)}\n`;
 }
-
-function mergeOpenClawProviderDeletes(
-	patchContent: string,
-	deletedProviderIds: readonly string[],
-): string {
-	if (deletedProviderIds.length === 0) return patchContent;
-	const parsed = JSON.parse(patchContent) as unknown;
-	const root = recordValue(parsed);
-	if (!root) return patchContent;
-	const patch = { ...root };
-	const existingModels = recordValue(patch.models);
-	const models: Record<string, unknown> = existingModels
-		? { ...existingModels }
-		: { mode: "merge" };
-	const existingProviders = recordValue(models.providers);
-	const providers = existingProviders ? { ...existingProviders } : {};
-	for (const providerId of deletedProviderIds) {
-		providers[providerId] = null;
-	}
-	models.providers = providers;
-	patch.models = models;
-	return `${JSON.stringify(patch, null, 2)}\n`;
-}
-
 function openClawProviderDeletePatch(
 	deletedProviderIds: readonly string[],
 ): Record<string, unknown> {
@@ -3023,19 +3015,6 @@ function openClawProviderDeletePatch(
 			providers: Object.fromEntries(deletedProviderIds.map((providerId) => [providerId, null])),
 		},
 	};
-}
-
-function hermesProviderIdsFromPatch(content: string): Set<string> {
-	if (!content.trim()) return new Set();
-	const parsed = parseYaml(content) as unknown;
-	const root = recordValue(parsed);
-	const providers = root ? recordValue(root.providers) : null;
-	if (!providers) return new Set();
-	return new Set(
-		Object.entries(providers)
-			.filter(([, value]) => value !== null)
-			.map(([providerId]) => providerId),
-	);
 }
 
 const HERMES_DIRECT_MODEL_FIELDS = [
@@ -3147,22 +3126,27 @@ function applyHermesProviderConfig(
 	);
 }
 
-function mergeHermesProviderDeletes(
+function mergeProviderDeletes(
+	runtime: ProviderPatchRuntime,
 	patchContent: string,
 	deletedProviderIds: readonly string[],
 ): string {
 	if (deletedProviderIds.length === 0) return patchContent;
-	const parsed = parseYaml(patchContent) as unknown;
-	const root = recordValue(parsed);
+	const root = providerPatchRoot(runtime, patchContent);
 	if (!root) return patchContent;
 	const patch = { ...root };
-	const existingProviders = recordValue(patch.providers);
+	const container =
+		runtime === "openclaw" ? { ...(recordValue(patch.models) ?? { mode: "merge" }) } : patch;
+	const existingProviders = recordValue(container.providers);
 	const providers = existingProviders ? { ...existingProviders } : {};
 	for (const providerId of deletedProviderIds) {
 		providers[providerId] = null;
 	}
-	patch.providers = providers;
-	return `${stringifyYaml(patch).trimEnd()}\n`;
+	container.providers = providers;
+	if (runtime === "openclaw") patch.models = container;
+	return runtime === "openclaw"
+		? `${JSON.stringify(patch, null, 2)}\n`
+		: `${stringifyYaml(patch).trimEnd()}\n`;
 }
 
 function staleProviderIds(

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -4815,48 +4815,6 @@ function runtimeSecretValues(load: RuntimeManifestLoad): Record<string, string> 
 		: undefined;
 }
 
-function validateRuntimeManifestPlan(
-	manifest: RuntimeManifest,
-	paths: RuntimePaths,
-	openClawWorkspaceRoot: string | null,
-): void {
-	const home = hostedRuntimeProjectionHome(manifest, paths);
-	for (const [name, runtime] of Object.entries(manifest.runtimes)) {
-		const runtimeName = runtimeNameSchema.parse(name);
-		const providerEnvironment = runtime.enabled
-			? hostedProviderEnvironment(manifest, name, { validateOverlap: true })
-			: { placeholderEnv: {}, secretEnv: {} };
-		const { placeholderEnv: providerPlaceholderEnv, secretEnv: providerSecretEnv } =
-			providerEnvironment;
-		const runtimeSettings = resolvedRuntimeSettings(
-			runtimeName,
-			runtime.run,
-			providerPlaceholderEnv,
-		);
-		if (runtime.enabled) mergeRuntimeSecretEnv(name, runtimeSettings, providerSecretEnv);
-		for (const [serviceName, serviceSettings] of Object.entries(runtime.services ?? {})) {
-			const service = runtimeServiceNameSchema.parse(serviceName);
-			const settings = resolvedRuntimeServiceSettings(
-				manifest,
-				runtimeName,
-				service,
-				serviceSettings,
-				providerPlaceholderEnv,
-			);
-			if (runtime.enabled) mergeRuntimeSecretEnv(name, settings, providerSecretEnv, service);
-		}
-		if (!runtime.enabled || !manifest.locale) continue;
-		const block = managedLocaleBlock(manifest.locale);
-		if (runtimeName === "openclaw") {
-			if (!openClawWorkspaceRoot)
-				throw new Error("OpenClaw official agent workspace is unavailable");
-			nextManagedLocaleFileContent(join(openClawWorkspaceRoot, "SOUL.md"), block);
-		} else if (runtimeName === "hermes") {
-			nextManagedLocaleFileContent(join(home, ".hermes", "SOUL.md"), block);
-		}
-	}
-}
-
 function planRuntimeSystemdUserPrograms(input: {
 	manifest: RuntimeManifest;
 	paths: RuntimePaths;
@@ -5860,7 +5818,6 @@ export function convergeRuntimeManifest(
 						manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2",
 				})
 			: null;
-		validateRuntimeManifestPlan(manifest, paths, openClawWorkspaceRoot);
 		validateRuntimeProjectionPlan({
 			manifest,
 			paths,

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -29,7 +29,6 @@ import {
 } from "../lib/chatgpt-oauth-reconciliation";
 import {
 	HERMES_CODEX_AUTH_HELPER,
-	type HermesCodexAuthAction,
 	type NativeOAuthCredentialMutationResult,
 	nativeOAuthMutationResult,
 	nativeOAuthObservation,
@@ -41,7 +40,6 @@ import {
 	OPENCLAW_PROVIDER_AUTH_HELPER,
 	OPENCLAW_PROVIDER_AUTH_MUTATION_EXPORTS,
 	OPENCLAW_PROVIDER_ENV_VARS_EXPORTS,
-	type OpenClawProviderAuthAction,
 	oauthCredentialFingerprint,
 	openClawSdkFunctionGuard,
 } from "../lib/codex-oauth-native-store";
@@ -435,6 +433,28 @@ interface HostedRuntimeOAuthCredential {
 	profile: string;
 	credentialRevision: string;
 	material: RuntimeOAuthMaterial;
+}
+
+type RuntimeOAuthCredentialAction = "inspect" | "seed-if-missing" | "upsert" | "remove";
+
+interface RuntimeOAuthCredentialCommand {
+	action: RuntimeOAuthCredentialAction;
+	nativeProfileId: string;
+	credentialRevision: string;
+	material?: RuntimeOAuthMaterial;
+	ownership?: OAuthCredentialOwnership;
+	expectedFingerprint?: string;
+}
+
+interface RuntimeOAuthCredentialDriver {
+	observe: (
+		input: Omit<RuntimeOAuthCredentialCommand, "action" | "material" | "expectedFingerprint">,
+	) => NativeOAuthCredentialObservation;
+	mutate: (
+		input: Omit<RuntimeOAuthCredentialCommand, "action"> & {
+			action: Exclude<RuntimeOAuthCredentialAction, "inspect">;
+		},
+	) => NativeOAuthCredentialMutationResult;
 }
 
 interface RuntimeInstallReceiptTarget {
@@ -1855,12 +1875,7 @@ function hermesAuthPath(home: string): string {
 function runHermesCodexAuthCommand(
 	home: string,
 	workspaceRoot: string,
-	action: HermesCodexAuthAction,
-	profileId: string,
-	credentialRevision: string,
-	material?: RuntimeOAuthMaterial,
-	ownership?: OAuthCredentialOwnership,
-	expectedFingerprint?: string,
+	input: RuntimeOAuthCredentialCommand,
 ): Record<string, unknown> {
 	const authPath = hermesAuthPath(home);
 	enforceRuntimeUserOwnership(
@@ -1877,67 +1892,23 @@ function runHermesCodexAuthCommand(
 			"--eval",
 			HERMES_CODEX_AUTH_HELPER,
 			authPath,
-			action,
-			profileId,
-			ownership?.nativeProfileId ?? "",
-			credentialRevision,
-			expectedFingerprint ?? "",
+			input.action,
+			input.nativeProfileId,
+			input.ownership?.nativeProfileId ?? "",
+			input.credentialRevision,
+			input.expectedFingerprint ?? "",
 		],
 		home,
 		workspaceRoot,
-		{ input: material ? JSON.stringify(material) : "null" },
+		{ input: input.material ? JSON.stringify(input.material) : "null" },
 	);
 	if (result.status !== 0) {
 		throw new Error(
-			`Hermes Codex auth ${action} failed: ${tail(String(result.stderr ?? "")) ?? "unknown"}`,
+			`Hermes Codex auth ${input.action} failed: ${tail(String(result.stderr ?? "")) ?? "unknown"}`,
 		);
 	}
 	const output = recordValue(JSON.parse(String(result.stdout || "{}")) as unknown);
 	return output ?? {};
-}
-
-function observeHermesCodexAuth(
-	home: string,
-	workspaceRoot: string,
-	profileId: string,
-	credentialRevision: string,
-	ownership?: OAuthCredentialOwnership,
-): NativeOAuthCredentialObservation {
-	return nativeOAuthObservation(
-		runHermesCodexAuthCommand(
-			home,
-			workspaceRoot,
-			"inspect",
-			profileId,
-			credentialRevision,
-			undefined,
-			ownership,
-		),
-	);
-}
-
-function runHermesCodexAuth(
-	home: string,
-	workspaceRoot: string,
-	action: Exclude<HermesCodexAuthAction, "inspect">,
-	profileId: string,
-	credentialRevision: string,
-	material?: RuntimeOAuthMaterial,
-	ownership?: OAuthCredentialOwnership,
-	expectedFingerprint?: string,
-): NativeOAuthCredentialMutationResult {
-	return nativeOAuthMutationResult(
-		runHermesCodexAuthCommand(
-			home,
-			workspaceRoot,
-			action,
-			profileId,
-			credentialRevision,
-			material,
-			ownership,
-			expectedFingerprint,
-		),
-	);
 }
 
 const OPENCLAW_OWNER_BROWSER_BOOTSTRAP_CAPABILITY_PROBE = `
@@ -2073,22 +2044,17 @@ function ensureHostedOpenClawProviderAuthCapability(input: {
 function runOpenClawProviderAuthCommand(
 	context: OpenClawHostedContext,
 	workspaceRoot: string,
-	action: OpenClawProviderAuthAction,
-	profileId: string,
-	credentialRevision: string,
-	material?: RuntimeOAuthMaterial,
-	ownership?: OAuthCredentialOwnership,
-	expectedFingerprint?: string,
+	input: RuntimeOAuthCredentialCommand,
 ): Record<string, unknown> {
-	const credential = material
+	const credential = input.material
 		? JSON.stringify({
 				type: "oauth",
 				provider: OPENCLAW_CODEX_PROVIDER_ID,
-				access: material.accessToken,
-				refresh: material.refreshToken,
-				expires: material.expires,
-				...(material.idToken ? { idToken: material.idToken } : {}),
-				...(material.accountId ? { accountId: material.accountId } : {}),
+				access: input.material.accessToken,
+				refresh: input.material.refreshToken,
+				expires: input.material.expires,
+				...(input.material.idToken ? { idToken: input.material.idToken } : {}),
+				...(input.material.accountId ? { accountId: input.material.accountId } : {}),
 				copyToAgents: false,
 			})
 		: "";
@@ -2100,11 +2066,11 @@ function runOpenClawProviderAuthCommand(
 			OPENCLAW_PROVIDER_AUTH_HELPER,
 			context.requireSdkExport("providerAuth"),
 			context.agentDirs.main,
-			action,
-			profileId,
-			ownership?.nativeProfileId ?? "",
-			credentialRevision,
-			expectedFingerprint ?? "",
+			input.action,
+			input.nativeProfileId,
+			input.ownership?.nativeProfileId ?? "",
+			input.credentialRevision,
+			input.expectedFingerprint ?? "",
 		],
 		context.home,
 		workspaceRoot,
@@ -2112,57 +2078,12 @@ function runOpenClawProviderAuthCommand(
 	);
 	if (result.status !== 0) {
 		throw new Error(
-			`OpenClaw provider-auth ${action} failed: ${tail(String(result.stderr ?? "")) ?? "unknown"}`,
+			`OpenClaw provider-auth ${input.action} failed: ${tail(String(result.stderr ?? "")) ?? "unknown"}`,
 		);
 	}
 	const output = recordValue(JSON.parse(String(result.stdout || "{}")) as unknown);
 	return output ?? {};
 }
-
-function observeOpenClawProviderAuth(
-	context: OpenClawHostedContext,
-	workspaceRoot: string,
-	profileId: string,
-	credentialRevision: string,
-	ownership?: OAuthCredentialOwnership,
-): NativeOAuthCredentialObservation {
-	return nativeOAuthObservation(
-		runOpenClawProviderAuthCommand(
-			context,
-			workspaceRoot,
-			"inspect",
-			profileId,
-			credentialRevision,
-			undefined,
-			ownership,
-		),
-	);
-}
-
-function runOpenClawProviderAuth(
-	context: OpenClawHostedContext,
-	workspaceRoot: string,
-	action: Exclude<OpenClawProviderAuthAction, "inspect">,
-	profileId: string,
-	credentialRevision: string,
-	material?: RuntimeOAuthMaterial,
-	ownership?: OAuthCredentialOwnership,
-	expectedFingerprint?: string,
-): NativeOAuthCredentialMutationResult {
-	return nativeOAuthMutationResult(
-		runOpenClawProviderAuthCommand(
-			context,
-			workspaceRoot,
-			action,
-			profileId,
-			credentialRevision,
-			material,
-			ownership,
-			expectedFingerprint,
-		),
-	);
-}
-
 function removeOpenClawManagedProviderAuthProfiles(
 	context: OpenClawHostedContext,
 	workspaceRoot: string,
@@ -2256,39 +2177,35 @@ function runtimeOAuthLedgerOwnership(
 	};
 }
 
-function observeHostedRuntimeOAuthCredential(input: {
+function runtimeOAuthCredentialDriver(
+	run: (input: RuntimeOAuthCredentialCommand) => Record<string, unknown>,
+): RuntimeOAuthCredentialDriver {
+	return {
+		observe: (input) => nativeOAuthObservation(run({ ...input, action: "inspect" })),
+		mutate: (input) => nativeOAuthMutationResult(run(input)),
+	};
+}
+
+function hostedRuntimeOAuthCredentialDriver(input: {
 	runtime: "hermes" | "openclaw";
 	home: string;
 	openClawContext: OpenClawHostedContext;
 	workspaceRoot: string;
-	nativeProfileId: string;
-	credentialRevision: string;
-	ownership?: OAuthCredentialOwnership;
-}): NativeOAuthCredentialObservation {
+}): RuntimeOAuthCredentialDriver {
 	if (input.runtime === "hermes") {
-		return observeHermesCodexAuth(
-			input.home,
-			input.workspaceRoot,
-			input.nativeProfileId,
-			input.credentialRevision,
-			input.ownership,
+		return runtimeOAuthCredentialDriver((command) =>
+			runHermesCodexAuthCommand(input.home, input.workspaceRoot, command),
 		);
 	}
-	return observeOpenClawProviderAuth(
-		input.openClawContext,
-		input.workspaceRoot,
-		input.nativeProfileId,
-		input.credentialRevision,
-		input.ownership,
+	return runtimeOAuthCredentialDriver((command) =>
+		runOpenClawProviderAuthCommand(input.openClawContext, input.workspaceRoot, command),
 	);
 }
 
 function executeHostedRuntimeOAuthAction(input: {
 	decision: ReturnType<typeof decideChatGptOAuthCredentialReconciliation>;
+	driver: RuntimeOAuthCredentialDriver;
 	runtime: "hermes" | "openclaw";
-	home: string;
-	openClawContext: OpenClawHostedContext;
-	workspaceRoot: string;
 	nativeProfileId: string;
 	credentialRevision: string;
 	material: RuntimeOAuthMaterial;
@@ -2307,30 +2224,13 @@ function executeHostedRuntimeOAuthAction(input: {
 		input.decision.targetCredentialFingerprint,
 		"target",
 	);
-	let result: NativeOAuthCredentialMutationResult;
-	if (input.runtime === "hermes") {
-		result = runHermesCodexAuth(
-			input.home,
-			input.workspaceRoot,
-			adapterAction,
-			input.nativeProfileId,
-			input.credentialRevision,
-			input.material,
-			undefined,
-			expectedFingerprint,
-		);
-	} else {
-		result = runOpenClawProviderAuth(
-			input.openClawContext,
-			input.workspaceRoot,
-			adapterAction,
-			input.nativeProfileId,
-			input.credentialRevision,
-			input.material,
-			undefined,
-			expectedFingerprint,
-		);
-	}
+	const result = input.driver.mutate({
+		action: adapterAction,
+		nativeProfileId: input.nativeProfileId,
+		credentialRevision: input.credentialRevision,
+		material: input.material,
+		expectedFingerprint,
+	});
 	assertRuntimeNativeMutationCompleted(
 		result,
 		expectedFingerprint,
@@ -2340,39 +2240,20 @@ function executeHostedRuntimeOAuthAction(input: {
 }
 
 function removeHostedRuntimeOAuthCredential(input: {
+	driver: RuntimeOAuthCredentialDriver;
 	runtime: "hermes" | "openclaw";
-	home: string;
-	openClawContext: OpenClawHostedContext;
-	workspaceRoot: string;
 	nativeProfileId: string;
 	credentialRevision: string;
 	ownership: OAuthCredentialOwnership;
 	expectedFingerprint: string;
 }): void {
-	let result: NativeOAuthCredentialMutationResult;
-	if (input.runtime === "hermes") {
-		result = runHermesCodexAuth(
-			input.home,
-			input.workspaceRoot,
-			"remove",
-			input.nativeProfileId,
-			input.credentialRevision,
-			undefined,
-			input.ownership,
-			input.expectedFingerprint,
-		);
-	} else {
-		result = runOpenClawProviderAuth(
-			input.openClawContext,
-			input.workspaceRoot,
-			"remove",
-			input.nativeProfileId,
-			input.credentialRevision,
-			undefined,
-			input.ownership,
-			input.expectedFingerprint,
-		);
-	}
+	const result = input.driver.mutate({
+		action: "remove",
+		nativeProfileId: input.nativeProfileId,
+		credentialRevision: input.credentialRevision,
+		ownership: input.ownership,
+		expectedFingerprint: input.expectedFingerprint,
+	});
 	assertRuntimeNativeRemovalCompleted(
 		result,
 		input.expectedFingerprint,
@@ -2432,6 +2313,7 @@ function reconcileHostedRuntimeOAuthCredentials(input: {
 	workspaceRoot: string;
 }): void {
 	const desired = hostedRuntimeOAuthCredentials(input.manifest, input.runtime, input.secretValues);
+	const driver = hostedRuntimeOAuthCredentialDriver(input);
 	const desiredProviderIds = new Set(desired.map((credential) => credential.providerId));
 	const ledgerDir = join(input.paths.oauthCredentialRoot, input.runtime);
 	if (existsSync(ledgerDir)) {
@@ -2443,11 +2325,7 @@ function reconcileHostedRuntimeOAuthCredentials(input: {
 			}
 			const snapshot = oauthCredentialLedgerSnapshot(ledger);
 			const ownership = runtimeOAuthLedgerOwnership(ledger);
-			const native = observeHostedRuntimeOAuthCredential({
-				runtime: input.runtime,
-				home: input.home,
-				openClawContext: input.openClawContext,
-				workspaceRoot: input.workspaceRoot,
+			const native = driver.observe({
 				nativeProfileId: ledger.nativeProfileId,
 				credentialRevision: ledger.credentialRevision,
 				ownership,
@@ -2478,10 +2356,8 @@ function reconcileHostedRuntimeOAuthCredentials(input: {
 					credentialFingerprint: expectedFingerprint,
 				};
 				removeHostedRuntimeOAuthCredential({
+					driver,
 					runtime: input.runtime,
-					home: input.home,
-					openClawContext: input.openClawContext,
-					workspaceRoot: input.workspaceRoot,
 					nativeProfileId: ledger.nativeProfileId,
 					credentialRevision: ledger.credentialRevision,
 					ownership: removalOwnership,
@@ -2501,11 +2377,7 @@ function reconcileHostedRuntimeOAuthCredentials(input: {
 			credential.material.accessToken,
 			credential.material.refreshToken,
 		);
-		const native = observeHostedRuntimeOAuthCredential({
-			runtime: input.runtime,
-			home: input.home,
-			openClawContext: input.openClawContext,
-			workspaceRoot: input.workspaceRoot,
+		const native = driver.observe({
 			nativeProfileId,
 			credentialRevision: credential.credentialRevision,
 			ownership: runtimeOAuthLedgerOwnership(ledger),
@@ -2527,10 +2399,8 @@ function reconcileHostedRuntimeOAuthCredentials(input: {
 		}
 		executeHostedRuntimeOAuthAction({
 			decision,
+			driver,
 			runtime: input.runtime,
-			home: input.home,
-			openClawContext: input.openClawContext,
-			workspaceRoot: input.workspaceRoot,
 			nativeProfileId,
 			credentialRevision: credential.credentialRevision,
 			material: credential.material,

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -400,6 +400,25 @@ interface RuntimeInstallObservation {
 	error: string | null;
 }
 
+function runtimeInstallObservation(
+	observation: Pick<RuntimeInstallObservation, "runtime" | "enabled" | "status"> &
+		Partial<Omit<RuntimeInstallObservation, "runtime" | "enabled" | "status">>,
+): RuntimeInstallObservation {
+	return {
+		executionUser: null,
+		commandPath: null,
+		appRoot: null,
+		install: null,
+		installerUrl: null,
+		executedInstallerUrl: null,
+		exitCode: null,
+		stdoutTail: null,
+		stderrTail: null,
+		error: null,
+		...observation,
+	};
+}
+
 const OPENCLAW_CODEX_PROVIDER_ID = "openai";
 
 interface RuntimeOAuthMaterial {
@@ -1175,12 +1194,7 @@ function materializeInstaller(
 function runOfficialInstaller(name: string, install: RuntimeInstall): RuntimeInstallObservation {
 	const installStartedAt = new Date().toISOString();
 	const installStartedMs = Date.now();
-	const finish = (
-		observation: Omit<
-			RuntimeInstallObservation,
-			"installStartedAt" | "installFinishedAt" | "installDurationMs"
-		>,
-	): RuntimeInstallObservation => ({
+	const finish = (observation: RuntimeInstallObservation): RuntimeInstallObservation => ({
 		...observation,
 		installStartedAt,
 		installFinishedAt: new Date().toISOString(),
@@ -1189,38 +1203,31 @@ function runOfficialInstaller(name: string, install: RuntimeInstall): RuntimeIns
 	const commandPath = runtimeCommandPath(name, install.home);
 	const appRoot = runtimeAppRoot(name, install.home);
 	if (!commandPath || !appRoot) {
-		return finish({
-			runtime: name,
-			enabled: true,
-			status: "install_failed",
-			executionUser: null,
-			commandPath,
-			appRoot,
-			install,
-			installerUrl: install.url,
-			executedInstallerUrl: null,
-			exitCode: null,
-			stdoutTail: null,
-			stderrTail: null,
-			error: `unsupported runtime ${name}`,
-		});
+		return finish(
+			runtimeInstallObservation({
+				runtime: name,
+				enabled: true,
+				status: "install_failed",
+				commandPath,
+				appRoot,
+				install,
+				installerUrl: install.url,
+				error: `unsupported runtime ${name}`,
+			}),
+		);
 	}
 	if (executableExists(commandPath)) {
-		return finish({
-			runtime: name,
-			enabled: true,
-			status: "present",
-			executionUser: null,
-			commandPath,
-			appRoot,
-			install,
-			installerUrl: install.url,
-			executedInstallerUrl: null,
-			exitCode: null,
-			stdoutTail: null,
-			stderrTail: null,
-			error: null,
-		});
+		return finish(
+			runtimeInstallObservation({
+				runtime: name,
+				enabled: true,
+				status: "present",
+				commandPath,
+				appRoot,
+				install,
+				installerUrl: install.url,
+			}),
+		);
 	}
 
 	enforceRuntimeUserOwnership(runtimeUserDirectoryOwnership(install.home));
@@ -1236,39 +1243,39 @@ function runOfficialInstaller(name: string, install: RuntimeInstall): RuntimeIns
 		});
 		const exitCode = result.status ?? 1;
 		const installed = exitCode === 0 && executableExists(commandPath);
-		return finish({
-			runtime: name,
-			enabled: true,
-			status: installed ? "installed" : "install_failed",
-			executionUser: execution.executionUser,
-			commandPath,
-			appRoot,
-			install,
-			installerUrl: install.url,
-			executedInstallerUrl: url === install.url ? install.url : url,
-			exitCode,
-			stdoutTail: tail(result.stdout),
-			stderrTail: tail(result.stderr),
-			error: installed
-				? null
-				: `runtime ${name} installer exited ${exitCode} or did not create ${commandPath}`,
-		});
+		return finish(
+			runtimeInstallObservation({
+				runtime: name,
+				enabled: true,
+				status: installed ? "installed" : "install_failed",
+				executionUser: execution.executionUser,
+				commandPath,
+				appRoot,
+				install,
+				installerUrl: install.url,
+				executedInstallerUrl: url === install.url ? install.url : url,
+				exitCode,
+				stdoutTail: tail(result.stdout),
+				stderrTail: tail(result.stderr),
+				error: installed
+					? null
+					: `runtime ${name} installer exited ${exitCode} or did not create ${commandPath}`,
+			}),
+		);
 	} catch (error) {
-		return finish({
-			runtime: name,
-			enabled: true,
-			status: "install_failed",
-			executionUser: null,
-			commandPath,
-			appRoot,
-			install,
-			installerUrl: install.url,
-			executedInstallerUrl: url,
-			exitCode: null,
-			stdoutTail: null,
-			stderrTail: null,
-			error: error instanceof Error ? error.message : String(error),
-		});
+		return finish(
+			runtimeInstallObservation({
+				runtime: name,
+				enabled: true,
+				status: "install_failed",
+				commandPath,
+				appRoot,
+				install,
+				installerUrl: install.url,
+				executedInstallerUrl: url,
+				error: error instanceof Error ? error.message : String(error),
+			}),
+		);
 	} finally {
 		if (materialized.cleanup) rmSync(materialized.cleanup, { recursive: true, force: true });
 	}
@@ -1280,21 +1287,13 @@ function observeRuntimeInstall(
 	home: string,
 ) {
 	if (!runtime.enabled) {
-		return {
+		return runtimeInstallObservation({
 			runtime: name,
 			enabled: false,
 			status: "disabled",
-			executionUser: null,
-			commandPath: null,
-			appRoot: null,
 			install: runtime.install ?? null,
 			installerUrl: runtime.install?.url ?? null,
-			executedInstallerUrl: null,
-			exitCode: null,
-			stdoutTail: null,
-			stderrTail: null,
-			error: null,
-		} satisfies RuntimeInstallObservation;
+		});
 	}
 	if (!runtime.install) {
 		if (runtime.run?.command?.trim() || isSupportedRuntimeName(name)) {
@@ -1303,37 +1302,20 @@ function observeRuntimeInstall(
 				isSupportedRuntimeName(name) && configuredCommand && commandResolvable(configuredCommand)
 					? configuredCommand
 					: null;
-			return {
+			return runtimeInstallObservation({
 				runtime: name,
 				enabled: true,
 				status: "configured",
-				executionUser: null,
 				commandPath,
 				appRoot: commandPath ? runtimeAppRoot(name, home) : null,
-				install: null,
-				installerUrl: null,
-				executedInstallerUrl: null,
-				exitCode: null,
-				stdoutTail: null,
-				stderrTail: null,
-				error: null,
-			} satisfies RuntimeInstallObservation;
+			});
 		}
-		return {
+		return runtimeInstallObservation({
 			runtime: name,
 			enabled: true,
 			status: "install_failed",
-			executionUser: null,
-			commandPath: null,
-			appRoot: null,
-			install: null,
-			installerUrl: null,
-			executedInstallerUrl: null,
-			exitCode: null,
-			stdoutTail: null,
-			stderrTail: null,
 			error: `runtime ${name} is enabled but missing install metadata`,
-		} satisfies RuntimeInstallObservation;
+		});
 	}
 	const observation = runOfficialInstaller(name, runtime.install);
 	if (observation.error) return observation;
@@ -1352,21 +1334,16 @@ function planRuntimeInstallObservation(
 	if (!runtime.enabled) return observeRuntimeInstall(name, runtime, home);
 	const commandPath = runtimeCommandPath(name, runtime.install.home);
 	const appRoot = runtimeAppRoot(name, runtime.install.home);
-	return {
+	return runtimeInstallObservation({
 		runtime: name,
 		enabled: true,
 		status: commandPath && executableExists(commandPath) ? "present" : "configured",
-		executionUser: null,
 		commandPath,
 		appRoot,
 		install: runtime.install,
 		installerUrl: runtime.install.url,
-		executedInstallerUrl: null,
-		exitCode: null,
-		stdoutTail: null,
-		stderrTail: null,
 		error: commandPath && appRoot ? null : `unsupported runtime ${name}`,
-	};
+	});
 }
 
 function projectionPayload(name: string, manifest: RuntimeManifest): unknown {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -3212,11 +3212,15 @@ function jsonMergePatchIsApplied(current: unknown, patch: unknown): boolean {
 	if (!isPlainRecord(patch)) return canonicalJsonEqual(current, patch);
 	if (!isPlainRecord(current)) return false;
 	return Object.entries(patch).every(([key, value]) =>
-		value === null ? !Object.hasOwn(current, key) : jsonMergePatchIsApplied(current[key], value),
+		value === undefined
+			? true
+			: value === null
+				? !Object.hasOwn(current, key)
+				: jsonMergePatchIsApplied(current[key], value),
 	);
 }
 
-function openClawGatewayHostedPatchIsApplied(
+function openClawConfigPatchIsApplied(
 	context: OpenClawHostedContext,
 	patch: Record<string, unknown>,
 ): boolean {
@@ -3245,7 +3249,7 @@ function applyOpenClawGatewayHostedProjection(
 	ownerBrowserBootstrapSupported: boolean,
 ): void {
 	const patch = openClawGatewayHostedPatch(manifest, secretValues, ownerBrowserBootstrapSupported);
-	if (!patch || openClawGatewayHostedPatchIsApplied(context, patch)) return;
+	if (!patch || openClawConfigPatchIsApplied(context, patch)) return;
 	runRuntimeUserCommand(
 		command,
 		["config", "patch", "--stdin"],
@@ -3348,6 +3352,7 @@ function applyHostedChannelProjection(
 	observation: RuntimeInstallObservation,
 	manifest: RuntimeManifest,
 	home: string,
+	openClawContext: OpenClawHostedContext,
 	workspaceRoot: string,
 	hermesWhatsAppAuthDir: string | null,
 ): boolean {
@@ -3364,14 +3369,16 @@ function applyHostedChannelProjection(
 			buildHermesManagedChannelsPatch(channels, hermesWhatsAppAuthDir),
 		);
 	}
+	const patch = openClawManagedChannelsPatch(channels);
+	if (openClawConfigPatchIsApplied(openClawContext, patch)) return false;
 	runRuntimeUserCommand(
 		observation.commandPath,
 		["config", "patch", "--stdin", ...openClawManagedAccountReplaceArgs(channels)],
-		`${JSON.stringify(openClawManagedChannelsPatch(channels), null, 2)}\n`,
+		`${JSON.stringify(patch, null, 2)}\n`,
 		home,
 		workspaceRoot,
 	);
-	return false;
+	return true;
 }
 
 function installHostedChannelProjectionDependencies(
@@ -6488,6 +6495,7 @@ export function convergeRuntimeManifest(
 					observation,
 					manifest,
 					projectionHome,
+					openClawContext,
 					workspaceRoot,
 					hermesWhatsAppAuthDir,
 				);

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1027,17 +1027,6 @@ function makeEgressIdentityPrivateDir(path: string): void {
 	}
 }
 
-function runtimeInstallerCommand(name: string, install: RuntimeInstall | undefined): string[] {
-	if (!install) return [];
-	if (name === "openclaw") {
-		return ["bash", "<downloaded-official-openclaw-installer>", ...install.args];
-	}
-	if (name === "hermes") {
-		return ["bash", "<downloaded-official-hermes-installer>", ...install.args];
-	}
-	return [];
-}
-
 function runtimeCommandPath(name: string, home: string): string | null {
 	if (name === "openclaw") return join(home, ".local", "bin", "openclaw");
 	if (name === "hermes") return join(home, ".local", "bin", "hermes");
@@ -2560,9 +2549,6 @@ function applyHostedCodexManagedProviderProjection(
 	const configContent = hostedCodexManagedConfigToml(provider);
 	writePrivateFileAtomic(configPath, configContent, { mode: 0o600, dirMode: 0o700 });
 	makeRuntimeUserOwned(configPath);
-	enforceRuntimeUserOwnership(
-		runtimeUserDirectoryOwnership(codexHome, { mode: 0o700, ancestorsUnder: home }),
-	);
 
 	return {
 		path: configPath,
@@ -6419,7 +6405,7 @@ export function convergeRuntimeManifest(
 					status: observation.status,
 					executionUser: observation.executionUser,
 					install: observation.install,
-					command: runtimeInstallerCommand(name, runtime.install),
+					installerArgs: runtime.install?.args ?? [],
 					commandPath: observation.commandPath,
 					appRoot: observation.appRoot,
 					installerUrl: observation.installerUrl,

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1549,48 +1549,23 @@ function mergeRuntimeSecretEnv(
 	runtimeName: string,
 	settings: RuntimeRunSettings | undefined,
 	providerSecretEnv: Record<string, string>,
+	serviceName?: string,
 ): Record<string, string> {
+	const scope = `runtime ${runtimeName}${serviceName ? ` service ${serviceName}` : ""}`;
 	const merged = { ...providerSecretEnv };
 	const runtimeSecretEnv = settings?.secretEnv ?? {};
 	for (const [envName, ref] of Object.entries(runtimeSecretEnv)) {
 		const existing = merged[envName];
 		if (existing !== undefined && existing !== ref) {
 			throw new Error(
-				`runtime ${runtimeName} secretEnv.${envName} conflicts with provider secret ref ${existing}`,
+				`${scope} secretEnv.${envName} conflicts with provider secret ref ${existing}`,
 			);
 		}
 		merged[envName] = ref;
 	}
 	for (const envName of Object.keys(settings?.env ?? {})) {
 		if (merged[envName] !== undefined) {
-			throw new Error(`runtime ${runtimeName} defines ${envName} in both env and secretEnv`);
-		}
-	}
-	return merged;
-}
-
-function mergeRuntimeServiceSecretEnv(
-	runtimeName: string,
-	serviceName: string,
-	serviceSettings: NonNullable<RuntimeManifest["runtimes"][string]["services"]>[string],
-	providerSecretEnv: Record<string, string>,
-): Record<string, string> {
-	const merged = { ...providerSecretEnv };
-	const serviceSecretEnv = serviceSettings.secretEnv ?? {};
-	for (const [envName, ref] of Object.entries(serviceSecretEnv)) {
-		const existing = merged[envName];
-		if (existing !== undefined && existing !== ref) {
-			throw new Error(
-				`runtime ${runtimeName} service ${serviceName} secretEnv.${envName} conflicts with provider secret ref ${existing}`,
-			);
-		}
-		merged[envName] = ref;
-	}
-	for (const envName of Object.keys(serviceSettings.env ?? {})) {
-		if (merged[envName] !== undefined) {
-			throw new Error(
-				`runtime ${runtimeName} service ${serviceName} defines ${envName} in both env and secretEnv`,
-			);
+			throw new Error(`${scope} defines ${envName} in both env and secretEnv`);
 		}
 	}
 	return merged;
@@ -4868,7 +4843,7 @@ function validateRuntimeManifestPlan(
 				serviceSettings,
 				providerPlaceholderEnv,
 			);
-			if (runtime.enabled) mergeRuntimeServiceSecretEnv(name, service, settings, providerSecretEnv);
+			if (runtime.enabled) mergeRuntimeSecretEnv(name, settings, providerSecretEnv, service);
 		}
 		if (!runtime.enabled || !manifest.locale) continue;
 		const block = managedLocaleBlock(manifest.locale);
@@ -5028,7 +5003,7 @@ function resolveRuntimeRunConfigs(input: {
 				settings,
 				secretFilePath: null,
 				secretEnv: input.runtime.enabled
-					? mergeRuntimeServiceSecretEnv(input.name, service, settings, providerSecretEnv)
+					? mergeRuntimeSecretEnv(input.name, settings, providerSecretEnv, service)
 					: {},
 			});
 		});
@@ -5155,7 +5130,7 @@ function validateRuntimeProjectionPlan(input: {
 				serviceSettings,
 				providerPlaceholderEnv,
 			);
-			mergeRuntimeServiceSecretEnv(name, service, settings, providerSecretEnv);
+			mergeRuntimeSecretEnv(name, settings, providerSecretEnv, service);
 		}
 
 		const projectionInput = agentTargetProjectionInput(hostedAiProviderCatalog(manifest, name));

--- a/packages/cli/src/runtime/projection-home.ts
+++ b/packages/cli/src/runtime/projection-home.ts
@@ -1,12 +1,12 @@
 import { isAbsolute } from "node:path";
-import type { RuntimeManifest } from "./manifest-contract";
+import { HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION, type RuntimeManifest } from "./manifest-contract";
 import type { RuntimePaths } from "./paths";
 
 export function hostedRuntimeProjectionHome(
 	manifest: Pick<RuntimeManifest, "projection">,
 	paths: Pick<RuntimePaths, "userHome">,
 ): string {
-	if (manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2") {
+	if (manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION) {
 		return paths.userHome;
 	}
 	const system = manifest.projection?.system;

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -20,7 +20,7 @@ import { ensureDirectoryWithinTrustedRoot } from "../lib/trusted-directory";
 import { runtimeContentSha256 } from "./applied-state";
 import { applyEgressTransparentRuntimeEnv } from "./egress-env";
 import type { RuntimeInstallReceiptEntry, RuntimeInstallReceipts } from "./install-receipts";
-import type { RuntimeManifest } from "./manifest-contract";
+import { HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION, type RuntimeManifest } from "./manifest-contract";
 import type { RuntimeMitmproxyEnsureResult } from "./mitmproxy-fetch";
 import {
 	DEFAULT_RUN_ROOT,
@@ -1411,7 +1411,7 @@ function writeRuntimeSystemdUserProgram(input: {
 	const isHermesDashboard = program.runtime === "hermes" && program.service === "dashboard";
 	const installerOnlySecretEnv =
 		descriptor?.runtime === "openclaw" &&
-		input.manifest.projection?.sourceBundleVersion === "clawdi.hosted-runtime.bundle.v2" &&
+		input.manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION &&
 		input.manifest.openclawGatewayAuth?.activation.enabled === true
 			? (descriptor.installSecretEnv ?? [])
 			: [];

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1276,8 +1276,33 @@ fi
 `;
 }
 
+function fakeOpenClawConfigPatchCommand(configPath: string): string {
+	return `if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
+  patch="$(cat)"
+  CLAWDI_TEST_OPENCLAW_PATCH="$patch" '${process.execPath}' - <<'NODE'
+const fs = require("node:fs");
+const configPath = ${JSON.stringify(configPath)};
+const current = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
+const patch = JSON.parse(process.env.CLAWDI_TEST_OPENCLAW_PATCH);
+const isRecord = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
+const merge = (currentValue, patchValue) => {
+  if (!isRecord(patchValue)) return patchValue;
+  const next = isRecord(currentValue) ? { ...currentValue } : {};
+  for (const [key, value] of Object.entries(patchValue)) {
+    if (value === null) delete next[key];
+    else next[key] = merge(next[key], value);
+  }
+  return next;
+};
+fs.writeFileSync(configPath, JSON.stringify(merge(current, patch)) + "\\n");
+NODE
+  exit 0
+fi`;
+}
+
 function seedOpenClawBinary(home: string): void {
 	const openclawBin = join(home, ".local", "bin", "openclaw");
+	const configPath = join(home, ".openclaw", "openclaw.json");
 	const unitPath = join(home, ".config", "systemd", "user", "openclaw-gateway.service");
 	const workspace = join(home, ".openclaw", "workspace");
 	mkdirSync(dirname(openclawBin), { recursive: true });
@@ -1300,9 +1325,7 @@ if [ "$*" = "gateway install --force --json" ]; then
   exit 0
 fi
 ${fakeManagedOpenClawProviderPluginCommands()}
-if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
-  cat >/dev/null
-fi
+${fakeOpenClawConfigPatchCommand(configPath)}
 exit 0
 `,
 	);
@@ -1466,13 +1489,7 @@ if [ "$*" = "agents list --json" ]; then
   printf '[{"id":"main","workspace":"${workspace}"}]\\n'
   exit 0
 fi
-if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
-	patch="$(cat)"
-	case "$patch" in
-	  *'"gateway"'*) printf '%s\n' "$patch" > '${openclawConfig}' ;;
-	esac
-	exit 0
-fi
+${fakeOpenClawConfigPatchCommand(openclawConfig)}
 if [ "$*" = "gateway install --force --json" ]; then
   mkdir -p '${dirname(unitPath)}'
   printf '%s\\n' '[Unit]' '[Service]' 'ExecStart=${openclawBin} gateway run' > '${unitPath}'


### PR DESCRIPTION
## Summary

This pass trims runtime manifest reconciliation without changing the converge phase order, the skill/systemd structure, or the OpenClaw hosted-context ownership model.

Overall diff: 394 additions, 497 deletions, net -103 lines.

## Audit Results

| Item | Latest-main verification and action | Net lines |
| --- | --- | ---: |
| 1. OAuth runtime pipelines | Verified duplicated Hermes/OpenClaw run, observe, mutate, and remove dispatch remained. Added a credential driver that preserves native helpers, CAS/write-ahead intent, capability guards, and fail-closed assertions. | -130 |
| 2. Install observations | Verified repeated wide RuntimeInstallObservation literals remained. Centralized defaults in a typed factory while preserving every status-specific field. | -23 |
| 3. JSON/YAML provider patches | Verified the provider-id extraction and stale-delete algorithms remained structurally duplicated. Shared format-aware helpers while retaining JSON and YAML parsers/serializers. | -16 |
| 4. Runtime secret env merges | Verified runtime/service variants differed only in conflict context. Unified them with an optional service name and unchanged collision errors. | -25 |
| 5. Previous projected provider IDs | Skipped after verification: #1131 already introduced retainPreviousProjectedProviderIds and covered all five copies on latest main. | 0 |
| 6. Plan validation | Verified manifest-plan validation repeated the provider environment, settings, secret env, and SOUL.md checks. Removed that duplicate pass and retained both intentional projection-plan validations around capability repair. | -43 |
| 7. Installer timeout | Verified invalid input could reach spawnSync without a usable timeout. Added bounded positive-integer validation, a 30-minute fallback, a warning, and regression coverage. | +24 |
| 8. OpenClaw channel restart | Verified OpenClaw always patched and always reported unchanged. Added serialized merge-patch idempotence checks and real changed reporting so drift repairs restart the gateway; updated command fixtures and added idempotence/drift regression coverage. | +106 |
| 9. Hosted bundle version | Verified production literals still existed, including new #1131 hosted-context paths. Exported one schema constant and reused it across all production consumers; test fixtures keep explicit wire literals. | +9 |
| 10. Legacy cleanup sunsets | Verified all four compatibility paths remain reachable and found no fleet minimum-version evidence that permits deletion. Added explicit SUNSET removal conditions for the retired WhatsApp receipt, MCP v1 ledger, Hermes provider plugin, and legacy tenant state cleanup. | +4 |
| 11. Inventory and Codex ownership | Verified fake downloaded-installer command paths remained and #1131 had converted Codex directory ownership to declarative enforcement while leaving the duplicate call. Inventory now records truthful installerArgs, and the second ownership pass is removed. | -9 |

## Verification

- bun run --cwd packages/cli typecheck
- bun x biome check on all changed TypeScript files
- bun test --isolate --max-concurrency=1 --timeout=30000 packages/cli/src/runtime/manifest-reconciliation.test.ts packages/cli/src/runtime/runtime-bundle-v2.test.ts packages/cli/src/runtime/manifest-mutation-parity.test.ts packages/cli/src/runtime/manifest-services.test.ts packages/cli/tests/runtime.test.ts
- Result: 442 passed, 0 failed, 3695 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)