### PR TITLE
fix(deploy): restore single API worker

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -50,16 +50,14 @@ servers:
     hosts:
       - <%= ENV.fetch("DEPLOY_HOST") %>
     options:
-      memory: 6g # two API workers, each with a local embedding model
+      memory: 4g # embedding model (~1.6G resident) + launch-load headroom
       ulimit: nofile=65536:65536 # long-lived SSE/WebSocket connections
       # tini as PID 1 reaps orphaned subprocesses (zombie prevention).
       init: true
     env:
       clear:
-        WEB_CONCURRENCY: 2
-        # SQLAlchemy owns one pool per worker; preserve the prior aggregate cap.
-        DB_POOL_SIZE: 10
-        DB_MAX_OVERFLOW: 10
+        # Resume replay, rate-limit, and SSE cap state is process-local.
+        WEB_CONCURRENCY: 1
   channels-worker:
     hosts:
       - <%= ENV.fetch("DEPLOY_HOST") %>

--- a/scripts/test-kamal-whatsapp-sidecar-render.sh
+++ b/scripts/test-kamal-whatsapp-sidecar-render.sh
@@ -140,6 +140,22 @@ raise "top-level logging did not render journald" unless config.logging_args == 
 config.roles.each do |role|
   raise "#{role.name} logging drifted" unless role.logging_args == expected_logging_args
 end
+
+web = config.role("web")
+unless web.specialized_env.clear == { "WEB_CONCURRENCY" => 1 }
+  raise "web role lost its single-worker contract"
+end
+raise "web role memory drifted" unless config.raw_config.servers.dig("web", "options", "memory") == "4g"
+web_env = web.env(web.primary_host).clear
+unless web_env.values_at("DB_POOL_SIZE", "DB_MAX_OVERFLOW") == [ 20, 20 ]
+  raise "web role did not inherit the top-level database pool"
+end
+channels_worker = config.role("channels-worker")
+worker_role = channels_worker.specialized_env.clear == { "CLAWDI_PROCESS_ROLE" => "channels-worker" }
+unless worker_role && !channels_worker.running_proxy?
+  raise "channels-worker role contract drifted"
+end
+
 config.accessories.each do |accessory|
   command = Kamal::Commands::Accessory.new(config, name: accessory.name).run
   unless command.each_cons(2).include?([ "--restart", "unless-stopped" ])


### PR DESCRIPTION
## Summary

- restore one Uvicorn API worker while process-local Resume, rate-limit, and SSE cap state remains
- keep the dedicated `channels-worker` Kamal role
- restore the web memory limit to 4 GiB and inherit the existing top-level 20+20 database pool
- enforce the rendered Kamal role contract

## Verification

- Kamal 2.12 render contract
- deployment contract tests
- related Bun contract tests
- Ruff lint and format
- shell syntax and `git diff --check`

## Operational intent

This is the minimal rollback of unsafe in-container API multiprocessing. It preserves the already-correct background worker split and all legacy `/api` contracts.