### PR TITLE
chore(cli): remove expired migration guards

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1527,6 +1527,9 @@ authentication overrides. The manifest identity is:
 {"args": ["gateway", "run"]}
 ```
 
+The reader still accepts the previous producer argv containing
+`--allow-unconfigured --port 18789 --bind lan --force` long enough for an old
+CLI to self-upgrade, then normalizes it before matching the official service.
 The official OpenClaw installer currently writes an absolute Node/CLI
 entrypoint with `gateway --port 18789`; that upstream argv is deliberately not
 duplicated or overridden by Clawdi.

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -1527,9 +1527,6 @@ authentication overrides. The manifest identity is:
 {"args": ["gateway", "run"]}
 ```
 
-The reader still accepts the previous producer argv containing
-`--allow-unconfigured --port 18789 --bind lan --force` long enough for an old
-CLI to self-upgrade, then normalizes it before matching the official service.
 The official OpenClaw installer currently writes an absolute Node/CLI
 entrypoint with `gateway --port 18789`; that upstream argv is deliberately not
 duplicated or overridden by Clawdi.

--- a/packages/cli/src/lib/oauth-credential-ledger.ts
+++ b/packages/cli/src/lib/oauth-credential-ledger.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { z } from "zod";
 import type { OAuthCredentialLedgerSnapshot } from "./chatgpt-oauth-reconciliation";
@@ -80,11 +80,6 @@ export function oauthCredentialLedgerPath(
 export function readOAuthCredentialLedger(path: string): OAuthCredentialLedger | null {
 	if (!existsSync(path)) return null;
 	const raw = JSON.parse(readFileSync(path, "utf8")) as unknown;
-	// SUNSET: remove after the fleet no longer carries pre-#1187 retired tombstones.
-	if (typeof raw === "object" && raw !== null && "state" in raw && raw.state === "retired") {
-		rmSync(path, { force: true });
-		return null;
-	}
 	return oauthCredentialLedgerSchema.parse(raw);
 }
 

--- a/packages/cli/src/runtime/applied-state.test.ts
+++ b/packages/cli/src/runtime/applied-state.test.ts
@@ -48,35 +48,6 @@ function appliedStateFixture() {
 	};
 }
 
-function releasedAppliedStateFixture(version: "0.13.92" | "0.14.14") {
-	return {
-		schemaVersion: "clawdi.runtimeAppliedState.v2" as const,
-		appliedAt: `2026-07-${version === "0.13.92" ? "13" : "14"}T06:00:00.000Z`,
-		instanceId: `hri_${version.replaceAll(".", "_")}`,
-		etag: `"release-${version}"`,
-		sourceRevision: "c".repeat(64),
-		generation: version === "0.13.92" ? 13 : 14,
-		contentIdentity: {
-			sourcePath: "https://runtime.test/v1/runtime/manifest",
-			sha256: "a".repeat(64),
-		},
-		egressSidecarSecretRevision: "e".repeat(64),
-		daemonAuthTokenRevision: "d".repeat(64),
-		daemonProgramRevision: "d".repeat(32),
-		userProcessRevisionAliases: {
-			"openclaw-gateway.service": {
-				desiredRevision: "d".repeat(32),
-				processRevision: "a".repeat(32),
-			},
-		},
-		providerIds: ["clawdi-default", "default"],
-		projectedProviderIds: {
-			hermes: ["clawdi-default"],
-			openclaw: ["default"],
-		},
-	};
-}
-
 afterEach(() => {
 	process.env = { ...originalEnv };
 	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
@@ -117,22 +88,7 @@ describe("runtime applied state", () => {
 		).toBe(false);
 	});
 
-	for (const version of ["0.13.92", "0.14.14"] as const) {
-		test(`migrates the ${version} released applied-state format`, () => {
-			const migrated = runtimeAppliedStateSchema.parse(releasedAppliedStateFixture(version));
-			expect(migrated.activated).toEqual({});
-			for (const field of [
-				"egressSidecarSecretRevision",
-				"daemonAuthTokenRevision",
-				"daemonProgramRevision",
-				"userProcessRevisionAliases",
-			]) {
-				expect(Object.hasOwn(migrated, field)).toBe(false);
-			}
-		});
-	}
-
-	test("reads old state through the named fallback and preserves explicit apply generation", () => {
+	test("preserves explicit apply generation", () => {
 		const state = appliedStateFixture();
 		const complete = {
 			...state,

--- a/packages/cli/src/runtime/applied-state.ts
+++ b/packages/cli/src/runtime/applied-state.ts
@@ -40,22 +40,7 @@ const providerIdsSchema = z
 		message: "provider IDs must be unique",
 	});
 
-const runtimeRevisionSchema = z.string().regex(/^[a-f0-9]{32}$/);
-
-const userProcessRevisionAliasesSchema = z.record(
-	z.string().regex(/^[A-Za-z0-9_.@-]+\.service$/),
-	z
-		.object({
-			desiredRevision: runtimeRevisionSchema,
-			processRevision: runtimeRevisionSchema,
-		})
-		.strict()
-		.refine((alias) => alias.desiredRevision !== alias.processRevision, {
-			message: "revision alias must describe distinct desired and process revisions",
-		}),
-);
-
-const runtimeAppliedStateFileSchema = z
+export const runtimeAppliedStateSchema = z
 	.object({
 		schemaVersion: z.literal("clawdi.runtimeAppliedState.v2"),
 		appliedAt: z.string().datetime({ offset: true }),
@@ -68,21 +53,7 @@ const runtimeAppliedStateFileSchema = z
 		applyReceiptId: z.string().min(16).max(128).optional(),
 		bootNonce: z.string().min(16).max(128).optional(),
 		contentIdentity: appliedContentSourceSchema,
-		activated: activatedSystemdUnitsSchema.optional(),
-		// Accepted only to migrate released 0.13.92 and 0.14.14 state.
-		egressSidecarSecretRevision: z
-			.string()
-			.regex(/^[a-f0-9]{64}$/)
-			.optional(),
-		daemonAuthTokenRevision: z
-			.string()
-			.regex(/^[a-f0-9]{64}$/)
-			.optional(),
-		daemonProgramRevision: z
-			.string()
-			.regex(/^[a-f0-9]{32}$/)
-			.optional(),
-		userProcessRevisionAliases: userProcessRevisionAliasesSchema.optional(),
+		activated: activatedSystemdUnitsSchema,
 		officialServiceCommandRevisions: officialServiceCommandRevisionsSchema.optional(),
 		providerIds: providerIdsSchema,
 		projectedProviderIds: projectedProviderIdsSchema,
@@ -106,17 +77,6 @@ const runtimeAppliedStateFileSchema = z
 			});
 		}
 	});
-
-export const runtimeAppliedStateSchema = runtimeAppliedStateFileSchema.transform(
-	({
-		egressSidecarSecretRevision: _egressSidecarSecretRevision,
-		daemonAuthTokenRevision: _daemonAuthTokenRevision,
-		daemonProgramRevision: _daemonProgramRevision,
-		userProcessRevisionAliases: _userProcessRevisionAliases,
-		...state
-	}) => ({ ...state, activated: state.activated ?? {} }),
-);
-
 export type RuntimeAppliedState = z.infer<typeof runtimeAppliedStateSchema>;
 export type RuntimeAppliedStateV2 = RuntimeAppliedState;
 export type RuntimeAppliedContentSource = z.infer<typeof appliedContentSourceSchema>;

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -96,48 +96,28 @@ const runtimeCliBadSchema = z
 
 type RuntimeCliBad = z.infer<typeof runtimeCliBadSchema>;
 
-const cliBootstrapV1Schema = z
+const runtimeCliStateSchema = z
 	.object({
 		schemaVersion: z.literal("clawdi.cliNpmBootstrapStatus.v1"),
 		generatedAt: z.string().min(1),
 		status: z.literal("installed"),
 		source: z.literal("npm"),
-		packageSpec: z.string().min(1),
-		registry: z.string().min(1).nullable(),
+		packageSpec: hostedCliPackageSpecSchema,
+		registry: z.literal(NPM_REGISTRY),
 		npmPrefix: z.string().min(1),
 		npmCache: z.string().min(1),
 		activePath: z.string().min(1),
 		activeTarget: z.string().min(1),
 		version: z.string().min(1),
-		verification: runtimeCliVerificationSchema.optional(),
+		verification: runtimeCliVerificationSchema,
+		previous: runtimeCliTargetSchema.nullable(),
+		bad: runtimeCliBadSchema.nullable(),
 		error: z.string().nullable(),
 	})
 	.strict();
 
-const runtimeCliBootstrapStatusSchema = cliBootstrapV1Schema
-	.partial()
-	.extend({
-		status: z.string().optional(),
-		source: z.string().optional(),
-		verification: runtimeCliVerificationSchema.loose().optional(),
-		previous: runtimeCliTargetSchema.loose().nullable().optional(),
-		bad: runtimeCliBadSchema.loose().nullable().optional(),
-	})
-	.loose();
-
-export type RuntimeCliBootstrapStatus = z.infer<typeof runtimeCliBootstrapStatusSchema>;
-
-const runtimeCliStateSchema = cliBootstrapV1Schema
-	.extend({
-		packageSpec: hostedCliPackageSpecSchema,
-		registry: z.literal(NPM_REGISTRY),
-		verification: runtimeCliVerificationSchema,
-		previous: runtimeCliTargetSchema.nullable(),
-		bad: runtimeCliBadSchema.nullable(),
-	})
-	.strict();
-
-type RuntimeCliState = z.infer<typeof runtimeCliStateSchema>;
+export type RuntimeCliBootstrapStatus = z.infer<typeof runtimeCliStateSchema>;
+type RuntimeCliState = RuntimeCliBootstrapStatus;
 
 interface VerifiedCliTarget extends RuntimeCliTarget {
 	verification: RuntimeCliVerification;
@@ -314,7 +294,6 @@ export function reconcilePendingRuntimeCliUpgrade(
 	paths: RuntimePaths,
 	runningVersion?: string,
 ): RuntimeCliReconciliationResult {
-	discardLegacyUpgradeState(paths);
 	const status = readRuntimeCliBootstrapStatus(paths);
 	let state = parseCliState(paths, status);
 	const activeTarget = activeLinkTarget(paths.cliManagedBin);
@@ -371,9 +350,7 @@ export function readRuntimeCliBootstrapStatus(
 ): RuntimeCliBootstrapStatus | null {
 	if (!existsSync(paths.cliBootstrapStatus)) return null;
 	try {
-		return runtimeCliBootstrapStatusSchema.parse(
-			JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8")),
-		);
+		return runtimeCliStateSchema.parse(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8")));
 	} catch (error) {
 		log.warn("runtime.cli_bootstrap_status_invalid", {
 			path: paths.cliBootstrapStatus,
@@ -553,10 +530,6 @@ function reconciliationResult(
 			activeVersion !== undefined &&
 			activeVersion !== runningVersion,
 	};
-}
-
-function discardLegacyUpgradeState(paths: RuntimePaths): void {
-	if (existsSync(paths.cliUpgradeState)) rmSync(paths.cliUpgradeState, { force: true });
 }
 
 function validateRegistry(value: string | undefined): void {

--- a/packages/cli/src/runtime/hosted-sourced-skill-archive.ts
+++ b/packages/cli/src/runtime/hosted-sourced-skill-archive.ts
@@ -132,7 +132,7 @@ async function fetchProjectSkillArchive(
 		const skillDir = join(extractedRoot, skillId);
 		const canonical = await snapshotSkillArchive(skillDir, extractedRoot, skillId);
 		const skillEntries = readdirSync(skillDir);
-		// SUNSET: remove once the control plane has backfilled tree hashes for pre-2026-04-28 project skills.
+		// SUNSET(hosted #1839): remove once the control plane has backfilled tree hashes for pre-2026-04-28 project skills.
 		const matchesLegacySingleFileHash =
 			skillEntries.length === 1 &&
 			skillEntries[0] === "SKILL.md" &&

--- a/packages/cli/src/runtime/manifest-channels.test.ts
+++ b/packages/cli/src/runtime/manifest-channels.test.ts
@@ -13,14 +13,10 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-	materializeHostedChannelCredentials,
-	validateHostedChannelCredentialsPlan,
-} from "./manifest-channels";
+import { materializeHostedChannelCredentials } from "./manifest-channels";
 import type { RuntimeManifest } from "./manifest-contract";
 import { withRuntimeUserFileAccess } from "./runtime-user-command";
 
-const LEGACY_MARKER = ".clawdi-managed-whatsapp-auth.json";
 const ACCOUNT_KEY = "clawdi_whatsapp_test";
 const SECRET_REF = `secret://channels/whatsapp/${ACCOUNT_KEY}/credentials/credential-test/creds-json`;
 
@@ -75,17 +71,12 @@ function manifest(path: string, credentialId = "credential-test"): RuntimeManife
 	};
 }
 
-function credsJson(
-	secret = "managed-secret",
-	credentialId?: string,
-	legacyCapability = false,
-): string {
+function credsJson(secret = "managed-secret", credentialId?: string): string {
 	return JSON.stringify({
 		advSecretKey: secret,
 		additionalData: {
 			"clawdi.managedWhatsAppSocket": {
 				schemaVersion: "clawdi.managedWhatsAppSocket.v1",
-				...(legacyCapability ? { capability: `clawdi_${"a".repeat(32)}` } : {}),
 				authCert: {
 					SERIAL: 7,
 					ISSUER: "clawdi",
@@ -105,16 +96,6 @@ function credsJson(
 				: {}),
 		},
 	});
-}
-
-function legacyMarker(credentialId = "credential-test"): string {
-	return `${JSON.stringify({
-		schemaVersion: "clawdi.managedWhatsAppAuth.v1",
-		provider: "whatsapp",
-		target: "legacy",
-		accountKey: ACCOUNT_KEY,
-		credentialId,
-	})}\n`;
 }
 
 describe("managed WhatsApp auth directories", () => {
@@ -145,36 +126,6 @@ describe("managed WhatsApp auth directories", () => {
 		expect(existsSync(path)).toBe(false);
 	});
 
-	test("adopts 0.13.92 and 0.14.14 creds metadata without replacing sessions", () => {
-		const path = authDir();
-		mkdirSync(path, { recursive: true });
-		const sessionPath = join(path, "session-key.json");
-		writeFileSync(join(path, "creds.json"), `${credsJson("legacy-secret", undefined, true)}\n`);
-		writeFileSync(sessionPath, '{"preserved":true}\n');
-		writeFileSync(join(path, LEGACY_MARKER), legacyMarker("credential-old"));
-		const sessionBefore = { bytes: readFileSync(sessionPath), inode: statSync(sessionPath).ino };
-		const desired = manifest(path, "credential-new");
-
-		validateHostedChannelCredentialsPlan(
-			desired,
-			{ [SECRET_REF]: credsJson("legacy-secret", "credential-new") },
-			home,
-		);
-		expect(existsSync(join(path, LEGACY_MARKER))).toBe(true);
-
-		materializeHostedChannelCredentials(
-			desired,
-			{ [SECRET_REF]: credsJson("legacy-secret", "credential-new") },
-			home,
-		);
-		expect(existsSync(join(path, LEGACY_MARKER))).toBe(false);
-		const rewrittenCreds = readFileSync(join(path, "creds.json"), "utf8");
-		expect(rewrittenCreds).toContain("credential-new");
-		expect(rewrittenCreds).not.toContain("capability");
-		expect(readFileSync(sessionPath)).toEqual(sessionBefore.bytes);
-		expect(statSync(sessionPath).ino).toBe(sessionBefore.inode);
-	});
-
 	test("rejects directories without valid creds metadata", () => {
 		const cases = [
 			JSON.stringify({ advSecretKey: "user-secret" }),
@@ -190,7 +141,6 @@ describe("managed WhatsApp auth directories", () => {
 			const path = authDir();
 			mkdirSync(path, { recursive: true });
 			writeFileSync(join(path, "creds.json"), `${creds}\n`);
-			writeFileSync(join(path, LEGACY_MARKER), legacyMarker());
 
 			expect(() =>
 				materializeHostedChannelCredentials(

--- a/packages/cli/src/runtime/manifest-channels.ts
+++ b/packages/cli/src/runtime/manifest-channels.ts
@@ -25,7 +25,7 @@ import {
 	runtimeFileCurrentRevision,
 } from "./manifest-install";
 import { openClawConfigPatchIsApplied } from "./manifest-providers";
-import { hasExactKeys, isPlainRecord, recordValue } from "./manifest-shared";
+import { isPlainRecord, recordValue } from "./manifest-shared";
 import { openClawPluginInspectSchema } from "./openclaw-plugin-observation";
 import {
 	runRuntimeUserCommand,
@@ -45,7 +45,6 @@ import {
 	parseManagedWhatsAppSocketMetadataJson,
 } from "./whatsapp-upstream-contract";
 
-const LEGACY_MANAGED_WHATSAPP_AUTH_MARKER = ".clawdi-managed-whatsapp-auth.json";
 export function materializeHostedChannelCredentials(
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
@@ -140,7 +139,6 @@ function materializeManagedWhatsAppAuthDir(
 			dirMode: 0o700,
 		},
 	);
-	rmSync(join(credential.authDir, LEGACY_MANAGED_WHATSAPP_AUTH_MARKER), { force: true });
 }
 
 interface ManagedWhatsAppAuthDirInspection {
@@ -292,17 +290,9 @@ export function readManagedWhatsAppAuthMetadata(
 			return null;
 		}
 		try {
-			const socketMetadata = recordValue(
+			parseManagedWhatsAppSocketMetadataJson(
 				additionalData[CLAWDI_MANAGED_WHATSAPP_SOCKET_METADATA_KEY],
 			);
-			const normalizedSocketMetadata =
-				socketMetadata &&
-				hasExactKeys(socketMetadata, ["authCert", "capability", "schemaVersion"]) &&
-				typeof socketMetadata.capability === "string" &&
-				/^clawdi_[a-f0-9]{32}$/.test(socketMetadata.capability)
-					? { schemaVersion: socketMetadata.schemaVersion, authCert: socketMetadata.authCert }
-					: socketMetadata;
-			parseManagedWhatsAppSocketMetadataJson(normalizedSocketMetadata);
 			const credentialMetadata = Object.hasOwn(
 				additionalData,
 				CLAWDI_MANAGED_WHATSAPP_CREDENTIAL_METADATA_KEY,

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -30,17 +30,6 @@ export const OFFICIAL_INSTALL_URLS: Record<string, string> = {
 };
 
 const HOSTED_GATEWAY_RUN_ARGS = ["gateway", "run"] as const;
-const LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS = [
-	"gateway",
-	"run",
-	"--allow-unconfigured",
-	"--port",
-	"18789",
-	"--bind",
-	"lan",
-	"--force",
-] as const;
-const LEGACY_HOSTED_HERMES_GATEWAY_RUN_ARGS = ["gateway", "run", "--replace"] as const;
 const HOSTED_HERMES_DASHBOARD_ARGS = [
 	"dashboard",
 	"--host",
@@ -55,17 +44,6 @@ function exactStringArray(value: unknown, expected: readonly string[]): boolean 
 		Array.isArray(value) &&
 		value.length === expected.length &&
 		value.every((entry, index) => entry === expected[index])
-	);
-}
-
-export function isHostedGatewayRunArgs(runtime: "openclaw" | "hermes", value: unknown): boolean {
-	// Keep the previous producer shape readable while the fleet moves to a CLI
-	// that leaves command ownership with the official gateway unit.
-	return (
-		exactStringArray(value, HOSTED_GATEWAY_RUN_ARGS) ||
-		(runtime === "openclaw" && exactStringArray(value, LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS)) ||
-		// SUNSET: remove once every hosted Hermes host has converged on CLI >= 0.14.14 (last-good rewritten canonical).
-		(runtime === "hermes" && exactStringArray(value, LEGACY_HOSTED_HERMES_GATEWAY_RUN_ARGS))
 	);
 }
 
@@ -781,7 +759,7 @@ function validateHostedRuntimeManifest(
 			);
 		}
 		const run = manifest.runtimes.openclaw?.run;
-		if (!isHostedGatewayRunArgs("openclaw", run?.args)) {
+		if (!exactStringArray(run?.args, HOSTED_GATEWAY_RUN_ARGS)) {
 			addIssue(
 				"OpenClaw v2 gateway must use the official gateway run command",
 				runtimePath("run", "args"),
@@ -827,7 +805,7 @@ function validateHostedRuntimeManifest(
 				systemPath("openclawGatewayTrustedProxies"),
 			);
 		}
-		if (!isHostedGatewayRunArgs("hermes", manifest.runtimes.hermes?.run.args)) {
+		if (!exactStringArray(manifest.runtimes.hermes?.run.args, HOSTED_GATEWAY_RUN_ARGS)) {
 			addIssue(
 				"Hermes gateway must use the official gateway run command",
 				runtimePath("run", "args"),
@@ -940,7 +918,7 @@ export const hostedRuntimeBundleV2ManifestSchema =
 						home: paths.userHome,
 						args: officialInstallArgs(selectedRuntime, paths.userHome),
 					},
-					run: hostedRuntimeRunSettings(selectedRuntime, runtime.run),
+					run: copyHostedRuntimeRunSettings(runtime.run),
 					services: Object.fromEntries(
 						Object.entries(runtime.services).map(([service, run]) => [
 							service,
@@ -976,15 +954,6 @@ function hostedRuntimeProviderBinding(
 	| { provider_ids: [] } {
 	if (runtime.providerMode === "unmanaged") return { provider_ids: [] };
 	return { provider_ids: runtime.provider_ids, primary_model: runtime.primary_model };
-}
-
-function hostedRuntimeRunSettings(
-	runtime: HostedRuntimeBundleV2ManifestWire["runtime"],
-	run: HostedRuntimeRunSettings,
-): ReturnType<typeof copyHostedRuntimeRunSettings> {
-	const settings = copyHostedRuntimeRunSettings(run);
-	if (isHostedGatewayRunArgs(runtime, run.args)) settings.args = ["gateway", "run"];
-	return settings;
 }
 
 function copyHostedRuntimeRunSettings(run: HostedRuntimeRunSettings): {

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -30,6 +30,19 @@ export const OFFICIAL_INSTALL_URLS: Record<string, string> = {
 };
 
 const HOSTED_GATEWAY_RUN_ARGS = ["gateway", "run"] as const;
+// SUNSET: delete after hosted flips `_runtime_run_state('openclaw')` to the canonical
+// official gateway command, existing runtime states are re-pushed, and the wire is
+// verified canonical.
+const LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS = [
+	"gateway",
+	"run",
+	"--allow-unconfigured",
+	"--port",
+	"18789",
+	"--bind",
+	"lan",
+	"--force",
+] as const;
 const HOSTED_HERMES_DASHBOARD_ARGS = [
 	"dashboard",
 	"--host",
@@ -44,6 +57,13 @@ function exactStringArray(value: unknown, expected: readonly string[]): boolean 
 		Array.isArray(value) &&
 		value.length === expected.length &&
 		value.every((entry, index) => entry === expected[index])
+	);
+}
+
+export function isHostedGatewayRunArgs(runtime: "openclaw" | "hermes", value: unknown): boolean {
+	return (
+		exactStringArray(value, HOSTED_GATEWAY_RUN_ARGS) ||
+		(runtime === "openclaw" && exactStringArray(value, LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS))
 	);
 }
 
@@ -759,7 +779,7 @@ function validateHostedRuntimeManifest(
 			);
 		}
 		const run = manifest.runtimes.openclaw?.run;
-		if (!exactStringArray(run?.args, HOSTED_GATEWAY_RUN_ARGS)) {
+		if (!isHostedGatewayRunArgs("openclaw", run?.args)) {
 			addIssue(
 				"OpenClaw v2 gateway must use the official gateway run command",
 				runtimePath("run", "args"),
@@ -805,7 +825,7 @@ function validateHostedRuntimeManifest(
 				systemPath("openclawGatewayTrustedProxies"),
 			);
 		}
-		if (!exactStringArray(manifest.runtimes.hermes?.run.args, HOSTED_GATEWAY_RUN_ARGS)) {
+		if (!isHostedGatewayRunArgs("hermes", manifest.runtimes.hermes?.run.args)) {
 			addIssue(
 				"Hermes gateway must use the official gateway run command",
 				runtimePath("run", "args"),
@@ -918,7 +938,7 @@ export const hostedRuntimeBundleV2ManifestSchema =
 						home: paths.userHome,
 						args: officialInstallArgs(selectedRuntime, paths.userHome),
 					},
-					run: copyHostedRuntimeRunSettings(runtime.run),
+					run: hostedRuntimeRunSettings(selectedRuntime, runtime.run),
 					services: Object.fromEntries(
 						Object.entries(runtime.services).map(([service, run]) => [
 							service,
@@ -954,6 +974,15 @@ function hostedRuntimeProviderBinding(
 	| { provider_ids: [] } {
 	if (runtime.providerMode === "unmanaged") return { provider_ids: [] };
 	return { provider_ids: runtime.provider_ids, primary_model: runtime.primary_model };
+}
+
+function hostedRuntimeRunSettings(
+	runtime: HostedRuntimeBundleV2ManifestWire["runtime"],
+	run: HostedRuntimeRunSettings,
+): ReturnType<typeof copyHostedRuntimeRunSettings> {
+	const settings = copyHostedRuntimeRunSettings(run);
+	if (isHostedGatewayRunArgs(runtime, run.args)) settings.args = ["gateway", "run"];
+	return settings;
 }
 
 function copyHostedRuntimeRunSettings(run: HostedRuntimeRunSettings): {

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, rmSync } from "node:fs";
+import { chmodSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { readRuntimeAppliedState } from "./applied-state";
 import { removeHostedCliPathExposure } from "./cli-update";
@@ -470,8 +470,6 @@ function prepareRuntimeApplyDependencies(
 		workspaceRoot,
 		runtimeEntries,
 	} = context;
-	// SUNSET: remove after the whole fleet has converged on receipt-free channel state.
-	rmSync(join(paths.managedResourceRoot, "whatsapp-auth"), { recursive: true, force: true });
 	ensureFileBrowserCompanion(manifest, paths, opts.fileBrowserInstallOptions);
 	let codexCli: Record<string, string> | null = null;
 	withRuntimeUserFileAccess(() => {

--- a/packages/cli/src/runtime/manifest-mcp.ts
+++ b/packages/cli/src/runtime/manifest-mcp.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
 	getHermesRawConfigValue,
@@ -72,8 +72,6 @@ export function applyHostedMcpProjections(
 			runRuntimeUserCommand(runtime.commandPath, args, "", plan.home, workspaceRoot);
 		}
 	}
-	// SUNSET: remove after the fleet has converged on content-owned MCP state.
-	rmSync(join(paths.managedResourceRoot, "managed-mcp-servers.json"), { force: true });
 }
 type HostedMcpTarget = (typeof HOSTED_RUNTIME_TARGETS)[number];
 type HostedMcpNativeServer = ReturnType<typeof hostedMcpNativeServerConfig>;

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -649,6 +649,7 @@ function hostedHermesManifestFixture(
 
 function hostedOpenClawV2ManifestFixture(
 	overrides: Record<string, unknown> = {},
+	gatewayArgs: string[] = ["gateway", "run"],
 ): Record<string, unknown> {
 	const publicUrl = "https://agent.example.test/control";
 	return hostedManifestFixture({
@@ -661,7 +662,7 @@ function hostedOpenClawV2ManifestFixture(
 		runtimes: {
 			openclaw: hostedRuntimeFixture({
 				run: {
-					args: ["gateway", "run"],
+					args: gatewayArgs,
 					secretEnv: {
 						OPENCLAW_GATEWAY_TOKEN: "secret://runtime/openclaw/gateway-token",
 					},
@@ -671,6 +672,17 @@ function hostedOpenClawV2ManifestFixture(
 		...overrides,
 	});
 }
+
+const LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS = [
+	"gateway",
+	"run",
+	"--allow-unconfigured",
+	"--port",
+	"18789",
+	"--bind",
+	"lan",
+	"--force",
+];
 
 function normalizeHostedBundleFixture(
 	manifest: Record<string, unknown>,
@@ -1033,6 +1045,24 @@ describe("runtime manifest reconciliation invariants", () => {
 		).hermes.services.dashboard;
 		dashboard.env = { EXTRA: "value" };
 		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(hermesDashboardEnv).success).toBe(false);
+	});
+
+	test("normalizes the hosted OpenClaw producer gateway args", () => {
+		const legacy = hostedRuntimeBundleV2ManifestSchema.parse(
+			hostedOpenClawV2ManifestFixture({}, LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS),
+		);
+		expect(legacy.runtimes.openclaw.run?.args).toEqual(["gateway", "run"]);
+
+		const unsupported = hostedOpenClawV2ManifestFixture({}, ["gateway", "run", "--force"]);
+		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(unsupported).success).toBe(false);
+
+		const legacyHermes = hostedHermesManifestFixture();
+		(legacyHermes.runtimes as { hermes: { run: { args: string[] } } }).hermes.run.args = [
+			"gateway",
+			"run",
+			"--replace",
+		];
+		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(legacyHermes).success).toBe(false);
 	});
 
 	test("requires official Basic auth and direct 9119 exposure for hosted Hermes v2", () => {
@@ -1882,7 +1912,10 @@ describe("runtime manifest reconciliation invariants", () => {
 		);
 		chmodSync(openclawBin, 0o700);
 
-		const projected = hostedRuntimeBundleV2ManifestSchema.parse(hostedOpenClawV2ManifestFixture());
+		const projected = hostedRuntimeBundleV2ManifestSchema.parse(
+			hostedOpenClawV2ManifestFixture({}, LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS),
+		);
+		expect(projected.runtimes.openclaw.run?.args).toEqual(["gateway", "run"]);
 		const normalized: RuntimeManifest = {
 			...projected,
 			egressEngine: installCachedTestEgressEngine(paths, "12.2.3-test-native-auth"),

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -615,7 +615,6 @@ function hostedRuntimeFixture(overrides: Record<string, unknown> = {}): Record<s
 
 function hostedHermesManifestFixture(
 	overrides: Record<string, unknown> = {},
-	gatewayArgs: string[] = ["gateway", "run"],
 ): Record<string, unknown> {
 	return hostedManifestFixture({
 		runtime: "hermes",
@@ -636,7 +635,7 @@ function hostedHermesManifestFixture(
 		},
 		runtimes: {
 			hermes: hostedRuntimeFixture({
-				run: { args: gatewayArgs },
+				run: { args: ["gateway", "run"] },
 				services: {
 					dashboard: {
 						args: ["dashboard", "--host", "0.0.0.0", "--port", "9119", "--no-open"],
@@ -648,20 +647,8 @@ function hostedHermesManifestFixture(
 	});
 }
 
-const LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS = [
-	"gateway",
-	"run",
-	"--allow-unconfigured",
-	"--port",
-	"18789",
-	"--bind",
-	"lan",
-	"--force",
-];
-
 function hostedOpenClawV2ManifestFixture(
 	overrides: Record<string, unknown> = {},
-	gatewayArgs: string[] = ["gateway", "run"],
 ): Record<string, unknown> {
 	const publicUrl = "https://agent.example.test/control";
 	return hostedManifestFixture({
@@ -674,7 +661,7 @@ function hostedOpenClawV2ManifestFixture(
 		runtimes: {
 			openclaw: hostedRuntimeFixture({
 				run: {
-					args: gatewayArgs,
+					args: ["gateway", "run"],
 					secretEnv: {
 						OPENCLAW_GATEWAY_TOKEN: "secret://runtime/openclaw/gateway-token",
 					},
@@ -1046,18 +1033,6 @@ describe("runtime manifest reconciliation invariants", () => {
 		).hermes.services.dashboard;
 		dashboard.env = { EXTRA: "value" };
 		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(hermesDashboardEnv).success).toBe(false);
-	});
-
-	test("normalizes previous gateway args during the official-unit rollout", () => {
-		const legacy = hostedOpenClawV2ManifestFixture({}, LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS);
-		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(legacy).success).toBe(true);
-		const legacyHermes = hostedRuntimeBundleV2ManifestSchema.parse(
-			hostedHermesManifestFixture({}, ["gateway", "run", "--replace"]),
-		);
-		expect(legacyHermes.runtimes.hermes.run?.args).toEqual(["gateway", "run"]);
-
-		const unsupported = hostedOpenClawV2ManifestFixture({}, ["gateway", "run", "--force"]);
-		expect(hostedRuntimeBundleV2ManifestSchema.safeParse(unsupported).success).toBe(false);
 	});
 
 	test("requires official Basic auth and direct 9119 exposure for hosted Hermes v2", () => {
@@ -1907,9 +1882,7 @@ describe("runtime manifest reconciliation invariants", () => {
 		);
 		chmodSync(openclawBin, 0o700);
 
-		const legacy = hostedOpenClawV2ManifestFixture({}, LEGACY_HOSTED_OPENCLAW_GATEWAY_RUN_ARGS);
-		const projected = hostedRuntimeBundleV2ManifestSchema.parse(legacy);
-		expect(projected.runtimes.openclaw.run?.args).toEqual(["gateway", "run"]);
+		const projected = hostedRuntimeBundleV2ManifestSchema.parse(hostedOpenClawV2ManifestFixture());
 		const normalized: RuntimeManifest = {
 			...projected,
 			egressEngine: installCachedTestEgressEngine(paths, "12.2.3-test-native-auth"),

--- a/packages/cli/src/runtime/observed-v2.test.ts
+++ b/packages/cli/src/runtime/observed-v2.test.ts
@@ -109,7 +109,29 @@ describe("hosted runtime observed v2", () => {
 		mkdirSync(dirname(paths.cliBootstrapStatus), { recursive: true });
 		writeFileSync(
 			paths.cliBootstrapStatus,
-			JSON.stringify({ version: "0.0.0-stale", imageShimExtension: true }),
+			JSON.stringify({
+				schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
+				generatedAt: "2026-07-13T06:00:00.000Z",
+				status: "installed",
+				source: "npm",
+				packageSpec: "clawdi@0.0.0-stale",
+				registry: "https://registry.npmjs.org",
+				npmPrefix: paths.cliNpmPrefix,
+				npmCache: paths.cliNpmCache,
+				activePath: paths.cliManagedBin,
+				activeTarget: join(paths.cliNpmPrefix, "bin", "clawdi"),
+				version: "0.0.0-stale",
+				verification: {
+					verifiedAt: "2026-07-13T06:00:00.000Z",
+					device: 0,
+					inode: 0,
+					size: 0,
+					modifiedAtMs: 0,
+				},
+				previous: null,
+				bad: null,
+				error: null,
+			}),
 		);
 
 		const observed = readHostedRuntimeObserved(paths);

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -152,13 +152,13 @@ function runtimeConvergeError(watchStatus: JsonRecord | null): string | null {
 function observedCli(value: RuntimeCliBootstrapStatus | null): HostedRuntimeObservedCli | null {
 	if (!value) return null;
 	return {
-		status: value.status ?? null,
-		source: value.source ?? null,
-		packageSpec: value.packageSpec ?? null,
-		registry: value.registry ?? null,
-		activePath: value.activePath ?? null,
-		activeTarget: value.activeTarget ?? null,
-		version: value.version ?? null,
+		status: value.status,
+		source: value.source,
+		packageSpec: value.packageSpec,
+		registry: value.registry,
+		activePath: value.activePath,
+		activeTarget: value.activeTarget,
+		version: value.version,
 	};
 }
 

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -40,7 +40,6 @@ export interface RuntimePaths {
 	cliNpmCache: string;
 	userNpmPrefix: string;
 	cliBootstrapStatus: string;
-	cliUpgradeState: string;
 	providerHealthStatus: string;
 	egressEngineMaintainedRoot: string;
 	fileBrowserInstallRoot: string;
@@ -178,7 +177,6 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 		cliNpmCache: join(cacheRoot, "npm"),
 		userNpmPrefix: userLocalRoot,
 		cliBootstrapStatus: join(statusRoot, "cli-bootstrap.json"),
-		cliUpgradeState: join(statusRoot, "cli-upgrade-state.json"),
 		providerHealthStatus: join(statusRoot, "provider-health.json"),
 		egressEngineMaintainedRoot: join(maintainedRoot, "egress-engine", "mitmproxy"),
 		fileBrowserInstallRoot: join(maintainedRoot, "filebrowser"),

--- a/packages/cli/src/runtime/state.ts
+++ b/packages/cli/src/runtime/state.ts
@@ -1,8 +1,7 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { chmodSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { assertTrustedDirectory, ensureDirectoryWithinTrustedRoot } from "../lib/trusted-directory";
-import { log, toErrorMessage } from "../serve/log";
 import type { HostPolicyReadResult } from "./host-policy";
 import type { RuntimeMitmproxyEnsureResult } from "./mitmproxy-fetch";
 import {
@@ -81,7 +80,6 @@ export interface RuntimeBootStatus {
 		cliManagedBin: string;
 		cliNpmPrefix: string;
 		cliBootstrapStatus: string;
-		cliUpgradeState: string;
 		bootStatus: string;
 		runtimeWatchStatus: string;
 		runRoot: string;
@@ -115,7 +113,6 @@ function pathSummary(paths: RuntimePaths): RuntimeBootStatus["paths"] {
 		cliManagedBin: paths.cliManagedBin,
 		cliNpmPrefix: paths.cliNpmPrefix,
 		cliBootstrapStatus: paths.cliBootstrapStatus,
-		cliUpgradeState: paths.cliUpgradeState,
 		bootStatus: paths.bootStatus,
 		runtimeWatchStatus: paths.runtimeWatchStatus,
 		runRoot: paths.runRoot,
@@ -208,14 +205,6 @@ export function writeRuntimePlatformFileAtomic(
 	writePrivateFileAtomic(path, content, { ...options, trustedRoot });
 }
 
-function removeRetiredRuntimeState(path: string): void {
-	try {
-		rmSync(path, { force: true, recursive: true });
-	} catch (error) {
-		log.warn("runtime.retired_state_cleanup_failed", { path, error: toErrorMessage(error) });
-	}
-}
-
 export function ensureRuntimeStateDirs(paths = getRuntimePaths()): void {
 	for (const [path, systemdPath, mode] of [
 		[paths.configurationRoot, DEFAULT_CONFIGURATION_ROOT, 0o700],
@@ -239,20 +228,6 @@ export function ensureRuntimeStateDirs(paths = getRuntimePaths()): void {
 			chmodSync(path, mode);
 		}
 	}
-	// SUNSET: remove state written before 0.14.14 once the fleet has upgraded.
-	for (const path of [
-		join(paths.configurationRoot, "clawdi.json"),
-		join(paths.configurationRoot, "runtime-live-sync-agents.json"),
-		join(paths.configurationRoot, "projections"),
-		join(paths.serviceStateRoot, "sync"),
-		join(paths.serviceStateRoot, "install-inventory"),
-		join(paths.statusRoot, "cloud-status.json"),
-		join(paths.statusRoot, "cloud-result.json"),
-		join(paths.statusRoot, "egress-engine.json"),
-		join(paths.statusRoot, "runtime-install-receipts.json"),
-		join(paths.cacheRoot, "channels.etag"),
-	])
-		removeRetiredRuntimeState(path);
 	for (const [dir, mode] of [
 		[paths.statusRoot, 0o755],
 		[paths.runConfigRoot, 0o755],

--- a/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
+++ b/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
@@ -293,6 +293,7 @@ function createFixture(): Fixture {
 				sourcePath: "https://runtime.test/v1/runtime/manifest",
 				sha256: "b".repeat(64),
 			},
+			activated: {},
 			providerIds: ["managed"],
 			projectedProviderIds: { codex: ["managed"] },
 		})}\n`,

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -221,6 +221,7 @@ function seedLocalCli(paths: ReturnType<typeof getRuntimePaths>): string {
 	);
 	expect(install.status, install.stderr).toBe(0);
 	const activeTarget = join(prefix, "bin", "clawdi");
+	const activeIdentity = statSync(activeTarget);
 	mkdirSync(dirname(paths.cliManagedBin), { recursive: true, mode: 0o755 });
 	symlinkSync(activeTarget, paths.cliManagedBin);
 	writeFileSync(
@@ -237,6 +238,15 @@ function seedLocalCli(paths: ReturnType<typeof getRuntimePaths>): string {
 			activePath: paths.cliManagedBin,
 			activeTarget,
 			version,
+			verification: {
+				verifiedAt: new Date().toISOString(),
+				device: activeIdentity.dev,
+				inode: activeIdentity.ino,
+				size: activeIdentity.size,
+				modifiedAtMs: activeIdentity.mtimeMs,
+			},
+			previous: null,
+			bad: null,
 			error: null,
 		})}\n`,
 		{ mode: 0o600 },

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -574,12 +574,7 @@ afterAll(() => {
 	process.exitCode = 0;
 });
 
-function seedCurrentCliInstall(
-	state: string,
-	packageSpec: string,
-	version = "1.2.3-test",
-	registry: string | null = null,
-): void {
+function seedCurrentCliInstall(state: string, version = "1.2.3-test"): void {
 	const paths = getRuntimePaths();
 	if (paths.serviceStateRoot !== state) throw new Error("CLI fixture state root mismatch");
 	const active = paths.cliManagedBin;
@@ -604,23 +599,6 @@ echo "seeded clawdi"
 	chmodSync(target, 0o700);
 	rmSync(active, { force: true });
 	symlinkSync(target, active);
-	writeFileSync(
-		paths.cliBootstrapStatus,
-		JSON.stringify({
-			schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
-			generatedAt: "2026-06-06T00:00:00Z",
-			status: "installed",
-			source: "npm",
-			packageSpec,
-			registry,
-			npmPrefix: paths.cliNpmPrefix,
-			npmCache: paths.cliNpmCache,
-			activePath: active,
-			activeTarget: target,
-			version,
-			error: null,
-		}),
-	);
 }
 
 function setRuntimeApplyContextFixture(
@@ -693,28 +671,6 @@ function pointManagedCliAt(paths: RuntimePaths, identity: RuntimeCliFixtureIdent
 	mkdirSync(dirname(paths.cliManagedBin), { recursive: true });
 	rmSync(paths.cliManagedBin, { force: true });
 	symlinkSync(identity.activeTarget, paths.cliManagedBin);
-}
-
-function writeCliBootstrapFixture(paths: RuntimePaths, identity: RuntimeCliFixtureIdentity): void {
-	mkdirSync(dirname(paths.cliBootstrapStatus), { recursive: true });
-	writeFileSync(
-		paths.cliBootstrapStatus,
-		`${JSON.stringify({
-			schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
-			generatedAt: "2026-07-29T00:00:00.000Z",
-			status: "installed",
-			source: "npm",
-			packageSpec: identity.packageSpec,
-			registry: identity.registry,
-			npmPrefix: identity.npmPrefix,
-			npmCache: paths.cliNpmCache,
-			activePath: paths.cliManagedBin,
-			activeTarget: identity.activeTarget,
-			version: identity.version,
-			error: null,
-		})}\n`,
-		{ mode: 0o600 },
-	);
 }
 
 function cliManifest(version: string): RuntimeManifest {
@@ -1405,12 +1361,7 @@ function seedRuntimeWatchLocaleBaseline(home: string, state: string, run: string
 	process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
 	process.env.CLAWDI_AUTH_TOKEN = "file-runtime-token";
 	setRuntimeApplyGeneration(1, CANONICAL_TEST_CONTEXT);
-	seedCurrentCliInstall(
-		state,
-		TEST_RUNNING_CLI_SPEC,
-		TEST_RUNNING_CLI_VERSION,
-		"https://registry.npmjs.org",
-	);
+	seedCurrentCliInstall(state, TEST_RUNNING_CLI_VERSION);
 	writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 	const paths = getRuntimePaths();
 	seedMitmproxyCache(paths);
@@ -2595,59 +2546,6 @@ describe("runtime manifest datasource", () => {
 			auth: { type: "bearer", token: "test-runtime-token" },
 		});
 		expect(parsed.success).toBe(false);
-	});
-
-	it("invalidates 0.13.92 and 0.14.14 normalized last-good state offline", async () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		const paths = getRuntimePaths();
-		mkdirSync(paths.cacheRoot, { recursive: true });
-		writeFileSync(
-			paths.manifestLastGood,
-			JSON.stringify({
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_cached_secret",
-				environmentId: "env_cached_secret",
-				instanceId: "iid_cached_secret",
-				generation: 3,
-				issuedAt: "2026-06-06T00:00:00Z",
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				clawdiCli: {
-					source: "npm:clawdi",
-					packageSpec: TEST_RUNNING_CLI_SPEC,
-					registry: "https://registry.npmjs.org",
-				},
-				runtimes: { openclaw: { enabled: false } },
-				projection: {
-					sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
-					providers: {
-						default: {
-							kind: "openai-compatible",
-							baseUrl: "https://sub2api.test/v1",
-							apiKeySecretRef: "secret://provider.default.apiKey",
-						},
-					},
-				},
-				recovery: { cacheManifest: true, allowOfflineBoot: true },
-			}),
-		);
-		writeFileSync(
-			paths.managedSecretCacheFile,
-			JSON.stringify({ "secret://provider.default.apiKey": "sk-cached-provider" }),
-		);
-
-		const loaded = await loadRuntimeManifest(paths);
-		expect("errors" in loaded).toBe(true);
-		if (!("errors" in loaded)) throw new Error("expected normalized cache invalidation");
-		expect(loaded.mode).toBe("repair");
-		expect(loaded.errors.join("\n")).toContain("could not read last-good runtime manifest");
-		expect(loaded.errors.join("\n")).not.toContain("sk-cached-provider");
 	});
 
 	it("fetches hosted-runtime manifests from a configured runtime source", async () => {
@@ -4370,11 +4268,6 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		const nativeProfileId = nativeOAuthProfileId("hermes", "openai-codex");
 		const ledgerKey = createHash("sha256").update("openai-codex").digest("hex");
 		const ledgerPath = join(paths.oauthCredentialRoot, "hermes", `${ledgerKey}.json`);
-		const retiredLedgerPath = join(
-			paths.oauthCredentialRoot,
-			"hermes",
-			`${createHash("sha256").update("retired-provider").digest("hex")}.json`,
-		);
 		mkdirSync(dirname(authPath), { recursive: true });
 		writeFileSync(
 			authPath,
@@ -4410,17 +4303,6 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 		});
 		mkdirSync(dirname(ledgerPath), { recursive: true });
 		writeFileSync(
-			retiredLedgerPath,
-			`${JSON.stringify({
-				schemaVersion: "clawdi.oauthCredentialOwnership.v2",
-				runtime: "hermes",
-				providerId: "retired-provider",
-				nativeProfileId: "retired",
-				credentialRevision: "retired",
-				state: "retired",
-			})}\n`,
-		);
-		writeFileSync(
 			ledgerPath,
 			`${JSON.stringify({
 				schemaVersion: "clawdi.oauthCredentialOwnership.v2",
@@ -4440,7 +4322,6 @@ chmod +x "$HOME/.hermes/hermes-agent/venv/bin/python"
 
 		const first = convergeRuntimeManifest(firstLoad, paths);
 		expect(first.installErrors).toEqual([]);
-		expect(existsSync(retiredLedgerPath)).toBe(false);
 		let auth = JSON.parse(readFileSync(authPath, "utf8"));
 		expect(auth.providers["openai-codex"].tokens.access_token).toBe("user-access");
 		expect(auth.credential_pool["openai-codex"][0]).toMatchObject({
@@ -6465,12 +6346,7 @@ exit 64
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(
-			state,
-			TEST_RUNNING_CLI_SPEC,
-			TEST_RUNNING_CLI_VERSION,
-			"https://registry.npmjs.org",
-		);
+		seedCurrentCliInstall(state, TEST_RUNNING_CLI_VERSION);
 		seedMitmproxyCache();
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		const { captured, restore } = mockFetch([
@@ -6665,12 +6541,7 @@ exit 64
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(
-			state,
-			TEST_RUNNING_CLI_SPEC,
-			TEST_RUNNING_CLI_VERSION,
-			"https://registry.npmjs.org",
-		);
+		seedCurrentCliInstall(state, TEST_RUNNING_CLI_VERSION);
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		setRuntimeApplyContextFixture(
 			{
@@ -7117,12 +6988,7 @@ exit 64
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(
-			state,
-			TEST_RUNNING_CLI_SPEC,
-			TEST_RUNNING_CLI_VERSION,
-			"https://registry.npmjs.org",
-		);
+		seedCurrentCliInstall(state, TEST_RUNNING_CLI_VERSION);
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		const paths = getRuntimePaths();
 		seedMitmproxyCache(paths);
@@ -7162,6 +7028,7 @@ exit 64
 						sourcePath: "https://runtime.test/v1/runtime/manifest",
 						sha256: "a".repeat(64),
 					},
+					activated: {},
 					providerIds: ["clawdi-managed-v2"],
 					projectedProviderIds: { openclaw: ["clawdi-managed-v2"] },
 				}),
@@ -7242,12 +7109,7 @@ exit 64
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
-		seedCurrentCliInstall(
-			state,
-			TEST_RUNNING_CLI_SPEC,
-			TEST_RUNNING_CLI_VERSION,
-			"https://registry.npmjs.org",
-		);
+		seedCurrentCliInstall(state, TEST_RUNNING_CLI_VERSION);
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
@@ -7977,7 +7839,7 @@ chmod +x "$prefix/bin/clawdi"
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(state, "clawdi@1.2.3-test", "1.2.3-test", "https://registry.npmjs.org");
+		seedCurrentCliInstall(state, "1.2.3-test");
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		let runtimeGeneration = 13;
 		let desiredCliPackageSpec = "clawdi@1.2.3-test";
@@ -8104,7 +7966,6 @@ chmod +x "$prefix/bin/clawdi"
 				applyGeneration: 13,
 			});
 			const appliedBeforeDaemonHandoff = readFileSync(paths.appliedState, "utf-8");
-			expect(existsSync(paths.cliUpgradeState)).toBe(false);
 			expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"))).toMatchObject({
 				status: "installed",
 				previous: { version: "1.2.3-test" },
@@ -8156,7 +8017,6 @@ chmod +x "$prefix/bin/clawdi"
 			expect(readFileSync(systemctlLog, "utf-8")).not.toContain(
 				"restart clawdi-runtime-sidecar.service",
 			);
-			expect(existsSync(paths.cliUpgradeState)).toBe(false);
 			expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"))).toMatchObject({
 				previous: null,
 				bad: null,
@@ -8305,12 +8165,7 @@ esac
 				);
 				chmodSync(npm, 0o700);
 			}
-			seedCurrentCliInstall(
-				state,
-				TEST_RUNNING_CLI_SPEC,
-				TEST_RUNNING_CLI_VERSION,
-				"https://registry.npmjs.org",
-			);
+			seedCurrentCliInstall(state, TEST_RUNNING_CLI_VERSION);
 			writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 			const mitmproxy = seedMitmproxyCache(paths);
 			console.log = (value?: unknown) => logs.push(String(value));
@@ -8466,7 +8321,7 @@ chmod +x "$prefix/bin/clawdi"
 		};
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		const paths = getRuntimePaths();
-		seedCurrentCliInstall(state, "clawdi@1.2.1-test.1", "1.2.1-test.1");
+		seedCurrentCliInstall(state, "1.2.1-test.1");
 		const mitmproxy = seedMitmproxyCache(paths);
 		const baseline = normalizeHostedManifestFixture(
 			hostedEgressSecretRotationPayload(home, mitmproxy, "sk-before-upgrade"),
@@ -8644,9 +8499,8 @@ chmod +x "$prefix/bin/clawdi"
 			process.env.CLAWDI_RUNTIME_MODE = "hosted";
 			process.env.CLAWDI_SERVICE_STATE_DIR = state;
 			process.env.CLAWDI_RUN_DIR = run;
-			const currentSpec = `clawdi@${currentVersion}`;
 			const desiredSpec = `clawdi@${desiredVersion}`;
-			seedCurrentCliInstall(state, currentSpec, currentVersion, "https://registry.npmjs.org");
+			seedCurrentCliInstall(state, currentVersion);
 
 			try {
 				const desired = normalizeHostedManifestFixture(
@@ -8669,7 +8523,6 @@ chmod +x "$prefix/bin/clawdi"
 				if (!result.activeTarget) throw new Error("CLI update did not return an active target");
 				expect(statSync(result.activeTarget).mode & 0o777).toBe(0o755);
 				expect(statSync(paths.cliBootstrapStatus).mode & 0o777).toBe(0o600);
-				expect(existsSync(paths.cliUpgradeState)).toBe(false);
 				const pending = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
 				expect(pending).toMatchObject({
 					status: "installed",
@@ -8709,82 +8562,6 @@ chmod +x "$prefix/bin/clawdi"
 		},
 	);
 
-	it.each([
-		{ writerVersion: "0.13.92", phase: "prepared" },
-		{ writerVersion: "0.14.14", phase: "activated" },
-	])("adopts $writerVersion persisted CLI state on first converge", ({ writerVersion, phase }) => {
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, `state-cli-adoption-${writerVersion}`);
-		process.env.CLAWDI_RUN_DIR = join(root, `run-cli-adoption-${writerVersion}`);
-		const paths = getRuntimePaths();
-		const previous = createVersionedCliFixture(paths, `1.2.6-${writerVersion}`);
-		const candidate = createVersionedCliFixture(paths, `1.2.7-${writerVersion}`);
-		const active = phase === "prepared" ? previous : candidate;
-		const stale = phase === "prepared" ? candidate : previous;
-		pointManagedCliAt(paths, active);
-		writeCliBootstrapFixture(paths, active);
-		writeFileSync(
-			paths.cliUpgradeState,
-			`${JSON.stringify({
-				schemaVersion: "clawdi.cliUpgradeState.v2",
-				transaction: {
-					phase,
-					previousIdentity: previous,
-					newIdentity: candidate,
-					rollbackEligible: true,
-					installedAt: "2026-07-29T00:00:00.000Z",
-					rollback:
-						phase === "activated"
-							? {
-									reason: "first converge failed",
-									markedAt: "2026-07-29T00:01:00.000Z",
-								}
-							: null,
-				},
-				badVersions: [
-					{
-						packageSpec: "clawdi@1.2.5",
-						registry: "https://registry.npmjs.org",
-						version: "1.2.5",
-						reason: "existing rollback",
-						markedAt: "2026-07-29T00:01:00.000Z",
-					},
-				],
-			})}\n`,
-			{ mode: 0o600 },
-		);
-		const retiredQuarantine = `${paths.cliUpgradeState}.corrupt-1722211200000-fixture`;
-		writeFileSync(retiredQuarantine, "{broken journal", { mode: 0o600 });
-		expect(statSync(paths.cliUpgradeState).mode & 0o777).toBe(0o600);
-
-		expect(reconcilePendingRuntimeCliUpgrade(paths, active.version)).toEqual({
-			status: "unchanged",
-			selfReexec: false,
-		});
-		expect(
-			applyRuntimeCliDesiredState(cliManifest(active.version), paths, {
-				runningVersion: active.version,
-			}),
-		).toMatchObject({ status: "current", version: active.version, selfReexec: false });
-		expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"))).toMatchObject({
-			packageSpec: active.packageSpec,
-			activeTarget: active.activeTarget,
-			version: active.version,
-			previous: null,
-			bad: null,
-			verification: { verifiedAt: expect.any(String) },
-		});
-		expect(readlinkSync(paths.cliManagedBin)).toBe(active.activeTarget);
-		expect(existsSync(paths.cliUpgradeState)).toBe(false);
-		expect(readFileSync(retiredQuarantine, "utf-8")).toBe("{broken journal");
-		expect(existsSync(active.npmPrefix)).toBe(true);
-		expect(existsSync(stale.npmPrefix)).toBe(false);
-		expect(statSync(active.npmPrefix).mode & 0o777).toBe(0o755);
-		expect(statSync(dirname(paths.cliManagedBin)).mode & 0o777).toBe(0o755);
-		expect(statSync(paths.cliBootstrapStatus).mode & 0o777).toBe(0o600);
-		expect(statSync(dirname(paths.cliBootstrapStatus)).mode & 0o777).toBe(0o755);
-	});
-
 	it("re-verifies the active CLI when its file identity drifts", () => {
 		const state = join(root, "state-cli-verification-cache");
 		const run = join(root, "run-cli-verification-cache");
@@ -8792,7 +8569,7 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(state, "clawdi@1.2.3", "1.2.3");
+		seedCurrentCliInstall(state, "1.2.3");
 		const paths = getRuntimePaths();
 		const activeTarget = readlinkSync(paths.cliManagedBin);
 		writeFileSync(
@@ -8825,7 +8602,6 @@ exit 64
 		const paths = getRuntimePaths();
 		const candidate = createVersionedCliFixture(paths, "1.2.8-test.1");
 		pointManagedCliAt(paths, candidate);
-		writeCliBootstrapFixture(paths, candidate);
 		reconcilePendingRuntimeCliUpgrade(paths, candidate.version);
 		const previous = createVersionedCliFixture(paths, "1.2.7-test.1");
 		const state = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
@@ -8879,12 +8655,7 @@ exit 64
 		);
 		chmodSync(join(bin, "npm"), 0o700);
 		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		seedCurrentCliInstall(
-			stateRoot,
-			"clawdi@1.2.9-test.1",
-			"1.2.9-test.1",
-			"https://registry.npmjs.org",
-		);
+		seedCurrentCliInstall(stateRoot, "1.2.9-test.1");
 		const paths = getRuntimePaths();
 		const previousTarget = readlinkSync(paths.cliManagedBin);
 
@@ -8908,7 +8679,7 @@ exit 64
 		}
 	});
 
-	it("runtime init replaces normalized last-good state while applying remote channels", async () => {
+	it("runtime init applies remote channels and caches canonical state", async () => {
 		installSuccessfulSystemctlFixture();
 		setRuntimeApplyGeneration(7, CANONICAL_TEST_CONTEXT);
 		const home = join(root, "home", "clawdi");
@@ -8985,50 +8756,8 @@ exit 64
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(
-			state,
-			TEST_RUNNING_CLI_SPEC,
-			TEST_RUNNING_CLI_VERSION,
-			"https://registry.npmjs.org",
-		);
+		seedCurrentCliInstall(state, TEST_RUNNING_CLI_VERSION);
 		const paths = getRuntimePaths();
-		mkdirSync(paths.cacheRoot, { recursive: true });
-		writeFileSync(
-			paths.manifestLastGood,
-			`${JSON.stringify({
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_init",
-				environmentId: "env_init",
-				instanceId: "iid_init",
-				generation: 6,
-				issuedAt: "2026-06-05T00:00:00Z",
-				controlPlane: { apiUrl: "https://cloud-api.test" },
-				clawdiCli: {
-					source: "npm:clawdi",
-					packageSpec: TEST_RUNNING_CLI_SPEC,
-					registry: "https://registry.npmjs.org",
-				},
-				runtimes: { openclaw: { enabled: false } },
-				projection: {
-					sourceBundleVersion: "clawdi.hosted-runtime.bundle.v2",
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
-					providers: {
-						legacy: {
-							kind: "openai-compatible",
-							baseUrl: "https://legacy-provider.test/v1",
-							apiKeySecretRef: "secret://provider.legacy.apiKey",
-						},
-					},
-				},
-				recovery: { cacheManifest: true, allowOfflineBoot: true },
-			})}\n`,
-			{ mode: 0o600 },
-		);
-		writeFileSync(
-			paths.managedSecretCacheFile,
-			'{"secret://provider.legacy.apiKey":"sk-legacy-cache"}\n',
-			{ mode: 0o600 },
-		);
 		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
@@ -9169,13 +8898,10 @@ exit 64
 				channelBindings: [{ provider: "telegram" }, { provider: "discord" }],
 				secretValues: {},
 			});
-			expect(cachedManifestText).not.toContain("sourceBundleVersion");
-			expect(cachedManifestText).not.toContain("sourceSchemaVersion");
 			expect(cachedManifestText).not.toContain("agent-token-init");
 			expect(cachedManifestText).not.toContain("discord-agent-token-init");
 			expect(statSync(paths.manifestLastGood).mode & 0o777).toBe(0o600);
 			const cachedSecretsText = readFileSync(paths.managedSecretCacheFile, "utf-8");
-			expect(cachedSecretsText).not.toContain("sk-legacy-cache");
 			expect(cachedSecretsText).toContain("placeholder-token");
 			expect(cachedSecretsText).toContain("999999999:");
 			expect(cachedSecretsText).toContain("clawdi_");
@@ -9610,12 +9336,9 @@ exit 64
 		process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;
 		const paths = getRuntimePaths();
 		const retiredWhatsAppReceipt = join(paths.managedResourceRoot, "hermes-whatsapp.json");
-		const retiredWhatsAppAuthReceipts = join(paths.managedResourceRoot, "whatsapp-auth");
 		const retiredWhatsAppReceiptContent = '{"schemaVersion":"clawdi.managedHermesWhatsApp.v1"}\n';
 		mkdirSync(dirname(retiredWhatsAppReceipt), { recursive: true });
 		writeFileSync(retiredWhatsAppReceipt, retiredWhatsAppReceiptContent);
-		mkdirSync(retiredWhatsAppAuthReceipts, { recursive: true });
-		writeFileSync(join(retiredWhatsAppAuthReceipts, "openclaw.json"), "{}\n");
 		mkdirSync(legacySessionDir, { recursive: true });
 		writeFileSync(legacySentinel, "preserved\n");
 
@@ -9729,7 +9452,6 @@ exit 64
 		expect(egressSecrets).toContain(agentTokenSecretRef);
 		expect(egressSecrets).not.toContain(capabilitySecretRef);
 		expect(readFileSync(retiredWhatsAppReceipt, "utf8")).toBe(retiredWhatsAppReceiptContent);
-		expect(existsSync(retiredWhatsAppAuthReceipts)).toBe(false);
 		expect(projected.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ENABLED).toBeUndefined();
 		expect(readSystemdEnvFile(paths, "hermes-gateway")).not.toContain("WHATSAPP_ENABLED");
 		expect(existsSync(sessionDir)).toBe(true);
@@ -10218,15 +9940,6 @@ exit 0
 		writeFileSync(
 			join(authDir, "creds.json"),
 			`${JSON.stringify({ advSecretKey: "stale-whatsapp-secret" })}\n`,
-		);
-		writeFileSync(
-			join(authDir, ".clawdi-managed-whatsapp-auth.json"),
-			`${JSON.stringify({
-				schemaVersion: "clawdi.managedWhatsAppAuth.v1",
-				provider: "whatsapp",
-				accountKey,
-				credentialId: "credential-stale",
-			})}\n`,
 		);
 		writeFileSync(
 			openclawBin,
@@ -10996,45 +10709,6 @@ install -D -m 700 '${fixtureBinary}' "$prefix/bin/openclaw"
 			"user-owned canonical skill\n",
 		);
 		expect(readFileSync(openclawCalls, "utf-8")).toContain("unset search.proxy");
-	});
-
-	it("removes retired hosted state on first convergence", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		const paths = getRuntimePaths();
-		const retiredFiles = [
-			join(paths.configurationRoot, "clawdi.json"),
-			join(paths.configurationRoot, "runtime-live-sync-agents.json"),
-			join(paths.statusRoot, "cloud-status.json"),
-			join(paths.statusRoot, "cloud-result.json"),
-			join(paths.statusRoot, "egress-engine.json"),
-			join(paths.statusRoot, "runtime-install-receipts.json"),
-			join(paths.cacheRoot, "channels.etag"),
-		];
-		const retiredDirectories = [
-			join(paths.configurationRoot, "projections"),
-			join(paths.serviceStateRoot, "sync"),
-			join(paths.serviceStateRoot, "install-inventory"),
-		];
-		for (const path of retiredFiles) {
-			mkdirSync(dirname(path), { recursive: true });
-			writeFileSync(path, "retired\n");
-		}
-		for (const path of retiredDirectories) {
-			mkdirSync(path, { recursive: true });
-			writeFileSync(join(path, "retired.json"), "{}\n");
-		}
-
-		ensureRuntimeStateDirs(paths);
-
-		for (const path of [...retiredFiles, ...retiredDirectories]) {
-			expect(existsSync(path)).toBe(false);
-		}
 	});
 
 	it("upgrades header-owned MCP state without a ledger and rejects an unmarked collision", () => {


### PR DESCRIPTION
## Summary

Remove CLI compatibility readers and one-time cleanup paths whose fleet-floor gate is satisfied for the 0.14.18 release. The hosted fleet is 65/65 on 0.14.17 with zero rollbacks, and every removed writer/cleanup path shipped before the 0.14.17 tag, so persisted state has already been rewritten or cleaned during repeated convergence.

This is a deletion-only behavior cleanup: no new environment variables, flags, or runtime behavior are introduced. Migration-only helpers, fixtures, tests, and stale documentation are removed with their guards.

## Removed guards and gate evidence

- **Hermes gateway argv normalization**: remove acceptance/normalization of `gateway run --replace`. The hosted Hermes producer emits canonical `gateway run`, and 0.14.17 has rewritten existing last-good state.
- **Applied-state compatibility**: remove the 0.13.92/0.14.14 fields `egressSidecarSecretRevision`, `daemonAuthTokenRevision`, `daemonProgramRevision`, and `userProcessRevisionAliases`, plus the missing-`activated` fallback. 0.14.17 writes canonical v2 applied state with `activated` on every successful convergence.
- **Managed CLI state migration**: remove the retired `cli-upgrade-state.json` path and cleanup, the loose bootstrap-status reader, and adoption fixtures for 0.13.92/0.14.14 journals. 0.14.17 reconciles the managed active symlink and persists the single canonical `cli-bootstrap.json` shape.
- **Retired runtime state cleanup**: remove recurring deletion of pre-0.14.14 configuration, projection, sync, inventory, status, and channel ETag files. Only old CLIs wrote these paths; every fleet host has run the 0.14.17 cleanup repeatedly.
- **MCP ledger cleanup**: remove deletion of `managed-mcp-servers.json`. MCP state is content-owned now, and 0.14.17 already removed the retired ledger on all fleet hosts.
- **WhatsApp receipt cleanup**: remove deletion of the retired `managed-resources/whatsapp-auth` directory. It is an old on-disk receipt path already cleared by 0.14.17.
- **WhatsApp legacy auth fallback**: remove the `.clawdi-managed-whatsapp-auth.json` marker cleanup and the legacy socket `capability` normalization. Current credential projection writes ownership into canonical `creds.json`; the old writer is no longer live.
- **OAuth retired tombstones**: remove the pre-#1187 `state: "retired"` reader/deleter. Current ownership is retired by deletion, and 0.14.17 has already consumed old tombstones.
- **Recursive tenant-home chown migration**: no additional diff was needed because #1214 already removed this one-time 0.13.92/0.14.14 migration from the current base.

The existing behavioral guards `replays last-good declarative state after a failed candidate and advances afterward` and `restarts only rendered-but-unactivated services after a write-side crash` are unchanged.

## Not yet eligible

- `manifest-contract.ts`: keep accepting and normalizing the OpenClaw `gateway run --allow-unconfigured --port 18789 --bind lan --force` wire argv because hosted `_runtime_run_state('openclaw')` still emits it and cloud-api passes it through unchanged. Delete only after hosted emits the canonical official gateway command, existing runtime states are re-pushed, and the wire is verified canonical.
- `hosted-sourced-skill-archive.ts`: keep `matchesLegacySingleFileHash` until hosted #1839 completes the `content_hash` / tree-hash backfill for pre-2026-04-28 Project Skills. The hosted control plane can still supply that legacy identity.
- `managed-skill-reservation.ts`: keep the legacy local setup Skill digests until the supported local setup upgrade window closes. This gate is not tied to the hosted fleet floor.

## Needs writer confirmation

- `apply-identity.ts`: keep the `clawdi.runtimeContext.v2` reader. Its writer is the external host/bootstrap plane rather than this repository, so the repository alone cannot prove that v2 has stopped being produced.

## Upgrade boundary

A direct 0.13.92 to 0.14.18 upgrade is unsupported. Hosts must converge through 0.14.17 before installing 0.14.18.

- **Non-self-healing legacy state**: a retired OAuth `state: "retired"` tombstone now fails ledger parsing without a local recovery catch, producing `installErrors` on every convergence; WhatsApp credentials carrying the legacy socket `capability` fail as invalid credentials on every convergence and are no longer rewritten in place.
- **Self-healing legacy state**: old applied-state and CLI bootstrap formats are rejected once, then normal convergence/active-link recovery rewrites canonical state. They still sit outside the supported direct-upgrade path.

## Verification

- `bun test src/runtime/observed-v2.test.ts` (`5 pass`)
- `bun run --cwd packages/cli test` (`1646 pass`, `4 skip`, `0 fail`; Docker clean runner across 133 files)
- `bun test --isolate --max-concurrency=1 --timeout=30000 src/runtime/manifest-reconciliation.test.ts tests/runtime.test.ts` (`286 pass`)
- `scripts/test.sh cli tests/e2e/runtime-official-installer-systemd.e2e.test.ts` (`9 pass`)
- `scripts/test.sh cli tests/e2e/daemon-rpc.e2e.test.ts` (`2 pass`)
- `bun run typecheck`
- `bun run check`
- `git diff --check`
