### PR TITLE
test(cli): fix release gate fixture ownership

### DIFF
--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -2424,6 +2424,10 @@ function installBehavioralGuardHermesRuntime(): void {
 		{ encoding: "utf8" },
 	);
 	if (install.status !== 0) throw new Error(install.stderr);
+	const dashboardRoot = "/home/clawdi/.hermes/hermes-agent/hermes_cli/web_dist";
+	mkdirSync(dashboardRoot, { recursive: true });
+	writeFileSync(join(dashboardRoot, "index.html"), "<html>Hermes dashboard</html>\n");
+	chownTreeWithoutFollowingLinks(dashboardRoot, 10_001, 10_001);
 }
 
 function behavioralGuardSkill(

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -203,6 +203,47 @@ async function waitForTcpPort(port: number): Promise<void> {
 	throw new Error(`port ${port} did not begin listening`);
 }
 
+function seedLocalCli(paths: ReturnType<typeof getRuntimePaths>): string {
+	const version = getCliVersion();
+	const prefix = join(paths.cliNpmPrefix, "packages", version);
+	const install = spawnSync(
+		"npm",
+		[
+			"install",
+			"--global",
+			`--prefix=${prefix}`,
+			"--ignore-scripts",
+			"--no-audit",
+			"--no-fund",
+			"/usr/local/share/clawdi/bootstrap/clawdi-local.tgz",
+		],
+		{ encoding: "utf8" },
+	);
+	expect(install.status, install.stderr).toBe(0);
+	const activeTarget = join(prefix, "bin", "clawdi");
+	mkdirSync(dirname(paths.cliManagedBin), { recursive: true, mode: 0o755 });
+	symlinkSync(activeTarget, paths.cliManagedBin);
+	writeFileSync(
+		paths.cliBootstrapStatus,
+		`${JSON.stringify({
+			schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
+			generatedAt: new Date().toISOString(),
+			status: "installed",
+			source: "npm",
+			packageSpec: `clawdi@${version}`,
+			registry: "https://registry.npmjs.org",
+			npmPrefix: prefix,
+			npmCache: paths.cliNpmCache,
+			activePath: paths.cliManagedBin,
+			activeTarget,
+			version,
+			error: null,
+		})}\n`,
+		{ mode: 0o600 },
+	);
+	return prefix;
+}
+
 test.each(["hermes", "openclaw"] as const)(
 	"runs the complete virgin %s first boot from a cold user manager",
 	async (runtime) => {
@@ -377,44 +418,7 @@ exec /usr/bin/systemctl "$@"
 			writeFileSync(systemctlLog, "", { mode: 0o666 });
 			chmodSync(systemctlLog, 0o666);
 
-			const cliVersion = getCliVersion();
-			const cliPrefix = join(paths.cliNpmPrefix, "packages", cliVersion);
-			const cliInstall = spawnSync(
-				"npm",
-				[
-					"install",
-					"--global",
-					"--prefix",
-					cliPrefix,
-					"--ignore-scripts",
-					"--no-audit",
-					"--no-fund",
-					"/usr/local/share/clawdi/bootstrap/clawdi-local.tgz",
-				],
-				{ encoding: "utf8" },
-			);
-			expect(cliInstall.status, cliInstall.stderr).toBe(0);
-			const cliTarget = join(cliPrefix, "bin", "clawdi");
-			mkdirSync(dirname(paths.cliManagedBin), { recursive: true, mode: 0o755 });
-			symlinkSync(cliTarget, paths.cliManagedBin);
-			writeFileSync(
-				paths.cliBootstrapStatus,
-				`${JSON.stringify({
-					schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
-					generatedAt: new Date().toISOString(),
-					status: "installed",
-					source: "npm",
-					packageSpec: `clawdi@${cliVersion}`,
-					registry: "https://registry.npmjs.org",
-					npmPrefix: cliPrefix,
-					npmCache: paths.cliNpmCache,
-					activePath: paths.cliManagedBin,
-					activeTarget: cliTarget,
-					version: cliVersion,
-					error: null,
-				})}\n`,
-				{ mode: 0o600 },
-			);
+			const cliPrefix = seedLocalCli(paths);
 
 			const gatewayToken = `virgin-${runtime}-gateway-token`;
 			const sourceRevision = createHash("sha256").update(`virgin-${runtime}-bundle`).digest("hex");
@@ -460,7 +464,7 @@ exec /usr/bin/systemctl "$@"
 				},
 				clawdiCli: {
 					source: "npm:clawdi",
-					packageSpec: `clawdi@${cliVersion}`,
+					packageSpec: `clawdi@${getCliVersion()}`,
 					registry: "https://registry.npmjs.org",
 				},
 				runtimes: {
@@ -2688,6 +2692,7 @@ exec /usr/bin/systemctl "$@"
 	const restoreEnvironment = configureBehavioralGuardEnvironment(root, systemctlWrapper);
 	const paths = getRuntimePaths({ mode: "hosted" });
 	ensureRuntimeStateDirs(paths);
+	seedLocalCli(paths);
 	ensureBehavioralGuardUserManager();
 	installBehavioralGuardHermesRuntime();
 	const skillRoot = join("/home/clawdi", ".hermes", "skills", "lean-replay-guard");
@@ -2809,6 +2814,7 @@ exec /usr/bin/systemctl "$@"
 	const restoreEnvironment = configureBehavioralGuardEnvironment(root, systemctlWrapper);
 	const paths = getRuntimePaths({ mode: "hosted" });
 	ensureRuntimeStateDirs(paths);
+	seedLocalCli(paths);
 	ensureBehavioralGuardUserManager();
 	installBehavioralGuardHermesRuntime();
 	const generationOne = behavioralGuardLoad({

--- a/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/run.sh
+++ b/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/run.sh
@@ -77,8 +77,8 @@ chown -R egress:egress "${EGRESS_HOME}"
 /opt/e2e-harness/.venv/bin/python "${FIXTURE_ROOT}/server.py" init "${E2E_SCENARIO}"
 
 export E2E_HOME E2E_OUTPUT E2E_SCENARIO
-bun test "${FIXTURE_ROOT}/project.e2e.ts"
 chown -R clawdi:clawdi "${E2E_OUTPUT}"
+runuser -u clawdi -- env HOME="${E2E_HOME}" bun test "${FIXTURE_ROOT}/project.e2e.ts"
 
 export CLAWDI_EGRESS_PROFILE_BUNDLE="${E2E_OUTPUT}/egress-profiles.json"
 export CLAWDI_EGRESS_SECRET_FILE="${E2E_OUTPUT}/egress-secrets.json"


### PR DESCRIPTION
## Summary

- Seed the locally built CLI tarball and bootstrap status into every privileged systemd E2E state root.
- Seed the Hermes dashboard artifact only for behavioral replay/crash guards, keeping virgin boot coverage intact.
- Run the managed WhatsApp projection fixture as the tenant that owns the stock runtime HOME.
- Keep product runtime behavior, release versions, environment flags, hooks, and the existing behavioral assertions unchanged.

## Root-cause decisions

### Privileged systemd E2E

The virgin Hermes and OpenClaw cases already seeded the local tarball, but the two declarative replay/crash guards create independent `CLAWDI_SERVICE_STATE_DIR` roots without a CLI bootstrap state. On a release bump those guards therefore attempted `npm install clawdi@<new-version>` and failed with `ETARGET`. The local tarball setup is now one fixture helper used by the virgin cases and both isolated behavioral guards, so every path executes the branch build.

The first CI run then exposed an independent test-budget issue: the replay guard spent its 300-second test timeout running the real Hermes dashboard `npm ci`/build before it could exercise replay behavior. Those two guards now seed a tenant-owned `web_dist/index.html` prerequisite as part of their stock-runtime fixture. The virgin Hermes test does not receive that seed and still covers the real dashboard prerequisite path.

### WhatsApp native E2E

This is a fixture ownership bug, not a missing P0 product migration.

Evidence from `clawdi-cli-v0.13.92`:

- `manifest.ts` materialized hosted channel credentials inside `withRuntimeUserFileAccess(...)`.
- `runtime-user-command.ts` implemented that boundary by switching the effective filesystem UID/GID to the configured runtime user.

The DinD fixture instead called `materializeHostedChannelCredentials(...)` directly from a root-owned `bun test` process. That created root-owned tenant HOME paths after the image had already copied the stock HOME as `clawdi:clawdi`. The fixture also bypasses normal manifest convergence, so the #1197 one-time recursive ownership migration was never the relevant production path. Running fixture projection as `clawdi` matches released production behavior. The same correction restores both Hermes credential access and the OpenClaw plugin connection.

## Verification

All verification ran in disposable containers with task-scoped images and cleanup.

- `scripts/test-runtime-official-installer-systemd.sh` with the CLI version temporarily changed to unpublished `98.76.54` (`npm view` returned 404): **9 passed, 0 failed, 401 assertions** in 862.14 seconds. The temporary version change was reverted before commit.
- `scripts/test-managed-whatsapp-native-e2e.sh`: OpenClaw and Hermes both passed the native plugin connection and message flow.
- CLI typecheck: passed in the clean runner.
- CLI full suite: **1646 passed, 4 skipped, 0 failed, 7890 assertions**.
- Biome: **1067 files checked, no fixes required**.

This unblocks rerunning release PR #1198 without requiring `clawdi@0.14.15` to exist on npm first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
