### PR TITLE
fix(web): add hosted plugins overview entry

### DIFF
--- a/apps/web/e2e/hosted-agent-plugins.pw.ts
+++ b/apps/web/e2e/hosted-agent-plugins.pw.ts
@@ -55,10 +55,8 @@ function desiredPlugin(name: string, overrides: Partial<DesiredPlugin> = {}): De
 	};
 }
 
-test("Agent Plugins stays closed without the per-user capability", async ({ page }) => {
-	await stubHostedApi(page, {
-		deployments: [deployment],
-	});
+test("Connected Agents reject Agent Plugins routes", async ({ page }) => {
+	await stubHostedApi(page);
 
 	await page.goto(`/agents/${AGENT_ID}`);
 	await expect(
@@ -129,7 +127,6 @@ test("Agent Plugin cards keep every status and action readable", async ({ page }
 		}),
 	];
 	await stubHostedApi(page, {
-		canUseAgentPluginsUI: true,
 		deployments: [deployment],
 	});
 	await page.route("http://127.0.0.1:8000/v1/plugin-catalog", async (route) => {
@@ -268,7 +265,7 @@ test("Agent Plugin cards keep every status and action readable", async ({ page }
 	await expect(page.getByRole("main").locator('[data-slot="status-badge"]')).toHaveCount(0);
 });
 
-test("Agent Plugins opens and installs with the per-user capability", async ({ page }) => {
+test("Hosted Agent Plugins opens and installs from the overview", async ({ page }) => {
 	let installed = false;
 	let acceptInstall = () => {};
 	const installAccepted = new Promise<void>((resolve) => {
@@ -288,7 +285,6 @@ test("Agent Plugins opens and installs with the per-user capability", async ({ p
 		updated_at: new Date().toISOString(),
 	};
 	await stubHostedApi(page, {
-		canUseAgentPluginsUI: true,
 		deployments: [deployment],
 	});
 	await page.route("http://127.0.0.1:8000/v1/plugin-catalog", async (route) => {

--- a/apps/web/e2e/hosted-agent-plugins.pw.ts
+++ b/apps/web/e2e/hosted-agent-plugins.pw.ts
@@ -61,11 +61,20 @@ test("Agent Plugins stays closed without the per-user capability", async ({ page
 	});
 
 	await page.goto(`/agents/${AGENT_ID}`);
-	await expect(page.getByRole("link", { name: "Plugins", exact: true })).toHaveCount(0);
+	await expect(
+		page.getByTestId("app-sidebar").getByRole("link", { name: "Plugins", exact: true }),
+	).toHaveCount(0);
+	await expect(page.locator('[data-overview-module="plugins"]')).toHaveCount(0);
 
 	await page.goto(`/agents/${AGENT_ID}/plugins`);
 	await expect(page).toHaveURL(new RegExp(`/agents/${AGENT_ID}$`));
-	await expect(page.getByRole("link", { name: "Plugins", exact: true })).toHaveCount(0);
+
+	await page.goto(`/agents/${AGENT_ID}/plugins/sui`);
+	await expect(page).toHaveURL(new RegExp(`/agents/${AGENT_ID}$`));
+	await expect(
+		page.getByTestId("app-sidebar").getByRole("link", { name: "Plugins", exact: true }),
+	).toHaveCount(0);
+	await expect(page.locator('[data-overview-module="plugins"]')).toHaveCount(0);
 });
 
 test("Agent Plugin cards keep every status and action readable", async ({ page }) => {
@@ -137,6 +146,11 @@ test("Agent Plugin cards keep every status and action readable", async ({ page }
 			body: JSON.stringify({ plugins: desired }),
 		});
 	});
+
+	await page.goto(`/agents/${AGENT_ID}`);
+	await expect(page.locator('[data-overview-module="plugins"]')).toContainText(
+		"3 installed · 2 pending · 1 failed",
+	);
 
 	await page.setViewportSize({ width: 320, height: 844 });
 	await page.goto(`/agents/${AGENT_ID}/plugins`);
@@ -324,8 +338,27 @@ test("Agent Plugins opens and installs with the per-user capability", async ({ p
 		},
 	);
 
+	await page.setViewportSize({ width: 1440, height: 1000 });
 	await page.goto(`/agents/${AGENT_ID}`);
-	await page.getByRole("link", { name: "Plugins", exact: true }).click();
+	await expect(
+		page.getByTestId("app-sidebar").getByRole("link", { name: "Plugins", exact: true }),
+	).toBeVisible();
+	const overviewPlugins = page.locator('[data-overview-module="plugins"]');
+	await expect(overviewPlugins).toContainText("No plugins installed");
+	const workspaceModules = page.locator(
+		'section[aria-labelledby="agent-overview-workspace"] [data-overview-module]',
+	);
+	await expect(workspaceModules).toHaveCount(4);
+	const workspaceRows = await workspaceModules.evaluateAll((modules) => {
+		const rowCounts = new Map<number, number>();
+		for (const module of modules) {
+			const top = Math.round(module.getBoundingClientRect().top);
+			rowCounts.set(top, (rowCounts.get(top) ?? 0) + 1);
+		}
+		return [...rowCounts.values()].sort();
+	});
+	expect(workspaceRows).toEqual([2, 2]);
+	await overviewPlugins.getByRole("link", { name: "Plugins", exact: true }).click();
 	await expect(page.getByRole("heading", { name: "Plugins" })).toBeVisible();
 	await expect(page.getByText("Sui Agent", { exact: true })).toBeVisible();
 

--- a/apps/web/e2e/hosted-stub-api.ts
+++ b/apps/web/e2e/hosted-stub-api.ts
@@ -279,12 +279,11 @@ export function readDeploymentFixture(value: unknown): unknown {
 // own modules live under /src/hosted/v2/... and a path glob would intercept
 // them and break module loading.
 
-function hostedUser(canUsePlanCBilling = true, canUseAgentPluginsUI = false) {
+function hostedUser(canUsePlanCBilling = true) {
 	return {
 		capabilities: {
 			can_use_v1: false,
 			can_use_v2: true,
-			can_use_agent_plugins_ui: canUseAgentPluginsUI,
 			can_use_plan_c_billing: canUsePlanCBilling,
 		},
 	};
@@ -774,7 +773,6 @@ export type HostedApiStubOptions = {
 	autoReloadRequests?: string[];
 	autoReloadResponses?: StubResponse[];
 	canUsePlanCBilling?: boolean;
-	canUseAgentPluginsUI?: boolean;
 	planBillingCapability?: { enabled: boolean };
 	productAccessRequests?: string[];
 	cancelRequests?: string[];
@@ -838,10 +836,7 @@ export async function stubHostedApi(page: Page, options: HostedApiStubOptions = 
 			options.productAccessRequests?.push(`DEPLOY ${p}`);
 			return fulfillJson(
 				r,
-				hostedUser(
-					options.planBillingCapability?.enabled ?? options.canUsePlanCBilling ?? true,
-					options.canUseAgentPluginsUI,
-				),
+				hostedUser(options.planBillingCapability?.enabled ?? options.canUsePlanCBilling ?? true),
 			);
 		}
 		if (p === "/v2/subscription/plans") return fulfillJson(r, plans);
@@ -1110,10 +1105,7 @@ export async function stubHostedApi(page: Page, options: HostedApiStubOptions = 
 			options.productAccessRequests?.push(`CLOUD ${p}`);
 			return fulfillJson(
 				r,
-				hostedUser(
-					options.planBillingCapability?.enabled ?? options.canUsePlanCBilling ?? true,
-					options.canUseAgentPluginsUI,
-				),
+				hostedUser(options.planBillingCapability?.enabled ?? options.canUsePlanCBilling ?? true),
 			);
 		}
 		if (p === "/v1/agents") {

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -505,11 +505,7 @@ function AgentFocusSections({
 		<AgentSectionList
 			agentId={agentId}
 			variant={kind === "cloud" ? "hosted" : "connected"}
-			visibleSectionIds={
-				kind === "cloud"
-					? hostedAgentVisibleSectionIds(filesAvailable === true)
-					: undefined
-			}
+			visibleSectionIds={kind === "cloud" ? hostedAgentVisibleSectionIds(filesAvailable === true) : undefined}
 			activeSection={activeSection}
 			primaryProject={primaryProject}
 			extraPrimaryItems={extraPrimaryItems}

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -505,7 +505,9 @@ function AgentFocusSections({
 		<AgentSectionList
 			agentId={agentId}
 			variant={kind === "cloud" ? "hosted" : "connected"}
-			visibleSectionIds={kind === "cloud" ? hostedAgentVisibleSectionIds(filesAvailable === true) : undefined}
+			visibleSectionIds={
+				kind === "cloud" ? hostedAgentVisibleSectionIds(filesAvailable === true) : undefined
+			}
 			activeSection={activeSection}
 			primaryProject={primaryProject}
 			extraPrimaryItems={extraPrimaryItems}

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -485,7 +485,7 @@ function AgentFocusSections({
 	primaryProject?: AgentPrimaryProjectNavigation | null;
 	onNavigate?: () => void;
 }) {
-	const { legacyDashboardUrl, canUseAgentPluginsUI } = useProductAccess();
+	const { legacyDashboardUrl } = useProductAccess();
 	const legacyDashboardHref = kind === "legacy" ? legacyDashboardUrl : null;
 	const extraPrimaryItems: SidebarNavItem[] = legacyDashboardHref
 		? [
@@ -507,7 +507,7 @@ function AgentFocusSections({
 			variant={kind === "cloud" ? "hosted" : "connected"}
 			visibleSectionIds={
 				kind === "cloud"
-					? hostedAgentVisibleSectionIds(filesAvailable === true, canUseAgentPluginsUI)
+					? hostedAgentVisibleSectionIds(filesAvailable === true)
 					: undefined
 			}
 			activeSection={activeSection}

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
@@ -9,6 +9,7 @@ import {
 	OverviewModuleError,
 } from "@/components/dashboard/agent-overview-capabilities";
 import { Card, CardDescription, CardTitle } from "@/components/ui/card";
+import { hostedAgentVisibleSectionIds } from "@/lib/navigation-model";
 
 describe("overview card typography", () => {
 	test("uses the existing small Card title and description hierarchy", () => {
@@ -64,9 +65,19 @@ describe("overview modules", () => {
 		const hosted = renderToStaticMarkup(
 			createElement(AgentOverviewCapabilitiesSkeleton, { variant: "hosted" }),
 		);
+		const hostedWithPlugins = renderToStaticMarkup(
+			createElement(AgentOverviewCapabilitiesSkeleton, {
+				variant: "hosted",
+				visibleSectionIds: hostedAgentVisibleSectionIds(true, true),
+			}),
+		);
 
 		expect(connected.match(/data-overview-module-skeleton=/g)).toHaveLength(5);
 		expect(hosted.match(/data-overview-module-skeleton=/g)).toHaveLength(7);
+		expect(hostedWithPlugins.match(/data-overview-module-skeleton=/g)).toHaveLength(8);
+		expect(hosted).not.toContain('data-overview-module-skeleton="plugins"');
+		expect(hostedWithPlugins).toContain('data-overview-module-skeleton="plugins"');
+		expect(hostedWithPlugins).toContain('data-overview-layout="two-column"');
 		expect(hosted).toContain("h-full min-w-0 py-3");
 		expect(hosted).toContain("grid-rows-1 content-center gap-0");
 		expect(hosted).not.toContain("h-40");

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.test.tsx
@@ -9,7 +9,6 @@ import {
 	OverviewModuleError,
 } from "@/components/dashboard/agent-overview-capabilities";
 import { Card, CardDescription, CardTitle } from "@/components/ui/card";
-import { hostedAgentVisibleSectionIds } from "@/lib/navigation-model";
 
 describe("overview card typography", () => {
 	test("uses the existing small Card title and description hierarchy", () => {
@@ -65,19 +64,11 @@ describe("overview modules", () => {
 		const hosted = renderToStaticMarkup(
 			createElement(AgentOverviewCapabilitiesSkeleton, { variant: "hosted" }),
 		);
-		const hostedWithPlugins = renderToStaticMarkup(
-			createElement(AgentOverviewCapabilitiesSkeleton, {
-				variant: "hosted",
-				visibleSectionIds: hostedAgentVisibleSectionIds(true, true),
-			}),
-		);
 
 		expect(connected.match(/data-overview-module-skeleton=/g)).toHaveLength(5);
-		expect(hosted.match(/data-overview-module-skeleton=/g)).toHaveLength(7);
-		expect(hostedWithPlugins.match(/data-overview-module-skeleton=/g)).toHaveLength(8);
-		expect(hosted).not.toContain('data-overview-module-skeleton="plugins"');
-		expect(hostedWithPlugins).toContain('data-overview-module-skeleton="plugins"');
-		expect(hostedWithPlugins).toContain('data-overview-layout="two-column"');
+		expect(hosted.match(/data-overview-module-skeleton=/g)).toHaveLength(8);
+		expect(hosted).toContain('data-overview-module-skeleton="plugins"');
+		expect(hosted).toContain('data-overview-layout="two-column"');
 		expect(hosted).toContain("h-full min-w-0 py-3");
 		expect(hosted).toContain("grid-rows-1 content-center gap-0");
 		expect(hosted).not.toContain("h-40");

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -10,6 +10,7 @@ import { agentSectionLink } from "@/lib/agent-routes";
 import {
 	AGENT_SECTION_NAVIGATION_ITEMS,
 	type AgentNavigationVariant,
+	type AgentSectionId,
 } from "@/lib/navigation-model";
 import { cn } from "@/lib/utils";
 
@@ -109,13 +110,15 @@ export function OverviewMetadata({
 export function AgentOverviewCapabilities({
 	agentId,
 	variant,
+	visibleSectionIds,
 	content,
 }: {
 	agentId: string;
 	variant: AgentNavigationVariant;
+	visibleSectionIds?: readonly AgentSectionId[];
 	content: Partial<Record<AgentOverviewModuleId, AgentOverviewModuleContent>>;
 }) {
-	const groups = agentOverviewGroups(variant);
+	const groups = agentOverviewGroups(variant, visibleSectionIds);
 	return (
 		<div className="flex flex-col gap-8" data-agent-overview={variant}>
 			{groups.map((group) => (
@@ -212,10 +215,12 @@ function OverviewNavigationCard({
 
 export function AgentOverviewCapabilitiesSkeleton({
 	variant,
+	visibleSectionIds,
 }: {
 	variant: AgentNavigationVariant;
+	visibleSectionIds?: readonly AgentSectionId[];
 }) {
-	const groups = agentOverviewGroups(variant);
+	const groups = agentOverviewGroups(variant, visibleSectionIds);
 	return (
 		<div className="flex flex-col gap-8" aria-hidden="true" data-agent-overview-skeleton={variant}>
 			{groups.map((group) => (

--- a/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
+++ b/apps/web/src/components/dashboard/agent-overview-capabilities.tsx
@@ -10,7 +10,6 @@ import { agentSectionLink } from "@/lib/agent-routes";
 import {
 	AGENT_SECTION_NAVIGATION_ITEMS,
 	type AgentNavigationVariant,
-	type AgentSectionId,
 } from "@/lib/navigation-model";
 import { cn } from "@/lib/utils";
 
@@ -110,15 +109,13 @@ export function OverviewMetadata({
 export function AgentOverviewCapabilities({
 	agentId,
 	variant,
-	visibleSectionIds,
 	content,
 }: {
 	agentId: string;
 	variant: AgentNavigationVariant;
-	visibleSectionIds?: readonly AgentSectionId[];
 	content: Partial<Record<AgentOverviewModuleId, AgentOverviewModuleContent>>;
 }) {
-	const groups = agentOverviewGroups(variant, visibleSectionIds);
+	const groups = agentOverviewGroups(variant);
 	return (
 		<div className="flex flex-col gap-8" data-agent-overview={variant}>
 			{groups.map((group) => (
@@ -215,12 +212,10 @@ function OverviewNavigationCard({
 
 export function AgentOverviewCapabilitiesSkeleton({
 	variant,
-	visibleSectionIds,
 }: {
 	variant: AgentNavigationVariant;
-	visibleSectionIds?: readonly AgentSectionId[];
 }) {
-	const groups = agentOverviewGroups(variant, visibleSectionIds);
+	const groups = agentOverviewGroups(variant);
 	return (
 		<div className="flex flex-col gap-8" aria-hidden="true" data-agent-overview-skeleton={variant}>
 			{groups.map((group) => (

--- a/apps/web/src/hosted/access/product-access-model.test.ts
+++ b/apps/web/src/hosted/access/product-access-model.test.ts
@@ -11,7 +11,6 @@ describe("hostedProductAccessFromProfile", () => {
 			legacyHostedAccessStatus: "unresolved",
 			canCreateCloudAgents: false,
 			canUseCloudAgents: false,
-			canUseAgentPluginsUI: false,
 		});
 	});
 
@@ -25,7 +24,6 @@ describe("hostedProductAccessFromProfile", () => {
 			legacyHostedAccessStatus: "disabled",
 			canCreateCloudAgents: true,
 			canUseCloudAgents: true,
-			canUseAgentPluginsUI: false,
 		});
 	});
 
@@ -39,7 +37,6 @@ describe("hostedProductAccessFromProfile", () => {
 			legacyHostedAccessStatus: "enabled",
 			canCreateCloudAgents: false,
 			canUseCloudAgents: false,
-			canUseAgentPluginsUI: false,
 		});
 	});
 
@@ -49,7 +46,6 @@ describe("hostedProductAccessFromProfile", () => {
 				capabilities: {
 					can_use_v1: false,
 					can_use_v2: false,
-					can_use_agent_plugins_ui: true,
 				},
 			}),
 		).toEqual({
@@ -57,7 +53,6 @@ describe("hostedProductAccessFromProfile", () => {
 			legacyHostedAccessStatus: "disabled",
 			canCreateCloudAgents: false,
 			canUseCloudAgents: false,
-			canUseAgentPluginsUI: true,
 		});
 	});
 });

--- a/apps/web/src/hosted/access/product-access-model.ts
+++ b/apps/web/src/hosted/access/product-access-model.ts
@@ -13,7 +13,6 @@ export interface HostedProductAccess {
 	canUseLegacyHostedDashboard: boolean;
 	legacyHostedAccessStatus: LegacyHostedAccessStatus;
 	canCreateCloudAgents: boolean;
-	canUseAgentPluginsUI: boolean;
 	/**
 	 * Back-compat alias for the rollout flag. New code should choose the
 	 * narrower `canCreateCloudAgents` name so existing deployment management
@@ -62,6 +61,5 @@ export function hostedProductAccessFromProfile(
 		legacyHostedAccessStatus,
 		canCreateCloudAgents,
 		canUseCloudAgents: canCreateCloudAgents,
-		canUseAgentPluginsUI: capabilities?.can_use_agent_plugins_ui === true,
 	};
 }

--- a/apps/web/src/hosted/access/product-access-projection.ts
+++ b/apps/web/src/hosted/access/product-access-projection.ts
@@ -7,7 +7,6 @@ function sameProductAccess(left: ProductAccess, right: ProductAccess): boolean {
 		left.legacyDashboardUrl === right.legacyDashboardUrl &&
 		left.canCreateCloudAgents === right.canCreateCloudAgents &&
 		left.canUseCloudAgents === right.canUseCloudAgents &&
-		left.canUseAgentPluginsUI === right.canUseAgentPluginsUI &&
 		left.status === right.status &&
 		left.isLoading === right.isLoading &&
 		left.isError === right.isError &&

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -21,7 +21,6 @@ import {
 	HOSTED_AGENT_SECTION_IDS,
 } from "@/lib/agent-routes";
 import { hostedAgentVisibleSectionIds } from "@/lib/navigation-model";
-import { useProductAccess } from "@/lib/product-access";
 
 export async function runManualDeploymentRefetch(
 	refetch: () => Promise<unknown>,
@@ -52,7 +51,6 @@ export function AgentHome({
 	routeSearch: AgentRouteSearch;
 }) {
 	const router = useRouter();
-	const { canUseAgentPluginsUI, isLoading: productAccessLoading } = useProductAccess();
 	const pathname = useLocation({ select: (location) => location.pathname });
 	const {
 		deployment,
@@ -71,15 +69,13 @@ export function AgentHome({
 		agentRouteOwnsSection(pathname, environmentId, section) ||
 		(section === "plugins" && agentRouteBelongsToSection(pathname, environmentId, section));
 	const hostedSectionIds = deployment
-		? hostedAgentVisibleSectionIds(deploymentFilesUrl(deployment) !== null, canUseAgentPluginsUI)
+		? hostedAgentVisibleSectionIds(deploymentFilesUrl(deployment) !== null)
 		: HOSTED_AGENT_SECTION_IDS;
-	const agentPluginsAccessPending = section === "plugins" && productAccessLoading;
-	const hostedSection =
-		agentPluginsAccessPending || hostedSectionIds.some((candidate) => candidate === section);
+	const hostedSection = hostedSectionIds.some((candidate) => candidate === section);
 	const connectedSection = CONNECTED_AGENT_SECTION_IDS.some((candidate) => candidate === section);
 
-	// Canonicalize only the exact section root, plus Plugins detail routes that
-	// share its capability gate. A stale rendered match cannot rewrite a newer route.
+	// Canonicalize exact section roots and nested Plugins routes, while a stale
+	// rendered match cannot rewrite a newer route.
 	useEffect(() => {
 		if (!ownsCurrentSection) return;
 
@@ -155,9 +151,6 @@ export function AgentHome({
 	}
 
 	if (deployment) {
-		if (agentPluginsAccessPending) {
-			return <ConnectedAgentDetailSkeleton hosted section={section} />;
-		}
 		// Scope the detail to the deployment's selected runtime.
 		const runtime =
 			matchedRuntime && isHostedRuntime(matchedRuntime)

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -15,6 +15,7 @@ import { defaultDeploymentRuntime, deploymentFilesUrl, isHostedRuntime } from "@
 import {
 	type AgentRouteSearch,
 	type AgentSectionId,
+	agentRouteBelongsToSection,
 	agentRouteOwnsSection,
 	CONNECTED_AGENT_SECTION_IDS,
 	HOSTED_AGENT_SECTION_IDS,
@@ -66,7 +67,9 @@ export function AgentHome({
 	} = useAgentDeployment(environmentId);
 	const manualCheckInFlightRef = useRef(false);
 	const [manualChecking, setManualChecking] = useState(false);
-	const ownsCurrentSection = agentRouteOwnsSection(pathname, environmentId, section);
+	const ownsCurrentSection =
+		agentRouteOwnsSection(pathname, environmentId, section) ||
+		(section === "plugins" && agentRouteBelongsToSection(pathname, environmentId, section));
 	const hostedSectionIds = deployment
 		? hostedAgentVisibleSectionIds(deploymentFilesUrl(deployment) !== null, canUseAgentPluginsUI)
 		: HOSTED_AGENT_SECTION_IDS;
@@ -75,8 +78,8 @@ export function AgentHome({
 		agentPluginsAccessPending || hostedSectionIds.some((candidate) => candidate === section);
 	const connectedSection = CONNECTED_AGENT_SECTION_IDS.some((candidate) => candidate === section);
 
-	// Only the exact current section may redirect an unsupported surface; a
-	// stale rendered match cannot rewrite a newer route.
+	// Canonicalize only the exact section root, plus Plugins detail routes that
+	// share its capability gate. A stale rendered match cannot rewrite a newer route.
 	useEffect(() => {
 		if (!ownsCurrentSection) return;
 

--- a/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
@@ -35,8 +35,9 @@ describe("hosted agent detail header", () => {
 		expect(source).toContain("Open in new tab");
 		expect(source).toContain("Opening Files…");
 		expect(source).not.toContain('target="_blank"');
+		expect(source).toContain("hostedAgentVisibleSectionIds(");
 		expect(source).toContain(
-			'const activeTab = requestedTab === "files" && filesUrl === null ? "overview" : requestedTab;',
+			'const activeTab = visibleSectionIds.includes(parsedTab) ? parsedTab : "overview";',
 		);
 
 		// The Clerk token only ever travels in the HTTPS Authorization header —

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -459,7 +459,6 @@ export function HostedAgentDetail({
 }) {
 	const $api = useOpenApi();
 	const queryClient = useQueryClient();
-	const { canUseAgentPluginsUI } = useProductAccess();
 	const [isCheckingProjection, setIsCheckingProjection] = useState(false);
 	const deploymentStatus = deploymentStatusFromResource(deployment.resource.status);
 	const deploymentFailure = deploymentFailurePresentation(deployment);
@@ -498,7 +497,7 @@ export function HostedAgentDetail({
 		: agentDisplayName({ default_name: deployment.resource.name, agent_type: runtime });
 	const parsedTab = parseHostedAgentTab(section) ?? "overview";
 	const filesUrl = deploymentFilesUrl(deployment);
-	const visibleSectionIds = hostedAgentVisibleSectionIds(filesUrl !== null, canUseAgentPluginsUI);
+	const visibleSectionIds = hostedAgentVisibleSectionIds(filesUrl !== null);
 	const activeTab = visibleSectionIds.includes(parsedTab) ? parsedTab : "overview";
 	useSetBreadcrumbTitle(
 		activeTab === "overview" ? availableAgentTitle : agentSectionLabel(activeTab),
@@ -613,7 +612,6 @@ export function HostedAgentDetail({
 							}
 							onRetrySessions={() => sessions.refetch()}
 							sessionLink={(session) => scopedSessionLink(session.id)}
-							visibleSectionIds={visibleSectionIds}
 							deploymentTransitionTimedOut={deploymentTransitionTimedOut}
 							deploymentTransitionEscalated={deploymentTransitionEscalated}
 						/>
@@ -1156,7 +1154,6 @@ function OverviewTab({
 	sessionsError,
 	onRetrySessions,
 	sessionLink,
-	visibleSectionIds,
 	deploymentTransitionTimedOut,
 	deploymentTransitionEscalated,
 }: {
@@ -1173,7 +1170,6 @@ function OverviewTab({
 		to: "/agents/$id/sessions/$sessionId";
 		params: { id: string; sessionId: string };
 	};
-	visibleSectionIds: readonly AgentSectionId[];
 	deploymentTransitionTimedOut: boolean;
 	deploymentTransitionEscalated: boolean;
 }) {
@@ -1224,10 +1220,7 @@ function OverviewTab({
 		enabled: isRunningStatus(deploymentStatus),
 		retry: billingQueryRetry,
 	});
-	const pluginsVisible = visibleSectionIds.includes("plugins");
-	const pluginDesiredState = useQuery(
-		agentPluginDesiredStateQueryOptions(useOpenApi(), agentId, { enabled: pluginsVisible }),
-	);
+	const pluginDesiredState = useQuery(agentPluginDesiredStateQueryOptions(useOpenApi(), agentId));
 	const pluginOverview = agentPluginOverviewState({
 		plugins: pluginDesiredState.data?.plugins,
 		isLoading: pluginDesiredState.isLoading,
@@ -1332,7 +1325,6 @@ function OverviewTab({
 			<AgentOverviewCapabilities
 				agentId={agentId}
 				variant="hosted"
-				visibleSectionIds={visibleSectionIds}
 				content={{
 					projects: overviewProjectsModule({
 						bindings: {

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -220,6 +220,8 @@ import {
 	runtimeConsoleUrl,
 	runtimeDisplayName,
 } from "@/hosted/runtimes";
+import { agentPluginOverviewState } from "@/hosted/v2/agent-plugins/agent-plugin-model";
+import { agentPluginDesiredStateQueryOptions } from "@/hosted/v2/agent-plugins/agent-plugin-query";
 import { AgentPluginsSurface } from "@/hosted/v2/agent-plugins/agent-plugins-surface";
 import { AddProviderDialog } from "@/hosted/v2/ai-providers/add-provider-dialog";
 import {
@@ -302,7 +304,10 @@ import {
 import { ApiError, toastApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import type { SessionListItem } from "@/lib/api-schemas";
 import { formatMemoryMib, formatShortDate } from "@/lib/format";
-import { AGENT_SECTION_NAVIGATION_ITEMS } from "@/lib/navigation-model";
+import {
+	AGENT_SECTION_NAVIGATION_ITEMS,
+	hostedAgentVisibleSectionIds,
+} from "@/lib/navigation-model";
 import { useProductAccess } from "@/lib/product-access";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import { agentResourceScope } from "@/lib/resource-navigation";
@@ -492,9 +497,9 @@ export function HostedAgentDetail({
 		? agentDisplayName(agent)
 		: agentDisplayName({ default_name: deployment.resource.name, agent_type: runtime });
 	const parsedTab = parseHostedAgentTab(section) ?? "overview";
-	const requestedTab = parsedTab === "plugins" && !canUseAgentPluginsUI ? "overview" : parsedTab;
 	const filesUrl = deploymentFilesUrl(deployment);
-	const activeTab = requestedTab === "files" && filesUrl === null ? "overview" : requestedTab;
+	const visibleSectionIds = hostedAgentVisibleSectionIds(filesUrl !== null, canUseAgentPluginsUI);
+	const activeTab = visibleSectionIds.includes(parsedTab) ? parsedTab : "overview";
 	useSetBreadcrumbTitle(
 		activeTab === "overview" ? availableAgentTitle : agentSectionLabel(activeTab),
 	);
@@ -608,6 +613,7 @@ export function HostedAgentDetail({
 							}
 							onRetrySessions={() => sessions.refetch()}
 							sessionLink={(session) => scopedSessionLink(session.id)}
+							visibleSectionIds={visibleSectionIds}
 							deploymentTransitionTimedOut={deploymentTransitionTimedOut}
 							deploymentTransitionEscalated={deploymentTransitionEscalated}
 						/>
@@ -1150,6 +1156,7 @@ function OverviewTab({
 	sessionsError,
 	onRetrySessions,
 	sessionLink,
+	visibleSectionIds,
 	deploymentTransitionTimedOut,
 	deploymentTransitionEscalated,
 }: {
@@ -1166,6 +1173,7 @@ function OverviewTab({
 		to: "/agents/$id/sessions/$sessionId";
 		params: { id: string; sessionId: string };
 	};
+	visibleSectionIds: readonly AgentSectionId[];
 	deploymentTransitionTimedOut: boolean;
 	deploymentTransitionEscalated: boolean;
 }) {
@@ -1216,6 +1224,27 @@ function OverviewTab({
 		enabled: isRunningStatus(deploymentStatus),
 		retry: billingQueryRetry,
 	});
+	const pluginsVisible = visibleSectionIds.includes("plugins");
+	const pluginDesiredState = useQuery(
+		agentPluginDesiredStateQueryOptions(useOpenApi(), agentId, { enabled: pluginsVisible }),
+	);
+	const pluginOverview = agentPluginOverviewState({
+		plugins: pluginDesiredState.data?.plugins,
+		isLoading: pluginDesiredState.isLoading,
+		error: shouldBlockQueryError(pluginDesiredState.error, pluginDesiredState.data)
+			? pluginDesiredState.error
+			: null,
+	});
+	const pluginsModule = {
+		description:
+			pluginOverview.kind === "loading" ? (
+				<OverviewDescriptionSkeleton label="plugins" />
+			) : pluginOverview.kind === "error" ? (
+				"Unavailable right now"
+			) : (
+				pluginOverview.description
+			),
+	};
 	const skillsModule = runtimeSkills.isLoading
 		? { description: <OverviewDescriptionSkeleton label="skills" /> }
 		: runtimeSkills.error
@@ -1303,6 +1332,7 @@ function OverviewTab({
 			<AgentOverviewCapabilities
 				agentId={agentId}
 				variant="hosted"
+				visibleSectionIds={visibleSectionIds}
 				content={{
 					projects: overviewProjectsModule({
 						bindings: {
@@ -1321,6 +1351,7 @@ function OverviewTab({
 							? agentProjectResourceLink(agentId, workspaceProjectId, "skills")
 							: null,
 					},
+					plugins: pluginsModule,
 					memories: memoriesModule,
 					vaults: {
 						...vaultsModule,

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.test.ts
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.test.ts
@@ -3,6 +3,7 @@ import type { AgentPluginCatalogEntry, AgentPluginDesiredState } from "./agent-p
 import {
 	agentPluginActionState,
 	agentPluginInstallability,
+	agentPluginOverviewState,
 	agentPluginStatusPresentation,
 	assignAgentPluginGroups,
 	buildAgentPluginInventory,
@@ -50,6 +51,31 @@ function desired(
 }
 
 describe("Agent Plugin model", () => {
+	test("summarizes Overview loading, error, empty, and convergence states", () => {
+		expect(agentPluginOverviewState({ isLoading: true, error: null })).toEqual({
+			kind: "loading",
+		});
+		expect(agentPluginOverviewState({ isLoading: false, error: new Error("offline") })).toEqual({
+			kind: "error",
+		});
+		expect(agentPluginOverviewState({ plugins: [], isLoading: false, error: null })).toEqual({
+			kind: "ready",
+			description: "No plugins installed",
+		});
+		expect(
+			agentPluginOverviewState({
+				plugins: [
+					desired("installed-1"),
+					desired("installed-2"),
+					desired("pending", { convergence: "not_observed" }),
+					desired("failed", { convergence: "failed" }),
+				],
+				isLoading: false,
+				error: null,
+			}),
+		).toEqual({ kind: "ready", description: "2 installed · 1 pending · 1 failed" });
+	});
+
 	test("merges Store and desired state without dropping historical installations", () => {
 		const inventory = buildAgentPluginInventory(
 			[catalogEntry("sui"), catalogEntry("cetus")],

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.ts
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-model.ts
@@ -13,6 +13,11 @@ export type AgentPluginInventoryItem = {
 
 export type AgentPluginGroup = "installed" | "available";
 
+export type AgentPluginOverviewState =
+	| { kind: "loading" }
+	| { kind: "error" }
+	| { kind: "ready"; description: string };
+
 export type AgentPluginInstallability = {
 	installable: boolean;
 	label: string;
@@ -216,6 +221,47 @@ export function agentPluginStatusPresentation(
 							"This plugin is being installed. You can leave this page while it finishes.",
 					};
 	}
+}
+
+export function agentPluginOverviewState({
+	plugins,
+	isLoading,
+	error,
+}: {
+	plugins?: readonly AgentPluginDesiredState[];
+	isLoading: boolean;
+	error: unknown;
+}): AgentPluginOverviewState {
+	if (isLoading) return { kind: "loading" };
+	if (error) return { kind: "error" };
+	if (!plugins?.length) return { kind: "ready", description: "No plugins installed" };
+
+	let installed = 0;
+	let pending = 0;
+	let failed = 0;
+	for (const plugin of plugins) {
+		switch (plugin.convergence) {
+			case "installed":
+				installed += 1;
+				break;
+			case "not_observed":
+				pending += 1;
+				break;
+			case "failed":
+				failed += 1;
+				break;
+		}
+	}
+	return {
+		kind: "ready",
+		description: [
+			installed ? `${installed} installed` : null,
+			pending ? `${pending} pending` : null,
+			failed ? `${failed} failed` : null,
+		]
+			.filter((value): value is string => value !== null)
+			.join(" · "),
+	};
 }
 
 export type AgentPluginActionState = {

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-query.ts
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-query.ts
@@ -1,0 +1,36 @@
+import type { OpenApiClient } from "@/lib/api";
+import { agentPluginIsStalled } from "./agent-plugin-model";
+
+export const AGENT_PLUGIN_DESIRED_QUERY_KEY = [
+	"get",
+	"/v1/agents/{agent_id}/agent-plugins",
+] as const;
+
+const ACTIVE_INSTALL_POLL_MS = 5_000;
+const STALLED_INSTALL_POLL_MS = 60_000;
+
+export function agentPluginDesiredStateQueryOptions(
+	api: OpenApiClient,
+	agentId: string,
+	{ enabled = true }: { enabled?: boolean } = {},
+) {
+	return api.queryOptions(
+		"get",
+		"/v1/agents/{agent_id}/agent-plugins",
+		{ params: { path: { agent_id: agentId } } },
+		{
+			enabled,
+			refetchInterval: (query) => {
+				const plugins = query.state.data?.plugins;
+				if (!plugins?.some((plugin) => plugin.convergence === "not_observed")) return false;
+				const now = new Date();
+				return plugins.some(
+					(plugin) => plugin.convergence === "not_observed" && !agentPluginIsStalled(plugin, now),
+				)
+					? ACTIVE_INSTALL_POLL_MS
+					: STALLED_INSTALL_POLL_MS;
+			},
+			refetchIntervalInBackground: false,
+		},
+	);
+}

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-query.ts
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-query.ts
@@ -9,10 +9,7 @@ export const AGENT_PLUGIN_DESIRED_QUERY_KEY = [
 const ACTIVE_INSTALL_POLL_MS = 5_000;
 const STALLED_INSTALL_POLL_MS = 60_000;
 
-export function agentPluginDesiredStateQueryOptions(
-	api: OpenApiClient,
-	agentId: string,
-) {
+export function agentPluginDesiredStateQueryOptions(api: OpenApiClient, agentId: string) {
 	return api.queryOptions(
 		"get",
 		"/v1/agents/{agent_id}/agent-plugins",

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugin-query.ts
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugin-query.ts
@@ -12,14 +12,12 @@ const STALLED_INSTALL_POLL_MS = 60_000;
 export function agentPluginDesiredStateQueryOptions(
 	api: OpenApiClient,
 	agentId: string,
-	{ enabled = true }: { enabled?: boolean } = {},
 ) {
 	return api.queryOptions(
 		"get",
 		"/v1/agents/{agent_id}/agent-plugins",
 		{ params: { path: { agent_id: agentId } } },
 		{
-			enabled,
 			refetchInterval: (query) => {
 				const plugins = query.state.data?.plugins;
 				if (!plugins?.some((plugin) => plugin.convergence === "not_observed")) return false;

--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocation, useRouter } from "@tanstack/react-router";
 import { AlertCircle, Blocks, RefreshCw } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -29,17 +29,16 @@ import {
 	type AgentPluginGroup,
 	type AgentPluginInventoryItem,
 	agentPluginInstallability,
-	agentPluginIsStalled,
 	agentPluginMatches,
 	assignAgentPluginGroups,
 	buildAgentPluginInventory,
 	pluginDisplayName,
 	pluginHasUpdate,
 } from "./agent-plugin-model";
-
-const DESIRED_QUERY_KEY = ["get", "/v1/agents/{agent_id}/agent-plugins"] as const;
-const ACTIVE_INSTALL_POLL_MS = 5_000;
-const STALLED_INSTALL_POLL_MS = 60_000;
+import {
+	AGENT_PLUGIN_DESIRED_QUERY_KEY,
+	agentPluginDesiredStateQueryOptions,
+} from "./agent-plugin-query";
 
 type PendingPluginMutation = {
 	name: string;
@@ -77,24 +76,7 @@ export function AgentPluginsSurface({
 		convergenceLog.current = { agentId, seen: new Map() };
 	}
 	const catalogQuery = api.useQuery("get", "/v1/plugin-catalog", {});
-	const desiredQuery = api.useQuery(
-		"get",
-		"/v1/agents/{agent_id}/agent-plugins",
-		{ params: { path: { agent_id: agentId } } },
-		{
-			refetchInterval: (query) => {
-				const plugins = query.state.data?.plugins;
-				if (!plugins?.some((plugin) => plugin.convergence === "not_observed")) return false;
-				const now = new Date();
-				return plugins.some(
-					(plugin) => plugin.convergence === "not_observed" && !agentPluginIsStalled(plugin, now),
-				)
-					? ACTIVE_INSTALL_POLL_MS
-					: STALLED_INSTALL_POLL_MS;
-			},
-			refetchIntervalInBackground: false,
-		},
-	);
+	const desiredQuery = useQuery(agentPluginDesiredStateQueryOptions(api, agentId));
 	const installMutation = api.useMutation(
 		"put",
 		"/v1/agents/{agent_id}/agent-plugins/{plugin_name}",
@@ -104,7 +86,8 @@ export function AgentPluginsSurface({
 		"/v1/agents/{agent_id}/agent-plugins/{plugin_name}",
 	);
 
-	const refreshDesired = () => queryClient.invalidateQueries({ queryKey: DESIRED_QUERY_KEY });
+	const refreshDesired = () =>
+		queryClient.invalidateQueries({ queryKey: AGENT_PLUGIN_DESIRED_QUERY_KEY });
 	const openPlugin = (name: string) => {
 		void router
 			.navigate({ href: agentPluginDetailHref(agentId, name), resetScroll: false })

--- a/apps/web/src/lib/agent-capabilities.test.ts
+++ b/apps/web/src/lib/agent-capabilities.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { agentOverviewGroups } from "@/lib/agent-capabilities";
-import { AGENT_SECTION_NAVIGATION_ITEMS } from "@/lib/navigation-model";
+import {
+	AGENT_SECTION_NAVIGATION_ITEMS,
+	hostedAgentVisibleSectionIds,
+} from "@/lib/navigation-model";
 
 describe("agent overview registry", () => {
 	test("only registers supported sections with real summaries", () => {
@@ -13,6 +16,10 @@ describe("agent overview registry", () => {
 	test("separates workspace, shared, and hosted tool summaries", () => {
 		const connected = agentOverviewGroups("connected");
 		const hosted = agentOverviewGroups("hosted");
+		const hostedWithPlugins = agentOverviewGroups(
+			"hosted",
+			hostedAgentVisibleSectionIds(true, true),
+		);
 		expect(connected.map((group) => group.id)).toEqual(["workspace", "shared"]);
 		expect(hosted.map((group) => group.id)).toEqual(["workspace", "shared", "operate"]);
 		expect(connected[0]?.modules.map((module) => module.id)).toEqual([
@@ -22,6 +29,16 @@ describe("agent overview registry", () => {
 		]);
 		expect(hosted[0]?.modules).toEqual(connected[0]?.modules);
 		expect(hosted[0]?.layout).toBe(connected[0]?.layout);
+		expect(hostedWithPlugins[0]?.modules.map((module) => module.id)).toEqual([
+			"projects",
+			"skills",
+			"vaults",
+			"plugins",
+		]);
+		expect(hostedWithPlugins[0]?.layout).toBe("two-column");
+		expect(agentOverviewGroups("connected", ["plugins"])[0]?.modules).toEqual(
+			connected[0]?.modules,
+		);
 		expect(connected[1]?.modules.map((module) => module.id)).toEqual(["memories", "connectors"]);
 		expect(hosted[1]?.modules).toEqual(connected[1]?.modules);
 		expect(hosted[2]?.modules.map((module) => module.id)).toEqual(["model-provider", "channels"]);

--- a/apps/web/src/lib/agent-capabilities.test.ts
+++ b/apps/web/src/lib/agent-capabilities.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { agentOverviewGroups } from "@/lib/agent-capabilities";
-import {
-	AGENT_SECTION_NAVIGATION_ITEMS,
-	hostedAgentVisibleSectionIds,
-} from "@/lib/navigation-model";
+import { AGENT_SECTION_NAVIGATION_ITEMS } from "@/lib/navigation-model";
 
 describe("agent overview registry", () => {
 	test("only registers supported sections with real summaries", () => {
@@ -16,10 +13,6 @@ describe("agent overview registry", () => {
 	test("separates workspace, shared, and hosted tool summaries", () => {
 		const connected = agentOverviewGroups("connected");
 		const hosted = agentOverviewGroups("hosted");
-		const hostedWithPlugins = agentOverviewGroups(
-			"hosted",
-			hostedAgentVisibleSectionIds(true, true),
-		);
 		expect(connected.map((group) => group.id)).toEqual(["workspace", "shared"]);
 		expect(hosted.map((group) => group.id)).toEqual(["workspace", "shared", "operate"]);
 		expect(connected[0]?.modules.map((module) => module.id)).toEqual([
@@ -27,18 +20,13 @@ describe("agent overview registry", () => {
 			"skills",
 			"vaults",
 		]);
-		expect(hosted[0]?.modules).toEqual(connected[0]?.modules);
-		expect(hosted[0]?.layout).toBe(connected[0]?.layout);
-		expect(hostedWithPlugins[0]?.modules.map((module) => module.id)).toEqual([
+		expect(hosted[0]?.modules.map((module) => module.id)).toEqual([
 			"projects",
 			"skills",
 			"vaults",
 			"plugins",
 		]);
-		expect(hostedWithPlugins[0]?.layout).toBe("two-column");
-		expect(agentOverviewGroups("connected", ["plugins"])[0]?.modules).toEqual(
-			connected[0]?.modules,
-		);
+		expect(hosted[0]?.layout).toBe("two-column");
 		expect(connected[1]?.modules.map((module) => module.id)).toEqual(["memories", "connectors"]);
 		expect(hosted[1]?.modules).toEqual(connected[1]?.modules);
 		expect(hosted[2]?.modules.map((module) => module.id)).toEqual(["model-provider", "channels"]);

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -3,11 +3,14 @@ import {
 	AGENT_SHARED_SECTION_IDS,
 	type AgentNavigationVariant,
 	type AgentSectionId,
+	HOSTED_AGENT_SECTION_IDS,
+	hostedAgentVisibleSectionIds,
 } from "@/lib/navigation-model";
 
 export type AgentOverviewModuleId =
 	| "projects"
 	| "skills"
+	| "plugins"
 	| "memories"
 	| "vaults"
 	| "connectors"
@@ -33,10 +36,17 @@ const WORKSPACE_RESOURCES = AGENT_OVERVIEW_WORKSPACE_SECTION_IDS.map((section) =
 	section,
 }));
 
+const HOSTED_WORKSPACE_RESOURCES = [
+	...WORKSPACE_RESOURCES,
+	{ id: "plugins", section: "plugins" },
+] as const;
+
 const SHARED_RESOURCES = AGENT_SHARED_SECTION_IDS.map((section) => ({
 	id: section,
 	section,
 }));
+
+const HOSTED_NAVIGATION_SECTIONS = new Set<AgentSectionId>(HOSTED_AGENT_SECTION_IDS);
 
 const AGENT_OVERVIEW_GROUPS = {
 	connected: [
@@ -58,7 +68,7 @@ const AGENT_OVERVIEW_GROUPS = {
 			id: "workspace",
 			label: "Workspace",
 			layout: "three-column",
-			modules: WORKSPACE_RESOURCES,
+			modules: HOSTED_WORKSPACE_RESOURCES,
 		},
 		{
 			id: "shared",
@@ -80,6 +90,24 @@ const AGENT_OVERVIEW_GROUPS = {
 
 export function agentOverviewGroups(
 	variant: AgentNavigationVariant,
+	visibleSectionIds?: readonly AgentSectionId[],
 ): readonly AgentOverviewGroup[] {
-	return AGENT_OVERVIEW_GROUPS[variant];
+	const groups = AGENT_OVERVIEW_GROUPS[variant];
+	if (variant !== "hosted") return groups;
+
+	const visibleSections = new Set(visibleSectionIds ?? hostedAgentVisibleSectionIds(true));
+	return groups.map((group) => {
+		const modules = group.modules.filter(
+			(module) =>
+				!HOSTED_NAVIGATION_SECTIONS.has(module.section) || visibleSections.has(module.section),
+		);
+		return {
+			...group,
+			layout:
+				group.id === "workspace" && modules.some((module) => module.id === "plugins")
+					? "two-column"
+					: group.layout,
+			modules,
+		};
+	});
 }

--- a/apps/web/src/lib/agent-capabilities.ts
+++ b/apps/web/src/lib/agent-capabilities.ts
@@ -3,8 +3,6 @@ import {
 	AGENT_SHARED_SECTION_IDS,
 	type AgentNavigationVariant,
 	type AgentSectionId,
-	HOSTED_AGENT_SECTION_IDS,
-	hostedAgentVisibleSectionIds,
 } from "@/lib/navigation-model";
 
 export type AgentOverviewModuleId =
@@ -46,8 +44,6 @@ const SHARED_RESOURCES = AGENT_SHARED_SECTION_IDS.map((section) => ({
 	section,
 }));
 
-const HOSTED_NAVIGATION_SECTIONS = new Set<AgentSectionId>(HOSTED_AGENT_SECTION_IDS);
-
 const AGENT_OVERVIEW_GROUPS = {
 	connected: [
 		{
@@ -67,7 +63,7 @@ const AGENT_OVERVIEW_GROUPS = {
 		{
 			id: "workspace",
 			label: "Workspace",
-			layout: "three-column",
+			layout: "two-column",
 			modules: HOSTED_WORKSPACE_RESOURCES,
 		},
 		{
@@ -90,24 +86,6 @@ const AGENT_OVERVIEW_GROUPS = {
 
 export function agentOverviewGroups(
 	variant: AgentNavigationVariant,
-	visibleSectionIds?: readonly AgentSectionId[],
 ): readonly AgentOverviewGroup[] {
-	const groups = AGENT_OVERVIEW_GROUPS[variant];
-	if (variant !== "hosted") return groups;
-
-	const visibleSections = new Set(visibleSectionIds ?? hostedAgentVisibleSectionIds(true));
-	return groups.map((group) => {
-		const modules = group.modules.filter(
-			(module) =>
-				!HOSTED_NAVIGATION_SECTIONS.has(module.section) || visibleSections.has(module.section),
-		);
-		return {
-			...group,
-			layout:
-				group.id === "workspace" && modules.some((module) => module.id === "plugins")
-					? "two-column"
-					: group.layout,
-			modules,
-		};
-	});
+	return AGENT_OVERVIEW_GROUPS[variant];
 }

--- a/apps/web/src/lib/agent-routes.test.ts
+++ b/apps/web/src/lib/agent-routes.test.ts
@@ -8,6 +8,7 @@ import {
 	agentProjectDetailLink,
 	agentProjectResourceHref,
 	agentProjectResourceLink,
+	agentRouteBelongsToSection,
 	agentRouteOwnsSection,
 	agentSectionHref,
 	agentSectionLabel,
@@ -144,6 +145,22 @@ describe("agent routes", () => {
 		).toBe(false);
 		expect(agentRouteOwnsSection("/agents/agent-1/plugins/sui", "agent-1", "plugins")).toBe(false);
 		expect(agentRouteOwnsSection("/agents/agent-1/skills", "agent-1", "overview")).toBe(false);
+	});
+
+	it("recognizes valid nested routes without weakening current-section identity", () => {
+		expect(agentRouteBelongsToSection("/agents/AGENT-1/plugins", "agent-1", "plugins")).toBe(true);
+		expect(agentRouteBelongsToSection("/agents/AGENT-1/plugins/sui", "agent-1", "plugins")).toBe(
+			true,
+		);
+		expect(agentRouteBelongsToSection("/agents/agent-2/plugins/sui", "agent-1", "plugins")).toBe(
+			false,
+		);
+		expect(agentRouteBelongsToSection("/agents/agent-1/plugins/sui", "agent-1", "overview")).toBe(
+			false,
+		);
+		expect(
+			agentRouteBelongsToSection("/agents/agent-1/plugins/sui/extra", "agent-1", "plugins"),
+		).toBe(false);
 	});
 
 	it("owns canonical section navigation with explicit typed search", () => {

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -158,6 +158,16 @@ export function agentRouteOwnsSection(
 	);
 }
 
+/** Whether the current pathname is this agent section or one of its valid detail routes. */
+export function agentRouteBelongsToSection(
+	pathname: string,
+	agentId: string,
+	section: AgentSectionId,
+): boolean {
+	const route = parseAgentPathname(pathname);
+	return Boolean(route && agentRouteIdsEqual(route.agentId, agentId) && route.section === section);
+}
+
 function optionalSearchString(value: unknown): string | undefined {
 	return typeof value === "string" ? value : undefined;
 }

--- a/apps/web/src/lib/navigation-model.test.ts
+++ b/apps/web/src/lib/navigation-model.test.ts
@@ -211,9 +211,9 @@ describe("sidebar navigation model", () => {
 			"settings",
 		]);
 		expect(hostedAgentVisibleSectionIds(false)).not.toContain("files");
+		expect(hostedAgentVisibleSectionIds(false)).toContain("plugins");
 		expect(hostedAgentVisibleSectionIds(true)).toContain("files");
-		expect(hostedAgentVisibleSectionIds(true)).not.toContain("plugins");
-		expect(hostedAgentVisibleSectionIds(true, true)).toContain("plugins");
+		expect(hostedAgentVisibleSectionIds(true)).toContain("plugins");
 
 		expect(groupShape(agentNavigationGroups("hosted", ["overview"]))).toEqual([
 			{

--- a/apps/web/src/lib/navigation-model.ts
+++ b/apps/web/src/lib/navigation-model.ts
@@ -461,14 +461,8 @@ export const CONNECTED_AGENT_SECTION_IDS: readonly AgentSectionId[] =
 export const HOSTED_AGENT_SECTION_IDS: readonly AgentSectionId[] =
 	agentNavigationSectionIds("hosted");
 
-export function hostedAgentVisibleSectionIds(
-	filesAvailable: boolean,
-	agentPluginsEnabled = false,
-): AgentSectionId[] {
-	return HOSTED_AGENT_SECTION_IDS.filter(
-		(section) =>
-			(filesAvailable || section !== "files") && (agentPluginsEnabled || section !== "plugins"),
-	);
+export function hostedAgentVisibleSectionIds(filesAvailable: boolean): AgentSectionId[] {
+	return HOSTED_AGENT_SECTION_IDS.filter((section) => filesAvailable || section !== "files");
 }
 
 export function agentNavigationGroups(

--- a/apps/web/src/lib/product-access.ts
+++ b/apps/web/src/lib/product-access.ts
@@ -11,7 +11,6 @@ export type ProductAccess = {
 	legacyDashboardUrl: string | null;
 	canCreateCloudAgents: boolean;
 	canUseCloudAgents: boolean;
-	canUseAgentPluginsUI: boolean;
 	status: ProductAccessStatus;
 	isLoading: boolean;
 	isError: boolean;
@@ -32,7 +31,6 @@ export const UNAVAILABLE_PRODUCT_ACCESS: ProductAccess = {
 	legacyDashboardUrl: null,
 	canCreateCloudAgents: false,
 	canUseCloudAgents: false,
-	canUseAgentPluginsUI: false,
 	status: "unavailable",
 	isLoading: false,
 	isError: false,

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1255,11 +1255,6 @@ export interface components {
              * @default false
              */
             can_use_v2: boolean;
-            /**
-             * Can Use Agent Plugins Ui
-             * @default false
-             */
-            can_use_agent_plugins_ui: boolean;
         };
         /** V1UserResponse */
         V1UserResponse: {


### PR DESCRIPTION
## Summary

- show Plugins in every Hosted Agent Sidebar and Overview; Connected Agents remain excluded
- remove the Agent Plugins UI product-access gate and generated deploy capability field
- share desired-state query and status summaries across Overview and the Plugins surface
- keep Sidebar, Overview, tab fallback, and nested Plugin route handling aligned
- use a stable two-column Workspace grid for the four Hosted modules

## Verification

- isolated Web typecheck
- 44 focused Web tests
- OSS production build
- Hosted Agent Plugins Playwright: 3 passed
- Biome and git diff --check
- deploy generated contract matches the paired clawdi-hosted OpenAPI change