### PR TITLE
release(cli): 0.14.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.7
+
+Package: `clawdi@0.14.7`
+
+### Fixed
+
+- Hosted project skills install from locally verified bytes served over a
+  transient loopback source, removing the network fetch (and its rate limits)
+  from Hermes skill installs entirely while keeping the official installer
+  path.
+
 ## Clawdi CLI v0.14.6
 
 Package: `clawdi@0.14.6`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.6",
+      "version": "0.14.7",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.6",
+	"version": "0.14.7",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Release `clawdi@0.14.7` — closes the seventh-canary finding (#1160).

Hermes 0.20 skill installs accept only registry identifiers or HTTP(S) URLs (verified against upstream source), so the CLI now serves its digest-verified staged bytes over a transient 127.0.0.1 source (random port + nonce path, allowlisted files, 120s lifetime, torn down in finally) and lets Hermes's official UrlSource/installer/lock pipeline do the rest. Byte chain is closed end-to-end and external network (and GitHub rate limits) are out of the install path — verified against real Hermes 0.20.4 with no network and no credentials: install → idempotent unchanged → uninstall.

Eighth canary round follows; pass bar unchanged: all 15 desired skills installed, five consecutive clean cycles, full forensics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)