### PR TITLE
release(cli): 0.14.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.13
+
+Package: `clawdi@0.14.13`
+
+### Fixed
+
+- Managed service enablement is now declared by the platform writing the
+  systemd wants links directly, removing the tenant-manager `enable` calls
+  that failed on brand-new hosts. Fresh deployments for both Hermes and
+  OpenClaw converge end to end, verified in a faithful zero-state environment.
+
 ## Clawdi CLI v0.14.12
 
 Package: `clawdi@0.14.12`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.12",
+      "version": "0.14.13",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.12",
+	"version": "0.14.13",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Release `clawdi@0.14.13` — declarative enablement (#1180), the virgin-boot completion release.

`systemctl --user enable` fundamentally requires the tenant manager to write into the platform-owned unit tree — a design conflict that only bites on brand-new hosts. Managed enablement is now declared by the platform materializing the wants links directly (single writer = platform; tenant manager reads and runs), deleting enable/disable from the managed path. Both runtimes' zero-state first boots were reproduced red (Access denied) and verified green end-to-end in a faithful isolated PID1 environment with real runtimes, plus a 25-row first-boot audit table (20 verified OK, 5 fixed here) covering every step × identity × zero-state precondition.

Follow-up: fleet to 0.14.13, then dual-runtime paid fresh-deployment certification as the final stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)