### PR TITLE
fix(cli): release stale skills and repair enclave ownership

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -362,7 +362,9 @@ native read/write access to tenant-owned home content, including `0600` files,
 `0700` directories, and dotfiles. Before snapshots, reconciliation repairs
 tenant-home ownership recursively except for declared platform enclaves:
 `$HOME/.config/systemd/user` and OpenClaw's
-`$HOME/.openclaw/gateway.systemd.env`. It does not rewrite modes or ACLs.
+`$HOME/.openclaw/gateway.systemd.env`. The same ownership enforcer repairs
+non-root drift inside those enclaves back to root while repairing root drift
+outside them back to the tenant. It does not rewrite modes or ACLs.
 Candidate directories and binaries remain root-owned. The root-authored JWT
 configuration is a `root:<runtime group>` `0440` file below a root-only `0700`
 directory, so other tenant processes cannot traverse to it; systemd publishes

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -539,7 +539,13 @@ export class OpenClawAdapter implements AgentAdapter {
 						const installedTree = collectManagedSkillTree(targetDir, {
 							exclude: new Set([".openclaw/source-origin.json"]),
 						});
-						if (!managedSkillTreesEqual(sourceTree, installedTree)) {
+						if (sourceTree.status !== "collected") {
+							throw new Error(`OpenClaw Skill source tree is ${sourceTree.status}`);
+						}
+						if (installedTree.status !== "collected") {
+							throw new Error(`OpenClaw installed Skill tree is ${installedTree.status}`);
+						}
+						if (!managedSkillTreesEqual(sourceTree.tree, installedTree.tree)) {
 							throw new Error(`OpenClaw installed an unexpected Skill tree in ${workspace}`);
 						}
 					},

--- a/packages/cli/src/runtime/hosted-hermes-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.test.ts
@@ -130,7 +130,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 				skill,
 				previouslyReserved: false,
 			}),
-		).toThrow("installed Skill tree is unsafe");
+		).toThrow("installed Skill tree is absent");
 		expect(readFileSync(commandLog, "utf8").trim()).toBe(
 			`skills install ${installUrl} --name review-pr --yes`,
 		);

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -7,6 +7,7 @@ import {
 	HERMES_MANAGED_SKILL_RECEIPT_SCHEMA,
 	ManagedSkillResourceError,
 	managedSkillMarkerMatchesIdentity,
+	managedSkillReceiptIdentityState,
 	managedSkillReceiptMatchesIdentity,
 	managedSkillReceiptPath,
 	managedSkillTreesEqual,
@@ -128,11 +129,22 @@ function runHermesUninstall(input: { home: string; appRoot: string }, skillId: s
 	return runHermes(input, ["skills", "uninstall", skillId], "y\n");
 }
 
-function bundledResultMatches(sourceDir: string, target: string): boolean {
-	return managedSkillTreesEqual(
-		collectManagedSkillTree(sourceDir),
-		collectRuntimeUserManagedSkillTree(target),
-	);
+function assertBundledResultMatches(sourceDir: string, target: string): void {
+	const source = collectManagedSkillTree(sourceDir);
+	const installed = collectRuntimeUserManagedSkillTree(target);
+	if (source.status !== "collected") {
+		throw new Error(`prepared Hermes bundled Skill tree is ${source.status}`);
+	}
+	if (installed.status !== "collected") {
+		throw new ManagedSkillResourceError(
+			`installed Hermes bundled Skill tree is ${installed.status}`,
+		);
+	}
+	if (!managedSkillTreesEqual(source.tree, installed.tree)) {
+		throw new ManagedSkillResourceError(
+			"Hermes bundled Skill activation changed exact source bytes",
+		);
+	}
 }
 
 export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDriver = {
@@ -152,11 +164,7 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 				replaceManagedSkillDirectoryAtomic(sourceDir, target, {
 					receipt: receipt.path,
 					afterActivate: () => {
-						if (!bundledResultMatches(sourceDir, target)) {
-							throw new ManagedSkillResourceError(
-								"Hermes bundled Skill activation changed exact source bytes",
-							);
-						}
+						assertBundledResultMatches(sourceDir, target);
 						writeManagedSkillReceipt(receipt);
 					},
 				});
@@ -214,11 +222,13 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 			input.skillId,
 			input.ownershipIdentity,
 		);
-		if (!withRuntimeUserFileAccess(() => existsSync(target))) {
+		const receiptState = managedSkillReceiptIdentityState(receipt);
+		if (receiptState === "absent") {
 			rmSync(receipt.path, { force: true });
 			return "absent";
 		}
-		if (!managedSkillReceiptMatchesIdentity(receipt))
+		if (receiptState === "unsafe") throw new Error("Hermes Skill tree is unsafe");
+		if (receiptState !== "matched")
 			throw new Error("Hermes Skill bytes no longer match the manifest ownership receipt");
 		const result = runHermesUninstall(input, input.skillId);
 		if (result.status !== 0)
@@ -240,11 +250,13 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 			input.skillId,
 			input.ownershipIdentity,
 		);
-		if (!withRuntimeUserFileAccess(() => existsSync(target))) {
+		const receiptState = managedSkillReceiptIdentityState(receipt);
+		if (receiptState === "absent") {
 			rmSync(receipt.path, { force: true });
 			return "absent";
 		}
-		if (!managedSkillReceiptMatchesIdentity(receipt)) {
+		if (receiptState === "unsafe") throw new Error("Hermes Skill tree is unsafe");
+		if (receiptState !== "matched") {
 			throw new Error("Hermes Skill bytes no longer match the manifest ownership receipt");
 		}
 		withRuntimeUserFileAccess(() => {

--- a/packages/cli/src/runtime/hosted-openclaw-skill.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.ts
@@ -9,6 +9,7 @@ import {
 	ManagedSkillResourceError,
 	managedSkillMarkerMatchesIdentity,
 	managedSkillMarkerOwnsTarget,
+	managedSkillReceiptIdentityState,
 	managedSkillReceiptMatchesIdentity,
 	managedSkillReceiptPath,
 	OPENCLAW_MANAGED_SKILL_RECEIPT_SCHEMA,
@@ -320,11 +321,15 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 			input.skillId,
 			input.ownershipIdentity,
 		);
-		if (!withRuntimeUserFileAccess(() => existsSync(target))) {
+		const receiptState = managedSkillReceiptIdentityState(receipt);
+		if (receiptState === "absent") {
 			rmSync(receipt.path, { force: true });
 			return "absent";
 		}
-		if (!managedSkillReceiptMatchesIdentity(receipt))
+		if (receiptState === "unsafe") {
+			throw new Error("refusing manifest cleanup because the OpenClaw Skill tree is unsafe");
+		}
+		if (receiptState !== "matched")
 			throw new Error(
 				"refusing manifest cleanup because OpenClaw Skill bytes no longer match the ownership receipt",
 			);

--- a/packages/cli/src/runtime/managed-skill-delivery.test.ts
+++ b/packages/cli/src/runtime/managed-skill-delivery.test.ts
@@ -6,14 +6,30 @@ import {
 	readFileSync,
 	renameSync,
 	rmSync,
+	symlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	collectManagedSkillTree,
 	managedSkillReceiptMatchesIdentity,
 	withManagedTargetRollback,
 } from "./managed-skill-delivery";
+
+test("distinguishes an absent Skill tree from an unsafe tree", () => {
+	const root = mkdtempSync(join(tmpdir(), "managed-skill-collection-"));
+	try {
+		const absent = join(root, "absent");
+		const unsafe = join(root, "unsafe");
+		symlinkSync(absent, unsafe);
+
+		expect(collectManagedSkillTree(absent)).toEqual({ status: "absent" });
+		expect(collectManagedSkillTree(unsafe)).toEqual({ status: "unsafe" });
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
 
 test("restores an already-backed-up target when receipt backup establishment fails", () => {
 	const root = mkdtempSync(join(tmpdir(), "managed-skill-rollback-"));

--- a/packages/cli/src/runtime/managed-skill-delivery.ts
+++ b/packages/cli/src/runtime/managed-skill-delivery.ts
@@ -56,13 +56,26 @@ export function legacyManagedSkillReceiptPath(skillsRoot: string, skillId: strin
 
 export type ManagedSkillTree = ReadonlyMap<string, Buffer>;
 
+export type ManagedSkillTreeCollection =
+	| { status: "collected"; tree: ManagedSkillTree }
+	| { status: "absent" }
+	| { status: "unsafe" };
+
+function isMissingPathError(error: unknown): boolean {
+	return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
 export function collectManagedSkillTree(
 	root: string,
 	options: { exclude?: ReadonlySet<string> } = {},
-): ManagedSkillTree | null {
-	if (!existsSync(root)) return null;
-	const rootStat = lstatSync(root);
-	if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) return null;
+): ManagedSkillTreeCollection {
+	let rootStat: ReturnType<typeof lstatSync>;
+	try {
+		rootStat = lstatSync(root);
+	} catch (error) {
+		return { status: isMissingPathError(error) ? "absent" : "unsafe" };
+	}
+	if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) return { status: "unsafe" };
 	const files = new Map<string, Buffer>();
 	let entries = 0;
 	let totalBytes = 0;
@@ -84,32 +97,35 @@ export function collectManagedSkillTree(
 	};
 	try {
 		visit(root);
-		return files;
-	} catch {
-		return null;
+		return { status: "collected", tree: files };
+	} catch (error) {
+		if (isMissingPathError(error)) {
+			try {
+				lstatSync(root);
+			} catch (rootError) {
+				if (isMissingPathError(rootError)) return { status: "absent" };
+			}
+		}
+		return { status: "unsafe" };
 	}
 }
 
 export function collectRuntimeUserManagedSkillTree(
 	root: string,
 	options: { exclude?: ReadonlySet<string> } = {},
-): ManagedSkillTree | null {
+): ManagedSkillTreeCollection {
 	return withRuntimeUserFileAccess(() => collectManagedSkillTree(root, options));
 }
 
-export function managedSkillTreeFingerprint(tree: ManagedSkillTree | null): string | null {
-	if (!tree) return null;
+export function managedSkillTreeFingerprint(tree: ManagedSkillTree): string {
 	const hash = createHash("sha256");
 	for (const [name, bytes] of [...tree].sort(([left], [right]) => left.localeCompare(right)))
 		hash.update(name).update("\0").update(bytes).update("\0");
 	return hash.digest("hex");
 }
 
-export function managedSkillTreesEqual(
-	left: ManagedSkillTree | null,
-	right: ManagedSkillTree | null,
-): boolean {
-	if (!left || !right || left.size !== right.size) return false;
+export function managedSkillTreesEqual(left: ManagedSkillTree, right: ManagedSkillTree): boolean {
+	if (left.size !== right.size) return false;
 	for (const [name, bytes] of left) if (!right.get(name)?.equals(bytes)) return false;
 	return true;
 }
@@ -130,10 +146,11 @@ export function writeManagedSkillReceipt(input: {
 	target: string;
 	exclude?: ReadonlySet<string>;
 }): void {
-	const treeFingerprint = managedSkillTreeFingerprint(
-		collectRuntimeUserManagedSkillTree(input.target, { exclude: input.exclude }),
-	);
-	if (!treeFingerprint) throw new ManagedSkillResourceError("installed Skill tree is unsafe");
+	const collection = collectRuntimeUserManagedSkillTree(input.target, { exclude: input.exclude });
+	if (collection.status !== "collected") {
+		throw new ManagedSkillResourceError(`installed Skill tree is ${collection.status}`);
+	}
+	const treeFingerprint = managedSkillTreeFingerprint(collection.tree);
 	writeManagedSkillReceiptRecord(input.managedResourceRoot, input.path, {
 		schemaVersion: input.schemaVersion,
 		skillId: input.skillId,
@@ -174,7 +191,6 @@ function readManagedSkillMarkerRaw(input: {
 }): ManagedSkillReceipt | null {
 	let descriptor: number | null = null;
 	try {
-		if (!runtimeUserTargetIsDirectory(input.target)) return null;
 		descriptor = openSync(input.path, constants.O_RDONLY | constants.O_NOFOLLOW);
 		const receiptStat = fstatSync(descriptor);
 		const effectiveUid = process.geteuid?.();
@@ -210,6 +226,7 @@ function readManagedSkillMarker(input: {
 	target: string;
 	exclude?: ReadonlySet<string>;
 }): ManagedSkillReceipt | null {
+	if (!runtimeUserTargetIsDirectory(input.target)) return null;
 	return readManagedSkillMarkerRaw(input);
 }
 
@@ -219,15 +236,18 @@ function readManagedSkillReceipt(input: {
 	skillId: string;
 	target: string;
 	exclude?: ReadonlySet<string>;
-}): ManagedSkillReceipt | null {
+}):
+	| { status: "matched"; receipt: ManagedSkillReceipt }
+	| { status: "absent" | "unsafe" | "mismatch" } {
+	const collection = collectRuntimeUserManagedSkillTree(input.target, {
+		exclude: input.exclude,
+	});
+	if (collection.status !== "collected") return collection;
 	const marker = readManagedSkillMarkerRaw(input);
-	if (!marker) return null;
-	return marker.treeFingerprint ===
-		managedSkillTreeFingerprint(
-			collectRuntimeUserManagedSkillTree(input.target, { exclude: input.exclude }),
-		)
-		? marker
-		: null;
+	if (!marker || marker.treeFingerprint !== managedSkillTreeFingerprint(collection.tree)) {
+		return { status: "mismatch" };
+	}
+	return { status: "matched", receipt: marker };
 }
 
 function realDirectoryWithin(root: string, path: string): boolean {
@@ -296,10 +316,10 @@ export function migrateLegacyManagedSkillReceiptDirectory(input: {
 				? { exclude: new Set([".openclaw/source-origin.json"]) }
 				: {}),
 		});
-		if (!receipt) continue;
+		if (receipt.status !== "matched") continue;
 		const destination = managedSkillReceiptPath(input.managedResourceRoot, input.runtime, skillId);
 		if (!existsSync(destination)) {
-			writeManagedSkillReceiptRecord(input.managedResourceRoot, destination, receipt);
+			writeManagedSkillReceiptRecord(input.managedResourceRoot, destination, receipt.receipt);
 		}
 	}
 	// This directory was always Clawdi metadata. Invalid or unknown entries are
@@ -336,7 +356,20 @@ export function managedSkillReceiptMatchesIdentity(input: {
 	target: string;
 	exclude?: ReadonlySet<string>;
 }): boolean {
-	return readManagedSkillReceipt(input)?.ownershipIdentity === input.ownershipIdentity;
+	return managedSkillReceiptIdentityState(input) === "matched";
+}
+
+export function managedSkillReceiptIdentityState(input: {
+	path: string;
+	schemaVersion: string;
+	skillId: string;
+	ownershipIdentity: string;
+	target: string;
+	exclude?: ReadonlySet<string>;
+}): "matched" | "absent" | "unsafe" | "mismatch" {
+	const result = readManagedSkillReceipt(input);
+	if (result.status !== "matched") return result.status;
+	return result.receipt.ownershipIdentity === input.ownershipIdentity ? "matched" : "mismatch";
 }
 
 export function withStagedManagedSkill<T>(
@@ -355,8 +388,10 @@ export function withStagedManagedSkill<T>(
 		});
 		if (extracted.status !== 0) throw new Error("prepared Skill archive could not be staged");
 		const sourceDir = join(root, skill.skillId);
-		if (!existsSync(join(sourceDir, "SKILL.md")) || !collectManagedSkillTree(sourceDir))
-			throw new Error("prepared Skill archive is invalid");
+		const sourceTree = collectManagedSkillTree(sourceDir);
+		if (!existsSync(join(sourceDir, "SKILL.md")) || sourceTree.status !== "collected") {
+			throw new Error(`prepared Skill archive is ${sourceTree.status}`);
+		}
 		const makeReadable = (path: string): void => {
 			const node = lstatSync(path);
 			if (node.isDirectory()) {

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -146,6 +146,7 @@ import {
 	enforceRuntimeUserOwnership,
 	executableExists,
 	makeRuntimeUserOwned,
+	runtimePlatformEnclaveOwnership,
 	runtimeUserDirectoryOwnership,
 	runtimeUserExistingOwnership,
 	withRuntimeUserFileAccess,
@@ -165,6 +166,7 @@ interface RuntimeConvergenceContext {
 	applyContext: NonNullable<RuntimeManifestLoad["applyContext"]>;
 	hostedRuntimeContract: ReturnType<typeof assertHostedRuntimeContract>;
 	projectionHome: string;
+	platformEnclaves: ReturnType<typeof runtimeSystemdPlatformEnclaves>;
 	openClawContext: ReturnType<typeof createOpenClawHostedContext>;
 	hermesWhatsAppAuthDir: string | null;
 	workspaceRoot: string;
@@ -280,8 +282,8 @@ function initializeRuntimeConvergence(
 	enforceRuntimeUserOwnership([
 		...runtimeUserDirectoryOwnership(projectionHome, { recursive: true, platformEnclaves }),
 		// Official user-service installers need the unit root itself writable. Its
-		// enclave contents retain their existing ownership and are not traversed.
-		...(platformEnclaves.includes(paths.systemdUserRoot)
+		// enclave contents remain root-owned until their exact mutation targets are staged.
+		...(platformEnclaves.some((enclave) => enclave.path === paths.systemdUserRoot)
 			? runtimeUserDirectoryOwnership(paths.systemdUserRoot)
 			: []),
 		...hostedOpenClawRuntimeUserOwnership(manifest, projectionHome),
@@ -380,6 +382,7 @@ function initializeRuntimeConvergence(
 			applyContext,
 			hostedRuntimeContract,
 			projectionHome,
+			platformEnclaves,
 			openClawContext,
 			hermesWhatsAppAuthDir,
 			workspaceRoot,
@@ -1497,7 +1500,16 @@ function activateRuntimeServices(
 	plan: RuntimeConvergencePlan,
 	activationPlan: RuntimeActivationPlan,
 ): RuntimeActivationOutputs {
-	const { load, manifest, paths, opts, hostedRuntimeContract, instanceRoot, generatedAt } = context;
+	const {
+		load,
+		manifest,
+		paths,
+		opts,
+		hostedRuntimeContract,
+		instanceRoot,
+		generatedAt,
+		platformEnclaves,
+	} = context;
 	const { officialServicePlan, systemdUnits } = activationPlan;
 	if (
 		officialServicePlan.pending.length > 0 &&
@@ -1527,6 +1539,14 @@ function activateRuntimeServices(
 			? opts.systemdApply.installOfficialService(item.unitName, install)
 			: install();
 		if (error) throw new Error(error);
+	}
+	enforceRuntimeUserOwnership(runtimePlatformEnclaveOwnership(platformEnclaves));
+	for (const item of officialServicePlan.pending) {
+		const currentRevision = item.target.currentRevision();
+		if (!currentRevision) {
+			throw new Error(`official ${item.unitName} service install could not be verified`);
+		}
+		item.target.expectedCurrentRevision = currentRevision;
 	}
 	hostedRuntimeContract.assertPlatformRoots();
 	const bootFinished = join(instanceRoot, "boot-finished");

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -60,9 +60,12 @@ import {
 	ManagedSkillResourceError,
 	managedSkillReceiptPath,
 	managedSkillTreeFingerprint,
+	writeManagedSkillReceipt,
 } from "./managed-skill-delivery";
 import {
 	managedSkillReservationLedgerPath,
+	managedSkillReservationState,
+	reserveManagedSkill,
 	shouldIgnoreUserSkill,
 } from "./managed-skill-reservation";
 import {
@@ -4451,10 +4454,11 @@ echo spawned > '${installerLog}'
 
 		expect(() => withRuntimeUserFileAccess(() => writeFileSync(receipt, "{}\n"))).toThrow();
 		withRuntimeUserFileAccess(() => writeFileSync(skillPath, "tenant mutation\n"));
-		const forgedFingerprint = managedSkillTreeFingerprint(
-			collectRuntimeUserManagedSkillTree(target),
-		);
-		if (!forgedFingerprint) throw new Error("counterfeit receipt fixture tree is unsafe");
+		const collectedTarget = collectRuntimeUserManagedSkillTree(target);
+		if (collectedTarget.status !== "collected") {
+			throw new Error(`counterfeit receipt fixture tree is ${collectedTarget.status}`);
+		}
+		const forgedFingerprint = managedSkillTreeFingerprint(collectedTarget.tree);
 		writeFileSync(
 			receipt,
 			`${JSON.stringify({
@@ -4770,6 +4774,51 @@ echo spawned > '${installerLog}'
 		expect(existsSync(skillDir)).toBe(false);
 		expect(readFileSync(join(userOwnedSibling, "SKILL.md"), "utf8")).toBe("keep me\n");
 		expect(shouldIgnoreUserSkill(userOwnedSibling, "user-owned")).toBe(false);
+	});
+
+	test("releases a stale hosted reservation after its Skill tree disappears", () => {
+		const paths = tempRuntimePaths();
+		ensureRuntimeStateDirs(paths);
+		mkdirSync(paths.managedResourceRoot, { recursive: true });
+		const skillId = "attio-composio-client-updates";
+		const sourceIdentity = `github\0${skillId}\0https://github.com/Clawdi-AI/store\0skills/${skillId}\0${"a".repeat(40)}`;
+		const target = join(paths.userHome, ".hermes", "skills", skillId);
+		const receipt = managedSkillReceiptPath(paths.managedResourceRoot, "hermes", skillId);
+		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		mkdirSync(dirname(hermesCommand), { recursive: true });
+		writeFileSync(hermesCommand, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+		mkdirSync(target, { recursive: true });
+		writeFileSync(join(target, "SKILL.md"), "historical test Skill\n");
+		writeManagedSkillReceipt({
+			path: receipt,
+			managedResourceRoot: paths.managedResourceRoot,
+			schemaVersion: "clawdi.hermesManifestSkillReceipt.v2",
+			skillId,
+			ownershipIdentity: sourceIdentity,
+			target,
+		});
+		reserveManagedSkill({
+			targetDir: target,
+			id: skillId,
+			manager: "hosted-manifest",
+			sourceIdentity,
+		});
+		rmSync(target, { recursive: true });
+
+		const manifest = baseManifest(
+			paths,
+			{ hermes: { enabled: true, run: runSettings(hermesCommand, ["gateway"]), services: {} } },
+			{ projection: { skills: { entries: {} } } },
+		);
+		const result = convergeRuntimeManifest(
+			manifestLoad(manifest, "stale-absent-hermes-skill"),
+			paths,
+		);
+
+		expect([...result.installErrors, ...result.resourceProjectionErrors]).toEqual([]);
+		expect(managedSkillReservationState(target, skillId)).toBe("unreserved");
+		expect(existsSync(receipt)).toBe(false);
+		expect(existsSync(target)).toBe(false);
 	});
 
 	test("isolates per-Skill resource failures without starving later Skills", () => {

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -94,15 +94,15 @@ export interface RuntimePaths {
 
 export function runtimeSystemdPlatformEnclaves(
 	paths: Pick<RuntimePaths, "systemdUserRoot" | "userHome">,
-): string[] {
+): Array<{ path: string; owner: "root" }> {
 	return [
 		// systemd requires user units below HOME. This root contains base units and
 		// backups, Clawdi drop-ins, and default.target enablement links. Preserving
 		// root-owned pre-images is required for rollback and generated-file authority.
-		paths.systemdUserRoot,
+		{ path: paths.systemdUserRoot, owner: "root" },
 		// OpenClaw's installer writes this private environment file in HOME. Clawdi
 		// must snapshot and restore a root-owned pre-image without first adopting it.
-		join(paths.userHome, ".openclaw", "gateway.systemd.env"),
+		{ path: join(paths.userHome, ".openclaw", "gateway.systemd.env"), owner: "root" },
 	];
 }
 

--- a/packages/cli/src/runtime/runtime-user-command.test.ts
+++ b/packages/cli/src/runtime/runtime-user-command.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	chmodSync,
 	chownSync,
+	lchownSync,
 	lstatSync,
 	mkdirSync,
 	mkdtempSync,
@@ -437,7 +438,7 @@ test("recursively restores runtime ownership only inside declared state roots", 
 	}
 });
 
-test("preserves declared platform enclaves while repairing the rest of runtime HOME", () => {
+test("enforces root ownership inside platform enclaves and runtime ownership outside", () => {
 	if (process.geteuid?.() !== 0) return;
 	const root = mkdtempSync(join(tmpdir(), "runtime-user-platform-enclaves-"));
 	const home = join(root, "home");
@@ -448,6 +449,8 @@ test("preserves declared platform enclaves while repairing the rest of runtime H
 	const enablement = join(wants, "openclaw-gateway.service");
 	const gatewayEnvironment = join(home, ".openclaw", "gateway.systemd.env");
 	const tenantFile = join(home, ".hermes", "config.yaml");
+	const outsideTarget = join(root, "outside-target");
+	const enclaveLink = join(wants, "outside-target");
 	const previousRuntimeUser = process.env.CLAWDI_RUNTIME_USER;
 	try {
 		mkdirSync(dirname(dropIn), { recursive: true });
@@ -459,6 +462,8 @@ test("preserves declared platform enclaves while repairing the rest of runtime H
 		symlinkSync("../openclaw-gateway.service", enablement);
 		writeFileSync(gatewayEnvironment, "TOKEN=platform\n", { mode: 0o600 });
 		writeFileSync(tenantFile, "model: tenant\n", { mode: 0o600 });
+		writeFileSync(outsideTarget, "outside\n", { mode: 0o600 });
+		symlinkSync(outsideTarget, enclaveLink);
 		for (const path of [
 			root,
 			home,
@@ -473,12 +478,30 @@ test("preserves declared platform enclaves while repairing the rest of runtime H
 			dirname(gatewayEnvironment),
 			dirname(tenantFile),
 			tenantFile,
+			outsideTarget,
 		]) {
 			chownSync(path, 0, 0);
 		}
 		process.env.CLAWDI_RUNTIME_USER = "nobody";
+		const expectedRuntimeOwner = [runtimeUserUid("nobody"), runtimeUserGid("nobody")];
+		for (const path of [
+			systemdUserRoot,
+			unit,
+			dirname(dropIn),
+			dropIn,
+			wants,
+			gatewayEnvironment,
+		]) {
+			chownSync(path, expectedRuntimeOwner[0], expectedRuntimeOwner[1]);
+		}
+		lchownSync(enablement, expectedRuntimeOwner[0], expectedRuntimeOwner[1]);
+		lchownSync(enclaveLink, expectedRuntimeOwner[0], expectedRuntimeOwner[1]);
+		chownSync(outsideTarget, expectedRuntimeOwner[0], expectedRuntimeOwner[1]);
 		const platformEnclaves = runtimeSystemdPlatformEnclaves({ userHome: home, systemdUserRoot });
-		expect(platformEnclaves).toEqual([systemdUserRoot, gatewayEnvironment]);
+		expect(platformEnclaves).toEqual([
+			{ path: systemdUserRoot, owner: "root" },
+			{ path: gatewayEnvironment, owner: "root" },
+		]);
 
 		enforceRuntimeUserOwnership(
 			runtimeUserDirectoryOwnership(home, { recursive: true, platformEnclaves }),
@@ -491,12 +514,12 @@ test("preserves declared platform enclaves while repairing the rest of runtime H
 			dropIn,
 			wants,
 			enablement,
+			enclaveLink,
 			gatewayEnvironment,
 		]) {
 			const node = lstatSync(path);
 			expect([node.uid, node.gid]).toEqual([0, 0]);
 		}
-		const expectedRuntimeOwner = [runtimeUserUid("nobody"), runtimeUserGid("nobody")];
 		for (const path of [
 			home,
 			join(home, ".config"),
@@ -508,6 +531,9 @@ test("preserves declared platform enclaves while repairing the rest of runtime H
 			const node = lstatSync(path);
 			expect([node.uid, node.gid]).toEqual(expectedRuntimeOwner);
 		}
+		expect([statSync(outsideTarget).uid, statSync(outsideTarget).gid]).toEqual(
+			expectedRuntimeOwner,
+		);
 	} finally {
 		if (previousRuntimeUser === undefined) delete process.env.CLAWDI_RUNTIME_USER;
 		else process.env.CLAWDI_RUNTIME_USER = previousRuntimeUser;
@@ -518,12 +544,14 @@ test("preserves declared platform enclaves while repairing the rest of runtime H
 test("rejects platform enclaves without a recursive in-bound ownership root", () => {
 	const home = join(tmpdir(), "runtime-user-platform-enclave-boundary");
 	expect(() =>
-		runtimeUserDirectoryOwnership(home, { platformEnclaves: [join(home, "platform")] }),
+		runtimeUserDirectoryOwnership(home, {
+			platformEnclaves: [{ path: join(home, "platform"), owner: "root" }],
+		}),
 	).toThrow("runtime-user platform enclaves require recursive ownership");
 	expect(() =>
 		runtimeUserDirectoryOwnership(home, {
 			recursive: true,
-			platformEnclaves: [join(home, "..", "platform")],
+			platformEnclaves: [{ path: join(home, "..", "platform"), owner: "root" }],
 		}),
 	).toThrow("runtime-user platform enclave is outside its ownership boundary");
 });

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -23,14 +23,18 @@ export interface RuntimeUserIdentity {
 	gid: number;
 }
 
+export interface RuntimeOwnershipEnclave {
+	path: string;
+	owner: "root";
+}
+
 export interface RuntimeUserOwnershipRule {
 	path: string;
-	owner: "runtime-user";
+	owner: "runtime-user" | "root";
 	kind: "directory" | "existing";
 	mode?: number;
 	recursive: boolean;
-	// Recursive ownership stops at these platform-owned subtree roots.
-	platformEnclaves?: readonly string[];
+	platformEnclaves?: readonly RuntimeOwnershipEnclave[];
 }
 
 export type RuntimeUserIdentityResolver = (runtimeUser: string) => RuntimeUserIdentity;
@@ -397,7 +401,7 @@ export function runtimeUserDirectoryOwnership(
 		mode?: number;
 		ancestorsUnder?: string;
 		recursive?: boolean;
-		platformEnclaves?: readonly string[];
+		platformEnclaves?: readonly RuntimeOwnershipEnclave[];
 	} = {},
 ): RuntimeUserOwnershipRule[] {
 	const target = resolve(path);
@@ -422,16 +426,14 @@ export function runtimeUserDirectoryOwnership(
 
 function normalizedPlatformEnclaves(
 	target: string,
-	options: { recursive?: boolean; platformEnclaves?: readonly string[] },
-): string[] {
-	const enclaves = [...new Set((options.platformEnclaves ?? []).map((path) => resolve(path)))].sort(
-		(left, right) => left.length - right.length || left.localeCompare(right),
-	);
+	options: { recursive?: boolean; platformEnclaves?: readonly RuntimeOwnershipEnclave[] },
+): RuntimeOwnershipEnclave[] {
+	const enclaves = normalizeOwnershipEnclaves(options.platformEnclaves ?? []);
 	if (enclaves.length > 0 && options.recursive !== true) {
 		throw new Error("runtime-user platform enclaves require recursive ownership");
 	}
 	for (const enclave of enclaves) {
-		const relativeEnclave = relative(target, enclave);
+		const relativeEnclave = relative(target, enclave.path);
 		if (
 			!relativeEnclave ||
 			relativeEnclave === ".." ||
@@ -439,17 +441,41 @@ function normalizedPlatformEnclaves(
 			isAbsolute(relativeEnclave)
 		) {
 			throw new Error(
-				`runtime-user platform enclave is outside its ownership boundary: ${enclave}`,
+				`runtime-user platform enclave is outside its ownership boundary: ${enclave.path}`,
 			);
 		}
 	}
 	return enclaves;
 }
 
+function normalizeOwnershipEnclaves(
+	enclaves: readonly RuntimeOwnershipEnclave[],
+): RuntimeOwnershipEnclave[] {
+	const normalized = new Map<string, RuntimeOwnershipEnclave>();
+	for (const enclave of enclaves) {
+		const path = resolve(enclave.path);
+		normalized.set(path, { path, owner: enclave.owner });
+	}
+	return [...normalized.values()].sort(
+		(left, right) => left.path.length - right.path.length || left.path.localeCompare(right.path),
+	);
+}
+
 export const runtimeUserExistingOwnership = (
 	paths: readonly string[],
 	options: { recursive?: boolean } = {},
 ) => runtimeUserOwnershipRules(paths, "existing", options);
+
+export function runtimePlatformEnclaveOwnership(
+	enclaves: readonly RuntimeOwnershipEnclave[],
+): RuntimeUserOwnershipRule[] {
+	return normalizeOwnershipEnclaves(enclaves).map((enclave) => ({
+		path: enclave.path,
+		owner: enclave.owner,
+		kind: "existing",
+		recursive: true,
+	}));
+}
 
 function runtimeUserOwnershipRules(
 	paths: readonly string[],
@@ -473,7 +499,8 @@ function runtimeUserOwnershipRules(
 
 export function enforceRuntimeUserOwnership(rules: readonly RuntimeUserOwnershipRule[]): void {
 	if (rules.length === 0) return;
-	const identity = runtimeFilesystemIdentity();
+	const runtimeIdentity = runtimeFilesystemIdentity();
+	const rootIdentity = runningAsRoot() ? { uid: 0, gid: 0 } : null;
 	for (const rule of rules) {
 		if (rule.kind === "directory") mkdirSync(rule.path, { recursive: true });
 		let node: NonNullable<ReturnType<typeof lstatSync>>;
@@ -489,9 +516,11 @@ export function enforceRuntimeUserOwnership(rules: readonly RuntimeUserOwnership
 		enforceRuntimeUserNodeOwnership(
 			rule.path,
 			node,
-			identity,
+			runtimeIdentity,
+			rootIdentity,
+			rule.owner,
 			rule.recursive,
-			new Set(rule.platformEnclaves ?? []),
+			new Map(rule.platformEnclaves?.map((enclave) => [enclave.path, enclave.owner]) ?? []),
 		);
 		if (rule.mode !== undefined) chmodSync(rule.path, rule.mode);
 	}
@@ -511,19 +540,30 @@ function runtimeFilesystemIdentity(): RuntimeUserIdentity | null {
 function enforceRuntimeUserNodeOwnership(
 	path: string,
 	node: NonNullable<ReturnType<typeof lstatSync>>,
-	identity: RuntimeUserIdentity | null,
+	runtimeIdentity: RuntimeUserIdentity | null,
+	rootIdentity: RuntimeUserIdentity | null,
+	owner: RuntimeUserOwnershipRule["owner"],
 	recursive: boolean,
-	platformEnclaves: ReadonlySet<string>,
+	platformEnclaves: ReadonlyMap<string, RuntimeOwnershipEnclave["owner"]>,
 ): void {
-	if (platformEnclaves.has(path)) return;
+	const effectiveOwner = platformEnclaves.get(path) ?? owner;
+	const identity = effectiveOwner === "root" ? rootIdentity : runtimeIdentity;
 	if (identity && (node.uid !== identity.uid || node.gid !== identity.gid)) {
-		if (node.isSymbolicLink()) lchownSync(path, identity.uid, identity.gid);
-		else chownSync(path, identity.uid, identity.gid);
+		// lchown is non-dereferencing even if the path is swapped after lstat.
+		lchownSync(path, identity.uid, identity.gid);
 	}
 	if (!recursive || !node.isDirectory() || node.isSymbolicLink()) return;
 	for (const entry of readdirSync(path)) {
 		const child = join(path, entry);
-		enforceRuntimeUserNodeOwnership(child, lstatSync(child), identity, true, platformEnclaves);
+		enforceRuntimeUserNodeOwnership(
+			child,
+			lstatSync(child),
+			runtimeIdentity,
+			rootIdentity,
+			effectiveOwner,
+			true,
+			platformEnclaves,
+		);
 	}
 }
 

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -947,6 +947,8 @@ test("runs Files as the tenant while preserving platform isolation", () => {
 	const tenantExisting = join(runtimeHome, "files-tenant-existing.txt");
 	writeFileSync(tenantExisting, "tenant-existing\n", { mode: 0o600 });
 	chownSync(tenantExisting, runtimeUid, runtimeGid);
+	const tenantOwnershipDrift = join(runtimeHome, "files-root-owned-drift.txt");
+	writeFileSync(tenantOwnershipDrift, "repair-to-tenant\n", { mode: 0o600 });
 	const hermesConfig = join(runtimeHome, ".hermes", "config.yaml");
 	mkdirSync(dirname(hermesConfig), { recursive: true, mode: 0o700 });
 	chownSync(dirname(hermesConfig), runtimeUid, runtimeGid);
@@ -983,6 +985,22 @@ test("runs Files as the tenant while preserving platform isolation", () => {
 	ensureRuntimeStateDirs(paths);
 	const rootOwnedControl = join(paths.systemdUserRoot, "files-root-owned-control");
 	writeFileSync(rootOwnedControl, "root-owned\n", { mode: 0o600 });
+	const platformDriftUnit = join(paths.systemdUserRoot, "legacy-platform-control.service");
+	const platformDriftDropIn = join(`${platformDriftUnit}.d`, "10-legacy.conf");
+	const platformDriftEnvironment = join(openClawStateDir, "gateway.systemd.env");
+	mkdirSync(dirname(platformDriftDropIn), { recursive: true });
+	writeFileSync(platformDriftUnit, "[Service]\nExecStart=/bin/true\n");
+	writeFileSync(platformDriftDropIn, "[Service]\nEnvironment=LEGACY=1\n");
+	writeFileSync(platformDriftEnvironment, "LEGACY_PLATFORM_ENV=1\n", { mode: 0o600 });
+	for (const path of [
+		paths.systemdUserRoot,
+		platformDriftUnit,
+		dirname(platformDriftDropIn),
+		platformDriftDropIn,
+		platformDriftEnvironment,
+	]) {
+		chownSync(path, runtimeUid, runtimeGid);
+	}
 	const legacyEnvironmentRoot = join(runtimeHome, ".clawdi", "environments");
 	mkdirSync(legacyEnvironmentRoot, { recursive: true });
 	writeFileSync(
@@ -1226,6 +1244,19 @@ http.createServer((request, response) => {
 	expect(statSync(paths.clawdiHome).uid).toBe(runtimeUid);
 	expect(statSync(paths.clawdiHome).gid).toBe(runtimeGid);
 	expect(statSync(paths.clawdiHome).mode & 0o777).toBe(0o750);
+	expect([statSync(tenantOwnershipDrift).uid, statSync(tenantOwnershipDrift).gid]).toEqual([
+		runtimeUid,
+		runtimeGid,
+	]);
+	for (const path of [
+		paths.systemdUserRoot,
+		platformDriftUnit,
+		dirname(platformDriftDropIn),
+		platformDriftDropIn,
+		platformDriftEnvironment,
+	]) {
+		expect([statSync(path).uid, statSync(path).gid]).toEqual([0, 0]);
+	}
 	const tenantClawdiAfterConverge = tenantClawdi();
 	expect(tenantClawdiAfterConverge.status).not.toBe(0);
 	expect(tenantClawdiAfterConverge.stdout).toBe("");


### PR DESCRIPTION
## Field evidence

The fourth 0.14.3 device pass exposed two remaining convergence defects:

- A historical Hermes-sourced reservation for `attio-composio-client-updates` remained after the Skill left desired state and its target directory disappeared. Cleanup intermittently classified the missing target as `installed Skill tree is unsafe`, so the reservation survived and the same projection error returned on later passes.
- On machines previously converged by 0.14.2, the recursive ownership enforcer had already changed all eight entries under `~/.config/systemd/user` to UID 10001 even though platform-owned systemd artifacts must remain root-owned. The #1153 enclave exclusion prevented future damage but could not repair existing drift.

## Fixes

### Release absent stale Skill reservations

Managed Skill collection now returns an explicit discriminated result: `collected`, `absent`, or `unsafe`. Release treats an absent target as an idempotent successful removal: it deletes any platform receipt and lets the reservation deletion commit normally. Unsafe trees still fail closed.

The regression coverage exercises both an already-missing stale reservation and the intermittent lifecycle in which a previously installed target and receipt disappear before the next desired-state removal pass. One convergence clears the reservation and receipt without reporting an install error.

### Enforce platform enclaves bidirectionally

The declarative enclave list now carries the required owner direction. The same recursive enforcer applies both halves of the boundary:

- outside an enclave, root-owned residue is repaired to the runtime user;
- inside a root enclave, non-root ownership is repaired back to root.

The implementation preserves the existing no-follow discipline by opening entries with `O_NOFOLLOW` and applying ownership with `lchown`. It handles both enclave trees and the single-file `gateway.systemd.env` declaration. Official gateway installation is followed by enclave ownership repair, and the official-service receipt is re-anchored to the final post-repair revision so a clean follow-up convergence remains stable.

## Missing is not unsafe audit

- Managed tree traversal distinguishes a missing root, including disappearance during traversal, from an unsafe node.
- Staged Skill source validation requires `collected`; absent and unsafe sources remain invalid.
- Receipt creation requires a collected installed tree and never blesses absent or unsafe state.
- Receipt identity checks propagate `absent`, `unsafe`, and `mismatch` separately.
- Hermes and OpenClaw release paths accept only `absent` as idempotent cleanup; unsafe and mismatched trees remain fail-closed.
- Legacy receipt migration promotes only an exact `matched` tree.
- Hermes bundled activation and OpenClaw native installation verification require two collected trees before byte comparison.

## Verification

- Pinned `./node_modules/.bin/biome` formatting/check: passed
- CLI typecheck: passed
- `manifest-mutation-parity.test.ts`: passed
- Full official clean runner, `bun run --cwd packages/cli test`: 1750 pass, 4 skip, 0 fail under Bun 1.4.0 `test:internal`
- Privileged PID1 e2e, `scripts/test-runtime-official-installer-systemd.sh`: 4 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)