### PR TITLE
Lean runtime lifecycle contracts

### DIFF
--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -97,6 +97,7 @@ import {
 	loadTransparentEgressEnvConfig,
 	type TransparentEgressEnvConfig,
 } from "../runtime/transparent-egress";
+import { log, toErrorMessage } from "../serve/log";
 import { consumeSse } from "../serve/sse-client";
 
 interface RuntimeInitOptions {
@@ -126,6 +127,14 @@ interface RuntimeVerifyOptions {
 // A dedicated temporary-failure exit makes it start the newly activated CLI;
 // runtime watch instead exits cleanly because its unit uses Restart=always.
 const RUNTIME_INIT_CLI_HANDOFF_EXIT_CODE = 75;
+const ACTIVE_CLI_VERSION = getCliVersion();
+const RUNTIME_WATCH_INTERVAL_MS = 15_000;
+const RUNTIME_WATCH_SELF_HEAL_MS = 300_000;
+const RUNTIME_WATCH_INITIAL_BACKOFF_MS = 60_000;
+const RUNTIME_WATCH_MAX_BACKOFF_MS = 300_000;
+const EGRESS_LISTEN_TIMEOUT_MS = 15_000;
+const EGRESS_CA_TIMEOUT_MS = 10_000;
+const EGRESS_READY_POLL_MS = 100;
 
 interface RuntimeDoctorCheck {
 	name: string;
@@ -234,6 +243,17 @@ export function runtimePublicContentRevision(load: RuntimeManifestLoad): string 
 	return runtimeContentSha256({ manifest: load.manifest });
 }
 
+function runtimeAppliedStatus(paths: RuntimePaths): {
+	activeGeneration: number | null;
+	instanceId: string | null;
+} {
+	const applied = readRuntimeAppliedState(paths);
+	return {
+		activeGeneration: applied?.generation ?? null,
+		instanceId: applied?.instanceId ?? null,
+	};
+}
+
 function runtimeCheckpointContent(
 	load: Pick<RuntimeManifestLoad, "manifest" | "secretValues">,
 ): unknown {
@@ -268,7 +288,8 @@ export function runtimeOnlyChangesCliPackage(
 			runtimeContentSha256(runtimeCheckpointContent(previous)) ===
 			runtimeContentSha256(runtimeCheckpointContent(next))
 		);
-	} catch {
+	} catch (error) {
+		log.warn("runtime.cli_only_checkpoint_compare_failed", { error: toErrorMessage(error) });
 		return false;
 	}
 }
@@ -586,7 +607,7 @@ function finishRuntimeInitCliHandoff(input: {
 		| { cliUpdate: RuntimeCliUpdateResult }
 		| { reconciliation: RuntimeCliReconciliationResult };
 }): void {
-	const activeAppliedState = readRuntimeAppliedState(input.paths);
+	const applied = runtimeAppliedStatus(input.paths);
 	emitRuntimeInitStatus({
 		opts: input.opts,
 		paths: input.paths,
@@ -596,9 +617,9 @@ function finishRuntimeInitCliHandoff(input: {
 			stage: "config",
 			bootId: input.bootId,
 			runtimeMode: input.mode,
-			activeGeneration: activeAppliedState?.generation ?? null,
+			activeGeneration: applied.activeGeneration,
 			rejectedGeneration: null,
-			instanceId: activeAppliedState?.instanceId ?? null,
+			instanceId: applied.instanceId,
 			enabledRuntimes: [],
 			errors: [],
 			exitCode: RUNTIME_INIT_CLI_HANDOFF_EXIT_CODE,
@@ -639,15 +660,13 @@ export async function runtimeVerify(opts: RuntimeVerifyOptions = {}) {
 				errors.push(`cached manifest parse failed: ${z.prettifyError(parsed.error)}`);
 			}
 		} catch (error) {
-			errors.push(
-				`cached manifest parse failed: ${error instanceof Error ? error.message : String(error)}`,
-			);
+			errors.push(`cached manifest parse failed: ${toErrorMessage(error)}`);
 		}
 	}
 	const result = {
 		schemaVersion: "clawdi.runtimeVerify.v1",
 		status: errors.length === 0 ? "ok" : "error",
-		cliVersion: getCliVersion(),
+		cliVersion: ACTIVE_CLI_VERSION,
 		manifestCache: {
 			path: paths.manifestLastGood,
 			exists: manifestCacheExists,
@@ -695,7 +714,7 @@ export async function runtimeInit(opts: RuntimeInitOptions = {}) {
 			platformRoots: "deferred",
 		});
 	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
+		const message = toErrorMessage(error);
 		emitRuntimeInitRepair({
 			opts,
 			paths,
@@ -719,11 +738,7 @@ export async function runtimeInit(opts: RuntimeInitOptions = {}) {
 			runtimeMode: mode,
 			stage: "detect",
 			exitCode: 20,
-			errors: [
-				`could not create runtime state directories: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
-			],
+			errors: [`could not create runtime state directories: ${toErrorMessage(error)}`],
 			persist: false,
 			render: (status) => console.log(chalk.red(status.error)),
 		});
@@ -742,7 +757,7 @@ async function runtimeInitLocked(
 ): Promise<void> {
 	const hostPolicy = readHostPolicy(paths.hostPolicy);
 	try {
-		const reconciliation = reconcilePendingRuntimeCliUpgrade(paths, getCliVersion());
+		const reconciliation = reconcilePendingRuntimeCliUpgrade(paths, ACTIVE_CLI_VERSION);
 		if (reconciliation.selfReexec) {
 			finishRuntimeInitCliHandoff({
 				opts,
@@ -755,7 +770,7 @@ async function runtimeInitLocked(
 			return;
 		}
 	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
+		const message = toErrorMessage(error);
 		emitRuntimeInitRepair({
 			opts,
 			paths,
@@ -818,8 +833,8 @@ async function runtimeInitLocked(
 				hostedRuntimeContract: opts.hostedRuntimeContract,
 			});
 		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			const activeAppliedState = readRuntimeAppliedState(paths);
+			const message = toErrorMessage(error);
+			const applied = runtimeAppliedStatus(paths);
 			emitRuntimeInitStatus({
 				opts,
 				paths,
@@ -829,9 +844,9 @@ async function runtimeInitLocked(
 					stage: "final",
 					bootId,
 					runtimeMode: mode,
-					activeGeneration: activeAppliedState?.generation ?? null,
+					activeGeneration: applied.activeGeneration,
 					rejectedGeneration: convergenceLoad.manifest.generation,
-					instanceId: activeAppliedState?.instanceId ?? null,
+					instanceId: applied.instanceId,
 					enabledRuntimes: [],
 					error: message,
 					errors: [message],
@@ -854,7 +869,7 @@ async function runtimeInitLocked(
 		}
 		if (applyResult.kind === "cli_update_failed") {
 			const message = applyResult.cliUpdate.error ?? "CLI update failed";
-			const activeAppliedState = readRuntimeAppliedState(paths);
+			const applied = runtimeAppliedStatus(paths);
 			emitRuntimeInitStatus({
 				opts,
 				paths,
@@ -864,9 +879,9 @@ async function runtimeInitLocked(
 					stage: "config",
 					bootId,
 					runtimeMode: mode,
-					activeGeneration: activeAppliedState?.generation ?? null,
+					activeGeneration: applied.activeGeneration,
 					rejectedGeneration: convergenceLoad.manifest.generation,
-					instanceId: activeAppliedState?.instanceId ?? null,
+					instanceId: applied.instanceId,
 					enabledRuntimes: [],
 					error: message,
 					errors: [message],
@@ -893,11 +908,11 @@ async function runtimeInitLocked(
 		const runtimeErrors = [...convergence.installErrors];
 		const runtimeReady = runtimeErrors.length === 0;
 		if (runtimeReady) {
-			completePendingRuntimeCliUpgrade(paths, getCliVersion());
+			completePendingRuntimeCliUpgrade(paths, ACTIVE_CLI_VERSION);
 		} else {
 			maybeRollbackFailedCliUpgrade(paths, runtimeErrors);
 		}
-		const activeAppliedState = readRuntimeAppliedState(paths);
+		const applied = runtimeAppliedStatus(paths);
 		emitRuntimeInitStatus({
 			opts,
 			paths,
@@ -907,9 +922,9 @@ async function runtimeInitLocked(
 				stage: "final",
 				bootId,
 				runtimeMode: mode,
-				activeGeneration: activeAppliedState?.generation ?? null,
+				activeGeneration: applied.activeGeneration,
 				rejectedGeneration: runtimeReady ? null : convergence.manifest.generation,
-				instanceId: activeAppliedState?.instanceId ?? null,
+				instanceId: applied.instanceId,
 				enabledRuntimes: convergence.enabledRuntimes,
 				error: runtimeErrors[0],
 				errors: runtimeErrors,
@@ -975,9 +990,9 @@ async function runtimeWatchTickLocked(
 ): Promise<Record<string, unknown> | null> {
 	let reconciliation: RuntimeCliReconciliationResult;
 	try {
-		reconciliation = reconcilePendingRuntimeCliUpgrade(paths, getCliVersion());
+		reconciliation = reconcilePendingRuntimeCliUpgrade(paths, ACTIVE_CLI_VERSION);
 	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
+		const message = toErrorMessage(error);
 		return {
 			schemaVersion: "clawdi.runtimeWatchEvent.v1",
 			status: "error",
@@ -1051,7 +1066,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 			runtimeAppliedApplyIdentity(activeAppliedState),
 		)
 	) {
-		const completion = completePendingRuntimeCliUpgrade(paths, getCliVersion());
+		const completion = completePendingRuntimeCliUpgrade(paths, ACTIVE_CLI_VERSION);
 		return {
 			schemaVersion: "clawdi.runtimeWatchEvent.v1",
 			status: "not_modified",
@@ -1091,15 +1106,15 @@ async function runtimeWatchTickAfterCliReconciliation(
 			hostedRuntimeContract: opts.hostedRuntimeContract,
 		});
 		if (applyResult.kind === "cli_handoff") {
-			const activeAppliedState = readRuntimeAppliedState(paths);
+			const applied = runtimeAppliedStatus(paths);
 			return {
 				schemaVersion: "clawdi.runtimeWatchEvent.v1",
 				status: "cli_handoff",
 				stage: "cli-update",
 				handoff: "cli_reexec",
-				activeGeneration: activeAppliedState?.generation ?? null,
+				activeGeneration: applied.activeGeneration,
 				desiredGeneration: loaded.manifest.generation,
-				instanceId: activeAppliedState?.instanceId ?? null,
+				instanceId: applied.instanceId,
 				cliUpdate: applyResult.cliUpdate,
 				selfReexec: true,
 				systemdUnitsChanged: false,
@@ -1112,16 +1127,16 @@ async function runtimeWatchTickAfterCliReconciliation(
 		}
 		if (applyResult.kind === "cli_update_failed") {
 			const error = applyResult.cliUpdate.error ?? "CLI update failed";
-			const activeAppliedState = readRuntimeAppliedState(paths);
+			const applied = runtimeAppliedStatus(paths);
 			return {
 				schemaVersion: "clawdi.runtimeWatchEvent.v1",
 				status: "error",
 				stage: "cli-update",
 				errors: [error],
 				error,
-				activeGeneration: activeAppliedState?.generation ?? null,
+				activeGeneration: applied.activeGeneration,
 				rejectedGeneration: loaded.manifest.generation,
-				instanceId: activeAppliedState?.instanceId ?? null,
+				instanceId: applied.instanceId,
 				etag: bundleEtag,
 				cliUpdate: applyResult.cliUpdate,
 				selfReexec: applyResult.cliUpdate.selfReexec,
@@ -1159,19 +1174,19 @@ async function runtimeWatchTickAfterCliReconciliation(
 				: maybeRollbackFailedCliUpgrade(paths, errors);
 			if (cliRollback?.status === "rolled_back") selfReexec = true;
 			if (resourceProjectionOnly) {
-				const completion = completePendingRuntimeCliUpgrade(paths, getCliVersion());
+				const completion = completePendingRuntimeCliUpgrade(paths, ACTIVE_CLI_VERSION);
 				selfReexec = selfReexec || completion.selfReexec;
 			}
-			const activeAppliedState = readRuntimeAppliedState(paths);
+			const applied = runtimeAppliedStatus(paths);
 			return {
 				schemaVersion: "clawdi.runtimeWatchEvent.v1",
 				status: "error",
 				stage: cliUpdateError ? "cli-update" : "final",
 				errors,
 				error: errors[0],
-				activeGeneration: activeAppliedState?.generation ?? null,
+				activeGeneration: applied.activeGeneration,
 				rejectedGeneration: resourceProjectionOnly ? null : convergence.manifest.generation,
-				instanceId: activeAppliedState?.instanceId ?? null,
+				instanceId: applied.instanceId,
 				etag: bundleEtag,
 				cliUpdate,
 				...(cliRollback ? { cliRollback } : {}),
@@ -1183,7 +1198,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 				...(agentPluginFailure ? { agentPlugins: agentPluginFailure } : {}),
 			};
 		}
-		const completion = completePendingRuntimeCliUpgrade(paths, getCliVersion());
+		const completion = completePendingRuntimeCliUpgrade(paths, ACTIVE_CLI_VERSION);
 		selfReexec = selfReexec || completion.selfReexec;
 		return {
 			schemaVersion: "clawdi.runtimeWatchEvent.v1",
@@ -1201,7 +1216,7 @@ async function runtimeWatchTickAfterCliReconciliation(
 			convergence: convergence.outputs,
 		};
 	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
+		const message = toErrorMessage(error);
 		return {
 			schemaVersion: "clawdi.runtimeWatchEvent.v1",
 			status: "error",
@@ -1284,7 +1299,7 @@ async function applyRuntimeDesiredState(
 			cliUpdate = applyRuntimeCliDesiredState(load.manifest, paths, {
 				deferInstall: opts.deferCliInstall,
 				deferReason: opts.deferCliInstallReason,
-				runningVersion: getCliVersion(),
+				runningVersion: ACTIVE_CLI_VERSION,
 			});
 		} catch (error) {
 			if (!opts.continueOnCliUpdateError) throw error;
@@ -1304,9 +1319,7 @@ async function applyRuntimeDesiredState(
 				});
 			} catch (error) {
 				resourcePreparationFailures.agentPlugins = {
-					error: `runtime Agent Plugin package preparation failed: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
+					error: `runtime Agent Plugin package preparation failed: ${toErrorMessage(error)}`,
 					installationNames: Object.keys(
 						load.manifest.projection?.agentPlugins?.installations ?? {},
 					).sort(),
@@ -1324,9 +1337,7 @@ async function applyRuntimeDesiredState(
 					},
 				);
 			} catch (error) {
-				resourcePreparationFailures.sourcedSkills = `runtime sourced Skill archive preparation failed: ${
-					error instanceof Error ? error.message : String(error)
-				}`;
+				resourcePreparationFailures.sourcedSkills = `runtime sourced Skill archive preparation failed: ${toErrorMessage(error)}`;
 			}
 		}
 		const previousSystemdUnits = readSystemdUnitSnapshot(paths);
@@ -1395,9 +1406,7 @@ async function applyRuntimeDesiredState(
 						return prerequisite;
 					} catch (error) {
 						throw new Error(
-							`transparent-egress prerequisite activation failed: ${
-								error instanceof Error ? error.message : String(error)
-							}`,
+							`transparent-egress prerequisite activation failed: ${toErrorMessage(error)}`,
 						);
 					}
 				},
@@ -1466,7 +1475,7 @@ async function applyRuntimeDesiredState(
 							)
 							.join(", ");
 						throw new Error(
-							`systemd apply failed: ${error instanceof Error ? error.message : String(error)}${
+							`systemd apply failed: ${toErrorMessage(error)}${
 								mutationJournal ? `; mutation journal: ${mutationJournal}` : ""
 							}`,
 						);
@@ -1487,11 +1496,7 @@ async function applyRuntimeDesiredState(
 					),
 				);
 			} catch (error) {
-				console.warn(
-					`post-commit Agent Plugin archive cleanup deferred: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
-				);
+				console.warn(`post-commit Agent Plugin archive cleanup deferred: ${toErrorMessage(error)}`);
 			}
 		}
 		return { kind: "converged", cliUpdate, convergence, systemdApply };
@@ -1507,7 +1512,7 @@ function runtimeCliUpdateError(
 	paths: ReturnType<typeof getRuntimePaths>,
 	error: unknown,
 ): RuntimeCliUpdateResult {
-	const rawRegistry = (manifest.clawdiCli as Record<string, unknown> | undefined)?.registry;
+	const rawRegistry = manifest.clawdiCli?.registry;
 	return {
 		status: "error",
 		packageSpec: manifest.clawdiCli?.packageSpec?.trim() || null,
@@ -1518,7 +1523,7 @@ function runtimeCliUpdateError(
 		activeTarget: null,
 		version: null,
 		selfReexec: false,
-		error: error instanceof Error ? error.message : String(error),
+		error: toErrorMessage(error),
 	};
 }
 
@@ -1554,8 +1559,8 @@ async function loadFullRuntimeManifestForWatch(
 export async function runtimeWatch(opts: RuntimeWatchOptions = {}) {
 	const paths = getRuntimePaths();
 	const mode = detectRuntimeMode();
-	const intervalMs = parsePositiveMs(opts.intervalMs, 15_000, "--interval-ms");
-	const selfHealMs = parsePositiveMs(opts.selfHealMs, 300_000, "--self-heal-ms");
+	const intervalMs = parsePositiveMs(opts.intervalMs, RUNTIME_WATCH_INTERVAL_MS, "--interval-ms");
+	const selfHealMs = parsePositiveMs(opts.selfHealMs, RUNTIME_WATCH_SELF_HEAL_MS, "--self-heal-ms");
 	let cliInstallRetryPending = false;
 	let cliInstallBackoffMs = 0;
 	let nextCliInstallRetryAt = 0;
@@ -1583,7 +1588,7 @@ export async function runtimeWatch(opts: RuntimeWatchOptions = {}) {
 			platformRoots: "deferred",
 		});
 	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
+		const message = toErrorMessage(error);
 		const event = {
 			schemaVersion: "clawdi.runtimeWatchEvent.v1",
 			status: "error",
@@ -1599,9 +1604,7 @@ export async function runtimeWatch(opts: RuntimeWatchOptions = {}) {
 	try {
 		ensureRuntimeStateDirs(paths);
 	} catch (error) {
-		const message = `could not create runtime state directories: ${
-			error instanceof Error ? error.message : String(error)
-		}`;
+		const message = `could not create runtime state directories: ${toErrorMessage(error)}`;
 		const event = {
 			schemaVersion: "clawdi.runtimeWatchEvent.v1",
 			status: "error",
@@ -1653,7 +1656,7 @@ export async function runtimeWatch(opts: RuntimeWatchOptions = {}) {
 						: undefined,
 				});
 			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
+				const message = toErrorMessage(error);
 				event = {
 					schemaVersion: "clawdi.runtimeWatchEvent.v1",
 					status: "error",
@@ -1727,8 +1730,8 @@ function runtimeWatchCliUpdateStatus(
 }
 
 function nextBoundedBackoffMs(previousMs: number): number {
-	if (previousMs <= 0) return 60_000;
-	return Math.min(previousMs * 2, 300_000);
+	if (previousMs <= 0) return RUNTIME_WATCH_INITIAL_BACKOFF_MS;
+	return Math.min(previousMs * 2, RUNTIME_WATCH_MAX_BACKOFF_MS);
 }
 
 export async function runtimeSidecar(): Promise<void> {
@@ -1779,9 +1782,7 @@ async function startRuntimeEgress(): Promise<RuntimeEgressModule> {
 		try {
 			cleanupTransparentEgressNftRulesFromEnv(process.env);
 		} catch (error) {
-			console.error(
-				`transparent egress nft cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
-			);
+			console.error(`transparent egress nft cleanup failed: ${toErrorMessage(error)}`);
 		}
 		redirectApplied = false;
 	};
@@ -1791,10 +1792,10 @@ async function startRuntimeEgress(): Promise<RuntimeEgressModule> {
 		if (!mitmdump.killed) mitmdump.kill("SIGTERM");
 	};
 	try {
-		await waitForTcpPort("127.0.0.1", config.transparentPort, 15_000, () =>
+		await waitForTcpPort("127.0.0.1", config.transparentPort, EGRESS_LISTEN_TIMEOUT_MS, () =>
 			childHasExited(mitmdump),
 		);
-		await waitForFile(config.caCertPath, 10_000, () => childHasExited(mitmdump));
+		await waitForFile(config.caCertPath, EGRESS_CA_TIMEOUT_MS, () => childHasExited(mitmdump));
 		publishEgressSystemCaBundle(config);
 		applyTransparentEgressNftRulesFromEnv(process.env);
 		redirectApplied = true;
@@ -1930,7 +1931,7 @@ function waitForTcpPort(
 				reject(new Error(`timed out waiting for egress engine on ${host}:${port}`));
 				return;
 			}
-			setTimeout(attempt, 100);
+			setTimeout(attempt, EGRESS_READY_POLL_MS);
 		};
 		attempt();
 	});
@@ -1972,7 +1973,7 @@ function waitForFile(path: string, timeoutMs: number, hasExited: () => boolean):
 				reject(new Error(`timed out waiting for ${path}`));
 				return;
 			}
-			setTimeout(attempt, 100);
+			setTimeout(attempt, EGRESS_READY_POLL_MS);
 		};
 		attempt();
 	});
@@ -2073,7 +2074,7 @@ export async function runtimeDoctor(opts: { json?: boolean } = {}) {
 		runtimeContextOk = context.backend === "incus";
 		runtimeContextDetail = context.backend;
 	} catch (error) {
-		runtimeContextDetail = error instanceof Error ? error.message : String(error);
+		runtimeContextDetail = toErrorMessage(error);
 	}
 	let platformRootsOk = true;
 	let platformRootsDetail = "trusted";
@@ -2081,7 +2082,7 @@ export async function runtimeDoctor(opts: { json?: boolean } = {}) {
 		assertRuntimePlatformRoots(paths);
 	} catch (error) {
 		platformRootsOk = false;
-		platformRootsDetail = error instanceof Error ? error.message : String(error);
+		platformRootsDetail = toErrorMessage(error);
 	}
 	const checks: RuntimeDoctorCheck[] = [
 		{

--- a/packages/cli/src/runtime/apply-identity.test.ts
+++ b/packages/cli/src/runtime/apply-identity.test.ts
@@ -109,19 +109,17 @@ describe("runtime apply identity", () => {
 		expect(() => readRuntimeApplyContext()).toThrow(/canonical absolute path/);
 	});
 
-	test("reads legacy v2 context without treating its CLI field as authority", () => {
-		const root = mkdtempSync(join(tmpdir(), "clawdi-paired-cli-fixture-"));
+	test("reads legacy v2 context only with an exact CLI version", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-v2-context-"));
 		roots.push(root);
 		const path = contextFile(root);
 		const parsed: Record<string, unknown> = JSON.parse(readFileSync(path, "utf-8"));
 		parsed.schemaVersion = "clawdi.runtimeContext.v2";
-		parsed.cliPackageSpec = "/usr/local/share/clawdi/bootstrap/clawdi-local.tgz";
+		parsed.cliPackageSpec = "clawdi@1.2.3-test";
 		writeFileSync(path, JSON.stringify(parsed));
-		expect(() => readRuntimeApplyContext(path)).toThrow(/CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS=1/);
-		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
 		expect(readRuntimeApplyContext(path).identity.generation).toBe(8);
 
-		parsed.cliPackageSpec = "/tmp/clawdi-local.tgz";
+		parsed.cliPackageSpec = "/usr/local/share/clawdi/bootstrap/clawdi-local.tgz";
 		writeFileSync(path, JSON.stringify(parsed));
 		expect(() => readRuntimeApplyContext(path)).toThrow(/invalid runtime context file/);
 	});

--- a/packages/cli/src/runtime/apply-identity.ts
+++ b/packages/cli/src/runtime/apply-identity.ts
@@ -1,10 +1,8 @@
 import { readFileSync } from "node:fs";
 import { isAbsolute } from "node:path";
 import { z } from "zod";
-import {
-	HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE,
-	hostedCliPackageSpecSchema,
-} from "./manifest-contract";
+import { toErrorMessage } from "../serve/log";
+import { hostedCliPackageSpecSchema } from "./manifest-contract";
 import { getRuntimePaths } from "./paths";
 
 export const runtimeApplyIdentitySchema = z
@@ -85,9 +83,7 @@ const runtimeContextV2FileSchema = z
 		schemaVersion: z.literal("clawdi.runtimeContext.v2"),
 		backend: z.literal("incus"),
 		apply: runtimeApplyIdentitySchema,
-		cliPackageSpec: hostedCliPackageSpecSchema.or(
-			z.literal(HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE),
-		),
+		cliPackageSpec: hostedCliPackageSpecSchema,
 		manifestSource: runtimeManifestSourceSchema,
 	})
 	.strict();
@@ -152,11 +148,7 @@ function readRuntimeContextFile(contextPath: string): RuntimeContextFile {
 	try {
 		raw = JSON.parse(readFileSync(contextPath, "utf-8"));
 	} catch (error) {
-		throw new Error(
-			`could not read runtime context file ${contextPath}: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		throw new Error(`could not read runtime context file ${contextPath}: ${toErrorMessage(error)}`);
 	}
 	const parsed = runtimeContextFileSchema.safeParse(raw);
 	if (!parsed.success) {
@@ -164,15 +156,6 @@ function readRuntimeContextFile(contextPath: string): RuntimeContextFile {
 			`invalid runtime context file ${contextPath}: ${parsed.error.issues
 				.map((issue) => `${issue.path.join(".")}: ${issue.message}`)
 				.join("; ")}`,
-		);
-	}
-	if (
-		parsed.data.schemaVersion === "clawdi.runtimeContext.v2" &&
-		parsed.data.cliPackageSpec === HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE &&
-		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS !== "1"
-	) {
-		throw new Error(
-			`invalid runtime context file ${contextPath}: cliPackageSpec: ${HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE} requires CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS=1`,
 		);
 	}
 	return parsed.data;

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -16,7 +16,7 @@ import {
 	symlinkSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { z } from "zod";
 import { log, toErrorMessage } from "../serve/log";
 import { HOSTED_RUNTIME_HOME, HOSTED_RUNTIME_USER } from "./hosted-runtime-contract";
@@ -75,7 +75,7 @@ const runtimeCliBootstrapStatusSchema = z
 		verification: runtimeCliVerificationSchema.optional(),
 		error: z.string().nullable().optional(),
 	})
-	.strict();
+	.loose();
 
 export type RuntimeCliBootstrapStatus = z.infer<typeof runtimeCliBootstrapStatusSchema>;
 
@@ -665,10 +665,23 @@ function cliInstallPlan(
 	const version = exactNpmPackageVersion(packageSpec);
 	if (!version) throw new Error(`clawdi CLI packageSpec must be exact: ${packageSpec}`);
 	return {
-		installPackageSpec: `clawdi@${version}`,
+		installPackageSpec: cliInstallSource(`clawdi@${version}`),
 		npmPrefix: cliPackagePrefix(paths, version),
 		version,
 	};
+}
+
+function cliInstallSource(packageSpec: string): string {
+	const envName = "CLAWDI_RUNTIME_TEST_CLI_INSTALLER";
+	const override = process.env[envName]?.trim();
+	if (!override) return packageSpec;
+	if (process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS !== "1") {
+		throw new Error(`${envName} requires CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS=1`);
+	}
+	if (!isAbsolute(override)) {
+		throw new Error(`${envName} must be an absolute test package path`);
+	}
+	return override;
 }
 
 function cliPackagePrefix(paths: RuntimePaths, version: string): string {

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -16,7 +16,7 @@ import {
 	symlinkSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { z } from "zod";
 import { log, toErrorMessage } from "../serve/log";
 import { HOSTED_RUNTIME_HOME, HOSTED_RUNTIME_USER } from "./hosted-runtime-contract";
@@ -647,10 +647,9 @@ function installCliPackage(
 	if (!before)
 		throw new Error(`installed clawdi bin disappeared before verification: ${activeTarget}`);
 	const version = smokeCliVersion(activeTarget);
-	const exactVersion = exactNpmPackageVersion(packageSpec);
-	if (exactVersion && version !== exactVersion) {
+	if (version !== installPlan.version) {
 		throw new Error(
-			`npm install ${installPlan.installPackageSpec} reported version ${version}, expected ${exactVersion}`,
+			`npm install ${installPlan.installPackageSpec} reported version ${version}, expected ${installPlan.version}`,
 		);
 	}
 	verifyCliRuntime(activeTarget);
@@ -665,23 +664,10 @@ function cliInstallPlan(
 	const version = exactNpmPackageVersion(packageSpec);
 	if (!version) throw new Error(`clawdi CLI packageSpec must be exact: ${packageSpec}`);
 	return {
-		installPackageSpec: cliInstallSource(`clawdi@${version}`),
+		installPackageSpec: `clawdi@${version}`,
 		npmPrefix: cliPackagePrefix(paths, version),
 		version,
 	};
-}
-
-function cliInstallSource(packageSpec: string): string {
-	const envName = "CLAWDI_RUNTIME_TEST_CLI_INSTALLER";
-	const override = process.env[envName]?.trim();
-	if (!override) return packageSpec;
-	if (process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS !== "1") {
-		throw new Error(`${envName} requires CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS=1`);
-	}
-	if (!isAbsolute(override)) {
-		throw new Error(`${envName} must be an absolute test package path`);
-	}
-	return override;
 }
 
 function cliPackagePrefix(paths: RuntimePaths, version: string): string {

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -1,5 +1,5 @@
 import { type SpawnSyncReturns, spawnSync } from "node:child_process";
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import {
 	accessSync,
 	constants,
@@ -20,12 +20,7 @@ import { dirname, join, resolve } from "node:path";
 import { z } from "zod";
 import { log, toErrorMessage } from "../serve/log";
 import { HOSTED_RUNTIME_HOME, HOSTED_RUNTIME_USER } from "./hosted-runtime-contract";
-import {
-	HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE,
-	hostedCliPackageSpecSchema,
-	hostedFixtureCliPackageSpecSchema,
-	type RuntimeManifest,
-} from "./manifest-contract";
+import { hostedCliPackageSpecSchema, type RuntimeManifest } from "./manifest-contract";
 import type { RuntimePaths } from "./paths";
 import { writeRuntimePlatformFileAtomic } from "./state";
 
@@ -44,28 +39,6 @@ export interface RuntimeCliUpdateResult {
 	error?: string | null;
 }
 
-interface RuntimeCliBootstrapStatus {
-	schemaVersion?: string;
-	status?: string;
-	source?: string;
-	packageSpec?: string;
-	registry?: string | null;
-	npmPrefix?: string;
-	npmCache?: string;
-	activePath?: string;
-	activeTarget?: string;
-	version?: string;
-	verification?: RuntimeCliVerification;
-	error?: string | null;
-}
-
-type RuntimeCliInstallIdentity = Required<
-	Pick<
-		RuntimeCliBootstrapStatus,
-		"packageSpec" | "registry" | "npmPrefix" | "activeTarget" | "version"
-	>
->;
-
 interface RuntimeCliBadVersion {
 	packageSpec: string;
 	registry: string | null;
@@ -74,13 +47,44 @@ interface RuntimeCliBadVersion {
 	markedAt?: string;
 }
 
-interface RuntimeCliVerification {
-	verifiedAt: string;
-	device: number;
-	inode: number;
-	size: number;
-	modifiedAtMs: number;
-}
+const runtimeCliVerificationSchema = z
+	.object({
+		verifiedAt: z.string().min(1),
+		device: z.number().int().nonnegative(),
+		inode: z.number().int().nonnegative(),
+		size: z.number().int().nonnegative(),
+		modifiedAtMs: z.number().nonnegative(),
+	})
+	.strict();
+
+type RuntimeCliVerification = z.infer<typeof runtimeCliVerificationSchema>;
+
+const runtimeCliBootstrapStatusSchema = z
+	.object({
+		schemaVersion: z.literal("clawdi.cliNpmBootstrapStatus.v1").optional(),
+		generatedAt: z.string().min(1).optional(),
+		status: z.string().optional(),
+		source: z.string().optional(),
+		packageSpec: z.string().optional(),
+		registry: z.string().nullable().optional(),
+		npmPrefix: z.string().optional(),
+		npmCache: z.string().optional(),
+		activePath: z.string().optional(),
+		activeTarget: z.string().optional(),
+		version: z.string().optional(),
+		verification: runtimeCliVerificationSchema.optional(),
+		error: z.string().nullable().optional(),
+	})
+	.strict();
+
+export type RuntimeCliBootstrapStatus = z.infer<typeof runtimeCliBootstrapStatusSchema>;
+
+type RuntimeCliInstallIdentity = Required<
+	Pick<
+		RuntimeCliBootstrapStatus,
+		"packageSpec" | "registry" | "npmPrefix" | "activeTarget" | "version"
+	>
+>;
 
 interface RuntimeCliUpgradeTransaction {
 	phase: "prepared" | "activated";
@@ -204,7 +208,7 @@ export function applyRuntimeCliDesiredState(
 ): RuntimeCliUpdateResult {
 	const reconciliation = reconcileCliUpgradeTransaction(paths, opts);
 	if (reconciliation.selfReexec) {
-		const status = readBootstrapStatus(paths.cliBootstrapStatus);
+		const status = readRuntimeCliBootstrapStatus(paths);
 		return baseResult(
 			"deferred",
 			paths,
@@ -230,7 +234,7 @@ export function applyRuntimeCliDesiredState(
 	}
 	validatePackageSpec(packageSpec);
 	const registry = cliRegistry(manifest);
-	const current = readBootstrapStatus(paths.cliBootstrapStatus);
+	const current = readRuntimeCliBootstrapStatus(paths);
 	if (isCurrentCliInstall(current, paths, packageSpec, registry)) {
 		return baseResult("current", paths, {
 			packageSpec,
@@ -351,7 +355,7 @@ function baseResult(
 }
 
 function cliRegistry(manifest: RuntimeManifest): string | null {
-	const value = (manifest.clawdiCli as Record<string, unknown> | undefined)?.registry;
+	const value = manifest.clawdiCli?.registry;
 	if (typeof value !== "string" || !value.trim()) return null;
 	const registry = value.trim();
 	let normalized: string;
@@ -371,19 +375,22 @@ function cliRegistry(manifest: RuntimeManifest): string | null {
 }
 
 function validatePackageSpec(packageSpec: string): void {
-	if (hostedFixtureCliPackageSpecSchema.safeParse(packageSpec).success) return;
-	throw new Error(
-		`clawdi CLI packageSpec must be clawdi@<exact-semver> or a managed bootstrap tarball: ${packageSpec}`,
-	);
+	if (hostedCliPackageSpecSchema.safeParse(packageSpec).success) return;
+	throw new Error(`clawdi CLI packageSpec must be clawdi@<exact-semver>: ${packageSpec}`);
+}
+
+export function readRuntimeCliBootstrapStatus(
+	paths: RuntimePaths,
+): RuntimeCliBootstrapStatus | null {
+	return readBootstrapStatus(paths.cliBootstrapStatus);
 }
 
 function readBootstrapStatus(path: string): RuntimeCliBootstrapStatus | null {
 	if (!existsSync(path)) return null;
 	try {
-		const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
-		if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
-		return parsed as RuntimeCliBootstrapStatus;
-	} catch {
+		return runtimeCliBootstrapStatusSchema.parse(JSON.parse(readFileSync(path, "utf-8")));
+	} catch (error) {
+		log.warn("runtime.cli_bootstrap_status_invalid", { path, error: toErrorMessage(error) });
 		return null;
 	}
 }
@@ -424,11 +431,7 @@ function isCurrentCliInstall(
 	if (!status.version) return false;
 	const exactVersion = exactNpmPackageVersion(packageSpec);
 	if (exactVersion && status.version !== exactVersion) return false;
-	const pairedFixtureMatches =
-		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS === "1" &&
-		status.packageSpec === HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE &&
-		exactVersion === status.version;
-	if (status.packageSpec !== packageSpec && !pairedFixtureMatches) return false;
+	if (status.packageSpec !== packageSpec) return false;
 	if ((status.registry ?? null) !== registry) return false;
 	if (!isExecutable(paths.cliManagedBin)) return false;
 	const fileIdentity = cliVerificationIdentity(status.activeTarget);
@@ -448,7 +451,7 @@ function isCurrentCliInstall(
 		writeCliBootstrapStatus(
 			paths,
 			{
-				packageSpec: pairedFixtureMatches ? HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE : packageSpec,
+				packageSpec,
 				registry,
 				npmPrefix: status.npmPrefix,
 				activeTarget: status.activeTarget,
@@ -457,7 +460,11 @@ function isCurrentCliInstall(
 			verification,
 		);
 		return true;
-	} catch {
+	} catch (error) {
+		log.warn("runtime.cli_current_install_verification_failed", {
+			active_target: status.activeTarget,
+			error: toErrorMessage(error),
+		});
 		return false;
 	}
 }
@@ -492,7 +499,7 @@ function verifiedActiveCliIdentity(
 			resolve(status.npmPrefix) === resolve(npmPrefix) &&
 			status.version === version &&
 			statusPackageSpec !== undefined &&
-			hostedFixtureCliPackageSpecSchema.safeParse(statusPackageSpec).success &&
+			hostedCliPackageSpecSchema.safeParse(statusPackageSpec).success &&
 			(exactStatusVersion === null || exactStatusVersion === version) &&
 			(statusRegistry === null || statusRegistry === "https://registry.npmjs.org");
 		return {
@@ -502,7 +509,11 @@ function verifiedActiveCliIdentity(
 			activeTarget,
 			version,
 		};
-	} catch {
+	} catch (error) {
+		log.warn("runtime.cli_active_identity_verification_failed", {
+			active_target: activeTarget,
+			error: toErrorMessage(error),
+		});
 		return null;
 	}
 }
@@ -575,7 +586,7 @@ function installCliPackage(
 	// The version-specific prefix is load-bearing: a fresh candidate is verified
 	// before cliManagedBin switches atomically, and the journal can restore the
 	// previous target without relying on an in-place npm rollback.
-	const installPlan = cliInstallPlan(paths, packageSpec, registry);
+	const installPlan = cliInstallPlan(paths, packageSpec);
 	if (isBadCliVersion(paths, packageSpec, registry, installPlan.version)) {
 		throw new Error(
 			`clawdi CLI ${installPlan.version} is marked bad after rollback; retry deferred until the rollback cooldown expires`,
@@ -650,24 +661,13 @@ function installCliPackage(
 function cliInstallPlan(
 	paths: RuntimePaths,
 	packageSpec: string,
-	registry: string | null,
 ): { installPackageSpec: string; npmPrefix: string; version: string } {
 	const version = exactNpmPackageVersion(packageSpec);
-	if (version) {
-		return {
-			installPackageSpec: `clawdi@${version}`,
-			npmPrefix: cliPackagePrefix(paths, version),
-			version,
-		};
-	}
-	const hash = createHash("sha256")
-		.update(JSON.stringify({ packageSpec, registry }))
-		.digest("hex")
-		.slice(0, 16);
+	if (!version) throw new Error(`clawdi CLI packageSpec must be exact: ${packageSpec}`);
 	return {
-		installPackageSpec: packageSpec,
-		npmPrefix: join(paths.cliNpmPrefix, "packages", `tarball-${hash}`),
-		version: `tarball-${hash}`,
+		installPackageSpec: `clawdi@${version}`,
+		npmPrefix: cliPackagePrefix(paths, version),
+		version,
 	};
 }
 
@@ -744,8 +744,11 @@ function pruneCliPackagePrefixes(paths: RuntimePaths, keepPrefixes: Array<string
 			const path = join(packageRoot, entry.name);
 			if (!keep.has(path)) rmSync(path, { recursive: true, force: true });
 		}
-	} catch {
-		// Best effort only; a failed prune must not block a validated CLI update.
+	} catch (error) {
+		log.warn("runtime.cli_package_prune_failed", {
+			package_root: packageRoot,
+			error: toErrorMessage(error),
+		});
 	}
 }
 
@@ -813,20 +816,14 @@ function verifyCliRuntime(command: string): void {
 		throw new Error("installed clawdi runtime verify self-check returned empty output");
 	}
 	try {
-		const parsed = JSON.parse(output) as unknown;
-		if (
-			!parsed ||
-			typeof parsed !== "object" ||
-			Array.isArray(parsed) ||
-			(parsed as Record<string, unknown>).status !== "ok"
-		) {
-			throw new Error("status was not ok");
-		}
+		z.object({ status: z.literal("ok") })
+			.loose()
+			.parse(JSON.parse(output));
 	} catch (error) {
 		throw new Error(
-			`installed clawdi runtime verify self-check returned invalid JSON: ${
-				error instanceof Error ? error.message : String(error)
-			}${commandOutput(result.stdout, result.stderr)}`,
+			`installed clawdi runtime verify self-check returned invalid JSON: ${toErrorMessage(
+				error,
+			)}${commandOutput(result.stdout, result.stderr)}`,
 		);
 	}
 }
@@ -1167,11 +1164,11 @@ function cliInstallIdentitiesMatch(
 }
 
 function verifiedActiveBootstrapIdentity(paths: RuntimePaths): RuntimeCliInstallIdentity | null {
-	const status = readBootstrapStatus(paths.cliBootstrapStatus);
+	const status = readRuntimeCliBootstrapStatus(paths);
 	const identity = cliBootstrapIdentity(paths, status);
 	if (!identity || activeLinkTarget(paths.cliManagedBin) !== identity.activeTarget) return null;
 	if (!verifyStoredCliIdentity(paths, identity)) return null;
-	const currentStatus = readBootstrapStatus(paths.cliBootstrapStatus);
+	const currentStatus = readRuntimeCliBootstrapStatus(paths);
 	return activeLinkTarget(paths.cliManagedBin) === identity.activeTarget &&
 		statusMatchesIdentity(currentStatus, paths, identity) &&
 		currentStatus?.schemaVersion === "clawdi.cliNpmBootstrapStatus.v1" &&
@@ -1214,7 +1211,7 @@ function cliReconciliationResult(
 	status: RuntimeCliReconciliationResult["status"],
 	runningVersion: string | undefined,
 ): RuntimeCliReconciliationResult {
-	const bootstrap = readBootstrapStatus(paths.cliBootstrapStatus);
+	const bootstrap = readRuntimeCliBootstrapStatus(paths);
 	const activeTarget = activeLinkTarget(paths.cliManagedBin);
 	const activeVersion = bootstrap?.activeTarget === activeTarget ? bootstrap.version : undefined;
 	return {
@@ -1288,7 +1285,7 @@ function verifyStoredCliIdentity(
 	identity: RuntimeCliInstallIdentity,
 ): RuntimeCliVerification | null {
 	if (
-		!hostedFixtureCliPackageSpecSchema.safeParse(identity.packageSpec).success ||
+		!hostedCliPackageSpecSchema.safeParse(identity.packageSpec).success ||
 		(identity.registry !== null && identity.registry !== "https://registry.npmjs.org") ||
 		!isManagedCliTarget(paths, identity.activeTarget) ||
 		!isManagedCliPrefix(paths, identity.npmPrefix) ||
@@ -1299,7 +1296,7 @@ function verifyStoredCliIdentity(
 	}
 	const exactVersion = exactNpmPackageVersion(identity.packageSpec);
 	if (exactVersion && exactVersion !== identity.version) return null;
-	const status = readBootstrapStatus(paths.cliBootstrapStatus);
+	const status = readRuntimeCliBootstrapStatus(paths);
 	const fileIdentity = cliVerificationIdentity(identity.activeTarget);
 	if (
 		statusMatchesIdentity(status, paths, identity) &&
@@ -1319,7 +1316,11 @@ function verifyStoredCliIdentity(
 			writeCliBootstrapStatus(paths, identity, verification);
 		}
 		return verification;
-	} catch {
+	} catch (error) {
+		log.warn("runtime.cli_stored_identity_verification_failed", {
+			active_target: identity.activeTarget,
+			error: toErrorMessage(error),
+		});
 		return null;
 	}
 }
@@ -1351,7 +1352,7 @@ function rollbackErrorResult(
 		previousVersion: transaction?.previousIdentity?.version ?? null,
 		activeTarget: transaction?.newIdentity.activeTarget ?? null,
 		previousActiveTarget: transaction?.previousIdentity?.activeTarget ?? null,
-		error: error instanceof Error ? error.message : String(error),
+		error: toErrorMessage(error),
 	};
 }
 
@@ -1436,7 +1437,7 @@ function quarantineInvalidCliUpgradeState(
 }
 
 function repairCliInstallAfterInvalidUpgradeState(paths: RuntimePaths): void {
-	const status = readBootstrapStatus(paths.cliBootstrapStatus);
+	const status = readRuntimeCliBootstrapStatus(paths);
 	const activeIdentity = verifiedActiveCliIdentity(paths, status);
 	if (activeIdentity) {
 		const verification = verifyStoredCliIdentity(paths, activeIdentity);

--- a/packages/cli/src/runtime/heartbeat-observation.test.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.test.ts
@@ -322,56 +322,6 @@ describe("hosted runtime heartbeat observation", () => {
 		});
 	});
 
-	test("advertises a successor before rotating legacy durable state", () => {
-		const paths = tempRuntimePaths();
-		writeRuntimeAppliedState(companionAppliedState(7), paths);
-		const statePath = runtimeHeartbeatObservationStatePath(paths, "env_legacy_handoff");
-		mkdirSync(dirname(statePath), { recursive: true });
-		writeFileSync(
-			statePath,
-			`${JSON.stringify({
-				schemaVersion: "clawdi.runtimeHeartbeatObservation.v1",
-				environmentId: "env_legacy_handoff",
-				bootIdentity: {
-					generation: 7,
-					manifestETag: '"frozen-manifest-7"',
-					applyReceiptId: "apply-receipt-0007",
-					bootNonce: "boot-nonce-000007",
-					bootSessionId: "boot-session-legacy",
-				},
-				nextSequence: 4,
-				lastCapturedAt: "2026-07-16T02:00:00.000Z",
-				pending: null,
-			})}\n`,
-		);
-		const session = new HostedRuntimeHeartbeatSession({
-			environmentId: "env_legacy_handoff",
-			paths,
-			now: clockSequence(["2026-07-16T02:01:00.000Z", "2026-07-16T02:02:00.000Z"]),
-			createId: idSequence(["event-prepare-handoff", "event-successor"]),
-			createSuccessorId: idSequence(["boot-session-successor", "boot-session-next"]),
-		});
-
-		const preparation = session.nextEvent();
-		if (!preparation) throw new Error("expected successor preparation event");
-		expect(preparation.event).toMatchObject({
-			bootSessionId: "boot-session-legacy",
-			successorBootSessionId: "boot-session-successor",
-			sequence: 4,
-		});
-		expect(preparation.event.predecessorBootSessionId).toBeUndefined();
-		expect(session.acknowledge(preparation.event.eventId)).toBe(true);
-
-		const successor = session.nextEvent();
-		if (!successor) throw new Error("expected causally fenced successor event");
-		expect(successor.event).toMatchObject({
-			bootSessionId: "boot-session-successor",
-			predecessorBootSessionId: "boot-session-legacy",
-			successorBootSessionId: "boot-session-next",
-			sequence: 1,
-		});
-	});
-
 	test("clamps capture time to the durable boot-session high-water", () => {
 		const paths = tempRuntimePaths();
 		writeRuntimeAppliedState(companionAppliedState(7), paths);

--- a/packages/cli/src/runtime/heartbeat-observation.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.ts
@@ -15,7 +15,6 @@ import {
 	runtimeApplyIdentitiesEqual,
 	runtimeApplyIdentitySchema,
 } from "./apply-identity";
-import { agentPluginsObservationSchema } from "./hosted-agent-plugin-observation";
 import { assertRuntimeBundleAuthority } from "./manifest-source";
 import { readHostedRuntimeObserved } from "./observed";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
@@ -24,153 +23,10 @@ import { writeRuntimePlatformFileAtomic } from "./state";
 const positiveSafeIntegerSchema = z.number().int().positive().max(Number.MAX_SAFE_INTEGER);
 const isoTimestampSchema = z.string().datetime({ offset: true });
 
-const observedAppliedSchema = z
-	.object({
-		etag: z.string(),
-		sourceRevision: z.string(),
-		generation: z.number().int().nonnegative(),
-		instanceId: z.string(),
-		appliedProviderIds: z.array(z.string()),
-	})
-	.strict();
-
-const observedBootSchema = z
-	.object({
-		status: z.enum(["ok", "error", "unknown"]),
-		mode: z.string(),
-		stage: z.string(),
-		timestamp: z.string(),
-		activeGeneration: z.number().int().nonnegative().nullable().optional(),
-		instanceId: z.string().nullable().optional(),
-		enabledRuntimes: z.array(z.string()),
-		errors: z.array(z.string()),
-	})
-	.strict();
-
-const observedCliSchema = z
-	.object({
-		status: z.string().nullable().optional(),
-		source: z.string().nullable().optional(),
-		packageSpec: z.string().nullable().optional(),
-		registry: z.string().nullable().optional(),
-		activePath: z.string().nullable().optional(),
-		activeTarget: z.string().nullable().optional(),
-		version: z.string().nullable().optional(),
-	})
-	.strict();
-
-const observedSystemdUnitSchema = z
-	.object({
-		scope: z.enum(["system", "user"]),
-		name: z.string(),
-		activeState: z.string(),
-		subState: z.string(),
-		status: z.enum(["ok", "error", "unknown"]),
-		error: z.string().nullable().optional(),
-	})
-	.strict();
-
-const observedSystemdSchema = z
-	.object({
-		status: z.enum(["ok", "error", "unknown"]),
-		unitCount: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
-		units: z.array(observedSystemdUnitSchema),
-	})
-	.strict()
-	.superRefine((systemd, ctx) => {
-		if (systemd.unitCount < systemd.units.length) {
-			ctx.addIssue({
-				code: "custom",
-				message: "unitCount must include every reported systemd unit",
-				path: ["unitCount"],
-			});
-		}
-	});
-
-const observedSupervisorProgramSchema = z
-	.object({
-		name: z.string(),
-		state: z.string(),
-		status: z.enum(["ok", "error", "unknown"]),
-		description: z.string().nullable().optional(),
-	})
-	.strict();
-
-const observedSupervisorSchema = z
-	.object({
-		status: z.enum(["ok", "error", "unknown"]),
-		programs: z.array(observedSupervisorProgramSchema),
-	})
-	.strict();
-
 export type HostedRuntimeObservedEvent = components["schemas"]["RuntimeObservationEventV2"] & {
 	generation: number;
 	manifestETag: string;
 };
-
-const hostedRuntimeObservedEventSchema: z.ZodType<HostedRuntimeObservedEvent> = z
-	.object({
-		schemaVersion: z.literal("clawdi.hostedRuntimeObserved.v2"),
-		reportedAt: isoTimestampSchema,
-		runtimeMode: z.literal("hosted"),
-		status: z.enum(["ok", "error", "unknown"]),
-		activeCliVersion: z.string().nullable(),
-		applied: observedAppliedSchema,
-		boot: observedBootSchema.nullable(),
-		cli: observedCliSchema.nullable(),
-		systemd: observedSystemdSchema.nullable().optional(),
-		supervisor: observedSupervisorSchema.nullable().optional(),
-		providers: z.record(z.string(), z.record(z.string(), z.unknown())).nullable().optional(),
-		agentPlugins: agentPluginsObservationSchema.nullable().optional(),
-		error: z.string().nullable().optional(),
-		convergeError: z.string().nullable().optional(),
-		truncated: z.boolean().nullable().optional(),
-		generation: positiveSafeIntegerSchema,
-		manifestETag: z.string().min(1).max(128),
-		applyReceiptId: z.string().min(16).max(128),
-		bootNonce: z.string().min(16).max(128),
-		bootSessionId: z.string().min(1).max(128),
-		successorBootSessionId: z.string().min(1).max(128).optional(),
-		predecessorBootSessionId: z.string().min(1).max(128).optional(),
-		sequence: positiveSafeIntegerSchema,
-		eventId: z.string().min(1).max(128),
-		capturedAt: isoTimestampSchema,
-	})
-	.strict()
-	.superRefine((event, ctx) => {
-		if (event.reportedAt !== event.capturedAt) {
-			ctx.addIssue({
-				code: "custom",
-				message: "reportedAt must equal the original capturedAt for companion events",
-				path: ["reportedAt"],
-			});
-		}
-		if (
-			event.systemd &&
-			event.systemd.unitCount > event.systemd.units.length &&
-			event.truncated !== true
-		) {
-			ctx.addIssue({
-				code: "custom",
-				message: "truncated must be true when systemd units are omitted",
-				path: ["truncated"],
-			});
-		}
-		if (event.predecessorBootSessionId === event.bootSessionId) {
-			ctx.addIssue({
-				code: "custom",
-				message: "predecessorBootSessionId must differ from bootSessionId",
-				path: ["predecessorBootSessionId"],
-			});
-		}
-		if (event.successorBootSessionId === event.bootSessionId) {
-			ctx.addIssue({
-				code: "custom",
-				message: "successorBootSessionId must differ from bootSessionId",
-				path: ["successorBootSessionId"],
-			});
-		}
-	});
 
 const persistedBootIdentitySchema = runtimeApplyIdentitySchema
 	.safeExtend({
@@ -182,17 +38,6 @@ const pendingEventSchema = z
 	.object({
 		payloadJson: z.string().min(1),
 		payloadSha256: z.string().regex(/^[a-f0-9]{64}$/),
-	})
-	.strict();
-
-const legacyHeartbeatStateSchema = z
-	.object({
-		schemaVersion: z.literal("clawdi.runtimeHeartbeatObservation.v1"),
-		environmentId: z.string().min(1),
-		bootIdentity: persistedBootIdentitySchema,
-		nextSequence: positiveSafeIntegerSchema,
-		lastCapturedAt: isoTimestampSchema.nullable().optional(),
-		pending: pendingEventSchema.nullable(),
 	})
 	.strict();
 
@@ -227,7 +72,6 @@ const heartbeatStateSchema = z
 	});
 
 type PersistedHeartbeatState = z.infer<typeof heartbeatStateSchema>;
-type LegacyHeartbeatState = z.infer<typeof legacyHeartbeatStateSchema>;
 type PersistedBootIdentity = z.infer<typeof persistedBootIdentitySchema>;
 
 export interface BufferedRuntimeObservedEvent {
@@ -292,28 +136,14 @@ export class HostedRuntimeHeartbeatSession {
 		return true;
 	}
 
-	private initializeAppliedState(
-		persisted: PersistedHeartbeatState | LegacyHeartbeatState | null,
-	): void {
+	private initializeAppliedState(persisted: PersistedHeartbeatState | null): void {
 		const appliedState = this.paths.mode === "hosted" ? readRuntimeAppliedState(this.paths) : null;
 		const applyIdentity = appliedState ? runtimeAppliedApplyIdentity(appliedState) : null;
 		if (!appliedState || !applyIdentity) return;
 
 		let candidate: PersistedHeartbeatState;
 		if (persisted && runtimeApplyIdentitiesEqual(persisted.bootIdentity, applyIdentity)) {
-			if (persisted.schemaVersion === "clawdi.runtimeHeartbeatObservation.v1") {
-				candidate = {
-					schemaVersion: "clawdi.runtimeHeartbeatObservation.v2",
-					environmentId: this.environmentId,
-					bootIdentity: persisted.bootIdentity,
-					successorBootSessionId: this.newSuccessorId(persisted.bootIdentity.bootSessionId),
-					predecessorBootSessionId: null,
-					phase: "preparing-successor",
-					nextSequence: persisted.nextSequence,
-					lastCapturedAt: persisted.lastCapturedAt ?? null,
-					pending: persisted.pending,
-				};
-			} else if (persisted.phase === "active") {
+			if (persisted.phase === "active") {
 				candidate = this.rotateState(persisted);
 			} else {
 				candidate = persisted;
@@ -399,8 +229,9 @@ export class HostedRuntimeHeartbeatSession {
 			throw new Error("runtime heartbeat snapshot does not match captured applied state");
 		}
 		assertRuntimeBundleAuthority(snapshot.applied.sourceRevision, snapshot.applied.etag);
-		const event = hostedRuntimeObservedEventSchema.parse({
+		const event: HostedRuntimeObservedEvent = {
 			...snapshot,
+			applied: snapshot.applied,
 			generation: this.currentBootIdentity.generation,
 			manifestETag: this.currentBootIdentity.manifestETag,
 			applyReceiptId: this.currentBootIdentity.applyReceiptId,
@@ -413,8 +244,8 @@ export class HostedRuntimeHeartbeatSession {
 			sequence: this.state.nextSequence,
 			eventId: nonEmptyId(this.createId(), "runtime heartbeat event ID"),
 			capturedAt,
-		});
-		const payloadJson = serializeObservedEvent(event);
+		};
+		const payloadJson = JSON.stringify(event);
 		const pending = {
 			payloadJson,
 			payloadSha256: sha256(payloadJson),
@@ -479,10 +310,7 @@ export function runtimeHeartbeatObservationStatePath(
 	return join(paths.runtimeHeartbeatRoot, `${environmentKey}.json`);
 }
 
-function readState(
-	path: string,
-	environmentId: string,
-): PersistedHeartbeatState | LegacyHeartbeatState | null {
+function readState(path: string, environmentId: string): PersistedHeartbeatState | null {
 	let serialized: string;
 	try {
 		serialized = readFileSync(path, "utf-8");
@@ -495,7 +323,7 @@ function readState(
 
 	try {
 		const raw: unknown = JSON.parse(serialized);
-		const state = z.union([heartbeatStateSchema, legacyHeartbeatStateSchema]).parse(raw);
+		const state = heartbeatStateSchema.parse(raw);
 		if (state.environmentId !== environmentId) {
 			throw new Error("runtime heartbeat state environment binding does not match");
 		}
@@ -539,25 +367,19 @@ function decodePendingEvent(
 	if (sha256(pending.payloadJson) !== pending.payloadSha256) {
 		throw new Error("durable runtime heartbeat event payload hash does not match");
 	}
-	let raw: unknown;
+	let event: HostedRuntimeObservedEvent;
 	try {
-		raw = JSON.parse(pending.payloadJson);
+		event = JSON.parse(pending.payloadJson);
 	} catch (error) {
 		throw new Error(
-			`durable runtime heartbeat event payload is invalid JSON: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
+			`durable runtime heartbeat event payload is invalid JSON: ${toErrorMessage(error)}`,
 		);
 	}
 	return {
-		event: hostedRuntimeObservedEventSchema.parse(raw),
+		event,
 		payloadJson: pending.payloadJson,
 		payloadSha256: pending.payloadSha256,
 	};
-}
-
-function serializeObservedEvent(event: HostedRuntimeObservedEvent): string {
-	return JSON.stringify(hostedRuntimeObservedEventSchema.parse(event));
 }
 
 function sha256(value: string): string {

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -37,6 +37,7 @@ const LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS = [
 	"lan",
 	"--force",
 ] as const;
+const LEGACY_HOSTED_HERMES_GATEWAY_RUN_ARGS = ["gateway", "run", "--replace"] as const;
 const HOSTED_HERMES_DASHBOARD_ARGS = [
 	"dashboard",
 	"--host",
@@ -59,7 +60,9 @@ export function isHostedGatewayRunArgs(runtime: "openclaw" | "hermes", value: un
 	// that leaves command ownership with the official gateway unit.
 	return (
 		exactStringArray(value, HOSTED_GATEWAY_RUN_ARGS) ||
-		(runtime === "openclaw" && exactStringArray(value, LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS))
+		(runtime === "openclaw" && exactStringArray(value, LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS)) ||
+		// SUNSET: remove once every hosted Hermes host has converged on CLI >= 0.14.14 (last-good rewritten canonical).
+		(runtime === "hermes" && exactStringArray(value, LEGACY_HOSTED_HERMES_GATEWAY_RUN_ARGS))
 	);
 }
 

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -37,7 +37,6 @@ const LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS = [
 	"lan",
 	"--force",
 ] as const;
-const LEGACY_HOSTED_HERMES_GATEWAY_RUN_ARGS = ["gateway", "run", "--replace"] as const;
 const HOSTED_HERMES_DASHBOARD_ARGS = [
 	"dashboard",
 	"--host",
@@ -60,12 +59,7 @@ export function isHostedGatewayRunArgs(runtime: "openclaw" | "hermes", value: un
 	// that leaves command ownership with the official gateway unit.
 	return (
 		exactStringArray(value, HOSTED_GATEWAY_RUN_ARGS) ||
-		exactStringArray(
-			value,
-			runtime === "openclaw"
-				? LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS
-				: LEGACY_HOSTED_HERMES_GATEWAY_RUN_ARGS,
-		)
+		(runtime === "openclaw" && exactStringArray(value, LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS))
 	);
 }
 
@@ -197,9 +191,6 @@ const cliPayloadPolicySchema = z.object({
 	registry: z.string().min(1).optional(),
 });
 
-const HOSTED_BOOTSTRAP_PACKAGE_ROOT = "/usr/local/share/clawdi/bootstrap/";
-export const HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE = `${HOSTED_BOOTSTRAP_PACKAGE_ROOT}clawdi-local.tgz`;
-
 function isHostedExactCliPackageSpec(value: string): boolean {
 	const npmVersion = /^clawdi@(.+)$/.exec(value)?.[1];
 	return npmVersion !== undefined && isHostedExactSemver(npmVersion);
@@ -218,25 +209,10 @@ function isHostedExactSemver(value: string): boolean {
 		.every((identifier) => !/^\d+$/.test(identifier) || /^(0|[1-9]\d*)$/.test(identifier));
 }
 
-function isHostedFixtureCliPackageSpec(value: string): boolean {
-	if (isHostedExactCliPackageSpec(value)) return true;
-	if (!value.startsWith(HOSTED_BOOTSTRAP_PACKAGE_ROOT)) return false;
-	const basename = value.slice(HOSTED_BOOTSTRAP_PACKAGE_ROOT.length);
-	return !basename.includes("..") && /^[A-Za-z0-9][A-Za-z0-9._-]*\.tgz$/.test(basename);
-}
-
 export const hostedCliPackageSpecSchema = z
 	.string()
 	.max(200)
 	.refine(isHostedExactCliPackageSpec, "must be clawdi@<exact-semver>");
-
-export const hostedFixtureCliPackageSpecSchema = z
-	.string()
-	.max(200)
-	.refine(
-		isHostedFixtureCliPackageSpec,
-		"must be clawdi@<exact-semver> or a managed bootstrap tarball",
-	);
 
 export const hostedCliPayloadPolicySchema = z
 	.object({
@@ -245,10 +221,6 @@ export const hostedCliPayloadPolicySchema = z
 		registry: z.literal("https://registry.npmjs.org"),
 	})
 	.strict();
-
-export const hostedFixtureCliPayloadPolicySchema = hostedCliPayloadPolicySchema.safeExtend({
-	packageSpec: hostedFixtureCliPackageSpecSchema,
-});
 
 const sha256Schema = z.string().regex(/^[a-fA-F0-9]{64}$/);
 

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -68,7 +68,6 @@ import {
 	reconcileHostedRuntimeOAuthCredentials,
 } from "./manifest-oauth";
 import {
-	excludeRuntimeSnapshotCoverage,
 	hostedSkillMutationTargets,
 	managedOpenClawPluginBootstrapMutationPlan,
 	managedWhatsAppCompatibilityRuntime,
@@ -518,16 +517,6 @@ function prepareRuntimeConvergencePlan(
 						manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
 				})
 			: null;
-		validateRuntimeProjectionPlan({
-			manifest,
-			paths,
-			openClawWorkspaceRoot,
-			secretValues,
-			observations: state.observations,
-			previousProjectedProviderIds,
-			hermesWhatsAppAuthDir,
-			openClawOwnerBrowserBootstrapSupported: state.openClawOwnerBrowserBootstrapSupported,
-		});
 		plannedRuntimePrograms = planRuntimeSystemdUserPrograms({
 			manifest,
 			paths,
@@ -537,6 +526,16 @@ function prepareRuntimeConvergencePlan(
 			observations: state.observations,
 			egressProfileBundlePath: plannedEgressProfileBundlePath,
 			egress: null,
+		});
+		validateRuntimeProjectionPlan({
+			manifest,
+			paths,
+			openClawWorkspaceRoot,
+			secretValues,
+			observations: state.observations,
+			previousProjectedProviderIds,
+			hermesWhatsAppAuthDir,
+			openClawOwnerBrowserBootstrapSupported: state.openClawOwnerBrowserBootstrapSupported,
 		});
 		validateRuntimeSystemdPlan(plannedRuntimePrograms);
 		mutationPlan = runtimeManagedMutationPlan({
@@ -572,19 +571,9 @@ function prepareRuntimeConvergencePlan(
 	const workspaceExistedBeforeApply = withRuntimeUserFileAccess(() => existsSync(workspaceRoot));
 	let liveSnapshot: RuntimeLiveSnapshot;
 	try {
-		let snapshotPlan = mutationPlan.snapshot;
-		if (installStage.coldInstallPlan) {
-			snapshotPlan = excludeRuntimeSnapshotCoverage(
-				snapshotPlan,
-				installStage.coldInstallPlan.snapshot,
-			);
-		}
-		if (installStage.pluginBootstrapPlan) {
-			snapshotPlan = excludeRuntimeSnapshotCoverage(snapshotPlan, installStage.pluginBootstrapPlan);
-		}
 		liveSnapshot = state.rollbackSnapshots.capture(
 			"runtime filesystem rollback failed",
-			snapshotPlan,
+			mutationPlan.snapshot,
 		);
 	} catch (error) {
 		throw state.rollbackSnapshots.failure(error);

--- a/packages/cli/src/runtime/manifest-planning.ts
+++ b/packages/cli/src/runtime/manifest-planning.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { buildAgentTargetProjection } from "../lib/ai-provider-projection";
+import { toErrorMessage } from "../serve/log";
 import {
 	type FileBrowserCompanionInstallOptions,
 	fileBrowserCompanionMutationPlan,
@@ -252,6 +253,7 @@ export function resolveRuntimeRunConfigs(input: {
 	const secretEnv = input.runtime.enabled
 		? mergeRuntimeSecretEnv(input.name, runtimeRunSettings, providerSecretEnv)
 		: {};
+	scopedSecretValues(input.secretValues, Object.values(secretEnv));
 	const secretFilePath = null;
 	const runtime = buildRuntimeRunConfig({
 		runtime: runtimeName,
@@ -390,35 +392,6 @@ export function validateRuntimeProjectionPlan(input: {
 	for (const [name, runtime] of Object.entries(manifest.runtimes).sort(([a], [b]) =>
 		a.localeCompare(b),
 	)) {
-		const observation = observations.get(name);
-		if (!observation) throw new Error(`runtime ${name} install observation is missing`);
-		const runtimeName = runtimeNameSchema.parse(name);
-		const providerEnvironment = runtime.enabled
-			? hostedProviderEnvironment(manifest, name, { validateOverlap: true })
-			: { placeholderEnv: {}, secretEnv: {} };
-		const { placeholderEnv: providerPlaceholderEnv, secretEnv: providerSecretEnv } =
-			providerEnvironment;
-		const runtimeSettings = resolvedRuntimeSettings(
-			runtimeName,
-			runtime.run,
-			providerPlaceholderEnv,
-		);
-		const secretEnv = runtime.enabled
-			? mergeRuntimeSecretEnv(name, runtimeSettings, providerSecretEnv)
-			: {};
-		scopedSecretValues(secretValues, Object.values(secretEnv));
-		for (const [serviceName, serviceSettings] of Object.entries(runtime.services ?? {})) {
-			const service = runtimeServiceNameSchema.parse(serviceName);
-			const settings = resolvedRuntimeServiceSettings(
-				manifest,
-				runtimeName,
-				service,
-				serviceSettings,
-				providerPlaceholderEnv,
-			);
-			mergeRuntimeSecretEnv(name, settings, providerSecretEnv, service);
-		}
-
 		const projectionInput = agentTargetProjectionInput(hostedAiProviderCatalog(manifest, name));
 		assertHostedProviderProjectionMode(name, manifest, projectionInput);
 		const configuredProjectionUnavailable =
@@ -461,30 +434,6 @@ export function validateRuntimeProjectionPlan(input: {
 	}
 	validateHostedMcpProjectionPlan(manifest, paths, observations);
 	validateHostedChannelCredentialsPlan(manifest, secretValues, home);
-}
-export function excludeRuntimeSnapshotCoverage(
-	plan: RuntimeManagedMutationPlan,
-	coveragePlan: RuntimeManagedMutationPlan,
-): RuntimeManagedMutationPlan {
-	const contentRoots = coveragePlan.runtimeUserTargets.map((path) => resolve(path));
-	const coveredByContentRoot = (path: string): boolean => {
-		const candidate = resolve(path);
-		return contentRoots.some((root) => {
-			const relativePath = relative(root, candidate);
-			return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
-		});
-	};
-	const coveredMetadata = new Set(coveragePlan.metadataTargets.map((path) => resolve(path)));
-	return {
-		...plan,
-		runtimeUserTargets: plan.runtimeUserTargets.filter((path) => !coveredByContentRoot(path)),
-		runtimeUserSymlinkTargets: plan.runtimeUserSymlinkTargets.filter(
-			(path) => !coveredByContentRoot(path),
-		),
-		metadataTargets: plan.metadataTargets.filter(
-			(path) => !coveredByContentRoot(path) && !coveredMetadata.has(resolve(path)),
-		),
-	};
 }
 export function managedOpenClawPluginBootstrapMutationPlan(
 	context: OpenClawHostedContext,
@@ -535,7 +484,7 @@ export class RuntimeSnapshotRollbackStack {
 	restore(
 		scope?: RuntimeSnapshotRollbackScope,
 		formatFailure: (failure: string, error: unknown) => string = (failure, error) =>
-			`${failure}: ${error instanceof Error ? error.message : String(error)}`,
+			`${failure}: ${toErrorMessage(error)}`,
 	): string[] {
 		const errors: string[] = [];
 		for (const { failure, snapshot } of this.#snapshots.splice(scope?.start ?? 0).reverse()) {
@@ -551,9 +500,7 @@ export class RuntimeSnapshotRollbackStack {
 	failure(error: unknown): unknown {
 		const rollbackErrors = this.restore();
 		if (rollbackErrors.length === 0) return error;
-		return new Error(
-			`${error instanceof Error ? error.message : String(error)}; ${rollbackErrors.join("; ")}`,
-		);
+		return new Error(`${toErrorMessage(error)}; ${rollbackErrors.join("; ")}`);
 	}
 }
 function hostedChannelCredentialMutationTargets(manifest: RuntimeManifest, home: string): string[] {
@@ -614,13 +561,9 @@ export function runtimeUserMutationTargets(
 		join(dirname(hermesAuthPath(home)), "auth.lock"),
 		openClawContext.agentDirs.main,
 		join(hostedCodexHome(home), CODEX_MANAGED_PROVIDER_CONFIG_FILE),
-		...installerTargets,
 		...hostedChannelCredentialMutationTargets(manifest, home),
 		...channelPluginTargets,
 	]);
-	if (openClawContext.managedApiKeyProjection) {
-		for (const target of openClawContext.providerPlugin.mutationTargets) targets.add(target);
-	}
 	if (openClawWorkspaceRoot) targets.add(join(openClawWorkspaceRoot, "SOUL.md"));
 	for (const name of HOSTED_RUNTIME_TARGETS) {
 		if (manifest.runtimes[name]?.enabled !== true) continue;

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -959,11 +959,13 @@ describe("runtime manifest reconciliation invariants", () => {
 		const legacy = hostedOpenClawV2ManifestFixture({}, LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS);
 		expect(hostedRuntimeManifestSchema.safeParse(legacy).success).toBe(true);
 		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(legacy).success).toBe(true);
-		expect(
-			hostedRuntimeBundleV2ManifestSchema.safeParse(
-				hostedHermesManifestFixture({}, ["gateway", "run", "--replace"]),
-			).success,
-		).toBe(false);
+		const legacyHermes = hostedRuntimeBundleV2ManifestSchema.parse(
+			hostedHermesManifestFixture({}, ["gateway", "run", "--replace"]),
+		);
+		expect(hostedManifestToRuntimeManifest(legacyHermes).runtimes.hermes.run?.args).toEqual([
+			"gateway",
+			"run",
+		]);
 
 		const unsupported = hostedOpenClawV2ManifestFixture({}, ["gateway", "run", "--force"]);
 		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(unsupported).success).toBe(false);

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -76,7 +76,6 @@ import {
 	AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR,
 	AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR,
 	fileBrowserCompanionSchema,
-	hostedFixtureCliPayloadPolicySchema,
 	hostedRuntimeBundleV2ManifestSchema,
 	hostedRuntimeManifestSchema,
 	manifestSchema,
@@ -128,9 +127,6 @@ const FILE_BROWSER_AMD64_SHA256 =
 	"8d51d1718d576d22e73e1f41a5194b451d152ddab0df97697cabe839cf59524e";
 const FILE_BROWSER_ARM64_SHA256 =
 	"3e18838ae33750a25da434dc6156a359968bf7935e01bdd884711f47f08ad92f";
-const hostedRuntimeManifestFixtureSchema = hostedRuntimeManifestSchema.safeExtend({
-	clawdiCli: hostedFixtureCliPayloadPolicySchema,
-});
 const TEST_HOSTED_SECRET_VALUES = {
 	"secret://clawdi/auth-token": "test-auth-token",
 	"secret://runtime/openclaw/gateway-token": "gateway-token",
@@ -643,7 +639,6 @@ const LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS = [
 	"lan",
 	"--force",
 ];
-const LEGACY_HOSTED_HERMES_GATEWAY_RUN_ARGS = ["gateway", "run", "--replace"];
 
 function hostedOpenClawV2ManifestFixture(
 	overrides: Record<string, unknown> = {},
@@ -964,13 +959,11 @@ describe("runtime manifest reconciliation invariants", () => {
 		const legacy = hostedOpenClawV2ManifestFixture({}, LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS);
 		expect(hostedRuntimeManifestSchema.safeParse(legacy).success).toBe(true);
 		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(legacy).success).toBe(true);
-		const legacyHermes = hostedRuntimeBundleV2ManifestSchema.parse(
-			hostedHermesManifestFixture({}, LEGACY_HOSTED_HERMES_GATEWAY_RUN_ARGS),
-		);
-		expect(hostedManifestToRuntimeManifest(legacyHermes).runtimes.hermes.run?.args).toEqual([
-			"gateway",
-			"run",
-		]);
+		expect(
+			hostedRuntimeBundleV2ManifestSchema.safeParse(
+				hostedHermesManifestFixture({}, ["gateway", "run", "--replace"]),
+			).success,
+		).toBe(false);
 
 		const unsupported = hostedOpenClawV2ManifestFixture({}, ["gateway", "run", "--force"]);
 		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(unsupported).success).toBe(false);
@@ -2363,7 +2356,7 @@ chmod 0755 '${commandPath}'
 		},
 	);
 
-	test("enforces the Cloud package spec length limit for remote and fixture Hosted schemas", () => {
+	test("enforces the Cloud package spec length limit", () => {
 		const atLimit = `clawdi@1.2.3-${"a".repeat(187)}`;
 		const overLimit = `clawdi@1.2.3-${"a".repeat(188)}`;
 		expect(atLimit).toHaveLength(200);
@@ -2379,7 +2372,6 @@ chmod 0755 '${commandPath}'
 			});
 			const expected = packageSpec === atLimit;
 			expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(expected);
-			expect(hostedRuntimeManifestFixtureSchema.safeParse(manifest).success).toBe(expected);
 		}
 	});
 

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { isAbsolute } from "node:path";
 import { z } from "zod";
+import { toErrorMessage } from "../serve/log";
 import {
 	readRuntimeAppliedState,
 	runtimeAppliedApplyIdentity,
@@ -295,7 +296,7 @@ async function fetchRuntimeManifestPayload(
 			return { url, raw: await response.json(), etag };
 		} catch (error) {
 			throw new RuntimeManifestResponseError(
-				`runtime manifest response is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+				`runtime manifest response is not valid JSON: ${toErrorMessage(error)}`,
 				etag,
 			);
 		}
@@ -326,11 +327,7 @@ export async function loadRemoteRuntimeManifest(
 		return {
 			mode: "repair",
 			stage: runtimeFetchFailureStage(error),
-			errors: [
-				`could not fetch runtime manifest: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
-			],
+			errors: [`could not fetch runtime manifest: ${toErrorMessage(error)}`],
 			...(error instanceof RuntimeManifestResponseError && error.etag ? { etag: error.etag } : {}),
 		};
 	}
@@ -358,7 +355,7 @@ export async function loadRemoteRuntimeManifest(
 		return {
 			mode: "manifest-rejected",
 			stage: "network",
-			errors: error instanceof z.ZodError ? zodErrors(error) : [String(error)],
+			errors: error instanceof z.ZodError ? zodErrors(error) : [toErrorMessage(error)],
 			etag: fetched.etag,
 			rejectedGeneration: rawGeneration(fetched.raw),
 			activeGeneration: loadExistingState(paths).generation ?? null,
@@ -382,7 +379,7 @@ function runtimeApplyContextFailure(error: unknown): RuntimeManifestFailure {
 	return {
 		mode: "repair",
 		stage: "local",
-		errors: [error instanceof Error ? error.message : String(error)],
+		errors: [toErrorMessage(error)],
 	};
 }
 
@@ -814,9 +811,7 @@ function loadLastGoodManifest(
 			mode: "repair",
 			stage: "local",
 			errors: [
-				`could not read last-good runtime manifest at ${paths.manifestLastGood}: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
+				`could not read last-good runtime manifest at ${paths.manifestLastGood}: ${toErrorMessage(error)}`,
 			],
 		};
 	}
@@ -863,9 +858,7 @@ function loadCachedSecretValues(
 			mode: "repair",
 			stage: "local",
 			errors: [
-				`could not read cached runtime secret values at ${paths.managedSecretCacheFile}: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
+				`could not read cached runtime secret values at ${paths.managedSecretCacheFile}: ${toErrorMessage(error)}`,
 			],
 		};
 	}

--- a/packages/cli/src/runtime/observed-v2.test.ts
+++ b/packages/cli/src/runtime/observed-v2.test.ts
@@ -110,6 +110,7 @@ describe("hosted runtime observed v2", () => {
 		const observed = readHostedRuntimeObserved(paths);
 		expect(observed?.schemaVersion).toBe("clawdi.hostedRuntimeObserved.v2");
 		expect(observed?.activeCliVersion).toBe(getCliVersion());
+		expect(observed?.cli?.version).toBe(getCliVersion());
 		expect(observed?.applied).toEqual({
 			etag: '"bundle-applied"',
 			sourceRevision: "a".repeat(64),

--- a/packages/cli/src/runtime/observed-v2.test.ts
+++ b/packages/cli/src/runtime/observed-v2.test.ts
@@ -75,7 +75,7 @@ function healthyAppliedRuntimePaths() {
 }
 
 describe("hosted runtime observed v2", () => {
-	test("reports authority only from applied state and the active process version", () => {
+	test("reports applied authority and keeps status version separate from the active process", () => {
 		const root = mkdtempSync(join(tmpdir(), "clawdi-observed-v2-"));
 		roots.push(root);
 		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
@@ -105,12 +105,15 @@ describe("hosted runtime observed v2", () => {
 			paths,
 		);
 		mkdirSync(dirname(paths.cliBootstrapStatus), { recursive: true });
-		writeFileSync(paths.cliBootstrapStatus, JSON.stringify({ version: "0.0.0-stale" }));
+		writeFileSync(
+			paths.cliBootstrapStatus,
+			JSON.stringify({ version: "0.0.0-stale", imageShimExtension: true }),
+		);
 
 		const observed = readHostedRuntimeObserved(paths);
 		expect(observed?.schemaVersion).toBe("clawdi.hostedRuntimeObserved.v2");
 		expect(observed?.activeCliVersion).toBe(getCliVersion());
-		expect(observed?.cli?.version).toBe(getCliVersion());
+		expect(observed?.cli?.version).toBe("0.0.0-stale");
 		expect(observed?.applied).toEqual({
 			etag: '"bundle-applied"',
 			sourceRevision: "a".repeat(64),

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -4,8 +4,10 @@ import { join } from "node:path";
 import type { components } from "@clawdi/shared/api";
 import { safeTruncate, sanitizeMetadata } from "../lib/sanitize";
 import { getCliVersion } from "../lib/version";
+import { toErrorMessage } from "../serve/log";
 import { type RuntimeAppliedState, readRuntimeAppliedState } from "./applied-state";
 import { resolveRuntimeApplyGeneration } from "./apply-identity";
+import { type RuntimeCliBootstrapStatus, readRuntimeCliBootstrapStatus } from "./cli-update";
 import { readHostedAgentPluginsObservation } from "./hosted-agent-plugin-observation";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { spawnRuntimeUserCommand } from "./runtime-user-command";
@@ -45,7 +47,8 @@ export function readHostedRuntimeObserved(
 	const appliedState =
 		options.appliedState === undefined ? readRuntimeAppliedState(paths) : options.appliedState;
 	const watchStatus = readJsonRecord(paths.runtimeWatchStatus);
-	const cliBootstrap = readJsonRecord(paths.cliBootstrapStatus);
+	const activeCliVersion = getCliVersion();
+	const cliBootstrap = readRuntimeCliBootstrapStatus(paths);
 	const systemd = readSystemdObserved(paths);
 	const providers = readProviderObserved(paths);
 	const appliedAuthority = appliedState
@@ -63,10 +66,10 @@ export function readHostedRuntimeObserved(
 		reportedAt: options.reportedAt ?? new Date().toISOString(),
 		runtimeMode: paths.mode,
 		status: observedStatus(boot.status, watchStatus, systemd, providers, appliedAuthority !== null),
-		activeCliVersion: getCliVersion(),
+		activeCliVersion,
 		applied: appliedAuthority,
 		boot: boot.status ? summarizeBootStatus(boot.status) : null,
-		cli: summarizeCliBootstrap(cliBootstrap),
+		cli: observedCli(cliBootstrap, activeCliVersion),
 	};
 	if (systemd) {
 		observed.systemd = systemd;
@@ -144,16 +147,19 @@ function runtimeConvergeError(watchStatus: JsonRecord | null): string | null {
 	);
 }
 
-function summarizeCliBootstrap(value: JsonRecord | null): HostedRuntimeObservedCli | null {
+function observedCli(
+	value: RuntimeCliBootstrapStatus | null,
+	activeCliVersion: string,
+): HostedRuntimeObservedCli | null {
 	if (!value) return null;
 	return {
-		status: stringValue(value.status),
-		source: stringValue(value.source),
-		packageSpec: stringValue(value.packageSpec),
-		registry: stringValue(value.registry),
-		activePath: stringValue(value.activePath),
-		activeTarget: stringValue(value.activeTarget),
-		version: stringValue(value.version),
+		status: value.status ?? null,
+		source: value.source ?? null,
+		packageSpec: value.packageSpec ?? null,
+		registry: value.registry ?? null,
+		activePath: value.activePath ?? null,
+		activeTarget: value.activeTarget ?? null,
+		version: activeCliVersion,
 	};
 }
 
@@ -411,7 +417,7 @@ function runRuntimeUserSystemctl(
 	} catch (error) {
 		return {
 			exitCode: 1,
-			output: error instanceof Error ? error.message : String(error),
+			output: toErrorMessage(error),
 		};
 	}
 }

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -69,7 +69,7 @@ export function readHostedRuntimeObserved(
 		activeCliVersion,
 		applied: appliedAuthority,
 		boot: boot.status ? summarizeBootStatus(boot.status) : null,
-		cli: observedCli(cliBootstrap, activeCliVersion),
+		cli: observedCli(cliBootstrap),
 	};
 	if (systemd) {
 		observed.systemd = systemd;
@@ -147,10 +147,7 @@ function runtimeConvergeError(watchStatus: JsonRecord | null): string | null {
 	);
 }
 
-function observedCli(
-	value: RuntimeCliBootstrapStatus | null,
-	activeCliVersion: string,
-): HostedRuntimeObservedCli | null {
+function observedCli(value: RuntimeCliBootstrapStatus | null): HostedRuntimeObservedCli | null {
 	if (!value) return null;
 	return {
 		status: value.status ?? null,
@@ -159,7 +156,7 @@ function observedCli(
 		registry: value.registry ?? null,
 		activePath: value.activePath ?? null,
 		activeTarget: value.activeTarget ?? null,
-		version: activeCliVersion,
+		version: value.version ?? null,
 	};
 }
 

--- a/packages/cli/src/runtime/run-config.ts
+++ b/packages/cli/src/runtime/run-config.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { z } from "zod";
+import { toErrorMessage } from "../serve/log";
 import { applyEgressTransparentRuntimeEnv } from "./egress-env";
 import type { RuntimePaths } from "./paths";
 import { getRuntimePaths } from "./paths";
@@ -178,7 +179,7 @@ export function readRuntimeRunConfigForCommand(
 			status: "invalid",
 			runtime,
 			path,
-			error: error instanceof Error ? error.message : String(error),
+			error: toErrorMessage(error),
 		};
 	}
 }
@@ -208,7 +209,7 @@ export function readRuntimeServiceRunConfig(
 			status: "invalid",
 			runtime: parsedRuntime.data,
 			path,
-			error: error instanceof Error ? error.message : String(error),
+			error: toErrorMessage(error),
 		};
 	}
 }
@@ -272,14 +273,12 @@ function runtimeSecretEnv(
 		try {
 			rawSecrets = JSON.parse(readFileSync(secretFilePath, "utf-8"));
 		} catch (error) {
-			throw new Error(
-				`Runtime secret file is unavailable: ${error instanceof Error ? error.message : String(error)}`,
-			);
+			throw new Error(`Runtime secret file is unavailable: ${toErrorMessage(error)}`);
 		}
 		if (!rawSecrets || typeof rawSecrets !== "object" || Array.isArray(rawSecrets)) {
 			throw new Error("Runtime secret file must contain a JSON object.");
 		}
-		secrets = rawSecrets as Record<string, unknown>;
+		secrets = z.record(z.string(), z.unknown()).parse(rawSecrets);
 	}
 	const env: Record<string, string> = {};
 	for (const [envName, ref] of entries) {

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -37,10 +37,7 @@ import {
 	buildOpenClawHostedProviderPatch,
 	convergeRuntimeManifest,
 } from "../../src/runtime/manifest";
-import {
-	manifestSchema,
-	type RuntimeManifest,
-} from "../../src/runtime/manifest-contract";
+import { manifestSchema, type RuntimeManifest } from "../../src/runtime/manifest-contract";
 import type { HostedSkillSource } from "../../src/runtime/manifest-resources";
 import {
 	HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
@@ -236,6 +233,7 @@ test.each(["hermes", "openclaw"] as const)(
 			"CLAWDI_RUNTIME_GID",
 			"CLAWDI_RUNTIME_HOME",
 			"CLAWDI_RUNTIME_MODE",
+			"CLAWDI_RUNTIME_TEST_CLI_INSTALLER",
 			"CLAWDI_RUNTIME_TEST_HERMES_INSTALLER",
 			"CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER",
 			"CLAWDI_RUNTIME_UID",
@@ -322,6 +320,7 @@ test.each(["hermes", "openclaw"] as const)(
 				CLAWDI_RUNTIME_GID: String(runtimeGid),
 				CLAWDI_RUNTIME_HOME: runtimeHome,
 				CLAWDI_RUNTIME_MODE: "hosted",
+				CLAWDI_RUNTIME_TEST_CLI_INSTALLER: "/usr/local/share/clawdi/bootstrap/clawdi-local.tgz",
 				CLAWDI_RUNTIME_UID: String(runtimeUid),
 				CLAWDI_RUNTIME_USER: "clawdi",
 				CLAWDI_SERVICE_STATE_DIR: join(root, "var", "lib", "clawdi"),

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -38,7 +38,6 @@ import {
 	convergeRuntimeManifest,
 } from "../../src/runtime/manifest";
 import {
-	HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE,
 	manifestSchema,
 	type RuntimeManifest,
 } from "../../src/runtime/manifest-contract";
@@ -386,7 +385,7 @@ exec /usr/bin/systemctl "$@"
 				controlPlane: { apiUrl: "https://cloud-api.example.test" },
 				clawdiCli: {
 					source: "npm:clawdi",
-					packageSpec: HOSTED_RUNTIME_PAIRED_FIXTURE_CLI_PACKAGE,
+					packageSpec: `clawdi@${cliVersion}`,
 					registry: "https://registry.npmjs.org",
 				},
 				runtimes: {

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -29,7 +29,6 @@ import {
 } from "../../src/lib/codex-oauth-native-store";
 import { getCliVersion } from "../../src/lib/version";
 import { readRuntimeAppliedState } from "../../src/runtime/applied-state";
-import { applyRuntimeCliDesiredState } from "../../src/runtime/cli-update";
 import { hostedOpenClawSkillDriver } from "../../src/runtime/hosted-openclaw-skill";
 import { hostedAiProviderCatalog } from "../../src/runtime/hosted-provider-resolution";
 import { prepareHostedSourcedSkillArchives } from "../../src/runtime/hosted-sourced-skill-archive";
@@ -233,7 +232,6 @@ test.each(["hermes", "openclaw"] as const)(
 			"CLAWDI_RUNTIME_GID",
 			"CLAWDI_RUNTIME_HOME",
 			"CLAWDI_RUNTIME_MODE",
-			"CLAWDI_RUNTIME_TEST_CLI_INSTALLER",
 			"CLAWDI_RUNTIME_TEST_HERMES_INSTALLER",
 			"CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER",
 			"CLAWDI_RUNTIME_UID",
@@ -320,7 +318,6 @@ test.each(["hermes", "openclaw"] as const)(
 				CLAWDI_RUNTIME_GID: String(runtimeGid),
 				CLAWDI_RUNTIME_HOME: runtimeHome,
 				CLAWDI_RUNTIME_MODE: "hosted",
-				CLAWDI_RUNTIME_TEST_CLI_INSTALLER: "/usr/local/share/clawdi/bootstrap/clawdi-local.tgz",
 				CLAWDI_RUNTIME_UID: String(runtimeUid),
 				CLAWDI_RUNTIME_USER: "clawdi",
 				CLAWDI_SERVICE_STATE_DIR: join(root, "var", "lib", "clawdi"),
@@ -374,32 +371,43 @@ exec /usr/bin/systemctl "$@"
 			chmodSync(systemctlLog, 0o666);
 
 			const cliVersion = getCliVersion();
-			const bootstrapManifest: RuntimeManifest = {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: `hdep_virgin_${runtime}_bootstrap`,
-				environmentId: `env_virgin_${runtime}_bootstrap`,
-				instanceId: `hri_virgin_${runtime}_bootstrap`,
-				generation: 1,
-				issuedAt: "2026-08-22T00:00:00.000Z",
-				controlPlane: { apiUrl: "https://cloud-api.example.test" },
-				clawdiCli: {
-					source: "npm:clawdi",
+			const cliPrefix = join(paths.cliNpmPrefix, "packages", cliVersion);
+			const cliInstall = spawnSync(
+				"npm",
+				[
+					"install",
+					"--global",
+					"--prefix",
+					cliPrefix,
+					"--ignore-scripts",
+					"--no-audit",
+					"--no-fund",
+					"/usr/local/share/clawdi/bootstrap/clawdi-local.tgz",
+				],
+				{ encoding: "utf8" },
+			);
+			expect(cliInstall.status, cliInstall.stderr).toBe(0);
+			const cliTarget = join(cliPrefix, "bin", "clawdi");
+			mkdirSync(dirname(paths.cliManagedBin), { recursive: true, mode: 0o755 });
+			symlinkSync(cliTarget, paths.cliManagedBin);
+			writeFileSync(
+				paths.cliBootstrapStatus,
+				`${JSON.stringify({
+					schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
+					generatedAt: new Date().toISOString(),
+					status: "installed",
+					source: "npm",
 					packageSpec: `clawdi@${cliVersion}`,
 					registry: "https://registry.npmjs.org",
-				},
-				runtimes: {
-					hermes: { enabled: false },
-					openclaw: { enabled: false },
-				},
-				recovery: {},
-			};
-			const bootstrap = applyRuntimeCliDesiredState(bootstrapManifest, paths, {
-				runningVersion: cliVersion,
-			});
-			expect(bootstrap.status).toBe("installed");
-			expect(bootstrap.selfReexec).toBe(true);
-			expect(bootstrap.version).toBe(cliVersion);
-			expect(lstatSync(paths.cliManagedBin).isSymbolicLink()).toBe(true);
+					npmPrefix: cliPrefix,
+					npmCache: paths.cliNpmCache,
+					activePath: paths.cliManagedBin,
+					activeTarget: cliTarget,
+					version: cliVersion,
+					error: null,
+				})}\n`,
+				{ mode: 0o600 },
+			);
 
 			const gatewayToken = `virgin-${runtime}-gateway-token`;
 			const sourceRevision = createHash("sha256").update(`virgin-${runtime}-bundle`).digest("hex");

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -318,6 +318,7 @@ const ENV_KEYS = [
 	"CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS",
 	"CLAWDI_RUNTIME_TEST_CONTEXT_FILE",
 	"CLAWDI_RUNTIME_INSTALL_TIMEOUT",
+	"CLAWDI_RUNTIME_TEST_CLI_INSTALLER",
 	"CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER",
 	"CLAWDI_RUNTIME_TEST_OPENCLAW_PROVIDER_AUTH_SDK",
 	"CLAWDI_RUNTIME_TEST_OPENCLAW_PROVIDER_ENV_VARS_SDK",
@@ -11418,11 +11419,11 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it.each([
-		["upgrades", "1.2.3-test.1", "1.2.3-test.2"],
-		["downgrades", "2.0.0-test.1", "1.2.3-test.2"],
+		["upgrades", "1.2.3-test.1", "1.2.3-test.2", null],
+		["downgrades", "2.0.0-test.1", "1.2.3-test.2", "/fixtures/clawdi-local.tgz"],
 	])(
 		"hosted exact CLI desired state %s without npm view",
-		(_name, currentVersion, desiredVersion) => {
+		(_name, currentVersion, desiredVersion, testInstallSource) => {
 			const home = join(root, `home-${currentVersion}`, "clawdi");
 			const state = join(root, `state-${currentVersion}`);
 			const run = join(root, `run-${currentVersion}`);
@@ -11473,6 +11474,10 @@ chmod +x "$prefix/bin/clawdi"
 			process.env.CLAWDI_RUNTIME_MODE = "hosted";
 			process.env.CLAWDI_SERVICE_STATE_DIR = state;
 			process.env.CLAWDI_RUN_DIR = run;
+			if (testInstallSource) {
+				process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
+				process.env.CLAWDI_RUNTIME_TEST_CLI_INSTALLER = testInstallSource;
+			}
 			const currentSpec = `clawdi@${currentVersion}`;
 			const desiredSpec = `clawdi@${desiredVersion}`;
 			seedCurrentCliInstall(state, currentSpec, currentVersion, "https://registry.npmjs.org");
@@ -11501,13 +11506,29 @@ chmod +x "$prefix/bin/clawdi"
 				expect(statSync(paths.cliUpgradeState).mode & 0o777).toBe(0o600);
 				const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
 				expect(npmCalls.some((call) => call.startsWith("view "))).toBe(false);
-				expect(npmCalls.some((call) => call.includes(desiredSpec))).toBe(true);
+				expect(npmCalls.some((call) => call.includes(testInstallSource ?? desiredSpec))).toBe(true);
 			} finally {
 				if (previousPath === undefined) delete process.env.PATH;
 				else process.env.PATH = previousPath;
 			}
 		},
 	);
+
+	it("rejects a local CLI install source without the test installer gate", () => {
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state-cli-test-installer-gate");
+		process.env.CLAWDI_RUN_DIR = join(root, "run-cli-test-installer-gate");
+		process.env.CLAWDI_RUNTIME_TEST_CLI_INSTALLER = "/fixtures/clawdi-local.tgz";
+		seedCurrentCliInstall(
+			process.env.CLAWDI_SERVICE_STATE_DIR,
+			"clawdi@1.2.3-test.1",
+			"1.2.3-test.1",
+		);
+
+		expect(() =>
+			applyRuntimeCliDesiredState(cliManifest("1.2.3-test.2"), getRuntimePaths()),
+		).toThrow("CLAWDI_RUNTIME_TEST_CLI_INSTALLER requires CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS=1");
+	});
 
 	it("cancels a prepared CLI transaction while the previous target is still active", () => {
 		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -318,7 +318,6 @@ const ENV_KEYS = [
 	"CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS",
 	"CLAWDI_RUNTIME_TEST_CONTEXT_FILE",
 	"CLAWDI_RUNTIME_INSTALL_TIMEOUT",
-	"CLAWDI_RUNTIME_TEST_CLI_INSTALLER",
 	"CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER",
 	"CLAWDI_RUNTIME_TEST_OPENCLAW_PROVIDER_AUTH_SDK",
 	"CLAWDI_RUNTIME_TEST_OPENCLAW_PROVIDER_ENV_VARS_SDK",
@@ -11419,11 +11418,11 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it.each([
-		["upgrades", "1.2.3-test.1", "1.2.3-test.2", null],
-		["downgrades", "2.0.0-test.1", "1.2.3-test.2", "/fixtures/clawdi-local.tgz"],
+		["upgrades", "1.2.3-test.1", "1.2.3-test.2"],
+		["downgrades", "2.0.0-test.1", "1.2.3-test.2"],
 	])(
 		"hosted exact CLI desired state %s without npm view",
-		(_name, currentVersion, desiredVersion, testInstallSource) => {
+		(_name, currentVersion, desiredVersion) => {
 			const home = join(root, `home-${currentVersion}`, "clawdi");
 			const state = join(root, `state-${currentVersion}`);
 			const run = join(root, `run-${currentVersion}`);
@@ -11474,10 +11473,6 @@ chmod +x "$prefix/bin/clawdi"
 			process.env.CLAWDI_RUNTIME_MODE = "hosted";
 			process.env.CLAWDI_SERVICE_STATE_DIR = state;
 			process.env.CLAWDI_RUN_DIR = run;
-			if (testInstallSource) {
-				process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
-				process.env.CLAWDI_RUNTIME_TEST_CLI_INSTALLER = testInstallSource;
-			}
 			const currentSpec = `clawdi@${currentVersion}`;
 			const desiredSpec = `clawdi@${desiredVersion}`;
 			seedCurrentCliInstall(state, currentSpec, currentVersion, "https://registry.npmjs.org");
@@ -11506,29 +11501,13 @@ chmod +x "$prefix/bin/clawdi"
 				expect(statSync(paths.cliUpgradeState).mode & 0o777).toBe(0o600);
 				const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
 				expect(npmCalls.some((call) => call.startsWith("view "))).toBe(false);
-				expect(npmCalls.some((call) => call.includes(testInstallSource ?? desiredSpec))).toBe(true);
+				expect(npmCalls.some((call) => call.includes(desiredSpec))).toBe(true);
 			} finally {
 				if (previousPath === undefined) delete process.env.PATH;
 				else process.env.PATH = previousPath;
 			}
 		},
 	);
-
-	it("rejects a local CLI install source without the test installer gate", () => {
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state-cli-test-installer-gate");
-		process.env.CLAWDI_RUN_DIR = join(root, "run-cli-test-installer-gate");
-		process.env.CLAWDI_RUNTIME_TEST_CLI_INSTALLER = "/fixtures/clawdi-local.tgz";
-		seedCurrentCliInstall(
-			process.env.CLAWDI_SERVICE_STATE_DIR,
-			"clawdi@1.2.3-test.1",
-			"1.2.3-test.1",
-		);
-
-		expect(() =>
-			applyRuntimeCliDesiredState(cliManifest("1.2.3-test.2"), getRuntimePaths()),
-		).toThrow("CLAWDI_RUNTIME_TEST_CLI_INSTALLER requires CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS=1");
-	});
 
 	it("cancels a prepared CLI transaction while the previous target is still active", () => {
 		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -13390,61 +13390,6 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
-	it("keeps the paired-image CLI current only behind the exact test fixture gate", () => {
-		const home = join(root, "home-paired-cli", "clawdi");
-		const state = join(root, "state-paired-cli");
-		const run = join(root, "run-paired-cli");
-		const bin = join(root, "bin-paired-cli");
-		const npmMarker = join(root, "paired-npm-invoked");
-		const previousPath = process.env.PATH;
-		mkdirSync(bin, { recursive: true });
-		writeFileSync(join(bin, "npm"), `#!/usr/bin/env sh\ntouch '${npmMarker}'\nexit 99\n`);
-		chmodSync(join(bin, "npm"), 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(
-			state,
-			"/usr/local/share/clawdi/bootstrap/clawdi-local.tgz",
-			"1.2.22",
-			"https://registry.npmjs.org",
-		);
-		const paths = getRuntimePaths();
-		const manifest: RuntimeManifest = {
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
-			deploymentId: "dep_paired_cli",
-			environmentId: "env_paired_cli",
-			instanceId: "iid_paired_cli",
-			generation: 1,
-			issuedAt: "2026-07-31T00:00:00Z",
-			controlPlane: { apiUrl: "https://cloud-api.test" },
-			clawdiCli: {
-				source: "npm:clawdi",
-				packageSpec: "clawdi@1.2.22",
-				registry: "https://registry.npmjs.org",
-			},
-			runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
-			recovery: {},
-		};
-
-		try {
-			const current = applyRuntimeCliDesiredState(manifest, paths);
-			expect(current.status).toBe("current");
-			expect(current.selfReexec).toBe(false);
-			expect(existsSync(npmMarker)).toBe(false);
-			expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8")).packageSpec).toBe(
-				"/usr/local/share/clawdi/bootstrap/clawdi-local.tgz",
-			);
-		} finally {
-			delete process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS;
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
-
 	it("preserves the real last-good CLI across a status-missing rollback and later upgrade", () => {
 		const home = join(root, "home-cli-rollback-lifecycle", "clawdi");
 		const state = join(root, "state-cli-rollback-lifecycle");


### PR DESCRIPTION
## Summary

- Build heartbeat events from the generated `RuntimeObservationEventV2` type and remove the handwritten observation schema copy, the never-produced supervisor schema, and heartbeat state v1 migration.
- Remove production paired-fixture CLI contracts, tarball install identities, and every CLI test-installer product hook. Hosted desired state and runtime context now accept only exact `clawdi@<semver>` package specs.
- Preserve the Hermes legacy gateway-argument read bridge until every hosted Hermes host has rewritten last-good state with CLI >= 0.14.14; keep the OpenClaw compatibility bridge.
- Parse the dual-writer CLI bootstrap status with loose Zod schemas, centralize error rendering through `toErrorMessage`, name runtime timing constants, reduce repeated applied-state and CLI-version reads, and emit reasons for failed CLI verification.
- Remove duplicate mutation snapshot coverage and run-config validation work while keeping the existing mutation parity coverage.
- Keep `cli.version` as the bootstrap-status version and `activeCliVersion` as the daemon process version.

## Review Evidence And Scope

This implements the low-risk findings documented in `C-lifecycle-contract.md` lines 8-14: C#4, the CLI portion of C#5, C#7, C#8, C#9, and C#10, with the fleet-required Hermes compatibility exception above.

The change is 286 insertions and 681 deletions across 16 files, for a net deletion of 395 lines.

The only production hunk outside the assigned file list is `packages/cli/src/runtime/manifest-converge.ts` (+11/-22). It is the minimum C#8 integration change needed to stop subtracting independently captured installer/plugin targets from the base snapshot and to preserve canonical run-config validation ordering. Existing tests were rewritten in place; no new test files were added.

The branch was rebased onto `7af27c1e9` after #1184 and #1186. The #1184 `applyRuntimeManifestLoad` authority-commit wiring and behavioral e2e harness remain intact.

## Added

- Loose Zod schemas for `cli-bootstrap.json` and its verification identity replace the unvalidated cast and repeated handwritten status validation. They preserve unknown fields because the image shim and CLI are independent writers.
- Named retry and verification timing constants replace repeated inline magic numbers.
- The existing privileged e2e setup installs the locally built tgz into `npm/packages/<version>`, creates the managed CLI symlink, and seeds `cli-bootstrap.json` with the exact manifest identity before `runtime init`. This replaces the removed production paired-tarball contract and the deleted `CLAWDI_RUNTIME_TEST_CLI_INSTALLER` hook; no product env, flag, hook, or optional assertion was added.

## Hosted Pairing

The manifest/bootstrap wire contract remains exact `clawdi@<semver>`. Paired tests must install their local build and seed the managed symlink plus bootstrap status in the test harness, matching `smoke-cloud-datasource.sh:1003-1012`; product code does not accept a tarball transport override. The hosted repository was not modified here.

## Verification

- Isolated Docker CLI runner: typecheck passed; 1754 passed, 4 skipped, 0 failed across 136 files with 9447 assertions.
- Privileged systemd e2e with the test-side local tgz seed:
  - Virgin Hermes first boot passed.
  - Virgin OpenClaw first boot passed.
  - Real OpenClaw installer failure rollback passed.
  - Full run: 7 passed; the existing large model-list projection hit its fixed 120-second timeout, and the final test then observed its leftover OpenClaw state.
  - The final crash-recovery test passed alone in a fresh privileged container: 1 passed, 8 filtered, 0 failed.
- Isolated Docker Biome: 1072 files checked, no fixes or errors.
- `git diff --check`: passed.
- Source mounts were read-only; work directories and dependency caches lived in containers/tmpfs. Task-owned containers, networks, and images were removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)