### PR TITLE
release(cli): 0.14.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.14
+
+Package: `clawdi@0.14.14`
+
+### Changed
+
+- Collapse hosted Skill ownership to the reservation ledger; platform receipt
+  subsystem removed (net -900 lines).
+- WhatsApp auth directory: adopt 0.13.x in-tree marker into the platform
+  receipt on upgrade, session preserved.
+
 ## Clawdi CLI v0.14.13
 
 Package: `clawdi@0.14.13`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.13",
+      "version": "0.14.14",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.13",
+	"version": "0.14.14",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary

- Bump the `clawdi` CLI package and lockfile entry from 0.14.13 to 0.14.14.
- Document reservation-ledger Skill ownership cleanup and WhatsApp auth marker adoption.

## Verification

- `bun run --cwd packages/cli typecheck`
- `bun run --cwd packages/cli test` (1763 passed, 4 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)