### PR TITLE
Simplify managed CLI upgrade state

### DIFF
--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -172,8 +172,6 @@ interface RuntimeApplyOptions {
 		authority: RuntimePrivateAppliedAuthority,
 	) => void;
 	continueOnCliUpdateError?: boolean;
-	deferCliInstall?: boolean;
-	deferCliInstallReason?: string;
 	recoverFailedSystemdUnits?: boolean;
 	requireSystemdApplied?: boolean;
 	preparedHostedSourcedSkills?: ReadonlyMap<string, PreparedHostedSkill>;
@@ -195,8 +193,6 @@ interface RuntimeWatchFailureBackoff {
 
 interface RuntimeWatchTickOptions {
 	forceRefresh: boolean;
-	deferCliInstall?: boolean;
-	deferCliInstallReason?: string;
 	recoverFailedSystemdUnits?: boolean;
 	failureBackoff?: RuntimeWatchFailureBackoff;
 	now: number;
@@ -1101,8 +1097,6 @@ async function runtimeWatchTickAfterCliReconciliation(
 		failureEtag = bundleEtag;
 		const applyResult = await applyRuntimeManifestLoad(loaded, paths, {
 			continueOnCliUpdateError: true,
-			deferCliInstall: opts.deferCliInstall,
-			deferCliInstallReason: opts.deferCliInstallReason,
 			recoverFailedSystemdUnits: opts.recoverFailedSystemdUnits,
 			hostedRuntimeContract: opts.hostedRuntimeContract,
 		});
@@ -1298,8 +1292,6 @@ async function applyRuntimeDesiredState(
 		let cliUpdate: RuntimeCliUpdateResult;
 		try {
 			cliUpdate = applyRuntimeCliDesiredState(load.manifest, paths, {
-				deferInstall: opts.deferCliInstall,
-				deferReason: opts.deferCliInstallReason,
 				runningVersion: ACTIVE_CLI_VERSION,
 			});
 		} catch (error) {
@@ -1308,6 +1300,12 @@ async function applyRuntimeDesiredState(
 				kind: "cli_update_failed",
 				cliUpdate: runtimeCliUpdateError(load.manifest, paths, error),
 			};
+		}
+		if (cliUpdate.status === "error") {
+			if (!opts.continueOnCliUpdateError) {
+				throw new Error(cliUpdate.error ?? "CLI update failed");
+			}
+			return { kind: "cli_update_failed", cliUpdate };
 		}
 		if (cliUpdate.selfReexec) {
 			return { kind: "cli_handoff", cliUpdate };
@@ -1524,6 +1522,7 @@ function runtimeCliUpdateError(
 		activePath: paths.cliManagedBin,
 		activeTarget: null,
 		version: null,
+		retryAt: null,
 		selfReexec: false,
 		error: toErrorMessage(error),
 	};
@@ -1563,8 +1562,6 @@ export async function runtimeWatch(opts: RuntimeWatchOptions = {}) {
 	const mode = detectRuntimeMode();
 	const intervalMs = parsePositiveMs(opts.intervalMs, RUNTIME_WATCH_INTERVAL_MS, "--interval-ms");
 	const selfHealMs = parsePositiveMs(opts.selfHealMs, RUNTIME_WATCH_SELF_HEAL_MS, "--self-heal-ms");
-	let cliInstallRetryPending = false;
-	let cliInstallBackoffMs = 0;
 	let nextCliInstallRetryAt = 0;
 	let failureBackoff: RuntimeWatchFailureBackoff | null = null;
 	const wakeSignal = createRuntimeWatchWakeSignal();
@@ -1633,8 +1630,7 @@ export async function runtimeWatch(opts: RuntimeWatchOptions = {}) {
 		for (;;) {
 			if (opts.abort?.aborted) return;
 			const tickNow = Date.now();
-			const cliInstallRetryDue = cliInstallRetryPending && tickNow >= nextCliInstallRetryAt;
-			const deferCliInstall = cliInstallRetryPending && !cliInstallRetryDue;
+			const cliInstallRetryDue = nextCliInstallRetryAt > 0 && tickNow >= nextCliInstallRetryAt;
 			const failureRetryDue = failureBackoff !== null && tickNow >= failureBackoff.nextRetryAt;
 			// Full refreshes also re-resolve floating CLI channels when manifest ETags are unchanged.
 			const forceRefresh =
@@ -1647,15 +1643,11 @@ export async function runtimeWatch(opts: RuntimeWatchOptions = {}) {
 					forceRefresh,
 					applyContext,
 					hostedRuntimeContract: opts.hostedRuntimeContract,
-					deferCliInstall,
 					failureBackoff: failureBackoff ?? undefined,
 					now: tickNow,
 					// Conditional retries run every 15 seconds. Recover failed units
 					// only on the five-minute full refresh, or once in one-shot mode.
 					recoverFailedSystemdUnits: forceRefresh || opts.once === true,
-					deferCliInstallReason: deferCliInstall
-						? `CLI install retry is in backoff until ${new Date(nextCliInstallRetryAt).toISOString()}`
-						: undefined,
 				});
 			} catch (error) {
 				const message = toErrorMessage(error);
@@ -1669,17 +1661,14 @@ export async function runtimeWatch(opts: RuntimeWatchOptions = {}) {
 			}
 			if (event !== null) {
 				const cliUpdateStatus = runtimeWatchCliUpdateStatus(event);
-				if (cliUpdateStatus === "error") {
-					cliInstallRetryPending = true;
-					cliInstallBackoffMs = nextBoundedBackoffMs(cliInstallBackoffMs);
-					nextCliInstallRetryAt = Date.now() + cliInstallBackoffMs;
+				const cliRetryAt = runtimeWatchCliRetryAt(event);
+				if (cliRetryAt !== null) {
+					nextCliInstallRetryAt = cliRetryAt;
 				} else if (
 					cliUpdateStatus === "installed" ||
 					cliUpdateStatus === "current" ||
 					cliUpdateStatus === "not_requested"
 				) {
-					cliInstallRetryPending = false;
-					cliInstallBackoffMs = 0;
 					nextCliInstallRetryAt = 0;
 				}
 				if (event.status === "error" && event.stage !== "cli-update") {
@@ -1729,6 +1718,15 @@ function runtimeWatchCliUpdateStatus(
 		return status;
 	}
 	return null;
+}
+
+function runtimeWatchCliRetryAt(event: Record<string, unknown>): number | null {
+	const cliUpdate = event.cliUpdate;
+	if (!cliUpdate || typeof cliUpdate !== "object" || Array.isArray(cliUpdate)) return null;
+	const retryAt = (cliUpdate as Record<string, unknown>).retryAt;
+	if (typeof retryAt !== "string") return null;
+	const timestamp = Date.parse(retryAt);
+	return Number.isFinite(timestamp) ? timestamp : null;
 }
 
 function nextBoundedBackoffMs(previousMs: number): number {

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -1,5 +1,4 @@
 import { type SpawnSyncReturns, spawnSync } from "node:child_process";
-import { randomUUID } from "node:crypto";
 import {
 	accessSync,
 	constants,
@@ -33,19 +32,36 @@ export interface RuntimeCliUpdateResult {
 	activePath: string;
 	activeTarget: string | null;
 	version: string | null;
+	retryAt: string | null;
 	// The active managed target no longer matches the code in this process.
 	// Callers must stop before manifest convergence or any authority side effect.
 	selfReexec: boolean;
 	error?: string | null;
 }
 
-interface RuntimeCliBadVersion {
-	packageSpec: string;
-	registry: string | null;
-	version: string;
-	reason: string;
-	markedAt?: string;
+export interface RuntimeCliRollbackResult {
+	status: "not_pending" | "rolled_back" | "error";
+	version: string | null;
+	previousVersion: string | null;
+	activeTarget: string | null;
+	previousActiveTarget: string | null;
+	error?: string | null;
 }
+
+export interface RuntimeCliReconciliationResult {
+	status: "unchanged" | "rolled_back";
+	selfReexec: boolean;
+}
+
+const NPM_REGISTRY = "https://registry.npmjs.org";
+const NPM_INSTALL_TIMEOUT_MS = 180_000;
+const VERSION_SMOKE_TIMEOUT_MS = 20_000;
+const RUNTIME_VERIFY_TIMEOUT_MS = 20_000;
+const CLI_VERIFY_CACHE_MAX_AGE_MS = 300_000;
+const CLI_RETRY_INITIAL_BACKOFF_MS = 60_000;
+const CLI_RETRY_MAX_BACKOFF_MS = 3_600_000;
+const HOSTED_TENANT_PATH_CLI = "/usr/local/bin/clawdi";
+const HOSTED_SYSTEM_NPM_CLI = "/usr/local/lib/node_modules/clawdi/bin/clawdi.mjs";
 
 const runtimeCliVerificationSchema = z
 	.object({
@@ -59,64 +75,73 @@ const runtimeCliVerificationSchema = z
 
 type RuntimeCliVerification = z.infer<typeof runtimeCliVerificationSchema>;
 
-const runtimeCliBootstrapStatusSchema = z
+const runtimeCliTargetSchema = z
 	.object({
-		schemaVersion: z.literal("clawdi.cliNpmBootstrapStatus.v1").optional(),
-		generatedAt: z.string().min(1).optional(),
+		activeTarget: z.string().min(1),
+		version: z.string().min(1),
+	})
+	.strict();
+
+type RuntimeCliTarget = z.infer<typeof runtimeCliTargetSchema>;
+
+const runtimeCliBadSchema = z
+	.object({
+		version: z.string().min(1),
+		reason: z.string().min(1),
+		attempts: z.number().int().positive(),
+		failedAt: z.string().min(1),
+		retryAt: z.string().min(1),
+	})
+	.strict();
+
+type RuntimeCliBad = z.infer<typeof runtimeCliBadSchema>;
+
+const cliBootstrapV1Schema = z
+	.object({
+		schemaVersion: z.literal("clawdi.cliNpmBootstrapStatus.v1"),
+		generatedAt: z.string().min(1),
+		status: z.literal("installed"),
+		source: z.literal("npm"),
+		packageSpec: z.string().min(1),
+		registry: z.string().min(1).nullable(),
+		npmPrefix: z.string().min(1),
+		npmCache: z.string().min(1),
+		activePath: z.string().min(1),
+		activeTarget: z.string().min(1),
+		version: z.string().min(1),
+		verification: runtimeCliVerificationSchema.optional(),
+		error: z.string().nullable(),
+	})
+	.strict();
+
+const runtimeCliBootstrapStatusSchema = cliBootstrapV1Schema
+	.partial()
+	.extend({
 		status: z.string().optional(),
 		source: z.string().optional(),
-		packageSpec: z.string().optional(),
-		registry: z.string().nullable().optional(),
-		npmPrefix: z.string().optional(),
-		npmCache: z.string().optional(),
-		activePath: z.string().optional(),
-		activeTarget: z.string().optional(),
-		version: z.string().optional(),
-		verification: runtimeCliVerificationSchema.optional(),
-		error: z.string().nullable().optional(),
+		verification: runtimeCliVerificationSchema.loose().optional(),
+		previous: runtimeCliTargetSchema.loose().nullable().optional(),
+		bad: runtimeCliBadSchema.loose().nullable().optional(),
 	})
 	.loose();
 
 export type RuntimeCliBootstrapStatus = z.infer<typeof runtimeCliBootstrapStatusSchema>;
 
-type RuntimeCliInstallIdentity = Required<
-	Pick<
-		RuntimeCliBootstrapStatus,
-		"packageSpec" | "registry" | "npmPrefix" | "activeTarget" | "version"
-	>
->;
+const runtimeCliStateSchema = cliBootstrapV1Schema
+	.extend({
+		packageSpec: hostedCliPackageSpecSchema,
+		registry: z.literal(NPM_REGISTRY),
+		verification: runtimeCliVerificationSchema,
+		previous: runtimeCliTargetSchema.nullable(),
+		bad: runtimeCliBadSchema.nullable(),
+	})
+	.strict();
 
-interface RuntimeCliUpgradeTransaction {
-	phase: "prepared" | "activated";
-	previousIdentity: RuntimeCliInstallIdentity | null;
-	newIdentity: RuntimeCliInstallIdentity;
-	rollbackEligible: boolean;
-	installedAt: string;
-	rollback: { reason: string; markedAt: string } | null;
+type RuntimeCliState = z.infer<typeof runtimeCliStateSchema>;
+
+interface VerifiedCliTarget extends RuntimeCliTarget {
+	verification: RuntimeCliVerification;
 }
-
-interface RuntimeCliUpgradeState {
-	schemaVersion?: string;
-	transaction?: RuntimeCliUpgradeTransaction | null;
-	badVersions?: RuntimeCliBadVersion[];
-}
-
-export interface RuntimeCliRollbackResult {
-	status: "not_pending" | "rolled_back" | "error";
-	version: string | null;
-	previousVersion: string | null;
-	activeTarget: string | null;
-	previousActiveTarget: string | null;
-	error?: string | null;
-}
-
-const NPM_INSTALL_TIMEOUT_MS = 180_000;
-const VERSION_SMOKE_TIMEOUT_MS = 20_000;
-const RUNTIME_VERIFY_TIMEOUT_MS = 20_000;
-const CLI_VERIFY_CACHE_MAX_AGE_MS = 300_000;
-const CLI_BAD_VERSION_TTL_MS = 60 * 60 * 1000;
-const HOSTED_TENANT_PATH_CLI = "/usr/local/bin/clawdi";
-const HOSTED_SYSTEM_NPM_CLI = "/usr/local/lib/node_modules/clawdi/bin/clawdi.mjs";
 
 export function removeHostedCliPathExposure(paths: RuntimePaths): void {
 	if (
@@ -146,185 +171,96 @@ export function removeHostedCliPathExposure(paths: RuntimePaths): void {
 	rmSync(HOSTED_TENANT_PATH_CLI);
 }
 
-interface RuntimeCliReconciliationOptions {
-	runningVersion?: string;
-}
-
-export interface RuntimeCliReconciliationResult {
-	status: "unchanged" | "activated" | "rolled_back";
-	selfReexec: boolean;
-}
-
-const cliInstallIdentityStateSchema = z
-	.object({
-		packageSpec: z.string().min(1),
-		registry: z.string().min(1).nullable(),
-		npmPrefix: z.string().min(1),
-		activeTarget: z.string().min(1),
-		version: z.string().min(1),
-	})
-	.strict();
-
-const cliBadVersionStateSchema = z
-	.object({
-		packageSpec: z.string().min(1),
-		registry: z.string().min(1).nullable(),
-		version: z.string().min(1),
-		reason: z.string(),
-		markedAt: z.string().min(1).optional(),
-	})
-	.strict();
-
-const cliUpgradeTransactionStateSchema = z
-	.object({
-		phase: z.enum(["prepared", "activated"]),
-		previousIdentity: cliInstallIdentityStateSchema.nullable(),
-		newIdentity: cliInstallIdentityStateSchema,
-		rollbackEligible: z.boolean(),
-		installedAt: z.string().min(1),
-		rollback: z
-			.object({ reason: z.string(), markedAt: z.string().min(1) })
-			.strict()
-			.nullable(),
-	})
-	.strict();
-
-const cliUpgradeStateV2Schema = z
-	.object({
-		schemaVersion: z.literal("clawdi.cliUpgradeState.v2"),
-		transaction: cliUpgradeTransactionStateSchema.nullable(),
-		badVersions: z.array(cliBadVersionStateSchema),
-	})
-	.strict();
-
 export function applyRuntimeCliDesiredState(
 	manifest: RuntimeManifest,
 	paths: RuntimePaths,
-	opts: {
-		deferInstall?: boolean;
-		deferReason?: string;
-		runningVersion?: string;
-	} = {},
+	opts: { runningVersion?: string } = {},
 ): RuntimeCliUpdateResult {
-	const reconciliation = reconcileCliUpgradeTransaction(paths, opts);
+	const reconciliation = reconcilePendingRuntimeCliUpgrade(paths, opts.runningVersion);
+	const packageSpec = manifest.clawdiCli?.packageSpec?.trim() || null;
 	if (reconciliation.selfReexec) {
-		const status = readRuntimeCliBootstrapStatus(paths);
-		return baseResult(
+		return resultFromState(
 			"deferred",
 			paths,
-			{
-				packageSpec: manifest.clawdiCli?.packageSpec?.trim() || null,
-				registry: status?.registry ?? null,
-				npmPrefix: status?.npmPrefix ?? paths.cliNpmPrefix,
-				activeTarget: status?.activeTarget ?? null,
-				version: status?.version ?? null,
-				error: `CLI transaction recovery ${reconciliation.status}; re-exec is required`,
-			},
+			readCliState(paths),
+			packageSpec,
+			"CLI recovery changed the active version; re-exec is required",
 			true,
 		);
 	}
-	const packageSpec = manifest.clawdiCli?.packageSpec?.trim();
-	if (!packageSpec) {
-		return baseResult("not_requested", paths, {
-			packageSpec: null,
-			registry: null,
-			activeTarget: null,
-			version: null,
-		});
+	if (!packageSpec) return baseResult("not_requested", paths, emptyResultValues());
+
+	const desiredVersion = exactNpmPackageVersion(packageSpec);
+	if (!desiredVersion) {
+		throw new Error(`clawdi CLI packageSpec must be clawdi@<exact-semver>: ${packageSpec}`);
 	}
-	validatePackageSpec(packageSpec);
-	const registry = cliRegistry(manifest);
-	const current = readRuntimeCliBootstrapStatus(paths);
-	if (isCurrentCliInstall(current, paths, packageSpec, registry)) {
-		return baseResult("current", paths, {
-			packageSpec,
-			registry,
-			npmPrefix: current.npmPrefix ?? prefixForActiveTarget(current.activeTarget),
-			activeTarget: current.activeTarget ?? null,
-			version: current.version ?? null,
-		});
+	validateRegistry(manifest.clawdiCli?.registry);
+	const status = readRuntimeCliBootstrapStatus(paths);
+	let state = parseCliState(paths, status);
+	const retainedBad = state?.bad ?? null;
+	if (
+		state?.version === desiredVersion &&
+		activeLinkTarget(paths.cliManagedBin) === state.activeTarget
+	) {
+		return resultFromState("current", paths, state, packageSpec);
 	}
-	const recovered = recoverCurrentCliInstallFromActiveLink(paths, packageSpec);
-	if (recovered) {
-		writeCliBootstrapStatus(
-			paths,
-			{
-				packageSpec,
-				registry,
-				npmPrefix: recovered.npmPrefix,
-				activeTarget: recovered.activeTarget,
-				version: recovered.version,
-			},
-			recovered.verification,
-		);
-		return baseResult("current", paths, {
-			packageSpec,
-			registry,
-			npmPrefix: recovered.npmPrefix,
-			activeTarget: recovered.activeTarget,
-			version: recovered.version,
-		});
-	}
-	if (opts.deferInstall) {
+	if (retainedBad?.version === desiredVersion && badVersionIsActive(retainedBad)) {
 		return baseResult("deferred", paths, {
 			packageSpec,
-			registry,
-			npmPrefix: current?.npmPrefix ?? paths.cliNpmPrefix,
-			activeTarget: current?.activeTarget ?? null,
-			version: current?.version ?? null,
-			error: opts.deferReason ?? "CLI install retry is in backoff",
+			registry: NPM_REGISTRY,
+			npmPrefix: state?.npmPrefix ?? paths.cliNpmPrefix,
+			activeTarget: state?.activeTarget ?? null,
+			version: state?.version ?? null,
+			retryAt: retainedBad.retryAt,
+			error: `clawdi CLI ${desiredVersion} retry is deferred until ${retainedBad.retryAt}`,
 		});
 	}
 
-	const previousIdentity = lastGoodCliIdentity(paths, current);
-	if (
-		previousIdentity &&
-		activeLinkTarget(paths.cliManagedBin) === previousIdentity.activeTarget &&
-		(current?.status !== "installed" ||
-			current.source !== "npm" ||
-			current.packageSpec !== previousIdentity.packageSpec ||
-			(current.registry ?? null) !== previousIdentity.registry ||
-			current.npmPrefix !== previousIdentity.npmPrefix ||
-			current.activePath !== paths.cliManagedBin ||
-			current.activeTarget !== previousIdentity.activeTarget ||
-			current.version !== previousIdentity.version)
-	) {
-		const verification = verifyStoredCliIdentity(paths, previousIdentity);
-		if (!verification) throw new Error("active clawdi CLI changed during verification");
-		writeCliBootstrapStatus(paths, previousIdentity, verification);
+	let installed: VerifiedCliTarget;
+	try {
+		installed = installCliPackage(paths, packageSpec);
+	} catch (error) {
+		const reason = toErrorMessage(error);
+		const bad = markBadVersion(retainedBad, desiredVersion, reason);
+		if (state) writeCliState(paths, activeFromState(state), state.previous, bad);
+		pruneCliPackagePrefixes(paths, state ? [state.npmPrefix, prefixForTarget(state.previous)] : []);
+		return baseResult("error", paths, {
+			packageSpec,
+			registry: NPM_REGISTRY,
+			npmPrefix: state?.npmPrefix ?? paths.cliNpmPrefix,
+			activeTarget: state?.activeTarget ?? activeLinkTarget(paths.cliManagedBin),
+			version: state?.version ?? null,
+			retryAt: bad.retryAt,
+			error: reason,
+		});
 	}
-	const installed = installCliPackage(paths, packageSpec, registry);
-	prepareCliUpgradeTransaction(paths, {
-		newIdentity: {
-			packageSpec,
-			registry,
-			npmPrefix: installed.npmPrefix,
-			activeTarget: installed.activeTarget,
-			version: installed.version,
-		},
-		previousIdentity,
-	});
+
+	state = readCliState(paths);
+	const previous = state?.previous ?? (state ? targetFromState(state) : null);
 	swapActiveCli(paths.cliManagedBin, installed.activeTarget);
-	writeCliBootstrapStatus(
-		paths,
-		{
-			packageSpec,
-			registry,
-			npmPrefix: installed.npmPrefix,
-			activeTarget: installed.activeTarget,
-			version: installed.version,
-		},
-		installed.verification,
-	);
-	activateCliUpgradeTransaction(paths);
-	pruneCliPackagePrefixes(paths, [installed.npmPrefix, previousIdentity?.npmPrefix ?? null]);
+	try {
+		writeCliState(
+			paths,
+			installed,
+			previous,
+			state?.bad?.version === installed.version ? state.bad : null,
+		);
+	} catch (error) {
+		if (state) swapActiveCli(paths.cliManagedBin, state.activeTarget);
+		else rmSync(paths.cliManagedBin, { force: true });
+		throw error;
+	}
+	pruneCliPackagePrefixes(paths, [
+		prefixForActiveTarget(installed.activeTarget),
+		prefixForTarget(previous),
+	]);
 	return baseResult(
 		"installed",
 		paths,
 		{
 			packageSpec,
-			registry,
-			npmPrefix: installed.npmPrefix,
+			registry: NPM_REGISTRY,
+			npmPrefix: prefixForActiveTarget(installed.activeTarget),
 			activeTarget: installed.activeTarget,
 			version: installed.version,
 		},
@@ -332,11 +268,126 @@ export function applyRuntimeCliDesiredState(
 	);
 }
 
+export function rollbackPendingRuntimeCliUpgrade(
+	paths: RuntimePaths,
+	reason: string,
+): RuntimeCliRollbackResult {
+	const before = readCliState(paths);
+	try {
+		const reconciliation = reconcilePendingRuntimeCliUpgrade(paths);
+		if (reconciliation.status === "rolled_back" && before?.previous) {
+			return rollbackResult(before, "rolled_back");
+		}
+		const state = readCliState(paths);
+		if (!state?.previous) return rollbackResult(state, "not_pending");
+		rollbackToPrevious(paths, state, reason);
+		return rollbackResult(state, "rolled_back");
+	} catch (error) {
+		return rollbackResult(before, "error", toErrorMessage(error));
+	}
+}
+
+export function completePendingRuntimeCliUpgrade(
+	paths: RuntimePaths,
+	currentVersion: string,
+): RuntimeCliReconciliationResult {
+	const reconciliation = reconcilePendingRuntimeCliUpgrade(paths, currentVersion);
+	if (reconciliation.selfReexec) return reconciliation;
+	const state = readCliState(paths);
+	if (
+		state?.previous &&
+		state.version === currentVersion &&
+		activeLinkTarget(paths.cliManagedBin) === state.activeTarget
+	) {
+		writeCliState(
+			paths,
+			activeFromState(state),
+			null,
+			state.bad?.version === state.version ? null : state.bad,
+		);
+		pruneCliPackagePrefixes(paths, [state.npmPrefix]);
+	}
+	return reconciliation;
+}
+
+export function reconcilePendingRuntimeCliUpgrade(
+	paths: RuntimePaths,
+	runningVersion?: string,
+): RuntimeCliReconciliationResult {
+	discardLegacyUpgradeState(paths);
+	const status = readRuntimeCliBootstrapStatus(paths);
+	let state = parseCliState(paths, status);
+	const activeTarget = activeLinkTarget(paths.cliManagedBin);
+	if (!state) {
+		if (!activeTarget) return { status: "unchanged", selfReexec: false };
+		const recovered = requireVerifiedCliTarget(paths, { activeTarget });
+		writeCliState(paths, recovered, null, null);
+		pruneCliPackagePrefixes(paths, [prefixForActiveTarget(recovered.activeTarget)]);
+		return reconciliationResult("unchanged", recovered.version, runningVersion);
+	}
+
+	if (activeTarget !== state.activeTarget) {
+		const fallback = state.previous ?? activeFromState(state);
+		const verifiedFallback = requireVerifiedCliTarget(paths, fallback);
+		if (activeTarget !== verifiedFallback.activeTarget) {
+			swapActiveCli(paths.cliManagedBin, verifiedFallback.activeTarget);
+		}
+		const bad = state.previous
+			? markBadVersion(
+					state.bad,
+					state.version,
+					"recovered interrupted or inconsistent clawdi CLI activation",
+				)
+			: state.bad;
+		writeCliState(paths, verifiedFallback, null, bad);
+		pruneCliPackagePrefixes(paths, [prefixForActiveTarget(verifiedFallback.activeTarget)]);
+		return reconciliationResult("rolled_back", verifiedFallback.version, runningVersion);
+	}
+
+	const verifiedActive = tryVerifyCliTarget(paths, activeFromState(state), state);
+	if (!verifiedActive) {
+		if (!state.previous)
+			throw new Error("active clawdi CLI is not verifiable and has no rollback target");
+		rollbackToPrevious(paths, state, "active clawdi CLI failed recovery verification");
+		state = readCliState(paths);
+		return reconciliationResult("rolled_back", state?.version, runningVersion);
+	}
+	if (
+		!verificationIdentityMatches(state.verification, verifiedActive.verification) ||
+		state.verification.verifiedAt !== verifiedActive.verification.verifiedAt
+	) {
+		writeCliState(paths, verifiedActive, state.previous, state.bad);
+	}
+	return reconciliationResult(
+		"unchanged",
+		verifiedActive.version,
+		runningVersion,
+		state.previous !== null,
+	);
+}
+
+export function readRuntimeCliBootstrapStatus(
+	paths: RuntimePaths,
+): RuntimeCliBootstrapStatus | null {
+	if (!existsSync(paths.cliBootstrapStatus)) return null;
+	try {
+		return runtimeCliBootstrapStatusSchema.parse(
+			JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8")),
+		);
+	} catch (error) {
+		log.warn("runtime.cli_bootstrap_status_invalid", {
+			path: paths.cliBootstrapStatus,
+			error: toErrorMessage(error),
+		});
+		return null;
+	}
+}
+
 type RuntimeCliResultValues = Pick<
 	RuntimeCliUpdateResult,
 	"packageSpec" | "registry" | "activeTarget" | "version"
 > &
-	Partial<Pick<RuntimeCliUpdateResult, "npmPrefix" | "npmCache" | "error">>;
+	Partial<Pick<RuntimeCliUpdateResult, "npmPrefix" | "npmCache" | "retryAt" | "error">>;
 
 function baseResult(
 	status: RuntimeCliUpdateResult["status"],
@@ -350,222 +401,177 @@ function baseResult(
 		npmPrefix: values.npmPrefix ?? paths.cliNpmPrefix,
 		npmCache: values.npmCache ?? paths.cliNpmCache,
 		activePath: paths.cliManagedBin,
+		retryAt: values.retryAt ?? null,
 		selfReexec,
 	};
 }
 
-function cliRegistry(manifest: RuntimeManifest): string | null {
-	const value = manifest.clawdiCli?.registry;
-	if (typeof value !== "string" || !value.trim()) return null;
-	const registry = value.trim();
+function emptyResultValues(): RuntimeCliResultValues {
+	return {
+		packageSpec: null,
+		registry: null,
+		activeTarget: null,
+		version: null,
+	};
+}
+
+function resultFromState(
+	status: RuntimeCliUpdateResult["status"],
+	paths: RuntimePaths,
+	state: RuntimeCliState | null,
+	packageSpec: string | null,
+	error?: string,
+	selfReexec = false,
+): RuntimeCliUpdateResult {
+	return baseResult(
+		status,
+		paths,
+		{
+			packageSpec,
+			registry: packageSpec ? NPM_REGISTRY : null,
+			npmPrefix: state?.npmPrefix ?? paths.cliNpmPrefix,
+			activeTarget: state?.activeTarget ?? activeLinkTarget(paths.cliManagedBin),
+			version: state?.version ?? null,
+			retryAt:
+				state?.bad?.version === exactNpmPackageVersion(packageSpec ?? "")
+					? state.bad.retryAt
+					: null,
+			error,
+		},
+		selfReexec,
+	);
+}
+
+function parseCliState(
+	paths: RuntimePaths,
+	status: RuntimeCliBootstrapStatus | null,
+): RuntimeCliState | null {
+	const parsed = runtimeCliStateSchema.safeParse(status);
+	if (!parsed.success) return null;
+	const state = parsed.data;
+	if (
+		state.activePath !== paths.cliManagedBin ||
+		state.npmCache !== paths.cliNpmCache ||
+		state.npmPrefix !== prefixForActiveTarget(state.activeTarget) ||
+		!isManagedCliTarget(paths, state.activeTarget) ||
+		exactNpmPackageVersion(state.packageSpec) !== state.version ||
+		!isValidRetryState(state.bad)
+	) {
+		log.warn("runtime.cli_state_invalid", { path: paths.cliBootstrapStatus });
+		return null;
+	}
+	return state;
+}
+
+function readCliState(paths: RuntimePaths): RuntimeCliState | null {
+	return parseCliState(paths, readRuntimeCliBootstrapStatus(paths));
+}
+
+function writeCliState(
+	paths: RuntimePaths,
+	active: VerifiedCliTarget,
+	previous: RuntimeCliTarget | null,
+	bad: RuntimeCliBad | null,
+): void {
+	const currentIdentity = cliVerificationIdentity(active.activeTarget);
+	if (!currentIdentity || !verificationIdentityMatches(active.verification, currentIdentity)) {
+		throw new Error(`clawdi CLI target changed after verification: ${active.activeTarget}`);
+	}
+	const state = runtimeCliStateSchema.parse({
+		schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
+		generatedAt: new Date().toISOString(),
+		status: "installed",
+		source: "npm",
+		packageSpec: `clawdi@${active.version}`,
+		registry: NPM_REGISTRY,
+		npmPrefix: prefixForActiveTarget(active.activeTarget),
+		npmCache: paths.cliNpmCache,
+		activePath: paths.cliManagedBin,
+		activeTarget: active.activeTarget,
+		version: active.version,
+		verification: active.verification,
+		previous,
+		bad,
+		error: null,
+	});
+	writeRuntimePlatformFileAtomic(
+		paths,
+		paths.cliBootstrapStatus,
+		`${JSON.stringify(state, null, 2)}\n`,
+		{ mode: 0o600, dirMode: 0o755 },
+	);
+}
+
+function activeFromState(state: RuntimeCliState): VerifiedCliTarget {
+	return {
+		activeTarget: state.activeTarget,
+		version: state.version,
+		verification: state.verification,
+	};
+}
+
+function targetFromState(state: RuntimeCliState): RuntimeCliTarget {
+	return { activeTarget: state.activeTarget, version: state.version };
+}
+
+function rollbackToPrevious(paths: RuntimePaths, state: RuntimeCliState, reason: string): void {
+	if (!state.previous) throw new Error("pending clawdi CLI upgrade has no rollback target");
+	const previous = requireVerifiedCliTarget(paths, state.previous);
+	if (activeLinkTarget(paths.cliManagedBin) !== previous.activeTarget) {
+		swapActiveCli(paths.cliManagedBin, previous.activeTarget);
+	}
+	writeCliState(paths, previous, null, markBadVersion(state.bad, state.version, reason));
+	pruneCliPackagePrefixes(paths, [prefixForActiveTarget(previous.activeTarget)]);
+}
+
+function rollbackResult(
+	state: RuntimeCliState | null,
+	status: RuntimeCliRollbackResult["status"],
+	error?: string,
+): RuntimeCliRollbackResult {
+	return {
+		status,
+		version: state?.version ?? null,
+		previousVersion: state?.previous?.version ?? null,
+		activeTarget: state?.activeTarget ?? null,
+		previousActiveTarget: state?.previous?.activeTarget ?? null,
+		...(error ? { error } : {}),
+	};
+}
+
+function reconciliationResult(
+	status: RuntimeCliReconciliationResult["status"],
+	activeVersion: string | undefined,
+	runningVersion: string | undefined,
+	requiresHandoff = status === "rolled_back",
+): RuntimeCliReconciliationResult {
+	return {
+		status,
+		selfReexec:
+			requiresHandoff &&
+			runningVersion !== undefined &&
+			activeVersion !== undefined &&
+			activeVersion !== runningVersion,
+	};
+}
+
+function discardLegacyUpgradeState(paths: RuntimePaths): void {
+	if (existsSync(paths.cliUpgradeState)) rmSync(paths.cliUpgradeState, { force: true });
+}
+
+function validateRegistry(value: string | undefined): void {
+	if (value === undefined || value.trim() === "") return;
 	let normalized: string;
 	try {
-		const parsed = new URL(registry);
+		const parsed = new URL(value.trim());
 		parsed.pathname = parsed.pathname.replace(/\/+$/, "");
 		parsed.search = "";
 		parsed.hash = "";
 		normalized = parsed.toString().replace(/\/$/, "");
 	} catch {
-		throw new Error(`unsupported clawdi CLI registry: ${registry}`);
+		throw new Error(`unsupported clawdi CLI registry: ${value}`);
 	}
-	if (normalized !== "https://registry.npmjs.org") {
-		throw new Error(`unsupported clawdi CLI registry: ${registry}`);
-	}
-	return "https://registry.npmjs.org";
-}
-
-function validatePackageSpec(packageSpec: string): void {
-	if (hostedCliPackageSpecSchema.safeParse(packageSpec).success) return;
-	throw new Error(`clawdi CLI packageSpec must be clawdi@<exact-semver>: ${packageSpec}`);
-}
-
-export function readRuntimeCliBootstrapStatus(
-	paths: RuntimePaths,
-): RuntimeCliBootstrapStatus | null {
-	return readBootstrapStatus(paths.cliBootstrapStatus);
-}
-
-function readBootstrapStatus(path: string): RuntimeCliBootstrapStatus | null {
-	if (!existsSync(path)) return null;
-	try {
-		return runtimeCliBootstrapStatusSchema.parse(JSON.parse(readFileSync(path, "utf-8")));
-	} catch (error) {
-		log.warn("runtime.cli_bootstrap_status_invalid", { path, error: toErrorMessage(error) });
-		return null;
-	}
-}
-
-function ensureManagedCliDirectory(path: string): void {
-	mkdirSync(path, { recursive: true });
-}
-
-function isManagedCliPrefix(paths: RuntimePaths, path: string): boolean {
-	const root = resolve(paths.cliNpmPrefix);
-	const candidate = resolve(path);
-	return candidate === root || candidate.startsWith(`${root}/`);
-}
-
-function isManagedCliTarget(paths: RuntimePaths, path: string): boolean {
-	return isManagedCliPrefix(paths, path) && path.endsWith("/bin/clawdi");
-}
-
-function isCurrentCliInstall(
-	status: RuntimeCliBootstrapStatus | null,
-	paths: RuntimePaths,
-	packageSpec: string,
-	registry: string | null,
-): status is RuntimeCliBootstrapStatus & { activeTarget: string } {
-	if (!status) return false;
-	if (status.status !== "installed" || status.source !== "npm") return false;
-	if (status.activePath !== paths.cliManagedBin) return false;
-	if (!status.activeTarget) return false;
-	if (!isManagedCliTarget(paths, status.activeTarget)) return false;
-	if (activeLinkTarget(paths.cliManagedBin) !== status.activeTarget) return false;
-	if (
-		!status.npmPrefix ||
-		resolve(status.npmPrefix) !== resolve(prefixForActiveTarget(status.activeTarget))
-	) {
-		return false;
-	}
-	if (!isExecutable(status.activeTarget)) return false;
-	if (!status.version) return false;
-	const exactVersion = exactNpmPackageVersion(packageSpec);
-	if (exactVersion && status.version !== exactVersion) return false;
-	if (status.packageSpec !== packageSpec) return false;
-	if ((status.registry ?? null) !== registry) return false;
-	if (!isExecutable(paths.cliManagedBin)) return false;
-	const fileIdentity = cliVerificationIdentity(status.activeTarget);
-	if (
-		fileIdentity &&
-		status.verification &&
-		verificationIdentityMatches(status.verification, fileIdentity) &&
-		verificationIsFresh(status.verification)
-	) {
-		return true;
-	}
-	if (!fileIdentity) return false;
-	try {
-		if (smokeCliVersion(status.activeTarget) !== status.version) return false;
-		verifyCliRuntime(status.activeTarget);
-		const verification = finishCliVerification(status.activeTarget, fileIdentity);
-		writeCliBootstrapStatus(
-			paths,
-			{
-				packageSpec,
-				registry,
-				npmPrefix: status.npmPrefix,
-				activeTarget: status.activeTarget,
-				version: status.version,
-			},
-			verification,
-		);
-		return true;
-	} catch (error) {
-		log.warn("runtime.cli_current_install_verification_failed", {
-			active_target: status.activeTarget,
-			error: toErrorMessage(error),
-		});
-		return false;
-	}
-}
-
-function verifiedActiveCliIdentity(
-	paths: RuntimePaths,
-	status: RuntimeCliBootstrapStatus | null,
-): RuntimeCliInstallIdentity | null {
-	const activeTarget = activeLinkTarget(paths.cliManagedBin);
-	if (!activeTarget || !isManagedCliTarget(paths, activeTarget)) return null;
-	const npmPrefix = prefixForActiveTarget(activeTarget);
-	if (!isManagedCliPrefix(paths, npmPrefix)) return null;
-	if (!isExecutable(activeTarget) || !isExecutable(paths.cliManagedBin)) return null;
-
-	try {
-		const before = cliVerificationIdentity(activeTarget);
-		if (!before) return null;
-		const version = smokeCliVersion(activeTarget);
-		verifyCliRuntime(activeTarget);
-		finishCliVerification(activeTarget, before);
-		const inferredPackageSpec = `clawdi@${version}`;
-		if (!hostedCliPackageSpecSchema.safeParse(inferredPackageSpec).success) return null;
-		const statusPackageSpec = status?.packageSpec;
-		const statusRegistry = status?.registry ?? null;
-		const exactStatusVersion = statusPackageSpec ? exactNpmPackageVersion(statusPackageSpec) : null;
-		const statusMatches =
-			status?.status === "installed" &&
-			status.source === "npm" &&
-			status.activePath === paths.cliManagedBin &&
-			status.activeTarget === activeTarget &&
-			status.npmPrefix !== undefined &&
-			resolve(status.npmPrefix) === resolve(npmPrefix) &&
-			status.version === version &&
-			statusPackageSpec !== undefined &&
-			hostedCliPackageSpecSchema.safeParse(statusPackageSpec).success &&
-			(exactStatusVersion === null || exactStatusVersion === version) &&
-			(statusRegistry === null || statusRegistry === "https://registry.npmjs.org");
-		return {
-			packageSpec: statusMatches && statusPackageSpec ? statusPackageSpec : inferredPackageSpec,
-			registry: statusMatches ? statusRegistry : null,
-			npmPrefix,
-			activeTarget,
-			version,
-		};
-	} catch (error) {
-		log.warn("runtime.cli_active_identity_verification_failed", {
-			active_target: activeTarget,
-			error: toErrorMessage(error),
-		});
-		return null;
-	}
-}
-
-function lastGoodCliIdentity(
-	paths: RuntimePaths,
-	status: RuntimeCliBootstrapStatus | null,
-): RuntimeCliInstallIdentity | null {
-	const activeIdentity = verifiedActiveCliIdentity(paths, status);
-	if (!activeIdentity) return null;
-	const transaction = readCliUpgradeState(paths).transaction;
-	if (
-		transaction?.phase !== "activated" ||
-		transaction.rollback ||
-		!transaction.previousIdentity ||
-		transaction.newIdentity.activeTarget !== activeIdentity.activeTarget
-	) {
-		return activeIdentity;
-	}
-	return verifyStoredCliIdentity(paths, transaction.previousIdentity)
-		? transaction.previousIdentity
-		: activeIdentity;
-}
-
-function recoverCurrentCliInstallFromActiveLink(
-	paths: RuntimePaths,
-	packageSpec: string,
-): {
-	npmPrefix: string;
-	activeTarget: string;
-	version: string;
-	verification: RuntimeCliVerification;
-} | null {
-	const desiredVersion = exactNpmPackageVersion(packageSpec);
-	if (!desiredVersion) return null;
-	const npmPrefix = cliPackagePrefix(paths, desiredVersion);
-	const activeTarget = activeLinkTarget(paths.cliManagedBin);
-	if (activeTarget !== join(npmPrefix, "bin", "clawdi")) return null;
-	if (!isManagedCliTarget(paths, activeTarget)) return null;
-	if (!isExecutable(activeTarget) || !isExecutable(paths.cliManagedBin)) return null;
-	const before = cliVerificationIdentity(activeTarget);
-	if (!before) return null;
-	const version = smokeCliVersion(activeTarget);
-	if (version !== desiredVersion) return null;
-	verifyCliRuntime(activeTarget);
-	const verification = finishCliVerification(activeTarget, before);
-	return {
-		npmPrefix: prefixForActiveTarget(activeTarget),
-		activeTarget,
-		version,
-		verification,
-	};
+	if (normalized !== NPM_REGISTRY) throw new Error(`unsupported clawdi CLI registry: ${value}`);
 }
 
 function exactNpmPackageVersion(packageSpec: string): string | null {
@@ -573,26 +579,10 @@ function exactNpmPackageVersion(packageSpec: string): string | null {
 	return packageSpec.slice("clawdi@".length);
 }
 
-function installCliPackage(
-	paths: RuntimePaths,
-	packageSpec: string,
-	registry: string | null,
-): {
-	npmPrefix: string;
-	activeTarget: string;
-	version: string;
-	verification: RuntimeCliVerification;
-} {
-	// The version-specific prefix is load-bearing: a fresh candidate is verified
-	// before cliManagedBin switches atomically, and the journal can restore the
-	// previous target without relying on an in-place npm rollback.
-	const installPlan = cliInstallPlan(paths, packageSpec);
-	if (isBadCliVersion(paths, packageSpec, registry, installPlan.version)) {
-		throw new Error(
-			`clawdi CLI ${installPlan.version} is marked bad after rollback; retry deferred until the rollback cooldown expires`,
-		);
-	}
-	const npmPrefix = installPlan.npmPrefix;
+function installCliPackage(paths: RuntimePaths, packageSpec: string): VerifiedCliTarget {
+	const version = exactNpmPackageVersion(packageSpec);
+	if (!version) throw new Error(`clawdi CLI packageSpec must be exact: ${packageSpec}`);
+	const npmPrefix = cliPackagePrefix(paths, version);
 	ensureManagedCliDirectory(dirname(dirname(paths.cliManagedBin)));
 	ensureManagedCliDirectory(dirname(paths.cliManagedBin));
 	ensureManagedCliDirectory(paths.cliNpmPrefix);
@@ -619,8 +609,9 @@ function installCliPackage(
 		"--no-audit",
 		"--no-fund",
 		"--no-update-notifier",
-		...(registry ? ["--registry", registry] : []),
-		installPlan.installPackageSpec,
+		"--registry",
+		NPM_REGISTRY,
+		packageSpec,
 	];
 	const result = spawnSync("npm", args, {
 		encoding: "utf8",
@@ -633,41 +624,103 @@ function installCliPackage(
 	});
 	if (result.status !== 0) {
 		throw new Error(
-			`npm install ${installPlan.installPackageSpec} failed${result.status === null ? "" : ` (${result.status})`}${
+			`npm install ${packageSpec} failed${result.status === null ? "" : ` (${result.status})`}${
 				result.error ? `: ${result.error.message}` : ""
 			}${commandOutput(result.stdout, result.stderr)}`,
 		);
 	}
 
-	const activeTarget = `${npmPrefix}/bin/clawdi`;
-	if (!isExecutable(activeTarget)) {
-		throw new Error(`npm install completed but clawdi bin is missing: ${activeTarget}`);
-	}
-	const before = cliVerificationIdentity(activeTarget);
-	if (!before)
-		throw new Error(`installed clawdi bin disappeared before verification: ${activeTarget}`);
-	const version = smokeCliVersion(activeTarget);
-	if (version !== installPlan.version) {
+	const activeTarget = join(npmPrefix, "bin", "clawdi");
+	const installed = requireVerifiedCliTarget(paths, { activeTarget });
+	if (installed.version !== version) {
 		throw new Error(
-			`npm install ${installPlan.installPackageSpec} reported version ${version}, expected ${installPlan.version}`,
+			`npm install ${packageSpec} reported version ${installed.version}, expected ${version}`,
 		);
 	}
-	verifyCliRuntime(activeTarget);
-	const verification = finishCliVerification(activeTarget, before);
-	return { npmPrefix, activeTarget, version, verification };
+	return installed;
 }
 
-function cliInstallPlan(
+function requireVerifiedCliTarget(
 	paths: RuntimePaths,
-	packageSpec: string,
-): { installPackageSpec: string; npmPrefix: string; version: string } {
-	const version = exactNpmPackageVersion(packageSpec);
-	if (!version) throw new Error(`clawdi CLI packageSpec must be exact: ${packageSpec}`);
+	target: { activeTarget: string; version?: string },
+): VerifiedCliTarget {
+	const verified = tryVerifyCliTarget(paths, target);
+	if (!verified) {
+		throw new Error(
+			`clawdi CLI target is missing, inconsistent, or not executable: ${target.activeTarget}`,
+		);
+	}
+	return verified;
+}
+
+function tryVerifyCliTarget(
+	paths: RuntimePaths,
+	target: { activeTarget: string; version?: string },
+	state?: RuntimeCliState,
+): VerifiedCliTarget | null {
+	if (!isManagedCliTarget(paths, target.activeTarget) || !isExecutable(target.activeTarget))
+		return null;
+	const before = cliVerificationIdentity(target.activeTarget);
+	if (!before) return null;
+	if (
+		state?.activeTarget === target.activeTarget &&
+		state.version === target.version &&
+		verificationIdentityMatches(state.verification, before) &&
+		verificationIsFresh(state.verification)
+	) {
+		return {
+			activeTarget: target.activeTarget,
+			version: state.version,
+			verification: state.verification,
+		};
+	}
+	try {
+		const version = smokeCliVersion(target.activeTarget);
+		if (target.version !== undefined && version !== target.version) return null;
+		if (!hostedCliPackageSpecSchema.safeParse(`clawdi@${version}`).success) return null;
+		verifyCliRuntime(target.activeTarget);
+		return {
+			activeTarget: target.activeTarget,
+			version,
+			verification: finishCliVerification(target.activeTarget, before),
+		};
+	} catch (error) {
+		log.warn("runtime.cli_target_verification_failed", {
+			active_target: target.activeTarget,
+			error: toErrorMessage(error),
+		});
+		return null;
+	}
+}
+
+function markBadVersion(
+	previous: RuntimeCliBad | null,
+	version: string,
+	reason: string,
+): RuntimeCliBad {
+	const attempts = previous?.version === version ? previous.attempts + 1 : 1;
+	const failedAt = new Date();
+	const backoffMs = Math.min(
+		CLI_RETRY_INITIAL_BACKOFF_MS * 2 ** (attempts - 1),
+		CLI_RETRY_MAX_BACKOFF_MS,
+	);
 	return {
-		installPackageSpec: `clawdi@${version}`,
-		npmPrefix: cliPackagePrefix(paths, version),
 		version,
+		reason,
+		attempts,
+		failedAt: failedAt.toISOString(),
+		retryAt: new Date(failedAt.getTime() + backoffMs).toISOString(),
 	};
+}
+
+function isValidRetryState(bad: RuntimeCliBad | null): boolean {
+	if (!bad) return true;
+	return Number.isFinite(Date.parse(bad.failedAt)) && Number.isFinite(Date.parse(bad.retryAt));
+}
+
+function badVersionIsActive(bad: RuntimeCliBad): boolean {
+	const retryAt = Date.parse(bad.retryAt);
+	return Number.isFinite(retryAt) && Date.now() < retryAt;
 }
 
 function cliPackagePrefix(paths: RuntimePaths, version: string): string {
@@ -679,6 +732,65 @@ function cliPackagePrefix(paths: RuntimePaths, version: string): string {
 
 function prefixForActiveTarget(activeTarget: string): string {
 	return dirname(dirname(activeTarget));
+}
+
+function prefixForTarget(target: RuntimeCliTarget | null): string | null {
+	return target ? prefixForActiveTarget(target.activeTarget) : null;
+}
+
+function isManagedCliPrefix(paths: RuntimePaths, path: string): boolean {
+	const root = resolve(paths.cliNpmPrefix);
+	const candidate = resolve(path);
+	return candidate === root || candidate.startsWith(`${root}/`);
+}
+
+function isManagedCliTarget(paths: RuntimePaths, path: string): boolean {
+	return isManagedCliPrefix(paths, path) && path.endsWith("/bin/clawdi");
+}
+
+function ensureManagedCliDirectory(path: string): void {
+	mkdirSync(path, { recursive: true });
+}
+
+function activeLinkTarget(activePath: string): string | null {
+	try {
+		return resolve(dirname(activePath), readlinkSync(activePath));
+	} catch {
+		return null;
+	}
+}
+
+function swapActiveCli(activePath: string, activeTarget: string): void {
+	const dir = dirname(activePath);
+	ensureManagedCliDirectory(dirname(dir));
+	ensureManagedCliDirectory(dir);
+	const tmp = `${dir}/.clawdi.next.${process.pid}.${Date.now()}`;
+	try {
+		rmSync(tmp, { force: true });
+		symlinkSync(activeTarget, tmp);
+		renameSync(tmp, activePath);
+	} catch (error) {
+		rmSync(tmp, { force: true });
+		throw error;
+	}
+}
+
+function pruneCliPackagePrefixes(paths: RuntimePaths, keepPrefixes: Array<string | null>): void {
+	const packageRoot = join(paths.cliNpmPrefix, "packages");
+	if (!existsSync(packageRoot)) return;
+	const keep = new Set(keepPrefixes.filter((value): value is string => Boolean(value)));
+	try {
+		for (const entry of readdirSync(packageRoot, { withFileTypes: true })) {
+			if (!entry.isDirectory()) continue;
+			const path = join(packageRoot, entry.name);
+			if (!keep.has(path)) rmSync(path, { recursive: true, force: true });
+		}
+	} catch (error) {
+		log.warn("runtime.cli_package_prune_failed", {
+			package_root: packageRoot,
+			error: toErrorMessage(error),
+		});
+	}
 }
 
 function cliVerificationIdentity(
@@ -724,31 +836,6 @@ function finishCliVerification(
 		throw new Error(`clawdi CLI target changed during verification: ${activeTarget}`);
 	}
 	return { verifiedAt: new Date().toISOString(), ...after };
-}
-
-function activeLinkTarget(activePath: string): string | null {
-	try {
-		return resolve(dirname(activePath), readlinkSync(activePath));
-	} catch {
-		return null;
-	}
-}
-
-function pruneCliPackagePrefixes(paths: RuntimePaths, keepPrefixes: Array<string | null>): void {
-	const packageRoot = join(paths.cliNpmPrefix, "packages");
-	const keep = new Set(keepPrefixes.filter((value): value is string => Boolean(value)));
-	try {
-		for (const entry of readdirSync(packageRoot, { withFileTypes: true })) {
-			if (!entry.isDirectory()) continue;
-			const path = join(packageRoot, entry.name);
-			if (!keep.has(path)) rmSync(path, { recursive: true, force: true });
-		}
-	} catch (error) {
-		log.warn("runtime.cli_package_prune_failed", {
-			package_root: packageRoot,
-			error: toErrorMessage(error),
-		});
-	}
 }
 
 function commandOutput(stdout: string | null, stderr: string | null): string {
@@ -811,9 +898,7 @@ function verifyCliRuntime(command: string): void {
 		);
 	}
 	const output = result.stdout.trim();
-	if (!output) {
-		throw new Error("installed clawdi runtime verify self-check returned empty output");
-	}
+	if (!output) throw new Error("installed clawdi runtime verify self-check returned empty output");
 	try {
 		z.object({ status: z.literal("ok") })
 			.loose()
@@ -825,682 +910,6 @@ function verifyCliRuntime(command: string): void {
 			)}${commandOutput(result.stdout, result.stderr)}`,
 		);
 	}
-}
-
-function swapActiveCli(activePath: string, activeTarget: string): void {
-	const dir = dirname(activePath);
-	ensureManagedCliDirectory(dirname(dir));
-	ensureManagedCliDirectory(dir);
-	const tmp = `${dir}/.clawdi.next.${process.pid}.${Date.now()}`;
-	try {
-		rmSync(tmp, { force: true });
-		symlinkSync(activeTarget, tmp);
-		renameSync(tmp, activePath);
-	} catch (error) {
-		rmSync(tmp, { force: true });
-		throw error;
-	}
-}
-
-function writeCliBootstrapStatus(
-	paths: RuntimePaths,
-	input: {
-		packageSpec: string;
-		registry: string | null;
-		npmPrefix: string;
-		activeTarget: string;
-		version: string;
-	},
-	verification?: RuntimeCliVerification,
-): void {
-	const currentIdentity = cliVerificationIdentity(input.activeTarget);
-	if (
-		verification &&
-		(!currentIdentity || !verificationIdentityMatches(verification, currentIdentity))
-	) {
-		throw new Error(`clawdi CLI target changed after verification: ${input.activeTarget}`);
-	}
-	writeRuntimePlatformFileAtomic(
-		paths,
-		paths.cliBootstrapStatus,
-		`${JSON.stringify(
-			{
-				schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
-				generatedAt: new Date().toISOString(),
-				status: "installed",
-				source: "npm",
-				packageSpec: input.packageSpec,
-				registry: input.registry,
-				npmPrefix: input.npmPrefix,
-				npmCache: paths.cliNpmCache,
-				activePath: paths.cliManagedBin,
-				activeTarget: input.activeTarget,
-				version: input.version,
-				verification,
-				error: null,
-			},
-			null,
-			2,
-		)}\n`,
-		{ mode: 0o600, dirMode: 0o755 },
-	);
-}
-
-export function rollbackPendingRuntimeCliUpgrade(
-	paths: RuntimePaths,
-	reason: string,
-): RuntimeCliRollbackResult {
-	let transaction: RuntimeCliUpgradeTransaction | null = null;
-	try {
-		transaction = readCliUpgradeState(paths).transaction ?? null;
-		reconcileCliUpgradeTransaction(paths);
-	} catch (error) {
-		return rollbackErrorResult(transaction, error);
-	}
-	const state = readCliUpgradeState(paths);
-	transaction = state.transaction ?? null;
-	if (!transaction) {
-		return {
-			status: "not_pending",
-			version: null,
-			previousVersion: null,
-			activeTarget: null,
-			previousActiveTarget: null,
-		};
-	}
-	if (!transaction.previousIdentity) {
-		return {
-			status: "not_pending",
-			version: transaction.newIdentity.version,
-			previousVersion: null,
-			activeTarget: transaction.newIdentity.activeTarget,
-			previousActiveTarget: null,
-		};
-	}
-	if (!verifyStoredCliIdentity(paths, transaction.previousIdentity)) {
-		return {
-			status: "error",
-			version: transaction.newIdentity.version,
-			previousVersion: transaction.previousIdentity.version,
-			activeTarget: transaction.newIdentity.activeTarget,
-			previousActiveTarget: transaction.previousIdentity.activeTarget,
-			error: "previous clawdi CLI identity is missing, inconsistent, or not executable",
-		};
-	}
-	if (activeLinkTarget(paths.cliManagedBin) !== transaction.newIdentity.activeTarget) {
-		return {
-			status: "error",
-			version: transaction.newIdentity.version,
-			previousVersion: transaction.previousIdentity.version,
-			activeTarget: transaction.newIdentity.activeTarget,
-			previousActiveTarget: transaction.previousIdentity.activeTarget,
-			error: "pending clawdi CLI target is no longer active",
-		};
-	}
-	try {
-		const rollbackTransaction: RuntimeCliUpgradeTransaction = {
-			...transaction,
-			rollback: { reason, markedAt: new Date().toISOString() },
-		};
-		writeCliUpgradeState(paths, { ...state, transaction: rollbackTransaction });
-		finishCliRollback(paths, rollbackTransaction);
-		return {
-			status: "rolled_back",
-			version: transaction.newIdentity.version,
-			previousVersion: transaction.previousIdentity.version,
-			activeTarget: transaction.newIdentity.activeTarget,
-			previousActiveTarget: transaction.previousIdentity.activeTarget,
-			error: null,
-		};
-	} catch (error) {
-		return rollbackErrorResult(transaction, error);
-	}
-}
-
-export function completePendingRuntimeCliUpgrade(
-	paths: RuntimePaths,
-	currentVersion: string,
-): RuntimeCliReconciliationResult {
-	const reconciliation = reconcileCliUpgradeTransaction(paths, {
-		runningVersion: currentVersion,
-	});
-	if (reconciliation.selfReexec) return reconciliation;
-	const state = readCliUpgradeState(paths);
-	const transaction = state.transaction ?? null;
-	if (transaction?.phase !== "activated" || transaction.rollback) return reconciliation;
-	if (transaction.newIdentity.version !== currentVersion) return reconciliation;
-	if (activeLinkTarget(paths.cliManagedBin) !== transaction.newIdentity.activeTarget) {
-		return reconciliation;
-	}
-	if (!verifyStoredCliIdentity(paths, transaction.newIdentity)) return reconciliation;
-	const nextState = normalizeCliUpgradeState(state);
-	nextState.transaction = null;
-	writeCliUpgradeState(paths, nextState);
-	pruneCliPackagePrefixes(paths, [transaction.newIdentity.npmPrefix]);
-	return reconciliation;
-}
-
-export function reconcilePendingRuntimeCliUpgrade(
-	paths: RuntimePaths,
-	runningVersion: string,
-): RuntimeCliReconciliationResult {
-	return reconcileCliUpgradeTransaction(paths, { runningVersion });
-}
-
-function prepareCliUpgradeTransaction(
-	paths: RuntimePaths,
-	input: {
-		newIdentity: RuntimeCliInstallIdentity;
-		previousIdentity: RuntimeCliInstallIdentity | null;
-	},
-): void {
-	const state = normalizeCliUpgradeState(readCliUpgradeState(paths));
-	state.transaction = {
-		phase: "prepared",
-		previousIdentity: input.previousIdentity,
-		newIdentity: input.newIdentity,
-		rollbackEligible: input.previousIdentity !== null,
-		installedAt: new Date().toISOString(),
-		rollback: null,
-	};
-	writeCliUpgradeState(paths, state);
-}
-
-function activateCliUpgradeTransaction(paths: RuntimePaths): void {
-	const state = readCliUpgradeState(paths);
-	const transaction = state.transaction;
-	if (transaction?.phase !== "prepared") {
-		throw new Error("prepared clawdi CLI upgrade transaction is missing");
-	}
-	if (activeLinkTarget(paths.cliManagedBin) !== transaction.newIdentity.activeTarget) {
-		throw new Error("prepared clawdi CLI target is not active");
-	}
-	writeCliUpgradeState(paths, {
-		...state,
-		transaction: { ...transaction, phase: "activated" },
-	});
-}
-
-function reconcileCliUpgradeTransaction(
-	paths: RuntimePaths,
-	opts: RuntimeCliReconciliationOptions = {},
-): RuntimeCliReconciliationResult {
-	const hadUpgradeState = existsSync(paths.cliUpgradeState);
-	const state = readCliUpgradeState(paths);
-	const transaction = state.transaction ?? null;
-	if (!transaction) {
-		return hadUpgradeState && !existsSync(paths.cliUpgradeState)
-			? cliReconciliationResult(paths, "unchanged", opts.runningVersion)
-			: { status: "unchanged", selfReexec: false };
-	}
-	if (transaction.rollback) {
-		finishCliRollback(paths, transaction);
-		return cliReconciliationResult(paths, "rolled_back", opts.runningVersion);
-	}
-
-	const activeTarget = activeLinkTarget(paths.cliManagedBin);
-	const previousTarget = transaction.previousIdentity?.activeTarget ?? null;
-	if (transaction.phase === "prepared") {
-		if (activeTarget === transaction.newIdentity.activeTarget) {
-			const verification = verifyStoredCliIdentity(paths, transaction.newIdentity);
-			if (!verification) {
-				rollBackInvalidTransaction(paths, transaction);
-				return cliReconciliationResult(paths, "rolled_back", opts.runningVersion);
-			}
-			writeCliBootstrapStatus(paths, transaction.newIdentity, verification);
-			activateCliUpgradeTransaction(paths);
-			pruneCliPackagePrefixes(paths, [
-				transaction.newIdentity.npmPrefix,
-				transaction.previousIdentity?.npmPrefix ?? null,
-			]);
-			return cliReconciliationResult(paths, "activated", opts.runningVersion);
-		}
-		if (activeTarget === previousTarget) {
-			if (transaction.previousIdentity) {
-				const verification = verifyStoredCliIdentity(paths, transaction.previousIdentity);
-				if (!verification) {
-					throw new Error("prepared clawdi CLI transaction has an invalid previous identity");
-				}
-				writeCliBootstrapStatus(paths, transaction.previousIdentity, verification);
-			}
-			writeCliUpgradeState(paths, { ...state, transaction: null });
-			pruneCliPackagePrefixes(paths, [transaction.previousIdentity?.npmPrefix ?? null]);
-			return cliReconciliationResult(paths, "unchanged", opts.runningVersion);
-		}
-		rollBackInvalidTransaction(paths, transaction);
-		return cliReconciliationResult(paths, "rolled_back", opts.runningVersion);
-	}
-
-	if (activeTarget === transaction.newIdentity.activeTarget) {
-		if (!verifyStoredCliIdentity(paths, transaction.newIdentity)) {
-			rollBackInvalidTransaction(paths, transaction);
-			return cliReconciliationResult(paths, "rolled_back", opts.runningVersion);
-		}
-		return cliReconciliationResult(paths, "unchanged", opts.runningVersion);
-	}
-	if (transaction.previousIdentity && activeTarget === previousTarget) {
-		const rollbackTransaction = withRecoveryRollback(transaction);
-		writeCliUpgradeState(paths, { ...state, transaction: rollbackTransaction });
-		finishCliRollback(paths, rollbackTransaction);
-		return cliReconciliationResult(paths, "rolled_back", opts.runningVersion);
-	}
-	// The root image bootstrap is an independent activation owner. Transfer the
-	// journal to its exact identity before ordinary reconciliation may continue.
-	if (handoffCliUpgradeTransactionToBootstrap(paths, transaction)) {
-		return cliReconciliationResult(paths, "activated", opts.runningVersion);
-	}
-	rollBackInvalidTransaction(paths, transaction);
-	return cliReconciliationResult(paths, "rolled_back", opts.runningVersion);
-}
-
-function handoffCliUpgradeTransactionToBootstrap(
-	paths: RuntimePaths,
-	expectedTransaction: RuntimeCliUpgradeTransaction,
-): boolean {
-	const bootstrapIdentity = verifiedActiveBootstrapIdentity(paths);
-	if (!bootstrapIdentity) return false;
-
-	// cli-upgrade-state has one writer under the runtime convergence lock. The
-	// complete prior transaction is the fence for this compare-and-replace.
-	const currentState = readCliUpgradeState(paths);
-	if (!cliUpgradeTransactionsMatch(currentState.transaction ?? null, expectedTransaction)) {
-		throw new Error("clawdi CLI transaction changed during bootstrap ownership handoff");
-	}
-	const currentBootstrapIdentity = verifiedActiveBootstrapIdentity(paths);
-	if (
-		!currentBootstrapIdentity ||
-		!cliInstallIdentitiesMatch(currentBootstrapIdentity, bootstrapIdentity)
-	) {
-		throw new Error("clawdi CLI bootstrap identity changed during ownership handoff");
-	}
-
-	writeCliUpgradeState(paths, {
-		...currentState,
-		transaction: {
-			phase: "activated",
-			previousIdentity: null,
-			newIdentity: bootstrapIdentity,
-			rollbackEligible: false,
-			installedAt: new Date().toISOString(),
-			rollback: null,
-		},
-	});
-	if (activeLinkTarget(paths.cliManagedBin) !== bootstrapIdentity.activeTarget) {
-		throw new Error("clawdi CLI bootstrap identity changed after ownership handoff");
-	}
-	pruneCliPackagePrefixes(paths, [bootstrapIdentity.npmPrefix]);
-	return true;
-}
-
-function cliUpgradeTransactionsMatch(
-	left: RuntimeCliUpgradeTransaction | null,
-	right: RuntimeCliUpgradeTransaction | null,
-): boolean {
-	if (left === null || right === null) return left === right;
-	return (
-		left.phase === right.phase &&
-		cliInstallIdentitiesMatch(left.previousIdentity, right.previousIdentity) &&
-		cliInstallIdentitiesMatch(left.newIdentity, right.newIdentity) &&
-		left.rollbackEligible === right.rollbackEligible &&
-		left.installedAt === right.installedAt &&
-		left.rollback?.reason === right.rollback?.reason &&
-		left.rollback?.markedAt === right.rollback?.markedAt
-	);
-}
-
-function cliInstallIdentitiesMatch(
-	left: RuntimeCliInstallIdentity | null,
-	right: RuntimeCliInstallIdentity | null,
-): boolean {
-	if (left === null || right === null) return left === right;
-	return (
-		left.packageSpec === right.packageSpec &&
-		left.registry === right.registry &&
-		left.npmPrefix === right.npmPrefix &&
-		left.activeTarget === right.activeTarget &&
-		left.version === right.version
-	);
-}
-
-function verifiedActiveBootstrapIdentity(paths: RuntimePaths): RuntimeCliInstallIdentity | null {
-	const status = readRuntimeCliBootstrapStatus(paths);
-	const identity = cliBootstrapIdentity(paths, status);
-	if (!identity || activeLinkTarget(paths.cliManagedBin) !== identity.activeTarget) return null;
-	if (!verifyStoredCliIdentity(paths, identity)) return null;
-	const currentStatus = readRuntimeCliBootstrapStatus(paths);
-	return activeLinkTarget(paths.cliManagedBin) === identity.activeTarget &&
-		statusMatchesIdentity(currentStatus, paths, identity) &&
-		currentStatus?.schemaVersion === "clawdi.cliNpmBootstrapStatus.v1" &&
-		currentStatus.error === null &&
-		currentStatus.npmCache === paths.cliNpmCache
-		? identity
-		: null;
-}
-
-function cliBootstrapIdentity(
-	paths: RuntimePaths,
-	status: RuntimeCliBootstrapStatus | null,
-): RuntimeCliInstallIdentity | null {
-	if (
-		status?.schemaVersion !== "clawdi.cliNpmBootstrapStatus.v1" ||
-		status.status !== "installed" ||
-		status.source !== "npm" ||
-		status.error !== null ||
-		status.activePath !== paths.cliManagedBin ||
-		status.npmCache !== paths.cliNpmCache ||
-		typeof status.packageSpec !== "string" ||
-		(status.registry !== null && typeof status.registry !== "string") ||
-		typeof status.npmPrefix !== "string" ||
-		typeof status.activeTarget !== "string" ||
-		typeof status.version !== "string"
-	) {
-		return null;
-	}
-	return {
-		packageSpec: status.packageSpec,
-		registry: status.registry,
-		npmPrefix: status.npmPrefix,
-		activeTarget: status.activeTarget,
-		version: status.version,
-	};
-}
-
-function cliReconciliationResult(
-	paths: RuntimePaths,
-	status: RuntimeCliReconciliationResult["status"],
-	runningVersion: string | undefined,
-): RuntimeCliReconciliationResult {
-	const bootstrap = readRuntimeCliBootstrapStatus(paths);
-	const activeTarget = activeLinkTarget(paths.cliManagedBin);
-	const activeVersion = bootstrap?.activeTarget === activeTarget ? bootstrap.version : undefined;
-	return {
-		status,
-		selfReexec:
-			runningVersion !== undefined &&
-			activeVersion !== undefined &&
-			activeVersion !== runningVersion,
-	};
-}
-
-function rollBackInvalidTransaction(
-	paths: RuntimePaths,
-	transaction: RuntimeCliUpgradeTransaction,
-): void {
-	if (
-		!transaction.previousIdentity ||
-		!verifyStoredCliIdentity(paths, transaction.previousIdentity)
-	) {
-		throw new Error("clawdi CLI transaction cannot restore a verified previous identity");
-	}
-	const rollbackTransaction = withRecoveryRollback(transaction);
-	const state = readCliUpgradeState(paths);
-	writeCliUpgradeState(paths, { ...state, transaction: rollbackTransaction });
-	finishCliRollback(paths, rollbackTransaction);
-}
-
-function withRecoveryRollback(
-	transaction: RuntimeCliUpgradeTransaction,
-): RuntimeCliUpgradeTransaction {
-	return {
-		...transaction,
-		rollback: {
-			reason: "recovered interrupted or inconsistent clawdi CLI transaction",
-			markedAt: new Date().toISOString(),
-		},
-	};
-}
-
-function finishCliRollback(paths: RuntimePaths, transaction: RuntimeCliUpgradeTransaction): void {
-	const previousIdentity = transaction.previousIdentity;
-	if (!transaction.rollback || !previousIdentity) {
-		throw new Error("clawdi CLI rollback transaction is incomplete");
-	}
-	const verification = verifyStoredCliIdentity(paths, previousIdentity);
-	if (!verification) {
-		throw new Error("previous clawdi CLI identity failed rollback verification");
-	}
-	const activeTarget = activeLinkTarget(paths.cliManagedBin);
-	if (activeTarget !== previousIdentity.activeTarget) {
-		swapActiveCli(paths.cliManagedBin, previousIdentity.activeTarget);
-	}
-	writeCliBootstrapStatus(paths, previousIdentity, verification);
-	const state = readCliUpgradeState(paths);
-	writeCliUpgradeState(paths, {
-		...state,
-		transaction: null,
-		badVersions: upsertBadVersion(state.badVersions ?? [], {
-			packageSpec: transaction.newIdentity.packageSpec,
-			registry: transaction.newIdentity.registry,
-			version: transaction.newIdentity.version,
-			reason: transaction.rollback.reason,
-			markedAt: transaction.rollback.markedAt,
-		}),
-	});
-	pruneCliPackagePrefixes(paths, [previousIdentity.npmPrefix]);
-}
-
-function verifyStoredCliIdentity(
-	paths: RuntimePaths,
-	identity: RuntimeCliInstallIdentity,
-): RuntimeCliVerification | null {
-	if (
-		!hostedCliPackageSpecSchema.safeParse(identity.packageSpec).success ||
-		(identity.registry !== null && identity.registry !== "https://registry.npmjs.org") ||
-		!isManagedCliTarget(paths, identity.activeTarget) ||
-		!isManagedCliPrefix(paths, identity.npmPrefix) ||
-		resolve(prefixForActiveTarget(identity.activeTarget)) !== resolve(identity.npmPrefix) ||
-		!isExecutable(identity.activeTarget)
-	) {
-		return null;
-	}
-	const exactVersion = exactNpmPackageVersion(identity.packageSpec);
-	if (exactVersion && exactVersion !== identity.version) return null;
-	const status = readRuntimeCliBootstrapStatus(paths);
-	const fileIdentity = cliVerificationIdentity(identity.activeTarget);
-	if (
-		statusMatchesIdentity(status, paths, identity) &&
-		fileIdentity &&
-		status?.verification &&
-		verificationIdentityMatches(status.verification, fileIdentity) &&
-		verificationIsFresh(status.verification)
-	) {
-		return status.verification;
-	}
-	if (!fileIdentity) return null;
-	try {
-		if (smokeCliVersion(identity.activeTarget) !== identity.version) return null;
-		verifyCliRuntime(identity.activeTarget);
-		const verification = finishCliVerification(identity.activeTarget, fileIdentity);
-		if (activeLinkTarget(paths.cliManagedBin) === identity.activeTarget) {
-			writeCliBootstrapStatus(paths, identity, verification);
-		}
-		return verification;
-	} catch (error) {
-		log.warn("runtime.cli_stored_identity_verification_failed", {
-			active_target: identity.activeTarget,
-			error: toErrorMessage(error),
-		});
-		return null;
-	}
-}
-
-function statusMatchesIdentity(
-	status: RuntimeCliBootstrapStatus | null,
-	paths: RuntimePaths,
-	identity: RuntimeCliInstallIdentity,
-): boolean {
-	return (
-		status?.status === "installed" &&
-		status.source === "npm" &&
-		status.packageSpec === identity.packageSpec &&
-		(status.registry ?? null) === identity.registry &&
-		status.npmPrefix === identity.npmPrefix &&
-		status.activePath === paths.cliManagedBin &&
-		status.activeTarget === identity.activeTarget &&
-		status.version === identity.version
-	);
-}
-
-function rollbackErrorResult(
-	transaction: RuntimeCliUpgradeTransaction | null,
-	error: unknown,
-): RuntimeCliRollbackResult {
-	return {
-		status: "error",
-		version: transaction?.newIdentity.version ?? null,
-		previousVersion: transaction?.previousIdentity?.version ?? null,
-		activeTarget: transaction?.newIdentity.activeTarget ?? null,
-		previousActiveTarget: transaction?.previousIdentity?.activeTarget ?? null,
-		error: toErrorMessage(error),
-	};
-}
-
-function isBadCliVersion(
-	paths: RuntimePaths,
-	packageSpec: string,
-	registry: string | null,
-	version: string,
-): boolean {
-	const state = readCliUpgradeState(paths);
-	const now = Date.now();
-	return (state.badVersions ?? []).some(
-		(entry) =>
-			entry.packageSpec === packageSpec &&
-			(entry.registry ?? null) === registry &&
-			entry.version === version &&
-			badVersionIsActive(entry, now),
-	);
-}
-
-function badVersionIsActive(entry: RuntimeCliBadVersion, now: number): boolean {
-	if (!entry.markedAt) return false;
-	const markedAt = Date.parse(entry.markedAt);
-	if (!Number.isFinite(markedAt)) return false;
-	const ageMs = now - markedAt;
-	return ageMs >= 0 && ageMs < CLI_BAD_VERSION_TTL_MS;
-}
-
-function readCliUpgradeState(paths: RuntimePaths): RuntimeCliUpgradeState {
-	if (!existsSync(paths.cliUpgradeState)) return emptyCliUpgradeState();
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8")) as unknown;
-	} catch (error) {
-		return quarantineInvalidCliUpgradeState(paths, `invalid JSON: ${toErrorMessage(error)}`);
-	}
-	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-		return quarantineInvalidCliUpgradeState(paths, "state must be a JSON object");
-	}
-	const schemaVersion = (parsed as Record<string, unknown>).schemaVersion;
-	if (schemaVersion === "clawdi.cliUpgradeState.v2") {
-		const result = cliUpgradeStateV2Schema.safeParse(parsed);
-		if (!result.success) {
-			return quarantineInvalidCliUpgradeState(
-				paths,
-				`invalid v2 state: ${result.error.issues[0]?.message ?? "schema validation failed"}`,
-			);
-		}
-		return result.data;
-	}
-	if (typeof schemaVersion !== "string") {
-		return quarantineInvalidCliUpgradeState(paths, "schemaVersion must be a string");
-	}
-	throw new Error(`unsupported clawdi CLI upgrade transaction schema: ${String(schemaVersion)}`);
-}
-
-function quarantineInvalidCliUpgradeState(
-	paths: RuntimePaths,
-	reason: string,
-): RuntimeCliUpgradeState {
-	try {
-		repairCliInstallAfterInvalidUpgradeState(paths);
-	} catch (error) {
-		throw new Error(
-			`invalid clawdi CLI upgrade state: ${reason}; disk recovery failed: ${toErrorMessage(error)}`,
-		);
-	}
-	const quarantinePath = `${paths.cliUpgradeState}.corrupt-${Date.now()}-${randomUUID()}`;
-	try {
-		renameSync(paths.cliUpgradeState, quarantinePath);
-	} catch (error) {
-		throw new Error(
-			`invalid clawdi CLI upgrade state: ${reason}; quarantine failed: ${toErrorMessage(error)}`,
-		);
-	}
-	log.warn("runtime.cli_upgrade_state_quarantined", {
-		path: paths.cliUpgradeState,
-		quarantine_path: quarantinePath,
-		error: reason,
-	});
-	return emptyCliUpgradeState();
-}
-
-function repairCliInstallAfterInvalidUpgradeState(paths: RuntimePaths): void {
-	const status = readRuntimeCliBootstrapStatus(paths);
-	const activeIdentity = verifiedActiveCliIdentity(paths, status);
-	if (activeIdentity) {
-		const verification = verifyStoredCliIdentity(paths, activeIdentity);
-		if (!verification) {
-			throw new Error("invalid clawdi CLI upgrade state has an unverifiable active CLI target");
-		}
-		writeCliBootstrapStatus(paths, activeIdentity, verification);
-		return;
-	}
-
-	const bootstrapIdentity = cliBootstrapIdentity(paths, status);
-	if (bootstrapIdentity) {
-		const verification = verifyStoredCliIdentity(paths, bootstrapIdentity);
-		if (verification) {
-			swapActiveCli(paths.cliManagedBin, bootstrapIdentity.activeTarget);
-			writeCliBootstrapStatus(paths, bootstrapIdentity, verification);
-			return;
-		}
-	}
-
-	if (activeLinkTarget(paths.cliManagedBin) === null && !existsSync(paths.cliBootstrapStatus))
-		return;
-	throw new Error(
-		"invalid clawdi CLI upgrade state cannot be quarantined because the active CLI installation is not recoverable",
-	);
-}
-
-function writeCliUpgradeState(paths: RuntimePaths, state: RuntimeCliUpgradeState): void {
-	writeRuntimePlatformFileAtomic(
-		paths,
-		paths.cliUpgradeState,
-		`${JSON.stringify(normalizeCliUpgradeState(state), null, 2)}\n`,
-		{ mode: 0o600, dirMode: 0o755 },
-	);
-}
-
-function normalizeCliUpgradeState(state: RuntimeCliUpgradeState): RuntimeCliUpgradeState {
-	return {
-		schemaVersion: "clawdi.cliUpgradeState.v2",
-		transaction: state.transaction ?? null,
-		badVersions: state.badVersions ?? [],
-	};
-}
-
-function emptyCliUpgradeState(): RuntimeCliUpgradeState {
-	return {
-		schemaVersion: "clawdi.cliUpgradeState.v2",
-		transaction: null,
-		badVersions: [],
-	};
-}
-
-function upsertBadVersion(
-	entries: RuntimeCliBadVersion[],
-	entry: RuntimeCliBadVersion,
-): RuntimeCliBadVersion[] {
-	const next = entries.filter(
-		(existing) =>
-			existing.packageSpec !== entry.packageSpec ||
-			(existing.registry ?? null) !== entry.registry ||
-			existing.version !== entry.version,
-	);
-	next.push(entry);
-	return next;
 }
 
 function isExecutable(path: string): boolean {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -117,6 +117,8 @@ const HERMES_CONFIG_CLI_MOCK = fileURLToPath(
 const TEST_PROCESS_USER = String(process.getuid?.() ?? 0);
 const TEST_PROCESS_UID = process.getuid?.() ?? 1_000;
 const TEST_PROCESS_GID = process.getgid?.() ?? 1_000;
+const TEST_RUNNING_CLI_VERSION = getCliVersion();
+const TEST_RUNNING_CLI_SPEC = `clawdi@${TEST_RUNNING_CLI_VERSION}`;
 
 function testHostedRuntimeContract(paths: RuntimePaths) {
 	if (!process.env.CLAWDI_RUNTIME_USER) process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
@@ -667,19 +669,6 @@ interface RuntimeCliFixtureIdentity {
 	version: string;
 }
 
-function currentCliFixtureIdentity(
-	paths: RuntimePaths,
-	version: string,
-): RuntimeCliFixtureIdentity {
-	return {
-		packageSpec: `clawdi@${version}`,
-		registry: null,
-		npmPrefix: paths.cliNpmPrefix,
-		activeTarget: join(paths.cliNpmPrefix, "bin", "clawdi"),
-		version,
-	};
-}
-
 function createVersionedCliFixture(
 	paths: RuntimePaths,
 	version: string,
@@ -705,7 +694,7 @@ exit 64
 	chmodSync(activeTarget, 0o700);
 	return {
 		packageSpec: `clawdi@${version}`,
-		registry: null,
+		registry: "https://registry.npmjs.org",
 		npmPrefix,
 		activeTarget,
 		version,
@@ -738,93 +727,6 @@ function writeCliBootstrapFixture(paths: RuntimePaths, identity: RuntimeCliFixtu
 		})}\n`,
 		{ mode: 0o600 },
 	);
-}
-
-function writeCliTransactionFixture(
-	paths: RuntimePaths,
-	input: {
-		phase: "prepared" | "activated";
-		previousIdentity: RuntimeCliFixtureIdentity;
-		newIdentity: RuntimeCliFixtureIdentity;
-		rollbackReason?: string;
-		badVersions?: Array<{ version: string; reason: string }>;
-	},
-): void {
-	mkdirSync(dirname(paths.cliUpgradeState), { recursive: true });
-	writeFileSync(
-		paths.cliUpgradeState,
-		`${JSON.stringify({
-			schemaVersion: "clawdi.cliUpgradeState.v2",
-			transaction: {
-				phase: input.phase,
-				previousIdentity: input.previousIdentity,
-				newIdentity: input.newIdentity,
-				rollbackEligible: true,
-				installedAt: "2026-07-29T00:00:00.000Z",
-				rollback: input.rollbackReason
-					? {
-							reason: input.rollbackReason,
-							markedAt: "2026-07-29T00:01:00.000Z",
-						}
-					: null,
-			},
-			badVersions: (input.badVersions ?? []).map((entry) => ({
-				packageSpec: input.newIdentity.packageSpec,
-				registry: input.newIdentity.registry,
-				version: entry.version,
-				reason: entry.reason,
-				markedAt: "2026-07-29T00:02:00.000Z",
-			})),
-		})}\n`,
-		{ mode: 0o600 },
-	);
-}
-
-function cliUpgradeQuarantineFiles(paths: RuntimePaths): string[] {
-	return readdirSync(dirname(paths.cliUpgradeState))
-		.filter((name) => name.startsWith("cli-upgrade-state.json.corrupt-"))
-		.map((name) => join(dirname(paths.cliUpgradeState), name));
-}
-
-function seedCliRecoveryFixture(state: string, run: string) {
-	process.env.CLAWDI_RUNTIME_MODE = "hosted";
-	process.env.CLAWDI_SERVICE_STATE_DIR = state;
-	process.env.CLAWDI_RUN_DIR = run;
-	seedCurrentCliInstall(state, "clawdi@1.2.3", "1.2.3");
-	const paths = getRuntimePaths();
-	return {
-		paths,
-		previousIdentity: currentCliFixtureIdentity(paths, "1.2.3"),
-		newIdentity: createVersionedCliFixture(paths, "1.2.4"),
-	};
-}
-
-function seedExternalCliBootstrapRecoveryFixture(
-	state: string,
-	run: string,
-	bootstrapVersion = "1.2.6",
-) {
-	process.env.CLAWDI_RUNTIME_MODE = "hosted";
-	process.env.CLAWDI_SERVICE_STATE_DIR = state;
-	process.env.CLAWDI_RUN_DIR = run;
-	const paths = getRuntimePaths();
-	const previousIdentity = createVersionedCliFixture(paths, "1.2.1");
-	const newIdentity = createVersionedCliFixture(paths, "1.2.5");
-	const bootstrapIdentity = createVersionedCliFixture(
-		paths,
-		bootstrapVersion,
-		join(paths.cliNpmPrefix, "installs", "install-external-bootstrap"),
-	);
-	pointManagedCliAt(paths, bootstrapIdentity);
-	writeCliBootstrapFixture(paths, bootstrapIdentity);
-	writeCliTransactionFixture(paths, {
-		phase: "activated",
-		previousIdentity,
-		newIdentity,
-		badVersions: [{ version: "1.2.0", reason: "existing rollback" }],
-	});
-	rmSync(previousIdentity.npmPrefix, { recursive: true, force: true });
-	return { paths, previousIdentity, newIdentity, bootstrapIdentity };
 }
 
 function cliManifest(version: string): RuntimeManifest {
@@ -957,7 +859,7 @@ function runtimeWatchLocaleManifest(
 		controlPlane: { apiUrl: "https://cloud-api.test" },
 		clawdiCli: {
 			source: "npm:clawdi",
-			packageSpec: "clawdi@1.2.3-test",
+			packageSpec: TEST_RUNNING_CLI_SPEC,
 			registry: "https://registry.npmjs.org",
 		},
 		runtimes: {
@@ -1116,7 +1018,7 @@ function hostedRuntimeWatchLocalePayload(
 			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 			clawdiCli: {
 				source: "npm:clawdi",
-				packageSpec: "clawdi@1.2.3-test",
+				packageSpec: TEST_RUNNING_CLI_SPEC,
 				registry: "https://registry.npmjs.org",
 			},
 			egressProfiles: { profiles: [] },
@@ -1150,7 +1052,7 @@ function hostedEgressSecretRotationPayload(
 			egressEngine,
 			clawdiCli: {
 				source: "npm:clawdi",
-				packageSpec: "clawdi@1.2.3-test",
+				packageSpec: TEST_RUNNING_CLI_SPEC,
 				registry: "https://registry.npmjs.org",
 			},
 			runtimes:
@@ -1559,7 +1461,12 @@ function seedRuntimeWatchLocaleBaseline(home: string, state: string, run: string
 	process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
 	process.env.CLAWDI_AUTH_TOKEN = "file-runtime-token";
 	setRuntimeApplyGeneration(1, CANONICAL_TEST_CONTEXT);
-	seedCurrentCliInstall(state, "clawdi@1.2.3-test", "1.2.3-test", "https://registry.npmjs.org");
+	seedCurrentCliInstall(
+		state,
+		TEST_RUNNING_CLI_SPEC,
+		TEST_RUNNING_CLI_VERSION,
+		"https://registry.npmjs.org",
+	);
 	writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 	const paths = getRuntimePaths();
 	const load: RuntimeManifestLoad = {
@@ -2923,7 +2830,7 @@ describe("runtime manifest datasource", () => {
 				controlPlane: { apiUrl: "https://cloud-api.test" },
 				clawdiCli: {
 					source: "npm:clawdi",
-					packageSpec: "clawdi@1.2.3-test",
+					packageSpec: TEST_RUNNING_CLI_SPEC,
 					registry: "https://registry.npmjs.org",
 				},
 				runtimes: { openclaw: { enabled: false } },
@@ -2965,7 +2872,7 @@ describe("runtime manifest datasource", () => {
 		mkdirSync(paths.cacheRoot, { recursive: true });
 		writeFileSync(
 			paths.manifestLastGood,
-			JSON.stringify(cachedHostedCliDesiredState(home, "clawdi@1.2.3-test")),
+			JSON.stringify(cachedHostedCliDesiredState(home, TEST_RUNNING_CLI_SPEC)),
 		);
 		const { restore } = mockFetch([
 			{
@@ -3030,7 +2937,7 @@ describe("runtime manifest datasource", () => {
 			controlPlane: { apiUrl: "https://cloud-api.test" },
 			clawdiCli: {
 				source: "npm:clawdi",
-				packageSpec: "clawdi@1.2.3-test",
+				packageSpec: TEST_RUNNING_CLI_SPEC,
 				registry: "https://registry.npmjs.org",
 			},
 			runtimes: { openclaw: { enabled: false } },
@@ -3107,7 +3014,7 @@ describe("runtime manifest datasource", () => {
 			controlPlane: { apiUrl: "https://cloud-api.test" },
 			clawdiCli: {
 				source: "npm:clawdi",
-				packageSpec: "clawdi@1.2.3-test",
+				packageSpec: TEST_RUNNING_CLI_SPEC,
 				registry: "https://registry.npmjs.org",
 			},
 			runtimes: { openclaw: { enabled: false } },
@@ -3156,7 +3063,7 @@ describe("runtime manifest datasource", () => {
 			controlPlane: { apiUrl: "https://cloud-api.test" },
 			clawdiCli: {
 				source: "npm:clawdi",
-				packageSpec: "clawdi@1.2.3-test",
+				packageSpec: TEST_RUNNING_CLI_SPEC,
 				registry: "https://registry.npmjs.org",
 			},
 			runtimes: { openclaw: { enabled: false } },
@@ -3219,7 +3126,7 @@ describe("runtime manifest datasource", () => {
 				controlPlane: { apiUrl: "https://cloud-api.test" },
 				clawdiCli: {
 					source: "npm:clawdi",
-					packageSpec: "clawdi@1.2.3-test",
+					packageSpec: TEST_RUNNING_CLI_SPEC,
 					registry: "https://registry.npmjs.org",
 				},
 				runtimes: { openclaw: { enabled: false } },
@@ -3277,7 +3184,7 @@ describe("runtime manifest datasource", () => {
 							},
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@1.2.3-test",
+								packageSpec: TEST_RUNNING_CLI_SPEC,
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
@@ -3328,7 +3235,7 @@ describe("runtime manifest datasource", () => {
 			expect(loaded.manifest.environmentId).toBe("env_test");
 			expect(loaded.manifest.controlPlane.apiUrl).toBe("https://cloud-api.test");
 			expect(loaded.manifest.clawdiCli?.source).toBe("npm:clawdi");
-			expect(loaded.manifest.clawdiCli?.packageSpec).toBe("clawdi@1.2.3-test");
+			expect(loaded.manifest.clawdiCli?.packageSpec).toBe(TEST_RUNNING_CLI_SPEC);
 			expect(loaded.manifest.projection?.mcp).toEqual({
 				servers: { clawdi: { command: "clawdi", args: ["mcp"] } },
 			});
@@ -3528,7 +3435,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 							},
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@1.2.3-test",
+								packageSpec: TEST_RUNNING_CLI_SPEC,
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
@@ -3713,7 +3620,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 							},
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@1.2.3-test",
+								packageSpec: TEST_RUNNING_CLI_SPEC,
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
@@ -3810,7 +3717,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 							},
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@1.2.3-test",
+								packageSpec: TEST_RUNNING_CLI_SPEC,
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
@@ -4411,7 +4318,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 
-		const wireResponse = hostedCliManifestResponse(home, "clawdi@1.2.3-test");
+		const wireResponse = hostedCliManifestResponse(home, TEST_RUNNING_CLI_SPEC);
 		const terminalTooling = expectRecord(wireResponse.manifest.terminalTooling, "terminal tooling");
 		const codex = expectRecord(terminalTooling.codex, "terminal Codex");
 		const wireProvider = expectRecord(codex.provider, "terminal Codex provider");
@@ -6522,7 +6429,7 @@ cp '${sdkSource}' '${sdkTarget}'
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
-						packageSpec: "clawdi@1.2.3-test",
+						packageSpec: TEST_RUNNING_CLI_SPEC,
 						registry: "https://registry.npmjs.org",
 					},
 					runtimes: {
@@ -6691,7 +6598,7 @@ exit 64
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
-						packageSpec: "clawdi@1.2.3-test",
+						packageSpec: TEST_RUNNING_CLI_SPEC,
 						registry: "https://registry.npmjs.org",
 					},
 					runtimes: {
@@ -6738,7 +6645,7 @@ exit 64
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
-						packageSpec: "clawdi@1.2.3-test",
+						packageSpec: TEST_RUNNING_CLI_SPEC,
 						registry: "https://registry.npmjs.org",
 					},
 					runtimes: {
@@ -6804,7 +6711,7 @@ exit 64
 							controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@1.2.3-test",
+								packageSpec: TEST_RUNNING_CLI_SPEC,
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: { hermes: hostedHermesRuntime() },
@@ -6858,7 +6765,7 @@ exit 64
 				egressEngine,
 				clawdiCli: {
 					source: "npm:clawdi",
-					packageSpec: "clawdi@1.2.3-test",
+					packageSpec: TEST_RUNNING_CLI_SPEC,
 					registry: "https://registry.npmjs.org",
 				},
 				runtimes: { openclaw: hostedOpenClawRuntime() },
@@ -7917,7 +7824,12 @@ exit 64
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(state, "clawdi@1.2.3-test", "1.2.3-test", "https://registry.npmjs.org");
+		seedCurrentCliInstall(
+			state,
+			TEST_RUNNING_CLI_SPEC,
+			TEST_RUNNING_CLI_VERSION,
+			"https://registry.npmjs.org",
+		);
 		seedMitmproxyCache();
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		const { captured, restore } = mockFetch([
@@ -7943,7 +7855,7 @@ exit 64
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
-									packageSpec: "clawdi@1.2.3-test",
+									packageSpec: TEST_RUNNING_CLI_SPEC,
 									registry: "https://registry.npmjs.org",
 								},
 								egressProfiles: { profiles: [] },
@@ -8118,7 +8030,12 @@ exit 64
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(state, "clawdi@1.2.3-test", "1.2.3-test", "https://registry.npmjs.org");
+		seedCurrentCliInstall(
+			state,
+			TEST_RUNNING_CLI_SPEC,
+			TEST_RUNNING_CLI_VERSION,
+			"https://registry.npmjs.org",
+		);
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		setRuntimeApplyContextFixture(
 			{
@@ -8522,7 +8439,12 @@ fi
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(state, "clawdi@1.2.3-test", "1.2.3-test", "https://registry.npmjs.org");
+		seedCurrentCliInstall(
+			state,
+			TEST_RUNNING_CLI_SPEC,
+			TEST_RUNNING_CLI_VERSION,
+			"https://registry.npmjs.org",
+		);
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		const { restore } = mockFetch([
 			{
@@ -8545,7 +8467,7 @@ fi
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
-									packageSpec: "clawdi@1.2.3-test",
+									packageSpec: TEST_RUNNING_CLI_SPEC,
 									registry: "https://registry.npmjs.org",
 								},
 								runtimes: {
@@ -8618,7 +8540,7 @@ fi
 				controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 				clawdiCli: {
 					source: "npm:clawdi",
-					packageSpec: "clawdi@1.2.3-test",
+					packageSpec: TEST_RUNNING_CLI_SPEC,
 					registry: "https://registry.npmjs.org",
 				},
 				runtimes: {
@@ -8713,7 +8635,12 @@ exit 64
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(state, "clawdi@1.2.3-test", "1.2.3-test", "https://registry.npmjs.org");
+		seedCurrentCliInstall(
+			state,
+			TEST_RUNNING_CLI_SPEC,
+			TEST_RUNNING_CLI_VERSION,
+			"https://registry.npmjs.org",
+		);
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		const paths = getRuntimePaths();
 		seedMitmproxyCache(paths);
@@ -8833,7 +8760,12 @@ exit 64
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
-		seedCurrentCliInstall(state, "clawdi@1.2.3-test", "1.2.3-test", "https://registry.npmjs.org");
+		seedCurrentCliInstall(
+			state,
+			TEST_RUNNING_CLI_SPEC,
+			TEST_RUNNING_CLI_VERSION,
+			"https://registry.npmjs.org",
+		);
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
@@ -8891,7 +8823,7 @@ exit 64
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
-									packageSpec: "clawdi@1.2.3-test",
+									packageSpec: TEST_RUNNING_CLI_SPEC,
 									registry: "https://registry.npmjs.org",
 								},
 								runtimes: { openclaw: hostedOpenClawRuntime() },
@@ -10103,7 +10035,6 @@ chmod +x "$prefix/bin/clawdi"
 			for (const unitPath of legacyUnitPaths) {
 				writeFileSync(unitPath, `${readFileSync(unitPath, "utf-8")}# legacy renderer drift\n`);
 			}
-
 			logs.length = 0;
 			writeFileSync(systemctlLog, "");
 			process.exitCode = undefined;
@@ -10149,9 +10080,11 @@ chmod +x "$prefix/bin/clawdi"
 				applyGeneration: 13,
 			});
 			const appliedBeforeDaemonHandoff = readFileSync(paths.appliedState, "utf-8");
-			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
-				transaction: { phase: "activated" },
-				badVersions: [],
+			expect(existsSync(paths.cliUpgradeState)).toBe(false);
+			expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"))).toMatchObject({
+				status: "installed",
+				previous: { version: "1.2.3-test" },
+				bad: null,
 			});
 
 			logs.length = 0;
@@ -10202,9 +10135,10 @@ chmod +x "$prefix/bin/clawdi"
 			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
 				"--user restart openclaw-gateway.service",
 			);
-			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
-				transaction: null,
-				badVersions: [],
+			expect(existsSync(paths.cliUpgradeState)).toBe(false);
+			expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"))).toMatchObject({
+				previous: null,
+				bad: null,
 			});
 
 			// Model a crash after the cache write but before the applied-state commit.
@@ -10328,7 +10262,12 @@ exit 0
 			if (runtime === "hermes") {
 				writeHermesDashboardPython(home, true);
 			}
-			seedCurrentCliInstall(state, "clawdi@1.2.3-test", "1.2.3-test", "https://registry.npmjs.org");
+			seedCurrentCliInstall(
+				state,
+				TEST_RUNNING_CLI_SPEC,
+				TEST_RUNNING_CLI_VERSION,
+				"https://registry.npmjs.org",
+			);
 			writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 			const mitmproxy = seedMitmproxyCache(paths);
 			console.log = (value?: unknown) => logs.push(String(value));
@@ -10450,7 +10389,12 @@ exit 0
 			logs.push(String(value));
 		};
 		try {
-			seedCurrentCliInstall(state, "clawdi@1.2.3-test", "1.2.3-test", "https://registry.npmjs.org");
+			seedCurrentCliInstall(
+				state,
+				TEST_RUNNING_CLI_SPEC,
+				TEST_RUNNING_CLI_VERSION,
+				"https://registry.npmjs.org",
+			);
 			writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 			const paths = getRuntimePaths();
 			const mitmproxy = seedMitmproxyCache(paths);
@@ -11054,7 +10998,7 @@ chmod +x "$prefix/bin/clawdi"
 		["downgrades", "2.0.0-test.1", "1.2.3-test.2"],
 	])(
 		"hosted exact CLI desired state %s without npm view",
-		(_name, currentVersion, desiredVersion) => {
+		(action, currentVersion, desiredVersion) => {
 			const home = join(root, `home-${currentVersion}`, "clawdi");
 			const state = join(root, `state-${currentVersion}`);
 			const run = join(root, `run-${currentVersion}`);
@@ -11130,10 +11074,39 @@ chmod +x "$prefix/bin/clawdi"
 				if (!result.activeTarget) throw new Error("CLI update did not return an active target");
 				expect(statSync(result.activeTarget).mode & 0o777).toBe(0o755);
 				expect(statSync(paths.cliBootstrapStatus).mode & 0o777).toBe(0o600);
-				expect(statSync(paths.cliUpgradeState).mode & 0o777).toBe(0o600);
+				expect(existsSync(paths.cliUpgradeState)).toBe(false);
+				const pending = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+				expect(pending).toMatchObject({
+					status: "installed",
+					packageSpec: desiredSpec,
+					activeTarget: result.activeTarget,
+					version: desiredVersion,
+					previous: { version: currentVersion },
+					bad: null,
+				});
+				expect(pending.verification).toBeDefined();
 				const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
 				expect(npmCalls.some((call) => call.startsWith("view "))).toBe(false);
 				expect(npmCalls.some((call) => call.includes(desiredSpec))).toBe(true);
+
+				if (action === "upgrades") {
+					expect(completePendingRuntimeCliUpgrade(paths, desiredVersion)).toEqual({
+						status: "unchanged",
+						selfReexec: false,
+					});
+					expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8")).previous).toBeNull();
+				} else {
+					expect(rollbackPendingRuntimeCliUpgrade(paths, "first converge failed").status).toBe(
+						"rolled_back",
+					);
+					const rolledBack = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+					expect(rolledBack).toMatchObject({
+						version: currentVersion,
+						previous: null,
+						bad: { version: desiredVersion, attempts: 1 },
+					});
+					expect(applyRuntimeCliDesiredState(desired.manifest, paths).status).toBe("deferred");
+				}
 			} finally {
 				if (previousPath === undefined) delete process.env.PATH;
 				else process.env.PATH = previousPath;
@@ -11141,411 +11114,83 @@ chmod +x "$prefix/bin/clawdi"
 		},
 	);
 
-	it("cancels a prepared CLI transaction while the previous target is still active", () => {
-		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(
-			join(root, "state-cli-prepared-previous"),
-			join(root, "run-cli-prepared-previous"),
-		);
-		pointManagedCliAt(paths, previousIdentity);
-		writeCliBootstrapFixture(paths, previousIdentity);
-		writeCliTransactionFixture(paths, {
-			phase: "prepared",
-			previousIdentity,
-			newIdentity,
-		});
-
-		const recovered = reconcilePendingRuntimeCliUpgrade(paths, previousIdentity.version);
-
-		expect(recovered).toEqual({ status: "unchanged", selfReexec: false });
-		expect(readlinkSync(paths.cliManagedBin)).toBe(previousIdentity.activeTarget);
-		expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8")).transaction).toBeNull();
-		expect(existsSync(newIdentity.npmPrefix)).toBe(false);
-	});
-
-	it("activates a prepared CLI transaction whose valid new target is already active", () => {
-		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(
-			join(root, "state-cli-prepared-new"),
-			join(root, "run-cli-prepared-new"),
-		);
-		pointManagedCliAt(paths, newIdentity);
-		writeCliBootstrapFixture(paths, previousIdentity);
-		writeCliTransactionFixture(paths, {
-			phase: "prepared",
-			previousIdentity,
-			newIdentity,
-		});
-
-		const recovered = reconcilePendingRuntimeCliUpgrade(paths, previousIdentity.version);
-		const transactionState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-		const bootstrap = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-
-		expect(recovered).toEqual({ status: "activated", selfReexec: true });
-		expect(transactionState.transaction).toMatchObject({
-			phase: "activated",
-			newIdentity,
-		});
-		expect(bootstrap).toMatchObject({
-			activeTarget: newIdentity.activeTarget,
-			version: newIdentity.version,
-		});
-		expect(readlinkSync(paths.cliManagedBin)).toBe(newIdentity.activeTarget);
-	});
-
-	it("keeps an old process behind the handoff fence for an activated transaction", () => {
-		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(
-			join(root, "state-cli-activated-old-process"),
-			join(root, "run-cli-activated-old-process"),
-		);
-		pointManagedCliAt(paths, newIdentity);
-		writeCliBootstrapFixture(paths, newIdentity);
-		writeCliTransactionFixture(paths, {
-			phase: "activated",
-			previousIdentity,
-			newIdentity,
-		});
-
-		const recovered = reconcilePendingRuntimeCliUpgrade(paths, previousIdentity.version);
-
-		expect(recovered).toEqual({ status: "unchanged", selfReexec: true });
-		expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
-			transaction: { phase: "activated", newIdentity },
-			badVersions: [],
-		});
-	});
-
-	it("reads legacy CLI journals whose bad-version entries have no timestamp", () => {
-		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(
-			join(root, "state-cli-legacy-bad-version"),
-			join(root, "run-cli-legacy-bad-version"),
-		);
-		pointManagedCliAt(paths, newIdentity);
-		writeCliBootstrapFixture(paths, newIdentity);
-		writeCliTransactionFixture(paths, {
-			phase: "activated",
-			previousIdentity,
-			newIdentity,
-			badVersions: [{ version: newIdentity.version, reason: "legacy rollback" }],
-		});
-		const legacyState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-		delete legacyState.badVersions[0].markedAt;
-		writeFileSync(paths.cliUpgradeState, `${JSON.stringify(legacyState)}\n`);
-
-		const recovered = reconcilePendingRuntimeCliUpgrade(paths, newIdentity.version);
-
-		expect(recovered).toEqual({ status: "unchanged", selfReexec: false });
-	});
-
-	it("accepts a verified external bootstrap that supersedes a stale activated transaction", () => {
-		const { paths, previousIdentity, newIdentity, bootstrapIdentity } =
-			seedExternalCliBootstrapRecoveryFixture(
-				join(root, "state-cli-external-bootstrap"),
-				join(root, "run-cli-external-bootstrap"),
-			);
-		const before = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-		expect(existsSync(previousIdentity.npmPrefix)).toBe(false);
-
-		const recovered = reconcilePendingRuntimeCliUpgrade(paths, bootstrapIdentity.version);
-		const handedOff = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-		const bootstrap = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-
-		expect(recovered).toEqual({ status: "activated", selfReexec: false });
-		expect(readlinkSync(paths.cliManagedBin)).toBe(bootstrapIdentity.activeTarget);
-		expect(handedOff.transaction).toMatchObject({
-			phase: "activated",
-			previousIdentity: null,
-			newIdentity: bootstrapIdentity,
-			rollbackEligible: false,
-			rollback: null,
-		});
-		expect(handedOff.badVersions).toEqual(before.badVersions);
-		expect(bootstrap).toMatchObject({
-			packageSpec: bootstrapIdentity.packageSpec,
-			npmPrefix: bootstrapIdentity.npmPrefix,
-			activeTarget: bootstrapIdentity.activeTarget,
-			version: bootstrapIdentity.version,
-			verification: {
-				verifiedAt: expect.any(String),
-				device: expect.any(Number),
-				inode: expect.any(Number),
-				size: expect.any(Number),
-				modifiedAtMs: expect.any(Number),
-			},
-		});
-		expect(existsSync(bootstrapIdentity.npmPrefix)).toBe(true);
-		expect(existsSync(newIdentity.npmPrefix)).toBe(false);
-
-		const journalAfterHandoff = readFileSync(paths.cliUpgradeState, "utf-8");
-		const staleOwnerRollback = rollbackPendingRuntimeCliUpgrade(
-			paths,
-			"stale self-upgrade owner must not roll back bootstrap",
-		);
-		expect(staleOwnerRollback.status).toBe("not_pending");
-		expect(readFileSync(paths.cliUpgradeState, "utf-8")).toBe(journalAfterHandoff);
-
-		const replayed = reconcilePendingRuntimeCliUpgrade(paths, bootstrapIdentity.version);
-		expect(replayed).toEqual({ status: "unchanged", selfReexec: false });
-		expect(readFileSync(paths.cliUpgradeState, "utf-8")).toBe(journalAfterHandoff);
-
-		completePendingRuntimeCliUpgrade(paths, bootstrapIdentity.version);
-		const completed = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-		expect(completed.transaction).toBeNull();
-		expect(completed.badVersions).toEqual(before.badVersions);
-	});
-
-	it("runtime watch fences an old process after durably handing off a trusted activation", async () => {
-		const runningVersion = getCliVersion();
-		const bootstrapVersion = runningVersion === "999.0.0" ? "999.0.1" : "999.0.0";
-		const state = join(root, "state-cli-external-bootstrap-old-process");
-		const run = join(root, "run-cli-external-bootstrap-old-process");
-		process.env.HOME = join(root, "home-cli-external-bootstrap-old-process");
-		process.env.CLAWDI_SYSTEMD_SYSTEM_ROOT = join(run, "systemd", "system");
-		const { paths, bootstrapIdentity } = seedExternalCliBootstrapRecoveryFixture(
-			state,
-			run,
-			bootstrapVersion,
-		);
-		const before = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-		const logs: string[] = [];
-		const previousLog = console.log;
-		const previousExitCode = process.exitCode;
-		const { captured, restore } = mockFetch([]);
-		expect(bootstrapIdentity.version).not.toBe(runningVersion);
-		console.log = (value?: unknown) => {
-			logs.push(String(value));
-		};
-		process.exitCode = undefined;
-
-		try {
-			await runtimeWatch({ once: true, json: true, notifications: false });
-
-			const event = JSON.parse(logs[0]);
-			const handedOff = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-			expect(process.exitCode ?? 0).toBe(0);
-			expect(event).toMatchObject({
-				status: "cli_handoff",
-				handoff: "cli_reexec",
-				reconciliation: { status: "activated", selfReexec: true },
-				selfReexec: true,
-			});
-			expect(captured).toHaveLength(0);
-			expect(readlinkSync(paths.cliManagedBin)).toBe(bootstrapIdentity.activeTarget);
-			expect(handedOff).toMatchObject({
-				transaction: {
-					phase: "activated",
-					previousIdentity: null,
-					newIdentity: bootstrapIdentity,
-					rollbackEligible: false,
-					rollback: null,
-				},
-				badVersions: before.badVersions,
-			});
-			expect(existsSync(paths.manifestLastGood)).toBe(false);
-			expect(existsSync(paths.appliedState)).toBe(false);
-		} finally {
-			restore();
-			console.log = previousLog;
-			process.exitCode = previousExitCode;
-		}
-	});
-
-	it("hands off by verified identity without using version ordering", () => {
-		const { paths, bootstrapIdentity } = seedExternalCliBootstrapRecoveryFixture(
-			join(root, "state-cli-external-bootstrap-lower-version"),
-			join(root, "run-cli-external-bootstrap-lower-version"),
-			"1.2.0",
-		);
-
-		const recovered = reconcilePendingRuntimeCliUpgrade(paths, bootstrapIdentity.version);
-		const handedOff = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-
-		expect(recovered).toEqual({ status: "activated", selfReexec: false });
-		expect(handedOff.transaction).toMatchObject({
-			newIdentity: bootstrapIdentity,
-			rollbackEligible: false,
-		});
-	});
-
-	it("fails closed when a bootstrap-owned handoff journal replays a tampered target", () => {
-		const { paths, bootstrapIdentity } = seedExternalCliBootstrapRecoveryFixture(
-			join(root, "state-cli-external-bootstrap-replay-tampered"),
-			join(root, "run-cli-external-bootstrap-replay-tampered"),
-		);
-		reconcilePendingRuntimeCliUpgrade(paths, bootstrapIdentity.version);
-		writeFileSync(bootstrapIdentity.activeTarget, "#!/usr/bin/env bash\nexit 1\n", {
-			mode: 0o700,
-		});
-		const handoffJournal = readFileSync(paths.cliUpgradeState, "utf-8");
-
-		expect(() => reconcilePendingRuntimeCliUpgrade(paths, bootstrapIdentity.version)).toThrow(
-			"clawdi CLI transaction cannot restore a verified previous identity",
-		);
-		expect(readFileSync(paths.cliUpgradeState, "utf-8")).toBe(handoffJournal);
-		expect(readlinkSync(paths.cliManagedBin)).toBe(bootstrapIdentity.activeTarget);
-	});
-
-	it("fails closed when an external bootstrap target was tampered", () => {
-		const { paths, bootstrapIdentity } = seedExternalCliBootstrapRecoveryFixture(
-			join(root, "state-cli-external-bootstrap-tampered"),
-			join(root, "run-cli-external-bootstrap-tampered"),
-		);
-		writeFileSync(bootstrapIdentity.activeTarget, "#!/usr/bin/env bash\nexit 1\n", {
-			mode: 0o700,
-		});
-		const before = readFileSync(paths.cliUpgradeState, "utf-8");
-
-		expect(() => reconcilePendingRuntimeCliUpgrade(paths, bootstrapIdentity.version)).toThrow(
-			"clawdi CLI transaction cannot restore a verified previous identity",
-		);
-		expect(readFileSync(paths.cliUpgradeState, "utf-8")).toBe(before);
-		expect(readlinkSync(paths.cliManagedBin)).toBe(bootstrapIdentity.activeTarget);
-	});
-
-	it("fails closed when bootstrap status is stale for the externally active target", () => {
-		const { paths, newIdentity, bootstrapIdentity } = seedExternalCliBootstrapRecoveryFixture(
-			join(root, "state-cli-external-bootstrap-stale-status"),
-			join(root, "run-cli-external-bootstrap-stale-status"),
-		);
-		writeCliBootstrapFixture(paths, newIdentity);
-		const before = readFileSync(paths.cliUpgradeState, "utf-8");
-
-		expect(() => reconcilePendingRuntimeCliUpgrade(paths, bootstrapIdentity.version)).toThrow(
-			"clawdi CLI transaction cannot restore a verified previous identity",
-		);
-		expect(readFileSync(paths.cliUpgradeState, "utf-8")).toBe(before);
-		expect(readlinkSync(paths.cliManagedBin)).toBe(bootstrapIdentity.activeTarget);
-	});
-
-	it("fails closed when bootstrap identity mismatches the externally active version", () => {
-		const { paths, bootstrapIdentity } = seedExternalCliBootstrapRecoveryFixture(
-			join(root, "state-cli-external-bootstrap-mismatch"),
-			join(root, "run-cli-external-bootstrap-mismatch"),
-		);
-		const bootstrap = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-		bootstrap.version = "1.2.5";
-		writeFileSync(paths.cliBootstrapStatus, `${JSON.stringify(bootstrap)}\n`);
-		const before = readFileSync(paths.cliUpgradeState, "utf-8");
-
-		expect(() => reconcilePendingRuntimeCliUpgrade(paths, bootstrapIdentity.version)).toThrow(
-			"clawdi CLI transaction cannot restore a verified previous identity",
-		);
-		expect(readFileSync(paths.cliUpgradeState, "utf-8")).toBe(before);
-		expect(readlinkSync(paths.cliManagedBin)).toBe(bootstrapIdentity.activeTarget);
-	});
-
-	it("completes a normal activated transaction without changing bad-version history", () => {
+	it.each([
+		{ writerVersion: "0.13.92", phase: "prepared" },
+		{ writerVersion: "0.14.14", phase: "activated" },
+	])("adopts $writerVersion persisted CLI state on first converge", ({ writerVersion, phase }) => {
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state-cli-normal-completion");
-		process.env.CLAWDI_RUN_DIR = join(root, "run-cli-normal-completion");
+		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, `state-cli-adoption-${writerVersion}`);
+		process.env.CLAWDI_RUN_DIR = join(root, `run-cli-adoption-${writerVersion}`);
 		const paths = getRuntimePaths();
-		const previousIdentity = createVersionedCliFixture(paths, "1.2.3");
-		const newIdentity = createVersionedCliFixture(paths, "1.2.4");
-		pointManagedCliAt(paths, newIdentity);
-		writeCliBootstrapFixture(paths, newIdentity);
-		writeCliTransactionFixture(paths, {
-			phase: "activated",
-			previousIdentity,
-			newIdentity,
-			badVersions: [{ version: "1.2.2", reason: "existing rollback" }],
+		const previous = createVersionedCliFixture(paths, `1.2.6-${writerVersion}`);
+		const candidate = createVersionedCliFixture(paths, `1.2.7-${writerVersion}`);
+		const active = phase === "prepared" ? previous : candidate;
+		const stale = phase === "prepared" ? candidate : previous;
+		pointManagedCliAt(paths, active);
+		writeCliBootstrapFixture(paths, active);
+		writeFileSync(
+			paths.cliUpgradeState,
+			`${JSON.stringify({
+				schemaVersion: "clawdi.cliUpgradeState.v2",
+				transaction: {
+					phase,
+					previousIdentity: previous,
+					newIdentity: candidate,
+					rollbackEligible: true,
+					installedAt: "2026-07-29T00:00:00.000Z",
+					rollback:
+						phase === "activated"
+							? {
+									reason: "first converge failed",
+									markedAt: "2026-07-29T00:01:00.000Z",
+								}
+							: null,
+				},
+				badVersions: [
+					{
+						packageSpec: "clawdi@1.2.5",
+						registry: "https://registry.npmjs.org",
+						version: "1.2.5",
+						reason: "existing rollback",
+						markedAt: "2026-07-29T00:01:00.000Z",
+					},
+				],
+			})}\n`,
+			{ mode: 0o600 },
+		);
+		const retiredQuarantine = `${paths.cliUpgradeState}.corrupt-1722211200000-fixture`;
+		writeFileSync(retiredQuarantine, "{broken journal", { mode: 0o600 });
+		expect(statSync(paths.cliUpgradeState).mode & 0o777).toBe(0o600);
+
+		expect(reconcilePendingRuntimeCliUpgrade(paths, active.version)).toEqual({
+			status: "unchanged",
+			selfReexec: false,
 		});
-		const before = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-
-		const completed = completePendingRuntimeCliUpgrade(paths, newIdentity.version);
-		const after = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-
-		expect(completed).toEqual({ status: "unchanged", selfReexec: false });
-		expect(after.transaction).toBeNull();
-		expect(after.badVersions).toEqual(before.badVersions);
-		expect(readlinkSync(paths.cliManagedBin)).toBe(newIdentity.activeTarget);
-		expect(existsSync(previousIdentity.npmPrefix)).toBe(false);
-		expect(existsSync(newIdentity.npmPrefix)).toBe(true);
-	});
-
-	it("rolls back an activated CLI transaction whose new target is invalid", () => {
-		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(
-			join(root, "state-cli-activated-invalid"),
-			join(root, "run-cli-activated-invalid"),
-		);
-		pointManagedCliAt(paths, newIdentity);
-		writeCliBootstrapFixture(paths, newIdentity);
-		writeCliTransactionFixture(paths, {
-			phase: "activated",
-			previousIdentity,
-			newIdentity,
-			badVersions: [{ version: "1.2.2", reason: "existing rollback" }],
-		});
-		writeFileSync(newIdentity.activeTarget, "#!/usr/bin/env bash\nexit 1\n", { mode: 0o700 });
-
-		const recovered = reconcilePendingRuntimeCliUpgrade(paths, newIdentity.version);
-		const transactionState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-
-		expect(recovered).toEqual({ status: "rolled_back", selfReexec: true });
-		expect(readlinkSync(paths.cliManagedBin)).toBe(previousIdentity.activeTarget);
-		expect(transactionState.transaction).toBeNull();
-		expect(transactionState.badVersions).toContainEqual(
-			expect.objectContaining({ version: newIdentity.version }),
-		);
-		expect(transactionState.badVersions).toContainEqual(
-			expect.objectContaining({ version: "1.2.2", reason: "existing rollback" }),
-		);
-	});
-
-	it("finishes a durable rollback intent while the new target is still active", () => {
-		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(
-			join(root, "state-cli-rollback-new"),
-			join(root, "run-cli-rollback-new"),
-		);
-		pointManagedCliAt(paths, newIdentity);
-		writeCliBootstrapFixture(paths, newIdentity);
-		writeCliTransactionFixture(paths, {
-			phase: "activated",
-			previousIdentity,
-			newIdentity,
-			rollbackReason: "fixture convergence failure",
-		});
-
-		const recovered = reconcilePendingRuntimeCliUpgrade(paths, newIdentity.version);
-		const transactionState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-
-		expect(recovered).toEqual({ status: "rolled_back", selfReexec: true });
-		expect(readlinkSync(paths.cliManagedBin)).toBe(previousIdentity.activeTarget);
-		expect(transactionState.transaction).toBeNull();
-		expect(transactionState.badVersions).toContainEqual(
-			expect.objectContaining({
-				version: newIdentity.version,
-				reason: "fixture convergence failure",
+		expect(
+			applyRuntimeCliDesiredState(cliManifest(active.version), paths, {
+				runningVersion: active.version,
 			}),
-		);
-		expect(existsSync(newIdentity.npmPrefix)).toBe(false);
+		).toMatchObject({ status: "current", version: active.version, selfReexec: false });
+		expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"))).toMatchObject({
+			packageSpec: active.packageSpec,
+			activeTarget: active.activeTarget,
+			version: active.version,
+			previous: null,
+			bad: null,
+			verification: { verifiedAt: expect.any(String) },
+		});
+		expect(readlinkSync(paths.cliManagedBin)).toBe(active.activeTarget);
+		expect(existsSync(paths.cliUpgradeState)).toBe(false);
+		expect(readFileSync(retiredQuarantine, "utf-8")).toBe("{broken journal");
+		expect(existsSync(active.npmPrefix)).toBe(true);
+		expect(existsSync(stale.npmPrefix)).toBe(false);
+		expect(statSync(active.npmPrefix).mode & 0o777).toBe(0o755);
+		expect(statSync(dirname(paths.cliManagedBin)).mode & 0o777).toBe(0o755);
+		expect(statSync(paths.cliBootstrapStatus).mode & 0o777).toBe(0o600);
+		expect(statSync(dirname(paths.cliBootstrapStatus)).mode & 0o777).toBe(0o755);
 	});
 
-	it("finishes rollback journal, status, and pruning when the previous target is active", () => {
-		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(
-			join(root, "state-cli-rollback-previous"),
-			join(root, "run-cli-rollback-previous"),
-		);
-		pointManagedCliAt(paths, previousIdentity);
-		writeCliBootstrapFixture(paths, newIdentity);
-		writeCliTransactionFixture(paths, {
-			phase: "activated",
-			previousIdentity,
-			newIdentity,
-			rollbackReason: "fixture convergence failure",
-		});
-
-		const recovered = reconcilePendingRuntimeCliUpgrade(paths, newIdentity.version);
-		const transactionState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-		const bootstrap = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-
-		expect(recovered).toEqual({ status: "rolled_back", selfReexec: true });
-		expect(transactionState.transaction).toBeNull();
-		expect(bootstrap).toMatchObject({
-			activeTarget: previousIdentity.activeTarget,
-			version: previousIdentity.version,
-		});
-		expect(existsSync(newIdentity.npmPrefix)).toBe(false);
-	});
-
-	it("re-verifies a current CLI periodically and whenever its file identity drifts", () => {
+	it("re-verifies the active CLI when its file identity drifts", () => {
 		const state = join(root, "state-cli-verification-cache");
 		const run = join(root, "run-cli-verification-cache");
 		const commandLog = join(root, "cli-verification-cache.log");
@@ -11576,1765 +11221,93 @@ exit 64
 		utimesSync(activeTarget, driftedAt, driftedAt);
 		applyRuntimeCliDesiredState(manifest, paths);
 		expect(readFileSync(commandLog, "utf-8").trim().split("\n")).toHaveLength(4);
-
-		const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-		status.verification.verifiedAt = "2020-01-01T00:00:00.000Z";
-		writeFileSync(paths.cliBootstrapStatus, JSON.stringify(status));
-		applyRuntimeCliDesiredState(manifest, paths);
-		expect(readFileSync(commandLog, "utf-8").trim().split("\n")).toHaveLength(6);
 	});
 
-	it("does not cache a changed target as the verified desired CLI", () => {
-		const state = join(root, "state-cli-verification-race");
-		const run = join(root, "run-cli-verification-race");
-		const bin = join(root, "bin-cli-verification-race");
-		const previousPath = process.env.PATH;
+	it("rolls back when the active symlink disagrees with state", () => {
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(state, "clawdi@1.2.3", "1.2.3");
+		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state-cli-crash-recovery");
+		process.env.CLAWDI_RUN_DIR = join(root, "run-cli-crash-recovery");
 		const paths = getRuntimePaths();
-		const activeTarget = readlinkSync(paths.cliManagedBin);
-		mkdirSync(bin, { recursive: true });
-		writeFileSync(join(bin, "npm"), "#!/usr/bin/env bash\nexit 97\n");
-		chmodSync(join(bin, "npm"), 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		writeFileSync(
-			activeTarget,
-			`#!/usr/bin/env bash
-if [ "\${1:-}" = "--version" ]; then
-  cat > "$0" <<'SH'
-#!/usr/bin/env bash
-if [ "\${1:-}" = "--version" ]; then echo '1.2.2'; exit 0; fi
-if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then echo '{"status":"ok"}'; exit 0; fi
-exit 64
-SH
-  chmod +x "$0"
-  echo '1.2.3'
-  exit 0
-fi
-if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then echo '{"status":"ok"}'; exit 0; fi
-exit 64
-`,
-		);
-		chmodSync(activeTarget, 0o700);
+		const candidate = createVersionedCliFixture(paths, "1.2.8-test.1");
+		pointManagedCliAt(paths, candidate);
+		writeCliBootstrapFixture(paths, candidate);
+		reconcilePendingRuntimeCliUpgrade(paths, candidate.version);
+		const previous = createVersionedCliFixture(paths, "1.2.7-test.1");
+		const state = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+		state.previous = { activeTarget: previous.activeTarget, version: previous.version };
+		writeFileSync(paths.cliBootstrapStatus, `${JSON.stringify(state)}\n`);
+		pointManagedCliAt(paths, previous);
 
-		try {
-			expect(() => applyRuntimeCliDesiredState(cliManifest("1.2.3"), paths)).toThrow(/npm install/);
-			const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-			expect(status.packageSpec).toBe("clawdi@1.2.2");
-			expect(status.version).toBe("1.2.2");
-			expect(status.verification).toBeDefined();
-		} finally {
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
-
-	it("quarantines corrupt CLI state and continues with the requested upgrade", () => {
-		const state = join(root, "state-cli-corrupt-journal");
-		const run = join(root, "run-cli-corrupt-journal");
-		const bin = join(root, "bin-cli-corrupt-journal");
-		const previousPath = process.env.PATH;
-		mkdirSync(bin, { recursive: true });
-		writeFileSync(
-			join(bin, "npm"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-prefix=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--prefix" ]; then
-    prefix="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-test -n "$prefix"
-install -d "$prefix/bin"
-cat > "$prefix/bin/clawdi" <<'SH'
-#!/usr/bin/env bash
-if [ "\${1:-}" = "--version" ]; then echo '1.2.4'; exit 0; fi
-if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
-  echo '{"status":"ok"}'
-  exit 0
-fi
-exit 64
-SH
-chmod +x "$prefix/bin/clawdi"
-`,
-		);
-		chmodSync(join(bin, "npm"), 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(state, "clawdi@1.2.3", "1.2.3");
-		const paths = getRuntimePaths();
-		writeFileSync(paths.cliUpgradeState, "{broken journal");
-
-		try {
-			const result = applyRuntimeCliDesiredState(cliManifest("1.2.4"), paths);
-			const quarantined = cliUpgradeQuarantineFiles(paths);
-
-			expect(result.status).toBe("installed");
-			expect(result.version).toBe("1.2.4");
-			expect(result.selfReexec).toBe(true);
-			expect(quarantined).toHaveLength(1);
-			expect(readFileSync(quarantined[0], "utf-8")).toBe("{broken journal");
-			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
-				transaction: { phase: "activated", newIdentity: { version: "1.2.4" } },
-			});
-		} finally {
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
-
-	it("repairs an interrupted activation before discarding corrupt CLI state", () => {
-		const { paths, previousIdentity, newIdentity } = seedCliRecoveryFixture(
-			join(root, "state-cli-corrupt-half-activation"),
-			join(root, "run-cli-corrupt-half-activation"),
-		);
-		pointManagedCliAt(paths, newIdentity);
-		writeFileSync(paths.cliUpgradeState, "{broken journal");
-
-		const recovered = reconcilePendingRuntimeCliUpgrade(paths, previousIdentity.version);
-		const bootstrap = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-
-		expect(recovered).toEqual({ status: "unchanged", selfReexec: true });
-		expect(readlinkSync(paths.cliManagedBin)).toBe(newIdentity.activeTarget);
-		expect(bootstrap).toMatchObject({
-			activeTarget: newIdentity.activeTarget,
-			version: newIdentity.version,
+		expect(reconcilePendingRuntimeCliUpgrade(paths, candidate.version)).toEqual({
+			status: "rolled_back",
+			selfReexec: true,
 		});
-		expect(cliUpgradeQuarantineFiles(paths)).toHaveLength(1);
-		expect(
-			applyRuntimeCliDesiredState(cliManifest(newIdentity.version), paths, {
-				runningVersion: newIdentity.version,
-			}).status,
-		).toBe("current");
+		const recovered = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+		expect(recovered).toMatchObject({
+			activeTarget: previous.activeTarget,
+			version: previous.version,
+			previous: null,
+			bad: { version: candidate.version, attempts: 1 },
+		});
+		expect(readlinkSync(paths.cliManagedBin)).toBe(previous.activeTarget);
+		expect(existsSync(candidate.npmPrefix)).toBe(false);
 	});
 
-	it("quarantines structurally invalid state for the current CLI upgrade schema", () => {
-		const state = join(root, "state-cli-invalid-current-schema");
-		const run = join(root, "run-cli-invalid-current-schema");
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(state, "clawdi@1.2.3", "1.2.3");
-		const paths = getRuntimePaths();
-		writeFileSync(
-			paths.cliUpgradeState,
-			`${JSON.stringify({ schemaVersion: "clawdi.cliUpgradeState.v2", transaction: null })}\n`,
-		);
-
-		expect(applyRuntimeCliDesiredState(cliManifest("1.2.3"), paths).status).toBe("current");
-		expect(cliUpgradeQuarantineFiles(paths)).toHaveLength(1);
-		expect(existsSync(paths.cliUpgradeState)).toBe(false);
-	});
-
-	it("preserves and rejects CLI upgrade state from a future schema", () => {
-		const state = join(root, "state-cli-future-schema");
-		const run = join(root, "run-cli-future-schema");
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(state, "clawdi@1.2.3", "1.2.3");
-		const paths = getRuntimePaths();
-		const futureState = `${JSON.stringify({
-			schemaVersion: "clawdi.cliUpgradeState.v3",
-			transaction: null,
-			badVersions: [],
-		})}\n`;
-		writeFileSync(paths.cliUpgradeState, futureState);
-
-		expect(() => applyRuntimeCliDesiredState(cliManifest("1.2.3"), paths)).toThrow(
-			"unsupported clawdi CLI upgrade transaction schema: clawdi.cliUpgradeState.v3",
-		);
-		expect(readFileSync(paths.cliUpgradeState, "utf-8")).toBe(futureState);
-		expect(cliUpgradeQuarantineFiles(paths)).toHaveLength(0);
-	});
-
-	it("recovers an exact CLI install when matching bootstrap status has no version", () => {
-		const desiredVersion = "1.2.3-test.2";
-		const desiredSpec = `clawdi@${desiredVersion}`;
-		const home = join(root, "home-exact-recovery", "clawdi");
-		const state = join(root, "state-exact-recovery");
-		const run = join(root, "run-exact-recovery");
-		const bin = join(root, "bin-exact-recovery");
-		const npmLog = join(root, "npm-exact-recovery.log");
+	it("keeps the active CLI and backs off when the candidate fails verification", () => {
+		const stateRoot = join(root, "state-cli-verification-failure");
+		const runRoot = join(root, "run-cli-verification-failure");
+		const bin = join(root, "bin-cli-verification-failure");
+		const npmLog = join(root, "npm-cli-verification-failure.log");
 		const previousPath = process.env.PATH;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = stateRoot;
+		process.env.CLAWDI_RUN_DIR = runRoot;
 		mkdirSync(bin, { recursive: true });
 		writeFileSync(
 			join(bin, "npm"),
 			`#!/usr/bin/env bash
-printf '%s\\n' "$*" >> '${npmLog}'
-exit 97
-`,
+	set -euo pipefail
+	printf '%s\\n' "$*" >> '${npmLog}'
+	prefix=""
+	while [ "$#" -gt 0 ]; do
+	  if [ "$1" = "--prefix" ]; then prefix="$2"; shift 2; else shift; fi
+	done
+	install -d "$prefix/bin"
+	cat > "$prefix/bin/clawdi" <<'SH'
+	#!/usr/bin/env bash
+	if [ "\${1:-}" = "--version" ]; then echo "9.9.9-test.1"; exit 0; fi
+	if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then echo '{"status":"ok"}'; exit 0; fi
+	exit 64
+	SH
+	chmod +x "$prefix/bin/clawdi"
+	`,
 		);
 		chmodSync(join(bin, "npm"), 0o700);
 		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(state, desiredSpec, desiredVersion, "https://registry.npmjs.org");
-		const paths = getRuntimePaths();
-		const exactPrefix = join(paths.cliNpmPrefix, "packages", desiredVersion);
-		const exactTarget = join(exactPrefix, "bin", "clawdi");
-		mkdirSync(dirname(exactTarget), { recursive: true });
-		writeFileSync(
-			exactTarget,
-			`#!/usr/bin/env bash
-if [ "\${1:-}" = "--version" ]; then
-  echo "${desiredVersion}"
-  exit 0
-fi
-if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
-  echo '{"status":"ok"}'
-  exit 0
-fi
-exit 64
-`,
-		);
-		chmodSync(exactTarget, 0o700);
-		rmSync(paths.cliManagedBin, { force: true });
-		symlinkSync(exactTarget, paths.cliManagedBin);
-		const bootstrapStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-		bootstrapStatus.npmPrefix = exactPrefix;
-		bootstrapStatus.activeTarget = exactTarget;
-		delete bootstrapStatus.version;
-		writeFileSync(paths.cliBootstrapStatus, JSON.stringify(bootstrapStatus));
-
-		try {
-			const desired = normalizeHostedManifestFixture(hostedCliManifestResponse(home, desiredSpec));
-			const result = applyRuntimeCliDesiredState(desired.manifest, paths);
-
-			expect(result.status).toBe("current");
-			expect(result.packageSpec).toBe(desiredSpec);
-			expect(result.version).toBe(desiredVersion);
-			expect(result.npmPrefix).toBe(exactPrefix);
-			expect(result.activeTarget).toBe(exactTarget);
-			expect(readlinkSync(paths.cliManagedBin)).toBe(exactTarget);
-			expect(existsSync(npmLog)).toBe(false);
-			const repairedStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-			expect(repairedStatus.version).toBe(desiredVersion);
-			expect(repairedStatus.npmPrefix).toBe(exactPrefix);
-			expect(repairedStatus.activeTarget).toBe(exactTarget);
-		} finally {
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
-
-	it("reinstalls an exact CLI spec when the active link uses a legacy hash prefix", () => {
-		const desiredVersion = "1.2.3-test.2";
-		const desiredSpec = `clawdi@${desiredVersion}`;
-		const registry = "https://registry.npmjs.org";
-		const home = join(root, "home-exact-missing-version", "clawdi");
-		const state = join(root, "state-exact-missing-version");
-		const run = join(root, "run-exact-missing-version");
-		const bin = join(root, "bin-exact-missing-version");
-		const npmLog = join(root, "npm-exact-missing-version.log");
-		const previousPath = process.env.PATH;
-		mkdirSync(bin, { recursive: true });
-		writeFileSync(
-			join(bin, "npm"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\n' "$*" >> '${npmLog}'
-if [ "\${1:-}" = "view" ]; then
-  echo "exact hosted CLI updates must not call npm view" >&2
-  exit 96
-fi
-prefix=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--prefix" ]; then
-    prefix="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-test -n "$prefix"
-install -d "$prefix/bin"
-cat > "$prefix/bin/clawdi" <<'SH'
-#!/usr/bin/env bash
-if [ "\${1:-}" = "--version" ]; then
-  echo "${desiredVersion}"
-  exit 0
-fi
-if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
-  echo '{"status":"ok"}'
-  exit 0
-fi
-exit 64
-SH
-chmod +x "$prefix/bin/clawdi"
-`,
-		);
-		chmodSync(join(bin, "npm"), 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(state, desiredSpec, desiredVersion, registry);
-		const paths = getRuntimePaths();
-		const legacyHash = createHash("sha256")
-			.update(JSON.stringify({ packageSpec: desiredSpec, registry }))
-			.digest("hex")
-			.slice(0, 16);
-		const legacyPrefix = join(paths.cliNpmPrefix, "packages", legacyHash);
-		const legacyTarget = join(legacyPrefix, "bin", "clawdi");
-		mkdirSync(dirname(legacyTarget), { recursive: true });
-		writeFileSync(
-			legacyTarget,
-			`#!/usr/bin/env bash
-if [ "\${1:-}" = "--version" ]; then
-  echo "${desiredVersion}"
-  exit 0
-fi
-exit 64
-`,
-		);
-		chmodSync(legacyTarget, 0o700);
-		rmSync(paths.cliManagedBin, { force: true });
-		symlinkSync(legacyTarget, paths.cliManagedBin);
-		const bootstrapStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-		bootstrapStatus.npmPrefix = legacyPrefix;
-		bootstrapStatus.activeTarget = legacyTarget;
-		delete bootstrapStatus.version;
-		writeFileSync(paths.cliBootstrapStatus, JSON.stringify(bootstrapStatus));
-
-		try {
-			const desired = normalizeHostedManifestFixture(hostedCliManifestResponse(home, desiredSpec));
-			const result = applyRuntimeCliDesiredState(desired.manifest, paths);
-			const canonicalPrefix = join(paths.cliNpmPrefix, "packages", desiredVersion);
-			const canonicalTarget = join(canonicalPrefix, "bin", "clawdi");
-
-			expect(result.status).toBe("installed");
-			expect(result.packageSpec).toBe(desiredSpec);
-			expect(result.version).toBe(desiredVersion);
-			expect(result.npmPrefix).toBe(canonicalPrefix);
-			expect(result.activeTarget).toBe(canonicalTarget);
-			expect(readlinkSync(paths.cliManagedBin)).toBe(canonicalTarget);
-			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
-			expect(npmCalls.some((call) => call.startsWith("view "))).toBe(false);
-			expect(npmCalls.some((call) => call.startsWith("install "))).toBe(true);
-			expect(npmCalls.some((call) => call.includes(desiredSpec))).toBe(true);
-			const repairedStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-			expect(repairedStatus.version).toBe(desiredVersion);
-		} finally {
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
-
-	it("rejects an exact CLI install that reports a different version without swapping active", () => {
-		const desiredVersion = "1.2.3-test.2";
-		const actualVersion = "1.2.3-test.1";
-		const desiredSpec = `clawdi@${desiredVersion}`;
-		const home = join(root, "home-exact-version-mismatch", "clawdi");
-		const state = join(root, "state-exact-version-mismatch");
-		const run = join(root, "run-exact-version-mismatch");
-		const bin = join(root, "bin-exact-version-mismatch");
-		const npmLog = join(root, "npm-exact-version-mismatch.log");
-		const previousPath = process.env.PATH;
-		mkdirSync(bin, { recursive: true });
-		writeFileSync(
-			join(bin, "npm"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\n' "$*" >> '${npmLog}'
-if [ "\${1:-}" = "view" ]; then
-  echo "exact hosted CLI updates must not call npm view" >&2
-  exit 96
-fi
-prefix=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--prefix" ]; then
-    prefix="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-test -n "$prefix"
-install -d "$prefix/bin"
-cat > "$prefix/bin/clawdi" <<'SH'
-#!/usr/bin/env bash
-if [ "\${1:-}" = "--version" ]; then
-  echo "${actualVersion}"
-  exit 0
-fi
-if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
-  echo '{"status":"ok"}'
-  exit 0
-fi
-exit 64
-SH
-chmod +x "$prefix/bin/clawdi"
-`,
-		);
-		chmodSync(join(bin, "npm"), 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
 		seedCurrentCliInstall(
-			state,
-			"clawdi@1.2.3-test.1",
-			"1.2.3-test.1",
+			stateRoot,
+			"clawdi@1.2.9-test.1",
+			"1.2.9-test.1",
 			"https://registry.npmjs.org",
 		);
 		const paths = getRuntimePaths();
-		const oldTarget = readlinkSync(paths.cliManagedBin);
-		const oldStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+		const previousTarget = readlinkSync(paths.cliManagedBin);
 
 		try {
-			const desired = normalizeHostedManifestFixture(hostedCliManifestResponse(home, desiredSpec));
-			expect(() => applyRuntimeCliDesiredState(desired.manifest, paths)).toThrow(
-				`npm install ${desiredSpec} reported version ${actualVersion}, expected ${desiredVersion}`,
-			);
-
-			expect(readlinkSync(paths.cliManagedBin)).toBe(oldTarget);
-			expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"))).toEqual(oldStatus);
-			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
-			expect(npmCalls).toHaveLength(1);
-			expect(npmCalls[0].startsWith("install ")).toBe(true);
-			expect(npmCalls[0]).toContain(desiredSpec);
-			expect(npmCalls.some((call) => call.startsWith("view "))).toBe(false);
-		} finally {
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
-
-	it("runtime watch self-heal installs an exact hosted CLI version and hands off", async () => {
-		installSuccessfulSystemctlFixture();
-		setRuntimeApplyGeneration(30, CANONICAL_TEST_CONTEXT);
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const bin = join(root, "bin");
-		const npmLog = join(root, "npm-self-heal.log");
-		const previousExitCode = process.exitCode;
-		const previousLog = console.log;
-		const previousPath = process.env.PATH;
-		const logs: string[] = [];
-		mkdirSync(join(run, "secrets"), { recursive: true });
-		mkdirSync(bin, { recursive: true });
-		seedOpenClawBinary(home);
-		writeFileSync(
-			join(bin, "npm"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\n' "$*" >> '${npmLog}'
-	if [ "\${1:-}" = "view" ]; then
-	  echo "exact hosted CLI updates must not call npm view" >&2
-	  exit 96
-fi
-prefix=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--prefix" ]; then
-    prefix="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-test -n "$prefix"
-install -d "$prefix/bin"
-cat > "$prefix/bin/clawdi" <<'SH'
-#!/usr/bin/env bash
-	if [ "\${1:-}" = "--version" ]; then
-	  echo "1.2.3-test"
-  exit 0
-fi
-if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
-  echo '{"status":"ok"}'
-  exit 0
-fi
-exit 64
-SH
-chmod +x "$prefix/bin/clawdi"
-`,
-		);
-		chmodSync(join(bin, "npm"), 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		process.exitCode = undefined;
-		console.log = (value?: unknown) => {
-			logs.push(String(value));
-		};
-		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
-		const paths = getRuntimePaths();
-		seedCurrentCliInstall(
-			state,
-			"clawdi@1.2.3-test.2",
-			"1.2.3-test.2",
-			"https://registry.npmjs.org",
-		);
-		const manifestPayload = {
-			manifest: {
-				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
-				runtime: "openclaw",
-				deploymentId: "dep_cli_self_heal",
-				environmentId: "env_cli_self_heal",
-				...hostedRequiredState(),
-				instanceId: "iid_cli_self_heal",
-				generation: 30,
-				issuedAt: "2026-07-11T00:00:00Z",
-				locale: TEST_HOSTED_LOCALE,
-				system: hostedSystemFixture(home),
-				controlPlane: { cloudApiUrl: "https://cloud-api.test" },
-				clawdiCli: {
-					source: "npm:clawdi",
-					packageSpec: "clawdi@1.2.3-test",
-					registry: "https://registry.npmjs.org",
-				},
-				runtimes: { openclaw: hostedOpenClawRuntime() },
-			},
-			secretValues: {},
-		};
-		const bundleEtag = `"sha256:${"a".repeat(64)}"`;
-		writeRuntimeAppliedState(
-			{
-				schemaVersion: "clawdi.runtimeAppliedState.v2",
-				appliedAt: "2026-07-13T05:00:00.000Z",
-				instanceId: "iid_cli_self_heal",
-				etag: bundleEtag,
-				sourceRevision: "a".repeat(64),
-				generation: 30,
-				contentIdentity: {
-					sourcePath: "https://runtime.test/v1/runtime/manifest",
-					sha256: "b".repeat(64),
-				},
-				providerIds: ["default"],
-				projectedProviderIds: {},
-			},
-			paths,
-		);
-		const { captured, restore } = mockFetch([
-			{
-				method: "GET",
-				path: "/v1/runtime/manifest",
-				response: (request) =>
-					request.headers["if-none-match"]
-						? new Response(null, {
-								status: 304,
-								headers: { etag: bundleEtag },
-							})
-						: hostedRuntimeBundleResponse(manifestPayload, {
-								etag: bundleEtag,
-							}),
-			},
-		]);
-		let timeoutId: ReturnType<typeof setTimeout> | undefined;
-
-		try {
-			await Promise.race([
-				runtimeWatch({
-					intervalMs: 20,
-					selfHealMs: 10,
-					json: true,
-					notifications: false,
-				}),
-				new Promise<never>(
-					(_, reject) =>
-						(timeoutId = setTimeout(
-							() => reject(new Error("runtime watch self-heal test timed out")),
-							2_000,
-						)),
-				),
-			]);
-
-			expect(process.exitCode ?? 0).toBe(0);
-			expect(captured).toHaveLength(2);
-			expect(captured.map((request) => request.path)).toEqual([
-				"/v1/runtime/manifest",
-				"/v1/runtime/manifest",
-			]);
-			expect(captured[0].headers["if-none-match"]).toBe(bundleEtag);
-			expect(captured[1].headers["if-none-match"]).toBeUndefined();
-			const events = logs.map((line) => JSON.parse(line));
-			expect(events.map((event) => event.status)).toEqual(["cli_handoff"]);
-			expect(events[0].cliUpdate).toEqual(
-				expect.objectContaining({
-					status: "installed",
-					packageSpec: "clawdi@1.2.3-test",
-					version: "1.2.3-test",
-				}),
-			);
-			expect(events[0].selfReexec).toBe(true);
-			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
-			expect(npmCalls.some((call) => call.startsWith("view "))).toBe(false);
-			expect(npmCalls.some((call) => call.startsWith("install "))).toBe(true);
-		} finally {
-			if (timeoutId !== undefined) clearTimeout(timeoutId);
-			restore();
-			console.log = previousLog;
-			process.exitCode = previousExitCode;
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
-
-	it("runtime watch commits core after CLI activation when Agent Plugin preparation fails", async () => {
-		setRuntimeApplyGeneration(16);
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const bin = join(root, "bin");
-		const previousExitCode = process.exitCode;
-		const previousLog = console.log;
-		const previousPath = process.env.PATH;
-		const currentVersion = getCliVersion();
-		const logs: string[] = [];
-		mkdirSync(join(run, "secrets"), { recursive: true });
-		mkdirSync(bin, { recursive: true });
-		mkdirSync(home, { recursive: true });
-		writeFileSync(
-			join(bin, "npm"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-prefix=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--prefix" ]; then
-    prefix="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-install -d "$prefix/bin"
-cat > "$prefix/bin/clawdi" <<'SH'
-#!/usr/bin/env bash
-if [ "\${1:-}" = "--version" ]; then
-  echo "${currentVersion}"
-  exit 0
-fi
-if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
-  echo '{"status":"ok"}'
-  exit 0
-fi
-echo "fake clawdi"
-SH
-chmod +x "$prefix/bin/clawdi"
-`,
-		);
-		chmodSync(join(bin, "npm"), 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		process.exitCode = undefined;
-		console.log = (value?: unknown) => {
-			logs.push(String(value));
-		};
-		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
-		const { captured, restore } = mockFetch([
-			{
-				method: "GET",
-				path: "/v1/runtime/manifest",
-				response: () =>
-					hostedRuntimeBundleResponse(
-						{
-							manifest: {
-								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
-								runtime: "openclaw",
-								deploymentId: "dep_cli_update_converge_failure",
-								environmentId: "env_cli_update_converge_failure",
-								...hostedRequiredState(),
-								instanceId: "iid_cli_update_converge_failure",
-								generation: 16,
-								issuedAt: "2026-06-06T00:00:00Z",
-								locale: TEST_HOSTED_LOCALE,
-								system: hostedSystemFixture(home),
-								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
-								clawdiCli: {
-									source: "npm:clawdi",
-									packageSpec: `clawdi@${currentVersion}`,
-									registry: "https://registry.npmjs.org",
-								},
-								agentPlugins: {
-									schemaVersion: 1,
-									installations: {
-										"unavailable.plugin": {
-											installationId: "install_unavailable_plugin",
-											version: "1.0.0",
-											agentPluginsSchema:
-												"https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
-											source: {
-												type: "github",
-												url: "https://github.com/acme/unavailable-agent-plugin",
-												path: "plugin",
-												commit: "d".repeat(40),
-											},
-											contentDigest: `sha256-tree-v1:${"e".repeat(64)}`,
-										},
-									},
-								},
-								runtimes: {
-									openclaw: hostedOpenClawRuntime({}),
-								},
-							},
-							channelBindings: [
-								{
-									provider: "telegram",
-									accountKey: "clawdi_accttelegram",
-									agentTokenSecretRef: "secret://channels/telegram/clawdi_accttelegram/agent-token",
-									placeholderTokenSecretRef:
-										"secret://channels/telegram/clawdi_accttelegram/placeholder-token",
-								},
-							],
-							secretValues: {
-								"secret://channels/telegram/clawdi_accttelegram/agent-token":
-									"telegram-agent-token-failure",
-								"secret://channels/telegram/clawdi_accttelegram/placeholder-token":
-									"999999999:00000000000000000000000000000000",
-							},
-						},
-						{ etag: testBundleEtag("etag-projection-failed") },
-					),
-			},
-		]);
-
-		try {
-			await runtimeWatch({ once: true, json: true });
-
-			expect(process.exitCode).toBe(0);
-			const event = JSON.parse(logs[0]);
-			expect(event.status).toBe("cli_handoff");
-			expect(event.cliUpdate.status).toBe("installed");
-			expect(event.selfReexec).toBe(true);
-			expect(event.errors).toBeUndefined();
-			expect(captured.map((request) => request.path)).toEqual(["/v1/runtime/manifest"]);
-			expect(existsSync(join(home, ".local", "bin", "openclaw"))).toBe(false);
-			expect(existsSync(join(state, "cache", "manifest.etag"))).toBe(false);
-			expect(existsSync(getRuntimePaths().appliedState)).toBe(false);
-
-			seedOpenClawBinary(home);
-			installSuccessfulSystemctlFixture();
-			logs.length = 0;
-			process.exitCode = undefined;
-			await runtimeWatch({ once: true, json: true });
-
-			expect(process.exitCode).toBe(1);
-			const failedProjection = JSON.parse(logs[0]);
-			expect(failedProjection).toMatchObject({
-				status: "error",
-				stage: "final",
-				healthImpact: "resource_projection",
-				activeGeneration: 16,
-				rejectedGeneration: null,
-				cliUpdate: { status: "current" },
-			});
-			expect(failedProjection.errors.join("\n")).toContain(
-				"Agent Plugin package preparation failed",
-			);
-			expect(failedProjection.cliRollback).toBeUndefined();
-			expect(readRuntimeAppliedState(getRuntimePaths())).toMatchObject({ generation: 16 });
-			expect(JSON.parse(readFileSync(getRuntimePaths().cliUpgradeState, "utf-8"))).toMatchObject({
-				transaction: null,
-				badVersions: [],
-			});
-
-			logs.length = 0;
-			process.exitCode = undefined;
-			await runtimeInit({ nonInteractive: true, json: true });
-
-			expect(process.exitCode).toBe(0);
-			const bootStatus = JSON.parse(logs[0]);
-			expect(bootStatus).toMatchObject({ status: "ok", activeGeneration: 16, errors: [] });
-			expect(bootStatus.resourceProjectionErrors.join("\n")).toContain(
-				"Agent Plugin package preparation failed",
-			);
-		} finally {
-			restore();
-			console.log = previousLog;
-			process.exitCode = previousExitCode;
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
-
-	it.each(["runtime watch", "runtime init"] as const)(
-		"%s rolls back a forward CLI upgrade on first converge failure",
-		async (command) => {
-			const home = join(root, "home", "clawdi");
-			const state = join(root, "var", "lib", "clawdi");
-			const run = join(root, "run", "clawdi");
-			const bin = join(root, "bin");
-			const npmLog = join(root, "npm.log");
-			const openclawInstaller = join(root, "install-openclaw.sh");
-			const previousExitCode = process.exitCode;
-			const previousLog = console.log;
-			const previousPath = process.env.PATH;
-			const currentVersion = getCliVersion();
-			const previousVersion = "0.13.107";
-			setRuntimeApplyGeneration(18);
-			const logs: string[] = [];
-			mkdirSync(join(run, "secrets"), { recursive: true });
-			mkdirSync(bin, { recursive: true });
-			mkdirSync(home, { recursive: true });
-			writeFileSync(
-				join(bin, "npm"),
-				`#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\n' "$*" >> '${npmLog}'
-if [ "\${1:-}" = "view" ]; then
-  echo '"${currentVersion}"'
-  exit 0
-fi
-prefix=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--prefix" ]; then
-    prefix="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-install -d "$prefix/bin"
-cat > "$prefix/bin/clawdi" <<'SH'
-#!/usr/bin/env bash
-if [ "\${1:-}" = "--version" ]; then
-  echo "${currentVersion}"
-  exit 0
-fi
-if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
-  echo '{"status":"ok"}'
-  exit 0
-fi
-echo "fake clawdi"
-SH
-chmod +x "$prefix/bin/clawdi"
-`,
-			);
-			chmodSync(join(bin, "npm"), 0o700);
-			writeFileSync(openclawInstaller, "#!/usr/bin/env bash\necho install failed >&2\nexit 73\n");
-			chmodSync(openclawInstaller, 0o700);
-			process.env.PATH = `${bin}:${previousPath ?? ""}`;
-			process.env.HOME = home;
-			process.env.CLAWDI_RUNTIME_MODE = "hosted";
-			process.env.CLAWDI_SERVICE_STATE_DIR = state;
-			process.env.CLAWDI_RUN_DIR = run;
-			process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
-			process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER = openclawInstaller;
-			process.exitCode = undefined;
-			console.log = (value?: unknown) => {
-				logs.push(String(value));
-			};
-			writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
-			seedCurrentCliInstall(state, `clawdi@${previousVersion}`, previousVersion);
-			const paths = getRuntimePaths();
-			const oldTarget = readlinkSync(paths.cliManagedBin);
-			const manifest = {
-				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
-				runtime: "openclaw",
-				deploymentId: "dep_cli_rollback",
-				environmentId: "env_cli_rollback",
-				...hostedRequiredState(),
-				instanceId: "iid_cli_rollback",
-				generation: 18,
-				issuedAt: "2026-06-06T00:00:00Z",
-				locale: TEST_HOSTED_LOCALE,
-				system: hostedSystemFixture(home),
-				controlPlane: { cloudApiUrl: "https://cloud-api.test" },
-				clawdiCli: {
-					source: "npm:clawdi",
-					packageSpec: `clawdi@${currentVersion}`,
-					registry: "https://registry.npmjs.org",
-				},
-				runtimes: {
-					openclaw: hostedOpenClawRuntime({}),
-				},
-			};
-			writeRuntimeAppliedState(
-				{
-					schemaVersion: "clawdi.runtimeAppliedState.v2",
-					appliedAt: "2026-07-13T05:00:00.000Z",
-					instanceId: "iid_cli_rollback",
-					etag: testBundleEtag("etag-cli-rollback-previous"),
-					sourceRevision: "a".repeat(64),
-					generation: 18,
-					contentIdentity: {
-						sourcePath: "https://runtime.test/v1/runtime/manifest",
-						sha256: "b".repeat(64),
-					},
-					providerIds: ["default"],
-					projectedProviderIds: {},
-				},
-				paths,
-			);
-			const { restore } = mockFetch([
-				{
-					method: "GET",
-					path: "/v1/runtime/manifest",
-					response: () =>
-						hostedRuntimeBundleResponse(
-							{
-								manifest,
-								secretValues: {},
-							},
-							{ etag: testBundleEtag("etag-cli-rollback") },
-						),
-				},
-			]);
-
-			try {
-				if (command === "runtime watch") {
-					await runtimeWatch({ once: true, json: true });
-				} else {
-					await runtimeInit({ nonInteractive: true, json: true });
-				}
-
-				expect(process.exitCode ?? 0).toBe(command === "runtime watch" ? 0 : 75);
-				const handoffEvent = JSON.parse(logs[0]);
-				expect(handoffEvent.status).toBe(command === "runtime watch" ? "cli_handoff" : "ok");
-				expect(handoffEvent.cliUpdate.status).toBe("installed");
-				expect(handoffEvent.cliRollback).toBeUndefined();
-				expect(readlinkSync(paths.cliManagedBin)).not.toBe(oldTarget);
-				expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
-					transaction: {
-						phase: "activated",
-						previousIdentity: { version: previousVersion },
-						newIdentity: { version: currentVersion },
-						rollbackEligible: true,
-					},
-					badVersions: [],
-				});
-
-				logs.length = 0;
-				process.exitCode = undefined;
-				if (command === "runtime watch") {
-					await runtimeWatch({ once: true, json: true });
-				} else {
-					await runtimeInit({ nonInteractive: true, json: true });
-				}
-
-				expect(process.exitCode).toBe(command === "runtime watch" ? 1 : 23);
-				const event = JSON.parse(logs[0]);
-				expect(event.status).toBe("error");
-				if (command === "runtime watch") {
-					expect(event.cliUpdate.status).toBe("current");
-					expect(event.cliRollback.status).toBe("rolled_back");
-					expect(event.cliRollback.version).toBe(currentVersion);
-					expect(event.selfReexec).toBe(true);
-				}
-				expect(event.errors.join("\n")).toContain("rolled back clawdi CLI");
-				expect(readlinkSync(paths.cliManagedBin)).toBe(oldTarget);
-				const upgradeState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-				expect(upgradeState.transaction).toBeNull();
-				expect(upgradeState.badVersions).toContainEqual(
-					expect.objectContaining({
-						packageSpec: `clawdi@${currentVersion}`,
-						version: currentVersion,
-					}),
-				);
-				const retryManifest: RuntimeManifest = {
-					schemaVersion: "clawdi.runtimeDesiredState.v1",
-					deploymentId: "dep_cli_rollback",
-					environmentId: "env_cli_rollback",
-					instanceId: "iid_cli_rollback",
-					generation: 18,
-					issuedAt: "2026-06-06T00:00:00Z",
-					controlPlane: { apiUrl: "https://cloud-api.test" },
-					clawdiCli: {
-						source: "npm:clawdi",
-						packageSpec: `clawdi@${currentVersion}`,
-						registry: "https://registry.npmjs.org",
-					},
-					runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
-					recovery: {},
-				};
-				const beforeRetryLog = readFileSync(npmLog, "utf-8");
-				expect(() => applyRuntimeCliDesiredState(retryManifest, paths)).toThrow(/marked bad/);
-				const afterRetryLog = readFileSync(npmLog, "utf-8");
-				expect(afterRetryLog.split("\n").filter((line) => line.startsWith("install ")).length).toBe(
-					beforeRetryLog.split("\n").filter((line) => line.startsWith("install ")).length,
-				);
-
-				upgradeState.badVersions[0].markedAt = new Date(
-					Date.now() - 60 * 60 * 1000 - 1_000,
-				).toISOString();
-				writeFileSync(paths.cliUpgradeState, `${JSON.stringify(upgradeState)}\n`);
-
-				const retried = applyRuntimeCliDesiredState(retryManifest, paths);
-				expect(retried.status).toBe("installed");
-				const afterTtlLog = readFileSync(npmLog, "utf-8");
-				expect(afterTtlLog.split("\n").filter((line) => line.startsWith("install ")).length).toBe(
-					beforeRetryLog.split("\n").filter((line) => line.startsWith("install ")).length + 1,
-				);
-			} finally {
-				restore();
-				console.log = previousLog;
-				process.exitCode = previousExitCode;
-				if (previousPath === undefined) delete process.env.PATH;
-				else process.env.PATH = previousPath;
-			}
-		},
-	);
-
-	it("runtime watch keeps npm ETARGET retryable without converging or marking the version bad", async () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const bin = join(root, "bin");
-		const previousExitCode = process.exitCode;
-		const previousLog = console.log;
-		const previousPath = process.env.PATH;
-		const currentVersion = getCliVersion();
-		setRuntimeApplyGeneration(17);
-		const firstAttempt = join(root, "npm-etarget-first-attempt");
-		const logs: string[] = [];
-		mkdirSync(join(run, "secrets"), { recursive: true });
-		mkdirSync(bin, { recursive: true });
-		seedOpenClawBinary(home);
-		writeFileSync(
-			join(bin, "npm"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-if [ ! -e '${firstAttempt}' ]; then
-  touch '${firstAttempt}'
-  echo 'npm ERR! code ETARGET' >&2
-  echo 'npm ERR! notarget No matching version found' >&2
-  exit 1
-fi
-prefix=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--prefix" ]; then
-    prefix="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-test -n "$prefix"
-install -d "$prefix/bin"
-cat > "$prefix/bin/clawdi" <<'SH'
-#!/usr/bin/env bash
-if [ "\${1:-}" = "--version" ]; then
-  echo "${currentVersion}"
-  exit 0
-fi
-if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
-  echo '{"status":"ok"}'
-  exit 0
-fi
-exit 64
-SH
-chmod +x "$prefix/bin/clawdi"
-`,
-		);
-		chmodSync(join(bin, "npm"), 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		process.exitCode = undefined;
-		console.log = (value?: unknown) => {
-			logs.push(String(value));
-		};
-		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
-		const { restore } = mockFetch([
-			{
-				method: "GET",
-				path: "/v1/runtime/manifest",
-				response: () =>
-					hostedRuntimeBundleResponse(
-						{
-							manifest: {
-								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
-								runtime: "openclaw",
-								deploymentId: "dep_cli_update_failure",
-								environmentId: "env_cli_update_failure",
-								...hostedRequiredState(),
-								instanceId: "iid_cli_update_failure",
-								generation: 17,
-								issuedAt: "2026-06-06T00:00:00Z",
-								locale: TEST_HOSTED_LOCALE,
-								system: hostedSystemFixture(home),
-								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
-								clawdiCli: {
-									source: "npm:clawdi",
-									packageSpec: `clawdi@${currentVersion}`,
-									registry: "https://registry.npmjs.org",
-								},
-								runtimes: {
-									openclaw: hostedOpenClawRuntime(),
-								},
-							},
-							secretValues: {},
-						},
-						{ etag: testBundleEtag("etag-cli-failed") },
-					),
-			},
-		]);
-
-		try {
-			await runtimeWatch({ once: true, json: true });
-
-			expect(process.exitCode).toBe(1);
-			const event = JSON.parse(logs[0]);
-			expect(event.status).toBe("error");
-			expect(event.stage).toBe("cli-update");
-			expect(event.cliUpdate.status).toBe("error");
-			expect(event.error).toContain("ETARGET");
-			expect(event.activeGeneration).toBeNull();
-			expect(event.rejectedGeneration).toBe(17);
-			const paths = getRuntimePaths();
-			expect(event.convergence).toBeUndefined();
-			expect(event.systemdUnitsChanged).toBe(false);
-			expect(event.systemdApply).toEqual({
-				applied: false,
-				systemUnitsChanged: [],
-				userUnitsChanged: [],
-			});
-			expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"))).toBe(false);
-			expect(existsSync(join(paths.systemdUserRoot, "openclaw-gateway.service"))).toBe(false);
-			expect(existsSync(paths.manifestLastGood)).toBe(false);
-			expect(existsSync(paths.appliedState)).toBe(false);
-			expect(existsSync(paths.cliUpgradeState)).toBe(false);
-
-			logs.length = 0;
-			process.exitCode = undefined;
-			await runtimeWatch({ once: true, json: true });
-
-			expect(process.exitCode).toBe(0);
-			const handoff = JSON.parse(logs[0]);
-			expect(handoff.status).toBe("cli_handoff");
-			expect(handoff.cliUpdate.status).toBe("installed");
-			expect(handoff.cliRollback).toBeUndefined();
-			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
-				transaction: { phase: "activated", newIdentity: { version: currentVersion } },
-				badVersions: [],
-			});
-		} finally {
-			restore();
-			console.log = previousLog;
-			process.exitCode = previousExitCode;
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
-
-	it("keeps the previous active CLI when installed CLI smoke fails", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const bin = join(root, "bin");
-		const previousPath = process.env.PATH;
-		mkdirSync(bin, { recursive: true });
-		writeFileSync(
-			join(bin, "npm"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-prefix=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--prefix" ]; then
-    prefix="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-if [ -z "$prefix" ]; then
-  echo "missing --prefix" >&2
-  exit 64
-fi
-install -d "$prefix/bin"
-cat > "$prefix/bin/clawdi" <<'SH'
-#!/usr/bin/env bash
-if [ "\${1:-}" = "--version" ]; then
-  echo "broken smoke" >&2
-  exit 42
-fi
-echo "new broken clawdi"
-SH
-chmod +x "$prefix/bin/clawdi"
-`,
-		);
-		chmodSync(join(bin, "npm"), 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(state, "clawdi@1.2.1-test.1", "1.2.1-test.1");
-		const paths = getRuntimePaths();
-		const oldTarget = readlinkSync(paths.cliManagedBin);
-		const oldStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-		const manifest: RuntimeManifest = {
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
-			deploymentId: "dep_cli_smoke_failure",
-			environmentId: "env_cli_smoke_failure",
-			instanceId: "iid_cli_smoke_failure",
-			generation: 14,
-			issuedAt: "2026-06-06T00:00:00Z",
-			controlPlane: { apiUrl: "https://cloud-api.test" },
-			clawdiCli: {
-				source: "npm:clawdi",
-				packageSpec: "clawdi@1.2.4-test.1",
-			},
-			runtimes: {
-				openclaw: { enabled: false },
-				hermes: { enabled: false },
-			},
-			recovery: {},
-		};
-
-		try {
-			expect(() => applyRuntimeCliDesiredState(manifest, paths)).toThrow(/smoke check/);
-			expect(readlinkSync(paths.cliManagedBin)).toBe(oldTarget);
-			const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-			expect(status).toEqual(oldStatus);
-		} finally {
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
-
-	it("keeps the previous active CLI when installed CLI self-check fails", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const bin = join(root, "bin");
-		const previousPath = process.env.PATH;
-		mkdirSync(bin, { recursive: true });
-		writeFileSync(
-			join(bin, "npm"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-prefix=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--prefix" ]; then
-    prefix="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-install -d "$prefix/bin"
-cat > "$prefix/bin/clawdi" <<'SH'
-#!/usr/bin/env bash
-if [ "\${1:-}" = "--version" ]; then
-  echo "1.2.4-test.2"
-  exit 0
-fi
-if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
-  echo '{"status":"error","errors":["manifest parse failed"]}'
-  exit 42
-fi
-SH
-chmod +x "$prefix/bin/clawdi"
-`,
-		);
-		chmodSync(join(bin, "npm"), 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(state, "clawdi@1.2.1-test.1", "1.2.1-test.1");
-		const paths = getRuntimePaths();
-		const oldTarget = readlinkSync(paths.cliManagedBin);
-		const oldStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-		const manifest: RuntimeManifest = {
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
-			deploymentId: "dep_cli_selfcheck_failure",
-			environmentId: "env_cli_selfcheck_failure",
-			instanceId: "iid_cli_selfcheck_failure",
-			generation: 14,
-			issuedAt: "2026-06-06T00:00:00Z",
-			controlPlane: { apiUrl: "https://cloud-api.test" },
-			clawdiCli: {
-				source: "npm:clawdi",
-				packageSpec: "clawdi@1.2.4-test.2",
-			},
-			runtimes: {
-				openclaw: { enabled: false },
-				hermes: { enabled: false },
-			},
-			recovery: {},
-		};
-
-		try {
-			expect(() => applyRuntimeCliDesiredState(manifest, paths)).toThrow(/self-check/);
-			expect(readlinkSync(paths.cliManagedBin)).toBe(oldTarget);
-			const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-			expect(status).toEqual(oldStatus);
-		} finally {
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
-
-	it("rejects unsafe clawdi CLI package specs and registries", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const bin = join(root, "bin");
-		const npmMarker = join(root, "npm-invoked");
-		const previousPath = process.env.PATH;
-		mkdirSync(home, { recursive: true });
-		mkdirSync(bin, { recursive: true });
-		writeFileSync(join(bin, "npm"), `#!/usr/bin/env sh\ntouch '${npmMarker}'\nexit 99\n`);
-		chmodSync(join(bin, "npm"), 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		const paths = getRuntimePaths();
-		const baseManifest: RuntimeManifest = {
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
-			deploymentId: "dep_cli_spec_validation",
-			environmentId: "env_cli_spec_validation",
-			instanceId: "iid_cli_spec_validation",
-			generation: 15,
-			issuedAt: "2026-06-06T00:00:00Z",
-			controlPlane: { apiUrl: "https://cloud-api.test" },
-			clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@1.2.4-test.1" },
-			runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
-			recovery: {},
-		};
-
-		for (const packageSpec of [
-			"clawdi@01.2.3",
-			"clawdi@1.2.3-01",
-			"clawdi@1.2.3+build.1",
-			"clawdi",
-			"clawdi@latest",
-			"clawdi@npm:evil",
-			"clawdi@https://evil.test/clawdi.tgz",
-			"clawdi@github:evil/clawdi",
-			"clawdi@file:/tmp/clawdi.tgz",
-		]) {
-			expect(() =>
-				applyRuntimeCliDesiredState(
-					{ ...baseManifest, clawdiCli: { source: "npm:clawdi", packageSpec } },
-					paths,
-				),
-			).toThrow(/packageSpec/);
-		}
-		expect(existsSync(npmMarker)).toBe(false);
-		expect(() =>
-			applyRuntimeCliDesiredState(
-				{
-					...baseManifest,
-					clawdiCli: {
-						source: "npm:clawdi",
-						packageSpec: "clawdi@1.2.4-test.1",
-						registry: "https://registry.evil.test",
-					},
-				},
-				paths,
-			),
-		).toThrow(/registry/);
-		expect(existsSync(npmMarker)).toBe(false);
-		if (previousPath === undefined) delete process.env.PATH;
-		else process.env.PATH = previousPath;
-	});
-
-	it("rebuilds missing CLI bootstrap status without reinstalling the active package", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const bin = join(root, "bin");
-		const npmLog = join(root, "npm.log");
-		const previousPath = process.env.PATH;
-		mkdirSync(bin, { recursive: true });
-		writeFileSync(
-			join(bin, "npm"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-prefix=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--prefix" ]; then
-    prefix="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-printf 'npm called\\n' >> '${npmLog}'
-install -d "$prefix/bin"
-cat > "$prefix/bin/clawdi" <<'SH'
-#!/usr/bin/env bash
-if [ "\${1:-}" = "--version" ]; then
-  echo "1.2.6-test.1"
-  exit 0
-fi
-if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
-  echo '{"status":"ok"}'
-  exit 0
-fi
-SH
-chmod +x "$prefix/bin/clawdi"
-`,
-		);
-		chmodSync(join(bin, "npm"), 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		const paths = getRuntimePaths();
-		const manifest: RuntimeManifest = {
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
-			deploymentId: "dep_cli_status_rebuild",
-			environmentId: "env_cli_status_rebuild",
-			instanceId: "iid_cli_status_rebuild",
-			generation: 1,
-			issuedAt: "2026-06-06T00:00:00Z",
-			controlPlane: { apiUrl: "https://cloud-api.test" },
-			clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@1.2.6-test.1" },
-			runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
-			recovery: {},
-		};
-
-		try {
-			const installed = applyRuntimeCliDesiredState(manifest, paths);
-			expect(installed.status).toBe("installed");
-			rmSync(paths.cliBootstrapStatus, { force: true });
-			rmSync(npmLog, { force: true });
-
-			const recovered = applyRuntimeCliDesiredState(manifest, paths);
-
-			expect(recovered.status).toBe("current");
-			expect(existsSync(npmLog)).toBe(false);
-			const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-			expect(status.packageSpec).toBe("clawdi@1.2.6-test.1");
-			expect(status.activeTarget).toBe(readlinkSync(paths.cliManagedBin));
-		} finally {
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
-
-	it("preserves the real last-good CLI across a status-missing rollback and later upgrade", () => {
-		const home = join(root, "home-cli-rollback-lifecycle", "clawdi");
-		const state = join(root, "state-cli-rollback-lifecycle");
-		const run = join(root, "run-cli-rollback-lifecycle");
-		const bin = join(root, "bin-cli-rollback-lifecycle");
-		const previousPath = process.env.PATH;
-		mkdirSync(bin, { recursive: true });
-		writeFileSync(
-			join(bin, "npm"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-prefix=""
-package=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--prefix" ]; then
-    prefix="$2"
-    shift 2
-    continue
-  fi
-  case "$1" in clawdi@*) package="$1" ;; esac
-  shift
-done
-version="\${package#clawdi@}"
-install -d "$prefix/bin"
-cat > "$prefix/bin/clawdi" <<SH
-#!/usr/bin/env bash
-if [ "\\\${1:-}" = "--version" ]; then
-  echo "$version"
-  exit 0
-fi
-if [ "\\\${1:-} \\\${2:-} \\\${3:-}" = "runtime verify --json" ]; then
-  echo '{"status":"ok"}'
-  exit 0
-fi
-exit 64
-SH
-chmod +x "$prefix/bin/clawdi"
-`,
-		);
-		chmodSync(join(bin, "npm"), 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		const paths = getRuntimePaths();
-		const manifestFor = (version: string): RuntimeManifest => ({
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
-			deploymentId: "dep_cli_rollback_lifecycle",
-			environmentId: "env_cli_rollback_lifecycle",
-			instanceId: "iid_cli_rollback_lifecycle",
-			generation: 1,
-			issuedAt: "2026-07-29T00:00:00Z",
-			controlPlane: { apiUrl: "https://cloud-api.test" },
-			clawdiCli: { source: "npm:clawdi", packageSpec: `clawdi@${version}` },
-			runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
-			recovery: {},
-		});
-
-		try {
-			const first = applyRuntimeCliDesiredState(manifestFor("1.2.20-test.1"), paths);
-			if (!first.activeTarget) throw new Error("first CLI install has no active target");
-			const lastGoodTarget = first.activeTarget;
-			const lastGoodPrefix = first.npmPrefix;
-			const firstState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-			expect(firstState.transaction.rollbackEligible).toBe(false);
-
-			rmSync(paths.cliBootstrapStatus, { force: true });
-			const failed = applyRuntimeCliDesiredState(manifestFor("1.2.20-test.2"), paths);
-			if (!failed.activeTarget) throw new Error("failed CLI install has no active target");
-			const failedTarget = failed.activeTarget;
-			const failedState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-			expect(failedState.transaction).toMatchObject({
-				rollbackEligible: true,
-				previousIdentity: {
-					activeTarget: lastGoodTarget,
-					npmPrefix: lastGoodPrefix,
-					version: "1.2.20-test.1",
-				},
-			});
-
-			const firstRollback = rollbackPendingRuntimeCliUpgrade(
-				paths,
-				"injected first converge failure",
-			);
-			expect(firstRollback.status).toBe("rolled_back");
-			expect(readlinkSync(paths.cliManagedBin)).toBe(lastGoodTarget);
-			expect(existsSync(lastGoodPrefix)).toBe(true);
-			expect(existsSync(dirname(dirname(failedTarget)))).toBe(false);
+			const failed = applyRuntimeCliDesiredState(cliManifest("1.2.10-test.1"), paths);
+			expect(failed.status).toBe("error");
+			expect(failed.retryAt).toBeString();
+			expect(readlinkSync(paths.cliManagedBin)).toBe(previousTarget);
 			expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"))).toMatchObject({
-				packageSpec: "clawdi@1.2.20-test.1",
-				npmPrefix: lastGoodPrefix,
-				activeTarget: lastGoodTarget,
-				version: "1.2.20-test.1",
+				activeTarget: previousTarget,
+				version: "1.2.9-test.1",
+				bad: { version: "1.2.10-test.1", attempts: 1, retryAt: failed.retryAt },
 			});
-
-			applyRuntimeCliDesiredState(manifestFor("1.2.20-test.3"), paths);
-			const secondState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
-			expect(secondState.transaction.previousIdentity.activeTarget).toBe(lastGoodTarget);
-			expect(secondState.transaction.previousIdentity.activeTarget).not.toBe(failedTarget);
-			expect(existsSync(lastGoodPrefix)).toBe(true);
-
-			const secondRollback = rollbackPendingRuntimeCliUpgrade(
-				paths,
-				"injected second converge failure",
+			expect(applyRuntimeCliDesiredState(cliManifest("1.2.10-test.1"), paths).status).toBe(
+				"deferred",
 			);
-			expect(secondRollback.status).toBe("rolled_back");
-			expect(readlinkSync(paths.cliManagedBin)).toBe(lastGoodTarget);
-			expect(existsSync(lastGoodPrefix)).toBe(true);
+			expect(readFileSync(npmLog, "utf-8").trim().split("\n")).toHaveLength(1);
 		} finally {
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
-
-	it("prunes old versioned CLI package prefixes after successful swaps", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const bin = join(root, "bin");
-		const previousPath = process.env.PATH;
-		mkdirSync(bin, { recursive: true });
-		writeFileSync(
-			join(bin, "npm"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-prefix=""
-package=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--prefix" ]; then
-    prefix="$2"
-    shift 2
-    continue
-  fi
-  package="$1"
-  shift
-done
-version="\${package#clawdi@}"
-install -d "$prefix/bin"
-cat > "$prefix/bin/clawdi" <<SH
-#!/usr/bin/env bash
-if [ "\\\${1:-}" = "--version" ]; then
-  echo "$version"
-  exit 0
-fi
-if [ "\\\${1:-} \\\${2:-} \\\${3:-}" = "runtime verify --json" ]; then
-  echo '{"status":"ok"}'
-  exit 0
-fi
-SH
-chmod +x "$prefix/bin/clawdi"
-`,
-		);
-		chmodSync(join(bin, "npm"), 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		const paths = getRuntimePaths();
-		const manifestFor = (packageSpec: string): RuntimeManifest => ({
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
-			deploymentId: "dep_cli_prune",
-			environmentId: "env_cli_prune",
-			instanceId: "iid_cli_prune",
-			generation: 1,
-			issuedAt: "2026-06-06T00:00:00Z",
-			controlPlane: { apiUrl: "https://cloud-api.test" },
-			clawdiCli: { source: "npm:clawdi", packageSpec },
-			runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
-			recovery: {},
-		});
-
-		try {
-			applyRuntimeCliDesiredState(manifestFor("clawdi@1.2.7-test.1"), paths);
-			applyRuntimeCliDesiredState(manifestFor("clawdi@1.2.8-test.1"), paths);
-			applyRuntimeCliDesiredState(manifestFor("clawdi@1.2.9-test.1"), paths);
-			const packageDirs = readdirSync(join(getRuntimePaths().cliNpmPrefix, "packages")).sort();
-
-			expect(packageDirs).toHaveLength(2);
-			const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-			expect(readlinkSync(paths.cliManagedBin)).toBe(status.activeTarget);
-			expect(packageDirs.map((entry) => join(paths.cliNpmPrefix, "packages", entry))).toContain(
-				status.npmPrefix,
-			);
-		} finally {
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
-
-	it("runtime init restarts the bootstrap before convergence and the new CLI completes init", async () => {
-		const home = join(root, "home-init-cli-handoff", "clawdi");
-		const state = join(root, "state-init-cli-handoff");
-		const run = join(root, "run-init-cli-handoff");
-		installSuccessfulSystemctlFixture(join(run, "egress", "systemd", "ca.pem"));
-		const policyPath = join(root, "etc-init-cli-handoff", "host-policy.json");
-		const bin = join(root, "bin-init-cli-handoff");
-		const previousExitCode = process.exitCode;
-		const previousLog = console.log;
-		const previousPath = process.env.PATH;
-		const currentVersion = getCliVersion();
-		setRuntimeApplyGeneration(1);
-		const logs: string[] = [];
-		mkdirSync(join(run, "secrets"), { recursive: true });
-		mkdirSync(dirname(policyPath), { recursive: true });
-		mkdirSync(bin, { recursive: true });
-		seedOpenClawBinary(home);
-		writeFileSync(
-			join(bin, "npm"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-prefix=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--prefix" ]; then
-    prefix="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-test -n "$prefix"
-install -d "$prefix/bin"
-cat > "$prefix/bin/clawdi" <<'SH'
-#!/usr/bin/env bash
-if [ "\${1:-}" = "--version" ]; then
-  echo "${currentVersion}"
-  exit 0
-fi
-if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
-  echo '{"status":"ok"}'
-  exit 0
-fi
-exit 64
-SH
-chmod +x "$prefix/bin/clawdi"
-`,
-		);
-		chmodSync(join(bin, "npm"), 0o700);
-		writeFileSync(
-			policyPath,
-			JSON.stringify({
-				schemaVersion: "clawdi.hostPolicy.v1",
-				mode: "hosted-runtime",
-				cliUpdateMode: "system-managed-npm",
-				deniedCommands: ["setup", "teardown", "update"],
-			}),
-		);
-		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_HOST_POLICY_PATH = policyPath;
-		process.exitCode = undefined;
-		console.log = (value?: unknown) => {
-			logs.push(String(value));
-		};
-		const { captured, restore } = mockFetch([
-			{
-				method: "GET",
-				path: "/v1/runtime/manifest",
-				response: () =>
-					hostedRuntimeBundleResponse(hostedCliManifestResponse(home, `clawdi@${currentVersion}`), {
-						etag: testBundleEtag("etag-init-cli-handoff"),
-					}),
-			},
-		]);
-
-		try {
-			await runtimeInit({ nonInteractive: true, json: true });
-
-			const paths = getRuntimePaths();
-			expect(process.exitCode).toBe(75);
-			expect(captured).toHaveLength(1);
-			const handoff = JSON.parse(logs[0]);
-			expect(handoff.status).toBe("ok");
-			expect(handoff.handoff).toBe("cli_reexec");
-			expect(handoff.cliUpdate.status).toBe("installed");
-			expect(handoff.selfReexec).toBe(true);
-			expect(handoff.exitCode).toBe(75);
-			expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"))).toBe(false);
-			expect(existsSync(join(paths.systemdUserRoot, "openclaw-gateway.service"))).toBe(false);
-			expect(existsSync(paths.manifestLastGood)).toBe(false);
-			expect(existsSync(paths.appliedState)).toBe(false);
-			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
-				transaction: { phase: "activated", newIdentity: { version: currentVersion } },
-				badVersions: [],
-			});
-
-			logs.length = 0;
-			process.exitCode = undefined;
-			setRuntimeApplyGeneration(1);
-			await runtimeInit({ nonInteractive: true, json: true });
-
-			if (process.exitCode !== undefined && process.exitCode !== 0) {
-				throw new Error(logs.join("\n"));
-			}
-			expect(process.exitCode).toBe(0);
-			expect(captured).toHaveLength(2);
-			const completed = JSON.parse(logs[0]);
-			expect(completed.status).toBe("ok");
-			expect(completed.handoff).toBeUndefined();
-			expect(readRuntimeAppliedState(paths)).toMatchObject({ generation: 1 });
-			expect(JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"))).toMatchObject({
-				transaction: null,
-				badVersions: [],
-			});
-		} finally {
-			restore();
-			console.log = previousLog;
-			process.exitCode = previousExitCode;
 			if (previousPath === undefined) delete process.env.PATH;
 			else process.env.PATH = previousPath;
 		}
@@ -13417,7 +11390,12 @@ exit 64
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(state, "clawdi@1.2.3-test", "1.2.3-test", "https://registry.npmjs.org");
+		seedCurrentCliInstall(
+			state,
+			TEST_RUNNING_CLI_SPEC,
+			TEST_RUNNING_CLI_VERSION,
+			"https://registry.npmjs.org",
+		);
 		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
@@ -13439,7 +11417,7 @@ exit 64
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
-									packageSpec: "clawdi@1.2.3-test",
+									packageSpec: TEST_RUNNING_CLI_SPEC,
 									registry: "https://registry.npmjs.org",
 								},
 								runtimes: {
@@ -15029,7 +13007,7 @@ exit 64
 							controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@1.2.3-test",
+								packageSpec: TEST_RUNNING_CLI_SPEC,
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
@@ -15088,7 +13066,7 @@ exit 64
 					controlPlane: { apiUrl: "https://api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
-						packageSpec: "clawdi@1.2.3-test",
+						packageSpec: TEST_RUNNING_CLI_SPEC,
 						registry: "https://registry.npmjs.org",
 					},
 					runtimes: {
@@ -15161,7 +13139,7 @@ exit 64
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
-						packageSpec: "clawdi@1.2.3-test",
+						packageSpec: TEST_RUNNING_CLI_SPEC,
 						registry: "https://registry.npmjs.org",
 					},
 					runtimes: {
@@ -16661,7 +14639,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			generation: 1,
 			issuedAt: "2026-06-06T00:00:00Z",
 			controlPlane: { apiUrl: "https://cloud-api.test" },
-			clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@1.2.3-test" },
+			clawdiCli: { source: "npm:clawdi", packageSpec: TEST_RUNNING_CLI_SPEC },
 			runtimes: {
 				openclaw: {
 					enabled: true,
@@ -16807,7 +14785,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 							controlPlane: {},
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@1.2.3-test",
+								packageSpec: TEST_RUNNING_CLI_SPEC,
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
@@ -16870,7 +14848,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 							egressEngine: mitmproxy,
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@1.2.3-test",
+								packageSpec: TEST_RUNNING_CLI_SPEC,
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
@@ -17007,7 +14985,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 							},
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@1.2.3-test",
+								packageSpec: TEST_RUNNING_CLI_SPEC,
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
@@ -17114,7 +15092,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
-						packageSpec: "clawdi@1.2.3-test",
+						packageSpec: TEST_RUNNING_CLI_SPEC,
 						registry: "https://registry.npmjs.org",
 					},
 					runtimes: {
@@ -17166,7 +15144,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
-						packageSpec: "clawdi@1.2.3-test",
+						packageSpec: TEST_RUNNING_CLI_SPEC,
 						registry: "https://registry.npmjs.org",
 					},
 					runtimes: {


### PR DESCRIPTION
Originally stacked on #1185; rebased to main after #1185 merged.

## Summary

- Replace the separate CLI bootstrap, upgrade journal, transaction phase, rollback eligibility, and bad-version ledgers with one Zod-validated `cli-bootstrap.json` v1 state.
- Keep exact `clawdi@<version>` installs in version-specific prefixes and preserve verify-before-swap activation.
- Collapse managed CLI retry scheduling into the persisted bad-version state and remove the second runtime-watch backoff.
- Stop writing `cli-upgrade-state.json`; old journals are retired during reconciliation.

## Evidence

- Review C#1 at `C-lifecycle-contract.md:5` identifies three copies of active CLI identity, three recovery paths, repeated bootstrap predicates, and duplicate bad-version retry mechanisms.
- The hosted image verifier at `verify-managed-clawdi.js:322-330` treats a missing journal as an empty transaction and falls back to `cli-bootstrap.json`.
- The hosted shim only reads the legacy journal and writes bootstrap status, so stopping journal writes does not require a hosted image change.

## State Machine

Before:

`bootstrap status + journal transaction + active symlink -> staged/activated/recovery/quarantine branches -> separate badVersions TTL -> separate runtime-watch retry backoff`

After:

`reconcile -> install exact package into version prefix -> --version smoke + runtime verify + exact-version check -> atomic symlink swap -> write single state with previous -> converge -> clear previous on success / swap to previous and mark bad on failure`

Crash recovery has one activation rule: if state records active `A` with previous `Z` and the symlink differs from `A`, verify and restore `Z`, persist `Z` as active, and mark `A` bad. Without `previous`, recovery verifies and restores the recorded active target.

Transition behavior is intentionally fix-forward: when this implementation takes over state written by an old CLI such as 0.13.92 or 0.14.14, the first converge failure does not roll back. Replaying the old journal after single-state takeover would alternate recovery authority and cause rollback ping-pong.

## Persistent State Migration

The parameterized test `adopts $writerVersion persisted CLI state on first converge` writes the exact main-era bootstrap and v2 journal shapes for 0.13.92 `prepared` and 0.14.14 `activated`, plus a main-era quarantine filename. Both fixtures complete the first desired-state converge, retain the verified active link, retire stale prefixes, and preserve the required modes.

- `status/cli-bootstrap.json`, schema `clawdi.cliNpmBootstrapStatus.v1`: 0.13.92 and 0.14.14 write `generatedAt`, `status="installed"`, `source="npm"`, `packageSpec`, `registry`, `npmPrefix`, `npmCache`, `activePath`, `activeTarget`, `version`, optional `verification`, and `error`. This PR claims that file: the first reconcile loosely reads either CLI/shim writer, verifies the active symlink target, and atomically rewrites the same v1 identity.
- `cli-bootstrap.json.verification`: old CLIs write `verifiedAt`, `device`, `inode`, `size`, and `modifiedAtMs`; the image shim may omit it. This PR re-verifies on takeover and owns those same fields, including re-verification when file identity drifts.
- `cli-bootstrap.json.previous`: 0.13.92 and 0.14.14 do not write it. This PR adds nullable `activeTarget` and `version`, replacing `transaction.previousIdentity`; old state is claimed as `previous=null`.
- `cli-bootstrap.json.bad`: 0.13.92 and 0.14.14 do not write it. This PR adds nullable `version`, `reason`, `attempts`, `failedAt`, and `retryAt`, replacing `badVersions` plus runtime-watch retry state; old state is claimed as `bad=null`.
- `status/cli-upgrade-state.json`, schema enum `clawdi.cliUpgradeState.v2`: both old versions write `transaction` and `badVersions`. This PR performs one retirement cleanup at the start of reconciliation and never writes the file again.
- `transaction.phase`, enum `prepared | activated`: both old versions use the same values. For 0.13.92 `prepared`, bootstrap and symlink still identify the previous target, so takeover verifies and claims it and prunes the interrupted candidate. For 0.14.14 `activated`, bootstrap and symlink identify the candidate, so takeover verifies and claims the candidate and prunes the previous prefix.
- `transaction.previousIdentity` and `transaction.newIdentity`: both contain `packageSpec`, `registry`, `npmPrefix`, `activeTarget`, and `version`. They are not copied; the verified bootstrap/symlink identity is the sole takeover authority.
- `transaction.rollbackEligible`, `installedAt`, and nullable `rollback.{reason,markedAt}`: both old versions write these fields. They are ignored with the retired journal. An old `activated` rollback marker therefore transitions to intentional fix-forward instead of replaying rollback.
- `badVersions[].{packageSpec,registry,version,reason,markedAt}`: 0.13.92 requires `markedAt` and treats entries indefinitely; 0.14.14 accepts a missing `markedAt`, while its actual rollback writer includes it and applies a one-hour TTL. The old array is ignored with the retired journal. A subsequent failure is recorded once in `cli-bootstrap.json.bad` with exponential retry capped at one hour.
- `status/cli-upgrade-state.json.corrupt-<timestamp>-<uuid>`: either old version may leave this filename after quarantining invalid journal content. This PR does not read or create quarantine files; existing files are ignored and cannot block first converge. The migration fixture leaves one in place while proving successful takeover.
- `maintained/clawdi/bin/clawdi`: both old versions atomically point this symlink at the active version target. This PR claims the verified symlink during old-state takeover; after single-state ownership, `symlink != state.active` follows the one rollback rule above.
- `maintained/clawdi/npm/packages/<version>/`: both old versions use version-specific prefixes and may leave both transaction identities on disk. On takeover this PR retains only the verified active prefix and retires the stale one. The package root, prefix, and managed `bin/` directories are assumed to be `0755`; the CLI target must be executable.
- Directory and file modes: both old writers create `status/` as `0755` and write `cli-bootstrap.json` and `cli-upgrade-state.json` as `0600`. This PR preserves `status/` `0755` and `cli-bootstrap.json` `0600`; the migration fixture asserts old journal mode before retirement and new bootstrap mode after takeover.

## Added

- Add `previous`, `verification`, and `bad` to the existing bootstrap v1 state. These fields replace the separate journal transaction identity, rollback eligibility, verification cache, and `badVersions` array.
- Add Zod schemas for the single active, previous, verification, and bad state. They replace five handwritten bootstrap/status predicates and journal validators.
- Add `retryAt` to the CLI update result. It replaces the independent retry-pending flag, delay accumulator, and exponential backoff in `commands/runtime.ts`.
- Add direct single-state recovery helpers. They replace the staged, activated, quarantine, bootstrap takeover, and four rollback helper paths removed from `cli-update.ts`.
- Add one takeover call to the existing prefix pruner. It replaces journal-phase cleanup of interrupted old-CLI prefixes.
- Replace the placeholder legacy-journal test with 0.13.92/0.14.14 persisted-state fixtures and retain the active-file identity drift safety assertion.

No product environment variable, flag, installer hook, or test-only product branch is added.

## Deletions

- 850 additions, 3,465 deletions across three owned files.
- Net deletion: 2,615 lines.
- CLI lifecycle tests shrink to the retained invariants instead of preserving tests for removed journal phases and duplicate recovery mechanisms.

## Verification

All dependency installation and checks ran in disposable containers with isolated HOME/cache/work directories.

- Final migration fixture: 2 pass, 147 filtered out, 0 fail; CLI typecheck passed.
- `bun run --cwd packages/cli test -- tests/runtime.test.ts`: 149 pass, 0 fail; CLI typecheck passed.
- `bun run --cwd packages/cli test`: 1,723 pass, 4 skip, 0 fail, 9,229 assertions; CLI typecheck passed.
- `bun run typecheck`: 4 workspace packages passed.
- `bun run check`: 1,072 files checked, 0 errors.
- Privileged `scripts/test-runtime-official-installer-systemd.sh`: every one of the nine scenarios has a green isolated run. The full run passed virgin Hermes, virgin OpenClaw, official-installer rollback, model-list projection, and managed-token serving before the external runner exited 137. Bounded clean reruns then passed last-good replay and write-side crash recovery (2/2), and Hermes cold boot plus Files tenant isolation and live Hermes repair (3/3). No test assertion failed in the 137 run.
- The privileged harness built this branch, packed `clawdi-local.tgz`, seeded the version-specific managed prefix/symlink/bootstrap state, and did not install the published CLI from npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
