### PR TITLE
fix(cli): converge virgin Hermes and OpenClaw deployments

### DIFF
--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1457,8 +1457,16 @@ async function applyRuntimeDesiredState(
 						};
 						return systemdApply;
 					} catch (error) {
+						const mutationJournal = systemdTransaction.journal
+							.map(
+								(entry) =>
+									`${entry.sequence}:${entry.stage}/${entry.scope}/${entry.action}(${entry.units.join(",") || "manager"})=${entry.outcome}`,
+							)
+							.join(", ");
 						throw new Error(
-							`systemd apply failed: ${error instanceof Error ? error.message : String(error)}`,
+							`systemd apply failed: ${error instanceof Error ? error.message : String(error)}${
+								mutationJournal ? `; mutation journal: ${mutationJournal}` : ""
+							}`,
 						);
 					}
 				},

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -1353,6 +1353,7 @@ function prepareRuntimeActivation(
 		manifest,
 		paths,
 		opts,
+		platformEnclaves,
 		secretValues,
 		projectionHome,
 		hermesWhatsAppAuthDir,
@@ -1379,6 +1380,12 @@ function prepareRuntimeActivation(
 			),
 		commonEnvironment: egressProjection.commonSystemdEnvironment,
 	});
+	if (platformEnclaves.some((enclave) => enclave.path === paths.systemdUserRoot)) {
+		// Candidate files are written under the root service's private umask.
+		// Publish manager-readable modes before a native installer can reload or
+		// start its unit for the first time.
+		enforceRuntimeUserSystemdManagerAccess(paths.systemdUserRoot);
+	}
 	state.staleSystemdFiles = systemdUnits.staleFiles;
 	const officialServicePlan = planOfficialRuntimeServices(
 		state.runtimeSystemdUserPrograms,

--- a/packages/cli/src/runtime/systemd-transaction.ts
+++ b/packages/cli/src/runtime/systemd-transaction.ts
@@ -326,7 +326,17 @@ export function applySystemdRuntimeUpdate(
 	for (const unit of user.present) {
 		const state = requiredSystemdUnitState(userStates, "user", unit);
 		if (state.activeState !== "active") continue;
-		const revisions = systemdProcessRevisions(paths, unit, state);
+		let revisions: ReturnType<typeof systemdProcessRevisions>;
+		try {
+			revisions = systemdProcessRevisions(paths, unit, state);
+		} catch (error) {
+			if (!state.needDaemonReload) throw error;
+			// The manager may still be running the pre-candidate view. Reload and
+			// restart before the final proof, while preserving reload-only behavior
+			// when the current process already proves the desired revision.
+			userProcessRevisionDrift.add(unit);
+			continue;
+		}
 		if (revisions.processRevision === revisions.desiredRevision) continue;
 		const committedAlias = committedAliases[unit];
 		if (
@@ -927,11 +937,28 @@ function systemdProcessRevisions(
 		}
 		processRevision = runtimeRevisionFromProcessEnvironment(environment);
 	} catch (error) {
-		throw new Error(`could not prove active runtime revision for managed systemd unit ${unit}`, {
-			cause: error,
-		});
+		const detail = activeRuntimeRevisionProofFailureDetail(error);
+		throw new Error(
+			`could not prove active runtime revision for managed systemd unit ${unit}: ${detail}; manager reload required=${state.needDaemonReload ? "yes" : "no"}`,
+			{ cause: error },
+		);
 	}
 	return { desiredRevision, processRevision };
+}
+
+function activeRuntimeRevisionProofFailureDetail(error: unknown): string {
+	if (error instanceof Error && error.message === "invalid revision entry") {
+		return "active process environment does not contain exactly one valid CLAWDI_RUNTIME_REV";
+	}
+	const code =
+		error && typeof error === "object" && "code" in error && typeof error.code === "string"
+			? error.code
+			: null;
+	if (code === "ENOENT" || code === "ESRCH") return "active process exited during revision proof";
+	if (code === "EACCES" || code === "EPERM") {
+		return "active process environment was not readable under its filesystem identity";
+	}
+	return "active process environment could not be read";
 }
 
 function runtimeRevisionFromProcessEnvironment(environment: Buffer): string {

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -30,7 +30,11 @@ import {
 	buildOpenClawHostedProviderPatch,
 	convergeRuntimeManifest,
 } from "../../src/runtime/manifest";
-import type { RuntimeManifest } from "../../src/runtime/manifest-contract";
+import {
+	OFFICIAL_INSTALL_URLS,
+	officialInstallArgs,
+	type RuntimeManifest,
+} from "../../src/runtime/manifest-contract";
 import type { RuntimeManifestLoad } from "../../src/runtime/manifest-source";
 import { CLAWDI_MANAGED_OPENCLAW_PROVIDER_PLUGIN_ID } from "../../src/runtime/openclaw-managed-provider-plugin";
 import { getRuntimePaths } from "../../src/runtime/paths";
@@ -127,6 +131,322 @@ function chownTreeWithoutFollowingLinks(path: string, uid: number, gid: number):
 		chownTreeWithoutFollowingLinks(join(path, entry), uid, gid);
 	}
 }
+
+test.each(["hermes", "openclaw"] as const)(
+	"converges a virgin %s deployment from a cold user manager",
+	(runtime) => {
+		if (process.env[REAL_SYSTEMD_GATE] !== "1") return;
+
+		expect(process.geteuid?.()).toBe(0);
+		const runtimeHome = "/home/clawdi";
+		const runtimeUid = 10_001;
+		const runtimeGid = 10_001;
+		const unitName = `${runtime}-gateway.service`;
+		const stockInstaller = "/opt/fixture/install-stock-runtime.sh";
+		const root = mkdtempSync(join(tmpdir(), `clawdi-virgin-${runtime}-`));
+		chmodSync(root, 0o755);
+		const environmentNames = [
+			"CLAWDI_AUTH_TOKEN",
+			"CLAWDI_CODEX_INSTALL_DISABLED",
+			"CLAWDI_HOME",
+			"CLAWDI_RUN_DIR",
+			"CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS",
+			"CLAWDI_RUNTIME_GID",
+			"CLAWDI_RUNTIME_HOME",
+			"CLAWDI_RUNTIME_MODE",
+			"CLAWDI_RUNTIME_TEST_HERMES_INSTALLER",
+			"CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER",
+			"CLAWDI_RUNTIME_UID",
+			"CLAWDI_RUNTIME_USER",
+			"CLAWDI_SERVICE_STATE_DIR",
+			"CLAWDI_SYSTEMD_SYSTEM_ROOT",
+			"CLAWDI_TEST_STOCK_RUNTIME",
+		] as const;
+		const previousEnvironment = new Map(environmentNames.map((name) => [name, process.env[name]]));
+		const runUserSystemctl = (...args: string[]) =>
+			spawnSync(
+				"runuser",
+				[
+					"-u",
+					"clawdi",
+					"--",
+					"env",
+					`HOME=${runtimeHome}`,
+					`XDG_RUNTIME_DIR=/run/user/${runtimeUid}`,
+					`DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${runtimeUid}/bus`,
+					"systemctl",
+					"--user",
+					...args,
+				],
+				{ encoding: "utf8" },
+			);
+		const waitForUserManager = () => {
+			for (let attempt = 0; attempt < 100; attempt++) {
+				const active = spawnSync("systemctl", [
+					"is-active",
+					"--quiet",
+					`user@${runtimeUid}.service`,
+				]);
+				if (active.status === 0 && existsSync(`/run/user/${runtimeUid}/bus`)) return;
+				Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+			}
+			throw new Error(`user@${runtimeUid}.service did not expose its D-Bus socket`);
+		};
+		let previousUmask: number | null = null;
+
+		try {
+			if (existsSync(`/run/user/${runtimeUid}/bus`)) {
+				for (const staleUnit of ["hermes-gateway.service", "openclaw-gateway.service"]) {
+					runUserSystemctl("disable", "--now", staleUnit);
+				}
+			}
+			spawnSync("loginctl", ["disable-linger", "clawdi"]);
+			const stopManager = spawnSync("systemctl", ["stop", `user@${runtimeUid}.service`], {
+				encoding: "utf8",
+			});
+			expect(stopManager.status, stopManager.stderr).toBe(0);
+			expect(
+				spawnSync("systemctl", ["is-active", "--quiet", `user@${runtimeUid}.service`]).status,
+			).not.toBe(0);
+
+			rmSync(runtimeHome, { recursive: true, force: true });
+			mkdirSync(runtimeHome, { mode: 0o700 });
+			chownSync(runtimeHome, runtimeUid, runtimeGid);
+			expect(existsSync(join(runtimeHome, ".config", "systemd", "user"))).toBe(false);
+
+			const enableLinger = spawnSync("loginctl", ["enable-linger", "clawdi"], {
+				encoding: "utf8",
+			});
+			expect(enableLinger.status, enableLinger.stderr).toBe(0);
+			const startManager = spawnSync("systemctl", ["start", `user@${runtimeUid}.service`], {
+				encoding: "utf8",
+			});
+			expect(startManager.status, startManager.stderr).toBe(0);
+			waitForUserManager();
+
+			Object.assign(process.env, {
+				CLAWDI_AUTH_TOKEN: `virgin-${runtime}-auth-token`,
+				CLAWDI_CODEX_INSTALL_DISABLED: "1",
+				CLAWDI_HOME: join(root, "clawdi-home"),
+				CLAWDI_RUN_DIR: join(root, "run"),
+				CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS: "1",
+				CLAWDI_RUNTIME_GID: String(runtimeGid),
+				CLAWDI_RUNTIME_HOME: runtimeHome,
+				CLAWDI_RUNTIME_MODE: "hosted",
+				CLAWDI_RUNTIME_UID: String(runtimeUid),
+				CLAWDI_RUNTIME_USER: "clawdi",
+				CLAWDI_SERVICE_STATE_DIR: join(root, "state"),
+				CLAWDI_SYSTEMD_SYSTEM_ROOT: "/run/systemd/system",
+				CLAWDI_TEST_STOCK_RUNTIME: runtime,
+			});
+			delete process.env.CLAWDI_RUNTIME_TEST_HERMES_INSTALLER;
+			delete process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER;
+			process.env[
+				runtime === "hermes"
+					? "CLAWDI_RUNTIME_TEST_HERMES_INSTALLER"
+					: "CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER"
+			] = stockInstaller;
+
+			previousUmask = process.umask(0o077);
+			const paths = getRuntimePaths({ mode: "hosted" });
+			ensureRuntimeStateDirs(paths);
+			const commandPath = join(runtimeHome, ".local", "bin", runtime);
+			const manifest: RuntimeManifest = {
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: `hdep_virgin_${runtime}`,
+				environmentId: `env_virgin_${runtime}`,
+				instanceId: `hri_virgin_${runtime}`,
+				generation: 1,
+				issuedAt: "2026-08-22T00:00:00.000Z",
+				workspaceRoot: join(runtimeHome, `clawdi-virgin-${runtime}-workspace`),
+				controlPlane: { apiUrl: "https://cloud-api.example.test" },
+				runtimes: {
+					[runtime]: {
+						enabled: true,
+						install: {
+							authority: "official",
+							method: "official-installer",
+							url: OFFICIAL_INSTALL_URLS[runtime],
+							home: runtimeHome,
+							args: officialInstallArgs(runtime, runtimeHome),
+						},
+						run: {
+							command: commandPath,
+							args: ["gateway", "run"],
+							env: {},
+							prependPath: [],
+						},
+						services: {},
+					},
+				},
+				recovery: {},
+			};
+			const load: RuntimeManifestLoad = {
+				manifest,
+				source: "remote-datasource",
+				sourcePath: `virgin-${runtime}-fixture`,
+				offline: false,
+				applyContext: {
+					kind: "context-file",
+					backend: "incus",
+					identity: {
+						generation: manifest.generation,
+						manifestETag: `"virgin-${runtime}-test"`,
+						applyReceiptId: `virgin-${runtime}-receipt`,
+						bootNonce: `virgin-${runtime}-boot`,
+					},
+					manifestSource: {
+						type: "http",
+						url: `https://runtime.test/v1/runtime/manifest?environment_id=env_virgin_${runtime}`,
+						auth: { type: "bearer", token: `virgin-${runtime}-auth-token` },
+					},
+				},
+			};
+			const before = readSystemdUnitSnapshot(paths);
+			const transaction = new SystemdRuntimeTransaction();
+			let stateBeforeSharedActivation = "";
+			const result = convergeRuntimeManifest(load, paths, {
+				cacheLastGood: false,
+				systemdApply: {
+					transactionState: () => transaction.state,
+					installOfficialService: (unit, install) =>
+						transaction.installOfficialService(paths, unit, install),
+					quiesce: (affectedUserUnits) => transaction.quiesce(paths, affectedUserUnits),
+					activateEgressPrerequisite: () => ({
+						applied: true,
+						systemUnitsChanged: [],
+						userUnitsChanged: [],
+					}),
+					activate: () => {
+						const state = runUserSystemctl(
+							"show",
+							unitName,
+							"--property=ActiveState",
+							"--property=MainPID",
+						);
+						expect(state.status, state.stderr).toBe(0);
+						stateBeforeSharedActivation = state.stdout;
+						return applySystemdRuntimeUpdate(paths, before, readSystemdUnitSnapshot(paths), {
+							transaction,
+							stage: "final-activation",
+						});
+					},
+					rollback: () => transaction.rollback(paths),
+				},
+			});
+			expect(result.installErrors).toEqual([]);
+			expect(stateBeforeSharedActivation).toContain("ActiveState=active");
+			expect(
+				Number.parseInt(stateBeforeSharedActivation.match(/^MainPID=(\d+)$/m)?.[1] ?? "0", 10),
+			).toBeGreaterThan(1);
+
+			const inventory = JSON.parse(
+				readFileSync(join(paths.installInventory, `${runtime}.json`), "utf8"),
+			) as Record<string, unknown>;
+			expect(inventory.status).toBe("installed");
+			expect(inventory.executionUser).toBe("clawdi");
+			expect(inventory.executedInstallerUrl).toBe(stockInstaller);
+
+			const state = runUserSystemctl(
+				"show",
+				unitName,
+				"--property=LoadState",
+				"--property=ActiveState",
+				"--property=MainPID",
+				"--property=NeedDaemonReload",
+			);
+			expect(state.status, state.stderr).toBe(0);
+			expect(state.stdout).toContain("LoadState=loaded");
+			expect(state.stdout).toContain("ActiveState=active");
+			expect(state.stdout).toContain("NeedDaemonReload=no");
+			expect(runUserSystemctl("is-enabled", unitName).stdout.trim()).toBe("enabled");
+			const mainPid = Number.parseInt(state.stdout.match(/^MainPID=(\d+)$/m)?.[1] ?? "0", 10);
+			expect(mainPid).toBeGreaterThan(1);
+			expect(statSync(`/proc/${mainPid}`).uid).toBe(runtimeUid);
+			const processRevisions = readFileSync(`/proc/${mainPid}/environ`)
+				.toString("utf8")
+				.split("\0")
+				.filter((entry) => entry.startsWith("CLAWDI_RUNTIME_REV="));
+			expect(processRevisions).toHaveLength(1);
+			const processRevision = processRevisions[0].slice("CLAWDI_RUNTIME_REV=".length);
+			expect(processRevision).toMatch(/^[a-f0-9]{32}$/);
+			const managedEnvironment = readFileSync(
+				join(paths.systemdEnvRoot, `${unitName}.env`),
+				"utf8",
+			);
+			const desiredRevision = managedEnvironment.match(
+				/^CLAWDI_RUNTIME_REV="([a-f0-9]{32})"$/m,
+			)?.[1];
+			expect(desiredRevision).toBe(processRevision);
+
+			const unitPath = join(paths.systemdUserRoot, unitName);
+			const dropInRoot = `${unitPath}.d`;
+			const dropInPath = join(dropInRoot, "10-clawdi-hosted.conf");
+			const enablementPath = join(paths.systemdUserRoot, "default.target.wants", unitName);
+			for (const path of [
+				paths.systemdUserRoot,
+				unitPath,
+				dropInRoot,
+				dropInPath,
+				enablementPath,
+			]) {
+				const node = lstatSync(path);
+				expect([node.uid, node.gid]).toEqual([0, 0]);
+			}
+			for (const path of [paths.systemdUserRoot, dropInRoot]) {
+				expect(lstatSync(path).mode & 0o555).toBe(0o555);
+			}
+			for (const path of [unitPath, dropInPath]) {
+				expect(lstatSync(path).mode & 0o444).toBe(0o444);
+			}
+
+			expect(transaction.journal).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						stage: "official-installer",
+						scope: "user",
+						action: "install",
+						units: [unitName],
+						outcome: "succeeded",
+					}),
+					expect.objectContaining({
+						stage: "final-activation",
+						scope: "user",
+						action: "daemon-reload",
+						outcome: "succeeded",
+					}),
+				]),
+			);
+		} finally {
+			if (previousUmask !== null) process.umask(previousUmask);
+			if (existsSync(`/run/user/${runtimeUid}/bus`)) {
+				for (const staleUnit of ["hermes-gateway.service", "openclaw-gateway.service"]) {
+					runUserSystemctl("disable", "--now", staleUnit);
+				}
+			}
+			rmSync(runtimeHome, { recursive: true, force: true });
+			mkdirSync(runtimeHome, { mode: 0o700 });
+			chownSync(runtimeHome, runtimeUid, runtimeGid);
+			for (const stockHome of ["/opt/stock/base-home", "/opt/stock/openclaw-home"]) {
+				const restore = spawnSync("cp", ["-a", `${stockHome}/.`, `${runtimeHome}/`], {
+					encoding: "utf8",
+				});
+				expect(restore.status, restore.stderr).toBe(0);
+			}
+			for (const [name, value] of previousEnvironment) {
+				if (value === undefined) delete process.env[name];
+				else process.env[name] = value;
+			}
+			rmSync(root, { recursive: true, force: true });
+			spawnSync("loginctl", ["enable-linger", "clawdi"]);
+			spawnSync("systemctl", ["start", `user@${runtimeUid}.service`]);
+			waitForUserManager();
+			const reload = runUserSystemctl("daemon-reload");
+			expect(reload.status, reload.stderr).toBe(0);
+		}
+	},
+	120_000,
+);
 
 test("propagates the real official OpenClaw installer failure and rolls back as UID 10001", () => {
 	if (process.env[REAL_SYSTEMD_GATE] !== "1") return;

--- a/packages/cli/tests/fixtures/runtime-official-installer-systemd/Dockerfile
+++ b/packages/cli/tests/fixtures/runtime-official-installer-systemd/Dockerfile
@@ -1,16 +1,20 @@
 ARG BUN_VERSION=1.4.0
 ARG NODE_VERSION=24.19.0
+ARG UV_VERSION=0.12.5
 
 FROM oven/bun:${BUN_VERSION} AS bun
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
 FROM node:${NODE_VERSION}-trixie
 
 COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=bun /usr/local/bin/bunx /usr/local/bin/bunx
+COPY --from=uv /uv /usr/local/bin/uv
 
 RUN apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 		ca-certificates \
 		dbus-user-session \
+		python3 \
 		systemd \
 		systemd-sysv \
 	&& rm -rf /var/lib/apt/lists/*
@@ -56,9 +60,53 @@ RUN npm pack "openclaw@${OPENCLAW_VERSION}" --pack-destination /tmp --silent >/d
 	&& printf '%s\n' "$OPENCLAW_VERSION_OUTPUT" \
 		| grep -F "$(printf '%s' "$OPENCLAW_COMMIT" | cut -c1-7)"
 
+RUN mkdir -p /opt/stock/base-home /opt/stock/openclaw-home \
+	&& cp -a /home/clawdi/.bash_logout /home/clawdi/.bashrc /home/clawdi/.profile \
+		/opt/stock/base-home/ \
+	&& cp -a /home/clawdi/.local /opt/stock/openclaw-home/.local \
+	&& chown -R clawdi:clawdi /opt/stock/base-home /opt/stock/openclaw-home
+
+ARG HERMES_COMMIT=cc4cab2f592e60a197e796506de9168f74baf3ea
+ARG HERMES_VERSION=0.19.1
+ADD --checksum=sha256:e75ad450f3e0932737bbfff3a0a997d4ed532dd8b5ece024072274791a648679 \
+	https://github.com/NousResearch/hermes-agent/archive/cc4cab2f592e60a197e796506de9168f74baf3ea.tar.gz \
+	/tmp/hermes-agent.tar.gz
+RUN mkdir -p /home/clawdi/.hermes/hermes-agent \
+	&& tar --extract --gzip --file /tmp/hermes-agent.tar.gz \
+		--directory /home/clawdi/.hermes/hermes-agent --strip-components=1 \
+	&& chown -R clawdi:clawdi /home/clawdi/.hermes \
+	&& runuser -u clawdi -- env \
+		HOME=/home/clawdi \
+		UV_PROJECT_ENVIRONMENT=/home/clawdi/.hermes/hermes-agent/venv \
+		uv sync \
+			--project /home/clawdi/.hermes/hermes-agent \
+			--python /usr/bin/python3 \
+			--frozen --extra messaging --no-dev \
+	&& printf '%s\n' \
+		'#!/usr/bin/env bash' \
+		'set -euo pipefail' \
+		'exec "$HOME/.hermes/hermes-agent/venv/bin/python" -m hermes_cli.main "$@"' \
+		> /home/clawdi/.local/bin/hermes \
+	&& chmod 0755 /home/clawdi/.local/bin/hermes \
+	&& chown clawdi:clawdi /home/clawdi/.local/bin/hermes \
+	&& runuser -u clawdi -- env HOME=/home/clawdi \
+		/home/clawdi/.local/bin/hermes --version \
+		| grep -F "Hermes Agent v${HERMES_VERSION}" \
+	&& mkdir -p /opt/stock/hermes-home/.local/bin \
+	&& cp -a /home/clawdi/.hermes /opt/stock/hermes-home/.hermes \
+	&& cp -a /home/clawdi/.local/bin/hermes /opt/stock/hermes-home/.local/bin/hermes \
+	&& chown -R clawdi:clawdi /opt/stock/hermes-home \
+	&& rm -rf /home/clawdi/.hermes /home/clawdi/.local/bin/hermes \
+		/tmp/hermes-agent.tar.gz
+
+COPY install-stock-runtime.sh /opt/fixture/install-stock-runtime.sh
+RUN chmod 0755 /opt/fixture/install-stock-runtime.sh
+
 ENV CLAWDI_TEST_OPENCLAW_VERSION=${OPENCLAW_VERSION} \
 	CLAWDI_TEST_OPENCLAW_COMMIT=${OPENCLAW_COMMIT} \
-	CLAWDI_TEST_OPENCLAW_NODE_VERSION=${OPENCLAW_NODE_VERSION}
+	CLAWDI_TEST_OPENCLAW_NODE_VERSION=${OPENCLAW_NODE_VERSION} \
+	CLAWDI_TEST_HERMES_VERSION=${HERMES_VERSION} \
+	CLAWDI_TEST_HERMES_COMMIT=${HERMES_COMMIT}
 
 STOPSIGNAL SIGRTMIN+3
 CMD ["/sbin/init"]

--- a/packages/cli/tests/fixtures/runtime-official-installer-systemd/install-stock-runtime.sh
+++ b/packages/cli/tests/fixtures/runtime-official-installer-systemd/install-stock-runtime.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runtime="${CLAWDI_TEST_STOCK_RUNTIME:?CLAWDI_TEST_STOCK_RUNTIME is required}"
+case "$runtime" in
+	hermes | openclaw) ;;
+	*)
+		echo "unsupported stock runtime: $runtime" >&2
+		exit 64
+		;;
+esac
+
+stock_home="/opt/stock/${runtime}-home"
+test -d "$stock_home"
+test -d "$HOME"
+cp -a "$stock_home/." "$HOME/"

--- a/scripts/test-runtime-official-installer-systemd.sh
+++ b/scripts/test-runtime-official-installer-systemd.sh
@@ -34,17 +34,6 @@ for _attempt in $(seq 1 100); do
 	sleep 0.1
 done
 
-docker exec "$container" loginctl enable-linger clawdi
-docker exec "$container" systemctl start user@10001.service
-for _attempt in $(seq 1 100); do
-	if docker exec "$container" test -S /run/user/10001/bus \
-		&& docker exec "$container" systemctl is-active --quiet user@10001.service; then
-		break
-	fi
-	sleep 0.1
-done
-docker exec "$container" test -S /run/user/10001/bus
-docker exec "$container" systemctl is-active --quiet user@10001.service
 docker exec "$container" bash -lc \
 	'cp -a /repo/. /work/ && bun install --frozen-lockfile'
 docker exec --env CLAWDI_TEST_REAL_OPENCLAW_SYSTEMD=1 "$container" \


### PR DESCRIPTION
## Paid deployment incident

A real paid, brand-new Incus deployment on CLI 0.14.11 installed Hermes successfully, but every first-convergence attempt failed with:

```text
runtime apply failed: systemd apply failed: could not prove active runtime revision for managed systemd unit hermes-gateway.service
```

The gateway remained `inactive/dead`, port 9119 never listened, and no observation or heartbeat was emitted. Existing deployments upgraded to 0.14.11 normally, so the missing path was specifically first convergence from zero state.

## Deterministic reproduction

The privileged PID1 fixture now runs one parameterized virgin-deployment test for both Hermes and OpenClaw. Each case wipes the tenant home, starts without a systemd user tree or Clawdi platform state, cold-starts `user@10001.service`, applies root's `0077` umask, installs a pinned stock official runtime, runs its real official service generator, and completes shared activation.

Before the fix, both runtime cases deterministically started a gateway without the managed revision and failed with:

```text
active process environment does not contain exactly one valid CLAWDI_RUNTIME_REV; manager reload required=yes
```

This proves the incident is in shared enclave/systemd activation, not Hermes-specific behavior. OpenClaw virgin deployments had the same failure mode.

## Root cause

1. Initial enclave repair ran while `~/.config/systemd/user` did not exist.
2. Root convergence later created the managed `.service.d` tree under its private umask, producing `0700 root:root` directories.
3. Both pinned official service installers start their gateway before shared activation.
4. The runtime user's systemd manager could not traverse the new drop-in, so the installer-started process lacked `CLAWDI_RUNTIME_REV`.
5. Post-installer ownership repair made the files readable, but systemd then reported `NeedDaemonReload=yes`.
6. The old transaction proved the stale process before daemon-reload/restart and rolled back, masking the causal state behind the generic proof error.

## Fix

- Publish manager-readable modes immediately after writing candidate user-systemd state and before either official installer can reload or start a unit.
- When initial process proof fails only while the manager explicitly reports `NeedDaemonReload=yes`, mark the unit for daemon-reload and restart, then perform the unchanged strict final `/proc/<pid>/environ` proof. Non-stale proof failures still fail immediately.
- Include categorized proof detail, manager reload state, and a safe mutation journal in systemd apply errors without including command output or secrets.
- Remove fixture-level user-manager prewarming so privileged coverage owns and verifies the cold-start sequence.

## Verification

- `bun run --cwd packages/cli test:internal`: 1768 pass, 4 skip, 0 fail
- `scripts/test-runtime-official-installer-systemd.sh`: 7 pass, 0 fail, including virgin Hermes and OpenClaw
- mutation parity: 1 pass, 0 fail
- `bun run --cwd packages/cli typecheck`
- `bun run check` with repository-pinned Biome 2.5.9: 1071 files checked, no fixes
- `git diff --check` and fixture shell syntax checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
