### PR TITLE
feat(auth): show suspended account experience

### DIFF
--- a/apps/web/src/components/account-suspended-page.test.tsx
+++ b/apps/web/src/components/account-suspended-page.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AccountSuspendedPage } from "./account-suspended-page";
+
+describe("AccountSuspendedPage", () => {
+	test("explains the access loss and preserves support and sign-out exits", () => {
+		const markup = renderToStaticMarkup(
+			createElement(AccountSuspendedPage, { onSignOut: () => undefined }),
+		);
+
+		expect(markup).toContain("Account deactivated");
+		expect(markup).toContain("can no longer access Clawdi");
+		expect(markup).toContain('href="mailto:support@clawdi.ai"');
+		expect(markup).toContain("Sign out");
+		expect(markup).not.toContain("account_suspended");
+		expect(markup).not.toContain("reason");
+	});
+});

--- a/apps/web/src/components/account-suspended-page.tsx
+++ b/apps/web/src/components/account-suspended-page.tsx
@@ -1,0 +1,57 @@
+import { LogOut, Mail, ShieldOff } from "lucide-react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+
+export function AccountSuspendedPage({
+	onSignOut,
+	signingOut = false,
+	signOutError = null,
+}: {
+	onSignOut: () => void;
+	signingOut?: boolean;
+	signOutError?: string | null;
+}) {
+	return (
+		<main className="flex min-h-dvh items-center justify-center bg-background px-6 py-12">
+			<section className="w-full max-w-lg text-center" aria-labelledby="account-suspended-title">
+				<img
+					src="/clawdi-logo-transparent.png"
+					alt="Clawdi"
+					className="mx-auto size-12 rounded-md"
+				/>
+				<div className="mx-auto mt-8 flex size-11 items-center justify-center rounded-md border bg-muted text-muted-foreground">
+					<ShieldOff className="size-5" aria-hidden="true" />
+				</div>
+				<h1 id="account-suspended-title" className="mt-5 text-xl font-semibold">
+					Account deactivated
+				</h1>
+				<p className="mx-auto mt-2 max-w-md text-sm leading-6 text-muted-foreground">
+					Your account has been deactivated and can no longer access Clawdi.
+				</p>
+				<p className="mx-auto mt-1 max-w-md text-sm leading-6 text-muted-foreground">
+					Contact support if you believe this is a mistake or need help.
+				</p>
+				<div className="mt-6 flex flex-col justify-center gap-2 sm:flex-row">
+					<a href="mailto:support@clawdi.ai" className={cn(buttonVariants())}>
+						<Mail data-icon="inline-start" />
+						Contact support
+					</a>
+					<Button variant="outline" disabled={signingOut} onClick={onSignOut}>
+						{signingOut ? (
+							<Spinner data-icon="inline-start" aria-label="Signing out" />
+						) : (
+							<LogOut data-icon="inline-start" />
+						)}
+						{signingOut ? "Signing out" : "Sign out"}
+					</Button>
+				</div>
+				{signOutError ? (
+					<p className="mt-4 text-sm text-destructive" role="alert">
+						{signOutError}
+					</p>
+				) : null}
+			</section>
+		</main>
+	);
+}

--- a/apps/web/src/components/account-suspension-boundary.tsx
+++ b/apps/web/src/components/account-suspension-boundary.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState, useSyncExternalStore } from "react";
+import { AccountSuspendedPage } from "@/components/account-suspended-page";
+import { Spinner } from "@/components/ui/spinner";
+import {
+	getAccountSuspendedServerSnapshot,
+	getAccountSuspendedSnapshot,
+	subscribeToAccountSuspension,
+} from "@/lib/account-suspension";
+import { useOpenApi } from "@/lib/api";
+import { isAccountSuspendedError } from "@/lib/api-errors";
+import { useAuthActions, useCurrentUser } from "@/lib/auth-client";
+import { useHydrated } from "@/lib/use-hydrated";
+
+export function AccountSuspensionBoundary({ children }: { children: React.ReactNode }) {
+	const hydrated = useHydrated();
+	const { isLoaded, isSignedIn } = useCurrentUser();
+	const suspended = useSyncExternalStore(
+		subscribeToAccountSuspension,
+		getAccountSuspendedSnapshot,
+		getAccountSuspendedServerSnapshot,
+	);
+	const api = useOpenApi();
+	const accessCheckEnabled = hydrated && isLoaded && Boolean(isSignedIn);
+	const access = api.useQuery(
+		"get",
+		"/v1/auth/me",
+		{},
+		{
+			enabled: accessCheckEnabled,
+			retry: false,
+			staleTime: Number.POSITIVE_INFINITY,
+			refetchOnWindowFocus: false,
+		},
+	);
+
+	if (!hydrated || !isLoaded || !isSignedIn || (accessCheckEnabled && access.isPending)) {
+		return <AccountAccessPending />;
+	}
+	if (suspended || isAccountSuspendedError(access.error)) {
+		return <SuspendedAccountState />;
+	}
+	return children;
+}
+
+function AccountAccessPending() {
+	return (
+		<main className="flex min-h-dvh items-center justify-center bg-background" aria-busy="true">
+			<div className="flex size-12 items-center justify-center">
+				<Spinner className="size-5 text-muted-foreground" aria-label="Checking account access" />
+			</div>
+		</main>
+	);
+}
+
+function SuspendedAccountState() {
+	const { signOut } = useAuthActions();
+	const [signingOut, setSigningOut] = useState(false);
+	const [signOutError, setSignOutError] = useState<string | null>(null);
+
+	const handleSignOut = async () => {
+		setSigningOut(true);
+		setSignOutError(null);
+		try {
+			await signOut({ redirectUrl: "/sign-in" });
+		} catch {
+			setSignOutError("We couldn't sign you out. Please try again.");
+			setSigningOut(false);
+		}
+	};
+
+	return (
+		<AccountSuspendedPage
+			onSignOut={() => void handleSignOut()}
+			signingOut={signingOut}
+			signOutError={signOutError}
+		/>
+	);
+}

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from "react";
 import { AnalyticsProvider } from "@/components/providers/analytics-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { clearAccountSuspension } from "@/lib/account-suspension";
 import { useCurrentUser } from "@/lib/auth-client";
 import { createAppQueryClient } from "@/lib/query-client";
 
@@ -38,6 +39,7 @@ function QueryCacheAuthBoundary({
 
 	useEffect(() => {
 		if (!isLoaded) return;
+		if (!isSignedIn) clearAccountSuspension();
 
 		const authKey = isSignedIn ? (user?.id ?? "signed-in") : "signed-out";
 		if (lastAuthKey.current === null) {
@@ -46,6 +48,7 @@ function QueryCacheAuthBoundary({
 		}
 		if (lastAuthKey.current !== authKey) {
 			queryClient.clear();
+			clearAccountSuspension();
 			lastAuthKey.current = authKey;
 		}
 	}, [isLoaded, isSignedIn, queryClient, user?.id]);

--- a/apps/web/src/lib/account-suspension.test.ts
+++ b/apps/web/src/lib/account-suspension.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	clearAccountSuspension,
+	getAccountSuspendedSnapshot,
+	isAccountSuspendedProblem,
+	observeAccountSuspensionResponse,
+} from "./account-suspension";
+
+const problem = {
+	type: "urn:clawdi:problem:account-suspended",
+	title: "Account suspended",
+	status: 401,
+	detail: "Account is suspended",
+	code: "account_suspended",
+};
+
+afterEach(() => clearAccountSuspension());
+
+describe("account suspension contract", () => {
+	test("recognizes only the stable typed problem", () => {
+		expect(isAccountSuspendedProblem(problem)).toBe(true);
+		expect(isAccountSuspendedProblem({ ...problem, code: "invalid_credentials" })).toBe(false);
+		expect(isAccountSuspendedProblem({ detail: "Account is suspended" })).toBe(false);
+	});
+
+	test("a suspension response switches the global access boundary", async () => {
+		const response = new Response(JSON.stringify(problem), {
+			status: 401,
+			headers: { "content-type": "application/problem+json" },
+		});
+
+		expect(await observeAccountSuspensionResponse(response)).toBe(true);
+		expect(getAccountSuspendedSnapshot()).toBe(true);
+	});
+
+	test("ordinary authentication failures do not look suspended", async () => {
+		const response = new Response(JSON.stringify({ detail: "Invalid credentials" }), {
+			status: 401,
+			headers: { "content-type": "application/json" },
+		});
+
+		expect(await observeAccountSuspensionResponse(response)).toBe(false);
+		expect(getAccountSuspendedSnapshot()).toBe(false);
+	});
+});

--- a/apps/web/src/lib/account-suspension.ts
+++ b/apps/web/src/lib/account-suspension.ts
@@ -1,0 +1,59 @@
+import type { AccountSuspendedProblem } from "@clawdi/shared/api";
+
+export const ACCOUNT_SUSPENDED_CODE: AccountSuspendedProblem["code"] = "account_suspended";
+const ACCOUNT_SUSPENDED_TYPE: AccountSuspendedProblem["type"] =
+	"urn:clawdi:problem:account-suspended";
+
+let accountSuspended = false;
+const listeners = new Set<() => void>();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+export function isAccountSuspendedProblem(value: unknown): value is AccountSuspendedProblem {
+	return (
+		isRecord(value) &&
+		value.type === ACCOUNT_SUSPENDED_TYPE &&
+		value.status === 401 &&
+		value.code === ACCOUNT_SUSPENDED_CODE &&
+		typeof value.detail === "string"
+	);
+}
+
+export function getAccountSuspendedSnapshot(): boolean {
+	return accountSuspended;
+}
+
+export function getAccountSuspendedServerSnapshot(): boolean {
+	return false;
+}
+
+export function subscribeToAccountSuspension(listener: () => void): () => void {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
+
+export function markAccountSuspended(): void {
+	if (accountSuspended) return;
+	accountSuspended = true;
+	for (const listener of listeners) listener();
+}
+
+export function clearAccountSuspension(): void {
+	if (!accountSuspended) return;
+	accountSuspended = false;
+	for (const listener of listeners) listener();
+}
+
+export async function observeAccountSuspensionResponse(response: Response): Promise<boolean> {
+	if (response.status !== 401) return false;
+	try {
+		const body: unknown = await response.clone().json();
+		if (!isAccountSuspendedProblem(body)) return false;
+		markAccountSuspended();
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/apps/web/src/lib/api-errors.test.ts
+++ b/apps/web/src/lib/api-errors.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 import {
 	ApiError,
 	ApiNetworkError,
+	apiErrorCode,
 	formatApiError,
+	isAccountSuspendedError,
 	isApiAuthError,
 	isApiNetworkError,
 	isApiNotFoundError,
@@ -46,6 +48,13 @@ describe("API error details", () => {
 	test("keeps plain text API errors readable", () => {
 		expect(formatApiError("project not found")).toBe("project not found");
 	});
+
+	test("extracts stable codes from Problem Details and structured FastAPI details", () => {
+		expect(apiErrorCode({ code: "account_suspended", detail: "Account is suspended" })).toBe(
+			"account_suspended",
+		);
+		expect(apiErrorCode({ detail: { code: "already_member" } })).toBe("already_member");
+	});
 });
 
 describe("cloud-api error classification", () => {
@@ -55,6 +64,13 @@ describe("cloud-api error classification", () => {
 		expect(isApiNotFoundError(e)).toBe(false);
 		expect(isApiServerError(e)).toBe(false);
 		expect(isApiNetworkError(e)).toBe(false);
+	});
+
+	test("suspension is distinguishable from an ordinary 401", () => {
+		expect(
+			isAccountSuspendedError(new ApiError(401, "Account is suspended", "account_suspended")),
+		).toBe(true);
+		expect(isAccountSuspendedError(new ApiError(401, "token expired"))).toBe(false);
 	});
 
 	test("404 is a not-found error, not transport", () => {
@@ -103,6 +119,14 @@ describe("normalizeApiError", () => {
 
 	test("401 → session expired prompt", () => {
 		expect(normalizeApiError(new ApiError(401, "jwt expired"))).toMatch(/session has expired/i);
+	});
+
+	test("suspension 401 uses deactivation copy without exposing detail", () => {
+		const message = normalizeApiError(
+			new ApiError(401, "internal suspension detail", "account_suspended"),
+		);
+		expect(message).toMatch(/account has been deactivated/i);
+		expect(message).not.toContain("internal suspension detail");
 	});
 
 	test("5xx → transient message, not the raw detail", () => {

--- a/apps/web/src/lib/api-errors.ts
+++ b/apps/web/src/lib/api-errors.ts
@@ -1,4 +1,5 @@
 import { toast } from "sonner";
+import { ACCOUNT_SUSPENDED_CODE } from "@/lib/account-suspension";
 
 /**
  * Cloud-api (`useApi` / openapi-fetch) error model + normalization.
@@ -15,6 +16,7 @@ export class ApiError extends Error {
 	constructor(
 		public status: number,
 		public detail: string,
+		public code: string | null = null,
 	) {
 		super(`API ${status}: ${detail}`);
 		this.name = "ApiError";
@@ -48,6 +50,16 @@ export function parseApiDetail(detail: string): unknown {
 	}
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+export function apiErrorCode(value: unknown): string | null {
+	if (!isRecord(value)) return null;
+	if (typeof value.code === "string") return value.code;
+	return isRecord(value.detail) && typeof value.detail.code === "string" ? value.detail.code : null;
+}
+
 export function formatApiError(detail: string): string {
 	const parsed = parseApiDetail(detail);
 	if (typeof parsed === "string") return parsed;
@@ -61,6 +73,10 @@ export function formatApiError(detail: string): string {
 /** Auth expired / invalid token mid-session (401). Needs re-auth, not a retry. */
 export function isApiAuthError(error: unknown): boolean {
 	return error instanceof ApiError && error.status === 401;
+}
+
+export function isAccountSuspendedError(error: unknown): boolean {
+	return error instanceof ApiError && error.status === 401 && error.code === ACCOUNT_SUSPENDED_CODE;
 }
 
 /** True not-found from the API. Transport failures must not collapse to 404 UI. */
@@ -91,6 +107,9 @@ export function normalizeApiError(error: unknown): string {
 			: "We couldn't reach the service. Check your connection and try again.";
 	}
 	if (error instanceof ApiError) {
+		if (isAccountSuspendedError(error)) {
+			return "Your account has been deactivated and can no longer access Clawdi.";
+		}
 		if (error.status === 401) {
 			return "Your session has expired. Please sign in again to continue.";
 		}
@@ -113,5 +132,8 @@ export function normalizeApiError(error: unknown): string {
  * the normalized, internal-free error copy as the description.
  */
 export function toastApiError(title: string) {
-	return (error: unknown) => toast.error(title, { description: normalizeApiError(error) });
+	return (error: unknown) => {
+		if (isAccountSuspendedError(error)) return;
+		toast.error(title, { description: normalizeApiError(error) });
+	};
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -4,7 +4,8 @@ import { type components, extractApiDetail, type paths } from "@clawdi/shared/ap
 import createClient from "openapi-fetch";
 import createQueryClient from "openapi-react-query";
 import { useCallback, useMemo } from "react";
-import { ApiError, ApiNetworkError } from "@/lib/api-errors";
+import { observeAccountSuspensionResponse } from "@/lib/account-suspension";
+import { ApiError, ApiNetworkError, apiErrorCode } from "@/lib/api-errors";
 import { useAuthToken } from "@/lib/auth-client";
 import { env } from "@/lib/env";
 
@@ -66,6 +67,10 @@ function fetchWithTimeout(request: Request, init?: RequestInit): Promise<Respons
 		controller.abort();
 	}, REQUEST_TIMEOUT_MS);
 	return fetch(request, { ...init, signal: controller.signal })
+		.then(async (response) => {
+			await observeAccountSuspensionResponse(response);
+			return response;
+		})
 		.catch((cause: unknown) => {
 			if (timedOut) throw new ApiNetworkError("timeout", { cause });
 			if (caller?.aborted) throw cause;
@@ -99,7 +104,7 @@ function useConfiguredApi(throwOnError: boolean) {
 			client.use({
 				async onResponse({ response }) {
 					if (!response.ok) {
-						throw new ApiError(response.status, await apiErrorDetail(response.clone()));
+						throw await apiErrorFromResponse(response.clone());
 					}
 					return response;
 				},
@@ -133,7 +138,11 @@ export type OpenApiClient = ReturnType<typeof useOpenApi>;
  */
 export function unwrap<T>(result: { data?: T; error?: unknown; response: Response }): T {
 	if (result.error !== undefined) {
-		throw new ApiError(result.response.status, extractApiDetail(result.error));
+		throw new ApiError(
+			result.response.status,
+			extractApiDetail(result.error),
+			apiErrorCode(result.error),
+		);
 	}
 	return result.data as T;
 }
@@ -143,15 +152,19 @@ export function ensureBlob(value: unknown): Blob {
 	throw new Error("Expected a binary API response");
 }
 
-async function apiErrorDetail(response: Response): Promise<string> {
+async function apiErrorFromResponse(response: Response): Promise<ApiError> {
 	try {
 		if ((response.headers.get("content-type") ?? "").includes("application/json")) {
 			const body: unknown = await response.json();
-			return extractApiDetail(body);
+			return new ApiError(response.status, extractApiDetail(body), apiErrorCode(body));
 		}
-		return (await response.text()) || response.statusText;
+		if ((response.headers.get("content-type") ?? "").includes("+json")) {
+			const body: unknown = await response.json();
+			return new ApiError(response.status, extractApiDetail(body), apiErrorCode(body));
+		}
+		return new ApiError(response.status, (await response.text()) || response.statusText);
 	} catch {
-		return response.statusText;
+		return new ApiError(response.status, response.statusText);
 	}
 }
 
@@ -187,7 +200,7 @@ export function useSkillArchiveUploader() {
 				}),
 			);
 			if (!response.ok) {
-				throw new ApiError(response.status, await apiErrorDetail(response));
+				throw await apiErrorFromResponse(response);
 			}
 			return readJson<SkillUploadResponse>(response);
 		},
@@ -213,7 +226,7 @@ export function useAgentAvatarUploader() {
 					body: form,
 				}),
 			);
-			if (!response.ok) throw new ApiError(response.status, await apiErrorDetail(response));
+			if (!response.ok) throw await apiErrorFromResponse(response);
 			return readJson<EnvironmentResponse>(response);
 		},
 		[getToken],

--- a/apps/web/src/pages/dashboard/skills/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/page.tsx
@@ -245,6 +245,7 @@ function SkillsPageInner() {
 						<Button
 							variant="outline"
 							size="sm"
+							nativeButton={false}
 							render={<Link to="/agents/$id/skills" params={{ id: legacyTarget }} />}
 						>
 							Open workspace
@@ -384,7 +385,7 @@ function ProjectSelection({ projects, loading }: { projects: ProjectRow[]; loadi
 				icon={FolderKanban}
 				description="Create a Project to bundle Skills and Vault access for Agents."
 				action={
-					<Button render={<Link to="/projects" />}>
+					<Button nativeButton={false} render={<Link to="/projects" />}>
 						<Plus />
 						Create project
 					</Button>

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -2,6 +2,7 @@ import { auth } from "@clerk/tanstack-react-start/server";
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import { setResponseHeader } from "@tanstack/react-start/server";
+import { AccountSuspensionBoundary } from "@/components/account-suspension-boundary";
 import { env } from "@/lib/env";
 
 const getAuthState = createServerFn({ method: "GET" }).handler(async () => {
@@ -21,5 +22,13 @@ export const Route = createFileRoute("/_protected")({
 			});
 		}
 	},
-	component: Outlet,
+	component: ProtectedLayout,
 });
+
+function ProtectedLayout() {
+	return (
+		<AccountSuspensionBoundary>
+			<Outlet />
+		</AccountSuspensionBoundary>
+	);
+}

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -23,6 +23,7 @@ from app.core.database import get_session
 from app.models.api_key import ApiKey
 from app.models.principal_lifecycle import PrincipalLifecycle
 from app.models.user import PRINCIPAL_KIND_CLERK, User
+from app.schemas.problem import ACCOUNT_SUSPENDED_DETAIL, AccountSuspendedProblem
 from app.services.app_setting_registry import CLERK_CLI_OAUTH_SPEC
 from app.services.app_settings import AppSettingUnavailable, resolve_app_setting
 from app.services.clerk_backend import clerk_backend_headers, clerk_user_url
@@ -55,6 +56,21 @@ _CLERK_JWKS_TIMEOUT_SECONDS = 5
 
 type _JwtClaims = dict[str, JsonValue]
 _JWT_CLAIMS_ADAPTER: TypeAdapter[_JwtClaims] = TypeAdapter(dict[str, JsonValue])
+
+
+class AccountSuspendedHTTPException(HTTPException):
+    """401 with a stable public Problem Details body for every auth mode."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=ACCOUNT_SUSPENDED_DETAIL,
+            headers={
+                "WWW-Authenticate": "Bearer",
+                "Cache-Control": "no-store, private",
+            },
+        )
+        self.problem = AccountSuspendedProblem()
 
 
 class ClerkEmailVerification(BaseModel):
@@ -224,7 +240,7 @@ async def _assert_active_user_or_401(db: AsyncSession, user_id: UUID) -> None:
         await assert_user_authority_active(db, user_id)
     except PrincipalSuspendedError:
         invalidate_user_api_key_auth_cache(user_id)
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account is suspended") from None
+        raise AccountSuspendedHTTPException() from None
     except PrincipalTerminatedError:
         invalidate_user_api_key_auth_cache(user_id)
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated") from None
@@ -371,7 +387,7 @@ async def _auth_via_dev_bypass(token: str, db: AsyncSession) -> AuthContext | No
     try:
         issuer = await assert_clerk_principal_active(db, subject=clerk_id)
     except PrincipalSuspendedError:
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account is suspended") from None
+        raise AccountSuspendedHTTPException() from None
     except PrincipalTerminatedError:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated") from None
     if issuer is None:
@@ -686,7 +702,7 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
                 )
             ).scalar_one_or_none()
     except PrincipalSuspendedError:
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account is suspended") from None
+        raise AccountSuspendedHTTPException() from None
     except PrincipalTerminatedError:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated") from None
     except PrincipalIdentityConflictError:
@@ -910,7 +926,7 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
             issuer=issuer or None,
         )
     except PrincipalSuspendedError:
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account is suspended") from None
+        raise AccountSuspendedHTTPException() from None
     except PrincipalTerminatedError:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated") from None
     await _assert_active_user_or_401(db, user.id)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from app.core.auth import warm_clerk_jwks
+from app.core.auth import AccountSuspendedHTTPException, warm_clerk_jwks
 from app.core.config import settings
 from app.core.database import async_session_factory, get_session
 from app.core.logging_config import configure_application_logging
@@ -456,7 +456,15 @@ async def clawdi_http_exception_handler(
     request: Request,
     exc: StarletteHTTPException,
 ):
-    response = await http_exception_handler(request, exc)
+    if isinstance(exc, AccountSuspendedHTTPException):
+        response = JSONResponse(
+            status_code=exc.status_code,
+            content=exc.problem.model_dump(mode="json"),
+            headers=exc.headers,
+            media_type="application/problem+json",
+        )
+    else:
+        response = await http_exception_handler(request, exc)
     return _apply_whatsapp_onboarding_cache_policy(
         request,
         _apply_public_session_export_cache_policy(request, response),

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -14,6 +14,7 @@ from app.schemas.api_key import (
     ApiKeyResponse,
     ApiKeyRevokeResponse,
 )
+from app.schemas.problem import AccountSuspendedProblem
 from app.schemas.user import CurrentUserResponse
 from app.services.api_key import mint_api_key
 
@@ -140,7 +141,20 @@ async def revoke_api_key(
     return ApiKeyRevokeResponse(status="revoked")
 
 
-@router.get("/me")
+@router.get(
+    "/me",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "model": AccountSuspendedProblem,
+            "description": "The authenticated account is suspended",
+            "content": {
+                "application/problem+json": {
+                    "schema": {"$ref": "#/components/schemas/AccountSuspendedProblem"}
+                }
+            },
+        }
+    },
+)
 async def get_me(auth: AuthContext = Depends(get_auth)) -> CurrentUserResponse:
     return CurrentUserResponse(
         id=str(auth.user.id),

--- a/backend/app/schemas/problem.py
+++ b/backend/app/schemas/problem.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+ACCOUNT_SUSPENDED_PROBLEM_CODE = "account_suspended"
+ACCOUNT_SUSPENDED_PROBLEM_TYPE = "urn:clawdi:problem:account-suspended"
+ACCOUNT_SUSPENDED_DETAIL = "Account is suspended"
+
+
+class AccountSuspendedProblem(BaseModel):
+    """Stable public auth rejection for a suspended account."""
+
+    type: Literal["urn:clawdi:problem:account-suspended"] = ACCOUNT_SUSPENDED_PROBLEM_TYPE
+    title: Literal["Account suspended"] = "Account suspended"
+    status: Literal[401] = 401
+    detail: Literal["Account is suspended"] = ACCOUNT_SUSPENDED_DETAIL
+    code: Literal["account_suspended"] = ACCOUNT_SUSPENDED_PROBLEM_CODE

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -213,6 +213,7 @@ strict = [
     "app/schemas/platform.py",
     "app/schemas/platform_oauth.py",
     "app/schemas/plugin_catalog.py",
+    "app/schemas/problem.py",
     "app/schemas/runtime.py",
     "app/schemas/runtime_observation.py",
     "app/schemas/runtime_observed.py",

--- a/backend/tests/test_cli_oauth_auth.py
+++ b/backend/tests/test_cli_oauth_auth.py
@@ -30,6 +30,7 @@ from app.services.clerk_cli_oauth_settings import (
     CLERK_CLI_OAUTH_SETTING_ADAPTER,
     CLERK_CLI_OAUTH_SETTING_KEY,
 )
+from app.services.principal_lifecycle import set_clerk_principal_suspension
 
 _ISSUER = "https://clerk.example.test"
 _CLIENT_ID = "client_clawdi_cli"
@@ -182,6 +183,53 @@ async def test_oauth_access_and_session_tokens_are_classified_separately(
     assert oauth is not None
     assert oauth.oauth_cli is True
     assert oauth.is_cli is False
+
+
+@pytest.mark.asyncio
+async def test_suspended_browser_and_oauth_tokens_share_public_problem_contract(
+    raw_auth_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    clerk_oauth_signing_key: str,
+) -> None:
+    subject = f"user_suspended_{uuid.uuid4().hex}"
+    browser_token = _session_token(
+        clerk_oauth_signing_key,
+        subject,
+        {"iss": _ISSUER},
+    )
+    oauth_token = _oauth_access_token(clerk_oauth_signing_key, subject)
+
+    admitted = await raw_auth_client.get(
+        "/v1/auth/me",
+        headers={"Authorization": f"Bearer {browser_token}"},
+    )
+    assert admitted.status_code == 200, admitted.text
+
+    await set_clerk_principal_suspension(
+        db_session,
+        issuer=_ISSUER,
+        subject=subject,
+        suspended=True,
+        reason="operator_internal_case_42",
+    )
+    await db_session.commit()
+
+    expected = {
+        "type": "urn:clawdi:problem:account-suspended",
+        "title": "Account suspended",
+        "status": 401,
+        "detail": "Account is suspended",
+        "code": "account_suspended",
+    }
+    for token in (browser_token, oauth_token):
+        response = await raw_auth_client.get(
+            "/v1/auth/me",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 401, response.text
+        assert response.headers["content-type"] == "application/problem+json"
+        assert response.json() == expected
+        assert "operator_internal_case_42" not in response.text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_principal_suspension.py
+++ b/backend/tests/test_principal_suspension.py
@@ -115,7 +115,17 @@ async def test_api_keys_are_denied_and_recover_without_credential_mutation(
             headers={"Authorization": f"Bearer {key.raw_key}"},
         )
         assert response.status_code == 401, response.text
-        assert response.json() == {"detail": "Account is suspended"}
+        assert response.headers["content-type"] == "application/problem+json"
+        assert response.headers["cache-control"] == "no-store, private"
+        assert response.headers["www-authenticate"] == "Bearer"
+        assert response.json() == {
+            "type": "urn:clawdi:problem:account-suspended",
+            "title": "Account suspended",
+            "status": 401,
+            "detail": "Account is suspended",
+            "code": "account_suspended",
+        }
+        assert "security_review" not in response.text
 
     persisted_keys = list(
         await db_session.scalars(select(ApiKey).where(ApiKey.user_id == seed_user.id))

--- a/packages/cli/tests/api-client.test.ts
+++ b/packages/cli/tests/api-client.test.ts
@@ -104,6 +104,37 @@ describe("ApiClient error classification", () => {
 		}
 	});
 
+	it("keeps a suspension Problem recognizable to existing CLI callers", async () => {
+		fakeLogin("http://127.0.0.1:0");
+		const origFetch = globalThis.fetch;
+		globalThis.fetch = async () =>
+			new Response(
+				JSON.stringify({
+					type: "urn:clawdi:problem:account-suspended",
+					title: "Account suspended",
+					status: 401,
+					detail: "Account is suspended",
+					code: "account_suspended",
+				}),
+				{ status: 401, headers: { "content-type": "application/problem+json" } },
+			);
+		try {
+			const { ApiClient, unwrap } = await import("../src/lib/api-client");
+			const api = new ApiClient();
+			let caught: unknown;
+			try {
+				unwrap(await api.GET("/v1/auth/me"));
+			} catch (error) {
+				caught = error;
+			}
+			expect(caught).toBeInstanceOf(ApiError);
+			expect((caught as ApiError).status).toBe(401);
+			expect((caught as ApiError).body).toBe("Account is suspended");
+		} finally {
+			globalThis.fetch = origFetch;
+		}
+	});
+
 	it("retries 5xx on GET up to the configured max", async () => {
 		fakeLogin("http://127.0.0.1:0");
 		const origFetch = globalThis.fetch;

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -3182,6 +3182,42 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /**
+         * AccountSuspendedProblem
+         * @description Stable public auth rejection for a suspended account.
+         */
+        AccountSuspendedProblem: {
+            /**
+             * Type
+             * @default urn:clawdi:problem:account-suspended
+             * @constant
+             */
+            type: "urn:clawdi:problem:account-suspended";
+            /**
+             * Title
+             * @default Account suspended
+             * @constant
+             */
+            title: "Account suspended";
+            /**
+             * Status
+             * @default 401
+             * @constant
+             */
+            status: 401;
+            /**
+             * Detail
+             * @default Account is suspended
+             * @constant
+             */
+            detail: "Account is suspended";
+            /**
+             * Code
+             * @default account_suspended
+             * @constant
+             */
+            code: "account_suspended";
+        };
         /** AgentMcpInventoryResponse */
         AgentMcpInventoryResponse: {
             /** Agent Id */
@@ -8344,6 +8380,16 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CurrentUserResponse"];
+                };
+            };
+            /** @description The authenticated account is suspended */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["AccountSuspendedProblem"];
+                    "application/json": components["schemas"]["AccountSuspendedProblem"];
                 };
             };
         };

--- a/packages/shared/src/api/schemas.ts
+++ b/packages/shared/src/api/schemas.ts
@@ -15,6 +15,7 @@ type Schemas = components["schemas"];
 
 // ── Auth ─────────────────────────────────────────────────────────────────
 export type CurrentUser = Schemas["CurrentUserResponse"];
+export type AccountSuspendedProblem = Schemas["AccountSuspendedProblem"];
 export type ApiKey = Schemas["ApiKeyResponse"];
 export type ApiKeyCreated = Schemas["ApiKeyCreated"];
 export type ApiKeyCreate = Schemas["ApiKeyCreate"];


### PR DESCRIPTION
## Summary

- return a stable `account_suspended` problem response across authenticated API entry points
- gate the protected web tree on `/v1/auth/me` and handle later suspension responses globally
- show a dedicated deactivated-account page with support and sign-out actions

## Verification

- backend focused PostgreSQL tests: 45 passed
- web full suite: 1058 passed
- web focused suite: 22 passed
- CLI focused suite: 23 passed
- typecheck, OSS build, Biome, Ruff, generated API checks passed
- desktop and mobile browser flows verified