### PR TITLE
fix(cli): install Hermes skills from verified loopback sources

### DIFF
--- a/packages/cli/src/runtime/hermes-skill-loopback-source.test.ts
+++ b/packages/cli/src/runtime/hermes-skill-loopback-source.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	hermesUrlSourceFiles,
+	withHermesSkillLoopbackSource,
+} from "./hermes-skill-loopback-source";
+
+let root = "";
+
+afterEach(() => {
+	if (root) rmSync(root, { recursive: true, force: true });
+	root = "";
+});
+
+function fetchProbe(url: string): Array<{ status: number; body: string }> {
+	const script = `
+const base = process.argv[1];
+const requests = [
+  fetch(base),
+  fetch(new URL("references/guide.md", base)),
+  fetch(new URL("unreferenced.txt", base)),
+  fetch(base, { method: "POST" }),
+  new Promise((resolve, reject) => {
+    const target = new URL(base);
+    const path = target.pathname.replace("/SKILL.md", "/references/%2e%2e/SKILL.md");
+    const request = process.getBuiltinModule("node:http").get({
+      hostname: target.hostname,
+      port: target.port,
+      path,
+    }, response => {
+      response.resume();
+      response.on("end", () => resolve({ status: response.statusCode, body: "" }));
+    });
+    request.on("error", reject);
+  }),
+];
+const responses = await Promise.all(requests);
+process.stdout.write(JSON.stringify(await Promise.all(responses.map(async response => (
+  "text" in response
+    ? { status: response.status, body: await response.text() }
+    : response
+)))));
+`;
+	const result = spawnSync(process.execPath, ["-e", script, url], {
+		encoding: "utf8",
+		timeout: 5_000,
+	});
+	if (result.status !== 0) throw new Error(result.stderr || "loopback fetch probe failed");
+	return JSON.parse(result.stdout) as Array<{ status: number; body: string }>;
+}
+
+test("serves only the nonce-scoped Hermes URL projection and closes synchronously", () => {
+	root = mkdtempSync(join(tmpdir(), "hermes-skill-loopback-source-"));
+	mkdirSync(join(root, "references"));
+	writeFileSync(join(root, "SKILL.md"), "# Test\n\n[Guide](references/guide.md)\n");
+	writeFileSync(join(root, "references", "guide.md"), "verified guide\n");
+	writeFileSync(join(root, "unreferenced.txt"), "not served\n");
+	let url = "";
+
+	withHermesSkillLoopbackSource(root, (source) => {
+		url = source.url;
+		expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/0[a-f0-9]{64}\/SKILL\.md$/);
+		expect([...source.files.keys()]).toEqual(["SKILL.md", "references/guide.md"]);
+		expect(fetchProbe(url)).toEqual([
+			{ status: 200, body: "# Test\n\n[Guide](references/guide.md)\n" },
+			{ status: 200, body: "verified guide\n" },
+			{ status: 404, body: "" },
+			{ status: 405, body: "" },
+			{ status: 400, body: "" },
+		]);
+	});
+
+	const closed = spawnSync(
+		process.execPath,
+		[
+			"-e",
+			"try { await fetch(process.argv[1], { signal: AbortSignal.timeout(1000) }); process.exit(1); } catch { process.stdout.write('closed'); }",
+			url,
+		],
+		{ encoding: "utf8", timeout: 2_000 },
+	);
+	expect(closed.status).toBe(0);
+	expect(closed.stdout).toBe("closed");
+});
+
+test("rejects source bytes that Hermes URL installation cannot preserve safely", () => {
+	root = mkdtempSync(join(tmpdir(), "hermes-skill-loopback-validation-"));
+	writeFileSync(join(root, "SKILL.md"), "[Missing](references/missing.md)\n");
+	expect(() => hermesUrlSourceFiles(root)).toThrow(
+		"prepared Hermes Skill support file is missing: references/missing.md",
+	);
+	writeFileSync(join(root, "SKILL.md"), "[Escape](references/%2e%2e/secret.md)\n");
+	expect(() => hermesUrlSourceFiles(root)).toThrow("unsafe support file reference");
+	writeFileSync(join(root, "SKILL.md"), Buffer.from([0xff]));
+	expect(() => hermesUrlSourceFiles(root)).toThrow("SKILL.md is not valid UTF-8");
+});

--- a/packages/cli/src/runtime/hermes-skill-loopback-source.ts
+++ b/packages/cli/src/runtime/hermes-skill-loopback-source.ts
@@ -1,0 +1,225 @@
+import { randomBytes } from "node:crypto";
+import { Worker } from "node:worker_threads";
+import { collectManagedSkillTree, type ManagedSkillTree } from "./managed-skill-delivery";
+
+const READY_TIMEOUT_MS = 5_000;
+const STOP_TIMEOUT_MS = 2_000;
+const SOURCE_LIFETIME_MS = 120_000;
+const ALLOWED_SUPPORT_DIRECTORIES = new Set([
+	"references",
+	"templates",
+	"scripts",
+	"assets",
+	"examples",
+]);
+const LOCAL_LINK_PATTERN =
+	/(?:\]\(|`|(?:^|[\s"']))((?:references|templates|scripts|assets|examples)\/[^\s)`"'<>]+)/gm;
+const SUSPICIOUS_LOCAL_REFERENCE_PATTERN =
+	/(?:references|templates|scripts|assets|examples)\/(?:[^\s)`"'<>]*\/)?\.\.(?:\/|$)/;
+
+enum SourceState {
+	Starting,
+	Ready,
+	Failed,
+	StopRequested,
+	Stopped,
+	Expired,
+}
+
+interface LoopbackWorkerData {
+	state: SharedArrayBuffer;
+	token: string;
+	files: Array<[string, Uint8Array]>;
+	lifetimeMs: number;
+}
+
+function normalizeReferencedPath(value: string): string | null {
+	const path = value.replace(/[.,;:]+$/, "").split(/[?#]/, 1)[0];
+	if (!path) return null;
+	let decoded: string;
+	try {
+		decoded = decodeURIComponent(path).replaceAll("\\", "/");
+	} catch {
+		return null;
+	}
+	if (decoded.startsWith("/")) return null;
+	const parts = decoded.split("/").filter((part) => part && part !== ".");
+	if (parts.length === 0 || parts.some((part) => part === ".." || part.includes(":"))) {
+		return null;
+	}
+	return parts.join("/");
+}
+
+export function hermesUrlSourceFiles(sourceDir: string): ManagedSkillTree {
+	const collected = collectManagedSkillTree(sourceDir);
+	if (collected.status !== "collected") {
+		throw new Error(`prepared Hermes Skill tree is ${collected.status}`);
+	}
+	const skillBytes = collected.tree.get("SKILL.md");
+	if (!skillBytes) throw new Error("prepared Hermes Skill is missing SKILL.md");
+	let skillText: string;
+	try {
+		skillText = new TextDecoder("utf-8", { fatal: true }).decode(skillBytes);
+	} catch {
+		throw new Error("prepared Hermes SKILL.md is not valid UTF-8");
+	}
+	const normalized = skillText.replaceAll("\\", "/");
+	if (SUSPICIOUS_LOCAL_REFERENCE_PATTERN.test(normalized)) {
+		throw new Error("prepared Hermes SKILL.md contains an unsafe support file reference");
+	}
+	const paths = new Set(["SKILL.md"]);
+	for (const match of normalized.matchAll(LOCAL_LINK_PATTERN)) {
+		const referenced = normalizeReferencedPath(match[1] ?? "");
+		if (!referenced || !ALLOWED_SUPPORT_DIRECTORIES.has(referenced.split("/", 1)[0] ?? "")) {
+			throw new Error("prepared Hermes SKILL.md contains an unsafe support file reference");
+		}
+		if (!collected.tree.has(referenced)) {
+			throw new Error(`prepared Hermes Skill support file is missing: ${referenced}`);
+		}
+		paths.add(referenced);
+	}
+	return new Map(
+		[...paths].sort().map((path) => [path, collected.tree.get(path) ?? Buffer.alloc(0)]),
+	);
+}
+
+function runLoopbackWorker(): void {
+	const { createServer } = process.getBuiltinModule("node:http");
+	const { workerData } = process.getBuiltinModule("node:worker_threads") as {
+		workerData: LoopbackWorkerData;
+	};
+	const state = new Int32Array(workerData.state);
+	const files = new Map(workerData.files.map(([path, bytes]) => [path, Buffer.from(bytes)]));
+	let closing = false;
+	let lifetime: ReturnType<typeof setTimeout>;
+	let stopPoll: ReturnType<typeof setInterval>;
+	const server = createServer((request, response) => {
+		try {
+			const requestTarget = request.url ?? "";
+			const prefix = `/${workerData.token}/`;
+			if (
+				request.method !== "GET" ||
+				requestTarget.includes("?") ||
+				requestTarget.includes("#") ||
+				!requestTarget.startsWith(prefix)
+			) {
+				response.writeHead(request.method === "GET" ? 404 : 405, { Connection: "close" });
+				response.end();
+				return;
+			}
+			let path: string;
+			try {
+				path = decodeURIComponent(requestTarget.slice(prefix.length));
+			} catch {
+				response.writeHead(400, { Connection: "close" });
+				response.end();
+				return;
+			}
+			const parts = path.split("/");
+			if (
+				path.includes("\\") ||
+				parts.some((part) => !part || part === "." || part === ".." || part.includes(":"))
+			) {
+				response.writeHead(400, { Connection: "close" });
+				response.end();
+				return;
+			}
+			const bytes = files.get(path);
+			if (!bytes) {
+				response.writeHead(404, { Connection: "close" });
+				response.end();
+				return;
+			}
+			response.writeHead(200, {
+				"Content-Type": path.endsWith(".md")
+					? "text/markdown; charset=utf-8"
+					: "application/octet-stream",
+				"Content-Length": String(bytes.byteLength),
+				"Cache-Control": "no-store",
+				"X-Content-Type-Options": "nosniff",
+				Connection: "close",
+			});
+			response.end(bytes);
+		} catch {
+			response.writeHead(400, { Connection: "close" });
+			response.end();
+		}
+	});
+	const close = (finalState: SourceState) => {
+		if (closing) return;
+		closing = true;
+		clearTimeout(lifetime);
+		clearInterval(stopPoll);
+		server.close(() => {
+			Atomics.store(state, 0, finalState);
+			Atomics.notify(state, 0);
+		});
+		server.closeAllConnections();
+	};
+	server.requestTimeout = 5_000;
+	server.headersTimeout = 5_000;
+	server.keepAliveTimeout = 1_000;
+	server.maxRequestsPerSocket = 16;
+	server.once("error", () => close(SourceState.Failed));
+	server.listen(0, "127.0.0.1", () => {
+		const address = server.address();
+		if (!address || typeof address === "string") {
+			close(SourceState.Failed);
+			return;
+		}
+		Atomics.store(state, 1, address.port);
+		Atomics.store(state, 0, SourceState.Ready);
+		Atomics.notify(state, 0);
+	});
+	lifetime = setTimeout(() => close(SourceState.Expired), workerData.lifetimeMs);
+	stopPoll = setInterval(() => {
+		if (Atomics.load(state, 0) === SourceState.StopRequested) close(SourceState.Stopped);
+	}, 10);
+}
+
+function waitForState(state: Int32Array, expected: SourceState, timeoutMs: number): SourceState {
+	const deadline = Date.now() + timeoutMs;
+	let current = Atomics.load(state, 0) as SourceState;
+	while (current === expected && Date.now() < deadline) {
+		Atomics.wait(state, 0, expected, Math.min(50, deadline - Date.now()));
+		current = Atomics.load(state, 0) as SourceState;
+	}
+	return current;
+}
+
+export function withHermesSkillLoopbackSource<T>(
+	sourceDir: string,
+	operation: (input: { url: string; files: ManagedSkillTree }) => T,
+): T {
+	const files = hermesUrlSourceFiles(sourceDir);
+	const token = `0${randomBytes(32).toString("hex")}`;
+	const shared = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
+	const state = new Int32Array(shared);
+	const worker = new Worker(`(${runLoopbackWorker.toString()})()`, {
+		eval: true,
+		workerData: {
+			state: shared,
+			token,
+			files: [...files],
+			lifetimeMs: SOURCE_LIFETIME_MS,
+		} satisfies LoopbackWorkerData,
+	});
+	worker.unref();
+	try {
+		const ready = waitForState(state, SourceState.Starting, READY_TIMEOUT_MS);
+		if (ready !== SourceState.Ready) throw new Error("Hermes Skill loopback source did not start");
+		const port = Atomics.load(state, 1);
+		if (port < 1 || port > 65_535)
+			throw new Error("Hermes Skill loopback source returned an invalid port");
+		return operation({ url: `http://127.0.0.1:${port}/${token}/SKILL.md`, files });
+	} finally {
+		if (Atomics.load(state, 0) === SourceState.Ready) {
+			Atomics.store(state, 0, SourceState.StopRequested);
+			Atomics.notify(state, 0);
+		}
+		const stopped = waitForState(state, SourceState.StopRequested, STOP_TIMEOUT_MS);
+		if (stopped === SourceState.Starting || stopped === SourceState.StopRequested) {
+			void worker.terminate();
+		}
+	}
+}

--- a/packages/cli/src/runtime/hosted-hermes-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.test.ts
@@ -42,44 +42,82 @@ function fakeHermesApp(home: string): string {
 		`#!/usr/bin/python3
 import json, os, re, shutil, sys
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import unquote, urljoin, urlparse, urlsplit
+from urllib.request import urlopen
 root = Path(os.environ["HOME"]) / ".hermes" / "skills"
 with Path(os.environ["FAKE_HERMES_LOG"]).open("a") as log:
     log.write(" ".join(sys.argv[1:]) + chr(10))
 if sys.argv[1:3] == ["skills", "install"]:
     assert "--yes" in sys.argv and "--name" in sys.argv
+    assert os.environ.get("HERMES_ALLOW_PRIVATE_URLS") == "true"
+    assert "127.0.0.1" in os.environ.get("NO_PROXY", "")
+    assert "127.0.0.1" in os.environ.get("no_proxy", "")
     identifier = sys.argv[3]
     name_override = sys.argv[sys.argv.index("--name") + 1]
-    source_skill = Path(os.environ["FAKE_HERMES_SOURCE"]) / "SKILL.md"
-    source_text = source_skill.read_bytes().decode("utf-8", errors="replace")
-    frontmatter = re.match(r"^---\\r?\\n(.*?)\\r?\\n---\\r?\\n", source_text, re.DOTALL)
-    native_name = None
-    if frontmatter:
-        name_line = re.search(r"""^name:\\s*['"]?([^'"\\r\\n]+)""", frontmatter.group(1), re.MULTILINE)
-        if name_line:
-            candidate = name_line.group(1).strip()
-            if re.fullmatch(r"[a-z][a-z0-9_-]*", candidate.lower()) and candidate.lower() not in {"skill", "readme", "index", "unnamed-skill"}:
-                native_name = candidate
-    if native_name is None:
-        parts = [part for part in urlparse(identifier).path.split("/") if part]
-        candidate = parts[-2] if len(parts) >= 2 and parts[-1].lower() == "skill.md" else re.sub(r"(?i)\\.md$", "", parts[-1])
-        if re.fullmatch(r"[a-z][a-z0-9_-]*", candidate.lower()) and candidate.lower() not in {"skill", "readme", "index", "unnamed-skill"}:
-            native_name = candidate
-    name = native_name or name_override
     if os.environ.get("FAKE_HERMES_INSTALL_NOOP") == "1":
         print("Error: Could not fetch source Skill")
         raise SystemExit(0)
+    try:
+        source_bytes = urlopen(identifier, timeout=5).read()
+        source_text = source_bytes.decode("utf-8")
+    except Exception:
+        print("Error: Could not fetch source Skill")
+        raise SystemExit(0)
+    native_name = None
+    if source_text.startswith("---"):
+        frontmatter_end = source_text.find(chr(10) + "---" + chr(10), 3)
+        if frontmatter_end >= 0:
+            for line in source_text[3:frontmatter_end].splitlines():
+                if line.startswith("name:"):
+                    candidate = line.split(":", 1)[1].strip().strip(chr(39) + chr(34))
+                    if re.fullmatch(r"[a-z][a-z0-9_-]*", candidate.lower()) and candidate.lower() not in {"skill", "readme", "index", "unnamed-skill"}:
+                        native_name = candidate
+                    break
+    if native_name is None:
+        parts = [part for part in urlparse(identifier).path.split("/") if part]
+        candidate = parts[-2] if len(parts) >= 2 and parts[-1].lower() == "skill.md" else parts[-1].removesuffix(".md")
+        if re.fullmatch(r"[a-z][a-z0-9_-]*", candidate.lower()) and candidate.lower() not in {"skill", "readme", "index", "unnamed-skill"}:
+            native_name = candidate
+    name = native_name or name_override
+    normalized = source_text.replace("\\\\", "/")
+    support_paths = set()
+    stop_characters = set(" ") | {chr(9), chr(10), chr(13), chr(34), chr(39), chr(41), chr(60), chr(62), chr(96)}
+    for directory in ("references", "templates", "scripts", "assets", "examples"):
+        marker = directory + "/"
+        start = 0
+        while True:
+            start = normalized.find(marker, start)
+            if start < 0:
+                break
+            end = start
+            while end < len(normalized) and normalized[end] not in stop_characters:
+                end += 1
+            raw = unquote(urlsplit(normalized[start:end].rstrip(".,;:")).path).replace("\\\\", "/")
+            parts = [part for part in raw.split("/") if part not in {"", "."}]
+            if raw.startswith("/") or not parts or ".." in parts or any(":" in part for part in parts):
+                print("Error: Could not fetch source Skill")
+                raise SystemExit(0)
+            preceded_by_link = normalized[max(0, start - 2):start] == "](" or start == 0 or normalized[start - 1] in stop_characters
+            if preceded_by_link:
+                support_paths.add("/".join(parts))
+            start = end
+    support_files = {}
+    for path in support_paths:
+        try:
+            support_files[path] = urlopen(urljoin(identifier, path), timeout=5).read()
+        except Exception:
+            print("Error: Could not fetch source Skill")
+            raise SystemExit(0)
     target = root / name
     marker = root / ".native-installed" / name
     shutil.rmtree(target, ignore_errors=True)
     target.parent.mkdir(parents=True, exist_ok=True)
     target.mkdir(parents=True, exist_ok=True)
-    (target / "SKILL.md").write_text(source_text, encoding="utf-8")
-    support = Path(os.environ["FAKE_HERMES_SOURCE"]) / "references" / "guide.md"
-    if support.exists():
-        (target / "references").mkdir(parents=True, exist_ok=True)
-        shutil.copy2(support, target / "references" / "guide.md")
-    (target / ".hermes-native.json").write_text(json.dumps({"installed": True}) + chr(10))
+    (target / "SKILL.md").write_bytes(source_bytes)
+    for path, content in support_files.items():
+        destination = target / path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(content)
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.write_text("installed")
     hub = root / ".hub"
@@ -127,7 +165,6 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 			join(sourceDir, "SKILL.md"),
 			'---\nname: native-review-pr\ndescription: "A long Project Skill description that keeps the native frontmatter name even when --name supplies the manifest id."\n---\n# Review PR\n',
 		);
-		process.env.FAKE_HERMES_SOURCE = sourceDir;
 		const commandLog = join(root, "hermes.log");
 		process.env.FAKE_HERMES_LOG = commandLog;
 		const archive = join(root, "review-pr.tar.gz");
@@ -164,8 +201,8 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 				previouslyReserved: false,
 			}),
 		).toThrow("did not record an installed target: Error: Could not fetch source Skill");
-		expect(readFileSync(commandLog, "utf8").trim()).toBe(
-			`skills install ${installUrl} --name review-pr --yes`,
+		expect(readFileSync(commandLog, "utf8").trim()).toMatch(
+			/^skills install http:\/\/127\.0\.0\.1:\d+\/0[a-f0-9]{64}\/SKILL\.md --name review-pr --yes$/,
 		);
 		expect(existsSync(join(home, ".hermes", "skills", "review-pr"))).toBe(false);
 		delete process.env.FAKE_HERMES_INSTALL_NOOP;
@@ -205,16 +242,13 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		const sourceDir = join(root, "source", "review-pr");
 		mkdirSync(sourceDir, { recursive: true });
 		const skillV1 =
-			"---\nname: review-pr\ndescription: Review pull requests\n---\n# Review PR\n\n[Guide](references/guide.md)\n[Missing](references/missing.md)\n";
+			"---\nname: review-pr\ndescription: Review pull requests\n---\n# Review PR\n\n[Guide](references/guide.md)\n";
 		const skillV2 =
 			"---\nname: review-pr\ndescription: Review pull requests\n---\n# Review PR v2\n\n[Guide](references/guide.md)\n";
-		const skillV1Source = Buffer.concat([Buffer.from(skillV1), Buffer.from([0xff])]);
-		const skillV1Native = Buffer.from(skillV1Source.toString("utf8"), "utf8");
-		writeFileSync(join(sourceDir, "SKILL.md"), skillV1Source);
+		writeFileSync(join(sourceDir, "SKILL.md"), skillV1);
 		mkdirSync(join(sourceDir, "references"), { recursive: true });
 		writeFileSync(join(sourceDir, "references", "guide.md"), "Pinned guide\n");
 		writeFileSync(join(sourceDir, "skill.json"), '{"catalog_only":true}\n');
-		process.env.FAKE_HERMES_SOURCE = sourceDir;
 		const commandLog = join(root, "hermes.log");
 		process.env.FAKE_HERMES_LOG = commandLog;
 		const archive = join(root, "review-pr.tar.gz");
@@ -244,17 +278,85 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		).toBe("installed");
 		const target = join(home, ".hermes", "skills", "review-pr");
 		const receipt = managedSkillReceiptPath(managedResourceRoot, "hermes", "review-pr");
-		expect(readFileSync(join(target, "SKILL.md"))).toEqual(skillV1Native);
+		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe(skillV1);
 		expect(readFileSync(join(target, "references", "guide.md"), "utf8")).toBe("Pinned guide\n");
-		expect(readFileSync(join(target, ".hermes-native.json"), "utf8")).toBe('{"installed": true}\n');
 		expect(existsSync(join(target, "skill.json"))).toBe(false);
 		expect(readFileSync(commandLog, "utf8")).not.toContain("--force");
-		expect(readFileSync(commandLog, "utf8")).toContain(`/${source.commit}/SKILL.md`);
-		expect(readFileSync(commandLog, "utf8")).not.toContain(`/${source.commit}//SKILL.md`);
+		const firstInstallCommand = readFileSync(commandLog, "utf8").trim();
+		expect(firstInstallCommand).toMatch(
+			/^skills install http:\/\/127\.0\.0\.1:\d+\/0[a-f0-9]{64}\/SKILL\.md --name review-pr --yes$/,
+		);
+		const firstInstallUrl = firstInstallCommand.split(" ")[2] ?? "";
+		const lockPath = join(home, ".hermes", "skills", ".hub", "lock.json");
+		const firstLock = JSON.parse(readFileSync(lockPath, "utf8")) as {
+			version: number;
+			installed: Record<string, Record<string, unknown>>;
+		};
+		expect(firstLock.installed["review-pr"]).toEqual({
+			source: "url",
+			identifier: firstInstallUrl,
+			install_path: "review-pr",
+		});
 		expect(hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: true })).toBe(
 			"unchanged",
 		);
 		expect(readFileSync(commandLog, "utf8").trim().split("\n")).toHaveLength(1);
+		firstLock.installed["review-pr"] = {
+			source: "url",
+			identifier: `https://raw.githubusercontent.com/Clawdi-AI/store/${source.commit}/SKILL.md`,
+			install_path: "review-pr",
+		};
+		writeFileSync(lockPath, `${JSON.stringify(firstLock)}\n`);
+		expect(hostedHermesSkillExactSourceDriver.target?.({ home, skill })).toBe(target);
+		expect(hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: true })).toBe(
+			"installed",
+		);
+		const migratedLock = JSON.parse(readFileSync(lockPath, "utf8")) as typeof firstLock;
+		const migratedIdentifier = migratedLock.installed["review-pr"]?.identifier;
+		expect(migratedIdentifier).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/0[a-f0-9]{64}\/SKILL\.md$/);
+		migratedLock.installed["review-pr"] = {
+			source: "url",
+			identifier: "http://127.0.0.1:1234/predictable/SKILL.md",
+			install_path: "review-pr",
+		};
+		writeFileSync(lockPath, `${JSON.stringify(migratedLock)}\n`);
+		expect(() => hostedHermesSkillExactSourceDriver.target?.({ home, skill })).toThrow(
+			"Hermes Skill lock source is invalid",
+		);
+		migratedLock.installed["review-pr"] = {
+			source: "url",
+			identifier: String(migratedIdentifier).replace(/:\d+\//, ":0/"),
+			install_path: "review-pr",
+		};
+		writeFileSync(lockPath, `${JSON.stringify(migratedLock)}\n`);
+		expect(() => hostedHermesSkillExactSourceDriver.target?.({ home, skill })).toThrow(
+			"Hermes Skill lock source is invalid",
+		);
+		migratedLock.installed["review-pr"] = {
+			source: "url",
+			identifier: String(migratedIdentifier).replace("http://127.0.0.1:", "HTTP://127.0.0.1:"),
+			install_path: "review-pr",
+		};
+		writeFileSync(lockPath, `${JSON.stringify(migratedLock)}\n`);
+		expect(() => hostedHermesSkillExactSourceDriver.target?.({ home, skill })).toThrow(
+			"Hermes Skill lock source is invalid",
+		);
+		migratedLock.installed["review-pr"] = {
+			source: "url",
+			identifier: migratedIdentifier,
+			install_path: "review-pr",
+		};
+		migratedLock.installed["duplicate-review-pr"] = {
+			source: "url",
+			identifier: migratedIdentifier,
+			install_path: "duplicate-review-pr",
+		};
+		writeFileSync(lockPath, `${JSON.stringify(migratedLock)}\n`);
+		expect(() => hostedHermesSkillExactSourceDriver.target?.({ home, skill })).toThrow(
+			"Hermes Skill lock source identity is ambiguous",
+		);
+		delete migratedLock.installed["duplicate-review-pr"];
+		writeFileSync(lockPath, `${JSON.stringify(migratedLock)}\n`);
 		expect(hostedHermesSkillExactSourceDriver.verifyOwned(input)).toBe(true);
 		expect(
 			hostedHermesSkillExactSourceDriver.hasOwnershipReceipt({
@@ -284,7 +386,7 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 		expect(hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: true })).toBe(
 			"installed",
 		);
-		expect(readFileSync(join(target, "SKILL.md"))).toEqual(skillV1Native);
+		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe(skillV1);
 		expect(hostedHermesSkillExactSourceDriver.verifyOwned(input)).toBe(true);
 		expect(existsSync(join(root, "wrong-profile", "skills", "review-pr"))).toBe(false);
 
@@ -319,9 +421,11 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 			}),
 		).toBe("installed");
 		expect(readFileSync(commandLog, "utf8").trim().split("\n").at(-1)).toContain("--force");
-		expect(readFileSync(commandLog, "utf8").trim().split("\n").at(-1)).toContain(
-			"/skills/review%20%231%25%3F/nested/SKILL.md",
+		const updateInstallCommand = readFileSync(commandLog, "utf8").trim().split("\n").at(-1) ?? "";
+		expect(updateInstallCommand).toMatch(
+			/^skills install http:\/\/127\.0\.0\.1:\d+\/0[a-f0-9]{64}\/SKILL\.md --name review-pr --yes --force$/,
 		);
+		expect(updateInstallCommand).not.toBe(firstInstallCommand);
 		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe(skillV2);
 		expect(
 			hostedHermesSkillExactSourceDriver.uninstall({

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
+import { withHermesSkillLoopbackSource } from "./hermes-skill-loopback-source";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import {
 	collectManagedSkillTree,
@@ -23,7 +24,7 @@ import {
 	withRuntimeUserFileAccess,
 } from "./runtime-user-command";
 
-const HERMES_SKILL_COMMAND_TIMEOUT_MS = 120_000;
+const HERMES_SKILL_COMMAND_TIMEOUT_MS = 110_000;
 
 export interface HostedHermesSkillExactSourceDriver {
 	target?(input: { home: string; skill: PreparedHostedSourcedSkill }): string;
@@ -100,23 +101,6 @@ function receiptInput(
 	};
 }
 
-function rawSkillUrl(skill: PreparedHostedSourcedSkill): string {
-	if (skill.source.type === "project") return skill.source.installUrl;
-	if (skill.source.type === "bundled") {
-		throw new Error("bundled Hermes Skills do not have a remote install URL");
-	}
-	const repository = new URL(skill.source.url);
-	const [owner, repo] = repository.pathname.slice(1).split("/");
-	if (!owner || !repo)
-		throw new Error("Hermes exact-source URL requires a canonical GitHub repository");
-	const encodedPath = skill.source.path
-		.split("/")
-		.map((segment) => encodeURIComponent(segment))
-		.join("/");
-	const skillPath = encodedPath ? `${encodedPath}/SKILL.md` : "SKILL.md";
-	return `https://raw.githubusercontent.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${skill.source.commit}/${skillPath}`;
-}
-
 const HERMES_URL_SKILL_NAME_PATTERN = /^[a-z][a-z0-9_-]*$/;
 const HERMES_RESERVED_URL_SKILL_NAMES = new Set(["skill", "readme", "index", "unnamed-skill"]);
 
@@ -152,16 +136,6 @@ function frontmatterName(sourceDir: string): string | null {
 	return null;
 }
 
-function urlSkillName(url: string): string | null {
-	const parts = new URL(url).pathname.split("/").filter(Boolean);
-	if (parts.at(-1)?.toLowerCase() === "skill.md" && parts.length >= 2) {
-		const candidate = parts.at(-2);
-		if (validHermesUrlSkillName(candidate)) return candidate;
-	}
-	const candidate = parts.at(-1)?.replace(/\.md$/i, "");
-	return validHermesUrlSkillName(candidate) ? candidate : null;
-}
-
 function plannedNativeTarget(
 	home: string,
 	skill: PreparedHostedSourcedSkill,
@@ -170,8 +144,7 @@ function plannedNativeTarget(
 	if (skill.source.type === "bundled") {
 		return join(home, ".hermes", "skills", skill.skillId);
 	}
-	const nativeName =
-		frontmatterName(sourceDir) ?? urlSkillName(rawSkillUrl(skill)) ?? skill.skillId;
+	const nativeName = frontmatterName(sourceDir) ?? skill.skillId;
 	return join(home, ".hermes", "skills", nativeName);
 }
 
@@ -182,26 +155,53 @@ function hermesCommandOutput(result: ReturnType<typeof runHermes>): string {
 		.join("\n");
 }
 
+function readHermesInstalledLock(home: string): {
+	skillsRoot: string;
+	installed: Record<string, unknown>;
+} | null {
+	const skillsRoot = resolve(home, ".hermes", "skills");
+	const lockPath = join(skillsRoot, ".hub", "lock.json");
+	if (!existsSync(lockPath)) return null;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(readFileSync(lockPath, "utf8"));
+	} catch {
+		throw new ManagedSkillResourceError("Hermes Skill lock is invalid");
+	}
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new ManagedSkillResourceError("Hermes Skill lock is invalid");
+	}
+	const lock = parsed as Record<string, unknown>;
+	if (
+		lock.version !== 1 ||
+		typeof lock.installed !== "object" ||
+		lock.installed === null ||
+		Array.isArray(lock.installed)
+	) {
+		throw new ManagedSkillResourceError("Hermes Skill lock is invalid");
+	}
+	return { skillsRoot, installed: lock.installed as Record<string, unknown> };
+}
+
+function hermesLockTarget(skillsRoot: string, name: string, installPath: unknown): string {
+	if (
+		!validHermesUrlSkillName(name) ||
+		typeof installPath !== "string" ||
+		installPath !== name ||
+		dirname(resolve(skillsRoot, installPath)) !== skillsRoot ||
+		basename(resolve(skillsRoot, installPath)) !== name
+	) {
+		throw new ManagedSkillResourceError("Hermes Skill lock install path is unsafe");
+	}
+	return join(skillsRoot, installPath);
+}
+
 function installedTargetFromHermesLock(home: string, identifier: string): string | null {
 	return withRuntimeUserFileAccess(() => {
-		const skillsRoot = resolve(home, ".hermes", "skills");
-		const lockPath = join(skillsRoot, ".hub", "lock.json");
-		if (!existsSync(lockPath)) return null;
-		let parsed: unknown;
-		try {
-			parsed = JSON.parse(readFileSync(lockPath, "utf8"));
-		} catch {
-			throw new ManagedSkillResourceError("Hermes Skill lock is invalid");
-		}
-		if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-			throw new ManagedSkillResourceError("Hermes Skill lock is invalid");
-		}
-		const lock = parsed as Record<string, unknown>;
-		if (lock.version !== 1 || typeof lock.installed !== "object" || lock.installed === null) {
-			throw new ManagedSkillResourceError("Hermes Skill lock is invalid");
-		}
+		const lock = readHermesInstalledLock(home);
+		if (!lock) return null;
 		const matches: Array<{ name: string; installPath: string }> = [];
-		for (const [name, value] of Object.entries(lock.installed as Record<string, unknown>)) {
+		for (const [name, value] of Object.entries(lock.installed)) {
 			if (typeof value !== "object" || value === null || Array.isArray(value)) continue;
 			const entry = value as Record<string, unknown>;
 			if (entry.identifier !== identifier) continue;
@@ -218,15 +218,58 @@ function installedTargetFromHermesLock(home: string, identifier: string): string
 			throw new ManagedSkillResourceError("Hermes Skill lock source identity is ambiguous");
 		}
 		const [{ name, installPath }] = matches;
-		if (
-			!validHermesUrlSkillName(name) ||
-			installPath !== name ||
-			dirname(resolve(skillsRoot, installPath)) !== skillsRoot ||
-			basename(resolve(skillsRoot, installPath)) !== name
-		) {
+		return hermesLockTarget(lock.skillsRoot, name, installPath);
+	});
+}
+
+function installedTargetFromHermesLoopbackLock(home: string, target: string): string | null {
+	const expected = resolve(target);
+	return withRuntimeUserFileAccess(() => {
+		const lock = readHermesInstalledLock(home);
+		if (!lock || dirname(expected) !== lock.skillsRoot) return null;
+		const name = basename(expected);
+		const entry = lock.installed[name];
+		if (typeof entry !== "object" || entry === null || Array.isArray(entry)) return null;
+		const record = entry as Record<string, unknown>;
+		if (record.source !== "url" || typeof record.identifier !== "string") {
+			throw new ManagedSkillResourceError("Hermes Skill lock source is invalid");
+		}
+		let source: URL;
+		try {
+			source = new URL(record.identifier);
+		} catch {
+			throw new ManagedSkillResourceError("Hermes Skill lock source is invalid");
+		}
+		if (hermesLockTarget(lock.skillsRoot, name, record.install_path) !== expected) {
 			throw new ManagedSkillResourceError("Hermes Skill lock install path is unsafe");
 		}
-		return join(skillsRoot, installPath);
+		if (source.protocol !== "http:" || source.hostname !== "127.0.0.1") return null;
+		if (
+			source.href !== record.identifier ||
+			!source.port ||
+			Number(source.port) < 1 ||
+			source.username ||
+			source.password ||
+			source.search ||
+			source.hash ||
+			!/^\/0[a-f0-9]{64}\/SKILL\.md$/.test(source.pathname)
+		) {
+			throw new ManagedSkillResourceError("Hermes Skill lock source is invalid");
+		}
+		let identityMatches = 0;
+		for (const value of Object.values(lock.installed)) {
+			if (typeof value !== "object" || value === null || Array.isArray(value)) continue;
+			const candidate = value as Record<string, unknown>;
+			if (candidate.identifier !== record.identifier) continue;
+			if (candidate.source !== "url") {
+				throw new ManagedSkillResourceError("Hermes Skill lock source is invalid");
+			}
+			identityMatches += 1;
+		}
+		if (identityMatches !== 1) {
+			throw new ManagedSkillResourceError("Hermes Skill lock source identity is ambiguous");
+		}
+		return expected;
 	});
 }
 
@@ -240,6 +283,24 @@ function runHermes(input: { home: string; appRoot: string }, args: string[], std
 			input: stdin,
 			timeoutMs: HERMES_SKILL_COMMAND_TIMEOUT_MS,
 			maxBufferBytes: 1024 * 1024,
+		},
+	);
+}
+
+function runHermesLoopbackInstall(input: { home: string; appRoot: string }, args: string[]) {
+	return spawnRuntimeUserCommand(
+		commandPath(input.home, input.appRoot),
+		args,
+		input.home,
+		input.appRoot,
+		{
+			timeoutMs: HERMES_SKILL_COMMAND_TIMEOUT_MS,
+			maxBufferBytes: 1024 * 1024,
+			environment: {
+				HERMES_ALLOW_PRIVATE_URLS: "true",
+				NO_PROXY: "127.0.0.1,localhost",
+				no_proxy: "127.0.0.1,localhost",
+			},
 		},
 	);
 }
@@ -269,22 +330,15 @@ function assertBundledResultMatches(sourceDir: string, target: string): void {
 
 export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDriver = {
 	target(input) {
-		if (input.skill.source.type !== "bundled") {
-			const installed = installedTargetFromHermesLock(input.home, rawSkillUrl(input.skill));
-			if (installed) return installed;
-		}
-		return withStagedManagedSkill(input.skill, (sourceDir) =>
-			plannedNativeTarget(input.home, input.skill, sourceDir),
-		);
+		return withStagedManagedSkill(input.skill, (sourceDir) => {
+			const planned = plannedNativeTarget(input.home, input.skill, sourceDir);
+			if (input.skill.source.type === "bundled") return planned;
+			return installedTargetFromHermesLoopbackLock(input.home, planned) ?? planned;
+		});
 	},
 	install(input) {
-		const installedBefore =
-			input.skill.source.type === "bundled"
-				? null
-				: installedTargetFromHermesLock(input.home, rawSkillUrl(input.skill));
 		const target = resolve(
 			input.targetDir ??
-				installedBefore ??
 				withStagedManagedSkill(input.skill, (sourceDir) =>
 					plannedNativeTarget(input.home, input.skill, sourceDir),
 				),
@@ -300,14 +354,13 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 		if (managedSkillReceiptMatchesIdentity(receipt)) {
 			if (
 				input.skill.source.type === "bundled" ||
-				installedTargetFromHermesLock(input.home, rawSkillUrl(input.skill)) === target
+				installedTargetFromHermesLoopbackLock(input.home, target) === target
 			) {
 				return "unchanged";
 			}
 		}
 		return withStagedManagedSkill(input.skill, (sourceDir) => {
-			const plannedTarget =
-				installedBefore ?? plannedNativeTarget(input.home, input.skill, sourceDir);
+			const plannedTarget = plannedNativeTarget(input.home, input.skill, sourceDir);
 			if (resolve(plannedTarget) !== target) {
 				throw new Error("Hermes Skill planned target changed during installation");
 			}
@@ -324,45 +377,45 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 			return withManagedTargetRollback({
 				target,
 				receipt: receipt.path,
-				operation: () => {
-					const args = [
-						"skills",
-						"install",
-						rawSkillUrl(input.skill),
-						"--name",
-						input.skill.skillId,
-						"--yes",
-					];
-					if (input.previouslyReserved) args.push("--force");
-					const result = runHermes(input, args);
-					if (result.status !== 0)
-						throw new ManagedSkillResourceError(
-							`Hermes official Skill install failed: ${hermesCommandOutput(result) || result.error?.message || "unknown error"}`,
+				operation: () =>
+					withHermesSkillLoopbackSource(sourceDir, ({ url: installUrl, files }) => {
+						const args = ["skills", "install", installUrl, "--name", input.skill.skillId, "--yes"];
+						if (input.previouslyReserved) args.push("--force");
+						const result = runHermesLoopbackInstall(input, args);
+						if (result.status !== 0)
+							throw new ManagedSkillResourceError(
+								`Hermes official Skill install failed: ${hermesCommandOutput(result) || result.error?.message || "unknown error"}`,
+							);
+						const installedTarget = installedTargetFromHermesLock(input.home, installUrl);
+						if (!installedTarget) {
+							throw new ManagedSkillResourceError(
+								`Hermes official Skill install did not record an installed target: ${hermesCommandOutput(result) || "unknown error"}`,
+							);
+						}
+						if (installedTarget !== target) {
+							throw new ManagedSkillResourceError(
+								`Hermes official Skill install recorded an unexpected target: ${installedTarget}`,
+							);
+						}
+						const installed = collectRuntimeUserManagedSkillTree(installedTarget);
+						if (
+							installed.status !== "collected" ||
+							!managedSkillTreesEqual(files, installed.tree)
+						) {
+							throw new ManagedSkillResourceError(
+								"Hermes official Skill install changed the verified source bytes",
+							);
+						}
+						writeManagedSkillReceipt(
+							receiptInput(
+								input.managedResourceRoot,
+								input.skill.skillId,
+								input.skill.sourceIdentity,
+								installedTarget,
+							),
 						);
-					const installedTarget = installedTargetFromHermesLock(
-						input.home,
-						rawSkillUrl(input.skill),
-					);
-					if (!installedTarget) {
-						throw new ManagedSkillResourceError(
-							`Hermes official Skill install did not record an installed target: ${hermesCommandOutput(result) || "unknown error"}`,
-						);
-					}
-					if (installedTarget !== target) {
-						throw new ManagedSkillResourceError(
-							`Hermes official Skill install recorded an unexpected target: ${installedTarget}`,
-						);
-					}
-					writeManagedSkillReceipt(
-						receiptInput(
-							input.managedResourceRoot,
-							input.skill.skillId,
-							input.skill.sourceIdentity,
-							installedTarget,
-						),
-					);
-					return "installed" as const;
-				},
+						return "installed" as const;
+					}),
 			});
 		});
 	},


### PR DESCRIPTION
## Incident

After #1158 correctly failed closed on the Hermes lock anchor, the seventh production-device run exposed the next layer: all 14 sourced Skills failed with `Hermes official Skill install did not record an installed target: Could not fetch ... from any source`, together with unauthenticated GitHub rate-limit diagnostics.

The CLI had already downloaded and digest-verified each prepared archive, but then passed the remote Skill-file URL to Hermes. Hermes independently fetched a second copy. That added an egress/rate-limit dependency and broke the byte-integrity chain because the bytes Hermes installed were not necessarily the bytes Clawdi had verified.

## Design

This change gives the verified staged bytes to the official Hermes installer through a transient loopback HTTP transport:

- Snapshot `SKILL.md` and only the explicitly referenced, Hermes-allowlisted support files into memory before serving.
- Bind `127.0.0.1:0` and expose one nonce-scoped URL: `http://127.0.0.1:<port>/<nonce>/SKILL.md`.
- Accept only `GET` requests for the exact in-memory allowlist; reject traversal, query strings, unsafe paths, missing references, invalid UTF-8, and directory enumeration.
- Bound startup, request, command, shutdown, and total source lifetime. The Worker and listener are stopped in `finally`; process termination leaves no disk or child-process residue.
- Set the official process-scoped `HERMES_ALLOW_PRIVATE_URLS=true` switch only for `skills install`, with loopback in both `NO_PROXY` variants.
- Continue through Hermes `UrlSource`, quarantine, security scan, official install, and lock recording. This does not bypass or replace the Hermes installer.
- Compare the installed file projection byte-for-byte with the served snapshot before writing the Clawdi ownership receipt.
- Preserve #1158's `source == "url"` and exact identifier anchor. Persisted loopback identities additionally require canonical URL shape, one unique identifier, and the same strict install-path safety.
- Treat an owned pre-change remote URL lock as a one-time migration and force a verified loopback reinstall. Subsequent convergence is `unchanged` and retains the same lock identity.
- Keep official uninstall source-independent. No private-URL or network environment is injected into uninstall.

This follows two established Clawdi patterns: the [verified local Git transport synthesized for Hermes Agent Plugins](https://github.com/Clawdi-AI/clawdi/blob/46a88e76b/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts#L438-L465), and the [nonce-scoped 127.0.0.1 Hermes canary controller](https://github.com/Clawdi-AI/clawdi/blob/46a88e76b/packages/cli/src/runtime/hermes-agent-plugin-canary-client.ts#L143-L235).

## Hermes source evidence

Hermes Agent commit [`a77ee88ce29c4f1d89f8d60e5b662322645072d8`](https://github.com/NousResearch/hermes-agent/commit/a77ee88ce29c4f1d89f8d60e5b662322645072d8) establishes the supported contract:

- [`skills install` accepts a registry identifier or direct HTTP(S) Skill URL](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/hermes_cli/subcommands/skills.py#L109-L130).
- [`UrlSource` fetches `SKILL.md` and explicit support references, then emits a normal `SkillBundle`](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/tools/skills_hub.py#L1431-L1564).
- [The reference parser allows only `references/templates/scripts/assets/examples` and rejects traversal](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/tools/skills_hub.py#L155-L179).
- [The official private-URL switch is process-scoped through `HERMES_ALLOW_PRIVATE_URLS`](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/tools/url_safety.py#L220-L279), while [cloud metadata endpoints remain unconditionally blocked](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/tools/url_safety.py#L163-L195).
- [Official install records `bundle.source`, `bundle.identifier`, and the relative `install_path` in `lock.json`](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/tools/skills_hub.py#L4046-L4059).

## Real Hermes reproduction

Validated against a real isolated Hermes Agent v0.20.4 checkout with an isolated `HOME`, GitHub credential variables removed, and all external HTTP(S)/ALL proxies pointed at unreachable `127.0.0.1:9`:

```text
first: installed
lock.source: url
lock.identifier: http://127.0.0.1:<port>/<nonce>/SKILL.md
lock.install_path: clawdi-final-loopback
installed files: SKILL.md, references/guide.md
unreferenced file installed: false
installed bytes match served bytes: true
loopback reachable after install: false
receipt verification: true
second: unchanged
lock stable across second converge: true
uninstall: removed
```

The core assertion is therefore exercised directly: installation succeeds without GitHub credentials or external network access because Hermes reads only the already-verified loopback bytes.

## Verification

- `packages/cli test:internal`: 1,757 passed, 4 conditional skips, 0 failed, 9,581 assertions
- Mutation parity: passed in focused and full suites
- `scripts/test-runtime-official-installer-systemd.sh`: 5 passed, 0 failed, 231 assertions
- `packages/cli typecheck`: passed
- Repository-pinned `biome ci .`: passed
- CLI development build: passed; the published Node bundle retains native `process.getBuiltinModule("node:http")` and `process.getBuiltinModule("node:worker_threads")` Worker imports
- `git diff --check`: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)