### PR TITLE
release(cli): 0.14.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.17
+
+Package: `clawdi@0.14.17`
+
+### Fixed
+
+- First converge after an upgrade no longer reruns official runtime installers (and no longer restarts the OpenClaw gateway a second time): a missing service command-revision record is adopted from the live binary instead of being treated as a change.
+
 ## Clawdi CLI v0.14.16
 
 Package: `clawdi@0.14.16`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.16",
+      "version": "0.14.17",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.16",
+	"version": "0.14.17",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Patch release carrying #1203.

- First converge after an upgrade no longer reruns official runtime installers (and no longer restarts the OpenClaw gateway a second time): a missing service command-revision record is adopted from the live binary instead of being treated as a change. Absence of the bookkeeping record is not evidence of change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)