### PR TITLE
fix(web): compact plugin status actions

### DIFF
--- a/apps/web/e2e/hosted-agent-plugins.pw.ts
+++ b/apps/web/e2e/hosted-agent-plugins.pw.ts
@@ -185,6 +185,11 @@ test("Agent Plugin cards keep every status and action readable", async ({ page }
 		"The agent could not apply this plugin.",
 	);
 	await expect(page.getByRole("main").locator('[data-slot="status-badge"]')).toHaveCount(0);
+	expect(
+		await cardFor("Installed Plugin")
+			.getByRole("button", { name: "Installed", exact: true })
+			.evaluate((button) => button.getBoundingClientRect().width),
+	).toBeLessThan(120);
 
 	const updateFooter = cardFor("Update Available Plugin").locator('[data-slot="entity-meta"]');
 	await expect(updateFooter).toContainText("Mysten Labs");

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-actions.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-actions.tsx
@@ -4,6 +4,7 @@ import { AlertCircle, Check, Clock3, Plus, RefreshCw, Trash2 } from "lucide-reac
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
 import {
 	type AgentPluginActionState,
 	type AgentPluginInventoryItem,
@@ -12,6 +13,28 @@ import {
 } from "./agent-plugin-model";
 
 export type AgentPluginPendingAction = "install" | "remove" | "retry" | null;
+
+const PRIMARY_ACTION_VARIANT = {
+	install: "default",
+	update: "outline",
+	retry: "destructive",
+	installing: "ghost",
+	waiting: "ghost",
+	installed: "ghost",
+	failed: "ghost",
+	unavailable: "ghost",
+} as const satisfies Record<
+	AgentPluginPrimaryAction["kind"],
+	"default" | "outline" | "destructive" | "ghost"
+>;
+
+const PASSIVE_ACTION_TONE: Partial<Record<AgentPluginPrimaryAction["kind"], string>> = {
+	installing: "text-warning-muted-foreground",
+	waiting: "text-warning-muted-foreground",
+	installed: "text-success-muted-foreground",
+	failed: "text-destructive-muted-foreground",
+	unavailable: "text-muted-foreground",
+};
 
 export function AgentPluginActions({
 	item,
@@ -106,10 +129,12 @@ function AgentPluginPrimaryButton({
 	return (
 		<Button
 			size="sm"
-			variant={
-				action.kind === "retry" ? "destructive" : action.kind === "install" ? "default" : "outline"
-			}
-			className="w-40"
+			variant={PRIMARY_ACTION_VARIANT[action.kind]}
+			className={cn(
+				"w-auto",
+				!interactive && "disabled:opacity-100",
+				PASSIVE_ACTION_TONE[action.kind],
+			)}
 			disabled={mutationsBlocked || !interactive}
 			title={description ?? undefined}
 			aria-busy={action.kind === "installing"}


### PR DESCRIPTION
## Summary

- keep one primary button as the single expression of each plugin state
- remove the fixed 160px action width and use compact, semantic treatments
- render Installed as a green ghost action while preserving clear Install, Update, and Retry hierarchy
- cover compact passive actions in the existing responsive status matrix

## Verification

- Docker Web suite: typecheck, frontend tests, OSS production build
- Web typecheck
- Biome
- Hosted Agent Plugin Playwright: 3 passed at mobile and desktop widths
- light and dark visual review
- git diff --check