### PR TITLE
fix: harden runtime convergence and WhatsApp health

### DIFF
--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import quote
 from uuid import UUID
@@ -157,6 +157,8 @@ from app.services.whatsapp_native_transport import (
 from app.services.whatsapp_sidecar_registry import get_active_whatsapp_sidecar_registry
 
 router = APIRouter(prefix="/channels", tags=["channels"])
+
+_CHANNEL_HEALTH_ERROR_WINDOW = timedelta(hours=24)
 
 
 async def _queue_agent_link_runtime_changed(
@@ -1529,6 +1531,7 @@ async def _channel_health_items(
     if not accounts:
         return []
     account_ids = [account.id for account in accounts]
+    recent_error_cutoff = datetime.now(UTC) - _CHANNEL_HEALTH_ERROR_WINDOW
 
     pending_inbox_rows = await db.execute(
         select(
@@ -1584,6 +1587,12 @@ async def _channel_health_items(
             func.count(ChannelDelivery.id)
             .filter(ChannelDelivery.status == DELIVERY_STATUS_FAILED)
             .label("failed_count"),
+            func.count(ChannelDelivery.id)
+            .filter(
+                ChannelDelivery.status == DELIVERY_STATUS_FAILED,
+                ChannelDelivery.updated_at >= recent_error_cutoff,
+            )
+            .label("recent_failed_count"),
         )
         .where(
             ChannelDelivery.account_id.in_(account_ids),
@@ -1592,8 +1601,8 @@ async def _channel_health_items(
         .group_by(ChannelDelivery.account_id)
     )
     delivery_counts_by_account = {
-        account_id: (int(pending), int(in_progress), int(failed))
-        for account_id, pending, in_progress, failed in delivery_rows.all()
+        account_id: (int(pending), int(in_progress), int(failed), int(recent_failed))
+        for account_id, pending, in_progress, failed, recent_failed in delivery_rows.all()
     }
 
     message_rows = await db.execute(
@@ -1695,11 +1704,12 @@ async def _channel_health_items(
         _channel_health_item(
             account=account,
             pending_inbox_stats=pending_inbox_by_account.get(account.id, (0, None)),
-            delivery_counts=delivery_counts_by_account.get(account.id, (0, 0, 0)),
+            delivery_counts=delivery_counts_by_account.get(account.id, (0, 0, 0, 0)),
             last_message_at=last_message_by_account.get(account.id),
             last_event_at=last_event_by_account.get(account.id),
             debug_error=debug_error_by_account.get(account.id),
             delivery_error=delivery_error_by_account.get(account.id),
+            recent_error_cutoff=recent_error_cutoff,
         )
         for account in accounts
     ]
@@ -1709,14 +1719,17 @@ def _channel_health_item(
     *,
     account: ChannelAccount,
     pending_inbox_stats: tuple[int, datetime | None],
-    delivery_counts: tuple[int, int, int],
+    delivery_counts: tuple[int, int, int, int],
     last_message_at: datetime | None,
     last_event_at: datetime | None,
     debug_error: tuple[datetime, str, str, str | None] | None,
     delivery_error: tuple[datetime, str] | None,
+    recent_error_cutoff: datetime,
 ) -> ChannelHealthItemResponse:
     pending_inbox, oldest_pending_inbox_at = pending_inbox_stats
-    pending_deliveries, in_progress_deliveries, failed_deliveries = delivery_counts
+    pending_deliveries, in_progress_deliveries, failed_deliveries, recent_failed_deliveries = (
+        delivery_counts
+    )
     last_error_at = None
     last_error = None
     last_error_stage = None
@@ -1730,12 +1743,22 @@ def _channel_health_item(
         last_error_stage = "delivery"
         last_error_outcome = "failure"
 
+    native_transport = _native_transport_health(account)
+    whatsapp_transport_connected = (
+        account.provider == CHANNEL_PROVIDER_WHATSAPP
+        and native_transport is not None
+        and native_transport.get("available") is True
+    )
     reasons: list[str] = []
     if account.status != CHANNEL_STATUS_ACTIVE:
         reasons.append("channel_disabled")
-    if failed_deliveries > 0:
+    if failed_deliveries > 0 and (not whatsapp_transport_connected or recent_failed_deliveries > 0):
         reasons.append("failed_deliveries")
-    if last_error is not None:
+    if last_error is not None and (
+        not whatsapp_transport_connected
+        or last_error_at is None
+        or last_error_at >= recent_error_cutoff
+    ):
         reasons.append("recent_error")
     if in_progress_deliveries > 0:
         reasons.append("deliveries_in_progress")
@@ -1775,7 +1798,7 @@ def _channel_health_item(
         last_error=last_error,
         last_error_stage=last_error_stage,
         last_error_outcome=last_error_outcome,
-        native_transport=_native_transport_health(account),
+        native_transport=native_transport,
     )
 
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -131,7 +131,11 @@ from app.services.whatsapp_native_transport import (
     WhatsAppSidecarHealth,
     WhatsAppSidecarUnavailableError,
 )
-from app.services.whatsapp_provider_bridge import persist_whatsapp_provider_event
+from app.services.whatsapp_provider_bridge import (
+    persist_whatsapp_provider_event,
+    register_whatsapp_provider_transport,
+    unregister_whatsapp_provider_transport,
+)
 
 pytestmark = [pytest.mark.usefixtures("channel_agent"), pytest.mark.committed_db]
 
@@ -1666,6 +1670,96 @@ async def test_channel_health_summarizes_delivery_and_debug_state(
     assert health["last_error_stage"] in {"delivery", None}
     assert health["last_message_at"] is not None
     assert health["last_event_at"] is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure_age", "expected_status", "expected_reasons"),
+    [
+        pytest.param(timedelta(days=10), "ok", [], id="historical-failure"),
+        pytest.param(
+            timedelta(minutes=1),
+            "error",
+            ["failed_deliveries", "recent_error"],
+            id="current-failure",
+        ),
+    ],
+)
+async def test_whatsapp_channel_health_only_surfaces_current_delivery_failures(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    failure_age: timedelta,
+    expected_status: str,
+    expected_reasons: list[str],
+):
+    class ConnectedWhatsAppTransport:
+        connected = True
+
+        async def relay_outbound_message(self, message):
+            return None
+
+        async def relay_raw_node(self, node):
+            return None
+
+        async def query_iq(self, node, timeout_ms):
+            return None
+
+    created_response = await client.post(
+        "/v1/channels",
+        json={"provider": "whatsapp", "name": f"health-whatsapp-{uuid4().hex}"},
+    )
+    assert created_response.status_code == 201, created_response.text
+    account_id = UUID(created_response.json()["id"])
+    failure_at = datetime.now(UTC) - failure_age
+    message = ChannelMessage(
+        account_id=account_id,
+        bot_agent_link_id=None,
+        user_id=seed_user.id,
+        direction=MESSAGE_DIRECTION_OUTBOUND,
+        external_chat_id="15551234567@s.whatsapp.net",
+        provider_message_id=None,
+        text="failed outbound",
+        payload={"delivery": DELIVERY_STATUS_FAILED},
+        created_at=failure_at,
+        updated_at=failure_at,
+    )
+    db_session.add(message)
+    await db_session.flush()
+    db_session.add(
+        ChannelDelivery(
+            account_id=account_id,
+            bot_agent_link_id=None,
+            message_id=message.id,
+            user_id=seed_user.id,
+            status=DELIVERY_STATUS_FAILED,
+            attempts=5,
+            max_attempts=5,
+            next_attempt_at=failure_at,
+            last_error="provider rejected request",
+            created_at=failure_at,
+            updated_at=failure_at,
+        )
+    )
+    await db_session.commit()
+
+    register_whatsapp_provider_transport(account_id, ConnectedWhatsAppTransport())
+    try:
+        response = await client.get("/v1/channels/health")
+    finally:
+        unregister_whatsapp_provider_transport(account_id)
+
+    assert response.status_code == 200, response.text
+    health = next(
+        item for item in response.json()["items"] if item["account_id"] == str(account_id)
+    )
+    assert health["health_status"] == expected_status
+    assert health["reasons"] == expected_reasons
+    assert health["pending_deliveries"] == 0
+    assert health["in_progress_deliveries"] == 0
+    assert health["failed_deliveries"] == 1
+    assert health["last_error"] == "channel_delivery_failed"
+    assert health["native_transport"]["available"] is True
 
 
 @pytest.mark.asyncio

--- a/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
@@ -17,9 +17,81 @@ import { hostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
 import { managedSkillReceiptPath } from "./managed-skill-delivery";
 
 let root = "";
+const originalSystemctlPath = process.env.CLAWDI_SYSTEMCTL_PATH;
 afterEach(() => {
 	if (root) rmSync(root, { recursive: true, force: true });
 	root = "";
+	if (originalSystemctlPath === undefined) delete process.env.CLAWDI_SYSTEMCTL_PATH;
+	else process.env.CLAWDI_SYSTEMCTL_PATH = originalSystemctlPath;
+});
+
+test("retries the official workspace roster while the OpenClaw gateway is restarting", () => {
+	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-gateway-restart-"));
+	const home = join(root, "home");
+	const workspaceRoot = join(home, "agent-workspace");
+	const command = join(home, ".local", "bin", "openclaw");
+	const systemctl = join(root, "systemctl");
+	const attempts = join(root, "attempts");
+	mkdirSync(dirname(command), { recursive: true });
+	writeFileSync(
+		command,
+		`#!/bin/sh
+set -eu
+attempt=$(($(cat '${attempts}' 2>/dev/null || printf 0) + 1))
+printf '%s\n' "$attempt" > '${attempts}'
+if test "$attempt" -eq 1; then exit 1; fi
+printf '%s\n' '[{"id":"main","workspace":"${workspaceRoot}"}]'
+`,
+	);
+	writeFileSync(
+		systemctl,
+		`#!/bin/sh
+test "$*" = "--user show openclaw-gateway.service --property=LoadState --property=ActiveState"
+printf '%s\n' 'LoadState=loaded' 'ActiveState=deactivating'
+`,
+	);
+	chmodSync(command, 0o755);
+	chmodSync(systemctl, 0o755);
+	process.env.CLAWDI_SYSTEMCTL_PATH = systemctl;
+
+	expect(hostedOpenClawSkillDriver.resolveWorkspace({ home })).toBe(workspaceRoot);
+	expect(readFileSync(attempts, "utf8")).toBe("2\n");
+});
+
+test("does not retry roster failures when the OpenClaw gateway failed or is not installed", () => {
+	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-gateway-failure-"));
+	for (const scenario of [
+		{ name: "failed", state: "LoadState=loaded\nActiveState=failed\n", exitCode: 0 },
+		{ name: "not-installed", state: "", exitCode: 1 },
+	] as const) {
+		const home = join(root, scenario.name, "home");
+		const command = join(home, ".local", "bin", "openclaw");
+		const systemctl = join(root, scenario.name, "systemctl");
+		const attempts = join(root, scenario.name, "attempts");
+		mkdirSync(dirname(command), { recursive: true });
+		writeFileSync(
+			command,
+			`#!/bin/sh
+printf '%s\n' "$*" >> '${attempts}'
+exit 1
+`,
+		);
+		writeFileSync(
+			systemctl,
+			`#!/bin/sh
+printf '%s' '${scenario.state}'
+exit ${scenario.exitCode}
+`,
+		);
+		chmodSync(command, 0o755);
+		chmodSync(systemctl, 0o755);
+		process.env.CLAWDI_SYSTEMCTL_PATH = systemctl;
+
+		expect(() => hostedOpenClawSkillDriver.resolveWorkspace({ home })).toThrow(
+			"official agent workspace roster is unavailable",
+		);
+		expect(readFileSync(attempts, "utf8")).toBe("agents list --json\n");
+	}
 });
 
 test("repairs typed invalid config once before retrying the official workspace roster", () => {

--- a/packages/cli/src/runtime/hosted-openclaw-skill.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.ts
@@ -22,12 +22,16 @@ import {
 	spawnRuntimeUserCommand,
 	withRuntimeUserFileAccess,
 } from "./runtime-user-command";
+import { parseSystemctlShow, systemctlPath } from "./systemd";
 
 const OPENCLAW_AGENT_ID = "main";
 const SOURCE_RECEIPT = ".openclaw/source-origin.json";
 const EXCLUDED_NATIVE_FILES = new Set([SOURCE_RECEIPT]);
 const OPENCLAW_CONFIG_PROBE_TIMEOUT_MS = 15_000;
 const OPENCLAW_CONFIG_REPAIR_TIMEOUT_MS = 120_000;
+const OPENCLAW_GATEWAY_UNIT = "openclaw-gateway.service";
+const OPENCLAW_GATEWAY_TRANSITION_RETRIES = 2;
+const OPENCLAW_GATEWAY_TRANSITION_RETRY_DELAY_MS = 3_000;
 
 export interface HostedOpenClawSkillDriver {
 	resolveWorkspace(input: { home: string; repairInvalidConfig?: boolean }): string;
@@ -165,12 +169,50 @@ function repairInvalidConfig(command: string, home: string): boolean {
 	return true;
 }
 
+function openClawGatewayIsTransitioning(home: string): boolean {
+	const result = spawnRuntimeUserCommand(
+		systemctlPath(),
+		["--user", "show", OPENCLAW_GATEWAY_UNIT, "--property=LoadState", "--property=ActiveState"],
+		home,
+		home,
+		{ timeoutMs: OPENCLAW_CONFIG_PROBE_TIMEOUT_MS, maxBufferBytes: 64 * 1024 },
+	);
+	if (result.status !== 0) return false;
+	const state = parseSystemctlShow(String(result.stdout));
+	return (
+		state.LoadState === "loaded" &&
+		(state.ActiveState === "activating" || state.ActiveState === "deactivating")
+	);
+}
+
+function waitForOpenClawGatewayTransition(): void {
+	Atomics.wait(
+		new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)),
+		0,
+		0,
+		OPENCLAW_GATEWAY_TRANSITION_RETRY_DELAY_MS,
+	);
+}
+
 function resolveOfficialWorkspace(home: string, repairInvalidConfigOnFailure = false): string {
 	const command = commandPath(home);
 	let result = spawnRuntimeUserCommand(command, ["agents", "list", "--json"], home, home, {
 		timeoutMs: OPENCLAW_CONFIG_PROBE_TIMEOUT_MS,
 		maxBufferBytes: 1024 * 1024,
 	});
+	for (
+		let attempt = 0;
+		result.status !== 0 &&
+		attempt < OPENCLAW_GATEWAY_TRANSITION_RETRIES &&
+		openClawGatewayIsTransitioning(home);
+		attempt += 1
+	) {
+		waitForOpenClawGatewayTransition();
+		result = spawnRuntimeUserCommand(command, ["agents", "list", "--json"], home, home, {
+			timeoutMs: OPENCLAW_CONFIG_PROBE_TIMEOUT_MS,
+			maxBufferBytes: 1024 * 1024,
+		});
+	}
 	if (result.status !== 0 && repairInvalidConfigOnFailure && repairInvalidConfig(command, home)) {
 		result = spawnRuntimeUserCommand(command, ["agents", "list", "--json"], home, home, {
 			timeoutMs: OPENCLAW_CONFIG_PROBE_TIMEOUT_MS,


### PR DESCRIPTION
## Field evidence

- A formal binding restart left `openclaw-gateway.service` in `deactivating` while a convergence tick read the official workspace roster. The tick emitted `OpenClaw official agent workspace roster is unavailable`; the next tick self-healed.
- WhatsApp transport was connected with no queue backlog, but channel health remained `error` because five failed deliveries from the August 12 incident were counted forever.

## Fix

- Retry the official OpenClaw workspace roster up to twice at three-second intervals only when the loaded gateway unit is explicitly `activating` or `deactivating`. Failed and missing units keep the original error behavior.
- Keep cumulative WhatsApp failure statistics, but use a 24-hour current-error window for health reasons when the native transport is connected. Pending, in-progress, and inbox backlog semantics remain unchanged.

## Verification

- CLI Bun 1.4.0 typecheck and focused test: 7 passed
- Biome check for the changed CLI files
- Backend Ruff lint and format checks
- Backend focused basedpyright: 0 errors
- Backend `channel_health` pytest group: 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
