### PR TITLE
fix(web): prevent Mava launcher overlap

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3026,6 +3026,30 @@ test("Help opens the hosted Mava live chat", async ({ page }) => {
 	await expect.poll(() => page.evaluate(() => window.__mavaLiveChatToggleCalls)).toBe(1);
 });
 
+test("deploy hides the Mava launcher while other dashboard pages reserve clearance", async ({
+	page,
+}) => {
+	await stubHostedApi(page, { plans: [basicPlan, performancePlan] });
+	await page.goto("/deploy");
+	await expect(page.getByTestId("deploy-action-bar")).toBeVisible();
+	await page.evaluate(() => {
+		const launcher = document.createElement("button");
+		launcher.id = "mava-webchat-launcher";
+		launcher.textContent = "Support";
+		document.body.appendChild(launcher);
+	});
+
+	const launcher = page.locator("#mava-webchat-launcher");
+	const dashboardContent = page.getByTestId("dashboard-page-content");
+	await expect(launcher).toBeHidden();
+	await expect(dashboardContent).toHaveCSS("padding-bottom", "20px");
+
+	await page.locator('a[href="/agents"]').first().click();
+	await expect(page).toHaveURL("/agents");
+	await expect(launcher).toBeVisible();
+	await expect(dashboardContent).toHaveCSS("padding-bottom", "80px");
+});
+
 test("hosted agent overview uses the modular hierarchy", async ({ page }, testInfo) => {
 	const sessionRequests: string[] = [];
 	const aiProviderRequests: string[] = [];

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.css
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.css
@@ -1,0 +1,4 @@
+body:has([data-mava-launcher="hidden"]) #mava-webchat-launcher {
+	/* biome-ignore lint/complexity/noImportantStyles: override the third-party launcher's injected styles */
+	display: none !important;
+}

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -178,6 +178,7 @@ import {
 import { ModelBindingPicker } from "@/hosted/v2/ai-providers/model-binding-picker";
 import { useAiProviderBindingDraft } from "@/hosted/v2/ai-providers/use-ai-provider-binding-draft";
 import { isApiAuthError, normalizeApiError } from "@/lib/api-errors";
+import "./deploy-wizard.css";
 import { env } from "@/lib/env";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import { cn } from "@/lib/utils";
@@ -1111,7 +1112,12 @@ export function DeployWizard() {
 	);
 
 	return (
-		<div data-hosted="true" data-v2="true" className={DEPLOY_PAGE_CLASS}>
+		<div
+			data-hosted="true"
+			data-v2="true"
+			data-mava-launcher="hidden"
+			className={DEPLOY_PAGE_CLASS}
+		>
 			{/* Guard only while idle: a submission in flight continues server-side
 			    (checkout-return recovers it), and the acceptance navigation is the
 			    wizard's own exit, not an abandonment. */}

--- a/apps/web/src/pages/dashboard/layout.tsx
+++ b/apps/web/src/pages/dashboard/layout.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useLocation } from "@tanstack/react-router";
 import { lazy, type ReactNode, Suspense, useCallback, useState } from "react";
 import { AppSidebar } from "@/components/app-sidebar";
 import { BreadcrumbTitleProvider } from "@/components/breadcrumb-title";
@@ -20,6 +21,7 @@ import {
 	UNAVAILABLE_PRODUCT_ACCESS,
 } from "@/lib/product-access";
 import { useHydrated } from "@/lib/use-hydrated";
+import { cn } from "@/lib/utils";
 
 // Cap dashboard content at 1536px (= Tailwind's 2xl screen) and center it in
 // SidebarInset. Below that width the constraint is inert; above it (27"/4K
@@ -55,6 +57,7 @@ const GlobalWalletBalance = IS_HOSTED_BUILD
 	: null;
 
 export default function DashboardLayout({ children }: { children: ReactNode }) {
+	const pathname = useLocation({ select: (location) => location.pathname });
 	const hydrated = useHydrated();
 	const [ownership, setOwnership] = useState<AgentOwnership | null>(null);
 	const [existingCloudDeploymentCount, setExistingCloudDeploymentCount] = useState<number | null>(
@@ -79,6 +82,7 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
 	// existing Cloud deployments remain manageable under rollback.
 	const noExternalControlPlane = !IS_HOSTED_BUILD;
 	const providedOwnership = noExternalControlPlane ? EMPTY_AGENT_OWNERSHIP : ownership;
+	const reserveHostedLauncherClearance = IS_HOSTED_BUILD && pathname !== "/deploy";
 	return (
 		<SidebarProvider
 			defaultOpen
@@ -131,7 +135,14 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
 								<div className="flex flex-1 flex-col">
 									<div className="@container/main flex flex-1 flex-col gap-2">
 										<div
-											className={`mx-auto flex w-full ${CONTENT_MAX_WIDTH} flex-col gap-4 py-4 md:gap-5 md:py-5`}
+											data-testid="dashboard-page-content"
+											className={cn(
+												"mx-auto flex w-full flex-col gap-4 pt-4 md:gap-5 md:pt-5",
+												CONTENT_MAX_WIDTH,
+												reserveHostedLauncherClearance
+													? "pb-[calc(--spacing(20)+env(safe-area-inset-bottom))]"
+													: "pb-4 md:pb-5",
+											)}
 										>
 											{children}
 										</div>


### PR DESCRIPTION
## Summary
- reserve a shared bottom clearance for Mava on hosted dashboard pages
- hide the default Mava launcher on the deploy route while keeping the Live chat entry available
- cover launcher visibility restoration and page clearance with a hosted browser test

## Verification
- Biome check on touched files
- `scripts/test.sh web src/hosted/oss-clean.test.ts src/hosted/billing/deploy/deploy-wizard.test.ts`
- hosted Playwright: `deploy hides the Mava launcher while other dashboard pages reserve clearance`