### PR TITLE
release(cli): 0.14.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
-## Unreleased
+## Clawdi CLI v0.14.21
+
+Package: `clawdi@0.14.21`
 
 ### Fixed
 

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.20",
+      "version": "0.14.21",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.20",
+	"version": "0.14.21",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary

- publish the hosted volatile-systemd enablement fix as `clawdi@0.14.21`
- finalize the matching changelog entry
- keep package and lockfile versions aligned

## Verification

- confirmed `clawdi@0.14.21` is unpublished
- CLI publish manifest check
- isolated CLI typecheck
- isolated version and smoke tests: 19 pass, 0 fail
- `git diff --check`