### PR TITLE
refactor(cli): collapse Skill ownership to the reservation ledger

### DIFF
--- a/packages/cli/src/runtime/hosted-hermes-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.test.ts
@@ -8,14 +8,12 @@ import {
 	readdirSync,
 	readFileSync,
 	rmSync,
-	statSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { hostedHermesSkillExactSourceDriver } from "./hosted-hermes-skill";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
-import { managedSkillReceiptPath } from "./managed-skill-delivery";
 
 let root: string | null = null;
 
@@ -118,8 +116,6 @@ describe("Hermes exact-source Workspace Skill driver", () => {
 	test("places a hub-blocked dangerous source on the official local discovery surface", () => {
 		root = mkdtempSync(join(tmpdir(), "hosted-hermes-dangerous-local-"));
 		const home = join(root, "home");
-		const managedResourceRoot = join(root, "managed-resources");
-		mkdirSync(managedResourceRoot, { recursive: true });
 		const skillId = "dangerous-local";
 		const dangerousSkill = `---
 name: blocked-page-recovery
@@ -149,9 +145,7 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 		expect(
 			hostedHermesSkillExactSourceDriver.install({
 				home,
-				managedResourceRoot,
 				skill,
-				previouslyReserved: false,
 			}),
 		).toBe("installed");
 		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe(dangerousSkill);
@@ -171,23 +165,11 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 
 		// A fresh discovery instance models a restarted gateway process.
 		expect(fakeHermesLocalSkills(home)).toHaveLength(1);
-		expect(
-			hostedHermesSkillExactSourceDriver.uninstall({
-				home,
-				managedResourceRoot,
-				skillId,
-				ownershipIdentity: skill.sourceIdentity,
-			}),
-		).toBe("removed");
-		expect(existsSync(target)).toBe(false);
-		expect(fakeHermesLocalSkills(home)).toEqual([]);
 	});
 
-	test("repairs receipt and byte drift and atomically replaces an owned source", () => {
+	test("atomically replaces an exact source", () => {
 		root = mkdtempSync(join(tmpdir(), "hosted-hermes-local-repair-"));
 		const home = join(root, "home");
-		const managedResourceRoot = join(root, "managed-resources");
-		mkdirSync(managedResourceRoot, { recursive: true });
 		const skillId = "review-pr";
 		const skillV1 = "---\nname: native-review-pr\n---\n# Review PR v1\n";
 		const skillV2 = "---\nname: native-review-pr\n---\n# Review PR v2\n";
@@ -196,56 +178,25 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 		const skill = sourcedSkill(skillId, archiveV1);
 		const updatedSkill = sourcedSkill(skillId, archiveV2, "b".repeat(40));
 		const target = join(home, ".hermes", "skills", skillId);
-		const receipt = managedSkillReceiptPath(managedResourceRoot, "hermes", skillId);
-		const input = {
-			home,
-			managedResourceRoot,
-			skill,
-		};
+		const input = { home, skill };
 
-		expect(
-			hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: false }),
-		).toBe("installed");
-		const stableInode = statSync(target).ino;
-		expect(hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: true })).toBe(
-			"unchanged",
-		);
-		expect(statSync(target).ino).toBe(stableInode);
-
-		rmSync(receipt);
-		expect(hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: true })).toBe(
-			"installed",
-		);
+		expect(hostedHermesSkillExactSourceDriver.install(input)).toBe("installed");
 		writeFileSync(join(target, "SKILL.md"), "tenant drift\n");
-		expect(hostedHermesSkillExactSourceDriver.verifyOwned(input)).toBe(false);
-		expect(hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: true })).toBe(
-			"installed",
-		);
+		expect(hostedHermesSkillExactSourceDriver.install(input)).toBe("installed");
 		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe(skillV1);
 
 		expect(
 			hostedHermesSkillExactSourceDriver.install({
 				...input,
 				skill: updatedSkill,
-				previouslyReserved: true,
 			}),
 		).toBe("installed");
 		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe(skillV2);
-		expect(
-			hostedHermesSkillExactSourceDriver.hasOwnershipReceipt({
-				home,
-				managedResourceRoot,
-				skillId,
-				ownershipIdentity: updatedSkill.sourceIdentity,
-			}),
-		).toBe(true);
 	});
 
-	test("ignores retired loopback hub metadata for a receipt-owned local Skill", () => {
+	test("does not modify Hermes hub metadata", () => {
 		root = mkdtempSync(join(tmpdir(), "hosted-hermes-loopback-metadata-"));
 		const home = join(root, "home");
-		const managedResourceRoot = join(root, "managed-resources");
-		mkdirSync(managedResourceRoot, { recursive: true });
 		const skillId = "review-pr";
 		const skillFiles = {
 			"SKILL.md": "---\nname: review-pr\n---\n# Review PR\n",
@@ -253,15 +204,9 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 		};
 		const archive = archiveSkill(root, skillId, skillFiles);
 		const skill = sourcedSkill(skillId, archive);
-		const input = {
-			home,
-			managedResourceRoot,
-			skill,
-		};
+		const input = { home, skill };
 
-		expect(
-			hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: false }),
-		).toBe("installed");
+		expect(hostedHermesSkillExactSourceDriver.install(input)).toBe("installed");
 		const lockPath = join(home, ".hermes", "skills", ".hub", "lock.json");
 		mkdirSync(dirname(lockPath), { recursive: true });
 		const externalEntry = {
@@ -284,9 +229,7 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 			})}\n`,
 		);
 		const lockBefore = readFileSync(lockPath);
-		expect(hostedHermesSkillExactSourceDriver.install({ ...input, previouslyReserved: true })).toBe(
-			"unchanged",
-		);
+		expect(hostedHermesSkillExactSourceDriver.install(input)).toBe("installed");
 		expect(readFileSync(lockPath)).toEqual(lockBefore);
 		expect(JSON.parse(readFileSync(lockPath, "utf8")).installed).toEqual({
 			[skillId]: {
@@ -296,46 +239,5 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 			},
 			"user-skill": externalEntry,
 		});
-	});
-
-	test("preserves unreserved and locally changed targets", () => {
-		const fixtureRoot = mkdtempSync(join(tmpdir(), "hosted-hermes-local-ownership-"));
-		root = fixtureRoot;
-		const home = join(fixtureRoot, "home");
-		const managedResourceRoot = join(fixtureRoot, "managed-resources");
-		mkdirSync(managedResourceRoot, { recursive: true });
-		const skillId = "review-pr";
-		const archive = archiveSkill(fixtureRoot, skillId, { "SKILL.md": "# Managed\n" });
-		const skill = sourcedSkill(skillId, archive);
-		const target = join(home, ".hermes", "skills", skillId);
-		mkdirSync(target, { recursive: true });
-		writeFileSync(join(target, "SKILL.md"), "user-owned\n");
-
-		expect(() =>
-			hostedHermesSkillExactSourceDriver.install({
-				home,
-				managedResourceRoot,
-				skill,
-				previouslyReserved: false,
-			}),
-		).toThrow("not paired with a manifest reservation");
-		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("user-owned\n");
-
-		hostedHermesSkillExactSourceDriver.anchorOwnership({
-			home,
-			managedResourceRoot,
-			skillId,
-			ownershipIdentity: skill.sourceIdentity,
-		});
-		writeFileSync(join(target, "SKILL.md"), "changed after receipt\n");
-		expect(() =>
-			hostedHermesSkillExactSourceDriver.cleanupManifestOwned({
-				home,
-				managedResourceRoot,
-				skillId,
-				ownershipIdentity: skill.sourceIdentity,
-			}),
-		).toThrow("ownership receipt");
-		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("changed after receipt\n");
 	});
 });

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -1,65 +1,19 @@
-import { existsSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import {
-	collectManagedSkillTree,
-	collectRuntimeUserManagedSkillTree,
-	HERMES_MANAGED_SKILL_RECEIPT_SCHEMA,
 	ManagedSkillResourceError,
-	managedSkillMarkerMatchesIdentity,
-	managedSkillReceiptIdentityState,
-	managedSkillReceiptMatchesIdentity,
-	managedSkillReceiptPath,
-	managedSkillTreesEqual,
+	managedSkillTargetMatchesSource,
 	withStagedManagedSkill,
-	writeManagedSkillReceipt,
 } from "./managed-skill-delivery";
 import { replaceManagedSkillDirectoryAtomic } from "./managed-skill-reservation";
-import { withRuntimeUserFileAccess } from "./runtime-user-command";
 
 export interface HostedHermesSkillExactSourceDriver {
 	target?(input: { home: string; skill: PreparedHostedSourcedSkill }): string;
 	install(input: {
 		home: string;
-		managedResourceRoot: string;
 		skill: PreparedHostedSourcedSkill;
 		targetDir?: string;
-		previouslyReserved: boolean;
 	}): "installed" | "unchanged";
-	anchorOwnership(input: {
-		home: string;
-		managedResourceRoot: string;
-		skillId: string;
-		ownershipIdentity: string;
-		targetDir?: string;
-	}): void;
-	verifyOwned(input: {
-		home: string;
-		managedResourceRoot: string;
-		skill: PreparedHostedSourcedSkill;
-		targetDir?: string;
-	}): boolean;
-	hasOwnershipReceipt(input: {
-		home: string;
-		managedResourceRoot: string;
-		skillId: string;
-		ownershipIdentity: string;
-		targetDir?: string;
-	}): boolean;
-	uninstall(input: {
-		home: string;
-		managedResourceRoot: string;
-		skillId: string;
-		ownershipIdentity: string;
-		targetDir?: string;
-	}): "absent" | "removed";
-	cleanupManifestOwned(input: {
-		home: string;
-		managedResourceRoot: string;
-		skillId: string;
-		ownershipIdentity: string;
-		targetDir?: string;
-	}): "absent" | "removed";
 }
 
 function targetDir(home: string, skillId: string): string {
@@ -69,64 +23,10 @@ function targetDir(home: string, skillId: string): string {
 	return join(home, ".hermes", "skills", skillId);
 }
 
-function receiptInput(
-	managedResourceRoot: string,
-	skillId: string,
-	ownershipIdentity: string,
-	target: string,
-) {
-	return {
-		path: managedSkillReceiptPath(managedResourceRoot, "hermes", skillId),
-		managedResourceRoot,
-		schemaVersion: HERMES_MANAGED_SKILL_RECEIPT_SCHEMA,
-		skillId,
-		ownershipIdentity,
-		target,
-	};
-}
-
 function assertActivationMatchesSource(sourceDir: string, target: string): void {
-	const source = collectManagedSkillTree(sourceDir);
-	const installed = collectRuntimeUserManagedSkillTree(target);
-	if (source.status !== "collected") {
-		throw new Error(`prepared Hermes Skill tree is ${source.status}`);
-	}
-	if (installed.status !== "collected") {
-		throw new ManagedSkillResourceError(`installed Hermes Skill tree is ${installed.status}`);
-	}
-	if (!managedSkillTreesEqual(source.tree, installed.tree)) {
+	if (!managedSkillTargetMatchesSource(sourceDir, target)) {
 		throw new ManagedSkillResourceError("Hermes Skill activation changed exact source bytes");
 	}
-}
-
-function removeOwnedSkill(input: {
-	home: string;
-	managedResourceRoot: string;
-	skillId: string;
-	ownershipIdentity: string;
-	targetDir?: string;
-}): "absent" | "removed" {
-	const target = resolve(input.targetDir ?? targetDir(input.home, input.skillId));
-	const receipt = receiptInput(
-		input.managedResourceRoot,
-		input.skillId,
-		input.ownershipIdentity,
-		target,
-	);
-	const receiptState = managedSkillReceiptIdentityState(receipt);
-	if (receiptState === "absent") {
-		rmSync(receipt.path, { force: true });
-		return "absent";
-	}
-	if (receiptState === "unsafe") throw new Error("Hermes Skill tree is unsafe");
-	if (receiptState !== "matched") {
-		throw new Error("Hermes Skill bytes no longer match the manifest ownership receipt");
-	}
-	withRuntimeUserFileAccess(() => {
-		rmSync(target, { recursive: true });
-	});
-	rmSync(receipt.path, { force: true });
-	return "removed";
 }
 
 export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDriver = {
@@ -135,61 +35,11 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 	},
 	install(input) {
 		const target = resolve(input.targetDir ?? targetDir(input.home, input.skill.skillId));
-		const receipt = receiptInput(
-			input.managedResourceRoot,
-			input.skill.skillId,
-			input.skill.sourceIdentity,
-			target,
-		);
-		if (withRuntimeUserFileAccess(() => existsSync(target)) && !input.previouslyReserved) {
-			throw new Error("Hermes Skill target is not paired with a manifest reservation");
-		}
-		if (managedSkillReceiptMatchesIdentity(receipt)) return "unchanged";
 		return withStagedManagedSkill(input.skill, (sourceDir) => {
 			replaceManagedSkillDirectoryAtomic(sourceDir, target, {
-				receipt: receipt.path,
-				afterActivate: () => {
-					assertActivationMatchesSource(sourceDir, target);
-					writeManagedSkillReceipt(receipt);
-				},
+				afterActivate: () => assertActivationMatchesSource(sourceDir, target),
 			});
 			return "installed" as const;
 		});
-	},
-	anchorOwnership(input) {
-		writeManagedSkillReceipt(
-			receiptInput(
-				input.managedResourceRoot,
-				input.skillId,
-				input.ownershipIdentity,
-				input.targetDir ?? targetDir(input.home, input.skillId),
-			),
-		);
-	},
-	verifyOwned(input) {
-		return managedSkillReceiptMatchesIdentity(
-			receiptInput(
-				input.managedResourceRoot,
-				input.skill.skillId,
-				input.skill.sourceIdentity,
-				input.targetDir ?? targetDir(input.home, input.skill.skillId),
-			),
-		);
-	},
-	hasOwnershipReceipt(input) {
-		return managedSkillMarkerMatchesIdentity(
-			receiptInput(
-				input.managedResourceRoot,
-				input.skillId,
-				input.ownershipIdentity,
-				input.targetDir ?? targetDir(input.home, input.skillId),
-			),
-		);
-	},
-	uninstall(input) {
-		return removeOwnedSkill(input);
-	},
-	cleanupManifestOwned(input) {
-		return removeOwnedSkill(input);
 	},
 };

--- a/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
@@ -8,13 +8,11 @@ import {
 	mkdtempSync,
 	readFileSync,
 	rmSync,
-	statSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { hostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
-import { managedSkillReceiptPath } from "./managed-skill-delivery";
 
 let root = "";
 const originalSystemctlPath = process.env.CLAWDI_SYSTEMCTL_PATH;
@@ -240,12 +238,10 @@ exit 2
 	}
 });
 
-test("runs official install from home before its first workspace exists and guards cleanup", async () => {
+test("runs official install from home and rolls back failed replacement", () => {
 	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-driver-"));
 	const home = join(root, "home");
 	const workspaceRoot = join(home, "agent-workspace");
-	const managedResourceRoot = join(root, "managed-resources");
-	mkdirSync(managedResourceRoot, { recursive: true });
 	const command = join(home, ".local", "bin", "openclaw");
 	const installLog = join(root, "install.log");
 	const installCwdLog = join(root, "install-cwd.log");
@@ -278,7 +274,6 @@ rm -rf '${workspaceRoot}/skills/'"$skill_id"
 cp -R "$source_dir" '${workspaceRoot}/skills/'"$skill_id"
 mkdir -p '${workspaceRoot}/skills/'"$skill_id"'/.openclaw'
 printf '{}\n' > '${workspaceRoot}/skills/'"$skill_id"'/.openclaw/source-origin.json'
-printf '{"installed":true}\n' > '${workspaceRoot}/skills/'"$skill_id"'/.openclaw-native.json'
 if test "\${FAKE_OPENCLAW_FAIL_AFTER_WRITE:-}" = "1"; then exit 45; fi
 if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDriftMarker}'; fi
 `,
@@ -305,59 +300,19 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 	};
 
 	expect(existsSync(workspaceRoot)).toBe(false);
-	expect(
-		hostedOpenClawSkillDriver.install({ home, workspaceRoot, managedResourceRoot, skill }),
-	).toBe("installed");
+	expect(hostedOpenClawSkillDriver.install({ home, workspaceRoot, skill })).toBe("installed");
 	expect(readFileSync(installCwdLog, "utf8")).toBe(`${home}\n`);
 	expect(readFileSync(installLog, "utf8")).toMatch(
 		/^skills install .* --agent main --as review-pr --force\n$/,
 	);
-	expect(
-		hostedOpenClawSkillDriver.install({ home, workspaceRoot, managedResourceRoot, skill }),
-	).toBe("unchanged");
-	expect(readFileSync(installLog, "utf8").trim().split("\n")).toHaveLength(1);
-	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, managedResourceRoot, skill })).toBe(
-		true,
-	);
 	const target = join(workspaceRoot, "skills", "review-pr");
-	const receipt = managedSkillReceiptPath(managedResourceRoot, "openclaw", "review-pr");
-	const receiptBytes = readFileSync(receipt);
-	const receiptStat = statSync(receipt);
-	expect(receiptStat.mode & 0o777).toBe(0o600);
-	if (process.geteuid) expect(receiptStat.uid).toBe(process.geteuid());
-	rmSync(receipt);
-	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, managedResourceRoot, skill })).toBe(
-		false,
-	);
-	writeFileSync(receipt, receiptBytes);
 	expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("# Review PR\n");
-	writeFileSync(join(target, "SKILL.md"), "tenant mutation\n");
-	chmodSync(receipt, 0o622);
-	expect(
-		hostedOpenClawSkillDriver.hasOwnershipReceipt({
-			workspaceRoot,
-			managedResourceRoot,
-			skillId: "review-pr",
-			ownershipIdentity: skill.sourceIdentity,
-		}),
-	).toBe(false);
-	chmodSync(receipt, 0o600);
-	expect(
-		hostedOpenClawSkillDriver.hasOwnershipReceipt({
-			workspaceRoot,
-			managedResourceRoot,
-			skillId: "review-pr",
-			ownershipIdentity: skill.sourceIdentity,
-		}),
-	).toBe(true);
 	expect(
 		hostedOpenClawSkillDriver.installDirectory({
 			home,
 			workspaceRoot,
-			managedResourceRoot,
 			skillId: "review-pr",
 			sourceDir,
-			ownershipIdentity: skill.sourceIdentity,
 		}),
 	).toBe("installed");
 	expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("# Review PR\n");
@@ -367,73 +322,30 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 		hostedOpenClawSkillDriver.installDirectory({
 			home,
 			workspaceRoot,
-			managedResourceRoot,
 			skillId: "review-pr",
 			sourceDir,
-			ownershipIdentity: `${skill.sourceIdentity}-v2`,
 		}),
 	).toThrow("official Skill install failed: exit code 45 without output");
 	expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("# Review PR\n");
-	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, managedResourceRoot, skill })).toBe(
-		true,
-	);
 	delete process.env.FAKE_OPENCLAW_FAIL_AFTER_WRITE;
 	process.env.FAKE_OPENCLAW_DRIFT_AFTER_WRITE = "1";
 	expect(() =>
 		hostedOpenClawSkillDriver.installDirectory({
 			home,
 			workspaceRoot,
-			managedResourceRoot,
 			skillId: "review-pr",
 			sourceDir,
-			ownershipIdentity: `${skill.sourceIdentity}-v2`,
 		}),
 	).toThrow("changed during Skill reconciliation");
 	expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("# Review PR\n");
-	expect(hostedOpenClawSkillDriver.verifyOwned({ workspaceRoot, managedResourceRoot, skill })).toBe(
-		true,
-	);
 	delete process.env.FAKE_OPENCLAW_DRIFT_AFTER_WRITE;
 	rmSync(workspaceDriftMarker);
-	writeFileSync(join(sourceDir, "SKILL.md"), "# Review PR\n");
-	writeFileSync(join(target, "SKILL.md"), "user changed\n");
-	expect(() =>
-		hostedOpenClawSkillDriver.cleanupManifestOwned({
-			workspaceRoot,
-			managedResourceRoot,
-			skillId: "review-pr",
-			ownershipIdentity: skill.sourceIdentity,
-		}),
-	).toThrow("ownership receipt");
-	expect(existsSync(target)).toBe(true);
-	writeFileSync(join(target, "SKILL.md"), "# Review PR\n");
-	expect(
-		hostedOpenClawSkillDriver.cleanupManifestOwned({
-			workspaceRoot,
-			managedResourceRoot,
-			skillId: "review-pr",
-			ownershipIdentity: skill.sourceIdentity,
-		}),
-	).toBe("removed");
-	expect(existsSync(target)).toBe(false);
-	writeFileSync(receipt, "{}\n");
-	expect(
-		hostedOpenClawSkillDriver.cleanupManifestOwned({
-			workspaceRoot,
-			managedResourceRoot,
-			skillId: "review-pr",
-			ownershipIdentity: skill.sourceIdentity,
-		}),
-	).toBe("absent");
-	expect(existsSync(receipt)).toBe(false);
 });
 
 test("fails before official install when the OpenClaw workspace changes during reconciliation", async () => {
 	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-workspace-mismatch-"));
 	const home = join(root, "home");
 	const workspaceRoot = join(home, "desired-workspace");
-	const managedResourceRoot = join(root, "managed-resources");
-	mkdirSync(managedResourceRoot, { recursive: true });
 	const command = join(home, ".local", "bin", "openclaw");
 	const installMarker = join(root, "install-called");
 	mkdirSync(dirname(command), { recursive: true });
@@ -457,12 +369,8 @@ exit 0
 		hostedOpenClawSkillDriver.installDirectory({
 			home,
 			workspaceRoot,
-			managedResourceRoot,
 			skillId: "review-pr",
 			sourceDir,
-			ownershipIdentity:
-				"github\0review-pr\0https://github.com/Clawdi-AI/store\0skills/review-pr\0" +
-				"a".repeat(40),
 		}),
 	).toThrow("changed during Skill reconciliation");
 	expect(existsSync(installMarker)).toBe(false);
@@ -473,8 +381,6 @@ test("reports a spawn error when the official install process cannot start", () 
 	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-spawn-error-"));
 	const home = join(root, "home");
 	const workspaceRoot = join(home, "agent-workspace");
-	const managedResourceRoot = join(root, "managed-resources");
-	mkdirSync(managedResourceRoot, { recursive: true });
 	const command = join(home, ".local", "bin", "openclaw");
 	mkdirSync(dirname(command), { recursive: true });
 	writeFileSync(
@@ -497,12 +403,8 @@ exit 64
 		hostedOpenClawSkillDriver.installDirectory({
 			home,
 			workspaceRoot,
-			managedResourceRoot,
 			skillId: "review-pr",
 			sourceDir,
-			ownershipIdentity:
-				"github\0review-pr\0https://github.com/Clawdi-AI/store\0skills/review-pr\0" +
-				"a".repeat(40),
 		});
 	} catch (error) {
 		message = error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/runtime/hosted-openclaw-skill.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.ts
@@ -1,4 +1,3 @@
-import { existsSync, rmSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
 import {
 	type OpenClawAgentWorkspace,
@@ -7,15 +6,9 @@ import {
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import {
 	ManagedSkillResourceError,
-	managedSkillMarkerMatchesIdentity,
-	managedSkillMarkerOwnsTarget,
-	managedSkillReceiptIdentityState,
-	managedSkillReceiptMatchesIdentity,
-	managedSkillReceiptPath,
-	OPENCLAW_MANAGED_SKILL_RECEIPT_SCHEMA,
+	managedSkillTargetMatchesSource,
 	withManagedTargetRollback,
 	withStagedManagedSkill,
-	writeManagedSkillReceipt,
 } from "./managed-skill-delivery";
 import {
 	executableExists,
@@ -25,8 +18,7 @@ import {
 import { parseSystemctlShow, systemctlPath } from "./systemd";
 
 const OPENCLAW_AGENT_ID = "main";
-const SOURCE_RECEIPT = ".openclaw/source-origin.json";
-const EXCLUDED_NATIVE_FILES = new Set([SOURCE_RECEIPT]);
+const OPENCLAW_INSTALLED_TREE_EXCLUDES = new Set([".openclaw/source-origin.json"]);
 const OPENCLAW_CONFIG_PROBE_TIMEOUT_MS = 15_000;
 const OPENCLAW_CONFIG_REPAIR_TIMEOUT_MS = 120_000;
 const OPENCLAW_GATEWAY_UNIT = "openclaw-gateway.service";
@@ -38,42 +30,14 @@ export interface HostedOpenClawSkillDriver {
 	installDirectory(input: {
 		home: string;
 		workspaceRoot: string;
-		managedResourceRoot: string;
 		skillId: string;
 		sourceDir: string;
-		ownershipIdentity: string;
-		previouslyReserved?: boolean;
 	}): "installed" | "unchanged";
 	install(input: {
 		home: string;
 		workspaceRoot: string;
-		managedResourceRoot: string;
 		skill: PreparedHostedSourcedSkill;
-		previouslyReserved?: boolean;
 	}): "installed" | "unchanged";
-	anchorOwnership(input: {
-		workspaceRoot: string;
-		managedResourceRoot: string;
-		skillId: string;
-		ownershipIdentity: string;
-	}): void;
-	hasOwnershipReceipt(input: {
-		workspaceRoot: string;
-		managedResourceRoot: string;
-		skillId: string;
-		ownershipIdentity: string;
-	}): boolean;
-	verifyOwned(input: {
-		workspaceRoot: string;
-		managedResourceRoot: string;
-		skill: PreparedHostedSourcedSkill;
-	}): boolean;
-	cleanupManifestOwned(input: {
-		workspaceRoot: string;
-		managedResourceRoot: string;
-		skillId: string;
-		ownershipIdentity: string;
-	}): "absent" | "removed";
 }
 
 function installedCommandPath(home: string): string | null {
@@ -94,22 +58,6 @@ function commandPath(home: string): string {
 }
 const targetDir = (workspaceRoot: string, skillId: string) =>
 	join(workspaceRoot, "skills", skillId);
-function receiptInput(
-	managedResourceRoot: string,
-	workspaceRoot: string,
-	skillId: string,
-	ownershipIdentity: string,
-) {
-	return {
-		path: managedSkillReceiptPath(managedResourceRoot, "openclaw", skillId),
-		managedResourceRoot,
-		schemaVersion: OPENCLAW_MANAGED_SKILL_RECEIPT_SCHEMA,
-		skillId,
-		ownershipIdentity,
-		target: targetDir(workspaceRoot, skillId),
-		exclude: EXCLUDED_NATIVE_FILES,
-	};
-}
 
 function parseOfficialWorkspaceRoster(stdout: string): string {
 	let roster: OpenClawAgentWorkspace[];
@@ -254,25 +202,9 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 	},
 	installDirectory(input) {
 		const target = targetDir(input.workspaceRoot, input.skillId);
-		const receipt = receiptInput(
-			input.managedResourceRoot,
-			input.workspaceRoot,
-			input.skillId,
-			input.ownershipIdentity,
-		);
-		if (managedSkillReceiptMatchesIdentity(receipt)) return "unchanged";
-		if (
-			withRuntimeUserFileAccess(() => existsSync(target)) &&
-			!input.previouslyReserved &&
-			!managedSkillMarkerOwnsTarget(receipt)
-		)
-			throw new Error(
-				"refusing to replace an OpenClaw Skill without a matching Clawdi ownership receipt",
-			);
 		assertOfficialWorkspace(input);
 		return withManagedTargetRollback({
 			target,
-			receipt: receipt.path,
 			operation: () => {
 				// The roster may reference a workspace OpenClaw has not created yet on first run.
 				const result = spawnRuntimeUserCommand(
@@ -296,89 +228,27 @@ export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
 						`OpenClaw official Skill install failed: ${commandFailureDetail(result)}`,
 					);
 				assertOfficialWorkspace(input);
-				writeManagedSkillReceipt(receipt);
+				if (
+					!managedSkillTargetMatchesSource(input.sourceDir, target, {
+						exclude: OPENCLAW_INSTALLED_TREE_EXCLUDES,
+					})
+				) {
+					throw new ManagedSkillResourceError(
+						"OpenClaw Skill activation changed exact source bytes",
+					);
+				}
 				return "installed" as const;
 			},
 		});
 	},
 	install(input) {
-		if (
-			managedSkillReceiptMatchesIdentity(
-				receiptInput(
-					input.managedResourceRoot,
-					input.workspaceRoot,
-					input.skill.skillId,
-					input.skill.sourceIdentity,
-				),
-			)
-		)
-			return "unchanged";
 		return withStagedManagedSkill(input.skill, (sourceDir) =>
 			this.installDirectory({
 				home: input.home,
 				workspaceRoot: input.workspaceRoot,
-				managedResourceRoot: input.managedResourceRoot,
 				skillId: input.skill.skillId,
 				sourceDir,
-				ownershipIdentity: input.skill.sourceIdentity,
-				previouslyReserved: input.previouslyReserved,
 			}),
 		);
-	},
-	anchorOwnership(input) {
-		writeManagedSkillReceipt(
-			receiptInput(
-				input.managedResourceRoot,
-				input.workspaceRoot,
-				input.skillId,
-				input.ownershipIdentity,
-			),
-		);
-	},
-	hasOwnershipReceipt(input) {
-		return managedSkillMarkerMatchesIdentity(
-			receiptInput(
-				input.managedResourceRoot,
-				input.workspaceRoot,
-				input.skillId,
-				input.ownershipIdentity,
-			),
-		);
-	},
-	verifyOwned(input) {
-		return managedSkillReceiptMatchesIdentity(
-			receiptInput(
-				input.managedResourceRoot,
-				input.workspaceRoot,
-				input.skill.skillId,
-				input.skill.sourceIdentity,
-			),
-		);
-	},
-	cleanupManifestOwned(input) {
-		const target = targetDir(input.workspaceRoot, input.skillId);
-		const receipt = receiptInput(
-			input.managedResourceRoot,
-			input.workspaceRoot,
-			input.skillId,
-			input.ownershipIdentity,
-		);
-		const receiptState = managedSkillReceiptIdentityState(receipt);
-		if (receiptState === "absent") {
-			rmSync(receipt.path, { force: true });
-			return "absent";
-		}
-		if (receiptState === "unsafe") {
-			throw new Error("refusing manifest cleanup because the OpenClaw Skill tree is unsafe");
-		}
-		if (receiptState !== "matched")
-			throw new Error(
-				"refusing manifest cleanup because OpenClaw Skill bytes no longer match the ownership receipt",
-			);
-		withRuntimeUserFileAccess(() => {
-			rmSync(target, { recursive: true });
-		});
-		rmSync(receipt.path, { force: true });
-		return "removed";
 	},
 };

--- a/packages/cli/src/runtime/hosted-sourced-skill-archive.ts
+++ b/packages/cli/src/runtime/hosted-sourced-skill-archive.ts
@@ -37,9 +37,9 @@ export interface PreparedHostedSourcedSkill {
 	source:
 		| HostedSkillSource
 		| { type: "bundled"; version: number; digest: string; assetDirectory: string };
-	/** Stable canonical ownership identity; independent of tar encoding and cache lifetime. */
+	/** Canonical manifest source identity persisted in sourced Skill reservations. */
 	sourceIdentity: string;
-	/** Byte hash used only to detect corruption in the local archive cache. */
+	/** SHA-256 of tarBytes; also the sourced Skill reservation payload digest. */
 	archiveSha256: string;
 	tarBytes: Buffer;
 }

--- a/packages/cli/src/runtime/managed-skill-delivery.test.ts
+++ b/packages/cli/src/runtime/managed-skill-delivery.test.ts
@@ -1,21 +1,8 @@
 import { expect, test } from "bun:test";
-import {
-	existsSync,
-	mkdirSync,
-	mkdtempSync,
-	readFileSync,
-	renameSync,
-	rmSync,
-	symlinkSync,
-	writeFileSync,
-} from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-	collectManagedSkillTree,
-	managedSkillReceiptMatchesIdentity,
-	withManagedTargetRollback,
-} from "./managed-skill-delivery";
+import { collectManagedSkillTree, withManagedTargetRollback } from "./managed-skill-delivery";
 
 test("distinguishes an absent Skill tree from an unsafe tree", () => {
 	const root = mkdtempSync(join(tmpdir(), "managed-skill-collection-"));
@@ -31,83 +18,19 @@ test("distinguishes an absent Skill tree from an unsafe tree", () => {
 	}
 });
 
-test("restores an already-backed-up target when receipt backup establishment fails", () => {
-	const root = mkdtempSync(join(tmpdir(), "managed-skill-rollback-"));
-	try {
-		const target = join(root, "skills", "review-pr");
-		const receipt = join(root, "receipts", "review-pr.json");
-		mkdirSync(target, { recursive: true });
-		mkdirSync(join(root, "receipts"), { recursive: true });
-		writeFileSync(join(target, "SKILL.md"), "owned\n");
-		writeFileSync(receipt, "receipt\n");
-		let calls = 0;
-		expect(() =>
-			withManagedTargetRollback({
-				target,
-				receipt,
-				operation: () => {
-					throw new Error("must not run");
-				},
-				rename: (from, to) => {
-					calls += 1;
-					if (calls === 2) throw new Error("injected receipt backup failure");
-					renameSync(from, to);
-				},
-			}),
-		).toThrow("injected receipt backup failure");
-		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("owned\n");
-		expect(readFileSync(receipt, "utf8")).toBe("receipt\n");
-		expect(existsSync(target)).toBe(true);
-	} finally {
-		rmSync(root, { recursive: true, force: true });
-	}
-});
-
-test("never treats a null fingerprint as ownership of an absent target", () => {
-	const root = mkdtempSync(join(tmpdir(), "managed-skill-receipt-"));
-	try {
-		const receipt = join(root, "review-pr.json");
-		writeFileSync(
-			receipt,
-			JSON.stringify({
-				schemaVersion: "test.receipt.v2",
-				skillId: "review-pr",
-				ownershipIdentity: "github\0review-pr",
-				treeFingerprint: null,
-			}),
-		);
-		expect(
-			managedSkillReceiptMatchesIdentity({
-				path: receipt,
-				schemaVersion: "test.receipt.v2",
-				skillId: "review-pr",
-				ownershipIdentity: "github\0review-pr",
-				target: join(root, "absent-target"),
-			}),
-		).toBe(false);
-	} finally {
-		rmSync(root, { recursive: true, force: true });
-	}
-});
-
 test("treats backup cleanup failure as GC after the operation commits", () => {
 	const root = mkdtempSync(join(tmpdir(), "managed-skill-commit-"));
 	try {
 		const target = join(root, "skills", "review-pr");
-		const receipt = join(root, "receipts", "review-pr.json");
 		mkdirSync(target, { recursive: true });
-		mkdirSync(join(root, "receipts"), { recursive: true });
 		writeFileSync(join(target, "SKILL.md"), "previous\n");
-		writeFileSync(receipt, "previous receipt\n");
 
 		expect(
 			withManagedTargetRollback({
 				target,
-				receipt,
 				operation: () => {
 					mkdirSync(target, { recursive: true });
 					writeFileSync(join(target, "SKILL.md"), "committed\n");
-					writeFileSync(receipt, "committed receipt\n");
 					return "installed" as const;
 				},
 				remove: () => {
@@ -116,7 +39,6 @@ test("treats backup cleanup failure as GC after the operation commits", () => {
 			}),
 		).toBe("installed");
 		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("committed\n");
-		expect(readFileSync(receipt, "utf8")).toBe("committed receipt\n");
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}

--- a/packages/cli/src/runtime/managed-skill-delivery.ts
+++ b/packages/cli/src/runtime/managed-skill-delivery.ts
@@ -2,13 +2,9 @@ import { spawnSync } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import {
 	chmodSync,
-	closeSync,
-	constants,
 	existsSync,
-	fstatSync,
 	lstatSync,
 	mkdtempSync,
-	openSync,
 	readdirSync,
 	readFileSync,
 	renameSync,
@@ -16,7 +12,6 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
-import { writePrivateFileAtomic } from "../lib/private-file";
 import { managedSkillDirectoryDigest } from "./hosted-bundled-skill";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import { withRuntimeUserFileAccess } from "./runtime-user-command";
@@ -24,29 +19,8 @@ import { withRuntimeUserFileAccess } from "./runtime-user-command";
 const MAX_ENTRIES = 1024;
 const MAX_FILE_BYTES = 16 * 1024 * 1024;
 const MAX_TREE_BYTES = 32 * 1024 * 1024;
-const MANAGED_SKILL_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
-const PLATFORM_RECEIPT_DIRECTORY = "skill-receipts";
-
-export const HERMES_MANAGED_SKILL_RECEIPT_SCHEMA = "clawdi.hermesManifestSkillReceipt.v2";
-export const OPENCLAW_MANAGED_SKILL_RECEIPT_SCHEMA = "clawdi.openclawManifestSkillReceipt.v2";
-export type ManagedSkillReceiptRuntime = "hermes" | "openclaw";
 
 export class ManagedSkillResourceError extends Error {}
-
-function assertManagedSkillId(skillId: string): void {
-	if (!MANAGED_SKILL_ID_PATTERN.test(skillId)) {
-		throw new Error(`invalid managed Skill id: ${skillId}`);
-	}
-}
-
-export function managedSkillReceiptPath(
-	managedResourceRoot: string,
-	runtime: ManagedSkillReceiptRuntime,
-	skillId: string,
-): string {
-	assertManagedSkillId(skillId);
-	return join(managedResourceRoot, PLATFORM_RECEIPT_DIRECTORY, runtime, `${skillId}.json`);
-}
 
 export type ManagedSkillTree = ReadonlyMap<string, Buffer>;
 
@@ -111,182 +85,24 @@ export function collectRuntimeUserManagedSkillTree(
 	return withRuntimeUserFileAccess(() => collectManagedSkillTree(root, options));
 }
 
-export function managedSkillTreeFingerprint(tree: ManagedSkillTree): string {
-	const hash = createHash("sha256");
-	for (const [name, bytes] of [...tree].sort(([left], [right]) => left.localeCompare(right)))
-		hash.update(name).update("\0").update(bytes).update("\0");
-	return hash.digest("hex");
-}
-
 export function managedSkillTreesEqual(left: ManagedSkillTree, right: ManagedSkillTree): boolean {
 	if (left.size !== right.size) return false;
 	for (const [name, bytes] of left) if (!right.get(name)?.equals(bytes)) return false;
 	return true;
 }
 
-type ManagedSkillReceipt = {
-	schemaVersion: string;
-	skillId: string;
-	ownershipIdentity: string;
-	treeFingerprint: string;
-};
-
-export function writeManagedSkillReceipt(input: {
-	path: string;
-	managedResourceRoot: string;
-	schemaVersion: string;
-	skillId: string;
-	ownershipIdentity: string;
-	target: string;
-	exclude?: ReadonlySet<string>;
-}): void {
-	const collection = collectRuntimeUserManagedSkillTree(input.target, { exclude: input.exclude });
-	if (collection.status !== "collected") {
-		throw new ManagedSkillResourceError(`installed Skill tree is ${collection.status}`);
-	}
-	const treeFingerprint = managedSkillTreeFingerprint(collection.tree);
-	writeManagedSkillReceiptRecord(input.managedResourceRoot, input.path, {
-		schemaVersion: input.schemaVersion,
-		skillId: input.skillId,
-		ownershipIdentity: input.ownershipIdentity,
-		treeFingerprint,
-	});
-}
-
-function writeManagedSkillReceiptRecord(
-	managedResourceRoot: string,
-	path: string,
-	receipt: ManagedSkillReceipt,
-): void {
-	writePrivateFileAtomic(path, `${JSON.stringify(receipt)}\n`, {
-		mode: 0o600,
-		dirMode: 0o700,
-		trustedRoot: managedResourceRoot,
-	});
-}
-
-function runtimeUserTargetIsDirectory(path: string): boolean {
-	return withRuntimeUserFileAccess(() => {
-		try {
-			const target = lstatSync(path);
-			return !target.isSymbolicLink() && target.isDirectory();
-		} catch {
-			return false;
-		}
-	});
-}
-
-function readManagedSkillMarkerRaw(input: {
-	path: string;
-	schemaVersion: string;
-	skillId: string;
-	target: string;
-	exclude?: ReadonlySet<string>;
-}): ManagedSkillReceipt | null {
-	let descriptor: number | null = null;
-	try {
-		descriptor = openSync(input.path, constants.O_RDONLY | constants.O_NOFOLLOW);
-		const receiptStat = fstatSync(descriptor);
-		const effectiveUid = process.geteuid?.();
-		if (
-			!receiptStat.isFile() ||
-			(receiptStat.mode & 0o022) !== 0 ||
-			(effectiveUid !== undefined && receiptStat.uid !== effectiveUid)
-		)
-			return null;
-		const receipt = JSON.parse(readFileSync(descriptor, "utf8")) as Record<string, unknown>;
-		if (
-			receipt.schemaVersion === input.schemaVersion &&
-			receipt.skillId === input.skillId &&
-			typeof receipt.ownershipIdentity === "string" &&
-			receipt.ownershipIdentity.length > 0 &&
-			receipt.ownershipIdentity.length <= 2048 &&
-			typeof receipt.treeFingerprint === "string" &&
-			/^[a-f0-9]{64}$/.test(receipt.treeFingerprint)
-		)
-			return receipt as ManagedSkillReceipt;
-		return null;
-	} catch {
-		return null;
-	} finally {
-		if (descriptor !== null) closeSync(descriptor);
-	}
-}
-
-function readManagedSkillMarker(input: {
-	path: string;
-	schemaVersion: string;
-	skillId: string;
-	target: string;
-	exclude?: ReadonlySet<string>;
-}): ManagedSkillReceipt | null {
-	if (!runtimeUserTargetIsDirectory(input.target)) return null;
-	return readManagedSkillMarkerRaw(input);
-}
-
-function readManagedSkillReceipt(input: {
-	path: string;
-	schemaVersion: string;
-	skillId: string;
-	target: string;
-	exclude?: ReadonlySet<string>;
-}):
-	| { status: "matched"; receipt: ManagedSkillReceipt }
-	| { status: "absent" | "unsafe" | "mismatch" } {
-	const collection = collectRuntimeUserManagedSkillTree(input.target, {
-		exclude: input.exclude,
-	});
-	if (collection.status !== "collected") return collection;
-	const marker = readManagedSkillMarkerRaw(input);
-	if (!marker || marker.treeFingerprint !== managedSkillTreeFingerprint(collection.tree)) {
-		return { status: "mismatch" };
-	}
-	return { status: "matched", receipt: marker };
-}
-
-export function managedSkillMarkerOwnsTarget(input: {
-	path: string;
-	schemaVersion: string;
-	skillId: string;
-	target: string;
-	exclude?: ReadonlySet<string>;
-}): boolean {
-	return readManagedSkillMarker(input) !== null;
-}
-
-export function managedSkillMarkerMatchesIdentity(input: {
-	path: string;
-	schemaVersion: string;
-	skillId: string;
-	ownershipIdentity: string;
-	target: string;
-	exclude?: ReadonlySet<string>;
-}): boolean {
-	return readManagedSkillMarker(input)?.ownershipIdentity === input.ownershipIdentity;
-}
-
-export function managedSkillReceiptMatchesIdentity(input: {
-	path: string;
-	schemaVersion: string;
-	skillId: string;
-	ownershipIdentity: string;
-	target: string;
-	exclude?: ReadonlySet<string>;
-}): boolean {
-	return managedSkillReceiptIdentityState(input) === "matched";
-}
-
-export function managedSkillReceiptIdentityState(input: {
-	path: string;
-	schemaVersion: string;
-	skillId: string;
-	ownershipIdentity: string;
-	target: string;
-	exclude?: ReadonlySet<string>;
-}): "matched" | "absent" | "unsafe" | "mismatch" {
-	const result = readManagedSkillReceipt(input);
-	if (result.status !== "matched") return result.status;
-	return result.receipt.ownershipIdentity === input.ownershipIdentity ? "matched" : "mismatch";
+export function managedSkillTargetMatchesSource(
+	sourceDir: string,
+	targetDir: string,
+	options: { exclude?: ReadonlySet<string> } = {},
+): boolean {
+	const source = collectManagedSkillTree(sourceDir);
+	const installed = collectRuntimeUserManagedSkillTree(targetDir, options);
+	return (
+		source.status === "collected" &&
+		installed.status === "collected" &&
+		managedSkillTreesEqual(source.tree, installed.tree)
+	);
 }
 
 export function withStagedManagedSkill<T>(
@@ -331,9 +147,18 @@ export function withStagedManagedSkill<T>(
 	}
 }
 
+export function installedTreeMatches(
+	skill: PreparedHostedSourcedSkill,
+	targetDir: string,
+	options: { exclude?: ReadonlySet<string> } = {},
+): boolean {
+	return withStagedManagedSkill(skill, (sourceDir) =>
+		managedSkillTargetMatchesSource(sourceDir, targetDir, options),
+	);
+}
+
 export function withManagedTargetRollback<T>(input: {
 	target: string;
-	receipt?: string;
 	operation: () => T;
 	targetBackup?: string;
 	beforeRestore?: () => void;
@@ -348,24 +173,14 @@ export function withManagedTargetRollback<T>(input: {
 	const targetBackup =
 		input.targetBackup ??
 		join(dirname(input.target), `.${basename(input.target)}-clawdi-rollback-${suffix}`);
-	const receiptBackup = input.receipt
-		? join(dirname(input.receipt), `.${basename(input.receipt)}-clawdi-rollback-${suffix}`)
-		: undefined;
 	const hadTarget = withRuntimeUserFileAccess(() => existsSync(input.target));
-	const hadReceipt = input.receipt !== undefined && existsSync(input.receipt);
 	let targetMoved = false;
-	let receiptMoved = false;
 	try {
 		if (hadTarget) {
 			withRuntimeUserFileAccess(() => rename(input.target, targetBackup));
 			targetMoved = true;
 		}
-		if (hadReceipt && input.receipt && receiptBackup) {
-			rename(input.receipt, receiptBackup);
-			receiptMoved = true;
-		}
 	} catch (error) {
-		if (receiptMoved && input.receipt && receiptBackup) rename(receiptBackup, input.receipt);
 		if (targetMoved) withRuntimeUserFileAccess(() => rename(targetBackup, input.target));
 		throw error;
 	}
@@ -374,13 +189,11 @@ export function withManagedTargetRollback<T>(input: {
 		result = input.operation();
 	} catch (error) {
 		withRuntimeUserFileAccess(() => remove(input.target, { recursive: true, force: true }));
-		if (input.receipt) remove(input.receipt, { force: true });
 		try {
 			if (hadTarget) {
 				input.beforeRestore?.();
 				withRuntimeUserFileAccess(() => rename(targetBackup, input.target));
 			}
-			if (hadReceipt && input.receipt && receiptBackup) rename(receiptBackup, input.receipt);
 		} catch (restoreError) {
 			if (input.restoreFailure) throw input.restoreFailure(error, restoreError);
 			throw restoreError;
@@ -388,11 +201,10 @@ export function withManagedTargetRollback<T>(input: {
 		throw error;
 	}
 	// The operation returning is the commit point. Backup cleanup is GC and
-	// must never roll back a live target or its ownership receipt.
+	// must never roll back a live target.
 	try {
 		if (hadTarget) input.beforeCleanup?.();
 		withRuntimeUserFileAccess(() => remove(targetBackup, { recursive: true, force: true }));
-		if (receiptBackup) remove(receiptBackup, { force: true });
 	} catch {}
 	return result;
 }

--- a/packages/cli/src/runtime/managed-skill-reservation.test.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.test.ts
@@ -151,6 +151,15 @@ describe("managed Skill reservations", () => {
 				digest: "not-a-sha256",
 			}),
 		).toThrow("identity is invalid");
+		expect(() =>
+			reserveManagedSkill({
+				targetDir: path,
+				id: "example",
+				manager: "hosted-manifest",
+				digest: "c".repeat(64),
+				sourceIdentity: "invalid",
+			}),
+		).toThrow("identity is invalid");
 		expect(managedSkillReservationState(path, "example")).toBe("unreserved");
 	});
 

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -51,6 +51,7 @@ interface ManagedSkillReservation {
 	target: string;
 	id: string;
 	version?: number;
+	/** Hosted archive SHA-256 after convergence, or a local-setup directory digest. */
 	digest?: string;
 	sourceIdentity?: string;
 	manager: ManagedSkillReservationManager;
@@ -303,13 +304,19 @@ export function pendingManagedSkillReservations(
 function reservationIdentityIsValid(value: {
 	digest?: unknown;
 	sourceIdentity?: unknown;
+	manager?: unknown;
 }): boolean {
 	const hasDigest = typeof value.digest === "string" && SHA256_PATTERN.test(value.digest);
+	const hasInvalidDigest = value.digest !== undefined && !hasDigest;
 	const hasSourceIdentity =
 		typeof value.sourceIdentity === "string" &&
 		(value.sourceIdentity.startsWith("github\0") || value.sourceIdentity.startsWith("project\0")) &&
 		value.sourceIdentity.length <= 2048;
-	return hasDigest !== hasSourceIdentity;
+	const hasInvalidSourceIdentity = value.sourceIdentity !== undefined && !hasSourceIdentity;
+	if (hasInvalidDigest || hasInvalidSourceIdentity) return false;
+	return value.manager === "local-setup"
+		? hasDigest && !hasSourceIdentity
+		: hasDigest || hasSourceIdentity;
 }
 
 function reservationMatches(
@@ -619,7 +626,6 @@ export function replaceManagedSkillDirectoryAtomic(
 		withRuntimeUserFileAccess(() => cpSync(sourceDir, stagedTarget, { recursive: true }));
 		withManagedTargetRollback({
 			target: targetDir,
-			receipt: options.receipt,
 			targetBackup: previousTarget,
 			beforeRestore: options.beforeRestore,
 			beforeCleanup: options.beforeCleanup,
@@ -647,7 +653,6 @@ export function replaceManagedSkillDirectoryAtomic(
 }
 
 export interface ManagedSkillDirectoryActivationOptions {
-	receipt?: string;
 	beforeActivate?: () => void;
 	afterActivate?: () => void;
 	beforeRestore?: () => void;

--- a/packages/cli/src/runtime/manifest-channels.test.ts
+++ b/packages/cli/src/runtime/manifest-channels.test.ts
@@ -16,6 +16,7 @@ import { dirname, join } from "node:path";
 import {
 	managedWhatsAppAuthReceiptPath,
 	materializeHostedChannelCredentials,
+	validateHostedChannelCredentialsPlan,
 } from "./manifest-channels";
 import type { RuntimeManifest } from "./manifest-contract";
 import { withRuntimeUserFileAccess } from "./runtime-user-command";
@@ -129,17 +130,33 @@ describe("managed WhatsApp auth receipts", () => {
 		expect(existsSync(receipt)).toBe(false);
 	});
 
-	test("rejects a legacy tree marker without a platform receipt", () => {
+	test("adopts a 0.13.92 tree marker without replacing session state", () => {
 		const path = authDir();
 		mkdirSync(path, { recursive: true });
+		const sessionPath = join(path, "session-key.json");
 		writeFileSync(join(path, "creds.json"), `${credsJson("legacy-secret")}\n`);
+		writeFileSync(sessionPath, '{"preserved":true}\n');
 		writeFileSync(join(path, LEGACY_MARKER), legacyMarker());
+		const sessionBefore = { bytes: readFileSync(sessionPath), inode: statSync(sessionPath).ino };
+		const desired = manifest(path);
 
-		expect(() =>
-			materializeHostedChannelCredentials(manifest(path), { [SECRET_REF]: credsJson() }, home),
-		).toThrow(`refusing to overwrite unmanaged WhatsApp auth directory ${path}`);
-		expect(readdirSync(path).sort()).toEqual([LEGACY_MARKER, "creds.json"]);
+		validateHostedChannelCredentialsPlan(
+			desired,
+			{ [SECRET_REF]: credsJson("legacy-secret") },
+			home,
+		);
+		expect(existsSync(join(path, LEGACY_MARKER))).toBe(true);
 		expect(existsSync(managedWhatsAppAuthReceiptPath(path))).toBe(false);
+
+		materializeHostedChannelCredentials(
+			desired,
+			{ [SECRET_REF]: credsJson("legacy-secret") },
+			home,
+		);
+		expect(existsSync(join(path, LEGACY_MARKER))).toBe(false);
+		expect(existsSync(managedWhatsAppAuthReceiptPath(path))).toBe(true);
+		expect(readFileSync(sessionPath)).toEqual(sessionBefore.bytes);
+		expect(statSync(sessionPath).ino).toBe(sessionBefore.inode);
 	});
 
 	test("does not adopt missing or malformed ownership state", () => {

--- a/packages/cli/src/runtime/manifest-channels.ts
+++ b/packages/cli/src/runtime/manifest-channels.ts
@@ -1,5 +1,15 @@
 import { createHash } from "node:crypto";
-import { existsSync, lstatSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import {
+	closeSync,
+	constants,
+	existsSync,
+	fstatSync,
+	lstatSync,
+	openSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+} from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import type { z } from "zod";
 import { writePrivateFileAtomic } from "../lib/private-file";
@@ -31,6 +41,7 @@ import {
 	runRuntimeUserCommand,
 	runtimeUserDirectoryOwnership,
 	spawnRuntimeUserCommand,
+	withRuntimeUserFileAccess,
 } from "./runtime-user-command";
 import { normalizeSecretValues, runtimeSecretValue } from "./secret-values";
 import { writeRuntimePlatformFileAtomic } from "./state";
@@ -46,6 +57,8 @@ import {
 const MANAGED_WHATSAPP_AUTH_MARKER_SCHEMA = "clawdi.managedWhatsAppAuth.v1";
 const MANAGED_WHATSAPP_AUTH_RECEIPT_SCHEMA = "clawdi.managedWhatsAppAuthReceipt.v1";
 const MANAGED_WHATSAPP_AUTH_RECEIPT_DIRECTORY = "whatsapp-auth";
+// SUNSET: remove once the whole fleet has converged on 0.14.14+ once.
+const LEGACY_MANAGED_WHATSAPP_AUTH_MARKER = ".clawdi-managed-whatsapp-auth.json";
 export function materializeHostedChannelCredentials(
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
@@ -201,6 +214,7 @@ function materializeManagedWhatsAppAuthDir(
 		accountKey: credential.accountKey,
 		credentialId: credential.credentialId,
 	});
+	rmSync(join(credential.authDir, LEGACY_MANAGED_WHATSAPP_AUTH_MARKER), { force: true });
 }
 function assertManagedWhatsAppMetadata(
 	creds: Record<string, unknown>,
@@ -261,6 +275,11 @@ interface ManagedWhatsAppAuthMarker {
 interface ManagedWhatsAppAuthReceiptInspection {
 	exists: boolean;
 	marker: ManagedWhatsAppAuthMarker | null;
+}
+
+interface ManagedWhatsAppAuthFileInspection {
+	exists: boolean;
+	value: unknown;
 }
 
 function isMissingFile(error: unknown): boolean {
@@ -333,47 +352,49 @@ function parseManagedWhatsAppAuthMarker(value: unknown): ManagedWhatsAppAuthMark
 	};
 }
 
-function inspectManagedWhatsAppAuthReceipt(authDir: string): ManagedWhatsAppAuthReceiptInspection {
-	const path = managedWhatsAppAuthReceiptPath(authDir);
-	let node: ReturnType<typeof lstatSync>;
+function inspectManagedWhatsAppAuthFile(path: string): ManagedWhatsAppAuthFileInspection {
+	let descriptor: number | null = null;
 	try {
-		node = lstatSync(path);
-	} catch (error) {
-		return { exists: !isMissingFile(error), marker: null };
-	}
-	const platformUid = process.getuid?.();
-	if (
-		node.isSymbolicLink() ||
-		!node.isFile() ||
-		(node.mode & 0o022) !== 0 ||
-		(platformUid !== undefined && node.uid !== platformUid)
-	) {
-		return { exists: true, marker: null };
-	}
-	try {
-		const record = recordValue(JSON.parse(readFileSync(path, "utf-8")) as unknown);
-		const marker = parseManagedWhatsAppAuthMarker(
-			record
-				? {
-						schemaVersion: record.markerSchemaVersion,
-						provider: record.provider,
-						target: record.target,
-						accountKey: record.accountKey,
-						credentialId: record.credentialId,
-					}
-				: null,
-		);
+		descriptor = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+		const node = fstatSync(descriptor);
+		const effectiveUid = process.geteuid?.();
 		if (
-			record?.schemaVersion !== MANAGED_WHATSAPP_AUTH_RECEIPT_SCHEMA ||
-			record.authDir !== resolve(authDir) ||
-			!marker
+			!node.isFile() ||
+			(node.mode & 0o022) !== 0 ||
+			(effectiveUid !== undefined && node.uid !== effectiveUid)
 		) {
-			return { exists: true, marker: null };
+			return { exists: true, value: null };
 		}
-		return { exists: true, marker };
-	} catch {
-		return { exists: true, marker: null };
+		return { exists: true, value: JSON.parse(readFileSync(descriptor, "utf8")) as unknown };
+	} catch (error) {
+		return { exists: !isMissingFile(error), value: null };
+	} finally {
+		if (descriptor !== null) closeSync(descriptor);
 	}
+}
+
+function inspectManagedWhatsAppAuthReceipt(authDir: string): ManagedWhatsAppAuthReceiptInspection {
+	const file = inspectManagedWhatsAppAuthFile(managedWhatsAppAuthReceiptPath(authDir));
+	const record = recordValue(file.value);
+	const marker = parseManagedWhatsAppAuthMarker(
+		record
+			? {
+					schemaVersion: record.markerSchemaVersion,
+					provider: record.provider,
+					target: record.target,
+					accountKey: record.accountKey,
+					credentialId: record.credentialId,
+				}
+			: null,
+	);
+	if (
+		record?.schemaVersion !== MANAGED_WHATSAPP_AUTH_RECEIPT_SCHEMA ||
+		record.authDir !== resolve(authDir) ||
+		!marker
+	) {
+		return { exists: file.exists, marker: null };
+	}
+	return { exists: true, marker };
 }
 
 function writeManagedWhatsAppAuthReceipt(authDir: string, marker: ManagedWhatsAppAuthMarker): void {
@@ -417,10 +438,15 @@ function removeManagedWhatsAppAuthReceipt(authDir: string): void {
 }
 
 export function readManagedWhatsAppAuthMarker(authDir: string): ManagedWhatsAppAuthMarker | null {
-	return withManagedWhatsAppReceiptAccess(() => {
-		const receipt = inspectManagedWhatsAppAuthReceipt(authDir);
-		return receipt.marker;
-	});
+	const receipt = withManagedWhatsAppReceiptAccess(() =>
+		inspectManagedWhatsAppAuthReceipt(authDir),
+	);
+	if (receipt.exists) return receipt.marker;
+	return withRuntimeUserFileAccess(() =>
+		parseManagedWhatsAppAuthMarker(
+			inspectManagedWhatsAppAuthFile(join(authDir, LEGACY_MANAGED_WHATSAPP_AUTH_MARKER)).value,
+		),
+	);
 }
 
 function removeManagedWhatsAppAuthDir(authDir: string): void {

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -1092,25 +1092,21 @@ function applyRuntimeResourceProjections(
 				manifest,
 				projectionHome,
 				plan.openClawWorkspaceRoot,
-				paths.managedResourceRoot,
 				preparedHostedSourcedSkills,
 				hermesSkillNativeReconciler,
 			);
 			skillProjectionScope = state.rollbackSnapshots.captureScoped(
 				"runtime Skill filesystem rollback failed",
 				{
-					rootTargets: [
-						managedSkillReservationLedgerPath(),
-						...skillMutationTargets.platformTargets,
-					],
+					rootTargets: [managedSkillReservationLedgerPath()],
 					trustedRootDirectories: [paths.managedResourceRoot],
-					runtimeUserTargets: skillMutationTargets.runtimeUserTargets,
+					runtimeUserTargets: skillMutationTargets,
 					runtimeUserTrustedRoots: [paths.userHome, paths.clawdiHome],
 					runtimeUserSymlinkTargets: [],
-					metadataTargets: mutationAncestorMetadataTargets(
-						skillMutationTargets.runtimeUserTargets,
-						[paths.userHome, paths.clawdiHome],
-					),
+					metadataTargets: mutationAncestorMetadataTargets(skillMutationTargets, [
+						paths.userHome,
+						paths.clawdiHome,
+					]),
 				},
 			);
 			state.resourceProjectionErrors.push(

--- a/packages/cli/src/runtime/manifest-planning.ts
+++ b/packages/cli/src/runtime/manifest-planning.ts
@@ -41,7 +41,7 @@ import {
 	managedBaileysCompatSnapshotRuntimes,
 } from "./managed-baileys-compat";
 import { buildHermesManagedChannelsPatch } from "./managed-channel-reconciliation";
-import { ManagedSkillResourceError, managedSkillReceiptPath } from "./managed-skill-delivery";
+import { ManagedSkillResourceError } from "./managed-skill-delivery";
 import { managedSkillReservations } from "./managed-skill-reservation";
 import {
 	hostedChannelCredentialsDeclared,
@@ -671,22 +671,19 @@ export function hostedSkillMutationTargets(
 	manifest: RuntimeManifest,
 	home: string,
 	openClawWorkspaceRoot: string | null,
-	managedResourceRoot: string,
 	preparedSourcedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
 	hermesDriver: HostedHermesSkillExactSourceDriver,
-): { platformTargets: string[]; runtimeUserTargets: string[] } {
+): string[] {
 	const runtimeUserTargets = new Set<string>();
-	const platformTargets = new Set<string>();
 	const hermesSkillsRoot = join(home, ".hermes", "skills");
 	const openClawSkillsRoot = openClawWorkspaceRoot ? join(openClawWorkspaceRoot, "skills") : null;
-	const addSkillTargets = (runtime: "hermes" | "openclaw", skillsRoot: string, skillId: string) => {
+	const addSkillTarget = (skillsRoot: string, skillId: string) => {
 		runtimeUserTargets.add(join(skillsRoot, skillId));
-		platformTargets.add(managedSkillReceiptPath(managedResourceRoot, runtime, skillId));
 	};
 	let managesHermesSourcedSkill = false;
 	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
-		addSkillTargets("hermes", hermesSkillsRoot, skillId);
-		if (openClawSkillsRoot) addSkillTargets("openclaw", openClawSkillsRoot, skillId);
+		addSkillTarget(hermesSkillsRoot, skillId);
+		if (openClawSkillsRoot) addSkillTarget(openClawSkillsRoot, skillId);
 		if ("source" in desired && manifest.runtimes.hermes?.enabled === true) {
 			managesHermesSourcedSkill = true;
 			const prepared = preparedSourcedSkills.get(skillId);
@@ -702,25 +699,20 @@ export function hostedSkillMutationTargets(
 		}
 	}
 	for (const skillId of hostedBundledSkillIds()) {
-		addSkillTargets("hermes", hermesSkillsRoot, skillId);
-		if (openClawSkillsRoot) addSkillTargets("openclaw", openClawSkillsRoot, skillId);
+		addSkillTarget(hermesSkillsRoot, skillId);
+		if (openClawSkillsRoot) addSkillTarget(openClawSkillsRoot, skillId);
 	}
 	for (const reservation of managedSkillReservations("hosted-manifest")) {
 		if (dirname(reservation.targetDir) === hermesSkillsRoot) {
 			if (reservation.sourceIdentity) managesHermesSourcedSkill = true;
 			runtimeUserTargets.add(reservation.targetDir);
-			platformTargets.add(managedSkillReceiptPath(managedResourceRoot, "hermes", reservation.id));
 		}
 		if (openClawSkillsRoot && dirname(reservation.targetDir) === openClawSkillsRoot) {
 			runtimeUserTargets.add(reservation.targetDir);
-			platformTargets.add(managedSkillReceiptPath(managedResourceRoot, "openclaw", reservation.id));
 		}
 	}
 	if (managesHermesSourcedSkill) runtimeUserTargets.add(join(hermesSkillsRoot, ".hub"));
-	return {
-		platformTargets: [...platformTargets].sort(),
-		runtimeUserTargets: [...runtimeUserTargets].sort(),
-	};
+	return [...runtimeUserTargets].sort();
 }
 export function runtimeManagedMutationPlan(input: {
 	manifest: RuntimeManifest;

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -55,13 +55,7 @@ import {
 	restoreRuntimeLiveSnapshot,
 	runtimeRootLiveMutationTargets,
 } from "./live-state-snapshot";
-import {
-	collectRuntimeUserManagedSkillTree,
-	ManagedSkillResourceError,
-	managedSkillReceiptPath,
-	managedSkillTreeFingerprint,
-	writeManagedSkillReceipt,
-} from "./managed-skill-delivery";
+import { ManagedSkillResourceError } from "./managed-skill-delivery";
 import {
 	managedSkillReservationLedgerPath,
 	managedSkillReservationState,
@@ -92,6 +86,7 @@ import {
 import {
 	AGENT_PLUGINS_SCHEMA_1_0_0,
 	type HostedAgentPluginsDesiredState,
+	type HostedSkillSource,
 } from "./manifest-resources";
 import {
 	hostedManifestToRuntimeManifest,
@@ -102,7 +97,6 @@ import {
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
 import { planRuntimeMutationSystemdUserUnits } from "./runtime-systemd-reconciliation";
-import { withRuntimeUserFileAccess } from "./runtime-user-command";
 import {
 	canonicalSecretRefSchema,
 	normalizeSecretValues,
@@ -276,6 +270,33 @@ function tempRuntimePaths(): RuntimePaths {
 	process.env.CLAWDI_HOME = join(root, "clawdi-home");
 	process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
 	return getRuntimePaths({ mode: "hosted" });
+}
+
+function preparedTestSourcedSkill(
+	skillId: string,
+	source: HostedSkillSource,
+	skillMd: string,
+): PreparedHostedSourcedSkill {
+	const fixtureRoot = mkdtempSync(join(tmpdir(), "clawdi-prepared-skill-test-"));
+	tempRoots.push(fixtureRoot);
+	const sourceRoot = join(fixtureRoot, "source");
+	const sourceDir = join(sourceRoot, skillId);
+	mkdirSync(sourceDir, { recursive: true });
+	writeFileSync(join(sourceDir, "SKILL.md"), skillMd);
+	const archive = join(fixtureRoot, "skill.tar.gz");
+	execFileSync("tar", ["-czf", archive, "-C", sourceRoot, skillId]);
+	const tarBytes = readFileSync(archive);
+	const sourceIdentity =
+		source.type === "github"
+			? ["github", skillId, source.url, source.path, source.commit].join("\0")
+			: ["project", skillId, source.projectId, source.contentHash].join("\0");
+	return {
+		skillId,
+		source,
+		sourceIdentity,
+		archiveSha256: createHash("sha256").update(tarBytes).digest("hex"),
+		tarBytes,
+	};
 }
 
 function convergeRuntimeManifest(
@@ -4264,22 +4285,88 @@ echo spawned > '${installerLog}'
 		expect(existsSync(join(paths.userHome, ".local", "bin", "openclaw"))).toBe(false);
 	});
 
-	test("rejects a legacy Hermes bundle marker without reservation-backed ownership", () => {
+	test("reconciles 0.13.92 Skill trees from ledger-backed ownership", () => {
 		const paths = tempRuntimePaths();
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		ensureRuntimeStateDirs(paths);
+		const runningAsRoot = process.geteuid?.() === 0;
+		const runtimeUser = runningAsRoot ? "nobody" : TEST_RUNTIME_USER;
+		const runtimeUid = runningAsRoot
+			? Number.parseInt(execFileSync("id", ["-u", runtimeUser], { encoding: "utf8" }).trim(), 10)
+			: TEST_PROCESS_UID;
+		const runtimeGid = runningAsRoot
+			? Number.parseInt(execFileSync("id", ["-g", runtimeUser], { encoding: "utf8" }).trim(), 10)
+			: TEST_PROCESS_GID;
+		process.env.CLAWDI_RUNTIME_USER = runtimeUser;
+		process.env.CLAWDI_RUNTIME_UID = String(runtimeUid);
+		process.env.CLAWDI_RUNTIME_GID = String(runtimeGid);
 		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
+		const openClawCommand = join(paths.userHome, ".local", "bin", "openclaw");
 		mkdirSync(dirname(hermesCommand), { recursive: true });
 		writeFileSync(hermesCommand, "#!/bin/sh\nexit 0\n");
 		chmodSync(hermesCommand, 0o755);
-		const source = resolve(import.meta.dir, "../..", "skills", "hosted-versions", "1", "clawdi");
-		const target = join(paths.userHome, ".hermes", "skills", "clawdi");
-		const skillPath = join(target, "SKILL.md");
+		writeFakeGatewayCli({
+			path: openClawCommand,
+			runtime: "openclaw",
+			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
+		});
+		if (runningAsRoot) {
+			chmodSync(dirname(paths.serviceStateRoot), 0o755);
+			for (const path of [
+				paths.userHome,
+				join(paths.userHome, ".local"),
+				dirname(hermesCommand),
+				hermesCommand,
+				openClawCommand,
+			]) {
+				chownSync(path, runtimeUid, runtimeGid);
+			}
+		}
+		const skillsRoot = join(paths.userHome, ".hermes", "skills");
+		const enabledTarget = join(skillsRoot, "clawdi");
+		const enabledSourcedId = "review-pr";
+		const disabledId = "disabled-review-pr";
+		const disabledTarget = join(skillsRoot, disabledId);
+		const legacyReceiptDirectory = join(skillsRoot, ".clawdi-manifest-receipts");
+		const openClawSkillsRoot = join(paths.userHome, ".openclaw", "workspace", "skills");
+		const openClawEnabledSourcedTarget = join(openClawSkillsRoot, enabledSourcedId);
+		const openClawLegacyReceiptDirectory = join(openClawSkillsRoot, ".clawdi-manifest-receipts");
+		const platformReceiptDirectory = join(paths.managedResourceRoot, "skill-receipts");
+		const bundledSource = resolve(
+			import.meta.dir,
+			"../..",
+			"skills",
+			"hosted-versions",
+			"1",
+			"clawdi",
+		);
 		const catalogEntry = resolveHostedBundledSkill("clawdi", 1);
-		cpSync(source, target, { recursive: true });
-		chmodSync(target, 0o755);
-		chmodSync(skillPath, 0o644);
+		const enabledSourcedSource = {
+			type: "github" as const,
+			url: "https://github.com/Clawdi-AI/store",
+			path: `skills/${enabledSourcedId}`,
+			commit: "b".repeat(40),
+		};
+		const enabledSourced = preparedTestSourcedSkill(
+			enabledSourcedId,
+			enabledSourcedSource,
+			"# Current Review PR\n",
+		);
+		const disabledSource = {
+			type: "github" as const,
+			url: "https://github.com/Clawdi-AI/store",
+			path: `skills/${disabledId}`,
+			commit: "a".repeat(40),
+		};
+		const disabledSourceIdentity = [
+			"github",
+			disabledId,
+			disabledSource.url,
+			disabledSource.path,
+			disabledSource.commit,
+		].join("\0");
+		cpSync(bundledSource, enabledTarget, { recursive: true });
 		writeFileSync(
-			join(target, ".clawdi-managed.json"),
+			join(enabledTarget, ".clawdi-managed.json"),
 			`${JSON.stringify({
 				schema: "clawdi.hostedBundledSkillMarker.v1",
 				owner: "clawdi runtime init",
@@ -4288,6 +4375,41 @@ echo spawned > '${installerLog}'
 				digest: catalogEntry.digest,
 			})}\n`,
 		);
+		mkdirSync(disabledTarget, { recursive: true });
+		writeFileSync(join(disabledTarget, "SKILL.md"), "# Review PR\n");
+		mkdirSync(openClawEnabledSourcedTarget, { recursive: true });
+		writeFileSync(join(openClawEnabledSourcedTarget, "SKILL.md"), "# Legacy Review PR\n");
+		mkdirSync(legacyReceiptDirectory, { recursive: true });
+		writeFileSync(
+			join(legacyReceiptDirectory, `${disabledId}.json`),
+			'{"schemaVersion":"clawdi.hermesManifestSkillReceipt.v2"}\n',
+		);
+		mkdirSync(openClawLegacyReceiptDirectory, { recursive: true });
+		writeFileSync(
+			join(openClawLegacyReceiptDirectory, `${enabledSourcedId}.json`),
+			'{"schemaVersion":"clawdi.openclawManifestSkillReceipt.v2"}\n',
+		);
+		mkdirSync(join(platformReceiptDirectory, "hermes"), { recursive: true });
+		writeFileSync(join(platformReceiptDirectory, "hermes", "clawdi.json"), "{}\n");
+		reserveManagedSkill({
+			targetDir: enabledTarget,
+			id: "clawdi",
+			manager: "hosted-manifest",
+			version: 1,
+			digest: catalogEntry.digest,
+		});
+		reserveManagedSkill({
+			targetDir: disabledTarget,
+			id: disabledId,
+			manager: "hosted-manifest",
+			sourceIdentity: disabledSourceIdentity,
+		});
+		reserveManagedSkill({
+			targetDir: openClawEnabledSourcedTarget,
+			id: enabledSourcedId,
+			manager: "hosted-manifest",
+			sourceIdentity: enabledSourced.sourceIdentity,
+		});
 		const manifest = baseManifest(
 			paths,
 			{
@@ -4296,173 +4418,59 @@ echo spawned > '${installerLog}'
 					run: runSettings(hermesCommand, ["gateway"]),
 					services: {},
 				},
-			},
-			{ projection: { skills: { entries: { clawdi: { enabled: true, version: 1 } } } } },
-		);
-		const marker = join(target, ".clawdi-managed.json");
-		const targetBefore = statSync(target).ino;
-		const skillBefore = readFileSync(skillPath);
-		const result = convergeRuntimeManifest(manifestLoad(manifest, "legacy-hermes-bundle"), paths);
-
-		expect(result.installErrors).toEqual([]);
-		expect(result.resourceProjectionErrors.join("\n")).toContain(
-			`refusing to replace unmanaged clawdi skill at ${target}`,
-		);
-		expect(statSync(target).ino).toBe(targetBefore);
-		expect(readFileSync(skillPath)).toEqual(skillBefore);
-		expect(existsSync(marker)).toBe(true);
-		expect(existsSync(managedSkillReceiptPath(paths.managedResourceRoot, "hermes", "clawdi"))).toBe(
-			false,
-		);
-	});
-
-	test("keeps Hermes Skill receipts root-owned and ignores in-home receipts", () => {
-		if (process.geteuid?.() !== 0) return;
-		const paths = tempRuntimePaths();
-		const fixtureRoot = dirname(paths.serviceStateRoot);
-		const runtimeUid = Number.parseInt(
-			execFileSync("id", ["-u", "nobody"], { encoding: "utf8" }).trim(),
-			10,
-		);
-		const runtimeGid = Number.parseInt(
-			execFileSync("id", ["-g", "nobody"], { encoding: "utf8" }).trim(),
-			10,
-		);
-		process.env.CLAWDI_RUNTIME_USER = "nobody";
-		process.env.CLAWDI_RUNTIME_UID = String(runtimeUid);
-		process.env.CLAWDI_RUNTIME_GID = String(runtimeGid);
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-
-		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
-		const source = resolve(import.meta.dir, "../..", "skills", "hosted-versions", "1", "clawdi");
-		const target = join(paths.userHome, ".hermes", "skills", "clawdi");
-		const skillPath = join(target, "SKILL.md");
-		const receipt = managedSkillReceiptPath(paths.managedResourceRoot, "hermes", "clawdi");
-		const legacyReceiptDirectory = join(
-			paths.userHome,
-			".hermes",
-			"skills",
-			".clawdi-manifest-receipts",
-		);
-		const catalogEntry = resolveHostedBundledSkill("clawdi", 1);
-
-		chmodSync(fixtureRoot, 0o755);
-		mkdirSync(dirname(hermesCommand), { recursive: true });
-		writeFileSync(hermesCommand, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
-		for (const path of [
-			paths.userHome,
-			join(paths.userHome, ".local"),
-			dirname(hermesCommand),
-			hermesCommand,
-		]) {
-			chownSync(path, runtimeUid, runtimeGid);
-		}
-
-		const manifest = baseManifest(
-			paths,
-			{
-				hermes: {
+				openclaw: {
 					enabled: true,
-					run: runSettings(hermesCommand, ["gateway"]),
+					run: runSettings(openClawCommand, ["gateway"]),
 					services: {},
 				},
 			},
-			{ projection: { skills: { entries: { clawdi: { enabled: true, version: 1 } } } } },
-		);
-		const converge = (generation: number) => {
-			const result = convergeRuntimeManifest(
-				manifestLoad({ ...manifest, generation }, `root-legacy-hermes-${generation}`),
-				paths,
-				{
-					hostedRuntimeContract: {
-						expectedIdentity: {
-							home: paths.userHome,
-							user: "nobody",
-							uid: runtimeUid,
-							gid: runtimeGid,
+			{
+				projection: {
+					skills: {
+						entries: {
+							clawdi: { enabled: true, version: 1 },
+							[enabledSourcedId]: { enabled: true, source: enabledSourcedSource },
+							[disabledId]: { enabled: false, source: disabledSource },
 						},
-						resolveUserIdentity: () => ({ uid: runtimeUid, gid: runtimeGid }),
 					},
 				},
-			);
-			expect([...result.installErrors, ...result.resourceProjectionErrors]).toEqual([]);
-		};
-
-		converge(1);
-		expect([statSync(target).uid, statSync(skillPath).uid]).toEqual([runtimeUid, runtimeUid]);
-		expect(statSync(receipt).uid).toBe(process.geteuid?.());
-		expect(statSync(receipt).mode & 0o777).toBe(0o600);
-		expect(statSync(dirname(receipt)).mode & 0o777).toBe(0o700);
-		expect(existsSync(legacyReceiptDirectory)).toBe(false);
-		expect(JSON.parse(readFileSync(receipt, "utf8"))).toMatchObject({
-			ownershipIdentity: `content-sha256\0${catalogEntry.digest}`,
-		});
-		const legacyReceipt = join(legacyReceiptDirectory, "clawdi.json");
-		const beforeLegacyReceipt = {
-			target: statSync(target).ino,
-			skill: statSync(skillPath).ino,
-			content: readFileSync(receipt),
-		};
-		mkdirSync(dirname(legacyReceipt), { recursive: true, mode: 0o700 });
-		chmodSync(dirname(legacyReceipt), 0o700);
-		writeFileSync(legacyReceipt, readFileSync(receipt), { mode: 0o600 });
-		const legacyReceiptContent = readFileSync(legacyReceipt);
-		converge(2);
-		expect(readFileSync(legacyReceipt)).toEqual(legacyReceiptContent);
-		expect({
-			target: statSync(target).ino,
-			skill: statSync(skillPath).ino,
-			content: readFileSync(receipt),
-		}).toEqual(beforeLegacyReceipt);
-		expect(statSync(receipt).uid).toBe(0);
-		const stable = {
-			target: statSync(target).ino,
-			skill: statSync(skillPath).ino,
-			receipt: statSync(receipt).ino,
-			content: readFileSync(receipt),
-		};
-		converge(3);
-		expect({
-			target: statSync(target).ino,
-			skill: statSync(skillPath).ino,
-			receipt: statSync(receipt).ino,
-			content: readFileSync(receipt),
-		}).toEqual(stable);
-
-		expect(() => withRuntimeUserFileAccess(() => writeFileSync(receipt, "{}\n"))).toThrow();
-		withRuntimeUserFileAccess(() => writeFileSync(skillPath, "tenant mutation\n"));
-		const collectedTarget = collectRuntimeUserManagedSkillTree(target);
-		if (collectedTarget.status !== "collected") {
-			throw new Error(`counterfeit receipt fixture tree is ${collectedTarget.status}`);
-		}
-		const forgedFingerprint = managedSkillTreeFingerprint(collectedTarget.tree);
-		writeFileSync(
-			receipt,
-			`${JSON.stringify({
-				schemaVersion: "clawdi.hermesManifestSkillReceipt.v2",
-				skillId: "clawdi",
-				ownershipIdentity: `content-sha256\0${catalogEntry.digest}`,
-				treeFingerprint: forgedFingerprint,
-			})}\n`,
-			{ mode: 0o600 },
+			},
 		);
-		chownSync(receipt, runtimeUid, runtimeGid);
-		converge(4);
-		expect(readFileSync(skillPath)).toEqual(readFileSync(join(source, "SKILL.md")));
-		expect(statSync(receipt).uid).toBe(0);
-		const repaired = {
-			target: statSync(target).ino,
-			skill: statSync(skillPath).ino,
-			receipt: statSync(receipt).ino,
-			content: readFileSync(receipt),
-		};
-		converge(5);
-		expect({
-			target: statSync(target).ino,
-			skill: statSync(skillPath).ino,
-			receipt: statSync(receipt).ino,
-			content: readFileSync(receipt),
-		}).toEqual(repaired);
+		const result = convergeRuntimeManifest(manifestLoad(manifest, "legacy-ledger-skills"), paths, {
+			preparedHostedSourcedSkills: new Map([[enabledSourcedId, enabledSourced]]),
+			hostedRuntimeContract: {
+				expectedIdentity: {
+					home: paths.userHome,
+					user: runtimeUser,
+					uid: runtimeUid,
+					gid: runtimeGid,
+				},
+				resolveUserIdentity: () => ({ uid: runtimeUid, gid: runtimeGid }),
+			},
+		});
+
+		expect([...result.installErrors, ...result.resourceProjectionErrors]).toEqual([]);
+		expect(readFileSync(join(enabledTarget, "SKILL.md"))).toEqual(
+			readFileSync(join(bundledSource, "SKILL.md")),
+		);
+		expect(existsSync(join(enabledTarget, ".clawdi-managed.json"))).toBe(false);
+		expect(managedSkillReservationState(enabledTarget, "clawdi")).toBe("reserved");
+		const ledger = JSON.parse(readFileSync(managedSkillReservationLedgerPath(), "utf8"));
+		expect(ledger.reservations[enabledTarget].digest).toBe(catalogEntry.digest);
+		expect(readFileSync(join(openClawEnabledSourcedTarget, "SKILL.md"), "utf8")).toBe(
+			"# Current Review PR\n",
+		);
+		expect(ledger.reservations[openClawEnabledSourcedTarget]).toMatchObject({
+			id: enabledSourcedId,
+			digest: enabledSourced.archiveSha256,
+			sourceIdentity: enabledSourced.sourceIdentity,
+			manager: "hosted-manifest",
+		});
+		expect(existsSync(disabledTarget)).toBe(false);
+		expect(managedSkillReservationState(disabledTarget, disabledId)).toBe("unreserved");
+		expect(existsSync(legacyReceiptDirectory)).toBe(false);
+		expect(existsSync(openClawLegacyReceiptDirectory)).toBe(false);
+		expect(existsSync(platformReceiptDirectory)).toBe(false);
 	});
 
 	test("keeps the hosted skill ledger root owned while mutating the runtime-user skill tree", () => {
@@ -4587,172 +4595,125 @@ echo spawned > '${installerLog}'
 		}
 	});
 
-	test("reconciles exact-source Hermes Workspace Skills through paired manifest ownership", () => {
+	test("reconciles exact-source Hermes Workspace Skills through the reservation ledger", () => {
 		const paths = tempRuntimePaths();
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
 		mkdirSync(dirname(hermesCommand), { recursive: true });
-		writeFileSync(hermesCommand, "#!/bin/sh\nexit 0\n");
-		chmodSync(hermesCommand, 0o755);
+		writeFileSync(hermesCommand, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
 		const source = {
 			type: "github" as const,
 			url: "https://github.com/Clawdi-AI/store",
 			path: "skills/review-pr",
 			commit: "a".repeat(40),
 		};
-		const prepared: PreparedHostedSourcedSkill = {
-			skillId: "review-pr",
-			source,
-			sourceIdentity:
-				"github\0review-pr\0https://github.com/Clawdi-AI/store\0skills/review-pr\0" +
-				"a".repeat(40),
-			archiveSha256: "b".repeat(64),
-			tarBytes: Buffer.from("exact archive"),
-		};
-		const desiredManifest = baseManifest(
+		const prepared = preparedTestSourcedSkill("review-pr", source, "manifest-owned\n");
+		const manifest = baseManifest(
 			paths,
-			{
-				hermes: {
-					enabled: true,
-					run: runSettings(hermesCommand, ["gateway"]),
-					services: {},
-				},
-			},
-			{
-				projection: {
-					skills: {
-						entries: { "review-pr": { enabled: true, source } },
-					},
-				},
-			},
+			{ hermes: { enabled: true, run: runSettings(hermesCommand, ["gateway"]), services: {} } },
+			{ projection: { skills: { entries: { "review-pr": { enabled: true, source } } } } },
 		);
 		const skillDir = join(paths.userHome, ".hermes", "skills", "review-pr");
 		const userOwnedSibling = join(paths.userHome, ".hermes", "skills", "user-owned");
 		mkdirSync(skillDir, { recursive: true });
 		writeFileSync(join(skillDir, "SKILL.md"), "user-owned collision\n");
+		const preparedSkills = new Map([[prepared.skillId, prepared]]);
+		let installs = 0;
+		const driver = {
+			install: () => {
+				installs += 1;
+				mkdirSync(skillDir, { recursive: true });
+				writeFileSync(join(skillDir, "SKILL.md"), "manifest-owned\n");
+				return "installed" as const;
+			},
+		};
+
 		const collision = convergeRuntimeManifest(
-			manifestLoad(desiredManifest, "catalog-collision"),
+			manifestLoad(manifest, "skill-ledger-collision"),
 			paths,
 			{
-				preparedHostedSourcedSkills: new Map([[prepared.skillId, prepared]]),
-				hostedHermesSkillExactSourceDriver: {
-					install: () => "installed",
-					anchorOwnership: () => undefined,
-					hasOwnershipReceipt: () => false,
-					verifyOwned: () => false,
-					uninstall: () => "removed",
-					cleanupManifestOwned: () => "removed",
-				},
+				preparedHostedSourcedSkills: preparedSkills,
+				hostedHermesSkillExactSourceDriver: driver,
 			},
 		);
-		expect(collision.installErrors).toEqual([]);
 		expect(collision.resourceProjectionErrors.join("\n")).toContain(
 			`refusing to replace unmanaged review-pr skill at ${skillDir}`,
 		);
-		expect(shouldIgnoreUserSkill(skillDir, "review-pr")).toBe(false);
+		expect(installs).toBe(0);
 		rmSync(skillDir, { recursive: true, force: true });
 		mkdirSync(userOwnedSibling, { recursive: true });
 		writeFileSync(join(userOwnedSibling, "SKILL.md"), "keep me\n");
 
-		const installs: boolean[] = [];
-		let verifyCalls = 0;
-		let uninstalls = 0;
-		const nativeReconciler = {
-			install: (input: { previouslyReserved: boolean }) => {
-				installs.push(input.previouslyReserved);
-				mkdirSync(skillDir, { recursive: true });
-				writeFileSync(join(skillDir, "SKILL.md"), "manifest-owned\n");
-				if (installs.length === 1) throw new Error("lost native install response");
-				return "unchanged" as const;
-			},
-			anchorOwnership: () => undefined,
-			hasOwnershipReceipt: () => false,
-			verifyOwned: (input: { skill: PreparedHostedSourcedSkill }) => {
-				verifyCalls += 1;
-				return (
-					input.skill.sourceIdentity === prepared.sourceIdentity &&
-					existsSync(join(skillDir, "SKILL.md")) &&
-					readFileSync(join(skillDir, "SKILL.md"), "utf8") === "manifest-owned\n"
-				);
-			},
-			uninstall: () => {
-				uninstalls += 1;
-				rmSync(skillDir, { recursive: true, force: true });
-				return "removed" as const;
-			},
-			cleanupManifestOwned: () => "removed" as const,
-		};
-		const options = {
-			preparedHostedSourcedSkills: new Map([[prepared.skillId, prepared]]),
-			hostedHermesSkillExactSourceDriver: nativeReconciler,
-		};
-		let authorityCommits = 0;
-		const lostResponse = convergeRuntimeManifest(
-			manifestLoad(desiredManifest, "catalog-lost-native-response"),
-			paths,
-			{ ...options, commitAuthority: () => authorityCommits++ },
-		);
-		expect(lostResponse.installErrors).toEqual([]);
-		expect(lostResponse.resourceProjectionErrors.join("\n")).toContain(
-			"lost native install response",
-		);
-		expect(authorityCommits).toBe(1);
-		expect(installs).toEqual([false]);
-		expect(shouldIgnoreUserSkill(skillDir, "review-pr")).toBe(false);
-		expect(existsSync(skillDir)).toBe(false);
-
-		mkdirSync(skillDir, { recursive: true });
-		writeFileSync(join(skillDir, "SKILL.md"), "forged user bytes\n");
-		const forged = convergeRuntimeManifest(
-			manifestLoad(desiredManifest, "catalog-forged-partial-commit"),
-			paths,
-			options,
-		);
-		expect(forged.installErrors).toEqual([]);
-		expect(forged.resourceProjectionErrors.join("\n")).toContain(
-			`refusing to replace unmanaged review-pr skill at ${skillDir}`,
-		);
-		expect(verifyCalls).toBe(1);
-		expect(shouldIgnoreUserSkill(skillDir, "review-pr")).toBe(false);
-
-		writeFileSync(join(skillDir, "SKILL.md"), "manifest-owned\n");
 		const installed = convergeRuntimeManifest(
-			manifestLoad(desiredManifest, "catalog-recover-native-commit"),
+			manifestLoad({ ...manifest, generation: 2 }, "skill-ledger-install"),
 			paths,
-			options,
+			{ preparedHostedSourcedSkills: preparedSkills, hostedHermesSkillExactSourceDriver: driver },
 		);
-		expect(installed.installErrors).toEqual([]);
-		expect(installs).toEqual([false, true]);
-		expect(verifyCalls).toBe(3);
-		expect(shouldIgnoreUserSkill(skillDir, "review-pr")).toBe(true);
-		expect(readFileSync(join(skillDir, "SKILL.md"), "utf8")).toBe("manifest-owned\n");
+		expect([...installed.installErrors, ...installed.resourceProjectionErrors]).toEqual([]);
+		expect(installs).toBe(1);
+		const ledger = JSON.parse(readFileSync(managedSkillReservationLedgerPath(), "utf8"));
+		expect(ledger.reservations[skillDir]).toMatchObject({
+			id: "review-pr",
+			digest: prepared.archiveSha256,
+			sourceIdentity: prepared.sourceIdentity,
+			manager: "hosted-manifest",
+		});
 
-		const repaired = convergeRuntimeManifest(
-			manifestLoad(desiredManifest, "catalog-repair"),
+		const stableInode = statSync(skillDir).ino;
+		const unchanged = convergeRuntimeManifest(
+			manifestLoad({ ...manifest, generation: 3 }, "skill-ledger-unchanged"),
 			paths,
-			options,
+			{ preparedHostedSourcedSkills: preparedSkills, hostedHermesSkillExactSourceDriver: driver },
 		);
-		expect(repaired.installErrors).toEqual([]);
-		expect(installs).toEqual([false, true, true]);
-
-		const removed = convergeRuntimeManifest(
+		expect([...unchanged.installErrors, ...unchanged.resourceProjectionErrors]).toEqual([]);
+		expect(installs).toBe(1);
+		expect(statSync(skillDir).ino).toBe(stableInode);
+		const movedSource = { ...source, commit: "c".repeat(40) };
+		const movedPrepared = {
+			...prepared,
+			source: movedSource,
+			sourceIdentity:
+				"github\0review-pr\0https://github.com/Clawdi-AI/store\0skills/review-pr\0" +
+				movedSource.commit,
+		};
+		const moved = convergeRuntimeManifest(
 			manifestLoad(
-				{ ...desiredManifest, projection: { skills: { entries: {} } } },
-				"catalog-remove",
+				{
+					...manifest,
+					generation: 4,
+					projection: {
+						skills: { entries: { "review-pr": { enabled: true, source: movedSource } } },
+					},
+				},
+				"skill-ledger-source-moved",
 			),
 			paths,
 			{
-				preparedHostedSourcedSkills: new Map(),
-				hostedHermesSkillExactSourceDriver: nativeReconciler,
+				preparedHostedSourcedSkills: new Map([[movedPrepared.skillId, movedPrepared]]),
+				hostedHermesSkillExactSourceDriver: driver,
 			},
 		);
-		expect(removed.installErrors).toEqual([]);
-		expect(uninstalls).toBe(1);
-		expect(existsSync(skillDir)).toBe(false);
-		expect(readFileSync(join(userOwnedSibling, "SKILL.md"), "utf8")).toBe("keep me\n");
-		expect(shouldIgnoreUserSkill(userOwnedSibling, "user-owned")).toBe(false);
-	});
+		expect([...moved.installErrors, ...moved.resourceProjectionErrors]).toEqual([]);
+		expect(installs).toBe(1);
+		expect(statSync(skillDir).ino).toBe(stableInode);
+		expect(
+			JSON.parse(readFileSync(managedSkillReservationLedgerPath(), "utf8")).reservations[skillDir]
+				.sourceIdentity,
+		).toBe(movedPrepared.sourceIdentity);
 
+		const removed = convergeRuntimeManifest(
+			manifestLoad(
+				{ ...manifest, generation: 5, projection: { skills: { entries: {} } } },
+				"skill-ledger-remove",
+			),
+			paths,
+			{ preparedHostedSourcedSkills: new Map(), hostedHermesSkillExactSourceDriver: driver },
+		);
+		expect([...removed.installErrors, ...removed.resourceProjectionErrors]).toEqual([]);
+		expect(existsSync(skillDir)).toBe(false);
+		expect(managedSkillReservationState(skillDir, "review-pr")).toBe("unreserved");
+		expect(readFileSync(join(userOwnedSibling, "SKILL.md"), "utf8")).toBe("keep me\n");
+	});
 	test("recovers a killed hosted Skill install before retrying convergence", async () => {
 		const paths = tempRuntimePaths();
 		ensureRuntimeStateDirs(paths);
@@ -4763,16 +4724,18 @@ echo spawned > '${installerLog}'
 			path: `skills/${skillId}`,
 			commit: "a".repeat(40),
 		};
-		const sourceIdentity = `github\0${skillId}\0${source.url}\0${source.path}\0${source.commit}`;
-		const prepared: PreparedHostedSourcedSkill = {
-			skillId,
-			source,
-			sourceIdentity,
-			archiveSha256: "b".repeat(64),
-			tarBytes: Buffer.from("crash recovery archive"),
-		};
+		const prepared = preparedTestSourcedSkill(skillId, source, "verified tree\n");
+		const sourceIdentity = prepared.sourceIdentity;
 		const target = join(paths.userHome, ".hermes", "skills", skillId);
-		const receipt = managedSkillReceiptPath(paths.managedResourceRoot, "hermes", skillId);
+		mkdirSync(target, { recursive: true });
+		writeFileSync(join(target, "SKILL.md"), "old committed tree\n");
+		reserveManagedSkill({
+			targetDir: target,
+			id: skillId,
+			digest: "a".repeat(64),
+			sourceIdentity,
+			manager: "hosted-manifest",
+		});
 		const ready = join(dirname(paths.serviceStateRoot), "skill-installer-ready");
 		const moduleUrl = new URL("./managed-skill-reservation.ts", import.meta.url).href;
 		const child = Bun.spawn(
@@ -4784,6 +4747,7 @@ const { installReservedManagedSkill } = await import(${JSON.stringify(moduleUrl)
 installReservedManagedSkill(${JSON.stringify({
 					targetDir: target,
 					id: skillId,
+					digest: prepared.archiveSha256,
 					sourceIdentity,
 					manager: "hosted-manifest",
 				})}, () => {
@@ -4802,10 +4766,9 @@ installReservedManagedSkill(${JSON.stringify({
 
 		const ledgerPath = managedSkillReservationLedgerPath();
 		const interruptedLedger = JSON.parse(readFileSync(ledgerPath, "utf8"));
-		expect(interruptedLedger.reservations[target]).toBeUndefined();
+		expect(interruptedLedger.reservations[target].digest).toBe("a".repeat(64));
 		expect(interruptedLedger.pendingReservations[target]).toBeDefined();
-		expect(existsSync(target)).toBe(false);
-		expect(existsSync(receipt)).toBe(false);
+		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("old committed tree\n");
 		expect(() =>
 			reserveManagedSkill({
 				targetDir: target,
@@ -4837,24 +4800,8 @@ installReservedManagedSkill(${JSON.stringify({
 						expect(installingLedger.pendingReservations[target]).toBeDefined();
 						mkdirSync(target, { recursive: true });
 						writeFileSync(join(target, "SKILL.md"), "verified tree\n");
-						writeManagedSkillReceipt({
-							path: receipt,
-							managedResourceRoot: paths.managedResourceRoot,
-							schemaVersion: "clawdi.hermesManifestSkillReceipt.v2",
-							skillId,
-							ownershipIdentity: sourceIdentity,
-							target,
-						});
 						return "installed";
 					},
-					anchorOwnership: () => undefined,
-					hasOwnershipReceipt: () => existsSync(receipt),
-					verifyOwned: () =>
-						existsSync(receipt) &&
-						existsSync(join(target, "SKILL.md")) &&
-						readFileSync(join(target, "SKILL.md"), "utf8") === "verified tree\n",
-					uninstall: () => "removed",
-					cleanupManifestOwned: () => "removed",
 				},
 			},
 		);
@@ -4863,7 +4810,7 @@ installReservedManagedSkill(${JSON.stringify({
 		expect(installs).toBe(1);
 		expect(managedSkillReservationState(target, skillId)).toBe("reserved");
 		const committedLedger = JSON.parse(readFileSync(ledgerPath, "utf8"));
-		expect(committedLedger.reservations[target]).toBeDefined();
+		expect(committedLedger.reservations[target].digest).toBe(prepared.archiveSha256);
 		expect(committedLedger.pendingReservations).toEqual({});
 	});
 
@@ -4874,20 +4821,11 @@ installReservedManagedSkill(${JSON.stringify({
 		const skillId = "attio-composio-client-updates";
 		const sourceIdentity = `github\0${skillId}\0https://github.com/Clawdi-AI/store\0skills/${skillId}\0${"a".repeat(40)}`;
 		const target = join(paths.userHome, ".hermes", "skills", skillId);
-		const receipt = managedSkillReceiptPath(paths.managedResourceRoot, "hermes", skillId);
 		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
 		mkdirSync(dirname(hermesCommand), { recursive: true });
 		writeFileSync(hermesCommand, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
 		mkdirSync(target, { recursive: true });
 		writeFileSync(join(target, "SKILL.md"), "historical test Skill\n");
-		writeManagedSkillReceipt({
-			path: receipt,
-			managedResourceRoot: paths.managedResourceRoot,
-			schemaVersion: "clawdi.hermesManifestSkillReceipt.v2",
-			skillId,
-			ownershipIdentity: sourceIdentity,
-			target,
-		});
 		reserveManagedSkill({
 			targetDir: target,
 			id: skillId,
@@ -4908,7 +4846,6 @@ installReservedManagedSkill(${JSON.stringify({
 
 		expect([...result.installErrors, ...result.resourceProjectionErrors]).toEqual([]);
 		expect(managedSkillReservationState(target, skillId)).toBe("unreserved");
-		expect(existsSync(receipt)).toBe(false);
 		expect(existsSync(target)).toBe(false);
 	});
 
@@ -4924,14 +4861,8 @@ installReservedManagedSkill(${JSON.stringify({
 			archiveUrl: "https://cloud-api.example.test/project-skill.tar.gz",
 			installUrl: "https://cloud-api.example.test/project-skill/SKILL.md",
 		};
-		const sourceIdentity = ["project", skillId, source.projectId, source.contentHash].join("\0");
-		const prepared: PreparedHostedSourcedSkill = {
-			skillId,
-			source,
-			sourceIdentity,
-			archiveSha256: "b".repeat(64),
-			tarBytes: Buffer.from("field-shaped archive"),
-		};
+		const prepared = preparedTestSourcedSkill(skillId, source, "native projection\n");
+		const sourceIdentity = prepared.sourceIdentity;
 		const staleTarget = join(paths.userHome, ".hermes", "skills", skillId);
 		const nativeTarget = join(paths.userHome, ".hermes", "skills", "phala-workflows");
 		reserveManagedSkill({
@@ -4957,25 +4888,11 @@ installReservedManagedSkill(${JSON.stringify({
 				hostedHermesSkillExactSourceDriver: {
 					target: () => nativeTarget,
 					install: (input) => {
-						expect(input.previouslyReserved).toBe(true);
 						expect(input.targetDir).toBe(nativeTarget);
 						mkdirSync(nativeTarget, { recursive: true });
 						writeFileSync(join(nativeTarget, "SKILL.md"), "native projection\n");
-						writeManagedSkillReceipt({
-							path: managedSkillReceiptPath(paths.managedResourceRoot, "hermes", skillId),
-							managedResourceRoot: paths.managedResourceRoot,
-							schemaVersion: "clawdi.hermesManifestSkillReceipt.v2",
-							skillId,
-							ownershipIdentity: sourceIdentity,
-							target: nativeTarget,
-						});
 						return "installed";
 					},
-					anchorOwnership: () => undefined,
-					hasOwnershipReceipt: () => false,
-					verifyOwned: () => true,
-					uninstall: () => "removed",
-					cleanupManifestOwned: () => "removed",
 				},
 			},
 		);
@@ -5002,13 +4919,7 @@ installReservedManagedSkill(${JSON.stringify({
 				path: `skills/${skillId}`,
 				commit: "a".repeat(40),
 			};
-			preparedSkills.set(skillId, {
-				skillId,
-				source,
-				sourceIdentity: `github\0${skillId}\0${source.url}\0${source.path}\0${source.commit}`,
-				archiveSha256: "b".repeat(64),
-				tarBytes: Buffer.from(`archive:${skillId}`),
-			});
+			preparedSkills.set(skillId, preparedTestSourcedSkill(skillId, source, `${skillId}\n`));
 			entries.entries[skillId] = { enabled: true, source };
 		}
 		const manifest = baseManifest(
@@ -5039,11 +4950,6 @@ installReservedManagedSkill(${JSON.stringify({
 					writeFileSync(join(target, "SKILL.md"), `${skill.skillId}\n`);
 					return "installed";
 				},
-				anchorOwnership: () => undefined,
-				hasOwnershipReceipt: () => false,
-				verifyOwned: () => true,
-				uninstall: () => "removed",
-				cleanupManifestOwned: () => "removed",
 			},
 		});
 
@@ -5075,13 +4981,7 @@ installReservedManagedSkill(${JSON.stringify({
 				path: `skills/${skillId}`,
 				commit: "a".repeat(40),
 			};
-			preparedSkills.set(skillId, {
-				skillId,
-				source,
-				sourceIdentity: `github\0${skillId}\0${source.url}\0${source.path}\0${source.commit}`,
-				archiveSha256: "b".repeat(64),
-				tarBytes: Buffer.from(`archive:${skillId}`),
-			});
+			preparedSkills.set(skillId, preparedTestSourcedSkill(skillId, source, `${skillId}\n`));
 			entries.entries[skillId] = { enabled: true, source };
 		}
 		const unmanaged = join(paths.userHome, ".hermes", "skills", "a-unmanaged");
@@ -5109,11 +5009,6 @@ installReservedManagedSkill(${JSON.stringify({
 						attempted.push(skill.skillId);
 						return "installed";
 					},
-					anchorOwnership: () => undefined,
-					hasOwnershipReceipt: () => false,
-					verifyOwned: () => false,
-					uninstall: () => "removed",
-					cleanupManifestOwned: () => "removed",
 				},
 			},
 		);
@@ -5164,37 +5059,45 @@ installReservedManagedSkill(${JSON.stringify({
 			readFileSync(join(packageSource, "SKILL.md")),
 		);
 		expect(existsSync(join(target, ".clawdi-managed.json"))).toBe(false);
-		const receipt = managedSkillReceiptPath(paths.managedResourceRoot, "openclaw", "clawdi");
-		const legacyReceipt = join(dirname(target), ".clawdi-manifest-receipts", "clawdi.json");
-		expect(existsSync(receipt)).toBe(true);
-		expect(
-			existsSync(
-				join(paths.userHome, ".openclaw", "workspace", "skills", ".clawdi-manifest-receipts"),
-			),
-		).toBe(false);
 		expect(shouldIgnoreUserSkill(target, "clawdi")).toBe(true);
 
-		const targetBeforeLegacyReceipt = statSync(target).ino;
-		const receiptBeforeLegacyReceipt = readFileSync(receipt);
-		mkdirSync(dirname(legacyReceipt), { recursive: true, mode: 0o700 });
-		writeFileSync(legacyReceipt, receiptBeforeLegacyReceipt, { mode: 0o600 });
-		const reconvergedWithLegacyReceipt = convergeRuntimeManifest(
-			manifestLoad({ ...manifest, generation: 2 }, "bundled-openclaw-skill-legacy-receipt"),
+		const targetBeforeRetiredReceipts = statSync(target).ino;
+		const legacyReceiptDirectory = join(dirname(target), ".clawdi-manifest-receipts");
+		const platformReceiptDirectory = join(paths.managedResourceRoot, "skill-receipts");
+		mkdirSync(legacyReceiptDirectory, { recursive: true });
+		writeFileSync(join(legacyReceiptDirectory, "clawdi.json"), "{}\n");
+		mkdirSync(join(platformReceiptDirectory, "openclaw"), { recursive: true });
+		writeFileSync(join(platformReceiptDirectory, "openclaw", "clawdi.json"), "{}\n");
+		const reconverged = convergeRuntimeManifest(
+			manifestLoad({ ...manifest, generation: 2 }, "bundled-openclaw-skill-retired-receipts"),
 			paths,
 		);
-		expect(reconvergedWithLegacyReceipt.resourceProjectionErrors).toEqual([]);
-		expect(statSync(target).ino).toBe(targetBeforeLegacyReceipt);
-		expect(readFileSync(receipt)).toEqual(receiptBeforeLegacyReceipt);
-		expect(readFileSync(legacyReceipt)).toEqual(receiptBeforeLegacyReceipt);
+		expect([...reconverged.installErrors, ...reconverged.resourceProjectionErrors]).toEqual([]);
+		expect(statSync(target).ino).toBe(targetBeforeRetiredReceipts);
+		expect(readFileSync(sourceLog, "utf8").trim().split("\n")).toHaveLength(1);
+		expect(existsSync(legacyReceiptDirectory)).toBe(false);
+		expect(existsSync(platformReceiptDirectory)).toBe(false);
+
+		const targetBeforeRepair = statSync(target).ino;
+		writeFileSync(join(target, "SKILL.md"), "tenant mutation\n");
+		const repaired = convergeRuntimeManifest(
+			manifestLoad({ ...manifest, generation: 3 }, "bundled-openclaw-skill-repair"),
+			paths,
+		);
+		expect([...repaired.installErrors, ...repaired.resourceProjectionErrors]).toEqual([]);
+		expect(readFileSync(join(target, "SKILL.md"))).toEqual(
+			readFileSync(join(packageSource, "SKILL.md")),
+		);
+		expect(statSync(target).ino).not.toBe(targetBeforeRepair);
 
 		writeFileSync(join(target, "SKILL.md"), "tenant mutation\n");
 		rmSync(managedSkillReservationLedgerPath(), { force: true });
-		const reconverged = convergeRuntimeManifest(
-			manifestLoad({ ...manifest, generation: 3 }, "bundled-openclaw-skill-restart"),
+		const withoutLedger = convergeRuntimeManifest(
+			manifestLoad({ ...manifest, generation: 4 }, "bundled-openclaw-skill-restart"),
 			paths,
 		);
-		expect(reconverged.installErrors).toEqual([]);
-		expect(reconverged.resourceProjectionErrors.join("\n")).toContain(
+		expect(withoutLedger.installErrors).toEqual([]);
+		expect(withoutLedger.resourceProjectionErrors.join("\n")).toContain(
 			`refusing to replace unmanaged clawdi skill at ${target}`,
 		);
 		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("tenant mutation\n");
@@ -5226,8 +5129,6 @@ installReservedManagedSkill(${JSON.stringify({
 			{ openclaw: { enabled: true, run: runSettings(command, ["gateway"]), services: {} } },
 			{ projection: { skills: { entries: {} } } },
 		);
-		let ownershipAnchors = 0;
-		let guardedCleanupCalls = 0;
 		const result = convergeRuntimeManifest(
 			manifestLoad(manifest, "legacy-openclaw-remove"),
 			paths,
@@ -5236,22 +5137,10 @@ installReservedManagedSkill(${JSON.stringify({
 					resolveWorkspace: () => openClawWorkspaceRoot,
 					installDirectory: () => "installed",
 					install: () => "installed",
-					anchorOwnership: () => {
-						ownershipAnchors += 1;
-					},
-					hasOwnershipReceipt: () => false,
-					verifyOwned: () => false,
-					cleanupManifestOwned: () => {
-						guardedCleanupCalls += 1;
-						rmSync(target, { recursive: true, force: true });
-						return "removed";
-					},
 				},
 			},
 		);
 		expect(result.installErrors).toEqual([]);
-		expect(ownershipAnchors).toBe(0);
-		expect(guardedCleanupCalls).toBe(0);
 		expect(existsSync(target)).toBe(true);
 		expect(existsSync(join(target, ".clawdi-managed.json"))).toBe(true);
 	});

--- a/packages/cli/src/runtime/manifest-skills-apply.ts
+++ b/packages/cli/src/runtime/manifest-skills-apply.ts
@@ -7,7 +7,7 @@ import {
 	type PreparedHostedSourcedSkill,
 	prepareHostedBundledSkillArchive,
 } from "./hosted-sourced-skill-archive";
-import { ManagedSkillResourceError, managedSkillReceiptPath } from "./managed-skill-delivery";
+import { installedTreeMatches, ManagedSkillResourceError } from "./managed-skill-delivery";
 import {
 	installReservedManagedSkill,
 	type ManagedSkillReservationSnapshot,
@@ -35,15 +35,9 @@ interface HostedSkillProjectionDriver {
 	name: "hermes" | "openclaw";
 	enabled: boolean;
 	skillsRoot: string | null;
+	installedTreeExcludes?: ReadonlySet<string>;
 	target(skill: PreparedHostedSourcedSkill): string;
-	install(
-		skill: PreparedHostedSourcedSkill,
-		targetDir: string,
-		previousReservation?: ManagedSkillReservationSnapshot,
-	): "installed" | "unchanged";
-	anchorOwnership(skillId: string, ownershipIdentity: string, targetDir: string): void;
-	verifyOwned(skill: PreparedHostedSourcedSkill, targetDir: string): boolean;
-	remove(reservation: ManagedSkillReservationSnapshot): void;
+	install(skill: PreparedHostedSourcedSkill, targetDir: string): "installed" | "unchanged";
 }
 function preparedSkillMatchesDesired(
 	prepared: PreparedHostedSourcedSkill | undefined,
@@ -83,17 +77,11 @@ function preparedReservationIdentity(skill: PreparedHostedSourcedSkill): {
 } {
 	return skill.source.type === "bundled"
 		? { version: skill.source.version, digest: skill.source.digest }
-		: { sourceIdentity: skill.sourceIdentity };
-}
-function reservationOwnershipIdentity(reservation: ManagedSkillReservationSnapshot): string {
-	if (reservation.sourceIdentity) return reservation.sourceIdentity;
-	if (reservation.digest) return `content-sha256\0${reservation.digest}`;
-	throw new Error(`managed Skill ${reservation.id} has no ownership identity`);
+		: { sourceIdentity: skill.sourceIdentity, digest: skill.archiveSha256 };
 }
 function hostedSkillProjectionDrivers(input: {
 	manifest: RuntimeManifest;
 	home: string;
-	managedResourceRoot: string;
 	openClawWorkspaceRoot: string | null;
 	hermesDriver: HostedHermesSkillExactSourceDriver;
 	openClawDriver: HostedOpenClawSkillDriver;
@@ -110,61 +98,25 @@ function hostedSkillProjectionDrivers(input: {
 			target: (skill) =>
 				input.hermesDriver.target?.({ home: input.home, skill }) ??
 				join(hermesSkillsRoot, skill.skillId),
-			install: (skill, targetDir, previousReservation) =>
+			install: (skill, targetDir) =>
 				input.hermesDriver.install({
 					home: input.home,
-					managedResourceRoot: input.managedResourceRoot,
-					skill,
-					targetDir,
-					previouslyReserved: previousReservation !== undefined,
-				}),
-			anchorOwnership: (skillId, ownershipIdentity, targetDir) =>
-				input.hermesDriver.anchorOwnership({
-					home: input.home,
-					managedResourceRoot: input.managedResourceRoot,
-					skillId,
-					ownershipIdentity,
-					targetDir,
-				}),
-			verifyOwned: (skill, targetDir) =>
-				input.hermesDriver.verifyOwned({
-					home: input.home,
-					managedResourceRoot: input.managedResourceRoot,
 					skill,
 					targetDir,
 				}),
-			remove: (reservation) => {
-				const ownershipIdentity = reservationOwnershipIdentity(reservation);
-				if (reservation.digest) {
-					input.hermesDriver.cleanupManifestOwned({
-						home: input.home,
-						managedResourceRoot: input.managedResourceRoot,
-						skillId: reservation.id,
-						ownershipIdentity,
-						targetDir: reservation.targetDir,
-					});
-					return;
-				}
-				input.hermesDriver.uninstall({
-					home: input.home,
-					managedResourceRoot: input.managedResourceRoot,
-					skillId: reservation.id,
-					ownershipIdentity,
-					targetDir: reservation.targetDir,
-				});
-			},
 		},
 		{
 			name: "openclaw",
 			enabled: input.manifest.runtimes.openclaw?.enabled === true,
 			skillsRoot: openClawSkillsRoot,
+			installedTreeExcludes: new Set([".openclaw/source-origin.json"]),
 			target: (skill) => {
 				if (!openClawSkillsRoot) {
 					throw new Error("OpenClaw official agent workspace is unavailable");
 				}
 				return join(openClawSkillsRoot, skill.skillId);
 			},
-			install: (skill, targetDir, previousReservation) => {
+			install: (skill, targetDir) => {
 				if (!input.openClawWorkspaceRoot) {
 					throw new Error("OpenClaw official agent workspace is unavailable");
 				}
@@ -172,39 +124,7 @@ function hostedSkillProjectionDrivers(input: {
 				return input.openClawDriver.install({
 					home: input.home,
 					workspaceRoot: input.openClawWorkspaceRoot,
-					managedResourceRoot: input.managedResourceRoot,
 					skill,
-					previouslyReserved: previousReservation !== undefined,
-				});
-			},
-			anchorOwnership: (skillId, ownershipIdentity, _targetDir) => {
-				if (!input.openClawWorkspaceRoot) {
-					throw new Error("OpenClaw official agent workspace is unavailable");
-				}
-				input.openClawDriver.anchorOwnership({
-					workspaceRoot: input.openClawWorkspaceRoot,
-					managedResourceRoot: input.managedResourceRoot,
-					skillId,
-					ownershipIdentity,
-				});
-			},
-			verifyOwned: (skill, _targetDir) => {
-				if (!input.openClawWorkspaceRoot) return false;
-				return input.openClawDriver.verifyOwned({
-					workspaceRoot: input.openClawWorkspaceRoot,
-					managedResourceRoot: input.managedResourceRoot,
-					skill,
-				});
-			},
-			remove: (reservation) => {
-				if (!input.openClawWorkspaceRoot) {
-					throw new Error("OpenClaw official agent workspace is unavailable");
-				}
-				input.openClawDriver.cleanupManifestOwned({
-					workspaceRoot: input.openClawWorkspaceRoot,
-					managedResourceRoot: input.managedResourceRoot,
-					skillId: reservation.id,
-					ownershipIdentity: reservationOwnershipIdentity(reservation),
 				});
 			},
 		},
@@ -224,20 +144,13 @@ function pendingReservationMatchesPrepared(
 	);
 }
 
-function discardPendingHostedSkill(
-	driver: HostedSkillProjectionDriver,
-	managedResourceRoot: string,
-	skillId: string,
-	targetDir: string,
-): void {
+function discardPendingHostedSkill(targetDir: string): void {
 	withRuntimeUserFileAccess(() => rmSync(targetDir, { recursive: true, force: true }));
-	rmSync(managedSkillReceiptPath(managedResourceRoot, driver.name, skillId), { force: true });
 }
 
 function recoverPendingHostedSkillInstallations(
 	driver: HostedSkillProjectionDriver,
 	manifest: RuntimeManifest,
-	managedResourceRoot: string,
 	preparedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
 ): void {
 	if (!hostedBundledSkillsEnabled() || !driver.skillsRoot) return;
@@ -259,52 +172,12 @@ function recoverPendingHostedSkillInstallations(
 			targetDir: reservation.targetDir,
 			id: reservation.id,
 			manager: "hosted-manifest",
-			verify: () => promotable !== null && driver.verifyOwned(promotable, reservation.targetDir),
-			discard: () =>
-				discardPendingHostedSkill(
-					driver,
-					managedResourceRoot,
-					reservation.id,
-					reservation.targetDir,
-				),
-		});
-	}
-}
-
-function recoverHostedSkillReservations(
-	driver: HostedSkillProjectionDriver,
-	manifest: RuntimeManifest,
-	preparedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
-): void {
-	if (!hostedBundledSkillsEnabled() || !driver.skillsRoot) return;
-	const desiredEntries = manifest.projection?.skills?.entries ?? {};
-	const skillIds = new Set([...Object.keys(desiredEntries), ...hostedBundledSkillIds()]);
-	for (const skillId of [...skillIds].sort()) {
-		const desired = desiredEntries[skillId];
-		if (!driver.enabled || desired?.enabled !== true) continue;
-		const prepared = preparedSkills.get(skillId);
-		if (!preparedSkillMatchesDesired(prepared, desired, skillId)) {
-			continue;
-		}
-		let targetDir: string;
-		try {
-			targetDir = driver.target(prepared);
-		} catch (error) {
-			if (error instanceof ManagedSkillResourceError) continue;
-			throw error;
-		}
-		if (
-			!withRuntimeUserFileAccess(() => existsSync(targetDir)) ||
-			managedSkillReservationOwner(targetDir, skillId) !== "unreserved" ||
-			!driver.verifyOwned(prepared, targetDir)
-		) {
-			continue;
-		}
-		reserveManagedSkill({
-			targetDir,
-			id: skillId,
-			manager: "hosted-manifest",
-			...preparedReservationIdentity(prepared),
+			verify: () =>
+				promotable !== null &&
+				installedTreeMatches(promotable, reservation.targetDir, {
+					exclude: driver.installedTreeExcludes,
+				}),
+			discard: () => discardPendingHostedSkill(reservation.targetDir),
 		});
 	}
 }
@@ -346,7 +219,6 @@ function applyHostedSkills(
 	driver: HostedSkillProjectionDriver,
 	observation: RuntimeInstallObservation | undefined,
 	manifest: RuntimeManifest,
-	managedResourceRoot: string,
 	preparedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
 ): string[] {
 	if (!hostedBundledSkillsEnabled() || !driver.skillsRoot) return [];
@@ -377,7 +249,11 @@ function applyHostedSkills(
 					targetDir: reservation.targetDir,
 					id: skillId,
 					manager: "hosted-manifest",
-					removeTarget: () => driver.remove(reservation),
+					removeTarget: () => {
+						withRuntimeUserFileAccess(() =>
+							rmSync(reservation.targetDir, { recursive: true, force: true }),
+						);
+					},
 				});
 			} catch (error) {
 				if (!(error instanceof ManagedSkillResourceError)) throw error;
@@ -402,6 +278,27 @@ function applyHostedSkills(
 		if (withRuntimeUserFileAccess(() => existsSync(targetDir)) && owner !== "hosted-manifest") {
 			throw new Error(`refusing to replace unmanaged ${skillId} skill at ${targetDir}`);
 		}
+		const reservationIdentity = preparedReservationIdentity(prepared);
+		if (
+			reservation?.targetDir === targetDir &&
+			reservation.digest === reservationIdentity.digest &&
+			installedTreeMatches(prepared, targetDir, {
+				exclude: driver.installedTreeExcludes,
+			})
+		) {
+			if (
+				reservation.version !== reservationIdentity.version ||
+				reservation.sourceIdentity !== reservationIdentity.sourceIdentity
+			) {
+				reserveManagedSkill({
+					targetDir,
+					id: skillId,
+					manager: "hosted-manifest",
+					...reservationIdentity,
+				});
+			}
+			continue;
+		}
 		try {
 			installReservedManagedSkill(
 				{
@@ -414,11 +311,14 @@ function applyHostedSkills(
 					...preparedReservationIdentity(prepared),
 				},
 				() => {
-					return driver.install(prepared, targetDir, reservation);
+					return driver.install(prepared, targetDir);
 				},
 				{
-					verify: () => driver.verifyOwned(prepared, targetDir),
-					discard: () => discardPendingHostedSkill(driver, managedResourceRoot, skillId, targetDir),
+					verify: () =>
+						installedTreeMatches(prepared, targetDir, {
+							exclude: driver.installedTreeExcludes,
+						}),
+					discard: () => discardPendingHostedSkill(targetDir),
 				},
 			);
 		} catch (error) {
@@ -461,15 +361,25 @@ export function reconcileHostedSkillProjection(input: {
 	const drivers = hostedSkillProjectionDrivers({
 		manifest,
 		home,
-		managedResourceRoot,
 		openClawWorkspaceRoot,
 		hermesDriver,
 		openClawDriver,
 	});
+	rmSync(join(managedResourceRoot, "skill-receipts"), { recursive: true, force: true });
+	for (const driver of drivers) {
+		const skillsRoot = driver.skillsRoot;
+		if (skillsRoot) {
+			withRuntimeUserFileAccess(() =>
+				rmSync(join(skillsRoot, ".clawdi-manifest-receipts"), {
+					recursive: true,
+					force: true,
+				}),
+			);
+		}
+	}
 	runHostedSkillProjectionStep("runtime Skill projection planning failed", () => {
 		for (const driver of drivers) {
-			recoverPendingHostedSkillInstallations(driver, manifest, managedResourceRoot, preparedSkills);
-			recoverHostedSkillReservations(driver, manifest, preparedSkills);
+			recoverPendingHostedSkillInstallations(driver, manifest, preparedSkills);
 			validateHostedSkillsPlan(driver, manifest, preparedSkills);
 		}
 	});
@@ -477,14 +387,7 @@ export function reconcileHostedSkillProjection(input: {
 	for (const driver of drivers) {
 		const driverFailures = runHostedSkillProjectionStep(
 			`runtime ${driver.name} Skill projection failed`,
-			() =>
-				applyHostedSkills(
-					driver,
-					observations.get(driver.name),
-					manifest,
-					managedResourceRoot,
-					preparedSkills,
-				),
+			() => applyHostedSkills(driver, observations.get(driver.name), manifest, preparedSkills),
 		);
 		failures.push(
 			...driverFailures.map(

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -61,8 +61,11 @@ import { createOpenClawHostedContext } from "../src/runtime/hosted-openclaw-cont
 import { hostedOpenClawSkillDriver } from "../src/runtime/hosted-openclaw-skill";
 import { hostedAiProviderCatalog } from "../src/runtime/hosted-provider-resolution";
 import { MANAGED_BAILEYS_STATIC_PATCH_TARGETS } from "../src/runtime/managed-baileys-compat";
-import { managedSkillReceiptPath } from "../src/runtime/managed-skill-delivery";
-import { releaseManagedSkill, reserveManagedSkill } from "../src/runtime/managed-skill-reservation";
+import {
+	managedSkillReservationLedgerPath,
+	releaseManagedSkill,
+	reserveManagedSkill,
+} from "../src/runtime/managed-skill-reservation";
 import {
 	buildOpenClawHostedProviderPatch,
 	convergeRuntimeManifest as convergeRuntimeManifestWithContext,
@@ -15918,14 +15921,17 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			runtimes: { openclaw: ["clawdi", "search.proxy"] },
 		});
 		expect(
-			existsSync(managedSkillReceiptPath(paths.managedResourceRoot, "openclaw", "clawdi")),
-		).toBe(true);
+			JSON.parse(readFileSync(managedSkillReservationLedgerPath(), "utf-8")).reservations[
+				openclawSkill
+			],
+		).toMatchObject({ id: "clawdi", manager: "hosted-manifest" });
 
+		const installedSkill = readFileSync(join(openclawSkill, "SKILL.md"), "utf-8");
 		writeFileSync(join(openclawSkill, "SKILL.md"), "tenant mutation before restart\n");
 		rmSync(paths.configurationRoot, { recursive: true, force: true });
 		const restarted = convergeRuntimeManifest(load(1, "openclaw", initialServers), paths);
 		expect(restarted.installErrors).toEqual([]);
-		expect(readFileSync(join(openclawSkill, "SKILL.md"), "utf-8")).not.toContain("tenant mutation");
+		expect(readFileSync(join(openclawSkill, "SKILL.md"), "utf-8")).toBe(installedSkill);
 		expect(readOpenClawMcpServers(home).clawdi).toEqual(initialServers.clawdi);
 		expect(existsSync(ledgerPath)).toBe(true);
 
@@ -15968,14 +15974,13 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			hermes: ["clawdi", "search.proxy"],
 		});
 		const hermesSkill = join(home, ".hermes", "skills", "clawdi");
-		const hermesSkillReceipt = JSON.parse(
-			readFileSync(managedSkillReceiptPath(paths.managedResourceRoot, "hermes", "clawdi"), "utf-8"),
-		);
-		expect(hermesSkillReceipt).toEqual({
-			schemaVersion: "clawdi.hermesManifestSkillReceipt.v2",
-			skillId: "clawdi",
-			ownershipIdentity: expect.stringMatching(/^content-sha256\0[a-f0-9]{64}$/),
-			treeFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+		const hermesSkillReservation = JSON.parse(
+			readFileSync(managedSkillReservationLedgerPath(), "utf-8"),
+		).reservations[hermesSkill];
+		expect(hermesSkillReservation).toMatchObject({
+			id: "clawdi",
+			manager: "hosted-manifest",
+			digest: expect.stringMatching(/^[a-f0-9]{64}$/),
 		});
 		process.env.CLAWDI_RUNTIME_MODE = "local";
 		expect(() =>


### PR DESCRIPTION
## Summary

- Collapse hosted Skill ownership to the managed reservation ledger and remove the parallel platform receipt subsystem.
- Verify the installed tree against the prepared source during pending-install recovery, unchanged detection, and installation commit; repair drift instead of promoting stale, partial, or symlinked targets.
- Keep bundled reservation identity on the stable catalog content digest and use the prepared archive SHA-256 for sourced reservation payload identity.
- Garbage-collect both retired Skill receipt directories during reconciliation.
- Preserve non-rebuildable WhatsApp sessions with a one-release fallback that reads the legacy in-tree marker through the hardened reader, writes the current receipt, and removes only the old marker after successful materialization.

## Background

A production-state audit found that Skill ownership was duplicated between ledger reservations and platform receipts. Keeping both records synchronized created ambiguous unmanaged-state decisions and made a missing delivery receipt block cleanup even when the reservation ledger already proved platform ownership.

Released 0.13.x CLIs already reserved both bundled and sourced hosted Skill targets. This change makes that existing ledger the single source of truth: the manifest defines desired state, the reservation defines ownership, and rebuildable Skill trees are replaced or removed without legacy-marker migration.

The audit also identified a crash window where a pending reservation could be promoted solely because its target path existed. A restart between the pending-ledger write and the installer's final rename could therefore bless an old or partial tree. Recovery and steady-state convergence now compare the prepared and installed trees byte-for-byte. OpenClaw's official `.openclaw/source-origin.json` metadata is excluded from that comparison, matching its native install contract.

## Ledger semantics

For `hosted-manifest` reservations, `digest` is the source-native payload digest: the catalog tree digest for bundled Skills and the prepared archive SHA-256 for sourced Skills. The digest is a cheap desired-source precondition; exact installed-tree equality is the final unchanged and promotion condition. `local-setup` reservations continue to use the installed directory-content digest.

The first 0.14.13 to 0.14.14 convergence reinstalls each sourced managed Skill once because its 0.14.13 reservation has `sourceIdentity` but no payload `digest`; successful convergence promotes it to the new ledger semantics. Bundled reservations already carry the stable catalog content digest and remain in place when their installed tree is exact. This is intentionally not described as a zero-change upgrade.

## Verification

- CLI Docker clean runner: 1763 passed, 4 skipped, 0 failed across 1767 tests
- CLI TypeScript typecheck passed in the same clean runner
- Root-container 0.13.92 Hermes/OpenClaw upgrade fixture passed
- Full repository Biome check passed in an isolated container (1071 files)
- Focused Skill and reconciliation suite: 202 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
