### PR TITLE
refactor(cli): remove completed migration shims

### DIFF
--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -1384,8 +1384,10 @@ def test_runtime_bundle_matches_shared_golden(monkeypatch) -> None:
         "decrypt",
         lambda ciphertext, _nonce: plaintext_by_ciphertext[ciphertext],
     )
+    batch = _batch()
+    _set_healthy_cli_observation(batch, desired="clawdi@1.2.3-test")
     source = render_runtime_source(
-        _batch(),
+        batch,
         environment_id=ENV_ID,
         public_api_url="https://cloud.test/",
         vault_key_identity="vault-key-generation-1",

--- a/packages/cli/src/runtime/hosted-bundled-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.test.ts
@@ -1,9 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
-	chmodSync,
 	cpSync,
 	existsSync,
-	mkdirSync,
 	mkdtempSync,
 	readFileSync,
 	rmSync,
@@ -15,7 +13,6 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import {
 	assertHostedBundledSkillCatalogDigest,
-	claimLegacyHostedBundledSkill,
 	resolveHostedBundledSkill,
 } from "./hosted-bundled-skill";
 import { prepareHostedBundledSkillArchive } from "./hosted-sourced-skill-archive";
@@ -74,6 +71,16 @@ describe("hosted bundled Skill preparation", () => {
 			"catalog digest mismatch",
 		);
 
+		const legacy = join(root, "legacy-marker");
+		cpSync(bundledSourceDir, legacy, { recursive: true });
+		writeFileSync(
+			join(legacy, ".clawdi-managed.json"),
+			`${JSON.stringify({ managedBy: "clawdi runtime init", skillName: "clawdi" })}\n`,
+		);
+		expect(() => assertHostedBundledSkillCatalogDigest(catalogEntry, legacy)).toThrow(
+			"catalog digest mismatch",
+		);
+
 		cpSync(bundledSourceDir, copied, { recursive: true, force: true });
 		const outside = join(root, "outside");
 		writeFileSync(outside, "outside\n");
@@ -81,69 +88,5 @@ describe("hosted bundled Skill preparation", () => {
 		expect(() => assertHostedBundledSkillCatalogDigest(catalogEntry, copied)).toThrow(
 			"symbolic links are not supported",
 		);
-	});
-
-	test("claims every legacy marker schema through one receipt-anchored transaction", () => {
-		root = mkdtempSync(join(tmpdir(), "hosted-bundled-legacy-"));
-		const target = join(root, "skills", "clawdi");
-		mkdirSync(dirname(target), { recursive: true });
-		cpSync(bundledSourceDir, target, { recursive: true });
-		chmodSync(target, 0o755);
-		chmodSync(join(target, "SKILL.md"), 0o644);
-		const marker = join(target, ".clawdi-managed.json");
-		const receipt = join(root, "receipts", "clawdi.json");
-		for (const markerValue of [
-			{ managedBy: "clawdi runtime init", skillName: "clawdi" },
-			{
-				schema: "clawdi.hostedBundledSkillMarker.v1",
-				owner: "clawdi runtime init",
-				id: "clawdi",
-				version: 1,
-				digest: catalogEntry.digest,
-			},
-		]) {
-			const operations: string[] = [];
-			writeFileSync(marker, `${JSON.stringify(markerValue)}\n`);
-			expect(
-				claimLegacyHostedBundledSkill({
-					targetDir: target,
-					skillId: "clawdi",
-					reserve: (entry) => operations.push(`reserve:${entry.version}`),
-					anchorOwnership: (identity) => {
-						operations.push(`anchor:${identity}`);
-						mkdirSync(dirname(receipt), { recursive: true });
-						writeFileSync(receipt, identity);
-					},
-				}),
-			).toBe(true);
-			expect(operations).toEqual(["reserve:1", `anchor:content-sha256\0${catalogEntry.digest}`]);
-			expect(existsSync(marker)).toBe(false);
-			expect(readFileSync(receipt, "utf8")).toBe(`content-sha256\0${catalogEntry.digest}`);
-		}
-
-		writeFileSync(
-			marker,
-			`${JSON.stringify({
-				schema: "clawdi.hostedBundledSkillMarker.v1",
-				owner: "clawdi runtime init",
-				id: "clawdi",
-				version: 1,
-				digest: catalogEntry.digest,
-			})}\n`,
-		);
-		writeFileSync(join(target, "SKILL.md"), "tenant bytes\n");
-		expect(
-			claimLegacyHostedBundledSkill({
-				targetDir: target,
-				skillId: "clawdi",
-				reserve: () => {
-					throw new Error("must not reserve");
-				},
-				anchorOwnership: () => {
-					throw new Error("must not anchor");
-				},
-			}),
-		).toBe(false);
-		expect(existsSync(marker)).toBe(true);
 	});
 });

--- a/packages/cli/src/runtime/hosted-bundled-skill.ts
+++ b/packages/cli/src/runtime/hosted-bundled-skill.ts
@@ -1,15 +1,6 @@
-import { lstatSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { lstatSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import {
-	canonicalManagedBundleFileMode,
-	computeManagedBundleHash,
-	type ManagedBundleHashEntry,
-} from "./managed-bundle-hash";
-import { withRuntimeUserFileAccess } from "./runtime-user-command";
-
-const LEGACY_MARKER = ".clawdi-managed.json";
-const LEGACY_MARKER_SCHEMA = "clawdi.hostedBundledSkillMarker.v1";
-const LEGACY_MARKER_OWNER = "clawdi runtime init";
+import { computeManagedBundleHash, type ManagedBundleHashEntry } from "./managed-bundle-hash";
 
 export interface HostedBundledSkillCatalogEntry {
 	id: string;
@@ -41,7 +32,6 @@ const HOSTED_BUNDLED_SKILL_CATALOG = new Map<
 function collectDirectoryEntries(
 	directory: string,
 	prefix: string,
-	options: { excludeLegacyMarker: boolean; requireCanonicalModes: boolean },
 	files: ManagedBundleHashEntry[],
 ): void {
 	const entries = readdirSync(directory, { withFileTypes: true }).sort((left, right) =>
@@ -49,24 +39,17 @@ function collectDirectoryEntries(
 	);
 	for (const entry of entries) {
 		const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
-		if (options.excludeLegacyMarker && relativePath === LEGACY_MARKER) continue;
 		const path = join(directory, entry.name);
 		const stat = lstatSync(path);
 		if (stat.isSymbolicLink()) {
 			throw new Error(`symbolic links are not supported in managed skills: ${path}`);
 		}
 		if (stat.isDirectory()) {
-			if (options.requireCanonicalModes && (stat.mode & 0o777) !== 0o755) {
-				throw new Error(`managed skill directory mode is not canonical: ${path}`);
-			}
-			collectDirectoryEntries(path, relativePath, options, files);
+			collectDirectoryEntries(path, relativePath, files);
 			continue;
 		}
 		if (stat.isFile()) {
 			const mode = stat.mode & 0o777;
-			if (options.requireCanonicalModes && mode !== canonicalManagedBundleFileMode(mode)) {
-				throw new Error(`managed skill file mode is not canonical: ${path}`);
-			}
 			files.push({ relativePath, mode, content: readFileSync(path) });
 			continue;
 		}
@@ -74,27 +57,13 @@ function collectDirectoryEntries(
 	}
 }
 
-function directoryDigest(
-	directory: string,
-	options: { excludeLegacyMarker?: boolean; requireCanonicalModes?: boolean } = {},
-): string {
+function directoryDigest(directory: string): string {
 	const stat = lstatSync(directory);
 	if (stat.isSymbolicLink() || !stat.isDirectory()) {
 		throw new Error(`managed skill path is not a directory: ${directory}`);
 	}
-	if (options.requireCanonicalModes && (stat.mode & 0o777) !== 0o755) {
-		throw new Error(`managed skill directory mode is not canonical: ${directory}`);
-	}
 	const files: ManagedBundleHashEntry[] = [];
-	collectDirectoryEntries(
-		directory,
-		"",
-		{
-			excludeLegacyMarker: options.excludeLegacyMarker ?? false,
-			requireCanonicalModes: options.requireCanonicalModes ?? false,
-		},
-		files,
-	);
+	collectDirectoryEntries(directory, "", files);
 	return computeManagedBundleHash(files);
 }
 
@@ -128,79 +97,4 @@ export function assertHostedBundledSkillCatalogDigest(
 			`bundled hosted skill catalog digest mismatch for ${catalogEntry.id} version ${catalogEntry.version}`,
 		);
 	}
-}
-
-function readLegacyMarker(targetDir: string): Record<string, unknown> | null {
-	try {
-		const path = join(targetDir, LEGACY_MARKER);
-		if (!lstatSync(path).isFile()) return null;
-		const value: unknown = JSON.parse(readFileSync(path, "utf8"));
-		return value && typeof value === "object" && !Array.isArray(value)
-			? (value as Record<string, unknown>)
-			: null;
-	} catch {
-		return null;
-	}
-}
-
-/**
- * One-time migration shim for pre-ledger hosted bundles. Remove only after all
- * supported hosted CLI versions have written reservation-backed receipts and
- * the oldest pre-ledger runtime image is outside the supported upgrade window.
- */
-function adoptableLegacyHostedBundledSkill(
-	targetDir: string,
-	skillId: string,
-): HostedBundledSkillCatalogEntry | null {
-	const marker = readLegacyMarker(targetDir);
-	if (!marker) return null;
-	const current =
-		marker.schema === LEGACY_MARKER_SCHEMA &&
-		marker.owner === LEGACY_MARKER_OWNER &&
-		marker.id === skillId &&
-		typeof marker.version === "number" &&
-		Number.isSafeInteger(marker.version) &&
-		marker.version > 0 &&
-		typeof marker.digest === "string";
-	const legacy = marker.managedBy === LEGACY_MARKER_OWNER && marker.skillName === skillId;
-	if (!current && !legacy) return null;
-	let catalogEntry: HostedBundledSkillCatalogEntry;
-	try {
-		catalogEntry = resolveHostedBundledSkill(skillId, current ? (marker.version as number) : 1);
-	} catch {
-		return null;
-	}
-	if (current && marker.digest !== catalogEntry.digest) return null;
-	try {
-		return directoryDigest(targetDir, {
-			excludeLegacyMarker: true,
-			requireCanonicalModes: true,
-		}) === catalogEntry.digest
-			? catalogEntry
-			: null;
-	} catch {
-		return null;
-	}
-}
-
-export function claimLegacyHostedBundledSkill(input: {
-	targetDir: string;
-	skillId: string;
-	reserve(catalogEntry: HostedBundledSkillCatalogEntry): void;
-	anchorOwnership(ownershipIdentity: string): void;
-}): boolean {
-	const catalogEntry = withRuntimeUserFileAccess(() =>
-		adoptableLegacyHostedBundledSkill(input.targetDir, input.skillId),
-	);
-	if (!catalogEntry) return false;
-
-	input.reserve(catalogEntry);
-	withRuntimeUserFileAccess(() => {
-		if (adoptableLegacyHostedBundledSkill(input.targetDir, input.skillId) !== catalogEntry) {
-			throw new Error("legacy hosted Skill identity changed during ownership claim");
-		}
-		rmSync(join(input.targetDir, LEGACY_MARKER));
-	});
-	input.anchorOwnership(`content-sha256\0${catalogEntry.digest}`);
-	return true;
 }

--- a/packages/cli/src/runtime/hosted-hermes-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.test.ts
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
-	chmodSync,
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
@@ -22,7 +21,6 @@ let root: string | null = null;
 
 afterEach(() => {
 	delete process.env.CLAWDI_RUNTIME_USER;
-	delete process.env.FAKE_HERMES_LOG;
 	if (root) rmSync(root, { recursive: true, force: true });
 	root = null;
 });
@@ -116,35 +114,6 @@ function fakeHermesLocalSkills(home: string): Array<{
 		});
 }
 
-function fakeHermesUninstaller(home: string): string {
-	const appRoot = join(home, ".hermes", "hermes-agent");
-	const hermes = join(appRoot, "venv", "bin", "hermes");
-	mkdirSync(dirname(hermes), { recursive: true });
-	writeFileSync(
-		hermes,
-		`#!/usr/bin/python3
-import json, os, shutil, sys
-from pathlib import Path
-
-if sys.argv[1:3] != ["skills", "uninstall"] or len(sys.argv) != 4:
-    raise SystemExit(2)
-if sys.stdin.readline().strip().lower() not in {"y", "yes"}:
-    raise SystemExit(3)
-name = sys.argv[3]
-skills_root = Path(os.environ["HOME"]) / ".hermes" / "skills"
-shutil.rmtree(skills_root / name)
-lock_path = skills_root / ".hub" / "lock.json"
-lock = json.loads(lock_path.read_text())
-lock["installed"].pop(name, None)
-lock_path.write_text(json.dumps(lock, indent=2) + chr(10))
-with Path(os.environ["FAKE_HERMES_LOG"]).open("a") as log:
-    log.write(" ".join(sys.argv[1:]) + chr(10))
-`,
-	);
-	chmodSync(hermes, 0o755);
-	return appRoot;
-}
-
 describe("Hermes exact-source Workspace Skill driver", () => {
 	test("places a hub-blocked dangerous source on the official local discovery surface", () => {
 		root = mkdtempSync(join(tmpdir(), "hosted-hermes-dangerous-local-"));
@@ -180,7 +149,6 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 		expect(
 			hostedHermesSkillExactSourceDriver.install({
 				home,
-				appRoot: join(home, ".hermes", "hermes-agent"),
 				managedResourceRoot,
 				skill,
 				previouslyReserved: false,
@@ -206,7 +174,6 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 		expect(
 			hostedHermesSkillExactSourceDriver.uninstall({
 				home,
-				appRoot: join(home, ".hermes", "hermes-agent"),
 				managedResourceRoot,
 				skillId,
 				ownershipIdentity: skill.sourceIdentity,
@@ -232,7 +199,6 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 		const receipt = managedSkillReceiptPath(managedResourceRoot, "hermes", skillId);
 		const input = {
 			home,
-			appRoot: join(root, "missing-hermes-app"),
 			managedResourceRoot,
 			skill,
 		};
@@ -275,8 +241,8 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 		).toBe(true);
 	});
 
-	test("migrates an owned legacy loopback hub install to stable local discovery once", () => {
-		root = mkdtempSync(join(tmpdir(), "hosted-hermes-loopback-migration-"));
+	test("ignores retired loopback hub metadata for a receipt-owned local Skill", () => {
+		root = mkdtempSync(join(tmpdir(), "hosted-hermes-loopback-metadata-"));
 		const home = join(root, "home");
 		const managedResourceRoot = join(root, "managed-resources");
 		mkdirSync(managedResourceRoot, { recursive: true });
@@ -287,10 +253,8 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 		};
 		const archive = archiveSkill(root, skillId, skillFiles);
 		const skill = sourcedSkill(skillId, archive);
-		const target = join(home, ".hermes", "skills", skillId);
 		const input = {
 			home,
-			appRoot: join(home, ".hermes", "hermes-agent"),
 			managedResourceRoot,
 			skill,
 		};
@@ -298,8 +262,6 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 		expect(
 			hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: false }),
 		).toBe("installed");
-		const skillBytes = readFileSync(join(target, "SKILL.md"));
-		const guideBytes = readFileSync(join(target, "references", "guide.md"));
 		const lockPath = join(home, ".hermes", "skills", ".hub", "lock.json");
 		mkdirSync(dirname(lockPath), { recursive: true });
 		const externalEntry = {
@@ -321,36 +283,19 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 				},
 			})}\n`,
 		);
-		const commandLog = join(root, "hermes.log");
-		process.env.FAKE_HERMES_LOG = commandLog;
-		input.appRoot = fakeHermesUninstaller(home);
-
-		expect(
-			hostedHermesSkillExactSourceDriver.install({
-				...input,
-				previouslyReserved: true,
-				previousTargetDir: target,
-				previousOwnershipIdentity: skill.sourceIdentity,
-			}),
-		).toBe("installed");
-		expect(readFileSync(join(target, "SKILL.md"))).toEqual(skillBytes);
-		expect(readFileSync(join(target, "references", "guide.md"))).toEqual(guideBytes);
-		expect(JSON.parse(readFileSync(lockPath, "utf8"))).toEqual({
-			version: 1,
-			installed: { "user-skill": externalEntry },
-		});
-		expect(fakeHermesLocalSkills(home)).toEqual([
-			{ name: skillId, source: "local", trust: "local", status: "enabled" },
-		]);
-		expect(readFileSync(commandLog, "utf8")).toBe(`skills uninstall ${skillId}\n`);
-
+		const lockBefore = readFileSync(lockPath);
 		expect(hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: true })).toBe(
 			"unchanged",
 		);
-		expect(readFileSync(commandLog, "utf8")).toBe(`skills uninstall ${skillId}\n`);
-		expect(JSON.parse(readFileSync(lockPath, "utf8")).installed["user-skill"]).toEqual(
-			externalEntry,
-		);
+		expect(readFileSync(lockPath)).toEqual(lockBefore);
+		expect(JSON.parse(readFileSync(lockPath, "utf8")).installed).toEqual({
+			[skillId]: {
+				source: "url",
+				identifier: `http://127.0.0.1:43123/0${"a".repeat(64)}/SKILL.md`,
+				install_path: skillId,
+			},
+			"user-skill": externalEntry,
+		});
 	});
 
 	test("preserves unreserved and locally changed targets", () => {
@@ -369,7 +314,6 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 		expect(() =>
 			hostedHermesSkillExactSourceDriver.install({
 				home,
-				appRoot: join(fixtureRoot, "missing-hermes-app"),
 				managedResourceRoot,
 				skill,
 				previouslyReserved: false,

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, rmSync } from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
+import { existsSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import {
 	collectManagedSkillTree,
@@ -15,25 +15,16 @@ import {
 	writeManagedSkillReceipt,
 } from "./managed-skill-delivery";
 import { replaceManagedSkillDirectoryAtomic } from "./managed-skill-reservation";
-import {
-	executableExists,
-	spawnRuntimeUserCommand,
-	withRuntimeUserFileAccess,
-} from "./runtime-user-command";
-
-const HERMES_SKILL_COMMAND_TIMEOUT_MS = 120_000;
+import { withRuntimeUserFileAccess } from "./runtime-user-command";
 
 export interface HostedHermesSkillExactSourceDriver {
 	target?(input: { home: string; skill: PreparedHostedSourcedSkill }): string;
 	install(input: {
 		home: string;
-		appRoot: string;
 		managedResourceRoot: string;
 		skill: PreparedHostedSourcedSkill;
 		targetDir?: string;
 		previouslyReserved: boolean;
-		previousTargetDir?: string;
-		previousOwnershipIdentity?: string;
 	}): "installed" | "unchanged";
 	anchorOwnership(input: {
 		home: string;
@@ -44,7 +35,6 @@ export interface HostedHermesSkillExactSourceDriver {
 	}): void;
 	verifyOwned(input: {
 		home: string;
-		appRoot: string;
 		managedResourceRoot: string;
 		skill: PreparedHostedSourcedSkill;
 		targetDir?: string;
@@ -58,7 +48,6 @@ export interface HostedHermesSkillExactSourceDriver {
 	}): boolean;
 	uninstall(input: {
 		home: string;
-		appRoot: string;
 		managedResourceRoot: string;
 		skillId: string;
 		ownershipIdentity: string;
@@ -78,18 +67,6 @@ function targetDir(home: string, skillId: string): string {
 	// hub install guard. Revisit if upstream starts guarding this path
 	// (NousResearch/hermes-agent#89704, Clawdi-AI/clawdi#1148).
 	return join(home, ".hermes", "skills", skillId);
-}
-
-function commandPath(home: string, appRoot: string): string {
-	return withRuntimeUserFileAccess(() => {
-		for (const candidate of [
-			join(appRoot, "venv", "bin", "hermes"),
-			join(home, ".local", "bin", "hermes"),
-		]) {
-			if (executableExists(candidate)) return candidate;
-		}
-		throw new Error("installed Hermes Skill CLI is unavailable");
-	});
 }
 
 function receiptInput(
@@ -119,182 +96,6 @@ function assertActivationMatchesSource(sourceDir: string, target: string): void 
 	}
 	if (!managedSkillTreesEqual(source.tree, installed.tree)) {
 		throw new ManagedSkillResourceError("Hermes Skill activation changed exact source bytes");
-	}
-}
-
-const HERMES_URL_SKILL_NAME_PATTERN = /^[a-z][a-z0-9_-]*$/;
-const HERMES_RESERVED_URL_SKILL_NAMES = new Set(["skill", "readme", "index", "unnamed-skill"]);
-
-function validHermesUrlSkillName(value: unknown): value is string {
-	if (typeof value !== "string") return false;
-	const candidate = value.trim().toLowerCase();
-	return (
-		candidate.length > 0 &&
-		!HERMES_RESERVED_URL_SKILL_NAMES.has(candidate) &&
-		HERMES_URL_SKILL_NAME_PATTERN.test(candidate)
-	);
-}
-
-function readHermesInstalledLock(home: string): {
-	skillsRoot: string;
-	installed: Record<string, unknown>;
-} | null {
-	const skillsRoot = resolve(home, ".hermes", "skills");
-	const lockPath = join(skillsRoot, ".hub", "lock.json");
-	if (!existsSync(lockPath)) return null;
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(readFileSync(lockPath, "utf8"));
-	} catch {
-		throw new ManagedSkillResourceError("Hermes Skill lock is invalid");
-	}
-	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-		throw new ManagedSkillResourceError("Hermes Skill lock is invalid");
-	}
-	const lock = parsed as Record<string, unknown>;
-	if (
-		lock.version !== 1 ||
-		typeof lock.installed !== "object" ||
-		lock.installed === null ||
-		Array.isArray(lock.installed)
-	) {
-		throw new ManagedSkillResourceError("Hermes Skill lock is invalid");
-	}
-	return { skillsRoot, installed: lock.installed as Record<string, unknown> };
-}
-
-function hermesLockTarget(skillsRoot: string, name: string, installPath: unknown): string {
-	if (
-		!validHermesUrlSkillName(name) ||
-		typeof installPath !== "string" ||
-		installPath !== name ||
-		dirname(resolve(skillsRoot, installPath)) !== skillsRoot ||
-		basename(resolve(skillsRoot, installPath)) !== name
-	) {
-		throw new ManagedSkillResourceError("Hermes Skill lock install path is unsafe");
-	}
-	return join(skillsRoot, installPath);
-}
-
-function legacyLoopbackHubTarget(home: string, target: string): string | null {
-	const expected = resolve(target);
-	return withRuntimeUserFileAccess(() => {
-		const lock = readHermesInstalledLock(home);
-		if (!lock || dirname(expected) !== lock.skillsRoot) return null;
-		const name = basename(expected);
-		const entry = lock.installed[name];
-		if (typeof entry !== "object" || entry === null || Array.isArray(entry)) return null;
-		const record = entry as Record<string, unknown>;
-		if (record.source !== "url") return null;
-		if (typeof record.identifier !== "string") {
-			throw new ManagedSkillResourceError("Hermes Skill lock source is invalid");
-		}
-		let source: URL;
-		try {
-			source = new URL(record.identifier);
-		} catch {
-			throw new ManagedSkillResourceError("Hermes Skill lock source is invalid");
-		}
-		if (source.protocol !== "http:" || source.hostname !== "127.0.0.1") return null;
-		if (
-			source.href !== record.identifier ||
-			!source.port ||
-			Number(source.port) < 1 ||
-			source.username ||
-			source.password ||
-			source.search ||
-			source.hash ||
-			!/^\/0[a-f0-9]{64}\/SKILL\.md$/.test(source.pathname)
-		) {
-			throw new ManagedSkillResourceError("Hermes Skill lock source is invalid");
-		}
-		if (hermesLockTarget(lock.skillsRoot, name, record.install_path) !== expected) {
-			throw new ManagedSkillResourceError("Hermes Skill lock install path is unsafe");
-		}
-		let identityMatches = 0;
-		for (const value of Object.values(lock.installed)) {
-			if (typeof value !== "object" || value === null || Array.isArray(value)) continue;
-			const candidate = value as Record<string, unknown>;
-			if (candidate.identifier !== record.identifier) continue;
-			if (candidate.source !== "url") {
-				throw new ManagedSkillResourceError("Hermes Skill lock source is invalid");
-			}
-			identityMatches += 1;
-		}
-		if (identityMatches !== 1) {
-			throw new ManagedSkillResourceError("Hermes Skill lock source identity is ambiguous");
-		}
-		return expected;
-	});
-}
-
-function hermesLockHasTarget(home: string, target: string): boolean {
-	const expected = resolve(target);
-	return withRuntimeUserFileAccess(() => {
-		const lock = readHermesInstalledLock(home);
-		if (!lock || dirname(expected) !== lock.skillsRoot) return false;
-		return Object.hasOwn(lock.installed, basename(expected));
-	});
-}
-
-function runHermesUninstall(
-	input: { home: string; appRoot: string },
-	skillName: string,
-): ReturnType<typeof spawnRuntimeUserCommand> {
-	// Feed stdin for Hermes 0.20 variants that predate the --yes flag.
-	return spawnRuntimeUserCommand(
-		commandPath(input.home, input.appRoot),
-		["skills", "uninstall", skillName],
-		input.home,
-		input.appRoot,
-		{
-			input: "y\n",
-			timeoutMs: HERMES_SKILL_COMMAND_TIMEOUT_MS,
-			maxBufferBytes: 1024 * 1024,
-		},
-	);
-}
-
-function hermesCommandOutput(result: ReturnType<typeof runHermesUninstall>): string {
-	return [result.stderr, result.stdout]
-		.map((value) => String(value ?? "").trim())
-		.filter(Boolean)
-		.join("\n");
-}
-
-function migrateLegacyLoopbackHubInstall(input: {
-	home: string;
-	appRoot: string;
-	managedResourceRoot: string;
-	skillId: string;
-	ownershipIdentity: string;
-	target: string;
-}): void {
-	const receipt = receiptInput(
-		input.managedResourceRoot,
-		input.skillId,
-		input.ownershipIdentity,
-		input.target,
-	);
-	if (!managedSkillReceiptMatchesIdentity(receipt)) return;
-	if (legacyLoopbackHubTarget(input.home, input.target) !== input.target) return;
-
-	// SUNSET(#1148): remove after the fleet has fully upgraded through CLI 0.14.10.
-	const result = runHermesUninstall(input, basename(input.target));
-	if (result.status !== 0) {
-		throw new ManagedSkillResourceError(
-			`Hermes official Skill uninstall failed: ${hermesCommandOutput(result) || result.error?.message || "unknown error"}`,
-		);
-	}
-	if (withRuntimeUserFileAccess(() => existsSync(input.target))) {
-		throw new ManagedSkillResourceError(
-			"Hermes official Skill uninstall did not remove the Skill target",
-		);
-	}
-	if (hermesLockHasTarget(input.home, input.target)) {
-		throw new ManagedSkillResourceError(
-			"Hermes official Skill uninstall did not remove the Skill lock entry",
-		);
 	}
 }
 
@@ -334,16 +135,6 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 	},
 	install(input) {
 		const target = resolve(input.targetDir ?? targetDir(input.home, input.skill.skillId));
-		if (input.previouslyReserved) {
-			migrateLegacyLoopbackHubInstall({
-				home: input.home,
-				appRoot: input.appRoot,
-				managedResourceRoot: input.managedResourceRoot,
-				skillId: input.skill.skillId,
-				ownershipIdentity: input.previousOwnershipIdentity ?? input.skill.sourceIdentity,
-				target: resolve(input.previousTargetDir ?? target),
-			});
-		}
 		const receipt = receiptInput(
 			input.managedResourceRoot,
 			input.skill.skillId,

--- a/packages/cli/src/runtime/managed-skill-delivery.ts
+++ b/packages/cli/src/runtime/managed-skill-delivery.ts
@@ -15,7 +15,7 @@ import {
 	rmSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { managedSkillDirectoryDigest } from "./hosted-bundled-skill";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
@@ -25,7 +25,6 @@ const MAX_ENTRIES = 1024;
 const MAX_FILE_BYTES = 16 * 1024 * 1024;
 const MAX_TREE_BYTES = 32 * 1024 * 1024;
 const MANAGED_SKILL_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
-const LEGACY_RECEIPT_DIRECTORY = ".clawdi-manifest-receipts";
 const PLATFORM_RECEIPT_DIRECTORY = "skill-receipts";
 
 export const HERMES_MANAGED_SKILL_RECEIPT_SCHEMA = "clawdi.hermesManifestSkillReceipt.v2";
@@ -47,11 +46,6 @@ export function managedSkillReceiptPath(
 ): string {
 	assertManagedSkillId(skillId);
 	return join(managedResourceRoot, PLATFORM_RECEIPT_DIRECTORY, runtime, `${skillId}.json`);
-}
-
-export function legacyManagedSkillReceiptPath(skillsRoot: string, skillId: string): string {
-	assertManagedSkillId(skillId);
-	return join(skillsRoot, LEGACY_RECEIPT_DIRECTORY, `${skillId}.json`);
 }
 
 export type ManagedSkillTree = ReadonlyMap<string, Buffer>;
@@ -248,83 +242,6 @@ function readManagedSkillReceipt(input: {
 		return { status: "mismatch" };
 	}
 	return { status: "matched", receipt: marker };
-}
-
-function realDirectoryWithin(root: string, path: string): boolean {
-	const trustedRoot = resolve(root);
-	const target = resolve(path);
-	const child = relative(trustedRoot, target);
-	if (child.startsWith("..") || isAbsolute(child)) {
-		throw new Error(`legacy managed Skill receipt root is outside tenant HOME: ${path}`);
-	}
-	let current = trustedRoot;
-	for (const segment of child ? ["", ...child.split("/")] : [""]) {
-		if (segment) current = join(current, segment);
-		try {
-			const node = lstatSync(current);
-			if (node.isSymbolicLink() || !node.isDirectory()) {
-				throw new Error(`legacy managed Skill receipt path is unsafe: ${current}`);
-			}
-		} catch (error) {
-			if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
-			throw error;
-		}
-	}
-	return true;
-}
-
-/**
- * SUNSET(#1148): remove after every supported hosted CLI has migrated
- * tenant-home Skill receipts into the platform managed-resource root.
- */
-export function migrateLegacyManagedSkillReceiptDirectory(input: {
-	tenantHome: string;
-	managedResourceRoot: string;
-	runtime: ManagedSkillReceiptRuntime;
-	skillsRoot: string;
-}): void {
-	if (!realDirectoryWithin(input.tenantHome, input.skillsRoot)) return;
-	const legacyDirectory = join(input.skillsRoot, LEGACY_RECEIPT_DIRECTORY);
-	let directory: ReturnType<typeof lstatSync>;
-	try {
-		directory = lstatSync(legacyDirectory);
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
-		throw error;
-	}
-	if (directory.isSymbolicLink() || !directory.isDirectory()) {
-		rmSync(legacyDirectory, { recursive: true, force: true });
-		return;
-	}
-
-	const schemaVersion =
-		input.runtime === "hermes"
-			? HERMES_MANAGED_SKILL_RECEIPT_SCHEMA
-			: OPENCLAW_MANAGED_SKILL_RECEIPT_SCHEMA;
-	for (const entry of readdirSync(legacyDirectory, { withFileTypes: true })) {
-		const match = /^([a-z0-9][a-z0-9._-]{0,63})\.json$/.exec(entry.name);
-		if (!match || !entry.isFile() || entry.isSymbolicLink()) continue;
-		const skillId = match[1];
-		const legacyPath = join(legacyDirectory, entry.name);
-		const target = join(input.skillsRoot, skillId);
-		const receipt = readManagedSkillReceipt({
-			path: legacyPath,
-			schemaVersion,
-			skillId,
-			target,
-			...(input.runtime === "openclaw"
-				? { exclude: new Set([".openclaw/source-origin.json"]) }
-				: {}),
-		});
-		if (receipt.status !== "matched") continue;
-		const destination = managedSkillReceiptPath(input.managedResourceRoot, input.runtime, skillId);
-		if (!existsSync(destination)) {
-			writeManagedSkillReceiptRecord(input.managedResourceRoot, destination, receipt.receipt);
-		}
-	}
-	// This directory was always Clawdi metadata. Invalid or unknown entries are
-	// deliberately not promoted into platform ownership authority.
-	rmSync(legacyDirectory, { recursive: true, force: true });
 }
 
 export function managedSkillMarkerOwnsTarget(input: {

--- a/packages/cli/src/runtime/manifest-channels.test.ts
+++ b/packages/cli/src/runtime/manifest-channels.test.ts
@@ -129,16 +129,17 @@ describe("managed WhatsApp auth receipts", () => {
 		expect(existsSync(receipt)).toBe(false);
 	});
 
-	test("adopts a valid legacy tree marker exactly once", () => {
+	test("rejects a legacy tree marker without a platform receipt", () => {
 		const path = authDir();
 		mkdirSync(path, { recursive: true });
 		writeFileSync(join(path, "creds.json"), `${credsJson("legacy-secret")}\n`);
 		writeFileSync(join(path, LEGACY_MARKER), legacyMarker());
 
-		materializeHostedChannelCredentials(manifest(path), { [SECRET_REF]: credsJson() }, home);
-
-		expect(readdirSync(path)).toEqual(["creds.json"]);
-		expect(existsSync(managedWhatsAppAuthReceiptPath(path))).toBe(true);
+		expect(() =>
+			materializeHostedChannelCredentials(manifest(path), { [SECRET_REF]: credsJson() }, home),
+		).toThrow(`refusing to overwrite unmanaged WhatsApp auth directory ${path}`);
+		expect(readdirSync(path).sort()).toEqual([LEGACY_MARKER, "creds.json"]);
+		expect(existsSync(managedWhatsAppAuthReceiptPath(path))).toBe(false);
 	});
 
 	test("does not adopt missing or malformed ownership state", () => {

--- a/packages/cli/src/runtime/manifest-channels.ts
+++ b/packages/cli/src/runtime/manifest-channels.ts
@@ -43,12 +43,9 @@ import {
 	parseManagedWhatsAppSocketMetadataJson,
 } from "./whatsapp-upstream-contract";
 
-const LEGACY_MANAGED_WHATSAPP_AUTH_MARKER = ".clawdi-managed-whatsapp-auth.json";
 const MANAGED_WHATSAPP_AUTH_MARKER_SCHEMA = "clawdi.managedWhatsAppAuth.v1";
 const MANAGED_WHATSAPP_AUTH_RECEIPT_SCHEMA = "clawdi.managedWhatsAppAuthReceipt.v1";
 const MANAGED_WHATSAPP_AUTH_RECEIPT_DIRECTORY = "whatsapp-auth";
-// SUNSET: Remove after every fleet host has converged past the retired Hermes WhatsApp receipt writer.
-export const RETIRED_MANAGED_HERMES_WHATSAPP_RECEIPT = "hermes-whatsapp.json";
 export function materializeHostedChannelCredentials(
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
@@ -336,17 +333,6 @@ function parseManagedWhatsAppAuthMarker(value: unknown): ManagedWhatsAppAuthMark
 	};
 }
 
-function readLegacyManagedWhatsAppAuthMarker(authDir: string): ManagedWhatsAppAuthMarker | null {
-	try {
-		const path = join(authDir, LEGACY_MANAGED_WHATSAPP_AUTH_MARKER);
-		const node = lstatSync(path);
-		if (node.isSymbolicLink() || !node.isFile()) return null;
-		return parseManagedWhatsAppAuthMarker(JSON.parse(readFileSync(path, "utf-8")) as unknown);
-	} catch {
-		return null;
-	}
-}
-
 function inspectManagedWhatsAppAuthReceipt(authDir: string): ManagedWhatsAppAuthReceiptInspection {
 	const path = managedWhatsAppAuthReceiptPath(authDir);
 	let node: ReturnType<typeof lstatSync>;
@@ -433,20 +419,7 @@ function removeManagedWhatsAppAuthReceipt(authDir: string): void {
 export function readManagedWhatsAppAuthMarker(authDir: string): ManagedWhatsAppAuthMarker | null {
 	return withManagedWhatsAppReceiptAccess(() => {
 		const receipt = inspectManagedWhatsAppAuthReceipt(authDir);
-		if (receipt.exists) {
-			if (receipt.marker && readLegacyManagedWhatsAppAuthMarker(authDir)) {
-				rmSync(join(authDir, LEGACY_MANAGED_WHATSAPP_AUTH_MARKER));
-			}
-			return receipt.marker;
-		}
-
-		const legacyMarker = readLegacyManagedWhatsAppAuthMarker(authDir);
-		if (!legacyMarker) return null;
-		// SUNSET(#1148): Remove tree-marker adoption after every fleet host has
-		// converged with out-of-tree managed WhatsApp auth receipts.
-		writeManagedWhatsAppAuthReceipt(authDir, legacyMarker);
-		rmSync(join(authDir, LEGACY_MANAGED_WHATSAPP_AUTH_MARKER));
-		return legacyMarker;
+		return receipt.marker;
 	});
 }
 

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -17,16 +17,6 @@ import { canonicalSecretRefName, canonicalSecretRefSchema } from "./secret-value
 export const RUNTIME_DESIRED_STATE_SCHEMA_VERSION = "clawdi.runtimeDesiredState.v1";
 export const HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION = "clawdi.hosted-runtime.bundle.v2";
 
-// SUNSET(#1148): remove v1 reads after every supported hosted manifest producer
-// emits MANAGED_AI_PROVIDER_RUNTIME_ENV. Runtime providers and generated config stay canonical-only.
-export const LEGACY_HOSTED_CODEX_MANAGED_RUNTIME_ENV = "OPENAI_API_KEY";
-
-export function isHostedCodexManagedRuntimeEnv(value: string | null | undefined): boolean {
-	return (
-		value === MANAGED_AI_PROVIDER_RUNTIME_ENV || value === LEGACY_HOSTED_CODEX_MANAGED_RUNTIME_ENV
-	);
-}
-
 export const OFFICIAL_INSTALL_URLS: Record<string, string> = {
 	openclaw: "https://openclaw.ai/install-cli.sh",
 	hermes: "https://hermes-agent.nousresearch.com/install.sh",
@@ -622,7 +612,7 @@ const hostedProviderAuthSchema = z
 		}
 	});
 
-const hostedProviderSchema = z
+const hostedProviderBaseSchema = z
 	.object({
 		kind: z.literal("openai-compatible"),
 		type: z.string().min(1).optional(),
@@ -643,28 +633,34 @@ const hostedProviderSchema = z
 			.optional(),
 		auth: hostedProviderAuthSchema.optional(),
 	})
-	.strict()
-	.superRefine((provider, ctx) => {
-		const hasErrorStatus = provider.status === "error";
-		const hasError = provider.error !== undefined;
-		if (hasErrorStatus !== hasError) {
-			ctx.addIssue({
-				code: "custom",
-				message: "provider status:error and error must be supplied together",
-				path: hasErrorStatus ? ["error"] : ["status"],
-			});
-		}
+	.strict();
 
-		const isProviderNotFound = hasErrorStatus && provider.error?.code === "provider_not_found";
-		const hasNormalProjection = provider.type !== undefined && provider.baseUrl !== undefined;
-		if (!isProviderNotFound && !hasNormalProjection) {
-			ctx.addIssue({
-				code: "custom",
-				message: "provider must include type and baseUrl unless it is a provider_not_found error",
-				path: [],
-			});
-		}
-	});
+function validateHostedProvider(
+	provider: z.infer<typeof hostedProviderBaseSchema>,
+	ctx: z.RefinementCtx,
+): void {
+	const hasErrorStatus = provider.status === "error";
+	const hasError = provider.error !== undefined;
+	if (hasErrorStatus !== hasError) {
+		ctx.addIssue({
+			code: "custom",
+			message: "provider status:error and error must be supplied together",
+			path: hasErrorStatus ? ["error"] : ["status"],
+		});
+	}
+
+	const isProviderNotFound = hasErrorStatus && provider.error?.code === "provider_not_found";
+	const hasNormalProjection = provider.type !== undefined && provider.baseUrl !== undefined;
+	if (!isProviderNotFound && !hasNormalProjection) {
+		ctx.addIssue({
+			code: "custom",
+			message: "provider must include type and baseUrl unless it is a provider_not_found error",
+			path: [],
+		});
+	}
+}
+
+const hostedProviderSchema = hostedProviderBaseSchema.superRefine(validateHostedProvider);
 
 const hostedRuntimeProviderSchema = hostedProviderSchema.superRefine((provider, ctx) => {
 	if (
@@ -679,17 +675,16 @@ const hostedRuntimeProviderSchema = hostedProviderSchema.superRefine((provider, 
 	}
 });
 
-const hostedCodexProviderV1ReadSchema = hostedProviderSchema.transform(
-	({ models: _legacyModels, ...provider }) => provider,
-);
+const hostedCodexProviderSchema = hostedProviderBaseSchema
+	.omit({ models: true })
+	.superRefine(validateHostedProvider);
 
 const hostedCodexToolSchema = z
 	.object({
 		enabled: z.literal(true),
 		provider_id: z.string().min(1),
 		primary_model: hostedPrimaryModelSchema,
-		// Older v1 manifests carried a Codex catalog. Accept it only long enough to self-upgrade.
-		provider: hostedCodexProviderV1ReadSchema,
+		provider: hostedCodexProviderSchema,
 	})
 	.strict()
 	.superRefine((tool, ctx) => {
@@ -704,7 +699,7 @@ const hostedCodexToolSchema = z
 			tool.provider.managed_by !== "clawdi" ||
 			tool.provider.apiMode !== "openai_responses" ||
 			canonicalSecretRefName(tool.provider.apiKeySecretRef) !== "tool.codex.apiKey" ||
-			!isHostedCodexManagedRuntimeEnv(tool.provider.runtimeEnvName) ||
+			tool.provider.runtimeEnvName !== MANAGED_AI_PROVIDER_RUNTIME_ENV ||
 			tool.provider.status === "error"
 		) {
 			ctx.addIssue({

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -33,7 +33,6 @@ import {
 	applyHostedChannelProjection,
 	installHostedChannelProjectionDependencies,
 	materializeHostedChannelCredentials,
-	RETIRED_MANAGED_HERMES_WHATSAPP_RECEIPT,
 } from "./manifest-channels";
 import {
 	AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR,
@@ -96,7 +95,6 @@ import {
 import { applyHostedRuntimeConfigProjection, projectionPayload } from "./manifest-runtime-config";
 import {
 	daemonAuthTokenRevision,
-	removeLegacyTenantClawdiState,
 	removeStaleRuntimeRunConfigs,
 	runtimeProgramRevisionForManifest,
 	writeDaemonAuthToken,
@@ -117,10 +115,7 @@ import {
 	writeJsonFile,
 	writeRuntimePrivateFileAtomic,
 } from "./manifest-shared";
-import {
-	migrateLegacyHostedSkillReceipts,
-	reconcileHostedSkillProjection,
-} from "./manifest-skills-apply";
+import { reconcileHostedSkillProjection } from "./manifest-skills-apply";
 import type { RuntimeManifestLoad } from "./manifest-source";
 import { ensureRuntimeMitmproxy } from "./mitmproxy-fetch";
 import { ensureManagedOpenClawProviderPlugin } from "./openclaw-managed-provider-plugin";
@@ -270,12 +265,7 @@ function initializeRuntimeConvergence(
 	);
 	const projectionHome = hostedRuntimeProjectionHome(manifest, paths);
 	// Tenant HOME belongs to the runtime user except for declared platform
-	// enclaves. Metadata migration and ownership repair precede snapshots by design.
-	migrateLegacyHostedSkillReceipts({
-		manifest,
-		home: projectionHome,
-		managedResourceRoot: paths.managedResourceRoot,
-	});
+	// enclaves. Ownership repair precedes snapshots by design.
 	const platformEnclaves =
 		resolve(projectionHome) === resolve(paths.userHome)
 			? runtimeSystemdPlatformEnclaves(paths)
@@ -290,7 +280,6 @@ function initializeRuntimeConvergence(
 	const openClawContext = createOpenClawHostedContext(manifest, projectionHome);
 	const hermesWhatsAppAuthDir = managedHermesWhatsAppAuthDir(manifest, projectionHome);
 	removeHostedCliPathExposure(paths);
-	removeLegacyTenantClawdiState(paths);
 	if (manifest.companions?.filebrowser) {
 		if (manifest.projection?.sourceBundleVersion !== HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION) {
 			throw new Error("Files companion requires a hosted v2 bundle");
@@ -1677,9 +1666,6 @@ function commitRuntimeConvergence(
 	const egressRevisionPreviouslyCommitted =
 		state.desiredEgressSidecarSecretRevision !== undefined &&
 		state.desiredEgressSidecarSecretRevision === appliedState?.egressSidecarSecretRevision;
-	rmSync(join(paths.managedResourceRoot, RETIRED_MANAGED_HERMES_WHATSAPP_RECEIPT), {
-		force: true,
-	});
 	commitRuntimeInstallReceipts(state.installReceiptTargets, paths);
 	opts.commitAuthority?.(convergence, {
 		...(state.desiredDaemonAuthTokenRevision !== undefined &&

--- a/packages/cli/src/runtime/manifest-mcp.ts
+++ b/packages/cli/src/runtime/manifest-mcp.ts
@@ -24,8 +24,6 @@ export const HOSTED_RUNTIME_TARGETS = [
 	"openclaw",
 	"hermes",
 ] as const satisfies readonly RuntimeName[];
-// SUNSET: Remove v1 parsing and the projection-root fallback after every fleet host has written the v2 managed-resource ledger.
-const HOSTED_MCP_LEDGER_V1_SCHEMA_VERSION = "clawdi.hostedManagedMcpServers.v1";
 const HOSTED_MCP_LEDGER_SCHEMA_VERSION = "clawdi.hostedManagedMcpServers.v2";
 const HOSTED_MCP_LEDGER_FILE = "managed-mcp-servers.json";
 const HOSTED_MCP_SERVER_NAME_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
@@ -41,19 +39,14 @@ export function hostedMcpIntent(manifest: RuntimeManifest): HostedMcpIntent {
 function hostedMcpLedgerPath(paths: RuntimePaths): string {
 	return join(paths.managedResourceRoot, HOSTED_MCP_LEDGER_FILE);
 }
-function legacyHostedMcpLedgerPath(paths: RuntimePaths): string {
-	return join(paths.projectionRoot, HOSTED_MCP_LEDGER_FILE);
-}
 function readHostedMcpManagedLedger(paths: RuntimePaths): HostedMcpManagedLedger {
 	const path = hostedMcpLedgerPath(paths);
-	const legacyPath = legacyHostedMcpLedgerPath(paths);
-	const sourcePath = existsSync(path) ? path : existsSync(legacyPath) ? legacyPath : null;
-	if (!sourcePath) {
+	if (!existsSync(path)) {
 		return { schemaVersion: HOSTED_MCP_LEDGER_SCHEMA_VERSION, runtimes: {} };
 	}
 	let payload: unknown;
 	try {
-		payload = JSON.parse(readFileSync(sourcePath, "utf-8"));
+		payload = JSON.parse(readFileSync(path, "utf-8"));
 	} catch (error) {
 		throw new Error(
 			`hosted MCP last-applied ledger is invalid: ${
@@ -61,11 +54,7 @@ function readHostedMcpManagedLedger(paths: RuntimePaths): HostedMcpManagedLedger
 			}`,
 		);
 	}
-	if (
-		!isPlainRecord(payload) ||
-		(payload.schemaVersion !== HOSTED_MCP_LEDGER_V1_SCHEMA_VERSION &&
-			payload.schemaVersion !== HOSTED_MCP_LEDGER_SCHEMA_VERSION)
-	) {
+	if (!isPlainRecord(payload) || payload.schemaVersion !== HOSTED_MCP_LEDGER_SCHEMA_VERSION) {
 		throw new Error("hosted MCP last-applied ledger has an unsupported schema");
 	}
 	if (
@@ -86,15 +75,7 @@ function readHostedMcpManagedLedger(paths: RuntimePaths): HostedMcpManagedLedger
 	for (const runtime of HOSTED_RUNTIME_TARGETS) {
 		const runtimeOwnership = runtimes[runtime];
 		if (runtimeOwnership === undefined) continue;
-		// V1 values are untrusted legacy desired state. Migrate ownership by name only.
-		const names =
-			payload.schemaVersion === HOSTED_MCP_LEDGER_V1_SCHEMA_VERSION
-				? isPlainRecord(runtimeOwnership)
-					? Object.keys(runtimeOwnership)
-					: null
-				: Array.isArray(runtimeOwnership)
-					? runtimeOwnership
-					: null;
+		const names = Array.isArray(runtimeOwnership) ? runtimeOwnership : null;
 		if (!names) {
 			throw new Error(`hosted MCP last-applied ledger has invalid ${runtime} servers`);
 		}
@@ -172,11 +153,7 @@ export function applyHostedMcpProjections(
 		outputs.add(runtime.commandPath);
 	}
 	// The last-applied ownership map advances only after every native target.
-	if (
-		Object.keys(plan.nextLedger.runtimes).length > 0 ||
-		existsSync(ledgerPath) ||
-		existsSync(legacyHostedMcpLedgerPath(paths))
-	) {
+	if (Object.keys(plan.nextLedger.runtimes).length > 0 || existsSync(ledgerPath)) {
 		writeHostedMcpManagedLedger(paths, plan.nextLedger);
 	}
 	return [...outputs];

--- a/packages/cli/src/runtime/manifest-planning.ts
+++ b/packages/cli/src/runtime/manifest-planning.ts
@@ -69,7 +69,6 @@ import {
 	hostedCodexHome,
 	hostedCodexManagedConfigToml,
 	hostedCodexManagedProvider,
-	legacyHermesModelProviderPluginDir,
 	openClawGatewayHostedPatch,
 } from "./manifest-providers";
 import {
@@ -615,7 +614,6 @@ export function runtimeUserMutationTargets(
 		join(dirname(hermesAuthPath(home)), "auth.lock"),
 		openClawContext.agentDirs.main,
 		join(hostedCodexHome(home), CODEX_MANAGED_PROVIDER_CONFIG_FILE),
-		legacyHermesModelProviderPluginDir(home),
 		...installerTargets,
 		...hostedChannelCredentialMutationTargets(manifest, home),
 		...channelPluginTargets,

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -20,11 +20,7 @@ import {
 	hostedAiProviderCatalog,
 	hostedProviderRequiresApiKey,
 } from "./hosted-provider-resolution";
-import {
-	HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
-	isHostedCodexManagedRuntimeEnv,
-	type RuntimeManifest,
-} from "./manifest-contract";
+import { HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION, type RuntimeManifest } from "./manifest-contract";
 import { type RuntimeInstallObservation, tail } from "./manifest-install";
 import { removeOpenClawManagedProviderAuthProfiles } from "./manifest-oauth";
 import { hermesConfigContext } from "./manifest-runtime-config";
@@ -368,19 +364,18 @@ export function hostedCodexManagedProvider(
 	const providerId = stringValue(codex?.provider_id);
 	const baseUrl = stringValue(provider?.baseUrl);
 	const apiMode = stringValue(provider?.apiMode);
-	// Manifest v1 keeps this field so older CLIs can parse and self-upgrade; Codex chooses its model.
-	const compatibilityModel = stringValue(primaryModel?.model);
+	const primaryModelName = stringValue(primaryModel?.model);
 	if (
 		codex?.enabled !== true ||
 		!provider ||
 		provider.managed_by !== "clawdi" ||
 		apiMode !== "openai_responses" ||
-		!isHostedCodexManagedRuntimeEnv(stringValue(provider.runtimeEnvName)) ||
+		stringValue(provider.runtimeEnvName) !== MANAGED_AI_PROVIDER_RUNTIME_ENV ||
 		normalizeSecretRef(stringValue(provider.apiKeySecretRef)) !== "secret://tool.codex.apiKey" ||
 		!providerId ||
 		stringValue(primaryModel?.provider_id) !== providerId ||
 		!baseUrl ||
-		!compatibilityModel
+		!primaryModelName
 	) {
 		return null;
 	}
@@ -519,7 +514,6 @@ function applyHostedHermesAiProviderProjection(
 	apply = true,
 ): HostedAiProviderProjectionResult {
 	const configPath = join(home, ".hermes", "config.yaml");
-	if (apply) removeLegacyHermesModelProviderPlugin(home);
 	if (!projectionInput) {
 		const deletedProviderIds = staleProviderIds(new Set(previousProviderIds), new Set());
 		if (apply && deletedProviderIds.length > 0) {
@@ -576,15 +570,6 @@ function applyHostedHermesAiProviderProjection(
 }
 function quoteTomlString(value: string): string {
 	return JSON.stringify(value);
-}
-export function legacyHermesModelProviderPluginDir(home: string): string {
-	return join(home, ".hermes", "plugins", "model-providers", "clawdi");
-}
-// SUNSET: Remove after every fleet host has migrated to native Hermes provider projection.
-function removeLegacyHermesModelProviderPlugin(home: string): void {
-	withRuntimeUserFileAccess(() =>
-		rmSync(legacyHermesModelProviderPluginDir(home), { recursive: true, force: true }),
-	);
 }
 export interface OpenClawHostedProviderPatch {
 	apply: boolean;

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -12,7 +12,6 @@ import {
 	mkdtempSync,
 	readFileSync,
 	readlinkSync,
-	renameSync,
 	rmSync,
 	statSync,
 	symlinkSync,
@@ -58,7 +57,6 @@ import {
 } from "./live-state-snapshot";
 import {
 	collectRuntimeUserManagedSkillTree,
-	legacyManagedSkillReceiptPath,
 	ManagedSkillResourceError,
 	managedSkillReceiptPath,
 	managedSkillTreeFingerprint,
@@ -1685,6 +1683,31 @@ chmod 0755 '${commandPath}'
 		expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(false);
 	});
 
+	test("rejects retired terminal Codex provider shapes", () => {
+		const legacyEnv = structuredClone(TEST_HOSTED_CODEX_TOOLING);
+		legacyEnv.codex.provider.runtimeEnvName = "OPENAI_API_KEY";
+		expect(
+			hostedRuntimeManifestSchema.safeParse(hostedManifestFixture({ terminalTooling: legacyEnv }))
+				.success,
+		).toBe(false);
+
+		const legacyCatalog: unknown = {
+			...structuredClone(TEST_HOSTED_CODEX_TOOLING),
+			codex: {
+				...structuredClone(TEST_HOSTED_CODEX_TOOLING.codex),
+				provider: {
+					...structuredClone(TEST_HOSTED_CODEX_TOOLING.codex.provider),
+					models: [{ id: "legacy-codex-model" }],
+				},
+			},
+		};
+		expect(
+			hostedRuntimeManifestSchema.safeParse(
+				hostedManifestFixture({ terminalTooling: legacyCatalog }),
+			).success,
+		).toBe(false);
+	});
+
 	test.each(["openai_chat", "anthropic_messages", "google_generate_content"])(
 		"rejects terminal Codex without the fixed responses API mode (%s)",
 		(apiMode) => {
@@ -2935,7 +2958,7 @@ chmod 0755 '${commandPath}'
 
 		expect(initial.installErrors).toEqual([]);
 		expect(initial.projectedProviderIds.hermes).toEqual(["responses"]);
-		expect(existsSync(dirname(legacyPlugin))).toBe(false);
+		expect(readFileSync(legacyPlugin, "utf8")).toBe('raise RuntimeError("obsolete")\n');
 		const initialConfig = readFileSync(hermesConfig, "utf8");
 		const initialRunConfig = readFileSync(runtimeRunConfigPath("hermes", paths), "utf8");
 		const initialHermes = parseYaml(initialConfig) as {
@@ -4241,7 +4264,7 @@ echo spawned > '${installerLog}'
 		expect(existsSync(join(paths.userHome, ".local", "bin", "openclaw"))).toBe(false);
 	});
 
-	test("migrates a runtime-owned legacy Hermes bundle once and then stays receipt-anchored", () => {
+	test("rejects a legacy Hermes bundle marker without reservation-backed ownership", () => {
 		const paths = tempRuntimePaths();
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
@@ -4251,7 +4274,6 @@ echo spawned > '${installerLog}'
 		const source = resolve(import.meta.dir, "../..", "skills", "hosted-versions", "1", "clawdi");
 		const target = join(paths.userHome, ".hermes", "skills", "clawdi");
 		const skillPath = join(target, "SKILL.md");
-		const sourceSkill = readFileSync(join(source, "SKILL.md"));
 		const catalogEntry = resolveHostedBundledSkill("clawdi", 1);
 		cpSync(source, target, { recursive: true });
 		chmodSync(target, 0o755);
@@ -4277,47 +4299,24 @@ echo spawned > '${installerLog}'
 			},
 			{ projection: { skills: { entries: { clawdi: { enabled: true, version: 1 } } } } },
 		);
-		const receipt = managedSkillReceiptPath(paths.managedResourceRoot, "hermes", "clawdi");
-		const converge = (generation: number) => {
-			const result = convergeRuntimeManifest(
-				manifestLoad({ ...manifest, generation }, `legacy-hermes-bundle-${generation}`),
-				paths,
-			);
-			expect([...result.installErrors, ...result.resourceProjectionErrors]).toEqual([]);
-		};
-		const snapshot = () => ({
-			target: statSync(target).ino,
-			skill: statSync(skillPath).ino,
-			receipt: readFileSync(receipt),
-		});
+		const marker = join(target, ".clawdi-managed.json");
+		const targetBefore = statSync(target).ino;
+		const skillBefore = readFileSync(skillPath);
+		const result = convergeRuntimeManifest(manifestLoad(manifest, "legacy-hermes-bundle"), paths);
 
-		converge(1);
-		expect(existsSync(join(target, ".clawdi-managed.json"))).toBe(false);
-		expect(readFileSync(skillPath)).toEqual(sourceSkill);
-		expect(sourceSkill).toHaveLength(6002);
-		expect(createHash("sha256").update(sourceSkill).digest("hex")).toBe(
-			"89b3820af2f694a84526c06990ab6398fef2aa5b25d7812dd7a04ed1d46bdd61",
+		expect(result.installErrors).toEqual([]);
+		expect(result.resourceProjectionErrors.join("\n")).toContain(
+			`refusing to replace unmanaged clawdi skill at ${target}`,
 		);
-		expect(JSON.parse(readFileSync(receipt, "utf8"))).toMatchObject({
-			ownershipIdentity: `content-sha256\0${catalogEntry.digest}`,
-			treeFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
-		});
-
-		let stable = snapshot();
-		for (const generation of [2, 3]) {
-			converge(generation);
-			expect(snapshot()).toEqual(stable);
-		}
-
-		writeFileSync(skillPath, "tampered\n");
-		converge(4);
-		expect(readFileSync(skillPath)).toEqual(sourceSkill);
-		stable = snapshot();
-		converge(5);
-		expect(snapshot()).toEqual(stable);
+		expect(statSync(target).ino).toBe(targetBefore);
+		expect(readFileSync(skillPath)).toEqual(skillBefore);
+		expect(existsSync(marker)).toBe(true);
+		expect(existsSync(managedSkillReceiptPath(paths.managedResourceRoot, "hermes", "clawdi"))).toBe(
+			false,
+		);
 	});
 
-	test("repairs and claims a root-owned unreadable legacy Hermes marker", () => {
+	test("keeps Hermes Skill receipts root-owned and ignores in-home receipts", () => {
 		if (process.geteuid?.() !== 0) return;
 		const paths = tempRuntimePaths();
 		const fixtureRoot = dirname(paths.serviceStateRoot);
@@ -4338,7 +4337,6 @@ echo spawned > '${installerLog}'
 		const source = resolve(import.meta.dir, "../..", "skills", "hosted-versions", "1", "clawdi");
 		const target = join(paths.userHome, ".hermes", "skills", "clawdi");
 		const skillPath = join(target, "SKILL.md");
-		const marker = join(target, ".clawdi-managed.json");
 		const receipt = managedSkillReceiptPath(paths.managedResourceRoot, "hermes", "clawdi");
 		const legacyReceiptDirectory = join(
 			paths.userHome,
@@ -4351,34 +4349,14 @@ echo spawned > '${installerLog}'
 		chmodSync(fixtureRoot, 0o755);
 		mkdirSync(dirname(hermesCommand), { recursive: true });
 		writeFileSync(hermesCommand, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
-		cpSync(source, target, { recursive: true });
-		chmodSync(target, 0o755);
-		chmodSync(skillPath, 0o644);
-		writeFileSync(
-			marker,
-			`${JSON.stringify({
-				schema: "clawdi.hostedBundledSkillMarker.v1",
-				owner: "clawdi runtime init",
-				id: "clawdi",
-				version: 1,
-				digest: catalogEntry.digest,
-			})}\n`,
-			{ mode: 0o600 },
-		);
 		for (const path of [
 			paths.userHome,
 			join(paths.userHome, ".local"),
 			dirname(hermesCommand),
 			hermesCommand,
-			join(paths.userHome, ".hermes"),
-			join(paths.userHome, ".hermes", "skills"),
-			target,
-			skillPath,
 		]) {
 			chownSync(path, runtimeUid, runtimeGid);
 		}
-		chownSync(marker, 0, 0);
-		expect(() => withRuntimeUserFileAccess(() => readFileSync(marker))).toThrow();
 
 		const manifest = baseManifest(
 			paths,
@@ -4411,7 +4389,6 @@ echo spawned > '${installerLog}'
 		};
 
 		converge(1);
-		expect(existsSync(marker)).toBe(false);
 		expect([statSync(target).uid, statSync(skillPath).uid]).toEqual([runtimeUid, runtimeUid]);
 		expect(statSync(receipt).uid).toBe(process.geteuid?.());
 		expect(statSync(receipt).mode & 0o777).toBe(0o600);
@@ -4420,25 +4397,23 @@ echo spawned > '${installerLog}'
 		expect(JSON.parse(readFileSync(receipt, "utf8"))).toMatchObject({
 			ownershipIdentity: `content-sha256\0${catalogEntry.digest}`,
 		});
-		const legacyReceipt = legacyManagedSkillReceiptPath(
-			join(paths.userHome, ".hermes", "skills"),
-			"clawdi",
-		);
-		const beforeMigration = {
+		const legacyReceipt = join(legacyReceiptDirectory, "clawdi.json");
+		const beforeLegacyReceipt = {
 			target: statSync(target).ino,
 			skill: statSync(skillPath).ino,
 			content: readFileSync(receipt),
 		};
 		mkdirSync(dirname(legacyReceipt), { recursive: true, mode: 0o700 });
 		chmodSync(dirname(legacyReceipt), 0o700);
-		renameSync(receipt, legacyReceipt);
+		writeFileSync(legacyReceipt, readFileSync(receipt), { mode: 0o600 });
+		const legacyReceiptContent = readFileSync(legacyReceipt);
 		converge(2);
-		expect(existsSync(legacyReceiptDirectory)).toBe(false);
+		expect(readFileSync(legacyReceipt)).toEqual(legacyReceiptContent);
 		expect({
 			target: statSync(target).ino,
 			skill: statSync(skillPath).ino,
 			content: readFileSync(receipt),
-		}).toEqual(beforeMigration);
+		}).toEqual(beforeLegacyReceipt);
 		expect(statSync(receipt).uid).toBe(0);
 		const stable = {
 			target: statSync(target).ino,
@@ -5190,7 +5165,7 @@ installReservedManagedSkill(${JSON.stringify({
 		);
 		expect(existsSync(join(target, ".clawdi-managed.json"))).toBe(false);
 		const receipt = managedSkillReceiptPath(paths.managedResourceRoot, "openclaw", "clawdi");
-		const legacyReceipt = legacyManagedSkillReceiptPath(dirname(target), "clawdi");
+		const legacyReceipt = join(dirname(target), ".clawdi-manifest-receipts", "clawdi.json");
 		expect(existsSync(receipt)).toBe(true);
 		expect(
 			existsSync(
@@ -5199,17 +5174,18 @@ installReservedManagedSkill(${JSON.stringify({
 		).toBe(false);
 		expect(shouldIgnoreUserSkill(target, "clawdi")).toBe(true);
 
-		const targetBeforeMigration = statSync(target).ino;
+		const targetBeforeLegacyReceipt = statSync(target).ino;
+		const receiptBeforeLegacyReceipt = readFileSync(receipt);
 		mkdirSync(dirname(legacyReceipt), { recursive: true, mode: 0o700 });
-		renameSync(receipt, legacyReceipt);
-		const migrated = convergeRuntimeManifest(
-			manifestLoad({ ...manifest, generation: 2 }, "bundled-openclaw-skill-receipt-migration"),
+		writeFileSync(legacyReceipt, receiptBeforeLegacyReceipt, { mode: 0o600 });
+		const reconvergedWithLegacyReceipt = convergeRuntimeManifest(
+			manifestLoad({ ...manifest, generation: 2 }, "bundled-openclaw-skill-legacy-receipt"),
 			paths,
 		);
-		expect(migrated.resourceProjectionErrors).toEqual([]);
-		expect(statSync(target).ino).toBe(targetBeforeMigration);
-		expect(existsSync(receipt)).toBe(true);
-		expect(existsSync(dirname(legacyReceipt))).toBe(false);
+		expect(reconvergedWithLegacyReceipt.resourceProjectionErrors).toEqual([]);
+		expect(statSync(target).ino).toBe(targetBeforeLegacyReceipt);
+		expect(readFileSync(receipt)).toEqual(receiptBeforeLegacyReceipt);
+		expect(readFileSync(legacyReceipt)).toEqual(receiptBeforeLegacyReceipt);
 
 		writeFileSync(join(target, "SKILL.md"), "tenant mutation\n");
 		rmSync(managedSkillReservationLedgerPath(), { force: true });
@@ -5225,7 +5201,7 @@ installReservedManagedSkill(${JSON.stringify({
 		expect(shouldIgnoreUserSkill(target, "clawdi")).toBe(false);
 	});
 
-	test("claims legacy OpenClaw Skills before receipt-guarded removal", () => {
+	test("ignores legacy OpenClaw markers without reservation-backed ownership", () => {
 		const paths = tempRuntimePaths();
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		const command = join(paths.userHome, ".local", "bin", "openclaw");
@@ -5274,9 +5250,10 @@ installReservedManagedSkill(${JSON.stringify({
 			},
 		);
 		expect(result.installErrors).toEqual([]);
-		expect(ownershipAnchors).toBe(1);
-		expect(guardedCleanupCalls).toBe(1);
-		expect(existsSync(target)).toBe(false);
+		expect(ownershipAnchors).toBe(0);
+		expect(guardedCleanupCalls).toBe(0);
+		expect(existsSync(target)).toBe(true);
+		expect(existsSync(join(target, ".clawdi-managed.json"))).toBe(true);
 	});
 
 	test("restores exact root and runtime-user targets before systemd rollback reconciliation", () => {

--- a/packages/cli/src/runtime/manifest-runtime-state.ts
+++ b/packages/cli/src/runtime/manifest-runtime-state.ts
@@ -1,13 +1,5 @@
-import {
-	existsSync,
-	lstatSync,
-	mkdirSync,
-	readdirSync,
-	readFileSync,
-	rmdirSync,
-	rmSync,
-} from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { runtimeContentSha256 } from "./applied-state";
 import { ensureRuntimeAuthTokenFile } from "./auth-token";
@@ -107,66 +99,6 @@ export function writeLiveSyncEnvironmentFiles(
 	});
 	writeLiveSyncEnvironmentIndex(desiredTypes, paths);
 	return written;
-}
-// SUNSET: Remove after every fleet host has migrated to the dedicated hosted CLAWDI_HOME.
-export function removeLegacyTenantClawdiState(paths: RuntimePaths): void {
-	const legacyRoot = join(paths.userHome, ".clawdi");
-	if (resolve(legacyRoot) === resolve(paths.clawdiHome)) return;
-	let root: ReturnType<typeof lstatSync>;
-	try {
-		root = lstatSync(legacyRoot);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-		throw error;
-	}
-	if (!root.isDirectory() || root.isSymbolicLink()) return;
-	const environments = join(legacyRoot, "environments");
-	let directory: ReturnType<typeof lstatSync>;
-	try {
-		directory = lstatSync(environments);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-		throw error;
-	}
-	if (!directory.isDirectory() || directory.isSymbolicLink()) return;
-	let removedManagedFile = false;
-	for (const entry of readdirSync(environments)) {
-		if (!entry.endsWith(".json")) continue;
-		const path = join(environments, entry);
-		try {
-			const node = lstatSync(path);
-			if (!node.isFile() || node.isSymbolicLink()) continue;
-			let value: unknown;
-			try {
-				value = JSON.parse(readFileSync(path, "utf8")) as unknown;
-			} catch {
-				continue;
-			}
-			if (
-				typeof value !== "object" ||
-				value === null ||
-				Array.isArray(value) ||
-				(value as Record<string, unknown>).managedBy !== "clawdi runtime init"
-			) {
-				continue;
-			}
-			rmSync(path);
-			removedManagedFile = true;
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-		}
-	}
-	if (!removedManagedFile) return;
-	removeEmptyLegacyDirectory(environments);
-	removeEmptyLegacyDirectory(legacyRoot);
-}
-function removeEmptyLegacyDirectory(path: string): void {
-	try {
-		rmdirSync(path);
-	} catch (error) {
-		const code = (error as NodeJS.ErrnoException).code;
-		if (code !== "ENOENT" && code !== "ENOTEMPTY") throw error;
-	}
 }
 function liveSyncEnvironmentIndexPath(paths: RuntimePaths): string {
 	return paths.liveSyncEnvironmentIndex;

--- a/packages/cli/src/runtime/manifest-skills-apply.ts
+++ b/packages/cli/src/runtime/manifest-skills-apply.ts
@@ -1,21 +1,13 @@
 import { existsSync, rmSync } from "node:fs";
-import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
-import {
-	claimLegacyHostedBundledSkill,
-	hostedBundledSkillIds,
-	resolveHostedBundledSkill,
-} from "./hosted-bundled-skill";
+import { dirname, join } from "node:path";
+import { hostedBundledSkillIds, resolveHostedBundledSkill } from "./hosted-bundled-skill";
 import type { HostedHermesSkillExactSourceDriver } from "./hosted-hermes-skill";
 import type { HostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
 import {
 	type PreparedHostedSourcedSkill,
 	prepareHostedBundledSkillArchive,
 } from "./hosted-sourced-skill-archive";
-import {
-	ManagedSkillResourceError,
-	managedSkillReceiptPath,
-	migrateLegacyManagedSkillReceiptDirectory,
-} from "./managed-skill-delivery";
+import { ManagedSkillResourceError, managedSkillReceiptPath } from "./managed-skill-delivery";
 import {
 	installReservedManagedSkill,
 	type ManagedSkillReservationSnapshot,
@@ -106,7 +98,6 @@ function hostedSkillProjectionDrivers(input: {
 	hermesDriver: HostedHermesSkillExactSourceDriver;
 	openClawDriver: HostedOpenClawSkillDriver;
 }): HostedSkillProjectionDriver[] {
-	const appRoot = join(input.home, ".hermes", "hermes-agent");
 	const hermesSkillsRoot = join(input.home, ".hermes", "skills");
 	const openClawSkillsRoot = input.openClawWorkspaceRoot
 		? join(input.openClawWorkspaceRoot, "skills")
@@ -122,15 +113,10 @@ function hostedSkillProjectionDrivers(input: {
 			install: (skill, targetDir, previousReservation) =>
 				input.hermesDriver.install({
 					home: input.home,
-					appRoot,
 					managedResourceRoot: input.managedResourceRoot,
 					skill,
 					targetDir,
 					previouslyReserved: previousReservation !== undefined,
-					previousTargetDir: previousReservation?.targetDir,
-					previousOwnershipIdentity: previousReservation
-						? reservationOwnershipIdentity(previousReservation)
-						: undefined,
 				}),
 			anchorOwnership: (skillId, ownershipIdentity, targetDir) =>
 				input.hermesDriver.anchorOwnership({
@@ -143,7 +129,6 @@ function hostedSkillProjectionDrivers(input: {
 			verifyOwned: (skill, targetDir) =>
 				input.hermesDriver.verifyOwned({
 					home: input.home,
-					appRoot,
 					managedResourceRoot: input.managedResourceRoot,
 					skill,
 					targetDir,
@@ -162,7 +147,6 @@ function hostedSkillProjectionDrivers(input: {
 				}
 				input.hermesDriver.uninstall({
 					home: input.home,
-					appRoot,
 					managedResourceRoot: input.managedResourceRoot,
 					skillId: reservation.id,
 					ownershipIdentity,
@@ -225,45 +209,6 @@ function hostedSkillProjectionDrivers(input: {
 			},
 		},
 	];
-}
-
-function assertSkillsRootInTenantHome(home: string, skillsRoot: string): void {
-	const candidate = relative(resolve(home), resolve(skillsRoot));
-	if (candidate.startsWith("..") || isAbsolute(candidate) || basename(skillsRoot) !== "skills") {
-		throw new Error(`managed Skill reservation is outside tenant HOME: ${skillsRoot}`);
-	}
-}
-
-export function migrateLegacyHostedSkillReceipts(input: {
-	manifest: RuntimeManifest;
-	home: string;
-	managedResourceRoot: string;
-}): void {
-	const hermesSkillsRoot = join(input.home, ".hermes", "skills");
-	const roots = new Map<string, "hermes" | "openclaw">([
-		[hermesSkillsRoot, "hermes"],
-		[join(input.home, ".openclaw", "workspace", "skills"), "openclaw"],
-	]);
-	if (input.manifest.workspaceRoot) {
-		const manifestSkillsRoot = join(input.manifest.workspaceRoot, "skills");
-		assertSkillsRootInTenantHome(input.home, manifestSkillsRoot);
-		roots.set(manifestSkillsRoot, "openclaw");
-	}
-	for (const reservation of managedSkillReservations("hosted-manifest")) {
-		const skillsRoot = dirname(reservation.targetDir);
-		assertSkillsRootInTenantHome(input.home, skillsRoot);
-		roots.set(skillsRoot, skillsRoot === hermesSkillsRoot ? "hermes" : "openclaw");
-	}
-	for (const [skillsRoot, runtime] of [...roots].sort(([left], [right]) =>
-		left.localeCompare(right),
-	)) {
-		migrateLegacyManagedSkillReceiptDirectory({
-			tenantHome: input.home,
-			managedResourceRoot: input.managedResourceRoot,
-			runtime,
-			skillsRoot,
-		});
-	}
 }
 
 function pendingReservationMatchesPrepared(
@@ -335,28 +280,6 @@ function recoverHostedSkillReservations(
 	const desiredEntries = manifest.projection?.skills?.entries ?? {};
 	const skillIds = new Set([...Object.keys(desiredEntries), ...hostedBundledSkillIds()]);
 	for (const skillId of [...skillIds].sort()) {
-		const legacyTargetDir = join(driver.skillsRoot, skillId);
-		if (
-			withRuntimeUserFileAccess(() => existsSync(legacyTargetDir)) &&
-			managedSkillReservationOwner(legacyTargetDir, skillId) === "unreserved" &&
-			claimLegacyHostedBundledSkill({
-				targetDir: legacyTargetDir,
-				skillId,
-				reserve: (legacy) => {
-					reserveManagedSkill({
-						targetDir: legacyTargetDir,
-						id: skillId,
-						manager: "hosted-manifest",
-						version: legacy.version,
-						digest: legacy.digest,
-					});
-				},
-				anchorOwnership: (ownershipIdentity) =>
-					driver.anchorOwnership(skillId, ownershipIdentity, legacyTargetDir),
-			})
-		) {
-			continue;
-		}
 		const desired = desiredEntries[skillId];
 		if (!driver.enabled || desired?.enabled !== true) continue;
 		const prepared = preparedSkills.get(skillId);

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -47,7 +47,7 @@ const goldenPath = resolve(
 	"../../../../test-fixtures/runtime-bundle-v2.golden.json",
 );
 const EXPECTED_GOLDEN_SOURCE_REVISION =
-	"b9a4035525dabac848b7d896ca2dd8f4936e7f49fd04c58fbbf801d854224b6f";
+	"5cd6786cf4ca7021d7002f920c8a2870bfddbd9b20ba7503a8ec6977a4c5fbef";
 const originalEnv = { ...process.env };
 const originalFetch = globalThis.fetch;
 const roots: string[] = [];

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -1019,15 +1019,14 @@ test("runs Files as the tenant while preserving platform isolation", () => {
 		chownSync(path, runtimeUid, runtimeGid);
 	}
 	const legacyEnvironmentRoot = join(runtimeHome, ".clawdi", "environments");
+	const legacyEnvironmentPath = join(legacyEnvironmentRoot, "openclaw.json");
+	const legacyEnvironmentContent = `${JSON.stringify({
+		id: "env_legacy_openclaw",
+		agentType: "openclaw",
+		managedBy: "clawdi runtime init",
+	})}\n`;
 	mkdirSync(legacyEnvironmentRoot, { recursive: true });
-	writeFileSync(
-		join(legacyEnvironmentRoot, "openclaw.json"),
-		`${JSON.stringify({
-			id: "env_legacy_openclaw",
-			agentType: "openclaw",
-			managedBy: "clawdi runtime init",
-		})}\n`,
-	);
+	writeFileSync(legacyEnvironmentPath, legacyEnvironmentContent);
 	const systemNpmCli = "/usr/local/lib/node_modules/clawdi/bin/clawdi.mjs";
 	mkdirSync(dirname(systemNpmCli), { recursive: true });
 	writeFileSync(systemNpmCli, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
@@ -1257,7 +1256,7 @@ http.createServer((request, response) => {
 		auth: "api-key",
 		apiKey: { id: "CLAWDI_AI_API_KEY" },
 	});
-	expect(existsSync(join(runtimeHome, ".clawdi"))).toBe(false);
+	expect(readFileSync(legacyEnvironmentPath, "utf8")).toBe(legacyEnvironmentContent);
 	expect(statSync(paths.clawdiHome).uid).toBe(runtimeUid);
 	expect(statSync(paths.clawdiHome).gid).toBe(runtimeGid);
 	expect(statSync(paths.clawdiHome).mode & 0o777).toBe(0o750);

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -4452,25 +4452,13 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 
-		const legacyWireResponse = hostedCliManifestResponse(home, "clawdi@1.2.3-test");
-		const terminalTooling = expectRecord(
-			legacyWireResponse.manifest.terminalTooling,
-			"legacy terminal tooling",
-		);
-		const codex = expectRecord(terminalTooling.codex, "legacy terminal Codex");
-		const wireProvider = expectRecord(codex.provider, "legacy terminal Codex provider");
+		const wireResponse = hostedCliManifestResponse(home, "clawdi@1.2.3-test");
+		const terminalTooling = expectRecord(wireResponse.manifest.terminalTooling, "terminal tooling");
+		const codex = expectRecord(terminalTooling.codex, "terminal Codex");
+		const wireProvider = expectRecord(codex.provider, "terminal Codex provider");
 		wireProvider.baseUrl = "https://codex-provider.example.test/v1";
-		wireProvider.runtimeEnvName = "OPENAI_API_KEY";
-		wireProvider.models = [{ id: "legacy-codex-model" }];
-		const normalized = normalizeHostedManifestFixture(legacyWireResponse);
-		const normalizedTerminalTooling = expectRecord(
-			normalized.manifest.projection?.terminalTooling,
-			"normalized terminal tooling",
-		);
-		const normalizedCodex = expectRecord(normalizedTerminalTooling.codex, "normalized Codex");
-		const normalizedProvider = expectRecord(normalizedCodex.provider, "normalized Codex provider");
-		expect(normalizedProvider.models).toBeUndefined();
-		const legacyWireLoad: RuntimeManifestLoad = {
+		const normalized = normalizeHostedManifestFixture(wireResponse);
+		const wireLoad: RuntimeManifestLoad = {
 			...normalized,
 			source: "remote-datasource",
 			sourcePath: "https://runtime-source.test/desired-state",
@@ -4488,7 +4476,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		};
 		const paths = getRuntimePaths();
 		seedMitmproxyCache(paths);
-		const convergence = convergeRuntimeManifest(legacyWireLoad, paths);
+		const convergence = convergeRuntimeManifest(wireLoad, paths);
 
 		expect(convergence.installErrors).toEqual([]);
 		expect(statSync(codexHome).mode & 0o777).toBe(0o700);
@@ -4623,7 +4611,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 										baseUrl: "https://managed-provider.example.test/v1",
 										apiMode: "openai_responses",
 										managed_by: "clawdi",
-										runtimeEnvName: "OPENAI_API_KEY",
+										runtimeEnvName: "CLAWDI_AI_API_KEY",
 										apiKeySecretRef: "secret://tool.codex.apiKey",
 									},
 								},
@@ -6299,7 +6287,7 @@ cp '${sdkSource}' '${sdkTarget}'
 		expect(manifestSchema.safeParse(loaded.manifest).success).toBe(false);
 	});
 
-	it("removes the stale Hermes plugin and native provider when projection disappears", () => {
+	it("ignores a retired Hermes plugin while removing the native provider", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -6335,14 +6323,14 @@ cp '${sdkSource}' '${sdkTarget}'
 		const first = convergeRuntimeManifest(withProvider, paths);
 		writeTestRuntimeAppliedState(paths, withProvider, first);
 		const firstRevision = systemdEnvRevision(readSystemdEnvFile(paths, "hermes-gateway"));
-		expect(existsSync(hermesModelProviderPluginDir(home))).toBe(false);
+		expect(existsSync(hermesModelProviderPluginDir(home))).toBe(true);
 		expect(
 			expectRecord(readHermesConfigYaml(home).providers, "Hermes providers").hermes,
 		).toBeDefined();
 
 		convergeRuntimeManifest(withoutProvider, paths);
 
-		expect(existsSync(hermesModelProviderPluginDir(home))).toBe(false);
+		expect(existsSync(hermesModelProviderPluginDir(home))).toBe(true);
 		const unmanagedConfig = readHermesConfigYaml(home);
 		expect(unmanagedConfig.providers).toBeUndefined();
 		expect(unmanagedConfig.model).toBeUndefined();
@@ -6598,7 +6586,7 @@ cp '${sdkSource}' '${sdkTarget}'
 		const initialConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf-8");
 		expect(initialConfig).toContain("provider: custom:hermes");
 		expect(initialConfig).toMatch(/api: "?https:\/\/hermes-provider\.example\.test\/v1"?/);
-		expect(existsSync(hermesModelProviderPluginDir(home))).toBe(false);
+		expect(existsSync(hermesModelProviderPluginDir(home))).toBe(true);
 
 		writeHermesVersionBinary(home, "0.18.0");
 		convergeRuntimeManifest(loaded, paths);
@@ -6606,7 +6594,7 @@ cp '${sdkSource}' '${sdkTarget}'
 		const currentRevision = systemdEnvRevision(readSystemdEnvFile(paths, "hermes-gateway"));
 		const currentConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf-8");
 		expect(currentConfig).toBe(initialConfig);
-		expect(existsSync(hermesModelProviderPluginDir(home))).toBe(false);
+		expect(existsSync(hermesModelProviderPluginDir(home))).toBe(true);
 		expect(currentRevision).toBe(yamlRevision);
 	});
 
@@ -14546,6 +14534,10 @@ exit 64
 		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlPath;
 		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
 		const paths = getRuntimePaths();
+		const retiredWhatsAppReceipt = join(paths.managedResourceRoot, "hermes-whatsapp.json");
+		const retiredWhatsAppReceiptContent = '{"schemaVersion":"clawdi.managedHermesWhatsApp.v1"}\n';
+		mkdirSync(dirname(retiredWhatsAppReceipt), { recursive: true });
+		writeFileSync(retiredWhatsAppReceipt, retiredWhatsAppReceiptContent);
 		mkdirSync(legacySessionDir, { recursive: true });
 		writeFileSync(legacySentinel, "preserved\n");
 
@@ -14664,6 +14656,7 @@ exit 64
 		});
 		const convergence = convergeRuntimeManifest(projected, paths);
 		expect(convergence.installErrors).toEqual([]);
+		expect(readFileSync(retiredWhatsAppReceipt, "utf8")).toBe(retiredWhatsAppReceiptContent);
 		expect(projected.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ENABLED).toBeUndefined();
 		expect(readSystemdEnvFile(paths, "hermes-gateway")).not.toContain("WHATSAPP_ENABLED");
 		expect(existsSync(sessionDir)).toBe(true);
@@ -16121,7 +16114,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		expect(readFileSync(openclawCalls, "utf-8")).toContain("unset search.proxy");
 	});
 
-	it("migrates retained v1 MCP ownership without copying legacy config values", () => {
+	it("ignores a retired projection-root v1 MCP ledger", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -16134,13 +16127,11 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		const legacyLedgerPath = join(paths.projectionRoot, "managed-mcp-servers.json");
 		const ledgerPath = join(paths.managedResourceRoot, "managed-mcp-servers.json");
 		const hermesConfigPath = join(home, ".hermes", "config.yaml");
-		const legacySecretRef = "env://REDACTED_LEGACY_NAME";
-		const legacyPrefix = "Bearer ";
 		const legacyServer = {
 			url: "https://legacy.example.test/mcp",
 			transport: "streamable-http",
 			headers: {
-				Authorization: { secretRef: legacySecretRef, prefix: legacyPrefix },
+				Authorization: { secretRef: "env://REDACTED_LEGACY_NAME", prefix: "Bearer " },
 			},
 		};
 		const retainedV1Ledger = {
@@ -16154,92 +16145,50 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			`${JSON.stringify({ mcp_servers: { clawdi: legacyServer } }, null, 2)}\n`,
 		);
 		mkdirSync(dirname(legacyLedgerPath), { recursive: true });
-		writeFileSync(legacyLedgerPath, `${JSON.stringify(retainedV1Ledger, null, 2)}\n`);
-		expect(legacyPrefix).toHaveLength(7);
-		const load = (generation: number, includeServer: boolean): RuntimeManifestLoad => ({
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_mcp_ledger_migration",
-				environmentId: "env_mcp_ledger_migration",
-				instanceId: "iid_mcp_ledger_migration",
-				generation,
-				issuedAt: "2026-07-31T00:00:00Z",
-				workspaceRoot: workspace,
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					hermes: {
-						enabled: true,
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://hermes-agent.nousresearch.com/install.sh",
-							home,
-							args: [],
+		const legacyLedger = `${JSON.stringify(retainedV1Ledger, null, 2)}\n`;
+		writeFileSync(legacyLedgerPath, legacyLedger);
+
+		const result = convergeRuntimeManifest(
+			{
+				manifest: {
+					schemaVersion: "clawdi.runtimeDesiredState.v1",
+					deploymentId: "dep_retired_mcp_ledger",
+					environmentId: "env_retired_mcp_ledger",
+					instanceId: "iid_retired_mcp_ledger",
+					generation: 1,
+					issuedAt: "2026-07-31T00:00:00Z",
+					workspaceRoot: workspace,
+					controlPlane: { apiUrl: "https://cloud-api.test" },
+					runtimes: {
+						hermes: {
+							enabled: true,
+							install: {
+								authority: "official",
+								method: "official-installer",
+								url: "https://hermes-agent.nousresearch.com/install.sh",
+								home,
+								args: [],
+							},
 						},
 					},
-				},
-				projection: {
-					system: { home, workspace },
-					mcp: {
-						servers: includeServer
-							? {
-									clawdi: {
-										url: "https://current.example.test/mcp",
-										transport: "sse",
-										headers: { "X-Manifest": "current-only" },
-									},
-								}
-							: {},
+					projection: {
+						system: { home, workspace },
+						mcp: { servers: {} },
 					},
+					recovery: {},
 				},
-				recovery: {},
+				source: "remote-datasource",
+				sourcePath: "test://retired-mcp-ledger",
+				offline: false,
+				secretValues: {},
 			},
-			source: "remote-datasource",
-			sourcePath: `test://mcp-ledger-migration-${generation}`,
-			offline: false,
-			secretValues: {},
-		});
+			getRuntimePaths(),
+		);
 
-		const migrated = convergeRuntimeManifest(load(1, true), getRuntimePaths());
-		expect(migrated.installErrors).toEqual([]);
-		expect(readHermesConfigYaml(home).mcp_servers).toEqual({
-			clawdi: {
-				url: "https://current.example.test/mcp",
-				transport: "sse",
-				headers: { "X-Manifest": "current-only" },
-			},
-		});
-		const migratedLedgerPayload = JSON.parse(readFileSync(ledgerPath, "utf-8"));
-		expect(migratedLedgerPayload).toEqual({
-			schemaVersion: "clawdi.hostedManagedMcpServers.v2",
-			runtimes: { hermes: ["clawdi"] },
-		});
-		const migratedNative = readFileSync(hermesConfigPath, "utf-8");
-		const migratedLedger = readFileSync(ledgerPath, "utf-8");
-		for (const legacyValue of [
-			legacyServer.url,
-			legacyServer.transport,
-			legacySecretRef,
-			legacyPrefix,
-		]) {
-			expect(migratedNative).not.toContain(legacyValue);
-			expect(migratedLedger).not.toContain(legacyValue);
-		}
-		expect(migratedLedger).not.toContain("env://");
-		expect(JSON.stringify(migratedLedgerPayload)).not.toContain(JSON.stringify(legacyServer));
-
-		const roundTripped = convergeRuntimeManifest(load(2, true), getRuntimePaths());
-		expect(roundTripped.installErrors).toEqual([]);
-		expect(readFileSync(hermesConfigPath, "utf-8")).toBe(migratedNative);
-		expect(readFileSync(ledgerPath, "utf-8")).toBe(migratedLedger);
-
-		const removed = convergeRuntimeManifest(load(3, false), getRuntimePaths());
-		expect(removed.installErrors).toEqual([]);
-		expect(readHermesConfigYaml(home).mcp_servers).toBeUndefined();
-		expect(JSON.parse(readFileSync(ledgerPath, "utf-8"))).toEqual({
-			schemaVersion: "clawdi.hostedManagedMcpServers.v2",
-			runtimes: {},
-		});
+		expect(result.installErrors).toEqual([]);
+		expect(readHermesConfigYaml(home).mcp_servers).toEqual({ clawdi: legacyServer });
+		expect(readFileSync(legacyLedgerPath, "utf-8")).toBe(legacyLedger);
+		expect(existsSync(ledgerPath)).toBe(false);
 	});
 
 	it.each([
@@ -16254,7 +16203,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			"invalid runtimes",
 		],
 		[
-			"invalid v1 server name",
+			"retired v1 schema",
 			{
 				schemaVersion: "clawdi.hostedManagedMcpServers.v1",
 				runtimes: {
@@ -16272,7 +16221,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 					},
 				},
 			},
-			"invalid hermes server name",
+			"unsupported schema",
 		],
 		[
 			"invalid v2 server name",
@@ -17557,6 +17506,14 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_AUTH_TOKEN = "runtime-auth-token";
+		const retiredEnvironment = join(home, ".clawdi", "environments", "openclaw.json");
+		const retiredEnvironmentContent = `${JSON.stringify({
+			id: "env-retired",
+			agentType: "openclaw",
+			managedBy: "clawdi runtime init",
+		})}\n`;
+		mkdirSync(dirname(retiredEnvironment), { recursive: true });
+		writeFileSync(retiredEnvironment, retiredEnvironmentContent);
 		setRuntimeApplyGeneration(9, {
 			...CANONICAL_TEST_CONTEXT,
 			bootstrapBearer: "runtime-auth-token",
@@ -17626,6 +17583,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 				join(paths.localEnvironments, "codex.json"),
 				join(paths.localEnvironments, "openclaw.json"),
 			]);
+			expect(readFileSync(retiredEnvironment, "utf-8")).toBe(retiredEnvironmentContent);
 			expect(convergence.outputs.daemonAuthTokenFile).toBe(join(run, "secrets", "auth-token"));
 			expect(readFileSync(join(run, "secrets", "auth-token"), "utf-8")).toBe(
 				"runtime-auth-token\n",

--- a/test-fixtures/runtime-bundle-v2.golden.json
+++ b/test-fixtures/runtime-bundle-v2.golden.json
@@ -117,7 +117,7 @@
 					"baseUrl": "https://provider.test/v1",
 					"kind": "openai-compatible",
 					"managed_by": "clawdi",
-					"runtimeEnvName": "OPENAI_API_KEY",
+					"runtimeEnvName": "CLAWDI_AI_API_KEY",
 					"type": "custom_openai_compatible"
 				},
 				"provider_id": "clawdi"
@@ -132,5 +132,5 @@
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/agent-token": "123456789:telegram-agent-golden",
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/placeholder-token": "999999999:9ded1453047ec0a48ec3b735075f7448"
 	},
-	"sourceRevision": "b9a4035525dabac848b7d896ca2dd8f4936e7f49fd04c58fbbf801d854224b6f"
+	"sourceRevision": "5cd6786cf4ca7021d7002f920c8a2870bfddbd9b20ba7503a8ec6977a4c5fbef"
 }


### PR DESCRIPTION
## Summary

Remove the migration shims tracked by #1148 now that all four v2 fleet hosts run `clawdi@0.14.10` and the one-time migrations have converged. The change is a net deletion of 805 lines while retaining fail-closed or safe-ignore behavior for every retired shape.

Refs #1148.

## Sunset checklist

- [x] **Manifest provider cleanup (#1138).** Removed deletion of the legacy Hermes model-provider plugin directory. The cleanup contract shipped no later than `clawdi-cli-v0.13.110`, below the fleet's `0.14.10` floor. A surviving legacy plugin is now ignored and left untouched; native provider projection remains authoritative.
- [x] **Runtime-state cleanup (#1138).** Removed cleanup of tenant `~/.clawdi/environments` state and its empty parent directories. The migration shipped no later than `clawdi-cli-v0.13.110`. Retired tenant state is non-authoritative, ignored, and preserved.
- [x] **Channel cleanup (#1138).** Removed deletion of the retired platform `hermes-whatsapp.json` receipt. The migration shipped no later than `clawdi-cli-v0.13.110`. The stale receipt is ignored and preserved.
- [x] **MCP ledger cleanup (#1138).** Removed v1 ledger parsing and the projection-root fallback. The migration shipped no later than `clawdi-cli-v0.13.110`. A projection-root v1 ledger is safely ignored and left untouched; a v1 ledger at the canonical managed-resource path is rejected as an unsupported schema.
- [x] **Hosted bundled-Skill marker claim (#1145/#1147).** Removed both legacy marker schemas and their receipt-anchored claim transaction. The claim path shipped by `clawdi-cli-v0.14.3`. A marker-bearing tree is now unmanaged: its extra marker changes the tree digest and reconciliation refuses to replace it without reservation-backed ownership.
- [x] **WhatsApp tree-marker migration (#1149).** Removed tree-marker adoption and deletion. The out-of-tree receipt migration shipped in `clawdi-cli-v0.14.3`. Only the platform receipt is authoritative; without one, a legacy-marked auth directory is treated as unmanaged and overwrite fails closed.
- [x] **Hermes loopback hub migration (#1168).** Removed legacy `.hub/lock.json` parsing, official uninstall, and reinstallation through local discovery. This migration shipped immediately before `clawdi-cli-v0.14.10`, and fleet evidence confirms the records are already zero. Retired loopback metadata is non-authoritative, ignored, and left unchanged.
- [x] **In-home Skill receipt migration (#1147).** Removed migration and deletion of `.clawdi-manifest-receipts` under tenant Skill roots. The platform receipt cutover shipped in `clawdi-cli-v0.14.3`. In-home receipts are ignored and preserved; platform receipts remain the sole ownership authority.
- [x] **Temporary Codex v1 manifest reads.** Removed `OPENAI_API_KEY` managed-runtime env compatibility and the legacy Codex `models` catalog read. The compatibility first shipped in `clawdi-cli-v0.13.6`. Legacy shapes now fail strict manifest admission.

## Bootstrap verification

The hosted pre-CLI resolver at `infra/v2/hosted-runtime/image/bin/resolve-hosted-cli-package.mjs` reads only `bundle.manifest.clawdiCli.packageSpec` to select the CLI package. It does not read the Codex provider `runtimeEnvName` or catalog, and the hosted producer emits canonical `CLAWDI_AI_API_KEY`. Removing the v1 read compatibility therefore does not weaken fresh-deployment bootstrap or self-upgrade.

The shared v2 golden fixture now records the canonical terminal env and its regenerated source revision.

## Verification

- `bun test --isolate --max-concurrency=1 --timeout=30000 packages/cli/src/runtime/manifest-mutation-parity.test.ts` (Bun 1.4.0): 1 pass, 0 fail
- `bun run --cwd packages/cli test:internal` (Bun 1.4.0): 1766 pass, 4 skip, 0 fail
- `scripts/test-runtime-official-installer-systemd.sh`: 5 pass, 0 fail
- `bun run check` (Bun 1.4.0): pinned Biome checked 1070 files, no fixes
- `bun run --cwd packages/cli typecheck` (Bun 1.4.0): pass
- Focused backend golden fixture pytest: 1 passed
- Focused Ruff check and format verification: pass
- `git diff --check origin/main...HEAD`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
