### PR TITLE
fix(backend): harden channel wakeups and database transactions

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -20,6 +20,14 @@ engine = create_async_engine(
     pool_timeout=settings.db_pool_timeout,
     pool_recycle=settings.db_pool_recycle,
     pool_pre_ping=True,
+    # Alembic creates a separate synchronous engine, so long-running DDL does
+    # not inherit these runtime request safeguards.
+    connect_args={
+        "server_settings": {
+            "statement_timeout": "120s",
+            "idle_in_transaction_session_timeout": "5min",
+        }
+    },
 )
 async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
 

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -652,6 +652,7 @@ async def telegram_file_api(
         )
 
     provider_token = decrypt_provider_token(account)
+    await db.rollback()
     base_url = settings.channel_telegram_api_base_url.strip()
     await _validate_telegram_provider_base_url(base_url)
     url = f"{base_url.rstrip('/')}/file/bot{provider_token}/{file_path}"
@@ -2187,8 +2188,11 @@ async def _handle_telegram_get_file(
             "Forbidden: file_id is not bound to this bot",
             403,
         )
+    account_id = account.id
+    provider_token = decrypt_provider_token(account)
+    await db.rollback()
     response = await _telegram_provider_response(
-        account=account,
+        provider_token=provider_token,
         method="getFile",
         request=request,
         raw_body=raw_body,
@@ -2205,6 +2209,7 @@ async def _handle_telegram_get_file(
         and file_path
     ):
         try:
+            account = await get_active_channel_account(db, account_id=account_id)
             await record_channel_agent_reference(
                 db,
                 account=account,
@@ -2217,12 +2222,12 @@ async def _handle_telegram_get_file(
         except Exception:
             log.exception(
                 "telegram_reference_recording_failed account_id=%s link_id=%s method=getFile",
-                account.id,
+                account_id,
                 bot_agent_link_id,
             )
             await _rollback_telegram_reference_recording(
                 db,
-                account_id=account.id,
+                account_id=account_id,
                 bot_agent_link_id=bot_agent_link_id,
                 method="getFile",
             )
@@ -2253,8 +2258,10 @@ async def _handle_telegram_callback_answer(
             "Forbidden: callback_query_id is not bound to this bot",
             403,
         )
+    provider_token = decrypt_provider_token(account)
+    await db.rollback()
     response = await _telegram_provider_response(
-        account=account,
+        provider_token=provider_token,
         method=method,
         request=request,
         raw_body=raw_body,
@@ -2536,8 +2543,11 @@ async def _proxy_telegram_bot_method(
             and "message_thread_id" in request_params
             and "direct_messages_topic_id" not in request_params
         )
+    account_id = account.id
+    provider_token = decrypt_provider_token(account)
+    await db.rollback()
     response = await _telegram_provider_response(
-        account=account,
+        provider_token=provider_token,
         method=method,
         request=request,
         raw_body=raw_body,
@@ -2553,6 +2563,7 @@ async def _proxy_telegram_bot_method(
             )
             if file_ids or message_references:
                 try:
+                    account = await get_active_channel_account(db, account_id=account_id)
                     for file_id in sorted(file_ids):
                         await record_channel_agent_reference(
                             db,
@@ -2573,13 +2584,13 @@ async def _proxy_telegram_bot_method(
                 except Exception:
                     log.exception(
                         "telegram_reference_recording_failed account_id=%s link_id=%s method=%s",
-                        account.id,
+                        account_id,
                         bot_agent_link_id,
                         method,
                     )
                     await _rollback_telegram_reference_recording(
                         db,
-                        account_id=account.id,
+                        account_id=account_id,
                         bot_agent_link_id=bot_agent_link_id,
                         method=method,
                     )
@@ -2631,13 +2642,12 @@ def _telegram_result_message_references(
 
 async def _telegram_provider_response(
     *,
-    account: ChannelAccount,
+    provider_token: str,
     method: str,
     request: Request,
     raw_body: bytes,
     translate_direct_topic: bool = False,
 ) -> httpx.Response:
-    provider_token = decrypt_provider_token(account)
     base_url = settings.channel_telegram_api_base_url.strip()
     await _validate_telegram_provider_base_url(base_url)
     url = httpx.URL(f"{base_url.rstrip('/')}/bot{provider_token}/{method}")

--- a/backend/app/routes/channel_routers/whatsapp.py
+++ b/backend/app/routes/channel_routers/whatsapp.py
@@ -614,6 +614,7 @@ async def _wait_whatsapp_websocket_inbox(
 
     messages = await wait_for_channel_inbound_messages(
         fetch,
+        account_id=str(account_id),
         timeout_seconds=settings.channel_long_poll_max_seconds,
         wakeup=channel_inbound_messages_enqueued,
     )

--- a/backend/app/services/channel_delivery_worker.py
+++ b/backend/app/services/channel_delivery_worker.py
@@ -7,7 +7,11 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from app.services.channel_wakeups import ChannelWakeup, channel_deliveries_enqueued
+from app.services.channel_wakeups import (
+    CHANNEL_DELIVERIES_ENQUEUED,
+    ChannelWakeup,
+    channel_deliveries_enqueued,
+)
 from app.services.channels import claim_next_channel_delivery, deliver_channel_delivery
 
 log = logging.getLogger(__name__)
@@ -40,7 +44,7 @@ class ChannelDeliveryWorker:
 
     async def run_forever(self, stop: asyncio.Event | None = None) -> None:
         stop_event = stop or asyncio.Event()
-        notified = self._wakeup.subscribe()
+        notified = self._wakeup.subscribe(CHANNEL_DELIVERIES_ENQUEUED)
         try:
             while not stop_event.is_set():
                 notified.clear()
@@ -70,4 +74,4 @@ class ChannelDeliveryWorker:
                                 task.cancel()
                         await asyncio.gather(stop_task, wake_task, return_exceptions=True)
         finally:
-            self._wakeup.unsubscribe(notified)
+            self._wakeup.unsubscribe(CHANNEL_DELIVERIES_ENQUEUED, notified)

--- a/backend/app/services/channel_wakeups.py
+++ b/backend/app/services/channel_wakeups.py
@@ -15,21 +15,26 @@ CHANNEL_INBOUND_MESSAGES_ENQUEUED = "channel_inbound_messages_enqueued"
 
 
 class ChannelWakeup:
-    """Process-local broadcast subscription for PostgreSQL notifications."""
+    """Process-local keyed subscription for PostgreSQL notifications."""
 
     def __init__(self) -> None:
-        self._waiters: set[asyncio.Event] = set()
+        self._waiters: dict[str, set[asyncio.Event]] = {}
 
-    def subscribe(self) -> asyncio.Event:
+    def subscribe(self, key: str) -> asyncio.Event:
         waiter = asyncio.Event()
-        self._waiters.add(waiter)
+        self._waiters.setdefault(key, set()).add(waiter)
         return waiter
 
-    def unsubscribe(self, waiter: asyncio.Event) -> None:
-        self._waiters.discard(waiter)
+    def unsubscribe(self, key: str, waiter: asyncio.Event) -> None:
+        waiters = self._waiters.get(key)
+        if waiters is None:
+            return
+        waiters.discard(waiter)
+        if not waiters:
+            del self._waiters[key]
 
-    def signal(self) -> None:
-        for waiter in self._waiters:
+    def signal(self, key: str) -> None:
+        for waiter in self._waiters.get(key, ()):
             waiter.set()
 
 
@@ -40,6 +45,7 @@ channel_inbound_messages_enqueued = ChannelWakeup()
 async def wait_for_channel_inbound_messages[T](
     fetch: Callable[[], Awaitable[list[T]]],
     *,
+    account_id: str,
     timeout_seconds: int | float | None,
     fallback_poll_seconds: float | None = None,
     wakeup: ChannelWakeup | None = None,
@@ -56,7 +62,7 @@ async def wait_for_channel_inbound_messages[T](
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
     source = wakeup or channel_inbound_messages_enqueued
-    notified = source.subscribe()
+    notified = source.subscribe(account_id)
     try:
         while True:
             # Clearing before the query is load-bearing. A commit notification
@@ -76,21 +82,25 @@ async def wait_for_channel_inbound_messages[T](
             except TimeoutError:
                 pass
     finally:
-        source.unsubscribe(notified)
+        source.unsubscribe(account_id, notified)
 
 
 async def notify_channel_delivery_enqueued(db: AsyncSession) -> None:
     """Wake delivery workers after the surrounding transaction commits."""
-    await _notify_channel_work_enqueued(db, CHANNEL_DELIVERIES_ENQUEUED)
+    await _notify_channel_work_enqueued(
+        db,
+        CHANNEL_DELIVERIES_ENQUEUED,
+        CHANNEL_DELIVERIES_ENQUEUED,
+    )
 
 
-async def notify_channel_inbound_message_enqueued(db: AsyncSession) -> None:
+async def notify_channel_inbound_message_enqueued(db: AsyncSession, *, account_id: str) -> None:
     """Wake inbox consumers after the surrounding transaction commits."""
-    await _notify_channel_work_enqueued(db, CHANNEL_INBOUND_MESSAGES_ENQUEUED)
+    await _notify_channel_work_enqueued(db, CHANNEL_INBOUND_MESSAGES_ENQUEUED, account_id)
 
 
-async def _notify_channel_work_enqueued(db: AsyncSession, channel: str) -> None:
+async def _notify_channel_work_enqueued(db: AsyncSession, channel: str, key: str) -> None:
     await db.execute(
-        text("SELECT pg_notify(:channel, '')"),
-        {"channel": channel},
+        text("SELECT pg_notify(:channel, :key)"),
+        {"channel": channel, "key": key},
     )

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -3043,7 +3043,7 @@ async def _record_inbound_message_with_status(
         if existing is not None:
             return existing, False
         raise
-    await notify_channel_inbound_message_enqueued(db)
+    await notify_channel_inbound_message_enqueued(db, account_id=str(account.id))
     inbound_messages.labels(channel=account.provider).inc()
     return message, True
 
@@ -3780,6 +3780,7 @@ async def wait_for_telegram_updates(
 
     return await wait_for_channel_inbound_messages(
         fetch,
+        account_id=str(account_id),
         timeout_seconds=timeout_seconds,
         fallback_poll_seconds=poll_interval_seconds,
         wakeup=channel_inbound_messages_enqueued,
@@ -4497,6 +4498,7 @@ async def wait_for_channel_inbox_events(
 
     return await wait_for_channel_inbound_messages(
         fetch,
+        account_id=str(account_id),
         timeout_seconds=timeout_seconds,
         fallback_poll_seconds=poll_interval_seconds,
         wakeup=channel_inbound_messages_enqueued,

--- a/backend/app/services/sync_events.py
+++ b/backend/app/services/sync_events.py
@@ -703,12 +703,12 @@ def _on_postgres_notification(
     _broadcast(envelope.user_id, envelope.event)
 
 
-def _on_channel_delivery_enqueued(_pid: int, _channel: str, _payload: str) -> None:
-    channel_deliveries_enqueued.signal()
+def _on_channel_delivery_enqueued(_pid: int, _channel: str, payload: str) -> None:
+    channel_deliveries_enqueued.signal(payload)
 
 
-def _on_channel_inbound_message_enqueued(_pid: int, _channel: str, _payload: str) -> None:
-    channel_inbound_messages_enqueued.signal()
+def _on_channel_inbound_message_enqueued(_pid: int, _channel: str, payload: str) -> None:
+    channel_inbound_messages_enqueued.signal(payload)
 
 
 async def get_skills_revision(db: AsyncSession, user_id: UUID) -> int:

--- a/backend/tests/test_channel_workers.py
+++ b/backend/tests/test_channel_workers.py
@@ -11,7 +11,11 @@ from app.routes.channel_routers.whatsapp import _wait_whatsapp_websocket_inbox
 from app.services.ai_provider_oauth_revoke_worker import AiProviderOAuthRevokeWorker
 from app.services.channel_delivery_worker import ChannelDeliveryWorker
 from app.services.channel_message_retention_worker import ChannelMessageRetentionWorker
-from app.services.channel_wakeups import ChannelWakeup
+from app.services.channel_wakeups import (
+    CHANNEL_DELIVERIES_ENQUEUED,
+    ChannelWakeup,
+    wait_for_channel_inbound_messages,
+)
 from app.services.channel_webhook_delivery_worker import ChannelWebhookDeliveryWorker
 from app.services.channels import ChannelRetentionBatch
 from app.services.discord_command_reconciliation_worker import (
@@ -134,10 +138,42 @@ async def test_channel_delivery_worker_wakes_on_enqueue_signal(monkeypatch):
     task = asyncio.create_task(worker.run_forever(stop))
     await idle.wait()
 
-    wakeup.signal()
+    wakeup.signal(CHANNEL_DELIVERIES_ENQUEUED)
 
     await asyncio.wait_for(awakened.wait(), timeout=1)
     await asyncio.wait_for(task, timeout=1)
+    assert calls == 2
+
+
+def test_channel_wakeup_routes_signal_by_account():
+    wakeup = ChannelWakeup()
+    account_a = wakeup.subscribe("account-a")
+    account_b = wakeup.subscribe("account-b")
+
+    wakeup.signal("account-a")
+
+    assert account_a.is_set()
+    assert not account_b.is_set()
+
+
+@pytest.mark.asyncio
+async def test_channel_inbound_wait_falls_back_when_notification_is_lost():
+    calls = 0
+
+    async def fetch():
+        nonlocal calls
+        calls += 1
+        return [] if calls == 1 else ["message"]
+
+    messages = await wait_for_channel_inbound_messages(
+        fetch,
+        account_id="account-a",
+        timeout_seconds=1,
+        fallback_poll_seconds=0.001,
+        wakeup=ChannelWakeup(),
+    )
+
+    assert messages == ["message"]
     assert calls == 2
 
 
@@ -214,7 +250,7 @@ async def test_whatsapp_websocket_inbox_wakes_on_inbound_signal(monkeypatch):
     )
     await first_query_complete.wait()
 
-    wakeup.signal()
+    wakeup.signal("00000000-0000-4000-8000-000000000906")
 
     events = await asyncio.wait_for(waiting, timeout=1)
     assert [event.provider_message_id for event in events] == ["message-1"]

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -5995,7 +5995,10 @@ async def test_telegram_get_updates_wait_helper_sees_new_committed_update(
                 )
             )
             await insert_session.flush()
-            await notify_channel_inbound_message_enqueued(insert_session)
+            await notify_channel_inbound_message_enqueued(
+                insert_session,
+                account_id=created["id"],
+            )
             await insert_session.commit()
 
         updates = await asyncio.wait_for(pending, timeout=1)

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -102,6 +102,7 @@ from app.services.channels import (
     record_discord_dispatch,
     send_provider_outbound_payload,
     telegram_direct_messages_topic_id_from_update,
+    telegram_message_reference_value,
     telegram_message_thread_id_from_update,
     wait_for_telegram_updates,
 )
@@ -8541,6 +8542,79 @@ async def test_telegram_native_attach_multipart_is_forwarded_byte_for_byte_and_r
 
     assert reuse.status_code == 200
     assert len(_FakeProviderClient.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_telegram_proxy_releases_transaction_during_provider_io(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_fake_provider_client({"ok": True, "result": True})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = await _create_paired_telegram_channel(
+        client,
+        name="telegram-provider-transaction",
+        chat_id="42",
+    )
+
+    class TransactionObservingProviderClient(_FakeProviderClient):
+        fail = False
+
+        async def request(self, method, url, **kwargs):
+            assert not db_session.in_transaction()
+            if self.fail:
+                raise httpx.ConnectError("network down")
+            return await super().request(method, url, **kwargs)
+
+    _reset_fake_provider_client(
+        {
+            "ok": True,
+            "result": {
+                "message_id": 71,
+                "chat": {"id": 42, "type": "private"},
+                "document": {"file_id": "transaction-safe-file"},
+            },
+        }
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.telegram.httpx.AsyncClient",
+        TransactionObservingProviderClient,
+    )
+
+    sent = await client.post(
+        _telegram_bot_path(created, "sendDocument"),
+        headers=_telegram_agent_headers(created),
+        json={"chat_id": "42", "document": "https://example.test/report.pdf"},
+    )
+
+    assert sent.status_code == 200
+    assert not db_session.in_transaction()
+    references = set(
+        await db_session.scalars(
+            select(ChannelAgentReference.ref_value).where(
+                ChannelAgentReference.account_id == UUID(created["id"]),
+                ChannelAgentReference.ref_value.in_(
+                    {"transaction-safe-file", telegram_message_reference_value("42", 71)}
+                ),
+            )
+        )
+    )
+    assert references == {
+        "transaction-safe-file",
+        telegram_message_reference_value("42", 71),
+    }
+    await db_session.rollback()
+
+    TransactionObservingProviderClient.fail = True
+    failed = await client.post(
+        _telegram_bot_path(created, "sendChatAction"),
+        headers=_telegram_agent_headers(created),
+        json={"chat_id": "42", "action": "typing"},
+    )
+
+    assert failed.status_code == 502
+    assert not db_session.in_transaction()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_database_timeouts.py
+++ b/backend/tests/test_database_timeouts.py
@@ -1,0 +1,25 @@
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+
+from app.core.database import engine
+
+
+@pytest.mark.asyncio
+async def test_database_engine_applies_and_enforces_postgres_timeouts():
+    async with engine.connect() as connection:
+        configured = (
+            await connection.execute(
+                text(
+                    "SELECT current_setting('statement_timeout'), "
+                    "current_setting('idle_in_transaction_session_timeout')"
+                )
+            )
+        ).one()
+        assert configured == ("2min", "5min")
+
+        await connection.execute(text("SET LOCAL statement_timeout = '10ms'"))
+        with pytest.raises(DBAPIError) as cancelled:
+            await connection.execute(text("SELECT pg_sleep(0.1)"))
+
+        assert cancelled.value.orig.sqlstate == "57014"

--- a/backend/tests/test_sync_events.py
+++ b/backend/tests/test_sync_events.py
@@ -40,6 +40,7 @@ from app.models.hosted_runtime import HostedRuntimeState
 from app.models.user import User
 from app.services import sync_events
 from app.services.channel_wakeups import (
+    CHANNEL_DELIVERIES_ENQUEUED,
     channel_deliveries_enqueued,
     channel_inbound_messages_enqueued,
     notify_channel_delivery_enqueued,
@@ -719,12 +720,13 @@ async def test_postgres_listener_ignores_malformed_notification_before_valid_eve
 
 @pytest.mark.asyncio
 async def test_postgres_listener_wakes_channel_consumers(db_session: AsyncSession):
-    delivery_waiter = channel_deliveries_enqueued.subscribe()
-    inbound_waiter = channel_inbound_messages_enqueued.subscribe()
+    account_id = "00000000-0000-4000-8000-000000000901"
+    delivery_waiter = channel_deliveries_enqueued.subscribe(CHANNEL_DELIVERIES_ENQUEUED)
+    inbound_waiter = channel_inbound_messages_enqueued.subscribe(account_id)
     await sync_events.start_postgres_listener()
     try:
         await notify_channel_delivery_enqueued(db_session)
-        await notify_channel_inbound_message_enqueued(db_session)
+        await notify_channel_inbound_message_enqueued(db_session, account_id=account_id)
         await asyncio.sleep(0)
         assert not delivery_waiter.is_set()
         assert not inbound_waiter.is_set()
@@ -735,8 +737,8 @@ async def test_postgres_listener_wakes_channel_consumers(db_session: AsyncSessio
         await asyncio.wait_for(inbound_waiter.wait(), timeout=2)
     finally:
         await sync_events.stop_postgres_listener()
-        channel_deliveries_enqueued.unsubscribe(delivery_waiter)
-        channel_inbound_messages_enqueued.unsubscribe(inbound_waiter)
+        channel_deliveries_enqueued.unsubscribe(CHANNEL_DELIVERIES_ENQUEUED, delivery_waiter)
+        channel_inbound_messages_enqueued.unsubscribe(account_id, inbound_waiter)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- route channel inbox wakeups by `account_id` through PostgreSQL notification payloads and process-local keyed waiters, while retaining the 5-second notification-loss fallback
- release request-scoped database transactions before Telegram Bot API and authorized file proxy I/O, then use a fresh short transaction only when successful responses require reference persistence
- apply runtime PostgreSQL safeguards with a 120-second `statement_timeout` and 5-minute `idle_in_transaction_session_timeout`, without adding environment settings or flags

Follow-up to #1211 and #1208.

## Production evidence

- the 04:50 database pool-pressure incident produced 853 errors
- slow-request logs show Telegram `sendChatAction` calls taking 838ms and longer while the request session previously remained idle in transaction
- at 9,000 parked boxes and a global inbound rate of 10 messages/second, broadcast wakeups projected to 90,000 avoidable wakeup/dequeue queries per second

## Timeout rationale and scope

Repository search shows runtime cleanup work is bounded by configured batches (500 by default, capped at 10,000), channel dequeues are limited, and long-lived SSE and channel polling paths use short sessions or roll back before parking. A 120-second statement limit therefore leaves substantial headroom for the slowest legitimate runtime SQL while bounding lock waits and regressions. The 5-minute idle-in-transaction limit is deliberately minutes-scale and well above the 30-second Telegram long-poll window; keyed notifications remain the latency path and the existing 5-second poll is only notification-loss recovery.

Alembic migrations are exempt: `backend/alembic/env.py` creates its own synchronous `engine_from_config`/`NullPool` engine and does not import the runtime async engine or its `connect_args`, so long DDL does not inherit these limits.

## Verification

- focused PostgreSQL 18.4 + pgvector 0.8.6 suite on a migrated throwaway database: 11 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m compileall -q app scripts tests alembic`
- BasedPyright on all changed production Python modules: 0 errors, 0 warnings
- `uv lock --check`
- dependency authority and outbound API governance checks

`bun run check` was unavailable in this worktree because JavaScript dependencies are not installed (`biome: command not found`); no JavaScript files changed.
