### PR TITLE
refactor(cli): untangle runtime module cycles

### DIFF
--- a/packages/cli/src/lib/tar.ts
+++ b/packages/cli/src/lib/tar.ts
@@ -12,7 +12,6 @@ import { lstat, readdir, realpath } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { createGunzip } from "node:zlib";
 import * as tar from "tar";
-import { isReservedSkillArchivePath } from "../runtime/managed-skill-reservation";
 import { assertValidSkillKey } from "./skill-key";
 
 /**
@@ -89,6 +88,10 @@ function isRegularArchiveFile(type: string | undefined): boolean {
 
 function isAllowedArchiveEntry(type: string | undefined): boolean {
 	return isRegularArchiveFile(type) || type === "Directory";
+}
+
+function isReservedSkillArchivePath(path: string): boolean {
+	return path.split(/[\\/]/).some((segment) => segment.toLowerCase().startsWith(".clawdi-managed"));
 }
 
 /**

--- a/packages/cli/src/runtime/egress-engine.ts
+++ b/packages/cli/src/runtime/egress-engine.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const egressEngineSchema = z.object({
+	type: z.literal("mitmproxy"),
+	version: z.string().min(1),
+	url: z.string().url(),
+	sha256: z.string().regex(/^[a-fA-F0-9]{64}$/),
+});
+
+export type EgressEnginePin = z.infer<typeof egressEngineSchema>;

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -675,7 +675,3 @@ export function releaseManagedSkill(input: {
 		return "removed";
 	});
 }
-
-export function isReservedSkillArchivePath(path: string): boolean {
-	return path.split(/[\\/]/).some((segment) => segment.toLowerCase().startsWith(".clawdi-managed"));
-}

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { MANAGED_AI_PROVIDER_RUNTIME_ENV } from "@clawdi/shared";
 import { z } from "zod";
+import { egressEngineSchema } from "./egress-engine";
 import { egressProfileInputBundleSchema } from "./egress-profiles";
 import {
 	hostedAgentPluginsDesiredStateSchema,
@@ -13,6 +14,9 @@ import {
 	runtimeServiceNameSchema,
 } from "./run-config";
 import { canonicalSecretRefName, canonicalSecretRefSchema } from "./secret-values";
+
+export type { EgressEnginePin } from "./egress-engine";
+export { egressEngineSchema } from "./egress-engine";
 
 export const RUNTIME_DESIRED_STATE_SCHEMA_VERSION = "clawdi.runtimeDesiredState.v1";
 export const HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION = "clawdi.hosted-runtime.bundle.v2";
@@ -362,15 +366,6 @@ const runtimeCompanionsSchema = z
 		filebrowser: fileBrowserCompanionSchema.optional(),
 	})
 	.strict();
-
-export const egressEngineSchema = z.object({
-	type: z.literal("mitmproxy"),
-	version: z.string().min(1),
-	url: z.string().url(),
-	sha256: sha256Schema,
-});
-
-export type EgressEnginePin = z.infer<typeof egressEngineSchema>;
 
 const liveSyncAgentSchema = z.object({
 	agentType: runtimeNameSchema,

--- a/packages/cli/src/runtime/mitmproxy-fetch.ts
+++ b/packages/cli/src/runtime/mitmproxy-fetch.ts
@@ -12,7 +12,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
-import type { EgressEnginePin } from "./manifest-contract";
+import type { EgressEnginePin } from "./egress-engine";
 import type { RuntimePaths } from "./paths";
 
 export interface RuntimeMitmproxyReady {


### PR DESCRIPTION
## Summary

- keep reserved managed metadata archive filtering in the low-level tar module instead of importing the runtime reservation layer
- extract the egress engine schema and pin type into a focused lower-level contract shared by manifest parsing and mitmproxy preparation
- preserve the existing `manifest-contract.ts` exports and runtime behavior

## Circular dependency graph

### Before (`20eb5e6ad`, after #1173)

```text
bun x madge --circular packages/cli/src/runtime/manifest.ts

Processed 84 files (5 warnings)
Found 4 circular dependencies:

1) ../lib/github-skill-archive.ts
   > ../lib/tar.ts
   > managed-skill-reservation.ts
   > managed-skill-delivery.ts
   > hosted-sourced-skill-archive.ts

2) ../lib/tar.ts
   > managed-skill-reservation.ts
   > managed-skill-delivery.ts
   > hosted-sourced-skill-archive.ts

3) ../lib/github-skill-archive.ts
   > ../lib/tar.ts
   > managed-skill-reservation.ts
   > managed-skill-delivery.ts
   > hosted-sourced-skill-archive.ts
   > manifest-contract.ts
   > manifest-resources.ts

4) manifest-contract.ts
   > run-config.ts
   > state.ts
   > mitmproxy-fetch.ts
```

### After

```text
bun x madge --circular packages/cli/src/runtime/manifest.ts

Processed 85 files (2 warnings)
No circular dependency found.
```

`bun x madge --circular packages/cli/src/index.ts` now reports only the five existing `adapters/base.ts > adapters/registry.ts` family cycles. They are the local adapter registry family: `registry.ts` owns the concrete adapter constructors, the implementations share `base.ts`, and `base.ts` uses the registry's `AgentType` re-export. This PR leaves that non-runtime registry pattern unchanged.

## Verification

- `bun test packages/cli/src/runtime/manifest-mutation-parity.test.ts --isolate --max-concurrency=1 --timeout=30000` (1 pass)
- `bun run --cwd packages/cli test:internal` (1766 pass, 4 existing native-artifact skips, 0 fail)
- `scripts/test-runtime-official-installer-systemd.sh` (5 pass, 0 fail)
- `bun run --cwd packages/cli typecheck`
- `bun run check` with the repository-pinned Biome 2.5.9
- all Bun verification used the declared Bun 1.4.0 toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
