### PR TITLE
fix(cli): enable volatile hosted systemd units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Unreleased
+
+### Fixed
+
+- Hosted runtimes now enable generated system services in the volatile systemd unit tree, so immutable images no longer fail by trying to write persistent links under `/etc`.
+
 ## Clawdi CLI v0.14.20
 
 Package: `clawdi@0.14.20`

--- a/packages/cli/src/runtime/systemd-transaction.ts
+++ b/packages/cli/src/runtime/systemd-transaction.ts
@@ -198,7 +198,7 @@ export function applySystemdRuntimeUpdate(
 	}
 	if (system.removed.length > 0) {
 		systemctl(["stop", ...system.removed]);
-		systemctl(["disable", ...system.removed]);
+		systemctl(systemUnitFileMutationArgs(paths, "disable", system.removed));
 	}
 	if (user.removed.length > 0) {
 		runtimeUserSystemctl(paths, ["stop", ...user.removed]);
@@ -237,7 +237,7 @@ export function applySystemdRuntimeUpdate(
 	// Each reconciliation makes at most one recovery attempt per failed unit.
 	// Transitional units remain untouched and fail final proof below.
 	if (enableSystemUnits.length > 0) {
-		systemctl(["enable", ...enableSystemUnits]);
+		systemctl(systemUnitFileMutationArgs(paths, "enable", enableSystemUnits));
 	}
 	if (resetFailedSystemUnits.length > 0) {
 		systemctl(["reset-failed", ...resetFailedSystemUnits]);
@@ -509,7 +509,19 @@ function shouldApplySystemdRuntimeUpdate(paths: ReturnType<typeof getRuntimePath
 	const override = process.env.CLAWDI_SYSTEMD_APPLY?.trim().toLowerCase();
 	if (override === "1" || override === "true") return true;
 	if (override === "0" || override === "false") return false;
+	return usesRuntimeSystemUnitFiles(paths);
+}
+
+function usesRuntimeSystemUnitFiles(paths: ReturnType<typeof getRuntimePaths>): boolean {
 	return paths.systemdSystemRoot === "/run/systemd/system";
+}
+
+function systemUnitFileMutationArgs(
+	paths: ReturnType<typeof getRuntimePaths>,
+	command: "enable" | "disable",
+	units: readonly string[],
+): string[] {
+	return [command, ...(usesRuntimeSystemUnitFiles(paths) ? ["--runtime"] : []), ...units];
 }
 
 function systemctl(args: string[]): string {

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -716,6 +716,7 @@ exec /usr/bin/systemctl "$@"
 				),
 			);
 			expect(firstMutations.length).toBeGreaterThan(0);
+			expect(firstMutations).toContain("enable --runtime clawdi-runtime-sidecar.service");
 
 			await Bun.sleep(500);
 			writeFileSync(systemctlLog, "", { mode: 0o666 });


### PR DESCRIPTION
## Summary

- enable and disable system units with `--runtime` when Clawdi owns `/run/systemd/system`
- preserve existing behavior for non-hosted/custom systemd roots and all user units
- assert the volatile enable contract in the existing PID-1 systemd E2E

## Verification

- `bash scripts/test.sh cli src/runtime/manifest-services.test.ts`
- `bash scripts/test-runtime-official-installer-systemd.sh -t "runs the complete virgin hermes first boot"`
- `bash scripts/test.sh cli src/adapters/openclaw-skill-install.test.ts`
- Biome 2.5.9 on changed TypeScript files
- `git diff --check`

A full serial CLI run progressed through the runtime suite but stalled in the unchanged OpenClaw Skill test file; that file passed immediately when rerun alone in a fresh isolated runner.