### PR TITLE
fix(runtime): always emit canonical Codex env

### DIFF
--- a/backend/app/schemas/runtime.py
+++ b/backend/app/schemas/runtime.py
@@ -686,7 +686,7 @@ class HostedCodexProviderProjection(BaseModel):
     baseUrl: str = Field(min_length=1, max_length=1000)
     apiMode: Literal["openai_responses"]
     managed_by: Literal["clawdi"]
-    runtimeEnvName: Literal["OPENAI_API_KEY", "CLAWDI_AI_API_KEY"]
+    runtimeEnvName: Literal["CLAWDI_AI_API_KEY"]
     apiKeySecretRef: Literal["secret://tool.codex.apiKey"]
 
 

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -56,11 +56,9 @@ from app.schemas.runtime import (
     HostedRuntimeTools,
     PersistedHostedRuntimeSkills,
     is_canonical_secret_ref,
-    parse_exact_semver,
     validate_clawdi_cli_package_spec,
     validate_hosted_runtime_desired_state,
 )
-from app.schemas.runtime_observed import HostedRuntimeObservedV2
 from app.services.channels import (
     HOSTED_RUNTIME_SINGLE_ACCOUNT_PROVIDERS,
     channel_runtime_account_key,
@@ -81,7 +79,6 @@ from app.services.project_runtime_skills import (
     project_skill_file_signature,
     project_skill_runtime_identity,
 )
-from app.services.runtime_generation import resolve_runtime_apply_generation
 from app.services.url_security import UnsafePublicHttpsUrlError, validate_public_https_url
 from app.services.vault_crypto import decrypt
 from app.services.whatsapp_baileys import (
@@ -99,8 +96,6 @@ RUNTIME_AGENT_PLUGIN_GITHUB_RELEASE_SOURCE_CAPABILITY = "agent-plugin-github-rel
 _CLAWDI_AUTH_TOKEN_SECRET_REF = "secret://clawdi/auth-token"
 _SUPPORTED_RUNTIMES = {"hermes", "openclaw"}
 _MANAGED_PROVIDER_RUNTIME_ENV = "CLAWDI_AI_API_KEY"
-_CODEX_TOOL_LEGACY_RUNTIME_ENV = "OPENAI_API_KEY"
-_CODEX_TOOL_CANONICAL_ENV_MINIMUM_CLI_VERSION = (0, 13, 69)
 _CODEX_TOOL_SECRET_REF = "secret://tool.codex.apiKey"
 _CODEX_TOOL_API_MODE = "openai_responses"
 _CODEX_PROVIDER_SOURCE_API_MODES = {"openai_chat", "openai_responses"}
@@ -120,47 +115,6 @@ def expected_runtime_bundle_v2_etag(source_revision: str) -> str:
     if not re.fullmatch(r"[0-9a-f]{64}", source_revision):
         raise ValueError("runtime bundle source revision must be a SHA-256 digest")
     return f'"sha256:{source_revision}"'
-
-
-def _codex_tool_runtime_env(
-    state: HostedRuntimeState,
-    observation: HostedRuntimeConfigObservation | None,
-) -> str:
-    desired_version = state.cli_package_spec.removeprefix("clawdi@")
-    parsed_version = parse_exact_semver(desired_version)
-    if parsed_version is None or (
-        parsed_version[:3] < _CODEX_TOOL_CANONICAL_ENV_MINIMUM_CLI_VERSION
-        or (
-            parsed_version[:3] == _CODEX_TOOL_CANONICAL_ENV_MINIMUM_CLI_VERSION
-            and parsed_version[3]
-        )
-    ):
-        return _CODEX_TOOL_LEGACY_RUNTIME_ENV
-    if observation is None:
-        return _CODEX_TOOL_LEGACY_RUNTIME_ENV
-    try:
-        observed = HostedRuntimeObservedV2.model_validate(observation.diagnostics)
-    except ValidationError:
-        return _CODEX_TOOL_LEGACY_RUNTIME_ENV
-    expected_generation = resolve_runtime_apply_generation(
-        generation=state.generation,
-        apply_generation=state.apply_generation,
-    )
-    # The env-name change creates the next source revision, so gate only on the
-    # last applied record's internal identity instead of this render's revision.
-    if not (
-        observed.status == "ok"
-        and observed.converge_error is None
-        and observed.active_cli_version == desired_version
-        and observed.applied is not None
-        and observed.applied.instance_id == state.instance_id
-        and observed.applied.generation == expected_generation
-        and observation.observed_config_generation == expected_generation
-        and observation.observed_manifest_etag == observed.applied.etag
-        and observation.observed_source_revision == observed.applied.source_revision
-    ):
-        return _CODEX_TOOL_LEGACY_RUNTIME_ENV
-    return _MANAGED_PROVIDER_RUNTIME_ENV
 
 
 @dataclass(frozen=True)
@@ -849,7 +803,7 @@ def render_runtime_source(
         "baseUrl": codex_provider_material.get("baseUrl"),
         "apiMode": _CODEX_TOOL_API_MODE,
         "managed_by": codex_provider_material.get("managed_by"),
-        "runtimeEnvName": _codex_tool_runtime_env(state, row.observation),
+        "runtimeEnvName": _MANAGED_PROVIDER_RUNTIME_ENV,
         "apiKeySecretRef": codex_provider_material.get("apiKeySecretRef"),
     }
     try:

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -383,53 +383,6 @@ def _render(batch: RuntimeSourceBatch):
     )
 
 
-def _set_healthy_cli_observation(
-    batch: RuntimeSourceBatch,
-    *,
-    desired: str,
-    active: str | None = None,
-    source_revision: str = "a" * 64,
-) -> HostedRuntimeConfigObservation:
-    row = batch.rows[ENV_ID]
-    assert row.state is not None
-    row.state.cli_package_spec = desired
-    expected_generation = (
-        row.state.apply_generation
-        if row.state.apply_generation is not None
-        else row.state.generation
-    )
-    etag = expected_runtime_bundle_v2_etag(source_revision)
-    observation = HostedRuntimeConfigObservation(
-        environment_id=ENV_ID,
-        observed_config_generation=expected_generation,
-        observed_manifest_etag=etag,
-        observed_source_revision=source_revision,
-        diagnostics={
-            "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
-            "reportedAt": "2026-07-13T00:00:00Z",
-            "runtimeMode": "hosted",
-            "status": "ok",
-            "activeCliVersion": active or desired.removeprefix("clawdi@"),
-            "applied": {
-                "etag": etag,
-                "sourceRevision": source_revision,
-                "generation": expected_generation,
-                "instanceId": row.state.instance_id,
-                "appliedProviderIds": ["managed"],
-            },
-            "boot": None,
-            "cli": None,
-            "convergeError": None,
-        },
-    )
-    batch.rows[ENV_ID] = RuntimeSourceRow(row.environment, row.state, observation)
-    return observation
-
-
-def _codex_runtime_env(batch: RuntimeSourceBatch) -> str:
-    return _render(batch).manifest["terminalTooling"]["codex"]["provider"]["runtimeEnvName"]
-
-
 def test_runtime_source_revision_uses_only_projected_descriptor_and_secret_sources() -> None:
     initial = _render(_batch())
     irrelevant = _render(_batch(provider_label="Renamed", channel_name="Renamed bot"))
@@ -900,6 +853,7 @@ def test_unmanaged_runtime_tool_secret_uses_auth_payload_without_user_vault_refs
     ("field", "value"),
     [
         ("apiMode", "openai_chat"),
+        ("runtimeEnvName", "OPENAI_API_KEY"),
         ("runtimeEnvName", "CUSTOM_OPENAI_API_KEY"),
     ],
 )
@@ -910,7 +864,7 @@ def test_codex_tool_projection_rejects_invalid_fixed_fields(field: str, value: s
         "baseUrl": "https://provider.test/v1",
         "apiMode": "openai_responses",
         "managed_by": "clawdi",
-        "runtimeEnvName": "OPENAI_API_KEY",
+        "runtimeEnvName": "CLAWDI_AI_API_KEY",
         "apiKeySecretRef": "secret://tool.codex.apiKey",
     }
     projection[field] = value
@@ -919,127 +873,40 @@ def test_codex_tool_projection_rejects_invalid_fixed_fields(field: str, value: s
         HostedCodexProviderProjection.model_validate(projection)
 
 
-@pytest.mark.parametrize(
-    ("desired", "active", "expected"),
-    [
-        ("0.13.68", "0.13.68", "OPENAI_API_KEY"),
-        ("0.13.69-rc.1", "0.13.69-rc.1", "OPENAI_API_KEY"),
-        ("0.13.69", "0.13.68", "OPENAI_API_KEY"),
-        ("0.13.69", "0.13.69", "CLAWDI_AI_API_KEY"),
-        ("0.14.0-rc.1", "0.14.0-rc.1", "CLAWDI_AI_API_KEY"),
-        ("0.13.68", "0.14.0", "OPENAI_API_KEY"),
-    ],
-)
-def test_codex_tool_env_respects_cli_version_boundary(
-    desired: str,
-    active: str,
-    expected: str,
-) -> None:
+def test_codex_tool_env_is_canonical_during_cli_upgrade_handoff() -> None:
     batch = _batch()
-    _set_healthy_cli_observation(
-        batch,
-        desired=f"clawdi@{desired}",
-        active=active,
+    row = batch.rows[ENV_ID]
+    assert row.state is not None
+    row.state.cli_package_spec = "clawdi@0.14.11"
+    source_revision = "a" * 64
+    etag = expected_runtime_bundle_v2_etag(source_revision)
+    observation = HostedRuntimeConfigObservation(
+        environment_id=ENV_ID,
+        observed_config_generation=row.state.apply_generation,
+        observed_manifest_etag=etag,
+        observed_source_revision=source_revision,
+        diagnostics={
+            "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
+            "reportedAt": "2026-07-13T00:00:00Z",
+            "runtimeMode": "hosted",
+            "status": "ok",
+            "activeCliVersion": "0.14.10",
+            "applied": {
+                "etag": etag,
+                "sourceRevision": source_revision,
+                "generation": row.state.apply_generation,
+                "instanceId": row.state.instance_id,
+                "appliedProviderIds": ["managed"],
+            },
+            "boot": None,
+            "cli": None,
+            "convergeError": None,
+        },
     )
+    batch.rows[ENV_ID] = RuntimeSourceRow(row.environment, row.state, observation)
 
-    assert _codex_runtime_env(batch) == expected
-
-
-def test_codex_tool_env_rejects_compatible_installed_cli_until_it_is_running() -> None:
-    batch = _batch()
-    observation = _set_healthy_cli_observation(
-        batch,
-        desired="clawdi@0.13.69",
-        active="0.13.68",
-    )
-    assert isinstance(observation.diagnostics, dict)
-    observation.diagnostics["cli"] = {
-        "status": "installed",
-        "source": "npm",
-        "packageSpec": "clawdi@0.13.69",
-        "registry": "https://registry.npmjs.org",
-        "activePath": "/test/managed/clawdi",
-        "activeTarget": "/test/managed/packages/0.13.69/clawdi",
-        "version": "0.13.69",
-    }
-
-    assert observation.diagnostics["activeCliVersion"] == "0.13.68"
-    assert _codex_runtime_env(batch) == "OPENAI_API_KEY"
-
-
-def test_codex_tool_env_stays_legacy_until_new_cli_is_observed() -> None:
-    missing = _batch()
-    assert missing.rows[ENV_ID].state is not None
-    missing.rows[ENV_ID].state.cli_package_spec = "clawdi@0.13.69"
-    invalid = _batch()
-    invalid_observation = _set_healthy_cli_observation(invalid, desired="clawdi@0.13.69")
-    invalid_observation.diagnostics = {"schemaVersion": "clawdi.hostedRuntimeObserved.v2"}
-
-    assert [_codex_runtime_env(batch) for batch in (missing, invalid)] == [
-        "OPENAI_API_KEY",
-        "OPENAI_API_KEY",
-    ]
-
-
-@pytest.mark.parametrize(
-    ("diagnostics_update", "applied_update", "observation_update"),
-    [
-        ({"status": "error"}, {}, {}),
-        ({"convergeError": "apply failed"}, {}, {}),
-        ({"applied": None}, {}, {}),
-        ({}, {"instanceId": "hri_previous"}, {}),
-        ({}, {"generation": 0}, {}),
-        ({}, {}, {"observed_config_generation": 0}),
-        ({}, {}, {"observed_manifest_etag": expected_runtime_bundle_v2_etag("b" * 64)}),
-        ({}, {}, {"observed_source_revision": "b" * 64}),
-    ],
-)
-def test_codex_tool_env_rejects_unhealthy_or_inconsistent_observations(
-    diagnostics_update: dict[str, object],
-    applied_update: dict[str, object],
-    observation_update: dict[str, object],
-) -> None:
-    batch = _batch()
-    observation = _set_healthy_cli_observation(batch, desired="clawdi@0.13.69")
-    assert isinstance(observation.diagnostics, dict)
-    applied = observation.diagnostics["applied"]
-    observation.diagnostics.update(diagnostics_update)
-    if applied_update:
-        assert isinstance(applied, dict)
-        applied.update(applied_update)
-    for field, value in observation_update.items():
-        setattr(observation, field, value)
-
-    assert _codex_runtime_env(batch) == "OPENAI_API_KEY"
-
-
-def test_codex_tool_env_cutover_reaches_a_stable_source_revision() -> None:
-    batch = _batch()
-    assert batch.rows[ENV_ID].state is not None
-    batch.rows[ENV_ID].state.cli_package_spec = "clawdi@0.13.69"
-    legacy = _render(batch)
-    assert _codex_runtime_env(batch) == "OPENAI_API_KEY"
-
-    observation = _set_healthy_cli_observation(
-        batch,
-        desired="clawdi@0.13.69",
-        source_revision=legacy.source_revision,
-    )
-    canonical = _render(batch)
-    assert canonical.source_revision != legacy.source_revision
-    assert observation.observed_source_revision == legacy.source_revision
-    assert observation.observed_source_revision != canonical.source_revision
-    assert _codex_runtime_env(batch) == "CLAWDI_AI_API_KEY"
-    assert _render(batch).source_revision == canonical.source_revision
-
-    assert isinstance(observation.diagnostics, dict)
-    applied = observation.diagnostics["applied"]
-    assert isinstance(applied, dict)
-    canonical_etag = expected_runtime_bundle_v2_etag(canonical.source_revision)
-    applied.update({"etag": canonical_etag, "sourceRevision": canonical.source_revision})
-    observation.observed_manifest_etag = canonical_etag
-    observation.observed_source_revision = canonical.source_revision
-    assert _render(batch).source_revision == canonical.source_revision
+    provider = _render(batch).manifest["terminalTooling"]["codex"]["provider"]
+    assert provider["runtimeEnvName"] == "CLAWDI_AI_API_KEY"
 
 
 def test_legacy_managed_v2_chat_storage_projects_responses() -> None:
@@ -1055,7 +922,7 @@ def test_legacy_managed_v2_chat_storage_projects_responses() -> None:
         "baseUrl": "https://provider.test/v1",
         "apiMode": "openai_responses",
         "managed_by": "clawdi",
-        "runtimeEnvName": "OPENAI_API_KEY",
+        "runtimeEnvName": "CLAWDI_AI_API_KEY",
         "apiKeySecretRef": "secret://tool.codex.apiKey",
     }
 
@@ -1385,7 +1252,6 @@ def test_runtime_bundle_matches_shared_golden(monkeypatch) -> None:
         lambda ciphertext, _nonce: plaintext_by_ciphertext[ciphertext],
     )
     batch = _batch()
-    _set_healthy_cli_observation(batch, desired="clawdi@1.2.3-test")
     source = render_runtime_source(
         batch,
         environment_id=ENV_ID,

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -574,23 +574,6 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
         applied_generation=4,
         applied_instance_id="iid-observed-api",
     )
-    heartbeat = await client.post(
-        f"/v1/agents/{env_id}/sync-heartbeat",
-        json={"queue_depth": 1, "runtime_observed": observed},
-    )
-    assert heartbeat.status_code == 204, heartbeat.text
-
-    transitioning = (await client.get(f"/v1/environments/{env_id}/runtime-observed")).json()
-    canonical_source_revision = transitioning["desired"]["desired_source_revision"]
-    assert canonical_source_revision != desired_source_revision
-    assert transitioning["health"]["status"] == "unknown"
-
-    observed = _runtime_observed(
-        source_revision=canonical_source_revision,
-        active_cli_version="1.2.5-test",
-        applied_generation=4,
-        applied_instance_id="iid-observed-api",
-    )
     received_at_lower_bound = datetime.now(UTC)
     heartbeat = await client.post(
         f"/v1/agents/{env_id}/sync-heartbeat",
@@ -602,6 +585,7 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
     response = await client.get(f"/v1/environments/{env_id}/runtime-observed")
     assert response.status_code == 200, response.text
     payload = response.json()
+    assert payload["desired"]["desired_source_revision"] == desired_source_revision
     assert payload["environment"]["id"] == env_id
     assert payload["desired"] == {
         "deployment_id": "dep-observed-api",
@@ -632,9 +616,9 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
     ) == datetime.fromisoformat(observed["reportedAt"])
     assert payload["observed"]["observed_config_generation"] == 4
     assert payload["observed"]["observed_manifest_etag"] == expected_runtime_bundle_v2_etag(
-        canonical_source_revision
+        desired_source_revision
     )
-    assert payload["observed"]["observed_source_revision"] == canonical_source_revision
+    assert payload["observed"]["observed_source_revision"] == desired_source_revision
     assert payload["observed"]["diagnostics"]["schemaVersion"] == (
         "clawdi.hostedRuntimeObserved.v2"
     )


### PR DESCRIPTION
## Summary

- remove the observed-CLI/version gate that downgraded the Hosted Codex `runtimeEnvName`
- emit `CLAWDI_AI_API_KEY` unconditionally from the runtime source renderer
- narrow the Cloud-owned producer projection type so `OPENAI_API_KEY` is rejected
- replace compatibility-output tests with canonical-only coverage, including a desired 0.14.11 / observed 0.14.10 handoff

## Deadlock mechanism

During a managed CLI upgrade, the renderer compared the desired CLI version with the last observed active CLI and applied identity. Until the observation matched, it emitted the legacy Codex env name `OPENAI_API_KEY`.

CLI 0.14.11 removed that read compatibility and accepts only `CLAWDI_AI_API_KEY`. The new watcher therefore rejected the legacy manifest, convergence could not advance, the active observation could not update, and the renderer continued emitting the legacy manifest. This closed the loop seen on `hdep_p3E45EJM`.

## Producer-side removal

This change removes the fallback at the producer. It does not add any consumer read compatibility.

The fleet floor is CLI 0.14.10, which already parses both field names:

- [`MANAGED_AI_PROVIDER_RUNTIME_ENV` is `CLAWDI_AI_API_KEY`](https://github.com/Clawdi-AI/clawdi/blob/clawdi-cli-v0.14.10/packages/shared/src/ai-provider.ts#L241)
- [the 0.14.10 Hosted Codex manifest guard accepts that canonical constant](https://github.com/Clawdi-AI/clawdi/blob/clawdi-cli-v0.14.10/packages/cli/src/runtime/manifest-contract.ts#L20-L27), and [the terminal Codex schema uses that guard](https://github.com/Clawdi-AI/clawdi/blob/clawdi-cli-v0.14.10/packages/cli/src/runtime/manifest-contract.ts#L703-L708)
- [the 0.14.10 Codex projection writes the canonical constant into generated Codex config](https://github.com/Clawdi-AI/clawdi/blob/clawdi-cli-v0.14.10/packages/cli/src/runtime/manifest-providers.ts#L392-L404)

New deployments bootstrap the current latest CLI. Canonical-only output is therefore parseable by every surviving consumer, and the producer compatibility branch has no remaining consumer.

## Compatibility branch sweep

| Removed branch | Location | Legacy output | Canonical output | CLI 0.14.10 evidence |
| --- | --- | --- | --- | --- |
| Desired semver, missing or invalid observation, active CLI mismatch, or applied identity mismatch | `backend/app/services/runtime_source.py::_codex_tool_runtime_env` | `OPENAI_API_KEY` | `CLAWDI_AI_API_KEY` | The tag contract and projection links above show canonical parse and projection support. |

A sweep of `runtime_source.py` and the related backend render paths found no other observed-CLI/version-dependent legacy output branches.

## Test coverage

The remaining changed tests protect distinct boundaries: the producer projection rejects the legacy env name, the renderer stays canonical during a desired 0.14.11 / observed 0.14.10 handoff, and desired/observed health keeps one stable source revision after a heartbeat. The obsolete version, observation-error, and cutover revision compatibility matrix was removed.

No test files were added. Relative to `main`, this PR removes four test functions and fifteen collected pytest cases net.

## Recovery after delivery

After this lands, the backend deploys automatically from `main`. The next p3 render emits `CLAWDI_AI_API_KEY`, the already-installed 0.14.11 watcher can converge, and the deadlock resolves without manual intervention. The other three machines continue their normal rollout.

No setting rollback and no new CLI release are required.

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run --extra mem0 python scripts/type_governance.py owned`
- `uv run pytest -q tests/test_runtime_source.py` (`42 passed`)
- `scripts/test.sh backend` (`2354 passed, 12 skipped`)
- `uv run python scripts/check_generated_api.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)