### PR TITLE
feat(backend): refresh linked Project skill snapshots

### DIFF
--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -47,7 +47,8 @@ from app.core.skill_sync_protocol import (
     SkillSyncProtocol,
     resolve_skill_sync_protocol,
 )
-from app.models.project import PROJECT_KIND_ENVIRONMENT, Project
+from app.models.agent_project_binding import AgentProjectBinding
+from app.models.project import PROJECT_KIND_ENVIRONMENT, PROJECT_KIND_WORKSPACE, Project
 from app.models.project_membership import ProjectMembership
 from app.models.session import AgentEnvironment
 from app.models.skill import (
@@ -60,6 +61,7 @@ from app.schemas.common import Paginated
 from app.schemas.skill import (
     PersistedProjectKind,
     PersistedSkillAuthority,
+    ProjectSkillRefreshRequest,
     SkillContentUpdateRequest,
     SkillCreateRequest,
     SkillDeleteResponse,
@@ -69,6 +71,7 @@ from app.schemas.skill import (
     SkillSummaryResponse,
     SkillUploadResponse,
 )
+from app.services.audit import record_control_plane_audit
 from app.services.file_store import get_file_store
 from app.services.http_cache import if_none_match_contains
 from app.services.project_runtime_skills import (
@@ -1116,6 +1119,246 @@ async def upload_skill_project(
         create_only=create_only,
         content_hash=content_hash,
         skill_sync_protocol=skill_sync_protocol,
+    )
+
+
+async def _project_skill_refresh_rows(
+    db: AsyncSession,
+    *,
+    owner_user_id: UUID,
+    project_id: UUID,
+    skill_key: str,
+    source_agent_id: UUID,
+    for_update: bool = False,
+) -> tuple[Skill, Skill]:
+    project = (
+        await db.execute(
+            select(Project).where(
+                Project.id == project_id,
+                Project.user_id == owner_user_id,
+                Project.archived_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if project is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "project not found")
+    if project.kind != PROJECT_KIND_WORKSPACE:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail={
+                "code": "project_skill_refresh_requires_workspace",
+                "message": "Only user-created Project Skills can be refreshed.",
+            },
+        )
+
+    target_query = select(Skill).where(
+        Skill.user_id == owner_user_id,
+        Skill.project_id == project_id,
+        Skill.skill_key == skill_key,
+        Skill.is_active,
+    )
+    if for_update:
+        target_query = target_query.with_for_update()
+    target = (await db.execute(target_query)).scalar_one_or_none()
+    if target is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Skill not found")
+    if target.authority != SKILL_AUTHORITY_CLOUD:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail={
+                "code": "project_skill_refresh_requires_cloud_authority",
+                "message": "Only Cloud-owned Project Skills can be refreshed.",
+            },
+        )
+
+    source_project_id = (
+        await db.execute(
+            select(AgentEnvironment.default_project_id)
+            .join(Project, Project.id == AgentEnvironment.default_project_id)
+            .where(
+                AgentEnvironment.id == source_agent_id,
+                AgentEnvironment.user_id == owner_user_id,
+                AgentEnvironment.archived_at.is_(None),
+                Project.user_id == owner_user_id,
+                Project.kind == PROJECT_KIND_ENVIRONMENT,
+                Project.origin_environment_id == source_agent_id,
+                Project.archived_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if source_project_id is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Source Agent not found")
+    is_linked = await db.scalar(
+        select(AgentProjectBinding.id).where(
+            AgentProjectBinding.agent_id == source_agent_id,
+            AgentProjectBinding.project_id == project_id,
+            AgentProjectBinding.binding_type == "context",
+        )
+    )
+    if is_linked is None:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail={
+                "code": "project_skill_refresh_source_not_linked",
+                "message": "Link the source Agent to this Project before refreshing its Skill.",
+            },
+        )
+
+    source_query = select(Skill).where(
+        Skill.user_id == owner_user_id,
+        Skill.project_id == source_project_id,
+        Skill.skill_key == skill_key,
+        Skill.authority == SKILL_AUTHORITY_AGENT_SYNC,
+        Skill.authority_agent_id == source_agent_id,
+        Skill.is_active,
+    )
+    if for_update:
+        source_query = source_query.with_for_update()
+    source = (await db.execute(source_query)).scalar_one_or_none()
+    if source is None:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail={
+                "code": "project_skill_refresh_source_missing",
+                "message": "The source Agent has not synced this Skill.",
+            },
+        )
+    if source.file_key is None or source.file_count is None:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail={
+                "code": "project_skill_refresh_source_unavailable",
+                "message": "The source Agent's Skill archive is unavailable.",
+            },
+        )
+    return target, source
+
+
+@project_router.post("/refresh", response_model=SkillUploadResponse)
+async def refresh_project_skill(
+    project_id: UUID,
+    body: ProjectSkillRefreshRequest,
+    auth: AuthContext = Depends(require_scope_short_session("skills:write")),
+    db: AsyncSession = Depends(get_session),
+) -> SkillUploadResponse:
+    """Explicitly replace one linked Project snapshot from its source Agent."""
+    if not is_valid_skill_key(body.skill_key):
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, "Invalid skill_key")
+    await validate_project_for_caller(db, auth, project_id)
+    _target, source = await _project_skill_refresh_rows(
+        db,
+        owner_user_id=auth.user_id,
+        project_id=project_id,
+        skill_key=body.skill_key,
+        source_agent_id=body.source_agent_id,
+    )
+    source_snapshot = (source.id, source.content_hash, source.file_key)
+
+    # Do not retain database locks while checking the immutable source object.
+    await db.commit()
+    try:
+        source_exists = await file_store.exists(source.file_key)
+    except Exception as exc:
+        log.warning(
+            "project_skill_refresh_source_check_failed user=%s project=%s skill_key=%s error=%s",
+            auth.user_id,
+            project_id,
+            body.skill_key,
+            _sanitize_log(exc),
+        )
+        source_exists = False
+    if not source_exists:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail={
+                "code": "project_skill_refresh_source_unavailable",
+                "message": "The source Agent's Skill archive is unavailable.",
+            },
+        )
+
+    await assert_project_skill_write_compatible(
+        db,
+        project_id=project_id,
+        skill_key=body.skill_key,
+        local_skill_key=source.name,
+        enforce_total_limit=False,
+        source_agent_id=body.source_agent_id,
+    )
+    lock_key = project_skill_advisory_lock_key(auth.user_id, project_id, body.skill_key)
+    await db.execute(text("SELECT pg_advisory_xact_lock(:k)"), {"k": lock_key})
+    target, source = await _project_skill_refresh_rows(
+        db,
+        owner_user_id=auth.user_id,
+        project_id=project_id,
+        skill_key=body.skill_key,
+        source_agent_id=body.source_agent_id,
+        for_update=True,
+    )
+    if (source.id, source.content_hash, source.file_key) != source_snapshot:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail={
+                "code": "project_skill_refresh_source_changed",
+                "message": "The source Agent's Skill changed during refresh; retry.",
+            },
+        )
+
+    previous_content_hash = target.content_hash
+    changed = any(
+        (
+            target.name != source.name,
+            target.description != source.description,
+            target.content_hash != source.content_hash,
+            target.file_key != source.file_key,
+            target.file_count != source.file_count,
+            target.source_repo != source.source_repo,
+            target.agent_types != source.agent_types,
+        )
+    )
+    if changed:
+        target.name = source.name
+        target.description = source.description
+        target.content_hash = source.content_hash
+        target.file_key = source.file_key
+        target.file_count = source.file_count
+        target.source_repo = source.source_repo
+        target.agent_types = source.agent_types
+        target.authority = SKILL_AUTHORITY_CLOUD
+        target.authority_agent_id = None
+        target.version += 1
+        await bump_skills_revision(
+            db,
+            auth.user_id,
+            skill_key=target.skill_key,
+            project_id=project_id,
+            content_hash=target.content_hash,
+        )
+    record_control_plane_audit(
+        db,
+        actor_type="user",
+        actor_user_id=auth.user_id,
+        target_user_id=auth.user_id,
+        source="skills.api",
+        action="project_skill.refresh",
+        resource_type="skill",
+        resource_id=str(target.id),
+        environment_id=body.source_agent_id,
+        details={
+            "project_id": str(project_id),
+            "skill_key": target.skill_key,
+            "source_skill_id": str(source.id),
+            "previous_content_hash": previous_content_hash,
+            "content_hash": target.content_hash,
+            "changed": changed,
+        },
+    )
+    await db.commit()
+    return SkillUploadResponse(
+        skill_key=target.skill_key,
+        name=target.name,
+        version=target.version,
+        file_count=source.file_count,
+        content_hash=target.content_hash,
     )
 
 

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -1130,7 +1130,7 @@ async def _project_skill_refresh_rows(
     skill_key: str,
     source_agent_id: UUID,
     for_update: bool = False,
-) -> tuple[Skill, Skill]:
+) -> tuple[Skill, Skill, str, int]:
     project = (
         await db.execute(
             select(Project).where(
@@ -1223,7 +1223,9 @@ async def _project_skill_refresh_rows(
                 "message": "The source Agent has not synced this Skill.",
             },
         )
-    if source.file_key is None or source.file_count is None:
+    source_file_key = source.file_key
+    source_file_count = source.file_count
+    if source_file_key is None or source_file_count is None:
         raise HTTPException(
             status.HTTP_409_CONFLICT,
             detail={
@@ -1231,7 +1233,7 @@ async def _project_skill_refresh_rows(
                 "message": "The source Agent's Skill archive is unavailable.",
             },
         )
-    return target, source
+    return target, source, source_file_key, source_file_count
 
 
 @project_router.post("/refresh", response_model=SkillUploadResponse)
@@ -1245,19 +1247,19 @@ async def refresh_project_skill(
     if not is_valid_skill_key(body.skill_key):
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, "Invalid skill_key")
     await validate_project_for_caller(db, auth, project_id)
-    _target, source = await _project_skill_refresh_rows(
+    _target, source, source_file_key, source_file_count = await _project_skill_refresh_rows(
         db,
         owner_user_id=auth.user_id,
         project_id=project_id,
         skill_key=body.skill_key,
         source_agent_id=body.source_agent_id,
     )
-    source_snapshot = (source.id, source.content_hash, source.file_key)
+    source_snapshot = (source.id, source.content_hash, source_file_key, source_file_count)
 
     # Do not retain database locks while checking the immutable source object.
     await db.commit()
     try:
-        source_exists = await file_store.exists(source.file_key)
+        source_exists = await file_store.exists(source_file_key)
     except Exception as exc:
         log.warning(
             "project_skill_refresh_source_check_failed user=%s project=%s skill_key=%s error=%s",
@@ -1286,7 +1288,7 @@ async def refresh_project_skill(
     )
     lock_key = project_skill_advisory_lock_key(auth.user_id, project_id, body.skill_key)
     await db.execute(text("SELECT pg_advisory_xact_lock(:k)"), {"k": lock_key})
-    target, source = await _project_skill_refresh_rows(
+    target, source, source_file_key, source_file_count = await _project_skill_refresh_rows(
         db,
         owner_user_id=auth.user_id,
         project_id=project_id,
@@ -1294,7 +1296,7 @@ async def refresh_project_skill(
         source_agent_id=body.source_agent_id,
         for_update=True,
     )
-    if (source.id, source.content_hash, source.file_key) != source_snapshot:
+    if (source.id, source.content_hash, source_file_key, source_file_count) != source_snapshot:
         raise HTTPException(
             status.HTTP_409_CONFLICT,
             detail={
@@ -1309,8 +1311,8 @@ async def refresh_project_skill(
             target.name != source.name,
             target.description != source.description,
             target.content_hash != source.content_hash,
-            target.file_key != source.file_key,
-            target.file_count != source.file_count,
+            target.file_key != source_file_key,
+            target.file_count != source_file_count,
             target.source_repo != source.source_repo,
             target.agent_types != source.agent_types,
         )
@@ -1319,8 +1321,8 @@ async def refresh_project_skill(
         target.name = source.name
         target.description = source.description
         target.content_hash = source.content_hash
-        target.file_key = source.file_key
-        target.file_count = source.file_count
+        target.file_key = source_file_key
+        target.file_count = source_file_count
         target.source_repo = source.source_repo
         target.agent_types = source.agent_types
         target.authority = SKILL_AUTHORITY_CLOUD
@@ -1357,7 +1359,7 @@ async def refresh_project_skill(
         skill_key=target.skill_key,
         name=target.name,
         version=target.version,
-        file_count=source.file_count,
+        file_count=source_file_count,
         content_hash=target.content_hash,
     )
 

--- a/backend/app/schemas/skill.py
+++ b/backend/app/schemas/skill.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Literal
+from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -100,6 +101,11 @@ class SkillUploadResponse(BaseModel):
     # an extra round-trip. Empty (legacy) is fine for old callers
     # that don't read it.
     content_hash: str = ""
+
+
+class ProjectSkillRefreshRequest(BaseModel):
+    skill_key: str = Field(min_length=1, max_length=200)
+    source_agent_id: UUID
 
 
 class SkillContentUpdateRequest(BaseModel):

--- a/backend/app/services/project_runtime_skills.py
+++ b/backend/app/services/project_runtime_skills.py
@@ -339,6 +339,7 @@ async def _assert_agent_accepts_project_skills(
     agent_id: UUID,
     project_id: UUID,
     skill_identities: Iterable[ProjectSkillRuntimeIdentity],
+    allowed_workspace_skill_keys: set[str] | None = None,
 ) -> None:
     identities = tuple(skill_identities)
     if not identities:
@@ -378,7 +379,9 @@ async def _assert_agent_accepts_project_skills(
         else await _connected_workspace_skill_keys(db, agent=agent)
     )
     local_skill_keys = set(local_owners)
-    workspace_conflicts = local_skill_keys & workspace_skill_keys
+    workspace_conflicts = local_skill_keys & (
+        workspace_skill_keys - (allowed_workspace_skill_keys or set())
+    )
     project_conflicts = local_skill_keys & await _other_project_local_skill_keys(
         db,
         agent_id=agent_id,
@@ -428,6 +431,7 @@ async def assert_project_skill_write_compatible(
     skill_key: str,
     local_skill_key: str | None = None,
     enforce_total_limit: bool = True,
+    source_agent_id: UUID | None = None,
 ) -> list[UUID]:
     """Lock the graph and prove a Cloud Skill write has one runtime owner."""
     agent_ids = await lock_project_runtime_graph(db, project_id)
@@ -443,6 +447,9 @@ async def assert_project_skill_write_compatible(
                 agent_id=agent_id,
                 project_id=project_id,
                 skill_identities=proposed_identities,
+                allowed_workspace_skill_keys=(
+                    {local_skill_key} if agent_id == source_agent_id else None
+                ),
             )
     if enforce_total_limit:
         await _assert_project_skill_write_capacity(
@@ -483,7 +490,33 @@ async def assert_agent_workspace_skill_write_compatible(
     project_local_skill_keys = {
         project_skill_runtime_identity(skill_key, name).local_skill_key for skill_key, name in rows
     }
-    conflicts = sorted(skill_keys & project_local_skill_keys)
+    conflicts = skill_keys & project_local_skill_keys
+    if not conflicts:
+        return
+
+    # A linked Project may have been explicitly published from an existing
+    # Agent Workspace projection. Keep accepting updates to that established
+    # source row so a later explicit refresh can converge the Cloud snapshot;
+    # a new local copy still has no ownership evidence and remains rejected.
+    existing_source_keys = set(
+        (
+            await db.execute(
+                select(Skill.skill_key)
+                .join(
+                    AgentEnvironment,
+                    AgentEnvironment.default_project_id == Skill.project_id,
+                )
+                .where(
+                    AgentEnvironment.id == agent_id,
+                    AgentEnvironment.archived_at.is_(None),
+                    Skill.authority_agent_id == agent_id,
+                    Skill.authority == SKILL_AUTHORITY_AGENT_SYNC,
+                    Skill.is_active,
+                )
+            )
+        ).scalars()
+    )
+    conflicts = sorted(conflicts - existing_source_keys)
     if conflicts:
         skill_key = conflicts[0]
         raise HTTPException(

--- a/backend/tests/test_project_runtime_skills.py
+++ b/backend/tests/test_project_runtime_skills.py
@@ -362,6 +362,61 @@ async def test_linked_project_skill_refreshes_from_established_agent_source(
 
 
 @pytest.mark.asyncio
+async def test_project_skill_refresh_rejects_incomplete_agent_source(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user: User,
+    workspace_project: Project,
+    channel_agent: AgentEnvironment,
+):
+    skill_key = "incomplete-refresh-source"
+    uploaded = await _upload_project_skill(client, workspace_project.id, skill_key)
+    assert uploaded.status_code == 200, uploaded.text
+    db_session.add(
+        Skill(
+            user_id=seed_user.id,
+            project_id=channel_agent.default_project_id,
+            skill_key=skill_key,
+            name=skill_key,
+            description="Incomplete Agent source",
+            content_hash="f" * 64,
+            file_key=None,
+            file_count=None,
+            source=SKILL_AUTHORITY_AGENT_SYNC,
+            authority=SKILL_AUTHORITY_AGENT_SYNC,
+            authority_agent_id=channel_agent.id,
+        )
+    )
+    await db_session.commit()
+    linked = await _link(
+        client,
+        agent_id=channel_agent.id,
+        project_id=workspace_project.id,
+    )
+    assert linked.status_code == 200, linked.text
+
+    rejected = await client.post(
+        f"/v1/projects/{workspace_project.id}/skills/refresh",
+        json={"skill_key": skill_key, "source_agent_id": str(channel_agent.id)},
+    )
+    assert rejected.status_code == 409, rejected.text
+    assert rejected.json()["detail"] == {
+        "code": "project_skill_refresh_source_unavailable",
+        "message": "The source Agent's Skill archive is unavailable.",
+    }
+    project_skill = (
+        await db_session.execute(
+            select(Skill).where(
+                Skill.project_id == workspace_project.id,
+                Skill.skill_key == skill_key,
+                Skill.is_active,
+            )
+        )
+    ).scalar_one()
+    assert project_skill.content_hash == uploaded.json()["content_hash"]
+
+
+@pytest.mark.asyncio
 async def test_project_skill_refresh_rejects_viewer(
     client: httpx.AsyncClient,
     db_session: AsyncSession,

--- a/backend/tests/test_project_runtime_skills.py
+++ b/backend/tests/test_project_runtime_skills.py
@@ -16,8 +16,10 @@ from app.core.config import settings
 from app.main import app
 from app.models.agent_project_binding import AgentProjectBinding
 from app.models.api_key import ApiKey
+from app.models.audit import ControlPlaneAuditEvent
 from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
 from app.models.project import PROJECT_KIND_WORKSPACE, Project
+from app.models.project_membership import ProjectMembership
 from app.models.session import AgentEnvironment
 from app.models.skill import SKILL_AUTHORITY_AGENT_SYNC, SKILL_AUTHORITY_CLOUD, Skill
 from app.models.user import User
@@ -209,6 +211,213 @@ async def test_linked_project_skill_is_composed_into_managed_runtime_manifest(
     assert archive.status_code == 200, archive.text
     with tarfile.open(fileobj=io.BytesIO(archive.content), mode="r:gz") as result:
         assert result.getnames() == [f"{local_skill_key}/SKILL.md"]
+
+
+@pytest.mark.asyncio
+async def test_linked_project_skill_refreshes_from_established_agent_source(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user: User,
+    workspace_project: Project,
+    channel_agent: AgentEnvironment,
+):
+    skill_key = "refreshable-source"
+    uploaded = await _upload_project_skill(
+        client,
+        workspace_project.id,
+        skill_key,
+        marker="Old Project snapshot",
+    )
+    assert uploaded.status_code == 200, uploaded.text
+    old_hash = uploaded.json()["content_hash"]
+
+    _set_auth(_connected_agent_auth(seed_user))
+    try:
+        initial_source = await client.post(
+            f"/v1/agents/{channel_agent.id}/skills/sync/upload",
+            data={"skill_key": skill_key},
+            files={
+                "file": (
+                    f"{skill_key}.tar.gz",
+                    _skill_archive(skill_key, "Initial Agent source"),
+                    "application/gzip",
+                )
+            },
+        )
+    finally:
+        _set_auth(AuthContext(user=seed_user))
+    assert initial_source.status_code == 200, initial_source.text
+
+    linked = await _link(
+        client,
+        agent_id=channel_agent.id,
+        project_id=workspace_project.id,
+    )
+    assert linked.status_code == 200, linked.text
+    await _make_runtime_renderable(
+        db_session,
+        user=seed_user,
+        agent_id=channel_agent.id,
+    )
+    old_batch = await load_runtime_source_batch(
+        db_session,
+        environment_ids=[channel_agent.id],
+        owner_user_id=seed_user.id,
+    )
+    old_rendered = render_runtime_source(
+        old_batch,
+        environment_id=channel_agent.id,
+        public_api_url="https://cloud.example.test",
+        vault_key_identity=vault_key_identity(settings.vault_encryption_key),
+        decrypt_secrets=False,
+    )
+    old_source = old_rendered.manifest["skills"]["entries"][skill_key]["source"]
+    assert old_source["contentHash"] == old_hash
+
+    _set_auth(_connected_agent_auth(seed_user))
+    try:
+        updated_source = await client.post(
+            f"/v1/agents/{channel_agent.id}/skills/sync/upload",
+            data={"skill_key": skill_key},
+            files={
+                "file": (
+                    f"{skill_key}.tar.gz",
+                    _skill_archive(skill_key, "Updated Agent source"),
+                    "application/gzip",
+                )
+            },
+        )
+    finally:
+        _set_auth(AuthContext(user=seed_user))
+    assert updated_source.status_code == 200, updated_source.text
+    new_hash = updated_source.json()["content_hash"]
+    assert new_hash != old_hash
+
+    refreshed = await client.post(
+        f"/v1/projects/{workspace_project.id}/skills/refresh",
+        json={"skill_key": skill_key, "source_agent_id": str(channel_agent.id)},
+    )
+    assert refreshed.status_code == 200, refreshed.text
+    assert refreshed.json()["content_hash"] == new_hash
+
+    source_skill = (
+        await db_session.execute(
+            select(Skill).where(
+                Skill.project_id == channel_agent.default_project_id,
+                Skill.skill_key == skill_key,
+                Skill.is_active,
+            )
+        )
+    ).scalar_one()
+    project_skill = (
+        await db_session.execute(
+            select(Skill).where(
+                Skill.project_id == workspace_project.id,
+                Skill.skill_key == skill_key,
+                Skill.is_active,
+            )
+        )
+    ).scalar_one()
+    assert project_skill.authority == SKILL_AUTHORITY_CLOUD
+    assert project_skill.authority_agent_id is None
+    assert project_skill.content_hash == source_skill.content_hash
+    assert project_skill.file_key == source_skill.file_key
+    assert project_skill.file_count == source_skill.file_count
+
+    refreshed_batch = await load_runtime_source_batch(
+        db_session,
+        environment_ids=[channel_agent.id],
+        owner_user_id=seed_user.id,
+    )
+    refreshed_rendered = render_runtime_source(
+        refreshed_batch,
+        environment_id=channel_agent.id,
+        public_api_url="https://cloud.example.test",
+        vault_key_identity=vault_key_identity(settings.vault_encryption_key),
+        decrypt_secrets=False,
+    )
+    refreshed_source = refreshed_rendered.manifest["skills"]["entries"][skill_key]["source"]
+    assert refreshed_source["contentHash"] == new_hash
+    assert refreshed_source["archiveUrl"] != old_source["archiveUrl"]
+    archive = await client.get(urlsplit(refreshed_source["archiveUrl"]).path)
+    assert archive.status_code == 200, archive.text
+    with tarfile.open(fileobj=io.BytesIO(archive.content), mode="r:gz") as result:
+        skill_md = result.extractfile(f"{skill_key}/SKILL.md")
+        assert skill_md is not None
+        assert "Updated Agent source" in skill_md.read().decode()
+
+    audit = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.action == "project_skill.refresh",
+                ControlPlaneAuditEvent.resource_id == str(project_skill.id),
+            )
+        )
+    ).scalar_one()
+    assert audit.actor_user_id == seed_user.id
+    assert audit.environment_id == channel_agent.id
+    assert audit.details["previous_content_hash"] == old_hash
+    assert audit.details["content_hash"] == new_hash
+    assert audit.details["changed"] is True
+
+
+@pytest.mark.asyncio
+async def test_project_skill_refresh_rejects_viewer(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user: User,
+    workspace_project: Project,
+    channel_agent: AgentEnvironment,
+):
+    skill_key = "owner-refresh-only"
+    uploaded = await _upload_project_skill(client, workspace_project.id, skill_key)
+    assert uploaded.status_code == 200, uploaded.text
+    viewer = User(
+        clerk_id=f"viewer_{uuid.uuid4().hex}",
+        email=f"viewer-{uuid.uuid4().hex}@test.dev",
+        name="Project Viewer",
+    )
+    db_session.add(viewer)
+    await db_session.flush()
+    db_session.add(
+        ProjectMembership(
+            project_id=workspace_project.id,
+            member_user_id=viewer.id,
+            role="viewer",
+            joined_via="invite",
+            joined_at=datetime.now(UTC),
+            resolved_owner_handle="project-owner",
+        )
+    )
+    await db_session.commit()
+
+    _set_auth(AuthContext(user=viewer))
+    try:
+        rejected = await client.post(
+            f"/v1/projects/{workspace_project.id}/skills/refresh",
+            json={"skill_key": skill_key, "source_agent_id": str(channel_agent.id)},
+        )
+    finally:
+        _set_auth(AuthContext(user=seed_user))
+    assert rejected.status_code == 404, rejected.text
+
+    project_skill = (
+        await db_session.execute(
+            select(Skill).where(
+                Skill.project_id == workspace_project.id,
+                Skill.skill_key == skill_key,
+                Skill.is_active,
+            )
+        )
+    ).scalar_one()
+    assert project_skill.content_hash == uploaded.json()["content_hash"]
+    audit_count = await db_session.scalar(
+        select(ControlPlaneAuditEvent.id).where(
+            ControlPlaneAuditEvent.action == "project_skill.refresh",
+            ControlPlaneAuditEvent.resource_id == str(project_skill.id),
+        )
+    )
+    assert audit_count is None
 
 
 @pytest.mark.asyncio

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1785,6 +1785,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/projects/{project_id}/skills/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Refresh Project Skill
+         * @description Explicitly replace one linked Project snapshot from its source Agent.
+         */
+        post: operations["refresh_project_skill_v1_projects__project_id__skills_refresh_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/projects/{project_id}/skills": {
         parameters: {
             query?: never;
@@ -6664,6 +6684,16 @@ export interface components {
              * @constant
              */
             project_skill_reconcile_version: 1;
+        };
+        /** ProjectSkillRefreshRequest */
+        ProjectSkillRefreshRequest: {
+            /** Skill Key */
+            skill_key: string;
+            /**
+             * Source Agent Id
+             * Format: uuid
+             */
+            source_agent_id: string;
         };
         /** ProjectUpdate */
         ProjectUpdate: {
@@ -11806,6 +11836,41 @@ export interface operations {
         requestBody: {
             content: {
                 "multipart/form-data": components["schemas"]["Body_upload_skill_project_v1_projects__project_id__skills_upload_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SkillUploadResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    refresh_project_skill_v1_projects__project_id__skills_refresh_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProjectSkillRefreshRequest"];
             };
         };
         responses: {


### PR DESCRIPTION
## Current model

- Agent Workspace Skills persist as `authority=agent_sync` observations in the Agent environment Project.
- Linked Projects deliver only `authority=cloud` rows, and runtime manifests pin the Project Skill id plus content hash.
- Agent sync intentionally does not auto-publish into linked Projects, so the Cloud row remains a one-time snapshot.

## Refresh design

- Add `POST /v1/projects/{project_id}/skills/refresh` for an explicit owner-triggered refresh.
- Require a source Agent owned by the Project owner, linked to the target workspace Project, with an established same-key `agent_sync` row in its current environment Project.
- Revalidate the Project graph under the existing Project-to-Agent lock order, preserve the stable Cloud Skill id and Cloud authority, and copy the latest content hash, file key, file count, and content metadata.
- Reuse the existing Skill revision and runtime-manifest invalidation fan-out so the changed Project source identity causes normal fleet reinstall behavior.
- Record `project_skill.refresh` in the control-plane audit log. Viewer members remain read-only.

## 409 semantics

- Continue rejecting creation of a new Agent Workspace Skill whose runtime name is already supplied by a linked Project.
- Allow updates only when that key already has an active `agent_sync` row owned by the same Agent in its current environment Project. This preserves the original ambiguity guard while allowing an established publish source to converge instead of remaining stuck on `agent_workspace_project_skill_name_conflict`.
- During refresh, exempt only the explicitly named source Agent from the corresponding Project-write collision check; every other linked Agent and sibling Project conflict remains enforced.

## Verification

- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run python -m compileall -q app scripts tests alembic`
- `uv run pytest -q tests/test_project_runtime_skills.py tests/test_runtime_manifest.py -k ...` (16 passed)
- focused refresh, 409, and viewer tests (3 passed)
- `uv run python scripts/check_generated_api.py`
- `bunx bun@1.4.0 run --cwd packages/shared typecheck`

Closes #1164

🤖 Generated with [Claude Code](https://claude.com/claude-code)