### PR TITLE
perf(backend): reduce daemon hot-path database work

### DIFF
--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -20,7 +20,7 @@ from fastapi import (
     status,
 )
 from pydantic import BaseModel, Field, JsonValue, TypeAdapter, ValidationError, field_validator
-from sqlalchemy import case, func, or_, select, text, update
+from sqlalchemy import case, func, or_, select, text, true, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -368,21 +368,17 @@ async def _list_agent_identities(
         ).where(AgentProjectBinding.project_id == project_id)
     result = await db.execute(stmt)
     envs = result.scalars().all()
-    states_by_env: dict[UUID, HostedRuntimeState] = {}
+    hosted_deployment_ids: dict[UUID, str] = {}
     env_ids = [env.id for env in envs]
     if not agent_response and env_ids:
-        states = (
-            (
-                await db.execute(
-                    select(HostedRuntimeState).where(HostedRuntimeState.environment_id.in_(env_ids))
-                )
-            )
-            .scalars()
-            .all()
-        )
-        states_by_env = {state.environment_id: state for state in states}
+        hosted_deployment_ids = await _hosted_deployment_ids(db, env_ids)
     payload = [
-        _identity_response(e, states_by_env.get(e.id), agent_response=agent_response) for e in envs
+        _identity_response(
+            e,
+            hosted_deployment_ids.get(e.id),
+            agent_response=agent_response,
+        )
+        for e in envs
     ]
     etag = strong_json_etag([item.model_dump(mode="json") for item in payload])
     headers = {"ETag": etag, "Cache-Control": "private, no-cache"}
@@ -477,7 +473,7 @@ async def _get_agent_identity(
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
     row = (
         await db.execute(
-            select(AgentEnvironment, HostedRuntimeState)
+            select(AgentEnvironment, HostedRuntimeState.deployment_id)
             .outerjoin(
                 HostedRuntimeState,
                 HostedRuntimeState.environment_id == AgentEnvironment.id,
@@ -490,7 +486,7 @@ async def _get_agent_identity(
     ).first()
     if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
-    env, state = row
+    env, hosted_deployment_id = row
     if env.archived_at is not None:
         # The owner may distinguish their retained, disconnected identity from
         # a random id. The user_id predicate above and bound-id fence before the
@@ -503,7 +499,11 @@ async def _get_agent_identity(
                 "message": "Agent is disconnected",
             },
         )
-    payload = _identity_response(env, state, agent_response=agent_response)
+    payload = _identity_response(
+        env,
+        hosted_deployment_id,
+        agent_response=agent_response,
+    )
     etag = strong_json_etag(payload.model_dump(mode="json"))
     headers = {"ETag": etag, "Cache-Control": "private, no-cache"}
     if if_none_match_contains(request.headers.get("if-none-match"), etag):
@@ -606,7 +606,10 @@ async def list_environment_runtime_observed(
         setattr(counts, health.status, getattr(counts, health.status) + 1)
         items.append(
             RuntimeObservedSummaryItemResponse(
-                environment=_env_to_response(env, state),
+                environment=_env_to_response(
+                    env,
+                    state.deployment_id if state is not None else None,
+                ),
                 desired=(
                     _runtime_observed_desired(
                         state,
@@ -690,20 +693,13 @@ async def _reorder_agent_identities(
     await db.commit()
 
     env_ids = [env.id for env in ordered]
-    states_by_env: dict[UUID, HostedRuntimeState] = {}
-    if env_ids:
-        states = (
-            (
-                await db.execute(
-                    select(HostedRuntimeState).where(HostedRuntimeState.environment_id.in_(env_ids))
-                )
-            )
-            .scalars()
-            .all()
-        )
-        states_by_env = {state.environment_id: state for state in states}
+    hosted_deployment_ids = await _hosted_deployment_ids(db, env_ids) if not agent_response else {}
     return [
-        _identity_response(env, states_by_env.get(env.id), agent_response=agent_response)
+        _identity_response(
+            env,
+            hosted_deployment_ids.get(env.id),
+            agent_response=agent_response,
+        )
         for env in ordered
     ]
 
@@ -823,12 +819,14 @@ async def _update_agent_identity(
     await db.commit()
     await db.refresh(env)
 
-    state = (
-        await db.execute(
-            select(HostedRuntimeState).where(HostedRuntimeState.environment_id == agent_id)
-        )
-    ).scalar_one_or_none()
-    return _identity_response(env, state, agent_response=agent_response)
+    hosted_deployment_ids = (
+        await _hosted_deployment_ids(db, [agent_id]) if not agent_response else {}
+    )
+    return _identity_response(
+        env,
+        hosted_deployment_ids.get(agent_id),
+        agent_response=agent_response,
+    )
 
 
 @router.patch("/agents/{agent_id}", response_model=AgentResponse)
@@ -892,12 +890,14 @@ async def _clear_agent_avatar(
     await db.refresh(env)
     await _delete_managed_avatar_key_best_effort(old_avatar_key)
 
-    state = (
-        await db.execute(
-            select(HostedRuntimeState).where(HostedRuntimeState.environment_id == agent_id)
-        )
-    ).scalar_one_or_none()
-    return _identity_response(env, state, agent_response=agent_response)
+    hosted_deployment_ids = (
+        await _hosted_deployment_ids(db, [agent_id]) if not agent_response else {}
+    )
+    return _identity_response(
+        env,
+        hosted_deployment_ids.get(agent_id),
+        agent_response=agent_response,
+    )
 
 
 @router.delete("/agents/{agent_id}/avatar", response_model=AgentResponse)
@@ -987,12 +987,14 @@ async def _upload_agent_avatar(
     await db.refresh(env)
     await _delete_managed_avatar_key_best_effort(old_avatar_key)
 
-    state = (
-        await db.execute(
-            select(HostedRuntimeState).where(HostedRuntimeState.environment_id == agent_id)
-        )
-    ).scalar_one_or_none()
-    return _identity_response(env, state, agent_response=agent_response)
+    hosted_deployment_ids = (
+        await _hosted_deployment_ids(db, [agent_id]) if not agent_response else {}
+    )
+    return _identity_response(
+        env,
+        hosted_deployment_ids.get(agent_id),
+        agent_response=agent_response,
+    )
 
 
 @router.post("/agents/{agent_id}/avatar", response_model=AgentResponse)
@@ -1078,7 +1080,10 @@ async def get_environment_runtime_observed(
         )
     ).scalar_one_or_none()
     return RuntimeObservedResponse(
-        environment=_env_to_response(env, state),
+        environment=_env_to_response(
+            env,
+            state.deployment_id if state is not None else None,
+        ),
         desired=(
             _runtime_observed_desired(state, source_revision=source_revision)
             if state is not None
@@ -1238,19 +1243,35 @@ async def get_public_asset(asset_key: str) -> Response:
 
 def _env_to_response(
     env: AgentEnvironment,
-    hosted_state: HostedRuntimeState | None = None,
+    hosted_deployment_id: str | None = None,
 ) -> EnvironmentResponse:
-    resolved_hosted_deployment_id = hosted_state.deployment_id if hosted_state is not None else None
     # Deprecated signal: dashboards now classify agents through their control
     # plane's ownership surface. Kept (runtime-state-derived only) for older
     # API consumers until the field is removed from EnvironmentResponse.
-    hosted_managed = resolved_hosted_deployment_id is not None
+    hosted_managed = hosted_deployment_id is not None
     agent = _agent_to_response(env)
     return EnvironmentResponse(
         **agent.model_dump(),
         hosted_managed=hosted_managed,
-        hosted_deployment_id=resolved_hosted_deployment_id,
+        hosted_deployment_id=hosted_deployment_id,
     )
+
+
+async def _hosted_deployment_ids(
+    db: AsyncSession,
+    environment_ids: list[UUID],
+) -> dict[UUID, str]:
+    if not environment_ids:
+        return {}
+    rows = (
+        await db.execute(
+            select(
+                HostedRuntimeState.environment_id,
+                HostedRuntimeState.deployment_id,
+            ).where(HostedRuntimeState.environment_id.in_(environment_ids))
+        )
+    ).all()
+    return {environment_id: deployment_id for environment_id, deployment_id in rows}
 
 
 def _agent_to_response(env: AgentEnvironment) -> AgentResponse:
@@ -1284,14 +1305,14 @@ def _agent_to_response(env: AgentEnvironment) -> AgentResponse:
 
 @overload
 def _identity_response(
-    env: AgentEnvironment, hosted_state: HostedRuntimeState | None, *, agent_response: Literal[True]
+    env: AgentEnvironment, hosted_deployment_id: str | None, *, agent_response: Literal[True]
 ) -> AgentResponse: ...
 
 
 @overload
 def _identity_response(
     env: AgentEnvironment,
-    hosted_state: HostedRuntimeState | None,
+    hosted_deployment_id: str | None,
     *,
     agent_response: Literal[False],
 ) -> EnvironmentResponse: ...
@@ -1299,13 +1320,13 @@ def _identity_response(
 
 def _identity_response(
     env: AgentEnvironment,
-    hosted_state: HostedRuntimeState | None,
+    hosted_deployment_id: str | None,
     *,
     agent_response: bool,
 ) -> AgentResponse | EnvironmentResponse:
     if agent_response:
         return _agent_to_response(env)
-    return _env_to_response(env, hosted_state)
+    return _env_to_response(env, hosted_deployment_id)
 
 
 def _agent_name_from_fields(
@@ -1914,111 +1935,147 @@ async def sync_heartbeat(
     light endpoint: validate ownership / env-id binding, update a
     handful of columns, commit. No heavy queries.
     """
-    env = (
-        await db.execute(
-            select(AgentEnvironment).where(
-                AgentEnvironment.id == agent_id,
-                AgentEnvironment.user_id == auth.user_id,
-                active_agent_filter(),
-            )
-        )
-    ).scalar_one_or_none()
-    if env is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "agent environment not found")
-
-    # If the deploy-key is bound to a specific env, refuse calls
-    # for any other env. Resource-level project alone wasn't enough
-    # — without this, a key from pod A could heartbeat under
-    # pod B's id and corrupt B's observability fields.
-    if (
+    binding_matches = not (
         auth.is_cli
         and auth.api_key is not None
         and auth.api_key.environment_id is not None
         and auth.api_key.environment_id != agent_id
-    ):
-        raise HTTPException(
-            status.HTTP_403_FORBIDDEN,
-            "api key bound to a different environment",
-        )
+    )
 
     # Conditional write: skip the UPDATE entirely when nothing
     # interesting has changed since the prior heartbeat. Daemons
-    # heartbeat every 30s; with N daemons per user × M users
+    # heartbeat every 30-60s; with N daemons per user × M users
     # this was the single highest-write hot path in the backend.
     # Now we only commit when last_sync_error flips, queue HWM
     # advances, dropped delta is non-zero, or sync_enabled needs
     # to flip on — all real state-change signals. last_sync_at
     # advances on every commit (so the dashboard's "live" badge
-    # transitions still fire) but we throttle commits to one per
-    # 30s of *content change*, not one per heartbeat. The badge
+    # transitions still fire) but unchanged state writes happen at
+    # most once per 40s, not once per heartbeat. The badge
     # logic on the dashboard tolerates last_sync_at being stale
     # by up to ~90s.
     now = datetime.now(UTC)
     new_error = body.last_sync_error
     new_revision = body.last_revision_seen
     runtime_observed = body.runtime_observed
-    hosted_state = None
+    hosted_runtime_exists = False
     observation = None
     runtime_observed_values = None
     observed_changed = False
-    if runtime_observed is not None:
+    if runtime_observed is not None and binding_matches:
         runtime_observed_values = _runtime_observed_columns(
             runtime_observed,
             observed_at=now,
         )
         row = (
             await db.execute(
-                select(HostedRuntimeState, HostedRuntimeConfigObservation)
+                select(
+                    HostedRuntimeState.environment_id,
+                    HostedRuntimeConfigObservation,
+                )
                 .outerjoin(
                     HostedRuntimeConfigObservation,
                     HostedRuntimeConfigObservation.environment_id
                     == HostedRuntimeState.environment_id,
                 )
-                .where(HostedRuntimeState.environment_id == agent_id)
+                .join(
+                    AgentEnvironment,
+                    AgentEnvironment.id == HostedRuntimeState.environment_id,
+                )
+                .where(
+                    HostedRuntimeState.environment_id == agent_id,
+                    AgentEnvironment.user_id == auth.user_id,
+                    active_agent_filter(),
+                )
             )
         ).first()
         if row is not None:
-            hosted_state, observation = row
+            hosted_runtime_exists = True
+            _, observation = row
             observed_changed = _runtime_observation_changed(observation, runtime_observed_values)
-    has_state_change = (
-        env.last_sync_error != new_error
-        or (new_revision is not None and env.last_revision_seen != new_revision)
-        or (
-            body.queue_depth is not None
-            and body.queue_depth > env.queue_depth_high_water_since_start
-        )
-        or bool(body.dropped_count_delta)
-        or not env.sync_enabled
-        or observed_changed
-    )
-    # Even with no state change, refresh last_sync_at on a bounded
-    # cadence. The dashboard freshness cutoff is 90s; 40s keeps new
-    # 60s clients live while preventing old 30s clients from writing
-    # on every heartbeat.
-    last = env.last_sync_at
-    needs_freshness_refresh = (
-        last is None or now - _as_utc(last) > _HEARTBEAT_FRESHNESS_WRITE_INTERVAL
-    )
-    if not has_state_change and not needs_freshness_refresh:
-        return
-    env.last_sync_at = now
-    env.last_sync_error = new_error
+
+    write_conditions = [
+        AgentEnvironment.last_sync_error.is_distinct_from(new_error),
+        AgentEnvironment.sync_enabled.is_(False),
+        AgentEnvironment.last_sync_at.is_(None),
+        AgentEnvironment.last_sync_at < now - _HEARTBEAT_FRESHNESS_WRITE_INTERVAL,
+    ]
     if new_revision is not None:
-        env.last_revision_seen = new_revision
-    if body.queue_depth is not None and body.queue_depth > env.queue_depth_high_water_since_start:
-        env.queue_depth_high_water_since_start = body.queue_depth
+        write_conditions.append(AgentEnvironment.last_revision_seen.is_distinct_from(new_revision))
+    if body.queue_depth is not None:
+        write_conditions.append(
+            body.queue_depth > AgentEnvironment.queue_depth_high_water_since_start
+        )
+    if body.dropped_count_delta or observed_changed:
+        write_conditions.append(true())
+
+    update_values: dict[str, Any] = {
+        "last_sync_at": now,
+        "last_sync_error": new_error,
+        "sync_enabled": True,
+        "updated_at": func.now(),
+    }
+    if new_revision is not None:
+        update_values["last_revision_seen"] = new_revision
+    if body.queue_depth is not None:
+        update_values["queue_depth_high_water_since_start"] = func.greatest(
+            AgentEnvironment.queue_depth_high_water_since_start,
+            body.queue_depth,
+        )
     if body.dropped_count_delta:
-        env.dropped_count_since_start = (
-            env.dropped_count_since_start or 0
-        ) + body.dropped_count_delta
-    # A heartbeat IS the user opting in: they ran `clawdi daemon` (or
-    # installed the launchd / systemd unit) and the daemon is
-    # successfully posting liveness. The `sync_enabled` flag was a
-    # canary toggle so existing envs wouldn't auto-pick-up sync at
-    # rollout — it has done its job once an actual heartbeat arrives.
-    if not env.sync_enabled:
-        env.sync_enabled = True
-    if hosted_state is not None and runtime_observed_values is not None:
+        update_values["dropped_count_since_start"] = (
+            AgentEnvironment.dropped_count_since_start + body.dropped_count_delta
+        )
+
+    # One statement owns the active/owner check and the conditional mutation.
+    # The data-modifying CTE keeps unchanged heartbeats at one round trip while
+    # preserving the legacy distinction between a same-owner binding mismatch
+    # (403) and an unavailable/cross-owner Agent (404). Database expressions
+    # make queue HWM and dropped deltas atomic under concurrent heartbeats.
+    heartbeat_target = (
+        select(AgentEnvironment.id)
+        .where(
+            AgentEnvironment.id == agent_id,
+            AgentEnvironment.user_id == auth.user_id,
+            active_agent_filter(),
+        )
+        .cte("heartbeat_target")
+    )
+    if binding_matches:
+        heartbeat_update = (
+            update(AgentEnvironment)
+            .where(
+                AgentEnvironment.id == heartbeat_target.c.id,
+                AgentEnvironment.user_id == auth.user_id,
+                active_agent_filter(),
+                or_(*write_conditions),
+            )
+            .values(**update_values)
+            .returning(AgentEnvironment.id)
+            .cte("heartbeat_update")
+        )
+        target_exists, heartbeat_updated = (
+            await db.execute(
+                select(
+                    select(heartbeat_target.c.id).exists(),
+                    select(heartbeat_update.c.id).exists(),
+                )
+            )
+        ).one()
+    else:
+        target_exists = await db.scalar(select(select(heartbeat_target.c.id).exists()))
+        heartbeat_updated = False
+    if not target_exists:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "agent environment not found")
+    if not binding_matches:
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            "api key bound to a different environment",
+        )
+    if not heartbeat_updated:
+        return
+
+    if hosted_runtime_exists and runtime_observed_values is not None:
         insert_observation = pg_insert(HostedRuntimeConfigObservation).values(
             environment_id=agent_id,
             **runtime_observed_values,

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -20,7 +20,7 @@ from fastapi import (
     status,
 )
 from pydantic import BaseModel, Field, JsonValue, TypeAdapter, ValidationError, field_validator
-from sqlalchemy import case, func, or_, select, text, true, update
+from sqlalchemy import case, func, or_, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -606,10 +606,7 @@ async def list_environment_runtime_observed(
         setattr(counts, health.status, getattr(counts, health.status) + 1)
         items.append(
             RuntimeObservedSummaryItemResponse(
-                environment=_env_to_response(
-                    env,
-                    state.deployment_id if state is not None else None,
-                ),
+                environment=_env_to_response(env, state),
                 desired=(
                     _runtime_observed_desired(
                         state,
@@ -1080,10 +1077,7 @@ async def get_environment_runtime_observed(
         )
     ).scalar_one_or_none()
     return RuntimeObservedResponse(
-        environment=_env_to_response(
-            env,
-            state.deployment_id if state is not None else None,
-        ),
+        environment=_env_to_response(env, state),
         desired=(
             _runtime_observed_desired(state, source_revision=source_revision)
             if state is not None
@@ -1243,7 +1237,17 @@ async def get_public_asset(asset_key: str) -> Response:
 
 def _env_to_response(
     env: AgentEnvironment,
-    hosted_deployment_id: str | None = None,
+    hosted_state: HostedRuntimeState | None = None,
+) -> EnvironmentResponse:
+    return _env_to_response_with_deployment_id(
+        env,
+        hosted_state.deployment_id if hosted_state is not None else None,
+    )
+
+
+def _env_to_response_with_deployment_id(
+    env: AgentEnvironment,
+    hosted_deployment_id: str | None,
 ) -> EnvironmentResponse:
     # Deprecated signal: dashboards now classify agents through their control
     # plane's ownership surface. Kept (runtime-state-derived only) for older
@@ -1326,7 +1330,7 @@ def _identity_response(
 ) -> AgentResponse | EnvironmentResponse:
     if agent_response:
         return _agent_to_response(env)
-    return _env_to_response(env, hosted_deployment_id)
+    return _env_to_response_with_deployment_id(env, hosted_deployment_id)
 
 
 def _agent_name_from_fields(
@@ -1935,147 +1939,111 @@ async def sync_heartbeat(
     light endpoint: validate ownership / env-id binding, update a
     handful of columns, commit. No heavy queries.
     """
-    binding_matches = not (
+    env = (
+        await db.execute(
+            select(AgentEnvironment).where(
+                AgentEnvironment.id == agent_id,
+                AgentEnvironment.user_id == auth.user_id,
+                active_agent_filter(),
+            )
+        )
+    ).scalar_one_or_none()
+    if env is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "agent environment not found")
+
+    # If the deploy-key is bound to a specific env, refuse calls
+    # for any other env. Resource-level project alone wasn't enough
+    # — without this, a key from pod A could heartbeat under
+    # pod B's id and corrupt B's observability fields.
+    if (
         auth.is_cli
         and auth.api_key is not None
         and auth.api_key.environment_id is not None
         and auth.api_key.environment_id != agent_id
-    )
+    ):
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            "api key bound to a different environment",
+        )
 
     # Conditional write: skip the UPDATE entirely when nothing
     # interesting has changed since the prior heartbeat. Daemons
-    # heartbeat every 30-60s; with N daemons per user × M users
+    # heartbeat every 30s; with N daemons per user × M users
     # this was the single highest-write hot path in the backend.
     # Now we only commit when last_sync_error flips, queue HWM
     # advances, dropped delta is non-zero, or sync_enabled needs
     # to flip on — all real state-change signals. last_sync_at
     # advances on every commit (so the dashboard's "live" badge
-    # transitions still fire) but unchanged state writes happen at
-    # most once per 40s, not once per heartbeat. The badge
+    # transitions still fire) but we throttle commits to one per
+    # 30s of *content change*, not one per heartbeat. The badge
     # logic on the dashboard tolerates last_sync_at being stale
     # by up to ~90s.
     now = datetime.now(UTC)
     new_error = body.last_sync_error
     new_revision = body.last_revision_seen
     runtime_observed = body.runtime_observed
-    hosted_runtime_exists = False
+    hosted_state = None
     observation = None
     runtime_observed_values = None
     observed_changed = False
-    if runtime_observed is not None and binding_matches:
+    if runtime_observed is not None:
         runtime_observed_values = _runtime_observed_columns(
             runtime_observed,
             observed_at=now,
         )
         row = (
             await db.execute(
-                select(
-                    HostedRuntimeState.environment_id,
-                    HostedRuntimeConfigObservation,
-                )
+                select(HostedRuntimeState, HostedRuntimeConfigObservation)
                 .outerjoin(
                     HostedRuntimeConfigObservation,
                     HostedRuntimeConfigObservation.environment_id
                     == HostedRuntimeState.environment_id,
                 )
-                .join(
-                    AgentEnvironment,
-                    AgentEnvironment.id == HostedRuntimeState.environment_id,
-                )
-                .where(
-                    HostedRuntimeState.environment_id == agent_id,
-                    AgentEnvironment.user_id == auth.user_id,
-                    active_agent_filter(),
-                )
+                .where(HostedRuntimeState.environment_id == agent_id)
             )
         ).first()
         if row is not None:
-            hosted_runtime_exists = True
-            _, observation = row
+            hosted_state, observation = row
             observed_changed = _runtime_observation_changed(observation, runtime_observed_values)
-
-    write_conditions = [
-        AgentEnvironment.last_sync_error.is_distinct_from(new_error),
-        AgentEnvironment.sync_enabled.is_(False),
-        AgentEnvironment.last_sync_at.is_(None),
-        AgentEnvironment.last_sync_at < now - _HEARTBEAT_FRESHNESS_WRITE_INTERVAL,
-    ]
-    if new_revision is not None:
-        write_conditions.append(AgentEnvironment.last_revision_seen.is_distinct_from(new_revision))
-    if body.queue_depth is not None:
-        write_conditions.append(
-            body.queue_depth > AgentEnvironment.queue_depth_high_water_since_start
+    has_state_change = (
+        env.last_sync_error != new_error
+        or (new_revision is not None and env.last_revision_seen != new_revision)
+        or (
+            body.queue_depth is not None
+            and body.queue_depth > env.queue_depth_high_water_since_start
         )
-    if body.dropped_count_delta or observed_changed:
-        write_conditions.append(true())
-
-    update_values: dict[str, Any] = {
-        "last_sync_at": now,
-        "last_sync_error": new_error,
-        "sync_enabled": True,
-        "updated_at": func.now(),
-    }
-    if new_revision is not None:
-        update_values["last_revision_seen"] = new_revision
-    if body.queue_depth is not None:
-        update_values["queue_depth_high_water_since_start"] = func.greatest(
-            AgentEnvironment.queue_depth_high_water_since_start,
-            body.queue_depth,
-        )
-    if body.dropped_count_delta:
-        update_values["dropped_count_since_start"] = (
-            AgentEnvironment.dropped_count_since_start + body.dropped_count_delta
-        )
-
-    # One statement owns the active/owner check and the conditional mutation.
-    # The data-modifying CTE keeps unchanged heartbeats at one round trip while
-    # preserving the legacy distinction between a same-owner binding mismatch
-    # (403) and an unavailable/cross-owner Agent (404). Database expressions
-    # make queue HWM and dropped deltas atomic under concurrent heartbeats.
-    heartbeat_target = (
-        select(AgentEnvironment.id)
-        .where(
-            AgentEnvironment.id == agent_id,
-            AgentEnvironment.user_id == auth.user_id,
-            active_agent_filter(),
-        )
-        .cte("heartbeat_target")
+        or bool(body.dropped_count_delta)
+        or not env.sync_enabled
+        or observed_changed
     )
-    if binding_matches:
-        heartbeat_update = (
-            update(AgentEnvironment)
-            .where(
-                AgentEnvironment.id == heartbeat_target.c.id,
-                AgentEnvironment.user_id == auth.user_id,
-                active_agent_filter(),
-                or_(*write_conditions),
-            )
-            .values(**update_values)
-            .returning(AgentEnvironment.id)
-            .cte("heartbeat_update")
-        )
-        target_exists, heartbeat_updated = (
-            await db.execute(
-                select(
-                    select(heartbeat_target.c.id).exists(),
-                    select(heartbeat_update.c.id).exists(),
-                )
-            )
-        ).one()
-    else:
-        target_exists = await db.scalar(select(select(heartbeat_target.c.id).exists()))
-        heartbeat_updated = False
-    if not target_exists:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "agent environment not found")
-    if not binding_matches:
-        raise HTTPException(
-            status.HTTP_403_FORBIDDEN,
-            "api key bound to a different environment",
-        )
-    if not heartbeat_updated:
+    # Even with no state change, refresh last_sync_at on a bounded
+    # cadence. The dashboard freshness cutoff is 90s; 40s keeps new
+    # 60s clients live while preventing old 30s clients from writing
+    # on every heartbeat.
+    last = env.last_sync_at
+    needs_freshness_refresh = (
+        last is None or now - _as_utc(last) > _HEARTBEAT_FRESHNESS_WRITE_INTERVAL
+    )
+    if not has_state_change and not needs_freshness_refresh:
         return
-
-    if hosted_runtime_exists and runtime_observed_values is not None:
+    env.last_sync_at = now
+    env.last_sync_error = new_error
+    if new_revision is not None:
+        env.last_revision_seen = new_revision
+    if body.queue_depth is not None and body.queue_depth > env.queue_depth_high_water_since_start:
+        env.queue_depth_high_water_since_start = body.queue_depth
+    if body.dropped_count_delta:
+        env.dropped_count_since_start = (
+            env.dropped_count_since_start or 0
+        ) + body.dropped_count_delta
+    # A heartbeat IS the user opting in: they ran `clawdi daemon` (or
+    # installed the launchd / systemd unit) and the daemon is
+    # successfully posting liveness. The `sync_enabled` flag was a
+    # canary toggle so existing envs wouldn't auto-pick-up sync at
+    # rollout — it has done its job once an actual heartbeat arrives.
+    if not env.sync_enabled:
+        env.sync_enabled = True
+    if hosted_state is not None and runtime_observed_values is not None:
         insert_observation = pg_insert(HostedRuntimeConfigObservation).values(
             environment_id=agent_id,
             **runtime_observed_values,

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -22,6 +22,7 @@ from fastapi import (
 from fastapi.responses import Response
 from sqlalchemy import and_, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from app.core.auth import AuthContext, require_scope_short_session
 from app.core.database import async_session_factory, get_session
@@ -86,7 +87,6 @@ from app.services.sync_events import (
     AGENT_SKILL_CHANGED_EVENT,
     AGENT_SKILL_DELETED_EVENT,
     bump_skills_revision,
-    get_skills_revision,
 )
 from app.services.tar_utils import (
     SkillTextValidationError,
@@ -397,12 +397,12 @@ async def _list_skills_with_db(
     # a committed Skill mutation. Both the caller revision (kept as the first
     # ETag segment for CLI 0.13.13) and every visible owner's revision come
     # from this database snapshot before a 304 is considered.
-    revision = await get_skills_revision(db, auth.user_id)
     (
+        revision,
         visible_revision_fingerprint,
         metadata_fingerprint,
         project_meta,
-    ) = await _visible_skills_etag_state(db, visible_project_ids)
+    ) = await _skills_etag_state(db, auth.user_id, visible_project_ids)
     if (auth.is_cli or auth.oauth_cli) and visible_project_ids:
         has_agent_project = any(
             meta["kind"] == PROJECT_KIND_ENVIRONMENT for meta in project_meta.values()
@@ -645,45 +645,59 @@ async def _resolve_legacy_skill(
     return skill
 
 
-async def _visible_skills_etag_state(
+async def _skills_etag_state(
     db: AsyncSession,
+    caller_user_id: UUID,
     visible_project_ids: list[UUID],
-) -> tuple[str, str, dict[UUID, _ProjectSkillMetadata]]:
-    """Load current owner revisions and all response-visible metadata.
+) -> tuple[int, str, str, dict[UUID, _ProjectSkillMetadata]]:
+    """Load the caller revision, owner revisions, and visible metadata.
 
     `users.skills_revision` is bumped on the owner account when a skill
     changes. For shared projects, the recipient's own revision does not
     move. Project and Agent metadata have no shared revision counter, so hash
-    their actual projected values. Both fingerprints cover the full visible
-    set and therefore remain identical across pages.
+    their actual projected values. The caller User is the query root so its
+    current revision is returned from the same snapshot even when the visible
+    project set is empty.
     """
-    if not visible_project_ids:
-        return "none", "none", {}
-
+    caller = aliased(User, name="caller_user")
+    owner = aliased(User, name="project_owner")
     rows = (
         await db.execute(
             select(
-                Project.id,
-                Project.user_id,
-                User.skills_revision,
+                caller.skills_revision.label("caller_skills_revision"),
+                Project.id.label("project_id"),
+                Project.user_id.label("project_user_id"),
+                owner.skills_revision.label("owner_skills_revision"),
                 Project.name,
                 Project.kind,
                 Project.origin_environment_id,
                 AgentEnvironment.machine_name,
             )
-            .join(User, User.id == Project.user_id)
+            .select_from(caller)
+            .outerjoin(Project, Project.id.in_(visible_project_ids))
+            .outerjoin(owner, owner.id == Project.user_id)
             .outerjoin(
                 AgentEnvironment,
                 AgentEnvironment.id == Project.origin_environment_id,
             )
-            .where(Project.id.in_(visible_project_ids))
+            .where(caller.id == caller_user_id)
         )
     ).all()
-    owner_revisions = {row.user_id: int(row.skills_revision or 0) for row in rows}
-    owner_parts = sorted(f"{owner_id}:{revision}" for owner_id, revision in owner_revisions.items())
-    visible_revision_fingerprint = hashlib.sha256(":".join(owner_parts).encode()).hexdigest()[:16]
+    if not rows:
+        raise RuntimeError("Authenticated user disappeared during the skills snapshot")
 
-    rows_by_project_id = {row.id: row for row in rows}
+    revision = int(rows[0].caller_skills_revision or 0)
+    owner_revisions = {
+        row.project_user_id: int(row.owner_skills_revision or 0)
+        for row in rows
+        if row.project_user_id is not None
+    }
+    owner_parts = sorted(f"{owner_id}:{revision}" for owner_id, revision in owner_revisions.items())
+    visible_revision_fingerprint = (
+        hashlib.sha256(":".join(owner_parts).encode()).hexdigest()[:16] if owner_parts else "none"
+    )
+
+    rows_by_project_id = {row.project_id: row for row in rows if row.project_id is not None}
     metadata_values: list[list[str | None]] = []
     project_meta: dict[UUID, _ProjectSkillMetadata] = {}
     for project_id in sorted(set(visible_project_ids), key=str):
@@ -707,14 +721,18 @@ async def _visible_skills_etag_state(
             "environment_id": environment_id,
             "machine_name": row.machine_name,
         }
-    metadata_fingerprint = hashlib.sha256(
-        json.dumps(
-            metadata_values,
-            ensure_ascii=False,
-            separators=(",", ":"),
-        ).encode()
-    ).hexdigest()[:16]
-    return visible_revision_fingerprint, metadata_fingerprint, project_meta
+    metadata_fingerprint = (
+        hashlib.sha256(
+            json.dumps(
+                metadata_values,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode()
+        ).hexdigest()[:16]
+        if metadata_values
+        else "none"
+    )
+    return revision, visible_revision_fingerprint, metadata_fingerprint, project_meta
 
 
 async def _build_skill_detail(skill: Skill, db: AsyncSession | None = None) -> SkillDetailResponse:

--- a/backend/tests/test_agent_endpoints.py
+++ b/backend/tests/test_agent_endpoints.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 import httpx
 import pytest
-from sqlalchemy import select
+from sqlalchemy import event, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import AuthContext, get_auth, get_auth_short_session
@@ -195,6 +195,57 @@ async def test_agent_and_environment_routes_share_non_deprecated_payloads(
         json={"environment_ids": [second_id, agent_id]},
     )
     _assert_agent_list_response_matches_environment(reordered_agents, reordered_environments)
+
+
+@pytest.mark.asyncio
+async def test_environment_detail_projects_only_hosted_deployment_id(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    engine,
+):
+    agent_id = await _register_agent(client)
+    db_session.add(
+        HostedRuntimeState(
+            environment_id=uuid.UUID(agent_id),
+            deployment_id="dep-narrow-environment-read",
+            instance_id="iid-narrow-environment-read",
+            generation=1,
+            cli_package_spec=_TEST_CLI_PACKAGE_SPEC,
+            locale=_TEST_LOCALE,
+            system=_TEST_SYSTEM,
+            live_sync={"enabled": False, "agents": []},
+            recovery={"cacheManifest": True, "allowOfflineBoot": True},
+            runtimes={"wide": {"payload": "not-needed-by-environment-response"}},
+            skills={"entries": {"wide": {"enabled": True}}},
+            tools={"catalog": "not-needed-by-environment-response"},
+        )
+    )
+    await db_session.commit()
+
+    statements: list[str] = []
+
+    def capture_statement(_conn, _cursor, statement, _params, _context, _many) -> None:
+        statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", capture_statement)
+    try:
+        response = await client.get(f"/api/environments/{agent_id}")
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", capture_statement)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["hosted_managed"] is True
+    assert response.json()["hosted_deployment_id"] == "dep-narrow-environment-read"
+    selects = [
+        statement.lower()
+        for statement in statements
+        if statement.lstrip().upper().startswith("SELECT")
+    ]
+    assert len(selects) == 1
+    statement = selects[0]
+    assert "hosted_runtime_states.deployment_id" in statement
+    for unneeded_column in ("runtimes", "live_sync", "recovery", "mcp", "skills", "tools"):
+        assert f"hosted_runtime_states.{unneeded_column}" not in statement
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -15,7 +15,9 @@ import uuid
 import httpx
 import pytest
 import yaml
-from sqlalchemy import select
+from fastapi.responses import Response
+from sqlalchemy import event, select
+from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from app.core.auth import AuthContext
 from app.core.skill_sync_protocol import (
@@ -1290,6 +1292,60 @@ async def test_bound_api_key_skills_etag_reads_current_db_revision(
     changed_etag = changed.headers["etag"]
     assert changed_etag != etag
     assert int(changed_etag.strip('"').split(":", 1)[0]) == int(first_revision) + 1
+
+
+@pytest.mark.asyncio
+async def test_skills_304_loads_etag_state_in_one_snapshot_query(
+    engine,
+    seed_user,
+    project_id: str,
+):
+    from app.models.api_key import ApiKey
+
+    project_uuid = uuid.UUID(project_id)
+    auth = AuthContext(
+        user=seed_user,
+        api_key=ApiKey(user_id=seed_user.id),
+        api_key_project_id=project_uuid,
+    )
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def list_with_etag(if_none_match: str | None) -> Response:
+        async with session_factory() as db:
+            result = await skill_routes._list_skills_with_db(
+                auth=auth,
+                db=db,
+                q=None,
+                page=1,
+                page_size=200,
+                include_content=False,
+                project_id=project_uuid,
+                if_none_match=if_none_match,
+                skill_sync_protocol=None,
+            )
+        assert isinstance(result, Response)
+        return result
+
+    first = await list_with_etag(None)
+    etag = first.headers["etag"]
+    statements: list[str] = []
+
+    def capture_statement(_conn, _cursor, statement, _params, _context, _many) -> None:
+        statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", capture_statement)
+    try:
+        replay = await list_with_etag(etag)
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", capture_statement)
+
+    assert replay.status_code == 304
+    selects = [
+        statement for statement in statements if statement.lstrip().upper().startswith("SELECT")
+    ]
+    assert len(selects) == 1
+    assert "caller_skills_revision" in selects[0]
+    assert "owner_skills_revision" in selects[0]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -13,6 +13,7 @@ disguise a broken sync as healthy.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
@@ -22,8 +23,8 @@ import httpx
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport
-from sqlalchemy import event
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import event, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.ext.asyncio.engine import AsyncEngine
 
 from app.core.auth import AuthContext, get_auth
@@ -404,6 +405,88 @@ async def test_heartbeat_dropped_count_accumulates(client: httpx.AsyncClient):
     )
     detail = (await client.get(f"/v1/environments/{env_id}")).json()
     assert detail["dropped_count"] == 5
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_state_update_is_one_database_statement(
+    client: httpx.AsyncClient,
+    engine: AsyncEngine,
+    seed_user,
+):
+    env_id = uuid.UUID(await _create_env(client))
+    statements: list[str] = []
+
+    def capture_statement(_conn, _cursor, statement, _params, _context, _many) -> None:
+        statements.append(statement)
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    event.listen(engine.sync_engine, "before_cursor_execute", capture_statement)
+    try:
+        async with session_factory() as request_db:
+            await session_routes.sync_heartbeat(
+                env_id,
+                session_routes.SyncHeartbeatRequest(),
+                AuthContext(user=seed_user),
+                request_db,
+            )
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", capture_statement)
+
+    assert len(statements) == 1
+    assert "heartbeat_target" in statements[0]
+    assert "UPDATE agent_environments" in statements[0]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_heartbeat_dropped_deltas_accumulate_atomically(
+    client: httpx.AsyncClient,
+    engine: AsyncEngine,
+    seed_user,
+):
+    env_id = uuid.UUID(await _create_env(client))
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    updates_issued = asyncio.Event()
+    update_count = 0
+
+    def observe_update(_conn, _cursor, statement, _params, _context, _many) -> None:
+        nonlocal update_count
+        if "UPDATE agent_environments" not in statement:
+            return
+        update_count += 1
+        if update_count == 2:
+            updates_issued.set()
+
+    async def heartbeat(delta: int) -> None:
+        async with session_factory() as request_db:
+            await session_routes.sync_heartbeat(
+                env_id,
+                session_routes.SyncHeartbeatRequest(dropped_count_delta=delta),
+                AuthContext(user=seed_user),
+                request_db,
+            )
+
+    tasks: list[asyncio.Task[None]] = []
+    async with session_factory() as blocker:
+        await blocker.execute(
+            select(AgentEnvironment.id).where(AgentEnvironment.id == env_id).with_for_update()
+        )
+        event.listen(engine.sync_engine, "before_cursor_execute", observe_update)
+        try:
+            tasks = [asyncio.create_task(heartbeat(2)), asyncio.create_task(heartbeat(3))]
+            await asyncio.wait_for(updates_issued.wait(), timeout=2)
+        finally:
+            await blocker.rollback()
+            event.remove(engine.sync_engine, "before_cursor_execute", observe_update)
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+    results = [task.result() for task in tasks]
+    assert results == [None, None]
+    async with session_factory() as verify_db:
+        dropped_count = await verify_db.scalar(
+            select(AgentEnvironment.dropped_count_since_start).where(AgentEnvironment.id == env_id)
+        )
+    assert dropped_count == 5
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -13,7 +13,6 @@ disguise a broken sync as healthy.
 
 from __future__ import annotations
 
-import asyncio
 import uuid
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
@@ -23,8 +22,8 @@ import httpx
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport
-from sqlalchemy import event, select
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.asyncio.engine import AsyncEngine
 
 from app.core.auth import AuthContext, get_auth
@@ -405,88 +404,6 @@ async def test_heartbeat_dropped_count_accumulates(client: httpx.AsyncClient):
     )
     detail = (await client.get(f"/v1/environments/{env_id}")).json()
     assert detail["dropped_count"] == 5
-
-
-@pytest.mark.asyncio
-async def test_heartbeat_state_update_is_one_database_statement(
-    client: httpx.AsyncClient,
-    engine: AsyncEngine,
-    seed_user,
-):
-    env_id = uuid.UUID(await _create_env(client))
-    statements: list[str] = []
-
-    def capture_statement(_conn, _cursor, statement, _params, _context, _many) -> None:
-        statements.append(statement)
-
-    session_factory = async_sessionmaker(engine, expire_on_commit=False)
-    event.listen(engine.sync_engine, "before_cursor_execute", capture_statement)
-    try:
-        async with session_factory() as request_db:
-            await session_routes.sync_heartbeat(
-                env_id,
-                session_routes.SyncHeartbeatRequest(),
-                AuthContext(user=seed_user),
-                request_db,
-            )
-    finally:
-        event.remove(engine.sync_engine, "before_cursor_execute", capture_statement)
-
-    assert len(statements) == 1
-    assert "heartbeat_target" in statements[0]
-    assert "UPDATE agent_environments" in statements[0]
-
-
-@pytest.mark.asyncio
-async def test_concurrent_heartbeat_dropped_deltas_accumulate_atomically(
-    client: httpx.AsyncClient,
-    engine: AsyncEngine,
-    seed_user,
-):
-    env_id = uuid.UUID(await _create_env(client))
-    session_factory = async_sessionmaker(engine, expire_on_commit=False)
-    updates_issued = asyncio.Event()
-    update_count = 0
-
-    def observe_update(_conn, _cursor, statement, _params, _context, _many) -> None:
-        nonlocal update_count
-        if "UPDATE agent_environments" not in statement:
-            return
-        update_count += 1
-        if update_count == 2:
-            updates_issued.set()
-
-    async def heartbeat(delta: int) -> None:
-        async with session_factory() as request_db:
-            await session_routes.sync_heartbeat(
-                env_id,
-                session_routes.SyncHeartbeatRequest(dropped_count_delta=delta),
-                AuthContext(user=seed_user),
-                request_db,
-            )
-
-    tasks: list[asyncio.Task[None]] = []
-    async with session_factory() as blocker:
-        await blocker.execute(
-            select(AgentEnvironment.id).where(AgentEnvironment.id == env_id).with_for_update()
-        )
-        event.listen(engine.sync_engine, "before_cursor_execute", observe_update)
-        try:
-            tasks = [asyncio.create_task(heartbeat(2)), asyncio.create_task(heartbeat(3))]
-            await asyncio.wait_for(updates_issued.wait(), timeout=2)
-        finally:
-            await blocker.rollback()
-            event.remove(engine.sync_engine, "before_cursor_execute", observe_update)
-            if tasks:
-                await asyncio.gather(*tasks, return_exceptions=True)
-
-    results = [task.result() for task in tasks]
-    assert results == [None, None]
-    async with session_factory() as verify_db:
-        dropped_count = await verify_db.scalar(
-            select(AgentEnvironment.dropped_count_since_start).where(AgentEnvironment.id == env_id)
-        )
-    assert dropped_count == 5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- project only `HostedRuntimeState.deployment_id` for environment identity responses instead of materializing wide runtime JSONB
- load caller and visible-owner Skill revisions plus project metadata in one repeatable-read snapshot query

## Correctness

- preserves `/api`, `/v1`, old payload, ETag, pagination, shared-project, OAuth, and unbound-key behavior
- leaves the byte-frozen v1 runtime-observation and heartbeat symbols unchanged
- does not add workers, caches, locks, migrations, or client requirements

## Verification

- Docker focused regression: `49 passed`, including the v1 byte-freeze contract
- Ruff lint and format check: passed
- compileall: passed
- owned type governance: 196 files, 0 errors, 0 warnings
- strict exception audit: passed
- `git diff --check`: passed

## Expected impact

At the current production traffic shape this removes one database query from roughly 258 conditional Skill reads per minute, about 4.3 queries per second on average with larger synchronized peak savings. It also avoids wide runtime JSONB decoding on environment identity reads, currently about 525 requests per minute. Heartbeat behavior is intentionally unchanged because released clients share a byte-frozen compatibility boundary; production impact will be measured after an authorized deployment.