### PR TITLE
release(cli): 0.14.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.9
+
+Package: `clawdi@0.14.9`
+
+### Fixed
+
+- Hosted Hermes skills now install by placing the verified bytes directly into
+  Hermes's official local skills directory — the same mechanism the bundled
+  skill has always used — instead of driving `hermes skills install` over a
+  loopback URL. This removes the installer's scanner, naming, and
+  reference-fetch failure modes entirely.
+- Repairing drifted ownership no longer re-runs official service installers:
+  install receipts are bound to content only, not ownership metadata.
+- Platform enclaves stay root-owned at all times outside installer critical
+  sections, and skill reservations are recorded only after a verified install.
+
 ## Clawdi CLI v0.14.8
 
 Package: `clawdi@0.14.8`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.8",
+      "version": "0.14.9",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.8",
+	"version": "0.14.9",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Release `clawdi@0.14.9` — the unification release (#1166, #1165).

- Hermes managed skills now install via Hermes's official local-skills discovery surface (atomic placement of digest-verified bytes — the mechanism the bundled skill has always used), deleting the loopback source, lock anchoring, and CLI-install pipeline (net −863 lines). Verified against real Hermes 0.20.4: a dangerous-verdict fixture that hub install blocks works as a local skill, listed and usable, cleanly removable.
- Ownership-drift repair is metadata-only end to end: service install receipts bind to command + unit bytes (not uid/gid/mode), platform enclaves stay root outside installer critical sections, and reservations are recorded only after verified installs (pending state is never authoritative).

Tenth canary round follows: pass bar is the full 15-skill desired set installed, five consecutive clean cycles, and full forensics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)