### PR TITLE
release(cli): 0.14.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.8
+
+Package: `clawdi@0.14.8`
+
+### Fixed
+
+- The loopback skill source now serves the staged archive's actual contents
+  and lets Hermes's official semantics decide about missing referenced files;
+  a skill with broken content fails alone, attributed by name, without
+  blocking the remaining skills.
+
 ## Clawdi CLI v0.14.7
 
 Package: `clawdi@0.14.7`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.7",
+      "version": "0.14.8",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.7",
+	"version": "0.14.8",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Release `clawdi@0.14.8` — closes the eighth-canary finding (#1162).

The loopback skill source now serves the staged archive's actual contents (path-safety only) instead of predicting Hermes's support-file references; missing referenced files get official 404 semantics (verified upstream: bundle fetch fails, exit 0, no lock — caught by our lock fail-closed as a typed per-skill error). Skill-level resource failures are attributed by skill ID and isolated, so one broken skill no longer blocks the rest.

Ninth canary round follows; pass bar unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)