### PR TITLE
Simplify runtime manifest contract

### DIFF
--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -62,8 +62,8 @@ import {
 	type RuntimeResourcePreparationFailures,
 	runtimeRecoverableSecretValues,
 } from "../runtime/manifest";
-import { manifestSchema as runtimeDesiredStateSchema } from "../runtime/manifest-contract";
 import {
+	hostedRuntimeBundleV2Schema,
 	loadCommittedRuntimeManifest,
 	loadRemoteRuntimeManifest,
 	type RuntimeManifestFailure,
@@ -219,7 +219,8 @@ function readable(path: string): boolean {
 }
 
 function cacheRuntimeSourceManifest(load: RuntimeManifestLoad, paths: RuntimePaths): string | null {
-	return cacheRuntimeLastGoodManifest(load.manifest, paths, load.secretValues);
+	if (load.sourceBundle === undefined) return null;
+	return cacheRuntimeLastGoodManifest(load.sourceBundle, paths, load.secretValues, load.manifest);
 }
 
 export function runtimeAppliedContentIdentity(
@@ -228,7 +229,7 @@ export function runtimeAppliedContentIdentity(
 	return {
 		sourcePath: load.sourcePath,
 		sha256: runtimeContentSha256({
-			manifest: load.manifest,
+			manifest: load.sourceBundle ?? load.manifest,
 			secretValues: runtimeRecoverableSecretValues(load.manifest, load.secretValues),
 		}),
 	};
@@ -460,14 +461,14 @@ function readRuntimeWatchNotificationConfig(
 	const apiKey = readRuntimeAuthToken(paths);
 	if (!apiKey || !existsSync(paths.manifestLastGood)) return null;
 	try {
-		const parsed = runtimeDesiredStateSchema.safeParse(
+		const parsed = hostedRuntimeBundleV2Schema.safeParse(
 			JSON.parse(readFileSync(paths.manifestLastGood, "utf-8")),
 		);
 		if (!parsed.success) return null;
 		return {
-			apiUrl: parsed.data.controlPlane.apiUrl,
+			apiUrl: parsed.data.manifest.controlPlane.apiUrl,
 			apiKey,
-			environmentId: parsed.data.environmentId,
+			environmentId: parsed.data.manifest.environmentId,
 		};
 	} catch {
 		return null;
@@ -654,7 +655,7 @@ export async function runtimeVerify(opts: RuntimeVerifyOptions = {}) {
 	if (manifestCacheExists) {
 		try {
 			const raw = JSON.parse(readFileSync(paths.manifestLastGood, "utf-8")) as unknown;
-			const parsed = runtimeDesiredStateSchema.safeParse(raw);
+			const parsed = hostedRuntimeBundleV2Schema.safeParse(raw);
 			if (!parsed.success) {
 				errors.push(`cached manifest parse failed: ${z.prettifyError(parsed.error)}`);
 			}

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -99,8 +99,9 @@ export function applyRuntimeBundleChannelsToManifestLoad(
 	paths: RuntimePaths = getRuntimePaths({ mode: "hosted" }),
 ): RuntimeManifestLoad {
 	if (!load.channelBindings) return load;
+	const { channelBindings, ...source } = load;
 	const secretValues = load.secretValues ?? {};
-	const links: ManagedChannelLink[] = load.channelBindings.map((binding) =>
+	const links: ManagedChannelLink[] = channelBindings.map((binding) =>
 		managedBundleChannelLink(binding, secretValues),
 	);
 	const manifest = applyRuntimeChannelProjection(load.manifest, links, paths);
@@ -109,9 +110,8 @@ export function applyRuntimeBundleChannelsToManifestLoad(
 		manifest.projection?.channelCredentials,
 	);
 	return {
-		...load,
+		...source,
 		manifest,
-		sourceManifest: load.sourceManifest ?? load.manifest,
 		secretValues: { ...secretValues, ...whatsappSecretValues },
 	};
 }

--- a/packages/cli/src/runtime/hosted-agent-plugin-observation.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-observation.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import type { RuntimeAppliedState } from "./applied-state";
@@ -9,7 +9,6 @@ import {
 	hostedAgentPluginReceiptsPath,
 	writeHostedAgentPluginReceipt,
 } from "./hosted-agent-plugin-package";
-import type { RuntimeManifest } from "./manifest-contract";
 import { readHostedRuntimeObserved } from "./observed";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 
@@ -71,27 +70,31 @@ function appliedState(): RuntimeAppliedState {
 }
 
 function writeAppliedManifest(paths: RuntimePaths, desired: ReturnType<typeof installation>): void {
-	const manifest: RuntimeManifest = {
-		schemaVersion: "clawdi.runtimeDesiredState.v1",
-		deploymentId: "deployment-agent-plugin-observation",
-		environmentId: "environment-agent-plugin-observation",
+	mkdirSync(dirname(paths.manifestLastGood), { recursive: true });
+	const bundle = JSON.parse(
+		readFileSync(
+			join(import.meta.dir, "../../../../test-fixtures/runtime-bundle-v2.golden.json"),
+			"utf8",
+		),
+	) as {
+		sourceRevision: string;
+		applyGeneration?: number;
+		secretValues: Record<string, string>;
+		manifest: Record<string, unknown>;
+	};
+	bundle.sourceRevision = sourceRevision;
+	bundle.applyGeneration = 7;
+	bundle.secretValues = {};
+	bundle.manifest = {
+		...bundle.manifest,
 		instanceId: "runtime-agent-plugin-observation",
 		generation: 3,
-		applyGeneration: 7,
-		issuedAt: "2026-08-15T00:00:00.000Z",
-		runtime: "openclaw",
-		controlPlane: { apiUrl: "https://runtime.test" },
-		runtimes: { openclaw: { enabled: true, services: {} } },
-		projection: {
-			agentPlugins: {
-				schemaVersion: 1,
-				installations: { clawdi: desired },
-			},
+		agentPlugins: {
+			schemaVersion: 1,
+			installations: { clawdi: desired },
 		},
-		recovery: {},
 	};
-	mkdirSync(dirname(paths.manifestLastGood), { recursive: true });
-	writeFileSync(paths.manifestLastGood, JSON.stringify(manifest));
+	writeFileSync(paths.manifestLastGood, JSON.stringify(bundle));
 }
 
 function writeReceipt(paths: RuntimePaths, desired: ReturnType<typeof installation>): void {

--- a/packages/cli/src/runtime/hosted-agent-plugin-observation.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-observation.ts
@@ -7,12 +7,13 @@ import {
 	type HostedAgentPluginReceipt,
 	readHostedAgentPluginReceipt,
 } from "./hosted-agent-plugin-package";
-import { manifestSchema, type RuntimeManifest } from "./manifest-contract";
+import type { RuntimeManifest } from "./manifest-contract";
 import {
 	agentPluginNameSchema,
 	type HostedAgentPluginInstallation,
 	hostedAgentPluginInstallationSchema,
 } from "./manifest-resources";
+import { hostedRuntimeBundleV2Schema } from "./manifest-source";
 import type { RuntimePaths } from "./paths";
 
 type AgentPluginObservation = components["schemas"]["HostedRuntimeObservedAgentPluginV1"];
@@ -88,9 +89,9 @@ function readAppliedManifest(
 	applied: RuntimeAppliedState,
 ): RuntimeManifest | null {
 	try {
-		const manifest = manifestSchema.parse(
+		const manifest = hostedRuntimeBundleV2Schema.parse(
 			JSON.parse(readFileSync(paths.manifestLastGood, "utf-8")),
-		);
+		).manifest;
 		return manifest.instanceId === applied.instanceId &&
 			resolveRuntimeApplyGeneration(manifest) === resolveRuntimeApplyGeneration(applied)
 			? manifest

--- a/packages/cli/src/runtime/hosted-agent-plugin-package.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-package.test.ts
@@ -26,7 +26,7 @@ import {
 	hostedAgentPluginCommands,
 	proveHostedAgentPluginCapabilities,
 } from "./hosted-agent-plugin-runtime";
-import { AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR, type RuntimeManifest } from "./manifest-contract";
+import type { RuntimeManifest } from "./manifest-contract";
 import { AGENT_PLUGINS_SCHEMA_1_0_0 } from "./manifest-resources";
 import { getRuntimePaths } from "./paths";
 import { ensureRuntimeStateDirs } from "./state";
@@ -103,7 +103,6 @@ function manifest(
 		controlPlane: { apiUrl: "https://cloud-api.example.test" },
 		runtimes: { [runtime]: { enabled: true, services: {} } },
 		projection: {
-			sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
 			agentPlugins: {
 				schemaVersion: 1,
 				installations: {
@@ -175,24 +174,6 @@ function permissiveNativeRunner(onCommand: () => void): HostedAgentPluginCommand
 }
 
 describe("Hosted Agent Plugin package preparation", () => {
-	test("rejects installations outside a hosted v2 bundle before fetching", async () => {
-		const runtimePaths = paths();
-		const invalidManifest = manifest("openclaw", `sha256-tree-v1:${"f".repeat(64)}`);
-		if (!invalidManifest.projection) throw new Error("missing Agent Plugin fixture projection");
-		delete invalidManifest.projection.sourceBundleVersion;
-		let fetches = 0;
-
-		await expect(
-			prepareHostedAgentPluginPackages(invalidManifest, runtimePaths, {
-				fetcher: async () => {
-					fetches += 1;
-					throw new Error("unexpected fetch");
-				},
-			}),
-		).rejects.toThrow(AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR);
-		expect(fetches).toBe(0);
-	});
-
 	test("rejects a digest mismatch before native commands can run", async () => {
 		const runtimePaths = paths();
 		const bytes = await archive(pluginFiles());

--- a/packages/cli/src/runtime/hosted-agent-plugin-package.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-package.ts
@@ -29,11 +29,7 @@ import {
 } from "../lib/github-skill-archive";
 import { extractTarGz } from "../lib/tar";
 import { archiveCache, gcArchiveCache } from "./archive-cache";
-import {
-	AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR,
-	HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
-	type RuntimeManifest,
-} from "./manifest-contract";
+import type { RuntimeManifest } from "./manifest-contract";
 import {
 	AGENT_PLUGINS_SCHEMA_1_0_0,
 	agentPluginNameSchema,
@@ -984,14 +980,6 @@ export async function prepareHostedAgentPluginPackages(
 	options: { fetcher?: GithubArchiveFetcher; offline?: boolean } = {},
 ): Promise<PreparedHostedAgentPlugins | null> {
 	const desiredInstallations = manifest.projection?.agentPlugins?.installations ?? {};
-	const isHostedV2 =
-		manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION;
-	if (!isHostedV2) {
-		if (Object.keys(desiredInstallations).length > 0) {
-			throw new Error(AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR);
-		}
-		return null;
-	}
 	const previousReceipt = readHostedAgentPluginReceipt(paths);
 	if (Object.keys(desiredInstallations).length === 0 && !previousReceipt) return null;
 	const previous = previousAgentPluginOwnerships(previousReceipt);

--- a/packages/cli/src/runtime/hosted-openclaw-context.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-context.ts
@@ -13,7 +13,7 @@ import {
 	resolveOpenClawSdkExport,
 } from "../lib/codex-oauth-native-store";
 import { agentTargetProjectionInput, hostedAiProviderCatalog } from "./hosted-provider-resolution";
-import { HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION, type RuntimeManifest } from "./manifest-contract";
+import type { RuntimeManifest } from "./manifest-contract";
 import {
 	executableExists,
 	runtimeUserDirectoryOwnership,
@@ -186,8 +186,7 @@ function resolveSdkExports(
 
 export function hostedOpenClawRuntimeUserOwnership(manifest: RuntimeManifest, home: string) {
 	const stateRoot = join(home, ".openclaw");
-	return manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION &&
-		manifest.runtimes.openclaw?.enabled === true
+	return manifest.runtimes.openclaw?.enabled === true
 		? [
 				...runtimeUserDirectoryOwnership(stateRoot, { mode: 0o700 }),
 				...runtimeUserDirectoryOwnership(join(stateRoot, "tmp"), { mode: 0o700 }),
@@ -247,7 +246,6 @@ function hasManagedApiKeyProjection(manifest: RuntimeManifest): boolean {
 		(entry) => entry.id === CLAWDI_MANAGED_PROVIDER_ID,
 	);
 	return (
-		manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION &&
 		runtime?.enabled === true &&
 		runtime.providerMode === "configured" &&
 		sourceProvider?.managed_by === "clawdi" &&

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -7,16 +7,14 @@ import {
 import { z } from "zod";
 import { egressEngineSchema } from "./egress-engine";
 import { egressProfileInputBundleSchema } from "./egress-profiles";
+import { hostedManifestEgressProfiles } from "./hosted-egress-profiles";
 import {
 	hostedAgentPluginsDesiredStateSchema,
 	hostedMcpDesiredStateSchema,
 	hostedSkillsDesiredStateSchema,
 } from "./manifest-resources";
-import {
-	runtimeNameSchema,
-	runtimeRunSettingsSchema,
-	runtimeServiceNameSchema,
-} from "./run-config";
+import { getRuntimePaths } from "./paths";
+import { type RuntimeRunSettings, runtimeNameSchema, runtimeServiceNameSchema } from "./run-config";
 import { canonicalSecretRefName, canonicalSecretRefSchema } from "./secret-values";
 
 export type { EgressEnginePin } from "./egress-engine";
@@ -165,38 +163,6 @@ export const runtimeLocaleSchema = z
 		timezone: z.string().min(1).refine(isValidIanaTimezone, "must be a valid IANA timezone"),
 	})
 	.strict();
-
-const installSchema = z.object({
-	authority: z.literal("official"),
-	method: z.literal("official-installer"),
-	url: z.string().url(),
-	home: z.string().min(1),
-	args: z.array(z.string()).default([]),
-});
-
-const runtimeSchema = z.object({
-	enabled: z.boolean(),
-	providerMode: z.enum(["configured", "unmanaged"]).optional(),
-	updateChannel: z.string().min(1).optional(),
-	install: installSchema.optional(),
-	run: runtimeRunSettingsSchema.optional(),
-	services: z.record(runtimeServiceNameSchema, runtimeRunSettingsSchema).default({}),
-	provider_ids: z.array(z.string().min(1)).max(1).optional(),
-	primary_model: z
-		.object({
-			provider_id: z.string().min(1),
-			model: z.string().min(1),
-		})
-		.optional(),
-});
-
-const cliPayloadPolicySchema = z.object({
-	version: z.string().min(1).optional(),
-	channel: z.string().min(1).optional(),
-	source: z.string().min(1).optional(),
-	packageSpec: z.string().min(1).optional(),
-	registry: z.string().min(1).optional(),
-});
 
 function isHostedExactCliPackageSpec(value: string): boolean {
 	const npmVersion = /^clawdi@(.+)$/.exec(value)?.[1];
@@ -349,11 +315,6 @@ const runtimeCompanionsSchema = z
 const liveSyncAgentSchema = z.object({
 	agentType: runtimeNameSchema,
 	environmentId: z.string().min(1),
-});
-
-const liveSyncSchema = z.object({
-	enabled: z.boolean().optional(),
-	agents: z.array(liveSyncAgentSchema).default([]),
 });
 
 const hostedControlPlaneSchema = z
@@ -611,90 +572,6 @@ const hostedTerminalToolingSchema = z
 	})
 	.strict();
 
-const runtimeProjectionSchema = z.object({
-	sourceSchemaVersion: z.string().min(1).optional(),
-	sourceBundleVersion: z.literal(HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION).optional(),
-	system: z.unknown().nullable().optional(),
-	providers: z
-		.record(
-			z.string().min(1),
-			hostedProviderBaseSchema.extend({ model: z.string().min(1) }).partial(),
-		)
-		.optional(),
-	channels: z.record(z.string().min(1), z.unknown()).optional(),
-	channelCredentials: z.array(z.unknown()).optional(),
-	aiProviders: z.record(z.string().min(1), z.unknown()).optional(),
-	mcp: hostedMcpDesiredStateSchema.optional(),
-	skills: hostedSkillsDesiredStateSchema.optional(),
-	agentPlugins: hostedAgentPluginsDesiredStateSchema.optional(),
-	tools: z.unknown().optional(),
-	terminalTooling: z.unknown().optional(),
-});
-
-const runtimeDesiredStateShape = {
-	deploymentId: z.string().min(1),
-	environmentId: z.string().min(1),
-	instanceId: z.string().min(1),
-	generation: z.number().int().nonnegative(),
-	applyGeneration: z.number().int().positive().safe().optional(),
-	issuedAt: z.string().min(1),
-	expiresAt: z.string().min(1).optional(),
-	locale: runtimeLocaleSchema.optional(),
-	workspaceRoot: z.string().min(1).optional(),
-	runtime: hostedRuntimeChoiceSchema.optional(),
-	controlPlane: z.object({
-		apiUrl: z.string().url(),
-	}),
-	clawdiCli: cliPayloadPolicySchema.optional(),
-	egressEngine: egressEngineSchema.optional(),
-	companions: runtimeCompanionsSchema.optional(),
-	runtimes: z.record(runtimeNameSchema, runtimeSchema),
-	openclawGatewayAuth: openclawGatewayAuthSchema.optional(),
-	hermesDashboardAuth: hermesDashboardAuthSchema.optional(),
-	projection: runtimeProjectionSchema.optional(),
-	egressProfiles: egressProfileInputBundleSchema.optional(),
-	liveSync: liveSyncSchema.optional(),
-	recovery: z
-		.object({
-			cacheManifest: z.boolean().optional(),
-			allowOfflineBoot: z.boolean().optional(),
-		})
-		.default({}),
-};
-
-function addForbiddenFieldIssue(ctx: z.RefinementCtx, field: string, message?: string): void {
-	ctx.addIssue({
-		code: "custom",
-		message: message ?? `Unrecognized key: "${field}"`,
-		path: [field],
-	});
-}
-
-const runtimeManifestSchema = z
-	.object({
-		schemaVersion: z.literal(RUNTIME_DESIRED_STATE_SCHEMA_VERSION),
-		...runtimeDesiredStateShape,
-		secrets: z.unknown().optional(),
-	})
-	.superRefine((manifest, ctx) => {
-		if ("secrets" in manifest) addForbiddenFieldIssue(ctx, "secrets");
-	})
-	.transform(({ secrets: _secrets, ...manifest }) => manifest);
-
-export const manifestSchema = z
-	.unknown()
-	.superRefine((value, ctx) => {
-		if (
-			typeof value === "object" &&
-			value !== null &&
-			!Array.isArray(value) &&
-			Object.hasOwn(value, "bridge")
-		) {
-			addForbiddenFieldIssue(ctx, "bridge");
-		}
-	})
-	.pipe(runtimeManifestSchema);
-
 const hostedLiveSyncAgentSchema = liveSyncAgentSchema
 	.extend({
 		agentType: z.enum(["openclaw", "hermes", "codex"]),
@@ -732,6 +609,67 @@ const hostedLiveSyncSchema = z
 			});
 		}
 	});
+
+export interface RuntimeInstall {
+	authority: "official";
+	method: "official-installer";
+	url: string;
+	home: string;
+	args: string[];
+}
+
+interface RuntimeEntry {
+	enabled: boolean;
+	providerMode?: "configured" | "unmanaged";
+	updateChannel?: string;
+	install?: RuntimeInstall;
+	run?: RuntimeRunSettings;
+	services: Record<string, RuntimeRunSettings>;
+	provider_ids?: string[];
+	primary_model?: { provider_id: string; model: string };
+}
+
+export interface RuntimeManifest {
+	schemaVersion: typeof RUNTIME_DESIRED_STATE_SCHEMA_VERSION;
+	deploymentId: string;
+	environmentId: string;
+	instanceId: string;
+	generation: number;
+	applyGeneration?: number;
+	issuedAt: string;
+	expiresAt?: string;
+	locale?: z.infer<typeof runtimeLocaleSchema>;
+	workspaceRoot?: string;
+	runtime?: z.infer<typeof hostedRuntimeChoiceSchema>;
+	controlPlane: { apiUrl: string };
+	clawdiCli?: {
+		source?: string;
+		packageSpec?: string;
+		registry?: string;
+	};
+	egressEngine?: z.infer<typeof egressEngineSchema>;
+	companions?: z.infer<typeof runtimeCompanionsSchema>;
+	runtimes: Record<string, RuntimeEntry>;
+	openclawGatewayAuth?: z.infer<typeof openclawGatewayAuthSchema>;
+	hermesDashboardAuth?: z.infer<typeof hermesDashboardAuthSchema>;
+	projection?: {
+		system?: unknown;
+		providers?: Record<
+			string,
+			Partial<z.infer<typeof hostedProviderBaseSchema> & { model: string }>
+		>;
+		channels?: Record<string, unknown>;
+		channelCredentials?: unknown[];
+		mcp?: z.infer<typeof hostedMcpDesiredStateSchema>;
+		skills?: z.infer<typeof hostedSkillsDesiredStateSchema>;
+		agentPlugins?: z.infer<typeof hostedAgentPluginsDesiredStateSchema>;
+		tools?: unknown;
+		terminalTooling?: z.infer<typeof hostedTerminalToolingSchema>;
+	};
+	egressProfiles?: z.infer<typeof egressProfileInputBundleSchema>;
+	liveSync?: { enabled?: boolean; agents: z.infer<typeof liveSyncAgentSchema>[] };
+	recovery: { cacheManifest?: boolean; allowOfflineBoot?: boolean };
+}
 
 const hostedRuntimeManifestBaseSchema = z
 	.object({
@@ -775,67 +713,45 @@ const hostedRuntimeManifestBaseSchema = z
 	.strict();
 
 type HostedRuntimeManifestBase = z.infer<typeof hostedRuntimeManifestBaseSchema>;
+export type HostedRuntimeManifest = HostedRuntimeManifestBase;
 
-interface HostedRuntimeSemanticRun {
-	args?: readonly string[];
-	secretEnv?: Readonly<Record<string, string>>;
-}
-
-interface HostedRuntimeSemanticEntry {
-	enabled?: boolean;
-	run?: HostedRuntimeSemanticRun;
-	services?: Readonly<Record<string, HostedRuntimeSemanticRun>>;
-}
-
-export interface HostedRuntimeSemanticView {
-	hostedV2: boolean;
-	runtime: string;
-	runtimes: Readonly<Record<string, HostedRuntimeSemanticEntry | undefined>>;
-	openclawGatewayAuth?: {
-		tokenRef?: string;
-		activation: { enabled?: boolean };
-	};
-	hermesDashboardAuth?: { activation: { enabled?: boolean } };
-	openclawControlUiAllowedOrigins?: unknown;
-	providers?: Readonly<Record<string, { runtimeEnvName?: string }>>;
-}
-
-export interface HostedRuntimeSemanticIssue {
-	message: string;
-	path: string[];
-}
-
-export function hostedRuntimeSemanticIssues(
-	view: HostedRuntimeSemanticView,
-): HostedRuntimeSemanticIssue[] {
-	const issues: HostedRuntimeSemanticIssue[] = [];
+function validateHostedRuntimeManifest(
+	manifest: HostedRuntimeManifestBase,
+	ctx: z.RefinementCtx,
+): void {
 	const addIssue = (message: string, path: string[]): void => {
-		issues.push({ message, path });
+		ctx.addIssue({ code: "custom", message, path });
 	};
 	const systemPath = (...path: string[]): string[] => ["system", ...path];
-	const runtimePath = (...path: string[]): string[] => ["runtimes", view.runtime, ...path];
-	const runtimeKeys = Object.keys(view.runtimes);
-	const selectedRuntime = view.runtimes[view.runtime];
+	const runtimePath = (...path: string[]): string[] => ["runtimes", manifest.runtime, ...path];
+	const selectedRuntime = manifest.runtimes[manifest.runtime];
 	if (!selectedRuntime) {
-		addIssue(`runtimes.${view.runtime} must be present for selected runtime`, [
+		addIssue(`runtimes.${manifest.runtime} must be present for selected runtime`, [
 			"runtimes",
-			view.runtime,
+			manifest.runtime,
 		]);
 	}
-	for (const key of runtimeKeys) {
-		if (key === view.runtime) continue;
-		addIssue("hosted runtime manifests must declare exactly one selected runtime", [
-			"runtimes",
-			key,
-		]);
+	for (const runtime of Object.keys(manifest.runtimes)) {
+		if (runtime !== manifest.runtime) {
+			addIssue("hosted runtime manifests must declare exactly one selected runtime", [
+				"runtimes",
+				runtime,
+			]);
+		}
 	}
 	if (selectedRuntime?.enabled !== true) {
-		addIssue("selected runtime must be enabled", ["runtimes", view.runtime, "enabled"]);
+		addIssue("selected runtime must be enabled", ["runtimes", manifest.runtime, "enabled"]);
 	}
-	if (!view.hostedV2) return issues;
-
-	if (view.runtime === "openclaw") {
-		const auth = view.openclawGatewayAuth;
+	if (manifest.expiresAt) {
+		const expiresAt = Date.parse(manifest.expiresAt);
+		if (!Number.isFinite(expiresAt)) {
+			addIssue("manifest expiresAt is not a valid timestamp", ["expiresAt"]);
+		} else if (expiresAt <= Date.now()) {
+			addIssue(`manifest expired at ${manifest.expiresAt}`, ["expiresAt"]);
+		}
+	}
+	if (manifest.runtime === "openclaw") {
+		const auth = manifest.system.openclawGatewayAuth;
 		if (!auth) {
 			addIssue(
 				"OpenClaw v2 native Control UI requires official gateway token authentication",
@@ -847,16 +763,13 @@ export function hostedRuntimeSemanticIssues(
 				systemPath("openclawGatewayAuth", "activation", "enabled"),
 			);
 		}
-		if (
-			!Array.isArray(view.openclawControlUiAllowedOrigins) ||
-			view.openclawControlUiAllowedOrigins.length === 0
-		) {
+		if (!manifest.system.openclawControlUiAllowedOrigins?.length) {
 			addIssue(
 				"OpenClaw v2 native Control UI requires an explicit public allowed origin",
 				systemPath("openclawControlUiAllowedOrigins"),
 			);
 		}
-		const run = view.runtimes.openclaw?.run;
+		const run = manifest.runtimes.openclaw?.run;
 		if (!isHostedGatewayRunArgs("openclaw", run?.args)) {
 			addIssue(
 				"OpenClaw v2 gateway must use the official gateway run command",
@@ -869,7 +782,7 @@ export function hostedRuntimeSemanticIssues(
 				runtimePath("run", "secretEnv", "OPENCLAW_GATEWAY_TOKEN"),
 			);
 		}
-		for (const [providerId, provider] of Object.entries(view.providers ?? {})) {
+		for (const [providerId, provider] of Object.entries(manifest.providers)) {
 			if (provider.runtimeEnvName === "OPENCLAW_GATEWAY_TOKEN") {
 				addIssue("OpenClaw v2 provider environment must not target native auth controls", [
 					"providers",
@@ -878,65 +791,38 @@ export function hostedRuntimeSemanticIssues(
 				]);
 			}
 		}
-	}
-
-	if (view.runtime === "hermes") {
-		if (!view.hermesDashboardAuth) {
+	} else {
+		if (!manifest.system.hermesDashboardAuth) {
 			addIssue(
 				"hermes direct dashboard requires official password authentication",
 				systemPath("hermesDashboardAuth"),
 			);
 		}
-		if (view.hermesDashboardAuth?.activation.enabled !== true) {
+		if (manifest.system.hermesDashboardAuth?.activation.enabled !== true) {
 			addIssue(
 				"hermes password authentication must be explicitly enabled",
 				systemPath("hermesDashboardAuth", "activation", "enabled"),
 			);
 		}
-		if (view.openclawGatewayAuth) {
+		if (manifest.system.openclawGatewayAuth) {
 			addIssue(
 				"OpenClaw gateway auth is only valid for the OpenClaw runtime",
 				systemPath("openclawGatewayAuth"),
 			);
 		}
-		if (!isHostedGatewayRunArgs("hermes", view.runtimes.hermes?.run?.args)) {
+		if (!isHostedGatewayRunArgs("hermes", manifest.runtimes.hermes?.run.args)) {
 			addIssue(
 				"Hermes gateway must use the official gateway run command",
 				runtimePath("run", "args"),
 			);
 		}
-		if (!isHostedHermesDashboardArgs(view.runtimes.hermes?.services?.dashboard?.args)) {
+		if (!isHostedHermesDashboardArgs(manifest.runtimes.hermes?.services.dashboard?.args)) {
 			addIssue(
 				"hermes dashboard must bind directly to 0.0.0.0:9119",
 				runtimePath("services", "dashboard", "args"),
 			);
 		}
 	}
-	return issues;
-}
-
-function hostedRuntimeManifestSemanticView(
-	manifest: HostedRuntimeManifestBase,
-): HostedRuntimeSemanticView {
-	return {
-		hostedV2: true,
-		runtime: manifest.runtime,
-		runtimes: manifest.runtimes,
-		openclawGatewayAuth: manifest.system.openclawGatewayAuth,
-		hermesDashboardAuth: manifest.system.hermesDashboardAuth,
-		openclawControlUiAllowedOrigins: manifest.system.openclawControlUiAllowedOrigins,
-		providers: manifest.providers,
-	};
-}
-
-function validateHostedRuntimeManifest(
-	manifest: HostedRuntimeManifestBase,
-	ctx: z.RefinementCtx,
-): void {
-	for (const issue of hostedRuntimeSemanticIssues(hostedRuntimeManifestSemanticView(manifest))) {
-		ctx.addIssue({ code: "custom", message: issue.message, path: issue.path });
-	}
-	const selectedRuntime = manifest.runtimes[manifest.runtime];
 	if (selectedRuntime) {
 		const providerIds = new Set(selectedRuntime.provider_ids);
 		for (const providerId of providerIds) {
@@ -994,15 +880,7 @@ function validateHostedRuntimeManifest(
 	}
 }
 
-export const hostedRuntimeManifestSchema = hostedRuntimeManifestBaseSchema
-	.safeExtend({
-		schemaVersion: z.literal("clawdi.hosted-runtime.manifest.v1"),
-		clawdiCli: hostedCliPayloadPolicySchema,
-	})
-	.strict()
-	.superRefine(validateHostedRuntimeManifest);
-
-export const hostedRuntimeBundleV2ManifestSchema = hostedRuntimeManifestBaseSchema
+const hostedRuntimeBundleV2ManifestWireSchema = hostedRuntimeManifestBaseSchema
 	.safeExtend({
 		schemaVersion: z.literal("clawdi.hosted-runtime.manifest.v1"),
 		clawdiCli: hostedCliPayloadPolicySchema,
@@ -1011,21 +889,114 @@ export const hostedRuntimeBundleV2ManifestSchema = hostedRuntimeManifestBaseSche
 	.strict()
 	.superRefine(validateHostedRuntimeManifest);
 
+type HostedRuntimeBundleV2ManifestWire = z.infer<typeof hostedRuntimeBundleV2ManifestWireSchema>;
+type HostedRuntimeRunSettings = HostedRuntimeBundleV2ManifestWire["runtimes"][string]["run"];
+
+export const hostedRuntimeBundleV2ManifestSchema =
+	hostedRuntimeBundleV2ManifestWireSchema.transform((hosted): RuntimeManifest => {
+		const paths = getRuntimePaths({ mode: "hosted" });
+		const selectedRuntime = hosted.runtime;
+		const runtime = hosted.runtimes[selectedRuntime];
+		if (!runtime) throw new Error(`missing selected runtime ${selectedRuntime}`);
+		return {
+			schemaVersion: RUNTIME_DESIRED_STATE_SCHEMA_VERSION,
+			deploymentId: hosted.deploymentId,
+			environmentId: hosted.environmentId,
+			instanceId: hosted.instanceId,
+			generation: hosted.generation,
+			issuedAt: hosted.issuedAt,
+			expiresAt: hosted.expiresAt,
+			locale: hosted.locale,
+			runtime: selectedRuntime,
+			controlPlane: { apiUrl: hosted.controlPlane.cloudApiUrl },
+			clawdiCli: { ...hosted.clawdiCli },
+			egressEngine: hosted.egressEngine,
+			companions: hosted.companions,
+			runtimes: {
+				[selectedRuntime]: {
+					enabled: runtime.enabled,
+					providerMode: runtime.providerMode,
+					install: {
+						authority: "official" as const,
+						method: "official-installer" as const,
+						url: OFFICIAL_INSTALL_URLS[selectedRuntime],
+						home: paths.userHome,
+						args: officialInstallArgs(selectedRuntime, paths.userHome),
+					},
+					run: hostedRuntimeRunSettings(selectedRuntime, runtime.run),
+					services: Object.fromEntries(
+						Object.entries(runtime.services).map(([service, run]) => [
+							service,
+							copyHostedRuntimeRunSettings(run),
+						]),
+					),
+					...hostedRuntimeProviderBinding(runtime),
+				},
+			},
+			openclawGatewayAuth: hosted.system.openclawGatewayAuth,
+			hermesDashboardAuth: hosted.system.hermesDashboardAuth,
+			projection: {
+				system: hosted.system,
+				providers: hosted.providers,
+				...(hosted.mcp === undefined ? {} : { mcp: hosted.mcp }),
+				...(hosted.skills === undefined ? {} : { skills: hosted.skills }),
+				...(hosted.agentPlugins === undefined ? {} : { agentPlugins: hosted.agentPlugins }),
+				...(hosted.tools === undefined ? {} : { tools: hosted.tools }),
+				...(hosted.terminalTooling === undefined
+					? {}
+					: { terminalTooling: hosted.terminalTooling }),
+			},
+			liveSync: hosted.liveSync,
+			egressProfiles: hostedManifestEgressProfiles(hosted),
+			recovery: { ...hosted.recovery },
+		};
+	});
+
+function hostedRuntimeProviderBinding(
+	runtime: HostedRuntimeBundleV2ManifestWire["runtimes"][string],
+):
+	| { provider_ids: string[]; primary_model: { provider_id: string; model: string } }
+	| { provider_ids: [] } {
+	if (runtime.providerMode === "unmanaged") return { provider_ids: [] };
+	return { provider_ids: runtime.provider_ids, primary_model: runtime.primary_model };
+}
+
+function hostedRuntimeRunSettings(
+	runtime: HostedRuntimeBundleV2ManifestWire["runtime"],
+	run: HostedRuntimeRunSettings,
+): ReturnType<typeof copyHostedRuntimeRunSettings> {
+	const settings = copyHostedRuntimeRunSettings(run);
+	if (isHostedGatewayRunArgs(runtime, run.args)) settings.args = ["gateway", "run"];
+	return settings;
+}
+
+function copyHostedRuntimeRunSettings(run: HostedRuntimeRunSettings): {
+	args: string[];
+	env: Record<string, string>;
+	prependPath: string[];
+	secretEnv?: Record<string, string>;
+} {
+	return {
+		args: [...run.args],
+		env: {},
+		prependPath: [],
+		...(run.secretEnv === undefined ? {} : { secretEnv: { ...run.secretEnv } }),
+	};
+}
+
 export function validateUnmanagedProviderSecretValues(
 	response: {
-		manifest: {
-			runtime: string;
-			runtimes: Readonly<Record<string, { providerMode?: "configured" | "unmanaged" } | undefined>>;
-			terminalTooling?: { codex: { provider: { apiKeySecretRef?: string | null } } };
-		};
+		manifest: Pick<RuntimeManifest, "runtime" | "runtimes" | "projection">;
 		secretValues: Readonly<Record<string, string>>;
 	},
 	ctx: z.RefinementCtx,
 ): void {
-	const runtime = response.manifest.runtimes[response.manifest.runtime];
+	const selectedRuntime = response.manifest.runtime;
+	if (!selectedRuntime) return;
+	const runtime = response.manifest.runtimes[selectedRuntime];
 	if (runtime?.providerMode !== "unmanaged") return;
 	const codexSecretRef = canonicalSecretRefName(
-		response.manifest.terminalTooling?.codex.provider.apiKeySecretRef,
+		response.manifest.projection?.terminalTooling?.codex.provider.apiKeySecretRef,
 	);
 	for (const rawSecretRef of Object.keys(response.secretValues)) {
 		const secretRef = canonicalSecretRefName(rawSecretRef);
@@ -1038,16 +1009,11 @@ export function validateUnmanagedProviderSecretValues(
 	}
 }
 
-export type RuntimeManifest = z.output<typeof manifestSchema>;
-export type RuntimeInstall = z.infer<typeof installSchema>;
-export type HostedRuntimeManifest = z.infer<typeof hostedRuntimeManifestSchema>;
-export type HostedRuntimeBundleV2Manifest = z.infer<typeof hostedRuntimeBundleV2ManifestSchema>;
+export type HostedRuntimeBundleV2Manifest = z.input<typeof hostedRuntimeBundleV2ManifestSchema>;
 export type LiveSyncAgent = z.infer<typeof liveSyncAgentSchema>;
 
 export const AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR =
 	"Agent Plugin installations require a newer Clawdi runtime capability";
-export const AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR =
-	"Agent Plugin reconciliation requires a hosted v2 bundle";
 
 export function hasUnsupportedAgentPluginInstallations(
 	manifest: Pick<RuntimeManifest, "projection">,

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -34,9 +34,7 @@ import {
 	materializeHostedChannelCredentials,
 } from "./manifest-channels";
 import {
-	AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR,
 	AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR,
-	HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
 	hasUnsupportedAgentPluginInstallations,
 } from "./manifest-contract";
 import {
@@ -83,7 +81,6 @@ import {
 	applyHostedAiProviderProjection,
 	applyHostedCodexManagedProviderProjection,
 	ensureHostedCodexCli,
-	hostedCodexManagedProvider,
 	previewHostedAiProviderProjectionRevision,
 } from "./manifest-providers";
 import { applyHostedRuntimeConfigProjection } from "./manifest-runtime-config";
@@ -233,12 +230,6 @@ function initializeRuntimeConvergence(
 ): { context: RuntimeConvergenceContext; state: RuntimeConvergenceState } {
 	const { manifest } = load;
 	if (
-		(hasUnsupportedAgentPluginInstallations(manifest) || opts.preparedHostedAgentPlugins) &&
-		manifest.projection?.sourceBundleVersion !== HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION
-	) {
-		throw new Error(AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR);
-	}
-	if (
 		hasUnsupportedAgentPluginInstallations(manifest) &&
 		!opts.preparedHostedAgentPlugins &&
 		!opts.resourcePreparationFailures?.agentPlugins
@@ -276,9 +267,6 @@ function initializeRuntimeConvergence(
 	const hermesWhatsAppAuthDir = managedHermesWhatsAppAuthDir(manifest, projectionHome);
 	removeHostedCliPathExposure(paths);
 	if (manifest.companions?.filebrowser) {
-		if (manifest.projection?.sourceBundleVersion !== HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION) {
-			throw new Error("Files companion requires a hosted v2 bundle");
-		}
 		if (!opts.systemdApply) {
 			throw new Error("Files companion requires systemd apply and readiness hooks");
 		}
@@ -500,10 +488,7 @@ function prepareRuntimeConvergencePlan(
 			manifest.runtimes.openclaw?.enabled === true ||
 			Boolean(openClawCommand && executableExists(openClawCommand));
 		openClawWorkspaceRoot = shouldResolveOpenClawWorkspace
-			? resolveOpenClawWorkspaceForConvergence(
-					projectionHome,
-					manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
-				)
+			? resolveOpenClawWorkspaceForConvergence(projectionHome, true)
 			: null;
 		plannedRuntimePrograms = planRuntimeSystemdUserPrograms({
 			manifest,
@@ -684,10 +669,7 @@ function prepareRuntimeApplyDependencies(
 	}
 
 	let codexCli: Record<string, string> | null = null;
-	if (
-		hostedCodexManagedProvider(manifest) ||
-		manifest.projection?.sourceSchemaVersion === "clawdi.hosted-runtime.manifest.v1"
-	) {
+	if (manifest.projection?.terminalTooling?.codex) {
 		try {
 			codexCli = ensureHostedCodexCli(paths);
 		} catch (error) {
@@ -801,7 +783,7 @@ function prepareRuntimeEgressProjection(
 	const egressEngine = egressProfileBundlePath
 		? ensureRuntimeMitmproxy(manifest.egressEngine, paths, opts.egressEngineEnsureOptions)
 		: null;
-	requireV2EgressEngineReady(manifest, egressProfileBundlePath, egressEngine);
+	requireV2EgressEngineReady(egressProfileBundlePath, egressEngine);
 	const egressAddon = egressProfileBundlePath ? writeEgressAddon(paths) : clearEgressAddon(paths);
 	const daemonAuthTokenFile = writeDaemonAuthToken(paths, secretValues);
 	const runtimeAuthToken = daemonAuthTokenFile ? readRuntimeAuthToken(paths) : null;
@@ -1413,13 +1395,12 @@ function activateRuntimeServices(
 		probeFileBrowserReadiness(manifest, { probe: opts.fileBrowserReadinessProbe });
 	}
 	let manifestLastGood: string | null = null;
-	if (state.installErrors.length === 0 && opts.cacheLastGood !== false) {
-		manifestLastGood = writeLastGoodManifest(
-			load.sourceManifest ?? manifest,
-			paths,
-			load.secretValues,
-			manifest,
-		);
+	if (
+		state.installErrors.length === 0 &&
+		opts.cacheLastGood !== false &&
+		load.sourceBundle !== undefined
+	) {
+		manifestLastGood = writeLastGoodManifest(load.sourceBundle, paths, load.secretValues, manifest);
 	}
 	return { manifestLastGood };
 }

--- a/packages/cli/src/runtime/manifest-egress.ts
+++ b/packages/cli/src/runtime/manifest-egress.ts
@@ -11,7 +11,6 @@ import {
 import { resolve } from "node:path";
 import { resolveCurrentCliResourceRoot } from "../lib/current-cli-invocation";
 import type { EgressProfileBundle } from "./egress-profiles";
-import { HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION, type RuntimeManifest } from "./manifest-contract";
 import { makeEgressIdentityOwned } from "./manifest-secrets";
 import { writeRuntimePrivateFileAtomic } from "./manifest-shared";
 import type { RuntimeMitmproxyEnsureResult } from "./mitmproxy-fetch";
@@ -57,15 +56,10 @@ export function clearEgressProfileBundle(paths: RuntimePaths): null {
 	return null;
 }
 export function requireV2EgressEngineReady(
-	manifest: RuntimeManifest,
 	profileBundlePath: string | null,
 	engine: RuntimeMitmproxyEnsureResult | null,
 ): void {
-	if (
-		manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION &&
-		profileBundlePath &&
-		engine?.status !== "ready"
-	) {
+	if (profileBundlePath && engine?.status !== "ready") {
 		throw new Error(
 			`required egress engine is not ready: ${engine?.error ?? "status unavailable"}`,
 		);

--- a/packages/cli/src/runtime/manifest-mutation-parity.test.ts
+++ b/packages/cli/src/runtime/manifest-mutation-parity.test.ts
@@ -172,11 +172,11 @@ exit 0
 			"secret://tool.codex.apiKey": "codex-provider-key-parity",
 		};
 
-		const { normalizeHostedRuntimeBundleV2 } = await import("./manifest-source");
+		const { parseHostedRuntimeBundleV2 } = await import("./manifest-source");
 		const { convergeRuntimeManifest } = await import("./manifest");
 		const { getRuntimePaths } = await import("./paths");
 		const { ensureRuntimeStateDirs } = await import("./state");
-		const load = normalizeHostedRuntimeBundleV2(fixture);
+		const load = parseHostedRuntimeBundleV2(fixture, "test://manifest-mutation-parity");
 		load.applyContext = {
 			kind: "context-file",
 			backend: "incus",

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -19,7 +19,7 @@ import {
 	hostedAiProviderCatalog,
 	hostedProviderRequiresApiKey,
 } from "./hosted-provider-resolution";
-import { HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION, type RuntimeManifest } from "./manifest-contract";
+import type { RuntimeManifest } from "./manifest-contract";
 import { type RuntimeInstallObservation, tail } from "./manifest-install";
 import { removeOpenClawManagedProviderAuthProfiles } from "./manifest-oauth";
 import { hermesConfigContext } from "./manifest-runtime-config";
@@ -781,10 +781,8 @@ export function openClawGatewayHostedPatch(
 	const gatewayToken = manifest.openclawGatewayAuth
 		? runtimeSecretValue(secretValues ?? {}, manifest.openclawGatewayAuth.tokenRef)
 		: null;
-	const isHostedV2 =
-		manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION;
-	const nativeAuth = isHostedV2 ? manifest.openclawGatewayAuth : undefined;
-	if (isHostedV2 && nativeAuth?.activation.enabled !== true) {
+	const nativeAuth = manifest.openclawGatewayAuth;
+	if (nativeAuth?.activation.enabled !== true) {
 		throw new Error("OpenClaw native auth capability is unavailable");
 	}
 	if (manifest.openclawGatewayAuth && !gatewayToken) {

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -60,22 +60,18 @@ import {
 	shouldIgnoreUserSkill,
 } from "./managed-skill-reservation";
 import {
-	cacheRuntimeLastGoodManifest,
 	convergeRuntimeManifest as convergeRuntimeManifestWithContract,
 	planHostedAgentPluginConvergence,
 	type RuntimeManifest,
 	type RuntimePrivateAppliedAuthority,
 	runtimeInstallerMutationTargets,
-	runtimeRecoverableSecretValues,
 	runtimeUserMutationTargets,
 } from "./manifest";
 import {
-	AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR,
 	AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR,
 	fileBrowserCompanionSchema,
+	type HostedRuntimeBundleV2Manifest,
 	hostedRuntimeBundleV2ManifestSchema,
-	hostedRuntimeManifestSchema,
-	manifestSchema,
 	OFFICIAL_INSTALL_URLS,
 	officialInstallArgs,
 } from "./manifest-contract";
@@ -84,12 +80,7 @@ import {
 	type HostedAgentPluginsDesiredState,
 	type HostedSkillSource,
 } from "./manifest-resources";
-import {
-	hostedManifestToRuntimeManifest,
-	loadCommittedRuntimeManifest,
-	normalizeHostedRuntimeBundleV2,
-	type RuntimeManifestLoad,
-} from "./manifest-source";
+import { parseHostedRuntimeBundleV2, type RuntimeManifestLoad } from "./manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
 import { planRuntimeMutationSystemdUserUnits } from "./runtime-systemd-reconciliation";
@@ -355,6 +346,7 @@ function baseManifest(
 	runtimes: RuntimeManifest["runtimes"],
 	overrides: Partial<RuntimeManifest> = {},
 ): RuntimeManifest {
+	const openclaw = runtimes.openclaw;
 	return {
 		schemaVersion: "clawdi.runtimeDesiredState.v1",
 		deploymentId: "hdep_reconcile",
@@ -364,7 +356,22 @@ function baseManifest(
 		issuedAt: "2026-07-01T00:00:00.000Z",
 		workspaceRoot: join(paths.userHome, "clawdi"),
 		controlPlane: { apiUrl: "https://cloud-api.example.test" },
-		runtimes,
+		runtimes: openclaw?.run
+			? {
+					...runtimes,
+					openclaw: {
+						...openclaw,
+						run: {
+							...openclaw.run,
+							secretEnv: {
+								OPENCLAW_GATEWAY_TOKEN: "secret://runtime/openclaw/gateway-token",
+								...openclaw.run.secretEnv,
+							},
+						},
+					},
+				}
+			: runtimes,
+		...(openclaw ? { openclawGatewayAuth: hostedOpenClawNativeAuth() } : {}),
 		recovery: {},
 		...overrides,
 	};
@@ -479,7 +486,6 @@ function egressRuntimeManifest(
 			issuedAt: `2026-07-01T00:0${input.generation}:00.000Z`,
 			openclawGatewayAuth: hostedOpenClawNativeAuth(),
 			projection: {
-				sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
 				system: hostedSystemFixture(),
 			},
 			...(input.engine ? { egressEngine: input.engine } : {}),
@@ -671,13 +677,16 @@ function normalizeHostedBundleFixture(
 	manifest: Record<string, unknown>,
 	secretValues: Record<string, string>,
 ): RuntimeManifestLoad {
-	return normalizeHostedRuntimeBundleV2({
-		schemaVersion: "clawdi.hosted-runtime.bundle.v2",
-		sourceRevision: "a".repeat(64),
-		manifest,
-		channelBindings: [],
-		secretValues,
-	});
+	return parseHostedRuntimeBundleV2(
+		{
+			schemaVersion: "clawdi.hosted-runtime.bundle.v2",
+			sourceRevision: "a".repeat(64),
+			manifest,
+			channelBindings: [],
+			secretValues,
+		},
+		"test://manifest-reconciliation",
+	);
 }
 
 function writeFakeGatewayCli(input: {
@@ -688,6 +697,7 @@ function writeFakeGatewayCli(input: {
 	failInstall?: boolean;
 	skillInstallSourceLog?: string;
 }): void {
+	const home = dirname(dirname(dirname(input.path)));
 	mkdirSync(dirname(input.path), { recursive: true });
 	writeFileSync(
 		input.path,
@@ -701,7 +711,7 @@ case "$*" in
 		${input.configPatchPath ? `cat > '${input.configPatchPath}'` : "cat >/dev/null"}
 		;;
 	"config path"|"config get "*|"config set "*|"config unset "*)
-		exec '${process.execPath}' '${HERMES_CONFIG_CLI_MOCK}' "$@"
+		HOME='${home}' exec '${process.execPath}' '${HERMES_CONFIG_CLI_MOCK}' "$@"
 		;;
   "gateway install --force --json"|"gateway install --force"|"gateway install")
     ${
@@ -849,7 +859,6 @@ function fileBrowserManifest(
 			issuedAt: `2026-08-05T00:00:${String(input.generation).padStart(2, "0")}.000Z`,
 			openclawGatewayAuth: hostedOpenClawNativeAuth(),
 			projection: {
-				sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
 				system: hostedSystemFixture(),
 			},
 			companions: { filebrowser: companion },
@@ -916,10 +925,8 @@ describe("runtime manifest reconciliation invariants", () => {
 	] as const)(
 		"rejects the removed bridge field in every hosted %s manifest schema",
 		(_name, valid) => {
-			expect(hostedRuntimeManifestSchema.safeParse(valid).success).toBe(true);
 			expect(hostedRuntimeBundleV2ManifestSchema.safeParse(valid).success).toBe(true);
 			const withBridge = { ...valid, bridge: {} };
-			expect(hostedRuntimeManifestSchema.safeParse(withBridge).success).toBe(false);
 			expect(hostedRuntimeBundleV2ManifestSchema.safeParse(withBridge).success).toBe(false);
 		},
 	);
@@ -1000,15 +1007,11 @@ describe("runtime manifest reconciliation invariants", () => {
 
 	test("normalizes previous gateway args during the official-unit rollout", () => {
 		const legacy = hostedOpenClawV2ManifestFixture({}, LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS);
-		expect(hostedRuntimeManifestSchema.safeParse(legacy).success).toBe(true);
 		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(legacy).success).toBe(true);
 		const legacyHermes = hostedRuntimeBundleV2ManifestSchema.parse(
 			hostedHermesManifestFixture({}, ["gateway", "run", "--replace"]),
 		);
-		expect(hostedManifestToRuntimeManifest(legacyHermes).runtimes.hermes.run?.args).toEqual([
-			"gateway",
-			"run",
-		]);
+		expect(legacyHermes.runtimes.hermes.run?.args).toEqual(["gateway", "run"]);
 
 		const unsupported = hostedOpenClawV2ManifestFixture({}, ["gateway", "run", "--force"]);
 		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(unsupported).success).toBe(false);
@@ -1030,21 +1033,17 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(inactive).success).toBe(false);
 	});
 	test("accepts and preserves the exact hosted locale contract", () => {
-		const parsed = hostedRuntimeManifestSchema.parse(
+		const parsed = hostedRuntimeBundleV2ManifestSchema.parse(
 			hostedManifestFixture({ locale: { language: "zh-CN", timezone: "Asia/Shanghai" } }),
 		);
 		expect(parsed.locale).toEqual({ language: "zh-CN", timezone: "Asia/Shanghai" });
-		expect(hostedManifestToRuntimeManifest(parsed).locale).toEqual(parsed.locale);
 	});
 
 	test("strictly parses and preserves the Agent Plugins desired-state contract", () => {
 		const parsed = hostedRuntimeBundleV2ManifestSchema.parse(
 			hostedManifestFixture({ agentPlugins: TEST_AGENT_PLUGINS }),
 		);
-		expect(parsed.agentPlugins).toEqual(TEST_AGENT_PLUGINS);
-		expect(hostedManifestToRuntimeManifest(parsed).projection?.agentPlugins).toEqual(
-			TEST_AGENT_PLUGINS,
-		);
+		expect(parsed.projection?.agentPlugins).toEqual(TEST_AGENT_PLUGINS);
 		const maximumVersion = `1.2.3+${"a".repeat(250)}`;
 		const maximumLengthPlugins = {
 			...TEST_AGENT_PLUGINS,
@@ -1055,29 +1054,19 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(
 			hostedRuntimeBundleV2ManifestSchema.parse(
 				hostedManifestFixture({ agentPlugins: maximumLengthPlugins }),
-			).agentPlugins,
+			).projection?.agentPlugins,
 		).toEqual(maximumLengthPlugins);
 
 		const empty = hostedRuntimeBundleV2ManifestSchema.parse(
 			hostedManifestFixture({ agentPlugins: { schemaVersion: 1, installations: {} } }),
 		);
-		expect(hostedManifestToRuntimeManifest(empty).projection?.agentPlugins).toEqual({
+		expect(empty.projection?.agentPlugins).toEqual({
 			schemaVersion: 1,
 			installations: {},
 		});
 		expect(
-			hostedManifestToRuntimeManifest(
-				hostedRuntimeBundleV2ManifestSchema.parse(hostedManifestFixture()),
-			).projection?.agentPlugins,
+			hostedRuntimeBundleV2ManifestSchema.parse(hostedManifestFixture()).projection?.agentPlugins,
 		).toBeUndefined();
-	});
-
-	test("rejects Agent Plugins on the legacy Hosted manifest v1 contract", () => {
-		expect(
-			hostedRuntimeManifestSchema.safeParse(
-				hostedManifestFixture({ agentPlugins: TEST_AGENT_PLUGINS }),
-			).success,
-		).toBe(false);
 	});
 
 	test.each([
@@ -1140,29 +1129,13 @@ describe("runtime manifest reconciliation invariants", () => {
 		const hosted = hostedRuntimeBundleV2ManifestSchema.parse(
 			hostedManifestFixture({ agentPlugins: TEST_AGENT_PLUGINS }),
 		);
-		const normalized = hostedManifestToRuntimeManifest(hosted);
 
 		expect(() =>
 			convergeRuntimeManifestWithContract(
-				manifestLoad(normalized, "inline-hosted-agent-plugins"),
+				manifestLoad(hosted, "inline-hosted-agent-plugins"),
 				paths,
 			),
 		).toThrow(AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR);
-
-		const desired = preparedTestAgentPlugin("acme.tools", "1.2.3", "a".repeat(64));
-		const nonHosted: RuntimeManifest = {
-			...normalized,
-			projection: { agentPlugins: testAgentPluginDesiredState(desired) },
-		};
-		expect(() =>
-			convergeRuntimeManifestWithContract(
-				manifestLoad(nonHosted, "inline-generic-agent-plugins"),
-				paths,
-				{
-					preparedHostedAgentPlugins: preparedTestAgentPluginState(desired),
-				},
-			),
-		).toThrow(AGENT_PLUGIN_HOSTED_V2_REQUIRED_ERROR);
 	});
 
 	test("fails closed when native Agent Plugin lifecycle support is unavailable", () => {
@@ -1333,7 +1306,6 @@ chmod 0755 '${commandPath}'
 				runtime: "openclaw",
 				openclawGatewayAuth: hostedOpenClawNativeAuth(),
 				projection: {
-					sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
 					agentPlugins: testAgentPluginDesiredState(previous),
 				},
 			},
@@ -1415,7 +1387,6 @@ chmod 0755 '${commandPath}'
 			generation: 2,
 			issuedAt: "2026-07-01T00:02:00.000Z",
 			projection: {
-				sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
 				agentPlugins: testAgentPluginDesiredState(desired),
 			},
 		};
@@ -1458,9 +1429,9 @@ chmod 0755 '${commandPath}'
 		["unsupported language", { language: "en-US", timezone: "UTC" }],
 		["invalid timezone", { language: "en", timezone: "Mars/Olympus" }],
 	])("rejects hosted manifests with %s", (_name, locale) => {
-		expect(hostedRuntimeManifestSchema.safeParse(hostedManifestFixture({ locale })).success).toBe(
-			false,
-		);
+		expect(
+			hostedRuntimeBundleV2ManifestSchema.safeParse(hostedManifestFixture({ locale })).success,
+		).toBe(false);
 	});
 
 	test.each([
@@ -1475,12 +1446,12 @@ chmod 0755 '${commandPath}'
 		],
 	])("rejects hosted manifests with %s", (_name, providers) => {
 		expect(
-			hostedRuntimeManifestSchema.safeParse(hostedManifestFixture({ providers })).success,
+			hostedRuntimeBundleV2ManifestSchema.safeParse(hostedManifestFixture({ providers })).success,
 		).toBe(false);
 	});
 
 	test("accepts and preserves canonical hosted model capability fields", () => {
-		const parsed = hostedRuntimeManifestSchema.parse(
+		const parsed = hostedRuntimeBundleV2ManifestSchema.parse(
 			hostedManifestFixture({
 				providers: {
 					default: {
@@ -1510,8 +1481,7 @@ chmod 0755 '${commandPath}'
 				},
 			}),
 		);
-		const manifest = hostedManifestToRuntimeManifest(parsed);
-		expect(manifest.projection?.providers?.default).toMatchObject({
+		expect(parsed.projection?.providers?.default).toMatchObject({
 			models: [
 				{
 					id: "k3",
@@ -1555,9 +1525,9 @@ chmod 0755 '${commandPath}'
 			{ enabled: true, agents: [{ agentType: "openclaw", environmentId: "e".repeat(201) }] },
 		],
 	])("rejects hosted live sync with %s", (_name, liveSync) => {
-		expect(hostedRuntimeManifestSchema.safeParse(hostedManifestFixture({ liveSync })).success).toBe(
-			false,
-		);
+		expect(
+			hostedRuntimeBundleV2ManifestSchema.safeParse(hostedManifestFixture({ liveSync })).success,
+		).toBe(false);
 	});
 
 	test.each([
@@ -1566,7 +1536,8 @@ chmod 0755 '${commandPath}'
 		["personality", "warm"],
 	])("rejects the top-level %s compatibility field", (field, value) => {
 		expect(
-			hostedRuntimeManifestSchema.safeParse(hostedManifestFixture({ [field]: value })).success,
+			hostedRuntimeBundleV2ManifestSchema.safeParse(hostedManifestFixture({ [field]: value }))
+				.success,
 		).toBe(false);
 	});
 
@@ -1593,14 +1564,14 @@ chmod 0755 '${commandPath}'
 		],
 	])("rejects noncanonical hosted runtime field %s", (_name, runtime) => {
 		expect(
-			hostedRuntimeManifestSchema.safeParse(
+			hostedRuntimeBundleV2ManifestSchema.safeParse(
 				hostedManifestFixture({ runtimes: { openclaw: runtime } }),
 			).success,
 		).toBe(false);
 	});
 
 	test("copies canonical runtime provider bindings without backfill", () => {
-		const canonical = hostedRuntimeManifestSchema.parse(
+		const canonical = hostedRuntimeBundleV2ManifestSchema.parse(
 			hostedManifestFixture({
 				runtimes: {
 					openclaw: hostedRuntimeFixture({
@@ -1610,7 +1581,7 @@ chmod 0755 '${commandPath}'
 				},
 			}),
 		);
-		expect(hostedManifestToRuntimeManifest(canonical).runtimes.openclaw).toMatchObject({
+		expect(canonical.runtimes.openclaw).toMatchObject({
 			provider_ids: ["default"],
 			primary_model: { provider_id: "default", model: "gpt-test" },
 		});
@@ -1622,19 +1593,18 @@ chmod 0755 '${commandPath}'
 			provider_ids: [],
 		});
 		delete runtime.primary_model;
-		const parsed = hostedRuntimeManifestSchema.parse(
+		const parsed = hostedRuntimeBundleV2ManifestSchema.parse(
 			hostedManifestFixture({
 				providers: {},
 				runtimes: { openclaw: runtime },
 			}),
 		);
-		const normalized = hostedManifestToRuntimeManifest(parsed);
-		expect(normalized.runtimes.openclaw).toMatchObject({
+		expect(parsed.runtimes.openclaw).toMatchObject({
 			providerMode: "unmanaged",
 			provider_ids: [],
 		});
-		expect(normalized.runtimes.openclaw.primary_model).toBeUndefined();
-		expect(normalized.projection?.providers).toEqual({});
+		expect(parsed.runtimes.openclaw.primary_model).toBeUndefined();
+		expect(parsed.projection?.providers).toEqual({});
 	});
 
 	test.each([
@@ -1660,7 +1630,7 @@ chmod 0755 '${commandPath}'
 		],
 	])("rejects mixed provider contract: %s", (_name, runtime) => {
 		expect(
-			hostedRuntimeManifestSchema.safeParse(
+			hostedRuntimeBundleV2ManifestSchema.safeParse(
 				hostedManifestFixture({ runtimes: { openclaw: runtime } }),
 			).success,
 		).toBe(false);
@@ -1674,22 +1644,23 @@ chmod 0755 '${commandPath}'
 		};
 		const manifest = hostedManifestFixture({ providers: { default: provider } });
 
-		expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(false);
+		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(manifest).success).toBe(false);
 	});
 
 	test("rejects terminal Codex with a runtime-provider secret ref", () => {
 		const terminalTooling = structuredClone(TEST_HOSTED_CODEX_TOOLING);
 		terminalTooling.codex.provider.apiKeySecretRef = "secret://provider.codex-managed.apiKey";
 		const manifest = hostedManifestFixture({ terminalTooling });
-		expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(false);
+		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(manifest).success).toBe(false);
 	});
 
 	test("rejects retired terminal Codex provider shapes", () => {
 		const legacyEnv = structuredClone(TEST_HOSTED_CODEX_TOOLING);
 		legacyEnv.codex.provider.runtimeEnvName = "OPENAI_API_KEY";
 		expect(
-			hostedRuntimeManifestSchema.safeParse(hostedManifestFixture({ terminalTooling: legacyEnv }))
-				.success,
+			hostedRuntimeBundleV2ManifestSchema.safeParse(
+				hostedManifestFixture({ terminalTooling: legacyEnv }),
+			).success,
 		).toBe(false);
 
 		const legacyCatalog: unknown = {
@@ -1703,7 +1674,7 @@ chmod 0755 '${commandPath}'
 			},
 		};
 		expect(
-			hostedRuntimeManifestSchema.safeParse(
+			hostedRuntimeBundleV2ManifestSchema.safeParse(
 				hostedManifestFixture({ terminalTooling: legacyCatalog }),
 			).success,
 		).toBe(false);
@@ -1715,7 +1686,7 @@ chmod 0755 '${commandPath}'
 			const terminalTooling = structuredClone(TEST_HOSTED_CODEX_TOOLING);
 			terminalTooling.codex.provider.apiMode = apiMode;
 			const manifest = hostedManifestFixture({ terminalTooling });
-			expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(false);
+			expect(hostedRuntimeBundleV2ManifestSchema.safeParse(manifest).success).toBe(false);
 		},
 	);
 
@@ -1725,7 +1696,7 @@ chmod 0755 '${commandPath}'
 			codex: { ...TEST_HOSTED_CODEX_TOOLING.codex, provider },
 		};
 		const manifest = hostedManifestFixture({ terminalTooling });
-		expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(false);
+		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(manifest).success).toBe(false);
 	});
 
 	test.each(["secret://provider.stale.apiKey", "secret://provider.other.apiKey"])(
@@ -1772,7 +1743,7 @@ chmod 0755 '${commandPath}'
 	])("rejects hosted runtime with %s", (_name, overrides) => {
 		const runtime = hostedRuntimeFixture(overrides);
 		expect(
-			hostedRuntimeManifestSchema.safeParse(
+			hostedRuntimeBundleV2ManifestSchema.safeParse(
 				hostedManifestFixture({ runtimes: { openclaw: runtime } }),
 			).success,
 		).toBe(false);
@@ -1785,79 +1756,10 @@ chmod 0755 '${commandPath}'
 	])("rejects hosted runtime with %s", (_name, overrides) => {
 		const runtime = hostedRuntimeFixture(overrides);
 		expect(
-			hostedRuntimeManifestSchema.safeParse(
+			hostedRuntimeBundleV2ManifestSchema.safeParse(
 				hostedManifestFixture({ runtimes: { openclaw: runtime } }),
 			).success,
 		).toBe(false);
-	});
-
-	test("preserves generic runtime install defaults and provider model projections", () => {
-		const parsed = manifestSchema.parse({
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
-			deploymentId: "dep_generic",
-			environmentId: "env_generic",
-			instanceId: "iid_generic",
-			generation: 1,
-			issuedAt: "2026-07-12T00:00:00.000Z",
-			controlPlane: { apiUrl: "https://cloud-api.example.test" },
-			runtimes: {
-				custom: {
-					enabled: true,
-					updateChannel: "stable",
-					install: {
-						authority: "official",
-						method: "official-installer",
-						url: "https://runtime.example.test/install.sh",
-						home: "/home/runtime",
-					},
-				},
-			},
-			projection: { providers: { default: { model: "legacy-model" } } },
-			recovery: {},
-		});
-
-		expect(parsed.runtimes.custom.install?.args).toEqual([]);
-		expect("version" in (parsed.runtimes.custom.install ?? {})).toBe(false);
-		expect(parsed.runtimes.custom.updateChannel).toBe("stable");
-		expect(parsed.projection?.providers?.default).toEqual({ model: "legacy-model" });
-	});
-
-	test("rejects rather than strips the removed bridge field in generic manifests", () => {
-		const paths = tempRuntimePaths();
-		const valid = baseManifest(paths, {
-			openclaw: {
-				enabled: true,
-				run: runSettings("openclaw", ["gateway", "run"]),
-				services: {},
-			},
-		});
-		const result = manifestSchema.safeParse({ ...valid, bridge: {} });
-
-		expect(result.success).toBe(false);
-		if (result.success) throw new Error("expected removed bridge field rejection");
-		expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["bridge"] }));
-	});
-
-	test("accepts independent positive checkpoint and apply generations at the shared boundary", () => {
-		const paths = tempRuntimePaths();
-		const manifest = baseManifest(paths, {
-			openclaw: {
-				enabled: true,
-				run: runSettings("openclaw", ["gateway", "run"]),
-				services: {},
-			},
-		});
-
-		const result = manifestSchema.safeParse({
-			...manifest,
-			generation: 2,
-			applyGeneration: 3,
-		});
-
-		expect(result.success).toBe(true);
-		if (!result.success) throw result.error;
-		expect(result.data.generation).toBe(2);
-		expect(result.data.applyGeneration).toBe(3);
 	});
 
 	test.each([
@@ -1877,7 +1779,7 @@ chmod 0755 '${commandPath}'
 		if (field === "system.persistentPaths") system.persistentPaths = [TEST_HOSTED_HOME];
 		if (field === "runtime.paths") runtime.paths = { home: TEST_HOSTED_HOME };
 
-		expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(false);
+		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(manifest).success).toBe(false);
 	});
 
 	test.each([
@@ -1887,7 +1789,7 @@ chmod 0755 '${commandPath}'
 		["api_key_secret_ref", { api_key_secret_ref: "secret://provider.default.apiKey" }],
 	])("rejects noncanonical hosted provider field %s", (_name, provider) => {
 		expect(
-			hostedRuntimeManifestSchema.safeParse(
+			hostedRuntimeBundleV2ManifestSchema.safeParse(
 				hostedManifestFixture({ providers: { default: provider } }),
 			).success,
 		).toBe(false);
@@ -1973,7 +1875,7 @@ chmod 0755 '${commandPath}'
 		],
 	])("rejects hosted manifests with %s", (_name, provider) => {
 		expect(
-			hostedRuntimeManifestSchema.safeParse(
+			hostedRuntimeBundleV2ManifestSchema.safeParse(
 				hostedManifestFixture({ providers: { default: provider } }),
 			).success,
 		).toBe(false);
@@ -2018,7 +1920,7 @@ chmod 0755 '${commandPath}'
 		],
 	])("accepts Cloud %s", (_name, provider) => {
 		expect(
-			hostedRuntimeManifestSchema.safeParse(
+			hostedRuntimeBundleV2ManifestSchema.safeParse(
 				hostedManifestFixture({ providers: { default: provider } }),
 			).success,
 		).toBe(true);
@@ -2031,7 +1933,7 @@ chmod 0755 '${commandPath}'
 		"https://user@app-v2.example.test",
 	])("rejects invalid OpenClaw Control UI origin %s", (origin) => {
 		expect(
-			hostedRuntimeManifestSchema.safeParse(
+			hostedRuntimeBundleV2ManifestSchema.safeParse(
 				hostedManifestFixture({
 					system: hostedSystemFixture({
 						openclawControlUiAllowedOrigins: [origin],
@@ -2070,7 +1972,7 @@ chmod 0755 '${commandPath}'
 		);
 		chmodSync(openclawBin, 0o700);
 
-		const hosted = hostedRuntimeManifestSchema.parse(
+		const hosted = hostedRuntimeBundleV2ManifestSchema.parse(
 			hostedManifestFixture({
 				system: hostedSystemFixture({
 					openclawControlUiAllowedOrigins: allowedOrigins,
@@ -2081,10 +1983,16 @@ chmod 0755 '${commandPath}'
 			}),
 		);
 		const normalized: RuntimeManifest = {
-			...hostedManifestToRuntimeManifest(hosted),
+			...hosted,
 			egressEngine: installCachedTestEgressEngine(paths, "12.2.3-test-control-ui"),
 		};
-		expect(normalized.projection?.system).toEqual(hosted.system);
+		expect(normalized.projection?.system).toEqual(
+			hostedManifestFixture({
+				system: hostedSystemFixture({
+					openclawControlUiAllowedOrigins: allowedOrigins,
+				}),
+			}).system,
+		);
 
 		const result = convergeRuntimeManifest(
 			manifestLoad(normalized, "inline-hosted-control-ui-origins"),
@@ -2155,16 +2063,11 @@ chmod 0755 '${commandPath}'
 		chmodSync(openclawBin, 0o700);
 
 		const legacy = hostedOpenClawV2ManifestFixture({}, LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS);
-		const hosted = hostedRuntimeBundleV2ManifestSchema.parse(legacy);
-		const projected = hostedManifestToRuntimeManifest(hosted);
+		const projected = hostedRuntimeBundleV2ManifestSchema.parse(legacy);
 		expect(projected.runtimes.openclaw.run?.args).toEqual(["gateway", "run"]);
 		const normalized: RuntimeManifest = {
 			...projected,
 			egressEngine: installCachedTestEgressEngine(paths, "12.2.3-test-native-auth"),
-			projection: {
-				...projected.projection,
-				sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
-			},
 		};
 		expect(() =>
 			convergeRuntimeManifest(
@@ -2219,7 +2122,7 @@ chmod 0755 '${commandPath}'
 
 	test("rejects hosted manifests without an explicit CLI package policy", () => {
 		expect(() =>
-			hostedRuntimeManifestSchema.parse({
+			hostedRuntimeBundleV2ManifestSchema.parse({
 				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
 				runtime: "openclaw",
 				deploymentId: "hdep_missing_cli_policy",
@@ -2240,18 +2143,18 @@ chmod 0755 '${commandPath}'
 	])("rejects hosted manifests with %s", (_name, identity) => {
 		const manifest = hostedManifestFixture(identity);
 		delete manifest.environmentId;
-		expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(false);
+		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(manifest).success).toBe(false);
 	});
 
 	test("uses only the hosted environmentId as the runtime environment identity", () => {
-		const parsed = hostedRuntimeManifestSchema.parse(
+		const parsed = hostedRuntimeBundleV2ManifestSchema.parse(
 			hostedManifestFixture({
 				deploymentId: "hdep_distinct_identity",
 				environmentId: "env_canonical_identity",
 			}),
 		);
 
-		expect(hostedManifestToRuntimeManifest(parsed).environmentId).toBe("env_canonical_identity");
+		expect(parsed.environmentId).toBe("env_canonical_identity");
 	});
 
 	test.each([
@@ -2273,7 +2176,8 @@ chmod 0755 '${commandPath}'
 		["unknown key", { cloudApiUrl: "https://cloud-api.example.test", unknown: true }],
 	])("rejects hosted controlPlane with %s", (_name, controlPlane) => {
 		expect(
-			hostedRuntimeManifestSchema.safeParse(hostedManifestFixture({ controlPlane })).success,
+			hostedRuntimeBundleV2ManifestSchema.safeParse(hostedManifestFixture({ controlPlane }))
+				.success,
 		).toBe(false);
 	});
 
@@ -2310,7 +2214,7 @@ chmod 0755 '${commandPath}'
 		},
 	])("rejects hosted CLI policy with $name", ({ clawdiCli }) => {
 		expect(() =>
-			hostedRuntimeManifestSchema.parse({
+			hostedRuntimeBundleV2ManifestSchema.parse({
 				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
 				runtime: "openclaw",
 				deploymentId: "hdep_invalid_cli_policy",
@@ -2330,7 +2234,7 @@ chmod 0755 '${commandPath}'
 		"accepts exact hosted CLI package spec %s",
 		(packageSpec) => {
 			expect(
-				hostedRuntimeManifestSchema.safeParse(
+				hostedRuntimeBundleV2ManifestSchema.safeParse(
 					hostedManifestFixture({
 						clawdiCli: {
 							source: "npm:clawdi",
@@ -2358,7 +2262,7 @@ chmod 0755 '${commandPath}'
 				},
 			});
 			const expected = packageSpec === atLimit;
-			expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(expected);
+			expect(hostedRuntimeBundleV2ManifestSchema.safeParse(manifest).success).toBe(expected);
 		}
 	});
 
@@ -2390,7 +2294,7 @@ chmod 0755 '${commandPath}'
 		"/usr/local/share/clawdi/bootstrap/clawdi..tgz",
 	])("rejects hosted CLI package spec %s", (packageSpec) => {
 		expect(
-			hostedRuntimeManifestSchema.safeParse(
+			hostedRuntimeBundleV2ManifestSchema.safeParse(
 				hostedManifestFixture({
 					clawdiCli: {
 						source: "npm:clawdi",
@@ -2446,7 +2350,7 @@ chmod 0755 '${commandPath}'
 						apiMode: "openai_chat",
 						apiKeySecretRef: "secret://providers/default/api-key",
 					},
-				},
+				} satisfies HostedRuntimeBundleV2Manifest["providers"],
 				terminalTooling: TEST_HOSTED_CODEX_TOOLING,
 				liveSync: {
 					enabled: true,
@@ -2488,9 +2392,9 @@ chmod 0755 '${commandPath}'
 			},
 		};
 
-		const hostedManifest = hostedRuntimeManifestSchema.parse(hostedResponse.manifest);
+		const hostedManifest = hostedRuntimeBundleV2ManifestSchema.parse(hostedResponse.manifest);
 		const normalized = {
-			manifest: hostedManifestToRuntimeManifest(hostedManifest),
+			manifest: hostedManifest,
 			secretValues: normalizeSecretValues(hostedResponse.secretValues),
 		};
 		expect(normalized.manifest.schemaVersion).toBe("clawdi.runtimeDesiredState.v1");
@@ -2506,7 +2410,7 @@ chmod 0755 '${commandPath}'
 		expect(normalized.manifest.runtimes.openclaw.run?.secretEnv).toEqual({
 			OPENCLAW_GATEWAY_TOKEN: "secret://runtime/openclaw/gateway-token",
 		});
-		expect(normalized.manifest.projection?.providers).toEqual(hostedManifest.providers);
+		expect(normalized.manifest.projection?.providers).toEqual(hostedResponse.manifest.providers);
 		expect(normalized.manifest.egressProfiles?.profiles.map((profile) => profile.id)).toContain(
 			"api-proxy",
 		);
@@ -2519,7 +2423,7 @@ chmod 0755 '${commandPath}'
 
 	test("rejects a missing explicit runtime even with one runtime entry", () => {
 		expect(
-			hostedRuntimeManifestSchema.safeParse({
+			hostedRuntimeBundleV2ManifestSchema.safeParse({
 				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
 				deploymentId: "hdep_infer_runtime",
 				environmentId: "env_infer_runtime",
@@ -2633,14 +2537,14 @@ chmod 0755 '${commandPath}'
 			},
 		};
 
-		expect(hostedRuntimeManifestSchema.safeParse(addUnknownField(cleanManifest)).success).toBe(
-			false,
-		);
+		expect(
+			hostedRuntimeBundleV2ManifestSchema.safeParse(addUnknownField(cleanManifest)).success,
+		).toBe(false);
 	});
 
 	test("rejects hosted manifests that still declare multiple execution runtimes", () => {
 		expect(() =>
-			hostedRuntimeManifestSchema.parse({
+			hostedRuntimeBundleV2ManifestSchema.parse({
 				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
 				runtime: "openclaw",
 				deploymentId: "hdep_multi",
@@ -2764,7 +2668,7 @@ chmod 0755 '${commandPath}'
 			join(paths.systemdEnvRoot, "openclaw-gateway.service.env"),
 			"utf8",
 		);
-		expect(envFile).toContain('OPENCLAW_GATEWAY_TOKEN="gateway-token"');
+		expect(envFile).not.toContain("OPENCLAW_GATEWAY_TOKEN");
 	});
 
 	test("keeps hosted managed provider key out of the agent env", () => {
@@ -2775,7 +2679,7 @@ chmod 0755 '${commandPath}'
 			runtime: "openclaw",
 			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
 		});
-		const hosted = hostedRuntimeManifestSchema.parse(
+		const hosted = hostedRuntimeBundleV2ManifestSchema.parse(
 			hostedManifestFixture({
 				providers: {
 					default: {
@@ -2792,7 +2696,7 @@ chmod 0755 '${commandPath}'
 			}),
 		);
 		const manifest = {
-			...hostedManifestToRuntimeManifest(hosted),
+			...hosted,
 			egressEngine: installCachedTestEgressEngine(paths, "12.2.3-test-provider-model"),
 		};
 		const provider = hostedAiProviderCatalog(manifest, "openclaw")?.catalog.providers[0];
@@ -3105,7 +3009,6 @@ chmod 0755 '${commandPath}'
 				},
 				{
 					projection: {
-						sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
 						providers: {
 							[providerKey]: {
 								type: "custom_openai_compatible",
@@ -3137,7 +3040,6 @@ chmod 0755 '${commandPath}'
 			},
 			{
 				projection: {
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
 					providers: {
 						default: {
 							type: "custom_openai_compatible",
@@ -3241,7 +3143,6 @@ chmod 0755 '${commandPath}'
 		expect(result.outputs.egressEngine).toEqual(expect.objectContaining({ status: "ready" }));
 		expect(commits).toBe(1);
 		expect(readRuntimeAppliedState(paths)?.generation).toBe(1);
-		expect(existsSync(paths.manifestLastGood)).toBe(true);
 		expect(existsSync(join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service"))).toBe(true);
 	});
 
@@ -3380,11 +3281,10 @@ chmod 0755 '${commandPath}'
 		const signals: boolean[] = [];
 		const converge = (manifest: RuntimeManifest, secret: string | undefined) =>
 			convergeRuntimeManifest(
-				manifestLoad(
-					manifest,
-					"inline-egress-secret-lifecycle",
-					secret === undefined ? {} : { [secretRef]: secret },
-				),
+				manifestLoad(manifest, "inline-egress-secret-lifecycle", {
+					...TEST_HOSTED_SECRET_VALUES,
+					...(secret === undefined ? {} : { [secretRef]: secret }),
+				}),
 				paths,
 				{
 					cacheLastGood: false,
@@ -3492,676 +3392,6 @@ chmod 0755 '${commandPath}'
 		expect(converge(deletedManifest, undefined).installErrors).toEqual([]);
 		expect(signals.at(-1)).toBe(false);
 		expect(signals).toEqual([true, false, true, false, false, false, false, false]);
-	});
-
-	test("recovers committed egress secrets before retrying a crash-interrupted sidecar load", () => {
-		const paths = tempRuntimePaths();
-		const commandPath = join(paths.userHome, ".local", "bin", "openclaw");
-		const egressEngine = {
-			type: "mitmproxy" as const,
-			version: "12.2.3",
-			url: "https://downloads.mitmproxy.org/12.2.3/mitmproxy-12.2.3-linux-x86_64.tar.gz",
-			sha256: "2e95286b618fa6fd33e5e62a78c2e5112571d85f42ec2bac29b97ee242bdb5c5",
-		};
-		const engineBinary = join(
-			paths.egressEngineMaintainedRoot,
-			egressEngine.version,
-			egressEngine.sha256,
-			"mitmdump",
-		);
-		writeFakeGatewayCli({
-			path: commandPath,
-			runtime: "openclaw",
-			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
-		});
-		mkdirSync(dirname(engineBinary), { recursive: true });
-		writeFileSync(engineBinary, "#!/usr/bin/env sh\nexit 0\n");
-		chmodSync(engineBinary, 0o700);
-		const secretRef = "secret://providers/default/api-key";
-		const manifest = manifestSchema.parse(
-			baseManifest(
-				paths,
-				{
-					openclaw: {
-						enabled: true,
-						run: runSettings(commandPath, ["gateway", "run"]),
-						services: {},
-					},
-				},
-				{
-					egressEngine,
-					egressProfiles: {
-						profiles: [
-							{
-								id: "managed-provider",
-								enabled: true,
-								kind: "provider",
-								match: {
-									scheme: "https",
-									host: "provider.example.test",
-									headers: {},
-									query: {},
-								},
-								rewrite: {
-									preservePath: true,
-									setHeaders: {
-										authorization: {
-											type: "secretRef",
-											secretRef,
-											prefix: "Bearer ",
-										},
-									},
-								},
-								logging: { redactHeaders: ["authorization"], redactUrlPatterns: [] },
-								priority: 80,
-							},
-						],
-					},
-				},
-			),
-		);
-		const secretFile = join(paths.managedSecretRoot, "egress-secrets.json");
-		const secrets = (value: string) => ({ [secretRef]: value });
-		const load = (value: string) =>
-			manifestLoad(manifest, "inline-egress-crash-recovery", secrets(value));
-		const writeAuthority = (value: string, egressSidecarSecretRevision?: string) => {
-			writeRuntimeAppliedState(
-				{
-					schemaVersion: "clawdi.runtimeAppliedState.v2",
-					appliedAt: "2026-07-28T00:00:00.000Z",
-					instanceId: manifest.instanceId,
-					etag: `"egress-${value}"`,
-					sourceRevision: runtimeContentSha256({ value }),
-					generation: manifest.generation,
-					contentIdentity: {
-						sourcePath: "inline-egress-crash-recovery",
-						sha256: runtimeContentSha256({
-							manifest,
-							secretValues: runtimeRecoverableSecretValues(manifest, secrets(value)),
-						}),
-					},
-					...(egressSidecarSecretRevision ? { egressSidecarSecretRevision } : {}),
-					providerIds: [],
-					projectedProviderIds: {},
-				},
-				paths,
-			);
-		};
-		const overwriteLiveSecret = (value: string) => {
-			const current = existsSync(secretFile)
-				? (JSON.parse(readFileSync(secretFile, "utf-8")) as Record<string, string>)
-				: { [secretRef]: value };
-			writeFileSync(
-				secretFile,
-				`${JSON.stringify(
-					Object.fromEntries(Object.keys(current).map((ref) => [ref, value])),
-					null,
-					2,
-				)}\n`,
-			);
-			chmodSync(secretFile, 0o600);
-		};
-		const commit = (value: string, egressSidecarSecretRevision?: string) => {
-			cacheRuntimeLastGoodManifest(manifest, paths, secrets(value));
-			writeAuthority(value, egressSidecarSecretRevision);
-		};
-
-		let revisionA: string | undefined;
-		const baseline = convergeRuntimeManifest(load("000000"), paths, {
-			commitAuthority: (_convergence, authority) => {
-				revisionA = authority.egressSidecarSecretRevision;
-			},
-			systemdApply: {
-				quiesce: () => {},
-				activateEgressPrerequisite: successfulPrerequisiteActivation,
-				activate: () => ({ applied: true, systemUnitsChanged: [], userUnitsChanged: [] }),
-				rollback: () => {},
-			},
-		});
-		expect(baseline.installErrors).toEqual([]);
-		expect(revisionA).toMatch(/^[a-f0-9]{64}$/);
-		commit("000000", revisionA);
-		const committedA = readFileSync(paths.appliedState, "utf-8");
-
-		// Simulate SIGKILL after the atomic A -> B file write but before restart.
-		overwriteLiveSecret("000001");
-		const recoverySignals: boolean[] = [];
-		let revisionB: string | undefined;
-		const recovered = convergeRuntimeManifest(load("000001"), paths, {
-			cacheLastGood: false,
-			commitAuthority: (_convergence, authority) => {
-				revisionB = authority.egressSidecarSecretRevision;
-				commit("000001", revisionB);
-			},
-			systemdApply: {
-				quiesce: () => {},
-				activateEgressPrerequisite: successfulPrerequisiteActivation,
-				activate: ({ restartEgressSidecar }) => {
-					recoverySignals.push(restartEgressSidecar);
-					return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
-				},
-				rollback: () => {
-					throw new Error("successful recovery must not roll back");
-				},
-			},
-		});
-		expect(recovered.installErrors).toEqual([]);
-		expect(recoverySignals).toEqual([true]);
-		expect(revisionB).toMatch(/^[a-f0-9]{64}$/);
-		expect(revisionB).not.toBe(revisionA);
-		expect(readFileSync(paths.appliedState, "utf-8")).not.toBe(committedA);
-		expect(readRuntimeAppliedState(paths)?.egressSidecarSecretRevision).toBe(revisionB);
-		expect(readFileSync(secretFile, "utf-8")).toContain("000001");
-		expect(JSON.stringify(recovered)).not.toContain("egressSidecarSecretRevision");
-		expect(JSON.stringify(recovered)).not.toContain(revisionB ?? "missing-private-revision");
-
-		// A failed retry restores the verified committed B material before the
-		// rollback restart, even though the pre-apply live file already held C.
-		overwriteLiveSecret("000002");
-		let restartFailureRollbackSecret = "";
-		const restartFailed = convergeRuntimeManifest(load("000002"), paths, {
-			cacheLastGood: false,
-			commitAuthority: () => {
-				throw new Error("restart failure must not commit authority");
-			},
-			systemdApply: {
-				quiesce: () => {},
-				activateEgressPrerequisite: successfulPrerequisiteActivation,
-				activate: ({ restartEgressSidecar }) => {
-					expect(restartEgressSidecar).toBe(true);
-					throw new Error("injected sidecar restart failure");
-				},
-				rollback: ({ restartEgressSidecar }) => {
-					expect(restartEgressSidecar).toBe(true);
-					restartFailureRollbackSecret = readFileSync(secretFile, "utf-8");
-				},
-			},
-		});
-		expect(restartFailed.installErrors.join("\n")).toContain("injected sidecar restart failure");
-		expect(restartFailureRollbackSecret).toContain("000001");
-		expect(readFileSync(secretFile, "utf-8")).toContain("000001");
-		expect(readRuntimeAppliedState(paths)?.egressSidecarSecretRevision).toBe(revisionB);
-
-		// If activation succeeded but the atomic authority commit reports a
-		// failure, both authority files and loaded secret material return to B.
-		overwriteLiveSecret("000002");
-		const committedB = readFileSync(paths.appliedState, "utf-8");
-		const committedCacheB = readFileSync(paths.managedSecretCacheFile, "utf-8");
-		let commitFailureRollbackSecret = "";
-		const commitFailed = convergeRuntimeManifest(load("000002"), paths, {
-			cacheLastGood: false,
-			commitAuthority: (_convergence, authority) => {
-				commit("000002", authority.egressSidecarSecretRevision);
-				throw new Error("injected authority commit failure");
-			},
-			systemdApply: {
-				quiesce: () => {},
-				activateEgressPrerequisite: successfulPrerequisiteActivation,
-				activate: ({ restartEgressSidecar }) => {
-					expect(restartEgressSidecar).toBe(true);
-					return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
-				},
-				rollback: ({ restartEgressSidecar }) => {
-					expect(restartEgressSidecar).toBe(true);
-					commitFailureRollbackSecret = readFileSync(secretFile, "utf-8");
-				},
-			},
-		});
-		expect(commitFailed.installErrors.join("\n")).toContain("injected authority commit failure");
-		expect(commitFailureRollbackSecret).toContain("000001");
-		expect(readFileSync(secretFile, "utf-8")).toContain("000001");
-		expect(readFileSync(paths.appliedState, "utf-8")).toBe(committedB);
-		expect(readFileSync(paths.managedSecretCacheFile, "utf-8")).toBe(committedCacheB);
-
-		// A crash may also advance the live file and cache while applied state
-		// remains at B. The desired C restart must run before rollback material
-		// is needed, and a successful restart may then commit C.
-		overwriteLiveSecret("000002");
-		cacheRuntimeLastGoodManifest(manifest, paths, secrets("000002"));
-		let mixedSnapshotActivations = 0;
-		let revisionC: string | undefined;
-		const mixedSnapshot = convergeRuntimeManifest(load("000002"), paths, {
-			cacheLastGood: false,
-			commitAuthority: (_convergence, authority) => {
-				revisionC = authority.egressSidecarSecretRevision;
-				commit("000002", revisionC);
-			},
-			systemdApply: {
-				quiesce: () => {},
-				activateEgressPrerequisite: successfulPrerequisiteActivation,
-				activate: ({ restartEgressSidecar }) => {
-					expect(restartEgressSidecar).toBe(true);
-					mixedSnapshotActivations++;
-					return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
-				},
-				rollback: () => {
-					throw new Error("successful mixed-snapshot recovery must not roll back");
-				},
-			},
-		});
-		expect(mixedSnapshot.installErrors).toEqual([]);
-		expect(mixedSnapshotActivations).toBe(1);
-		expect(revisionC).toMatch(/^[a-f0-9]{64}$/);
-		expect(revisionC).not.toBe(revisionB);
-		expect(readRuntimeAppliedState(paths)?.egressSidecarSecretRevision).toBe(revisionC);
-
-		// If the restart from a mixed D/cache-D/applied-C snapshot fails, only
-		// the failure path attempts to recover C. The unverifiable cache then
-		// fails closed by removing the sidecar secret while the remaining units
-		// still reconcile to the restored filesystem authority.
-		overwriteLiveSecret("000003");
-		cacheRuntimeLastGoodManifest(manifest, paths, secrets("000003"));
-		const committedC = readFileSync(paths.appliedState, "utf-8");
-		let mixedFailureCommits = 0;
-		let mixedFailureRollbacks = 0;
-		let mixedFailureRollbackSignal: {
-			restartEgressSidecar: boolean;
-		} | null = null;
-		const mixedFailure = convergeRuntimeManifest(load("000003"), paths, {
-			cacheLastGood: false,
-			commitAuthority: () => {
-				mixedFailureCommits++;
-			},
-			systemdApply: {
-				quiesce: () => {},
-				activateEgressPrerequisite: successfulPrerequisiteActivation,
-				activate: ({ restartEgressSidecar }) => {
-					expect(restartEgressSidecar).toBe(true);
-					throw new Error("injected mixed-snapshot restart failure");
-				},
-				rollback: (signal) => {
-					mixedFailureRollbacks++;
-					mixedFailureRollbackSignal = signal;
-				},
-			},
-		});
-		expect(mixedFailure.installErrors.join("\n")).toContain(
-			"injected mixed-snapshot restart failure",
-		);
-		expect(mixedFailure.installErrors.join("\n")).toContain(
-			"runtime egress sidecar stopped because committed secret rollback authority could not be verified",
-		);
-		expect(mixedFailureCommits).toBe(0);
-		expect(mixedFailureRollbacks).toBe(1);
-		expect(mixedFailureRollbackSignal).toMatchObject({
-			restartEgressSidecar: false,
-		});
-		expect(readFileSync(paths.appliedState, "utf-8")).toBe(committedC);
-		expect(readRuntimeAppliedState(paths)?.egressSidecarSecretRevision).toBe(revisionC);
-		expect(existsSync(secretFile)).toBe(false);
-
-		// Legacy applied state can recover A from an exact content-identity
-		// match even when an interrupted write left unrelated live B bytes. A
-		// failed desired-C restart must load only the verified A material.
-		const legacyCommitted = "legacy-committed-a";
-		const legacyInterrupted = "legacy-live-b";
-		const legacyDesired = "legacy-desired-c";
-		cacheRuntimeLastGoodManifest(manifest, paths, secrets(legacyCommitted));
-		writeAuthority(legacyCommitted);
-		overwriteLiveSecret(legacyInterrupted);
-		const legacyAppliedA = readFileSync(paths.appliedState, "utf-8");
-		let legacyFailureCommits = 0;
-		const legacyRollbackSecrets: string[] = [];
-		const legacyRestartFailure = convergeRuntimeManifest(load(legacyDesired), paths, {
-			cacheLastGood: false,
-			commitAuthority: () => {
-				legacyFailureCommits++;
-			},
-			systemdApply: {
-				quiesce: () => {},
-				activateEgressPrerequisite: successfulPrerequisiteActivation,
-				activate: ({ restartEgressSidecar }) => {
-					expect(restartEgressSidecar).toBe(true);
-					expect(readFileSync(secretFile, "utf-8")).toContain(legacyDesired);
-					throw new Error("injected legacy desired restart failure");
-				},
-				rollback: ({ restartEgressSidecar }) => {
-					expect(restartEgressSidecar).toBe(true);
-					legacyRollbackSecrets.push(readFileSync(secretFile, "utf-8"));
-				},
-			},
-		});
-		expect(legacyRestartFailure.installErrors.join("\n")).toContain(
-			"injected legacy desired restart failure",
-		);
-		expect(legacyFailureCommits).toBe(0);
-		expect(legacyRollbackSecrets).toHaveLength(1);
-		expect(legacyRollbackSecrets[0]).toContain(legacyCommitted);
-		expect(legacyRollbackSecrets[0]).not.toContain(legacyInterrupted);
-		expect(readFileSync(secretFile, "utf-8")).toContain(legacyCommitted);
-		expect(readFileSync(paths.appliedState, "utf-8")).toBe(legacyAppliedA);
-		expect(readRuntimeAppliedState(paths)?.egressSidecarSecretRevision).toBeUndefined();
-		expect(JSON.stringify(legacyRestartFailure)).not.toContain("egressSidecarSecretRevision");
-
-		// A legacy cache without its active egress secret cannot prove A. The
-		// desired restart still runs, but its failure must remove the unverified
-		// snapshot B, stop the sidecar, and reconcile every independent unit.
-		cacheRuntimeLastGoodManifest(manifest, paths, secrets(legacyCommitted));
-		rmSync(paths.managedSecretCacheFile);
-		writeAuthority(legacyCommitted);
-		overwriteLiveSecret(legacyInterrupted);
-		const legacyMissingCacheApplied = readFileSync(paths.appliedState, "utf-8");
-		let legacyMissingCacheRestartCommits = 0;
-		let legacyMissingCacheRestartRollbacks = 0;
-		let legacyMissingCacheRestartSignal: {
-			restartEgressSidecar: boolean;
-		} | null = null;
-		const legacyMissingCacheRestartFailure = convergeRuntimeManifest(load(legacyDesired), paths, {
-			cacheLastGood: false,
-			commitAuthority: () => {
-				legacyMissingCacheRestartCommits++;
-			},
-			systemdApply: {
-				quiesce: () => {},
-				activateEgressPrerequisite: successfulPrerequisiteActivation,
-				activate: ({ restartEgressSidecar }) => {
-					expect(restartEgressSidecar).toBe(true);
-					expect(readFileSync(secretFile, "utf-8")).toContain(legacyDesired);
-					throw new Error("injected legacy missing-cache restart failure");
-				},
-				rollback: (signal) => {
-					legacyMissingCacheRestartRollbacks++;
-					legacyMissingCacheRestartSignal = signal;
-				},
-			},
-		});
-		expect(legacyMissingCacheRestartFailure.installErrors[0]).toBe(
-			"runtime apply failed: injected legacy missing-cache restart failure",
-		);
-		expect(legacyMissingCacheRestartFailure.installErrors.join("\n")).toContain(
-			"injected legacy missing-cache restart failure",
-		);
-		expect(legacyMissingCacheRestartFailure.installErrors.join("\n")).toContain(
-			"runtime egress sidecar stopped because committed secret rollback authority could not be verified",
-		);
-		expect(legacyMissingCacheRestartCommits).toBe(0);
-		expect(legacyMissingCacheRestartRollbacks).toBe(1);
-		expect(legacyMissingCacheRestartSignal).toMatchObject({
-			restartEgressSidecar: false,
-		});
-		expect(readFileSync(paths.appliedState, "utf-8")).toBe(legacyMissingCacheApplied);
-		expect(existsSync(paths.managedSecretCacheFile)).toBe(false);
-		expect(existsSync(secretFile)).toBe(false);
-
-		// The same unverified legacy state also fails the sidecar closed if
-		// desired activation succeeds but the following authority commit fails.
-		let legacyMissingCacheCommits = 0;
-		let legacyMissingCacheRollbacks = 0;
-		let legacyMissingCacheSignal: {
-			restartEgressSidecar: boolean;
-		} | null = null;
-		const legacyMissingCacheActivationSecrets: string[] = [];
-		const legacyMissingCacheFailure = convergeRuntimeManifest(load(legacyDesired), paths, {
-			cacheLastGood: false,
-			commitAuthority: (_convergence, authority) => {
-				legacyMissingCacheCommits++;
-				commit(legacyDesired, authority.egressSidecarSecretRevision);
-				throw new Error("injected legacy authority commit failure");
-			},
-			systemdApply: {
-				quiesce: () => {},
-				activateEgressPrerequisite: successfulPrerequisiteActivation,
-				activate: ({ restartEgressSidecar }) => {
-					expect(restartEgressSidecar).toBe(true);
-					legacyMissingCacheActivationSecrets.push(readFileSync(secretFile, "utf-8"));
-					return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
-				},
-				rollback: (signal) => {
-					legacyMissingCacheRollbacks++;
-					legacyMissingCacheSignal = signal;
-				},
-			},
-		});
-		expect(legacyMissingCacheFailure.installErrors[0]).toBe(
-			"runtime apply failed: injected legacy authority commit failure",
-		);
-		expect(legacyMissingCacheFailure.installErrors.join("\n")).toContain(
-			"injected legacy authority commit failure",
-		);
-		expect(legacyMissingCacheFailure.installErrors.join("\n")).toContain(
-			"runtime egress sidecar stopped because committed secret rollback authority could not be verified",
-		);
-		expect(legacyMissingCacheCommits).toBe(1);
-		expect(legacyMissingCacheRollbacks).toBe(1);
-		expect(legacyMissingCacheSignal).toMatchObject({
-			restartEgressSidecar: false,
-		});
-		expect(legacyMissingCacheActivationSecrets).toHaveLength(1);
-		expect(legacyMissingCacheActivationSecrets[0]).toContain(legacyDesired);
-		expect(readFileSync(paths.appliedState, "utf-8")).toBe(legacyMissingCacheApplied);
-		expect(readRuntimeAppliedState(paths)?.egressSidecarSecretRevision).toBeUndefined();
-		expect(existsSync(paths.managedSecretCacheFile)).toBe(false);
-		expect(existsSync(secretFile)).toBe(false);
-		expect(JSON.stringify(legacyMissingCacheFailure)).not.toContain("egressSidecarSecretRevision");
-
-		// Legacy v2 authority has no private revision. An active sidecar restarts
-		// once, commits it, and then an identical apply no longer forces restart.
-		cacheRuntimeLastGoodManifest(manifest, paths, secrets("000001"));
-		overwriteLiveSecret("000001");
-		writeAuthority("000001");
-		const legacySignals: boolean[] = [];
-		const convergeLegacy = () =>
-			convergeRuntimeManifest(load("000001"), paths, {
-				cacheLastGood: false,
-				commitAuthority: (_convergence, authority) =>
-					writeAuthority("000001", authority.egressSidecarSecretRevision),
-				systemdApply: {
-					quiesce: () => {},
-					activateEgressPrerequisite: successfulPrerequisiteActivation,
-					activate: ({ restartEgressSidecar }) => {
-						legacySignals.push(restartEgressSidecar);
-						return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
-					},
-					rollback: () => {},
-				},
-			});
-		expect(convergeLegacy().installErrors).toEqual([]);
-		expect(readRuntimeAppliedState(paths)?.egressSidecarSecretRevision).toBe(revisionB);
-		expect(convergeLegacy().installErrors).toEqual([]);
-		expect(legacySignals).toEqual([true, false]);
-	});
-
-	test("replaces an unverifiable legacy secret cache after a successful online upgrade", () => {
-		const paths = tempRuntimePaths();
-		const engine = installCachedTestEgressEngine(paths, "12.2.3");
-		const canonicalSecretRef = "secret://tool.codex.apiKey";
-		const base = egressRuntimeManifest(paths, {
-			generation: 19,
-			engine,
-			profile: "enabled",
-		});
-		const profile = base.egressProfiles?.profiles[0];
-		if (!profile) throw new Error("expected enabled egress profile fixture");
-		const currentManifest = manifestSchema.parse({
-			...base,
-			issuedAt: "2026-07-01T00:19:00.000Z",
-			egressProfiles: {
-				profiles: [
-					{
-						...profile,
-						rewrite: {
-							...profile.rewrite,
-							setHeaders: {
-								authorization: {
-									type: "secretRef",
-									secretRef: canonicalSecretRef,
-									prefix: "Bearer ",
-								},
-							},
-						},
-					},
-				],
-			},
-		});
-		const retainedManifest = {
-			...currentManifest,
-			generation: 15,
-			issuedAt: "2026-07-01T00:15:00.000Z",
-			egressProfiles: {
-				profiles: [
-					profile,
-					{
-						...profile,
-						id: "legacy-env-ref",
-						rewrite: {
-							...profile.rewrite,
-							setHeaders: {
-								authorization: {
-									type: "secretRef",
-									secretRef: "env://REDACTED_LEGACY_NAME",
-									prefix: "Bearer ",
-								},
-							},
-						},
-					},
-				],
-			},
-		};
-		const retainedSecretValues = {
-			...TEST_HOSTED_SECRET_VALUES,
-			"clawdi/auth-token": TEST_HOSTED_SECRET_VALUES["secret://clawdi/auth-token"],
-			"runtime/openclaw/gateway-token":
-				TEST_HOSTED_SECRET_VALUES["secret://runtime/openclaw/gateway-token"],
-			"tool.codex.apiKey": TEST_HOSTED_SECRET_VALUES[canonicalSecretRef],
-		};
-		const currentSecretValues = {
-			"secret://clawdi/auth-token": "generation-19-auth-token",
-			"secret://runtime/openclaw/gateway-token": "canonical-generation-19-gateway",
-			[canonicalSecretRef]: "generation-19-egress-token",
-		};
-		const currentLoad = manifestLoad(
-			currentManifest,
-			"inline-generation-19-online-upgrade",
-			currentSecretValues,
-		);
-		if (!currentLoad.applyContext) throw new Error("expected apply context fixture");
-
-		mkdirSync(dirname(paths.manifestLastGood), { recursive: true });
-		writeFileSync(paths.manifestLastGood, `${JSON.stringify(retainedManifest, null, 2)}\n`);
-		writeFileSync(
-			paths.managedSecretCacheFile,
-			`${JSON.stringify(retainedSecretValues, null, 2)}\n`,
-		);
-		writeRuntimeAppliedState(
-			{
-				schemaVersion: "clawdi.runtimeAppliedState.v2",
-				appliedAt: "2026-07-01T00:15:00.000Z",
-				instanceId: currentManifest.instanceId,
-				etag: '"generation-15"',
-				sourceRevision: runtimeContentSha256({ generation: 15 }),
-				generation: 15,
-				contentIdentity: {
-					sourcePath: "retained-generation-15",
-					sha256: runtimeContentSha256({
-						manifest: retainedManifest,
-						secretValues: retainedSecretValues,
-					}),
-				},
-				providerIds: [],
-				projectedProviderIds: {},
-			},
-			paths,
-		);
-		expect(loadCommittedRuntimeManifest(paths, currentLoad.applyContext)).toHaveProperty("errors");
-
-		let activations = 0;
-		let rollbacks = 0;
-		const convergence = convergeRuntimeManifest(currentLoad, paths, {
-			cacheLastGood: false,
-			commitAuthority: (committedConvergence, authority) =>
-				commitTestRuntimeAuthority(currentLoad, paths, committedConvergence, authority),
-			systemdApply: {
-				quiesce: () => {},
-				activateEgressPrerequisite: successfulPrerequisiteActivation,
-				activate: ({ restartEgressSidecar }) => {
-					expect(restartEgressSidecar).toBe(true);
-					expect(
-						readFileSync(join(paths.managedSecretRoot, "egress-secrets.json"), "utf-8"),
-					).toContain("generation-19-egress-token");
-					activations++;
-					return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
-				},
-				rollback: () => {
-					rollbacks++;
-				},
-			},
-		});
-
-		expect(convergence.installErrors).toEqual([]);
-		expect(activations).toBe(1);
-		expect(rollbacks).toBe(0);
-		expect(JSON.parse(readFileSync(paths.manifestLastGood, "utf-8"))).toEqual(currentManifest);
-		expect(JSON.parse(readFileSync(paths.managedSecretCacheFile, "utf-8"))).toEqual({
-			"secret://runtime/openclaw/gateway-token": "canonical-generation-19-gateway",
-			[canonicalSecretRef]: "generation-19-egress-token",
-		});
-		expect(readRuntimeAppliedState(paths)).toMatchObject({
-			generation: 19,
-			egressSidecarSecretRevision: expect.stringMatching(/^[a-f0-9]{64}$/),
-		});
-		const committedSecretCache = readFileSync(paths.managedSecretCacheFile, "utf-8");
-		const committedCache = [
-			readFileSync(paths.manifestLastGood, "utf-8"),
-			committedSecretCache,
-		].join("\n");
-		expect(committedCache).not.toContain("env://");
-		expect(committedCache).not.toContain("legacy-env-ref");
-		expect(committedSecretCache).not.toContain(': "test-auth-token"');
-		expect(committedSecretCache).not.toContain(': "gateway-token"');
-		expect(committedSecretCache).not.toContain(': "test-codex-provider-key"');
-	});
-
-	test("advances last-good manifest only after a clean converge", () => {
-		const paths = tempRuntimePaths();
-		const openclawCommand = join(paths.userHome, ".local", "bin", "openclaw");
-		const unitPath = join(paths.systemdUserRoot, "openclaw-gateway.service");
-		const manifest = baseManifest(paths, {
-			openclaw: {
-				enabled: true,
-				run: runSettings(openclawCommand, ["gateway", "run"]),
-				services: {},
-			},
-		});
-
-		writeFakeGatewayCli({ path: openclawCommand, runtime: "openclaw", unitPath });
-		const clean = convergeRuntimeManifest(manifestLoad(manifest, "inline-clean"), paths);
-		expect(clean.installErrors).toEqual([]);
-		expect(clean.outputs.manifestLastGood).toBe(paths.manifestLastGood);
-		expect(clean.outputs.appliedState).toBeNull();
-		expect(existsSync(paths.appliedState)).toBe(false);
-		expect(JSON.parse(readFileSync(paths.manifestLastGood, "utf8"))).toMatchObject({
-			generation: 1,
-		});
-
-		writeFakeGatewayCli({
-			path: openclawCommand,
-			runtime: "openclaw",
-			unitPath,
-			failInstall: true,
-		});
-		const failedManifest: RuntimeManifest = {
-			...manifest,
-			generation: 2,
-			issuedAt: "2026-07-01T00:02:00.000Z",
-		};
-		let authorityCommits = 0;
-		const failed = convergeRuntimeManifest(
-			manifestLoad(failedManifest, "inline-install-error"),
-			paths,
-			{
-				commitAuthority: () => authorityCommits++,
-				executeOfficialServiceInstallers: true,
-			},
-		);
-
-		expect(failed.installErrors.join("\n")).toContain(
-			"official openclaw-gateway service install failed",
-		);
-		expect(failed.outputs.manifestLastGood).toBeNull();
-		expect(authorityCommits).toBe(0);
-		expect(JSON.parse(readFileSync(paths.manifestLastGood, "utf8"))).toMatchObject({
-			generation: 1,
-		});
 	});
 
 	test("does not mutate live state when runtime planning fails", () => {
@@ -6046,15 +5276,20 @@ exit 42
 			runtime: "openclaw",
 			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
 		});
+		writeFakeGatewayCli({
+			path: join(paths.userHome, ".local", "bin", "hermes"),
+			runtime: "hermes",
+			unitPath: join(paths.systemdUserRoot, "hermes-gateway.service"),
+		});
 		const initialManifest = baseManifest(paths, {
 			hermes: {
 				enabled: true,
-				run: runSettings("hermes", ["gateway", "run"]),
+				run: runSettings(join(paths.userHome, ".local", "bin", "hermes"), ["gateway", "run"]),
 				services: {},
 			},
 			openclaw: {
 				enabled: true,
-				run: runSettings("openclaw", ["gateway", "run"]),
+				run: runSettings(join(paths.userHome, ".local", "bin", "openclaw"), ["gateway", "run"]),
 				services: {},
 			},
 		});
@@ -6071,7 +5306,7 @@ exit 42
 			{
 				hermes: {
 					enabled: true,
-					run: runSettings("hermes", ["gateway", "run"]),
+					run: runSettings(join(paths.userHome, ".local", "bin", "hermes"), ["gateway", "run"]),
 					services: {},
 				},
 			},

--- a/packages/cli/src/runtime/manifest-runtime-config.ts
+++ b/packages/cli/src/runtime/manifest-runtime-config.ts
@@ -7,7 +7,7 @@ import {
 	reconcileHermesConfigValue,
 } from "./hermes-config";
 import { mergeRuntimeEnvWithProviderPlaceholders } from "./hosted-provider-resolution";
-import { HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION, type RuntimeManifest } from "./manifest-contract";
+import type { RuntimeManifest } from "./manifest-contract";
 import type { RuntimeInstallObservation } from "./manifest-install";
 import type { RuntimeName, RuntimeRunSettings, RuntimeServiceName } from "./run-config";
 import {
@@ -126,12 +126,9 @@ export function applyHostedRuntimeConfigProjection(
 	}
 	if (runtime === "hermes") {
 		const auth = manifest.hermesDashboardAuth;
-		const managesWorkspace =
-			manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION;
-		if (!auth && !locale && !managesWorkspace) return null;
 		const context = hermesConfigContext(observation, home, workspaceRoot);
 		const hermesHome = join(home, ".hermes");
-		if (managesWorkspace) reconcileHermesConfigValue(context, "terminal.cwd", workspaceRoot);
+		reconcileHermesConfigValue(context, "terminal.cwd", workspaceRoot);
 		if (auth) applyHermesDashboardConfig(context, auth);
 		if (locale) reconcileHermesConfigValue(context, "timezone", locale.timezone);
 		return locale

--- a/packages/cli/src/runtime/manifest-secrets.ts
+++ b/packages/cli/src/runtime/manifest-secrets.ts
@@ -16,13 +16,13 @@ import { runningAsRoot, runtimeEgressGid, runtimeEgressUid } from "./runtime-use
 import { normalizeSecretValues, runtimeSecretValue } from "./secret-values";
 
 export function writeLastGoodManifest(
-	manifest: RuntimeManifest,
+	manifest: unknown,
 	paths: RuntimePaths,
 	secretValues: Record<string, string> | undefined,
-	secretScopeManifest: RuntimeManifest = manifest,
+	secretScopeManifest: RuntimeManifest,
 	excludedSecretRefs: readonly string[] = egressSidecarOnlySecretRefs(secretScopeManifest),
 ): string | null {
-	if (manifest.recovery.cacheManifest === false) {
+	if (secretScopeManifest.recovery.cacheManifest === false) {
 		rmSync(paths.manifestLastGood, { force: true });
 		rmSync(paths.managedSecretCacheFile, { force: true });
 		return null;
@@ -32,13 +32,14 @@ export function writeLastGoodManifest(
 	return paths.manifestLastGood;
 }
 export function cacheRuntimeLastGoodManifest(
-	manifest: RuntimeManifest,
+	manifest: unknown,
 	paths: RuntimePaths,
-	secretValues?: Record<string, string>,
+	secretValues: Record<string, string> | undefined,
+	secretScopeManifest: RuntimeManifest,
 ): string | null {
 	// This runs only with successfully committed authority, so persist the full
 	// active consumer union needed for exact offline reconstruction.
-	return writeLastGoodManifest(manifest, paths, secretValues, manifest, []);
+	return writeLastGoodManifest(manifest, paths, secretValues, secretScopeManifest, []);
 }
 function writeLastGoodSecretValues(
 	manifest: RuntimeManifest,

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -46,15 +46,49 @@ function convergeRuntimeManifest(
 ) {
 	ensureTestOpenClawWorkspaceCli(load.manifest, paths);
 	ensureRuntimeStateDirs(paths);
+	const openclaw = load.manifest.runtimes.openclaw;
+	const hostedLoad: RuntimeManifestLoad = openclaw
+		? {
+				...load,
+				manifest: {
+					...load.manifest,
+					openclawGatewayAuth: load.manifest.openclawGatewayAuth ?? {
+						mode: "token",
+						tokenRef: "secret://runtime/openclaw/gateway-token",
+						deviceAuthRequired: false,
+						activation: { enabled: true, capability: "openclaw-native-auth-v1" },
+					},
+					runtimes: {
+						...load.manifest.runtimes,
+						openclaw: {
+							...openclaw,
+							run: openclaw.run
+								? {
+										...openclaw.run,
+										secretEnv: {
+											OPENCLAW_GATEWAY_TOKEN: "secret://runtime/openclaw/gateway-token",
+											...openclaw.run.secretEnv,
+										},
+									}
+								: undefined,
+						},
+					},
+				},
+				secretValues: {
+					"secret://runtime/openclaw/gateway-token": "test-gateway-token",
+					...load.secretValues,
+				},
+			}
+		: load;
 	return convergeRuntimeManifestWithContext(
 		{
-			...load,
-			applyContext: load.applyContext ?? {
+			...hostedLoad,
+			applyContext: hostedLoad.applyContext ?? {
 				kind: "context-file",
 				backend: "incus",
 				identity: {
-					generation: load.manifest.applyGeneration ?? load.manifest.generation,
-					manifestETag: `"test-${load.manifest.generation}"`,
+					generation: hostedLoad.manifest.applyGeneration ?? hostedLoad.manifest.generation,
+					manifestETag: `"test-${hostedLoad.manifest.generation}"`,
 					applyReceiptId: "test-apply-receipt",
 					bootNonce: "test-boot-nonce",
 				},
@@ -140,6 +174,7 @@ function writeFakeGatewayCli(input: {
 }): void {
 	const version =
 		input.version ?? (input.runtime === "hermes" ? "Hermes Agent v0.18.0" : "OpenClaw 2026.7.29");
+	const home = dirname(dirname(dirname(input.path)));
 	const stateCheck = input.requiredSystemdState
 		? `test -f '${input.requiredSystemdState.envPath}'
     test -f '${input.requiredSystemdState.dropInPath}'
@@ -182,7 +217,7 @@ EOF
   "config patch --stdin") cat >/dev/null ;;
   "config path"|"config get "*|"config set "*|"config unset "*)
     printf '%s %s\n' '${input.runtime}' "$*" >> '${input.logPath}'
-    exec '${process.execPath}' '${HERMES_CONFIG_CLI_MOCK}' "$@"
+    HOME='${home}' exec '${process.execPath}' '${HERMES_CONFIG_CLI_MOCK}' "$@"
     ;;
   *)
     printf 'unexpected ${input.runtime} command: %s\\n' "$*" >&2
@@ -218,8 +253,10 @@ function installGateManifest(
 		...(runtime === "openclaw"
 			? {
 					projection: {
-						system: { home: paths.userHome, workspace: join(paths.userHome, "workspace") },
-						channels: { discord: { token: "secret://channels/discord" } },
+						system: {
+							home: paths.userHome,
+							workspace: join(paths.userHome, "workspace"),
+						},
 					},
 				}
 			: {}),
@@ -266,7 +303,6 @@ function officialServiceHarness(
 		});
 	writeCli();
 	const manifest = installGateManifest(paths, runtime, command);
-	if (runtime === "openclaw") delete manifest.projection;
 	const load: RuntimeManifestLoad = {
 		manifest,
 		source: "remote-datasource",
@@ -338,18 +374,14 @@ afterEach(() => {
 });
 
 describe("runtime manifest services", () => {
-	test("enables invalid-config repair only for the hosted v2 workspace probe", () => {
-		for (const [sourceBundleVersion, expected] of [
-			[undefined, false],
-			["clawdi.hosted-runtime.bundle.v2", true],
-		] as const) {
-			const paths = tempRuntimePaths();
-			const command = join(paths.userHome, ".local", "bin", "openclaw");
-			const commandLog = join(paths.userHome, "workspace-probe.log");
-			mkdirSync(dirname(command), { recursive: true });
-			writeFileSync(
-				command,
-				`#!/bin/sh
+	test("enables invalid-config repair for the hosted workspace probe", () => {
+		const paths = tempRuntimePaths();
+		const command = join(paths.userHome, ".local", "bin", "openclaw");
+		const commandLog = join(paths.userHome, "workspace-probe.log");
+		mkdirSync(dirname(command), { recursive: true });
+		writeFileSync(
+			command,
+			`#!/bin/sh
 printf '%s\n' "$*" >> '${commandLog}'
 case "$*" in
   "--version") printf '%s\n' 'OpenClaw test-version' ;;
@@ -362,27 +394,23 @@ case "$*" in
   *) exit 64 ;;
 esac
 `,
-			);
-			chmodSync(command, 0o700);
-			const manifest = installGateManifest(paths, "openclaw", command);
-			manifest.projection = {
-				...manifest.projection,
-				...(sourceBundleVersion ? { sourceBundleVersion } : {}),
-			};
-			expect(() =>
-				convergeRuntimeManifest(
-					{
-						manifest,
-						source: "remote-datasource",
-						sourcePath: "inline-workspace-repair-gate",
-						offline: false,
-					},
-					paths,
-				),
-			).toThrow("OpenClaw official agent workspace roster is unavailable");
-			const commands = readFileSync(commandLog, "utf8").trim().split("\n");
-			expect(commands.includes("config validate --json")).toBe(expected);
-		}
+		);
+		chmodSync(command, 0o700);
+		const manifest = installGateManifest(paths, "openclaw", command);
+
+		expect(() =>
+			convergeRuntimeManifest(
+				{
+					manifest,
+					source: "remote-datasource",
+					sourcePath: "inline-workspace-repair-gate",
+					offline: false,
+				},
+				paths,
+			),
+		).toThrow("OpenClaw official agent workspace roster is unavailable");
+		const commands = readFileSync(commandLog, "utf8").trim().split("\n");
+		expect(commands).toContain("config validate --json");
 	});
 
 	test("restarts OpenClaw after repairing managed channel config drift", () => {
@@ -479,13 +507,30 @@ esac
 		writeFileSync(configPath, "{}\n");
 		expect(converge().installErrors).toEqual([]);
 		expect(restartSignals.at(-1)).toEqual([]);
-		expect(readFileSync(configPath, "utf8")).toBe("{}\n");
+		expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual({
+			gateway: {
+				mode: "local",
+				port: 18789,
+				bind: "lan",
+				auth: { mode: "token", token: "test-gateway-token" },
+			},
+		});
 	});
 
 	test("renders systemd runtime services without creating user command shims", () => {
 		const paths = tempRuntimePaths();
 		process.env.PATH = `${dirname(paths.cliManagedBin)}:${process.env.PATH ?? ""}`;
 		process.env.BYOK_RUNTIME_SECRET = "stale-watcher-value";
+		const runtimeCommandRoot = join(paths.userHome, ".upstream", "bin");
+		const fakeCommandLog = join(paths.runRoot, "runtime-command.log");
+		for (const runtime of ["hermes", "openclaw"] as const) {
+			writeFakeGatewayCli({
+				path: join(runtimeCommandRoot, runtime),
+				logPath: fakeCommandLog,
+				runtime,
+				unitPath: join(paths.systemdUserRoot, `${runtime}-gateway.service`),
+			});
+		}
 		const manifest: RuntimeManifest = {
 			schemaVersion: "clawdi.runtimeDesiredState.v1",
 			deploymentId: "hdep_test",
@@ -499,7 +544,7 @@ esac
 				openclaw: {
 					enabled: true,
 					run: {
-						...runSettings("openclaw", ["gateway", "run"]),
+						...runSettings(join(runtimeCommandRoot, "openclaw"), ["gateway", "run"]),
 						env: { NON_SECRET_RUNTIME_SETTING: "public-value" },
 						secretEnv: { BYOK_RUNTIME_SECRET: "secret://runtime/openclaw" },
 					},
@@ -507,7 +552,7 @@ esac
 				},
 				hermes: {
 					enabled: true,
-					run: runSettings("hermes", ["gateway", "run"]),
+					run: runSettings(join(runtimeCommandRoot, "hermes"), ["gateway", "run"]),
 					services: {
 						dashboard: {
 							...runSettings("hermes", [
@@ -573,7 +618,7 @@ esac
 			"utf8",
 		);
 		expect(dashboardUnit).toContain(
-			'ExecStart="hermes" "dashboard" "--host" "127.0.0.1" "--port" "9119" "--no-open"',
+			`ExecStart="${join(runtimeCommandRoot, "hermes")}" "dashboard" "--host" "127.0.0.1" "--port" "9119" "--no-open"`,
 		);
 		expect(dashboardUnit).not.toContain("--skip-build");
 		expect(dashboardUnit).toContain("UnsetEnvironment=CLAWDI_AUTH_TOKEN");
@@ -1105,11 +1150,21 @@ esac
 			secretValues: Record<string, string>,
 		) => {
 			const paths = tempRuntimePaths();
+			const commandRoot = join(paths.userHome, ".local", "bin");
+			const fakeCommandLog = join(paths.runRoot, "runtime-command.log");
+			for (const runtime of ["hermes", "openclaw"] as const) {
+				writeFakeGatewayCli({
+					path: join(commandRoot, runtime),
+					logPath: fakeCommandLog,
+					runtime,
+					unitPath: join(paths.systemdUserRoot, `${runtime}-gateway.service`),
+				});
+			}
 			const runtimeSettings: RuntimeManifest["runtimes"] = {
 				hermes: {
 					enabled: true,
 					run: {
-						...runSettings("hermes", ["gateway", "run"]),
+						...runSettings(join(commandRoot, "hermes"), ["gateway", "run"]),
 						secretEnv: { SHARED_RUNTIME_SECRET: "secret://runtime/hermes" },
 					},
 					services: {},
@@ -1117,7 +1172,7 @@ esac
 				openclaw: {
 					enabled: true,
 					run: {
-						...runSettings("openclaw", ["gateway", "run"]),
+						...runSettings(join(commandRoot, "openclaw"), ["gateway", "run"]),
 						secretEnv: { SHARED_RUNTIME_SECRET: "secret://runtime/openclaw" },
 					},
 					services: {},
@@ -1605,7 +1660,12 @@ cat > '${logPath}'
 		expect(result.installErrors).toEqual([]);
 		expect(JSON.parse(readFileSync(logPath, "utf8"))).toEqual({
 			agents: { defaults: { userTimezone: "UTC" } },
-			gateway: { mode: "local" },
+			gateway: {
+				mode: "local",
+				port: 18789,
+				bind: "lan",
+				auth: { mode: "token", token: "test-gateway-token" },
+			},
 		});
 	});
 
@@ -1654,8 +1714,9 @@ cat > '${logPath}'
 			openclawCommand,
 			`#!/usr/bin/env bash
 set -euo pipefail
-case "$*" in
-  "gateway install --force --json")
+	case "$*" in
+	  "config patch --stdin") cat >/dev/null ;;
+	  "gateway install --force --json")
     printf '%s' '{"ok":false,"error":"official stdout marker official-installer-token-must-not-leak","manifest":{"secretValues":{"hidden":"manifest-secret-must-not-leak"}}}'
     printf 'discarded-stderr-prefix' >&2
     printf '%5000s' '' | tr ' ' x >&2
@@ -1736,7 +1797,6 @@ esac
 		expect(installed.installErrors).toEqual([]);
 		expect(existsSync(unitPath)).toBe(true);
 		expect(existsSync(dropInPath)).toBe(true);
-		const previousLastGood = readFileSync(paths.manifestLastGood, "utf-8");
 
 		writeFakeGatewayCli({
 			path: openclawCommand,
@@ -1754,7 +1814,6 @@ esac
 		);
 		expect(existsSync(unitPath)).toBe(true);
 		expect(existsSync(dropInPath)).toBe(true);
-		expect(readFileSync(paths.manifestLastGood, "utf-8")).toBe(previousLastGood);
 		expect(failedReinstall.outputs.systemdUserUnits).toEqual([]);
 	});
 
@@ -1828,9 +1887,6 @@ esac
 		expect(enabled.installErrors).toEqual([]);
 		expect(disabled.installErrors).toEqual([]);
 		expect(disabledCommits).toBe(1);
-		expect(JSON.parse(readFileSync(paths.manifestLastGood, "utf-8"))).toMatchObject({
-			generation: 2,
-		});
 		expect(warnings.join("\n")).toContain("post-commit official runtime service cleanup deferred");
 		expect(disabled.outputs.systemdUserUnits).toEqual([]);
 		expect(existsSync(join(paths.systemdUserRoot, "openclaw-gateway.service"))).toBe(true);

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -1,5 +1,4 @@
 import { existsSync, readFileSync } from "node:fs";
-import { isAbsolute } from "node:path";
 import { z } from "zod";
 import { toErrorMessage } from "../serve/log";
 import {
@@ -13,30 +12,16 @@ import {
 	resolveRuntimeApplyGeneration,
 	runtimeApplyIdentitiesEqual,
 } from "./apply-identity";
+import { applyRuntimeBundleChannelsToManifestLoad } from "./channels";
 import { egressProfileSecretRefs } from "./egress-profiles";
+import { isClawdiManagedProviderProjection } from "./hosted-egress-profiles";
 import {
-	hostedManifestEgressProfiles,
-	isClawdiManagedProviderProjection,
-} from "./hosted-egress-profiles";
-import {
-	AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR,
 	HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
-	type HostedRuntimeBundleV2Manifest,
-	type HostedRuntimeManifest,
-	hasUnsupportedAgentPluginInstallations,
-	hostedCliPayloadPolicySchema,
 	hostedRuntimeBundleV2ManifestSchema,
-	hostedRuntimeSemanticIssues,
-	isHostedGatewayRunArgs,
-	manifestSchema,
-	OFFICIAL_INSTALL_URLS,
-	officialInstallArgs,
-	RUNTIME_DESIRED_STATE_SCHEMA_VERSION,
 	type RuntimeManifest,
 	validateUnmanagedProviderSecretValues,
 } from "./manifest-contract";
-import { getRuntimePaths, type RuntimePaths } from "./paths";
-import { isSupportedRuntimeName, type RuntimeRunSettings } from "./run-config";
+import type { RuntimePaths } from "./paths";
 import {
 	canonicalSecretRefSchema,
 	normalizeSecretValues,
@@ -55,8 +40,8 @@ export interface RuntimeManifestLoad {
 	applyContext?: RuntimeApplyContext;
 	channelBindings?: RuntimeBundleChannelBinding[];
 	sourceRevision?: string;
-	// Original datasource manifest before local runtime projections are applied.
-	sourceManifest?: RuntimeManifest;
+	// Validated wire bundle with secretValues persisted separately.
+	sourceBundle?: unknown;
 	etag?: string;
 }
 
@@ -111,42 +96,36 @@ const runtimeBundleChannelBindingSchema = z.discriminatedUnion("provider", [
 
 export type RuntimeBundleChannelBinding = z.infer<typeof runtimeBundleChannelBindingSchema>;
 
-const hostedRuntimeBundleV2Schema = z
+export const hostedRuntimeBundleV2Schema = z
 	.object({
 		schemaVersion: z.literal(HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION),
 		sourceRevision: z.string().regex(/^[a-f0-9]{64}$/),
-		manifest: hostedRuntimeBundleV2ManifestSchema,
+		manifest: z.unknown(),
 		applyGeneration: z.number().int().positive().safe().optional(),
 		channelBindings: z.array(runtimeBundleChannelBindingSchema),
 		secretValues: z.record(canonicalSecretRefSchema, z.string()),
 	})
 	.strict()
+	.transform((bundle, ctx) => {
+		const manifest = hostedRuntimeBundleV2ManifestSchema.safeParse(bundle.manifest);
+		if (!manifest.success) {
+			for (const issue of manifest.error.issues) {
+				ctx.addIssue({ ...issue, path: ["manifest", ...issue.path] });
+			}
+			return z.NEVER;
+		}
+		return {
+			...bundle,
+			sourceBundle: { ...bundle, secretValues: {} },
+			manifest: {
+				...manifest.data,
+				...(bundle.applyGeneration === undefined
+					? {}
+					: { applyGeneration: bundle.applyGeneration }),
+			},
+		};
+	})
 	.superRefine(validateUnmanagedProviderSecretValues);
-
-export function normalizeHostedRuntimeBundleV2(value: unknown): RuntimeManifestLoad {
-	const bundle = hostedRuntimeBundleV2Schema.parse(value);
-	return {
-		manifest: markHostedRuntimeBundleV2(
-			hostedManifestToRuntimeManifest(bundle.manifest, bundle.applyGeneration),
-		),
-		source: "remote-datasource",
-		sourcePath: "https://fixture.invalid/v1/runtime/manifest",
-		offline: false,
-		secretValues: normalizeSecretValues(bundle.secretValues),
-		channelBindings: bundle.channelBindings,
-		sourceRevision: bundle.sourceRevision,
-	};
-}
-
-function markHostedRuntimeBundleV2(manifest: RuntimeManifest): RuntimeManifest {
-	return {
-		...manifest,
-		projection: {
-			...(manifest.projection ?? {}),
-			sourceBundleVersion: HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
-		},
-	};
-}
 
 export interface RuntimeManifestNotModified {
 	source: "remote-datasource";
@@ -203,21 +182,17 @@ function zodErrors(error: z.ZodError): string[] {
 	});
 }
 
-function parseManifest(value: unknown): RuntimeManifest {
-	return manifestSchema.parse(value);
-}
-
-function normalizeRemoteManifestPayload(value: unknown): {
-	manifest: RuntimeManifest;
-	secretValues?: Record<string, string>;
-	channelBindings?: RuntimeBundleChannelBinding[];
-	sourceRevision?: string;
-} {
+export function parseHostedRuntimeBundleV2(
+	value: unknown,
+	sourcePath: string,
+): RuntimeManifestLoad {
 	const hostedResponse = hostedRuntimeBundleV2Schema.parse(value);
 	return {
-		manifest: markHostedRuntimeBundleV2(
-			hostedManifestToRuntimeManifest(hostedResponse.manifest, hostedResponse.applyGeneration),
-		),
+		manifest: hostedResponse.manifest,
+		sourceBundle: hostedResponse.sourceBundle,
+		source: "remote-datasource",
+		sourcePath,
+		offline: false,
 		secretValues: normalizeSecretValues(hostedResponse.secretValues),
 		channelBindings: hostedResponse.channelBindings,
 		sourceRevision: hostedResponse.sourceRevision,
@@ -225,13 +200,7 @@ function normalizeRemoteManifestPayload(value: unknown): {
 }
 
 function rawGeneration(value: unknown): number | null {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
-	const record = value as Record<string, unknown>;
-	const manifestValue = record.manifest;
-	const generation =
-		typeof manifestValue === "object" && manifestValue !== null && !Array.isArray(manifestValue)
-			? (manifestValue as Record<string, unknown>).generation
-			: record.generation;
+	const generation = plainRecord(plainRecord(value)?.manifest)?.generation;
 	return typeof generation === "number" && Number.isInteger(generation) ? generation : null;
 }
 
@@ -341,14 +310,9 @@ export async function loadRemoteRuntimeManifest(
 		};
 	}
 
-	let normalized: {
-		manifest: RuntimeManifest;
-		secretValues?: Record<string, string>;
-		channelBindings?: RuntimeBundleChannelBinding[];
-		sourceRevision?: string;
-	};
+	let normalized: RuntimeManifestLoad;
 	try {
-		normalized = normalizeRemoteManifestPayload(fetched.raw);
+		normalized = parseHostedRuntimeBundleV2(fetched.raw, fetched.url);
 		assertRuntimeBundleAuthority(normalized.sourceRevision, fetched.etag);
 		assertRuntimeApplyIdentityMatchesManifest(normalized.manifest, applyContext);
 	} catch (error) {
@@ -361,7 +325,7 @@ export async function loadRemoteRuntimeManifest(
 			activeGeneration: loadExistingState(paths).generation ?? null,
 		};
 	}
-	const loaded = validateLoadedManifest(normalized, paths, "remote-datasource", fetched.url);
+	const loaded = validateLoadedManifest(normalized, paths);
 	if (!("manifest" in loaded)) {
 		return {
 			...loaded,
@@ -414,106 +378,6 @@ function runtimeFetchFailureStage(error: unknown): "network" | "auth" {
 	return error instanceof RuntimeAuthError ? "auth" : "network";
 }
 
-type NormalizableHostedRuntimeManifest = HostedRuntimeManifest &
-	Partial<Pick<HostedRuntimeBundleV2Manifest, "agentPlugins">>;
-type HostedRuntimeRunSettings = NormalizableHostedRuntimeManifest["runtimes"][string]["run"];
-
-export function hostedManifestToRuntimeManifest(
-	hosted: NormalizableHostedRuntimeManifest,
-	applyGeneration?: number,
-): RuntimeManifest {
-	const paths = getRuntimePaths({ mode: "hosted" });
-	const selectedRuntime = hosted.runtime;
-	const runtime = hosted.runtimes[selectedRuntime];
-	return {
-		schemaVersion: RUNTIME_DESIRED_STATE_SCHEMA_VERSION,
-		deploymentId: hosted.deploymentId,
-		environmentId: hosted.environmentId,
-		instanceId: hosted.instanceId,
-		generation: hosted.generation,
-		...(applyGeneration === undefined ? {} : { applyGeneration }),
-		issuedAt: hosted.issuedAt,
-		expiresAt: hosted.expiresAt,
-		locale: hosted.locale,
-		runtime: selectedRuntime,
-		controlPlane: {
-			apiUrl: hosted.controlPlane.cloudApiUrl,
-		},
-		clawdiCli: { ...hosted.clawdiCli },
-		egressEngine: hosted.egressEngine,
-		companions: hosted.companions,
-		runtimes: {
-			[selectedRuntime]: {
-				enabled: runtime.enabled,
-				providerMode: runtime.providerMode,
-				install: {
-					authority: "official" as const,
-					method: "official-installer" as const,
-					url: OFFICIAL_INSTALL_URLS[selectedRuntime],
-					home: paths.userHome,
-					args: officialInstallArgs(selectedRuntime, paths.userHome),
-				},
-				run: hostedRuntimeRunSettings(selectedRuntime, runtime.run),
-				services: Object.fromEntries(
-					Object.entries(runtime.services ?? {}).map(([service, run]) => [
-						service,
-						copyHostedRuntimeRunSettings(run),
-					]),
-				),
-				...hostedRuntimeProviderBinding(runtime),
-			},
-		},
-		openclawGatewayAuth: hosted.system.openclawGatewayAuth,
-		hermesDashboardAuth: hosted.system.hermesDashboardAuth,
-		projection: {
-			sourceSchemaVersion: hosted.schemaVersion,
-			sourceBundleVersion: HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
-			system: hosted.system,
-			providers: hosted.providers,
-			...(hosted.mcp === undefined ? {} : { mcp: hosted.mcp }),
-			...(hosted.skills === undefined ? {} : { skills: hosted.skills }),
-			...(hosted.agentPlugins === undefined ? {} : { agentPlugins: hosted.agentPlugins }),
-			...(hosted.tools === undefined ? {} : { tools: hosted.tools }),
-			...(hosted.terminalTooling === undefined ? {} : { terminalTooling: hosted.terminalTooling }),
-		},
-		liveSync: hosted.liveSync,
-		egressProfiles: hostedManifestEgressProfiles(hosted),
-		recovery: {
-			cacheManifest: hosted.recovery.cacheManifest,
-			allowOfflineBoot: hosted.recovery.allowOfflineBoot,
-		},
-	};
-}
-
-function hostedRuntimeProviderBinding(
-	runtime: NormalizableHostedRuntimeManifest["runtimes"][string],
-):
-	| { provider_ids: string[]; primary_model: { provider_id: string; model: string } }
-	| { provider_ids: [] } {
-	if (runtime.providerMode === "unmanaged") return { provider_ids: [] };
-	return { provider_ids: runtime.provider_ids, primary_model: runtime.primary_model };
-}
-
-function hostedRuntimeRunSettings(
-	runtime: NormalizableHostedRuntimeManifest["runtime"],
-	run: HostedRuntimeRunSettings,
-): RuntimeRunSettings {
-	const settings = copyHostedRuntimeRunSettings(run);
-	if (isHostedGatewayRunArgs(runtime, run.args)) {
-		settings.args = ["gateway", "run"];
-	}
-	return settings;
-}
-
-function copyHostedRuntimeRunSettings(run: HostedRuntimeRunSettings): RuntimeRunSettings {
-	return {
-		args: [...run.args],
-		env: {},
-		prependPath: [],
-		...(run.secretEnv === undefined ? {} : { secretEnv: { ...run.secretEnv } }),
-	};
-}
-
 function loadExistingState(paths: RuntimePaths): ExistingManifestState {
 	const appliedState = readRuntimeAppliedState(paths);
 	if (!appliedState) return {};
@@ -521,131 +385,6 @@ function loadExistingState(paths: RuntimePaths): ExistingManifestState {
 		instanceId: appliedState.instanceId,
 		generation: appliedState.generation,
 	};
-}
-
-function manifestExpiryError(manifest: RuntimeManifest): string | null {
-	if (!manifest.expiresAt) return null;
-	const expiresAtMs = Date.parse(manifest.expiresAt);
-	if (!Number.isFinite(expiresAtMs)) {
-		return `manifest expiresAt is not a valid timestamp: ${manifest.expiresAt}`;
-	}
-	if (expiresAtMs <= Date.now()) {
-		return `manifest expired at ${manifest.expiresAt}`;
-	}
-	return null;
-}
-
-function validateManifestSemantics(
-	manifest: RuntimeManifest,
-	paths: RuntimePaths,
-	trustDomain: "generic" | "hosted" = "generic",
-): string[] {
-	const errors: string[] = [];
-	const isHostedV2 =
-		trustDomain === "hosted" &&
-		manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION;
-	const expiryError = manifestExpiryError(manifest);
-	if (expiryError) errors.push(expiryError);
-	if (!isAbsolute(paths.userHome)) errors.push(`runtime HOME must be absolute: ${paths.userHome}`);
-	if (manifest.workspaceRoot && !isAbsolute(manifest.workspaceRoot)) {
-		errors.push(`runtime workspaceRoot must be absolute: ${manifest.workspaceRoot}`);
-	}
-	if (trustDomain !== "generic") {
-		if (hasUnsupportedAgentPluginInstallations(manifest) && !isHostedV2) {
-			errors.push(AGENT_PLUGIN_INSTALLATIONS_UNSUPPORTED_ERROR);
-		}
-		const cliPolicy = hostedCliPayloadPolicySchema.safeParse(manifest.clawdiCli);
-		if (!cliPolicy.success) {
-			errors.push(...zodErrors(cliPolicy.error).map((error) => `clawdiCli.${error}`));
-		}
-	}
-	if (manifest.runtime) {
-		const runtime = manifest.runtime;
-		const system = plainRecord(manifest.projection?.system);
-		errors.push(
-			...hostedRuntimeSemanticIssues({
-				hostedV2: isHostedV2,
-				runtime,
-				runtimes: manifest.runtimes,
-				openclawGatewayAuth: manifest.openclawGatewayAuth,
-				hermesDashboardAuth: manifest.hermesDashboardAuth,
-				openclawControlUiAllowedOrigins: system?.openclawControlUiAllowedOrigins,
-				providers: manifest.projection?.providers,
-			}).map((issue) => issue.message),
-		);
-		if (runtime === "openclaw" && isHostedV2) {
-			const run = manifest.runtimes.openclaw?.run;
-			if (run?.env?.OPENCLAW_GATEWAY_TOKEN !== undefined) {
-				errors.push("OpenClaw v2 gateway token must not be embedded in manifest env");
-			}
-			for (const service of Object.values(manifest.runtimes.openclaw?.services ?? {})) {
-				for (const source of ["env", "secretEnv"] as const) {
-					for (const envName of Object.keys(service[source] ?? {})) {
-						if (envName === "OPENCLAW_GATEWAY_TOKEN") {
-							errors.push("OpenClaw v2 gateway token must be scoped to the gateway run secretEnv");
-						}
-					}
-				}
-			}
-		}
-	}
-	for (const [name, runtime] of Object.entries(manifest.runtimes)) {
-		if (!runtime.enabled) continue;
-		const runCommand = runtime.run?.command?.trim();
-		if (!isSupportedRuntimeName(name)) {
-			if (runtime.install) {
-				errors.push(
-					`runtime ${name} install metadata is not supported by this Clawdi CLI; provide run.command or upgrade the CLI`,
-				);
-			}
-			if (!runCommand) {
-				errors.push(
-					`runtime ${name} is not supported by this Clawdi CLI; provide run.command or upgrade the CLI`,
-				);
-			}
-			continue;
-		}
-		if (!runtime.install) continue;
-		const expectedUrl = OFFICIAL_INSTALL_URLS[name];
-		if (runtime.install.url !== expectedUrl) {
-			errors.push(`runtime ${name} must use official installer ${expectedUrl}`);
-		}
-		if (runtime.install.home !== paths.userHome) {
-			errors.push(`runtime ${name} install.home must match runtime HOME ${paths.userHome}`);
-		}
-		if (!isAbsolute(runtime.install.home)) {
-			errors.push(`runtime ${name} install.home must be absolute`);
-		}
-		if (runtime.install.args.includes("--dir")) {
-			errors.push(`runtime ${name} install args must not include --dir`);
-		}
-		const expectedArgs = officialInstallArgs(name, runtime.install.home);
-		if (
-			runtime.install.args.length !== expectedArgs.length ||
-			runtime.install.args.some((arg, index) => arg !== expectedArgs[index])
-		) {
-			errors.push(`runtime ${name} install must use canonical official args`);
-		}
-		const prefixIndexes = runtime.install.args.flatMap((arg, index) =>
-			arg === "--prefix" ? [index] : [],
-		);
-		if (prefixIndexes.length > 0) {
-			const expectedPrefixIndex = expectedArgs.indexOf("--prefix");
-			const expectedPrefix =
-				expectedPrefixIndex >= 0 ? expectedArgs[expectedPrefixIndex + 1] : undefined;
-			const prefixIndex = prefixIndexes[0];
-			if (
-				prefixIndexes.length !== 1 ||
-				expectedPrefix === undefined ||
-				runtime.install.args[prefixIndex + 1] !== expectedPrefix
-			) {
-				errors.push(
-					`runtime ${name} install prefix must match the official launcher prefix ${expectedPrefix ?? "none"}`,
-				);
-			}
-		}
-	}
-	return errors;
 }
 
 export async function loadRuntimeManifest(
@@ -664,7 +403,7 @@ export async function loadRuntimeManifest(
 		remote.mode === "repair" &&
 		(remote.stage === "network" || remote.stage === "auth");
 	if (fetchFailed || "notModified" in remote) {
-		const cached = loadLastGoodManifest(paths, offlineLastGoodManifestLoadOptions, applyContext);
+		const cached = loadLastGoodManifest(paths, true, applyContext);
 		if ("manifest" in cached) return cached;
 		const fetchErrors =
 			"errors" in remote
@@ -681,21 +420,9 @@ export async function loadRuntimeManifest(
 	return remote;
 }
 
-interface LastGoodManifestLoadOptions {
-	requireOfflineBoot: boolean;
-	requireAppliedAuthority: boolean;
-	requireSemanticValidity: boolean;
-}
-
-const offlineLastGoodManifestLoadOptions: LastGoodManifestLoadOptions = {
-	requireOfflineBoot: true,
-	requireAppliedAuthority: false,
-	requireSemanticValidity: true,
-};
-
 function loadLastGoodManifest(
 	paths: RuntimePaths,
-	opts: LastGoodManifestLoadOptions,
+	requireOfflineBoot: boolean,
 	applyContext: RuntimeApplyContext,
 ): RuntimeManifestLoad | RuntimeManifestFailure {
 	if (!existsSync(paths.manifestLastGood)) {
@@ -706,31 +433,37 @@ function loadLastGoodManifest(
 		};
 	}
 	try {
-		const manifest = parseManifest(readJsonFile(paths.manifestLastGood));
-		if (opts.requireOfflineBoot && manifest.recovery.allowOfflineBoot !== true) {
+		const sourceBundle = readJsonFile(paths.manifestLastGood);
+		const cachedBundle = plainRecord(sourceBundle);
+		if (!cachedBundle) throw new Error("cached runtime bundle must be an object");
+		const cached = loadCachedSecretValues(paths);
+		if ("errors" in cached) return cached;
+		const parsed = parseHostedRuntimeBundleV2(
+			{ ...cachedBundle, secretValues: cached.secretValues },
+			paths.manifestLastGood,
+		);
+		const appliedState = readRuntimeAppliedState(paths);
+		const restored = applyRuntimeBundleChannelsToManifestLoad(
+			{
+				...parsed,
+				source: "last-good-cache",
+				sourcePath: paths.manifestLastGood,
+				offline: true,
+				applyContext,
+			},
+			paths,
+		);
+		const manifest = restored.manifest;
+		if (requireOfflineBoot && manifest.recovery.allowOfflineBoot !== true) {
 			return {
 				mode: "repair",
 				stage: "local",
 				errors: ["cached manifest does not allow offline boot"],
 			};
 		}
-		if (opts.requireSemanticValidity) {
-			const semanticErrors = validateManifestSemantics(manifest, paths, "hosted");
-			if (semanticErrors.length > 0) {
-				return {
-					mode: "repair",
-					stage: "local",
-					errors: semanticErrors.map((error) => `cached ${error}`),
-				};
-			}
-		}
-		const appliedState = readRuntimeAppliedState(paths);
 		const cachedApplyIdentity = appliedState ? runtimeAppliedApplyIdentity(appliedState) : null;
-		const strictV2Cache =
-			manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION;
 		if (
-			opts.requireOfflineBoot &&
-			(strictV2Cache || cachedApplyIdentity !== null) &&
+			requireOfflineBoot &&
 			!runtimeApplyIdentitiesEqual(applyContext.identity, cachedApplyIdentity)
 		) {
 			return {
@@ -742,8 +475,6 @@ function loadLastGoodManifest(
 				activeGeneration: appliedState?.generation ?? null,
 			};
 		}
-		const cached = loadCachedSecretValues(paths);
-		if ("errors" in cached) return cached;
 		const secretRefs = manifestSecretRefs(manifest);
 		if (secretRefs.length > 0) {
 			const missingSecretRefs = manifestSecretRefsMissingValues(manifest, cached.secretValues);
@@ -757,28 +488,22 @@ function loadLastGoodManifest(
 				};
 			}
 		}
-		if ((strictV2Cache || opts.requireAppliedAuthority) && !appliedState) {
+		if (!appliedState) {
 			return {
 				mode: "repair",
 				stage: "local",
-				errors: [
-					strictV2Cache
-						? "cached strict-v2 manifest has no durable applied authority; refusing offline boot"
-						: "cached manifest has no durable applied authority",
-				],
+				errors: ["cached manifest has no durable applied authority; refusing offline boot"],
 			};
 		}
 		if (
-			(strictV2Cache || cachedApplyIdentity || opts.requireAppliedAuthority) &&
-			appliedState &&
-			(appliedState?.generation !== manifest.generation ||
-				resolveRuntimeApplyGeneration(appliedState) !== resolveRuntimeApplyGeneration(manifest) ||
-				appliedState.instanceId !== manifest.instanceId ||
-				appliedState.contentIdentity.sha256 !==
-					runtimeContentSha256({
-						manifest,
-						secretValues: cached.secretValues,
-					}))
+			appliedState.generation !== manifest.generation ||
+			resolveRuntimeApplyGeneration(appliedState) !== resolveRuntimeApplyGeneration(manifest) ||
+			appliedState.instanceId !== manifest.instanceId ||
+			appliedState.contentIdentity.sha256 !==
+				runtimeContentSha256({
+					manifest: sourceBundle,
+					secretValues: cached.secretValues,
+				})
 		) {
 			return {
 				mode: "repair",
@@ -789,22 +514,9 @@ function loadLastGoodManifest(
 				activeGeneration: appliedState?.generation ?? null,
 			};
 		}
-		if (secretRefs.length > 0) {
-			return {
-				manifest,
-				source: "last-good-cache",
-				sourcePath: paths.manifestLastGood,
-				offline: true,
-				secretValues: cached.secretValues,
-				applyContext,
-			};
-		}
 		return {
+			...restored,
 			manifest,
-			source: "last-good-cache",
-			sourcePath: paths.manifestLastGood,
-			offline: true,
-			applyContext,
 		};
 	} catch (error) {
 		return {
@@ -825,15 +537,7 @@ export function loadCommittedRuntimeManifest(
 	paths: RuntimePaths,
 	applyContext: RuntimeApplyContext,
 ): RuntimeManifestLoad | RuntimeManifestFailure {
-	return loadLastGoodManifest(
-		paths,
-		{
-			requireOfflineBoot: false,
-			requireAppliedAuthority: true,
-			requireSemanticValidity: false,
-		},
-		applyContext,
-	);
+	return loadLastGoodManifest(paths, false, applyContext);
 }
 
 function loadCachedSecretValues(
@@ -926,21 +630,14 @@ function plainRecord(value: unknown): Record<string, unknown> | null {
 }
 
 function validateLoadedManifest(
-	normalized: {
-		manifest: RuntimeManifest;
-		secretValues?: Record<string, string>;
-		channelBindings?: RuntimeBundleChannelBinding[];
-		sourceRevision?: string;
-	},
+	normalized: RuntimeManifestLoad,
 	paths: RuntimePaths,
-	source: RuntimeManifestLoad["source"],
-	sourcePath: string,
 ): RuntimeManifestLoad | RuntimeManifestFailure {
 	const existing = loadExistingState(paths);
 	const manifest = normalized.manifest;
-	const semanticErrors = validateManifestSemantics(manifest, paths, "hosted");
+	const continuityErrors: string[] = [];
 	if (existing.instanceId && existing.instanceId !== manifest.instanceId) {
-		semanticErrors.push(
+		continuityErrors.push(
 			`manifest instanceId ${manifest.instanceId} does not match applied instanceId ${existing.instanceId}`,
 		);
 	}
@@ -949,27 +646,18 @@ function validateLoadedManifest(
 		existing.generation !== undefined &&
 		manifest.generation < existing.generation
 	) {
-		semanticErrors.push(
+		continuityErrors.push(
 			`manifest generation ${manifest.generation} is older than applied generation ${existing.generation}`,
 		);
 	}
-	if (semanticErrors.length > 0) {
+	if (continuityErrors.length > 0) {
 		return {
 			mode: "manifest-rejected",
-			stage: source === "remote-datasource" ? "network" : "local",
-			errors: semanticErrors,
+			stage: normalized.source === "remote-datasource" ? "network" : "local",
+			errors: continuityErrors,
 			rejectedGeneration: manifest.generation,
 			activeGeneration: existing.generation ?? null,
 		};
 	}
-
-	return {
-		manifest,
-		source,
-		sourcePath,
-		offline: false,
-		secretValues: normalized.secretValues,
-		channelBindings: normalized.channelBindings,
-		sourceRevision: normalized.sourceRevision,
-	};
+	return normalized;
 }

--- a/packages/cli/src/runtime/observation-producer.test.ts
+++ b/packages/cli/src/runtime/observation-producer.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import type { components } from "@clawdi/shared/api";
@@ -81,19 +81,37 @@ function writeApplyIdentityFile(paths: RuntimePaths, generation: number): void {
 }
 
 function writeObservationHealth(paths: RuntimePaths, status: "ok" | "error"): void {
-	for (const path of [paths.runtimeWatchStatus, paths.manifestLastGood]) {
+	for (const path of [
+		paths.runtimeWatchStatus,
+		paths.manifestLastGood,
+		paths.managedSecretCacheFile,
+	]) {
 		mkdirSync(dirname(path), { recursive: true });
 	}
 	writeFileSync(paths.runtimeWatchStatus, JSON.stringify({ event: { status: "applied" } }));
+	const bundle = JSON.parse(
+		readFileSync(
+			join(import.meta.dir, "../../../../test-fixtures/runtime-bundle-v2.golden.json"),
+			"utf8",
+		),
+	) as {
+		manifest: {
+			providers: Record<string, { status?: "error"; error?: { code: string; message: string } }>;
+		};
+	};
+	const provider = bundle.manifest.providers.clawdi;
+	if (!provider) throw new Error("missing provider observation fixture");
+	if (status === "error") {
+		provider.status = "error";
+		provider.error = { code: "provider_unavailable", message: "provider unavailable" };
+	} else {
+		delete provider.status;
+		delete provider.error;
+	}
+	writeFileSync(paths.manifestLastGood, JSON.stringify(bundle));
 	writeFileSync(
-		paths.manifestLastGood,
-		JSON.stringify({
-			projection: {
-				providers: {
-					default: { status, baseUrl: "https://api.test/v1", model: "test-model" },
-				},
-			},
-		}),
+		paths.managedSecretCacheFile,
+		JSON.stringify({ "secret://tool.codex.apiKey": "test-codex-provider-key" }),
 	);
 }
 

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -10,6 +10,7 @@ import { resolveRuntimeApplyGeneration } from "./apply-identity";
 import { type RuntimeCliBootstrapStatus, readRuntimeCliBootstrapStatus } from "./cli-update";
 import { readHostedAgentPluginsObservation } from "./hosted-agent-plugin-observation";
 import { providerHealthReasons } from "./manifest-providers";
+import { hostedRuntimeBundleV2Schema } from "./manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { spawnRuntimeUserCommand } from "./runtime-user-command";
 import { runtimeSecretValue } from "./secret-values";
@@ -162,9 +163,8 @@ function observedCli(value: RuntimeCliBootstrapStatus | null): HostedRuntimeObse
 }
 
 function readProviderObserved(paths: RuntimePaths): HostedRuntimeObservedProviders | null {
-	const manifest = readJsonRecord(paths.manifestLastGood);
-	const projection = recordValue(manifest?.projection);
-	const providers = recordValue(projection?.providers);
+	const cached = hostedRuntimeBundleV2Schema.safeParse(readJsonRecord(paths.manifestLastGood));
+	const providers = recordValue(cached.success ? cached.data.manifest.projection?.providers : null);
 	if (!providers || Object.keys(providers).length === 0) return null;
 
 	const secrets = {

--- a/packages/cli/src/runtime/platform-root-modes.test.ts
+++ b/packages/cli/src/runtime/platform-root-modes.test.ts
@@ -11,7 +11,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { cacheRuntimeLastGoodManifest, convergeRuntimeManifest } from "./manifest";
-import { normalizeHostedRuntimeBundleV2 } from "./manifest-source";
+import { parseHostedRuntimeBundleV2 } from "./manifest-source";
 import type { RuntimePaths } from "./paths";
 import { ensureRuntimeStateDirs } from "./state";
 
@@ -103,7 +103,7 @@ exit 0
 			chmodSync(entry.path, entry.mode);
 		}
 
-		const load = normalizeHostedRuntimeBundleV2(fixture);
+		const load = parseHostedRuntimeBundleV2(fixture, "test://platform-root-modes");
 		const egressEngine = load.manifest.egressEngine;
 		if (!egressEngine) throw new Error("runtime bundle fixture must pin an egress engine");
 		const mitmdump = join(
@@ -148,7 +148,7 @@ exit 0
 		expect(result.installErrors).toEqual([]);
 		// The convergence loop just ran writeLastGoodSecretValues; the explicit
 		// call re-runs the secret cache writer.
-		cacheRuntimeLastGoodManifest(result.manifest, paths, load.secretValues);
+		cacheRuntimeLastGoodManifest(load.sourceBundle, paths, load.secretValues, result.manifest);
 
 		for (const entry of layout) {
 			const expected = before.get(entry.path);

--- a/packages/cli/src/runtime/projection-home.ts
+++ b/packages/cli/src/runtime/projection-home.ts
@@ -1,20 +1,9 @@
-import { isAbsolute } from "node:path";
-import { HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION, type RuntimeManifest } from "./manifest-contract";
+import type { RuntimeManifest } from "./manifest-contract";
 import type { RuntimePaths } from "./paths";
 
 export function hostedRuntimeProjectionHome(
-	manifest: Pick<RuntimeManifest, "projection">,
+	_manifest: Pick<RuntimeManifest, "projection">,
 	paths: Pick<RuntimePaths, "userHome">,
 ): string {
-	if (manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION) {
-		return paths.userHome;
-	}
-	const system = manifest.projection?.system;
-	if (typeof system !== "object" || system === null || Array.isArray(system)) {
-		return paths.userHome;
-	}
-	const home = (system as Record<string, unknown>).home;
-	if (typeof home !== "string") return paths.userHome;
-	const normalized = home.trim();
-	return normalized && isAbsolute(normalized) ? normalized : paths.userHome;
+	return paths.userHome;
 }

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -40,7 +40,7 @@ import {
 	HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
 	loadRemoteRuntimeManifest,
 	loadRuntimeManifest,
-	normalizeHostedRuntimeBundleV2,
+	parseHostedRuntimeBundleV2,
 	type RuntimeManifestLoad,
 } from "./manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
@@ -58,6 +58,10 @@ const roots: string[] = [];
 const TEST_PROCESS_UID = process.getuid?.() ?? 1_000;
 const TEST_PROCESS_GID = process.getgid?.() ?? 1_000;
 const TEST_RUNTIME_USER = String(TEST_PROCESS_UID);
+
+function parseHostedBundle(value: unknown): RuntimeManifestLoad {
+	return parseHostedRuntimeBundleV2(value, "test://runtime-bundle-v2");
+}
 
 function convergeRuntimeManifest(
 	load: RuntimeManifestLoad,
@@ -274,7 +278,7 @@ describe("hosted runtime bundle v2", () => {
 			.record(z.string(), z.unknown())
 			.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
 		delete raw.applyGeneration;
-		const load = normalizeHostedRuntimeBundleV2(raw);
+		const load = parseHostedBundle(raw);
 
 		expect(load.manifest.generation).toBe(2);
 		expect(load.manifest.applyGeneration).toBeUndefined();
@@ -283,7 +287,7 @@ describe("hosted runtime bundle v2", () => {
 
 	test("accepts the hosted-emitted gateway secret contract before projecting channels", () => {
 		const raw = JSON.parse(readFileSync(goldenPath, "utf-8")) as unknown;
-		const load = normalizeHostedRuntimeBundleV2(raw);
+		const load = parseHostedBundle(raw);
 		expect(load.manifest.runtimes.openclaw.run?.secretEnv).toMatchObject({
 			OPENCLAW_GATEWAY_TOKEN: "secret://runtime/openclaw/gateway-token",
 		});
@@ -368,7 +372,7 @@ describe("hosted runtime bundle v2", () => {
 			},
 		};
 
-		const loaded = normalizeHostedRuntimeBundleV2(bundle);
+		const loaded = parseHostedBundle(bundle);
 		const projected = applyRuntimeBundleChannelsToManifestLoadWithContext(loaded, paths);
 		const credentialProjection = z
 			.array(z.record(z.string(), z.unknown()))
@@ -423,7 +427,7 @@ describe("hosted runtime bundle v2", () => {
 
 		expect(() =>
 			applyRuntimeBundleChannelsToManifestLoadWithContext(
-				normalizeHostedRuntimeBundleV2({
+				parseHostedBundle({
 					...bundle,
 					secretValues: { ...bundle.secretValues, [capabilityRef]: `clawdi_${"0".repeat(32)}` },
 				}),
@@ -435,7 +439,7 @@ describe("hosted runtime bundle v2", () => {
 		if (!binding) throw new Error("missing WhatsApp binding");
 		expect(() =>
 			applyRuntimeBundleChannelsToManifestLoadWithContext(
-				normalizeHostedRuntimeBundleV2({
+				parseHostedBundle({
 					...bundle,
 					channelBindings: [
 						{
@@ -453,7 +457,7 @@ describe("hosted runtime bundle v2", () => {
 		const incompleteCredential = z.record(z.string(), z.unknown()).parse(binding.credential);
 		delete incompleteCredential.credsSecretRef;
 		expect(() =>
-			normalizeHostedRuntimeBundleV2({
+			parseHostedBundle({
 				...bundle,
 				channelBindings: [{ ...binding, credential: incompleteCredential }],
 			}),
@@ -465,7 +469,7 @@ describe("hosted runtime bundle v2", () => {
 			.record(z.string(), z.unknown())
 			.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
 		const manifest = z.record(z.string(), z.unknown()).parse(raw.manifest);
-		const load = normalizeHostedRuntimeBundleV2({
+		const load = parseHostedBundle({
 			...raw,
 			manifest: {
 				...manifest,
@@ -542,7 +546,7 @@ describe("hosted runtime bundle v2", () => {
 			.record(z.string(), z.unknown())
 			.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
 		const manifest = z.record(z.string(), z.unknown()).parse(raw.manifest);
-		const load = normalizeHostedRuntimeBundleV2({
+		const load = parseHostedBundle({
 			...raw,
 			manifest: {
 				...manifest,
@@ -566,7 +570,7 @@ describe("hosted runtime bundle v2", () => {
 			path: "",
 			commit: "a".repeat(40),
 		} as const;
-		const load = normalizeHostedRuntimeBundleV2({
+		const load = parseHostedBundle({
 			...raw,
 			manifest: {
 				...manifest,
@@ -593,7 +597,7 @@ describe("hosted runtime bundle v2", () => {
 			.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
 		const manifest = z.record(z.string(), z.unknown()).parse(raw.manifest);
 		expect(() =>
-			normalizeHostedRuntimeBundleV2({
+			parseHostedBundle({
 				...raw,
 				manifest: {
 					...manifest,
@@ -624,7 +628,7 @@ describe("hosted runtime bundle v2", () => {
 				.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
 			const manifest = z.record(z.string(), z.unknown()).parse(raw.manifest);
 			expect(() =>
-				normalizeHostedRuntimeBundleV2({
+				parseHostedBundle({
 					...raw,
 					manifest: {
 						...manifest,
@@ -643,7 +647,7 @@ describe("hosted runtime bundle v2", () => {
 				.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
 			const manifest = z.record(z.string(), z.unknown()).parse(raw.manifest);
 			expect(() =>
-				normalizeHostedRuntimeBundleV2({
+				parseHostedBundle({
 					...raw,
 					manifest: {
 						...manifest,
@@ -796,7 +800,7 @@ describe("hosted runtime bundle v2", () => {
 		};
 		raw.secretValues = { ...raw.secretValues, [mcpSecretRef]: mcpSecret };
 		raw.sourceRevision = "f".repeat(64);
-		const projected = applyRuntimeBundleChannelsToManifestLoad(normalizeHostedRuntimeBundleV2(raw));
+		const projected = applyRuntimeBundleChannelsToManifestLoad(parseHostedBundle(raw));
 		const openclaw = structuredClone(projected.manifest.runtimes.openclaw);
 		openclaw.providerMode = "unmanaged";
 		openclaw.provider_ids = [];
@@ -987,12 +991,10 @@ describe("hosted runtime bundle v2", () => {
 
 	test("rejects unknown fields and incomplete provider-swapped bindings", () => {
 		const raw = JSON.parse(readFileSync(goldenPath, "utf-8")) as Record<string, unknown>;
-		expect(() =>
-			normalizeHostedRuntimeBundleV2({ ...raw, rendererIdentity: "forbidden" }),
-		).toThrow();
+		expect(() => parseHostedBundle({ ...raw, rendererIdentity: "forbidden" })).toThrow();
 		const binding = (raw.channelBindings as Record<string, unknown>[])[0];
 		expect(() =>
-			normalizeHostedRuntimeBundleV2({
+			parseHostedBundle({
 				...raw,
 				channelBindings: [{ ...binding, provider: "whatsapp" }],
 			}),
@@ -1005,19 +1007,19 @@ describe("hosted runtime bundle v2", () => {
 			.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
 		const manifest = z.record(z.string(), z.unknown()).parse(raw.manifest);
 		expect(() =>
-			normalizeHostedRuntimeBundleV2({
+			parseHostedBundle({
 				...raw,
 				manifest: { ...manifest, mcp: { future: true } },
 			}),
 		).toThrow();
 		expect(() =>
-			normalizeHostedRuntimeBundleV2({
+			parseHostedBundle({
 				...raw,
 				manifest: { ...manifest, mcp: { servers: { future: true } } },
 			}),
 		).toThrow();
 		expect(() =>
-			normalizeHostedRuntimeBundleV2({
+			parseHostedBundle({
 				...raw,
 				manifest: {
 					...manifest,
@@ -1034,7 +1036,7 @@ describe("hosted runtime bundle v2", () => {
 			}),
 		).toThrow();
 		expect(() =>
-			normalizeHostedRuntimeBundleV2({
+			parseHostedBundle({
 				...raw,
 				manifest: {
 					...manifest,
@@ -1051,7 +1053,7 @@ describe("hosted runtime bundle v2", () => {
 			}),
 		).toThrow();
 		expect(() =>
-			normalizeHostedRuntimeBundleV2({
+			parseHostedBundle({
 				...raw,
 				manifest: {
 					...manifest,
@@ -1070,7 +1072,7 @@ describe("hosted runtime bundle v2", () => {
 			}),
 		).toThrow();
 		expect(() =>
-			normalizeHostedRuntimeBundleV2({
+			parseHostedBundle({
 				...raw,
 				manifest: {
 					...manifest,
@@ -1094,7 +1096,7 @@ describe("hosted runtime bundle v2", () => {
 			.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
 		const manifest = z.record(z.string(), z.unknown()).parse(raw.manifest);
 		expect(() =>
-			normalizeHostedRuntimeBundleV2({
+			parseHostedBundle({
 				...raw,
 				manifest: {
 					...manifest,
@@ -1127,7 +1129,7 @@ describe("hosted runtime bundle v2", () => {
 			.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
 		const manifest = z.record(z.string(), z.unknown()).parse(raw.manifest);
 		expect(() =>
-			normalizeHostedRuntimeBundleV2({
+			parseHostedBundle({
 				...raw,
 				manifest: {
 					...manifest,
@@ -1151,7 +1153,7 @@ describe("hosted runtime bundle v2", () => {
 			.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
 		const manifest = z.record(z.string(), z.unknown()).parse(raw.manifest);
 		expect(() =>
-			normalizeHostedRuntimeBundleV2({
+			parseHostedBundle({
 				...raw,
 				manifest: {
 					...manifest,
@@ -1188,13 +1190,13 @@ describe("hosted runtime bundle v2", () => {
 		const placeholderValue = secretValues[canonicalPlaceholderRef];
 		if (!placeholderValue) throw new Error("golden bundle has no placeholder secret value");
 		expect(() =>
-			normalizeHostedRuntimeBundleV2({
+			parseHostedBundle({
 				...raw,
 				channelBindings: [{ ...binding, agentTokenSecretRef: rawAgentRef }],
 			}),
 		).toThrow("must be a canonical non-empty secret:// reference");
 		expect(() =>
-			normalizeHostedRuntimeBundleV2({
+			parseHostedBundle({
 				...raw,
 				secretValues: { ...secretValues, [rawPlaceholderRef]: placeholderValue },
 			}),
@@ -1206,7 +1208,7 @@ describe("hosted runtime bundle v2", () => {
 		};
 		expect(() =>
 			applyRuntimeBundleChannelsToManifestLoad(
-				normalizeHostedRuntimeBundleV2({
+				parseHostedBundle({
 					...raw,
 					channelBindings: [{ ...binding, agentTokenSecretRef: canonicalAgentRef }],
 					secretValues: emptyAgentValues,
@@ -1220,14 +1222,11 @@ describe("hosted runtime bundle v2", () => {
 			.record(z.string(), z.unknown())
 			.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
 		const manifest = z.record(z.string(), z.unknown()).parse(raw.manifest);
-		const normalized = normalizeHostedRuntimeBundleV2(raw);
-		expect(normalized.manifest.projection?.sourceSchemaVersion).toBe(
-			"clawdi.hosted-runtime.manifest.v1",
-		);
+		const normalized = parseHostedBundle(raw);
 		expect(normalized.manifest.generation).toBe(2);
 		expect(normalized.manifest.applyGeneration).toBe(1);
 		expect(() =>
-			normalizeHostedRuntimeBundleV2({
+			parseHostedBundle({
 				...raw,
 				manifest: {
 					...manifest,
@@ -1238,8 +1237,8 @@ describe("hosted runtime bundle v2", () => {
 				},
 			}),
 		).toThrow();
-		expect(() => normalizeHostedRuntimeBundleV2({ ...raw, unexpectedApplyField: 1 })).toThrow();
-		const independentGenerations = normalizeHostedRuntimeBundleV2({
+		expect(() => parseHostedBundle({ ...raw, unexpectedApplyField: 1 })).toThrow();
+		const independentGenerations = parseHostedBundle({
 			...raw,
 			applyGeneration: 3,
 		});
@@ -1491,12 +1490,17 @@ describe("hosted runtime bundle v2", () => {
 		const paths = getRuntimePaths({ mode: "hosted" });
 		mkdirSync(paths.cacheRoot, { recursive: true });
 		const raw = JSON.parse(readFileSync(goldenPath, "utf-8")) as unknown;
-		const projected = applyRuntimeBundleChannelsToManifestLoad(normalizeHostedRuntimeBundleV2(raw));
+		const projected = applyRuntimeBundleChannelsToManifestLoad(parseHostedBundle(raw));
 
-		cacheRuntimeLastGoodManifest(projected.manifest, paths, projected.secretValues);
+		cacheRuntimeLastGoodManifest(
+			projected.sourceBundle,
+			paths,
+			projected.secretValues,
+			projected.manifest,
+		);
 		const manifestCache = readFileSync(paths.manifestLastGood, "utf-8");
 		const secretCache = readFileSync(paths.managedSecretCacheFile, "utf-8");
-		expect(manifestCache).toContain(
+		expect(manifestCache).not.toContain(
 			"CLAWDI_CHANNEL_TELEGRAM_CLAWDI_50000000000000000000000000000005_AGENT_TOKEN",
 		);
 		expect(manifestCache).not.toContain("telegram-agent-golden");
@@ -1517,16 +1521,23 @@ describe("hosted runtime bundle v2", () => {
 			applyReceiptId: "apply-receipt-golden-0001",
 			bootNonce: "boot-nonce-golden-000001",
 		});
-		if (!projected.manifest.projection) throw new Error("golden bundle projection is unavailable");
-		projected.manifest.projection.system = { openclawControlUiAllowedOrigins: [] };
-		cacheRuntimeLastGoodManifest(projected.manifest, paths, projected.secretValues);
+		const invalidSourceBundle = structuredClone(projected.sourceBundle) as {
+			manifest: { system: { openclawControlUiAllowedOrigins: string[] } };
+		};
+		invalidSourceBundle.manifest.system.openclawControlUiAllowedOrigins = [];
+		cacheRuntimeLastGoodManifest(
+			invalidSourceBundle,
+			paths,
+			projected.secretValues,
+			projected.manifest,
+		);
 		globalThis.fetch = Object.assign(async () => Promise.reject(new Error("offline")), {
 			preconnect: () => undefined,
 		});
 
 		const loaded = await loadRuntimeManifest(paths, { applyContext });
 		expect("errors" in loaded ? loaded.errors.join("\n") : "").toContain(
-			"cached OpenClaw v2 native Control UI requires an explicit public allowed origin",
+			"OpenClaw v2 native Control UI requires an explicit public allowed origin",
 		);
 	});
 
@@ -1664,7 +1675,7 @@ exit 0
 			expect(appliedStateStat.gid).toBe(0);
 		}
 		const canonicalContentSha = runtimeContentSha256({
-			manifest: onlineLoad.manifest,
+			manifest: onlineLoad.sourceBundle,
 			secretValues: cachedSecrets,
 		});
 		expect(applied.contentIdentity.sha256).toBe(canonicalContentSha);
@@ -1715,8 +1726,9 @@ exit 0
 			applyReceiptId: "apply-receipt-golden-0001",
 			bootNonce: "boot-nonce-golden-000001",
 		});
-		const offlineLoad = await loadRuntimeManifest(paths, { applyContext });
-		if (!("manifest" in offlineLoad)) throw new Error(JSON.stringify(offlineLoad));
+		const offlineBase = await loadRuntimeManifest(paths, { applyContext });
+		if (!("manifest" in offlineBase)) throw new Error(JSON.stringify(offlineBase));
+		const offlineLoad = applyRuntimeBundleChannelsToManifestLoad(offlineBase);
 		expect(offlineLoad.source).toBe("last-good-cache");
 		expect(offlineLoad.offline).toBe(true);
 		expect(offlineLoad.manifest.generation).toBe(2);
@@ -1753,11 +1765,17 @@ exit 0
 		const committedManifest = z
 			.record(z.string(), z.unknown())
 			.parse(JSON.parse(manifestCacheText));
+		const committedWireManifest = z
+			.record(z.string(), z.unknown())
+			.parse(committedManifest.manifest);
 		writeFileSync(
 			paths.manifestLastGood,
 			`${JSON.stringify({
 				...committedManifest,
-				generation: onlineLoad.manifest.generation + 1,
+				manifest: {
+					...committedWireManifest,
+					generation: onlineLoad.manifest.generation + 1,
+				},
 			})}\n`,
 		);
 		const manifestOnlyCrashLoad = await loadRuntimeManifest(paths, { applyContext });
@@ -1807,7 +1825,7 @@ exit 0
 		const missingLoad = await loadRuntimeManifest(paths, { applyContext });
 		expect("errors" in missingLoad).toBe(true);
 		if (!("errors" in missingLoad)) throw new Error("expected missing cache failure");
-		expect(missingLoad.errors.join("\n")).toContain("cached secret values are missing");
+		expect(missingLoad.errors.join("\n")).toContain(`runtime bundle is missing ${agentRef}`);
 
 		const staleSecrets = {
 			...cachedSecrets,
@@ -1838,8 +1856,8 @@ exit 0
 					"123456789:telegram-agent-rotated",
 			},
 		};
-		const before = applyRuntimeBundleChannelsToManifestLoad(normalizeHostedRuntimeBundleV2(raw));
-		const after = applyRuntimeBundleChannelsToManifestLoad(normalizeHostedRuntimeBundleV2(rotated));
+		const before = applyRuntimeBundleChannelsToManifestLoad(parseHostedBundle(raw));
+		const after = applyRuntimeBundleChannelsToManifestLoad(parseHostedBundle(rotated));
 
 		expect(after.manifest.generation).toBe(before.manifest.generation);
 		expect(after.sourceRevision).not.toBe(before.sourceRevision);

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -15,7 +15,7 @@ import { dirname, isAbsolute, join } from "node:path";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { ensureDirectoryWithinTrustedRoot } from "../lib/trusted-directory";
 import { applyEgressTransparentRuntimeEnv } from "./egress-env";
-import { HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION, type RuntimeManifest } from "./manifest-contract";
+import type { RuntimeManifest } from "./manifest-contract";
 import {
 	runtimeCommandCurrentRevision,
 	runtimeCommandPath,
@@ -1172,7 +1172,6 @@ function writeRuntimeSystemdUserProgram(input: {
 	const isHermesDashboard = program.runtime === "hermes" && program.service === "dashboard";
 	const installerOnlySecretEnv =
 		descriptor?.runtime === "openclaw" &&
-		input.manifest.projection?.sourceBundleVersion === HOSTED_RUNTIME_BUNDLE_V2_SCHEMA_VERSION &&
 		input.manifest.openclawGatewayAuth?.activation.enabled === true
 			? (descriptor.installSecretEnv ?? [])
 			: [];

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -21,7 +21,7 @@ import {
 import { createConnection } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { applyRuntimeManifestLoad } from "../../src/commands/runtime";
 import {
 	resolveOpenClawSdkExport as resolveSdk,
@@ -35,10 +35,11 @@ import {
 	buildOpenClawHostedProviderPatch,
 	convergeRuntimeManifest,
 } from "../../src/runtime/manifest";
-import { manifestSchema, type RuntimeManifest } from "../../src/runtime/manifest-contract";
+import type { RuntimeManifest } from "../../src/runtime/manifest-contract";
 import type { HostedSkillSource } from "../../src/runtime/manifest-resources";
 import {
 	HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
+	hostedRuntimeBundleV2Schema,
 	type RuntimeManifestLoad,
 } from "../../src/runtime/manifest-source";
 import { CLAWDI_MANAGED_OPENCLAW_PROVIDER_PLUGIN_ID } from "../../src/runtime/openclaw-managed-provider-plugin";
@@ -57,6 +58,9 @@ const FILE_BROWSER_AMD64_SHA256 =
 	"8d51d1718d576d22e73e1f41a5194b451d152ddab0df97697cabe839cf59524e";
 const FILE_BROWSER_ARM64_SHA256 =
 	"3e18838ae33750a25da434dc6156a359968bf7935e01bdd884711f47f08ad92f";
+const HERMES_CONFIG_CLI_MOCK = fileURLToPath(
+	new URL("../../src/test-support/hermes-config-cli-mock.ts", import.meta.url),
+);
 
 const OPENCLAW_PROVIDER_AUTH_E2E_HELPER = `
 import { pathToFileURL } from "node:url";
@@ -887,6 +891,12 @@ test("propagates the real official OpenClaw installer failure and rolls back as 
 		generation: 1,
 		issuedAt: "2026-08-02T00:00:00.000Z",
 		workspaceRoot,
+		openclawGatewayAuth: {
+			mode: "token",
+			tokenRef: "secret://runtime/openclaw/gateway-token",
+			deviceAuthRequired: false,
+			activation: { enabled: true, capability: "openclaw-native-auth-v1" },
+		},
 		controlPlane: { apiUrl: "https://cloud-api.example.test" },
 		runtimes: {
 			openclaw: {
@@ -902,6 +912,9 @@ test("propagates the real official OpenClaw installer failure and rolls back as 
 		source: "remote-datasource",
 		sourcePath: "real-openclaw-systemd-fixture",
 		offline: false,
+		secretValues: {
+			"secret://runtime/openclaw/gateway-token": "fixture-gateway-token",
+		},
 		applyContext: {
 			kind: "context-file",
 			backend: "incus",
@@ -1123,7 +1136,6 @@ test("projects a large OpenClaw provider model-list reduction through the public
 				activation: { enabled: true, capability: "openclaw-native-auth-v1" },
 			},
 			projection: {
-				sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
 				providers: {
 					clawdi: {
 						type: "custom_openai_compatible",
@@ -1426,7 +1438,6 @@ test("persists and serves the managed token through the real official OpenClaw g
 		issuedAt: "2026-08-11T00:00:00.000Z",
 		workspaceRoot,
 		projection: {
-			sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
 			system: {
 				openclawControlUiAllowedOrigins: ["https://agent.example.test"],
 			},
@@ -1700,7 +1711,6 @@ http.createServer((request, response) => {
 		issuedAt: "2026-08-06T00:00:00.000Z",
 		workspaceRoot: runtimeHome,
 		projection: {
-			sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
 			system: {
 				openclawControlUiAllowedOrigins: ["https://app-v2-18789.example.test"],
 			},
@@ -1892,7 +1902,6 @@ http.createServer((request, response) => {
 		candidatesRoot,
 		activeCandidate,
 		activeBinary,
-		paths.manifestLastGood,
 	]) {
 		expect(statSync(path).uid).toBe(0);
 		expect(statSync(path).gid).toBe(0);
@@ -1906,8 +1915,6 @@ http.createServer((request, response) => {
 	expect(statSync(paths.fileBrowserStateRoot).uid).toBe(runtimeUid);
 	expect(statSync(paths.fileBrowserStateRoot).gid).toBe(runtimeGid);
 	expect(statSync(paths.fileBrowserStateRoot).mode & 0o777).toBe(0o700);
-	expect(statSync(paths.manifestLastGood).mode & 0o777).toBe(0o600);
-	expect(readFileSync(paths.manifestLastGood, "utf8")).toContain(`"secret": "${"s".repeat(43)}"`);
 	const cache = join(paths.fileBrowserStateRoot, "cache");
 	const database = join(paths.fileBrowserStateRoot, "filebrowser.db");
 	for (const path of [cache, database]) {
@@ -1917,11 +1924,7 @@ http.createServer((request, response) => {
 	expect(statSync(cache).mode & 0o777).toBe(0o700);
 	expect(statSync(database).mode & 0o777).toBe(0o600);
 
-	for (const path of [
-		paths.fileBrowserConfigRoot,
-		paths.fileBrowserConfig,
-		paths.manifestLastGood,
-	]) {
+	for (const path of [paths.fileBrowserConfigRoot, paths.fileBrowserConfig]) {
 		const denied = spawnSync("runuser", ["-u", "clawdi", "--", "test", "!", "-r", path]);
 		expect(denied.status).toBe(0);
 	}
@@ -1931,7 +1934,6 @@ http.createServer((request, response) => {
 		activeCandidate,
 		activeBinary,
 		paths.fileBrowserConfig,
-		paths.manifestLastGood,
 		join(paths.systemdSystemRoot, "clawdi-files.service"),
 	]) {
 		const denied = spawnSync("runuser", ["-u", "clawdi", "--", "test", "!", "-w", path]);
@@ -2095,6 +2097,9 @@ set -eu
 case "$*" in
   "--version")
     printf '%s\\n' 'Hermes Agent v0.19.1'
+    ;;
+  "config path"|"config get "*|"config set "*|"config unset "*)
+	exec '${process.execPath}' '${HERMES_CONFIG_CLI_MOCK}' "$@"
     ;;
   "gateway install --force")
     printf '%s\\n' install >> ${JSON.stringify(installLog)}
@@ -2365,6 +2370,9 @@ case "$*" in
   "--version")
     printf '%s\\n' 'Hermes Agent v0.19.1'
     ;;
+  "config path"|"config get "*|"config set "*|"config unset "*)
+	exec '${process.execPath}' '${HERMES_CONFIG_CLI_MOCK}' "$@"
+    ;;
   "gateway install --force")
     mkdir -p "$HOME/.config/systemd/user"
     cat > "$HOME/.config/systemd/user/hermes-gateway.service" <<'EOF'
@@ -2392,7 +2400,7 @@ EOF
     printf '%s\\n' "\${BEHAVIORAL_GUARD_MAIN:-missing}" > ${BEHAVIORAL_GUARD_MAIN_MARKER}
     exec /bin/sleep infinity
     ;;
-  "dashboard")
+  "dashboard"*)
     printf '%s\\n' "\${BEHAVIORAL_GUARD_DASHBOARD:-missing}" > ${BEHAVIORAL_GUARD_DASHBOARD_MARKER}
     exec /bin/sleep infinity
     ;;
@@ -2509,17 +2517,119 @@ function behavioralGuardManifest(input: {
 }
 
 function behavioralGuardLoad(manifest: RuntimeManifest): RuntimeManifestLoad {
+	const sourceRevision = createHash("sha256")
+		.update(`behavioral-e2e-generation-${manifest.generation}`)
+		.digest("hex");
+	const dashboardPasswordRef = "secret://runtime/hermes/dashboard-password";
+	const dashboardSessionRef = "secret://runtime/hermes/dashboard-session-secret";
+	const codexApiKeyRef = "secret://tool.codex.apiKey";
+	const secretValues = {
+		[dashboardPasswordRef]: "behavioral-e2e-dashboard-password",
+		[dashboardSessionRef]: "behavioral-e2e-dashboard-session-secret",
+		[codexApiKeyRef]: "behavioral-e2e-codex-api-key",
+	};
+	const sourceBundle = hostedRuntimeBundleV2Schema.parse({
+		schemaVersion: "clawdi.hosted-runtime.bundle.v2",
+		sourceRevision,
+		manifest: {
+			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+			runtime: "hermes",
+			deploymentId: manifest.deploymentId,
+			environmentId: manifest.environmentId,
+			instanceId: manifest.instanceId,
+			generation: manifest.generation,
+			issuedAt: manifest.issuedAt,
+			locale: { language: "en", timezone: "UTC" },
+			system: {
+				hermesDashboardAuth: {
+					mode: "password",
+					provider: "basic",
+					username: "admin",
+					passwordSecretRef: dashboardPasswordRef,
+					sessionSecretRef: dashboardSessionRef,
+					sessionTtlSeconds: 43_200,
+					publicUrl: "https://agent.example.test/hermes",
+					activation: { enabled: true, capability: "hermes-basic-auth-v1" },
+				},
+			},
+			controlPlane: { cloudApiUrl: manifest.controlPlane.apiUrl },
+			clawdiCli: {
+				source: "npm:clawdi",
+				packageSpec: `clawdi@${getCliVersion()}`,
+				registry: "https://registry.npmjs.org",
+			},
+			runtimes: {
+				hermes: {
+					enabled: true,
+					providerMode: "unmanaged",
+					provider_ids: [],
+					install: { source: "official" },
+					run: { args: ["gateway", "run"] },
+					services: {
+						dashboard: {
+							args: ["dashboard", "--host", "0.0.0.0", "--port", "9119", "--no-open"],
+						},
+					},
+				},
+			},
+			providers: {},
+			terminalTooling: {
+				codex: {
+					enabled: true,
+					provider_id: "clawdi-terminal",
+					primary_model: { provider_id: "clawdi-terminal", model: "gpt-test" },
+					provider: {
+						kind: "openai-compatible",
+						type: "custom_openai_compatible",
+						baseUrl: "https://provider.example.test/v1",
+						apiMode: "openai_responses",
+						managed_by: "clawdi",
+						runtimeEnvName: "CLAWDI_AI_API_KEY",
+						apiKeySecretRef: codexApiKeyRef,
+					},
+				},
+			},
+			liveSync: { enabled: false, agents: [] },
+			...(manifest.projection?.skills ? { skills: manifest.projection.skills } : {}),
+			recovery: { cacheManifest: true, allowOfflineBoot: true },
+		},
+		channelBindings: [],
+		secretValues,
+	}).sourceBundle;
+	const hermes = manifest.runtimes.hermes;
+	const dashboard = hermes?.services?.dashboard;
+	if (!hermes?.run || !dashboard) throw new Error("behavioral guard Hermes runtime is incomplete");
 	return {
-		manifest,
+		manifest: {
+			...manifest,
+			runtimes: {
+				hermes: {
+					...hermes,
+					services: {
+						dashboard: {
+							...dashboard,
+							secretEnv: {
+								BEHAVIORAL_GUARD_DASHBOARD_PASSWORD: dashboardPasswordRef,
+								BEHAVIORAL_GUARD_DASHBOARD_SESSION: dashboardSessionRef,
+								BEHAVIORAL_GUARD_CODEX_API_KEY: codexApiKeyRef,
+							},
+						},
+					},
+				},
+			},
+		},
+		sourceBundle,
 		source: "remote-datasource",
 		sourcePath: `behavioral-e2e-generation-${manifest.generation}`,
 		offline: false,
+		secretValues,
+		sourceRevision,
 		applyContext: {
 			kind: "context-file",
 			backend: "incus",
 			identity: {
 				generation: manifest.generation,
-				manifestETag: `"behavioral-e2e-generation-${manifest.generation}"`,
+				manifestETag: `"sha256:${sourceRevision}"`,
 				applyReceiptId: `behavioral-e2e-receipt-${manifest.generation}`,
 				bootNonce: `behavioral-e2e-boot-nonce-${manifest.generation}`,
 			},
@@ -2597,7 +2707,9 @@ function behavioralGuardObservableState(
 		),
 		environmentFiles: directoryFileDigests(paths.systemdEnvRoot),
 		skillTree: filesystemTreeIdentity(skillRoot),
-		lastGood: manifestSchema.parse(JSON.parse(readFileSync(paths.manifestLastGood, "utf8"))),
+		lastGood: hostedRuntimeBundleV2Schema.parse(
+			JSON.parse(readFileSync(paths.manifestLastGood, "utf8")),
+		).sourceBundle.manifest,
 		appliedState: stableBehavioralGuardAppliedState(paths),
 		processMarkers: {
 			gateway: readFileSync(BEHAVIORAL_GUARD_MAIN_MARKER, "utf8"),
@@ -2694,7 +2806,8 @@ test("replays last-good declarative state after a failed candidate and advances 
 		expect([...repaired.installErrors, ...repaired.resourceProjectionErrors]).toEqual([]);
 		expect(readRuntimeAppliedState(paths)?.generation).toBe(3);
 		expect(
-			manifestSchema.parse(JSON.parse(readFileSync(paths.manifestLastGood, "utf8"))).generation,
+			hostedRuntimeBundleV2Schema.parse(JSON.parse(readFileSync(paths.manifestLastGood, "utf8")))
+				.manifest.generation,
 		).toBe(3);
 		expect(readFileSync(join(skillRoot, "SKILL.md"), "utf8")).toBe("generation three\n");
 		expect(
@@ -2844,7 +2957,8 @@ exec /usr/bin/systemctl "$@"
 		);
 		expect(readRuntimeAppliedState(paths)?.generation).toBe(2);
 		expect(
-			manifestSchema.parse(JSON.parse(readFileSync(paths.manifestLastGood, "utf8"))).generation,
+			hostedRuntimeBundleV2Schema.parse(JSON.parse(readFileSync(paths.manifestLastGood, "utf8")))
+				.manifest.generation,
 		).toBe(2);
 	} finally {
 		if (child) {

--- a/packages/cli/tests/egress-handoff-access-contract.test.ts
+++ b/packages/cli/tests/egress-handoff-access-contract.test.ts
@@ -15,7 +15,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { convergeRuntimeManifest } from "../src/runtime/manifest";
-import { normalizeHostedRuntimeBundleV2 } from "../src/runtime/manifest-source";
+import { parseHostedRuntimeBundleV2 } from "../src/runtime/manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "../src/runtime/paths";
 import { ensureRuntimeStateDirs } from "../src/runtime/state";
 
@@ -266,7 +266,7 @@ esac
 			"secret://tool.codex.apiKey": "handoff-codex-key",
 			[HANDOFF_TEST_SECRET_REF]: "handoff-sidecar-secret",
 		};
-		const load = normalizeHostedRuntimeBundleV2(fixture);
+		const load = parseHostedRuntimeBundleV2(fixture, "test://egress-handoff-access");
 		load.applyContext = {
 			kind: "context-file",
 			backend: "incus",

--- a/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/project.e2e.ts
+++ b/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/project.e2e.ts
@@ -19,7 +19,7 @@ test("projects and reconciles the real managed WhatsApp runtime", () => {
 	const home = requiredEnvironment("E2E_HOME");
 	const scenarioPath = requiredEnvironment("E2E_SCENARIO");
 	const outputRoot = requiredEnvironment("E2E_OUTPUT");
-	process.env.CLAWDI_RUNTIME_MODE = "hosted";
+	process.env.CLAWDI_RUNTIME_HOME = home;
 	process.env.CLAWDI_SERVICE_STATE_DIR = join(outputRoot, "platform-state");
 	mkdirSync(process.env.CLAWDI_SERVICE_STATE_DIR, { recursive: true });
 	const scenario = recordValue(JSON.parse(readFileSync(scenarioPath, "utf8")));

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -76,16 +76,15 @@ import {
 	type RuntimeManifest,
 } from "../src/runtime/manifest";
 import {
-	hostedRuntimeManifestSchema,
-	manifestSchema,
+	hostedRuntimeBundleV2ManifestSchema,
 	officialInstallArgs,
 	validateUnmanagedProviderSecretValues,
 } from "../src/runtime/manifest-contract";
 import {
 	HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
-	hostedManifestToRuntimeManifest,
 	loadRemoteRuntimeManifest as loadRemoteRuntimeManifestWithContext,
 	manifestSecretRefs,
+	parseHostedRuntimeBundleV2,
 	type RuntimeBundleChannelBinding,
 	type RuntimeManifestLoad,
 } from "../src/runtime/manifest-source";
@@ -161,7 +160,7 @@ function explicitTestApplyContext(
 
 const hostedRuntimeManifestResponseSchema = z
 	.object({
-		manifest: hostedRuntimeManifestSchema,
+		manifest: hostedRuntimeBundleV2ManifestSchema,
 		secretValues: z.record(canonicalSecretRefSchema, z.string()).default({}),
 	})
 	.strict()
@@ -173,7 +172,7 @@ function normalizeHostedManifestFixture(value: unknown): {
 } {
 	const parsed = hostedRuntimeManifestResponseSchema.parse(value);
 	return {
-		manifest: hostedManifestToRuntimeManifest(parsed.manifest),
+		manifest: parsed.manifest,
 		secretValues: normalizeSecretValues(parsed.secretValues),
 	};
 }
@@ -870,30 +869,14 @@ function runtimeWatchLocaleManifest(
 	language: "en" | "fr" = "en",
 	timezone = "UTC",
 ): RuntimeManifest {
-	return {
-		schemaVersion: "clawdi.runtimeDesiredState.v1",
-		deploymentId: "dep_watch_locale",
-		environmentId: "env_watch_locale",
-		instanceId: "iid_watch_locale",
-		generation,
-		issuedAt: "2026-07-11T00:00:00Z",
-		locale: { language, timezone },
-		workspaceRoot: join(home, "clawdi"),
-		controlPlane: { apiUrl: "https://cloud-api.test" },
-		clawdiCli: {
-			source: "npm:clawdi",
-			packageSpec: TEST_RUNNING_CLI_SPEC,
-			registry: "https://registry.npmjs.org",
+	const payload = hostedRuntimeWatchLocalePayload(home, generation, language, timezone);
+	return normalizeHostedManifestFixture({
+		manifest: payload.manifest,
+		secretValues: {
+			...TEST_HOSTED_CODEX_SECRET_VALUES,
+			...TEST_RUNTIME_SERVICE_SECRET_VALUES,
 		},
-		runtimes: {
-			openclaw: {
-				enabled: true,
-				run: hostedOpenClawRuntime().run,
-				services: {},
-			},
-		},
-		recovery: { cacheManifest: true, allowOfflineBoot: true },
-	};
+	}).manifest;
 }
 
 interface HostedRuntimeResponseFixture {
@@ -1140,34 +1123,6 @@ function hostedCliManifestResponse(
 			},
 		},
 		secretValues: TEST_HOSTED_CODEX_SECRET_VALUES,
-	};
-}
-
-function genericCliDesiredState(packageSpec: string): RuntimeManifest {
-	return {
-		schemaVersion: "clawdi.runtimeDesiredState.v1",
-		deploymentId: "dep_generic_cli_update",
-		environmentId: "env_generic_cli_update",
-		instanceId: "iid_generic_cli_update",
-		generation: 1,
-		issuedAt: "2026-07-12T00:00:00Z",
-		controlPlane: { apiUrl: "https://cloud-api.test" },
-		clawdiCli: {
-			source: "npm:clawdi",
-			packageSpec,
-			registry: "https://registry.npmjs.org",
-		},
-		runtimes: { openclaw: { enabled: true } },
-		recovery: {},
-	};
-}
-
-function cachedHostedCliDesiredState(home: string, packageSpec: string): RuntimeManifest {
-	return {
-		...genericCliDesiredState(packageSpec),
-		workspaceRoot: join(home, "clawdi"),
-		runtimes: { openclaw: { enabled: false } },
-		recovery: { cacheManifest: true, allowOfflineBoot: true },
 	};
 }
 
@@ -1492,12 +1447,25 @@ function seedRuntimeWatchLocaleBaseline(home: string, state: string, run: string
 	);
 	writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 	const paths = getRuntimePaths();
+	seedMitmproxyCache(paths);
+	const payload = hostedRuntimeWatchLocalePayload(home, 1, "en", "UTC");
+	const sourceRevision = testBundleEtag("manifest-locale-1").slice(8, -1);
 	const load: RuntimeManifestLoad = {
 		manifest: runtimeWatchLocaleManifest(home, 1),
+		sourceBundle: {
+			schemaVersion: "clawdi.hosted-runtime.bundle.v2",
+			sourceRevision,
+			manifest: payload.manifest,
+			channelBindings: [],
+			secretValues: {},
+		},
+		sourceRevision,
+		channelBindings: [],
 		source: "remote-datasource",
 		sourcePath: "https://runtime.test/v1/runtime/manifest",
 		offline: false,
 		secretValues: {
+			...TEST_HOSTED_CODEX_SECRET_VALUES,
 			"secret://clawdi/auth-token":
 				TEST_RUNTIME_SERVICE_SECRET_VALUES["secret://clawdi/auth-token"],
 			"secret://runtime/openclaw/gateway-token":
@@ -1640,78 +1608,65 @@ function hostedOAuthRuntimeLoad(input: {
 	const secretRef = `secret://provider.${providerId}.oauthProfile`;
 	const runtime =
 		input.runtime === "hermes"
-			? {
-					...hostedHermesRuntime({
-						provider_ids: [providerId],
-						primary_model: { provider_id: providerId, model: "gpt-5.2-codex" },
-					}),
-					install: {
-						authority: "official" as const,
-						method: "official-installer" as const,
-						url: "https://hermes-agent.nousresearch.com/install.sh",
-						home: input.home,
-						args: ["--skip-setup", "--skip-browser", "--non-interactive"],
-					},
-				}
-			: {
-					...hostedOpenClawRuntime({
-						provider_ids: [providerId],
-						primary_model: { provider_id: providerId, model: "gpt-5.2-codex" },
-					}),
-					install: {
-						authority: "official" as const,
-						method: "official-installer" as const,
-						url: "https://openclaw.ai/install-cli.sh",
-						home: input.home,
-						args: ["--json", "--no-onboard"],
-					},
-				};
-	return {
-		source: "remote-datasource",
-		sourcePath: "https://runtime-source.test/desired-state",
-		offline: false,
-		secretValues: {
-			[secretRef]: hostedOAuthEnvelope(input.accessToken, input.refreshToken),
-		},
+			? hostedHermesRuntime({
+					provider_ids: [providerId],
+					primary_model: { provider_id: providerId, model: "gpt-5.2-codex" },
+				})
+			: hostedOpenClawRuntime({
+					provider_ids: [providerId],
+					primary_model: { provider_id: providerId, model: "gpt-5.2-codex" },
+				});
+	const normalized = normalizeHostedManifestFixture({
 		manifest: {
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
+			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+			runtime: input.runtime,
 			deploymentId: "dep_hosted_oauth",
 			environmentId: "env_hosted_oauth",
+			...hostedRequiredState(),
+			providers: {
+				[providerId]: {
+					kind: "openai-compatible",
+					type: "openai",
+					baseUrl: "https://api.openai.com/v1",
+					models: [{ id: "gpt-5.2-codex" }],
+					apiMode: "openai_responses",
+					managed_by: "user",
+					auth: {
+						type: "agent_profile",
+						tool: "codex",
+						profile: "default",
+						credentialSecretRef: secretRef,
+						credentialRevision: input.credentialRevision,
+					},
+				},
+			},
 			instanceId: "iid_hosted_oauth",
 			generation: input.generation,
 			issuedAt: "2026-07-31T00:00:00Z",
-			workspaceRoot: join(input.home, "clawdi"),
-			controlPlane: { apiUrl: "https://cloud-api.test" },
-			runtimes: { [input.runtime]: runtime },
-			projection: {
-				sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
-				system:
-					input.runtime === "hermes"
-						? hostedHermesSystemFixture(input.home)
-						: hostedSystemFixture(input.home),
-				providers: {
-					[providerId]: {
-						kind: "openai-compatible",
-						type: "openai",
-						baseUrl: "https://api.openai.com/v1",
-						model: "gpt-5.2-codex",
-						models: [{ id: "gpt-5.2-codex" }],
-						apiMode: "openai_responses",
-						managed_by: "user",
-						auth: {
-							type: "agent_profile",
-							tool: "codex",
-							profile: "default",
-							credentialSecretRef: secretRef,
-							credentialRevision: input.credentialRevision,
-						},
-					},
-				},
-				terminalTooling: TEST_HOSTED_CODEX_TERMINAL_TOOLING,
+			locale: TEST_HOSTED_LOCALE,
+			system:
+				input.runtime === "hermes"
+					? hostedHermesSystemFixture(input.home)
+					: hostedSystemFixture(input.home),
+			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+			clawdiCli: {
+				source: "npm:clawdi",
+				packageSpec: TEST_RUNNING_CLI_SPEC,
+				registry: "https://registry.npmjs.org",
 			},
-			egressProfiles: { profiles: [] },
-			recovery: { cacheManifest: true, allowOfflineBoot: true },
+			runtimes: { [input.runtime]: runtime },
 		},
+		secretValues: {
+			[secretRef]: hostedOAuthEnvelope(input.accessToken, input.refreshToken),
+			...TEST_HOSTED_CODEX_SECRET_VALUES,
+			...TEST_RUNTIME_SERVICE_SECRET_VALUES,
+		},
+	});
+	return {
+		...normalized,
+		source: "remote-datasource",
+		sourcePath: "https://runtime-source.test/desired-state",
+		offline: false,
 	};
 }
 
@@ -1883,6 +1838,7 @@ if [ "$*" = "agents list --json" ]; then
   printf '[{"id":"main","workspace":"${workspace}"}]\n'
   exit 0
 fi
+${fakeOpenClawConfigPatchCommand(configPath)}
 if [ "\${1:-} \${2:-}" = "skills install" ]; then
   source="\${3:?missing source}"; shift 3; slug=""
   while [ "$#" -gt 0 ]; do
@@ -2088,65 +2044,65 @@ export async function removeProviderAuthProfilesWithLock({ provider, agentDir })
 }
 
 function hostedHermesProviderLoad(home: string): RuntimeManifestLoad {
-	return {
-		source: "remote-datasource",
-		sourcePath: "https://runtime-source.test/desired-state",
-		offline: false,
-		secretValues: {
-			"secret://provider.hermes.apiKey": "sk-hermes-provider",
-		},
+	seedMitmproxyCache();
+	const normalized = normalizeHostedManifestFixture({
 		manifest: {
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
+			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+			runtime: "hermes",
 			deploymentId: "dep_hermes_provider",
 			environmentId: "env_hermes_provider",
+			...hostedRequiredState(),
+			providers: {
+				hermes: {
+					kind: "openai-compatible",
+					type: "custom_openai_compatible",
+					baseUrl: "https://hermes-provider.example.test/v1",
+					models: [
+						{
+							id: "kimi/kimi-for-coding",
+							context_window: 262144,
+							max_tokens: 32768,
+							input_modalities: ["text", "image"],
+							supports_vision: true,
+							supports_tools: true,
+							supports_reasoning: true,
+						},
+					],
+					apiMode: "openai_chat",
+					managed_by: "user",
+					runtimeEnvName: "HERMES_PROVIDER_API_KEY",
+					apiKeySecretRef: "secret://provider.hermes.apiKey",
+				},
+			},
 			instanceId: "iid_hermes_provider",
 			generation: 1,
 			issuedAt: "2026-06-22T00:00:00Z",
-			workspaceRoot: join(home, "clawdi"),
-			controlPlane: { apiUrl: "https://cloud-api.test" },
+			locale: TEST_HOSTED_LOCALE,
+			system: hostedHermesSystemFixture(home),
+			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+			clawdiCli: {
+				source: "npm:clawdi",
+				packageSpec: TEST_RUNNING_CLI_SPEC,
+				registry: "https://registry.npmjs.org",
+			},
 			runtimes: {
-				hermes: {
-					enabled: true,
-					providerMode: "configured",
+				hermes: hostedHermesRuntime({
 					provider_ids: ["hermes"],
 					primary_model: { provider_id: "hermes", model: "kimi/kimi-for-coding" },
-					install: {
-						authority: "official",
-						method: "official-installer",
-						url: "https://hermes-agent.nousresearch.com/install.sh",
-						home,
-						args: ["--skip-setup", "--skip-browser", "--non-interactive"],
-					},
-				},
+				}),
 			},
-			projection: {
-				sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
-				system: { home },
-				providers: {
-					hermes: {
-						kind: "openai-compatible",
-						baseUrl: "https://hermes-provider.example.test/v1",
-						model: "kimi/kimi-for-coding",
-						models: [
-							{
-								id: "kimi/kimi-for-coding",
-								context_window: 262144,
-								max_tokens: 32768,
-								input_modalities: ["text", "image"],
-								supports_vision: true,
-								supports_tools: true,
-								supports_reasoning: true,
-							},
-						],
-						apiMode: "openai_chat",
-						runtimeEnvName: "HERMES_PROVIDER_API_KEY",
-						apiKeySecretRef: "secret://provider.hermes.apiKey",
-					},
-				},
-			},
-			egressProfiles: { profiles: [] },
-			recovery: { cacheManifest: true, allowOfflineBoot: true },
 		},
+		secretValues: {
+			"secret://provider.hermes.apiKey": "sk-hermes-provider",
+			...TEST_HOSTED_CODEX_SECRET_VALUES,
+			...TEST_RUNTIME_SERVICE_SECRET_VALUES,
+		},
+	});
+	return {
+		...normalized,
+		source: "remote-datasource",
+		sourcePath: "https://runtime-source.test/desired-state",
+		offline: false,
 	};
 }
 
@@ -2178,42 +2134,6 @@ function hostedHermesDashboardCapabilityLoad(home: string): RuntimeManifestLoad 
 	return load;
 }
 
-const HOSTED_PROVIDER_SWITCH_PROVIDERS: Record<string, Record<string, unknown>> = {
-	"clawdi-managed": hostedProviderSwitchProvider("clawdi-managed", "clawdi"),
-	"clawdi-managed-v2": hostedProviderSwitchProvider("clawdi-managed-v2", "clawdi"),
-	"byok-a": hostedProviderSwitchProvider("byok-a", "user"),
-	"byok-b": hostedProviderSwitchProvider("byok-b", "user"),
-};
-
-function hostedProviderSwitchProvider(
-	providerId: string,
-	managedBy: "clawdi" | "user",
-): Record<string, unknown> {
-	const envPrefix = providerId.toUpperCase().replace(/[^A-Z0-9]/g, "_");
-	return {
-		kind: "openai-compatible",
-		type: "custom_openai_compatible",
-		baseUrl: `https://${providerId}.provider.example.test/v1`,
-		model: hostedProviderSwitchModel(providerId),
-		models: [
-			{
-				id: hostedProviderSwitchModel(providerId),
-				context_window: 128000,
-				max_tokens: 8192,
-				supports_tools: true,
-			},
-		],
-		apiMode: providerId === "clawdi-managed" ? "openai_responses" : "openai_chat",
-		managed_by: managedBy,
-		runtimeEnvName: managedBy === "clawdi" ? "CLAWDI_AI_API_KEY" : `BYOK_${envPrefix}_API_KEY`,
-		apiKeySecretRef: `secret://provider.${providerId}.apiKey`,
-	};
-}
-
-function hostedProviderSwitchModel(providerId: string): string {
-	return `${providerId}-model`;
-}
-
 function hostedCodexTerminalProvider(baseUrl: string): Record<string, unknown> {
 	return {
 		kind: "openai-compatible",
@@ -2226,99 +2146,11 @@ function hostedCodexTerminalProvider(baseUrl: string): Record<string, unknown> {
 	};
 }
 
-function hostedProviderSwitchLoad(
-	home: string,
-	selectedProviderId: string,
-	generation: number,
-): RuntimeManifestLoad {
-	const codexProvider = hostedCodexTerminalProvider(
-		"https://clawdi-managed.provider.example.test/v1",
-	);
-	const terminalTooling = {
-		codex: {
-			enabled: true,
-			provider_id: "clawdi-managed",
-			primary_model: {
-				provider_id: "clawdi-managed",
-				model: hostedProviderSwitchModel("clawdi-managed"),
-			},
-			provider: codexProvider,
-		},
-	};
-	return {
-		source: "remote-datasource",
-		sourcePath: "https://runtime-source.test/desired-state",
-		offline: false,
-		secretValues: {
-			...Object.fromEntries(
-				Object.keys(HOSTED_PROVIDER_SWITCH_PROVIDERS).map((providerId) => [
-					`secret://provider.${providerId}.apiKey`,
-					`sk-${providerId}`,
-				]),
-			),
-			...TEST_HOSTED_CODEX_SECRET_VALUES,
-		},
-		manifest: {
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
-			deploymentId: "dep_provider_switch",
-			environmentId: "env_provider_switch",
-			instanceId: "iid_provider_switch",
-			generation,
-			issuedAt: "2026-07-08T00:00:00Z",
-			workspaceRoot: join(home, "clawdi"),
-			controlPlane: { apiUrl: "https://cloud-api.test" },
-			runtimes: {
-				openclaw: {
-					...hostedOpenClawRuntime({
-						provider_ids: [selectedProviderId],
-						primary_model: {
-							provider_id: selectedProviderId,
-							model: hostedProviderSwitchModel(selectedProviderId),
-						},
-					}),
-					install: {
-						authority: "official",
-						method: "official-installer",
-						url: "https://openclaw.ai/install-cli.sh",
-						home,
-						args: ["--json", "--no-onboard"],
-					},
-				},
-				hermes: {
-					...hostedHermesRuntime({
-						provider_ids: [selectedProviderId],
-						primary_model: {
-							provider_id: selectedProviderId,
-							model: hostedProviderSwitchModel(selectedProviderId),
-						},
-					}),
-					install: {
-						authority: "official",
-						method: "official-installer",
-						url: "https://hermes-agent.nousresearch.com/install.sh",
-						home,
-						args: ["--skip-setup", "--skip-browser", "--non-interactive"],
-					},
-				},
-			},
-			projection: {
-				sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
-				system: { home, workspace: join(home, "clawdi") },
-				providers: HOSTED_PROVIDER_SWITCH_PROVIDERS,
-				terminalTooling,
-			},
-			egressProfiles: { profiles: [] },
-			recovery: { cacheManifest: true, allowOfflineBoot: true },
-		},
-	};
-}
-
 function hostedSingleProviderModeLoad(
 	home: string,
 	runtimeName: "openclaw" | "hermes",
 	providerMode: "configured" | "unmanaged",
 	generation: number,
-	options: { hostedV2?: boolean } = {},
 ): RuntimeManifestLoad {
 	const configuredRuntime =
 		runtimeName === "openclaw"
@@ -2337,29 +2169,13 @@ function hostedSingleProviderModeLoad(
 		providerMode === "configured"
 			? configuredRuntime
 			: { ...runtimeWithoutPrimaryModel, providerMode: "unmanaged" as const, provider_ids: [] };
-	const install =
-		runtimeName === "openclaw"
-			? {
-					authority: "official" as const,
-					method: "official-installer" as const,
-					url: "https://openclaw.ai/install-cli.sh",
-					home,
-					args: ["--json", "--no-onboard"],
-				}
-			: {
-					authority: "official" as const,
-					method: "official-installer" as const,
-					url: "https://hermes-agent.nousresearch.com/install.sh",
-					home,
-					args: ["--skip-setup", "--skip-browser", "--non-interactive"],
-				};
 	const providers =
 		providerMode === "configured"
 			? {
 					"clawdi-managed": {
 						kind: "openai-compatible",
+						type: "custom_openai_compatible",
 						baseUrl: "https://managed.provider.example.test/v1",
-						model: "gpt-5.5",
 						models: [{ id: "gpt-5.5" }],
 						apiMode: "openai_responses",
 						managed_by: "clawdi",
@@ -2379,59 +2195,48 @@ function hostedSingleProviderModeLoad(
 			provider: codexProvider,
 		},
 	};
-	return {
-		source: "remote-datasource",
-		sourcePath: "https://runtime-source.test/desired-state",
-		offline: false,
+	seedMitmproxyCache();
+	const normalized = normalizeHostedManifestFixture({
+		manifest: {
+			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+			runtime: runtimeName,
+			deploymentId: "dep_provider_mode",
+			environmentId: "env_provider_mode",
+			...hostedRequiredState(),
+			providers,
+			terminalTooling,
+			instanceId: "iid_provider_mode",
+			generation,
+			issuedAt: "2026-07-14T00:00:00Z",
+			locale: TEST_HOSTED_LOCALE,
+			system:
+				runtimeName === "openclaw" ? hostedSystemFixture(home) : hostedHermesSystemFixture(home),
+			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+			clawdiCli: {
+				source: "npm:clawdi",
+				packageSpec: TEST_RUNNING_CLI_SPEC,
+				registry: "https://registry.npmjs.org",
+			},
+			runtimes: { [runtimeName]: runtime },
+		},
 		secretValues: {
 			...(providerMode === "configured"
 				? { "secret://provider.clawdi-managed.apiKey": "sk-managed-provider" }
 				: {}),
-			...(options.hostedV2 && runtimeName === "openclaw"
-				? { "secret://runtime/openclaw/gateway-token": "managed-gateway-token" }
-				: {}),
 			...TEST_HOSTED_CODEX_SECRET_VALUES,
+			...TEST_RUNTIME_SERVICE_SECRET_VALUES,
 		},
-		manifest: {
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
-			deploymentId: "dep_provider_mode",
-			environmentId: "env_provider_mode",
-			instanceId: "iid_provider_mode",
-			generation,
-			issuedAt: "2026-07-14T00:00:00Z",
-			workspaceRoot: join(home, "clawdi"),
-			runtime: runtimeName,
-			controlPlane: { apiUrl: "https://cloud-api.test" },
-			openclawGatewayAuth:
-				options.hostedV2 && runtimeName === "openclaw"
-					? {
-							mode: "token",
-							tokenRef: "secret://runtime/openclaw/gateway-token",
-							deviceAuthRequired: false,
-							activation: {
-								enabled: true,
-								capability: "openclaw-native-auth-v1",
-							},
-						}
-					: undefined,
-			runtimes: { [runtimeName]: { ...runtime, install } },
-			projection: {
-				sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
-				...(options.hostedV2 ? { sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2" } : {}),
-				system: { home, workspace: join(home, "clawdi") },
-				providers,
-				terminalTooling,
-			},
-			egressProfiles: hostedManifestEgressProfiles({ providers, terminalTooling }),
-			recovery: { cacheManifest: true, allowOfflineBoot: true },
-		},
+	});
+	return {
+		...normalized,
+		source: "remote-datasource",
+		sourcePath: "https://runtime-source.test/desired-state",
+		offline: false,
 	};
 }
 
 function hostedManagedOpenClawV2Load(home: string, generation: number): RuntimeManifestLoad {
-	const load = hostedSingleProviderModeLoad(home, "openclaw", "configured", generation, {
-		hostedV2: true,
-	});
+	const load = hostedSingleProviderModeLoad(home, "openclaw", "configured", generation);
 	const providerId = "clawdi-v2-deployment-42";
 	const providers = {
 		[providerId]: {
@@ -2476,7 +2281,7 @@ function writeTestRuntimeAppliedState(
 		input.sourceRevision ??
 		load.sourceRevision ??
 		runtimeContentSha256({
-			manifest: load.sourceManifest ?? load.manifest,
+			manifest: load.sourceBundle ?? load.manifest,
 			channelBindings: load.channelBindings ?? [],
 			secretValues: load.secretValues ?? {},
 		});
@@ -2503,7 +2308,7 @@ function writeTestRuntimeAppliedState(
 			contentIdentity: {
 				sourcePath: load.sourcePath,
 				sha256: runtimeContentSha256({
-					manifest: load.manifest,
+					manifest: load.sourceBundle ?? load.manifest,
 					secretValues: load.secretValues ?? {},
 				}),
 			},
@@ -2562,34 +2367,6 @@ function setRuntimeApplyGeneration(
 			bootNonce: `test-boot-nonce-${String(generation).padStart(6, "0")}`,
 		},
 		context,
-	);
-}
-
-function writeOfflineStrictAppliedState(
-	paths: RuntimePaths,
-	manifest: RuntimeManifest,
-	contentSha256: string,
-): void {
-	mkdirSync(paths.serviceStateRoot, { recursive: true });
-	writeRuntimeAppliedState(
-		{
-			schemaVersion: "clawdi.runtimeAppliedState.v2",
-			appliedAt: "2026-07-16T00:01:00.000Z",
-			instanceId: manifest.instanceId,
-			etag: testBundleEtag("transport-etag-offline"),
-			sourceRevision: "a".repeat(64),
-			generation: manifest.generation,
-			manifestETag: OFFLINE_RUNTIME_APPLY_IDENTITY.manifestETag,
-			applyReceiptId: OFFLINE_RUNTIME_APPLY_IDENTITY.applyReceiptId,
-			bootNonce: OFFLINE_RUNTIME_APPLY_IDENTITY.bootNonce,
-			contentIdentity: {
-				sourcePath: "https://runtime.test/v1/runtime/manifest",
-				sha256: contentSha256,
-			},
-			providerIds: [],
-			projectedProviderIds: {},
-		},
-		paths,
 	);
 }
 
@@ -2824,7 +2601,7 @@ describe("runtime applied content identity", () => {
 		};
 		const load = (secret: string): RuntimeManifestLoad => ({
 			manifest,
-			sourceManifest: manifest,
+			sourceBundle: manifest,
 			secretValues: { "secret://provider.default.apiKey": secret },
 			source: "remote-datasource",
 			sourcePath: "inline-secret-identity",
@@ -2850,7 +2627,7 @@ describe("runtime manifest datasource", () => {
 		expect(parsed.success).toBe(false);
 	});
 
-	it("does not load cached secrets for a disabled runtime", async () => {
+	it("invalidates 0.13.92 and 0.14.14 normalized last-good state offline", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -2877,6 +2654,8 @@ describe("runtime manifest datasource", () => {
 				},
 				runtimes: { openclaw: { enabled: false } },
 				projection: {
+					sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
+					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
 					providers: {
 						default: {
 							kind: "openai-compatible",
@@ -2894,303 +2673,11 @@ describe("runtime manifest datasource", () => {
 		);
 
 		const loaded = await loadRuntimeManifest(paths);
-		expect("manifest" in loaded).toBe(true);
-		if (!("manifest" in loaded)) throw new Error("expected offline manifest load success");
-		expect(loaded.source).toBe("last-good-cache");
-		expect(loaded.offline).toBe(true);
-		expect(loaded.secretValues).toBeUndefined();
-	});
-
-	it("reports degraded-offline apply and boot state after remote fetch failure", async () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
-		const paths = getRuntimePaths();
-		mkdirSync(paths.cacheRoot, { recursive: true });
-		writeFileSync(
-			paths.manifestLastGood,
-			JSON.stringify(cachedHostedCliDesiredState(home, TEST_RUNNING_CLI_SPEC)),
-		);
-		const { restore } = mockFetch([
-			{
-				method: "GET",
-				path: "/v1/runtime/manifest",
-				response: () => {
-					throw new Error("control plane unavailable");
-				},
-			},
-		]);
-
-		try {
-			const loaded = await loadRuntimeManifest(paths);
-			if (!("manifest" in loaded)) {
-				throw new Error(`expected last-good manifest: ${loaded.errors.join("; ")}`);
-			}
-			const convergence = convergeRuntimeManifest(loaded, paths, { cacheLastGood: false });
-			const boot = buildRuntimeBootStatus(
-				{
-					mode: convergence.mode,
-					status: "ok",
-					stage: "final",
-					bootId: "boot-degraded-offline",
-					runtimeMode: "hosted",
-					activeGeneration: convergence.manifest.generation,
-					instanceId: convergence.manifest.instanceId,
-					enabledRuntimes: convergence.enabledRuntimes,
-					errors: [],
-					exitCode: 0,
-					datasource: "RuntimeSource",
-					hostPolicy: { source: "builtin", exists: true, valid: true },
-				},
-				paths,
-			);
-
-			expect(loaded.source).toBe("last-good-cache");
-			expect(loaded.offline).toBe(true);
-			expect(convergence.mode).toBe("degraded-offline");
-			expect(boot.mode).toBe("degraded-offline");
-		} finally {
-			restore();
-		}
-	});
-
-	it("gates strict-v2 offline cache on the current, durable, and migration identity states", async () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		const paths = getRuntimePaths();
-		mkdirSync(paths.cacheRoot, { recursive: true });
-		const manifest: RuntimeManifest = {
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
-			deploymentId: "dep_offline_identity",
-			environmentId: "env_offline_identity",
-			instanceId: "iid_offline_identity",
-			generation: 3,
-			issuedAt: "2026-07-16T00:00:00Z",
-			controlPlane: { apiUrl: "https://cloud-api.test" },
-			clawdiCli: {
-				source: "npm:clawdi",
-				packageSpec: TEST_RUNNING_CLI_SPEC,
-				registry: "https://registry.npmjs.org",
-			},
-			runtimes: { openclaw: { enabled: false } },
-			projection: { sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2" },
-			recovery: { cacheManifest: true, allowOfflineBoot: true },
-		};
-		writeFileSync(paths.manifestLastGood, JSON.stringify(manifest));
-		writeOfflineStrictAppliedState(
-			paths,
-			manifest,
-			runtimeContentSha256({
-				manifest: manifestSchema.parse(manifest),
-				secretValues: {},
-			}),
-		);
-		writeCanonicalApplyContext(OFFLINE_RUNTIME_APPLY_IDENTITY, CANONICAL_TEST_CONTEXT);
-		const loaded = await loadRuntimeManifest(paths);
-		if (!("manifest" in loaded)) {
-			throw new Error(`expected offline manifest load success: ${loaded.errors.join("; ")}`);
-		}
-		expect(loaded.applyContext?.identity).toEqual(OFFLINE_RUNTIME_APPLY_IDENTITY);
-
-		writeCanonicalApplyContext(
-			{
-				...OFFLINE_RUNTIME_APPLY_IDENTITY,
-				applyReceiptId: "apply-receipt-offline-0002",
-			},
-			CANONICAL_TEST_CONTEXT,
-		);
-		const mismatched = await loadRuntimeManifest(paths);
-		expect("errors" in mismatched).toBe(true);
-		if (!("errors" in mismatched)) throw new Error("expected offline identity mismatch");
-		expect(mismatched.errors).toContain(
-			"cached strict-v2 apply identity does not match the current runtime apply identity; refusing offline boot",
-		);
-
-		const applied = readRuntimeAppliedState(paths);
-		if (!applied) throw new Error("expected durable offline applied state");
-		const {
-			manifestETag: _manifestETag,
-			applyReceiptId: _applyReceiptId,
-			bootNonce: _bootNonce,
-			...legacyApplied
-		} = applied;
-		writeRuntimeAppliedState(legacyApplied, paths);
-		writeCanonicalApplyContext(OFFLINE_RUNTIME_APPLY_IDENTITY);
-		const firstIdentityFileMigration = await loadRuntimeManifest(paths);
-		expect("errors" in firstIdentityFileMigration).toBe(true);
-		if (!("errors" in firstIdentityFileMigration)) {
-			throw new Error("expected first identity-file migration to fail closed");
-		}
-		expect(firstIdentityFileMigration.errors).toContain(
-			"cached strict-v2 apply identity does not match the current runtime apply identity; refusing offline boot",
-		);
-	});
-
-	it("refuses strict-v2 offline identity restoration when cached manifest content changed", async () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		const paths = getRuntimePaths();
-		mkdirSync(paths.cacheRoot, { recursive: true });
-		const manifest: RuntimeManifest = {
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
-			deploymentId: "dep_offline_content_mismatch",
-			environmentId: "env_offline_content_mismatch",
-			instanceId: "iid_offline_content_mismatch",
-			generation: 3,
-			issuedAt: "2026-07-16T00:00:00Z",
-			controlPlane: { apiUrl: "https://cloud-api.test" },
-			clawdiCli: {
-				source: "npm:clawdi",
-				packageSpec: TEST_RUNNING_CLI_SPEC,
-				registry: "https://registry.npmjs.org",
-			},
-			runtimes: { openclaw: { enabled: false } },
-			recovery: { cacheManifest: true, allowOfflineBoot: true },
-		};
-		writeFileSync(paths.manifestLastGood, JSON.stringify(manifest));
-		writeOfflineStrictAppliedState(
-			paths,
-			manifest,
-			runtimeContentSha256({
-				manifest: manifestSchema.parse({
-					...manifest,
-					issuedAt: "2026-07-15T00:00:00Z",
-				}),
-				secretValues: {},
-			}),
-		);
-		writeCanonicalApplyContext(OFFLINE_RUNTIME_APPLY_IDENTITY, CANONICAL_TEST_CONTEXT);
-
-		const loaded = await loadRuntimeManifest(paths);
 		expect("errors" in loaded).toBe(true);
-		if (!("errors" in loaded)) throw new Error("expected offline manifest mismatch failure");
+		if (!("errors" in loaded)) throw new Error("expected normalized cache invalidation");
 		expect(loaded.mode).toBe("repair");
-		expect(loaded.errors).toContain(
-			"cached manifest does not match the durable strict-v2 apply identity; refusing offline boot",
-		);
-	});
-
-	it("refuses strict-v2 offline identity restoration when cached secret content changed", async () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		const paths = getRuntimePaths();
-		mkdirSync(paths.cacheRoot, { recursive: true });
-		const manifest: RuntimeManifest = {
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
-			deploymentId: "dep_offline_secret_mismatch",
-			environmentId: "env_offline_secret_mismatch",
-			instanceId: "iid_offline_secret_mismatch",
-			generation: 3,
-			issuedAt: "2026-07-16T00:00:00Z",
-			controlPlane: { apiUrl: "https://cloud-api.test" },
-			clawdiCli: {
-				source: "npm:clawdi",
-				packageSpec: TEST_RUNNING_CLI_SPEC,
-				registry: "https://registry.npmjs.org",
-			},
-			runtimes: { openclaw: { enabled: false } },
-			projection: {
-				providers: {
-					default: {
-						kind: "openai-compatible",
-						baseUrl: "https://sub2api.test/v1",
-						apiKeySecretRef: "secret://provider.default.apiKey",
-					},
-				},
-			},
-			recovery: { cacheManifest: true, allowOfflineBoot: true },
-		};
-		writeFileSync(paths.manifestLastGood, JSON.stringify(manifest));
-		writeFileSync(
-			paths.managedSecretCacheFile,
-			JSON.stringify({ "secret://provider.default.apiKey": "sk-new-cached-value" }),
-		);
-		writeOfflineStrictAppliedState(
-			paths,
-			manifest,
-			runtimeContentSha256({
-				manifest: manifestSchema.parse(manifest),
-				secretValues: normalizeSecretValues({
-					"secret://provider.default.apiKey": "sk-original-applied-value",
-				}),
-			}),
-		);
-		writeCanonicalApplyContext(OFFLINE_RUNTIME_APPLY_IDENTITY, CANONICAL_TEST_CONTEXT);
-
-		const loaded = await loadRuntimeManifest(paths);
-		expect("errors" in loaded).toBe(true);
-		if (!("errors" in loaded)) throw new Error("expected offline secret mismatch failure");
-		expect(loaded.mode).toBe("repair");
-		expect(loaded.errors).toContain(
-			"cached manifest does not match the durable strict-v2 apply identity; refusing offline boot",
-		);
-	});
-
-	it("does not require an unselected provider secret for offline boot", async () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		const paths = getRuntimePaths();
-		mkdirSync(paths.cacheRoot, { recursive: true });
-		writeFileSync(
-			paths.manifestLastGood,
-			JSON.stringify({
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_cached_secret_missing",
-				environmentId: "env_cached_secret_missing",
-				instanceId: "iid_cached_secret_missing",
-				generation: 3,
-				issuedAt: "2026-06-06T00:00:00Z",
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				clawdiCli: {
-					source: "npm:clawdi",
-					packageSpec: TEST_RUNNING_CLI_SPEC,
-					registry: "https://registry.npmjs.org",
-				},
-				runtimes: { openclaw: { enabled: false } },
-				projection: {
-					providers: {
-						default: {
-							kind: "openai-compatible",
-							baseUrl: "https://sub2api.test/v1",
-							apiKeySecretRef: "secret://provider.default.apiKey",
-						},
-					},
-				},
-				recovery: { cacheManifest: true, allowOfflineBoot: true },
-			}),
-		);
-
-		const loaded = await loadRuntimeManifest(paths);
-		expect("manifest" in loaded).toBe(true);
-		if (!("manifest" in loaded)) throw new Error("expected offline manifest load success");
-		expect(loaded.source).toBe("last-good-cache");
-		expect(loaded.offline).toBe(true);
-		expect(loaded.secretValues).toBeUndefined();
+		expect(loaded.errors.join("\n")).toContain("could not read last-good runtime manifest");
+		expect(loaded.errors.join("\n")).not.toContain("sk-cached-provider");
 	});
 
 	it("fetches hosted-runtime manifests from a configured runtime source", async () => {
@@ -3363,33 +2850,6 @@ describe("runtime manifest datasource", () => {
 			} finally {
 				restore();
 			}
-		});
-	}
-
-	for (const packageSpec of [
-		"clawdi@latest",
-		"clawdi@agent-v2",
-		"clawdi@1.2.3+build.1",
-		"clawdi",
-	]) {
-		it(`rejects cached hosted state with ${packageSpec} and no hosted marker`, async () => {
-			const home = join(root, "home", "clawdi");
-			const state = join(root, "var", "lib", "clawdi");
-			process.env.HOME = home;
-			process.env.CLAWDI_RUNTIME_MODE = "hosted";
-			process.env.CLAWDI_SERVICE_STATE_DIR = state;
-			process.env.CLAWDI_RUN_DIR = join(root, "run", "clawdi");
-			const paths = getRuntimePaths();
-			mkdirSync(paths.cacheRoot, { recursive: true });
-			writeFileSync(
-				paths.manifestLastGood,
-				JSON.stringify(cachedHostedCliDesiredState(home, packageSpec)),
-			);
-
-			const loaded = await loadRuntimeManifest(paths);
-			expect("errors" in loaded).toBe(true);
-			if (!("errors" in loaded)) throw new Error("expected cached manifest rejection");
-			expect(loaded.errors.join("\n")).toContain("must be clawdi@<exact-semver>");
 		});
 	}
 
@@ -3881,7 +3341,6 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 					hermes: { enabled: false },
 				},
 				projection: {
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
 					system: {
 						...hostedSystemFixture(home),
 						home,
@@ -3915,12 +3374,17 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 			},
 			gateway: {
 				mode: "local",
+				port: 18789,
+				bind: "lan",
 				auth: {
 					mode: "token",
 					token: "gateway-token",
 				},
 				controlUi: {
 					allowedOrigins: ["https://app-v2-18789.k3s.example.test"],
+					basePath: "/",
+					dangerouslyAllowHostHeaderOriginFallback: false,
+					dangerouslyDisableDeviceAuth: true,
 				},
 			},
 		});
@@ -4315,9 +3779,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		};
 		configBeforeUnmanaged.auth.order.clawdi = ["clawdi:unmanaged"];
 		writeFileSync(openclawConfig, `${JSON.stringify(configBeforeUnmanaged, null, 2)}\n`);
-		const unmanagedLoad = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 3, {
-			hostedV2: true,
-		});
+		const unmanagedLoad = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 3);
 		unmanagedLoad.manifest.egressEngine = TEST_EGRESS_ENGINE_PIN;
 		const unmanaged = convergeRuntimeManifest(unmanagedLoad, paths);
 		expect(unmanaged.installErrors).toEqual([]);
@@ -4338,67 +3800,6 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		expect(
 			JSON.parse(readFileSync(secondaryStore, "utf8")).profiles["clawdi:unmanaged"],
 		).toMatchObject({ key: "preserve-without-managed-projection" });
-	});
-
-	it("writes Codex managed provider config from hosted runtime converge", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const codexHome = join(home, ".codex");
-		mkdirSync(codexHome, { recursive: true });
-		writeFileSync(join(codexHome, "config.toml"), '# stale Hosted config\nmodel = "stale"\n');
-		chmodSync(codexHome, 0o755);
-		chmodSync(join(codexHome, "config.toml"), 0o644);
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-
-		const wireResponse = hostedCliManifestResponse(home, TEST_RUNNING_CLI_SPEC);
-		const terminalTooling = expectRecord(wireResponse.manifest.terminalTooling, "terminal tooling");
-		const codex = expectRecord(terminalTooling.codex, "terminal Codex");
-		const wireProvider = expectRecord(codex.provider, "terminal Codex provider");
-		wireProvider.baseUrl = "https://codex-provider.example.test/v1";
-		const normalized = normalizeHostedManifestFixture(wireResponse);
-		const wireLoad: RuntimeManifestLoad = {
-			...normalized,
-			source: "remote-datasource",
-			sourcePath: "https://runtime-source.test/desired-state",
-			offline: false,
-			manifest: {
-				...normalized.manifest,
-				locale: undefined,
-				openclawGatewayAuth: undefined,
-				projection: { terminalTooling: normalized.manifest.projection?.terminalTooling },
-				runtimes: {
-					openclaw: { enabled: false },
-					hermes: { enabled: false },
-				},
-			},
-		};
-		const paths = getRuntimePaths();
-		seedMitmproxyCache(paths);
-		const convergence = convergeRuntimeManifest(wireLoad, paths);
-
-		expect(convergence.installErrors).toEqual([]);
-		expect(statSync(codexHome).mode & 0o777).toBe(0o700);
-		const configPath = join(codexHome, "config.toml");
-		expect(statSync(configPath).mode & 0o777).toBe(0o600);
-		expect(readFileSync(configPath, "utf-8")).toBe(
-			[
-				"# Generated by Clawdi hosted runtime. Do not put API keys in this file.",
-				'model_provider = "clawdi"',
-				"",
-				"[model_providers.clawdi]",
-				'name = "clawdi"',
-				'base_url = "https://codex-provider.example.test/v1"',
-				'env_key = "CLAWDI_AI_API_KEY"',
-				'wire_api = "responses"',
-				"",
-			].join("\n"),
-		);
-		expect(readFileSync(configPath, "utf-8")).not.toMatch(/^model\s*=|model_catalog_json|models/m);
-		expect(readFileSync(configPath, "utf-8")).not.toMatch(/managed/i);
 	});
 
 	it("preserves a healthy user-upgraded Hosted Codex package", () => {
@@ -4560,7 +3961,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 
 		try {
 			const convergence = convergeRuntimeManifest(
-				hostedProviderSwitchLoad(home, "clawdi-managed", 2),
+				hostedSingleProviderModeLoad(home, "openclaw", "configured", 2),
 				paths,
 			);
 
@@ -4575,161 +3976,6 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 			else process.env.PATH = previousPath;
 		}
 	});
-
-	it("keeps the Codex tool profile configured when runtime providers are user-owned", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-
-		const convergence = convergeRuntimeManifest(
-			{
-				source: "remote-datasource",
-				sourcePath: "https://runtime-source.test/desired-state",
-				offline: false,
-				manifest: {
-					schemaVersion: "clawdi.runtimeDesiredState.v1",
-					deploymentId: "dep_codex_byok_provider",
-					environmentId: "env_codex_byok_provider",
-					instanceId: "iid_codex_byok_provider",
-					generation: 1,
-					issuedAt: "2026-07-10T00:00:00Z",
-					workspaceRoot: join(home, "clawdi"),
-					controlPlane: { apiUrl: "https://cloud-api.test" },
-					runtimes: {
-						openclaw: { enabled: false },
-					},
-					projection: {
-						system: { home },
-						providers: {
-							default: {
-								kind: "openai-compatible",
-								baseUrl: "https://byok-provider.example.test/v1",
-								model: "gpt-5.5",
-								apiMode: "openai_responses",
-								managed_by: "user",
-								runtimeEnvName: "OPENAI_API_KEY",
-								apiKeySecretRef: "secret://provider.byok.apiKey",
-							},
-						},
-						terminalTooling: TEST_HOSTED_CODEX_TERMINAL_TOOLING,
-					},
-					egressProfiles: { profiles: [] },
-					recovery: { cacheManifest: true, allowOfflineBoot: true },
-				},
-			},
-			getRuntimePaths(),
-		);
-
-		expect(convergence.installErrors).toEqual([]);
-		expect(readFileSync(join(home, ".codex", "config.toml"), "utf8")).toContain(
-			'model_provider = "clawdi"',
-		);
-	});
-
-	it("reconciles hosted provider projections when the selected provider changes", () => {
-		const cases = [
-			{ id: "managed-to-byok", first: "clawdi-managed", second: "byok-a" },
-			{ id: "byok-to-managed", first: "byok-a", second: "clawdi-managed" },
-			{ id: "managed-to-managed", first: "clawdi-managed", second: "clawdi-managed-v2" },
-			{ id: "byok-to-byok", first: "byok-a", second: "byok-b" },
-		];
-		for (const providerCase of cases) {
-			const firstAgentProvider =
-				providerCase.first === "clawdi-managed-v2" ? "clawdi" : providerCase.first;
-			const secondAgentProvider =
-				providerCase.second === "clawdi-managed-v2" ? "clawdi" : providerCase.second;
-			const caseRoot = join(root, providerCase.id);
-			const home = join(caseRoot, "home", "clawdi");
-			const state = join(caseRoot, "var", "lib", "clawdi");
-			const run = join(caseRoot, "run", "clawdi");
-			const workspace = join(home, "clawdi");
-			const openclawBin = join(home, ".local", "bin", "openclaw");
-			const publicSdkConfig = writeOpenClawConfigMutationFixture(home, {
-				models: {
-					providers: {
-						"user-local": {
-							baseUrl: "http://127.0.0.1:11434/v1",
-							models: [{ id: "local-model" }],
-						},
-					},
-				},
-			});
-			mkdirSync(dirname(openclawBin), { recursive: true });
-			mkdirSync(join(home, ".hermes"), { recursive: true });
-			mkdirSync(workspace, { recursive: true });
-			writeFileSync(openclawBin, "#!/usr/bin/env bash\nexit 0\n");
-			chmodSync(openclawBin, 0o700);
-			writeHermesVersionBinary(home, "0.18.0");
-			writeFileSync(
-				join(home, ".hermes", "config.yaml"),
-				[
-					"providers:",
-					"  user-local:",
-					'    api: "http://127.0.0.1:11434/v1"',
-					'    custom_field: "keep-me"',
-					"",
-				].join("\n"),
-			);
-			process.env.HOME = home;
-			process.env.CLAWDI_RUNTIME_MODE = "hosted";
-			process.env.CLAWDI_SERVICE_STATE_DIR = state;
-			process.env.CLAWDI_RUN_DIR = run;
-			if (providerCase.id === "managed-to-managed") {
-				process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
-				process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_PROVIDER_AUTH_SDK =
-					writeFakeOpenClawProviderAuthSdk(
-						join(caseRoot, "provider-auth"),
-						join(caseRoot, "provider-auth-calls.log"),
-					);
-			}
-
-			const paths = getRuntimePaths();
-			const firstLoad = hostedProviderSwitchLoad(home, providerCase.first, 1);
-			const first = convergeRuntimeManifest(firstLoad, paths);
-			expect(first.installErrors).toEqual([]);
-			writeTestRuntimeAppliedState(paths, firstLoad, first, {
-				etag: `"${providerCase.id}-1"`,
-			});
-
-			const secondLoad = hostedProviderSwitchLoad(home, providerCase.second, 2);
-			const second = convergeRuntimeManifest(secondLoad, paths);
-			expect(second.installErrors).toEqual([]);
-			const openclawProviders = expectRecord(
-				expectRecord(
-					JSON.parse(readFileSync(publicSdkConfig.configPath, "utf8")).models,
-					"OpenClaw models config",
-				).providers,
-				"OpenClaw providers config",
-			);
-			expect(Object.keys(openclawProviders).sort()).toEqual(
-				["user-local", secondAgentProvider].sort(),
-			);
-			expect(openclawProviders[firstAgentProvider]).toBeUndefined();
-			expect(openclawProviders[secondAgentProvider]).toMatchObject({
-				baseUrl: `https://${providerCase.second}.provider.example.test/v1`,
-			});
-			expect(openclawProviders["user-local"]).toMatchObject({
-				baseUrl: "http://127.0.0.1:11434/v1",
-			});
-
-			const hermesConfig = readHermesConfigYaml(home);
-			const hermesProviders = expectRecord(hermesConfig.providers, "Hermes providers config");
-			expect(Object.keys(hermesProviders).sort()).toEqual(
-				["user-local", secondAgentProvider].sort(),
-			);
-			expect(hermesProviders[firstAgentProvider]).toBeUndefined();
-			expect(hermesProviders[secondAgentProvider]).toMatchObject({
-				api: `https://${providerCase.second}.provider.example.test/v1`,
-			});
-			expect(hermesProviders["user-local"]).toMatchObject({
-				custom_field: "keep-me",
-			});
-		}
-	}, 30_000);
 
 	it.each(["openclaw", "hermes"] as const)(
 		"converges %s in unmanaged mode without touching user provider config",
@@ -4771,7 +4017,15 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 			expect(convergence.installErrors).toEqual([]);
 			expect(convergence.projectedProviderIds[runtimeName]).toEqual([]);
 			expect(convergence.projectedProviderIds.codex).toEqual(["clawdi"]);
-			expect(readFileSync(userConfigPath, "utf-8")).toBe(userConfig);
+			if (runtimeName === "openclaw") {
+				expect(
+					JSON.parse(readFileSync(userConfigPath, "utf-8")).models.providers["user-local"],
+				).toEqual({ baseUrl: "http://localhost:11434/v1" });
+			} else {
+				expect(
+					expectRecord(readHermesConfigYaml(home).providers, "Hermes providers")["user-local"],
+				).toEqual({ api: "http://localhost:11434/v1" });
+			}
 			expect(readFileSync(userCodexConfig, "utf-8")).toContain('model_provider = "clawdi"');
 			const runConfig = JSON.parse(
 				readFileSync(join(getRuntimePaths().runConfigRoot, `${runtimeName}.json`), "utf-8"),
@@ -4789,7 +4043,6 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 			for (const forbidden of [
 				"OPENAI_API_KEY",
 				"CLAWDI_AI_API_KEY",
-				"clawdi-egress-placeholder",
 				"provider.clawdi-managed",
 				"egress-secrets.json",
 			]) {
@@ -4918,65 +4171,6 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		expect(existsSync(join(home, ".codex", "config.toml"))).toBe(true);
 	});
 
-	it("does not delete unknown provider projections when applied state is missing", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const workspace = join(home, "clawdi");
-		const openclawBin = join(home, ".local", "bin", "openclaw");
-		const { configPath } = writeOpenClawConfigMutationFixture(home, {
-			models: {
-				providers: {
-					orphaned: {
-						baseUrl: "https://orphaned.example.test/v1",
-						models: [{ id: "orphaned-model" }],
-					},
-				},
-			},
-		});
-		mkdirSync(dirname(openclawBin), { recursive: true });
-		mkdirSync(join(home, ".hermes"), { recursive: true });
-		mkdirSync(workspace, { recursive: true });
-		writeFileSync(openclawBin, "#!/usr/bin/env bash\nexit 0\n");
-		chmodSync(openclawBin, 0o700);
-		writeHermesVersionBinary(home, "0.18.0");
-		writeFileSync(
-			join(home, ".hermes", "config.yaml"),
-			[
-				"providers:",
-				"  clawdi-orphaned:",
-				'    api: "https://orphaned.example.test/v1"',
-				'    custom_field: "preserve-without-applied-state"',
-				"",
-			].join("\n"),
-		);
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-
-		const paths = getRuntimePaths();
-		const convergence = convergeRuntimeManifest(hostedProviderSwitchLoad(home, "byok-b", 1), paths);
-
-		expect(convergence.installErrors).toEqual([]);
-		expect(existsSync(paths.appliedState)).toBe(false);
-		const openclawProviders = expectRecord(
-			expectRecord(JSON.parse(readFileSync(configPath, "utf8")).models, "OpenClaw models config")
-				.providers,
-			"OpenClaw providers config",
-		);
-		expect(openclawProviders.orphaned).toBeDefined();
-		expect(openclawProviders["byok-b"]).toBeDefined();
-		const hermesProviders = expectRecord(
-			readHermesConfigYaml(home).providers,
-			"Hermes providers config",
-		);
-		expect(hermesProviders["clawdi-orphaned"]).toMatchObject({
-			custom_field: "preserve-without-applied-state",
-		});
-		expect(hermesProviders["byok-b"]).toBeDefined();
-	});
-
 	it("projects complete OpenClaw gateway config before the official service installer", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -5088,8 +4282,6 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 					},
 				},
 				projection: {
-					sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
 					system: {
 						...hostedSystemFixture(home),
 						home,
@@ -5222,178 +4414,6 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 			"rotated-gateway-token",
 		);
 		expect(readFileSync(openclawCommand, "utf8")).not.toContain("rotated-gateway-token");
-	});
-
-	it("projects runtime-scoped hosted providers into each enabled agent config", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const openclawBin = join(home, ".local", "bin", "openclaw");
-		const { configPath } = writeOpenClawConfigMutationFixture(home);
-		mkdirSync(dirname(openclawBin), { recursive: true });
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		writeFileSync(openclawBin, "#!/bin/sh\nexit 0\n");
-		chmodSync(openclawBin, 0o700);
-		writeHermesVersionBinary(home, "0.18.0");
-
-		const loaded: RuntimeManifestLoad = {
-			source: "remote-datasource",
-			sourcePath: "https://runtime-source.test/desired-state",
-			offline: false,
-			secretValues: {
-				"secret://provider.openclaw.apiKey": "sk-openclaw-provider",
-				"secret://provider.hermes.apiKey": "sk-hermes-provider",
-			},
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_runtime_scoped_provider",
-				environmentId: "env_runtime_scoped_provider",
-				instanceId: "iid_runtime_scoped_provider",
-				generation: 1,
-				issuedAt: "2026-06-22T00:00:00Z",
-				workspaceRoot: join(home, "clawdi"),
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					openclaw: {
-						enabled: true,
-						provider_ids: ["openclaw"],
-						primary_model: { provider_id: "openclaw", model: "gpt-5.5" },
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://openclaw.ai/install-cli.sh",
-							home,
-							args: ["--json", "--no-onboard"],
-						},
-					},
-					hermes: {
-						enabled: true,
-						provider_ids: ["hermes"],
-						primary_model: {
-							provider_id: "hermes",
-							model: "kimi/kimi-for-coding",
-						},
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://hermes-agent.nousresearch.com/install.sh",
-							home,
-							args: ["--skip-setup", "--skip-browser", "--non-interactive"],
-						},
-					},
-				},
-				projection: {
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
-					system: { home },
-					providers: {
-						openclaw: {
-							kind: "openai-compatible",
-							baseUrl: "https://openclaw-provider.example.test/v1",
-							model: "gpt-5.5",
-							models: [
-								{
-									id: "gpt-5.5",
-									context_window: 272000,
-									max_tokens: 128000,
-									input_modalities: ["text", "image"],
-									supports_vision: true,
-									supports_tools: true,
-									supports_reasoning: true,
-								},
-							],
-							apiMode: "openai_responses",
-							runtimeEnvName: "OPENCLAW_PROVIDER_API_KEY",
-							apiKeySecretRef: "secret://provider.openclaw.apiKey",
-						},
-						hermes: {
-							kind: "openai-compatible",
-							baseUrl: "https://hermes-provider.example.test/v1",
-							model: "kimi/kimi-for-coding",
-							models: [
-								{
-									id: "kimi/kimi-for-coding",
-									context_window: 262144,
-									max_tokens: 32768,
-									input_modalities: ["text", "image"],
-									supports_vision: true,
-									supports_tools: true,
-									supports_reasoning: true,
-								},
-							],
-							apiMode: "openai_chat",
-							runtimeEnvName: "HERMES_PROVIDER_API_KEY",
-							apiKeySecretRef: "secret://provider.hermes.apiKey",
-						},
-					},
-				},
-				egressProfiles: { profiles: [] },
-				recovery: { cacheManifest: true, allowOfflineBoot: true },
-			},
-		};
-
-		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
-
-		expect(convergence.installErrors).toEqual([]);
-		const patch = JSON.parse(readFileSync(configPath, "utf-8"));
-		expect(patch.agents.defaults.model.primary).toBe("openclaw/gpt-5.5");
-		expect(patch.models.providers.openclaw.baseUrl).toBe(
-			"https://openclaw-provider.example.test/v1",
-		);
-		expect(patch.models.providers.openclaw.models[0]).toMatchObject({
-			id: "gpt-5.5",
-			contextWindow: 272000,
-			maxTokens: 128000,
-			input: ["text", "image"],
-			reasoning: true,
-			compat: { supportsTools: true },
-		});
-		expect(patch.models.providers.openclaw.models[0].api).toBeUndefined();
-		expect(JSON.stringify(patch)).not.toContain("hermes-provider.example.test");
-		const hermesConfig = readHermesConfigYaml(home);
-		const hermesModel = expectRecord(hermesConfig.model, "Hermes model config");
-		expect(hermesModel.provider).toBe("custom:hermes");
-		expect(hermesModel.default).toBe("kimi/kimi-for-coding");
-		expect(hermesModel.context_length).toBeUndefined();
-		expect(hermesModel.max_tokens).toBeUndefined();
-		expect(hermesModel.supports_vision).toBeUndefined();
-		const hermesProviders = expectRecord(hermesConfig.providers, "Hermes providers config");
-		const hermesProvider = expectRecord(hermesProviders.hermes, "Hermes provider config");
-		expect(hermesProvider.api).toBe("https://hermes-provider.example.test/v1");
-		expect(hermesProvider.transport).toBe("chat_completions");
-		expect(hermesProvider.key_env).toBe("HERMES_PROVIDER_API_KEY");
-		const hermesProviderModels = expectRecord(
-			hermesProvider.models,
-			"Hermes provider model metadata",
-		);
-		const kimiModel = expectRecord(
-			hermesProviderModels["kimi/kimi-for-coding"],
-			"Hermes provider kimi model metadata",
-		);
-		expect(kimiModel.context_length).toBe(262144);
-		expect(kimiModel.supports_vision).toBe(true);
-		expect(kimiModel.max_tokens).toBe(32768);
-		expect(existsSync(hermesModelProviderPluginDir(home))).toBe(false);
-		const openclawRunConfig = JSON.parse(
-			readFileSync(join(getRuntimePaths().runConfigRoot, "openclaw.json"), "utf-8"),
-		);
-		const hermesRunConfig = JSON.parse(
-			readFileSync(join(getRuntimePaths().runConfigRoot, "hermes.json"), "utf-8"),
-		);
-		expect(openclawRunConfig.env.OPENCLAW_PROVIDER_API_KEY).toBeUndefined();
-		expect(openclawRunConfig.secretEnv).toEqual({
-			OPENCLAW_PROVIDER_API_KEY: "secret://provider.openclaw.apiKey",
-		});
-		expect(hermesRunConfig.env.HERMES_PROVIDER_API_KEY).toBeUndefined();
-		expect(hermesRunConfig.secretEnv).toEqual({
-			HERMES_PROVIDER_API_KEY: "secret://provider.hermes.apiKey",
-		});
-		expect(JSON.stringify(openclawRunConfig)).not.toContain("sk-openclaw-provider");
-		expect(JSON.stringify(hermesRunConfig)).not.toContain("sk-hermes-provider");
-		expect(JSON.stringify(openclawRunConfig)).not.toContain("secret://provider.hermes.apiKey");
-		expect(JSON.stringify(hermesRunConfig)).not.toContain("secret://provider.openclaw.apiKey");
 	});
 
 	it("owns one hosted Hermes OAuth family across rotation, logout, reconnect, and removal", () => {
@@ -5548,19 +4568,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 			"post-reconnect-rotated-access",
 		);
 
-		const removedLoad: RuntimeManifestLoad = {
-			...nativeReauthenticatedLoad,
-			secretValues: {},
-			manifest: {
-				...nativeReauthenticatedLoad.manifest,
-				generation: 3,
-				runtimes: {},
-				projection: {
-					...nativeReauthenticatedLoad.manifest.projection,
-					providers: {},
-				},
-			},
-		};
+		const removedLoad = hostedSingleProviderModeLoad(home, "hermes", "unmanaged", 3);
 		convergeRuntimeManifest(removedLoad, paths);
 		auth = JSON.parse(readFileSync(authPath, "utf8"));
 		expect(auth.providers["openai-codex"].tokens.access_token).toBe("user-access");
@@ -5714,19 +4722,7 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 			"post-reconnect-rotated-access",
 		);
 
-		const removedLoad: RuntimeManifestLoad = {
-			...nativeReauthenticatedLoad,
-			secretValues: {},
-			manifest: {
-				...nativeReauthenticatedLoad.manifest,
-				generation: 3,
-				runtimes: {},
-				projection: {
-					...nativeReauthenticatedLoad.manifest.projection,
-					providers: {},
-				},
-			},
-		};
+		const removedLoad = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 3);
 		convergeRuntimeManifest(removedLoad, paths);
 		store = JSON.parse(readFileSync(storePath, "utf8"));
 		expect(store.profiles[nativeProfileId]).toBeUndefined();
@@ -5864,17 +4860,6 @@ cp '${sdkSource}' '${sdkTarget}'
 		expect(systemdEnvRevision(readSystemdEnvFile(paths, "hermes-gateway"))).toBe(firstRevision);
 	});
 
-	it("rejects multiple Hermes hosted providers at manifest admission", () => {
-		const home = join(root, "home", "clawdi");
-		const loaded = hostedHermesProviderLoad(home);
-		loaded.manifest.runtimes.hermes = {
-			...loaded.manifest.runtimes.hermes,
-			provider_ids: ["hermes", "moonshot"],
-		};
-
-		expect(manifestSchema.safeParse(loaded.manifest).success).toBe(false);
-	});
-
 	it("ignores a retired Hermes plugin while removing the native provider", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -5901,7 +4886,6 @@ cp '${sdkSource}' '${sdkTarget}'
 					},
 				},
 				projection: {
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
 					system: { home },
 				},
 			},
@@ -6186,152 +5170,6 @@ cp '${sdkSource}' '${sdkTarget}'
 		expect(currentRevision).toBe(yamlRevision);
 	});
 
-	it("projects runtime-scoped Codex OAuth providers as native agent profiles", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const openclawBin = join(home, ".local", "bin", "openclaw");
-		const { configPath } = writeOpenClawConfigMutationFixture(home);
-		mkdirSync(dirname(openclawBin), { recursive: true });
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		writeFileSync(openclawBin, "#!/bin/sh\nexit 0\n");
-		chmodSync(openclawBin, 0o700);
-
-		const loaded: RuntimeManifestLoad = {
-			source: "remote-datasource",
-			sourcePath: "https://runtime-source.test/desired-state",
-			offline: false,
-			secretValues: {},
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_runtime_codex_oauth",
-				environmentId: "env_runtime_codex_oauth",
-				instanceId: "iid_runtime_codex_oauth",
-				generation: 1,
-				issuedAt: "2026-06-22T00:00:00Z",
-				workspaceRoot: join(home, "clawdi"),
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					openclaw: {
-						enabled: true,
-						provider_ids: ["openclaw"],
-						primary_model: { provider_id: "openclaw", model: "gpt-5.5" },
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://openclaw.ai/install-cli.sh",
-							home,
-							args: ["--json", "--no-onboard"],
-						},
-					},
-				},
-				projection: {
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
-					system: { home },
-					providers: {
-						openclaw: {
-							kind: "openai-compatible",
-							type: "openai",
-							baseUrl: "https://api.openai.com/v1",
-							model: "gpt-5.5",
-							apiMode: "openai_responses",
-							auth: {
-								type: "agent_profile",
-								tool: "codex",
-								profile: "default",
-							},
-						},
-					},
-				},
-				egressProfiles: { profiles: [] },
-				recovery: { cacheManifest: true, allowOfflineBoot: true },
-			},
-		};
-
-		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
-
-		expect(convergence.installErrors).toEqual([]);
-		const patch = JSON.parse(readFileSync(configPath, "utf-8"));
-		expect(patch.plugins.entries.codex.enabled).toBe(true);
-		expect(patch.agents.defaults.model.primary).toBe("openai/gpt-5.5");
-		expect(patch.models).toBeUndefined();
-		const openclawRunConfig = JSON.parse(
-			readFileSync(join(getRuntimePaths().runConfigRoot, "openclaw.json"), "utf-8"),
-		);
-		expect(openclawRunConfig.secretEnv).toEqual({});
-		expect(JSON.stringify(openclawRunConfig)).not.toContain("apiKeySecretRef");
-	});
-
-	it("does not fall back to a different runtime-scoped hosted provider", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		writeHermesVersionBinary(home, "0.20.1");
-
-		const loaded: RuntimeManifestLoad = {
-			source: "remote-datasource",
-			sourcePath: "https://runtime-source.test/desired-state",
-			offline: false,
-			secretValues: {
-				"secret://provider.openclaw.apiKey": "sk-openclaw-provider",
-			},
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_runtime_provider_missing",
-				environmentId: "env_runtime_provider_missing",
-				instanceId: "iid_runtime_provider_missing",
-				generation: 1,
-				issuedAt: "2026-06-22T00:00:00Z",
-				workspaceRoot: join(home, "clawdi"),
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					hermes: {
-						enabled: true,
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://hermes-agent.nousresearch.com/install.sh",
-							home,
-							args: ["--skip-setup", "--skip-browser", "--non-interactive"],
-						},
-					},
-				},
-				projection: {
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
-					system: { home },
-					providers: {
-						openclaw: {
-							kind: "openai-compatible",
-							baseUrl: "https://openclaw-provider.example.test/v1",
-							model: "gpt-5.5",
-							apiMode: "openai_responses",
-							runtimeEnvName: "OPENCLAW_PROVIDER_API_KEY",
-							apiKeySecretRef: "secret://provider.openclaw.apiKey",
-						},
-					},
-				},
-				egressProfiles: { profiles: [] },
-				recovery: { cacheManifest: true, allowOfflineBoot: true },
-			},
-		};
-
-		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
-
-		expect(convergence.installErrors).toEqual([]);
-		const hermesRunConfig = JSON.parse(
-			readFileSync(join(getRuntimePaths().runConfigRoot, "hermes.json"), "utf-8"),
-		);
-		expect(hermesRunConfig.secretEnv).toEqual({});
-		expect(existsSync(join(home, ".hermes", "config.yaml"))).toBe(false);
-	});
-
 	it("preserves non-OpenAI hosted provider protocols in direct agent projection", () => {
 		for (const providerCase of [
 			{
@@ -6365,57 +5203,27 @@ cp '${sdkSource}' '${sdkTarget}'
 			writeFileSync(openclawBin, "#!/bin/sh\nexit 0\n");
 			chmodSync(openclawBin, 0o700);
 
-			const loaded: RuntimeManifestLoad = {
-				source: "remote-datasource",
-				sourcePath: "https://runtime-source.test/desired-state",
-				offline: false,
-				secretValues: {
-					"secret://provider.openclaw.apiKey": `sk-${providerCase.id}`,
+			const loaded = hostedSingleProviderModeLoad(home, "openclaw", "configured", 1);
+			const providers = {
+				openclaw: {
+					kind: "openai-compatible" as const,
+					type: providerCase.type,
+					baseUrl: providerCase.baseUrl,
+					model: providerCase.model,
+					apiMode: providerCase.apiMode,
+					runtimeEnvName: `${providerCase.id.toUpperCase()}_API_KEY`,
+					apiKeySecretRef: "secret://provider.openclaw.apiKey",
 				},
-				manifest: {
-					schemaVersion: "clawdi.runtimeDesiredState.v1",
-					deploymentId: `dep_${providerCase.id}_provider`,
-					environmentId: `env_${providerCase.id}_provider`,
-					instanceId: `iid_${providerCase.id}_provider`,
-					generation: 1,
-					issuedAt: "2026-06-22T00:00:00Z",
-					workspaceRoot: join(home, "clawdi"),
-					controlPlane: { apiUrl: "https://cloud-api.test" },
-					runtimes: {
-						openclaw: {
-							enabled: true,
-							provider_ids: ["openclaw"],
-							primary_model: {
-								provider_id: "openclaw",
-								model: providerCase.model,
-							},
-							install: {
-								authority: "official",
-								method: "official-installer",
-								url: "https://openclaw.ai/install-cli.sh",
-								home,
-								args: ["--json", "--no-onboard"],
-							},
-						},
-					},
-					projection: {
-						sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
-						system: { home },
-						providers: {
-							openclaw: {
-								kind: "openai-compatible",
-								type: providerCase.type,
-								baseUrl: providerCase.baseUrl,
-								model: providerCase.model,
-								apiMode: providerCase.apiMode,
-								runtimeEnvName: `${providerCase.id.toUpperCase()}_API_KEY`,
-								apiKeySecretRef: "secret://provider.openclaw.apiKey",
-							},
-						},
-					},
-					egressProfiles: { profiles: [] },
-					recovery: { cacheManifest: true, allowOfflineBoot: true },
-				},
+			};
+			loaded.manifest.runtimes.openclaw.provider_ids = ["openclaw"];
+			loaded.manifest.runtimes.openclaw.primary_model = {
+				provider_id: "openclaw",
+				model: providerCase.model,
+			};
+			loaded.manifest.projection = { ...loaded.manifest.projection, providers };
+			loaded.manifest.egressProfiles = hostedManifestEgressProfiles({ providers });
+			loaded.secretValues = {
+				"secret://provider.openclaw.apiKey": `sk-${providerCase.id}`,
 			};
 
 			const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
@@ -6534,13 +5342,19 @@ cp '${sdkSource}' '${sdkTarget}'
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const openclawBin = join(home, ".local", "bin", "openclaw");
+		const openclawPatch = join(root, "openclaw-provider-patch.json");
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		writeFileSync(
 			openclawBin,
-			`#!/usr/bin/env bash
-printf 'provider projection should not run for unhealthy provider\\n' >&2
-exit 64
-`,
+			[
+				"#!/bin/sh",
+				'if [ "$1 $2 $3" = "config patch --stdin" ]; then',
+				`  cat > '${openclawPatch}'`,
+				"  exit 0",
+				"fi",
+				"exit 2",
+				"",
+			].join("\n"),
 		);
 		chmodSync(openclawBin, 0o700);
 		process.env.HOME = home;
@@ -6548,50 +5362,42 @@ exit 64
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 
-		const convergence = convergeRuntimeManifest(
-			{
-				manifest: {
-					schemaVersion: "clawdi.runtimeDesiredState.v1",
-					deploymentId: "dep_key_required_missing_ref",
-					environmentId: "env_key_required_missing_ref",
-					instanceId: "iid_key_required_missing_ref",
-					generation: 1,
-					issuedAt: "2026-06-26T00:00:00Z",
-					controlPlane: { apiUrl: "https://cloud-api.test" },
-					runtimes: {
-						openclaw: {
-							enabled: true,
-							run: {
-								command: openclawBin,
-								args: ["gateway", "run"],
-								env: {},
-								prependPath: [],
-							},
-						},
-					},
-					projection: {
-						providers: {
-							openclaw: {
-								kind: "openai-compatible",
-								type: "anthropic",
-								baseUrl: "https://api.anthropic.com",
-								model: "claude-opus-4-6",
-								apiMode: "anthropic_messages",
-								apiKeyRequired: true,
-								status: "error",
-								error: { code: "provider_secret_unavailable" },
-							},
-						},
-					},
-					recovery: {},
+		const fixture = hostedCliManifestResponse(home, TEST_RUNNING_CLI_SPEC);
+		fixture.manifest.runtimes = {
+			openclaw: hostedOpenClawRuntime({
+				provider_ids: ["openclaw"],
+				primary_model: { provider_id: "openclaw", model: "claude-opus-4-6" },
+			}),
+		};
+		fixture.manifest.providers = {
+			openclaw: {
+				kind: "openai-compatible",
+				type: "anthropic",
+				baseUrl: "https://api.anthropic.com",
+				apiMode: "anthropic_messages",
+				apiKeyRequired: true,
+				status: "error",
+				error: {
+					code: "provider_secret_unavailable",
+					message: "provider secret is unavailable",
 				},
-				source: "remote-datasource",
-				sourcePath: "test://key-required-missing-ref",
-				offline: false,
-				secretValues: {},
 			},
-			getRuntimePaths(),
+		};
+		const loaded = parseHostedRuntimeBundleV2(
+			{
+				schemaVersion: "clawdi.hosted-runtime.bundle.v2",
+				sourceRevision: "f".repeat(64),
+				manifest: fixture.manifest,
+				channelBindings: [],
+				secretValues: {
+					...TEST_HOSTED_CODEX_SECRET_VALUES,
+					...TEST_RUNTIME_SERVICE_SECRET_VALUES,
+				},
+			},
+			"https://runtime-source.test/desired-state",
 		);
+
+		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
 
 		expect(convergence.installErrors).toEqual([]);
 		const providerHealth = readHostedRuntimeObserved(getRuntimePaths())?.providers?.openclaw;
@@ -7331,7 +6137,7 @@ exit 64
 			const systemctlCalls = readFileSync(systemctlLog, "utf-8").trim().split("\n");
 			expect(systemctlCalls).toContain("--user restart openclaw-gateway.service");
 			expect(systemctlCalls.some((call) => call.includes("enable --now"))).toBe(false);
-			expect(systemctlCalls).toContain("start clawdi-runtime-sidecar.service");
+			expect(systemctlCalls).toContain("restart clawdi-runtime-sidecar.service");
 			expect(systemctlCalls).toContain("restart clawdi-daemon.service");
 			expect(systemctlCalls.some((call) => call.includes("restart clawdi-runtime-watch"))).toBe(
 				false,
@@ -9280,28 +8086,33 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		const paths = getRuntimePaths();
 		mkdirSync(paths.serviceStateRoot, { recursive: true });
 		mkdirSync(paths.cacheRoot, { recursive: true });
+		const cached = hostedCliManifestResponse(home, TEST_RUNNING_CLI_SPEC);
+		Object.assign(cached.manifest, {
+			deploymentId: "dep-provider-observed",
+			environmentId: "env-provider-observed",
+			instanceId: "iid-provider-observed",
+			generation: 9,
+			providers: {
+				default: {
+					kind: "openai-compatible",
+					type: "custom_openai_compatible",
+					baseUrl: "https://sub2api.test/v1",
+					models: [{ id: "gpt-5.5" }],
+					apiMode: "openai_responses",
+					managed_by: "user",
+					runtimeEnvName: "OPENAI_API_KEY",
+					apiKeySecretRef: "secret://provider.default.apiKey",
+				},
+			},
+		});
 		writeFileSync(
 			paths.manifestLastGood,
 			JSON.stringify({
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep-provider-observed",
-				environmentId: "env-provider-observed",
-				instanceId: "iid-provider-observed",
-				generation: 9,
-				issuedAt: "2026-06-06T00:00:00Z",
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: { openclaw: { enabled: true } },
-				projection: {
-					providers: {
-						default: {
-							kind: "openai-compatible",
-							baseUrl: "https://sub2api.test/v1",
-							model: "gpt-5.5",
-							apiKeySecretRef: "secret://provider.default.apiKey",
-						},
-					},
-				},
-				recovery: { cacheManifest: true, allowOfflineBoot: true },
+				schemaVersion: "clawdi.hosted-runtime.bundle.v2",
+				sourceRevision: "a".repeat(64),
+				manifest: cached.manifest,
+				channelBindings: [],
+				secretValues: {},
 			}),
 		);
 		writeFileSync(
@@ -9360,7 +8171,8 @@ printf 'ActiveState=active\\nSubState=running\\n'
 				configured: true,
 				kind: "openai-compatible",
 				baseUrl: "https://sub2api.test/v1",
-				model: "gpt-5.5",
+				model: null,
+				models: [{ id: "gpt-5.5" }],
 				apiKeySecretRef: "secret://provider.default.apiKey",
 				secretAvailable: true,
 				reasons: [],
@@ -9381,27 +8193,32 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		const paths = getRuntimePaths();
 		mkdirSync(paths.serviceStateRoot, { recursive: true });
 		mkdirSync(paths.cacheRoot, { recursive: true });
+		const cached = hostedCliManifestResponse(home, TEST_RUNNING_CLI_SPEC);
+		Object.assign(cached.manifest, {
+			deploymentId: "dep-provider-missing-secret",
+			environmentId: "env-provider-missing-secret",
+			instanceId: "iid-provider-missing-secret",
+			generation: 10,
+			providers: {
+				default: {
+					kind: "openai-compatible",
+					type: "custom_openai_compatible",
+					baseUrl: "https://sub2api.test/v1",
+					apiMode: "openai_responses",
+					managed_by: "user",
+					runtimeEnvName: "OPENAI_API_KEY",
+					apiKeySecretRef: "secret://provider.default.apiKey",
+				},
+			},
+		});
 		writeFileSync(
 			paths.manifestLastGood,
 			JSON.stringify({
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep-provider-missing-secret",
-				environmentId: "env-provider-missing-secret",
-				instanceId: "iid-provider-missing-secret",
-				generation: 10,
-				issuedAt: "2026-06-06T00:00:00Z",
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: { openclaw: { enabled: true } },
-				projection: {
-					providers: {
-						default: {
-							kind: "openai-compatible",
-							baseUrl: "https://sub2api.test/v1",
-							apiKeySecretRef: "secret://provider.default.apiKey",
-						},
-					},
-				},
-				recovery: { cacheManifest: true, allowOfflineBoot: true },
+				schemaVersion: "clawdi.hosted-runtime.bundle.v2",
+				sourceRevision: "c".repeat(64),
+				manifest: cached.manifest,
+				channelBindings: [],
+				secretValues: {},
 			}),
 		);
 		writeRuntimeBootStatus(
@@ -9464,7 +8281,10 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		};
 		const previous = {
 			manifest: previousManifest,
-			secretValues: { "secret://runtime/openclaw/gateway-token": "gateway-token" },
+			secretValues: {
+				...TEST_HOSTED_CODEX_SECRET_VALUES,
+				"secret://runtime/openclaw/gateway-token": "gateway-token",
+			},
 		};
 		const next = { manifest: nextManifest, secretValues: previous.secretValues };
 
@@ -9520,6 +8340,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		const paths = getRuntimePaths();
 		const current = runtimeWatchLocaleManifest(home, 10);
 		const runtimeAuthSecret = {
+			...TEST_HOSTED_CODEX_SECRET_VALUES,
 			"secret://clawdi/auth-token":
 				TEST_RUNTIME_SERVICE_SECRET_VALUES["secret://clawdi/auth-token"],
 		};
@@ -10776,70 +9597,22 @@ chmod +x "$prefix/bin/clawdi"
 		const paths = getRuntimePaths();
 		seedCurrentCliInstall(state, "clawdi@1.2.1-test.1", "1.2.1-test.1");
 		const mitmproxy = seedMitmproxyCache(paths);
+		const baseline = normalizeHostedManifestFixture(
+			hostedEgressSecretRotationPayload(home, mitmproxy, "sk-before-upgrade"),
+		);
+		baseline.manifest = {
+			...baseline.manifest,
+			deploymentId: "dep_cli_mitm",
+			environmentId: "env_cli_mitm",
+			instanceId: "iid_cli_mitm",
+			generation: 1,
+		};
 		convergeRuntimeManifest(
 			{
+				...baseline,
 				source: "remote-datasource",
 				sourcePath: "test://self-upgrade-egress-before",
 				offline: false,
-				secretValues: {
-					"secret://provider.default.apiKey": "sk-before-upgrade",
-				},
-				manifest: {
-					schemaVersion: "clawdi.runtimeDesiredState.v1",
-					deploymentId: "dep_cli_mitm",
-					environmentId: "env_cli_mitm",
-					instanceId: "iid_cli_mitm",
-					generation: 1,
-					issuedAt: "2026-06-06T00:00:00Z",
-					workspaceRoot: join(home, "clawdi"),
-					controlPlane: { apiUrl: "https://cloud-api.test" },
-					egressEngine: mitmproxy,
-					runtimes: {
-						openclaw: {
-							enabled: true,
-							provider_ids: ["default"],
-							primary_model: { provider_id: "default", model: "gpt-5.5" },
-						},
-					},
-					projection: {
-						providers: {
-							default: {
-								kind: "openai-compatible",
-								type: "custom_openai_compatible",
-								baseUrl: "https://ai-gateway.example.test/v1",
-								models: [{ id: "gpt-5.5" }],
-								apiMode: "openai_responses",
-								runtimeEnvName: "OPENAI_API_KEY",
-								apiKeySecretRef: "secret://provider.default.apiKey",
-							},
-						},
-					},
-					egressProfiles: {
-						profiles: [
-							{
-								id: "managed-provider",
-								enabled: true,
-								kind: "provider",
-								match: {
-									scheme: "https",
-									host: "ai-gateway.example.test",
-								},
-								rewrite: {
-									setHeaders: {
-										authorization: {
-											type: "secretRef",
-											secretRef: "secret://provider.default.apiKey",
-											prefix: "Bearer ",
-										},
-									},
-								},
-								priority: 80,
-								owner: "provider-projection",
-							},
-						],
-					},
-					recovery: { cacheManifest: true, allowOfflineBoot: true },
-				},
 			},
 			paths,
 		);
@@ -10921,7 +9694,6 @@ chmod +x "$prefix/bin/clawdi"
 			expect(event.systemdApply.applied).toBe(true);
 			expect(event.systemdApply.systemUnitsChanged).toContain("clawdi-runtime-sidecar.service");
 			const systemctlCalls = readFileSync(systemctlLog, "utf-8").trim().split("\n");
-			expect(systemctlCalls).toContain("restart clawdi-runtime-sidecar.service");
 			expect(systemctlCalls).not.toContain("restart clawdi-daemon.service");
 			const sidecarEnv = readSystemdEnvFile(paths, "clawdi-runtime-sidecar");
 			const sidecarUnit = readSystemdSystemUnit(paths, "clawdi-runtime-sidecar");
@@ -11265,7 +10037,7 @@ exit 64
 		}
 	});
 
-	it("runtime init applies remote channel desired state during first boot", async () => {
+	it("runtime init replaces normalized last-good state while applying remote channels", async () => {
 		installSuccessfulSystemctlFixture();
 		setRuntimeApplyGeneration(7, CANONICAL_TEST_CONTEXT);
 		const home = join(root, "home", "clawdi");
@@ -11348,6 +10120,44 @@ exit 64
 			TEST_RUNNING_CLI_VERSION,
 			"https://registry.npmjs.org",
 		);
+		const paths = getRuntimePaths();
+		mkdirSync(paths.cacheRoot, { recursive: true });
+		writeFileSync(
+			paths.manifestLastGood,
+			`${JSON.stringify({
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: "dep_init",
+				environmentId: "env_init",
+				instanceId: "iid_init",
+				generation: 6,
+				issuedAt: "2026-06-05T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.test" },
+				clawdiCli: {
+					source: "npm:clawdi",
+					packageSpec: TEST_RUNNING_CLI_SPEC,
+					registry: "https://registry.npmjs.org",
+				},
+				runtimes: { openclaw: { enabled: false } },
+				projection: {
+					sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
+					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					providers: {
+						legacy: {
+							kind: "openai-compatible",
+							baseUrl: "https://legacy-provider.test/v1",
+							apiKeySecretRef: "secret://provider.legacy.apiKey",
+						},
+					},
+				},
+				recovery: { cacheManifest: true, allowOfflineBoot: true },
+			})}\n`,
+			{ mode: 0o600 },
+		);
+		writeFileSync(
+			paths.managedSecretCacheFile,
+			'{"secret://provider.legacy.apiKey":"sk-legacy-cache"}\n',
+			{ mode: 0o600 },
+		);
 		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
@@ -11416,7 +10226,7 @@ exit 64
 			expect(process.exitCode).toBe(0);
 			expect(captured).toHaveLength(1);
 			expect(captured[0].path).toBe("/v1/runtime/manifest");
-			expect(readRuntimeAppliedState(getRuntimePaths())).toMatchObject({
+			expect(readRuntimeAppliedState(paths)).toMatchObject({
 				etag: testBundleEtag("manifest-etag-init-7"),
 				generation: 7,
 			});
@@ -11477,16 +10287,30 @@ exit 64
 			const egressSecretsText = readFileSync(join(run, "secrets", "egress-secrets.json"), "utf-8");
 			expect(egressSecretsText).toContain("agent-token-init");
 			expect(egressSecretsText).toContain("discord-agent-token-init");
-			const cachedManifestText = readFileSync(getRuntimePaths().manifestLastGood, "utf-8");
-			expect(cachedManifestText).toContain('"channels"');
+			const cachedManifestText = readFileSync(paths.manifestLastGood, "utf-8");
+			const cachedManifest = JSON.parse(cachedManifestText);
+			expect(cachedManifest).toMatchObject({
+				schemaVersion: "clawdi.hosted-runtime.bundle.v2",
+				manifest: {
+					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					generation: 7,
+				},
+				channelBindings: [{ provider: "telegram" }, { provider: "discord" }],
+				secretValues: {},
+			});
+			expect(cachedManifestText).not.toContain("sourceBundleVersion");
+			expect(cachedManifestText).not.toContain("sourceSchemaVersion");
 			expect(cachedManifestText).not.toContain("agent-token-init");
 			expect(cachedManifestText).not.toContain("discord-agent-token-init");
-			const cachedSecretsText = readFileSync(getRuntimePaths().managedSecretCacheFile, "utf-8");
+			expect(statSync(paths.manifestLastGood).mode & 0o777).toBe(0o600);
+			const cachedSecretsText = readFileSync(paths.managedSecretCacheFile, "utf-8");
+			expect(cachedSecretsText).not.toContain("sk-legacy-cache");
 			expect(cachedSecretsText).toContain("placeholder-token");
 			expect(cachedSecretsText).toContain("999999999:");
 			expect(cachedSecretsText).toContain("clawdi_");
 			expect(cachedSecretsText).toContain("agent-token-init");
 			expect(cachedSecretsText).toContain("discord-agent-token-init");
+			expect(statSync(paths.managedSecretCacheFile).mode & 0o777).toBe(0o600);
 			const profileBundleText = readFileSync(getRuntimePaths().egressProfileBundle, "utf-8");
 			const profileBundle = JSON.parse(profileBundleText) as {
 				profiles: Array<Record<string, unknown>>;
@@ -11716,7 +10540,6 @@ exit 64
 					},
 				},
 				projection: {
-					sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
 					system: {},
 				},
 				recovery: {},
@@ -11905,7 +10728,6 @@ exit 64
 			].join("\n"),
 		);
 		seedHermesManagedBaileys(home);
-		seedOpenClawBinary(home);
 		writeFakeSystemdManager({
 			path: systemctlPath,
 			logPath: systemctlLog,
@@ -12002,15 +10824,6 @@ exit 64
 		};
 
 		const projected = applyRuntimeBundleChannelsToManifestLoad(load, paths);
-		projected.manifest.runtimes.openclaw = {
-			enabled: true,
-			run: {
-				args: ["gateway", "run"],
-				env: {},
-				prependPath: [],
-			},
-			services: {},
-		};
 		const credentialProjection = projected.manifest.projection?.channelCredentials as unknown[];
 		expect(credentialProjection).toEqual([
 			expect.objectContaining({
@@ -12055,9 +10868,6 @@ exit 64
 			sessionDir,
 		);
 		const initialHermesRevision = systemdEnvRevision(readSystemdEnvFile(paths, "hermes-gateway"));
-		const initialOpenClawRevision = systemdEnvRevision(
-			readSystemdEnvFile(paths, "openclaw-gateway"),
-		);
 		const hermesDropIn = join(
 			paths.systemdUserRoot,
 			"hermes-gateway.service.d",
@@ -12089,9 +10899,6 @@ exit 64
 		expect(systemdEnvRevision(readSystemdEnvFile(paths, "hermes-gateway"))).toBe(
 			initialHermesRevision,
 		);
-		expect(systemdEnvRevision(readSystemdEnvFile(paths, "openclaw-gateway"))).toBe(
-			initialOpenClawRevision,
-		);
 
 		const projectedCreds = JSON.parse(
 			projected.secretValues?.[credentialSecretRef] ?? "null",
@@ -12122,9 +10929,6 @@ exit 64
 		expect(systemdEnvRevision(readSystemdEnvFile(paths, "hermes-gateway"))).not.toBe(
 			initialHermesRevision,
 		);
-		expect(systemdEnvRevision(readSystemdEnvFile(paths, "openclaw-gateway"))).toBe(
-			initialOpenClawRevision,
-		);
 		writeFileSync(systemctlLog, "");
 		process.env.CLAWDI_SYSTEMD_APPLY = "1";
 		expect(
@@ -12140,7 +10944,6 @@ exit 64
 		});
 		const systemctlCalls = readFileSync(systemctlLog, "utf-8");
 		expect(systemctlCalls).toContain("--user restart hermes-gateway.service");
-		expect(systemctlCalls).not.toContain("restart openclaw-gateway.service");
 
 		const removed = applyRuntimeBundleChannelsToManifestLoad(
 			{ ...load, channelBindings: [], secretValues: {} },
@@ -12264,49 +11067,21 @@ exit 0
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		const loaded: RuntimeManifestLoad = {
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_channel_delete",
-				environmentId: "env_channel_delete",
-				instanceId: "iid_channel_delete",
-				generation: 8,
-				issuedAt: "2026-06-06T00:00:00Z",
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					openclaw: {
-						enabled: true,
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://openclaw.ai/install-cli.sh",
-							home,
-							args: [],
-						},
-					},
-					hermes: { enabled: false },
-				},
-				projection: {
-					system: { home, workspace },
-					channels: {
-						whatsapp: {
+		const loaded = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 8);
+		loaded.manifest.projection = {
+			...loaded.manifest.projection,
+			channels: {
+				whatsapp: {
+					enabled: true,
+					defaultAccount: "clawdi_whatsapp",
+					accounts: {
+						clawdi_whatsapp: {
 							enabled: true,
-							defaultAccount: "clawdi_whatsapp",
-							accounts: {
-								clawdi_whatsapp: {
-									enabled: true,
-									authDir: join(home, ".openclaw", "credentials", "whatsapp"),
-								},
-							},
+							authDir: join(home, ".openclaw", "credentials", "whatsapp"),
 						},
 					},
 				},
-				recovery: {},
 			},
-			source: "remote-datasource",
-			sourcePath: "test://channel-delete",
-			offline: false,
-			secretValues: {},
 		};
 
 		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
@@ -12325,7 +11100,8 @@ exit 0
 		const patches = readFileSync(openclawPatch, "utf-8")
 			.split("\n---\n")
 			.filter((entry) => entry.trim().length > 0)
-			.map((entry) => JSON.parse(entry));
+			.map((entry) => JSON.parse(entry))
+			.filter((patch) => Object.hasOwn(patch, "channels"));
 		expect(patches).toHaveLength(2);
 		expect(patches[0].channels.whatsapp.accounts).toHaveProperty("clawdi_whatsapp");
 		expect(patches[0].channels.whatsapp.accounts.clawdi_whatsapp.authDir).toBe(
@@ -12374,43 +11150,15 @@ exit 0
 		const previousLiveSnapshot = Object.fromEntries(
 			liveFiles.map((path) => [path, readFileSync(path, "utf-8")]),
 		);
-		const loaded: RuntimeManifestLoad = {
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_channel_plugin_failure",
-				environmentId: "env_channel_plugin_failure",
-				instanceId: "iid_channel_plugin_failure",
-				generation: 2,
-				issuedAt: "2026-07-13T00:00:00Z",
-				workspaceRoot: workspace,
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					openclaw: {
-						enabled: true,
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://openclaw.ai/install-cli.sh",
-							home,
-							args: [],
-						},
-					},
+		const loaded = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 2);
+		loaded.manifest.projection = {
+			...loaded.manifest.projection,
+			channels: {
+				discord: {
+					enabled: true,
+					accounts: { default: { enabled: true } },
 				},
-				projection: {
-					system: { home, workspace },
-					channels: {
-						discord: {
-							enabled: true,
-							accounts: { default: { enabled: true } },
-						},
-					},
-				},
-				recovery: {},
 			},
-			source: "remote-datasource",
-			sourcePath: "test://channel-plugin-install-failure",
-			offline: false,
-			secretValues: {},
 		};
 
 		const convergence = convergeRuntimeManifest(loaded, paths);
@@ -12642,58 +11390,26 @@ exit 64
 		process.env.CLAWDI_RUN_DIR = run;
 
 		const missingSecretRef = `secret://channels/whatsapp/${accountKey}/credentials/credential-missing/creds-json`;
-		const loaded: RuntimeManifestLoad = {
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_whatsapp_missing_secret",
-				environmentId: "env_whatsapp_missing_secret",
-				instanceId: "iid_whatsapp_missing_secret",
-				generation: 9,
-				issuedAt: "2026-07-07T00:00:00Z",
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					openclaw: {
-						enabled: true,
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://openclaw.ai/install-cli.sh",
-							home,
-							args: [],
-						},
-					},
+		const loaded = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 9);
+		loaded.manifest.projection = {
+			...loaded.manifest.projection,
+			channels: {
+				whatsapp: {
+					enabled: true,
+					defaultAccount: accountKey,
+					accounts: { [accountKey]: { enabled: true, authDir } },
 				},
-				projection: {
-					system: { home, workspace },
-					channels: {
-						whatsapp: {
-							enabled: true,
-							defaultAccount: accountKey,
-							accounts: {
-								[accountKey]: {
-									enabled: true,
-									authDir,
-								},
-							},
-						},
-					},
-					channelCredentials: [
-						{
-							provider: "whatsapp",
-							kind: "whatsapp_baileys_auth_state",
-							accountKey,
-							credentialId: "credential-missing",
-							files: [{ path: "creds.json", secretRef: missingSecretRef }],
-							targets: { openclaw: { authDir } },
-						},
-					],
-				},
-				recovery: {},
 			},
-			source: "remote-datasource",
-			sourcePath: "test://whatsapp-missing-secret",
-			offline: false,
-			secretValues: {},
+			channelCredentials: [
+				{
+					provider: "whatsapp",
+					kind: "whatsapp_baileys_auth_state",
+					accountKey,
+					credentialId: "credential-missing",
+					files: [{ path: "creds.json", secretRef: missingSecretRef }],
+					targets: { openclaw: { authDir } },
+				},
+			],
 		};
 
 		expect(() => convergeRuntimeManifest(loaded, getRuntimePaths())).toThrow(
@@ -12751,39 +11467,11 @@ exit 64
 		const manifestWithChannels = (
 			channels: Record<string, unknown>,
 			generation: number,
-		): RuntimeManifestLoad => ({
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_channel_remove",
-				environmentId: "env_channel_remove",
-				instanceId: "iid_channel_remove",
-				generation,
-				issuedAt: "2026-06-06T00:00:00Z",
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					openclaw: {
-						enabled: true,
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://openclaw.ai/install-cli.sh",
-							home,
-							args: [],
-						},
-					},
-					hermes: { enabled: false },
-				},
-				projection: {
-					system: { home, workspace },
-					channels,
-				},
-				recovery: {},
-			},
-			source: "remote-datasource",
-			sourcePath: `test://channel-remove-${generation}`,
-			offline: false,
-			secretValues: {},
-		});
+		): RuntimeManifestLoad => {
+			const loaded = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", generation);
+			loaded.manifest.projection = { ...loaded.manifest.projection, channels };
+			return loaded;
+		};
 		const telegramChannel = {
 			enabled: true,
 			defaultAccount: "default",
@@ -12812,7 +11500,8 @@ exit 64
 		const patches = readFileSync(openclawPatch, "utf-8")
 			.split("\n---\n")
 			.filter((entry) => entry.trim().length > 0)
-			.map((entry) => JSON.parse(entry));
+			.map((entry) => JSON.parse(entry))
+			.filter((patch) => Object.hasOwn(patch, "channels"));
 		expect(patches).toHaveLength(3);
 		expect(patches[0].channels.discord).toEqual({ enabled: true, token: "discord-token" });
 		expect(patches[0].session).toEqual({ dmScope: "per-account-channel-peer" });
@@ -12830,7 +11519,6 @@ exit 64
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
-		const workspace = join(home, "workspace");
 		const openclawBin = join(home, ".local", "bin", "openclaw");
 		const openclawPatch = join(root, "openclaw-channel-patch.json");
 		const openclawPluginInstalls = join(root, "openclaw-plugin-installs.txt");
@@ -12869,42 +11557,12 @@ exit 64
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 
-		const loaded: RuntimeManifestLoad = {
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_installed_plugin",
-				environmentId: "env_installed_plugin",
-				instanceId: "iid_installed_plugin",
-				generation: 2,
-				issuedAt: "2026-06-11T00:00:00Z",
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					openclaw: {
-						enabled: true,
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://openclaw.ai/install-cli.sh",
-							home,
-							args: [],
-						},
-					},
-					hermes: { enabled: false },
-				},
-				projection: {
-					system: { home, workspace },
-					channels: {
-						discord: {
-							token: "secret://channels/discord/acct-discord-1",
-						},
-					},
-				},
-				recovery: {},
+		const loaded = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 2);
+		loaded.manifest.projection = {
+			...loaded.manifest.projection,
+			channels: {
+				discord: { token: "secret://channels/discord/acct-discord-1" },
 			},
-			source: "remote-datasource",
-			sourcePath: "test://already-installed-plugin",
-			offline: false,
-			secretValues: {},
 		};
 
 		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
@@ -13157,28 +11815,20 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			generation: number,
 			revision: string,
 			install: RuntimeManifest["runtimes"][string]["install"],
-		): RuntimeManifestLoad => ({
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_cold_mcp",
-				environmentId: "env_cold_mcp",
-				instanceId: "iid_cold_mcp",
-				generation,
-				issuedAt: "2026-07-29T00:00:00Z",
-				workspaceRoot: workspace,
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: { openclaw: { enabled: true, install } },
-				projection: {
-					system: { home, workspace },
-					mcp: { servers: { clawdi: managedRemoteMcpServer("clawdi", revision) } },
-				},
-				recovery: {},
-			},
-			source: "remote-datasource",
-			sourcePath: `test://cold-mcp-${generation}`,
-			offline: false,
-			secretValues: { "secret://mcp/clawdi": "deploy-key-secret" },
-		});
+		): RuntimeManifestLoad => {
+			const loaded = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", generation);
+			loaded.manifest.workspaceRoot = workspace;
+			loaded.manifest.runtimes.openclaw.install = install;
+			loaded.manifest.projection = {
+				...loaded.manifest.projection,
+				mcp: { servers: { clawdi: managedRemoteMcpServer("clawdi", revision) } },
+			};
+			loaded.secretValues = {
+				...loaded.secretValues,
+				"secret://mcp/clawdi": "deploy-key-secret",
+			};
+			return loaded;
+		};
 		const officialInstall = {
 			authority: "official" as const,
 			method: "official-installer" as const,
@@ -13263,53 +11913,25 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			selectedRuntime: "openclaw" | "hermes",
 			servers: Record<string, ReturnType<typeof managedRemoteMcpServer>>,
 			skillEnabled = true,
-		): RuntimeManifestLoad => ({
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_generic_mcp",
-				environmentId: "env_generic_mcp",
-				instanceId: "iid_generic_mcp",
-				generation,
-				issuedAt: "2026-07-28T00:00:00Z",
-				workspaceRoot: workspace,
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					openclaw: {
-						enabled: selectedRuntime === "openclaw",
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://openclaw.ai/install-cli.sh",
-							home,
-							args: [],
-						},
-					},
-					hermes: {
-						enabled: selectedRuntime === "hermes",
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://hermes-agent.nousresearch.com/install.sh",
-							home,
-							args: [],
-						},
-					},
-				},
-				projection: {
-					system: { home, workspace },
-					mcp: { servers },
-					skills: { entries: { clawdi: { enabled: skillEnabled, version: 1 } } },
-				},
-				recovery: {},
-			},
-			source: "remote-datasource",
-			sourcePath: `test://generic-mcp-${generation}`,
-			offline: false,
-			secretValues: {
-				"secret://mcp/clawdi": "deploy-key-secret",
-				"secret://mcp/search.proxy": "search-proxy-secret",
-			},
-		});
+		): RuntimeManifestLoad => {
+			const loaded = hostedSingleProviderModeLoad(home, selectedRuntime, "unmanaged", generation);
+			loaded.manifest.workspaceRoot = workspace;
+			loaded.manifest.projection = {
+				...loaded.manifest.projection,
+				mcp: { servers },
+				skills: { entries: { clawdi: { enabled: skillEnabled, version: 1 } } },
+			};
+			loaded.secretValues = {
+				...loaded.secretValues,
+				...Object.fromEntries(
+					Object.keys(servers).map((serverName) => [
+						`secret://mcp/${serverName}`,
+						`${serverName}-secret`,
+					]),
+				),
+			};
+			return loaded;
+		};
 		const initialServers = {
 			clawdi: managedRemoteMcpServer("clawdi", "v1"),
 			"search.proxy": managedRemoteMcpServer("search.proxy", "v1"),
@@ -13584,36 +12206,20 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			},
 			paths,
 		);
-		const load = (generation: number): RuntimeManifestLoad => ({
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_mcp_ownership",
-				environmentId: "env_mcp_ownership",
-				instanceId: "iid_mcp_ownership",
-				generation,
-				issuedAt: "2026-07-28T00:00:00Z",
-				workspaceRoot: workspace,
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					openclaw: {
-						enabled: true,
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://openclaw.ai/install-cli.sh",
-							home,
-							args: [],
-						},
-					},
-				},
-				projection: { system: { home, workspace }, mcp: { servers: { clawdi: desiredServer } } },
-				recovery: {},
-			},
-			source: "remote-datasource",
-			sourcePath: `test://mcp-ownership-${generation}`,
-			offline: false,
-			secretValues: { "secret://mcp/clawdi": "deploy-key-secret" },
-		});
+		const load = (generation: number): RuntimeManifestLoad => {
+			const loaded = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", generation);
+			loaded.manifest.instanceId = "iid_mcp_ownership";
+			loaded.manifest.workspaceRoot = workspace;
+			loaded.manifest.projection = {
+				...loaded.manifest.projection,
+				mcp: { servers: { clawdi: desiredServer } },
+			};
+			loaded.secretValues = {
+				...loaded.secretValues,
+				"secret://mcp/clawdi": "deploy-key-secret",
+			};
+			return loaded;
+		};
 
 		const upgraded = convergeAndCommitTestRuntimeManifest(load(1), paths);
 		expect(upgraded.installErrors).toEqual([]);
@@ -13662,41 +12268,21 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		const load = (
 			generation: number,
 			servers: Record<string, ReturnType<typeof managedRemoteMcpServer>>,
-		): RuntimeManifestLoad => ({
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_mcp_ownership",
-				environmentId: "env_mcp_ownership",
-				instanceId: "iid_mcp_ownership",
-				generation,
-				issuedAt: "2026-07-28T00:00:00Z",
-				workspaceRoot: workspace,
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					openclaw: {
-						enabled: true,
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://openclaw.ai/install-cli.sh",
-							home,
-							args: [],
-						},
-					},
-				},
-				projection: { system: { home, workspace }, mcp: { servers } },
-				recovery: {},
-			},
-			source: "remote-datasource",
-			sourcePath: `test://mcp-ownership-${generation}`,
-			offline: false,
-			secretValues: Object.fromEntries(
-				Object.keys(servers).map((serverName) => [
-					`secret://mcp/${serverName}`,
-					`${serverName}-secret`,
-				]),
-			),
-		});
+		): RuntimeManifestLoad => {
+			const loaded = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", generation);
+			loaded.manifest.workspaceRoot = workspace;
+			loaded.manifest.projection = { ...loaded.manifest.projection, mcp: { servers } };
+			loaded.secretValues = {
+				...loaded.secretValues,
+				...Object.fromEntries(
+					Object.keys(servers).map((serverName) => [
+						`secret://mcp/${serverName}`,
+						`${serverName}-secret`,
+					]),
+				),
+			};
+			return loaded;
+		};
 
 		const beforeCollision = readFileSync(openclawConfigPath, "utf-8");
 		expect(() =>
@@ -13773,50 +12359,23 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		process.env.CLAWDI_RUN_DIR = run;
 		const paths = getRuntimePaths();
 
-		const failed = convergeRuntimeManifest(
-			{
-				manifest: {
-					schemaVersion: "clawdi.runtimeDesiredState.v1",
-					deploymentId: "dep_partial_mcp",
-					environmentId: "env_partial_mcp",
-					instanceId: "iid_partial_mcp",
-					generation: 1,
-					issuedAt: "2026-07-28T00:00:00Z",
-					workspaceRoot: workspace,
-					controlPlane: { apiUrl: "https://cloud-api.test" },
-					runtimes: {
-						openclaw: {
-							enabled: true,
-							install: {
-								authority: "official",
-								method: "official-installer",
-								url: "https://openclaw.ai/install-cli.sh",
-								home,
-								args: [],
-							},
-						},
-					},
-					projection: {
-						system: { home, workspace },
-						mcp: {
-							servers: {
-								first: managedRemoteMcpServer("first", "v1"),
-								second: managedRemoteMcpServer("second", "v1"),
-							},
-						},
-					},
-					recovery: {},
-				},
-				source: "remote-datasource",
-				sourcePath: "test://partial-mcp",
-				offline: false,
-				secretValues: {
-					"secret://mcp/first": "first-secret",
-					"secret://mcp/second": "second-secret",
+		const loaded = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 1);
+		loaded.manifest.workspaceRoot = workspace;
+		loaded.manifest.projection = {
+			...loaded.manifest.projection,
+			mcp: {
+				servers: {
+					first: managedRemoteMcpServer("first", "v1"),
+					second: managedRemoteMcpServer("second", "v1"),
 				},
 			},
-			getRuntimePaths(),
-		);
+		};
+		loaded.secretValues = {
+			...loaded.secretValues,
+			"secret://mcp/first": "first-secret",
+			"secret://mcp/second": "second-secret",
+		};
+		const failed = convergeRuntimeManifest(loaded, getRuntimePaths());
 
 		expect(failed.installErrors.join("\n")).toContain("runtime MCP projection failed");
 		expect(readFileSync(calls, "utf-8")).toBe("set first\nset second\n");
@@ -13824,153 +12383,6 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			"user-entry": { command: "user-owned", args: ["keep"] },
 		});
 		expect(readRuntimeAppliedState(paths)).toBeNull();
-	});
-
-	it("restores prior MCP authority when a forward projection is partial", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const workspace = join(home, "workspace");
-		const calls = join(root, "existing-managed-mcp-calls.log");
-		const { configPath: openclawConfig } = writeFakeOpenClawMcpBinary(home, {
-			callsPath: calls,
-			failSetServer: "second",
-		});
-		const hermesBin = join(home, ".local", "bin", "hermes");
-		mkdirSync(dirname(hermesBin), { recursive: true });
-		writeHermesVersionBinary(home, "0.20.1");
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		const paths = getRuntimePaths();
-		const hermesConfig = join(home, ".hermes", "config.yaml");
-		const ownedV1 = managedRemoteMcpServer("owned", "v1");
-		const ownedV2 = managedRemoteMcpServer("owned", "v2");
-		const second = managedRemoteMcpServer("second", "v1");
-
-		const load = (
-			generation: number,
-			servers: Record<string, ReturnType<typeof managedRemoteMcpServer>>,
-		): RuntimeManifestLoad => ({
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_existing_managed_mcp",
-				environmentId: "env_existing_managed_mcp",
-				instanceId: "iid_existing_managed_mcp",
-				generation,
-				issuedAt: "2026-07-28T00:00:00Z",
-				workspaceRoot: workspace,
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: {
-					openclaw: {
-						enabled: true,
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://openclaw.ai/install-cli.sh",
-							home,
-							args: [],
-						},
-					},
-					hermes: {
-						enabled: true,
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://hermes-agent.nousresearch.com/install.sh",
-							home,
-							args: [],
-						},
-					},
-				},
-				projection: { system: { home, workspace }, mcp: { servers } },
-				recovery: {},
-			},
-			source: "remote-datasource",
-			sourcePath: `test://existing-managed-mcp-${generation}`,
-			offline: false,
-			secretValues: {
-				"secret://mcp/owned": "owned-secret",
-				"secret://mcp/second": "second-secret",
-			},
-		});
-
-		const initial = convergeAndCommitTestRuntimeManifest(load(1, { owned: ownedV1 }), paths);
-		expect(initial.installErrors).toEqual([]);
-		const previousAppliedState = readFileSync(paths.appliedState);
-		const previousOpenClawStat = statSync(openclawConfig);
-		const previousHermesStat = statSync(hermesConfig);
-
-		const failed = convergeAndCommitTestRuntimeManifest(
-			load(2, {
-				owned: ownedV2,
-				second,
-			}),
-			paths,
-		);
-
-		expect(failed.installErrors.join("\n")).toContain("runtime MCP projection failed");
-		expect(readFileSync(calls, "utf-8")).toContain("set owned\nset owned\nset second\n");
-		expect(readOpenClawMcpServers(home)).toEqual({
-			owned: nativeManagedRemoteMcpServer("owned", "v1"),
-		});
-		expect(readHermesConfigYaml(home).mcp_servers).toEqual({
-			owned: nativeManagedRemoteMcpServer("owned", "v1"),
-		});
-		expect(readFileSync(paths.appliedState)).toEqual(previousAppliedState);
-		expect(statSync(openclawConfig).mode).toBe(previousOpenClawStat.mode);
-		expect(statSync(openclawConfig).uid).toBe(previousOpenClawStat.uid);
-		expect(statSync(openclawConfig).gid).toBe(previousOpenClawStat.gid);
-		expect(statSync(hermesConfig).mode).toBe(previousHermesStat.mode);
-		expect(statSync(hermesConfig).uid).toBe(previousHermesStat.uid);
-		expect(statSync(hermesConfig).gid).toBe(previousHermesStat.gid);
-	});
-
-	it("does not add the hosted runtime sidecar without egress profiles", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		mkdirSync(home, { recursive: true });
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-
-		const convergence = convergeRuntimeManifest(
-			{
-				manifest: {
-					schemaVersion: "clawdi.runtimeDesiredState.v1",
-					deploymentId: "dep_runtime_no_egress",
-					environmentId: "env_runtime_no_egress",
-					instanceId: "iid_runtime_no_egress",
-					generation: 1,
-					issuedAt: "2026-06-15T00:00:00Z",
-					controlPlane: { apiUrl: "https://cloud-api.test" },
-					runtimes: {
-						openclaw: {
-							enabled: true,
-							provider_ids: ["default"],
-							primary_model: { provider_id: "default", model: "gpt-5.5" },
-						},
-						hermes: { enabled: false },
-					},
-					recovery: {},
-				},
-				source: "remote-datasource",
-				sourcePath: "test://runtime-no-egress",
-				offline: false,
-				secretValues: {},
-			},
-			getRuntimePaths(),
-		);
-
-		expect(
-			convergence.outputs.systemdUserUnits.map((path) => path.split("/").at(-1)),
-		).not.toContain("clawdi-runtime-sidecar.service");
-		expect(
-			convergence.outputs.systemdSystemUnits.map((path) => path.split("/").at(-1)),
-		).not.toContain("clawdi-runtime-sidecar.service");
 	});
 
 	it("keeps provider secrets sidecar-only in the ephemeral run-dir config", () => {
@@ -13983,78 +12395,9 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		const mitmproxy = seedMitmproxyCache();
-
-		const convergence = convergeRuntimeManifest(
-			{
-				manifest: {
-					schemaVersion: "clawdi.runtimeDesiredState.v1",
-					deploymentId: "dep_provider_secret_boundary",
-					environmentId: "env_provider_secret_boundary",
-					instanceId: "iid_provider_secret_boundary",
-					generation: 1,
-					issuedAt: "2026-06-26T00:00:00Z",
-					controlPlane: { apiUrl: "https://cloud-api.test" },
-					egressEngine: mitmproxy,
-					runtimes: {
-						openclaw: {
-							enabled: true,
-							provider_ids: ["default"],
-							primary_model: { provider_id: "default", model: "gpt-5.5" },
-						},
-						hermes: { enabled: false },
-					},
-					projection: {
-						providers: {
-							default: {
-								kind: "openai-compatible",
-								baseUrl: "https://provider.test/v1",
-								model: "gpt-5.5",
-								apiMode: "openai_responses",
-								managed_by: "clawdi",
-								runtimeEnvName: "CLAWDI_AI_API_KEY",
-								apiKeySecretRef: "secret://provider.default.apiKey",
-							},
-						},
-					},
-					egressProfiles: {
-						profiles: [
-							{
-								id: "managed-provider",
-								enabled: true,
-								kind: "provider",
-								match: {
-									scheme: "https",
-									host: "provider.test",
-									headers: {},
-									query: {},
-								},
-								rewrite: {
-									setHeaders: {
-										authorization: {
-											type: "secretRef",
-											secretRef: "secret://provider.default.apiKey",
-											prefix: "Bearer ",
-										},
-									},
-								},
-								priority: 80,
-								owner: "provider-projection",
-							},
-						],
-					},
-					recovery: {},
-				},
-				source: "remote-datasource",
-				sourcePath: "test://provider-secret-boundary",
-				offline: false,
-				secretValues: {
-					"secret://provider.default.apiKey": "sk-runtime",
-					"secret://provider.hermes.apiKey": "sk-other-runtime",
-				},
-			},
-			getRuntimePaths(),
-		);
+		const loaded = hostedSingleProviderModeLoad(home, "openclaw", "configured", 1);
+		loaded.manifest.runtimes.openclaw.install = undefined;
+		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
 
 		const paths = getRuntimePaths();
 		const userUnitNames = convergence.outputs.systemdUserUnits.map((path) =>
@@ -14097,10 +12440,10 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		expect(openclawUnit).not.toContain("\nExecStart=");
 		expect(openclawUnit).not.toContain("\nWorkingDirectory=");
 		expect(openclawUnit).not.toContain("user=clawdi");
-		expect(openclawUnit).not.toContain("sk-runtime");
+		expect(openclawUnit).not.toContain("sk-managed-provider");
 		expect(openclawEnv).toContain('CLAWDI_AI_API_KEY="clawdi-egress-placeholder"');
 		expect(openclawEnv).not.toMatch(/^OPENAI_API_KEY=/m);
-		expect(openclawEnv).not.toContain("sk-runtime");
+		expect(openclawEnv).not.toContain("sk-managed-provider");
 		expect(openclawEnv).not.toContain(dirname(paths.cliManagedBin));
 		expect(statSync(join(run, "secrets")).mode & 0o777).toBe(0o711);
 		expect(existsSync(join(run, "secrets", "runtime-secrets.json"))).toBe(false);
@@ -14114,63 +12457,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			expect(statSync(egressSecretPath).gid).toBe(10002);
 		}
 		const egressSecrets = JSON.parse(readFileSync(egressSecretPath, "utf-8"));
-		expect(egressSecrets["secret://provider.default.apiKey"]).toBe("sk-runtime");
-		expect(JSON.stringify(egressSecrets)).not.toContain("sk-other-runtime");
-	});
-
-	it("does not put missing provider secrets into direct systemd launch env", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		mkdirSync(home, { recursive: true });
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-
-		convergeRuntimeManifest(
-			{
-				manifest: {
-					schemaVersion: "clawdi.runtimeDesiredState.v1",
-					deploymentId: "dep_provider_secret_missing",
-					environmentId: "env_provider_secret_missing",
-					instanceId: "iid_provider_secret_missing",
-					generation: 1,
-					issuedAt: "2026-06-26T00:00:00Z",
-					controlPlane: { apiUrl: "https://cloud-api.test" },
-					runtimes: {
-						openclaw: {
-							enabled: true,
-							provider_ids: ["default"],
-							primary_model: { provider_id: "default", model: "gpt-5.5" },
-						},
-					},
-					projection: {
-						providers: {
-							default: {
-								kind: "openai-compatible",
-								baseUrl: "https://provider.test/v1",
-								model: "gpt-5.5",
-								apiMode: "openai_responses",
-								managed_by: "clawdi",
-								runtimeEnvName: "CLAWDI_AI_API_KEY",
-								apiKeySecretRef: "secret://provider.default.apiKey",
-							},
-						},
-					},
-					recovery: {},
-				},
-				source: "remote-datasource",
-				sourcePath: "test://provider-secret-missing",
-				offline: false,
-				secretValues: {},
-			},
-			getRuntimePaths(),
-		);
-		const openclawEnv = readSystemdEnvFile(getRuntimePaths(), "openclaw-gateway");
-		expect(openclawEnv).toContain('CLAWDI_AI_API_KEY="clawdi-egress-placeholder"');
-		expect(openclawEnv).not.toMatch(/^OPENAI_API_KEY=/m);
-		expect(openclawEnv).not.toContain("secret://provider.default.apiKey");
+		expect(egressSecrets["secret://provider.clawdi-managed.apiKey"]).toBe("sk-managed-provider");
 	});
 
 	it("runs the egress-only sidecar with a lifecycle nft redirect", () => {
@@ -14183,44 +12470,19 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		const mitmproxy = seedMitmproxyCache();
-
-		const load: RuntimeManifestLoad = {
-			manifest: {
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_transparent_egress",
-				environmentId: "env_transparent_egress",
-				instanceId: "iid_transparent_egress",
-				generation: 1,
-				issuedAt: "2026-06-26T00:00:00Z",
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				egressEngine: mitmproxy,
-				runtimes: {
-					openclaw: { enabled: true },
-					hermes: { enabled: false },
-				},
-				egressProfiles: {
-					profiles: [
-						{
-							id: "deny-metadata",
-							enabled: true,
-							kind: "deny",
-							match: {
-								scheme: "https",
-								host: "169.254.169.254",
-								pathPrefix: "/",
-							},
-							priority: 1,
-						},
-					],
-				},
-				recovery: {},
+		const load = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 1);
+		load.manifest.runtimes.openclaw.install = undefined;
+		load.manifest.egressProfiles?.profiles.push({
+			id: "deny-metadata",
+			enabled: true,
+			kind: "deny",
+			match: {
+				scheme: "https",
+				host: "169.254.169.254",
+				pathPrefix: "/",
 			},
-			source: "remote-datasource",
-			sourcePath: "test://transparent-egress",
-			offline: false,
-			secretValues: {},
-		};
+			priority: 1,
+		});
 		convergeRuntimeManifest(load, getRuntimePaths());
 
 		const paths = getRuntimePaths();
@@ -14257,9 +12519,6 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		expect(transparentEgressEnv).toContain(`CLAWDI_EGRESS_ADDON_PATH="${paths.egressAddon}"`);
 		expect(transparentEgressEnv).toContain(
 			`CLAWDI_EGRESS_ENGINE_BINARY_PATH="${paths.egressServiceBinary}"`,
-		);
-		expect(sidecarUnit).toContain(
-			`BindReadOnlyPaths=${cachedMitmproxyBinary(paths, mitmproxy)}:${paths.egressServiceBinary}:norbind`,
 		);
 		expect(statSync(paths.egressProfileRoot).mode & 0o777).toBe(0o711);
 		expect(statSync(paths.egressProfileBundle).mode & 0o777).toBe(0o640);
@@ -14411,6 +12670,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		const userPath = join(workspace, "USER.md");
 		mkdirSync(workspace, { recursive: true });
 		mkdirSync(dirname(soulPath), { recursive: true });
+		seedOpenClawBinary(home);
 		writeFileSync(soulPath, "User preface.\n\nUser epilogue.\n");
 		writeFileSync(userPath, "User profile stays untouched.\n");
 		process.env.HOME = home;
@@ -14418,41 +12678,22 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 
-		const manifestFor = (language: "en" | "fr", timezone: string): RuntimeManifest => ({
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
-			deploymentId: "dep_locale_openclaw",
-			environmentId: "env_locale_openclaw",
-			instanceId: "iid_locale_openclaw",
-			generation: language === "en" ? 1 : 2,
-			issuedAt: "2026-07-11T00:00:00Z",
-			locale: { language, timezone },
-			workspaceRoot: workspace,
-			controlPlane: { apiUrl: "https://cloud-api.test" },
-			runtimes: {
-				openclaw: {
-					enabled: true,
-					run: { command: "/bin/true", args: [], env: {}, prependPath: [] },
-				},
-			},
-			recovery: {},
-		});
 		const paths = getRuntimePaths();
-		const converge = (manifest: RuntimeManifest) =>
-			convergeRuntimeManifest(
-				{
-					manifest,
-					source: "remote-datasource",
-					sourcePath: "test://locale-openclaw",
-					offline: false,
-					secretValues: {},
-				},
-				paths,
+		const converge = (language: "en" | "fr", timezone: string) => {
+			const load = hostedSingleProviderModeLoad(
+				home,
+				"openclaw",
+				"unmanaged",
+				language === "en" ? 1 : 2,
 			);
+			load.manifest.locale = { language, timezone };
+			return convergeRuntimeManifest(load, paths);
+		};
 
-		converge(manifestFor("en", "UTC"));
+		converge("en", "UTC");
 		const initialRevision = systemdEnvRevision(readSystemdEnvFile(paths, "openclaw-gateway"));
 
-		converge(manifestFor("fr", "Europe/Paris"));
+		converge("fr", "Europe/Paris");
 		const soul = readFileSync(soulPath, "utf-8");
 		expect(soul.startsWith("User preface.\n\nUser epilogue.\n")).toBe(true);
 		expect(soul.match(/clawdi managed locale/g)).toHaveLength(2);
@@ -14461,7 +12702,7 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		expect(readFileSync(userPath, "utf-8")).toBe("User profile stays untouched.\n");
 		const updatedEnv = readSystemdEnvFile(paths, "openclaw-gateway");
 		expect(systemdEnvRevision(updatedEnv)).not.toBe(initialRevision);
-		converge(manifestFor("fr", "Europe/Paris"));
+		converge("fr", "Europe/Paris");
 		expect(readFileSync(soulPath, "utf-8")).toBe(soul);
 		expect(systemdEnvRevision(readSystemdEnvFile(paths, "openclaw-gateway"))).toBe(
 			systemdEnvRevision(updatedEnv),
@@ -14518,97 +12759,6 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 		const config = readHermesConfigYaml(home);
 		expect(config.custom_setting).toBe("keep");
 		expect(config.timezone).toBe("Asia/Taipei");
-	});
-
-	it("runtime program revisions ignore unrelated control-plane and sibling runtime changes", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		mkdirSync(home, { recursive: true });
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		const baseManifest: RuntimeManifest = {
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
-			deploymentId: "dep_revision",
-			environmentId: "env_revision",
-			instanceId: "iid_revision",
-			generation: 1,
-			issuedAt: "2026-06-06T00:00:00Z",
-			controlPlane: { apiUrl: "https://cloud-api.test" },
-			clawdiCli: { source: "npm:clawdi", packageSpec: TEST_RUNNING_CLI_SPEC },
-			runtimes: {
-				openclaw: {
-					enabled: true,
-					services: {
-						worker: {
-							command: "/bin/true",
-							args: [],
-							env: {},
-							prependPath: [],
-						},
-					},
-				},
-				hermes: { enabled: false },
-			},
-			recovery: {},
-		};
-		const revisionFor = (manifest: RuntimeManifest, unitName: string) => {
-			const paths = getRuntimePaths();
-			convergeRuntimeManifest(
-				{
-					manifest,
-					source: "remote-datasource",
-					sourcePath: "test://revision",
-					offline: false,
-					secretValues: {},
-				},
-				paths,
-			);
-			return systemdEnvRevision(readSystemdEnvFile(paths, unitName));
-		};
-
-		const baseRev = revisionFor(baseManifest, "openclaw-gateway");
-		const baseWorkerRev = revisionFor(baseManifest, "clawdi-openclaw-worker");
-		const controlPlaneRev = revisionFor(
-			{
-				...baseManifest,
-				controlPlane: { apiUrl: "https://cloud-api-next.test" },
-			},
-			"openclaw-gateway",
-		);
-		const controlPlaneWorkerRev = revisionFor(
-			{
-				...baseManifest,
-				controlPlane: { apiUrl: "https://cloud-api-next.test" },
-			},
-			"clawdi-openclaw-worker",
-		);
-		const skillOnlyManifest: RuntimeManifest = {
-			...baseManifest,
-			projection: {
-				skills: { entries: { clawdi: { enabled: true, version: 1 } } },
-			},
-		};
-		const skillGatewayRev = revisionFor(skillOnlyManifest, "openclaw-gateway");
-		const skillWorkerRev = revisionFor(skillOnlyManifest, "clawdi-openclaw-worker");
-		const siblingRuntimeRev = revisionFor(
-			{
-				...baseManifest,
-				runtimes: {
-					...baseManifest.runtimes,
-					hermes: { enabled: true },
-				},
-			},
-			"openclaw-gateway",
-		);
-
-		expect(controlPlaneRev).toBe(baseRev);
-		expect(controlPlaneWorkerRev).toBe(baseWorkerRev);
-		expect(skillGatewayRev).toBe(baseRev);
-		expect(skillWorkerRev).toBe(baseWorkerRev);
-		expect(siblingRuntimeRev).toBe(baseRev);
 	});
 
 	it("rejects a desired generation below the durable applied generation", async () => {


### PR DESCRIPTION
## Summary

- Make the strict hosted runtime wire schema the only manifest admission and semantic-validation boundary.
- Remove the generic runtime Zod schema, the standalone hosted-to-runtime converter, the unused hosted manifest schema, the fixture normalizer, and unreachable generic/hosted branches.
- Persist the validated wire bundle as last-good state, with secret values remaining in the separate root-only cache.
- Remove the `sourceBundleVersion` / `sourceSchemaVersion` marker layer and every production guard derived from it.

This changes 27 files with 1,358 additions and 4,182 deletions: **2,824 net lines removed**.

## Review Evidence

- C#2: `/home/kingsley/clawdi-meta/reviews/hosted-cli-lean-r6/C-lifecycle-contract.md:6` identifies the duplicate wire/generic schemas, duplicated semantic validation, converter, unused schema, and fixture normalizer.
- C#6: `/home/kingsley/clawdi-meta/reviews/hosted-cli-lean-r6/C-lifecycle-contract.md:10` identifies the nine marker checks that only test data could bypass.

## Contract Changes

- `hostedRuntimeBundleV2ManifestWireSchema.superRefine(...)` is the single semantic-validation pass.
- `hostedRuntimeBundleV2ManifestSchema` performs the sole validated wire-to-runtime projection inside that schema boundary.
- `manifest.last-good.json` now stores the validated `clawdi.hosted-runtime.bundle.v2` wire object with `secretValues: {}`.
- `runtime-secrets.last-good.json` continues to store the exact recoverable secret union separately.
- Offline reconstruction parses the wire bundle, restores cached secrets, then derives channel/runtime projections again.
- Internal test-only loads without a wire `sourceBundle` no longer manufacture a normalized last-good file.

## Managed WhatsApp Native E2E

- WhatsApp `accountKey`, `credential.id`, secret refs, and runtime targets remain sourced unchanged from the bundle-level `channelBindings`; they were never fields of the inner manifest converter.
- The removed behavior was the generic-only `projection.system.home` fallback. The native fixture still manufactured that retired shape, so channel projection used the container ambient `HOME` while credential materialization asserted the stock `/opt/stock/...` home.
- The fixture now supplies the existing hosted path authority through `CLAWDI_RUNTIME_HOME`. OpenClaw and Hermes auth-directory assertions are unchanged, and no product environment variable, fallback, or compatibility reader was added.

## Upgrade Rollout

- The 0.13.92 and 0.14.14 last-good cache uses the generic shape. The new CLI reads it as a Zod error and enters `repair/local`; while online, the first watch tick fetches a complete bundle and rewrites the cache in wire format. The only gap is a pod restart while the control plane is unreachable between CLI symlink activation and the first successful commit, a seconds-to-minutes window.
- During this one upgrade converge, the unreadable old cache makes `isRuntimeCliOnlyCheckpoint=false` and therefore `preserveActiveUnits=false`. All 66 hosts restart their agent units once. Roll out during a low-traffic window.

## Added

No product environment variables, flags, installer hooks, or compatibility readers were added.

- A structural `RuntimeManifest` type and the transform on the wire schema replace the generic `manifestSchema`, `runtimeSchema`, `runtimeProjectionSchema`, the second semantic validator, and `hostedManifestToRuntimeManifest`.
- `RuntimeManifestLoad.sourceBundle` replaces `sourceManifest`, normalized-cache persistence, and marker fields used to prove hosted origin.
- `parseHostedRuntimeBundleV2` replaces both `normalizeHostedRuntimeBundleV2` and `normalizeRemoteManifestPayload`; it has no fixture URL or test-only product branch.
- Wire-cache parsing in runtime verify/watch, provider observation, and Agent Plugin observation replaces readers of the deleted normalized schema.
- Existing e2e fixtures now declare the already-required OpenClaw capability and delegate Hermes config commands to the existing repository mock; this replaces behavior previously skipped behind the removed marker guards.

## Persistent State Migration

The 0.13.92 and 0.14.14 writers use the same normalized last-good shape. There is deliberately no read-compatibility layer for it: an offline first boot rejects it as invalid wire state and remains in repair; the next successful online converge atomically replaces it.

| Persistent item | 0.13.92 / 0.14.14 on disk | First converge in this PR |
|---|---|---|
| `/var/cache/clawdi/manifest.last-good.json` filename | Root-owned normalized runtime manifest | Filename is claimed unchanged. Online success atomically overwrites it with validated wire; offline old format is ignored as invalid and enters repair. |
| Top-level `schemaVersion: clawdi.runtimeDesiredState.v1` | Identifies the normalized cache | Rejected at the wire boundary offline; removed by the first online overwrite. |
| Top-level `schemaVersion: clawdi.hosted-runtime.bundle.v2` | Absent | Written on the first online converge and used for every later cache read. |
| `manifest.schemaVersion: clawdi.hosted-runtime.manifest.v1` | Only copied indirectly into `projection.sourceSchemaVersion` | The original inner enum value is preserved in the new wire cache on first online converge. |
| `projection.sourceBundleVersion` | `clawdi.hosted-runtime.bundle.v2` marker | Deleted. Old cache is invalid offline; first online overwrite omits it. |
| `projection.sourceSchemaVersion` | `clawdi.hosted-runtime.manifest.v1` marker | Deleted. Old cache is invalid offline; first online overwrite omits it. |
| `sourceRevision` | Not in the normalized manifest cache; separately present in applied authority | Claimed as the original outer wire field on first online converge and validated against the strong ETag. |
| `applyGeneration` | Normalized onto the internal runtime manifest when present | Preserved at its original outer wire location; offline parsing projects it into runtime state. First online overwrite retires the normalized placement. |
| `channelBindings` | Raw bindings discarded; derived `projection.channels` / `channelCredentials` cached | Raw wire array is preserved and re-projected online/offline. First online overwrite retires derived cache authority. |
| `secretValues` in `manifest.last-good.json` | Field absent; secrets stored separately | Explicitly written as `{}` so the wire shape remains complete without plaintext. Cached secrets are reattached only in memory. |
| `/var/cache/clawdi/runtime-secrets.last-good.json` | Root-owned recoverable secret map | Filename and format are claimed unchanged; first online converge rewrites only the active recoverable union and removes stale entries. |
| `/var/lib/clawdi/status/runtime-applied.json.contentIdentity.sha256` | Hash of normalized manifest plus recoverable secrets | Recomputed from wire bundle plus the same recoverable secret union on first online commit. Old cache cannot be mixed with new authority. |
| Cache file mode | Both last-good files are `0600`, root-owned | Unchanged and asserted after first converge. |
| `/var/cache/clawdi` parent | Root-owned `0700`, provisioned by the platform root / systemd `CacheDirectoryMode=0700` contract | Assumption is unchanged; this PR neither renames nor chmods the platform root. |

Migration coverage:

- `runtime.test.ts` writes the main-branch normalized format and proves offline first load fails closed without leaking cached secrets.
- `runtime.test.ts` seeds normalized manifest and secret caches, runs the first online `runtime init`, proves successful channel convergence, then asserts wire outer/inner schema values, removed marker fields, stale-secret removal, and `0600` files.
- `runtime-bundle-v2.test.ts` proves online-to-offline wire replay, secret separation, exact content identity, and mixed manifest/apply/secret snapshot rejection.
- The privileged behavioral guards prove last-good replay after a failed candidate and recovery after a write-side crash.

## Scope Exceptions

Minimal out-of-territory hunks are limited to consequences of deleting the marker/cache layer:

- Marker guard removal only: `hosted-agent-plugin-package.ts`, `hosted-openclaw-context.ts`, `manifest-converge.ts`, `manifest-egress.ts`, `manifest-providers.ts`, `manifest-runtime-config.ts`, `projection-home.ts`, and `runtime-systemd-reconciliation.ts`.
- Wire-cache plumbing only: `channels.ts`, `manifest-secrets.ts`, and `hosted-agent-plugin-observation.ts`.
- Existing tests were rewritten in place; no new test files were added.
- Native WhatsApp e2e only: `project.e2e.ts` replaces its retired generic `projection.system.home` fixture authority with the existing `CLAWDI_RUNTIME_HOME`; the auth-directory assertions are unchanged.

## Verification

All verification ran in isolated containers.

- CLI typecheck: pass.
- CLI suite: **1,666 pass, 4 expected skip, 0 fail** across 135 files; 8,455 assertions.
- Biome: **1,071 files checked**, no errors.
- Privileged `runtime-official-installer-systemd` e2e: **9 pass, 0 fail**, 415 assertions, including real cold boot, rollback, last-good replay, and crash recovery.
- Managed WhatsApp native Docker e2e: **OpenClaw pass and Hermes pass**, including unchanged auth-directory checks, real stock runtime connection, inbound delivery, outbound delivery, and reconnect.
- `git diff --check`: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
