### PR TITLE
perf(backend): scale API workers safely

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.core.auth import AccountSuspendedHTTPException, warm_clerk_jwks
 from app.core.config import settings
-from app.core.database import async_session_factory, get_session
+from app.core.database import get_session
 from app.core.logging_config import configure_application_logging
 from app.core.sentry import init_sentry
 from app.middleware.body_size_limit import BodySizeLimitMiddleware
@@ -69,13 +69,8 @@ from app.services.ai_provider_auth_transition import OAuthCredentialPayloadCorru
 from app.services.composio import close_composio_client
 from app.services.embedding import LocalEmbedder
 from app.services.memory_types import MemoryProviderUnavailableError, MemoryProviderUpstreamError
-from app.services.plugin_catalog import PluginCatalogSyncWorker
 from app.services.sync_events import start_postgres_listener, stop_postgres_listener
-from app.services.whatsapp_device_onboarding import expire_stale_whatsapp_onboarding_sessions
-from app.services.whatsapp_managed_onboarding import (
-    expire_stale_platform_whatsapp_pairing_sessions,
-)
-from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarRegistry
+from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarClientPool
 
 configure_application_logging()
 log = logging.getLogger(__name__)
@@ -108,69 +103,19 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     finishes before the first embedding call, that call is fast.
     """
     background: set[asyncio.Task[None]] = set()
-    whatsapp_sidecars = ConfiguredWhatsAppSidecarRegistry(
+    whatsapp_sidecars = ConfiguredWhatsAppSidecarClientPool(
         settings.channel_whatsapp_baileys_sidecar_token.get_secret_value(),
         base_url=settings.channel_whatsapp_baileys_sidecar_url or None,
     )
     await start_postgres_listener()
     try:
         await whatsapp_sidecars.start()
-        if whatsapp_sidecars.enabled:
-            await whatsapp_sidecars.reconcile_custom_ownership()
-            await whatsapp_sidecars.reconcile_managed_ownership()
     except Exception:
         await whatsapp_sidecars.stop()
         await stop_postgres_listener()
         raise
 
     await warm_clerk_jwks()
-
-    if settings.plugin_catalog_sync_enabled:
-        catalog_worker = PluginCatalogSyncWorker(
-            async_session_factory,
-            interval_seconds=settings.plugin_catalog_sync_interval_seconds,
-            timeout_seconds=settings.plugin_catalog_sync_timeout_seconds,
-        )
-        task = asyncio.create_task(
-            catalog_worker.run_forever(),
-            name="plugin-catalog-sync",
-        )
-        background.add(task)
-        task.add_done_callback(background.discard)
-
-    if whatsapp_sidecars.enabled:
-
-        async def _expire_whatsapp_onboarding() -> None:
-            while True:
-                await asyncio.sleep(15)
-                try:
-                    await whatsapp_sidecars.reconcile_custom_ownership()
-                    await whatsapp_sidecars.reconcile_managed_ownership()
-                except asyncio.CancelledError:
-                    raise
-                except Exception:
-                    log.exception("WhatsApp sidecar ownership reconciliation failed")
-                try:
-                    async with async_session_factory() as db:
-                        await expire_stale_whatsapp_onboarding_sessions(
-                            db,
-                            registry=whatsapp_sidecars,
-                        )
-                        await expire_stale_platform_whatsapp_pairing_sessions(
-                            db,
-                            registry=whatsapp_sidecars,
-                        )
-                except asyncio.CancelledError:
-                    raise
-                except Exception:
-                    log.exception("WhatsApp onboarding expiry sweep failed")
-
-        task = asyncio.create_task(
-            _expire_whatsapp_onboarding(),
-            name="whatsapp-onboarding-expiry",
-        )
-        background.add(task)
-        task.add_done_callback(background.discard)
 
     if settings.memory_embedding_mode.lower() == "local":
 

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -231,7 +231,7 @@ from app.services.whatsapp_managed_onboarding import (
     get_platform_whatsapp_pairing,
     start_platform_whatsapp_pairing,
 )
-from app.services.whatsapp_sidecar_registry import get_active_whatsapp_sidecar_registry
+from app.services.whatsapp_sidecar_registry import get_active_whatsapp_sidecar_clients
 
 logger = logging.getLogger(__name__)
 
@@ -1882,7 +1882,7 @@ async def admin_start_platform_whatsapp_pairing(
         account_id=body.account_id,
         request_id=body.request_id,
         name=body.name,
-        registry=get_active_whatsapp_sidecar_registry(),
+        registry=get_active_whatsapp_sidecar_clients(),
     )
     record_control_plane_audit(
         db,
@@ -1910,7 +1910,7 @@ async def admin_get_platform_whatsapp_pairing(
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     _no_store(response)
     result = await get_platform_whatsapp_pairing(
-        db, session_id=session_id, registry=get_active_whatsapp_sidecar_registry()
+        db, session_id=session_id, registry=get_active_whatsapp_sidecar_clients()
     )
     return result
 
@@ -1927,7 +1927,7 @@ async def admin_cancel_platform_whatsapp_pairing(
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     _no_store(response)
     result = await cancel_platform_whatsapp_pairing(
-        db, session_id=session_id, registry=get_active_whatsapp_sidecar_registry()
+        db, session_id=session_id, registry=get_active_whatsapp_sidecar_clients()
     )
     record_control_plane_audit(
         db,
@@ -2180,7 +2180,7 @@ async def admin_delete_channel(
     await require_whatsapp_logout_for_archive(
         db,
         account=account,
-        registry=get_active_whatsapp_sidecar_registry(),
+        registry=get_active_whatsapp_sidecar_clients(),
     )
     await archive_channel_account(db, account=account)
     if account.provider in RUNTIME_CHANNEL_PROVIDERS:

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -160,7 +160,7 @@ from app.services.whatsapp_native_transport import (
     WhatsAppSidecarError,
     whatsapp_phone_number_from_pn_jid,
 )
-from app.services.whatsapp_sidecar_registry import get_active_whatsapp_sidecar_registry
+from app.services.whatsapp_sidecar_registry import get_active_whatsapp_sidecar_clients
 
 router = APIRouter(prefix="/channels", tags=["channels"])
 
@@ -677,7 +677,7 @@ async def delete_channel(
     await require_whatsapp_logout_for_archive(
         db,
         account=account,
-        registry=get_active_whatsapp_sidecar_registry(),
+        registry=get_active_whatsapp_sidecar_clients(),
     )
     await archive_channel_account(db, account=account)
     for link in active_links:
@@ -721,10 +721,10 @@ async def _whatsapp_pair_deep_link(
         )
         if trusted_phone_number is not None:
             return f"https://wa.me/{trusted_phone_number}?text={quote(pairing_command, safe='')}"
-    registry = get_active_whatsapp_sidecar_registry()
-    if registry is None or registry.managed_account_revision(account.id) != configured_revision:
+    registry = get_active_whatsapp_sidecar_clients()
+    if registry is None or registry.session_revision(account.id) != configured_revision:
         return None
-    client = registry.get_managed_client(account.id)
+    client = registry.session_client(account.id)
     if client is None:
         return None
     try:
@@ -749,7 +749,7 @@ async def create_channel_pair_code(
     account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
     await require_whatsapp_custom_link_ready(
         account,
-        registry=get_active_whatsapp_sidecar_registry(),
+        registry=get_active_whatsapp_sidecar_clients(),
     )
     if (
         account.provider == CHANNEL_PROVIDER_TELEGRAM
@@ -896,7 +896,7 @@ async def create_channel_agent_link(
     account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
     await require_whatsapp_custom_link_ready(
         account,
-        registry=get_active_whatsapp_sidecar_registry(),
+        registry=get_active_whatsapp_sidecar_clients(),
     )
     agent_id = await _resolve_agent_id_for_link(db, auth=auth, requested_agent_id=body.agent_id)
     link, agent_token = await get_or_create_bot_agent_link(

--- a/backend/app/routes/channel_routers/whatsapp.py
+++ b/backend/app/routes/channel_routers/whatsapp.py
@@ -73,7 +73,7 @@ from app.services.whatsapp_provider_bridge import (
     WhatsAppProviderBridge,
 )
 from app.services.whatsapp_runtime_types import WhatsAppOutboundMessage
-from app.services.whatsapp_sidecar_registry import get_active_whatsapp_sidecar_registry
+from app.services.whatsapp_sidecar_registry import get_active_whatsapp_sidecar_clients
 
 router = APIRouter(prefix="/channels/whatsapp", tags=["channels"])
 
@@ -415,16 +415,16 @@ async def _resolve_whatsapp_noise_lid(
 
 
 async def _authenticated_sidecar_health(account: ChannelAccount) -> WhatsAppSidecarHealth:
-    registry = get_active_whatsapp_sidecar_registry()
+    registry = get_active_whatsapp_sidecar_clients()
     config = account.config if isinstance(account.config, dict) else {}
     revision = config.get("sidecar_config_revision")
     if registry is None or not isinstance(revision, str):
         raise WhatsAppSidecarProtocolError("WhatsApp sidecar identity is unavailable")
     mode = config.get("connection_mode")
     if mode == "baileys_managed":
-        if registry.managed_account_revision(account.id) != revision:
+        if registry.session_revision(account.id) != revision:
             raise WhatsAppSidecarProtocolError("managed WhatsApp sidecar revision mismatch")
-        client = registry.get_managed_client(account.id)
+        client = registry.session_client(account.id)
     elif mode == "baileys_custom":
         raw_session_id = config.get("sidecar_account_id")
         try:
@@ -432,8 +432,8 @@ async def _authenticated_sidecar_health(account: ChannelAccount) -> WhatsAppSide
         except ValueError:
             session_id = None
         client = (
-            registry.get_custom_lifecycle_client(session_id, config_revision=revision)
-            if session_id is not None
+            registry.session_client(session_id)
+            if session_id is not None and registry.session_revision(session_id) == revision
             else None
         )
     else:

--- a/backend/app/routes/channel_routers/whatsapp_onboarding.py
+++ b/backend/app/routes/channel_routers/whatsapp_onboarding.py
@@ -23,15 +23,15 @@ from app.services.whatsapp_device_onboarding import (
     whatsapp_onboarding_readiness,
 )
 from app.services.whatsapp_sidecar_registry import (
-    ConfiguredWhatsAppSidecarRegistry,
-    get_active_whatsapp_sidecar_registry,
+    WhatsAppSidecarClients,
+    get_active_whatsapp_sidecar_clients,
 )
 
 router = APIRouter(prefix="/channels/whatsapp/onboarding", tags=["channels"])
 
 
-def get_whatsapp_sidecar_registry() -> ConfiguredWhatsAppSidecarRegistry | None:
-    return get_active_whatsapp_sidecar_registry()
+def get_whatsapp_sidecar_clients() -> WhatsAppSidecarClients | None:
+    return get_active_whatsapp_sidecar_clients()
 
 
 def _prevent_sensitive_caching(response: Response) -> None:
@@ -44,7 +44,7 @@ async def get_whatsapp_onboarding_readiness(
     response: Response,
     _auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
-    registry: ConfiguredWhatsAppSidecarRegistry | None = Depends(get_whatsapp_sidecar_registry),
+    registry: WhatsAppSidecarClients | None = Depends(get_whatsapp_sidecar_clients),
 ) -> ChannelWhatsAppOnboardingReadinessResponse:
     _prevent_sensitive_caching(response)
     return await whatsapp_onboarding_readiness(db, registry=registry)
@@ -56,7 +56,7 @@ async def create_whatsapp_onboarding_session(
     response: Response,
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
-    registry: ConfiguredWhatsAppSidecarRegistry | None = Depends(get_whatsapp_sidecar_registry),
+    registry: WhatsAppSidecarClients | None = Depends(get_whatsapp_sidecar_clients),
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     _prevent_sensitive_caching(response)
     return await start_whatsapp_onboarding(
@@ -74,7 +74,7 @@ async def get_whatsapp_onboarding_session(
     response: Response,
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
-    registry: ConfiguredWhatsAppSidecarRegistry | None = Depends(get_whatsapp_sidecar_registry),
+    registry: WhatsAppSidecarClients | None = Depends(get_whatsapp_sidecar_clients),
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     _prevent_sensitive_caching(response)
     return await refresh_whatsapp_onboarding(
@@ -92,7 +92,7 @@ async def create_whatsapp_onboarding_pairing_code(
     response: Response,
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
-    registry: ConfiguredWhatsAppSidecarRegistry | None = Depends(get_whatsapp_sidecar_registry),
+    registry: WhatsAppSidecarClients | None = Depends(get_whatsapp_sidecar_clients),
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     _prevent_sensitive_caching(response)
     return await request_whatsapp_pairing_code(
@@ -110,7 +110,7 @@ async def cancel_whatsapp_onboarding_session(
     response: Response,
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
-    registry: ConfiguredWhatsAppSidecarRegistry | None = Depends(get_whatsapp_sidecar_registry),
+    registry: WhatsAppSidecarClients | None = Depends(get_whatsapp_sidecar_clients),
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     _prevent_sensitive_caching(response)
     return await cancel_whatsapp_onboarding(
@@ -127,7 +127,7 @@ async def retry_whatsapp_onboarding_session(
     response: Response,
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
-    registry: ConfiguredWhatsAppSidecarRegistry | None = Depends(get_whatsapp_sidecar_registry),
+    registry: WhatsAppSidecarClients | None = Depends(get_whatsapp_sidecar_clients),
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     _prevent_sensitive_caching(response)
     return await retry_whatsapp_onboarding(
@@ -144,7 +144,7 @@ async def repair_whatsapp_channel_account(
     response: Response,
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
-    registry: ConfiguredWhatsAppSidecarRegistry | None = Depends(get_whatsapp_sidecar_registry),
+    registry: WhatsAppSidecarClients | None = Depends(get_whatsapp_sidecar_clients),
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     _prevent_sensitive_caching(response)
     return await repair_whatsapp_account(

--- a/backend/app/services/whatsapp_device_onboarding.py
+++ b/backend/app/services/whatsapp_device_onboarding.py
@@ -48,8 +48,8 @@ from app.services.whatsapp_native_transport import (
     whatsapp_phone_number_from_pn_jid,
 )
 from app.services.whatsapp_sidecar_registry import (
-    ConfiguredWhatsAppSidecarRegistry,
     WhatsAppSidecarClient,
+    WhatsAppSidecarClients,
 )
 
 WHATSAPP_ONBOARDING_TTL = timedelta(minutes=5)
@@ -80,7 +80,7 @@ _WHATSAPP_ONBOARDING_STATES = frozenset(
 async def whatsapp_onboarding_readiness(
     db: AsyncSession,
     *,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    registry: WhatsAppSidecarClients | None,
 ) -> ChannelWhatsAppOnboardingReadinessResponse:
     if registry is None or not registry.enabled:
         return ChannelWhatsAppOnboardingReadinessResponse(
@@ -106,7 +106,7 @@ async def start_whatsapp_onboarding(
     user_id: UUID,
     request_id: UUID,
     name: str,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    registry: WhatsAppSidecarClients | None,
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     existing = await db.scalar(
         select(ChannelWhatsAppOnboardingSession).where(
@@ -175,7 +175,7 @@ async def start_whatsapp_onboarding(
         )
 
     sidecar_account_id = uuid4()
-    sidecar_config_revision = registry.custom_session_revision(sidecar_account_id)
+    sidecar_config_revision = registry.session_revision(sidecar_account_id)
     if sidecar_config_revision is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -198,7 +198,7 @@ async def start_whatsapp_onboarding(
     await db.flush()
     await db.commit()
     onboarding = await _owned_session(db, user_id=user_id, session_id=onboarding.id)
-    client = registry.get_custom_client(sidecar_account_id)
+    client = registry.session_client(sidecar_account_id)
     if client is None:
         return await _mark_session_error(db, onboarding)
     try:
@@ -224,7 +224,7 @@ async def refresh_whatsapp_onboarding(
     *,
     user_id: UUID,
     session_id: UUID,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    registry: WhatsAppSidecarClients | None,
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     onboarding = await _owned_session(db, user_id=user_id, session_id=session_id)
     if onboarding.state not in WHATSAPP_ONBOARDING_ACTIVE_STATES:
@@ -246,7 +246,7 @@ async def refresh_whatsapp_onboarding(
 
     if registry is None:
         return await _mark_session_error(db, onboarding)
-    client = registry.get_custom_client(onboarding.sidecar_account_id)
+    client = registry.session_client(onboarding.sidecar_account_id)
     if client is None:
         return await _mark_session_error(db, onboarding)
     try:
@@ -273,7 +273,7 @@ async def request_whatsapp_pairing_code(
     user_id: UUID,
     session_id: UUID,
     phone_number: str,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    registry: WhatsAppSidecarClients | None,
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     if _E164_DIGITS.fullmatch(phone_number) is None:
         raise HTTPException(
@@ -296,7 +296,7 @@ async def request_whatsapp_pairing_code(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="WhatsApp account connection is temporarily unavailable",
         )
-    client = registry.get_custom_client(onboarding.sidecar_account_id)
+    client = registry.session_client(onboarding.sidecar_account_id)
     if client is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -333,7 +333,7 @@ async def cancel_whatsapp_onboarding(
     *,
     user_id: UUID,
     session_id: UUID,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    registry: WhatsAppSidecarClients | None,
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     onboarding = await _owned_session(db, user_id=user_id, session_id=session_id)
     if onboarding.state in {
@@ -347,7 +347,7 @@ async def cancel_whatsapp_onboarding(
             detail="Disconnect the connected WhatsApp account instead",
         )
     client = (
-        registry.get_custom_client(onboarding.sidecar_account_id) if registry is not None else None
+        registry.session_client(onboarding.sidecar_account_id) if registry is not None else None
     )
     if client is None:
         await _mark_session_error(db, onboarding)
@@ -381,7 +381,7 @@ async def retry_whatsapp_onboarding(
     *,
     user_id: UUID,
     session_id: UUID,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    registry: WhatsAppSidecarClients | None,
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     onboarding = await _owned_session(db, user_id=user_id, session_id=session_id)
     if onboarding.state in WHATSAPP_ONBOARDING_ACTIVE_STATES:
@@ -422,11 +422,8 @@ async def retry_whatsapp_onboarding(
                 detail="This WhatsApp connection cannot be retried",
             )
         try:
-            await registry.prepare_custom_account_repair(
-                session_id=physical_session_id,
-                account_id=account.id,
-                config_revision=config_revision,
-            )
+            if registry.session_client(physical_session_id) is None:
+                raise WhatsAppSidecarProtocolError("custom Baileys session is unavailable")
         except WhatsAppSidecarError:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -439,7 +436,7 @@ async def retry_whatsapp_onboarding(
     await _lock_allocation(db)
     onboarding = await _owned_session(db, user_id=user_id, session_id=session_id)
     sidecar_account_id = onboarding.sidecar_account_id
-    sidecar_config_revision = registry.custom_session_revision(sidecar_account_id)
+    sidecar_config_revision = registry.session_revision(sidecar_account_id)
     if sidecar_config_revision is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -455,7 +452,7 @@ async def retry_whatsapp_onboarding(
     onboarding.completed_at = None
     await db.commit()
     onboarding = await _owned_session(db, user_id=user_id, session_id=session_id)
-    client = registry.get_custom_client(sidecar_account_id)
+    client = registry.session_client(sidecar_account_id)
     if client is None:
         return await _mark_session_error(db, onboarding)
     try:
@@ -481,7 +478,7 @@ async def repair_whatsapp_account(
     *,
     user_id: UUID,
     account_id: UUID,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    registry: WhatsAppSidecarClients | None,
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     """Start an owner-requested re-pair without replacing the durable account."""
 
@@ -520,10 +517,7 @@ async def repair_whatsapp_account(
         await db.commit()
         return _session_response(existing, manual_pairing_code_supported=False)
 
-    client = registry.get_custom_lifecycle_client(
-        session_id,
-        config_revision=config_revision,
-    )
+    client = registry.session_client(session_id)
     if client is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -569,11 +563,9 @@ async def repair_whatsapp_account(
     await db.commit()
     onboarding = await _owned_session(db, user_id=user_id, session_id=onboarding.id)
     try:
-        client = await registry.prepare_custom_account_repair(
-            session_id=session_id,
-            account_id=account.id,
-            config_revision=config_revision,
-        )
+        client = registry.session_client(session_id)
+        if client is None:
+            raise WhatsAppSidecarProtocolError("custom Baileys session is unavailable")
         if repair_reason == "remote_logged_out":
             recovered = await client.pairing_recover()
             if recovered.status != "stopped" or recovered.registered:
@@ -601,7 +593,7 @@ async def repair_whatsapp_account(
 async def require_whatsapp_custom_link_ready(
     account: ChannelAccount,
     *,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    registry: WhatsAppSidecarClients | None,
 ) -> None:
     """Fail a Custom WhatsApp Link unless its physical transport is usable."""
 
@@ -617,16 +609,13 @@ async def require_whatsapp_custom_link_ready(
             detail="whatsapp_connection_temporarily_unavailable",
         )
     try:
-        session_id, config_revision = _custom_account_session(account, registry=registry)
+        session_id, _ = _custom_account_session(account, registry=registry)
     except WhatsAppSidecarError:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="whatsapp_connection_temporarily_unavailable",
         ) from None
-    client = registry.get_custom_lifecycle_client(
-        session_id,
-        config_revision=config_revision,
-    )
+    client = registry.session_client(session_id)
     if client is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -664,7 +653,7 @@ def _repair_reason(health: WhatsAppSidecarHealth) -> _WhatsAppRepairReason | Non
 def _custom_account_session(
     account: ChannelAccount,
     *,
-    registry: ConfiguredWhatsAppSidecarRegistry,
+    registry: WhatsAppSidecarClients,
 ) -> tuple[UUID, str]:
     config = account.config if isinstance(account.config, dict) else {}
     raw_session_id = config.get("sidecar_account_id")
@@ -675,7 +664,7 @@ def _custom_account_session(
         session_id = UUID(raw_session_id) if isinstance(raw_session_id, str) else None
     except ValueError:
         session_id = None
-    if session_id is None or registry.custom_session_revision(session_id) != config_revision:
+    if session_id is None or registry.session_revision(session_id) != config_revision:
         raise WhatsAppSidecarProtocolError("custom Baileys account identity is unavailable")
     return session_id, config_revision
 
@@ -684,7 +673,7 @@ async def require_whatsapp_logout_for_archive(
     db: AsyncSession,
     *,
     account: ChannelAccount,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    registry: WhatsAppSidecarClients | None,
 ) -> None:
     if account.provider != CHANNEL_PROVIDER_WHATSAPP:
         return
@@ -697,11 +686,11 @@ async def require_whatsapp_logout_for_archive(
                 detail="WhatsApp disconnect could not be confirmed",
             )
         revision = config.get("sidecar_config_revision")
-        client = registry.get_managed_client(account.id)
+        client = registry.session_client(account.id)
         if (
             client is None
             or not isinstance(revision, str)
-            or registry.managed_account_revision(account.id) != revision
+            or registry.session_revision(account.id) != revision
         ):
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -719,7 +708,6 @@ async def require_whatsapp_logout_for_archive(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="WhatsApp disconnect could not be confirmed",
             )
-        await registry.unbind_managed_account(account.id)
         return
     if connection_mode != "baileys_custom":
         return
@@ -745,16 +733,13 @@ async def require_whatsapp_logout_for_archive(
         )
     if (
         not isinstance(sidecar_config_revision, str)
-        or registry.custom_session_revision(sidecar_account_id) != sidecar_config_revision
+        or registry.session_revision(sidecar_account_id) != sidecar_config_revision
     ):
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="WhatsApp disconnect could not be confirmed",
         )
-    client = registry.get_custom_lifecycle_client(
-        sidecar_account_id,
-        config_revision=sidecar_config_revision,
-    )
+    client = registry.session_client(sidecar_account_id)
     if client is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -767,7 +752,6 @@ async def require_whatsapp_logout_for_archive(
             raise WhatsAppSidecarProtocolError("custom sidecar registration state drifted")
         if current.registered and health.last_disconnect_reason != "remote_logged_out":
             await _ensure_connected_transport_for_account(
-                account_id=account.id,
                 session_id=sidecar_account_id,
                 config_revision=sidecar_config_revision,
                 registry=registry,
@@ -787,11 +771,6 @@ async def require_whatsapp_logout_for_archive(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="WhatsApp disconnect could not be confirmed",
         )
-    if registry.custom_binding(account.id) == sidecar_account_id:
-        await registry.unbind_custom_account(
-            session_id=sidecar_account_id,
-            account_id=account.id,
-        )
     onboarding = await db.scalar(
         select(ChannelWhatsAppOnboardingSession).where(
             ChannelWhatsAppOnboardingSession.ownership_kind == WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
@@ -809,7 +788,7 @@ async def require_whatsapp_logout_for_archive(
 async def expire_stale_whatsapp_onboarding_sessions(
     db: AsyncSession,
     *,
-    registry: ConfiguredWhatsAppSidecarRegistry,
+    registry: WhatsAppSidecarClients,
 ) -> int:
     """Stop abandoned browser sessions after their durable deadline."""
 
@@ -886,7 +865,7 @@ async def _apply_pairing_status(
     pairing: WhatsAppSidecarPairingStatus,
     health: WhatsAppSidecarHealth,
     capabilities: WhatsAppSidecarCapabilities,
-    registry: ConfiguredWhatsAppSidecarRegistry,
+    registry: WhatsAppSidecarClients,
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     manual_supported = "code" in capabilities.pairing
     if pairing.status == "connected" and pairing.registered:
@@ -955,21 +934,19 @@ async def _finalize_connected_account(
     db: AsyncSession,
     *,
     onboarding: ChannelWhatsAppOnboardingSession,
-    registry: ConfiguredWhatsAppSidecarRegistry,
+    registry: WhatsAppSidecarClients,
     health: WhatsAppSidecarHealth,
 ) -> None:
     if health.account_jid is None or health.account_lid is None:
         raise WhatsAppSidecarProtocolError("custom sidecar PN/LID identity is unavailable")
     session_id = onboarding.sidecar_account_id
     session_revision = onboarding.sidecar_config_revision
-    account_id: UUID | None = None
-    newly_bound = False
     try:
         owner_user_id = onboarding.user_id
         if owner_user_id is None:
             raise WhatsAppSidecarProtocolError("custom sidecar tenant owner is missing")
         await assert_user_authority_active(db, owner_user_id)
-        configured_revision = registry.custom_session_revision(session_id)
+        configured_revision = registry.session_revision(session_id)
         if configured_revision != session_revision:
             raise WhatsAppSidecarProtocolError("custom sidecar revision mismatch")
         existing = (
@@ -1017,40 +994,22 @@ async def _finalize_connected_account(
                 "lid": health.account_lid,
             }
             existing.config = config
-        account_id = existing.id
-        newly_bound = await registry.bind_custom_account(
-            session_id=session_id,
-            account_id=account_id,
-            config_revision=session_revision,
-        )
         onboarding.state = WHATSAPP_ONBOARDING_STATE_CONNECTED
         onboarding.completed_at = datetime.now(UTC)
         await db.commit()
     except BaseException:
-        try:
-            await db.rollback()
-        finally:
-            if (
-                newly_bound
-                and account_id is not None
-                and registry.custom_binding(account_id) == session_id
-            ):
-                await registry.unbind_custom_account(
-                    session_id=session_id,
-                    account_id=account_id,
-                )
+        await db.rollback()
         raise
 
 
 async def _ensure_connected_transport(
     *,
     onboarding: ChannelWhatsAppOnboardingSession,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    registry: WhatsAppSidecarClients | None,
 ) -> None:
     if onboarding.channel_account_id is None:
         raise WhatsAppSidecarProtocolError("connected WhatsApp session has no account")
     await _ensure_connected_transport_for_account(
-        account_id=onboarding.channel_account_id,
         session_id=onboarding.sidecar_account_id,
         config_revision=onboarding.sidecar_config_revision,
         registry=registry,
@@ -1059,40 +1018,32 @@ async def _ensure_connected_transport(
 
 async def _ensure_connected_transport_for_account(
     *,
-    account_id: UUID,
     session_id: UUID,
     config_revision: str,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    registry: WhatsAppSidecarClients | None,
 ) -> None:
     if registry is None:
         raise WhatsAppSidecarProtocolError("custom Baileys registry is unavailable")
-    if registry.custom_session_revision(session_id) != config_revision:
+    if registry.session_revision(session_id) != config_revision:
         raise WhatsAppSidecarProtocolError("custom Baileys session revision mismatch")
-    if registry.custom_binding(account_id) == session_id:
-        return
-    client = registry.get_custom_client(session_id)
+    client = registry.session_client(session_id)
     if client is None:
         raise WhatsAppSidecarProtocolError("custom Baileys session is unavailable")
     health = await client.health()
     pairing = await client.pairing_status()
     if not health.registered or not pairing.registered:
         raise WhatsAppSidecarProtocolError("custom Baileys physical auth is unavailable")
-    await registry.bind_custom_account(
-        session_id=session_id,
-        account_id=account_id,
-        config_revision=config_revision,
-    )
 
 
 async def _expire_session(
     db: AsyncSession,
     *,
     onboarding: ChannelWhatsAppOnboardingSession,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    registry: WhatsAppSidecarClients | None,
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     if registry is None:
         return await _mark_session_error(db, onboarding)
-    client = registry.get_custom_client(onboarding.sidecar_account_id)
+    client = registry.session_client(onboarding.sidecar_account_id)
     if client is None:
         return await _mark_session_error(db, onboarding)
     try:
@@ -1134,9 +1085,9 @@ async def _expire_session(
 async def _confirm_stopped(
     onboarding: ChannelWhatsAppOnboardingSession,
     *,
-    registry: ConfiguredWhatsAppSidecarRegistry,
+    registry: WhatsAppSidecarClients,
 ) -> None:
-    client = registry.get_custom_client(onboarding.sidecar_account_id)
+    client = registry.session_client(onboarding.sidecar_account_id)
     if client is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/backend/app/services/whatsapp_managed_onboarding.py
+++ b/backend/app/services/whatsapp_managed_onboarding.py
@@ -37,7 +37,7 @@ from app.services.whatsapp_native_transport import (
     WhatsAppSidecarProtocolError,
     whatsapp_phone_number_from_pn_jid,
 )
-from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarRegistry
+from app.services.whatsapp_sidecar_registry import WhatsAppSidecarClients
 
 _LOCK_ID = 8_071_323_913
 _OWNING_STATES = ("generating", "ready", "scanned", "error")
@@ -50,11 +50,11 @@ async def start_platform_whatsapp_pairing(
     account_id: UUID,
     request_id: UUID,
     name: str,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    registry: WhatsAppSidecarClients | None,
 ) -> ChannelWhatsAppOnboardingSessionResponse:
-    if registry is None or registry.get_managed_client(account_id) is None:
+    if registry is None or registry.session_client(account_id) is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "configured WhatsApp account not found")
-    revision = registry.managed_account_revision(account_id)
+    revision = registry.session_revision(account_id)
     if revision is None:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp onboarding unavailable")
     await db.execute(text("SELECT pg_advisory_xact_lock(:id)"), {"id": _LOCK_ID})
@@ -102,7 +102,7 @@ async def start_platform_whatsapp_pairing(
             raise HTTPException(
                 status.HTTP_409_CONFLICT, "configured WhatsApp account name conflicts"
             )
-        client = registry.get_managed_client(account_id)
+        client = registry.session_client(account_id)
         if client is None:
             raise HTTPException(
                 status.HTTP_503_SERVICE_UNAVAILABLE, "WhatsApp onboarding unavailable"
@@ -171,7 +171,7 @@ async def get_platform_whatsapp_pairing(
     db: AsyncSession,
     *,
     session_id: UUID,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    registry: WhatsAppSidecarClients | None,
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     onboarding = await _session(db, session_id)
     if onboarding.state in {
@@ -187,7 +187,7 @@ async def cancel_platform_whatsapp_pairing(
     db: AsyncSession,
     *,
     session_id: UUID,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    registry: WhatsAppSidecarClients | None,
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     onboarding = await _session(db, session_id)
     if onboarding.state == WHATSAPP_ONBOARDING_STATE_CANCELED:
@@ -196,7 +196,7 @@ async def cancel_platform_whatsapp_pairing(
         raise HTTPException(
             status.HTTP_409_CONFLICT, "archive the connected WhatsApp account instead"
         )
-    client = registry.get_managed_client(onboarding.sidecar_account_id) if registry else None
+    client = registry.session_client(onboarding.sidecar_account_id) if registry else None
     try:
         stopped = (
             await stop_whatsapp_pairing(client, allow_remote_logout_recovery=True)
@@ -220,7 +220,7 @@ async def cancel_platform_whatsapp_pairing(
 async def expire_stale_platform_whatsapp_pairing_sessions(
     db: AsyncSession,
     *,
-    registry: ConfiguredWhatsAppSidecarRegistry,
+    registry: WhatsAppSidecarClients,
 ) -> int:
     session_ids = list(
         (
@@ -246,14 +246,14 @@ async def _refresh(
     db: AsyncSession,
     *,
     onboarding: ChannelWhatsAppOnboardingSession,
-    registry: ConfiguredWhatsAppSidecarRegistry | None,
+    registry: WhatsAppSidecarClients | None,
     start_qr: bool,
 ) -> ChannelWhatsAppOnboardingSessionResponse:
     if registry is None:
         return await _error(db, onboarding)
-    client = registry.get_managed_client(onboarding.sidecar_account_id)
+    client = registry.session_client(onboarding.sidecar_account_id)
     if client is None or (
-        registry.managed_account_revision(onboarding.sidecar_account_id)
+        registry.session_revision(onboarding.sidecar_account_id)
         != onboarding.sidecar_config_revision
     ):
         return await _error(db, onboarding)
@@ -272,7 +272,6 @@ async def _refresh(
         await _promote(
             db,
             onboarding=onboarding,
-            registry=registry,
             phone_number=phone_number,
             account_jid=health.account_jid,
             account_lid=health.account_lid,
@@ -312,14 +311,12 @@ async def _promote(
     db: AsyncSession,
     *,
     onboarding: ChannelWhatsAppOnboardingSession,
-    registry: ConfiguredWhatsAppSidecarRegistry,
     phone_number: str,
     account_jid: str,
     account_lid: str,
 ) -> None:
     account_id = onboarding.sidecar_account_id
     session_id = onboarding.id
-    newly_bound = False
     account = await db.get(ChannelAccount, onboarding.sidecar_account_id)
     try:
         if account is None:
@@ -346,17 +343,12 @@ async def _promote(
             config["phone_number"] = phone_number
             config["self_identity"] = {"id": account_jid, "lid": account_lid}
             account.config = config
-        newly_bound = await registry.bind_managed_account(
-            account.id, config_revision=onboarding.sidecar_config_revision
-        )
         onboarding.channel_account_id = account.id
         onboarding.state = WHATSAPP_ONBOARDING_STATE_CONNECTED
         onboarding.completed_at = datetime.now(UTC)
         await db.commit()
     except BaseException as exc:
         await db.rollback()
-        if newly_bound:
-            await registry.unbind_managed_account(account_id)
         failed = await _session(db, session_id)
         failed.state = WHATSAPP_ONBOARDING_STATE_ERROR
         await db.commit()

--- a/backend/app/services/whatsapp_sidecar_registry.py
+++ b/backend/app/services/whatsapp_sidecar_registry.py
@@ -122,17 +122,23 @@ class WhatsAppSidecarClient(WhatsAppNativeUpstreamClient, Protocol):
     async def pairing_recover(self) -> WhatsAppSidecarPairingStatus: ...
 
 
+class WhatsAppSidecarClients(Protocol):
+    @property
+    def enabled(self) -> bool: ...
+
+    async def service_ready(self) -> bool: ...
+
+    def session_client(self, session_id: UUID) -> WhatsAppSidecarClient | None: ...
+
+    def session_revision(self, session_id: UUID) -> str | None: ...
+
+
 SidecarClientFactory = Callable[[WhatsAppBaileysSidecarConfig], WhatsAppSidecarClient]
-_active_registry: ConfiguredWhatsAppSidecarRegistry | None = None
+_active_sidecar_clients: ConfiguredWhatsAppSidecarClientPool | None = None
 
 
-class ConfiguredWhatsAppSidecarRegistry:
-    """Bind product-owned accounts to opaque sessions on one provider service.
-
-    The sidecar endpoint has no tenant, Shared, Custom, inventory, or capacity
-    knowledge. PostgreSQL owns those policies; this registry only creates a
-    session-scoped client and restores local transport/ingress bindings.
-    """
+class ConfiguredWhatsAppSidecarClientPool:
+    """Process-local HTTP pool for stateless sidecar control operations."""
 
     def __init__(
         self,
@@ -152,13 +158,6 @@ class ConfiguredWhatsAppSidecarRegistry:
         self._shared_service: WhatsAppBaileysSidecarService | None = None
         self._service_client: WhatsAppSidecarClient | None = None
         self._clients_by_session: dict[UUID, WhatsAppSidecarClient] = {}
-        self._bound_managed_accounts: set[UUID] = set()
-        self._managed_attach_failures: dict[UUID, str] = {}
-        self._custom_session_to_account: dict[UUID, UUID] = {}
-        self._custom_account_to_session: dict[UUID, UUID] = {}
-        self._blocked_custom_sessions: set[UUID] = set()
-        self._ingress_tasks: dict[UUID, asyncio.Task[None]] = {}
-        self._custom_reconcile_lock = asyncio.Lock()
         self._started = False
         if self.enabled:
             self._service_config()
@@ -166,6 +165,116 @@ class ConfiguredWhatsAppSidecarRegistry:
     @property
     def enabled(self) -> bool:
         return bool(self._api_token)
+
+    async def start(self) -> None:
+        global _active_sidecar_clients
+        if self._started or _active_sidecar_clients is not None:
+            raise RuntimeError("WhatsApp sidecar clients are already started")
+        if self._uses_shared_service and self._shared_service is None:
+            self._shared_service = WhatsAppBaileysSidecarService(self._service_config())
+        self._started = True
+        _active_sidecar_clients = self
+
+    async def stop(self) -> None:
+        global _active_sidecar_clients
+        if _active_sidecar_clients is self:
+            _active_sidecar_clients = None
+        self._started = False
+        clients = tuple(self._clients_by_session.values())
+        self._clients_by_session.clear()
+        if self._service_client is not None:
+            clients = (*clients, self._service_client)
+            self._service_client = None
+        if clients:
+            await asyncio.gather(*(client.aclose() for client in clients), return_exceptions=True)
+        if self._shared_service is not None:
+            await self._shared_service.aclose()
+            self._shared_service = None
+
+    async def service_ready(self) -> bool:
+        if not self._started or not self.enabled:
+            return False
+        if self._shared_service is not None:
+            try:
+                return await self._shared_service.service_ready()
+            except WhatsAppSidecarError:
+                return False
+        if self._service_client is None:
+            self._service_client = self._client_factory(self._service_config())
+        try:
+            return await self._service_client.service_ready()
+        except WhatsAppSidecarError:
+            return False
+
+    def session_client(self, session_id: UUID) -> WhatsAppSidecarClient | None:
+        return self._client(session_id)
+
+    def session_revision(self, session_id: UUID) -> str | None:
+        config = self._session_config(session_id)
+        return config.binding_revision if config is not None else None
+
+    def _client(self, session_id: UUID) -> WhatsAppSidecarClient | None:
+        if not self._started or not self.enabled:
+            return None
+        client = self._clients_by_session.get(session_id)
+        if client is None:
+            config = self._session_config(session_id)
+            if config is None:
+                return None
+            client = (
+                self._shared_service.session_client(session_id)
+                if self._shared_service is not None
+                else self._client_factory(config)
+            )
+            self._clients_by_session[session_id] = client
+        return client
+
+    def _session_config(self, session_id: UUID) -> WhatsAppBaileysSidecarConfig | None:
+        if not self.enabled:
+            return None
+        return WhatsAppBaileysSidecarConfig(
+            api_token=self._api_token,
+            base_url=self._base_url,
+            unix_socket_path=self._unix_socket_path,
+            timeout_seconds=self._timeout_seconds,
+            account_id=session_id,
+        )
+
+    def _service_config(self) -> WhatsAppBaileysSidecarConfig:
+        return WhatsAppBaileysSidecarConfig(
+            api_token=self._api_token,
+            base_url=self._base_url,
+            unix_socket_path=self._unix_socket_path,
+            timeout_seconds=self._timeout_seconds,
+        )
+
+
+class ConfiguredWhatsAppSidecarRegistry(ConfiguredWhatsAppSidecarClientPool):
+    """Own provider ingress and account bindings in the channel worker."""
+
+    def __init__(
+        self,
+        api_token: str,
+        *,
+        base_url: str | None = None,
+        unix_socket_path: str = DEFAULT_WHATSAPP_SIDECAR_SOCKET_PATH,
+        timeout_seconds: float = 10.0,
+        client_factory: SidecarClientFactory | None = None,
+    ) -> None:
+        super().__init__(
+            api_token,
+            base_url=base_url,
+            unix_socket_path=unix_socket_path,
+            timeout_seconds=timeout_seconds,
+            client_factory=client_factory,
+        )
+        self._bound_managed_accounts: set[UUID] = set()
+        self._managed_attach_failures: dict[UUID, str] = {}
+        self._custom_session_to_account: dict[UUID, UUID] = {}
+        self._custom_account_to_session: dict[UUID, UUID] = {}
+        self._blocked_custom_sessions: set[UUID] = set()
+        self._ingress_tasks: dict[UUID, asyncio.Task[None]] = {}
+        self._custom_reconcile_lock = asyncio.Lock()
 
     @property
     def managed_account_ids(self) -> tuple[UUID, ...]:
@@ -211,20 +320,7 @@ class ConfiguredWhatsAppSidecarRegistry:
     def custom_account_for_session(self, session_id: UUID) -> UUID | None:
         return self._custom_session_to_account.get(session_id)
 
-    async def start(self) -> None:
-        global _active_registry
-        if self._started or _active_registry is not None:
-            raise RuntimeError("WhatsApp sidecar registry is already started")
-        if self._uses_shared_service and self._shared_service is None:
-            self._shared_service = WhatsAppBaileysSidecarService(self._service_config())
-        self._started = True
-        _active_registry = self
-
     async def stop(self) -> None:
-        global _active_registry
-        if _active_registry is self:
-            _active_registry = None
-        self._started = False
         tasks = tuple(self._ingress_tasks.values())
         self._ingress_tasks.clear()
         for task in tasks:
@@ -238,31 +334,7 @@ class ConfiguredWhatsAppSidecarRegistry:
         self._custom_session_to_account.clear()
         self._custom_account_to_session.clear()
         self._blocked_custom_sessions.clear()
-        clients = tuple(self._clients_by_session.values())
-        self._clients_by_session.clear()
-        if self._service_client is not None:
-            clients = (*clients, self._service_client)
-            self._service_client = None
-        if clients:
-            await asyncio.gather(*(client.aclose() for client in clients), return_exceptions=True)
-        if self._shared_service is not None:
-            await self._shared_service.aclose()
-            self._shared_service = None
-
-    async def service_ready(self) -> bool:
-        if not self._started or not self.enabled:
-            return False
-        if self._shared_service is not None:
-            try:
-                return await self._shared_service.service_ready()
-            except WhatsAppSidecarError:
-                return False
-        if self._service_client is None:
-            self._service_client = self._client_factory(self._service_config())
-        try:
-            return await self._service_client.service_ready()
-        except WhatsAppSidecarError:
-            return False
+        await super().stop()
 
     async def bind_managed_account(self, account_id: UUID, *, config_revision: str) -> bool:
         client = self._client(account_id)
@@ -445,33 +517,15 @@ class ConfiguredWhatsAppSidecarRegistry:
         self._custom_account_to_session.pop(account_id, None)
         return True
 
-    async def reconcile_custom_ownership(self) -> None:
+    async def reconcile_custom_ownership(self, db: AsyncSession | None = None) -> None:
         if not self.enabled:
             return
         async with self._custom_reconcile_lock:
-            async with async_session_factory() as db:
-                accounts = list(
-                    (
-                        await db.scalars(
-                            select(ChannelAccount).where(
-                                ChannelAccount.provider == CHANNEL_PROVIDER_WHATSAPP,
-                                ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
-                                ChannelAccount.archived_at.is_(None),
-                            )
-                        )
-                    ).all()
-                )
-                sessions = list(
-                    (
-                        await db.scalars(
-                            select(ChannelWhatsAppOnboardingSession).where(
-                                ChannelWhatsAppOnboardingSession.ownership_kind
-                                == WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
-                                ChannelWhatsAppOnboardingSession.state.in_(_UNRELEASED_STATES),
-                            )
-                        )
-                    ).all()
-                )
+            if db is None:
+                async with async_session_factory() as owned_db:
+                    accounts, sessions = await self._custom_ownership_rows(owned_db)
+            else:
+                accounts, sessions = await self._custom_ownership_rows(db)
 
             owners: dict[UUID, tuple[UUID, str]] = {}
             invalid_sessions: set[UUID] = set()
@@ -557,6 +611,34 @@ class ConfiguredWhatsAppSidecarRegistry:
                         await self._block_custom_session_unlocked(session_id, current_account)
                     else:
                         self._blocked_custom_sessions.discard(session_id)
+
+    async def _custom_ownership_rows(
+        self,
+        db: AsyncSession,
+    ) -> tuple[list[ChannelAccount], list[ChannelWhatsAppOnboardingSession]]:
+        accounts = list(
+            (
+                await db.scalars(
+                    select(ChannelAccount).where(
+                        ChannelAccount.provider == CHANNEL_PROVIDER_WHATSAPP,
+                        ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+                        ChannelAccount.archived_at.is_(None),
+                    )
+                )
+            ).all()
+        )
+        sessions = list(
+            (
+                await db.scalars(
+                    select(ChannelWhatsAppOnboardingSession).where(
+                        ChannelWhatsAppOnboardingSession.ownership_kind
+                        == WHATSAPP_ONBOARDING_OWNERSHIP_CUSTOM,
+                        ChannelWhatsAppOnboardingSession.state.in_(_UNRELEASED_STATES),
+                    )
+                )
+            ).all()
+        )
+        return accounts, sessions
 
     async def _block_custom_session_unlocked(
         self,
@@ -669,41 +751,11 @@ class ConfiguredWhatsAppSidecarRegistry:
                     _PROVIDER_INGRESS_RETRY_MAX_SECONDS,
                 )
 
-    def _client(self, session_id: UUID) -> WhatsAppSidecarClient | None:
-        if not self._started or not self.enabled:
-            return None
-        client = self._clients_by_session.get(session_id)
-        if client is None:
-            config = self._session_config(session_id)
-            if config is None:
-                return None
-            client = (
-                self._shared_service.session_client(session_id)
-                if self._shared_service is not None
-                else self._client_factory(config)
-            )
-            self._clients_by_session[session_id] = client
-        return client
 
-    def _session_config(self, session_id: UUID) -> WhatsAppBaileysSidecarConfig | None:
-        if not self.enabled:
-            return None
-        return WhatsAppBaileysSidecarConfig(
-            api_token=self._api_token,
-            base_url=self._base_url,
-            unix_socket_path=self._unix_socket_path,
-            timeout_seconds=self._timeout_seconds,
-            account_id=session_id,
-        )
-
-    def _service_config(self) -> WhatsAppBaileysSidecarConfig:
-        return WhatsAppBaileysSidecarConfig(
-            api_token=self._api_token,
-            base_url=self._base_url,
-            unix_socket_path=self._unix_socket_path,
-            timeout_seconds=self._timeout_seconds,
-        )
+def get_active_whatsapp_sidecar_clients() -> ConfiguredWhatsAppSidecarClientPool | None:
+    return _active_sidecar_clients
 
 
 def get_active_whatsapp_sidecar_registry() -> ConfiguredWhatsAppSidecarRegistry | None:
-    return _active_registry
+    active = _active_sidecar_clients
+    return active if isinstance(active, ConfiguredWhatsAppSidecarRegistry) else None

--- a/backend/app/workers/channels.py
+++ b/backend/app/workers/channels.py
@@ -7,6 +7,7 @@ import signal
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
+from app.core.config import settings
 from app.core.database import async_session_factory, engine
 from app.core.logging_config import configure_application_logging
 from app.services.ai_provider_oauth_revoke_worker import AiProviderOAuthRevokeWorker
@@ -18,9 +19,15 @@ from app.services.discord_command_reconciliation_worker import (
 )
 from app.services.discord_gateway_worker import DiscordGatewayWorker
 from app.services.metrics import metrics_content_type, render_metrics
+from app.services.plugin_catalog import PluginCatalogSyncWorker
 from app.services.principal_lifecycle_cleanup_worker import PrincipalLifecycleCleanupWorker
 from app.services.runtime_observation_retention_worker import RuntimeObservationRetentionWorker
 from app.services.sync_events import start_postgres_listener, stop_postgres_listener
+from app.services.whatsapp_device_onboarding import expire_stale_whatsapp_onboarding_sessions
+from app.services.whatsapp_managed_onboarding import (
+    expire_stale_platform_whatsapp_pairing_sessions,
+)
+from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarRegistry
 
 configure_application_logging()
 log = logging.getLogger(__name__)
@@ -163,14 +170,63 @@ async def run_channel_workers(
     stop: asyncio.Event,
     health: ChannelWorkerHealth | None = None,
 ) -> None:
+    whatsapp_sidecars = ConfiguredWhatsAppSidecarRegistry(
+        settings.channel_whatsapp_baileys_sidecar_token.get_secret_value(),
+        base_url=settings.channel_whatsapp_baileys_sidecar_url or None,
+    )
     await start_postgres_listener()
     try:
+        await whatsapp_sidecars.start()
+        if whatsapp_sidecars.enabled:
+            await whatsapp_sidecars.reconcile_custom_ownership()
+            await whatsapp_sidecars.reconcile_managed_ownership()
         workers = build_channel_workers()
         if health is not None:
             health.ready = True
-        await asyncio.gather(*(worker.run_forever(stop) for worker in workers))
+        async with asyncio.TaskGroup() as tasks:
+            for worker in workers:
+                tasks.create_task(worker.run_forever(stop))
+            if settings.plugin_catalog_sync_enabled:
+                catalog_worker = PluginCatalogSyncWorker(
+                    async_session_factory,
+                    interval_seconds=settings.plugin_catalog_sync_interval_seconds,
+                    timeout_seconds=settings.plugin_catalog_sync_timeout_seconds,
+                )
+                tasks.create_task(catalog_worker.run_forever(stop))
+            if whatsapp_sidecars.enabled:
+                tasks.create_task(_run_whatsapp_ownership(stop, whatsapp_sidecars))
     finally:
-        await stop_postgres_listener()
+        try:
+            await whatsapp_sidecars.stop()
+        finally:
+            await stop_postgres_listener()
+
+
+async def _run_whatsapp_ownership(
+    stop: asyncio.Event,
+    registry: ConfiguredWhatsAppSidecarRegistry,
+) -> None:
+    while not stop.is_set():
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=15)
+            return
+        except TimeoutError:
+            pass
+        try:
+            await registry.reconcile_custom_ownership()
+            await registry.reconcile_managed_ownership()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("WhatsApp sidecar ownership reconciliation failed")
+        try:
+            async with async_session_factory() as db:
+                await expire_stale_whatsapp_onboarding_sessions(db, registry=registry)
+                await expire_stale_platform_whatsapp_pairing_sessions(db, registry=registry)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("WhatsApp onboarding expiry sweep failed")
 
 
 async def main() -> None:

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -3956,7 +3956,7 @@ async def test_admin_platform_whatsapp_qr_promotes_only_after_connected_and_logo
         client_factory=lambda _config: fake,
     )
     await registry.start()
-    monkeypatch.setattr(admin_routes, "get_active_whatsapp_sidecar_registry", lambda: registry)
+    monkeypatch.setattr(admin_routes, "get_active_whatsapp_sidecar_clients", lambda: registry)
     payload = {
         "account_id": str(account_id),
         "request_id": str(uuid.uuid4()),
@@ -3998,7 +3998,7 @@ async def test_admin_platform_whatsapp_qr_promotes_only_after_connected_and_logo
         await registry.start()
         await registry.reconcile_managed_ownership(db_session)
         assert registry.managed_is_bound(account_id)
-        monkeypatch.setattr(admin_routes, "get_active_whatsapp_sidecar_registry", lambda: registry)
+        monkeypatch.setattr(admin_routes, "get_active_whatsapp_sidecar_clients", lambda: registry)
         db_session.add(
             ChannelBotAgentLink(
                 account_id=account.id,
@@ -4043,7 +4043,7 @@ async def test_admin_platform_whatsapp_errors_are_authenticated_configured_only_
 ):
     import app.routes.admin as admin_routes
 
-    monkeypatch.setattr(admin_routes, "get_active_whatsapp_sidecar_registry", lambda: None)
+    monkeypatch.setattr(admin_routes, "get_active_whatsapp_sidecar_clients", lambda: None)
     payload = {
         "account_id": str(uuid.uuid4()),
         "request_id": str(uuid.uuid4()),
@@ -4075,7 +4075,7 @@ async def test_admin_platform_whatsapp_cancel_success_is_no_store(admin_client, 
         client_factory=lambda _config: fake,
     )
     await registry.start()
-    monkeypatch.setattr(admin_routes, "get_active_whatsapp_sidecar_registry", lambda: registry)
+    monkeypatch.setattr(admin_routes, "get_active_whatsapp_sidecar_clients", lambda: registry)
     pairing_url = "/v1/admin/channels/whatsapp/pairing-sessions"
     try:
         started = await admin_client.post(

--- a/backend/tests/test_channel_workers.py
+++ b/backend/tests/test_channel_workers.py
@@ -46,14 +46,40 @@ def test_channel_worker_stack_runs_revoke_delivery_webhook_gateway_and_retention
 
 
 @pytest.mark.asyncio
-async def test_channel_worker_process_owns_postgres_listener(monkeypatch):
+async def test_channel_worker_process_owns_singleton_services(monkeypatch):
     import app.workers.channels as channel_workers
 
     calls: list[str] = []
+    health = ChannelWorkerHealth()
 
     class Worker:
         async def run_forever(self, _stop):
             calls.append("worker")
+
+    class Sidecars:
+        enabled = True
+
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def start(self):
+            calls.append("sidecars-start")
+
+        async def reconcile_custom_ownership(self):
+            calls.append("custom-reconcile")
+
+        async def reconcile_managed_ownership(self):
+            calls.append("managed-reconcile")
+
+        async def stop(self):
+            calls.append("sidecars-stop")
+
+    class CatalogWorker:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def run_forever(self, _stop):
+            calls.append("catalog")
 
     async def start_listener():
         calls.append("start-listener")
@@ -61,13 +87,28 @@ async def test_channel_worker_process_owns_postgres_listener(monkeypatch):
     async def stop_listener():
         calls.append("stop-listener")
 
+    async def run_ownership(_stop, _registry):
+        calls.append("ownership")
+
     monkeypatch.setattr(channel_workers, "start_postgres_listener", start_listener)
     monkeypatch.setattr(channel_workers, "stop_postgres_listener", stop_listener)
     monkeypatch.setattr(channel_workers, "build_channel_workers", lambda: (Worker(),))
+    monkeypatch.setattr(channel_workers, "ConfiguredWhatsAppSidecarRegistry", Sidecars)
+    monkeypatch.setattr(channel_workers, "PluginCatalogSyncWorker", CatalogWorker)
+    monkeypatch.setattr(channel_workers, "_run_whatsapp_ownership", run_ownership)
+    monkeypatch.setattr(settings, "plugin_catalog_sync_enabled", True)
 
-    await run_channel_workers(asyncio.Event())
+    await run_channel_workers(asyncio.Event(), health)
 
-    assert calls == ["start-listener", "worker", "stop-listener"]
+    assert calls[:4] == [
+        "start-listener",
+        "sidecars-start",
+        "custom-reconcile",
+        "managed-reconcile",
+    ]
+    assert set(calls[4:7]) == {"worker", "catalog", "ownership"}
+    assert calls[-2:] == ["sidecars-stop", "stop-listener"]
+    assert health.ready is True
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -12367,24 +12367,11 @@ class _WhatsAppPairLinkRegistry:
     def managed_is_bound(self, account_id: UUID) -> bool:
         return self._bound and account_id == self._account_id
 
-    def managed_account_revision(self, account_id: UUID) -> str | None:
-        return self._revision if account_id == self._account_id else None
-
-    def get_managed_client(self, account_id: UUID) -> _WhatsAppPairLinkSidecar | None:
-        return self._client if account_id == self._account_id else None
-
-    def custom_session_revision(self, session_id: UUID) -> str | None:
+    def session_revision(self, session_id: UUID) -> str | None:
         return self._revision if session_id == self._account_id else None
 
-    def get_custom_lifecycle_client(
-        self,
-        session_id: UUID,
-        *,
-        config_revision: str,
-    ) -> _WhatsAppPairLinkSidecar | None:
-        if session_id != self._account_id or config_revision != self._revision:
-            return None
-        return self._client
+    def session_client(self, session_id: UUID) -> _WhatsAppPairLinkSidecar | None:
+        return self._client if session_id == self._account_id else None
 
 
 async def _create_whatsapp_pair_target(
@@ -12432,7 +12419,7 @@ async def test_whatsapp_pair_code_returns_click_to_chat_for_bound_public_managed
         )
     )
     registry = _WhatsAppPairLinkRegistry(account_id=account.id, client=sidecar)
-    monkeypatch.setattr(public_router, "get_active_whatsapp_sidecar_registry", lambda: registry)
+    monkeypatch.setattr(public_router, "get_active_whatsapp_sidecar_clients", lambda: registry)
 
     response = await client.post(
         f"/v1/channels/{account.id}/pair-codes",
@@ -12469,7 +12456,7 @@ async def test_whatsapp_pair_code_uses_durable_phone_when_sidecar_is_unavailable
     await db_session.commit()
     sidecar = _WhatsAppPairLinkSidecar(WhatsAppSidecarUnavailableError("unavailable"))
     registry = _WhatsAppPairLinkRegistry(account_id=account.id, client=sidecar)
-    monkeypatch.setattr(public_router, "get_active_whatsapp_sidecar_registry", lambda: registry)
+    monkeypatch.setattr(public_router, "get_active_whatsapp_sidecar_clients", lambda: registry)
 
     response = await client.post(
         f"/v1/channels/{account.id}/pair-codes",
@@ -12511,7 +12498,7 @@ async def test_whatsapp_pair_code_never_links_to_a_private_custom_identity(
         )
     )
     registry = _WhatsAppPairLinkRegistry(account_id=account.id, client=sidecar)
-    monkeypatch.setattr(public_router, "get_active_whatsapp_sidecar_registry", lambda: registry)
+    monkeypatch.setattr(public_router, "get_active_whatsapp_sidecar_clients", lambda: registry)
 
     response = await client.post(
         f"/v1/channels/{account.id}/pair-codes",

--- a/backend/tests/test_whatsapp_custom_onboarding.py
+++ b/backend/tests/test_whatsapp_custom_onboarding.py
@@ -374,6 +374,10 @@ async def test_qr_lifecycle_is_idempotent_and_finishes_only_after_connection(
     }
     assert account.encrypted_provider_token is None
     assert account.provider_token_nonce is None
+    assert get_whatsapp_provider_transport(channel_account_id) is None
+    registry = get_active_whatsapp_sidecar_registry()
+    assert registry is not None
+    await registry.reconcile_custom_ownership(db_session)
     assert get_whatsapp_provider_transport(channel_account_id) is not None
     assert whatsapp_provider_transport_status(channel_account_id).available is True
     relayed_message_id, relay_details = await relay_whatsapp_provider_payload(
@@ -804,6 +808,7 @@ async def test_restart_fails_closed_on_durable_session_revision_drift(
 @pytest.mark.asyncio
 async def test_connected_ingress_pump_uses_the_durable_channel_account_id(
     client: httpx.AsyncClient,
+    db_session: AsyncSession,
     custom_sidecar: tuple[UUID, FakeCustomSidecar],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -844,6 +849,9 @@ async def test_connected_ingress_pump_uses_the_durable_channel_account_id(
 
     connected = await client.get(f"/v1/channels/whatsapp/onboarding/sessions/{session_id}")
     durable_account_id = UUID(connected.json()["channel_account_id"])
+    registry = get_active_whatsapp_sidecar_registry()
+    assert registry is not None
+    await registry.reconcile_custom_ownership(db_session)
     await asyncio.wait_for(persisted.wait(), timeout=2)
     await asyncio.wait_for(fake.provider_acknowledged.wait(), timeout=2)
 
@@ -1103,6 +1111,10 @@ async def test_failed_physical_logout_never_archives_or_unregisters_transport(
     fake.current = WhatsAppSidecarPairingStatus(status="connected", registered=True)
     connected = await client.get(f"/v1/channels/whatsapp/onboarding/sessions/{session_id}")
     account_id = UUID(connected.json()["channel_account_id"])
+    registry = get_active_whatsapp_sidecar_registry()
+    assert registry is not None
+    await registry.reconcile_custom_ownership(db_session)
+    assert registry.custom_binding(account_id) == provider_session_id
     fake.logout_result = WhatsAppSidecarPairingStatus(
         status="connected",
         registered=True,
@@ -1114,14 +1126,12 @@ async def test_failed_physical_logout_never_archives_or_unregisters_transport(
     account = await db_session.get(ChannelAccount, account_id)
     assert account is not None
     assert account.archived_at is None
-    registry = get_active_whatsapp_sidecar_registry()
-    assert registry is not None
     assert registry.custom_binding(account_id) == provider_session_id
     assert get_whatsapp_provider_transport(account_id) is not None
 
     fake.current = WhatsAppSidecarPairingStatus(status="disconnected", registered=True)
     fake.last_disconnect_reason = "remote_logged_out"
-    await registry.reconcile_custom_ownership()
+    await registry.reconcile_custom_ownership(db_session)
     assert registry.custom_session_is_blocked(provider_session_id) is True
 
     deleted = await client.delete(f"/v1/channels/{account_id}")

--- a/backend/tests/test_whatsapp_managed_onboarding.py
+++ b/backend/tests/test_whatsapp_managed_onboarding.py
@@ -219,6 +219,7 @@ async def test_multiple_shared_accounts_use_distinct_sessions_on_one_service(
             session_id=second.id,
             registry=registry,
         )
+        await registry.reconcile_managed_ownership(db_session)
 
         assert registry.managed_is_bound(first_id)
         assert registry.managed_is_bound(second_id)
@@ -293,6 +294,7 @@ async def test_existing_shared_account_reauth_preserves_inventory_and_history(
         )
         assert connected.state == "connected"
         assert await db_session.get(ChannelAccount, account_id) is account
+        await registry.reconcile_managed_ownership(db_session)
         assert registry.managed_is_bound(account_id)
         await db_session.refresh(account)
         assert account.config["phone_number"] == "15551234567"
@@ -345,9 +347,7 @@ async def test_explicit_reauth_recovers_retained_remote_logout(db_session) -> No
 
 
 @pytest.mark.asyncio
-async def test_bind_failure_rolls_back_promotion_and_marks_reservation_error(
-    db_session, monkeypatch
-):
+async def test_bind_failure_does_not_rollback_durable_promotion(db_session, monkeypatch):
     account_id = uuid4()
     fake = FakeManagedSidecar()
     registry = _registry(account_id, fake)
@@ -360,16 +360,17 @@ async def test_bind_failure_rolls_back_promotion_and_marks_reservation_error(
             raise WhatsAppSidecarProtocolError("injected bind failure")
 
         monkeypatch.setattr(registry, "bind_managed_account", fail_bind)
-        with pytest.raises(HTTPException) as exc_info:
-            await get_platform_whatsapp_pairing(
-                db_session, session_id=started.id, registry=registry
-            )
-        assert exc_info.value.status_code == 503
-        assert await db_session.get(ChannelAccount, account_id) is None
+        connected = await get_platform_whatsapp_pairing(
+            db_session, session_id=started.id, registry=registry
+        )
+        await registry.reconcile_managed_ownership(db_session)
+
+        assert connected.state == "connected"
+        assert await db_session.get(ChannelAccount, account_id) is not None
         session = await db_session.get(ChannelWhatsAppOnboardingSession, started.id)
         assert session is not None
-        assert session.state == "error"
-        assert session.channel_account_id is None
+        assert session.state == "connected"
+        assert session.channel_account_id == account_id
         assert not registry.managed_is_bound(account_id)
     finally:
         await registry.stop()

--- a/backend/tests/test_whatsapp_noise.py
+++ b/backend/tests/test_whatsapp_noise.py
@@ -1579,17 +1579,15 @@ async def test_whatsapp_baileys_websocket_records_noise_runtime_debug_events(
             )
 
     class AuthenticatedSidecarRegistry:
-        def custom_session_revision(self, session_id: UUID) -> str | None:
+        def session_revision(self, session_id: UUID) -> str | None:
             return sidecar_revision if session_id == sidecar_session_id else None
 
-        def get_custom_lifecycle_client(self, session_id: UUID, *, config_revision: str):
-            if session_id == sidecar_session_id and config_revision == sidecar_revision:
-                return AuthenticatedSidecar()
-            return None
+        def session_client(self, session_id: UUID):
+            return AuthenticatedSidecar() if session_id == sidecar_session_id else None
 
     monkeypatch.setattr(
         whatsapp_router_module,
-        "get_active_whatsapp_sidecar_registry",
+        "get_active_whatsapp_sidecar_clients",
         lambda: AuthenticatedSidecarRegistry(),
     )
     binding = ChannelBinding(

--- a/backend/tests/test_whatsapp_sidecar_registry.py
+++ b/backend/tests/test_whatsapp_sidecar_registry.py
@@ -19,7 +19,10 @@ from app.services.whatsapp_provider_bridge import (
     whatsapp_provider_transport_status,
 )
 from app.services.whatsapp_sidecar_registry import (
+    ConfiguredWhatsAppSidecarClientPool,
     ConfiguredWhatsAppSidecarRegistry,
+    get_active_whatsapp_sidecar_clients,
+    get_active_whatsapp_sidecar_registry,
 )
 
 
@@ -52,6 +55,23 @@ class _FakeSidecarClient:
 
     async def query(self, node, timeout_ms):
         raise AssertionError((node, timeout_ms))
+
+
+@pytest.mark.asyncio
+async def test_client_pool_exposes_sidecar_sessions_without_transport_ownership():
+    session_id = UUID("00000000-0000-4000-8000-000000000887")
+    pool = ConfiguredWhatsAppSidecarClientPool(
+        "secret",
+        client_factory=_FakeSidecarClient,
+    )
+    await pool.start()
+    try:
+        assert get_active_whatsapp_sidecar_clients() is pool
+        assert get_active_whatsapp_sidecar_registry() is None
+        assert pool.session_client(session_id) is not None
+        assert whatsapp_provider_transport_status(session_id).available is False
+    finally:
+        await pool.stop()
 
 
 @pytest.mark.asyncio

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -50,10 +50,16 @@ servers:
     hosts:
       - <%= ENV.fetch("DEPLOY_HOST") %>
     options:
-      memory: 4g # embedding model (~1.6G resident) + launch-load headroom
+      memory: 6g # two API workers, each with a local embedding model
       ulimit: nofile=65536:65536 # long-lived SSE/WebSocket connections
       # tini as PID 1 reaps orphaned subprocesses (zombie prevention).
       init: true
+    env:
+      clear:
+        WEB_CONCURRENCY: 2
+        # SQLAlchemy owns one pool per worker; preserve the prior aggregate cap.
+        DB_POOL_SIZE: 10
+        DB_MAX_OVERFLOW: 10
   channels-worker:
     hosts:
       - <%= ENV.fetch("DEPLOY_HOST") %>


### PR DESCRIPTION
## Summary

- make FastAPI workers stateless by moving WhatsApp ingress ownership, onboarding sweeps, and plugin catalog sync into the existing channels worker
- reuse the existing Baileys HTTP service from each API process through a client-only pool
- run two Uvicorn workers while preserving the previous aggregate Web database connection ceiling
- use structured concurrency so a failed channel worker cancels its siblings before shared resources close

## Compatibility

- legacy /api aliases and payload contracts are unchanged
- old CLI clients do not need an update
- durable WhatsApp account promotion commits before worker attachment; provider events remain queued by the sidecar during the reconciliation window

## Verification

- affected backend suite: 590 passed; three stale test doubles updated and rechecked: 3 passed
- focused ownership/promotion suite: 6 passed
- legacy API alias suite: 13 passed
- Ruff lint and format checks passed
- changed-production type gate: 9 files, 0 errors, 0 warnings
- compileall and git diff --check passed

## Operations

- Web: WEB_CONCURRENCY=2, DB_POOL_SIZE=10, DB_MAX_OVERFLOW=10
- aggregate Web pool maximum remains 40 connections
- Web memory limit increases from 4 GiB to 6 GiB because local embeddings remain process-local
- newly promoted WhatsApp sessions may take up to 15 seconds to attach to the channels worker