### PR TITLE
fix(cli): make hosted runtime first boot declarative

### DIFF
--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1404,6 +1404,7 @@ async function applyRuntimeDesiredState(
 				activate: ({
 					restartDaemon,
 					restartEgressSidecar,
+					reloadUserUnits,
 					restartUserUnits,
 					staleSystemUnits,
 					staleUserUnits,
@@ -1428,6 +1429,7 @@ async function applyRuntimeDesiredState(
 									...(restartDaemon ? [RUNTIME_DAEMON_SYSTEM_UNIT] : []),
 									...(restartEgressSidecar ? [RUNTIME_SIDECAR_SYSTEM_UNIT] : []),
 								],
+								forceReloadUserUnits: reloadUserUnits,
 								forceRestartUserUnits: restartUserUnits,
 								preserveActiveUnits,
 								previousUserDesiredRevisions,

--- a/packages/cli/src/runtime/live-state-snapshot.ts
+++ b/packages/cli/src/runtime/live-state-snapshot.ts
@@ -330,6 +330,7 @@ function restoreRuntimeLiveOwnership(
 }
 
 function restoreRuntimeLiveNode(path: string, node: RuntimeLiveSnapshotNode): void {
+	if (runtimeLiveNodeMatches(path, node)) return;
 	if (node.kind === "metadata") {
 		if (!node.existed) {
 			if (existsSync(path) && readdirSync(path).length === 0) rmSync(path, { recursive: true });
@@ -358,4 +359,56 @@ function restoreRuntimeLiveNode(path: string, node: RuntimeLiveSnapshotNode): vo
 	chmodSync(path, node.mode);
 	for (const [entry, child] of node.entries) restoreRuntimeLiveNode(join(path, entry), child);
 	restoreRuntimeLiveOwnership(path, node.uid, node.gid, false);
+}
+
+function runtimeLiveNodeMatches(path: string, node: RuntimeLiveSnapshotNode): boolean {
+	let stat: ReturnType<typeof lstatSync>;
+	try {
+		stat = lstatSync(path);
+	} catch {
+		return node.kind === "missing" || (node.kind === "metadata" && !node.existed);
+	}
+	if (node.kind === "missing" || (node.kind === "metadata" && !node.existed)) return false;
+	if (node.kind === "metadata") {
+		return (
+			stat.isDirectory() &&
+			!stat.isSymbolicLink() &&
+			(stat.mode & 0o777) === node.mode &&
+			stat.uid === node.uid &&
+			stat.gid === node.gid
+		);
+	}
+	if (node.kind === "symlink") {
+		return (
+			stat.isSymbolicLink() &&
+			readlinkSync(path) === node.target &&
+			stat.uid === node.uid &&
+			stat.gid === node.gid
+		);
+	}
+	if (node.kind === "file") {
+		return (
+			stat.isFile() &&
+			!stat.isSymbolicLink() &&
+			(stat.mode & 0o777) === node.mode &&
+			stat.uid === node.uid &&
+			stat.gid === node.gid &&
+			readFileSync(path).equals(node.content)
+		);
+	}
+	if (
+		!stat.isDirectory() ||
+		stat.isSymbolicLink() ||
+		(stat.mode & 0o777) !== node.mode ||
+		stat.uid !== node.uid ||
+		stat.gid !== node.gid
+	) {
+		return false;
+	}
+	const entries = readdirSync(path).sort();
+	if (entries.length !== node.entries.size) return false;
+	return entries.every((entry) => {
+		const child = node.entries.get(entry);
+		return child !== undefined && runtimeLiveNodeMatches(join(path, entry), child);
+	});
 }

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -1519,6 +1519,7 @@ function activateRuntimeServices(
 			restartEgressSidecar: state.restartEgressSidecar,
 			stopEgressSidecar: false,
 			reconcileUserUnits: plan.mutationPlan.systemdUserUnits,
+			reloadUserUnits: [],
 			restartUserUnits: [],
 			staleSystemUnits: [],
 			staleUserUnits: [],
@@ -1534,11 +1535,9 @@ function activateRuntimeServices(
 		const unitPath = join(paths.systemdUserRoot, item.unitName);
 		const installerOwnership = [
 			...runtimeUserDirectoryOwnership(paths.systemdUserRoot),
-			...runtimeUserDirectoryOwnership(join(paths.systemdUserRoot, "default.target.wants")),
 			...runtimeUserExistingOwnership([
 				unitPath,
 				`${unitPath}.bak`,
-				join(paths.systemdUserRoot, "default.target.wants", item.unitName),
 				...(item.program.runtime === "openclaw"
 					? [join(paths.userHome, ".openclaw", "gateway.systemd.env")]
 					: []),
@@ -1578,6 +1577,7 @@ function activateRuntimeServices(
 			restartEgressSidecar: state.restartEgressSidecar,
 			stopEgressSidecar: false,
 			reconcileUserUnits: plan.mutationPlan.systemdUserUnits,
+			reloadUserUnits: systemdUnits.userEnablementChangedUnits,
 			restartUserUnits: [
 				...new Set([
 					...state.agentPluginRestartUserUnits,
@@ -1817,6 +1817,7 @@ function rollbackRuntimeApply(
 				restartEgressSidecar: state.restartEgressSidecar && state.egressRollbackAuthorityVerified,
 				stopEgressSidecar: state.restartEgressSidecar && !state.egressRollbackAuthorityVerified,
 				reconcileUserUnits: plan.mutationPlan.systemdUserUnits,
+				reloadUserUnits: [],
 				restartUserUnits: [
 					...new Set([
 						...state.agentPluginRestartUserUnits,

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -947,7 +947,16 @@ export function openClawGatewayHostedPatch(
 }
 function jsonMergePatchIsApplied(current: unknown, patch: unknown): boolean {
 	if (!isPlainRecord(patch)) return canonicalJsonEqual(current, patch);
-	if (!isPlainRecord(current)) return false;
+	if (!isPlainRecord(current)) {
+		if (current !== undefined) return false;
+		// OpenClaw canonicalizes deletion-only patches by omitting their empty parents.
+		return Object.values(patch).every(
+			(value) =>
+				value === undefined ||
+				value === null ||
+				(isPlainRecord(value) && jsonMergePatchIsApplied(undefined, value)),
+		);
+	}
 	return Object.entries(patch).every(([key, value]) =>
 		value === undefined
 			? true

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -5377,7 +5377,7 @@ installReservedManagedSkill(${JSON.stringify({
 		expect(rollbackCalls).toBe(1);
 	});
 
-	test("keeps stale systemd files through authority commit and removes them afterward", () => {
+	test("keeps stale unit authority through commit while declaratively disabling user units", () => {
 		const paths = tempRuntimePaths();
 		const staleSystemUnit = join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service");
 		const staleUserUnit = join(paths.systemdUserRoot, "clawdi-old.service");
@@ -5403,6 +5403,8 @@ installReservedManagedSkill(${JSON.stringify({
 			staleUserEnvironment,
 			staleDropInEnvironment,
 		];
+		const staleEnablementFiles = [staleUserWant, staleDropInWant];
+		const retainedStaleFiles = staleFiles.filter((path) => !staleEnablementFiles.includes(path));
 		for (const path of staleFiles) {
 			mkdirSync(dirname(path), { recursive: true });
 			writeFileSync(path, `${GENERATED_RUNTIME_SYSTEMD_FILE_HEADER}\nstale\n`);
@@ -5431,7 +5433,8 @@ installReservedManagedSkill(${JSON.stringify({
 				cacheLastGood: false,
 				commitAuthority: () => {
 					expect(activated).toBe(true);
-					for (const path of staleFiles) expect(existsSync(path)).toBe(true);
+					for (const path of retainedStaleFiles) expect(existsSync(path)).toBe(true);
+					for (const path of staleEnablementFiles) expect(existsSync(path)).toBe(false);
 					committed = true;
 				},
 				systemdApply: {
@@ -5443,7 +5446,8 @@ installReservedManagedSkill(${JSON.stringify({
 							"clawdi-old.service",
 							"openclaw-gateway.service",
 						]);
-						for (const path of staleFiles) expect(existsSync(path)).toBe(true);
+						for (const path of retainedStaleFiles) expect(existsSync(path)).toBe(true);
+						for (const path of staleEnablementFiles) expect(existsSync(path)).toBe(false);
 						activated = true;
 						return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
 					},
@@ -6048,6 +6052,9 @@ printf '{"ok":true}\\n'
 		]);
 		expect(statSync(paths.daemonAuthToken).mode & 0o777).toBe(0o600);
 
+		rmSync(enablementPath);
+		symlinkSync("../unexpected.service", enablementPath);
+		lchownSync(enablementPath, 0, 0);
 		let installerBoundaryObserved = false;
 		const installed = convergeRuntimeManifest(
 			manifestLoad({ ...manifest, generation: 2 }, "root-openclaw-installer-boundary"),
@@ -6065,19 +6072,21 @@ printf '{"ok":true}\\n'
 							unitPath,
 							unitBackupPath,
 							gatewayEnvironment,
-							wantsRoot,
-							enablementPath,
 						]) {
 							const node = lstatSync(path);
 							expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
 						}
-						for (const path of [dirname(dropInPath), dropInPath]) {
+						for (const path of [dirname(dropInPath), dropInPath, wantsRoot, enablementPath]) {
 							const node = lstatSync(path);
 							expect([node.uid, node.gid]).toEqual([0, 0]);
 						}
+						expect(readlinkSync(enablementPath)).toBe("../openclaw-gateway.service");
 						return install();
 					},
-					activate: successfulPrerequisiteActivation,
+					activate: (signal) => {
+						expect(signal.reloadUserUnits).toEqual(["openclaw-gateway.service"]);
+						return successfulPrerequisiteActivation();
+					},
 					rollback: () => {},
 				},
 			},

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -591,6 +591,12 @@ esac
 
 		expect(converge().installErrors).toEqual([]);
 		expect(restartSignals.at(-1)).toEqual(["openclaw-gateway.service"]);
+
+		manifest.projection = { channels: {} };
+		writeFileSync(configPath, "{}\n");
+		expect(converge().installErrors).toEqual([]);
+		expect(restartSignals.at(-1)).toEqual([]);
+		expect(readFileSync(configPath, "utf8")).toBe("{}\n");
 	});
 
 	test("renders systemd runtime services without creating user command shims", () => {

--- a/packages/cli/src/runtime/manifest-shared.ts
+++ b/packages/cli/src/runtime/manifest-shared.ts
@@ -57,6 +57,7 @@ interface RuntimeSystemdApplySignal {
 	restartEgressSidecar: boolean;
 	stopEgressSidecar: boolean;
 	reconcileUserUnits: string[];
+	reloadUserUnits: string[];
 	restartUserUnits: string[];
 	staleSystemUnits: string[];
 	staleUserUnits: string[];

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -5,6 +5,7 @@ import {
 	chmodSync,
 	chownSync,
 	existsSync,
+	lchownSync,
 	lstatSync,
 	readdirSync,
 	readFileSync,
@@ -12,6 +13,7 @@ import {
 	rmdirSync,
 	rmSync,
 	statSync,
+	symlinkSync,
 } from "node:fs";
 import { dirname, isAbsolute, join } from "node:path";
 import { writePrivateFileAtomic } from "../lib/private-file";
@@ -1396,6 +1398,58 @@ export function removeStaleRuntimeSystemdFiles(
 	return errors;
 }
 
+function materializeRuntimeSystemdUserEnablement(
+	paths: RuntimePaths,
+	desiredUnits: readonly string[],
+	staleUnits: readonly string[],
+): string[] {
+	const desired = new Set(desiredUnits);
+	const units = [...new Set([...desiredUnits, ...staleUnits])].sort();
+	if (units.length === 0) return [];
+
+	const wantsRoot = join(paths.systemdUserRoot, "default.target.wants");
+	ensureDirectoryWithinTrustedRoot(paths.systemdUserRoot, wantsRoot, { mode: 0o755 });
+	chmodSync(wantsRoot, 0o755);
+	if (runningAsRoot()) chownSync(wantsRoot, 0, 0);
+
+	const changed: string[] = [];
+	for (const unitName of units) {
+		const path = join(wantsRoot, unitName);
+		const target = `../${unitName}`;
+		let current: ReturnType<typeof lstatSync> | null = null;
+		try {
+			current = lstatSync(path);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+
+		if (!desired.has(unitName)) {
+			if (!current) continue;
+			if (current.isDirectory() && !current.isSymbolicLink()) {
+				throw new Error(`managed systemd enablement path is a directory: ${path}`);
+			}
+			rmSync(path, { force: true });
+			changed.push(unitName);
+			continue;
+		}
+
+		if (current?.isSymbolicLink() && readlinkSync(path) === target) {
+			if (runningAsRoot() && (current.uid !== 0 || current.gid !== 0)) lchownSync(path, 0, 0);
+			continue;
+		}
+		if (current) {
+			if (current.isDirectory() && !current.isSymbolicLink()) {
+				throw new Error(`managed systemd enablement path is a directory: ${path}`);
+			}
+			rmSync(path, { force: true });
+		}
+		symlinkSync(target, path);
+		if (runningAsRoot()) lchownSync(path, 0, 0);
+		changed.push(unitName);
+	}
+	return changed;
+}
+
 export function runtimeSystemdCommonEnvironment(paths: RuntimePaths): Record<string, string> {
 	const environment: Record<string, string> = {
 		HOME: paths.userHome,
@@ -1614,6 +1668,7 @@ export function writeRuntimeSystemdState(input: {
 }): {
 	systemUnits: string[];
 	userUnits: string[];
+	userEnablementChangedUnits: string[];
 	egressSidecarActive: boolean;
 	staleFiles: RuntimeSystemdStaleFilePlan;
 } {
@@ -1731,8 +1786,19 @@ export function writeRuntimeSystemdState(input: {
 			}),
 		);
 	}
+	const userEnablementChangedUnits = materializeRuntimeSystemdUserEnablement(
+		paths,
+		desiredUserUnitNames,
+		staleFiles.userUnits,
+	);
 
-	return { systemUnits, userUnits, egressSidecarActive: shouldRunEgress, staleFiles };
+	return {
+		systemUnits,
+		userUnits,
+		userEnablementChangedUnits,
+		egressSidecarActive: shouldRunEgress,
+		staleFiles,
+	};
 }
 
 export function validateRuntimeSystemdPlan(programs: RuntimeSystemdUserProgram[]): void {

--- a/packages/cli/src/runtime/systemd-transaction.ts
+++ b/packages/cli/src/runtime/systemd-transaction.ts
@@ -31,9 +31,6 @@ type SystemdRuntimeMutationStage =
 
 type SystemdRuntimeMutationAction =
 	| "daemon-reload"
-	| "disable"
-	| "enable"
-	| "enable-and-start"
 	| "install"
 	| "reset-failed"
 	| "restart"
@@ -239,6 +236,7 @@ export function applySystemdRuntimeUpdate(
 		stage: Extract<SystemdRuntimeMutationStage, "egress-prerequisite" | "final-activation">;
 		forceRestartSystemUnits?: readonly string[];
 		forceStopSystemUnits?: readonly string[];
+		forceReloadUserUnits?: readonly string[];
 		forceRestartUserUnits?: readonly string[];
 		recoverFailedUnits?: boolean;
 		activationScope?: {
@@ -282,6 +280,9 @@ export function applySystemdRuntimeUpdate(
 		(unit) => after.system.has(unit) && (!scopedSystemUnits || scopedSystemUnits.has(unit)),
 	);
 	const scopedUserUnits = opts.activationScope ? new Set(opts.activationScope.userUnits) : null;
+	const forcedUserReloads = (opts.forceReloadUserUnits ?? []).filter(
+		(unit) => !scopedUserUnits || scopedUserUnits.has(unit),
+	);
 	const forcedUserRestarts = (opts.forceRestartUserUnits ?? []).filter(
 		(unit) => after.user.has(unit) && (!scopedUserUnits || scopedUserUnits.has(unit)),
 	);
@@ -295,7 +296,9 @@ export function applySystemdRuntimeUpdate(
 		user.removed.length > 0 ||
 		forcedSystemRestarts.length > 0 ||
 		forcedSystemStops.length > 0 ||
+		forcedUserReloads.length > 0 ||
 		forcedUserRestarts.length > 0;
+	for (const unit of forcedUserReloads) userUnitsChanged.add(unit);
 	if (!shouldApplySystemdRuntimeUpdate(paths)) {
 		return {
 			applied: !activationChanged,
@@ -372,11 +375,6 @@ export function applySystemdRuntimeUpdate(
 				runtimeUserSystemctl(paths, ["stop", unit]),
 			);
 		}
-		if (!systemdUnitAbsentOrDisabled(state)) {
-			runJournaledSystemdMutation(transaction, stage, "user", "disable", [unit], () =>
-				runtimeUserSystemctl(paths, ["disable", unit]),
-			);
-		}
 	}
 	for (const unit of forcedSystemStops) {
 		const state = requiredSystemdUnitState(systemStates, "system", unit);
@@ -402,6 +400,7 @@ export function applySystemdRuntimeUpdate(
 		user.added.length > 0 ||
 		user.changed.length > 0 ||
 		user.removed.length > 0 ||
+		forcedUserReloads.length > 0 ||
 		userManagerNeedsReload.size > 0
 	) {
 		runJournaledSystemdMutation(transaction, stage, "user", "daemon-reload", [], () =>
@@ -468,12 +467,9 @@ export function applySystemdRuntimeUpdate(
 	const resetFailedUserUnits: string[] = [];
 	const forcedRestartUserUnits = new Set(forcedUserRestarts);
 	const startUserUnits: string[] = [];
-	const enableUserUnits: string[] = [];
-	const enableAndStartUserUnits: string[] = [];
 	const restartUserUnits: string[] = [];
 	for (const unit of user.present) {
 		const state = requiredSystemdUnitState(userStates, "user", unit);
-		const enabled = systemdUnitEnabled(state);
 		if (state.activeState === "failed" && recoverFailedUnits) {
 			resetFailedUserUnits.push(unit);
 			userUnitsChanged.add(unit);
@@ -482,16 +478,11 @@ export function applySystemdRuntimeUpdate(
 			state.activeState === "inactive" ||
 			(state.activeState === "failed" && recoverFailedUnits)
 		) {
-			if (enabled) startUserUnits.push(unit);
-			else enableAndStartUserUnits.push(unit);
+			startUserUnits.push(unit);
 			userUnitsChanged.add(unit);
 			continue;
 		}
 		if (state.activeState !== "active") continue;
-		if (!enabled) {
-			enableUserUnits.push(unit);
-			userUnitsChanged.add(unit);
-		}
 		if (
 			userProcessRevisionDrift.has(unit) ||
 			(changedUserUnits.has(unit) && !opts.preserveActiveUnits) ||
@@ -511,18 +502,6 @@ export function applySystemdRuntimeUpdate(
 			resetFailedUserUnits,
 			() => runtimeUserSystemctl(paths, ["reset-failed", ...resetFailedUserUnits]),
 		);
-	}
-	if (enableAndStartUserUnits.length > 0) {
-		runJournaledRuntimeUserEnable(
-			paths,
-			transaction,
-			stage,
-			"enable-and-start",
-			enableAndStartUserUnits,
-		);
-	}
-	if (enableUserUnits.length > 0) {
-		runJournaledRuntimeUserEnable(paths, transaction, stage, "enable", enableUserUnits);
 	}
 	if (startUserUnits.length > 0) {
 		runJournaledSystemdMutation(transaction, stage, "user", "start", startUserUnits, () =>
@@ -613,12 +592,7 @@ function systemdRuntimeCandidateUnits(transaction: SystemdRuntimeTransaction): {
 	system: Set<string>;
 	user: Set<string>;
 } {
-	const candidateActions = new Set<SystemdRuntimeMutationAction>([
-		"enable-and-start",
-		"install",
-		"restart",
-		"start",
-	]);
+	const candidateActions = new Set<SystemdRuntimeMutationAction>(["install", "restart", "start"]);
 	const candidateUnits = { system: new Set<string>(), user: new Set<string>() };
 	for (const entry of transaction.journal) {
 		if (!SYSTEMD_ACTIVATION_STAGES.has(entry.stage) || !candidateActions.has(entry.action)) {
@@ -665,21 +639,11 @@ function rollbackSystemdRuntimeTransaction(
 		const initiallyEnabled = systemdUnitEnabled(initial);
 		const currentlyEnabled = systemdUnitEnabled(systemdUnitManagerState(paths, "user", unit));
 		if (initiallyEnabled !== currentlyEnabled) {
-			const action = initiallyEnabled ? "enable" : "disable";
-			if (action === "enable") {
-				runJournaledRuntimeUserEnable(paths, transaction, "rollback", action, [unit]);
-			} else {
-				runJournaledSystemdMutation(transaction, "rollback", "user", action, [unit], () =>
-					runtimeUserSystemctl(paths, [action, unit]),
-				);
-			}
+			throw new Error(`systemd rollback did not restore user unit ${unit} enablement`);
 		}
 		if (initial.activeState !== "active") continue;
 		restoreActiveSystemdUnit(paths, transaction, "user", unit);
 		const restored = systemdUnitManagerState(paths, "user", unit);
-		if (systemdUnitEnabled(restored) !== initiallyEnabled) {
-			throw new Error(`systemd rollback did not restore user unit ${unit} enablement`);
-		}
 		if (!systemdProcessRevisionMatches(paths, unit, restored)) {
 			throw new Error(`systemd rollback restored stale runtime revision for ${unit}`);
 		}
@@ -798,44 +762,6 @@ function runJournaledSystemdMutation<T>(
 	} catch (error) {
 		entry.outcome = "failed";
 		throw error;
-	}
-}
-
-function runJournaledRuntimeUserEnable(
-	paths: ReturnType<typeof getRuntimePaths>,
-	transaction: SystemdRuntimeTransaction,
-	stage: SystemdRuntimeMutationStage,
-	action: Extract<SystemdRuntimeMutationAction, "enable" | "enable-and-start">,
-	units: readonly string[],
-): string {
-	const args = action === "enable-and-start" ? ["enable", "--now", ...units] : ["enable", ...units];
-	const enable = () =>
-		runJournaledSystemdMutation(transaction, stage, "user", action, units, () =>
-			runtimeUserSystemctl(paths, args),
-		);
-	try {
-		return enable();
-	} catch (error) {
-		if (!missingRuntimeUserUnitExists(paths, units, error)) throw error;
-		runJournaledSystemdMutation(transaction, stage, "user", "daemon-reload", [], () =>
-			runtimeUserSystemctl(paths, ["daemon-reload"]),
-		);
-		return enable();
-	}
-}
-
-function missingRuntimeUserUnitExists(
-	paths: ReturnType<typeof getRuntimePaths>,
-	units: readonly string[],
-	error: unknown,
-): boolean {
-	const message = error instanceof Error ? error.message : String(error);
-	const unit = message.match(/\bUnit\s+([^\s:]+)\s+does not exist\b/i)?.[1];
-	if (!unit || !units.includes(unit)) return false;
-	try {
-		return statSync(join(paths.systemdUserRoot, unit)).isFile();
-	} catch {
-		return false;
 	}
 }
 

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -11,6 +11,7 @@ import {
 	mkdtempSync,
 	readdirSync,
 	readFileSync,
+	readlinkSync,
 	realpathSync,
 	rmSync,
 	statSync,
@@ -250,6 +251,8 @@ test.each(["hermes", "openclaw"] as const)(
 			previousUmask = process.umask(0o077);
 			const paths = getRuntimePaths({ mode: "hosted" });
 			ensureRuntimeStateDirs(paths);
+			const wantsRoot = join(paths.systemdUserRoot, "default.target.wants");
+			const enablementPath = join(wantsRoot, unitName);
 			const commandPath = join(runtimeHome, ".local", "bin", runtime);
 			const manifest: RuntimeManifest = {
 				schemaVersion: "clawdi.runtimeDesiredState.v1",
@@ -310,14 +313,18 @@ test.each(["hermes", "openclaw"] as const)(
 				systemdApply: {
 					transactionState: () => transaction.state,
 					installOfficialService: (unit, install) =>
-						transaction.installOfficialService(paths, unit, install),
+						transaction.installOfficialService(paths, unit, () => {
+							chownTreeWithoutFollowingLinks(wantsRoot, 0, 0);
+							expect([lstatSync(wantsRoot).uid, lstatSync(wantsRoot).gid]).toEqual([0, 0]);
+							return install();
+						}),
 					quiesce: (affectedUserUnits) => transaction.quiesce(paths, affectedUserUnits),
 					activateEgressPrerequisite: () => ({
 						applied: true,
 						systemUnitsChanged: [],
 						userUnitsChanged: [],
 					}),
-					activate: () => {
+					activate: ({ reloadUserUnits }) => {
 						const state = runUserSystemctl(
 							"show",
 							unitName,
@@ -329,6 +336,7 @@ test.each(["hermes", "openclaw"] as const)(
 						return applySystemdRuntimeUpdate(paths, before, readSystemdUnitSnapshot(paths), {
 							transaction,
 							stage: "final-activation",
+							forceReloadUserUnits: reloadUserUnits,
 						});
 					},
 					rollback: () => transaction.rollback(paths),
@@ -382,7 +390,6 @@ test.each(["hermes", "openclaw"] as const)(
 			const unitPath = join(paths.systemdUserRoot, unitName);
 			const dropInRoot = `${unitPath}.d`;
 			const dropInPath = join(dropInRoot, "10-clawdi-hosted.conf");
-			const enablementPath = join(paths.systemdUserRoot, "default.target.wants", unitName);
 			for (const path of [
 				paths.systemdUserRoot,
 				unitPath,
@@ -399,6 +406,7 @@ test.each(["hermes", "openclaw"] as const)(
 			for (const path of [unitPath, dropInPath]) {
 				expect(lstatSync(path).mode & 0o444).toBe(0o444);
 			}
+			expect(readlinkSync(enablementPath)).toBe(`../${unitName}`);
 
 			expect(transaction.journal).toEqual(
 				expect.arrayContaining([
@@ -1547,10 +1555,11 @@ http.createServer((request, response) => {
 					systemUnitsChanged: [],
 					userUnitsChanged: [],
 				}),
-				activate: () => {
+				activate: ({ reloadUserUnits }) => {
 					return applySystemdRuntimeUpdate(paths, before, readSystemdUnitSnapshot(paths), {
 						transaction,
 						stage: "final-activation",
+						forceReloadUserUnits: reloadUserUnits,
 					});
 				},
 				rollback: () => transaction.rollback(paths),
@@ -1949,10 +1958,11 @@ esac
 					systemUnitsChanged: [],
 					userUnitsChanged: [],
 				}),
-				activate: () =>
+				activate: ({ reloadUserUnits }) =>
 					applySystemdRuntimeUpdate(paths, before, readSystemdUnitSnapshot(paths), {
 						transaction,
 						stage: "final-activation",
+						forceReloadUserUnits: reloadUserUnits,
 					}),
 				rollback: () => transaction.rollback(paths),
 			},

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -18,6 +18,7 @@ import {
 	symlinkSync,
 	writeFileSync,
 } from "node:fs";
+import { createConnection } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -25,6 +26,9 @@ import {
 	resolveOpenClawSdkExport as resolveSdk,
 	OPENCLAW_SDK_EXPORT_PATHS as SDK_EXPORTS,
 } from "../../src/lib/codex-oauth-native-store";
+import { getCliVersion } from "../../src/lib/version";
+import { readRuntimeAppliedState } from "../../src/runtime/applied-state";
+import { applyRuntimeCliDesiredState } from "../../src/runtime/cli-update";
 import { hostedOpenClawSkillDriver } from "../../src/runtime/hosted-openclaw-skill";
 import { hostedAiProviderCatalog } from "../../src/runtime/hosted-provider-resolution";
 import {
@@ -32,11 +36,13 @@ import {
 	convergeRuntimeManifest,
 } from "../../src/runtime/manifest";
 import {
-	OFFICIAL_INSTALL_URLS,
-	officialInstallArgs,
+	HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE,
 	type RuntimeManifest,
 } from "../../src/runtime/manifest-contract";
-import type { RuntimeManifestLoad } from "../../src/runtime/manifest-source";
+import {
+	HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
+	type RuntimeManifestLoad,
+} from "../../src/runtime/manifest-source";
 import { CLAWDI_MANAGED_OPENCLAW_PROVIDER_PLUGIN_ID } from "../../src/runtime/openclaw-managed-provider-plugin";
 import { getRuntimePaths } from "../../src/runtime/paths";
 import { ensureRuntimeStateDirs } from "../../src/runtime/state";
@@ -133,22 +139,94 @@ function chownTreeWithoutFollowingLinks(path: string, uid: number, gid: number):
 	}
 }
 
+function filesystemTreeIdentity(root: string, relative = ""): Record<string, string> {
+	const identity: Record<string, string> = {};
+	for (const entry of readdirSync(join(root, relative), { withFileTypes: true })) {
+		const entryRelative = join(relative, entry.name);
+		const path = join(root, entryRelative);
+		const node = lstatSync(path);
+		const metadata = `${node.uid}:${node.gid}:${node.mode & 0o777}`;
+		if (entry.isDirectory()) {
+			identity[entryRelative] = `directory:${metadata}`;
+			Object.assign(identity, filesystemTreeIdentity(root, entryRelative));
+		} else if (entry.isSymbolicLink()) {
+			identity[entryRelative] = `symlink:${metadata}:${readlinkSync(path)}`;
+		} else if (entry.isFile()) {
+			identity[entryRelative] = `file:${metadata}:${createHash("sha256")
+				.update(readFileSync(path))
+				.digest("hex")}`;
+		}
+	}
+	return identity;
+}
+
+function expectRootOwnedReadableTree(root: string): void {
+	const visit = (path: string): void => {
+		const node = lstatSync(path);
+		expect([node.uid, node.gid]).toEqual([0, 0]);
+		if (node.isSymbolicLink()) return;
+		if (node.isDirectory()) {
+			expect(node.mode & 0o555).toBe(0o555);
+			for (const entry of readdirSync(path)) visit(join(path, entry));
+			return;
+		}
+		if (node.isFile()) expect(node.mode & 0o444).toBe(0o444);
+	};
+	visit(root);
+}
+
+async function waitForTcpPort(port: number): Promise<void> {
+	for (let attempt = 0; attempt < 600; attempt += 1) {
+		const listening = await new Promise<boolean>((resolve) => {
+			const socket = createConnection({ host: "127.0.0.1", port });
+			let settled = false;
+			const finish = (value: boolean) => {
+				if (settled) return;
+				settled = true;
+				socket.destroy();
+				resolve(value);
+			};
+			socket.setTimeout(250);
+			socket.once("connect", () => finish(true));
+			socket.once("error", () => finish(false));
+			socket.once("timeout", () => finish(false));
+		});
+		if (listening) return;
+		await Bun.sleep(100);
+	}
+	throw new Error(`port ${port} did not begin listening`);
+}
+
 test.each(["hermes", "openclaw"] as const)(
-	"converges a virgin %s deployment from a cold user manager",
-	(runtime) => {
+	"runs the complete virgin %s first boot from a cold user manager",
+	async (runtime) => {
 		if (process.env[REAL_SYSTEMD_GATE] !== "1") return;
 
 		expect(process.geteuid?.()).toBe(0);
 		const runtimeHome = "/home/clawdi";
 		const runtimeUid = 10_001;
 		const runtimeGid = 10_001;
-		const unitName = `${runtime}-gateway.service`;
 		const stockInstaller = "/opt/fixture/install-stock-runtime.sh";
 		const root = mkdtempSync(join(tmpdir(), `clawdi-virgin-${runtime}-`));
 		chmodSync(root, 0o755);
+		const systemctlLog = join(root, "systemctl.log");
+		const systemctlWrapper = join(root, "systemctl");
+		const systemUnits = [
+			"clawdi-runtime-watch.service",
+			"clawdi-daemon.service",
+			"clawdi-runtime-sidecar.service",
+			"clawdi-files.service",
+		];
+		const allUserUnits = [
+			"hermes-gateway.service",
+			"clawdi-hermes-dashboard.service",
+			"openclaw-gateway.service",
+		];
 		const environmentNames = [
 			"CLAWDI_AUTH_TOKEN",
 			"CLAWDI_CODEX_INSTALL_DISABLED",
+			"CLAWDI_EGRESS_GID",
+			"CLAWDI_EGRESS_UID",
 			"CLAWDI_HOME",
 			"CLAWDI_RUN_DIR",
 			"CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS",
@@ -160,6 +238,8 @@ test.each(["hermes", "openclaw"] as const)(
 			"CLAWDI_RUNTIME_UID",
 			"CLAWDI_RUNTIME_USER",
 			"CLAWDI_SERVICE_STATE_DIR",
+			"CLAWDI_SYSTEMCTL_PATH",
+			"CLAWDI_SYSTEMD_APPLY",
 			"CLAWDI_SYSTEMD_SYSTEM_ROOT",
 			"CLAWDI_TEST_STOCK_RUNTIME",
 		] as const;
@@ -194,13 +274,16 @@ test.each(["hermes", "openclaw"] as const)(
 			throw new Error(`user@${runtimeUid}.service did not expose its D-Bus socket`);
 		};
 		let previousUmask: number | null = null;
+		let manifestServer: ReturnType<typeof Bun.serve> | null = null;
+		let paths: ReturnType<typeof getRuntimePaths> | null = null;
 
 		try {
 			if (existsSync(`/run/user/${runtimeUid}/bus`)) {
-				for (const staleUnit of ["hermes-gateway.service", "openclaw-gateway.service"]) {
-					runUserSystemctl("disable", "--now", staleUnit);
-				}
+				runUserSystemctl("stop", ...allUserUnits);
 			}
+			spawnSync("systemctl", ["stop", ...systemUnits]);
+			for (const unit of systemUnits) rmSync(join("/run/systemd/system", unit), { force: true });
+			spawnSync("systemctl", ["daemon-reload"]);
 			spawnSync("loginctl", ["disable-linger", "clawdi"]);
 			const stopManager = spawnSync("systemctl", ["stop", `user@${runtimeUid}.service`], {
 				encoding: "utf8",
@@ -228,15 +311,19 @@ test.each(["hermes", "openclaw"] as const)(
 			Object.assign(process.env, {
 				CLAWDI_AUTH_TOKEN: `virgin-${runtime}-auth-token`,
 				CLAWDI_CODEX_INSTALL_DISABLED: "1",
-				CLAWDI_HOME: join(root, "clawdi-home"),
-				CLAWDI_RUN_DIR: join(root, "run"),
+				CLAWDI_EGRESS_GID: "10002",
+				CLAWDI_EGRESS_UID: "10002",
+				CLAWDI_HOME: join(root, "var", "lib", "clawdi-user"),
+				CLAWDI_RUN_DIR: join(root, "run", "clawdi"),
 				CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS: "1",
 				CLAWDI_RUNTIME_GID: String(runtimeGid),
 				CLAWDI_RUNTIME_HOME: runtimeHome,
 				CLAWDI_RUNTIME_MODE: "hosted",
 				CLAWDI_RUNTIME_UID: String(runtimeUid),
 				CLAWDI_RUNTIME_USER: "clawdi",
-				CLAWDI_SERVICE_STATE_DIR: join(root, "state"),
+				CLAWDI_SERVICE_STATE_DIR: join(root, "var", "lib", "clawdi"),
+				CLAWDI_SYSTEMCTL_PATH: systemctlWrapper,
+				CLAWDI_SYSTEMD_APPLY: "1",
 				CLAWDI_SYSTEMD_SYSTEM_ROOT: "/run/systemd/system",
 				CLAWDI_TEST_STOCK_RUNTIME: runtime,
 			});
@@ -249,104 +336,258 @@ test.each(["hermes", "openclaw"] as const)(
 			] = stockInstaller;
 
 			previousUmask = process.umask(0o077);
-			const paths = getRuntimePaths({ mode: "hosted" });
+			paths = getRuntimePaths({ mode: "hosted" });
+			for (const path of [
+				join(root, "etc"),
+				join(root, "var"),
+				join(root, "var", "lib"),
+				join(root, "var", "cache"),
+				join(root, "run"),
+			]) {
+				mkdirSync(path, { recursive: true, mode: 0o755 });
+				chmodSync(path, 0o755);
+				chownSync(path, 0, 0);
+			}
+			for (const [path, mode] of [
+				[paths.configurationRoot, 0o700],
+				[paths.serviceStateRoot, 0o700],
+				[paths.cacheRoot, 0o700],
+				[paths.runRoot, 0o711],
+			] as const) {
+				mkdirSync(path, { recursive: true, mode });
+				chmodSync(path, mode);
+				chownSync(path, 0, 0);
+			}
 			ensureRuntimeStateDirs(paths);
-			const wantsRoot = join(paths.systemdUserRoot, "default.target.wants");
-			const enablementPath = join(wantsRoot, unitName);
-			const commandPath = join(runtimeHome, ".local", "bin", runtime);
-			const manifest: RuntimeManifest = {
+			writeFileSync(
+				systemctlWrapper,
+				`#!/bin/sh
+printf '%s\\n' "$*" >> ${JSON.stringify(systemctlLog)}
+exec /usr/bin/systemctl "$@"
+				`,
+				{ mode: 0o755 },
+			);
+			chmodSync(systemctlWrapper, 0o755);
+			writeFileSync(systemctlLog, "", { mode: 0o666 });
+			chmodSync(systemctlLog, 0o666);
+
+			const cliVersion = getCliVersion();
+			const bootstrapManifest: RuntimeManifest = {
 				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: `hdep_virgin_${runtime}_bootstrap`,
+				environmentId: `env_virgin_${runtime}_bootstrap`,
+				instanceId: `hri_virgin_${runtime}_bootstrap`,
+				generation: 1,
+				issuedAt: "2026-08-22T00:00:00.000Z",
+				controlPlane: { apiUrl: "https://cloud-api.example.test" },
+				clawdiCli: {
+					source: "npm:clawdi",
+					packageSpec: HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE,
+					registry: "https://registry.npmjs.org",
+				},
+				runtimes: {
+					hermes: { enabled: false },
+					openclaw: { enabled: false },
+				},
+				recovery: {},
+			};
+			const bootstrap = applyRuntimeCliDesiredState(bootstrapManifest, paths, {
+				runningVersion: cliVersion,
+			});
+			expect(bootstrap.status).toBe("installed");
+			expect(bootstrap.selfReexec).toBe(true);
+			expect(bootstrap.version).toBe(cliVersion);
+			expect(lstatSync(paths.cliManagedBin).isSymbolicLink()).toBe(true);
+
+			const gatewayToken = `virgin-${runtime}-gateway-token`;
+			const sourceRevision = createHash("sha256").update(`virgin-${runtime}-bundle`).digest("hex");
+			const etag = `"sha256:${sourceRevision}"`;
+			const hostedManifest = {
+				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				runtime,
 				deploymentId: `hdep_virgin_${runtime}`,
 				environmentId: `env_virgin_${runtime}`,
 				instanceId: `hri_virgin_${runtime}`,
 				generation: 1,
 				issuedAt: "2026-08-22T00:00:00.000Z",
-				workspaceRoot: join(runtimeHome, `clawdi-virgin-${runtime}-workspace`),
-				controlPlane: { apiUrl: "https://cloud-api.example.test" },
+				locale: { language: "en", timezone: "UTC" },
+				system:
+					runtime === "openclaw"
+						? {
+								openclawControlUiAllowedOrigins: ["https://agent.example.test"],
+								openclawGatewayAuth: {
+									mode: "token",
+									tokenRef: "secret://runtime/openclaw/gateway-token",
+									deviceAuthRequired: false,
+									activation: { enabled: true, capability: "openclaw-native-auth-v1" },
+								},
+							}
+						: {
+								hermesDashboardAuth: {
+									mode: "password",
+									provider: "basic",
+									username: "admin",
+									passwordSecretRef: "secret://runtime/hermes/dashboard-password",
+									sessionSecretRef: "secret://runtime/hermes/dashboard-session-secret",
+									sessionTtlSeconds: 43_200,
+									publicUrl: "https://agent.example.test/hermes",
+									activation: { enabled: true, capability: "hermes-basic-auth-v1" },
+								},
+							},
+				controlPlane: { cloudApiUrl: "https://cloud-api.example.test" },
+				egressEngine: {
+					type: "mitmproxy",
+					version: "12.2.3",
+					url: "https://downloads.mitmproxy.org/12.2.3/mitmproxy-12.2.3-linux-x86_64.tar.gz",
+					sha256: "2e95286b618fa6fd33e5e62a78c2e5112571d85f42ec2bac29b97ee242bdb5c5",
+				},
+				clawdiCli: {
+					source: "npm:clawdi",
+					packageSpec: `clawdi@${cliVersion}`,
+					registry: "https://registry.npmjs.org",
+				},
 				runtimes: {
 					[runtime]: {
 						enabled: true,
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: OFFICIAL_INSTALL_URLS[runtime],
-							home: runtimeHome,
-							args: officialInstallArgs(runtime, runtimeHome),
-						},
+						providerMode: "unmanaged",
+						provider_ids: [],
+						install: { source: "official" },
 						run: {
-							command: commandPath,
 							args: ["gateway", "run"],
-							env: {},
-							prependPath: [],
+							...(runtime === "openclaw"
+								? {
+										secretEnv: {
+											OPENCLAW_GATEWAY_TOKEN: "secret://runtime/openclaw/gateway-token",
+										},
+									}
+								: {}),
 						},
-						services: {},
+						services:
+							runtime === "hermes"
+								? {
+										dashboard: {
+											args: ["dashboard", "--host", "0.0.0.0", "--port", "9119", "--no-open"],
+										},
+									}
+								: {},
 					},
 				},
-				recovery: {},
+				providers: {},
+				terminalTooling: {
+					codex: {
+						enabled: true,
+						provider_id: "clawdi-terminal",
+						primary_model: { provider_id: "clawdi-terminal", model: "gpt-test" },
+						provider: {
+							kind: "openai-compatible",
+							type: "custom_openai_compatible",
+							baseUrl: "https://provider.example.test/v1",
+							apiMode: "openai_responses",
+							managed_by: "clawdi",
+							runtimeEnvName: "CLAWDI_AI_API_KEY",
+							apiKeySecretRef: "secret://tool.codex.apiKey",
+						},
+					},
+				},
+				liveSync: { enabled: false, agents: [] },
+				recovery: { cacheManifest: true, allowOfflineBoot: true },
 			};
-			const load: RuntimeManifestLoad = {
-				manifest,
-				source: "remote-datasource",
-				sourcePath: `virgin-${runtime}-fixture`,
-				offline: false,
-				applyContext: {
-					kind: "context-file",
+			const bundle = {
+				schemaVersion: "clawdi.hosted-runtime.bundle.v2",
+				sourceRevision,
+				applyGeneration: 1,
+				manifest: hostedManifest,
+				channelBindings: [],
+				secretValues: {
+					"secret://clawdi/auth-token": `virgin-${runtime}-daemon-token`,
+					"secret://tool.codex.apiKey": `virgin-${runtime}-codex-key`,
+					...(runtime === "openclaw"
+						? { "secret://runtime/openclaw/gateway-token": gatewayToken }
+						: {
+								"secret://runtime/hermes/dashboard-password": "virgin-dashboard-password",
+								"secret://runtime/hermes/dashboard-session-secret":
+									"virgin-dashboard-session-secret",
+							}),
+				},
+			};
+			let manifestFetches = 0;
+			manifestServer = Bun.serve({
+				hostname: "127.0.0.1",
+				port: 0,
+				fetch: (request) => {
+					const url = new URL(request.url);
+					if (url.pathname !== "/v1/runtime/manifest")
+						return new Response("not found", { status: 404 });
+					expect(request.headers.get("authorization")).toBe(`Bearer virgin-${runtime}-auth-token`);
+					expect(request.headers.get("accept")).toBe(HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE);
+					manifestFetches += 1;
+					if (request.headers.get("if-none-match") === etag) {
+						return new Response(null, { status: 304, headers: { etag } });
+					}
+					return Response.json(bundle, {
+						headers: {
+							"content-type": HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
+							etag,
+						},
+					});
+				},
+			});
+			const manifestUrl = `http://127.0.0.1:${manifestServer.port}/v1/runtime/manifest`;
+			writeFileSync(
+				paths.runtimeContextFile,
+				`${JSON.stringify({
+					schemaVersion: "clawdi.runtimeContext.v3",
 					backend: "incus",
-					identity: {
-						generation: manifest.generation,
-						manifestETag: `"virgin-${runtime}-test"`,
-						applyReceiptId: `virgin-${runtime}-receipt`,
-						bootNonce: `virgin-${runtime}-boot`,
+					apply: {
+						generation: 1,
+						manifestETag: etag,
+						applyReceiptId: `virgin-${runtime}-receipt-0001`,
+						bootNonce: `virgin-${runtime}-boot-nonce-0001`,
 					},
 					manifestSource: {
 						type: "http",
-						url: `https://runtime.test/v1/runtime/manifest?environment_id=env_virgin_${runtime}`,
+						url: manifestUrl,
 						auth: { type: "bearer", token: `virgin-${runtime}-auth-token` },
 					},
-				},
-			};
-			const before = readSystemdUnitSnapshot(paths);
-			const transaction = new SystemdRuntimeTransaction();
-			let stateBeforeSharedActivation = "";
-			const result = convergeRuntimeManifest(load, paths, {
-				cacheLastGood: false,
-				systemdApply: {
-					transactionState: () => transaction.state,
-					installOfficialService: (unit, install) =>
-						transaction.installOfficialService(paths, unit, () => {
-							chownTreeWithoutFollowingLinks(wantsRoot, 0, 0);
-							expect([lstatSync(wantsRoot).uid, lstatSync(wantsRoot).gid]).toEqual([0, 0]);
-							return install();
-						}),
-					quiesce: (affectedUserUnits) => transaction.quiesce(paths, affectedUserUnits),
-					activateEgressPrerequisite: () => ({
-						applied: true,
-						systemUnitsChanged: [],
-						userUnitsChanged: [],
-					}),
-					activate: ({ reloadUserUnits }) => {
-						const state = runUserSystemctl(
-							"show",
-							unitName,
-							"--property=ActiveState",
-							"--property=MainPID",
-						);
-						expect(state.status, state.stderr).toBe(0);
-						stateBeforeSharedActivation = state.stdout;
-						return applySystemdRuntimeUpdate(paths, before, readSystemdUnitSnapshot(paths), {
-							transaction,
-							stage: "final-activation",
-							forceReloadUserUnits: reloadUserUnits,
-						});
+				})}\n`,
+				{ mode: 0o600 },
+			);
+
+			const runManagedInit = async () => {
+				const child = Bun.spawn(
+					[paths.cliManagedBin, "runtime", "init", "--non-interactive", "--json"],
+					{
+						env: { ...process.env },
+						stdout: "pipe",
+						stderr: "pipe",
 					},
-					rollback: () => transaction.rollback(paths),
-				},
-			});
-			expect(result.installErrors).toEqual([]);
-			expect(stateBeforeSharedActivation).toContain("ActiveState=active");
-			expect(
-				Number.parseInt(stateBeforeSharedActivation.match(/^MainPID=(\d+)$/m)?.[1] ?? "0", 10),
-			).toBeGreaterThan(1);
+				);
+				const timeout = setTimeout(() => child.kill("SIGKILL"), 180_000);
+				try {
+					const [status, stdout, stderr] = await Promise.all([
+						child.exited,
+						new Response(child.stdout).text(),
+						new Response(child.stderr).text(),
+					]);
+					return { status, stdout, stderr };
+				} finally {
+					clearTimeout(timeout);
+				}
+			};
+			const firstInit = await runManagedInit();
+			expect(firstInit.status, `${firstInit.stdout}\n${firstInit.stderr}`).toBe(0);
+			const firstStatus = JSON.parse(firstInit.stdout) as Record<string, unknown>;
+			expect(firstStatus.status).toBe("ok");
+			expect(firstStatus.stage).toBe("final");
+			expect(firstStatus.exitCode).toBe(0);
+			const firstAppliedState = readRuntimeAppliedState(paths);
+			expect(firstAppliedState).not.toBeNull();
+			const clawdiHome = lstatSync(paths.clawdiHome);
+			expect([clawdiHome.uid, clawdiHome.gid, clawdiHome.mode & 0o777]).toEqual([
+				runtimeUid,
+				runtimeGid,
+				0o750,
+			]);
 
 			const inventory = JSON.parse(
 				readFileSync(join(paths.installInventory, `${runtime}.json`), "utf8"),
@@ -355,83 +596,122 @@ test.each(["hermes", "openclaw"] as const)(
 			expect(inventory.executionUser).toBe("clawdi");
 			expect(inventory.executedInstallerUrl).toBe(stockInstaller);
 
-			const state = runUserSystemctl(
-				"show",
-				unitName,
-				"--property=LoadState",
-				"--property=ActiveState",
-				"--property=MainPID",
-				"--property=NeedDaemonReload",
-			);
-			expect(state.status, state.stderr).toBe(0);
-			expect(state.stdout).toContain("LoadState=loaded");
-			expect(state.stdout).toContain("ActiveState=active");
-			expect(state.stdout).toContain("NeedDaemonReload=no");
-			expect(runUserSystemctl("is-enabled", unitName).stdout.trim()).toBe("enabled");
-			const mainPid = Number.parseInt(state.stdout.match(/^MainPID=(\d+)$/m)?.[1] ?? "0", 10);
-			expect(mainPid).toBeGreaterThan(1);
-			expect(statSync(`/proc/${mainPid}`).uid).toBe(runtimeUid);
-			const processRevisions = readFileSync(`/proc/${mainPid}/environ`)
-				.toString("utf8")
-				.split("\0")
-				.filter((entry) => entry.startsWith("CLAWDI_RUNTIME_REV="));
-			expect(processRevisions).toHaveLength(1);
-			const processRevision = processRevisions[0].slice("CLAWDI_RUNTIME_REV=".length);
-			expect(processRevision).toMatch(/^[a-f0-9]{32}$/);
-			const managedEnvironment = readFileSync(
-				join(paths.systemdEnvRoot, `${unitName}.env`),
-				"utf8",
-			);
-			const desiredRevision = managedEnvironment.match(
-				/^CLAWDI_RUNTIME_REV="([a-f0-9]{32})"$/m,
-			)?.[1];
-			expect(desiredRevision).toBe(processRevision);
-
-			const unitPath = join(paths.systemdUserRoot, unitName);
-			const dropInRoot = `${unitPath}.d`;
-			const dropInPath = join(dropInRoot, "10-clawdi-hosted.conf");
-			for (const path of [
-				paths.systemdUserRoot,
-				unitPath,
-				dropInRoot,
-				dropInPath,
-				enablementPath,
-			]) {
-				const node = lstatSync(path);
-				expect([node.uid, node.gid]).toEqual([0, 0]);
+			const unitNames =
+				runtime === "hermes"
+					? ["hermes-gateway.service", "clawdi-hermes-dashboard.service"]
+					: ["openclaw-gateway.service"];
+			const firstPids = new Map<string, number>();
+			for (const unitName of unitNames) {
+				const state = runUserSystemctl(
+					"show",
+					unitName,
+					"--property=LoadState",
+					"--property=ActiveState",
+					"--property=MainPID",
+					"--property=NeedDaemonReload",
+				);
+				expect(state.status, state.stderr).toBe(0);
+				expect(state.stdout).toContain("LoadState=loaded");
+				expect(state.stdout).toContain("ActiveState=active");
+				expect(state.stdout).toContain("NeedDaemonReload=no");
+				expect(runUserSystemctl("is-enabled", unitName).stdout.trim()).toBe("enabled");
+				const mainPid = Number.parseInt(state.stdout.match(/^MainPID=(\d+)$/m)?.[1] ?? "0", 10);
+				expect(mainPid).toBeGreaterThan(1);
+				expect(statSync(`/proc/${mainPid}`).uid).toBe(runtimeUid);
+				firstPids.set(unitName, mainPid);
+				const processRevisions = readFileSync(`/proc/${mainPid}/environ`)
+					.toString("utf8")
+					.split("\0")
+					.filter((entry) => entry.startsWith("CLAWDI_RUNTIME_REV="));
+				expect(processRevisions).toHaveLength(1);
+				const processRevision = processRevisions[0].slice("CLAWDI_RUNTIME_REV=".length);
+				expect(processRevision).toMatch(/^[a-f0-9]{32}$/);
+				const managedEnvironment = readFileSync(
+					join(paths.systemdEnvRoot, `${unitName}.env`),
+					"utf8",
+				);
+				expect(managedEnvironment.match(/^CLAWDI_RUNTIME_REV="([a-f0-9]{32})"$/m)?.[1]).toBe(
+					processRevision,
+				);
+				const enablementPath = join(paths.systemdUserRoot, "default.target.wants", unitName);
+				expect(readlinkSync(enablementPath)).toBe(`../${unitName}`);
 			}
-			for (const path of [paths.systemdUserRoot, dropInRoot]) {
-				expect(lstatSync(path).mode & 0o555).toBe(0o555);
-			}
-			for (const path of [unitPath, dropInPath]) {
-				expect(lstatSync(path).mode & 0o444).toBe(0o444);
-			}
-			expect(readlinkSync(enablementPath)).toBe(`../${unitName}`);
-
-			expect(transaction.journal).toEqual(
-				expect.arrayContaining([
-					expect.objectContaining({
-						stage: "official-installer",
-						scope: "user",
-						action: "install",
-						units: [unitName],
-						outcome: "succeeded",
-					}),
-					expect.objectContaining({
-						stage: "final-activation",
-						scope: "user",
-						action: "daemon-reload",
-						outcome: "succeeded",
-					}),
-				]),
-			);
-		} finally {
-			if (previousUmask !== null) process.umask(previousUmask);
-			if (existsSync(`/run/user/${runtimeUid}/bus`)) {
-				for (const staleUnit of ["hermes-gateway.service", "openclaw-gateway.service"]) {
-					runUserSystemctl("disable", "--now", staleUnit);
+			for (const [port, unitName] of runtime === "hermes"
+				? ([[9119, "clawdi-hermes-dashboard.service"]] as const)
+				: ([[18789, "openclaw-gateway.service"]] as const)) {
+				try {
+					await waitForTcpPort(port);
+				} catch (error) {
+					const journal = spawnSync(
+						"runuser",
+						[
+							"-u",
+							"clawdi",
+							"--",
+							"env",
+							`HOME=${runtimeHome}`,
+							`XDG_RUNTIME_DIR=/run/user/${runtimeUid}`,
+							`DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${runtimeUid}/bus`,
+							"journalctl",
+							"--user",
+							"--unit",
+							unitName,
+							"--no-pager",
+							"--lines=100",
+						],
+						{ encoding: "utf8" },
+					);
+					throw new Error(
+						`${error instanceof Error ? error.message : String(error)}\n${journal.stdout}${journal.stderr}`,
+					);
 				}
 			}
+			expectRootOwnedReadableTree(paths.systemdUserRoot);
+			const firstTree = filesystemTreeIdentity(paths.systemdUserRoot);
+			const firstMutations = readFileSync(systemctlLog, "utf8")
+				.trim()
+				.split("\n")
+				.filter((call) =>
+					/^(?:--user )?(?:daemon-reload|start|stop|restart|reset-failed)\b/.test(call),
+				);
+			expect(firstMutations.length).toBeGreaterThan(0);
+			expect(readFileSync(systemctlLog, "utf8")).not.toMatch(/(?:^|\s)(?:enable|disable)(?:\s|$)/m);
+
+			await Bun.sleep(500);
+			writeFileSync(systemctlLog, "", { mode: 0o666 });
+			chmodSync(systemctlLog, 0o666);
+			const secondInit = await runManagedInit();
+			expect(secondInit.status, `${secondInit.stdout}\n${secondInit.stderr}`).toBe(0);
+			const secondStatus = JSON.parse(secondInit.stdout) as Record<string, unknown>;
+			expect(secondStatus.status).toBe("ok");
+			expect(secondStatus.stage).toBe("final");
+			await Bun.sleep(250);
+			const secondMutations = readFileSync(systemctlLog, "utf8")
+				.trim()
+				.split("\n")
+				.filter((call) =>
+					/^(?:--user )?(?:daemon-reload|start|stop|restart|reset-failed)\b/.test(call),
+				);
+			const secondTree = filesystemTreeIdentity(paths.systemdUserRoot);
+			expect(secondMutations).toEqual([]);
+			expect(secondTree).toEqual(firstTree);
+			for (const [unitName, firstPid] of firstPids) {
+				const state = runUserSystemctl("show", unitName, "--property=MainPID");
+				expect(state.status, state.stderr).toBe(0);
+				expect(Number.parseInt(state.stdout.match(/^MainPID=(\d+)$/m)?.[1] ?? "0", 10)).toBe(
+					firstPid,
+				);
+			}
+			expect(manifestFetches).toBeGreaterThanOrEqual(2);
+		} finally {
+			manifestServer?.stop(true);
+			if (previousUmask !== null) process.umask(previousUmask);
+			if (existsSync(`/run/user/${runtimeUid}/bus`)) {
+				runUserSystemctl("stop", ...allUserUnits);
+			}
+			spawnSync("systemctl", ["stop", ...systemUnits]);
+			for (const unit of systemUnits) rmSync(join("/run/systemd/system", unit), { force: true });
+			spawnSync("systemctl", ["daemon-reload"]);
 			rmSync(runtimeHome, { recursive: true, force: true });
 			mkdirSync(runtimeHome, { mode: 0o700 });
 			chownSync(runtimeHome, runtimeUid, runtimeGid);
@@ -453,7 +733,7 @@ test.each(["hermes", "openclaw"] as const)(
 			expect(reload.status, reload.stderr).toBe(0);
 		}
 	},
-	120_000,
+	300_000,
 );
 
 test("propagates the real official OpenClaw installer failure and rolls back as UID 10001", () => {

--- a/packages/cli/tests/fixtures/runtime-official-installer-systemd/Dockerfile
+++ b/packages/cli/tests/fixtures/runtime-official-installer-systemd/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 		ca-certificates \
 		dbus-user-session \
+		nftables \
 		python3 \
 		systemd \
 		systemd-sysv \

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -425,7 +425,6 @@ function writeFakeSystemdManager(input: {
 	environmentRoot: string;
 	failNextGatewayRestart?: string;
 	failNextSidecarRestart?: string;
-	failFirstMissingUserEnableUnit?: string;
 	sidecarReadyPath?: string;
 }): void {
 	fakeSystemdStateRoots.add(input.stateRoot);
@@ -480,9 +479,9 @@ case "$command" in
     [ ! -f "$(state_path "$unit" pid)" ] || main_pid="$(cat "$(state_path "$unit" pid)")"
     printf 'LoadState=%s\\nActiveState=%s\\nMainPID=%s\\nNeedDaemonReload=%s\\n' "$load_state" "$active_state" "$main_pid" "$need_daemon_reload"
     ;;
-  is-enabled)
-    unit="\${1:-}"
-    if [ -f "$(state_path "$unit" enabled)" ]; then
+	  is-enabled)
+	    unit="\${1:-}"
+	    if [ -f "$(state_path "$unit" enabled)" ] || [ -L "$HOME/.config/systemd/user/default.target.wants/$unit" ]; then
       printf 'enabled\\n'
     else
       printf 'disabled\\n'
@@ -531,11 +530,6 @@ case "$command" in
 	    start_now=0
 	    if [ "\${1:-}" = "--now" ]; then start_now=1; shift; fi
 	    for unit in "$@"; do
-	      if [ "$scope" = user ] && [ "$unit" = '${input.failFirstMissingUserEnableUnit ?? ""}' ] && [ ! -f "$(state_path "$unit" enable-retried)" ]; then
-	        touch "$(state_path "$unit" enable-retried)"
-	        printf 'Failed to enable unit: Unit %s does not exist\n' "$unit" >&2
-	        exit 1
-	      fi
 	      touch "$(state_path "$unit" enabled)"
       if [ "$start_now" = "1" ]; then rm -f "$(state_path "$unit" failed)" "$(state_path "$unit" not-found)"; touch "$(state_path "$unit" active)"; start_process "$unit"; fi
     done
@@ -10082,87 +10076,6 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		expect(driftRepairCalls).not.toContain("restart clawdi-runtime-watch.service");
 	});
 
-	it("reloads once before retrying an enable for an existing user unit", () => {
-		const home = join(root, "missing-enable", "home", "clawdi");
-		const run = join(root, "missing-enable", "run", "clawdi");
-		const systemctlPath = join(root, "missing-enable", "bin", "systemctl");
-		const systemctlLog = join(root, "missing-enable", "systemctl.log");
-		const systemctlStateRoot = join(root, "missing-enable", "systemctl-state");
-		const unit = "hermes-gateway.service";
-		writeFakeSystemdManager({
-			path: systemctlPath,
-			logPath: systemctlLog,
-			stateRoot: systemctlStateRoot,
-			environmentRoot: join(run, "systemd", "env"),
-			failFirstMissingUserEnableUnit: unit,
-		});
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
-		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_SYSTEMCTL_PATH = systemctlPath;
-		process.env.CLAWDI_SYSTEMD_APPLY = "1";
-		const paths = getRuntimePaths();
-		const revision = "a".repeat(32);
-		const units = {
-			system: new Map<string, string>(),
-			user: new Map([[unit, "hermes"]]),
-		};
-		mkdirSync(paths.systemdUserRoot, { recursive: true });
-		writeFileSync(join(paths.systemdUserRoot, unit), "[Service]\nExecStart=/bin/true\n");
-		mkdirSync(paths.systemdEnvRoot, { recursive: true });
-		writeFileSync(join(paths.systemdEnvRoot, `${unit}.env`), `CLAWDI_RUNTIME_REV="${revision}"\n`);
-		seedFakeSystemdProcess(systemctlStateRoot, "user", unit, revision);
-		writeFileSync(systemctlLog, "");
-		const transaction = new SystemdRuntimeTransaction();
-
-		expect(
-			applySystemdRuntimeUpdate(paths, units, units, {
-				transaction,
-				stage: "final-activation",
-			}),
-		).toEqual({
-			applied: true,
-			systemUnitsChanged: [],
-			userUnitsChanged: [unit],
-		});
-		expect(transaction.journal).toEqual([
-			{
-				sequence: 1,
-				stage: "final-activation",
-				scope: "user",
-				action: "enable",
-				units: [unit],
-				outcome: "failed",
-			},
-			{
-				sequence: 2,
-				stage: "final-activation",
-				scope: "user",
-				action: "daemon-reload",
-				units: [],
-				outcome: "succeeded",
-			},
-			{
-				sequence: 3,
-				stage: "final-activation",
-				scope: "user",
-				action: "enable",
-				units: [unit],
-				outcome: "succeeded",
-			},
-		]);
-		const mutations = readFileSync(systemctlLog, "utf8")
-			.trim()
-			.split("\n")
-			.filter((call) => /(?:^|\s)(?:daemon-reload|enable)(?:\s|$)/.test(call));
-		expect(mutations).toEqual([
-			`--user enable ${unit}`,
-			"--user daemon-reload",
-			`--user enable ${unit}`,
-		]);
-	});
-
 	it("adopts a cross-version user revision only until its desired program changes", () => {
 		const home = join(root, "revision-alias", "home", "clawdi");
 		const state = join(root, "revision-alias", "var", "lib", "clawdi");
@@ -10969,10 +10882,9 @@ exit 0
 				),
 			).toHaveLength(1);
 			expect(
-				initialSystemctlCalls.filter(
-					(call) => call === "--user enable --now openclaw-gateway.service",
-				),
+				initialSystemctlCalls.filter((call) => call === "--user start openclaw-gateway.service"),
 			).toHaveLength(1);
+			expect(initialSystemctlCalls.some((call) => call.includes("--user enable"))).toBe(false);
 			expect(
 				initialSystemctlCalls.filter((call) => call === "restart clawdi-runtime-sidecar.service"),
 			).toHaveLength(1);
@@ -11030,10 +10942,11 @@ exit 0
 			for (const call of [
 				"reset-failed clawdi-daemon.service",
 				"start clawdi-daemon.service",
-				"--user enable --now openclaw-gateway.service",
+				"--user start openclaw-gateway.service",
 			]) {
 				expect(managerRepairCalls.filter((candidate) => candidate === call)).toHaveLength(1);
 			}
+			expect(managerRepairCalls.some((call) => call.includes("--user enable"))).toBe(false);
 			expect(managerRepairCalls.some((call) => call.includes("restart"))).toBe(false);
 			expect(readRuntimeAppliedState(paths)?.egressSidecarSecretRevision).toBe(
 				initialPrivateRevision,
@@ -11210,13 +11123,11 @@ exit 0
 			expect(rollbackMutations).toEqual([
 				"start clawdi-daemon.service",
 				"restart clawdi-runtime-sidecar.service",
-				"--user enable openclaw-gateway.service",
 				"--user restart openclaw-gateway.service",
 				"--user stop openclaw-gateway.service",
 				"stop clawdi-daemon.service",
 				"stop clawdi-runtime-sidecar.service",
 				"start clawdi-runtime-sidecar.service",
-				"--user disable openclaw-gateway.service",
 				"--user start openclaw-gateway.service",
 			]);
 			expect(

--- a/scripts/test-runtime-official-installer-systemd.sh
+++ b/scripts/test-runtime-official-installer-systemd.sh
@@ -35,7 +35,14 @@ for _attempt in $(seq 1 100); do
 done
 
 docker exec "$container" bash -lc \
-	'cp -a /repo/. /work/ && bun install --frozen-lockfile'
+	'cp -a /repo/. /work/ \
+		&& bun install --frozen-lockfile \
+		&& bun run --cwd packages/cli build \
+		&& mkdir -p /usr/local/share/clawdi/bootstrap \
+		&& npm pack ./packages/cli --pack-destination /usr/local/share/clawdi/bootstrap --silent >/dev/null \
+		&& mv /usr/local/share/clawdi/bootstrap/clawdi-*.tgz \
+			/usr/local/share/clawdi/bootstrap/clawdi-local.tgz'
 docker exec --env CLAWDI_TEST_REAL_OPENCLAW_SYSTEMD=1 "$container" \
 	bun test --isolate --max-concurrency=1 --timeout 30000 \
+	"$@" \
 	packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts


### PR DESCRIPTION
## Field incident

A paid Hermes 0.14.12 deployment failed on its first boot at:

```text
systemctl --user enable --now clawdi-hermes-dashboard.service
Failed to enable unit: Access denied
```

The managed user-unit tree was correctly root-owned and mode 0755. Existing deployments usually hid the conflict because their enablement links already existed, so `enable` was an idempotent no-write operation. A virgin deployment had to create `default.target.wants/<unit>` as UID 10001 and failed.

Before this change, the privileged zero-state suite reproduced the incident for both runtimes: 5 passed, 2 failed, with `Failed to enable unit: Access denied`.

## Design conflict and fix

`systemctl --user enable` asks the tenant user manager to write an install link into a platform-owned tree. That contradicts the ownership enclave by construction; it is not a chmod or retry problem.

This PR materializes the `[Install]` result declaratively as part of the existing root reconciliation plan:

```text
~/.config/systemd/user/default.target.wants/<unit> -> ../<unit>
```

The planning side already included these paths in `symlinkTargets`; the write side now creates, repairs, removes, snapshots, and rolls them back under the same authority. Managed missing or wrong-target links are repaired. Foreign wants links remain untouched.

All managed `systemctl --user enable`, `disable`, and `enable --now` calls are removed, including the no-longer-used post-enable reload/retry defense. User-manager `daemon-reload`, `start`, `stop`, and `restart` remain.

The terminal invariant is now complete: **the platform process running as root is the sole writer of the managed unit tree; the tenant user manager only reads unit state and runs services.**

## Additional first-boot layer

The complete OpenClaw virgin path exposed a second product failure: a deletion-only JSON merge patch treated an absent parent object as drift. A second converge therefore restarted an otherwise unchanged gateway. The patch comparison now recognizes OpenClaw's canonical omission of empty parents, so the second converge is genuinely unchanged and keeps the same gateway PID.

The full CLI gate also exposed an inherited fail-closed defect from current `main`: rollback rebuilt an untouched, rejected unmanaged Skill target and changed its inode. Snapshot restore now detects an exact unchanged preimage and leaves it untouched. The existing no-touch test moved from red to green without weakening ownership validation.

## Faithful virgin-boot regression

The existing two-runtime parameterized privileged E2E now runs the complete first boot rather than stopping at an installer boundary:

- real PID 1 and a cold systemd user manager
- empty HOME, UID 10001 tenant, root-owned unit enclave, and umask 0077
- current CLI built and packed in the image, then bootstrapped as root
- official Hermes and OpenClaw installers run as UID 10001 inside the container
- local authenticated manifest endpoint with matching ETag and 304 behavior
- first converge, active service/PID/UID/revision checks, root-owned unit-tree checks, and live TCP probes
- Hermes gateway service active with its declared dashboard accepting on 9119; OpenClaw gateway accepting on 18789
- second full init with stable PIDs, byte-identical unit tree, and an empty systemctl mutation journal

No host runtime, venv, package, service, or configuration is installed by this test. Every task-scoped container, image, volume, and network is removed on success and failure.

## First-boot audit

| Operation | Execution identity | Zero-state prerequisite | Status |
| --- | --- | --- | --- |
| Start the privileged container with real PID 1 | Docker/runtime root | systemd-capable image and cgroup mount are available | Verified OK |
| Bootstrap the tenant account and empty HOME | root | UID/GID 10001 are unused; HOME does not exist | Verified OK |
| Create FHS parents and platform state leaves | root | root-owned parents may be created at 0755 and private leaves at 0700 | Verified OK |
| Apply the deployment umask | root bootstrap and tenant subprocesses | umask starts at 0077 before generated helpers and runtime state | Verified OK |
| Enable linger and start a cold user manager | root, then systemd user manager as UID 10001 | login session state, D-Bus, and `/run/user/10001` can be initialized from zero | Verified OK |
| Export `XDG_RUNTIME_DIR` and address the user bus | root convergence invoking the UID 10001 boundary | `/run/user/10001` exists and the user manager is ready | Verified OK |
| Build and pack the current CLI in the E2E image | isolated image builder | pinned Bun toolchain and repository sources are present | Verified OK |
| Bootstrap the packed CLI into the platform prefix | root | exact package tarball and declared npm registry are available in the container | Verified OK |
| Serve the hosted manifest and secrets fixture | root fixture process | loopback HTTP is available and the canonical bearer is known | Verified OK |
| Revalidate unchanged desired state with ETag/304 | root watcher/init client | matching ETag is persisted after the first successful apply | Verified OK |
| Reach official runtime installer dependencies | image build and tenant installer | container egress, CA trust, npm registry, and installer network are available | Verified OK |
| Install official Hermes/OpenClaw runtime | UID 10001 | writable empty tenant HOME and executable installer inputs are available | Verified OK |
| Render unit, drop-in, environment, and wants state | platform root | managed unit root exists or can be created without tenant ownership | Fixed in this PR |
| Repair missing or wrong managed wants symlinks | platform root | path is in the planned managed `symlinkTargets` set | Fixed in this PR |
| Preserve foreign wants links | platform root | foreign link is outside the managed unit-name set | Verified OK |
| Reload the user manager after filesystem commit | user manager as UID 10001 | root has completed all managed tree writes | Fixed in this PR |
| Start and inspect managed user services | user manager as UID 10001 | daemon-reload has made the declarative links and unit content visible | Verified OK |
| Verify runtime process identity and revision | root observer reading user-manager state | service is active with a main PID | Verified OK |
| Probe the declared live ports | isolated E2E client | Hermes dashboard is bound to 9119; OpenClaw gateway is bound to 18789 | Verified OK |
| Commit authority and garbage-collect stale files | platform root | candidate services and exact rendered state passed activation checks | Verified OK |
| Restore snapshots on apply failure | platform root plus UID 10001 file boundary | all managed mutation targets, including wants links, were captured before mutation | Verified OK |
| Leave rejected unmanaged resources untouched | platform root plus UID 10001 file boundary | ownership reservation is absent or invalid | Fixed in this PR |
| Run the second complete converge | root convergence and read/run-only user manager | first generation is committed and the fixture returns 304 | Verified OK |
| Prove unchanged convergence | root observer | gateway PID, unit-tree digest, and systemctl mutation journal are comparable | Fixed in this PR |
| Tear down task-scoped Docker state | test harness root | cleanup trap runs on success, failure, and interruption | Verified OK |

## Verification evidence

- Privileged before: `5 pass / 2 fail`; both virgin runtime branches reproduced `Failed to enable unit: Access denied`.
- Privileged after, final HEAD: `7 pass / 0 fail / 379 assertions`; test body 465.93s, full image-build/test/cleanup 613.96s.
- Virgin Hermes: 101.60s. Virgin OpenClaw: 70.88s.
- CLI typecheck plus full `test:internal`: `1767 pass / 4 skip / 0 fail / 9577 assertions` across 136 files in 160.86s. `manifest-mutation-parity.test.ts` passed in that run.
- Pinned Biome: 1071 files checked, no fixes.
- Focused no-touch rollback regression: `1 pass / 0 fail / 6 assertions`.
- Final task-scoped Docker residue: zero containers, images, volumes, or networks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
