### PR TITLE
perf(backend): make SSE auth refreshes event-driven

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -216,6 +216,7 @@ from app.services.runtime_source import RuntimeSourceError, RuntimeSourceNotFoun
 from app.services.runtime_source_authority import load_runtime_source_authority
 from app.services.runtime_state_cleanup import lock_runtime_state_write_fence
 from app.services.sync_events import (
+    notify_sync_subscriptions_changed,
     queue_environment_runtime_manifest_changed,
     queue_provider_runtime_manifest_changed,
     queue_runtime_manifest_changed,
@@ -983,6 +984,7 @@ async def admin_revoke_api_key(
         return ApiKeyRevokeResponse(status="revoked")
 
     api_key.revoked_at = datetime.now(UTC)
+    await notify_sync_subscriptions_changed(db, [api_key.user_id])
     record_control_plane_audit(
         db,
         actor_type="admin",

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -17,6 +17,7 @@ from app.schemas.api_key import (
 from app.schemas.problem import AccountSuspendedProblem
 from app.schemas.user import CurrentUserResponse
 from app.services.api_key import mint_api_key
+from app.services.sync_events import notify_sync_subscriptions_changed
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -136,6 +137,7 @@ async def revoke_api_key(
         raise HTTPException(status.HTTP_403_FORBIDDEN, "Managed API keys cannot be revoked here")
 
     api_key.revoked_at = datetime.now(UTC)
+    await notify_sync_subscriptions_changed(db, [api_key.user_id])
     await db.commit()
     invalidate_api_key_auth_cache(api_key.id)
     return ApiKeyRevokeResponse(status="revoked")

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -94,6 +94,7 @@ from app.services.runtime_source import RuntimeSourceError, RuntimeSourceNotFoun
 from app.services.runtime_source_authority import load_runtime_source_authority
 from app.services.runtime_state_cleanup import lock_runtime_state_write_fence
 from app.services.sync_events import (
+    notify_sync_subscriptions_changed,
     queue_environment_runtime_manifest_changed,
     queue_runtime_manifest_changed,
 )
@@ -1311,6 +1312,7 @@ async def platform_revoke_api_key(
     already_revoked = api_key.revoked_at is not None
     if not already_revoked:
         api_key.revoked_at = datetime.now(UTC)
+        await notify_sync_subscriptions_changed(db, [api_key.user_id])
     response = ApiKeyRevokeResponse(status="revoked")
     await _complete_mutation(
         db,

--- a/backend/app/routes/projects.py
+++ b/backend/app/routes/projects.py
@@ -37,6 +37,7 @@ from app.services.project_runtime_skills import (
 from app.services.sharing import safe_owner_display, safe_owner_handle
 from app.services.sync_events import (
     active_runtime_manifest_targets,
+    notify_sync_subscriptions_changed,
     queue_runtime_manifests_changed,
 )
 
@@ -301,6 +302,7 @@ async def create_project(
     )
     db.add(project)
     try:
+        await notify_sync_subscriptions_changed(db, [user_id])
         await db.commit()
     except IntegrityError as exc:
         await db.rollback()
@@ -549,6 +551,17 @@ async def archive_project(
             "Only user-created Projects can be archived",
         )
     targets = await active_runtime_manifest_targets(db, agent_ids)
+    member_user_ids = list(
+        (
+            await db.execute(
+                select(ProjectMembership.member_user_id).where(
+                    ProjectMembership.project_id == project_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
     await db.execute(
         delete(AgentProjectBinding).where(
             AgentProjectBinding.project_id == project_id,
@@ -556,6 +569,7 @@ async def archive_project(
         )
     )
     project.archived_at = datetime.now(UTC)
+    await notify_sync_subscriptions_changed(db, [auth.user_id, *member_user_ids])
     await queue_runtime_manifests_changed(db, targets)
     await db.commit()
     return ProjectArchiveResponse(unlinked_agent_count=len(agent_ids))

--- a/backend/app/routes/sharing.py
+++ b/backend/app/routes/sharing.py
@@ -42,6 +42,7 @@ from app.services.sharing import (
     safe_owner_display,
     token_prefix,
 )
+from app.services.sync_events import notify_sync_subscriptions_changed
 
 logger = logging.getLogger(__name__)
 
@@ -433,6 +434,7 @@ async def remove_member(
         project_id=project_id,
         user_ids=[member_user_id],
     )
+    await notify_sync_subscriptions_changed(db, [member_user_id])
     await db.commit()
     return ProjectMemberRemoveResponse(
         status="removed",
@@ -474,6 +476,7 @@ async def leave_project(
         project_id=project_id,
         user_ids=[auth.user_id],
     )
+    await notify_sync_subscriptions_changed(db, [auth.user_id])
     await db.commit()
     return ProjectLeaveResponse(
         status="left",
@@ -536,6 +539,7 @@ async def unshare_project(
     for member in members:
         await db.delete(member)
 
+    await notify_sync_subscriptions_changed(db, member_user_ids)
     await db.commit()
     return UnshareResponse(
         links_revoked=len(active_links),

--- a/backend/app/routes/sync.py
+++ b/backend/app/routes/sync.py
@@ -39,9 +39,12 @@ import json
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 from datetime import UTC, datetime, timedelta
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import AuthContext, require_scope_short_session
 from app.core.database import async_session_factory
@@ -50,6 +53,7 @@ from app.core.skill_sync_protocol import (
     SKILL_SYNC_PROTOCOL_HEADER,
     resolve_skill_sync_protocol,
 )
+from app.models.api_key import ApiKey
 from app.services import sync_events
 
 router = APIRouter(prefix="/sync", tags=["sync"])
@@ -134,7 +138,7 @@ async def _stream(
     subscriber's visible projects) and emits heartbeats so proxies
     don't nuke the connection during quiet periods. Returns when
     the client disconnects, when `revoked` fires (api_key
-    revocation noticed by the periodic refresher), or whichever
+    revocation noticed by the subscription refresher), or whichever
     happens first."""
     yield b": connected\n\n"
     while True:
@@ -179,14 +183,19 @@ async def _stream(
         yield f"event: {event_payload['type']}\ndata: {payload}\n\n".encode()
 
 
-# Cadence at which the SSE channel re-queries the caller's
-# `project_ids_visible_to` to catch runtime project reassignment.
-# Without this, a deploy key whose env's default_project_id changed
-# mid-stream would keep receiving events for the old project until
-# disconnection. Aligned with the daemon's own
-# `refreshDefaultProjectIdLoop` (HEARTBEAT_INTERVAL_MS) so client
-# and server converge on the new project at the same cadence.
-PROJECT_VISIBILITY_REFRESH_INTERVAL_S = 30.0
+# Notifications drive normal refreshes. This slow poll only catches a lost
+# PostgreSQL notification or a listener outage.
+SUBSCRIPTION_REFRESH_FALLBACK_INTERVAL_S = 5 * 60.0
+
+
+async def _api_key_inactive_reason(db: AsyncSession, api_key_id: UUID) -> str | None:
+    result = await db.execute(select(ApiKey.id, ApiKey.revoked_at).where(ApiKey.id == api_key_id))
+    row = result.first()
+    if row is None:
+        return "deleted"
+    if row.revoked_at is not None:
+        return "revoked"
+    return None
 
 
 @router.get("/events")
@@ -220,32 +229,41 @@ async def events(
     if _oauth_cli_access_expired(auth):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "OAuth access token has expired")
 
-    # Resolve the caller's initial visible-project set, then atomic
-    # cap-and-subscribe. The cap check + register pair is wrapped
-    # in a lock inside `try_subscribe` so concurrent handshakes
-    # can't both pass a stale count read and exceed the cap.
-    async with async_session_factory() as initial_db:
-        initial_visible = frozenset(await project_ids_visible_to(initial_db, auth))
-    subscription = await sync_events.try_subscribe(
-        user_id,
-        initial_visible,
-        max_per_user=PER_USER_CONNECTION_CAP,
-        api_key_id=auth.api_key.id if auth.api_key is not None else None,
-        # Per-key cap only applies to Agent API keys. Unbound
-        # CLI keys are user-level (one key shared across N daemons
-        # via `clawdi daemon install --all`), so any small per-key
-        # cap would silently 429 later local agents on a multi-agent
-        # machine. Bound keys use `try_subscribe`'s single default
-        # authority of 3: skill sync + runtime watch + one diagnostic.
-        is_env_bound=(auth.api_key is not None and auth.api_key.environment_id is not None),
-        environment_id=(auth.api_key.environment_id if auth.api_key is not None else None),
-    )
-    if subscription is None:
-        raise HTTPException(
-            status.HTTP_429_TOO_MANY_REQUESTS,
-            detail="too many concurrent sync subscriptions for this user",
-            headers={"Retry-After": "30"},
+    refresh_key = str(user_id)
+    refresh_requested = sync_events.sync_subscriptions_changed.subscribe(refresh_key)
+    try:
+        # Subscribe to mutation wakeups before the initial reads. A commit that
+        # crosses the handshake either appears in these reads or leaves the
+        # waiter set for an immediate recheck.
+        async with async_session_factory() as initial_db:
+            if auth.api_key is not None:
+                inactive_reason = await _api_key_inactive_reason(initial_db, auth.api_key.id)
+                if inactive_reason is not None:
+                    raise HTTPException(status.HTTP_401_UNAUTHORIZED, "API key is revoked")
+            initial_visible = frozenset(await project_ids_visible_to(initial_db, auth))
+        subscription = await sync_events.try_subscribe(
+            user_id,
+            initial_visible,
+            max_per_user=PER_USER_CONNECTION_CAP,
+            api_key_id=auth.api_key.id if auth.api_key is not None else None,
+            # Per-key cap only applies to Agent API keys. Unbound
+            # CLI keys are user-level (one key shared across N daemons
+            # via `clawdi daemon install --all`), so any small per-key
+            # cap would silently 429 later local agents on a multi-agent
+            # machine. Bound keys use `try_subscribe`'s single default
+            # authority of 3: skill sync + runtime watch + one diagnostic.
+            is_env_bound=(auth.api_key is not None and auth.api_key.environment_id is not None),
+            environment_id=(auth.api_key.environment_id if auth.api_key is not None else None),
         )
+        if subscription is None:
+            raise HTTPException(
+                status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="too many concurrent sync subscriptions for this user",
+                headers={"Retry-After": "30"},
+            )
+    except BaseException:
+        sync_events.sync_subscriptions_changed.unsubscribe(refresh_key, refresh_requested)
+        raise
     queue, subscriber = subscription
 
     log.info(
@@ -255,7 +273,7 @@ async def events(
         sync_events.connection_count(user_id),
     )
 
-    # Set when the periodic refresher notices the caller's api_key
+    # Set when the event-driven refresher notices the caller's api_key
     # was revoked. Closes the auth-after-handshake window where a
     # subscriber kept receiving `skill_changed` / `skill_deleted`
     # invalidations, which wake an Agent-authoritative local rescan and Cloud
@@ -263,9 +281,10 @@ async def events(
     revoked = asyncio.Event()
 
     async def refresh_visibility() -> None:
-        """Periodically re-query the caller's visible project set
-        and re-check api_key revocation. Closes both the cross-
-        project leak window when an env's default_project_id changes
+        """Refresh after a committed mutation or the slow fallback timeout.
+
+        Re-checks both project visibility and api_key revocation, closing the
+        cross-project leak window when an env's default_project_id changes
         mid-stream AND the post-revocation auth window.
 
         Opens its own short-lived `async_session_factory()` per
@@ -274,12 +293,17 @@ async def events(
         session for the lifetime of its stream — a few hundred
         daemons would exhaust the pool.
         """
-        from sqlalchemy import select
-
-        from app.models.api_key import ApiKey
-
         while True:
-            await asyncio.sleep(PROJECT_VISIBILITY_REFRESH_INTERVAL_S)
+            try:
+                await asyncio.wait_for(
+                    refresh_requested.wait(),
+                    timeout=SUBSCRIPTION_REFRESH_FALLBACK_INTERVAL_S,
+                )
+            except TimeoutError:
+                pass
+            # Clear before querying. A mutation committed during the reads sets
+            # the waiter again and forces another pass.
+            refresh_requested.clear()
             try:
                 async with async_session_factory() as refresh_db:
                     # Revocation check first — if the key is dead, the
@@ -292,21 +316,14 @@ async def events(
                     # or_none()` returning None would be silently
                     # interpreted as "still valid".
                     if auth.api_key is not None:
-                        result = await refresh_db.execute(
-                            select(ApiKey.id, ApiKey.revoked_at).where(ApiKey.id == auth.api_key.id)
+                        inactive_reason = await _api_key_inactive_reason(
+                            refresh_db,
+                            auth.api_key.id,
                         )
-                        row = result.first()
-                        if row is None:
+                        if inactive_reason is not None:
                             log.info(
-                                "sync events: api_key row deleted mid-stream user=%s key=%s",
-                                user_id,
-                                auth.api_key.id,
-                            )
-                            revoked.set()
-                            return
-                        if row.revoked_at is not None:
-                            log.info(
-                                "sync events: api_key revoked mid-stream user=%s key=%s",
+                                "sync events: api_key %s mid-stream user=%s key=%s",
+                                inactive_reason,
                                 user_id,
                                 auth.api_key.id,
                             )
@@ -340,12 +357,18 @@ async def events(
             try:
                 await _cancel_and_wait(refresh_task, expiry_task)
             finally:
-                sync_events.unsubscribe(user_id, queue)
-                log.info(
-                    "sync events: unsubscribed user=%s remaining=%s",
-                    user_id,
-                    sync_events.connection_count(user_id),
-                )
+                try:
+                    sync_events.sync_subscriptions_changed.unsubscribe(
+                        refresh_key,
+                        refresh_requested,
+                    )
+                finally:
+                    sync_events.unsubscribe(user_id, queue)
+                    log.info(
+                        "sync events: unsubscribed user=%s remaining=%s",
+                        user_id,
+                        sync_events.connection_count(user_id),
+                    )
 
     # `text/event-stream` is the SSE content type. `X-Accel-Buffering:
     # no` disables nginx response buffering on the off chance an

--- a/backend/app/services/agent_environments.py
+++ b/backend/app/services/agent_environments.py
@@ -20,6 +20,7 @@ from app.models.project import PROJECT_KIND_ENVIRONMENT, Project
 from app.models.session import AgentEnvironment
 from app.services.agent_lifecycle import reactivate_agent_and_project
 from app.services.principal_lifecycle import assert_user_authority_active
+from app.services.sync_events import notify_sync_subscriptions_changed
 
 _AGENT_TYPE_LABELS = {
     "openclaw": "OpenClaw",
@@ -185,6 +186,7 @@ async def register_agent_environment(
         db.add(env)
         await db.flush()
         project.origin_environment_id = env.id
+        await notify_sync_subscriptions_changed(db, [user_id])
         if commit:
             await db.commit()
         else:
@@ -308,6 +310,7 @@ async def _refresh_agent_environment(
         db.add(healing_project)
         await db.flush()
         env.default_project_id = healing_project.id
+        await notify_sync_subscriptions_changed(db, [user_id])
 
 
 async def _next_explicit_default_name(db: AsyncSession, user_id: UUID, agent_type: str) -> str:

--- a/backend/app/services/agent_lifecycle.py
+++ b/backend/app/services/agent_lifecycle.py
@@ -9,7 +9,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.api_key import ApiKey
 from app.models.project import PROJECT_KIND_ENVIRONMENT, Project
 from app.models.session import AgentEnvironment
-from app.services.sync_events import queue_environment_runtime_manifest_changed
+from app.services.sync_events import (
+    notify_sync_subscriptions_changed,
+    queue_environment_runtime_manifest_changed,
+)
 
 
 class AgentLifecycleBoundaryError(RuntimeError):
@@ -85,6 +88,7 @@ async def archive_agent_and_project(
         ).all()
     )
     await db.execute(update(ApiKey).where(ApiKey.id.in_(key_ids)).values(revoked_at=archived_at))
+    await notify_sync_subscriptions_changed(db, [locked_agent.user_id])
     return tuple(key_ids)
 
 
@@ -126,6 +130,7 @@ async def reactivate_agent_and_project(db: AsyncSession, *, agent: AgentEnvironm
         raise AgentLifecycleBoundaryError("Agent Project is shared by another Agent")
     locked_agent.archived_at = None
     project.archived_at = None
+    await notify_sync_subscriptions_changed(db, [locked_agent.user_id])
     await queue_environment_runtime_manifest_changed(
         db,
         locked_agent.user_id,

--- a/backend/app/services/principal_lifecycle.py
+++ b/backend/app/services/principal_lifecycle.py
@@ -55,6 +55,7 @@ from app.services.project_runtime_skills import (
 from app.services.runtime_observation import retire_runtime_environment
 from app.services.sync_events import (
     active_runtime_manifest_targets,
+    notify_sync_subscriptions_changed,
     queue_runtime_manifests_changed,
 )
 
@@ -922,7 +923,7 @@ async def complete_principal_cleanup(
     )
 
     owned_project_ids = select(Project.id).where(Project.user_id == user.id)
-    deleted_membership_ids = tuple(
+    deleted_membership_user_ids = tuple(
         (
             await db.scalars(
                 delete(ProjectMembership)
@@ -932,7 +933,7 @@ async def complete_principal_cleanup(
                         ProjectMembership.project_id.in_(owned_project_ids),
                     )
                 )
-                .returning(ProjectMembership.id)
+                .returning(ProjectMembership.member_user_id)
             )
         ).all()
     )
@@ -1040,9 +1041,13 @@ async def complete_principal_cleanup(
     if not attempt_already_recorded:
         lifecycle.cleanup_attempts += 1
     _mark_principal_cleanup_complete(lifecycle, completed_at=current_time)
+    await notify_sync_subscriptions_changed(
+        db,
+        {user.id, *deleted_membership_user_ids},
+    )
     await db.flush()
     project_access_revoked = (
-        len(deleted_membership_ids) + len(deleted_invitation_ids) + len(revoked_share_link_ids)
+        len(deleted_membership_user_ids) + len(deleted_invitation_ids) + len(revoked_share_link_ids)
     )
     return PrincipalCleanupResult(
         user_disabled=True,

--- a/backend/app/services/sharing.py
+++ b/backend/app/services/sharing.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.project_membership import ProjectMembership
 from app.models.user import User
+from app.services.sync_events import notify_sync_subscriptions_changed
 
 _NON_ALNUM = re.compile(r"[^a-z0-9]+")
 _TRIM_DASHES = re.compile(r"^-+|-+$")
@@ -154,4 +155,5 @@ async def ensure_viewer_membership(
     )
     db.add(membership)
     await db.flush()
+    await notify_sync_subscriptions_changed(db, [member_user_id])
     return membership

--- a/backend/app/services/sync_events.py
+++ b/backend/app/services/sync_events.py
@@ -82,6 +82,7 @@ from app.schemas.runtime import HostedRuntimeTools, validate_hosted_runtime_desi
 from app.services.channel_wakeups import (
     CHANNEL_DELIVERIES_ENQUEUED,
     CHANNEL_INBOUND_MESSAGES_ENQUEUED,
+    ChannelWakeup,
     channel_deliveries_enqueued,
     channel_inbound_messages_enqueued,
 )
@@ -96,6 +97,7 @@ from app.services.postgres_listener import PostgresListener, connect_postgres_li
 log = logging.getLogger(__name__)
 
 _POSTGRES_CHANNEL = "clawdi_sync_events"
+SYNC_SUBSCRIPTIONS_CHANGED = "sync_subscriptions_changed"
 _PROCESS_TOKEN = uuid4().hex
 _POSTGRES_PAYLOAD_LIMIT_BYTES = 7900
 
@@ -129,11 +131,10 @@ class _Subscriber:
 
     `visible_project_ids` is mutable — an out-of-band refresh
     task on the SSE channel re-queries `project_ids_visible_to`
-    every 30s and replaces the field, so a runtime env-project
-    reassignment converges within one refresh cycle. Without
-    this, a deploy key whose env is reassigned to a different
-    project would keep receiving event metadata for its former
-    project until the connection drops.
+    after a keyed mutation notification, with a slow fallback poll. Without
+    this, a deploy key whose env is reassigned to a different project would
+    keep receiving event metadata for its former project until the connection
+    drops.
     """
 
     queue: SyncEventQueue = field(default_factory=lambda: asyncio.Queue(maxsize=64))
@@ -160,6 +161,23 @@ _subscribers: dict[UUID, list[_Subscriber]] = defaultdict(list)
 # lock around read+write — these calls don't await between
 # count and append.
 _subscribe_lock = asyncio.Lock()
+
+# Visibility and revocation mutations wake only streams owned by the affected
+# user. PostgreSQL carries the signal across workers; this keyed process-local
+# registry is the same waiter primitive used by channel long polling.
+sync_subscriptions_changed = ChannelWakeup()
+
+
+async def notify_sync_subscriptions_changed(
+    db: AsyncSession,
+    user_ids: Iterable[UUID],
+) -> None:
+    """Wake affected SSE subscriptions after the transaction commits."""
+    for user_id in set(user_ids):
+        await db.execute(
+            text("SELECT pg_notify(:channel, :key)"),
+            {"channel": SYNC_SUBSCRIPTIONS_CHANGED, "key": str(user_id)},
+        )
 
 
 async def try_subscribe(
@@ -683,6 +701,7 @@ async def _postgres_listener_loop(
                     _POSTGRES_CHANNEL: _on_postgres_notification,
                     CHANNEL_DELIVERIES_ENQUEUED: _on_channel_delivery_enqueued,
                     CHANNEL_INBOUND_MESSAGES_ENQUEUED: _on_channel_inbound_message_enqueued,
+                    SYNC_SUBSCRIPTIONS_CHANGED: _on_sync_subscriptions_changed,
                 },
                 terminated.set,
             )
@@ -754,6 +773,10 @@ def _on_channel_delivery_enqueued(_pid: int, _channel: str, payload: str) -> Non
 
 def _on_channel_inbound_message_enqueued(_pid: int, _channel: str, payload: str) -> None:
     channel_inbound_messages_enqueued.signal(payload)
+
+
+def _on_sync_subscriptions_changed(_pid: int, _channel: str, payload: str) -> None:
+    sync_subscriptions_changed.signal(payload)
 
 
 async def get_skills_revision(db: AsyncSession, user_id: UUID) -> int:

--- a/backend/tests/test_sync_events.py
+++ b/backend/tests/test_sync_events.py
@@ -21,14 +21,17 @@ from __future__ import annotations
 import asyncio
 import json
 import uuid
+from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 
 import pytest
 from fastapi import HTTPException, Request
-from sqlalchemy import select, text
+from sqlalchemy import event, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.types import Message
 
+from app.core.auth import AuthContext
+from app.core.database import engine as app_engine
 from app.core.skill_sync_protocol import (
     SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V0,
     SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
@@ -61,6 +64,27 @@ def _connected_request() -> Request:
         return {"type": "http.request", "body": b"", "more_body": False}
 
     return Request({"type": "http"}, receive)
+
+
+async def _open_api_key_stream(
+    db_session: AsyncSession,
+    user: User,
+) -> tuple[ApiKey, AuthContext, AsyncIterator[bytes]]:
+    from app.routes import sync as sync_route
+    from app.services.api_key import mint_api_key
+
+    minted = await mint_api_key(
+        db_session,
+        user_id=user.id,
+        label="sync refresh test",
+        commit=False,
+    )
+    await db_session.commit()
+    auth = AuthContext(user=user, api_key=minted.api_key)
+    response = await sync_route.events(_connected_request(), auth, None)
+    iterator = response.body_iterator.__aiter__()
+    assert await iterator.__anext__() == b": connected\n\n"
+    return minted.api_key, auth, iterator
 
 
 @pytest.mark.parametrize(
@@ -274,6 +298,92 @@ async def test_stream_returns_when_revoked_event_set():
     revoked.set()
     with pytest.raises(StopAsyncIteration):
         await gen.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_api_key_revoke_notification_closes_only_affected_user_stream(
+    db_session: AsyncSession,
+    seed_user: User,
+):
+    from app.routes.auth import revoke_api_key
+
+    api_key, _auth, iterator = await _open_api_key_stream(db_session, seed_user)
+    other_user_id = uuid.uuid4()
+    other_waiter = sync_events.sync_subscriptions_changed.subscribe(str(other_user_id))
+    await sync_events.start_postgres_listener()
+    try:
+        response = await revoke_api_key(
+            str(api_key.id),
+            AuthContext(user=seed_user),
+            db_session,
+        )
+        assert response.status == "revoked"
+        with pytest.raises(StopAsyncIteration):
+            await asyncio.wait_for(iterator.__anext__(), timeout=2)
+        assert not other_waiter.is_set()
+    finally:
+        await iterator.aclose()
+        await sync_events.stop_postgres_listener()
+        sync_events.sync_subscriptions_changed.unsubscribe(str(other_user_id), other_waiter)
+
+
+@pytest.mark.asyncio
+async def test_api_key_revoke_fallback_closes_stream_when_notification_is_lost(
+    db_session: AsyncSession,
+    seed_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from app.routes import sync as sync_route
+
+    monkeypatch.setattr(sync_route, "SUBSCRIPTION_REFRESH_FALLBACK_INTERVAL_S", 0.01)
+    api_key, _auth, iterator = await _open_api_key_stream(db_session, seed_user)
+    try:
+        # Simulate durable state changing while its PostgreSQL notification is
+        # lost: bypass every mutation helper and update the row directly.
+        await db_session.execute(
+            update(ApiKey).where(ApiKey.id == api_key.id).values(revoked_at=datetime.now(UTC))
+        )
+        await db_session.commit()
+
+        with pytest.raises(StopAsyncIteration):
+            await asyncio.wait_for(iterator.__anext__(), timeout=1)
+    finally:
+        await iterator.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sync_stream_queries_only_after_keyed_refresh_signal(
+    db_session: AsyncSession,
+    seed_user: User,
+):
+    _api_key, _auth, iterator = await _open_api_key_stream(db_session, seed_user)
+    refresh_statements: list[str] = []
+
+    def capture_refresh_statement(_connection, _cursor, statement: str, *_args) -> None:
+        if any(
+            table in statement
+            for table in ("FROM api_keys", "FROM projects", "FROM project_memberships")
+        ):
+            refresh_statements.append(statement)
+
+    event.listen(app_engine.sync_engine, "before_cursor_execute", capture_refresh_statement)
+    try:
+        await asyncio.sleep(0.05)
+        assert refresh_statements == []
+
+        sync_events.sync_subscriptions_changed.signal(str(seed_user.id))
+        deadline = asyncio.get_running_loop().time() + 1
+        while len(refresh_statements) < 3 and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.01)
+
+        # One api_key check plus the existing owned/shared Project visibility
+        # reads. No private 30-second loop continues querying afterward.
+        assert len(refresh_statements) == 3
+        await asyncio.sleep(0.05)
+        assert len(refresh_statements) == 3
+    finally:
+        event.remove(app_engine.sync_engine, "before_cursor_execute", capture_refresh_statement)
+        await iterator.aclose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Replace each SSE connection's private 30-second authorization/visibility refresh loop with a keyed `user_id` wakeup on the existing PostgreSQL listener.
- Emit transactional refresh notifications from the existing API key revoke, Project visibility, membership, Agent lifecycle, and principal cleanup mutation boundaries.
- Keep a five-minute fallback refresh solely for notification loss or listener outages.
- Add behavior coverage for immediate key-revoke disconnects, cross-user isolation, notification-loss fallback, and steady-state SQL counts.

## Existing mechanism only

This adds no new coordination mechanism, environment variable, feature flag, or product behavior. It only extends the established `services/sync_events.py` + `services/postgres_listener.py` LISTEN/NOTIFY lifecycle and reuses the keyed `ChannelWakeup` waiter pattern hardened in #1219. Notifications are queued inside the mutation transaction, so PostgreSQL delivers them after commit and drops them on rollback.

## Load and latency

Before, every connection refreshed every 30 seconds. Using the stated two-query refresh model, that is 0.067 query/s per connection: 12-18 steady query/s for 90 boxes with 2-3 streams each, and 1,200-1,800 query/s for 9,000 boxes.

After, quiet connections issue no refresh SQL until a relevant keyed mutation. The loss-recovery poll runs every 300 seconds, reducing polling floor by 90%: approximately 1.2-1.8 query/s at 90 boxes and 120-180 query/s at 9,000 boxes under the same two-query model. Mutation-driven refreshes are transient and scoped to the affected user.

API key revocation previously took up to 30 seconds to close an established stream. It now wakes the affected user's waiter after the revoke commits and immediately reruns the existing key status and Project visibility checks. A different user's streams are not awakened. The five-minute poll remains only as a notification-loss safety net.

## Verification

- `uv run pytest -q tests/test_sync_events.py` (36 passed)
- Focused auth, Project, sharing, and principal lifecycle suites (65 passed)
- Focused admin, platform, Agent lifecycle, and query-count tests (6 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m compileall -q app scripts tests alembic`
- `uv run --extra mem0 python scripts/type_governance.py owned` (197 files, 0 errors, 0 warnings)
