### PR TITLE
Make user-facing status reflect runtime evidence

### DIFF
--- a/apps/web/src/components/dashboard/daemon-status.test.ts
+++ b/apps/web/src/components/dashboard/daemon-status.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { daemonStatusVisual } from "@/components/dashboard/daemon-status";
+
+function evidence(ageMs: number) {
+	return {
+		sync_enabled: true,
+		last_sync_at: new Date(Date.now() - ageMs).toISOString(),
+		last_sync_error: null,
+	};
+}
+
+describe("daemon runtime observation freshness", () => {
+	test("keeps a heartbeat live across two expected reporting intervals", () => {
+		expect(daemonStatusVisual(evidence(120_000)).kind).toBe("live");
+	});
+
+	test("marks a heartbeat stale after the 150 second evidence window", () => {
+		expect(daemonStatusVisual(evidence(151_000)).kind).toBe("paused");
+	});
+});

--- a/apps/web/src/components/dashboard/daemon-status.tsx
+++ b/apps/web/src/components/dashboard/daemon-status.tsx
@@ -18,8 +18,10 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { cn, relativeTime } from "@/lib/utils";
 
 type Env = components["schemas"]["AgentResponse"];
+type DaemonSyncEvidence = Pick<Env, "sync_enabled" | "last_sync_at" | "last_sync_error">;
 
-const FRESH_WINDOW_MS = 90_000;
+// Runtime reports every 60 +/- 15 seconds. Match the backend's two-interval window.
+const FRESH_WINDOW_MS = 150_000;
 
 export type DaemonStatusKind = "live" | "set-up" | "errored" | "paused";
 export type DaemonStatusSource = "self-managed" | "on-clawdi";
@@ -84,7 +86,7 @@ function isRetryExhaustedError(raw: string | null | undefined): boolean {
 	return typeof raw === "string" && raw.startsWith("retry_exhausted: ");
 }
 
-function classify(env: Env | null | undefined): DaemonStatusKind {
+function classify(env: DaemonSyncEvidence | null | undefined): DaemonStatusKind {
 	if (!env) return "set-up";
 	// Treat "never heartbeated" the same as "sync disabled" from
 	// the user's POV — both mean the daemon isn't running on this
@@ -162,7 +164,7 @@ const DOT_LABEL: Record<DaemonStatusKind, string> = {
 };
 
 export function daemonStatusVisual(
-	env: Env | null | undefined,
+	env: DaemonSyncEvidence | null | undefined,
 	source: DaemonStatusSource = "self-managed",
 ): DaemonStatusVisual {
 	const kind = classify(env);

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -261,7 +261,10 @@ import {
 } from "@/hosted/v2/channels/agent-channel-cards.logic";
 import { CHANNEL_CARD_GRID_CLASS, ChannelCard } from "@/hosted/v2/channels/channel-card";
 import { pairCodeExpiryLabel } from "@/hosted/v2/channels/channel-detail-page.logic";
-import type { AgentChannelLink } from "@/hosted/v2/channels/channel-edit-client.logic";
+import {
+	type AgentChannelLink,
+	linkedChannelConnectionSummary,
+} from "@/hosted/v2/channels/channel-edit-client.logic";
 import {
 	agentProviderLinkReplacementRequired,
 	agentProviderLinkStatusUnknown,
@@ -269,6 +272,7 @@ import {
 import { channelKeys } from "@/hosted/v2/channels/channel-query-cache";
 import {
 	CHANNEL_DESTRUCTIVE_ACTION_CLASS,
+	ChannelRuntimeStatusBadge,
 	ChannelStatusBadge,
 	CopyInline,
 	isNormalChannelStatus,
@@ -1214,8 +1218,7 @@ function OverviewTab({
 	};
 	const billingClient = useBillingClient();
 	const projectBindings = useAgentProjectBindings(agentId, { enabled: Boolean(agent) });
-	const channelLinks = useAgentChannelLinks(agentId, Boolean(agent));
-	const linkedChannelCount = channelLinks.data?.length ?? 0;
+	const channelLinks = useAgentChannelLinks(agentId, Boolean(agent), true);
 	const projectionLoading = projectionStatus === "loading";
 	const projectionUnavailable = projectionStatus !== "resolved" && !projectionLoading;
 	const workspaceProjectId = agent
@@ -1383,10 +1386,10 @@ function OverviewTab({
 								<OverviewDescriptionSkeleton label="channels" />
 							) : projectionUnavailable || channelLinks.error ? (
 								"Unavailable right now"
-							) : linkedChannelCount === 0 ? (
-								"No channels connected"
 							) : (
-								`${linkedChannelCount} connected ${linkedChannelCount === 1 ? "channel" : "channels"}`
+								linkedChannelConnectionSummary(channelLinks.data ?? [], {
+									agentStopped: deploymentStatus.kind === "stopped",
+								})
 							),
 					},
 				}}
@@ -2835,6 +2838,7 @@ function ChannelsTab({
 				account_id: data.account_id,
 				agent_id: data.agent_id,
 				status: data.status,
+				runtime_status: data.runtime_status ?? "connecting",
 				created_at: data.created_at,
 				binding_count: 0,
 			});
@@ -3008,6 +3012,7 @@ function ChannelsTab({
 							account_id: bot.id,
 							agent_id: environmentId,
 							status: "active",
+							runtime_status: "connecting",
 							created_at: new Date().toISOString(),
 							binding_count: 0,
 						}),
@@ -3427,6 +3432,7 @@ function LinkedChannelRow({
 	}
 	const relationshipState = [
 		pairedChatsControl,
+		<ChannelRuntimeStatusBadge key="runtime-status" status={link.runtime_status} />,
 		!isNormalChannelStatus(link.status) ? (
 			<ChannelStatusBadge key="status" status={link.status} />
 		) : null,

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
@@ -4,6 +4,7 @@ import {
 	modelsFromText,
 	providerFormIdentity,
 	providerListAllowsSubmit,
+	runPostSaveProviderConnectionTest,
 	shouldUseCatalogModels,
 } from "@/hosted/v2/ai-providers/add-provider-dialog.logic";
 import { providerPresetSummary } from "@/hosted/v2/ai-providers/model-binding";
@@ -30,6 +31,64 @@ describe("provider list submit gate", () => {
 
 	test("does not block editing an already-loaded provider snapshot", () => {
 		expect(providerListAllowsSubmit(true, false)).toBe(true);
+	});
+});
+
+describe("post-save provider connection test", () => {
+	test("tests a saved managed API key against its first model", async () => {
+		const inputs: unknown[] = [];
+		const result = await runPostSaveProviderConnectionTest(
+			{
+				provider_id: "openai",
+				auth: { type: "api_key", source: "managed" },
+				models: [{ id: "gpt-5" }],
+			},
+			async (input) => {
+				inputs.push(input);
+				return { ok: true, error: null };
+			},
+		);
+
+		expect(inputs).toEqual([
+			{
+				params: { path: { provider_id: "openai" } },
+				body: { model: "gpt-5" },
+			},
+		]);
+		expect(result?.ok).toBe(true);
+	});
+
+	test("keeps a successful save authoritative when its follow-up test fails", async () => {
+		const result = await runPostSaveProviderConnectionTest(
+			{
+				provider_id: "openai",
+				auth: { type: "api_key", source: "managed" },
+				models: null,
+			},
+			async () => {
+				throw new Error("offline");
+			},
+		);
+
+		expect(result).toBeNull();
+	});
+
+	test("does not run the API-key test for OAuth providers", async () => {
+		let called = false;
+		const result = await runPostSaveProviderConnectionTest(
+			{
+				provider_id: "openai-codex",
+				auth: { type: "agent_profile", tool: "codex", profile: "default" },
+				models: [{ id: "gpt-5" }],
+			},
+			async () => {
+				called = true;
+				return { ok: true, error: null };
+			},
+		);
+
+		expect(called).toBe(false);
+		expect(result).toBeNull();
 	});
 });
 

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
@@ -13,6 +13,7 @@ import {
 } from "@/hosted/v2/ai-providers/provider-types";
 import type {
 	AiProvider,
+	AiProviderConnectionTestResponse,
 	AiProviderUpsert,
 	AiProviderUpsertAuth,
 } from "@/hosted/v2/ai-providers/types";
@@ -38,6 +39,30 @@ export function authFor(method: AuthMethod): AiProviderUpsertAuth {
 
 export function providerListAllowsSubmit(isEdit: boolean, listLoaded: boolean): boolean {
 	return isEdit || listLoaded;
+}
+
+export type SavedProviderConnectionTestInput = {
+	params: { path: { provider_id: string } };
+	body: { model?: string };
+};
+
+type SavedProviderConnectionTestResult = Pick<AiProviderConnectionTestResponse, "ok" | "error">;
+
+export async function runPostSaveProviderConnectionTest(
+	provider: Pick<AiProvider, "provider_id" | "auth" | "models">,
+	execute: (input: SavedProviderConnectionTestInput) => Promise<SavedProviderConnectionTestResult>,
+): Promise<SavedProviderConnectionTestResult | null> {
+	if (provider.auth.type !== "api_key" || provider.auth.source !== "managed") return null;
+	const model = provider.models?.[0]?.id;
+	try {
+		return await execute({
+			params: { path: { provider_id: provider.provider_id } },
+			body: model ? { model } : {},
+		});
+	} catch {
+		// Saving is authoritative. A follow-up test failure must not turn it into a failed mutation.
+		return null;
+	}
 }
 
 export function modelsToText(models: ReadonlyArray<{ id: string }> | null | undefined): string {

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -24,6 +24,7 @@ import {
 	modelsToText,
 	providerFormIdentity,
 	providerListAllowsSubmit,
+	runPostSaveProviderConnectionTest,
 } from "@/hosted/v2/ai-providers/add-provider-dialog.logic";
 import {
 	useAcceptProvider,
@@ -32,6 +33,7 @@ import {
 	useOAuthDeviceStart,
 	usePatchProvider,
 	useTestDraftProviderConnection,
+	useTestProviderConnection,
 } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { codexProviderBody } from "@/hosted/v2/ai-providers/codex-oauth";
 import { type ProviderChoice, ProviderChooser } from "@/hosted/v2/ai-providers/provider-chooser";
@@ -82,6 +84,7 @@ export function AddProviderDialog({
 	const acceptProvider = useAcceptProvider();
 	const patchProvider = usePatchProvider();
 	const testDraft = useTestDraftProviderConnection();
+	const testSaved = useTestProviderConnection();
 	const oauthDeviceStart = useOAuthDeviceStart();
 	const oauthDevicePoll = useOAuthDevicePoll();
 	const pollDeviceOAuth = oauthDevicePoll.execute;
@@ -367,6 +370,7 @@ export function AddProviderDialog({
 					.catch(() => null);
 				if (result?.status !== "ready") return;
 				toast.success("Provider updated");
+				await reportPostSaveConnectionTest(result.provider);
 				requestClose(false);
 				return;
 			}
@@ -390,6 +394,7 @@ export function AddProviderDialog({
 				.catch(() => null);
 			if (!saved) return;
 			toast.success("Provider settings updated");
+			await reportPostSaveConnectionTest(saved);
 			requestClose(false);
 			return;
 		}
@@ -412,8 +417,21 @@ export function AddProviderDialog({
 			.catch(() => null);
 		if (result?.status !== "ready") return;
 		toast.success("Provider added");
+		await reportPostSaveConnectionTest(result.provider);
 		onCreated?.(result.provider.provider_id);
 		requestClose(false);
+	}
+
+	async function reportPostSaveConnectionTest(provider: AiProvider) {
+		const result = await runPostSaveProviderConnectionTest(provider, testSaved.mutateAsync);
+		if (!result) return;
+		if (result.ok) {
+			toast.success("Connection verified");
+			return;
+		}
+		toast.warning("Provider saved, but the connection needs attention", {
+			description: providerConnectionIssueMessage(result.error),
+		});
 	}
 
 	async function testDraftConnection() {
@@ -462,6 +480,7 @@ export function AddProviderDialog({
 		acceptProvider.isPending ||
 		patchProvider.isPending ||
 		testDraft.isPending ||
+		testSaved.isPending ||
 		oauthDeviceStart.isPending ||
 		oauthDevicePoll.isPending;
 

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
@@ -28,6 +28,15 @@ export function useAiProviders() {
 	return useOpenApi().useQuery("get", "/v1/ai-providers", {});
 }
 
+export function useProviderRuntimeObserved() {
+	return useOpenApi().useQuery(
+		"get",
+		"/v1/agents/runtime-observed",
+		{},
+		{ refetchInterval: 30_000 },
+	);
+}
+
 export function useUserAiProviders({ enabled = true }: { enabled?: boolean } = {}) {
 	return useOpenApi().useQuery(
 		"get",

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
@@ -33,16 +33,20 @@ import { AddProviderDialog } from "@/hosted/v2/ai-providers/add-provider-dialog"
 import {
 	useDeleteProvider,
 	useProviderRemovalImpact,
+	useProviderRuntimeObserved,
 	useUserAiProviders,
 } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import {
 	AuthBadge,
 	ManagedProviderCard,
 	ProviderIcon,
+	ProviderObservedBadge,
 	ProviderReadinessBadge,
+	providerObservedDescription,
 } from "@/hosted/v2/ai-providers/ai-providers-ui";
-import { providerPresentation } from "@/hosted/v2/ai-providers/model-binding";
+import { MANAGED_PROVIDER_ID, providerPresentation } from "@/hosted/v2/ai-providers/model-binding";
 import { ProviderConnectionTest } from "@/hosted/v2/ai-providers/provider-connection-test";
+import { providerObservedHealth } from "@/hosted/v2/ai-providers/provider-observed-health";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn } from "@/lib/utils";
@@ -53,6 +57,7 @@ const PROVIDER_GRID_CLASS = ENTITY_GRID_CLASS;
 
 export function AiProvidersPage() {
 	const providers = useUserAiProviders();
+	const runtimeObserved = useProviderRuntimeObserved();
 	const [addOpen, setAddOpen] = useState(false);
 	const [editing, setEditing] = useState<AiProvider | null>(null);
 
@@ -83,7 +88,9 @@ export function AiProvidersPage() {
 
 			<div className="flex flex-col gap-2">
 				<SectionLabel>Clawdi</SectionLabel>
-				<ManagedProviderCard />
+				<ManagedProviderCard
+					observedHealth={providerObservedHealth(MANAGED_PROVIDER_ID, runtimeObserved.data)}
+				/>
 			</div>
 
 			<div className="flex flex-col gap-2">
@@ -127,6 +134,7 @@ export function AiProvidersPage() {
 							<ProviderCard
 								key={provider.provider_id}
 								provider={provider}
+								observedHealth={providerObservedHealth(provider.provider_id, runtimeObserved.data)}
 								onEdit={() => {
 									setEditing(provider);
 									setAddOpen(true);
@@ -142,7 +150,15 @@ export function AiProvidersPage() {
 	);
 }
 
-function ProviderCard({ provider, onEdit }: { provider: AiProvider; onEdit: () => void }) {
+function ProviderCard({
+	provider,
+	observedHealth,
+	onEdit,
+}: {
+	provider: AiProvider;
+	observedHealth: ReturnType<typeof providerObservedHealth>;
+	onEdit: () => void;
+}) {
 	const presentation = providerPresentation(provider);
 	const deployable =
 		(provider.readiness?.deployable ?? provider.usable) && provider.auth.type !== "none";
@@ -157,6 +173,7 @@ function ProviderCard({ provider, onEdit }: { provider: AiProvider; onEdit: () =
 					<span className="inline-flex items-center gap-1.5">
 						<AuthBadge auth={provider.auth} />
 						<ProviderReadinessBadge deployable={deployable} />
+						<ProviderObservedBadge health={observedHealth} />
 					</span>
 				}
 				meta={[
@@ -168,6 +185,7 @@ function ProviderCard({ provider, onEdit }: { provider: AiProvider; onEdit: () =
 							: provider.usable
 								? "This setup isn't available for hosted agents. Review Advanced settings."
 								: "Finish setup before assigning this provider to an agent.",
+					providerObservedDescription(observedHealth),
 				]}
 			/>
 			<div className="mt-auto flex flex-wrap items-center gap-2 pt-3">

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { AuthBadge, ProviderReadinessBadge } from "@/hosted/v2/ai-providers/ai-providers-ui";
+import {
+	AuthBadge,
+	ProviderObservedBadge,
+	ProviderReadinessBadge,
+} from "@/hosted/v2/ai-providers/ai-providers-ui";
 
 const providerPageSource = readFileSync(
 	new URL("./ai-providers-page.tsx", import.meta.url),
@@ -44,5 +48,36 @@ describe("ProviderReadinessBadge", () => {
 		expect(markup).toContain("Ready");
 		expect(markup).not.toContain("Connected");
 		expect(markup).toContain('data-status="success"');
+	});
+});
+
+describe("ProviderObservedBadge", () => {
+	test("uses green only for observed runtime success", () => {
+		const ok = renderToStaticMarkup(
+			createElement(ProviderObservedBadge, {
+				health: { status: "ok", agentCount: 1, reason: null },
+			}),
+		);
+		const unknown = renderToStaticMarkup(
+			createElement(ProviderObservedBadge, {
+				health: { status: "unobserved", agentCount: 1, reason: null },
+			}),
+		);
+
+		expect(ok).toContain("Observed OK");
+		expect(ok).toContain('data-status="success"');
+		expect(unknown).toContain("Not observed");
+		expect(unknown).toContain('data-status="neutral"');
+	});
+
+	test("renders observed failures as degraded", () => {
+		const markup = renderToStaticMarkup(
+			createElement(ProviderObservedBadge, {
+				health: { status: "degraded", agentCount: 1, reason: "Credential unavailable." },
+			}),
+		);
+
+		expect(markup).toContain("Degraded");
+		expect(markup).toContain('data-status="destructive"');
 	});
 });

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.tsx
@@ -11,6 +11,7 @@ import {
 	MANAGED_PROVIDER_LABEL,
 	providerPresentation,
 } from "@/hosted/v2/ai-providers/model-binding";
+import type { ProviderObservedHealth } from "@/hosted/v2/ai-providers/provider-observed-health";
 import type { AiProvider, AiProviderAuth } from "@/hosted/v2/ai-providers/types";
 
 /** Brand-preserving icon for a saved provider or provider reference. */
@@ -75,8 +76,38 @@ export function ProviderReadinessBadge({ deployable }: { deployable: boolean }) 
 	);
 }
 
+export function ProviderObservedBadge({ health }: { health: ProviderObservedHealth }) {
+	const status =
+		health.status === "ok" ? "success" : health.status === "degraded" ? "destructive" : "neutral";
+	const label =
+		health.status === "ok"
+			? "Observed OK"
+			: health.status === "degraded"
+				? "Degraded"
+				: "Not observed";
+	return (
+		<StatusBadge status={status} withDot>
+			{label}
+		</StatusBadge>
+	);
+}
+
+export function providerObservedDescription(health: ProviderObservedHealth): string {
+	if (health.reason) return health.reason;
+	if (health.status === "ok") {
+		return `Observed on ${health.agentCount} ${health.agentCount === 1 ? "agent" : "agents"}.`;
+	}
+	return health.agentCount > 0
+		? "Waiting for a fresh runtime observation."
+		: "Not currently observed on an agent.";
+}
+
 /** The always-on managed default, no setup. */
-export function ManagedProviderCard() {
+export function ManagedProviderCard({
+	observedHealth,
+}: {
+	observedHealth: ProviderObservedHealth;
+}) {
 	return (
 		<div data-hosted="true" data-v2="true" className={ENTITY_CARD_BASE}>
 			<EntityHeader
@@ -84,12 +115,15 @@ export function ManagedProviderCard() {
 				icon={<ProviderIcon provider={MANAGED_PROVIDER_ID} />}
 				title={MANAGED_PROVIDER_LABEL}
 				titleAdornment={
-					<StatusBadge status="success">
-						<ShieldCheck className="size-3" />
-						Default
-					</StatusBadge>
+					<span className="inline-flex items-center gap-1.5">
+						<StatusBadge status="success">
+							<ShieldCheck className="size-3" />
+							Default
+						</StatusBadge>
+						<ProviderObservedBadge health={observedHealth} />
+					</span>
 				}
-				meta={["No setup required", "Wallet billed"]}
+				meta={["No setup required · Wallet billed", providerObservedDescription(observedHealth)]}
 			/>
 		</div>
 	);

--- a/apps/web/src/hosted/v2/ai-providers/provider-observed-health.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-observed-health.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { providerObservedHealth } from "@/hosted/v2/ai-providers/provider-observed-health";
+
+function summary(
+	healthStatus: "ok" | "error" | "stale" | "unknown" | "not_configured",
+	providerStatus: "ok" | "error" | "unknown" | "not_configured",
+	reasons: string[] = [],
+): Parameters<typeof providerObservedHealth>[1] {
+	return {
+		items: [
+			{
+				health: { status: healthStatus, reasons, observed_at: null },
+				provider_health: [
+					{
+						provider_id: "openai",
+						status: providerStatus,
+						reasons,
+						desired: { selected: true, primary: true },
+						observed: null,
+					},
+				],
+			},
+		],
+	};
+}
+
+describe("providerObservedHealth", () => {
+	test.each([
+		["missing", undefined],
+		["stale", summary("stale", "ok")],
+		["unknown", summary("unknown", "unknown")],
+	] as const)("does not present %s runtime evidence as healthy", (_label, observed) => {
+		expect(providerObservedHealth("openai", observed).status).toBe("unobserved");
+	});
+
+	test("presents a provider as healthy only with fresh runtime and provider evidence", () => {
+		expect(providerObservedHealth("openai", summary("ok", "ok"))).toEqual({
+			status: "ok",
+			agentCount: 1,
+			reason: null,
+		});
+	});
+
+	test("surfaces observed provider failures with a safe reason", () => {
+		expect(providerObservedHealth("openai", summary("error", "error", ["secret_missing"]))).toEqual(
+			{
+				status: "degraded",
+				agentCount: 1,
+				reason: "The runtime cannot access this provider credential.",
+			},
+		);
+	});
+
+	test("expires an old provider failure instead of keeping a permanent red state", () => {
+		expect(
+			providerObservedHealth(
+				"openai",
+				summary("error", "error", ["runtime_observed_stale", "secret_missing"]),
+			),
+		).toEqual({
+			status: "unobserved",
+			agentCount: 1,
+			reason: null,
+		});
+	});
+
+	test("clears degraded state when the latest fresh observation succeeds", () => {
+		expect(providerObservedHealth("openai", summary("error", "error"))).toMatchObject({
+			status: "degraded",
+		});
+		expect(providerObservedHealth("openai", summary("ok", "ok"))).toEqual({
+			status: "ok",
+			agentCount: 1,
+			reason: null,
+		});
+	});
+});

--- a/apps/web/src/hosted/v2/ai-providers/provider-observed-health.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-observed-health.ts
@@ -1,0 +1,73 @@
+import type { RuntimeObservedSummary } from "@/hosted/v2/ai-providers/types";
+
+export type ProviderObservedHealth = {
+	status: "ok" | "degraded" | "unobserved";
+	agentCount: number;
+	reason: string | null;
+};
+
+type RuntimeObservedItem = RuntimeObservedSummary["items"][number];
+type ProviderRuntimeObservedSummary = {
+	items: Array<Pick<RuntimeObservedItem, "health" | "provider_health">>;
+};
+
+const REASON_MESSAGE: Readonly<Record<string, string>> = {
+	provider_error: "The runtime reported a provider error.",
+	provider_not_configured: "The provider is not configured in the runtime.",
+	provider_secret_missing: "The runtime cannot access this provider credential.",
+	secret_missing: "The runtime cannot access this provider credential.",
+	runtime_error: "The agent runtime reported an error.",
+	supervisor_error: "The agent runtime supervisor reported an error.",
+	daemon_error: "The agent daemon reported an error.",
+};
+const STALE_REASONS = new Set(["daemon_stale", "runtime_observed_stale"]);
+
+export function providerObservedHealth(
+	providerId: string,
+	summary: ProviderRuntimeObservedSummary | null | undefined,
+): ProviderObservedHealth {
+	if (!summary) return { status: "unobserved", agentCount: 0, reason: null };
+
+	const assignments = summary.items.flatMap((item) => {
+		const provider = item.provider_health.find(
+			(candidate) => candidate.provider_id === providerId && candidate.desired?.selected === true,
+		);
+		return provider ? [{ health: item.health, provider }] : [];
+	});
+	if (assignments.length === 0) {
+		return { status: "unobserved", agentCount: 0, reason: null };
+	}
+
+	const freshAssignments = assignments.filter(
+		({ health }) => !health.reasons.some((reason) => STALE_REASONS.has(reason)),
+	);
+	const explicitFailure = freshAssignments.find(
+		({ provider }) => provider.status === "error" || provider.status === "not_configured",
+	);
+	if (explicitFailure) {
+		const reasonCode = [
+			...explicitFailure.provider.reasons,
+			...explicitFailure.health.reasons,
+		].find((reason) => REASON_MESSAGE[reason] !== undefined);
+		const fallbackReason =
+			explicitFailure.provider.status === "not_configured"
+				? REASON_MESSAGE.provider_not_configured
+				: "The agent runtime reported a provider issue.";
+		return {
+			status: "degraded",
+			agentCount: assignments.length,
+			reason: reasonCode ? REASON_MESSAGE[reasonCode] : fallbackReason,
+		};
+	}
+
+	if (
+		freshAssignments.length === assignments.length &&
+		freshAssignments.every(
+			({ health, provider }) => health.status === "ok" && provider.status === "ok",
+		)
+	) {
+		return { status: "ok", agentCount: assignments.length, reason: null };
+	}
+
+	return { status: "unobserved", agentCount: assignments.length, reason: null };
+}

--- a/apps/web/src/hosted/v2/ai-providers/types.ts
+++ b/apps/web/src/hosted/v2/ai-providers/types.ts
@@ -21,3 +21,4 @@ export type AiProviderConnectionTestRequest = Schemas["AiProviderConnectionTestR
 export type AiProviderConnectionTestResponse = Schemas["AiProviderConnectionTestResponse"];
 export type AiProviderOAuthDeviceStartResponse = Schemas["AiProviderOAuthDeviceStartResponse"];
 export type AiProviderOAuthDevicePollResponse = Schemas["AiProviderOAuthDevicePollResponse"];
+export type RuntimeObservedSummary = Schemas["RuntimeObservedSummaryResponse"];

--- a/apps/web/src/hosted/v2/channels/agent-channel-cards.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/agent-channel-cards.logic.test.ts
@@ -55,6 +55,7 @@ function link(
 		account_id: accountId,
 		agent_id: agentId,
 		status: "active",
+		runtime_status: overrides.runtime_status ?? "connecting",
 		created_at: createdAt,
 		...overrides,
 		binding_count: overrides.binding_count ?? 0,

--- a/apps/web/src/hosted/v2/channels/channel-convergence-contract.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-convergence-contract.test.ts
@@ -5,6 +5,7 @@ const source = (relativePath: string) =>
 	readFileSync(new URL(relativePath, import.meta.url), "utf8");
 
 const agentDetail = source("../../agents/hosted-agent-detail.tsx");
+const channelDetail = source("./channel-detail-page.tsx");
 const linkedChannelRow = agentDetail.slice(
 	agentDetail.indexOf("function LinkedChannelRow"),
 	agentDetail.indexOf("// ── Settings / Compute"),
@@ -16,6 +17,14 @@ const queryCache = source("./channel-query-cache.ts");
 const queryGuide = source("../../../../../../docs/openapi-react-query.md");
 
 describe("Telegram and Discord channel convergence contract", () => {
+	test("renders runtime convergence status on both sides of the Agent link", () => {
+		expect(agentDetail).toContain(
+			'<ChannelRuntimeStatusBadge key="runtime-status" status={link.runtime_status} />',
+		);
+		expect(channelDetail).toContain("<ChannelRuntimeStatusBadge");
+		expect(channelDetail).toContain("status={link.runtime_status}");
+	});
+
 	test("keeps Pair exact and paired chats as the only clickable relationship badge", () => {
 		expect(linkedChannelRow).toContain('{creatingPairCode ? "Generating…" : "Pair"}');
 		expect(linkedChannelRow).not.toContain("Pair Telegram");

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -36,6 +36,7 @@ import { channelHealthSummary } from "@/hosted/v2/channels/channel-health-summar
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
 import type { ChannelActivityItem, ChannelAgentLink } from "@/hosted/v2/channels/channel-types";
 import {
+	ChannelRuntimeStatusBadge,
 	ChannelStatusBadge,
 	CopyInline,
 	DeliveryBadge,
@@ -318,7 +319,7 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 // ── Agents ───────────────────────────────────────────────────────────────────
 
 function AgentsTab({ accountId }: { accountId: string }) {
-	const links = useChannelAgentLinks(accountId);
+	const links = useChannelAgentLinks(accountId, true);
 	const envs = useEnvironments();
 
 	if (links.isLoading || envs.isLoading) {
@@ -369,6 +370,7 @@ function AgentsTab({ accountId }: { accountId: string }) {
 							<AgentName
 								env={findEnv(envs.data, link.agent_id)}
 								meta={[
+									<ChannelRuntimeStatusBadge key="runtime-status" status={link.runtime_status} />,
 									...(isNormalChannelStatus(link.status)
 										? []
 										: [<ChannelStatusBadge key="status" status={link.status} />]),

--- a/apps/web/src/hosted/v2/channels/channel-edit-client.logic.ts
+++ b/apps/web/src/hosted/v2/channels/channel-edit-client.logic.ts
@@ -1,16 +1,46 @@
 import type { components } from "@clawdi/shared/api";
 
 type GeneratedAgentChannelLink = components["schemas"]["ChannelAgentLinkWithAccountResponse"];
-type AgentChannelLinkPayload = Omit<GeneratedAgentChannelLink, "binding_count"> & {
+type AgentChannelLinkPayload = Omit<
+	GeneratedAgentChannelLink,
+	"binding_count" | "runtime_status"
+> & {
 	binding_count?: number;
+	runtime_status?: GeneratedAgentChannelLink["runtime_status"];
 };
 
 export type AgentChannelLink = Omit<GeneratedAgentChannelLink, "account"> & {
 	account?: components["schemas"]["ChannelAccountResponse"] | null;
 };
 
+export type ChannelRuntimeStatus = "connecting" | "connected";
+
+export function channelRuntimeStatus(
+	link: Pick<AgentChannelLink, "runtime_status">,
+): ChannelRuntimeStatus {
+	return link.runtime_status === "connected" ? "connected" : "connecting";
+}
+
+export function linkedChannelConnectionSummary(
+	links: readonly AgentChannelLink[],
+	{ agentStopped = false }: { agentStopped?: boolean } = {},
+): string {
+	if (links.length === 0) return "No channels linked";
+	if (agentStopped) return "Agent stopped";
+	const connected = links.filter((link) => channelRuntimeStatus(link) === "connected").length;
+	const connecting = links.length - connected;
+	if (connecting === 0) return `${connected} connected ${connected === 1 ? "channel" : "channels"}`;
+	if (connected === 0)
+		return `${connecting} connecting ${connecting === 1 ? "channel" : "channels"}`;
+	return `${connected} connected, ${connecting} connecting`;
+}
+
 export function normalizeAgentChannelLinks(
 	links: readonly AgentChannelLinkPayload[],
 ): AgentChannelLink[] {
-	return links.map((link) => ({ ...link, binding_count: link.binding_count ?? 0 }));
+	return links.map((link) => ({
+		...link,
+		binding_count: link.binding_count ?? 0,
+		runtime_status: link.runtime_status ?? "connecting",
+	}));
 }

--- a/apps/web/src/hosted/v2/channels/channel-edit-client.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-edit-client.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { normalizeAgentChannelLinks } from "./channel-edit-client.logic";
+import {
+	channelRuntimeStatus,
+	linkedChannelConnectionSummary,
+	normalizeAgentChannelLinks,
+} from "./channel-edit-client.logic";
 
 const account = {
 	id: "11111111-1111-4111-8111-111111111111",
@@ -31,5 +35,23 @@ describe("agent channel link response normalization", () => {
 
 	test("preserves the backend aggregate when present", () => {
 		expect(normalizeAgentChannelLinks([link(3)])[0]?.binding_count).toBe(3);
+	});
+
+	test("withholds connected copy until the backend reports observed convergence", () => {
+		const connecting = normalizeAgentChannelLinks([link()])[0];
+		const connected = normalizeAgentChannelLinks([
+			{ ...link(), runtime_status: "connected" as const },
+		])[0];
+		expect(connecting && channelRuntimeStatus(connecting)).toBe("connecting");
+		expect(connected && channelRuntimeStatus(connected)).toBe("connected");
+		expect(linkedChannelConnectionSummary(connecting ? [connecting] : [])).toBe(
+			"1 connecting channel",
+		);
+		expect(linkedChannelConnectionSummary(connected ? [connected] : [])).toBe(
+			"1 connected channel",
+		);
+		expect(
+			linkedChannelConnectionSummary(connecting ? [connecting] : [], { agentStopped: true }),
+		).toBe("Agent stopped");
 	});
 });

--- a/apps/web/src/hosted/v2/channels/channel-health-summary.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-health-summary.test.ts
@@ -47,6 +47,39 @@ describe("channel health summaries", () => {
 		});
 	});
 
+	test("degrades missing and stale runtime evidence instead of claiming healthy", () => {
+		expect(
+			channelHealthSummary(
+				health({ health_status: "warning", reasons: ["runtime_observation_missing"] }),
+			),
+		).toEqual({
+			label: "Waiting for runtime",
+			detail: "No Agent runtime activity has been observed for this channel yet.",
+		});
+		expect(
+			channelHealthSummary(
+				health({ health_status: "warning", reasons: ["runtime_observation_stale"] }),
+			).label,
+		).toBe("Runtime inactive");
+	});
+
+	test("distinguishes reconnection and an unlinked channel from missing runtime evidence", () => {
+		expect(
+			channelHealthSummary(
+				health({ health_status: "warning", reasons: ["native_transport_reconnecting"] }),
+			),
+		).toEqual({
+			label: "Reconnecting",
+			detail: "The channel transport is reconnecting after a service restart.",
+		});
+		expect(
+			channelHealthSummary(health({ health_status: "warning", reasons: ["agent_not_linked"] })),
+		).toEqual({
+			label: "Not linked",
+			detail: "This channel is not linked to an Agent.",
+		});
+	});
+
 	test("prioritizes actionable error states", () => {
 		expect(
 			channelHealthSummary(

--- a/apps/web/src/hosted/v2/channels/channel-health-summary.ts
+++ b/apps/web/src/hosted/v2/channels/channel-health-summary.ts
@@ -54,9 +54,34 @@ export function channelHealthSummary(health: ChannelHealthItem): ChannelHealthSu
 				detail: "A recent channel operation failed. Open the channel Health view for details.",
 			};
 		}
+		if (health.reasons?.includes("native_transport_unavailable")) {
+			return {
+				label: "Channel unavailable",
+				detail: "The channel transport is not available. Open the Health view for details.",
+			};
+		}
+		if (health.reasons?.includes("runtime_observation_error")) {
+			return {
+				label: "Runtime error",
+				detail: "The Agent runtime reported an error for this channel.",
+			};
+		}
 		return {
 			label: "Channel error",
 			detail: "Channel health reported an error. Open the channel Health view for details.",
+		};
+	}
+
+	if (health.reasons?.includes("native_transport_reconnecting")) {
+		return {
+			label: "Reconnecting",
+			detail: "The channel transport is reconnecting after a service restart.",
+		};
+	}
+	if (health.reasons?.includes("agent_not_linked")) {
+		return {
+			label: "Not linked",
+			detail: "This channel is not linked to an Agent.",
 		};
 	}
 
@@ -68,6 +93,30 @@ export function channelHealthSummary(health: ChannelHealthItem): ChannelHealthSu
 				details.length > 1
 					? `Additional activity: ${details.slice(1).join("; ")}.`
 					: "This channel activity is still being processed.",
+		};
+	}
+	if (health.reasons?.includes("runtime_observation_missing")) {
+		return {
+			label: "Waiting for runtime",
+			detail: "No Agent runtime activity has been observed for this channel yet.",
+		};
+	}
+	if (health.reasons?.includes("runtime_observation_stale")) {
+		return {
+			label: "Runtime inactive",
+			detail: "The Agent runtime has not checked in recently.",
+		};
+	}
+	if (health.reasons?.includes("runtime_not_converged")) {
+		return {
+			label: "Applying channel",
+			detail: "The Agent runtime has not applied the current channel configuration yet.",
+		};
+	}
+	if (health.reasons?.includes("runtime_observation_unknown")) {
+		return {
+			label: "Runtime unverified",
+			detail: "The Agent runtime did not provide a usable channel health signal.",
 		};
 	}
 

--- a/apps/web/src/hosted/v2/channels/channel-ui.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-ui.tsx
@@ -4,9 +4,10 @@ import { Check, CircleAlert, CircleCheck, Copy, TriangleAlert } from "lucide-rea
 import { EntityIcon, type EntityIconSize } from "@/components/entity-icon";
 import { StatusBadge, type StatusTone } from "@/components/ui/status-badge";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+import { channelRuntimeStatus } from "@/hosted/v2/channels/channel-edit-client.logic";
 import { channelHealthSummary } from "@/hosted/v2/channels/channel-health-summary";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
-import type { ChannelHealthItem } from "@/hosted/v2/channels/channel-types";
+import type { ChannelAgentLink, ChannelHealthItem } from "@/hosted/v2/channels/channel-types";
 import { cn } from "@/lib/utils";
 
 export const CHANNEL_DESTRUCTIVE_ACTION_CLASS =
@@ -87,6 +88,19 @@ export function ChannelStatusBadge({ status, className }: { status: string; clas
 
 export function isNormalChannelStatus(status: string | null | undefined): boolean {
 	return ["active", "connected", "paired"].includes(status?.toLowerCase() ?? "");
+}
+
+export function ChannelRuntimeStatusBadge({
+	status,
+}: {
+	status: ChannelAgentLink["runtime_status"];
+}) {
+	const runtimeStatus = channelRuntimeStatus({ runtime_status: status });
+	return (
+		<StatusBadge status={runtimeStatus === "connected" ? "success" : "warning"}>
+			{runtimeStatus === "connected" ? "Connected" : "Connecting…"}
+		</StatusBadge>
+	);
 }
 
 const DELIVERY_TONE: Record<string, StatusTone> = {

--- a/apps/web/src/hosted/v2/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.ts
@@ -10,7 +10,10 @@ import {
 	channelKeys as keys,
 	removeDeletedChannelQueries,
 } from "@/hosted/v2/channels/channel-query-cache";
-import { agentChannelLinksQueryBehavior } from "@/hosted/v2/channels/channel-query-options.logic";
+import {
+	AGENT_CHANNEL_LINKS_REFETCH_INTERVAL_MS,
+	agentChannelLinksQueryBehavior,
+} from "@/hosted/v2/channels/channel-query-options.logic";
 import type {
 	ChannelCreate,
 	ChannelCreated,
@@ -147,12 +150,16 @@ export function useWhatsAppOnboardingActions() {
 	return { start, refresh, pairingCode, cancel, retry, repair };
 }
 
-export function useChannelAgentLinks(id: string) {
+export function useChannelAgentLinks(id: string, poll = false) {
 	return useOpenApi().useQuery(
 		"get",
 		"/v1/channels/{account_id}/agent-links",
 		{ params: { path: { account_id: id } } },
-		{ enabled: Boolean(id) },
+		{
+			enabled: Boolean(id),
+			refetchInterval: poll ? AGENT_CHANNEL_LINKS_REFETCH_INTERVAL_MS : false,
+			refetchIntervalInBackground: false,
+		},
 	);
 }
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -263,7 +263,9 @@ class Settings(BaseSettings):
     # opaque to Hosted; empty uses encryption_key so existing deployments need
     # no additional secret before adopting the protocol.
     runtime_observation_cursor_key: str = ""
-    runtime_observation_freshness_seconds: Annotated[int, Field(gt=0, le=86_400)] = 90
+    # Runtime reports every 60 +/- 15 seconds. Allow two full intervals before
+    # treating the latest observation as stale.
+    runtime_observation_freshness_seconds: Annotated[int, Field(gt=0, le=86_400)] = 150
     runtime_observation_max_future_skew_seconds: Annotated[int, Field(gt=0, le=86_400)] = 300
     runtime_observation_max_capture_age_days: Annotated[int, Field(gt=0, le=365)] = 30
     runtime_observation_replay_horizon_days: Annotated[int, Field(gt=0, le=365)] = 7

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -16,7 +16,7 @@ from fastapi import (
     status,
 )
 from fastapi.responses import JSONResponse
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, func, or_, select, union_all
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -40,6 +40,7 @@ from app.models.channel import (
     DELIVERY_STATUS_FAILED,
     DELIVERY_STATUS_IN_PROGRESS,
     DELIVERY_STATUS_PENDING,
+    DELIVERY_STATUS_SUCCEEDED,
     ChannelAccount,
     ChannelBinding,
     ChannelBotAgentLink,
@@ -144,6 +145,10 @@ from app.services.channels import (
     telegram_reserved_commands_are_current,
 )
 from app.services.http_cache import if_none_match_contains, strong_json_etag
+from app.services.runtime_observed_evidence import (
+    RuntimeObservedEvidence,
+    load_runtime_observed_evidence,
+)
 from app.services.sync_events import queue_environment_runtime_manifest_changed
 from app.services.whatsapp_baileys import ensure_whatsapp_agent_credential
 from app.services.whatsapp_device_onboarding import (
@@ -1533,6 +1538,33 @@ async def _channel_health_items(
     account_ids = [account.id for account in accounts]
     recent_error_cutoff = datetime.now(UTC) - _CHANNEL_HEALTH_ERROR_WINDOW
 
+    runtime_link_rows = (
+        await db.execute(
+            select(
+                ChannelBotAgentLink.account_id,
+                ChannelBotAgentLink.agent_id,
+            ).where(
+                ChannelBotAgentLink.account_id.in_(account_ids),
+                ChannelBotAgentLink.user_id == user_id,
+                ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                ChannelBotAgentLink.archived_at.is_(None),
+            )
+        )
+    ).all()
+    runtime_evidence_by_agent = await load_runtime_observed_evidence(
+        db,
+        environment_ids=[agent_id for _account_id, agent_id in runtime_link_rows],
+        owner_user_id=user_id,
+    )
+    runtime_evidence_by_account: dict[UUID, list[RuntimeObservedEvidence]] = {}
+    for account_id, agent_id in runtime_link_rows:
+        runtime_evidence_by_account.setdefault(account_id, []).append(
+            runtime_evidence_by_agent.get(
+                agent_id,
+                RuntimeObservedEvidence(status="missing", observed_at=None, converged=False),
+            )
+        )
+
     pending_inbox_rows = await db.execute(
         select(
             ChannelMessage.account_id,
@@ -1575,6 +1607,37 @@ async def _channel_health_items(
         for account_id, count, oldest_pending_at in pending_inbox_rows.all()
     }
 
+    successful_events = union_all(
+        select(
+            ChannelDebugEvent.account_id.label("account_id"),
+            ChannelDebugEvent.created_at.label("succeeded_at"),
+        ).where(
+            ChannelDebugEvent.account_id.in_(account_ids),
+            ChannelDebugEvent.user_id == user_id,
+            ChannelDebugEvent.outcome == "success",
+        ),
+        select(
+            ChannelDelivery.account_id.label("account_id"),
+            ChannelDelivery.updated_at.label("succeeded_at"),
+        ).where(
+            ChannelDelivery.account_id.in_(account_ids),
+            ChannelDelivery.user_id == user_id,
+            ChannelDelivery.status == DELIVERY_STATUS_SUCCEEDED,
+        ),
+    ).subquery()
+    latest_success = (
+        select(
+            successful_events.c.account_id,
+            func.max(successful_events.c.succeeded_at).label("succeeded_at"),
+        )
+        .group_by(successful_events.c.account_id)
+        .subquery()
+    )
+    last_success_rows = await db.execute(
+        select(latest_success.c.account_id, latest_success.c.succeeded_at)
+    )
+    last_success_by_account: dict[UUID, datetime] = dict(last_success_rows.tuples().all())
+
     delivery_rows = await db.execute(
         select(
             ChannelDelivery.account_id,
@@ -1585,14 +1648,19 @@ async def _channel_health_items(
             .filter(ChannelDelivery.status == DELIVERY_STATUS_IN_PROGRESS)
             .label("in_progress_count"),
             func.count(ChannelDelivery.id)
-            .filter(ChannelDelivery.status == DELIVERY_STATUS_FAILED)
-            .label("failed_count"),
-            func.count(ChannelDelivery.id)
             .filter(
                 ChannelDelivery.status == DELIVERY_STATUS_FAILED,
                 ChannelDelivery.updated_at >= recent_error_cutoff,
+                or_(
+                    latest_success.c.succeeded_at.is_(None),
+                    ChannelDelivery.updated_at > latest_success.c.succeeded_at,
+                ),
             )
-            .label("recent_failed_count"),
+            .label("failed_count"),
+        )
+        .outerjoin(
+            latest_success,
+            latest_success.c.account_id == ChannelDelivery.account_id,
         )
         .where(
             ChannelDelivery.account_id.in_(account_ids),
@@ -1601,8 +1669,8 @@ async def _channel_health_items(
         .group_by(ChannelDelivery.account_id)
     )
     delivery_counts_by_account = {
-        account_id: (int(pending), int(in_progress), int(failed), int(recent_failed))
-        for account_id, pending, in_progress, failed, recent_failed in delivery_rows.all()
+        account_id: (int(pending), int(in_progress), int(failed))
+        for account_id, pending, in_progress, failed in delivery_rows.all()
     }
 
     message_rows = await db.execute(
@@ -1631,7 +1699,7 @@ async def _channel_health_items(
         if account_id is not None
     }
 
-    debug_error_ranked = (
+    debug_signal_ranked = (
         select(
             ChannelDebugEvent.account_id,
             ChannelDebugEvent.created_at,
@@ -1649,30 +1717,32 @@ async def _channel_health_items(
             ChannelDebugEvent.account_id.in_(account_ids),
             ChannelDebugEvent.user_id == user_id,
             or_(
+                ChannelDebugEvent.outcome == "success",
                 ChannelDebugEvent.outcome == "failure",
                 ChannelDebugEvent.error.is_not(None),
             ),
         )
         .subquery()
     )
-    debug_error_rows = await db.execute(
+    debug_signal_rows = await db.execute(
         select(
-            debug_error_ranked.c.account_id,
-            debug_error_ranked.c.created_at,
-            debug_error_ranked.c.stage,
-            debug_error_ranked.c.outcome,
-            debug_error_ranked.c.error,
-        ).where(debug_error_ranked.c.row_number == 1)
+            debug_signal_ranked.c.account_id,
+            debug_signal_ranked.c.created_at,
+            debug_signal_ranked.c.stage,
+            debug_signal_ranked.c.outcome,
+            debug_signal_ranked.c.error,
+        ).where(debug_signal_ranked.c.row_number == 1)
     )
-    debug_error_by_account = {
+    debug_signal_by_account = {
         account_id: (created_at, stage, outcome, error)
-        for account_id, created_at, stage, outcome, error in debug_error_rows.all()
+        for account_id, created_at, stage, outcome, error in debug_signal_rows.all()
     }
 
-    delivery_error_ranked = (
+    delivery_signal_ranked = (
         select(
             ChannelDelivery.account_id,
             ChannelDelivery.updated_at,
+            ChannelDelivery.status,
             ChannelDelivery.last_error,
             func.row_number()
             .over(
@@ -1684,31 +1754,37 @@ async def _channel_health_items(
         .where(
             ChannelDelivery.account_id.in_(account_ids),
             ChannelDelivery.user_id == user_id,
-            ChannelDelivery.last_error.is_not(None),
+            or_(
+                ChannelDelivery.status == DELIVERY_STATUS_SUCCEEDED,
+                ChannelDelivery.last_error.is_not(None),
+            ),
         )
         .subquery()
     )
-    delivery_error_rows = await db.execute(
+    delivery_signal_rows = await db.execute(
         select(
-            delivery_error_ranked.c.account_id,
-            delivery_error_ranked.c.updated_at,
-            delivery_error_ranked.c.last_error,
-        ).where(delivery_error_ranked.c.row_number == 1)
+            delivery_signal_ranked.c.account_id,
+            delivery_signal_ranked.c.updated_at,
+            delivery_signal_ranked.c.status,
+            delivery_signal_ranked.c.last_error,
+        ).where(delivery_signal_ranked.c.row_number == 1)
     )
-    delivery_error_by_account = {
-        account_id: (updated_at, last_error)
-        for account_id, updated_at, last_error in delivery_error_rows.all()
+    delivery_signal_by_account = {
+        account_id: (updated_at, delivery_status, last_error)
+        for account_id, updated_at, delivery_status, last_error in delivery_signal_rows.all()
     }
 
     return [
         _channel_health_item(
             account=account,
             pending_inbox_stats=pending_inbox_by_account.get(account.id, (0, None)),
-            delivery_counts=delivery_counts_by_account.get(account.id, (0, 0, 0, 0)),
+            delivery_counts=delivery_counts_by_account.get(account.id, (0, 0, 0)),
             last_message_at=last_message_by_account.get(account.id),
             last_event_at=last_event_by_account.get(account.id),
-            debug_error=debug_error_by_account.get(account.id),
-            delivery_error=delivery_error_by_account.get(account.id),
+            debug_signal=debug_signal_by_account.get(account.id),
+            delivery_signal=delivery_signal_by_account.get(account.id),
+            last_success_at=last_success_by_account.get(account.id),
+            runtime_evidence=runtime_evidence_by_account.get(account.id, []),
             recent_error_cutoff=recent_error_cutoff,
         )
         for account in accounts
@@ -1719,29 +1795,43 @@ def _channel_health_item(
     *,
     account: ChannelAccount,
     pending_inbox_stats: tuple[int, datetime | None],
-    delivery_counts: tuple[int, int, int, int],
+    delivery_counts: tuple[int, int, int],
     last_message_at: datetime | None,
     last_event_at: datetime | None,
-    debug_error: tuple[datetime, str, str, str | None] | None,
-    delivery_error: tuple[datetime, str] | None,
+    debug_signal: tuple[datetime, str, str, str | None] | None,
+    delivery_signal: tuple[datetime, str, str | None] | None,
+    last_success_at: datetime | None,
+    runtime_evidence: list[RuntimeObservedEvidence],
     recent_error_cutoff: datetime,
 ) -> ChannelHealthItemResponse:
     pending_inbox, oldest_pending_inbox_at = pending_inbox_stats
-    pending_deliveries, in_progress_deliveries, failed_deliveries, recent_failed_deliveries = (
-        delivery_counts
-    )
+    pending_deliveries, in_progress_deliveries, failed_deliveries = delivery_counts
     last_error_at = None
     last_error = None
     last_error_stage = None
     last_error_outcome = None
-    if debug_error is not None:
-        last_error_at, last_error_stage, last_error_outcome, raw_error = debug_error
+    if debug_signal is not None and (debug_signal[2] == "failure" or debug_signal[3] is not None):
+        last_error_at, last_error_stage, last_error_outcome, raw_error = debug_signal
         last_error = public_channel_operation_error(raw_error)
-    if delivery_error is not None and (last_error_at is None or delivery_error[0] > last_error_at):
-        last_error_at = delivery_error[0]
-        last_error = public_channel_delivery_error(delivery_error[1])
+    if (
+        delivery_signal is not None
+        and delivery_signal[1] != DELIVERY_STATUS_SUCCEEDED
+        and delivery_signal[2] is not None
+        and (last_error_at is None or delivery_signal[0] > last_error_at)
+    ):
+        last_error_at = delivery_signal[0]
+        last_error = public_channel_delivery_error(delivery_signal[2])
         last_error_stage = "delivery"
         last_error_outcome = "failure"
+    if (
+        last_error_at is not None
+        and last_success_at is not None
+        and last_success_at >= last_error_at
+    ):
+        last_error_at = None
+        last_error = None
+        last_error_stage = None
+        last_error_outcome = None
 
     native_transport = _native_transport_health(account)
     whatsapp_transport_connected = (
@@ -1749,17 +1839,42 @@ def _channel_health_item(
         and native_transport is not None
         and native_transport.get("available") is True
     )
+    whatsapp_transport_reconnecting = (
+        account.provider == CHANNEL_PROVIDER_WHATSAPP
+        and native_transport is not None
+        and native_transport.get("reconnecting") is True
+    )
     reasons: list[str] = []
     if account.status != CHANNEL_STATUS_ACTIVE:
         reasons.append("channel_disabled")
-    if failed_deliveries > 0 and (not whatsapp_transport_connected or recent_failed_deliveries > 0):
+    if failed_deliveries > 0:
         reasons.append("failed_deliveries")
-    if last_error is not None and (
-        not whatsapp_transport_connected
-        or last_error_at is None
-        or last_error_at >= recent_error_cutoff
+    if (
+        last_error is not None
+        and last_error_at is not None
+        and last_error_at >= recent_error_cutoff
     ):
         reasons.append("recent_error")
+    if account.provider == CHANNEL_PROVIDER_WHATSAPP and not whatsapp_transport_connected:
+        reasons.append(
+            "native_transport_reconnecting"
+            if whatsapp_transport_reconnecting
+            else "native_transport_unavailable"
+        )
+    if runtime_evidence:
+        statuses = {item.status for item in runtime_evidence}
+        if "error" in statuses:
+            reasons.append("runtime_observation_error")
+        elif "missing" in statuses:
+            reasons.append("runtime_observation_missing")
+        elif "stale" in statuses:
+            reasons.append("runtime_observation_stale")
+        elif "unknown" in statuses:
+            reasons.append("runtime_observation_unknown")
+        if not all(item.converged for item in runtime_evidence):
+            reasons.append("runtime_not_converged")
+    elif account.provider != CHANNEL_PROVIDER_WHATSAPP:
+        reasons.append("agent_not_linked")
     if in_progress_deliveries > 0:
         reasons.append("deliveries_in_progress")
     if pending_deliveries > 0:
@@ -1773,6 +1888,8 @@ def _channel_health_item(
             "channel_disabled",
             "failed_deliveries",
             "recent_error",
+            "native_transport_unavailable",
+            "runtime_observation_error",
         )
     ):
         health_status = "error"

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -84,6 +84,7 @@ from app.schemas.channel import (
     ChannelMessageResponse,
     ChannelPairCodeCreate,
     ChannelPairCodeResponse,
+    ChannelRuntimeStatus,
     ChannelSendMessageRequest,
 )
 from app.services.agent_bindings import get_owned_agent_or_404
@@ -194,12 +195,14 @@ def _agent_link_response(
     link: ChannelBotAgentLink,
     *,
     agent_token: str | None = None,
+    runtime_status: ChannelRuntimeStatus = "connecting",
 ) -> ChannelAgentLinkResponse:
     return ChannelAgentLinkResponse(
         id=link.id,
         account_id=link.account_id,
         agent_id=link.agent_id,
         status=link.status,
+        runtime_status=runtime_status,
         created_at=link.created_at,
         agent_token=agent_token,
     )
@@ -210,12 +213,21 @@ def _agent_link_with_account_response(
     account: ChannelAccount,
     *,
     binding_count: int = 0,
+    runtime_status: ChannelRuntimeStatus = "connecting",
 ) -> ChannelAgentLinkWithAccountResponse:
     return ChannelAgentLinkWithAccountResponse(
-        **_agent_link_response(link).model_dump(),
+        **_agent_link_response(link, runtime_status=runtime_status).model_dump(),
         account=account_response(account),
         binding_count=binding_count,
     )
+
+
+def _agent_link_runtime_status(
+    evidence: RuntimeObservedEvidence | None,
+) -> ChannelRuntimeStatus:
+    if evidence is not None and evidence.status == "ok" and evidence.converged:
+        return "connected"
+    return "connecting"
 
 
 def _activity_message_response(
@@ -563,11 +575,18 @@ async def list_agent_channel_links(
         user_id=auth.user_id,
         agent_id=agent_id,
     )
+    runtime_evidence = await load_runtime_observed_evidence(
+        db,
+        environment_ids=[agent_id],
+        owner_user_id=auth.user_id,
+    )
+    runtime_status = _agent_link_runtime_status(runtime_evidence.get(agent_id))
     return [
         _agent_link_with_account_response(
             link,
             account,
             binding_count=binding_count,
+            runtime_status=runtime_status,
         )
         for link, account, binding_count in rows
     ]
@@ -852,7 +871,19 @@ async def list_channel_agent_links(
         )
         .order_by(ChannelBotAgentLink.created_at)
     )
-    return [_agent_link_response(link) for link in result.scalars().all()]
+    links = list(result.scalars().all())
+    runtime_evidence = await load_runtime_observed_evidence(
+        db,
+        environment_ids=[link.agent_id for link in links],
+        owner_user_id=auth.user_id,
+    )
+    return [
+        _agent_link_response(
+            link,
+            runtime_status=_agent_link_runtime_status(runtime_evidence.get(link.agent_id)),
+        )
+        for link in links
+    ]
 
 
 @router.post("/{account_id}/agent-links", status_code=status.HTTP_201_CREATED)

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -132,7 +132,7 @@ _MAX_AGENT_AVATAR_BYTES = 2 * 1024 * 1024
 _AGENT_AVATAR_PREFIX = "agent-avatars/"
 _AGENT_AVATAR_KEY_RE = re.compile(r"^agent-avatars/[0-9a-f]{32}\.(png|jpg|webp)$")
 _SESSION_LOCAL_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._\-]{0,199}$"
-_RUNTIME_OBSERVED_STALE_AFTER = timedelta(seconds=90)
+_RUNTIME_OBSERVED_STALE_AFTER = timedelta(seconds=settings.runtime_observation_freshness_seconds)
 _HEARTBEAT_FRESHNESS_WRITE_INTERVAL = timedelta(seconds=40)
 _AGENT_DISCONNECTED_ERROR_CODE = "agent_disconnected"
 _RUNTIME_OBSERVED_ADAPTER = TypeAdapter(HostedRuntimeObserved)

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -623,6 +623,18 @@ async def list_environment_runtime_observed(
     return RuntimeObservedSummaryResponse(counts=counts, items=items)
 
 
+@router.get(
+    "/agents/runtime-observed",
+    response_model=RuntimeObservedSummaryResponse,
+)
+async def list_agent_runtime_observed(
+    limit: int = Query(default=100, ge=1, le=500),
+    auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_session),
+) -> RuntimeObservedSummaryResponse:
+    return await list_environment_runtime_observed(limit=limit, auth=auth, db=db)
+
+
 @overload
 async def _reorder_agent_identities(
     requested_ids: list[UUID], auth: AuthContext, db: AsyncSession, *, agent_response: Literal[True]

--- a/backend/app/schemas/channel.py
+++ b/backend/app/schemas/channel.py
@@ -10,6 +10,7 @@ ChannelProvider = Literal["telegram", "discord", "whatsapp"]
 ChannelVisibility = Literal["private", "public"]
 ChannelBotPoolAccess = Literal["owner", "public"]
 ChannelHealthStatus = Literal["ok", "warning", "error"]
+ChannelRuntimeStatus = Literal["connecting", "connected"]
 WhatsAppOnboardingState = Literal[
     "generating",
     "ready",
@@ -164,6 +165,7 @@ class ChannelAgentLinkResponse(BaseModel):
     account_id: UUID
     agent_id: UUID
     status: str
+    runtime_status: ChannelRuntimeStatus = "connecting"
     created_at: datetime
     agent_token: str | None = None
 

--- a/backend/app/services/runtime_observed_evidence.py
+++ b/backend/app/services/runtime_observed_evidence.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Literal
+from uuid import UUID
+
+from pydantic import TypeAdapter, ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
+from app.schemas.runtime_observed import HostedRuntimeObserved, HostedRuntimeObservedV2
+from app.services.runtime_generation import resolve_runtime_apply_generation
+from app.services.runtime_source import (
+    RuntimeSourceError,
+    expected_runtime_bundle_v2_etag,
+    load_runtime_source_batch,
+    render_runtime_source,
+    vault_key_identity,
+)
+
+RuntimeEvidenceStatus = Literal["ok", "error", "unknown", "missing", "stale"]
+_RUNTIME_OBSERVED_ADAPTER = TypeAdapter(HostedRuntimeObserved)
+
+
+@dataclass(frozen=True)
+class RuntimeObservedEvidence:
+    status: RuntimeEvidenceStatus
+    observed_at: datetime | None
+    converged: bool
+
+
+def validated_runtime_observed_diagnostics(
+    observation: HostedRuntimeConfigObservation | None,
+) -> HostedRuntimeObservedV2 | None:
+    if observation is None:
+        return None
+    try:
+        return _RUNTIME_OBSERVED_ADAPTER.validate_python(observation.diagnostics)
+    except ValidationError:
+        return None
+
+
+async def load_runtime_observed_evidence(
+    db: AsyncSession,
+    *,
+    environment_ids: list[UUID],
+    owner_user_id: UUID,
+    now: datetime | None = None,
+) -> dict[UUID, RuntimeObservedEvidence]:
+    requested_ids = sorted(set(environment_ids), key=str)
+    if not requested_ids:
+        return {}
+
+    batch = await load_runtime_source_batch(
+        db,
+        environment_ids=requested_ids,
+        owner_user_id=owner_user_id,
+    )
+    current = now or datetime.now(UTC)
+    freshness = timedelta(seconds=settings.runtime_observation_freshness_seconds)
+    evidence: dict[UUID, RuntimeObservedEvidence] = {}
+    for environment_id in requested_ids:
+        row = batch.rows.get(environment_id)
+        desired_source_revision = None
+        if row is not None and row.state is not None:
+            try:
+                desired_source_revision = render_runtime_source(
+                    batch,
+                    environment_id=environment_id,
+                    public_api_url=settings.public_api_url,
+                    vault_key_identity=vault_key_identity(settings.vault_encryption_key),
+                    decrypt_secrets=False,
+                ).source_revision
+            except RuntimeSourceError:
+                pass
+        evidence[environment_id] = _runtime_observed_evidence(
+            state=row.state if row is not None else None,
+            observation=row.observation if row is not None else None,
+            desired_source_revision=desired_source_revision,
+            current=current,
+            freshness=freshness,
+        )
+    return evidence
+
+
+def _runtime_observed_evidence(
+    *,
+    state: HostedRuntimeState | None,
+    observation: HostedRuntimeConfigObservation | None,
+    desired_source_revision: str | None,
+    current: datetime,
+    freshness: timedelta,
+) -> RuntimeObservedEvidence:
+    if state is None or observation is None or observation.observed_at is None:
+        return RuntimeObservedEvidence(status="missing", observed_at=None, converged=False)
+
+    observed_at = _as_utc(observation.observed_at)
+    diagnostics = validated_runtime_observed_diagnostics(observation)
+    converged = _runtime_observation_matches_desired(
+        state=state,
+        observation=observation,
+        diagnostics=diagnostics,
+        desired_source_revision=desired_source_revision,
+    )
+    if current - observed_at > freshness:
+        return RuntimeObservedEvidence(
+            status="stale",
+            observed_at=observed_at,
+            converged=converged,
+        )
+    if diagnostics is None:
+        return RuntimeObservedEvidence(
+            status="unknown",
+            observed_at=observed_at,
+            converged=False,
+        )
+    return RuntimeObservedEvidence(
+        status=diagnostics.status,
+        observed_at=observed_at,
+        converged=converged,
+    )
+
+
+def _runtime_observation_matches_desired(
+    *,
+    state: HostedRuntimeState,
+    observation: HostedRuntimeConfigObservation,
+    diagnostics: HostedRuntimeObservedV2 | None,
+    desired_source_revision: str | None,
+) -> bool:
+    if diagnostics is None or diagnostics.applied is None or desired_source_revision is None:
+        return False
+    expected_generation = resolve_runtime_apply_generation(
+        generation=state.generation,
+        apply_generation=state.apply_generation,
+    )
+    expected_etag = expected_runtime_bundle_v2_etag(desired_source_revision)
+    applied = diagnostics.applied
+    return (
+        observation.observed_config_generation == expected_generation
+        and observation.observed_manifest_etag == expected_etag
+        and observation.observed_source_revision == desired_source_revision
+        and applied.generation == expected_generation
+        and applied.etag == expected_etag
+        and applied.source_revision == desired_source_revision
+        and applied.instance_id == state.instance_id
+    )
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)

--- a/backend/app/services/whatsapp_provider_bridge.py
+++ b/backend/app/services/whatsapp_provider_bridge.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import secrets
+import time
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from typing import Literal, Protocol, TypeGuard
@@ -81,6 +82,7 @@ class WhatsAppProviderNodeRelayResult:
 @dataclass(frozen=True)
 class WhatsAppProviderTransportStatus:
     available: bool
+    reconnecting: bool
     mode: Literal["sidecar", "none"]
     reason: str | None
     supports_outbound_messages: bool
@@ -88,6 +90,7 @@ class WhatsAppProviderTransportStatus:
     def as_dict(self) -> dict[str, JsonValue]:
         return {
             "available": self.available,
+            "reconnecting": self.reconnecting,
             "mode": self.mode,
             "reason": self.reason,
             "supportsOutboundMessages": self.supports_outbound_messages,
@@ -107,6 +110,13 @@ class WhatsAppProviderTransport(Protocol):
 
 
 _PROVIDER_TRANSPORTS: dict[UUID, WhatsAppProviderTransport] = {}
+_PROVIDER_TRANSPORT_UNAVAILABLE_SINCE: dict[UUID, float] = {}
+_PROVIDER_TRANSPORTS_STARTED_AT = time.monotonic()
+_PROVIDER_TRANSPORT_RECONNECT_GRACE_SECONDS = 5 * 60
+
+
+def _transport_clock() -> float:
+    return time.monotonic()
 
 
 class WhatsAppProviderAccountRetired(Exception):
@@ -122,10 +132,13 @@ def register_whatsapp_provider_transport(
     if account_id in _PROVIDER_TRANSPORTS:
         raise RuntimeError(f"WhatsApp provider transport already registered for {account_id}")
     _PROVIDER_TRANSPORTS[account_id] = transport
+    _PROVIDER_TRANSPORT_UNAVAILABLE_SINCE.pop(account_id, None)
 
 
 def unregister_whatsapp_provider_transport(account_id: UUID) -> None:
-    _PROVIDER_TRANSPORTS.pop(account_id, None)
+    removed = _PROVIDER_TRANSPORTS.pop(account_id, None)
+    if removed is not None:
+        _PROVIDER_TRANSPORT_UNAVAILABLE_SINCE[account_id] = _transport_clock()
 
 
 def get_whatsapp_provider_transport(account_id: UUID) -> WhatsAppProviderTransport | None:
@@ -133,17 +146,30 @@ def get_whatsapp_provider_transport(account_id: UUID) -> WhatsAppProviderTranspo
 
 
 def whatsapp_provider_transport_status(account_id: UUID) -> WhatsAppProviderTransportStatus:
+    now = _transport_clock()
     transport = get_whatsapp_provider_transport(account_id)
     if transport is None:
+        unavailable_since = _PROVIDER_TRANSPORT_UNAVAILABLE_SINCE.get(
+            account_id, _PROVIDER_TRANSPORTS_STARTED_AT
+        )
         return WhatsAppProviderTransportStatus(
             available=False,
+            reconnecting=(now - unavailable_since < _PROVIDER_TRANSPORT_RECONNECT_GRACE_SECONDS),
             mode="none",
             reason="provider-transport-unavailable",
             supports_outbound_messages=False,
         )
     connected = _transport_connected(transport)
+    if connected:
+        _PROVIDER_TRANSPORT_UNAVAILABLE_SINCE.pop(account_id, None)
+        unavailable_since = now
+    else:
+        unavailable_since = _PROVIDER_TRANSPORT_UNAVAILABLE_SINCE.setdefault(account_id, now)
     return WhatsAppProviderTransportStatus(
         available=connected,
+        reconnecting=(
+            not connected and now - unavailable_since < _PROVIDER_TRANSPORT_RECONNECT_GRACE_SECONDS
+        ),
         mode="sidecar",
         reason=None if connected else "provider-transport-disconnected",
         supports_outbound_messages=True,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -279,6 +279,7 @@ strict = [
     "app/services/runtime_manifest_resources.py",
     "app/services/runtime_observation.py",
     "app/services/runtime_observation_retention_worker.py",
+    "app/services/runtime_observed_evidence.py",
     "app/services/runtime_source.py",
     "app/services/runtime_source_authority.py",
     "app/services/runtime_state_cleanup.py",

--- a/backend/tests/test_channel_debug_events.py
+++ b/backend/tests/test_channel_debug_events.py
@@ -373,6 +373,7 @@ async def test_channel_debug_health_reports_whatsapp_native_transport_status(
         "available": False,
         "mode": "none",
         "reason": "provider-transport-unavailable",
+        "reconnecting": True,
         "supportsOutboundMessages": False,
     }
 
@@ -391,5 +392,6 @@ async def test_channel_debug_health_reports_whatsapp_native_transport_status(
         "available": True,
         "mode": "sidecar",
         "reason": None,
+        "reconnecting": False,
         "supportsOutboundMessages": True,
     }

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -149,7 +149,7 @@ from app.services.whatsapp_provider_bridge import (
 )
 from tests.hosted_runtime_fixtures import (
     CANONICAL_CODEX_TOOLS,
-    canonical_codex_tool_provider_graph,
+    ensure_canonical_codex_tool_provider,
 )
 
 pytestmark = [pytest.mark.usefixtures("channel_agent"), pytest.mark.committed_db]
@@ -569,6 +569,62 @@ async def _seed_created_channel_link(
         agent_token=raw_token,
     )
     return link
+
+
+async def _converge_hosted_runtime(
+    db_session: AsyncSession,
+    *,
+    user,
+    agent_id: UUID,
+) -> HostedRuntimeConfigObservation:
+    state = await db_session.get(HostedRuntimeState, agent_id)
+    assert state is not None
+    state.tools = CANONICAL_CODEX_TOOLS
+    await ensure_canonical_codex_tool_provider(db_session, user)
+    await db_session.commit()
+
+    batch = await load_runtime_source_batch(
+        db_session,
+        environment_ids=[agent_id],
+        owner_user_id=user.id,
+    )
+    rendered = render_runtime_source(
+        batch,
+        environment_id=agent_id,
+        public_api_url=settings.public_api_url,
+        vault_key_identity=vault_key_identity(settings.vault_encryption_key),
+        decrypt_secrets=False,
+    )
+    observation = await db_session.get(HostedRuntimeConfigObservation, agent_id)
+    assert observation is not None
+    observed_at = datetime.now(UTC)
+    generation = resolve_runtime_apply_generation(
+        generation=state.generation,
+        apply_generation=state.apply_generation,
+    )
+    etag = expected_runtime_bundle_v2_etag(rendered.source_revision)
+    observation.observed_at = observed_at
+    observation.observed_config_generation = generation
+    observation.observed_manifest_etag = etag
+    observation.observed_source_revision = rendered.source_revision
+    observation.diagnostics = {
+        "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
+        "reportedAt": observed_at.isoformat(),
+        "runtimeMode": "hosted",
+        "status": "ok",
+        "activeCliVersion": state.cli_package_spec.removeprefix("clawdi@"),
+        "applied": {
+            "etag": etag,
+            "sourceRevision": rendered.source_revision,
+            "generation": generation,
+            "instanceId": state.instance_id,
+            "appliedProviderIds": [],
+        },
+        "boot": None,
+        "cli": None,
+    }
+    await db_session.commit()
+    return observation
 
 
 async def _create_public_channel_with_links(
@@ -2013,54 +2069,13 @@ async def test_channel_health_requires_fresh_converged_runtime_evidence(
     assert created_response.status_code == 201, created_response.text
     created = created_response.json()
 
-    state = await db_session.get(HostedRuntimeState, channel_agent.id)
-    assert state is not None
-    state.tools = CANONICAL_CODEX_TOOLS
-    provider, payload = canonical_codex_tool_provider_graph(seed_user)
-    db_session.add_all([provider, payload])
-    await db_session.commit()
-
-    batch = await load_runtime_source_batch(
+    observation = await _converge_hosted_runtime(
         db_session,
-        environment_ids=[channel_agent.id],
-        owner_user_id=seed_user.id,
+        user=seed_user,
+        agent_id=channel_agent.id,
     )
-    rendered = render_runtime_source(
-        batch,
-        environment_id=channel_agent.id,
-        public_api_url=settings.public_api_url,
-        vault_key_identity=vault_key_identity(settings.vault_encryption_key),
-        decrypt_secrets=False,
-    )
-    observation = await db_session.get(HostedRuntimeConfigObservation, channel_agent.id)
-    assert observation is not None
-    observed_at = datetime.now(UTC)
-    generation = resolve_runtime_apply_generation(
-        generation=state.generation,
-        apply_generation=state.apply_generation,
-    )
-    etag = expected_runtime_bundle_v2_etag(rendered.source_revision)
-    observation.observed_at = observed_at
-    observation.observed_config_generation = generation
-    observation.observed_manifest_etag = etag
-    observation.observed_source_revision = rendered.source_revision
-    observation.diagnostics = {
-        "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
-        "reportedAt": observed_at.isoformat(),
-        "runtimeMode": "hosted",
-        "status": "ok",
-        "activeCliVersion": state.cli_package_spec.removeprefix("clawdi@"),
-        "applied": {
-            "etag": etag,
-            "sourceRevision": rendered.source_revision,
-            "generation": generation,
-            "instanceId": state.instance_id,
-            "appliedProviderIds": [],
-        },
-        "boot": None,
-        "cli": None,
-    }
-    await db_session.commit()
+    assert observation.observed_at is not None
+    observed_at = observation.observed_at
 
     fresh_response = await client.get("/v1/channels/health")
     fresh = next(
@@ -4132,6 +4147,52 @@ async def test_delete_channel_agent_link_cleans_only_link_scoped_runtime_state(
 
 
 @pytest.mark.asyncio
+async def test_channel_agent_link_is_connected_only_after_runtime_convergence(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    channel_agent,
+):
+    created_response = await client.post(
+        "/v1/channels",
+        json={
+            "provider": "telegram",
+            "name": f"link-convergence-{uuid4().hex}",
+            "agent_id": str(channel_agent.id),
+        },
+    )
+    assert created_response.status_code == 201, created_response.text
+    created = created_response.json()
+
+    connecting = await client.get(f"/v1/channels/{created['id']}/agent-links")
+    assert connecting.status_code == 200, connecting.text
+    assert connecting.json()[0]["runtime_status"] == "connecting"
+
+    await _converge_hosted_runtime(
+        db_session,
+        user=seed_user,
+        agent_id=channel_agent.id,
+    )
+    connected = await client.get(
+        "/v1/channels/agent-links",
+        params={"agent_id": str(channel_agent.id)},
+    )
+    assert connected.status_code == 200, connected.text
+    item = next(link for link in connected.json() if link["account_id"] == created["id"])
+    assert item["runtime_status"] == "connected"
+
+    rotated = await client.post(
+        f"/v1/channels/{created['id']}/agent-links/{created['agent_link_id']}/token"
+    )
+    assert rotated.status_code == 200, rotated.text
+    assert rotated.json()["runtime_status"] == "connecting"
+
+    reconciling = await client.get(f"/v1/channels/{created['id']}/agent-links")
+    assert reconciling.status_code == 200, reconciling.text
+    assert reconciling.json()[0]["runtime_status"] == "connecting"
+
+
+@pytest.mark.asyncio
 async def test_list_channel_agent_links_by_agent_returns_linked_channel_summaries(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
@@ -4252,6 +4313,7 @@ async def test_list_channel_agent_links_by_agent_returns_linked_channel_summarie
     assert private_item["id"] == private["agent_link_id"]
     assert private_item["agent_id"] == str(channel_agent.id)
     assert private_item["status"] == "active"
+    assert private_item["runtime_status"] == "connecting"
     assert private_item["agent_token"] is None
     assert private_item["account"]["id"] == private["id"]
     assert private_item["account"]["name"] == private["name"]
@@ -4263,7 +4325,7 @@ async def test_list_channel_agent_links_by_agent_returns_linked_channel_summarie
     assert public_item["binding_count"] == 1
     assert other_private["id"] not in by_account_id
     assert other_user_listing.status_code == 404
-    assert select_count == 2
+    assert select_count == 8
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -44,6 +44,7 @@ from app.models.channel import (
     DELIVERY_STATUS_FAILED,
     DELIVERY_STATUS_IN_PROGRESS,
     DELIVERY_STATUS_PENDING,
+    DELIVERY_STATUS_SUCCEEDED,
     MESSAGE_DIRECTION_INBOUND,
     MESSAGE_DIRECTION_OUTBOUND,
     PAIR_CODE_STATUS_CLAIMED,
@@ -61,7 +62,7 @@ from app.models.channel import (
     ChannelSecret,
     ChannelWhatsAppAuthCert,
 )
-from app.models.hosted_runtime import HostedRuntimeState
+from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
 from app.models.runtime_observation import V2RuntimeEnvironmentFence
 from app.routes import admin as admin_router
 from app.routes.channel_routers import discord as discord_router
@@ -79,6 +80,7 @@ from app.schemas.channel import ChannelAccountCreate, ChannelAgentLinkCreate
 from app.services import channel_config as channel_config_service
 from app.services import channels as channel_service
 from app.services import sync_events
+from app.services import whatsapp_provider_bridge as whatsapp_provider_bridge_service
 from app.services.channel_debug_events import record_channel_debug_event
 from app.services.channel_delivery_worker import ChannelDeliveryWorker
 from app.services.channel_wakeups import notify_channel_inbound_message_enqueued
@@ -120,7 +122,14 @@ from app.services.discord_gateway_worker import (
     record_discord_gateway_dispatch,
 )
 from app.services.discord_rate_limiter import DiscordRateLimiter
+from app.services.runtime_generation import resolve_runtime_apply_generation
 from app.services.runtime_observation import retire_runtime_environment
+from app.services.runtime_source import (
+    expected_runtime_bundle_v2_etag,
+    load_runtime_source_batch,
+    render_runtime_source,
+    vault_key_identity,
+)
 from app.services.telegram_rate_limiter import telegram_rate_limiter
 from app.services.url_security import UnsafeOutboundUrlError
 from app.services.whatsapp_baileys import (
@@ -137,6 +146,10 @@ from app.services.whatsapp_provider_bridge import (
     persist_whatsapp_provider_event,
     register_whatsapp_provider_transport,
     unregister_whatsapp_provider_transport,
+)
+from tests.hosted_runtime_fixtures import (
+    CANONICAL_CODEX_TOOLS,
+    canonical_codex_tool_provider_graph,
 )
 
 pytestmark = [pytest.mark.usefixtures("channel_agent"), pytest.mark.committed_db]
@@ -1676,13 +1689,14 @@ async def test_channel_health_summarizes_delivery_and_debug_state(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("failure_age", "expected_status", "expected_reasons"),
+    ("failure_age", "expected_status", "expected_reasons", "expected_failed_deliveries"),
     [
-        pytest.param(timedelta(days=10), "ok", [], id="historical-failure"),
+        pytest.param(timedelta(days=10), "ok", [], 0, id="historical-failure"),
         pytest.param(
             timedelta(minutes=1),
             "error",
             ["failed_deliveries", "recent_error"],
+            1,
             id="current-failure",
         ),
     ],
@@ -1694,6 +1708,7 @@ async def test_whatsapp_channel_health_only_surfaces_current_delivery_failures(
     failure_age: timedelta,
     expected_status: str,
     expected_reasons: list[str],
+    expected_failed_deliveries: int,
 ):
     class ConnectedWhatsAppTransport:
         connected = True
@@ -1759,9 +1774,339 @@ async def test_whatsapp_channel_health_only_surfaces_current_delivery_failures(
     assert health["reasons"] == expected_reasons
     assert health["pending_deliveries"] == 0
     assert health["in_progress_deliveries"] == 0
-    assert health["failed_deliveries"] == 1
+    assert health["failed_deliveries"] == expected_failed_deliveries
     assert health["last_error"] == "channel_delivery_failed"
     assert health["native_transport"]["available"] is True
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_channel_health_graces_transport_reconnection_after_restart(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class ConnectedWhatsAppTransport:
+        connected = True
+
+        async def relay_outbound_message(self, message):
+            return None
+
+        async def relay_raw_node(self, node):
+            return None
+
+        async def query_iq(self, node, timeout_ms):
+            return None
+
+    clock = [1_000.0]
+    monkeypatch.setattr(
+        whatsapp_provider_bridge_service,
+        "_PROVIDER_TRANSPORTS_STARTED_AT",
+        clock[0],
+    )
+    monkeypatch.setattr(
+        whatsapp_provider_bridge_service,
+        "_PROVIDER_TRANSPORT_UNAVAILABLE_SINCE",
+        {},
+    )
+    monkeypatch.setattr(
+        whatsapp_provider_bridge_service,
+        "_transport_clock",
+        lambda: clock[0],
+    )
+    created_response = await client.post(
+        "/v1/channels",
+        json={"provider": "whatsapp", "name": f"health-reconnect-{uuid4().hex}"},
+    )
+    assert created_response.status_code == 201, created_response.text
+    account_id = UUID(created_response.json()["id"])
+
+    try:
+        reconnecting_response = await client.get("/v1/channels/health")
+        reconnecting = next(
+            item
+            for item in reconnecting_response.json()["items"]
+            if item["account_id"] == str(account_id)
+        )
+        assert reconnecting["health_status"] == "warning"
+        assert reconnecting["reasons"] == ["native_transport_reconnecting"]
+        assert reconnecting["native_transport"]["reconnecting"] is True
+
+        clock[0] += 301
+        unavailable_response = await client.get("/v1/channels/health")
+        unavailable = next(
+            item
+            for item in unavailable_response.json()["items"]
+            if item["account_id"] == str(account_id)
+        )
+        assert unavailable["health_status"] == "error"
+        assert unavailable["reasons"] == ["native_transport_unavailable"]
+        assert unavailable["native_transport"]["reconnecting"] is False
+
+        register_whatsapp_provider_transport(account_id, ConnectedWhatsAppTransport())
+        connected_response = await client.get("/v1/channels/health")
+        connected = next(
+            item
+            for item in connected_response.json()["items"]
+            if item["account_id"] == str(account_id)
+        )
+        assert connected["health_status"] == "ok"
+        assert connected["reasons"] == []
+        assert connected["native_transport"]["available"] is True
+    finally:
+        unregister_whatsapp_provider_transport(account_id)
+
+
+@pytest.mark.asyncio
+async def test_non_whatsapp_channel_health_expires_failures_and_clears_them_after_success(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    channel_agent,
+):
+    created_response = await client.post(
+        "/v1/channels",
+        json={
+            "provider": "telegram",
+            "name": f"health-window-{uuid4().hex}",
+            "agent_id": str(channel_agent.id),
+        },
+    )
+    assert created_response.status_code == 201, created_response.text
+    created = created_response.json()
+    account_id = UUID(created["id"])
+    link_id = UUID(created["agent_link_id"])
+    account = await db_session.get(ChannelAccount, account_id)
+    assert account is not None
+    now = datetime.now(UTC)
+
+    historical_message = ChannelMessage(
+        account_id=account_id,
+        bot_agent_link_id=link_id,
+        user_id=seed_user.id,
+        direction=MESSAGE_DIRECTION_OUTBOUND,
+        external_chat_id="historical-failure",
+        text="historical failure",
+        payload={},
+        created_at=now - timedelta(days=10),
+        updated_at=now - timedelta(days=10),
+    )
+    recent_failed_message = ChannelMessage(
+        account_id=account_id,
+        bot_agent_link_id=link_id,
+        user_id=seed_user.id,
+        direction=MESSAGE_DIRECTION_OUTBOUND,
+        external_chat_id="recent-failure",
+        text="recent failure",
+        payload={},
+        created_at=now - timedelta(minutes=2),
+        updated_at=now - timedelta(minutes=2),
+    )
+    successful_message = ChannelMessage(
+        account_id=account_id,
+        bot_agent_link_id=link_id,
+        user_id=seed_user.id,
+        direction=MESSAGE_DIRECTION_OUTBOUND,
+        external_chat_id="successful-delivery",
+        text="success",
+        payload={},
+        created_at=now - timedelta(minutes=1),
+        updated_at=now - timedelta(minutes=1),
+    )
+    db_session.add_all([historical_message, recent_failed_message, successful_message])
+    await db_session.flush()
+    db_session.add_all(
+        [
+            ChannelDelivery(
+                account_id=account_id,
+                bot_agent_link_id=link_id,
+                message_id=historical_message.id,
+                user_id=seed_user.id,
+                status=DELIVERY_STATUS_FAILED,
+                attempts=5,
+                max_attempts=5,
+                next_attempt_at=now - timedelta(days=10),
+                last_error="historical provider failure",
+                created_at=now - timedelta(days=10),
+                updated_at=now - timedelta(days=10),
+            ),
+            ChannelDelivery(
+                account_id=account_id,
+                bot_agent_link_id=link_id,
+                message_id=recent_failed_message.id,
+                user_id=seed_user.id,
+                status=DELIVERY_STATUS_FAILED,
+                attempts=5,
+                max_attempts=5,
+                next_attempt_at=now - timedelta(minutes=2),
+                last_error="recent provider failure",
+                created_at=now - timedelta(minutes=2),
+                updated_at=now - timedelta(minutes=2),
+            ),
+            ChannelDelivery(
+                account_id=account_id,
+                bot_agent_link_id=link_id,
+                message_id=successful_message.id,
+                user_id=seed_user.id,
+                status=DELIVERY_STATUS_SUCCEEDED,
+                attempts=1,
+                max_attempts=5,
+                next_attempt_at=now - timedelta(minutes=1),
+                created_at=now - timedelta(minutes=1),
+                updated_at=now - timedelta(minutes=1),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    await record_channel_debug_event(
+        db_session,
+        account=account,
+        user_id=seed_user.id,
+        provider="telegram",
+        direction="outbound",
+        stage="delivery",
+        outcome="failure",
+        error="provider rejected request",
+    )
+    await db_session.commit()
+    failed_response = await client.get("/v1/channels/health")
+    assert failed_response.status_code == 200, failed_response.text
+    failed_health = next(
+        item for item in failed_response.json()["items"] if item["account_id"] == created["id"]
+    )
+    assert "recent_error" in failed_health["reasons"]
+
+    await record_channel_debug_event(
+        db_session,
+        account=account,
+        user_id=seed_user.id,
+        provider="telegram",
+        direction="outbound",
+        stage="delivery",
+        outcome="success",
+    )
+    await db_session.commit()
+    response = await client.get("/v1/channels/health")
+
+    assert response.status_code == 200, response.text
+    health = next(item for item in response.json()["items"] if item["account_id"] == created["id"])
+    assert health["failed_deliveries"] == 0
+    assert "failed_deliveries" not in health["reasons"]
+    assert "recent_error" not in health["reasons"]
+    assert health["last_error"] is None
+
+
+@pytest.mark.asyncio
+async def test_channel_health_requires_fresh_converged_runtime_evidence(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    channel_agent,
+):
+    created_response = await client.post(
+        "/v1/channels",
+        json={
+            "provider": "telegram",
+            "name": f"health-runtime-{uuid4().hex}",
+            "agent_id": str(channel_agent.id),
+        },
+    )
+    assert created_response.status_code == 201, created_response.text
+    created = created_response.json()
+
+    state = await db_session.get(HostedRuntimeState, channel_agent.id)
+    assert state is not None
+    state.tools = CANONICAL_CODEX_TOOLS
+    provider, payload = canonical_codex_tool_provider_graph(seed_user)
+    db_session.add_all([provider, payload])
+    await db_session.commit()
+
+    batch = await load_runtime_source_batch(
+        db_session,
+        environment_ids=[channel_agent.id],
+        owner_user_id=seed_user.id,
+    )
+    rendered = render_runtime_source(
+        batch,
+        environment_id=channel_agent.id,
+        public_api_url=settings.public_api_url,
+        vault_key_identity=vault_key_identity(settings.vault_encryption_key),
+        decrypt_secrets=False,
+    )
+    observation = await db_session.get(HostedRuntimeConfigObservation, channel_agent.id)
+    assert observation is not None
+    observed_at = datetime.now(UTC)
+    generation = resolve_runtime_apply_generation(
+        generation=state.generation,
+        apply_generation=state.apply_generation,
+    )
+    etag = expected_runtime_bundle_v2_etag(rendered.source_revision)
+    observation.observed_at = observed_at
+    observation.observed_config_generation = generation
+    observation.observed_manifest_etag = etag
+    observation.observed_source_revision = rendered.source_revision
+    observation.diagnostics = {
+        "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
+        "reportedAt": observed_at.isoformat(),
+        "runtimeMode": "hosted",
+        "status": "ok",
+        "activeCliVersion": state.cli_package_spec.removeprefix("clawdi@"),
+        "applied": {
+            "etag": etag,
+            "sourceRevision": rendered.source_revision,
+            "generation": generation,
+            "instanceId": state.instance_id,
+            "appliedProviderIds": [],
+        },
+        "boot": None,
+        "cli": None,
+    }
+    await db_session.commit()
+
+    fresh_response = await client.get("/v1/channels/health")
+    fresh = next(
+        item for item in fresh_response.json()["items"] if item["account_id"] == created["id"]
+    )
+    assert fresh["health_status"] == "ok"
+    assert fresh["reasons"] == []
+
+    observation.observed_at = observed_at - timedelta(
+        seconds=settings.runtime_observation_freshness_seconds + 1
+    )
+    await db_session.commit()
+    stale_response = await client.get("/v1/channels/health")
+    stale = next(
+        item for item in stale_response.json()["items"] if item["account_id"] == created["id"]
+    )
+    assert stale["health_status"] == "warning"
+    assert "runtime_observation_stale" in stale["reasons"]
+
+
+@pytest.mark.asyncio
+async def test_channel_health_reports_an_unlinked_channel_without_implying_runtime_wait(
+    client: httpx.AsyncClient,
+    channel_agent,
+):
+    created_response = await client.post(
+        "/v1/channels",
+        json={
+            "provider": "telegram",
+            "name": f"health-unlinked-{uuid4().hex}",
+            "agent_id": str(channel_agent.id),
+        },
+    )
+    assert created_response.status_code == 201, created_response.text
+    created = created_response.json()
+
+    unlinked_response = await client.delete(
+        f"/v1/channels/{created['id']}/agent-links/{created['agent_link_id']}"
+    )
+    assert unlinked_response.status_code == 204, unlinked_response.text
+
+    response = await client.get("/v1/channels/health")
+    assert response.status_code == 200, response.text
+    health = next(item for item in response.json()["items"] if item["account_id"] == created["id"])
+    assert health["health_status"] == "warning"
+    assert health["reasons"] == ["agent_not_linked"]
 
 
 @pytest.mark.asyncio
@@ -1801,7 +2146,7 @@ async def test_channel_health_select_count_is_constant_across_accounts(
         await create_account(index)
     five_account_count = await health_select_count()
 
-    assert one_account_count == 7
+    assert one_account_count == 15
     assert five_account_count == one_account_count
 
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -145,6 +145,11 @@ def test_runtime_observation_settings_require_positive_bounds(field: str):
         Settings(_env_file=None, **{field: 0})
 
 
+def test_runtime_observation_freshness_allows_two_heartbeat_intervals(monkeypatch):
+    monkeypatch.delenv("RUNTIME_OBSERVATION_FRESHNESS_SECONDS", raising=False)
+    assert Settings(_env_file=None).runtime_observation_freshness_seconds == 150
+
+
 def test_runtime_observation_hard_retention_cannot_precede_replay_horizon():
     with pytest.raises(ValidationError, match="hard_retention_days"):
         Settings(

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -2306,7 +2306,10 @@ async def test_snapshot_and_high_water_share_one_repeatable_read_snapshot(
     assert first.stream_position < second.stream_position
     assert incremental["events"][0]["runtimeIdentity"]["bootSessionId"] == ("boot-session-0001")
     assert (
-        incremental["events"][0]["freshnessDeadline"] == (base + timedelta(seconds=91)).isoformat()
+        incremental["events"][0]["freshnessDeadline"]
+        == (
+            base + timedelta(seconds=1 + settings.runtime_observation_freshness_seconds)
+        ).isoformat()
     )
     assert set(incremental["events"][0]["evidenceReference"]) == {"eventId", "cursor"}
     assert "streamPosition" not in incremental

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -1657,6 +1657,10 @@ async def test_runtime_observed_summary_has_bounded_queries_without_secret_decry
     )
     assert by_env[missing_state_env_id]["health"]["status"] == "not_configured"
 
+    canonical = await client.get("/v1/agents/runtime-observed")
+    assert canonical.status_code == 200, canonical.text
+    assert canonical.json() == payload
+
 
 @pytest.mark.asyncio
 async def test_sync_heartbeat_rejects_malformed_observed_scalar(

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -857,11 +857,24 @@ async def test_runtime_health_fences_stale_instance_source_and_freshness(
     )
     assert heartbeat.status_code == 204, heartbeat.text
 
-    stale_at = datetime.now(UTC) - timedelta(minutes=5)
     observation = await db_session.get(HostedRuntimeConfigObservation, uuid.UUID(env_id))
     agent = await db_session.get(AgentEnvironment, uuid.UUID(env_id))
     assert observation is not None
     assert agent is not None
+
+    still_fresh_at = datetime.now(UTC) - timedelta(seconds=120)
+    observation.observed_at = still_fresh_at
+    agent.last_sync_at = still_fresh_at
+    await db_session.commit()
+
+    fresh_response = await client.get(f"/v1/agents/{env_id}/runtime-observed")
+    assert fresh_response.status_code == 200, fresh_response.text
+    fresh_health = fresh_response.json()["health"]
+    assert fresh_health["status"] == "unknown"
+    assert "daemon_stale" not in fresh_health["reasons"]
+    assert "runtime_observed_stale" not in fresh_health["reasons"]
+
+    stale_at = datetime.now(UTC) - timedelta(seconds=151)
     observation.observed_at = stale_at
     agent.last_sync_at = stale_at
     await db_session.commit()

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -437,9 +437,9 @@ function printAgentStatus(report: DaemonStatusReport): void {
 	console.log(`agent:   ${report.agent}`);
 	console.log(`state:   ${report.state_dir}`);
 	if (health.exists) {
-		// The 90s cutoff matches the dashboard's "online/offline"
-		// freshness window. A daemon writing `health` more recently
-		// than that AND posting heartbeats is what we call "live".
+		// The local health file has its own 90s freshness window. Cloud
+		// runtime evidence uses a wider two-heartbeat window because it
+		// also includes network delivery jitter.
 		console.log(
 			`health:  ${health.fresh ? "✓ live" : "stale"} (last write ${health.ageSeconds}s ago)`,
 		);

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -4503,6 +4503,12 @@ export interface components {
             /** Status */
             status: string;
             /**
+             * Runtime Status
+             * @default connecting
+             * @enum {string}
+             */
+            runtime_status: "connecting" | "connected";
+            /**
              * Created At
              * Format: date-time
              */
@@ -4529,6 +4535,12 @@ export interface components {
             agent_id: string;
             /** Status */
             status: string;
+            /**
+             * Runtime Status
+             * @default connecting
+             * @enum {string}
+             */
+            runtime_status: "connecting" | "connected";
             /**
              * Created At
              * Format: date-time

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -894,6 +894,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/agents/runtime-observed": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Agent Runtime Observed */
+        get: operations["list_agent_runtime_observed_v1_agents_runtime_observed_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/agents/order": {
         parameters: {
             query?: never;
@@ -10139,6 +10156,37 @@ export interface operations {
         };
     };
     list_environment_runtime_observed_v1_environments_runtime_observed_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RuntimeObservedSummaryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_agent_runtime_observed_v1_agents_runtime_observed_get: {
         parameters: {
             query?: {
                 limit?: number;


### PR DESCRIPTION
## Summary

Make positive user-facing status depend on fresh observed runtime evidence, and bound negative delivery/error state to a recent window that is cleared by later success.

| Surface | Lying condition | Fixed behavior |
| --- | --- | --- |
| S1: Channel health | Lifetime delivery failures and 24-hour debug errors stayed red after recovery; an idle or dead linked runtime could still produce Healthy. A Cloud API restart also made every WhatsApp transport look permanently unavailable. | Delivery failures are counted only inside the 24-hour window and after the latest success. A later successful debug or delivery event clears older error evidence. Non-WhatsApp health requires fresh, converged runtime evidence. WhatsApp transport absence is amber **Reconnecting** for five minutes after process start or transport disconnect, red after the grace expires, and green only after the native transport reconnects. |
| S2: Channel connections | An account/link row was presented as Connected before the runtime applied the manifest generation containing it. A stopped hosted Agent could remain labeled Connecting. | Link responses expose `runtime_status`; Connected requires a fresh successful observation that exactly matches the current generation, source revision, bundle etag, and instance id. Token rotation returns the link to Connecting until a new receipt arrives. Hosted Agent summaries show **Agent stopped** when deployment authority is stopped, and unlinked channels show **Not linked** rather than implying runtime work is pending. |
| S3: Skills | The UI has desired Skill inventory but no structured per-Skill runtime result, so failures cannot be attributed safely. | No synthetic success or failure was added. The exact observation-wire gap is documented below; desired state and Agent Plugin evidence are not reused as Skill observation. |
| S4: AI providers | Provider cards exposed saved/readiness state but hid the existing per-provider runtime observation. | Cards aggregate the canonical Agent runtime summary. Green **Observed OK** requires fresh healthy runtime and provider evidence for every Agent using that provider. Fresh provider errors show **Degraded** with allowlisted copy; stale, unknown, or missing evidence is neutral. Managed API-key saves automatically run the existing connection test without rolling back a successful save when the test fails. |

## Freshness consumers

The observation evidence window is intentionally unified at 150 seconds, covering two 60 +/- 15 second reporting intervals:

1. Backend runtime-observed summaries derive stale health from `runtime_observation_freshness_seconds`.
2. Channel health and link convergence consume the same fresh observation evidence.
3. Web daemon status uses the same 150-second window.
4. Hosted controller readiness consumes `freshnessDeadline`; its evidence validity moves from 90 to 150 seconds, and the visibility delay for a genuinely dead runtime therefore also moves from 90 to 150 seconds.

The CLI's local health file remains an independent 90-second signal; only its stale comment was corrected.

## Compatibility

The deprecated `/v1/environments/runtime-observed` handler remains the original byte-frozen `list_environment_runtime_observed` function. `/v1/agents/runtime-observed` is served by a separate new handler, and the generated shared API client was regenerated.

## Observation wire gap: Skills

`packages/cli/src/runtime/observed.ts` serializes `boot`, `cli`, `systemd`, `providers`, and optional `agentPlugins`. The backend's strict observation schema has no `skills` field and forbids extras. Skill projection currently produces local `failures: string[]` values that are folded into `state.resourceProjectionErrors`, so there is no durable structured per-Skill observation to expose.

A future wire addition needs, at minimum, `skills[].skillKey`, `status`, `appliedGeneration`, `sourceRevision`, and a sanitized `reasonCode`. `agentPlugins` is a different resource and must not be reused for Skills.

## Performance note

The Agent Links polling path now batches runtime source and observation reads per request. There is no existing generation-aware memoization boundary for `render_runtime_source` plus source SHA computation, so this PR does not add a cross-request cache without a complete invalidation contract. The main-branch hot-path work in #1211 does not introduce that cache.

## Verification

### Local

- `bun run test`: passed in the isolated Docker runner; workspace typecheck and JS tests passed, backend reported `2379 passed, 12 skipped`.
- `bun run check`: passed (`1079` files, no fixes).
- Backend Ruff lint and format check: passed (`361` files formatted).
- Backend `compileall`: passed.
- Generated OpenAPI client consistency: passed.
- Type governance `owned`: `196` files, 0 errors/warnings/information.
- Type governance `exceptions`: passed with the existing 34 audited diagnostics.
- Type governance `inventory`: completed successfully with the existing repository inventory.

### GitHub CI

`gh pr checks 1210` passed for head `7c730519d`:

- `lint-and-typecheck`: pass (3m25s)
- `test`: pass (4m52s)
- `verify`: pass (5m41s)
- `web-e2e`: pass (4m24s)
- `docker-runner`: pass (3m0s)
- `privileged-systemd-e2e`: pass (15m6s)
- Vercel, Vercel Preview Comments, and both `changes` jobs: pass
- `deploy-contract-drift`, `deploy-contract-drift-daily`, `sidecar`, and `whatsapp-native-e2e`: skipped by workflow conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
