### PR TITLE
fix(channels): coalesce Discord command projections

### DIFF
--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -1715,7 +1715,6 @@ async def _replay_discord_commands_on_pair(
             account=account,
             bot_agent_link_id=link.id,
             application_id=application_id,
-            commands=[command for command in commands if isinstance(command, dict)],
             guild_ids={guild_id},
             force=True,
         )

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -79,7 +79,11 @@ _DISCORD_RESPONSE_HEADER_ALLOWLIST = (
 )
 _DISCORD_AGENT_COMMANDS_CONFIG_KEY = "discord_agent_commands"
 _DISCORD_COMMAND_MATERIALIZATIONS_CONFIG_KEY = "discord_command_materializations"
+_DISCORD_COMMAND_PROJECTION_SETTLE_AT_CONFIG_KEY = "discord_command_projection_settle_at"
 _DISCORD_COMMAND_RETRIES_CONFIG_KEY = "discord_command_retries"
+# Diff-based clients send one mutation at a time. Give their durable shadow a
+# short quiet window so one final Guild bulk overwrite replaces the whole burst.
+_DISCORD_COMMAND_PROJECTION_SETTLE_SECONDS = 10.0
 _JSON_VALUE_ADAPTER: TypeAdapter[JsonValue] = TypeAdapter(JsonValue)
 _JSON_OBJECT_ADAPTER: TypeAdapter[dict[str, JsonValue]] = TypeAdapter(dict[str, JsonValue])
 type RequestParam = JsonValue | UploadFile
@@ -394,7 +398,6 @@ async def handle_discord_application_commands(
             link=link,
             application_id=application_id,
             guild_id=guild_id,
-            commands=[],
         )
         return {}
     if request.method == "DELETE" and command_id is not None:
@@ -405,14 +408,11 @@ async def handle_discord_application_commands(
         if len(filtered) == len(command_list):
             return _discord_command_error("Unknown application command", 10063, 404)
         commands[scope_key] = filtered
-        await _store_discord_command_shadow(db, link=link, commands=commands)
-        await _materialize_discord_command_scope(
+        await _store_discord_command_shadow(
             db,
-            account=account,
             link=link,
-            application_id=application_id,
-            guild_id=guild_id,
-            commands=filtered,
+            commands=commands,
+            coalesce_projection=True,
         )
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     if request.method not in {"POST", "PUT", "PATCH"}:
@@ -442,7 +442,6 @@ async def handle_discord_application_commands(
             link=link,
             application_id=application_id,
             guild_id=guild_id,
-            commands=command_list,
         )
         return command_list
 
@@ -458,14 +457,11 @@ async def handle_discord_application_commands(
             if _discord_command_key_conflicts(command_list, command, ignored_id=command_id):
                 return _discord_command_error("Application command already exists", 30032, 400)
             command_list[index] = command
-            await _store_discord_command_shadow(db, link=link, commands=commands)
-            await _materialize_discord_command_scope(
+            await _store_discord_command_shadow(
                 db,
-                account=account,
                 link=link,
-                application_id=application_id,
-                guild_id=guild_id,
-                commands=command_list,
+                commands=commands,
+                coalesce_projection=True,
             )
             return command
         return _discord_command_error("Unknown application command", 10063, 404)
@@ -476,14 +472,11 @@ async def handle_discord_application_commands(
     command = _discord_command_shape(params, application_id=application_id)
     command_list = commands.setdefault(scope_key, [])
     _discord_upsert_command(command_list, command)
-    await _store_discord_command_shadow(db, link=link, commands=commands)
-    await _materialize_discord_command_scope(
+    await _store_discord_command_shadow(
         db,
-        account=account,
         link=link,
-        application_id=application_id,
-        guild_id=guild_id,
-        commands=command_list,
+        commands=commands,
+        coalesce_projection=True,
     )
     return command
 
@@ -689,13 +682,38 @@ async def _store_discord_command_shadow(
     *,
     link: ChannelBotAgentLink,
     commands: DiscordCommandScopes,
+    coalesce_projection: bool = False,
 ) -> None:
     config = dict(link.config) if isinstance(link.config, dict) else {}
     config[_DISCORD_AGENT_COMMANDS_CONFIG_KEY] = _JSON_OBJECT_ADAPTER.validate_python(
         commands, strict=True
     )
+    if coalesce_projection:
+        config[_DISCORD_COMMAND_PROJECTION_SETTLE_AT_CONFIG_KEY] = (
+            datetime.now(UTC) + timedelta(seconds=_DISCORD_COMMAND_PROJECTION_SETTLE_SECONDS)
+        ).isoformat()
     link.config = config
     await db.commit()
+
+
+def _discord_command_projection_is_settled(link: ChannelBotAgentLink) -> bool:
+    config = link.config if isinstance(link.config, dict) else {}
+    raw = config.get(_DISCORD_COMMAND_PROJECTION_SETTLE_AT_CONFIG_KEY)
+    if not isinstance(raw, str):
+        return True
+    try:
+        settle_at = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    return settle_at.tzinfo is None or settle_at <= datetime.now(UTC)
+
+
+def _clear_discord_command_projection_settle_at(link: ChannelBotAgentLink) -> None:
+    config = dict(link.config) if isinstance(link.config, dict) else {}
+    if _DISCORD_COMMAND_PROJECTION_SETTLE_AT_CONFIG_KEY not in config:
+        return
+    config.pop(_DISCORD_COMMAND_PROJECTION_SETTLE_AT_CONFIG_KEY)
+    link.config = config
 
 
 def _discord_command_list_shape(
@@ -1000,7 +1018,6 @@ async def fan_out_discord_global_commands(
     account: ChannelAccount,
     bot_agent_link_id: UUID,
     application_id: str,
-    commands: list[DiscordCommand],
     guild_ids: set[str] | None = None,
     automatic: bool = False,
     force: bool = False,
@@ -1066,6 +1083,9 @@ async def fan_out_discord_global_commands(
         if materializations.get(guild_id) == fingerprint:
             await db.commit()
             continue
+        if automatic and not force and not _discord_command_projection_is_settled(link):
+            await db.commit()
+            continue
         retry = retries.get(guild_id)
         if not force and not _discord_retry_is_due(retry, fingerprint=fingerprint):
             await db.commit()
@@ -1126,6 +1146,12 @@ async def fan_out_discord_global_commands(
         link.config = config
         await db.commit()
         reconciled += 1
+    config = link.config if isinstance(link.config, dict) else {}
+    if automatic and _DISCORD_COMMAND_PROJECTION_SETTLE_AT_CONFIG_KEY in config:
+        await db.refresh(link, with_for_update=True)
+        if _discord_command_projection_is_settled(link):
+            _clear_discord_command_projection_settle_at(link)
+        await db.commit()
     if first_error is not None:
         raise first_error
     return reconciled
@@ -1253,7 +1279,6 @@ async def _materialize_discord_command_scope(
     link: ChannelBotAgentLink,
     application_id: str,
     guild_id: str | None,
-    commands: list[DiscordCommand],
 ) -> None:
     # Agent-defined commands are Link shadows. Never write them to the shared
     # physical global command set or DMs; only materialize them into this
@@ -1291,7 +1316,6 @@ async def _materialize_discord_command_scope(
         account=account,
         bot_agent_link_id=link.id,
         application_id=application_id,
-        commands=commands,
         guild_ids=set(selected_guild_ids),
     )
 

--- a/backend/app/services/discord_command_reconciliation_worker.py
+++ b/backend/app/services/discord_command_reconciliation_worker.py
@@ -79,7 +79,6 @@ async def reconcile_discord_guild_commands(
                         account=account,
                         bot_agent_link_id=link.id,
                         application_id=_discord_application_id(account),
-                        commands=[],
                         guild_ids={guild_id},
                         automatic=False,
                         force=True,
@@ -245,7 +244,6 @@ class DiscordCommandReconciliationWorker:
                         account=account,
                         bot_agent_link_id=link.id,
                         application_id=application_id,
-                        commands=[],
                         automatic=True,
                     )
                     await db.refresh(link)

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -16963,7 +16963,6 @@ async def test_discord_interaction_pair_replays_shadowed_commands_once_for_guild
         account: ChannelAccount,
         bot_agent_link_id: UUID,
         application_id: str,
-        commands: list[dict[str, Any]],
         guild_ids: set[str] | None = None,
         automatic: bool = False,
         force: bool = False,
@@ -16973,7 +16972,6 @@ async def test_discord_interaction_pair_replays_shadowed_commands_once_for_guild
                 "account_id": account.id,
                 "bot_agent_link_id": bot_agent_link_id,
                 "application_id": application_id,
-                "commands": commands,
                 "guild_ids": guild_ids,
                 "automatic": automatic,
                 "force": force,
@@ -17044,7 +17042,6 @@ async def test_discord_interaction_pair_replays_shadowed_commands_once_for_guild
             "account_id": UUID(created["id"]),
             "bot_agent_link_id": UUID(created["agent_link_id"]),
             "application_id": DISCORD_TEST_APPLICATION_ID,
-            "commands": [shadowed_command],
             "guild_ids": {"interaction-replay-guild"},
             "automatic": False,
             "force": True,
@@ -22509,6 +22506,106 @@ async def _make_discord_retry_due(
     await db_session.commit()
 
 
+async def _make_discord_projection_due(
+    db_session: AsyncSession,
+    *,
+    link_id: UUID,
+) -> None:
+    await db_session.rollback()
+    link = await db_session.get(ChannelBotAgentLink, link_id)
+    assert link is not None
+    await db_session.refresh(link, with_for_update=True)
+    config = dict(link.config) if isinstance(link.config, dict) else {}
+    config["discord_command_projection_settle_at"] = (
+        datetime.now(UTC) - timedelta(seconds=1)
+    ).isoformat()
+    link.config = config
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_discord_individual_command_mutations_coalesce_once_per_guild(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guild_ids = {"coalesced-command-guild-a", "coalesced-command-guild-b"}
+    created = await _create_paired_discord_channel(
+        client,
+        name="discord-coalesced-command-mutations",
+        channel_id="coalesced-command-channel",
+        guild_id="coalesced-command-guild-a",
+    )
+    account = await db_session.get(ChannelAccount, UUID(created["id"]))
+    assert account is not None
+    db_session.add(
+        ChannelBinding(
+            account_id=account.id,
+            bot_agent_link_id=UUID(created["agent_link_id"]),
+            user_id=account.user_id,
+            external_chat_id="coalesced-command-guild-b",
+            external_chat_type="guild_text",
+            external_chat_name="coalesced-command-guild-b",
+            paired_external_user_id="discord-pair-user",
+        )
+    )
+    await db_session.commit()
+    provider_calls: list[dict[str, Any]] = []
+
+    async def provider_success(**kwargs: Any) -> shared_router.DiscordProviderResult:
+        provider_calls.append(kwargs)
+        return _discord_provider_result(200, [])
+
+    monkeypatch.setattr(shared_router, "request_discord_provider", provider_success)
+    command_url = f"/v1/channels/discord/v10/applications/{DISCORD_TEST_APPLICATION_ID}/commands"
+    headers = {"Authorization": f"Bot {created['agent_token']}"}
+
+    first = await client.post(
+        command_url,
+        headers=headers,
+        json={"name": "first", "description": "First command"},
+    )
+    second = await client.post(
+        command_url,
+        headers=headers,
+        json={"name": "second", "description": "Second command"},
+    )
+    updated = await client.patch(
+        f"{command_url}/{second.json()['id']}",
+        headers=headers,
+        json={"description": "Updated second command"},
+    )
+    deleted = await client.delete(
+        f"{command_url}/{first.json()['id']}",
+        headers=headers,
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert updated.status_code == 200
+    assert deleted.status_code == 204
+    assert provider_calls == []
+
+    link_id = UUID(created["agent_link_id"])
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    worker = DiscordCommandReconciliationWorker(sessionmaker, poll_interval_seconds=0.01)
+    assert await worker.run_once() == 0
+    assert provider_calls == []
+
+    await _make_discord_projection_due(db_session, link_id=link_id)
+    assert await worker.run_once() == 2
+    assert {
+        call["path"].split("/guilds/", 1)[1].split("/", 1)[0] for call in provider_calls
+    } == guild_ids
+    assert all(
+        json.loads(call["body"])
+        == [{"name": "second", "description": "Updated second command", "type": 1}]
+        for call in provider_calls
+    )
+    listed = await client.get(command_url, headers=headers)
+    assert [command["name"] for command in listed.json()] == ["second"]
+
+
 @pytest.mark.asyncio
 async def test_discord_prod_timeline_reconciles_shadow_after_guild_create(
     client: httpx.AsyncClient,
@@ -22609,7 +22706,7 @@ async def test_discord_prod_timeline_reconciles_shadow_after_guild_create(
 
 
 @pytest.mark.asyncio
-async def test_discord_delete_tombstone_recovers_after_provider_failure(
+async def test_discord_individual_delete_tombstone_coalesces_and_recovers(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
@@ -22637,30 +22734,40 @@ async def test_discord_delete_tombstone_recovers_after_provider_failure(
     stored = await client.put(
         command_url,
         headers={"Authorization": f"Bot {created['agent_token']}"},
-        json=[{"name": "ephemeral", "description": "Ephemeral command"}],
+        json=[
+            {"name": "ephemeral", "description": "Ephemeral command"},
+            {"name": "temporary", "description": "Temporary command"},
+        ],
     )
-    command_id = stored.json()[0]["id"]
+    assert stored.status_code == 200
+    stored_commands = stored.json()
 
-    failed_delete = await client.delete(
-        f"{command_url}/{command_id}",
-        headers={"Authorization": f"Bot {created['agent_token']}"},
-    )
+    for command in stored_commands:
+        deleted = await client.delete(
+            f"{command_url}/{command['id']}",
+            headers={"Authorization": f"Bot {created['agent_token']}"},
+        )
+        assert deleted.status_code == 204
     retry_delete = await client.delete(
-        f"{command_url}/{command_id}",
+        f"{command_url}/{stored_commands[0]['id']}",
         headers={"Authorization": f"Bot {created['agent_token']}"},
     )
 
-    assert failed_delete.status_code == 502
     assert retry_delete.status_code == 404
-    assert len(provider_calls) == 2
+    assert len(provider_calls) == 1
     link_id = UUID(created["agent_link_id"])
+    await _make_discord_projection_due(db_session, link_id=link_id)
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    worker = DiscordCommandReconciliationWorker(sessionmaker, poll_interval_seconds=0.01)
+
+    assert await worker.run_once() == 0
+    assert len(provider_calls) == 2
+    assert provider_calls[1]["body"] == b"[]"
     await _make_discord_retry_due(
         db_session,
         link_id=link_id,
         guild_id=guild_id,
     )
-    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
-    worker = DiscordCommandReconciliationWorker(sessionmaker, poll_interval_seconds=0.01)
 
     assert await worker.run_once() == 1
     assert len(provider_calls) == 3
@@ -23074,7 +23181,6 @@ async def test_discord_projection_lock_prevents_stale_put_after_new_desired_stat
                 account=account,
                 bot_agent_link_id=link_id,
                 application_id=DISCORD_TEST_APPLICATION_ID,
-                commands=[],
                 force=True,
             )
 


### PR DESCRIPTION
## Summary

- persist individual Discord command mutations in the existing durable Link shadow
- debounce diff-based create, edit, and delete bursts before one final Guild bulk overwrite
- preserve immediate bulk operations, per-Guild receipts, retries, pair replay, and projection locking
- remove the unused command snapshot parameter so reconciliation always reads the latest locked shadow

## Upstream behavior

Hermes defaults `DISCORD_COMMAND_SYNC_POLICY` to `safe` and spaces individual delete, upsert, and edit mutations by 4.5 seconds. Discord defines these as individual operations while Guild bulk overwrite replaces the full command list. The proxy now coalesces that diff stream without setting runtime-specific environment variables or detecting Hermes versions.

Telegram uses the provider-native `setMyCommands` and `deleteMyCommands` list/scope operations, and the other supported channels do not expose this proxied dynamic command-registration pattern.

## Verification

- focused final command create/edit/delete and retry tests: 2 passed
- full backend suite: 2475 passed, 12 skipped
- Ruff check and format check: passed
- owned backend type governance: 201 files, 0 errors
- `git diff --check`: passed
