### PR TITLE
fix(runtime): stage bundled Skills before tenant access

### DIFF
--- a/packages/cli/src/runtime/managed-skill-delivery.test.ts
+++ b/packages/cli/src/runtime/managed-skill-delivery.test.ts
@@ -1,8 +1,22 @@
 import { expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { collectManagedSkillTree, withManagedTargetRollback } from "./managed-skill-delivery";
+import { prepareHostedBundledSkill } from "./hosted-sourced-skill-archive";
+import {
+	collectManagedSkillTree,
+	ManagedSkillResourceError,
+	withManagedTargetRollback,
+	withPreparedHostedSkill,
+} from "./managed-skill-delivery";
 
 test("distinguishes an absent Skill tree from an unsafe tree", () => {
 	const root = mkdtempSync(join(tmpdir(), "managed-skill-collection-"));
@@ -14,6 +28,33 @@ test("distinguishes an absent Skill tree from an unsafe tree", () => {
 		expect(collectManagedSkillTree(absent)).toEqual({ status: "absent" });
 		expect(collectManagedSkillTree(unsafe)).toEqual({ status: "unsafe" });
 	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("preserves the cause, errno, and path when bundled Skill staging fails", () => {
+	const root = mkdtempSync(join(tmpdir(), "managed-skill-staging-error-"));
+	const sourceDir = join(root, "clawdi");
+	const blocked = join(sourceDir, "blocked");
+	try {
+		mkdirSync(blocked, { recursive: true });
+		writeFileSync(join(sourceDir, "SKILL.md"), "# Clawdi\n");
+		writeFileSync(join(blocked, "resource.txt"), "private\n");
+		chmodSync(blocked, 0o000);
+		const prepared = { ...prepareHostedBundledSkill("clawdi", 1), sourceDir };
+		let failure: unknown;
+		try {
+			withPreparedHostedSkill(prepared, () => undefined);
+		} catch (error) {
+			failure = error;
+		}
+		expect(failure).toBeInstanceOf(ManagedSkillResourceError);
+		if (!(failure instanceof ManagedSkillResourceError)) return;
+		expect(failure.cause).toBeInstanceOf(Error);
+		expect(failure.message).toContain("EACCES");
+		expect(failure.message).toContain(blocked);
+	} finally {
+		chmodSync(blocked, 0o755);
 		rmSync(root, { recursive: true, force: true });
 	}
 });

--- a/packages/cli/src/runtime/managed-skill-delivery.ts
+++ b/packages/cli/src/runtime/managed-skill-delivery.ts
@@ -15,6 +15,7 @@ import { collectRegularFileTree } from "../lib/file-tree";
 import { extractTarGzSync } from "../lib/tar";
 import { MANAGED_SKILL_TREE_LIMITS, managedSkillDirectoryDigest } from "./hosted-bundled-skill";
 import type { PreparedHostedSkill } from "./hosted-sourced-skill-archive";
+import { withRuntimeUserFileAccess } from "./runtime-user-command";
 
 export class ManagedSkillResourceError extends Error {}
 
@@ -97,7 +98,11 @@ export function withPreparedHostedSkill<T>(
 				cpSync(skill.sourceDir, sourceDir, { recursive: true });
 			} catch (error) {
 				if (error instanceof ManagedSkillResourceError) throw error;
-				throw new ManagedSkillResourceError("prepared bundled Skill could not be staged");
+				const detail = error instanceof Error ? error.message : String(error);
+				throw new ManagedSkillResourceError(
+					`prepared bundled Skill could not be staged: ${detail}`,
+					{ cause: error },
+				);
 			}
 		} else {
 			if (createHash("sha256").update(skill.tarBytes).digest("hex") !== skill.identity.digest) {
@@ -105,8 +110,10 @@ export function withPreparedHostedSkill<T>(
 			}
 			try {
 				extractTarGzSync(root, skill.tarBytes);
-			} catch {
-				throw new ManagedSkillResourceError("prepared Skill archive could not be staged");
+			} catch (error) {
+				throw new ManagedSkillResourceError("prepared Skill archive could not be staged", {
+					cause: error,
+				});
 			}
 		}
 		const sourceTree = collectManagedSkillTree(sourceDir);
@@ -133,7 +140,7 @@ export function installedTreeMatches(
 	options: { exclude?: ReadonlySet<string> } = {},
 ): boolean {
 	return withPreparedHostedSkill(skill, (sourceDir) =>
-		managedSkillTargetMatchesSource(sourceDir, targetDir, options),
+		withRuntimeUserFileAccess(() => managedSkillTargetMatchesSource(sourceDir, targetDir, options)),
 	);
 }
 

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -34,10 +34,7 @@ import type {
 	PreparedHostedAgentPlugins,
 } from "./hosted-agent-plugin-package";
 import type { HostedAgentPluginCommandRunner } from "./hosted-agent-plugin-runtime";
-import {
-	assertHostedBundledSkillCatalogDigest,
-	resolveHostedBundledSkill,
-} from "./hosted-bundled-skill";
+import { resolveHostedBundledSkill } from "./hosted-bundled-skill";
 import { hostedAiProviderCatalog } from "./hosted-provider-resolution";
 import type { PreparedHostedSkill } from "./hosted-sourced-skill-archive";
 import {
@@ -3380,13 +3377,19 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(existsSync(platformReceiptDirectory)).toBe(false);
 	});
 
-	test("keeps the hosted skill ledger root owned while mutating the runtime-user skill tree", () => {
+	test("upgrades a reserved bundled Skill from a private platform source idempotently", () => {
 		if (process.geteuid?.() !== 0) return;
 		const paths = tempRuntimePaths();
 		const fixtureRoot = dirname(paths.serviceStateRoot);
-		const hermesCommand = writeFakeHermesCli(paths);
-		const skillDir = join(paths.userHome, ".hermes", "skills", "clawdi");
+		const command = join(paths.userHome, ".local", "bin", "openclaw");
+		writeFakeGatewayCli({
+			path: command,
+			runtime: "openclaw",
+			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
+		});
+		const skillDir = join(paths.userHome, ".openclaw", "workspace", "skills", "clawdi");
 		const ledger = join(paths.managedResourceRoot, "managed-skills.json");
+		const previousDigest = "272ec28025eb3c5227e4f7d7215327d5c070e7c4c87933e4d6df2f5bf33f9b9c";
 		const cliRoot = resolve(import.meta.dir, "../..");
 		const skillSource = join(cliRoot, "skills", "hosted-versions", "1", "clawdi");
 		const protectedSourceAncestors = [
@@ -3399,38 +3402,50 @@ describe("runtime manifest reconciliation invariants", () => {
 		const originalSourceModes = new Map(
 			protectedSourceAncestors.map((path) => [path, statSync(path).mode & 0o777]),
 		);
-		const runtimeUid = Number.parseInt(
-			execFileSync("id", ["-u", "nobody"], { encoding: "utf8" }).trim(),
-			10,
-		);
-		const runtimeGid = Number.parseInt(
-			execFileSync("id", ["-g", "nobody"], { encoding: "utf8" }).trim(),
-			10,
-		);
-		process.env.CLAWDI_RUNTIME_USER = "nobody";
+		const runtimeUid = 10_001;
+		const runtimeGid = 10_001;
+		process.env.CLAWDI_RUNTIME_USER = "clawdi";
+		process.env.CLAWDI_RUNTIME_UID = String(runtimeUid);
+		process.env.CLAWDI_RUNTIME_GID = String(runtimeGid);
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 
 		chmodSync(fixtureRoot, 0o755);
 		mkdirSync(paths.clawdiHome, { recursive: true });
 		chownSync(paths.clawdiHome, runtimeUid, runtimeGid);
+		mkdirSync(skillDir, { recursive: true });
+		writeFileSync(join(skillDir, "SKILL.md"), "# Clawdi 0.14.13\n");
+		for (const path of [
+			paths.userHome,
+			join(paths.userHome, ".local"),
+			dirname(command),
+			command,
+			join(paths.userHome, ".openclaw"),
+			join(paths.userHome, ".openclaw", "workspace"),
+			dirname(skillDir),
+			skillDir,
+			join(skillDir, "SKILL.md"),
+		]) {
+			chownSync(path, runtimeUid, runtimeGid);
+		}
+		ensureRuntimeStateDirs(paths);
+		reserveManagedSkill({
+			targetDir: skillDir,
+			id: "clawdi",
+			manager: "hosted-manifest",
+			version: 1,
+			digest: previousDigest,
+		});
 		const manifest = baseManifest(
 			paths,
 			{
-				hermes: {
+				openclaw: {
 					enabled: true,
-					run: runSettings(hermesCommand, ["gateway"]),
+					run: runSettings(command, ["gateway"]),
 					services: {},
 				},
 			},
 			{ projection: { skills: { entries: { clawdi: { enabled: true, version: 1 } } } } },
 		);
-		const driftedSource = join(fixtureRoot, "drifted-skill-source");
-		cpSync(skillSource, driftedSource, { recursive: true });
-		writeFileSync(join(driftedSource, "SKILL.md"), "catalog drift\n");
-		expect(() =>
-			assertHostedBundledSkillCatalogDigest(resolveHostedBundledSkill("clawdi", 1), driftedSource),
-		).toThrow("catalog digest mismatch");
-
 		for (const path of protectedSourceAncestors) chmodSync(path, 0o700);
 		const accountPrivilegeTool = ["run", "user"].join("");
 		try {
@@ -3449,8 +3464,24 @@ describe("runtime manifest reconciliation invariants", () => {
 					join(skillSource, "SKILL.md"),
 				]),
 			).toThrow();
-			const result = convergeRuntimeManifest(manifestLoad(manifest, "inline-hermes-skill"), paths);
+			const hostedRuntimeContract = {
+				expectedIdentity: {
+					home: paths.userHome,
+					user: "clawdi",
+					uid: runtimeUid,
+					gid: runtimeGid,
+				},
+				resolveUserIdentity: () => ({ uid: runtimeUid, gid: runtimeGid }),
+			};
+			const result = convergeRuntimeManifest(
+				manifestLoad(manifest, "bundled-skill-upgrade"),
+				paths,
+				{
+					hostedRuntimeContract,
+				},
+			);
 			expect(result.installErrors).toEqual([]);
+			expect(result.resourceProjectionErrors).toEqual([]);
 			expect(readFileSync(join(skillDir, "SKILL.md"), "utf8")).toContain("# Clawdi");
 			expect(statSync(skillDir).uid).toBe(runtimeUid);
 			expect(statSync(join(skillDir, "SKILL.md")).uid).toBe(runtimeUid);
@@ -3458,9 +3489,22 @@ describe("runtime manifest reconciliation invariants", () => {
 			expect(statSync(paths.managedResourceRoot).mode & 0o777).toBe(0o755);
 			expect(statSync(ledger).uid).toBe(0);
 			expect(statSync(ledger).mode & 0o022).toBe(0);
+			const upgradedLedger = JSON.parse(readFileSync(ledger, "utf8"));
+			expect(upgradedLedger.reservations[skillDir].digest).toBe(
+				resolveHostedBundledSkill("clawdi", 1).digest,
+			);
+			expect(upgradedLedger.pendingReservations).toEqual({});
 			for (const path of protectedSourceAncestors) {
 				expect(statSync(path).mode & 0o777).toBe(0o700);
 			}
+			const upgradedInode = statSync(skillDir).ino;
+			const unchanged = convergeRuntimeManifest(
+				manifestLoad({ ...manifest, generation: 2 }, "bundled-skill-unchanged"),
+				paths,
+				{ hostedRuntimeContract },
+			);
+			expect([...unchanged.installErrors, ...unchanged.resourceProjectionErrors]).toEqual([]);
+			expect(statSync(skillDir).ino).toBe(upgradedInode);
 
 			expect(() =>
 				execFileSync(accountPrivilegeTool, [
@@ -3476,9 +3520,10 @@ describe("runtime manifest reconciliation invariants", () => {
 			const removal = convergeRuntimeManifest(
 				manifestLoad(
 					{ ...manifest, projection: { skills: { entries: {} } } },
-					"inline-hermes-skill-removal",
+					"bundled-skill-removal",
 				),
 				paths,
+				{ hostedRuntimeContract },
 			);
 
 			expect(removal.installErrors).toEqual([]);

--- a/packages/cli/src/runtime/manifest-skills-apply.ts
+++ b/packages/cli/src/runtime/manifest-skills-apply.ts
@@ -197,11 +197,9 @@ function recoverPendingHostedSkillInstallations(
 			manager: "hosted-manifest",
 			verify: () =>
 				promotable !== null &&
-				withRuntimeUserSkillFiles(() =>
-					installedTreeMatches(promotable, reservation.targetDir, {
-						exclude: driver.exclude,
-					}),
-				),
+				installedTreeMatches(promotable, reservation.targetDir, {
+					exclude: driver.exclude,
+				}),
 			discard: () => discardPendingHostedSkill(reservation.targetDir),
 		});
 	}
@@ -282,11 +280,9 @@ function applyHostedSkills(
 		if (
 			reservation?.targetDir === targetDir &&
 			reservation.digest === reservationIdentity.digest &&
-			withRuntimeUserSkillFiles(() =>
-				installedTreeMatches(prepared, targetDir, {
-					exclude: driver.exclude,
-				}),
-			)
+			installedTreeMatches(prepared, targetDir, {
+				exclude: driver.exclude,
+			})
 		) {
 			if (
 				reservation.version !== reservationIdentity.version ||
@@ -313,11 +309,9 @@ function applyHostedSkills(
 					withPreparedHostedSkill(prepared, (sourceDir) => driver.activate(sourceDir, targetDir)),
 				{
 					verify: () =>
-						withRuntimeUserSkillFiles(() =>
-							installedTreeMatches(prepared, targetDir, {
-								exclude: driver.exclude,
-							}),
-						),
+						installedTreeMatches(prepared, targetDir, {
+							exclude: driver.exclude,
+						}),
 					discard: () => discardPendingHostedSkill(targetDir),
 				},
 			);


### PR DESCRIPTION
## Summary

- restore one filesystem identity boundary for hosted Skills: root reads private platform sources and creates tenant-readable staging, while the runtime user consumes staging and reads or writes tenant trees
- preserve the original staging failure as `ManagedSkillResourceError.cause` and retain its errno and path in the surfaced message
- cover the 0.14.15 canary state: a private `0700` resource root, an existing old tenant Skill tree, and a committed 0.14.13 ledger digest

## Root cause

`installedTreeMatches` was called inside `withRuntimeUserFileAccess`. That lowered EUID before `withPreparedHostedSkill` validated and copied the bundled source, so planning and verification tried to traverse the root-owned `0700` platform tree as UID 10001. The install path already staged the source as root before handing it to the runtime user, but the tree-comparison paths inverted that boundary.

The fix removes the three outer tenant-EUID wrappers and centralizes the handoff in `installedTreeMatches`: `withPreparedHostedSkill` reads and stages as root, applies `0755`/`0644`, then its callback compares the staging and target trees as the runtime user.

The post-rebase tree no longer contains symbols named `withStagedManagedSkill` or `prepareHostedBundledSkillArchive`; their current equivalents are `withPreparedHostedSkill` and `prepareHostedBundledSkill`/`prepareHostedSkillArchives`.

## EUID audit

| Call site | Platform/source read | Staging | Tenant target |
|---|---|---|---|
| `prepareHostedBundledSkill` | root: resolve and digest bundled platform tree | n/a | n/a |
| `prepareHostedSkillArchives` / `completePreparedHostedSkills` | root: call bundled preparation outside tenant access | n/a | n/a |
| `withPreparedHostedSkill` | root: validate digest and copy bundled source | root writes, then normalizes to `0755`/`0644` | callback handoff only |
| pending recovery `installedTreeMatches` | root via `withPreparedHostedSkill` | root prepares; runtime user reads staging in callback | runtime user |
| committed-tree `installedTreeMatches` | root via `withPreparedHostedSkill` | root prepares; runtime user reads staging in callback | runtime user |
| post-install `installedTreeMatches` | root via `withPreparedHostedSkill` | root prepares; runtime user reads staging in callback | runtime user |
| `driver.activate` (Hermes/OpenClaw) | no platform read; receives prepared staging | runtime user consumes existing readable staging | runtime user |
| hosted activation `managedSkillTargetMatchesSource` | runtime user reads staging under the driver boundary | already prepared by root | runtime user |
| local OpenClaw archive adapter | invoking-user temp archive, not a hosted platform source | invoking user | invoking user |
| local setup/built-in install | local CLI resource path, outside the hosted root/tenant boundary | invoking user | invoking user |

## Regression evidence

The test uses UID/GID 10001, makes every bundled source ancestor `0700`, installs an old tenant-owned `SKILL.md`, and reserves it with the real 0.14.13 digest `272ec28025eb3c5227e4f7d7215327d5c070e7c4c87933e4d6df2f5bf33f9b9c`.

With the final regression fixture and `origin/main` product files (`493913706`):

```text
0 pass
1 fail
runtime openclaw Skill projection failed: clawdi: prepared bundled Skill could not be staged
```

With this branch (`c931f72b8`):

```text
1 pass
0 fail
35 expect() calls
```

The green run verifies reinstall, ledger promotion to the current digest, pending reservation cleanup, and a second idempotent convergence without replacing the installed inode.

## Verification

All verification ran in disposable containers with a read-only repository mount and task-scoped image cleanup.

- CLI typecheck: passed
- CLI suite: 133/133 test files passed, each in an independent Bun process with the existing 30-second test timeout
- workspace typecheck: 4/4 packages passed
- Biome: 1,067 files passed; final changed-file recheck passed
- focused staging/cause tests: 5/5 passed
- privileged systemd E2E: 9/9 passed, 401 assertions
- root canary regression: main red, branch green as shown above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
