### PR TITLE
fix(cli): anchor hosted Skill idempotence to install receipts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -395,30 +395,18 @@ native runtime contracts: Hermes receives the signed `SKILL.md` URL through
 `openclaw skills install`. Unlink, archive, access loss, deletion, or hash change
 invalidates the signed file lookup.
 
-Hermes URL delivery follows the upstream native adapter verified at
-[`NousResearch/hermes-agent@a77ee88ce29c4f1d89f8d60e5b662322645072d8`](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/tools/skills_hub.py#L1428-L1564):
-it installs `SKILL.md` plus explicitly referenced files from the supported
-Skill directories and runs Hermes' normal quarantine and security scan. The
-URL adapter decodes `SKILL.md` as HTTP text and writes it as UTF-8 while support
-files remain byte payloads, so the CLI compares against that same native
-projection. An older Hermes that only installs one file fails closed and rolls
-back instead of silently accepting incomplete Skill bytes.
+Native Skill delivery treats the official installer output as authoritative.
+After the verified source is installed, the CLI fingerprints the actual Skill
+tree and writes that fingerprint to a private receipt bound to the immutable
+source identity. Later convergence compares the current tree only with that
+receipt. An identity change or fingerprint mismatch requires the reservation
+ledger to prove ownership before a forced reinstall records a new fingerprint.
+The official installer is already inside the execution trust boundary; Clawdi
+does not maintain a version-specific prediction of its output.
 
-OpenClaw directory delivery follows the upstream native CLI verified at
-[`openclaw/openclaw@74014c286d36a4fd8ec16d451333a17e8776fcfe`](https://github.com/openclaw/openclaw/blob/74014c286d36a4fd8ec16d451333a17e8776fcfe/src/cli/skills-cli.ts#L615-L695).
-The command resolves an explicit `--agent` Workspace and sends local-directory
-sources through
-[`installSkillFromSource`](https://github.com/openclaw/openclaw/blob/74014c286d36a4fd8ec16d451333a17e8776fcfe/src/skills/lifecycle/source-install.ts#L360-L415),
-whose native archive path validates `SKILL.md`, runs the normal install policy
-and security scan, and copies the full directory into the resolved Workspace
-[`skills/<slug>` target](https://github.com/openclaw/openclaw/blob/74014c286d36a4fd8ec16d451333a17e8776fcfe/src/skills/lifecycle/archive-install.ts#L137-L238).
-Clawdi also checks the configured Workspace against the exact `workspace`
-field built into OpenClaw's
-[`AgentSummary`](https://github.com/openclaw/openclaw/blob/74014c286d36a4fd8ec16d451333a17e8776fcfe/src/commands/agents.config.ts#L22-L113)
-and returned by
-[`openclaw agents list --json`](https://github.com/openclaw/openclaw/blob/74014c286d36a4fd8ec16d451333a17e8776fcfe/src/commands/agents.commands.list.ts#L137-L140)
-before and after installation. Any target or byte mismatch rolls back instead
-of creating a second writer.
+OpenClaw directory delivery also checks the configured Workspace against the
+official `openclaw agents list --json` roster before and after installation.
+A Workspace mismatch fails closed instead of creating a second writer.
 
 Hosted manifests render linked Project Skills for every `HostedRuntimeState`;
 Connected inventory returns them after Connected identity and authorization

--- a/packages/cli/src/runtime/hosted-hermes-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.test.ts
@@ -57,9 +57,10 @@ if sys.argv[1:3] == ["skills", "install"]:
     source_skill = Path(os.environ["FAKE_HERMES_SOURCE"]) / "SKILL.md"
     (target / "SKILL.md").write_text(source_skill.read_bytes().decode("utf-8", errors="replace"), encoding="utf-8")
     support = Path(os.environ["FAKE_HERMES_SOURCE"]) / "references" / "guide.md"
-    if support.exists() and os.environ.get("FAKE_HERMES_OMIT_SUPPORT") != "1":
+    if support.exists():
         (target / "references").mkdir(parents=True, exist_ok=True)
         shutil.copy2(support, target / "references" / "guide.md")
+    (target / ".hermes-native.json").write_text(json.dumps({"installed": True}) + chr(10))
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.write_text("installed")
 elif sys.argv[1:3] == ["skills", "uninstall"]:
@@ -125,7 +126,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 				skill,
 				previouslyReserved: false,
 			}),
-		).toThrow("did not preserve the exact native catalog projection");
+		).toThrow("installed Skill tree is unsafe");
 		expect(readFileSync(commandLog, "utf8").trim()).toBe(
 			`skills install ${installUrl} --name review-pr --yes`,
 		);
@@ -141,7 +142,8 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		const appRoot = fakeHermesApp(home);
 		const sourceDir = join(root, "source", "review-pr");
 		mkdirSync(sourceDir, { recursive: true });
-		const skillV1 = "# Review PR\n\n[Guide](references/guide.md)\n";
+		const skillV1 =
+			"# Review PR\n\n[Guide](references/guide.md)\n[Missing](references/missing.md)\n";
 		const skillV2 = "# Review PR v2\n\n[Guide](references/guide.md)\n";
 		const skillV1Source = Buffer.concat([Buffer.from(skillV1), Buffer.from([0xff])]);
 		const skillV1Native = Buffer.from(skillV1Source.toString("utf8"), "utf8");
@@ -180,10 +182,15 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		const receipt = join(home, ".hermes", "skills", ".clawdi-manifest-receipts", "review-pr.json");
 		expect(readFileSync(join(target, "SKILL.md"))).toEqual(skillV1Native);
 		expect(readFileSync(join(target, "references", "guide.md"), "utf8")).toBe("Pinned guide\n");
+		expect(readFileSync(join(target, ".hermes-native.json"), "utf8")).toBe('{"installed": true}\n');
 		expect(existsSync(join(target, "skill.json"))).toBe(false);
 		expect(readFileSync(commandLog, "utf8")).not.toContain("--force");
 		expect(readFileSync(commandLog, "utf8")).toContain(`/${source.commit}/SKILL.md`);
 		expect(readFileSync(commandLog, "utf8")).not.toContain(`/${source.commit}//SKILL.md`);
+		expect(hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: true })).toBe(
+			"unchanged",
+		);
+		expect(readFileSync(commandLog, "utf8").trim().split("\n")).toHaveLength(1);
 		expect(hostedHermesSkillExactSourceDriver.verifyOwned(input)).toBe(true);
 		expect(
 			hostedHermesSkillExactSourceDriver.hasOwnershipReceipt({
@@ -199,10 +206,12 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 				ownershipIdentity: `${skill.sourceIdentity}-other`,
 			}),
 		).toBe(false);
-		const receiptBytes = readFileSync(receipt);
 		rmSync(receipt);
 		expect(hostedHermesSkillExactSourceDriver.verifyOwned(input)).toBe(false);
-		writeFileSync(receipt, receiptBytes, { mode: 0o600 });
+		expect(hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: true })).toBe(
+			"installed",
+		);
+		expect(hostedHermesSkillExactSourceDriver.verifyOwned(input)).toBe(true);
 
 		writeFileSync(join(target, "SKILL.md"), "forged user bytes\n");
 		expect(hostedHermesSkillExactSourceDriver.verifyOwned(input)).toBe(false);
@@ -216,9 +225,6 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		expect(() =>
 			hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: false }),
 		).toThrow("not paired with a manifest reservation");
-		expect(hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: true })).toBe(
-			"unchanged",
-		);
 		writeFileSync(join(sourceDir, "SKILL.md"), skillV2);
 		const updateArchive = join(root, "review-pr-update.tar.gz");
 		const updatePacked = spawnSync("tar", [
@@ -250,41 +256,6 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 			"/skills/review%20%231%25%3F/nested/SKILL.md",
 		);
 		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe(skillV2);
-		const wrongSource = join(root, "wrong-source");
-		mkdirSync(wrongSource, { recursive: true });
-		writeFileSync(join(wrongSource, "SKILL.md"), "wrong bytes\n");
-		process.env.FAKE_HERMES_SOURCE = wrongSource;
-		const nativeMarker = join(home, ".hermes", "skills", ".native-installed", "review-pr");
-		writeFileSync(join(sourceDir, "SKILL.md"), "# Review PR v3\n\n[Guide](references/guide.md)\n");
-		const failingArchive = join(root, "review-pr-failing.tar.gz");
-		const failingPacked = spawnSync("tar", [
-			"-czf",
-			failingArchive,
-			"-C",
-			dirname(sourceDir),
-			"review-pr",
-		]);
-		if (failingPacked.status !== 0) throw new Error("test failing tar creation failed");
-		const failingSkill = {
-			...updatedSkill,
-			sourceIdentity: `${updatedSkill.sourceIdentity}-failure-test`,
-			...preparedArchive(failingArchive),
-		};
-		expect(() =>
-			hostedHermesSkillExactSourceDriver.install({
-				home,
-				appRoot,
-				skill: failingSkill,
-				previouslyReserved: true,
-			}),
-		).toThrow("did not preserve the exact native catalog projection");
-		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe(skillV2);
-		expect(
-			hostedHermesSkillExactSourceDriver.verifyOwned({ home, appRoot, skill: updatedSkill }),
-		).toBe(true);
-		expect(existsSync(nativeMarker)).toBe(true);
-		writeFileSync(join(sourceDir, "SKILL.md"), skillV2);
-		process.env.FAKE_HERMES_SOURCE = sourceDir;
 		expect(
 			hostedHermesSkillExactSourceDriver.uninstall({
 				home,
@@ -304,41 +275,12 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 			}),
 		).toBe("absent");
 		expect(existsSync(receipt)).toBe(false);
-		process.env.FAKE_HERMES_SOURCE = sourceDir;
-		process.env.FAKE_HERMES_OMIT_SUPPORT = "1";
-		expect(() =>
-			hostedHermesSkillExactSourceDriver.install({
-				home,
-				appRoot,
-				skill: updatedSkill,
-				previouslyReserved: true,
-			}),
-		).toThrow("did not preserve the exact native catalog projection");
-		expect(existsSync(receipt)).toBe(false);
-		expect(existsSync(target)).toBe(false);
-		expect(existsSync(nativeMarker)).toBe(false);
-		delete process.env.FAKE_HERMES_OMIT_SUPPORT;
-		process.env.FAKE_HERMES_SOURCE = sourceDir;
-		expect(
-			hostedHermesSkillExactSourceDriver.install({
-				home,
-				appRoot,
-				skill: updatedSkill,
-				previouslyReserved: true,
-			}),
-		).toBe("installed");
-		expect(existsSync(nativeMarker)).toBe(true);
-		expect(
-			hostedHermesSkillExactSourceDriver.uninstall({
-				home,
-				appRoot,
-				skillId: "review-pr",
-				ownershipIdentity: updatedSkill.sourceIdentity,
-			}),
-		).toBe("removed");
 
 		mkdirSync(target, { recursive: true });
 		writeFileSync(join(target, "SKILL.md"), "user-owned\n");
+		expect(() =>
+			hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: false }),
+		).toThrow("not paired with a manifest reservation");
 		expect(() =>
 			hostedHermesSkillExactSourceDriver.uninstall({
 				home,

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -99,80 +99,28 @@ function runHermesUninstall(input: { home: string; appRoot: string }, skillId: s
 	return runHermes(input, ["skills", "uninstall", skillId], "y\n");
 }
 
-const HERMES_SUPPORT_DIRS = new Set(["references", "templates", "scripts", "assets", "examples"]);
-const HERMES_SUPPORT_REFERENCE =
-	/(?:\]\(|`|(?:^|[\s"']))((?:references|templates|scripts|assets|examples)\/[^\s)`"'<>]+)/gm;
-
-/** Mirrors Hermes UrlSource at NousResearch/hermes-agent@a77ee88ce29c4f1d89f8d60e5b662322645072d8. */
-function expectedHermesNativeTree(sourceDir: string) {
-	const catalogTree = collectManagedSkillTree(sourceDir);
-	const skillMd = catalogTree?.get("SKILL.md");
-	if (!catalogTree || !skillMd) return null;
-	const text = skillMd.toString("utf8").replaceAll("\\", "/");
-	if (
-		/(?:references|templates|scripts|assets|examples)\/(?:[^\s)`"'<>]*\/)?\.\.(?:\/|$)/m.test(text)
-	)
-		return null;
-	// UrlSource fetches SKILL.md as HTTP text and quarantine_bundle writes that
-	// text as UTF-8. Support files stay byte-for-byte HTTP payloads.
-	const expected = new Map<string, Buffer>([
-		["SKILL.md", Buffer.from(skillMd.toString("utf8"), "utf8")],
-	]);
-	for (const match of text.matchAll(HERMES_SUPPORT_REFERENCE)) {
-		let relative: string;
-		try {
-			relative = decodeURIComponent(
-				(match[1] ?? "").replace(/[.,;:]+$/, "").split(/[?#]/, 1)[0] ?? "",
-			);
-		} catch {
-			return null;
-		}
-		const segments = relative.split("/");
-		if (
-			!HERMES_SUPPORT_DIRS.has(segments[0] ?? "") ||
-			segments.some((segment) => !segment || segment === "." || segment === "..")
-		)
-			return null;
-		const bytes = catalogTree.get(relative);
-		if (!bytes) return null;
-		expected.set(relative, bytes);
-	}
-	return expected;
-}
-
-function nativeResultMatches(
-	skill: PreparedHostedSourcedSkill,
-	sourceDir: string,
-	target: string,
-): boolean {
+function bundledResultMatches(sourceDir: string, target: string): boolean {
 	return managedSkillTreesEqual(
-		skill.source.type === "bundled"
-			? collectManagedSkillTree(sourceDir)
-			: expectedHermesNativeTree(sourceDir),
+		collectManagedSkillTree(sourceDir),
 		collectManagedSkillTree(target),
 	);
 }
 
 export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDriver = {
 	install(input) {
+		const target = targetDir(input.home, input.skill.skillId);
+		const receipt = receiptInput(input.home, input.skill.skillId, input.skill.sourceIdentity);
+		if (existsSync(target) && !input.previouslyReserved)
+			throw new Error("Hermes Skill target is not paired with a manifest reservation");
+		if (managedSkillReceiptMatchesIdentity(receipt)) return "unchanged";
 		return withStagedManagedSkill(input.skill, (sourceDir) => {
-			const target = targetDir(input.home, input.skill.skillId);
-			const receipt = receiptInput(input.home, input.skill.skillId, input.skill.sourceIdentity);
-			const hadTarget = existsSync(target);
-			if (hadTarget && !input.previouslyReserved)
-				throw new Error("Hermes Skill target is not paired with a manifest reservation");
-			if (
-				nativeResultMatches(input.skill, sourceDir, target) &&
-				managedSkillReceiptMatchesIdentity(receipt)
-			)
-				return "unchanged";
 			return withManagedTargetRollback({
 				target,
 				receipt: receipt.path,
 				operation: () => {
 					if (input.skill.source.type === "bundled") {
 						withRuntimeUserFileAccess(() => replaceManagedSkillDirectoryAtomic(sourceDir, target));
-						if (!nativeResultMatches(input.skill, sourceDir, target)) {
+						if (!bundledResultMatches(sourceDir, target)) {
 							throw new Error("Hermes bundled Skill activation changed exact source bytes");
 						}
 						writeManagedSkillReceipt(receipt);
@@ -192,18 +140,6 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 						throw new Error(
 							`Hermes official Skill install failed: ${String(result.stderr || result.stdout).trim() || "unknown error"}`,
 						);
-					if (!nativeResultMatches(input.skill, sourceDir, target)) {
-						if (!hadTarget && existsSync(target)) {
-							const rollback = runHermesUninstall(input, input.skill.skillId);
-							if (rollback.status !== 0 || existsSync(target))
-								throw new Error(
-									`Hermes official install produced invalid Skill bytes and native rollback failed: ${String(rollback.stderr || rollback.stdout).trim() || (existsSync(target) ? "Skill target still exists" : "unknown error")}`,
-								);
-						}
-						throw new Error(
-							"Hermes official install did not preserve the exact native catalog projection",
-						);
-					}
 					writeManagedSkillReceipt(receipt);
 					return "installed" as const;
 				},
@@ -211,13 +147,8 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 		});
 	},
 	verifyOwned(input) {
-		return withStagedManagedSkill(
-			input.skill,
-			(sourceDir) =>
-				nativeResultMatches(input.skill, sourceDir, targetDir(input.home, input.skill.skillId)) &&
-				managedSkillReceiptMatchesIdentity(
-					receiptInput(input.home, input.skill.skillId, input.skill.sourceIdentity),
-				),
+		return managedSkillReceiptMatchesIdentity(
+			receiptInput(input.home, input.skill.skillId, input.skill.sourceIdentity),
 		);
 	},
 	hasOwnershipReceipt(input) {

--- a/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
@@ -203,6 +203,7 @@ rm -rf '${workspaceRoot}/skills/'"$skill_id"
 cp -R "$source_dir" '${workspaceRoot}/skills/'"$skill_id"
 mkdir -p '${workspaceRoot}/skills/'"$skill_id"'/.openclaw'
 printf '{}\n' > '${workspaceRoot}/skills/'"$skill_id"'/.openclaw/source-origin.json'
+printf '{"installed":true}\n' > '${workspaceRoot}/skills/'"$skill_id"'/.openclaw-native.json'
 if test "\${FAKE_OPENCLAW_FAIL_AFTER_WRITE:-}" = "1"; then exit 45; fi
 if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDriftMarker}'; fi
 `,
@@ -234,6 +235,8 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 	expect(readFileSync(installLog, "utf8")).toMatch(
 		/^skills install .* --agent main --as review-pr --force\n$/,
 	);
+	expect(hostedOpenClawSkillDriver.install({ home, workspaceRoot, skill })).toBe("unchanged");
+	expect(readFileSync(installLog, "utf8").trim().split("\n")).toHaveLength(1);
 	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, skill })).toBe(true);
 	const target = join(workspaceRoot, "skills", "review-pr");
 	const receipt = join(workspaceRoot, "skills", ".clawdi-manifest-receipts", "review-pr.json");

--- a/packages/cli/src/runtime/hosted-openclaw-skill.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.ts
@@ -6,11 +6,9 @@ import {
 } from "../adapters/openclaw-workspace";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import {
-	collectManagedSkillTree,
 	managedSkillMarkerMatchesIdentity,
 	managedSkillMarkerOwnsTarget,
 	managedSkillReceiptMatchesIdentity,
-	managedSkillTreesEqual,
 	withManagedTargetRollback,
 	withStagedManagedSkill,
 	writeManagedSkillReceipt,
@@ -161,13 +159,6 @@ function assertOfficialWorkspace(input: { home: string; workspaceRoot: string })
 		throw new Error("OpenClaw official agent workspace changed during Skill reconciliation");
 }
 
-function nativeResultMatches(sourceDir: string, target: string): boolean {
-	return managedSkillTreesEqual(
-		collectManagedSkillTree(sourceDir),
-		collectManagedSkillTree(target, { exclude: EXCLUDED_NATIVE_FILES }),
-	);
-}
-
 function commandFailureDetail(result: ReturnType<typeof spawnRuntimeUserCommand>): string {
 	const details: string[] = [];
 	if (result.error) details.push(`spawn error: ${result.error.message}`);
@@ -191,8 +182,7 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 	installDirectory(input) {
 		const target = targetDir(input.workspaceRoot, input.skillId);
 		const receipt = receiptInput(input.workspaceRoot, input.skillId, input.ownershipIdentity);
-		if (nativeResultMatches(input.sourceDir, target) && managedSkillReceiptMatchesIdentity(receipt))
-			return "unchanged";
+		if (managedSkillReceiptMatchesIdentity(receipt)) return "unchanged";
 		if (existsSync(target) && !input.previouslyReserved && !managedSkillMarkerOwnsTarget(receipt))
 			throw new Error(
 				"refusing to replace an OpenClaw Skill without a matching Clawdi ownership receipt",
@@ -223,10 +213,6 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 					throw new Error(
 						`OpenClaw official Skill install failed: ${commandFailureDetail(result)}`,
 					);
-				if (!nativeResultMatches(input.sourceDir, target))
-					throw new Error(
-						`OpenClaw installed Skill outside the configured agent workspace or changed exact source bytes: ${target}`,
-					);
 				assertOfficialWorkspace(input);
 				writeManagedSkillReceipt(receipt);
 				return "installed" as const;
@@ -234,6 +220,12 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 		});
 	},
 	install(input) {
+		if (
+			managedSkillReceiptMatchesIdentity(
+				receiptInput(input.workspaceRoot, input.skill.skillId, input.skill.sourceIdentity),
+			)
+		)
+			return "unchanged";
 		return withStagedManagedSkill(input.skill, (sourceDir) =>
 			this.installDirectory({
 				home: input.home,
@@ -251,13 +243,8 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 		);
 	},
 	verifyOwned(input) {
-		return withStagedManagedSkill(
-			input.skill,
-			(sourceDir) =>
-				nativeResultMatches(sourceDir, targetDir(input.workspaceRoot, input.skill.skillId)) &&
-				managedSkillMarkerMatchesIdentity(
-					receiptInput(input.workspaceRoot, input.skill.skillId, input.skill.sourceIdentity),
-				),
+		return managedSkillReceiptMatchesIdentity(
+			receiptInput(input.workspaceRoot, input.skill.skillId, input.skill.sourceIdentity),
 		);
 	},
 	cleanupManifestOwned(input) {

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -4223,6 +4223,88 @@ echo spawned > '${installerLog}'
 		expect(existsSync(join(paths.userHome, ".local", "bin", "openclaw"))).toBe(false);
 	});
 
+	test("migrates the real legacy Hermes bundle once and then stays receipt-anchored", () => {
+		const paths = tempRuntimePaths();
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		mkdirSync(dirname(hermesCommand), { recursive: true });
+		writeFileSync(hermesCommand, "#!/bin/sh\nexit 0\n");
+		chmodSync(hermesCommand, 0o755);
+		const source = resolve(import.meta.dir, "../..", "skills", "hosted-versions", "1", "clawdi");
+		const target = join(paths.userHome, ".hermes", "skills", "clawdi");
+		const skillPath = join(target, "SKILL.md");
+		const sourceSkill = readFileSync(join(source, "SKILL.md"));
+		const catalogEntry = resolveHostedBundledSkill("clawdi", 1);
+		cpSync(source, target, { recursive: true });
+		chmodSync(target, 0o755);
+		chmodSync(skillPath, 0o644);
+		writeFileSync(
+			join(target, ".clawdi-managed.json"),
+			`${JSON.stringify({
+				schema: "clawdi.hostedBundledSkillMarker.v1",
+				owner: "clawdi runtime init",
+				id: "clawdi",
+				version: 1,
+				digest: catalogEntry.digest,
+			})}\n`,
+		);
+		const manifest = baseManifest(
+			paths,
+			{
+				hermes: {
+					enabled: true,
+					run: runSettings(hermesCommand, ["gateway"]),
+					services: {},
+				},
+			},
+			{ projection: { skills: { entries: { clawdi: { enabled: true, version: 1 } } } } },
+		);
+		const receipt = join(
+			paths.userHome,
+			".hermes",
+			"skills",
+			".clawdi-manifest-receipts",
+			"clawdi.json",
+		);
+		const converge = (generation: number) => {
+			const result = convergeRuntimeManifest(
+				manifestLoad({ ...manifest, generation }, `legacy-hermes-bundle-${generation}`),
+				paths,
+			);
+			expect([...result.installErrors, ...result.resourceProjectionErrors]).toEqual([]);
+		};
+		const snapshot = () => ({
+			target: statSync(target).ino,
+			skill: statSync(skillPath).ino,
+			receipt: readFileSync(receipt),
+		});
+
+		converge(1);
+		expect(existsSync(join(target, ".clawdi-managed.json"))).toBe(false);
+		expect(readFileSync(skillPath)).toEqual(sourceSkill);
+		expect(sourceSkill).toHaveLength(6002);
+		expect(createHash("sha256").update(sourceSkill).digest("hex")).toBe(
+			"89b3820af2f694a84526c06990ab6398fef2aa5b25d7812dd7a04ed1d46bdd61",
+		);
+		expect(JSON.parse(readFileSync(receipt, "utf8"))).toMatchObject({
+			ownershipIdentity: `content-sha256\0${catalogEntry.digest}`,
+			treeFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+		});
+
+		let stable = snapshot();
+		for (const generation of [2, 3]) {
+			converge(generation);
+			expect(snapshot()).toEqual(stable);
+		}
+
+		writeFileSync(skillPath, "tampered\n");
+		converge(4);
+		expect(readFileSync(skillPath)).toEqual(sourceSkill);
+		stable = snapshot();
+		converge(5);
+		expect(snapshot()).toEqual(stable);
+	});
+
 	test("keeps the hosted skill ledger root owned while mutating the runtime-user skill tree", () => {
 		if (process.geteuid?.() !== 0) return;
 		const paths = tempRuntimePaths();


### PR DESCRIPTION
## Field evidence

The 0.14.1 Hermes canary repeatedly reported:

```
runtime hermes Skill projection failed: Hermes official install did not preserve the exact native catalog projection
```

Follow-up forensics disproved the initial upstream-drift hypothesis:

- Hermes was v0.20.4 at commit `a77ee88`, the same revision mirrored by the CLI predictor.
- The machine had no sourced Skills. It had only the legacy bundled `clawdi` Skill, identified by a v1 tree marker and no manifest receipt.
- Its `SKILL.md` exactly matched the shipped asset: 6002 bytes, SHA-256 `89b3820af2f694a84526c06990ab6398fef2aa5b25d7812dd7a04ed1d46bdd61`.
- The predictor returned a non-null tree for that asset, and the long quoted YAML description did not cause upstream re-encoding.
- The 0.14.1 bundled path does not invoke the sourced projection check.

That exact disk state therefore reproduces the legacy adoption state machine, but does not independently explain how a sourced-only error was emitted. This PR does not claim version drift, YAML re-encoding, or the predictor's null path as the proven field trigger.

The structural failure is independently reproducible: a successful official install can produce legitimate native files outside the CLI's predicted tree, while unresolved support references can make the predictor return `null`. The old code installed first and then deterministically rejected both results with the same misleading projection error. A version-specific output predictor is not a valid correctness authority for an intentionally unpinned official installer.

## Design

- Keep archive SHA verification, staging safety checks, and bundled catalog digest verification unchanged.
- Bind each receipt to the manifest source identity and the fingerprint of the tree the official installer actually wrote.
- Treat matching source identity plus matching current-tree fingerprint as `unchanged`, before staging or invoking a CLI.
- On source identity or tree mismatch, require the existing reservation and reinstall with native force semantics before recording a new fingerprint.
- Recover an exact legacy bundled marker into the reservation ledger once, reinstall through the normal managed path, write the receipt, and remove the tree marker.
- Apply the same receipt anchor to OpenClaw, whose driver had the same output-prediction coupling.

The Hermes predictor, support-path parser, `a77ee88` mirror note, null behavior, projection check, and projection error are deleted completely. OpenClaw's source-vs-native tree prediction is deleted as well.

## Trust and ownership boundary

This is trust-on-install, not a new trust grant. Clawdi already executes the official Hermes or OpenClaw binary and trusts its native installation side effects. Recording that binary's actual output in a receipt uses the same trust boundary instead of maintaining a second implementation of upstream behavior.

The receipt is only an integrity anchor. The reservation ledger remains the sole ownership authority. Existing unmanaged-target refusal, private receipt ownership/mode checks, safe tree fingerprinting, rollback, and cleanup fail-closed behavior remain intact.

If the process is killed after native install but before the receipt write, the durable reservation still proves ownership while the missing/mismatched receipt prevents `unchanged`. The next convergence force-reinstalls and records a fresh anchor. It never adopts an unreserved target.

## Regression coverage

- Use the real 6002-byte bundled `clawdi` asset and a field-shaped v1 marker; verify first convergence writes a receipt and removes the marker.
- Verify two subsequent generations preserve target, `SKILL.md`, and receipt inodes/bytes with no reinstall.
- Tamper with the installed tree, verify self-healing reinstall, then verify the repaired state remains stable.
- Simulate Hermes output transformation, an extra native file, and a missing support reference that made the old predictor return `null`; verify install anchors successfully and the next pass is unchanged.
- Verify source identity changes reinstall and re-anchor.
- Verify an unreserved existing target is still rejected.
- Verify equivalent OpenClaw native output is receipt-anchored.

Verification:

- `bun run --cwd packages/cli typecheck`
- Biome: 332 files, no fixes
- Skill-related suite: 655 tests across 23 files, 0 failures
- `git diff --check`

This change is 133 insertions and 200 deletions: net 67 lines removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
