### PR TITLE
perf(backend): eliminate daemon and channel hot-path churn

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -14,7 +14,7 @@ import jwt
 from fastapi import Depends, Header, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field, JsonValue, TypeAdapter, ValidationError
-from sqlalchemy import or_, select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -22,6 +22,7 @@ from app.core.config import canonical_clerk_issuer, settings
 from app.core.database import get_session
 from app.models.api_key import ApiKey
 from app.models.principal_lifecycle import PrincipalLifecycle
+from app.models.session import AgentEnvironment
 from app.models.user import PRINCIPAL_KIND_CLERK, User
 from app.schemas.problem import ACCOUNT_SUSPENDED_DETAIL, AccountSuspendedProblem
 from app.services.app_setting_registry import CLERK_CLI_OAUTH_SPEC
@@ -35,6 +36,8 @@ from app.services.principal_lifecycle import (
     assert_clerk_principal_active,
     assert_user_authority_active,
     load_clerk_user_for_issuer,
+    lock_api_key_user_authority_shared,
+    user_authority_sql_expressions,
 )
 from app.services.user_provisioning import lazy_create_user_with_personal_project
 
@@ -159,6 +162,15 @@ class _CachedApiKeyAuth:
             revoked_at=None,
         )
         return AuthContext(user=user, api_key=api_key, api_key_project_id=self.api_key_project_id)
+
+
+@dataclass(frozen=True, slots=True)
+class _ApiKeyAuthority:
+    api_key: ApiKey
+    user: User | None
+    api_key_project_id: UUID | None
+    suspended: bool
+    disabled: bool
 
 
 _api_key_auth_cache: dict[str, tuple[float, _CachedApiKeyAuth]] = {}
@@ -292,8 +304,6 @@ async def _auth_via_api_key(token: str, db: AsyncSession) -> AuthContext | None:
         # post-commit invalidation, and so other worker-local caches fail
         # closed immediately after they observe the committed archive.
         if cached.api_key is not None and cached.api_key.environment_id is not None:
-            from app.models.session import AgentEnvironment
-
             active_key_id = await db.scalar(
                 select(ApiKey.id)
                 .join(
@@ -311,61 +321,114 @@ async def _auth_via_api_key(token: str, db: AsyncSession) -> AuthContext | None:
                 raise HTTPException(status.HTTP_401_UNAUTHORIZED, "API key has been revoked")
         return cached
 
-    result = await db.execute(select(ApiKey).where(ApiKey.key_hash == key_hash))
-    api_key = result.scalar_one_or_none()
-
-    if not api_key:
+    # A separate statement after the advisory lock is intentional: under
+    # READ COMMITTED a statement snapshot is fixed before a lock wait, so the
+    # joined authority read must start only after any committed lifecycle
+    # mutation holding the exclusive lock has finished.
+    user_id = await lock_api_key_user_authority_shared(db, key_hash)
+    if user_id is None:
         return None
-    if api_key.revoked_at:
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "API key has been revoked")
+    authority = await _load_api_key_authority(db, key_hash)
+    if authority is None:
+        return None
     now = datetime.now(UTC)
-    if api_key.expires_at and api_key.expires_at < now:
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "API key has expired")
-
-    result = await db.execute(select(User).where(User.id == api_key.user_id))
-    user = result.scalar_one_or_none()
-    if not user:
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "User not found")
-    await _assert_active_user_or_401(db, user.id)
+    context = _validated_api_key_auth_context(authority, now=now)
 
     # Throttle last_used_at writes: once per LAST_USED_THROTTLE per key.
-    last = api_key.last_used_at
+    last = authority.api_key.last_used_at
     if last is None or (now - last) > LAST_USED_THROTTLE:
-        api_key.last_used_at = now
+        authority.api_key.last_used_at = now
         await db.commit()
-        # Commit releases the authority lock. Reacquire and recheck before
-        # returning a credential snapshot to the route.
-        await _assert_active_user_or_401(db, user.id)
-
-    api_key_project_id = None
-    if api_key.environment_id is not None:
-        from app.models.session import AgentEnvironment
-
-        api_key_project_id = (
-            await db.execute(
-                select(AgentEnvironment.default_project_id).where(
-                    AgentEnvironment.id == api_key.environment_id,
-                    AgentEnvironment.user_id == api_key.user_id,
-                    AgentEnvironment.archived_at.is_(None),
-                )
-            )
-        ).scalar_one_or_none()
-        if api_key_project_id is None:
-            raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Agent is archived")
+        # Commit releases the authority lock. Reacquire it and rerun the full
+        # key/user/lifecycle/Agent read before returning authority.
+        if await lock_api_key_user_authority_shared(db, key_hash) is None:
+            raise HTTPException(status.HTTP_401_UNAUTHORIZED, "API key has been revoked")
+        authority = await _load_api_key_authority(db, key_hash)
+        if authority is None:
+            raise HTTPException(status.HTTP_401_UNAUTHORIZED, "API key has been revoked")
+        now = datetime.now(UTC)
+        context = _validated_api_key_auth_context(authority, now=now)
 
     # Agent-bound keys are lifecycle authority and must never be installed in
     # a process-local cache. A cache fill racing archive commit could otherwise
     # happen after the archive caller's post-commit invalidation. Unbound keys
     # retain the existing cache behavior.
-    if api_key.environment_id is None:
+    if authority.api_key.environment_id is None:
         _cache_api_key_auth(
             key_hash=key_hash,
-            api_key=api_key,
-            user=user,
-            api_key_project_id=api_key_project_id,
+            api_key=authority.api_key,
+            user=context.user,
+            api_key_project_id=authority.api_key_project_id,
             now=now,
         )
-    return AuthContext(user=user, api_key=api_key, api_key_project_id=api_key_project_id)
+    return context
+
+
+async def _load_api_key_authority(
+    db: AsyncSession,
+    key_hash: str,
+) -> _ApiKeyAuthority | None:
+    expressions = user_authority_sql_expressions()
+    row = (
+        await db.execute(
+            select(
+                ApiKey,
+                User,
+                AgentEnvironment.default_project_id,
+                expressions.suspended.label("principal_suspended"),
+                expressions.disabled.label("principal_disabled"),
+            )
+            .outerjoin(User, User.id == ApiKey.user_id)
+            .outerjoin(
+                AgentEnvironment,
+                and_(
+                    AgentEnvironment.id == ApiKey.environment_id,
+                    AgentEnvironment.user_id == ApiKey.user_id,
+                    AgentEnvironment.archived_at.is_(None),
+                ),
+            )
+            .where(ApiKey.key_hash == key_hash)
+            .execution_options(populate_existing=True)
+        )
+    ).one_or_none()
+    if row is None:
+        return None
+    api_key, user, api_key_project_id, suspended, disabled = row
+    return _ApiKeyAuthority(
+        api_key=api_key,
+        user=user,
+        api_key_project_id=api_key_project_id,
+        suspended=bool(suspended),
+        disabled=bool(disabled),
+    )
+
+
+def _validated_api_key_auth_context(
+    authority: _ApiKeyAuthority,
+    *,
+    now: datetime,
+) -> AuthContext:
+    api_key = authority.api_key
+    if api_key.revoked_at:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "API key has been revoked")
+    if api_key.expires_at and api_key.expires_at < now:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "API key has expired")
+    user = authority.user
+    if user is None:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "User not found")
+    if authority.suspended:
+        invalidate_user_api_key_auth_cache(user.id)
+        raise AccountSuspendedHTTPException()
+    if authority.disabled:
+        invalidate_user_api_key_auth_cache(user.id)
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated")
+    if api_key.environment_id is not None and authority.api_key_project_id is None:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Agent is archived")
+    return AuthContext(
+        user=user,
+        api_key=api_key,
+        api_key_project_id=authority.api_key_project_id,
+    )
 
 
 async def _auth_via_dev_bypass(token: str, db: AsyncSession) -> AuthContext | None:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -311,10 +311,10 @@ class Settings(BaseSettings):
     memory_embedding_base_url: str = ""
     memory_embedding_model: str = "text-embedding-3-small"
 
-    # Channel emulation waits. Production defaults preserve the native APIs'
-    # long-poll behaviour; tests can lower these without changing route code.
+    # Channel emulation waits. PostgreSQL notifications wake normal long polls;
+    # the interval is a bounded fallback for listener failure or notification loss.
     channel_long_poll_max_seconds: float = 30.0
-    channel_long_poll_interval_seconds: float = 0.1
+    channel_long_poll_interval_seconds: float = 5.0
     discord_gateway_poll_interval_seconds: float = 1.0
     channel_message_retention_days: Annotated[int, Field(gt=0, le=3_650)] = 30
     channel_unbound_message_retention_hours: Annotated[int, Field(gt=0, le=87_600)] = 24

--- a/backend/app/routes/channel_routers/whatsapp.py
+++ b/backend/app/routes/channel_routers/whatsapp.py
@@ -30,7 +30,10 @@ from app.routes.channel_routers.shared import (
     optional_str,
 )
 from app.services.channel_debug_events import record_channel_debug_event
-from app.services.channel_wakeups import channel_inbound_messages_enqueued
+from app.services.channel_wakeups import (
+    channel_inbound_messages_enqueued,
+    wait_for_channel_inbound_messages,
+)
 from app.services.channels import (
     get_active_channel_account,
     resolve_channel_agent_by_identity,
@@ -592,53 +595,38 @@ async def _wait_whatsapp_websocket_inbox(
     after_sequence: int,
     limit: int = 100,
 ) -> list[WhatsAppInboxPumpEvent]:
-    timeout = max(0.0, min(settings.channel_long_poll_max_seconds, 30.0))
-    poll_interval = max(0.001, settings.channel_long_poll_interval_seconds)
-    deadline = asyncio.get_running_loop().time() + timeout
-    notified = channel_inbound_messages_enqueued.subscribe()
-    try:
-        while True:
-            notified.clear()
-            async with async_session_factory() as db:
-                result = await db.execute(
-                    select(ChannelMessage)
-                    .where(
-                        ChannelMessage.account_id == account_id,
-                        ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
-                        ChannelMessage.binding_id.is_not(None),
-                        ChannelMessage.delivered_at.is_(None),
-                        ChannelMessage.inbox_sequence > after_sequence,
-                        ChannelMessage.bot_agent_link_id == bot_agent_link_id,
-                    )
-                    .order_by(ChannelMessage.inbox_sequence, ChannelMessage.created_at)
-                    .limit(max(0, limit))
+    async def fetch() -> list[ChannelMessage]:
+        async with async_session_factory() as db:
+            result = await db.execute(
+                select(ChannelMessage)
+                .where(
+                    ChannelMessage.account_id == account_id,
+                    ChannelMessage.direction == MESSAGE_DIRECTION_INBOUND,
+                    ChannelMessage.binding_id.is_not(None),
+                    ChannelMessage.delivered_at.is_(None),
+                    ChannelMessage.inbox_sequence > after_sequence,
+                    ChannelMessage.bot_agent_link_id == bot_agent_link_id,
                 )
-                messages = list(result.scalars().all())
-            if messages or timeout == 0 or asyncio.get_running_loop().time() >= deadline:
-                return [
-                    WhatsAppInboxPumpEvent(
-                        sequence=message.inbox_sequence,
-                        external_chat_id=message.external_chat_id,
-                        payload=message.payload if isinstance(message.payload, dict) else {},
-                        provider_message_id=message.provider_message_id,
-                        text=message.text,
-                    )
-                    for message in messages
-                ]
-            if notified.is_set():
-                continue
-            try:
-                await asyncio.wait_for(
-                    notified.wait(),
-                    timeout=min(
-                        poll_interval,
-                        max(0.0, deadline - asyncio.get_running_loop().time()),
-                    ),
-                )
-            except TimeoutError:
-                pass
-    finally:
-        channel_inbound_messages_enqueued.unsubscribe(notified)
+                .order_by(ChannelMessage.inbox_sequence, ChannelMessage.created_at)
+                .limit(max(0, limit))
+            )
+            return list(result.scalars().all())
+
+    messages = await wait_for_channel_inbound_messages(
+        fetch,
+        timeout_seconds=settings.channel_long_poll_max_seconds,
+        wakeup=channel_inbound_messages_enqueued,
+    )
+    return [
+        WhatsAppInboxPumpEvent(
+            sequence=message.inbox_sequence,
+            external_chat_id=message.external_chat_id,
+            payload=message.payload if isinstance(message.payload, dict) else {},
+            provider_message_id=message.provider_message_id,
+            text=message.text,
+        )
+        for message in messages
+    ]
 
 
 async def _ack_whatsapp_websocket_inbox(

--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hmac
 import io
 import tarfile
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from urllib.parse import quote
 from uuid import UUID
@@ -65,6 +66,13 @@ _MAX_PROJECT_SKILL_ARCHIVE_BYTES = 25 * 1024 * 1024
 file_store = get_file_store()
 
 
+@dataclass(frozen=True, slots=True)
+class _RuntimeManifestSnapshot:
+    source: RenderedRuntimeSource | None
+    etag: str | None
+    repair_link_ids: tuple[UUID, ...]
+
+
 @router.get("/manifest")
 async def get_runtime_manifest(
     request: Request,
@@ -89,28 +97,31 @@ async def get_runtime_manifest(
     project_agent_plugin_github_release_sources = (
         RUNTIME_AGENT_PLUGIN_GITHUB_RELEASE_SOURCE_CAPABILITY in capabilities
     )
+    if_none_match = request.headers.get("if-none-match")
     try:
-        source, repair_link_ids = await _render_runtime_source_snapshot(
+        snapshot = await _render_runtime_source_snapshot(
             environment_id=environment_id,
             owner_user_id=auth.user_id,
+            if_none_match=if_none_match,
             project_agent_plugins=project_agent_plugins,
             project_agent_plugin_github_release_sources=project_agent_plugin_github_release_sources,
         )
-        if repair_link_ids:
+        if snapshot.repair_link_ids:
             await ensure_runtime_whatsapp_credentials(
                 db,
                 environment_id=environment_id,
                 owner_user_id=auth.user_id,
-                link_ids=repair_link_ids,
+                link_ids=snapshot.repair_link_ids,
             )
             await db.commit()
-            source, repair_link_ids = await _render_runtime_source_snapshot(
+            snapshot = await _render_runtime_source_snapshot(
                 environment_id=environment_id,
                 owner_user_id=auth.user_id,
+                if_none_match=if_none_match,
                 project_agent_plugins=project_agent_plugins,
                 project_agent_plugin_github_release_sources=project_agent_plugin_github_release_sources,
             )
-        if source is None:
+        if snapshot.repair_link_ids or snapshot.etag is None:
             raise RuntimeSourceError(
                 "Active runtime WhatsApp Link has no synthetic credential material"
             )
@@ -119,16 +130,15 @@ async def get_runtime_manifest(
     except RuntimeSourceError as exc:
         raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
 
-    payload = render_runtime_bundle(source)
-    etag = expected_runtime_bundle_v2_etag(source.source_revision)
     headers = {
-        "ETag": etag,
+        "ETag": snapshot.etag,
         "Cache-Control": _RUNTIME_MANIFEST_CACHE_CONTROL,
         "Vary": _RUNTIME_MANIFEST_VARY,
         "Content-Type": RUNTIME_BUNDLE_V2_MEDIA_TYPE,
     }
-    if if_none_match_contains(request.headers.get("if-none-match"), etag):
+    if snapshot.source is None:
         return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
+    payload = render_runtime_bundle(snapshot.source)
     return JSONResponse(payload, headers=headers)
 
 
@@ -136,9 +146,10 @@ async def _render_runtime_source_snapshot(
     *,
     environment_id: UUID,
     owner_user_id: UUID,
+    if_none_match: str | None,
     project_agent_plugins: bool,
     project_agent_plugin_github_release_sources: bool,
-) -> tuple[RenderedRuntimeSource | None, tuple[UUID, ...]]:
+) -> _RuntimeManifestSnapshot:
     async with runtime_snapshot_session() as source_db:
         batch = await load_runtime_source_batch(
             source_db,
@@ -150,19 +161,35 @@ async def _render_runtime_source_snapshot(
             environment_id=environment_id,
         )
         if repair_link_ids:
-            return None, repair_link_ids
-        return (
-            render_runtime_source(
-                batch,
-                environment_id=environment_id,
-                public_api_url=settings.public_api_url,
-                vault_key_identity=vault_key_identity(settings.vault_encryption_key),
-                decrypt_secrets=True,
-                project_agent_plugins=project_agent_plugins,
-                project_agent_plugin_github_release_sources=project_agent_plugin_github_release_sources,
-            ),
-            (),
+            return _RuntimeManifestSnapshot(
+                source=None,
+                etag=None,
+                repair_link_ids=repair_link_ids,
+            )
+        source_without_secrets = render_runtime_source(
+            batch,
+            environment_id=environment_id,
+            public_api_url=settings.public_api_url,
+            vault_key_identity=vault_key_identity(settings.vault_encryption_key),
+            decrypt_secrets=False,
+            project_agent_plugins=project_agent_plugins,
+            project_agent_plugin_github_release_sources=project_agent_plugin_github_release_sources,
         )
+        etag = expected_runtime_bundle_v2_etag(source_without_secrets.source_revision)
+        if if_none_match_contains(if_none_match, etag):
+            return _RuntimeManifestSnapshot(source=None, etag=etag, repair_link_ids=())
+        source = render_runtime_source(
+            batch,
+            environment_id=environment_id,
+            public_api_url=settings.public_api_url,
+            vault_key_identity=vault_key_identity(settings.vault_encryption_key),
+            decrypt_secrets=True,
+            project_agent_plugins=project_agent_plugins,
+            project_agent_plugin_github_release_sources=project_agent_plugin_github_release_sources,
+        )
+        if source.source_revision != source_without_secrets.source_revision:
+            raise RuntimeSourceError("Runtime source revision depends on secret decryption")
+        return _RuntimeManifestSnapshot(source=source, etag=etag, repair_link_ids=())
 
 
 def _authorized_environment_id(auth: AuthContext, requested_environment_id: UUID | None) -> UUID:

--- a/backend/app/services/channel_wakeups.py
+++ b/backend/app/services/channel_wakeups.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
 
 CHANNEL_DELIVERIES_ENQUEUED = "channel_deliveries_enqueued"
 CHANNEL_INBOUND_MESSAGES_ENQUEUED = "channel_inbound_messages_enqueued"
@@ -32,6 +35,48 @@ class ChannelWakeup:
 
 channel_deliveries_enqueued = ChannelWakeup()
 channel_inbound_messages_enqueued = ChannelWakeup()
+
+
+async def wait_for_channel_inbound_messages[T](
+    fetch: Callable[[], Awaitable[list[T]]],
+    *,
+    timeout_seconds: int | float | None,
+    fallback_poll_seconds: float | None = None,
+    wakeup: ChannelWakeup | None = None,
+) -> list[T]:
+    """Wait without holding a DB session, with a bounded notification-loss fallback."""
+
+    timeout = max(0.0, min(float(timeout_seconds or 0), 30.0))
+    configured_fallback = (
+        settings.channel_long_poll_interval_seconds
+        if fallback_poll_seconds is None
+        else fallback_poll_seconds
+    )
+    fallback = max(0.001, float(configured_fallback))
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    source = wakeup or channel_inbound_messages_enqueued
+    notified = source.subscribe()
+    try:
+        while True:
+            # Clearing before the query is load-bearing. A commit notification
+            # during or immediately after the query remains set and forces a
+            # recheck, closing the query-to-wait lost-wakeup window.
+            notified.clear()
+            values = await fetch()
+            if values or timeout == 0 or loop.time() >= deadline:
+                return values
+            if notified.is_set():
+                continue
+            try:
+                await asyncio.wait_for(
+                    notified.wait(),
+                    timeout=min(fallback, max(0.0, deadline - loop.time())),
+                )
+            except TimeoutError:
+                pass
+    finally:
+        source.unsubscribe(notified)
 
 
 async def notify_channel_delivery_enqueued(db: AsyncSession) -> None:

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import base64
 import hashlib
 import hmac
@@ -10,7 +9,6 @@ import re
 import secrets
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from time import monotonic
 from typing import TypeGuard
 from uuid import UUID, uuid4
 
@@ -75,8 +73,10 @@ from app.services.channel_config import (
 )
 from app.services.channel_debug_events import record_channel_debug_event
 from app.services.channel_wakeups import (
+    channel_inbound_messages_enqueued,
     notify_channel_delivery_enqueued,
     notify_channel_inbound_message_enqueued,
+    wait_for_channel_inbound_messages,
 )
 from app.services.discord_rate_limiter import discord_rate_limiter
 from app.services.metrics import (
@@ -3765,10 +3765,7 @@ async def wait_for_telegram_updates(
     timeout_seconds: int | float | None = None,
     poll_interval_seconds: float | None = None,
 ) -> list[JsonObject]:
-    timeout = max(0.0, min(float(timeout_seconds or 0), 30.0))
-    poll_interval = _channel_long_poll_interval(poll_interval_seconds)
-    deadline = monotonic() + timeout
-    while True:
+    async def fetch() -> list[JsonObject]:
         async with sessionmaker() as db:
             updates = await dequeue_telegram_updates(
                 db,
@@ -3779,9 +3776,14 @@ async def wait_for_telegram_updates(
                 allowed_updates=allowed_updates,
             )
             await db.commit()
-        if updates or timeout == 0 or monotonic() >= deadline:
             return updates
-        await asyncio.sleep(min(poll_interval, max(0.0, deadline - monotonic())))
+
+    return await wait_for_channel_inbound_messages(
+        fetch,
+        timeout_seconds=timeout_seconds,
+        fallback_poll_seconds=poll_interval_seconds,
+        wakeup=channel_inbound_messages_enqueued,
+    )
 
 
 async def dequeue_channel_inbox_events(
@@ -4481,10 +4483,7 @@ async def wait_for_channel_inbox_events(
     timeout_seconds: int | float | None = None,
     poll_interval_seconds: float | None = None,
 ) -> list[ChannelMessage]:
-    timeout = max(0.0, min(float(timeout_seconds or 0), 30.0))
-    poll_interval = _channel_long_poll_interval(poll_interval_seconds)
-    deadline = monotonic() + timeout
-    while True:
+    async def fetch() -> list[ChannelMessage]:
         async with sessionmaker() as db:
             events = await dequeue_channel_inbox_events(
                 db,
@@ -4494,14 +4493,14 @@ async def wait_for_channel_inbox_events(
                 limit=limit,
             )
             await db.commit()
-        if events or timeout == 0 or monotonic() >= deadline:
             return events
-        await asyncio.sleep(min(poll_interval, max(0.0, deadline - monotonic())))
 
-
-def _channel_long_poll_interval(value: float | None) -> float:
-    configured = settings.channel_long_poll_interval_seconds if value is None else value
-    return max(0.001, float(configured))
+    return await wait_for_channel_inbound_messages(
+        fetch,
+        timeout_seconds=timeout_seconds,
+        fallback_poll_seconds=poll_interval_seconds,
+        wakeup=channel_inbound_messages_enqueued,
+    )
 
 
 async def pending_channel_inbox_count(

--- a/backend/app/services/principal_lifecycle.py
+++ b/backend/app/services/principal_lifecycle.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from sqlalchemy import and_, delete, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
 
 from app.core.config import settings
 from app.models.agent_project_binding import AgentProjectBinding
@@ -81,6 +82,13 @@ class PrincipalCleanupClaimLostError(RuntimeError):
 
 PRINCIPAL_CLEANUP_CLAIM_LEASE_SECONDS = 60
 PRINCIPAL_CLEANUP_BACKOFF_CAP_SECONDS = 15 * 60
+_USER_AUTHORITY_LOCK_PREFIX = "user-authority:"
+
+
+@dataclass(frozen=True, slots=True)
+class _UserAuthoritySqlExpressions:
+    suspended: ColumnElement[bool]
+    disabled: ColumnElement[bool]
 
 
 @dataclass(frozen=True, slots=True)
@@ -160,13 +168,69 @@ async def lock_clerk_principal_shared(
 async def lock_user_authority(db: AsyncSession, user_id: UUID) -> None:
     """Hold the exclusive user authority lock for fence/cleanup."""
 
-    await _advisory_xact_lock(db, f"user-authority:{user_id}")
+    await _advisory_xact_lock(db, f"{_USER_AUTHORITY_LOCK_PREFIX}{user_id}")
 
 
 async def lock_user_authority_shared(db: AsyncSession, user_id: UUID) -> None:
     """Hold the shared user authority lock for an active request."""
 
-    await _advisory_xact_lock_shared(db, f"user-authority:{user_id}")
+    await _advisory_xact_lock_shared(db, f"{_USER_AUTHORITY_LOCK_PREFIX}{user_id}")
+
+
+async def lock_api_key_user_authority_shared(
+    db: AsyncSession,
+    key_hash: str,
+) -> UUID | None:
+    """Resolve an API key's user and acquire its shared authority lock."""
+
+    row = (
+        await db.execute(
+            select(
+                ApiKey.user_id,
+                func.pg_advisory_xact_lock_shared(
+                    func.hashtextextended(
+                        func.concat(_USER_AUTHORITY_LOCK_PREFIX, ApiKey.user_id),
+                        0,
+                    )
+                ),
+            ).where(ApiKey.key_hash == key_hash)
+        )
+    ).first()
+    return row[0] if row is not None else None
+
+
+def user_authority_sql_expressions() -> _UserAuthoritySqlExpressions:
+    """Build the correlated predicates shared by durable user-authority reads."""
+
+    lifecycle_fenced = (
+        select(PrincipalLifecycle.id).where(PrincipalLifecycle.user_id == User.id).exists()
+    )
+    clerk_banned = (
+        select(ClerkPrincipalAuthority.id)
+        .where(
+            ClerkPrincipalAuthority.issuer == User.clerk_issuer,
+            ClerkPrincipalAuthority.subject == User.clerk_id,
+            ClerkPrincipalAuthority.banned.is_(True),
+        )
+        .exists()
+    )
+    suspended = (
+        select(ClerkPrincipalSuspension.subject)
+        .where(
+            or_(
+                ClerkPrincipalSuspension.user_id == User.id,
+                and_(
+                    ClerkPrincipalSuspension.issuer == User.clerk_issuer,
+                    ClerkPrincipalSuspension.subject == User.clerk_id,
+                ),
+            )
+        )
+        .exists()
+    )
+    return _UserAuthoritySqlExpressions(
+        suspended=suspended,
+        disabled=or_(lifecycle_fenced, clerk_banned),
+    )
 
 
 async def assert_clerk_principal_active(
@@ -302,47 +366,20 @@ async def assert_user_authority_active(
 
     if lock:
         await lock_user_authority_shared(db, user_id)
-    active_id = await db.scalar(
-        select(User.id).where(
-            User.id == user_id,
-            ~select(PrincipalLifecycle.id).where(PrincipalLifecycle.user_id == User.id).exists(),
-            ~select(ClerkPrincipalAuthority.id)
-            .where(
-                ClerkPrincipalAuthority.issuer == User.clerk_issuer,
-                ClerkPrincipalAuthority.subject == User.clerk_id,
-                ClerkPrincipalAuthority.banned.is_(True),
+    expressions = user_authority_sql_expressions()
+    authority = (
+        await db.execute(
+            select(
+                expressions.suspended.label("suspended"),
+                expressions.disabled.label("disabled"),
             )
-            .exists(),
-            ~select(ClerkPrincipalSuspension.subject)
-            .where(
-                or_(
-                    ClerkPrincipalSuspension.user_id == User.id,
-                    and_(
-                        ClerkPrincipalSuspension.issuer == User.clerk_issuer,
-                        ClerkPrincipalSuspension.subject == User.clerk_id,
-                    ),
-                )
-            )
-            .exists(),
-        )
-    )
-    if active_id is None:
-        suspended = await db.scalar(
-            select(ClerkPrincipalSuspension.subject)
-            .join(
-                User,
-                or_(
-                    ClerkPrincipalSuspension.user_id == User.id,
-                    and_(
-                        ClerkPrincipalSuspension.issuer == User.clerk_issuer,
-                        ClerkPrincipalSuspension.subject == User.clerk_id,
-                    ),
-                ),
-            )
+            .select_from(User)
             .where(User.id == user_id)
         )
-        if suspended is not None:
-            raise PrincipalSuspendedError("user authority is suspended")
+    ).one_or_none()
+    if authority is not None and authority.suspended:
+        raise PrincipalSuspendedError("user authority is suspended")
+    if authority is None or authority.disabled:
         raise PrincipalTerminatedError("user authority is disabled")
 
 
@@ -1142,4 +1179,5 @@ __all__ = [
     "resolve_clerk_owner_issuer",
     "record_principal_cleanup_failure",
     "set_clerk_principal_suspension",
+    "user_authority_sql_expressions",
 ]

--- a/backend/tests/test_auth_keys.py
+++ b/backend/tests/test_auth_keys.py
@@ -114,12 +114,13 @@ async def test_revoked_api_key_is_rejected(db_session, seed_user):
 
 @pytest.mark.asyncio
 async def test_agent_key_is_not_cached_and_disconnect_revokes_after_commit(
-    client: httpx.AsyncClient, db_session, seed_user
+    client: httpx.AsyncClient, db_session, engine, seed_user
 ):
     import hashlib
     import uuid
 
     from fastapi import HTTPException
+    from sqlalchemy import event
 
     from app.core.auth import _api_key_auth_cache, _auth_via_api_key
     from app.services.agent_environments import (
@@ -147,7 +148,22 @@ async def test_agent_key_is_not_cached_and_disconnect_revokes_after_commit(
         environment_id=registered.env.id,
     )
     assert await _auth_via_api_key(minted.raw_key, db_session) is not None
-    assert await _auth_via_api_key(minted.raw_key, db_session) is not None
+
+    statements: list[str] = []
+
+    def capture_statement(_connection, _cursor, statement: str, *_args) -> None:
+        statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", capture_statement)
+    try:
+        assert await _auth_via_api_key(minted.raw_key, db_session) is not None
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", capture_statement)
+
+    assert len(statements) == 2
+    assert "pg_advisory_xact_lock_shared" in statements[0]
+    assert "LEFT OUTER JOIN users" in statements[1]
+    assert "LEFT OUTER JOIN agent_environments" in statements[1]
     key_hash = hashlib.sha256(minted.raw_key.encode()).hexdigest()
     assert key_hash not in _api_key_auth_cache
 
@@ -155,6 +171,74 @@ async def test_agent_key_is_not_cached_and_disconnect_revokes_after_commit(
     assert disconnected.status_code == 204, disconnected.text
     with pytest.raises(HTTPException) as exc_info:
         await _auth_via_api_key(minted.raw_key, db_session)
+    assert exc_info.value.status_code == 401
+    assert "revoked" in str(exc_info.value.detail).lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_agent_key_revalidation_refreshes_revocation_after_last_used_commit(
+    db_session,
+    engine,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from datetime import UTC, datetime
+
+    from sqlalchemy import update
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from app.core.auth import _auth_via_api_key
+    from app.services.agent_environments import (
+        local_machine_registration_key,
+        register_agent_environment,
+    )
+    from app.services.api_key import mint_api_key
+
+    machine_id = f"revalidation-{uuid.uuid4().hex}"
+    registered = await register_agent_environment(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=machine_id,
+        machine_name="Revalidation Agent",
+        agent_type="codex",
+        agent_version="1.0.0",
+        os_name="linux",
+        sort_order=0,
+        registration_key=local_machine_registration_key(machine_id, "codex"),
+    )
+    minted = await mint_api_key(
+        db_session,
+        user_id=seed_user.id,
+        label="revalidation key",
+        environment_id=registered.env.id,
+    )
+    await db_session.commit()
+
+    original_commit = db_session.commit
+    revoke_injected = False
+
+    async def commit_then_revoke() -> None:
+        nonlocal revoke_injected
+        await original_commit()
+        if revoke_injected:
+            return
+        revoke_injected = True
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+        async with sessionmaker() as revoke_session:
+            await revoke_session.execute(
+                update(ApiKey)
+                .where(ApiKey.id == minted.api_key.id)
+                .values(revoked_at=datetime.now(UTC))
+            )
+            await revoke_session.commit()
+
+    monkeypatch.setattr(db_session, "commit", commit_then_revoke)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _auth_via_api_key(minted.raw_key, db_session)
+
+    assert revoke_injected is True
     assert exc_info.value.status_code == 401
     assert "revoked" in str(exc_info.value.detail).lower()
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -78,8 +78,10 @@ from app.routes.channel_routers.shared import discord_gateway_dispatch
 from app.schemas.channel import ChannelAccountCreate, ChannelAgentLinkCreate
 from app.services import channel_config as channel_config_service
 from app.services import channels as channel_service
+from app.services import sync_events
 from app.services.channel_debug_events import record_channel_debug_event
 from app.services.channel_delivery_worker import ChannelDeliveryWorker
+from app.services.channel_wakeups import notify_channel_inbound_message_enqueued
 from app.services.channel_webhook_delivery_worker import ChannelWebhookDeliveryWorker
 from app.services.channels import (
     ChannelAgentContext,
@@ -5550,42 +5552,51 @@ async def test_telegram_get_updates_wait_helper_sees_new_committed_update(
             offset=2,
             limit=100,
             timeout_seconds=1,
-            poll_interval_seconds=0.005,
+            poll_interval_seconds=30,
         )
     )
-    await asyncio.sleep(0.01)
-    async with sessionmaker() as insert_session:
-        binding = (
-            await insert_session.execute(
-                select(ChannelBinding).where(
-                    ChannelBinding.account_id == UUID(created["id"]),
-                    ChannelBinding.external_chat_id == "222",
+    await sync_events.start_postgres_listener()
+    try:
+        await asyncio.sleep(0.01)
+        async with sessionmaker() as insert_session:
+            binding = (
+                await insert_session.execute(
+                    select(ChannelBinding).where(
+                        ChannelBinding.account_id == UUID(created["id"]),
+                        ChannelBinding.external_chat_id == "222",
+                    )
+                )
+            ).scalar_one()
+            insert_session.add(
+                ChannelMessage(
+                    account_id=binding.account_id,
+                    bot_agent_link_id=binding.bot_agent_link_id,
+                    binding_id=binding.id,
+                    user_id=binding.user_id,
+                    direction=MESSAGE_DIRECTION_INBOUND,
+                    external_chat_id="222",
+                    provider_message_id="2",
+                    text="arrived during long poll",
+                    payload={
+                        "update_id": 2,
+                        "message": {
+                            "message_id": 2,
+                            "text": "arrived during long poll",
+                            "chat": {"id": 222, "type": "private"},
+                        },
+                    },
                 )
             )
-        ).scalar_one()
-        insert_session.add(
-            ChannelMessage(
-                account_id=binding.account_id,
-                bot_agent_link_id=binding.bot_agent_link_id,
-                binding_id=binding.id,
-                user_id=binding.user_id,
-                direction=MESSAGE_DIRECTION_INBOUND,
-                external_chat_id="222",
-                provider_message_id="2",
-                text="arrived during long poll",
-                payload={
-                    "update_id": 2,
-                    "message": {
-                        "message_id": 2,
-                        "text": "arrived during long poll",
-                        "chat": {"id": 222, "type": "private"},
-                    },
-                },
-            )
-        )
-        await insert_session.commit()
+            await insert_session.flush()
+            await notify_channel_inbound_message_enqueued(insert_session)
+            await insert_session.commit()
 
-    updates = await pending
+        updates = await asyncio.wait_for(pending, timeout=1)
+    finally:
+        await sync_events.stop_postgres_listener()
+        if not pending.done():
+            pending.cancel()
+            await asyncio.gather(pending, return_exceptions=True)
 
     assert updates == [
         {
@@ -5602,6 +5613,7 @@ async def test_telegram_get_updates_wait_helper_sees_new_committed_update(
 @pytest.mark.asyncio
 async def test_telegram_bot_api_get_updates_long_poll_times_out_empty(
     client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     created = await _create_paired_telegram_channel(
         client,
@@ -5610,6 +5622,16 @@ async def test_telegram_bot_api_get_updates_long_poll_times_out_empty(
         provider_token=None,
     )
 
+    calls = 0
+    original_dequeue = channel_service.dequeue_telegram_updates
+
+    async def observed_dequeue(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return await original_dequeue(*args, **kwargs)
+
+    monkeypatch.setattr(channel_service, "dequeue_telegram_updates", observed_dequeue)
+    monkeypatch.setattr(settings, "channel_long_poll_interval_seconds", 5.0)
     updates = await client.get(
         _telegram_bot_path(created, "getUpdates"),
         headers=_telegram_agent_headers(created),
@@ -5618,6 +5640,9 @@ async def test_telegram_bot_api_get_updates_long_poll_times_out_empty(
 
     assert updates.status_code == 200
     assert updates.json() == {"ok": True, "result": []}
+    # One initial read, plus at most one deadline recheck. The previous 5 ms
+    # test fallback opened roughly ten sessions over this 50 ms long poll.
+    assert 1 <= calls <= 2
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -45,6 +45,7 @@ from app.models.runtime_observation import V2RuntimeEnvironmentFence
 from app.models.session import AgentEnvironment
 from app.models.skill import SKILL_AUTHORITY_CLOUD, Skill
 from app.models.user import User
+from app.routes import runtime as runtime_routes
 from app.routes.admin import _admin_upsert_runtime_state
 from app.routes.sessions import (
     _runtime_observed_desired,
@@ -4097,6 +4098,56 @@ async def test_runtime_manifest_requires_exact_v2_media_type(admin_client, db_se
     assert unsupported.status_code == 406
     assert unsupported.headers["cache-control"] == "no-store"
     assert unsupported.headers["vary"] == "Accept"
+
+
+@pytest.mark.asyncio
+async def test_runtime_manifest_conditional_render_skips_secrets_and_bundle(
+    admin_client,
+    db_session,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    env, _, _, _, _ = await _create_bundle_runtime(admin_client, db_session, seed_user)
+    api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="conditional-render")
+    render_calls: list[tuple[bool, str]] = []
+    bundle_calls: list[str] = []
+    original_render_source = runtime_routes.render_runtime_source
+    original_render_bundle = runtime_routes.render_runtime_bundle
+
+    def tracked_render_source(*args, **kwargs):
+        source = original_render_source(*args, **kwargs)
+        render_calls.append((kwargs["decrypt_secrets"], source.source_revision))
+        return source
+
+    def tracked_render_bundle(source):
+        bundle_calls.append(source.source_revision)
+        return original_render_bundle(source)
+
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        initial = await client.get("/v1/runtime/manifest")
+        assert initial.status_code == 200, initial.text
+        monkeypatch.setattr(runtime_routes, "render_runtime_source", tracked_render_source)
+        monkeypatch.setattr(runtime_routes, "render_runtime_bundle", tracked_render_bundle)
+
+        not_modified = await client.get(
+            "/v1/runtime/manifest",
+            headers={"If-None-Match": initial.headers["etag"]},
+        )
+        assert not_modified.status_code == 304, not_modified.text
+        assert render_calls == [(False, initial.json()["sourceRevision"])]
+        assert bundle_calls == []
+
+        render_calls.clear()
+        refreshed = await client.get("/v1/runtime/manifest")
+    app.dependency_overrides.clear()
+
+    assert refreshed.status_code == 200, refreshed.text
+    assert refreshed.json() == initial.json()
+    assert render_calls == [
+        (False, initial.json()["sourceRevision"]),
+        (True, initial.json()["sourceRevision"]),
+    ]
+    assert bundle_calls == [initial.json()["sourceRevision"]]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- collapse Agent-bound API key authority checks into a lock-ordered authoritative read while preserving commit-time fail-closed behavior
- avoid secret decryption and bundle construction for unchanged runtime manifest requests
- replace 100ms channel inbox polling with commit-driven PostgreSQL wakeups plus a bounded 5s recovery poll
- keep the optimization fully server-side so deployed legacy CLIs benefit without an update

## Production rationale

The web container has 16 host cores available but intentionally runs one Uvicorn process because lifespan currently owns process-local listeners and WhatsApp background registries. The observed CPU was dominated by avoidable request and idle polling churn, especially Telegram long polls. This change removes those hot paths before changing process ownership or worker count.

For 13 idle Telegram accounts, the theoretical database polling rate falls from about 130 transactions/second to about 2.6 transactions/second when notifications are unavailable; normal committed messages wake consumers immediately.

## Verification

- Docker-isolated full affected-module regression: `783 passed in 79.54s`
- Ruff lint and format: passed
- BasedPyright: `195 files analyzed, 0 errors, 0 warnings`
- Python compileall: passed
- `git diff --check`: passed

No database migration, CLI change, cache consistency window, connection-pool tuning, or multi-worker duplication is introduced.