### PR TITLE
release(cli): 0.14.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.18
+
+Package: `clawdi@0.14.18`
+
+### Changed
+
+- Steady-state converge now completes in about a second with single-digit process spawns (previously ~25s and dozens of spawns): Hermes config reconciliation reads and writes the config once per round, OpenClaw probes are cached against manifest revisions with on-disk verification, and systemd state is read in batch.
+- Successful convergence is reported to the control plane immediately instead of waiting for the next heartbeat, so plugin and skill installs show as applied right away.
+- The per-round recursive ownership sweep of the tenant home was removed; every write path now creates files under the correct owner (requires upgrading from 0.14.17).
+
+### Removed
+
+- Expired migration guards for pre-0.14.17 on-disk state (legacy applied-state fields, CLI upgrade journal, MCP ledger and WhatsApp marker cleanup, retired runtime state cleanup, Hermes legacy gateway argv). Upgrading directly from 0.13.x to 0.14.18 is not supported; upgrade through 0.14.17 first.
+
 ## Clawdi CLI v0.14.17
 
 Package: `clawdi@0.14.17`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.17",
+      "version": "0.14.18",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.17",
+	"version": "0.14.18",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Release `clawdi@0.14.18`.

## Contents (since 0.14.17)

- #1214 — converge hot path: immediate convergence observation, single-transaction Hermes config, recursive tenant-home chown removal, revision-keyed probe cache with on-disk verification. Steady-state converge ~25s → ~1s (Hermes p50 1.05s/5 spawns, OpenClaw p50 0.43s/4 spawns).
- #1217 — expired pre-0.14.17 migration guard removal (net -560 lines). OpenClaw gateway argv compatibility retained (producer still emits legacy shape).

## Upgrade boundary

Fleet floor 0.14.17 required. Direct 0.13.x → 0.14.18 is not supported; upgrade through 0.14.17 first.

## Rollout plan

npm publish on merge → validate on owner test deployments (fresh pinned 0.14.17 → 0.14.18 path + steady-state converge timing) → fleet rollout via admin channel only after explicit owner approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)