### PR TITLE
fix(backend): eliminate channel ingress stability loops

### DIFF
--- a/backend/alembic/versions/4a8d2c7e9f31_widen_channel_message_text.py
+++ b/backend/alembic/versions/4a8d2c7e9f31_widen_channel_message_text.py
@@ -1,0 +1,36 @@
+"""Widen channel message text to preserve provider payloads.
+
+Revision ID: 4a8d2c7e9f31
+Revises: 2e6a9c4f1b7d
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "4a8d2c7e9f31"
+down_revision: str | Sequence[str] | None = "2e6a9c4f1b7d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "channel_messages",
+        "text",
+        existing_type=sa.String(length=4096),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "channel_messages",
+        "text",
+        existing_type=sa.Text(),
+        type_=sa.String(length=4096),
+        existing_nullable=True,
+    )

--- a/backend/app/models/channel.py
+++ b/backend/app/models/channel.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Integer,
     LargeBinary,
     String,
+    Text,
     UniqueConstraint,
 )
 from sqlalchemy import (
@@ -511,7 +512,7 @@ class ChannelMessage(Base, TimestampMixin):
         default=PROVIDER_EVENT_SCOPE_CHAT,
         server_default=PROVIDER_EVENT_SCOPE_CHAT,
     )
-    text: Mapped[str | None] = mapped_column(String(4096))
+    text: Mapped[str | None] = mapped_column(Text)
     payload: Mapped[dict[str, JsonValue] | None] = mapped_column(JSONB(none_as_null=True))
     delivered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), index=True)
 

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -28,7 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.datastructures import UploadFile
 
 from app.core.config import settings
-from app.core.database import get_session
+from app.core.database import async_session_factory, get_session
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     BINDING_STATUS_ARCHIVED,
@@ -424,16 +424,21 @@ async def telegram_bot_api(
             0.0,
             min(float(timeout or 0), settings.channel_long_poll_max_seconds),
         )
+        account_id = account.id
+        bot_agent_link_id = agent.link.id
+        # End the request-scoped authentication transaction before parking the
+        # request. Each poll below owns a fresh, short transaction so newly
+        # committed updates are visible without pinning a pooled connection.
+        await db.rollback()
         updates = await wait_for_telegram_updates(
-            db,
-            account=account,
-            bot_agent_link_id=agent.link.id,
+            async_session_factory,
+            account_id=account_id,
+            bot_agent_link_id=bot_agent_link_id,
             offset=offset,
             limit=limit,
             allowed_updates=allowed_updates(params.get("allowed_updates")),
             timeout_seconds=timeout_seconds,
         )
-        await db.commit()
         return telegram_ok(updates)
     if method_key == "setwebhook":
         webhook_url = optional_str(params.get("url"))

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -23,7 +23,7 @@ from sqlalchemy import and_, delete, exists, func, or_, select, union_all, updat
 from sqlalchemy import text as sql_text
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.config import settings
 from app.models.channel import (
@@ -3673,7 +3673,7 @@ def _virtualized_telegram_direct_message(message: JsonObject) -> JsonObject:
 async def dequeue_telegram_updates(
     db: AsyncSession,
     *,
-    account: ChannelAccount,
+    account_id: UUID,
     bot_agent_link_id: UUID | None = None,
     offset: int | None,
     limit: int,
@@ -3681,7 +3681,7 @@ async def dequeue_telegram_updates(
 ) -> list[JsonObject]:
     now = datetime.now(UTC)
     filters = [
-        ChannelMessage.account_id == account.id,
+        ChannelMessage.account_id == account_id,
         ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
         ChannelMessage.binding_id.is_not(None),
         ChannelMessage.delivered_at.is_(None),
@@ -3755,9 +3755,9 @@ async def dequeue_telegram_updates(
 
 
 async def wait_for_telegram_updates(
-    db: AsyncSession,
+    sessionmaker: async_sessionmaker[AsyncSession],
     *,
-    account: ChannelAccount,
+    account_id: UUID,
     bot_agent_link_id: UUID | None = None,
     offset: int | None,
     limit: int,
@@ -3769,14 +3769,16 @@ async def wait_for_telegram_updates(
     poll_interval = _channel_long_poll_interval(poll_interval_seconds)
     deadline = monotonic() + timeout
     while True:
-        updates = await dequeue_telegram_updates(
-            db,
-            account=account,
-            bot_agent_link_id=bot_agent_link_id,
-            offset=offset,
-            limit=limit,
-            allowed_updates=allowed_updates,
-        )
+        async with sessionmaker() as db:
+            updates = await dequeue_telegram_updates(
+                db,
+                account_id=account_id,
+                bot_agent_link_id=bot_agent_link_id,
+                offset=offset,
+                limit=limit,
+                allowed_updates=allowed_updates,
+            )
+            await db.commit()
         if updates or timeout == 0 or monotonic() >= deadline:
             return updates
         await asyncio.sleep(min(poll_interval, max(0.0, deadline - monotonic())))
@@ -3785,13 +3787,13 @@ async def wait_for_telegram_updates(
 async def dequeue_channel_inbox_events(
     db: AsyncSession,
     *,
-    account: ChannelAccount,
+    account_id: UUID,
     bot_agent_link_id: UUID | None = None,
     after_sequence: int,
     limit: int,
 ) -> list[ChannelMessage]:
     filters = [
-        ChannelMessage.account_id == account.id,
+        ChannelMessage.account_id == account_id,
         ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
         ChannelMessage.binding_id.is_not(None),
         ChannelMessage.delivered_at.is_(None),
@@ -4470,9 +4472,9 @@ async def channel_queue_snapshots(
 
 
 async def wait_for_channel_inbox_events(
-    db: AsyncSession,
+    sessionmaker: async_sessionmaker[AsyncSession],
     *,
-    account: ChannelAccount,
+    account_id: UUID,
     bot_agent_link_id: UUID | None = None,
     after_sequence: int,
     limit: int,
@@ -4483,13 +4485,15 @@ async def wait_for_channel_inbox_events(
     poll_interval = _channel_long_poll_interval(poll_interval_seconds)
     deadline = monotonic() + timeout
     while True:
-        events = await dequeue_channel_inbox_events(
-            db,
-            account=account,
-            bot_agent_link_id=bot_agent_link_id,
-            after_sequence=after_sequence,
-            limit=limit,
-        )
+        async with sessionmaker() as db:
+            events = await dequeue_channel_inbox_events(
+                db,
+                account_id=account_id,
+                bot_agent_link_id=bot_agent_link_id,
+                after_sequence=after_sequence,
+                limit=limit,
+            )
+            await db.commit()
         if events or timeout == 0 or monotonic() >= deadline:
             return events
         await asyncio.sleep(min(poll_interval, max(0.0, deadline - monotonic())))

--- a/backend/app/services/discord_gateway_worker.py
+++ b/backend/app/services/discord_gateway_worker.py
@@ -91,6 +91,7 @@ class _GatewayState:
     heartbeat_acknowledged: bool = True
     session_id: str | None = None
     resume_gateway_url: str | None = None
+    account_revision: str | None = None
 
     def can_resume(self) -> bool:
         return self.sequence is not None and bool(self.session_id) and bool(self.resume_gateway_url)
@@ -120,12 +121,13 @@ class DiscordGatewayWorker:
         self._reconnect_max_seconds = reconnect_max_seconds
         self._connect_factory = connect_factory
         self._tasks: dict[UUID, asyncio.Task[None]] = {}
+        self._terminal_account_revisions: dict[UUID, str] = {}
 
     async def run_once(self, stop: asyncio.Event | None = None) -> int:
-        account_ids = await list_active_discord_gateway_account_ids(self._sessionmaker)
+        accounts = await list_active_discord_gateway_accounts(self._sessionmaker)
         stop_event = stop or asyncio.Event()
-        self._sync_tasks(account_ids, stop_event)
-        return len(account_ids)
+        self._sync_tasks(accounts, stop_event)
+        return len(accounts)
 
     async def run_forever(self, stop: asyncio.Event | None = None) -> None:
         stop_event = stop or asyncio.Event()
@@ -148,18 +150,30 @@ class DiscordGatewayWorker:
         if self._tasks:
             await asyncio.gather(*self._tasks.values(), return_exceptions=True)
         self._tasks.clear()
+        self._terminal_account_revisions.clear()
 
-    def _sync_tasks(self, active_account_ids: list[UUID], stop: asyncio.Event) -> None:
-        active = set(active_account_ids)
+    def _sync_tasks(
+        self,
+        active_accounts: dict[UUID, str],
+        stop: asyncio.Event,
+    ) -> None:
+        active = set(active_accounts)
         for account_id, task in list(self._tasks.items()):
             if task.done():
                 self._observe_done_task(account_id, task)
                 self._tasks.pop(account_id, None)
             elif account_id not in active:
                 task.cancel()
-        for account_id in active_account_ids:
+        for account_id in set(self._terminal_account_revisions) - active:
+            self._terminal_account_revisions.pop(account_id, None)
+        for account_id, revision in active_accounts.items():
             if account_id in self._tasks:
                 continue
+            terminal_revision = self._terminal_account_revisions.get(account_id)
+            if terminal_revision == revision:
+                continue
+            if terminal_revision is not None:
+                self._terminal_account_revisions.pop(account_id, None)
             self._tasks[account_id] = asyncio.create_task(
                 self._run_account_forever(account_id, stop),
                 name=f"discord-gateway-{account_id}",
@@ -187,8 +201,9 @@ class DiscordGatewayWorker:
                         account_id,
                         close_code,
                     )
-                    await _sleep_until_stop(stop, self._reconnect_max_seconds)
-                    continue
+                    if state.account_revision is not None:
+                        self._terminal_account_revisions[account_id] = state.account_revision
+                    return
                 log.warning("discord gateway account %s disconnected: %s", account_id, exc)
             except Exception as exc:
                 # Gateway workers must reconnect after transport and protocol faults.
@@ -222,6 +237,7 @@ class DiscordGatewayWorker:
         account = await load_discord_gateway_account(self._sessionmaker, account_id)
         if account is None:
             return
+        state.account_revision = discord_gateway_account_revision(account)
         try:
             token = decrypt_provider_token(account)
         except HTTPException as exc:
@@ -345,9 +361,9 @@ class DiscordGatewayWorker:
                 log.error("discord gateway task %s exited: %s", account_id, exc)
 
 
-async def list_active_discord_gateway_account_ids(
+async def list_active_discord_gateway_accounts(
     sessionmaker: async_sessionmaker[AsyncSession],
-) -> list[UUID]:
+) -> dict[UUID, str]:
     async with sessionmaker() as db:
         result = await db.execute(
             select(ChannelAccount)
@@ -361,7 +377,11 @@ async def list_active_discord_gateway_account_ids(
             .order_by(ChannelAccount.created_at, ChannelAccount.id)
         )
         accounts = result.scalars().all()
-        return [account.id for account in accounts if discord_gateway_enabled(account)]
+        return {
+            account.id: discord_gateway_account_revision(account)
+            for account in accounts
+            if discord_gateway_enabled(account)
+        }
 
 
 async def load_discord_gateway_account(
@@ -585,6 +605,20 @@ def discord_gateway_intents(account: ChannelAccount) -> int:
 def discord_gateway_enabled(account: ChannelAccount) -> bool:
     value = _account_config_value(account, "gateway_enabled")
     return value is not False
+
+
+def discord_gateway_account_revision(account: ChannelAccount) -> str:
+    """Fingerprint the credentials and configuration that drive one Gateway session."""
+
+    config = account.config if isinstance(account.config, dict) else {}
+    material = b"\0".join(
+        (
+            account.encrypted_provider_token or b"",
+            account.provider_token_nonce or b"",
+            json.dumps(config, sort_keys=True, separators=(",", ":")).encode("utf-8"),
+        )
+    )
+    return hashlib.sha256(material).hexdigest()
 
 
 def parse_gateway_frame(raw_frame: str | bytes) -> GatewayFrame | None:

--- a/backend/app/services/metrics.py
+++ b/backend/app/services/metrics.py
@@ -44,6 +44,12 @@ ingress_errors = Counter(
     ["channel", "bot_id"],
     registry=registry,
 )
+provider_ingress_terminal_events = Counter(
+    "msg_router_provider_ingress_terminal_events_total",
+    "Provider ingress events terminally acknowledged without durable admission",
+    ["channel", "reason"],
+    registry=registry,
+)
 proxy_latency = Histogram(
     "msg_router_proxy_latency_seconds",
     "Outbound proxy request latency in seconds",

--- a/backend/app/services/whatsapp_native_transport.py
+++ b/backend/app/services/whatsapp_native_transport.py
@@ -34,6 +34,10 @@ _PROVIDER_EVENTS_PATH = "/v1/provider-events"
 _PROVIDER_EVENTS_ACK_PATH = "/v1/provider-events/ack"
 _PROVIDER_EVENTS_MAX_WAIT_MS = 8_000
 _PROVIDER_EVENTS_READ_TIMEOUT_SECONDS = 10.0
+_MAX_PROVIDER_EVENTS_JSON_BYTES = 8 * 1024 * 1024
+_MAX_PROVIDER_EVENT_ID_LENGTH = 300
+_MAX_PROVIDER_EVENT_NAME_LENGTH = 4096
+_MAX_PROVIDER_EVENT_PROTO_BASE64_LENGTH = 4 * 1024 * 1024
 _JSON_VALUE_ADAPTER: TypeAdapter[JsonValue] = TypeAdapter(JsonValue)
 
 type _NativeNodeValue = (
@@ -137,6 +141,15 @@ class WhatsAppProviderMessageEvent:
     push_name: str | None
     message_timestamp: int | None
     message_proto: bytes
+
+
+@dataclass(frozen=True)
+class WhatsAppRejectedProviderEvent:
+    sequence: int
+    reason: Literal["invalid_schema", "identity_too_long", "payload_too_large"]
+
+
+type WhatsAppProviderEvent = WhatsAppProviderMessageEvent | WhatsAppRejectedProviderEvent
 
 
 @dataclass(frozen=True)
@@ -415,7 +428,7 @@ class WhatsAppBaileysSidecarClient:
         *,
         limit: int = 100,
         wait_ms: int = 0,
-    ) -> list[WhatsAppProviderMessageEvent]:
+    ) -> list[WhatsAppProviderEvent]:
         if not 0 <= wait_ms <= _PROVIDER_EVENTS_MAX_WAIT_MS:
             raise ValueError("baileys provider events wait must be between 0 and 8000 milliseconds")
         response = await self._request(
@@ -424,6 +437,8 @@ class WhatsAppBaileysSidecarClient:
             params={"limit": limit, "waitMs": wait_ms},
             timeout=httpx.Timeout(_PROVIDER_EVENTS_READ_TIMEOUT_SECONDS),
         )
+        if len(response.content) > _MAX_PROVIDER_EVENTS_JSON_BYTES:
+            raise WhatsAppSidecarProtocolError("Baileys provider events response too large")
         data = _response_json(response)
         if not isinstance(data, dict):
             raise ValueError("baileys provider events response must contain an event list")
@@ -803,49 +818,65 @@ def _pairing_status(value: Mapping[str, JsonValue]) -> WhatsAppSidecarPairingSta
     )
 
 
-def _provider_message_event(value: JsonValue) -> WhatsAppProviderMessageEvent:
+def _provider_message_event(value: JsonValue) -> WhatsAppProviderEvent:
     if not isinstance(value, dict):
-        raise ValueError("baileys provider event must be an object")
+        raise WhatsAppSidecarProtocolError("Baileys provider event has no sequence")
     sequence = value.get("sequence")
     if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 1:
-        raise ValueError("baileys provider event sequence must be positive")
+        raise WhatsAppSidecarProtocolError("Baileys provider event has no sequence")
     if value.get("eventType") != "messages.upsert" or value.get("fromMe") is not False:
-        raise ValueError("unsupported baileys provider event")
-    message_id = _required_event_str(value, "messageId")
-    remote_jid = _required_event_str(value, "remoteJid")
-    raw_proto = _required_event_str(value, "messageProtoBase64")
+        return WhatsAppRejectedProviderEvent(sequence=sequence, reason="invalid_schema")
+    message_id = _event_str(value, "messageId")
+    remote_jid = _event_str(value, "remoteJid")
+    raw_proto = _event_str(value, "messageProtoBase64")
+    if message_id is None or remote_jid is None or raw_proto is None:
+        return WhatsAppRejectedProviderEvent(sequence=sequence, reason="invalid_schema")
+    if any(len(item) > _MAX_PROVIDER_EVENT_ID_LENGTH for item in (message_id, remote_jid)):
+        return WhatsAppRejectedProviderEvent(sequence=sequence, reason="identity_too_long")
+    if len(raw_proto) > _MAX_PROVIDER_EVENT_PROTO_BASE64_LENGTH:
+        return WhatsAppRejectedProviderEvent(sequence=sequence, reason="payload_too_large")
     try:
         message_proto = base64.b64decode(raw_proto, validate=True)
-    except ValueError as exc:
-        raise ValueError("baileys provider event proto must be base64") from exc
+    except ValueError:
+        return WhatsAppRejectedProviderEvent(sequence=sequence, reason="invalid_schema")
     if not message_proto:
-        raise ValueError("baileys provider event proto must not be empty")
+        return WhatsAppRejectedProviderEvent(sequence=sequence, reason="invalid_schema")
     timestamp = value.get("messageTimestamp")
     if timestamp is not None and (
         isinstance(timestamp, bool) or not isinstance(timestamp, int) or timestamp < 1
     ):
-        raise ValueError("baileys provider event timestamp must be positive")
+        return WhatsAppRejectedProviderEvent(sequence=sequence, reason="invalid_schema")
+    optional_identity_keys = ("remoteJidAlt", "participant", "participantAlt")
+    optional_identities = tuple(_event_str(value, key) for key in optional_identity_keys)
+    if any(
+        value.get(key) is not None and item is None
+        for key, item in zip(optional_identity_keys, optional_identities, strict=True)
+    ):
+        return WhatsAppRejectedProviderEvent(sequence=sequence, reason="invalid_schema")
+    if any(
+        item is not None and len(item) > _MAX_PROVIDER_EVENT_ID_LENGTH
+        for item in optional_identities
+    ):
+        return WhatsAppRejectedProviderEvent(sequence=sequence, reason="identity_too_long")
+    push_name = _event_str(value, "pushName")
+    if value.get("pushName") is not None and push_name is None:
+        return WhatsAppRejectedProviderEvent(sequence=sequence, reason="invalid_schema")
+    if push_name is not None and len(push_name) > _MAX_PROVIDER_EVENT_NAME_LENGTH:
+        return WhatsAppRejectedProviderEvent(sequence=sequence, reason="identity_too_long")
     return WhatsAppProviderMessageEvent(
         sequence=sequence,
         message_id=message_id,
         remote_jid=remote_jid,
-        remote_jid_alt=_optional_event_str(value, "remoteJidAlt"),
-        participant=_optional_event_str(value, "participant"),
-        participant_alt=_optional_event_str(value, "participantAlt"),
-        push_name=_optional_event_str(value, "pushName"),
+        remote_jid_alt=optional_identities[0],
+        participant=optional_identities[1],
+        participant_alt=optional_identities[2],
+        push_name=push_name,
         message_timestamp=timestamp,
         message_proto=message_proto,
     )
 
 
-def _required_event_str(value: Mapping[str, JsonValue], key: str) -> str:
-    item = _optional_event_str(value, key)
-    if item is None:
-        raise ValueError(f"baileys provider event {key} is required")
-    return item
-
-
-def _optional_event_str(value: Mapping[str, JsonValue], key: str) -> str | None:
+def _event_str(value: Mapping[str, JsonValue], key: str) -> str | None:
     item = value.get(key)
     return item if isinstance(item, str) and item else None
 

--- a/backend/app/services/whatsapp_provider_bridge.py
+++ b/backend/app/services/whatsapp_provider_bridge.py
@@ -459,7 +459,9 @@ async def persist_whatsapp_provider_event(
     route_jid = choose_whatsapp_route_jid(remote_jid, alt_jid)
     external_chat_id = route_jid
     external_chat_type = "group" if route_jid.endswith("@g.us") else "dm"
-    external_chat_name = event.push_name
+    # The provider payload below retains the full pushName. Channel bindings
+    # use a bounded display label, matching their VARCHAR(300) schema.
+    external_chat_name = event.push_name[:300] if event.push_name is not None else None
     binding_lookup = await resolve_whatsapp_binding_by_jids(
         db,
         account=account,

--- a/backend/app/services/whatsapp_sidecar_registry.py
+++ b/backend/app/services/whatsapp_sidecar_registry.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable
-from typing import Protocol
+from typing import Literal, Protocol
 from uuid import UUID
 
 from sqlalchemy import select
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import async_session_factory
@@ -19,6 +20,7 @@ from app.models.channel import (
     ChannelAccount,
     ChannelWhatsAppOnboardingSession,
 )
+from app.services.metrics import provider_ingress_terminal_events
 from app.services.whatsapp_delivery_transport import (
     DEFAULT_WHATSAPP_SIDECAR_SOCKET_PATH,
     configured_whatsapp_sidecar_session_id,
@@ -28,8 +30,9 @@ from app.services.whatsapp_native_transport import (
     WhatsAppBaileysSidecarConfig,
     WhatsAppBaileysSidecarService,
     WhatsAppNativeUpstreamClient,
-    WhatsAppProviderMessageEvent,
+    WhatsAppProviderEvent,
     WhatsAppProviderTransportAdapter,
+    WhatsAppRejectedProviderEvent,
     WhatsAppSidecarCapabilities,
     WhatsAppSidecarError,
     WhatsAppSidecarHealth,
@@ -51,6 +54,37 @@ _UNRELEASED_STATES = (
     WHATSAPP_ONBOARDING_STATE_ERROR,
 )
 _PROVIDER_EVENTS_WAIT_MS = 8_000
+_PROVIDER_INGRESS_RETRY_INITIAL_SECONDS = 1.0
+_PROVIDER_INGRESS_RETRY_MAX_SECONDS = 60.0
+_PROVIDER_INGRESS_EMPTY_POLL_DELAY_SECONDS = 0.1
+type _TerminalProviderEventReason = Literal[
+    "invalid_schema",
+    "identity_too_long",
+    "payload_too_large",
+    "persistence_data_error",
+]
+
+
+def _record_terminal_provider_event(
+    account_id: UUID,
+    *,
+    sequence: int,
+    reason: _TerminalProviderEventReason,
+) -> None:
+    provider_ingress_terminal_events.labels(channel="whatsapp", reason=reason).inc()
+    log.error(
+        "WhatsApp provider ingress terminally acknowledged account=%s sequence=%s reason=%s",
+        account_id,
+        sequence,
+        reason,
+    )
+
+
+def _is_terminal_provider_data_error(exc: DBAPIError) -> bool:
+    # asyncpg's SQLAlchemy adapter maps Postgres data exceptions through its
+    # generic DBAPI Error. SQLSTATE 22001 is the deterministic varchar overflow
+    # observed in production; other DB failures must remain retryable.
+    return getattr(exc.orig, "sqlstate", None) == "22001"
 
 
 class WhatsAppSidecarClient(WhatsAppNativeUpstreamClient, Protocol):
@@ -65,7 +99,7 @@ class WhatsAppSidecarClient(WhatsAppNativeUpstreamClient, Protocol):
         *,
         limit: int = 100,
         wait_ms: int = 0,
-    ) -> list[WhatsAppProviderMessageEvent]: ...
+    ) -> list[WhatsAppProviderEvent]: ...
 
     async def acknowledge_provider_events(self, *, through_sequence: int) -> None: ...
 
@@ -578,25 +612,47 @@ class ConfiguredWhatsAppSidecarRegistry:
         account_id: UUID,
         client: WhatsAppSidecarClient,
     ) -> None:
+        retry_seconds = _PROVIDER_INGRESS_RETRY_INITIAL_SECONDS
         while True:
             try:
                 events = await client.provider_events(
-                    limit=100,
+                    # The sidecar acknowledgement cursor is ordered. Pull one
+                    # event so a terminally bad row can be acknowledged without
+                    # accidentally skipping an unprocessed later row.
+                    limit=1,
                     wait_ms=_PROVIDER_EVENTS_WAIT_MS,
                 )
                 if not events:
                     # A compatible older endpoint may ignore wait_ms and return
-                    # immediately. Yield without reintroducing timed polling.
-                    await asyncio.sleep(0)
+                    # immediately. Keep that endpoint from becoming a busy loop.
+                    await asyncio.sleep(_PROVIDER_INGRESS_EMPTY_POLL_DELAY_SECONDS)
+                    retry_seconds = _PROVIDER_INGRESS_RETRY_INITIAL_SECONDS
                     continue
-                for event in events:
-                    async with async_session_factory() as db:
-                        await persist_whatsapp_provider_event(
-                            db,
-                            account_id=account_id,
-                            event=event,
+                event = events[0]
+                if isinstance(event, WhatsAppRejectedProviderEvent):
+                    _record_terminal_provider_event(
+                        account_id,
+                        sequence=event.sequence,
+                        reason=event.reason,
+                    )
+                else:
+                    try:
+                        async with async_session_factory() as db:
+                            await persist_whatsapp_provider_event(
+                                db,
+                                account_id=account_id,
+                                event=event,
+                            )
+                    except DBAPIError as exc:
+                        if not _is_terminal_provider_data_error(exc):
+                            raise
+                        _record_terminal_provider_event(
+                            account_id,
+                            sequence=event.sequence,
+                            reason="persistence_data_error",
                         )
-                    await client.acknowledge_provider_events(through_sequence=event.sequence)
+                await client.acknowledge_provider_events(through_sequence=event.sequence)
+                retry_seconds = _PROVIDER_INGRESS_RETRY_INITIAL_SECONDS
             except asyncio.CancelledError:
                 raise
             except WhatsAppProviderAccountRetired:
@@ -607,7 +663,11 @@ class ConfiguredWhatsAppSidecarRegistry:
                 return
             except Exception:
                 log.exception("WhatsApp provider ingress pump failed for account %s", account_id)
-                await asyncio.sleep(1.0)
+                await asyncio.sleep(retry_seconds)
+                retry_seconds = min(
+                    retry_seconds * 2,
+                    _PROVIDER_INGRESS_RETRY_MAX_SECONDS,
+                )
 
     def _client(self, session_id: UUID) -> WhatsAppSidecarClient | None:
         if not self._started or not self.enabled:

--- a/backend/tests/test_channel_inbox.py
+++ b/backend/tests/test_channel_inbox.py
@@ -5,9 +5,10 @@ from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+import app.services.channels as channel_service
 from app.models.channel import (
     CHANNEL_PROVIDER_DISCORD,
     CHANNEL_PROVIDER_TELEGRAM,
@@ -128,7 +129,7 @@ async def test_channel_inbox_assigns_monotonic_sequences_and_dequeues_by_account
 
     events = await dequeue_channel_inbox_events(
         db_session,
-        account=account,
+        account_id=account.id,
         after_sequence=0,
         limit=100,
     )
@@ -136,7 +137,7 @@ async def test_channel_inbox_assigns_monotonic_sequences_and_dequeues_by_account
 
     after_first = await dequeue_channel_inbox_events(
         db_session,
-        account=account,
+        account_id=account.id,
         after_sequence=first.inbox_sequence,
         limit=100,
     )
@@ -144,7 +145,7 @@ async def test_channel_inbox_assigns_monotonic_sequences_and_dequeues_by_account
 
     limited = await dequeue_channel_inbox_events(
         db_session,
-        account=account,
+        account_id=account.id,
         after_sequence=0,
         limit=1,
     )
@@ -188,7 +189,7 @@ async def test_channel_inbox_ack_marks_events_through_sequence_for_account_only(
     )
     remaining = await dequeue_channel_inbox_events(
         db_session,
-        account=account,
+        account_id=account.id,
         after_sequence=0,
         limit=100,
     )
@@ -534,7 +535,7 @@ async def test_telegram_inbox_uses_update_id_offset_and_drains_filtered_updates(
 
     updates = await dequeue_telegram_updates(
         db_session,
-        account=account,
+        account_id=account.id,
         offset=101,
         limit=100,
         allowed_updates={"callback_query"},
@@ -559,7 +560,7 @@ async def test_telegram_inbox_uses_update_id_offset_and_drains_filtered_updates(
     assert (
         await dequeue_telegram_updates(
             db_session,
-            account=account,
+            account_id=account.id,
             offset=106,
             limit=100,
         )
@@ -603,7 +604,7 @@ async def test_telegram_inbox_terminally_consumes_updates_older_than_official_re
 
     updates = await dequeue_telegram_updates(
         db_session,
-        account=account,
+        account_id=account.id,
         offset=None,
         limit=100,
     )
@@ -631,23 +632,97 @@ async def test_channel_inbox_wait_polls_until_new_committed_event(
     await db_session.commit()
     sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
 
-    async with sessionmaker() as wait_session:
-        wait_account = await wait_session.get(ChannelAccount, account.id)
-        assert wait_account is not None
+    pending = asyncio.create_task(
+        wait_for_channel_inbox_events(
+            sessionmaker,
+            account_id=account.id,
+            after_sequence=0,
+            limit=10,
+            timeout_seconds=1,
+            poll_interval_seconds=0.005,
+        )
+    )
+
+    await asyncio.sleep(0.01)
+    await _add_message(db_session, account=account, binding=binding, text="delayed")
+    await db_session.commit()
+    events = await pending
+
+    assert [event.text for event in events] == ["delayed"]
+
+
+@pytest.mark.asyncio
+async def test_telegram_wait_has_no_transaction_during_sleep_or_after_cancellation(
+    engine,
+    db_session: AsyncSession,
+    seed_user: User,
+    channel_agent: AgentEnvironment,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    account, _binding = await _create_account_and_binding(
+        db_session,
+        user=seed_user,
+        agent=channel_agent,
+        provider=CHANNEL_PROVIDER_TELEGRAM,
+        chat_id="telegram-cancelled-wait",
+    )
+    account_id = account.id
+    await db_session.commit()
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    first_poll_finished = asyncio.Event()
+    poll_backend_pid: int | None = None
+    original_dequeue = channel_service.dequeue_telegram_updates
+
+    async def observed_dequeue(db: AsyncSession, **kwargs):
+        nonlocal poll_backend_pid
+        pid = await db.scalar(select(func.pg_backend_pid()))
+        assert isinstance(pid, int)
+        poll_backend_pid = pid
+        updates = await original_dequeue(db, **kwargs)
+        first_poll_finished.set()
+        return updates
+
+    monkeypatch.setattr(channel_service, "dequeue_telegram_updates", observed_dequeue)
+    async with engine.connect() as observer:
         pending = asyncio.create_task(
-            wait_for_channel_inbox_events(
-                wait_session,
-                account=wait_account,
-                after_sequence=0,
-                limit=10,
-                timeout_seconds=1,
-                poll_interval_seconds=0.005,
+            channel_service.wait_for_telegram_updates(
+                sessionmaker,
+                account_id=account_id,
+                offset=None,
+                limit=100,
+                timeout_seconds=30,
+                poll_interval_seconds=30,
             )
         )
 
-        await asyncio.sleep(0.01)
-        await _add_message(db_session, account=account, binding=binding, text="delayed")
-        await db_session.commit()
-        events = await pending
+        async def wait_until_poll_connection_is_idle() -> None:
+            while True:
+                assert poll_backend_pid is not None
+                row = (
+                    await observer.execute(
+                        text(
+                            """
+                            SELECT state, xact_start
+                            FROM pg_stat_activity
+                            WHERE pid = :backend_pid
+                            """
+                        ),
+                        {"backend_pid": poll_backend_pid},
+                    )
+                ).one()
+                await observer.rollback()
+                if row.state == "idle" and row.xact_start is None:
+                    return
+                await asyncio.sleep(0.01)
 
-    assert [event.text for event in events] == ["delayed"]
+        try:
+            await asyncio.wait_for(first_poll_finished.wait(), timeout=2)
+            await asyncio.wait_for(wait_until_poll_connection_is_idle(), timeout=2)
+            pending.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await pending
+            await asyncio.wait_for(wait_until_poll_connection_is_idle(), timeout=2)
+        finally:
+            if not pending.done():
+                pending.cancel()
+                await asyncio.gather(pending, return_exceptions=True)

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -5543,55 +5543,49 @@ async def test_telegram_get_updates_wait_helper_sees_new_committed_update(
     )
     sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
 
-    async with sessionmaker() as wait_session:
-        account = (
-            await wait_session.execute(
-                select(ChannelAccount).where(ChannelAccount.id == UUID(created["id"]))
+    pending = asyncio.create_task(
+        wait_for_telegram_updates(
+            sessionmaker,
+            account_id=UUID(created["id"]),
+            offset=2,
+            limit=100,
+            timeout_seconds=1,
+            poll_interval_seconds=0.005,
+        )
+    )
+    await asyncio.sleep(0.01)
+    async with sessionmaker() as insert_session:
+        binding = (
+            await insert_session.execute(
+                select(ChannelBinding).where(
+                    ChannelBinding.account_id == UUID(created["id"]),
+                    ChannelBinding.external_chat_id == "222",
+                )
             )
         ).scalar_one()
-        pending = asyncio.create_task(
-            wait_for_telegram_updates(
-                wait_session,
-                account=account,
-                offset=2,
-                limit=100,
-                timeout_seconds=1,
-                poll_interval_seconds=0.005,
+        insert_session.add(
+            ChannelMessage(
+                account_id=binding.account_id,
+                bot_agent_link_id=binding.bot_agent_link_id,
+                binding_id=binding.id,
+                user_id=binding.user_id,
+                direction=MESSAGE_DIRECTION_INBOUND,
+                external_chat_id="222",
+                provider_message_id="2",
+                text="arrived during long poll",
+                payload={
+                    "update_id": 2,
+                    "message": {
+                        "message_id": 2,
+                        "text": "arrived during long poll",
+                        "chat": {"id": 222, "type": "private"},
+                    },
+                },
             )
         )
-        await asyncio.sleep(0.01)
-        async with sessionmaker() as insert_session:
-            binding = (
-                await insert_session.execute(
-                    select(ChannelBinding).where(
-                        ChannelBinding.account_id == UUID(created["id"]),
-                        ChannelBinding.external_chat_id == "222",
-                    )
-                )
-            ).scalar_one()
-            insert_session.add(
-                ChannelMessage(
-                    account_id=binding.account_id,
-                    bot_agent_link_id=binding.bot_agent_link_id,
-                    binding_id=binding.id,
-                    user_id=binding.user_id,
-                    direction=MESSAGE_DIRECTION_INBOUND,
-                    external_chat_id="222",
-                    provider_message_id="2",
-                    text="arrived during long poll",
-                    payload={
-                        "update_id": 2,
-                        "message": {
-                            "message_id": 2,
-                            "text": "arrived during long poll",
-                            "chat": {"id": 222, "type": "private"},
-                        },
-                    },
-                )
-            )
-            await insert_session.commit()
+        await insert_session.commit()
 
-        updates = await pending
+    updates = await pending
 
     assert updates == [
         {

--- a/backend/tests/test_discord_gateway_websockets.py
+++ b/backend/tests/test_discord_gateway_websockets.py
@@ -4,13 +4,14 @@ import asyncio
 import json
 from dataclasses import dataclass
 from urllib.parse import parse_qs, urlsplit
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 from websockets.asyncio.server import ServerConnection, serve
 from websockets.exceptions import ConnectionClosedError
 
+import app.services.discord_gateway_worker as discord_gateway_worker_module
 from app.services.discord_gateway_worker import (
     DiscordGatewayWorker,
     GatewayFrame,
@@ -32,6 +33,86 @@ class _ObservedGatewayExchange:
 
 def _gateway_json(frame: GatewayFrame) -> str:
     return json.dumps(frame, separators=(",", ":"))
+
+
+@pytest.mark.asyncio
+async def test_terminal_discord_auth_close_waits_for_account_revision_change(
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = UUID("00000000-0000-4000-8000-000000000907")
+    worker = DiscordGatewayWorker(
+        async_sessionmaker(engine, expire_on_commit=False),
+        lock_engine=engine,
+    )
+    attempts = 0
+    rearmed = asyncio.Event()
+
+    async def run_account(_account_id, _stop, state):
+        nonlocal attempts
+        attempts += 1
+        state.account_revision = f"revision-{attempts}"
+        if attempts == 1:
+            raise ConnectionClosedError(None, None, None)
+        rearmed.set()
+        await asyncio.Future()
+
+    monkeypatch.setattr(worker, "_run_account_with_lock", run_account)
+    monkeypatch.setattr(
+        discord_gateway_worker_module, "discord_gateway_close_code", lambda _exc: 4004
+    )
+    stop = asyncio.Event()
+
+    worker._sync_tasks({account_id: "revision-1"}, stop)
+    first_task = worker._tasks[account_id]
+    await asyncio.wait_for(first_task, timeout=1)
+    worker._sync_tasks({account_id: "revision-1"}, stop)
+
+    assert attempts == 1
+    assert account_id not in worker._tasks
+    assert worker._terminal_account_revisions == {account_id: "revision-1"}
+
+    worker._sync_tasks({account_id: "revision-2"}, stop)
+    try:
+        await asyncio.wait_for(rearmed.wait(), timeout=1)
+        assert attempts == 2
+        assert worker._terminal_account_revisions == {}
+    finally:
+        await worker.stop()
+
+
+@pytest.mark.asyncio
+async def test_transient_discord_gateway_failures_use_bounded_exponential_backoff(
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worker = DiscordGatewayWorker(
+        async_sessionmaker(engine, expire_on_commit=False),
+        lock_engine=engine,
+        reconnect_initial_seconds=1,
+        reconnect_max_seconds=4,
+    )
+    stop = asyncio.Event()
+    attempts = 0
+    delays: list[float] = []
+
+    async def run_account(_account_id, _stop, _state):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 5:
+            stop.set()
+            return True
+        raise OSError("temporary DNS failure")
+
+    async def record_delay(_stop, timeout_seconds: float) -> None:
+        delays.append(timeout_seconds)
+
+    monkeypatch.setattr(worker, "_run_account_with_lock", run_account)
+    monkeypatch.setattr(discord_gateway_worker_module, "_sleep_until_stop", record_delay)
+
+    await worker._run_account_forever(uuid4(), stop)
+
+    assert delays == [1, 2, 4, 4, 1]
 
 
 @pytest.mark.parametrize("resume", [False, True], ids=["identify", "resume"])

--- a/backend/tests/test_whatsapp_native_transport.py
+++ b/backend/tests/test_whatsapp_native_transport.py
@@ -18,7 +18,9 @@ from app.services.whatsapp_native_transport import (
     WhatsAppBaileysSidecarService,
     WhatsAppNativeRelayRequest,
     WhatsAppProviderTransportAdapter,
+    WhatsAppRejectedProviderEvent,
     WhatsAppSidecarUnavailableError,
+    _provider_message_event,
     _sidecar_account_lid,
     whatsapp_phone_number_from_pn_jid,
 )
@@ -353,6 +355,34 @@ def test_whatsapp_phone_number_requires_strict_pn_jid(
     phone_number: str | None,
 ) -> None:
     assert whatsapp_phone_number_from_pn_jid(account_jid) == phone_number
+
+
+@pytest.mark.parametrize(
+    ("override", "reason"),
+    [
+        ({"remoteJid": "x" * 301}, "identity_too_long"),
+        ({"pushName": "x" * 4097}, "identity_too_long"),
+        ({"messageProtoBase64": "not-base64"}, "invalid_schema"),
+    ],
+)
+def test_whatsapp_provider_event_with_sequence_is_terminally_rejected_at_boundary(
+    override: dict[str, object],
+    reason: str,
+) -> None:
+    value = {
+        "sequence": 9,
+        "eventType": "messages.upsert",
+        "fromMe": False,
+        "messageId": "provider-9",
+        "remoteJid": "15551112222@s.whatsapp.net",
+        "messageProtoBase64": "CgVoZWxsbw==",
+        **override,
+    }
+
+    assert _provider_message_event(value) == WhatsAppRejectedProviderEvent(
+        sequence=9,
+        reason=reason,
+    )
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_whatsapp_provider_bridge.py
+++ b/backend/tests/test_whatsapp_provider_bridge.py
@@ -1244,7 +1244,8 @@ async def test_whatsapp_provider_ingress_preserves_proto_aliases_and_account_ded
         name="wa-provider-ingress",
     )
     lid_jid = "7826185388106@lid"
-    message_proto = whatsapp_text_message_proto("hello from physical provider")
+    text = "x" * 5_000
+    message_proto = whatsapp_text_message_proto(text)
     event = WhatsAppProviderMessageEvent(
         sequence=1,
         message_id="physical-inbound-1",
@@ -1282,7 +1283,7 @@ async def test_whatsapp_provider_ingress_preserves_proto_aliases_and_account_ded
     assert messages[0].direction == MESSAGE_DIRECTION_INBOUND
     assert messages[0].binding_id == binding.id
     assert messages[0].external_chat_id == binding.external_chat_id
-    assert messages[0].text == "hello from physical provider"
+    assert messages[0].text == text
     assert messages[0].payload["messageProtoBase64"] == base64.b64encode(message_proto).decode(
         "ascii"
     )

--- a/backend/tests/test_whatsapp_sidecar_registry.py
+++ b/backend/tests/test_whatsapp_sidecar_registry.py
@@ -4,6 +4,7 @@ import asyncio
 from uuid import UUID
 
 import pytest
+from sqlalchemy.exc import DBAPIError
 
 import app.services.whatsapp_delivery_transport as delivery_transport_module
 import app.services.whatsapp_sidecar_registry as sidecar_registry_module
@@ -11,6 +12,7 @@ from app.services.whatsapp_delivery_transport import resolve_whatsapp_delivery_t
 from app.services.whatsapp_native_transport import (
     WhatsAppBaileysSidecarConfig,
     WhatsAppProviderMessageEvent,
+    WhatsAppRejectedProviderEvent,
 )
 from app.services.whatsapp_provider_bridge import (
     WhatsAppProviderAccountRetired,
@@ -19,6 +21,10 @@ from app.services.whatsapp_provider_bridge import (
 from app.services.whatsapp_sidecar_registry import (
     ConfiguredWhatsAppSidecarRegistry,
 )
+
+
+class _StringDataRightTruncationError(ValueError):
+    sqlstate = "22001"
 
 
 class _FakeSidecarClient:
@@ -31,7 +37,7 @@ class _FakeSidecarClient:
         self.closed = True
 
     async def provider_events(self, *, limit: int = 100, wait_ms: int = 0):
-        assert limit == 100
+        assert limit == 1
         assert wait_ms in {0, 8_000}
         return []
 
@@ -179,7 +185,7 @@ async def test_provider_ingress_ack_waits_until_persistence_returns(monkeypatch)
             self._first_poll = True
 
         async def provider_events(self, *, limit: int = 100, wait_ms: int = 0):
-            assert limit == 100
+            assert limit == 1
             assert wait_ms == 8_000
             if self._first_poll:
                 self._first_poll = False
@@ -211,7 +217,7 @@ async def test_provider_ingress_ack_waits_until_persistence_returns(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_provider_ingress_reissues_long_poll_without_idle_sleep():
+async def test_provider_ingress_bounds_empty_long_poll_retries():
     account_id = UUID("00000000-0000-4000-8000-000000000905")
     second_request = asyncio.Event()
     calls = 0
@@ -220,7 +226,7 @@ async def test_provider_ingress_reissues_long_poll_without_idle_sleep():
         async def provider_events(self, *, limit: int = 100, wait_ms: int = 0):
             nonlocal calls
             calls += 1
-            assert limit == 100
+            assert limit == 1
             assert wait_ms == 8_000
             if calls == 2:
                 second_request.set()
@@ -235,6 +241,163 @@ async def test_provider_ingress_reissues_long_poll_without_idle_sleep():
     try:
         await asyncio.wait_for(second_request.wait(), timeout=1)
         assert calls == 2
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("first_event", "terminal_reason"),
+    [
+        (WhatsAppRejectedProviderEvent(sequence=1, reason="invalid_schema"), "invalid_schema"),
+        (
+            WhatsAppProviderMessageEvent(
+                sequence=1,
+                message_id="provider-invalid-1",
+                remote_jid="15550001111@s.whatsapp.net",
+                remote_jid_alt=None,
+                participant=None,
+                participant_alt=None,
+                push_name=None,
+                message_timestamp=None,
+                message_proto=b"\x0a\x05hello",
+            ),
+            "persistence_data_error",
+        ),
+    ],
+)
+async def test_provider_ingress_terminally_acks_poison_event_then_continues(
+    monkeypatch: pytest.MonkeyPatch,
+    first_event,
+    terminal_reason: str,
+) -> None:
+    account_id = UUID("00000000-0000-4000-8000-000000000906")
+    valid_event = WhatsAppProviderMessageEvent(
+        sequence=2,
+        message_id="provider-valid-2",
+        remote_jid="15550001111@s.whatsapp.net",
+        remote_jid_alt=None,
+        participant=None,
+        participant_alt=None,
+        push_name=None,
+        message_timestamp=None,
+        message_proto=b"\x0a\x05world",
+    )
+    queued = [first_event, valid_event]
+    persisted: list[int] = []
+    acknowledged: list[int] = []
+    terminal: list[tuple[int, str]] = []
+    completed = asyncio.Event()
+
+    class SessionContext:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+    async def persist(_db, *, account_id, event):
+        if event.sequence == 1:
+            raise DBAPIError(
+                "insert",
+                {},
+                _StringDataRightTruncationError("invalid persisted value"),
+                False,
+            )
+        persisted.append(event.sequence)
+
+    class PumpClient:
+        async def provider_events(self, *, limit: int = 100, wait_ms: int = 0):
+            assert limit == 1
+            assert wait_ms == 8_000
+            if queued:
+                return queued[:limit]
+            await asyncio.Future()
+
+        async def acknowledge_provider_events(self, *, through_sequence: int):
+            acknowledged.append(through_sequence)
+            queued[:] = [event for event in queued if event.sequence > through_sequence]
+            if through_sequence == 2:
+                completed.set()
+
+    def record_terminal(_account_id, *, sequence: int, reason: str) -> None:
+        terminal.append((sequence, reason))
+
+    monkeypatch.setattr(sidecar_registry_module, "async_session_factory", lambda: SessionContext())
+    monkeypatch.setattr(sidecar_registry_module, "persist_whatsapp_provider_event", persist)
+    monkeypatch.setattr(sidecar_registry_module, "_record_terminal_provider_event", record_terminal)
+    registry = ConfiguredWhatsAppSidecarRegistry("")
+    task = asyncio.create_task(registry._pump_provider_ingress(account_id, PumpClient()))
+    try:
+        await asyncio.wait_for(completed.wait(), timeout=1)
+        assert acknowledged == [1, 2]
+        assert persisted == [2]
+        assert terminal == [(1, terminal_reason)]
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_provider_ingress_retries_transient_database_error_without_ack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account_id = UUID("00000000-0000-4000-8000-000000000908")
+    event = WhatsAppProviderMessageEvent(
+        sequence=1,
+        message_id="provider-retry-1",
+        remote_jid="15550001111@s.whatsapp.net",
+        remote_jid_alt=None,
+        participant=None,
+        participant_alt=None,
+        push_name=None,
+        message_timestamp=None,
+        message_proto=b"\x0a\x05hello",
+    )
+    persistence_attempts = 0
+    acknowledged: list[int] = []
+    delays: list[float] = []
+    completed = asyncio.Event()
+
+    class SessionContext:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+    async def persist(_db, *, account_id, event):
+        nonlocal persistence_attempts
+        persistence_attempts += 1
+        if persistence_attempts == 1:
+            raise DBAPIError("insert", {}, OSError("database unavailable"), False)
+
+    class PumpClient:
+        async def provider_events(self, *, limit: int = 100, wait_ms: int = 0):
+            assert limit == 1
+            assert wait_ms == 8_000
+            if acknowledged:
+                await asyncio.Future()
+            return [event]
+
+        async def acknowledge_provider_events(self, *, through_sequence: int):
+            acknowledged.append(through_sequence)
+            completed.set()
+
+    async def record_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr(sidecar_registry_module, "async_session_factory", lambda: SessionContext())
+    monkeypatch.setattr(sidecar_registry_module, "persist_whatsapp_provider_event", persist)
+    monkeypatch.setattr(sidecar_registry_module.asyncio, "sleep", record_sleep)
+    registry = ConfiguredWhatsAppSidecarRegistry("")
+    task = asyncio.create_task(registry._pump_provider_ingress(account_id, PumpClient()))
+    try:
+        await asyncio.wait_for(completed.wait(), timeout=1)
+        assert persistence_attempts == 2
+        assert acknowledged == [1]
+        assert delays == [1.0]
     finally:
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)
@@ -284,7 +447,7 @@ async def test_terminal_ingress_releases_local_owner_and_can_reattach(
 
         async def provider_events(self, *, limit=100, wait_ms=0):
             assert wait_ms == 8_000
-            assert limit == 100
+            assert limit == 1
             return [event]
 
         async def acknowledge_provider_events(self, *, through_sequence):


### PR DESCRIPTION
## Summary

- widen `channel_messages.text` to `TEXT` so valid long WhatsApp messages persist in full
- terminally acknowledge sequence-bearing malformed provider events, retry transient failures with bounded exponential backoff, and expose a terminal-event metric
- release Telegram long-poll database transactions before sleeping and use a short session per poll
- stop Discord reconnect loops on terminal close codes until credentials or configuration change

## Production diagnosis

A poison WhatsApp event was failing with SQLSTATE `22001` about 46 times/minute and blocking the ordered sidecar cursor. Telegram long polls accounted for up to 16 `idle in transaction` connections, and a Discord account with close code `4004` continued reconnecting. Host CPU, memory, disk, networking, conntrack, container restarts, and OOM state were otherwise healthy.

## Verification

- `scripts/test.sh backend`: 2371 passed, 12 skipped
- focused ingress regression: 10 passed
- Ruff check and format check: passed
- BasedPyright on 8 changed production modules: 0 errors, 0 warnings
- `git diff --check`: passed
- clean PostgreSQL 18 migration to Alembic head: passed

## Deployment notes

Apply the Alembic migration before the updated ingress pump begins consuming messages. This change deliberately does not add uvicorn workers or increase the connection pool because the WhatsApp registry and background tasks remain process-owned; multi-worker scaling requires explicit cross-process ownership coordination.

Terminal Discord suppression is process-local, so a process restart makes one authentication attempt before the terminal close code suppresses it again.