### PR TITLE
fix(web): keep plugin card metadata readable

### DIFF
--- a/apps/web/e2e/hosted-agent-plugins.pw.ts
+++ b/apps/web/e2e/hosted-agent-plugins.pw.ts
@@ -1,3 +1,4 @@
+import type { components } from "@clawdi/shared/api";
 import { expect, test } from "@playwright/test";
 import { includedBasicDeployment, stubHostedApi } from "./hosted-stub-api";
 
@@ -14,6 +15,46 @@ const deployment = {
 	},
 };
 
+type CatalogEntry = components["schemas"]["PluginCatalogEntryResponse"];
+type DesiredPlugin = components["schemas"]["AgentPluginDesiredStateResponse"];
+let desiredPluginSequence = 0;
+
+function catalogEntry(name: string, overrides: Partial<CatalogEntry> = {}): CatalogEntry {
+	return {
+		name,
+		version: "1.0.0",
+		display_name: name,
+		description: `${name} guidance and tools for coding agents.`,
+		publisher: "Example Partner",
+		category: "developer-tools",
+		keywords: [name],
+		languages: ["en"],
+		runtimes: ["openclaw", "hermes"],
+		components: { skills: [`${name}-skill`], mcpServers: {} },
+		installable: true,
+		...overrides,
+	};
+}
+
+function desiredPlugin(name: string, overrides: Partial<DesiredPlugin> = {}): DesiredPlugin {
+	desiredPluginSequence += 1;
+	const idSuffix = desiredPluginSequence.toString(16).padStart(12, "0");
+	return {
+		installation_id: `22222222-2222-4222-8222-${idSuffix}`,
+		agent_id: AGENT_ID,
+		plugin_name: name,
+		version: "1.0.0",
+		catalog_revision: "a".repeat(40),
+		desired_state: "present",
+		convergence: "installed",
+		observation_error_code: null,
+		observed_at: "2026-08-22T00:00:00Z",
+		created_at: "2026-08-22T00:00:00Z",
+		updated_at: "2026-08-22T00:00:00Z",
+		...overrides,
+	};
+}
+
 test("Agent Plugins stays closed without the per-user capability", async ({ page }) => {
 	await stubHostedApi(page, {
 		deployments: [deployment],
@@ -25,6 +66,167 @@ test("Agent Plugins stays closed without the per-user capability", async ({ page
 	await page.goto(`/agents/${AGENT_ID}/plugins`);
 	await expect(page).toHaveURL(new RegExp(`/agents/${AGENT_ID}$`));
 	await expect(page.getByRole("link", { name: "Plugins", exact: true })).toHaveCount(0);
+});
+
+test("Agent Plugin cards keep every status and action readable", async ({ page }) => {
+	const catalog = [
+		catalogEntry("available", { display_name: "Available Plugin" }),
+		catalogEntry("failed", { display_name: "Failed Plugin", version: "2.0.0" }),
+		catalogEntry("installed", { display_name: "Installed Plugin" }),
+		catalogEntry("installing", { display_name: "Installing Plugin", version: "2.0.0" }),
+		catalogEntry("requires-setup", {
+			display_name: "Plugin Requiring Setup",
+			installable: false,
+			installability_reason: "configuration_not_supported",
+		}),
+		catalogEntry("reserved", {
+			display_name: "Reserved Plugin",
+			installable: false,
+			installability_reason: "reserved_name",
+		}),
+		catalogEntry("runtime-unavailable", {
+			display_name: "Runtime Unavailable Plugin",
+			runtimes: ["openclaw"],
+		}),
+		catalogEntry("update", {
+			display_name: "Update Available Plugin",
+			version: "2.0.0",
+			publisher: "Mysten Labs",
+			components: {
+				skills: Array.from({ length: 21 }, (_, index) => `sui-${index}`),
+				mcpServers: { "sui-docs": "streamable-http" },
+			},
+		}),
+		catalogEntry("waiting", {
+			display_name: "Plugin Waiting for Agent",
+			version: "2.0.0",
+		}),
+	];
+	const desired = [
+		desiredPlugin("failed", {
+			convergence: "failed",
+			observation_error_code: "reconcile_failed",
+		}),
+		desiredPlugin("installed"),
+		desiredPlugin("installing", {
+			convergence: "not_observed",
+			updated_at: new Date().toISOString(),
+		}),
+		desiredPlugin("legacy-plugin"),
+		desiredPlugin("update"),
+		desiredPlugin("waiting", {
+			convergence: "not_observed",
+			updated_at: new Date(Date.now() - 11 * 60 * 1000).toISOString(),
+		}),
+	];
+	await stubHostedApi(page, {
+		canUseAgentPluginsUI: true,
+		deployments: [deployment],
+	});
+	await page.route("http://127.0.0.1:8000/v1/plugin-catalog", async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({ plugins: catalog }),
+		});
+	});
+	await page.route(`http://127.0.0.1:8000/v1/agents/${AGENT_ID}/agent-plugins`, async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({ plugins: desired }),
+		});
+	});
+
+	await page.setViewportSize({ width: 320, height: 844 });
+	await page.goto(`/agents/${AGENT_ID}/plugins`);
+	const cardFor = (title: string) =>
+		page.getByRole("button", { name: `View ${title} details` }).locator("..");
+	const states = [
+		{ title: "Available Plugin", status: null, action: "Install" },
+		{ title: "Plugin Requiring Setup", status: null, action: "Requires setup" },
+		{ title: "Reserved Plugin", status: null, action: "Reserved" },
+		{ title: "Runtime Unavailable Plugin", status: null, action: "Unavailable" },
+		{ title: "Installed Plugin", status: "Installed", action: "Remove" },
+		{ title: "Update Available Plugin", status: "Update available", action: "Update" },
+		{ title: "Installing Plugin", status: "Installing", action: "Update" },
+		{ title: "Plugin Waiting for Agent", status: "Waiting for agent", action: "Update" },
+		{ title: "Failed Plugin", status: "Install failed", action: "Retry" },
+		{ title: "legacy-plugin", status: "Installed", action: "Remove" },
+	] as const;
+	for (const state of states) {
+		const card = cardFor(state.title);
+		await expect(card).toBeVisible();
+		await expect(card.getByRole("button", { name: state.action, exact: true })).toBeVisible();
+		const badges = card.locator('[data-slot="status-badge"]');
+		if (state.status) {
+			await expect(badges).toHaveCount(1);
+			await expect(badges).toHaveText(state.status);
+		} else {
+			await expect(badges).toHaveCount(0);
+		}
+	}
+
+	for (const title of ["Installing Plugin", "Plugin Waiting for Agent", "Failed Plugin"]) {
+		await expect(cardFor(title).getByText("Update available", { exact: true })).toHaveCount(0);
+	}
+
+	const updateFooter = cardFor("Update Available Plugin").locator('[data-slot="entity-meta"]');
+	await expect(updateFooter).toContainText("Mysten Labs");
+	await expect(updateFooter).toContainText("v1.0.0 → v2.0.0");
+	await expect(updateFooter).toContainText("21 Skills · 1 MCP server");
+	expect(
+		await updateFooter
+			.locator(":scope > span")
+			.evaluateAll((items) => new Set(items.map((item) => (item as HTMLElement).offsetTop)).size),
+	).toBeGreaterThan(1);
+
+	const cards = page.locator('[data-slot="entity-card"]');
+	await expect(cards).toHaveCount(states.length);
+	const readLayouts = () =>
+		cards.evaluateAll((elements) =>
+			elements.map((card) => {
+				const cardRect = card.getBoundingClientRect();
+				const heading = card.querySelector("h3");
+				const badge = card.querySelector('[data-slot="status-badge"]');
+				const controls = Array.from(card.querySelectorAll("button"));
+				return {
+					title: heading?.textContent ?? "Unknown plugin",
+					cardFits: card.scrollWidth <= card.clientWidth,
+					badgesFit: Array.from(card.querySelectorAll('[data-slot="status-badge"]')).every(
+						(item) => item.scrollWidth <= item.clientWidth,
+					),
+					metadataFits: Array.from(
+						card.querySelectorAll('[data-slot="entity-meta"] > span > span'),
+					).every((item) => item.scrollWidth <= item.clientWidth),
+					controlsFit: controls.every((control) => {
+						const rect = control.getBoundingClientRect();
+						return (
+							control.scrollWidth <= control.clientWidth &&
+							rect.left >= cardRect.left - 1 &&
+							rect.right <= cardRect.right + 1
+						);
+					}),
+					titleClearsBadge:
+						!heading ||
+						!badge ||
+						heading.getBoundingClientRect().right <= badge.getBoundingClientRect().left,
+				};
+			}),
+		);
+	for (const viewport of [
+		{ width: 320, height: 844 },
+		{ width: 1440, height: 1000 },
+	]) {
+		await page.setViewportSize(viewport);
+		const layouts = await readLayouts();
+		expect(
+			layouts.filter(
+				({ cardFits, badgesFit, metadataFits, controlsFit, titleClearsBadge }) =>
+					!cardFits || !badgesFit || !metadataFits || !controlsFit || !titleClearsBadge,
+			),
+		).toEqual([]);
+	}
 });
 
 test("Agent Plugins opens and installs with the per-user capability", async ({ page }) => {

--- a/apps/web/e2e/hosted-stub-api.ts
+++ b/apps/web/e2e/hosted-stub-api.ts
@@ -1121,6 +1121,9 @@ export async function stubHostedApi(page: Page, options: HostedApiStubOptions = 
 				? fulfillJson(r, options.cloudAgentsResponse.body, options.cloudAgentsResponse.status)
 				: fulfillJson(r, options.cloudAgents ?? []);
 		}
+		if (/^\/v1\/agents\/[^/]+\/project-bindings$/.test(p) && r.request().method() === "GET") {
+			return fulfillJson(r, []);
+		}
 		if (p.startsWith("/v1/agents/") && r.request().method() === "GET") {
 			const id = decodeURIComponent(p.slice("/v1/agents/".length));
 			const response = options.cloudAgentResponses?.[id]?.shift();
@@ -1157,6 +1160,7 @@ export async function stubHostedApi(page: Page, options: HostedApiStubOptions = 
 		if (p === "/v1/channels") return fulfillJson(r, []);
 		if (p === "/v1/channels/bot-pool") return fulfillJson(r, { providers: {} });
 		if (p === "/v1/channels/health") return fulfillJson(r, { items: [] });
+		if (p === "/v1/connectors") return fulfillJson(r, []);
 		if (p === "/v1/projects") return fulfillJson(r, []);
 		if (p === "/v1/sessions") return fulfillJson(r, emptyPage);
 		if (p === "/v1/auth/keys") return fulfillJson(r, []);

--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -286,13 +286,16 @@ export function HeroCardSkeleton({
 	);
 }
 
-/** Meta line — array items render middot-separated on one truncating line. */
+/** Meta facts use middots on one truncating line or stable spacing when wrapping. */
 export function EntityMeta({
 	items,
 	className,
+	wrap = false,
 }: {
 	items: ReactNode | ReactNode[];
 	className?: string;
+	/** Keep each item intact and wrap between items instead of compressing the row. */
+	wrap?: boolean;
 }) {
 	const arr = (Array.isArray(items) ? items : [items]).filter(
 		(x) => x !== null && x !== undefined && x !== false && x !== "",
@@ -304,18 +307,22 @@ export function EntityMeta({
 		typeof item === "string" || typeof item === "number" ? `t:${item}` : `n:${i}`;
 	return (
 		<div
+			data-slot="entity-meta"
 			className={cn(
-				"mt-0.5 flex min-w-0 items-center overflow-hidden text-sm text-muted-foreground",
+				"mt-0.5 flex min-w-0 items-center text-sm text-muted-foreground",
+				wrap ? "flex-wrap gap-x-3 gap-y-1 overflow-visible" : "overflow-hidden",
 				className,
 			)}
 		>
 			{arr.map((item, i) => (
 				<span
 					key={keyFor(item, i)}
-					className="inline-flex min-w-0 items-center"
+					className={cn("inline-flex min-w-0 items-center", wrap && "max-w-full shrink-0")}
 					title={typeof item === "string" || typeof item === "number" ? String(item) : undefined}
 				>
-					{i > 0 ? <span className="mx-1.5 shrink-0 text-muted-foreground/40">·</span> : null}
+					{i > 0 && !wrap ? (
+						<span className="mx-1.5 shrink-0 text-muted-foreground/40">·</span>
+					) : null}
 					<span className="min-w-0 truncate">{item}</span>
 				</span>
 			))}
@@ -396,6 +403,7 @@ export function HeroCard({
 	titleClassName,
 	descriptionClassName,
 	footerClassName,
+	footerWrap = false,
 	children,
 }: {
 	icon?: ReactNode;
@@ -414,6 +422,8 @@ export function HeroCard({
 	titleClassName?: string;
 	descriptionClassName?: string;
 	footerClassName?: string;
+	/** Wrap dense footer facts between intact items. */
+	footerWrap?: boolean;
 	children?: ReactNode;
 }) {
 	return (
@@ -458,6 +468,7 @@ export function HeroCard({
 				<EntityMeta
 					items={footer}
 					className={cn("mt-auto text-xs text-muted-foreground tabular-nums", footerClassName)}
+					wrap={footerWrap}
 				/>
 			) : null}
 			{link ? (

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-card.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-card.tsx
@@ -40,6 +40,8 @@ export function AgentPluginCard({
 	const title = pluginDisplayName(item);
 	const { status, installability, hasUpdate, canInstall, canRetry, version } =
 		agentPluginActionState(item, runtime);
+	const showUpdateBadge = hasUpdate && item.desired?.convergence === "installed";
+	const visibleStatus = showUpdateBadge ? null : status;
 
 	return (
 		<div data-hosted="true" data-v2="true" className="contents">
@@ -53,24 +55,27 @@ export function AgentPluginCard({
 					</IconChip>
 				}
 				title={title}
+				badges={
+					visibleStatus || showUpdateBadge ? (
+						<>
+							{visibleStatus ? (
+								<StatusBadge status={visibleStatus.tone} withDot>
+									{visibleStatus.label}
+								</StatusBadge>
+							) : null}
+							{showUpdateBadge ? <StatusBadge status="info">Update available</StatusBadge> : null}
+						</>
+					) : undefined
+				}
 				description={
 					item.catalog?.description ?? "This plugin is no longer available in the Store."
 				}
 				footer={[
-					status ? (
-						<StatusBadge key="status" status={status.tone} withDot>
-							{status.label}
-						</StatusBadge>
-					) : null,
-					hasUpdate ? (
-						<StatusBadge key="update" status="info">
-							Update available
-						</StatusBadge>
-					) : null,
 					item.catalog?.publisher,
 					version,
 					item.catalog ? agentPluginComponentSummary(item.catalog) : null,
 				]}
+				footerWrap
 				actionsVisibility="always"
 				actions={
 					<>


### PR DESCRIPTION
Summary
- move plugin state badges into the standard HeroCard badge slot and let dense metadata wrap as intact facts
- render exactly one truthful badge: stable installs may show Update available, while installing, waiting, and failed installs retain their own convergence status
- make Hosted browser fixtures return contract-correct arrays for connectors and project bindings

Coverage
- one browser matrix covers Available, Requires setup, Reserved, Runtime unavailable, Installed, Update available, Installing, Waiting for agent, Install failed / Retry, and an installed historical plugin missing from the Store
- at 320x844 and 1440x1000, assert no card overflow, clipped badges or metadata, out-of-bounds actions, or title/badge overlap
- verify the dense update footer wraps between intact facts on narrow screens

Verification
- Playwright hosted-agent-plugins: 3 passed
- Docker Web suite: 1058 passed, 0 failed
- Docker Web typecheck and OSS production build passed
- Biome and git diff --check passed
- visually checked at 320px, 390px, and 1440px