### PR TITLE
fix(runtime): project trusted proxies for OpenClaw

### DIFF
--- a/backend/app/schemas/runtime.py
+++ b/backend/app/schemas/runtime.py
@@ -8,6 +8,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    IPvAnyAddress,
     JsonValue,
     SecretStr,
     TypeAdapter,
@@ -577,6 +578,11 @@ class HostedRuntimeSystem(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     openclawControlUiAllowedOrigins: list[str] | None = None
+    openclawGatewayTrustedProxies: list[IPvAnyAddress] | None = Field(
+        default=None,
+        min_length=1,
+        max_length=16,
+    )
     openclawControlUiBasePath: str | None = None
     openclawGatewayAuth: HostedOpenClawGatewayAuth | None = None
     hermesDashboardAuth: HostedHermesDashboardAuth | None = None
@@ -587,6 +593,16 @@ class HostedRuntimeSystem(BaseModel):
         if value is None:
             return None
         return [_validate_http_origin(origin) for origin in value]
+
+    @field_validator("openclawGatewayTrustedProxies")
+    @classmethod
+    def _validate_trusted_proxies(
+        cls,
+        value: list[IPvAnyAddress] | None,
+    ) -> list[IPvAnyAddress] | None:
+        if value is not None and len(set(value)) != len(value):
+            raise ValueError("must not contain duplicate IP addresses")
+        return value
 
     @field_validator("openclawControlUiBasePath")
     @classmethod

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -2069,6 +2069,12 @@ async def test_admin_runtime_state_rejects_noncanonical_runtime_entries(
         {**TEST_SYSTEM, "openclawControlUiAllowedOrigins": ["ftp://cloud.test"]},
         {**TEST_SYSTEM, "openclawControlUiAllowedOrigins": ["https://cloud.test/path"]},
         {**TEST_SYSTEM, "openclawControlUiAllowedOrigins": ["https://cloud.test/"]},
+        {**TEST_SYSTEM, "openclawGatewayTrustedProxies": ["10.173.0.0/20"]},
+        {**TEST_SYSTEM, "openclawGatewayTrustedProxies": ["incusbr0"]},
+        {
+            **TEST_SYSTEM,
+            "openclawGatewayTrustedProxies": ["10.173.0.1", "10.173.0.1"],
+        },
     ],
 )
 async def test_admin_runtime_state_requires_canonical_system(

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -159,6 +159,7 @@ def _batch(
         locale={"language": "en", "timezone": "UTC"},
         system={
             "openclawControlUiAllowedOrigins": ["https://agent.example.test"],
+            "openclawGatewayTrustedProxies": ["10.173.0.1"],
             "openclawGatewayAuth": {
                 "mode": "token",
                 "tokenRef": "secret://runtime/openclaw/gateway-token",
@@ -390,6 +391,9 @@ def test_runtime_source_revision_uses_only_projected_descriptor_and_secret_sourc
 
     assert initial.source_revision == irrelevant.source_revision
     assert initial.source_revision != rotated.source_revision
+    assert initial.manifest["system"]["openclawGatewayTrustedProxies"] == [
+        "10.173.0.1"
+    ]
     assert initial.manifest["skills"] == {"entries": {"clawdi": {"enabled": True, "version": 1}}}
     assert initial.secret_values == {}
     assert initial.channel_bindings == [

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -391,9 +391,7 @@ def test_runtime_source_revision_uses_only_projected_descriptor_and_secret_sourc
 
     assert initial.source_revision == irrelevant.source_revision
     assert initial.source_revision != rotated.source_revision
-    assert initial.manifest["system"]["openclawGatewayTrustedProxies"] == [
-        "10.173.0.1"
-    ]
+    assert initial.manifest["system"]["openclawGatewayTrustedProxies"] == ["10.173.0.1"]
     assert initial.manifest["skills"] == {"entries": {"clawdi": {"enabled": True, "version": 1}}}
     assert initial.secret_values == {}
     assert initial.channel_bindings == [

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -780,12 +780,6 @@ function validateHostedRuntimeManifest(
 				systemPath("openclawControlUiAllowedOrigins"),
 			);
 		}
-		if (!manifest.system.openclawGatewayTrustedProxies?.length) {
-			addIssue(
-				"OpenClaw v2 reverse proxy requires explicit trusted proxy IPs",
-				systemPath("openclawGatewayTrustedProxies"),
-			);
-		}
 		const run = manifest.runtimes.openclaw?.run;
 		if (!isHostedGatewayRunArgs("openclaw", run?.args)) {
 			addIssue(

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -1,3 +1,4 @@
+import { isIP } from "node:net";
 import { join } from "node:path";
 import {
 	AI_PROVIDER_API_MODES,
@@ -83,6 +84,10 @@ export function officialInstallArgs(runtime: string, home: string): string[] {
 }
 
 const hostedRuntimeChoiceSchema = z.enum(["openclaw", "hermes"]);
+const trustedProxyIpSchema = z
+	.string()
+	.max(64)
+	.refine((value) => isIP(value) !== 0, "must be an exact IPv4 or IPv6 address");
 
 function cleanHttpsUrl(value: string): URL | null {
 	try {
@@ -684,6 +689,12 @@ const hostedRuntimeManifestBaseSchema = z
 		system: z
 			.object({
 				openclawControlUiAllowedOrigins: z.array(urlOriginSchema).optional(),
+				openclawGatewayTrustedProxies: z
+					.array(trustedProxyIpSchema)
+					.min(1)
+					.max(16)
+					.refine((values) => new Set(values).size === values.length, "must not contain duplicates")
+					.optional(),
 				openclawControlUiBasePath: z
 					.string()
 					.regex(/^\/(?:[^/?#]+(?:\/[^/?#]+)*)?$/)
@@ -769,6 +780,12 @@ function validateHostedRuntimeManifest(
 				systemPath("openclawControlUiAllowedOrigins"),
 			);
 		}
+		if (!manifest.system.openclawGatewayTrustedProxies?.length) {
+			addIssue(
+				"OpenClaw v2 reverse proxy requires explicit trusted proxy IPs",
+				systemPath("openclawGatewayTrustedProxies"),
+			);
+		}
 		const run = manifest.runtimes.openclaw?.run;
 		if (!isHostedGatewayRunArgs("openclaw", run?.args)) {
 			addIssue(
@@ -808,6 +825,12 @@ function validateHostedRuntimeManifest(
 			addIssue(
 				"OpenClaw gateway auth is only valid for the OpenClaw runtime",
 				systemPath("openclawGatewayAuth"),
+			);
+		}
+		if (manifest.system.openclawGatewayTrustedProxies) {
+			addIssue(
+				"OpenClaw trusted proxies are only valid for the OpenClaw runtime",
+				systemPath("openclawGatewayTrustedProxies"),
 			);
 		}
 		if (!isHostedGatewayRunArgs("hermes", manifest.runtimes.hermes?.run.args)) {

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -778,6 +778,7 @@ export function openClawGatewayHostedPatch(
 	ownerBrowserBootstrapSupported: boolean,
 ): Record<string, unknown> | null {
 	const allowedOrigins = openClawControlUiAllowedOrigins(manifest);
+	const trustedProxies = openClawGatewayTrustedProxies(manifest);
 	const gatewayToken = manifest.openclawGatewayAuth
 		? runtimeSecretValue(secretValues ?? {}, manifest.openclawGatewayAuth.tokenRef)
 		: null;
@@ -801,6 +802,7 @@ export function openClawGatewayHostedPatch(
 			: {}),
 		gateway: {
 			mode: "local",
+			trustedProxies,
 			...(gatewayToken || allowedOrigins.length > 0
 				? {
 						...(nativeAuth ? { port: 18789, bind: "lan" } : {}),
@@ -904,4 +906,12 @@ function openClawControlUiAllowedOrigins(manifest: RuntimeManifest): string[] {
 		origins.push(origin);
 	}
 	return origins;
+}
+function openClawGatewayTrustedProxies(manifest: RuntimeManifest): string[] {
+	const system = manifest.projection?.system;
+	if (!isPlainRecord(system)) return [];
+	const raw = system.openclawGatewayTrustedProxies;
+	return Array.isArray(raw)
+		? raw.filter((value): value is string => typeof value === "string")
+		: [];
 }

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -802,7 +802,7 @@ export function openClawGatewayHostedPatch(
 			: {}),
 		gateway: {
 			mode: "local",
-			trustedProxies,
+			...(trustedProxies.length > 0 ? { trustedProxies } : {}),
 			...(gatewayToken || allowedOrigins.length > 0
 				? {
 						...(nativeAuth ? { port: 18789, bind: "lan" } : {}),

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -248,6 +248,7 @@ function preparedTestAgentPluginState(
 function hostedSystemFixture(overrides: Record<string, unknown> = {}): Record<string, unknown> {
 	return {
 		openclawControlUiAllowedOrigins: ["https://agent.example.test"],
+		openclawGatewayTrustedProxies: ["10.173.0.1"],
 		openclawControlUiBasePath: "/control",
 		openclawGatewayAuth: hostedOpenClawNativeAuth(),
 		...overrides,
@@ -2088,6 +2089,22 @@ chmod 0755 '${commandPath}'
 		).toBe(false);
 	});
 
+	test.each([
+		{ trustedProxies: ["10.173.0.0/20"] },
+		{ trustedProxies: ["incusbr0"] },
+		{ trustedProxies: ["10.173.0.1", "10.173.0.1"] },
+	])("rejects non-exact OpenClaw trusted proxy IPs $trustedProxies", ({ trustedProxies }) => {
+		expect(
+			hostedRuntimeBundleV2ManifestSchema.safeParse(
+				hostedManifestFixture({
+					system: hostedSystemFixture({
+						openclawGatewayTrustedProxies: trustedProxies,
+					}),
+				}),
+			).success,
+		).toBe(false);
+	});
+
 	test("preserves canonical OpenClaw Control UI origins through gateway projection", () => {
 		const paths = tempRuntimePaths();
 		const openclawBin = join(paths.userHome, ".local", "bin", "openclaw");
@@ -2149,6 +2166,7 @@ chmod 0755 '${commandPath}'
 			gateway: {
 				port: 18789,
 				bind: "lan",
+				trustedProxies: ["10.173.0.1"],
 				auth: { mode: "token", token: "gateway-token" },
 				controlUi: {
 					allowedOrigins,

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -71,6 +71,7 @@ import {
 	OFFICIAL_INSTALL_URLS,
 	officialInstallArgs,
 } from "./manifest-contract";
+import { openClawGatewayHostedPatch } from "./manifest-providers";
 import {
 	AGENT_PLUGINS_SCHEMA_1_0_0,
 	type HostedAgentPluginsDesiredState,
@@ -2103,6 +2104,17 @@ chmod 0755 '${commandPath}'
 				}),
 			).success,
 		).toBe(false);
+	});
+
+	test("accepts legacy OpenClaw manifests without trusted proxies and omits the patch", () => {
+		const system = hostedSystemFixture();
+		delete system.openclawGatewayTrustedProxies;
+		const manifest = hostedRuntimeBundleV2ManifestSchema.parse(hostedManifestFixture({ system }));
+
+		const patch = openClawGatewayHostedPatch(manifest, TEST_HOSTED_SECRET_VALUES, false);
+
+		expect(patch).not.toBeNull();
+		expect(patch).not.toHaveProperty("gateway.trustedProxies");
 	});
 
 	test("preserves canonical OpenClaw Control UI origins through gateway projection", () => {

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -51,7 +51,7 @@ const goldenPath = resolve(
 	"../../../../test-fixtures/runtime-bundle-v2.golden.json",
 );
 const EXPECTED_GOLDEN_SOURCE_REVISION =
-	"5cd6786cf4ca7021d7002f920c8a2870bfddbd9b20ba7503a8ec6977a4c5fbef";
+	"ded7e0de9c12e7386940243ff8f7e4a5f3e37e3d2a1b91a6626724ffe618a4ce";
 const originalEnv = { ...process.env };
 const originalFetch = globalThis.fetch;
 const roots: string[] = [];

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -6097,6 +6097,8 @@ export interface components {
         HostedRuntimeSystem: {
             /** Openclawcontroluiallowedorigins */
             openclawControlUiAllowedOrigins?: string[] | null;
+            /** Openclawgatewaytrustedproxies */
+            openclawGatewayTrustedProxies?: string[] | null;
             /** Openclawcontroluibasepath */
             openclawControlUiBasePath?: string | null;
             openclawGatewayAuth?: components["schemas"]["HostedOpenClawGatewayAuth"] | null;

--- a/test-fixtures/runtime-bundle-v2.golden.json
+++ b/test-fixtures/runtime-bundle-v2.golden.json
@@ -94,6 +94,7 @@
 		},
 		"system": {
 			"openclawControlUiAllowedOrigins": ["https://agent.example.test"],
+			"openclawGatewayTrustedProxies": ["10.173.0.1"],
 			"openclawGatewayAuth": {
 				"mode": "token",
 				"tokenRef": "secret://runtime/openclaw/gateway-token",
@@ -132,5 +133,5 @@
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/agent-token": "123456789:telegram-agent-golden",
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/placeholder-token": "999999999:9ded1453047ec0a48ec3b735075f7448"
 	},
-	"sourceRevision": "5cd6786cf4ca7021d7002f920c8a2870bfddbd9b20ba7503a8ec6977a4c5fbef"
+	"sourceRevision": "ded7e0de9c12e7386940243ff8f7e4a5f3e37e3d2a1b91a6626724ffe618a4ce"
 }


### PR DESCRIPTION
## Summary

- accept exact trusted proxy IPs in the hosted runtime system contract
- require the field for OpenClaw manifests and reject it for Hermes
- project the trusted proxies into `gateway.trustedProxies` during CLI reconciliation

## Rollout

Deploy the cloud-api receiver and publish the updated CLI before the dependent Hosted producer PR begins emitting this field.

## Verification

- `scripts/test.sh cli src/runtime/manifest-reconciliation.test.ts` (184 passed)
- `scripts/test.sh backend tests/test_runtime_manifest.py::test_admin_runtime_state_requires_canonical_system tests/test_runtime_source.py::test_runtime_source_revision_uses_only_projected_descriptor_and_secret_sources` (12 passed)
- Biome check on the three changed CLI files
- Ruff check on the three changed backend files