### PR TITLE
release(cli): 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.1
+
+Package: `clawdi@0.14.1`
+
+### Fixed
+
+- Hermes plugin installs no longer fail when `plugins.scan_on_install` has
+  never been set: the managed install-scanner policy is now a simple idempotent
+  persistent setting instead of a transient toggle that read the current value
+  first.
+
 ## Clawdi CLI v0.14.0
 
 Package: `clawdi@0.14.0`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Release `clawdi@0.14.1` — canary-driven patch on 0.14.0.

The 0.14.0 owner-deployment canary caught a real-machine-only regression: the Hermes plugin install-scanner policy read failed when `plugins.scan_on_install` had never been set (\"Config key not set\"), failing agent plugin planning. Per owner decision, #1143 replaced the transient toggle with a simple idempotent persistent setting (net −181 lines); the unset-key failure mode no longer exists.

Canary evidence from 0.14.0 (same deployment, retest planned on this version):
- The long-stuck hermes sourced-skill deadlock self-healed on upgrade (#1117 verified on a real machine).
- Truthful plugin failure reporting (#1124) is what surfaced this regression — the old CLI masked it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)