### PR TITLE
release(cli): 0.14.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.16
+
+Package: `clawdi@0.14.16`
+
+### Fixed
+
+- Bundled Skill staging on hosts with a root-only platform state root: tree verification now stages the platform source as root and only reads the tenant tree as the runtime user. Hosts stuck on "prepared bundled Skill could not be staged" self-heal on upgrade.
+- Managed Skill staging errors now carry the underlying cause, errno, and path.
+
 ## Clawdi CLI v0.14.15
 
 Package: `clawdi@0.14.15`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.15",
+      "version": "0.14.16",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.15",
+	"version": "0.14.16",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Patch release carrying #1200.

- Fix bundled Skill staging on hosts with a root-only platform state root: tree verification stages the platform source as root and only reads the tenant tree as the runtime user. Hosts stuck on `prepared bundled Skill could not be staged` (0.14.15 canary finding) self-heal on upgrade.
- Managed Skill staging errors now carry the underlying cause, errno, and path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)