### PR TITLE
fix(cli): serve complete staged archives to Hermes

### DIFF
--- a/packages/cli/src/runtime/hermes-skill-loopback-source.test.ts
+++ b/packages/cli/src/runtime/hermes-skill-loopback-source.test.ts
@@ -7,6 +7,7 @@ import {
 	hermesUrlSourceFiles,
 	withHermesSkillLoopbackSource,
 } from "./hermes-skill-loopback-source";
+import { ManagedSkillResourceError } from "./managed-skill-delivery";
 
 let root = "";
 
@@ -22,6 +23,7 @@ const requests = [
   fetch(base),
   fetch(new URL("references/guide.md", base)),
   fetch(new URL("unreferenced.txt", base)),
+  fetch(new URL("scripts/missing.py", base)),
   fetch(base, { method: "POST" }),
   new Promise((resolve, reject) => {
     const target = new URL(base);
@@ -52,21 +54,32 @@ process.stdout.write(JSON.stringify(await Promise.all(responses.map(async respon
 	return JSON.parse(result.stdout) as Array<{ status: number; body: string }>;
 }
 
-test("serves only the nonce-scoped Hermes URL projection and closes synchronously", () => {
+test("serves every safe archive file and leaves missing references to Hermes", () => {
 	root = mkdtempSync(join(tmpdir(), "hermes-skill-loopback-source-"));
 	mkdirSync(join(root, "references"));
-	writeFileSync(join(root, "SKILL.md"), "# Test\n\n[Guide](references/guide.md)\n");
+	writeFileSync(
+		join(root, "SKILL.md"),
+		"# Test\n\n[Guide](references/guide.md)\n[Missing](scripts/missing.py)\n",
+	);
 	writeFileSync(join(root, "references", "guide.md"), "verified guide\n");
-	writeFileSync(join(root, "unreferenced.txt"), "not served\n");
+	writeFileSync(join(root, "unreferenced.txt"), "archive content\n");
 	let url = "";
 
 	withHermesSkillLoopbackSource(root, (source) => {
 		url = source.url;
 		expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/0[a-f0-9]{64}\/SKILL\.md$/);
-		expect([...source.files.keys()]).toEqual(["SKILL.md", "references/guide.md"]);
+		expect([...source.files.keys()]).toEqual([
+			"references/guide.md",
+			"SKILL.md",
+			"unreferenced.txt",
+		]);
 		expect(fetchProbe(url)).toEqual([
-			{ status: 200, body: "# Test\n\n[Guide](references/guide.md)\n" },
+			{
+				status: 200,
+				body: "# Test\n\n[Guide](references/guide.md)\n[Missing](scripts/missing.py)\n",
+			},
 			{ status: 200, body: "verified guide\n" },
+			{ status: 200, body: "archive content\n" },
 			{ status: 404, body: "" },
 			{ status: 405, body: "" },
 			{ status: 400, body: "" },
@@ -86,14 +99,15 @@ test("serves only the nonce-scoped Hermes URL projection and closes synchronousl
 	expect(closed.stdout).toBe("closed");
 });
 
-test("rejects source bytes that Hermes URL installation cannot preserve safely", () => {
+test("validates only the staged archive tree and URL path safety", () => {
 	root = mkdtempSync(join(tmpdir(), "hermes-skill-loopback-validation-"));
-	writeFileSync(join(root, "SKILL.md"), "[Missing](references/missing.md)\n");
-	expect(() => hermesUrlSourceFiles(root)).toThrow(
-		"prepared Hermes Skill support file is missing: references/missing.md",
-	);
-	writeFileSync(join(root, "SKILL.md"), "[Escape](references/%2e%2e/secret.md)\n");
-	expect(() => hermesUrlSourceFiles(root)).toThrow("unsafe support file reference");
+	expect(() => hermesUrlSourceFiles(root)).toThrow(ManagedSkillResourceError);
+	expect(() => hermesUrlSourceFiles(root)).toThrow("prepared Hermes Skill is missing SKILL.md");
 	writeFileSync(join(root, "SKILL.md"), Buffer.from([0xff]));
-	expect(() => hermesUrlSourceFiles(root)).toThrow("SKILL.md is not valid UTF-8");
+	expect(hermesUrlSourceFiles(root).get("SKILL.md")).toEqual(Buffer.from([0xff]));
+	writeFileSync(join(root, "bad:name"), "unsafe URL path\n");
+	expect(() => hermesUrlSourceFiles(root)).toThrow(ManagedSkillResourceError);
+	expect(() => hermesUrlSourceFiles(root)).toThrow(
+		"prepared Hermes Skill path is unsafe: bad:name",
+	);
 });

--- a/packages/cli/src/runtime/hermes-skill-loopback-source.ts
+++ b/packages/cli/src/runtime/hermes-skill-loopback-source.ts
@@ -1,22 +1,14 @@
 import { randomBytes } from "node:crypto";
 import { Worker } from "node:worker_threads";
-import { collectManagedSkillTree, type ManagedSkillTree } from "./managed-skill-delivery";
+import {
+	collectManagedSkillTree,
+	ManagedSkillResourceError,
+	type ManagedSkillTree,
+} from "./managed-skill-delivery";
 
 const READY_TIMEOUT_MS = 5_000;
 const STOP_TIMEOUT_MS = 2_000;
 const SOURCE_LIFETIME_MS = 120_000;
-const ALLOWED_SUPPORT_DIRECTORIES = new Set([
-	"references",
-	"templates",
-	"scripts",
-	"assets",
-	"examples",
-]);
-const LOCAL_LINK_PATTERN =
-	/(?:\]\(|`|(?:^|[\s"']))((?:references|templates|scripts|assets|examples)\/[^\s)`"'<>]+)/gm;
-const SUSPICIOUS_LOCAL_REFERENCE_PATTERN =
-	/(?:references|templates|scripts|assets|examples)\/(?:[^\s)`"'<>]*\/)?\.\.(?:\/|$)/;
-
 enum SourceState {
 	Starting,
 	Ready,
@@ -33,54 +25,24 @@ interface LoopbackWorkerData {
 	lifetimeMs: number;
 }
 
-function normalizeReferencedPath(value: string): string | null {
-	const path = value.replace(/[.,;:]+$/, "").split(/[?#]/, 1)[0];
-	if (!path) return null;
-	let decoded: string;
-	try {
-		decoded = decodeURIComponent(path).replaceAll("\\", "/");
-	} catch {
-		return null;
-	}
-	if (decoded.startsWith("/")) return null;
-	const parts = decoded.split("/").filter((part) => part && part !== ".");
-	if (parts.length === 0 || parts.some((part) => part === ".." || part.includes(":"))) {
-		return null;
-	}
-	return parts.join("/");
-}
-
 export function hermesUrlSourceFiles(sourceDir: string): ManagedSkillTree {
 	const collected = collectManagedSkillTree(sourceDir);
 	if (collected.status !== "collected") {
-		throw new Error(`prepared Hermes Skill tree is ${collected.status}`);
+		throw new ManagedSkillResourceError(`prepared Hermes Skill tree is ${collected.status}`);
 	}
-	const skillBytes = collected.tree.get("SKILL.md");
-	if (!skillBytes) throw new Error("prepared Hermes Skill is missing SKILL.md");
-	let skillText: string;
-	try {
-		skillText = new TextDecoder("utf-8", { fatal: true }).decode(skillBytes);
-	} catch {
-		throw new Error("prepared Hermes SKILL.md is not valid UTF-8");
+	if (!collected.tree.has("SKILL.md")) {
+		throw new ManagedSkillResourceError("prepared Hermes Skill is missing SKILL.md");
 	}
-	const normalized = skillText.replaceAll("\\", "/");
-	if (SUSPICIOUS_LOCAL_REFERENCE_PATTERN.test(normalized)) {
-		throw new Error("prepared Hermes SKILL.md contains an unsafe support file reference");
-	}
-	const paths = new Set(["SKILL.md"]);
-	for (const match of normalized.matchAll(LOCAL_LINK_PATTERN)) {
-		const referenced = normalizeReferencedPath(match[1] ?? "");
-		if (!referenced || !ALLOWED_SUPPORT_DIRECTORIES.has(referenced.split("/", 1)[0] ?? "")) {
-			throw new Error("prepared Hermes SKILL.md contains an unsafe support file reference");
+	for (const path of collected.tree.keys()) {
+		const parts = path.split("/");
+		if (
+			path.includes("\\") ||
+			parts.some((part) => !part || part === "." || part === ".." || part.includes(":"))
+		) {
+			throw new ManagedSkillResourceError(`prepared Hermes Skill path is unsafe: ${path}`);
 		}
-		if (!collected.tree.has(referenced)) {
-			throw new Error(`prepared Hermes Skill support file is missing: ${referenced}`);
-		}
-		paths.add(referenced);
 	}
-	return new Map(
-		[...paths].sort().map((path) => [path, collected.tree.get(path) ?? Buffer.alloc(0)]),
-	);
+	return new Map([...collected.tree].sort(([left], [right]) => left.localeCompare(right)));
 }
 
 function runLoopbackWorker(): void {
@@ -195,22 +157,32 @@ export function withHermesSkillLoopbackSource<T>(
 	const token = `0${randomBytes(32).toString("hex")}`;
 	const shared = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
 	const state = new Int32Array(shared);
-	const worker = new Worker(`(${runLoopbackWorker.toString()})()`, {
-		eval: true,
-		workerData: {
-			state: shared,
-			token,
-			files: [...files],
-			lifetimeMs: SOURCE_LIFETIME_MS,
-		} satisfies LoopbackWorkerData,
-	});
+	let worker: Worker;
+	try {
+		worker = new Worker(`(${runLoopbackWorker.toString()})()`, {
+			eval: true,
+			workerData: {
+				state: shared,
+				token,
+				files: [...files],
+				lifetimeMs: SOURCE_LIFETIME_MS,
+			} satisfies LoopbackWorkerData,
+		});
+	} catch (error) {
+		throw new ManagedSkillResourceError("Hermes Skill loopback source did not start", {
+			cause: error,
+		});
+	}
 	worker.unref();
 	try {
 		const ready = waitForState(state, SourceState.Starting, READY_TIMEOUT_MS);
-		if (ready !== SourceState.Ready) throw new Error("Hermes Skill loopback source did not start");
+		if (ready !== SourceState.Ready) {
+			throw new ManagedSkillResourceError("Hermes Skill loopback source did not start");
+		}
 		const port = Atomics.load(state, 1);
-		if (port < 1 || port > 65_535)
-			throw new Error("Hermes Skill loopback source returned an invalid port");
+		if (port < 1 || port > 65_535) {
+			throw new ManagedSkillResourceError("Hermes Skill loopback source returned an invalid port");
+		}
 		return operation({ url: `http://127.0.0.1:${port}/${token}/SKILL.md`, files });
 	} finally {
 		if (Atomics.load(state, 0) === SourceState.Ready) {

--- a/packages/cli/src/runtime/hosted-hermes-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.test.ts
@@ -14,7 +14,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { hostedHermesSkillExactSourceDriver } from "./hosted-hermes-skill";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
-import { managedSkillReceiptPath } from "./managed-skill-delivery";
+import { ManagedSkillResourceError, managedSkillReceiptPath } from "./managed-skill-delivery";
 
 const originalEnv = { ...process.env };
 let root = "";
@@ -229,6 +229,57 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 				targetDir: nativeTarget,
 			}),
 		).toBe(true);
+	});
+
+	test("lets official Hermes reject a support reference missing from the archive", () => {
+		root = mkdtempSync(join(tmpdir(), "hosted-hermes-missing-support-"));
+		delete process.env.CLAWDI_RUNTIME_USER;
+		const home = join(root, "home");
+		const managedResourceRoot = join(root, "managed-resources");
+		mkdirSync(managedResourceRoot, { recursive: true });
+		const appRoot = fakeHermesApp(home);
+		const sourceDir = join(root, "source", "missing-support");
+		mkdirSync(sourceDir, { recursive: true });
+		writeFileSync(
+			join(sourceDir, "SKILL.md"),
+			"---\nname: missing-support\n---\n# Missing support\n\n[Sync](scripts/hermes-direct-slack-sync.py)\n",
+		);
+		writeFileSync(join(sourceDir, "archive-only.txt"), "served but not requested\n");
+		const archive = join(root, "missing-support.tar.gz");
+		const packed = spawnSync("tar", ["-czf", archive, "-C", dirname(sourceDir), "missing-support"]);
+		if (packed.status !== 0) throw new Error("test tar creation failed");
+		process.env.FAKE_HERMES_LOG = join(root, "hermes.log");
+		const skill: PreparedHostedSourcedSkill = {
+			skillId: "missing-support",
+			source: {
+				type: "github",
+				url: "https://github.com/Clawdi-AI/store",
+				path: "skills/missing-support",
+				commit: "a".repeat(40),
+			},
+			sourceIdentity: `github\0missing-support\0https://github.com/Clawdi-AI/store\0skills/missing-support\0${"a".repeat(40)}`,
+			...preparedArchive(archive),
+		};
+		let failure: unknown;
+
+		try {
+			hostedHermesSkillExactSourceDriver.install({
+				home,
+				appRoot,
+				managedResourceRoot,
+				skill,
+				previouslyReserved: false,
+			});
+		} catch (error) {
+			failure = error;
+		}
+
+		expect(failure).toBeInstanceOf(ManagedSkillResourceError);
+		expect(failure).toHaveProperty(
+			"message",
+			"Hermes official Skill install did not record an installed target: Error: Could not fetch source Skill",
+		);
+		expect(existsSync(join(home, ".hermes", "skills", "missing-support"))).toBe(false);
 	});
 
 	test("requires paired ownership and uses Hermes install and uninstall semantics", async () => {

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -328,6 +328,17 @@ function assertBundledResultMatches(sourceDir: string, target: string): void {
 	}
 }
 
+function installedProjectionMatchesSource(
+	source: ReadonlyMap<string, Buffer>,
+	installed: ReadonlyMap<string, Buffer>,
+): boolean {
+	if (!installed.has("SKILL.md")) return false;
+	for (const [path, bytes] of installed) {
+		if (!source.get(path)?.equals(bytes)) return false;
+	}
+	return true;
+}
+
 export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDriver = {
 	target(input) {
 		return withStagedManagedSkill(input.skill, (sourceDir) => {
@@ -400,7 +411,7 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 						const installed = collectRuntimeUserManagedSkillTree(installedTarget);
 						if (
 							installed.status !== "collected" ||
-							!managedSkillTreesEqual(files, installed.tree)
+							!installedProjectionMatchesSource(files, installed.tree)
 						) {
 							throw new ManagedSkillResourceError(
 								"Hermes official Skill install changed the verified source bytes",

--- a/packages/cli/src/runtime/managed-skill-delivery.ts
+++ b/packages/cli/src/runtime/managed-skill-delivery.ts
@@ -377,7 +377,7 @@ export function withStagedManagedSkill<T>(
 	operation: (sourceDir: string) => T,
 ): T {
 	if (createHash("sha256").update(skill.tarBytes).digest("hex") !== skill.archiveSha256) {
-		throw new Error("prepared Skill archive digest mismatch");
+		throw new ManagedSkillResourceError("prepared Skill archive digest mismatch");
 	}
 	const root = mkdtempSync(join(tmpdir(), "clawdi-managed-skill-"));
 	try {
@@ -386,11 +386,13 @@ export function withStagedManagedSkill<T>(
 			stdio: ["pipe", "pipe", "pipe"],
 			maxBuffer: 1024 * 1024,
 		});
-		if (extracted.status !== 0) throw new Error("prepared Skill archive could not be staged");
+		if (extracted.status !== 0) {
+			throw new ManagedSkillResourceError("prepared Skill archive could not be staged");
+		}
 		const sourceDir = join(root, skill.skillId);
 		const sourceTree = collectManagedSkillTree(sourceDir);
 		if (!existsSync(join(sourceDir, "SKILL.md")) || sourceTree.status !== "collected") {
-			throw new Error(`prepared Skill archive is ${sourceTree.status}`);
+			throw new ManagedSkillResourceError(`prepared Skill archive is ${sourceTree.status}`);
 		}
 		const makeReadable = (path: string): void => {
 			const node = lstatSync(path);
@@ -404,7 +406,7 @@ export function withStagedManagedSkill<T>(
 			skill.source.type === "bundled" &&
 			managedSkillDirectoryDigest(sourceDir) !== skill.source.digest
 		) {
-			throw new Error("prepared bundled Skill tree digest mismatch");
+			throw new ManagedSkillResourceError("prepared bundled Skill tree digest mismatch");
 		}
 		return operation(sourceDir);
 	} finally {

--- a/packages/cli/src/runtime/manifest-planning.ts
+++ b/packages/cli/src/runtime/manifest-planning.ts
@@ -41,7 +41,7 @@ import {
 	managedBaileysCompatSnapshotRuntimes,
 } from "./managed-baileys-compat";
 import { buildHermesManagedChannelsPatch } from "./managed-channel-reconciliation";
-import { managedSkillReceiptPath } from "./managed-skill-delivery";
+import { ManagedSkillResourceError, managedSkillReceiptPath } from "./managed-skill-delivery";
 import { managedSkillReservations } from "./managed-skill-reservation";
 import {
 	hostedChannelCredentialsDeclared,
@@ -693,7 +693,12 @@ export function hostedSkillMutationTargets(
 			managesHermesSourcedSkill = true;
 			const prepared = preparedSourcedSkills.get(skillId);
 			if (prepared?.skillId === skillId) {
-				const target = hermesDriver.target?.({ home, skill: prepared });
+				let target: string | undefined;
+				try {
+					target = hermesDriver.target?.({ home, skill: prepared });
+				} catch (error) {
+					if (!(error instanceof ManagedSkillResourceError)) throw error;
+				}
 				if (target) runtimeUserTargets.add(target);
 			}
 		}

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -4935,11 +4935,14 @@ echo spawned > '${installerLog}'
 		const result = convergeRuntimeManifest(manifestLoad(manifest, "skill-item-isolation"), paths, {
 			preparedHostedSourcedSkills: preparedSkills,
 			hostedHermesSkillExactSourceDriver: {
+				target: ({ skill }) => {
+					if (skill.skillId === "a-fail") {
+						throw new ManagedSkillResourceError("prepared Skill archive could not be staged");
+					}
+					return join(paths.userHome, ".hermes", "skills", skill.skillId);
+				},
 				install: ({ skill }) => {
 					attempted.push(skill.skillId);
-					if (skill.skillId === "a-fail") {
-						throw new ManagedSkillResourceError("deterministic native install failure");
-					}
 					const target = join(paths.userHome, ".hermes", "skills", skill.skillId);
 					mkdirSync(target, { recursive: true });
 					writeFileSync(join(target, "SKILL.md"), `${skill.skillId}\n`);
@@ -4955,9 +4958,9 @@ echo spawned > '${installerLog}'
 
 		expect(result.installErrors).toEqual([]);
 		expect(result.resourceProjectionErrors).toEqual([
-			"runtime hermes Skill projection failed: a-fail: deterministic native install failure",
+			"runtime hermes Skill projection failed: a-fail: prepared Skill archive could not be staged",
 		]);
-		expect(attempted).toEqual(skillIds);
+		expect(attempted).toEqual(["b-ready", "c-ready"]);
 		expect(existsSync(join(paths.userHome, ".hermes", "skills", "a-fail"))).toBe(false);
 		for (const skillId of ["b-ready", "c-ready"]) {
 			expect(

--- a/packages/cli/src/runtime/manifest-skills-apply.ts
+++ b/packages/cli/src/runtime/manifest-skills-apply.ts
@@ -295,7 +295,13 @@ function recoverHostedSkillReservations(
 		if (!preparedSkillMatchesDesired(prepared, desired, skillId)) {
 			continue;
 		}
-		const targetDir = driver.target(prepared);
+		let targetDir: string;
+		try {
+			targetDir = driver.target(prepared);
+		} catch (error) {
+			if (error instanceof ManagedSkillResourceError) continue;
+			throw error;
+		}
 		if (
 			!withRuntimeUserFileAccess(() => existsSync(targetDir)) ||
 			managedSkillReservationOwner(targetDir, skillId) !== "unreserved" ||
@@ -330,7 +336,13 @@ function validateHostedSkillsPlan(
 		if (!preparedSkillMatchesDesired(prepared, desired, skillId)) {
 			throw new Error(`pinned archive for hosted Skill ${skillId} is unavailable`);
 		}
-		const targetDir = driver.target(prepared);
+		let targetDir: string;
+		try {
+			targetDir = driver.target(prepared);
+		} catch (error) {
+			if (error instanceof ManagedSkillResourceError) continue;
+			throw error;
+		}
 		if (
 			withRuntimeUserFileAccess(() => existsSync(targetDir)) &&
 			managedSkillReservationOwner(targetDir, skillId) !== "hosted-manifest"
@@ -386,7 +398,14 @@ function applyHostedSkills(
 		if (!preparedSkillMatchesDesired(prepared, desired, skillId)) {
 			throw new Error(`pinned archive for hosted Skill ${skillId} is unavailable`);
 		}
-		const targetDir = driver.target(prepared);
+		let targetDir: string;
+		try {
+			targetDir = driver.target(prepared);
+		} catch (error) {
+			if (!(error instanceof ManagedSkillResourceError)) throw error;
+			failures.push(`${skillId}: ${error.message}`);
+			continue;
+		}
 		const owner = managedSkillReservationOwner(targetDir, skillId);
 		if (withRuntimeUserFileAccess(() => existsSync(targetDir)) && owner !== "hosted-manifest") {
 			throw new Error(`refusing to replace unmanaged ${skillId} skill at ${targetDir}`);


### PR DESCRIPTION
## Incident

The eighth production-device run showed that the verified loopback transport from #1160 worked, but one sourced Skill stopped all 14 sourced installs before Hermes could decide how to handle its content:

```text
runtime hermes Skill projection failed: prepared Hermes Skill support file is missing: scripts/hermes-direct-slack-sync.py
```

The error had no Skill ID because `hermesUrlSourceFiles()` parsed `SKILL.md`, predicted the support-file projection, and threw a plain `Error`. That escaped the `ManagedSkillResourceError` per-Skill boundary and aborted the remaining Skills.

## Service, not prediction

A loopback source is a byte-serving boundary, not a second implementation of Hermes content semantics.

- Snapshot every safe regular file in the staged, digest-verified archive under the existing entry, per-file, and total-byte ceilings.
- Keep the nonce-scoped exact-GET transport and pure URL path-safety checks.
- Remove Clawdi parsing of support references, missing-reference checks, and UTF-8 policy from the serving allowlist.
- Return 404 when Hermes requests a path absent from the archive.
- Verify that every file Hermes installs is a byte-identical member of the served snapshot. The installed tree may be a subset because Hermes owns the URL projection rules; archive files that Hermes does not request remain uninstalled.

This restores the same boundary established earlier in the sourced-Skill work: Clawdi validates transport and archive safety, while the official runtime owns Skill meaning.

## Hermes 404 behavior

Hermes Agent commit [`a77ee88ce29c4f1d89f8d60e5b662322645072d8`](https://github.com/NousResearch/hermes-agent/commit/a77ee88ce29c4f1d89f8d60e5b662322645072d8) makes the missing-file behavior exact:

- [`UrlSource.fetch()` parses references and fetches each support path](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/tools/skills_hub.py#L1506-L1528).
- [`_fetch_bytes()` returns `None` for every non-200 response, including 404](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/tools/skills_hub.py#L1560-L1564).
- `UrlSource.fetch()` then returns `None` for the whole bundle. [`do_install()` prints `Could not fetch ... from any source` and returns without installing](https://github.com/NousResearch/hermes-agent/blob/a77ee88ce29c4f1d89f8d60e5b662322645072d8/hermes_cli/skills_hub.py#L585-L607).

That logical failure exits zero. Clawdi therefore uses the existing exact loopback lock anchor: no matching lock record becomes `Hermes official Skill install did not record an installed target`, a typed per-Skill resource failure. This is the official behavior rather than a Clawdi preflight guess.

## Attribution and isolation

The fix also closes the layer where the incident lost attribution:

- Loopback snapshot/start failures and prepared-archive staging failures are now `ManagedSkillResourceError`.
- Recovery, validation, and mutation-target discovery defer typed target/staging failures to the per-Skill apply pass.
- Apply reports them as `${skillId}: ${message}` and continues later Skills.
- Non-resource planning invariants remain fail-closed for the whole Skill domain.

Regression coverage exercises both the exact missing-support-file path and a target/staging failure before install, proving later Skills still install.

## Real Hermes reproduction

Validated with the exact `a77ee88` source tarball installed editable into an isolated Python 3.12 environment and isolated `HOME`. External HTTP, HTTPS, and ALL proxies pointed at unreachable `127.0.0.1:9`; GitHub credential variables were empty.

The first archive referenced `scripts/hermes-direct-slack-sync.py` without containing it. The second archive contained a valid referenced file plus an unreferenced archive file:

```json
{
  "missingFailure": "Hermes official Skill install did not record an installed target: ... Error: Could not fetch ... from any source.",
  "missingInstalled": false,
  "readyResult": "installed",
  "readyInstalled": true,
  "archiveOnlyInstalled": false
}
```

The complete Skill installed immediately after the broken one, its referenced bytes matched, and the unreferenced archive file remained absent from the official projection.

## Verification

- Focused CLI tests: 194 passed, 0 failed, 1,300 assertions
- Focused mutation parity: 1 passed, 0 failed
- Full `packages/cli test:internal` through the Bun 1.4.0 clean runner: 1,758 passed, 4 conditional skips, 0 failed, 9,581 assertions
- Privileged official-installer systemd e2e: 5 passed, 0 failed, 231 assertions
- CLI typecheck: passed in focused and full clean-runner suites
- Repository-pinned Biome 2.5.9: 1,067 files checked, no fixes
- `git diff --check`: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)