### PR TITLE
fix(cli): migrate legacy Hermes loopback hub installs

### DIFF
--- a/packages/cli/src/runtime/hosted-hermes-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
+	chmodSync,
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
@@ -21,6 +22,7 @@ let root: string | null = null;
 
 afterEach(() => {
 	delete process.env.CLAWDI_RUNTIME_USER;
+	delete process.env.FAKE_HERMES_LOG;
 	if (root) rmSync(root, { recursive: true, force: true });
 	root = null;
 });
@@ -112,6 +114,35 @@ function fakeHermesLocalSkills(home: string): Array<{
 			const name = /^---\s*\n[\s\S]*?^name:\s*([^\n]+)$/m.exec(content)?.[1]?.trim();
 			return [{ name: name || entry.name, source: "local", trust: "local", status: "enabled" }];
 		});
+}
+
+function fakeHermesUninstaller(home: string): string {
+	const appRoot = join(home, ".hermes", "hermes-agent");
+	const hermes = join(appRoot, "venv", "bin", "hermes");
+	mkdirSync(dirname(hermes), { recursive: true });
+	writeFileSync(
+		hermes,
+		`#!/usr/bin/python3
+import json, os, shutil, sys
+from pathlib import Path
+
+if sys.argv[1:3] != ["skills", "uninstall"] or len(sys.argv) != 4:
+    raise SystemExit(2)
+if sys.stdin.readline().strip().lower() not in {"y", "yes"}:
+    raise SystemExit(3)
+name = sys.argv[3]
+skills_root = Path(os.environ["HOME"]) / ".hermes" / "skills"
+shutil.rmtree(skills_root / name)
+lock_path = skills_root / ".hub" / "lock.json"
+lock = json.loads(lock_path.read_text())
+lock["installed"].pop(name, None)
+lock_path.write_text(json.dumps(lock, indent=2) + chr(10))
+with Path(os.environ["FAKE_HERMES_LOG"]).open("a") as log:
+    log.write(" ".join(sys.argv[1:]) + chr(10))
+`,
+	);
+	chmodSync(hermes, 0o755);
+	return appRoot;
 }
 
 describe("Hermes exact-source Workspace Skill driver", () => {
@@ -242,6 +273,84 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 				ownershipIdentity: updatedSkill.sourceIdentity,
 			}),
 		).toBe(true);
+	});
+
+	test("migrates an owned legacy loopback hub install to stable local discovery once", () => {
+		root = mkdtempSync(join(tmpdir(), "hosted-hermes-loopback-migration-"));
+		const home = join(root, "home");
+		const managedResourceRoot = join(root, "managed-resources");
+		mkdirSync(managedResourceRoot, { recursive: true });
+		const skillId = "review-pr";
+		const skillFiles = {
+			"SKILL.md": "---\nname: review-pr\n---\n# Review PR\n",
+			"references/guide.md": "Pinned guide bytes\n",
+		};
+		const archive = archiveSkill(root, skillId, skillFiles);
+		const skill = sourcedSkill(skillId, archive);
+		const target = join(home, ".hermes", "skills", skillId);
+		const input = {
+			home,
+			appRoot: join(home, ".hermes", "hermes-agent"),
+			managedResourceRoot,
+			skill,
+		};
+
+		expect(
+			hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: false }),
+		).toBe("installed");
+		const skillBytes = readFileSync(join(target, "SKILL.md"));
+		const guideBytes = readFileSync(join(target, "references", "guide.md"));
+		const lockPath = join(home, ".hermes", "skills", ".hub", "lock.json");
+		mkdirSync(dirname(lockPath), { recursive: true });
+		const externalEntry = {
+			source: "url",
+			identifier: "https://example.test/user-skill/SKILL.md",
+			install_path: "user-skill",
+		};
+		writeFileSync(
+			lockPath,
+			`${JSON.stringify({
+				version: 1,
+				installed: {
+					[skillId]: {
+						source: "url",
+						identifier: `http://127.0.0.1:43123/0${"a".repeat(64)}/SKILL.md`,
+						install_path: skillId,
+					},
+					"user-skill": externalEntry,
+				},
+			})}\n`,
+		);
+		const commandLog = join(root, "hermes.log");
+		process.env.FAKE_HERMES_LOG = commandLog;
+		input.appRoot = fakeHermesUninstaller(home);
+
+		expect(
+			hostedHermesSkillExactSourceDriver.install({
+				...input,
+				previouslyReserved: true,
+				previousTargetDir: target,
+				previousOwnershipIdentity: skill.sourceIdentity,
+			}),
+		).toBe("installed");
+		expect(readFileSync(join(target, "SKILL.md"))).toEqual(skillBytes);
+		expect(readFileSync(join(target, "references", "guide.md"))).toEqual(guideBytes);
+		expect(JSON.parse(readFileSync(lockPath, "utf8"))).toEqual({
+			version: 1,
+			installed: { "user-skill": externalEntry },
+		});
+		expect(fakeHermesLocalSkills(home)).toEqual([
+			{ name: skillId, source: "local", trust: "local", status: "enabled" },
+		]);
+		expect(readFileSync(commandLog, "utf8")).toBe(`skills uninstall ${skillId}\n`);
+
+		expect(hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: true })).toBe(
+			"unchanged",
+		);
+		expect(readFileSync(commandLog, "utf8")).toBe(`skills uninstall ${skillId}\n`);
+		expect(JSON.parse(readFileSync(lockPath, "utf8")).installed["user-skill"]).toEqual(
+			externalEntry,
+		);
 	});
 
 	test("preserves unreserved and locally changed targets", () => {

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -1,5 +1,5 @@
-import { existsSync, rmSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import {
 	collectManagedSkillTree,
@@ -15,7 +15,13 @@ import {
 	writeManagedSkillReceipt,
 } from "./managed-skill-delivery";
 import { replaceManagedSkillDirectoryAtomic } from "./managed-skill-reservation";
-import { withRuntimeUserFileAccess } from "./runtime-user-command";
+import {
+	executableExists,
+	spawnRuntimeUserCommand,
+	withRuntimeUserFileAccess,
+} from "./runtime-user-command";
+
+const HERMES_SKILL_COMMAND_TIMEOUT_MS = 120_000;
 
 export interface HostedHermesSkillExactSourceDriver {
 	target?(input: { home: string; skill: PreparedHostedSourcedSkill }): string;
@@ -26,6 +32,8 @@ export interface HostedHermesSkillExactSourceDriver {
 		skill: PreparedHostedSourcedSkill;
 		targetDir?: string;
 		previouslyReserved: boolean;
+		previousTargetDir?: string;
+		previousOwnershipIdentity?: string;
 	}): "installed" | "unchanged";
 	anchorOwnership(input: {
 		home: string;
@@ -72,6 +80,18 @@ function targetDir(home: string, skillId: string): string {
 	return join(home, ".hermes", "skills", skillId);
 }
 
+function commandPath(home: string, appRoot: string): string {
+	return withRuntimeUserFileAccess(() => {
+		for (const candidate of [
+			join(appRoot, "venv", "bin", "hermes"),
+			join(home, ".local", "bin", "hermes"),
+		]) {
+			if (executableExists(candidate)) return candidate;
+		}
+		throw new Error("installed Hermes Skill CLI is unavailable");
+	});
+}
+
 function receiptInput(
 	managedResourceRoot: string,
 	skillId: string,
@@ -99,6 +119,182 @@ function assertActivationMatchesSource(sourceDir: string, target: string): void 
 	}
 	if (!managedSkillTreesEqual(source.tree, installed.tree)) {
 		throw new ManagedSkillResourceError("Hermes Skill activation changed exact source bytes");
+	}
+}
+
+const HERMES_URL_SKILL_NAME_PATTERN = /^[a-z][a-z0-9_-]*$/;
+const HERMES_RESERVED_URL_SKILL_NAMES = new Set(["skill", "readme", "index", "unnamed-skill"]);
+
+function validHermesUrlSkillName(value: unknown): value is string {
+	if (typeof value !== "string") return false;
+	const candidate = value.trim().toLowerCase();
+	return (
+		candidate.length > 0 &&
+		!HERMES_RESERVED_URL_SKILL_NAMES.has(candidate) &&
+		HERMES_URL_SKILL_NAME_PATTERN.test(candidate)
+	);
+}
+
+function readHermesInstalledLock(home: string): {
+	skillsRoot: string;
+	installed: Record<string, unknown>;
+} | null {
+	const skillsRoot = resolve(home, ".hermes", "skills");
+	const lockPath = join(skillsRoot, ".hub", "lock.json");
+	if (!existsSync(lockPath)) return null;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(readFileSync(lockPath, "utf8"));
+	} catch {
+		throw new ManagedSkillResourceError("Hermes Skill lock is invalid");
+	}
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new ManagedSkillResourceError("Hermes Skill lock is invalid");
+	}
+	const lock = parsed as Record<string, unknown>;
+	if (
+		lock.version !== 1 ||
+		typeof lock.installed !== "object" ||
+		lock.installed === null ||
+		Array.isArray(lock.installed)
+	) {
+		throw new ManagedSkillResourceError("Hermes Skill lock is invalid");
+	}
+	return { skillsRoot, installed: lock.installed as Record<string, unknown> };
+}
+
+function hermesLockTarget(skillsRoot: string, name: string, installPath: unknown): string {
+	if (
+		!validHermesUrlSkillName(name) ||
+		typeof installPath !== "string" ||
+		installPath !== name ||
+		dirname(resolve(skillsRoot, installPath)) !== skillsRoot ||
+		basename(resolve(skillsRoot, installPath)) !== name
+	) {
+		throw new ManagedSkillResourceError("Hermes Skill lock install path is unsafe");
+	}
+	return join(skillsRoot, installPath);
+}
+
+function legacyLoopbackHubTarget(home: string, target: string): string | null {
+	const expected = resolve(target);
+	return withRuntimeUserFileAccess(() => {
+		const lock = readHermesInstalledLock(home);
+		if (!lock || dirname(expected) !== lock.skillsRoot) return null;
+		const name = basename(expected);
+		const entry = lock.installed[name];
+		if (typeof entry !== "object" || entry === null || Array.isArray(entry)) return null;
+		const record = entry as Record<string, unknown>;
+		if (record.source !== "url") return null;
+		if (typeof record.identifier !== "string") {
+			throw new ManagedSkillResourceError("Hermes Skill lock source is invalid");
+		}
+		let source: URL;
+		try {
+			source = new URL(record.identifier);
+		} catch {
+			throw new ManagedSkillResourceError("Hermes Skill lock source is invalid");
+		}
+		if (source.protocol !== "http:" || source.hostname !== "127.0.0.1") return null;
+		if (
+			source.href !== record.identifier ||
+			!source.port ||
+			Number(source.port) < 1 ||
+			source.username ||
+			source.password ||
+			source.search ||
+			source.hash ||
+			!/^\/0[a-f0-9]{64}\/SKILL\.md$/.test(source.pathname)
+		) {
+			throw new ManagedSkillResourceError("Hermes Skill lock source is invalid");
+		}
+		if (hermesLockTarget(lock.skillsRoot, name, record.install_path) !== expected) {
+			throw new ManagedSkillResourceError("Hermes Skill lock install path is unsafe");
+		}
+		let identityMatches = 0;
+		for (const value of Object.values(lock.installed)) {
+			if (typeof value !== "object" || value === null || Array.isArray(value)) continue;
+			const candidate = value as Record<string, unknown>;
+			if (candidate.identifier !== record.identifier) continue;
+			if (candidate.source !== "url") {
+				throw new ManagedSkillResourceError("Hermes Skill lock source is invalid");
+			}
+			identityMatches += 1;
+		}
+		if (identityMatches !== 1) {
+			throw new ManagedSkillResourceError("Hermes Skill lock source identity is ambiguous");
+		}
+		return expected;
+	});
+}
+
+function hermesLockHasTarget(home: string, target: string): boolean {
+	const expected = resolve(target);
+	return withRuntimeUserFileAccess(() => {
+		const lock = readHermesInstalledLock(home);
+		if (!lock || dirname(expected) !== lock.skillsRoot) return false;
+		return Object.hasOwn(lock.installed, basename(expected));
+	});
+}
+
+function runHermesUninstall(
+	input: { home: string; appRoot: string },
+	skillName: string,
+): ReturnType<typeof spawnRuntimeUserCommand> {
+	// Feed stdin for Hermes 0.20 variants that predate the --yes flag.
+	return spawnRuntimeUserCommand(
+		commandPath(input.home, input.appRoot),
+		["skills", "uninstall", skillName],
+		input.home,
+		input.appRoot,
+		{
+			input: "y\n",
+			timeoutMs: HERMES_SKILL_COMMAND_TIMEOUT_MS,
+			maxBufferBytes: 1024 * 1024,
+		},
+	);
+}
+
+function hermesCommandOutput(result: ReturnType<typeof runHermesUninstall>): string {
+	return [result.stderr, result.stdout]
+		.map((value) => String(value ?? "").trim())
+		.filter(Boolean)
+		.join("\n");
+}
+
+function migrateLegacyLoopbackHubInstall(input: {
+	home: string;
+	appRoot: string;
+	managedResourceRoot: string;
+	skillId: string;
+	ownershipIdentity: string;
+	target: string;
+}): void {
+	const receipt = receiptInput(
+		input.managedResourceRoot,
+		input.skillId,
+		input.ownershipIdentity,
+		input.target,
+	);
+	if (!managedSkillReceiptMatchesIdentity(receipt)) return;
+	if (legacyLoopbackHubTarget(input.home, input.target) !== input.target) return;
+
+	// SUNSET(#1148): remove after the fleet has fully upgraded through CLI 0.14.10.
+	const result = runHermesUninstall(input, basename(input.target));
+	if (result.status !== 0) {
+		throw new ManagedSkillResourceError(
+			`Hermes official Skill uninstall failed: ${hermesCommandOutput(result) || result.error?.message || "unknown error"}`,
+		);
+	}
+	if (withRuntimeUserFileAccess(() => existsSync(input.target))) {
+		throw new ManagedSkillResourceError(
+			"Hermes official Skill uninstall did not remove the Skill target",
+		);
+	}
+	if (hermesLockHasTarget(input.home, input.target)) {
+		throw new ManagedSkillResourceError(
+			"Hermes official Skill uninstall did not remove the Skill lock entry",
+		);
 	}
 }
 
@@ -138,6 +334,16 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 	},
 	install(input) {
 		const target = resolve(input.targetDir ?? targetDir(input.home, input.skill.skillId));
+		if (input.previouslyReserved) {
+			migrateLegacyLoopbackHubInstall({
+				home: input.home,
+				appRoot: input.appRoot,
+				managedResourceRoot: input.managedResourceRoot,
+				skillId: input.skill.skillId,
+				ownershipIdentity: input.previousOwnershipIdentity ?? input.skill.sourceIdentity,
+				target: resolve(input.previousTargetDir ?? target),
+			});
+		}
 		const receipt = receiptInput(
 			input.managedResourceRoot,
 			input.skill.skillId,

--- a/packages/cli/src/runtime/manifest-skills-apply.ts
+++ b/packages/cli/src/runtime/manifest-skills-apply.ts
@@ -47,7 +47,7 @@ interface HostedSkillProjectionDriver {
 	install(
 		skill: PreparedHostedSourcedSkill,
 		targetDir: string,
-		previouslyReserved: boolean,
+		previousReservation?: ManagedSkillReservationSnapshot,
 	): "installed" | "unchanged";
 	anchorOwnership(skillId: string, ownershipIdentity: string, targetDir: string): void;
 	verifyOwned(skill: PreparedHostedSourcedSkill, targetDir: string): boolean;
@@ -119,14 +119,18 @@ function hostedSkillProjectionDrivers(input: {
 			target: (skill) =>
 				input.hermesDriver.target?.({ home: input.home, skill }) ??
 				join(hermesSkillsRoot, skill.skillId),
-			install: (skill, targetDir, previouslyReserved) =>
+			install: (skill, targetDir, previousReservation) =>
 				input.hermesDriver.install({
 					home: input.home,
 					appRoot,
 					managedResourceRoot: input.managedResourceRoot,
 					skill,
 					targetDir,
-					previouslyReserved,
+					previouslyReserved: previousReservation !== undefined,
+					previousTargetDir: previousReservation?.targetDir,
+					previousOwnershipIdentity: previousReservation
+						? reservationOwnershipIdentity(previousReservation)
+						: undefined,
 				}),
 			anchorOwnership: (skillId, ownershipIdentity, targetDir) =>
 				input.hermesDriver.anchorOwnership({
@@ -176,7 +180,7 @@ function hostedSkillProjectionDrivers(input: {
 				}
 				return join(openClawSkillsRoot, skill.skillId);
 			},
-			install: (skill, targetDir, previouslyReserved) => {
+			install: (skill, targetDir, previousReservation) => {
 				if (!input.openClawWorkspaceRoot) {
 					throw new Error("OpenClaw official agent workspace is unavailable");
 				}
@@ -186,7 +190,7 @@ function hostedSkillProjectionDrivers(input: {
 					workspaceRoot: input.openClawWorkspaceRoot,
 					managedResourceRoot: input.managedResourceRoot,
 					skill,
-					previouslyReserved,
+					previouslyReserved: previousReservation !== undefined,
 				});
 			},
 			anchorOwnership: (skillId, ownershipIdentity, _targetDir) => {
@@ -487,7 +491,7 @@ function applyHostedSkills(
 					...preparedReservationIdentity(prepared),
 				},
 				() => {
-					return driver.install(prepared, targetDir, reservation !== undefined);
+					return driver.install(prepared, targetDir, reservation);
 				},
 				{
 					verify: () => driver.verifyOwned(prepared, targetDir),


### PR DESCRIPTION
## Field residual

The tenth-round device validation was otherwise green: all 15 managed Skills installed, five convergence cycles completed without errors, and the platform enclave remained root-owned. Five Skills installed by the retired loopback URL driver still appeared as url/hub-installed in the Hermes catalog, with dead 127.0.0.1 URLs retained in skills/.hub/lock.json. The local exact-source driver correctly judged their bytes unchanged, but that left the historical Hermes provenance behind.

## Official-surface migration

- Carry the prior managed reservation target and ownership identity into the Hermes driver.
- Read the Hermes v1 lock with the same strict shape, target-path, source-identity, and ambiguity checks introduced in #1158.
- Select only a reservation-backed tree whose Clawdi receipt still matches and whose Hermes URL is the exact retired form: http://127.0.0.1:<port>/0<64 hex>/SKILL.md.
- Leave every non-loopback URL record and every unrelated Hermes lock entry untouched.
- Invoke the official hermes skills uninstall command with stdin confirmation so Hermes removes its own tree and lock record.
- Let the existing exact-source pipeline observe the missing tree and atomically place the verified archive on the local discovery surface in the same convergence pass.

Production code never writes Hermes lock internals directly.

## Crash safety

The official uninstall intentionally leaves the Clawdi receipt and reservation transaction alone. If the process exits after Hermes removes the tree and lock but before local placement completes, the next convergence sees a missing tree and therefore a non-matching receipt. Pending-install recovery either discards the incomplete pending state or retains the prior committed reservation, after which the normal reserved installation path recreates the exact local tree and receipt. Repeating convergence then returns unchanged because the loopback lock entry is gone.

## SUNSET

The migration is marked SUNSET(#1148) and can be removed after the fleet has fully upgraded through CLI 0.14.10.

## Verification

- Fake Hermes fixture: loopback lock entry plus managed tree and receipt migrates in one pass; SKILL.md and support-file bytes remain exact; an unrelated HTTPS hub entry is preserved; the following pass is unchanged.
- Real Hermes Agent 0.20.4 in an isolated temporary HOME: the official uninstall removed the loopback record, the driver restored the exact local tree, hermes skills list --source local discovered it, and the second pass was unchanged.
- Docker clean CLI runner: typecheck plus full test:internal, 1764 passed, 4 existing native lifecycle tests skipped, 0 failed; mutation-parity passed.
- Privileged systemd e2e: 5 passed, 0 failed.
- Repository-pinned Biome 2.5.9: passed on all changed files.

Tracking: #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)