### PR TITLE
release(cli): 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,43 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.0
+
+Package: `clawdi@0.14.0`
+
+This release consolidates a full review-and-hardening pass over the hosted
+runtime supervisor.
+
+### Security
+
+- Commands the supervisor runs as the runtime user no longer inherit platform
+  credentials, and tenant-writable directories are removed from their `PATH`,
+  closing a credential-exposure and command-shadowing window.
+
+### Fixed
+
+- Failed CLI self-upgrades now roll back automatically to the previous
+  verified version, with a one-hour cooldown before the same version is
+  retried, so a bad rollout can no longer strand a fleet.
+- Agent plugin failures during reconvergence are reported truthfully to the
+  control plane instead of being filtered as healthy.
+- Managed skills tampered with inside the runtime now self-heal on the next
+  convergence, and a cleanup failure can no longer roll back a committed
+  install.
+- OpenClaw configuration drift now restarts the runtime after repair, matching
+  Hermes behavior.
+- Corrupted supervisor state files (upgrade journal, heartbeat state) are
+  quarantined and rebuilt instead of permanently blocking convergence.
+- Hermes plugin installs disable the upstream install scanner only for the
+  duration of the managed install and restore the tenant's own setting
+  afterwards.
+
+### Improved
+
+- The hosted convergence engine was consolidated and split into
+  single-responsibility modules, removing duplicated validation, ownership,
+  and rollback logic across runtimes without behavior changes.
+
 ## Clawdi CLI v0.13.109
 
 Package: `clawdi@0.13.109`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.13.110",
+      "version": "0.14.0",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.13.110",
+	"version": "0.14.0",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Release `clawdi@0.14.0` — the consolidation release for the hosted runtime supervisor review-and-hardening pass (#1116–#1141, 16 PRs).

Highlights (curated in CHANGELOG.md):
- **Security**: privilege-drop credential stripping + tenant `PATH` hardening.
- **Fleet safety**: failed self-upgrades auto-roll-back with a 1h retry cooldown.
- **Truthful observation**: plugin failures reported instead of filtered; systemd unit counts honest with explicit truncation.
- **Self-healing**: corrupted state files quarantined; tampered managed skills repaired; OpenClaw drift restarts the runtime.
- **Structure**: convergence engine consolidated and split into single-responsibility modules (no behavior change, AST-verified).

Release preconditions verified:
- Deployed backend image SHA `dd646db` contains the required observation-protocol changes (#1124, #1128) — backend-first ordering satisfied.
- Publishing to npm does not touch any hosted agent; rollout is gated separately by the hosted exact-version authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)