### PR TITLE
fix(backend): harden Discord consumer lease

### DIFF
--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -33,16 +33,14 @@ from fastapi import (
 )
 from fastapi.responses import JSONResponse, Response
 from pydantic import JsonValue, TypeAdapter, ValidationError
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, select, text
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from starlette.datastructures import UploadFile
 
 from app.core.config import settings
-from app.core.database import (
-    async_session_factory,
-    get_session,
-)
+from app.core.database import async_session_factory, get_session
+from app.core.database import engine as database_engine
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     BOT_AGENT_LINK_STATUS_ACTIVE,
@@ -108,6 +106,10 @@ from app.services.channels import (
     verify_discord_signature,
     verify_webhook_secret,
 )
+from app.services.discord_gateway_worker import (
+    release_advisory_lock,
+    try_advisory_lock,
+)
 
 router = APIRouter(prefix="/channels/discord", tags=["channels"])
 log = logging.getLogger(__name__)
@@ -121,6 +123,10 @@ _DISCORD_GATEWAY_CAPABILITY_AUDIENCE = "clawdi_discord_gateway"
 type JsonObject = dict[str, JsonValue]
 _JSON_VALUE_ADAPTER: TypeAdapter[JsonValue] = TypeAdapter(JsonValue)
 _JSON_OBJECT_ADAPTER: TypeAdapter[JsonObject] = TypeAdapter(dict[str, JsonValue])
+
+
+class _DiscordGatewayConsumerLeaseLost(RuntimeError):
+    pass
 
 
 @dataclass(frozen=True)
@@ -2028,16 +2034,95 @@ async def _discord_gateway_consumer_lease(
     *,
     account_id: UUID,
     bot_agent_link_id: UUID,
+    lock_engine: AsyncEngine | None = None,
+    liveness_interval_seconds: float | None = None,
 ):
     """Allow one synthetic shard consumer per AgentLink across processes."""
+    connection = await (lock_engine or database_engine).connect()
+    acquired = False
+    lock_key: int | None = None
+    safe_to_pool = False
+    monitor_failure: Exception | None = None
+    body_error: BaseException | None = None
+    cleanup_error: BaseException | None = None
+    monitor_stop = asyncio.Event()
+    monitor_task: asyncio.Task[None] | None = None
+    owner_task = asyncio.current_task()
+    if owner_task is None:
+        await connection.close()
+        raise RuntimeError("discord gateway consumer lease requires an asyncio task")
     lock_name = f"discord-agent-gateway:{account_id}:{bot_agent_link_id}"
-    async with async_session_factory() as db:
-        acquired = bool(
-            await db.scalar(
-                select(func.pg_try_advisory_xact_lock(func.hashtextextended(lock_name, 0)))
-            )
+
+    async def monitor_connection() -> None:
+        nonlocal monitor_failure
+        interval = max(
+            0.001,
+            liveness_interval_seconds
+            if liveness_interval_seconds is not None
+            else settings.discord_gateway_poll_interval_seconds,
         )
         try:
+            while True:
+                try:
+                    await asyncio.wait_for(monitor_stop.wait(), timeout=interval)
+                    return
+                except TimeoutError:
+                    await connection.execute(text("SELECT 1"))
+                    await connection.commit()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            monitor_failure = exc
+            owner_task.cancel()
+
+    try:
+        await connection.execution_options(isolation_level="AUTOCOMMIT")
+        # Keep the transaction-level lease identity used by older rolling-deploy peers.
+        lock_key_result = await connection.execute(
+            text("SELECT hashtextextended(:lock_name, 0)"),
+            {"lock_name": lock_name},
+        )
+        await connection.commit()
+        resolved_lock_key = lock_key_result.scalar_one()
+        if not isinstance(resolved_lock_key, int) or isinstance(resolved_lock_key, bool):
+            raise RuntimeError("discord gateway consumer advisory lock key is invalid")
+        lock_key = resolved_lock_key
+        acquired = await try_advisory_lock(connection, lock_key)
+        safe_to_pool = not acquired
+        if acquired:
+            monitor_task = asyncio.create_task(
+                monitor_connection(),
+                name=f"discord-gateway-consumer-lease-{bot_agent_link_id}",
+            )
+        try:
             yield acquired
+        except BaseException as exc:
+            body_error = exc
+    finally:
+        monitor_stop.set()
+        try:
+            if monitor_task is not None:
+                await monitor_task
+            if acquired:
+                if lock_key is None:
+                    raise RuntimeError("discord gateway consumer advisory lock key is missing")
+                if not await release_advisory_lock(connection, lock_key):
+                    raise RuntimeError("discord gateway consumer advisory unlock failed")
+                safe_to_pool = True
+        except BaseException as exc:
+            cleanup_error = exc
         finally:
-            await db.rollback()
+            try:
+                if not safe_to_pool:
+                    await connection.invalidate()
+            finally:
+                await connection.close()
+
+    if monitor_failure is not None:
+        raise _DiscordGatewayConsumerLeaseLost(
+            "discord gateway consumer lease connection lost"
+        ) from monitor_failure
+    if cleanup_error is not None:
+        raise cleanup_error
+    if body_error is not None:
+        raise body_error

--- a/backend/app/services/discord_gateway_worker.py
+++ b/backend/app/services/discord_gateway_worker.py
@@ -219,13 +219,14 @@ class DiscordGatewayWorker:
     ) -> bool:
         lock_key = discord_gateway_advisory_lock_key(account_id)
         async with self._lock_engine.connect() as lock_connection:
-            acquired = await _try_advisory_lock(lock_connection, lock_key)
+            acquired = await try_advisory_lock(lock_connection, lock_key)
             if not acquired:
                 return False
             try:
                 await self._connect_and_record(account_id, stop, state)
             finally:
-                await _release_advisory_lock(lock_connection, lock_key)
+                if not await release_advisory_lock(lock_connection, lock_key):
+                    raise RuntimeError("discord gateway advisory unlock failed")
         return True
 
     async def _connect_and_record(
@@ -656,7 +657,7 @@ def discord_gateway_close_code(exc: ConnectionClosed) -> int | None:
     return exc.rcvd.code if exc.rcvd is not None else None
 
 
-async def _try_advisory_lock(connection: AsyncConnection, lock_key: int) -> bool:
+async def try_advisory_lock(connection: AsyncConnection, lock_key: int) -> bool:
     result = await connection.execute(
         text("SELECT pg_try_advisory_lock(:lock_key)"),
         {"lock_key": lock_key},
@@ -665,12 +666,13 @@ async def _try_advisory_lock(connection: AsyncConnection, lock_key: int) -> bool
     return result.scalar_one() is True
 
 
-async def _release_advisory_lock(connection: AsyncConnection, lock_key: int) -> None:
-    await connection.execute(
+async def release_advisory_lock(connection: AsyncConnection, lock_key: int) -> bool:
+    result = await connection.execute(
         text("SELECT pg_advisory_unlock(:lock_key)"),
         {"lock_key": lock_key},
     )
     await connection.commit()
+    return result.scalar_one() is True
 
 
 async def _recv_gateway_frame(websocket: _GatewayConnection) -> GatewayFrame:

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -15452,6 +15452,10 @@ def _install_discord_gateway_test_session_factory(monkeypatch: pytest.MonkeyPatc
         "app.routes.channel_routers.discord.async_session_factory",
         async_sessionmaker(gateway_engine, expire_on_commit=False),
     )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.discord.database_engine",
+        gateway_engine,
+    )
 
 
 def test_discord_gateway_rejects_unsupported_encoding_and_compress():

--- a/backend/tests/test_discord_gateway_websockets.py
+++ b/backend/tests/test_discord_gateway_websockets.py
@@ -7,11 +7,13 @@ from urllib.parse import parse_qs, urlsplit
 from uuid import UUID, uuid4
 
 import pytest
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 from websockets.asyncio.server import ServerConnection, serve
 from websockets.exceptions import ConnectionClosedError
 
 import app.services.discord_gateway_worker as discord_gateway_worker_module
+from app.routes.channel_routers import discord as discord_router
 from app.services.discord_gateway_worker import (
     DiscordGatewayWorker,
     GatewayFrame,
@@ -33,6 +35,195 @@ class _ObservedGatewayExchange:
 
 def _gateway_json(frame: GatewayFrame) -> str:
     return json.dumps(frame, separators=(",", ":"))
+
+
+async def _consumer_lease_backend_pid(engine: AsyncEngine, lock_key: int) -> int:
+    lock_class = (lock_key >> 32) & 0xFFFF_FFFF
+    lock_object = lock_key & 0xFFFF_FFFF
+    async with engine.connect() as observer:
+        backend_pid = await observer.scalar(
+            text(
+                """
+                SELECT pid
+                FROM pg_locks
+                WHERE locktype = 'advisory'
+                  AND database = (SELECT oid FROM pg_database WHERE datname = current_database())
+                  AND classid::bigint = :lock_class
+                  AND objid::bigint = :lock_object
+                  AND objsubid = 1
+                  AND granted
+                """
+            ),
+            {"lock_class": lock_class, "lock_object": lock_object},
+        )
+    assert isinstance(backend_pid, int)
+    return backend_pid
+
+
+async def _legacy_consumer_lease_lock_key(
+    engine: AsyncEngine,
+    account_id: UUID,
+    link_id: UUID,
+) -> int:
+    lock_name = f"discord-agent-gateway:{account_id}:{link_id}"
+    async with engine.connect() as observer:
+        lock_key = await observer.scalar(
+            text("SELECT hashtextextended(:lock_name, 0)"),
+            {"lock_name": lock_name},
+        )
+    assert isinstance(lock_key, int) and not isinstance(lock_key, bool)
+    return lock_key
+
+
+@pytest.mark.asyncio
+async def test_synthetic_gateway_consumer_lease_preserves_legacy_key_without_transaction(
+    engine: AsyncEngine,
+) -> None:
+    account_id = UUID("00000000-0000-4000-8000-000000000910")
+    link_id = UUID("00000000-0000-4000-8000-000000000911")
+    legacy_lock_key = await _legacy_consumer_lease_lock_key(engine, account_id, link_id)
+
+    async with discord_router._discord_gateway_consumer_lease(
+        account_id=account_id,
+        bot_agent_link_id=link_id,
+        lock_engine=engine,
+        liveness_interval_seconds=60,
+    ) as acquired:
+        assert acquired is True
+        backend_pid = await _consumer_lease_backend_pid(engine, legacy_lock_key)
+        async with engine.connect() as observer:
+            state, transaction_started_at = (
+                await observer.execute(
+                    text("SELECT state, xact_start FROM pg_stat_activity WHERE pid = :pid"),
+                    {"pid": backend_pid},
+                )
+            ).one()
+
+        assert state == "idle"
+        assert transaction_started_at is None
+
+
+@pytest.mark.asyncio
+async def test_synthetic_gateway_consumer_lease_rejects_lock_contention(
+    engine: AsyncEngine,
+) -> None:
+    account_id = UUID("00000000-0000-4000-8000-000000000912")
+    link_id = UUID("00000000-0000-4000-8000-000000000913")
+
+    async with discord_router._discord_gateway_consumer_lease(
+        account_id=account_id,
+        bot_agent_link_id=link_id,
+        lock_engine=engine,
+        liveness_interval_seconds=60,
+    ) as first_acquired:
+        async with discord_router._discord_gateway_consumer_lease(
+            account_id=account_id,
+            bot_agent_link_id=link_id,
+            lock_engine=engine,
+            liveness_interval_seconds=60,
+        ) as second_acquired:
+            assert first_acquired is True
+            assert second_acquired is False
+
+
+@pytest.mark.asyncio
+async def test_synthetic_gateway_consumer_lease_unlocks_on_normal_exit(
+    engine: AsyncEngine,
+) -> None:
+    account_id = UUID("00000000-0000-4000-8000-000000000914")
+    link_id = UUID("00000000-0000-4000-8000-000000000915")
+
+    async with discord_router._discord_gateway_consumer_lease(
+        account_id=account_id,
+        bot_agent_link_id=link_id,
+        lock_engine=engine,
+        liveness_interval_seconds=60,
+    ) as acquired:
+        assert acquired is True
+
+    async with discord_router._discord_gateway_consumer_lease(
+        account_id=account_id,
+        bot_agent_link_id=link_id,
+        lock_engine=engine,
+        liveness_interval_seconds=60,
+    ) as reacquired:
+        assert reacquired is True
+
+
+@pytest.mark.asyncio
+async def test_synthetic_gateway_consumer_lease_unlocks_when_cancelled(
+    engine: AsyncEngine,
+) -> None:
+    account_id = UUID("00000000-0000-4000-8000-000000000916")
+    link_id = UUID("00000000-0000-4000-8000-000000000917")
+    entered = asyncio.Event()
+
+    async def hold_lease() -> None:
+        async with discord_router._discord_gateway_consumer_lease(
+            account_id=account_id,
+            bot_agent_link_id=link_id,
+            lock_engine=engine,
+            liveness_interval_seconds=60,
+        ) as acquired:
+            assert acquired is True
+            entered.set()
+            await asyncio.Future()
+
+    holder = asyncio.create_task(hold_lease())
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    holder.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await holder
+
+    async with discord_router._discord_gateway_consumer_lease(
+        account_id=account_id,
+        bot_agent_link_id=link_id,
+        lock_engine=engine,
+        liveness_interval_seconds=60,
+    ) as reacquired:
+        assert reacquired is True
+
+
+@pytest.mark.asyncio
+async def test_synthetic_gateway_consumer_stops_when_lease_connection_is_lost(
+    engine: AsyncEngine,
+) -> None:
+    account_id = UUID("00000000-0000-4000-8000-000000000918")
+    link_id = UUID("00000000-0000-4000-8000-000000000919")
+    legacy_lock_key = await _legacy_consumer_lease_lock_key(engine, account_id, link_id)
+    entered = asyncio.Event()
+
+    async def hold_lease() -> None:
+        async with discord_router._discord_gateway_consumer_lease(
+            account_id=account_id,
+            bot_agent_link_id=link_id,
+            lock_engine=engine,
+            liveness_interval_seconds=0.01,
+        ) as acquired:
+            assert acquired is True
+            entered.set()
+            await asyncio.Future()
+
+    holder = asyncio.create_task(hold_lease())
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=1)
+        backend_pid = await _consumer_lease_backend_pid(engine, legacy_lock_key)
+        async with engine.connect() as observer:
+            terminated = await observer.scalar(
+                text("SELECT pg_terminate_backend(:pid)"),
+                {"pid": backend_pid},
+            )
+        assert terminated is True
+
+        with pytest.raises(
+            discord_router._DiscordGatewayConsumerLeaseLost,
+            match="lease connection lost",
+        ):
+            await asyncio.wait_for(holder, timeout=2)
+    finally:
+        if not holder.done():
+            holder.cancel()
+            await asyncio.gather(holder, return_exceptions=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- replace the request-long transaction advisory lock with a session advisory lock on a dedicated AUTOCOMMIT connection
- preserve the legacy PostgreSQL hash identity so old and new containers contend during rolling deploys
- fail closed when the lease connection is lost and invalidate any connection that cannot be safely returned to the pool

## Production root cause

PostgreSQL enforces a five-minute idle-in-transaction timeout. The synthetic Discord Gateway consumer held pg_try_advisory_xact_lock for the full WebSocket lifetime, so PostgreSQL released exclusivity at five minutes while the consumer could continue running.

## Verification

- Docker PostgreSQL 18: 41 focused tests passed
- websocket lease contracts cover no long transaction, legacy key compatibility, contention, normal/cancel cleanup, and connection-loss fail-closed
- Ruff, format, compileall, and strict type governance passed
- deploy configuration is unchanged from main: one API worker, 4 GiB web memory, inherited 20/20 DB pool
