### PR TITLE
refactor(cli): return tenant home ownership to runtime user

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Status | Public runtime contract |
-| Last updated | 2026-08-20 |
+| Last updated | 2026-08-24 |
 | Owner | CLI runtime and cloud-api layers |
 
 This document describes the public Clawdi CLI and dashboard contract for managed
@@ -351,13 +351,11 @@ candidate has no separate active/previous link state or hand-built chroot.
 
 `clawdi-files.service` runs as the non-root tenant runtime UID/GID so Files has
 native read/write access to tenant-owned home content, including `0600` files,
-`0700` directories, and dotfiles. Reconciliation repairs tenant-home ownership
-recursively except for declared platform enclaves:
-`$HOME/.config/systemd/user` and OpenClaw's
-`$HOME/.openclaw/gateway.systemd.env`. The same ownership enforcer repairs
-non-root drift inside those enclaves back to root while repairing root drift
-outside them back to the tenant. It does not rewrite modes or ACLs.
-Candidate directories and binaries remain root-owned. The root-authored JWT
+`0700` directories, and dotfiles. The entire tenant home, including user units
+and official runtime configuration, belongs to the tenant UID/GID. Hosted
+convergence recursively migrates legacy root-owned home trees without following
+symlinks. Candidate directories and binaries remain root-owned outside the
+tenant home. The root-authored JWT
 configuration is a `root:<runtime group>` `0440` file below a root-only `0700`
 directory, so other tenant processes cannot traverse to it; systemd publishes
 that file and the verified binary only inside the Files mount namespace through
@@ -393,15 +391,19 @@ When a later manifest omits the companion, normal stale-unit
 reconciliation stops and withdraws only `clawdi-files.service` while preserving
 the selected Hermes or OpenClaw unit.
 
-The unavoidable workspace boundary is content-level: the tenant owns its home
-outside the declared platform enclaves and can edit or delete its contents and
-Files state. This does not grant the tenant control over the root-owned binary,
-configuration secret source,
-receipts, unit, or listener authority. Port 9120 has normal socket exclusivity
-rather than a separate tenant-slice reservation: the tenant cannot displace the
-running service, but can bind 9120 while it is not listening and thereby cause
-later activation/readiness proof to fail. That remaining availability boundary
-does not let reconciliation adopt the tenant process as the managed unit.
+The unavoidable workspace boundary is content-level: the tenant owns its whole
+home and can edit or delete its contents, user units, official runtime config,
+and Files state. The tenant can already stop, start, or alter its own user
+services. Hosted convergence restores managed unit and drop-in bytes from
+declarative state and restarts an active unit when those rendered bytes changed;
+it leaves every foreign systemd drop-in untouched. This does not grant the
+tenant control over the root-owned Files binary, configuration secret source,
+receipts, system unit, or listener authority. Port 9120 has normal socket
+exclusivity rather than a separate tenant-slice reservation: the tenant cannot
+displace the running service, but can bind 9120 while it is not listening and
+thereby cause later activation/readiness proof to fail. That remaining
+availability boundary does not let reconciliation adopt the tenant process as
+the managed unit.
 
 The pinned upstream contracts are File Browser's
 [JWT verifier](https://github.com/gtsteffaniak/filebrowser/blob/79552f8adb27c3e29934c4001660eb98f4aab5d6/backend/auth/jwt.go),
@@ -1380,8 +1382,8 @@ and ephemeral runtime handoffs. Important outputs include:
 | `/run/clawdi/systemd/env/*.service.env` | Root-owned system-service env files or tenant-owned `0600` user-service env handoffs |
 | `/run/clawdi/egress/systemd/ca.pem` | Deliberately published root:tenant-group `0640` transparent-egress CA bundle |
 | `$CLAWDI_RUN_DIR/systemd/system/*.service` or `/run/systemd/system/*.service` | Generated system units for root-owned Clawdi support programs |
-| `$HOME/.config/systemd/user/*.service` | Official runtime gateway base units and direct runtime-user programs |
-| `$HOME/.config/systemd/user/*.service.d/10-clawdi-hosted.conf` | Transparent hosted drop-ins for official runtime units |
+| `$HOME/.config/systemd/user/*.service` | Tenant-owned official runtime gateway base units and direct runtime-user programs |
+| `$HOME/.config/systemd/user/*.service.d/10-clawdi-hosted.conf` | Tenant-owned hosted drop-ins for official runtime units; foreign drop-ins are preserved |
 
 Hosted convergence never writes `~/.clawdi`. Before launch it removes legacy
 `~/.clawdi/environments/*.json` files only when their `managedBy` value is

--- a/packages/cli/src/runtime/hermes-config.ts
+++ b/packages/cli/src/runtime/hermes-config.ts
@@ -3,11 +3,7 @@ import { isAbsolute } from "node:path";
 import { parseDocument } from "yaml";
 import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "../lib/private-file";
 import { stripTerminalEscapes } from "../lib/sanitize";
-import {
-	RuntimeUserCommandTimeoutError,
-	spawnRuntimeUserCommand,
-	withRuntimeUserFileAccess,
-} from "./runtime-user-command";
+import { RuntimeUserCommandTimeoutError, spawnRuntimeUserCommand } from "./runtime-user-command";
 
 const HERMES_CONFIG_COMMAND_TIMEOUT_MS = 30_000;
 
@@ -88,7 +84,7 @@ function readHermesConfigDocumentAtPath(path: string): {
 } {
 	let content = "";
 	try {
-		content = withRuntimeUserFileAccess(() => readFileSync(path, "utf8"));
+		content = readFileSync(path, "utf8");
 	} catch (error) {
 		if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
 			throw new Error(
@@ -162,12 +158,10 @@ function setHermesStructuredConfigValue(
 		}
 	}
 	document.setIn(keyPath, document.createNode(value));
-	withRuntimeUserFileAccess(() =>
-		writePrivateFileAtomic(path, String(document), {
-			mode: PRIVATE_FILE_MODE,
-			dirMode: PRIVATE_DIR_MODE,
-		}),
-	);
+	writePrivateFileAtomic(path, String(document), {
+		mode: PRIVATE_FILE_MODE,
+		dirMode: PRIVATE_DIR_MODE,
+	});
 }
 
 export function setHermesConfigValue(

--- a/packages/cli/src/runtime/hosted-agent-plugin-package.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-package.ts
@@ -44,7 +44,6 @@ import {
 	looksLikeMcpSecretLiteral,
 } from "./mcp-credential-policy";
 import type { RuntimePaths } from "./paths";
-import { makeRuntimeUserOwned, withRuntimeUserFileAccess } from "./runtime-user-command";
 import { writeRuntimePlatformFileAtomic } from "./state";
 
 export const HERMES_AGENT_PLUGIN_REMOTE_UNSUPPORTED_ERROR =
@@ -1044,16 +1043,13 @@ export function withPreparedAgentPluginDirectory<T>(
 	const root = mkdtempSync(join(tmpdir(), "clawdi-agent-plugin-stage-"));
 	try {
 		chmodSync(root, 0o700);
-		makeRuntimeUserOwned(root);
 		const sourceDir = join(root, "package");
-		withRuntimeUserFileAccess(() => {
-			mkdirSync(sourceDir, { recursive: true, mode: 0o700 });
-			for (const file of prepared.tree) {
-				const target = join(sourceDir, ...file.path.split("/"));
-				mkdirSync(dirname(target), { recursive: true, mode: 0o700 });
-				writeFileSync(target, file.bytes, { mode: file.mode & 0o777 });
-			}
-		});
+		mkdirSync(sourceDir, { recursive: true, mode: 0o700 });
+		for (const file of prepared.tree) {
+			const target = join(sourceDir, ...file.path.split("/"));
+			mkdirSync(dirname(target), { recursive: true, mode: 0o700 });
+			writeFileSync(target, file.bytes, { mode: file.mode & 0o777 });
+		}
 		return operation(sourceDir);
 	} finally {
 		rmSync(root, { recursive: true, force: true });

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
@@ -25,8 +25,7 @@ import {
 } from "./hosted-agent-plugin-runtime";
 import { AGENT_PLUGINS_SCHEMA_1_0_0 } from "./manifest-resources";
 import {
-	enforceRuntimeUserOwnership,
-	runtimeUserExistingOwnership,
+	ensureRuntimeUserHomeOwnership,
 	runtimeUserGid,
 	runtimeUserUid,
 } from "./runtime-user-command";
@@ -458,7 +457,10 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 				}),
 			).toThrow();
 
-			enforceRuntimeUserOwnership(runtimeUserExistingOwnership([stateRoot], { recursive: true }));
+			ensureRuntimeUserHomeOwnership(stateRoot, {
+				uid: runtimeUserUid("nobody"),
+				gid: runtimeUserGid("nobody"),
+			});
 			expect(() =>
 				prepareHostedAgentPluginTransaction({
 					prepared,

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
@@ -219,14 +219,12 @@ function nativeInstallRoot(home: string, runtime: HostedAgentPluginRuntime): str
 
 function nativeInstallTargetNames(home: string, runtime: HostedAgentPluginRuntime): Set<string> {
 	const root = nativeInstallRoot(home, runtime);
-	return withRuntimeUserFileAccess(() => {
-		try {
-			return new Set(readdirSync(root));
-		} catch (error) {
-			if (error instanceof Error && "code" in error && error.code === "ENOENT") return new Set();
-			throw error;
-		}
-	});
+	try {
+		return new Set(readdirSync(root));
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return new Set();
+		throw error;
+	}
 }
 
 function assertTrustedInstalledDirectory(
@@ -266,20 +264,18 @@ function inspectInstalledPluginDirectory(input: {
 	reportedPath?: string;
 	ignoreTopLevelGitMetadata?: boolean;
 }): { installPath: string; contentDigest: string } {
-	return withRuntimeUserFileAccess(() => {
-		const installPath = assertTrustedInstalledDirectory(
-			input.home,
-			input.runtime,
-			input.nativeId,
-			input.reportedPath,
-		);
-		return {
-			installPath,
-			contentDigest: hostedAgentPluginDirectoryDigest(installPath, {
-				ignoreTopLevelGitMetadata: input.ignoreTopLevelGitMetadata,
-			}),
-		};
-	});
+	const installPath = assertTrustedInstalledDirectory(
+		input.home,
+		input.runtime,
+		input.nativeId,
+		input.reportedPath,
+	);
+	return {
+		installPath,
+		contentDigest: hostedAgentPluginDirectoryDigest(installPath, {
+			ignoreTopLevelGitMetadata: input.ignoreTopLevelGitMetadata,
+		}),
+	};
 }
 
 function createOpenClawDriver(input: {
@@ -414,9 +410,7 @@ type HermesNativeCommand = (args: string[]) => AgentPluginCommandResult;
 
 function ensureHermesPluginScanDisabled(home: string, run: HermesNativeCommand): void {
 	const configPath = join(home, ".hermes", "config.yaml");
-	const current = withRuntimeUserFileAccess(() =>
-		getHermesRawConfigFileValue(configPath, HERMES_PLUGIN_SCAN_POLICY_KEY),
-	);
+	const current = getHermesRawConfigFileValue(configPath, HERMES_PLUGIN_SCAN_POLICY_KEY);
 	if (current.exists && current.value === false) return;
 
 	// Remove this persistent policy when NousResearch/hermes-agent#89704 ships
@@ -718,81 +712,85 @@ export function prepareHostedAgentPluginTransaction(input: {
 		mutationNames: [...new Set(mutations.map((mutation) => mutation.name))].sort(),
 		hasMutations: mutations.length > 0,
 		apply() {
-			const installTargetsBefore = new Map<HostedAgentPluginRuntime, Set<string>>();
-			for (const mutation of mutations) {
-				if (mutation.nativeId || installTargetsBefore.has(mutation.runtime)) continue;
-				installTargetsBefore.set(
-					mutation.runtime,
-					nativeInstallTargetNames(input.home, mutation.runtime),
-				);
-			}
-			const namesByNativeId = new Map<string, string>();
-			const claimNativeId = (name: string, nativeId: string): void => {
-				const existing = namesByNativeId.get(nativeId);
-				if (existing !== undefined && existing !== name) {
-					throw new Error("Agent Plugin packages resolve to the same native identity");
+			return withRuntimeUserFileAccess(() => {
+				const installTargetsBefore = new Map<HostedAgentPluginRuntime, Set<string>>();
+				for (const mutation of mutations) {
+					if (mutation.nativeId || installTargetsBefore.has(mutation.runtime)) continue;
+					installTargetsBefore.set(
+						mutation.runtime,
+						nativeInstallTargetNames(input.home, mutation.runtime),
+					);
 				}
-				namesByNativeId.set(nativeId, name);
-			};
-			for (const mutation of mutations) {
-				if (
-					!observationUnchanged(
-						mutation.driver.observe(mutation.name, mutation.nativeId ?? undefined),
-						mutation.before,
-					)
-				) {
-					throw new Error("native Agent Plugin changed after ownership was verified");
-				}
-				if ((mutation.action === "remove" || mutation.action === "replace") && mutation.before) {
-					mutation.driver.remove(mutation.before);
-				}
-				if (mutation.action === "install" || mutation.action === "replace") {
-					if (!mutation.desired) throw new Error("Agent Plugin mutation plan is invalid");
-					const installed = mutation.driver.install(nativePackage(mutation.desired));
-					if (mutation.nativeId && installed.nativeId !== mutation.nativeId) {
-						throw new Error("Agent Plugin native identity no longer matches its ownership receipt");
+				const namesByNativeId = new Map<string, string>();
+				const claimNativeId = (name: string, nativeId: string): void => {
+					const existing = namesByNativeId.get(nativeId);
+					if (existing !== undefined && existing !== name) {
+						throw new Error("Agent Plugin packages resolve to the same native identity");
 					}
+					namesByNativeId.set(nativeId, name);
+				};
+				for (const mutation of mutations) {
 					if (
-						!mutation.nativeId &&
-						installTargetsBefore.get(mutation.runtime)?.has(installed.nativeId)
+						!observationUnchanged(
+							mutation.driver.observe(mutation.name, mutation.nativeId ?? undefined),
+							mutation.before,
+						)
 					) {
-						throw new Error("refusing to replace an unmanaged native Agent Plugin target");
+						throw new Error("native Agent Plugin changed after ownership was verified");
 					}
-					if (!observationMatches(installed, mutation.desired, installed.nativeId)) {
-						throw new Error("native Agent Plugin installed an unexpected identity or package");
+					if ((mutation.action === "remove" || mutation.action === "replace") && mutation.before) {
+						mutation.driver.remove(mutation.before);
 					}
-					claimNativeId(mutation.name, installed.nativeId);
-					resolvedNativeIds.set(mutation.name, installed.nativeId);
-					mutation.driver.setEnabled(installed, true);
+					if (mutation.action === "install" || mutation.action === "replace") {
+						if (!mutation.desired) throw new Error("Agent Plugin mutation plan is invalid");
+						const installed = mutation.driver.install(nativePackage(mutation.desired));
+						if (mutation.nativeId && installed.nativeId !== mutation.nativeId) {
+							throw new Error(
+								"Agent Plugin native identity no longer matches its ownership receipt",
+							);
+						}
+						if (
+							!mutation.nativeId &&
+							installTargetsBefore.get(mutation.runtime)?.has(installed.nativeId)
+						) {
+							throw new Error("refusing to replace an unmanaged native Agent Plugin target");
+						}
+						if (!observationMatches(installed, mutation.desired, installed.nativeId)) {
+							throw new Error("native Agent Plugin installed an unexpected identity or package");
+						}
+						claimNativeId(mutation.name, installed.nativeId);
+						resolvedNativeIds.set(mutation.name, installed.nativeId);
+						mutation.driver.setEnabled(installed, true);
+					}
+					if (mutation.action === "enable") {
+						if (!mutation.before) throw new Error("Agent Plugin mutation plan is invalid");
+						mutation.driver.setEnabled(mutation.before, true);
+					}
+					const nativeId = mutation.desired
+						? resolvedNativeIds.get(mutation.name)
+						: mutation.nativeId;
+					if (!nativeId) throw new Error("Agent Plugin mutation plan is invalid");
+					const observed = mutation.driver.observe(mutation.name, nativeId);
+					if (mutation.desired) {
+						if (!observationMatches(observed, mutation.desired, nativeId) || !observed.enabled) {
+							throw new Error("native Agent Plugin did not converge to the desired state");
+						}
+					} else if (observed) {
+						throw new Error("native Agent Plugin uninstall did not converge");
+					}
 				}
-				if (mutation.action === "enable") {
-					if (!mutation.before) throw new Error("Agent Plugin mutation plan is invalid");
-					mutation.driver.setEnabled(mutation.before, true);
-				}
-				const nativeId = mutation.desired
-					? resolvedNativeIds.get(mutation.name)
-					: mutation.nativeId;
-				if (!nativeId) throw new Error("Agent Plugin mutation plan is invalid");
-				const observed = mutation.driver.observe(mutation.name, nativeId);
-				if (mutation.desired) {
-					if (!observationMatches(observed, mutation.desired, nativeId) || !observed.enabled) {
+				for (const plugin of input.prepared.desired.values()) {
+					const nativeId = resolvedNativeIds.get(plugin.name);
+					if (!nativeId)
+						throw new Error("Agent Plugin native identity was not resolved during apply");
+					claimNativeId(plugin.name, nativeId);
+					const observed = driverFor(input.prepared.runtime).observe(plugin.name, nativeId);
+					if (!observationMatches(observed, plugin, nativeId) || !observed.enabled) {
 						throw new Error("native Agent Plugin did not converge to the desired state");
 					}
-				} else if (observed) {
-					throw new Error("native Agent Plugin uninstall did not converge");
 				}
-			}
-			for (const plugin of input.prepared.desired.values()) {
-				const nativeId = resolvedNativeIds.get(plugin.name);
-				if (!nativeId)
-					throw new Error("Agent Plugin native identity was not resolved during apply");
-				claimNativeId(plugin.name, nativeId);
-				const observed = driverFor(input.prepared.runtime).observe(plugin.name, nativeId);
-				if (!observationMatches(observed, plugin, nativeId) || !observed.enabled) {
-					throw new Error("native Agent Plugin did not converge to the desired state");
-				}
-			}
-			return desiredReceipt(input.prepared, resolvedNativeIds);
+				return desiredReceipt(input.prepared, resolvedNativeIds);
+			});
 		},
 	};
 }

--- a/packages/cli/src/runtime/hosted-openclaw-context.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-context.ts
@@ -14,12 +14,7 @@ import {
 } from "../lib/codex-oauth-native-store";
 import { agentTargetProjectionInput, hostedAiProviderCatalog } from "./hosted-provider-resolution";
 import type { RuntimeManifest } from "./manifest-contract";
-import {
-	executableExists,
-	runtimeUserDirectoryOwnership,
-	spawnRuntimeUserCommand,
-	withRuntimeUserFileAccess,
-} from "./runtime-user-command";
+import { executableExists, spawnRuntimeUserCommand } from "./runtime-user-command";
 import { parseSystemctlShow, systemctlPath } from "./systemd";
 
 export const CLAWDI_MANAGED_OPENCLAW_PROVIDER_PLUGIN_ID = "clawdi-managed-provider";
@@ -33,15 +28,13 @@ const OPENCLAW_GATEWAY_TRANSITION_RETRY_DELAY_MS = 3_000;
 export type OpenClawHostedContext = ReturnType<typeof createOpenClawHostedContext>;
 
 function installedCommandPath(home: string): string | null {
-	return withRuntimeUserFileAccess(() => {
-		for (const candidate of [
-			join(home, ".local", "bin", "openclaw"),
-			join(home, ".openclaw", "bin", "openclaw"),
-		]) {
-			if (executableExists(candidate)) return candidate;
-		}
-		return null;
-	});
+	for (const candidate of [
+		join(home, ".local", "bin", "openclaw"),
+		join(home, ".openclaw", "bin", "openclaw"),
+	]) {
+		if (executableExists(candidate)) return candidate;
+	}
+	return null;
 }
 
 function commandPath(home: string): string {
@@ -175,23 +168,13 @@ function resolveSdkExports(
 		}
 		return value || null;
 	};
-	return withRuntimeUserFileAccess(() => ({
+	return {
 		configMutation: resolve(OPENCLAW_SDK_EXPORT_PATHS.configMutation),
 		deviceBootstrap: resolve(OPENCLAW_SDK_EXPORT_PATHS.deviceBootstrap),
 		providerAuth: testOverride("PROVIDER_AUTH") ?? resolve(OPENCLAW_SDK_EXPORT_PATHS.providerAuth),
 		providerEnvVars:
 			testOverride("PROVIDER_ENV_VARS") ?? resolve(OPENCLAW_SDK_EXPORT_PATHS.providerEnvVars),
-	}));
-}
-
-export function hostedOpenClawRuntimeUserOwnership(manifest: RuntimeManifest, home: string) {
-	const stateRoot = join(home, ".openclaw");
-	return manifest.runtimes.openclaw?.enabled === true
-		? [
-				...runtimeUserDirectoryOwnership(stateRoot, { mode: 0o700 }),
-				...runtimeUserDirectoryOwnership(join(stateRoot, "tmp"), { mode: 0o700 }),
-			]
-		: [];
+	};
 }
 
 export function createOpenClawHostedContext(manifest: RuntimeManifest, home: string) {
@@ -202,13 +185,11 @@ export function createOpenClawHostedContext(manifest: RuntimeManifest, home: str
 	const sourceDir = statePath("managed-sources", CLAWDI_MANAGED_OPENCLAW_PROVIDER_PLUGIN_ID);
 	const installDir = statePath("extensions", CLAWDI_MANAGED_OPENCLAW_PROVIDER_PLUGIN_ID);
 	const sdk = resolveSdkExports(home);
-	const ownership = hostedOpenClawRuntimeUserOwnership(manifest, home);
 	return {
 		home,
 		managedApiKeyProjection: hasManagedApiKeyProjection(manifest),
 		stateRoot,
 		configPath,
-		ownership,
 		agentDirs: {
 			main: statePath("agents", "main", "agent"),
 			managed: [] as string[],

--- a/packages/cli/src/runtime/hosted-openclaw-skill.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.ts
@@ -4,24 +4,18 @@ import {
 	managedSkillTargetMatchesSource,
 	withManagedTargetRollback,
 } from "./managed-skill-delivery";
-import {
-	executableExists,
-	spawnRuntimeUserCommand,
-	withRuntimeUserFileAccess,
-} from "./runtime-user-command";
+import { executableExists, spawnRuntimeUserCommand } from "./runtime-user-command";
 
 const OPENCLAW_AGENT_ID = "main";
 const OPENCLAW_INSTALLED_TREE_EXCLUDES = new Set([".openclaw/source-origin.json"]);
 
 function installedCommandPath(home: string): string | null {
-	return withRuntimeUserFileAccess(() => {
-		for (const candidate of [
-			join(home, ".local", "bin", "openclaw"),
-			join(home, ".openclaw", "bin", "openclaw"),
-		])
-			if (executableExists(candidate)) return candidate;
-		return null;
-	});
+	for (const candidate of [
+		join(home, ".local", "bin", "openclaw"),
+		join(home, ".openclaw", "bin", "openclaw"),
+	])
+		if (executableExists(candidate)) return candidate;
+	return null;
 }
 
 function commandPath(home: string): string {

--- a/packages/cli/src/runtime/managed-skill-delivery.ts
+++ b/packages/cli/src/runtime/managed-skill-delivery.ts
@@ -15,7 +15,6 @@ import { collectRegularFileTree } from "../lib/file-tree";
 import { extractTarGzSync } from "../lib/tar";
 import { MANAGED_SKILL_TREE_LIMITS, managedSkillDirectoryDigest } from "./hosted-bundled-skill";
 import type { PreparedHostedSkill } from "./hosted-sourced-skill-archive";
-import { withRuntimeUserFileAccess } from "./runtime-user-command";
 
 export class ManagedSkillResourceError extends Error {}
 
@@ -60,13 +59,6 @@ export function collectManagedSkillTree(
 	}
 }
 
-export function collectRuntimeUserManagedSkillTree(
-	root: string,
-	options: { exclude?: ReadonlySet<string> } = {},
-): ManagedSkillTreeCollection {
-	return withRuntimeUserFileAccess(() => collectManagedSkillTree(root, options));
-}
-
 export function managedSkillTreesEqual(left: ManagedSkillTree, right: ManagedSkillTree): boolean {
 	if (left.size !== right.size) return false;
 	for (const [name, bytes] of left) if (!right.get(name)?.equals(bytes)) return false;
@@ -79,7 +71,7 @@ export function managedSkillTargetMatchesSource(
 	options: { exclude?: ReadonlySet<string> } = {},
 ): boolean {
 	const source = collectManagedSkillTree(sourceDir);
-	const installed = collectRuntimeUserManagedSkillTree(targetDir, options);
+	const installed = collectManagedSkillTree(targetDir, options);
 	return (
 		source.status === "collected" &&
 		installed.status === "collected" &&
@@ -161,26 +153,26 @@ export function withManagedTargetRollback<T>(input: {
 	const targetBackup =
 		input.targetBackup ??
 		join(dirname(input.target), `.${basename(input.target)}-clawdi-rollback-${suffix}`);
-	const hadTarget = withRuntimeUserFileAccess(() => existsSync(input.target));
+	const hadTarget = existsSync(input.target);
 	let targetMoved = false;
 	try {
 		if (hadTarget) {
-			withRuntimeUserFileAccess(() => rename(input.target, targetBackup));
+			rename(input.target, targetBackup);
 			targetMoved = true;
 		}
 	} catch (error) {
-		if (targetMoved) withRuntimeUserFileAccess(() => rename(targetBackup, input.target));
+		if (targetMoved) rename(targetBackup, input.target);
 		throw error;
 	}
 	let result: T;
 	try {
 		result = input.operation();
 	} catch (error) {
-		withRuntimeUserFileAccess(() => remove(input.target, { recursive: true, force: true }));
+		remove(input.target, { recursive: true, force: true });
 		try {
 			if (hadTarget) {
 				input.beforeRestore?.();
-				withRuntimeUserFileAccess(() => rename(targetBackup, input.target));
+				rename(targetBackup, input.target);
 			}
 		} catch (restoreError) {
 			if (input.restoreFailure) throw input.restoreFailure(error, restoreError);
@@ -192,7 +184,7 @@ export function withManagedTargetRollback<T>(input: {
 	// must never roll back a live target.
 	try {
 		if (hadTarget) input.beforeCleanup?.();
-		withRuntimeUserFileAccess(() => remove(targetBackup, { recursive: true, force: true }));
+		remove(targetBackup, { recursive: true, force: true });
 	} catch {}
 	return result;
 }

--- a/packages/cli/src/runtime/managed-skill-reservation.ts
+++ b/packages/cli/src/runtime/managed-skill-reservation.ts
@@ -15,7 +15,6 @@ import { writePrivateFileAtomic } from "../lib/private-file";
 import { withRuntimeConvergeLock } from "./converge-lock";
 import { ManagedSkillResourceError, withManagedTargetRollback } from "./managed-skill-delivery";
 import { detectRuntimeMode, getRuntimePaths } from "./paths";
-import { withRuntimeUserFileAccess } from "./runtime-user-command";
 import { runtimePlatformRootForPath, writeRuntimePlatformFileAtomic } from "./state";
 
 const LEDGER_FILE = "managed-skills.json";
@@ -532,13 +531,11 @@ export function replaceManagedSkillDirectoryAtomic(
 	options: ManagedSkillDirectoryActivationOptions = {},
 ): void {
 	const parent = dirname(targetDir);
-	const stagingRoot = withRuntimeUserFileAccess(() => {
-		mkdirSync(parent, { recursive: true });
-		return mkdtempSync(join(parent, `.${basename(targetDir)}-stage-`));
-	});
+	mkdirSync(parent, { recursive: true });
+	const stagingRoot = mkdtempSync(join(parent, `.${basename(targetDir)}-stage-`));
 	const stagedTarget = join(stagingRoot, basename(targetDir));
 	try {
-		withRuntimeUserFileAccess(() => cpSync(sourceDir, stagedTarget, { recursive: true }));
+		cpSync(sourceDir, stagedTarget, { recursive: true });
 		withManagedTargetRollback({
 			target: targetDir,
 			beforeRestore: options.beforeRestore,
@@ -554,15 +551,13 @@ export function replaceManagedSkillDirectoryAtomic(
 				);
 			},
 			operation: () => {
-				withRuntimeUserFileAccess(() => {
-					options.beforeActivate?.();
-					renameSync(stagedTarget, targetDir);
-				});
+				options.beforeActivate?.();
+				renameSync(stagedTarget, targetDir);
 				options.afterActivate?.();
 			},
 		});
 	} finally {
-		withRuntimeUserFileAccess(() => rmSync(stagingRoot, { recursive: true, force: true }));
+		rmSync(stagingRoot, { recursive: true, force: true });
 	}
 }
 

--- a/packages/cli/src/runtime/manifest-channels.ts
+++ b/packages/cli/src/runtime/manifest-channels.ts
@@ -29,10 +29,7 @@ import { hermesConfigContext } from "./manifest-runtime-config";
 import { hasExactKeys, isPlainRecord, recordValue } from "./manifest-shared";
 import { openClawPluginInspectSchema } from "./openclaw-plugin-observation";
 import {
-	enforceRuntimeUserOwnership,
-	makeRuntimeUserOwned,
 	runRuntimeUserCommand,
-	runtimeUserDirectoryOwnership,
 	spawnRuntimeUserCommand,
 	withRuntimeUserFileAccess,
 } from "./runtime-user-command";
@@ -136,9 +133,6 @@ function materializeManagedWhatsAppAuthDir(
 		rmSync(credential.authDir, { recursive: true, force: true });
 	}
 
-	enforceRuntimeUserOwnership(
-		runtimeUserDirectoryOwnership(credential.authDir, { mode: 0o700, ancestorsUnder: home }),
-	);
 	writePrivateFileAtomic(
 		join(credential.authDir, "creds.json"),
 		`${JSON.stringify(inspection.creds, null, 2)}\n`,
@@ -147,7 +141,6 @@ function materializeManagedWhatsAppAuthDir(
 			dirMode: 0o700,
 		},
 	);
-	makeRuntimeUserOwned(join(credential.authDir, "creds.json"));
 	rmSync(join(credential.authDir, LEGACY_MANAGED_WHATSAPP_AUTH_MARKER), { force: true });
 }
 

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -1,5 +1,5 @@
 import { chmodSync, mkdirSync, rmSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join } from "node:path";
 import { readRuntimeAppliedState } from "./applied-state";
 import { removeHostedCliPathExposure } from "./cli-update";
 import { buildEgressProfileBundle, hasEnabledEgressProfiles } from "./egress-profiles";
@@ -15,7 +15,6 @@ import {
 } from "./hosted-agent-plugin-runtime";
 import {
 	createOpenClawHostedContext,
-	hostedOpenClawRuntimeUserOwnership,
 	repairHostedOpenClawConfig,
 	resolveHostedOpenClawWorkspace,
 } from "./hosted-openclaw-context";
@@ -88,7 +87,7 @@ import { reconcileHostedSkillProjection } from "./manifest-skills-apply";
 import type { RuntimeManifestLoad } from "./manifest-source";
 import { ensureRuntimeMitmproxy } from "./mitmproxy-fetch";
 import { ensureManagedOpenClawProviderPlugin } from "./openclaw-managed-provider-plugin";
-import { type RuntimePaths, runtimeSystemdPlatformEnclaves } from "./paths";
+import type { RuntimePaths } from "./paths";
 import { hostedRuntimeProjectionHome } from "./projection-home";
 import { runtimeRunConfigId, writeRuntimeRunConfig } from "./run-config";
 import {
@@ -105,13 +104,8 @@ import {
 	writeRuntimeSystemdState,
 } from "./runtime-systemd-reconciliation";
 import {
-	enforceRuntimeUserOwnership,
-	enforceRuntimeUserSystemdManagerAccess,
+	ensureRuntimeUserHomeOwnership,
 	executableExists,
-	makeRuntimeUserOwned,
-	runtimePlatformEnclaveOwnership,
-	runtimeUserDirectoryOwnership,
-	runtimeUserExistingOwnership,
 	withRuntimeUserFileAccess,
 } from "./runtime-user-command";
 import { ensureRuntimePlatformDirectory } from "./state";
@@ -128,7 +122,6 @@ interface RuntimeConvergenceContext {
 	applyContext: NonNullable<RuntimeManifestLoad["applyContext"]>;
 	hostedRuntimeContract: ReturnType<typeof assertHostedRuntimeContract>;
 	projectionHome: string;
-	platformEnclaves: ReturnType<typeof runtimeSystemdPlatformEnclaves>;
 	openClawContext: ReturnType<typeof createOpenClawHostedContext>;
 	hermesWhatsAppAuthDir: string | null;
 	workspaceRoot: string;
@@ -203,21 +196,20 @@ function initializeRuntimeConvergence(
 		opts.hostedRuntimeContract,
 	);
 	const projectionHome = hostedRuntimeProjectionHome(manifest, paths);
-	// Tenant HOME belongs to the runtime user except for declared platform enclaves.
-	const platformEnclaves =
-		resolve(projectionHome) === resolve(paths.userHome)
-			? runtimeSystemdPlatformEnclaves(paths)
-			: [];
-	if (platformEnclaves.some((enclave) => enclave.path === paths.systemdUserRoot)) {
-		enforceRuntimeUserSystemdManagerAccess(paths.systemdUserRoot);
+	// SUNSET: remove the recursive migration after every 0.13.92/0.14.14 host has
+	// converged once; those releases could leave tenant HOME trees root-owned.
+	ensureRuntimeUserHomeOwnership(projectionHome, hostedRuntimeContract.identity);
+	if (manifest.runtimes.openclaw?.enabled === true) {
+		withRuntimeUserFileAccess(() => {
+			for (const path of [
+				join(projectionHome, ".openclaw"),
+				join(projectionHome, ".openclaw", "tmp"),
+			]) {
+				mkdirSync(path, { recursive: true });
+				chmodSync(path, 0o700);
+			}
+		}, hostedRuntimeContract.identity);
 	}
-	enforceRuntimeUserOwnership(
-		[
-			...runtimeUserDirectoryOwnership(projectionHome, { recursive: true, platformEnclaves }),
-			...hostedOpenClawRuntimeUserOwnership(manifest, projectionHome),
-		],
-		hostedRuntimeContract.identity,
-	);
 	const openClawContext = createOpenClawHostedContext(manifest, projectionHome);
 	const hermesWhatsAppAuthDir = managedHermesWhatsAppAuthDir(manifest, projectionHome);
 	removeHostedCliPathExposure(paths);
@@ -267,7 +259,7 @@ function initializeRuntimeConvergence(
 		openClawOwnerBrowserBootstrapSupported: false,
 		activated: {},
 		officialServiceCommandRevisions: {},
-		staleSystemdFiles: { files: [], systemUnits: [], userUnits: [] },
+		staleSystemdFiles: { platformFiles: [], userFiles: [], systemUnits: [], userUnits: [] },
 	};
 	if (opts.resourcePreparationFailures?.sourcedSkills) {
 		state.resourceProjectionErrors.push(opts.resourcePreparationFailures.sourcedSkills);
@@ -288,7 +280,6 @@ function initializeRuntimeConvergence(
 			applyContext,
 			hostedRuntimeContract,
 			projectionHome,
-			platformEnclaves,
 			openClawContext,
 			hermesWhatsAppAuthDir,
 			workspaceRoot,
@@ -375,7 +366,6 @@ function prepareRuntimeConvergencePlan(
 		manifest,
 		paths,
 		projectionHome,
-		openClawContext,
 		secretValues,
 		previousProjectedProviderIds,
 		hermesWhatsAppAuthDir,
@@ -411,25 +401,10 @@ function prepareRuntimeConvergencePlan(
 		openClawOwnerBrowserBootstrapSupported: state.openClawOwnerBrowserBootstrapSupported,
 	});
 	try {
-		validateRuntimeSystemdPlan(plannedRuntimePrograms, paths);
+		validateRuntimeSystemdPlan(plannedRuntimePrograms);
 	} catch (error) {
 		state.installErrors.push(error instanceof Error ? error.message : String(error));
 		return { result: runtimeConvergenceFailure(context, state) };
-	}
-	if (openClawContext.managedApiKeyProjection) {
-		try {
-			const observation = state.observations.get("openclaw");
-			if (!observation?.commandPath) {
-				throw new Error("OpenClaw managed provider plugin requires an installed runtime");
-			}
-			ensureManagedOpenClawProviderPlugin({
-				context: openClawContext,
-				commandPath: observation.commandPath,
-			});
-		} catch (error) {
-			state.installErrors.push(error instanceof Error ? error.message : String(error));
-			return { result: runtimeConvergenceFailure(context, state) };
-		}
 	}
 	return {
 		plan: {
@@ -456,127 +431,122 @@ function prepareRuntimeApplyDependencies(
 	// SUNSET: remove after the whole fleet has converged on receipt-free channel state.
 	rmSync(join(paths.managedResourceRoot, "whatsapp-auth"), { recursive: true, force: true });
 	ensureFileBrowserCompanion(manifest, paths, opts.fileBrowserInstallOptions);
-	const openClawObservation = state.observations.get("openclaw");
-	if (openClawObservation) {
-		try {
-			ensureHostedOpenClawProviderAuthCapability({
-				manifest,
-				secretValues,
-				context: openClawContext,
-			});
-		} catch (error) {
-			state.installErrors.push(
-				`runtime openclaw credential capability check failed: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
-			);
-		}
-	}
-	if (state.installErrors.length > 0) throw new Error(state.installErrors.join("; "));
-	const managedOpenClawObservation = state.observations.get("openclaw");
-	if (managedOpenClawObservation && openClawContext.managedApiKeyProjection) {
-		openClawContext.agentDirs.managed =
-			discoverOpenClawManagedProviderAuthAgentDirs(openClawContext);
-		if (openClawContext.agentDirs.managed.length > 0) {
-			enforceRuntimeUserOwnership(
-				runtimeUserExistingOwnership(openClawContext.agentDirs.managed),
-				hostedRuntimeContract.identity,
-			);
-		}
-	}
-	if (opts.preparedHostedAgentPlugins) {
-		const commands = hostedAgentPluginCommands(projectionHome);
-		let planned: ReturnType<typeof planHostedAgentPluginConvergence>;
-		try {
-			planned = planHostedAgentPluginConvergence({
-				prepared: opts.preparedHostedAgentPlugins,
-				home: projectionHome,
-				commands,
-				...(opts.hostedAgentPluginCommandRunner
-					? { runner: opts.hostedAgentPluginCommandRunner }
-					: {}),
-			});
-		} catch (error) {
-			for (const name of opts.preparedHostedAgentPlugins.desired.keys()) {
-				state.agentPluginFailedNames.add(name);
-			}
-			state.resourceProjectionErrors.push(
-				`runtime Agent Plugin projection planning failed: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
-			);
-			planned = { transaction: null };
-		}
-		state.agentPluginTransaction = planned.transaction;
-		if (state.agentPluginTransaction?.hasMutations && !opts.systemdApply) {
-			throw new Error("Agent Plugin mutations require systemd activation and readiness");
-		}
-	}
-
 	let codexCli: Record<string, string> | null = null;
-	if (manifest.projection?.terminalTooling?.codex) {
-		try {
-			codexCli = ensureHostedCodexCli(paths);
-		} catch (error) {
-			state.installErrors.push(
-				`runtime codex setup failed: ${error instanceof Error ? error.message : String(error)}`,
-			);
-		}
-	}
-	for (const [name] of runtimeEntries) {
-		const observation = state.observations.get(name);
-		if (!observation) throw new Error(`runtime ${name} install observation is missing`);
-		try {
-			installHostedChannelProjectionDependencies(
-				name,
-				observation,
-				manifest,
-				projectionHome,
-				paths.userHome,
-			);
-		} catch (error) {
-			state.installErrors.push(
-				`runtime ${name} channel plugin install failed: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
-			);
-		}
-	}
-	const managedWhatsAppRuntime = managedWhatsAppCompatibilityRuntime(manifest);
-	try {
-		const observation = managedWhatsAppRuntime
-			? state.observations.get(managedWhatsAppRuntime)
-			: undefined;
-		if (managedWhatsAppRuntime && !observation?.appRoot) {
-			throw new Error(`runtime ${managedWhatsAppRuntime} artifact root is unavailable`);
-		}
-		const compatibility = reconcileManagedBaileysCompatibility({
-			desiredRuntime: managedWhatsAppRuntime,
-			home: projectionHome,
-			...(observation?.appRoot ? { appRoot: observation.appRoot } : {}),
-		});
-		if (compatibility.status === "rollback-refused") {
-			throw new Error(compatibility.errors.join(", "));
-		}
-	} catch (error) {
-		const operation = managedWhatsAppRuntime
-			? `runtime ${managedWhatsAppRuntime} managed WhatsApp compatibility`
-			: "runtime managed WhatsApp compatibility cleanup";
-		state.installErrors.push(
-			`${operation} failed: ${error instanceof Error ? error.message : String(error)}`,
-		);
-	}
-	if (state.installErrors.length > 0) throw new Error(state.installErrors.join("; "));
-
-	enforceRuntimeUserOwnership(
-		runtimeUserDirectoryOwnership(paths.userHome),
-		hostedRuntimeContract.identity,
-	);
-	ensureRuntimeUserCliStateRoot(paths.clawdiHome, hostedRuntimeContract.identity);
 	withRuntimeUserFileAccess(() => {
+		const openClawObservation = state.observations.get("openclaw");
+		if (openClawObservation) {
+			try {
+				ensureHostedOpenClawProviderAuthCapability({
+					manifest,
+					secretValues,
+					context: openClawContext,
+				});
+			} catch (error) {
+				state.installErrors.push(
+					`runtime openclaw credential capability check failed: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+			}
+		}
+		if (state.installErrors.length > 0) throw new Error(state.installErrors.join("; "));
+		const managedOpenClawObservation = state.observations.get("openclaw");
+		if (managedOpenClawObservation && openClawContext.managedApiKeyProjection) {
+			openClawContext.agentDirs.managed =
+				discoverOpenClawManagedProviderAuthAgentDirs(openClawContext);
+			if (!managedOpenClawObservation.commandPath) {
+				throw new Error("OpenClaw managed provider plugin requires an installed runtime");
+			}
+			ensureManagedOpenClawProviderPlugin({
+				context: openClawContext,
+				commandPath: managedOpenClawObservation.commandPath,
+			});
+		}
+		if (opts.preparedHostedAgentPlugins) {
+			const commands = hostedAgentPluginCommands(projectionHome);
+			let planned: ReturnType<typeof planHostedAgentPluginConvergence>;
+			try {
+				planned = planHostedAgentPluginConvergence({
+					prepared: opts.preparedHostedAgentPlugins,
+					home: projectionHome,
+					commands,
+					...(opts.hostedAgentPluginCommandRunner
+						? { runner: opts.hostedAgentPluginCommandRunner }
+						: {}),
+				});
+			} catch (error) {
+				for (const name of opts.preparedHostedAgentPlugins.desired.keys()) {
+					state.agentPluginFailedNames.add(name);
+				}
+				state.resourceProjectionErrors.push(
+					`runtime Agent Plugin projection planning failed: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+				planned = { transaction: null };
+			}
+			state.agentPluginTransaction = planned.transaction;
+			if (state.agentPluginTransaction?.hasMutations && !opts.systemdApply) {
+				throw new Error("Agent Plugin mutations require systemd activation and readiness");
+			}
+		}
+
+		if (manifest.projection?.terminalTooling?.codex) {
+			try {
+				codexCli = ensureHostedCodexCli(paths);
+			} catch (error) {
+				state.installErrors.push(
+					`runtime codex setup failed: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		}
+		for (const [name] of runtimeEntries) {
+			const observation = state.observations.get(name);
+			if (!observation) throw new Error(`runtime ${name} install observation is missing`);
+			try {
+				installHostedChannelProjectionDependencies(
+					name,
+					observation,
+					manifest,
+					projectionHome,
+					paths.userHome,
+				);
+			} catch (error) {
+				state.installErrors.push(
+					`runtime ${name} channel plugin install failed: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+			}
+		}
+		const managedWhatsAppRuntime = managedWhatsAppCompatibilityRuntime(manifest);
+		try {
+			const observation = managedWhatsAppRuntime
+				? state.observations.get(managedWhatsAppRuntime)
+				: undefined;
+			if (managedWhatsAppRuntime && !observation?.appRoot) {
+				throw new Error(`runtime ${managedWhatsAppRuntime} artifact root is unavailable`);
+			}
+			const compatibility = reconcileManagedBaileysCompatibility({
+				desiredRuntime: managedWhatsAppRuntime,
+				home: projectionHome,
+				...(observation?.appRoot ? { appRoot: observation.appRoot } : {}),
+			});
+			if (compatibility.status === "rollback-refused") {
+				throw new Error(compatibility.errors.join(", "));
+			}
+		} catch (error) {
+			const operation = managedWhatsAppRuntime
+				? `runtime ${managedWhatsAppRuntime} managed WhatsApp compatibility`
+				: "runtime managed WhatsApp compatibility cleanup";
+			state.installErrors.push(
+				`${operation} failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+		if (state.installErrors.length > 0) throw new Error(state.installErrors.join("; "));
 		mkdirSync(workspaceRoot, { recursive: true });
-		makeRuntimeUserOwned(workspaceRoot);
 	}, hostedRuntimeContract.identity);
+	ensureRuntimeUserCliStateRoot(paths.clawdiHome, hostedRuntimeContract.identity);
 	ensureRuntimePlatformDirectory(paths, paths.managedSecretRoot);
 	makeManagedSecretRoot(paths.managedSecretRoot);
 	ensureRuntimePlatformDirectory(paths, paths.egressRoot, { mode: 0o711 });
@@ -584,10 +554,6 @@ function prepareRuntimeApplyDependencies(
 	makeEgressIdentityPrivateDir(paths.egressCaDir);
 	ensureRuntimePlatformDirectory(paths, dirname(paths.egressSystemCaFile), { mode: 0o711 });
 	chmodSync(dirname(paths.egressSystemCaFile), 0o711);
-	enforceRuntimeUserOwnership(
-		runtimeUserDirectoryOwnership(paths.egressScratchRoot, { mode: 0o700 }),
-		hostedRuntimeContract.identity,
-	);
 	return codexCli;
 }
 
@@ -629,18 +595,19 @@ function prepareRuntimeEgressProjection(
 	requireV2EgressEngineReady(egressProfileBundlePath, egressEngine);
 	const egressAddon = egressProfileBundlePath ? writeEgressAddon(paths) : clearEgressAddon(paths);
 	const daemonAuthTokenFile = writeDaemonAuthToken(paths, secretValues);
-	try {
-		withRuntimeUserFileAccess(
-			() => materializeHostedChannelCredentials(manifest, secretValues, projectionHome),
-			hostedRuntimeContract.identity,
-		);
-	} catch (error) {
-		state.installErrors.push(
-			`runtime channel credential materialization failed: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
-	}
+	let liveSyncEnvironments: string[] = [];
+	withRuntimeUserFileAccess(() => {
+		try {
+			materializeHostedChannelCredentials(manifest, secretValues, projectionHome);
+		} catch (error) {
+			state.installErrors.push(
+				`runtime channel credential materialization failed: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
+		liveSyncEnvironments = writeLiveSyncEnvironmentFiles(manifest, paths);
+	}, hostedRuntimeContract.identity);
 	const egressSecretFile = writeEgressSecretFile(manifest, secretValues, paths).path;
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
 	const resolvedSystemdIdentity = resolveRuntimeSystemdIdentity({
@@ -666,7 +633,6 @@ function prepareRuntimeEgressProjection(
 		egressUid,
 		egressGid,
 	});
-	const liveSyncEnvironments = writeLiveSyncEnvironmentFiles(manifest, paths);
 	const writtenRunConfigIds = new Set<string>();
 	state.runtimeSystemdUserPrograms.push(
 		...planRuntimeSystemdUserPrograms({
@@ -843,72 +809,74 @@ function applyRuntimeEntryProjections(
 				);
 			}
 		}
-		try {
-			const localeFile = applyHostedRuntimeConfigProjection(
-				name,
-				observation,
+		const resolved = withRuntimeUserFileAccess(() => {
+			try {
+				const localeFile = applyHostedRuntimeConfigProjection(
+					name,
+					observation,
+					manifest,
+					projectionHome,
+					plan.openClawWorkspaceRoot,
+					workspaceRoot,
+				);
+				if (localeFile) state.managedLocaleFiles.push(localeFile);
+			} catch (error) {
+				state.installErrors.push(
+					`runtime ${name} config projection failed: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+			}
+			try {
+				const providerProjection = applyHostedAiProviderProjection(
+					name,
+					observation,
+					manifest,
+					secretValues,
+					projectionHome,
+					openClawContext,
+					workspaceRoot,
+					previousProjectedProviderIds[name] ?? [],
+					state.openClawOwnerBrowserBootstrapSupported,
+				);
+				state.projectedProviderIds[name] = providerProjection.providerIds;
+			} catch (error) {
+				state.installErrors.push(
+					`runtime ${name} provider projection failed: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+			}
+			try {
+				applyHostedChannelProjection(
+					name,
+					observation,
+					manifest,
+					projectionHome,
+					openClawContext,
+					workspaceRoot,
+					hermesWhatsAppAuthDir,
+				);
+			} catch (error) {
+				state.installErrors.push(
+					`runtime ${name} channel projection failed: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+			}
+			if (state.installErrors.length > 0) throw new Error(state.installErrors.join("; "));
+			return resolveRuntimeRunConfigs({
 				manifest,
-				projectionHome,
-				plan.openClawWorkspaceRoot,
+				paths,
+				name,
+				runtime,
+				observation,
 				workspaceRoot,
-			);
-			if (localeFile) state.managedLocaleFiles.push(localeFile);
-		} catch (error) {
-			state.installErrors.push(
-				`runtime ${name} config projection failed: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
-			);
-		}
-		try {
-			const providerProjection = applyHostedAiProviderProjection(
-				name,
-				observation,
-				manifest,
+				generatedAt,
 				secretValues,
-				projectionHome,
-				openClawContext,
-				workspaceRoot,
-				previousProjectedProviderIds[name] ?? [],
-				state.openClawOwnerBrowserBootstrapSupported,
-			);
-			state.projectedProviderIds[name] = providerProjection.providerIds;
-		} catch (error) {
-			state.installErrors.push(
-				`runtime ${name} provider projection failed: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
-			);
-		}
-		try {
-			applyHostedChannelProjection(
-				name,
-				observation,
-				manifest,
-				projectionHome,
-				openClawContext,
-				workspaceRoot,
-				hermesWhatsAppAuthDir,
-			);
-		} catch (error) {
-			state.installErrors.push(
-				`runtime ${name} channel projection failed: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
-			);
-		}
-		if (state.installErrors.length > 0) throw new Error(state.installErrors.join("; "));
-		const resolved = resolveRuntimeRunConfigs({
-			manifest,
-			paths,
-			name,
-			runtime,
-			observation,
-			workspaceRoot,
-			generatedAt,
-			secretValues,
-			egressProfileBundlePath: egressProjection.egressProfileBundlePath,
-		});
+				egressProfileBundlePath: egressProjection.egressProfileBundlePath,
+			});
+		}, context.hostedRuntimeContract.identity);
 		const runConfigPath = writeRuntimeRunConfig(resolved.runtime, paths);
 		state.runConfigs.push(runConfigPath);
 		egressProjection.writtenRunConfigIds.add(runtimeRunConfigId(resolved.runtime.runtime));
@@ -933,15 +901,7 @@ function prepareRuntimeActivation(
 	egressProjection: RuntimeEgressProjection,
 	providerProjectionRevisions: Partial<Record<string, string | null>>,
 ): RuntimeActivationPlan {
-	const {
-		manifest,
-		paths,
-		opts,
-		platformEnclaves,
-		secretValues,
-		hermesWhatsAppAuthDir,
-		workspaceRoot,
-	} = context;
+	const { manifest, paths, opts, secretValues, hermesWhatsAppAuthDir, workspaceRoot } = context;
 	const systemdUnits = writeRuntimeSystemdState({
 		runtimePrograms: state.runtimeSystemdUserPrograms,
 		egressProgram: egressProjection.egressSystemdProgram,
@@ -964,20 +924,6 @@ function prepareRuntimeActivation(
 			),
 		commonEnvironment: egressProjection.commonSystemdEnvironment,
 	});
-	if (platformEnclaves.some((enclave) => enclave.path === paths.systemdUserRoot)) {
-		// Candidate files are written under the root service's private umask.
-		// Publish manager-readable modes before a native installer can reload or
-		// start its unit for the first time.
-		enforceRuntimeUserSystemdManagerAccess(paths.systemdUserRoot);
-	}
-	if (systemdUnits.userUnits.length > 0 || systemdUnits.staleFiles.userUnits.length > 0) {
-		enforceRuntimeUserOwnership(
-			runtimeUserDirectoryOwnership(join(paths.systemdUserRoot, "default.target.wants"), {
-				mode: 0o755,
-			}),
-			context.hostedRuntimeContract.identity,
-		);
-	}
 	state.staleSystemdFiles = systemdUnits.staleFiles;
 	const staleSystemdFileErrors = removeStaleRuntimeSystemdFiles(state.staleSystemdFiles);
 	if (staleSystemdFileErrors.length > 0) throw new Error(staleSystemdFileErrors.join("; "));
@@ -1021,7 +967,7 @@ function activateRuntimeServices(
 	state: RuntimeConvergenceState,
 	activationPlan: RuntimeActivationPlan,
 ): RuntimeActivationOutputs {
-	const { load, manifest, paths, opts, hostedRuntimeContract, platformEnclaves } = context;
+	const { load, manifest, paths, opts, hostedRuntimeContract } = context;
 	const { officialServicePlan, systemdUnits } = activationPlan;
 	if (
 		officialServicePlan.pending.length > 0 &&
@@ -1045,28 +991,7 @@ function activateRuntimeServices(
 	if (dependencyError) throw new Error(dependencyError);
 
 	for (const item of officialServicePlan.pending) {
-		const unitPath = join(paths.systemdUserRoot, item.unitName);
-		const installerOwnership = [
-			...runtimeUserDirectoryOwnership(paths.systemdUserRoot),
-			...runtimeUserExistingOwnership([
-				unitPath,
-				`${unitPath}.bak`,
-				...(item.program.runtime === "openclaw"
-					? [join(paths.userHome, ".openclaw", "gateway.systemd.env")]
-					: []),
-			]),
-		];
-		let error: string | null;
-		try {
-			enforceRuntimeUserOwnership(installerOwnership, hostedRuntimeContract.identity);
-			error = installOfficialRuntimeService(item, paths, hostedRuntimeContract.identity);
-		} finally {
-			enforceRuntimeUserSystemdManagerAccess(paths.systemdUserRoot);
-			enforceRuntimeUserOwnership(
-				runtimePlatformEnclaveOwnership(platformEnclaves),
-				hostedRuntimeContract.identity,
-			);
-		}
+		const error = installOfficialRuntimeService(item, paths, hostedRuntimeContract.identity);
 		if (error) throw new Error(error);
 		if (!item.serviceRevision) {
 			throw new Error(`official ${item.unitName} service revision could not be verified`);
@@ -1074,13 +999,6 @@ function activateRuntimeServices(
 		officialServicePlan.serviceRevisions[item.unitName] = item.serviceRevision;
 	}
 	state.officialServiceCommandRevisions = officialServicePlan.serviceRevisions;
-	if (platformEnclaves.some((enclave) => enclave.path === paths.systemdUserRoot)) {
-		enforceRuntimeUserSystemdManagerAccess(paths.systemdUserRoot);
-	}
-	enforceRuntimeUserOwnership(
-		runtimePlatformEnclaveOwnership(platformEnclaves),
-		hostedRuntimeContract.identity,
-	);
 	if (opts.systemdApply) {
 		const activation = opts.systemdApply.activate({
 			staleSystemUnits: state.staleSystemdFiles.systemUnits,

--- a/packages/cli/src/runtime/manifest-install.ts
+++ b/packages/cli/src/runtime/manifest-install.ts
@@ -21,10 +21,8 @@ import {
 	buildRuntimeUserCommand,
 	clearTenantToolLocationOverrides,
 	commandResolvable,
-	enforceRuntimeUserOwnership,
 	executableExists,
 	RuntimeUserCommandTimeoutError,
-	runtimeUserDirectoryOwnership,
 	spawnRuntimeUserCommand,
 } from "./runtime-user-command";
 import { writeRuntimePlatformFileAtomic } from "./state";
@@ -278,7 +276,6 @@ function runOfficialInstaller(
 		);
 	}
 
-	enforceRuntimeUserOwnership(runtimeUserDirectoryOwnership(install.home), identity);
 	const url = executionInstallerUrl(name, install.url);
 	const materialized = materializeInstaller(name, url, paths);
 	try {

--- a/packages/cli/src/runtime/manifest-oauth.ts
+++ b/packages/cli/src/runtime/manifest-oauth.ts
@@ -33,11 +33,7 @@ import type { RuntimeManifest } from "./manifest-contract";
 import { tail } from "./manifest-install";
 import { recordValue, stringValue } from "./manifest-shared";
 import type { RuntimePaths } from "./paths";
-import {
-	enforceRuntimeUserOwnership,
-	runtimeUserDirectoryOwnership,
-	spawnRuntimeUserCommand,
-} from "./runtime-user-command";
+import { spawnRuntimeUserCommand } from "./runtime-user-command";
 import { runtimeSecretValue } from "./secret-values";
 
 const OPENCLAW_CODEX_PROVIDER_ID = "openai";
@@ -158,9 +154,6 @@ function runHermesCodexAuthCommand(
 	input: RuntimeOAuthCredentialCommand,
 ): Record<string, unknown> {
 	const authPath = hermesAuthPath(home);
-	enforceRuntimeUserOwnership(
-		runtimeUserDirectoryOwnership(dirname(authPath), { mode: 0o700, ancestorsUnder: home }),
-	);
 	const result = spawnRuntimeUserCommand(
 		"flock",
 		[
@@ -201,7 +194,6 @@ process.stdout.write(normalized?.purpose === "control-ui-owner" ? "supported" : 
 export function openClawSupportsOwnerBrowserBootstrap(context: OpenClawHostedContext): boolean {
 	const sdkPath = context.sdk.deviceBootstrap;
 	if (!sdkPath) return false;
-	enforceRuntimeUserOwnership(runtimeUserDirectoryOwnership(context.home));
 	const result = spawnRuntimeUserCommand(
 		"node",
 		["--input-type=module", "--eval", OPENCLAW_OWNER_BROWSER_BOOTSTRAP_CAPABILITY_PROBE, sdkPath],
@@ -242,7 +234,6 @@ if (
 `;
 function requireOpenClawProviderAuthCapability(context: OpenClawHostedContext): void {
 	const sdkPath = context.requireSdkExport("providerAuth");
-	enforceRuntimeUserOwnership(runtimeUserDirectoryOwnership(context.home));
 	const result = spawnRuntimeUserCommand(
 		"node",
 		["--input-type=module", "--eval", OPENCLAW_PROVIDER_AUTH_CAPABILITY_PROBE, sdkPath],
@@ -263,7 +254,6 @@ function requireOpenClawManagedProviderAuthCleanupCapability(context: OpenClawHo
 	if (!configMutationSdkPath) {
 		throw new Error("installed OpenClaw public config-mutation SDK export is unavailable");
 	}
-	enforceRuntimeUserOwnership(runtimeUserDirectoryOwnership(context.home));
 	const result = spawnRuntimeUserCommand(
 		"node",
 		[

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -28,13 +28,9 @@ import type { RuntimePaths } from "./paths";
 import { runtimeImpactRevision } from "./runtime-impact-revision";
 import {
 	commandExists,
-	enforceRuntimeUserOwnership,
 	executableExists,
-	makeRuntimeUserOwned,
 	runRuntimeUserCommand,
-	runtimeUserDirectoryOwnership,
 	spawnRuntimeUserCommand,
-	withRuntimeUserFileAccess,
 } from "./runtime-user-command";
 import { runtimeSecretValue } from "./secret-values";
 
@@ -262,13 +258,9 @@ export function applyHostedCodexManagedProviderProjection(
 	if (!provider) return { path: null, revision: null, providerIds: [] };
 
 	const codexHome = hostedCodexHome(home);
-	enforceRuntimeUserOwnership(
-		runtimeUserDirectoryOwnership(codexHome, { mode: 0o700, ancestorsUnder: home }),
-	);
 	const configPath = join(codexHome, CODEX_MANAGED_PROVIDER_CONFIG_FILE);
 	const configContent = hostedCodexManagedConfigToml(provider);
 	writePrivateFileAtomic(configPath, configContent, { mode: 0o600, dirMode: 0o700 });
-	makeRuntimeUserOwned(configPath);
 
 	return {
 		path: configPath,
@@ -388,7 +380,7 @@ function installHostedCodexBootstrap(
 	if (!commandExists("npm")) {
 		throw new Error("Codex bootstrap requires npm on PATH");
 	}
-	withRuntimeUserFileAccess(() => mkdirSync(npmPrefix, { recursive: true }));
+	mkdirSync(npmPrefix, { recursive: true });
 	const result = spawnRuntimeUserCommand(
 		"npm",
 		[
@@ -553,7 +545,6 @@ function applyOpenClawHostedProviderPatch(
 	workspaceRoot: string,
 ): void {
 	const sdkPath = context.requireSdkExport("configMutation");
-	enforceRuntimeUserOwnership(runtimeUserDirectoryOwnership(context.home));
 	runRuntimeUserCommand(
 		"node",
 		["--input-type=module", "--eval", OPENCLAW_CONFIG_MUTATION_HELPER, sdkPath],

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -4154,7 +4154,7 @@ exit 0
 		expect(readlinkSync(commandPath)).toBe(commandTarget);
 	});
 
-	test("keeps generated systemd files root-owned outside the UID 10001 installer boundary", () => {
+	test("migrates legacy root-owned systemd files into the UID 10001 tenant tree", () => {
 		const numericPrivilegeToolPath = ["/usr/bin/set", "priv"].join("");
 		if (process.geteuid?.() !== 0 || !existsSync(numericPrivilegeToolPath)) return;
 		const paths = tempRuntimePaths();
@@ -4174,15 +4174,13 @@ exit 0
 		);
 		const wantsRoot = join(paths.systemdUserRoot, "default.target.wants");
 		const enablementPath = join(wantsRoot, "openclaw-gateway.service");
-		const runtimeOwnedPaths = [
+		const tenantOwnedPaths = [
 			appRoot,
 			binDir,
 			commandPath,
 			dirname(dirname(paths.systemdUserRoot)),
 			dirname(paths.systemdUserRoot),
 			wantsRoot,
-		];
-		const platformOwnedPaths = [
 			paths.systemdUserRoot,
 			unitPath,
 			unitBackupPath,
@@ -4215,9 +4213,9 @@ case "$*" in
   "agents list --json")
     printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace"
     ;;
-  "skills install "*)
-    : > '${skillProjectionLog}'
-    ${platformOwnedPaths.map((path) => `stat -c '%u:%g' '${path}' >> '${skillProjectionLog}'`).join("\n    ")}
+			"skills install "*)
+			    : > '${skillProjectionLog}'
+			    ${tenantOwnedPaths.map((path) => `stat -c '%u:%g' '${path}' >> '${skillProjectionLog}'`).join("\n    ")}
     exit 45
     ;;
   "gateway install --force --json")
@@ -4241,12 +4239,12 @@ esac
 			chownSync(path, 0, 0);
 			chmodSync(path, 0o700);
 		}
-		for (const path of [commandPath, ...platformOwnedPaths]) {
+		for (const path of tenantOwnedPaths) {
 			if (lstatSync(path).isSymbolicLink()) continue;
 			chownSync(path, 0, 0);
 			chmodSync(path, 0o700);
 		}
-		lchownSync(enablementPath, runtimeUid, runtimeGid);
+		lchownSync(enablementPath, 0, 0);
 		chmodSync(unitPath, 0o600);
 		chmodSync(unitBackupPath, 0o600);
 		chmodSync(dropInPath, 0o600);
@@ -4296,19 +4294,11 @@ esac
 			"OpenClaw official Skill install failed: exit code 45 without output",
 		);
 		expect(readFileSync(skillProjectionLog, "utf8").trim().split("\n")).toEqual(
-			platformOwnedPaths.map(() => "0:0"),
+			tenantOwnedPaths.map(() => `${runtimeUid}:${runtimeGid}`),
 		);
-		for (const path of runtimeOwnedPaths) {
+		for (const path of [...tenantOwnedPaths, enablementPath]) {
 			const node = lstatSync(path);
 			expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
-		}
-		expect([lstatSync(enablementPath).uid, lstatSync(enablementPath).gid]).toEqual([
-			runtimeUid,
-			runtimeGid,
-		]);
-		for (const path of platformOwnedPaths) {
-			const node = lstatSync(path);
-			expect([node.uid, node.gid]).toEqual([0, 0]);
 		}
 		expect(statSync(appRoot).mode & 0o777).toBe(0o700);
 		expect(statSync(commandPath).mode & 0o777).toBe(0o700);
@@ -4332,15 +4322,10 @@ esac
 			},
 		);
 		expect(installed.installErrors).toEqual([]);
-		for (const path of platformOwnedPaths) {
+		for (const path of [...tenantOwnedPaths, enablementPath]) {
 			const node = lstatSync(path);
-			expect([node.uid, node.gid]).toEqual([0, 0]);
+			expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
 		}
-		expect([statSync(wantsRoot).uid, statSync(wantsRoot).gid]).toEqual([runtimeUid, runtimeGid]);
-		expect([lstatSync(enablementPath).uid, lstatSync(enablementPath).gid]).toEqual([
-			runtimeUid,
-			runtimeGid,
-		]);
 		expect(statSync(gatewayEnvironment).mode & 0o777).toBe(0o600);
 	});
 

--- a/packages/cli/src/runtime/manifest-runtime-config.ts
+++ b/packages/cli/src/runtime/manifest-runtime-config.ts
@@ -10,11 +10,7 @@ import { mergeRuntimeEnvWithProviderPlaceholders } from "./hosted-provider-resol
 import type { RuntimeManifest } from "./manifest-contract";
 import type { RuntimeInstallObservation } from "./manifest-install";
 import type { RuntimeName, RuntimeRunSettings, RuntimeServiceName } from "./run-config";
-import {
-	executableExists,
-	makeRuntimeUserOwned,
-	withRuntimeUserFileAccess,
-} from "./runtime-user-command";
+import { executableExists } from "./runtime-user-command";
 
 const MANAGED_LOCALE_BLOCK_START = "<!-- >>> clawdi managed locale >>>";
 const MANAGED_LOCALE_BLOCK_END = "<!-- <<< clawdi managed locale <<< -->";
@@ -64,13 +60,10 @@ export function nextManagedLocaleFileContent(
 	return { existing, next };
 }
 function updateManagedLocaleFile(path: string, block: string): string {
-	return withRuntimeUserFileAccess(() => {
-		const { existing, next } = nextManagedLocaleFileContent(path, block);
-		if (next === existing) return path;
-		writePrivateFileAtomic(path, next, { mode: 0o600, dirMode: 0o700 });
-		makeRuntimeUserOwned(path);
-		return path;
-	});
+	const { existing, next } = nextManagedLocaleFileContent(path, block);
+	if (next === existing) return path;
+	writePrivateFileAtomic(path, next, { mode: 0o600, dirMode: 0o700 });
+	return path;
 }
 export function hermesConfigContext(
 	observation: RuntimeInstallObservation,

--- a/packages/cli/src/runtime/manifest-runtime-state.ts
+++ b/packages/cli/src/runtime/manifest-runtime-state.ts
@@ -21,7 +21,6 @@ import { makeManagedSecretRoot, scopedSecretValues } from "./manifest-secrets";
 import type { RuntimePaths } from "./paths";
 import { runtimeNameSchema, runtimeServiceNameSchema } from "./run-config";
 import { runtimeProgramRevision } from "./runtime-impact-revision";
-import { makeRuntimeUserOwned, withRuntimeUserFileAccess } from "./runtime-user-command";
 
 export function removeStaleRuntimeRunConfigs(
 	writtenRunConfigIds: Set<string>,
@@ -58,39 +57,34 @@ export function writeLiveSyncEnvironmentFiles(
 ): string[] {
 	const agents = desiredLiveSyncAgents(manifest);
 	const desiredTypes = new Set(agents.map((agent) => agent.agentType));
-	const written = withRuntimeUserFileAccess(() => {
-		const envDir = paths.localEnvironments;
-		mkdirSync(envDir, { recursive: true });
-		makeRuntimeUserOwned(envDir);
-		for (const agentType of MANAGED_LIVE_SYNC_AGENTS) {
-			if (!desiredTypes.has(agentType)) {
-				rmSync(join(envDir, `${agentType}.json`), { force: true });
-			}
+	const envDir = paths.localEnvironments;
+	mkdirSync(envDir, { recursive: true });
+	for (const agentType of MANAGED_LIVE_SYNC_AGENTS) {
+		if (!desiredTypes.has(agentType)) {
+			rmSync(join(envDir, `${agentType}.json`), { force: true });
 		}
-		const outputs: string[] = [];
-		for (const agent of agents) {
-			const path = join(envDir, `${agent.agentType}.json`);
-			writePrivateFileAtomic(
-				path,
-				`${JSON.stringify(
-					{
-						id: agent.environmentId,
-						agentType: agent.agentType,
-						managedBy: "clawdi runtime init",
-						deploymentId: manifest.deploymentId,
-						instanceId: manifest.instanceId,
-					},
-					null,
-					2,
-				)}\n`,
-				{ mode: 0o600, dirMode: 0o700 },
-			);
-			makeRuntimeUserOwned(path);
-			outputs.push(path);
-		}
-		return outputs;
-	});
-	return written;
+	}
+	const outputs: string[] = [];
+	for (const agent of agents) {
+		const path = join(envDir, `${agent.agentType}.json`);
+		writePrivateFileAtomic(
+			path,
+			`${JSON.stringify(
+				{
+					id: agent.environmentId,
+					agentType: agent.agentType,
+					managedBy: "clawdi runtime init",
+					deploymentId: manifest.deploymentId,
+					instanceId: manifest.instanceId,
+				},
+				null,
+				2,
+			)}\n`,
+			{ mode: 0o600, dirMode: 0o700 },
+		);
+		outputs.push(path);
+	}
+	return outputs;
 }
 export function writeDaemonAuthToken(
 	paths: RuntimePaths,

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -1394,24 +1394,21 @@ esac
 	test.each([
 		["Hermes", "hermes"],
 		["OpenClaw", "openclaw"],
-	] as const)("reports foreign %s gateway drop-ins without deleting them", (_name, runtime) => {
-		const harness = officialServiceHarness(runtime);
-		expect(harness.converge().installErrors).toEqual([]);
-		const foreignDropIn = harness.addForeignDropIn();
-		const foreignContents = readFileSync(foreignDropIn, "utf8");
+	] as const)(
+		"preserves foreign %s gateway drop-ins while reconciling its own",
+		(_name, runtime) => {
+			const harness = officialServiceHarness(runtime);
+			expect(harness.converge().installErrors).toEqual([]);
+			const foreignDropIn = harness.addForeignDropIn();
+			const foreignContents = readFileSync(foreignDropIn, "utf8");
 
-		const drifted = harness.converge();
+			const converged = harness.converge();
 
-		expect(drifted.installErrors).toEqual([
-			expect.stringContaining(
-				`foreign systemd drop-in drift detected for ${runtime}-gateway.service`,
-			),
-		]);
-		expect(drifted.installErrors.join("\n")).toContain(foreignDropIn);
-		expect(drifted.outputs.systemdUserUnits).toEqual([]);
-		expect(harness.installCount()).toBe(1);
-		expect(readFileSync(foreignDropIn, "utf8")).toBe(foreignContents);
-	});
+			expect(converged.installErrors).toEqual([]);
+			expect(harness.installCount()).toBe(1);
+			expect(readFileSync(foreignDropIn, "utf8")).toBe(foreignContents);
+		},
+	);
 
 	test("turns a hanging runtime version probe into a bounded convergence error", () => {
 		const harness = officialServiceHarness("openclaw");

--- a/packages/cli/src/runtime/manifest-skills-apply.ts
+++ b/packages/cli/src/runtime/manifest-skills-apply.ts
@@ -39,6 +39,12 @@ interface HostedSkillProjectionDriver {
 }
 type HostedSkillRuntime = "hermes" | "openclaw";
 
+function withRuntimeUserSkillFiles<T>(
+	operation: () => T & (T extends PromiseLike<unknown> ? never : unknown),
+): T {
+	return withRuntimeUserFileAccess(operation);
+}
+
 function preparedSkillMatchesDesired(
 	prepared: PreparedHostedSkill | undefined,
 	desired: HostedSkillDesired,
@@ -70,7 +76,7 @@ function requirePreparedSkillTarget(
 	}
 	const targetDir = join(skillsRoot, prepared.id);
 	if (
-		withRuntimeUserFileAccess(() => existsSync(targetDir)) &&
+		withRuntimeUserSkillFiles(() => existsSync(targetDir)) &&
 		managedSkillReservationOwner(targetDir, skillId) !== "hosted-manifest"
 	) {
 		throw new Error(`refusing to replace unmanaged ${skillId} skill at ${targetDir}`);
@@ -117,7 +123,8 @@ function hostedSkillProjectionDrivers(input: {
 			"hermes",
 			{
 				skillsRoot: hermesSkillsRoot,
-				activate: activateHostedHermesSkill,
+				activate: (sourceDir, targetDir) =>
+					withRuntimeUserSkillFiles(() => activateHostedHermesSkill(sourceDir, targetDir)),
 			},
 		],
 		[
@@ -126,13 +133,16 @@ function hostedSkillProjectionDrivers(input: {
 				skillsRoot: openClawSkillsRoot,
 				exclude: new Set([".openclaw/source-origin.json"]),
 				activate: (sourceDir, targetDir) => {
-					if (!input.openClawWorkspaceRoot) openClawWorkspaceUnavailable();
-					activateHostedOpenClawSkill({
-						home: input.home,
-						workspaceRoot: input.openClawWorkspaceRoot,
-						sourceDir,
-						targetDir,
-					});
+					const workspaceRoot = input.openClawWorkspaceRoot;
+					if (!workspaceRoot) openClawWorkspaceUnavailable();
+					withRuntimeUserSkillFiles(() =>
+						activateHostedOpenClawSkill({
+							home: input.home,
+							workspaceRoot,
+							sourceDir,
+							targetDir,
+						}),
+					);
 				},
 			},
 		],
@@ -157,7 +167,7 @@ function pendingReservationMatchesPrepared(
 }
 
 function discardPendingHostedSkill(targetDir: string): void {
-	withRuntimeUserFileAccess(() => rmSync(targetDir, { recursive: true, force: true }));
+	withRuntimeUserSkillFiles(() => rmSync(targetDir, { recursive: true, force: true }));
 }
 
 function recoverPendingHostedSkillInstallations(
@@ -187,9 +197,11 @@ function recoverPendingHostedSkillInstallations(
 			manager: "hosted-manifest",
 			verify: () =>
 				promotable !== null &&
-				installedTreeMatches(promotable, reservation.targetDir, {
-					exclude: driver.exclude,
-				}),
+				withRuntimeUserSkillFiles(() =>
+					installedTreeMatches(promotable, reservation.targetDir, {
+						exclude: driver.exclude,
+					}),
+				),
 			discard: () => discardPendingHostedSkill(reservation.targetDir),
 		});
 	}
@@ -248,7 +260,7 @@ function applyHostedSkills(
 					id: skillId,
 					manager: "hosted-manifest",
 					removeTarget: () => {
-						withRuntimeUserFileAccess(() =>
+						withRuntimeUserSkillFiles(() =>
 							rmSync(reservation.targetDir, { recursive: true, force: true }),
 						);
 					},
@@ -270,9 +282,11 @@ function applyHostedSkills(
 		if (
 			reservation?.targetDir === targetDir &&
 			reservation.digest === reservationIdentity.digest &&
-			installedTreeMatches(prepared, targetDir, {
-				exclude: driver.exclude,
-			})
+			withRuntimeUserSkillFiles(() =>
+				installedTreeMatches(prepared, targetDir, {
+					exclude: driver.exclude,
+				}),
+			)
 		) {
 			if (
 				reservation.version !== reservationIdentity.version ||
@@ -299,9 +313,11 @@ function applyHostedSkills(
 					withPreparedHostedSkill(prepared, (sourceDir) => driver.activate(sourceDir, targetDir)),
 				{
 					verify: () =>
-						installedTreeMatches(prepared, targetDir, {
-							exclude: driver.exclude,
-						}),
+						withRuntimeUserSkillFiles(() =>
+							installedTreeMatches(prepared, targetDir, {
+								exclude: driver.exclude,
+							}),
+						),
 					discard: () => discardPendingHostedSkill(targetDir),
 				},
 			);
@@ -346,7 +362,7 @@ export function reconcileHostedSkillProjection(input: {
 	for (const [, driver] of drivers) {
 		const skillsRoot = driver.skillsRoot;
 		if (skillsRoot) {
-			withRuntimeUserFileAccess(() =>
+			withRuntimeUserSkillFiles(() =>
 				rmSync(join(skillsRoot, ".clawdi-manifest-receipts"), {
 					recursive: true,
 					force: true,

--- a/packages/cli/src/runtime/openclaw-managed-provider-plugin.ts
+++ b/packages/cli/src/runtime/openclaw-managed-provider-plugin.ts
@@ -10,7 +10,7 @@ import {
 	type OpenClawHostedContext,
 } from "./hosted-openclaw-context";
 import { openClawPluginInspectSchema } from "./openclaw-plugin-observation";
-import { spawnRuntimeUserCommand, withRuntimeUserFileAccess } from "./runtime-user-command";
+import { spawnRuntimeUserCommand } from "./runtime-user-command";
 
 export { CLAWDI_MANAGED_OPENCLAW_PROVIDER_PLUGIN_ID } from "./hosted-openclaw-context";
 
@@ -91,15 +91,13 @@ function pluginDirectoryIsCurrent(directory: string): boolean {
 }
 
 function materializePluginDirectory(directory: string): string {
-	return withRuntimeUserFileAccess(() => {
-		if (pluginDirectoryIsCurrent(directory)) return directory;
-		rmSync(directory, { recursive: true, force: true });
-		mkdirSync(directory, { recursive: true, mode: 0o700 });
-		for (const [name, content] of pluginFiles) {
-			writeFileSync(join(directory, name), content, { mode: 0o600 });
-		}
-		return directory;
-	});
+	if (pluginDirectoryIsCurrent(directory)) return directory;
+	rmSync(directory, { recursive: true, force: true });
+	mkdirSync(directory, { recursive: true, mode: 0o700 });
+	for (const [name, content] of pluginFiles) {
+		writeFileSync(join(directory, name), content, { mode: 0o600 });
+	}
+	return directory;
 }
 
 function materializePluginSource(context: OpenClawHostedContext): string {

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -69,7 +69,6 @@ export interface RuntimePaths {
 	managedSecretRoot: string;
 	daemonStateRoot: string;
 	egressRoot: string;
-	egressScratchRoot: string;
 	egressTransparentEnv: string;
 	egressAddon: string;
 	egressCaDir: string;
@@ -78,19 +77,6 @@ export interface RuntimePaths {
 	egressServiceBinary: string;
 	daemonAuthToken: string;
 	workspaceRoot: string;
-}
-
-export function runtimeSystemdPlatformEnclaves(
-	paths: Pick<RuntimePaths, "systemdUserRoot" | "userHome">,
-): Array<{ path: string; owner: "runtime-user" | "root" }> {
-	return [
-		// systemd requires user units below HOME. This root contains base units and
-		// Clawdi drop-ins under generated-file authority.
-		{ path: paths.systemdUserRoot, owner: "root" },
-		{ path: join(paths.systemdUserRoot, "default.target.wants"), owner: "runtime-user" },
-		// OpenClaw's installer writes this private environment file in HOME.
-		{ path: join(paths.userHome, ".openclaw", "gateway.systemd.env"), owner: "root" },
-	];
 }
 
 function envPath(name: string): string | undefined {
@@ -222,7 +208,6 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 		managedSecretRoot: join(runRoot, "secrets"),
 		daemonStateRoot: join(serviceStateRoot, "daemon"),
 		egressRoot: join(runRoot, "egress"),
-		egressScratchRoot: join(runRoot, "egress-scratch"),
 		egressTransparentEnv: join(runRoot, "egress", "transparent-egress.env"),
 		egressAddon: join(runRoot, "egress", "clawdi_egress_addon.py"),
 		egressCaDir: join(runRoot, "egress", "ca"),

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -4,6 +4,7 @@ import {
 	chownSync,
 	existsSync,
 	lstatSync,
+	mkdirSync,
 	readdirSync,
 	readFileSync,
 	rmdirSync,
@@ -95,7 +96,8 @@ export interface OfficialRuntimeServicePlan {
 }
 
 export interface RuntimeSystemdStaleFilePlan {
-	files: string[];
+	platformFiles: string[];
+	userFiles: string[];
 	systemUnits: string[];
 	userUnits: string[];
 }
@@ -531,10 +533,15 @@ function writeSystemdProgramEnvironment(input: {
 	return writeSystemdEnvironmentFile(input);
 }
 
+function withRuntimeUserSystemdFiles<T>(
+	operation: () => T & (T extends PromiseLike<unknown> ? never : unknown),
+): T {
+	return withRuntimeUserFileAccess(operation);
+}
+
 function writeSystemdUnit(input: {
 	root: string;
 	owner: "root" | "runtime-user";
-	unitOwner?: "root" | "runtime-user";
 	paths: RuntimePaths;
 	name: string;
 	description: string;
@@ -553,7 +560,6 @@ function writeSystemdUnit(input: {
 	wantedBy: "multi-user.target" | "default.target";
 }): string {
 	const path = join(input.root, systemdUnitFileName(input.name));
-	const unitOwner = input.unitOwner ?? input.owner;
 	const envFile = writeSystemdProgramEnvironment({
 		paths: input.paths,
 		name: input.name,
@@ -611,19 +617,21 @@ function writeSystemdUnit(input: {
 		"",
 	];
 	const writeUnitFile = (): string => {
+		if (input.owner === "runtime-user") mkdirSync(input.root, { recursive: true });
 		ensureDirectoryWithinTrustedRoot(input.root, input.root);
-		if (unitOwner === "runtime-user") makeRuntimeUserOwned(input.root);
 		writeSystemdManagedFile({
 			path,
 			content: lines.join("\n"),
 			mode: 0o644,
 			dirMode: 0o755,
 			trustedRoot: input.root,
-			owner: unitOwner,
+			owner: input.owner,
 		});
 		return path;
 	};
-	return unitOwner === "runtime-user" ? withRuntimeUserFileAccess(writeUnitFile) : writeUnitFile();
+	return input.owner === "runtime-user"
+		? withRuntimeUserSystemdFiles(writeUnitFile)
+		: writeUnitFile();
 }
 
 function writeSystemdSystemUnit(
@@ -644,7 +652,6 @@ function writeSystemdUserUnit(
 		...input,
 		root: input.paths.systemdUserRoot,
 		owner: "runtime-user",
-		unitOwner: "root",
 		wantedBy: "default.target",
 	});
 }
@@ -678,15 +685,18 @@ function writeSystemdUserEnvironmentDropIn(input: {
 		`EnvironmentFile=${systemdPath(envFile)}`,
 		"",
 	];
-	removeGeneratedRuntimeBaseUnit(input.paths, unitName);
-	ensureDirectoryWithinTrustedRoot(input.paths.systemdUserRoot, dirname(path));
-	writeSystemdManagedFile({
-		path,
-		content: lines.join("\n"),
-		mode: 0o644,
-		dirMode: 0o755,
-		trustedRoot: input.paths.systemdUserRoot,
-		owner: "root",
+	withRuntimeUserSystemdFiles(() => {
+		removeGeneratedRuntimeBaseUnit(input.paths, unitName);
+		mkdirSync(input.paths.systemdUserRoot, { recursive: true });
+		ensureDirectoryWithinTrustedRoot(input.paths.systemdUserRoot, dirname(path));
+		writeSystemdManagedFile({
+			path,
+			content: lines.join("\n"),
+			mode: 0o644,
+			dirMode: 0o755,
+			trustedRoot: input.paths.systemdUserRoot,
+			owner: "runtime-user",
+		});
 	});
 	return join(input.paths.systemdUserRoot, unitName);
 }
@@ -848,42 +858,6 @@ function uninstallOfficialRuntimeUserService(input: {
 	}
 }
 
-function foreignRuntimeSystemdUserDropIns(paths: RuntimePaths, unitName: string): string[] {
-	const dropInRoot = join(paths.systemdUserRoot, `${unitName}.d`);
-	let rootStat: ReturnType<typeof lstatSync>;
-	try {
-		rootStat = lstatSync(dropInRoot);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
-		throw error;
-	}
-	if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) return [dropInRoot];
-	// systemd merges only *.conf files from unit drop-in directories:
-	// https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html
-	return readdirSync(dropInRoot)
-		.filter((entry) => entry.endsWith(".conf") && entry !== RUNTIME_SYSTEMD_DROP_IN_FILE)
-		.map((entry) => join(dropInRoot, entry))
-		.sort();
-}
-
-function officialRuntimeSystemdUserDropInDriftErrors(
-	programs: RuntimeSystemdUserProgram[],
-	paths: RuntimePaths,
-): string[] {
-	const errors: string[] = [];
-	for (const program of officialRuntimeSystemdPrograms(programs)) {
-		const unitName = systemdUnitFileName(runtimeSystemdProgramName(program));
-		const foreignDropIns = foreignRuntimeSystemdUserDropIns(paths, unitName);
-		if (foreignDropIns.length === 0) continue;
-		errors.push(
-			`foreign systemd drop-in drift detected for ${unitName}; refusing to reconcile the platform override while these drop-ins exist: ${foreignDropIns
-				.map((path) => JSON.stringify(path))
-				.join(", ")}`,
-		);
-	}
-	return errors;
-}
-
 export function uninstallStaleOfficialRuntimeServices(input: {
 	paths: RuntimePaths;
 	unitNames: readonly string[];
@@ -906,7 +880,8 @@ function planStaleRuntimeSystemdFiles(
 	desiredSystemUnits: readonly string[],
 	desiredUserUnits: readonly string[],
 ): RuntimeSystemdStaleFilePlan {
-	const files = new Set<string>();
+	const platformFiles = new Set<string>();
+	const userFiles = new Set<string>();
 	const systemUnits = new Set<string>();
 	const userUnits = new Set<string>();
 	const desiredSystem = new Set(desiredSystemUnits);
@@ -920,13 +895,13 @@ function planStaleRuntimeSystemdFiles(
 	if (existsSync(paths.systemdSystemRoot)) {
 		for (const entry of readdirSync(paths.systemdSystemRoot)) {
 			if (!managedSystem.has(entry) || desiredSystem.has(entry)) continue;
-			files.add(join(paths.systemdSystemRoot, entry));
+			platformFiles.add(join(paths.systemdSystemRoot, entry));
 			systemUnits.add(entry);
 		}
 	}
 	for (const entry of managedRuntimeSystemdUnitEntries(paths.systemdUserRoot)) {
 		if (desiredUser.has(entry.unitName)) continue;
-		files.add(entry.path);
+		userFiles.add(entry.path);
 		userUnits.add(entry.unitName);
 	}
 	const desiredEnvironmentFiles = new Set(
@@ -937,11 +912,12 @@ function planStaleRuntimeSystemdFiles(
 			if (!entry.endsWith(".service.env") || desiredEnvironmentFiles.has(entry)) continue;
 			const path = join(paths.systemdEnvRoot, entry);
 			if (!entry.startsWith("clawdi-") && !isGeneratedRuntimeSystemdPath(path)) continue;
-			files.add(path);
+			platformFiles.add(path);
 		}
 	}
 	return {
-		files: [...files].sort(),
+		platformFiles: [...platformFiles].sort(),
+		userFiles: [...userFiles].sort(),
 		systemUnits: [...systemUnits].sort(),
 		userUnits: [...userUnits].sort(),
 	};
@@ -949,16 +925,20 @@ function planStaleRuntimeSystemdFiles(
 
 export function removeStaleRuntimeSystemdFiles(plan: RuntimeSystemdStaleFilePlan): string[] {
 	const errors: string[] = [];
-	for (const path of plan.files) {
-		try {
-			rmSync(path, { force: true });
-			if (path.endsWith(`/${RUNTIME_SYSTEMD_DROP_IN_FILE}`) && existsSync(dirname(path))) {
-				if (readdirSync(dirname(path)).length === 0) rmdirSync(dirname(path));
+	const removeFiles = (paths: readonly string[]) => {
+		for (const path of paths) {
+			try {
+				rmSync(path, { force: true });
+				if (path.endsWith(`/${RUNTIME_SYSTEMD_DROP_IN_FILE}`) && existsSync(dirname(path))) {
+					if (readdirSync(dirname(path)).length === 0) rmdirSync(dirname(path));
+				}
+			} catch (error) {
+				errors.push(error instanceof Error ? error.message : String(error));
 			}
-		} catch (error) {
-			errors.push(error instanceof Error ? error.message : String(error));
 		}
-	}
+	};
+	removeFiles(plan.platformFiles);
+	withRuntimeUserSystemdFiles(() => removeFiles(plan.userFiles));
 	return errors;
 }
 
@@ -1312,10 +1292,7 @@ export function writeRuntimeSystemdState(input: {
 	};
 }
 
-export function validateRuntimeSystemdPlan(
-	programs: RuntimeSystemdUserProgram[],
-	paths: RuntimePaths,
-): void {
+export function validateRuntimeSystemdPlan(programs: RuntimeSystemdUserProgram[]): void {
 	for (const program of programs) {
 		systemdUnitFileName(runtimeSystemdProgramName(program));
 		systemdPath(program.cwd);
@@ -1327,6 +1304,4 @@ export function validateRuntimeSystemdPlan(
 			systemdEnvironmentFileQuote(value);
 		}
 	}
-	const driftErrors = officialRuntimeSystemdUserDropInDriftErrors(programs, paths);
-	if (driftErrors.length > 0) throw new Error(driftErrors.join("; "));
 }

--- a/packages/cli/src/runtime/runtime-user-command.test.ts
+++ b/packages/cli/src/runtime/runtime-user-command.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
 	chmodSync,
-	chownSync,
-	lchownSync,
 	lstatSync,
 	mkdirSync,
 	mkdtempSync,
@@ -13,19 +11,15 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
-import { runtimeSystemdPlatformEnclaves } from "./paths";
+import { join } from "node:path";
 import {
 	buildNumericUserCommand,
 	buildRuntimeUserCommand,
 	clearTenantToolLocationOverrides,
 	commandExists,
 	createPrivilegeDropResolver,
-	enforceRuntimeUserOwnership,
-	enforceRuntimeUserSystemdManagerAccess,
+	ensureRuntimeUserHomeOwnership,
 	runRuntimeUserCommand,
-	runtimeUserDirectoryOwnership,
-	runtimeUserExistingOwnership,
 	runtimeUserGid,
 	runtimeUserUid,
 	spawnRuntimeUserCommand,
@@ -392,172 +386,39 @@ test("fully drops root identity when spawned during runtime-user file access", (
 	}
 });
 
-test("recursively restores runtime ownership only inside declared state roots", () => {
+test("migrates a legacy root-owned tenant home without following symlinks", () => {
 	if (process.geteuid?.() !== 0) return;
-	const root = mkdtempSync(join(tmpdir(), "runtime-user-ownership-boundary-"));
-	const managedRoot = join(root, "home");
-	const nestedDirectory = join(managedRoot, ".hermes", "skills", "clawdi");
-	const nestedFile = join(nestedDirectory, ".clawdi-managed.json");
+	const root = mkdtempSync(join(tmpdir(), "runtime-user-home-migration-"));
+	const home = join(root, "home");
+	const systemdRoot = join(home, ".config", "systemd", "user");
+	const unit = join(systemdRoot, "hermes-gateway.service");
 	const outside = join(root, "platform-state");
-	const previousRuntimeUser = process.env.CLAWDI_RUNTIME_USER;
+	const outsideLink = join(home, "platform-link");
 	try {
-		mkdirSync(nestedDirectory, { recursive: true });
-		writeFileSync(nestedFile, "legacy\n", { mode: 0o600 });
+		mkdirSync(systemdRoot, { recursive: true, mode: 0o700 });
+		writeFileSync(unit, "legacy\n", { mode: 0o600 });
 		writeFileSync(outside, "preserve\n", { mode: 0o600 });
-		for (const path of [
-			managedRoot,
-			join(managedRoot, ".hermes"),
-			join(managedRoot, ".hermes", "skills"),
-			nestedDirectory,
-			nestedFile,
-			outside,
-		]) {
-			chownSync(path, 0, 0);
-		}
-		process.env.CLAWDI_RUNTIME_USER = "nobody";
+		symlinkSync(outside, outsideLink);
+		const identity = { uid: runtimeUserUid("nobody"), gid: runtimeUserGid("nobody") };
 
-		enforceRuntimeUserOwnership(runtimeUserExistingOwnership([managedRoot], { recursive: true }));
+		ensureRuntimeUserHomeOwnership(home, identity);
 
-		const expected = [runtimeUserUid("nobody"), runtimeUserGid("nobody")];
 		for (const path of [
-			managedRoot,
-			join(managedRoot, ".hermes"),
-			join(managedRoot, ".hermes", "skills"),
-			nestedDirectory,
-			nestedFile,
+			home,
+			join(home, ".config"),
+			join(home, ".config", "systemd"),
+			systemdRoot,
+			unit,
+			outsideLink,
 		]) {
-			const node = statSync(path);
-			expect([node.uid, node.gid]).toEqual(expected);
+			const node = lstatSync(path);
+			expect([node.uid, node.gid]).toEqual([identity.uid, identity.gid]);
 		}
-		expect(statSync(nestedFile).mode & 0o777).toBe(0o600);
+		expect(statSync(systemdRoot).mode & 0o777).toBe(0o700);
+		expect(statSync(unit).mode & 0o777).toBe(0o600);
 		expect([statSync(outside).uid, statSync(outside).gid]).toEqual([0, 0]);
 		expect(readFileSync(outside, "utf8")).toBe("preserve\n");
 	} finally {
-		if (previousRuntimeUser === undefined) delete process.env.CLAWDI_RUNTIME_USER;
-		else process.env.CLAWDI_RUNTIME_USER = previousRuntimeUser;
 		rmSync(root, { recursive: true, force: true });
 	}
-});
-
-test("enforces root ownership inside platform enclaves and runtime ownership outside", () => {
-	if (process.geteuid?.() !== 0) return;
-	const root = mkdtempSync(join(tmpdir(), "runtime-user-platform-enclaves-"));
-	const home = join(root, "home");
-	const systemdUserRoot = join(home, ".config", "systemd", "user");
-	const unit = join(systemdUserRoot, "openclaw-gateway.service");
-	const dropIn = join(`${unit}.d`, "10-clawdi-hosted.conf");
-	const wants = join(systemdUserRoot, "default.target.wants");
-	const enablement = join(wants, "openclaw-gateway.service");
-	const gatewayEnvironment = join(home, ".openclaw", "gateway.systemd.env");
-	const tenantFile = join(home, ".hermes", "config.yaml");
-	const outsideTarget = join(root, "outside-target");
-	const enclaveLink = join(wants, "outside-target");
-	const previousRuntimeUser = process.env.CLAWDI_RUNTIME_USER;
-	try {
-		mkdirSync(dirname(dropIn), { recursive: true });
-		mkdirSync(wants, { recursive: true });
-		mkdirSync(dirname(gatewayEnvironment), { recursive: true });
-		mkdirSync(dirname(tenantFile), { recursive: true });
-		writeFileSync(unit, "unit\n");
-		writeFileSync(dropIn, "drop-in\n");
-		symlinkSync("../openclaw-gateway.service", enablement);
-		writeFileSync(gatewayEnvironment, "TOKEN=platform\n", { mode: 0o600 });
-		writeFileSync(tenantFile, "model: tenant\n", { mode: 0o600 });
-		writeFileSync(outsideTarget, "outside\n", { mode: 0o600 });
-		symlinkSync(outsideTarget, enclaveLink);
-		for (const path of [
-			root,
-			home,
-			join(home, ".config"),
-			join(home, ".config", "systemd"),
-			systemdUserRoot,
-			unit,
-			dirname(dropIn),
-			dropIn,
-			wants,
-			gatewayEnvironment,
-			dirname(gatewayEnvironment),
-			dirname(tenantFile),
-			tenantFile,
-			outsideTarget,
-		]) {
-			chownSync(path, 0, 0);
-		}
-		process.env.CLAWDI_RUNTIME_USER = "nobody";
-		const expectedRuntimeOwner = [runtimeUserUid("nobody"), runtimeUserGid("nobody")];
-		for (const path of [
-			systemdUserRoot,
-			unit,
-			dirname(dropIn),
-			dropIn,
-			wants,
-			gatewayEnvironment,
-		]) {
-			chownSync(path, expectedRuntimeOwner[0], expectedRuntimeOwner[1]);
-		}
-		lchownSync(enablement, expectedRuntimeOwner[0], expectedRuntimeOwner[1]);
-		lchownSync(enclaveLink, expectedRuntimeOwner[0], expectedRuntimeOwner[1]);
-		chownSync(outsideTarget, expectedRuntimeOwner[0], expectedRuntimeOwner[1]);
-		for (const path of [systemdUserRoot, dirname(dropIn), wants]) chmodSync(path, 0o700);
-		for (const path of [unit, dropIn]) chmodSync(path, 0o600);
-		const platformEnclaves = runtimeSystemdPlatformEnclaves({ userHome: home, systemdUserRoot });
-		expect(platformEnclaves).toEqual([
-			{ path: systemdUserRoot, owner: "root" },
-			{ path: wants, owner: "runtime-user" },
-			{ path: gatewayEnvironment, owner: "root" },
-		]);
-
-		enforceRuntimeUserSystemdManagerAccess(systemdUserRoot);
-		enforceRuntimeUserOwnership(
-			runtimeUserDirectoryOwnership(home, { recursive: true, platformEnclaves }),
-		);
-
-		for (const path of [systemdUserRoot, unit, dirname(dropIn), dropIn, gatewayEnvironment]) {
-			const node = lstatSync(path);
-			expect([node.uid, node.gid]).toEqual([0, 0]);
-		}
-		for (const path of [
-			home,
-			join(home, ".config"),
-			join(home, ".config", "systemd"),
-			dirname(gatewayEnvironment),
-			dirname(tenantFile),
-			tenantFile,
-			wants,
-			enablement,
-			enclaveLink,
-		]) {
-			const node = lstatSync(path);
-			expect([node.uid, node.gid]).toEqual(expectedRuntimeOwner);
-		}
-		expect([statSync(outsideTarget).uid, statSync(outsideTarget).gid]).toEqual(
-			expectedRuntimeOwner,
-		);
-		for (const path of [systemdUserRoot, dirname(dropIn), wants]) {
-			expect(statSync(path).mode & 0o777).toBe(0o755);
-		}
-		for (const path of [unit, dropIn]) {
-			expect(statSync(path).mode & 0o777).toBe(0o644);
-		}
-		expect(statSync(gatewayEnvironment).mode & 0o777).toBe(0o600);
-	} finally {
-		if (previousRuntimeUser === undefined) delete process.env.CLAWDI_RUNTIME_USER;
-		else process.env.CLAWDI_RUNTIME_USER = previousRuntimeUser;
-		rmSync(root, { recursive: true, force: true });
-	}
-});
-
-test("rejects platform enclaves without a recursive in-bound ownership root", () => {
-	const home = join(tmpdir(), "runtime-user-platform-enclave-boundary");
-	expect(() =>
-		runtimeUserDirectoryOwnership(home, {
-			platformEnclaves: [{ path: join(home, "platform"), owner: "root" }],
-		}),
-	).toThrow("runtime-user platform enclaves require recursive ownership");
-	expect(() =>
-		runtimeUserDirectoryOwnership(home, {
-			recursive: true,
-			platformEnclaves: [{ path: join(home, "..", "platform"), owner: "root" }],
-		}),
-	).toThrow("runtime-user platform enclave is outside its ownership boundary");
 });

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -1,15 +1,6 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import {
-	accessSync,
-	chmodSync,
-	chownSync,
-	constants,
-	lchownSync,
-	lstatSync,
-	mkdirSync,
-	readdirSync,
-} from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { accessSync, chownSync, constants, lstatSync, mkdirSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
 import { withEffectiveFilesystemIdentity } from "./effective-identity";
 import { applyEgressTransparentRuntimeEnv } from "./egress-env";
 import { clearPlatformCredentialEnv } from "./platform-credential-env";
@@ -21,20 +12,6 @@ const DEFAULT_SYSTEM_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/
 export interface RuntimeUserIdentity {
 	uid: number;
 	gid: number;
-}
-
-export interface RuntimeOwnershipEnclave {
-	path: string;
-	owner: "runtime-user" | "root";
-}
-
-export interface RuntimeUserOwnershipRule {
-	path: string;
-	owner: "runtime-user" | "root";
-	kind: "directory" | "existing";
-	mode?: number;
-	recursive: boolean;
-	platformEnclaves?: readonly RuntimeOwnershipEnclave[];
 }
 
 export type RuntimeUserIdentityResolver = (runtimeUser: string) => RuntimeUserIdentity;
@@ -393,223 +370,18 @@ function positiveLinuxIdEnv(key: string, fallback: number): number {
 	return raw ? parsePositiveLinuxId(raw, key) : fallback;
 }
 
-export function runtimeUserDirectoryOwnership(
-	path: string,
-	options: {
-		mode?: number;
-		ancestorsUnder?: string;
-		recursive?: boolean;
-		platformEnclaves?: readonly RuntimeOwnershipEnclave[];
-	} = {},
-): RuntimeUserOwnershipRule[] {
-	const target = resolve(path);
-	const paths = [target];
-	if (options.ancestorsUnder) {
-		const boundary = resolve(options.ancestorsUnder);
-		const relativeTarget = relative(boundary, target);
-		if (relativeTarget === ".." || relativeTarget.startsWith("../") || isAbsolute(relativeTarget)) {
-			throw new Error(`runtime-user directory is outside its ownership boundary: ${target}`);
-		}
-		for (let current = dirname(target); ; current = dirname(current)) {
-			paths.push(current);
-			if (current === boundary) break;
-		}
+export function ensureRuntimeUserHomeOwnership(path: string, identity: RuntimeUserIdentity): void {
+	mkdirSync(path, { recursive: true });
+	const node = lstatSync(path);
+	if (!node.isDirectory() || node.isSymbolicLink()) {
+		throw new Error(`runtime-user home must be a real directory: ${path}`);
 	}
-	const rules = runtimeUserOwnershipRules(paths, "directory", options, target);
-	const platformEnclaves = normalizedPlatformEnclaves(target, options);
-	return platformEnclaves.length === 0
-		? rules
-		: rules.map((rule) => (rule.path === target ? { ...rule, platformEnclaves } : rule));
-}
-
-function normalizedPlatformEnclaves(
-	target: string,
-	options: { recursive?: boolean; platformEnclaves?: readonly RuntimeOwnershipEnclave[] },
-): RuntimeOwnershipEnclave[] {
-	const enclaves = normalizeOwnershipEnclaves(options.platformEnclaves ?? []);
-	if (enclaves.length > 0 && options.recursive !== true) {
-		throw new Error("runtime-user platform enclaves require recursive ownership");
-	}
-	for (const enclave of enclaves) {
-		const relativeEnclave = relative(target, enclave.path);
-		if (
-			!relativeEnclave ||
-			relativeEnclave === ".." ||
-			relativeEnclave.startsWith("../") ||
-			isAbsolute(relativeEnclave)
-		) {
-			throw new Error(
-				`runtime-user platform enclave is outside its ownership boundary: ${enclave.path}`,
-			);
-		}
-	}
-	return enclaves;
-}
-
-function normalizeOwnershipEnclaves(
-	enclaves: readonly RuntimeOwnershipEnclave[],
-): RuntimeOwnershipEnclave[] {
-	const normalized = new Map<string, RuntimeOwnershipEnclave>();
-	for (const enclave of enclaves) {
-		const path = resolve(enclave.path);
-		normalized.set(path, { path, owner: enclave.owner });
-	}
-	return [...normalized.values()].sort(
-		(left, right) => left.path.length - right.path.length || left.path.localeCompare(right.path),
-	);
-}
-
-export const runtimeUserExistingOwnership = (
-	paths: readonly string[],
-	options: { recursive?: boolean } = {},
-) => runtimeUserOwnershipRules(paths, "existing", options);
-
-export function runtimePlatformEnclaveOwnership(
-	enclaves: readonly RuntimeOwnershipEnclave[],
-): RuntimeUserOwnershipRule[] {
-	return normalizeOwnershipEnclaves(enclaves).map((enclave) => ({
-		path: enclave.path,
-		owner: enclave.owner,
-		kind: "existing",
-		recursive: true,
-	}));
-}
-
-function runtimeUserOwnershipRules(
-	paths: readonly string[],
-	kind: RuntimeUserOwnershipRule["kind"],
-	options: { mode?: number; recursive?: boolean },
-	target?: string,
-): RuntimeUserOwnershipRule[] {
-	return [...new Set(paths.map((path) => resolve(path)))]
-		.sort((left, right) => left.length - right.length || left.localeCompare(right))
-		.map((path) => ({
-			path,
-			owner: "runtime-user",
-			kind,
-			...(path === target && options.mode !== undefined ? { mode: options.mode } : {}),
-			recursive:
-				target === undefined
-					? options.recursive === true
-					: path === target && options.recursive === true,
-		}));
-}
-
-export function enforceRuntimeUserOwnership(
-	rules: readonly RuntimeUserOwnershipRule[],
-	identity?: RuntimeUserIdentity,
-): void {
-	if (rules.length === 0) return;
-	const runtimeIdentity = runningAsRoot() ? (identity ?? runtimeFilesystemIdentity()) : null;
-	const rootIdentity = runningAsRoot() ? { uid: 0, gid: 0 } : null;
-	for (const rule of rules) {
-		if (rule.kind === "directory") mkdirSync(rule.path, { recursive: true });
-		let node: NonNullable<ReturnType<typeof lstatSync>>;
-		try {
-			node = lstatSync(rule.path);
-		} catch (error) {
-			if (rule.kind === "existing" && (error as NodeJS.ErrnoException).code === "ENOENT") continue;
-			throw error;
-		}
-		if (rule.kind === "directory" && (!node.isDirectory() || node.isSymbolicLink())) {
-			throw new Error(`runtime-user ownership path must be a real directory: ${rule.path}`);
-		}
-		enforceRuntimeUserNodeOwnership(
-			rule.path,
-			node,
-			runtimeIdentity,
-			rootIdentity,
-			rule.owner,
-			rule.recursive,
-			new Map(rule.platformEnclaves?.map((enclave) => [enclave.path, enclave.owner]) ?? []),
-		);
-		if (rule.mode !== undefined) chmodSync(rule.path, rule.mode);
-	}
-}
-
-export function enforceRuntimeUserSystemdManagerAccess(systemdUserRoot: string): void {
 	if (!runningAsRoot()) return;
-	let root: NonNullable<ReturnType<typeof lstatSync>>;
-	try {
-		root = lstatSync(systemdUserRoot);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-		throw error;
-	}
-	if (!root.isDirectory() || root.isSymbolicLink()) {
-		throw new Error(`runtime-user systemd root must be a real directory: ${systemdUserRoot}`);
-	}
-	ensureRuntimeUserManagerMode(systemdUserRoot, root, 0o555);
-	for (const entry of readdirSync(systemdUserRoot, { withFileTypes: true })) {
-		const path = join(systemdUserRoot, entry.name);
-		if (entry.isFile() && entry.name.endsWith(".service")) {
-			ensureRuntimeUserManagerMode(path, lstatSync(path), 0o444);
-			continue;
-		}
-		if (!entry.isDirectory()) continue;
-		if (entry.name === "default.target.wants") {
-			ensureRuntimeUserManagerMode(path, lstatSync(path), 0o555);
-			continue;
-		}
-		if (!entry.name.endsWith(".service.d")) continue;
-		ensureRuntimeUserManagerMode(path, lstatSync(path), 0o555);
-		for (const dropIn of readdirSync(path, { withFileTypes: true })) {
-			if (!dropIn.isFile() || !dropIn.name.endsWith(".conf")) continue;
-			const dropInPath = join(path, dropIn.name);
-			ensureRuntimeUserManagerMode(dropInPath, lstatSync(dropInPath), 0o444);
-		}
-	}
-}
-
-function ensureRuntimeUserManagerMode(
-	path: string,
-	node: NonNullable<ReturnType<typeof lstatSync>>,
-	requiredMode: number,
-): void {
-	const currentMode = Number(node.mode) & 0o7777;
-	const nextMode = currentMode | requiredMode;
-	if (nextMode !== currentMode) chmodSync(path, nextMode);
-}
-
-function runtimeFilesystemIdentity(): RuntimeUserIdentity | null {
-	if (!runningAsRoot()) return null;
-	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
-	if (!runtimeUser || runtimeUser === "root" || runtimeUser === "0") return null;
-	const identity = { uid: runtimeUserUid(runtimeUser), gid: runtimeUserGid(runtimeUser) };
 	if (identity.uid === 0 || identity.gid === 0) {
-		throw new Error(`runtime user ${runtimeUser} resolved to a root filesystem identity`);
+		throw new Error("runtime user resolved to a root filesystem identity");
 	}
-	return identity;
-}
-
-function enforceRuntimeUserNodeOwnership(
-	path: string,
-	node: NonNullable<ReturnType<typeof lstatSync>>,
-	runtimeIdentity: RuntimeUserIdentity | null,
-	rootIdentity: RuntimeUserIdentity | null,
-	owner: RuntimeUserOwnershipRule["owner"],
-	recursive: boolean,
-	platformEnclaves: ReadonlyMap<string, RuntimeOwnershipEnclave["owner"]>,
-): void {
-	const effectiveOwner = platformEnclaves.get(path) ?? owner;
-	const identity = effectiveOwner === "root" ? rootIdentity : runtimeIdentity;
-	if (identity && (node.uid !== identity.uid || node.gid !== identity.gid)) {
-		// lchown is non-dereferencing even if the path is swapped after lstat.
-		lchownSync(path, identity.uid, identity.gid);
-	}
-	if (!recursive || !node.isDirectory() || node.isSymbolicLink()) return;
-	for (const entry of readdirSync(path)) {
-		const child = join(path, entry);
-		enforceRuntimeUserNodeOwnership(
-			child,
-			lstatSync(child),
-			runtimeIdentity,
-			rootIdentity,
-			effectiveOwner,
-			true,
-			platformEnclaves,
-		);
-	}
+	// SUNSET: remove after all 0.13.92/0.14.14 hosts have migrated their root-owned tenant trees.
+	execFileSync("chown", ["-hR", "-P", `${identity.uid}:${identity.gid}`, "--", path]);
 }
 
 export function makeRuntimeUserOwned(path: string): void {

--- a/packages/cli/src/runtime/systemd-transaction.ts
+++ b/packages/cli/src/runtime/systemd-transaction.ts
@@ -269,10 +269,7 @@ export function applySystemdRuntimeUpdate(
 			continue;
 		}
 		if (state.activeState !== "active") continue;
-		if (
-			(opts.restartChangedUnits && user.changed.includes(unit)) ||
-			pendingUserActivation.has(unit)
-		) {
+		if (user.changed.includes(unit) || pendingUserActivation.has(unit)) {
 			restartUserUnits.push(unit);
 			userUnitsChanged.add(unit);
 		}

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -167,18 +167,16 @@ function expectManagedSystemdTreeOwnership(
 	runtimeUid: number,
 	runtimeGid: number,
 ): void {
-	const enablementRoot = join(root, "default.target.wants");
 	const visit = (path: string): void => {
 		const node = lstatSync(path);
-		const runtimeOwned = path === enablementRoot || path.startsWith(`${enablementRoot}/`);
-		expect([node.uid, node.gid]).toEqual(runtimeOwned ? [runtimeUid, runtimeGid] : [0, 0]);
+		expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
 		if (node.isSymbolicLink()) return;
 		if (node.isDirectory()) {
-			expect(node.mode & 0o555).toBe(0o555);
+			expect(node.mode & 0o500).toBe(0o500);
 			for (const entry of readdirSync(path)) visit(join(path, entry));
 			return;
 		}
-		if (node.isFile()) expect(node.mode & 0o444).toBe(0o444);
+		if (node.isFile()) expect(node.mode & 0o400).toBe(0o400);
 	};
 	visit(root);
 }
@@ -958,8 +956,8 @@ test("propagates the real official OpenClaw installer failure without committing
 	expect(readFileSync(openClawConfig, "utf8")).not.toBe(initialOpenClawConfig);
 	for (const path of [unitPath, gatewayEnvironment]) {
 		const stat = statSync(path);
-		expect(stat.uid).toBe(0);
-		expect(stat.gid).toBe(0);
+		expect(stat.uid).toBe(runtimeUid);
+		expect(stat.gid).toBe(runtimeGid);
 	}
 	expect(statSync(openClawConfig).uid).toBe(runtimeUid);
 	expect(statSync(openClawConfig).gid).toBe(runtimeGid);
@@ -1606,24 +1604,17 @@ test("runs Files as the tenant while preserving platform isolation", () => {
 	chownSync(openClawConfig, runtimeUid, runtimeGid);
 	const paths = getRuntimePaths({ mode: "hosted" });
 	ensureRuntimeStateDirs(paths);
-	const rootOwnedControl = join(paths.systemdUserRoot, "files-root-owned-control");
+	const rootOwnedControl = join(paths.statusRoot, "files-root-owned-control");
 	writeFileSync(rootOwnedControl, "root-owned\n", { mode: 0o600 });
-	const platformDriftUnit = join(paths.systemdUserRoot, "legacy-platform-control.service");
-	const platformDriftDropIn = join(`${platformDriftUnit}.d`, "10-legacy.conf");
-	const platformDriftEnvironment = join(openClawStateDir, "gateway.systemd.env");
-	mkdirSync(dirname(platformDriftDropIn), { recursive: true });
-	writeFileSync(platformDriftUnit, "[Service]\nExecStart=/bin/true\n");
-	writeFileSync(platformDriftDropIn, "[Service]\nEnvironment=LEGACY=1\n");
-	writeFileSync(platformDriftEnvironment, "LEGACY_PLATFORM_ENV=1\n", { mode: 0o600 });
-	for (const path of [
-		paths.systemdUserRoot,
-		platformDriftUnit,
-		dirname(platformDriftDropIn),
-		platformDriftDropIn,
-		platformDriftEnvironment,
-	]) {
-		chownSync(path, runtimeUid, runtimeGid);
-	}
+	const legacyRootOwnedUnit = join(paths.systemdUserRoot, "legacy-root-owned.service");
+	const legacyRootOwnedDropIn = join(`${legacyRootOwnedUnit}.d`, "10-legacy.conf");
+	const legacyRootOwnedEnvironment = join(openClawStateDir, "gateway.systemd.env");
+	mkdirSync(dirname(legacyRootOwnedDropIn), { recursive: true });
+	writeFileSync(legacyRootOwnedUnit, "[Service]\nExecStart=/bin/true\n");
+	writeFileSync(legacyRootOwnedDropIn, "[Service]\nEnvironment=LEGACY=1\n");
+	writeFileSync(legacyRootOwnedEnvironment, "LEGACY_ROOT_OWNED_ENV=1\n", { mode: 0o600 });
+	chownTreeWithoutFollowingLinks(paths.systemdUserRoot, 0, 0);
+	chownSync(legacyRootOwnedEnvironment, 0, 0);
 	const legacyEnvironmentRoot = join(runtimeHome, ".clawdi", "environments");
 	const legacyEnvironmentPath = join(legacyEnvironmentRoot, "openclaw.json");
 	const legacyEnvironmentContent = `${JSON.stringify({
@@ -1862,13 +1853,14 @@ http.createServer((request, response) => {
 	]);
 	for (const path of [
 		paths.systemdUserRoot,
-		platformDriftUnit,
-		dirname(platformDriftDropIn),
-		platformDriftDropIn,
-		platformDriftEnvironment,
+		legacyRootOwnedUnit,
+		dirname(legacyRootOwnedDropIn),
+		legacyRootOwnedDropIn,
+		legacyRootOwnedEnvironment,
 	]) {
-		expect([statSync(path).uid, statSync(path).gid]).toEqual([0, 0]);
+		expect([statSync(path).uid, statSync(path).gid]).toEqual([runtimeUid, runtimeGid]);
 	}
+	expect([statSync(rootOwnedControl).uid, statSync(rootOwnedControl).gid]).toEqual([0, 0]);
 	const tenantClawdiAfterConverge = tenantClawdi();
 	expect(tenantClawdiAfterConverge.status).not.toBe(0);
 	expect(tenantClawdiAfterConverge.stdout).toBe("");
@@ -2052,14 +2044,14 @@ http.createServer((request, response) => {
 	expect(tenantRead.stdout).toBe("tenant-existing\n");
 }, 120_000);
 
-test("repairs a live Hermes user-service ownership enclave without losing the unit", async () => {
+test("migrates a legacy root-owned Hermes user-service tree without losing the unit", async () => {
 	if (process.env[REAL_SYSTEMD_GATE] !== "1") return;
 
 	expect(process.geteuid?.()).toBe(0);
 	const runtimeHome = "/home/clawdi";
 	const runtimeUid = 10_001;
 	const runtimeGid = 10_001;
-	const root = mkdtempSync(join(tmpdir(), "clawdi-live-hermes-enclave-"));
+	const root = mkdtempSync(join(tmpdir(), "clawdi-live-hermes-ownership-"));
 	chmodSync(root, 0o755);
 	const hermesCommand = join(runtimeHome, ".local", "bin", "hermes");
 	const installLog = join(root, "hermes-installer.log");
@@ -2194,6 +2186,31 @@ esac
 		if (result.kind !== "converged") throw new Error(`unexpected apply result: ${result.kind}`);
 		return result.convergence;
 	};
+	mkdirSync(dropInRoot, { recursive: true });
+	mkdirSync(dirname(enablementPath), { recursive: true });
+	writeFileSync(
+		unitPath,
+		`[Unit]
+Description=Legacy Hermes Gateway
+
+[Service]
+Type=simple
+ExecStart=${hermesCommand} gateway run
+Restart=always
+
+[Install]
+WantedBy=default.target
+`,
+		{ mode: 0o600 },
+	);
+	writeFileSync(join(dropInRoot, "10-clawdi-hosted.conf"), "[Service]\nEnvironment=LEGACY=1\n", {
+		mode: 0o600,
+	});
+	symlinkSync("../hermes-gateway.service", enablementPath);
+	chownTreeWithoutFollowingLinks(paths.systemdUserRoot, 0, 0);
+	for (const path of [paths.systemdUserRoot, dropInRoot, dirname(enablementPath)]) {
+		chmodSync(path, 0o700);
+	}
 
 	try {
 		expect((await converge()).installErrors).toEqual([]);
@@ -2213,50 +2230,70 @@ esac
 		);
 		expect(initialPid).toBeGreaterThan(1);
 		expect(runUserSystemctl("is-enabled", unitName).stdout.trim()).toBe("enabled");
-		for (const path of [paths.systemdUserRoot, unitPath, dropInRoot]) {
-			const node = lstatSync(path);
-			expect([node.uid, node.gid]).toEqual([0, 0]);
-		}
-		expect([lstatSync(enablementPath).uid, lstatSync(enablementPath).gid]).toEqual([
-			runtimeUid,
-			runtimeGid,
-		]);
-
-		chmodSync(unitPath, 0o600);
-		chownTreeWithoutFollowingLinks(paths.systemdUserRoot, runtimeUid, runtimeGid);
 		for (const path of [paths.systemdUserRoot, unitPath, dropInRoot, enablementPath]) {
 			const node = lstatSync(path);
 			expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
 		}
+		const declaredUnit = readFileSync(unitPath, "utf8");
+		expect(declaredUnit).not.toContain("Legacy Hermes Gateway");
 
-		const repaired = await converge();
-		expect(repaired.installErrors).toEqual([]);
+		const idempotent = await converge();
+		expect(idempotent.installErrors).toEqual([]);
 		expect(readFileSync(installLog, "utf8").trim().split("\n")).toEqual(["install"]);
-		for (const path of [paths.systemdUserRoot, unitPath, dropInRoot]) {
+		for (const path of [paths.systemdUserRoot, unitPath, dropInRoot, enablementPath]) {
 			const node = lstatSync(path);
-			expect([node.uid, node.gid]).toEqual([0, 0]);
+			expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
 		}
-		expect([lstatSync(enablementPath).uid, lstatSync(enablementPath).gid]).toEqual([
-			runtimeUid,
-			runtimeGid,
-		]);
-		const repairedState = runUserSystemctl(
+		const idempotentState = runUserSystemctl(
 			"show",
 			unitName,
 			"--property=LoadState",
 			"--property=ActiveState",
 			"--property=MainPID",
 		);
-		expect(repairedState.status, repairedState.stderr).toBe(0);
-		expect(repairedState.stdout).toContain("LoadState=loaded");
+		expect(idempotentState.status, idempotentState.stderr).toBe(0);
+		expect(idempotentState.stdout).toContain("LoadState=loaded");
+		expect(idempotentState.stdout).toContain("ActiveState=active");
+		const idempotentPid = Number.parseInt(
+			idempotentState.stdout.match(/^MainPID=(\d+)$/m)?.[1] ?? "0",
+			10,
+		);
+		expect(idempotentPid).toBe(initialPid);
+		expect(runUserSystemctl("is-enabled", unitName).stdout.trim()).toBe("enabled");
+
+		const tamper = spawnSync(
+			"runuser",
+			["-u", "clawdi", "--", "sh", "-c", 'printf "\\n# tenant drift\\n" >> "$1"', "sh", unitPath],
+			{ encoding: "utf8" },
+		);
+		expect(tamper.status, tamper.stderr).toBe(0);
+		expect(runUserSystemctl("daemon-reload").status).toBe(0);
+		expect(runUserSystemctl("restart", unitName).status).toBe(0);
+		const tamperedState = runUserSystemctl("show", unitName, "--property=MainPID");
+		const tamperedPid = Number.parseInt(
+			tamperedState.stdout.match(/^MainPID=(\d+)$/m)?.[1] ?? "0",
+			10,
+		);
+		expect(tamperedPid).toBeGreaterThan(1);
+		expect(tamperedPid).not.toBe(initialPid);
+
+		const repaired = await converge();
+		expect(repaired.installErrors).toEqual([]);
+		expect(readFileSync(unitPath, "utf8")).toBe(declaredUnit);
+		expect(readFileSync(installLog, "utf8").trim().split("\n")).toEqual(["install", "install"]);
+		const repairedState = runUserSystemctl(
+			"show",
+			unitName,
+			"--property=ActiveState",
+			"--property=MainPID",
+		);
 		expect(repairedState.stdout).toContain("ActiveState=active");
 		const repairedPid = Number.parseInt(
 			repairedState.stdout.match(/^MainPID=(\d+)$/m)?.[1] ?? "0",
 			10,
 		);
-		expect(repairedPid).toBe(initialPid);
-		expect(runUserSystemctl("is-enabled", unitName).stdout.trim()).toBe("enabled");
-		expect(runUserSystemctl("enable", unitName).status).toBe(0);
+		expect(repairedPid).toBeGreaterThan(1);
+		expect(repairedPid).not.toBe(tamperedPid);
 	} finally {
 		runUserSystemctl("disable", "--now", unitName);
 		rmSync(unitPath, { force: true });

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -3424,10 +3424,6 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		expect(statSync(openClawTmp).mode & 0o777).toBe(0o700);
 
 		const context = createOpenClawHostedContext(loaded.manifest, home);
-		expect(context.ownership.map(({ path, mode, recursive }) => [path, mode, recursive])).toEqual([
-			[join(home, ".openclaw"), 0o700, false],
-			[join(home, ".openclaw", "tmp"), 0o700, false],
-		]);
 		loaded.manifest.runtimes.openclaw.enabled = false;
 		expect(context.managedApiKeyProjection).toBe(true);
 		expect(createOpenClawHostedContext(loaded.manifest, home).managedApiKeyProjection).toBe(false);
@@ -7906,7 +7902,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 			},
 		});
 	});
-	it("hands off a CLI update and restarts only changed daemon bytes", async () => {
+	it("hands off a CLI update and restarts changed daemon and tenant unit bytes", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -8116,7 +8112,7 @@ chmod +x "$prefix/bin/clawdi"
 			expect(completedEvent.systemdApply).toEqual({
 				applied: true,
 				systemUnitsChanged: ["clawdi-daemon.service"],
-				userUnitsChanged: [],
+				userUnitsChanged: ["openclaw-gateway.service"],
 			});
 			const completedAppliedState = readRuntimeAppliedState(paths);
 			expect(completedAppliedState).toMatchObject({
@@ -8139,15 +8135,13 @@ chmod +x "$prefix/bin/clawdi"
 				"daemon-reload",
 				"--user daemon-reload",
 				"restart clawdi-daemon.service",
+				"--user restart openclaw-gateway.service",
 			]);
 			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
 				"restart clawdi-runtime-watch.service",
 			);
 			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
 				"restart clawdi-runtime-sidecar.service",
-			);
-			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
-				"--user restart openclaw-gateway.service",
 			);
 			expect(existsSync(paths.cliUpgradeState)).toBe(false);
 			expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"))).toMatchObject({
@@ -11341,7 +11335,6 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			expect(statSync(paths.egressTransparentEnv).uid).toBe(0);
 			expect(statSync(paths.egressTransparentEnv).gid).toBe(10002);
 		}
-		expect(statSync(join(run, "egress-scratch")).mode & 0o777).toBe(0o700);
 		expect(openclawUnit).not.toContain("\nExecStart=");
 		expect(openclawUnit).not.toContain("\nWorkingDirectory=");
 		expect(openclawEnv).not.toContain("CLAWDI_EGRESS_PROFILE_BUNDLE");


### PR DESCRIPTION
## Summary

- make the runtime user the sole owner and writer of the complete tenant HOME tree while keeping platform authority under `/etc/clawdi`, `/var/lib/clawdi`, and `/run/clawdi`
- remove the platform-enclave ownership DSL, manager-access mode repair, installer chown ping-pong, and hand-materialized `default.target.wants` links
- use `systemctl --user enable/disable` for `[Install] WantedBy=` and preserve foreign systemd drop-ins while managing only `10-clawdi-hosted.conf`
- collapse runtime-user filesystem access from 45 production call sites on `main` to 9 explicit boundaries

## Size

- Changed: 27 files
- Added: no new persistent item or product surface; only the sunset ownership migration and focused behavior assertions
- Removed: 1,184 lines
- Added lines: 630
- Net: **-554 lines**

## Permission and persistence migration

| Item | 0.13.92 / 0.14.14 state | First convergence with this change | Main-format fixture proof |
| --- | --- | --- | --- |
| Entire tenant HOME | Tenant content was runtime-owned except for root-owned platform enclaves, so a released host could contain a mixed-owner tree. | Root runs one non-dereferencing `chown -hR -P <uid>:<gid> -- $HOME` before tenant writes. The SUNSET comment permits removal after the fleet has converged once. Modes and ACLs are not rewritten. | `runtime-user-command.test.ts`: `migrates a legacy root-owned tenant home without following symlinks`; privileged `migrates a legacy root-owned Hermes user-service tree without losing the unit`. |
| `~/.config/systemd/user` with legacy `0700` directories / `0600` files | The enclave root, units, and Clawdi drop-ins could be root-owned and unreadable to the user manager. | The same first-pass recursive chown transfers the directory, files, and symlinks to the runtime UID/GID without following symlink targets or widening modes; all subsequent writes run as the tenant. A second convergence is idempotent. | Privileged `migrates a legacy root-owned Hermes user-service tree without losing the unit` creates the released 0700/0600 shape, proves first-pass ownership, preserves the unit, and proves the second pass does not reinstall or restart it. |
| User base units and `10-clawdi-hosted.conf` | Base units and the hosted drop-in were treated as root-owned generated authority, with ownership restored after official installers. | Legacy bytes are adopted into the tenant tree, then exact desired bytes are rendered as the tenant. Byte drift is overwritten and an active changed unit is restarted. | The same privileged migration test tampers with the unit as `clawdi`, then proves the next convergence restores exact declared bytes and changes the PID; virgin Hermes/OpenClaw tests prove cold install. |
| `default.target.wants` | Clawdi manually materialized enablement symlinks because the runtime user could not write the root-owned parent. | Existing links are transferred with the legacy tree. Normal activation now calls `systemctl --user enable`; removal calls `systemctl --user disable`, so systemd interprets `[Install] WantedBy=default.target`. | The privileged migration and virgin first-boot tests assert `systemctl --user is-enabled` and service activation; stale-service coverage proves disable/removal. |
| `~/.openclaw/gateway.systemd.env` | This private installer file was a root-owned HOME enclave. | It is transferred with HOME and future official installer writes occur as the runtime user; its private mode remains unchanged. | Privileged `runs Files as the tenant while preserving platform isolation` starts from a root-owned legacy file and proves runtime ownership plus retained `0600`; the main-format UID 10001 reconciliation fixture covers the same path. |
| Foreign user-unit drop-ins | Any foreign `*.conf` caused convergence to refuse the official service plan even though systemd supports merged drop-ins. | The legacy chown places them under the tenant owner; convergence neither rejects, overwrites, nor deletes them and continues to manage only `10-clawdi-hosted.conf`. | `manifest-services.test.ts`: `preserves foreign Hermes gateway drop-ins while reconciling its own` and the OpenClaw counterpart. |
| Platform receipts, ledgers, secrets, and run state | Root-authored authority lived under `/etc/clawdi`, `/var/lib/clawdi`, and `/run/clawdi`. | No ownership migration. Platform writes stay root-side; tenant target mutations are separated from receipt/ledger commits. | `manifest-reconciliation.test.ts`: `keeps the hosted skill ledger root owned while mutating the runtime-user skill tree`; privileged Files isolation proves root platform state remains unreadable to the tenant. |
| `/run/clawdi/egress-scratch` | An empty ephemeral directory was created, but production had no reader or persistent contract for it. | Nothing to migrate; the unused path and creation are removed. Other egress state remains under `/run/clawdi/egress`. | CLI full-suite `runs the egress-only sidecar with a lifecycle nft redirect` and transparent-egress coverage pass without the scratch directory. |

The former privileged e2e `repairs a live Hermes user-service ownership enclave without losing the unit` is intentionally rewritten as `migrates a legacy root-owned Hermes user-service tree without losing the unit`: the old test asserted the retired enclave model, while the new test exercises the released legacy shape and its one-time migration.

The two recovery tests below are byte-for-byte unchanged from `main` and pass:

- `replays last-good declarative state after a failed candidate and advances afterward`
- `restarts only rendered-but-unactivated services after a write-side crash`

## Security boundary

Root ownership of user units did not prevent tenant control. The tenant already owns its user manager, can stop or start its services, and can edit other files in its HOME. Moving these files to the tenant therefore does not add a capability the tenant lacked.

The managed guarantee is declarative convergence, not inode ownership: every convergence renders the complete managed unit/drop-in state, compares exact bytes, overwrites drift, performs `daemon-reload`, and restarts an active user unit whose rendered bytes changed. The activated revision hash continues to distinguish rendered-but-unactivated state after crashes. The new privileged tamper test proves this path end to end. Foreign drop-ins remain tenant-controlled by design, just like the user manager itself.

The one-time migration validates a non-root UID/GID, refuses a symlink HOME root, uses `chown -hR -P` so traversal never follows symlinks, preserves existing modes, and fails convergence before tenant writes if migration fails.

## Verification

All verification ran in disposable containers with isolated workspaces/HOME state:

- `bun run --cwd packages/cli test` (includes CLI typecheck): **1646 pass, 4 conditional skips, 0 fail**
- `scripts/test-runtime-official-installer-systemd.sh`: **9 pass, 0 fail, 399 assertions**
- `bunx biome check docs/managed-runtime.md packages/cli/src packages/cli/tests`: **330 files checked, 0 errors**
- `git diff --check`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
