### PR TITLE
release(cli): 0.14.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.12
+
+Package: `clawdi@0.14.12`
+
+### Fixed
+
+- Fresh deployments converge on first boot: systemd files created for the
+  first time are published with manager-readable permissions before official
+  installers start gateways, and activation proof waits for the manager
+  reload it just required. Existing deployments were unaffected.
+
 ## Clawdi CLI v0.14.11
 
 Package: `clawdi@0.14.11`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.11",
+      "version": "0.14.12",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.11",
+	"version": "0.14.12",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Release `clawdi@0.14.12` — the virgin-boot fix (#1178).

A real paid fresh-deployment test caught that first-boot convergence deadlocked on brand-new hosts: systemd user files created for the first time under root's 0077 umask were unreadable to the tenant's systemd manager, official installers started gateways before activation, and the activation proof ran before the manager reload it had just made necessary. Reproduced on real PID1 with both Hermes and OpenClaw (shared activation layer); fixed by publishing manager-readable permissions at write time and sequencing proof after the required reload — the strict /proc environ verification is unchanged. One parameterized zero-state privileged e2e now covers both runtimes.

Follow-up: paid fresh-deployment certification for both runtimes, then final all-users sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)