### PR TITLE
refactor(cli): simplify hosted resource reconciliation

### DIFF
--- a/packages/cli/src/lib/chatgpt-oauth-reconciliation.test.ts
+++ b/packages/cli/src/lib/chatgpt-oauth-reconciliation.test.ts
@@ -120,7 +120,7 @@ describe("ChatGPT OAuth ownership ledger", () => {
 			requiresWriteAheadIntent: true,
 			expectedCredentialFingerprint: TARGET_FINGERPRINT,
 		});
-		expect(intentLedgerForDecision(decision)).toEqual({
+		expect(intentLedgerForDecision(decision, seedIntent)).toEqual({
 			nativeProfileId: "native:provider-1",
 			credentialRevision: "revision-1",
 			state: "intent",
@@ -159,7 +159,7 @@ describe("ChatGPT OAuth ownership ledger", () => {
 		});
 	});
 
-	it("retries remove from before evidence and retires only after absence is proven", () => {
+	it("retries remove from before evidence and drops the ledger only after absence is proven", () => {
 		const firstDecision = decide({
 			desiredCredentialRevision: null,
 			desiredNativeProfileId: null,
@@ -167,7 +167,7 @@ describe("ChatGPT OAuth ownership ledger", () => {
 			ledger: seeded,
 			native: { state: "managed", credentialFingerprint: TARGET_FINGERPRINT },
 		});
-		const intent = intentLedgerForDecision(firstDecision);
+		const intent = intentLedgerForDecision(firstDecision, seeded);
 		expect(intent).toEqual({
 			nativeProfileId: "native:provider-1",
 			credentialRevision: "revision-1",
@@ -199,11 +199,7 @@ describe("ChatGPT OAuth ownership ledger", () => {
 		).toEqual({
 			nativeAction: "preserve",
 			requiresWriteAheadIntent: false,
-			nextLedger: {
-				nativeProfileId: "native:provider-1",
-				credentialRevision: "revision-1",
-				state: "retired",
-			},
+			nextLedger: null,
 		});
 		expect(
 			decide({

--- a/packages/cli/src/lib/chatgpt-oauth-reconciliation.ts
+++ b/packages/cli/src/lib/chatgpt-oauth-reconciliation.ts
@@ -5,7 +5,7 @@ export interface NativeOAuthCredentialObservation {
 	credentialFingerprint?: string;
 }
 
-export type OAuthCredentialLedgerStableState = "seeded" | "adopted" | "revoked" | "retired";
+export type OAuthCredentialLedgerStableState = "seeded" | "adopted" | "revoked";
 
 export type OAuthCredentialLedgerState = "intent" | OAuthCredentialLedgerStableState;
 
@@ -25,7 +25,7 @@ export type NativeOAuthCredentialAction = "preserve" | OAuthCredentialIntentOper
 
 export interface OAuthCredentialReconciliationDecision {
 	nativeAction: NativeOAuthCredentialAction;
-	nextLedger: OAuthCredentialLedgerSnapshot;
+	nextLedger: OAuthCredentialLedgerSnapshot | null;
 	requiresWriteAheadIntent: boolean;
 	expectedCredentialFingerprint?: string;
 	targetCredentialFingerprint?: string;
@@ -77,14 +77,6 @@ export function decideChatGptOAuthCredentialReconciliation(input: {
 		ledger.credentialRevision === desiredCredentialRevision
 	) {
 		if (native.state === "missing") {
-			if (ledger.state === "retired") {
-				return seedDecision(
-					desiredNativeProfileId,
-					desiredCredentialRevision,
-					desiredCredentialFingerprint,
-					true,
-				);
-			}
 			return preserveDecision({
 				nativeProfileId: desiredNativeProfileId,
 				credentialRevision: desiredCredentialRevision,
@@ -130,6 +122,7 @@ export function decideChatGptOAuthCredentialReconciliation(input: {
 
 export function intentLedgerForDecision(
 	decision: OAuthCredentialReconciliationDecision,
+	currentLedger: OAuthCredentialLedgerSnapshot | null = null,
 ): OAuthCredentialLedgerSnapshot {
 	if (!decision.requiresWriteAheadIntent || decision.nativeAction === "preserve") {
 		throw new Error("OAuth credential decision does not require a write-ahead intent");
@@ -146,9 +139,11 @@ export function intentLedgerForDecision(
 	) {
 		throw new Error(`${decision.nativeAction} intent requires target-credential evidence`);
 	}
+	const identity = decision.nextLedger ?? currentLedger;
+	if (!identity) throw new Error("OAuth credential intent requires ledger identity");
 	return {
-		nativeProfileId: decision.nextLedger.nativeProfileId,
-		credentialRevision: decision.nextLedger.credentialRevision,
+		nativeProfileId: identity.nativeProfileId,
+		credentialRevision: identity.credentialRevision,
 		state: "intent",
 		operation: decision.nativeAction,
 		...(decision.expectedCredentialFingerprint
@@ -164,32 +159,32 @@ function decideWithoutDesiredCredential(
 	ledger: OAuthCredentialLedgerSnapshot | null,
 	native: NativeOAuthCredentialObservation,
 ): OAuthCredentialReconciliationDecision {
-	if (!ledger) return preserveDecision(retiredLedger(null));
+	if (!ledger) return preserveDecision(null);
 	if (ledger.state === "intent") {
 		if (ledger.operation === "remove") {
-			if (native.state === "missing") return preserveDecision(retiredLedger(ledger));
+			if (native.state === "missing") return preserveDecision(null);
 			if (
 				ledger.beforeCredentialFingerprint &&
 				native.credentialFingerprint === ledger.beforeCredentialFingerprint
 			) {
-				return removeDecision(ledger, ledger.beforeCredentialFingerprint, false);
+				return removeDecision(ledger.beforeCredentialFingerprint, false);
 			}
 			return preserveDecision(ledger);
 		}
 
 		const targetFingerprint = intentTargetFingerprint(ledger);
 		if (targetFingerprint && native.credentialFingerprint === targetFingerprint) {
-			return removeDecision(ledger, targetFingerprint, true);
+			return removeDecision(targetFingerprint, true);
 		}
 		if (ledger.operation === "seed" && native.state === "missing") {
-			return preserveDecision(retiredLedger(ledger));
+			return preserveDecision(null);
 		}
 		if (
 			ledger.operation === "upsert" &&
 			ledger.beforeCredentialFingerprint &&
 			native.credentialFingerprint === ledger.beforeCredentialFingerprint
 		) {
-			return preserveDecision(retiredLedger(ledger));
+			return preserveDecision(null);
 		}
 		return preserveDecision(ledger);
 	}
@@ -201,9 +196,9 @@ function decideWithoutDesiredCredential(
 			(ledger.credentialFingerprint !== undefined &&
 				native.credentialFingerprint === ledger.credentialFingerprint));
 	if (owned) {
-		return removeDecision(ledger, requireObservedFingerprint(native), true);
+		return removeDecision(requireObservedFingerprint(native), true);
 	}
-	return preserveDecision(retiredLedger(ledger));
+	return preserveDecision(null);
 }
 
 function decideFromIntent(input: {
@@ -342,7 +337,6 @@ function upsertDecision(
 }
 
 function removeDecision(
-	ledger: OAuthCredentialLedgerSnapshot,
 	expectedCredentialFingerprint: string,
 	requiresWriteAheadIntent: boolean,
 ): OAuthCredentialReconciliationDecision {
@@ -350,12 +344,12 @@ function removeDecision(
 		nativeAction: "remove",
 		requiresWriteAheadIntent,
 		expectedCredentialFingerprint,
-		nextLedger: retiredLedger(ledger),
+		nextLedger: null,
 	};
 }
 
 function preserveDecision(
-	nextLedger: OAuthCredentialLedgerSnapshot,
+	nextLedger: OAuthCredentialLedgerSnapshot | null,
 ): OAuthCredentialReconciliationDecision {
 	return {
 		nativeAction: "preserve",
@@ -374,16 +368,6 @@ function seededLedger(
 		credentialRevision,
 		state: "seeded",
 		...(credentialFingerprint ? { credentialFingerprint } : {}),
-	};
-}
-
-function retiredLedger(
-	ledger: OAuthCredentialLedgerSnapshot | null,
-): OAuthCredentialLedgerSnapshot {
-	return {
-		nativeProfileId: ledger?.nativeProfileId ?? "retired",
-		credentialRevision: ledger?.credentialRevision ?? "retired",
-		state: "retired",
 	};
 }
 

--- a/packages/cli/src/lib/oauth-credential-ledger.test.ts
+++ b/packages/cli/src/lib/oauth-credential-ledger.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -46,33 +46,5 @@ describe("OAuth credential ownership ledger persistence", () => {
 			targetCredentialFingerprint,
 		});
 		expect(readOAuthCredentialLedger(path)).toEqual(ledger);
-	});
-
-	it("reads a legacy receipt without migrating it unless explicitly requested", () => {
-		root = mkdtempSync(join(tmpdir(), "clawdi-oauth-ledger-"));
-		const path = join(root, "provider.json");
-		const legacyBytes = `${JSON.stringify({
-			schemaVersion: "clawdi.runtimeOAuthCredential.v1",
-			runtime: "hermes",
-			providerId: "openai-codex",
-			nativeProfileId: "clawdi:profile",
-			credentialRevision: "revision-1",
-			state: "seeded",
-		})}\n`;
-		writeFileSync(path, legacyBytes);
-
-		const ledger = readOAuthCredentialLedger(path);
-		expect(ledger).toMatchObject({
-			schemaVersion: OAUTH_CREDENTIAL_LEDGER_SCHEMA_VERSION,
-			runtime: "hermes",
-			providerId: "openai-codex",
-			state: "seeded",
-		});
-		expect(readFileSync(path, "utf8")).toBe(legacyBytes);
-
-		const migrated = readOAuthCredentialLedger(path, { migrateLegacy: true });
-		expect(migrated).toEqual(ledger);
-		expect(JSON.parse(readFileSync(path, "utf8"))).toEqual(migrated);
-		expect(readOAuthCredentialLedger(path)).toEqual(migrated);
 	});
 });

--- a/packages/cli/src/lib/oauth-credential-ledger.ts
+++ b/packages/cli/src/lib/oauth-credential-ledger.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { z } from "zod";
 import type { OAuthCredentialLedgerSnapshot } from "./chatgpt-oauth-reconciliation";
@@ -14,7 +14,7 @@ const oauthCredentialLedgerSchema = z
 		providerId: z.string().min(1),
 		nativeProfileId: z.string().min(1),
 		credentialRevision: z.string().min(1).max(64),
-		state: z.enum(["intent", "seeded", "adopted", "revoked", "retired"]),
+		state: z.enum(["intent", "seeded", "adopted", "revoked"]),
 		operation: z.enum(["seed", "upsert", "remove"]).optional(),
 		credentialFingerprint: z
 			.string()
@@ -65,21 +65,6 @@ const oauthCredentialLedgerSchema = z
 		}
 	});
 
-const legacyOAuthCredentialReceiptSchema = z
-	.object({
-		schemaVersion: z.literal("clawdi.runtimeOAuthCredential.v1"),
-		runtime: z.enum(["hermes", "openclaw"]),
-		providerId: z.string().min(1),
-		nativeProfileId: z.string().min(1),
-		credentialRevision: z.string().min(1).max(64),
-		state: z.enum(["seeded", "adopted", "revoked"]),
-		credentialFingerprint: z
-			.string()
-			.regex(/^sha256:[a-f0-9]{64}$/)
-			.optional(),
-	})
-	.strict();
-
 export type OAuthCredentialLedger = z.infer<typeof oauthCredentialLedgerSchema>;
 export type OAuthCredentialLedgerRuntime = OAuthCredentialLedger["runtime"];
 
@@ -92,38 +77,15 @@ export function oauthCredentialLedgerPath(
 	return join(root, runtime, `${providerKey}.json`);
 }
 
-export function readOAuthCredentialLedger(
-	path: string,
-	options: {
-		migrateLegacy?: boolean;
-		afterMigrate?: (path: string, parent: string) => void;
-	} = {},
-): OAuthCredentialLedger | null {
+export function readOAuthCredentialLedger(path: string): OAuthCredentialLedger | null {
 	if (!existsSync(path)) return null;
 	const raw = JSON.parse(readFileSync(path, "utf8")) as unknown;
-	const canonical = oauthCredentialLedgerSchema.safeParse(raw);
-	if (canonical.success) return canonical.data;
-	const legacy = legacyOAuthCredentialReceiptSchema.parse(raw);
-	const migrated = oauthCredentialLedgerSchema.parse({
-		schemaVersion: OAUTH_CREDENTIAL_LEDGER_SCHEMA_VERSION,
-		runtime: legacy.runtime,
-		providerId: legacy.providerId,
-		nativeProfileId: legacy.nativeProfileId,
-		credentialRevision: legacy.credentialRevision,
-		state: legacy.state,
-		...(legacy.credentialFingerprint
-			? { credentialFingerprint: legacy.credentialFingerprint }
-			: {}),
-	});
-	if (!options.migrateLegacy) return migrated;
-	const migratedSnapshot = oauthCredentialLedgerSnapshot(migrated);
-	if (!migratedSnapshot) throw new Error("Migrated OAuth credential ledger snapshot is missing");
-	return writeOAuthCredentialLedger(
-		path,
-		{ runtime: migrated.runtime, providerId: migrated.providerId },
-		migratedSnapshot,
-		{ afterWrite: options.afterMigrate },
-	);
+	// SUNSET: remove after the fleet no longer carries pre-#1187 retired tombstones.
+	if (typeof raw === "object" && raw !== null && "state" in raw && raw.state === "retired") {
+		rmSync(path, { force: true });
+		return null;
+	}
+	return oauthCredentialLedgerSchema.parse(raw);
 }
 
 export function writeOAuthCredentialLedger(

--- a/packages/cli/src/runtime/hosted-hermes-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.test.ts
@@ -1,6 +1,4 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import {
 	existsSync,
 	mkdirSync,
@@ -12,8 +10,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { hostedHermesSkillExactSourceDriver } from "./hosted-hermes-skill";
-import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
+import { activateHostedHermesSkill } from "./hosted-hermes-skill";
 
 let root: string | null = null;
 
@@ -23,17 +20,7 @@ afterEach(() => {
 	root = null;
 });
 
-function preparedArchive(
-	archive: string,
-): Pick<PreparedHostedSourcedSkill, "archiveSha256" | "tarBytes"> {
-	const tarBytes = readFileSync(archive);
-	return {
-		archiveSha256: createHash("sha256").update(tarBytes).digest("hex"),
-		tarBytes,
-	};
-}
-
-function archiveSkill(
+function writeSkill(
 	fixtureRoot: string,
 	skillId: string,
 	files: Readonly<Record<string, string>>,
@@ -45,34 +32,7 @@ function archiveSkill(
 		mkdirSync(dirname(path), { recursive: true });
 		writeFileSync(path, content);
 	}
-	const archive = join(fixtureRoot, `${skillId}${suffix}.tar.gz`);
-	const packed = spawnSync("tar", ["-czf", archive, "-C", dirname(sourceDir), skillId]);
-	if (packed.status !== 0) throw new Error("test tar creation failed");
-	return archive;
-}
-
-function sourcedSkill(
-	skillId: string,
-	archive: string,
-	revision = "a".repeat(40),
-): PreparedHostedSourcedSkill {
-	return {
-		skillId,
-		source: {
-			type: "github",
-			url: "https://github.com/Clawdi-AI/store",
-			path: `skills/${skillId}`,
-			commit: revision,
-		},
-		sourceIdentity: [
-			"github",
-			skillId,
-			"https://github.com/Clawdi-AI/store",
-			`skills/${skillId}`,
-			revision,
-		].join("\0"),
-		...preparedArchive(archive),
-	};
+	return sourceDir;
 }
 
 function fakeHubInstallVerdict(
@@ -112,7 +72,7 @@ function fakeHermesLocalSkills(home: string): Array<{
 		});
 }
 
-describe("Hermes exact-source Workspace Skill driver", () => {
+describe("Hermes exact-source Workspace Skill activation", () => {
 	test("places a hub-blocked dangerous source on the official local discovery surface", () => {
 		root = mkdtempSync(join(tmpdir(), "hosted-hermes-dangerous-local-"));
 		const home = join(root, "home");
@@ -132,8 +92,7 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 				'import os\nimport subprocess\nsubprocess.run(input(), shell=True)\neval(os.environ["RECOVERY_EXPRESSION"])\n',
 			"skill.json": '{"catalog_only":true}\n',
 		};
-		const archive = archiveSkill(root, skillId, dangerousFiles);
-		const skill = sourcedSkill(skillId, archive);
+		const sourceDir = writeSkill(root, skillId, dangerousFiles);
 		const target = join(home, ".hermes", "skills", skillId);
 
 		expect(fakeHubInstallVerdict(dangerousFiles, true)).toEqual({
@@ -141,14 +100,7 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 			detail:
 				"Blocked (community source + dangerous verdict, 3 findings). --force does not override a dangerous verdict.",
 		});
-		expect(hostedHermesSkillExactSourceDriver.target({ home, skill })).toBe(target);
-		expect(
-			hostedHermesSkillExactSourceDriver.install({
-				home,
-				skill,
-				targetDir: target,
-			}),
-		).toBe("installed");
+		activateHostedHermesSkill(sourceDir, target);
 		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe(dangerousSkill);
 		expect(readFileSync(join(target, "references", "policy.md"), "utf8")).toBe(
 			"Verified support file\n",
@@ -174,24 +126,16 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 		const skillId = "review-pr";
 		const skillV1 = "---\nname: native-review-pr\n---\n# Review PR v1\n";
 		const skillV2 = "---\nname: native-review-pr\n---\n# Review PR v2\n";
-		const archiveV1 = archiveSkill(root, skillId, { "SKILL.md": skillV1 });
-		const archiveV2 = archiveSkill(root, skillId, { "SKILL.md": skillV2 }, "-v2");
-		const skill = sourcedSkill(skillId, archiveV1);
-		const updatedSkill = sourcedSkill(skillId, archiveV2, "b".repeat(40));
+		const sourceV1 = writeSkill(root, skillId, { "SKILL.md": skillV1 });
+		const sourceV2 = writeSkill(root, skillId, { "SKILL.md": skillV2 }, "-v2");
 		const target = join(home, ".hermes", "skills", skillId);
-		const input = { home, skill, targetDir: target };
 
-		expect(hostedHermesSkillExactSourceDriver.install(input)).toBe("installed");
+		activateHostedHermesSkill(sourceV1, target);
 		writeFileSync(join(target, "SKILL.md"), "tenant drift\n");
-		expect(hostedHermesSkillExactSourceDriver.install(input)).toBe("installed");
+		activateHostedHermesSkill(sourceV1, target);
 		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe(skillV1);
 
-		expect(
-			hostedHermesSkillExactSourceDriver.install({
-				...input,
-				skill: updatedSkill,
-			}),
-		).toBe("installed");
+		activateHostedHermesSkill(sourceV2, target);
 		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe(skillV2);
 	});
 
@@ -203,11 +147,10 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 			"SKILL.md": "---\nname: review-pr\n---\n# Review PR\n",
 			"references/guide.md": "Pinned guide bytes\n",
 		};
-		const archive = archiveSkill(root, skillId, skillFiles);
-		const skill = sourcedSkill(skillId, archive);
-		const input = { home, skill, targetDir: join(home, ".hermes", "skills", skillId) };
+		const sourceDir = writeSkill(root, skillId, skillFiles);
+		const target = join(home, ".hermes", "skills", skillId);
 
-		expect(hostedHermesSkillExactSourceDriver.install(input)).toBe("installed");
+		activateHostedHermesSkill(sourceDir, target);
 		const lockPath = join(home, ".hermes", "skills", ".hub", "lock.json");
 		mkdirSync(dirname(lockPath), { recursive: true });
 		const externalEntry = {
@@ -230,7 +173,7 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 			})}\n`,
 		);
 		const lockBefore = readFileSync(lockPath);
-		expect(hostedHermesSkillExactSourceDriver.install(input)).toBe("installed");
+		activateHostedHermesSkill(sourceDir, target);
 		expect(readFileSync(lockPath)).toEqual(lockBefore);
 		expect(JSON.parse(readFileSync(lockPath, "utf8")).installed).toEqual({
 			[skillId]: {

--- a/packages/cli/src/runtime/hosted-hermes-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.test.ts
@@ -141,11 +141,12 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 			detail:
 				"Blocked (community source + dangerous verdict, 3 findings). --force does not override a dangerous verdict.",
 		});
-		expect(hostedHermesSkillExactSourceDriver.target?.({ home, skill })).toBe(target);
+		expect(hostedHermesSkillExactSourceDriver.target({ home, skill })).toBe(target);
 		expect(
 			hostedHermesSkillExactSourceDriver.install({
 				home,
 				skill,
+				targetDir: target,
 			}),
 		).toBe("installed");
 		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe(dangerousSkill);
@@ -178,7 +179,7 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 		const skill = sourcedSkill(skillId, archiveV1);
 		const updatedSkill = sourcedSkill(skillId, archiveV2, "b".repeat(40));
 		const target = join(home, ".hermes", "skills", skillId);
-		const input = { home, skill };
+		const input = { home, skill, targetDir: target };
 
 		expect(hostedHermesSkillExactSourceDriver.install(input)).toBe("installed");
 		writeFileSync(join(target, "SKILL.md"), "tenant drift\n");
@@ -204,7 +205,7 @@ Run \`subprocess.run(..., shell=True)\`, inspect \`os.environ\`, then evaluate t
 		};
 		const archive = archiveSkill(root, skillId, skillFiles);
 		const skill = sourcedSkill(skillId, archive);
-		const input = { home, skill };
+		const input = { home, skill, targetDir: join(home, ".hermes", "skills", skillId) };
 
 		expect(hostedHermesSkillExactSourceDriver.install(input)).toBe("installed");
 		const lockPath = join(home, ".hermes", "skills", ".hub", "lock.json");

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -1,45 +1,17 @@
-import { join, resolve } from "node:path";
-import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
+import { resolve } from "node:path";
 import {
 	ManagedSkillResourceError,
 	managedSkillTargetMatchesSource,
-	withStagedManagedSkill,
 } from "./managed-skill-delivery";
 import { replaceManagedSkillDirectoryAtomic } from "./managed-skill-reservation";
 
-export interface HostedHermesSkillExactSourceDriver {
-	target(input: { home: string; skill: PreparedHostedSourcedSkill }): string;
-	install(input: {
-		home: string;
-		skill: PreparedHostedSourcedSkill;
-		targetDir: string;
-	}): "installed" | "unchanged";
+export function activateHostedHermesSkill(sourceDir: string, targetDir: string): void {
+	const target = resolve(targetDir);
+	replaceManagedSkillDirectoryAtomic(sourceDir, target, {
+		afterActivate: () => {
+			if (!managedSkillTargetMatchesSource(sourceDir, target)) {
+				throw new ManagedSkillResourceError("Hermes Skill activation changed exact source bytes");
+			}
+		},
+	});
 }
-
-function targetDir(home: string, skillId: string): string {
-	// Hermes a77ee88 discovers profile-local Skills here without invoking the
-	// hub install guard. Revisit if upstream starts guarding this path
-	// (NousResearch/hermes-agent#89704, Clawdi-AI/clawdi#1148).
-	return join(home, ".hermes", "skills", skillId);
-}
-
-function assertActivationMatchesSource(sourceDir: string, target: string): void {
-	if (!managedSkillTargetMatchesSource(sourceDir, target)) {
-		throw new ManagedSkillResourceError("Hermes Skill activation changed exact source bytes");
-	}
-}
-
-export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDriver = {
-	target(input) {
-		return targetDir(input.home, input.skill.skillId);
-	},
-	install(input) {
-		const target = resolve(input.targetDir);
-		return withStagedManagedSkill(input.skill, (sourceDir) => {
-			replaceManagedSkillDirectoryAtomic(sourceDir, target, {
-				afterActivate: () => assertActivationMatchesSource(sourceDir, target),
-			});
-			return "installed" as const;
-		});
-	},
-};

--- a/packages/cli/src/runtime/hosted-hermes-skill.ts
+++ b/packages/cli/src/runtime/hosted-hermes-skill.ts
@@ -8,11 +8,11 @@ import {
 import { replaceManagedSkillDirectoryAtomic } from "./managed-skill-reservation";
 
 export interface HostedHermesSkillExactSourceDriver {
-	target?(input: { home: string; skill: PreparedHostedSourcedSkill }): string;
+	target(input: { home: string; skill: PreparedHostedSourcedSkill }): string;
 	install(input: {
 		home: string;
 		skill: PreparedHostedSourcedSkill;
-		targetDir?: string;
+		targetDir: string;
 	}): "installed" | "unchanged";
 }
 
@@ -34,7 +34,7 @@ export const hostedHermesSkillExactSourceDriver: HostedHermesSkillExactSourceDri
 		return targetDir(input.home, input.skill.skillId);
 	},
 	install(input) {
-		const target = resolve(input.targetDir ?? targetDir(input.home, input.skill.skillId));
+		const target = resolve(input.targetDir);
 		return withStagedManagedSkill(input.skill, (sourceDir) => {
 			replaceManagedSkillDirectoryAtomic(sourceDir, target, {
 				afterActivate: () => assertActivationMatchesSource(sourceDir, target),

--- a/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
@@ -1,6 +1,4 @@
 import { afterEach, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import {
 	chmodSync,
 	existsSync,
@@ -12,7 +10,10 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { hostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
+import {
+	activateHostedOpenClawSkill,
+	resolveHostedOpenClawWorkspace,
+} from "./hosted-openclaw-skill";
 
 let root = "";
 const originalSystemctlPath = process.env.CLAWDI_SYSTEMCTL_PATH;
@@ -52,7 +53,7 @@ printf '%s\n' 'LoadState=loaded' 'ActiveState=deactivating'
 	chmodSync(systemctl, 0o755);
 	process.env.CLAWDI_SYSTEMCTL_PATH = systemctl;
 
-	expect(hostedOpenClawSkillDriver.resolveWorkspace({ home })).toBe(workspaceRoot);
+	expect(resolveHostedOpenClawWorkspace(home)).toBe(workspaceRoot);
 	expect(readFileSync(attempts, "utf8")).toBe("2\n");
 });
 
@@ -85,7 +86,7 @@ exit ${scenario.exitCode}
 		chmodSync(systemctl, 0o755);
 		process.env.CLAWDI_SYSTEMCTL_PATH = systemctl;
 
-		expect(() => hostedOpenClawSkillDriver.resolveWorkspace({ home })).toThrow(
+		expect(() => resolveHostedOpenClawWorkspace(home)).toThrow(
 			"official agent workspace roster is unavailable",
 		);
 		expect(readFileSync(attempts, "utf8")).toBe("agents list --json\n");
@@ -162,9 +163,7 @@ esac
 	);
 	chmodSync(command, 0o755);
 
-	expect(hostedOpenClawSkillDriver.resolveWorkspace({ home, repairInvalidConfig: true })).toBe(
-		workspaceRoot,
-	);
+	expect(resolveHostedOpenClawWorkspace(home, true)).toBe(workspaceRoot);
 	expect(readFileSync(commandLog, "utf-8").trim().split("\n")).toEqual([
 		"agents list --json",
 		"config validate --json",
@@ -226,12 +225,9 @@ exit 2
 		);
 		chmodSync(command, 0o755);
 
-		expect(() =>
-			hostedOpenClawSkillDriver.resolveWorkspace({
-				home,
-				repairInvalidConfig: scenario.repairInvalidConfig,
-			}),
-		).toThrow("official agent workspace roster is unavailable");
+		expect(() => resolveHostedOpenClawWorkspace(home, scenario.repairInvalidConfig)).toThrow(
+			"official agent workspace roster is unavailable",
+		);
 		expect(readFileSync(commandLog, "utf-8").trim().split("\n")).toEqual([
 			...scenario.expectedCommands,
 		]);
@@ -282,61 +278,26 @@ if test "\${FAKE_OPENCLAW_DRIFT_AFTER_WRITE:-}" = "1"; then touch '${workspaceDr
 	const sourceDir = join(root, "source", "review-pr");
 	mkdirSync(sourceDir, { recursive: true });
 	writeFileSync(join(sourceDir, "SKILL.md"), "# Review PR\n");
-	const archive = join(root, "review-pr.tar.gz");
-	const packed = spawnSync("tar", ["-czf", archive, "-C", dirname(sourceDir), "review-pr"]);
-	if (packed.status !== 0) throw new Error("test tar creation failed");
-	const tarBytes = readFileSync(archive);
-	const skill = {
-		skillId: "review-pr",
-		source: {
-			type: "github" as const,
-			url: "https://github.com/Clawdi-AI/store",
-			path: "skills/review-pr",
-			commit: "a".repeat(40),
-		},
-		sourceIdentity: `github\0review-pr\0https://github.com/Clawdi-AI/store\0skills/review-pr\0${"a".repeat(40)}`,
-		archiveSha256: createHash("sha256").update(tarBytes).digest("hex"),
-		tarBytes,
-	};
+	const target = join(workspaceRoot, "skills", "review-pr");
+	const activate = () =>
+		activateHostedOpenClawSkill({ home, workspaceRoot, sourceDir, targetDir: target });
 
 	expect(existsSync(workspaceRoot)).toBe(false);
-	expect(hostedOpenClawSkillDriver.install({ home, workspaceRoot, skill })).toBe("installed");
+	activate();
 	expect(readFileSync(installCwdLog, "utf8")).toBe(`${home}\n`);
 	expect(readFileSync(installLog, "utf8")).toMatch(
 		/^skills install .* --agent main --as review-pr --force\n$/,
 	);
-	const target = join(workspaceRoot, "skills", "review-pr");
 	expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("# Review PR\n");
-	expect(
-		hostedOpenClawSkillDriver.installDirectory({
-			home,
-			workspaceRoot,
-			skillId: "review-pr",
-			sourceDir,
-		}),
-	).toBe("installed");
+	activate();
 	expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("# Review PR\n");
 	writeFileSync(join(sourceDir, "SKILL.md"), "# Review PR v2\n");
 	process.env.FAKE_OPENCLAW_FAIL_AFTER_WRITE = "1";
-	expect(() =>
-		hostedOpenClawSkillDriver.installDirectory({
-			home,
-			workspaceRoot,
-			skillId: "review-pr",
-			sourceDir,
-		}),
-	).toThrow("official Skill install failed: exit code 45 without output");
+	expect(activate).toThrow("official Skill install failed: exit code 45 without output");
 	expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("# Review PR\n");
 	delete process.env.FAKE_OPENCLAW_FAIL_AFTER_WRITE;
 	process.env.FAKE_OPENCLAW_DRIFT_AFTER_WRITE = "1";
-	expect(() =>
-		hostedOpenClawSkillDriver.installDirectory({
-			home,
-			workspaceRoot,
-			skillId: "review-pr",
-			sourceDir,
-		}),
-	).toThrow("changed during Skill reconciliation");
+	expect(activate).toThrow("changed during Skill reconciliation");
 	expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("# Review PR\n");
 	delete process.env.FAKE_OPENCLAW_DRIFT_AFTER_WRITE;
 	rmSync(workspaceDriftMarker);
@@ -366,11 +327,11 @@ exit 0
 	mkdirSync(sourceDir, { recursive: true });
 	writeFileSync(join(sourceDir, "SKILL.md"), "# Review PR\n");
 	expect(() =>
-		hostedOpenClawSkillDriver.installDirectory({
+		activateHostedOpenClawSkill({
 			home,
 			workspaceRoot,
-			skillId: "review-pr",
 			sourceDir,
+			targetDir: join(workspaceRoot, "skills", "review-pr"),
 		}),
 	).toThrow("changed during Skill reconciliation");
 	expect(existsSync(installMarker)).toBe(false);
@@ -400,11 +361,11 @@ exit 64
 	writeFileSync(join(sourceDir, "SKILL.md"), "# Review PR\n");
 	let message = "";
 	try {
-		hostedOpenClawSkillDriver.installDirectory({
+		activateHostedOpenClawSkill({
 			home,
 			workspaceRoot,
-			skillId: "review-pr",
 			sourceDir,
+			targetDir: join(workspaceRoot, "skills", "review-pr"),
 		});
 	} catch (error) {
 		message = error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/runtime/hosted-openclaw-skill.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.ts
@@ -1,14 +1,12 @@
-import { isAbsolute, join, resolve } from "node:path";
+import { basename, isAbsolute, join, resolve } from "node:path";
 import {
 	type OpenClawAgentWorkspace,
 	parseOpenClawAgentWorkspaces,
 } from "../adapters/openclaw-workspace";
-import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import {
 	ManagedSkillResourceError,
 	managedSkillTargetMatchesSource,
 	withManagedTargetRollback,
-	withStagedManagedSkill,
 } from "./managed-skill-delivery";
 import {
 	executableExists,
@@ -24,21 +22,6 @@ const OPENCLAW_CONFIG_REPAIR_TIMEOUT_MS = 120_000;
 const OPENCLAW_GATEWAY_UNIT = "openclaw-gateway.service";
 const OPENCLAW_GATEWAY_TRANSITION_RETRIES = 2;
 const OPENCLAW_GATEWAY_TRANSITION_RETRY_DELAY_MS = 3_000;
-
-export interface HostedOpenClawSkillDriver {
-	resolveWorkspace(input: { home: string; repairInvalidConfig?: boolean }): string;
-	installDirectory(input: {
-		home: string;
-		workspaceRoot: string;
-		skillId: string;
-		sourceDir: string;
-	}): "installed" | "unchanged";
-	install(input: {
-		home: string;
-		workspaceRoot: string;
-		skill: PreparedHostedSourcedSkill;
-	}): "installed" | "unchanged";
-}
 
 function installedCommandPath(home: string): string | null {
 	return withRuntimeUserFileAccess(() => {
@@ -142,7 +125,10 @@ function waitForOpenClawGatewayTransition(): void {
 	);
 }
 
-function resolveOfficialWorkspace(home: string, repairInvalidConfigOnFailure = false): string {
+export function resolveHostedOpenClawWorkspace(
+	home: string,
+	repairInvalidConfigOnFailure = false,
+): string {
 	const command = commandPath(home);
 	let result = spawnRuntimeUserCommand(command, ["agents", "list", "--json"], home, home, {
 		timeoutMs: OPENCLAW_CONFIG_PROBE_TIMEOUT_MS,
@@ -174,7 +160,7 @@ function resolveOfficialWorkspace(home: string, repairInvalidConfigOnFailure = f
 }
 
 function assertOfficialWorkspace(input: { home: string; workspaceRoot: string }): void {
-	if (resolveOfficialWorkspace(input.home) !== resolve(input.workspaceRoot))
+	if (resolveHostedOpenClawWorkspace(input.home) !== resolve(input.workspaceRoot))
 		throw new Error("OpenClaw official agent workspace changed during Skill reconciliation");
 }
 
@@ -194,61 +180,51 @@ function commandFailureDetail(result: ReturnType<typeof spawnRuntimeUserCommand>
 	return details.join("; ") || "process failed without details";
 }
 
-export const hostedOpenClawSkillDriver: HostedOpenClawSkillDriver = {
-	resolveWorkspace(input) {
-		return withRuntimeUserFileAccess(() =>
-			resolveOfficialWorkspace(input.home, input.repairInvalidConfig),
-		);
-	},
-	installDirectory(input) {
-		const target = targetDir(input.workspaceRoot, input.skillId);
-		assertOfficialWorkspace(input);
-		return withManagedTargetRollback({
-			target,
-			operation: () => {
-				// The roster may reference a workspace OpenClaw has not created yet on first run.
-				const result = spawnRuntimeUserCommand(
-					commandPath(input.home),
-					[
-						"skills",
-						"install",
-						input.sourceDir,
-						"--agent",
-						OPENCLAW_AGENT_ID,
-						"--as",
-						input.skillId,
-						"--force",
-					],
-					input.home,
-					input.home,
-					{ timeoutMs: 120_000, maxBufferBytes: 1024 * 1024 },
+export function activateHostedOpenClawSkill(input: {
+	home: string;
+	workspaceRoot: string;
+	sourceDir: string;
+	targetDir: string;
+}): void {
+	const skillId = basename(input.targetDir);
+	const target = resolve(input.targetDir);
+	if (target !== resolve(targetDir(input.workspaceRoot, skillId))) {
+		throw new ManagedSkillResourceError("OpenClaw Skill target is invalid");
+	}
+	assertOfficialWorkspace(input);
+	withManagedTargetRollback({
+		target,
+		operation: () => {
+			// The roster may reference a workspace OpenClaw has not created yet on first run.
+			const result = spawnRuntimeUserCommand(
+				commandPath(input.home),
+				[
+					"skills",
+					"install",
+					input.sourceDir,
+					"--agent",
+					OPENCLAW_AGENT_ID,
+					"--as",
+					skillId,
+					"--force",
+				],
+				input.home,
+				input.home,
+				{ timeoutMs: 120_000, maxBufferBytes: 1024 * 1024 },
+			);
+			if (result.status !== 0) {
+				throw new ManagedSkillResourceError(
+					`OpenClaw official Skill install failed: ${commandFailureDetail(result)}`,
 				);
-				if (result.status !== 0)
-					throw new ManagedSkillResourceError(
-						`OpenClaw official Skill install failed: ${commandFailureDetail(result)}`,
-					);
-				assertOfficialWorkspace(input);
-				if (
-					!managedSkillTargetMatchesSource(input.sourceDir, target, {
-						exclude: OPENCLAW_INSTALLED_TREE_EXCLUDES,
-					})
-				) {
-					throw new ManagedSkillResourceError(
-						"OpenClaw Skill activation changed exact source bytes",
-					);
-				}
-				return "installed" as const;
-			},
-		});
-	},
-	install(input) {
-		return withStagedManagedSkill(input.skill, (sourceDir) =>
-			this.installDirectory({
-				home: input.home,
-				workspaceRoot: input.workspaceRoot,
-				skillId: input.skill.skillId,
-				sourceDir,
-			}),
-		);
-	},
-};
+			}
+			assertOfficialWorkspace(input);
+			if (
+				!managedSkillTargetMatchesSource(input.sourceDir, target, {
+					exclude: OPENCLAW_INSTALLED_TREE_EXCLUDES,
+				})
+			) {
+				throw new ManagedSkillResourceError("OpenClaw Skill activation changed exact source bytes");
+			}
+		},
+	});
+}

--- a/packages/cli/src/runtime/hosted-provider-resolution.ts
+++ b/packages/cli/src/runtime/hosted-provider-resolution.ts
@@ -310,50 +310,41 @@ function assertNoProviderEnvOverlap(
 	}
 }
 
+type RuntimeProviderSettings = RuntimeManifest["runtimes"][string]["run"];
+type RuntimeServiceProviderSettings = NonNullable<
+	RuntimeManifest["runtimes"][string]["services"]
+>[string];
+
 export function mergeRuntimeEnvWithProviderPlaceholders(
 	runtimeName: string,
-	settings: RuntimeManifest["runtimes"][string]["run"],
+	settings: RuntimeServiceProviderSettings,
 	providerEnv: Record<string, string>,
-): RuntimeManifest["runtimes"][string]["run"] {
+	serviceName: string,
+): RuntimeServiceProviderSettings;
+export function mergeRuntimeEnvWithProviderPlaceholders(
+	runtimeName: string,
+	settings: RuntimeProviderSettings,
+	providerEnv: Record<string, string>,
+): RuntimeProviderSettings;
+export function mergeRuntimeEnvWithProviderPlaceholders(
+	runtimeName: string,
+	settings: RuntimeProviderSettings | RuntimeServiceProviderSettings,
+	providerEnv: Record<string, string>,
+	serviceName?: string,
+): RuntimeProviderSettings | RuntimeServiceProviderSettings {
 	if (Object.keys(providerEnv).length === 0) return settings;
 	const userEnv = settings?.env ?? {};
 	for (const envName of Object.keys(providerEnv)) {
 		if (settings?.secretEnv?.[envName] !== undefined) {
 			throw new Error(
-				`runtime ${runtimeName} provider placeholder ${envName} conflicts with secretEnv`,
+				`runtime ${runtimeName}${serviceName ? ` service ${serviceName}` : ""} provider placeholder ${envName} conflicts with secretEnv`,
 			);
 		}
 	}
 	return {
 		...(settings ?? {}),
 		prependPath: settings?.prependPath ?? [],
-		env: {
-			...userEnv,
-			...providerEnv,
-		},
-	};
-}
-
-export function mergeRuntimeServiceEnvWithProviderPlaceholders(
-	runtimeName: string,
-	serviceName: string,
-	settings: NonNullable<RuntimeManifest["runtimes"][string]["services"]>[string],
-	providerEnv: Record<string, string>,
-): NonNullable<RuntimeManifest["runtimes"][string]["services"]>[string] {
-	if (Object.keys(providerEnv).length === 0) return settings;
-	for (const envName of Object.keys(providerEnv)) {
-		if (settings.secretEnv?.[envName] !== undefined) {
-			throw new Error(
-				`runtime ${runtimeName} service ${serviceName} provider placeholder ${envName} conflicts with secretEnv`,
-			);
-		}
-	}
-	return {
-		...settings,
-		env: {
-			...(settings.env ?? {}),
-			...providerEnv,
-		},
+		env: { ...userEnv, ...providerEnv },
 	};
 }
 

--- a/packages/cli/src/runtime/hosted-sourced-skill-archive.test.ts
+++ b/packages/cli/src/runtime/hosted-sourced-skill-archive.test.ts
@@ -219,10 +219,7 @@ describe("hosted sourced Skill archives", () => {
 			projectManifest(legacyHash),
 			hostedRuntimePaths(),
 			{
-				fetcher: async () =>
-					new Response(Uint8Array.from(canonical.archive), {
-						status: 200,
-					}),
+				fetcher: async () => new Response(Uint8Array.from(canonical.archive), { status: 200 }),
 			},
 		);
 

--- a/packages/cli/src/runtime/hosted-sourced-skill-archive.ts
+++ b/packages/cli/src/runtime/hosted-sourced-skill-archive.ts
@@ -153,38 +153,14 @@ function isReceipt(value: unknown): value is HostedSourcedSkillArchiveReceipt {
 				typeof source.installUrl === "string";
 }
 
-function assertProjectSkillEndpoints(
+function assertProjectSkillOrigin(
 	manifest: RuntimeManifest,
 	skillId: string,
 	source: Extract<HostedSkillSource, { type: "project" }>,
 ): void {
-	const controlPlane = new URL(manifest.controlPlane.apiUrl);
-	const archive = new URL(source.archiveUrl);
-	const install = new URL(source.installUrl);
-	if (archive.origin !== controlPlane.origin || install.origin !== controlPlane.origin) {
+	const origin = new URL(manifest.controlPlane.apiUrl).origin;
+	if ([source.archiveUrl, source.installUrl].some((url) => new URL(url).origin !== origin)) {
 		throw new Error(`Project Skill ${skillId} download endpoints do not match the control plane`);
-	}
-	const archiveMatch =
-		/^\/v1\/runtime\/project-skill-archives\/([0-9a-f-]{36})\/([0-9a-f-]{36})\/([0-9a-f-]{36})\/([a-f0-9]{64})\/([a-f0-9]{64})\/([a-z0-9-]+)\.tar\.gz$/.exec(
-			archive.pathname,
-		);
-	const installMatch =
-		/^\/v1\/runtime\/project-skill-files\/([0-9a-f-]{36})\/([0-9a-f-]{36})\/([a-f0-9]{64})\/([a-f0-9]{64})\/SKILL\.md$/.exec(
-			install.pathname,
-		);
-	if (
-		!archiveMatch ||
-		!installMatch ||
-		archiveMatch[1] !== manifest.environmentId ||
-		archiveMatch[2] !== source.projectId ||
-		archiveMatch[4] !== source.contentHash ||
-		archiveMatch[6] !== skillId ||
-		installMatch[1] !== manifest.environmentId ||
-		installMatch[2] !== archiveMatch[3] ||
-		installMatch[3] !== source.contentHash ||
-		installMatch[4] !== archiveMatch[5]
-	) {
-		throw new Error(`Project Skill ${skillId} install endpoint is invalid`);
 	}
 }
 
@@ -216,6 +192,7 @@ async function fetchProjectSkillArchive(
 		const skillDir = join(extractedRoot, skillId);
 		const canonical = await snapshotSkillArchive(skillDir, extractedRoot, skillId);
 		const skillEntries = readdirSync(skillDir);
+		// SUNSET: remove once the control plane has backfilled tree hashes for pre-2026-04-28 project skills.
 		const matchesLegacySingleFileHash =
 			skillEntries.length === 1 &&
 			skillEntries[0] === "SKILL.md" &&
@@ -276,7 +253,7 @@ export async function prepareHostedSourcedSkillArchives(
 			continue;
 		}
 		if (desired.source.type === "project") {
-			assertProjectSkillEndpoints(manifest, skillId, desired.source);
+			assertProjectSkillOrigin(manifest, skillId, desired.source);
 		}
 		const cached = readCachedArchive(paths, skillId, desired.source);
 		if (cached) {

--- a/packages/cli/src/runtime/live-state-snapshot.ts
+++ b/packages/cli/src/runtime/live-state-snapshot.ts
@@ -53,7 +53,6 @@ export function runtimeRootLiveMutationTargets(
 	const result = new Set<string>([
 		paths.managedConfig,
 		paths.syncState,
-		paths.providerHealthStatus,
 		paths.egressEngineStatus,
 		paths.manifestLastGood,
 		paths.managedSecretCacheFile,

--- a/packages/cli/src/runtime/managed-skill-reservation.test.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.test.ts
@@ -222,6 +222,7 @@ describe("managed Skill reservations", () => {
 	it("records legacy migration independently for each canonical target", () => {
 		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
 		process.env.HOME = root;
+		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "service-state");
 		const existing = join(root, "one", "skills", "clawdi");
 		const absent = join(root, "two", "skills", "clawdi");
 		cpSync(resolve(import.meta.dir, "../../skills/clawdi"), existing, { recursive: true });

--- a/packages/cli/src/runtime/managed-skill-reservation.test.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.test.ts
@@ -70,6 +70,24 @@ describe("managed Skill reservations", () => {
 		});
 		expect(managedSkillReservationState(first, "example")).toBe("reserved");
 		expect(managedSkillReservationState(second, "example")).toBe("unreserved");
+
+		const legacyTarget = join(root, "hub", "skills", "legacy-key");
+		const ledgerPath = managedSkillReservationLedgerPath();
+		const ledger = JSON.parse(readFileSync(ledgerPath, "utf8"));
+		ledger.reservations[legacyTarget] = {
+			...ledger.reservations[first],
+			target: legacyTarget,
+		};
+		writeFileSync(ledgerPath, `${JSON.stringify(ledger)}\n`);
+		const warnings: string[] = [];
+		const warn = console.warn;
+		try {
+			console.warn = (message?: unknown) => warnings.push(String(message));
+			expect(managedSkillReservationState(first, "example")).toBe("reserved");
+		} finally {
+			console.warn = warn;
+		}
+		expect(warnings.join("\n")).toContain(legacyTarget);
 	});
 
 	it("does not treat a forged co-located marker as authority", () => {
@@ -185,68 +203,6 @@ describe("managed Skill reservations", () => {
 			}),
 		).toBe("created");
 		expect(managedSkillReservationState(path, "example")).toBe("reserved");
-	});
-
-	it("moves a sourced reservation to the official native target", () => {
-		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
-		mkdirSync(join(root, "state"));
-		const previousTarget = join(root, "skills", "project-skill");
-		const nativeTarget = join(root, "skills", "frontmatter-name");
-		const sourceIdentity = [
-			"project",
-			"project-skill",
-			"22222222-2222-4222-8222-222222222222",
-			"a".repeat(64),
-		].join("\0");
-		reserveManagedSkill({
-			targetDir: previousTarget,
-			id: "project-skill",
-			manager: "hosted-manifest",
-			sourceIdentity,
-		});
-
-		installReservedManagedSkill(
-			{
-				targetDir: nativeTarget,
-				previousTargetDir: previousTarget,
-				id: "project-skill",
-				manager: "hosted-manifest",
-				sourceIdentity,
-			},
-			() => {
-				expect(shouldIgnoreUserSkill(previousTarget, "project-skill")).toBe(true);
-				expect(shouldIgnoreUserSkill(nativeTarget, "frontmatter-name")).toBe(false);
-			},
-			verifiedInstall,
-		);
-
-		expect(managedSkillReservationState(previousTarget, "project-skill")).toBe("unreserved");
-		expect(managedSkillReservationState(nativeTarget, "project-skill")).toBe("reserved");
-		expect(shouldIgnoreUserSkill(nativeTarget, "frontmatter-name")).toBe(true);
-	});
-
-	it("rejects unsafe native targets for sourced reservations", () => {
-		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
-		mkdirSync(join(root, "state"));
-		const sourceIdentity = [
-			"project",
-			"project-skill",
-			"22222222-2222-4222-8222-222222222222",
-			"a".repeat(64),
-		].join("\0");
-
-		expect(() =>
-			reserveManagedSkill({
-				targetDir: join(root, "skills", ".hub"),
-				id: "project-skill",
-				manager: "hosted-manifest",
-				sourceIdentity,
-			}),
-		).toThrow("managed Skill reservation identity is invalid");
 	});
 
 	it("reports malformed ownership state instead of silently hiding Skills", () => {
@@ -483,7 +439,7 @@ describe("managed Skill reservations", () => {
 		expect(managedSkillReservationState(path, "example")).toBe("unreserved");
 	});
 
-	it("preserves the previous target when activation and restore both fail", () => {
+	it("preserves the rollback backup when activation and restore both fail", () => {
 		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
 		process.env.HOME = root;
 		const source = join(root, "source");
@@ -517,7 +473,7 @@ describe("managed Skill reservations", () => {
 
 		expect(existsSync(path)).toBe(false);
 		const recovery = readdirSync(dirname(path)).find((entry) =>
-			entry.startsWith(`.${basename(path)}-previous-`),
+			entry.startsWith(`.${basename(path)}-clawdi-rollback-`),
 		);
 		expect(recovery).toBeDefined();
 		if (!recovery) throw new Error("expected recovery artifact");
@@ -525,7 +481,7 @@ describe("managed Skill reservations", () => {
 		expect(managedSkillReservationState(path, "example")).toBe("unreserved");
 	});
 
-	it("keeps committed ownership when previous-target cleanup fails", () => {
+	it("keeps committed ownership when rollback backup cleanup fails", () => {
 		root = mkdtempSync(join(tmpdir(), "skill-reservation-"));
 		process.env.HOME = root;
 		const source = join(root, "source");
@@ -553,7 +509,9 @@ describe("managed Skill reservations", () => {
 		expect(readFileSync(join(path, "SKILL.md"), "utf8")).toBe("# Updated\n");
 		expect(managedSkillReservationState(path, "example")).toBe("reserved");
 		expect(
-			readdirSync(dirname(path)).some((entry) => entry.startsWith(`.${basename(path)}-previous-`)),
+			readdirSync(dirname(path)).some((entry) =>
+				entry.startsWith(`.${basename(path)}-clawdi-rollback-`),
+			),
 		).toBe(true);
 	});
 

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import {
 	cpSync,
 	existsSync,
@@ -22,13 +21,6 @@ import { runtimePlatformRootForPath, writeRuntimePlatformFileAtomic } from "./st
 const LEDGER_FILE = "managed-skills.json";
 const LEDGER_SCHEMA = "clawdi.managedSkillReservations.v1";
 const MANAGED_SKILL_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
-const SOURCED_MANAGED_SKILL_TARGET_PATTERN = /^[a-z][a-z0-9_-]*$/;
-const RESERVED_SOURCED_MANAGED_SKILL_TARGETS = new Set([
-	"skill",
-	"readme",
-	"index",
-	"unnamed-skill",
-]);
 const SHA256_PATTERN = /^[a-f0-9]{64}$/;
 // Exact local bundled Skill trees shipped by published CLI releases before the
 // ownership ledger. Pre-ledger installs had no marker, so content is the only
@@ -72,13 +64,9 @@ interface ManagedSkillReservationLedger {
 	localSetupMigrations: Record<string, { target: string; id: string }>;
 }
 
-interface PendingManagedSkillReservation extends ManagedSkillReservation {
-	previousTarget?: string;
-}
+type PendingManagedSkillReservation = ManagedSkillReservation;
 
-export interface PendingManagedSkillReservationSnapshot extends ManagedSkillReservationSnapshot {
-	previousTargetDir?: string;
-}
+export type PendingManagedSkillReservationSnapshot = ManagedSkillReservationSnapshot;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -97,13 +85,6 @@ export function managedSkillReservationLedgerPath(): string {
 	return ledgerPath();
 }
 
-function legacyHostedLedgerPath(path: string): string | null {
-	const runtimePaths = getRuntimePaths({ mode: "hosted" });
-	return path === join(runtimePaths.managedResourceRoot, LEDGER_FILE)
-		? join(runtimePaths.projectionRoot, LEDGER_FILE)
-		: null;
-}
-
 function emptyLedger(): ManagedSkillReservationLedger {
 	return {
 		schemaVersion: LEDGER_SCHEMA,
@@ -113,28 +94,14 @@ function emptyLedger(): ManagedSkillReservationLedger {
 	};
 }
 
-function validSourcedManagedSkillTarget(value: string): boolean {
-	const candidate = value.toLowerCase();
-	return (
-		SOURCED_MANAGED_SKILL_TARGET_PATTERN.test(candidate) &&
-		!RESERVED_SOURCED_MANAGED_SKILL_TARGETS.has(candidate)
-	);
-}
-
 function reservationTargetMatchesIdentity(
 	target: string,
-	value: { id?: unknown; sourceIdentity?: unknown; manager?: unknown },
+	value: { id?: unknown },
 ): boolean {
-	const targetName = basename(target);
-	return (
-		targetName === value.id ||
-		(value.manager === "hosted-manifest" &&
-			typeof value.sourceIdentity === "string" &&
-			validSourcedManagedSkillTarget(targetName))
-	);
+	return basename(target) === value.id;
 }
 
-function parseReservation(target: string, raw: unknown): ManagedSkillReservation {
+function parseReservation(target: string, raw: unknown): ManagedSkillReservation | null {
 	if (
 		!isRecord(raw) ||
 		raw.target !== target ||
@@ -149,7 +116,8 @@ function parseReservation(target: string, raw: unknown): ManagedSkillReservation
 		!reservationIdentityIsValid(raw) ||
 		(raw.manager !== "hosted-manifest" && raw.manager !== "local-setup")
 	) {
-		throw new Error("managed Skill ownership state is invalid");
+		console.warn(`ignoring invalid managed Skill ownership entry at ${target}`);
+		return null;
 	}
 	return {
 		target,
@@ -162,18 +130,12 @@ function parseReservation(target: string, raw: unknown): ManagedSkillReservation
 }
 
 function readLedger(path: string): ManagedSkillReservationLedger {
-	const legacyPath = legacyHostedLedgerPath(path);
-	const sourcePath = existsSync(path)
-		? path
-		: legacyPath && existsSync(legacyPath)
-			? legacyPath
-			: null;
-	if (!sourcePath) return emptyLedger();
+	if (!existsSync(path)) return emptyLedger();
 	let value: unknown;
 	try {
-		const stat = lstatSync(sourcePath);
+		const stat = lstatSync(path);
 		if (!stat.isFile() || stat.isSymbolicLink()) throw new Error("not a regular file");
-		value = JSON.parse(readFileSync(sourcePath, "utf8"));
+		value = JSON.parse(readFileSync(path, "utf8"));
 	} catch {
 		throw new Error("managed Skill ownership state is invalid");
 	}
@@ -188,27 +150,13 @@ function readLedger(path: string): ManagedSkillReservationLedger {
 	}
 	const reservations: Record<string, ManagedSkillReservation> = {};
 	for (const [target, raw] of Object.entries(value.reservations)) {
-		reservations[target] = parseReservation(target, raw);
+		const reservation = parseReservation(target, raw);
+		if (reservation) reservations[target] = reservation;
 	}
 	const pendingReservations: Record<string, PendingManagedSkillReservation> = {};
-	try {
-		for (const [target, raw] of Object.entries(value.pendingReservations ?? {})) {
-			const reservation = parseReservation(target, raw);
-			if (
-				!isRecord(raw) ||
-				(raw.previousTarget !== undefined &&
-					(typeof raw.previousTarget !== "string" ||
-						resolve(raw.previousTarget) !== raw.previousTarget))
-			) {
-				throw new Error("invalid pending reservation");
-			}
-			pendingReservations[target] = {
-				...reservation,
-				previousTarget: typeof raw.previousTarget === "string" ? raw.previousTarget : undefined,
-			};
-		}
-	} catch {
-		throw new Error("managed Skill ownership state is invalid");
+	for (const [target, raw] of Object.entries(value.pendingReservations ?? {})) {
+		const reservation = parseReservation(target, raw);
+		if (reservation) pendingReservations[target] = reservation;
 	}
 	const localSetupMigrations: Record<string, { target: string; id: string }> = {};
 	for (const [target, raw] of Object.entries(value.localSetupMigrations ?? {})) {
@@ -292,7 +240,6 @@ export function pendingManagedSkillReservations(
 		.filter((reservation) => reservation.manager === manager)
 		.map((reservation) => ({
 			targetDir: reservation.target,
-			previousTargetDir: reservation.previousTarget,
 			id: reservation.id,
 			version: reservation.version,
 			digest: reservation.digest,
@@ -476,7 +423,6 @@ export function reserveManagedSkill(input: {
 export function installReservedManagedSkill<T>(
 	input: {
 		targetDir: string;
-		previousTargetDir?: string;
 		id: string;
 		version?: number;
 		digest?: string;
@@ -488,7 +434,6 @@ export function installReservedManagedSkill<T>(
 ): T {
 	const path = ledgerPath();
 	const target = resolve(input.targetDir);
-	const previousTarget = input.previousTargetDir ? resolve(input.previousTargetDir) : target;
 	if (
 		!reservationTargetMatchesIdentity(target, input) ||
 		!MANAGED_SKILL_ID_PATTERN.test(input.id) ||
@@ -500,26 +445,15 @@ export function installReservedManagedSkill<T>(
 	return withLedgerWriteLock(input.manager, () => {
 		const ledger = readLedger(path);
 		const previous = ledger.reservations[target];
-		const replaced = previousTarget === target ? previous : ledger.reservations[previousTarget];
 		const pending = ledger.pendingReservations[target];
 		if (previous && (previous.manager !== input.manager || previous.id !== input.id)) {
 			throw new Error(`managed Skill ${input.id} is owned by a different manager`);
 		}
-		if (
-			pending &&
-			(!reservationMatches(pending, input) || (pending.previousTarget ?? target) !== previousTarget)
-		) {
+		if (pending && !reservationMatches(pending, input)) {
 			throw new Error(`managed Skill ${input.id} is pending for a different installation`);
-		}
-		if (
-			previousTarget !== target &&
-			(!replaced || replaced.manager !== input.manager || replaced.id !== input.id)
-		) {
-			throw new Error(`managed Skill ${input.id} replacement reservation is invalid`);
 		}
 		ledger.pendingReservations[target] = {
 			target,
-			...(previousTarget !== target ? { previousTarget } : {}),
 			id: input.id,
 			version: input.version,
 			digest: input.digest,
@@ -554,7 +488,6 @@ export function installReservedManagedSkill<T>(
 			sourceIdentity: input.sourceIdentity,
 			manager: input.manager,
 		};
-		if (previousTarget !== target) delete ledger.reservations[previousTarget];
 		delete ledger.pendingReservations[target];
 		writeLedger(path, ledger);
 		return result;
@@ -586,12 +519,6 @@ export function recoverPendingManagedSkillInstallation(input: {
 				sourceIdentity: pending.sourceIdentity,
 				manager: pending.manager,
 			};
-			if (pending.previousTarget && pending.previousTarget !== target) {
-				const replaced = ledger.reservations[pending.previousTarget];
-				if (replaced && replaced.id === pending.id && replaced.manager === pending.manager) {
-					delete ledger.reservations[pending.previousTarget];
-				}
-			}
 			delete ledger.pendingReservations[target];
 			writeLedger(path, ledger);
 			return "promoted";
@@ -618,15 +545,10 @@ export function replaceManagedSkillDirectoryAtomic(
 		return mkdtempSync(join(parent, `.${basename(targetDir)}-stage-`));
 	});
 	const stagedTarget = join(stagingRoot, basename(targetDir));
-	const previousTarget = join(
-		parent,
-		`.${basename(targetDir)}-previous-${process.pid}-${randomUUID()}`,
-	);
 	try {
 		withRuntimeUserFileAccess(() => cpSync(sourceDir, stagedTarget, { recursive: true }));
 		withManagedTargetRollback({
 			target: targetDir,
-			targetBackup: previousTarget,
 			beforeRestore: options.beforeRestore,
 			beforeCleanup: options.beforeCleanup,
 			restoreFailure: (activationError, restoreError) => {

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -14,7 +14,7 @@ import { withPrivateDirectoryLockSync } from "../lib/private-directory-lock";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { withRuntimeConvergeLock } from "./converge-lock";
 import { ManagedSkillResourceError, withManagedTargetRollback } from "./managed-skill-delivery";
-import { getRuntimePaths } from "./paths";
+import { detectRuntimeMode, getRuntimePaths } from "./paths";
 import { withRuntimeUserFileAccess } from "./runtime-user-command";
 import { runtimePlatformRootForPath, writeRuntimePlatformFileAtomic } from "./state";
 
@@ -73,9 +73,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function ledgerPath(): string {
-	const root = process.env.CLAWDI_SERVICE_STATE_DIR?.trim();
-	const mode = process.env.CLAWDI_RUNTIME_MODE?.trim().toLowerCase();
-	if (mode === "hosted" || root) {
+	if (detectRuntimeMode() === "hosted") {
 		return join(getRuntimePaths({ mode: "hosted" }).managedResourceRoot, LEDGER_FILE);
 	}
 	return join(getClawdiDir(), "managed-resources", LEDGER_FILE);
@@ -94,10 +92,7 @@ function emptyLedger(): ManagedSkillReservationLedger {
 	};
 }
 
-function reservationTargetMatchesIdentity(
-	target: string,
-	value: { id?: unknown },
-): boolean {
+function reservationTargetMatchesIdentity(target: string, value: { id?: unknown }): boolean {
 	return basename(target) === value.id;
 }
 
@@ -312,10 +307,7 @@ export function mutateUserSkillTarget<T>(targetDir: string, skillId: string, mut
 		assertUserSkillTargetMutable(targetDir, skillId);
 		return mutation();
 	};
-	if (
-		process.env.CLAWDI_RUNTIME_MODE?.trim().toLowerCase() === "hosted" ||
-		process.env.CLAWDI_SERVICE_STATE_DIR?.trim()
-	) {
+	if (detectRuntimeMode() === "hosted") {
 		return withRuntimeConvergeLock(getRuntimePaths({ mode: "hosted" }), commit);
 	}
 	return withPrivateDirectoryLockSync(join(getClawdiDir(), "locks", "managed-skills.lock"), commit);
@@ -327,8 +319,7 @@ export function migrateLegacyLocalSetupSkill(input: {
 	version: number;
 	digest: (targetDir: string) => string;
 }): "adopted" | "already_migrated" | "absent" | "unmanaged" | "hosted" {
-	if (process.env.CLAWDI_RUNTIME_MODE?.trim().toLowerCase() === "hosted") return "hosted";
-	if (process.env.CLAWDI_SERVICE_STATE_DIR?.trim()) return "hosted";
+	if (detectRuntimeMode() === "hosted") return "hosted";
 	const path = ledgerPath();
 	const target = resolve(input.targetDir);
 	if (

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -88,7 +88,6 @@ import {
 	ensureHostedCodexCli,
 	hostedCodexManagedProvider,
 	previewHostedAiProviderProjectionRevision,
-	writeProviderHealthStatus,
 } from "./manifest-providers";
 import { applyHostedRuntimeConfigProjection, projectionPayload } from "./manifest-runtime-config";
 import {
@@ -868,7 +867,6 @@ function prepareRuntimeEgressProjection(
 	state: RuntimeConvergenceState,
 ): RuntimeEgressProjection {
 	const {
-		load,
 		manifest,
 		paths,
 		opts,
@@ -937,7 +935,6 @@ function prepareRuntimeEgressProjection(
 		egressUid,
 		egressGid,
 	});
-	writeProviderHealthStatus(manifest, load.secretValues, paths);
 	const liveSyncEnvironments = writeLiveSyncEnvironmentFiles(manifest, paths);
 	const writtenRunConfigIds = new Set<string>();
 	state.runtimeSystemdUserPrograms.push(

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -17,12 +17,11 @@ import {
 	type HostedAgentPluginTransaction,
 	hostedAgentPluginCommands,
 } from "./hosted-agent-plugin-runtime";
-import { hostedHermesSkillExactSourceDriver } from "./hosted-hermes-skill";
 import {
 	createOpenClawHostedContext,
 	hostedOpenClawRuntimeUserOwnership,
 } from "./hosted-openclaw-context";
-import { hostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
+import { resolveHostedOpenClawWorkspace } from "./hosted-openclaw-skill";
 import { assertHostedRuntimeContract } from "./hosted-runtime-contract";
 import { type RuntimeInstallReceipts, readRuntimeInstallReceipts } from "./install-receipts";
 import { captureRuntimeLiveSnapshot, type RuntimeLiveSnapshot } from "./live-state-snapshot";
@@ -177,10 +176,6 @@ interface RuntimeConvergenceContext {
 		RuntimeConvergenceOptions["preparedHostedSourcedSkills"]
 	>;
 	sourcedSkillsPrepared: boolean;
-	hermesSkillNativeReconciler: NonNullable<
-		RuntimeConvergenceOptions["hostedHermesSkillExactSourceDriver"]
-	>;
-	openClawSkillDriver: NonNullable<RuntimeConvergenceOptions["hostedOpenClawSkillDriver"]>;
 	retainPreviousProjectedProviderIds: () => Record<string, string[]>;
 }
 
@@ -315,9 +310,6 @@ function initializeRuntimeConvergence(
 	const runtimeEntries = Object.entries(manifest.runtimes).sort(([a], [b]) => a.localeCompare(b));
 	const preparedHostedSourcedSkills = opts.preparedHostedSourcedSkills ?? new Map();
 	const sourcedSkillsPrepared = opts.resourcePreparationFailures?.sourcedSkills === undefined;
-	const hermesSkillNativeReconciler =
-		opts.hostedHermesSkillExactSourceDriver ?? hostedHermesSkillExactSourceDriver;
-	const openClawSkillDriver = opts.hostedOpenClawSkillDriver ?? hostedOpenClawSkillDriver;
 	const state: RuntimeConvergenceState = {
 		agentPluginTransaction: null,
 		agentPluginFailedNames: new Set(),
@@ -383,8 +375,6 @@ function initializeRuntimeConvergence(
 			runtimeEntries,
 			preparedHostedSourcedSkills,
 			sourcedSkillsPrepared,
-			hermesSkillNativeReconciler,
-			openClawSkillDriver,
 			retainPreviousProjectedProviderIds,
 		},
 		state,
@@ -494,7 +484,6 @@ function prepareRuntimeConvergencePlan(
 		paths,
 		projectionHome,
 		openClawContext,
-		openClawSkillDriver,
 		secretValues,
 		previousProjectedProviderIds,
 		hermesWhatsAppAuthDir,
@@ -511,11 +500,10 @@ function prepareRuntimeConvergencePlan(
 			manifest.runtimes.openclaw?.enabled === true ||
 			Boolean(openClawCommand && executableExists(openClawCommand));
 		openClawWorkspaceRoot = shouldResolveOpenClawWorkspace
-			? openClawSkillDriver.resolveWorkspace({
-					home: projectionHome,
-					repairInvalidConfig:
-						manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
-				})
+			? resolveHostedOpenClawWorkspace(
+					projectionHome,
+					manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
+				)
 			: null;
 		plannedRuntimePrograms = planRuntimeSystemdUserPrograms({
 			manifest,
@@ -607,7 +595,6 @@ function prepareRuntimeApplyDependencies(
 		hostedRuntimeContract,
 		projectionHome,
 		openClawContext,
-		openClawSkillDriver,
 		workspaceRoot,
 		instanceRoot,
 		runtimeEntries,
@@ -674,8 +661,7 @@ function prepareRuntimeApplyDependencies(
 	}
 	if (
 		plan.openClawWorkspaceRoot &&
-		resolve(openClawSkillDriver.resolveWorkspace({ home: projectionHome })) !==
-			resolve(plan.openClawWorkspaceRoot)
+		resolve(resolveHostedOpenClawWorkspace(projectionHome)) !== resolve(plan.openClawWorkspaceRoot)
 	) {
 		throw new Error("OpenClaw official agent workspace changed during runtime reconciliation");
 	}
@@ -1034,8 +1020,6 @@ function applyRuntimeResourceProjections(
 		runtimeEntries,
 		preparedHostedSourcedSkills,
 		sourcedSkillsPrepared,
-		hermesSkillNativeReconciler,
-		openClawSkillDriver,
 	} = context;
 	// Capability repair and managed auth-target discovery can change the plan;
 	// this second validation is an intentional post-repair revalidation.
@@ -1083,8 +1067,6 @@ function applyRuntimeResourceProjections(
 				manifest,
 				projectionHome,
 				plan.openClawWorkspaceRoot,
-				preparedHostedSourcedSkills,
-				hermesSkillNativeReconciler,
 			);
 			skillProjectionScope = state.rollbackSnapshots.captureScoped(
 				"runtime Skill filesystem rollback failed",
@@ -1108,8 +1090,6 @@ function applyRuntimeResourceProjections(
 					managedResourceRoot: paths.managedResourceRoot,
 					openClawWorkspaceRoot: plan.openClawWorkspaceRoot,
 					preparedSourcedSkills: preparedHostedSourcedSkills,
-					hermesDriver: hermesSkillNativeReconciler,
-					openClawDriver: openClawSkillDriver,
 				}),
 			);
 		} catch (error) {

--- a/packages/cli/src/runtime/manifest-oauth.ts
+++ b/packages/cli/src/runtime/manifest-oauth.ts
@@ -1,10 +1,9 @@
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
 	decideChatGptOAuthCredentialReconciliation,
 	intentLedgerForDecision,
 	type NativeOAuthCredentialObservation,
-	type OAuthCredentialLedgerSnapshot,
 } from "../lib/chatgpt-oauth-reconciliation";
 import {
 	HERMES_CODEX_AUTH_HELPER,
@@ -74,24 +73,6 @@ interface RuntimeOAuthCredentialDriver {
 			action: Exclude<RuntimeOAuthCredentialAction, "inspect">;
 		},
 	) => NativeOAuthCredentialMutationResult;
-}
-function runtimeOAuthLedgerPath(
-	paths: RuntimePaths,
-	runtime: "hermes" | "openclaw",
-	providerId: string,
-): string {
-	return oauthCredentialLedgerPath(paths.oauthCredentialRoot, runtime, providerId);
-}
-function writeRuntimeOAuthLedger(
-	path: string,
-	runtime: "hermes" | "openclaw",
-	providerId: string,
-	snapshot: OAuthCredentialLedgerSnapshot,
-): void {
-	writeOAuthCredentialLedger(path, { runtime, providerId }, snapshot);
-}
-function readRuntimeOAuthLedger(path: string): OAuthCredentialLedger | null {
-	return readOAuthCredentialLedger(path, { migrateLegacy: true });
 }
 function decodeJwtExpiryMs(token: string): number | null {
 	const encoded = token.split(".")[1];
@@ -601,8 +582,8 @@ export function reconcileHostedRuntimeOAuthCredentials(input: {
 	if (existsSync(ledgerDir)) {
 		for (const filename of readdirSync(ledgerDir).filter((name) => name.endsWith(".json"))) {
 			const path = join(ledgerDir, filename);
-			const ledger = readRuntimeOAuthLedger(path);
-			if (!ledger || desiredProviderIds.has(ledger.providerId) || ledger.state === "retired") {
+			const ledger = readOAuthCredentialLedger(path);
+			if (!ledger || desiredProviderIds.has(ledger.providerId)) {
 				continue;
 			}
 			const snapshot = oauthCredentialLedgerSnapshot(ledger);
@@ -620,11 +601,10 @@ export function reconcileHostedRuntimeOAuthCredentials(input: {
 				native,
 			});
 			if (decision.requiresWriteAheadIntent) {
-				writeRuntimeOAuthLedger(
+				writeOAuthCredentialLedger(
 					path,
-					input.runtime,
-					ledger.providerId,
-					intentLedgerForDecision(decision),
+					{ runtime: input.runtime, providerId: ledger.providerId },
+					intentLedgerForDecision(decision, snapshot),
 				);
 			}
 			if (decision.nativeAction === "remove") {
@@ -646,12 +626,24 @@ export function reconcileHostedRuntimeOAuthCredentials(input: {
 					expectedFingerprint,
 				});
 			}
-			writeRuntimeOAuthLedger(path, input.runtime, ledger.providerId, decision.nextLedger);
+			if (decision.nextLedger) {
+				writeOAuthCredentialLedger(
+					path,
+					{ runtime: input.runtime, providerId: ledger.providerId },
+					decision.nextLedger,
+				);
+			} else {
+				rmSync(path, { force: true });
+			}
 		}
 	}
 	for (const credential of desired) {
-		const ledgerPath = runtimeOAuthLedgerPath(input.paths, input.runtime, credential.providerId);
-		const ledger = readRuntimeOAuthLedger(ledgerPath);
+		const ledgerPath = oauthCredentialLedgerPath(
+			input.paths.oauthCredentialRoot,
+			input.runtime,
+			credential.providerId,
+		);
+		const ledger = readOAuthCredentialLedger(ledgerPath);
 		const snapshot = oauthCredentialLedgerSnapshot(ledger);
 		const nativeProfileId = nativeOAuthProfileId(input.runtime, credential.providerId);
 		const desiredFingerprint = oauthCredentialFingerprint(
@@ -672,11 +664,10 @@ export function reconcileHostedRuntimeOAuthCredentials(input: {
 			native,
 		});
 		if (decision.requiresWriteAheadIntent) {
-			writeRuntimeOAuthLedger(
+			writeOAuthCredentialLedger(
 				ledgerPath,
-				input.runtime,
-				credential.providerId,
-				intentLedgerForDecision(decision),
+				{ runtime: input.runtime, providerId: credential.providerId },
+				intentLedgerForDecision(decision, snapshot),
 			);
 		}
 		executeHostedRuntimeOAuthAction({
@@ -687,6 +678,13 @@ export function reconcileHostedRuntimeOAuthCredentials(input: {
 			credentialRevision: credential.credentialRevision,
 			material: credential.material,
 		});
-		writeRuntimeOAuthLedger(ledgerPath, input.runtime, credential.providerId, decision.nextLedger);
+		if (!decision.nextLedger) {
+			throw new Error("Desired hosted OAuth reconciliation cannot delete its ownership ledger");
+		}
+		writeOAuthCredentialLedger(
+			ledgerPath,
+			{ runtime: input.runtime, providerId: credential.providerId },
+			decision.nextLedger,
+		);
 	}
 }

--- a/packages/cli/src/runtime/manifest-planning.ts
+++ b/packages/cli/src/runtime/manifest-planning.ts
@@ -622,21 +622,17 @@ export function hostedSkillMutationTargets(
 	const addSkillTarget = (skillsRoot: string, skillId: string) => {
 		runtimeUserTargets.add(join(skillsRoot, skillId));
 	};
-	let managesHermesSourcedSkill = false;
 	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
 		addSkillTarget(hermesSkillsRoot, skillId);
 		if (openClawSkillsRoot) addSkillTarget(openClawSkillsRoot, skillId);
 		if ("source" in desired && manifest.runtimes.hermes?.enabled === true) {
-			managesHermesSourcedSkill = true;
 			const prepared = preparedSourcedSkills.get(skillId);
 			if (prepared?.skillId === skillId) {
-				let target: string | undefined;
 				try {
-					target = hermesDriver.target?.({ home, skill: prepared });
+					runtimeUserTargets.add(hermesDriver.target({ home, skill: prepared }));
 				} catch (error) {
 					if (!(error instanceof ManagedSkillResourceError)) throw error;
 				}
-				if (target) runtimeUserTargets.add(target);
 			}
 		}
 	}
@@ -646,14 +642,12 @@ export function hostedSkillMutationTargets(
 	}
 	for (const reservation of managedSkillReservations("hosted-manifest")) {
 		if (dirname(reservation.targetDir) === hermesSkillsRoot) {
-			if (reservation.sourceIdentity) managesHermesSourcedSkill = true;
 			runtimeUserTargets.add(reservation.targetDir);
 		}
 		if (openClawSkillsRoot && dirname(reservation.targetDir) === openClawSkillsRoot) {
 			runtimeUserTargets.add(reservation.targetDir);
 		}
 	}
-	if (managesHermesSourcedSkill) runtimeUserTargets.add(join(hermesSkillsRoot, ".hub"));
 	return [...runtimeUserTargets].sort();
 }
 export function runtimeManagedMutationPlan(input: {

--- a/packages/cli/src/runtime/manifest-planning.ts
+++ b/packages/cli/src/runtime/manifest-planning.ts
@@ -17,9 +17,7 @@ import {
 	proveHostedAgentPluginCapabilities,
 } from "./hosted-agent-plugin-runtime";
 import { hostedBundledSkillIds } from "./hosted-bundled-skill";
-import type { HostedHermesSkillExactSourceDriver } from "./hosted-hermes-skill";
 import { createOpenClawHostedContext, type OpenClawHostedContext } from "./hosted-openclaw-context";
-import type { HostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
 import {
 	agentTargetProjectionInput,
 	hostedAiProviderCatalog,
@@ -42,7 +40,6 @@ import {
 	managedBaileysCompatSnapshotRuntimes,
 } from "./managed-baileys-compat";
 import { buildHermesManagedChannelsPatch } from "./managed-channel-reconciliation";
-import { ManagedSkillResourceError } from "./managed-skill-delivery";
 import { managedSkillReservations } from "./managed-skill-reservation";
 import {
 	hostedChannelCredentialsDeclared,
@@ -126,8 +123,6 @@ export interface RuntimeConvergenceOptions {
 	preparedHostedAgentPlugins?: PreparedHostedAgentPlugins;
 	resourcePreparationFailures?: RuntimeResourcePreparationFailures;
 	hostedAgentPluginCommandRunner?: HostedAgentPluginCommandRunner;
-	hostedHermesSkillExactSourceDriver?: HostedHermesSkillExactSourceDriver;
-	hostedOpenClawSkillDriver?: HostedOpenClawSkillDriver;
 	hostedRuntimeContract?: HostedRuntimeContractOptions;
 }
 
@@ -613,8 +608,6 @@ export function hostedSkillMutationTargets(
 	manifest: RuntimeManifest,
 	home: string,
 	openClawWorkspaceRoot: string | null,
-	preparedSourcedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
-	hermesDriver: HostedHermesSkillExactSourceDriver,
 ): string[] {
 	const runtimeUserTargets = new Set<string>();
 	const hermesSkillsRoot = join(home, ".hermes", "skills");
@@ -622,19 +615,9 @@ export function hostedSkillMutationTargets(
 	const addSkillTarget = (skillsRoot: string, skillId: string) => {
 		runtimeUserTargets.add(join(skillsRoot, skillId));
 	};
-	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
+	for (const skillId of Object.keys(manifest.projection?.skills?.entries ?? {})) {
 		addSkillTarget(hermesSkillsRoot, skillId);
 		if (openClawSkillsRoot) addSkillTarget(openClawSkillsRoot, skillId);
-		if ("source" in desired && manifest.runtimes.hermes?.enabled === true) {
-			const prepared = preparedSourcedSkills.get(skillId);
-			if (prepared?.skillId === skillId) {
-				try {
-					runtimeUserTargets.add(hermesDriver.target({ home, skill: prepared }));
-				} catch (error) {
-					if (!(error instanceof ManagedSkillResourceError)) throw error;
-				}
-			}
-		}
 	}
 	for (const skillId of hostedBundledSkillIds()) {
 		addSkillTarget(hermesSkillsRoot, skillId);

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -1,11 +1,10 @@
-import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { MANAGED_AI_PROVIDER_RUNTIME_ENV } from "@clawdi/shared";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { buildAgentTargetProjection } from "../lib/ai-provider-projection";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { isValidSemver } from "../lib/semver";
-import { MANAGED_EGRESS_PLACEHOLDER_VALUE } from "./egress-env";
 import {
 	getHermesRawConfigValue,
 	getHermesResolvedConfigValue,
@@ -160,7 +159,7 @@ export function applyHostedAiProviderProjection(
 		);
 		const providerPatch = buildOpenClawHostedProviderPatch(projectionInput, previousProviderIds);
 		if (providerPatch.apply) {
-			applyOpenClawHostedProviderPatch(observation, providerPatch, openClawContext, workspaceRoot);
+			applyOpenClawHostedProviderPatch(providerPatch, openClawContext, workspaceRoot);
 		}
 		if (openClawContext.managedApiKeyProjection) {
 			if (openClawContext.agentDirs.managed.length === 0) {
@@ -339,7 +338,6 @@ export function ensureHostedCodexCli(paths: RuntimePaths): Record<string, string
 	if (process.env.CLAWDI_CODEX_INSTALL_DISABLED === "1") return null;
 	const npmPrefix = paths.userNpmPrefix;
 	const realBin = join(npmPrefix, "bin", "codex");
-	removeLegacyHostedCodexCommandShim(realBin, paths.userHome);
 	let installedVersion = hostedCodexInstalledVersion(npmPrefix);
 	const bootstrapRequired = installedVersion === null || !executableExists(realBin);
 	if (bootstrapRequired) {
@@ -423,25 +421,6 @@ function installHostedCodexBootstrap(
 		);
 	}
 }
-function removeLegacyHostedCodexCommandShim(commandPath: string, home: string): void {
-	let content: string;
-	try {
-		content = readFileSync(commandPath, "utf8");
-	} catch {
-		// A missing or unreadable command is handled by the normal bootstrap check.
-		return;
-	}
-	const legacyRealBin = join(home, ".local", "share", "clawdi", "codex", "bin", "codex");
-	const expected = [
-		"#!/usr/bin/env sh",
-		`export ${MANAGED_AI_PROVIDER_RUNTIME_ENV}='${MANAGED_EGRESS_PLACEHOLDER_VALUE}'`,
-		`exec '${legacyRealBin}' "$@"`,
-		"",
-	].join("\n");
-	if (content === expected) {
-		withRuntimeUserFileAccess(() => rmSync(commandPath));
-	}
-}
 function applyHostedHermesAiProviderProjection(
 	observation: RuntimeInstallObservation,
 	projectionInput: HostedAiProviderProjectionInput | null,
@@ -510,7 +489,6 @@ function quoteTomlString(value: string): string {
 }
 export interface OpenClawHostedProviderPatch {
 	apply: boolean;
-	args: string[];
 	content: string;
 	providerIds: string[];
 }
@@ -570,22 +548,11 @@ await sdk.mutateConfigFile({
 });
 `;
 function applyOpenClawHostedProviderPatch(
-	observation: RuntimeInstallObservation,
 	patch: OpenClawHostedProviderPatch,
 	context: OpenClawHostedContext,
 	workspaceRoot: string,
 ): void {
-	const sdkPath = context.sdk.configMutation;
-	if (!sdkPath) {
-		runRuntimeUserCommand(
-			observation.commandPath ?? "openclaw",
-			["config", "patch", "--stdin", ...patch.args],
-			patch.content,
-			context.home,
-			workspaceRoot,
-		);
-		return;
-	}
+	const sdkPath = context.requireSdkExport("configMutation");
 	enforceRuntimeUserOwnership(runtimeUserDirectoryOwnership(context.home));
 	runRuntimeUserCommand(
 		"node",
@@ -603,7 +570,6 @@ export function buildOpenClawHostedProviderPatch(
 		const deletedProviderIds = staleProviderIds(new Set(previousProviderIds), new Set());
 		return {
 			apply: deletedProviderIds.length > 0,
-			args: [],
 			content: `${JSON.stringify(openClawProviderDeletePatch(deletedProviderIds), null, 2)}\n`,
 			providerIds: [],
 		};
@@ -621,7 +587,6 @@ export function buildOpenClawHostedProviderPatch(
 		providerIds.length > 0 ? withOpenClawProviderMode(file.content, "replace") : file.content;
 	return {
 		apply: true,
-		args: openClawProviderReplacementArgs(file.content),
 		content: mergeProviderDeletes("openclaw", providerPatchContent, deletedProviderIds),
 		providerIds,
 	};
@@ -650,18 +615,6 @@ function providerIdsFromPatch(runtime: ProviderPatchRuntime, content: string): S
 			.filter(([, value]) => value !== null)
 			.map(([providerId]) => providerId),
 	);
-}
-function openClawProviderReplacementArgs(content: string): string[] {
-	const parsed = JSON.parse(content) as unknown;
-	const root = recordValue(parsed);
-	const models = root ? recordValue(root.models) : null;
-	const providers = models ? recordValue(models.providers) : null;
-	if (!providers) return [];
-	return Object.entries(providers).flatMap(([providerId, provider]) => {
-		const providerConfig = recordValue(provider);
-		if (!providerConfig) return [];
-		return ["--replace-path", `models.providers[${JSON.stringify(providerId)}]`];
-	});
 }
 function withOpenClawProviderMode(patchContent: string, mode: "merge" | "replace"): string {
 	const parsed = JSON.parse(patchContent) as unknown;

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -24,13 +24,7 @@ import { HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION, type RuntimeManifest } from ".
 import { type RuntimeInstallObservation, tail } from "./manifest-install";
 import { removeOpenClawManagedProviderAuthProfiles } from "./manifest-oauth";
 import { hermesConfigContext } from "./manifest-runtime-config";
-import {
-	canonicalJsonEqual,
-	isPlainRecord,
-	recordValue,
-	stringValue,
-	writeRuntimePrivateFileAtomic,
-} from "./manifest-shared";
+import { canonicalJsonEqual, isPlainRecord, recordValue, stringValue } from "./manifest-shared";
 import type { RuntimePaths } from "./paths";
 import { runtimeImpactRevision } from "./runtime-impact-revision";
 import {
@@ -47,64 +41,7 @@ import { runtimeSecretValue } from "./secret-values";
 
 const CODEX_BOOTSTRAP_TIMEOUT_MS = 600_000;
 
-export function writeProviderHealthStatus(
-	manifest: RuntimeManifest,
-	secretValues: Record<string, string> | undefined,
-	paths: RuntimePaths,
-): string | null {
-	const providers = recordValue(manifest.projection?.providers);
-	if (!providers || Object.keys(providers).length === 0) {
-		rmSync(paths.providerHealthStatus, { force: true });
-		return null;
-	}
-
-	const observed: Record<string, unknown> = {};
-	for (const providerId of Object.keys(providers).sort()) {
-		const provider = recordValue(providers[providerId]);
-		if (!provider) continue;
-		const apiKeySecretRef = stringValue(provider.apiKeySecretRef);
-		const secretAvailable =
-			apiKeySecretRef === null
-				? null
-				: providerSecretAvailable(secretValues ?? {}, apiKeySecretRef);
-		const reasons = providerHealthReasons(provider, secretAvailable);
-		observed[providerId] = {
-			status: reasons.length > 0 ? "error" : "ok",
-			configured: true,
-			kind: stringValue(provider.kind),
-			baseUrl: stringValue(provider.baseUrl),
-			model: stringValue(provider.model),
-			models: Array.isArray(provider.models) ? provider.models : undefined,
-			apiKeySecretRef,
-			secretAvailable,
-			reasons,
-		};
-	}
-
-	if (Object.keys(observed).length === 0) {
-		rmSync(paths.providerHealthStatus, { force: true });
-		return null;
-	}
-	writeRuntimePrivateFileAtomic(
-		paths,
-		paths.providerHealthStatus,
-		`${JSON.stringify(
-			{
-				schemaVersion: "clawdi.hostedRuntimeProviderHealth.v1",
-				generatedAt: new Date().toISOString(),
-				providers: observed,
-			},
-			null,
-			2,
-		)}\n`,
-		{ mode: 0o644, dirMode: 0o755 },
-	);
-	return paths.providerHealthStatus;
-}
-function providerSecretAvailable(secretValues: Record<string, string>, ref: string): boolean {
-	return runtimeSecretValue(secretValues, ref) !== null;
-}
-function providerHealthReasons(
+export function providerHealthReasons(
 	provider: Record<string, unknown>,
 	secretAvailable: boolean | null,
 ): string[] {

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -2847,15 +2847,6 @@ chmod 0755 '${commandPath}'
 		expect(envFile).toContain('CLAWDI_AI_API_KEY="clawdi-egress-placeholder"');
 		expect(envFile).not.toMatch(/^OPENAI_API_KEY=/m);
 		expect(envFile).not.toContain("sk-managed");
-		expect(JSON.parse(readFileSync(paths.providerHealthStatus, "utf8"))).toMatchObject({
-			providers: {
-				default: {
-					status: "ok",
-					models: [{ id: "gpt-test" }],
-					reasons: [],
-				},
-			},
-		});
 	});
 
 	test("replaces the selected Hermes provider with secret refs and stale cleanup", () => {
@@ -5254,7 +5245,6 @@ installReservedManagedSkill(${JSON.stringify({
 			[
 				paths.managedConfig,
 				paths.syncState,
-				paths.providerHealthStatus,
 				paths.egressEngineStatus,
 				paths.manifestLastGood,
 				paths.managedSecretCacheFile,

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -742,6 +742,38 @@ esac
 	chmodSync(input.path, 0o700);
 }
 
+function writeFakeOpenClawConfigMutationSdk(home: string): string {
+	const packageRoot = join(home, ".local", "lib", "node_modules", "openclaw");
+	const configPath = join(home, ".openclaw", "openclaw.json");
+	mkdirSync(packageRoot, { recursive: true });
+	mkdirSync(dirname(configPath), { recursive: true });
+	writeFileSync(configPath, "{}\n");
+	writeFileSync(
+		join(packageRoot, "package.json"),
+		JSON.stringify({
+			name: "openclaw",
+			type: "module",
+			exports: { "./plugin-sdk/config-mutation": "./config-mutation.mjs" },
+		}),
+	);
+	writeFileSync(
+		join(packageRoot, "config-mutation.mjs"),
+		`import { readFileSync, writeFileSync } from "node:fs";
+const configPath = ${JSON.stringify(configPath)};
+export async function readConfigFileSnapshotForWrite() {
+  const config = JSON.parse(readFileSync(configPath, "utf8"));
+  return { snapshot: { valid: true, config, sourceConfig: structuredClone(config) } };
+}
+export async function mutateConfigFile(options) {
+  const config = JSON.parse(readFileSync(configPath, "utf8"));
+  await options.mutate(config, { snapshot: {}, previousHash: null, attempt: 1 });
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\\n");
+}
+`,
+	);
+	return configPath;
+}
+
 type FileBrowserCompanion = NonNullable<NonNullable<RuntimeManifest["companions"]>["filebrowser"]>;
 
 function fileBrowserCompanion(accessRevision = "a".repeat(64)): FileBrowserCompanion {
@@ -2782,12 +2814,11 @@ chmod 0755 '${commandPath}'
 
 	test("keeps hosted managed provider key out of the agent env", () => {
 		const paths = tempRuntimePaths();
-		const providerPatchPath = join(paths.serviceStateRoot, "openclaw-provider-patch.json");
+		const configPath = writeFakeOpenClawConfigMutationSdk(paths.userHome);
 		writeFakeGatewayCli({
 			path: join(paths.userHome, ".local", "bin", "openclaw"),
 			runtime: "openclaw",
 			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
-			configPatchPath: providerPatchPath,
 		});
 		const hosted = hostedRuntimeManifestSchema.parse(
 			hostedManifestFixture({
@@ -2822,7 +2853,7 @@ chmod 0755 '${commandPath}'
 
 		expect(result.installErrors).toEqual([]);
 		expect(result.projectedProviderIds.openclaw).toEqual(["clawdi-managed"]);
-		expect(JSON.parse(readFileSync(providerPatchPath, "utf8"))).toMatchObject({
+		expect(JSON.parse(readFileSync(configPath, "utf8"))).toMatchObject({
 			models: {
 				providers: {
 					"clawdi-managed": {

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -4614,6 +4614,8 @@ echo spawned > '${installerLog}'
 		const preparedSkills = new Map([[prepared.skillId, prepared]]);
 		let installs = 0;
 		const driver = {
+			target: ({ skill }: { skill: PreparedHostedSourcedSkill }) =>
+				join(paths.userHome, ".hermes", "skills", skill.skillId),
 			install: () => {
 				installs += 1;
 				mkdirSync(skillDir, { recursive: true });
@@ -4787,6 +4789,7 @@ installReservedManagedSkill(${JSON.stringify({
 			{
 				preparedHostedSourcedSkills: new Map([[skillId, prepared]]),
 				hostedHermesSkillExactSourceDriver: {
+					target: () => target,
 					install: () => {
 						installs += 1;
 						const installingLedger = JSON.parse(readFileSync(ledgerPath, "utf8"));
@@ -4841,61 +4844,6 @@ installReservedManagedSkill(${JSON.stringify({
 		expect([...result.installErrors, ...result.resourceProjectionErrors]).toEqual([]);
 		expect(managedSkillReservationState(target, skillId)).toBe("unreserved");
 		expect(existsSync(target)).toBe(false);
-	});
-
-	test("moves an enabled stale reservation to the Hermes native target", () => {
-		const paths = tempRuntimePaths();
-		ensureRuntimeStateDirs(paths);
-		mkdirSync(paths.managedResourceRoot, { recursive: true });
-		const skillId = "phala-cloud-template-workflows";
-		const source = {
-			type: "project" as const,
-			projectId: "22222222-2222-4222-8222-222222222222",
-			contentHash: "a".repeat(64),
-			archiveUrl: "https://cloud-api.example.test/project-skill.tar.gz",
-			installUrl: "https://cloud-api.example.test/project-skill/SKILL.md",
-		};
-		const prepared = preparedTestSourcedSkill(skillId, source, "native projection\n");
-		const sourceIdentity = prepared.sourceIdentity;
-		const staleTarget = join(paths.userHome, ".hermes", "skills", skillId);
-		const nativeTarget = join(paths.userHome, ".hermes", "skills", "phala-workflows");
-		reserveManagedSkill({
-			targetDir: staleTarget,
-			id: skillId,
-			manager: "hosted-manifest",
-			sourceIdentity,
-		});
-		const hermesCommand = join(paths.userHome, ".local", "bin", "hermes");
-		mkdirSync(dirname(hermesCommand), { recursive: true });
-		writeFileSync(hermesCommand, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
-		const manifest = baseManifest(
-			paths,
-			{ hermes: { enabled: true, run: runSettings(hermesCommand, ["gateway"]), services: {} } },
-			{ projection: { skills: { entries: { [skillId]: { enabled: true, source } } } } },
-		);
-
-		const result = convergeRuntimeManifest(
-			manifestLoad(manifest, "stale-enabled-hermes-skill"),
-			paths,
-			{
-				preparedHostedSourcedSkills: new Map([[skillId, prepared]]),
-				hostedHermesSkillExactSourceDriver: {
-					target: () => nativeTarget,
-					install: (input) => {
-						expect(input.targetDir).toBe(nativeTarget);
-						mkdirSync(nativeTarget, { recursive: true });
-						writeFileSync(join(nativeTarget, "SKILL.md"), "native projection\n");
-						return "installed";
-					},
-				},
-			},
-		);
-
-		expect([...result.installErrors, ...result.resourceProjectionErrors]).toEqual([]);
-		expect(managedSkillReservationState(staleTarget, skillId)).toBe("unreserved");
-		expect(managedSkillReservationState(nativeTarget, skillId)).toBe("reserved");
-		expect(shouldIgnoreUserSkill(nativeTarget, "phala-workflows")).toBe(true);
-		expect(readFileSync(join(nativeTarget, "SKILL.md"), "utf8")).toBe("native projection\n");
 	});
 
 	test("isolates per-Skill resource failures without starving later Skills", () => {
@@ -4999,6 +4947,8 @@ installReservedManagedSkill(${JSON.stringify({
 			{
 				preparedHostedSourcedSkills: preparedSkills,
 				hostedHermesSkillExactSourceDriver: {
+					target: ({ skill }) =>
+						join(paths.userHome, ".hermes", "skills", skill.skillId),
 					install: ({ skill }) => {
 						attempted.push(skill.skillId);
 						return "installed";

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -46,7 +46,6 @@ import {
 	assertHostedBundledSkillCatalogDigest,
 	resolveHostedBundledSkill,
 } from "./hosted-bundled-skill";
-import { hostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
 import { hostedAiProviderCatalog } from "./hosted-provider-resolution";
 import type { PreparedHostedSourcedSkill } from "./hosted-sourced-skill-archive";
 import { readRuntimeInstallReceipts } from "./install-receipts";
@@ -55,7 +54,6 @@ import {
 	restoreRuntimeLiveSnapshot,
 	runtimeRootLiveMutationTargets,
 } from "./live-state-snapshot";
-import { ManagedSkillResourceError } from "./managed-skill-delivery";
 import {
 	managedSkillReservationLedgerPath,
 	managedSkillReservationState,
@@ -4612,30 +4610,16 @@ echo spawned > '${installerLog}'
 		mkdirSync(skillDir, { recursive: true });
 		writeFileSync(join(skillDir, "SKILL.md"), "user-owned collision\n");
 		const preparedSkills = new Map([[prepared.skillId, prepared]]);
-		let installs = 0;
-		const driver = {
-			target: ({ skill }: { skill: PreparedHostedSourcedSkill }) =>
-				join(paths.userHome, ".hermes", "skills", skill.skillId),
-			install: () => {
-				installs += 1;
-				mkdirSync(skillDir, { recursive: true });
-				writeFileSync(join(skillDir, "SKILL.md"), "manifest-owned\n");
-				return "installed" as const;
-			},
-		};
 
 		const collision = convergeRuntimeManifest(
 			manifestLoad(manifest, "skill-ledger-collision"),
 			paths,
-			{
-				preparedHostedSourcedSkills: preparedSkills,
-				hostedHermesSkillExactSourceDriver: driver,
-			},
+			{ preparedHostedSourcedSkills: preparedSkills },
 		);
 		expect(collision.resourceProjectionErrors.join("\n")).toContain(
 			`refusing to replace unmanaged review-pr skill at ${skillDir}`,
 		);
-		expect(installs).toBe(0);
+		expect(readFileSync(join(skillDir, "SKILL.md"), "utf8")).toBe("user-owned collision\n");
 		rmSync(skillDir, { recursive: true, force: true });
 		mkdirSync(userOwnedSibling, { recursive: true });
 		writeFileSync(join(userOwnedSibling, "SKILL.md"), "keep me\n");
@@ -4643,10 +4627,10 @@ echo spawned > '${installerLog}'
 		const installed = convergeRuntimeManifest(
 			manifestLoad({ ...manifest, generation: 2 }, "skill-ledger-install"),
 			paths,
-			{ preparedHostedSourcedSkills: preparedSkills, hostedHermesSkillExactSourceDriver: driver },
+			{ preparedHostedSourcedSkills: preparedSkills },
 		);
 		expect([...installed.installErrors, ...installed.resourceProjectionErrors]).toEqual([]);
-		expect(installs).toBe(1);
+		expect(readFileSync(join(skillDir, "SKILL.md"), "utf8")).toBe("manifest-owned\n");
 		const ledger = JSON.parse(readFileSync(managedSkillReservationLedgerPath(), "utf8"));
 		expect(ledger.reservations[skillDir]).toMatchObject({
 			id: "review-pr",
@@ -4659,10 +4643,9 @@ echo spawned > '${installerLog}'
 		const unchanged = convergeRuntimeManifest(
 			manifestLoad({ ...manifest, generation: 3 }, "skill-ledger-unchanged"),
 			paths,
-			{ preparedHostedSourcedSkills: preparedSkills, hostedHermesSkillExactSourceDriver: driver },
+			{ preparedHostedSourcedSkills: preparedSkills },
 		);
 		expect([...unchanged.installErrors, ...unchanged.resourceProjectionErrors]).toEqual([]);
-		expect(installs).toBe(1);
 		expect(statSync(skillDir).ino).toBe(stableInode);
 		const movedSource = { ...source, commit: "c".repeat(40) };
 		const movedPrepared = {
@@ -4684,13 +4667,9 @@ echo spawned > '${installerLog}'
 				"skill-ledger-source-moved",
 			),
 			paths,
-			{
-				preparedHostedSourcedSkills: new Map([[movedPrepared.skillId, movedPrepared]]),
-				hostedHermesSkillExactSourceDriver: driver,
-			},
+			{ preparedHostedSourcedSkills: new Map([[movedPrepared.skillId, movedPrepared]]) },
 		);
 		expect([...moved.installErrors, ...moved.resourceProjectionErrors]).toEqual([]);
-		expect(installs).toBe(1);
 		expect(statSync(skillDir).ino).toBe(stableInode);
 		expect(
 			JSON.parse(readFileSync(managedSkillReservationLedgerPath(), "utf8")).reservations[skillDir]
@@ -4703,7 +4682,7 @@ echo spawned > '${installerLog}'
 				"skill-ledger-remove",
 			),
 			paths,
-			{ preparedHostedSourcedSkills: new Map(), hostedHermesSkillExactSourceDriver: driver },
+			{ preparedHostedSourcedSkills: new Map() },
 		);
 		expect([...removed.installErrors, ...removed.resourceProjectionErrors]).toEqual([]);
 		expect(existsSync(skillDir)).toBe(false);
@@ -4782,29 +4761,14 @@ installReservedManagedSkill(${JSON.stringify({
 			{ hermes: { enabled: true, run: runSettings(hermesCommand, ["gateway"]), services: {} } },
 			{ projection: { skills: { entries: { [skillId]: { enabled: true, source } } } } },
 		);
-		let installs = 0;
 		const result = convergeRuntimeManifest(
 			manifestLoad(manifest, "recover-killed-skill-installer"),
 			paths,
-			{
-				preparedHostedSourcedSkills: new Map([[skillId, prepared]]),
-				hostedHermesSkillExactSourceDriver: {
-					target: () => target,
-					install: () => {
-						installs += 1;
-						const installingLedger = JSON.parse(readFileSync(ledgerPath, "utf8"));
-						expect(installingLedger.reservations[target]).toBeUndefined();
-						expect(installingLedger.pendingReservations[target]).toBeDefined();
-						mkdirSync(target, { recursive: true });
-						writeFileSync(join(target, "SKILL.md"), "verified tree\n");
-						return "installed";
-					},
-				},
-			},
+			{ preparedHostedSourcedSkills: new Map([[skillId, prepared]]) },
 		);
 
 		expect([...result.installErrors, ...result.resourceProjectionErrors]).toEqual([]);
-		expect(installs).toBe(1);
+		expect(readFileSync(join(target, "SKILL.md"), "utf8")).toBe("verified tree\n");
 		expect(managedSkillReservationState(target, skillId)).toBe("reserved");
 		const committedLedger = JSON.parse(readFileSync(ledgerPath, "utf8"));
 		expect(committedLedger.reservations[target].digest).toBe(prepared.archiveSha256);
@@ -4864,6 +4828,10 @@ installReservedManagedSkill(${JSON.stringify({
 			preparedSkills.set(skillId, preparedTestSourcedSkill(skillId, source, `${skillId}\n`));
 			entries.entries[skillId] = { enabled: true, source };
 		}
+		const failed = preparedSkills.get("a-fail");
+		if (!failed) throw new Error("missing failing Skill fixture");
+		failed.tarBytes = Buffer.from("invalid archive");
+		failed.archiveSha256 = createHash("sha256").update(failed.tarBytes).digest("hex");
 		const manifest = baseManifest(
 			paths,
 			{
@@ -4875,31 +4843,14 @@ installReservedManagedSkill(${JSON.stringify({
 			},
 			{ projection: { skills: entries } },
 		);
-		const attempted: string[] = [];
 		const result = convergeRuntimeManifest(manifestLoad(manifest, "skill-item-isolation"), paths, {
 			preparedHostedSourcedSkills: preparedSkills,
-			hostedHermesSkillExactSourceDriver: {
-				target: ({ skill }) => {
-					if (skill.skillId === "a-fail") {
-						throw new ManagedSkillResourceError("prepared Skill archive could not be staged");
-					}
-					return join(paths.userHome, ".hermes", "skills", skill.skillId);
-				},
-				install: ({ skill }) => {
-					attempted.push(skill.skillId);
-					const target = join(paths.userHome, ".hermes", "skills", skill.skillId);
-					mkdirSync(target, { recursive: true });
-					writeFileSync(join(target, "SKILL.md"), `${skill.skillId}\n`);
-					return "installed";
-				},
-			},
 		});
 
 		expect(result.installErrors).toEqual([]);
 		expect(result.resourceProjectionErrors).toEqual([
 			"runtime hermes Skill projection failed: a-fail: prepared Skill archive could not be staged",
 		]);
-		expect(attempted).toEqual(["b-ready", "c-ready"]);
 		expect(existsSync(join(paths.userHome, ".hermes", "skills", "a-fail"))).toBe(false);
 		for (const skillId of ["b-ready", "c-ready"]) {
 			expect(
@@ -4929,7 +4880,6 @@ installReservedManagedSkill(${JSON.stringify({
 		const unmanaged = join(paths.userHome, ".hermes", "skills", "a-unmanaged");
 		mkdirSync(unmanaged, { recursive: true });
 		writeFileSync(join(unmanaged, "SKILL.md"), "tenant owned\n");
-		const attempted: string[] = [];
 		const manifest = baseManifest(
 			paths,
 			{
@@ -4946,21 +4896,12 @@ installReservedManagedSkill(${JSON.stringify({
 			paths,
 			{
 				preparedHostedSourcedSkills: preparedSkills,
-				hostedHermesSkillExactSourceDriver: {
-					target: ({ skill }) =>
-						join(paths.userHome, ".hermes", "skills", skill.skillId),
-					install: ({ skill }) => {
-						attempted.push(skill.skillId);
-						return "installed";
-					},
-				},
 			},
 		);
 
 		expect(result.resourceProjectionErrors.join("\n")).toContain(
 			`refusing to replace unmanaged a-unmanaged skill at ${unmanaged}`,
 		);
-		expect(attempted).toEqual([]);
 		expect(readFileSync(join(unmanaged, "SKILL.md"), "utf8")).toBe("tenant owned\n");
 		expect(existsSync(join(paths.userHome, ".hermes", "skills", "b-ready"))).toBe(false);
 		expect(existsSync(join(paths.userHome, ".hermes", "skills", "c-ready"))).toBe(false);
@@ -5073,17 +5014,7 @@ installReservedManagedSkill(${JSON.stringify({
 			{ openclaw: { enabled: true, run: runSettings(command, ["gateway"]), services: {} } },
 			{ projection: { skills: { entries: {} } } },
 		);
-		const result = convergeRuntimeManifest(
-			manifestLoad(manifest, "legacy-openclaw-remove"),
-			paths,
-			{
-				hostedOpenClawSkillDriver: {
-					resolveWorkspace: () => openClawWorkspaceRoot,
-					installDirectory: () => "installed",
-					install: () => "installed",
-				},
-			},
-		);
+		const result = convergeRuntimeManifest(manifestLoad(manifest, "legacy-openclaw-remove"), paths);
 		expect(result.installErrors).toEqual([]);
 		expect(existsSync(target)).toBe(true);
 		expect(existsSync(join(target, ".clawdi-managed.json"))).toBe(true);
@@ -5763,6 +5694,7 @@ exit 0
 			wantsRoot,
 			enablementPath,
 		];
+		const skillProjectionLog = join(appRoot, "skill-projection-owners.log");
 
 		chmodSync(fixtureRoot, 0o755);
 		mkdirSync(paths.userHome, { recursive: true });
@@ -5780,17 +5712,28 @@ exit 0
 			`#!/usr/bin/env bash
 set -euo pipefail
 test "$(id -u)" = "10001"
-if [ "$*" = "--version" ]; then
-  printf '%s\\n' 'OpenClaw test-version'
-  exit 0
-fi
-test "$*" = "gateway install --force --json"
-unit="$HOME/.config/systemd/user/\${OPENCLAW_SYSTEMD_UNIT:-openclaw-gateway.service}"
-cp "$unit" "$unit.bak"
-printf '%s\\n' '[Unit]' '[Service]' 'ExecStart=openclaw gateway run' > "$unit"
-printf '%s\\n' 'OPENCLAW_OFFICIAL_USER_STATE=1' > "$HOME/.openclaw/gateway.systemd.env"
-chmod 0600 "$HOME/.openclaw/gateway.systemd.env"
-printf '{"ok":true}\\n'
+case "$*" in
+  "--version")
+    printf '%s\\n' 'OpenClaw test-version'
+    ;;
+  "agents list --json")
+    printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace"
+    ;;
+  "skills install "*)
+    : > '${skillProjectionLog}'
+    ${platformOwnedPaths.map((path) => `stat -c '%u:%g' '${path}' >> '${skillProjectionLog}'`).join("\n    ")}
+    exit 45
+    ;;
+  "gateway install --force --json")
+    unit="$HOME/.config/systemd/user/\${OPENCLAW_SYSTEMD_UNIT:-openclaw-gateway.service}"
+    cp "$unit" "$unit.bak"
+    printf '%s\\n' '[Unit]' '[Service]' 'ExecStart=openclaw gateway run' > "$unit"
+    printf '%s\\n' 'OPENCLAW_OFFICIAL_USER_STATE=1' > "$HOME/.openclaw/gateway.systemd.env"
+    chmod 0600 "$HOME/.openclaw/gateway.systemd.env"
+    printf '{"ok":true}\\n'
+    ;;
+  *) exit 64 ;;
+esac
 `,
 		);
 		writeFileSync(unitPath, "[Unit]\nDescription=previous official unit\n");
@@ -5825,19 +5768,6 @@ printf '{"ok":true}\\n'
 			},
 			resolveUserIdentity: () => ({ uid: runtimeUid, gid: runtimeGid }),
 		};
-		let skillProjectionObserved = false;
-		const openClawSkillDriver = {
-			...hostedOpenClawSkillDriver,
-			resolveWorkspace: () => join(appRoot, "workspace"),
-			install: () => {
-				skillProjectionObserved = true;
-				for (const path of platformOwnedPaths) {
-					const node = lstatSync(path);
-					expect([node.uid, node.gid]).toEqual([0, 0]);
-				}
-				throw new ManagedSkillResourceError("injected Skill projection stop");
-			},
-		};
 		const manifest = baseManifest(
 			paths,
 			{
@@ -5863,12 +5793,15 @@ printf '{"ok":true}\\n'
 			{
 				executeOfficialServiceInstallers: false,
 				hostedRuntimeContract,
-				hostedOpenClawSkillDriver: openClawSkillDriver,
 			},
 		);
 		expect(result.installErrors).toEqual([]);
-		expect(result.resourceProjectionErrors.join("\n")).toContain("injected Skill projection stop");
-		expect(skillProjectionObserved).toBe(true);
+		expect(result.resourceProjectionErrors.join("\n")).toContain(
+			"OpenClaw official Skill install failed: exit code 45 without output",
+		);
+		expect(readFileSync(skillProjectionLog, "utf8").trim().split("\n")).toEqual(
+			platformOwnedPaths.map(() => "0:0"),
+		);
 		for (const path of runtimeOwnedPaths) {
 			const node = lstatSync(path);
 			expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
@@ -5894,7 +5827,6 @@ printf '{"ok":true}\\n'
 			paths,
 			{
 				hostedRuntimeContract,
-				hostedOpenClawSkillDriver: openClawSkillDriver,
 				systemdApply: {
 					quiesce: () => {},
 					activateEgressPrerequisite: successfulPrerequisiteActivation,
@@ -5955,7 +5887,6 @@ printf '{"ok":true}\\n'
 				},
 				executeOfficialServiceInstallers: false,
 				hostedRuntimeContract,
-				hostedOpenClawSkillDriver: openClawSkillDriver,
 			},
 		);
 		expect(failed.installErrors.join("\n")).toContain("injected ownership commit failure");

--- a/packages/cli/src/runtime/manifest-runtime-config.ts
+++ b/packages/cli/src/runtime/manifest-runtime-config.ts
@@ -7,10 +7,7 @@ import {
 	type HermesConfigCommandContext,
 	reconcileHermesConfigValue,
 } from "./hermes-config";
-import {
-	mergeRuntimeEnvWithProviderPlaceholders,
-	mergeRuntimeServiceEnvWithProviderPlaceholders,
-} from "./hosted-provider-resolution";
+import { mergeRuntimeEnvWithProviderPlaceholders } from "./hosted-provider-resolution";
 import { HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION, type RuntimeManifest } from "./manifest-contract";
 import type { RuntimeInstallObservation } from "./manifest-install";
 import {
@@ -183,12 +180,7 @@ export function resolvedRuntimeServiceSettings(
 	settings: RuntimeRunSettings,
 	providerEnv: Record<string, string>,
 ): RuntimeRunSettings {
-	const merged = mergeRuntimeServiceEnvWithProviderPlaceholders(
-		runtime,
-		service,
-		settings,
-		providerEnv,
-	);
+	const merged = mergeRuntimeEnvWithProviderPlaceholders(runtime, settings, providerEnv, service);
 	return runtime === "hermes" && service === "dashboard"
 		? (withHermesDashboardAuthEnvironment(manifest, merged) ?? merged)
 		: merged;

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -16,11 +16,11 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+	ensureTestOpenClawWorkspaceCli,
 	type TestConvergeOptions,
 	withTestSystemdTransaction,
 } from "../test-support/systemd-apply";
 import { runtimeContentSha256 } from "./applied-state";
-import { hostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
 import { readRuntimeInstallReceipts, writeRuntimeInstallReceipts } from "./install-receipts";
 import {
 	convergeRuntimeManifest as convergeRuntimeManifestWithContext,
@@ -47,6 +47,7 @@ function convergeRuntimeManifest(
 	paths: RuntimePaths,
 	opts: TestConvergeOptions = {},
 ) {
+	ensureTestOpenClawWorkspaceCli(load.manifest, paths);
 	ensureRuntimeStateDirs(paths);
 	return convergeRuntimeManifestWithContext(
 		{
@@ -71,10 +72,6 @@ function convergeRuntimeManifest(
 		{
 			...opts,
 			systemdApply: opts.systemdApply ? withTestSystemdTransaction(opts.systemdApply) : undefined,
-			hostedOpenClawSkillDriver: opts?.hostedOpenClawSkillDriver ?? {
-				...hostedOpenClawSkillDriver,
-				resolveWorkspace: () => join(paths.userHome, ".openclaw", "workspace"),
-			},
 			hostedRuntimeContract: opts?.hostedRuntimeContract ?? {
 				expectedIdentity: {
 					home: paths.userHome,
@@ -478,16 +475,30 @@ describe("runtime manifest services", () => {
 		] as const) {
 			const paths = tempRuntimePaths();
 			const command = join(paths.userHome, ".local", "bin", "openclaw");
+			const commandLog = join(paths.userHome, "workspace-probe.log");
 			mkdirSync(dirname(command), { recursive: true });
-			writeFileSync(command, "#!/bin/sh\nexit 0\n");
+			writeFileSync(
+				command,
+				`#!/bin/sh
+printf '%s\n' "$*" >> '${commandLog}'
+case "$*" in
+  "--version") printf '%s\n' 'OpenClaw test-version' ;;
+  "agents list --json") exit 2 ;;
+  "config validate --json")
+    printf '%s\n' '{"valid":false,"path":"/tmp/openclaw.json","issues":[{"path":"x","message":"x"}]}'
+    exit 1
+    ;;
+  "doctor --fix --non-interactive") exit 0 ;;
+  *) exit 64 ;;
+esac
+`,
+			);
 			chmodSync(command, 0o700);
 			const manifest = installGateManifest(paths, "openclaw", command);
 			manifest.projection = {
 				...manifest.projection,
 				...(sourceBundleVersion ? { sourceBundleVersion } : {}),
 			};
-			let repairInvalidConfig: boolean | undefined;
-
 			expect(() =>
 				convergeRuntimeManifest(
 					{
@@ -497,18 +508,10 @@ describe("runtime manifest services", () => {
 						offline: false,
 					},
 					paths,
-					{
-						hostedOpenClawSkillDriver: {
-							...hostedOpenClawSkillDriver,
-							resolveWorkspace: (input) => {
-								repairInvalidConfig = input.repairInvalidConfig;
-								throw new Error("workspace probe captured");
-							},
-						},
-					},
 				),
-			).toThrow("workspace probe captured");
-			expect(repairInvalidConfig).toBe(expected);
+			).toThrow("OpenClaw official agent workspace roster is unavailable");
+			const commands = readFileSync(commandLog, "utf8").trim().split("\n");
+			expect(commands.includes("config validate --json")).toBe(expected);
 		}
 	});
 

--- a/packages/cli/src/runtime/manifest-skills-apply.ts
+++ b/packages/cli/src/runtime/manifest-skills-apply.ts
@@ -1,13 +1,17 @@
 import { existsSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { hostedBundledSkillIds, resolveHostedBundledSkill } from "./hosted-bundled-skill";
-import type { HostedHermesSkillExactSourceDriver } from "./hosted-hermes-skill";
-import type { HostedOpenClawSkillDriver } from "./hosted-openclaw-skill";
+import { activateHostedHermesSkill } from "./hosted-hermes-skill";
+import { activateHostedOpenClawSkill } from "./hosted-openclaw-skill";
 import {
 	type PreparedHostedSourcedSkill,
 	prepareHostedBundledSkillArchive,
 } from "./hosted-sourced-skill-archive";
-import { installedTreeMatches, ManagedSkillResourceError } from "./managed-skill-delivery";
+import {
+	installedTreeMatches,
+	ManagedSkillResourceError,
+	withStagedManagedSkill,
+} from "./managed-skill-delivery";
 import {
 	installReservedManagedSkill,
 	type ManagedSkillReservationSnapshot,
@@ -32,13 +36,11 @@ type HostedSkillDesired =
 	| { enabled: boolean; version: number }
 	| { enabled: boolean; source: HostedSkillSource };
 interface HostedSkillProjectionDriver {
-	name: "hermes" | "openclaw";
-	enabled: boolean;
 	skillsRoot: string | null;
-	installedTreeExcludes?: ReadonlySet<string>;
-	target(skill: PreparedHostedSourcedSkill): string;
-	install(skill: PreparedHostedSourcedSkill, targetDir: string): "installed" | "unchanged";
+	activate(sourceDir: string, targetDir: string): void;
+	exclude?: ReadonlySet<string>;
 }
+type HostedSkillRuntime = "hermes" | "openclaw";
 function preparedSkillMatchesDesired(
 	prepared: PreparedHostedSourcedSkill | undefined,
 	desired: HostedSkillDesired,
@@ -80,53 +82,44 @@ function preparedReservationIdentity(skill: PreparedHostedSourcedSkill): {
 		: { sourceIdentity: skill.sourceIdentity, digest: skill.archiveSha256 };
 }
 function hostedSkillProjectionDrivers(input: {
-	manifest: RuntimeManifest;
 	home: string;
 	openClawWorkspaceRoot: string | null;
-	hermesDriver: HostedHermesSkillExactSourceDriver;
-	openClawDriver: HostedOpenClawSkillDriver;
-}): HostedSkillProjectionDriver[] {
+}): ReadonlyArray<readonly [HostedSkillRuntime, HostedSkillProjectionDriver]> {
 	const hermesSkillsRoot = join(input.home, ".hermes", "skills");
 	const openClawSkillsRoot = input.openClawWorkspaceRoot
 		? join(input.openClawWorkspaceRoot, "skills")
 		: null;
 	return [
-		{
-			name: "hermes",
-			enabled: input.manifest.runtimes.hermes?.enabled === true,
-			skillsRoot: hermesSkillsRoot,
-			target: (skill) => input.hermesDriver.target({ home: input.home, skill }),
-			install: (skill, targetDir) =>
-				input.hermesDriver.install({
-					home: input.home,
-					skill,
-					targetDir,
-				}),
-		},
-		{
-			name: "openclaw",
-			enabled: input.manifest.runtimes.openclaw?.enabled === true,
-			skillsRoot: openClawSkillsRoot,
-			installedTreeExcludes: new Set([".openclaw/source-origin.json"]),
-			target: (skill) => {
-				if (!openClawSkillsRoot) {
-					throw new Error("OpenClaw official agent workspace is unavailable");
-				}
-				return join(openClawSkillsRoot, skill.skillId);
+		[
+			"hermes",
+			{
+				skillsRoot: hermesSkillsRoot,
+				activate: activateHostedHermesSkill,
 			},
-			install: (skill, targetDir) => {
-				if (!input.openClawWorkspaceRoot) {
-					throw new Error("OpenClaw official agent workspace is unavailable");
-				}
-				void targetDir;
-				return input.openClawDriver.install({
-					home: input.home,
-					workspaceRoot: input.openClawWorkspaceRoot,
-					skill,
-				});
+		],
+		[
+			"openclaw",
+			{
+				skillsRoot: openClawSkillsRoot,
+				exclude: new Set([".openclaw/source-origin.json"]),
+				activate: (sourceDir, targetDir) => {
+					if (!input.openClawWorkspaceRoot) {
+						throw new Error("OpenClaw official agent workspace is unavailable");
+					}
+					activateHostedOpenClawSkill({
+						home: input.home,
+						workspaceRoot: input.openClawWorkspaceRoot,
+						sourceDir,
+						targetDir,
+					});
+				},
 			},
-		},
+		],
 	];
+}
+
+function runtimeEnabled(manifest: RuntimeManifest, runtime: HostedSkillRuntime): boolean {
+	return manifest.runtimes[runtime]?.enabled === true;
 }
 
 function pendingReservationMatchesPrepared(
@@ -147,6 +140,7 @@ function discardPendingHostedSkill(targetDir: string): void {
 }
 
 function recoverPendingHostedSkillInstallations(
+	runtime: HostedSkillRuntime,
 	driver: HostedSkillProjectionDriver,
 	manifest: RuntimeManifest,
 	preparedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
@@ -160,7 +154,7 @@ function recoverPendingHostedSkillInstallations(
 		const desired = desiredEntries[reservation.id];
 		const prepared = preparedSkills.get(reservation.id);
 		const promotable =
-			driver.enabled &&
+			runtimeEnabled(manifest, runtime) &&
 			desired?.enabled === true &&
 			preparedSkillMatchesDesired(prepared, desired, reservation.id) &&
 			pendingReservationMatchesPrepared(reservation, prepared)
@@ -173,19 +167,20 @@ function recoverPendingHostedSkillInstallations(
 			verify: () =>
 				promotable !== null &&
 				installedTreeMatches(promotable, reservation.targetDir, {
-					exclude: driver.installedTreeExcludes,
+					exclude: driver.exclude,
 				}),
 			discard: () => discardPendingHostedSkill(reservation.targetDir),
 		});
 	}
 }
 function validateHostedSkillsPlan(
+	runtime: HostedSkillRuntime,
 	driver: HostedSkillProjectionDriver,
 	manifest: RuntimeManifest,
 	preparedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
 ): void {
 	if (!hostedBundledSkillsEnabled()) return;
-	if (driver.enabled && !driver.skillsRoot) {
+	if (runtimeEnabled(manifest, runtime) && !driver.skillsRoot) {
 		throw new Error("OpenClaw official agent workspace is unavailable");
 	}
 	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
@@ -193,18 +188,12 @@ function validateHostedSkillsPlan(
 			throw new Error(`bundled hosted Skill ${skillId} must not declare a catalog source`);
 		}
 		if (!("source" in desired)) resolveHostedBundledSkill(skillId, desired.version);
-		if (!driver.enabled || !driver.skillsRoot || !desired.enabled) continue;
+		if (!runtimeEnabled(manifest, runtime) || !driver.skillsRoot || !desired.enabled) continue;
 		const prepared = preparedSkills.get(skillId);
 		if (!preparedSkillMatchesDesired(prepared, desired, skillId)) {
 			throw new Error(`pinned archive for hosted Skill ${skillId} is unavailable`);
 		}
-		let targetDir: string;
-		try {
-			targetDir = driver.target(prepared);
-		} catch (error) {
-			if (error instanceof ManagedSkillResourceError) continue;
-			throw error;
-		}
+		const targetDir = join(driver.skillsRoot, prepared.skillId);
 		if (
 			withRuntimeUserFileAccess(() => existsSync(targetDir)) &&
 			managedSkillReservationOwner(targetDir, skillId) !== "hosted-manifest"
@@ -214,6 +203,7 @@ function validateHostedSkillsPlan(
 	}
 }
 function applyHostedSkills(
+	runtime: HostedSkillRuntime,
 	driver: HostedSkillProjectionDriver,
 	observation: RuntimeInstallObservation | undefined,
 	manifest: RuntimeManifest,
@@ -240,7 +230,7 @@ function applyHostedSkills(
 	for (const skillId of [...skillIds].sort()) {
 		const reservation = reservationsById.get(skillId);
 		const desired = desiredEntries[skillId];
-		if (!driver.enabled || desired?.enabled !== true) {
+		if (!runtimeEnabled(manifest, runtime) || desired?.enabled !== true) {
 			if (!reservation) continue;
 			try {
 				releaseManagedSkill({
@@ -264,14 +254,7 @@ function applyHostedSkills(
 		if (!preparedSkillMatchesDesired(prepared, desired, skillId)) {
 			throw new Error(`pinned archive for hosted Skill ${skillId} is unavailable`);
 		}
-		let targetDir: string;
-		try {
-			targetDir = driver.target(prepared);
-		} catch (error) {
-			if (!(error instanceof ManagedSkillResourceError)) throw error;
-			failures.push(`${skillId}: ${error.message}`);
-			continue;
-		}
+		const targetDir = join(driver.skillsRoot, prepared.skillId);
 		const owner = managedSkillReservationOwner(targetDir, skillId);
 		if (withRuntimeUserFileAccess(() => existsSync(targetDir)) && owner !== "hosted-manifest") {
 			throw new Error(`refusing to replace unmanaged ${skillId} skill at ${targetDir}`);
@@ -281,7 +264,7 @@ function applyHostedSkills(
 			reservation?.targetDir === targetDir &&
 			reservation.digest === reservationIdentity.digest &&
 			installedTreeMatches(prepared, targetDir, {
-				exclude: driver.installedTreeExcludes,
+				exclude: driver.exclude,
 			})
 		) {
 			if (
@@ -305,13 +288,12 @@ function applyHostedSkills(
 					manager: "hosted-manifest",
 					...preparedReservationIdentity(prepared),
 				},
-				() => {
-					return driver.install(prepared, targetDir);
-				},
+				() =>
+					withStagedManagedSkill(prepared, (sourceDir) => driver.activate(sourceDir, targetDir)),
 				{
 					verify: () =>
 						installedTreeMatches(prepared, targetDir, {
-							exclude: driver.installedTreeExcludes,
+							exclude: driver.exclude,
 						}),
 					discard: () => discardPendingHostedSkill(targetDir),
 				},
@@ -339,8 +321,6 @@ export function reconcileHostedSkillProjection(input: {
 	managedResourceRoot: string;
 	openClawWorkspaceRoot: string | null;
 	preparedSourcedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>;
-	hermesDriver: HostedHermesSkillExactSourceDriver;
-	openClawDriver: HostedOpenClawSkillDriver;
 }): string[] {
 	const {
 		manifest,
@@ -349,19 +329,14 @@ export function reconcileHostedSkillProjection(input: {
 		managedResourceRoot,
 		openClawWorkspaceRoot,
 		preparedSourcedSkills,
-		hermesDriver,
-		openClawDriver,
 	} = input;
 	const preparedSkills = completePreparedHostedSkills(manifest, preparedSourcedSkills);
 	const drivers = hostedSkillProjectionDrivers({
-		manifest,
 		home,
 		openClawWorkspaceRoot,
-		hermesDriver,
-		openClawDriver,
 	});
 	rmSync(join(managedResourceRoot, "skill-receipts"), { recursive: true, force: true });
-	for (const driver of drivers) {
+	for (const [, driver] of drivers) {
 		const skillsRoot = driver.skillsRoot;
 		if (skillsRoot) {
 			withRuntimeUserFileAccess(() =>
@@ -373,21 +348,19 @@ export function reconcileHostedSkillProjection(input: {
 		}
 	}
 	runHostedSkillProjectionStep("runtime Skill projection planning failed", () => {
-		for (const driver of drivers) {
-			recoverPendingHostedSkillInstallations(driver, manifest, preparedSkills);
-			validateHostedSkillsPlan(driver, manifest, preparedSkills);
+		for (const [runtime, driver] of drivers) {
+			recoverPendingHostedSkillInstallations(runtime, driver, manifest, preparedSkills);
+			validateHostedSkillsPlan(runtime, driver, manifest, preparedSkills);
 		}
 	});
 	const failures: string[] = [];
-	for (const driver of drivers) {
+	for (const [runtime, driver] of drivers) {
 		const driverFailures = runHostedSkillProjectionStep(
-			`runtime ${driver.name} Skill projection failed`,
-			() => applyHostedSkills(driver, observations.get(driver.name), manifest, preparedSkills),
+			`runtime ${runtime} Skill projection failed`,
+			() => applyHostedSkills(runtime, driver, observations.get(runtime), manifest, preparedSkills),
 		);
 		failures.push(
-			...driverFailures.map(
-				(failure) => `runtime ${driver.name} Skill projection failed: ${failure}`,
-			),
+			...driverFailures.map((failure) => `runtime ${runtime} Skill projection failed: ${failure}`),
 		);
 	}
 	return failures;

--- a/packages/cli/src/runtime/manifest-skills-apply.ts
+++ b/packages/cli/src/runtime/manifest-skills-apply.ts
@@ -1,5 +1,6 @@
 import { existsSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import { hostedBundledSkillIds, resolveHostedBundledSkill } from "./hosted-bundled-skill";
 import { activateHostedHermesSkill } from "./hosted-hermes-skill";
 import { activateHostedOpenClawSkill } from "./hosted-openclaw-skill";
@@ -26,12 +27,8 @@ import {
 import type { RuntimeManifest } from "./manifest-contract";
 import type { RuntimeInstallObservation } from "./manifest-install";
 import type { HostedSkillSource } from "./manifest-resources";
-import { detectRuntimeMode } from "./paths";
 import { withRuntimeUserFileAccess } from "./runtime-user-command";
 
-function hostedBundledSkillsEnabled(): boolean {
-	return detectRuntimeMode() === "hosted";
-}
 type HostedSkillDesired =
 	| { enabled: boolean; version: number }
 	| { enabled: boolean; source: HostedSkillSource };
@@ -41,6 +38,7 @@ interface HostedSkillProjectionDriver {
 	exclude?: ReadonlySet<string>;
 }
 type HostedSkillRuntime = "hermes" | "openclaw";
+
 function preparedSkillMatchesDesired(
 	prepared: PreparedHostedSourcedSkill | undefined,
 	desired: HostedSkillDesired,
@@ -48,7 +46,7 @@ function preparedSkillMatchesDesired(
 ): prepared is PreparedHostedSourcedSkill {
 	if (!prepared || prepared.skillId !== skillId) return false;
 	if ("source" in desired) {
-		return JSON.stringify(prepared.source) === JSON.stringify(desired.source);
+		return prepared.source.type !== "bundled" && isDeepStrictEqual(prepared.source, desired.source);
 	}
 	const catalogEntry = resolveHostedBundledSkill(skillId, desired.version);
 	return (
@@ -58,11 +56,35 @@ function preparedSkillMatchesDesired(
 		prepared.source.assetDirectory === catalogEntry.assetDirectory
 	);
 }
+
+function requirePreparedSkillTarget(
+	skillsRoot: string,
+	preparedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
+	desired: HostedSkillDesired,
+	skillId: string,
+): readonly [PreparedHostedSourcedSkill, string] {
+	const prepared = preparedSkills.get(skillId);
+	if (!preparedSkillMatchesDesired(prepared, desired, skillId)) {
+		throw new Error(`pinned archive for hosted Skill ${skillId} is unavailable`);
+	}
+	const targetDir = join(skillsRoot, prepared.skillId);
+	if (
+		withRuntimeUserFileAccess(() => existsSync(targetDir)) &&
+		managedSkillReservationOwner(targetDir, skillId) !== "hosted-manifest"
+	) {
+		throw new Error(`refusing to replace unmanaged ${skillId} skill at ${targetDir}`);
+	}
+	return [prepared, targetDir];
+}
+
+function openClawWorkspaceUnavailable(): never {
+	throw new Error("OpenClaw official agent workspace is unavailable");
+}
+
 function completePreparedHostedSkills(
 	manifest: RuntimeManifest,
 	prepared: ReadonlyMap<string, PreparedHostedSourcedSkill>,
 ): ReadonlyMap<string, PreparedHostedSourcedSkill> {
-	if (!hostedBundledSkillsEnabled()) return prepared;
 	const complete = new Map(prepared);
 	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
 		if (!desired.enabled || "source" in desired) continue;
@@ -103,9 +125,7 @@ function hostedSkillProjectionDrivers(input: {
 				skillsRoot: openClawSkillsRoot,
 				exclude: new Set([".openclaw/source-origin.json"]),
 				activate: (sourceDir, targetDir) => {
-					if (!input.openClawWorkspaceRoot) {
-						throw new Error("OpenClaw official agent workspace is unavailable");
-					}
+					if (!input.openClawWorkspaceRoot) openClawWorkspaceUnavailable();
 					activateHostedOpenClawSkill({
 						home: input.home,
 						workspaceRoot: input.openClawWorkspaceRoot,
@@ -145,7 +165,7 @@ function recoverPendingHostedSkillInstallations(
 	manifest: RuntimeManifest,
 	preparedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
 ): void {
-	if (!hostedBundledSkillsEnabled() || !driver.skillsRoot) return;
+	if (!driver.skillsRoot) return;
 	const desiredEntries = manifest.projection?.skills?.entries ?? {};
 	const pendingReservations = pendingManagedSkillReservations("hosted-manifest").filter(
 		(reservation) => dirname(reservation.targetDir) === driver.skillsRoot,
@@ -179,9 +199,8 @@ function validateHostedSkillsPlan(
 	manifest: RuntimeManifest,
 	preparedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
 ): void {
-	if (!hostedBundledSkillsEnabled()) return;
 	if (runtimeEnabled(manifest, runtime) && !driver.skillsRoot) {
-		throw new Error("OpenClaw official agent workspace is unavailable");
+		openClawWorkspaceUnavailable();
 	}
 	for (const [skillId, desired] of Object.entries(manifest.projection?.skills?.entries ?? {})) {
 		if ("source" in desired && hostedBundledSkillIds().includes(skillId)) {
@@ -189,17 +208,7 @@ function validateHostedSkillsPlan(
 		}
 		if (!("source" in desired)) resolveHostedBundledSkill(skillId, desired.version);
 		if (!runtimeEnabled(manifest, runtime) || !driver.skillsRoot || !desired.enabled) continue;
-		const prepared = preparedSkills.get(skillId);
-		if (!preparedSkillMatchesDesired(prepared, desired, skillId)) {
-			throw new Error(`pinned archive for hosted Skill ${skillId} is unavailable`);
-		}
-		const targetDir = join(driver.skillsRoot, prepared.skillId);
-		if (
-			withRuntimeUserFileAccess(() => existsSync(targetDir)) &&
-			managedSkillReservationOwner(targetDir, skillId) !== "hosted-manifest"
-		) {
-			throw new Error(`refusing to replace unmanaged ${skillId} skill at ${targetDir}`);
-		}
+		requirePreparedSkillTarget(driver.skillsRoot, preparedSkills, desired, skillId);
 	}
 }
 function applyHostedSkills(
@@ -209,7 +218,7 @@ function applyHostedSkills(
 	manifest: RuntimeManifest,
 	preparedSkills: ReadonlyMap<string, PreparedHostedSourcedSkill>,
 ): string[] {
-	if (!hostedBundledSkillsEnabled() || !driver.skillsRoot) return [];
+	if (!driver.skillsRoot) return [];
 	const failures: string[] = [];
 	const desiredEntries = manifest.projection?.skills?.entries ?? {};
 	const reservations = managedSkillReservations("hosted-manifest").filter(
@@ -250,15 +259,12 @@ function applyHostedSkills(
 			continue;
 		}
 		if (!observation?.enabled || observation.status === "install_failed") continue;
-		const prepared = preparedSkills.get(skillId);
-		if (!preparedSkillMatchesDesired(prepared, desired, skillId)) {
-			throw new Error(`pinned archive for hosted Skill ${skillId} is unavailable`);
-		}
-		const targetDir = join(driver.skillsRoot, prepared.skillId);
-		const owner = managedSkillReservationOwner(targetDir, skillId);
-		if (withRuntimeUserFileAccess(() => existsSync(targetDir)) && owner !== "hosted-manifest") {
-			throw new Error(`refusing to replace unmanaged ${skillId} skill at ${targetDir}`);
-		}
+		const [prepared, targetDir] = requirePreparedSkillTarget(
+			driver.skillsRoot,
+			preparedSkills,
+			desired,
+			skillId,
+		);
 		const reservationIdentity = preparedReservationIdentity(prepared);
 		if (
 			reservation?.targetDir === targetDir &&

--- a/packages/cli/src/runtime/manifest-skills-apply.ts
+++ b/packages/cli/src/runtime/manifest-skills-apply.ts
@@ -95,9 +95,7 @@ function hostedSkillProjectionDrivers(input: {
 			name: "hermes",
 			enabled: input.manifest.runtimes.hermes?.enabled === true,
 			skillsRoot: hermesSkillsRoot,
-			target: (skill) =>
-				input.hermesDriver.target?.({ home: input.home, skill }) ??
-				join(hermesSkillsRoot, skill.skillId),
+			target: (skill) => input.hermesDriver.target({ home: input.home, skill }),
 			install: (skill, targetDir) =>
 				input.hermesDriver.install({
 					home: input.home,
@@ -303,9 +301,6 @@ function applyHostedSkills(
 			installReservedManagedSkill(
 				{
 					targetDir,
-					...(reservation && reservation.targetDir !== targetDir
-						? { previousTargetDir: reservation.targetDir }
-						: {}),
 					id: skillId,
 					manager: "hosted-manifest",
 					...preparedReservationIdentity(prepared),

--- a/packages/cli/src/runtime/observation-producer.test.ts
+++ b/packages/cli/src/runtime/observation-producer.test.ts
@@ -81,11 +81,20 @@ function writeApplyIdentityFile(paths: RuntimePaths, generation: number): void {
 }
 
 function writeObservationHealth(paths: RuntimePaths, status: "ok" | "error"): void {
-	for (const path of [paths.runtimeWatchStatus, paths.providerHealthStatus]) {
+	for (const path of [paths.runtimeWatchStatus, paths.manifestLastGood]) {
 		mkdirSync(dirname(path), { recursive: true });
 	}
 	writeFileSync(paths.runtimeWatchStatus, JSON.stringify({ event: { status: "applied" } }));
-	writeFileSync(paths.providerHealthStatus, JSON.stringify({ providers: { default: { status } } }));
+	writeFileSync(
+		paths.manifestLastGood,
+		JSON.stringify({
+			projection: {
+				providers: {
+					default: { status, baseUrl: "https://api.test/v1", model: "test-model" },
+				},
+			},
+		}),
+	);
 }
 
 async function observationSchedule(

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -9,6 +9,7 @@ import { type RuntimeAppliedState, readRuntimeAppliedState } from "./applied-sta
 import { resolveRuntimeApplyGeneration } from "./apply-identity";
 import { type RuntimeCliBootstrapStatus, readRuntimeCliBootstrapStatus } from "./cli-update";
 import { readHostedAgentPluginsObservation } from "./hosted-agent-plugin-observation";
+import { providerHealthReasons } from "./manifest-providers";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { spawnRuntimeUserCommand } from "./runtime-user-command";
 import { runtimeSecretValue } from "./secret-values";
@@ -161,17 +162,6 @@ function observedCli(value: RuntimeCliBootstrapStatus | null): HostedRuntimeObse
 }
 
 function readProviderObserved(paths: RuntimePaths): HostedRuntimeObservedProviders | null {
-	const providerStatus = readJsonRecord(paths.providerHealthStatus);
-	const statusProviders = recordValue(providerStatus?.providers);
-	if (statusProviders && Object.keys(statusProviders).length > 0) {
-		const observed: HostedRuntimeObservedProviders = {};
-		for (const [providerId, value] of Object.entries(statusProviders)) {
-			const provider = recordValue(value);
-			if (provider) observed[providerId] = provider;
-		}
-		if (Object.keys(observed).length > 0) return observed;
-	}
-
 	const manifest = readJsonRecord(paths.manifestLastGood);
 	const projection = recordValue(manifest?.projection);
 	const providers = recordValue(projection?.providers);
@@ -188,13 +178,14 @@ function readProviderObserved(paths: RuntimePaths): HostedRuntimeObservedProvide
 		const apiKeySecretRef = stringValue(provider.apiKeySecretRef);
 		const secretAvailable =
 			apiKeySecretRef === null ? null : providerSecretAvailable(secrets, apiKeySecretRef);
-		const reasons = providerReasons(provider, secretAvailable);
+		const reasons = providerHealthReasons(provider, secretAvailable);
 		observed[providerId] = {
 			status: reasons.length > 0 ? "error" : "ok",
 			configured: true,
 			kind: stringValue(provider.kind),
 			baseUrl: stringValue(provider.baseUrl),
 			model: stringValue(provider.model),
+			models: Array.isArray(provider.models) ? provider.models : undefined,
 			apiKeySecretRef,
 			secretAvailable,
 			reasons,
@@ -205,47 +196,6 @@ function readProviderObserved(paths: RuntimePaths): HostedRuntimeObservedProvide
 
 function providerSecretAvailable(secrets: JsonRecord, ref: string): boolean {
 	return runtimeSecretValue(secrets, ref) !== null;
-}
-
-function providerReasons(provider: JsonRecord, secretAvailable: boolean | null): string[] {
-	const reasons: string[] = [];
-	const status = stringValue(provider.status);
-	if (status && status !== "ok") {
-		reasons.push(`provider_${status}`);
-	}
-	const error = recordValue(provider.error);
-	const errorCode = error ? stringValue(error.code) : null;
-	if (errorCode) {
-		reasons.push(errorCode);
-	}
-	const baseUrl = stringValue(provider.baseUrl);
-	if (!baseUrl) {
-		reasons.push("base_url_missing");
-	} else {
-		try {
-			const parsed = new URL(baseUrl);
-			const apiMode = stringValue(provider.apiMode);
-			if (isOpenAiCompatibleMode(apiMode) && (!parsed.pathname || parsed.pathname === "/")) {
-				reasons.push("base_url_path_missing");
-			}
-		} catch {
-			reasons.push("base_url_invalid");
-		}
-	}
-	if (!stringValue(provider.model)) {
-		reasons.push("model_missing");
-	}
-	if (stringValue(provider.apiKeySecretRef) && secretAvailable === false) {
-		reasons.push("secret_missing");
-	}
-	if (provider.apiKeyRequired === true && !stringValue(provider.apiKeySecretRef)) {
-		reasons.push("api_key_secret_ref_missing");
-	}
-	return reasons;
-}
-
-function isOpenAiCompatibleMode(apiMode: string | null): boolean {
-	return apiMode === "openai_chat" || apiMode === "openai_responses";
 }
 
 function readSystemdObserved(paths: RuntimePaths): HostedRuntimeObservedSystemd | null {

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -42,7 +42,6 @@ export interface RuntimePaths {
 	userNpmPrefix: string;
 	cliBootstrapStatus: string;
 	cliUpgradeState: string;
-	providerHealthStatus: string;
 	egressEngineStatus: string;
 	egressEngineMaintainedRoot: string;
 	fileBrowserInstallRoot: string;
@@ -214,7 +213,6 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 		userNpmPrefix: userLocalRoot,
 		cliBootstrapStatus: join(statusRoot, "cli-bootstrap.json"),
 		cliUpgradeState: join(statusRoot, "cli-upgrade-state.json"),
-		providerHealthStatus: join(statusRoot, "provider-health.json"),
 		egressEngineStatus: join(statusRoot, "egress-engine.json"),
 		egressEngineMaintainedRoot: join(maintainedRoot, "egress-engine", "mitmproxy"),
 		fileBrowserInstallRoot: join(maintainedRoot, "filebrowser"),

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -1688,7 +1688,6 @@ exit 0
 			for (const unitPath of generatedUnitPaths) {
 				expect(readFileSync(unitPath, "utf-8")).not.toContain(secret);
 			}
-			expect(readFileSync(paths.providerHealthStatus, "utf-8")).not.toContain(secret);
 		}
 
 		rmSync(egressSecretFile);

--- a/packages/cli/src/test-support/systemd-apply.ts
+++ b/packages/cli/src/test-support/systemd-apply.ts
@@ -1,4 +1,9 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import type { convergeRuntimeManifest } from "../runtime/manifest";
+import type { RuntimeManifest } from "../runtime/manifest-contract";
+import type { RuntimePaths } from "../runtime/paths";
 
 type ConvergeOptions = NonNullable<Parameters<typeof convergeRuntimeManifest>[2]>;
 type SystemdApplyHooks = NonNullable<ConvergeOptions["systemdApply"]>;
@@ -32,4 +37,52 @@ export function withTestSystemdTransaction(hooks: TestSystemdApplyHooks): System
 			return hooks.activate(signal);
 		},
 	};
+}
+
+export function ensureTestOpenClawWorkspaceCli(
+	manifest: RuntimeManifest,
+	paths: RuntimePaths,
+): void {
+	const runtime = manifest.runtimes.openclaw;
+	if (!runtime) return;
+	const installed = join(paths.userHome, ".local", "bin", "openclaw");
+	if (existsSync(installed)) {
+		const content = readFileSync(installed, "utf8");
+		if (
+			content.includes("CLAWDI_TEST_WORKSPACE_ROSTER") ||
+			content.includes("agents list --json")
+		) {
+			return;
+		}
+		const delegate = `${installed}.without-workspace-roster`;
+		renameSync(installed, delegate);
+		writeFileSync(
+			installed,
+			`#!/bin/sh
+# CLAWDI_TEST_WORKSPACE_ROSTER ${createHash("sha256").update(content).digest("hex")}
+if [ "$*" = "agents list --json" ]; then
+  printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace"
+  exit 0
+fi
+exec '${delegate}' "$@"
+`,
+			{ mode: 0o700 },
+		);
+		return;
+	}
+	if (runtime.enabled !== true) return;
+	const fallback = join(paths.userHome, ".openclaw", "bin", "openclaw");
+	mkdirSync(dirname(fallback), { recursive: true });
+	writeFileSync(
+		fallback,
+		`#!/bin/sh
+# CLAWDI_TEST_WORKSPACE_ROSTER
+if [ "$*" = "agents list --json" ]; then
+  printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace"
+  exit 0
+fi
+exit 64
+`,
+		{ mode: 0o700 },
+	);
 }

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -1169,35 +1169,15 @@ test("projects a large OpenClaw provider model-list reduction through the public
 		const projectionInput = hostedAiProviderCatalog(manifest, "openclaw");
 		if (!projectionInput) throw new Error("expected OpenClaw provider projection");
 		const intendedPatch = buildOpenClawHostedProviderPatch(projectionInput, ["clawdi"]);
-		expect(intendedPatch.args).toEqual(["--replace-path", 'models.providers["clawdi"]']);
-		const rejected = spawnSync(
-			"runuser",
-			[
-				"-u",
-				"clawdi",
-				"--",
-				"env",
-				`HOME=${runtimeHome}`,
-				`OPENCLAW_CONFIG_PATH=${configPath}`,
-				"CLAWDI_AI_API_KEY=clawdi-egress-placeholder",
-				commandPath,
-				"config",
-				"patch",
-				"--stdin",
-				...intendedPatch.args,
-			],
-			{ encoding: "utf8", input: intendedPatch.content },
+		const configMutationSdkPath = resolveSdk(
+			runtimeHome,
+			[commandPath],
+			SDK_EXPORTS.configMutation,
 		);
-		expect(rejected.status).not.toBe(0);
-		const rejectedOutput = `${rejected.stdout}\n${rejected.stderr}`;
-		const sizeDrop = rejectedOutput.match(/size-drop:(\d+)->(\d+)/);
-		expect(sizeDrop).not.toBeNull();
-		if (!sizeDrop) throw new Error(rejectedOutput);
-		const beforeBytes = Number(sizeDrop[1]);
-		const rejectedBytes = Number(sizeDrop[2]);
-		expect(beforeBytes).toBeGreaterThan(5_000);
-		expect(rejectedBytes).toBeLessThan(Math.floor(beforeBytes * 0.5));
-		expect(readFileSync(configPath, "utf8")).toBe(originalConfig);
+		expect(configMutationSdkPath).not.toBeNull();
+		if (!configMutationSdkPath) {
+			throw new Error("official OpenClaw config-mutation SDK is unavailable");
+		}
 		writeFileSync(
 			configPath,
 			`${JSON.stringify(
@@ -1214,6 +1194,8 @@ test("projects a large OpenClaw provider model-list reduction through the public
 			{ mode: 0o600 },
 		);
 		chownSync(configPath, runtimeUid, runtimeGid);
+		const beforeBytes = Buffer.byteLength(readFileSync(configPath, "utf8"));
+		expect(beforeBytes).toBeGreaterThan(5_000);
 
 		const convergence = convergeRuntimeManifest(load, paths, { cacheLastGood: false });
 		expect(convergence.installErrors).toEqual([]);

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -29,7 +29,6 @@ import {
 } from "../../src/lib/codex-oauth-native-store";
 import { getCliVersion } from "../../src/lib/version";
 import { readRuntimeAppliedState } from "../../src/runtime/applied-state";
-import { hostedOpenClawSkillDriver } from "../../src/runtime/hosted-openclaw-skill";
 import { hostedAiProviderCatalog } from "../../src/runtime/hosted-provider-resolution";
 import { prepareHostedSourcedSkillArchives } from "../../src/runtime/hosted-sourced-skill-archive";
 import {
@@ -904,12 +903,6 @@ test("propagates the real official OpenClaw installer failure and rolls back as 
 	const result = convergeRuntimeManifest(load, paths, {
 		executeOfficialServiceInstallers: true,
 		cacheLastGood: false,
-		// This case exercises installer rollback; live roster behavior is covered
-		// by the full OpenClaw projection cases below.
-		hostedOpenClawSkillDriver: {
-			...hostedOpenClawSkillDriver,
-			resolveWorkspace: () => openClawWorkspaceRoot,
-		},
 		commitAuthority: () => {
 			authorityCommits += 1;
 		},

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -66,7 +66,6 @@ import {
 	reserveManagedSkill,
 } from "../src/runtime/managed-skill-reservation";
 import {
-	buildOpenClawHostedProviderPatch,
 	convergeRuntimeManifest as convergeRuntimeManifestWithContext,
 	loadRuntimeManifest as loadRuntimeManifestFromContext,
 	materializeHostedChannelCredentials,
@@ -1302,6 +1301,7 @@ fi`;
 }
 
 function seedOpenClawBinary(home: string): void {
+	writeOpenClawConfigMutationFixture(home);
 	const openclawBin = join(home, ".local", "bin", "openclaw");
 	const configPath = join(home, ".openclaw", "openclaw.json");
 	const unitPath = join(home, ".config", "systemd", "user", "openclaw-gateway.service");
@@ -2641,27 +2641,6 @@ function writeOfflineStrictAppliedState(
 	);
 }
 
-function applyOpenClawProviderPatchLog(
-	patchLog: string,
-	initialProviders: Record<string, unknown>,
-): Record<string, unknown> {
-	const providers = { ...initialProviders };
-	const patchText = existsSync(patchLog) ? readFileSync(patchLog, "utf-8") : "";
-	for (const rawPatch of patchText.split("\n---\n")) {
-		const trimmed = rawPatch.trim();
-		if (!trimmed) continue;
-		const patch = JSON.parse(trimmed);
-		if (!isRecord(patch)) continue;
-		const models = isRecord(patch.models) ? patch.models : {};
-		const patchProviders = isRecord(models.providers) ? models.providers : {};
-		for (const [providerId, providerPatch] of Object.entries(patchProviders)) {
-			if (providerPatch === null) delete providers[providerId];
-			else providers[providerId] = providerPatch;
-		}
-	}
-	return providers;
-}
-
 describe("runtime paths", () => {
 	it("uses ~/.clawdi in local mode", () => {
 		const home = join(root, "home", "alice");
@@ -3896,8 +3875,8 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		const run = join(root, "run", "clawdi");
 		const openclawBin = join(home, ".local", "bin", "openclaw");
 		const openclawPatch = join(root, "openclaw-provider-patch.json");
-		const openclawOriginsPatch = join(root, "openclaw-origins-patch.json");
 		const openclawCommand = join(root, "openclaw-provider-command.txt");
+		const { configPath } = writeOpenClawConfigMutationFixture(home);
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
@@ -3909,11 +3888,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 				"#!/bin/sh",
 				`printf '%s\\n' "$*" >> '${openclawCommand}'`,
 				'if [ "$1 $2 $3" = "config patch --stdin" ]; then',
-				`  if [ ! -f '${openclawPatch}' ]; then`,
-				`    cat > '${openclawPatch}'`,
-				"  else",
-				`    cat > '${openclawOriginsPatch}'`,
-				"  fi",
+				`  cat > '${openclawPatch}'`,
 				"  exit 0",
 				"fi",
 				"printf 'unexpected openclaw command: %s\\n' \"$*\" >&2",
@@ -3988,10 +3963,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
 
 		expect(convergence.installErrors).toEqual([]);
-		expect(readFileSync(openclawCommand, "utf-8").trim().split("\n")).toEqual([
-			"config patch --stdin",
-			'config patch --stdin --replace-path models.providers["default"]',
-		]);
+		expect(readFileSync(openclawCommand, "utf-8").trim()).toBe("config patch --stdin");
 		expect(JSON.parse(readFileSync(openclawPatch, "utf-8"))).toEqual({
 			agents: {
 				defaults: {
@@ -4009,7 +3981,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 				},
 			},
 		});
-		const patch = JSON.parse(readFileSync(openclawOriginsPatch, "utf-8"));
+		const patch = JSON.parse(readFileSync(configPath, "utf-8"));
 		expect(patch.agents.defaults.model.primary).toBe("default/gpt-5.4-mini");
 		expect(patch.secrets).toEqual({
 			providers: {
@@ -4486,173 +4458,6 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		expect(readFileSync(configPath, "utf-8")).not.toMatch(/managed/i);
 	});
 
-	it("migrates the legacy Codex shim before bootstrapping the user npm prefix", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const binDir = join(root, "fake-bin");
-		const npmArgsPath = join(root, "npm-args.txt");
-		const userCodexConfig = join(home, ".codex", "config.toml");
-		const legacyCodexMarker = join(home, ".local", "share", "clawdi", "codex", "user-data");
-		const legacyCodexCommand = join(home, ".local", "bin", "codex");
-		const legacyCodexRealBin = join(home, ".local", "share", "clawdi", "codex", "bin", "codex");
-		const partialPackageJson = join(
-			home,
-			".local",
-			"lib",
-			"node_modules",
-			"@openai",
-			"codex",
-			"package.json",
-		);
-		const userConfigBytes = Buffer.from('# user config\nmodel = "user-model"\n');
-		const previousPath = process.env.PATH;
-		const previousUmask = process.umask(0o077);
-		mkdirSync(binDir, { recursive: true });
-		mkdirSync(dirname(userCodexConfig), { recursive: true });
-		mkdirSync(dirname(legacyCodexMarker), { recursive: true });
-		mkdirSync(dirname(legacyCodexCommand), { recursive: true });
-		mkdirSync(dirname(partialPackageJson), { recursive: true });
-		writeFileSync(userCodexConfig, userConfigBytes);
-		writeFileSync(legacyCodexMarker, "preserve\n");
-		writeFileSync(partialPackageJson, '{"version":"0.147.0"}\n');
-		writeFileSync(
-			legacyCodexCommand,
-			[
-				"#!/usr/bin/env sh",
-				"export CLAWDI_AI_API_KEY='clawdi-egress-placeholder'",
-				`exec '${legacyCodexRealBin}' "$@"`,
-				"",
-			].join("\n"),
-		);
-		chmodSync(legacyCodexCommand, 0o755);
-		writeFileSync(
-			join(binDir, "npm"),
-			[
-				"#!/usr/bin/env bash",
-				"set -euo pipefail",
-				`printf '%s\\n' "$@" > '${npmArgsPath}'`,
-				"prefix=''",
-				'while [ "$#" -gt 0 ]; do',
-				'  case "$1" in',
-				"    --prefix)",
-				'      prefix="$2"',
-				"      shift 2",
-				"      ;;",
-				"    *)",
-				"      shift",
-				"      ;;",
-				"  esac",
-				"done",
-				'test ! -e "$prefix/bin/codex"',
-				'mkdir -p "$prefix/bin" "$prefix/lib/node_modules/@openai/codex"',
-				`printf '%s\\n' '{"version":"0.146.0"}' > "$prefix/lib/node_modules/@openai/codex/package.json"`,
-				"cat > \"$prefix/bin/codex\" <<'SH'",
-				"#!/usr/bin/env sh",
-				'for arg in "$@"; do printf \'arg=<%s>\\n\' "$arg"; done',
-				"SH",
-				'chmod 755 "$prefix/bin/codex"',
-				"",
-			].join("\n"),
-		);
-		chmodSync(join(binDir, "npm"), 0o755);
-		delete process.env.CLAWDI_CODEX_INSTALL_DISABLED;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		process.env.PATH = [binDir, previousPath].filter(Boolean).join(":");
-		const paths = getRuntimePaths();
-
-		try {
-			const convergence = convergeRuntimeManifest(
-				{
-					source: "remote-datasource",
-					sourcePath: "https://runtime-source.test/desired-state",
-					offline: false,
-					manifest: {
-						schemaVersion: "clawdi.runtimeDesiredState.v1",
-						deploymentId: "dep_codex_addon",
-						environmentId: "env_codex_addon",
-						instanceId: "iid_codex_addon",
-						generation: 1,
-						issuedAt: "2026-07-10T00:00:00Z",
-						workspaceRoot: join(home, "clawdi"),
-						controlPlane: { apiUrl: "https://cloud-api.test" },
-						runtimes: {
-							openclaw: { enabled: false },
-						},
-						projection: {
-							system: { home },
-							providers: {},
-							terminalTooling: {
-								codex: {
-									enabled: true,
-									provider_id: "codex-managed",
-									primary_model: {
-										provider_id: "codex-managed",
-										model: "gpt-5.5",
-									},
-									provider: {
-										kind: "openai-compatible",
-										baseUrl: "https://managed-provider.example.test/v1",
-										apiMode: "openai_responses",
-										managed_by: "clawdi",
-										runtimeEnvName: "CLAWDI_AI_API_KEY",
-										apiKeySecretRef: "secret://tool.codex.apiKey",
-									},
-								},
-							},
-						},
-						egressProfiles: { profiles: [] },
-						recovery: { cacheManifest: true, allowOfflineBoot: true },
-					},
-				},
-				paths,
-			);
-
-			expect(convergence.installErrors).toEqual([]);
-		} finally {
-			process.umask(previousUmask);
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-			process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
-		}
-
-		const npmArgs = readFileSync(npmArgsPath, "utf-8");
-		expect(npmArgs).toContain("@openai/codex@0.146.0");
-		expect(npmArgs).toContain(`${paths.userNpmPrefix}\n`);
-		expect(npmArgs).not.toContain("--force\n");
-		expect(npmArgs).not.toContain("--cache\n");
-		const realBin = join(paths.userNpmPrefix, "bin", "codex");
-		const packageJson = join(paths.userNpmPrefix, "lib/node_modules/@openai/codex/package.json");
-		expect(statSync(paths.userNpmPrefix).mode & 0o777).toBe(0o700);
-		expect(statSync(dirname(realBin)).mode & 0o777).toBe(0o700);
-		expect(statSync(realBin).mode & 0o777).toBe(0o755);
-		expect(statSync(packageJson).mode & 0o777).toBe(0o600);
-		expect(readFileSync(userCodexConfig, "utf8")).toContain('env_key = "CLAWDI_AI_API_KEY"');
-		expect(readFileSync(legacyCodexMarker, "utf8")).toBe("preserve\n");
-
-		const runCodex = (args: string[]) => {
-			const result = spawnSync(realBin, args, {
-				encoding: "utf8",
-			});
-			expect(result.status).toBe(0);
-			return result.stdout.trimEnd().split("\n");
-		};
-		expect(runCodex(["exec", "quoted arg", ""])).toEqual([
-			"arg=<exec>",
-			"arg=<quoted arg>",
-			"arg=<>",
-		]);
-		for (const args of [
-			["resume", "session id", "--flag=value"],
-			["exec", "", "'quoted'", '"double quoted"'],
-		]) {
-			expect(runCodex(args)).toEqual(args.map((arg) => `arg=<${arg}>`));
-		}
-	});
-
 	it("preserves a healthy user-upgraded Hosted Codex package", () => {
 		const home = join(root, "codex-user-upgraded", "home", "clawdi");
 		const state = join(root, "codex-user-upgraded", "var", "lib", "clawdi");
@@ -4902,35 +4707,20 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 			const run = join(caseRoot, "run", "clawdi");
 			const workspace = join(home, "clawdi");
 			const openclawBin = join(home, ".local", "bin", "openclaw");
-			const openclawPatchLog = join(caseRoot, "openclaw-provider-patches.jsonl");
-			const publicSdkConfig =
-				providerCase.id === "managed-to-managed"
-					? writeOpenClawConfigMutationFixture(home, {
-							models: {
-								providers: {
-									"user-local": {
-										baseUrl: "http://127.0.0.1:11434/v1",
-										models: [{ id: "local-model" }],
-									},
-								},
-							},
-						})
-					: null;
+			const publicSdkConfig = writeOpenClawConfigMutationFixture(home, {
+				models: {
+					providers: {
+						"user-local": {
+							baseUrl: "http://127.0.0.1:11434/v1",
+							models: [{ id: "local-model" }],
+						},
+					},
+				},
+			});
 			mkdirSync(dirname(openclawBin), { recursive: true });
 			mkdirSync(join(home, ".hermes"), { recursive: true });
 			mkdirSync(workspace, { recursive: true });
-			writeFileSync(
-				openclawBin,
-				`#!/usr/bin/env bash
-set -euo pipefail
-if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
-  cat >> '${openclawPatchLog}'
-  printf '\\n---\\n' >> '${openclawPatchLog}'
-  exit 0
-fi
-exit 0
-`,
-			);
+			writeFileSync(openclawBin, "#!/usr/bin/env bash\nexit 0\n");
 			chmodSync(openclawBin, 0o700);
 			writeHermesVersionBinary(home, "0.18.0");
 			writeFileSync(
@@ -4947,7 +4737,7 @@ exit 0
 			process.env.CLAWDI_RUNTIME_MODE = "hosted";
 			process.env.CLAWDI_SERVICE_STATE_DIR = state;
 			process.env.CLAWDI_RUN_DIR = run;
-			if (publicSdkConfig) {
+			if (providerCase.id === "managed-to-managed") {
 				process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
 				process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_PROVIDER_AUTH_SDK =
 					writeFakeOpenClawProviderAuthSdk(
@@ -4967,38 +4757,13 @@ exit 0
 			const secondLoad = hostedProviderSwitchLoad(home, providerCase.second, 2);
 			const second = convergeRuntimeManifest(secondLoad, paths);
 			expect(second.installErrors).toEqual([]);
-			if (providerCase.id === "byok-to-byok") {
-				const projectionInput = hostedAiProviderCatalog(secondLoad.manifest, "openclaw");
-				expect(projectionInput).not.toBeNull();
-				if (!projectionInput) throw new Error("expected OpenClaw provider projection input");
-				const sharedPatch = buildOpenClawHostedProviderPatch(projectionInput, [firstAgentProvider]);
-				const appliedProviderPatches = readFileSync(openclawPatchLog, "utf-8")
-					.split("\n---\n")
-					.map((content) => content.trim())
-					.filter(Boolean)
-					.map((content) => JSON.parse(content) as unknown)
-					.filter((patch): patch is Record<string, unknown> => {
-						if (!isRecord(patch)) return false;
-						const models = patch.models;
-						return isRecord(models) && isRecord(models.providers);
-					});
-				expect(appliedProviderPatches.at(-1)).toEqual(JSON.parse(sharedPatch.content));
-			}
-
-			const openclawProviders = publicSdkConfig
-				? expectRecord(
-						expectRecord(
-							JSON.parse(readFileSync(publicSdkConfig.configPath, "utf8")).models,
-							"OpenClaw models config",
-						).providers,
-						"OpenClaw providers config",
-					)
-				: applyOpenClawProviderPatchLog(openclawPatchLog, {
-						"user-local": {
-							baseUrl: "http://127.0.0.1:11434/v1",
-							models: [{ id: "local-model" }],
-						},
-					});
+			const openclawProviders = expectRecord(
+				expectRecord(
+					JSON.parse(readFileSync(publicSdkConfig.configPath, "utf8")).models,
+					"OpenClaw models config",
+				).providers,
+				"OpenClaw providers config",
+			);
 			expect(Object.keys(openclawProviders).sort()).toEqual(
 				["user-local", secondAgentProvider].sort(),
 			);
@@ -5219,22 +4984,20 @@ exit 0
 		const run = join(root, "run", "clawdi");
 		const workspace = join(home, "clawdi");
 		const openclawBin = join(home, ".local", "bin", "openclaw");
-		const openclawPatchLog = join(root, "openclaw-provider-patches.jsonl");
+		const { configPath } = writeOpenClawConfigMutationFixture(home, {
+			models: {
+				providers: {
+					orphaned: {
+						baseUrl: "https://orphaned.example.test/v1",
+						models: [{ id: "orphaned-model" }],
+					},
+				},
+			},
+		});
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		mkdirSync(join(home, ".hermes"), { recursive: true });
 		mkdirSync(workspace, { recursive: true });
-		writeFileSync(
-			openclawBin,
-			`#!/usr/bin/env bash
-set -euo pipefail
-if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
-  cat >> '${openclawPatchLog}'
-  printf '\\n---\\n' >> '${openclawPatchLog}'
-  exit 0
-fi
-exit 0
-`,
-		);
+		writeFileSync(openclawBin, "#!/usr/bin/env bash\nexit 0\n");
 		chmodSync(openclawBin, 0o700);
 		writeHermesVersionBinary(home, "0.18.0");
 		writeFileSync(
@@ -5257,12 +5020,11 @@ exit 0
 
 		expect(convergence.installErrors).toEqual([]);
 		expect(existsSync(paths.appliedState)).toBe(false);
-		const openclawProviders = applyOpenClawProviderPatchLog(openclawPatchLog, {
-			orphaned: {
-				baseUrl: "https://orphaned.example.test/v1",
-				models: [{ id: "orphaned-model" }],
-			},
-		});
+		const openclawProviders = expectRecord(
+			expectRecord(JSON.parse(readFileSync(configPath, "utf8")).models, "OpenClaw models config")
+				.providers,
+			"OpenClaw providers config",
+		);
 		expect(openclawProviders.orphaned).toBeDefined();
 		expect(openclawProviders["byok-b"]).toBeDefined();
 		const hermesProviders = expectRecord(
@@ -5287,6 +5049,7 @@ exit 0
 		const patchCount = join(root, "openclaw-patch-count");
 		const unitPath = join(home, ".config", "systemd", "user", "openclaw-gateway.service");
 		const gatewayEnvPath = join(run, "systemd", "env", "openclaw-gateway.service.env");
+		writeOpenClawConfigMutationFixture(home);
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
@@ -5433,7 +5196,6 @@ exit 0
 		expect(readFileSync(openclawCommand, "utf-8").trim().split("\n")).toEqual([
 			"config patch --stdin",
 			"config patch --stdin",
-			'config patch --stdin --replace-path models.providers["default"]',
 			"gateway install --force --json",
 		]);
 		expect(JSON.parse(readFileSync(join(root, "openclaw-patch-1.json"), "utf-8"))).toEqual({
@@ -5477,13 +5239,12 @@ exit 0
 		utimesSync(gatewayEnvPath, fixedCredentialTime, fixedCredentialTime);
 		const configMtime = statSync(openclawConfig).mtimeMs;
 		const envMtime = statSync(gatewayEnvPath).mtimeMs;
+		const commandsAfterConvergence = readFileSync(openclawCommand, "utf8");
 		const idempotent = convergeRuntimeManifest(loaded, getRuntimePaths(), {
 			executeOfficialServiceInstallers: true,
 		});
 		expect(idempotent.installErrors).toEqual([]);
-		expect(readFileSync(openclawCommand, "utf8").trim().split("\n").slice(-1)).toEqual([
-			'config patch --stdin --replace-path models.providers["default"]',
-		]);
+		expect(readFileSync(openclawCommand, "utf8")).toBe(commandsAfterConvergence);
 		expect(statSync(openclawConfig).mtimeMs).toBe(configMtime);
 		expect(statSync(gatewayEnvPath).mtimeMs).toBe(envMtime);
 
@@ -5492,8 +5253,7 @@ exit 0
 			executeOfficialServiceInstallers: true,
 		});
 		expect(reinstalled.installErrors).toEqual([]);
-		expect(readFileSync(openclawCommand, "utf8").trim().split("\n").slice(-2)).toEqual([
-			'config patch --stdin --replace-path models.providers["default"]',
+		expect(readFileSync(openclawCommand, "utf8").trim().split("\n").slice(-1)).toEqual([
 			"gateway install --force --json",
 		]);
 		expect(readFileSync(installerToken, "utf8")).toBe("gateway-token\n");
@@ -5509,9 +5269,8 @@ exit 0
 			executeOfficialServiceInstallers: true,
 		});
 		expect(rotated.installErrors).toEqual([]);
-		expect(readFileSync(openclawCommand, "utf8").trim().split("\n").slice(-2)).toEqual([
+		expect(readFileSync(openclawCommand, "utf8").trim().split("\n").slice(-1)).toEqual([
 			"config patch --stdin",
-			'config patch --stdin --replace-path models.providers["default"]',
 		]);
 		expect(JSON.parse(readFileSync(openclawConfig, "utf8")).gateway.auth.token).toBe(
 			"rotated-gateway-token",
@@ -5530,24 +5289,13 @@ exit 0
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const openclawBin = join(home, ".local", "bin", "openclaw");
-		const openclawPatch = join(root, "openclaw-runtime-provider-patch.json");
+		const { configPath } = writeOpenClawConfigMutationFixture(home);
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		writeFileSync(
-			openclawBin,
-			[
-				"#!/bin/sh",
-				'if [ "$1 $2 $3" = "config patch --stdin" ]; then',
-				`  cat > '${openclawPatch}'`,
-				"  exit 0",
-				"fi",
-				"exit 2",
-				"",
-			].join("\n"),
-		);
+		writeFileSync(openclawBin, "#!/bin/sh\nexit 0\n");
 		chmodSync(openclawBin, 0o700);
 		writeHermesVersionBinary(home, "0.18.0");
 
@@ -5649,7 +5397,7 @@ exit 0
 		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
 
 		expect(convergence.installErrors).toEqual([]);
-		const patch = JSON.parse(readFileSync(openclawPatch, "utf-8"));
+		const patch = JSON.parse(readFileSync(configPath, "utf-8"));
 		expect(patch.agents.defaults.model.primary).toBe("openclaw/gpt-5.5");
 		expect(patch.models.providers.openclaw.baseUrl).toBe(
 			"https://openclaw-provider.example.test/v1",
@@ -6503,24 +6251,13 @@ cp '${sdkSource}' '${sdkTarget}'
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const openclawBin = join(home, ".local", "bin", "openclaw");
-		const openclawPatch = join(root, "openclaw-codex-oauth-patch.json");
+		const { configPath } = writeOpenClawConfigMutationFixture(home);
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		writeFileSync(
-			openclawBin,
-			[
-				"#!/bin/sh",
-				'if [ "$1 $2 $3" = "config patch --stdin" ]; then',
-				`  cat > '${openclawPatch}'`,
-				"  exit 0",
-				"fi",
-				"exit 2",
-				"",
-			].join("\n"),
-		);
+		writeFileSync(openclawBin, "#!/bin/sh\nexit 0\n");
 		chmodSync(openclawBin, 0o700);
 
 		const loaded: RuntimeManifestLoad = {
@@ -6577,7 +6314,7 @@ cp '${sdkSource}' '${sdkTarget}'
 		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
 
 		expect(convergence.installErrors).toEqual([]);
-		const patch = JSON.parse(readFileSync(openclawPatch, "utf-8"));
+		const patch = JSON.parse(readFileSync(configPath, "utf-8"));
 		expect(patch.plugins.entries.codex.enabled).toBe(true);
 		expect(patch.agents.defaults.model.primary).toBe("openai/gpt-5.5");
 		expect(patch.models).toBeUndefined();
@@ -6682,24 +6419,13 @@ cp '${sdkSource}' '${sdkTarget}'
 			const state = join(caseRoot, "var", "lib", "clawdi");
 			const run = join(caseRoot, "run", "clawdi");
 			const openclawBin = join(home, ".local", "bin", "openclaw");
-			const openclawPatch = join(caseRoot, "openclaw-provider-patch.json");
+			const { configPath } = writeOpenClawConfigMutationFixture(home);
 			mkdirSync(dirname(openclawBin), { recursive: true });
 			process.env.HOME = home;
 			process.env.CLAWDI_RUNTIME_MODE = "hosted";
 			process.env.CLAWDI_SERVICE_STATE_DIR = state;
 			process.env.CLAWDI_RUN_DIR = run;
-			writeFileSync(
-				openclawBin,
-				[
-					"#!/bin/sh",
-					'if [ "$1 $2 $3" = "config patch --stdin" ]; then',
-					`  cat > '${openclawPatch}'`,
-					"  exit 0",
-					"fi",
-					"exit 2",
-					"",
-				].join("\n"),
-			);
+			writeFileSync(openclawBin, "#!/bin/sh\nexit 0\n");
 			chmodSync(openclawBin, 0o700);
 
 			const loaded: RuntimeManifestLoad = {
@@ -6757,7 +6483,7 @@ cp '${sdkSource}' '${sdkTarget}'
 
 			const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
 			expect(convergence.installErrors).toEqual([]);
-			const patch = JSON.parse(readFileSync(openclawPatch, "utf-8"));
+			const patch = JSON.parse(readFileSync(configPath, "utf-8"));
 			expect(patch.models.providers.openclaw.api).toBe(providerCase.expectedOpenClawApi);
 			expect(patch.models.providers.openclaw.api).not.toBeUndefined();
 		}
@@ -8134,6 +7860,7 @@ exit 64
 		const previousLog = console.log;
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
+		writeOpenClawConfigMutationFixture(home);
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		writeFileSync(
 			openclawBin,
@@ -10553,6 +10280,7 @@ chmod +x "$prefix/bin/clawdi"
 			let runtimeExitCode: number | undefined;
 			const logs: string[] = [];
 			mkdirSync(join(run, "secrets"), { recursive: true });
+			if (runtime === "openclaw") writeOpenClawConfigMutationFixture(home);
 			mkdirSync(dirname(runtimeBin), { recursive: true });
 			mkdirSync(bin, { recursive: true });
 			process.env.HOME = home;
@@ -17107,7 +16835,6 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
-		writeOpenClawConfigMutationFixture(home);
 		seedOpenClawBinary(home);
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -5723,6 +5723,11 @@ exit 0
 		const nativeProfileId = nativeOAuthProfileId("hermes", "openai-codex");
 		const ledgerKey = createHash("sha256").update("openai-codex").digest("hex");
 		const ledgerPath = join(paths.oauthCredentialRoot, "hermes", `${ledgerKey}.json`);
+		const retiredLedgerPath = join(
+			paths.oauthCredentialRoot,
+			"hermes",
+			`${createHash("sha256").update("retired-provider").digest("hex")}.json`,
+		);
 		mkdirSync(dirname(authPath), { recursive: true });
 		writeFileSync(
 			authPath,
@@ -5758,6 +5763,17 @@ exit 0
 		});
 		mkdirSync(dirname(ledgerPath), { recursive: true });
 		writeFileSync(
+			retiredLedgerPath,
+			`${JSON.stringify({
+				schemaVersion: "clawdi.oauthCredentialOwnership.v2",
+				runtime: "hermes",
+				providerId: "retired-provider",
+				nativeProfileId: "retired",
+				credentialRevision: "retired",
+				state: "retired",
+			})}\n`,
+		);
+		writeFileSync(
 			ledgerPath,
 			`${JSON.stringify({
 				schemaVersion: "clawdi.oauthCredentialOwnership.v2",
@@ -5777,6 +5793,7 @@ exit 0
 
 		const first = convergeRuntimeManifest(firstLoad, paths);
 		expect(first.installErrors).toEqual([]);
+		expect(existsSync(retiredLedgerPath)).toBe(false);
 		let auth = JSON.parse(readFileSync(authPath, "utf8"));
 		expect(auth.providers["openai-codex"].tokens.access_token).toBe("user-access");
 		expect(auth.credential_pool["openai-codex"][0]).toMatchObject({
@@ -5866,53 +5883,7 @@ exit 0
 				refresh_token: "user-independent-refresh",
 			}),
 		]);
-		expect(JSON.parse(readFileSync(ledgerPath, "utf8")).state).toBe("retired");
-
-		auth.credential_pool["openai-codex"].unshift({
-			id: nativeProfileId,
-			label: "User replacement",
-			auth_type: "oauth",
-			priority: 0,
-			source: "manual:device_code",
-			access_token: "foreign-namespaced-access",
-			refresh_token: "foreign-namespaced-refresh",
-		});
-		writeFileSync(authPath, `${JSON.stringify(auth, null, 2)}\n`);
-		writeFileSync(
-			ledgerPath,
-			`${JSON.stringify({
-				schemaVersion: "clawdi.oauthCredentialOwnership.v2",
-				runtime: "hermes",
-				providerId: "openai-codex",
-				nativeProfileId,
-				credentialRevision: "hermes-revision-2",
-				state: "adopted",
-			})}\n`,
-		);
-		convergeRuntimeManifest(removedLoad, paths);
-		auth = JSON.parse(readFileSync(authPath, "utf8"));
-		expect(auth.credential_pool["openai-codex"]).toEqual([
-			expect.objectContaining({
-				id: nativeProfileId,
-				access_token: "foreign-namespaced-access",
-				refresh_token: "foreign-namespaced-refresh",
-			}),
-			expect.objectContaining({ id: "user-independent" }),
-		]);
-		expect(JSON.parse(readFileSync(ledgerPath, "utf8")).state).toBe("retired");
-
-		const readdedLoad: RuntimeManifestLoad = {
-			...nativeReauthenticatedLoad,
-			manifest: { ...nativeReauthenticatedLoad.manifest, generation: 4 },
-		};
-		convergeRuntimeManifest(readdedLoad, paths);
-		auth = JSON.parse(readFileSync(authPath, "utf8"));
-		expect(auth.credential_pool["openai-codex"][0]).toMatchObject({
-			id: nativeProfileId,
-			access_token: "foreign-namespaced-access",
-			refresh_token: "foreign-namespaced-refresh",
-		});
-		expect(JSON.parse(readFileSync(ledgerPath, "utf8")).state).toBe("adopted");
+		expect(existsSync(ledgerPath)).toBe(false);
 	}, 30_000);
 
 	it("uses OpenClaw provider-auth SQLite ownership without reviving logout", () => {
@@ -6068,17 +6039,6 @@ exit 0
 				},
 			},
 		};
-		writeFileSync(
-			ledgerPath,
-			`${JSON.stringify({
-				schemaVersion: "clawdi.runtimeOAuthCredential.v1",
-				runtime: "openclaw",
-				providerId: "openai-codex",
-				nativeProfileId,
-				credentialRevision: "openclaw-revision-2",
-				state: "seeded",
-			})}\n`,
-		);
 		convergeRuntimeManifest(removedLoad, paths);
 		store = JSON.parse(readFileSync(storePath, "utf8"));
 		expect(store.profiles[nativeProfileId]).toBeUndefined();
@@ -6090,54 +6050,7 @@ exit 0
 		expect(store.order?.openai ?? []).toEqual(["openai:default"]);
 		expect(store.lastGood?.openai).toBeUndefined();
 		expect(store.usageStats?.[nativeProfileId]).toBeUndefined();
-		expect(JSON.parse(readFileSync(ledgerPath, "utf8"))).toMatchObject({
-			schemaVersion: "clawdi.oauthCredentialOwnership.v2",
-			state: "retired",
-		});
-
-		store.profiles[nativeProfileId] = {
-			type: "oauth",
-			provider: "openai",
-			access: "foreign-namespaced-access",
-			refresh: "foreign-namespaced-refresh",
-		};
-		store.order.openai = [nativeProfileId, "openai:default"];
-		writeFileSync(storePath, `${JSON.stringify(store, null, 2)}\n`);
-		writeFileSync(
-			ledgerPath,
-			`${JSON.stringify({
-				schemaVersion: "clawdi.oauthCredentialOwnership.v2",
-				runtime: "openclaw",
-				providerId: "openai-codex",
-				nativeProfileId,
-				credentialRevision: "openclaw-revision-2",
-				state: "adopted",
-			})}\n`,
-		);
-		convergeRuntimeManifest(removedLoad, paths);
-		store = JSON.parse(readFileSync(storePath, "utf8"));
-		expect(store.profiles[nativeProfileId]).toMatchObject({
-			access: "foreign-namespaced-access",
-			refresh: "foreign-namespaced-refresh",
-		});
-		expect(store.profiles["openai:default"]).toMatchObject({
-			access: "native-reauth-access",
-			refresh: "native-reauth-refresh",
-		});
-		expect(store.order.openai).toEqual([nativeProfileId, "openai:default"]);
-		expect(JSON.parse(readFileSync(ledgerPath, "utf8")).state).toBe("retired");
-
-		const readdedLoad: RuntimeManifestLoad = {
-			...nativeReauthenticatedLoad,
-			manifest: { ...nativeReauthenticatedLoad.manifest, generation: 4 },
-		};
-		convergeRuntimeManifest(readdedLoad, paths);
-		store = JSON.parse(readFileSync(storePath, "utf8"));
-		expect(store.profiles[nativeProfileId]).toMatchObject({
-			access: "foreign-namespaced-access",
-			refresh: "foreign-namespaced-refresh",
-		});
-		expect(JSON.parse(readFileSync(ledgerPath, "utf8")).state).toBe("adopted");
+		expect(existsSync(ledgerPath)).toBe(false);
 		const calls = readFileSync(sdkCalls, "utf8");
 		expect(calls).toContain("ensure ");
 		expect(calls).toContain("update ");

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -6931,13 +6931,11 @@ exit 64
 		);
 
 		expect(convergence.installErrors).toEqual([]);
-		const providerHealth = JSON.parse(
-			readFileSync(getRuntimePaths().providerHealthStatus, "utf-8"),
-		);
-		expect(providerHealth.providers.openclaw.status).toBe("error");
-		expect(providerHealth.providers.openclaw.reasons).toContain("provider_error");
-		expect(providerHealth.providers.openclaw.reasons).toContain("provider_secret_unavailable");
-		expect(providerHealth.providers.openclaw.reasons).toContain("api_key_secret_ref_missing");
+		const providerHealth = readHostedRuntimeObserved(getRuntimePaths())?.providers?.openclaw;
+		expect(providerHealth?.status).toBe("error");
+		expect(providerHealth?.reasons).toContain("provider_error");
+		expect(providerHealth?.reasons).toContain("provider_secret_unavailable");
+		expect(providerHealth?.reasons).toContain("api_key_secret_ref_missing");
 	});
 
 	it("loads only the selected hosted runtime entry", async () => {
@@ -7289,7 +7287,6 @@ exit 64
 				);
 			}
 			expect(readFileSync(paths.appliedState, "utf-8")).not.toContain(runtimeAuthToken);
-			expectExistingFileNotToContain(paths.providerHealthStatus, runtimeAuthToken);
 			expect(JSON.stringify(convergence)).not.toContain(runtimeAuthToken);
 			expect(JSON.stringify(watchedConvergence)).not.toContain(runtimeAuthToken);
 		} finally {
@@ -17220,10 +17217,8 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			expect(watchUnit).not.toContain("sk-runtime");
 			expect(watchEnv).not.toContain("sk-runtime");
 			expect(readFileSync(getRuntimePaths().manifestLastGood, "utf-8")).not.toContain("sk-runtime");
-			const providerHealth = JSON.parse(
-				readFileSync(getRuntimePaths().providerHealthStatus, "utf-8"),
-			);
-			expect(providerHealth.providers["clawdi-managed-v2"]).toEqual({
+			const providerHealth = readHostedRuntimeObserved(paths)?.providers;
+			expect(providerHealth?.["clawdi-managed-v2"]).toEqual({
 				status: "ok",
 				configured: true,
 				kind: "openai-compatible",

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -58,7 +58,6 @@ import {
 } from "../src/runtime/host-policy";
 import { hostedManifestEgressProfiles } from "../src/runtime/hosted-egress-profiles";
 import { createOpenClawHostedContext } from "../src/runtime/hosted-openclaw-context";
-import { hostedOpenClawSkillDriver } from "../src/runtime/hosted-openclaw-skill";
 import { hostedAiProviderCatalog } from "../src/runtime/hosted-provider-resolution";
 import { MANAGED_BAILEYS_STATIC_PATCH_TARGETS } from "../src/runtime/managed-baileys-compat";
 import {
@@ -107,6 +106,7 @@ import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "../src/runtime/systemd-us
 import { TRANSPARENT_EGRESS_PORT } from "../src/runtime/transparent-egress";
 import { getDaemonControlTokenPath } from "../src/serve/paths";
 import {
+	ensureTestOpenClawWorkspaceCli,
 	type TestConvergeOptions,
 	withTestSystemdTransaction,
 } from "../src/test-support/systemd-apply";
@@ -237,6 +237,7 @@ function convergeRuntimeManifest(
 ) {
 	if (!process.env.CLAWDI_RUNTIME_MODE) process.env.CLAWDI_RUNTIME_MODE = "hosted";
 	if (!process.env.CLAWDI_RUNTIME_USER) process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
+	ensureTestOpenClawWorkspaceCli(load.manifest, paths);
 	ensureRuntimeStateDirs(paths);
 	const requiredSecretRefs = new Set(manifestSecretRefs(load.manifest));
 	const defaultSecretValues = Object.fromEntries(
@@ -254,10 +255,6 @@ function convergeRuntimeManifest(
 		{
 			...opts,
 			systemdApply: opts.systemdApply ? withTestSystemdTransaction(opts.systemdApply) : undefined,
-			hostedOpenClawSkillDriver: opts?.hostedOpenClawSkillDriver ?? {
-				...hostedOpenClawSkillDriver,
-				resolveWorkspace: () => join(paths.userHome, ".openclaw", "workspace"),
-			},
 			hostedRuntimeContract: opts?.hostedRuntimeContract ?? testHostedRuntimeContract(paths),
 		},
 	);
@@ -4072,9 +4069,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		const loaded = hostedManagedOpenClawV2Load(home, 1);
 		loaded.manifest.egressEngine = seedMitmproxyCache(paths);
 
-		const convergence = convergeRuntimeManifest(loaded, paths, {
-			hostedOpenClawSkillDriver,
-		});
+		const convergence = convergeRuntimeManifest(loaded, paths);
 
 		expect(convergence.installErrors).toEqual([]);
 		const commands = readFileSync(commandLog, "utf8").trim().split("\n");
@@ -4095,7 +4090,6 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		writeFileSync(configPath, '{"legacyInvalidConfig":true}\n');
 		writeFileSync(database, "preserve\n");
 		convergeRuntimeManifest(loaded, paths, {
-			hostedOpenClawSkillDriver,
 			commitAuthority: () => {
 				throw new Error("late authority failure");
 			},
@@ -16472,7 +16466,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		mkdirSync(home, { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_RUNTIME_USER = "clawdi";
+		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		const mitmproxy = seedMitmproxyCache();
@@ -16568,11 +16562,11 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		expect(userUnitNames).not.toContain("clawdi-runtime-sidecar.service");
 		expect(systemUnitNames).toContain("clawdi-runtime-sidecar.service");
 		expect(runtimeSidecarUnit).toContain(`ExecStart="${paths.cliManagedBin}" "runtime" "sidecar"`);
-		expect(runtimeSidecarUnit).toContain("Before=user@10001.service");
+		expect(runtimeSidecarUnit).toContain(`Before=user@${TEST_PROCESS_UID}.service`);
 		expect(runtimeSidecarEnv).toContain(`CLAWDI_EGRESS_ENV_FILE="${paths.egressTransparentEnv}"`);
-		expect(transparentEgressEnv).toContain('CLAWDI_RUNTIME_USER="clawdi"');
-		expect(transparentEgressEnv).toContain('CLAWDI_RUNTIME_UID="10001"');
-		expect(transparentEgressEnv).toContain('CLAWDI_RUNTIME_GID="10001"');
+		expect(transparentEgressEnv).toContain(`CLAWDI_RUNTIME_USER="${TEST_PROCESS_USER}"`);
+		expect(transparentEgressEnv).toContain(`CLAWDI_RUNTIME_UID="${TEST_PROCESS_UID}"`);
+		expect(transparentEgressEnv).toContain(`CLAWDI_RUNTIME_GID="${TEST_PROCESS_GID}"`);
 		expect(transparentEgressEnv).toContain('CLAWDI_EGRESS_UID="10002"');
 		expect(transparentEgressEnv).toContain('CLAWDI_EGRESS_GID="10002"');
 		expect(transparentEgressEnv).toContain('CLAWDI_EGRESS_NFT_TABLE="clawdi_transparent_egress"');
@@ -16672,7 +16666,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		mkdirSync(home, { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_RUNTIME_USER = "clawdi";
+		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		const mitmproxy = seedMitmproxyCache();
@@ -16723,7 +16717,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		const openclawUnit = readSystemdUserServiceConfig(paths, "openclaw-gateway");
 		const openclawEnv = readSystemdEnvFile(paths, "openclaw-gateway");
 		expect(sidecarUnit).toContain("Type=notify");
-		expect(sidecarUnit).toContain("Before=user@10001.service");
+		expect(sidecarUnit).toContain(`Before=user@${TEST_PROCESS_UID}.service`);
 		expect(sidecarUnit).toContain(`ExecStart="${paths.cliManagedBin}" "runtime" "sidecar"`);
 		expect(sidecarEnv).toContain(`CLAWDI_EGRESS_ENV_FILE="${paths.egressTransparentEnv}"`);
 		expect(transparentEgressEnv).toContain(
@@ -16733,8 +16727,8 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			`CLAWDI_EGRESS_TRANSPARENT_PORT="${TRANSPARENT_EGRESS_PORT}"`,
 		);
 		expect(transparentEgressEnv).toContain('CLAWDI_EGRESS_NFT_TABLE="clawdi_transparent_egress"');
-		expect(transparentEgressEnv).toContain('CLAWDI_RUNTIME_UID="10001"');
-		expect(transparentEgressEnv).toContain('CLAWDI_RUNTIME_GID="10001"');
+		expect(transparentEgressEnv).toContain(`CLAWDI_RUNTIME_UID="${TEST_PROCESS_UID}"`);
+		expect(transparentEgressEnv).toContain(`CLAWDI_RUNTIME_GID="${TEST_PROCESS_GID}"`);
 		expect(transparentEgressEnv).toContain('CLAWDI_EGRESS_UID="10002"');
 		expect(transparentEgressEnv).toContain('CLAWDI_EGRESS_GID="10002"');
 		expect(sidecarEnv).toContain(


### PR DESCRIPTION
## Summary

- Remove the remaining pre-ledger Skill Hub paths and fallback targets while keeping malformed legacy ledger entries isolated to their individual records.
- Collapse hosted Skill delivery to one small driver record per runtime and let manifest apply consume those records directly.
- Delete the legacy OAuth receipt migration, retire active ownership by deleting the ledger, and consume pre-upgrade retired tombstones at the read boundary.
- Centralize hosted-mode detection, remove redundant Skill guards, and use structured identity checks and shared failure handling.
- Derive provider health once from the manifest provider contract instead of writing and rereading provider-health.json.
- Route hosted OpenClaw provider mutation exclusively through the pinned official installer public config-mutation SDK export, remove the one-time Codex shim cleanup, and unify runtime/service environment projection.
- Remove project endpoint path self-checking while retaining the control-plane origin boundary; retain the legacy single-file hash fallback until pre-2026-04-28 project Skill hashes are backfilled.

The Agent Plugin proof, probe, canary, and Hermes canary paths remain unchanged for the phase 3 follow-up. The Codex shim cleanup deletion and retired-to-upsert semantics remain accepted. This branch is rebased on main after #1182, #1184, #1185, and #1186 and does not recreate the retired receipt subsystem.

## Deletion evidence

- 29 existing files changed; no files added
- Source: 278 insertions, 748 deletions, net deletion 470 lines
- Tests and test support: 334 insertions, 935 deletions, net deletion 601 lines
- Total: 612 insertions, 1,683 deletions, net deletion 1,071 lines
- Hub cleanup: net -206
- Skill driver collapse: net -238
- OAuth cleanup: net -175
- Skill reconciliation guard cleanup: net -2
- Provider health derivation: net -126
- Provider mutation standardization: net -324

## Added

Every added block replaces a larger implementation or restores a required released-data boundary; this PR adds no environment variable, feature flag, production test hook, optional assertion, or anti-regression grep.

- Compact `{ skillsRoot, activate, exclude }` runtime driver records and shared target/failure helpers replace the Hermes/OpenClaw driver interfaces, forwarding adapters, optional target fallbacks, repeated ownership checks, and repeated error wrappers.
- Per-entry reservation parsing replaces whole-ledger rejection for malformed legacy entries while preserving fail-closed top-level ledger parsing.
- One retired-tombstone cleanup at the OAuth ledger read boundary replaces the removed live retired state and migration path; current retirement still deletes the ledger.
- The exported `providerHealthReasons` implementation replaces the drifted observation fallback and the provider-health file writer; there is one derivation path.
- One overloaded runtime environment merge replaces the separate runtime and service merge implementations.
- The official config-mutation SDK resolver/caller replaces the CLI config-patch branch and the one-time legacy command shim cleanup.
- Temporary-HOME OpenClaw roster and config-mutation fixtures replace removed production driver injection options and the older patch-command harness; affected test code remains net-deleted.
- The retained origin comparison replaces the removed endpoint path-regex self-check without weakening runtime-token confinement.

## Persisted state removed or changed

| Item | What 0.13.92 wrote | What 0.14.14 wrote | First convergence in this PR | Test |
| --- | --- | --- | --- | --- |
| OAuth retired tombstone | `clawdi.oauthCredentialOwnership.v2` with `state: "retired"` after ChatGPT disconnect or provider replacement. | The same v2 retired tombstone. | The read boundary deletes the tombstone and treats ownership as absent; future retirement deletes the ledger file instead of writing a tombstone. | Existing runtime reconciliation coverage seeds a retired provider ledger, completes convergence, and verifies that the file disappears. |
| Legacy OAuth receipt v1 | Nothing new; only 0.13.23-0.13.28 wrote `clawdi.runtimeOAuthCredential.v1`, while 0.13.92 still parsed and migrated it to v2. | Nothing new; the legacy parser/migration remained available. | The v2-only parse rejects the file, so that runtime's OAuth reconciliation fails and leaves it untouched. This is not the fleet-wide P0 caused by v2 retired tombstones. | Legacy migration tests were removed with the migration; `oauth-credential-ledger.test.ts` retains current v2 round-trip coverage. |
| Legacy hosted Skill ledger path | No new writes; retained fallback read/delete handling for the pre-0.13.55 `/etc/clawdi/projections/managed-skills.json` path. | No new writes; retained the same fallback cleanup. | The old path is neither read nor deleted. Any residual file remains in place but inert; only the managed-resource ledger is authoritative. | Old-path migration tests were removed with the fallback; canonical ledger reconciliation coverage remains. |
| `status/provider-health.json` | `clawdi.hostedRuntimeProviderHealth.v1` derived during convergence. | The same health snapshot. | The file is no longer written, read, or deleted; an existing file remains in place but is ignored. Observation derives health from last-good provider state and the secret cache. | Runtime observation tests cover available and unavailable provider secret references without exposing secret values. |
| Hub-era Skill ledger entry with `basename(target) != id` | Could retain a hosted sourced reservation accepted by the Hub-era target rules. | Could retain the same legacy entry. | The malformed entry is warned and skipped without rejecting the rest of the ledger; new mismatched entries are not written. | Existing malformed-reservation coverage verifies per-entry isolation. |
| Pre-2026-04-28 project Skill single-file hash | A project Skill could carry `content_hash = sha256(SKILL.md)` from the control plane. | The same record could remain without tree-hash backfill. | Archive validation still accepts the legacy single-file hash fallback, marked for removal after control-plane backfill. | `hosted-sourced-skill-archive.test.ts` retains the legacy single-file hash case. |

## Verification

All JavaScript/TypeScript verification ran in clean, task-scoped containers with temporary HOME and caches.

- `scripts/test.sh cli`
  - Bun 1.4.0 CLI typecheck passed
  - 1,749 passed, 4 skipped, 0 failed across 136 files
- `bun run check`
  - 1,072 files checked, no fixes
- `scripts/test-runtime-official-installer-systemd.sh`
  - 9 passed, 0 failed, 413 assertions in one fresh privileged container
  - Covers virgin Hermes/OpenClaw boot, installer rollback as UID 10001, public SDK provider mutation, live gateway token, Files tenant isolation, Hermes ownership repair, last-good replay, and write-side crash recovery
- `git diff --check origin/main...HEAD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
