### PR TITLE
fix(cli): enforce tenant ownership and secure Skill receipts

### DIFF
--- a/packages/cli/src/runtime/hermes-agent-plugin-canary-client.ts
+++ b/packages/cli/src/runtime/hermes-agent-plugin-canary-client.ts
@@ -8,7 +8,7 @@ import {
 	hostedAgentPluginTreeDigest,
 	type PreparedHostedAgentPlugin,
 } from "./hosted-agent-plugin-package";
-import { makeRuntimeUserOwned, withRuntimeUserFileAccess } from "./runtime-user-command";
+import { withRuntimeUserFileAccess } from "./runtime-user-command";
 
 const HERMES_REMOTE_PROBE_TIMEOUT_MS = 30_000;
 const HERMES_CONTROLLER_READY_TIMEOUT_MS = 5_000;
@@ -47,12 +47,15 @@ function waitForJsonFile<T>(path: string, schema: z.ZodType<T>, timeoutMs: numbe
 	let sawInvalidEvidence = false;
 	while (Date.now() < deadline) {
 		try {
-			const stat = lstatSync(path);
-			if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 64 * 1024) {
-				throw new Error("Hermes Agent Plugin canary returned unsafe evidence");
-			}
+			const evidence = withRuntimeUserFileAccess(() => {
+				const stat = lstatSync(path);
+				if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 64 * 1024) {
+					throw new Error("Hermes Agent Plugin canary returned unsafe evidence");
+				}
+				return readFileSync(path, "utf8");
+			});
 			try {
-				const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+				const parsed: unknown = JSON.parse(evidence);
 				return schema.parse(parsed);
 			} catch {
 				sawInvalidEvidence = true;
@@ -173,11 +176,9 @@ export function runHermesAgentPluginCanary(input: HermesAgentPluginCanaryInput):
 		const hermesRoot = join(input.home, ".hermes");
 		// Hermes exposes this packaged-install override independently of HERMES_HOME/plugins.
 		const bundledPluginRoot = join(input.home, ".clawdi-hermes-canary-bundled-plugins");
-		mkdirSync(hermesRoot, { recursive: true, mode: 0o700 });
-		mkdirSync(bundledPluginRoot, { recursive: true, mode: 0o700 });
-		makeRuntimeUserOwned(hermesRoot);
-		makeRuntimeUserOwned(bundledPluginRoot);
-		withRuntimeUserFileAccess(() =>
+		withRuntimeUserFileAccess(() => {
+			mkdirSync(hermesRoot, { recursive: true, mode: 0o700 });
+			mkdirSync(bundledPluginRoot, { recursive: true, mode: 0o700 });
 			writeFileSync(
 				join(hermesRoot, "config.yaml"),
 				[
@@ -200,8 +201,8 @@ export function runHermesAgentPluginCanary(input: HermesAgentPluginCanaryInput):
 					"",
 				].join("\n"),
 				{ mode: 0o600 },
-			),
-		);
+			);
+		});
 		input.withEnabledCanary(canary, () => {
 			input.runOneShot({
 				args: [

--- a/packages/cli/src/runtime/hermes-agent-plugin-canary-controller.test.ts
+++ b/packages/cli/src/runtime/hermes-agent-plugin-canary-controller.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { chownSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -19,6 +20,15 @@ test("records MCP list and call evidence without inference assertions", async ()
 	const readyFile = join(root, "ready.json");
 	const resultFile = join(root, "result.json");
 	const nonce = "a".repeat(32);
+	const runtimeIdentity =
+		process.geteuid?.() === 0
+			? {
+					user: "nobody",
+					uid: Number(execFileSync("id", ["-u", "nobody"], { encoding: "utf8" })),
+					gid: Number(execFileSync("id", ["-g", "nobody"], { encoding: "utf8" })),
+				}
+			: null;
+	if (runtimeIdentity) chownSync(root, runtimeIdentity.uid, runtimeIdentity.gid);
 	const child = Bun.spawn(
 		[
 			"bun",
@@ -34,7 +44,18 @@ test("records MCP list and call evidence without inference assertions", async ()
 		],
 		{
 			cwd: root,
-			env: { ...process.env, CLAWDI_NO_UPDATE_CHECK: "1", CLAWDI_NO_AUTO_UPDATE: "1" },
+			env: {
+				...process.env,
+				CLAWDI_NO_UPDATE_CHECK: "1",
+				CLAWDI_NO_AUTO_UPDATE: "1",
+				...(runtimeIdentity
+					? {
+							CLAWDI_RUNTIME_USER: runtimeIdentity.user,
+							CLAWDI_RUNTIME_UID: String(runtimeIdentity.uid),
+							CLAWDI_RUNTIME_GID: String(runtimeIdentity.gid),
+						}
+					: {}),
+			},
 			stdout: "ignore",
 			stderr: "pipe",
 		},
@@ -55,6 +76,12 @@ test("records MCP list and call evidence without inference assertions", async ()
 			mcpToolsList: true,
 			mcpToolCall: true,
 		});
+		if (runtimeIdentity) {
+			expect([statSync(readyFile).uid, statSync(resultFile).uid]).toEqual([
+				runtimeIdentity.uid,
+				runtimeIdentity.uid,
+			]);
+		}
 	} finally {
 		await client?.close();
 		child.kill("SIGTERM");

--- a/packages/cli/src/runtime/hermes-agent-plugin-canary-controller.ts
+++ b/packages/cli/src/runtime/hermes-agent-plugin-canary-controller.ts
@@ -4,6 +4,7 @@ import { isAbsolute } from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { z } from "zod";
+import { withRuntimeUserFileAccess } from "./runtime-user-command";
 
 const MAX_REQUEST_BYTES = 8 * 1024 * 1024;
 const CONTROLLER_LIFETIME_MS = 45_000;
@@ -22,13 +23,15 @@ interface CanaryEvidence {
 }
 
 function writeJsonAtomic(path: string, value: unknown, nonce: string): void {
-	const temporary = `${path}.${process.pid}.${nonce}.tmp`;
-	try {
-		writeFileSync(temporary, `${JSON.stringify(value)}\n`, { flag: "wx", mode: 0o600 });
-		renameSync(temporary, path);
-	} finally {
-		rmSync(temporary, { force: true });
-	}
+	withRuntimeUserFileAccess(() => {
+		const temporary = `${path}.${process.pid}.${nonce}.tmp`;
+		try {
+			writeFileSync(temporary, `${JSON.stringify(value)}\n`, { flag: "wx", mode: 0o600 });
+			renameSync(temporary, path);
+		} finally {
+			rmSync(temporary, { force: true });
+		}
+	});
 }
 
 function parseJsonObject(bytes: Buffer): Record<string, unknown> {

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
@@ -1,6 +1,16 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	chownSync,
+	cpSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -17,6 +27,12 @@ import {
 	proveHostedAgentPluginCapabilities,
 } from "./hosted-agent-plugin-runtime";
 import { AGENT_PLUGINS_SCHEMA_1_0_0 } from "./manifest-resources";
+import {
+	enforceRuntimeUserOwnership,
+	runtimeUserExistingOwnership,
+	runtimeUserGid,
+	runtimeUserUid,
+} from "./runtime-user-command";
 
 type CommandInput = Parameters<HostedAgentPluginCommandRunner["run"]>[0];
 
@@ -438,6 +454,77 @@ function desiredState(
 const commands = { openclaw: "/runtime/openclaw", hermes: "/runtime/hermes" };
 
 describe("Hosted Agent Plugin native reconciliation", () => {
+	test("observes installed plugin bytes only through the repaired runtime-user identity", () => {
+		if (process.geteuid?.() !== 0) return;
+		const runner = new FakeNativeRunner();
+		const desired = plugin("acme.tools", "1.2.3", "8".repeat(64));
+		runner.seed(
+			"openclaw",
+			{
+				name: desired.name,
+				nativeId: "acme-tools",
+				version: desired.installation.version,
+				enabled: true,
+				compatible: true,
+			},
+			desired,
+		);
+		const prepared = desiredState("openclaw", desired, {
+			runtime: "openclaw",
+			plugin: desired,
+		});
+		const capabilityProof = proveHostedAgentPluginCapabilities({ prepared, commands, runner });
+		const stateRoot = join(runner.liveHome, ".openclaw");
+		const installRoot = join(stateRoot, "extensions", "acme-tools");
+		const runtimeUid = runtimeUserUid("nobody");
+		const runtimeGid = runtimeUserGid("nobody");
+		const previousRootMode = statSync(runtimeTestRoot).mode & 0o777;
+		const previousRuntimeUser = process.env.CLAWDI_RUNTIME_USER;
+		const previousRuntimeUid = process.env.CLAWDI_RUNTIME_UID;
+		const previousRuntimeGid = process.env.CLAWDI_RUNTIME_GID;
+		try {
+			chmodSync(runtimeTestRoot, 0o755);
+			for (const path of [runner.liveHome, stateRoot, join(stateRoot, "extensions")]) {
+				chownSync(path, runtimeUid, runtimeGid);
+			}
+			chownSync(installRoot, 0, 0);
+			chmodSync(installRoot, 0o700);
+			process.env.CLAWDI_RUNTIME_USER = "nobody";
+			process.env.CLAWDI_RUNTIME_UID = String(runtimeUid);
+			process.env.CLAWDI_RUNTIME_GID = String(runtimeGid);
+
+			expect(() =>
+				prepareHostedAgentPluginTransaction({
+					prepared,
+					home: runner.liveHome,
+					commands,
+					capabilityProof,
+					runner,
+				}),
+			).toThrow();
+
+			enforceRuntimeUserOwnership(runtimeUserExistingOwnership([stateRoot], { recursive: true }));
+			expect(() =>
+				prepareHostedAgentPluginTransaction({
+					prepared,
+					home: runner.liveHome,
+					commands,
+					capabilityProof,
+					runner,
+				}),
+			).not.toThrow();
+			expect(statSync(installRoot).uid).toBe(runtimeUid);
+		} finally {
+			chmodSync(runtimeTestRoot, previousRootMode);
+			if (previousRuntimeUser === undefined) delete process.env.CLAWDI_RUNTIME_USER;
+			else process.env.CLAWDI_RUNTIME_USER = previousRuntimeUser;
+			if (previousRuntimeUid === undefined) delete process.env.CLAWDI_RUNTIME_UID;
+			else process.env.CLAWDI_RUNTIME_UID = previousRuntimeUid;
+			if (previousRuntimeGid === undefined) delete process.env.CLAWDI_RUNTIME_GID;
+			else process.env.CLAWDI_RUNTIME_GID = previousRuntimeGid;
+		}
+	});
+
 	test("uses OpenClaw native lifecycle and repeats as a live no-op", () => {
 		const runner = new FakeNativeRunner();
 		const desired = plugin("acme.tools", "1.2.3", "a".repeat(64));

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
@@ -23,6 +23,7 @@ import {
 	commandResolvable,
 	makeRuntimeUserOwned,
 	spawnRuntimeUserCommand,
+	withRuntimeUserFileAccess,
 } from "./runtime-user-command";
 
 const COMMAND_TIMEOUT_MS = 120_000;
@@ -112,7 +113,7 @@ export type HermesRemoteCapabilityProbe = (input: {
 }) => void;
 
 const defaultCommandRunner: HostedAgentPluginCommandRunner = {
-	available: commandResolvable,
+	available: (command) => withRuntimeUserFileAccess(() => commandResolvable(command)),
 	run(input) {
 		const result = spawnRuntimeUserCommand(input.command, input.args, input.home, input.cwd, {
 			environmentOverrides: input.environmentOverrides,
@@ -261,13 +262,15 @@ function nativeInstallTarget(
 }
 
 function nativeInstallTargetExists(path: string): boolean {
-	try {
-		lstatSync(path);
-		return true;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
-		throw error;
-	}
+	return withRuntimeUserFileAccess(() => {
+		try {
+			lstatSync(path);
+			return true;
+		} catch (error) {
+			if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+			throw error;
+		}
+	});
 }
 
 function assertTrustedInstalledDirectory(
@@ -298,6 +301,29 @@ function assertTrustedInstalledDirectory(
 		}
 	}
 	return expected;
+}
+
+function inspectInstalledPluginDirectory(input: {
+	home: string;
+	runtime: HostedAgentPluginRuntime;
+	nativeId: string;
+	reportedPath?: string;
+	ignoreTopLevelGitMetadata?: boolean;
+}): { installPath: string; contentDigest: string } {
+	return withRuntimeUserFileAccess(() => {
+		const installPath = assertTrustedInstalledDirectory(
+			input.home,
+			input.runtime,
+			input.nativeId,
+			input.reportedPath,
+		);
+		return {
+			installPath,
+			contentDigest: hostedAgentPluginDirectoryDigest(installPath, {
+				ignoreTopLevelGitMetadata: input.ignoreTopLevelGitMetadata,
+			}),
+		};
+	});
 }
 
 function createOpenClawDriver(input: {
@@ -340,13 +366,12 @@ function createOpenClawDriver(input: {
 			if (!inspect.install.installPath) {
 				throw new Error("OpenClaw did not report a controlled Agent Plugin install path");
 			}
-			installPath = assertTrustedInstalledDirectory(
-				input.home,
-				"openclaw",
-				inspect.plugin.id,
-				inspect.install.installPath,
-			);
-			contentDigest = hostedAgentPluginDirectoryDigest(installPath);
+			({ installPath, contentDigest } = inspectInstalledPluginDirectory({
+				home: input.home,
+				runtime: "openclaw",
+				nativeId: inspect.plugin.id,
+				reportedPath: inspect.install.installPath,
+			}));
 		}
 		return {
 			runtime: "openclaw",
@@ -444,7 +469,9 @@ type HermesNativeCommand = (args: string[]) => AgentPluginCommandResult;
 
 function ensureHermesPluginScanDisabled(home: string, run: HermesNativeCommand): void {
 	const configPath = join(home, ".hermes", "config.yaml");
-	const current = getHermesRawConfigFileValue(configPath, HERMES_PLUGIN_SCAN_POLICY_KEY);
+	const current = withRuntimeUserFileAccess(() =>
+		getHermesRawConfigFileValue(configPath, HERMES_PLUGIN_SCAN_POLICY_KEY),
+	);
 	if (current.exists && current.value === false) return;
 
 	// Remove this persistent policy when NousResearch/hermes-agent#89704 ships
@@ -480,10 +507,12 @@ function createHermesDriver(input: {
 		let installPath: string | null = null;
 		let contentDigest: string | null = null;
 		if (compatible) {
-			installPath = assertTrustedInstalledDirectory(input.home, "hermes", plugin.name);
-			contentDigest = hostedAgentPluginDirectoryDigest(installPath, {
+			({ installPath, contentDigest } = inspectInstalledPluginDirectory({
+				home: input.home,
+				runtime: "hermes",
+				nativeId: plugin.name,
 				ignoreTopLevelGitMetadata: true,
-			});
+			}));
 		}
 		return {
 			runtime: "hermes",

--- a/packages/cli/src/runtime/hosted-bundled-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.test.ts
@@ -14,8 +14,8 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import {
-	adoptableLegacyHostedBundledSkill,
 	assertHostedBundledSkillCatalogDigest,
+	claimLegacyHostedBundledSkill,
 	resolveHostedBundledSkill,
 } from "./hosted-bundled-skill";
 import { prepareHostedBundledSkillArchive } from "./hosted-sourced-skill-archive";
@@ -83,7 +83,7 @@ describe("hosted bundled Skill preparation", () => {
 		);
 	});
 
-	test("adopts legacy tree markers only while identity and bytes match exactly", () => {
+	test("claims every legacy marker schema through one receipt-anchored transaction", () => {
 		root = mkdtempSync(join(tmpdir(), "hosted-bundled-legacy-"));
 		const target = join(root, "skills", "clawdi");
 		mkdirSync(dirname(target), { recursive: true });
@@ -91,11 +91,35 @@ describe("hosted bundled Skill preparation", () => {
 		chmodSync(target, 0o755);
 		chmodSync(join(target, "SKILL.md"), 0o644);
 		const marker = join(target, ".clawdi-managed.json");
-		writeFileSync(
-			marker,
-			`${JSON.stringify({ managedBy: "clawdi runtime init", skillName: "clawdi" })}\n`,
-		);
-		expect(adoptableLegacyHostedBundledSkill(target, "clawdi")).toEqual(catalogEntry);
+		const receipt = join(root, "receipts", "clawdi.json");
+		for (const markerValue of [
+			{ managedBy: "clawdi runtime init", skillName: "clawdi" },
+			{
+				schema: "clawdi.hostedBundledSkillMarker.v1",
+				owner: "clawdi runtime init",
+				id: "clawdi",
+				version: 1,
+				digest: catalogEntry.digest,
+			},
+		]) {
+			const operations: string[] = [];
+			writeFileSync(marker, `${JSON.stringify(markerValue)}\n`);
+			expect(
+				claimLegacyHostedBundledSkill({
+					targetDir: target,
+					skillId: "clawdi",
+					reserve: (entry) => operations.push(`reserve:${entry.version}`),
+					anchorOwnership: (identity) => {
+						operations.push(`anchor:${identity}`);
+						mkdirSync(dirname(receipt), { recursive: true });
+						writeFileSync(receipt, identity);
+					},
+				}),
+			).toBe(true);
+			expect(operations).toEqual(["reserve:1", `anchor:content-sha256\0${catalogEntry.digest}`]);
+			expect(existsSync(marker)).toBe(false);
+			expect(readFileSync(receipt, "utf8")).toBe(`content-sha256\0${catalogEntry.digest}`);
+		}
 
 		writeFileSync(
 			marker,
@@ -107,8 +131,19 @@ describe("hosted bundled Skill preparation", () => {
 				digest: catalogEntry.digest,
 			})}\n`,
 		);
-		expect(adoptableLegacyHostedBundledSkill(target, "clawdi")).toEqual(catalogEntry);
 		writeFileSync(join(target, "SKILL.md"), "tenant bytes\n");
-		expect(adoptableLegacyHostedBundledSkill(target, "clawdi")).toBeNull();
+		expect(
+			claimLegacyHostedBundledSkill({
+				targetDir: target,
+				skillId: "clawdi",
+				reserve: () => {
+					throw new Error("must not reserve");
+				},
+				anchorOwnership: () => {
+					throw new Error("must not anchor");
+				},
+			}),
+		).toBe(false);
+		expect(existsSync(marker)).toBe(true);
 	});
 });

--- a/packages/cli/src/runtime/hosted-bundled-skill.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.ts
@@ -200,7 +200,7 @@ export function claimLegacyHostedBundledSkill(input: {
 			throw new Error("legacy hosted Skill identity changed during ownership claim");
 		}
 		rmSync(join(input.targetDir, LEGACY_MARKER));
-		input.anchorOwnership(`content-sha256\0${catalogEntry.digest}`);
 	});
+	input.anchorOwnership(`content-sha256\0${catalogEntry.digest}`);
 	return true;
 }

--- a/packages/cli/src/runtime/hosted-bundled-skill.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.ts
@@ -1,10 +1,11 @@
-import { lstatSync, readdirSync, readFileSync } from "node:fs";
+import { lstatSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import {
 	canonicalManagedBundleFileMode,
 	computeManagedBundleHash,
 	type ManagedBundleHashEntry,
 } from "./managed-bundle-hash";
+import { withRuntimeUserFileAccess } from "./runtime-user-command";
 
 const LEGACY_MARKER = ".clawdi-managed.json";
 const LEGACY_MARKER_SCHEMA = "clawdi.hostedBundledSkillMarker.v1";
@@ -147,7 +148,7 @@ function readLegacyMarker(targetDir: string): Record<string, unknown> | null {
  * supported hosted CLI versions have written reservation-backed receipts and
  * the oldest pre-ledger runtime image is outside the supported upgrade window.
  */
-export function adoptableLegacyHostedBundledSkill(
+function adoptableLegacyHostedBundledSkill(
 	targetDir: string,
 	skillId: string,
 ): HostedBundledSkillCatalogEntry | null {
@@ -180,4 +181,26 @@ export function adoptableLegacyHostedBundledSkill(
 	} catch {
 		return null;
 	}
+}
+
+export function claimLegacyHostedBundledSkill(input: {
+	targetDir: string;
+	skillId: string;
+	reserve(catalogEntry: HostedBundledSkillCatalogEntry): void;
+	anchorOwnership(ownershipIdentity: string): void;
+}): boolean {
+	const catalogEntry = withRuntimeUserFileAccess(() =>
+		adoptableLegacyHostedBundledSkill(input.targetDir, input.skillId),
+	);
+	if (!catalogEntry) return false;
+
+	input.reserve(catalogEntry);
+	withRuntimeUserFileAccess(() => {
+		if (adoptableLegacyHostedBundledSkill(input.targetDir, input.skillId) !== catalogEntry) {
+			throw new Error("legacy hosted Skill identity changed during ownership claim");
+		}
+		rmSync(join(input.targetDir, LEGACY_MARKER));
+		input.anchorOwnership(`content-sha256\0${catalogEntry.digest}`);
+	});
+	return true;
 }

--- a/packages/cli/src/runtime/hosted-hermes-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { hostedHermesSkillExactSourceDriver } from "./hosted-hermes-skill";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
+import { managedSkillReceiptPath } from "./managed-skill-delivery";
 
 const originalEnv = { ...process.env };
 let root = "";
@@ -87,6 +88,8 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		root = mkdtempSync(join(tmpdir(), "hosted-hermes-project-skill-"));
 		delete process.env.CLAWDI_RUNTIME_USER;
 		const home = join(root, "home");
+		const managedResourceRoot = join(root, "managed-resources");
+		mkdirSync(managedResourceRoot, { recursive: true });
 		const appRoot = fakeHermesApp(home);
 		const sourceDir = join(root, "source", "review-pr");
 		mkdirSync(sourceDir, { recursive: true });
@@ -123,6 +126,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 			hostedHermesSkillExactSourceDriver.install({
 				home,
 				appRoot,
+				managedResourceRoot,
 				skill,
 				previouslyReserved: false,
 			}),
@@ -139,6 +143,8 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		delete process.env.CLAWDI_RUNTIME_USER;
 		process.env.HERMES_HOME = join(root, "wrong-profile");
 		const home = join(root, "home");
+		const managedResourceRoot = join(root, "managed-resources");
+		mkdirSync(managedResourceRoot, { recursive: true });
 		const appRoot = fakeHermesApp(home);
 		const sourceDir = join(root, "source", "review-pr");
 		mkdirSync(sourceDir, { recursive: true });
@@ -172,6 +178,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		const input = {
 			home,
 			appRoot,
+			managedResourceRoot,
 			skill,
 		};
 
@@ -179,7 +186,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 			hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: false }),
 		).toBe("installed");
 		const target = join(home, ".hermes", "skills", "review-pr");
-		const receipt = join(home, ".hermes", "skills", ".clawdi-manifest-receipts", "review-pr.json");
+		const receipt = managedSkillReceiptPath(managedResourceRoot, "hermes", "review-pr");
 		expect(readFileSync(join(target, "SKILL.md"))).toEqual(skillV1Native);
 		expect(readFileSync(join(target, "references", "guide.md"), "utf8")).toBe("Pinned guide\n");
 		expect(readFileSync(join(target, ".hermes-native.json"), "utf8")).toBe('{"installed": true}\n');
@@ -195,6 +202,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		expect(
 			hostedHermesSkillExactSourceDriver.hasOwnershipReceipt({
 				home,
+				managedResourceRoot,
 				skillId: "review-pr",
 				ownershipIdentity: skill.sourceIdentity,
 			}),
@@ -202,6 +210,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		expect(
 			hostedHermesSkillExactSourceDriver.hasOwnershipReceipt({
 				home,
+				managedResourceRoot,
 				skillId: "review-pr",
 				ownershipIdentity: `${skill.sourceIdentity}-other`,
 			}),
@@ -247,6 +256,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 			hostedHermesSkillExactSourceDriver.install({
 				home,
 				appRoot,
+				managedResourceRoot,
 				skill: updatedSkill,
 				previouslyReserved: true,
 			}),
@@ -260,6 +270,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 			hostedHermesSkillExactSourceDriver.uninstall({
 				home,
 				appRoot,
+				managedResourceRoot,
 				skillId: "review-pr",
 				ownershipIdentity: updatedSkill.sourceIdentity,
 			}),
@@ -270,6 +281,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 			hostedHermesSkillExactSourceDriver.uninstall({
 				home,
 				appRoot,
+				managedResourceRoot,
 				skillId: "review-pr",
 				ownershipIdentity: updatedSkill.sourceIdentity,
 			}),
@@ -285,6 +297,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 			hostedHermesSkillExactSourceDriver.uninstall({
 				home,
 				appRoot,
+				managedResourceRoot,
 				skillId: "review-pr",
 				ownershipIdentity: skill.sourceIdentity,
 			}),

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import {
 	collectManagedSkillTree,
+	collectRuntimeUserManagedSkillTree,
 	managedSkillMarkerMatchesIdentity,
 	managedSkillReceiptMatchesIdentity,
 	managedSkillTreesEqual,
@@ -26,6 +27,7 @@ export interface HostedHermesSkillExactSourceDriver {
 		skill: PreparedHostedSourcedSkill;
 		previouslyReserved: boolean;
 	}): "installed" | "unchanged";
+	anchorOwnership(input: { home: string; skillId: string; ownershipIdentity: string }): void;
 	verifyOwned(input: { home: string; appRoot: string; skill: PreparedHostedSourcedSkill }): boolean;
 	hasOwnershipReceipt(input: { home: string; skillId: string; ownershipIdentity: string }): boolean;
 	uninstall(input: {
@@ -42,12 +44,14 @@ export interface HostedHermesSkillExactSourceDriver {
 }
 
 function commandPath(home: string, appRoot: string): string {
-	for (const candidate of [
-		join(appRoot, "venv", "bin", "hermes"),
-		join(home, ".local", "bin", "hermes"),
-	])
-		if (executableExists(candidate)) return candidate;
-	throw new Error("installed Hermes Skill CLI is unavailable");
+	return withRuntimeUserFileAccess(() => {
+		for (const candidate of [
+			join(appRoot, "venv", "bin", "hermes"),
+			join(home, ".local", "bin", "hermes"),
+		])
+			if (executableExists(candidate)) return candidate;
+		throw new Error("installed Hermes Skill CLI is unavailable");
+	});
 }
 const targetDir = (home: string, skillId: string) => join(home, ".hermes", "skills", skillId);
 const receiptPath = (home: string, skillId: string) =>
@@ -102,7 +106,7 @@ function runHermesUninstall(input: { home: string; appRoot: string }, skillId: s
 function bundledResultMatches(sourceDir: string, target: string): boolean {
 	return managedSkillTreesEqual(
 		collectManagedSkillTree(sourceDir),
-		collectManagedSkillTree(target),
+		collectRuntimeUserManagedSkillTree(target),
 	);
 }
 
@@ -110,41 +114,46 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 	install(input) {
 		const target = targetDir(input.home, input.skill.skillId);
 		const receipt = receiptInput(input.home, input.skill.skillId, input.skill.sourceIdentity);
-		if (existsSync(target) && !input.previouslyReserved)
+		if (withRuntimeUserFileAccess(() => existsSync(target)) && !input.previouslyReserved)
 			throw new Error("Hermes Skill target is not paired with a manifest reservation");
 		if (managedSkillReceiptMatchesIdentity(receipt)) return "unchanged";
 		return withStagedManagedSkill(input.skill, (sourceDir) => {
-			return withManagedTargetRollback({
-				target,
-				receipt: receipt.path,
-				operation: () => {
-					if (input.skill.source.type === "bundled") {
-						withRuntimeUserFileAccess(() => replaceManagedSkillDirectoryAtomic(sourceDir, target));
-						if (!bundledResultMatches(sourceDir, target)) {
-							throw new Error("Hermes bundled Skill activation changed exact source bytes");
+			return withRuntimeUserFileAccess(() =>
+				withManagedTargetRollback({
+					target,
+					receipt: receipt.path,
+					operation: () => {
+						if (input.skill.source.type === "bundled") {
+							replaceManagedSkillDirectoryAtomic(sourceDir, target);
+							if (!bundledResultMatches(sourceDir, target)) {
+								throw new Error("Hermes bundled Skill activation changed exact source bytes");
+							}
+							writeManagedSkillReceipt(receipt);
+							return "installed" as const;
 						}
+						const args = [
+							"skills",
+							"install",
+							rawSkillUrl(input.skill),
+							"--name",
+							input.skill.skillId,
+							"--yes",
+						];
+						if (input.previouslyReserved) args.push("--force");
+						const result = runHermes(input, args);
+						if (result.status !== 0)
+							throw new Error(
+								`Hermes official Skill install failed: ${String(result.stderr || result.stdout).trim() || "unknown error"}`,
+							);
 						writeManagedSkillReceipt(receipt);
 						return "installed" as const;
-					}
-					const args = [
-						"skills",
-						"install",
-						rawSkillUrl(input.skill),
-						"--name",
-						input.skill.skillId,
-						"--yes",
-					];
-					if (input.previouslyReserved) args.push("--force");
-					const result = runHermes(input, args);
-					if (result.status !== 0)
-						throw new Error(
-							`Hermes official Skill install failed: ${String(result.stderr || result.stdout).trim() || "unknown error"}`,
-						);
-					writeManagedSkillReceipt(receipt);
-					return "installed" as const;
-				},
-			});
+					},
+				}),
+			);
 		});
+	},
+	anchorOwnership(input) {
+		writeManagedSkillReceipt(receiptInput(input.home, input.skillId, input.ownershipIdentity));
 	},
 	verifyOwned(input) {
 		return managedSkillReceiptMatchesIdentity(
@@ -157,42 +166,46 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 		);
 	},
 	uninstall(input) {
-		const target = targetDir(input.home, input.skillId);
-		const receipt = {
-			path: receiptPath(input.home, input.skillId),
-			schemaVersion: RECEIPT_SCHEMA,
-			skillId: input.skillId,
-			ownershipIdentity: input.ownershipIdentity,
-			target,
-		};
-		if (!existsSync(target)) {
+		return withRuntimeUserFileAccess(() => {
+			const target = targetDir(input.home, input.skillId);
+			const receipt = {
+				path: receiptPath(input.home, input.skillId),
+				schemaVersion: RECEIPT_SCHEMA,
+				skillId: input.skillId,
+				ownershipIdentity: input.ownershipIdentity,
+				target,
+			};
+			if (!existsSync(target)) {
+				rmSync(receipt.path, { force: true });
+				return "absent";
+			}
+			if (!managedSkillReceiptMatchesIdentity(receipt))
+				throw new Error("Hermes Skill bytes no longer match the manifest ownership receipt");
+			const result = runHermesUninstall(input, input.skillId);
+			if (result.status !== 0)
+				throw new Error(
+					`Hermes official Skill uninstall failed: ${String(result.stderr || result.stdout).trim() || "unknown error"}`,
+				);
+			if (existsSync(target))
+				throw new Error("Hermes official Skill uninstall did not remove the Skill target");
 			rmSync(receipt.path, { force: true });
-			return "absent";
-		}
-		if (!managedSkillReceiptMatchesIdentity(receipt))
-			throw new Error("Hermes Skill bytes no longer match the manifest ownership receipt");
-		const result = runHermesUninstall(input, input.skillId);
-		if (result.status !== 0)
-			throw new Error(
-				`Hermes official Skill uninstall failed: ${String(result.stderr || result.stdout).trim() || "unknown error"}`,
-			);
-		if (existsSync(target))
-			throw new Error("Hermes official Skill uninstall did not remove the Skill target");
-		rmSync(receipt.path, { force: true });
-		return "removed";
+			return "removed";
+		});
 	},
 	cleanupManifestOwned(input) {
-		const target = targetDir(input.home, input.skillId);
-		const receipt = receiptInput(input.home, input.skillId, input.ownershipIdentity);
-		if (!existsSync(target)) {
+		return withRuntimeUserFileAccess(() => {
+			const target = targetDir(input.home, input.skillId);
+			const receipt = receiptInput(input.home, input.skillId, input.ownershipIdentity);
+			if (!existsSync(target)) {
+				rmSync(receipt.path, { force: true });
+				return "absent";
+			}
+			if (!managedSkillReceiptMatchesIdentity(receipt)) {
+				throw new Error("Hermes Skill bytes no longer match the manifest ownership receipt");
+			}
+			rmSync(target, { recursive: true });
 			rmSync(receipt.path, { force: true });
-			return "absent";
-		}
-		if (!managedSkillReceiptMatchesIdentity(receipt)) {
-			throw new Error("Hermes Skill bytes no longer match the manifest ownership receipt");
-		}
-		withRuntimeUserFileAccess(() => rmSync(target, { recursive: true }));
-		rmSync(receipt.path, { force: true });
-		return "removed";
+			return "removed";
+		});
 	},
 };

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -4,8 +4,11 @@ import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive"
 import {
 	collectManagedSkillTree,
 	collectRuntimeUserManagedSkillTree,
+	HERMES_MANAGED_SKILL_RECEIPT_SCHEMA,
+	ManagedSkillResourceError,
 	managedSkillMarkerMatchesIdentity,
 	managedSkillReceiptMatchesIdentity,
+	managedSkillReceiptPath,
 	managedSkillTreesEqual,
 	withManagedTargetRollback,
 	withStagedManagedSkill,
@@ -18,26 +21,42 @@ import {
 	withRuntimeUserFileAccess,
 } from "./runtime-user-command";
 
-const RECEIPT_SCHEMA = "clawdi.hermesManifestSkillReceipt.v2";
-
 export interface HostedHermesSkillExactSourceDriver {
 	install(input: {
 		home: string;
 		appRoot: string;
+		managedResourceRoot: string;
 		skill: PreparedHostedSourcedSkill;
 		previouslyReserved: boolean;
 	}): "installed" | "unchanged";
-	anchorOwnership(input: { home: string; skillId: string; ownershipIdentity: string }): void;
-	verifyOwned(input: { home: string; appRoot: string; skill: PreparedHostedSourcedSkill }): boolean;
-	hasOwnershipReceipt(input: { home: string; skillId: string; ownershipIdentity: string }): boolean;
+	anchorOwnership(input: {
+		home: string;
+		managedResourceRoot: string;
+		skillId: string;
+		ownershipIdentity: string;
+	}): void;
+	verifyOwned(input: {
+		home: string;
+		appRoot: string;
+		managedResourceRoot: string;
+		skill: PreparedHostedSourcedSkill;
+	}): boolean;
+	hasOwnershipReceipt(input: {
+		home: string;
+		managedResourceRoot: string;
+		skillId: string;
+		ownershipIdentity: string;
+	}): boolean;
 	uninstall(input: {
 		home: string;
 		appRoot: string;
+		managedResourceRoot: string;
 		skillId: string;
 		ownershipIdentity: string;
 	}): "absent" | "removed";
 	cleanupManifestOwned(input: {
 		home: string;
+		managedResourceRoot: string;
 		skillId: string;
 		ownershipIdentity: string;
 	}): "absent" | "removed";
@@ -54,13 +73,17 @@ function commandPath(home: string, appRoot: string): string {
 	});
 }
 const targetDir = (home: string, skillId: string) => join(home, ".hermes", "skills", skillId);
-const receiptPath = (home: string, skillId: string) =>
-	join(home, ".hermes", "skills", ".clawdi-manifest-receipts", `${skillId}.json`);
 
-function receiptInput(home: string, skillId: string, ownershipIdentity: string) {
+function receiptInput(
+	managedResourceRoot: string,
+	home: string,
+	skillId: string,
+	ownershipIdentity: string,
+) {
 	return {
-		path: receiptPath(home, skillId),
-		schemaVersion: RECEIPT_SCHEMA,
+		path: managedSkillReceiptPath(managedResourceRoot, "hermes", skillId),
+		managedResourceRoot,
+		schemaVersion: HERMES_MANAGED_SKILL_RECEIPT_SCHEMA,
 		skillId,
 		ownershipIdentity,
 		target: targetDir(home, skillId),
@@ -113,99 +136,115 @@ function bundledResultMatches(sourceDir: string, target: string): boolean {
 export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDriver = {
 	install(input) {
 		const target = targetDir(input.home, input.skill.skillId);
-		const receipt = receiptInput(input.home, input.skill.skillId, input.skill.sourceIdentity);
+		const receipt = receiptInput(
+			input.managedResourceRoot,
+			input.home,
+			input.skill.skillId,
+			input.skill.sourceIdentity,
+		);
 		if (withRuntimeUserFileAccess(() => existsSync(target)) && !input.previouslyReserved)
 			throw new Error("Hermes Skill target is not paired with a manifest reservation");
 		if (managedSkillReceiptMatchesIdentity(receipt)) return "unchanged";
-		return withStagedManagedSkill(input.skill, (sourceDir) => {
-			return withRuntimeUserFileAccess(() =>
-				withManagedTargetRollback({
-					target,
-					receipt: receipt.path,
-					operation: () => {
-						if (input.skill.source.type === "bundled") {
-							replaceManagedSkillDirectoryAtomic(sourceDir, target);
-							if (!bundledResultMatches(sourceDir, target)) {
-								throw new Error("Hermes bundled Skill activation changed exact source bytes");
-							}
-							writeManagedSkillReceipt(receipt);
-							return "installed" as const;
-						}
-						const args = [
-							"skills",
-							"install",
-							rawSkillUrl(input.skill),
-							"--name",
-							input.skill.skillId,
-							"--yes",
-						];
-						if (input.previouslyReserved) args.push("--force");
-						const result = runHermes(input, args);
-						if (result.status !== 0)
-							throw new Error(
-								`Hermes official Skill install failed: ${String(result.stderr || result.stdout).trim() || "unknown error"}`,
+		return withStagedManagedSkill(input.skill, (sourceDir) =>
+			withManagedTargetRollback({
+				target,
+				receipt: receipt.path,
+				operation: () => {
+					if (input.skill.source.type === "bundled") {
+						withRuntimeUserFileAccess(() => replaceManagedSkillDirectoryAtomic(sourceDir, target));
+						if (!bundledResultMatches(sourceDir, target)) {
+							throw new ManagedSkillResourceError(
+								"Hermes bundled Skill activation changed exact source bytes",
 							);
+						}
 						writeManagedSkillReceipt(receipt);
 						return "installed" as const;
-					},
-				}),
-			);
-		});
+					}
+					const args = [
+						"skills",
+						"install",
+						rawSkillUrl(input.skill),
+						"--name",
+						input.skill.skillId,
+						"--yes",
+					];
+					if (input.previouslyReserved) args.push("--force");
+					const result = runHermes(input, args);
+					if (result.status !== 0)
+						throw new ManagedSkillResourceError(
+							`Hermes official Skill install failed: ${String(result.stderr || result.stdout).trim() || "unknown error"}`,
+						);
+					writeManagedSkillReceipt(receipt);
+					return "installed" as const;
+				},
+			}),
+		);
 	},
 	anchorOwnership(input) {
-		writeManagedSkillReceipt(receiptInput(input.home, input.skillId, input.ownershipIdentity));
+		writeManagedSkillReceipt(
+			receiptInput(input.managedResourceRoot, input.home, input.skillId, input.ownershipIdentity),
+		);
 	},
 	verifyOwned(input) {
 		return managedSkillReceiptMatchesIdentity(
-			receiptInput(input.home, input.skill.skillId, input.skill.sourceIdentity),
+			receiptInput(
+				input.managedResourceRoot,
+				input.home,
+				input.skill.skillId,
+				input.skill.sourceIdentity,
+			),
 		);
 	},
 	hasOwnershipReceipt(input) {
 		return managedSkillMarkerMatchesIdentity(
-			receiptInput(input.home, input.skillId, input.ownershipIdentity),
+			receiptInput(input.managedResourceRoot, input.home, input.skillId, input.ownershipIdentity),
 		);
 	},
 	uninstall(input) {
-		return withRuntimeUserFileAccess(() => {
-			const target = targetDir(input.home, input.skillId);
-			const receipt = {
-				path: receiptPath(input.home, input.skillId),
-				schemaVersion: RECEIPT_SCHEMA,
-				skillId: input.skillId,
-				ownershipIdentity: input.ownershipIdentity,
-				target,
-			};
-			if (!existsSync(target)) {
-				rmSync(receipt.path, { force: true });
-				return "absent";
-			}
-			if (!managedSkillReceiptMatchesIdentity(receipt))
-				throw new Error("Hermes Skill bytes no longer match the manifest ownership receipt");
-			const result = runHermesUninstall(input, input.skillId);
-			if (result.status !== 0)
-				throw new Error(
-					`Hermes official Skill uninstall failed: ${String(result.stderr || result.stdout).trim() || "unknown error"}`,
-				);
-			if (existsSync(target))
-				throw new Error("Hermes official Skill uninstall did not remove the Skill target");
+		const target = targetDir(input.home, input.skillId);
+		const receipt = receiptInput(
+			input.managedResourceRoot,
+			input.home,
+			input.skillId,
+			input.ownershipIdentity,
+		);
+		if (!withRuntimeUserFileAccess(() => existsSync(target))) {
 			rmSync(receipt.path, { force: true });
-			return "removed";
-		});
+			return "absent";
+		}
+		if (!managedSkillReceiptMatchesIdentity(receipt))
+			throw new Error("Hermes Skill bytes no longer match the manifest ownership receipt");
+		const result = runHermesUninstall(input, input.skillId);
+		if (result.status !== 0)
+			throw new ManagedSkillResourceError(
+				`Hermes official Skill uninstall failed: ${String(result.stderr || result.stdout).trim() || "unknown error"}`,
+			);
+		if (withRuntimeUserFileAccess(() => existsSync(target)))
+			throw new ManagedSkillResourceError(
+				"Hermes official Skill uninstall did not remove the Skill target",
+			);
+		rmSync(receipt.path, { force: true });
+		return "removed";
 	},
 	cleanupManifestOwned(input) {
-		return withRuntimeUserFileAccess(() => {
-			const target = targetDir(input.home, input.skillId);
-			const receipt = receiptInput(input.home, input.skillId, input.ownershipIdentity);
-			if (!existsSync(target)) {
-				rmSync(receipt.path, { force: true });
-				return "absent";
-			}
-			if (!managedSkillReceiptMatchesIdentity(receipt)) {
-				throw new Error("Hermes Skill bytes no longer match the manifest ownership receipt");
-			}
-			rmSync(target, { recursive: true });
+		const target = targetDir(input.home, input.skillId);
+		const receipt = receiptInput(
+			input.managedResourceRoot,
+			input.home,
+			input.skillId,
+			input.ownershipIdentity,
+		);
+		if (!withRuntimeUserFileAccess(() => existsSync(target))) {
 			rmSync(receipt.path, { force: true });
-			return "removed";
+			return "absent";
+		}
+		if (!managedSkillReceiptMatchesIdentity(receipt)) {
+			throw new Error("Hermes Skill bytes no longer match the manifest ownership receipt");
+		}
+		withRuntimeUserFileAccess(() => {
+			rmSync(target, { recursive: true });
 		});
+		rmSync(receipt.path, { force: true });
+		return "removed";
 	},
 };

--- a/packages/cli/src/runtime/hosted-openclaw-context.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-context.ts
@@ -10,7 +10,7 @@ import {
 } from "../lib/codex-oauth-native-store";
 import { agentTargetProjectionInput, hostedAiProviderCatalog } from "./hosted-provider-resolution";
 import { HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION, type RuntimeManifest } from "./manifest-contract";
-import { runtimeUserDirectoryOwnership } from "./runtime-user-command";
+import { runtimeUserDirectoryOwnership, withRuntimeUserFileAccess } from "./runtime-user-command";
 
 export const CLAWDI_MANAGED_OPENCLAW_PROVIDER_PLUGIN_ID = "clawdi-managed-provider";
 
@@ -31,13 +31,24 @@ function resolveSdkExports(
 		}
 		return value || null;
 	};
-	return {
+	return withRuntimeUserFileAccess(() => ({
 		configMutation: resolve(OPENCLAW_SDK_EXPORT_PATHS.configMutation),
 		deviceBootstrap: resolve(OPENCLAW_SDK_EXPORT_PATHS.deviceBootstrap),
 		providerAuth: testOverride("PROVIDER_AUTH") ?? resolve(OPENCLAW_SDK_EXPORT_PATHS.providerAuth),
 		providerEnvVars:
 			testOverride("PROVIDER_ENV_VARS") ?? resolve(OPENCLAW_SDK_EXPORT_PATHS.providerEnvVars),
-	};
+	}));
+}
+
+export function hostedOpenClawRuntimeUserOwnership(manifest: RuntimeManifest, home: string) {
+	const stateRoot = join(home, ".openclaw");
+	return manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION &&
+		manifest.runtimes.openclaw?.enabled === true
+		? [
+				...runtimeUserDirectoryOwnership(stateRoot, { mode: 0o700 }),
+				...runtimeUserDirectoryOwnership(join(stateRoot, "tmp"), { mode: 0o700 }),
+			]
+		: [];
 }
 
 export function createOpenClawHostedContext(manifest: RuntimeManifest, home: string) {
@@ -48,15 +59,7 @@ export function createOpenClawHostedContext(manifest: RuntimeManifest, home: str
 	const sourceDir = statePath("managed-sources", CLAWDI_MANAGED_OPENCLAW_PROVIDER_PLUGIN_ID);
 	const installDir = statePath("extensions", CLAWDI_MANAGED_OPENCLAW_PROVIDER_PLUGIN_ID);
 	const sdk = resolveSdkExports(home);
-	const ownership =
-		manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION &&
-		manifest.runtimes.openclaw?.enabled === true
-			? [
-					...runtimeUserDirectoryOwnership(home),
-					...runtimeUserDirectoryOwnership(stateRoot, { mode: 0o700 }),
-					...runtimeUserDirectoryOwnership(statePath("tmp"), { mode: 0o700 }),
-				]
-			: [];
+	const ownership = hostedOpenClawRuntimeUserOwnership(manifest, home);
 	return {
 		home,
 		managedApiKeyProjection: hasManagedApiKeyProjection(manifest),

--- a/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
@@ -14,6 +14,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { hostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
+import { managedSkillReceiptPath } from "./managed-skill-delivery";
 
 let root = "";
 afterEach(() => {
@@ -171,6 +172,8 @@ test("runs official install from home before its first workspace exists and guar
 	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-driver-"));
 	const home = join(root, "home");
 	const workspaceRoot = join(home, "agent-workspace");
+	const managedResourceRoot = join(root, "managed-resources");
+	mkdirSync(managedResourceRoot, { recursive: true });
 	const command = join(home, ".local", "bin", "openclaw");
 	const installLog = join(root, "install.log");
 	const installCwdLog = join(root, "install-cwd.log");
@@ -230,22 +233,30 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 	};
 
 	expect(existsSync(workspaceRoot)).toBe(false);
-	expect(hostedOpenClawSkillDriver.install({ home, workspaceRoot, skill })).toBe("installed");
+	expect(
+		hostedOpenClawSkillDriver.install({ home, workspaceRoot, managedResourceRoot, skill }),
+	).toBe("installed");
 	expect(readFileSync(installCwdLog, "utf8")).toBe(`${home}\n`);
 	expect(readFileSync(installLog, "utf8")).toMatch(
 		/^skills install .* --agent main --as review-pr --force\n$/,
 	);
-	expect(hostedOpenClawSkillDriver.install({ home, workspaceRoot, skill })).toBe("unchanged");
+	expect(
+		hostedOpenClawSkillDriver.install({ home, workspaceRoot, managedResourceRoot, skill }),
+	).toBe("unchanged");
 	expect(readFileSync(installLog, "utf8").trim().split("\n")).toHaveLength(1);
-	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, skill })).toBe(true);
+	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, managedResourceRoot, skill })).toBe(
+		true,
+	);
 	const target = join(workspaceRoot, "skills", "review-pr");
-	const receipt = join(workspaceRoot, "skills", ".clawdi-manifest-receipts", "review-pr.json");
+	const receipt = managedSkillReceiptPath(managedResourceRoot, "openclaw", "review-pr");
 	const receiptBytes = readFileSync(receipt);
 	const receiptStat = statSync(receipt);
 	expect(receiptStat.mode & 0o777).toBe(0o600);
 	if (process.geteuid) expect(receiptStat.uid).toBe(process.geteuid());
 	rmSync(receipt);
-	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, skill })).toBe(false);
+	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, managedResourceRoot, skill })).toBe(
+		false,
+	);
 	writeFileSync(receipt, receiptBytes);
 	expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("# Review PR\n");
 	writeFileSync(join(target, "SKILL.md"), "tenant mutation\n");
@@ -253,6 +264,7 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 	expect(
 		hostedOpenClawSkillDriver.hasOwnershipReceipt({
 			workspaceRoot,
+			managedResourceRoot,
 			skillId: "review-pr",
 			ownershipIdentity: skill.sourceIdentity,
 		}),
@@ -261,6 +273,7 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 	expect(
 		hostedOpenClawSkillDriver.hasOwnershipReceipt({
 			workspaceRoot,
+			managedResourceRoot,
 			skillId: "review-pr",
 			ownershipIdentity: skill.sourceIdentity,
 		}),
@@ -269,6 +282,7 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 		hostedOpenClawSkillDriver.installDirectory({
 			home,
 			workspaceRoot,
+			managedResourceRoot,
 			skillId: "review-pr",
 			sourceDir,
 			ownershipIdentity: skill.sourceIdentity,
@@ -281,26 +295,32 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 		hostedOpenClawSkillDriver.installDirectory({
 			home,
 			workspaceRoot,
+			managedResourceRoot,
 			skillId: "review-pr",
 			sourceDir,
 			ownershipIdentity: `${skill.sourceIdentity}-v2`,
 		}),
 	).toThrow("official Skill install failed: exit code 45 without output");
 	expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("# Review PR\n");
-	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, skill })).toBe(true);
+	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, managedResourceRoot, skill })).toBe(
+		true,
+	);
 	delete process.env.FAKE_OPENCLAW_FAIL_AFTER_WRITE;
 	process.env.FAKE_OPENCLAW_DRIFT_AFTER_WRITE = "1";
 	expect(() =>
 		hostedOpenClawSkillDriver.installDirectory({
 			home,
 			workspaceRoot,
+			managedResourceRoot,
 			skillId: "review-pr",
 			sourceDir,
 			ownershipIdentity: `${skill.sourceIdentity}-v2`,
 		}),
 	).toThrow("changed during Skill reconciliation");
 	expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("# Review PR\n");
-	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, skill })).toBe(true);
+	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, managedResourceRoot, skill })).toBe(
+		true,
+	);
 	delete process.env.FAKE_OPENCLAW_DRIFT_AFTER_WRITE;
 	rmSync(workspaceDriftMarker);
 	writeFileSync(join(sourceDir, "SKILL.md"), "# Review PR\n");
@@ -308,6 +328,7 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 	expect(() =>
 		hostedOpenClawSkillDriver.cleanupManifestOwned({
 			workspaceRoot,
+			managedResourceRoot,
 			skillId: "review-pr",
 			ownershipIdentity: skill.sourceIdentity,
 		}),
@@ -317,6 +338,7 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 	expect(
 		hostedOpenClawSkillDriver.cleanupManifestOwned({
 			workspaceRoot,
+			managedResourceRoot,
 			skillId: "review-pr",
 			ownershipIdentity: skill.sourceIdentity,
 		}),
@@ -326,6 +348,7 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 	expect(
 		hostedOpenClawSkillDriver.cleanupManifestOwned({
 			workspaceRoot,
+			managedResourceRoot,
 			skillId: "review-pr",
 			ownershipIdentity: skill.sourceIdentity,
 		}),
@@ -337,6 +360,8 @@ test("fails before official install when the OpenClaw workspace changes during r
 	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-workspace-mismatch-"));
 	const home = join(root, "home");
 	const workspaceRoot = join(home, "desired-workspace");
+	const managedResourceRoot = join(root, "managed-resources");
+	mkdirSync(managedResourceRoot, { recursive: true });
 	const command = join(home, ".local", "bin", "openclaw");
 	const installMarker = join(root, "install-called");
 	mkdirSync(dirname(command), { recursive: true });
@@ -360,6 +385,7 @@ exit 0
 		hostedOpenClawSkillDriver.installDirectory({
 			home,
 			workspaceRoot,
+			managedResourceRoot,
 			skillId: "review-pr",
 			sourceDir,
 			ownershipIdentity:
@@ -375,6 +401,8 @@ test("reports a spawn error when the official install process cannot start", () 
 	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-spawn-error-"));
 	const home = join(root, "home");
 	const workspaceRoot = join(home, "agent-workspace");
+	const managedResourceRoot = join(root, "managed-resources");
+	mkdirSync(managedResourceRoot, { recursive: true });
 	const command = join(home, ".local", "bin", "openclaw");
 	mkdirSync(dirname(command), { recursive: true });
 	writeFileSync(
@@ -397,6 +425,7 @@ exit 64
 		hostedOpenClawSkillDriver.installDirectory({
 			home,
 			workspaceRoot,
+			managedResourceRoot,
 			skillId: "review-pr",
 			sourceDir,
 			ownershipIdentity:

--- a/packages/cli/src/runtime/hosted-openclaw-skill.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.ts
@@ -6,9 +6,12 @@ import {
 } from "../adapters/openclaw-workspace";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import {
+	ManagedSkillResourceError,
 	managedSkillMarkerMatchesIdentity,
 	managedSkillMarkerOwnsTarget,
 	managedSkillReceiptMatchesIdentity,
+	managedSkillReceiptPath,
+	OPENCLAW_MANAGED_SKILL_RECEIPT_SCHEMA,
 	withManagedTargetRollback,
 	withStagedManagedSkill,
 	writeManagedSkillReceipt,
@@ -22,13 +25,13 @@ import {
 const OPENCLAW_AGENT_ID = "main";
 const SOURCE_RECEIPT = ".openclaw/source-origin.json";
 const EXCLUDED_NATIVE_FILES = new Set([SOURCE_RECEIPT]);
-const RECEIPT_SCHEMA = "clawdi.openclawManifestSkillReceipt.v2";
 
 export interface HostedOpenClawSkillDriver {
 	resolveWorkspace(input: { home: string; repairInvalidConfig?: boolean }): string;
 	installDirectory(input: {
 		home: string;
 		workspaceRoot: string;
+		managedResourceRoot: string;
 		skillId: string;
 		sourceDir: string;
 		ownershipIdentity: string;
@@ -37,22 +40,30 @@ export interface HostedOpenClawSkillDriver {
 	install(input: {
 		home: string;
 		workspaceRoot: string;
+		managedResourceRoot: string;
 		skill: PreparedHostedSourcedSkill;
 		previouslyReserved?: boolean;
 	}): "installed" | "unchanged";
 	anchorOwnership(input: {
 		workspaceRoot: string;
+		managedResourceRoot: string;
 		skillId: string;
 		ownershipIdentity: string;
 	}): void;
 	hasOwnershipReceipt(input: {
 		workspaceRoot: string;
+		managedResourceRoot: string;
 		skillId: string;
 		ownershipIdentity: string;
 	}): boolean;
-	verifyOwned(input: { workspaceRoot: string; skill: PreparedHostedSourcedSkill }): boolean;
+	verifyOwned(input: {
+		workspaceRoot: string;
+		managedResourceRoot: string;
+		skill: PreparedHostedSourcedSkill;
+	}): boolean;
 	cleanupManifestOwned(input: {
 		workspaceRoot: string;
+		managedResourceRoot: string;
 		skillId: string;
 		ownershipIdentity: string;
 	}): "absent" | "removed";
@@ -76,12 +87,16 @@ function commandPath(home: string): string {
 }
 const targetDir = (workspaceRoot: string, skillId: string) =>
 	join(workspaceRoot, "skills", skillId);
-const receiptPath = (workspaceRoot: string, skillId: string) =>
-	join(workspaceRoot, "skills", ".clawdi-manifest-receipts", `${skillId}.json`);
-function receiptInput(workspaceRoot: string, skillId: string, ownershipIdentity: string) {
+function receiptInput(
+	managedResourceRoot: string,
+	workspaceRoot: string,
+	skillId: string,
+	ownershipIdentity: string,
+) {
 	return {
-		path: receiptPath(workspaceRoot, skillId),
-		schemaVersion: RECEIPT_SCHEMA,
+		path: managedSkillReceiptPath(managedResourceRoot, "openclaw", skillId),
+		managedResourceRoot,
+		schemaVersion: OPENCLAW_MANAGED_SKILL_RECEIPT_SCHEMA,
 		skillId,
 		ownershipIdentity,
 		target: targetDir(workspaceRoot, skillId),
@@ -193,51 +208,63 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 		);
 	},
 	installDirectory(input) {
-		return withRuntimeUserFileAccess(() => {
-			const target = targetDir(input.workspaceRoot, input.skillId);
-			const receipt = receiptInput(input.workspaceRoot, input.skillId, input.ownershipIdentity);
-			if (managedSkillReceiptMatchesIdentity(receipt)) return "unchanged";
-			if (existsSync(target) && !input.previouslyReserved && !managedSkillMarkerOwnsTarget(receipt))
-				throw new Error(
-					"refusing to replace an OpenClaw Skill without a matching Clawdi ownership receipt",
+		const target = targetDir(input.workspaceRoot, input.skillId);
+		const receipt = receiptInput(
+			input.managedResourceRoot,
+			input.workspaceRoot,
+			input.skillId,
+			input.ownershipIdentity,
+		);
+		if (managedSkillReceiptMatchesIdentity(receipt)) return "unchanged";
+		if (
+			withRuntimeUserFileAccess(() => existsSync(target)) &&
+			!input.previouslyReserved &&
+			!managedSkillMarkerOwnsTarget(receipt)
+		)
+			throw new Error(
+				"refusing to replace an OpenClaw Skill without a matching Clawdi ownership receipt",
+			);
+		assertOfficialWorkspace(input);
+		return withManagedTargetRollback({
+			target,
+			receipt: receipt.path,
+			operation: () => {
+				// The roster may reference a workspace OpenClaw has not created yet on first run.
+				const result = spawnRuntimeUserCommand(
+					commandPath(input.home),
+					[
+						"skills",
+						"install",
+						input.sourceDir,
+						"--agent",
+						OPENCLAW_AGENT_ID,
+						"--as",
+						input.skillId,
+						"--force",
+					],
+					input.home,
+					input.home,
+					{ timeoutMs: 120_000, maxBufferBytes: 1024 * 1024 },
 				);
-			assertOfficialWorkspace(input);
-			return withManagedTargetRollback({
-				target,
-				receipt: receipt.path,
-				operation: () => {
-					// The roster may reference a workspace OpenClaw has not created yet on first run.
-					const result = spawnRuntimeUserCommand(
-						commandPath(input.home),
-						[
-							"skills",
-							"install",
-							input.sourceDir,
-							"--agent",
-							OPENCLAW_AGENT_ID,
-							"--as",
-							input.skillId,
-							"--force",
-						],
-						input.home,
-						input.home,
-						{ timeoutMs: 120_000, maxBufferBytes: 1024 * 1024 },
+				if (result.status !== 0)
+					throw new ManagedSkillResourceError(
+						`OpenClaw official Skill install failed: ${commandFailureDetail(result)}`,
 					);
-					if (result.status !== 0)
-						throw new Error(
-							`OpenClaw official Skill install failed: ${commandFailureDetail(result)}`,
-						);
-					assertOfficialWorkspace(input);
-					writeManagedSkillReceipt(receipt);
-					return "installed" as const;
-				},
-			});
+				assertOfficialWorkspace(input);
+				writeManagedSkillReceipt(receipt);
+				return "installed" as const;
+			},
 		});
 	},
 	install(input) {
 		if (
 			managedSkillReceiptMatchesIdentity(
-				receiptInput(input.workspaceRoot, input.skill.skillId, input.skill.sourceIdentity),
+				receiptInput(
+					input.managedResourceRoot,
+					input.workspaceRoot,
+					input.skill.skillId,
+					input.skill.sourceIdentity,
+				),
 			)
 		)
 			return "unchanged";
@@ -245,6 +272,7 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 			this.installDirectory({
 				home: input.home,
 				workspaceRoot: input.workspaceRoot,
+				managedResourceRoot: input.managedResourceRoot,
 				skillId: input.skill.skillId,
 				sourceDir,
 				ownershipIdentity: input.skill.sourceIdentity,
@@ -254,34 +282,54 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 	},
 	anchorOwnership(input) {
 		writeManagedSkillReceipt(
-			receiptInput(input.workspaceRoot, input.skillId, input.ownershipIdentity),
+			receiptInput(
+				input.managedResourceRoot,
+				input.workspaceRoot,
+				input.skillId,
+				input.ownershipIdentity,
+			),
 		);
 	},
 	hasOwnershipReceipt(input) {
 		return managedSkillMarkerMatchesIdentity(
-			receiptInput(input.workspaceRoot, input.skillId, input.ownershipIdentity),
+			receiptInput(
+				input.managedResourceRoot,
+				input.workspaceRoot,
+				input.skillId,
+				input.ownershipIdentity,
+			),
 		);
 	},
 	verifyOwned(input) {
 		return managedSkillReceiptMatchesIdentity(
-			receiptInput(input.workspaceRoot, input.skill.skillId, input.skill.sourceIdentity),
+			receiptInput(
+				input.managedResourceRoot,
+				input.workspaceRoot,
+				input.skill.skillId,
+				input.skill.sourceIdentity,
+			),
 		);
 	},
 	cleanupManifestOwned(input) {
-		return withRuntimeUserFileAccess(() => {
-			const target = targetDir(input.workspaceRoot, input.skillId);
-			const receipt = receiptInput(input.workspaceRoot, input.skillId, input.ownershipIdentity);
-			if (!existsSync(target)) {
-				rmSync(receipt.path, { force: true });
-				return "absent";
-			}
-			if (!managedSkillReceiptMatchesIdentity(receipt))
-				throw new Error(
-					"refusing manifest cleanup because OpenClaw Skill bytes no longer match the ownership receipt",
-				);
-			rmSync(target, { recursive: true });
+		const target = targetDir(input.workspaceRoot, input.skillId);
+		const receipt = receiptInput(
+			input.managedResourceRoot,
+			input.workspaceRoot,
+			input.skillId,
+			input.ownershipIdentity,
+		);
+		if (!withRuntimeUserFileAccess(() => existsSync(target))) {
 			rmSync(receipt.path, { force: true });
-			return "removed";
+			return "absent";
+		}
+		if (!managedSkillReceiptMatchesIdentity(receipt))
+			throw new Error(
+				"refusing manifest cleanup because OpenClaw Skill bytes no longer match the ownership receipt",
+			);
+		withRuntimeUserFileAccess(() => {
+			rmSync(target, { recursive: true });
 		});
+		rmSync(receipt.path, { force: true });
+		return "removed";
 	},
 };

--- a/packages/cli/src/runtime/hosted-openclaw-skill.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.ts
@@ -13,7 +13,11 @@ import {
 	withStagedManagedSkill,
 	writeManagedSkillReceipt,
 } from "./managed-skill-delivery";
-import { executableExists, spawnRuntimeUserCommand } from "./runtime-user-command";
+import {
+	executableExists,
+	spawnRuntimeUserCommand,
+	withRuntimeUserFileAccess,
+} from "./runtime-user-command";
 
 const OPENCLAW_AGENT_ID = "main";
 const SOURCE_RECEIPT = ".openclaw/source-origin.json";
@@ -36,6 +40,11 @@ export interface HostedOpenClawSkillDriver {
 		skill: PreparedHostedSourcedSkill;
 		previouslyReserved?: boolean;
 	}): "installed" | "unchanged";
+	anchorOwnership(input: {
+		workspaceRoot: string;
+		skillId: string;
+		ownershipIdentity: string;
+	}): void;
 	hasOwnershipReceipt(input: {
 		workspaceRoot: string;
 		skillId: string;
@@ -50,12 +59,14 @@ export interface HostedOpenClawSkillDriver {
 }
 
 function installedCommandPath(home: string): string | null {
-	for (const candidate of [
-		join(home, ".local", "bin", "openclaw"),
-		join(home, ".openclaw", "bin", "openclaw"),
-	])
-		if (executableExists(candidate)) return candidate;
-	return null;
+	return withRuntimeUserFileAccess(() => {
+		for (const candidate of [
+			join(home, ".local", "bin", "openclaw"),
+			join(home, ".openclaw", "bin", "openclaw"),
+		])
+			if (executableExists(candidate)) return candidate;
+		return null;
+	});
 }
 
 function commandPath(home: string): string {
@@ -177,46 +188,50 @@ function commandFailureDetail(result: ReturnType<typeof spawnRuntimeUserCommand>
 
 export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 	resolveWorkspace(input) {
-		return resolveOfficialWorkspace(input.home, input.repairInvalidConfig);
+		return withRuntimeUserFileAccess(() =>
+			resolveOfficialWorkspace(input.home, input.repairInvalidConfig),
+		);
 	},
 	installDirectory(input) {
-		const target = targetDir(input.workspaceRoot, input.skillId);
-		const receipt = receiptInput(input.workspaceRoot, input.skillId, input.ownershipIdentity);
-		if (managedSkillReceiptMatchesIdentity(receipt)) return "unchanged";
-		if (existsSync(target) && !input.previouslyReserved && !managedSkillMarkerOwnsTarget(receipt))
-			throw new Error(
-				"refusing to replace an OpenClaw Skill without a matching Clawdi ownership receipt",
-			);
-		assertOfficialWorkspace(input);
-		return withManagedTargetRollback({
-			target,
-			receipt: receipt.path,
-			operation: () => {
-				// The roster may reference a workspace OpenClaw has not created yet on first run.
-				const result = spawnRuntimeUserCommand(
-					commandPath(input.home),
-					[
-						"skills",
-						"install",
-						input.sourceDir,
-						"--agent",
-						OPENCLAW_AGENT_ID,
-						"--as",
-						input.skillId,
-						"--force",
-					],
-					input.home,
-					input.home,
-					{ timeoutMs: 120_000, maxBufferBytes: 1024 * 1024 },
+		return withRuntimeUserFileAccess(() => {
+			const target = targetDir(input.workspaceRoot, input.skillId);
+			const receipt = receiptInput(input.workspaceRoot, input.skillId, input.ownershipIdentity);
+			if (managedSkillReceiptMatchesIdentity(receipt)) return "unchanged";
+			if (existsSync(target) && !input.previouslyReserved && !managedSkillMarkerOwnsTarget(receipt))
+				throw new Error(
+					"refusing to replace an OpenClaw Skill without a matching Clawdi ownership receipt",
 				);
-				if (result.status !== 0)
-					throw new Error(
-						`OpenClaw official Skill install failed: ${commandFailureDetail(result)}`,
+			assertOfficialWorkspace(input);
+			return withManagedTargetRollback({
+				target,
+				receipt: receipt.path,
+				operation: () => {
+					// The roster may reference a workspace OpenClaw has not created yet on first run.
+					const result = spawnRuntimeUserCommand(
+						commandPath(input.home),
+						[
+							"skills",
+							"install",
+							input.sourceDir,
+							"--agent",
+							OPENCLAW_AGENT_ID,
+							"--as",
+							input.skillId,
+							"--force",
+						],
+						input.home,
+						input.home,
+						{ timeoutMs: 120_000, maxBufferBytes: 1024 * 1024 },
 					);
-				assertOfficialWorkspace(input);
-				writeManagedSkillReceipt(receipt);
-				return "installed" as const;
-			},
+					if (result.status !== 0)
+						throw new Error(
+							`OpenClaw official Skill install failed: ${commandFailureDetail(result)}`,
+						);
+					assertOfficialWorkspace(input);
+					writeManagedSkillReceipt(receipt);
+					return "installed" as const;
+				},
+			});
 		});
 	},
 	install(input) {
@@ -237,6 +252,11 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 			}),
 		);
 	},
+	anchorOwnership(input) {
+		writeManagedSkillReceipt(
+			receiptInput(input.workspaceRoot, input.skillId, input.ownershipIdentity),
+		);
+	},
 	hasOwnershipReceipt(input) {
 		return managedSkillMarkerMatchesIdentity(
 			receiptInput(input.workspaceRoot, input.skillId, input.ownershipIdentity),
@@ -248,18 +268,20 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 		);
 	},
 	cleanupManifestOwned(input) {
-		const target = targetDir(input.workspaceRoot, input.skillId);
-		const receipt = receiptInput(input.workspaceRoot, input.skillId, input.ownershipIdentity);
-		if (!existsSync(target)) {
+		return withRuntimeUserFileAccess(() => {
+			const target = targetDir(input.workspaceRoot, input.skillId);
+			const receipt = receiptInput(input.workspaceRoot, input.skillId, input.ownershipIdentity);
+			if (!existsSync(target)) {
+				rmSync(receipt.path, { force: true });
+				return "absent";
+			}
+			if (!managedSkillReceiptMatchesIdentity(receipt))
+				throw new Error(
+					"refusing manifest cleanup because OpenClaw Skill bytes no longer match the ownership receipt",
+				);
+			rmSync(target, { recursive: true });
 			rmSync(receipt.path, { force: true });
-			return "absent";
-		}
-		if (!managedSkillReceiptMatchesIdentity(receipt))
-			throw new Error(
-				"refusing manifest cleanup because OpenClaw Skill bytes no longer match the ownership receipt",
-			);
-		rmSync(target, { recursive: true });
-		rmSync(receipt.path, { force: true });
-		return "removed";
+			return "removed";
+		});
 	},
 };

--- a/packages/cli/src/runtime/managed-skill-delivery.ts
+++ b/packages/cli/src/runtime/managed-skill-delivery.ts
@@ -15,6 +15,7 @@ import { basename, dirname, join } from "node:path";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { managedSkillDirectoryDigest } from "./hosted-bundled-skill";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
+import { withRuntimeUserFileAccess } from "./runtime-user-command";
 
 const MAX_ENTRIES = 1024;
 const MAX_FILE_BYTES = 16 * 1024 * 1024;
@@ -56,6 +57,13 @@ export function collectManagedSkillTree(
 	}
 }
 
+export function collectRuntimeUserManagedSkillTree(
+	root: string,
+	options: { exclude?: ReadonlySet<string> } = {},
+): ManagedSkillTree | null {
+	return withRuntimeUserFileAccess(() => collectManagedSkillTree(root, options));
+}
+
 export function managedSkillTreeFingerprint(tree: ManagedSkillTree | null): string | null {
 	if (!tree) return null;
 	const hash = createHash("sha256");
@@ -88,23 +96,25 @@ export function writeManagedSkillReceipt(input: {
 	target: string;
 	exclude?: ReadonlySet<string>;
 }): void {
-	const treeFingerprint = managedSkillTreeFingerprint(
-		collectManagedSkillTree(input.target, { exclude: input.exclude }),
-	);
-	if (!treeFingerprint) throw new Error("installed Skill tree is unsafe");
-	const receipt: ManagedSkillReceipt = {
-		schemaVersion: input.schemaVersion,
-		skillId: input.skillId,
-		ownershipIdentity: input.ownershipIdentity,
-		treeFingerprint,
-	};
-	writePrivateFileAtomic(input.path, `${JSON.stringify(receipt)}\n`, {
-		mode: 0o600,
-		dirMode: 0o700,
+	withRuntimeUserFileAccess(() => {
+		const treeFingerprint = managedSkillTreeFingerprint(
+			collectManagedSkillTree(input.target, { exclude: input.exclude }),
+		);
+		if (!treeFingerprint) throw new Error("installed Skill tree is unsafe");
+		const receipt: ManagedSkillReceipt = {
+			schemaVersion: input.schemaVersion,
+			skillId: input.skillId,
+			ownershipIdentity: input.ownershipIdentity,
+			treeFingerprint,
+		};
+		writePrivateFileAtomic(input.path, `${JSON.stringify(receipt)}\n`, {
+			mode: 0o600,
+			dirMode: 0o700,
+		});
 	});
 }
 
-function readManagedSkillMarker(input: {
+function readManagedSkillMarkerRaw(input: {
 	path: string;
 	schemaVersion: string;
 	skillId: string;
@@ -140,6 +150,16 @@ function readManagedSkillMarker(input: {
 	}
 }
 
+function readManagedSkillMarker(input: {
+	path: string;
+	schemaVersion: string;
+	skillId: string;
+	target: string;
+	exclude?: ReadonlySet<string>;
+}): ManagedSkillReceipt | null {
+	return withRuntimeUserFileAccess(() => readManagedSkillMarkerRaw(input));
+}
+
 function readManagedSkillReceipt(input: {
 	path: string;
 	schemaVersion: string;
@@ -147,11 +167,14 @@ function readManagedSkillReceipt(input: {
 	target: string;
 	exclude?: ReadonlySet<string>;
 }): ManagedSkillReceipt | null {
-	const marker = readManagedSkillMarker(input);
-	return marker?.treeFingerprint ===
-		managedSkillTreeFingerprint(collectManagedSkillTree(input.target, { exclude: input.exclude }))
-		? marker
-		: null;
+	return withRuntimeUserFileAccess(() => {
+		const marker = readManagedSkillMarkerRaw(input);
+		if (!marker) return null;
+		return marker.treeFingerprint ===
+			managedSkillTreeFingerprint(collectManagedSkillTree(input.target, { exclude: input.exclude }))
+			? marker
+			: null;
+	});
 }
 
 export function managedSkillMarkerOwnsTarget(input: {

--- a/packages/cli/src/runtime/managed-skill-delivery.ts
+++ b/packages/cli/src/runtime/managed-skill-delivery.ts
@@ -2,16 +2,20 @@ import { spawnSync } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import {
 	chmodSync,
+	closeSync,
+	constants,
 	existsSync,
+	fstatSync,
 	lstatSync,
 	mkdtempSync,
+	openSync,
 	readdirSync,
 	readFileSync,
 	renameSync,
 	rmSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { managedSkillDirectoryDigest } from "./hosted-bundled-skill";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
@@ -20,6 +24,35 @@ import { withRuntimeUserFileAccess } from "./runtime-user-command";
 const MAX_ENTRIES = 1024;
 const MAX_FILE_BYTES = 16 * 1024 * 1024;
 const MAX_TREE_BYTES = 32 * 1024 * 1024;
+const MANAGED_SKILL_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+const LEGACY_RECEIPT_DIRECTORY = ".clawdi-manifest-receipts";
+const PLATFORM_RECEIPT_DIRECTORY = "skill-receipts";
+
+export const HERMES_MANAGED_SKILL_RECEIPT_SCHEMA = "clawdi.hermesManifestSkillReceipt.v2";
+export const OPENCLAW_MANAGED_SKILL_RECEIPT_SCHEMA = "clawdi.openclawManifestSkillReceipt.v2";
+export type ManagedSkillReceiptRuntime = "hermes" | "openclaw";
+
+export class ManagedSkillResourceError extends Error {}
+
+function assertManagedSkillId(skillId: string): void {
+	if (!MANAGED_SKILL_ID_PATTERN.test(skillId)) {
+		throw new Error(`invalid managed Skill id: ${skillId}`);
+	}
+}
+
+export function managedSkillReceiptPath(
+	managedResourceRoot: string,
+	runtime: ManagedSkillReceiptRuntime,
+	skillId: string,
+): string {
+	assertManagedSkillId(skillId);
+	return join(managedResourceRoot, PLATFORM_RECEIPT_DIRECTORY, runtime, `${skillId}.json`);
+}
+
+export function legacyManagedSkillReceiptPath(skillsRoot: string, skillId: string): string {
+	assertManagedSkillId(skillId);
+	return join(skillsRoot, LEGACY_RECEIPT_DIRECTORY, `${skillId}.json`);
+}
 
 export type ManagedSkillTree = ReadonlyMap<string, Buffer>;
 
@@ -90,27 +123,45 @@ type ManagedSkillReceipt = {
 
 export function writeManagedSkillReceipt(input: {
 	path: string;
+	managedResourceRoot: string;
 	schemaVersion: string;
 	skillId: string;
 	ownershipIdentity: string;
 	target: string;
 	exclude?: ReadonlySet<string>;
 }): void {
-	withRuntimeUserFileAccess(() => {
-		const treeFingerprint = managedSkillTreeFingerprint(
-			collectManagedSkillTree(input.target, { exclude: input.exclude }),
-		);
-		if (!treeFingerprint) throw new Error("installed Skill tree is unsafe");
-		const receipt: ManagedSkillReceipt = {
-			schemaVersion: input.schemaVersion,
-			skillId: input.skillId,
-			ownershipIdentity: input.ownershipIdentity,
-			treeFingerprint,
-		};
-		writePrivateFileAtomic(input.path, `${JSON.stringify(receipt)}\n`, {
-			mode: 0o600,
-			dirMode: 0o700,
-		});
+	const treeFingerprint = managedSkillTreeFingerprint(
+		collectRuntimeUserManagedSkillTree(input.target, { exclude: input.exclude }),
+	);
+	if (!treeFingerprint) throw new ManagedSkillResourceError("installed Skill tree is unsafe");
+	writeManagedSkillReceiptRecord(input.managedResourceRoot, input.path, {
+		schemaVersion: input.schemaVersion,
+		skillId: input.skillId,
+		ownershipIdentity: input.ownershipIdentity,
+		treeFingerprint,
+	});
+}
+
+function writeManagedSkillReceiptRecord(
+	managedResourceRoot: string,
+	path: string,
+	receipt: ManagedSkillReceipt,
+): void {
+	writePrivateFileAtomic(path, `${JSON.stringify(receipt)}\n`, {
+		mode: 0o600,
+		dirMode: 0o700,
+		trustedRoot: managedResourceRoot,
+	});
+}
+
+function runtimeUserTargetIsDirectory(path: string): boolean {
+	return withRuntimeUserFileAccess(() => {
+		try {
+			const target = lstatSync(path);
+			return !target.isSymbolicLink() && target.isDirectory();
+		} catch {
+			return false;
+		}
 	});
 }
 
@@ -121,19 +172,19 @@ function readManagedSkillMarkerRaw(input: {
 	target: string;
 	exclude?: ReadonlySet<string>;
 }): ManagedSkillReceipt | null {
+	let descriptor: number | null = null;
 	try {
-		const target = lstatSync(input.target);
-		if (target.isSymbolicLink() || !target.isDirectory()) return null;
-		const receiptStat = lstatSync(input.path);
+		if (!runtimeUserTargetIsDirectory(input.target)) return null;
+		descriptor = openSync(input.path, constants.O_RDONLY | constants.O_NOFOLLOW);
+		const receiptStat = fstatSync(descriptor);
 		const effectiveUid = process.geteuid?.();
 		if (
-			receiptStat.isSymbolicLink() ||
 			!receiptStat.isFile() ||
 			(receiptStat.mode & 0o022) !== 0 ||
 			(effectiveUid !== undefined && receiptStat.uid !== effectiveUid)
 		)
 			return null;
-		const receipt = JSON.parse(readFileSync(input.path, "utf8")) as Record<string, unknown>;
+		const receipt = JSON.parse(readFileSync(descriptor, "utf8")) as Record<string, unknown>;
 		if (
 			receipt.schemaVersion === input.schemaVersion &&
 			receipt.skillId === input.skillId &&
@@ -147,6 +198,8 @@ function readManagedSkillMarkerRaw(input: {
 		return null;
 	} catch {
 		return null;
+	} finally {
+		if (descriptor !== null) closeSync(descriptor);
 	}
 }
 
@@ -157,7 +210,7 @@ function readManagedSkillMarker(input: {
 	target: string;
 	exclude?: ReadonlySet<string>;
 }): ManagedSkillReceipt | null {
-	return withRuntimeUserFileAccess(() => readManagedSkillMarkerRaw(input));
+	return readManagedSkillMarkerRaw(input);
 }
 
 function readManagedSkillReceipt(input: {
@@ -167,14 +220,91 @@ function readManagedSkillReceipt(input: {
 	target: string;
 	exclude?: ReadonlySet<string>;
 }): ManagedSkillReceipt | null {
-	return withRuntimeUserFileAccess(() => {
-		const marker = readManagedSkillMarkerRaw(input);
-		if (!marker) return null;
-		return marker.treeFingerprint ===
-			managedSkillTreeFingerprint(collectManagedSkillTree(input.target, { exclude: input.exclude }))
-			? marker
-			: null;
-	});
+	const marker = readManagedSkillMarkerRaw(input);
+	if (!marker) return null;
+	return marker.treeFingerprint ===
+		managedSkillTreeFingerprint(
+			collectRuntimeUserManagedSkillTree(input.target, { exclude: input.exclude }),
+		)
+		? marker
+		: null;
+}
+
+function realDirectoryWithin(root: string, path: string): boolean {
+	const trustedRoot = resolve(root);
+	const target = resolve(path);
+	const child = relative(trustedRoot, target);
+	if (child.startsWith("..") || isAbsolute(child)) {
+		throw new Error(`legacy managed Skill receipt root is outside tenant HOME: ${path}`);
+	}
+	let current = trustedRoot;
+	for (const segment of child ? ["", ...child.split("/")] : [""]) {
+		if (segment) current = join(current, segment);
+		try {
+			const node = lstatSync(current);
+			if (node.isSymbolicLink() || !node.isDirectory()) {
+				throw new Error(`legacy managed Skill receipt path is unsafe: ${current}`);
+			}
+		} catch (error) {
+			if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+			throw error;
+		}
+	}
+	return true;
+}
+
+/**
+ * SUNSET(#1148): remove after every supported hosted CLI has migrated
+ * tenant-home Skill receipts into the platform managed-resource root.
+ */
+export function migrateLegacyManagedSkillReceiptDirectory(input: {
+	tenantHome: string;
+	managedResourceRoot: string;
+	runtime: ManagedSkillReceiptRuntime;
+	skillsRoot: string;
+}): void {
+	if (!realDirectoryWithin(input.tenantHome, input.skillsRoot)) return;
+	const legacyDirectory = join(input.skillsRoot, LEGACY_RECEIPT_DIRECTORY);
+	let directory: ReturnType<typeof lstatSync>;
+	try {
+		directory = lstatSync(legacyDirectory);
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+		throw error;
+	}
+	if (directory.isSymbolicLink() || !directory.isDirectory()) {
+		rmSync(legacyDirectory, { recursive: true, force: true });
+		return;
+	}
+
+	const schemaVersion =
+		input.runtime === "hermes"
+			? HERMES_MANAGED_SKILL_RECEIPT_SCHEMA
+			: OPENCLAW_MANAGED_SKILL_RECEIPT_SCHEMA;
+	for (const entry of readdirSync(legacyDirectory, { withFileTypes: true })) {
+		const match = /^([a-z0-9][a-z0-9._-]{0,63})\.json$/.exec(entry.name);
+		if (!match || !entry.isFile() || entry.isSymbolicLink()) continue;
+		const skillId = match[1];
+		const legacyPath = join(legacyDirectory, entry.name);
+		const target = join(input.skillsRoot, skillId);
+		const receipt = readManagedSkillReceipt({
+			path: legacyPath,
+			schemaVersion,
+			skillId,
+			target,
+			...(input.runtime === "openclaw"
+				? { exclude: new Set([".openclaw/source-origin.json"]) }
+				: {}),
+		});
+		if (!receipt) continue;
+		const destination = managedSkillReceiptPath(input.managedResourceRoot, input.runtime, skillId);
+		if (!existsSync(destination)) {
+			writeManagedSkillReceiptRecord(input.managedResourceRoot, destination, receipt);
+		}
+	}
+	// This directory was always Clawdi metadata. Invalid or unknown entries are
+	// deliberately not promoted into platform ownership authority.
+	rmSync(legacyDirectory, { recursive: true, force: true });
 }
 
 export function managedSkillMarkerOwnsTarget(input: {
@@ -274,13 +404,13 @@ export function withManagedTargetRollback<T>(input: {
 	const receiptBackup = input.receipt
 		? join(dirname(input.receipt), `.${basename(input.receipt)}-clawdi-rollback-${suffix}`)
 		: undefined;
-	const hadTarget = existsSync(input.target);
+	const hadTarget = withRuntimeUserFileAccess(() => existsSync(input.target));
 	const hadReceipt = input.receipt !== undefined && existsSync(input.receipt);
 	let targetMoved = false;
 	let receiptMoved = false;
 	try {
 		if (hadTarget) {
-			rename(input.target, targetBackup);
+			withRuntimeUserFileAccess(() => rename(input.target, targetBackup));
 			targetMoved = true;
 		}
 		if (hadReceipt && input.receipt && receiptBackup) {
@@ -289,23 +419,23 @@ export function withManagedTargetRollback<T>(input: {
 		}
 	} catch (error) {
 		if (receiptMoved && input.receipt && receiptBackup) rename(receiptBackup, input.receipt);
-		if (targetMoved) rename(targetBackup, input.target);
+		if (targetMoved) withRuntimeUserFileAccess(() => rename(targetBackup, input.target));
 		throw error;
 	}
 	let result: T;
 	try {
 		result = input.operation();
 	} catch (error) {
-		remove(input.target, { recursive: true, force: true });
+		withRuntimeUserFileAccess(() => remove(input.target, { recursive: true, force: true }));
 		if (input.receipt) remove(input.receipt, { force: true });
-		if (hadTarget) rename(targetBackup, input.target);
+		if (hadTarget) withRuntimeUserFileAccess(() => rename(targetBackup, input.target));
 		if (hadReceipt && input.receipt && receiptBackup) rename(receiptBackup, input.receipt);
 		throw error;
 	}
 	// The operation returning is the commit point. Backup cleanup is GC and
 	// must never roll back a live target or its ownership receipt.
 	try {
-		remove(targetBackup, { recursive: true, force: true });
+		withRuntimeUserFileAccess(() => remove(targetBackup, { recursive: true, force: true }));
 		if (receiptBackup) remove(receiptBackup, { force: true });
 	} catch {}
 	return result;

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -120,7 +120,10 @@ import {
 	writeJsonFile,
 	writeRuntimePrivateFileAtomic,
 } from "./manifest-shared";
-import { reconcileHostedSkillProjection } from "./manifest-skills-apply";
+import {
+	migrateLegacyHostedSkillReceipts,
+	reconcileHostedSkillProjection,
+} from "./manifest-skills-apply";
 import type { RuntimeManifestLoad } from "./manifest-source";
 import { ensureRuntimeMitmproxy } from "./mitmproxy-fetch";
 import { ensureManagedOpenClawProviderPlugin } from "./openclaw-managed-provider-plugin";
@@ -183,8 +186,13 @@ export function convergeRuntimeManifest(
 		opts.hostedRuntimeContract,
 	);
 	const projectionHome = hostedRuntimeProjectionHome(manifest, paths);
-	// Runtime-user state ownership is a platform invariant, not a manifest
-	// mutation: repair it before snapshots so rollback cannot restore drift.
+	// Platform metadata must leave tenant HOME before the recursive ownership
+	// invariant is repaired. Both operations precede snapshots by design.
+	migrateLegacyHostedSkillReceipts({
+		manifest,
+		home: projectionHome,
+		managedResourceRoot: paths.managedResourceRoot,
+	});
 	enforceRuntimeUserOwnership([
 		...runtimeUserDirectoryOwnership(projectionHome, { recursive: true }),
 		...hostedOpenClawRuntimeUserOwnership(manifest, projectionHome),
@@ -852,27 +860,34 @@ export function convergeRuntimeManifest(
 					manifest,
 					projectionHome,
 					openClawWorkspaceRoot,
+					paths.managedResourceRoot,
 				);
 				skillProjectionSnapshot = captureRuntimeLiveSnapshot({
-					rootTargets: [managedSkillReservationLedgerPath()],
+					rootTargets: [
+						managedSkillReservationLedgerPath(),
+						...skillMutationTargets.platformTargets,
+					],
 					trustedRootDirectories: [paths.managedResourceRoot],
-					runtimeUserTargets: skillMutationTargets,
+					runtimeUserTargets: skillMutationTargets.runtimeUserTargets,
 					runtimeUserTrustedRoots: [paths.userHome, paths.clawdiHome],
 					runtimeUserSymlinkTargets: [],
-					metadataTargets: mutationAncestorMetadataTargets(skillMutationTargets, [
-						paths.userHome,
-						paths.clawdiHome,
-					]),
+					metadataTargets: mutationAncestorMetadataTargets(
+						skillMutationTargets.runtimeUserTargets,
+						[paths.userHome, paths.clawdiHome],
+					),
 				});
-				reconcileHostedSkillProjection({
-					manifest,
-					observations,
-					home: projectionHome,
-					openClawWorkspaceRoot,
-					preparedSourcedSkills: preparedHostedSourcedSkills,
-					hermesDriver: hermesSkillNativeReconciler,
-					openClawDriver: openClawSkillDriver,
-				});
+				resourceProjectionErrors.push(
+					...reconcileHostedSkillProjection({
+						manifest,
+						observations,
+						home: projectionHome,
+						managedResourceRoot: paths.managedResourceRoot,
+						openClawWorkspaceRoot,
+						preparedSourcedSkills: preparedHostedSourcedSkills,
+						hermesDriver: hermesSkillNativeReconciler,
+						openClawDriver: openClawSkillDriver,
+					}),
+				);
 			} catch (error) {
 				const projectionError = error instanceof Error ? error.message : String(error);
 				try {

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -18,7 +18,10 @@ import {
 	hostedAgentPluginCommands,
 } from "./hosted-agent-plugin-runtime";
 import { hostedHermesSkillExactSourceDriver } from "./hosted-hermes-skill";
-import { createOpenClawHostedContext } from "./hosted-openclaw-context";
+import {
+	createOpenClawHostedContext,
+	hostedOpenClawRuntimeUserOwnership,
+} from "./hosted-openclaw-context";
 import { hostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
 import { assertHostedRuntimeContract } from "./hosted-runtime-contract";
 import { type RuntimeInstallReceipts, readRuntimeInstallReceipts } from "./install-receipts";
@@ -180,10 +183,13 @@ export function convergeRuntimeManifest(
 		opts.hostedRuntimeContract,
 	);
 	const projectionHome = hostedRuntimeProjectionHome(manifest, paths);
-	const openClawContext = createOpenClawHostedContext(manifest, projectionHome);
 	// Runtime-user state ownership is a platform invariant, not a manifest
 	// mutation: repair it before snapshots so rollback cannot restore drift.
-	enforceRuntimeUserOwnership(openClawContext.ownership);
+	enforceRuntimeUserOwnership([
+		...runtimeUserDirectoryOwnership(projectionHome, { recursive: true }),
+		...hostedOpenClawRuntimeUserOwnership(manifest, projectionHome),
+	]);
+	const openClawContext = createOpenClawHostedContext(manifest, projectionHome);
 	const hermesWhatsAppAuthDir = managedHermesWhatsAppAuthDir(manifest, projectionHome);
 	removeHostedCliPathExposure(paths);
 	removeLegacyTenantClawdiState(paths);
@@ -416,7 +422,7 @@ export function convergeRuntimeManifest(
 			projectedProviderIds: retainPreviousProjectedProviderIds(),
 		});
 	}
-	const workspaceExistedBeforeApply = existsSync(workspaceRoot);
+	const workspaceExistedBeforeApply = withRuntimeUserFileAccess(() => existsSync(workspaceRoot));
 	let liveSnapshot: ReturnType<typeof captureRuntimeLiveSnapshot>;
 	try {
 		let snapshotPlan = mutationPlan.snapshot;
@@ -1419,7 +1425,7 @@ export function convergeRuntimeManifest(
 			filesystemRollbackSucceeded &&
 			!workspaceExistedBeforeApply &&
 			resolve(workspaceRoot) !== resolve(paths.userHome) &&
-			existsSync(workspaceRoot)
+			withRuntimeUserFileAccess(() => existsSync(workspaceRoot))
 		) {
 			try {
 				withRuntimeUserFileAccess(() => {

--- a/packages/cli/src/runtime/manifest-planning.ts
+++ b/packages/cli/src/runtime/manifest-planning.ts
@@ -651,25 +651,29 @@ export function hostedSkillMutationTargets(
 	const targets = new Set<string>();
 	const hermesSkillsRoot = join(home, ".hermes", "skills");
 	const openClawSkillsRoot = openClawWorkspaceRoot ? join(openClawWorkspaceRoot, "skills") : null;
+	const addSkillTargets = (skillsRoot: string, skillId: string) => {
+		targets.add(join(skillsRoot, skillId));
+		targets.add(join(skillsRoot, ".clawdi-manifest-receipts", `${skillId}.json`));
+	};
 	let managesHermesSourcedSkill = false;
 	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
-		targets.add(join(hermesSkillsRoot, skillId));
-		if (openClawSkillsRoot) targets.add(join(openClawSkillsRoot, skillId));
+		addSkillTargets(hermesSkillsRoot, skillId);
+		if (openClawSkillsRoot) addSkillTargets(openClawSkillsRoot, skillId);
 		if ("source" in desired && manifest.runtimes.hermes?.enabled === true) {
 			managesHermesSourcedSkill = true;
 		}
 	}
 	for (const skillId of hostedBundledSkillIds()) {
-		targets.add(join(hermesSkillsRoot, skillId));
-		if (openClawSkillsRoot) targets.add(join(openClawSkillsRoot, skillId));
+		addSkillTargets(hermesSkillsRoot, skillId);
+		if (openClawSkillsRoot) addSkillTargets(openClawSkillsRoot, skillId);
 	}
 	for (const reservation of managedSkillReservations("hosted-manifest")) {
 		if (dirname(reservation.targetDir) === hermesSkillsRoot) {
 			if (reservation.sourceIdentity) managesHermesSourcedSkill = true;
-			targets.add(reservation.targetDir);
+			addSkillTargets(hermesSkillsRoot, reservation.id);
 		}
 		if (openClawSkillsRoot && dirname(reservation.targetDir) === openClawSkillsRoot) {
-			targets.add(reservation.targetDir);
+			addSkillTargets(openClawSkillsRoot, reservation.id);
 		}
 	}
 	if (managesHermesSourcedSkill) targets.add(join(hermesSkillsRoot, ".hub"));

--- a/packages/cli/src/runtime/manifest-planning.ts
+++ b/packages/cli/src/runtime/manifest-planning.ts
@@ -41,6 +41,7 @@ import {
 	managedBaileysCompatSnapshotRuntimes,
 } from "./managed-baileys-compat";
 import { buildHermesManagedChannelsPatch } from "./managed-channel-reconciliation";
+import { managedSkillReceiptPath } from "./managed-skill-delivery";
 import { managedSkillReservations } from "./managed-skill-reservation";
 import {
 	hostedChannelCredentialsDeclared,
@@ -647,37 +648,42 @@ export function hostedSkillMutationTargets(
 	manifest: RuntimeManifest,
 	home: string,
 	openClawWorkspaceRoot: string | null,
-): string[] {
-	const targets = new Set<string>();
+	managedResourceRoot: string,
+): { platformTargets: string[]; runtimeUserTargets: string[] } {
+	const runtimeUserTargets = new Set<string>();
+	const platformTargets = new Set<string>();
 	const hermesSkillsRoot = join(home, ".hermes", "skills");
 	const openClawSkillsRoot = openClawWorkspaceRoot ? join(openClawWorkspaceRoot, "skills") : null;
-	const addSkillTargets = (skillsRoot: string, skillId: string) => {
-		targets.add(join(skillsRoot, skillId));
-		targets.add(join(skillsRoot, ".clawdi-manifest-receipts", `${skillId}.json`));
+	const addSkillTargets = (runtime: "hermes" | "openclaw", skillsRoot: string, skillId: string) => {
+		runtimeUserTargets.add(join(skillsRoot, skillId));
+		platformTargets.add(managedSkillReceiptPath(managedResourceRoot, runtime, skillId));
 	};
 	let managesHermesSourcedSkill = false;
 	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
-		addSkillTargets(hermesSkillsRoot, skillId);
-		if (openClawSkillsRoot) addSkillTargets(openClawSkillsRoot, skillId);
+		addSkillTargets("hermes", hermesSkillsRoot, skillId);
+		if (openClawSkillsRoot) addSkillTargets("openclaw", openClawSkillsRoot, skillId);
 		if ("source" in desired && manifest.runtimes.hermes?.enabled === true) {
 			managesHermesSourcedSkill = true;
 		}
 	}
 	for (const skillId of hostedBundledSkillIds()) {
-		addSkillTargets(hermesSkillsRoot, skillId);
-		if (openClawSkillsRoot) addSkillTargets(openClawSkillsRoot, skillId);
+		addSkillTargets("hermes", hermesSkillsRoot, skillId);
+		if (openClawSkillsRoot) addSkillTargets("openclaw", openClawSkillsRoot, skillId);
 	}
 	for (const reservation of managedSkillReservations("hosted-manifest")) {
 		if (dirname(reservation.targetDir) === hermesSkillsRoot) {
 			if (reservation.sourceIdentity) managesHermesSourcedSkill = true;
-			addSkillTargets(hermesSkillsRoot, reservation.id);
+			addSkillTargets("hermes", hermesSkillsRoot, reservation.id);
 		}
 		if (openClawSkillsRoot && dirname(reservation.targetDir) === openClawSkillsRoot) {
-			addSkillTargets(openClawSkillsRoot, reservation.id);
+			addSkillTargets("openclaw", openClawSkillsRoot, reservation.id);
 		}
 	}
-	if (managesHermesSourcedSkill) targets.add(join(hermesSkillsRoot, ".hub"));
-	return [...targets].sort();
+	if (managesHermesSourcedSkill) runtimeUserTargets.add(join(hermesSkillsRoot, ".hub"));
+	return {
+		platformTargets: [...platformTargets].sort(),
+		runtimeUserTargets: [...runtimeUserTargets].sort(),
+	};
 }
 export function runtimeManagedMutationPlan(input: {
 	manifest: RuntimeManifest;

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -44,6 +44,7 @@ import {
 	assertHostedBundledSkillCatalogDigest,
 	resolveHostedBundledSkill,
 } from "./hosted-bundled-skill";
+import { hostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
 import { hostedAiProviderCatalog } from "./hosted-provider-resolution";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import { readRuntimeInstallReceipts } from "./install-receipts";
@@ -87,6 +88,7 @@ import {
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
 import { planRuntimeMutationSystemdUserUnits } from "./runtime-systemd-reconciliation";
+import { withRuntimeUserFileAccess } from "./runtime-user-command";
 import {
 	canonicalSecretRefSchema,
 	normalizeSecretValues,
@@ -4223,7 +4225,7 @@ echo spawned > '${installerLog}'
 		expect(existsSync(join(paths.userHome, ".local", "bin", "openclaw"))).toBe(false);
 	});
 
-	test("migrates the real legacy Hermes bundle once and then stays receipt-anchored", () => {
+	test("migrates a runtime-owned legacy Hermes bundle once and then stays receipt-anchored", () => {
 		const paths = tempRuntimePaths();
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
@@ -4303,6 +4305,126 @@ echo spawned > '${installerLog}'
 		stable = snapshot();
 		converge(5);
 		expect(snapshot()).toEqual(stable);
+	});
+
+	test("repairs and claims a root-owned unreadable legacy Hermes marker", () => {
+		if (process.geteuid?.() !== 0) return;
+		const paths = tempRuntimePaths();
+		const fixtureRoot = dirname(paths.serviceStateRoot);
+		const runtimeUid = Number.parseInt(
+			execFileSync("id", ["-u", "nobody"], { encoding: "utf8" }).trim(),
+			10,
+		);
+		const runtimeGid = Number.parseInt(
+			execFileSync("id", ["-g", "nobody"], { encoding: "utf8" }).trim(),
+			10,
+		);
+		process.env.CLAWDI_RUNTIME_USER = "nobody";
+		process.env.CLAWDI_RUNTIME_UID = String(runtimeUid);
+		process.env.CLAWDI_RUNTIME_GID = String(runtimeGid);
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+
+		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		const source = resolve(import.meta.dir, "../..", "skills", "hosted-versions", "1", "clawdi");
+		const target = join(paths.userHome, ".hermes", "skills", "clawdi");
+		const skillPath = join(target, "SKILL.md");
+		const marker = join(target, ".clawdi-managed.json");
+		const receipt = join(
+			paths.userHome,
+			".hermes",
+			"skills",
+			".clawdi-manifest-receipts",
+			"clawdi.json",
+		);
+		const catalogEntry = resolveHostedBundledSkill("clawdi", 1);
+
+		chmodSync(fixtureRoot, 0o755);
+		mkdirSync(dirname(hermesCommand), { recursive: true });
+		writeFileSync(hermesCommand, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+		cpSync(source, target, { recursive: true });
+		chmodSync(target, 0o755);
+		chmodSync(skillPath, 0o644);
+		writeFileSync(
+			marker,
+			`${JSON.stringify({
+				schema: "clawdi.hostedBundledSkillMarker.v1",
+				owner: "clawdi runtime init",
+				id: "clawdi",
+				version: 1,
+				digest: catalogEntry.digest,
+			})}\n`,
+			{ mode: 0o600 },
+		);
+		for (const path of [
+			paths.userHome,
+			join(paths.userHome, ".local"),
+			dirname(hermesCommand),
+			hermesCommand,
+			join(paths.userHome, ".hermes"),
+			join(paths.userHome, ".hermes", "skills"),
+			target,
+			skillPath,
+		]) {
+			chownSync(path, runtimeUid, runtimeGid);
+		}
+		chownSync(marker, 0, 0);
+		expect(() => withRuntimeUserFileAccess(() => readFileSync(marker))).toThrow();
+
+		const manifest = baseManifest(
+			paths,
+			{
+				hermes: {
+					enabled: true,
+					run: runSettings(hermesCommand, ["gateway"]),
+					services: {},
+				},
+			},
+			{ projection: { skills: { entries: { clawdi: { enabled: true, version: 1 } } } } },
+		);
+		const converge = (generation: number) => {
+			const result = convergeRuntimeManifest(
+				manifestLoad({ ...manifest, generation }, `root-legacy-hermes-${generation}`),
+				paths,
+				{
+					hostedRuntimeContract: {
+						expectedIdentity: {
+							home: paths.userHome,
+							user: "nobody",
+							uid: runtimeUid,
+							gid: runtimeGid,
+						},
+						resolveUserIdentity: () => ({ uid: runtimeUid, gid: runtimeGid }),
+					},
+				},
+			);
+			expect([...result.installErrors, ...result.resourceProjectionErrors]).toEqual([]);
+		};
+
+		converge(1);
+		expect(existsSync(marker)).toBe(false);
+		expect([statSync(target).uid, statSync(skillPath).uid, statSync(receipt).uid]).toEqual([
+			runtimeUid,
+			runtimeUid,
+			runtimeUid,
+		]);
+		expect(JSON.parse(readFileSync(receipt, "utf8"))).toMatchObject({
+			ownershipIdentity: `content-sha256\0${catalogEntry.digest}`,
+		});
+		const stable = {
+			target: statSync(target).ino,
+			skill: statSync(skillPath).ino,
+			receipt: statSync(receipt).ino,
+			content: readFileSync(receipt),
+		};
+		for (const generation of [2, 3]) {
+			converge(generation);
+			expect({
+				target: statSync(target).ino,
+				skill: statSync(skillPath).ino,
+				receipt: statSync(receipt).ino,
+				content: readFileSync(receipt),
+			}).toEqual(stable);
+		}
 	});
 
 	test("keeps the hosted skill ledger root owned while mutating the runtime-user skill tree", () => {
@@ -4477,6 +4599,7 @@ echo spawned > '${installerLog}'
 				preparedHostedSourcedSkills: new Map([[prepared.skillId, prepared]]),
 				hostedHermesSkillExactSourceDriver: {
 					install: () => "installed",
+					anchorOwnership: () => undefined,
 					hasOwnershipReceipt: () => false,
 					verifyOwned: () => false,
 					uninstall: () => "removed",
@@ -4504,6 +4627,7 @@ echo spawned > '${installerLog}'
 				if (installs.length === 1) throw new Error("lost native install response");
 				return "unchanged" as const;
 			},
+			anchorOwnership: () => undefined,
 			hasOwnershipReceipt: (input: { ownershipIdentity: string }) => {
 				verifyCalls += 1;
 				return (
@@ -4655,7 +4779,7 @@ echo spawned > '${installerLog}'
 		expect(shouldIgnoreUserSkill(target, "clawdi")).toBe(true);
 	});
 
-	test("removes only strictly identified legacy bundled OpenClaw Skills without requiring a new receipt", () => {
+	test("claims legacy OpenClaw Skills before receipt-guarded removal", () => {
 		const paths = tempRuntimePaths();
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		const command = join(paths.userHome, ".local", "bin", "openclaw");
@@ -4680,6 +4804,7 @@ echo spawned > '${installerLog}'
 			{ openclaw: { enabled: true, run: runSettings(command, ["gateway"]), services: {} } },
 			{ projection: { skills: { entries: {} } } },
 		);
+		let ownershipAnchors = 0;
 		let guardedCleanupCalls = 0;
 		const result = convergeRuntimeManifest(
 			manifestLoad(manifest, "legacy-openclaw-remove"),
@@ -4689,17 +4814,22 @@ echo spawned > '${installerLog}'
 					resolveWorkspace: () => openClawWorkspaceRoot,
 					installDirectory: () => "installed",
 					install: () => "installed",
+					anchorOwnership: () => {
+						ownershipAnchors += 1;
+					},
 					hasOwnershipReceipt: () => false,
 					verifyOwned: () => false,
 					cleanupManifestOwned: () => {
 						guardedCleanupCalls += 1;
+						rmSync(target, { recursive: true, force: true });
 						return "removed";
 					},
 				},
 			},
 		);
 		expect(result.installErrors).toEqual([]);
-		expect(guardedCleanupCalls).toBe(0);
+		expect(ownershipAnchors).toBe(1);
+		expect(guardedCleanupCalls).toBe(1);
 		expect(existsSync(target)).toBe(false);
 	});
 
@@ -5369,6 +5499,7 @@ exit 0
 		chownSync(paths.clawdiHome, runtimeUid, runtimeGid);
 		chmodSync(paths.clawdiHome, 0o700);
 		mkdirSync(binDir, { recursive: true });
+		mkdirSync(appRoot, { recursive: true });
 		mkdirSync(dirname(unitPath), { recursive: true });
 		writeFileSync(
 			commandPath,
@@ -5406,6 +5537,19 @@ printf '{"ok":true}\\n'
 		process.env.CLAWDI_RUNTIME_USER = "clawdi";
 		process.env.CLAWDI_RUNTIME_UID = String(runtimeUid);
 		process.env.CLAWDI_RUNTIME_GID = String(runtimeGid);
+		const hostedRuntimeContract = {
+			expectedIdentity: {
+				home: paths.userHome,
+				user: "clawdi",
+				uid: runtimeUid,
+				gid: runtimeGid,
+			},
+			resolveUserIdentity: () => ({ uid: runtimeUid, gid: runtimeGid }),
+		};
+		const openClawSkillDriver = {
+			...hostedOpenClawSkillDriver,
+			resolveWorkspace: () => join(appRoot, "workspace"),
+		};
 		const manifest = baseManifest(paths, {
 			openclaw: {
 				enabled: true,
@@ -5426,6 +5570,8 @@ printf '{"ok":true}\\n'
 			paths,
 			{
 				executeOfficialServiceInstallers: false,
+				hostedRuntimeContract,
+				hostedOpenClawSkillDriver: openClawSkillDriver,
 			},
 		);
 		expect(result.installErrors).toEqual([]);
@@ -5486,12 +5632,14 @@ printf '{"ok":true}\\n'
 					throw new Error("injected ownership commit failure");
 				},
 				executeOfficialServiceInstallers: false,
+				hostedRuntimeContract,
+				hostedOpenClawSkillDriver: openClawSkillDriver,
 			},
 		);
 		expect(failed.installErrors.join("\n")).toContain("injected ownership commit failure");
 		for (const [path, previous] of beforeRollback) {
 			const node = statSync(path);
-			expect([node.uid, node.gid]).toEqual([0, 0]);
+			expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
 			expect(node.mode & 0o777).toBe(previous.mode);
 			if (previous.content) expect(readFileSync(path)).toEqual(previous.content);
 		}

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -10,6 +10,7 @@ import {
 	mkdtempSync,
 	readFileSync,
 	readlinkSync,
+	renameSync,
 	rmSync,
 	statSync,
 	symlinkSync,
@@ -53,7 +54,17 @@ import {
 	restoreRuntimeLiveSnapshot,
 	runtimeRootLiveMutationTargets,
 } from "./live-state-snapshot";
-import { shouldIgnoreUserSkill } from "./managed-skill-reservation";
+import {
+	collectRuntimeUserManagedSkillTree,
+	legacyManagedSkillReceiptPath,
+	ManagedSkillResourceError,
+	managedSkillReceiptPath,
+	managedSkillTreeFingerprint,
+} from "./managed-skill-delivery";
+import {
+	managedSkillReservationLedgerPath,
+	shouldIgnoreUserSkill,
+} from "./managed-skill-reservation";
 import {
 	cacheRuntimeLastGoodManifest,
 	convergeRuntimeManifest as convergeRuntimeManifestWithContract,
@@ -4261,13 +4272,7 @@ echo spawned > '${installerLog}'
 			},
 			{ projection: { skills: { entries: { clawdi: { enabled: true, version: 1 } } } } },
 		);
-		const receipt = join(
-			paths.userHome,
-			".hermes",
-			"skills",
-			".clawdi-manifest-receipts",
-			"clawdi.json",
-		);
+		const receipt = managedSkillReceiptPath(paths.managedResourceRoot, "hermes", "clawdi");
 		const converge = (generation: number) => {
 			const result = convergeRuntimeManifest(
 				manifestLoad({ ...manifest, generation }, `legacy-hermes-bundle-${generation}`),
@@ -4329,12 +4334,12 @@ echo spawned > '${installerLog}'
 		const target = join(paths.userHome, ".hermes", "skills", "clawdi");
 		const skillPath = join(target, "SKILL.md");
 		const marker = join(target, ".clawdi-managed.json");
-		const receipt = join(
+		const receipt = managedSkillReceiptPath(paths.managedResourceRoot, "hermes", "clawdi");
+		const legacyReceiptDirectory = join(
 			paths.userHome,
 			".hermes",
 			"skills",
 			".clawdi-manifest-receipts",
-			"clawdi.json",
 		);
 		const catalogEntry = resolveHostedBundledSkill("clawdi", 1);
 
@@ -4402,29 +4407,81 @@ echo spawned > '${installerLog}'
 
 		converge(1);
 		expect(existsSync(marker)).toBe(false);
-		expect([statSync(target).uid, statSync(skillPath).uid, statSync(receipt).uid]).toEqual([
-			runtimeUid,
-			runtimeUid,
-			runtimeUid,
-		]);
+		expect([statSync(target).uid, statSync(skillPath).uid]).toEqual([runtimeUid, runtimeUid]);
+		expect(statSync(receipt).uid).toBe(process.geteuid?.());
+		expect(statSync(receipt).mode & 0o777).toBe(0o600);
+		expect(statSync(dirname(receipt)).mode & 0o777).toBe(0o700);
+		expect(existsSync(legacyReceiptDirectory)).toBe(false);
 		expect(JSON.parse(readFileSync(receipt, "utf8"))).toMatchObject({
 			ownershipIdentity: `content-sha256\0${catalogEntry.digest}`,
 		});
+		const legacyReceipt = legacyManagedSkillReceiptPath(
+			join(paths.userHome, ".hermes", "skills"),
+			"clawdi",
+		);
+		const beforeMigration = {
+			target: statSync(target).ino,
+			skill: statSync(skillPath).ino,
+			content: readFileSync(receipt),
+		};
+		mkdirSync(dirname(legacyReceipt), { recursive: true, mode: 0o700 });
+		chmodSync(dirname(legacyReceipt), 0o700);
+		renameSync(receipt, legacyReceipt);
+		converge(2);
+		expect(existsSync(legacyReceiptDirectory)).toBe(false);
+		expect({
+			target: statSync(target).ino,
+			skill: statSync(skillPath).ino,
+			content: readFileSync(receipt),
+		}).toEqual(beforeMigration);
+		expect(statSync(receipt).uid).toBe(0);
 		const stable = {
 			target: statSync(target).ino,
 			skill: statSync(skillPath).ino,
 			receipt: statSync(receipt).ino,
 			content: readFileSync(receipt),
 		};
-		for (const generation of [2, 3]) {
-			converge(generation);
-			expect({
-				target: statSync(target).ino,
-				skill: statSync(skillPath).ino,
-				receipt: statSync(receipt).ino,
-				content: readFileSync(receipt),
-			}).toEqual(stable);
-		}
+		converge(3);
+		expect({
+			target: statSync(target).ino,
+			skill: statSync(skillPath).ino,
+			receipt: statSync(receipt).ino,
+			content: readFileSync(receipt),
+		}).toEqual(stable);
+
+		expect(() => withRuntimeUserFileAccess(() => writeFileSync(receipt, "{}\n"))).toThrow();
+		withRuntimeUserFileAccess(() => writeFileSync(skillPath, "tenant mutation\n"));
+		const forgedFingerprint = managedSkillTreeFingerprint(
+			collectRuntimeUserManagedSkillTree(target),
+		);
+		if (!forgedFingerprint) throw new Error("counterfeit receipt fixture tree is unsafe");
+		writeFileSync(
+			receipt,
+			`${JSON.stringify({
+				schemaVersion: "clawdi.hermesManifestSkillReceipt.v2",
+				skillId: "clawdi",
+				ownershipIdentity: `content-sha256\0${catalogEntry.digest}`,
+				treeFingerprint: forgedFingerprint,
+			})}\n`,
+			{ mode: 0o600 },
+		);
+		chownSync(receipt, runtimeUid, runtimeGid);
+		converge(4);
+		expect(readFileSync(skillPath)).toEqual(readFileSync(join(source, "SKILL.md")));
+		expect(statSync(receipt).uid).toBe(0);
+		const repaired = {
+			target: statSync(target).ino,
+			skill: statSync(skillPath).ino,
+			receipt: statSync(receipt).ino,
+			content: readFileSync(receipt),
+		};
+		converge(5);
+		expect({
+			target: statSync(target).ino,
+			skill: statSync(skillPath).ino,
+			receipt: statSync(receipt).ino,
+			content: readFileSync(receipt),
+		}).toEqual(repaired);
 	});
 
 	test("keeps the hosted skill ledger root owned while mutating the runtime-user skill tree", () => {
@@ -4715,6 +4772,143 @@ echo spawned > '${installerLog}'
 		expect(shouldIgnoreUserSkill(userOwnedSibling, "user-owned")).toBe(false);
 	});
 
+	test("isolates per-Skill resource failures without starving later Skills", () => {
+		const paths = tempRuntimePaths();
+		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		mkdirSync(dirname(hermesCommand), { recursive: true });
+		writeFileSync(hermesCommand, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+		const skillIds = ["a-fail", "b-ready", "c-ready"];
+		const preparedSkills = new Map<string, PreparedHostedSourcedSkill>();
+		const entries: NonNullable<RuntimeManifest["projection"]>["skills"] = { entries: {} };
+		for (const skillId of skillIds) {
+			const source = {
+				type: "github" as const,
+				url: "https://github.com/Clawdi-AI/store",
+				path: `skills/${skillId}`,
+				commit: "a".repeat(40),
+			};
+			preparedSkills.set(skillId, {
+				skillId,
+				source,
+				sourceIdentity: `github\0${skillId}\0${source.url}\0${source.path}\0${source.commit}`,
+				archiveSha256: "b".repeat(64),
+				tarBytes: Buffer.from(`archive:${skillId}`),
+			});
+			entries.entries[skillId] = { enabled: true, source };
+		}
+		const manifest = baseManifest(
+			paths,
+			{
+				hermes: {
+					enabled: true,
+					run: runSettings(hermesCommand, ["gateway"]),
+					services: {},
+				},
+			},
+			{ projection: { skills: entries } },
+		);
+		const attempted: string[] = [];
+		const result = convergeRuntimeManifest(manifestLoad(manifest, "skill-item-isolation"), paths, {
+			preparedHostedSourcedSkills: preparedSkills,
+			hostedHermesSkillExactSourceDriver: {
+				install: ({ skill }) => {
+					attempted.push(skill.skillId);
+					if (skill.skillId === "a-fail") {
+						throw new ManagedSkillResourceError("deterministic native install failure");
+					}
+					const target = join(paths.userHome, ".hermes", "skills", skill.skillId);
+					mkdirSync(target, { recursive: true });
+					writeFileSync(join(target, "SKILL.md"), `${skill.skillId}\n`);
+					return "installed";
+				},
+				anchorOwnership: () => undefined,
+				hasOwnershipReceipt: () => false,
+				verifyOwned: () => false,
+				uninstall: () => "removed",
+				cleanupManifestOwned: () => "removed",
+			},
+		});
+
+		expect(result.installErrors).toEqual([]);
+		expect(result.resourceProjectionErrors).toEqual([
+			"runtime hermes Skill projection failed: a-fail: deterministic native install failure",
+		]);
+		expect(attempted).toEqual(skillIds);
+		expect(existsSync(join(paths.userHome, ".hermes", "skills", "a-fail"))).toBe(false);
+		for (const skillId of ["b-ready", "c-ready"]) {
+			expect(
+				readFileSync(join(paths.userHome, ".hermes", "skills", skillId, "SKILL.md"), "utf8"),
+			).toBe(`${skillId}\n`);
+		}
+	});
+
+	test("keeps unmanaged Skill rejection fail-closed across the Skill domain", () => {
+		const paths = tempRuntimePaths();
+		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		mkdirSync(dirname(hermesCommand), { recursive: true });
+		writeFileSync(hermesCommand, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+		const skillIds = ["a-unmanaged", "b-ready", "c-ready"];
+		const preparedSkills = new Map<string, PreparedHostedSourcedSkill>();
+		const entries: NonNullable<RuntimeManifest["projection"]>["skills"] = { entries: {} };
+		for (const skillId of skillIds) {
+			const source = {
+				type: "github" as const,
+				url: "https://github.com/Clawdi-AI/store",
+				path: `skills/${skillId}`,
+				commit: "a".repeat(40),
+			};
+			preparedSkills.set(skillId, {
+				skillId,
+				source,
+				sourceIdentity: `github\0${skillId}\0${source.url}\0${source.path}\0${source.commit}`,
+				archiveSha256: "b".repeat(64),
+				tarBytes: Buffer.from(`archive:${skillId}`),
+			});
+			entries.entries[skillId] = { enabled: true, source };
+		}
+		const unmanaged = join(paths.userHome, ".hermes", "skills", "a-unmanaged");
+		mkdirSync(unmanaged, { recursive: true });
+		writeFileSync(join(unmanaged, "SKILL.md"), "tenant owned\n");
+		const attempted: string[] = [];
+		const manifest = baseManifest(
+			paths,
+			{
+				hermes: {
+					enabled: true,
+					run: runSettings(hermesCommand, ["gateway"]),
+					services: {},
+				},
+			},
+			{ projection: { skills: entries } },
+		);
+		const result = convergeRuntimeManifest(
+			manifestLoad(manifest, "skill-domain-integrity"),
+			paths,
+			{
+				preparedHostedSourcedSkills: preparedSkills,
+				hostedHermesSkillExactSourceDriver: {
+					install: ({ skill }) => {
+						attempted.push(skill.skillId);
+						return "installed";
+					},
+					anchorOwnership: () => undefined,
+					hasOwnershipReceipt: () => false,
+					verifyOwned: () => false,
+					uninstall: () => "removed",
+					cleanupManifestOwned: () => "removed",
+				},
+			},
+		);
+
+		expect(result.resourceProjectionErrors.join("\n")).toContain(
+			`refusing to replace unmanaged a-unmanaged skill at ${unmanaged}`,
+		);
+		expect(attempted).toEqual([]);
+		expect(readFileSync(join(unmanaged, "SKILL.md"), "utf8")).toBe("tenant owned\n");
+		expect(existsSync(join(paths.userHome, ".hermes", "skills", "b-ready"))).toBe(false);
+		expect(existsSync(join(paths.userHome, ".hermes", "skills", "c-ready"))).toBe(false);
+	});
+
 	test("installs a bundled OpenClaw Skill from cleaned runtime-readable staging", () => {
 		const paths = tempRuntimePaths();
 		const command = join(paths.userHome, ".local", "bin", "openclaw");
@@ -4752,24 +4946,32 @@ echo spawned > '${installerLog}'
 			readFileSync(join(packageSource, "SKILL.md")),
 		);
 		expect(existsSync(join(target, ".clawdi-managed.json"))).toBe(false);
+		const receipt = managedSkillReceiptPath(paths.managedResourceRoot, "openclaw", "clawdi");
+		const legacyReceipt = legacyManagedSkillReceiptPath(dirname(target), "clawdi");
+		expect(existsSync(receipt)).toBe(true);
 		expect(
 			existsSync(
-				join(
-					paths.userHome,
-					".openclaw",
-					"workspace",
-					"skills",
-					".clawdi-manifest-receipts",
-					"clawdi.json",
-				),
+				join(paths.userHome, ".openclaw", "workspace", "skills", ".clawdi-manifest-receipts"),
 			),
-		).toBe(true);
+		).toBe(false);
 		expect(shouldIgnoreUserSkill(target, "clawdi")).toBe(true);
 
+		const targetBeforeMigration = statSync(target).ino;
+		mkdirSync(dirname(legacyReceipt), { recursive: true, mode: 0o700 });
+		renameSync(receipt, legacyReceipt);
+		const migrated = convergeRuntimeManifest(
+			manifestLoad({ ...manifest, generation: 2 }, "bundled-openclaw-skill-receipt-migration"),
+			paths,
+		);
+		expect(migrated.resourceProjectionErrors).toEqual([]);
+		expect(statSync(target).ino).toBe(targetBeforeMigration);
+		expect(existsSync(receipt)).toBe(true);
+		expect(existsSync(dirname(legacyReceipt))).toBe(false);
+
 		writeFileSync(join(target, "SKILL.md"), "tenant mutation\n");
-		rmSync(paths.managedResourceRoot, { recursive: true, force: true });
+		rmSync(managedSkillReservationLedgerPath(), { force: true });
 		const reconverged = convergeRuntimeManifest(
-			manifestLoad({ ...manifest, generation: 2 }, "bundled-openclaw-skill-restart"),
+			manifestLoad({ ...manifest, generation: 3 }, "bundled-openclaw-skill-restart"),
 			paths,
 		);
 		expect(reconverged.installErrors).toEqual([]);

--- a/packages/cli/src/runtime/manifest-skills-apply.ts
+++ b/packages/cli/src/runtime/manifest-skills-apply.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import {
 	claimLegacyHostedBundledSkill,
 	hostedBundledSkillIds,
@@ -11,6 +11,10 @@ import {
 	type PreparedHostedSourcedSkill,
 	prepareHostedBundledSkillArchive,
 } from "./hosted-sourced-skill-archive";
+import {
+	ManagedSkillResourceError,
+	migrateLegacyManagedSkillReceiptDirectory,
+} from "./managed-skill-delivery";
 import {
 	installReservedManagedSkill,
 	type ManagedSkillReservationSnapshot,
@@ -91,6 +95,7 @@ function reservationOwnershipIdentity(reservation: ManagedSkillReservationSnapsh
 function hostedSkillProjectionDrivers(input: {
 	manifest: RuntimeManifest;
 	home: string;
+	managedResourceRoot: string;
 	openClawWorkspaceRoot: string | null;
 	hermesDriver: HostedHermesSkillExactSourceDriver;
 	openClawDriver: HostedOpenClawSkillDriver;
@@ -109,14 +114,21 @@ function hostedSkillProjectionDrivers(input: {
 				input.hermesDriver.install({
 					home: input.home,
 					appRoot,
+					managedResourceRoot: input.managedResourceRoot,
 					skill,
 					previouslyReserved,
 				}),
 			anchorOwnership: (skillId, ownershipIdentity) =>
-				input.hermesDriver.anchorOwnership({ home: input.home, skillId, ownershipIdentity }),
+				input.hermesDriver.anchorOwnership({
+					home: input.home,
+					managedResourceRoot: input.managedResourceRoot,
+					skillId,
+					ownershipIdentity,
+				}),
 			hasOwnershipReceipt: (skill) =>
 				input.hermesDriver.hasOwnershipReceipt({
 					home: input.home,
+					managedResourceRoot: input.managedResourceRoot,
 					skillId: skill.skillId,
 					ownershipIdentity: skill.sourceIdentity,
 				}),
@@ -125,6 +137,7 @@ function hostedSkillProjectionDrivers(input: {
 				if (reservation.digest) {
 					input.hermesDriver.cleanupManifestOwned({
 						home: input.home,
+						managedResourceRoot: input.managedResourceRoot,
 						skillId: reservation.id,
 						ownershipIdentity,
 					});
@@ -133,6 +146,7 @@ function hostedSkillProjectionDrivers(input: {
 				input.hermesDriver.uninstall({
 					home: input.home,
 					appRoot,
+					managedResourceRoot: input.managedResourceRoot,
 					skillId: reservation.id,
 					ownershipIdentity,
 				});
@@ -149,6 +163,7 @@ function hostedSkillProjectionDrivers(input: {
 				return input.openClawDriver.install({
 					home: input.home,
 					workspaceRoot: input.openClawWorkspaceRoot,
+					managedResourceRoot: input.managedResourceRoot,
 					skill,
 					previouslyReserved,
 				});
@@ -159,6 +174,7 @@ function hostedSkillProjectionDrivers(input: {
 				}
 				input.openClawDriver.anchorOwnership({
 					workspaceRoot: input.openClawWorkspaceRoot,
+					managedResourceRoot: input.managedResourceRoot,
 					skillId,
 					ownershipIdentity,
 				});
@@ -167,6 +183,7 @@ function hostedSkillProjectionDrivers(input: {
 				if (!input.openClawWorkspaceRoot) return false;
 				return input.openClawDriver.hasOwnershipReceipt({
 					workspaceRoot: input.openClawWorkspaceRoot,
+					managedResourceRoot: input.managedResourceRoot,
 					skillId: skill.skillId,
 					ownershipIdentity: skill.sourceIdentity,
 				});
@@ -177,12 +194,52 @@ function hostedSkillProjectionDrivers(input: {
 				}
 				input.openClawDriver.cleanupManifestOwned({
 					workspaceRoot: input.openClawWorkspaceRoot,
+					managedResourceRoot: input.managedResourceRoot,
 					skillId: reservation.id,
 					ownershipIdentity: reservationOwnershipIdentity(reservation),
 				});
 			},
 		},
 	];
+}
+
+function assertSkillsRootInTenantHome(home: string, skillsRoot: string): void {
+	const candidate = relative(resolve(home), resolve(skillsRoot));
+	if (candidate.startsWith("..") || isAbsolute(candidate) || basename(skillsRoot) !== "skills") {
+		throw new Error(`managed Skill reservation is outside tenant HOME: ${skillsRoot}`);
+	}
+}
+
+export function migrateLegacyHostedSkillReceipts(input: {
+	manifest: RuntimeManifest;
+	home: string;
+	managedResourceRoot: string;
+}): void {
+	const hermesSkillsRoot = join(input.home, ".hermes", "skills");
+	const roots = new Map<string, "hermes" | "openclaw">([
+		[hermesSkillsRoot, "hermes"],
+		[join(input.home, ".openclaw", "workspace", "skills"), "openclaw"],
+	]);
+	if (input.manifest.workspaceRoot) {
+		const manifestSkillsRoot = join(input.manifest.workspaceRoot, "skills");
+		assertSkillsRootInTenantHome(input.home, manifestSkillsRoot);
+		roots.set(manifestSkillsRoot, "openclaw");
+	}
+	for (const reservation of managedSkillReservations("hosted-manifest")) {
+		const skillsRoot = dirname(reservation.targetDir);
+		assertSkillsRootInTenantHome(input.home, skillsRoot);
+		roots.set(skillsRoot, skillsRoot === hermesSkillsRoot ? "hermes" : "openclaw");
+	}
+	for (const [skillsRoot, runtime] of [...roots].sort(([left], [right]) =>
+		left.localeCompare(right),
+	)) {
+		migrateLegacyManagedSkillReceiptDirectory({
+			tenantHome: input.home,
+			managedResourceRoot: input.managedResourceRoot,
+			runtime,
+			skillsRoot,
+		});
+	}
 }
 function recoverHostedSkillReservations(
 	driver: HostedSkillProjectionDriver,
@@ -268,8 +325,9 @@ function applyHostedSkills(
 	observation: RuntimeInstallObservation | undefined,
 	manifest: RuntimeManifest,
 	preparedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
-): void {
-	if (!hostedBundledSkillsEnabled() || !driver.skillsRoot) return;
+): string[] {
+	if (!hostedBundledSkillsEnabled() || !driver.skillsRoot) return [];
+	const failures: string[] = [];
 	const desiredEntries = manifest.projection?.skills?.entries ?? {};
 	const reservations = managedSkillReservations("hosted-manifest").filter(
 		(reservation) => dirname(reservation.targetDir) === driver.skillsRoot,
@@ -292,12 +350,17 @@ function applyHostedSkills(
 				(entry) => entry.targetDir === targetDir && entry.id === skillId,
 			);
 			if (!reservation) throw new Error(`managed Skill ${skillId} has no ownership reservation`);
-			releaseManagedSkill({
-				targetDir,
-				id: skillId,
-				manager: "hosted-manifest",
-				removeTarget: () => driver.remove(reservation),
-			});
+			try {
+				releaseManagedSkill({
+					targetDir,
+					id: skillId,
+					manager: "hosted-manifest",
+					removeTarget: () => driver.remove(reservation),
+				});
+			} catch (error) {
+				if (!(error instanceof ManagedSkillResourceError)) throw error;
+				failures.push(`${skillId}: ${error.message}`);
+			}
 			continue;
 		}
 		if (!observation?.enabled || observation.status === "install_failed") continue;
@@ -309,20 +372,26 @@ function applyHostedSkills(
 		if (withRuntimeUserFileAccess(() => existsSync(targetDir)) && owner !== "hosted-manifest") {
 			throw new Error(`refusing to replace unmanaged ${skillId} skill at ${targetDir}`);
 		}
-		installReservedManagedSkill(
-			{
-				targetDir,
-				id: skillId,
-				manager: "hosted-manifest",
-				...preparedReservationIdentity(prepared),
-			},
-			() => driver.install(prepared, owner === "hosted-manifest"),
-		);
+		try {
+			installReservedManagedSkill(
+				{
+					targetDir,
+					id: skillId,
+					manager: "hosted-manifest",
+					...preparedReservationIdentity(prepared),
+				},
+				() => driver.install(prepared, owner === "hosted-manifest"),
+			);
+		} catch (error) {
+			if (!(error instanceof ManagedSkillResourceError)) throw error;
+			failures.push(`${skillId}: ${error.message}`);
+		}
 	}
+	return failures;
 }
-function runHostedSkillProjectionStep(label: string, step: () => void): void {
+function runHostedSkillProjectionStep<T>(label: string, step: () => T): T {
 	try {
-		step();
+		return step();
 	} catch (error) {
 		throw new Error(`${label}: ${error instanceof Error ? error.message : String(error)}`, {
 			cause: error,
@@ -333,15 +402,17 @@ export function reconcileHostedSkillProjection(input: {
 	manifest: RuntimeManifest;
 	observations: ReadonlyMap<string, RuntimeInstallObservation>;
 	home: string;
+	managedResourceRoot: string;
 	openClawWorkspaceRoot: string | null;
 	preparedSourcedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>;
 	hermesDriver: HostedHermesSkillExactSourceDriver;
 	openClawDriver: HostedOpenClawSkillDriver;
-}): void {
+}): string[] {
 	const {
 		manifest,
 		observations,
 		home,
+		managedResourceRoot,
 		openClawWorkspaceRoot,
 		preparedSourcedSkills,
 		hermesDriver,
@@ -351,6 +422,7 @@ export function reconcileHostedSkillProjection(input: {
 	const drivers = hostedSkillProjectionDrivers({
 		manifest,
 		home,
+		managedResourceRoot,
 		openClawWorkspaceRoot,
 		hermesDriver,
 		openClawDriver,
@@ -361,9 +433,17 @@ export function reconcileHostedSkillProjection(input: {
 			validateHostedSkillsPlan(driver, manifest, preparedSkills);
 		}
 	});
+	const failures: string[] = [];
 	for (const driver of drivers) {
-		runHostedSkillProjectionStep(`runtime ${driver.name} Skill projection failed`, () => {
-			applyHostedSkills(driver, observations.get(driver.name), manifest, preparedSkills);
-		});
+		const driverFailures = runHostedSkillProjectionStep(
+			`runtime ${driver.name} Skill projection failed`,
+			() => applyHostedSkills(driver, observations.get(driver.name), manifest, preparedSkills),
+		);
+		failures.push(
+			...driverFailures.map(
+				(failure) => `runtime ${driver.name} Skill projection failed: ${failure}`,
+			),
+		);
 	}
+	return failures;
 }

--- a/packages/cli/src/runtime/manifest-skills-apply.ts
+++ b/packages/cli/src/runtime/manifest-skills-apply.ts
@@ -1,7 +1,7 @@
-import { existsSync, rmSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
-	adoptableLegacyHostedBundledSkill,
+	claimLegacyHostedBundledSkill,
 	hostedBundledSkillIds,
 	resolveHostedBundledSkill,
 } from "./hosted-bundled-skill";
@@ -39,8 +39,9 @@ interface HostedSkillProjectionDriver {
 		skill: PreparedHostedSourcedSkill,
 		previouslyReserved: boolean,
 	): "installed" | "unchanged";
+	anchorOwnership(skillId: string, ownershipIdentity: string): void;
 	hasOwnershipReceipt(skill: PreparedHostedSourcedSkill): boolean;
-	remove(reservation: ManagedSkillReservationSnapshot, legacy: boolean): void;
+	remove(reservation: ManagedSkillReservationSnapshot): void;
 }
 function preparedSkillMatchesDesired(
 	prepared: PreparedHostedSourcedSkill | undefined,
@@ -111,19 +112,15 @@ function hostedSkillProjectionDrivers(input: {
 					skill,
 					previouslyReserved,
 				}),
+			anchorOwnership: (skillId, ownershipIdentity) =>
+				input.hermesDriver.anchorOwnership({ home: input.home, skillId, ownershipIdentity }),
 			hasOwnershipReceipt: (skill) =>
 				input.hermesDriver.hasOwnershipReceipt({
 					home: input.home,
 					skillId: skill.skillId,
 					ownershipIdentity: skill.sourceIdentity,
 				}),
-			remove: (reservation, legacy) => {
-				if (legacy) {
-					withRuntimeUserFileAccess(() =>
-						rmSync(reservation.targetDir, { recursive: true, force: true }),
-					);
-					return;
-				}
+			remove: (reservation) => {
 				const ownershipIdentity = reservationOwnershipIdentity(reservation);
 				if (reservation.digest) {
 					input.hermesDriver.cleanupManifestOwned({
@@ -156,6 +153,16 @@ function hostedSkillProjectionDrivers(input: {
 					previouslyReserved,
 				});
 			},
+			anchorOwnership: (skillId, ownershipIdentity) => {
+				if (!input.openClawWorkspaceRoot) {
+					throw new Error("OpenClaw official agent workspace is unavailable");
+				}
+				input.openClawDriver.anchorOwnership({
+					workspaceRoot: input.openClawWorkspaceRoot,
+					skillId,
+					ownershipIdentity,
+				});
+			},
 			hasOwnershipReceipt: (skill) => {
 				if (!input.openClawWorkspaceRoot) return false;
 				return input.openClawDriver.hasOwnershipReceipt({
@@ -164,15 +171,9 @@ function hostedSkillProjectionDrivers(input: {
 					ownershipIdentity: skill.sourceIdentity,
 				});
 			},
-			remove: (reservation, legacy) => {
+			remove: (reservation) => {
 				if (!input.openClawWorkspaceRoot) {
 					throw new Error("OpenClaw official agent workspace is unavailable");
-				}
-				if (legacy) {
-					withRuntimeUserFileAccess(() =>
-						rmSync(reservation.targetDir, { recursive: true, force: true }),
-					);
-					return;
 				}
 				input.openClawDriver.cleanupManifestOwned({
 					workspaceRoot: input.openClawWorkspaceRoot,
@@ -194,20 +195,27 @@ function recoverHostedSkillReservations(
 	for (const skillId of [...skillIds].sort()) {
 		const targetDir = join(driver.skillsRoot, skillId);
 		if (
-			!existsSync(targetDir) ||
+			!withRuntimeUserFileAccess(() => existsSync(targetDir)) ||
 			managedSkillReservationOwner(targetDir, skillId) !== "unreserved"
 		) {
 			continue;
 		}
-		const legacy = adoptableLegacyHostedBundledSkill(targetDir, skillId);
-		if (legacy) {
-			reserveManagedSkill({
+		if (
+			claimLegacyHostedBundledSkill({
 				targetDir,
-				id: skillId,
-				manager: "hosted-manifest",
-				version: legacy.version,
-				digest: legacy.digest,
-			});
+				skillId,
+				reserve: (legacy) => {
+					reserveManagedSkill({
+						targetDir,
+						id: skillId,
+						manager: "hosted-manifest",
+						version: legacy.version,
+						digest: legacy.digest,
+					});
+				},
+				anchorOwnership: (ownershipIdentity) => driver.anchorOwnership(skillId, ownershipIdentity),
+			})
+		) {
 			continue;
 		}
 		const desired = desiredEntries[skillId];
@@ -248,7 +256,7 @@ function validateHostedSkillsPlan(
 		}
 		const targetDir = join(driver.skillsRoot, skillId);
 		if (
-			existsSync(targetDir) &&
+			withRuntimeUserFileAccess(() => existsSync(targetDir)) &&
 			managedSkillReservationOwner(targetDir, skillId) !== "hosted-manifest"
 		) {
 			throw new Error(`refusing to replace unmanaged ${skillId} skill at ${targetDir}`);
@@ -288,11 +296,7 @@ function applyHostedSkills(
 				targetDir,
 				id: skillId,
 				manager: "hosted-manifest",
-				removeTarget: () =>
-					driver.remove(
-						reservation,
-						adoptableLegacyHostedBundledSkill(targetDir, skillId) !== null,
-					),
+				removeTarget: () => driver.remove(reservation),
 			});
 			continue;
 		}
@@ -302,7 +306,7 @@ function applyHostedSkills(
 			throw new Error(`pinned archive for hosted Skill ${skillId} is unavailable`);
 		}
 		const owner = managedSkillReservationOwner(targetDir, skillId);
-		if (existsSync(targetDir) && owner !== "hosted-manifest") {
+		if (withRuntimeUserFileAccess(() => existsSync(targetDir)) && owner !== "hosted-manifest") {
 			throw new Error(`refusing to replace unmanaged ${skillId} skill at ${targetDir}`);
 		}
 		installReservedManagedSkill(

--- a/packages/cli/src/runtime/openclaw-managed-provider-plugin.ts
+++ b/packages/cli/src/runtime/openclaw-managed-provider-plugin.ts
@@ -91,15 +91,15 @@ function pluginDirectoryIsCurrent(directory: string): boolean {
 }
 
 function materializePluginDirectory(directory: string): string {
-	if (pluginDirectoryIsCurrent(directory)) return directory;
-	withRuntimeUserFileAccess(() => {
+	return withRuntimeUserFileAccess(() => {
+		if (pluginDirectoryIsCurrent(directory)) return directory;
 		rmSync(directory, { recursive: true, force: true });
 		mkdirSync(directory, { recursive: true, mode: 0o700 });
 		for (const [name, content] of pluginFiles) {
 			writeFileSync(join(directory, name), content, { mode: 0o600 });
 		}
+		return directory;
 	});
-	return directory;
 }
 
 function materializePluginSource(context: OpenClawHostedContext): string {

--- a/packages/cli/src/runtime/runtime-user-command.test.ts
+++ b/packages/cli/src/runtime/runtime-user-command.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	chownSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -8,7 +17,10 @@ import {
 	clearTenantToolLocationOverrides,
 	commandExists,
 	createPrivilegeDropResolver,
+	enforceRuntimeUserOwnership,
 	runRuntimeUserCommand,
+	runtimeUserExistingOwnership,
+	runtimeUserGid,
 	runtimeUserUid,
 	spawnRuntimeUserCommand,
 	withRuntimeUserFileAccess,
@@ -367,6 +379,53 @@ test("fully drops root identity when spawned during runtime-user file access", (
 		expect(result.status).toBe(0);
 		expect(readFileSync(output, "utf8").trim()).toBe(String(runtimeUserUid("nobody")));
 		expect(statSync(output).uid).toBe(runtimeUserUid("nobody"));
+	} finally {
+		if (previousRuntimeUser === undefined) delete process.env.CLAWDI_RUNTIME_USER;
+		else process.env.CLAWDI_RUNTIME_USER = previousRuntimeUser;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("recursively restores runtime ownership only inside declared state roots", () => {
+	if (process.geteuid?.() !== 0) return;
+	const root = mkdtempSync(join(tmpdir(), "runtime-user-ownership-boundary-"));
+	const managedRoot = join(root, "home");
+	const nestedDirectory = join(managedRoot, ".hermes", "skills", "clawdi");
+	const nestedFile = join(nestedDirectory, ".clawdi-managed.json");
+	const outside = join(root, "platform-state");
+	const previousRuntimeUser = process.env.CLAWDI_RUNTIME_USER;
+	try {
+		mkdirSync(nestedDirectory, { recursive: true });
+		writeFileSync(nestedFile, "legacy\n", { mode: 0o600 });
+		writeFileSync(outside, "preserve\n", { mode: 0o600 });
+		for (const path of [
+			managedRoot,
+			join(managedRoot, ".hermes"),
+			join(managedRoot, ".hermes", "skills"),
+			nestedDirectory,
+			nestedFile,
+			outside,
+		]) {
+			chownSync(path, 0, 0);
+		}
+		process.env.CLAWDI_RUNTIME_USER = "nobody";
+
+		enforceRuntimeUserOwnership(runtimeUserExistingOwnership([managedRoot], { recursive: true }));
+
+		const expected = [runtimeUserUid("nobody"), runtimeUserGid("nobody")];
+		for (const path of [
+			managedRoot,
+			join(managedRoot, ".hermes"),
+			join(managedRoot, ".hermes", "skills"),
+			nestedDirectory,
+			nestedFile,
+		]) {
+			const node = statSync(path);
+			expect([node.uid, node.gid]).toEqual(expected);
+		}
+		expect(statSync(nestedFile).mode & 0o777).toBe(0o600);
+		expect([statSync(outside).uid, statSync(outside).gid]).toEqual([0, 0]);
+		expect(readFileSync(outside, "utf8")).toBe("preserve\n");
 	} finally {
 		if (previousRuntimeUser === undefined) delete process.env.CLAWDI_RUNTIME_USER;
 		else process.env.CLAWDI_RUNTIME_USER = previousRuntimeUser;

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -391,7 +391,7 @@ function positiveLinuxIdEnv(key: string, fallback: number): number {
 
 export function runtimeUserDirectoryOwnership(
 	path: string,
-	options: { mode?: number; ancestorsUnder?: string } = {},
+	options: { mode?: number; ancestorsUnder?: string; recursive?: boolean } = {},
 ): RuntimeUserOwnershipRule[] {
 	const target = resolve(path);
 	const paths = [target];
@@ -409,13 +409,15 @@ export function runtimeUserDirectoryOwnership(
 	return runtimeUserOwnershipRules(paths, "directory", options, target);
 }
 
-export const runtimeUserExistingOwnership = (paths: readonly string[]) =>
-	runtimeUserOwnershipRules(paths, "existing", {});
+export const runtimeUserExistingOwnership = (
+	paths: readonly string[],
+	options: { recursive?: boolean } = {},
+) => runtimeUserOwnershipRules(paths, "existing", options);
 
 function runtimeUserOwnershipRules(
 	paths: readonly string[],
 	kind: RuntimeUserOwnershipRule["kind"],
-	options: { mode?: number },
+	options: { mode?: number; recursive?: boolean },
 	target?: string,
 ): RuntimeUserOwnershipRule[] {
 	return [...new Set(paths.map((path) => resolve(path)))]
@@ -425,7 +427,10 @@ function runtimeUserOwnershipRules(
 			owner: "runtime-user",
 			kind,
 			...(path === target && options.mode !== undefined ? { mode: options.mode } : {}),
-			recursive: false,
+			recursive:
+				target === undefined
+					? options.recursive === true
+					: path === target && options.recursive === true,
 		}));
 }
 
@@ -502,24 +507,22 @@ export function withRuntimeUserFileAccess<T>(
 	return withEffectiveFilesystemIdentity({ uid, gid }, operation);
 }
 
-export function spawnRuntimeUserCommand(
+interface RuntimeUserCommandOptions {
+	egressSystemCaFile?: string;
+	environmentOverrides?: Readonly<Record<string, string | undefined>>;
+	environment?: Record<string, string>;
+	runtimeUser?: string;
+	runtimeUid?: number;
+	runtimeGid?: number;
+	resolver?: PrivilegeDropResolver;
+}
+
+function runtimeUserCommand(
 	command: string,
 	args: string[],
 	home: string,
-	cwd: string,
-	options: {
-		egressSystemCaFile?: string;
-		environmentOverrides?: Readonly<Record<string, string | undefined>>;
-		environment?: Record<string, string>;
-		input?: string;
-		maxBufferBytes?: number;
-		timeoutMs?: number;
-		runtimeUser?: string;
-		runtimeUid?: number;
-		runtimeGid?: number;
-		resolver?: PrivilegeDropResolver;
-	} = {},
-): ReturnType<typeof spawnSync> {
+	options: RuntimeUserCommandOptions,
+) {
 	const runtimeUser = options.runtimeUser ?? process.env.CLAWDI_RUNTIME_USER?.trim();
 	const dropsToRuntimeUser = Boolean(runtimeUser && runtimeUser !== "root");
 	const runtimeUid = dropsToRuntimeUser
@@ -538,8 +541,23 @@ export function spawnRuntimeUserCommand(
 		...options.environment,
 	};
 	clearPlatformCredentialEnv(env);
+	return { command: child.command, args: child.args, env };
+}
+
+export function spawnRuntimeUserCommand(
+	command: string,
+	args: string[],
+	home: string,
+	cwd: string,
+	options: RuntimeUserCommandOptions & {
+		input?: string;
+		maxBufferBytes?: number;
+		timeoutMs?: number;
+	} = {},
+): ReturnType<typeof spawnSync> {
+	const child = runtimeUserCommand(command, args, home, options);
 	return spawnSync(child.command, child.args, {
-		env,
+		env: child.env,
 		cwd,
 		encoding: "utf8",
 		input: options.input,
@@ -554,31 +572,15 @@ export function runRuntimeUserCommand(
 	stdin: string,
 	home: string,
 	cwd: string,
-	options: {
-		egressSystemCaFile?: string;
+	options: RuntimeUserCommandOptions & {
 		timeoutMs?: number;
-		runtimeUser?: string;
-		runtimeUid?: number;
-		runtimeGid?: number;
-		resolver?: PrivilegeDropResolver;
 	} = {},
 ): void {
-	const runtimeUser = options.runtimeUser ?? process.env.CLAWDI_RUNTIME_USER?.trim();
-	const dropsToRuntimeUser = Boolean(runtimeUser && runtimeUser !== "root");
-	const runtimeUid = dropsToRuntimeUser
-		? (options.runtimeUid ?? runtimeUserUid(runtimeUser ?? ""))
-		: null;
-	const child = dropsToRuntimeUser
-		? buildRuntimeUserCommand(runtimeUser ?? "", home, command, args, {
-				runtimeUid: runtimeUid ?? undefined,
-				runtimeGid: options.runtimeGid,
-				resolver: options.resolver,
-			})
-		: { command, args, env: {} };
+	const child = runtimeUserCommand(command, args, home, options);
 	try {
 		execFileSync(child.command, child.args, {
 			input: stdin,
-			env: { ...runtimeUserCommandEnv(home, runtimeUid, options), ...child.env },
+			env: child.env,
 			cwd,
 			stdio: "pipe",
 			timeout: options.timeoutMs,

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -61,6 +61,7 @@ import { createOpenClawHostedContext } from "../src/runtime/hosted-openclaw-cont
 import { hostedOpenClawSkillDriver } from "../src/runtime/hosted-openclaw-skill";
 import { hostedAiProviderCatalog } from "../src/runtime/hosted-provider-resolution";
 import { MANAGED_BAILEYS_STATIC_PATCH_TARGETS } from "../src/runtime/managed-baileys-compat";
+import { managedSkillReceiptPath } from "../src/runtime/managed-skill-delivery";
 import { releaseManagedSkill, reserveManagedSkill } from "../src/runtime/managed-skill-reservation";
 import {
 	buildOpenClawHostedProviderPatch,
@@ -15915,7 +15916,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			runtimes: { openclaw: ["clawdi", "search.proxy"] },
 		});
 		expect(
-			existsSync(join(dirname(openclawSkill), ".clawdi-manifest-receipts", "clawdi.json")),
+			existsSync(managedSkillReceiptPath(paths.managedResourceRoot, "openclaw", "clawdi")),
 		).toBe(true);
 
 		writeFileSync(join(openclawSkill, "SKILL.md"), "tenant mutation before restart\n");
@@ -15966,7 +15967,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		});
 		const hermesSkill = join(home, ".hermes", "skills", "clawdi");
 		const hermesSkillReceipt = JSON.parse(
-			readFileSync(join(dirname(hermesSkill), ".clawdi-manifest-receipts", "clawdi.json"), "utf-8"),
+			readFileSync(managedSkillReceiptPath(paths.managedResourceRoot, "hermes", "clawdi"), "utf-8"),
 		);
 		expect(hermesSkillReceipt).toEqual({
 			schemaVersion: "clawdi.hermesManifestSkillReceipt.v2",

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -4103,7 +4103,6 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 
 		const context = createOpenClawHostedContext(loaded.manifest, home);
 		expect(context.ownership.map(({ path, mode, recursive }) => [path, mode, recursive])).toEqual([
-			[home, undefined, false],
 			[join(home, ".openclaw"), 0o700, false],
 			[join(home, ".openclaw", "tmp"), 0o700, false],
 		]);


### PR DESCRIPTION
## Architecture principles

This fix implements the existing managed-runtime architecture rather than adding a migration subsystem:

- `docs/managed-runtime.md` defines the Core Architecture split between root-owned platform state and tenant-UID state under runtime HOME.
- Its Managed CLI privilege boundary requires root callers to access tenant tools and tenant state through the runtime identity while retaining platform metadata under platform authority.
- #1104 established that runtime-user state ownership is a platform invariant, not a manifest mutation, and must be repaired before snapshots so rollback cannot restore drift.
- #1131 established declarative ownership rules plus one fail-closed enforcer.

The resulting identity rule is: **tenant HOME = runtime identity; managed resource root = platform identity**.

Manifest orchestration is unchanged except at the existing pre-snapshot platform-invariant repair point.

## Three-round field evidence and throw point

The third 0.14.2 device rollout produced one consistent failure chain:

1. Hermes initially converged, then intermittently reported `runtime hermes Skill projection failed: installed Skill tree is unsafe`.
2. `.clawdi-manifest-receipts/` was never created, so the #1145 receipt anchor never committed.
3. The installed Skill directory and `SKILL.md` were ordinary UID 10001 entries, while the legacy `.clawdi-managed.json` was a root-owned `0600` file left by an older CLI.
4. The same tree passed symlink, special-file, and size checks as root but was unreadable as UID 10001.

The throw originates in `writeManagedSkillReceipt()` in `managed-skill-delivery.ts`: runtime-identity collection collapses an unreadable/unsafe tree to `null`, and receipt anchoring fails closed with `installed Skill tree is unsafe`. A real root/nobody fixture proves the legacy marker produces `EACCES` before ownership repair and becomes readable after the existing enforcer restores tenant ownership. Mixed root/runtime reads were therefore the source of the intermittent result, not a second tree-safety defect.

## A. Extend the tenant ownership invariant

The existing declarative ownership rule now supports recursive targets. At the established pre-snapshot invariant point, convergence declares the complete projection HOME recursively runtime-owned, then applies the existing explicit OpenClaw directory modes. This covers `.hermes`, `.openclaw`, Skill and Plugin trees, and official workspaces under tenant HOME.

The single enforcer remains fail closed for invalid roots, does not follow symlinks, preserves bytes and modes, and never enters paths outside the declared tenant root. Root-owned entries under tenant HOME are historical platform drift; changing only UID/GID restores the platform invariant and does not mutate tenant data.

## B. Make the filesystem identity boundary explicit

All Skill/Plugin decisions over tenant state now use `withRuntimeUserFileAccess` or a runtime-user command. Platform ledgers, staging, snapshots, and Skill receipts use the platform identity.

| Call site | Before | After |
| --- | --- | --- |
| `hosted-openclaw-context.ts:34` SDK/workspace context | root before repair | runtime identity after repair |
| `managed-skill-delivery.ts:93,124,172,390` Skill tree collection and rollback | mixed/root | tenant tree via runtime identity; receipt via platform identity |
| `hosted-hermes-skill.ts:66,111,145,154,211,244` command, target, install, cleanup | mixed | runtime identity for tenant state/commands |
| `hosted-openclaw-skill.ts:73,146,167,220,233,321,329` command, workspace, target, cleanup | mixed | runtime identity for tenant state/commands |
| `hosted-agent-plugin-runtime.ts:116,265,313,472` probe, traversal, digest, Hermes config | root/mixed | runtime identity |
| `openclaw-managed-provider-plugin.ts:94` source inspection/materialization | root read/runtime write | one runtime-identity block |
| `hermes-agent-plugin-canary-client.ts:50,179` evidence/probe state | root/mixed | runtime identity |
| `hermes-agent-plugin-canary-controller.ts:26` ready/result state | root | runtime filesystem identity |
| `manifest-converge.ts:433,620,731,842,1443` workspace and tenant projections | root/mixed | runtime identity |

The canary controller remains a root Clawdi support process because the managed CLI is intentionally not tenant-executable; only its tenant-HOME filesystem operations drop identity.

## Receipt platform-side authority

Hermes and OpenClaw receipts now live symmetrically at:

```text
<managedResourceRoot>/skill-receipts/{hermes|openclaw}/{skillId}.json
```

Receipt directories are `0700`, receipt files are `0600`, and writes use the managed resource root as the trusted platform boundary. Reads use `O_NOFOLLOW`, validate the opened descriptor with `fstat`, require the effective platform UID, and read from that same descriptor. Tenant-owned counterfeit receipts are rejected, preserving #1117's anti-forgery property even if a matching fingerprint is supplied.

Tree fingerprints are still computed entirely through runtime-user access. Thus tenant content is observed exactly as the runtime observes it, while the authority that records that observation remains unavailable to the tenant.

A one-time pre-enforcer migration discovers legacy receipt directories for Hermes, the default OpenClaw workspace, the manifest workspace, and reservation-ledger workspaces. Valid root-authored receipts are copied into platform state without touching Skill inodes; existing platform receipts win; the old metadata directory is then removed. `SUNSET(#1148)` is registered in #1148.

Receipt and Skill rollback are split into platform and runtime-user snapshot targets, so mixed-identity rollback no longer relies on one caller identity.

## C. Keep one legacy claim entry

Both historical in-tree marker schemas use `claimLegacyHostedBundledSkill()`:

1. validate marker schema, catalog identity, canonical modes, and exact digest as the runtime user;
2. reserve ownership in the platform ledger and revalidate against drift;
3. remove the in-tree marker as the runtime user;
4. restore platform identity and write the external root-owned receipt.

After claim, no Clawdi metadata remains inside the Skill tree. Marker knowledge stays private to this one migration entry; there is no permanent digest exclusion or scattered direct-delete branch.

## Per-Skill failure isolation

Hosted Skill apply/remove now isolates only explicitly typed `ManagedSkillResourceError` failures per Skill. Official install/uninstall failures and installed-result validation failures are recorded as `skillId: error`, the loop continues, and all failures are appended independently to `resourceProjectionErrors` after the domain finishes. One deterministic bad Skill can no longer starve later Skills on every convergence.

Platform-integrity failures remain fail closed and abort the Skill domain with its existing snapshot rollback: reservation-ledger errors, ownership/receipt assertions, unmanaged-target rejection, workspace identity drift, platform receipt persistence failures, and prepared archive/source-integrity failures are deliberately not converted into resource errors.

## Net cleanup and safety

- Tenant-HOME receipt directories are removed after migration.
- Legacy marker schema handling is centralized in one claim entry.
- Runtime receipts no longer need tenant-ownership exceptions.
- Unmanaged and differently managed targets remain rejected.
- Receipt-guarded cleanup still verifies exact installed bytes.
- Symlinks, special files, oversized trees, malformed markers, source drift, and noncanonical bundled modes still fail closed.

## Verification

- `bun run --cwd packages/cli typecheck`
- `bunx --bun biome check packages/cli` (341 files)
- Bun 1.4.0 Docker Skill/manifest suite: 201 pass, 0 fail, 1,343 assertions
- `manifest-mutation-parity.test.ts`: pass
- Real root/nobody unreadable-marker fixture: 1 pass, 21 assertions
- Client CI: Biome, all-package typecheck/build, native smoke, publish validation, all client tests, and WhatsApp native E2E passed
- Fixtures cover recursive file/directory ownership boundaries, root-owned `0600` marker claim, Hermes/OpenClaw receipt migration, counterfeit tenant-owned receipt rejection and self-heal, repeated unchanged convergence, per-Skill continuation, and fail-closed unmanaged rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)