### PR TITLE
release(cli): 0.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.4
+
+Package: `clawdi@0.14.4`
+
+### Fixed
+
+- Stale skill reservations whose target directory no longer exists are now
+  released idempotently instead of failing convergence with a misleading
+  "tree is unsafe" error.
+- Platform-owned systemd artifacts inside the tenant home that had drifted to
+  tenant ownership are repaired back to root; the ownership enforcer is now
+  bidirectional across declared platform enclaves.
+
 ## Clawdi CLI v0.14.3
 
 Package: `clawdi@0.14.3`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.3",
+	"version": "0.14.4",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Release `clawdi@0.14.4` — closes the last two real-machine findings from the fourth canary round (#1154):

- Stale reservations with absent targets release idempotently (absent ≠ unsafe, three-state classification).
- Ownership enforcement is bidirectional across declared platform enclaves: repairs pre-existing tenant-ownership drift of systemd artifacts back to root.

Fourth-round evidence already confirmed on the canary deployment: platform-side receipt anchoring, legacy marker adoption, tenant-tree ownership, and per-skill failure isolation all working. Fifth canary round follows this release; pass bar is five consecutive clean observation cycles plus enclave/receipt forensics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)