### PR TITLE
perf(runtime): converge unchanged hosted runtimes in under two seconds

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -352,9 +352,8 @@ candidate has no separate active/previous link state or hand-built chroot.
 `clawdi-files.service` runs as the non-root tenant runtime UID/GID so Files has
 native read/write access to tenant-owned home content, including `0600` files,
 `0700` directories, and dotfiles. The entire tenant home, including user units
-and official runtime configuration, belongs to the tenant UID/GID. Hosted
-convergence recursively migrates legacy root-owned home trees without following
-symlinks. Candidate directories and binaries remain root-owned outside the
+and official runtime configuration, belongs to the tenant UID/GID. Candidate
+directories and binaries remain root-owned outside the
 tenant home. The root-authored JWT
 configuration is a `root:<runtime group>` `0440` file below a root-only `0700`
 directory, so other tenant processes cannot traverse to it; systemd publishes

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -113,6 +113,7 @@ const RUNTIME_WATCH_MAX_BACKOFF_MS = 300_000;
 
 type RuntimeApplyResult =
 	| RuntimeApplyConvergedResult
+	| RuntimeApplyDeferredResult
 	| RuntimeApplyCliHandoffResult
 	| RuntimeApplyCliUpdateFailedResult;
 
@@ -121,6 +122,13 @@ interface RuntimeApplyConvergedResult {
 	convergence: ReturnType<typeof convergeRuntimeManifest>;
 	cliUpdate: RuntimeCliUpdateResult;
 	systemdApply: Omit<ReturnType<typeof applySystemdRuntimeUpdate>, "activated">;
+}
+
+interface RuntimeApplyDeferredResult {
+	kind: "deferred";
+	reason: NonNullable<RuntimeApplyConvergedResult["convergence"]["deferredReason"]>;
+	convergence: RuntimeApplyConvergedResult["convergence"];
+	cliUpdate: RuntimeCliUpdateResult;
 }
 
 interface RuntimeApplyCliHandoffResult {
@@ -196,6 +204,12 @@ type ConvergeOutcome =
 	  >)
 	| { kind: "apply_error"; error: string; load?: RuntimeManifestLoad; etag?: string }
 	| { kind: "cli_update_failed"; load: RuntimeManifestLoad; cliUpdate: RuntimeCliUpdateResult }
+	| {
+			kind: "deferred";
+			load: RuntimeManifestLoad;
+			reason: RuntimeApplyDeferredResult["reason"];
+			convergence: RuntimeApplyDeferredResult["convergence"];
+	  }
 	| {
 			kind: "converged";
 			load: RuntimeManifestLoad;
@@ -774,6 +788,24 @@ async function runtimeInitLocked(
 		});
 		return;
 	}
+	if (outcome.kind === "deferred") {
+		const message = "Hermes config changed during runtime convergence; retry on the next poll";
+		const applied = runtimeAppliedStatus(paths);
+		emitRuntimeInitRepair({
+			opts,
+			paths,
+			stage: "final",
+			bootId,
+			runtimeMode: mode,
+			errors: [message],
+			exitCode: 23,
+			active: applied,
+			rejectedGeneration: outcome.load.manifest.generation,
+			manifestLoad: outcome.load,
+			render: renderRuntimeInit(paths, `repair: ${message}`, chalk.red),
+		});
+		return;
+	}
 	if (outcome.kind === "apply_error" || outcome.kind === "cli_update_failed") {
 		const message =
 			outcome.kind === "apply_error"
@@ -908,6 +940,14 @@ async function convergeOnce(
 	if (applyResult.kind === "cli_update_failed") {
 		return { kind: "cli_update_failed", load: convergenceLoad, cliUpdate: applyResult.cliUpdate };
 	}
+	if (applyResult.kind === "deferred") {
+		return {
+			kind: "deferred",
+			load: convergenceLoad,
+			reason: applyResult.reason,
+			convergence: applyResult.convergence,
+		};
+	}
 
 	const cliUpdateError =
 		applyResult.cliUpdate.status === "error"
@@ -1016,6 +1056,7 @@ function runtimeWatchEventForOutcome(
 	paths: RuntimePaths,
 ): RuntimeWatchEvent | null {
 	if (outcome.kind === "idle") return null;
+	if (outcome.kind === "deferred") return null;
 	if (outcome.kind === "reconciliation_error") {
 		return runtimeWatchError("cli-update", [outcome.error], { selfReexec: false });
 	}
@@ -1328,6 +1369,14 @@ async function applyRuntimeDesiredState(
 				},
 			},
 		});
+		if (convergence.deferredReason) {
+			return {
+				kind: "deferred",
+				reason: convergence.deferredReason,
+				convergence,
+				cliUpdate,
+			};
+		}
 		if (
 			convergence.installErrors.length > 0 &&
 			load.source !== "last-good-cache" &&

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -154,6 +154,7 @@ interface RuntimeApplyOptions {
 	preparedHostedAgentPlugins?: PreparedHostedAgentPlugins | null;
 	hostedAgentPluginCommandRunner?: HostedAgentPluginCommandRunner;
 	hostedRuntimeContract?: HostedRuntimeContractOptions;
+	refreshCachedRuntimeProbes?: boolean;
 }
 
 export type RuntimeManifestApplyOptions = Omit<
@@ -882,6 +883,7 @@ async function runtimeWatchTick(
 			await convergeOnce(() => loadRuntimeManifestForWatch(paths, opts), paths, {
 				continueOnCliUpdateError: true,
 				recoverFailedSystemdUnits: opts.recoverFailedSystemdUnits,
+				refreshCachedRuntimeProbes: opts.forceRefresh,
 				hostedRuntimeContract: opts.hostedRuntimeContract,
 				requireAppliedAuthority: true,
 			}),
@@ -1282,6 +1284,7 @@ async function applyRuntimeDesiredState(
 		const convergence = convergeRuntimeManifest(load, paths, {
 			cacheLastGood: false,
 			hostedRuntimeContract: opts.hostedRuntimeContract,
+			refreshCachedRuntimeProbes: opts.refreshCachedRuntimeProbes,
 			preparedHostedSourcedSkills,
 			...(preparedHostedAgentPlugins ? { preparedHostedAgentPlugins } : {}),
 			...(Object.keys(resourcePreparationFailures).length > 0

--- a/packages/cli/src/runtime/hermes-config.test.ts
+++ b/packages/cli/src/runtime/hermes-config.test.ts
@@ -5,14 +5,18 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
-import { reconcileHermesConfigValue } from "./hermes-config";
+import {
+	beginHermesConfigTransaction,
+	commitHermesConfigTransaction,
+	reconcileHermesConfigValue,
+} from "./hermes-config";
 
 const root = mkdtempSync(join(tmpdir(), "clawdi-hermes-config-test-"));
 const mock = fileURLToPath(new URL("../test-support/hermes-config-cli-mock.ts", import.meta.url));
 
 afterAll(() => rmSync(root, { recursive: true, force: true }));
 
-test("reconciles structured values without relying on Hermes JSON parsing", () => {
+test("merges a round of config patches into one comment-preserving write", () => {
 	const commandLog = join(root, "commands.log");
 	const command = join(root, "hermes");
 	writeFileSync(
@@ -51,13 +55,21 @@ test("reconciles structured values without relying on Hermes JSON parsing", () =
 		cwd: home,
 		environment: { HERMES_HOME: join(home, ".hermes") },
 	};
-	reconcileHermesConfigValue(context, "mcp_servers", {
+	writeFileSync(commandLog, "");
+	const before = readFileSync(configPath, "utf8");
+	const transaction = beginHermesConfigTransaction(context);
+	reconcileHermesConfigValue(transaction, "mcp_servers", {
 		"user.server": { command: "user-owned" },
 		"managed.server.with.dots": { command: "clawdi", args: ["mcp"] },
 	});
-	reconcileHermesConfigValue(context, "plugins.disabled", ["user/plugin", "dashboard_auth/nous"]);
+	reconcileHermesConfigValue(transaction, "plugins.disabled", [
+		"user/plugin",
+		"dashboard_auth/nous",
+	]);
+	reconcileHermesConfigValue(transaction, "plugins.scan_on_install", false);
+	expect(readFileSync(configPath, "utf8")).toBe(before);
+	expect(commitHermesConfigTransaction(transaction)).toBe("committed");
 	expect(readFileSync(configPath, "utf8")).toContain("# operator-owned comment");
-	reconcileHermesConfigValue(context, "plugins.scan_on_install", false);
 
 	const config = parseYaml(readFileSync(configPath, "utf8")) as Record<string, unknown>;
 	expect(config.mcp_servers).toEqual({
@@ -68,16 +80,45 @@ test("reconciles structured values without relying on Hermes JSON parsing", () =
 		disabled: ["user/plugin", "dashboard_auth/nous"],
 		scan_on_install: false,
 	});
-	const commands = readFileSync(commandLog, "utf8");
-	expect(commands).toContain("config set --force contract.probe");
-	expect(commands).toContain("config set --force plugins.scan_on_install false");
-	expect(commands).not.toContain("config set --force mcp_servers");
-	expect(commands).not.toContain("config set --force plugins.disabled");
+	const commands = readFileSync(commandLog, "utf8").trim().split("\n");
+	expect(commands).toEqual(["config path"]);
+	expect(commands.length).toBeLessThanOrEqual(2);
 
 	const scalarParent = "dashboard: user-owned\n";
 	writeFileSync(configPath, scalarParent);
+	const invalid = beginHermesConfigTransaction(context);
 	expect(() =>
-		reconcileHermesConfigValue(context, "dashboard.basic_auth", { username: "admin" }),
+		reconcileHermesConfigValue(invalid, "dashboard.basic_auth", { username: "admin" }),
 	).toThrow("Hermes config field dashboard must be an object");
 	expect(readFileSync(configPath, "utf8")).toBe(scalarParent);
+});
+
+test("defers a conflicting write and replays from the next config snapshot", () => {
+	const command = join(root, "conflict-hermes");
+	const home = join(root, "conflict");
+	const configPath = join(home, ".hermes", "config.yaml");
+	mkdirSync(dirname(configPath), { recursive: true });
+	writeFileSync(
+		command,
+		`#!/bin/sh\nif [ "$*" = "config path" ]; then printf '%s\\n' ${JSON.stringify(configPath)}; fi\n`,
+		{ mode: 0o755 },
+	);
+	writeFileSync(configPath, "# original\nmcp_servers: {}\n");
+	const context = { command, home, cwd: home };
+	const first = beginHermesConfigTransaction(context);
+	reconcileHermesConfigValue(first, "plugins.scan_on_install", false);
+
+	const userUpdate = "# user update\nmcp_servers:\n  user.server:\n    command: user-owned\n";
+	writeFileSync(configPath, userUpdate);
+	expect(commitHermesConfigTransaction(first)).toBe("conflict");
+	expect(readFileSync(configPath, "utf8")).toBe(userUpdate);
+
+	const replay = beginHermesConfigTransaction(context);
+	reconcileHermesConfigValue(replay, "plugins.scan_on_install", false);
+	expect(commitHermesConfigTransaction(replay)).toBe("committed");
+	expect(readFileSync(configPath, "utf8")).toContain("# user update");
+	expect(parseYaml(readFileSync(configPath, "utf8"))).toEqual({
+		mcp_servers: { "user.server": { command: "user-owned" } },
+		plugins: { scan_on_install: false },
+	});
 });

--- a/packages/cli/src/runtime/hermes-config.ts
+++ b/packages/cli/src/runtime/hermes-config.ts
@@ -19,6 +19,16 @@ export interface HermesConfigValue {
 	value?: unknown;
 }
 
+export interface HermesConfigTransaction {
+	readonly context: HermesConfigCommandContext;
+	readonly path: string;
+	readonly sourceContent: string;
+	readonly document: ReturnType<typeof parseDocument>;
+	changed: boolean;
+}
+
+export type HermesConfigCommitResult = "unchanged" | "committed" | "conflict";
+
 function commandText(value: string | Buffer | null | undefined): string {
 	return stripTerminalEscapes(String(value ?? "")).trim();
 }
@@ -77,33 +87,39 @@ function isConfigRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function readHermesConfigContentAtPath(path: string): string {
+	try {
+		return readFileSync(path, "utf8");
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") return "";
+		throw new Error(
+			`Hermes config could not be read: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
+
 function readHermesConfigDocumentAtPath(path: string): {
 	path: string;
+	content: string;
 	document: ReturnType<typeof parseDocument>;
 	root: Record<string, unknown>;
 } {
-	let content = "";
-	try {
-		content = readFileSync(path, "utf8");
-	} catch (error) {
-		if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
-			throw new Error(
-				`Hermes config could not be read: ${error instanceof Error ? error.message : String(error)}`,
-			);
-		}
-	}
+	const content = readHermesConfigContentAtPath(path);
 	const document = parseDocument(content);
 	if (document.errors.length > 0) {
 		throw new Error(`Hermes config is invalid YAML: ${document.errors[0]?.message}`);
 	}
 	const parsed = document.toJS() as unknown;
-	if (parsed === null || parsed === undefined) return { path, document, root: {} };
+	if (parsed === null || parsed === undefined) return { path, content, document, root: {} };
 	if (!isConfigRecord(parsed)) throw new Error("Hermes config must be an object");
-	return { path, document, root: parsed };
+	return { path, content, document, root: parsed };
 }
 
-function readHermesConfigDocument(context: HermesConfigCommandContext) {
-	return readHermesConfigDocumentAtPath(hermesConfigPath(context));
+export function beginHermesConfigTransaction(
+	context: HermesConfigCommandContext,
+): HermesConfigTransaction {
+	const { path, content, document } = readHermesConfigDocumentAtPath(hermesConfigPath(context));
+	return { context, path, sourceContent: content, document, changed: false };
 }
 
 function rawConfigValue(root: Record<string, unknown>, key: string): HermesConfigValue {
@@ -116,10 +132,12 @@ function rawConfigValue(root: Record<string, unknown>, key: string): HermesConfi
 }
 
 export function getHermesRawConfigValue(
-	context: HermesConfigCommandContext,
+	source: HermesConfigCommandContext | HermesConfigTransaction,
 	key: string,
 ): HermesConfigValue {
-	return rawConfigValue(readHermesConfigDocument(context).root, key);
+	if ("document" in source) return rawConfigValue(configDocumentRoot(source.document), key);
+	const transaction = beginHermesConfigTransaction(source);
+	return rawConfigValue(configDocumentRoot(transaction.document), key);
 }
 
 export function getHermesRawConfigFileValue(path: string, key: string): HermesConfigValue {
@@ -139,54 +157,38 @@ function configValueAtPath(
 	return { exists: true, value: current };
 }
 
-function setHermesStructuredConfigValue(
-	context: HermesConfigCommandContext,
+function setHermesConfigValue(
+	transaction: HermesConfigTransaction,
 	key: string,
-	value: object | null,
+	value: unknown,
 ): void {
-	const { path, document, root } = readHermesConfigDocument(context);
 	const keyPath = key.split(".");
 	for (let index = 1; index < keyPath.length; index += 1) {
 		const parentPath = keyPath.slice(0, index);
-		const parent = configValueAtPath(root, parentPath);
+		const parent = configValueAtPath(configDocumentRoot(transaction.document), parentPath);
 		if (!parent.exists) {
-			document.setIn(parentPath, document.createNode({}));
+			transaction.document.setIn(parentPath, transaction.document.createNode({}));
 			continue;
 		}
 		if (!isConfigRecord(parent.value)) {
 			throw new Error(`Hermes config field ${parentPath.join(".")} must be an object`);
 		}
 	}
-	document.setIn(keyPath, document.createNode(value));
-	writePrivateFileAtomic(path, String(document), {
-		mode: PRIVATE_FILE_MODE,
-		dirMode: PRIVATE_DIR_MODE,
-	});
+	transaction.document.setIn(keyPath, transaction.document.createNode(value));
+	transaction.changed = true;
 }
 
-export function setHermesConfigValue(
-	context: HermesConfigCommandContext,
-	key: string,
-	value: unknown,
-): void {
-	// Hermes config set does not reliably coerce structured CLI values across
-	// supported installs, so mappings and arrays use its resolved config path
-	// and an atomic YAML document update instead.
-	if (typeof value === "object") {
-		setHermesStructuredConfigValue(context, key, value);
-		return;
+function unsetHermesConfigValue(transaction: HermesConfigTransaction, key: string): void {
+	const keyPath = key.split(".");
+	transaction.document.deleteIn(keyPath);
+	for (let length = keyPath.length - 1; length > 0; length -= 1) {
+		const parentPath = keyPath.slice(0, length);
+		const parent = configValueAtPath(configDocumentRoot(transaction.document), parentPath);
+		if (!parent.exists || !isConfigRecord(parent.value) || Object.keys(parent.value).length > 0)
+			break;
+		transaction.document.deleteIn(parentPath);
 	}
-	const result = runHermesConfigCommand(context, ["set", "--force", key, String(value)]);
-	if (result.status !== 0 || result.error) {
-		throw commandFailure(`Hermes config set ${key}`, result);
-	}
-}
-
-export function unsetHermesConfigValue(context: HermesConfigCommandContext, key: string): void {
-	const result = runHermesConfigCommand(context, ["unset", key]);
-	if (result.status !== 0 || result.error) {
-		throw commandFailure(`Hermes config unset ${key}`, result);
-	}
+	transaction.changed = true;
 }
 
 function canonicalJsonValue(value: unknown): unknown {
@@ -204,17 +206,48 @@ function configValuesEqual(left: unknown, right: unknown): boolean {
 }
 
 export function reconcileHermesConfigValue(
-	context: HermesConfigCommandContext,
+	source: HermesConfigCommandContext | HermesConfigTransaction,
 	key: string,
 	desired: unknown | undefined,
 ): boolean {
-	const current = getHermesRawConfigValue(context, key);
+	const transaction = "document" in source ? source : beginHermesConfigTransaction(source);
+	const current = rawConfigValue(configDocumentRoot(transaction.document), key);
 	if (desired === undefined) {
 		if (!current.exists) return false;
-		unsetHermesConfigValue(context, key);
+		unsetHermesConfigValue(transaction, key);
+		if (!("document" in source)) commitImmediateHermesConfigTransaction(transaction);
 		return true;
 	}
 	if (current.exists && configValuesEqual(current.value, desired)) return false;
-	setHermesConfigValue(context, key, desired);
+	setHermesConfigValue(transaction, key, desired);
+	if (!("document" in source)) commitImmediateHermesConfigTransaction(transaction);
 	return true;
+}
+
+function commitImmediateHermesConfigTransaction(transaction: HermesConfigTransaction): void {
+	if (commitHermesConfigTransaction(transaction) === "conflict") {
+		throw new Error("Hermes config changed during reconciliation");
+	}
+}
+
+export function commitHermesConfigTransaction(
+	transaction: HermesConfigTransaction,
+): HermesConfigCommitResult {
+	if (!transaction.changed) return "unchanged";
+	if (readHermesConfigContentAtPath(transaction.path) !== transaction.sourceContent) {
+		return "conflict";
+	}
+	writePrivateFileAtomic(transaction.path, String(transaction.document), {
+		mode: PRIVATE_FILE_MODE,
+		dirMode: PRIVATE_DIR_MODE,
+	});
+	transaction.changed = false;
+	return "committed";
+}
+
+function configDocumentRoot(document: ReturnType<typeof parseDocument>): Record<string, unknown> {
+	const parsed = document.toJS() as unknown;
+	if (parsed === null || parsed === undefined) return {};
+	if (!isConfigRecord(parsed)) throw new Error("Hermes config must be an object");
+	return parsed;
 }

--- a/packages/cli/src/runtime/hosted-agent-plugin-package.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-package.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import {
+	cpSync,
 	existsSync,
 	lstatSync,
 	mkdirSync,
@@ -750,6 +751,13 @@ describe("Hosted Agent Plugin package preparation", () => {
 				run(input) {
 					calls.push(input.args);
 					if (input.args[1] === "list") {
+						if (!existsSync(installRoot)) {
+							return {
+								status: 0,
+								stdout: runtime === "hermes" ? "[]" : '{"plugins":[]}',
+								stderr: "",
+							};
+						}
 						if (runtime === "hermes") {
 							return {
 								status: 0,
@@ -808,6 +816,16 @@ describe("Hosted Agent Plugin package preparation", () => {
 							stderr: "",
 						};
 					}
+					if (runtime === "openclaw" && input.args[1] === "install") {
+						const source = input.args[2];
+						if (!source) throw new Error("missing native install source");
+						rmSync(installRoot, { recursive: true, force: true });
+						cpSync(source, installRoot, { recursive: true });
+						return { status: 0, stdout: "", stderr: "" };
+					}
+					if (runtime === "openclaw" && input.args[1] === "enable") {
+						return { status: 0, stdout: "", stderr: "" };
+					}
 					throw new Error(`unexpected native mutation: ${input.args.join(" ")}`);
 				},
 			};
@@ -821,6 +839,57 @@ describe("Hosted Agent Plugin package preparation", () => {
 			expect(transaction?.hasMutations).toBe(false);
 			expect(transaction?.apply()).toEqual(persistedReceipt);
 			expect(calls.every((args) => args[1] === "list" || args[1] === "inspect")).toBe(true);
+			const observedCalls = calls.length;
+			const cached = planHostedAgentPluginConvergence({
+				prepared,
+				home: runtimePaths.userHome,
+				commands: hostedAgentPluginCommands(runtimePaths.userHome),
+				runner,
+			}).transaction;
+			expect(cached?.hasMutations).toBe(false);
+			expect(cached?.apply()).toEqual(persistedReceipt);
+			expect(calls).toHaveLength(observedCalls);
+
+			if (runtime === "openclaw") {
+				rmSync(installRoot, { recursive: true });
+				const stillCached = planHostedAgentPluginConvergence({
+					prepared,
+					home: runtimePaths.userHome,
+					commands: hostedAgentPluginCommands(runtimePaths.userHome),
+					runner,
+				}).transaction;
+				expect(stillCached?.hasMutations).toBe(false);
+				expect(calls).toHaveLength(observedCalls);
+
+				const selfHeal = planHostedAgentPluginConvergence({
+					prepared,
+					home: runtimePaths.userHome,
+					commands: hostedAgentPluginCommands(runtimePaths.userHome),
+					runner,
+					refreshCachedRuntimeProbes: true,
+				}).transaction;
+				expect(selfHeal?.hasMutations).toBe(true);
+				expect(selfHeal?.apply()).toEqual(persistedReceipt);
+				expect(existsSync(join(installRoot, "plugin.json"))).toBe(true);
+			}
+
+			const revisedPlugin = {
+				...plugin,
+				installation: {
+					...plugin.installation,
+					ownershipIdentity: "f".repeat(64),
+				},
+			};
+			planHostedAgentPluginConvergence({
+				prepared: {
+					...prepared,
+					desired: new Map([["acme.tools", revisedPlugin]]),
+				},
+				home: runtimePaths.userHome,
+				commands: hostedAgentPluginCommands(runtimePaths.userHome),
+				runner,
+			});
+			expect(calls.length).toBeGreaterThan(observedCalls);
 		},
 	);
 });

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.test.ts
@@ -24,11 +24,7 @@ import {
 	prepareHostedAgentPluginTransaction,
 } from "./hosted-agent-plugin-runtime";
 import { AGENT_PLUGINS_SCHEMA_1_0_0 } from "./manifest-resources";
-import {
-	ensureRuntimeUserHomeOwnership,
-	runtimeUserGid,
-	runtimeUserUid,
-} from "./runtime-user-command";
+import { runtimeUserGid, runtimeUserUid } from "./runtime-user-command";
 
 type CommandInput = Parameters<HostedAgentPluginCommandRunner["run"]>[0];
 
@@ -410,7 +406,7 @@ function desiredState(
 const commands = { openclaw: "/runtime/openclaw", hermes: "/runtime/hermes" };
 
 describe("Hosted Agent Plugin native reconciliation", () => {
-	test("observes installed plugin bytes only through the repaired runtime-user identity", () => {
+	test("observes tenant-owned plugin bytes through the runtime-user identity", () => {
 		if (process.geteuid?.() !== 0) return;
 		const runner = new FakeNativeRunner();
 		const desired = plugin("acme.tools", "1.2.3", "8".repeat(64));
@@ -439,28 +435,13 @@ describe("Hosted Agent Plugin native reconciliation", () => {
 		const previousRuntimeGid = process.env.CLAWDI_RUNTIME_GID;
 		try {
 			chmodSync(runtimeTestRoot, 0o755);
-			for (const path of [runner.liveHome, stateRoot, join(stateRoot, "extensions")]) {
+			for (const path of [runner.liveHome, stateRoot, join(stateRoot, "extensions"), installRoot]) {
 				chownSync(path, runtimeUid, runtimeGid);
 			}
-			chownSync(installRoot, 0, 0);
-			chmodSync(installRoot, 0o700);
 			process.env.CLAWDI_RUNTIME_USER = "nobody";
 			process.env.CLAWDI_RUNTIME_UID = String(runtimeUid);
 			process.env.CLAWDI_RUNTIME_GID = String(runtimeGid);
 
-			expect(() =>
-				prepareHostedAgentPluginTransaction({
-					prepared,
-					home: runner.liveHome,
-					commands,
-					runner,
-				}),
-			).toThrow();
-
-			ensureRuntimeUserHomeOwnership(stateRoot, {
-				uid: runtimeUserUid("nobody"),
-				gid: runtimeUserGid("nobody"),
-			});
 			expect(() =>
 				prepareHostedAgentPluginTransaction({
 					prepared,

--- a/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
+++ b/packages/cli/src/runtime/hosted-agent-plugin-runtime.ts
@@ -12,14 +12,20 @@ import {
 	type PreparedHostedAgentPlugins,
 	withPreparedAgentPluginDirectory,
 } from "./hosted-agent-plugin-package";
+import { runtimeFileCurrentRevision } from "./manifest-install";
 import {
 	openClawAgentPluginInspectSchema,
 	openClawPluginListSchema,
 } from "./openclaw-plugin-observation";
+import { runtimeImpactRevision } from "./runtime-impact-revision";
 import { spawnRuntimeUserCommand, withRuntimeUserFileAccess } from "./runtime-user-command";
 
 const COMMAND_TIMEOUT_MS = 120_000;
 const COMMAND_MAX_BUFFER_BYTES = 1024 * 1024;
+const stableAgentPluginRevisions = new Map<
+	string,
+	{ revision: string; receipt: HostedAgentPluginReceipt | null }
+>();
 const isolatedGitEnvironment: Readonly<Record<string, string | undefined>> = {
 	GIT_ALTERNATE_OBJECT_DIRECTORIES: undefined,
 	GIT_ATTR_NOSYSTEM: "1",
@@ -620,7 +626,39 @@ export function prepareHostedAgentPluginTransaction(input: {
 	home: string;
 	commands: HostedAgentPluginCommands;
 	runner?: HostedAgentPluginCommandRunner;
+	refreshCachedRuntimeProbes?: boolean;
 }): HostedAgentPluginTransaction {
+	const revision = runtimeImpactRevision({
+		runtime: input.prepared.runtime,
+		desired: [...input.prepared.desired]
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(([name, plugin]) => ({
+				name,
+				ownershipIdentity: plugin.installation.ownershipIdentity,
+			})),
+		previous: [...input.prepared.previous]
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(([name, plugin]) => ({
+				name,
+				runtime: plugin.runtime,
+				nativeId: plugin.nativeId,
+				ownershipIdentity: plugin.installation.ownershipIdentity,
+			})),
+		commands: Object.fromEntries(
+			Object.entries(input.commands).map(([runtime, command]) => [
+				runtime,
+				runtimeFileCurrentRevision(command),
+			]),
+		),
+	});
+	const cached = stableAgentPluginRevisions.get(input.home);
+	if (!input.refreshCachedRuntimeProbes && cached?.revision === revision) {
+		return {
+			mutationNames: [],
+			hasMutations: false,
+			apply: () => cached.receipt,
+		};
+	}
 	const runner = input.runner ?? defaultCommandRunner;
 	const drivers = new Map<HostedAgentPluginRuntime, NativeAgentPluginDriver>();
 	const driverFor = (runtime: HostedAgentPluginRuntime): NativeAgentPluginDriver => {
@@ -706,6 +744,12 @@ export function prepareHostedAgentPluginTransaction(input: {
 			driver,
 			before,
 			action: before ? "replace" : "install",
+		});
+	}
+	if (mutations.length === 0) {
+		stableAgentPluginRevisions.set(input.home, {
+			revision,
+			receipt: desiredReceipt(input.prepared, resolvedNativeIds),
 		});
 	}
 	return {

--- a/packages/cli/src/runtime/hosted-openclaw-context.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-context.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
 import {
 	CLAWDI_MANAGED_PROVIDER_ID,
@@ -14,6 +15,8 @@ import {
 } from "../lib/codex-oauth-native-store";
 import { agentTargetProjectionInput, hostedAiProviderCatalog } from "./hosted-provider-resolution";
 import type { RuntimeManifest } from "./manifest-contract";
+import { runtimeFileCurrentRevision } from "./manifest-install";
+import { runtimeImpactRevision } from "./runtime-impact-revision";
 import { executableExists, spawnRuntimeUserCommand } from "./runtime-user-command";
 import { parseSystemctlShow, systemctlPath } from "./systemd";
 
@@ -24,6 +27,7 @@ const OPENCLAW_CONFIG_REPAIR_TIMEOUT_MS = 120_000;
 const OPENCLAW_GATEWAY_UNIT = "openclaw-gateway.service";
 const OPENCLAW_GATEWAY_TRANSITION_RETRIES = 2;
 const OPENCLAW_GATEWAY_TRANSITION_RETRY_DELAY_MS = 3_000;
+const openClawWorkspaces = new Map<string, { revision: string; workspace: string }>();
 
 export type OpenClawHostedContext = ReturnType<typeof createOpenClawHostedContext>;
 
@@ -57,6 +61,33 @@ function parseOfficialWorkspaceRoster(stdout: string): string {
 	return resolve(main[0].workspace);
 }
 
+export function openClawRosterConfigRevision(home: string): string {
+	try {
+		const config = JSON.parse(
+			readFileSync(join(home, ".openclaw", "openclaw.json"), "utf8"),
+		) as unknown;
+		const root =
+			config && typeof config === "object" && !Array.isArray(config)
+				? (config as Record<string, unknown>)
+				: {};
+		const agents =
+			root.agents && typeof root.agents === "object" && !Array.isArray(root.agents)
+				? (root.agents as Record<string, unknown>)
+				: {};
+		const defaults =
+			agents.defaults && typeof agents.defaults === "object" && !Array.isArray(agents.defaults)
+				? (agents.defaults as Record<string, unknown>)
+				: {};
+		return runtimeImpactRevision({
+			defaultWorkspace: defaults.workspace ?? null,
+			entries: agents.entries ?? null,
+			list: agents.list ?? null,
+		});
+	} catch {
+		return "unavailable";
+	}
+}
+
 function openClawGatewayIsTransitioning(home: string): boolean {
 	const result = spawnRuntimeUserCommand(
 		systemctlPath(),
@@ -84,6 +115,11 @@ function waitForOpenClawGatewayTransition(): void {
 
 export function resolveHostedOpenClawWorkspace(home: string): string {
 	const command = commandPath(home);
+	const revision = [runtimeFileCurrentRevision(command), openClawRosterConfigRevision(home)].join(
+		"\0",
+	);
+	const cached = openClawWorkspaces.get(home);
+	if (cached?.revision === revision) return cached.workspace;
 	let result = spawnRuntimeUserCommand(command, ["agents", "list", "--json"], home, home, {
 		timeoutMs: OPENCLAW_CONFIG_PROBE_TIMEOUT_MS,
 		maxBufferBytes: 1024 * 1024,
@@ -104,7 +140,9 @@ export function resolveHostedOpenClawWorkspace(home: string): string {
 	if (result.status !== 0) {
 		throw new Error("OpenClaw official agent workspace roster is unavailable");
 	}
-	return parseOfficialWorkspaceRoster(String(result.stdout));
+	const workspace = parseOfficialWorkspaceRoster(String(result.stdout));
+	openClawWorkspaces.set(home, { revision, workspace });
+	return workspace;
 }
 
 function invalidConfigValidation(result: ReturnType<typeof spawnRuntimeUserCommand>): boolean {

--- a/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
@@ -58,6 +58,43 @@ printf '%s\n' 'LoadState=loaded' 'ActiveState=deactivating'
 	expect(readFileSync(attempts, "utf8")).toBe("2\n");
 });
 
+test("reuses the official roster until its config revision changes", () => {
+	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-roster-cache-"));
+	const home = join(root, "home");
+	const firstWorkspace = join(home, "first-workspace");
+	const secondWorkspace = join(home, "second-workspace");
+	const command = join(home, ".local", "bin", "openclaw");
+	const config = join(home, ".openclaw", "openclaw.json");
+	const commandLog = join(root, "commands.log");
+	mkdirSync(dirname(command), { recursive: true });
+	mkdirSync(dirname(config), { recursive: true });
+	writeFileSync(config, '{"agents":{"defaults":{"workspace":"first"}}}\n');
+	writeFileSync(
+		command,
+		`#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> '${commandLog}'
+if grep -q second '${config}'; then
+  printf '%s\n' '[{"id":"main","workspace":"${secondWorkspace}"}]'
+else
+  printf '%s\n' '[{"id":"main","workspace":"${firstWorkspace}"}]'
+fi
+`,
+		{ mode: 0o755 },
+	);
+
+	expect(resolveHostedOpenClawWorkspace(home)).toBe(firstWorkspace);
+	expect(resolveHostedOpenClawWorkspace(home)).toBe(firstWorkspace);
+	expect(readFileSync(commandLog, "utf8").trim().split("\n")).toEqual(["agents list --json"]);
+
+	writeFileSync(config, '{"agents":{"defaults":{"workspace":"second"}}}\n');
+	expect(resolveHostedOpenClawWorkspace(home)).toBe(secondWorkspace);
+	expect(readFileSync(commandLog, "utf8").trim().split("\n")).toEqual([
+		"agents list --json",
+		"agents list --json",
+	]);
+});
+
 test("does not retry roster failures when the OpenClaw gateway failed or is not installed", () => {
 	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-gateway-failure-"));
 	for (const scenario of [

--- a/packages/cli/src/runtime/manifest-channels.ts
+++ b/packages/cli/src/runtime/manifest-channels.ts
@@ -12,7 +12,7 @@ import {
 import { join, resolve } from "node:path";
 import type { z } from "zod";
 import { writePrivateFileAtomic } from "../lib/private-file";
-import { type HermesConfigCommandContext, reconcileHermesConfigValue } from "./hermes-config";
+import { type HermesConfigTransaction, reconcileHermesConfigValue } from "./hermes-config";
 import type { OpenClawHostedContext } from "./hosted-openclaw-context";
 import {
 	buildHermesManagedChannelsPatch,
@@ -25,7 +25,6 @@ import {
 	runtimeFileCurrentRevision,
 } from "./manifest-install";
 import { openClawConfigPatchIsApplied } from "./manifest-providers";
-import { hermesConfigContext } from "./manifest-runtime-config";
 import { hasExactKeys, isPlainRecord, recordValue } from "./manifest-shared";
 import { openClawPluginInspectSchema } from "./openclaw-plugin-observation";
 import {
@@ -355,7 +354,7 @@ export function hostedChannelProjection(manifest: RuntimeManifest): Record<strin
 	return channels;
 }
 function applyHermesNestedConfigPatch(
-	context: HermesConfigCommandContext,
+	context: HermesConfigTransaction,
 	prefix: string,
 	patch: Record<string, unknown>,
 ): boolean {
@@ -374,7 +373,7 @@ function applyHermesNestedConfigPatch(
 	return changed;
 }
 function applyHermesChannelConfig(
-	context: HermesConfigCommandContext,
+	context: HermesConfigTransaction,
 	patch: Record<string, unknown>,
 ): boolean {
 	let changed = false;
@@ -422,6 +421,7 @@ export function applyHostedChannelProjection(
 	openClawContext: OpenClawHostedContext,
 	workspaceRoot: string,
 	hermesWhatsAppAuthDir: string | null,
+	hermesConfig: HermesConfigTransaction | null,
 ): boolean {
 	if (name !== "openclaw" && name !== "hermes") return false;
 	if (!observation.enabled || observation.status === "install_failed" || !observation.commandPath) {
@@ -431,8 +431,9 @@ export function applyHostedChannelProjection(
 	if (!channels) return false;
 
 	if (name === "hermes") {
+		if (!hermesConfig) throw new Error("Hermes config command is unavailable");
 		return applyHermesChannelConfig(
-			hermesConfigContext(observation, home, workspaceRoot),
+			hermesConfig,
 			buildHermesManagedChannelsPatch(channels, hermesWhatsAppAuthDir),
 		);
 	}

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -108,11 +108,7 @@ import {
 	validateRuntimeSystemdPlan,
 	writeRuntimeSystemdState,
 } from "./runtime-systemd-reconciliation";
-import {
-	ensureRuntimeUserHomeOwnership,
-	executableExists,
-	withRuntimeUserFileAccess,
-} from "./runtime-user-command";
+import { executableExists, withRuntimeUserFileAccess } from "./runtime-user-command";
 import { ensureRuntimePlatformDirectory } from "./state";
 
 type RuntimeManifest = RuntimeManifestLoad["manifest"];
@@ -202,9 +198,6 @@ function initializeRuntimeConvergence(
 		opts.hostedRuntimeContract,
 	);
 	const projectionHome = hostedRuntimeProjectionHome(manifest, paths);
-	// SUNSET: remove the recursive migration after every 0.13.92/0.14.14 host has
-	// converged once; those releases could leave tenant HOME trees root-owned.
-	ensureRuntimeUserHomeOwnership(projectionHome, hostedRuntimeContract.identity);
 	if (manifest.runtimes.openclaw?.enabled === true) {
 		withRuntimeUserFileAccess(() => {
 			for (const path of [

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -95,6 +95,7 @@ import { ensureManagedOpenClawProviderPlugin } from "./openclaw-managed-provider
 import type { RuntimePaths } from "./paths";
 import { hostedRuntimeProjectionHome } from "./projection-home";
 import { runtimeRunConfigId, writeRuntimeRunConfig } from "./run-config";
+import { runtimeImpactRevision, runtimeProviderRevision } from "./runtime-impact-revision";
 import {
 	installOfficialRuntimeService,
 	planOfficialRuntimeServices,
@@ -156,6 +157,28 @@ interface RuntimeConvergenceState {
 	activated: Record<string, string>;
 	officialServiceCommandRevisions: Record<string, string>;
 	staleSystemdFiles: RuntimeSystemdStaleFilePlan;
+}
+
+function officialServiceCommandRevision(
+	context: RuntimeConvergenceContext,
+	runtime: string,
+): string | null {
+	const unitName =
+		runtime === "openclaw"
+			? "openclaw-gateway.service"
+			: runtime === "hermes"
+				? "hermes-gateway.service"
+				: null;
+	return unitName
+		? (context.appliedState?.officialServiceCommandRevisions?.[unitName] ?? null)
+		: null;
+}
+
+function runtimeProbeRevision(context: RuntimeConvergenceContext, runtime: string): string {
+	return runtimeImpactRevision({
+		provider: runtimeProviderRevision(context.manifest, runtime),
+		officialServiceCommand: officialServiceCommandRevision(context, runtime),
+	});
 }
 
 interface RuntimeConvergencePlan {
@@ -342,6 +365,7 @@ function prepareRuntimeInstallStage(
 			projectionHome,
 			paths,
 			hostedRuntimeContract.identity,
+			officialServiceCommandRevision(context, name),
 		);
 		state.observations.set(name, observation);
 		if (observation.error) state.installErrors.push(observation.error);
@@ -349,6 +373,7 @@ function prepareRuntimeInstallStage(
 		if (name === "openclaw" && observation.enabled && observation.commandPath) {
 			state.openClawOwnerBrowserBootstrapSupported = openClawSupportsOwnerBrowserBootstrap(
 				context.openClawContext,
+				runtimeProbeRevision(context, "openclaw"),
 			);
 		}
 	}
@@ -457,6 +482,7 @@ function prepareRuntimeApplyDependencies(
 					manifest,
 					secretValues,
 					context: openClawContext,
+					revision: runtimeProbeRevision(context, "openclaw"),
 				});
 			} catch (error) {
 				state.installErrors.push(
@@ -469,14 +495,18 @@ function prepareRuntimeApplyDependencies(
 		if (state.installErrors.length > 0) throw new Error(state.installErrors.join("; "));
 		const managedOpenClawObservation = state.observations.get("openclaw");
 		if (managedOpenClawObservation && openClawContext.managedApiKeyProjection) {
-			openClawContext.agentDirs.managed =
-				discoverOpenClawManagedProviderAuthAgentDirs(openClawContext);
+			openClawContext.agentDirs.managed = discoverOpenClawManagedProviderAuthAgentDirs(
+				openClawContext,
+				runtimeProbeRevision(context, "openclaw"),
+			);
 			if (!managedOpenClawObservation.commandPath) {
 				throw new Error("OpenClaw managed provider plugin requires an installed runtime");
 			}
 			ensureManagedOpenClawProviderPlugin({
 				context: openClawContext,
 				commandPath: managedOpenClawObservation.commandPath,
+				revision: runtimeProbeRevision(context, "openclaw"),
+				refreshCachedRuntimeProbes: opts.refreshCachedRuntimeProbes,
 			});
 		}
 		if (opts.preparedHostedAgentPlugins) {
@@ -490,6 +520,7 @@ function prepareRuntimeApplyDependencies(
 					...(opts.hostedAgentPluginCommandRunner
 						? { runner: opts.hostedAgentPluginCommandRunner }
 						: {}),
+					refreshCachedRuntimeProbes: opts.refreshCachedRuntimeProbes,
 				});
 			} catch (error) {
 				for (const name of opts.preparedHostedAgentPlugins.desired.keys()) {
@@ -859,6 +890,7 @@ function applyRuntimeEntryProjections(
 					previousProjectedProviderIds[name] ?? [],
 					state.openClawOwnerBrowserBootstrapSupported,
 					hermesConfig,
+					runtimeProbeRevision(context, name),
 				);
 				state.projectedProviderIds[name] = providerProjection.providerIds;
 			} catch (error) {

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -8,6 +8,11 @@ import {
 	gcFileBrowserCompanionCandidates,
 	probeFileBrowserReadiness,
 } from "./file-browser-companion";
+import {
+	beginHermesConfigTransaction,
+	commitHermesConfigTransaction,
+	type HermesConfigTransaction,
+} from "./hermes-config";
 import { writeHostedAgentPluginReceipt } from "./hosted-agent-plugin-package";
 import {
 	type HostedAgentPluginTransaction,
@@ -123,6 +128,7 @@ interface RuntimeConvergenceContext {
 	hostedRuntimeContract: ReturnType<typeof assertHostedRuntimeContract>;
 	projectionHome: string;
 	openClawContext: ReturnType<typeof createOpenClawHostedContext>;
+	hermesConfig: HermesConfigTransaction | null;
 	hermesWhatsAppAuthDir: string | null;
 	workspaceRoot: string;
 	enabledRuntimes: string[];
@@ -281,6 +287,7 @@ function initializeRuntimeConvergence(
 			hostedRuntimeContract,
 			projectionHome,
 			openClawContext,
+			hermesConfig: null,
 			hermesWhatsAppAuthDir,
 			workspaceRoot,
 			enabledRuntimes,
@@ -358,6 +365,21 @@ function prepareRuntimeInstallStage(
 	return null;
 }
 
+function beginRuntimeHermesConfig(
+	context: RuntimeConvergenceContext,
+	state: RuntimeConvergenceState,
+): HermesConfigTransaction | null {
+	const command =
+		state.observations.get("hermes")?.commandPath ??
+		runtimeCommandPath("hermes", context.projectionHome);
+	if (!command || !executableExists(command)) return null;
+	return beginHermesConfigTransaction({
+		command,
+		home: context.projectionHome,
+		cwd: context.projectionHome,
+	});
+}
+
 function prepareRuntimeConvergencePlan(
 	context: RuntimeConvergenceContext,
 	state: RuntimeConvergenceState,
@@ -369,6 +391,7 @@ function prepareRuntimeConvergencePlan(
 		secretValues,
 		previousProjectedProviderIds,
 		hermesWhatsAppAuthDir,
+		hermesConfig,
 		workspaceRoot,
 		generatedAt,
 		plannedEgressProfileBundlePath,
@@ -398,6 +421,7 @@ function prepareRuntimeConvergencePlan(
 		observations: state.observations,
 		previousProjectedProviderIds,
 		hermesWhatsAppAuthDir,
+		hermesConfig,
 		openClawOwnerBrowserBootstrapSupported: state.openClawOwnerBrowserBootstrapSupported,
 	});
 	try {
@@ -674,6 +698,7 @@ function applyRuntimeResourceProjections(
 		projectionHome,
 		openClawContext,
 		hermesWhatsAppAuthDir,
+		hermesConfig,
 		workspaceRoot,
 		previousProjectedProviderIds,
 		runtimeEntries,
@@ -690,6 +715,7 @@ function applyRuntimeResourceProjections(
 		observations: state.observations,
 		previousProjectedProviderIds,
 		hermesWhatsAppAuthDir,
+		hermesConfig,
 		openClawOwnerBrowserBootstrapSupported: state.openClawOwnerBrowserBootstrapSupported,
 	});
 	const providerProjectionRevisions: Partial<Record<string, string | null>> = {};
@@ -736,7 +762,7 @@ function applyRuntimeResourceProjections(
 		}
 	}
 	try {
-		applyHostedMcpProjections(manifest, paths, state.observations, workspaceRoot);
+		applyHostedMcpProjections(manifest, paths, state.observations, workspaceRoot, hermesConfig);
 	} catch (error) {
 		state.installErrors.push(
 			`runtime MCP projection failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -781,6 +807,7 @@ function applyRuntimeEntryProjections(
 		projectionHome,
 		openClawContext,
 		hermesWhatsAppAuthDir,
+		hermesConfig,
 		workspaceRoot,
 		generatedAt,
 		previousProjectedProviderIds,
@@ -813,11 +840,11 @@ function applyRuntimeEntryProjections(
 			try {
 				const localeFile = applyHostedRuntimeConfigProjection(
 					name,
-					observation,
 					manifest,
 					projectionHome,
 					plan.openClawWorkspaceRoot,
 					workspaceRoot,
+					hermesConfig,
 				);
 				if (localeFile) state.managedLocaleFiles.push(localeFile);
 			} catch (error) {
@@ -838,6 +865,7 @@ function applyRuntimeEntryProjections(
 					workspaceRoot,
 					previousProjectedProviderIds[name] ?? [],
 					state.openClawOwnerBrowserBootstrapSupported,
+					hermesConfig,
 				);
 				state.projectedProviderIds[name] = providerProjection.providerIds;
 			} catch (error) {
@@ -856,6 +884,7 @@ function applyRuntimeEntryProjections(
 					openClawContext,
 					workspaceRoot,
 					hermesWhatsAppAuthDir,
+					hermesConfig,
 				);
 			} catch (error) {
 				state.installErrors.push(
@@ -1125,6 +1154,7 @@ export function convergeRuntimeManifest(
 	const { context, state } = initializeRuntimeConvergence(load, paths, opts);
 	const installResult = prepareRuntimeInstallStage(context, state);
 	if (installResult) return installResult.result;
+	context.hermesConfig = beginRuntimeHermesConfig(context, state);
 	const planResult = prepareRuntimeConvergencePlan(context, state);
 	if ("result" in planResult) return planResult.result;
 	const plan = planResult.plan;
@@ -1139,6 +1169,19 @@ export function convergeRuntimeManifest(
 		);
 
 		applyRuntimeEntryProjections(context, state, plan, egressProjection);
+		if (context.hermesConfig) {
+			const hermesConfig = context.hermesConfig;
+			const commitResult = withRuntimeUserFileAccess(
+				() => commitHermesConfigTransaction(hermesConfig),
+				context.hostedRuntimeContract.identity,
+			);
+			if (commitResult === "conflict") {
+				return {
+					...runtimeConvergenceFailure(context, state),
+					deferredReason: "hermes_config_conflict",
+				};
+			}
+		}
 		const activationPlan = prepareRuntimeActivation(
 			context,
 			state,

--- a/packages/cli/src/runtime/manifest-install.ts
+++ b/packages/cli/src/runtime/manifest-install.ts
@@ -73,6 +73,11 @@ const HERMES_DASHBOARD_CAPABILITY_PROBE =
 	"import uvicorn; assert callable(getattr(uvicorn.Server, 'capture_signals', None))";
 const HERMES_DASHBOARD_CAPABILITY_PROBE_TIMEOUT_MS = 30_000;
 const DEFAULT_RUNTIME_INSTALL_TIMEOUT_MS = 30 * 60 * 1000;
+const runtimeCommandRevisions = new Map<
+	string,
+	{ executableRevision: string; commandRevision: string }
+>();
+const hermesDashboardCapabilityRevisions = new Map<string, string>();
 function runtimeInstallTimeoutMs(): number {
 	const raw = process.env.CLAWDI_RUNTIME_INSTALL_TIMEOUT;
 	if (raw === undefined) return DEFAULT_RUNTIME_INSTALL_TIMEOUT_MS;
@@ -86,6 +91,7 @@ function runtimeInstallTimeoutMs(): number {
 function hermesDashboardCapabilityError(
 	name: string,
 	runtime: RuntimeManifest["runtimes"][string],
+	officialServiceCommandRevision?: string | null,
 ): string | null {
 	if (name !== "hermes" || !runtime.enabled || !runtime.install || !runtime.services?.dashboard)
 		return null;
@@ -93,6 +99,11 @@ function hermesDashboardCapabilityError(
 	if (!executableExists(python)) {
 		return `Hermes dashboard runtime is missing its managed Python interpreter: ${python}`;
 	}
+	const capabilityRevision = [
+		officialServiceCommandRevision ?? "uncommitted",
+		runtimeFileCurrentRevision(python) ?? "missing",
+	].join("\0");
+	if (hermesDashboardCapabilityRevisions.get(python) === capabilityRevision) return null;
 	let result: ReturnType<typeof spawnRuntimeUserCommand>;
 	try {
 		result = spawnRuntimeUserCommand(
@@ -107,7 +118,10 @@ function hermesDashboardCapabilityError(
 			error instanceof Error ? error.message : String(error)
 		}`;
 	}
-	if (result.status === 0) return null;
+	if (result.status === 0) {
+		hermesDashboardCapabilityRevisions.set(python, capabilityRevision);
+		return null;
+	}
 	return `Hermes dashboard runtime is incompatible: ${
 		tail(String(result.stderr ?? "")) ??
 		(result.error instanceof Error
@@ -331,6 +345,7 @@ export function observeRuntimeInstall(
 	home: string,
 	paths: RuntimePaths,
 	identity: { uid: number; gid: number },
+	officialServiceCommandRevision?: string | null,
 ) {
 	if (!runtime.enabled) {
 		return runtimeInstallObservation({
@@ -365,7 +380,11 @@ export function observeRuntimeInstall(
 	}
 	const observation = runOfficialInstaller(name, runtime.install, paths, identity);
 	if (observation.error) return observation;
-	const capabilityError = hermesDashboardCapabilityError(name, runtime);
+	const capabilityError = hermesDashboardCapabilityError(
+		name,
+		runtime,
+		officialServiceCommandRevision,
+	);
 	return capabilityError
 		? { ...observation, status: "install_failed" as const, error: capabilityError }
 		: observation;
@@ -457,6 +476,9 @@ export function runtimeCommandCurrentRevision(
 ): string | null {
 	const executableRevision = runtimeFileCurrentRevision(command);
 	if (!executableRevision) return null;
+	const cacheKey = `${command}\0${home}\0${cwd}`;
+	const cached = runtimeCommandRevisions.get(cacheKey);
+	if (cached?.executableRevision === executableRevision) return cached.commandRevision;
 	try {
 		const versionResult = spawnRuntimeUserCommand(command, ["--version"], home, cwd, {
 			timeoutMs: 10_000,
@@ -477,10 +499,12 @@ export function runtimeCommandCurrentRevision(
 			: versionResult.stderr;
 		const version = [stdout, stderr].filter(Boolean).join("\n").trim();
 		if (!version) return null;
-		return runtimeContentSha256({
+		const commandRevision = runtimeContentSha256({
 			executableRevision,
 			version,
 		});
+		runtimeCommandRevisions.set(cacheKey, { executableRevision, commandRevision });
+		return commandRevision;
 	} catch (error) {
 		if (error instanceof RuntimeUserCommandTimeoutError) throw error;
 		return null;

--- a/packages/cli/src/runtime/manifest-mcp.ts
+++ b/packages/cli/src/runtime/manifest-mcp.ts
@@ -1,6 +1,10 @@
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { getHermesRawConfigValue, reconcileHermesConfigValue } from "./hermes-config";
+import {
+	getHermesRawConfigValue,
+	type HermesConfigTransaction,
+	reconcileHermesConfigValue,
+} from "./hermes-config";
 import { managedMcpHeaderPlaceholder } from "./hosted-egress-profiles";
 import type { RuntimeManifest } from "./manifest-contract";
 import { type RuntimeInstallObservation, runtimeCommandPath } from "./manifest-install";
@@ -34,14 +38,15 @@ export function applyHostedMcpProjections(
 	paths: RuntimePaths,
 	observations: ReadonlyMap<string, RuntimeInstallObservation>,
 	workspaceRoot: string,
+	hermesConfig: HermesConfigTransaction | null,
 ): void {
-	const plan = buildHostedMcpReconciliationPlan(manifest, paths, observations, workspaceRoot);
+	const plan = buildHostedMcpReconciliationPlan(manifest, paths, observations, hermesConfig);
 	for (const runtime of [...plan.runtimes].sort((left, right) =>
 		left.name === right.name ? 0 : left.name === "hermes" ? -1 : 1,
 	)) {
 		if (runtime.mutations.length === 0) continue;
 		if (runtime.name === "hermes") {
-			if (!runtime.commandPath || !executableExists(runtime.commandPath)) {
+			if (!runtime.commandPath || !executableExists(runtime.commandPath) || !hermesConfig) {
 				throw new Error("could not mutate managed Hermes MCP servers: runtime is unavailable");
 			}
 			const nextServers = { ...runtime.native.servers };
@@ -50,7 +55,7 @@ export function applyHostedMcpProjections(
 				else nextServers[mutation.serverName] = mutation.server;
 			}
 			reconcileHermesConfigValue(
-				{ command: runtime.commandPath, home: plan.home, cwd: workspaceRoot },
+				hermesConfig,
 				"mcp_servers",
 				Object.keys(nextServers).length > 0 ? nextServers : undefined,
 			);
@@ -92,7 +97,7 @@ function buildHostedMcpReconciliationPlan(
 	manifest: RuntimeManifest,
 	paths: RuntimePaths,
 	observations: ReadonlyMap<string, RuntimeInstallObservation>,
-	cwd = hostedRuntimeProjectionHome(manifest, paths),
+	hermesConfig: HermesConfigTransaction | null = null,
 ): HostedMcpReconciliationPlan {
 	const intent = hostedMcpIntent(manifest);
 	const home = hostedRuntimeProjectionHome(manifest, paths);
@@ -106,7 +111,7 @@ function buildHostedMcpReconciliationPlan(
 		}
 		const native =
 			name === "openclaw" || runtimeAvailable
-				? readHostedMcpNativeState(name, home, commandPath, cwd)
+				? readHostedMcpNativeState(name, home, commandPath, hermesConfig)
 				: { servers: {} };
 		const managedServerNames = new Set(
 			Object.entries(native.servers).flatMap(([serverName, server]) =>
@@ -152,11 +157,11 @@ function readHostedMcpNativeState(
 	name: HostedMcpTarget,
 	home: string,
 	commandPath: string | null,
-	cwd: string,
+	hermesConfig: HermesConfigTransaction | null,
 ): HostedMcpNativeState {
 	if (name === "hermes") {
-		if (!commandPath) throw new Error("Hermes config command is unavailable");
-		const current = getHermesRawConfigValue({ command: commandPath, home, cwd }, "mcp_servers");
+		if (!commandPath || !hermesConfig) throw new Error("Hermes config command is unavailable");
+		const current = getHermesRawConfigValue(hermesConfig, "mcp_servers");
 		if (!current.exists) return { servers: {} };
 		if (!isPlainRecord(current.value)) {
 			throw new Error("Hermes config field mcp_servers must be an object");
@@ -212,6 +217,7 @@ export function validateHostedMcpProjectionPlan(
 	manifest: RuntimeManifest,
 	paths: RuntimePaths,
 	observations: ReadonlyMap<string, RuntimeInstallObservation>,
+	hermesConfig: HermesConfigTransaction | null,
 ): void {
-	buildHostedMcpReconciliationPlan(manifest, paths, observations);
+	buildHostedMcpReconciliationPlan(manifest, paths, observations, hermesConfig);
 }

--- a/packages/cli/src/runtime/manifest-oauth.ts
+++ b/packages/cli/src/runtime/manifest-oauth.ts
@@ -28,15 +28,29 @@ import {
 	readOAuthCredentialLedger,
 	writeOAuthCredentialLedger,
 } from "../lib/oauth-credential-ledger";
-import type { OpenClawHostedContext } from "./hosted-openclaw-context";
+import {
+	type OpenClawHostedContext,
+	openClawRosterConfigRevision,
+} from "./hosted-openclaw-context";
 import type { RuntimeManifest } from "./manifest-contract";
-import { tail } from "./manifest-install";
+import { runtimeFileCurrentRevision, tail } from "./manifest-install";
 import { recordValue, stringValue } from "./manifest-shared";
 import type { RuntimePaths } from "./paths";
+import { runtimeImpactRevision } from "./runtime-impact-revision";
 import { spawnRuntimeUserCommand } from "./runtime-user-command";
 import { runtimeSecretValue } from "./secret-values";
 
 const OPENCLAW_CODEX_PROVIDER_ID = "openai";
+const openClawOwnerBrowserCapabilities = new Map<
+	string,
+	{ revision: string; supported: boolean }
+>();
+const openClawProviderAuthCapabilityRevisions = new Map<string, string>();
+const openClawManagedProviderAuthAgentDirs = new Map<
+	string,
+	{ revision: string; agentDirs: string[] }
+>();
+const openClawManagedProviderAuthCleanupRevisions = new Map<string, string>();
 interface RuntimeOAuthMaterial {
 	accessToken: string;
 	refreshToken: string;
@@ -191,9 +205,15 @@ const normalized = typeof sdk.normalizeDeviceBootstrapProfile === "function"
   : null;
 process.stdout.write(normalized?.purpose === "control-ui-owner" ? "supported" : "unsupported");
 `;
-export function openClawSupportsOwnerBrowserBootstrap(context: OpenClawHostedContext): boolean {
+export function openClawSupportsOwnerBrowserBootstrap(
+	context: OpenClawHostedContext,
+	revision: string,
+): boolean {
 	const sdkPath = context.sdk.deviceBootstrap;
 	if (!sdkPath) return false;
+	const capabilityRevision = [revision, runtimeFileCurrentRevision(sdkPath)].join("\0");
+	const cached = openClawOwnerBrowserCapabilities.get(context.home);
+	if (cached?.revision === capabilityRevision) return cached.supported;
 	const result = spawnRuntimeUserCommand(
 		"node",
 		["--input-type=module", "--eval", OPENCLAW_OWNER_BROWSER_BOOTSTRAP_CAPABILITY_PROBE, sdkPath],
@@ -208,8 +228,14 @@ export function openClawSupportsOwnerBrowserBootstrap(context: OpenClawHostedCon
 		);
 	}
 	const outcome = String(result.stdout ?? "").trim();
-	if (outcome === "supported") return true;
-	if (outcome === "unsupported") return false;
+	if (outcome === "supported" || outcome === "unsupported") {
+		const supported = outcome === "supported";
+		openClawOwnerBrowserCapabilities.set(context.home, {
+			revision: capabilityRevision,
+			supported,
+		});
+		return supported;
+	}
 	throw new Error("installed OpenClaw device-bootstrap capability probe returned invalid output");
 }
 const OPENCLAW_PROVIDER_AUTH_CAPABILITY_PROBE = `
@@ -279,10 +305,20 @@ export function ensureHostedOpenClawProviderAuthCapability(input: {
 	manifest: RuntimeManifest;
 	secretValues: Record<string, string> | undefined;
 	context: OpenClawHostedContext;
+	revision: string;
 }): void {
 	const desired = hostedRuntimeOAuthCredentials(input.manifest, "openclaw", input.secretValues);
 	const cleanupManagedProvider = input.context.managedApiKeyProjection;
 	if (desired.length === 0 && !cleanupManagedProvider) return;
+	const capabilityRevision = [
+		input.revision,
+		runtimeFileCurrentRevision(input.context.sdk.providerAuth ?? ""),
+		runtimeFileCurrentRevision(input.context.sdk.configMutation ?? ""),
+		runtimeFileCurrentRevision(input.context.sdk.providerEnvVars ?? ""),
+	].join("\0");
+	if (openClawProviderAuthCapabilityRevisions.get(input.context.home) === capabilityRevision) {
+		return;
+	}
 	const requirement =
 		desired.length > 0 && cleanupManagedProvider
 			? "OpenClaw credential convergence"
@@ -302,6 +338,7 @@ export function ensureHostedOpenClawProviderAuthCapability(input: {
 			}`,
 		);
 	}
+	openClawProviderAuthCapabilityRevisions.set(input.context.home, capabilityRevision);
 }
 function runOpenClawProviderAuthCommand(
 	context: OpenClawHostedContext,
@@ -349,7 +386,15 @@ function runOpenClawProviderAuthCommand(
 export function removeOpenClawManagedProviderAuthProfiles(
 	context: OpenClawHostedContext,
 	workspaceRoot: string,
+	revision: string,
 ): void {
+	const cleanupRevision = runtimeImpactRevision({
+		revision,
+		agentDirs: context.agentDirs.managed,
+		providerAuthSdk: runtimeFileCurrentRevision(context.sdk.providerAuth ?? ""),
+		configMutationSdk: runtimeFileCurrentRevision(context.sdk.configMutation ?? ""),
+	});
+	if (openClawManagedProviderAuthCleanupRevisions.get(context.home) === cleanupRevision) return;
 	const configMutationSdkPath = context.sdk.configMutation;
 	if (!configMutationSdkPath) {
 		throw new Error("installed OpenClaw public config-mutation SDK export is unavailable");
@@ -376,10 +421,20 @@ export function removeOpenClawManagedProviderAuthProfiles(
 			}`,
 		);
 	}
+	openClawManagedProviderAuthCleanupRevisions.set(context.home, cleanupRevision);
 }
 export function discoverOpenClawManagedProviderAuthAgentDirs(
 	context: OpenClawHostedContext,
+	revision: string,
 ): string[] {
+	const discoveryRevision = [
+		revision,
+		openClawRosterConfigRevision(context.home),
+		runtimeFileCurrentRevision(context.sdk.providerAuth ?? ""),
+		runtimeFileCurrentRevision(context.sdk.configMutation ?? ""),
+	].join("\0");
+	const cached = openClawManagedProviderAuthAgentDirs.get(context.home);
+	if (cached?.revision === discoveryRevision) return [...cached.agentDirs];
 	const configMutationSdkPath = context.sdk.configMutation;
 	if (!configMutationSdkPath) {
 		throw new Error("installed OpenClaw public config-mutation SDK export is unavailable");
@@ -413,7 +468,11 @@ export function discoverOpenClawManagedProviderAuthAgentDirs(
 	if (agentDirs.length !== output.agentDirs.length || agentDirs.length === 0) {
 		throw new Error("OpenClaw managed provider-auth store discovery returned invalid targets");
 	}
-	return agentDirs;
+	openClawManagedProviderAuthAgentDirs.set(context.home, {
+		revision: discoveryRevision,
+		agentDirs,
+	});
+	return [...agentDirs];
 }
 function runtimeOAuthLedgerOwnership(
 	ledger: OAuthCredentialLedger | null,

--- a/packages/cli/src/runtime/manifest-planning.ts
+++ b/packages/cli/src/runtime/manifest-planning.ts
@@ -85,6 +85,7 @@ export interface RuntimeConvergenceOptions {
 	resourcePreparationFailures?: RuntimeResourcePreparationFailures;
 	hostedAgentPluginCommandRunner?: HostedAgentPluginCommandRunner;
 	hostedRuntimeContract?: HostedRuntimeContractOptions;
+	refreshCachedRuntimeProbes?: boolean;
 }
 
 export interface RuntimeResourcePreparationFailures {
@@ -99,6 +100,7 @@ export function planHostedAgentPluginConvergence(input: {
 	home: string;
 	commands: HostedAgentPluginCommands;
 	runner?: HostedAgentPluginCommandRunner;
+	refreshCachedRuntimeProbes?: boolean;
 }): {
 	transaction: HostedAgentPluginTransaction | null;
 } {
@@ -108,6 +110,7 @@ export function planHostedAgentPluginConvergence(input: {
 			home: input.home,
 			commands: input.commands,
 			...(input.runner ? { runner: input.runner } : {}),
+			refreshCachedRuntimeProbes: input.refreshCachedRuntimeProbes,
 		}),
 	};
 }

--- a/packages/cli/src/runtime/manifest-planning.ts
+++ b/packages/cli/src/runtime/manifest-planning.ts
@@ -5,6 +5,7 @@ import {
 	type FileBrowserCompanionInstallOptions,
 	fileBrowserCompanionProgram,
 } from "./file-browser-companion";
+import type { HermesConfigTransaction } from "./hermes-config";
 import type { PreparedHostedAgentPlugins } from "./hosted-agent-plugin-package";
 import {
 	type HostedAgentPluginCommandRunner,
@@ -297,6 +298,7 @@ export function validateRuntimeProjectionPlan(input: {
 	observations: Map<string, RuntimeInstallObservation>;
 	previousProjectedProviderIds: Record<string, string[]>;
 	hermesWhatsAppAuthDir: string | null;
+	hermesConfig: HermesConfigTransaction | null;
 	openClawOwnerBrowserBootstrapSupported: boolean;
 }): void {
 	const {
@@ -307,6 +309,7 @@ export function validateRuntimeProjectionPlan(input: {
 		observations,
 		previousProjectedProviderIds,
 		hermesWhatsAppAuthDir,
+		hermesConfig,
 		openClawOwnerBrowserBootstrapSupported,
 	} = input;
 	const home = hostedRuntimeProjectionHome(manifest, paths);
@@ -373,7 +376,7 @@ export function validateRuntimeProjectionPlan(input: {
 			buildHermesManagedChannelsPatch(channels, hermesWhatsAppAuthDir);
 		}
 	}
-	validateHostedMcpProjectionPlan(manifest, paths, observations);
+	validateHostedMcpProjectionPlan(manifest, paths, observations, hermesConfig);
 	validateHostedChannelCredentialsPlan(manifest, secretValues, home);
 }
 export function managedWhatsAppCompatibilityRuntime(

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -8,7 +8,7 @@ import { isValidSemver } from "../lib/semver";
 import {
 	getHermesRawConfigValue,
 	getHermesResolvedConfigValue,
-	type HermesConfigCommandContext,
+	type HermesConfigTransaction,
 	reconcileHermesConfigValue,
 } from "./hermes-config";
 import { normalizeSecretRef } from "./hosted-egress-profiles";
@@ -22,7 +22,6 @@ import {
 import type { RuntimeManifest } from "./manifest-contract";
 import { type RuntimeInstallObservation, tail } from "./manifest-install";
 import { removeOpenClawManagedProviderAuthProfiles } from "./manifest-oauth";
-import { hermesConfigContext } from "./manifest-runtime-config";
 import { canonicalJsonEqual, isPlainRecord, recordValue, stringValue } from "./manifest-shared";
 import type { RuntimePaths } from "./paths";
 import { runtimeImpactRevision } from "./runtime-impact-revision";
@@ -116,6 +115,7 @@ export function applyHostedAiProviderProjection(
 	workspaceRoot: string,
 	previousProviderIds: readonly string[],
 	openClawOwnerBrowserBootstrapSupported: boolean,
+	hermesConfig: HermesConfigTransaction | null,
 ): HostedAiProviderProjectionResult {
 	if (!observation.enabled || observation.status === "install_failed" || !observation.commandPath) {
 		return { path: null, revision: null, providerIds: [] };
@@ -137,11 +137,10 @@ export function applyHostedAiProviderProjection(
 	}
 	if (name === "hermes") {
 		return applyHostedHermesAiProviderProjection(
-			observation,
 			projectionInput,
 			previousProviderIds,
 			home,
-			workspaceRoot,
+			hermesConfig,
 		);
 	}
 	if (name === "openclaw") {
@@ -211,11 +210,10 @@ export function previewHostedAiProviderProjectionRevision(
 		});
 	}
 	return applyHostedHermesAiProviderProjection(
-		observation,
 		projectionInput,
 		previousProviderIds,
 		home,
-		home,
+		null,
 		false,
 	).revision;
 }
@@ -414,22 +412,18 @@ function installHostedCodexBootstrap(
 	}
 }
 function applyHostedHermesAiProviderProjection(
-	observation: RuntimeInstallObservation,
 	projectionInput: HostedAiProviderProjectionInput | null,
 	previousProviderIds: readonly string[],
 	home: string,
-	workspaceRoot: string,
+	config: HermesConfigTransaction | null,
 	apply = true,
 ): HostedAiProviderProjectionResult {
 	const configPath = join(home, ".hermes", "config.yaml");
 	if (!projectionInput) {
 		const deletedProviderIds = staleProviderIds(new Set(previousProviderIds), new Set());
 		if (apply && deletedProviderIds.length > 0) {
-			applyHermesProviderConfig(
-				hermesConfigContext(observation, home, workspaceRoot),
-				{},
-				deletedProviderIds,
-			);
+			if (!config) throw new Error("Hermes config command is unavailable");
+			applyHermesProviderConfig(config, {}, deletedProviderIds);
 		}
 		return {
 			path: null,
@@ -441,8 +435,6 @@ function applyHostedHermesAiProviderProjection(
 		};
 	}
 
-	const commandPath = observation.commandPath;
-	if (!commandPath) return { path: null, revision: null, providerIds: [] };
 	const projection = buildAgentTargetProjection(
 		"hermes",
 		projectionInput.catalog,
@@ -458,14 +450,11 @@ function applyHostedHermesAiProviderProjection(
 	);
 	const patchContent = mergeProviderDeletes("hermes", file.content, deletedProviderIds);
 	if (apply) {
+		if (!config) throw new Error("Hermes config command is unavailable");
 		const patch = parseYaml(file.content) as unknown;
 		const root = recordValue(patch);
 		if (!root) throw new Error("Hermes projection patch must be a YAML object.");
-		applyHermesProviderConfig(
-			hermesConfigContext(observation, home, workspaceRoot),
-			root,
-			deletedProviderIds,
-		);
+		applyHermesProviderConfig(config, root, deletedProviderIds);
 	}
 	return {
 		path: configPath,
@@ -651,7 +640,7 @@ const HERMES_GENERATED_PROVIDER_FIELDS = [
 	"auth_type",
 ] as const;
 function applyHermesProviderConfig(
-	context: HermesConfigCommandContext,
+	context: HermesConfigTransaction,
 	patch: Record<string, unknown>,
 	deletedProviderIds: readonly string[],
 ): void {
@@ -662,7 +651,7 @@ function applyHermesProviderConfig(
 		reconcileHermesConfigValue(context, `model.${key}`, value === null ? undefined : value);
 	}
 	if (!Object.hasOwn(patchModel, "provider") && deletedProviderIds.length > 0) {
-		const currentProvider = getHermesResolvedConfigValue(context, "model.provider");
+		const currentProvider = getHermesResolvedConfigValue(context.context, "model.provider");
 		if (currentProvider.exists && typeof currentProvider.value !== "string") {
 			throw new Error("Hermes config field model.provider must be a string");
 		}

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -20,7 +20,11 @@ import {
 	hostedProviderRequiresApiKey,
 } from "./hosted-provider-resolution";
 import type { RuntimeManifest } from "./manifest-contract";
-import { type RuntimeInstallObservation, tail } from "./manifest-install";
+import {
+	type RuntimeInstallObservation,
+	runtimeFileCurrentRevision,
+	tail,
+} from "./manifest-install";
 import { removeOpenClawManagedProviderAuthProfiles } from "./manifest-oauth";
 import { canonicalJsonEqual, isPlainRecord, recordValue, stringValue } from "./manifest-shared";
 import type { RuntimePaths } from "./paths";
@@ -34,6 +38,7 @@ import {
 import { runtimeSecretValue } from "./secret-values";
 
 const CODEX_BOOTSTRAP_TIMEOUT_MS = 600_000;
+const openClawProviderPatchRevisions = new Map<string, string>();
 
 export function providerHealthReasons(
 	provider: Record<string, unknown>,
@@ -116,6 +121,7 @@ export function applyHostedAiProviderProjection(
 	previousProviderIds: readonly string[],
 	openClawOwnerBrowserBootstrapSupported: boolean,
 	hermesConfig: HermesConfigTransaction | null,
+	providerRevision: string,
 ): HostedAiProviderProjectionResult {
 	if (!observation.enabled || observation.status === "install_failed" || !observation.commandPath) {
 		return { path: null, revision: null, providerIds: [] };
@@ -154,7 +160,12 @@ export function applyHostedAiProviderProjection(
 		);
 		const providerPatch = buildOpenClawHostedProviderPatch(projectionInput, previousProviderIds);
 		if (providerPatch.apply) {
-			applyOpenClawHostedProviderPatch(providerPatch, openClawContext, workspaceRoot);
+			applyOpenClawHostedProviderPatch(
+				providerPatch,
+				openClawContext,
+				workspaceRoot,
+				providerRevision,
+			);
 		}
 		if (openClawContext.managedApiKeyProjection) {
 			if (openClawContext.agentDirs.managed.length === 0) {
@@ -162,7 +173,7 @@ export function applyHostedAiProviderProjection(
 					"OpenClaw managed provider-auth stores were not transactionally discovered",
 				);
 			}
-			removeOpenClawManagedProviderAuthProfiles(openClawContext, workspaceRoot);
+			removeOpenClawManagedProviderAuthProfiles(openClawContext, workspaceRoot, providerRevision);
 		}
 		return {
 			path: observation.commandPath,
@@ -532,8 +543,19 @@ function applyOpenClawHostedProviderPatch(
 	patch: OpenClawHostedProviderPatch,
 	context: OpenClawHostedContext,
 	workspaceRoot: string,
+	providerRevision: string,
 ): void {
 	const sdkPath = context.requireSdkExport("configMutation");
+	const patchRevision = runtimeImpactRevision({
+		providerRevision,
+		content: patch.content,
+		sdk: runtimeFileCurrentRevision(sdkPath),
+	});
+	if (openClawProviderPatchRevisions.get(context.configPath) === patchRevision) {
+		const expected = recordValue(JSON.parse(patch.content) as unknown);
+		if (!expected) throw new Error("OpenClaw provider projection patch must be an object");
+		if (openClawConfigPatchIsApplied(context, expected)) return;
+	}
 	runRuntimeUserCommand(
 		"node",
 		["--input-type=module", "--eval", OPENCLAW_CONFIG_MUTATION_HELPER, sdkPath],
@@ -541,6 +563,7 @@ function applyOpenClawHostedProviderPatch(
 		context.home,
 		workspaceRoot,
 	);
+	openClawProviderPatchRevisions.set(context.configPath, patchRevision);
 }
 export function buildOpenClawHostedProviderPatch(
 	projectionInput: HostedAiProviderProjectionInput | null,

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -6,8 +6,6 @@ import {
 	chownSync,
 	cpSync,
 	existsSync,
-	lchownSync,
-	lstatSync,
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
@@ -4199,7 +4197,7 @@ exit 0
 		expect(readlinkSync(commandPath)).toBe(commandTarget);
 	});
 
-	test("migrates legacy root-owned systemd files into the UID 10001 tenant tree", () => {
+	test("0.14.18 does not recursively chown tenant home and keeps tenant writes owned", () => {
 		const numericPrivilegeToolPath = ["/usr/bin/set", "priv"].join("");
 		if (process.geteuid?.() !== 0 || !existsSync(numericPrivilegeToolPath)) return;
 		const paths = tempRuntimePaths();
@@ -4207,45 +4205,17 @@ exit 0
 		const runtimeUid = 10_001;
 		const runtimeGid = 10_001;
 		const appRoot = join(paths.userHome, ".openclaw");
+		const localRoot = join(paths.userHome, ".local");
 		const binDir = join(paths.userHome, ".local", "bin");
 		const commandPath = join(binDir, "openclaw");
-		const gatewayEnvironment = join(appRoot, "gateway.systemd.env");
-		const unitPath = join(paths.systemdUserRoot, "openclaw-gateway.service");
-		const unitBackupPath = `${unitPath}.bak`;
-		const dropInPath = join(
-			paths.systemdUserRoot,
-			"openclaw-gateway.service.d",
-			"10-clawdi-hosted.conf",
-		);
-		const wantsRoot = join(paths.systemdUserRoot, "default.target.wants");
-		const enablementPath = join(wantsRoot, "openclaw-gateway.service");
-		const tenantOwnedPaths = [
-			appRoot,
-			binDir,
-			commandPath,
-			dirname(dirname(paths.systemdUserRoot)),
-			dirname(paths.systemdUserRoot),
-			wantsRoot,
-			paths.systemdUserRoot,
-			unitPath,
-			unitBackupPath,
-			gatewayEnvironment,
-			dirname(dropInPath),
-			dropInPath,
-		];
 		const skillProjectionLog = join(appRoot, "skill-projection-owners.log");
+		const rootOwnedSentinel = join(paths.userHome, "root-owned-sentinel");
 
 		chmodSync(fixtureRoot, 0o755);
 		mkdirSync(paths.userHome, { recursive: true });
-		chownSync(paths.userHome, runtimeUid, runtimeGid);
-		chmodSync(paths.userHome, 0o700);
 		mkdirSync(paths.clawdiHome, { recursive: true });
-		chownSync(paths.clawdiHome, runtimeUid, runtimeGid);
-		chmodSync(paths.clawdiHome, 0o700);
 		mkdirSync(binDir, { recursive: true });
 		mkdirSync(appRoot, { recursive: true });
-		mkdirSync(dirname(dropInPath), { recursive: true });
-		mkdirSync(wantsRoot, { recursive: true });
 		writeFileSync(
 			commandPath,
 			`#!/usr/bin/env bash
@@ -4258,42 +4228,26 @@ case "$*" in
   "agents list --json")
     printf '[{"id":"main","workspace":"%s"}]\\n' "$HOME/.openclaw/workspace"
     ;;
-			"skills install "*)
-			    : > '${skillProjectionLog}'
-			    ${tenantOwnedPaths.map((path) => `stat -c '%u:%g' '${path}' >> '${skillProjectionLog}'`).join("\n    ")}
+  "skills install "*)
+    printf '%s:%s\\n' "$(id -u)" "$(id -g)" > '${skillProjectionLog}'
     exit 45
-    ;;
-  "gateway install --force --json")
-    unit="$HOME/.config/systemd/user/\${OPENCLAW_SYSTEMD_UNIT:-openclaw-gateway.service}"
-    cp "$unit" "$unit.bak"
-    printf '%s\\n' '[Unit]' '[Service]' 'ExecStart=openclaw gateway run' > "$unit"
-    printf '%s\\n' 'OPENCLAW_OFFICIAL_USER_STATE=1' > "$HOME/.openclaw/gateway.systemd.env"
-    chmod 0600 "$HOME/.openclaw/gateway.systemd.env"
-    printf '{"ok":true}\\n'
     ;;
   *) exit 64 ;;
 esac
 `,
 		);
-		writeFileSync(unitPath, "[Unit]\nDescription=previous official unit\n");
-		writeFileSync(unitBackupPath, "previous official backup\n");
-		writeFileSync(dropInPath, "[Service]\nEnvironment=PREVIOUS=1\n");
-		symlinkSync("../openclaw-gateway.service", enablementPath);
-		writeFileSync(gatewayEnvironment, "PREVIOUS_OFFICIAL_STATE=1\n");
-		for (const path of [appRoot, binDir]) {
-			chownSync(path, 0, 0);
-			chmodSync(path, 0o700);
+		chmodSync(commandPath, 0o700);
+		for (const path of [
+			paths.userHome,
+			paths.clawdiHome,
+			localRoot,
+			binDir,
+			appRoot,
+			commandPath,
+		]) {
+			chownSync(path, runtimeUid, runtimeGid);
 		}
-		for (const path of tenantOwnedPaths) {
-			if (lstatSync(path).isSymbolicLink()) continue;
-			chownSync(path, 0, 0);
-			chmodSync(path, 0o700);
-		}
-		lchownSync(enablementPath, 0, 0);
-		chmodSync(unitPath, 0o600);
-		chmodSync(unitBackupPath, 0o600);
-		chmodSync(dropInPath, 0o600);
-		chmodSync(gatewayEnvironment, 0o600);
+		writeFileSync(rootOwnedSentinel, "preserve root ownership\n", { mode: 0o600 });
 
 		process.env.CLAWDI_RUNTIME_USER = "clawdi";
 		process.env.CLAWDI_RUNTIME_UID = String(runtimeUid);
@@ -4338,40 +4292,18 @@ esac
 		expect(result.resourceProjectionErrors.join("\n")).toContain(
 			"OpenClaw official Skill install failed: exit code 45 without output",
 		);
-		expect(readFileSync(skillProjectionLog, "utf8").trim().split("\n")).toEqual(
-			tenantOwnedPaths.map(() => `${runtimeUid}:${runtimeGid}`),
-		);
-		for (const path of [...tenantOwnedPaths, enablementPath]) {
-			const node = lstatSync(path);
-			expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
-		}
-		expect(statSync(appRoot).mode & 0o777).toBe(0o700);
-		expect(statSync(commandPath).mode & 0o777).toBe(0o700);
-		expect(statSync(gatewayEnvironment).mode & 0o777).toBe(0o600);
+		expect(readFileSync(skillProjectionLog, "utf8")).toBe(`${runtimeUid}:${runtimeGid}\n`);
+		expect([statSync(skillProjectionLog).uid, statSync(skillProjectionLog).gid]).toEqual([
+			runtimeUid,
+			runtimeGid,
+		]);
+		expect(readFileSync(rootOwnedSentinel, "utf8")).toBe("preserve root ownership\n");
+		expect([statSync(rootOwnedSentinel).uid, statSync(rootOwnedSentinel).gid]).toEqual([0, 0]);
+		expect(statSync(rootOwnedSentinel).mode & 0o777).toBe(0o600);
 		expect([statSync(paths.daemonAuthToken).uid, statSync(paths.daemonAuthToken).gid]).toEqual([
 			0, 0,
 		]);
 		expect(statSync(paths.daemonAuthToken).mode & 0o777).toBe(0o600);
-
-		const installed = convergeRuntimeManifest(
-			manifestLoad({ ...manifest, generation: 2 }, "root-openclaw-installer-boundary"),
-			paths,
-			{
-				hostedRuntimeContract,
-				systemdApply: {
-					activateEgressPrerequisite: successfulPrerequisiteActivation,
-					activate: () => {
-						return successfulPrerequisiteActivation();
-					},
-				},
-			},
-		);
-		expect(installed.installErrors).toEqual([]);
-		for (const path of [...tenantOwnedPaths, enablementPath]) {
-			const node = lstatSync(path);
-			expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
-		}
-		expect(statSync(gatewayEnvironment).mode & 0o777).toBe(0o600);
 	});
 
 	test("rejects a malformed Hermes MCP patch before Apply", () => {

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -708,6 +708,7 @@ function writeFakeGatewayCli(input: {
 	configPatchPath?: string;
 	failInstall?: boolean;
 	skillInstallSourceLog?: string;
+	commandLog?: string;
 }): void {
 	const home = dirname(dirname(dirname(input.path)));
 	mkdirSync(dirname(input.path), { recursive: true });
@@ -715,6 +716,7 @@ function writeFakeGatewayCli(input: {
 		input.path,
 		`#!/usr/bin/env bash
 set -euo pipefail
+${input.commandLog ? `printf '%s\\n' "$*" >> '${input.commandLog}'` : ""}
 case "$*" in
 	"--version")
 		printf '%s\\n' '${input.runtime === "openclaw" ? "OpenClaw test-version" : "Hermes test-version"}'
@@ -746,6 +748,17 @@ EOF
 	  "agents list --json")
 	    printf '[{"id":"main","workspace":"%s"}]\n' "$HOME/.openclaw/workspace"
 	    ;;
+	  "plugins inspect clawdi-managed-provider --json")
+	    test -f "$HOME/.openclaw/extensions/clawdi-managed-provider/openclaw.plugin.json" || exit 1
+	    printf '{"plugin":{"id":"clawdi-managed-provider","name":"Clawdi Managed Provider Metadata","source":"%s/.openclaw/extensions/clawdi-managed-provider/index.js","origin":"global","status":"loaded","version":"1.0.0","enabled":true},"mcpServers":[],"diagnostics":[],"install":{"source":"path","sourcePath":"%s/.openclaw/managed-sources/clawdi-managed-provider","installPath":"%s/.openclaw/extensions/clawdi-managed-provider"}}\n' "$HOME" "$HOME" "$HOME"
+	    ;;
+	  "plugins install "*" --force")
+	    rm -rf "$HOME/.openclaw/extensions/clawdi-managed-provider"
+	    mkdir -p "$HOME/.openclaw/extensions"
+	    cp -R "$3" "$HOME/.openclaw/extensions/clawdi-managed-provider"
+	    ;;
+	  "plugins enable clawdi-managed-provider")
+	    ;;
 	  "skills install "*)
 	    source_dir="$3"
 	    skill_id="$7"
@@ -767,7 +780,7 @@ esac
 	chmodSync(input.path, 0o700);
 }
 
-function writeFakeOpenClawConfigMutationSdk(home: string): string {
+function writeFakeOpenClawConfigMutationSdk(home: string, importLog?: string): string {
 	const packageRoot = join(home, ".local", "lib", "node_modules", "openclaw");
 	const configPath = join(home, ".openclaw", "openclaw.json");
 	mkdirSync(packageRoot, { recursive: true });
@@ -778,12 +791,21 @@ function writeFakeOpenClawConfigMutationSdk(home: string): string {
 		JSON.stringify({
 			name: "openclaw",
 			type: "module",
-			exports: { "./plugin-sdk/config-mutation": "./config-mutation.mjs" },
+			exports: {
+				"./plugin-sdk/config-mutation": "./config-mutation.mjs",
+				"./plugin-sdk/device-bootstrap": "./device-bootstrap.mjs",
+				"./plugin-sdk/provider-auth": "./provider-auth.mjs",
+				"./plugin-sdk/provider-env-vars": "./provider-env-vars.mjs",
+			},
 		}),
 	);
+	const logImport = (name: string) =>
+		importLog
+			? `import { appendFileSync } from "node:fs"; appendFileSync(${JSON.stringify(importLog)}, ${JSON.stringify(`${name}\n`)});\n`
+			: "";
 	writeFileSync(
 		join(packageRoot, "config-mutation.mjs"),
-		`import { readFileSync, writeFileSync } from "node:fs";
+		`${logImport("config-mutation")}import { readFileSync, writeFileSync } from "node:fs";
 const configPath = ${JSON.stringify(configPath)};
 export async function readConfigFileSnapshotForWrite() {
   const config = JSON.parse(readFileSync(configPath, "utf8"));
@@ -795,6 +817,22 @@ export async function mutateConfigFile(options) {
   writeFileSync(configPath, JSON.stringify(config, null, 2) + "\\n");
 }
 `,
+	);
+	writeFileSync(
+		join(packageRoot, "device-bootstrap.mjs"),
+		`${logImport("device-bootstrap")}export const normalizeDeviceBootstrapProfile = (profile) => profile;\n`,
+	);
+	writeFileSync(
+		join(packageRoot, "provider-auth.mjs"),
+		`${logImport("provider-auth")}export const ensureAuthProfileStoreForLocalUpdate = () => ({ profiles: {} });
+export const updateAuthProfileStoreWithLock = async () => ({});
+export const listProfilesForProvider = () => [];
+export const removeProviderAuthProfilesWithLock = async () => ({});
+`,
+	);
+	writeFileSync(
+		join(packageRoot, "provider-env-vars.mjs"),
+		`${logImport("provider-env-vars")}export const listKnownProviderAuthEnvVarNames = () => ["CLAWDI_AI_API_KEY"];\n`,
 	);
 	return configPath;
 }
@@ -2544,6 +2582,167 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(envFile).toContain('CLAWDI_AI_API_KEY="clawdi-egress-placeholder"');
 		expect(envFile).not.toMatch(/^OPENAI_API_KEY=/m);
 		expect(envFile).not.toContain("sk-managed");
+	});
+
+	test("reuses OpenClaw probes until the provider revision changes", () => {
+		const paths = tempRuntimePaths();
+		const commandLog = join(paths.serviceStateRoot, "openclaw-probe-commands.log");
+		const sdkLog = join(paths.serviceStateRoot, "openclaw-probe-sdk.log");
+		const configPath = writeFakeOpenClawConfigMutationSdk(paths.userHome, sdkLog);
+		writeFakeGatewayCli({
+			path: join(paths.userHome, ".local", "bin", "openclaw"),
+			runtime: "openclaw",
+			unitPath: join(paths.systemdUserRoot, "openclaw-gateway.service"),
+			commandLog,
+		});
+		const egressEngine = installCachedTestEgressEngine(paths, "12.2.3-test-probe-cache");
+		const manifestFor = (baseUrl: string, generation: number): RuntimeManifest => ({
+			...hostedRuntimeBundleV2ManifestSchema.parse(
+				hostedManifestFixture({
+					generation,
+					issuedAt: `2026-07-11T00:00:0${generation}.000Z`,
+					providers: {
+						clawdi: {
+							kind: "openai-compatible",
+							type: "custom_openai_compatible",
+							managed_by: "clawdi",
+							baseUrl,
+							apiMode: "openai_responses",
+							models: [{ id: "gpt-test" }],
+							runtimeEnvName: "CLAWDI_AI_API_KEY",
+							apiKeySecretRef: "secret://providers/clawdi/api-key",
+						},
+					},
+					runtimes: {
+						openclaw: hostedRuntimeFixture({
+							provider_ids: ["clawdi"],
+							primary_model: { provider_id: "clawdi", model: "gpt-test" },
+						}),
+					},
+				}),
+			),
+			egressEngine,
+		});
+		const secrets = {
+			...TEST_HOSTED_SECRET_VALUES,
+			"secret://providers/clawdi/api-key": "sk-managed",
+		};
+		const converge = (manifest: RuntimeManifest, opts: RuntimeConvergenceOptions = {}) =>
+			convergeRuntimeManifest(
+				manifestLoad(manifest, `provider-${manifest.generation}`, secrets),
+				paths,
+				opts,
+			);
+		const callCounts = (calls: string[]) =>
+			Object.fromEntries(
+				[...new Set(calls)].map((call) => [
+					call,
+					calls.filter((candidate) => candidate === call).length,
+				]),
+			);
+		const hotspotCounts = () =>
+			callCounts(
+				readFileSync(commandLog, "utf8")
+					.trim()
+					.split("\n")
+					.filter(
+						(command) =>
+							command === "agents list --json" ||
+							command === "plugins inspect clawdi-managed-provider --json",
+					),
+			);
+		const sdkCounts = () => callCounts(readFileSync(sdkLog, "utf8").trim().split("\n"));
+
+		expect(converge(manifestFor("https://provider.example.test/v1", 1)).installErrors).toEqual([]);
+		const firstHotspots = hotspotCounts();
+		const firstSdkCalls = sdkCounts();
+		for (const hotspot of [
+			"agents list --json",
+			"plugins inspect clawdi-managed-provider --json",
+		]) {
+			expect(firstHotspots[hotspot]).toBeGreaterThan(0);
+		}
+		for (const sdk of [
+			"device-bootstrap",
+			"provider-auth",
+			"config-mutation",
+			"provider-env-vars",
+		]) {
+			expect(firstSdkCalls[sdk]).toBeGreaterThan(0);
+		}
+
+		expect(converge(manifestFor("https://provider.example.test/v1", 1)).installErrors).toEqual([]);
+		expect(hotspotCounts()).toEqual(firstHotspots);
+		expect(sdkCounts()).toEqual(firstSdkCalls);
+
+		const driftedConfig = JSON.parse(readFileSync(configPath, "utf8")) as Record<string, unknown>;
+		const driftedModels = driftedConfig.models as Record<string, unknown>;
+		const driftedProviders = driftedModels.providers as Record<string, unknown>;
+		delete driftedProviders.clawdi;
+		writeFileSync(configPath, `${JSON.stringify(driftedConfig, null, 2)}\n`);
+		expect(converge(manifestFor("https://provider.example.test/v1", 1)).installErrors).toEqual([]);
+		expect(
+			(
+				(JSON.parse(readFileSync(configPath, "utf8")) as Record<string, unknown>).models as Record<
+					string,
+					Record<string, unknown>
+				>
+			).providers.clawdi,
+		).toBeDefined();
+		expect(hotspotCounts()).toEqual(firstHotspots);
+		const repairedProviderSdkCalls = sdkCounts();
+		expect(repairedProviderSdkCalls["config-mutation"]).toBeGreaterThan(
+			firstSdkCalls["config-mutation"] ?? 0,
+		);
+
+		const managedProviderInstallDir = join(
+			paths.userHome,
+			".openclaw",
+			"extensions",
+			"clawdi-managed-provider",
+		);
+		rmSync(managedProviderInstallDir, { recursive: true });
+		expect(converge(manifestFor("https://provider.example.test/v1", 1)).installErrors).toEqual([]);
+		expect(existsSync(managedProviderInstallDir)).toBe(false);
+		expect(hotspotCounts()).toEqual(firstHotspots);
+		expect(
+			converge(manifestFor("https://provider.example.test/v1", 1), {
+				refreshCachedRuntimeProbes: true,
+			}).installErrors,
+		).toEqual([]);
+		expect(existsSync(join(managedProviderInstallDir, "openclaw.plugin.json"))).toBe(true);
+		const selfHealedHotspots = hotspotCounts();
+		expect(selfHealedHotspots["plugins inspect clawdi-managed-provider --json"]).toBeGreaterThan(
+			firstHotspots["plugins inspect clawdi-managed-provider --json"] ?? 0,
+		);
+
+		const rosterConfig = JSON.parse(readFileSync(configPath, "utf8")) as Record<string, unknown>;
+		const agents = rosterConfig.agents as Record<string, unknown>;
+		agents.list = [{ id: "research", agentDir: join(paths.userHome, "research-agent") }];
+		writeFileSync(configPath, `${JSON.stringify(rosterConfig, null, 2)}\n`);
+		const beforeRosterChange = sdkCounts();
+		expect(converge(manifestFor("https://provider.example.test/v1", 1)).installErrors).toEqual([]);
+		expect(hotspotCounts()["agents list --json"]).toBeGreaterThan(
+			selfHealedHotspots["agents list --json"] ?? 0,
+		);
+		const afterRosterChange = sdkCounts();
+		expect(afterRosterChange["provider-auth"]).toBeGreaterThan(
+			beforeRosterChange["provider-auth"] ?? 0,
+		);
+		const rosterChangedHotspots = hotspotCounts();
+
+		expect(converge(manifestFor("https://provider-v2.example.test/v1", 2)).installErrors).toEqual(
+			[],
+		);
+		const revisedHotspots = hotspotCounts();
+		expect(revisedHotspots["agents list --json"]).toBe(rosterChangedHotspots["agents list --json"]);
+		expect(revisedHotspots["plugins inspect clawdi-managed-provider --json"]).toBeGreaterThan(
+			firstHotspots["plugins inspect clawdi-managed-provider --json"] ?? 0,
+		);
+		const revisedSdkCalls = sdkCounts();
+		for (const [sdk, count] of Object.entries(firstSdkCalls)) {
+			expect(revisedSdkCalls[sdk]).toBeGreaterThan(count);
+		}
 	});
 
 	test("replaces the selected Hermes provider with secret refs and stale cleanup", () => {

--- a/packages/cli/src/runtime/manifest-runtime-config.ts
+++ b/packages/cli/src/runtime/manifest-runtime-config.ts
@@ -3,14 +3,12 @@ import { join } from "node:path";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import {
 	getHermesRawConfigValue,
-	type HermesConfigCommandContext,
+	type HermesConfigTransaction,
 	reconcileHermesConfigValue,
 } from "./hermes-config";
 import { mergeRuntimeEnvWithProviderPlaceholders } from "./hosted-provider-resolution";
 import type { RuntimeManifest } from "./manifest-contract";
-import type { RuntimeInstallObservation } from "./manifest-install";
 import type { RuntimeName, RuntimeRunSettings, RuntimeServiceName } from "./run-config";
-import { executableExists } from "./runtime-user-command";
 
 const MANAGED_LOCALE_BLOCK_START = "<!-- >>> clawdi managed locale >>>";
 const MANAGED_LOCALE_BLOCK_END = "<!-- <<< clawdi managed locale <<< -->";
@@ -65,18 +63,8 @@ function updateManagedLocaleFile(path: string, block: string): string {
 	writePrivateFileAtomic(path, next, { mode: 0o600, dirMode: 0o700 });
 	return path;
 }
-export function hermesConfigContext(
-	observation: RuntimeInstallObservation,
-	home: string,
-	cwd: string,
-): HermesConfigCommandContext {
-	if (!observation.commandPath || !executableExists(observation.commandPath)) {
-		throw new Error("Hermes config command is unavailable");
-	}
-	return { command: observation.commandPath, home, cwd };
-}
 function applyHermesDashboardConfig(
-	context: HermesConfigCommandContext,
+	context: HermesConfigTransaction,
 	auth: NonNullable<RuntimeManifest["hermesDashboardAuth"]>,
 ): void {
 	reconcileHermesConfigValue(context, "dashboard.basic_auth", {
@@ -103,11 +91,11 @@ function applyHermesDashboardConfig(
 }
 export function applyHostedRuntimeConfigProjection(
 	runtime: string,
-	observation: RuntimeInstallObservation,
 	manifest: RuntimeManifest,
 	home: string,
 	openClawWorkspaceRoot: string | null,
 	workspaceRoot: string,
+	hermesConfig: HermesConfigTransaction | null,
 ): string | null {
 	if (manifest.runtimes[runtime]?.enabled !== true) return null;
 	const locale = manifest.locale;
@@ -118,12 +106,12 @@ export function applyHostedRuntimeConfigProjection(
 			: null;
 	}
 	if (runtime === "hermes") {
+		if (!hermesConfig) throw new Error("Hermes config command is unavailable");
 		const auth = manifest.hermesDashboardAuth;
-		const context = hermesConfigContext(observation, home, workspaceRoot);
 		const hermesHome = join(home, ".hermes");
-		reconcileHermesConfigValue(context, "terminal.cwd", workspaceRoot);
-		if (auth) applyHermesDashboardConfig(context, auth);
-		if (locale) reconcileHermesConfigValue(context, "timezone", locale.timezone);
+		reconcileHermesConfigValue(hermesConfig, "terminal.cwd", workspaceRoot);
+		if (auth) applyHermesDashboardConfig(hermesConfig, auth);
+		if (locale) reconcileHermesConfigValue(hermesConfig, "timezone", locale.timezone);
 		return locale
 			? updateManagedLocaleFile(join(hermesHome, "SOUL.md"), managedLocaleBlock(locale))
 			: null;

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -20,6 +20,8 @@ import {
 	type RuntimeConvergenceOptions,
 	type RuntimeManifest,
 } from "./manifest";
+import { OFFICIAL_INSTALL_URLS, officialInstallArgs } from "./manifest-contract";
+import { observeRuntimeInstall, runtimeCommandCurrentRevision } from "./manifest-install";
 import { manifestSecretRefs, type RuntimeManifestLoad } from "./manifest-source";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
@@ -35,6 +37,74 @@ const TEST_RUNTIME_USER = String(TEST_PROCESS_UID);
 const HERMES_CONFIG_CLI_MOCK = fileURLToPath(
 	new URL("../test-support/hermes-config-cli-mock.ts", import.meta.url),
 );
+
+test("reuses a runtime version until its executable revision changes", () => {
+	const paths = tempRuntimePaths();
+	mkdirSync(paths.runRoot, { recursive: true });
+	mkdirSync(paths.userHome, { recursive: true });
+	const command = join(paths.runRoot, "versioned-runtime");
+	const log = join(paths.runRoot, "version-probes.log");
+	const writeCommand = (version: string) => {
+		writeFileSync(
+			command,
+			`#!/bin/sh
+printf '%s\n' "$*" >> '${log}'
+printf '%s\n' '${version}'
+`,
+			{ mode: 0o755 },
+		);
+	};
+	writeCommand("runtime 1.0.0");
+
+	const first = runtimeCommandCurrentRevision(command, paths.userHome, paths.userHome);
+	expect(runtimeCommandCurrentRevision(command, paths.userHome, paths.userHome)).toBe(first);
+	expect(readFileSync(log, "utf8").trim().split("\n")).toEqual(["--version"]);
+
+	writeCommand("runtime 1.0.1");
+	const revised = runtimeCommandCurrentRevision(command, paths.userHome, paths.userHome);
+	expect(revised).not.toBe(first);
+	expect(readFileSync(log, "utf8").trim().split("\n")).toEqual(["--version", "--version"]);
+});
+
+test("reuses the Hermes dashboard capability until its service revision changes", () => {
+	const paths = tempRuntimePaths();
+	mkdirSync(paths.runRoot, { recursive: true });
+	const command = join(paths.userHome, ".local", "bin", "hermes");
+	const python = join(paths.userHome, ".hermes", "hermes-agent", "venv", "bin", "python");
+	const log = join(paths.runRoot, "dashboard-capability.log");
+	for (const executable of [command, python]) {
+		mkdirSync(dirname(executable), { recursive: true });
+		writeFileSync(executable, `#!/bin/sh\nprintf '%s\\n' "$*" >> '${log}'\n`, {
+			mode: 0o755,
+		});
+	}
+	const runtime: RuntimeManifest["runtimes"][string] = {
+		enabled: true,
+		install: {
+			authority: "official",
+			method: "official-installer",
+			url: OFFICIAL_INSTALL_URLS.hermes,
+			home: paths.userHome,
+			args: officialInstallArgs("hermes", paths.userHome),
+		},
+		services: { dashboard: runSettings(command, ["dashboard"]) },
+	};
+	const observe = (revision: string) =>
+		observeRuntimeInstall(
+			"hermes",
+			runtime,
+			paths.userHome,
+			paths,
+			{ uid: TEST_PROCESS_UID, gid: TEST_PROCESS_GID },
+			revision,
+		);
+
+	expect(observe("a".repeat(64)).error).toBeNull();
+	expect(observe("a".repeat(64)).error).toBeNull();
+	expect(readFileSync(log, "utf8").trim().split("\n")).toHaveLength(1);
+	expect(observe("b".repeat(64)).error).toBeNull();
+	expect(readFileSync(log, "utf8").trim().split("\n")).toHaveLength(2);
+});
 
 function convergeRuntimeManifest(
 	load: RuntimeManifestLoad,

--- a/packages/cli/src/runtime/manifest-shared.ts
+++ b/packages/cli/src/runtime/manifest-shared.ts
@@ -17,6 +17,7 @@ export interface RuntimeConvergenceResult {
 	resourceProjectionErrors: string[];
 	projectedProviderIds: Record<string, string[]>;
 	agentPluginFailedNames: string[];
+	deferredReason?: "hermes_config_conflict";
 	outputs: {
 		processManager: "systemd";
 		workspaceRoot: string;

--- a/packages/cli/src/runtime/observation-producer.test.ts
+++ b/packages/cli/src/runtime/observation-producer.test.ts
@@ -521,6 +521,45 @@ describe("hosted runtime observation producer", () => {
 		]);
 	});
 
+	test("reports a successful converge without waiting for the steady cadence", async () => {
+		const paths = tempRuntimePaths();
+		writeApplyIdentityFile(paths, 1);
+		writeRuntimeAppliedState(appliedState(1), paths);
+		writeObservationHealth(paths, "ok");
+		const abort = new AbortController();
+		const attempts: number[] = [];
+		let clock = 0;
+
+		await runRuntimeObservationProducer({
+			abort: abort.signal,
+			paths,
+			contextPath: runtimeContextPath(paths),
+			submit: async () => {
+				attempts.push(clock);
+				if (attempts.length === 2) abort.abort();
+				return "accepted";
+			},
+			now: () => clock,
+			delay: async (ms) => {
+				await Promise.resolve();
+				await Promise.resolve();
+				await Promise.resolve();
+				clock += ms;
+				if (attempts.length === 1) {
+					writeFileSync(
+						paths.runtimeWatchStatus,
+						JSON.stringify({
+							timestamp: "2026-07-22T00:01:00.000Z",
+							event: { status: "applied" },
+						}),
+					);
+				}
+			},
+		});
+
+		expect(attempts).toEqual([0, 1_000]);
+	});
+
 	test.each([
 		[
 			"bounds non-ok fast observations to ninety seconds",

--- a/packages/cli/src/runtime/observation-producer.ts
+++ b/packages/cli/src/runtime/observation-producer.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { ApiClient, unwrap } from "../lib/api-client";
 import { log, toErrorMessage } from "../serve/log";
 import { readRuntimeAppliedState, runtimeAppliedApplyIdentity } from "./applied-state";
@@ -48,6 +49,7 @@ interface AttestedRuntimeObservationContext {
 interface ObservationSchedule {
 	nextAttemptAt: number;
 	convergenceWindowEnd: number | "closed" | null;
+	lastAttemptedAppliedReceipt: string | null;
 }
 
 export class HostedRuntimeObservationProducer {
@@ -184,12 +186,18 @@ export async function runRuntimeObservationProducer(
 			pruneRetiredIdentityEntries(activeAttempts, identityKey);
 			pruneRetiredIdentityEntries(schedules, identityKey);
 			if (identityKey && !activeAttempts.has(identityKey)) {
+				const appliedReceipt = readRuntimeWatchAppliedReceipt(paths);
 				const schedule = schedules.get(identityKey) ?? {
 					nextAttemptAt: 0,
 					convergenceWindowEnd: null,
+					lastAttemptedAppliedReceipt: null,
 				};
 				schedules.set(identityKey, schedule);
-				if (now() >= schedule.nextAttemptAt) {
+				if (
+					now() >= schedule.nextAttemptAt ||
+					(appliedReceipt !== null && appliedReceipt !== schedule.lastAttemptedAppliedReceipt)
+				) {
+					schedule.lastAttemptedAppliedReceipt = appliedReceipt;
 					const attempt = producer.sendOnce().then((result) => {
 						const completedAt = now();
 						let interval = OBSERVATION_INTERVAL_MS;
@@ -219,6 +227,22 @@ export async function runRuntimeObservationProducer(
 			log.info("daemon.runtime_observation_failed", { error: toErrorMessage(error) });
 		}
 		await delay(IDLE_RETRY_INTERVAL_MS, options.abort);
+	}
+}
+
+function readRuntimeWatchAppliedReceipt(paths: RuntimePaths): string | null {
+	let content: string;
+	try {
+		content = readFileSync(paths.runtimeWatchStatus, "utf-8");
+	} catch {
+		return null;
+	}
+	try {
+		const status: unknown = JSON.parse(content);
+		if (!isUnknownRecord(status) || !isUnknownRecord(status.event)) return null;
+		return status.event.status === "applied" ? content : null;
+	} catch {
+		return null;
 	}
 }
 

--- a/packages/cli/src/runtime/openclaw-managed-provider-plugin.ts
+++ b/packages/cli/src/runtime/openclaw-managed-provider-plugin.ts
@@ -9,6 +9,7 @@ import {
 	CLAWDI_MANAGED_OPENCLAW_PROVIDER_PLUGIN_ID,
 	type OpenClawHostedContext,
 } from "./hosted-openclaw-context";
+import { runtimeFileCurrentRevision } from "./manifest-install";
 import { openClawPluginInspectSchema } from "./openclaw-plugin-observation";
 import { spawnRuntimeUserCommand } from "./runtime-user-command";
 
@@ -16,6 +17,7 @@ export { CLAWDI_MANAGED_OPENCLAW_PROVIDER_PLUGIN_ID } from "./hosted-openclaw-co
 
 const PLUGIN_VERSION = "1.0.0";
 const COMMAND_TIMEOUT_MS = 120_000;
+const managedProviderPluginRevisions = new Map<string, string>();
 const managedOpenClawPluginInspectSchema = openClawPluginInspectSchema.extend({
 	install: openClawPluginInspectSchema.shape.install.optional(),
 });
@@ -230,8 +232,20 @@ function requireManagedOpenClawProviderMarker(context: OpenClawHostedContext): v
 export function ensureManagedOpenClawProviderPlugin(input: {
 	context: OpenClawHostedContext;
 	commandPath: string;
+	revision: string;
+	refreshCachedRuntimeProbes?: boolean;
 }): void {
 	const sourceDir = materializePluginSource(input.context);
+	const probeRevision = [
+		input.revision,
+		runtimeFileCurrentRevision(input.commandPath),
+		runtimeFileCurrentRevision(input.context.requireSdkExport("providerEnvVars")),
+	].join("\0");
+	if (
+		!input.refreshCachedRuntimeProbes &&
+		managedProviderPluginRevisions.get(input.context.home) === probeRevision
+	)
+		return;
 	let observation = inspectPlugin(input.commandPath, input.context.home);
 	if (
 		observation &&
@@ -241,6 +255,7 @@ export function ensureManagedOpenClawProviderPlugin(input: {
 	) {
 		try {
 			requireManagedOpenClawProviderMarker(input.context);
+			managedProviderPluginRevisions.set(input.context.home, probeRevision);
 			return;
 		} catch {
 			observation = null;
@@ -288,4 +303,5 @@ export function ensureManagedOpenClawProviderPlugin(input: {
 		);
 	}
 	requireManagedOpenClawProviderMarker(input.context);
+	managedProviderPluginRevisions.set(input.context.home, probeRevision);
 }

--- a/packages/cli/src/runtime/runtime-impact-revision.ts
+++ b/packages/cli/src/runtime/runtime-impact-revision.ts
@@ -59,6 +59,26 @@ export function runtimeImpactRevision(value: unknown): string {
 		.slice(0, 32);
 }
 
+export function runtimeProviderRevision(manifest: RuntimeManifest, runtimeName: string): string {
+	const runtime = manifest.runtimes[runtimeName];
+	const providerIds = runtime?.provider_ids ?? [];
+	const providers = manifest.projection?.providers ?? {};
+	return runtimeImpactRevision({
+		runtime: runtime
+			? {
+					providerMode: runtime.providerMode ?? null,
+					provider_ids: providerIds,
+					primary_model: runtime.primary_model ?? null,
+				}
+			: null,
+		providers: Object.fromEntries(
+			providerIds
+				.filter((providerId) => Object.hasOwn(providers, providerId))
+				.map((providerId) => [providerId, providers[providerId]]),
+		),
+	});
+}
+
 export function runtimeProgramRevision(input: RuntimeProgramRevisionInput): string {
 	const runtime = input.desiredRuntime
 		? Object.fromEntries(

--- a/packages/cli/src/runtime/runtime-user-command.test.ts
+++ b/packages/cli/src/runtime/runtime-user-command.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -8,7 +16,9 @@ import {
 	clearTenantToolLocationOverrides,
 	commandExists,
 	createPrivilegeDropResolver,
+	resolveRuntimeUserIdentity,
 	runRuntimeUserCommand,
+	runtimeUserGid,
 	runtimeUserUid,
 	spawnRuntimeUserCommand,
 	withRuntimeUserFileAccess,
@@ -17,6 +27,57 @@ import {
 test("command existence follows shell resolution", () => {
 	expect(commandExists("command")).toBe(true);
 	expect(commandExists("clawdi-command-that-does-not-exist")).toBe(false);
+});
+
+test("resolves each runtime user identity once per process", () => {
+	const root = mkdtempSync(join(tmpdir(), "runtime-user-id-cache-"));
+	const bin = join(root, "bin");
+	const command = join(bin, "id");
+	const log = join(root, "id.log");
+	const previousPath = process.env.PATH;
+	const previousUid = process.env.CLAWDI_RUNTIME_UID;
+	const previousGid = process.env.CLAWDI_RUNTIME_GID;
+	const firstUser = `runtime-a-${root.split("-").at(-1)}`;
+	const secondUser = `runtime-b-${root.split("-").at(-1)}`;
+	try {
+		mkdirSync(bin, { recursive: true });
+		writeFileSync(
+			command,
+			`#!/bin/sh
+printf '%s %s\n' "$1" "$2" >> '${log}'
+case "$1" in
+  -u) printf '12345\n' ;;
+  -g) printf '23456\n' ;;
+  *) exit 64 ;;
+esac
+`,
+			{ mode: 0o755 },
+		);
+		process.env.PATH = `${bin}:/usr/bin:/bin`;
+		delete process.env.CLAWDI_RUNTIME_UID;
+		delete process.env.CLAWDI_RUNTIME_GID;
+
+		expect(resolveRuntimeUserIdentity(firstUser)).toEqual({ uid: 12345, gid: 23456 });
+		expect(resolveRuntimeUserIdentity(firstUser)).toEqual({ uid: 12345, gid: 23456 });
+		expect(runtimeUserUid(firstUser)).toBe(12345);
+		expect(runtimeUserGid(firstUser)).toBe(23456);
+		expect(resolveRuntimeUserIdentity(secondUser)).toEqual({ uid: 12345, gid: 23456 });
+
+		expect(readFileSync(log, "utf8").trim().split("\n")).toEqual([
+			`-u ${firstUser}`,
+			`-g ${firstUser}`,
+			`-u ${secondUser}`,
+			`-g ${secondUser}`,
+		]);
+	} finally {
+		if (previousPath === undefined) delete process.env.PATH;
+		else process.env.PATH = previousPath;
+		if (previousUid === undefined) delete process.env.CLAWDI_RUNTIME_UID;
+		else process.env.CLAWDI_RUNTIME_UID = previousUid;
+		if (previousGid === undefined) delete process.env.CLAWDI_RUNTIME_GID;
+		else process.env.CLAWDI_RUNTIME_GID = previousGid;
+		rmSync(root, { recursive: true, force: true });
+	}
 });
 
 test("tenant tools inherit HOME but not platform location overrides", () => {

--- a/packages/cli/src/runtime/runtime-user-command.test.ts
+++ b/packages/cli/src/runtime/runtime-user-command.test.ts
@@ -1,15 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import {
-	chmodSync,
-	lstatSync,
-	mkdirSync,
-	mkdtempSync,
-	readFileSync,
-	rmSync,
-	statSync,
-	symlinkSync,
-	writeFileSync,
-} from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -18,9 +8,7 @@ import {
 	clearTenantToolLocationOverrides,
 	commandExists,
 	createPrivilegeDropResolver,
-	ensureRuntimeUserHomeOwnership,
 	runRuntimeUserCommand,
-	runtimeUserGid,
 	runtimeUserUid,
 	spawnRuntimeUserCommand,
 	withRuntimeUserFileAccess,
@@ -382,43 +370,6 @@ test("fully drops root identity when spawned during runtime-user file access", (
 	} finally {
 		if (previousRuntimeUser === undefined) delete process.env.CLAWDI_RUNTIME_USER;
 		else process.env.CLAWDI_RUNTIME_USER = previousRuntimeUser;
-		rmSync(root, { recursive: true, force: true });
-	}
-});
-
-test("migrates a legacy root-owned tenant home without following symlinks", () => {
-	if (process.geteuid?.() !== 0) return;
-	const root = mkdtempSync(join(tmpdir(), "runtime-user-home-migration-"));
-	const home = join(root, "home");
-	const systemdRoot = join(home, ".config", "systemd", "user");
-	const unit = join(systemdRoot, "hermes-gateway.service");
-	const outside = join(root, "platform-state");
-	const outsideLink = join(home, "platform-link");
-	try {
-		mkdirSync(systemdRoot, { recursive: true, mode: 0o700 });
-		writeFileSync(unit, "legacy\n", { mode: 0o600 });
-		writeFileSync(outside, "preserve\n", { mode: 0o600 });
-		symlinkSync(outside, outsideLink);
-		const identity = { uid: runtimeUserUid("nobody"), gid: runtimeUserGid("nobody") };
-
-		ensureRuntimeUserHomeOwnership(home, identity);
-
-		for (const path of [
-			home,
-			join(home, ".config"),
-			join(home, ".config", "systemd"),
-			systemdRoot,
-			unit,
-			outsideLink,
-		]) {
-			const node = lstatSync(path);
-			expect([node.uid, node.gid]).toEqual([identity.uid, identity.gid]);
-		}
-		expect(statSync(systemdRoot).mode & 0o777).toBe(0o700);
-		expect(statSync(unit).mode & 0o777).toBe(0o600);
-		expect([statSync(outside).uid, statSync(outside).gid]).toEqual([0, 0]);
-		expect(readFileSync(outside, "utf8")).toBe("preserve\n");
-	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
 });

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { accessSync, chownSync, constants, lstatSync, mkdirSync } from "node:fs";
+import { accessSync, chownSync, constants } from "node:fs";
 import { isAbsolute, join } from "node:path";
 import { withEffectiveFilesystemIdentity } from "./effective-identity";
 import { applyEgressTransparentRuntimeEnv } from "./egress-env";
@@ -368,20 +368,6 @@ export function runtimeEgressGid(): number {
 function positiveLinuxIdEnv(key: string, fallback: number): number {
 	const raw = process.env[key]?.trim();
 	return raw ? parsePositiveLinuxId(raw, key) : fallback;
-}
-
-export function ensureRuntimeUserHomeOwnership(path: string, identity: RuntimeUserIdentity): void {
-	mkdirSync(path, { recursive: true });
-	const node = lstatSync(path);
-	if (!node.isDirectory() || node.isSymbolicLink()) {
-		throw new Error(`runtime-user home must be a real directory: ${path}`);
-	}
-	if (!runningAsRoot()) return;
-	if (identity.uid === 0 || identity.gid === 0) {
-		throw new Error("runtime user resolved to a root filesystem identity");
-	}
-	// SUNSET: remove after all 0.13.92/0.14.14 hosts have migrated their root-owned tenant trees.
-	execFileSync("chown", ["-hR", "-P", `${identity.uid}:${identity.gid}`, "--", path]);
 }
 
 export function makeRuntimeUserOwned(path: string): void {

--- a/packages/cli/src/runtime/runtime-user-command.ts
+++ b/packages/cli/src/runtime/runtime-user-command.ts
@@ -8,6 +8,8 @@ import { parsePositiveLinuxId } from "./transparent-egress";
 
 const RUNTIME_IDENTITY_PROBE_TIMEOUT_MS = 5_000;
 const DEFAULT_SYSTEM_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+const runtimeUserUids = new Map<string, number>();
+const runtimeUserGids = new Map<string, number>();
 
 export interface RuntimeUserIdentity {
 	uid: number;
@@ -232,10 +234,15 @@ export function runtimeUserUid(runtimeUser: string): number {
 	if (explicit !== null) return explicit;
 	const numericUser = linuxUid(runtimeUser);
 	if (numericUser !== null) return numericUser;
+	const cached = runtimeUserUids.get(runtimeUser);
+	if (cached !== undefined) return cached;
 	const resolved = spawnSync("id", ["-u", runtimeUser], { encoding: "utf8" });
 	if (resolved.status === 0) {
 		const uid = linuxUid(resolved.stdout.trim());
-		if (uid !== null) return uid;
+		if (uid !== null) {
+			runtimeUserUids.set(runtimeUser, uid);
+			return uid;
+		}
 	}
 	if (runtimeUser === "clawdi") return 10_001;
 	throw new Error(`could not resolve uid for ${runtimeUser}`);
@@ -248,6 +255,9 @@ function linuxUid(value: string): number | null {
 }
 
 function strictRuntimeUserId(runtimeUser: string, kind: "uid" | "gid"): number {
+	const cache = kind === "uid" ? runtimeUserUids : runtimeUserGids;
+	const cached = cache.get(runtimeUser);
+	if (cached !== undefined) return cached;
 	const flag = kind === "uid" ? "-u" : "-g";
 	const resolved = spawnSync("id", [flag, runtimeUser], {
 		encoding: "utf8",
@@ -266,6 +276,7 @@ function strictRuntimeUserId(runtimeUser: string, kind: "uid" | "gid"): number {
 	if (parsed === null) {
 		throw new Error(`runtime user ${runtimeUser} resolved an invalid ${kind}`);
 	}
+	cache.set(runtimeUser, parsed);
 	return parsed;
 }
 
@@ -348,10 +359,15 @@ export function clearTenantToolLocationOverrides(env: NodeJS.ProcessEnv): void {
 export function runtimeUserGid(runtimeUser: string): number {
 	const explicit = linuxUid(process.env.CLAWDI_RUNTIME_GID?.trim() ?? "");
 	if (explicit !== null) return explicit;
+	const cached = runtimeUserGids.get(runtimeUser);
+	if (cached !== undefined) return cached;
 	const resolved = spawnSync("id", ["-g", runtimeUser], { encoding: "utf8" });
 	if (resolved.status === 0) {
 		const gid = linuxUid(resolved.stdout.trim());
-		if (gid !== null) return gid;
+		if (gid !== null) {
+			runtimeUserGids.set(runtimeUser, gid);
+			return gid;
+		}
 	}
 	if (runtimeUser === "clawdi") return 10_001;
 	throw new Error(`could not resolve runtime gid for ${runtimeUser}`);

--- a/packages/cli/src/runtime/state.ts
+++ b/packages/cli/src/runtime/state.ts
@@ -268,7 +268,6 @@ export function ensureRuntimeStateDirs(paths = getRuntimePaths()): void {
 		if (platformRoot) ensureDirectoryWithinTrustedRoot(platformRoot, dir, { mode });
 		else assertTrustedDirectory(dir, "systemd platform directory");
 	}
-	mkdirSync(paths.systemdUserRoot, { recursive: true });
 	assertRuntimePlatformRoots(paths);
 }
 

--- a/packages/cli/src/runtime/systemd-transaction.ts
+++ b/packages/cli/src/runtime/systemd-transaction.ts
@@ -286,6 +286,41 @@ export function applySystemdRuntimeUpdate(
 	if (restartUserUnits.length > 0) {
 		runtimeUserSystemctl(paths, ["restart", ...restartUserUnits]);
 	}
+	if (
+		!activationChanged &&
+		system.present.every((unit) => {
+			const state = requiredSystemdUnitState(systemStates, "system", unit);
+			return (
+				state.loadState !== "not-found" &&
+				state.activeState === "active" &&
+				!state.needDaemonReload &&
+				systemdUnitEnabled(state)
+			);
+		}) &&
+		user.present.every((unit) => {
+			const state = requiredSystemdUnitState(userStates, "user", unit);
+			return (
+				state.loadState !== "not-found" &&
+				state.activeState === "active" &&
+				!state.needDaemonReload &&
+				systemdUnitEnabled(state)
+			);
+		})
+	) {
+		return {
+			applied: true,
+			activated: Object.fromEntries(
+				[
+					...system.present.filter((unit) => !NON_TRANSACTIONAL_SYSTEM_UNITS.has(unit)),
+					...user.present,
+				]
+					.map((unit) => [unit, after.system.get(unit) ?? after.user.get(unit)])
+					.filter((entry): entry is [string, string] => entry[1] !== undefined),
+			),
+			systemUnitsChanged: [],
+			userUnitsChanged: [],
+		};
+	}
 
 	const systemConverged = system.present.every((unit) => {
 		const state = systemdUnitManagerState(paths, "system", unit);
@@ -340,10 +375,31 @@ function readSystemdRuntimeUnits(
 	scope: SystemdRuntimeScope,
 	units: readonly string[],
 ): Map<string, SystemdUnitManagerState> {
+	const uniqueUnits = [...new Set(units)].sort();
 	const states = new Map<string, SystemdUnitManagerState>();
-	for (const unit of [...new Set(units)].sort()) {
-		const state = systemdUnitManagerState(paths, scope, unit);
-		states.set(unit, state);
+	if (uniqueUnits.length === 0) return states;
+	const showArgs = [
+		"show",
+		...uniqueUnits,
+		"--property=LoadState",
+		"--property=ActiveState",
+		"--property=NeedDaemonReload",
+	];
+	const show = systemdCommandResult(paths, scope, showArgs);
+	assertCommandSucceeded(systemdCommandName(scope), showArgs, show);
+	const blocks = show.stdout
+		.trim()
+		.split(/\r?\n\s*\r?\n/)
+		.filter(Boolean);
+	if (blocks.length !== uniqueUnits.length) {
+		throw new Error(`systemd ${scope} returned incomplete batched manager state`);
+	}
+	const enabled = readSystemdUnitEnablement(paths, scope, uniqueUnits);
+	for (const [index, unit] of uniqueUnits.entries()) {
+		states.set(
+			unit,
+			parseSystemdUnitManagerState(scope, unit, blocks[index] ?? "", enabled.get(unit)),
+		);
 	}
 	return states;
 }
@@ -362,17 +418,16 @@ function systemdUnitManagerState(
 	scope: "system" | "user",
 	unit: string,
 ): SystemdUnitManagerState {
-	const showArgs = [
-		"show",
-		unit,
-		"--property=LoadState",
-		"--property=ActiveState",
-		"--property=NeedDaemonReload",
-	];
-	const show =
-		scope === "system" ? systemctlResult(showArgs) : runtimeUserSystemctlResult(paths, showArgs);
-	assertCommandSucceeded(scope === "system" ? systemctlPath() : "systemctl --user", showArgs, show);
-	const properties = parseSystemctlShow(show.stdout);
+	return requiredSystemdUnitState(readSystemdRuntimeUnits(paths, scope, [unit]), scope, unit);
+}
+
+function parseSystemdUnitManagerState(
+	scope: SystemdRuntimeScope,
+	unit: string,
+	show: string,
+	enabled: boolean | undefined,
+): SystemdUnitManagerState {
+	const properties = parseSystemctlShow(show);
 	const loadState = properties.LoadState;
 	const activeState = properties.ActiveState;
 	const needDaemonReload = properties.NeedDaemonReload;
@@ -389,19 +444,53 @@ function systemdUnitManagerState(
 		activeState,
 		needDaemonReload: needDaemonReload === "yes",
 	};
-	const enabledArgs = ["is-enabled", "--quiet", unit];
-	const enabled =
-		scope === "system"
-			? systemctlResult(enabledArgs)
-			: runtimeUserSystemctlResult(paths, enabledArgs);
-	if (enabled.status === null || enabled.error) {
-		assertCommandSucceeded(
-			scope === "system" ? systemctlPath() : "systemctl --user",
-			enabledArgs,
-			enabled,
-		);
+	return { ...managerState, enabled };
+}
+
+function readSystemdUnitEnablement(
+	paths: ReturnType<typeof getRuntimePaths>,
+	scope: SystemdRuntimeScope,
+	units: readonly string[],
+): Map<string, boolean> {
+	const args = ["is-enabled", ...units];
+	const result = systemdCommandResult(paths, scope, args);
+	if (result.status === null || result.error) {
+		assertCommandSucceeded(systemdCommandName(scope), args, result);
 	}
-	return { ...managerState, enabled: enabled.status === 0 };
+	const output = result.stdout.trim().split(/\r?\n/);
+	return new Map(
+		units.map((unit, index) => {
+			const state = output.length === units.length ? output[index]?.trim() : undefined;
+			if (state === "enabled") return [unit, true];
+			if (state === "disabled") return [unit, false];
+			return [unit, probeSystemdUnitEnabled(paths, scope, unit)];
+		}),
+	);
+}
+
+function probeSystemdUnitEnabled(
+	paths: ReturnType<typeof getRuntimePaths>,
+	scope: SystemdRuntimeScope,
+	unit: string,
+): boolean {
+	const args = ["is-enabled", "--quiet", unit];
+	const result = systemdCommandResult(paths, scope, args);
+	if (result.status === null || result.error) {
+		assertCommandSucceeded(systemdCommandName(scope), args, result);
+	}
+	return result.status === 0;
+}
+
+function systemdCommandResult(
+	paths: ReturnType<typeof getRuntimePaths>,
+	scope: SystemdRuntimeScope,
+	args: string[],
+): CommandResult {
+	return scope === "system" ? systemctlResult(args) : runtimeUserSystemctlResult(paths, args);
+}
+
+function systemdCommandName(scope: SystemdRuntimeScope): string {
+	return scope === "system" ? systemctlPath() : "systemctl --user";
 }
 
 function systemdUnitEnabled(state: SystemdUnitManagerState): boolean {

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -878,9 +878,11 @@ test("propagates the real official OpenClaw installer failure without committing
 	writeFileSync(openClawConfig, initialOpenClawConfig, { mode: 0o600 });
 	chownSync(openClawConfig, runtimeUid, runtimeGid);
 	writeFileSync(gatewayEnvironment, "PRESERVED_ENV=before\n", { mode: 0o600 });
+	chownSync(gatewayEnvironment, runtimeUid, runtimeGid);
 	mkdirSync(dirname(unitPath), { recursive: true });
 	mkdirSync(unitPath, { recursive: false });
 	writeFileSync(unitSentinel, "preserve directory target\n");
+	chownTreeWithoutFollowingLinks(paths.systemdUserRoot, runtimeUid, runtimeGid);
 
 	const workspaceRoot = join(runtimeHome, "clawdi-systemd-test-workspace");
 	const manifest: RuntimeManifest = {
@@ -1572,8 +1574,8 @@ test("runs Files as the tenant while preserving platform isolation", () => {
 	const tenantExisting = join(runtimeHome, "files-tenant-existing.txt");
 	writeFileSync(tenantExisting, "tenant-existing\n", { mode: 0o600 });
 	chownSync(tenantExisting, runtimeUid, runtimeGid);
-	const tenantOwnershipDrift = join(runtimeHome, "files-root-owned-drift.txt");
-	writeFileSync(tenantOwnershipDrift, "repair-to-tenant\n", { mode: 0o600 });
+	const rootOwnedSentinel = join(runtimeHome, "files-root-owned-sentinel.txt");
+	writeFileSync(rootOwnedSentinel, "preserve root ownership\n", { mode: 0o600 });
 	const hermesConfig = join(runtimeHome, ".hermes", "config.yaml");
 	mkdirSync(dirname(hermesConfig), { recursive: true, mode: 0o700 });
 	chownSync(dirname(hermesConfig), runtimeUid, runtimeGid);
@@ -1610,15 +1612,6 @@ test("runs Files as the tenant while preserving platform isolation", () => {
 	ensureRuntimeStateDirs(paths);
 	const rootOwnedControl = join(paths.statusRoot, "files-root-owned-control");
 	writeFileSync(rootOwnedControl, "root-owned\n", { mode: 0o600 });
-	const legacyRootOwnedUnit = join(paths.systemdUserRoot, "legacy-root-owned.service");
-	const legacyRootOwnedDropIn = join(`${legacyRootOwnedUnit}.d`, "10-legacy.conf");
-	const legacyRootOwnedEnvironment = join(openClawStateDir, "gateway.systemd.env");
-	mkdirSync(dirname(legacyRootOwnedDropIn), { recursive: true });
-	writeFileSync(legacyRootOwnedUnit, "[Service]\nExecStart=/bin/true\n");
-	writeFileSync(legacyRootOwnedDropIn, "[Service]\nEnvironment=LEGACY=1\n");
-	writeFileSync(legacyRootOwnedEnvironment, "LEGACY_ROOT_OWNED_ENV=1\n", { mode: 0o600 });
-	chownTreeWithoutFollowingLinks(paths.systemdUserRoot, 0, 0);
-	chownSync(legacyRootOwnedEnvironment, 0, 0);
 	const legacyEnvironmentRoot = join(runtimeHome, ".clawdi", "environments");
 	const legacyEnvironmentPath = join(legacyEnvironmentRoot, "openclaw.json");
 	const legacyEnvironmentContent = `${JSON.stringify({
@@ -1628,6 +1621,7 @@ test("runs Files as the tenant while preserving platform isolation", () => {
 	})}\n`;
 	mkdirSync(legacyEnvironmentRoot, { recursive: true });
 	writeFileSync(legacyEnvironmentPath, legacyEnvironmentContent);
+	chownTreeWithoutFollowingLinks(join(runtimeHome, ".clawdi"), runtimeUid, runtimeGid);
 	const systemNpmCli = "/usr/local/lib/node_modules/clawdi/bin/clawdi.mjs";
 	mkdirSync(dirname(systemNpmCli), { recursive: true });
 	writeFileSync(systemNpmCli, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
@@ -1851,19 +1845,7 @@ http.createServer((request, response) => {
 	expect(statSync(paths.clawdiHome).uid).toBe(runtimeUid);
 	expect(statSync(paths.clawdiHome).gid).toBe(runtimeGid);
 	expect(statSync(paths.clawdiHome).mode & 0o777).toBe(0o750);
-	expect([statSync(tenantOwnershipDrift).uid, statSync(tenantOwnershipDrift).gid]).toEqual([
-		runtimeUid,
-		runtimeGid,
-	]);
-	for (const path of [
-		paths.systemdUserRoot,
-		legacyRootOwnedUnit,
-		dirname(legacyRootOwnedDropIn),
-		legacyRootOwnedDropIn,
-		legacyRootOwnedEnvironment,
-	]) {
-		expect([statSync(path).uid, statSync(path).gid]).toEqual([runtimeUid, runtimeGid]);
-	}
+	expect([statSync(rootOwnedSentinel).uid, statSync(rootOwnedSentinel).gid]).toEqual([0, 0]);
 	expect([statSync(rootOwnedControl).uid, statSync(rootOwnedControl).gid]).toEqual([0, 0]);
 	const tenantClawdiAfterConverge = tenantClawdi();
 	expect(tenantClawdiAfterConverge.status).not.toBe(0);
@@ -2048,7 +2030,7 @@ http.createServer((request, response) => {
 	expect(tenantRead.stdout).toBe("tenant-existing\n");
 }, 120_000);
 
-test("adopts a healthy legacy root-owned Hermes user-service tree and repairs later drift", async () => {
+test("0.14.18 keeps tenant-owned Hermes state writable without chowning tenant home", async () => {
 	if (process.env[REAL_SYSTEMD_GATE] !== "1") return;
 
 	expect(process.geteuid?.()).toBe(0);
@@ -2059,6 +2041,7 @@ test("adopts a healthy legacy root-owned Hermes user-service tree and repairs la
 	chmodSync(root, 0o755);
 	const hermesCommand = join(runtimeHome, ".local", "bin", "hermes");
 	const installLog = join(root, "hermes-installer.log");
+	const rootOwnedSentinel = join(runtimeHome, "root-owned-sentinel");
 	writeFileSync(installLog, "");
 	chownSync(installLog, runtimeUid, runtimeGid);
 	const unitName = "hermes-gateway.service";
@@ -2195,7 +2178,7 @@ esac
 	writeFileSync(
 		unitPath,
 		`[Unit]
-Description=Legacy Hermes Gateway
+Description=Existing Hermes Gateway
 
 [Service]
 Type=simple
@@ -2211,10 +2194,11 @@ WantedBy=default.target
 		mode: 0o600,
 	});
 	symlinkSync("../hermes-gateway.service", enablementPath);
-	chownTreeWithoutFollowingLinks(paths.systemdUserRoot, 0, 0);
+	chownTreeWithoutFollowingLinks(paths.systemdUserRoot, runtimeUid, runtimeGid);
 	for (const path of [paths.systemdUserRoot, dropInRoot, dirname(enablementPath)]) {
 		chmodSync(path, 0o700);
 	}
+	writeFileSync(rootOwnedSentinel, "preserve root ownership\n", { mode: 0o600 });
 
 	try {
 		expect((await converge()).installErrors).toEqual([]);
@@ -2238,8 +2222,9 @@ WantedBy=default.target
 			const node = lstatSync(path);
 			expect([node.uid, node.gid]).toEqual([runtimeUid, runtimeGid]);
 		}
+		expect([statSync(rootOwnedSentinel).uid, statSync(rootOwnedSentinel).gid]).toEqual([0, 0]);
 		const declaredUnit = readFileSync(unitPath, "utf8");
-		expect(declaredUnit).toContain("Legacy Hermes Gateway");
+		expect(declaredUnit).toContain("Existing Hermes Gateway");
 
 		const idempotent = await converge();
 		expect(idempotent.installErrors).toEqual([]);
@@ -2283,8 +2268,10 @@ WantedBy=default.target
 
 		const repaired = await converge();
 		expect(repaired.installErrors).toEqual([]);
-		expect(readFileSync(unitPath, "utf8")).not.toContain("Legacy Hermes Gateway");
+		expect(readFileSync(unitPath, "utf8")).not.toContain("Existing Hermes Gateway");
 		expect(readFileSync(installLog, "utf8").trim().split("\n")).toEqual(["install"]);
+		expect([statSync(unitPath).uid, statSync(unitPath).gid]).toEqual([runtimeUid, runtimeGid]);
+		expect([statSync(rootOwnedSentinel).uid, statSync(rootOwnedSentinel).gid]).toEqual([0, 0]);
 		const repairedState = runUserSystemctl(
 			"show",
 			unitName,
@@ -2303,6 +2290,7 @@ WantedBy=default.target
 		rmSync(unitPath, { force: true });
 		rmSync(dropInRoot, { recursive: true, force: true });
 		rmSync(enablementPath, { force: true });
+		rmSync(rootOwnedSentinel, { force: true });
 		rmSync(root, { recursive: true, force: true });
 	}
 }, 120_000);

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -442,28 +442,36 @@ start_process() {
 }
 case "$command" in
   show)
-    unit="\${1:-}"
-    load_state=loaded
-    active_state=inactive
-    [ ! -f "$(state_path "$unit" active)" ] || active_state=active
-    [ ! -f "$(state_path "$unit" failed)" ] || active_state=failed
-    if [ -f "$(state_path "$unit" not-found)" ]; then load_state=not-found; active_state=inactive; fi
-    need_daemon_reload=no
-    [ ! -f "$(state_path "$unit" reload)" ] || need_daemon_reload=yes
-    main_pid=0
-    [ ! -f "$(state_path "$unit" pid)" ] || main_pid="$(cat "$(state_path "$unit" pid)")"
-    printf 'LoadState=%s\\nActiveState=%s\\nMainPID=%s\\nNeedDaemonReload=%s\\n' "$load_state" "$active_state" "$main_pid" "$need_daemon_reload"
+    first=1
+    for unit in "$@"; do
+      case "$unit" in --property=*) continue ;; esac
+      if [ "$first" = "0" ]; then printf '\\n'; fi
+      first=0
+      load_state=loaded
+      active_state=inactive
+      [ ! -f "$(state_path "$unit" active)" ] || active_state=active
+      [ ! -f "$(state_path "$unit" failed)" ] || active_state=failed
+      if [ -f "$(state_path "$unit" not-found)" ]; then load_state=not-found; active_state=inactive; fi
+      need_daemon_reload=no
+      [ ! -f "$(state_path "$unit" reload)" ] || need_daemon_reload=yes
+      main_pid=0
+      [ ! -f "$(state_path "$unit" pid)" ] || main_pid="$(cat "$(state_path "$unit" pid)")"
+      printf 'LoadState=%s\\nActiveState=%s\\nMainPID=%s\\nNeedDaemonReload=%s\\n' "$load_state" "$active_state" "$main_pid" "$need_daemon_reload"
+    done
     ;;
-	  is-enabled)
-	    quiet=0
-	    if [ "\${1:-}" = "--quiet" ]; then quiet=1; shift; fi
-	    unit="\${1:-}"
-	    if [ -f "$(state_path "$unit" enabled)" ] || [ -L "$HOME/.config/systemd/user/default.target.wants/$unit" ]; then
-	      if [ "$quiet" = "0" ]; then printf 'enabled\\n'; fi
-	    else
-	      if [ "$quiet" = "0" ]; then printf 'disabled\\n'; fi
-	      exit 1
-    fi
+  is-enabled)
+    quiet=0
+    if [ "\${1:-}" = "--quiet" ]; then quiet=1; shift; fi
+    status=0
+    for unit in "$@"; do
+      if [ -f "$(state_path "$unit" enabled)" ] || [ -L "$HOME/.config/systemd/user/default.target.wants/$unit" ]; then
+        if [ "$quiet" = "0" ]; then printf 'enabled\\n'; fi
+      else
+        if [ "$quiet" = "0" ]; then printf 'disabled\\n'; fi
+        status=1
+      fi
+    done
+    exit "$status"
     ;;
   start)
     for unit in "$@"; do
@@ -5010,7 +5018,12 @@ cp '${sdkSource}' '${sdkTarget}'
 			});
 			expect(systemdEnvDigest(readSystemdEnvFile(paths, runtimeUnit))).toBe(initialRevision);
 			const systemctlCalls = readFileSync(systemctlLog, "utf-8");
-			expect(systemctlCalls).toContain(`--user show ${runtimeUnit}.service`);
+			const managerReads = systemctlCalls.trim().split("\n");
+			expect(managerReads.find((call) => call.startsWith("--user show "))).toContain(
+				`${runtimeUnit}.service`,
+			);
+			expect(managerReads.filter((call) => /^(?:--user )?show /.test(call))).toHaveLength(2);
+			expect(managerReads.filter((call) => /^(?:--user )?is-enabled /.test(call))).toHaveLength(2);
 			expect(systemctlCalls).not.toMatch(
 				/(?:^|\s)(?:start|restart|stop|enable|disable|reset-failed)(?:\s|$)/m,
 			);


### PR DESCRIPTION
## Summary

This PR is the 0.14.18 convergence hot-path cleanup, split into four ordered commits:

1. Report a successful runtime apply on the next existing observation-producer pass instead of waiting for the 60-second steady cadence. This reuses the existing runtime-watch.json channel between the watch service and daemon; it adds no IPC, timer, or fleet-wide cadence change.
2. Reconcile one Hermes round through one comment-preserving YAML document and one atomic write. hermes config path is resolved once for the transaction, then provider, channel, MCP, locale, and runtime patches share the in-memory document. Commit now compares the current file bytes with the begin snapshot; a concurrent user edit defers the managed write, activation, and applied-authority commit so the next 15-second poll replays from the user's new document.
3. Remove the recursive /home/clawdi chown that turned the one-time #1197 ownership repair into steady-state work.
4. Memoize unchanged upstream probes in the long-lived converge process by existing revisions, remove the duplicate systemd no-op read, and batch systemd manager reads per scope. First process start remains a full probe. Cheap disk evidence or the existing five-minute full-refresh round restores externally drifted managed state without adding a timer or persistent cache.

No new environment variable, feature flag, hook, IPC surface, timer, or persistent state is introduced.

## Owner baselines and expected improvement

| Commit | Owner-measured baseline | Expected/result |
| --- | ---: | --- |
| Immediate observation | Up to 60s after a successful install | Next existing daemon producer pass after the applied watch receipt; the 60s cadence remains the fallback |
| Hermes config transaction | About 24s from about 38 repeated config command/path/read/parse cycles | One config path, one parse, merged in-memory patches, at most one CAS-protected atomic write |
| Recursive ownership repair | About 5.8s for 93k nodes / 2.05GB | Zero recursive tenant-home chown in 0.14.18 |
| Revision-keyed steady state | Hermes 22.918s / 67 direct spawns; OpenClaw 26.885s / 31 direct spawns | Hermes p50 1.046s / 5 direct spawns; OpenClaw p50 0.433s / 4 direct spawns |

The recursive-chown deletion was also isolated against a 93,001-node / 2,050,024,300-byte fixture on this host: origin/main 622.76ms -> this branch 22.45ms (600.31ms / 96.4% / 27.7x improvement). The owner 5.8s number remains the production-size baseline.

## Privileged steady-state measurement

The privileged fixture uses Hermes 0.19.1 and OpenClaw 2026.7.1-2 with live systemd managers and the same virgin runtime layout as the behavioral E2E. Each runtime was warmed once, then measured for 10 unchanged rounds in the same process. Parent-only strace counted direct process creation without following or perturbing upstream child processes.

| Runtime | Owner baseline p50 | 0.14.18 p50 | 10-round range | Direct spawns per round |
| --- | ---: | ---: | ---: | ---: |
| Hermes | 22.918s | 1.046s | 0.876-1.235s | 5 |
| OpenClaw | 26.885s | 0.433s | 0.239-0.569s | 4 |

Changed-round semantics remain revision driven: command bytes/version, provider content, roster content, plugin desired/receipt identity, and official service command revisions all force their corresponding probes to run again.

## Cache drift and self-heal

| Probe | Unchanged 15-second hot path | External drift invalidation | Behavioral test |
| --- | --- | --- | --- |
| OpenClaw hosted provider patch | Cached patch revision plus one zero-spawn openclaw.json read/parse | A missing managed provider block fails the disk check and reruns the original mutation on the next converge | deleting models.providers.clawdi is repaired on the next unchanged-manifest round |
| Clawdi managed provider plugin | Process-local memo skips inspect and marker work | The existing five-minute forceRefresh bypasses the memo and reruns inspect/marker/install | deleting the managed extension remains hot-cached, then the self-heal round reinstalls it |
| Manifest Agent Plugins | Process-local desired/receipt memo skips driver.observe | The existing five-minute forceRefresh bypasses the memo and performs full driver observation/reconciliation | removing an installed required plugin is observed and reinstalled on the self-heal round |
| Managed provider auth agent directories | Revision-keyed discovery memo | openClawRosterConfigRevision is part of the key; roster config drift reruns roster and auth discovery | changing agents.list reruns roster and provider-auth discovery |

## Persistent-state disposition

| Persistent item | 0.13.92 / 0.14.17 wrote what | 0.14.18 first-round disposition | Test |
| --- | --- | --- | --- |
| runtime-watch.json | The latest watch event, including an applied result, was atomically replaced after watch ticks | No migration or rewrite. The daemon treats the existing applied event bytes as a wake receipt; malformed/non-applied snapshots are ignored and the normal watch writer replaces the file | reports a successful converge without waiting for the steady cadence |
| ~/.hermes/config.yaml | Managed provider/channel/MCP/runtime keys were applied through repeated field-level command/path/read/parse/write cycles alongside user YAML | Resolve and parse the existing document once, preserve user fields/comments, merge managed changes, and atomically write once only if unchanged since begin. A concurrent edit wins and the next poll replays from it | merged-patch/comment preservation; third-party edit conflict skips commit and the next snapshot replays successfully |
| /home/clawdi ownership metadata | 0.14.17 recursively reassigned the tenant tree each round as the #1197 repair | No 0.14.18 ownership pass. Existing deployments rely on completed 0.14.17 convergence; new deployments are tenant-owned at creation | 0.14.18 does not recursively chown tenant home and keeps tenant writes owned; privileged tenant-write E2E |
| ~/.config/systemd/user units, drop-ins, and enablement links | Official installers and Clawdi persisted the desired user-unit tree; 0.14.17 also completed legacy ownership placement | No steady-state rewrite or ownership migration. Unit bytes remain authoritative; manager state is read once per scope and changed revisions still use the existing write/reload/restart transaction | batched manager-read assertion; privileged 9/9 including changed apply, rollback, and crash recovery |
| runtime-applied.json | Applied authority included existing officialServiceCommandRevisions and activated unit digests | No schema or write change. Existing official-command revisions are process-local probe keys; missing/changed values force the original probes. Hermes CAS conflict does not advance this authority | official command revision change re-probes; Hermes conflict returns before activation/authority commit |
| runtime-agent-plugin-receipts.json and native plugin installs | Released plugin ownership/install receipts and runtime-native plugin state were persisted after successful reconciliation | No migration or new receipt. Desired/receipt identity changes probe immediately; unchanged hot rounds memoize; the existing five-minute self-heal round re-observes native state and repairs external removal | released receipt adoption; key change re-observes; deleted required OpenClaw Agent Plugin is reinstalled on self-heal |
| ~/.openclaw/openclaw.json and provider auth stores | User roster config plus managed provider/auth projection were persisted by existing OpenClaw reconciliation | Preserve user bytes and ownership. Managed provider presence is disk-validated every converge; provider input changes rerun mutations; roster content revision invalidates roster/auth discovery | managed provider deletion repairs next round; provider key change reruns mutation; roster config change reruns auth discovery |
| ~/.openclaw/extensions/clawdi-managed-provider | Existing convergence installed the managed provider extension and marker-backed source | No migration. First process round performs full inspect; unchanged hot rounds memoize; the existing five-minute self-heal round bypasses memo and reinstalls a removed extension | deleted extension is absent on the hot memoized round and restored on forceRefresh |

Release prerequisite: fleet must be fully converged on 0.14.17 before the 0.14.18 rollout.

Do not merge until the owner confirms fleet-wide 0.14.17 convergence.

## Verification

All verification ran in disposable Docker/tmpfs environments with no host dependency or daemon mutation:

- Focused P1/P2 regression suite: 192 passed, 0 failed
- scripts/test.sh cli on the final rebased tree: 1,653 passed, 4 skipped, 0 failed
- Workspace typecheck: 4/4 packages successful
- Biome: 1,079 files checked, no findings
- Privileged official-installer/systemd E2E: 9/9 passed, 399 assertions, including both unchanged behavioral guard assertions
- Hermes config fake command assertion: at most 2 command starts per round
- Privileged 10-round steady-state measurement: Hermes p50 1.046s / 5 direct spawns; OpenClaw p50 0.433s / 4 direct spawns
