### PR TITLE
refactor(cli): move WhatsApp auth markers out of tree

### DIFF
--- a/packages/cli/src/runtime/manifest-channels.test.ts
+++ b/packages/cli/src/runtime/manifest-channels.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	chmodSync,
+	chownSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+	managedWhatsAppAuthReceiptPath,
+	materializeHostedChannelCredentials,
+} from "./manifest-channels";
+import type { RuntimeManifest } from "./manifest-contract";
+import { withRuntimeUserFileAccess } from "./runtime-user-command";
+
+const LEGACY_MARKER = ".clawdi-managed-whatsapp-auth.json";
+const ACCOUNT_KEY = "clawdi_whatsapp_test";
+const SECRET_REF = `secret://channels/whatsapp/${ACCOUNT_KEY}/credentials/credential-test/creds-json`;
+
+let root: string;
+let home: string;
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "clawdi-manifest-channels-"));
+	home = join(root, "home", "clawdi");
+	process.env.CLAWDI_RUNTIME_MODE = "hosted";
+	process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "var", "lib", "clawdi");
+	mkdirSync(process.env.CLAWDI_SERVICE_STATE_DIR, { recursive: true });
+});
+
+afterEach(() => {
+	delete process.env.CLAWDI_RUNTIME_MODE;
+	delete process.env.CLAWDI_SERVICE_STATE_DIR;
+	delete process.env.CLAWDI_RUNTIME_USER;
+	delete process.env.CLAWDI_RUNTIME_UID;
+	delete process.env.CLAWDI_RUNTIME_GID;
+	rmSync(root, { recursive: true, force: true });
+});
+
+function authDir(name = ACCOUNT_KEY): string {
+	return join(home, ".openclaw", "credentials", "whatsapp", name);
+}
+
+function manifest(path: string, credentialId = "credential-test"): RuntimeManifest {
+	return {
+		schemaVersion: "clawdi.runtimeDesiredState.v1",
+		deploymentId: "dep_whatsapp_receipt_test",
+		environmentId: "env_whatsapp_receipt_test",
+		instanceId: "iid_whatsapp_receipt_test",
+		generation: 1,
+		issuedAt: "2026-08-21T00:00:00Z",
+		controlPlane: { apiUrl: "https://cloud-api.test" },
+		runtimes: {},
+		projection: {
+			system: { home, workspace: join(home, "clawdi") },
+			channelCredentials: [
+				{
+					provider: "whatsapp",
+					kind: "whatsapp_baileys_auth_state",
+					accountKey: ACCOUNT_KEY,
+					credentialId,
+					authDir: path,
+					files: [{ path: "creds.json", secretRef: SECRET_REF }],
+				},
+			],
+		},
+		recovery: {},
+	};
+}
+
+function credsJson(secret = "managed-secret"): string {
+	return JSON.stringify({
+		advSecretKey: secret,
+		additionalData: {
+			"clawdi.managedWhatsAppSocket": {
+				schemaVersion: "clawdi.managedWhatsAppSocket.v1",
+				capability: `clawdi_${"a".repeat(32)}`,
+				authCert: {
+					SERIAL: 7,
+					ISSUER: "clawdi",
+					PUBLIC_KEY: {
+						type: "Buffer",
+						data: Buffer.alloc(32, 7).toString("base64"),
+					},
+				},
+			},
+		},
+	});
+}
+
+function legacyMarker(credentialId = "credential-test"): string {
+	return `${JSON.stringify({
+		schemaVersion: "clawdi.managedWhatsAppAuth.v1",
+		provider: "whatsapp",
+		target: "legacy",
+		accountKey: ACCOUNT_KEY,
+		credentialId,
+	})}\n`;
+}
+
+describe("managed WhatsApp auth receipts", () => {
+	test("materializes ownership out of tree and removes it with the auth directory", () => {
+		const path = authDir();
+		const desired = manifest(path);
+		materializeHostedChannelCredentials(desired, { [SECRET_REF]: credsJson() }, home);
+
+		const receipt = managedWhatsAppAuthReceiptPath(path);
+		expect(readdirSync(path)).toEqual(["creds.json"]);
+		expect(JSON.parse(readFileSync(receipt, "utf8"))).toMatchObject({
+			schemaVersion: "clawdi.managedWhatsAppAuthReceipt.v1",
+			markerSchemaVersion: "clawdi.managedWhatsAppAuth.v1",
+			authDir: path,
+			credentialId: "credential-test",
+		});
+
+		materializeHostedChannelCredentials(
+			{ ...desired, projection: { ...desired.projection, channelCredentials: [] } },
+			{},
+			home,
+		);
+		expect(existsSync(path)).toBe(false);
+		expect(existsSync(receipt)).toBe(false);
+	});
+
+	test("adopts a valid legacy tree marker exactly once", () => {
+		const path = authDir();
+		mkdirSync(path, { recursive: true });
+		writeFileSync(join(path, "creds.json"), `${credsJson("legacy-secret")}\n`);
+		writeFileSync(join(path, LEGACY_MARKER), legacyMarker());
+
+		materializeHostedChannelCredentials(manifest(path), { [SECRET_REF]: credsJson() }, home);
+
+		expect(readdirSync(path)).toEqual(["creds.json"]);
+		expect(existsSync(managedWhatsAppAuthReceiptPath(path))).toBe(true);
+	});
+
+	test("does not adopt missing or malformed ownership state", () => {
+		const cases: Array<{ name: string; seedOwnership(path: string): void }> = [
+			{ name: "missing", seedOwnership: () => undefined },
+			{
+				name: "malformed-legacy",
+				seedOwnership: (path) => writeFileSync(join(path, LEGACY_MARKER), "{}\n"),
+			},
+			{
+				name: "malformed-receipt",
+				seedOwnership: (path) => {
+					writeFileSync(join(path, LEGACY_MARKER), legacyMarker());
+					const receipt = managedWhatsAppAuthReceiptPath(path);
+					mkdirSync(dirname(receipt), { recursive: true });
+					writeFileSync(receipt, "{}\n", { mode: 0o600 });
+				},
+			},
+		];
+		for (const testCase of cases) {
+			const path = authDir(testCase.name);
+			mkdirSync(path, { recursive: true });
+			writeFileSync(join(path, "creds.json"), `${credsJson("user-secret")}\n`);
+			testCase.seedOwnership(path);
+
+			expect(() =>
+				materializeHostedChannelCredentials(manifest(path), { [SECRET_REF]: credsJson() }, home),
+			).toThrow(`refusing to overwrite unmanaged WhatsApp auth directory ${path}`);
+		}
+	});
+
+	test("keeps the receipt platform-owned while materializing auth as the runtime user", () => {
+		if (process.getuid?.() !== 0) return;
+		const runtimeId = 1_000;
+		process.env.CLAWDI_RUNTIME_USER = String(runtimeId);
+		process.env.CLAWDI_RUNTIME_UID = String(runtimeId);
+		process.env.CLAWDI_RUNTIME_GID = String(runtimeId);
+		mkdirSync(home, { recursive: true });
+		chmodSync(root, 0o755);
+		chownSync(join(root, "home"), runtimeId, runtimeId);
+		chownSync(home, runtimeId, runtimeId);
+
+		const path = authDir();
+		withRuntimeUserFileAccess(() =>
+			materializeHostedChannelCredentials(manifest(path), { [SECRET_REF]: credsJson() }, home),
+		);
+
+		expect(statSync(join(path, "creds.json")).uid).toBe(runtimeId);
+		const receipt = statSync(managedWhatsAppAuthReceiptPath(path));
+		expect(receipt.uid).toBe(0);
+		expect(receipt.mode & 0o777).toBe(0o600);
+	});
+});

--- a/packages/cli/src/runtime/manifest-channels.ts
+++ b/packages/cli/src/runtime/manifest-channels.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync, lstatSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import type { z } from "zod";
@@ -21,8 +22,9 @@ import {
 } from "./manifest-install";
 import { openClawConfigPatchIsApplied } from "./manifest-providers";
 import { hermesConfigContext } from "./manifest-runtime-config";
-import { isPlainRecord, recordValue, stringValue, writeJsonFile } from "./manifest-shared";
+import { isPlainRecord, recordValue, stringValue } from "./manifest-shared";
 import { openClawPluginInspectSchema } from "./openclaw-plugin-observation";
+import { getRuntimePaths } from "./paths";
 import {
 	enforceRuntimeUserOwnership,
 	makeRuntimeUserOwned,
@@ -31,6 +33,7 @@ import {
 	spawnRuntimeUserCommand,
 } from "./runtime-user-command";
 import { normalizeSecretValues, runtimeSecretValue } from "./secret-values";
+import { writeRuntimePlatformFileAtomic } from "./state";
 import {
 	type ManagedWhatsAppAuthCredential,
 	managedWhatsAppAuthCredentials,
@@ -40,7 +43,10 @@ import {
 	parseManagedWhatsAppSocketMetadataJson,
 } from "./whatsapp-upstream-contract";
 
-const MANAGED_WHATSAPP_AUTH_MARKER = ".clawdi-managed-whatsapp-auth.json";
+const LEGACY_MANAGED_WHATSAPP_AUTH_MARKER = ".clawdi-managed-whatsapp-auth.json";
+const MANAGED_WHATSAPP_AUTH_MARKER_SCHEMA = "clawdi.managedWhatsAppAuth.v1";
+const MANAGED_WHATSAPP_AUTH_RECEIPT_SCHEMA = "clawdi.managedWhatsAppAuthReceipt.v1";
+const MANAGED_WHATSAPP_AUTH_RECEIPT_DIRECTORY = "whatsapp-auth";
 // SUNSET: Remove after every fleet host has converged past the retired Hermes WhatsApp receipt writer.
 export const RETIRED_MANAGED_HERMES_WHATSAPP_RECEIPT = "hermes-whatsapp.json";
 export function materializeHostedChannelCredentials(
@@ -191,14 +197,13 @@ function materializeManagedWhatsAppAuthDir(
 		},
 	);
 	makeRuntimeUserOwned(join(credential.authDir, "creds.json"));
-	writeJsonFile(join(credential.authDir, MANAGED_WHATSAPP_AUTH_MARKER), {
-		schemaVersion: "clawdi.managedWhatsAppAuth.v1",
+	writeManagedWhatsAppAuthReceipt(credential.authDir, {
+		schemaVersion: MANAGED_WHATSAPP_AUTH_MARKER_SCHEMA,
 		provider: "whatsapp",
 		target: credential.target,
 		accountKey: credential.accountKey,
 		credentialId: credential.credentialId,
 	});
-	makeRuntimeUserOwned(join(credential.authDir, MANAGED_WHATSAPP_AUTH_MARKER));
 }
 function assertManagedWhatsAppMetadata(
 	creds: Record<string, unknown>,
@@ -249,49 +254,212 @@ export function managedWhatsAppAuthRoot(
 		: resolve(home, ".openclaw", "credentials", "whatsapp");
 }
 interface ManagedWhatsAppAuthMarker {
-	schemaVersion: "clawdi.managedWhatsAppAuth.v1";
+	schemaVersion: typeof MANAGED_WHATSAPP_AUTH_MARKER_SCHEMA;
 	provider: "whatsapp";
 	target: ManagedWhatsAppAuthCredential["target"];
 	accountKey: string;
 	credentialId: string;
 }
-export function readManagedWhatsAppAuthMarker(authDir: string): ManagedWhatsAppAuthMarker | null {
-	const markerPath = join(authDir, MANAGED_WHATSAPP_AUTH_MARKER);
+
+interface ManagedWhatsAppAuthReceiptInspection {
+	exists: boolean;
+	marker: ManagedWhatsAppAuthMarker | null;
+}
+
+function isMissingFile(error: unknown): boolean {
+	return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function withManagedWhatsAppReceiptAccess<T>(operation: () => T): T {
+	const realUid = process.getuid?.();
+	const realGid = process.getgid?.();
+	const effectiveUid = process.geteuid?.();
+	const effectiveGid = process.getegid?.();
+	if (
+		realUid === undefined ||
+		realGid === undefined ||
+		effectiveUid === undefined ||
+		effectiveGid === undefined ||
+		realUid !== 0 ||
+		effectiveUid === realUid
+	) {
+		return operation();
+	}
+	if (typeof process.seteuid !== "function" || typeof process.setegid !== "function") {
+		throw new Error("managed WhatsApp auth receipt access requires platform filesystem identity");
+	}
+
+	// Auth projection runs with the tenant filesystem identity. Receipt access is
+	// narrowly restored to the real platform identity and dropped again here.
+	process.seteuid(realUid);
 	try {
-		if (!lstatSync(markerPath).isFile()) return null;
-		const parsed = JSON.parse(readFileSync(markerPath, "utf-8")) as unknown;
-		const record = recordValue(parsed);
-		const target = record ? stringValue(record.target) : null;
-		const accountKey = record ? stringValue(record.accountKey) : null;
-		const credentialId = record ? stringValue(record.credentialId) : null;
-		if (
-			record?.schemaVersion !== "clawdi.managedWhatsAppAuth.v1" ||
-			record.provider !== "whatsapp" ||
-			(target !== "openclaw" && target !== "hermes" && target !== "legacy") ||
-			!accountKey ||
-			!credentialId
-		) {
-			return null;
+		process.setegid(realGid);
+		return operation();
+	} finally {
+		try {
+			process.setegid(effectiveGid);
+		} finally {
+			process.seteuid(effectiveUid);
 		}
-		return {
-			schemaVersion: "clawdi.managedWhatsAppAuth.v1",
-			provider: "whatsapp",
-			target,
-			accountKey,
-			credentialId,
-		};
+	}
+}
+
+export function managedWhatsAppAuthReceiptPath(authDir: string): string {
+	const key = createHash("sha256").update(resolve(authDir)).digest("hex");
+	return join(
+		getRuntimePaths({ mode: "hosted" }).managedResourceRoot,
+		MANAGED_WHATSAPP_AUTH_RECEIPT_DIRECTORY,
+		`${key}.json`,
+	);
+}
+
+function parseManagedWhatsAppAuthMarker(value: unknown): ManagedWhatsAppAuthMarker | null {
+	const record = recordValue(value);
+	const target = record ? stringValue(record.target) : null;
+	const accountKey = record ? stringValue(record.accountKey) : null;
+	const credentialId = record ? stringValue(record.credentialId) : null;
+	if (
+		record?.schemaVersion !== MANAGED_WHATSAPP_AUTH_MARKER_SCHEMA ||
+		record.provider !== "whatsapp" ||
+		(target !== "openclaw" && target !== "hermes" && target !== "legacy") ||
+		!accountKey ||
+		!credentialId
+	) {
+		return null;
+	}
+	return {
+		schemaVersion: MANAGED_WHATSAPP_AUTH_MARKER_SCHEMA,
+		provider: "whatsapp",
+		target,
+		accountKey,
+		credentialId,
+	};
+}
+
+function readLegacyManagedWhatsAppAuthMarker(authDir: string): ManagedWhatsAppAuthMarker | null {
+	try {
+		const path = join(authDir, LEGACY_MANAGED_WHATSAPP_AUTH_MARKER);
+		const node = lstatSync(path);
+		if (node.isSymbolicLink() || !node.isFile()) return null;
+		return parseManagedWhatsAppAuthMarker(JSON.parse(readFileSync(path, "utf-8")) as unknown);
 	} catch {
 		return null;
 	}
 }
+
+function inspectManagedWhatsAppAuthReceipt(authDir: string): ManagedWhatsAppAuthReceiptInspection {
+	const path = managedWhatsAppAuthReceiptPath(authDir);
+	let node: ReturnType<typeof lstatSync>;
+	try {
+		node = lstatSync(path);
+	} catch (error) {
+		return { exists: !isMissingFile(error), marker: null };
+	}
+	const platformUid = process.getuid?.();
+	if (
+		node.isSymbolicLink() ||
+		!node.isFile() ||
+		(node.mode & 0o022) !== 0 ||
+		(platformUid !== undefined && node.uid !== platformUid)
+	) {
+		return { exists: true, marker: null };
+	}
+	try {
+		const record = recordValue(JSON.parse(readFileSync(path, "utf-8")) as unknown);
+		const marker = parseManagedWhatsAppAuthMarker(
+			record
+				? {
+						schemaVersion: record.markerSchemaVersion,
+						provider: record.provider,
+						target: record.target,
+						accountKey: record.accountKey,
+						credentialId: record.credentialId,
+					}
+				: null,
+		);
+		if (
+			record?.schemaVersion !== MANAGED_WHATSAPP_AUTH_RECEIPT_SCHEMA ||
+			record.authDir !== resolve(authDir) ||
+			!marker
+		) {
+			return { exists: true, marker: null };
+		}
+		return { exists: true, marker };
+	} catch {
+		return { exists: true, marker: null };
+	}
+}
+
+function writeManagedWhatsAppAuthReceipt(authDir: string, marker: ManagedWhatsAppAuthMarker): void {
+	withManagedWhatsAppReceiptAccess(() => {
+		const paths = getRuntimePaths({ mode: "hosted" });
+		const path = managedWhatsAppAuthReceiptPath(authDir);
+		writeRuntimePlatformFileAtomic(
+			paths,
+			path,
+			`${JSON.stringify(
+				{
+					schemaVersion: MANAGED_WHATSAPP_AUTH_RECEIPT_SCHEMA,
+					markerSchemaVersion: marker.schemaVersion,
+					provider: marker.provider,
+					target: marker.target,
+					accountKey: marker.accountKey,
+					credentialId: marker.credentialId,
+					authDir: resolve(authDir),
+				},
+				null,
+				2,
+			)}\n`,
+			{ mode: 0o600, dirMode: 0o755 },
+		);
+		const written = inspectManagedWhatsAppAuthReceipt(authDir).marker;
+		if (
+			!written ||
+			written.target !== marker.target ||
+			written.accountKey !== marker.accountKey ||
+			written.credentialId !== marker.credentialId
+		) {
+			throw new Error("managed WhatsApp auth receipt did not pass post-write verification");
+		}
+	});
+}
+
+function removeManagedWhatsAppAuthReceipt(authDir: string): void {
+	withManagedWhatsAppReceiptAccess(() => {
+		rmSync(managedWhatsAppAuthReceiptPath(authDir), { force: true });
+	});
+}
+
+export function readManagedWhatsAppAuthMarker(authDir: string): ManagedWhatsAppAuthMarker | null {
+	return withManagedWhatsAppReceiptAccess(() => {
+		const receipt = inspectManagedWhatsAppAuthReceipt(authDir);
+		if (receipt.exists) {
+			if (receipt.marker && readLegacyManagedWhatsAppAuthMarker(authDir)) {
+				rmSync(join(authDir, LEGACY_MANAGED_WHATSAPP_AUTH_MARKER));
+			}
+			return receipt.marker;
+		}
+
+		const legacyMarker = readLegacyManagedWhatsAppAuthMarker(authDir);
+		if (!legacyMarker) return null;
+		// SUNSET(#1148): Remove tree-marker adoption after every fleet host has
+		// converged with out-of-tree managed WhatsApp auth receipts.
+		writeManagedWhatsAppAuthReceipt(authDir, legacyMarker);
+		rmSync(join(authDir, LEGACY_MANAGED_WHATSAPP_AUTH_MARKER));
+		return legacyMarker;
+	});
+}
+
 function removeManagedWhatsAppAuthDir(authDir: string): void {
 	if (!readManagedWhatsAppAuthMarker(authDir)) return;
 	rmSync(authDir, { recursive: true, force: true });
+	removeManagedWhatsAppAuthReceipt(authDir);
 }
 function removeManagedHermesWhatsAppAuthDir(authDir: string): void {
 	const marker = readManagedWhatsAppAuthMarker(authDir);
 	if (marker?.target !== "hermes") return;
 	rmSync(authDir, { recursive: true, force: true });
+	removeManagedWhatsAppAuthReceipt(authDir);
 }
 function removeStaleManagedWhatsAppAuthDirs(home: string, expected: Set<string>): void {
 	const openclawRoot = managedWhatsAppAuthRoot(home, "openclaw");

--- a/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/project.e2e.ts
+++ b/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/project.e2e.ts
@@ -19,6 +19,9 @@ test("projects and reconciles the real managed WhatsApp runtime", () => {
 	const home = requiredEnvironment("E2E_HOME");
 	const scenarioPath = requiredEnvironment("E2E_SCENARIO");
 	const outputRoot = requiredEnvironment("E2E_OUTPUT");
+	process.env.CLAWDI_RUNTIME_MODE = "hosted";
+	process.env.CLAWDI_SERVICE_STATE_DIR = join(outputRoot, "platform-state");
+	mkdirSync(process.env.CLAWDI_SERVICE_STATE_DIR, { recursive: true });
 	const scenario = recordValue(JSON.parse(readFileSync(scenarioPath, "utf8")));
 	const channelMaterial = z
 		.object({

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -71,6 +71,10 @@ import {
 	type RuntimeManifest,
 } from "../src/runtime/manifest";
 import {
+	managedWhatsAppAuthReceiptPath,
+	readManagedWhatsAppAuthMarker,
+} from "../src/runtime/manifest-channels";
+import {
 	hostedRuntimeManifestSchema,
 	manifestSchema,
 	officialInstallArgs,
@@ -14690,13 +14694,14 @@ exit 64
 		);
 
 		writeFileSync(baileysSocket, patchedSocket);
-		const sessionMarker = join(sessionDir, ".clawdi-managed-whatsapp-auth.json");
-		const committedMarker = readFileSync(sessionMarker, "utf8");
-		writeFileSync(sessionMarker, '{"schemaVersion":"invalid"}\n');
+		const sessionReceipt = managedWhatsAppAuthReceiptPath(sessionDir);
+		const committedReceipt = readFileSync(sessionReceipt, "utf8");
+		writeFileSync(sessionReceipt, '{"schemaVersion":"invalid"}\n');
 		const invalidMarkerRemoval = convergeRuntimeManifest(removed, paths);
 		expect(invalidMarkerRemoval.installErrors).toEqual([]);
 		expect(existsSync(sessionDir)).toBe(true);
-		writeFileSync(sessionMarker, committedMarker);
+		writeFileSync(sessionReceipt, committedReceipt);
+		expect(readManagedWhatsAppAuthMarker(sessionDir)?.target).toBe("hermes");
 
 		const removedConvergence = convergeRuntimeManifest(removed, paths);
 		expect(removedConvergence.installErrors).toEqual([]);
@@ -14964,11 +14969,15 @@ exit 0
 
 	it("materializes, rotates, and removes OpenClaw managed WhatsApp auth", () => {
 		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
 		const workspace = join(home, "clawdi");
 		const accountKey = "clawdi_whatsapp_runtime";
 		const accountId = "00000000-0000-0000-0000-000000000001";
 		const authDir = join(home, ".openclaw", "credentials", "whatsapp", accountKey);
 		mkdirSync(workspace, { recursive: true });
+		mkdirSync(state, { recursive: true });
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		const managedMetadata = {
 			schemaVersion: "clawdi.managedWhatsAppSocket.v1",
 			capability: `clawdi_${"a".repeat(32)}`,
@@ -15102,9 +15111,10 @@ exit 0
 		const rotatedFile = readFileSync(join(authDir, "creds.json"), "utf8");
 		expect(rotatedFile).toContain("wa-rotated-secret");
 		expect(rotatedFile).not.toContain("wa-materialized-secret");
-		expect(readFileSync(join(authDir, ".clawdi-managed-whatsapp-auth.json"), "utf8")).toContain(
-			"credential-whatsapp-2",
-		);
+		expect(readdirSync(authDir)).toEqual(["creds.json"]);
+		const receipt = managedWhatsAppAuthReceiptPath(authDir);
+		expect(readFileSync(receipt, "utf8")).toContain("credential-whatsapp-2");
+		expect(statSync(receipt).mode & 0o777).toBe(0o600);
 
 		materializeHostedChannelCredentials(
 			unlinkedManifest.manifest,
@@ -15112,6 +15122,7 @@ exit 0
 			home,
 		);
 		expect(existsSync(authDir)).toBe(false);
+		expect(existsSync(receipt)).toBe(false);
 	});
 
 	it("preserves the last good OpenClaw WhatsApp auth when the next secret is missing", () => {


### PR DESCRIPTION
## Audit basis

The managed WhatsApp auth marker was the last live Clawdi ownership record written inside a tenant-managed resource tree. Unlike the root-owned receipt and ledger surfaces, the co-located marker gave the auth directory a second ownership authority writable by the runtime identity.

## Migration design

- Store one `0600` platform-owned receipt under `managed-resources/whatsapp-auth/`, keyed by the SHA-256 of the resolved auth directory.
- Bind each receipt to the resolved auth directory while preserving the existing provider, target, account, and credential identity fields.
- Read, write, and delete ownership only through the out-of-tree receipt.
- When no receipt exists, adopt only a legacy in-tree marker that passes the existing schema checks, verify the new receipt, and then remove the legacy marker.
- Never fall back to the legacy marker when an out-of-tree receipt exists but is malformed. The migration block is registered for fleet-convergence cleanup in #1148.

## Semantic preservation

The overwrite, credential-rotation, stale cleanup, Hermes target guard, and unmanaged-directory refusal decisions still use the same marker identity assertions. Missing or damaged ownership remains fail-closed, and new materializations leave only native auth files in the managed auth directory. Receipt access temporarily uses the platform filesystem identity because auth materialization itself runs under the runtime-user identity; the receipt path is internally derived and remains root-owned.

## Verification

- `bun run --cwd packages/cli typecheck`
- `bunx @biomejs/biome check` on all changed files
- 93 channel, Baileys, egress, sidecar, and receipt tests
- 1 WhatsApp runtime-bundle projection test
- 4 WhatsApp runtime convergence tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)