### PR TITLE
fix(runtime): adopt unrecorded official service revisions

### DIFF
--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -306,23 +306,30 @@ function officialServiceHarness(
 		sourcePath: "inline-service-receipt",
 		offline: false,
 	};
+	const converge = (afterCommit?: () => void) =>
+		convergeRuntimeManifest(load, paths, {
+			commitAuthority: (convergence, authority) => {
+				commitRuntimeAppliedState({
+					load,
+					paths,
+					etag: '"official-service-test"',
+					sourceRevision: "a".repeat(64),
+					convergence,
+					applyIdentity: null,
+					officialServiceCommandRevisions: authority.officialServiceCommandRevisions,
+				});
+				afterCommit?.();
+			},
+			executeOfficialServiceInstallers: true,
+		});
+	converge();
+	const appliedStateWithoutRevision = JSON.parse(
+		readFileSync(paths.appliedState, "utf8"),
+	) as Record<string, unknown>;
+	delete appliedStateWithoutRevision.officialServiceCommandRevisions;
+	writeFileSync(paths.appliedState, `${JSON.stringify(appliedStateWithoutRevision)}\n`);
 	return {
-		converge: (afterCommit) =>
-			convergeRuntimeManifest(load, paths, {
-				commitAuthority: (convergence, authority) => {
-					commitRuntimeAppliedState({
-						load,
-						paths,
-						etag: '"official-service-test"',
-						sourceRevision: "a".repeat(64),
-						convergence,
-						applyIdentity: null,
-						officialServiceCommandRevisions: authority.officialServiceCommandRevisions,
-					});
-					afterCommit?.();
-				},
-				executeOfficialServiceInstallers: true,
-			}),
+		converge,
 		drift: () => writeFileSync(unitPath, `${readFileSync(unitPath, "utf8")}# upstream drift\n`),
 		revise: () =>
 			writeCli(false, runtime === "hermes" ? "Hermes Agent v0.18.1" : "OpenClaw 2026.7.30"),
@@ -1332,7 +1339,7 @@ esac
 	});
 
 	test.each(installGateHarnesses)(
-		"gates %s installs on a live no-op and fails closed on drift",
+		"adopts %s command revision when no revision is committed and repairs later drift",
 		(_name, createHarness) => {
 			const harness = createHarness();
 			expect(harness.converge().installErrors).toEqual([]);

--- a/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
+++ b/packages/cli/src/runtime/runtime-systemd-reconciliation.ts
@@ -447,7 +447,10 @@ export function planOfficialRuntimeServices(
 		const unitName = systemdUnitFileName(runtimeSystemdProgramName(program));
 		const serviceRevision = officialRuntimeServiceRevision(program, paths);
 		if (serviceRevision) serviceRevisions[unitName] = serviceRevision;
-		if (!serviceRevision || committedServiceRevisions[unitName] !== serviceRevision) {
+		if (
+			!serviceRevision ||
+			(committedServiceRevisions[unitName] ?? serviceRevision) !== serviceRevision
+		) {
 			pending.push({ unitName, program, serviceRevision });
 		}
 	}

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -2048,7 +2048,7 @@ http.createServer((request, response) => {
 	expect(tenantRead.stdout).toBe("tenant-existing\n");
 }, 120_000);
 
-test("migrates a legacy root-owned Hermes user-service tree without losing the unit", async () => {
+test("adopts a healthy legacy root-owned Hermes user-service tree and repairs later drift", async () => {
 	if (process.env[REAL_SYSTEMD_GATE] !== "1") return;
 
 	expect(process.geteuid?.()).toBe(0);
@@ -2239,11 +2239,11 @@ WantedBy=default.target
 			expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
 		}
 		const declaredUnit = readFileSync(unitPath, "utf8");
-		expect(declaredUnit).not.toContain("Legacy Hermes Gateway");
+		expect(declaredUnit).toContain("Legacy Hermes Gateway");
 
 		const idempotent = await converge();
 		expect(idempotent.installErrors).toEqual([]);
-		expect(readFileSync(installLog, "utf8").trim().split("\n")).toEqual(["install"]);
+		expect(readFileSync(installLog, "utf8")).toBe("");
 		for (const path of [paths.systemdUserRoot, unitPath, dropInRoot, enablementPath]) {
 			const node = lstatSync(path);
 			expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
@@ -2283,8 +2283,8 @@ WantedBy=default.target
 
 		const repaired = await converge();
 		expect(repaired.installErrors).toEqual([]);
-		expect(readFileSync(unitPath, "utf8")).toBe(declaredUnit);
-		expect(readFileSync(installLog, "utf8").trim().split("\n")).toEqual(["install", "install"]);
+		expect(readFileSync(unitPath, "utf8")).not.toContain("Legacy Hermes Gateway");
+		expect(readFileSync(installLog, "utf8").trim().split("\n")).toEqual(["install"]);
 		const repairedState = runUserSystemctl(
 			"show",
 			unitName,


### PR DESCRIPTION
## Summary

Absence of the bookkeeping record is not evidence of change; observe and adopt, then compare forever after.

`planOfficialRuntimeServices` now adopts a healthy observed official-service revision through the existing atomic applied-state authority commit. It still reruns the official installer for a recorded revision mismatch or an unhealthy/missing base unit. No migration flag, version condition, new state field, or additional persistence path is introduced.

## Decision table

| Condition | Reconciliation | Managed-unit restart/start count |
| --- | --- | --- |
| Command-revision record absent; base unit exists, is non-generated, and command is executable | Observe and adopt; installer performs zero destructive actions | Exactly 1 on the reported first pass, solely from the independent `activated` hash bootstrap |
| Record present and differs from observation | Run the official installer exactly once | Exactly 1 from the installer; its restart is required for the binary change, while unchanged unit bytes leave final activation as a no-op |
| Base unit absent, generated, or command unavailable | Run the cold installer | Exactly 1 initial service start/activation |

## Field evidence

On the observed 0.13.92 -> 0.14.16 B-line upgrade:

1. At T+0, the missing `officialServiceCommandRevisions` entry was treated as drift, so the OpenClaw installer ran and issued its own `systemctl --user restart`.
2. At T+4s, the independently empty `activated` authority triggered the expected activation-hash bootstrap restart.
3. Hermes showed only the second transition because its installer performs daemon-reload and enable without restarting the gateway.

The fix removes the false first transition; it does not suppress or time-couple the required activation restart.

## Verification

- `scripts/test.sh cli`: 1647 passed, 4 skipped, 0 failed; includes CLI typecheck
- `bun run check` in a read-only-source, tmpfs-work container: 1067 files checked
- `scripts/test-runtime-official-installer-systemd.sh`: 9 passed, 0 failed, 401 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)