### PR TITLE
refactor(cli): converge runtime rollback orchestration

### DIFF
--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -21,6 +21,8 @@ import {
 	withRuntimeUserFileAccess,
 } from "./runtime-user-command";
 
+const HERMES_SKILL_COMMAND_TIMEOUT_MS = 120_000;
+
 export interface HostedHermesSkillExactSourceDriver {
 	install(input: {
 		home: string;
@@ -115,7 +117,7 @@ function runHermes(input: { home: string; appRoot: string }, args: string[], std
 		input.appRoot,
 		{
 			input: stdin,
-			timeoutMs: 120_000,
+			timeoutMs: HERMES_SKILL_COMMAND_TIMEOUT_MS,
 			maxBufferBytes: 1024 * 1024,
 		},
 	);

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -145,21 +145,25 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 		if (withRuntimeUserFileAccess(() => existsSync(target)) && !input.previouslyReserved)
 			throw new Error("Hermes Skill target is not paired with a manifest reservation");
 		if (managedSkillReceiptMatchesIdentity(receipt)) return "unchanged";
-		return withStagedManagedSkill(input.skill, (sourceDir) =>
-			withManagedTargetRollback({
-				target,
-				receipt: receipt.path,
-				operation: () => {
-					if (input.skill.source.type === "bundled") {
-						withRuntimeUserFileAccess(() => replaceManagedSkillDirectoryAtomic(sourceDir, target));
+		return withStagedManagedSkill(input.skill, (sourceDir) => {
+			if (input.skill.source.type === "bundled") {
+				replaceManagedSkillDirectoryAtomic(sourceDir, target, {
+					receipt: receipt.path,
+					afterActivate: () => {
 						if (!bundledResultMatches(sourceDir, target)) {
 							throw new ManagedSkillResourceError(
 								"Hermes bundled Skill activation changed exact source bytes",
 							);
 						}
 						writeManagedSkillReceipt(receipt);
-						return "installed" as const;
-					}
+					},
+				});
+				return "installed" as const;
+			}
+			return withManagedTargetRollback({
+				target,
+				receipt: receipt.path,
+				operation: () => {
 					const args = [
 						"skills",
 						"install",
@@ -177,8 +181,8 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 					writeManagedSkillReceipt(receipt);
 					return "installed" as const;
 				},
-			}),
-		);
+			});
+		});
 	},
 	anchorOwnership(input) {
 		writeManagedSkillReceipt(

--- a/packages/cli/src/runtime/hosted-openclaw-skill.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.ts
@@ -25,6 +25,8 @@ import {
 const OPENCLAW_AGENT_ID = "main";
 const SOURCE_RECEIPT = ".openclaw/source-origin.json";
 const EXCLUDED_NATIVE_FILES = new Set([SOURCE_RECEIPT]);
+const OPENCLAW_CONFIG_PROBE_TIMEOUT_MS = 15_000;
+const OPENCLAW_CONFIG_REPAIR_TIMEOUT_MS = 120_000;
 
 export interface HostedOpenClawSkillDriver {
 	resolveWorkspace(input: { home: string; repairInvalidConfig?: boolean }): string;
@@ -148,7 +150,7 @@ function repairInvalidConfig(command: string, home: string): boolean {
 		["config", "validate", "--json"],
 		home,
 		home,
-		{ timeoutMs: 15_000, maxBufferBytes: 1024 * 1024 },
+		{ timeoutMs: OPENCLAW_CONFIG_PROBE_TIMEOUT_MS, maxBufferBytes: 1024 * 1024 },
 	);
 	if (!invalidConfigValidation(validation)) return false;
 	const repair = spawnRuntimeUserCommand(
@@ -156,7 +158,7 @@ function repairInvalidConfig(command: string, home: string): boolean {
 		["doctor", "--fix", "--non-interactive"],
 		home,
 		home,
-		{ timeoutMs: 120_000, maxBufferBytes: 4 * 1024 * 1024 },
+		{ timeoutMs: OPENCLAW_CONFIG_REPAIR_TIMEOUT_MS, maxBufferBytes: 4 * 1024 * 1024 },
 	);
 	if (repair.status !== 0) throw new Error("OpenClaw official config repair failed");
 	return true;
@@ -165,12 +167,12 @@ function repairInvalidConfig(command: string, home: string): boolean {
 function resolveOfficialWorkspace(home: string, repairInvalidConfigOnFailure = false): string {
 	const command = commandPath(home);
 	let result = spawnRuntimeUserCommand(command, ["agents", "list", "--json"], home, home, {
-		timeoutMs: 15_000,
+		timeoutMs: OPENCLAW_CONFIG_PROBE_TIMEOUT_MS,
 		maxBufferBytes: 1024 * 1024,
 	});
 	if (result.status !== 0 && repairInvalidConfigOnFailure && repairInvalidConfig(command, home)) {
 		result = spawnRuntimeUserCommand(command, ["agents", "list", "--json"], home, home, {
-			timeoutMs: 15_000,
+			timeoutMs: OPENCLAW_CONFIG_PROBE_TIMEOUT_MS,
 			maxBufferBytes: 1024 * 1024,
 		});
 	}

--- a/packages/cli/src/runtime/managed-baileys-compat.ts
+++ b/packages/cli/src/runtime/managed-baileys-compat.ts
@@ -26,6 +26,7 @@ export const MANAGED_BAILEYS_PATCH_REVISION = "clawdi.managedBaileysCompat.v3";
 const BAILEYS_COMPATIBLE_MAJOR = 7;
 const RECEIPT_FILE = "managed-baileys-compat.json";
 const RECEIPT_SCHEMA = "clawdi.managedBaileysPatchReceipt.v4";
+const HERMES_BAILEYS_DEPENDENCY_INSTALL_TIMEOUT_MS = 300_000;
 
 export type ManagedBaileysRuntime = "openclaw" | "hermes";
 
@@ -426,7 +427,7 @@ function ensureHermesManagedBaileysDependencies(home: string, appRoot: string): 
 		["ci", "--ignore-scripts", "--silent"],
 		home,
 		bridgeRoot,
-		{ timeoutMs: 300_000 },
+		{ timeoutMs: HERMES_BAILEYS_DEPENDENCY_INSTALL_TIMEOUT_MS },
 	);
 	if (result.status !== 0) {
 		const detail = String(result.stderr || result.stdout || "npm ci failed")

--- a/packages/cli/src/runtime/managed-skill-delivery.test.ts
+++ b/packages/cli/src/runtime/managed-skill-delivery.test.ts
@@ -10,7 +10,10 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { managedSkillReceiptOwnsTarget, withManagedTargetRollback } from "./managed-skill-delivery";
+import {
+	managedSkillReceiptMatchesIdentity,
+	withManagedTargetRollback,
+} from "./managed-skill-delivery";
 
 test("restores an already-backed-up target when receipt backup establishment fails", () => {
 	const root = mkdtempSync(join(tmpdir(), "managed-skill-rollback-"));
@@ -58,10 +61,11 @@ test("never treats a null fingerprint as ownership of an absent target", () => {
 			}),
 		);
 		expect(
-			managedSkillReceiptOwnsTarget({
+			managedSkillReceiptMatchesIdentity({
 				path: receipt,
 				schemaVersion: "test.receipt.v2",
 				skillId: "review-pr",
+				ownershipIdentity: "github\0review-pr",
 				target: join(root, "absent-target"),
 			}),
 		).toBe(false);

--- a/packages/cli/src/runtime/managed-skill-delivery.ts
+++ b/packages/cli/src/runtime/managed-skill-delivery.ts
@@ -328,16 +328,6 @@ export function managedSkillMarkerMatchesIdentity(input: {
 	return readManagedSkillMarker(input)?.ownershipIdentity === input.ownershipIdentity;
 }
 
-export function managedSkillReceiptOwnsTarget(input: {
-	path: string;
-	schemaVersion: string;
-	skillId: string;
-	target: string;
-	exclude?: ReadonlySet<string>;
-}): boolean {
-	return readManagedSkillReceipt(input) !== null;
-}
-
 export function managedSkillReceiptMatchesIdentity(input: {
 	path: string;
 	schemaVersion: string;
@@ -391,16 +381,19 @@ export function withManagedTargetRollback<T>(input: {
 	target: string;
 	receipt?: string;
 	operation: () => T;
+	targetBackup?: string;
+	beforeRestore?: () => void;
+	beforeCleanup?: () => void;
+	restoreFailure?: (operationError: unknown, restoreError: unknown) => Error;
 	rename?: typeof renameSync;
 	remove?: typeof rmSync;
 }): T {
 	const rename = input.rename ?? renameSync;
 	const remove = input.remove ?? rmSync;
 	const suffix = randomBytes(8).toString("hex");
-	const targetBackup = join(
-		dirname(input.target),
-		`.${basename(input.target)}-clawdi-rollback-${suffix}`,
-	);
+	const targetBackup =
+		input.targetBackup ??
+		join(dirname(input.target), `.${basename(input.target)}-clawdi-rollback-${suffix}`);
 	const receiptBackup = input.receipt
 		? join(dirname(input.receipt), `.${basename(input.receipt)}-clawdi-rollback-${suffix}`)
 		: undefined;
@@ -428,13 +421,22 @@ export function withManagedTargetRollback<T>(input: {
 	} catch (error) {
 		withRuntimeUserFileAccess(() => remove(input.target, { recursive: true, force: true }));
 		if (input.receipt) remove(input.receipt, { force: true });
-		if (hadTarget) withRuntimeUserFileAccess(() => rename(targetBackup, input.target));
-		if (hadReceipt && input.receipt && receiptBackup) rename(receiptBackup, input.receipt);
+		try {
+			if (hadTarget) {
+				input.beforeRestore?.();
+				withRuntimeUserFileAccess(() => rename(targetBackup, input.target));
+			}
+			if (hadReceipt && input.receipt && receiptBackup) rename(receiptBackup, input.receipt);
+		} catch (restoreError) {
+			if (input.restoreFailure) throw input.restoreFailure(error, restoreError);
+			throw restoreError;
+		}
 		throw error;
 	}
 	// The operation returning is the commit point. Backup cleanup is GC and
 	// must never roll back a live target or its ownership receipt.
 	try {
+		if (hadTarget) input.beforeCleanup?.();
 		withRuntimeUserFileAccess(() => remove(targetBackup, { recursive: true, force: true }));
 		if (receiptBackup) remove(receiptBackup, { force: true });
 	} catch {}

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -14,7 +14,9 @@ import { getClawdiDir } from "../lib/config";
 import { withPrivateDirectoryLockSync } from "../lib/private-directory-lock";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { withRuntimeConvergeLock } from "./converge-lock";
+import { withManagedTargetRollback } from "./managed-skill-delivery";
 import { getRuntimePaths } from "./paths";
+import { withRuntimeUserFileAccess } from "./runtime-user-command";
 import { runtimePlatformRootForPath, writeRuntimePlatformFileAtomic } from "./state";
 
 const LEDGER_FILE = "managed-skills.json";
@@ -405,66 +407,52 @@ export function replaceManagedSkillDirectoryAtomic(
 	options: ManagedSkillDirectoryActivationOptions = {},
 ): void {
 	const parent = dirname(targetDir);
-	mkdirSync(parent, { recursive: true });
-	const stagingRoot = mkdtempSync(join(parent, `.${basename(targetDir)}-stage-`));
+	const stagingRoot = withRuntimeUserFileAccess(() => {
+		mkdirSync(parent, { recursive: true });
+		return mkdtempSync(join(parent, `.${basename(targetDir)}-stage-`));
+	});
 	const stagedTarget = join(stagingRoot, basename(targetDir));
 	const previousTarget = join(
 		parent,
 		`.${basename(targetDir)}-previous-${process.pid}-${randomUUID()}`,
 	);
 	try {
-		cpSync(sourceDir, stagedTarget, { recursive: true });
-		activateManagedSkillDirectory({ stagedTarget, targetDir, previousTarget, options });
+		withRuntimeUserFileAccess(() => cpSync(sourceDir, stagedTarget, { recursive: true }));
+		withManagedTargetRollback({
+			target: targetDir,
+			receipt: options.receipt,
+			targetBackup: previousTarget,
+			beforeRestore: options.beforeRestore,
+			beforeCleanup: options.beforeCleanup,
+			restoreFailure: (activationError, restoreError) => {
+				const activationMessage =
+					activationError instanceof Error ? activationError.message : String(activationError);
+				const restoreMessage =
+					restoreError instanceof Error ? restoreError.message : String(restoreError);
+				return new Error(
+					`Skill activation failed: ${activationMessage}; restoring the previous version failed: ${restoreMessage}; previous version retained as a recovery artifact`,
+					{ cause: activationError },
+				);
+			},
+			operation: () => {
+				withRuntimeUserFileAccess(() => {
+					options.beforeActivate?.();
+					renameSync(stagedTarget, targetDir);
+				});
+				options.afterActivate?.();
+			},
+		});
 	} finally {
-		rmSync(stagingRoot, { recursive: true, force: true });
+		withRuntimeUserFileAccess(() => rmSync(stagingRoot, { recursive: true, force: true }));
 	}
 }
 
 export interface ManagedSkillDirectoryActivationOptions {
+	receipt?: string;
 	beforeActivate?: () => void;
+	afterActivate?: () => void;
 	beforeRestore?: () => void;
 	beforeCleanup?: () => void;
-}
-
-export function activateManagedSkillDirectory(input: {
-	stagedTarget: string;
-	targetDir: string;
-	previousTarget: string;
-	options?: ManagedSkillDirectoryActivationOptions;
-}): void {
-	const hadPrevious = existsSync(input.targetDir);
-	if (hadPrevious) renameSync(input.targetDir, input.previousTarget);
-	try {
-		input.options?.beforeActivate?.();
-		renameSync(input.stagedTarget, input.targetDir);
-	} catch (activationError) {
-		if (!hadPrevious) throw activationError;
-		try {
-			input.options?.beforeRestore?.();
-			renameSync(input.previousTarget, input.targetDir);
-		} catch (restoreError) {
-			const activationMessage =
-				activationError instanceof Error ? activationError.message : String(activationError);
-			const restoreMessage =
-				restoreError instanceof Error ? restoreError.message : String(restoreError);
-			throw new Error(
-				`Skill activation failed: ${activationMessage}; restoring the previous version failed: ${restoreMessage}; previous version retained as a recovery artifact`,
-				{ cause: activationError },
-			);
-		}
-		throw activationError;
-	}
-
-	// Renaming the staged target is the commit point. Cleanup is GC only and
-	// must never make callers roll back ownership after the new target is live.
-	if (hadPrevious) {
-		try {
-			input.options?.beforeCleanup?.();
-			rmSync(input.previousTarget, { recursive: true, force: true });
-		} catch {
-			// Best effort. The uniquely named sibling is safe to collect later.
-		}
-	}
 }
 
 export function releaseManagedSkill(input: {

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -17,7 +17,8 @@ import { canonicalSecretRefName, canonicalSecretRefSchema } from "./secret-value
 export const RUNTIME_DESIRED_STATE_SCHEMA_VERSION = "clawdi.runtimeDesiredState.v1";
 export const HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION = "clawdi.hosted-runtime.bundle.v2";
 
-// Temporary v1 read compatibility. Runtime providers and generated config stay canonical-only.
+// SUNSET(#1148): remove v1 reads after every supported hosted manifest producer
+// emits MANAGED_AI_PROVIDER_RUNTIME_ENV. Runtime providers and generated config stay canonical-only.
 export const LEGACY_HOSTED_CODEX_MANAGED_RUNTIME_ENV = "OPENAI_API_KEY";
 
 export function isHostedCodexManagedRuntimeEnv(value: string | null | undefined): boolean {

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -25,11 +25,7 @@ import {
 import { hostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
 import { assertHostedRuntimeContract } from "./hosted-runtime-contract";
 import { type RuntimeInstallReceipts, readRuntimeInstallReceipts } from "./install-receipts";
-import {
-	captureRuntimeLiveSnapshot,
-	type RuntimeLiveSnapshot,
-	restoreRuntimeLiveSnapshot,
-} from "./live-state-snapshot";
+import { captureRuntimeLiveSnapshot } from "./live-state-snapshot";
 import { reconcileManagedBaileysCompatibility } from "./managed-baileys-compat";
 import { managedHermesWhatsAppAuthDir } from "./managed-channel-reconciliation";
 import { managedSkillReservationLedgerPath } from "./managed-skill-reservation";
@@ -212,8 +208,6 @@ export function convergeRuntimeManifest(
 	const workspaceRoot = runtimeWorkspaceRoot(manifest, paths);
 	let agentPluginTransaction: HostedAgentPluginTransaction | null = null;
 	const agentPluginFailedNames = new Set<string>();
-	let agentPluginSnapshot: RuntimeLiveSnapshot | null = null;
-	let skillProjectionSnapshot: RuntimeLiveSnapshot | null = null;
 	let agentPluginQuiesceAttempted = false;
 	let agentPluginUnitsQuiesced = false;
 	let agentPluginMutationAttempted = false;
@@ -444,6 +438,9 @@ export function convergeRuntimeManifest(
 	} catch (error) {
 		throw rollbackSnapshots.failure(error);
 	}
+	// Resource snapshots live below tenant-owned roots and restore before the
+	// platform-root assertion that guards every earlier snapshot.
+	const resourceRollbackScope = rollbackSnapshots.scope();
 	let systemdActivationApplied = false;
 	let restartDaemon = false;
 	let desiredDaemonAuthTokenRevision: string | undefined;
@@ -855,6 +852,7 @@ export function convergeRuntimeManifest(
 			throw new Error(installErrors.join("; "));
 		}
 		if (sourcedSkillsPrepared) {
+			let skillProjectionScope: ReturnType<typeof rollbackSnapshots.captureScoped> | null = null;
 			try {
 				const skillMutationTargets = hostedSkillMutationTargets(
 					manifest,
@@ -862,20 +860,23 @@ export function convergeRuntimeManifest(
 					openClawWorkspaceRoot,
 					paths.managedResourceRoot,
 				);
-				skillProjectionSnapshot = captureRuntimeLiveSnapshot({
-					rootTargets: [
-						managedSkillReservationLedgerPath(),
-						...skillMutationTargets.platformTargets,
-					],
-					trustedRootDirectories: [paths.managedResourceRoot],
-					runtimeUserTargets: skillMutationTargets.runtimeUserTargets,
-					runtimeUserTrustedRoots: [paths.userHome, paths.clawdiHome],
-					runtimeUserSymlinkTargets: [],
-					metadataTargets: mutationAncestorMetadataTargets(
-						skillMutationTargets.runtimeUserTargets,
-						[paths.userHome, paths.clawdiHome],
-					),
-				});
+				skillProjectionScope = rollbackSnapshots.captureScoped(
+					"runtime Skill filesystem rollback failed",
+					{
+						rootTargets: [
+							managedSkillReservationLedgerPath(),
+							...skillMutationTargets.platformTargets,
+						],
+						trustedRootDirectories: [paths.managedResourceRoot],
+						runtimeUserTargets: skillMutationTargets.runtimeUserTargets,
+						runtimeUserTrustedRoots: [paths.userHome, paths.clawdiHome],
+						runtimeUserSymlinkTargets: [],
+						metadataTargets: mutationAncestorMetadataTargets(
+							skillMutationTargets.runtimeUserTargets,
+							[paths.userHome, paths.clawdiHome],
+						),
+					},
+				);
 				resourceProjectionErrors.push(
 					...reconcileHostedSkillProjection({
 						manifest,
@@ -890,16 +891,16 @@ export function convergeRuntimeManifest(
 				);
 			} catch (error) {
 				const projectionError = error instanceof Error ? error.message : String(error);
-				try {
-					if (skillProjectionSnapshot) restoreRuntimeLiveSnapshot(skillProjectionSnapshot);
-				} catch (rollbackError) {
+				const rollbackErrors = skillProjectionScope
+					? rollbackSnapshots.restore(skillProjectionScope, (_failure, rollbackError) =>
+							rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
+						)
+					: [];
+				if (rollbackErrors.length > 0) {
 					throw new Error(
-						`runtime Skill projection failed and could not be rolled back: ${projectionError}; ${
-							rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
-						}`,
+						`runtime Skill projection failed and could not be rolled back: ${projectionError}; ${rollbackErrors.join("; ")}`,
 					);
 				}
-				skillProjectionSnapshot = null;
 				resourceProjectionErrors.push(projectionError);
 			}
 		}
@@ -1144,19 +1145,23 @@ export function convergeRuntimeManifest(
 			agentPluginMutationAttempted = true;
 		}
 		let agentPluginApplyCompleted = false;
+		let agentPluginSnapshotScope: ReturnType<typeof rollbackSnapshots.captureScoped> | null = null;
 		try {
 			if (appliedAgentPluginTransaction) {
-				agentPluginSnapshot = captureRuntimeLiveSnapshot({
-					rootTargets: [hostedAgentPluginReceiptsPath(paths)],
-					trustedRootDirectories: [paths.statusRoot],
-					runtimeUserTargets: [...appliedAgentPluginTransaction.snapshotTargets],
-					runtimeUserTrustedRoots: [projectionHome],
-					runtimeUserSymlinkTargets: [],
-					metadataTargets: mutationAncestorMetadataTargets(
-						appliedAgentPluginTransaction.snapshotTargets,
-						[projectionHome],
-					),
-				});
+				agentPluginSnapshotScope = rollbackSnapshots.captureScoped(
+					"runtime Agent Plugin filesystem rollback failed",
+					{
+						rootTargets: [hostedAgentPluginReceiptsPath(paths)],
+						trustedRootDirectories: [paths.statusRoot],
+						runtimeUserTargets: [...appliedAgentPluginTransaction.snapshotTargets],
+						runtimeUserTrustedRoots: [projectionHome],
+						runtimeUserSymlinkTargets: [],
+						metadataTargets: mutationAncestorMetadataTargets(
+							appliedAgentPluginTransaction.snapshotTargets,
+							[projectionHome],
+						),
+					},
+				);
 			}
 			appliedAgentPluginTransaction?.apply();
 			agentPluginApplyCompleted = true;
@@ -1171,13 +1176,15 @@ export function convergeRuntimeManifest(
 				agentPluginFailedNames.add(name);
 			}
 			const rollbackErrors = appliedAgentPluginTransaction?.rollback() ?? [];
-			try {
-				if (agentPluginSnapshot) restoreRuntimeLiveSnapshot(agentPluginSnapshot);
-			} catch (rollbackError) {
+			if (agentPluginSnapshotScope) {
 				rollbackErrors.push(
-					`runtime Agent Plugin snapshot rollback failed: ${
-						rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
-					}`,
+					...rollbackSnapshots.restore(
+						agentPluginSnapshotScope,
+						(_failure, rollbackError) =>
+							`runtime Agent Plugin snapshot rollback failed: ${
+								rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+							}`,
+					),
 				);
 			}
 			if (rollbackErrors.length > 0) {
@@ -1194,7 +1201,6 @@ export function convergeRuntimeManifest(
 				}`,
 			);
 			agentPluginTransaction = null;
-			agentPluginSnapshot = null;
 			agentPluginMutationAttempted = false;
 		}
 		if (
@@ -1353,6 +1359,7 @@ export function convergeRuntimeManifest(
 				console.warn(`post-commit official runtime service cleanup deferred: ${cleanupError}`);
 			}
 		}
+		rollbackSnapshots.pop();
 		return convergence;
 	} catch (error) {
 		if (agentPluginMutationAttempted) {
@@ -1380,31 +1387,8 @@ export function convergeRuntimeManifest(
 		let filesystemRollbackSucceeded = false;
 		if (candidateQuiesced) {
 			if (agentPluginTransaction) installErrors.push(...agentPluginTransaction.rollback());
-			let resourceFilesystemRollbackSucceeded = true;
-			if (agentPluginSnapshot) {
-				try {
-					restoreRuntimeLiveSnapshot(agentPluginSnapshot);
-				} catch (rollbackError) {
-					resourceFilesystemRollbackSucceeded = false;
-					installErrors.push(
-						`runtime Agent Plugin filesystem rollback failed: ${
-							rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
-						}`,
-					);
-				}
-			}
-			if (skillProjectionSnapshot) {
-				try {
-					restoreRuntimeLiveSnapshot(skillProjectionSnapshot);
-				} catch (rollbackError) {
-					resourceFilesystemRollbackSucceeded = false;
-					installErrors.push(
-						`runtime Skill filesystem rollback failed: ${
-							rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
-						}`,
-					);
-				}
-			}
+			const resourceSnapshotRollbackErrors = rollbackSnapshots.restore(resourceRollbackScope);
+			installErrors.push(...resourceSnapshotRollbackErrors);
 			try {
 				hostedRuntimeContract.assertPlatformRoots();
 				const snapshotRollbackErrors = rollbackSnapshots.restore();
@@ -1423,7 +1407,7 @@ export function convergeRuntimeManifest(
 					rmSync(egressSecretFilePath(paths), { force: true });
 				}
 				filesystemRollbackSucceeded =
-					resourceFilesystemRollbackSucceeded && snapshotRollbackErrors.length === 0;
+					resourceSnapshotRollbackErrors.length === 0 && snapshotRollbackErrors.length === 0;
 			} catch (rollbackError) {
 				installErrors.push(
 					`runtime filesystem rollback failed: ${

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -25,7 +25,7 @@ import {
 import { hostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
 import { assertHostedRuntimeContract } from "./hosted-runtime-contract";
 import { type RuntimeInstallReceipts, readRuntimeInstallReceipts } from "./install-receipts";
-import { captureRuntimeLiveSnapshot } from "./live-state-snapshot";
+import { captureRuntimeLiveSnapshot, type RuntimeLiveSnapshot } from "./live-state-snapshot";
 import { reconcileManagedBaileysCompatibility } from "./managed-baileys-compat";
 import { managedHermesWhatsAppAuthDir } from "./managed-channel-reconciliation";
 import { managedSkillReservationLedgerPath } from "./managed-skill-reservation";
@@ -76,6 +76,7 @@ import {
 	planHostedAgentPluginConvergence,
 	planRuntimeSystemdUserPrograms,
 	type RuntimeConvergenceOptions,
+	type RuntimeSnapshotRollbackScope,
 	RuntimeSnapshotRollbackStack,
 	resolveRuntimeRunConfigs,
 	runtimeConvergenceWithoutApply,
@@ -152,11 +153,94 @@ import {
 import { runtimeSecretValue } from "./secret-values";
 import { ensureRuntimePlatformDirectory } from "./state";
 
-export function convergeRuntimeManifest(
+type RuntimeManifest = RuntimeManifestLoad["manifest"];
+type RuntimeEntry = [string, RuntimeManifest["runtimes"][string]];
+
+interface RuntimeConvergenceContext {
+	load: RuntimeManifestLoad;
+	manifest: RuntimeManifest;
+	paths: RuntimePaths;
+	opts: RuntimeConvergenceOptions;
+	secretValues: ReturnType<typeof runtimeSecretValues>;
+	applyContext: NonNullable<RuntimeManifestLoad["applyContext"]>;
+	hostedRuntimeContract: ReturnType<typeof assertHostedRuntimeContract>;
+	projectionHome: string;
+	openClawContext: ReturnType<typeof createOpenClawHostedContext>;
+	hermesWhatsAppAuthDir: string | null;
+	workspaceRoot: string;
+	enabledRuntimes: string[];
+	generatedAt: string;
+	egressProfileBundle: ReturnType<typeof buildEgressProfileBundle>;
+	plannedEgressProfileBundlePath: string | null;
+	instanceRoot: string;
+	appliedState: ReturnType<typeof readRuntimeAppliedState>;
+	previousProjectedProviderIds: Record<string, string[]>;
+	runtimeEntries: RuntimeEntry[];
+	preparedHostedSourcedSkills: NonNullable<
+		RuntimeConvergenceOptions["preparedHostedSourcedSkills"]
+	>;
+	sourcedSkillsPrepared: boolean;
+	hermesSkillNativeReconciler: NonNullable<
+		RuntimeConvergenceOptions["hostedHermesSkillExactSourceDriver"]
+	>;
+	openClawSkillDriver: NonNullable<RuntimeConvergenceOptions["hostedOpenClawSkillDriver"]>;
+	retainPreviousProjectedProviderIds: () => Record<string, string[]>;
+}
+
+interface RuntimeConvergenceState {
+	agentPluginTransaction: HostedAgentPluginTransaction | null;
+	agentPluginFailedNames: Set<string>;
+	agentPluginQuiesceAttempted: boolean;
+	agentPluginUnitsQuiesced: boolean;
+	agentPluginMutationAttempted: boolean;
+	agentPluginQuiesceUserUnits: string[];
+	agentPluginRestartUserUnits: string[];
+	runtimeProjectionMutationRuntimes: Set<string>;
+	runtimeProjectionRestartUserUnits: string[];
+	installInventory: string[];
+	projections: string[];
+	managedLocaleFiles: string[];
+	runConfigs: string[];
+	runtimeSystemdUserPrograms: RuntimeSystemdUserProgram[];
+	installErrors: string[];
+	resourceProjectionErrors: string[];
+	installReceiptTargets: RuntimeInstallReceiptTargets;
+	projectedProviderIds: Record<string, string[]>;
+	observations: Map<string, RuntimeInstallObservation>;
+	openClawOwnerBrowserBootstrapSupported: boolean;
+	rollbackSnapshots: RuntimeSnapshotRollbackStack;
+	systemdActivationApplied: boolean;
+	restartDaemon: boolean;
+	desiredDaemonAuthTokenRevision?: string;
+	desiredDaemonProgramRevision?: string;
+	restartEgressSidecar: boolean;
+	desiredEgressSidecarSecretRevision?: string;
+	rollbackEgressSecretOverride?: RuntimeEgressSecretMaterial;
+	rollbackEgressSecretRevision?: string;
+	egressRollbackAuthorityVerified: boolean;
+	staleSystemdFiles: RuntimeSystemdStaleFilePlan;
+}
+
+interface RuntimeInstallStage {
+	previousInstallReceipts: RuntimeInstallReceipts | null;
+	coldInstallPlan: ReturnType<typeof runtimeColdInstallMutationPlan>;
+	pluginBootstrapPlan: ReturnType<typeof managedOpenClawPluginBootstrapMutationPlan>;
+}
+
+interface RuntimeConvergencePlan extends RuntimeInstallStage {
+	openClawWorkspaceRoot: string | null;
+	plannedRuntimePrograms: RuntimeSystemdUserProgram[];
+	mutationPlan: ReturnType<typeof runtimeManagedMutationPlan>;
+	workspaceExistedBeforeApply: boolean;
+	liveSnapshot: RuntimeLiveSnapshot;
+	resourceRollbackScope: RuntimeSnapshotRollbackScope;
+}
+
+function initializeRuntimeConvergence(
 	load: RuntimeManifestLoad,
 	paths: RuntimePaths,
-	opts: RuntimeConvergenceOptions = {},
-): RuntimeConvergenceResult {
+	opts: RuntimeConvergenceOptions,
+): { context: RuntimeConvergenceContext; state: RuntimeConvergenceState } {
 	const { manifest } = load;
 	if (
 		(hasUnsupportedAgentPluginInstallations(manifest) || opts.preparedHostedAgentPlugins) &&
@@ -206,15 +290,6 @@ export function convergeRuntimeManifest(
 		}
 	}
 	const workspaceRoot = runtimeWorkspaceRoot(manifest, paths);
-	let agentPluginTransaction: HostedAgentPluginTransaction | null = null;
-	const agentPluginFailedNames = new Set<string>();
-	let agentPluginQuiesceAttempted = false;
-	let agentPluginUnitsQuiesced = false;
-	let agentPluginMutationAttempted = false;
-	let agentPluginQuiesceUserUnits: string[] = [];
-	let agentPluginRestartUserUnits: string[] = [];
-	const runtimeProjectionMutationRuntimes = new Set<string>();
-	let runtimeProjectionRestartUserUnits: string[] = [];
 	const enabledRuntimes = Object.entries(manifest.runtimes)
 		.filter(([, runtime]) => runtime.enabled)
 		.map(([name]) => name)
@@ -230,20 +305,7 @@ export function convergeRuntimeManifest(
 		? paths.egressProfileBundle
 		: null;
 	const instanceRoot = join(paths.instanceRoot, manifest.instanceId);
-	const installInventory: string[] = [];
-	const projections: string[] = [];
-	const managedLocaleFiles: string[] = [];
-	const runConfigs: string[] = [];
-	const runtimeSystemdUserPrograms: RuntimeSystemdUserProgram[] = [];
-	const installErrors: string[] = [];
-	const resourceProjectionErrors: string[] = [];
 	const appliedState = readRuntimeAppliedState(paths);
-	let previousInstallReceipts: RuntimeInstallReceipts | null = null;
-	const installReceiptTargets: RuntimeInstallReceiptTargets = {
-		officialServices: new Map(),
-		channelPlugins: new Map(),
-		companions: new Map(),
-	};
 	const previousProjectedProviderIds = appliedState?.projectedProviderIds ?? {};
 	const retainPreviousProjectedProviderIds = () =>
 		Object.fromEntries(
@@ -252,73 +314,142 @@ export function convergeRuntimeManifest(
 				[...providerIds],
 			]),
 		);
-	const projectedProviderIds: Record<string, string[]> = {};
 	const runtimeEntries = Object.entries(manifest.runtimes).sort(([a], [b]) => a.localeCompare(b));
-	const observations = new Map<string, RuntimeInstallObservation>();
-	let openClawOwnerBrowserBootstrapSupported = false;
-
 	const preparedHostedSourcedSkills = opts.preparedHostedSourcedSkills ?? new Map();
 	const sourcedSkillsPrepared = opts.resourcePreparationFailures?.sourcedSkills === undefined;
-	if (opts.resourcePreparationFailures?.sourcedSkills) {
-		resourceProjectionErrors.push(opts.resourcePreparationFailures.sourcedSkills);
-	}
-	if (opts.resourcePreparationFailures?.agentPlugins) {
-		resourceProjectionErrors.push(opts.resourcePreparationFailures.agentPlugins.error);
-		for (const name of opts.resourcePreparationFailures.agentPlugins.installationNames) {
-			agentPluginFailedNames.add(name);
-		}
-	}
 	const hermesSkillNativeReconciler =
 		opts.hostedHermesSkillExactSourceDriver ?? hostedHermesSkillExactSourceDriver;
 	const openClawSkillDriver = opts.hostedOpenClawSkillDriver ?? hostedOpenClawSkillDriver;
-	for (const [name, runtime] of runtimeEntries) {
-		const observation = planRuntimeInstallObservation(name, runtime, projectionHome);
-		observations.set(name, observation);
-		if (observation.error) installErrors.push(observation.error);
+	const state: RuntimeConvergenceState = {
+		agentPluginTransaction: null,
+		agentPluginFailedNames: new Set(),
+		agentPluginQuiesceAttempted: false,
+		agentPluginUnitsQuiesced: false,
+		agentPluginMutationAttempted: false,
+		agentPluginQuiesceUserUnits: [],
+		agentPluginRestartUserUnits: [],
+		runtimeProjectionMutationRuntimes: new Set(),
+		runtimeProjectionRestartUserUnits: [],
+		installInventory: [],
+		projections: [],
+		managedLocaleFiles: [],
+		runConfigs: [],
+		runtimeSystemdUserPrograms: [],
+		installErrors: [],
+		resourceProjectionErrors: [],
+		installReceiptTargets: {
+			officialServices: new Map(),
+			channelPlugins: new Map(),
+			companions: new Map(),
+		},
+		projectedProviderIds: {},
+		observations: new Map(),
+		openClawOwnerBrowserBootstrapSupported: false,
+		rollbackSnapshots: new RuntimeSnapshotRollbackStack(),
+		systemdActivationApplied: false,
+		restartDaemon: false,
+		restartEgressSidecar: false,
+		egressRollbackAuthorityVerified: true,
+		staleSystemdFiles: { files: [], systemUnits: [], userUnits: [] },
+	};
+	if (opts.resourcePreparationFailures?.sourcedSkills) {
+		state.resourceProjectionErrors.push(opts.resourcePreparationFailures.sourcedSkills);
 	}
-	if (installErrors.length > 0) {
-		return runtimeConvergenceWithoutApply({
+	if (opts.resourcePreparationFailures?.agentPlugins) {
+		state.resourceProjectionErrors.push(opts.resourcePreparationFailures.agentPlugins.error);
+		for (const name of opts.resourcePreparationFailures.agentPlugins.installationNames) {
+			state.agentPluginFailedNames.add(name);
+		}
+	}
+	return {
+		context: {
 			load,
+			manifest,
 			paths,
+			opts,
+			secretValues,
+			applyContext,
+			hostedRuntimeContract,
+			projectionHome,
+			openClawContext,
+			hermesWhatsAppAuthDir,
 			workspaceRoot,
 			enabledRuntimes,
-			installErrors,
-			projectedProviderIds: retainPreviousProjectedProviderIds(),
-		});
+			generatedAt,
+			egressProfileBundle,
+			plannedEgressProfileBundlePath,
+			instanceRoot,
+			appliedState,
+			previousProjectedProviderIds,
+			runtimeEntries,
+			preparedHostedSourcedSkills,
+			sourcedSkillsPrepared,
+			hermesSkillNativeReconciler,
+			openClawSkillDriver,
+			retainPreviousProjectedProviderIds,
+		},
+		state,
+	};
+}
+
+function runtimeConvergenceFailure(
+	context: RuntimeConvergenceContext,
+	state: RuntimeConvergenceState,
+	includeAgentPluginFailures = false,
+): RuntimeConvergenceResult {
+	return runtimeConvergenceWithoutApply({
+		load: context.load,
+		paths: context.paths,
+		workspaceRoot: context.workspaceRoot,
+		enabledRuntimes: context.enabledRuntimes,
+		installErrors: state.installErrors,
+		projectedProviderIds: context.retainPreviousProjectedProviderIds(),
+		...(includeAgentPluginFailures
+			? { agentPluginFailedNames: [...state.agentPluginFailedNames].sort() }
+			: {}),
+	});
+}
+
+function rollbackRuntimeInstallFailure(
+	context: RuntimeConvergenceContext,
+	state: RuntimeConvergenceState,
+	error: unknown,
+): RuntimeConvergenceResult {
+	state.installErrors.push(...state.rollbackSnapshots.restore());
+	const message = error instanceof Error ? error.message : String(error);
+	if (!state.installErrors.includes(message)) state.installErrors.unshift(message);
+	return runtimeConvergenceFailure(context, state);
+}
+
+function prepareRuntimeInstallStage(
+	context: RuntimeConvergenceContext,
+	state: RuntimeConvergenceState,
+): { stage: RuntimeInstallStage } | { result: RuntimeConvergenceResult } {
+	const { manifest, paths, projectionHome, runtimeEntries, hostedRuntimeContract } = context;
+	for (const [name, runtime] of runtimeEntries) {
+		const observation = planRuntimeInstallObservation(name, runtime, projectionHome);
+		state.observations.set(name, observation);
+		if (observation.error) state.installErrors.push(observation.error);
 	}
+	if (state.installErrors.length > 0) {
+		return { result: runtimeConvergenceFailure(context, state) };
+	}
+	let previousInstallReceipts: RuntimeInstallReceipts | null;
 	try {
 		previousInstallReceipts = readRuntimeInstallReceipts(paths);
 	} catch (error) {
-		installErrors.push(error instanceof Error ? error.message : String(error));
-		return runtimeConvergenceWithoutApply({
-			load,
-			paths,
-			workspaceRoot,
-			enabledRuntimes,
-			installErrors,
-			projectedProviderIds: retainPreviousProjectedProviderIds(),
-		});
+		state.installErrors.push(error instanceof Error ? error.message : String(error));
+		return { result: runtimeConvergenceFailure(context, state) };
 	}
 
-	const coldInstallPlan = runtimeColdInstallMutationPlan(manifest, paths, observations);
-	const rollbackSnapshots = new RuntimeSnapshotRollbackStack();
+	const coldInstallPlan = runtimeColdInstallMutationPlan(manifest, paths, state.observations);
 	if (coldInstallPlan) {
-		rollbackSnapshots.capture("runtime installer rollback failed", coldInstallPlan.snapshot);
+		state.rollbackSnapshots.capture("runtime installer rollback failed", coldInstallPlan.snapshot);
 	}
-	const pluginBootstrapPlan = managedOpenClawPluginBootstrapMutationPlan(openClawContext, paths);
-	const rollbackInstallFailure = (error: unknown): RuntimeConvergenceResult => {
-		installErrors.push(...rollbackSnapshots.restore());
-		const message = error instanceof Error ? error.message : String(error);
-		if (!installErrors.includes(message)) installErrors.unshift(message);
-		return runtimeConvergenceWithoutApply({
-			load,
-			paths,
-			workspaceRoot,
-			enabledRuntimes,
-			installErrors,
-			projectedProviderIds: retainPreviousProjectedProviderIds(),
-		});
-	};
+	const pluginBootstrapPlan = managedOpenClawPluginBootstrapMutationPlan(
+		context.openClawContext,
+		paths,
+	);
 	try {
 		if (coldInstallPlan) {
 			hostedRuntimeContract.assertPlatformRoots();
@@ -326,17 +457,18 @@ export function convergeRuntimeManifest(
 		}
 		for (const [name, runtime] of runtimeEntries) {
 			const observation = observeRuntimeInstall(name, runtime, projectionHome);
-			observations.set(name, observation);
-			if (observation.error) installErrors.push(observation.error);
-			if (name === "openclaw") openClawContext.refreshSdkExports(observation);
+			state.observations.set(name, observation);
+			if (observation.error) state.installErrors.push(observation.error);
+			if (name === "openclaw") context.openClawContext.refreshSdkExports(observation);
 			if (name === "openclaw" && observation.enabled && observation.commandPath) {
-				openClawOwnerBrowserBootstrapSupported =
-					openClawSupportsOwnerBrowserBootstrap(openClawContext);
+				state.openClawOwnerBrowserBootstrapSupported = openClawSupportsOwnerBrowserBootstrap(
+					context.openClawContext,
+				);
 			}
 		}
-		if (installErrors.length > 0) throw new Error(installErrors.join("; "));
+		if (state.installErrors.length > 0) throw new Error(state.installErrors.join("; "));
 		if (pluginBootstrapPlan) {
-			rollbackSnapshots.capture(
+			state.rollbackSnapshots.capture(
 				"OpenClaw managed provider plugin rollback failed",
 				pluginBootstrapPlan,
 			);
@@ -348,9 +480,29 @@ export function convergeRuntimeManifest(
 			);
 		}
 	} catch (error) {
-		return rollbackInstallFailure(error);
+		return { result: rollbackRuntimeInstallFailure(context, state, error) };
 	}
+	return { stage: { previousInstallReceipts, coldInstallPlan, pluginBootstrapPlan } };
+}
 
+function prepareRuntimeConvergencePlan(
+	context: RuntimeConvergenceContext,
+	state: RuntimeConvergenceState,
+	installStage: RuntimeInstallStage,
+): { plan: RuntimeConvergencePlan } | { result: RuntimeConvergenceResult } {
+	const {
+		manifest,
+		paths,
+		projectionHome,
+		openClawContext,
+		openClawSkillDriver,
+		secretValues,
+		previousProjectedProviderIds,
+		hermesWhatsAppAuthDir,
+		workspaceRoot,
+		generatedAt,
+		plannedEgressProfileBundlePath,
+	} = context;
 	let openClawWorkspaceRoot: string | null;
 	let plannedRuntimePrograms: RuntimeSystemdUserProgram[];
 	let mutationPlan: ReturnType<typeof runtimeManagedMutationPlan>;
@@ -371,10 +523,10 @@ export function convergeRuntimeManifest(
 			paths,
 			openClawWorkspaceRoot,
 			secretValues,
-			observations,
+			observations: state.observations,
 			previousProjectedProviderIds,
 			hermesWhatsAppAuthDir,
-			openClawOwnerBrowserBootstrapSupported,
+			openClawOwnerBrowserBootstrapSupported: state.openClawOwnerBrowserBootstrapSupported,
 		});
 		plannedRuntimePrograms = planRuntimeSystemdUserPrograms({
 			manifest,
@@ -382,7 +534,7 @@ export function convergeRuntimeManifest(
 			workspaceRoot,
 			generatedAt,
 			secretValues,
-			observations,
+			observations: state.observations,
 			egressProfileBundlePath: plannedEgressProfileBundlePath,
 			egress: null,
 		});
@@ -393,14 +545,14 @@ export function convergeRuntimeManifest(
 			openClawWorkspaceRoot,
 			openClawContext,
 			programs: plannedRuntimePrograms,
-			observations,
+			observations: state.observations,
 		});
 	} catch (error) {
-		throw rollbackSnapshots.failure(error);
+		throw state.rollbackSnapshots.failure(error);
 	}
-	if (pluginBootstrapPlan) {
+	if (installStage.pluginBootstrapPlan) {
 		try {
-			const observation = observations.get("openclaw");
+			const observation = state.observations.get("openclaw");
 			if (!observation?.commandPath) {
 				throw new Error("OpenClaw managed provider plugin requires an installed runtime");
 			}
@@ -409,517 +561,676 @@ export function convergeRuntimeManifest(
 				commandPath: observation.commandPath,
 			});
 		} catch (error) {
-			return rollbackInstallFailure(error);
+			return { result: rollbackRuntimeInstallFailure(context, state, error) };
 		}
 	}
 	if (mutationPlan.systemdDriftErrors.length > 0) {
-		installErrors.push(...rollbackSnapshots.restore());
-		installErrors.push(...mutationPlan.systemdDriftErrors);
-		return runtimeConvergenceWithoutApply({
-			load,
-			paths,
-			workspaceRoot,
-			enabledRuntimes,
-			installErrors,
-			projectedProviderIds: retainPreviousProjectedProviderIds(),
-		});
+		state.installErrors.push(...state.rollbackSnapshots.restore());
+		state.installErrors.push(...mutationPlan.systemdDriftErrors);
+		return { result: runtimeConvergenceFailure(context, state) };
 	}
 	const workspaceExistedBeforeApply = withRuntimeUserFileAccess(() => existsSync(workspaceRoot));
-	let liveSnapshot: ReturnType<typeof captureRuntimeLiveSnapshot>;
+	let liveSnapshot: RuntimeLiveSnapshot;
 	try {
 		let snapshotPlan = mutationPlan.snapshot;
-		if (coldInstallPlan) {
-			snapshotPlan = excludeRuntimeSnapshotCoverage(snapshotPlan, coldInstallPlan.snapshot);
+		if (installStage.coldInstallPlan) {
+			snapshotPlan = excludeRuntimeSnapshotCoverage(
+				snapshotPlan,
+				installStage.coldInstallPlan.snapshot,
+			);
 		}
-		if (pluginBootstrapPlan) {
-			snapshotPlan = excludeRuntimeSnapshotCoverage(snapshotPlan, pluginBootstrapPlan);
+		if (installStage.pluginBootstrapPlan) {
+			snapshotPlan = excludeRuntimeSnapshotCoverage(snapshotPlan, installStage.pluginBootstrapPlan);
 		}
-		liveSnapshot = rollbackSnapshots.capture("runtime filesystem rollback failed", snapshotPlan);
+		liveSnapshot = state.rollbackSnapshots.capture(
+			"runtime filesystem rollback failed",
+			snapshotPlan,
+		);
 	} catch (error) {
-		throw rollbackSnapshots.failure(error);
+		throw state.rollbackSnapshots.failure(error);
 	}
 	// Resource snapshots live below tenant-owned roots and restore before the
 	// platform-root assertion that guards every earlier snapshot.
-	const resourceRollbackScope = rollbackSnapshots.scope();
-	let systemdActivationApplied = false;
-	let restartDaemon = false;
-	let desiredDaemonAuthTokenRevision: string | undefined;
-	let desiredDaemonProgramRevision: string | undefined;
-	let restartEgressSidecar = false;
-	let desiredEgressSidecarSecretRevision: string | undefined;
-	let rollbackEgressSecretOverride: RuntimeEgressSecretMaterial | undefined;
-	let rollbackEgressSecretRevision: string | undefined;
-	let egressRollbackAuthorityVerified = true;
-	let staleSystemdFiles: RuntimeSystemdStaleFilePlan = {
-		files: [],
-		systemUnits: [],
-		userUnits: [],
+	const resourceRollbackScope = state.rollbackSnapshots.scope();
+	return {
+		plan: {
+			...installStage,
+			openClawWorkspaceRoot,
+			plannedRuntimePrograms,
+			mutationPlan,
+			workspaceExistedBeforeApply,
+			liveSnapshot,
+			resourceRollbackScope,
+		},
 	};
-	try {
-		hostedRuntimeContract.assertPlatformRoots();
-		// Runtime-user targets and their ancestor metadata are already in the
-		// exact pre-image snapshot. Establish their positive ownership boundary
-		// before any official installer or CLI command drops privilege. Modes are
-		// intentionally preserved, so private runtime state stays private.
-		enforceRuntimeUserOwnership(mutationPlan.runtimeUserOwnership);
-		const fileBrowserInstall = ensureFileBrowserCompanion(
-			manifest,
-			paths,
-			previousInstallReceipts?.companions.filebrowser,
-			opts.fileBrowserInstallOptions,
-		);
-		if (fileBrowserInstall) {
-			installReceiptTargets.companions.set(
-				fileBrowserInstall.receiptKey,
-				fileBrowserInstall.receiptTarget,
-			);
-		}
-		const openClawObservation = observations.get("openclaw");
-		if (openClawObservation) {
-			try {
-				ensureHostedOpenClawProviderAuthCapability({
-					manifest,
-					secretValues,
-					context: openClawContext,
-				});
-			} catch (error) {
-				installErrors.push(
-					`runtime openclaw credential capability check failed: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
-				);
-			}
-		}
-		if (installErrors.length > 0) throw new Error(installErrors.join("; "));
-		const managedOpenClawObservation = observations.get("openclaw");
-		if (managedOpenClawObservation && openClawContext.managedApiKeyProjection) {
-			openClawContext.agentDirs.managed =
-				discoverOpenClawManagedProviderAuthAgentDirs(openClawContext);
-			const supplementalTargets = openClawContext.agentDirs.managed.filter(
-				(path) => !liveSnapshot.entries.has(path),
-			);
-			if (supplementalTargets.length > 0) {
-				const supplementalSnapshot = captureRuntimeLiveSnapshot({
-					rootTargets: [],
-					trustedRootDirectories: [],
-					runtimeUserTargets: supplementalTargets,
-					runtimeUserTrustedRoots: [paths.userHome, paths.clawdiHome],
-					runtimeUserSymlinkTargets: [],
-					metadataTargets: [],
-				});
-				for (const [path, node] of supplementalSnapshot.entries) {
-					if (!liveSnapshot.entries.has(path)) liveSnapshot.entries.set(path, node);
-				}
-				enforceRuntimeUserOwnership(runtimeUserExistingOwnership(supplementalTargets));
-			}
-		}
-		if (
-			openClawWorkspaceRoot &&
-			resolve(openClawSkillDriver.resolveWorkspace({ home: projectionHome })) !==
-				resolve(openClawWorkspaceRoot)
-		) {
-			throw new Error("OpenClaw official agent workspace changed during runtime reconciliation");
-		}
-		if (opts.preparedHostedAgentPlugins) {
-			const commands = hostedAgentPluginCommands(projectionHome);
-			let planned: ReturnType<typeof planHostedAgentPluginConvergence>;
-			try {
-				planned = planHostedAgentPluginConvergence({
-					prepared: opts.preparedHostedAgentPlugins,
-					home: projectionHome,
-					commands,
-					...(opts.hostedAgentPluginCommandRunner
-						? { runner: opts.hostedAgentPluginCommandRunner }
-						: {}),
-				});
-			} catch (error) {
-				for (const name of opts.preparedHostedAgentPlugins.desired.keys()) {
-					agentPluginFailedNames.add(name);
-				}
-				resourceProjectionErrors.push(
-					`runtime Agent Plugin projection planning failed: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
-				);
-				planned = { transaction: null };
-			}
-			agentPluginTransaction = planned.transaction;
-			if (agentPluginTransaction?.hasMutations && !opts.systemdApply) {
-				throw new Error("Agent Plugin mutations require systemd activation and readiness");
-			}
-		}
+}
 
-		hostedRuntimeContract.assertPlatformRoots();
-		let codexCli: Record<string, string> | null = null;
-		if (
-			hostedCodexManagedProvider(manifest) ||
-			manifest.projection?.sourceSchemaVersion === "clawdi.hosted-runtime.manifest.v1"
-		) {
-			try {
-				codexCli = ensureHostedCodexCli(paths);
-			} catch (error) {
-				installErrors.push(
-					`runtime codex setup failed: ${error instanceof Error ? error.message : String(error)}`,
-				);
-			}
-		}
-		for (const [name] of runtimeEntries) {
-			const observation = observations.get(name);
-			if (!observation) throw new Error(`runtime ${name} install observation is missing`);
-			try {
-				installHostedChannelProjectionDependencies(
-					name,
-					observation,
-					manifest,
-					projectionHome,
-					paths.userHome,
-					previousInstallReceipts,
-					installReceiptTargets,
-				);
-			} catch (error) {
-				installErrors.push(
-					`runtime ${name} channel plugin install failed: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
-				);
-			}
-		}
-		const managedWhatsAppRuntime = managedWhatsAppCompatibilityRuntime(manifest);
+function prepareRuntimeApplyDependencies(
+	context: RuntimeConvergenceContext,
+	state: RuntimeConvergenceState,
+	plan: RuntimeConvergencePlan,
+): Record<string, string> | null {
+	const {
+		manifest,
+		paths,
+		opts,
+		secretValues,
+		hostedRuntimeContract,
+		projectionHome,
+		openClawContext,
+		openClawSkillDriver,
+		workspaceRoot,
+		instanceRoot,
+		runtimeEntries,
+	} = context;
+	hostedRuntimeContract.assertPlatformRoots();
+	// Runtime-user targets and their ancestor metadata are already in the
+	// exact pre-image snapshot. Establish their positive ownership boundary
+	// before any official installer or CLI command drops privilege. Modes are
+	// intentionally preserved, so private runtime state stays private.
+	enforceRuntimeUserOwnership(plan.mutationPlan.runtimeUserOwnership);
+	const fileBrowserInstall = ensureFileBrowserCompanion(
+		manifest,
+		paths,
+		plan.previousInstallReceipts?.companions.filebrowser,
+		opts.fileBrowserInstallOptions,
+	);
+	if (fileBrowserInstall) {
+		state.installReceiptTargets.companions.set(
+			fileBrowserInstall.receiptKey,
+			fileBrowserInstall.receiptTarget,
+		);
+	}
+	const openClawObservation = state.observations.get("openclaw");
+	if (openClawObservation) {
 		try {
-			const observation = managedWhatsAppRuntime
-				? observations.get(managedWhatsAppRuntime)
-				: undefined;
-			if (managedWhatsAppRuntime && !observation?.appRoot) {
-				throw new Error(`runtime ${managedWhatsAppRuntime} artifact root is unavailable`);
-			}
-			const compatibility = reconcileManagedBaileysCompatibility({
-				desiredRuntime: managedWhatsAppRuntime,
-				home: projectionHome,
-				...(observation?.appRoot ? { appRoot: observation.appRoot } : {}),
-				paths,
+			ensureHostedOpenClawProviderAuthCapability({
+				manifest,
+				secretValues,
+				context: openClawContext,
 			});
-			if (compatibility.status === "rollback-refused") {
-				throw new Error(compatibility.errors.join(", "));
-			}
 		} catch (error) {
-			const operation = managedWhatsAppRuntime
-				? `runtime ${managedWhatsAppRuntime} managed WhatsApp compatibility`
-				: "runtime managed WhatsApp compatibility cleanup";
-			installErrors.push(
-				`${operation} failed: ${error instanceof Error ? error.message : String(error)}`,
-			);
-		}
-		if (installErrors.length > 0) throw new Error(installErrors.join("; "));
-
-		hostedRuntimeContract.assertPlatformRoots();
-		enforceRuntimeUserOwnership(runtimeUserDirectoryOwnership(paths.userHome));
-		ensureRuntimeUserCliStateRoot(paths.clawdiHome, hostedRuntimeContract.identity);
-		withRuntimeUserFileAccess(() => {
-			mkdirSync(workspaceRoot, { recursive: true });
-			makeRuntimeUserOwned(workspaceRoot);
-		});
-		for (const directory of [paths.installInventory, paths.projectionRoot, instanceRoot]) {
-			ensureRuntimePlatformDirectory(paths, directory, { mode: 0o755 });
-		}
-		ensureRuntimePlatformDirectory(paths, paths.managedSecretRoot);
-		makeManagedSecretRoot(paths.managedSecretRoot);
-		ensureRuntimePlatformDirectory(paths, paths.egressRoot, { mode: 0o711 });
-		chmodSync(paths.egressRoot, 0o711);
-		makeEgressIdentityPrivateDir(paths.egressCaDir);
-		ensureRuntimePlatformDirectory(paths, dirname(paths.egressSystemCaFile), { mode: 0o711 });
-		chmodSync(dirname(paths.egressSystemCaFile), 0o711);
-		enforceRuntimeUserOwnership(
-			runtimeUserDirectoryOwnership(paths.egressScratchRoot, { mode: 0o700 }),
-		);
-
-		let manifestLastGood: string | null = null;
-		writeJsonFile(
-			paths.managedConfig,
-			{
-				schemaVersion: "clawdi.hostedManagedConfig.v1",
-				generatedAt,
-				deploymentId: manifest.deploymentId,
-				environmentId: manifest.environmentId,
-				instanceId: manifest.instanceId,
-				generation: manifest.generation,
-				locale: manifest.locale ?? null,
-				controlPlane: manifest.controlPlane,
-				egressEngine: manifest.egressEngine ?? null,
-				auth: {
-					source: "runtime-instance-data",
-					token: "<redacted>",
-				},
-				workspaceRoot,
-			},
-			paths,
-		);
-		writeJsonFile(
-			paths.syncState,
-			{
-				schemaVersion: "clawdi.runtimeSyncState.v1",
-				generatedAt,
-				deploymentId: manifest.deploymentId,
-				environmentId: manifest.environmentId,
-				instanceId: manifest.instanceId,
-				generation: manifest.generation,
-				locale: manifest.locale ?? null,
-				runtimes: Object.fromEntries(
-					Object.entries(manifest.runtimes).map(([name, runtime]) => [
-						name,
-						{
-							enabled: runtime.enabled,
-							updateChannel: runtime.updateChannel ?? null,
-							workspaceRoot,
-						},
-					]),
-				),
-			},
-			paths,
-		);
-		writeJsonFile(
-			paths.instanceData,
-			{
-				schemaVersion: "clawdi.runtimeInstanceData.v1",
-				generatedAt,
-				deploymentId: manifest.deploymentId,
-				environmentId: manifest.environmentId,
-				instanceId: manifest.instanceId,
-				generation: manifest.generation,
-				locale: manifest.locale ?? null,
-				controlPlane: manifest.controlPlane,
-				workspaceRoot,
-			},
-			paths,
-		);
-		writeJsonFile(
-			paths.sensitiveInstanceData,
-			{
-				schemaVersion: "clawdi.runtimeSensitiveInstanceData.v1",
-				generatedAt,
-				tokenSource: runtimeSecretValue(secretValues ?? {}, RUNTIME_AUTH_TOKEN_SECRET_REF)
-					? "CLAWDI_AUTH_TOKEN"
-					: load.source,
-				token: "<redacted>",
-			},
-			paths,
-		);
-
-		const egressProfileBundlePath = hasEnabledEgressProfiles(egressProfileBundle)
-			? writeEgressProfileBundle(egressProfileBundle, paths)
-			: clearEgressProfileBundle(paths);
-		const egressEngine = writeEgressEngineStatus(
-			egressProfileBundlePath
-				? ensureRuntimeMitmproxy(manifest.egressEngine, paths, opts.egressEngineEnsureOptions)
-				: null,
-			paths,
-		);
-		requireV2EgressEngineReady(manifest, egressProfileBundlePath, egressEngine);
-		const egressAddon = egressProfileBundlePath ? writeEgressAddon(paths) : clearEgressAddon(paths);
-		const daemonAuthTokenFile = writeDaemonAuthToken(paths, secretValues);
-		const runtimeAuthToken = daemonAuthTokenFile ? readRuntimeAuthToken(paths) : null;
-		if (runtimeAuthToken) {
-			desiredDaemonAuthTokenRevision = daemonAuthTokenRevision(runtimeAuthToken);
-			desiredDaemonProgramRevision = daemonProgramRevision(manifest);
-			restartDaemon =
-				desiredDaemonAuthTokenRevision !== appliedState?.daemonAuthTokenRevision ||
-				desiredDaemonProgramRevision !== appliedState?.daemonProgramRevision;
-		}
-		try {
-			withRuntimeUserFileAccess(() =>
-				materializeHostedChannelCredentials(manifest, secretValues, projectionHome),
-			);
-		} catch (error) {
-			installErrors.push(
-				`runtime channel credential materialization failed: ${
+			state.installErrors.push(
+				`runtime openclaw credential capability check failed: ${
 					error instanceof Error ? error.message : String(error)
 				}`,
 			);
 		}
-		const egressSecretWrite = writeEgressSecretFile(manifest, secretValues, paths);
-		const egressSecretFile = egressSecretWrite.path;
-		const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
-		const resolvedSystemdIdentity = resolveRuntimeSystemdIdentity({
-			paths,
-			profileBundlePath: egressProfileBundlePath,
-			secretFilePath: egressSecretFile,
-			engine: egressEngine,
-			addon: egressAddon,
-			runtimeUser,
-		});
-		const egressSystemdProgram = resolvedSystemdIdentity.egressProgram;
-		const egressIdentity = resolvedSystemdIdentity.identity;
-		const runtimeUid = egressIdentity?.runtimeUid ?? 0;
-		const runtimeGid = egressIdentity?.runtimeGid ?? 0;
-		const egressUid = egressIdentity?.egressUid ?? 0;
-		const egressGid = egressIdentity?.egressGid ?? 0;
-		const egressTransparentEnv = writeTransparentEgressEnvFile({
-			program: egressSystemdProgram,
-			paths,
-			runtimeUser,
-			runtimeUid,
-			runtimeGid,
-			egressUid,
-			egressGid,
-		});
-		writeProviderHealthStatus(manifest, load.secretValues, paths);
-		const liveSyncEnvironments = writeLiveSyncEnvironmentFiles(manifest, paths);
-		const writtenRunConfigIds = new Set<string>();
-		runtimeSystemdUserPrograms.push(
-			...planRuntimeSystemdUserPrograms({
-				manifest,
-				paths,
-				workspaceRoot,
-				generatedAt,
-				secretValues,
-				observations,
-				egressProfileBundlePath,
-				egress: egressSystemdProgram,
-			}),
+	}
+	if (state.installErrors.length > 0) throw new Error(state.installErrors.join("; "));
+	const managedOpenClawObservation = state.observations.get("openclaw");
+	if (managedOpenClawObservation && openClawContext.managedApiKeyProjection) {
+		openClawContext.agentDirs.managed =
+			discoverOpenClawManagedProviderAuthAgentDirs(openClawContext);
+		const supplementalTargets = openClawContext.agentDirs.managed.filter(
+			(path) => !plan.liveSnapshot.entries.has(path),
 		);
-		const egressSidecarActive =
-			egressSystemdProgram !== null &&
-			egressIdentity !== null &&
-			runtimeSystemdUserPrograms.length > 0;
-		const committedEgressSidecarSecretRevision = appliedState?.egressSidecarSecretRevision;
-		if (egressSidecarActive) {
-			desiredEgressSidecarSecretRevision = egressSecretWrite.material.revision;
-			restartEgressSidecar =
-				egressSecretWrite.changed ||
-				committedEgressSidecarSecretRevision === undefined ||
-				committedEgressSidecarSecretRevision !== desiredEgressSidecarSecretRevision;
-			if (committedEgressSidecarSecretRevision === undefined) {
-				// Legacy applied state has no private egress revision. An exact
-				// applied content identity can still prove complete last-good material
-				// for rollback, but its absence must not block loading the desired
-				// material. If desired activation later fails, unverified live bytes
-				// must never be loaded by a rollback restart.
-				rollbackEgressSecretOverride =
-					verifiedCommittedEgressSecretMaterial(paths, applyContext) ?? undefined;
-				egressRollbackAuthorityVerified = rollbackEgressSecretOverride !== undefined;
-			} else if (
-				restartEgressSidecar &&
-				egressSecretWrite.previousRevision !== committedEgressSidecarSecretRevision
-			) {
-				if (desiredEgressSidecarSecretRevision === committedEgressSidecarSecretRevision) {
-					rollbackEgressSecretOverride = egressSecretWrite.material;
-				} else {
-					// A crash may have already advanced both the live file and last-good
-					// cache while the applied authority still describes the loaded secret.
-					// Do not require rollback material until activation actually fails:
-					// successfully restarting the desired material can safely commit it.
-					rollbackEgressSecretRevision = committedEgressSidecarSecretRevision;
-				}
+		if (supplementalTargets.length > 0) {
+			const supplementalSnapshot = captureRuntimeLiveSnapshot({
+				rootTargets: [],
+				trustedRootDirectories: [],
+				runtimeUserTargets: supplementalTargets,
+				runtimeUserTrustedRoots: [paths.userHome, paths.clawdiHome],
+				runtimeUserSymlinkTargets: [],
+				metadataTargets: [],
+			});
+			for (const [path, node] of supplementalSnapshot.entries) {
+				if (!plan.liveSnapshot.entries.has(path)) plan.liveSnapshot.entries.set(path, node);
 			}
+			enforceRuntimeUserOwnership(runtimeUserExistingOwnership(supplementalTargets));
 		}
-		const commonSystemdEnvironment = runtimeSystemdCommonEnvironment(paths);
+	}
+	if (
+		plan.openClawWorkspaceRoot &&
+		resolve(openClawSkillDriver.resolveWorkspace({ home: projectionHome })) !==
+			resolve(plan.openClawWorkspaceRoot)
+	) {
+		throw new Error("OpenClaw official agent workspace changed during runtime reconciliation");
+	}
+	if (opts.preparedHostedAgentPlugins) {
+		const commands = hostedAgentPluginCommands(projectionHome);
+		let planned: ReturnType<typeof planHostedAgentPluginConvergence>;
+		try {
+			planned = planHostedAgentPluginConvergence({
+				prepared: opts.preparedHostedAgentPlugins,
+				home: projectionHome,
+				commands,
+				...(opts.hostedAgentPluginCommandRunner
+					? { runner: opts.hostedAgentPluginCommandRunner }
+					: {}),
+			});
+		} catch (error) {
+			for (const name of opts.preparedHostedAgentPlugins.desired.keys()) {
+				state.agentPluginFailedNames.add(name);
+			}
+			state.resourceProjectionErrors.push(
+				`runtime Agent Plugin projection planning failed: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			planned = { transaction: null };
+		}
+		state.agentPluginTransaction = planned.transaction;
+		if (state.agentPluginTransaction?.hasMutations && !opts.systemdApply) {
+			throw new Error("Agent Plugin mutations require systemd activation and readiness");
+		}
+	}
 
-		validateRuntimeProjectionPlan({
-			manifest,
-			paths,
-			openClawWorkspaceRoot,
-			secretValues,
-			observations,
-			previousProjectedProviderIds,
-			hermesWhatsAppAuthDir,
-			openClawOwnerBrowserBootstrapSupported,
-		});
-		const providerProjectionRevisions: Partial<Record<string, string | null>> = {};
-		for (const [name] of runtimeEntries) {
-			const observation = observations.get(name);
-			if (!observation) throw new Error(`runtime ${name} install observation is missing`);
-			providerProjectionRevisions[name] = previewHostedAiProviderProjectionRevision(
+	hostedRuntimeContract.assertPlatformRoots();
+	let codexCli: Record<string, string> | null = null;
+	if (
+		hostedCodexManagedProvider(manifest) ||
+		manifest.projection?.sourceSchemaVersion === "clawdi.hosted-runtime.manifest.v1"
+	) {
+		try {
+			codexCli = ensureHostedCodexCli(paths);
+		} catch (error) {
+			state.installErrors.push(
+				`runtime codex setup failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
+	for (const [name] of runtimeEntries) {
+		const observation = state.observations.get(name);
+		if (!observation) throw new Error(`runtime ${name} install observation is missing`);
+		try {
+			installHostedChannelProjectionDependencies(
 				name,
 				observation,
 				manifest,
 				projectionHome,
-				previousProjectedProviderIds[name] ?? [],
+				paths.userHome,
+				plan.previousInstallReceipts,
+				state.installReceiptTargets,
 			);
-		}
-		try {
-			const codexProjection = withRuntimeUserFileAccess(() =>
-				applyHostedCodexManagedProviderProjection(manifest, projectionHome, codexCli),
-			);
-			providerProjectionRevisions.codex = codexProjection.revision;
-			projectedProviderIds.codex = codexProjection.providerIds;
 		} catch (error) {
-			installErrors.push(
-				`runtime codex provider projection failed: ${
+			state.installErrors.push(
+				`runtime ${name} channel plugin install failed: ${
 					error instanceof Error ? error.message : String(error)
 				}`,
 			);
 		}
-		if (installErrors.length > 0) {
-			throw new Error(installErrors.join("; "));
+	}
+	const managedWhatsAppRuntime = managedWhatsAppCompatibilityRuntime(manifest);
+	try {
+		const observation = managedWhatsAppRuntime
+			? state.observations.get(managedWhatsAppRuntime)
+			: undefined;
+		if (managedWhatsAppRuntime && !observation?.appRoot) {
+			throw new Error(`runtime ${managedWhatsAppRuntime} artifact root is unavailable`);
 		}
-		if (sourcedSkillsPrepared) {
-			let skillProjectionScope: ReturnType<typeof rollbackSnapshots.captureScoped> | null = null;
-			try {
-				const skillMutationTargets = hostedSkillMutationTargets(
-					manifest,
-					projectionHome,
-					openClawWorkspaceRoot,
-					paths.managedResourceRoot,
-				);
-				skillProjectionScope = rollbackSnapshots.captureScoped(
-					"runtime Skill filesystem rollback failed",
+		const compatibility = reconcileManagedBaileysCompatibility({
+			desiredRuntime: managedWhatsAppRuntime,
+			home: projectionHome,
+			...(observation?.appRoot ? { appRoot: observation.appRoot } : {}),
+			paths,
+		});
+		if (compatibility.status === "rollback-refused") {
+			throw new Error(compatibility.errors.join(", "));
+		}
+	} catch (error) {
+		const operation = managedWhatsAppRuntime
+			? `runtime ${managedWhatsAppRuntime} managed WhatsApp compatibility`
+			: "runtime managed WhatsApp compatibility cleanup";
+		state.installErrors.push(
+			`${operation} failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (state.installErrors.length > 0) throw new Error(state.installErrors.join("; "));
+
+	hostedRuntimeContract.assertPlatformRoots();
+	enforceRuntimeUserOwnership(runtimeUserDirectoryOwnership(paths.userHome));
+	ensureRuntimeUserCliStateRoot(paths.clawdiHome, hostedRuntimeContract.identity);
+	withRuntimeUserFileAccess(() => {
+		mkdirSync(workspaceRoot, { recursive: true });
+		makeRuntimeUserOwned(workspaceRoot);
+	});
+	for (const directory of [paths.installInventory, paths.projectionRoot, instanceRoot]) {
+		ensureRuntimePlatformDirectory(paths, directory, { mode: 0o755 });
+	}
+	ensureRuntimePlatformDirectory(paths, paths.managedSecretRoot);
+	makeManagedSecretRoot(paths.managedSecretRoot);
+	ensureRuntimePlatformDirectory(paths, paths.egressRoot, { mode: 0o711 });
+	chmodSync(paths.egressRoot, 0o711);
+	makeEgressIdentityPrivateDir(paths.egressCaDir);
+	ensureRuntimePlatformDirectory(paths, dirname(paths.egressSystemCaFile), { mode: 0o711 });
+	chmodSync(dirname(paths.egressSystemCaFile), 0o711);
+	enforceRuntimeUserOwnership(
+		runtimeUserDirectoryOwnership(paths.egressScratchRoot, { mode: 0o700 }),
+	);
+	return codexCli;
+}
+
+function writeRuntimeManifestState(context: RuntimeConvergenceContext): void {
+	const { load, manifest, paths, generatedAt, workspaceRoot } = context;
+	writeJsonFile(
+		paths.managedConfig,
+		{
+			schemaVersion: "clawdi.hostedManagedConfig.v1",
+			generatedAt,
+			deploymentId: manifest.deploymentId,
+			environmentId: manifest.environmentId,
+			instanceId: manifest.instanceId,
+			generation: manifest.generation,
+			locale: manifest.locale ?? null,
+			controlPlane: manifest.controlPlane,
+			egressEngine: manifest.egressEngine ?? null,
+			auth: { source: "runtime-instance-data", token: "<redacted>" },
+			workspaceRoot,
+		},
+		paths,
+	);
+	writeJsonFile(
+		paths.syncState,
+		{
+			schemaVersion: "clawdi.runtimeSyncState.v1",
+			generatedAt,
+			deploymentId: manifest.deploymentId,
+			environmentId: manifest.environmentId,
+			instanceId: manifest.instanceId,
+			generation: manifest.generation,
+			locale: manifest.locale ?? null,
+			runtimes: Object.fromEntries(
+				Object.entries(manifest.runtimes).map(([name, runtime]) => [
+					name,
 					{
-						rootTargets: [
-							managedSkillReservationLedgerPath(),
-							...skillMutationTargets.platformTargets,
-						],
-						trustedRootDirectories: [paths.managedResourceRoot],
-						runtimeUserTargets: skillMutationTargets.runtimeUserTargets,
-						runtimeUserTrustedRoots: [paths.userHome, paths.clawdiHome],
-						runtimeUserSymlinkTargets: [],
-						metadataTargets: mutationAncestorMetadataTargets(
-							skillMutationTargets.runtimeUserTargets,
-							[paths.userHome, paths.clawdiHome],
-						),
+						enabled: runtime.enabled,
+						updateChannel: runtime.updateChannel ?? null,
+						workspaceRoot,
 					},
-				);
-				resourceProjectionErrors.push(
-					...reconcileHostedSkillProjection({
-						manifest,
-						observations,
-						home: projectionHome,
-						managedResourceRoot: paths.managedResourceRoot,
-						openClawWorkspaceRoot,
-						preparedSourcedSkills: preparedHostedSourcedSkills,
-						hermesDriver: hermesSkillNativeReconciler,
-						openClawDriver: openClawSkillDriver,
-					}),
-				);
-			} catch (error) {
-				const projectionError = error instanceof Error ? error.message : String(error);
-				const rollbackErrors = skillProjectionScope
-					? rollbackSnapshots.restore(skillProjectionScope, (_failure, rollbackError) =>
-							rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
-						)
-					: [];
-				if (rollbackErrors.length > 0) {
-					throw new Error(
-						`runtime Skill projection failed and could not be rolled back: ${projectionError}; ${rollbackErrors.join("; ")}`,
-					);
-				}
-				resourceProjectionErrors.push(projectionError);
+				]),
+			),
+		},
+		paths,
+	);
+	writeJsonFile(
+		paths.instanceData,
+		{
+			schemaVersion: "clawdi.runtimeInstanceData.v1",
+			generatedAt,
+			deploymentId: manifest.deploymentId,
+			environmentId: manifest.environmentId,
+			instanceId: manifest.instanceId,
+			generation: manifest.generation,
+			locale: manifest.locale ?? null,
+			controlPlane: manifest.controlPlane,
+			workspaceRoot,
+		},
+		paths,
+	);
+	writeJsonFile(
+		paths.sensitiveInstanceData,
+		{
+			schemaVersion: "clawdi.runtimeSensitiveInstanceData.v1",
+			generatedAt,
+			tokenSource: runtimeSecretValue(context.secretValues ?? {}, RUNTIME_AUTH_TOKEN_SECRET_REF)
+				? "CLAWDI_AUTH_TOKEN"
+				: load.source,
+			token: "<redacted>",
+		},
+		paths,
+	);
+}
+
+interface RuntimeEgressProjection {
+	egressProfileBundlePath: ReturnType<typeof writeEgressProfileBundle> | null;
+	egressEngine: ReturnType<typeof writeEgressEngineStatus>;
+	egressAddon: ReturnType<typeof writeEgressAddon> | null;
+	daemonAuthTokenFile: ReturnType<typeof writeDaemonAuthToken>;
+	egressSecretFile: ReturnType<typeof writeEgressSecretFile>["path"];
+	egressSystemdProgram: ReturnType<typeof resolveRuntimeSystemdIdentity>["egressProgram"];
+	egressIdentity: ReturnType<typeof resolveRuntimeSystemdIdentity>["identity"];
+	egressTransparentEnv: ReturnType<typeof writeTransparentEgressEnvFile>;
+	liveSyncEnvironments: ReturnType<typeof writeLiveSyncEnvironmentFiles>;
+	writtenRunConfigIds: Set<string>;
+	commonSystemdEnvironment: ReturnType<typeof runtimeSystemdCommonEnvironment>;
+}
+
+function prepareRuntimeEgressProjection(
+	context: RuntimeConvergenceContext,
+	state: RuntimeConvergenceState,
+): RuntimeEgressProjection {
+	const {
+		load,
+		manifest,
+		paths,
+		opts,
+		secretValues,
+		applyContext,
+		projectionHome,
+		workspaceRoot,
+		generatedAt,
+		egressProfileBundle,
+		appliedState,
+	} = context;
+	const egressProfileBundlePath = hasEnabledEgressProfiles(egressProfileBundle)
+		? writeEgressProfileBundle(egressProfileBundle, paths)
+		: clearEgressProfileBundle(paths);
+	const egressEngine = writeEgressEngineStatus(
+		egressProfileBundlePath
+			? ensureRuntimeMitmproxy(manifest.egressEngine, paths, opts.egressEngineEnsureOptions)
+			: null,
+		paths,
+	);
+	requireV2EgressEngineReady(manifest, egressProfileBundlePath, egressEngine);
+	const egressAddon = egressProfileBundlePath ? writeEgressAddon(paths) : clearEgressAddon(paths);
+	const daemonAuthTokenFile = writeDaemonAuthToken(paths, secretValues);
+	const runtimeAuthToken = daemonAuthTokenFile ? readRuntimeAuthToken(paths) : null;
+	if (runtimeAuthToken) {
+		state.desiredDaemonAuthTokenRevision = daemonAuthTokenRevision(runtimeAuthToken);
+		state.desiredDaemonProgramRevision = daemonProgramRevision(manifest);
+		state.restartDaemon =
+			state.desiredDaemonAuthTokenRevision !== appliedState?.daemonAuthTokenRevision ||
+			state.desiredDaemonProgramRevision !== appliedState?.daemonProgramRevision;
+	}
+	try {
+		withRuntimeUserFileAccess(() =>
+			materializeHostedChannelCredentials(manifest, secretValues, projectionHome),
+		);
+	} catch (error) {
+		state.installErrors.push(
+			`runtime channel credential materialization failed: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+	const egressSecretWrite = writeEgressSecretFile(manifest, secretValues, paths);
+	const egressSecretFile = egressSecretWrite.path;
+	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
+	const resolvedSystemdIdentity = resolveRuntimeSystemdIdentity({
+		paths,
+		profileBundlePath: egressProfileBundlePath,
+		secretFilePath: egressSecretFile,
+		engine: egressEngine,
+		addon: egressAddon,
+		runtimeUser,
+	});
+	const egressSystemdProgram = resolvedSystemdIdentity.egressProgram;
+	const egressIdentity = resolvedSystemdIdentity.identity;
+	const runtimeUid = egressIdentity?.runtimeUid ?? 0;
+	const runtimeGid = egressIdentity?.runtimeGid ?? 0;
+	const egressUid = egressIdentity?.egressUid ?? 0;
+	const egressGid = egressIdentity?.egressGid ?? 0;
+	const egressTransparentEnv = writeTransparentEgressEnvFile({
+		program: egressSystemdProgram,
+		paths,
+		runtimeUser,
+		runtimeUid,
+		runtimeGid,
+		egressUid,
+		egressGid,
+	});
+	writeProviderHealthStatus(manifest, load.secretValues, paths);
+	const liveSyncEnvironments = writeLiveSyncEnvironmentFiles(manifest, paths);
+	const writtenRunConfigIds = new Set<string>();
+	state.runtimeSystemdUserPrograms.push(
+		...planRuntimeSystemdUserPrograms({
+			manifest,
+			paths,
+			workspaceRoot,
+			generatedAt,
+			secretValues,
+			observations: state.observations,
+			egressProfileBundlePath,
+			egress: egressSystemdProgram,
+		}),
+	);
+	const egressSidecarActive =
+		egressSystemdProgram !== null &&
+		egressIdentity !== null &&
+		state.runtimeSystemdUserPrograms.length > 0;
+	const committedEgressSidecarSecretRevision = appliedState?.egressSidecarSecretRevision;
+	if (egressSidecarActive) {
+		state.desiredEgressSidecarSecretRevision = egressSecretWrite.material.revision;
+		state.restartEgressSidecar =
+			egressSecretWrite.changed ||
+			committedEgressSidecarSecretRevision === undefined ||
+			committedEgressSidecarSecretRevision !== state.desiredEgressSidecarSecretRevision;
+		if (committedEgressSidecarSecretRevision === undefined) {
+			// Legacy applied state has no private egress revision. An exact
+			// applied content identity can still prove complete last-good material
+			// for rollback, but its absence must not block loading the desired
+			// material. If desired activation later fails, unverified live bytes
+			// must never be loaded by a rollback restart.
+			state.rollbackEgressSecretOverride =
+				verifiedCommittedEgressSecretMaterial(paths, applyContext) ?? undefined;
+			state.egressRollbackAuthorityVerified = state.rollbackEgressSecretOverride !== undefined;
+		} else if (
+			state.restartEgressSidecar &&
+			egressSecretWrite.previousRevision !== committedEgressSidecarSecretRevision
+		) {
+			if (state.desiredEgressSidecarSecretRevision === committedEgressSidecarSecretRevision) {
+				state.rollbackEgressSecretOverride = egressSecretWrite.material;
+			} else {
+				// A crash may have already advanced both the live file and last-good
+				// cache while the applied authority still describes the loaded secret.
+				// Do not require rollback material until activation actually fails:
+				// successfully restarting the desired material can safely commit it.
+				state.rollbackEgressSecretRevision = committedEgressSidecarSecretRevision;
 			}
 		}
+	}
+	return {
+		egressProfileBundlePath,
+		egressEngine,
+		egressAddon,
+		daemonAuthTokenFile,
+		egressSecretFile,
+		egressSystemdProgram,
+		egressIdentity,
+		egressTransparentEnv,
+		liveSyncEnvironments,
+		writtenRunConfigIds,
+		commonSystemdEnvironment: runtimeSystemdCommonEnvironment(paths),
+	};
+}
+
+function applyRuntimeResourceProjections(
+	context: RuntimeConvergenceContext,
+	state: RuntimeConvergenceState,
+	plan: RuntimeConvergencePlan,
+	codexCli: Record<string, string> | null,
+): Partial<Record<string, string | null>> {
+	const {
+		manifest,
+		paths,
+		secretValues,
+		projectionHome,
+		openClawContext,
+		hermesWhatsAppAuthDir,
+		workspaceRoot,
+		previousProjectedProviderIds,
+		runtimeEntries,
+		preparedHostedSourcedSkills,
+		sourcedSkillsPrepared,
+		hermesSkillNativeReconciler,
+		openClawSkillDriver,
+	} = context;
+	// Capability repair and managed auth-target discovery can change the plan;
+	// this second validation is an intentional post-repair revalidation.
+	validateRuntimeProjectionPlan({
+		manifest,
+		paths,
+		openClawWorkspaceRoot: plan.openClawWorkspaceRoot,
+		secretValues,
+		observations: state.observations,
+		previousProjectedProviderIds,
+		hermesWhatsAppAuthDir,
+		openClawOwnerBrowserBootstrapSupported: state.openClawOwnerBrowserBootstrapSupported,
+	});
+	const providerProjectionRevisions: Partial<Record<string, string | null>> = {};
+	for (const [name] of runtimeEntries) {
+		const observation = state.observations.get(name);
+		if (!observation) throw new Error(`runtime ${name} install observation is missing`);
+		providerProjectionRevisions[name] = previewHostedAiProviderProjectionRevision(
+			name,
+			observation,
+			manifest,
+			projectionHome,
+			previousProjectedProviderIds[name] ?? [],
+		);
+	}
+	try {
+		const codexProjection = withRuntimeUserFileAccess(() =>
+			applyHostedCodexManagedProviderProjection(manifest, projectionHome, codexCli),
+		);
+		providerProjectionRevisions.codex = codexProjection.revision;
+		state.projectedProviderIds.codex = codexProjection.providerIds;
+	} catch (error) {
+		state.installErrors.push(
+			`runtime codex provider projection failed: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+	if (state.installErrors.length > 0) throw new Error(state.installErrors.join("; "));
+	if (sourcedSkillsPrepared) {
+		let skillProjectionScope: ReturnType<typeof state.rollbackSnapshots.captureScoped> | null =
+			null;
 		try {
-			applyHostedMcpProjections(manifest, paths, observations, workspaceRoot);
+			const skillMutationTargets = hostedSkillMutationTargets(
+				manifest,
+				projectionHome,
+				plan.openClawWorkspaceRoot,
+				paths.managedResourceRoot,
+			);
+			skillProjectionScope = state.rollbackSnapshots.captureScoped(
+				"runtime Skill filesystem rollback failed",
+				{
+					rootTargets: [
+						managedSkillReservationLedgerPath(),
+						...skillMutationTargets.platformTargets,
+					],
+					trustedRootDirectories: [paths.managedResourceRoot],
+					runtimeUserTargets: skillMutationTargets.runtimeUserTargets,
+					runtimeUserTrustedRoots: [paths.userHome, paths.clawdiHome],
+					runtimeUserSymlinkTargets: [],
+					metadataTargets: mutationAncestorMetadataTargets(
+						skillMutationTargets.runtimeUserTargets,
+						[paths.userHome, paths.clawdiHome],
+					),
+				},
+			);
+			state.resourceProjectionErrors.push(
+				...reconcileHostedSkillProjection({
+					manifest,
+					observations: state.observations,
+					home: projectionHome,
+					managedResourceRoot: paths.managedResourceRoot,
+					openClawWorkspaceRoot: plan.openClawWorkspaceRoot,
+					preparedSourcedSkills: preparedHostedSourcedSkills,
+					hermesDriver: hermesSkillNativeReconciler,
+					openClawDriver: openClawSkillDriver,
+				}),
+			);
 		} catch (error) {
-			installErrors.push(
-				`runtime MCP projection failed: ${error instanceof Error ? error.message : String(error)}`,
+			const projectionError = error instanceof Error ? error.message : String(error);
+			const rollbackErrors = skillProjectionScope
+				? state.rollbackSnapshots.restore(skillProjectionScope, (_failure, rollbackError) =>
+						rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
+					)
+				: [];
+			if (rollbackErrors.length > 0) {
+				throw new Error(
+					`runtime Skill projection failed and could not be rolled back: ${projectionError}; ${rollbackErrors.join("; ")}`,
+				);
+			}
+			state.resourceProjectionErrors.push(projectionError);
+		}
+	}
+	try {
+		applyHostedMcpProjections(manifest, paths, state.observations, workspaceRoot);
+	} catch (error) {
+		state.installErrors.push(
+			`runtime MCP projection failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (state.installErrors.length > 0) throw new Error(state.installErrors.join("; "));
+
+	for (const runtime of ["hermes", "openclaw"] as const) {
+		if (Object.hasOwn(manifest.runtimes, runtime)) continue;
+		try {
+			reconcileHostedRuntimeOAuthCredentials({
+				runtime,
+				manifest,
+				secretValues,
+				paths,
+				home: projectionHome,
+				openClawContext,
+				workspaceRoot,
+			});
+		} catch (error) {
+			state.installErrors.push(
+				`stale ${runtime} OAuth credential reconciliation failed: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
 			);
 		}
-		if (installErrors.length > 0) {
-			throw new Error(installErrors.join("; "));
-		}
+	}
+	if (state.installErrors.length > 0) throw new Error(state.installErrors.join("; "));
+	return providerProjectionRevisions;
+}
 
-		for (const runtime of ["hermes", "openclaw"] as const) {
-			if (Object.hasOwn(manifest.runtimes, runtime)) continue;
+function applyRuntimeEntryProjections(
+	context: RuntimeConvergenceContext,
+	state: RuntimeConvergenceState,
+	plan: RuntimeConvergencePlan,
+	egressProjection: RuntimeEgressProjection,
+): void {
+	const {
+		manifest,
+		paths,
+		secretValues,
+		projectionHome,
+		openClawContext,
+		hermesWhatsAppAuthDir,
+		workspaceRoot,
+		generatedAt,
+		previousProjectedProviderIds,
+		runtimeEntries,
+		hostedRuntimeContract,
+	} = context;
+	for (const [name, runtime] of runtimeEntries) {
+		const observation = state.observations.get(name);
+		if (!observation) throw new Error(`runtime ${name} install observation is missing`);
+
+		const inventoryPath = join(paths.installInventory, `${name}.json`);
+		writeJsonFile(
+			inventoryPath,
+			{
+				schemaVersion: "clawdi.runtimeInstallInventory.v1",
+				generatedAt,
+				runtime: name,
+				enabled: runtime.enabled,
+				updateChannel: runtime.updateChannel ?? null,
+				simulation: false,
+				status: observation.status,
+				executionUser: observation.executionUser,
+				install: observation.install,
+				installerArgs: runtime.install?.args ?? [],
+				commandPath: observation.commandPath,
+				appRoot: observation.appRoot,
+				installerUrl: observation.installerUrl,
+				executedInstallerUrl: observation.executedInstallerUrl,
+				installStartedAt: observation.installStartedAt ?? null,
+				installFinishedAt: observation.installFinishedAt ?? null,
+				installDurationMs: observation.installDurationMs ?? null,
+				resultExitCode: observation.exitCode,
+				stdoutTail: observation.stdoutTail,
+				stderrTail: observation.stderrTail,
+				error: observation.error,
+			},
+			paths,
+		);
+		state.installInventory.push(inventoryPath);
+
+		const projectionPath = join(paths.projectionRoot, `${name}.json`);
+		writeJsonFile(projectionPath, projectionPayload(name, manifest), paths);
+		state.projections.push(projectionPath);
+		if (name === "hermes" || name === "openclaw") {
 			try {
 				reconcileHostedRuntimeOAuthCredentials({
-					runtime,
+					runtime: name,
 					manifest,
 					secretValues,
 					paths,
@@ -928,561 +1239,614 @@ export function convergeRuntimeManifest(
 					workspaceRoot,
 				});
 			} catch (error) {
-				installErrors.push(
-					`stale ${runtime} OAuth credential reconciliation failed: ${
+				state.installErrors.push(
+					`runtime ${name} OAuth credential reconciliation failed: ${
 						error instanceof Error ? error.message : String(error)
 					}`,
 				);
 			}
 		}
-		if (installErrors.length > 0) {
-			throw new Error(installErrors.join("; "));
-		}
-
-		for (const [name, runtime] of runtimeEntries) {
-			const observation = observations.get(name);
-			if (!observation) throw new Error(`runtime ${name} install observation is missing`);
-
-			const inventoryPath = join(paths.installInventory, `${name}.json`);
-			writeJsonFile(
-				inventoryPath,
-				{
-					schemaVersion: "clawdi.runtimeInstallInventory.v1",
-					generatedAt,
-					runtime: name,
-					enabled: runtime.enabled,
-					updateChannel: runtime.updateChannel ?? null,
-					simulation: false,
-					status: observation.status,
-					executionUser: observation.executionUser,
-					install: observation.install,
-					installerArgs: runtime.install?.args ?? [],
-					commandPath: observation.commandPath,
-					appRoot: observation.appRoot,
-					installerUrl: observation.installerUrl,
-					executedInstallerUrl: observation.executedInstallerUrl,
-					installStartedAt: observation.installStartedAt ?? null,
-					installFinishedAt: observation.installFinishedAt ?? null,
-					installDurationMs: observation.installDurationMs ?? null,
-					resultExitCode: observation.exitCode,
-					stdoutTail: observation.stdoutTail,
-					stderrTail: observation.stderrTail,
-					error: observation.error,
-				},
-				paths,
-			);
-			installInventory.push(inventoryPath);
-
-			const projectionPath = join(paths.projectionRoot, `${name}.json`);
-			writeJsonFile(projectionPath, projectionPayload(name, manifest), paths);
-			projections.push(projectionPath);
-			if (name === "hermes" || name === "openclaw") {
-				try {
-					reconcileHostedRuntimeOAuthCredentials({
-						runtime: name,
-						manifest,
-						secretValues,
-						paths,
-						home: projectionHome,
-						openClawContext,
-						workspaceRoot,
-					});
-				} catch (error) {
-					installErrors.push(
-						`runtime ${name} OAuth credential reconciliation failed: ${
-							error instanceof Error ? error.message : String(error)
-						}`,
-					);
-				}
-			}
-			try {
-				const localeFile = applyHostedRuntimeConfigProjection(
-					name,
-					observation,
-					manifest,
-					projectionHome,
-					openClawWorkspaceRoot,
-					workspaceRoot,
-				);
-				if (localeFile) managedLocaleFiles.push(localeFile);
-			} catch (error) {
-				installErrors.push(
-					`runtime ${name} config projection failed: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
-				);
-			}
-			try {
-				const providerProjection = applyHostedAiProviderProjection(
-					name,
-					observation,
-					manifest,
-					secretValues,
-					projectionHome,
-					openClawContext,
-					workspaceRoot,
-					previousProjectedProviderIds[name] ?? [],
-					openClawOwnerBrowserBootstrapSupported,
-				);
-				projectedProviderIds[name] = providerProjection.providerIds;
-			} catch (error) {
-				installErrors.push(
-					`runtime ${name} provider projection failed: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
-				);
-			}
-			try {
-				const channelConfigChanged = applyHostedChannelProjection(
-					name,
-					observation,
-					manifest,
-					projectionHome,
-					openClawContext,
-					workspaceRoot,
-					hermesWhatsAppAuthDir,
-				);
-				if (channelConfigChanged) runtimeProjectionMutationRuntimes.add(name);
-			} catch (error) {
-				installErrors.push(
-					`runtime ${name} channel projection failed: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
-				);
-			}
-			if (installErrors.length > 0) {
-				throw new Error(installErrors.join("; "));
-			}
-			const resolved = resolveRuntimeRunConfigs({
-				manifest,
-				paths,
-				name,
-				runtime,
-				observation,
-				workspaceRoot,
-				generatedAt,
-				secretValues,
-				egressProfileBundlePath,
-			});
-			const runConfigPath = writeRuntimeRunConfig(resolved.runtime, paths);
-			runConfigs.push(runConfigPath);
-			writtenRunConfigIds.add(runtimeRunConfigId(resolved.runtime.runtime));
-			for (const serviceRunConfig of resolved.services) {
-				const serviceRunConfigPath = writeRuntimeRunConfig(serviceRunConfig, paths);
-				runConfigs.push(serviceRunConfigPath);
-				writtenRunConfigIds.add(
-					runtimeRunConfigId(serviceRunConfig.runtime, serviceRunConfig.service),
-				);
-			}
-		}
-
-		const mcpProjection = join(paths.projectionRoot, "clawdi-mcp.json");
-		if (hostedMcpProjectionDeclared(manifest) || manifest.projection?.skills !== undefined) {
-			writeJsonFile(mcpProjection, projectionPayload("clawdi-mcp", manifest), paths);
-			projections.push(mcpProjection);
-		} else {
-			rmSync(mcpProjection, { force: true });
-		}
-		hostedRuntimeContract.assertPlatformRoots();
-		const systemdUnits = writeRuntimeSystemdState({
-			runtimePrograms: runtimeSystemdUserPrograms,
-			egressProgram: egressSystemdProgram,
-			egressIdentity,
-			manifest,
-			paths,
-			workspaceRoot,
-			daemonAuthTokenFile,
-			secretValues,
-			providerProjectionRevisions,
-			runtimeRevision: (desired, runtime, secrets, providerRevision) =>
-				runtimeProgramRevisionForManifest(
-					desired,
-					runtime,
-					secrets,
-					providerRevision,
-					hermesWhatsAppAuthDir,
-					openClawOwnerBrowserBootstrapSupported,
-				),
-			commonEnvironment: commonSystemdEnvironment,
-		});
-		staleSystemdFiles = systemdUnits.staleFiles;
-		const officialServicePlan = planOfficialRuntimeServices(
-			runtimeSystemdUserPrograms,
-			paths,
-			previousInstallReceipts,
-			opts.systemdApply !== undefined || opts.executeOfficialServiceInstallers === true,
-		);
-		const pendingOfficialUnits = new Set(officialServicePlan.pending.map((item) => item.unitName));
-		runtimeProjectionRestartUserUnits = [
-			...new Set(
-				runtimeSystemdUserPrograms
-					.filter(
-						(program) =>
-							program.programKind === "runtime" &&
-							program.service === null &&
-							runtimeProjectionMutationRuntimes.has(program.runtime),
-					)
-					.map(runtimeSystemdUserUnitName),
-			),
-		]
-			.filter((unitName) => !pendingOfficialUnits.has(unitName))
-			.sort();
-		installReceiptTargets.officialServices = officialServicePlan.targets;
-		// Agent Plugin mutations must precede every native service installer.
-		// The final activation below restarts the affected runtime units.
-		const appliedAgentPluginTransaction = agentPluginTransaction;
-		if (appliedAgentPluginTransaction?.hasMutations) {
-			const affectedUserUnits = planRuntimeMutationSystemdUserUnits({
-				runtimePrograms: runtimeSystemdUserPrograms,
-				staleUserUnits: staleSystemdFiles.userUnits,
-				mutationRuntimes: appliedAgentPluginTransaction.mutationRuntimes,
-			});
-			agentPluginQuiesceUserUnits = affectedUserUnits.quiesceUserUnits;
-			agentPluginRestartUserUnits = affectedUserUnits.restartUserUnits;
-			agentPluginQuiesceAttempted = true;
-			opts.systemdApply?.quiesce(agentPluginQuiesceUserUnits);
-			agentPluginUnitsQuiesced = true;
-			agentPluginMutationAttempted = true;
-		}
-		let agentPluginApplyCompleted = false;
-		let agentPluginSnapshotScope: ReturnType<typeof rollbackSnapshots.captureScoped> | null = null;
 		try {
-			if (appliedAgentPluginTransaction) {
-				agentPluginSnapshotScope = rollbackSnapshots.captureScoped(
-					"runtime Agent Plugin filesystem rollback failed",
-					{
-						rootTargets: [hostedAgentPluginReceiptsPath(paths)],
-						trustedRootDirectories: [paths.statusRoot],
-						runtimeUserTargets: [...appliedAgentPluginTransaction.snapshotTargets],
-						runtimeUserTrustedRoots: [projectionHome],
-						runtimeUserSymlinkTargets: [],
-						metadataTargets: mutationAncestorMetadataTargets(
-							appliedAgentPluginTransaction.snapshotTargets,
-							[projectionHome],
-						),
-					},
-				);
-			}
-			appliedAgentPluginTransaction?.apply();
-			agentPluginApplyCompleted = true;
-			if (appliedAgentPluginTransaction) {
-				writeHostedAgentPluginReceipt(appliedAgentPluginTransaction.nextReceipt, paths);
-			}
+			const localeFile = applyHostedRuntimeConfigProjection(
+				name,
+				observation,
+				manifest,
+				projectionHome,
+				plan.openClawWorkspaceRoot,
+				workspaceRoot,
+			);
+			if (localeFile) state.managedLocaleFiles.push(localeFile);
 		} catch (error) {
-			const failedNames = agentPluginApplyCompleted
-				? opts.preparedHostedAgentPlugins?.desired.keys()
-				: appliedAgentPluginTransaction?.mutationNames;
-			for (const name of failedNames ?? []) {
-				agentPluginFailedNames.add(name);
-			}
-			const rollbackErrors = appliedAgentPluginTransaction?.rollback() ?? [];
-			if (agentPluginSnapshotScope) {
-				rollbackErrors.push(
-					...rollbackSnapshots.restore(
-						agentPluginSnapshotScope,
-						(_failure, rollbackError) =>
-							`runtime Agent Plugin snapshot rollback failed: ${
-								rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
-							}`,
-					),
-				);
-			}
-			if (rollbackErrors.length > 0) {
-				throw new Error(
-					`runtime Agent Plugin projection failed and could not be rolled back: ${[
-						error instanceof Error ? error.message : String(error),
-						...rollbackErrors,
-					].join("; ")}`,
-				);
-			}
-			resourceProjectionErrors.push(
-				`runtime Agent Plugin projection failed: ${
+			state.installErrors.push(
+				`runtime ${name} config projection failed: ${
 					error instanceof Error ? error.message : String(error)
 				}`,
 			);
-			agentPluginTransaction = null;
-			agentPluginMutationAttempted = false;
 		}
-		if (
-			officialServicePlan.pending.length > 0 &&
-			systemdUnits.egressSidecarActive &&
-			opts.systemdApply
-		) {
-			agentPluginUnitsQuiesced = false;
-			const prerequisite = opts.systemdApply.activateEgressPrerequisite({
-				restartDaemon,
-				restartEgressSidecar,
-				stopEgressSidecar: false,
-				reconcileUserUnits: mutationPlan.systemdUserUnits,
-				restartUserUnits: [],
-				staleSystemUnits: [],
-				staleUserUnits: [],
-			});
-			if (!prerequisite.applied) {
-				throw new Error("transparent-egress system prerequisites did not reach readiness");
-			}
-		}
-
-		if (officialServicePlan.pending.length > 0) agentPluginUnitsQuiesced = false;
-		for (const item of officialServicePlan.pending) {
-			hostedRuntimeContract.assertPlatformRoots();
-			const install = () => installOfficialRuntimeService(item, paths);
-			const error = opts.systemdApply
-				? opts.systemdApply.installOfficialService(item.unitName, install)
-				: install();
-			if (error) throw new Error(error);
-		}
-		hostedRuntimeContract.assertPlatformRoots();
-		const bootFinished = join(instanceRoot, "boot-finished");
-		writeRuntimePrivateFileAtomic(paths, bootFinished, `${generatedAt}\n`);
-		if (opts.systemdApply) {
-			agentPluginUnitsQuiesced = false;
-			const activation = opts.systemdApply.activate({
-				restartDaemon,
-				restartEgressSidecar,
-				stopEgressSidecar: false,
-				reconcileUserUnits: mutationPlan.systemdUserUnits,
-				restartUserUnits: [
-					...new Set([...agentPluginRestartUserUnits, ...runtimeProjectionRestartUserUnits]),
-				].sort(),
-				staleSystemUnits: staleSystemdFiles.systemUnits,
-				staleUserUnits: staleSystemdFiles.userUnits,
-			});
-			systemdActivationApplied = activation.applied;
-			if (!activation.applied) {
-				throw new Error("systemd runtime services did not reach required readiness");
-			}
-			probeFileBrowserReadiness(manifest, { probe: opts.fileBrowserReadinessProbe });
-		}
-		if (installErrors.length === 0 && opts.cacheLastGood !== false) {
-			manifestLastGood = writeLastGoodManifest(
-				load.sourceManifest ?? manifest,
-				paths,
-				load.secretValues,
+		try {
+			const providerProjection = applyHostedAiProviderProjection(
+				name,
+				observation,
 				manifest,
+				secretValues,
+				projectionHome,
+				openClawContext,
+				workspaceRoot,
+				previousProjectedProviderIds[name] ?? [],
+				state.openClawOwnerBrowserBootstrapSupported,
+			);
+			state.projectedProviderIds[name] = providerProjection.providerIds;
+		} catch (error) {
+			state.installErrors.push(
+				`runtime ${name} provider projection failed: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
 			);
 		}
-
-		const convergence: RuntimeConvergenceResult = {
+		try {
+			const channelConfigChanged = applyHostedChannelProjection(
+				name,
+				observation,
+				manifest,
+				projectionHome,
+				openClawContext,
+				workspaceRoot,
+				hermesWhatsAppAuthDir,
+			);
+			if (channelConfigChanged) state.runtimeProjectionMutationRuntimes.add(name);
+		} catch (error) {
+			state.installErrors.push(
+				`runtime ${name} channel projection failed: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
+		if (state.installErrors.length > 0) throw new Error(state.installErrors.join("; "));
+		const resolved = resolveRuntimeRunConfigs({
 			manifest,
-			source: load.source,
-			sourcePath: load.sourcePath,
-			offline: load.offline,
-			mode: load.offline ? "degraded-offline" : "normal",
-			enabledRuntimes,
-			installErrors,
-			resourceProjectionErrors,
-			projectedProviderIds,
-			agentPluginFailedNames: [...agentPluginFailedNames].sort(),
-			outputs: {
-				processManager: "systemd",
-				workspaceRoot,
-				managedConfig: paths.managedConfig,
-				syncState: paths.syncState,
-				instanceData: paths.instanceData,
-				sensitiveInstanceData: paths.sensitiveInstanceData,
-				manifestLastGood,
-				appliedState: null,
-				installInventory,
-				projections,
-				managedLocaleFiles,
-				runConfigs,
-				systemdSystemUnitRoot: paths.systemdSystemRoot,
-				systemdSystemUnits: systemdUnits.systemUnits,
-				systemdUserUnitRoot: paths.systemdUserRoot,
-				systemdUserUnits: systemdUnits.userUnits,
-				egressProfileBundle: egressProfileBundlePath,
-				egressSecretFile,
-				egressEngine,
-				egressTransparentEnv,
-				egressAddon: egressAddon?.path ?? null,
-				liveSyncEnvironments,
-				daemonAuthTokenFile,
-				bootFinished,
-			},
-		};
-		if (installErrors.length === 0) {
-			hostedRuntimeContract.assertPlatformRoots();
-			const daemonAuthTokenRevisionPreviouslyCommitted =
-				desiredDaemonAuthTokenRevision !== undefined &&
-				desiredDaemonAuthTokenRevision === appliedState?.daemonAuthTokenRevision;
-			const daemonProgramRevisionPreviouslyCommitted =
-				desiredDaemonProgramRevision !== undefined &&
-				desiredDaemonProgramRevision === appliedState?.daemonProgramRevision;
-			const egressRevisionPreviouslyCommitted =
-				desiredEgressSidecarSecretRevision !== undefined &&
-				desiredEgressSidecarSecretRevision === appliedState?.egressSidecarSecretRevision;
-			rmSync(join(paths.managedResourceRoot, RETIRED_MANAGED_HERMES_WHATSAPP_RECEIPT), {
-				force: true,
-			});
-			commitRuntimeInstallReceipts(installReceiptTargets, paths);
-			opts.commitAuthority?.(convergence, {
-				...(desiredDaemonAuthTokenRevision !== undefined &&
-				(systemdActivationApplied || daemonAuthTokenRevisionPreviouslyCommitted)
-					? { daemonAuthTokenRevision: desiredDaemonAuthTokenRevision }
-					: {}),
-				...(desiredDaemonProgramRevision !== undefined &&
-				(systemdActivationApplied || daemonProgramRevisionPreviouslyCommitted)
-					? { daemonProgramRevision: desiredDaemonProgramRevision }
-					: {}),
-				...(desiredEgressSidecarSecretRevision !== undefined &&
-				(systemdActivationApplied || egressRevisionPreviouslyCommitted)
-					? { egressSidecarSecretRevision: desiredEgressSidecarSecretRevision }
-					: {}),
-			});
-			try {
-				gcFileBrowserCompanionCandidates(manifest, paths);
-			} catch (cleanupError) {
-				console.warn(
-					`post-commit Files companion candidate cleanup deferred: ${
-						cleanupError instanceof Error ? cleanupError.message : String(cleanupError)
-					}`,
-				);
-			}
-			try {
-				for (const cleanupError of removeStaleRuntimeSystemdFiles(paths, systemdUnits.staleFiles)) {
-					console.warn(`post-commit systemd file cleanup deferred: ${cleanupError}`);
-				}
-				removeStaleRuntimeRunConfigs(writtenRunConfigIds, paths);
-			} catch (cleanupError) {
-				console.warn(
-					`post-commit runtime file cleanup deferred: ${
-						cleanupError instanceof Error ? cleanupError.message : String(cleanupError)
-					}`,
-				);
-			}
-			for (const cleanupError of uninstallStaleOfficialRuntimeServices({
-				paths,
-				unitNames: mutationPlan.staleOfficialUnits,
-				workspaceRoot,
-			})) {
-				console.warn(`post-commit official runtime service cleanup deferred: ${cleanupError}`);
-			}
+			paths,
+			name,
+			runtime,
+			observation,
+			workspaceRoot,
+			generatedAt,
+			secretValues,
+			egressProfileBundlePath: egressProjection.egressProfileBundlePath,
+		});
+		const runConfigPath = writeRuntimeRunConfig(resolved.runtime, paths);
+		state.runConfigs.push(runConfigPath);
+		egressProjection.writtenRunConfigIds.add(runtimeRunConfigId(resolved.runtime.runtime));
+		for (const serviceRunConfig of resolved.services) {
+			const serviceRunConfigPath = writeRuntimeRunConfig(serviceRunConfig, paths);
+			state.runConfigs.push(serviceRunConfigPath);
+			egressProjection.writtenRunConfigIds.add(
+				runtimeRunConfigId(serviceRunConfig.runtime, serviceRunConfig.service),
+			);
 		}
-		rollbackSnapshots.pop();
-		return convergence;
+	}
+
+	const mcpProjection = join(paths.projectionRoot, "clawdi-mcp.json");
+	if (hostedMcpProjectionDeclared(manifest) || manifest.projection?.skills !== undefined) {
+		writeJsonFile(mcpProjection, projectionPayload("clawdi-mcp", manifest), paths);
+		state.projections.push(mcpProjection);
+	} else {
+		rmSync(mcpProjection, { force: true });
+	}
+	hostedRuntimeContract.assertPlatformRoots();
+}
+
+interface RuntimeActivationPlan {
+	systemdUnits: ReturnType<typeof writeRuntimeSystemdState>;
+	officialServicePlan: ReturnType<typeof planOfficialRuntimeServices>;
+}
+
+function prepareRuntimeActivation(
+	context: RuntimeConvergenceContext,
+	state: RuntimeConvergenceState,
+	plan: RuntimeConvergencePlan,
+	egressProjection: RuntimeEgressProjection,
+	providerProjectionRevisions: Partial<Record<string, string | null>>,
+): RuntimeActivationPlan {
+	const {
+		manifest,
+		paths,
+		opts,
+		secretValues,
+		projectionHome,
+		hermesWhatsAppAuthDir,
+		workspaceRoot,
+	} = context;
+	const systemdUnits = writeRuntimeSystemdState({
+		runtimePrograms: state.runtimeSystemdUserPrograms,
+		egressProgram: egressProjection.egressSystemdProgram,
+		egressIdentity: egressProjection.egressIdentity,
+		manifest,
+		paths,
+		workspaceRoot,
+		daemonAuthTokenFile: egressProjection.daemonAuthTokenFile,
+		secretValues,
+		providerProjectionRevisions,
+		runtimeRevision: (desired, runtime, secrets, providerRevision) =>
+			runtimeProgramRevisionForManifest(
+				desired,
+				runtime,
+				secrets,
+				providerRevision,
+				hermesWhatsAppAuthDir,
+				state.openClawOwnerBrowserBootstrapSupported,
+			),
+		commonEnvironment: egressProjection.commonSystemdEnvironment,
+	});
+	state.staleSystemdFiles = systemdUnits.staleFiles;
+	const officialServicePlan = planOfficialRuntimeServices(
+		state.runtimeSystemdUserPrograms,
+		paths,
+		plan.previousInstallReceipts,
+		opts.systemdApply !== undefined || opts.executeOfficialServiceInstallers === true,
+	);
+	const pendingOfficialUnits = new Set(officialServicePlan.pending.map((item) => item.unitName));
+	state.runtimeProjectionRestartUserUnits = [
+		...new Set(
+			state.runtimeSystemdUserPrograms
+				.filter(
+					(program) =>
+						program.programKind === "runtime" &&
+						program.service === null &&
+						state.runtimeProjectionMutationRuntimes.has(program.runtime),
+				)
+				.map(runtimeSystemdUserUnitName),
+		),
+	]
+		.filter((unitName) => !pendingOfficialUnits.has(unitName))
+		.sort();
+	state.installReceiptTargets.officialServices = officialServicePlan.targets;
+	// Agent Plugin mutations must precede every native service installer.
+	// The final activation below restarts the affected runtime units.
+	const appliedAgentPluginTransaction = state.agentPluginTransaction;
+	if (appliedAgentPluginTransaction?.hasMutations) {
+		const affectedUserUnits = planRuntimeMutationSystemdUserUnits({
+			runtimePrograms: state.runtimeSystemdUserPrograms,
+			staleUserUnits: state.staleSystemdFiles.userUnits,
+			mutationRuntimes: appliedAgentPluginTransaction.mutationRuntimes,
+		});
+		state.agentPluginQuiesceUserUnits = affectedUserUnits.quiesceUserUnits;
+		state.agentPluginRestartUserUnits = affectedUserUnits.restartUserUnits;
+		state.agentPluginQuiesceAttempted = true;
+		opts.systemdApply?.quiesce(state.agentPluginQuiesceUserUnits);
+		state.agentPluginUnitsQuiesced = true;
+		state.agentPluginMutationAttempted = true;
+	}
+	let agentPluginApplyCompleted = false;
+	let agentPluginSnapshotScope: ReturnType<typeof state.rollbackSnapshots.captureScoped> | null =
+		null;
+	try {
+		if (appliedAgentPluginTransaction) {
+			agentPluginSnapshotScope = state.rollbackSnapshots.captureScoped(
+				"runtime Agent Plugin filesystem rollback failed",
+				{
+					rootTargets: [hostedAgentPluginReceiptsPath(paths)],
+					trustedRootDirectories: [paths.statusRoot],
+					runtimeUserTargets: [...appliedAgentPluginTransaction.snapshotTargets],
+					runtimeUserTrustedRoots: [projectionHome],
+					runtimeUserSymlinkTargets: [],
+					metadataTargets: mutationAncestorMetadataTargets(
+						appliedAgentPluginTransaction.snapshotTargets,
+						[projectionHome],
+					),
+				},
+			);
+		}
+		appliedAgentPluginTransaction?.apply();
+		agentPluginApplyCompleted = true;
+		if (appliedAgentPluginTransaction) {
+			writeHostedAgentPluginReceipt(appliedAgentPluginTransaction.nextReceipt, paths);
+		}
 	} catch (error) {
-		if (agentPluginMutationAttempted) {
-			for (const name of agentPluginTransaction?.mutationNames ?? []) {
-				agentPluginFailedNames.add(name);
-			}
+		const failedNames = agentPluginApplyCompleted
+			? opts.preparedHostedAgentPlugins?.desired.keys()
+			: appliedAgentPluginTransaction?.mutationNames;
+		for (const name of failedNames ?? []) state.agentPluginFailedNames.add(name);
+		const rollbackErrors = appliedAgentPluginTransaction?.rollback() ?? [];
+		if (agentPluginSnapshotScope) {
+			rollbackErrors.push(
+				...state.rollbackSnapshots.restore(
+					agentPluginSnapshotScope,
+					(_failure, rollbackError) =>
+						`runtime Agent Plugin snapshot rollback failed: ${
+							rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+						}`,
+				),
+			);
 		}
-		const applyError = error instanceof Error ? error.message : String(error);
-		const systemdMutated = opts.systemdApply?.transactionState() === "mutated";
-		const rollbackRequiresQuiesce =
-			systemdMutated || agentPluginQuiesceAttempted || agentPluginMutationAttempted;
-		let candidateQuiesced = agentPluginUnitsQuiesced || !rollbackRequiresQuiesce;
-		if (rollbackRequiresQuiesce && !candidateQuiesced) {
-			try {
-				opts.systemdApply?.quiesce(agentPluginQuiesceUserUnits);
-				candidateQuiesced = true;
-			} catch (quiesceError) {
-				installErrors.push(
-					`runtime candidate service quiesce failed: ${
-						quiesceError instanceof Error ? quiesceError.message : String(quiesceError)
-					}`,
-				);
-			}
+		if (rollbackErrors.length > 0) {
+			throw new Error(
+				`runtime Agent Plugin projection failed and could not be rolled back: ${[
+					error instanceof Error ? error.message : String(error),
+					...rollbackErrors,
+				].join("; ")}`,
+			);
 		}
-		let filesystemRollbackSucceeded = false;
-		if (candidateQuiesced) {
-			if (agentPluginTransaction) installErrors.push(...agentPluginTransaction.rollback());
-			const resourceSnapshotRollbackErrors = rollbackSnapshots.restore(resourceRollbackScope);
-			installErrors.push(...resourceSnapshotRollbackErrors);
-			try {
-				hostedRuntimeContract.assertPlatformRoots();
-				const snapshotRollbackErrors = rollbackSnapshots.restore();
-				installErrors.push(...snapshotRollbackErrors);
-				if (rollbackEgressSecretOverride) {
-					writeEgressSecretMaterial(rollbackEgressSecretOverride, paths);
-				} else if (rollbackEgressSecretRevision) {
-					const committedMaterial = verifiedCommittedEgressSecretMaterial(paths, applyContext);
-					if (committedMaterial?.revision === rollbackEgressSecretRevision) {
-						writeEgressSecretMaterial(committedMaterial, paths);
-					} else {
-						egressRollbackAuthorityVerified = false;
-						rmSync(egressSecretFilePath(paths), { force: true });
-					}
-				} else if (!egressRollbackAuthorityVerified) {
+		state.resourceProjectionErrors.push(
+			`runtime Agent Plugin projection failed: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+		state.agentPluginTransaction = null;
+		state.agentPluginMutationAttempted = false;
+	}
+	return { systemdUnits, officialServicePlan };
+}
+
+interface RuntimeActivationOutputs {
+	manifestLastGood: string | null;
+	bootFinished: string;
+}
+
+function activateRuntimeServices(
+	context: RuntimeConvergenceContext,
+	state: RuntimeConvergenceState,
+	plan: RuntimeConvergencePlan,
+	activationPlan: RuntimeActivationPlan,
+): RuntimeActivationOutputs {
+	const { load, manifest, paths, opts, hostedRuntimeContract, instanceRoot, generatedAt } = context;
+	const { officialServicePlan, systemdUnits } = activationPlan;
+	if (
+		officialServicePlan.pending.length > 0 &&
+		systemdUnits.egressSidecarActive &&
+		opts.systemdApply
+	) {
+		state.agentPluginUnitsQuiesced = false;
+		const prerequisite = opts.systemdApply.activateEgressPrerequisite({
+			restartDaemon: state.restartDaemon,
+			restartEgressSidecar: state.restartEgressSidecar,
+			stopEgressSidecar: false,
+			reconcileUserUnits: plan.mutationPlan.systemdUserUnits,
+			restartUserUnits: [],
+			staleSystemUnits: [],
+			staleUserUnits: [],
+		});
+		if (!prerequisite.applied) {
+			throw new Error("transparent-egress system prerequisites did not reach readiness");
+		}
+	}
+
+	if (officialServicePlan.pending.length > 0) state.agentPluginUnitsQuiesced = false;
+	for (const item of officialServicePlan.pending) {
+		hostedRuntimeContract.assertPlatformRoots();
+		const install = () => installOfficialRuntimeService(item, paths);
+		const error = opts.systemdApply
+			? opts.systemdApply.installOfficialService(item.unitName, install)
+			: install();
+		if (error) throw new Error(error);
+	}
+	hostedRuntimeContract.assertPlatformRoots();
+	const bootFinished = join(instanceRoot, "boot-finished");
+	writeRuntimePrivateFileAtomic(paths, bootFinished, `${generatedAt}\n`);
+	if (opts.systemdApply) {
+		state.agentPluginUnitsQuiesced = false;
+		const activation = opts.systemdApply.activate({
+			restartDaemon: state.restartDaemon,
+			restartEgressSidecar: state.restartEgressSidecar,
+			stopEgressSidecar: false,
+			reconcileUserUnits: plan.mutationPlan.systemdUserUnits,
+			restartUserUnits: [
+				...new Set([
+					...state.agentPluginRestartUserUnits,
+					...state.runtimeProjectionRestartUserUnits,
+				]),
+			].sort(),
+			staleSystemUnits: state.staleSystemdFiles.systemUnits,
+			staleUserUnits: state.staleSystemdFiles.userUnits,
+		});
+		state.systemdActivationApplied = activation.applied;
+		if (!activation.applied) {
+			throw new Error("systemd runtime services did not reach required readiness");
+		}
+		probeFileBrowserReadiness(manifest, { probe: opts.fileBrowserReadinessProbe });
+	}
+	let manifestLastGood: string | null = null;
+	if (state.installErrors.length === 0 && opts.cacheLastGood !== false) {
+		manifestLastGood = writeLastGoodManifest(
+			load.sourceManifest ?? manifest,
+			paths,
+			load.secretValues,
+			manifest,
+		);
+	}
+	return { manifestLastGood, bootFinished };
+}
+
+function buildRuntimeConvergenceResult(
+	context: RuntimeConvergenceContext,
+	state: RuntimeConvergenceState,
+	egressProjection: RuntimeEgressProjection,
+	activationPlan: RuntimeActivationPlan,
+	activationOutputs: RuntimeActivationOutputs,
+): RuntimeConvergenceResult {
+	const { load, manifest, paths, workspaceRoot, enabledRuntimes } = context;
+	return {
+		manifest,
+		source: load.source,
+		sourcePath: load.sourcePath,
+		offline: load.offline,
+		mode: load.offline ? "degraded-offline" : "normal",
+		enabledRuntimes,
+		installErrors: state.installErrors,
+		resourceProjectionErrors: state.resourceProjectionErrors,
+		projectedProviderIds: state.projectedProviderIds,
+		agentPluginFailedNames: [...state.agentPluginFailedNames].sort(),
+		outputs: {
+			processManager: "systemd",
+			workspaceRoot,
+			managedConfig: paths.managedConfig,
+			syncState: paths.syncState,
+			instanceData: paths.instanceData,
+			sensitiveInstanceData: paths.sensitiveInstanceData,
+			manifestLastGood: activationOutputs.manifestLastGood,
+			appliedState: null,
+			installInventory: state.installInventory,
+			projections: state.projections,
+			managedLocaleFiles: state.managedLocaleFiles,
+			runConfigs: state.runConfigs,
+			systemdSystemUnitRoot: paths.systemdSystemRoot,
+			systemdSystemUnits: activationPlan.systemdUnits.systemUnits,
+			systemdUserUnitRoot: paths.systemdUserRoot,
+			systemdUserUnits: activationPlan.systemdUnits.userUnits,
+			egressProfileBundle: egressProjection.egressProfileBundlePath,
+			egressSecretFile: egressProjection.egressSecretFile,
+			egressEngine: egressProjection.egressEngine,
+			egressTransparentEnv: egressProjection.egressTransparentEnv,
+			egressAddon: egressProjection.egressAddon?.path ?? null,
+			liveSyncEnvironments: egressProjection.liveSyncEnvironments,
+			daemonAuthTokenFile: egressProjection.daemonAuthTokenFile,
+			bootFinished: activationOutputs.bootFinished,
+		},
+	};
+}
+
+function commitRuntimeConvergence(
+	context: RuntimeConvergenceContext,
+	state: RuntimeConvergenceState,
+	plan: RuntimeConvergencePlan,
+	egressProjection: RuntimeEgressProjection,
+	activationPlan: RuntimeActivationPlan,
+	convergence: RuntimeConvergenceResult,
+): void {
+	const { manifest, paths, opts, hostedRuntimeContract, workspaceRoot, appliedState } = context;
+	if (state.installErrors.length > 0) return;
+	hostedRuntimeContract.assertPlatformRoots();
+	const daemonAuthTokenRevisionPreviouslyCommitted =
+		state.desiredDaemonAuthTokenRevision !== undefined &&
+		state.desiredDaemonAuthTokenRevision === appliedState?.daemonAuthTokenRevision;
+	const daemonProgramRevisionPreviouslyCommitted =
+		state.desiredDaemonProgramRevision !== undefined &&
+		state.desiredDaemonProgramRevision === appliedState?.daemonProgramRevision;
+	const egressRevisionPreviouslyCommitted =
+		state.desiredEgressSidecarSecretRevision !== undefined &&
+		state.desiredEgressSidecarSecretRevision === appliedState?.egressSidecarSecretRevision;
+	rmSync(join(paths.managedResourceRoot, RETIRED_MANAGED_HERMES_WHATSAPP_RECEIPT), {
+		force: true,
+	});
+	commitRuntimeInstallReceipts(state.installReceiptTargets, paths);
+	opts.commitAuthority?.(convergence, {
+		...(state.desiredDaemonAuthTokenRevision !== undefined &&
+		(state.systemdActivationApplied || daemonAuthTokenRevisionPreviouslyCommitted)
+			? { daemonAuthTokenRevision: state.desiredDaemonAuthTokenRevision }
+			: {}),
+		...(state.desiredDaemonProgramRevision !== undefined &&
+		(state.systemdActivationApplied || daemonProgramRevisionPreviouslyCommitted)
+			? { daemonProgramRevision: state.desiredDaemonProgramRevision }
+			: {}),
+		...(state.desiredEgressSidecarSecretRevision !== undefined &&
+		(state.systemdActivationApplied || egressRevisionPreviouslyCommitted)
+			? { egressSidecarSecretRevision: state.desiredEgressSidecarSecretRevision }
+			: {}),
+	});
+	try {
+		gcFileBrowserCompanionCandidates(manifest, paths);
+	} catch (cleanupError) {
+		console.warn(
+			`post-commit Files companion candidate cleanup deferred: ${
+				cleanupError instanceof Error ? cleanupError.message : String(cleanupError)
+			}`,
+		);
+	}
+	try {
+		for (const cleanupError of removeStaleRuntimeSystemdFiles(
+			paths,
+			activationPlan.systemdUnits.staleFiles,
+		)) {
+			console.warn(`post-commit systemd file cleanup deferred: ${cleanupError}`);
+		}
+		removeStaleRuntimeRunConfigs(egressProjection.writtenRunConfigIds, paths);
+	} catch (cleanupError) {
+		console.warn(
+			`post-commit runtime file cleanup deferred: ${
+				cleanupError instanceof Error ? cleanupError.message : String(cleanupError)
+			}`,
+		);
+	}
+	for (const cleanupError of uninstallStaleOfficialRuntimeServices({
+		paths,
+		unitNames: plan.mutationPlan.staleOfficialUnits,
+		workspaceRoot,
+	})) {
+		console.warn(`post-commit official runtime service cleanup deferred: ${cleanupError}`);
+	}
+}
+
+function rollbackRuntimeApply(
+	context: RuntimeConvergenceContext,
+	state: RuntimeConvergenceState,
+	plan: RuntimeConvergencePlan,
+	error: unknown,
+): RuntimeConvergenceResult {
+	const { paths, opts, applyContext, hostedRuntimeContract, workspaceRoot } = context;
+	if (state.agentPluginMutationAttempted) {
+		for (const name of state.agentPluginTransaction?.mutationNames ?? []) {
+			state.agentPluginFailedNames.add(name);
+		}
+	}
+	const applyError = error instanceof Error ? error.message : String(error);
+	const systemdMutated = opts.systemdApply?.transactionState() === "mutated";
+	const rollbackRequiresQuiesce =
+		systemdMutated || state.agentPluginQuiesceAttempted || state.agentPluginMutationAttempted;
+	let candidateQuiesced = state.agentPluginUnitsQuiesced || !rollbackRequiresQuiesce;
+	if (rollbackRequiresQuiesce && !candidateQuiesced) {
+		try {
+			opts.systemdApply?.quiesce(state.agentPluginQuiesceUserUnits);
+			candidateQuiesced = true;
+		} catch (quiesceError) {
+			state.installErrors.push(
+				`runtime candidate service quiesce failed: ${
+					quiesceError instanceof Error ? quiesceError.message : String(quiesceError)
+				}`,
+			);
+		}
+	}
+	let filesystemRollbackSucceeded = false;
+	if (candidateQuiesced) {
+		if (state.agentPluginTransaction) {
+			state.installErrors.push(...state.agentPluginTransaction.rollback());
+		}
+		const resourceSnapshotRollbackErrors = state.rollbackSnapshots.restore(
+			plan.resourceRollbackScope,
+		);
+		state.installErrors.push(...resourceSnapshotRollbackErrors);
+		try {
+			hostedRuntimeContract.assertPlatformRoots();
+			const snapshotRollbackErrors = state.rollbackSnapshots.restore();
+			state.installErrors.push(...snapshotRollbackErrors);
+			if (state.rollbackEgressSecretOverride) {
+				writeEgressSecretMaterial(state.rollbackEgressSecretOverride, paths);
+			} else if (state.rollbackEgressSecretRevision) {
+				const committedMaterial = verifiedCommittedEgressSecretMaterial(paths, applyContext);
+				if (committedMaterial?.revision === state.rollbackEgressSecretRevision) {
+					writeEgressSecretMaterial(committedMaterial, paths);
+				} else {
+					state.egressRollbackAuthorityVerified = false;
 					rmSync(egressSecretFilePath(paths), { force: true });
 				}
-				filesystemRollbackSucceeded =
-					resourceSnapshotRollbackErrors.length === 0 && snapshotRollbackErrors.length === 0;
-			} catch (rollbackError) {
-				installErrors.push(
-					`runtime filesystem rollback failed: ${
-						rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
-					}`,
-				);
+			} else if (!state.egressRollbackAuthorityVerified) {
+				rmSync(egressSecretFilePath(paths), { force: true });
 			}
-		} else {
-			installErrors.push(
-				"runtime filesystem rollback skipped because candidate services did not quiesce",
+			filesystemRollbackSucceeded =
+				resourceSnapshotRollbackErrors.length === 0 && snapshotRollbackErrors.length === 0;
+		} catch (rollbackError) {
+			state.installErrors.push(
+				`runtime filesystem rollback failed: ${
+					rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+				}`,
 			);
 		}
-		if (
-			filesystemRollbackSucceeded &&
-			!workspaceExistedBeforeApply &&
-			resolve(workspaceRoot) !== resolve(paths.userHome) &&
-			withRuntimeUserFileAccess(() => existsSync(workspaceRoot))
-		) {
-			try {
-				withRuntimeUserFileAccess(() => {
-					if (readdirSync(workspaceRoot).length === 0) {
-						rmSync(workspaceRoot, { recursive: true });
-					}
-				});
-			} catch (rollbackError) {
-				installErrors.push(
-					`runtime workspace rollback failed: ${
-						rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
-					}`,
-				);
-			}
-		}
-		if (opts.systemdApply && filesystemRollbackSucceeded && rollbackRequiresQuiesce) {
-			try {
-				opts.systemdApply.rollback({
-					restartDaemon,
-					restartEgressSidecar: restartEgressSidecar && egressRollbackAuthorityVerified,
-					stopEgressSidecar: restartEgressSidecar && !egressRollbackAuthorityVerified,
-					reconcileUserUnits: mutationPlan.systemdUserUnits,
-					restartUserUnits: [
-						...new Set([...agentPluginRestartUserUnits, ...runtimeProjectionRestartUserUnits]),
-					].sort(),
-					staleSystemUnits: staleSystemdFiles.systemUnits,
-					staleUserUnits: staleSystemdFiles.userUnits,
-				});
-			} catch (rollbackError) {
-				installErrors.push(
-					`runtime systemd rollback failed: ${
-						rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
-					}`,
-				);
-			}
-		} else if (opts.systemdApply && rollbackRequiresQuiesce && candidateQuiesced) {
-			installErrors.push(
-				"runtime systemd rollback skipped because filesystem authority restoration failed",
-			);
-		} else if (opts.systemdApply && rollbackRequiresQuiesce) {
-			installErrors.push(
-				"runtime systemd reconciliation skipped because candidate services did not quiesce",
+	} else {
+		state.installErrors.push(
+			"runtime filesystem rollback skipped because candidate services did not quiesce",
+		);
+	}
+	if (
+		filesystemRollbackSucceeded &&
+		!plan.workspaceExistedBeforeApply &&
+		resolve(workspaceRoot) !== resolve(paths.userHome) &&
+		withRuntimeUserFileAccess(() => existsSync(workspaceRoot))
+	) {
+		try {
+			withRuntimeUserFileAccess(() => {
+				if (readdirSync(workspaceRoot).length === 0) {
+					rmSync(workspaceRoot, { recursive: true });
+				}
+			});
+		} catch (rollbackError) {
+			state.installErrors.push(
+				`runtime workspace rollback failed: ${
+					rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+				}`,
 			);
 		}
-		if (!egressRollbackAuthorityVerified) {
-			installErrors.push(
-				"runtime egress sidecar stopped because committed secret rollback authority could not be verified",
+	}
+	if (opts.systemdApply && filesystemRollbackSucceeded && rollbackRequiresQuiesce) {
+		try {
+			opts.systemdApply.rollback({
+				restartDaemon: state.restartDaemon,
+				restartEgressSidecar: state.restartEgressSidecar && state.egressRollbackAuthorityVerified,
+				stopEgressSidecar: state.restartEgressSidecar && !state.egressRollbackAuthorityVerified,
+				reconcileUserUnits: plan.mutationPlan.systemdUserUnits,
+				restartUserUnits: [
+					...new Set([
+						...state.agentPluginRestartUserUnits,
+						...state.runtimeProjectionRestartUserUnits,
+					]),
+				].sort(),
+				staleSystemUnits: state.staleSystemdFiles.systemUnits,
+				staleUserUnits: state.staleSystemdFiles.userUnits,
+			});
+		} catch (rollbackError) {
+			state.installErrors.push(
+				`runtime systemd rollback failed: ${
+					rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+				}`,
 			);
 		}
-		installErrors.unshift(`runtime apply failed: ${applyError}`);
-		return runtimeConvergenceWithoutApply({
-			load,
-			paths,
-			workspaceRoot,
-			enabledRuntimes,
-			installErrors,
-			projectedProviderIds: retainPreviousProjectedProviderIds(),
-			agentPluginFailedNames: [...agentPluginFailedNames].sort(),
-		});
+	} else if (opts.systemdApply && rollbackRequiresQuiesce && candidateQuiesced) {
+		state.installErrors.push(
+			"runtime systemd rollback skipped because filesystem authority restoration failed",
+		);
+	} else if (opts.systemdApply && rollbackRequiresQuiesce) {
+		state.installErrors.push(
+			"runtime systemd reconciliation skipped because candidate services did not quiesce",
+		);
+	}
+	if (!state.egressRollbackAuthorityVerified) {
+		state.installErrors.push(
+			"runtime egress sidecar stopped because committed secret rollback authority could not be verified",
+		);
+	}
+	state.installErrors.unshift(`runtime apply failed: ${applyError}`);
+	return runtimeConvergenceFailure(context, state, true);
+}
+
+export function convergeRuntimeManifest(
+	load: RuntimeManifestLoad,
+	paths: RuntimePaths,
+	opts: RuntimeConvergenceOptions = {},
+): RuntimeConvergenceResult {
+	const { context, state } = initializeRuntimeConvergence(load, paths, opts);
+	const installResult = prepareRuntimeInstallStage(context, state);
+	if ("result" in installResult) return installResult.result;
+	const planResult = prepareRuntimeConvergencePlan(context, state, installResult.stage);
+	if ("result" in planResult) return planResult.result;
+	const plan = planResult.plan;
+	try {
+		const codexCli = prepareRuntimeApplyDependencies(context, state, plan);
+		writeRuntimeManifestState(context);
+		const egressProjection = prepareRuntimeEgressProjection(context, state);
+		const providerProjectionRevisions = applyRuntimeResourceProjections(
+			context,
+			state,
+			plan,
+			codexCli,
+		);
+
+		applyRuntimeEntryProjections(context, state, plan, egressProjection);
+		const activationPlan = prepareRuntimeActivation(
+			context,
+			state,
+			plan,
+			egressProjection,
+			providerProjectionRevisions,
+		);
+		const activationOutputs = activateRuntimeServices(context, state, plan, activationPlan);
+		const convergence = buildRuntimeConvergenceResult(
+			context,
+			state,
+			egressProjection,
+			activationPlan,
+			activationOutputs,
+		);
+		commitRuntimeConvergence(context, state, plan, egressProjection, activationPlan, convergence);
+		state.rollbackSnapshots.pop();
+		return convergence;
+	} catch (error) {
+		return rollbackRuntimeApply(context, state, plan, error);
 	}
 }

--- a/packages/cli/src/runtime/manifest-install.ts
+++ b/packages/cli/src/runtime/manifest-install.ts
@@ -95,6 +95,7 @@ export function runtimeAppRoot(name: string, home: string): string | null {
 }
 const HERMES_DASHBOARD_CAPABILITY_PROBE =
 	"import uvicorn; assert callable(getattr(uvicorn.Server, 'capture_signals', None))";
+const HERMES_DASHBOARD_CAPABILITY_PROBE_TIMEOUT_MS = 30_000;
 const DEFAULT_RUNTIME_INSTALL_TIMEOUT_MS = 30 * 60 * 1000;
 function runtimeInstallTimeoutMs(): number {
 	const raw = process.env.CLAWDI_RUNTIME_INSTALL_TIMEOUT;
@@ -123,7 +124,7 @@ function hermesDashboardCapabilityError(
 			["-c", HERMES_DASHBOARD_CAPABILITY_PROBE],
 			runtime.install.home,
 			runtime.install.home,
-			{ timeoutMs: 30_000 },
+			{ timeoutMs: HERMES_DASHBOARD_CAPABILITY_PROBE_TIMEOUT_MS },
 		);
 	} catch (error) {
 		return `Hermes dashboard runtime capability probe failed: ${

--- a/packages/cli/src/runtime/manifest-planning.ts
+++ b/packages/cli/src/runtime/manifest-planning.ts
@@ -503,22 +503,47 @@ export function managedOpenClawPluginBootstrapMutationPlan(
 		metadataTargets: mutationAncestorMetadataTargets(targets, runtimeUserTrustedRoots),
 	};
 }
+export interface RuntimeSnapshotRollbackScope {
+	readonly start: number;
+}
+
+export interface RuntimeSnapshotCaptureScope extends RuntimeSnapshotRollbackScope {
+	readonly snapshot: RuntimeLiveSnapshot;
+}
+
 export class RuntimeSnapshotRollbackStack {
 	readonly #snapshots: Array<{ failure: string; snapshot: RuntimeLiveSnapshot }> = [];
 
 	capture(failure: string, plan: RuntimeManagedMutationPlan): RuntimeLiveSnapshot {
-		const snapshot = captureRuntimeLiveSnapshot(plan);
-		this.#snapshots.push({ failure, snapshot });
-		return snapshot;
+		return this.captureScoped(failure, plan).snapshot;
 	}
 
-	restore(): string[] {
+	scope(): RuntimeSnapshotRollbackScope {
+		return { start: this.#snapshots.length };
+	}
+
+	captureScoped(failure: string, plan: RuntimeManagedMutationPlan): RuntimeSnapshotCaptureScope {
+		const start = this.#snapshots.length;
+		const snapshot = captureRuntimeLiveSnapshot(plan);
+		this.#snapshots.push({ failure, snapshot });
+		return { start, snapshot };
+	}
+
+	pop(scope?: RuntimeSnapshotRollbackScope): void {
+		this.#snapshots.splice(scope?.start ?? 0);
+	}
+
+	restore(
+		scope?: RuntimeSnapshotRollbackScope,
+		formatFailure: (failure: string, error: unknown) => string = (failure, error) =>
+			`${failure}: ${error instanceof Error ? error.message : String(error)}`,
+	): string[] {
 		const errors: string[] = [];
-		for (const { failure, snapshot } of this.#snapshots.splice(0).reverse()) {
+		for (const { failure, snapshot } of this.#snapshots.splice(scope?.start ?? 0).reverse()) {
 			try {
 				restoreRuntimeLiveSnapshot(snapshot);
 			} catch (error) {
-				errors.push(`${failure}: ${error instanceof Error ? error.message : String(error)}`);
+				errors.push(formatFailure(failure, error));
 			}
 		}
 		return errors;

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -49,6 +49,8 @@ import {
 } from "./runtime-user-command";
 import { runtimeSecretValue } from "./secret-values";
 
+const CODEX_BOOTSTRAP_TIMEOUT_MS = 600_000;
+
 export function writeProviderHealthStatus(
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
@@ -481,7 +483,7 @@ function installHostedCodexBootstrap(
 		],
 		paths.userHome,
 		paths.userHome,
-		{ timeoutMs: 600_000 },
+		{ timeoutMs: CODEX_BOOTSTRAP_TIMEOUT_MS },
 	);
 	if (result.status !== 0) {
 		throw new Error(


### PR DESCRIPTION
## Summary

This is the final structural convergence pass for Hosted runtime rollback orchestration. It changes orchestration shape only: fail-closed behavior, snapshot trust boundaries, runtime identity rules, timeout values, and public contracts remain unchanged.

### 1. Bring resource snapshots into the rollback stack

**Before:** Skill projection and Agent Plugin snapshots lived outside `RuntimeSnapshotRollbackStack`, with separate inline restoration and outer-catch restoration paths.

**After:** the stack supports scoped capture, restore, and pop. Both resource snapshots register with the shared stack, successful local recovery pops its scope, and outer failure restores the remaining resource scopes in reverse order through one orchestration path. Resource snapshots still restore before the platform-root assertion; earlier platform snapshots still restore only after that assertion succeeds.

### 2. Unify managed target rollback

**Before:** `withManagedTargetRollback` and `activateManagedSkillDirectory` independently implemented rename-backup-restore, and bundled Hermes Skill installation nested both primitives.

**After:** `withManagedTargetRollback` is the single commit-point-aware primitive. Directory activation delegates target, receipt, restore hooks, cleanup hooks, and recovery-artifact error reporting to it. Bundled Hermes activation uses that primitive once. The production-unused `managedSkillReceiptOwnsTarget` export is removed.

### 3. Stage runtime manifest convergence

**Before:** `convergeRuntimeManifest` was a roughly 1,300-line function coordinating more than 15 mutable flags and five rollback ladders inline.

**After:** `convergeRuntimeManifest` is a 45-line sequential orchestrator. Cross-stage coordination is carried by explicit `RuntimeConvergenceContext` and `RuntimeConvergenceState` objects, while rollback stays centralized in the snapshot stack and existing transaction registries.

Stage map:

1. `initializeRuntimeConvergence`
2. `prepareRuntimeInstallStage`
3. `prepareRuntimeConvergencePlan`
4. `prepareRuntimeApplyDependencies`
5. `writeRuntimeManifestState`
6. `prepareRuntimeEgressProjection`
7. `applyRuntimeResourceProjections`
8. `applyRuntimeEntryProjections`
9. `prepareRuntimeActivation`
10. `activateRuntimeServices`
11. `buildRuntimeConvergenceResult`
12. `commitRuntimeConvergence`
13. `rollbackRuntimeApply`

Every stage is under 200 lines; the largest is 196 lines. The second `validateRuntimeProjectionPlan` call remains intentionally in place after capability repair and now documents why revalidation is required.

### 4. Package the remaining cleanup

**Before:** v1 manifest compatibility had no concrete retirement condition, Hosted operation timeout policy was repeated as inline numeric literals, and one obsolete managed Skill ownership helper remained exported.

**After:** the compatibility comment names the producer migration condition and #1148, each requested timeout has a file-level policy constant with the exact same value, and the obsolete export is gone.

## Zero-behavior-change evidence

- Snapshot capture plans, reverse restoration order, error aggregation, and platform-root trust assertion order are preserved.
- The managed directory commit point remains successful activation; backup cleanup remains best-effort GC and cannot roll back a live target or receipt.
- Both projection-plan validations remain, including the intentional post-capability-repair revalidation.
- Hosted timeout values are unchanged.
- No manifest schema, wire contract, fail-closed branch, or #1147 ownership identity rule changed.
- The exact mutation-parity gate passes against real Hosted converge mutations.

## Verification

Using the declared Bun 1.4.0 toolchain:

- `bun run --cwd packages/cli test:internal`: 1746 passed, 4 skipped, 0 failed across 136 files
- `manifest-mutation-parity.test.ts`: 1 passed, 0 failed
- `manifest-reconciliation.test.ts`: 187 passed, 0 failed
- `manifest-services.test.ts`: 31 passed, 0 failed
- `manifest-channels.test.ts`: 4 passed, 0 failed
- `manifest-contract.test.ts`: 2 passed, 0 failed
- `bun run --cwd packages/cli typecheck`: passed
- Biome check for all 11 changed files: passed
- `git diff --check origin/main...HEAD`: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
