### PR TITLE
perf: remove synchronized request latency floor

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -66,6 +66,7 @@ from app.routes.skills import scope_router as skills_scope_router
 from app.routes.sync import router as sync_router
 from app.routes.vault import router as vault_router
 from app.services.ai_provider_auth_transition import OAuthCredentialPayloadCorruptError
+from app.services.channels import close_channel_provider_http_client
 from app.services.composio import close_composio_client
 from app.services.embedding import LocalEmbedder
 from app.services.memory_types import MemoryProviderUnavailableError, MemoryProviderUpstreamError
@@ -145,8 +146,13 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         try:
             await whatsapp_sidecars.stop()
         finally:
-            await stop_postgres_listener()
-            await close_composio_client()
+            try:
+                await stop_postgres_listener()
+            finally:
+                try:
+                    await close_channel_provider_http_client()
+                finally:
+                    await close_composio_client()
 
 
 app = FastAPI(

--- a/backend/app/middleware/request_id.py
+++ b/backend/app/middleware/request_id.py
@@ -13,27 +13,37 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import Request
-from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
-from starlette.responses import Response
+from starlette.datastructures import Headers, MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 _INBOUND_HEADERS = ("x-request-id", "x-correlation-id")
 _OUTBOUND_HEADER = "X-Request-ID"
 
 
-class RequestIDMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-        request_id = _read_inbound(request) or uuid.uuid4().hex
-        request.state.request_id = request_id
+class RequestIDMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
 
-        response = await call_next(request)
-        response.headers[_OUTBOUND_HEADER] = request_id
-        return response
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_id = _read_inbound(scope) or uuid.uuid4().hex
+        scope.setdefault("state", {})["request_id"] = request_id
+
+        async def send_with_request_id(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                MutableHeaders(scope=message)[_OUTBOUND_HEADER] = request_id
+            await send(message)
+
+        await self.app(scope, receive, send_with_request_id)
 
 
-def _read_inbound(request: Request) -> str | None:
+def _read_inbound(scope: Scope) -> str | None:
+    headers = Headers(scope=scope)
     for key in _INBOUND_HEADERS:
-        value = request.headers.get(key)
+        value = headers.get(key)
         if value:
             # Trim and cap length so an upstream can't inject gigabyte headers.
             trimmed = value.strip()[:128]

--- a/backend/app/middleware/security_headers.py
+++ b/backend/app/middleware/security_headers.py
@@ -26,24 +26,33 @@ ingress, dev) consistent.
 
 from __future__ import annotations
 
-from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
-from starlette.requests import Request
-from starlette.responses import Response
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.core.config import settings
 
 
-class SecurityHeadersMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-        response: Response = await call_next(request)
-        # Only set if absent — don't clobber edge-proxy values.
-        h = response.headers
-        h.setdefault("X-Content-Type-Options", "nosniff")
-        h.setdefault("X-Frame-Options", "DENY")
-        h.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
-        if settings.environment == "production":
-            h.setdefault(
-                "Strict-Transport-Security",
-                "max-age=31536000; includeSubDomains",
-            )
-        return response
+class SecurityHeadersMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_security_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                # Only set if absent so an edge proxy value is preserved.
+                headers = MutableHeaders(scope=message)
+                headers.setdefault("X-Content-Type-Options", "nosniff")
+                headers.setdefault("X-Frame-Options", "DENY")
+                headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+                if settings.environment == "production":
+                    headers.setdefault(
+                        "Strict-Transport-Security",
+                        "max-age=31536000; includeSubDomains",
+                    )
+            await send(message)
+
+        await self.app(scope, receive, send_with_security_headers)

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -45,6 +45,7 @@ from app.services.channels import (
     channel_webhook_url,
     decrypt_provider_token,
     find_binding,
+    get_channel_provider_http_client,
     resolve_channel_agent_by_token,
 )
 from app.services.discord_rate_limiter import discord_rate_limiter
@@ -1406,22 +1407,22 @@ async def request_discord_provider(
         )
     try:
         with track_proxy_latency("discord", method):
-            async with httpx.AsyncClient(timeout=20.0) as client:
-                discord_rate_limiter.consume(account_scope, method, normalized_path)
-                response = await client.request(
-                    method,
-                    url,
-                    content=body,
-                    headers=headers,
-                    params=query_params,
-                )
-                discord_rate_limiter.observe(
-                    account_scope,
-                    method,
-                    normalized_path,
-                    _discord_rate_limit_response_headers(response),
-                    response.status_code,
-                )
+            discord_rate_limiter.consume(account_scope, method, normalized_path)
+            response = await get_channel_provider_http_client().request(
+                method,
+                url,
+                content=body,
+                headers=headers,
+                params=query_params,
+                timeout=20.0,
+            )
+            discord_rate_limiter.observe(
+                account_scope,
+                method,
+                normalized_path,
+                _discord_rate_limit_response_headers(response),
+                response.status_code,
+            )
     except httpx.HTTPError as exc:
         outbound_errors.labels(channel="discord", method=method).inc()
         raise HTTPException(

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -80,6 +80,7 @@ from app.services.channels import (
     find_existing_inbound_provider_event,
     find_platform_channel_runtime_marker,
     get_active_channel_account,
+    get_channel_provider_http_client,
     lock_channel_binding_identity,
     parse_channel_control_command,
     pending_channel_inbox_count,
@@ -657,8 +658,7 @@ async def telegram_file_api(
     await _validate_telegram_provider_base_url(base_url)
     url = f"{base_url.rstrip('/')}/file/bot{provider_token}/{file_path}"
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(url)
+        response = await get_channel_provider_http_client().get(url, timeout=30.0)
     except httpx.HTTPError as exc:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -1878,8 +1878,11 @@ async def _post_telegram_bot_payload(
     await _validate_telegram_provider_base_url(base_url)
     url = f"{base_url.rstrip('/')}/bot{provider_token}/{method}"
     try:
-        async with httpx.AsyncClient(timeout=20.0) as client:
-            return await client.post(url, json=payload)
+        return await get_channel_provider_http_client().post(
+            url,
+            json=payload,
+            timeout=20.0,
+        )
     except httpx.HTTPError as exc:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -2667,13 +2670,13 @@ async def _telegram_provider_response(
         url = url.copy_with(query=query_string)
     try:
         with track_proxy_latency("telegram", method):
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.request(
-                    request.method,
-                    url,
-                    content=raw_body if raw_body else None,
-                    headers=headers,
-                )
+            response = await get_channel_provider_http_client().request(
+                request.method,
+                url,
+                content=raw_body if raw_body else None,
+                headers=headers,
+                timeout=30.0,
+            )
     except httpx.HTTPError as exc:
         outbound_errors.labels(channel="telegram", method=method).inc()
         raise HTTPException(

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -92,6 +92,24 @@ from app.services.vault_crypto import decrypt, encrypt
 log = logging.getLogger(__name__)
 type JsonObject = dict[str, JsonValue]
 _JSON_OBJECT_ADAPTER: TypeAdapter[JsonObject] = TypeAdapter(dict[str, JsonValue])
+_channel_provider_http_client: httpx.AsyncClient | None = None
+
+
+def get_channel_provider_http_client() -> httpx.AsyncClient:
+    """Return the process-wide client for Telegram and Discord APIs."""
+    global _channel_provider_http_client
+    if _channel_provider_http_client is None:
+        _channel_provider_http_client = httpx.AsyncClient(timeout=30.0)
+    return _channel_provider_http_client
+
+
+async def close_channel_provider_http_client() -> None:
+    """Close the shared channel provider client on ASGI shutdown."""
+    global _channel_provider_http_client
+    client = _channel_provider_http_client
+    _channel_provider_http_client = None
+    if client is not None:
+        await client.aclose()
 
 
 def _is_object_dict(value: object) -> TypeGuard[dict[object, object]]:
@@ -2499,19 +2517,19 @@ async def discord_bot_guild_membership_check(
         return DiscordGuildMembershipCheck(denied_reason=DISCORD_BOT_GUILD_MEMBERSHIP_UNAVAILABLE)
     try:
         with track_proxy_latency(CHANNEL_PROVIDER_DISCORD, "GET"):
-            async with httpx.AsyncClient(timeout=20.0) as client:
-                discord_rate_limiter.consume(account_scope, "GET", path)
-                response = await client.get(
-                    f"{base_url.rstrip('/')}{path}",
-                    headers={"Authorization": f"Bot {token}"},
-                )
-                discord_rate_limiter.observe(
-                    account_scope,
-                    "GET",
-                    path,
-                    _discord_rate_limit_response_headers(response),
-                    response.status_code,
-                )
+            discord_rate_limiter.consume(account_scope, "GET", path)
+            response = await get_channel_provider_http_client().get(
+                f"{base_url.rstrip('/')}{path}",
+                headers={"Authorization": f"Bot {token}"},
+                timeout=20.0,
+            )
+            discord_rate_limiter.observe(
+                account_scope,
+                "GET",
+                path,
+                _discord_rate_limit_response_headers(response),
+                response.status_code,
+            )
     except httpx.HTTPError:
         outbound_errors.labels(channel=CHANNEL_PROVIDER_DISCORD, method="GET").inc()
         return DiscordGuildMembershipCheck(denied_reason=DISCORD_BOT_GUILD_MEMBERSHIP_UNAVAILABLE)
@@ -5401,21 +5419,21 @@ async def _discord_application_request(
         )
     try:
         with track_proxy_latency(CHANNEL_PROVIDER_DISCORD, method):
-            async with httpx.AsyncClient(timeout=20.0) as client:
-                discord_rate_limiter.consume(account_scope, method, path)
-                response = await client.request(
-                    method,
-                    url,
-                    headers=headers,
-                    json=json_payload,
-                )
-                discord_rate_limiter.observe(
-                    account_scope,
-                    method,
-                    path,
-                    _discord_rate_limit_response_headers(response),
-                    response.status_code,
-                )
+            discord_rate_limiter.consume(account_scope, method, path)
+            response = await get_channel_provider_http_client().request(
+                method,
+                url,
+                headers=headers,
+                json=json_payload,
+                timeout=20.0,
+            )
+            discord_rate_limiter.observe(
+                account_scope,
+                method,
+                path,
+                _discord_rate_limit_response_headers(response),
+                response.status_code,
+            )
     except httpx.HTTPError as exc:
         outbound_errors.labels(channel=CHANNEL_PROVIDER_DISCORD, method=method).inc()
         raise HTTPException(
@@ -5586,8 +5604,11 @@ async def sync_telegram_commands(
         {"commands": request_commands}, strict=True
     )
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.post(url, json=request_payload)
+        response = await get_channel_provider_http_client().post(
+            url,
+            json=request_payload,
+            timeout=10.0,
+        )
     except httpx.HTTPError as exc:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -5723,20 +5744,20 @@ async def _send_discord_provider_payload(
         )
     try:
         with track_proxy_latency(CHANNEL_PROVIDER_DISCORD, "POST"):
-            async with httpx.AsyncClient(timeout=20.0) as client:
-                discord_rate_limiter.consume(account_scope, "POST", path)
-                response = await client.post(
-                    url,
-                    headers={"Authorization": f"Bot {token}"},
-                    json=payload,
-                )
-                discord_rate_limiter.observe(
-                    account_scope,
-                    "POST",
-                    path,
-                    response.headers,
-                    response.status_code,
-                )
+            discord_rate_limiter.consume(account_scope, "POST", path)
+            response = await get_channel_provider_http_client().post(
+                url,
+                headers={"Authorization": f"Bot {token}"},
+                json=payload,
+                timeout=20.0,
+            )
+            discord_rate_limiter.observe(
+                account_scope,
+                "POST",
+                path,
+                response.headers,
+                response.status_code,
+            )
     except httpx.HTTPError as exc:
         outbound_errors.labels(channel=CHANNEL_PROVIDER_DISCORD, method="POST").inc()
         raise HTTPException(
@@ -5818,100 +5839,67 @@ async def sync_discord_commands(
     ]
     synced: list[JsonObject] = []
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            if reconcile_reserved_commands:
-                # Reconcile only Clawdi's reserved namespace. Bulk overwrite
-                # would make these two commands the complete scope and delete
-                # unrelated application/runtime commands owned elsewhere.
-                # Discord POST is an upsert by command name. Validate both new
-                # commands before deleting any legacy command so a partial
-                # provider failure cannot remove the only usable pair path.
-                # DELETE then targets only IDs found by the preceding GET.
-                # https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
-                # https://discord.com/developers/docs/interactions/application-commands#delete-global-application-command
-                # https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
-                headers = {
-                    "Authorization": f"Bot {token}",
-                    "Content-Type": "application/json",
-                }
-                response = await _discord_command_request(
-                    client,
-                    account_scope=str(account.id),
-                    method="GET",
-                    url=url,
-                    path=f"{path}/commands",
-                    headers=headers,
-                )
-                _raise_for_discord_command_sync_response(response)
-                existing_commands = _response_json_value(
-                    response,
+        client = get_channel_provider_http_client()
+        if reconcile_reserved_commands:
+            # Reconcile only Clawdi's reserved namespace. Bulk overwrite
+            # would make these two commands the complete scope and delete
+            # unrelated application/runtime commands owned elsewhere.
+            # Discord POST is an upsert by command name. Validate both new
+            # commands before deleting any legacy command so a partial
+            # provider failure cannot remove the only usable pair path.
+            # DELETE then targets only IDs found by the preceding GET.
+            # https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
+            # https://discord.com/developers/docs/interactions/application-commands#delete-global-application-command
+            # https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
+            headers = {
+                "Authorization": f"Bot {token}",
+                "Content-Type": "application/json",
+            }
+            response = await _discord_command_request(
+                client,
+                account_scope=str(account.id),
+                method="GET",
+                url=url,
+                path=f"{path}/commands",
+                headers=headers,
+            )
+            _raise_for_discord_command_sync_response(response)
+            existing_commands = _response_json_value(
+                response,
+                detail="discord api returned invalid commands",
+            )
+            if not isinstance(existing_commands, list) or not all(
+                isinstance(command, dict) for command in existing_commands
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
                     detail="discord api returned invalid commands",
                 )
-                if not isinstance(existing_commands, list) or not all(
-                    isinstance(command, dict) for command in existing_commands
-                ):
+            legacy_command_ids: list[str] = []
+            for existing_command in existing_commands:
+                if not isinstance(existing_command, dict):
                     raise HTTPException(
                         status_code=status.HTTP_502_BAD_GATEWAY,
                         detail="discord api returned invalid commands",
                     )
-                legacy_command_ids: list[str] = []
-                for existing_command in existing_commands:
-                    if not isinstance(existing_command, dict):
-                        raise HTTPException(
-                            status_code=status.HTTP_502_BAD_GATEWAY,
-                            detail="discord api returned invalid commands",
-                        )
-                    existing_name = _read_optional_str(existing_command.get("name"))
-                    if existing_name not in DISCORD_LEGACY_RESERVED_COMMAND_NAMES:
-                        continue
-                    existing_type = existing_command.get("type")
-                    if isinstance(existing_type, bool) or not isinstance(existing_type, int):
-                        raise HTTPException(
-                            status_code=status.HTTP_502_BAD_GATEWAY,
-                            detail="discord api returned invalid commands",
-                        )
-                    if existing_type != 1:
-                        continue
-                    command_id = _read_optional_str(existing_command.get("id"))
-                    if command_id is None or not valid_discord_application_id(command_id):
-                        raise HTTPException(
-                            status_code=status.HTTP_502_BAD_GATEWAY,
-                            detail="discord api returned invalid commands",
-                        )
-                    legacy_command_ids.append(command_id)
-                for command_payload in command_payloads:
-                    response = await _discord_command_request(
-                        client,
-                        account_scope=str(account.id),
-                        method="POST",
-                        url=url,
-                        path=f"{path}/commands",
-                        headers=headers,
-                        json_payload=command_payload,
+                existing_name = _read_optional_str(existing_command.get("name"))
+                if existing_name not in DISCORD_LEGACY_RESERVED_COMMAND_NAMES:
+                    continue
+                existing_type = existing_command.get("type")
+                if isinstance(existing_type, bool) or not isinstance(existing_type, int):
+                    raise HTTPException(
+                        status_code=status.HTTP_502_BAD_GATEWAY,
+                        detail="discord api returned invalid commands",
                     )
-                    _raise_for_discord_command_sync_response(response)
-                    synced_command = _validated_synced_discord_command(
-                        response,
-                        expected_name=_command_name(command_payload),
+                if existing_type != 1:
+                    continue
+                command_id = _read_optional_str(existing_command.get("id"))
+                if command_id is None or not valid_discord_application_id(command_id):
+                    raise HTTPException(
+                        status_code=status.HTTP_502_BAD_GATEWAY,
+                        detail="discord api returned invalid commands",
                     )
-                    synced.append(synced_command)
-                for command_id in legacy_command_ids:
-                    response = await _discord_command_request(
-                        client,
-                        account_scope=str(account.id),
-                        method="DELETE",
-                        url=f"{url}/{command_id}",
-                        path=f"{path}/commands/{command_id}",
-                        headers=headers,
-                    )
-                    # A concurrent reconciliation can delete the exact ID
-                    # discovered above before this request reaches Discord.
-                    # That 404 means the required absence already converged.
-                    _raise_for_discord_command_sync_response(
-                        response,
-                        allow_not_found=True,
-                    )
-                return synced
+                legacy_command_ids.append(command_id)
             for command_payload in command_payloads:
                 response = await _discord_command_request(
                     client,
@@ -5919,19 +5907,52 @@ async def sync_discord_commands(
                     method="POST",
                     url=url,
                     path=f"{path}/commands",
-                    headers={
-                        "Authorization": f"Bot {token}",
-                        "Content-Type": "application/json",
-                    },
+                    headers=headers,
                     json_payload=command_payload,
                 )
                 _raise_for_discord_command_sync_response(response)
-                synced.append(
-                    _validated_synced_discord_command(
-                        response,
-                        expected_name=_command_name(command_payload),
-                    )
+                synced_command = _validated_synced_discord_command(
+                    response,
+                    expected_name=_command_name(command_payload),
                 )
+                synced.append(synced_command)
+            for command_id in legacy_command_ids:
+                response = await _discord_command_request(
+                    client,
+                    account_scope=str(account.id),
+                    method="DELETE",
+                    url=f"{url}/{command_id}",
+                    path=f"{path}/commands/{command_id}",
+                    headers=headers,
+                )
+                # A concurrent reconciliation can delete the exact ID
+                # discovered above before this request reaches Discord.
+                # That 404 means the required absence already converged.
+                _raise_for_discord_command_sync_response(
+                    response,
+                    allow_not_found=True,
+                )
+            return synced
+        for command_payload in command_payloads:
+            response = await _discord_command_request(
+                client,
+                account_scope=str(account.id),
+                method="POST",
+                url=url,
+                path=f"{path}/commands",
+                headers={
+                    "Authorization": f"Bot {token}",
+                    "Content-Type": "application/json",
+                },
+                json_payload=command_payload,
+            )
+            _raise_for_discord_command_sync_response(response)
+            synced.append(
+                _validated_synced_discord_command(
+                    response,
+                    expected_name=_command_name(command_payload),
+                )
+            )
     except httpx.HTTPError as exc:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -5960,9 +5981,15 @@ async def _discord_command_request(
         )
     discord_rate_limiter.consume(account_scope, method, path)
     if json_payload is None:
-        response = await client.request(method, url, headers=headers)
+        response = await client.request(method, url, headers=headers, timeout=10.0)
     else:
-        response = await client.request(method, url, headers=headers, json=json_payload)
+        response = await client.request(
+            method,
+            url,
+            headers=headers,
+            json=json_payload,
+            timeout=10.0,
+        )
     discord_rate_limiter.observe(
         account_scope,
         method,
@@ -6172,13 +6199,13 @@ async def _post_provider_json(
     )
     try:
         with track_proxy_latency(channel, method):
-            async with httpx.AsyncClient(timeout=timeout_seconds) as client:
-                response = await client.post(
-                    url,
-                    params=params,
-                    headers=headers,
-                    json=json_payload,
-                )
+            response = await get_channel_provider_http_client().post(
+                url,
+                params=params,
+                headers=headers,
+                json=json_payload,
+                timeout=timeout_seconds,
+            )
     except httpx.HTTPError as exc:
         outbound_errors.labels(channel=channel, method=method).inc()
         raise HTTPException(

--- a/backend/tests/test_channel_provider_http.py
+++ b/backend/tests/test_channel_provider_http.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.services import channels
+
+
+@pytest.mark.asyncio
+async def test_channel_provider_http_client_is_reused_and_closed(monkeypatch):
+    clients: list[Any] = []
+
+    class FakeClient:
+        def __init__(self, *, timeout: float):
+            self.timeout = timeout
+            self.closed = False
+            clients.append(self)
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    monkeypatch.setattr(channels.httpx, "AsyncClient", FakeClient)
+    try:
+        first = channels.get_channel_provider_http_client()
+        second = channels.get_channel_provider_http_client()
+
+        assert first is second
+        assert len(clients) == 1
+        assert clients[0].timeout == 30.0
+
+        await channels.close_channel_provider_http_client()
+        assert clients[0].closed is True
+        assert channels.get_channel_provider_http_client() is not first
+        assert len(clients) == 2
+    finally:
+        await channels.close_channel_provider_http_client()

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -16,6 +16,7 @@ from uuid import UUID, uuid4
 
 import httpx
 import pytest
+import pytest_asyncio
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
@@ -685,6 +686,9 @@ class _FakeProviderClient:
     async def __aexit__(self, exc_type, exc, tb):
         return None
 
+    async def aclose(self):
+        return None
+
     async def post(self, url, **kwargs):
         self.calls.append({"url": url, **kwargs})
         return _FakeProviderResponse(
@@ -935,6 +939,15 @@ def _clear_fake_provider_calls() -> None:
     _FailingProviderClient.calls = []
     _SequencedProviderClient.calls = []
     _StatefulDiscordCommandClient.calls = []
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _reset_channel_provider_http_client():
+    await channel_service.close_channel_provider_http_client()
+    try:
+        yield
+    finally:
+        await channel_service.close_channel_provider_http_client()
 
 
 class _MemoryFileStore:
@@ -8546,9 +8559,11 @@ async def test_telegram_proxy_releases_transaction_during_provider_io(
 
     class TransactionObservingProviderClient(_FakeProviderClient):
         fail = False
+        transaction_states: list[bool] = []
 
         async def request(self, method, url, **kwargs):
-            assert not db_session.in_transaction()
+            self.transaction_states.append(db_session.in_transaction())
+            assert self.transaction_states[-1] is False
             if self.fail:
                 raise httpx.ConnectError("network down")
             return await super().request(method, url, **kwargs)
@@ -8567,6 +8582,7 @@ async def test_telegram_proxy_releases_transaction_during_provider_io(
         "app.routes.channel_routers.telegram.httpx.AsyncClient",
         TransactionObservingProviderClient,
     )
+    await channel_service.close_channel_provider_http_client()
 
     sent = await client.post(
         _telegram_bot_path(created, "sendDocument"),
@@ -8575,6 +8591,7 @@ async def test_telegram_proxy_releases_transaction_during_provider_io(
     )
 
     assert sent.status_code == 200
+    assert TransactionObservingProviderClient.transaction_states == [False]
     assert not db_session.in_transaction()
     references = set(
         await db_session.scalars(
@@ -8600,6 +8617,7 @@ async def test_telegram_proxy_releases_transaction_during_provider_io(
     )
 
     assert failed.status_code == 502
+    assert TransactionObservingProviderClient.transaction_states == [False, False]
     assert not db_session.in_transaction()
 
 
@@ -11713,6 +11731,7 @@ async def test_discord_create_message_transparently_returns_provider_error_and_s
         "app.routes.channel_routers.shared.httpx.AsyncClient",
         _FakeProviderClient,
     )
+    await channel_service.close_channel_provider_http_client()
 
     rejected = await client.post(
         "/v1/channels/discord/v10/channels/discord-error-channel/messages",
@@ -11737,6 +11756,7 @@ async def test_discord_create_message_transparently_returns_provider_error_and_s
         "app.routes.channel_routers.shared.httpx.AsyncClient",
         _FailingProviderClient,
     )
+    await channel_service.close_channel_provider_http_client()
     unreachable = await client.post(
         "/v1/channels/discord/v10/channels/discord-error-channel/messages",
         headers={"Authorization": f"Bot {created['agent_token']}"},
@@ -14325,6 +14345,7 @@ async def test_delete_binding_keeps_unpair_durable_when_telegram_notification_fa
         "app.routes.channel_routers.telegram.httpx.AsyncClient",
         _FailingProviderClient,
     )
+    await channel_service.close_channel_provider_http_client()
 
     deleted = await client.delete(f"/v1/channels/{created['id']}/bindings/{binding['id']}")
 
@@ -14376,6 +14397,7 @@ async def test_telegram_webhook_pair_reply_failure_does_not_roll_back_binding(
     ).json()
     _FailingProviderClient.calls = []
     monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FailingProviderClient)
+    await channel_service.close_channel_provider_http_client()
 
     webhook = await client.post(
         f"/v1/channels/telegram/{created['id']}/webhook",
@@ -17566,6 +17588,7 @@ async def test_discord_guild_cannot_move_to_second_link_until_explicit_unpair_an
         "app.routes.channel_routers.shared.httpx.AsyncClient",
         _FakeProviderClient,
     )
+    await channel_service.close_channel_provider_http_client()
     old_channel = await client.get(
         "/v1/channels/discord/v10/channels/link-a-channel",
         headers={"Authorization": f"Bot {link_b_body['agent_token']}"},
@@ -18253,6 +18276,7 @@ async def test_discord_dm_round_trip_is_isolated_from_other_dms_and_guilds(
         "app.routes.channel_routers.shared.httpx.AsyncClient",
         _FakeProviderClient,
     )
+    await channel_service.close_channel_provider_http_client()
     cross_guild_reply = await client.post(
         "/v1/channels/discord/v10/channels/discord-dm-a/messages",
         headers={"Authorization": f"Bot {created['agent_token']}"},
@@ -18291,6 +18315,7 @@ async def test_discord_dm_round_trip_is_isolated_from_other_dms_and_guilds(
         "app.routes.channel_routers.shared.httpx.AsyncClient",
         _FakeProviderClient,
     )
+    await channel_service.close_channel_provider_http_client()
     unpaired = await client.post(
         f"/v1/channels/discord/{created['id']}/webhook",
         headers={"x-clawdi-channel-secret": created["webhook_secret"]},
@@ -18967,6 +18992,9 @@ async def test_telegram_provider_429_preserves_official_retry_after(
             return self
 
         async def __aexit__(self, *_args):
+            return None
+
+        async def aclose(self):
             return None
 
         async def post(self, *_args, **_kwargs):

--- a/backend/tests/test_response_headers_middleware.py
+++ b/backend/tests/test_response_headers_middleware.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+from starlette.types import Message, Receive, Scope, Send
+
+from app.core.config import settings
+from app.middleware.request_id import RequestIDMiddleware
+from app.middleware.security_headers import SecurityHeadersMiddleware
+
+
+@pytest.mark.asyncio
+async def test_request_id_propagates_through_scope_and_response() -> None:
+    seen_request_id: str | None = None
+
+    async def inner(scope: Scope, _receive: Receive, send: Send) -> None:
+        nonlocal seen_request_id
+        seen_request_id = scope["state"]["request_id"]
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 204,
+                "headers": [(b"x-request-id", b"inner-value")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b""})
+
+    app = RequestIDMiddleware(inner)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/", headers={"X-Correlation-ID": "  caller-id  "})
+
+    assert seen_request_id == "caller-id"
+    assert response.headers["X-Request-ID"] == "caller-id"
+
+
+@pytest.mark.asyncio
+async def test_security_headers_preserve_existing_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "environment", "production")
+
+    async def inner(_scope: Scope, _receive: Receive, send: Send) -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"x-frame-options", b"SAMEORIGIN")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    app = SecurityHeadersMiddleware(inner)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/")
+
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-Frame-Options"] == "SAMEORIGIN"
+    assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+    assert response.headers["Strict-Transport-Security"] == ("max-age=31536000; includeSubDomains")
+
+
+@pytest.mark.asyncio
+async def test_response_header_middleware_passes_non_http_scopes_through() -> None:
+    seen: list[str] = []
+
+    async def inner(scope: Scope, _receive: Receive, _send: Send) -> None:
+        seen.append(scope["type"])
+
+    app = SecurityHeadersMiddleware(RequestIDMiddleware(inner))
+
+    async def receive() -> Message:
+        return {"type": "lifespan.shutdown"}
+
+    async def send(_message: Message) -> None:
+        return None
+
+    await app({"type": "lifespan", "asgi": {"version": "3.0"}, "state": {}}, receive, send)
+
+    assert seen == ["lifespan"]

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -111,6 +111,14 @@ const RUNTIME_WATCH_SELF_HEAL_MS = 300_000;
 const RUNTIME_WATCH_INITIAL_BACKOFF_MS = 60_000;
 const RUNTIME_WATCH_MAX_BACKOFF_MS = 300_000;
 
+export function runtimeWatchPollDelayMs(
+	intervalMs: number,
+	random: () => number = Math.random,
+): number {
+	const offset = (random() - 0.5) * intervalMs;
+	return Math.round(intervalMs + offset);
+}
+
 type RuntimeApplyResult =
 	| RuntimeApplyConvergedResult
 	| RuntimeApplyDeferredResult
@@ -1592,7 +1600,11 @@ export async function runtimeWatch(opts: RuntimeWatchOptions = {}) {
 			if (event?.selfReexec === true || opts.abort?.aborted) {
 				return;
 			}
-			if ((await wakeSignal.wait(intervalMs, opts.abort)) === "aborted") return;
+			// Per-cycle jitter keeps hosts started by the same rollout from
+			// synchronizing fallback polls. SSE notifications still wake immediately.
+			if ((await wakeSignal.wait(runtimeWatchPollDelayMs(intervalMs), opts.abort)) === "aborted") {
+				return;
+			}
 		}
 	} finally {
 		notificationSubscription?.abort.abort();

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -25,6 +25,7 @@ import {
 	runtimeAppliedContentIdentity,
 	runtimeInit as runtimeInitWithContext,
 	runtimePublicContentRevision,
+	runtimeWatchPollDelayMs,
 	runtimeWatch as runtimeWatchWithContext,
 } from "../src/commands/runtime";
 import {
@@ -116,6 +117,14 @@ const TEST_PROCESS_UID = process.getuid?.() ?? 1_000;
 const TEST_PROCESS_GID = process.getgid?.() ?? 1_000;
 const TEST_RUNNING_CLI_VERSION = getCliVersion();
 const TEST_RUNNING_CLI_SPEC = `clawdi@${TEST_RUNNING_CLI_VERSION}`;
+
+describe("runtime watch poll delay", () => {
+	it("jitters each fallback poll between half and one-and-a-half intervals", () => {
+		expect([0, 0.5, 1].map((value) => runtimeWatchPollDelayMs(15_000, () => value))).toEqual([
+			7_500, 15_000, 22_500,
+		]);
+	});
+});
 
 function testHostedRuntimeContract(paths: RuntimePaths) {
 	if (!process.env.CLAWDI_RUNTIME_USER) process.env.CLAWDI_RUNTIME_USER = TEST_PROCESS_USER;


### PR DESCRIPTION
## Summary

- replace the remaining two `BaseHTTPMiddleware` response wrappers with pure ASGI middleware
- jitter each hosted runtime fallback poll between 0.5x and 1.5x of its configured interval while preserving immediate SSE wakeups
- reuse one process-wide HTTPX async client for Telegram and Discord provider traffic and close it from FastAPI lifespan

## Root cause and reproduction

I used a real bound API key against `GET /v1/auth/me` on a single local uvicorn process and a migrated local PostgreSQL database.

The request was bisected as follows:

- warmed sequential `/health`: app p50 4.4 ms, p95 6.6 ms
- warmed sequential `/v1/auth/me` before this branch: app p50 7.3 ms, p95 10.2 ms
- direct bound-key auth, without HTTP/middleware/handler: p50 5.28 ms, p95 6.89 ms
- shared authority lock + key-owner SQL: p50 1.51 ms
- joined authority read: p50 1.32 ms

Ninety warmed keep-alive clients issuing the request at the same instant reproduced the production floor:

- HTTP app p50 694-1016 ms across runs
- direct auth at concurrency 90 p50 625-914 ms

The default 10 + 20 overflow SQLAlchemy pool makes those requests run in waves. With a warmed 90-connection diagnostic pool, concurrency-90 timings were much smaller (`SELECT 1` p50 17-23 ms; shared advisory lock p50 69-92 ms; lock plus joined read p50 161-182 ms), but this PR does not raise pool defaults without PostgreSQL capacity evidence.

Hosted runtime watch used a fixed 15-second fallback interval. Ninety hosts started in phase therefore repeatedly recreated the queue. Per-cycle jitter follows the existing heartbeat/reconcile pattern and disperses that fallback traffic. The first tick remains immediate so startup convergence behavior does not change.

## Before / after benchmark

Current branch, one uvicorn process, default DB pool, same real bound key, 90 pre-warmed keep-alive clients:

| Scenario | App p50 | App p95 | Wall p50 | Wall p95 |
| --- | ---: | ---: | ---: | ---: |
| sequential (100 requests) | 7.9 ms | 11.9 ms | 11.0 ms | 15.9 ms |
| fixed 90-client burst (270 requests) | 701.5 ms | 1110.2 ms | 797.3 ms | 1271.6 ms |
| 90 clients with seeded uniform jitter over 15 seconds | 13.8 ms | 19.5 ms | 19.7 ms | 26.2 ms |

The jittered model reduces the reproduced queue floor by about 98% at both app p50 and p95. The fixed-burst result intentionally remains slow: no auth cache, lock bypass, or oversized pool masks the diagnosed behavior.

## Middleware and Sentry findings

`RequestTimingMiddleware`, `BodySizeLimitMiddleware`, and `SkillUploadPreflightMiddleware` were already pure ASGI. Only request ID and security headers still inherited from `BaseHTTPMiddleware`.

In-process middleware microbenchmark:

| Stack | p50 | p95 |
| --- | ---: | ---: |
| bare ASGI | 200 us | 324 us |
| two BaseHTTP wrappers | 685 us | 1230 us |
| complete previous stack | 711 us | 987 us |
| complete pure ASGI stack | 267 us | 424 us |

Sentry is initialized once through its official FastAPI and Starlette integrations. The SDK adds one ASGI transaction wrapper and patches Starlette middleware calls; per-middleware spans are disabled by default. A repeated local A/B using the same six-layer middleware stack, no-op transport, and trace sample rate 0 measured:

- Sentry off: p50 380-382 us, p95 499-566 us
- Sentry on: p50 836-868 us, p95 1125-1260 us

That is measurable sub-millisecond overhead, not the one-second floor, so this PR does not reconfigure Sentry. The sampled Sentry monitor and executor workers also include waiting threads; py-spy sample count alone is not CPU attribution.

## Auth and lock findings

There is no bcrypt, synchronous file I/O, or synchronous DNS lookup in the bound-key auth path. Clerk JWKS work is already offloaded with `asyncio.to_thread`.

The two post-#1211 auth statements remain separate intentionally. Under PostgreSQL READ COMMITTED, combining the advisory-lock acquisition and authority read into one statement could retain a snapshot taken before waiting on an exclusive writer. An explicit one-second exclusive authority lock raised auth to p50 1155 ms / p95 1194 ms, but audited exclusive writer paths are low-frequency lifecycle/admin paths and no production `pg_locks` evidence currently shows sustained writer contention.

## Outbound HTTP findings

The Composio generated client was already a process singleton with lifespan shutdown, WhatsApp already uses a managed client pool, and the safe-public HTTP client owns per-pinned-address transports for SSRF/DNS pinning. The Composio MCP HTTP client has an operation-scoped lifecycle owned by the official MCP transport. Those remain unchanged.

Telegram and Discord provider paths did construct HTTPX clients per operation, matching the repeated SSL-context setup in the production profile. They now share the standard process-wide async client while preserving each request's existing 10/20/30-second timeout and error mapping.

Explicit backend thread offloads are limited to Clerk JWKS, local embeddings, Composio high-level SDK calls, file-store synchronous SDK/filesystem calls, and safe-public DNS resolution. None runs on the normal bound-key auth path.

## Verification

- `bun test packages/cli/tests/runtime.test.ts` (112 passed)
- `bun run typecheck` (4 packages passed)
- focused backend middleware/provider tests (38 passed)
- backend owned type governance (197 files, 0 diagnostics)
- `ruff check app scripts tests alembic`
- `ruff format --check app scripts tests alembic`
- `python scripts/outbound_api_governance.py`

## Requires owner decision (not implemented)

- caching bound-key auth results
- increasing DB pool defaults or adding uvicorn workers without production PostgreSQL/process capacity data
- changing the authority advisory-lock protocol without production `pg_stat_activity` / `pg_locks` evidence
- delaying the first runtime-watch tick with startup jitter, which trades rollout burst smoothing for slower initial convergence
