### PR TITLE
perf(backend): persist runtime source revisions

### DIFF
--- a/backend/alembic/versions/b5e7d9a1c3f2_persist_runtime_source_revision.py
+++ b/backend/alembic/versions/b5e7d9a1c3f2_persist_runtime_source_revision.py
@@ -1,0 +1,32 @@
+"""Persist hosted runtime source revisions.
+
+Revision ID: b5e7d9a1c3f2
+Revises: 4a8d2c7e9f31
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b5e7d9a1c3f2"
+down_revision: str | Sequence[str] | None = "4a8d2c7e9f31"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "hosted_runtime_states",
+        sa.Column("source_revision", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "hosted_runtime_states",
+        sa.Column("source_revision_contract", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("hosted_runtime_states", "source_revision_contract")
+    op.drop_column("hosted_runtime_states", "source_revision")

--- a/backend/app/models/hosted_runtime.py
+++ b/backend/app/models/hosted_runtime.py
@@ -36,6 +36,8 @@ class HostedRuntimeState(Base, TimestampMixin):
     instance_id: Mapped[str] = mapped_column(String(200), nullable=False)
     generation: Mapped[int] = mapped_column(Integer, nullable=False)
     apply_generation: Mapped[int | None] = mapped_column(Integer)
+    source_revision: Mapped[str | None] = mapped_column(String(64))
+    source_revision_contract: Mapped[str | None] = mapped_column(String(64))
     cli_package_spec: Mapped[str] = mapped_column(String(200), nullable=False)
     locale: Mapped[dict[str, JsonValue]] = mapped_column(JSONB(none_as_null=True), nullable=False)
     system: Mapped[dict[str, JsonValue]] = mapped_column(JSONB(none_as_null=True), nullable=False)

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -2065,17 +2065,16 @@ async def admin_update_channel(
         if "secrets" in updates:
             await upsert_channel_secrets(db, account=account, secrets_by_name=body.secrets)
         if account.status != previous_status and account.provider in RUNTIME_CHANNEL_PROVIDERS:
-            targets = list(
-                (
-                    await db.execute(
-                        select(ChannelBotAgentLink.user_id, ChannelBotAgentLink.agent_id).where(
-                            ChannelBotAgentLink.account_id == account.id,
-                            ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
-                            ChannelBotAgentLink.archived_at.is_(None),
-                        )
+            rows = (
+                await db.execute(
+                    select(ChannelBotAgentLink.user_id, ChannelBotAgentLink.agent_id).where(
+                        ChannelBotAgentLink.account_id == account.id,
+                        ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                        ChannelBotAgentLink.archived_at.is_(None),
                     )
-                ).all()
-            )
+                )
+            ).all()
+            targets = [(user_id, agent_id) for user_id, agent_id in rows]
             await queue_runtime_manifests_changed(db, targets)
         record_control_plane_audit(
             db,

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -219,6 +219,7 @@ from app.services.sync_events import (
     queue_environment_runtime_manifest_changed,
     queue_provider_runtime_manifest_changed,
     queue_runtime_manifest_changed,
+    queue_runtime_manifests_changed,
     runtime_manifest_provider_non_auth_signature,
 )
 from app.services.user_provisioning import (
@@ -1962,6 +1963,7 @@ async def admin_update_channel(
 ) -> AdminChannelResponse:
     account, owner = await _admin_get_channel_row(db, account_id=account_id)
     updates = set(body.model_fields_set)
+    previous_status = account.status
     if "name" in updates:
         account.name = body.name or account.name
     if "status" in updates and body.status is not None:
@@ -2062,6 +2064,19 @@ async def admin_update_channel(
     try:
         if "secrets" in updates:
             await upsert_channel_secrets(db, account=account, secrets_by_name=body.secrets)
+        if account.status != previous_status and account.provider in RUNTIME_CHANNEL_PROVIDERS:
+            targets = list(
+                (
+                    await db.execute(
+                        select(ChannelBotAgentLink.user_id, ChannelBotAgentLink.agent_id).where(
+                            ChannelBotAgentLink.account_id == account.id,
+                            ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                            ChannelBotAgentLink.archived_at.is_(None),
+                        )
+                    )
+                ).all()
+            )
+            await queue_runtime_manifests_changed(db, targets)
         record_control_plane_audit(
             db,
             actor_type="admin",
@@ -2591,7 +2606,7 @@ async def _admin_upsert_runtime_state(
         },
     )
     if changed_fields:
-        queue_runtime_manifest_changed(db, env.user_id, environment_id)
+        await queue_runtime_manifest_changed(db, env.user_id, environment_id)
     await db.commit()
     logger.info(
         "admin_runtime_state_upserted target_clerk_id=%s environment_id=%s "
@@ -2728,7 +2743,7 @@ async def _admin_delete_runtime_state(
             environment_id=environment_id,
         )
         await db.delete(state)
-        queue_runtime_manifest_changed(db, env.user_id, environment_id)
+        await queue_runtime_manifest_changed(db, env.user_id, environment_id)
 
     record_control_plane_audit(
         db,

--- a/backend/app/routes/ai_providers.py
+++ b/backend/app/routes/ai_providers.py
@@ -130,6 +130,7 @@ from app.services.platform_contract import (
 )
 from app.services.private_ip import is_private_hostname
 from app.services.sync_events import (
+    queue_environment_runtime_manifest_changed,
     queue_provider_runtime_manifest_changed,
     runtime_manifest_provider_non_auth_signature,
 )
@@ -1368,10 +1369,23 @@ async def resolve_ai_provider_auth(
                 status.HTTP_409_CONFLICT,
                 "OAuth auth resolve requires an explicit Agent runtime consumer",
             )
+        previous_consumer = (
+            payload.consumer_environment_id,
+            payload.consumer_runtime,
+        )
         try:
             await claim_oauth_payload(db, payload=payload, consumer=consumer)
         except OAuthCredentialClaimConflict as exc:
             raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+        if previous_consumer != (
+            payload.consumer_environment_id,
+            payload.consumer_runtime,
+        ):
+            await queue_environment_runtime_manifest_changed(
+                db,
+                auth.user_id,
+                consumer.environment_id,
+            )
         plaintext = decrypt(payload.encrypted_payload, payload.nonce)
         await db.commit()
     else:

--- a/backend/app/routes/channel_routers/whatsapp.py
+++ b/backend/app/routes/channel_routers/whatsapp.py
@@ -24,6 +24,7 @@ from app.models.channel import (
     ChannelAccount,
     ChannelAgentCredential,
     ChannelMessage,
+    ChannelWhatsAppAuthCert,
 )
 from app.routes.channel_routers.shared import (
     extract_bearer_token,
@@ -39,6 +40,7 @@ from app.services.channels import (
     resolve_channel_agent_by_identity,
     resolve_channel_agent_by_token,
 )
+from app.services.sync_events import queue_environment_runtime_manifest_changed
 from app.services.whatsapp_baileys import (
     BinaryNode,
     WhatsAppInboxPump,
@@ -131,9 +133,21 @@ async def _run_whatsapp_baileys_websocket(
         if account.provider != CHANNEL_PROVIDER_WHATSAPP:
             await websocket.close(code=1008)
             return
+        had_auth_cert = await db.scalar(
+            select(ChannelWhatsAppAuthCert.id).where(
+                ChannelWhatsAppAuthCert.account_id == account.id
+            )
+        )
         auth_cert = await load_or_create_whatsapp_auth_cert(db, account=account)
+        if had_auth_cert is None:
+            await queue_environment_runtime_manifest_changed(
+                db,
+                agent.link.user_id,
+                agent.link.agent_id,
+            )
         await db.commit()
         tenant_user_id = agent.link.user_id
+        tenant_agent_id = agent.link.agent_id
 
     session_revoked = asyncio.Event()
     session_revocation_lock = asyncio.Lock()
@@ -185,6 +199,8 @@ async def _run_whatsapp_baileys_websocket(
                 db,
                 account=resolved_account,
                 credential=credential,
+                user_id=tenant_user_id,
+                environment_id=tenant_agent_id,
             )
             return WhatsAppNoiseTenant(
                 tenant_id=str(credential.bot_agent_link_id),
@@ -386,6 +402,8 @@ async def _resolve_whatsapp_noise_lid(
     *,
     account: ChannelAccount,
     credential: ChannelAgentCredential,
+    user_id: UUID,
+    environment_id: UUID,
 ) -> str:
     account_changed = False
     identity = whatsapp_self_identity_from_config(account.config)
@@ -409,6 +427,12 @@ async def _resolve_whatsapp_noise_lid(
         credential=credential,
         self_identity=identity,
     )
+    if changed:
+        await queue_environment_runtime_manifest_changed(
+            db,
+            user_id,
+            environment_id,
+        )
     if changed or account_changed:
         await db.commit()
     return identity["lid"]

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -1055,7 +1055,7 @@ async def platform_upsert_runtime_state(
             desired=body.secret_values,
         )
     if changed_fields:
-        queue_runtime_manifest_changed(db, agent.user_id, agent_id)
+        await queue_runtime_manifest_changed(db, agent.user_id, agent_id)
     response = PlatformRuntimeStateResponse(
         environment_id=agent_id,
         deployment_id=body.deployment_id,
@@ -1161,7 +1161,7 @@ async def platform_delete_runtime_state(
             environment_id=agent_id,
         )
         await db.delete(runtime_state)
-        queue_runtime_manifest_changed(db, agent.user_id, agent_id)
+        await queue_runtime_manifest_changed(db, agent.user_id, agent_id)
     await _complete_mutation(
         db,
         operation="runtime_state.delete",

--- a/backend/app/routes/plugin_catalog.py
+++ b/backend/app/routes/plugin_catalog.py
@@ -351,7 +351,7 @@ async def put_agent_plugin_desired_state(
             row.updated_at = datetime.now(UTC)
             changed = True
     if changed:
-        queue_runtime_manifest_changed(db, auth.user_id, agent_id)
+        await queue_runtime_manifest_changed(db, auth.user_id, agent_id)
     await db.flush()
     await db.refresh(row)
     observations, observed_at, received_at = await _latest_agent_plugin_observations(
@@ -411,7 +411,7 @@ async def delete_agent_plugin_desired_state(
     resource_id = str(row.id) if row is not None else None
     if row is not None:
         await db.delete(row)
-        queue_runtime_manifest_changed(db, auth.user_id, agent_id)
+        await queue_runtime_manifest_changed(db, auth.user_id, agent_id)
     record_control_plane_audit(
         db,
         actor_type="user",

--- a/backend/app/routes/projects.py
+++ b/backend/app/routes/projects.py
@@ -33,9 +33,12 @@ from app.services.agent_lifecycle import active_project_filter
 from app.services.project_runtime_skills import (
     lock_project_change,
     lock_project_runtime_graph,
-    queue_project_runtime_manifest_changed,
 )
 from app.services.sharing import safe_owner_display, safe_owner_handle
+from app.services.sync_events import (
+    active_runtime_manifest_targets,
+    queue_runtime_manifests_changed,
+)
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
@@ -545,7 +548,7 @@ async def archive_project(
             status.HTTP_409_CONFLICT,
             "Only user-created Projects can be archived",
         )
-    await queue_project_runtime_manifest_changed(db, project_id=project_id)
+    targets = await active_runtime_manifest_targets(db, agent_ids)
     await db.execute(
         delete(AgentProjectBinding).where(
             AgentProjectBinding.project_id == project_id,
@@ -553,5 +556,6 @@ async def archive_project(
         )
     )
     project.archived_at = datetime.now(UTC)
+    await queue_runtime_manifests_changed(db, targets)
     await db.commit()
     return ProjectArchiveResponse(unlinked_agent_count=len(agent_ids))

--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -59,6 +59,7 @@ from app.services.runtime_source_authority import load_persisted_runtime_source_
 from app.services.runtime_source_revision import (
     persisted_runtime_source_revision,
     repair_runtime_source_revision,
+    runtime_source_contract_revision,
 )
 from app.services.sync_events import queue_environment_runtime_manifest_changed
 from app.services.tar_utils import reroot_skill_archive, tar_from_content
@@ -236,7 +237,10 @@ async def _render_runtime_source_snapshot(
                 )
             )
         except RuntimeSourceError:
-            if expected_revision is not None:
+            if (
+                expected_revision is not None
+                or expected_contract != runtime_source_contract_revision()
+            ):
                 repaired = await repair_runtime_source_revision(
                     db,
                     environment_id=environment_id,

--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -55,6 +55,12 @@ from app.services.runtime_source import (
     runtime_whatsapp_credential_repair_link_ids,
     vault_key_identity,
 )
+from app.services.runtime_source_authority import load_persisted_runtime_source_authority
+from app.services.runtime_source_revision import (
+    persisted_runtime_source_revision,
+    repair_runtime_source_revision,
+)
+from app.services.sync_events import queue_environment_runtime_manifest_changed
 from app.services.tar_utils import reroot_skill_archive, tar_from_content
 
 router = APIRouter(prefix="/runtime", tags=["runtime"])
@@ -100,6 +106,7 @@ async def get_runtime_manifest(
     if_none_match = request.headers.get("if-none-match")
     try:
         snapshot = await _render_runtime_source_snapshot(
+            db=db,
             environment_id=environment_id,
             owner_user_id=auth.user_id,
             if_none_match=if_none_match,
@@ -113,8 +120,14 @@ async def get_runtime_manifest(
                 owner_user_id=auth.user_id,
                 link_ids=snapshot.repair_link_ids,
             )
+            await queue_environment_runtime_manifest_changed(
+                db,
+                auth.user_id,
+                environment_id,
+            )
             await db.commit()
             snapshot = await _render_runtime_source_snapshot(
+                db=db,
                 environment_id=environment_id,
                 owner_user_id=auth.user_id,
                 if_none_match=if_none_match,
@@ -144,12 +157,37 @@ async def get_runtime_manifest(
 
 async def _render_runtime_source_snapshot(
     *,
+    db: AsyncSession,
     environment_id: UUID,
     owner_user_id: UUID,
     if_none_match: str | None,
     project_agent_plugins: bool,
     project_agent_plugin_github_release_sources: bool,
 ) -> _RuntimeManifestSnapshot:
+    canonical_projection = project_agent_plugins and project_agent_plugin_github_release_sources
+    if if_none_match is not None:
+        async with runtime_snapshot_session() as source_db:
+            authority = await load_persisted_runtime_source_authority(
+                source_db,
+                environment_id=environment_id,
+                owner_user_id=owner_user_id,
+            )
+        if (
+            authority.matches_projection(
+                project_agent_plugins=project_agent_plugins,
+                project_agent_plugin_github_release_sources=(
+                    project_agent_plugin_github_release_sources
+                ),
+            )
+            and authority.etag is not None
+            and if_none_match_contains(if_none_match, authority.etag)
+        ):
+            return _RuntimeManifestSnapshot(
+                source=None,
+                etag=authority.etag,
+                repair_link_ids=(),
+            )
+
     async with runtime_snapshot_session() as source_db:
         batch = await load_runtime_source_batch(
             source_db,
@@ -166,30 +204,80 @@ async def _render_runtime_source_snapshot(
                 etag=None,
                 repair_link_ids=repair_link_ids,
             )
-        source_without_secrets = render_runtime_source(
-            batch,
-            environment_id=environment_id,
-            public_api_url=settings.public_api_url,
-            vault_key_identity=vault_key_identity(settings.vault_encryption_key),
-            decrypt_secrets=False,
-            project_agent_plugins=project_agent_plugins,
-            project_agent_plugin_github_release_sources=project_agent_plugin_github_release_sources,
-        )
+        source_row = batch.rows.get(environment_id)
+        if source_row is None:
+            raise RuntimeSourceNotFoundError("Agent environment not found")
+        state = source_row.state
+        if state is None:
+            raise RuntimeSourceNotFoundError("Hosted runtime state not found")
+        expected_revision = state.source_revision
+        expected_contract = state.source_revision_contract
+        try:
+            canonical_source = render_runtime_source(
+                batch,
+                environment_id=environment_id,
+                public_api_url=settings.public_api_url,
+                vault_key_identity=vault_key_identity(settings.vault_encryption_key),
+                decrypt_secrets=False,
+            )
+            source_without_secrets = (
+                canonical_source
+                if canonical_projection
+                else render_runtime_source(
+                    batch,
+                    environment_id=environment_id,
+                    public_api_url=settings.public_api_url,
+                    vault_key_identity=vault_key_identity(settings.vault_encryption_key),
+                    decrypt_secrets=False,
+                    project_agent_plugins=project_agent_plugins,
+                    project_agent_plugin_github_release_sources=(
+                        project_agent_plugin_github_release_sources
+                    ),
+                )
+            )
+        except RuntimeSourceError:
+            if expected_revision is not None:
+                repaired = await repair_runtime_source_revision(
+                    db,
+                    environment_id=environment_id,
+                    expected_revision=expected_revision,
+                    expected_contract=expected_contract,
+                    computed_revision=None,
+                )
+                if repaired:
+                    await db.commit()
+            raise
         etag = expected_runtime_bundle_v2_etag(source_without_secrets.source_revision)
-        if if_none_match_contains(if_none_match, etag):
-            return _RuntimeManifestSnapshot(source=None, etag=etag, repair_link_ids=())
-        source = render_runtime_source(
-            batch,
+        source = None
+        if not if_none_match_contains(if_none_match, etag):
+            source = render_runtime_source(
+                batch,
+                environment_id=environment_id,
+                public_api_url=settings.public_api_url,
+                vault_key_identity=vault_key_identity(settings.vault_encryption_key),
+                decrypt_secrets=True,
+                project_agent_plugins=project_agent_plugins,
+                project_agent_plugin_github_release_sources=(
+                    project_agent_plugin_github_release_sources
+                ),
+            )
+            if source.source_revision != source_without_secrets.source_revision:
+                raise RuntimeSourceError("Runtime source revision depends on secret decryption")
+
+    if (
+        expected_revision != canonical_source.source_revision
+        or persisted_runtime_source_revision(state) is None
+    ):
+        repaired = await repair_runtime_source_revision(
+            db,
             environment_id=environment_id,
-            public_api_url=settings.public_api_url,
-            vault_key_identity=vault_key_identity(settings.vault_encryption_key),
-            decrypt_secrets=True,
-            project_agent_plugins=project_agent_plugins,
-            project_agent_plugin_github_release_sources=project_agent_plugin_github_release_sources,
+            expected_revision=expected_revision,
+            expected_contract=expected_contract,
+            computed_revision=canonical_source.source_revision,
         )
-        if source.source_revision != source_without_secrets.source_revision:
-            raise RuntimeSourceError("Runtime source revision depends on secret decryption")
-        return _RuntimeManifestSnapshot(source=source, etag=etag, repair_link_ids=())
+        if repaired:
+            await db.commit()
+    return _RuntimeManifestSnapshot(source=source, etag=etag, repair_link_ids=())
 
 
 def _authorized_environment_id(auth: AuthContext, requested_environment_id: UUID | None) -> UUID:

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -34,7 +34,7 @@ from app.core.auth import (
     require_web_auth,
 )
 from app.core.config import settings
-from app.core.database import get_session, runtime_snapshot_session
+from app.core.database import get_session
 from app.models.agent_project_binding import AgentProjectBinding
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
@@ -107,13 +107,8 @@ from app.services.file_store import get_file_store
 from app.services.http_cache import if_none_match_contains, strong_json_etag
 from app.services.memory_provider import get_memory_provider
 from app.services.runtime_generation import resolve_runtime_apply_generation
-from app.services.runtime_source import (
-    RuntimeSourceError,
-    expected_runtime_bundle_v2_etag,
-    load_runtime_source_batch,
-    render_runtime_source,
-    vault_key_identity,
-)
+from app.services.runtime_source import expected_runtime_bundle_v2_etag
+from app.services.runtime_source_revision import persisted_runtime_source_revision
 from app.services.session_content import (
     SessionContentInvalid,
     SessionContentMissing,
@@ -550,32 +545,21 @@ async def list_environment_runtime_observed(
     desired_cli_specs: dict[UUID, str] = {}
     observations_by_env: dict[UUID, HostedRuntimeConfigObservation] = {}
     if env_ids:
-        async with runtime_snapshot_session() as source_db:
-            source_batch = await load_runtime_source_batch(
-                source_db,
-                environment_ids=env_ids,
-                owner_user_id=auth.user_id,
-            )
-            states_by_env = {
-                environment_id: row.state
-                for environment_id, row in source_batch.rows.items()
-                if row.state is not None
-            }
-            key_identity = vault_key_identity(settings.vault_encryption_key)
-            for environment_id in source_batch.rows:
-                try:
-                    rendered = render_runtime_source(
-                        source_batch,
-                        environment_id=environment_id,
-                        public_api_url=settings.public_api_url,
-                        vault_key_identity=key_identity,
-                        decrypt_secrets=False,
-                    )
-                except RuntimeSourceError:
-                    source_errors.add(environment_id)
-                    continue
-                source_revisions[environment_id] = rendered.source_revision
-                desired_cli_specs[environment_id] = rendered.manifest["clawdiCli"]["packageSpec"]
+        states = list(
+            (
+                await db.execute(
+                    select(HostedRuntimeState).where(HostedRuntimeState.environment_id.in_(env_ids))
+                )
+            ).scalars()
+        )
+        states_by_env = {state.environment_id: state for state in states}
+        for state in states:
+            revision = persisted_runtime_source_revision(state)
+            if revision is None:
+                source_errors.add(state.environment_id)
+                continue
+            source_revisions[state.environment_id] = revision
+            desired_cli_specs[state.environment_id] = state.cli_package_spec
         observations = (
             (
                 await db.execute(
@@ -1032,43 +1016,29 @@ async def get_environment_runtime_observed(
     if bound_env is not None and environment_id != bound_env:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
 
-    env = (
+    row = (
         await db.execute(
-            select(AgentEnvironment).where(
+            select(AgentEnvironment, HostedRuntimeState)
+            .outerjoin(
+                HostedRuntimeState,
+                HostedRuntimeState.environment_id == AgentEnvironment.id,
+            )
+            .where(
                 AgentEnvironment.id == environment_id,
                 AgentEnvironment.user_id == auth.user_id,
                 active_agent_filter(),
             )
         )
-    ).scalar_one_or_none()
-    if env is None:
+    ).one_or_none()
+    if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
+    env, state = row
 
-    source_revision = None
-    source_error = False
-    desired_cli_package_spec = None
-    async with runtime_snapshot_session() as source_db:
-        source_batch = await load_runtime_source_batch(
-            source_db,
-            environment_ids=[environment_id],
-            owner_user_id=auth.user_id,
-        )
-        source_row = source_batch.rows.get(environment_id)
-        state = source_row.state if source_row is not None else None
-        if state is not None:
-            try:
-                rendered = render_runtime_source(
-                    source_batch,
-                    environment_id=environment_id,
-                    public_api_url=settings.public_api_url,
-                    vault_key_identity=vault_key_identity(settings.vault_encryption_key),
-                    decrypt_secrets=False,
-                )
-            except RuntimeSourceError:
-                source_error = True
-            else:
-                source_revision = rendered.source_revision
-                desired_cli_package_spec = rendered.manifest["clawdiCli"]["packageSpec"]
+    source_revision = persisted_runtime_source_revision(state) if state is not None else None
+    source_error = state is not None and source_revision is None
+    desired_cli_package_spec = (
+        state.cli_package_spec if source_revision is not None and state is not None else None
+    )
     observation = (
         await db.execute(
             select(HostedRuntimeConfigObservation).where(

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -108,7 +108,10 @@ from app.services.http_cache import if_none_match_contains, strong_json_etag
 from app.services.memory_provider import get_memory_provider
 from app.services.runtime_generation import resolve_runtime_apply_generation
 from app.services.runtime_source import expected_runtime_bundle_v2_etag
-from app.services.runtime_source_revision import persisted_runtime_source_revision
+from app.services.runtime_source_revision import (
+    persisted_runtime_source_error,
+    persisted_runtime_source_revision,
+)
 from app.services.session_content import (
     SessionContentInvalid,
     SessionContentMissing,
@@ -555,11 +558,11 @@ async def list_environment_runtime_observed(
         states_by_env = {state.environment_id: state for state in states}
         for state in states:
             revision = persisted_runtime_source_revision(state)
-            if revision is None:
-                source_errors.add(state.environment_id)
-                continue
-            source_revisions[state.environment_id] = revision
             desired_cli_specs[state.environment_id] = state.cli_package_spec
+            if revision is not None:
+                source_revisions[state.environment_id] = revision
+            elif persisted_runtime_source_error(state):
+                source_errors.add(state.environment_id)
         observations = (
             (
                 await db.execute(
@@ -1035,10 +1038,8 @@ async def get_environment_runtime_observed(
     env, state = row
 
     source_revision = persisted_runtime_source_revision(state) if state is not None else None
-    source_error = state is not None and source_revision is None
-    desired_cli_package_spec = (
-        state.cli_package_spec if source_revision is not None and state is not None else None
-    )
+    source_error = state is not None and persisted_runtime_source_error(state)
+    desired_cli_package_spec = state.cli_package_spec if state is not None else None
     observation = (
         await db.execute(
             select(HostedRuntimeConfigObservation).where(

--- a/backend/app/services/agent_lifecycle.py
+++ b/backend/app/services/agent_lifecycle.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.api_key import ApiKey
 from app.models.project import PROJECT_KIND_ENVIRONMENT, Project
 from app.models.session import AgentEnvironment
+from app.services.sync_events import queue_environment_runtime_manifest_changed
 
 
 class AgentLifecycleBoundaryError(RuntimeError):
@@ -125,6 +126,11 @@ async def reactivate_agent_and_project(db: AsyncSession, *, agent: AgentEnvironm
         raise AgentLifecycleBoundaryError("Agent Project is shared by another Agent")
     locked_agent.archived_at = None
     project.archived_at = None
+    await queue_environment_runtime_manifest_changed(
+        db,
+        locked_agent.user_id,
+        locked_agent.id,
+    )
 
 
 async def active_owned_agent(

--- a/backend/app/services/principal_lifecycle.py
+++ b/backend/app/services/principal_lifecycle.py
@@ -51,9 +51,12 @@ from app.services.ai_provider_auth_transition import transition_ai_provider_auth
 from app.services.ai_provider_oauth_lifecycle import terminal_oauth_attempt
 from app.services.project_runtime_skills import (
     lock_project_runtime_graphs,
-    queue_project_runtime_manifest_changed,
 )
 from app.services.runtime_observation import retire_runtime_environment
+from app.services.sync_events import (
+    active_runtime_manifest_targets,
+    queue_runtime_manifests_changed,
+)
 
 
 class PrincipalTerminatedError(RuntimeError):
@@ -757,9 +760,8 @@ async def complete_principal_cleanup(
         return PrincipalCleanupResult(user_disabled=False)
 
     # Owner deletion removes every other user's access to the owner's Projects.
-    # Take all Project locks before any affected Agent lock, notify managed
-    # Agents, and remove their links in this same transaction. Otherwise those
-    # Agents would keep a stale desired bundle until their next periodic poll.
+    # Take all Project locks before any affected Agent lock, capture surviving
+    # targets, and refresh them after removing the links in this transaction.
     owned_project_id_values = tuple(
         (
             await db.scalars(
@@ -767,9 +769,12 @@ async def complete_principal_cleanup(
             )
         ).all()
     )
-    await lock_project_runtime_graphs(db, owned_project_id_values)
-    for project_id in owned_project_id_values:
-        await queue_project_runtime_manifest_changed(db, project_id=project_id)
+    affected_agent_ids = await lock_project_runtime_graphs(db, owned_project_id_values)
+    affected_targets = [
+        target
+        for target in await active_runtime_manifest_targets(db, affected_agent_ids)
+        if target[0] != user.id
+    ]
     if owned_project_id_values:
         await db.execute(
             delete(AgentProjectBinding).where(
@@ -777,6 +782,7 @@ async def complete_principal_cleanup(
                 AgentProjectBinding.binding_type == "context",
             )
         )
+        await queue_runtime_manifests_changed(db, affected_targets)
 
     key_ids = tuple(
         (

--- a/backend/app/services/project_runtime_skills.py
+++ b/backend/app/services/project_runtime_skills.py
@@ -25,7 +25,7 @@ from app.models.project_membership import ProjectMembership
 from app.models.session import AgentEnvironment
 from app.models.skill import SKILL_AUTHORITY_AGENT_SYNC, SKILL_AUTHORITY_CLOUD, Skill
 from app.schemas.runtime import PersistedHostedRuntimeSkills
-from app.services.sync_events import queue_runtime_manifest_changed
+from app.services.sync_events import queue_runtime_manifests_changed
 
 # OpenClaw's native `skills install --as` contract accepts this slug shape.
 # Source keys may be namespaced. The SKILL.md name is the local install identity
@@ -551,11 +551,9 @@ async def queue_project_runtime_manifest_changed(
             )
         )
     ).all()
-    affected: list[UUID] = []
-    for user_id, agent_id in rows:
-        queue_runtime_manifest_changed(db, user_id, agent_id)
-        affected.append(agent_id)
-    return affected
+    targets = [(user_id, agent_id) for user_id, agent_id in rows]
+    await queue_runtime_manifests_changed(db, targets)
+    return [agent_id for _user_id, agent_id in targets]
 
 
 def project_skill_file_signature(

--- a/backend/app/services/runtime_observed_evidence.py
+++ b/backend/app/services/runtime_observed_evidence.py
@@ -6,19 +6,16 @@ from typing import Literal
 from uuid import UUID
 
 from pydantic import TypeAdapter, ValidationError
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
+from app.models.session import AgentEnvironment
 from app.schemas.runtime_observed import HostedRuntimeObserved, HostedRuntimeObservedV2
 from app.services.runtime_generation import resolve_runtime_apply_generation
-from app.services.runtime_source import (
-    RuntimeSourceError,
-    expected_runtime_bundle_v2_etag,
-    load_runtime_source_batch,
-    render_runtime_source,
-    vault_key_identity,
-)
+from app.services.runtime_source import expected_runtime_bundle_v2_etag
+from app.services.runtime_source_revision import persisted_runtime_source_revision
 
 RuntimeEvidenceStatus = Literal["ok", "error", "unknown", "missing", "stale"]
 _RUNTIME_OBSERVED_ADAPTER = TypeAdapter(HostedRuntimeObserved)
@@ -53,31 +50,37 @@ async def load_runtime_observed_evidence(
     if not requested_ids:
         return {}
 
-    batch = await load_runtime_source_batch(
-        db,
-        environment_ids=requested_ids,
-        owner_user_id=owner_user_id,
-    )
+    rows = (
+        await db.execute(
+            select(HostedRuntimeState, HostedRuntimeConfigObservation)
+            .join(
+                AgentEnvironment,
+                AgentEnvironment.id == HostedRuntimeState.environment_id,
+            )
+            .outerjoin(
+                HostedRuntimeConfigObservation,
+                HostedRuntimeConfigObservation.environment_id == HostedRuntimeState.environment_id,
+            )
+            .where(
+                HostedRuntimeState.environment_id.in_(requested_ids),
+                AgentEnvironment.user_id == owner_user_id,
+                AgentEnvironment.archived_at.is_(None),
+            )
+        )
+    ).all()
+    by_environment = {state.environment_id: (state, observation) for state, observation in rows}
     current = now or datetime.now(UTC)
     freshness = timedelta(seconds=settings.runtime_observation_freshness_seconds)
     evidence: dict[UUID, RuntimeObservedEvidence] = {}
     for environment_id in requested_ids:
-        row = batch.rows.get(environment_id)
-        desired_source_revision = None
-        if row is not None and row.state is not None:
-            try:
-                desired_source_revision = render_runtime_source(
-                    batch,
-                    environment_id=environment_id,
-                    public_api_url=settings.public_api_url,
-                    vault_key_identity=vault_key_identity(settings.vault_encryption_key),
-                    decrypt_secrets=False,
-                ).source_revision
-            except RuntimeSourceError:
-                pass
+        row = by_environment.get(environment_id)
+        state, observation = row if row is not None else (None, None)
+        desired_source_revision = (
+            persisted_runtime_source_revision(state) if state is not None else None
+        )
         evidence[environment_id] = _runtime_observed_evidence(
-            state=row.state if row is not None else None,
-            observation=row.observation if row is not None else None,
+            state=state,
+            observation=observation,
             desired_source_revision=desired_source_revision,
             current=current,
             freshness=freshness,

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -90,6 +90,7 @@ from app.services.whatsapp_baileys import (
 
 RUNTIME_BUNDLE_V2_MEDIA_TYPE = "application/vnd.clawdi.runtime-bundle.v2+json"
 RUNTIME_BUNDLE_V2_SCHEMA_VERSION = "clawdi.hosted-runtime.bundle.v2"
+RUNTIME_SOURCE_RENDERER_REVISION = "runtime-source.v1"
 RUNTIME_CAPABILITIES_HEADER = "X-Clawdi-Runtime-Capabilities"
 RUNTIME_AGENT_PLUGINS_MANIFEST_CAPABILITY = "agent-plugins-manifest-v1"
 RUNTIME_AGENT_PLUGIN_GITHUB_RELEASE_SOURCE_CAPABILITY = "agent-plugin-github-release-source-v1"
@@ -987,6 +988,7 @@ def render_runtime_source(
             )
 
     descriptor: dict[str, object] = {
+        "rendererRevision": RUNTIME_SOURCE_RENDERER_REVISION,
         "schemaVersion": RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
         "manifest": manifest,
         "channelBindings": bindings,

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -90,6 +90,9 @@ from app.services.whatsapp_baileys import (
 
 RUNTIME_BUNDLE_V2_MEDIA_TYPE = "application/vnd.clawdi.runtime-bundle.v2+json"
 RUNTIME_BUNDLE_V2_SCHEMA_VERSION = "clawdi.hosted-runtime.bundle.v2"
+# Renderer contract: bump this value whenever emitted desired-state material changes.
+# A bump makes each Agent render and backfill once on its next manifest poll, spreading
+# the fleet work naturally. Forgetting it can make an old ETag return 304 indefinitely.
 RUNTIME_SOURCE_RENDERER_REVISION = "runtime-source.v1"
 RUNTIME_CAPABILITIES_HEADER = "X-Clawdi-Runtime-Capabilities"
 RUNTIME_AGENT_PLUGINS_MANIFEST_CAPABILITY = "agent-plugins-manifest-v1"

--- a/backend/app/services/runtime_source_authority.py
+++ b/backend/app/services/runtime_source_authority.py
@@ -3,8 +3,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from uuid import UUID
 
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.core.config import settings
 from app.core.database import runtime_snapshot_session
+from app.models.agent_plugin import AgentPluginInstallation
+from app.models.hosted_runtime import HostedRuntimeState
+from app.models.session import AgentEnvironment
+from app.schemas.plugin_catalog import RESERVED_AGENT_PLUGIN_NAMES
 from app.services.runtime_source import (
     RuntimeSourceNotFoundError,
     expected_runtime_bundle_v2_etag,
@@ -12,6 +19,7 @@ from app.services.runtime_source import (
     render_runtime_source,
     vault_key_identity,
 )
+from app.services.runtime_source_revision import runtime_source_contract_revision
 
 
 @dataclass(frozen=True, slots=True)
@@ -23,14 +31,131 @@ class RuntimeSourceAuthority:
     etag: str
 
 
+@dataclass(frozen=True, slots=True)
+class PersistedRuntimeSourceAuthority:
+    environment_id: UUID
+    deployment_id: str
+    instance_id: str
+    source_revision: str | None
+    has_agent_plugins: bool
+    has_github_release_agent_plugins: bool
+
+    @property
+    def etag(self) -> str | None:
+        if self.source_revision is None:
+            return None
+        return expected_runtime_bundle_v2_etag(self.source_revision)
+
+    def matches_projection(
+        self,
+        *,
+        project_agent_plugins: bool,
+        project_agent_plugin_github_release_sources: bool,
+    ) -> bool:
+        if not self.has_agent_plugins:
+            return True
+        if not project_agent_plugins:
+            return False
+        return (
+            project_agent_plugin_github_release_sources or not self.has_github_release_agent_plugins
+        )
+
+
+async def load_persisted_runtime_source_authority(
+    db: AsyncSession,
+    *,
+    environment_id: UUID,
+    owner_user_id: UUID,
+) -> PersistedRuntimeSourceAuthority:
+    has_agent_plugins = (
+        select(AgentPluginInstallation.id)
+        .where(
+            AgentPluginInstallation.environment_id == AgentEnvironment.id,
+            AgentPluginInstallation.plugin_name.not_in(RESERVED_AGENT_PLUGIN_NAMES),
+        )
+        .exists()
+    )
+    has_github_release_agent_plugins = (
+        select(AgentPluginInstallation.id)
+        .where(
+            AgentPluginInstallation.environment_id == AgentEnvironment.id,
+            AgentPluginInstallation.plugin_name.not_in(RESERVED_AGENT_PLUGIN_NAMES),
+            AgentPluginInstallation.source["type"].as_string() == "github-release",
+        )
+        .exists()
+    )
+    row = (
+        await db.execute(
+            select(
+                AgentEnvironment.id,
+                HostedRuntimeState.environment_id,
+                HostedRuntimeState.deployment_id,
+                HostedRuntimeState.instance_id,
+                HostedRuntimeState.source_revision,
+                HostedRuntimeState.source_revision_contract,
+                has_agent_plugins,
+                has_github_release_agent_plugins,
+            )
+            .outerjoin(
+                HostedRuntimeState,
+                HostedRuntimeState.environment_id == AgentEnvironment.id,
+            )
+            .where(
+                AgentEnvironment.id == environment_id,
+                AgentEnvironment.user_id == owner_user_id,
+                AgentEnvironment.archived_at.is_(None),
+            )
+        )
+    ).one_or_none()
+    if row is None:
+        raise RuntimeSourceNotFoundError("Agent environment not found")
+    (
+        environment_id,
+        state_environment_id,
+        deployment_id,
+        instance_id,
+        source_revision,
+        source_revision_contract,
+        has_agent_plugins,
+        has_github_release_agent_plugins,
+    ) = row
+    if state_environment_id is None:
+        raise RuntimeSourceNotFoundError("Hosted runtime state not found")
+    return PersistedRuntimeSourceAuthority(
+        environment_id=environment_id,
+        deployment_id=deployment_id,
+        instance_id=instance_id,
+        source_revision=(
+            source_revision
+            if source_revision_contract == runtime_source_contract_revision()
+            else None
+        ),
+        has_agent_plugins=has_agent_plugins,
+        has_github_release_agent_plugins=has_github_release_agent_plugins,
+    )
+
+
 async def load_runtime_source_authority(
     *,
     environment_id: UUID,
     owner_user_id: UUID,
 ) -> RuntimeSourceAuthority:
-    """Render the non-secret authority for one exact owner/environment binding."""
+    """Load the persisted authority, rendering only an unbackfilled legacy row."""
 
     async with runtime_snapshot_session() as source_db:
+        persisted = await load_persisted_runtime_source_authority(
+            source_db,
+            environment_id=environment_id,
+            owner_user_id=owner_user_id,
+        )
+        if persisted.source_revision is not None and persisted.etag is not None:
+            return RuntimeSourceAuthority(
+                environment_id=persisted.environment_id,
+                deployment_id=persisted.deployment_id,
+                instance_id=persisted.instance_id,
+                source_revision=persisted.source_revision,
+                etag=persisted.etag,
+            )
         batch = await load_runtime_source_batch(
             source_db,
             environment_ids=[environment_id],

--- a/backend/app/services/runtime_source_revision.py
+++ b/backend/app/services/runtime_source_revision.py
@@ -39,6 +39,13 @@ def persisted_runtime_source_revision(state: HostedRuntimeState) -> str | None:
     return state.source_revision
 
 
+def persisted_runtime_source_error(state: HostedRuntimeState) -> bool:
+    return (
+        state.source_revision is None
+        and state.source_revision_contract == runtime_source_contract_revision()
+    )
+
+
 async def refresh_runtime_source_revisions(
     db: AsyncSession,
     environment_ids: Iterable[UUID],
@@ -78,8 +85,6 @@ async def refresh_runtime_source_revisions(
             )
         revisions[environment_id] = revision
         state = row.state
-        if revision is None and state.source_revision is None:
-            continue
         if (
             state.source_revision == revision
             and state.source_revision_contract == contract_revision

--- a/backend/app/services/runtime_source_revision.py
+++ b/backend/app/services/runtime_source_revision.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from collections.abc import Iterable
+from uuid import UUID
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import set_committed_value
+
+from app.core.config import settings
+from app.models.hosted_runtime import HostedRuntimeState
+from app.services.runtime_source import (
+    RUNTIME_SOURCE_RENDERER_REVISION,
+    RuntimeSourceError,
+    load_runtime_source_batch,
+    render_runtime_source,
+    vault_key_identity,
+)
+
+log = logging.getLogger(__name__)
+
+
+def runtime_source_contract_revision() -> str:
+    material = {
+        "publicApiUrl": settings.public_api_url.rstrip("/"),
+        "rendererRevision": RUNTIME_SOURCE_RENDERER_REVISION,
+        "vaultKeyIdentity": vault_key_identity(settings.vault_encryption_key),
+    }
+    canonical = json.dumps(material, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def persisted_runtime_source_revision(state: HostedRuntimeState) -> str | None:
+    if state.source_revision_contract != runtime_source_contract_revision():
+        return None
+    return state.source_revision
+
+
+async def refresh_runtime_source_revisions(
+    db: AsyncSession,
+    environment_ids: Iterable[UUID],
+) -> dict[UUID, str | None]:
+    requested_ids = sorted(set(environment_ids), key=str)
+    if not requested_ids:
+        return {}
+
+    await db.flush()
+    await db.execute(
+        select(HostedRuntimeState.environment_id)
+        .where(HostedRuntimeState.environment_id.in_(requested_ids))
+        .order_by(HostedRuntimeState.environment_id)
+        .with_for_update()
+    )
+    batch = await load_runtime_source_batch(db, environment_ids=requested_ids)
+    contract_revision = runtime_source_contract_revision()
+    revisions: dict[UUID, str | None] = {}
+    for environment_id in requested_ids:
+        row = batch.rows.get(environment_id)
+        if row is None or row.state is None:
+            continue
+        try:
+            revision = render_runtime_source(
+                batch,
+                environment_id=environment_id,
+                public_api_url=settings.public_api_url,
+                vault_key_identity=vault_key_identity(settings.vault_encryption_key),
+                decrypt_secrets=False,
+            ).source_revision
+        except RuntimeSourceError as exc:
+            revision = None
+            log.warning(
+                "runtime source revision refresh failed environment_id=%s reason=%s",
+                environment_id,
+                str(exc),
+            )
+        revisions[environment_id] = revision
+        state = row.state
+        if revision is None and state.source_revision is None:
+            continue
+        if (
+            state.source_revision == revision
+            and state.source_revision_contract == contract_revision
+        ):
+            continue
+        await db.execute(
+            update(HostedRuntimeState)
+            .where(HostedRuntimeState.environment_id == environment_id)
+            .values(
+                source_revision=revision,
+                source_revision_contract=contract_revision,
+                updated_at=HostedRuntimeState.updated_at,
+            )
+            .execution_options(synchronize_session=False)
+        )
+        set_committed_value(state, "source_revision", revision)
+        set_committed_value(state, "source_revision_contract", contract_revision)
+    return revisions
+
+
+async def repair_runtime_source_revision(
+    db: AsyncSession,
+    *,
+    environment_id: UUID,
+    expected_revision: str | None,
+    expected_contract: str | None,
+    computed_revision: str | None,
+) -> bool:
+    contract_revision = runtime_source_contract_revision()
+    repaired_id = await db.scalar(
+        update(HostedRuntimeState)
+        .where(
+            HostedRuntimeState.environment_id == environment_id,
+            HostedRuntimeState.source_revision.is_not_distinct_from(expected_revision),
+            HostedRuntimeState.source_revision_contract.is_not_distinct_from(expected_contract),
+        )
+        .values(
+            source_revision=computed_revision,
+            source_revision_contract=contract_revision,
+            updated_at=HostedRuntimeState.updated_at,
+        )
+        .returning(HostedRuntimeState.environment_id)
+        .execution_options(synchronize_session=False)
+    )
+    if repaired_id is None:
+        return False
+    if expected_revision is not None or expected_contract is not None:
+        log.warning(
+            "repaired stale runtime source revision environment_id=%s "
+            "persisted_revision=%s computed_revision=%s",
+            environment_id,
+            expected_revision,
+            computed_revision,
+        )
+    return True

--- a/backend/app/services/sync_events.py
+++ b/backend/app/services/sync_events.py
@@ -61,6 +61,7 @@ import json
 import logging
 import os
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from uuid import UUID, uuid4
 
@@ -327,6 +328,26 @@ async def queue_runtime_manifests_changed(
     )
     for user_id, environment_id in targets:
         _queue_runtime_manifest_changed(db, user_id, environment_id)
+
+
+async def active_runtime_manifest_targets(
+    db: AsyncSession,
+    environment_ids: Iterable[UUID],
+) -> list[tuple[UUID, UUID]]:
+    requested_ids = sorted(set(environment_ids), key=str)
+    if not requested_ids:
+        return []
+    rows = (
+        await db.execute(
+            select(AgentEnvironment.user_id, AgentEnvironment.id)
+            .where(
+                AgentEnvironment.id.in_(requested_ids),
+                AgentEnvironment.archived_at.is_(None),
+            )
+            .order_by(AgentEnvironment.id)
+        )
+    ).all()
+    return [(user_id, environment_id) for user_id, environment_id in rows]
 
 
 async def queue_runtime_manifest_changed(

--- a/backend/app/services/sync_events.py
+++ b/backend/app/services/sync_events.py
@@ -300,7 +300,7 @@ def _payload_uuid(value: object) -> UUID | None:
     return None
 
 
-def queue_runtime_manifest_changed(
+def _queue_runtime_manifest_changed(
     db: AsyncSession,
     user_id: UUID,
     environment_id: UUID,
@@ -311,6 +311,30 @@ def queue_runtime_manifest_changed(
         "environment_id": str(environment_id),
     }
     _queue_for_commit(db, user_id, payload, deduplicate=True)
+
+
+async def queue_runtime_manifests_changed(
+    db: AsyncSession,
+    targets: list[tuple[UUID, UUID]],
+) -> None:
+    if not targets:
+        return
+    from app.services.runtime_source_revision import refresh_runtime_source_revisions
+
+    await refresh_runtime_source_revisions(
+        db,
+        [environment_id for _user_id, environment_id in targets],
+    )
+    for user_id, environment_id in targets:
+        _queue_runtime_manifest_changed(db, user_id, environment_id)
+
+
+async def queue_runtime_manifest_changed(
+    db: AsyncSession,
+    user_id: UUID,
+    environment_id: UUID,
+) -> None:
+    await queue_runtime_manifests_changed(db, [(user_id, environment_id)])
 
 
 async def queue_environment_runtime_manifest_changed(
@@ -330,7 +354,7 @@ async def queue_environment_runtime_manifest_changed(
     ).scalar_one_or_none()
     if agent is None:
         return False
-    queue_runtime_manifest_changed(db, user_id, environment_id)
+    await queue_runtime_manifest_changed(db, user_id, environment_id)
     return True
 
 
@@ -354,13 +378,13 @@ async def queue_provider_runtime_manifest_changed(
         .scalars()
         .all()
     )
-    affected: list[UUID] = []
+    targets: list[tuple[UUID, UUID]] = []
     for state in states:
         if not _runtime_state_may_use_provider(state, provider_id):
             continue
-        queue_runtime_manifest_changed(db, user_id, state.environment_id)
-        affected.append(state.environment_id)
-    return affected
+        targets.append((user_id, state.environment_id))
+    await queue_runtime_manifests_changed(db, targets)
+    return [environment_id for _user_id, environment_id in targets]
 
 
 def runtime_manifest_provider_non_auth_signature(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -282,6 +282,7 @@ strict = [
     "app/services/runtime_observed_evidence.py",
     "app/services/runtime_source.py",
     "app/services/runtime_source_authority.py",
+    "app/services/runtime_source_revision.py",
     "app/services/runtime_state_cleanup.py",
     "app/services/safe_public_http.py",
     "app/services/secret_detection.py",

--- a/backend/tests/fixtures/v1_runtime_observation_baseline.json
+++ b/backend/tests/fixtures/v1_runtime_observation_baseline.json
@@ -22,8 +22,8 @@
 				"_runtime_observed_response": "8ef8aae004cb5bef49162dc40ffbf195d5bb9d621d963cdefbbf7441cd5bae27",
 				"_runtime_observed_summary": "a81dcb71c60b6c15e8ac850d1ed1cea0dac338923c01da1afa6616d049b9c68a",
 				"_validated_runtime_observed_diagnostics": "4e6bf338bbc8657b7a76e39abf4a32c63852069f966c2414a5c9f16d3231aa75",
-				"get_environment_runtime_observed": "dd4f3c99370ebec312aed74d64bbc3c77dc223f5b5998c943a7012d573deea1c",
-				"list_environment_runtime_observed": "831a7dbf1009763e7c0581cfbba143b2ba03d7ae404f7edb5c2440a655a2daa4",
+				"get_environment_runtime_observed": "d5fa28547faafa46433c37c4be4c799277f681fcaa02ade946ec58b853ccab12",
+				"list_environment_runtime_observed": "3fb1040c4effabbc50e7a5f5499d7c3bc1652c9ff050b68636d9a0b4906958d2",
 				"sync_heartbeat": "1b64282f6b3d0fdb519fa29d8915cd8f1f1ecb6533f11ee7756a4a6afa801317"
 			}
 		},

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -2711,6 +2711,11 @@ async def test_admin_channel_lifecycle_manages_public_bot(
     async def fake_get_telegram_bot_username(_provider_token: str):
         return rotated_identity["username"]
 
+    queued_runtime_targets: list[tuple[UUID, UUID]] = []
+
+    async def capture_runtime_targets(_db, targets):
+        queued_runtime_targets.extend(targets)
+
     monkeypatch.setattr(
         "app.routes.admin.configure_telegram_provider_webhook",
         fake_configure_telegram_provider_webhook,
@@ -2718,6 +2723,10 @@ async def test_admin_channel_lifecycle_manages_public_bot(
     monkeypatch.setattr(
         "app.routes.admin.get_telegram_bot_username",
         fake_get_telegram_bot_username,
+    )
+    monkeypatch.setattr(
+        "app.routes.admin.queue_runtime_manifests_changed",
+        capture_runtime_targets,
     )
 
     created = await admin_client.post(
@@ -2855,6 +2864,14 @@ async def test_admin_channel_lifecycle_manages_public_bot(
     assert rotated.status_code == 200
     await db_session.refresh(account)
     assert verify_hashed_token(rotated.json()["webhook_secret"], account.webhook_secret_hash)
+
+    disabled = await admin_client.patch(
+        f"/v1/admin/channels/{body['id']}",
+        headers=_AUTH,
+        json={"status": "disabled"},
+    )
+    assert disabled.status_code == 200, disabled.text
+    assert queued_runtime_targets == [(seed_user.id, channel_agent.id)]
 
     deleted = await admin_client.delete(f"/v1/admin/channels/{body['id']}", headers=_AUTH)
     assert deleted.status_code == 204

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -124,12 +124,8 @@ from app.services.discord_gateway_worker import (
 from app.services.discord_rate_limiter import DiscordRateLimiter
 from app.services.runtime_generation import resolve_runtime_apply_generation
 from app.services.runtime_observation import retire_runtime_environment
-from app.services.runtime_source import (
-    expected_runtime_bundle_v2_etag,
-    load_runtime_source_batch,
-    render_runtime_source,
-    vault_key_identity,
-)
+from app.services.runtime_source import expected_runtime_bundle_v2_etag
+from app.services.runtime_source_revision import refresh_runtime_source_revisions
 from app.services.telegram_rate_limiter import telegram_rate_limiter
 from app.services.url_security import UnsafeOutboundUrlError
 from app.services.whatsapp_baileys import (
@@ -581,20 +577,10 @@ async def _converge_hosted_runtime(
     assert state is not None
     state.tools = CANONICAL_CODEX_TOOLS
     await ensure_canonical_codex_tool_provider(db_session, user)
+    revisions = await refresh_runtime_source_revisions(db_session, [agent_id])
+    source_revision = revisions[agent_id]
+    assert source_revision is not None
     await db_session.commit()
-
-    batch = await load_runtime_source_batch(
-        db_session,
-        environment_ids=[agent_id],
-        owner_user_id=user.id,
-    )
-    rendered = render_runtime_source(
-        batch,
-        environment_id=agent_id,
-        public_api_url=settings.public_api_url,
-        vault_key_identity=vault_key_identity(settings.vault_encryption_key),
-        decrypt_secrets=False,
-    )
     observation = await db_session.get(HostedRuntimeConfigObservation, agent_id)
     assert observation is not None
     observed_at = datetime.now(UTC)
@@ -602,11 +588,11 @@ async def _converge_hosted_runtime(
         generation=state.generation,
         apply_generation=state.apply_generation,
     )
-    etag = expected_runtime_bundle_v2_etag(rendered.source_revision)
+    etag = expected_runtime_bundle_v2_etag(source_revision)
     observation.observed_at = observed_at
     observation.observed_config_generation = generation
     observation.observed_manifest_etag = etag
-    observation.observed_source_revision = rendered.source_revision
+    observation.observed_source_revision = source_revision
     observation.diagnostics = {
         "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
         "reportedAt": observed_at.isoformat(),
@@ -615,7 +601,7 @@ async def _converge_hosted_runtime(
         "activeCliVersion": state.cli_package_spec.removeprefix("clawdi@"),
         "applied": {
             "etag": etag,
-            "sourceRevision": rendered.source_revision,
+            "sourceRevision": source_revision,
             "generation": generation,
             "instanceId": state.instance_id,
             "appliedProviderIds": [],
@@ -2161,7 +2147,7 @@ async def test_channel_health_select_count_is_constant_across_accounts(
         await create_account(index)
     five_account_count = await health_select_count()
 
-    assert one_account_count == 15
+    assert one_account_count == 10
     assert five_account_count == one_account_count
 
 
@@ -4325,7 +4311,7 @@ async def test_list_channel_agent_links_by_agent_returns_linked_channel_summarie
     assert public_item["binding_count"] == 1
     assert other_private["id"] not in by_account_id
     assert other_user_listing.status_code == 404
-    assert select_count == 8
+    assert select_count == 3
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -44,7 +44,9 @@ from app.models.hosted_runtime import (
     HostedRuntimeSecret,
     HostedRuntimeState,
 )
+from app.models.principal_lifecycle import PrincipalLifecycle
 from app.models.project import PROJECT_KIND_WORKSPACE, Project
+from app.models.project_membership import ProjectMembership
 from app.models.runtime_observation import V2RuntimeEnvironmentFence
 from app.models.session import AgentEnvironment
 from app.models.skill import SKILL_AUTHORITY_CLOUD, Skill
@@ -65,9 +67,11 @@ from app.schemas.runtime import (
     validate_clawdi_cli_package_spec,
 )
 from app.services import sync_events
+from app.services.agent_lifecycle import archive_agent_and_project, reactivate_agent_and_project
 from app.services.audit import _sanitize_audit_details
 from app.services.channels import channel_runtime_account_key, channel_runtime_placeholder_token
 from app.services.managed_ai_provider import CLAWDI_MANAGED_PROVIDER_ID
+from app.services.principal_lifecycle import complete_principal_cleanup
 from app.services.runtime_source import (
     RUNTIME_AGENT_PLUGIN_GITHUB_RELEASE_SOURCE_CAPABILITY,
     RUNTIME_AGENT_PLUGINS_MANIFEST_CAPABILITY,
@@ -4492,6 +4496,210 @@ async def test_runtime_bundle_emits_explicit_apply_generation_and_revalidates_ap
     assert advanced.json()["manifest"]["generation"] == state.generation
     assert advanced.json()["sourceRevision"] != initial_body["sourceRevision"]
     assert advanced.headers["etag"] != initial.headers["etag"]
+
+
+@pytest.mark.asyncio
+async def test_archiving_linked_project_revalidates_manifest_without_project_skill(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"archive-project-runtime-{uuid4().hex[:8]}",
+        machine_name="Archive Project runtime",
+        agent_type="openclaw",
+    )
+    await _write_runtime_state(admin_client, str(env.id))
+    project = Project(
+        user_id=seed_user.id,
+        name="Archived runtime Project",
+        slug=f"archived-runtime-{uuid4().hex[:8]}",
+        kind=PROJECT_KIND_WORKSPACE,
+    )
+    db_session.add(project)
+    await db_session.flush()
+    skill_key = "archive-project-skill"
+    db_session.add_all(
+        [
+            Skill(
+                user_id=seed_user.id,
+                project_id=project.id,
+                skill_key=skill_key,
+                name=skill_key,
+                description="Removed when its Project is archived",
+                version=1,
+                content_hash="a" * 64,
+                authority=SKILL_AUTHORITY_CLOUD,
+            ),
+            AgentProjectBinding(
+                agent_id=env.id,
+                project_id=project.id,
+                binding_type="context",
+                priority=1,
+                default_write_enabled=False,
+                created_by_user_id=seed_user.id,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    api_key = ApiKey(user_id=seed_user.id, label="archive-project-runtime")
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        initial = await client.get(
+            "/v1/runtime/manifest",
+            params={"environment_id": str(env.id)},
+        )
+        archived = await client.delete(f"/v1/projects/{project.id}")
+        delivered = await client.get(
+            "/v1/runtime/manifest",
+            params={"environment_id": str(env.id)},
+            headers={"If-None-Match": initial.headers["etag"]},
+        )
+    app.dependency_overrides.clear()
+
+    assert initial.status_code == 200, initial.text
+    assert skill_key in initial.json()["manifest"]["skills"]["entries"]
+    assert archived.status_code == 200, archived.text
+    assert delivered.status_code == 200, delivered.text
+    assert delivered.headers["etag"] != initial.headers["etag"]
+    assert "skills" not in delivered.json()["manifest"]
+
+
+@pytest.mark.asyncio
+async def test_owner_cleanup_revalidates_member_manifest_without_project_skill(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"owner-cleanup-runtime-{uuid4().hex[:8]}",
+        machine_name="Owner cleanup runtime",
+        agent_type="openclaw",
+    )
+    await _write_runtime_state(admin_client, str(env.id))
+    now = datetime.now(UTC)
+    nonce = uuid4().hex
+    owner = User(
+        clerk_id=f"runtime-deleted-owner-{nonce}",
+        clerk_issuer="https://runtime-manifest.clerk.example.test",
+        email=f"runtime-deleted-owner-{nonce}@test.dev",
+        name="Runtime deleted owner",
+    )
+    db_session.add(owner)
+    await db_session.flush()
+    project = Project(
+        user_id=owner.id,
+        name="Deleted owner Project",
+        slug=f"deleted-owner-runtime-{nonce[:8]}",
+        kind=PROJECT_KIND_WORKSPACE,
+    )
+    db_session.add(project)
+    await db_session.flush()
+    skill_key = "deleted-owner-skill"
+    lifecycle = PrincipalLifecycle(
+        issuer=owner.clerk_issuer,
+        subject=owner.clerk_id,
+        user_id=owner.id,
+        terminated_at=now,
+        next_cleanup_attempt_at=now,
+    )
+    db_session.add_all(
+        [
+            lifecycle,
+            ProjectMembership(
+                project_id=project.id,
+                member_user_id=seed_user.id,
+                role="viewer",
+                joined_via="invite",
+                joined_at=now,
+                resolved_owner_handle="runtime-deleted-owner",
+            ),
+            Skill(
+                user_id=owner.id,
+                project_id=project.id,
+                skill_key=skill_key,
+                name=skill_key,
+                description="Removed when its owner is deleted",
+                version=1,
+                content_hash="b" * 64,
+                authority=SKILL_AUTHORITY_CLOUD,
+            ),
+            AgentProjectBinding(
+                agent_id=env.id,
+                project_id=project.id,
+                binding_type="context",
+                priority=1,
+                default_write_enabled=False,
+                created_by_user_id=seed_user.id,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    api_key = ApiKey(user_id=seed_user.id, label="owner-cleanup-runtime")
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        initial = await client.get(
+            "/v1/runtime/manifest",
+            params={"environment_id": str(env.id)},
+        )
+        await complete_principal_cleanup(db_session, lifecycle_id=lifecycle.id, now=now)
+        await db_session.commit()
+        delivered = await client.get(
+            "/v1/runtime/manifest",
+            params={"environment_id": str(env.id)},
+            headers={"If-None-Match": initial.headers["etag"]},
+        )
+    app.dependency_overrides.clear()
+
+    assert initial.status_code == 200, initial.text
+    assert skill_key in initial.json()["manifest"]["skills"]["entries"]
+    assert delivered.status_code == 200, delivered.text
+    assert delivered.headers["etag"] != initial.headers["etag"]
+    assert "skills" not in delivered.json()["manifest"]
+
+
+@pytest.mark.asyncio
+async def test_reactivating_agent_refreshes_changes_made_while_archived(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env, provider, _, _, _ = await _create_bundle_runtime(admin_client, db_session, seed_user)
+    api_key = ApiKey(user_id=seed_user.id, label="reactivation-runtime")
+
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        initial = await client.get(
+            "/v1/runtime/manifest",
+            params={"environment_id": str(env.id)},
+        )
+        await archive_agent_and_project(db_session, agent=env)
+        await db_session.commit()
+        provider.base_url = "https://reactivated-provider.test/v1"
+        await sync_events.queue_provider_runtime_manifest_changed(
+            db_session,
+            seed_user.id,
+            provider.provider_id,
+        )
+        await db_session.commit()
+        await reactivate_agent_and_project(db_session, agent=env)
+        await db_session.commit()
+        delivered = await client.get(
+            "/v1/runtime/manifest",
+            params={"environment_id": str(env.id)},
+            headers={"If-None-Match": initial.headers["etag"]},
+        )
+    app.dependency_overrides.clear()
+
+    assert initial.status_code == 200, initial.text
+    assert delivered.status_code == 200, delivered.text
+    assert delivered.headers["etag"] != initial.headers["etag"]
+    assert delivered.json()["manifest"]["providers"]["clawdi"]["baseUrl"] == (
+        "https://reactivated-provider.test/v1"
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -39,7 +39,11 @@ from app.models.channel import (
     ChannelBotAgentLink,
     ChannelWhatsAppAuthCert,
 )
-from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
+from app.models.hosted_runtime import (
+    HostedRuntimeConfigObservation,
+    HostedRuntimeSecret,
+    HostedRuntimeState,
+)
 from app.models.project import PROJECT_KIND_WORKSPACE, Project
 from app.models.runtime_observation import V2RuntimeEnvironmentFence
 from app.models.session import AgentEnvironment
@@ -65,12 +69,17 @@ from app.services.audit import _sanitize_audit_details
 from app.services.channels import channel_runtime_account_key, channel_runtime_placeholder_token
 from app.services.managed_ai_provider import CLAWDI_MANAGED_PROVIDER_ID
 from app.services.runtime_source import (
+    RUNTIME_AGENT_PLUGIN_GITHUB_RELEASE_SOURCE_CAPABILITY,
     RUNTIME_AGENT_PLUGINS_MANIFEST_CAPABILITY,
     RUNTIME_BUNDLE_V2_MEDIA_TYPE,
     RUNTIME_CAPABILITIES_HEADER,
     expected_runtime_bundle_v2_etag,
+    load_runtime_source_batch,
+    render_runtime_source,
     runtime_manifest_issued_at,
+    vault_key_identity,
 )
+from app.services.runtime_source_revision import refresh_runtime_source_revisions
 from app.services.vault_crypto import decrypt, encrypt
 from scripts.seed_dashboard_dev import (
     _create_hosted_runtime_graph,
@@ -2678,6 +2687,11 @@ async def test_runtime_manifest_provider_label_is_not_projected_but_projected_fi
     assert label_only.headers["etag"] == initial_etag
 
     provider.base_url = "https://provider-b.test/v1"
+    await sync_events.queue_provider_runtime_manifest_changed(
+        db_session,
+        seed_user.id,
+        provider.provider_id,
+    )
     await db_session.commit()
     async with await _runtime_client(db_session, seed_user, api_key) as client:
         projected_change = await client.get(
@@ -4129,12 +4143,28 @@ async def test_runtime_manifest_conditional_render_skips_secrets_and_bundle(
         monkeypatch.setattr(runtime_routes, "render_runtime_source", tracked_render_source)
         monkeypatch.setattr(runtime_routes, "render_runtime_bundle", tracked_render_bundle)
 
-        not_modified = await client.get(
-            "/v1/runtime/manifest",
-            headers={"If-None-Match": initial.headers["etag"]},
-        )
+        source_selects = 0
+
+        def count_source_selects(_connection, _cursor, statement, _params, _context, _many):
+            nonlocal source_selects
+            if statement.lstrip().upper().startswith("SELECT"):
+                source_selects += 1
+
+        event.listen(runtime_engine.sync_engine, "before_cursor_execute", count_source_selects)
+        try:
+            not_modified = await client.get(
+                "/v1/runtime/manifest",
+                headers={"If-None-Match": initial.headers["etag"]},
+            )
+        finally:
+            event.remove(
+                runtime_engine.sync_engine,
+                "before_cursor_execute",
+                count_source_selects,
+            )
         assert not_modified.status_code == 304, not_modified.text
-        assert render_calls == [(False, initial.json()["sourceRevision"])]
+        assert source_selects == 1
+        assert render_calls == []
         assert bundle_calls == []
 
         render_calls.clear()
@@ -4145,9 +4175,174 @@ async def test_runtime_manifest_conditional_render_skips_secrets_and_bundle(
     assert refreshed.json() == initial.json()
     assert render_calls == [
         (False, initial.json()["sourceRevision"]),
+        (False, initial.json()["sourceRevision"]),
         (True, initial.json()["sourceRevision"]),
     ]
     assert bundle_calls == [initial.json()["sourceRevision"]]
+
+
+@pytest.mark.asyncio
+async def test_runtime_state_write_persists_revision_before_next_manifest(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env, _, _, _, _ = await _create_bundle_runtime(admin_client, db_session, seed_user)
+    environment_id = env.id
+    capabilities = {
+        RUNTIME_CAPABILITIES_HEADER: ", ".join(
+            (
+                RUNTIME_AGENT_PLUGINS_MANIFEST_CAPABILITY,
+                RUNTIME_AGENT_PLUGIN_GITHUB_RELEASE_SOURCE_CAPABILITY,
+            )
+        )
+    }
+    api_key = ApiKey(user_id=seed_user.id, environment_id=environment_id, label="revision-write")
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        initial = await client.get("/v1/runtime/manifest", headers=capabilities)
+    app.dependency_overrides.clear()
+    assert initial.status_code == 200, initial.text
+
+    state = await db_session.get(HostedRuntimeState, environment_id)
+    assert state is not None
+    previous_revision = state.source_revision
+    body = _runtime_state_body(
+        str(environment_id),
+        deployment_id=state.deployment_id,
+        instance_id=state.instance_id,
+        generation=state.generation + 1,
+        runtimes=state.runtimes,
+    )
+    updated = await admin_client.put(
+        f"/v1/admin/environments/{environment_id}/runtime-state",
+        headers=_AUTH,
+        json=body,
+    )
+    assert updated.status_code == 200, updated.text
+    await db_session.refresh(state)
+    assert state.source_revision is not None
+    assert state.source_revision != previous_revision
+
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        delivered = await client.get(
+            "/v1/runtime/manifest",
+            headers={**capabilities, "If-None-Match": initial.headers["etag"]},
+        )
+    app.dependency_overrides.clear()
+    assert delivered.status_code == 200, delivered.text
+    assert delivered.json()["sourceRevision"] == state.source_revision
+
+
+@pytest.mark.asyncio
+async def test_concurrent_source_refresh_persists_complete_revision(
+    admin_client,
+    db_session,
+    engine,
+    seed_user,
+):
+    env, _, _, _, _ = await _create_bundle_runtime(admin_client, db_session, seed_user)
+    environment_id = env.id
+    first = HostedRuntimeSecret(
+        environment_id=environment_id,
+        secret_ref="secret://runtime/concurrent-first",
+        encrypted_value=b"first-v1",
+        nonce=b"first-nonce",
+    )
+    second = HostedRuntimeSecret(
+        environment_id=environment_id,
+        secret_ref="secret://runtime/concurrent-second",
+        encrypted_value=b"second-v1",
+        nonce=b"second-nonce",
+    )
+    db_session.add_all([first, second])
+    await db_session.flush()
+    await refresh_runtime_source_revisions(db_session, [environment_id])
+    await db_session.commit()
+
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    async with sessionmaker() as first_db, sessionmaker() as second_db:
+        first_row = await first_db.get(HostedRuntimeSecret, first.id)
+        second_row = await second_db.get(HostedRuntimeSecret, second.id)
+        assert first_row is not None
+        assert second_row is not None
+        first_row.encrypted_value = b"first-v2"
+        second_row.encrypted_value = b"second-v2"
+        await first_db.flush()
+        await first_db.execute(
+            select(HostedRuntimeState.environment_id)
+            .where(HostedRuntimeState.environment_id == environment_id)
+            .with_for_update()
+        )
+        await second_db.flush()
+
+        second_refresh = asyncio.create_task(
+            refresh_runtime_source_revisions(second_db, [environment_id])
+        )
+        try:
+            await asyncio.sleep(0.05)
+            assert not second_refresh.done()
+            await refresh_runtime_source_revisions(first_db, [environment_id])
+            await first_db.commit()
+            await second_refresh
+            await second_db.commit()
+        finally:
+            if not second_refresh.done():
+                second_refresh.cancel()
+                await asyncio.gather(second_refresh, return_exceptions=True)
+
+    async with sessionmaker() as verify_db:
+        batch = await load_runtime_source_batch(
+            verify_db,
+            environment_ids=[environment_id],
+            owner_user_id=seed_user.id,
+        )
+        rendered = render_runtime_source(
+            batch,
+            environment_id=environment_id,
+            public_api_url=settings.public_api_url,
+            vault_key_identity=vault_key_identity(settings.vault_encryption_key),
+            decrypt_secrets=False,
+        )
+        state = await verify_db.get(HostedRuntimeState, environment_id)
+        assert state is not None
+        assert state.source_revision == rendered.source_revision
+
+
+@pytest.mark.asyncio
+async def test_runtime_manifest_repairs_stale_persisted_revision(
+    admin_client,
+    db_session,
+    seed_user,
+    caplog: pytest.LogCaptureFixture,
+):
+    env, _, _, _, _ = await _create_bundle_runtime(admin_client, db_session, seed_user)
+    environment_id = env.id
+    state = await db_session.get(HostedRuntimeState, environment_id)
+    assert state is not None
+    state.source_revision = "f" * 64
+    await db_session.commit()
+
+    capabilities = {
+        RUNTIME_CAPABILITIES_HEADER: ", ".join(
+            (
+                RUNTIME_AGENT_PLUGINS_MANIFEST_CAPABILITY,
+                RUNTIME_AGENT_PLUGIN_GITHUB_RELEASE_SOURCE_CAPABILITY,
+            )
+        )
+    }
+    caplog.set_level("WARNING", logger="app.services.runtime_source_revision")
+    api_key = ApiKey(user_id=seed_user.id, environment_id=environment_id, label="revision-repair")
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        response = await client.get("/v1/runtime/manifest", headers=capabilities)
+    app.dependency_overrides.clear()
+    assert response.status_code == 200, response.text
+
+    db_session.expire_all()
+    repaired = await db_session.get(HostedRuntimeState, environment_id)
+    assert repaired is not None
+    assert repaired.source_revision == response.json()["sourceRevision"]
+    assert repaired.source_revision != "f" * 64
+    assert "repaired stale runtime source revision" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -4277,6 +4472,11 @@ async def test_runtime_bundle_emits_explicit_apply_generation_and_revalidates_ap
         initial = await client.get("/v1/runtime/manifest")
         initial_body = initial.json()
         state.apply_generation = 3
+        await sync_events.queue_runtime_manifest_changed(
+            db_session,
+            seed_user.id,
+            env.id,
+        )
         await db_session.commit()
         advanced = await client.get(
             "/v1/runtime/manifest",
@@ -5111,6 +5311,11 @@ async def test_runtime_manifest_projects_provider_secret_values_for_managed_acco
             AiProviderAuthPayload.provider_id == CANONICAL_CODEX_TOOL_PROVIDER_ID,
         )
         .values(encrypted_payload=ciphertext, nonce=nonce)
+    )
+    await sync_events.queue_provider_runtime_manifest_changed(
+        db_session,
+        seed_user.id,
+        CANONICAL_CODEX_TOOL_PROVIDER_ID,
     )
     await db_session.commit()
 

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -30,6 +30,7 @@ from app.services.managed_ai_provider import (
     V2_MANAGED_AI_PROVIDER_ID,
 )
 from app.services.runtime_source import (
+    RUNTIME_SOURCE_RENDERER_REVISION,
     RuntimeSourceBatch,
     RuntimeSourceError,
     RuntimeSourceRow,
@@ -1262,4 +1263,18 @@ def test_runtime_bundle_matches_shared_golden(monkeypatch) -> None:
         decrypt_secrets=True,
     )
     fixture_path = Path(__file__).parents[2] / "test-fixtures/runtime-bundle-v2.golden.json"
-    assert render_runtime_bundle(source) == json.loads(fixture_path.read_text())
+    golden = json.loads(fixture_path.read_text())
+    expected_revision = "81572b32d67e9f7386e58ea17899c71cf0864b85d874dcd9ccb76fa8a4f90a78"
+    assert (
+        RUNTIME_SOURCE_RENDERER_REVISION,
+        source.source_revision,
+        golden["sourceRevision"],
+    ) == (
+        "runtime-source.v1",
+        expected_revision,
+        expected_revision,
+    ), (
+        "Renderer output changed: bump RUNTIME_SOURCE_RENDERER_REVISION and update "
+        "the golden source revision"
+    )
+    assert render_runtime_bundle(source) == golden

--- a/backend/tests/test_runtime_source_revision_authority.py
+++ b/backend/tests/test_runtime_source_revision_authority.py
@@ -216,12 +216,17 @@ MUTATION_AUTHORITIES = (
     (
         "app/routes/projects.py",
         "archive_project",
-        "queue_project_runtime_manifest_changed",
+        "queue_runtime_manifests_changed",
     ),
     (
         "app/services/principal_lifecycle.py",
         "complete_principal_cleanup",
-        "queue_project_runtime_manifest_changed",
+        "queue_runtime_manifests_changed",
+    ),
+    (
+        "app/services/agent_lifecycle.py",
+        "reactivate_agent_and_project",
+        "queue_environment_runtime_manifest_changed",
     ),
     ("app/routes/skills.py", "refresh_project_skill", "bump_skills_revision"),
     ("app/routes/skills.py", "_do_upload_skill", "bump_skills_revision"),

--- a/backend/tests/test_runtime_source_revision_authority.py
+++ b/backend/tests/test_runtime_source_revision_authority.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).parents[1]
+
+# Every renderer-input mutation family terminates at one of these functions.
+# Adding a new write path requires extending this reviewed inventory.
+MUTATION_AUTHORITIES = (
+    (
+        "app/services/sync_events.py",
+        "queue_runtime_manifests_changed",
+        "refresh_runtime_source_revisions",
+    ),
+    (
+        "app/services/sync_events.py",
+        "queue_runtime_manifest_changed",
+        "queue_runtime_manifests_changed",
+    ),
+    (
+        "app/services/sync_events.py",
+        "queue_environment_runtime_manifest_changed",
+        "queue_runtime_manifest_changed",
+    ),
+    (
+        "app/services/sync_events.py",
+        "queue_provider_runtime_manifest_changed",
+        "queue_runtime_manifests_changed",
+    ),
+    (
+        "app/services/ai_provider_auth_transition.py",
+        "queue_provider_runtime_manifest_changed",
+        "queue_manifest_change",
+    ),
+    (
+        "app/services/ai_provider_auth_transition.py",
+        "transition_ai_provider_auth",
+        "queue_provider_runtime_manifest_changed",
+    ),
+    (
+        "app/services/project_runtime_skills.py",
+        "queue_project_runtime_manifest_changed",
+        "queue_runtime_manifests_changed",
+    ),
+    (
+        "app/services/sync_events.py",
+        "bump_skills_revision",
+        "queue_project_runtime_manifest_changed",
+    ),
+    ("app/routes/platform.py", "platform_upsert_runtime_state", "queue_runtime_manifest_changed"),
+    ("app/routes/platform.py", "platform_delete_runtime_state", "queue_runtime_manifest_changed"),
+    (
+        "app/routes/platform.py",
+        "platform_delete_agent",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    ("app/routes/admin.py", "_admin_upsert_runtime_state", "queue_runtime_manifest_changed"),
+    ("app/routes/admin.py", "_admin_delete_runtime_state", "queue_runtime_manifest_changed"),
+    (
+        "app/routes/admin.py",
+        "_admin_delete_environment",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/sessions.py",
+        "_delete_agent_identity",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/runtime.py",
+        "get_runtime_manifest",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/plugin_catalog.py",
+        "put_agent_plugin_desired_state",
+        "queue_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/plugin_catalog.py",
+        "delete_agent_plugin_desired_state",
+        "queue_runtime_manifest_changed",
+    ),
+    (
+        "app/services/ai_provider_auth_transition.py",
+        "transition_ai_provider_auth",
+        "queue_provider_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/ai_providers.py",
+        "upsert_ai_provider",
+        "queue_provider_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/ai_providers.py",
+        "patch_ai_provider",
+        "queue_provider_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/ai_providers.py",
+        "_accept_ai_provider",
+        "queue_provider_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/ai_providers.py",
+        "resolve_ai_provider_auth",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/admin.py",
+        "admin_upsert_clawdi_managed_ai_provider",
+        "queue_provider_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/admin.py",
+        "admin_replace_deployment_managed_ai_provider_metadata",
+        "queue_provider_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/admin.py",
+        "admin_cleanup_deployment_managed_ai_provider",
+        "queue_provider_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/admin.py",
+        "admin_delete_clawdi_managed_ai_provider",
+        "queue_provider_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/channel_routers/public.py",
+        "_queue_agent_link_runtime_changed",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    ("app/routes/channel_routers/public.py", "create_channel", "_queue_agent_link_runtime_changed"),
+    ("app/routes/channel_routers/public.py", "delete_channel", "_queue_agent_link_runtime_changed"),
+    (
+        "app/routes/channel_routers/public.py",
+        "create_channel_pair_code",
+        "_queue_agent_link_runtime_changed",
+    ),
+    (
+        "app/routes/channel_routers/public.py",
+        "create_channel_agent_link",
+        "_queue_agent_link_runtime_changed",
+    ),
+    (
+        "app/routes/channel_routers/public.py",
+        "rotate_channel_agent_link_token",
+        "_queue_agent_link_runtime_changed",
+    ),
+    (
+        "app/routes/channel_routers/public.py",
+        "delete_channel_agent_link",
+        "_queue_agent_link_runtime_changed",
+    ),
+    ("app/routes/admin.py", "admin_delete_channel", "queue_environment_runtime_manifest_changed"),
+    ("app/routes/admin.py", "admin_update_channel", "queue_runtime_manifests_changed"),
+    (
+        "app/routes/channel_routers/whatsapp.py",
+        "_run_whatsapp_baileys_websocket",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/channel_routers/whatsapp.py",
+        "_resolve_whatsapp_noise_lid",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    (
+        "app/services/agent_bindings.py",
+        "delete_project_bindings_for_users",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    (
+        "app/services/agent_bindings.py",
+        "attach_project_to_owned_agents",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    (
+        "app/services/agent_bindings.py",
+        "attach_projects_to_owned_agent",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    (
+        "app/services/agent_bindings.py",
+        "update_owned_agent_project_links",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    (
+        "app/services/agent_bindings.py",
+        "update_project_owned_agent_links",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/agent_project_bindings.py",
+        "list_project_bindings",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/agent_project_bindings.py",
+        "add_context_project_binding",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/agent_project_bindings.py",
+        "reorder_context_project_bindings",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/agent_project_bindings.py",
+        "delete_project_binding",
+        "queue_environment_runtime_manifest_changed",
+    ),
+    (
+        "app/routes/projects.py",
+        "archive_project",
+        "queue_project_runtime_manifest_changed",
+    ),
+    (
+        "app/services/principal_lifecycle.py",
+        "complete_principal_cleanup",
+        "queue_project_runtime_manifest_changed",
+    ),
+    ("app/routes/skills.py", "refresh_project_skill", "bump_skills_revision"),
+    ("app/routes/skills.py", "_do_upload_skill", "bump_skills_revision"),
+    ("app/routes/skills.py", "_do_delete_agent_synced_skill", "bump_skills_revision"),
+    ("app/routes/skills.py", "_do_delete_skill", "bump_skills_revision"),
+    ("app/routes/skills.py", "_upsert_skill", "bump_skills_revision"),
+    (
+        "app/services/agent_skill_projection.py",
+        "delete_agent_project_skill_rows",
+        "bump_skills_revision",
+    ),
+)
+
+
+def _awaited_calls(path: str, function_name: str) -> set[str]:
+    tree = ast.parse((BACKEND_ROOT / path).read_text())
+    function = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == function_name
+    )
+    calls: set[str] = set()
+    for awaited in (node for node in ast.walk(function) if isinstance(node, ast.Await)):
+        for call in (node for node in ast.walk(awaited.value) if isinstance(node, ast.Call)):
+            if isinstance(call.func, ast.Name):
+                calls.add(call.func.id)
+            elif isinstance(call.func, ast.Attribute):
+                calls.add(call.func.attr)
+    return calls
+
+
+@pytest.mark.parametrize(
+    ("path", "function_name", "authority"),
+    MUTATION_AUTHORITIES,
+)
+def test_runtime_source_mutations_await_revision_authority(
+    path: str,
+    function_name: str,
+    authority: str,
+) -> None:
+    assert authority in _awaited_calls(path, function_name)

--- a/backend/tests/test_sync_events.py
+++ b/backend/tests/test_sync_events.py
@@ -550,7 +550,7 @@ async def test_runtime_manifest_event_delivers_after_commit_not_rollback(
     )
     try:
         await db_session.execute(select(User.id).where(User.id == user_id))
-        sync_events.queue_runtime_manifest_changed(db_session, user_id, environment_id)
+        await sync_events.queue_runtime_manifest_changed(db_session, user_id, environment_id)
         assert queue.empty()
         await db_session.commit()
         assert queue.get_nowait() == {
@@ -559,7 +559,7 @@ async def test_runtime_manifest_event_delivers_after_commit_not_rollback(
         }
 
         await db_session.execute(select(User.id).where(User.id == user_id))
-        sync_events.queue_runtime_manifest_changed(db_session, user_id, environment_id)
+        await sync_events.queue_runtime_manifest_changed(db_session, user_id, environment_id)
         assert queue.empty()
         await db_session.rollback()
         assert queue.empty()

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -36,6 +36,7 @@ from app.models.user import User
 from app.routes import sessions as session_routes
 from app.schemas.session import RuntimeObservedResponse
 from app.services.runtime_source import expected_runtime_bundle_v2_etag
+from app.services.runtime_source_revision import refresh_runtime_source_revisions
 from tests.conftest import create_env_with_project
 from tests.hosted_runtime_fixtures import (
     CANONICAL_CODEX_TOOLS,
@@ -134,6 +135,18 @@ async def _create_env(client: httpx.AsyncClient) -> str:
     r = await client.post("/v1/environments", json=body)
     assert r.status_code == 200, r.text
     return r.json()["id"]
+
+
+async def _persist_runtime_source_revision(
+    db_session: AsyncSession,
+    environment_id: str,
+) -> str:
+    parsed_id = uuid.UUID(environment_id)
+    revisions = await refresh_runtime_source_revisions(db_session, [parsed_id])
+    await db_session.commit()
+    revision = revisions[parsed_id]
+    assert revision is not None
+    return revision
 
 
 @pytest.mark.asyncio
@@ -564,6 +577,7 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
     )
     db_session.add(state)
     await db_session.commit()
+    await _persist_runtime_source_revision(db_session, env_id)
 
     desired_source_revision = (
         await client.get(f"/v1/environments/{env_id}/runtime-observed")
@@ -841,6 +855,7 @@ async def test_runtime_health_fences_stale_instance_source_and_freshness(
     )
     db_session.add(state)
     await db_session.commit()
+    await _persist_runtime_source_revision(db_session, env_id)
     desired_source_revision = (await client.get(f"/v1/agents/{env_id}/runtime-observed")).json()[
         "desired"
     ]["desired_source_revision"]
@@ -1003,6 +1018,7 @@ async def test_v2_applied_authority_persists_and_drives_health(
         )
     )
     await db_session.commit()
+    await _persist_runtime_source_revision(db_session, env_id)
     desired = (await client.get(f"/v1/environments/{env_id}/runtime-observed")).json()["desired"]
     source_revision = desired["desired_source_revision"]
 
@@ -1107,6 +1123,7 @@ async def test_v2_health_requires_expected_etag_and_exact_source_provider_set(
         )
     )
     await db_session.commit()
+    await _persist_runtime_source_revision(db_session, env_id)
     desired = (await client.get(f"/v1/environments/{env_id}/runtime-observed")).json()["desired"]
     source_revision = desired["desired_source_revision"]
 
@@ -1611,6 +1628,11 @@ async def test_runtime_observed_summary_has_bounded_queries_without_secret_decry
                 runtimes=_test_runtimes(),
             ),
         ]
+    )
+    await db_session.commit()
+    await refresh_runtime_source_revisions(
+        db_session,
+        [uuid.UUID(ok_env_id), uuid.UUID(error_env_id)],
     )
     await db_session.commit()
     ok_observed = _runtime_observed(applied_generation=1)

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -36,7 +36,10 @@ from app.models.user import User
 from app.routes import sessions as session_routes
 from app.schemas.session import RuntimeObservedResponse
 from app.services.runtime_source import expected_runtime_bundle_v2_etag
-from app.services.runtime_source_revision import refresh_runtime_source_revisions
+from app.services.runtime_source_revision import (
+    refresh_runtime_source_revisions,
+    runtime_source_contract_revision,
+)
 from tests.conftest import create_env_with_project
 from tests.hosted_runtime_fixtures import (
     CANONICAL_CODEX_TOOLS,
@@ -833,6 +836,54 @@ async def test_mcp_inventory_exposes_only_proven_user_declarations(
     malformed = await client.get(f"/v1/agents/{env_id}/mcp")
     assert malformed.status_code == 503, malformed.text
     assert malformed.json() == {"detail": "Managed MCP inventory is temporarily unavailable."}
+
+
+@pytest.mark.asyncio
+async def test_runtime_observed_treats_unbackfilled_revision_as_pending(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+):
+    env_id = await _create_env(client)
+    state = canonical_hosted_runtime_state(
+        environment_id=uuid.UUID(env_id),
+        deployment_id="dep-revision-pending",
+        instance_id="iid-revision-pending",
+        generation=4,
+        cli_package_spec=_TEST_CLI_PACKAGE_SPEC,
+        locale=_TEST_LOCALE,
+        system=_TEST_SYSTEM,
+        live_sync={"enabled": False, "agents": []},
+        recovery={"cacheManifest": True, "allowOfflineBoot": True},
+        runtimes=_test_runtimes(),
+    )
+    db_session.add(state)
+    await db_session.commit()
+    heartbeat = await client.post(
+        f"/v1/agents/{env_id}/sync-heartbeat",
+        json={
+            "runtime_observed": _runtime_observed(
+                applied_generation=4,
+                applied_instance_id="iid-revision-pending",
+            )
+        },
+    )
+    assert heartbeat.status_code == 204, heartbeat.text
+
+    detail = (await client.get(f"/v1/agents/{env_id}/runtime-observed")).json()
+    summary = (await client.get("/v1/agents/runtime-observed")).json()
+    summary_item = next(item for item in summary["items"] if item["environment"]["id"] == env_id)
+    for payload in (detail, summary_item):
+        assert payload["desired"]["desired_source_revision"] is None
+        assert payload["health"]["status"] == "unknown"
+        assert "desired_source_revision_missing" in payload["health"]["reasons"]
+        assert "desired_source_invalid" not in payload["health"]["reasons"]
+        assert "desired_cli_version_invalid" not in payload["health"]["reasons"]
+
+    state.source_revision_contract = runtime_source_contract_revision()
+    await db_session.commit()
+    failed = (await client.get(f"/v1/agents/{env_id}/runtime-observed")).json()
+    assert "desired_source_invalid" in failed["health"]["reasons"]
+    assert "desired_source_revision_missing" not in failed["health"]["reasons"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_whatsapp_noise.py
+++ b/backend/tests/test_whatsapp_noise.py
@@ -193,6 +193,8 @@ async def test_whatsapp_noise_prefers_current_account_identity(
         db_session,
         account=account,
         credential=stored.credential,
+        user_id=channel_agent.user_id,
+        environment_id=channel_agent.id,
     )
 
     assert lid == "900000000000002:1@lid"

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -50,7 +50,7 @@ const goldenPath = resolve(
 	"../../../../test-fixtures/runtime-bundle-v2.golden.json",
 );
 const EXPECTED_GOLDEN_SOURCE_REVISION =
-	"ded7e0de9c12e7386940243ff8f7e4a5f3e37e3d2a1b91a6626724ffe618a4ce";
+	"81572b32d67e9f7386e58ea17899c71cf0864b85d874dcd9ccb76fa8a4f90a78";
 const originalEnv = { ...process.env };
 const originalFetch = globalThis.fetch;
 const roots: string[] = [];

--- a/test-fixtures/runtime-bundle-v2.golden.json
+++ b/test-fixtures/runtime-bundle-v2.golden.json
@@ -133,5 +133,5 @@
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/agent-token": "123456789:telegram-agent-golden",
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/placeholder-token": "999999999:9ded1453047ec0a48ec3b735075f7448"
 	},
-	"sourceRevision": "ded7e0de9c12e7386940243ff8f7e4a5f3e37e3d2a1b91a6626724ffe618a4ce"
+	"sourceRevision": "81572b32d67e9f7386e58ea17899c71cf0864b85d874dcd9ccb76fa8a4f90a78"
 }


### PR DESCRIPTION
## Summary

Persist each hosted Agent's canonical desired-state `source_revision` on writes, then use it as the O(1) authority for six polling surfaces:

1. `GET /runtime/manifest`
2. `GET /channels/agent-links`
3. `GET /channels/{account_id}/agent-links`
4. Channel health
5. `GET /agents/{id}/runtime-observed`
6. Environment-list runtime-observed summaries

A matching manifest `If-None-Match` now returns 304 from one narrow SELECT. Cache misses still perform the complete batch load and render, then CAS-repair NULL or stale persisted authority.

## Production impact

Production measurements attribute most of a cloud-api process's current `0.73 CPU core` usage to repeated runtime-source rendering for box and web polling. At 9k boxes, the unchanged-state path extrapolates to about `4,800 queries/s` solely to answer "not modified". This moves the eight-query batch load, manifest projection, canonical JSON, and SHA-256 work to mutations and cache misses.

## Correctness

- Serialize revision refreshes per Agent with hosted runtime state row locks in stable ID order.
- Keep revision-only writes from changing `updated_at`, because runtime `issuedAt` is renderer input.
- On every manifest full-render path, compute canonical non-secret output and CAS-repair NULL, stale, contract-mismatched, or failed authority.
- Clear a previously persisted revision when canonical rendering fails, preventing obsolete ETags from remaining authoritative.
- Distinguish legacy/unbackfilled revision state from a proven render failure: NULL with a missing/old contract is pending; NULL with the current contract is an error.
- Preserve capability-specific legacy representations. Agent Plugin projections that differ from canonical output still fall back to full rendering.

## Review follow-ups

- Project archive captures active Agent targets before unlinking, performs binding deletion/archive first, then refreshes the captured targets. An old-ETag behavior test proves the next poll is 200 and the archived Project Skill is absent.
- Principal cleanup captures surviving member Agents before removing an owner's Project bindings, then refreshes once after deletion. A shared-Project behavior test proves the deleted owner's Skill is removed on the next poll.
- Agent reactivation refreshes revision authority after restoring the Agent and its exclusive Project. A behavior test covers archive, provider change while archived, reactivation, and old-ETag 200 delivery.
- `RUNTIME_SOURCE_RENDERER_REVISION` now documents the fleet invalidation protocol and expected naturally staggered one-render-per-Agent cost. The shared golden test pins both renderer revision and source revision with an actionable failure message.
- Runtime-observed endpoints present unbackfilled NULL revisions as pending/unknown without live rendering, while retaining current-contract NULL as `desired_source_invalid`.

## Renderer contract

`runtime-source.v1` is included in the canonical revision descriptor. The persisted contract digest also covers the renderer revision, normalized public API URL, and vault-key identity, so renderer/config deployments invalidate old persisted revisions without an environment flag. Any emitted desired-state change must bump the renderer revision and update the golden source revision.

## Mutation completeness

The revision refresh authority is wired into and AST-guarded for:

- Hosted runtime state and encrypted runtime secrets
- AI Provider metadata, auth payload transitions, credential rotation/archive, OAuth acceptance, and OAuth consumer claims
- Channel account status/archive, Link create/archive/token rotation, pairing material, admin channel status bypasses, WhatsApp synthetic credential/self-identity repair, and auth certificate creation
- Agent/Project context binding add/remove/reorder, Project archive, principal cleanup, and Agent reactivation
- Project Skill create/update/delete/projection paths
- Agent Plugin install/update/delete desired state
- Manifest repair paths that create WhatsApp material

Runtime observations and presentation-only fields remain excluded because they do not affect rendered desired state.

## Migration

- Add nullable `hosted_runtime_states.source_revision` and `source_revision_contract` columns.
- Do not backfill during migration; the first manifest full render or desired-state mutation fills legacy NULL rows.
- Downgrade cleanly drops both columns.

## Verification

- `406 passed`: runtime manifest/source, revision authority, runtime-observed, Projects, principal cleanup, and Agent reactivation related suites on a fresh migrated PostgreSQL
- `61 passed`: focused review regressions plus the complete AST mutation authority matrix
- `2 passed`: admin channel revision fan-out and v1 runtime-observation byte-freeze governance
- Earlier branch verification: full channels `414 passed`; provider/admin/platform/plugin/Project `296 passed`; WhatsApp noise `28 passed`; CLI `1,646 pass`, `4 skip`
- BasedPyright owned gate: `197 files`, `0 errors`; v1 byte-freeze updated only for the two approved runtime-observed endpoint changes
- Ruff check/format, Python compileall, and `git diff --check`
- Alembic fresh-database upgrade; existing migration downgrade/re-upgrade verification remains unchanged
- Manifest 304 assertion: one SELECT and zero renderer/bundle calls
