### PR TITLE
fix(web): plugin toasts state the outcome, not the start

### DIFF
--- a/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
+++ b/apps/web/src/hosted/v2/agent-plugins/agent-plugins-surface.tsx
@@ -113,7 +113,7 @@ export function AgentPluginsSurface({
 				body: { version: item.catalog.version },
 			});
 			await refreshDesired();
-			toast.success(updating ? "Plugin update started" : "Plugin installation started");
+			toast.success(updating ? "Plugin updated" : "Plugin installed");
 		} catch (error) {
 			toast.error(updating ? "Couldn't update plugin" : "Couldn't install plugin", {
 				description: normalizeApiError(error),
@@ -133,7 +133,7 @@ export function AgentPluginsSurface({
 				params: { path: { agent_id: agentId, plugin_name: item.name } },
 			});
 			await refreshDesired();
-			toast.success("Plugin removal started");
+			toast.success("Plugin removed");
 			if (selectedPlugin === item.name) closePlugin();
 		} catch (error) {
 			toast.error("Couldn't remove plugin", { description: normalizeApiError(error) });
@@ -160,7 +160,7 @@ export function AgentPluginsSurface({
 				body: { version: item.catalog.version },
 			});
 			await refreshDesired();
-			toast.success("Plugin retry started");
+			toast.success("Plugin installed");
 		} catch (error) {
 			toast.error("Couldn't retry plugin", { description: normalizeApiError(error) });
 			throw error;


### PR DESCRIPTION
Per owner feedback: plugin operation toasts should just say installed/removed instead of "xxx started".

- "Plugin installation started" → "Plugin installed"
- "Plugin update started" → "Plugin updated"
- "Plugin removal started" → "Plugin removed"
- "Plugin retry started" → "Plugin installed"

Rationale: since CLI 0.14.18 the box reports successful convergence immediately, so installs/removals land in seconds; the list's per-plugin convergence state still shows the brief in-flight window. The only other "started" toast in the app ("Subscription started") is semantically correct and untouched.

Verified: `tsc --noEmit` clean; no test references the old strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)