### PR TITLE
release(cli): 0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.3
+
+Package: `clawdi@0.14.3`
+
+### Fixed
+
+- Legacy root-owned skill metadata left by older CLI versions no longer breaks
+  convergence: tenant-home ownership is repaired as a platform invariant before
+  every converge, legacy markers are claimed through a single adoption path,
+  and one skill failing to install no longer blocks the remaining skills.
+
+### Improved
+
+- All platform metadata (skill receipts, WhatsApp auth ownership) now lives in
+  platform state outside the tenant home; tenant directories contain only
+  tenant-owned content, read and written strictly as the runtime user.
+
 ## Clawdi CLI v0.14.2
 
 Package: `clawdi@0.14.2`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.2",
+	"version": "0.14.3",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Release `clawdi@0.14.3` — the root-cause release for the canary-discovered legacy-state failures, plus the final structural consolidation.

- **#1147**: tenant-home ownership repaired as a platform invariant before every converge; single legacy-marker adoption path; skill receipts moved to platform state (`managedResourceRoot/skill-receipts/`, root-owned, `O_NOFOLLOW`-hardened — anti-forgery preserved); one identity rule (tenant content as runtime user, platform metadata as platform); per-skill failure isolation (resource failures degrade and report per skill, integrity refusals still fail closed).
- **#1149**: WhatsApp auth ownership marker moved out of the auth tree to platform state, with one-shot migration.
- **#1151**: convergence engine phased — 45-line orchestrator over 13 named stages, single snapshot rollback stack, one directory-rollback primitive.

Fourth canary retest on the same legacy-state deployment follows this release; pass bar is sustained clean converges across multiple observation cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)