### PR TITLE
chore(cli): upgrade eventsource-parser to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ clawdi doctor
 ```
 
 On Windows, or when you prefer a package-manager-owned installation, use npm
-with Node.js ≥ 22.5:
+with Node.js 24+:
 
 ```bash
 npm i -g clawdi
@@ -65,7 +65,7 @@ Native installations update from checksum-verified exact GitHub Release assets.
 npm/Bun installations update through their current package manager. Hosted CLI
 transactions remain separate and select an exact npm version.
 
-With Node.js ≥ 22.5, you can also try without installing:
+With Node.js 24+, you can also try without installing:
 
 ```bash
 npx clawdi --help
@@ -243,7 +243,7 @@ local API key minting, health checks, `clawdi doctor`, and cleanup.
 
 Local self-hosting currently expects:
 
-- Node.js 22.5+ and Bun 1.3+
+- Node.js 24.x and Bun 1.4+
 - Python 3.12, uv for dependency sync, and PDM for backend scripts
 - PostgreSQL 16 with `pg_trgm` and `pgvector`
 - Clerk keys for dashboard auth

--- a/apps/web/src/components/dashboard/add-agent-setup.tsx
+++ b/apps/web/src/components/dashboard/add-agent-setup.tsx
@@ -130,7 +130,7 @@ export function AddAgentSetup() {
 				<TabsContent value="commands" className="mt-2 space-y-4">
 					<div>
 						<p className="text-sm font-medium">Run these commands in order on the machine</p>
-						<p className="mt-1 text-xs text-muted-foreground">Node.js 22.5+ is required.</p>
+						<p className="mt-1 text-xs text-muted-foreground">Node.js 24+ is required.</p>
 						<p className="mt-0.5 text-xs text-muted-foreground">
 							Prefer Bun? Use: bun add -g clawdi@latest
 						</p>

--- a/apps/web/src/components/dashboard/agent-onboarding.test.ts
+++ b/apps/web/src/components/dashboard/agent-onboarding.test.ts
@@ -93,7 +93,7 @@ describe("connected-agent setup paths", () => {
 	});
 
 	test("states the Node requirement and keeps Bun as a secondary alternative", () => {
-		expect(setupSource).toContain("Node.js 22.5+ is required.");
+		expect(setupSource).toContain("Node.js 24+ is required.");
 		expect(setupSource).toContain("Prefer Bun? Use: bun add -g clawdi@latest");
 	});
 });

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.109",
+      "version": "0.13.110",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },
@@ -87,10 +87,10 @@
         "@clawdi/shared": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@types/bun": "^1.4.0",
-        "@types/node": "^22.20.1",
+        "@types/node": "^24.13.3",
         "chalk": "^6.0.0",
         "commander": "^15.0.0",
-        "eventsource-parser": "^3.1.1",
+        "eventsource-parser": "^4.1.0",
         "openapi-fetch": "^0.17.0",
         "tar": "^7.5.22",
         "typescript": "catalog:",
@@ -1287,7 +1287,7 @@
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
-    "eventsource-parser": ["eventsource-parser@3.1.1", "", {}, "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="],
+    "eventsource-parser": ["eventsource-parser@4.1.0", "", {}, "sha512-+DHvQ1wLO//MK+1OZgcuXCbZFKgu3YjKPJt7n98rxX8vezL0ni+7s3ZQiM8bJkUEOk7MsuCycrPLj0FzUNf7Og=="],
 
     "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
 
@@ -2453,6 +2453,8 @@
 
     "@mdx-js/mdx/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
+    "@modelcontextprotocol/sdk/eventsource-parser": ["eventsource-parser@3.1.1", "", {}, "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="],
+
     "@pierre/diffs/diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
     "@posthog/browser-common/@posthog/core": ["@posthog/core@1.48.5", "", { "dependencies": { "@posthog/types": "^1.405.0" } }, "sha512-ZE27PmVyPmw9wZOVVyn64uaTdqhopuwQfX7PzBpyCvsezuvNmrUHAMpJKkqOvaHxu7HeJt1jTQtjtTuwy+S7Og=="],
@@ -2560,8 +2562,6 @@
     "baileys/pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
 
     "bun-types/@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
-
-    "clawdi/@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -2754,8 +2754,6 @@
     "baileys/pino/thread-stream": ["thread-stream@3.2.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
-
-    "clawdi/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/docs/adr/0004-keep-bun-for-cli-tests.md
+++ b/docs/adr/0004-keep-bun-for-cli-tests.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-The published CLI runs on Node.js 22.5 or newer, and Bun builds its distribution
+The published CLI runs on Node.js 24 or newer, and Bun builds its distribution
 with `--target node`. Its test suite, however, runs on the pinned Bun 1.3.14
 runtime. We evaluated whether moving the suite to a Node-native runner would
 make tests faster or more faithful to the published package without weakening

--- a/docs/clawdi-daemon-test-guide.md
+++ b/docs/clawdi-daemon-test-guide.md
@@ -343,7 +343,7 @@ backend-to-backend secret is required; the user's Clerk JWT is the conduit.
 
 | Agent | What you need to set |
 |---|---|
-| Hermes | `HERMES_HOME=<hermes-state-dir>` when the runtime does not use Hermes' default HOME path. The adapter reads SQLite via `node:sqlite` (Node 22.5+) or `bun:sqlite` — both are built-in, no native bindings to ship. |
+| Hermes | `HERMES_HOME=<hermes-state-dir>` when the runtime does not use Hermes' default HOME path. The adapter reads SQLite via `node:sqlite` on the supported Node 24+ runtime, or via `bun:sqlite` under Bun; both are built in, with no native bindings to ship. |
 | OpenClaw | `OPENCLAW_STATE_DIR=<openclaw-state-dir>` when the runtime does not use OpenClaw's default HOME path. `OPENCLAW_AGENT_ID=<id>` if the runtime runs a single agent personality; omit to sync every agent under `agents/`. |
 
 ### What NOT to do

--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ case "$os" in
   Linux) os=linux ;;
   Darwin) os=darwin ;;
   MINGW*|MSYS*|CYGWIN*|Windows_NT)
-    fail 'Windows native installation is not supported; install an exact version with npm: npm i -g clawdi@<version> (Node >=22.5)'
+    fail 'Windows native installation is not supported; install an exact version with npm: npm i -g clawdi@<version> (Node >=24)'
     ;;
   *) fail "unsupported operating system: $os" ;;
 esac

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ clawdi setup
 clawdi doctor
 ```
 
-Windows and package-manager installations require Node.js ≥ 22.5:
+Windows and package-manager installations require Node.js 24+:
 
 ```bash
 npm i -g clawdi

--- a/packages/cli/bin/clawdi.mjs
+++ b/packages/cli/bin/clawdi.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Thin wrapper that forwards to the bundled CLI. On Node 22+ enable the
+// Thin wrapper that forwards to the bundled CLI. On supported Node 24+ enable the
 // compile cache for faster startup; elsewhere this is a no-op.
 import module from "node:module";
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.109",
+	"version": "0.13.110",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",
@@ -17,7 +17,7 @@
 		"README.md"
 	],
 	"engines": {
-		"node": ">=22.5"
+		"node": ">=24"
 	},
 	"publishConfig": {
 		"access": "public"
@@ -65,10 +65,10 @@
 		"@clawdi/shared": "workspace:*",
 		"@modelcontextprotocol/sdk": "^1.30.0",
 		"@types/bun": "^1.4.0",
-		"@types/node": "^22.20.1",
+		"@types/node": "^24.13.3",
 		"chalk": "^6.0.0",
 		"commander": "^15.0.0",
-		"eventsource-parser": "^3.1.1",
+		"eventsource-parser": "^4.1.0",
 		"openapi-fetch": "^0.17.0",
 		"tar": "^7.5.22",
 		"typescript": "catalog:",

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -55,12 +55,11 @@ interface MessageRow {
 /**
  * Open a Hermes SQLite db using the runtime's built-in binding:
  * - Under Bun: `bun:sqlite` (built-in, the dev/test default).
- * - Under Node 22.5+: `node:sqlite` (built-in; Node 22.x still emits an
- *   ExperimentalWarning at first import, harmless and one-shot).
+ * - Under the supported Node 24+ runtime: `node:sqlite` (built-in).
  *
  * Neither cross-loads — Bun has no `node:sqlite` (oven-sh/bun#15561) and
  * Node has no `bun:sqlite`. Importing lazily means users who never touch
- * Hermes don't pay the load cost or hear the experimental warning.
+ * Hermes don't pay the load cost.
  *
  * Both expose a `prepare(sql).all(args)` surface, so call sites stay
  * runtime-agnostic.

--- a/packages/cli/src/serve/sse-client.test.ts
+++ b/packages/cli/src/serve/sse-client.test.ts
@@ -20,9 +20,11 @@ import {
 import { classifySseReconnect, consumeSse, parseRecord } from "./sse-client";
 
 const originalFetch = globalThis.fetch;
+const originalStderrWrite = process.stderr.write;
 
 afterEach(() => {
 	globalThis.fetch = originalFetch;
+	process.stderr.write = originalStderrWrite;
 });
 
 function responseFromChunks(chunks: string[]): Response {
@@ -140,14 +142,21 @@ describe("consumeSse reconnect metadata", () => {
 		]);
 	});
 
-	it("ignores comments and malformed records while continuing the stream", async () => {
-		const body =
-			': ping\nmalformed-field\n\nevent: skill_changed\ndata: not-json\n\nevent: skill_deleted\ndata: {"type":"skill_deleted","skill_key":"valid","project_id":"00000000-0000-0000-0000-000000000001","skills_revision":4}\n\n';
-		globalThis.fetch = Object.assign(async () => new Response(body), {
+	it("logs complete unknown fields, discards fragmented ones, and continues", async () => {
+		const chunks = [
+			": ping\ncomplete-unknown-field\n\npartial-unknown",
+			'field\n\nevent: skill_changed\ndata: not-json\n\nevent: skill_deleted\ndata: {"type":"skill_deleted","skill_key":"valid","project_id":"00000000-0000-0000-0000-000000000001","skills_revision":4}\n\n',
+		];
+		globalThis.fetch = Object.assign(async () => responseFromChunks(chunks), {
 			preconnect: originalFetch.preconnect,
 		});
 		const abort = new AbortController();
 		const events: unknown[] = [];
+		const logs: string[] = [];
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			logs.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+			return true;
+		}) as typeof process.stderr.write;
 		await consumeSse({
 			apiUrl: "https://cloud.example",
 			apiKey: "test-key",
@@ -158,6 +167,9 @@ describe("consumeSse reconnect metadata", () => {
 			onDisconnect: () => abort.abort(),
 		});
 		expect(events).toEqual([expect.objectContaining({ skill_key: "valid" })]);
+		const logEvents = logs.map((line) => JSON.parse(line) as { event?: string });
+		expect(logEvents.filter((entry) => entry.event === "sse.framing_invalid")).toHaveLength(1);
+		expect(logEvents.filter((entry) => entry.event === "sse.parse_failed")).toHaveLength(1);
 	});
 
 	it("declares the Agent-authoritative protocol on every stream", async () => {


### PR DESCRIPTION
## Summary

- upgrade the CLI SSE parser to eventsource-parser 4.1.0
- raise the published CLI runtime contract to Node 24+ and align Node types and install guidance
- bump the immutable CLI package version to 0.13.110
- pin the v4 invalid-line behavior at the existing SSE boundary without changing production parsing code

## Verification

- frozen Bun install and CLI typecheck
- SSE focused tests: 31 passed
- complete CLI suite: 1737 passed, 4 expected skips
- Web onboarding focused tests: 6 passed, typecheck and OSS build
- production CLI build and npm package
- offline tarball install on exact Node 24.0.0; version and help smoke passed
- Biome and git diff checks

Clawdi Hosted was not modified. No production or deployment operations were performed.