### PR TITLE
fix(cli): preserve live user units during enclave repair

### DIFF
--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -144,6 +144,7 @@ import {
 } from "./runtime-systemd-reconciliation";
 import {
 	enforceRuntimeUserOwnership,
+	enforceRuntimeUserSystemdManagerAccess,
 	executableExists,
 	makeRuntimeUserOwned,
 	runtimePlatformEnclaveOwnership,
@@ -279,6 +280,9 @@ function initializeRuntimeConvergence(
 		resolve(projectionHome) === resolve(paths.userHome)
 			? runtimeSystemdPlatformEnclaves(paths)
 			: [];
+	if (platformEnclaves.some((enclave) => enclave.path === paths.systemdUserRoot)) {
+		enforceRuntimeUserSystemdManagerAccess(paths.systemdUserRoot);
+	}
 	enforceRuntimeUserOwnership([
 		...runtimeUserDirectoryOwnership(projectionHome, { recursive: true, platformEnclaves }),
 		// Official user-service installers need the unit root itself writable. Its
@@ -1539,6 +1543,9 @@ function activateRuntimeServices(
 			? opts.systemdApply.installOfficialService(item.unitName, install)
 			: install();
 		if (error) throw new Error(error);
+	}
+	if (platformEnclaves.some((enclave) => enclave.path === paths.systemdUserRoot)) {
+		enforceRuntimeUserSystemdManagerAccess(paths.systemdUserRoot);
 	}
 	enforceRuntimeUserOwnership(runtimePlatformEnclaveOwnership(platformEnclaves));
 	for (const item of officialServicePlan.pending) {

--- a/packages/cli/src/runtime/runtime-user-command.test.ts
+++ b/packages/cli/src/runtime/runtime-user-command.test.ts
@@ -22,6 +22,7 @@ import {
 	commandExists,
 	createPrivilegeDropResolver,
 	enforceRuntimeUserOwnership,
+	enforceRuntimeUserSystemdManagerAccess,
 	runRuntimeUserCommand,
 	runtimeUserDirectoryOwnership,
 	runtimeUserExistingOwnership,
@@ -497,12 +498,15 @@ test("enforces root ownership inside platform enclaves and runtime ownership out
 		lchownSync(enablement, expectedRuntimeOwner[0], expectedRuntimeOwner[1]);
 		lchownSync(enclaveLink, expectedRuntimeOwner[0], expectedRuntimeOwner[1]);
 		chownSync(outsideTarget, expectedRuntimeOwner[0], expectedRuntimeOwner[1]);
+		for (const path of [systemdUserRoot, dirname(dropIn), wants]) chmodSync(path, 0o700);
+		for (const path of [unit, dropIn]) chmodSync(path, 0o600);
 		const platformEnclaves = runtimeSystemdPlatformEnclaves({ userHome: home, systemdUserRoot });
 		expect(platformEnclaves).toEqual([
 			{ path: systemdUserRoot, owner: "root" },
 			{ path: gatewayEnvironment, owner: "root" },
 		]);
 
+		enforceRuntimeUserSystemdManagerAccess(systemdUserRoot);
 		enforceRuntimeUserOwnership(
 			runtimeUserDirectoryOwnership(home, { recursive: true, platformEnclaves }),
 		);
@@ -534,6 +538,13 @@ test("enforces root ownership inside platform enclaves and runtime ownership out
 		expect([statSync(outsideTarget).uid, statSync(outsideTarget).gid]).toEqual(
 			expectedRuntimeOwner,
 		);
+		for (const path of [systemdUserRoot, dirname(dropIn), wants]) {
+			expect(statSync(path).mode & 0o777).toBe(0o755);
+		}
+		for (const path of [unit, dropIn]) {
+			expect(statSync(path).mode & 0o777).toBe(0o644);
+		}
+		expect(statSync(gatewayEnvironment).mode & 0o777).toBe(0o600);
 	} finally {
 		if (previousRuntimeUser === undefined) delete process.env.CLAWDI_RUNTIME_USER;
 		else process.env.CLAWDI_RUNTIME_USER = previousRuntimeUser;

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -526,6 +526,50 @@ export function enforceRuntimeUserOwnership(rules: readonly RuntimeUserOwnership
 	}
 }
 
+export function enforceRuntimeUserSystemdManagerAccess(systemdUserRoot: string): void {
+	if (!runningAsRoot()) return;
+	let root: NonNullable<ReturnType<typeof lstatSync>>;
+	try {
+		root = lstatSync(systemdUserRoot);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
+	if (!root.isDirectory() || root.isSymbolicLink()) {
+		throw new Error(`runtime-user systemd root must be a real directory: ${systemdUserRoot}`);
+	}
+	ensureRuntimeUserManagerMode(systemdUserRoot, root, 0o555);
+	for (const entry of readdirSync(systemdUserRoot, { withFileTypes: true })) {
+		const path = join(systemdUserRoot, entry.name);
+		if (entry.isFile() && entry.name.endsWith(".service")) {
+			ensureRuntimeUserManagerMode(path, lstatSync(path), 0o444);
+			continue;
+		}
+		if (!entry.isDirectory()) continue;
+		if (entry.name === "default.target.wants") {
+			ensureRuntimeUserManagerMode(path, lstatSync(path), 0o555);
+			continue;
+		}
+		if (!entry.name.endsWith(".service.d")) continue;
+		ensureRuntimeUserManagerMode(path, lstatSync(path), 0o555);
+		for (const dropIn of readdirSync(path, { withFileTypes: true })) {
+			if (!dropIn.isFile() || !dropIn.name.endsWith(".conf")) continue;
+			const dropInPath = join(path, dropIn.name);
+			ensureRuntimeUserManagerMode(dropInPath, lstatSync(dropInPath), 0o444);
+		}
+	}
+}
+
+function ensureRuntimeUserManagerMode(
+	path: string,
+	node: NonNullable<ReturnType<typeof lstatSync>>,
+	requiredMode: number,
+): void {
+	const currentMode = Number(node.mode) & 0o7777;
+	const nextMode = currentMode | requiredMode;
+	if (nextMode !== currentMode) chmodSync(path, nextMode);
+}
+
 function runtimeFilesystemIdentity(): RuntimeUserIdentity | null {
 	if (!runningAsRoot()) return null;
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();

--- a/packages/cli/src/runtime/systemd-transaction.ts
+++ b/packages/cli/src/runtime/systemd-transaction.ts
@@ -503,19 +503,16 @@ export function applySystemdRuntimeUpdate(
 		);
 	}
 	if (enableAndStartUserUnits.length > 0) {
-		runJournaledSystemdMutation(
+		runJournaledRuntimeUserEnable(
+			paths,
 			transaction,
 			stage,
-			"user",
 			"enable-and-start",
 			enableAndStartUserUnits,
-			() => runtimeUserSystemctl(paths, ["enable", "--now", ...enableAndStartUserUnits]),
 		);
 	}
 	if (enableUserUnits.length > 0) {
-		runJournaledSystemdMutation(transaction, stage, "user", "enable", enableUserUnits, () =>
-			runtimeUserSystemctl(paths, ["enable", ...enableUserUnits]),
-		);
+		runJournaledRuntimeUserEnable(paths, transaction, stage, "enable", enableUserUnits);
 	}
 	if (startUserUnits.length > 0) {
 		runJournaledSystemdMutation(transaction, stage, "user", "start", startUserUnits, () =>
@@ -659,9 +656,13 @@ function rollbackSystemdRuntimeTransaction(
 		const currentlyEnabled = systemdUnitEnabled(systemdUnitManagerState(paths, "user", unit));
 		if (initiallyEnabled !== currentlyEnabled) {
 			const action = initiallyEnabled ? "enable" : "disable";
-			runJournaledSystemdMutation(transaction, "rollback", "user", action, [unit], () =>
-				runtimeUserSystemctl(paths, [action, unit]),
-			);
+			if (action === "enable") {
+				runJournaledRuntimeUserEnable(paths, transaction, "rollback", action, [unit]);
+			} else {
+				runJournaledSystemdMutation(transaction, "rollback", "user", action, [unit], () =>
+					runtimeUserSystemctl(paths, [action, unit]),
+				);
+			}
 		}
 		if (initial.activeState !== "active") continue;
 		restoreActiveSystemdUnit(paths, transaction, "user", unit);
@@ -787,6 +788,44 @@ function runJournaledSystemdMutation<T>(
 	} catch (error) {
 		entry.outcome = "failed";
 		throw error;
+	}
+}
+
+function runJournaledRuntimeUserEnable(
+	paths: ReturnType<typeof getRuntimePaths>,
+	transaction: SystemdRuntimeTransaction,
+	stage: SystemdRuntimeMutationStage,
+	action: Extract<SystemdRuntimeMutationAction, "enable" | "enable-and-start">,
+	units: readonly string[],
+): string {
+	const args = action === "enable-and-start" ? ["enable", "--now", ...units] : ["enable", ...units];
+	const enable = () =>
+		runJournaledSystemdMutation(transaction, stage, "user", action, units, () =>
+			runtimeUserSystemctl(paths, args),
+		);
+	try {
+		return enable();
+	} catch (error) {
+		if (!missingRuntimeUserUnitExists(paths, units, error)) throw error;
+		runJournaledSystemdMutation(transaction, stage, "user", "daemon-reload", [], () =>
+			runtimeUserSystemctl(paths, ["daemon-reload"]),
+		);
+		return enable();
+	}
+}
+
+function missingRuntimeUserUnitExists(
+	paths: ReturnType<typeof getRuntimePaths>,
+	units: readonly string[],
+	error: unknown,
+): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	const unit = message.match(/\bUnit\s+([^\s:]+)\s+does not exist\b/i)?.[1];
+	if (!unit || !units.includes(unit)) return false;
+	try {
+		return statSync(join(paths.systemdUserRoot, unit)).isFile();
+	} catch {
+		return false;
 	}
 }
 

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -5,6 +5,7 @@ import {
 	chmodSync,
 	chownSync,
 	existsSync,
+	lchownSync,
 	lstatSync,
 	mkdirSync,
 	mkdtempSync,
@@ -115,6 +116,15 @@ function directoryFileDigests(root: string, relative = ""): Record<string, strin
 		}
 	}
 	return digests;
+}
+
+function chownTreeWithoutFollowingLinks(path: string, uid: number, gid: number): void {
+	const node = lstatSync(path);
+	lchownSync(path, uid, gid);
+	if (!node.isDirectory() || node.isSymbolicLink()) return;
+	for (const entry of readdirSync(path)) {
+		chownTreeWithoutFollowingLinks(join(path, entry), uid, gid);
+	}
 }
 
 test("propagates the real official OpenClaw installer failure and rolls back as UID 10001", () => {
@@ -1446,4 +1456,238 @@ http.createServer((request, response) => {
 	});
 	expect(tenantRead.status).toBe(0);
 	expect(tenantRead.stdout).toBe("tenant-existing\n");
+}, 120_000);
+
+test("repairs a live Hermes user-service ownership enclave without losing the unit", () => {
+	if (process.env[REAL_SYSTEMD_GATE] !== "1") return;
+
+	expect(process.geteuid?.()).toBe(0);
+	const runtimeHome = "/home/clawdi";
+	const runtimeUid = 10_001;
+	const runtimeGid = 10_001;
+	const root = mkdtempSync(join(tmpdir(), "clawdi-live-hermes-enclave-"));
+	chmodSync(root, 0o755);
+	const hermesCommand = join(runtimeHome, ".local", "bin", "hermes");
+	const installLog = join(root, "hermes-installer.log");
+	writeFileSync(installLog, "");
+	chownSync(installLog, runtimeUid, runtimeGid);
+	const unitName = "hermes-gateway.service";
+	const unitPath = join(runtimeHome, ".config", "systemd", "user", unitName);
+	const dropInRoot = `${unitPath}.d`;
+	const enablementPath = join(
+		runtimeHome,
+		".config",
+		"systemd",
+		"user",
+		"default.target.wants",
+		unitName,
+	);
+	const runUserSystemctl = (...args: string[]) =>
+		spawnSync(
+			"runuser",
+			[
+				"-u",
+				"clawdi",
+				"--",
+				"env",
+				`HOME=${runtimeHome}`,
+				`XDG_RUNTIME_DIR=/run/user/${runtimeUid}`,
+				`DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${runtimeUid}/bus`,
+				"systemctl",
+				"--user",
+				...args,
+			],
+			{ encoding: "utf8" },
+		);
+
+	for (const staleUnit of ["openclaw-gateway.service", unitName]) {
+		runUserSystemctl("disable", "--now", staleUnit);
+	}
+	rmSync(dirname(unitPath), { recursive: true, force: true });
+	mkdirSync(dirname(unitPath), { recursive: true });
+	const initialReload = runUserSystemctl("daemon-reload");
+	expect(initialReload.status, initialReload.stderr).toBe(0);
+	mkdirSync(dirname(hermesCommand), { recursive: true });
+	writeFileSync(
+		hermesCommand,
+		`#!/bin/sh
+set -eu
+case "$*" in
+  "--version")
+    printf '%s\\n' 'Hermes Agent v0.19.1'
+    ;;
+  "gateway install --force")
+    printf '%s\\n' install >> ${JSON.stringify(installLog)}
+    mkdir -p "$HOME/.config/systemd/user"
+    cat > "$HOME/.config/systemd/user/${unitName}" <<'EOF'
+[Unit]
+Description=Hermes Gateway
+
+[Service]
+Type=simple
+ExecStart=${hermesCommand} gateway run
+Restart=always
+
+[Install]
+WantedBy=default.target
+EOF
+    systemctl --user daemon-reload
+    systemctl --user enable ${unitName}
+    ;;
+  "gateway uninstall")
+    systemctl --user disable --now ${unitName} || true
+    rm -f "$HOME/.config/systemd/user/${unitName}"
+    systemctl --user daemon-reload
+    ;;
+  "gateway run")
+    exec /bin/sleep infinity
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+`,
+		{ mode: 0o755 },
+	);
+	chownSync(hermesCommand, runtimeUid, runtimeGid);
+
+	process.env.CLAWDI_RUNTIME_MODE = "hosted";
+	process.env.CLAWDI_RUNTIME_USER = "clawdi";
+	process.env.CLAWDI_RUNTIME_UID = String(runtimeUid);
+	process.env.CLAWDI_RUNTIME_GID = String(runtimeGid);
+	process.env.CLAWDI_RUNTIME_HOME = runtimeHome;
+	process.env.CLAWDI_HOME = join(root, "clawdi-home");
+	process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+	process.env.CLAWDI_RUN_DIR = join(root, "run");
+	process.env.CLAWDI_SYSTEMD_SYSTEM_ROOT = "/run/systemd/system";
+	process.env.CLAWDI_AUTH_TOKEN = "live-hermes-enclave-test-auth-token";
+	process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
+	const paths = getRuntimePaths({ mode: "hosted" });
+	ensureRuntimeStateDirs(paths);
+	const manifest: RuntimeManifest = {
+		schemaVersion: "clawdi.runtimeDesiredState.v1",
+		deploymentId: "hdep_live_hermes_enclave",
+		environmentId: "env_live_hermes_enclave",
+		instanceId: "hri_live_hermes_enclave",
+		generation: 1,
+		issuedAt: "2026-08-21T00:00:00.000Z",
+		workspaceRoot: join(runtimeHome, "clawdi-live-hermes-workspace"),
+		controlPlane: { apiUrl: "https://cloud-api.example.test" },
+		runtimes: {
+			hermes: {
+				enabled: true,
+				run: {
+					command: hermesCommand,
+					args: ["gateway", "run"],
+					env: {},
+					prependPath: [],
+				},
+				services: {},
+			},
+		},
+		recovery: {},
+	};
+	const load: RuntimeManifestLoad = {
+		manifest,
+		source: "remote-datasource",
+		sourcePath: "live-hermes-enclave-fixture",
+		offline: false,
+		applyContext: {
+			kind: "context-file",
+			backend: "incus",
+			identity: {
+				generation: manifest.generation,
+				manifestETag: '"live-hermes-enclave-test"',
+				applyReceiptId: "live-hermes-enclave-test-receipt",
+				bootNonce: "live-hermes-enclave-test-boot",
+			},
+			manifestSource: {
+				type: "http",
+				url: "https://runtime.test/v1/runtime/manifest?environment_id=env_live_hermes_enclave",
+				auth: { type: "bearer", token: "live-hermes-enclave-test-auth-token" },
+			},
+		},
+	};
+	const converge = () => {
+		const before = readSystemdUnitSnapshot(paths);
+		const transaction = new SystemdRuntimeTransaction();
+		return convergeRuntimeManifest(load, paths, {
+			cacheLastGood: false,
+			systemdApply: {
+				transactionState: () => transaction.state,
+				installOfficialService: (unit, install) =>
+					transaction.installOfficialService(paths, unit, install),
+				quiesce: (affectedUserUnits) => transaction.quiesce(paths, affectedUserUnits),
+				activateEgressPrerequisite: () => ({
+					applied: true,
+					systemUnitsChanged: [],
+					userUnitsChanged: [],
+				}),
+				activate: () =>
+					applySystemdRuntimeUpdate(paths, before, readSystemdUnitSnapshot(paths), {
+						transaction,
+						stage: "final-activation",
+					}),
+				rollback: () => transaction.rollback(paths),
+			},
+		});
+	};
+
+	try {
+		expect(converge().installErrors).toEqual([]);
+		const initialState = runUserSystemctl(
+			"show",
+			unitName,
+			"--property=LoadState",
+			"--property=ActiveState",
+			"--property=MainPID",
+		);
+		expect(initialState.status, initialState.stderr).toBe(0);
+		expect(initialState.stdout).toContain("LoadState=loaded");
+		expect(initialState.stdout).toContain("ActiveState=active");
+		const initialPid = Number.parseInt(
+			initialState.stdout.match(/^MainPID=(\d+)$/m)?.[1] ?? "0",
+			10,
+		);
+		expect(initialPid).toBeGreaterThan(1);
+		expect(runUserSystemctl("is-enabled", unitName).stdout.trim()).toBe("enabled");
+
+		chmodSync(unitPath, 0o600);
+		chownTreeWithoutFollowingLinks(paths.systemdUserRoot, runtimeUid, runtimeGid);
+		for (const path of [paths.systemdUserRoot, unitPath, dropInRoot, enablementPath]) {
+			const node = lstatSync(path);
+			expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
+		}
+
+		const repaired = converge();
+		expect(repaired.installErrors).toEqual([]);
+		expect(readFileSync(installLog, "utf8").trim().split("\n")).toEqual(["install", "install"]);
+		for (const path of [paths.systemdUserRoot, unitPath, dropInRoot, enablementPath]) {
+			const node = lstatSync(path);
+			expect([node.uid, node.gid]).toEqual([0, 0]);
+		}
+		const repairedState = runUserSystemctl(
+			"show",
+			unitName,
+			"--property=LoadState",
+			"--property=ActiveState",
+			"--property=MainPID",
+		);
+		expect(repairedState.status, repairedState.stderr).toBe(0);
+		expect(repairedState.stdout).toContain("LoadState=loaded");
+		expect(repairedState.stdout).toContain("ActiveState=active");
+		const repairedPid = Number.parseInt(
+			repairedState.stdout.match(/^MainPID=(\d+)$/m)?.[1] ?? "0",
+			10,
+		);
+		expect(repairedPid).toBe(initialPid);
+		expect(runUserSystemctl("is-enabled", unitName).stdout.trim()).toBe("enabled");
+		expect(runUserSystemctl("enable", unitName).status).toBe(0);
+	} finally {
+		runUserSystemctl("disable", "--now", unitName);
+		rmSync(unitPath, { force: true });
+		rmSync(dropInRoot, { recursive: true, force: true });
+		rmSync(enablementPath, { force: true });
+		rmSync(root, { recursive: true, force: true });
+	}
 }, 120_000);

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -425,6 +425,7 @@ function writeFakeSystemdManager(input: {
 	environmentRoot: string;
 	failNextGatewayRestart?: string;
 	failNextSidecarRestart?: string;
+	failFirstMissingUserEnableUnit?: string;
 	sidecarReadyPath?: string;
 }): void {
 	fakeSystemdStateRoots.add(input.stateRoot);
@@ -526,11 +527,16 @@ case "$command" in
       rm -f "$(state_path "$unit" active)" "$(state_path "$unit" failed)" "$(state_path "$unit" pid)"
     done
     ;;
-  enable)
-    start_now=0
-    if [ "\${1:-}" = "--now" ]; then start_now=1; shift; fi
-    for unit in "$@"; do
-      touch "$(state_path "$unit" enabled)"
+	  enable)
+	    start_now=0
+	    if [ "\${1:-}" = "--now" ]; then start_now=1; shift; fi
+	    for unit in "$@"; do
+	      if [ "$scope" = user ] && [ "$unit" = '${input.failFirstMissingUserEnableUnit ?? ""}' ] && [ ! -f "$(state_path "$unit" enable-retried)" ]; then
+	        touch "$(state_path "$unit" enable-retried)"
+	        printf 'Failed to enable unit: Unit %s does not exist\n' "$unit" >&2
+	        exit 1
+	      fi
+	      touch "$(state_path "$unit" enabled)"
       if [ "$start_now" = "1" ]; then rm -f "$(state_path "$unit" failed)" "$(state_path "$unit" not-found)"; touch "$(state_path "$unit" active)"; start_process "$unit"; fi
     done
     ;;
@@ -10086,6 +10092,87 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		expect(driftRepairCalls).not.toContain("daemon-reload");
 		expect(driftRepairCalls).toContain("--user restart hermes-gateway.service");
 		expect(driftRepairCalls).not.toContain("restart clawdi-runtime-watch.service");
+	});
+
+	it("reloads once before retrying an enable for an existing user unit", () => {
+		const home = join(root, "missing-enable", "home", "clawdi");
+		const run = join(root, "missing-enable", "run", "clawdi");
+		const systemctlPath = join(root, "missing-enable", "bin", "systemctl");
+		const systemctlLog = join(root, "missing-enable", "systemctl.log");
+		const systemctlStateRoot = join(root, "missing-enable", "systemctl-state");
+		const unit = "hermes-gateway.service";
+		writeFakeSystemdManager({
+			path: systemctlPath,
+			logPath: systemctlLog,
+			stateRoot: systemctlStateRoot,
+			environmentRoot: join(run, "systemd", "env"),
+			failFirstMissingUserEnableUnit: unit,
+		});
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlPath;
+		process.env.CLAWDI_SYSTEMD_APPLY = "1";
+		const paths = getRuntimePaths();
+		const revision = "a".repeat(32);
+		const units = {
+			system: new Map<string, string>(),
+			user: new Map([[unit, "hermes"]]),
+		};
+		mkdirSync(paths.systemdUserRoot, { recursive: true });
+		writeFileSync(join(paths.systemdUserRoot, unit), "[Service]\nExecStart=/bin/true\n");
+		mkdirSync(paths.systemdEnvRoot, { recursive: true });
+		writeFileSync(join(paths.systemdEnvRoot, `${unit}.env`), `CLAWDI_RUNTIME_REV="${revision}"\n`);
+		seedFakeSystemdProcess(systemctlStateRoot, "user", unit, revision);
+		writeFileSync(systemctlLog, "");
+		const transaction = new SystemdRuntimeTransaction();
+
+		expect(
+			applySystemdRuntimeUpdate(paths, units, units, {
+				transaction,
+				stage: "final-activation",
+			}),
+		).toEqual({
+			applied: true,
+			systemUnitsChanged: [],
+			userUnitsChanged: [unit],
+		});
+		expect(transaction.journal).toEqual([
+			{
+				sequence: 1,
+				stage: "final-activation",
+				scope: "user",
+				action: "enable",
+				units: [unit],
+				outcome: "failed",
+			},
+			{
+				sequence: 2,
+				stage: "final-activation",
+				scope: "user",
+				action: "daemon-reload",
+				units: [],
+				outcome: "succeeded",
+			},
+			{
+				sequence: 3,
+				stage: "final-activation",
+				scope: "user",
+				action: "enable",
+				units: [unit],
+				outcome: "succeeded",
+			},
+		]);
+		const mutations = readFileSync(systemctlLog, "utf8")
+			.trim()
+			.split("\n")
+			.filter((call) => /(?:^|\s)(?:daemon-reload|enable)(?:\s|$)/.test(call));
+		expect(mutations).toEqual([
+			`--user enable ${unit}`,
+			"--user daemon-reload",
+			`--user enable ${unit}`,
+		]);
 	});
 
 	it("adopts a cross-version user revision only until its desired program changes", () => {


### PR DESCRIPTION
## Evidence chain

CLI 0.14.4 marked itself bad after the first post-upgrade converge failed in `activateRuntimeServices`:

```text
first converge after CLI upgrade failed: runtime apply failed: systemd apply failed: systemctl --user enable hermes-gateway.service failed (1): Failed to enable unit: Unit hermes-gateway.service does not exist
```

The affected host still had the unit file on disk and the gateway process running, while the active UID 10001 user manager could no longer resolve the unit. Its entire `~/.config/systemd/user` tree was legacy UID/GID 10001 state, so #1154 exercised its enclave ownership repair against a live manager for the first time.

## Reproduction

A privileged PID1 fixture now creates the exact combination:

- an active `user@10001.service` manager;
- a running and enabled `hermes-gateway.service`;
- a real unit, hosted drop-in, and `default.target.wants` symlink;
- the complete user-systemd tree owned by UID/GID 10001;
- the existing Hermes unit at mode `0600`.

Before the fix, convergence reproduces the release failure exactly:

```text
runtime apply failed: systemd apply failed: systemctl --user enable hermes-gateway.service failed (1): Failed to enable unit: Unit hermes-gateway.service does not exist
```

A narrower systemd experiment isolated the transition. The tenant-owned `0600` unit is loadable and enableable. Changing only its ownership to root preserves the running process and MainPID, but `systemctl --user is-enabled` becomes `not-found` and `enable` reports that the unit does not exist.

## Exact mechanism

#1154 does not rename, rebuild, or delete enclave entries. Its recursive repair uses non-dereferencing `lchown` throughout, so this is not an inotify deletion race.

The failure comes from preserving a legacy private mode while changing the owner. An official installer can leave its tenant-owned unit at `0600`. The post-installer enclave repair then changes that file to root ownership without changing its mode. UID 10001's live user manager can keep the already-loaded process running, but it can no longer read the on-disk unit. Its enabled-state lookup therefore resolves as `not-found`, and final activation attempts an `enable` that fails with `Unit ... does not exist`.

The previous privileged fixtures started from clean root-owned, manager-readable files, so they never exercised this mode-and-owner repair path.

## Fix

The primary repair keeps ownership convergence transparent to the live manager:

- before any systemd observation or mutation, restore the minimum manager access bits on the user-systemd enclave;
- repeat that metadata repair after official installers and before returning the enclave to root;
- preserve all existing mode bits while requiring read/traverse access only for `*.service`, `*.service.d/*.conf`, the user-unit root, drop-in directories, and `default.target.wants`;
- keep unrelated private enclave files, including gateway environment files, at `0600`;
- retain recursive non-dereferencing `lchown` for ownership, with no rename, rebuild, or delete.

As defense in depth, a user-unit `enable` or `enable --now` failure is retried exactly once after `daemon-reload`, but only when the error names a requested `Unit ... does not exist` and that exact unit file exists on disk. Other errors, missing files, reload failures, and second failures remain fail-closed. Rollback enablement uses the same bounded recovery.

## Verification

- CLI clean runner typecheck and full `test:internal`: `1752 pass`, `4 skip`, `0 fail`
- focused mutation parity: `1 pass`, `0 fail`
- focused final ownership, retry, and mutation-parity tests: `3 pass`, `0 fail`
- privileged PID1 official-installer systemd suite: `5 pass`, `0 fail`
- repository-pinned Biome 2.5.9 on all changed files: clean
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
