### PR TITLE
release(cli): 0.14.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.15
+
+Package: `clawdi@0.14.15`
+
+### Changed
+
+- Major internal consolidation: ~17,400 lines removed with behavior preserved
+  (single-authority state records, single wire manifest schema, single-file CLI
+  upgrade state).
+- Runtime apply flattened to a declarative line; failed candidate generations
+  recover by replaying the last-good manifest (whole-tree snapshots, systemd
+  transaction journal, and /proc revision proofs removed).
+- Tenant home is now fully tenant-owned; legacy root-owned systemd trees
+  migrate once on first converge.
+- Operational note: the first converge after upgrading reinstalls each managed
+  skill once and restarts managed agent units once (state-record format
+  promotion). Roll out off-peak.
+
 ## Clawdi CLI v0.14.14
 
 Package: `clawdi@0.14.14`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.14",
+      "version": "0.14.15",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.14",
+	"version": "0.14.15",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary

- Bump the `clawdi` CLI package and lockfile entry from 0.14.14 to 0.14.15.
- Document the internal state/runtime consolidation, declarative last-good recovery, and tenant-owned home migration.
- Record the one-time post-upgrade managed Skill reinstall and managed agent unit restart; schedule the first converge off-peak.

## Verification

- `bun run --cwd packages/cli typecheck`
- `bun run --cwd packages/cli test` (1646 passed, 4 skipped)

## Release Impact

- Head SHA: `85063542450d9626f464ece90252755dd459ec25`
- Merging the CLI package version change triggers `Publish Agent v2 CLI` for `clawdi@0.14.15`.
- npm publish only; no rollout, deployment, app setting, or `agent_v2_cli_package_spec` change is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)