### PR TITLE
release(cli): 0.14.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
-## Unreleased
+## Clawdi CLI v0.14.20
+
+Package: `clawdi@0.14.20`
 
 ### Added
 

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.19",
+      "version": "0.14.20",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.19",
+	"version": "0.14.20",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary

- publish modular Agent adapters and Pi sessions support
- publish complete, incremental Session events with retry-safe generation uploads
- publish modern Hermes rich Session ingestion

## Verification

- CLI publish manifest check passed
- version 0.14.20 is not present in npm
- product implementation and full suites passed in #1229

## Release order

Merge only after the Cloud backend deployment for 9f7b55fc20bdedbae26ab07d138e5cf72b64b631 succeeds.