### PR TITLE
fix(cli): preserve platform ownership enclaves

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -358,14 +358,16 @@ previous exact pre-image. There is no separate active/previous link state or
 hand-built chroot.
 
 `clawdi-files.service` runs as the non-root tenant runtime UID/GID so Files has
-native read/write access to the complete tenant home, including `0600` files,
-`0700` directories, and dotfiles. Reconciliation does not rewrite ownership,
-modes, or ACLs across the home. Candidate directories and binaries remain
-root-owned. The root-authored JWT configuration is a `root:<runtime group>`
-`0440` file below a root-only `0700` directory, so other tenant processes
-cannot traverse to it; systemd publishes that file and the verified binary only
-inside the Files mount namespace through `BindReadOnlyPaths=`. Install receipts
-remain root-only `0600`.
+native read/write access to tenant-owned home content, including `0600` files,
+`0700` directories, and dotfiles. Before snapshots, reconciliation repairs
+tenant-home ownership recursively except for declared platform enclaves:
+`$HOME/.config/systemd/user` and OpenClaw's
+`$HOME/.openclaw/gateway.systemd.env`. It does not rewrite modes or ACLs.
+Candidate directories and binaries remain root-owned. The root-authored JWT
+configuration is a `root:<runtime group>` `0440` file below a root-only `0700`
+directory, so other tenant processes cannot traverse to it; systemd publishes
+that file and the verified binary only inside the Files mount namespace through
+`BindReadOnlyPaths=`. Install receipts remain root-only `0600`.
 
 DB/cache state lives in the tenant-owned `0700`
 `StateDirectory=clawdi-files`. The tenant can therefore inspect or alter its
@@ -398,8 +400,9 @@ reconciliation stops and withdraws only `clawdi-files.service` while preserving
 the selected Hermes or OpenClaw unit.
 
 The unavoidable workspace boundary is content-level: the tenant owns its home
-and can edit or delete its contents and Files state. This does not grant the
-tenant control over the root-owned binary, configuration secret source,
+outside the declared platform enclaves and can edit or delete its contents and
+Files state. This does not grant the tenant control over the root-owned binary,
+configuration secret source,
 receipts, unit, or listener authority. Port 9120 has normal socket exclusivity
 rather than a separate tenant-slice reservation: the tenant cannot displace the
 running service, but can bind 9120 while it is not listening and thereby cause

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -124,7 +124,7 @@ import {
 import type { RuntimeManifestLoad } from "./manifest-source";
 import { ensureRuntimeMitmproxy } from "./mitmproxy-fetch";
 import { ensureManagedOpenClawProviderPlugin } from "./openclaw-managed-provider-plugin";
-import { runtimeSystemdPlatformEnclaves, type RuntimePaths } from "./paths";
+import { type RuntimePaths, runtimeSystemdPlatformEnclaves } from "./paths";
 import { hostedRuntimeProjectionHome } from "./projection-home";
 import { runtimeRunConfigId, writeRuntimeRunConfig } from "./run-config";
 import { daemonProgramRevision } from "./runtime-impact-revision";
@@ -274,7 +274,9 @@ function initializeRuntimeConvergence(
 		managedResourceRoot: paths.managedResourceRoot,
 	});
 	const platformEnclaves =
-		resolve(projectionHome) === resolve(paths.userHome) ? runtimeSystemdPlatformEnclaves(paths) : [];
+		resolve(projectionHome) === resolve(paths.userHome)
+			? runtimeSystemdPlatformEnclaves(paths)
+			: [];
 	enforceRuntimeUserOwnership([
 		...runtimeUserDirectoryOwnership(projectionHome, { recursive: true, platformEnclaves }),
 		// Official user-service installers need the unit root itself writable. Its

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -124,7 +124,7 @@ import {
 import type { RuntimeManifestLoad } from "./manifest-source";
 import { ensureRuntimeMitmproxy } from "./mitmproxy-fetch";
 import { ensureManagedOpenClawProviderPlugin } from "./openclaw-managed-provider-plugin";
-import type { RuntimePaths } from "./paths";
+import { runtimeSystemdPlatformEnclaves, type RuntimePaths } from "./paths";
 import { hostedRuntimeProjectionHome } from "./projection-home";
 import { runtimeRunConfigId, writeRuntimeRunConfig } from "./run-config";
 import { daemonProgramRevision } from "./runtime-impact-revision";
@@ -266,15 +266,22 @@ function initializeRuntimeConvergence(
 		opts.hostedRuntimeContract,
 	);
 	const projectionHome = hostedRuntimeProjectionHome(manifest, paths);
-	// Platform metadata must leave tenant HOME before the recursive ownership
-	// invariant is repaired. Both operations precede snapshots by design.
+	// Tenant HOME belongs to the runtime user except for declared platform
+	// enclaves. Metadata migration and ownership repair precede snapshots by design.
 	migrateLegacyHostedSkillReceipts({
 		manifest,
 		home: projectionHome,
 		managedResourceRoot: paths.managedResourceRoot,
 	});
+	const platformEnclaves =
+		resolve(projectionHome) === resolve(paths.userHome) ? runtimeSystemdPlatformEnclaves(paths) : [];
 	enforceRuntimeUserOwnership([
-		...runtimeUserDirectoryOwnership(projectionHome, { recursive: true }),
+		...runtimeUserDirectoryOwnership(projectionHome, { recursive: true, platformEnclaves }),
+		// Official user-service installers need the unit root itself writable. Its
+		// enclave contents retain their existing ownership and are not traversed.
+		...(platformEnclaves.includes(paths.systemdUserRoot)
+			? runtimeUserDirectoryOwnership(paths.systemdUserRoot)
+			: []),
 		...hostedOpenClawRuntimeUserOwnership(manifest, projectionHome),
 	]);
 	const openClawContext = createOpenClawHostedContext(manifest, projectionHome);

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -92,6 +92,20 @@ export interface RuntimePaths {
 	workspaceRoot: string;
 }
 
+export function runtimeSystemdPlatformEnclaves(
+	paths: Pick<RuntimePaths, "systemdUserRoot" | "userHome">,
+): string[] {
+	return [
+		// systemd requires user units below HOME. This root contains base units and
+		// backups, Clawdi drop-ins, and default.target enablement links. Preserving
+		// root-owned pre-images is required for rollback and generated-file authority.
+		paths.systemdUserRoot,
+		// OpenClaw's installer writes this private environment file in HOME. Clawdi
+		// must snapshot and restore a root-owned pre-image without first adopting it.
+		join(paths.userHome, ".openclaw", "gateway.systemd.env"),
+	];
+}
+
 function envPath(name: string): string | undefined {
 	const value = process.env[name]?.trim();
 	return value ? value : undefined;

--- a/packages/cli/src/runtime/runtime-user-command.test.ts
+++ b/packages/cli/src/runtime/runtime-user-command.test.ts
@@ -2,15 +2,18 @@ import { describe, expect, test } from "bun:test";
 import {
 	chmodSync,
 	chownSync,
+	lstatSync,
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
 	rmSync,
 	statSync,
+	symlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { runtimeSystemdPlatformEnclaves } from "./paths";
 import {
 	buildNumericUserCommand,
 	buildRuntimeUserCommand,
@@ -19,6 +22,7 @@ import {
 	createPrivilegeDropResolver,
 	enforceRuntimeUserOwnership,
 	runRuntimeUserCommand,
+	runtimeUserDirectoryOwnership,
 	runtimeUserExistingOwnership,
 	runtimeUserGid,
 	runtimeUserUid,
@@ -431,4 +435,95 @@ test("recursively restores runtime ownership only inside declared state roots", 
 		else process.env.CLAWDI_RUNTIME_USER = previousRuntimeUser;
 		rmSync(root, { recursive: true, force: true });
 	}
+});
+
+test("preserves declared platform enclaves while repairing the rest of runtime HOME", () => {
+	if (process.geteuid?.() !== 0) return;
+	const root = mkdtempSync(join(tmpdir(), "runtime-user-platform-enclaves-"));
+	const home = join(root, "home");
+	const systemdUserRoot = join(home, ".config", "systemd", "user");
+	const unit = join(systemdUserRoot, "openclaw-gateway.service");
+	const dropIn = join(`${unit}.d`, "10-clawdi-hosted.conf");
+	const wants = join(systemdUserRoot, "default.target.wants");
+	const enablement = join(wants, "openclaw-gateway.service");
+	const gatewayEnvironment = join(home, ".openclaw", "gateway.systemd.env");
+	const tenantFile = join(home, ".hermes", "config.yaml");
+	const previousRuntimeUser = process.env.CLAWDI_RUNTIME_USER;
+	try {
+		mkdirSync(dirname(dropIn), { recursive: true });
+		mkdirSync(wants, { recursive: true });
+		mkdirSync(dirname(gatewayEnvironment), { recursive: true });
+		mkdirSync(dirname(tenantFile), { recursive: true });
+		writeFileSync(unit, "unit\n");
+		writeFileSync(dropIn, "drop-in\n");
+		symlinkSync("../openclaw-gateway.service", enablement);
+		writeFileSync(gatewayEnvironment, "TOKEN=platform\n", { mode: 0o600 });
+		writeFileSync(tenantFile, "model: tenant\n", { mode: 0o600 });
+		for (const path of [
+			root,
+			home,
+			join(home, ".config"),
+			join(home, ".config", "systemd"),
+			systemdUserRoot,
+			unit,
+			dirname(dropIn),
+			dropIn,
+			wants,
+			gatewayEnvironment,
+			dirname(gatewayEnvironment),
+			dirname(tenantFile),
+			tenantFile,
+		]) {
+			chownSync(path, 0, 0);
+		}
+		process.env.CLAWDI_RUNTIME_USER = "nobody";
+		const platformEnclaves = runtimeSystemdPlatformEnclaves({ userHome: home, systemdUserRoot });
+		expect(platformEnclaves).toEqual([systemdUserRoot, gatewayEnvironment]);
+
+		enforceRuntimeUserOwnership(
+			runtimeUserDirectoryOwnership(home, { recursive: true, platformEnclaves }),
+		);
+
+		for (const path of [
+			systemdUserRoot,
+			unit,
+			dirname(dropIn),
+			dropIn,
+			wants,
+			enablement,
+			gatewayEnvironment,
+		]) {
+			const node = lstatSync(path);
+			expect([node.uid, node.gid]).toEqual([0, 0]);
+		}
+		const expectedRuntimeOwner = [runtimeUserUid("nobody"), runtimeUserGid("nobody")];
+		for (const path of [
+			home,
+			join(home, ".config"),
+			join(home, ".config", "systemd"),
+			dirname(gatewayEnvironment),
+			dirname(tenantFile),
+			tenantFile,
+		]) {
+			const node = lstatSync(path);
+			expect([node.uid, node.gid]).toEqual(expectedRuntimeOwner);
+		}
+	} finally {
+		if (previousRuntimeUser === undefined) delete process.env.CLAWDI_RUNTIME_USER;
+		else process.env.CLAWDI_RUNTIME_USER = previousRuntimeUser;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("rejects platform enclaves without a recursive in-bound ownership root", () => {
+	const home = join(tmpdir(), "runtime-user-platform-enclave-boundary");
+	expect(() =>
+		runtimeUserDirectoryOwnership(home, { platformEnclaves: [join(home, "platform")] }),
+	).toThrow("runtime-user platform enclaves require recursive ownership");
+	expect(() =>
+		runtimeUserDirectoryOwnership(home, {
+			recursive: true,
+			platformEnclaves: [join(home, "..", "platform")],
+		}),
+	).toThrow("runtime-user platform enclave is outside its ownership boundary");
 });

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -29,6 +29,8 @@ export interface RuntimeUserOwnershipRule {
 	kind: "directory" | "existing";
 	mode?: number;
 	recursive: boolean;
+	// Recursive ownership stops at these platform-owned subtree roots.
+	platformEnclaves?: readonly string[];
 }
 
 export type RuntimeUserIdentityResolver = (runtimeUser: string) => RuntimeUserIdentity;
@@ -391,7 +393,12 @@ function positiveLinuxIdEnv(key: string, fallback: number): number {
 
 export function runtimeUserDirectoryOwnership(
 	path: string,
-	options: { mode?: number; ancestorsUnder?: string; recursive?: boolean } = {},
+	options: {
+		mode?: number;
+		ancestorsUnder?: string;
+		recursive?: boolean;
+		platformEnclaves?: readonly string[];
+	} = {},
 ): RuntimeUserOwnershipRule[] {
 	const target = resolve(path);
 	const paths = [target];
@@ -406,7 +413,37 @@ export function runtimeUserDirectoryOwnership(
 			if (current === boundary) break;
 		}
 	}
-	return runtimeUserOwnershipRules(paths, "directory", options, target);
+	const rules = runtimeUserOwnershipRules(paths, "directory", options, target);
+	const platformEnclaves = normalizedPlatformEnclaves(target, options);
+	return platformEnclaves.length === 0
+		? rules
+		: rules.map((rule) =>
+				rule.path === target ? { ...rule, platformEnclaves } : rule,
+			);
+}
+
+function normalizedPlatformEnclaves(
+	target: string,
+	options: { recursive?: boolean; platformEnclaves?: readonly string[] },
+): string[] {
+	const enclaves = [...new Set((options.platformEnclaves ?? []).map((path) => resolve(path)))].sort(
+		(left, right) => left.length - right.length || left.localeCompare(right),
+	);
+	if (enclaves.length > 0 && options.recursive !== true) {
+		throw new Error("runtime-user platform enclaves require recursive ownership");
+	}
+	for (const enclave of enclaves) {
+		const relativeEnclave = relative(target, enclave);
+		if (
+			!relativeEnclave ||
+			relativeEnclave === ".." ||
+			relativeEnclave.startsWith("../") ||
+			isAbsolute(relativeEnclave)
+		) {
+			throw new Error(`runtime-user platform enclave is outside its ownership boundary: ${enclave}`);
+		}
+	}
+	return enclaves;
 }
 
 export const runtimeUserExistingOwnership = (
@@ -449,7 +486,13 @@ export function enforceRuntimeUserOwnership(rules: readonly RuntimeUserOwnership
 		if (rule.kind === "directory" && (!node.isDirectory() || node.isSymbolicLink())) {
 			throw new Error(`runtime-user ownership path must be a real directory: ${rule.path}`);
 		}
-		enforceRuntimeUserNodeOwnership(rule.path, node, identity, rule.recursive);
+		enforceRuntimeUserNodeOwnership(
+			rule.path,
+			node,
+			identity,
+			rule.recursive,
+			new Set(rule.platformEnclaves ?? []),
+		);
 		if (rule.mode !== undefined) chmodSync(rule.path, rule.mode);
 	}
 }
@@ -470,7 +513,9 @@ function enforceRuntimeUserNodeOwnership(
 	node: NonNullable<ReturnType<typeof lstatSync>>,
 	identity: RuntimeUserIdentity | null,
 	recursive: boolean,
+	platformEnclaves: ReadonlySet<string>,
 ): void {
+	if (platformEnclaves.has(path)) return;
 	if (identity && (node.uid !== identity.uid || node.gid !== identity.gid)) {
 		if (node.isSymbolicLink()) lchownSync(path, identity.uid, identity.gid);
 		else chownSync(path, identity.uid, identity.gid);
@@ -478,7 +523,7 @@ function enforceRuntimeUserNodeOwnership(
 	if (!recursive || !node.isDirectory() || node.isSymbolicLink()) return;
 	for (const entry of readdirSync(path)) {
 		const child = join(path, entry);
-		enforceRuntimeUserNodeOwnership(child, lstatSync(child), identity, true);
+		enforceRuntimeUserNodeOwnership(child, lstatSync(child), identity, true, platformEnclaves);
 	}
 }
 

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -417,9 +417,7 @@ export function runtimeUserDirectoryOwnership(
 	const platformEnclaves = normalizedPlatformEnclaves(target, options);
 	return platformEnclaves.length === 0
 		? rules
-		: rules.map((rule) =>
-				rule.path === target ? { ...rule, platformEnclaves } : rule,
-			);
+		: rules.map((rule) => (rule.path === target ? { ...rule, platformEnclaves } : rule));
 }
 
 function normalizedPlatformEnclaves(
@@ -440,7 +438,9 @@ function normalizedPlatformEnclaves(
 			relativeEnclave.startsWith("../") ||
 			isAbsolute(relativeEnclave)
 		) {
-			throw new Error(`runtime-user platform enclave is outside its ownership boundary: ${enclave}`);
+			throw new Error(
+				`runtime-user platform enclave is outside its ownership boundary: ${enclave}`,
+			);
 		}
 	}
 	return enclaves;

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -947,8 +947,6 @@ test("runs Files as the tenant while preserving platform isolation", () => {
 	const tenantExisting = join(runtimeHome, "files-tenant-existing.txt");
 	writeFileSync(tenantExisting, "tenant-existing\n", { mode: 0o600 });
 	chownSync(tenantExisting, runtimeUid, runtimeGid);
-	const rootOwnedControl = join(runtimeHome, "files-root-owned-control.txt");
-	writeFileSync(rootOwnedControl, "root-owned\n", { mode: 0o600 });
 	const hermesConfig = join(runtimeHome, ".hermes", "config.yaml");
 	mkdirSync(dirname(hermesConfig), { recursive: true, mode: 0o700 });
 	chownSync(dirname(hermesConfig), runtimeUid, runtimeGid);
@@ -983,6 +981,8 @@ test("runs Files as the tenant while preserving platform isolation", () => {
 	chownSync(openClawConfig, runtimeUid, runtimeGid);
 	const paths = getRuntimePaths({ mode: "hosted" });
 	ensureRuntimeStateDirs(paths);
+	const rootOwnedControl = join(paths.systemdUserRoot, "files-root-owned-control");
+	writeFileSync(rootOwnedControl, "root-owned\n", { mode: 0o600 });
 	const legacyEnvironmentRoot = join(runtimeHome, ".clawdi", "environments");
 	mkdirSync(legacyEnvironmentRoot, { recursive: true });
 	writeFileSync(


### PR DESCRIPTION
## Incident

The privileged systemd E2E run `32476818572` exposed two 0.14.3 release blockers after #1147:

- rollback after a real OpenClaw installer failure restored the official user unit and `gateway.systemd.env` with UID 10001 instead of their original root ownership;
- the Files isolation scenario timed out in readiness with a non-empty `installErrors` result.

The recursive ownership repair introduced by #1147 ran before the live-state snapshot and adopted every node below the tenant home. That changed the ownership metadata of root-authored systemd pre-images before rollback could capture them.

The Files failure had the same invariant mismatch in its fixture: it placed an arbitrary root-owned control file directly in the tenant home. The ownership repair correctly adopted that non-enclave file, Files could read it, and the fixture deliberately exited 77, which surfaced as a readiness timeout.

## Invariant correction

Tenant HOME belongs to the runtime user **except for declared platform enclaves**.

This change makes platform enclaves a first-class property of recursive runtime-user ownership rules. An enclave must be strictly inside its ownership boundary, and traversal stops at the enclave root without changing that node or any descendant. The systemd user-unit root also receives a separate non-recursive runtime-user ownership rule so official installers can create their units while existing enclave contents retain their pre-image ownership.

## Platform enclave inventory

- `$HOME/.config/systemd/user`: systemd requires user units to live below HOME. This prefix covers official base units and `.bak` pre-images, Clawdi hosted drop-in directories/files, and `default.target.wants` enablement directories/symlinks. Preserving existing root-authored nodes is required for exact rollback metadata and generated-file authority checks.
- `$HOME/.openclaw/gateway.systemd.env`: the official OpenClaw installer may write this owner-only environment pre-image in HOME. It must be snapshotted and restored without convergence first adopting it.

The Files E2E control file now lives in the real systemd enclave, so the scenario verifies the corrected ownership boundary. The focused ownership test anchors every covered artifact class and also proves that a root-owned tenant file outside the enclaves is still repaired to the runtime UID/GID.

An audit of `writeSystemdUserUnit` and `writePrivateFileAtomic` call sites found no additional root-preserved artifacts inside the projection home. Generated service environment files under `/run/clawdi/systemd/env` are outside tenant HOME and remain governed by the existing platform-root contract.

## Verification

- privileged PID1 systemd E2E: 4 passed, 0 failed, 201 assertions (including both reported regressions)
- focused ownership tests: 22 passed
- runtime paths tests: 6 passed
- CLI TypeScript typecheck: passed under the repository `bun@1.4.0` Docker runner
- CLI full `test:internal`: 1,748 passed, 4 conditionally skipped, 0 failed, 9,532 assertions
- `bunx biome check packages/cli`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
