### PR TITLE
release(cli): 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.2
+
+Package: `clawdi@0.14.2`
+
+### Fixed
+
+- Managed skill installs are now anchored to the receipt of what the official
+  installer actually wrote, instead of predicting the installer's byte
+  transformation. This removes the "did not preserve the exact native catalog
+  projection" failure class entirely and decouples skill convergence from the
+  installed Hermes version.
+
 ## Clawdi CLI v0.14.1
 
 Package: `clawdi@0.14.1`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.1",
+	"version": "0.14.2",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Release `clawdi@0.14.2` — second canary-driven patch.

The 0.14.1 retest on the owner deployment cleared the plugin regression (sui failed→installed) but surfaced an intermittent managed-skill projection error. #1145 removed the entire "predict the official installer's byte transformation" shadow layer (net −67 lines) and anchored skill idempotence to the receipt of what the installer actually wrote — eliminating that failure class and decoupling skill convergence from the installed Hermes version.

Retest on the same deployment follows this release; pass bar is multiple consecutive clean converges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)