### PR TITLE
fix(cli): anchor sourced Hermes skills to native installs

### DIFF
--- a/packages/cli/src/runtime/hosted-hermes-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.test.ts
@@ -40,23 +40,41 @@ function fakeHermesApp(home: string): string {
 	writeFileSync(
 		hermes,
 		`#!/usr/bin/python3
-import json, os, shutil, sys
+import json, os, re, shutil, sys
 from pathlib import Path
+from urllib.parse import urlparse
 root = Path(os.environ["HOME"]) / ".hermes" / "skills"
 with Path(os.environ["FAKE_HERMES_LOG"]).open("a") as log:
     log.write(" ".join(sys.argv[1:]) + chr(10))
 if sys.argv[1:3] == ["skills", "install"]:
     assert "--yes" in sys.argv and "--name" in sys.argv
-    name = sys.argv[sys.argv.index("--name") + 1]
+    identifier = sys.argv[3]
+    name_override = sys.argv[sys.argv.index("--name") + 1]
+    source_skill = Path(os.environ["FAKE_HERMES_SOURCE"]) / "SKILL.md"
+    source_text = source_skill.read_bytes().decode("utf-8", errors="replace")
+    frontmatter = re.match(r"^---\\r?\\n(.*?)\\r?\\n---\\r?\\n", source_text, re.DOTALL)
+    native_name = None
+    if frontmatter:
+        name_line = re.search(r"""^name:\\s*['"]?([^'"\\r\\n]+)""", frontmatter.group(1), re.MULTILINE)
+        if name_line:
+            candidate = name_line.group(1).strip()
+            if re.fullmatch(r"[a-z][a-z0-9_-]*", candidate.lower()) and candidate.lower() not in {"skill", "readme", "index", "unnamed-skill"}:
+                native_name = candidate
+    if native_name is None:
+        parts = [part for part in urlparse(identifier).path.split("/") if part]
+        candidate = parts[-2] if len(parts) >= 2 and parts[-1].lower() == "skill.md" else re.sub(r"(?i)\\.md$", "", parts[-1])
+        if re.fullmatch(r"[a-z][a-z0-9_-]*", candidate.lower()) and candidate.lower() not in {"skill", "readme", "index", "unnamed-skill"}:
+            native_name = candidate
+    name = native_name or name_override
     if os.environ.get("FAKE_HERMES_INSTALL_NOOP") == "1":
+        print("Error: Could not fetch source Skill")
         raise SystemExit(0)
     target = root / name
     marker = root / ".native-installed" / name
     shutil.rmtree(target, ignore_errors=True)
     target.parent.mkdir(parents=True, exist_ok=True)
     target.mkdir(parents=True, exist_ok=True)
-    source_skill = Path(os.environ["FAKE_HERMES_SOURCE"]) / "SKILL.md"
-    (target / "SKILL.md").write_text(source_skill.read_bytes().decode("utf-8", errors="replace"), encoding="utf-8")
+    (target / "SKILL.md").write_text(source_text, encoding="utf-8")
     support = Path(os.environ["FAKE_HERMES_SOURCE"]) / "references" / "guide.md"
     if support.exists():
         (target / "references").mkdir(parents=True, exist_ok=True)
@@ -64,6 +82,13 @@ if sys.argv[1:3] == ["skills", "install"]:
     (target / ".hermes-native.json").write_text(json.dumps({"installed": True}) + chr(10))
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.write_text("installed")
+    hub = root / ".hub"
+    lock_path = hub / "lock.json"
+    hub.mkdir(parents=True, exist_ok=True)
+    lock = json.loads(lock_path.read_text()) if lock_path.exists() else {"version": 1, "installed": {}}
+    lock["installed"][name] = {"source": "url", "identifier": identifier, "install_path": name}
+    lock_path.write_text(json.dumps(lock, indent=2) + chr(10))
+    print("Installed: " + name)
 elif sys.argv[1:3] == ["skills", "uninstall"]:
     if len(sys.argv) != 4:
         print("hermes skills uninstall: error: unrecognized arguments: " + " ".join(sys.argv[4:]), file=sys.stderr)
@@ -73,8 +98,13 @@ elif sys.argv[1:3] == ["skills", "uninstall"]:
         raise SystemExit(0)
     if os.environ.get("FAKE_HERMES_UNINSTALL_FAIL") == "1":
         raise SystemExit(43)
-    shutil.rmtree(root / sys.argv[3])
-    (root / ".native-installed" / sys.argv[3]).unlink(missing_ok=True)
+    name = sys.argv[3]
+    shutil.rmtree(root / name)
+    (root / ".native-installed" / name).unlink(missing_ok=True)
+    lock_path = root / ".hub" / "lock.json"
+    lock = json.loads(lock_path.read_text())
+    lock["installed"].pop(name, None)
+    lock_path.write_text(json.dumps(lock, indent=2) + chr(10))
 else:
     raise SystemExit(2)
 `,
@@ -84,7 +114,7 @@ else:
 }
 
 describe("Hermes exact-source Workspace Skill driver", () => {
-	test("rejects a native false success without running a fake rollback", () => {
+	test("rejects a native false success and anchors the official frontmatter target", () => {
 		root = mkdtempSync(join(tmpdir(), "hosted-hermes-project-skill-"));
 		delete process.env.CLAWDI_RUNTIME_USER;
 		const home = join(root, "home");
@@ -93,7 +123,10 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		const appRoot = fakeHermesApp(home);
 		const sourceDir = join(root, "source", "review-pr");
 		mkdirSync(sourceDir, { recursive: true });
-		writeFileSync(join(sourceDir, "SKILL.md"), "# Review PR\n");
+		writeFileSync(
+			join(sourceDir, "SKILL.md"),
+			'---\nname: native-review-pr\ndescription: "A long Project Skill description that keeps the native frontmatter name even when --name supplies the manifest id."\n---\n# Review PR\n',
+		);
 		process.env.FAKE_HERMES_SOURCE = sourceDir;
 		const commandLog = join(root, "hermes.log");
 		process.env.FAKE_HERMES_LOG = commandLog;
@@ -130,12 +163,35 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 				skill,
 				previouslyReserved: false,
 			}),
-		).toThrow("installed Skill tree is absent");
+		).toThrow("did not record an installed target: Error: Could not fetch source Skill");
 		expect(readFileSync(commandLog, "utf8").trim()).toBe(
 			`skills install ${installUrl} --name review-pr --yes`,
 		);
 		expect(existsSync(join(home, ".hermes", "skills", "review-pr"))).toBe(false);
 		delete process.env.FAKE_HERMES_INSTALL_NOOP;
+		const nativeTarget = hostedHermesSkillExactSourceDriver.target?.({ home, skill });
+		expect(nativeTarget).toBe(join(home, ".hermes", "skills", "native-review-pr"));
+		expect(
+			hostedHermesSkillExactSourceDriver.install({
+				home,
+				appRoot,
+				managedResourceRoot,
+				skill,
+				targetDir: nativeTarget,
+				previouslyReserved: false,
+			}),
+		).toBe("installed");
+		expect(existsSync(join(home, ".hermes", "skills", "review-pr"))).toBe(false);
+		expect(existsSync(nativeTarget ?? "")).toBe(true);
+		expect(
+			hostedHermesSkillExactSourceDriver.verifyOwned({
+				home,
+				appRoot,
+				managedResourceRoot,
+				skill,
+				targetDir: nativeTarget,
+			}),
+		).toBe(true);
 	});
 
 	test("requires paired ownership and uses Hermes install and uninstall semantics", async () => {
@@ -149,8 +205,9 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		const sourceDir = join(root, "source", "review-pr");
 		mkdirSync(sourceDir, { recursive: true });
 		const skillV1 =
-			"# Review PR\n\n[Guide](references/guide.md)\n[Missing](references/missing.md)\n";
-		const skillV2 = "# Review PR v2\n\n[Guide](references/guide.md)\n";
+			"---\nname: review-pr\ndescription: Review pull requests\n---\n# Review PR\n\n[Guide](references/guide.md)\n[Missing](references/missing.md)\n";
+		const skillV2 =
+			"---\nname: review-pr\ndescription: Review pull requests\n---\n# Review PR v2\n\n[Guide](references/guide.md)\n";
 		const skillV1Source = Buffer.concat([Buffer.from(skillV1), Buffer.from([0xff])]);
 		const skillV1Native = Buffer.from(skillV1Source.toString("utf8"), "utf8");
 		writeFileSync(join(sourceDir, "SKILL.md"), skillV1Source);

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -1,5 +1,6 @@
-import { existsSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import {
 	collectManagedSkillTree,
@@ -25,11 +26,13 @@ import {
 const HERMES_SKILL_COMMAND_TIMEOUT_MS = 120_000;
 
 export interface HostedHermesSkillExactSourceDriver {
+	target?(input: { home: string; skill: PreparedHostedSourcedSkill }): string;
 	install(input: {
 		home: string;
 		appRoot: string;
 		managedResourceRoot: string;
 		skill: PreparedHostedSourcedSkill;
+		targetDir?: string;
 		previouslyReserved: boolean;
 	}): "installed" | "unchanged";
 	anchorOwnership(input: {
@@ -37,18 +40,21 @@ export interface HostedHermesSkillExactSourceDriver {
 		managedResourceRoot: string;
 		skillId: string;
 		ownershipIdentity: string;
+		targetDir?: string;
 	}): void;
 	verifyOwned(input: {
 		home: string;
 		appRoot: string;
 		managedResourceRoot: string;
 		skill: PreparedHostedSourcedSkill;
+		targetDir?: string;
 	}): boolean;
 	hasOwnershipReceipt(input: {
 		home: string;
 		managedResourceRoot: string;
 		skillId: string;
 		ownershipIdentity: string;
+		targetDir?: string;
 	}): boolean;
 	uninstall(input: {
 		home: string;
@@ -56,12 +62,14 @@ export interface HostedHermesSkillExactSourceDriver {
 		managedResourceRoot: string;
 		skillId: string;
 		ownershipIdentity: string;
+		targetDir?: string;
 	}): "absent" | "removed";
 	cleanupManifestOwned(input: {
 		home: string;
 		managedResourceRoot: string;
 		skillId: string;
 		ownershipIdentity: string;
+		targetDir?: string;
 	}): "absent" | "removed";
 }
 
@@ -75,13 +83,12 @@ function commandPath(home: string, appRoot: string): string {
 		throw new Error("installed Hermes Skill CLI is unavailable");
 	});
 }
-const targetDir = (home: string, skillId: string) => join(home, ".hermes", "skills", skillId);
 
 function receiptInput(
 	managedResourceRoot: string,
-	home: string,
 	skillId: string,
 	ownershipIdentity: string,
+	target: string,
 ) {
 	return {
 		path: managedSkillReceiptPath(managedResourceRoot, "hermes", skillId),
@@ -89,7 +96,7 @@ function receiptInput(
 		schemaVersion: HERMES_MANAGED_SKILL_RECEIPT_SCHEMA,
 		skillId,
 		ownershipIdentity,
-		target: targetDir(home, skillId),
+		target,
 	};
 }
 
@@ -108,6 +115,119 @@ function rawSkillUrl(skill: PreparedHostedSourcedSkill): string {
 		.join("/");
 	const skillPath = encodedPath ? `${encodedPath}/SKILL.md` : "SKILL.md";
 	return `https://raw.githubusercontent.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${skill.source.commit}/${skillPath}`;
+}
+
+const HERMES_URL_SKILL_NAME_PATTERN = /^[a-z][a-z0-9_-]*$/;
+const HERMES_RESERVED_URL_SKILL_NAMES = new Set(["skill", "readme", "index", "unnamed-skill"]);
+
+function validHermesUrlSkillName(value: unknown): value is string {
+	if (typeof value !== "string") return false;
+	const candidate = value.trim().toLowerCase();
+	return (
+		candidate.length > 0 &&
+		!HERMES_RESERVED_URL_SKILL_NAMES.has(candidate) &&
+		HERMES_URL_SKILL_NAME_PATTERN.test(candidate)
+	);
+}
+
+function frontmatterName(sourceDir: string): string | null {
+	const content = readFileSync(join(sourceDir, "SKILL.md"), "utf8").replace(/^\uFEFF/, "");
+	if (!content.startsWith("---")) return null;
+	const body = content.slice(3);
+	const end = /\n---\s*\n/.exec(body);
+	if (!end) return null;
+	try {
+		const parsed = parseYaml(body.slice(0, end.index));
+		if (
+			typeof parsed === "object" &&
+			parsed !== null &&
+			!Array.isArray(parsed) &&
+			validHermesUrlSkillName((parsed as Record<string, unknown>).name)
+		) {
+			return String((parsed as Record<string, unknown>).name).trim();
+		}
+	} catch {
+		return null;
+	}
+	return null;
+}
+
+function urlSkillName(url: string): string | null {
+	const parts = new URL(url).pathname.split("/").filter(Boolean);
+	if (parts.at(-1)?.toLowerCase() === "skill.md" && parts.length >= 2) {
+		const candidate = parts.at(-2);
+		if (validHermesUrlSkillName(candidate)) return candidate;
+	}
+	const candidate = parts.at(-1)?.replace(/\.md$/i, "");
+	return validHermesUrlSkillName(candidate) ? candidate : null;
+}
+
+function plannedNativeTarget(
+	home: string,
+	skill: PreparedHostedSourcedSkill,
+	sourceDir: string,
+): string {
+	if (skill.source.type === "bundled") {
+		return join(home, ".hermes", "skills", skill.skillId);
+	}
+	const nativeName =
+		frontmatterName(sourceDir) ?? urlSkillName(rawSkillUrl(skill)) ?? skill.skillId;
+	return join(home, ".hermes", "skills", nativeName);
+}
+
+function hermesCommandOutput(result: ReturnType<typeof runHermes>): string {
+	return [result.stderr, result.stdout]
+		.map((value) => String(value ?? "").trim())
+		.filter(Boolean)
+		.join("\n");
+}
+
+function installedTargetFromHermesLock(home: string, identifier: string): string | null {
+	return withRuntimeUserFileAccess(() => {
+		const skillsRoot = resolve(home, ".hermes", "skills");
+		const lockPath = join(skillsRoot, ".hub", "lock.json");
+		if (!existsSync(lockPath)) return null;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(readFileSync(lockPath, "utf8"));
+		} catch {
+			throw new ManagedSkillResourceError("Hermes Skill lock is invalid");
+		}
+		if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+			throw new ManagedSkillResourceError("Hermes Skill lock is invalid");
+		}
+		const lock = parsed as Record<string, unknown>;
+		if (lock.version !== 1 || typeof lock.installed !== "object" || lock.installed === null) {
+			throw new ManagedSkillResourceError("Hermes Skill lock is invalid");
+		}
+		const matches: Array<{ name: string; installPath: string }> = [];
+		for (const [name, value] of Object.entries(lock.installed as Record<string, unknown>)) {
+			if (typeof value !== "object" || value === null || Array.isArray(value)) continue;
+			const entry = value as Record<string, unknown>;
+			if (entry.identifier !== identifier) continue;
+			if (entry.source !== "url") {
+				throw new ManagedSkillResourceError("Hermes Skill lock source is invalid");
+			}
+			if (typeof entry.install_path !== "string") {
+				throw new ManagedSkillResourceError("Hermes Skill lock install path is invalid");
+			}
+			matches.push({ name, installPath: entry.install_path });
+		}
+		if (matches.length === 0) return null;
+		if (matches.length !== 1) {
+			throw new ManagedSkillResourceError("Hermes Skill lock source identity is ambiguous");
+		}
+		const [{ name, installPath }] = matches;
+		if (
+			!validHermesUrlSkillName(name) ||
+			installPath !== name ||
+			dirname(resolve(skillsRoot, installPath)) !== skillsRoot ||
+			basename(resolve(skillsRoot, installPath)) !== name
+		) {
+			throw new ManagedSkillResourceError("Hermes Skill lock install path is unsafe");
+		}
+		return join(skillsRoot, installPath);
+	});
 }
 
 function runHermes(input: { home: string; appRoot: string }, args: string[], stdin?: string) {
@@ -148,18 +268,49 @@ function assertBundledResultMatches(sourceDir: string, target: string): void {
 }
 
 export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDriver = {
+	target(input) {
+		if (input.skill.source.type !== "bundled") {
+			const installed = installedTargetFromHermesLock(input.home, rawSkillUrl(input.skill));
+			if (installed) return installed;
+		}
+		return withStagedManagedSkill(input.skill, (sourceDir) =>
+			plannedNativeTarget(input.home, input.skill, sourceDir),
+		);
+	},
 	install(input) {
-		const target = targetDir(input.home, input.skill.skillId);
+		const installedBefore =
+			input.skill.source.type === "bundled"
+				? null
+				: installedTargetFromHermesLock(input.home, rawSkillUrl(input.skill));
+		const target = resolve(
+			input.targetDir ??
+				installedBefore ??
+				withStagedManagedSkill(input.skill, (sourceDir) =>
+					plannedNativeTarget(input.home, input.skill, sourceDir),
+				),
+		);
 		const receipt = receiptInput(
 			input.managedResourceRoot,
-			input.home,
 			input.skill.skillId,
 			input.skill.sourceIdentity,
+			target,
 		);
 		if (withRuntimeUserFileAccess(() => existsSync(target)) && !input.previouslyReserved)
 			throw new Error("Hermes Skill target is not paired with a manifest reservation");
-		if (managedSkillReceiptMatchesIdentity(receipt)) return "unchanged";
+		if (managedSkillReceiptMatchesIdentity(receipt)) {
+			if (
+				input.skill.source.type === "bundled" ||
+				installedTargetFromHermesLock(input.home, rawSkillUrl(input.skill)) === target
+			) {
+				return "unchanged";
+			}
+		}
 		return withStagedManagedSkill(input.skill, (sourceDir) => {
+			const plannedTarget =
+				installedBefore ?? plannedNativeTarget(input.home, input.skill, sourceDir);
+			if (resolve(plannedTarget) !== target) {
+				throw new Error("Hermes Skill planned target changed during installation");
+			}
 			if (input.skill.source.type === "bundled") {
 				replaceManagedSkillDirectoryAtomic(sourceDir, target, {
 					receipt: receipt.path,
@@ -186,9 +337,30 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 					const result = runHermes(input, args);
 					if (result.status !== 0)
 						throw new ManagedSkillResourceError(
-							`Hermes official Skill install failed: ${String(result.stderr || result.stdout).trim() || "unknown error"}`,
+							`Hermes official Skill install failed: ${hermesCommandOutput(result) || result.error?.message || "unknown error"}`,
 						);
-					writeManagedSkillReceipt(receipt);
+					const installedTarget = installedTargetFromHermesLock(
+						input.home,
+						rawSkillUrl(input.skill),
+					);
+					if (!installedTarget) {
+						throw new ManagedSkillResourceError(
+							`Hermes official Skill install did not record an installed target: ${hermesCommandOutput(result) || "unknown error"}`,
+						);
+					}
+					if (installedTarget !== target) {
+						throw new ManagedSkillResourceError(
+							`Hermes official Skill install recorded an unexpected target: ${installedTarget}`,
+						);
+					}
+					writeManagedSkillReceipt(
+						receiptInput(
+							input.managedResourceRoot,
+							input.skill.skillId,
+							input.skill.sourceIdentity,
+							installedTarget,
+						),
+					);
 					return "installed" as const;
 				},
 			});
@@ -196,31 +368,44 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 	},
 	anchorOwnership(input) {
 		writeManagedSkillReceipt(
-			receiptInput(input.managedResourceRoot, input.home, input.skillId, input.ownershipIdentity),
+			receiptInput(
+				input.managedResourceRoot,
+				input.skillId,
+				input.ownershipIdentity,
+				input.targetDir ?? join(input.home, ".hermes", "skills", input.skillId),
+			),
 		);
 	},
 	verifyOwned(input) {
 		return managedSkillReceiptMatchesIdentity(
 			receiptInput(
 				input.managedResourceRoot,
-				input.home,
 				input.skill.skillId,
 				input.skill.sourceIdentity,
+				input.targetDir ??
+					withStagedManagedSkill(input.skill, (sourceDir) =>
+						plannedNativeTarget(input.home, input.skill, sourceDir),
+					),
 			),
 		);
 	},
 	hasOwnershipReceipt(input) {
 		return managedSkillMarkerMatchesIdentity(
-			receiptInput(input.managedResourceRoot, input.home, input.skillId, input.ownershipIdentity),
+			receiptInput(
+				input.managedResourceRoot,
+				input.skillId,
+				input.ownershipIdentity,
+				input.targetDir ?? join(input.home, ".hermes", "skills", input.skillId),
+			),
 		);
 	},
 	uninstall(input) {
-		const target = targetDir(input.home, input.skillId);
+		const target = resolve(input.targetDir ?? join(input.home, ".hermes", "skills", input.skillId));
 		const receipt = receiptInput(
 			input.managedResourceRoot,
-			input.home,
 			input.skillId,
 			input.ownershipIdentity,
+			target,
 		);
 		const receiptState = managedSkillReceiptIdentityState(receipt);
 		if (receiptState === "absent") {
@@ -230,10 +415,10 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 		if (receiptState === "unsafe") throw new Error("Hermes Skill tree is unsafe");
 		if (receiptState !== "matched")
 			throw new Error("Hermes Skill bytes no longer match the manifest ownership receipt");
-		const result = runHermesUninstall(input, input.skillId);
+		const result = runHermesUninstall(input, basename(target));
 		if (result.status !== 0)
 			throw new ManagedSkillResourceError(
-				`Hermes official Skill uninstall failed: ${String(result.stderr || result.stdout).trim() || "unknown error"}`,
+				`Hermes official Skill uninstall failed: ${hermesCommandOutput(result) || result.error?.message || "unknown error"}`,
 			);
 		if (withRuntimeUserFileAccess(() => existsSync(target)))
 			throw new ManagedSkillResourceError(
@@ -243,12 +428,12 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 		return "removed";
 	},
 	cleanupManifestOwned(input) {
-		const target = targetDir(input.home, input.skillId);
+		const target = resolve(input.targetDir ?? join(input.home, ".hermes", "skills", input.skillId));
 		const receipt = receiptInput(
 			input.managedResourceRoot,
-			input.home,
 			input.skillId,
 			input.ownershipIdentity,
+			target,
 		);
 		const receiptState = managedSkillReceiptIdentityState(receipt);
 		if (receiptState === "absent") {

--- a/packages/cli/src/runtime/managed-skill-reservation.test.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.test.ts
@@ -172,6 +172,67 @@ describe("managed Skill reservations", () => {
 		expect(managedSkillReservationState(path, "example")).toBe("reserved");
 	});
 
+	it("moves a sourced reservation to the official native target", () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+		mkdirSync(join(root, "state"));
+		const previousTarget = join(root, "skills", "project-skill");
+		const nativeTarget = join(root, "skills", "frontmatter-name");
+		const sourceIdentity = [
+			"project",
+			"project-skill",
+			"22222222-2222-4222-8222-222222222222",
+			"a".repeat(64),
+		].join("\0");
+		reserveManagedSkill({
+			targetDir: previousTarget,
+			id: "project-skill",
+			manager: "hosted-manifest",
+			sourceIdentity,
+		});
+
+		installReservedManagedSkill(
+			{
+				targetDir: nativeTarget,
+				previousTargetDir: previousTarget,
+				id: "project-skill",
+				manager: "hosted-manifest",
+				sourceIdentity,
+			},
+			() => {
+				expect(shouldIgnoreUserSkill(previousTarget, "project-skill")).toBe(true);
+				expect(shouldIgnoreUserSkill(nativeTarget, "frontmatter-name")).toBe(true);
+			},
+		);
+
+		expect(managedSkillReservationState(previousTarget, "project-skill")).toBe("unreserved");
+		expect(managedSkillReservationState(nativeTarget, "project-skill")).toBe("reserved");
+		expect(shouldIgnoreUserSkill(nativeTarget, "frontmatter-name")).toBe(true);
+	});
+
+	it("rejects unsafe native targets for sourced reservations", () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+		mkdirSync(join(root, "state"));
+		const sourceIdentity = [
+			"project",
+			"project-skill",
+			"22222222-2222-4222-8222-222222222222",
+			"a".repeat(64),
+		].join("\0");
+
+		expect(() =>
+			reserveManagedSkill({
+				targetDir: join(root, "skills", ".hub"),
+				id: "project-skill",
+				manager: "hosted-manifest",
+				sourceIdentity,
+			}),
+		).toThrow("managed Skill reservation identity is invalid");
+	});
+
 	it("reports malformed ownership state instead of silently hiding Skills", () => {
 		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
 		process.env.HOME = root;

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -22,6 +22,13 @@ import { runtimePlatformRootForPath, writeRuntimePlatformFileAtomic } from "./st
 const LEDGER_FILE = "managed-skills.json";
 const LEDGER_SCHEMA = "clawdi.managedSkillReservations.v1";
 const MANAGED_SKILL_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+const SOURCED_MANAGED_SKILL_TARGET_PATTERN = /^[a-z][a-z0-9_-]*$/;
+const RESERVED_SOURCED_MANAGED_SKILL_TARGETS = new Set([
+	"skill",
+	"readme",
+	"index",
+	"unnamed-skill",
+]);
 const SHA256_PATTERN = /^[a-f0-9]{64}$/;
 // Exact local bundled Skill trees shipped by published CLI releases before the
 // ownership ledger. Pre-ledger installs had no marker, so content is the only
@@ -91,6 +98,27 @@ function emptyLedger(): ManagedSkillReservationLedger {
 	return { schemaVersion: LEDGER_SCHEMA, reservations: {}, localSetupMigrations: {} };
 }
 
+function validSourcedManagedSkillTarget(value: string): boolean {
+	const candidate = value.toLowerCase();
+	return (
+		SOURCED_MANAGED_SKILL_TARGET_PATTERN.test(candidate) &&
+		!RESERVED_SOURCED_MANAGED_SKILL_TARGETS.has(candidate)
+	);
+}
+
+function reservationTargetMatchesIdentity(
+	target: string,
+	value: { id?: unknown; sourceIdentity?: unknown; manager?: unknown },
+): boolean {
+	const targetName = basename(target);
+	return (
+		targetName === value.id ||
+		(value.manager === "hosted-manifest" &&
+			typeof value.sourceIdentity === "string" &&
+			validSourcedManagedSkillTarget(targetName))
+	);
+}
+
 function readLedger(path: string): ManagedSkillReservationLedger {
 	const legacyPath = legacyHostedLedgerPath(path);
 	const sourcePath = existsSync(path)
@@ -122,7 +150,7 @@ function readLedger(path: string): ManagedSkillReservationLedger {
 			raw.target !== target ||
 			resolve(target) !== target ||
 			typeof raw.id !== "string" ||
-			basename(target) !== raw.id ||
+			!reservationTargetMatchesIdentity(target, raw) ||
 			!MANAGED_SKILL_ID_PATTERN.test(raw.id) ||
 			(raw.version !== undefined &&
 				(typeof raw.version !== "number" ||
@@ -230,11 +258,15 @@ function reservationIdentityIsValid(value: {
 }
 
 export function shouldIgnoreUserSkill(targetDir: string, skillId = basename(targetDir)): boolean {
-	const state = managedSkillReservationState(targetDir, skillId);
-	if (state === "indeterminate") {
+	let reservation: ManagedSkillReservation | undefined;
+	try {
+		reservation = readLedger(ledgerPath()).reservations[resolve(targetDir)];
+	} catch {
 		throw new Error("managed Skill ownership state is invalid");
 	}
-	return state === "reserved";
+	if (!reservation) return false;
+	if (reservation.id !== skillId && basename(resolve(targetDir)) === reservation.id) return false;
+	return true;
 }
 
 export function assertUserSkillTargetMutable(
@@ -327,7 +359,7 @@ export function reserveManagedSkill(input: {
 	const path = ledgerPath();
 	const target = resolve(input.targetDir);
 	if (
-		basename(target) !== input.id ||
+		!reservationTargetMatchesIdentity(target, input) ||
 		!MANAGED_SKILL_ID_PATTERN.test(input.id) ||
 		(input.version !== undefined && (!Number.isSafeInteger(input.version) || input.version <= 0)) ||
 		!reservationIdentityIsValid(input)
@@ -338,7 +370,7 @@ export function reserveManagedSkill(input: {
 		const ledger = readLedger(path);
 		const previous = ledger.reservations[target];
 		const manager = input.manager;
-		if (previous && previous.manager !== manager) {
+		if (previous && (previous.manager !== manager || previous.id !== input.id)) {
 			throw new Error(`managed Skill ${input.id} is owned by a different manager`);
 		}
 		ledger.reservations[target] = {
@@ -357,6 +389,7 @@ export function reserveManagedSkill(input: {
 export function installReservedManagedSkill<T>(
 	input: {
 		targetDir: string;
+		previousTargetDir?: string;
 		id: string;
 		version?: number;
 		digest?: string;
@@ -367,8 +400,9 @@ export function installReservedManagedSkill<T>(
 ): T {
 	const path = ledgerPath();
 	const target = resolve(input.targetDir);
+	const previousTarget = input.previousTargetDir ? resolve(input.previousTargetDir) : target;
 	if (
-		basename(target) !== input.id ||
+		!reservationTargetMatchesIdentity(target, input) ||
 		!MANAGED_SKILL_ID_PATTERN.test(input.id) ||
 		(input.version !== undefined && (!Number.isSafeInteger(input.version) || input.version <= 0)) ||
 		!reservationIdentityIsValid(input)
@@ -378,8 +412,15 @@ export function installReservedManagedSkill<T>(
 	return withLedgerWriteLock(input.manager, () => {
 		const ledger = readLedger(path);
 		const previous = ledger.reservations[target];
-		if (previous && previous.manager !== input.manager) {
+		const replaced = previousTarget === target ? previous : ledger.reservations[previousTarget];
+		if (previous && (previous.manager !== input.manager || previous.id !== input.id)) {
 			throw new Error(`managed Skill ${input.id} is owned by a different manager`);
+		}
+		if (
+			previousTarget !== target &&
+			(!replaced || replaced.manager !== input.manager || replaced.id !== input.id)
+		) {
+			throw new Error(`managed Skill ${input.id} replacement reservation is invalid`);
 		}
 		ledger.reservations[target] = {
 			target,
@@ -391,10 +432,18 @@ export function installReservedManagedSkill<T>(
 		};
 		writeLedger(path, ledger);
 		try {
-			return install();
+			const result = install();
+			if (previousTarget !== target) {
+				delete ledger.reservations[previousTarget];
+				writeLedger(path, ledger);
+			}
+			return result;
 		} catch (error) {
 			if (previous) ledger.reservations[target] = previous;
 			else delete ledger.reservations[target];
+			if (previousTarget !== target && replaced) {
+				ledger.reservations[previousTarget] = replaced;
+			}
 			writeLedger(path, ledger);
 			throw error;
 		}

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -1109,6 +1109,8 @@ function applyRuntimeResourceProjections(
 				projectionHome,
 				plan.openClawWorkspaceRoot,
 				paths.managedResourceRoot,
+				preparedHostedSourcedSkills,
+				hermesSkillNativeReconciler,
 			);
 			skillProjectionScope = state.rollbackSnapshots.captureScoped(
 				"runtime Skill filesystem rollback failed",

--- a/packages/cli/src/runtime/manifest-planning.ts
+++ b/packages/cli/src/runtime/manifest-planning.ts
@@ -674,6 +674,8 @@ export function hostedSkillMutationTargets(
 	home: string,
 	openClawWorkspaceRoot: string | null,
 	managedResourceRoot: string,
+	preparedSourcedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
+	hermesDriver: HostedHermesSkillExactSourceDriver,
 ): { platformTargets: string[]; runtimeUserTargets: string[] } {
 	const runtimeUserTargets = new Set<string>();
 	const platformTargets = new Set<string>();
@@ -689,6 +691,11 @@ export function hostedSkillMutationTargets(
 		if (openClawSkillsRoot) addSkillTargets("openclaw", openClawSkillsRoot, skillId);
 		if ("source" in desired && manifest.runtimes.hermes?.enabled === true) {
 			managesHermesSourcedSkill = true;
+			const prepared = preparedSourcedSkills.get(skillId);
+			if (prepared?.skillId === skillId) {
+				const target = hermesDriver.target?.({ home, skill: prepared });
+				if (target) runtimeUserTargets.add(target);
+			}
 		}
 	}
 	for (const skillId of hostedBundledSkillIds()) {
@@ -698,10 +705,12 @@ export function hostedSkillMutationTargets(
 	for (const reservation of managedSkillReservations("hosted-manifest")) {
 		if (dirname(reservation.targetDir) === hermesSkillsRoot) {
 			if (reservation.sourceIdentity) managesHermesSourcedSkill = true;
-			addSkillTargets("hermes", hermesSkillsRoot, reservation.id);
+			runtimeUserTargets.add(reservation.targetDir);
+			platformTargets.add(managedSkillReceiptPath(managedResourceRoot, "hermes", reservation.id));
 		}
 		if (openClawSkillsRoot && dirname(reservation.targetDir) === openClawSkillsRoot) {
-			addSkillTargets("openclaw", openClawSkillsRoot, reservation.id);
+			runtimeUserTargets.add(reservation.targetDir);
+			platformTargets.add(managedSkillReceiptPath(managedResourceRoot, "openclaw", reservation.id));
 		}
 	}
 	if (managesHermesSourcedSkill) runtimeUserTargets.add(join(hermesSkillsRoot, ".hub"));

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -4821,6 +4821,81 @@ echo spawned > '${installerLog}'
 		expect(existsSync(target)).toBe(false);
 	});
 
+	test("moves an enabled stale reservation to the Hermes native target", () => {
+		const paths = tempRuntimePaths();
+		ensureRuntimeStateDirs(paths);
+		mkdirSync(paths.managedResourceRoot, { recursive: true });
+		const skillId = "phala-cloud-template-workflows";
+		const source = {
+			type: "project" as const,
+			projectId: "22222222-2222-4222-8222-222222222222",
+			contentHash: "a".repeat(64),
+			archiveUrl: "https://cloud-api.example.test/project-skill.tar.gz",
+			installUrl: "https://cloud-api.example.test/project-skill/SKILL.md",
+		};
+		const sourceIdentity = ["project", skillId, source.projectId, source.contentHash].join("\0");
+		const prepared: PreparedHostedSourcedSkill = {
+			skillId,
+			source,
+			sourceIdentity,
+			archiveSha256: "b".repeat(64),
+			tarBytes: Buffer.from("field-shaped archive"),
+		};
+		const staleTarget = join(paths.userHome, ".hermes", "skills", skillId);
+		const nativeTarget = join(paths.userHome, ".hermes", "skills", "phala-workflows");
+		reserveManagedSkill({
+			targetDir: staleTarget,
+			id: skillId,
+			manager: "hosted-manifest",
+			sourceIdentity,
+		});
+		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		mkdirSync(dirname(hermesCommand), { recursive: true });
+		writeFileSync(hermesCommand, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+		const manifest = baseManifest(
+			paths,
+			{ hermes: { enabled: true, run: runSettings(hermesCommand, ["gateway"]), services: {} } },
+			{ projection: { skills: { entries: { [skillId]: { enabled: true, source } } } } },
+		);
+
+		const result = convergeRuntimeManifest(
+			manifestLoad(manifest, "stale-enabled-hermes-skill"),
+			paths,
+			{
+				preparedHostedSourcedSkills: new Map([[skillId, prepared]]),
+				hostedHermesSkillExactSourceDriver: {
+					target: () => nativeTarget,
+					install: (input) => {
+						expect(input.previouslyReserved).toBe(true);
+						expect(input.targetDir).toBe(nativeTarget);
+						mkdirSync(nativeTarget, { recursive: true });
+						writeFileSync(join(nativeTarget, "SKILL.md"), "native projection\n");
+						writeManagedSkillReceipt({
+							path: managedSkillReceiptPath(paths.managedResourceRoot, "hermes", skillId),
+							managedResourceRoot: paths.managedResourceRoot,
+							schemaVersion: "clawdi.hermesManifestSkillReceipt.v2",
+							skillId,
+							ownershipIdentity: sourceIdentity,
+							target: nativeTarget,
+						});
+						return "installed";
+					},
+					anchorOwnership: () => undefined,
+					hasOwnershipReceipt: () => false,
+					verifyOwned: () => false,
+					uninstall: () => "removed",
+					cleanupManifestOwned: () => "removed",
+				},
+			},
+		);
+
+		expect([...result.installErrors, ...result.resourceProjectionErrors]).toEqual([]);
+		expect(managedSkillReservationState(staleTarget, skillId)).toBe("unreserved");
+		expect(managedSkillReservationState(nativeTarget, skillId)).toBe("reserved");
+		expect(shouldIgnoreUserSkill(nativeTarget, "phala-workflows")).toBe(true);
+		expect(readFileSync(join(nativeTarget, "SKILL.md"), "utf8")).toBe("native projection\n");
+	});
+
 	test("isolates per-Skill resource failures without starving later Skills", () => {
 		const paths = tempRuntimePaths();
 		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");

--- a/packages/cli/src/runtime/manifest-skills-apply.ts
+++ b/packages/cli/src/runtime/manifest-skills-apply.ts
@@ -39,12 +39,14 @@ interface HostedSkillProjectionDriver {
 	name: "hermes" | "openclaw";
 	enabled: boolean;
 	skillsRoot: string | null;
+	target(skill: PreparedHostedSourcedSkill): string;
 	install(
 		skill: PreparedHostedSourcedSkill,
+		targetDir: string,
 		previouslyReserved: boolean,
 	): "installed" | "unchanged";
-	anchorOwnership(skillId: string, ownershipIdentity: string): void;
-	hasOwnershipReceipt(skill: PreparedHostedSourcedSkill): boolean;
+	anchorOwnership(skillId: string, ownershipIdentity: string, targetDir: string): void;
+	hasOwnershipReceipt(skill: PreparedHostedSourcedSkill, targetDir: string): boolean;
 	remove(reservation: ManagedSkillReservationSnapshot): void;
 }
 function preparedSkillMatchesDesired(
@@ -110,27 +112,33 @@ function hostedSkillProjectionDrivers(input: {
 			name: "hermes",
 			enabled: input.manifest.runtimes.hermes?.enabled === true,
 			skillsRoot: hermesSkillsRoot,
-			install: (skill, previouslyReserved) =>
+			target: (skill) =>
+				input.hermesDriver.target?.({ home: input.home, skill }) ??
+				join(hermesSkillsRoot, skill.skillId),
+			install: (skill, targetDir, previouslyReserved) =>
 				input.hermesDriver.install({
 					home: input.home,
 					appRoot,
 					managedResourceRoot: input.managedResourceRoot,
 					skill,
+					targetDir,
 					previouslyReserved,
 				}),
-			anchorOwnership: (skillId, ownershipIdentity) =>
+			anchorOwnership: (skillId, ownershipIdentity, targetDir) =>
 				input.hermesDriver.anchorOwnership({
 					home: input.home,
 					managedResourceRoot: input.managedResourceRoot,
 					skillId,
 					ownershipIdentity,
+					targetDir,
 				}),
-			hasOwnershipReceipt: (skill) =>
+			hasOwnershipReceipt: (skill, targetDir) =>
 				input.hermesDriver.hasOwnershipReceipt({
 					home: input.home,
 					managedResourceRoot: input.managedResourceRoot,
 					skillId: skill.skillId,
 					ownershipIdentity: skill.sourceIdentity,
+					targetDir,
 				}),
 			remove: (reservation) => {
 				const ownershipIdentity = reservationOwnershipIdentity(reservation);
@@ -140,6 +148,7 @@ function hostedSkillProjectionDrivers(input: {
 						managedResourceRoot: input.managedResourceRoot,
 						skillId: reservation.id,
 						ownershipIdentity,
+						targetDir: reservation.targetDir,
 					});
 					return;
 				}
@@ -149,6 +158,7 @@ function hostedSkillProjectionDrivers(input: {
 					managedResourceRoot: input.managedResourceRoot,
 					skillId: reservation.id,
 					ownershipIdentity,
+					targetDir: reservation.targetDir,
 				});
 			},
 		},
@@ -156,10 +166,17 @@ function hostedSkillProjectionDrivers(input: {
 			name: "openclaw",
 			enabled: input.manifest.runtimes.openclaw?.enabled === true,
 			skillsRoot: openClawSkillsRoot,
-			install: (skill, previouslyReserved) => {
+			target: (skill) => {
+				if (!openClawSkillsRoot) {
+					throw new Error("OpenClaw official agent workspace is unavailable");
+				}
+				return join(openClawSkillsRoot, skill.skillId);
+			},
+			install: (skill, targetDir, previouslyReserved) => {
 				if (!input.openClawWorkspaceRoot) {
 					throw new Error("OpenClaw official agent workspace is unavailable");
 				}
+				void targetDir;
 				return input.openClawDriver.install({
 					home: input.home,
 					workspaceRoot: input.openClawWorkspaceRoot,
@@ -168,7 +185,7 @@ function hostedSkillProjectionDrivers(input: {
 					previouslyReserved,
 				});
 			},
-			anchorOwnership: (skillId, ownershipIdentity) => {
+			anchorOwnership: (skillId, ownershipIdentity, _targetDir) => {
 				if (!input.openClawWorkspaceRoot) {
 					throw new Error("OpenClaw official agent workspace is unavailable");
 				}
@@ -179,7 +196,7 @@ function hostedSkillProjectionDrivers(input: {
 					ownershipIdentity,
 				});
 			},
-			hasOwnershipReceipt: (skill) => {
+			hasOwnershipReceipt: (skill, _targetDir) => {
 				if (!input.openClawWorkspaceRoot) return false;
 				return input.openClawDriver.hasOwnershipReceipt({
 					workspaceRoot: input.openClawWorkspaceRoot,
@@ -250,27 +267,24 @@ function recoverHostedSkillReservations(
 	const desiredEntries = manifest.projection?.skills?.entries ?? {};
 	const skillIds = new Set([...Object.keys(desiredEntries), ...hostedBundledSkillIds()]);
 	for (const skillId of [...skillIds].sort()) {
-		const targetDir = join(driver.skillsRoot, skillId);
+		const legacyTargetDir = join(driver.skillsRoot, skillId);
 		if (
-			!withRuntimeUserFileAccess(() => existsSync(targetDir)) ||
-			managedSkillReservationOwner(targetDir, skillId) !== "unreserved"
-		) {
-			continue;
-		}
-		if (
+			withRuntimeUserFileAccess(() => existsSync(legacyTargetDir)) &&
+			managedSkillReservationOwner(legacyTargetDir, skillId) === "unreserved" &&
 			claimLegacyHostedBundledSkill({
-				targetDir,
+				targetDir: legacyTargetDir,
 				skillId,
 				reserve: (legacy) => {
 					reserveManagedSkill({
-						targetDir,
+						targetDir: legacyTargetDir,
 						id: skillId,
 						manager: "hosted-manifest",
 						version: legacy.version,
 						digest: legacy.digest,
 					});
 				},
-				anchorOwnership: (ownershipIdentity) => driver.anchorOwnership(skillId, ownershipIdentity),
+				anchorOwnership: (ownershipIdentity) =>
+					driver.anchorOwnership(skillId, ownershipIdentity, legacyTargetDir),
 			})
 		) {
 			continue;
@@ -278,9 +292,14 @@ function recoverHostedSkillReservations(
 		const desired = desiredEntries[skillId];
 		if (!driver.enabled || desired?.enabled !== true) continue;
 		const prepared = preparedSkills.get(skillId);
+		if (!preparedSkillMatchesDesired(prepared, desired, skillId)) {
+			continue;
+		}
+		const targetDir = driver.target(prepared);
 		if (
-			!preparedSkillMatchesDesired(prepared, desired, skillId) ||
-			!driver.hasOwnershipReceipt(prepared)
+			!withRuntimeUserFileAccess(() => existsSync(targetDir)) ||
+			managedSkillReservationOwner(targetDir, skillId) !== "unreserved" ||
+			!driver.hasOwnershipReceipt(prepared, targetDir)
 		) {
 			continue;
 		}
@@ -311,7 +330,7 @@ function validateHostedSkillsPlan(
 		if (!preparedSkillMatchesDesired(prepared, desired, skillId)) {
 			throw new Error(`pinned archive for hosted Skill ${skillId} is unavailable`);
 		}
-		const targetDir = join(driver.skillsRoot, skillId);
+		const targetDir = driver.target(prepared);
 		if (
 			withRuntimeUserFileAccess(() => existsSync(targetDir)) &&
 			managedSkillReservationOwner(targetDir, skillId) !== "hosted-manifest"
@@ -332,27 +351,26 @@ function applyHostedSkills(
 	const reservations = managedSkillReservations("hosted-manifest").filter(
 		(reservation) => dirname(reservation.targetDir) === driver.skillsRoot,
 	);
+	const reservationsById = new Map<string, ManagedSkillReservationSnapshot>();
+	for (const reservation of reservations) {
+		if (reservationsById.has(reservation.id)) {
+			throw new Error(`managed Skill ${reservation.id} has multiple ownership reservations`);
+		}
+		reservationsById.set(reservation.id, reservation);
+	}
 	const skillIds = new Set([
 		...Object.keys(desiredEntries),
 		...reservations.map((reservation) => reservation.id),
 		...hostedBundledSkillIds(),
 	]);
 	for (const skillId of [...skillIds].sort()) {
-		const targetDir = join(driver.skillsRoot, skillId);
+		const reservation = reservationsById.get(skillId);
 		const desired = desiredEntries[skillId];
 		if (!driver.enabled || desired?.enabled !== true) {
-			const owner = managedSkillReservationOwner(targetDir, skillId);
-			if (owner === "unreserved" || owner === "local-setup") continue;
-			if (owner !== "hosted-manifest") {
-				throw new Error(`managed Skill ${skillId} is owned by a different manager`);
-			}
-			const reservation = managedSkillReservations("hosted-manifest").find(
-				(entry) => entry.targetDir === targetDir && entry.id === skillId,
-			);
-			if (!reservation) throw new Error(`managed Skill ${skillId} has no ownership reservation`);
+			if (!reservation) continue;
 			try {
 				releaseManagedSkill({
-					targetDir,
+					targetDir: reservation.targetDir,
 					id: skillId,
 					manager: "hosted-manifest",
 					removeTarget: () => driver.remove(reservation),
@@ -368,6 +386,7 @@ function applyHostedSkills(
 		if (!preparedSkillMatchesDesired(prepared, desired, skillId)) {
 			throw new Error(`pinned archive for hosted Skill ${skillId} is unavailable`);
 		}
+		const targetDir = driver.target(prepared);
 		const owner = managedSkillReservationOwner(targetDir, skillId);
 		if (withRuntimeUserFileAccess(() => existsSync(targetDir)) && owner !== "hosted-manifest") {
 			throw new Error(`refusing to replace unmanaged ${skillId} skill at ${targetDir}`);
@@ -376,11 +395,16 @@ function applyHostedSkills(
 			installReservedManagedSkill(
 				{
 					targetDir,
+					...(reservation && reservation.targetDir !== targetDir
+						? { previousTargetDir: reservation.targetDir }
+						: {}),
 					id: skillId,
 					manager: "hosted-manifest",
 					...preparedReservationIdentity(prepared),
 				},
-				() => driver.install(prepared, owner === "hosted-manifest"),
+				() => {
+					return driver.install(prepared, targetDir, reservation !== undefined);
+				},
 			);
 		} catch (error) {
 			if (!(error instanceof ManagedSkillResourceError)) throw error;


### PR DESCRIPTION
## Summary

Fix sourced Project Skill projection for Hermes 0.20.4 by treating Hermes's native lock record as the post-install source of truth instead of assuming the manifest Skill ID is the installed directory name.

- derive only a pre-mutation candidate with Hermes's current frontmatter/URL naming rules
- require one exact `source: "url"` lock entry for the immutable install URL after the official command returns
- bind receipts, reservations, rollback targets, user-Skill filtering, uninstall, and stale cleanup to the recorded native target
- atomically migrate legacy manifest-ID reservations to the native target
- preserve fail-closed, per-Skill isolation when Hermes prints a logical failure but exits zero

## Field evidence

The 0.14.5 device desired state contained the bundled `clawdi` Skill plus 14 sourced Project Skills. All 14 sourced Skills were absent from both the flat and categorized Hermes trees. `hermes skills list` reported only 77 built-ins plus the local `clawdi` Skill; the sourced receipts were absent, and only the stale `phala-cloud-template-workflows` reservation remained.

Convergence reached the official install and then reported this independently for each sourced Skill:

```text
runtime hermes Skill projection failed: <id>: installed Skill tree is absent
```

That proved the install command was considered successful and the failure occurred while anchoring the assumed manifest-ID target.

## Real Hermes reproduction

I installed the official latest Hermes into an isolated HOME. It resolved to Hermes 0.20.4 at:

```text
a77ee88ce29c4f1d89f8d60e5b662322645072d8
```

I then exercised the Clawdi driver with a real Attio-shaped Project Skill archive, including its long YAML frontmatter, and a public raw `SKILL.md` install URL. The exact command shape was:

```text
hermes skills install <attio-SKILL.md-url> --name attio-composio-client-updates --yes
```

The first isolated run on commit `a77ee88` recorded exit 0, an empty stderr stream, and the decisive stdout line `Installed: attio-install-auth`. A second isolated capture with the host existing Hermes 0.20.4 checkout at `8794e5a21c980a0f26532cb4883284b786cb3f25` reproduced the same behavior. Its complete raw process streams are below (ANSI disabled; Rich terminal-width wrapping preserved):

```json
{
  "status": 0,
  "stdout": "\nFetching: \nhttps://raw.githubusercontent.com/jeremylongshore/claude-code-plugins-plus-skill\ns/d8b908f40c71517c7845b31550889f50ce71a171/skills/.curated/attio-install-auth/SK\nILL.md\nQuarantined to .hub/quarantine/attio-install-auth\nRunning security scan...\nScan: attio-install-auth \n(https://raw.githubusercontent.com/jeremylongshore/claude-code-plugins-plus-skil\nls/d8b908f40c71517c7845b31550889f50ce71a171/skills/.curated/attio-install-auth/S\nKILL.md/community)  Verdict: SAFE\n  MEDIUM   supply_chain   SKILL.md:140                   \"const tokenRes = await\nfetch(\"https://app.attio.com/oauth/to\"\n  LOW      privilege_escalation SKILL.md:14                    \"allowed-tools: \nRead, Write, Edit, Bash(npm:*), Bash(npx:*), \"\n\nDecision: ALLOWED — Allowed (community source, safe verdict)\nScan provenance: fresh; scanner skills-guard-v1; hash \nsha256:28a457b7c4c87a756a416ac593eb786c350d76caa54e8ed8c74b39a7feab769f\nSource: \nhttps://raw.githubusercontent.com/jeremylongshore/claude-code-plugins-plus-skill\ns/d8b908f40c71517c7845b31550889f50ce71a171/skills/.curated/attio-install-auth/SK\nILL.md; scanned 2026-08-21T17:23:23.775854+00:00; rules: allowed_tools_field, \nremote_fetch\nInstalled: attio-install-auth\nFiles: SKILL.md\n\n",
  "stderr": ""
}
```

Filesystem and lock evidence:

```text
requested --name:  attio-composio-client-updates
installed target:  ~/.hermes/skills/attio-install-auth
lock source:       url
lock install_path: attio-install-auth
```

The old driver then checked `~/.hermes/skills/attio-composio-client-updates`, which did not exist. The fixed driver completed with:

```json
{
  "error": "",
  "expectedTargetExists": false,
  "actualTargetExists": true
}
```

The official installer required about 3.1 GB for its clone, venv, and isolated HOME. I removed the reproduction tree after the run.

## Mechanism

Hermes documents URL input and `--name` at [`hermes_cli/subcommands/skills.py:109-130`](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/hermes_cli/subcommands/skills.py#L109-L130), but `--name` is only consulted when neither valid frontmatter nor the URL can supply a name. The relevant precedence is implemented in [`hermes_cli/skills_hub.py:609-654`](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/hermes_cli/skills_hub.py#L609-L654) and [`tools/skills_hub.py:1581-1610`](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/tools/skills_hub.py#L1581-L1610). A valid frontmatter `name: attio-install-auth` therefore wins over Clawdi's manifest ID override.

Hermes also has logical failure branches that print and return without a nonzero process exit, including fetch failure, existing installs without force, quarantine rejection, and scan-policy rejection: [`hermes_cli/skills_hub.py:589-607`](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/hermes_cli/skills_hub.py#L589-L607), [`669-689`](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/hermes_cli/skills_hub.py#L669-L689), and [`721-731`](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/hermes_cli/skills_hub.py#L721-L731). Exit code alone is therefore not a valid success contract.

The successful install path is the value Hermes writes to `.hub/lock.json` after moving the quarantined tree: [`hermes_cli/skills_hub.py:777-789`](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/hermes_cli/skills_hub.py#L777-L789) and [`tools/skills_hub.py:3940-4059`](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/tools/skills_hub.py#L3940-L4059).

## Fix

For mutation planning, Clawdi now derives the same flat candidate that Hermes 0.20.4 will choose from staged `SKILL.md` frontmatter, then URL, then the supplied fallback. This candidate exists only so the transaction can snapshot and reject collisions before invoking an external installer.

After invocation, Clawdi requires exactly one safe lock entry whose `source` is `url` and whose `identifier` exactly matches the immutable install URL. Missing, malformed, ambiguous, nested, or escaping lock data fails closed. The official `install_path` then anchors the ownership receipt and all later lifecycle operations.

A zero exit with no matching lock entry now reports both stderr and stdout as `did not record an installed target`. This covers Hermes's print-and-return failure branches without weakening the existing nonzero-exit handling.

The stale `phala-cloud-template-workflows` reservation was not removed by #1154 because it was still enabled in desired state, so it never entered stale deletion. Its failed install transaction correctly restored the pre-existing reservation. This change atomically moves that enabled reservation to the official native target after a successful install and restores the old reservation if installation or ledger commit fails.

## Fake Hermes fidelity

The fake CLI no longer treats `--name` as an unconditional override or every zero exit as an installation. It now:

- gives valid frontmatter names precedence over URL and `--name`
- writes the Hermes 0.20.4 `.hub/lock.json` shape with `source`, `identifier`, and `install_path`
- prints a logical fetch error and exits zero for the false-success fixture
- removes the matching lock entry on uninstall
- covers a long Attio-style frontmatter case where manifest ID and native name differ

A true-Hermes sourced-install CI case is not added: the official installer consumed about 3.1 GB and depends on live network clone/build/scanner behavior, making it unsuitable for the bounded privileged lane. The privileged lane remains focused on deterministic systemd/installer integration, while the fake now reproduces the real naming, lock, and zero-exit failure semantics observed above.

## Verification

- CLI focused tests: 210 pass, 0 fail
- CLI typecheck: pass
- mutation parity: pass
- pinned workspace Biome: 1,065 files checked, 0 fixes
- Bun 1.4.0 CLI clean runner / full `test:internal`: 1,755 pass, 4 existing skips, 0 fail
- privileged official-installer systemd e2e: 5 pass, 0 fail
- `git diff --check`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
