### PR TITLE
release(cli): 0.14.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.19
+
+Package: `clawdi@0.14.19`
+
+### Changed
+
+- The manifest fallback polling interval is now uniformly jittered around its 15-second average. Fleets no longer phase-align into synchronized request bursts after rollouts, which removes the shared ~1s latency floor those bursts imposed on the control plane.
+
 ## Clawdi CLI v0.14.18
 
 Package: `clawdi@0.14.18`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.18",
+      "version": "0.14.19",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.18",
+	"version": "0.14.19",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Release `clawdi@0.14.19`.

## Contents (since 0.14.18)

- #1225 (CLI part) — uniformly jitter the runtime watch fallback polling interval ([0.5, 1.5) × 15s, expected period unchanged, worst case 22.5s). Kills fleet-wide phase-aligned polling bursts; local reproduction showed p50 701ms → 13.8ms for a 90-client synchronized burst vs jittered.

No on-disk format changes; no upgrade boundary beyond the standing 0.14.17 floor.

## Rollout plan

npm publish on merge → owner test deployments first → fleet via admin rollout (owner approved this upgrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)