### PR TITLE
release(cli): 0.14.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.11
+
+Package: `clawdi@0.14.11`
+
+### Improved
+
+- Convergence no longer reports transient errors when a gateway is restarting
+  during an upgrade handoff.
+- Completed one-shot migrations from the 0.14.x rollout were removed now that
+  the fleet has fully converged, together with the last internal module
+  dependency cycles.
+
 ## Clawdi CLI v0.14.10
 
 Package: `clawdi@0.14.10`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.10",
+      "version": "0.14.11",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.10",
+	"version": "0.14.11",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Release `clawdi@0.14.11` — the final-state release.

Contains the post-campaign hardenings (#1171: gateway-restart-tolerant roster reads), the completed-migration cleanup (#1173: net −805 lines of one-shot shims, fleet fully converged), and the last module-cycle untangling (#1174: zero circular dependencies on the runtime side).

Follow-up: fleet update to this version plus a real fresh-deployment verification (bootstrap → latest CLI → Ready → skills → teardown) to certify the all-users upgrade path end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)