### PR TITLE
release(cli): 0.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.5
+
+Package: `clawdi@0.14.5`
+
+### Fixed
+
+- Repairing drifted ownership of systemd artifacts now also restores the
+  read/traverse permissions the tenant's systemd user manager needs, so the
+  repair no longer makes running units unresolvable. A bounded daemon-reload
+  retry guards enable calls when the manager's unit view is stale.
+
 ## Clawdi CLI v0.14.4
 
 Package: `clawdi@0.14.4`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.4",
+      "version": "0.14.5",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.4",
+	"version": "0.14.5",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Release `clawdi@0.14.5` — closes the fifth-canary finding (#1156).

Root cause, reproduced in a controlled PID1 environment: repairing drifted tenant-owned (`0600`) systemd unit files back to root ownership left them unreadable to the uid-10001 user manager, which then reported running units as not-found and failed `enable` — tripping the (correctly working) auto-rollback safety net. The repair now restores the minimum read/traverse bits alongside ownership, and a tightly-scoped daemon-reload retry guards `enable` against a stale manager view.

New privileged e2e permanently pins the real-machine combination (drifted ownership + live manager + running unit). Sixth canary round follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)