### PR TITLE
fix(cli): persist Hermes plugin scan disablement

### DIFF
--- a/packages/cli/src/runtime/hermes-config.ts
+++ b/packages/cli/src/runtime/hermes-config.ts
@@ -81,12 +81,11 @@ function isConfigRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function readHermesConfigDocument(context: HermesConfigCommandContext): {
+function readHermesConfigDocumentAtPath(path: string): {
 	path: string;
 	document: ReturnType<typeof parseDocument>;
 	root: Record<string, unknown>;
 } {
-	const path = hermesConfigPath(context);
 	let content = "";
 	try {
 		content = withRuntimeUserFileAccess(() => readFileSync(path, "utf8"));
@@ -107,16 +106,29 @@ function readHermesConfigDocument(context: HermesConfigCommandContext): {
 	return { path, document, root: parsed };
 }
 
-export function getHermesRawConfigValue(
-	context: HermesConfigCommandContext,
-	key: string,
-): HermesConfigValue {
-	let current: unknown = readHermesConfigDocument(context).root;
+function readHermesConfigDocument(context: HermesConfigCommandContext) {
+	return readHermesConfigDocumentAtPath(hermesConfigPath(context));
+}
+
+function rawConfigValue(root: Record<string, unknown>, key: string): HermesConfigValue {
+	let current: unknown = root;
 	for (const part of key.split(".")) {
 		if (!isConfigRecord(current) || !Object.hasOwn(current, part)) return { exists: false };
 		current = current[part];
 	}
 	return { exists: true, value: current };
+}
+
+export function getHermesRawConfigValue(
+	context: HermesConfigCommandContext,
+	key: string,
+): HermesConfigValue {
+	return rawConfigValue(readHermesConfigDocument(context).root, key);
+}
+
+export function getHermesRawConfigFileValue(path: string, key: string): HermesConfigValue {
+	if (!isAbsolute(path)) throw new Error("Hermes config path must be absolute");
+	return rawConfigValue(readHermesConfigDocumentAtPath(path).root, key);
 }
 
 function configValueAtPath(

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
@@ -1,14 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import {
-	cpSync,
-	existsSync,
-	mkdirSync,
-	mkdtempSync,
-	readFileSync,
-	rmSync,
-	writeFileSync,
-} from "node:fs";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -128,8 +120,8 @@ class FakeNativeRunner implements HostedAgentPluginCommandRunner {
 		writeFileSync(join(stateRoot, "config.yaml"), `plugins:\n  scan_on_install: ${value}\n`);
 	}
 
-	hermesScanPolicy(): boolean {
-		return this.hermesScanPolicies.get(this.liveHome) ?? true;
+	hermesScanPolicy(): boolean | "unset" {
+		return this.hermesScanPolicies.get(this.liveHome) ?? "unset";
 	}
 
 	private pluginFromSource(path: string): {
@@ -178,30 +170,15 @@ class FakeNativeRunner implements HostedAgentPluginCommandRunner {
 		const args = input.args;
 		if (
 			runtime === "hermes" &&
-			args.join("\0") === ["config", "get", "plugins.scan_on_install", "--json"].join("\0")
+			args.join("\0") ===
+				["config", "set", "--force", "plugins.scan_on_install", "false"].join("\0")
 		) {
-			return {
-				status: 0,
-				stdout: JSON.stringify(this.hermesScanPolicies.get(input.home) ?? true),
-				stderr: "",
-			};
-		}
-		if (
-			runtime === "hermes" &&
-			args.slice(0, 4).join("\0") ===
-				["config", "set", "--force", "plugins.scan_on_install"].join("\0") &&
-			(args[4] === "true" || args[4] === "false")
-		) {
-			if (input.home === this.liveHome && args[4] === "false" && this.failLiveHermesScanPolicy) {
+			if (input.home === this.liveHome && this.failLiveHermesScanPolicy) {
 				return { status: 44, stdout: "", stderr: "scan policy failure" };
 			}
-			const value = args[4] === "true";
-			this.hermesScanPolicies.set(input.home, value);
+			this.hermesScanPolicies.set(input.home, false);
 			mkdirSync(expectedStateRoot, { recursive: true });
-			writeFileSync(
-				join(expectedStateRoot, "config.yaml"),
-				`plugins:\n  scan_on_install: ${value}\n`,
-			);
+			writeFileSync(join(expectedStateRoot, "config.yaml"), "plugins:\n  scan_on_install: false\n");
 			return { status: 0, stdout: "", stderr: "" };
 		}
 		if (args[0] !== "plugins") return { status: 2, stdout: "", stderr: "" };
@@ -642,42 +619,40 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 		});
 	});
 
-	test("installs the Hermes stdio-capable package from a local file Git transport", () => {
+	test("persistently disables an unset Hermes install scan before managed installation", () => {
 		const runner = new FakeNativeRunner();
 		const desired = plugin("acme.tools", "1.2.3", "b".repeat(64));
 		const transaction = prepareTransaction(desiredState("hermes", desired), runner);
 		expect(transaction.snapshotTargets).toContain(join(runner.liveHome, ".hermes", "config.yaml"));
+
 		transaction.apply();
+
 		const installIndex = runner.calls.findIndex(
 			(call) => call.home === runner.liveHome && call.args[1] === "install",
 		);
-		const liveConfigCalls = runner.calls.filter(
+		const scanPolicyIndex = runner.calls.findIndex(
 			(call) => call.home === runner.liveHome && call.args[0] === "config",
 		);
-		const disableIndex = runner.calls.findIndex(
-			(call) => call.home === runner.liveHome && call.args.at(-1) === "false",
-		);
-		const restoreIndex = runner.calls.findIndex(
-			(call) => call.home === runner.liveHome && call.args.at(-1) === "true",
-		);
 		const install = runner.calls[installIndex];
-		expect(liveConfigCalls.map((call) => call.args)).toEqual([
-			["config", "get", "plugins.scan_on_install", "--json"],
-			["config", "set", "--force", "plugins.scan_on_install", "false"],
-			["config", "get", "plugins.scan_on_install", "--json"],
-			["config", "set", "--force", "plugins.scan_on_install", "true"],
+		const scanPolicy = runner.calls[scanPolicyIndex];
+		expect(scanPolicy?.args).toEqual([
+			"config",
+			"set",
+			"--force",
+			"plugins.scan_on_install",
+			"false",
 		]);
-		expect(disableIndex).toBeGreaterThanOrEqual(0);
-		expect(disableIndex).toBeLessThan(installIndex);
-		expect(restoreIndex).toBeGreaterThan(installIndex);
+		expect(scanPolicyIndex).toBeGreaterThanOrEqual(0);
+		expect(scanPolicyIndex).toBeLessThan(installIndex);
+		expect(scanPolicy?.home).toBe(runner.liveHome);
+		expect(scanPolicy?.cwd).toBe(runner.liveHome);
+		expect(scanPolicy?.environmentOverrides).toEqual(install?.environmentOverrides);
 		expect(install?.args[2]?.startsWith("file://")).toBe(true);
 		expect(install?.args.join(" ")).not.toContain("github.com");
 		expect(readFileSync(join(runner.liveHome, ".hermes", "config.yaml"), "utf-8")).toContain(
-			"scan_on_install: true",
+			"scan_on_install: false",
 		);
-		expect(existsSync(join(runner.liveHome, ".hermes", ".clawdi-plugin-scan-guard.json"))).toBe(
-			false,
-		);
+		expect(runner.hermesScanPolicy()).toBe(false);
 		expect(install?.environmentOverrides).toEqual({
 			OPENCLAW_HOME: undefined,
 			OPENCLAW_PROFILE: undefined,
@@ -729,7 +704,7 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 		).toBe(false);
 	});
 
-	test("preserves a tenant-disabled Hermes install scan without writing a guard", () => {
+	test("does not rewrite an already-disabled Hermes install scan", () => {
 		const runner = new FakeNativeRunner();
 		runner.setHermesScanPolicy(false);
 		const desired = plugin("acme.tools", "1.2.3", "9".repeat(64));
@@ -740,45 +715,9 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 		const liveConfigCalls = runner.calls.filter(
 			(call) => call.home === runner.liveHome && call.args[0] === "config",
 		);
-		expect(liveConfigCalls.map((call) => call.args)).toEqual([
-			["config", "get", "plugins.scan_on_install", "--json"],
-		]);
+		expect(liveConfigCalls).toEqual([]);
 		expect(runner.hermesScanPolicy()).toBe(false);
-		expect(existsSync(join(runner.liveHome, ".hermes", ".clawdi-plugin-scan-guard.json"))).toBe(
-			false,
-		);
-	});
-
-	test("restores the Hermes install scan after install failure and after an interrupted guard", () => {
-		const runner = new FakeNativeRunner();
-		const desired = plugin("acme.tools", "1.2.3", "8".repeat(64));
-		const prepared = desiredState("hermes", desired);
-		const capabilityProof = proveHostedAgentPluginCapabilities({ prepared, commands, runner });
-		const guardPath = join(runner.liveHome, ".hermes", ".clawdi-plugin-scan-guard.json");
-		runner.setHermesScanPolicy(false);
-		writeFileSync(
-			guardPath,
-			`${JSON.stringify({
-				schemaVersion: "clawdi.hermesPluginScanGuard.v1",
-				previousValue: true,
-			})}\n`,
-			{ mode: 0o600 },
-		);
-
-		const transaction = prepareHostedAgentPluginTransaction({
-			prepared,
-			home: runner.liveHome,
-			commands,
-			capabilityProof,
-			runner,
-		});
-		expect(runner.hermesScanPolicy()).toBe(true);
-		expect(existsSync(guardPath)).toBe(false);
-
-		runner.failLiveInstallVersion = desired.installation.version;
-		expect(() => transaction.apply()).toThrow("Hermes native Agent Plugin install failed");
-		expect(runner.hermesScanPolicy()).toBe(true);
-		expect(existsSync(guardPath)).toBe(false);
+		expect(runner.get("hermes", desired.name)?.enabled).toBe(true);
 	});
 
 	test("requires the Hermes one-shot remote behavior proof before live mutation", () => {

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
@@ -1,10 +1,10 @@
-import { lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { lstatSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { z } from "zod";
-import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "../lib/private-file";
 import { runHermesAgentPluginCanary } from "./hermes-agent-plugin-canary-client";
+import { getHermesRawConfigFileValue } from "./hermes-config";
 import {
 	type HostedAgentPluginReceipt,
 	type HostedAgentPluginRuntime,
@@ -23,7 +23,6 @@ import {
 	commandResolvable,
 	makeRuntimeUserOwned,
 	spawnRuntimeUserCommand,
-	withRuntimeUserFileAccess,
 } from "./runtime-user-command";
 
 const COMMAND_TIMEOUT_MS = 120_000;
@@ -105,14 +104,6 @@ const OPENCLAW_AGENT_PLUGIN_STANDARD_UNSUPPORTED_ERROR =
 	"OpenClaw installed the package but did not report it as an Agent Plugins 1.0.0 bundle; standards-native installation is unsupported";
 const AGENT_PLUGIN_CAPABILITY_CANARY_NAME = "clawdi-capability-canary";
 const HERMES_PLUGIN_SCAN_POLICY_KEY = "plugins.scan_on_install";
-const HERMES_PLUGIN_SCAN_GUARD_SCHEMA = "clawdi.hermesPluginScanGuard.v1";
-const HERMES_PLUGIN_SCAN_GUARD_FILE = ".clawdi-plugin-scan-guard.json";
-const hermesPluginScanGuardSchema = z
-	.object({
-		schemaVersion: z.literal(HERMES_PLUGIN_SCAN_GUARD_SCHEMA),
-		previousValue: z.boolean(),
-	})
-	.strict();
 
 export type HermesRemoteCapabilityProbe = (input: {
 	command: string;
@@ -449,129 +440,19 @@ function initializeLocalGitTransport(
 	}
 }
 
-function hermesPluginScanGuardPath(home: string): string {
-	return join(home, ".hermes", HERMES_PLUGIN_SCAN_GUARD_FILE);
-}
-
-function readHermesPluginScanGuard(
-	home: string,
-): z.infer<typeof hermesPluginScanGuardSchema> | null {
-	const path = hermesPluginScanGuardPath(home);
-	try {
-		return withRuntimeUserFileAccess(() => {
-			const stat = lstatSync(path);
-			if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 4 * 1024) {
-				throw new Error("Hermes Agent Plugin scan guard receipt is unsafe");
-			}
-			if ((stat.mode & 0o777) !== PRIVATE_FILE_MODE) {
-				throw new Error("Hermes Agent Plugin scan guard receipt is not private");
-			}
-			const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-			return hermesPluginScanGuardSchema.parse(parsed);
-		});
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
-		if (error instanceof Error && error.message.startsWith("Hermes Agent Plugin scan guard")) {
-			throw error;
-		}
-		throw new Error("Hermes Agent Plugin scan guard receipt is invalid");
-	}
-}
-
-function writeHermesPluginScanGuard(home: string, previousValue: boolean): void {
-	const path = hermesPluginScanGuardPath(home);
-	withRuntimeUserFileAccess(() =>
-		writePrivateFileAtomic(
-			path,
-			`${JSON.stringify({
-				schemaVersion: HERMES_PLUGIN_SCAN_GUARD_SCHEMA,
-				previousValue,
-			})}\n`,
-			{ mode: PRIVATE_FILE_MODE, dirMode: PRIVATE_DIR_MODE },
-		),
-	);
-}
-
-function clearHermesPluginScanGuard(home: string): void {
-	withRuntimeUserFileAccess(() => rmSync(hermesPluginScanGuardPath(home), { force: true }));
-}
-
 type HermesNativeCommand = (args: string[]) => AgentPluginCommandResult;
 
-function readHermesPluginScanPolicy(run: HermesNativeCommand): boolean {
-	const result = run(["config", "get", HERMES_PLUGIN_SCAN_POLICY_KEY, "--json"]);
+function ensureHermesPluginScanDisabled(home: string, run: HermesNativeCommand): void {
+	const configPath = join(home, ".hermes", "config.yaml");
+	const current = getHermesRawConfigFileValue(configPath, HERMES_PLUGIN_SCAN_POLICY_KEY);
+	if (current.exists && current.value === false) return;
+
+	// Remove this persistent policy when NousResearch/hermes-agent#89704 ships
+	// an immutable-ref install exemption in the supported Hermes release.
+	const result = run(["config", "set", "--force", HERMES_PLUGIN_SCAN_POLICY_KEY, "false"]);
 	if (result.status !== 0) {
-		throw nativeCommandFailure("Hermes Agent Plugin scan policy read failed", result);
+		throw nativeCommandFailure("Hermes Agent Plugin scan policy update failed", result);
 	}
-	try {
-		return z.boolean().parse(JSON.parse(result.stdout));
-	} catch {
-		throw new Error("Hermes Agent Plugin scan policy is not a boolean");
-	}
-}
-
-function setHermesPluginScanPolicy(
-	run: HermesNativeCommand,
-	value: boolean,
-	operation: "update" | "restoration",
-): void {
-	const result = run(["config", "set", "--force", HERMES_PLUGIN_SCAN_POLICY_KEY, String(value)]);
-	if (result.status !== 0) {
-		throw nativeCommandFailure(`Hermes Agent Plugin scan policy ${operation} failed`, result);
-	}
-}
-
-function restoreHermesPluginScanPolicy(home: string, run: HermesNativeCommand): void {
-	const guard = readHermesPluginScanGuard(home);
-	if (!guard) return;
-	if (readHermesPluginScanPolicy(run) !== guard.previousValue) {
-		setHermesPluginScanPolicy(run, guard.previousValue, "restoration");
-	}
-	clearHermesPluginScanGuard(home);
-}
-
-function withHermesPluginScanDisabled<T>(
-	home: string,
-	run: HermesNativeCommand,
-	install: () => T,
-): T {
-	const previousValue = readHermesPluginScanPolicy(run);
-	if (!previousValue) return install();
-
-	// Temporary until NousResearch/hermes-agent#89704 ships in the supported
-	// Hermes release; then use its immutable-ref --no-scan install exemption.
-	writeHermesPluginScanGuard(home, previousValue);
-	let installOutcome: { ok: true; value: T } | { ok: false; error: unknown };
-	try {
-		setHermesPluginScanPolicy(run, false, "update");
-		installOutcome = { ok: true, value: install() };
-	} catch (error) {
-		installOutcome = { ok: false, error };
-	}
-	let restoreOutcome: { ok: true } | { ok: false; error: unknown };
-	try {
-		restoreHermesPluginScanPolicy(home, run);
-		restoreOutcome = { ok: true };
-	} catch (error) {
-		restoreOutcome = { ok: false, error };
-	}
-	if (!restoreOutcome.ok) {
-		if (installOutcome.ok) throw restoreOutcome.error;
-		const installMessage =
-			installOutcome.error instanceof Error
-				? installOutcome.error.message
-				: String(installOutcome.error);
-		const restoreMessage =
-			restoreOutcome.error instanceof Error
-				? restoreOutcome.error.message
-				: String(restoreOutcome.error);
-		throw new Error(
-			`Hermes Agent Plugin install failed: ${installMessage}; scan policy restoration failed: ${restoreMessage}`,
-			{ cause: installOutcome.error },
-		);
-	}
-	if (!installOutcome.ok) throw installOutcome.error;
-	return installOutcome.value;
 }
 
 function createHermesDriver(input: {
@@ -622,26 +503,22 @@ function createHermesDriver(input: {
 	return {
 		runtime: "hermes",
 		installTarget: (nativeId) => nativeInstallTarget(input.home, "hermes", nativeId),
-		mutationStateTargets: () => [
-			join(input.home, ".hermes", "config.yaml"),
-			hermesPluginScanGuardPath(input.home),
-		],
+		mutationStateTargets: () => [join(input.home, ".hermes", "config.yaml")],
 		observe,
 		install(prepared) {
 			withPreparedAgentPluginDirectory(prepared, (sourceDir) => {
+				ensureHermesPluginScanDisabled(input.home, run);
 				initializeLocalGitTransport(input.runner, "hermes", input.home, sourceDir);
-				withHermesPluginScanDisabled(input.home, run, () => {
-					const result = run([
-						"plugins",
-						"install",
-						pathToFileURL(sourceDir).href,
-						"--force",
-						"--no-enable",
-					]);
-					if (result.status !== 0) {
-						throw nativeCommandFailure("Hermes native Agent Plugin install failed", result);
-					}
-				});
+				const result = run([
+					"plugins",
+					"install",
+					pathToFileURL(sourceDir).href,
+					"--force",
+					"--no-enable",
+				]);
+				if (result.status !== 0) {
+					throw nativeCommandFailure("Hermes native Agent Plugin install failed", result);
+				}
 			});
 			const installed = observe(prepared.name);
 			if (!installed) throw new Error("Hermes did not report the installed Agent Plugin");
@@ -1091,15 +968,6 @@ export function prepareHostedAgentPluginTransaction(input: {
 		runner,
 		proof: input.capabilityProof,
 	});
-	restoreHermesPluginScanPolicy(input.home, (args) =>
-		runNative(runner, {
-			runtime: "hermes",
-			command: input.commands.hermes,
-			args,
-			home: input.home,
-			cwd: input.home,
-		}),
-	);
 	const drivers = new Map<HostedAgentPluginRuntime, NativeAgentPluginDriver>();
 	const driverFor = (runtime: HostedAgentPluginRuntime): NativeAgentPluginDriver => {
 		const existing = drivers.get(runtime);


### PR DESCRIPTION
## Production incident

The 0.14.0 canary rollout reproduced an Agent Plugin projection failure on a real Hermes agent running in Incus prod11:

```text
runtime Agent Plugin projection planning failed: Hermes Agent Plugin scan policy read failed: Config key not set: plugins.scan_on_install
```

#1130 introduced a transient scan-policy guard that read the previous value before installation and restored it afterward. Hermes legitimately reports an unset key as an error, so the read aborted planning before managed plugin reconciliation could proceed.

## Owner decision

Remove the transient mechanism instead of extending it with a third state.

Before installing a managed Hermes plugin, the runtime now idempotently ensures:

```text
plugins.scan_on_install = false
```

The setting is intentionally persistent. There is no post-install or post-removal restoration.

The write continues through the existing native runtime-user command path. This preserves the tenant ownership boundary and avoids creating root-owned files under the tenant's `.hermes` directory. When the authored config already contains strict boolean `false`, reconciliation skips the write.

This also removes the transient toggle, restoration path, crash-recovery guard receipt, receipt schema, startup recovery, and their associated tests. The patch is 70 additions and 251 deletions, for a net reduction of 181 lines.

## Follow-up hook

The source comment retains the cleanup reference to NousResearch/hermes-agent#89704. Once Hermes supports an install-scoped exemption for immutable managed plugin refs, the persistent global setting can be removed in favor of that explicit exemption.

## Verification

- CLI typecheck passed with Bun 1.4.0
- Agent Plugin focused tests: 37 passed, 0 failed
- Hermes config and runtime-user focused tests: 35 passed, 0 failed
- Root-runner UID/ownership coverage: 19 passed, 0 failed
- Biome passed for all three changed files
- `git diff --check` passed
- Regression coverage confirms an unset key no longer fails planning and is persisted as `false`
- Idempotency coverage confirms an existing `false` value is not rewritten
- Runtime-user coverage confirms config writes use the same demoted execution path as native installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
