### PR TITLE
fix(cli): narrow runtime transaction boundaries

### DIFF
--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { hostname } from "node:os";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
@@ -284,6 +284,11 @@ async function installBuiltinSkill(agentType: AgentType) {
 				manager: "local-setup",
 			},
 			() => replaceManagedSkillDirectoryAtomic(sourceDir, targetDir),
+			{
+				verify: () =>
+					existsSync(targetDir) && managedSkillDirectoryDigest(targetDir) === sourceDigest,
+				discard: () => rmSync(targetDir, { recursive: true, force: true }),
+			},
 		);
 		console.log(
 			chalk.green(`✓ Clawdi skill ${alreadyInstalled ? "updated" : "installed"} in ${label}`),

--- a/packages/cli/src/runtime/managed-skill-reservation.test.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.test.ts
@@ -15,6 +15,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import { managedSkillDirectoryDigest } from "./hosted-bundled-skill";
 import {
 	installReservedManagedSkill,
+	managedSkillReservationLedgerPath,
 	managedSkillReservationState,
 	migrateLegacyLocalSetupSkill,
 	mutateUserSkillTarget,
@@ -28,6 +29,11 @@ const originalHome = process.env.HOME;
 const originalMode = process.env.CLAWDI_RUNTIME_MODE;
 const originalState = process.env.CLAWDI_SERVICE_STATE_DIR;
 let root = "";
+
+const verifiedInstall = {
+	verify: () => true,
+	discard: () => undefined,
+};
 
 function target(parent = "one"): string {
 	const path = join(root, parent, "skills", "example");
@@ -202,8 +208,9 @@ describe("managed Skill reservations", () => {
 			},
 			() => {
 				expect(shouldIgnoreUserSkill(previousTarget, "project-skill")).toBe(true);
-				expect(shouldIgnoreUserSkill(nativeTarget, "frontmatter-name")).toBe(true);
+				expect(shouldIgnoreUserSkill(nativeTarget, "frontmatter-name")).toBe(false);
 			},
+			verifiedInstall,
 		);
 
 		expect(managedSkillReservationState(previousTarget, "project-skill")).toBe("unreserved");
@@ -347,6 +354,7 @@ describe("managed Skill reservations", () => {
 		writeFileSync(join(source, "SKILL.md"), "# Updated\n");
 		writeFileSync(join(path, "removed.txt"), "stale\n");
 
+		const ledgerPath = managedSkillReservationLedgerPath();
 		installReservedManagedSkill(
 			{
 				targetDir: path,
@@ -355,12 +363,44 @@ describe("managed Skill reservations", () => {
 				digest: "e".repeat(64),
 				manager: "local-setup",
 			},
-			() => replaceManagedSkillDirectoryAtomic(source, path),
+			() => {
+				expect(managedSkillReservationState(path, "example")).toBe("unreserved");
+				const pendingLedger = JSON.parse(readFileSync(ledgerPath, "utf8"));
+				expect(pendingLedger.reservations[path]).toBeUndefined();
+				expect(pendingLedger.pendingReservations[path]).toMatchObject({
+					id: "example",
+					manager: "local-setup",
+				});
+				replaceManagedSkillDirectoryAtomic(source, path);
+			},
+			{
+				verify: () => readFileSync(join(path, "SKILL.md"), "utf8") === "# Updated\n",
+				discard: () => rmSync(path, { recursive: true, force: true }),
+			},
 		);
 
 		expect(readFileSync(join(path, "SKILL.md"), "utf8")).toBe("# Updated\n");
 		expect(existsSync(join(path, "removed.txt"))).toBe(false);
 		expect(managedSkillReservationState(path, "example")).toBe("reserved");
+		expect(JSON.parse(readFileSync(ledgerPath, "utf8")).pendingReservations).toEqual({});
+		const committedLedger = readFileSync(ledgerPath, "utf8");
+		expect(
+			installReservedManagedSkill(
+				{
+					targetDir: path,
+					id: "example",
+					version: 2,
+					digest: "e".repeat(64),
+					manager: "local-setup",
+				},
+				() => "unchanged" as const,
+				{
+					verify: () => readFileSync(join(path, "SKILL.md"), "utf8") === "# Updated\n",
+					discard: () => rmSync(path, { recursive: true, force: true }),
+				},
+			),
+		).toBe("unchanged");
+		expect(readFileSync(ledgerPath, "utf8")).toBe(committedLedger);
 	});
 
 	it("restores target and ownership when activation fails", () => {
@@ -370,6 +410,13 @@ describe("managed Skill reservations", () => {
 		const path = target();
 		mkdirSync(source, { recursive: true });
 		writeFileSync(join(source, "SKILL.md"), "# Updated\n");
+		reserveManagedSkill({
+			targetDir: path,
+			id: "example",
+			version: 1,
+			digest: "e".repeat(64),
+			manager: "local-setup",
+		});
 
 		expect(() =>
 			installReservedManagedSkill(
@@ -386,10 +433,44 @@ describe("managed Skill reservations", () => {
 							throw new Error("injected activation failure");
 						},
 					}),
+				verifiedInstall,
 			),
 		).toThrow("injected activation failure");
 
 		expect(readFileSync(join(path, "SKILL.md"), "utf8")).toBe("# Example\n");
+		expect(managedSkillReservationState(path, "example")).toBe("reserved");
+	});
+
+	it("removes stale committed ownership when an installed replacement cannot be verified", () => {
+		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
+		process.env.HOME = root;
+		const path = target();
+		reserveManagedSkill({
+			targetDir: path,
+			id: "example",
+			version: 1,
+			digest: "e".repeat(64),
+			manager: "local-setup",
+		});
+
+		expect(() =>
+			installReservedManagedSkill(
+				{
+					targetDir: path,
+					id: "example",
+					version: 2,
+					digest: "f".repeat(64),
+					manager: "local-setup",
+				},
+				() => writeFileSync(join(path, "SKILL.md"), "# Unverified\n"),
+				{
+					verify: () => false,
+					discard: () => rmSync(path, { recursive: true, force: true }),
+				},
+			),
+		).toThrow("installation could not be verified");
+
+		expect(existsSync(path)).toBe(false);
 		expect(managedSkillReservationState(path, "example")).toBe("unreserved");
 	});
 
@@ -419,6 +500,7 @@ describe("managed Skill reservations", () => {
 							throw new Error("restore failed");
 						},
 					}),
+				verifiedInstall,
 			),
 		).toThrow(
 			/activation failed.*restore failed.*previous version retained as a recovery artifact/,
@@ -456,6 +538,7 @@ describe("managed Skill reservations", () => {
 						throw new Error("cleanup failed");
 					},
 				}),
+			verifiedInstall,
 		);
 
 		expect(readFileSync(join(path, "SKILL.md"), "utf8")).toBe("# Updated\n");
@@ -492,9 +575,9 @@ try {
 		manager: "local-setup",
 	})}, () => {
     writeFileSync(${JSON.stringify(ready)}, "ready");
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
-    throw new Error("rollback");
-  });
+	    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+	    throw new Error("rollback");
+	  }, { verify: () => true, discard: () => {} });
 } catch (error) {
   if (!(error instanceof Error) || error.message !== "rollback") throw error;
 }`,
@@ -550,9 +633,9 @@ installReservedManagedSkill(${JSON.stringify({
 				})}, () => {
   mkdirSync(${JSON.stringify(path)}, { recursive: true });
   writeFileSync(${JSON.stringify(join(path, "SKILL.md"))}, "# Managed\\n");
-  writeFileSync(${JSON.stringify(ready)}, "ready");
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
-});`,
+	  writeFileSync(${JSON.stringify(ready)}, "ready");
+	  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+	}, { verify: () => true, discard: () => {} });`,
 			],
 			{
 				env: {

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -14,7 +14,7 @@ import { getClawdiDir } from "../lib/config";
 import { withPrivateDirectoryLockSync } from "../lib/private-directory-lock";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { withRuntimeConvergeLock } from "./converge-lock";
-import { withManagedTargetRollback } from "./managed-skill-delivery";
+import { ManagedSkillResourceError, withManagedTargetRollback } from "./managed-skill-delivery";
 import { getRuntimePaths } from "./paths";
 import { withRuntimeUserFileAccess } from "./runtime-user-command";
 import { runtimePlatformRootForPath, writeRuntimePlatformFileAtomic } from "./state";
@@ -67,7 +67,16 @@ export interface ManagedSkillReservationSnapshot {
 interface ManagedSkillReservationLedger {
 	schemaVersion: typeof LEDGER_SCHEMA;
 	reservations: Record<string, ManagedSkillReservation>;
+	pendingReservations: Record<string, PendingManagedSkillReservation>;
 	localSetupMigrations: Record<string, { target: string; id: string }>;
+}
+
+interface PendingManagedSkillReservation extends ManagedSkillReservation {
+	previousTarget?: string;
+}
+
+export interface PendingManagedSkillReservationSnapshot extends ManagedSkillReservationSnapshot {
+	previousTargetDir?: string;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -95,7 +104,12 @@ function legacyHostedLedgerPath(path: string): string | null {
 }
 
 function emptyLedger(): ManagedSkillReservationLedger {
-	return { schemaVersion: LEDGER_SCHEMA, reservations: {}, localSetupMigrations: {} };
+	return {
+		schemaVersion: LEDGER_SCHEMA,
+		reservations: {},
+		pendingReservations: {},
+		localSetupMigrations: {},
+	};
 }
 
 function validSourcedManagedSkillTarget(value: string): boolean {
@@ -119,6 +133,33 @@ function reservationTargetMatchesIdentity(
 	);
 }
 
+function parseReservation(target: string, raw: unknown): ManagedSkillReservation {
+	if (
+		!isRecord(raw) ||
+		raw.target !== target ||
+		resolve(target) !== target ||
+		typeof raw.id !== "string" ||
+		!reservationTargetMatchesIdentity(target, raw) ||
+		!MANAGED_SKILL_ID_PATTERN.test(raw.id) ||
+		(raw.version !== undefined &&
+			(typeof raw.version !== "number" ||
+				!Number.isSafeInteger(raw.version) ||
+				raw.version <= 0)) ||
+		!reservationIdentityIsValid(raw) ||
+		(raw.manager !== "hosted-manifest" && raw.manager !== "local-setup")
+	) {
+		throw new Error("managed Skill ownership state is invalid");
+	}
+	return {
+		target,
+		id: raw.id,
+		version: raw.version,
+		digest: typeof raw.digest === "string" ? raw.digest : undefined,
+		sourceIdentity: typeof raw.sourceIdentity === "string" ? raw.sourceIdentity : undefined,
+		manager: raw.manager,
+	};
+}
+
 function readLedger(path: string): ManagedSkillReservationLedger {
 	const legacyPath = legacyHostedLedgerPath(path);
 	const sourcePath = existsSync(path)
@@ -139,36 +180,34 @@ function readLedger(path: string): ManagedSkillReservationLedger {
 		!isRecord(value) ||
 		value.schemaVersion !== LEDGER_SCHEMA ||
 		!isRecord(value.reservations) ||
+		(value.pendingReservations !== undefined && !isRecord(value.pendingReservations)) ||
 		(value.localSetupMigrations !== undefined && !isRecord(value.localSetupMigrations))
 	) {
 		throw new Error("managed Skill ownership state is invalid");
 	}
 	const reservations: Record<string, ManagedSkillReservation> = {};
 	for (const [target, raw] of Object.entries(value.reservations)) {
-		if (
-			!isRecord(raw) ||
-			raw.target !== target ||
-			resolve(target) !== target ||
-			typeof raw.id !== "string" ||
-			!reservationTargetMatchesIdentity(target, raw) ||
-			!MANAGED_SKILL_ID_PATTERN.test(raw.id) ||
-			(raw.version !== undefined &&
-				(typeof raw.version !== "number" ||
-					!Number.isSafeInteger(raw.version) ||
-					raw.version <= 0)) ||
-			!reservationIdentityIsValid(raw) ||
-			(raw.manager !== "hosted-manifest" && raw.manager !== "local-setup")
-		) {
-			throw new Error("managed Skill ownership state is invalid");
+		reservations[target] = parseReservation(target, raw);
+	}
+	const pendingReservations: Record<string, PendingManagedSkillReservation> = {};
+	try {
+		for (const [target, raw] of Object.entries(value.pendingReservations ?? {})) {
+			const reservation = parseReservation(target, raw);
+			if (
+				!isRecord(raw) ||
+				(raw.previousTarget !== undefined &&
+					(typeof raw.previousTarget !== "string" ||
+						resolve(raw.previousTarget) !== raw.previousTarget))
+			) {
+				throw new Error("invalid pending reservation");
+			}
+			pendingReservations[target] = {
+				...reservation,
+				previousTarget: typeof raw.previousTarget === "string" ? raw.previousTarget : undefined,
+			};
 		}
-		reservations[target] = {
-			target,
-			id: raw.id,
-			version: raw.version,
-			digest: typeof raw.digest === "string" ? raw.digest : undefined,
-			sourceIdentity: typeof raw.sourceIdentity === "string" ? raw.sourceIdentity : undefined,
-			manager: raw.manager,
-		};
+	} catch {
+		throw new Error("managed Skill ownership state is invalid");
 	}
 	const localSetupMigrations: Record<string, { target: string; id: string }> = {};
 	for (const [target, raw] of Object.entries(value.localSetupMigrations ?? {})) {
@@ -184,7 +223,7 @@ function readLedger(path: string): ManagedSkillReservationLedger {
 		}
 		localSetupMigrations[target] = { target, id: raw.id };
 	}
-	return { schemaVersion: LEDGER_SCHEMA, reservations, localSetupMigrations };
+	return { schemaVersion: LEDGER_SCHEMA, reservations, pendingReservations, localSetupMigrations };
 }
 
 function writeLedger(path: string, ledger: ManagedSkillReservationLedger): void {
@@ -245,6 +284,22 @@ export function managedSkillReservations(
 		.sort((left, right) => left.targetDir.localeCompare(right.targetDir));
 }
 
+export function pendingManagedSkillReservations(
+	manager: ManagedSkillReservationManager,
+): PendingManagedSkillReservationSnapshot[] {
+	return Object.values(readLedger(ledgerPath()).pendingReservations)
+		.filter((reservation) => reservation.manager === manager)
+		.map((reservation) => ({
+			targetDir: reservation.target,
+			previousTargetDir: reservation.previousTarget,
+			id: reservation.id,
+			version: reservation.version,
+			digest: reservation.digest,
+			sourceIdentity: reservation.sourceIdentity,
+		}))
+		.sort((left, right) => left.targetDir.localeCompare(right.targetDir));
+}
+
 function reservationIdentityIsValid(value: {
 	digest?: unknown;
 	sourceIdentity?: unknown;
@@ -255,6 +310,25 @@ function reservationIdentityIsValid(value: {
 		(value.sourceIdentity.startsWith("github\0") || value.sourceIdentity.startsWith("project\0")) &&
 		value.sourceIdentity.length <= 2048;
 	return hasDigest !== hasSourceIdentity;
+}
+
+function reservationMatches(
+	reservation: ManagedSkillReservation,
+	input: {
+		id: string;
+		version?: number;
+		digest?: string;
+		sourceIdentity?: string;
+		manager: ManagedSkillReservationManager;
+	},
+): boolean {
+	return (
+		reservation.id === input.id &&
+		reservation.version === input.version &&
+		reservation.digest === input.digest &&
+		reservation.sourceIdentity === input.sourceIdentity &&
+		reservation.manager === input.manager
+	);
 }
 
 export function shouldIgnoreUserSkill(targetDir: string, skillId = basename(targetDir)): boolean {
@@ -369,9 +443,15 @@ export function reserveManagedSkill(input: {
 	return withLedgerWriteLock(input.manager, () => {
 		const ledger = readLedger(path);
 		const previous = ledger.reservations[target];
+		const pending = ledger.pendingReservations[target];
 		const manager = input.manager;
 		if (previous && (previous.manager !== manager || previous.id !== input.id)) {
 			throw new Error(`managed Skill ${input.id} is owned by a different manager`);
+		}
+		if (pending) {
+			throw new Error(
+				`managed Skill ${input.id} has a pending installation that requires recovery`,
+			);
 		}
 		ledger.reservations[target] = {
 			target,
@@ -397,6 +477,7 @@ export function installReservedManagedSkill<T>(
 		manager: ManagedSkillReservationManager;
 	},
 	install: () => T,
+	verification: { verify: () => boolean; discard: () => void },
 ): T {
 	const path = ledgerPath();
 	const target = resolve(input.targetDir);
@@ -413,14 +494,50 @@ export function installReservedManagedSkill<T>(
 		const ledger = readLedger(path);
 		const previous = ledger.reservations[target];
 		const replaced = previousTarget === target ? previous : ledger.reservations[previousTarget];
+		const pending = ledger.pendingReservations[target];
 		if (previous && (previous.manager !== input.manager || previous.id !== input.id)) {
 			throw new Error(`managed Skill ${input.id} is owned by a different manager`);
+		}
+		if (
+			pending &&
+			(!reservationMatches(pending, input) || (pending.previousTarget ?? target) !== previousTarget)
+		) {
+			throw new Error(`managed Skill ${input.id} is pending for a different installation`);
 		}
 		if (
 			previousTarget !== target &&
 			(!replaced || replaced.manager !== input.manager || replaced.id !== input.id)
 		) {
 			throw new Error(`managed Skill ${input.id} replacement reservation is invalid`);
+		}
+		ledger.pendingReservations[target] = {
+			target,
+			...(previousTarget !== target ? { previousTarget } : {}),
+			id: input.id,
+			version: input.version,
+			digest: input.digest,
+			sourceIdentity: input.sourceIdentity,
+			manager: input.manager,
+		};
+		writeLedger(path, ledger);
+		let result: T;
+		try {
+			result = install();
+		} catch (error) {
+			delete ledger.pendingReservations[target];
+			writeLedger(path, ledger);
+			throw error;
+		}
+		if (!verification.verify()) {
+			verification.discard();
+			if (previous?.id === input.id && previous.manager === input.manager) {
+				delete ledger.reservations[target];
+			}
+			delete ledger.pendingReservations[target];
+			writeLedger(path, ledger);
+			throw new ManagedSkillResourceError(
+				`managed Skill ${input.id} installation could not be verified`,
+			);
 		}
 		ledger.reservations[target] = {
 			target,
@@ -430,23 +547,56 @@ export function installReservedManagedSkill<T>(
 			sourceIdentity: input.sourceIdentity,
 			manager: input.manager,
 		};
+		if (previousTarget !== target) delete ledger.reservations[previousTarget];
+		delete ledger.pendingReservations[target];
 		writeLedger(path, ledger);
-		try {
-			const result = install();
-			if (previousTarget !== target) {
-				delete ledger.reservations[previousTarget];
-				writeLedger(path, ledger);
-			}
-			return result;
-		} catch (error) {
-			if (previous) ledger.reservations[target] = previous;
-			else delete ledger.reservations[target];
-			if (previousTarget !== target && replaced) {
-				ledger.reservations[previousTarget] = replaced;
-			}
-			writeLedger(path, ledger);
-			throw error;
+		return result;
+	});
+}
+
+export function recoverPendingManagedSkillInstallation(input: {
+	targetDir: string;
+	id: string;
+	manager: ManagedSkillReservationManager;
+	verify: () => boolean;
+	discard: () => void;
+}): "absent" | "promoted" | "discarded" {
+	const path = ledgerPath();
+	const target = resolve(input.targetDir);
+	return withLedgerWriteLock(input.manager, () => {
+		const ledger = readLedger(path);
+		const pending = ledger.pendingReservations[target];
+		if (!pending) return "absent";
+		if (pending.id !== input.id || pending.manager !== input.manager) {
+			throw new Error("pending managed Skill reservation identity mismatch");
 		}
+		if (input.verify()) {
+			ledger.reservations[target] = {
+				target,
+				id: pending.id,
+				version: pending.version,
+				digest: pending.digest,
+				sourceIdentity: pending.sourceIdentity,
+				manager: pending.manager,
+			};
+			if (pending.previousTarget && pending.previousTarget !== target) {
+				const replaced = ledger.reservations[pending.previousTarget];
+				if (replaced && replaced.id === pending.id && replaced.manager === pending.manager) {
+					delete ledger.reservations[pending.previousTarget];
+				}
+			}
+			delete ledger.pendingReservations[target];
+			writeLedger(path, ledger);
+			return "promoted";
+		}
+		const committed = ledger.reservations[target];
+		if (committed && committed.id === pending.id && committed.manager === pending.manager) {
+			delete ledger.reservations[target];
+		}
+		input.discard();
+		delete ledger.pendingReservations[target];
+		writeLedger(path, ledger);
+		return "discarded";
 	});
 }
 

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -285,11 +285,6 @@ function initializeRuntimeConvergence(
 	}
 	enforceRuntimeUserOwnership([
 		...runtimeUserDirectoryOwnership(projectionHome, { recursive: true, platformEnclaves }),
-		// Official user-service installers need the unit root itself writable. Its
-		// enclave contents remain root-owned until their exact mutation targets are staged.
-		...(platformEnclaves.some((enclave) => enclave.path === paths.systemdUserRoot)
-			? runtimeUserDirectoryOwnership(paths.systemdUserRoot)
-			: []),
 		...hostedOpenClawRuntimeUserOwnership(manifest, projectionHome),
 	]);
 	const openClawContext = createOpenClawHostedContext(manifest, projectionHome);
@@ -1540,10 +1535,30 @@ function activateRuntimeServices(
 	if (officialServicePlan.pending.length > 0) state.agentPluginUnitsQuiesced = false;
 	for (const item of officialServicePlan.pending) {
 		hostedRuntimeContract.assertPlatformRoots();
-		const install = () => installOfficialRuntimeService(item, paths);
-		const error = opts.systemdApply
-			? opts.systemdApply.installOfficialService(item.unitName, install)
-			: install();
+		const unitPath = join(paths.systemdUserRoot, item.unitName);
+		const installerOwnership = [
+			...runtimeUserDirectoryOwnership(paths.systemdUserRoot),
+			...runtimeUserDirectoryOwnership(join(paths.systemdUserRoot, "default.target.wants")),
+			...runtimeUserExistingOwnership([
+				unitPath,
+				`${unitPath}.bak`,
+				join(paths.systemdUserRoot, "default.target.wants", item.unitName),
+				...(item.program.runtime === "openclaw"
+					? [join(paths.userHome, ".openclaw", "gateway.systemd.env")]
+					: []),
+			]),
+		];
+		let error: string | null;
+		try {
+			enforceRuntimeUserOwnership(installerOwnership);
+			const install = () => installOfficialRuntimeService(item, paths);
+			error = opts.systemdApply
+				? opts.systemdApply.installOfficialService(item.unitName, install)
+				: install();
+		} finally {
+			enforceRuntimeUserSystemdManagerAccess(paths.systemdUserRoot);
+			enforceRuntimeUserOwnership(runtimePlatformEnclaveOwnership(platformEnclaves));
+		}
 		if (error) throw new Error(error);
 	}
 	if (platformEnclaves.some((enclave) => enclave.path === paths.systemdUserRoot)) {

--- a/packages/cli/src/runtime/manifest-planning.ts
+++ b/packages/cli/src/runtime/manifest-planning.ts
@@ -90,7 +90,7 @@ import {
 } from "./manifest-shared";
 import type { RuntimeManifestLoad } from "./manifest-source";
 import type { EnsureRuntimeMitmproxyOptions } from "./mitmproxy-fetch";
-import type { RuntimePaths } from "./paths";
+import { type RuntimePaths, runtimeSystemdPlatformEnclaves } from "./paths";
 import { hostedRuntimeProjectionHome } from "./projection-home";
 import {
 	buildRuntimeRunConfig,
@@ -786,11 +786,19 @@ export function runtimeManagedMutationPlan(input: {
 			...mutationAncestorMetadataTargets(runtimeUserTargets, runtimeUserBoundaries),
 		]),
 	].sort();
+	const platformEnclaveRoots = runtimeSystemdPlatformEnclaves(input.paths).map((enclave) =>
+		resolve(enclave.path),
+	);
 	const runtimeUserOwnership = runtimeUserExistingOwnership([
 		...runtimeUserTargets,
 		...runtimeUserMetadataTargets,
 		...runtimeCommandTargets,
-	]);
+	]).filter((rule) =>
+		platformEnclaveRoots.every((root) => {
+			const candidate = relative(root, rule.path);
+			return candidate.startsWith("..") || isAbsolute(candidate);
+		}),
+	);
 	return {
 		snapshot: {
 			rootTargets: rootTargetsList,

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -4691,15 +4691,15 @@ echo spawned > '${installerLog}'
 				return "unchanged" as const;
 			},
 			anchorOwnership: () => undefined,
-			hasOwnershipReceipt: (input: { ownershipIdentity: string }) => {
+			hasOwnershipReceipt: () => false,
+			verifyOwned: (input: { skill: PreparedHostedSourcedSkill }) => {
 				verifyCalls += 1;
 				return (
-					input.ownershipIdentity === prepared.sourceIdentity &&
+					input.skill.sourceIdentity === prepared.sourceIdentity &&
 					existsSync(join(skillDir, "SKILL.md")) &&
 					readFileSync(join(skillDir, "SKILL.md"), "utf8") === "manifest-owned\n"
 				);
 			},
-			verifyOwned: () => false,
 			uninstall: () => {
 				uninstalls += 1;
 				rmSync(skillDir, { recursive: true, force: true });
@@ -4748,7 +4748,7 @@ echo spawned > '${installerLog}'
 		);
 		expect(installed.installErrors).toEqual([]);
 		expect(installs).toEqual([false, true]);
-		expect(verifyCalls).toBe(2);
+		expect(verifyCalls).toBe(3);
 		expect(shouldIgnoreUserSkill(skillDir, "review-pr")).toBe(true);
 		expect(readFileSync(join(skillDir, "SKILL.md"), "utf8")).toBe("manifest-owned\n");
 
@@ -4776,6 +4776,120 @@ echo spawned > '${installerLog}'
 		expect(existsSync(skillDir)).toBe(false);
 		expect(readFileSync(join(userOwnedSibling, "SKILL.md"), "utf8")).toBe("keep me\n");
 		expect(shouldIgnoreUserSkill(userOwnedSibling, "user-owned")).toBe(false);
+	});
+
+	test("recovers a killed hosted Skill install before retrying convergence", async () => {
+		const paths = tempRuntimePaths();
+		ensureRuntimeStateDirs(paths);
+		const skillId = "crash-recovery";
+		const source = {
+			type: "github" as const,
+			url: "https://github.com/Clawdi-AI/store",
+			path: `skills/${skillId}`,
+			commit: "a".repeat(40),
+		};
+		const sourceIdentity = `github\0${skillId}\0${source.url}\0${source.path}\0${source.commit}`;
+		const prepared: PreparedHostedSourcedSkill = {
+			skillId,
+			source,
+			sourceIdentity,
+			archiveSha256: "b".repeat(64),
+			tarBytes: Buffer.from("crash recovery archive"),
+		};
+		const target = join(paths.userHome, ".hermes", "skills", skillId);
+		const receipt = managedSkillReceiptPath(paths.managedResourceRoot, "hermes", skillId);
+		const ready = join(dirname(paths.serviceStateRoot), "skill-installer-ready");
+		const moduleUrl = new URL("./managed-skill-reservation.ts", import.meta.url).href;
+		const child = Bun.spawn(
+			[
+				process.execPath,
+				"-e",
+				`import { writeFileSync } from "node:fs";
+const { installReservedManagedSkill } = await import(${JSON.stringify(moduleUrl)});
+installReservedManagedSkill(${JSON.stringify({
+					targetDir: target,
+					id: skillId,
+					sourceIdentity,
+					manager: "hosted-manifest",
+				})}, () => {
+  writeFileSync(${JSON.stringify(ready)}, "ready");
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 60_000);
+}, { verify: () => true, discard: () => {} });`,
+			],
+			{ env: process.env, stdout: "pipe", stderr: "pipe" },
+		);
+		for (let attempt = 0; attempt < 200 && !existsSync(ready); attempt += 1) {
+			await Bun.sleep(10);
+		}
+		expect(existsSync(ready)).toBe(true);
+		child.kill("SIGKILL");
+		expect(await child.exited).not.toBe(0);
+
+		const ledgerPath = managedSkillReservationLedgerPath();
+		const interruptedLedger = JSON.parse(readFileSync(ledgerPath, "utf8"));
+		expect(interruptedLedger.reservations[target]).toBeUndefined();
+		expect(interruptedLedger.pendingReservations[target]).toBeDefined();
+		expect(existsSync(target)).toBe(false);
+		expect(existsSync(receipt)).toBe(false);
+		expect(() =>
+			reserveManagedSkill({
+				targetDir: target,
+				id: skillId,
+				sourceIdentity,
+				manager: "hosted-manifest",
+			}),
+		).toThrow("pending installation that requires recovery");
+
+		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		mkdirSync(dirname(hermesCommand), { recursive: true });
+		writeFileSync(hermesCommand, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+		const manifest = baseManifest(
+			paths,
+			{ hermes: { enabled: true, run: runSettings(hermesCommand, ["gateway"]), services: {} } },
+			{ projection: { skills: { entries: { [skillId]: { enabled: true, source } } } } },
+		);
+		let installs = 0;
+		const result = convergeRuntimeManifest(
+			manifestLoad(manifest, "recover-killed-skill-installer"),
+			paths,
+			{
+				preparedHostedSourcedSkills: new Map([[skillId, prepared]]),
+				hostedHermesSkillExactSourceDriver: {
+					install: () => {
+						installs += 1;
+						const installingLedger = JSON.parse(readFileSync(ledgerPath, "utf8"));
+						expect(installingLedger.reservations[target]).toBeUndefined();
+						expect(installingLedger.pendingReservations[target]).toBeDefined();
+						mkdirSync(target, { recursive: true });
+						writeFileSync(join(target, "SKILL.md"), "verified tree\n");
+						writeManagedSkillReceipt({
+							path: receipt,
+							managedResourceRoot: paths.managedResourceRoot,
+							schemaVersion: "clawdi.hermesManifestSkillReceipt.v2",
+							skillId,
+							ownershipIdentity: sourceIdentity,
+							target,
+						});
+						return "installed";
+					},
+					anchorOwnership: () => undefined,
+					hasOwnershipReceipt: () => existsSync(receipt),
+					verifyOwned: () =>
+						existsSync(receipt) &&
+						existsSync(join(target, "SKILL.md")) &&
+						readFileSync(join(target, "SKILL.md"), "utf8") === "verified tree\n",
+					uninstall: () => "removed",
+					cleanupManifestOwned: () => "removed",
+				},
+			},
+		);
+
+		expect([...result.installErrors, ...result.resourceProjectionErrors]).toEqual([]);
+		expect(installs).toBe(1);
+		expect(managedSkillReservationState(target, skillId)).toBe("reserved");
+		const committedLedger = JSON.parse(readFileSync(ledgerPath, "utf8"));
+		expect(committedLedger.reservations[target]).toBeDefined();
+		expect(committedLedger.pendingReservations).toEqual({});
 	});
 
 	test("releases a stale hosted reservation after its Skill tree disappears", () => {
@@ -4884,7 +4998,7 @@ echo spawned > '${installerLog}'
 					},
 					anchorOwnership: () => undefined,
 					hasOwnershipReceipt: () => false,
-					verifyOwned: () => false,
+					verifyOwned: () => true,
 					uninstall: () => "removed",
 					cleanupManifestOwned: () => "removed",
 				},
@@ -4952,7 +5066,7 @@ echo spawned > '${installerLog}'
 				},
 				anchorOwnership: () => undefined,
 				hasOwnershipReceipt: () => false,
-				verifyOwned: () => false,
+				verifyOwned: () => true,
 				uninstall: () => "removed",
 				cleanupManifestOwned: () => "removed",
 			},
@@ -5104,10 +5218,11 @@ echo spawned > '${installerLog}'
 			paths,
 		);
 		expect(reconverged.installErrors).toEqual([]);
-		expect(readFileSync(join(target, "SKILL.md"))).toEqual(
-			readFileSync(join(packageSource, "SKILL.md")),
+		expect(reconverged.resourceProjectionErrors.join("\n")).toContain(
+			`refusing to replace unmanaged clawdi skill at ${target}`,
 		);
-		expect(shouldIgnoreUserSkill(target, "clawdi")).toBe(true);
+		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("tenant mutation\n");
+		expect(shouldIgnoreUserSkill(target, "clawdi")).toBe(false);
 	});
 
 	test("claims legacy OpenClaw Skills before receipt-guarded removal", () => {

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -6,6 +6,8 @@ import {
 	chownSync,
 	cpSync,
 	existsSync,
+	lchownSync,
+	lstatSync,
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
@@ -5795,7 +5797,7 @@ exit 0
 		expect(readlinkSync(commandPath)).toBe(commandTarget);
 	});
 
-	test("repairs root bootstrap ownership for the UID 10001 official OpenClaw service path", () => {
+	test("keeps the systemd enclave root-owned outside the UID 10001 installer boundary", () => {
 		const numericPrivilegeToolPath = ["/usr/bin/set", "priv"].join("");
 		if (process.geteuid?.() !== 0 || !existsSync(numericPrivilegeToolPath)) return;
 		const paths = tempRuntimePaths();
@@ -5808,16 +5810,29 @@ exit 0
 		const gatewayEnvironment = join(appRoot, "gateway.systemd.env");
 		const unitPath = join(paths.systemdUserRoot, "openclaw-gateway.service");
 		const unitBackupPath = `${unitPath}.bak`;
+		const dropInPath = join(
+			paths.systemdUserRoot,
+			"openclaw-gateway.service.d",
+			"10-clawdi-hosted.conf",
+		);
+		const wantsRoot = join(paths.systemdUserRoot, "default.target.wants");
+		const enablementPath = join(wantsRoot, "openclaw-gateway.service");
 		const runtimeOwnedPaths = [
 			appRoot,
 			binDir,
 			commandPath,
 			dirname(dirname(paths.systemdUserRoot)),
 			dirname(paths.systemdUserRoot),
+		];
+		const platformOwnedPaths = [
 			paths.systemdUserRoot,
 			unitPath,
 			unitBackupPath,
 			gatewayEnvironment,
+			dirname(dropInPath),
+			dropInPath,
+			wantsRoot,
+			enablementPath,
 		];
 
 		chmodSync(fixtureRoot, 0o755);
@@ -5829,7 +5844,8 @@ exit 0
 		chmodSync(paths.clawdiHome, 0o700);
 		mkdirSync(binDir, { recursive: true });
 		mkdirSync(appRoot, { recursive: true });
-		mkdirSync(dirname(unitPath), { recursive: true });
+		mkdirSync(dirname(dropInPath), { recursive: true });
+		mkdirSync(wantsRoot, { recursive: true });
 		writeFileSync(
 			commandPath,
 			`#!/usr/bin/env bash
@@ -5850,17 +5866,22 @@ printf '{"ok":true}\\n'
 		);
 		writeFileSync(unitPath, "[Unit]\nDescription=previous official unit\n");
 		writeFileSync(unitBackupPath, "previous official backup\n");
+		writeFileSync(dropInPath, "[Service]\nEnvironment=PREVIOUS=1\n");
+		symlinkSync("../openclaw-gateway.service", enablementPath);
 		writeFileSync(gatewayEnvironment, "PREVIOUS_OFFICIAL_STATE=1\n");
 		for (const path of [appRoot, binDir]) {
 			chownSync(path, 0, 0);
 			chmodSync(path, 0o700);
 		}
-		for (const path of [commandPath, unitPath, unitBackupPath, gatewayEnvironment]) {
+		for (const path of [commandPath, ...platformOwnedPaths]) {
+			if (lstatSync(path).isSymbolicLink()) continue;
 			chownSync(path, 0, 0);
 			chmodSync(path, 0o700);
 		}
+		for (const path of [enablementPath]) lchownSync(path, 0, 0);
 		chmodSync(unitPath, 0o600);
 		chmodSync(unitBackupPath, 0o600);
+		chmodSync(dropInPath, 0o600);
 		chmodSync(gatewayEnvironment, 0o600);
 
 		process.env.CLAWDI_RUNTIME_USER = "clawdi";
@@ -5875,24 +5896,37 @@ printf '{"ok":true}\\n'
 			},
 			resolveUserIdentity: () => ({ uid: runtimeUid, gid: runtimeGid }),
 		};
+		let skillProjectionObserved = false;
 		const openClawSkillDriver = {
 			...hostedOpenClawSkillDriver,
 			resolveWorkspace: () => join(appRoot, "workspace"),
-		};
-		const manifest = baseManifest(paths, {
-			openclaw: {
-				enabled: true,
-				install: {
-					authority: "official",
-					method: "official-installer",
-					url: OFFICIAL_INSTALL_URLS.openclaw,
-					home: paths.userHome,
-					args: officialInstallArgs("openclaw", paths.userHome),
-				},
-				run: runSettings(commandPath, ["gateway", "run"]),
-				services: {},
+			install: () => {
+				skillProjectionObserved = true;
+				for (const path of platformOwnedPaths) {
+					const node = lstatSync(path);
+					expect([node.uid, node.gid]).toEqual([0, 0]);
+				}
+				throw new ManagedSkillResourceError("injected Skill projection stop");
 			},
-		});
+		};
+		const manifest = baseManifest(
+			paths,
+			{
+				openclaw: {
+					enabled: true,
+					install: {
+						authority: "official",
+						method: "official-installer",
+						url: OFFICIAL_INSTALL_URLS.openclaw,
+						home: paths.userHome,
+						args: officialInstallArgs("openclaw", paths.userHome),
+					},
+					run: runSettings(commandPath, ["gateway", "run"]),
+					services: {},
+				},
+			},
+			{ projection: { skills: { entries: { clawdi: { enabled: true, version: 1 } } } } },
+		);
 
 		const result = convergeRuntimeManifest(
 			manifestLoad(manifest, "root-openclaw-ownership"),
@@ -5904,9 +5938,15 @@ printf '{"ok":true}\\n'
 			},
 		);
 		expect(result.installErrors).toEqual([]);
+		expect(result.resourceProjectionErrors.join("\n")).toContain("injected Skill projection stop");
+		expect(skillProjectionObserved).toBe(true);
 		for (const path of runtimeOwnedPaths) {
-			const node = statSync(path);
+			const node = lstatSync(path);
 			expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
+		}
+		for (const path of platformOwnedPaths) {
+			const node = lstatSync(path);
+			expect([node.uid, node.gid]).toEqual([0, 0]);
 		}
 		expect(statSync(appRoot).mode & 0o777).toBe(0o700);
 		expect(statSync(commandPath).mode & 0o777).toBe(0o700);
@@ -5916,32 +5956,51 @@ printf '{"ok":true}\\n'
 		]);
 		expect(statSync(paths.daemonAuthToken).mode & 0o777).toBe(0o600);
 
-		const installed = execFileSync(
-			numericPrivilegeToolPath,
-			[
-				`--reuid=${runtimeUid}`,
-				`--regid=${runtimeGid}`,
-				"--clear-groups",
-				"env",
-				`HOME=${paths.userHome}`,
-				"OPENCLAW_SYSTEMD_UNIT=openclaw-gateway.service",
-				commandPath,
-				"gateway",
-				"install",
-				"--force",
-				"--json",
-			],
-			{ cwd: paths.userHome, encoding: "utf8" },
+		let installerBoundaryObserved = false;
+		const installed = convergeRuntimeManifest(
+			manifestLoad({ ...manifest, generation: 2 }, "root-openclaw-installer-boundary"),
+			paths,
+			{
+				hostedRuntimeContract,
+				hostedOpenClawSkillDriver: openClawSkillDriver,
+				systemdApply: {
+					quiesce: () => {},
+					activateEgressPrerequisite: successfulPrerequisiteActivation,
+					installOfficialService: (_unitName, install) => {
+						installerBoundaryObserved = true;
+						for (const path of [
+							paths.systemdUserRoot,
+							unitPath,
+							unitBackupPath,
+							gatewayEnvironment,
+							wantsRoot,
+							enablementPath,
+						]) {
+							const node = lstatSync(path);
+							expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
+						}
+						for (const path of [dirname(dropInPath), dropInPath]) {
+							const node = lstatSync(path);
+							expect([node.uid, node.gid]).toEqual([0, 0]);
+						}
+						return install();
+					},
+					activate: successfulPrerequisiteActivation,
+					rollback: () => {},
+				},
+			},
 		);
-		expect(JSON.parse(installed)).toEqual({ ok: true });
-		expect(statSync(unitPath).uid).toBe(runtimeUid);
-		expect(statSync(unitBackupPath).uid).toBe(runtimeUid);
-		expect(statSync(gatewayEnvironment).uid).toBe(runtimeUid);
+		expect(installed.installErrors).toEqual([]);
+		expect(installerBoundaryObserved).toBe(true);
+		for (const path of platformOwnedPaths) {
+			const node = lstatSync(path);
+			expect([node.uid, node.gid]).toEqual([0, 0]);
+		}
 		expect(statSync(gatewayEnvironment).mode & 0o777).toBe(0o600);
 
 		for (const path of runtimeOwnedPaths) chownSync(path, 0, 0);
 		const beforeRollback = new Map(
-			runtimeOwnedPaths.map(
+			[...runtimeOwnedPaths, ...platformOwnedPaths].map(
 				(path) =>
 					[
 						path,
@@ -5953,7 +6012,7 @@ printf '{"ok":true}\\n'
 			),
 		);
 		const failed = convergeRuntimeManifest(
-			manifestLoad({ ...manifest, generation: 2 }, "root-openclaw-ownership-rollback"),
+			manifestLoad({ ...manifest, generation: 3 }, "root-openclaw-ownership-rollback"),
 			paths,
 			{
 				cacheLastGood: false,
@@ -5967,8 +6026,9 @@ printf '{"ok":true}\\n'
 		);
 		expect(failed.installErrors.join("\n")).toContain("injected ownership commit failure");
 		for (const [path, previous] of beforeRollback) {
-			const node = statSync(path);
-			expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
+			const node = lstatSync(path);
+			const expectedOwner = platformOwnedPaths.includes(path) ? [0, 0] : [runtimeUid, runtimeGid];
+			expect([node.uid, node.gid]).toEqual(expectedOwner);
 			expect(node.mode & 0o777).toBe(previous.mode);
 			if (previous.content) expect(readFileSync(path)).toEqual(previous.content);
 		}

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
 	chmodSync,
 	existsSync,
+	lstatSync,
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
@@ -17,8 +19,9 @@ import {
 	type TestConvergeOptions,
 	withTestSystemdTransaction,
 } from "../test-support/systemd-apply";
+import { runtimeContentSha256 } from "./applied-state";
 import { hostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
-import { readRuntimeInstallReceipts } from "./install-receipts";
+import { readRuntimeInstallReceipts, writeRuntimeInstallReceipts } from "./install-receipts";
 import {
 	convergeRuntimeManifest as convergeRuntimeManifestWithContext,
 	type RuntimeManifest,
@@ -26,6 +29,7 @@ import {
 import { manifestSecretRefs, type RuntimeManifestLoad } from "./manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
+import { runtimeCommandCurrentRevision } from "./runtime-systemd-reconciliation";
 import { ensureRuntimeStateDirs } from "./state";
 
 const originalEnv = { ...process.env };
@@ -298,7 +302,9 @@ interface InstallGateHarness {
 
 interface OfficialServiceInstallHarness extends InstallGateHarness {
 	addForeignDropIn: () => string;
+	driftMetadata: () => void;
 	hangVersionProbe: () => void;
+	stageLegacyReceipt: () => unknown;
 }
 
 function officialServiceHarness(
@@ -311,6 +317,7 @@ function officialServiceHarness(
 			? join(paths.userHome, ".local", "bin", "openclaw")
 			: join(paths.userHome, ".local", "bin", "hermes");
 	const unitPath = join(paths.systemdUserRoot, `${runtime}-gateway.service`);
+	const unitName = `${runtime}-gateway.service`;
 	const systemctlCommand = join(paths.runRoot, "bin", "systemctl");
 	process.env.CLAWDI_SYSTEMCTL_PATH = systemctlCommand;
 	writeFakeSystemctl({ path: systemctlCommand, logPath });
@@ -338,7 +345,7 @@ function officialServiceHarness(
 				...(commitAuthority ? { commitAuthority } : {}),
 				executeOfficialServiceInstallers: true,
 			}),
-		drift: () => chmodSync(unitPath, 0o600),
+		drift: () => writeFileSync(unitPath, `${readFileSync(unitPath, "utf8")}# drift\n`),
 		revise: () =>
 			writeCli(false, runtime === "hermes" ? "Hermes Agent v0.18.1" : "OpenClaw 2026.7.30"),
 		failNextInstall: () => writeCli(true),
@@ -346,8 +353,7 @@ function officialServiceHarness(
 		installCount: () =>
 			readFileSync(logPath, "utf8").match(new RegExp(`${runtime} gateway install`, "g"))?.length ??
 			0,
-		receipt: () =>
-			readRuntimeInstallReceipts(paths)?.officialServices[`${runtime}-gateway.service`],
+		receipt: () => readRuntimeInstallReceipts(paths)?.officialServices[unitName],
 		addForeignDropIn: () => {
 			const path = join(
 				paths.systemdUserRoot,
@@ -358,8 +364,34 @@ function officialServiceHarness(
 			writeFileSync(path, "[Service]\nExecStart=\nExecStart=/usr/bin/false\n");
 			return path;
 		},
+		driftMetadata: () => chmodSync(unitPath, 0o600),
 		hangVersionProbe: () =>
 			writeFakeGatewayCli({ path: command, logPath, runtime, unitPath, hangVersion: true }),
+		stageLegacyReceipt: () => {
+			const receipts = readRuntimeInstallReceipts(paths);
+			const receipt = receipts?.officialServices[unitName];
+			if (!receipts || !receipt) throw new Error("official service receipt is unavailable");
+			const canonicalReceipt = structuredClone(receipt);
+			const commandRevision = runtimeCommandCurrentRevision(
+				command,
+				paths.userHome,
+				paths.userHome,
+			);
+			if (!commandRevision) throw new Error("official service command revision is unavailable");
+			const unit = readFileSync(unitPath);
+			const unitStat = lstatSync(unitPath);
+			receipt.currentRevision = runtimeContentSha256({
+				commandRevision,
+				programName: `${runtime}-gateway`,
+				unitName,
+				unitSha256: createHash("sha256").update(unit).digest("hex"),
+				unitMode: unitStat.mode & 0o7777,
+				unitUid: unitStat.uid,
+				unitGid: unitStat.gid,
+			});
+			writeRuntimeInstallReceipts(receipts, paths);
+			return canonicalReceipt;
+		},
 	};
 }
 
@@ -1409,6 +1441,37 @@ esac
 			expect(harness.installCount()).toBe(2);
 		},
 	);
+
+	test.each([
+		["Hermes", "hermes"],
+		["OpenClaw", "openclaw"],
+	] as const)("does not reinstall %s for service metadata drift", (_name, runtime) => {
+		const harness = officialServiceHarness(runtime);
+		expect(harness.converge().installErrors).toEqual([]);
+		expect(harness.installCount()).toBe(1);
+		const receipt = harness.receipt();
+
+		harness.driftMetadata();
+		expect(harness.converge().installErrors).toEqual([]);
+
+		expect(harness.installCount()).toBe(1);
+		expect(harness.receipt()).toEqual(receipt);
+	});
+
+	test.each([
+		["Hermes", "hermes"],
+		["OpenClaw", "openclaw"],
+	] as const)("migrates a legacy %s service receipt without reinstalling", (_name, runtime) => {
+		const harness = officialServiceHarness(runtime);
+		expect(harness.converge().installErrors).toEqual([]);
+		const canonicalReceipt = harness.stageLegacyReceipt();
+		expect(harness.receipt()).not.toEqual(canonicalReceipt);
+
+		expect(harness.converge().installErrors).toEqual([]);
+
+		expect(harness.installCount()).toBe(1);
+		expect(harness.receipt()).toEqual(canonicalReceipt);
+	});
 
 	test.each(installGateHarnesses)(
 		"rolls back the %s receipt when authority commit fails",

--- a/packages/cli/src/runtime/manifest-skills-apply.ts
+++ b/packages/cli/src/runtime/manifest-skills-apply.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import {
 	claimLegacyHostedBundledSkill,
@@ -13,6 +13,7 @@ import {
 } from "./hosted-sourced-skill-archive";
 import {
 	ManagedSkillResourceError,
+	managedSkillReceiptPath,
 	migrateLegacyManagedSkillReceiptDirectory,
 } from "./managed-skill-delivery";
 import {
@@ -20,6 +21,9 @@ import {
 	type ManagedSkillReservationSnapshot,
 	managedSkillReservationOwner,
 	managedSkillReservations,
+	type PendingManagedSkillReservationSnapshot,
+	pendingManagedSkillReservations,
+	recoverPendingManagedSkillInstallation,
 	releaseManagedSkill,
 	reserveManagedSkill,
 } from "./managed-skill-reservation";
@@ -46,7 +50,7 @@ interface HostedSkillProjectionDriver {
 		previouslyReserved: boolean,
 	): "installed" | "unchanged";
 	anchorOwnership(skillId: string, ownershipIdentity: string, targetDir: string): void;
-	hasOwnershipReceipt(skill: PreparedHostedSourcedSkill, targetDir: string): boolean;
+	verifyOwned(skill: PreparedHostedSourcedSkill, targetDir: string): boolean;
 	remove(reservation: ManagedSkillReservationSnapshot): void;
 }
 function preparedSkillMatchesDesired(
@@ -132,12 +136,12 @@ function hostedSkillProjectionDrivers(input: {
 					ownershipIdentity,
 					targetDir,
 				}),
-			hasOwnershipReceipt: (skill, targetDir) =>
-				input.hermesDriver.hasOwnershipReceipt({
+			verifyOwned: (skill, targetDir) =>
+				input.hermesDriver.verifyOwned({
 					home: input.home,
+					appRoot,
 					managedResourceRoot: input.managedResourceRoot,
-					skillId: skill.skillId,
-					ownershipIdentity: skill.sourceIdentity,
+					skill,
 					targetDir,
 				}),
 			remove: (reservation) => {
@@ -196,13 +200,12 @@ function hostedSkillProjectionDrivers(input: {
 					ownershipIdentity,
 				});
 			},
-			hasOwnershipReceipt: (skill, _targetDir) => {
+			verifyOwned: (skill, _targetDir) => {
 				if (!input.openClawWorkspaceRoot) return false;
-				return input.openClawDriver.hasOwnershipReceipt({
+				return input.openClawDriver.verifyOwned({
 					workspaceRoot: input.openClawWorkspaceRoot,
 					managedResourceRoot: input.managedResourceRoot,
-					skillId: skill.skillId,
-					ownershipIdentity: skill.sourceIdentity,
+					skill,
 				});
 			},
 			remove: (reservation) => {
@@ -258,6 +261,67 @@ export function migrateLegacyHostedSkillReceipts(input: {
 		});
 	}
 }
+
+function pendingReservationMatchesPrepared(
+	reservation: PendingManagedSkillReservationSnapshot,
+	skill: PreparedHostedSourcedSkill,
+): boolean {
+	const identity = preparedReservationIdentity(skill);
+	return (
+		reservation.id === skill.skillId &&
+		reservation.version === identity.version &&
+		reservation.digest === identity.digest &&
+		reservation.sourceIdentity === identity.sourceIdentity
+	);
+}
+
+function discardPendingHostedSkill(
+	driver: HostedSkillProjectionDriver,
+	managedResourceRoot: string,
+	skillId: string,
+	targetDir: string,
+): void {
+	withRuntimeUserFileAccess(() => rmSync(targetDir, { recursive: true, force: true }));
+	rmSync(managedSkillReceiptPath(managedResourceRoot, driver.name, skillId), { force: true });
+}
+
+function recoverPendingHostedSkillInstallations(
+	driver: HostedSkillProjectionDriver,
+	manifest: RuntimeManifest,
+	managedResourceRoot: string,
+	preparedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
+): void {
+	if (!hostedBundledSkillsEnabled() || !driver.skillsRoot) return;
+	const desiredEntries = manifest.projection?.skills?.entries ?? {};
+	const pendingReservations = pendingManagedSkillReservations("hosted-manifest").filter(
+		(reservation) => dirname(reservation.targetDir) === driver.skillsRoot,
+	);
+	for (const reservation of pendingReservations) {
+		const desired = desiredEntries[reservation.id];
+		const prepared = preparedSkills.get(reservation.id);
+		const promotable =
+			driver.enabled &&
+			desired?.enabled === true &&
+			preparedSkillMatchesDesired(prepared, desired, reservation.id) &&
+			pendingReservationMatchesPrepared(reservation, prepared)
+				? prepared
+				: null;
+		recoverPendingManagedSkillInstallation({
+			targetDir: reservation.targetDir,
+			id: reservation.id,
+			manager: "hosted-manifest",
+			verify: () => promotable !== null && driver.verifyOwned(promotable, reservation.targetDir),
+			discard: () =>
+				discardPendingHostedSkill(
+					driver,
+					managedResourceRoot,
+					reservation.id,
+					reservation.targetDir,
+				),
+		});
+	}
+}
+
 function recoverHostedSkillReservations(
 	driver: HostedSkillProjectionDriver,
 	manifest: RuntimeManifest,
@@ -305,7 +369,7 @@ function recoverHostedSkillReservations(
 		if (
 			!withRuntimeUserFileAccess(() => existsSync(targetDir)) ||
 			managedSkillReservationOwner(targetDir, skillId) !== "unreserved" ||
-			!driver.hasOwnershipReceipt(prepared, targetDir)
+			!driver.verifyOwned(prepared, targetDir)
 		) {
 			continue;
 		}
@@ -355,6 +419,7 @@ function applyHostedSkills(
 	driver: HostedSkillProjectionDriver,
 	observation: RuntimeInstallObservation | undefined,
 	manifest: RuntimeManifest,
+	managedResourceRoot: string,
 	preparedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
 ): string[] {
 	if (!hostedBundledSkillsEnabled() || !driver.skillsRoot) return [];
@@ -424,6 +489,10 @@ function applyHostedSkills(
 				() => {
 					return driver.install(prepared, targetDir, reservation !== undefined);
 				},
+				{
+					verify: () => driver.verifyOwned(prepared, targetDir),
+					discard: () => discardPendingHostedSkill(driver, managedResourceRoot, skillId, targetDir),
+				},
 			);
 		} catch (error) {
 			if (!(error instanceof ManagedSkillResourceError)) throw error;
@@ -472,6 +541,7 @@ export function reconcileHostedSkillProjection(input: {
 	});
 	runHostedSkillProjectionStep("runtime Skill projection planning failed", () => {
 		for (const driver of drivers) {
+			recoverPendingHostedSkillInstallations(driver, manifest, managedResourceRoot, preparedSkills);
 			recoverHostedSkillReservations(driver, manifest, preparedSkills);
 			validateHostedSkillsPlan(driver, manifest, preparedSkills);
 		}
@@ -480,7 +550,14 @@ export function reconcileHostedSkillProjection(input: {
 	for (const driver of drivers) {
 		const driverFailures = runHostedSkillProjectionStep(
 			`runtime ${driver.name} Skill projection failed`,
-			() => applyHostedSkills(driver, observations.get(driver.name), manifest, preparedSkills),
+			() =>
+				applyHostedSkills(
+					driver,
+					observations.get(driver.name),
+					manifest,
+					managedResourceRoot,
+					preparedSkills,
+				),
 		);
 		failures.push(
 			...driverFailures.map(

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -583,10 +583,15 @@ export function runtimeCommandCurrentRevisionCached(
 	return revision;
 }
 
-function officialServiceCurrentRevision(
+interface OfficialServiceCurrentRevisions {
+	canonical: string;
+	legacyMetadataAware: string;
+}
+
+function officialServiceCurrentRevisions(
 	program: RuntimeSystemdUserProgram,
 	paths: RuntimePaths,
-): string | null {
+): OfficialServiceCurrentRevisions | null {
 	const descriptor = officialRuntimeServiceDescriptorForProgram(program);
 	if (!descriptor) return null;
 	const unitName = systemdUnitFileName(descriptor.programName);
@@ -602,15 +607,21 @@ function officialServiceCurrentRevision(
 			paths.userHome,
 		);
 		if (!commandRevision) return null;
-		return runtimeContentSha256({
+		const contentIdentity = {
 			commandRevision,
 			programName: descriptor.programName,
 			unitName,
 			unitSha256: createHash("sha256").update(contents).digest("hex"),
-			unitMode: unitStat.mode & 0o7777,
-			unitUid: unitStat.uid,
-			unitGid: unitStat.gid,
-		});
+		};
+		return {
+			canonical: runtimeContentSha256(contentIdentity),
+			legacyMetadataAware: runtimeContentSha256({
+				...contentIdentity,
+				unitMode: unitStat.mode & 0o7777,
+				unitUid: unitStat.uid,
+				unitGid: unitStat.gid,
+			}),
+		};
 	} catch (error) {
 		if (error instanceof RuntimeUserCommandTimeoutError) throw error;
 		return null;
@@ -632,11 +643,17 @@ function officialServiceDesiredRevision(program: RuntimeSystemdUserProgram): str
 function verifiedReceiptCurrentRevision(
 	receipt: RuntimeInstallReceiptEntry | undefined,
 	desiredRevision: string,
-	currentRevision: () => string | null,
+	currentRevisions: () => OfficialServiceCurrentRevisions | null,
 ): string | null {
 	if (!receipt || receipt.desiredRevision !== desiredRevision) return null;
-	const current = currentRevision();
-	return current === receipt.currentRevision ? current : null;
+	const current = currentRevisions();
+	if (!current) return null;
+	// Pre-content-only receipts included unit ownership and mode. Accept them
+	// once, then commit the canonical content revision without reinstalling.
+	return receipt.currentRevision === current.canonical ||
+		receipt.currentRevision === current.legacyMetadataAware
+		? current.canonical
+		: null;
 }
 
 export function planOfficialRuntimeServices(
@@ -651,11 +668,12 @@ export function planOfficialRuntimeServices(
 	for (const program of officialRuntimeSystemdPrograms(programs)) {
 		const key = systemdUnitFileName(runtimeSystemdProgramName(program));
 		const desiredRevision = officialServiceDesiredRevision(program);
-		const currentRevision = () => officialServiceCurrentRevision(program, paths);
+		const currentRevisions = () => officialServiceCurrentRevisions(program, paths);
+		const currentRevision = () => currentRevisions()?.canonical ?? null;
 		const expectedCurrentRevision = verifiedReceiptCurrentRevision(
 			receipts?.officialServices[key],
 			desiredRevision,
-			currentRevision,
+			currentRevisions,
 		);
 		const target = { desiredRevision, currentRevision, expectedCurrentRevision };
 		targets.set(key, target);

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -753,6 +753,7 @@ function writeSystemdProgramEnvironment(input: {
 function writeSystemdUnit(input: {
 	root: string;
 	owner: "root" | "runtime-user";
+	unitOwner?: "root" | "runtime-user";
 	paths: RuntimePaths;
 	name: string;
 	description: string;
@@ -772,6 +773,7 @@ function writeSystemdUnit(input: {
 	wantedBy: "multi-user.target" | "default.target";
 }): string {
 	const path = join(input.root, systemdUnitFileName(input.name));
+	const unitOwner = input.unitOwner ?? input.owner;
 	const { envFile, envRevision } = writeSystemdProgramEnvironment({
 		paths: input.paths,
 		name: input.name,
@@ -832,20 +834,18 @@ function writeSystemdUnit(input: {
 	];
 	const writeUnitFile = (): string => {
 		ensureDirectoryWithinTrustedRoot(input.root, input.root);
-		if (input.owner === "runtime-user") makeRuntimeUserOwned(input.root);
+		if (unitOwner === "runtime-user") makeRuntimeUserOwned(input.root);
 		writeSystemdManagedFile({
 			path,
 			content: lines.join("\n"),
 			mode: 0o644,
 			dirMode: 0o755,
 			trustedRoot: input.root,
-			owner: input.owner,
+			owner: unitOwner,
 		});
 		return path;
 	};
-	return input.owner === "runtime-user"
-		? withRuntimeUserFileAccess(writeUnitFile)
-		: writeUnitFile();
+	return unitOwner === "runtime-user" ? withRuntimeUserFileAccess(writeUnitFile) : writeUnitFile();
 }
 
 function writeSystemdSystemUnit(
@@ -866,6 +866,7 @@ function writeSystemdUserUnit(
 		...input,
 		root: input.paths.systemdUserRoot,
 		owner: "runtime-user",
+		unitOwner: "root",
 		wantedBy: "default.target",
 	});
 }
@@ -900,20 +901,17 @@ function writeSystemdUserEnvironmentDropIn(input: {
 		`EnvironmentFile=${systemdPath(envFile)}`,
 		"",
 	];
-	return withRuntimeUserFileAccess(() => {
-		removeGeneratedRuntimeBaseUnit(input.paths, unitName);
-		ensureDirectoryWithinTrustedRoot(input.paths.systemdUserRoot, dirname(path));
-		makeRuntimeUserOwned(dirname(path));
-		writeSystemdManagedFile({
-			path,
-			content: lines.join("\n"),
-			mode: 0o644,
-			dirMode: 0o755,
-			trustedRoot: input.paths.systemdUserRoot,
-			owner: "runtime-user",
-		});
-		return join(input.paths.systemdUserRoot, unitName);
+	removeGeneratedRuntimeBaseUnit(input.paths, unitName);
+	ensureDirectoryWithinTrustedRoot(input.paths.systemdUserRoot, dirname(path));
+	writeSystemdManagedFile({
+		path,
+		content: lines.join("\n"),
+		mode: 0o644,
+		dirMode: 0o755,
+		trustedRoot: input.paths.systemdUserRoot,
+		owner: "root",
 	});
+	return join(input.paths.systemdUserRoot, unitName);
 }
 
 function removeGeneratedRuntimeBaseUnit(paths: RuntimePaths, unitName: string): void {

--- a/packages/cli/src/test-support/systemd-apply.ts
+++ b/packages/cli/src/test-support/systemd-apply.ts
@@ -6,7 +6,9 @@ type SystemdApplyHooks = NonNullable<ConvergeOptions["systemdApply"]>;
 export type TestSystemdApplyHooks = Omit<
 	SystemdApplyHooks,
 	"installOfficialService" | "transactionState"
->;
+> & {
+	installOfficialService?: SystemdApplyHooks["installOfficialService"];
+};
 
 export type TestConvergeOptions = Omit<ConvergeOptions, "systemdApply"> & {
 	systemdApply?: TestSystemdApplyHooks;
@@ -17,9 +19,9 @@ export function withTestSystemdTransaction(hooks: TestSystemdApplyHooks): System
 	return {
 		...hooks,
 		transactionState: () => (mutated ? "mutated" : "pristine"),
-		installOfficialService: (_unit, install) => {
+		installOfficialService: (unit, install) => {
 			mutated = true;
-			return install();
+			return hooks.installOfficialService ? hooks.installOfficialService(unit, install) : install();
 		},
 		activateEgressPrerequisite: (signal) => {
 			mutated = true;

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -1651,6 +1651,10 @@ esac
 		);
 		expect(initialPid).toBeGreaterThan(1);
 		expect(runUserSystemctl("is-enabled", unitName).stdout.trim()).toBe("enabled");
+		for (const path of [paths.systemdUserRoot, unitPath, dropInRoot, enablementPath]) {
+			const node = lstatSync(path);
+			expect([node.uid, node.gid]).toEqual([0, 0]);
+		}
 
 		chmodSync(unitPath, 0o600);
 		chownTreeWithoutFollowingLinks(paths.systemdUserRoot, runtimeUid, runtimeGid);
@@ -1661,7 +1665,7 @@ esac
 
 		const repaired = converge();
 		expect(repaired.installErrors).toEqual([]);
-		expect(readFileSync(installLog, "utf8").trim().split("\n")).toEqual(["install", "install"]);
+		expect(readFileSync(installLog, "utf8").trim().split("\n")).toEqual(["install"]);
 		for (const path of [paths.systemdUserRoot, unitPath, dropInRoot, enablementPath]) {
 			const node = lstatSync(path);
 			expect([node.uid, node.gid]).toEqual([0, 0]);

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -24,6 +24,7 @@ import {
 	resolveOpenClawSdkExport as resolveSdk,
 	OPENCLAW_SDK_EXPORT_PATHS as SDK_EXPORTS,
 } from "../../src/lib/codex-oauth-native-store";
+import { hostedOpenClawSkillDriver } from "../../src/runtime/hosted-openclaw-skill";
 import { hostedAiProviderCatalog } from "../../src/runtime/hosted-provider-resolution";
 import {
 	buildOpenClawHostedProviderPatch,
@@ -285,6 +286,12 @@ test("propagates the real official OpenClaw installer failure and rolls back as 
 	const result = convergeRuntimeManifest(load, paths, {
 		executeOfficialServiceInstallers: true,
 		cacheLastGood: false,
+		// This case exercises installer rollback; live roster behavior is covered
+		// by the full OpenClaw projection cases below.
+		hostedOpenClawSkillDriver: {
+			...hostedOpenClawSkillDriver,
+			resolveWorkspace: () => openClawWorkspaceRoot,
+		},
 		commitAuthority: () => {
 			authorityCommits += 1;
 		},


### PR DESCRIPTION
## Summary

- Keep the systemd user-manager enclave root-owned throughout convergence, except for the exact official service-installer critical section.
- Keep provisional managed Skill reservations out of committed ownership state and promote them only after the installed tree and receipt are verified.
- Recover crash-interrupted Skill installs at the start of convergence by promoting complete installs or discarding incomplete targets and receipts before retrying.
- Keep systemd ownership repairs metadata-only: they never invoke an official service installer.

## Ninth-round evidence

The ninth round of on-host evidence exposed both failures when the first sourced Skill installation made the convergence window materially longer:

1. Generic runtime-user ownership staging included the systemd unit, symlink, drop-in, and directory nodes. They became tenant-owned before Skill projection and were only restored to root during activation.
2. `installReservedManagedSkill` wrote a provisional reservation into committed `managed-skills.json` before invoking the official installer. An upgrade re-exec or process death bypassed the exception cleanup and left an orphaned committed reservation.

These are the same transaction-boundary bug: an intermediate state was published as committed state for the duration of a long external operation.

## Fix

### Root-owned systemd enclave

Systemd enclave nodes remain in rollback snapshots but are excluded from generic runtime-user ownership staging. Clawdi-authored units and drop-ins remain root-owned. The official service installer receives tenant ownership only for the exact nodes it needs, and a `finally` block immediately restores root ownership and the manager-readable modes.

This composes with the existing manager-access repair from #1156: steady state is root ownership plus the required read bits, with no tenant-owned window outside the installer critical section.

### Installer-free metadata repair

The full-order privileged CI run exposed a remaining environment-sensitive classifier: official service receipts included the base unit's UID, GID, and mode. A pure ownership or permission repair could therefore be classified as service-content drift and rerun the official installer.

Official service canonical revisions now bind only the runtime command revision and base-unit bytes. Legacy metadata-aware receipts are accepted once and atomically migrated to the canonical content revision without reinstalling. Real command or unit-content drift remains fail-closed and still invokes the installer exactly once.

### Verified managed Skill reservations

The ledger now separates `pendingReservations` from committed `reservations`; owner checks and user-skill scanning only recognize committed entries. Installation writes pending state first, verifies the full installed tree and ownership receipt, then atomically moves the entry into committed state in one ledger write.

At convergence start, pending hosted installs are verified against current desired state. Complete tree-plus-receipt installs are promoted; incomplete or stale installs have their provisional target and receipt removed before the normal retry. Legacy receipt recovery also requires full ownership verification rather than receipt presence alone.

## #1166 compatibility

This branch is rebased onto `main` after #1166. The pending-reservation flow uses the new local Hermes Skill layout (`~/.hermes/skills/<skillId>`) and passes `appRoot` to the updated `HostedHermesSkillExactSourceDriver` install, verification, recovery, and uninstall paths. No removed loopback-module references remain.

## Transaction invariant

Intermediate state must not enter committed state. Transaction boundaries are narrowed to the smallest external-operation critical section, and steady-state invariants hold throughout convergence rather than only at its end:

- the systemd enclave is root-owned outside the official installer critical section;
- official service install decisions depend on service content, not ownership-repair metadata;
- committed managed Skill reservations describe verified tree-plus-receipt installations only.

## Verification

- Repository-pinned Biome: pass
- CLI typecheck: pass
- Focused Skill, mutation-parity, reconciliation, and official-service suites: 248 pass, 0 fail
- Docker clean runner / full CLI `test:internal` on Bun 1.4.0: 1763 pass, 4 skip, 0 fail
- Privileged real-systemd e2e on Bun 1.4.0, full CI order: 5 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
