### PR TITLE
release(cli): 0.14.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.10
+
+Package: `clawdi@0.14.10`
+
+### Fixed
+
+- Skills installed through the retired loopback-URL path are migrated once to
+  Hermes's local form via the official uninstall, clearing stale hub install
+  records; genuinely user-installed hub skills are untouched.
+
 ## Clawdi CLI v0.14.9
 
 Package: `clawdi@0.14.9`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.9",
+      "version": "0.14.10",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.9",
+	"version": "0.14.10",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Release `clawdi@0.14.10` — final cleanup migration (#1168).

Managed skills that earlier releases installed through the retired loopback-URL path are migrated once to Hermes's local form: the official uninstall clears Hermes's stale hub lock records, and the unified placement pipeline re-anchors them in the same converge. Non-loopback hub records are never touched. Verified against real Hermes 0.20.4 (migrate → zero lock records → local discovery → idempotent unchanged).

Eleventh canary round follows across all owner deployments (three accounts), then fleet promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)