### PR TITLE
release(cli): 0.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.6
+
+Package: `clawdi@0.14.6`
+
+### Fixed
+
+- Hosted project skills now install correctly on Hermes 0.20: the installed
+  location is resolved from Hermes's own install lock instead of assuming the
+  manifest ID names the directory, and installs that print errors but exit
+  zero are no longer treated as success.
+
 ## Clawdi CLI v0.14.5
 
 Package: `clawdi@0.14.5`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.5",
+      "version": "0.14.6",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.5",
+	"version": "0.14.6",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Release `clawdi@0.14.6` — closes the sixth-canary finding (#1158), the final layer of the sourced-skill failure chain present since 0.13.103.

Verified against Hermes 0.20.4 source and a live reproduction: Hermes derives the install directory from the skill's frontmatter name (our `--name` is only a fallback), and several logical failures print errors while exiting zero. The install flow now binds receipts/reservations/rollback to the authoritative record in Hermes's own `.hub/lock.json` (unique, exact-URL, path-safe) and fails closed when the lock has no record — completing the anchor philosophy: bytes, identity, and now paths are all taken from official reality, never predicted. The fake Hermes fixture now faithfully mirrors these semantics, including the exit-0-failure shape.

Seventh canary round follows: the pass bar is the deployment's full desired skill set (15 skills) installed for the first time ever, plus five consecutive clean cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)