### PR TITLE
feat(sessions): preserve private agent reasoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Unreleased
+
+### Added
+
+- OpenCode is available as a Connected sessions-only adapter. It reads the official SQLite store and incrementally syncs messages, hidden text, private reasoning, tool calls/results, safe attachment metadata, and lifecycle markers.
+- Rich Session events now preserve owner-private reasoning and continuation state while ordinary content, sharing, search, and memory projections remain limited to useful visible messages.
+
 ## Clawdi CLI v0.14.21
 
 Package: `clawdi@0.14.21`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <img src="docs/images/dashboard-preview.png" alt="Clawdi dashboard" width="900">
 </p>
 
-> Think of Clawdi as iCloud for AI agents — install once on any device, and your Claude Code, Codex, Hermes, and OpenClaw agents share memory, secrets, Skill inventory, sessions, and app connections. Agent Skill files remain authoritative on their own filesystems.
+> Think of Clawdi as iCloud for AI agents — install once on any device, and your Claude Code, Codex, Hermes, and OpenClaw agents share memory, secrets, Skill inventory, sessions, and app connections. Pi and OpenCode sessions join the same private history. Agent Skill files remain authoritative on their own filesystems.
 
 The fastest way to try it is hosted Clawdi Cloud. The whole stack is also here: MIT-licensed CLI, FastAPI backend, TanStack Start dashboard, database schema, migrations, and docs. Use the hosted service, self-host it, fork it, or build your own agent sync layer from the pieces.
 
@@ -53,9 +53,9 @@ npm i -g clawdi
 That gets you:
 
 - Browser-based login to Clawdi Cloud
-- Agent auto-detection for Claude Code, Codex, Hermes, and OpenClaw
-- MCP registration so your agent can call Clawdi tools
-- The bundled `clawdi` skill installed into each detected agent
+- Agent auto-detection for Claude Code, Codex, Hermes, OpenClaw, Pi, and OpenCode
+- MCP registration for adapters that expose an MCP lifecycle
+- The bundled `clawdi` skill installed into adapters that support Skills
 - Background sync daemons installed and started for every registered agent
 - A health check that verifies auth, agent paths, vault access, and MCP config
 
@@ -207,7 +207,7 @@ The second is deepening multi-player workflows beyond read-only Project sharing.
 - An agent-to-agent channel for handoff and ask-for-help.
 - Task tracking that every connected agent can use.
 
-We'll also keep adding adapters. Cursor, OpenCode, Amp, Pi, and others. The same memory, skills, and connections follow you everywhere.
+We'll also keep adding adapters. Cursor, Amp, and others are next candidates. Each integration exposes only the modules the underlying agent actually supports.
 
 Want any of this sooner? [Open an issue](https://github.com/Clawdi-AI/clawdi/issues). What's loud is what we build first.
 
@@ -284,8 +284,10 @@ For the deeper map, read [`docs/architecture.md`](docs/architecture.md).
 | Codex | Yes | Yes | Automatic |
 | Hermes | Yes | Yes | Automatic |
 | OpenClaw | Yes | Yes | Manual MCP hint where required |
+| Pi | Yes | No | No |
+| OpenCode | Yes | No | No |
 
-Each agent has a dedicated adapter in [`packages/cli/src/adapters`](packages/cli/src/adapters). Adding another agent means implementing the same adapter shape: detect it, read sessions, read/write skills, and define how commands run with injected env.
+Each agent has a dedicated adapter in [`packages/cli/src/adapters`](packages/cli/src/adapters). An adapter exposes at least one complete module, Sessions or Skills; it never fills unsupported modules with no-op methods.
 
 ## CLI Reference
 
@@ -457,7 +459,7 @@ clawdi doctor
 Common issues:
 
 - **`clawdi auth login` fails** - Re-run login; over SSH use `clawdi auth login --no-open` and paste the complete failed loopback callback URL. `--manual` is legacy API-key compatibility and does not authorize Hosted deploys.
-- **No supported agent detected** - Install a supported agent or pass `--agent claude_code`, `--agent codex`, `--agent hermes`, or `--agent openclaw`.
+- **No supported agent detected** - Install a supported agent or pass `--agent claude_code`, `--agent codex`, `--agent hermes`, `--agent openclaw`, `--agent pi`, or `--agent opencode`.
 - **Memory search is empty** - Add a memory first with `clawdi memory add "..."`, then verify with `clawdi memory search "..."`.
 - **Local backend cannot start because `vector` is missing** - Install `pgvector` for your PostgreSQL 16 instance, or use the included Docker Compose database.
 - **Agent MCP tools look stale** - Run `clawdi setup --agent <type>` again, then `clawdi daemon restart`.

--- a/apps/web/src/components/dashboard/agent-label.test.ts
+++ b/apps/web/src/components/dashboard/agent-label.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	agentDisplayName,
 	agentIdentity,
+	agentTypeLabel,
 	cleanMachineName,
 	compareAgentEnvironments,
 } from "@/components/dashboard/agent-label";
@@ -18,6 +19,11 @@ describe("cleanMachineName", () => {
 });
 
 describe("agentDisplayName", () => {
+	test("uses canonical labels for session-only adapters", () => {
+		expect(agentTypeLabel("pi")).toBe("Pi");
+		expect(agentTypeLabel("opencode")).toBe("OpenCode");
+	});
+
 	test("uses a direct canonical name without appending the runtime", () => {
 		expect(agentIdentity({ name: "e2e-2", agent_type: "hermes" })).toEqual({
 			primaryLabel: "e2e-2",

--- a/apps/web/src/components/dashboard/agent-label.tsx
+++ b/apps/web/src/components/dashboard/agent-label.tsx
@@ -88,6 +88,8 @@ const TYPE_LABEL: Record<string, string> = {
 	codex: "Codex",
 	hermes: "Hermes",
 	openclaw: "OpenClaw",
+	opencode: "OpenCode",
+	pi: "Pi",
 };
 
 export function agentTypeLabel(type: string | null | undefined): string {

--- a/backend/app/schemas/session_events.py
+++ b/backend/app/schemas/session_events.py
@@ -144,8 +144,22 @@ class SessionToolResultEvent(SessionEventBase):
     result_json: str | None = None
 
 
+class SessionReasoningEvent(SessionEventBase):
+    type: Literal["reasoning"]
+    kind: Literal["thinking", "reasoning", "redacted"]
+    parts: list[SessionTextPart] = Field(max_length=1000)
+    payload_json: str | None = None
+    model: str | None = Field(default=None, max_length=100)
+
+    @model_validator(mode="after")
+    def validate_content(self) -> SessionReasoningEvent:
+        if not self.parts and self.payload_json is None:
+            raise ValueError("reasoning events require text or private provider state")
+        return self
+
+
 SessionEvent = Annotated[
-    SessionMessageEvent | SessionToolCallEvent | SessionToolResultEvent,
+    SessionMessageEvent | SessionToolCallEvent | SessionToolResultEvent | SessionReasoningEvent,
     Field(discriminator="type"),
 ]
 

--- a/backend/app/schemas/session_events.py
+++ b/backend/app/schemas/session_events.py
@@ -14,7 +14,7 @@ Sha256Hex = Annotated[str, StringConstraints(pattern=r"^[0-9a-f]{64}$")]
 class SessionEventSource(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    adapter: Literal["claude_code", "codex", "hermes", "openclaw", "pi"]
+    adapter: Literal["claude_code", "codex", "hermes", "openclaw", "pi", "opencode"]
     session_key: str = Field(min_length=1, max_length=500)
     record_id: str = Field(min_length=1, max_length=500)
     record_seq: int | None = Field(default=None, ge=0)

--- a/backend/app/services/agent_environments.py
+++ b/backend/app/services/agent_environments.py
@@ -29,6 +29,7 @@ _AGENT_TYPE_LABELS = {
     "claude-code": "Claude Code",
     "codex": "Codex",
     "pi": "Pi",
+    "opencode": "OpenCode",
 }
 
 

--- a/backend/app/services/session_events.py
+++ b/backend/app/services/session_events.py
@@ -92,6 +92,8 @@ def project_safe_messages(events: Sequence[SessionEvent]) -> list[dict[str, obje
     for event in events:
         if not isinstance(event, SessionMessageEvent) or event.role not in ("user", "assistant"):
             continue
+        if event.semantics is not None and event.semantics.display == "hidden":
+            continue
         text = "\n".join(
             part.text for part in event.parts if isinstance(part, SessionTextPart) and part.text
         )

--- a/backend/tests/test_session_events.py
+++ b/backend/tests/test_session_events.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import httpx
 import pytest
+from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -74,6 +75,13 @@ def test_hermes_event_semantics_are_strict_and_normalized() -> None:
     assert validated.semantics.lifecycle == "inactive"
     assert validated.semantics.display_metadata is not None
     assert validated.semantics.display_metadata.attempt == 2
+
+
+def test_reasoning_event_requires_private_content() -> None:
+    with pytest.raises(ValidationError):
+        EVENT_ADAPTER.validate_python(
+            _event(0, "reasoning", "empty", kind="thinking", parts=[]), strict=True
+        )
 
 
 async def _register_session(
@@ -348,10 +356,11 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
     monkeypatch.setattr(event_routes, "file_store", no_read)
     appended_event = _event(
         5,
-        "message",
+        "reasoning",
         "assistant-2",
-        role="assistant",
-        parts=[{"type": "text", "text": "appended answer"}],
+        kind="thinking",
+        parts=[{"type": "text", "text": "private chain of thought"}],
+        payload_json='{"signature":"opaque"}',
     )
     appended_data, appended_hash = _chunk([appended_event])
     final_head = advance_event_head(base_head, [appended_event])
@@ -399,9 +408,9 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
     second_event = _event(
         6,
         "message",
-        "system-2",
-        role="system",
-        parts=[{"type": "text", "text": "advanced system context"}],
+        "assistant-3",
+        role="assistant",
+        parts=[{"type": "text", "text": "appended answer"}],
     )
     second_data, second_hash = _chunk([second_event])
     second_head = advance_event_head(final_head, [second_event])
@@ -474,9 +483,13 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
         "tool_call",
         "tool_result",
         "message",
-        "message",
+        "reasoning",
         "message",
     ]
+    private_reasoning = private.json()["events"][5]
+    assert private_reasoning["kind"] == "thinking"
+    assert private_reasoning["parts"] == [{"type": "text", "text": "private chain of thought"}]
+    assert private_reasoning["payload_json"] == '{"signature":"opaque"}'
     projected = await client.get(f"/v1/sessions/{session.id}/content")
     assert projected.status_code == 200, projected.text
     assert projected.json() == [
@@ -490,6 +503,8 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
         {"role": "assistant", "content": "appended answer", "model": None, "timestamp": None},
     ]
     assert "private context" not in projected.text
+    assert "private chain of thought" not in projected.text
+    assert "opaque" not in projected.text
     assert "secret tool output" not in projected.text
 
 

--- a/backend/tests/test_session_events.py
+++ b/backend/tests/test_session_events.py
@@ -17,6 +17,7 @@ from app.services.session_events import (
     EVENT_ADAPTER,
     advance_event_head,
     canonical_event_json,
+    project_safe_messages,
 )
 
 
@@ -82,6 +83,42 @@ def test_reasoning_event_requires_private_content() -> None:
         EVENT_ADAPTER.validate_python(
             _event(0, "reasoning", "empty", kind="thinking", parts=[]), strict=True
         )
+
+
+def test_safe_projection_keeps_hidden_opencode_content_private() -> None:
+    visible = EVENT_ADAPTER.validate_python(
+        _event(
+            0,
+            "message",
+            "visible",
+            role="assistant",
+            parts=[{"type": "text", "text": "visible answer"}],
+        ),
+        strict=True,
+    )
+    hidden_payload = _event(
+        1,
+        "message",
+        "ignored",
+        role="assistant",
+        parts=[{"type": "text", "text": "private ignored text"}],
+        semantics={
+            "lifecycle": "active",
+            "display": "hidden",
+            "compressed_summary": False,
+            "display_kind": "ignored_text",
+        },
+    )
+    hidden_payload["source"]["adapter"] = "opencode"
+    hidden_payload["event_id"] = hashlib.sha256(
+        canonical_event_json({"source": hidden_payload["source"], "type": "message"})
+    ).hexdigest()
+    hidden = EVENT_ADAPTER.validate_python(hidden_payload, strict=True)
+
+    assert hidden.source.adapter == "opencode"
+    assert project_safe_messages([visible, hidden]) == [
+        {"role": "assistant", "content": "visible answer"}
+    ]
 
 
 async def _register_session(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,11 +8,11 @@ For contributor commands, start in [`AGENTS.md`](../AGENTS.md).
 
 ```text
 Self-managed machine
-  Claude Code / Codex / Hermes / OpenClaw / Pi
+  Claude Code / Codex / Hermes / OpenClaw / Pi / OpenCode
         | local files + stdio MCP
         v
   clawdi CLI
-    adapters: claude_code, codex, hermes, openclaw, pi
+    adapters: claude_code, codex, hermes, openclaw, pi, opencode
     commands: setup, push, pull, run, daemon, mcp
         |
         | HTTPS /v1, bearer API key
@@ -31,7 +31,7 @@ First-party hosted control planes
 
 cloud-api stores:
   PostgreSQL: metadata, pgvector memories, pg_trgm/FTS indexes
-  object store: session JSONL bodies, skill tarballs, asset blobs
+  object store: session snapshots/event chunks, skill tarballs, asset blobs
 ```
 
 The hosted box is intentionally opaque. This repo defines API contracts,
@@ -136,11 +136,13 @@ Adapter roots are verified in `packages/cli/src/adapters/*`:
 | Hermes | `$HERMES_HOME/state.db` or `~/.hermes/state.db` | `$HERMES_HOME/skills/<category>/<key>/SKILL.md` | `hermes --version` |
 | OpenClaw | `$OPENCLAW_STATE_DIR/agents/<id>/sessions/` or `~/.openclaw/agents/<id>/sessions/` | `agents/<id>/skills/<key>/SKILL.md` | `openclaw --version` |
 | Pi | `$PI_CODING_AGENT_DIR/sessions/**/*.jsonl` or `~/.pi/agent/sessions/**/*.jsonl` | — | `pi --version` |
+| OpenCode | `$OPENCODE_DB` or `$XDG_DATA_HOME/opencode/opencode.db` | — | `opencode --version` |
 
 `AgentAdapter` is core identity plus at least one complete `sessions` or
 `skills` module. Methods inside a present module are mandatory. MCP lifecycle
 belongs to the registry, not either data module. Pi is the first sessions-only
-consumer; the other four adapters expose both modules.
+consumer; OpenCode is also sessions-only, while the other four adapters expose
+both modules.
 
 ## Sync Engine
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,18 +188,20 @@ Uniqueness and object keys include the immutable origin, so equal local IDs from
 different Agents cannot collide.
 
 Legacy `snapshot-v1` message arrays remain readable. `events-v1` stores strict
-Message/ToolCall/ToolResult NDJSON in immutable generation chunks with a DB
-chunk index, revision, count, and canonical chained head. Append writes only new
-objects; truncation stages a generation and CAS-commits it. Private `/events`
-reads rich content, while `/content`, public sharing, exports, and memory inputs
-project only user/assistant text. Attachment parts identify either a safe
-external reference or an explicit metadata-only record; this protocol does not
-store attachment bodies or local paths. Hidden reasoning and encrypted provider
-state are excluded before upload. A worker removes abandoned staging generations
-after one day and superseded committed generations after a seven-day read grace
-period; the current generation is never eligible. Deleting an Agent nulls `environment_id`
-without deleting history; deletion suppression remains fenced to immutable
-origin, with legacy origin-less suppressions read as wildcards.
+Message/ToolCall/ToolResult/Reasoning NDJSON in immutable generation chunks with
+a DB chunk index, revision, count, and canonical chained head. Append writes only
+new objects; truncation stages a generation and CAS-commits it. Owner-only
+`/events` reads the complete rich stream, including model reasoning and the
+reasoning-specific continuation state needed to preserve it. `/content`, public
+sharing, exports, search, and memory inputs continue to project only useful
+user/assistant text. Attachment parts identify either a safe external reference
+or an explicit metadata-only record; this protocol does not store attachment
+bodies, local paths, or duplicate provider message envelopes. A worker removes
+abandoned staging generations after one day and superseded committed generations
+after a seven-day read grace period; the current generation is never eligible.
+Deleting an Agent nulls `environment_id` without deleting history; deletion
+suppression remains fenced to immutable origin, with legacy origin-less
+suppressions read as wildcards.
 
 ## Projects And Agent Use
 

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -284,6 +284,11 @@ Shape:
   owner-private thinking with visible-only message projection; Pi has no Skills
   fixture because it is sessions-only
 
+OpenCode's adapter test creates the consumed subset of the pinned upstream
+SQLite schema in a temporary directory. That fixture is intentionally generated
+per test so the same test can mutate the database and verify queue-time
+backing-store re-reads without committing a binary database copy.
+
 Fixtures are committed (not regenerated on every test run). Regenerate only
 when an upstream agent's on-disk format changes and a test breaks.
 

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -281,8 +281,8 @@ Shape:
 - `openclaw/` — `sessions.json` index + `<id>.jsonl` transcript (with a `model_change` event); `skills/demo` + `skills/node_modules` (SKIP_DIRS)
 - `pi/` — official JSONL v1-v4 records covering active-leaf branching,
   compaction retained tails, visible tools, attachment metadata, and
-  hidden-thinking exclusion; Pi has no Skills fixture because it is
-  sessions-only
+  owner-private thinking with visible-only message projection; Pi has no Skills
+  fixture because it is sessions-only
 
 Fixtures are committed (not regenerated on every test run). Regenerate only
 when an upstream agent's on-disk format changes and a test breaks.

--- a/docs/designs/cli-agent-adapter-capabilities.md
+++ b/docs/designs/cli-agent-adapter-capabilities.md
@@ -46,11 +46,11 @@ leaf, applies compaction retained-tail semantics, ignores a partial final line,
 and re-reads the current backing store when a queued item drains. Path scans
 fall back to a complete scan when their containment cannot be proven.
 
-Pi uploads namespaced identities (`pi.<session-id>`), visible messages, tool
-calls/results, attachment metadata/references, visible custom messages, and
-compaction/branch summaries. Provider thinking content and signatures are never
-uploaded. Pi is Connected-only: it is not a Hosted runtime, plugin, channel,
-control-plane, or deployment type.
+Pi uploads namespaced identities (`pi.<session-id>`), messages, tool
+calls/results, attachment metadata/references, visible custom messages,
+compaction/branch summaries, and owner-private reasoning/signatures. Default
+message projections omit the private reasoning events. Pi is Connected-only: it
+is not a Hosted runtime, plugin, channel, control-plane, or deployment type.
 
 ## Session Content Protocols
 
@@ -63,26 +63,28 @@ rather than claiming event fidelity. A new CLI probes
 `/v1/sessions/upload-capabilities`; a 404 selects `snapshot-v1`, so an old
 server never receives an events envelope.
 
-`events-v1` is strict and private. It contains only continuous, source-identified
-`Message`, `ToolCall`, and `ToolResult` events. Message content is text or
-an `AttachmentRef` with stable identity and `external` or `metadata_only`
-availability. Only safe HTTPS references and opaque provider references carry a
-URI. Inline bytes become hash/size metadata, local paths expose at most a
-basename, and no attachment body is stored by this version. The schema forbids
-extra fields. Hidden chain of thought, encrypted continuation state, and
-redacted thinking are excluded at the adapter boundary.
+`events-v1` is strict and private. It contains continuous, source-identified
+`Message`, `ToolCall`, `ToolResult`, and owner-private `Reasoning` events. Message
+content is text or an `AttachmentRef` with stable identity and `external` or
+`metadata_only` availability. Reasoning stores its own text plus only explicit
+continuation fields such as signatures, encrypted state, redacted data, and
+reasoning details/items; it never wraps a complete source record. Only safe
+HTTPS references and opaque provider references carry a URI. Inline bytes become
+hash/size metadata, local paths expose at most a basename, and no attachment body
+is stored by this version. The schema forbids extra fields. Default content,
+share, export, search, and memory projections ignore Reasoning events.
 
 Hermes events follow `messages.id` insertion order and retain every durable
 row, including compacted copies and rewound inactive rows. Normalized lifecycle,
 compressed-summary, display-kind, and safe presentation metadata let a later
 projection reproduce Hermes' active/display/audit views without discarding the
-complete store. Dedicated reasoning columns, provider API envelopes, and Codex
-reasoning/message carrier fields are never selected.
+complete store. Dedicated reasoning columns and Codex reasoning items become
+Reasoning events. Provider API envelopes and Codex message carrier fields remain
+unselected because they duplicate visible message semantics.
 
-Codex `AgentMessage` records are emitted only when their persisted content is
-entirely plaintext. Because events-v1 has no author/recipient fields, the
-visible author-to-recipient context is downgraded into an explicit developer
-message prefix; any record containing encrypted content is omitted. Tool-search
+Codex `AgentMessage` records preserve plaintext author-to-recipient content as an
+explicit developer message prefix. Encrypted continuation blocks become separate
+Reasoning events instead of suppressing the visible handoff. Tool-search
 calls/results and image-generation results map to the strict tool events, with
 generated image bytes reduced to attachment metadata.
 

--- a/docs/designs/cli-agent-adapter-capabilities.md
+++ b/docs/designs/cli-agent-adapter-capabilities.md
@@ -7,7 +7,7 @@
 | Owner | CLI and Session sync |
 
 > HISTORICAL - this document replaces the former mandatory-Session PR-A plan.
-> Pi is now the first real session-only adapter, so the deferred module split is complete.
+> Pi and OpenCode are real session-only adapters, so the deferred module split is complete.
 
 ## Adapter Contract
 
@@ -26,11 +26,11 @@ capability flags, no no-op implementations, and no string capability table.
 MCP registration is an optional registry lifecycle with both `register` and
 `unregister`; it is not a data module.
 
-Claude Code, Codex, Hermes, and OpenClaw expose Sessions and Skills. Pi exposes
-Sessions only. The sync engine narrows modules once, starts only their producers,
-and shares one API client, heartbeat, health state, supervisor, persisted queue,
-and queue drain. A queue item for a missing module or an old unfenced Session
-item is dropped fail-closed at that single drain boundary.
+Claude Code, Codex, Hermes, and OpenClaw expose Sessions and Skills. Pi and
+OpenCode expose Sessions only. The sync engine narrows modules once, starts only
+their producers, and shares one API client, heartbeat, health state, supervisor,
+persisted queue, and queue drain. A queue item for a missing module or an old
+unfenced Session item is dropped fail-closed at that single drain boundary.
 
 Foreground commands, setup/teardown, doctor, inbox, help, Skill SSE and
 reconciliation, and Connected dashboard routes gate on real modules. Cloud
@@ -51,6 +51,23 @@ calls/results, attachment metadata/references, visible custom messages,
 compaction/branch summaries, and owner-private reasoning/signatures. Default
 message projections omit the private reasoning events. Pi is Connected-only: it
 is not a Hosted runtime, plugin, channel, control-plane, or deployment type.
+
+## OpenCode Driver
+
+OpenCode reads the official SQLite store at `$OPENCODE_DB` or
+`$XDG_DATA_HOME/opencode/opencode.db`. It follows the upstream ordering contract
+(`message.time_created, message.id`, then `part.id`) and uses stable message,
+part, and call IDs for incremental event identity. The database, WAL, and
+rollback journal form one watch group; a change triggers a complete inventory
+scan, while queue drain resolves one Session by exact SQL identity.
+
+OpenCode uploads namespaced identities (`opencode.<session-id>`), visible and
+hidden text, owner-private reasoning/provider metadata, tool calls/results,
+safe structured results, attachment metadata, and normalized lifecycle markers.
+Provider request envelopes, snapshot bodies, patch paths, and local attachment
+paths are not copied. OpenCode is Connected-only and exposes no fake Skills or
+MCP lifecycle. Clawdi can only preserve rows still present in OpenCode's current
+database; it cannot reconstruct history OpenCode has physically deleted.
 
 ## Session Content Protocols
 
@@ -119,7 +136,7 @@ limit enter durable blocked health instead of retrying every five minutes.
 ## Verification
 
 ```bash
-bun run --cwd packages/cli test -- src/adapters/pi.test.ts src/lib/session-upload.test.ts src/serve/sync-engine.test.ts
+bun run --cwd packages/cli test -- src/adapters/pi.test.ts src/adapters/opencode.test.ts src/lib/session-upload.test.ts src/serve/sync-engine.test.ts
 cd backend && uv run pytest -q tests/test_session_events.py tests/test_session_deletion.py tests/test_sessions.py
 ```
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,6 +54,7 @@
 		"codex",
 		"openclaw",
 		"hermes",
+		"opencode",
 		"ai-agents",
 		"skills",
 		"memory",

--- a/packages/cli/src/adapters/agent-types.ts
+++ b/packages/cli/src/adapters/agent-types.ts
@@ -1,3 +1,10 @@
 /** Canonical agent identities supported by the CLI. */
-export const AGENT_TYPES = ["claude_code", "codex", "openclaw", "hermes", "pi"] as const;
+export const AGENT_TYPES = [
+	"claude_code",
+	"codex",
+	"openclaw",
+	"hermes",
+	"pi",
+	"opencode",
+] as const;
 export type AgentType = (typeof AGENT_TYPES)[number];

--- a/packages/cli/src/adapters/base.ts
+++ b/packages/cli/src/adapters/base.ts
@@ -81,7 +81,21 @@ export interface SessionToolResultEvent extends SessionEventBase {
 	result_json?: string;
 }
 
-export type SessionEvent = SessionMessageEvent | SessionToolCallEvent | SessionToolResultEvent;
+/** Owner-private model reasoning. Display/search projections never consume this event. */
+export interface SessionReasoningEvent extends SessionEventBase {
+	type: "reasoning";
+	kind: "thinking" | "reasoning" | "redacted";
+	parts: Array<{ type: "text"; text: string }>;
+	/** Canonical JSON containing only non-display provider state such as signatures. */
+	payload_json?: string;
+	model?: string;
+}
+
+export type SessionEvent =
+	| SessionMessageEvent
+	| SessionToolCallEvent
+	| SessionToolResultEvent
+	| SessionReasoningEvent;
 
 export interface RawSession {
 	localSessionId: string;

--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -28,6 +28,7 @@ import {
 	type JsonObject,
 	jsonObject,
 	jsonString,
+	reasoningContent,
 	stableRecordId,
 	toolResultContent,
 	visibleContentParts,
@@ -96,6 +97,16 @@ function claudeEventDrafts(
 	for (let index = 0; index < blocks.length; index++) {
 		const block = jsonObject(blocks[index]);
 		if (!block) continue;
+		const reasoning = role === "assistant" ? reasoningContent(block) : null;
+		if (reasoning) {
+			drafts.push({
+				type: "reasoning",
+				...reasoning,
+				source: eventSource(index + 1),
+				...(timestamp ? { timestamp } : {}),
+				...(model ? { model } : {}),
+			});
+		}
 		if (role === "assistant" && block.type === "tool_use") {
 			const callId = jsonString(block.id);
 			const name = jsonString(block.name);
@@ -123,7 +134,6 @@ function claudeEventDrafts(
 				...(timestamp ? { timestamp } : {}),
 			});
 		}
-		// `thinking` and `redacted_thinking` blocks never produce events.
 	}
 	return drafts;
 }

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -28,6 +28,7 @@ import {
 	type JsonObject,
 	jsonObject,
 	jsonString,
+	reasoningContent,
 	stableRecordId,
 	toolResultContent,
 	visibleContentParts,
@@ -102,6 +103,19 @@ function codexEventDrafts(
 						type: "message",
 						role,
 						parts,
+						source: eventSource(),
+						...(timestamp ? { timestamp } : {}),
+					},
+				]
+			: [];
+	}
+	if (payloadType === "reasoning") {
+		const reasoning = reasoningContent(payload);
+		return reasoning
+			? [
+					{
+						type: "reasoning",
+						...reasoning,
 						source: eventSource(),
 						...(timestamp ? { timestamp } : {}),
 					},
@@ -207,7 +221,6 @@ function codexEventDrafts(
 	}
 	if (payloadType === "agent_message") {
 		const content = Array.isArray(payload.content) ? payload.content : [];
-		if (content.some((item) => jsonObject(item)?.type === "encrypted_content")) return [];
 		const text = content
 			.map((item) => jsonObject(item))
 			.filter((item): item is JsonObject => item?.type === "input_text")
@@ -216,16 +229,27 @@ function codexEventDrafts(
 			.join("\n");
 		const author = jsonString(payload.author);
 		const recipient = jsonString(payload.recipient);
-		if (!text || !author || !recipient) return [];
-		return [
-			{
+		const drafts: SessionEventDraft[] = [];
+		if (text && author && recipient) {
+			drafts.push({
 				type: "message",
 				role: "developer",
 				parts: [{ type: "text", text: `[Agent message from ${author} to ${recipient}]\n${text}` }],
 				source: eventSource(),
 				...(timestamp ? { timestamp } : {}),
-			},
-		];
+			});
+		}
+		for (let index = 0; index < content.length; index++) {
+			const reasoning = reasoningContent(content[index]);
+			if (!reasoning) continue;
+			drafts.push({
+				type: "reasoning",
+				...reasoning,
+				source: eventSource(index + 1),
+				...(timestamp ? { timestamp } : {}),
+			});
+		}
+		return drafts;
 	}
 	if (payloadType === "local_shell_call") {
 		const callId = jsonString(payload.call_id) ?? jsonString(payload.id);
@@ -255,8 +279,6 @@ function codexEventDrafts(
 			},
 		];
 	}
-	// `reasoning`, including `encrypted_content`, is provider continuation
-	// state and is never part of events-v1.
 	return [];
 }
 

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -31,6 +31,7 @@ import {
 	canonicalStructuredString,
 	jsonObject,
 	jsonString,
+	reasoningContent,
 	toolResultContent,
 	visibleContentParts,
 } from "./rich-event-mapping";
@@ -66,6 +67,10 @@ interface ModernMessageRow extends MessageRow {
 	compacted: number;
 	display_kind: string | null;
 	display_metadata: string | null;
+	reasoning: string | null;
+	reasoning_content: string | null;
+	reasoning_details: string | null;
+	codex_reasoning_items: string | null;
 }
 
 interface TableInfoRow {
@@ -85,6 +90,10 @@ const MODERN_MESSAGE_OPTIONAL_COLUMNS = [
 	["compacted", "0"],
 	["display_kind", "NULL"],
 	["display_metadata", "NULL"],
+	["reasoning", "NULL"],
+	["reasoning_content", "NULL"],
+	["reasoning_details", "NULL"],
+	["codex_reasoning_items", "NULL"],
 ] as const;
 
 const HERMES_CONTENT_JSON_PREFIX = "\0json:";
@@ -143,6 +152,32 @@ function stripHiddenReasoning(text: string): string {
 	return visible.replace(ORPHAN_REASONING_CLOSE, "");
 }
 
+function hiddenReasoningTexts(text: string): string[] {
+	const texts: string[] = [];
+	for (const match of text.matchAll(CLOSED_REASONING_BLOCK)) {
+		const value = match[0].replace(/^<[^>]+>/, "").replace(/<\/[^>]+>$/, "");
+		if (value) texts.push(value);
+	}
+	for (const match of text.matchAll(OPEN_REASONING_TAG)) {
+		const index = match.index;
+		const lineStart = text.lastIndexOf("\n", index - 1) + 1;
+		if (text.slice(lineStart, index).trim().length > 0) continue;
+		const tail = text.slice(index + match[0].length);
+		if (!tail.includes("</") && tail) texts.push(tail);
+		break;
+	}
+	return texts;
+}
+
+function decodeOptionalJson(value: string | null): unknown {
+	if (value === null) return undefined;
+	try {
+		return JSON.parse(value);
+	} catch {
+		return value;
+	}
+}
+
 function safeHermesContent(content: string | null, scrubReasoning: boolean): unknown {
 	const decoded = decodeHermesContent(content);
 	if (!scrubReasoning) return decoded;
@@ -159,6 +194,30 @@ function hermesContentParts(content: string | null, scrubReasoning: boolean): Se
 	return visibleContentParts(safeHermesContent(content, scrubReasoning)).filter(
 		(part) => part.type !== "text" || part.text.length > 0,
 	);
+}
+
+function hermesReasoning(row: ModernMessageRow) {
+	if (row.role !== "assistant") return null;
+	const decoded = decodeHermesContent(row.content);
+	const texts: string[] = [];
+	if (row.reasoning) texts.push(row.reasoning);
+	if (row.reasoning_content) texts.push(row.reasoning_content);
+	const collect = (value: unknown) => {
+		if (typeof value === "string") texts.push(...hiddenReasoningTexts(value));
+		else {
+			const block = jsonObject(value);
+			if (typeof block?.text === "string") texts.push(...hiddenReasoningTexts(block.text));
+		}
+	};
+	if (Array.isArray(decoded)) decoded.forEach(collect);
+	else collect(decoded);
+	const uniqueTexts = [...new Set(texts.filter(Boolean))];
+	return reasoningContent({
+		type: "reasoning",
+		summary: uniqueTexts.map((text) => ({ type: "summary_text", text })),
+		reasoning_details: decodeOptionalJson(row.reasoning_details),
+		codex_reasoning_items: decodeOptionalJson(row.codex_reasoning_items),
+	});
 }
 
 function timestampIso(value: number): string | undefined {
@@ -247,6 +306,17 @@ function hermesEventDrafts(
 	});
 	const drafts: SessionEventDraft[] = [];
 	const calls = parseToolCalls(row.tool_calls);
+	const reasoning = hermesReasoning(row);
+	if (reasoning) {
+		drafts.push({
+			type: "reasoning",
+			...reasoning,
+			source: source(0),
+			semantics,
+			...(timestamp ? { timestamp } : {}),
+			...(model ? { model } : {}),
+		});
+	}
 	if (
 		row.role === "user" ||
 		row.role === "assistant" ||

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -40,6 +40,7 @@ import {
 	type JsonObject,
 	jsonObject,
 	jsonString,
+	reasoningContent,
 	stableRecordId,
 	toolResultContent,
 	visibleContentParts,
@@ -196,6 +197,16 @@ function openClawEventDrafts(
 	for (let index = 0; index < blocks.length; index++) {
 		const block = jsonObject(blocks[index]);
 		if (!block) continue;
+		const reasoning = role === "assistant" ? reasoningContent(block) : null;
+		if (reasoning) {
+			drafts.push({
+				type: "reasoning",
+				...reasoning,
+				source: eventSource(index + 1),
+				...(timestamp ? { timestamp } : {}),
+				...(model ? { model } : {}),
+			});
+		}
 		if (role === "assistant" && (block.type === "toolCall" || block.type === "tool_use")) {
 			const callId = jsonString(block.id);
 			const name = jsonString(block.name);
@@ -236,7 +247,6 @@ function openClawEventDrafts(
 				...(timestamp ? { timestamp } : {}),
 			});
 	}
-	// OpenClaw `thinking` blocks are intentionally ignored.
 	return drafts;
 }
 

--- a/packages/cli/src/adapters/opencode.test.ts
+++ b/packages/cli/src/adapters/opencode.test.ts
@@ -1,0 +1,379 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { OpenCodeAdapter } from "./opencode";
+
+const originalDb = process.env.OPENCODE_DB;
+const originalXdgData = process.env.XDG_DATA_HOME;
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+	if (originalDb === undefined) delete process.env.OPENCODE_DB;
+	else process.env.OPENCODE_DB = originalDb;
+	if (originalXdgData === undefined) delete process.env.XDG_DATA_HOME;
+	else process.env.XDG_DATA_HOME = originalXdgData;
+	for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function insertJson(db: Database, table: "message" | "part", values: (string | number)[]): void {
+	if (table === "message") {
+		db.run(
+			"INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+			values,
+		);
+		return;
+	}
+	db.run(
+		"INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
+		values,
+	);
+}
+
+function fixtureDatabase(): { adapter: OpenCodeAdapter; databasePath: string } {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-opencode-adapter-"));
+	temporaryRoots.push(root);
+	const databasePath = join(root, "data", "opencode.db");
+	mkdirSync(dirname(databasePath), { recursive: true });
+	process.env.OPENCODE_DB = databasePath;
+	delete process.env.XDG_DATA_HOME;
+	const db = new Database(databasePath);
+	db.exec(`
+		CREATE TABLE session (
+			id TEXT PRIMARY KEY,
+			directory TEXT NOT NULL,
+			title TEXT NOT NULL,
+			version TEXT NOT NULL,
+			tokens_input INTEGER NOT NULL DEFAULT 0,
+			tokens_output INTEGER NOT NULL DEFAULT 0,
+			tokens_reasoning INTEGER NOT NULL DEFAULT 0,
+			tokens_cache_read INTEGER NOT NULL DEFAULT 0,
+			tokens_cache_write INTEGER NOT NULL DEFAULT 0,
+			time_created INTEGER NOT NULL,
+			time_updated INTEGER NOT NULL,
+			time_archived INTEGER,
+			model TEXT,
+			agent TEXT
+		);
+		CREATE TABLE message (
+			id TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			time_created INTEGER NOT NULL,
+			time_updated INTEGER NOT NULL,
+			data TEXT NOT NULL
+		);
+		CREATE TABLE part (
+			id TEXT PRIMARY KEY,
+			message_id TEXT NOT NULL,
+			session_id TEXT NOT NULL,
+			time_created INTEGER NOT NULL,
+			time_updated INTEGER NOT NULL,
+			data TEXT NOT NULL
+		);
+	`);
+	const started = Date.parse("2026-08-27T10:00:00.000Z");
+	db.run(
+		`INSERT INTO session (
+			id, directory, title, version, tokens_input, tokens_output,
+			tokens_reasoning, tokens_cache_read, tokens_cache_write,
+			time_created, time_updated, model, agent
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		[
+			"ses_fixture",
+			"/workspace/opencode",
+			"New session - 2026-08-27T10:00:00.000Z",
+			"1.18.23",
+			120,
+			42,
+			18,
+			9,
+			3,
+			started,
+			started + 5000,
+			JSON.stringify({ id: "claude-sonnet-4-5", providerID: "anthropic" }),
+			"build",
+		],
+	);
+	insertJson(db, "message", [
+		"msg_user",
+		"ses_fixture",
+		started + 1000,
+		started + 1000,
+		JSON.stringify({
+			role: "user",
+			time: { created: started + 1000 },
+			agent: "build",
+			model: { providerID: "anthropic", modelID: "claude-sonnet-4-5" },
+			system: "Private OpenCode system instruction",
+			providerEnvelope: "must-not-upload",
+		}),
+	]);
+	insertJson(db, "part", [
+		"prt_001",
+		"msg_user",
+		"ses_fixture",
+		started + 1000,
+		started + 1000,
+		JSON.stringify({ type: "text", text: "Inspect this workspace" }),
+	]);
+	insertJson(db, "part", [
+		"prt_002",
+		"msg_user",
+		"ses_fixture",
+		started + 1001,
+		started + 1001,
+		JSON.stringify({
+			type: "file",
+			mime: "text/plain",
+			filename: "report.txt",
+			url: "file:///private/workspace/report.txt",
+			source: { type: "file", path: "/private/workspace/report.txt" },
+		}),
+	]);
+	insertJson(db, "message", [
+		"msg_assistant",
+		"ses_fixture",
+		started + 2000,
+		started + 5000,
+		JSON.stringify({
+			role: "assistant",
+			time: { created: started + 2000, completed: started + 5000 },
+			parentID: "msg_user",
+			providerID: "anthropic",
+			modelID: "claude-sonnet-4-5",
+			mode: "build",
+			agent: "build",
+			path: { cwd: "/private/workspace", root: "/private" },
+			providerEnvelope: "must-not-upload",
+		}),
+	]);
+	insertJson(db, "part", [
+		"prt_003",
+		"msg_assistant",
+		"ses_fixture",
+		started + 2000,
+		started + 2100,
+		JSON.stringify({
+			type: "reasoning",
+			text: "Private OpenCode reasoning",
+			metadata: { anthropic: { signature: "opaque-signature" } },
+			time: { start: started + 2000, end: started + 2100 },
+		}),
+	]);
+	insertJson(db, "part", [
+		"prt_004",
+		"msg_assistant",
+		"ses_fixture",
+		started + 2200,
+		started + 2200,
+		JSON.stringify({ type: "text", text: "Visible OpenCode answer" }),
+	]);
+	insertJson(db, "part", [
+		"prt_005",
+		"msg_assistant",
+		"ses_fixture",
+		started + 2300,
+		started + 3000,
+		JSON.stringify({
+			type: "tool",
+			callID: "call_read",
+			tool: "read",
+			state: {
+				status: "completed",
+				input: { filePath: "/workspace/opencode/README.md", apiKey: "tool-input-preserved" },
+				output: "Tool output",
+				title: "Read README",
+				metadata: { lines: 12 },
+				time: { start: started + 2300, end: started + 3000 },
+				attachments: [
+					{
+						type: "file",
+						mime: "image/png",
+						filename: "preview.png",
+						url: "file:///private/output/preview.png",
+					},
+				],
+			},
+		}),
+	]);
+	insertJson(db, "part", [
+		"prt_006",
+		"msg_assistant",
+		"ses_fixture",
+		started + 3100,
+		started + 3200,
+		JSON.stringify({
+			type: "tool",
+			callID: "call_shell",
+			tool: "shell",
+			state: {
+				status: "error",
+				input: { command: "false" },
+				error: "Command failed",
+				metadata: { exitCode: 1 },
+				time: { start: started + 3100, end: started + 3200 },
+			},
+		}),
+	]);
+	insertJson(db, "part", [
+		"prt_007",
+		"msg_assistant",
+		"ses_fixture",
+		started + 3300,
+		started + 3300,
+		JSON.stringify({ type: "text", text: "Internal ignored separator", ignored: true }),
+	]);
+	insertJson(db, "part", [
+		"prt_008",
+		"msg_assistant",
+		"ses_fixture",
+		started + 4000,
+		started + 4000,
+		JSON.stringify({
+			type: "step-finish",
+			reason: "stop",
+			cost: 0.02,
+			tokens: { input: 120, output: 42, reasoning: 18, cache: { read: 9, write: 3 } },
+		}),
+	]);
+	insertJson(db, "part", [
+		"prt_009",
+		"msg_assistant",
+		"ses_fixture",
+		started + 4100,
+		started + 4100,
+		JSON.stringify({
+			type: "patch",
+			hash: "private-snapshot-hash",
+			files: ["/private/workspace/secret.ts"],
+		}),
+	]);
+	db.close();
+	return { adapter: new OpenCodeAdapter(), databasePath };
+}
+
+describe("OpenCode session adapter", () => {
+	test("follows the official XDG default and relative database override", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-opencode-paths-"));
+		temporaryRoots.push(root);
+		delete process.env.OPENCODE_DB;
+		process.env.XDG_DATA_HOME = root;
+		const adapter = new OpenCodeAdapter();
+		expect(adapter.sessions.watchPaths()[0]).toBe(join(root, "opencode", "opencode.db"));
+
+		process.env.OPENCODE_DB = "work.db";
+		expect(adapter.sessions.watchPaths()[0]).toBe(join(root, "opencode", "work.db"));
+	});
+
+	test("maps the official SQLite store to complete private events and a useful projection", async () => {
+		const { adapter, databasePath } = fixtureDatabase();
+		expect(await adapter.detect()).toBe(true);
+		expect("skills" in adapter).toBe(false);
+		expect(adapter.sessions.watchPaths()).toEqual([
+			databasePath,
+			`${databasePath}-wal`,
+			`${databasePath}-journal`,
+		]);
+
+		const scan = await adapter.sessions.collect({ kind: "complete" });
+		expect(scan).toMatchObject({ coverage: "complete", dedupedCount: 0 });
+		expect(scan.sessions).toHaveLength(1);
+		const session = scan.sessions[0];
+		expect(session).toMatchObject({
+			localSessionId: "opencode.ses_fixture",
+			projectPath: "/workspace/opencode",
+			messageCount: 2,
+			inputTokens: 120,
+			outputTokens: 42,
+			cacheReadTokens: 9,
+			model: "claude-sonnet-4-5",
+			modelsUsed: ["claude-sonnet-4-5"],
+			summary: "Inspect this workspace",
+		});
+		expect(session?.events?.every((event, index) => event.seq === index)).toBe(true);
+		expect(session?.events).toContainEqual(
+			expect.objectContaining({
+				type: "reasoning",
+				parts: [{ type: "text", text: "Private OpenCode reasoning" }],
+				payload_json: '{"details":{"anthropic":{"signature":"opaque-signature"}}}',
+			}),
+		);
+		expect(session?.events).toContainEqual(
+			expect.objectContaining({
+				type: "tool_call",
+				call_id: "call_read",
+				name: "read",
+				arguments_json:
+					'{"apiKey":"tool-input-preserved","filePath":"/workspace/opencode/README.md"}',
+			}),
+		);
+		expect(session?.events).toContainEqual(
+			expect.objectContaining({
+				type: "tool_result",
+				call_id: "call_read",
+				status: "completed",
+				parts: expect.arrayContaining([
+					{ type: "text", text: "Tool output" },
+					expect.objectContaining({
+						type: "attachment",
+						availability: "metadata_only",
+						name: "preview.png",
+					}),
+				]),
+				result_json: '{"lines":12}',
+			}),
+		);
+		expect(session?.events).toContainEqual(
+			expect.objectContaining({
+				type: "tool_result",
+				call_id: "call_shell",
+				status: "error",
+			}),
+		);
+		const serialized = JSON.stringify(session?.events);
+		expect(serialized).toContain("Private OpenCode system instruction");
+		expect(serialized).toContain("Internal ignored separator");
+		const stepFinish = session?.events?.find(
+			(event) => event.semantics?.display_kind === "step_finish",
+		);
+		expect(stepFinish).toMatchObject({
+			type: "message",
+			parts: [expect.objectContaining({ text: expect.stringContaining('"reasoning":18') })],
+		});
+		expect(serialized).not.toContain("must-not-upload");
+		expect(serialized).not.toContain("/private/output/preview.png");
+		expect(serialized).not.toContain("/private/workspace/secret.ts");
+		expect(serialized).not.toContain("private-snapshot-hash");
+		expect(JSON.stringify(session?.messages)).not.toContain("Private OpenCode reasoning");
+		expect(JSON.stringify(session?.messages)).not.toContain("Internal ignored separator");
+		expect(session?.messages.map((message) => message.content)).toEqual([
+			"Inspect this workspace",
+			"Visible OpenCode answer",
+		]);
+	});
+
+	test("resolves one current session without a stale in-memory snapshot", async () => {
+		const { adapter, databasePath } = fixtureDatabase();
+		const before = await adapter.sessions.resolve("opencode.ses_fixture");
+		const previousIds = before?.events?.map((event) => event.event_id) ?? [];
+		const db = new Database(databasePath);
+		const now = Date.parse("2026-08-27T10:00:06.000Z");
+		insertJson(db, "part", [
+			"prt_010",
+			"msg_assistant",
+			"ses_fixture",
+			now,
+			now,
+			JSON.stringify({ type: "text", text: "Fresh backing-store answer" }),
+		]);
+		db.close();
+
+		const after = await adapter.sessions.resolve("ses_fixture");
+		expect(after?.events?.slice(0, previousIds.length).map((event) => event.event_id)).toEqual(
+			previousIds,
+		);
+		expect(after?.messages.at(-1)?.content).toBe("Fresh backing-store answer");
+		expect(await adapter.sessions.resolve("opencode.missing")).toBeNull();
+	});
+});

--- a/packages/cli/src/adapters/opencode.ts
+++ b/packages/cli/src/adapters/opencode.ts
@@ -1,0 +1,591 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { safeTruncate } from "../lib/sanitize";
+import { durationSecondsBetween } from "../lib/session-duration";
+import {
+	canonicalJson,
+	projectEventsToMessages,
+	type SessionEventDraft,
+	sequenceSessionEvents,
+} from "../lib/session-events";
+import type {
+	AgentAdapterCore,
+	RawSession,
+	SessionContentPart,
+	SessionEventSemantics,
+	SessionScanRequest,
+	SessionScanResult,
+} from "./base";
+import { getOpenCodeDataDir, getOpenCodeDbPath } from "./paths";
+import {
+	canonicalStructuredString,
+	type JsonObject,
+	jsonObject,
+	jsonString,
+	reasoningContent,
+	toolResultContent,
+	visibleContentParts,
+} from "./rich-event-mapping";
+import { openReadonlySqlite, type ReadonlySqliteDatabase } from "./sqlite";
+import { readCommandVersion } from "./version";
+
+interface TableInfoRow {
+	name: string;
+	pk: number;
+}
+
+interface OpenCodeSessionRow {
+	id: string;
+	directory: string;
+	title: string;
+	version: string;
+	tokens_input: number;
+	tokens_output: number;
+	tokens_reasoning: number;
+	tokens_cache_read: number;
+	tokens_cache_write: number;
+	time_created: number;
+	time_updated: number;
+	time_archived: number | null;
+	model: string | null;
+	agent: string | null;
+}
+
+interface OpenCodeMessageRow {
+	id: string;
+	time_created: number;
+	time_updated: number;
+	data: string;
+}
+
+interface OpenCodePartRow {
+	id: string;
+	message_id: string;
+	time_created: number;
+	time_updated: number;
+	data: string;
+}
+
+interface ParsedMessage {
+	row: OpenCodeMessageRow;
+	data: JsonObject;
+	parts: Array<{ row: OpenCodePartRow; data: JsonObject }>;
+}
+
+const REQUIRED_COLUMNS = {
+	session: [
+		"id",
+		"directory",
+		"title",
+		"version",
+		"tokens_input",
+		"tokens_output",
+		"tokens_reasoning",
+		"tokens_cache_read",
+		"tokens_cache_write",
+		"time_created",
+		"time_updated",
+		"time_archived",
+		"model",
+		"agent",
+	],
+	message: ["id", "session_id", "time_created", "time_updated", "data"],
+	part: ["id", "message_id", "session_id", "time_created", "time_updated", "data"],
+} as const;
+
+const EVENT_SEMANTICS: SessionEventSemantics = {
+	lifecycle: "active",
+	display: "event",
+	compressed_summary: false,
+};
+
+function tableInfo(
+	db: ReadonlySqliteDatabase,
+	table: keyof typeof REQUIRED_COLUMNS,
+): TableInfoRow[] {
+	return db.prepare(`PRAGMA table_info(${table})`).all() as TableInfoRow[];
+}
+
+function assertSupportedSchema(db: ReadonlySqliteDatabase): void {
+	for (const table of ["session", "message", "part"] as const) {
+		const required = REQUIRED_COLUMNS[table];
+		const columns = tableInfo(db, table);
+		const names = new Set(columns.map((column) => column.name));
+		if (!required.every((column) => names.has(column))) {
+			throw new Error(`OpenCode session database has an unsupported ${table} table`);
+		}
+		const id = columns.find((column) => column.name === "id");
+		if (id?.pk !== 1) throw new Error(`OpenCode session database ${table}.id is not stable`);
+	}
+}
+
+function parseStoredObject(value: string, label: string): JsonObject {
+	try {
+		const parsed = jsonObject(JSON.parse(value));
+		if (parsed) return parsed;
+	} catch {
+		// The error below identifies the durable source row without exposing its contents.
+	}
+	throw new Error(`OpenCode ${label} contains invalid JSON`);
+}
+
+function timestampIso(value: unknown): string | undefined {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return undefined;
+	const date = new Date(value);
+	return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function nonNegativeNumber(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+function modelName(value: unknown): string | undefined {
+	const model = jsonObject(value);
+	return jsonString(model?.modelID) ?? jsonString(model?.id) ?? undefined;
+}
+
+function sessionModel(value: string | null): string | undefined {
+	if (!value) return undefined;
+	try {
+		return modelName(JSON.parse(value));
+	} catch {
+		return undefined;
+	}
+}
+
+function source(sessionKey: string, recordId: string, partIndex?: number) {
+	return {
+		adapter: "opencode" as const,
+		session_key: sessionKey,
+		record_id: recordId,
+		...(partIndex === undefined ? {} : { part_index: partIndex }),
+	};
+}
+
+function partTimestamp(part: JsonObject, fallback: number): string | undefined {
+	const time = jsonObject(part.time);
+	return timestampIso(time?.start) ?? timestampIso(time?.created) ?? timestampIso(fallback);
+}
+
+function markerEvent(
+	sessionKey: string,
+	recordId: string,
+	kind: string,
+	value: JsonObject,
+	timestamp?: string,
+): SessionEventDraft {
+	return {
+		type: "message",
+		role: "system",
+		parts: [{ type: "text", text: `OpenCode ${kind}: ${canonicalJson(value)}` }],
+		source: source(sessionKey, recordId),
+		semantics: { ...EVENT_SEMANTICS, display_kind: kind },
+		...(timestamp ? { timestamp } : {}),
+	};
+}
+
+function safeError(value: unknown): JsonObject {
+	const error = jsonObject(value);
+	const data = jsonObject(error?.data);
+	const name = jsonString(error?.name);
+	const message = jsonString(data?.message);
+	return {
+		...(name ? { name } : {}),
+		...(message ? { message } : {}),
+		...(typeof data?.statusCode === "number" ? { status_code: data.statusCode } : {}),
+		...(typeof data?.isRetryable === "boolean" ? { retryable: data.isRetryable } : {}),
+	};
+}
+
+function toolSemantics(part: JsonObject): SessionEventSemantics | undefined {
+	const state = jsonObject(part.state);
+	const time = jsonObject(state?.time);
+	return typeof time?.compacted === "number"
+		? { ...EVENT_SEMANTICS, lifecycle: "compacted", display_kind: "tool" }
+		: undefined;
+}
+
+function messagePreludeEvents(
+	sessionKey: string,
+	message: OpenCodeMessageRow,
+	data: JsonObject,
+): SessionEventDraft[] {
+	const drafts: SessionEventDraft[] = [];
+	const timestamp =
+		timestampIso(jsonObject(data.time)?.created) ?? timestampIso(message.time_created);
+	const system = jsonString(data.system);
+	if (system) {
+		drafts.push({
+			type: "message",
+			role: "system",
+			parts: [{ type: "text", text: system }],
+			source: source(sessionKey, `${message.id}:system`),
+			semantics: EVENT_SEMANTICS,
+			...(timestamp ? { timestamp } : {}),
+		});
+	}
+	return drafts;
+}
+
+function messageEpilogueEvents(
+	sessionKey: string,
+	message: OpenCodeMessageRow,
+	data: JsonObject,
+): SessionEventDraft[] {
+	if (data.role !== "assistant") return [];
+	const drafts: SessionEventDraft[] = [];
+	const timestamp =
+		timestampIso(jsonObject(data.time)?.completed) ?? timestampIso(message.time_updated);
+	const structured = data.structured === undefined ? undefined : canonicalJson(data.structured);
+	if (structured) {
+		const model = modelName(data);
+		drafts.push({
+			type: "message",
+			role: "assistant",
+			parts: [{ type: "text", text: structured }],
+			source: source(sessionKey, `${message.id}:structured`),
+			...(model ? { model } : {}),
+			...(timestamp ? { timestamp } : {}),
+		});
+	}
+	if (data.error !== undefined) {
+		drafts.push(
+			markerEvent(
+				sessionKey,
+				`${message.id}:error`,
+				"assistant_error",
+				safeError(data.error),
+				timestamp,
+			),
+		);
+	}
+	return drafts;
+}
+
+function partEvents(
+	sessionKey: string,
+	message: OpenCodeMessageRow,
+	messageData: JsonObject,
+	part: OpenCodePartRow,
+	data: JsonObject,
+): SessionEventDraft[] {
+	const type = jsonString(data.type);
+	const role = messageData.role === "assistant" ? "assistant" : "user";
+	const model = modelName(messageData);
+	const timestamp = partTimestamp(data, part.time_created || message.time_created);
+	const eventSource = source(sessionKey, part.id);
+	if (type === "text") {
+		const text = jsonString(data.text);
+		if (!text) return [];
+		return [
+			{
+				type: "message",
+				role,
+				parts: [{ type: "text", text }],
+				source: eventSource,
+				...(data.ignored === true
+					? {
+							semantics: {
+								lifecycle: "active" as const,
+								display: "hidden" as const,
+								compressed_summary: false,
+								display_kind: "ignored_text",
+							},
+						}
+					: {}),
+				...(role === "assistant" && model ? { model } : {}),
+				...(timestamp ? { timestamp } : {}),
+			},
+		];
+	}
+	if (type === "reasoning") {
+		const reasoning = reasoningContent({
+			type: "reasoning",
+			text: data.text,
+			reasoning_details: data.metadata,
+		});
+		return reasoning
+			? [
+					{
+						type: "reasoning",
+						...reasoning,
+						source: eventSource,
+						...(model ? { model } : {}),
+						...(timestamp ? { timestamp } : {}),
+					},
+				]
+			: [];
+	}
+	if (type === "file") {
+		const parts = visibleContentParts(data);
+		return parts.length > 0
+			? [
+					{
+						type: "message",
+						role,
+						parts,
+						source: eventSource,
+						...(role === "assistant" && model ? { model } : {}),
+						...(timestamp ? { timestamp } : {}),
+					},
+				]
+			: [];
+	}
+	if (type === "tool") {
+		const state = jsonObject(data.state);
+		const callId = jsonString(data.callID);
+		const name = jsonString(data.tool);
+		if (!state || !callId || !name) return [];
+		const semantics = toolSemantics(data);
+		const call: SessionEventDraft = {
+			type: "tool_call",
+			call_id: callId,
+			name,
+			arguments_json: canonicalStructuredString(state.input),
+			source: source(sessionKey, part.id, 0),
+			...(semantics ? { semantics } : {}),
+			...(model ? { model } : {}),
+			...(timestamp ? { timestamp } : {}),
+		};
+		if (state.status !== "completed" && state.status !== "error") return [call];
+		const result = toolResultContent(
+			state.status === "completed" ? state.output : state.error,
+			state.metadata,
+		);
+		const attachments: SessionContentPart[] =
+			state.status === "completed" ? visibleContentParts(state.attachments) : [];
+		return [
+			call,
+			{
+				type: "tool_result",
+				call_id: callId,
+				name,
+				status: state.status,
+				...result,
+				parts: [...result.parts, ...attachments],
+				source: source(sessionKey, part.id, 1),
+				...(semantics ? { semantics } : {}),
+				...(timestamp ? { timestamp } : {}),
+			},
+		];
+	}
+	if (type === "subtask") {
+		const prompt = jsonString(data.prompt);
+		const agent = jsonString(data.agent);
+		if (!prompt || !agent) return [];
+		return [
+			{
+				type: "tool_call",
+				call_id: `opencode-subtask:${part.id}`,
+				name: "subtask",
+				arguments_json: canonicalStructuredString({
+					prompt,
+					description: jsonString(data.description),
+					agent,
+					model: data.model,
+					command: jsonString(data.command),
+				}),
+				source: eventSource,
+				...(timestamp ? { timestamp } : {}),
+			},
+		];
+	}
+	if (type === "agent") {
+		const name = jsonString(data.name);
+		return name ? [markerEvent(sessionKey, part.id, "agent", { name }, timestamp)] : [];
+	}
+	if (type === "compaction") {
+		return [
+			markerEvent(
+				sessionKey,
+				part.id,
+				"compaction",
+				{
+					auto: data.auto === true,
+					overflow: data.overflow === true,
+					tail_start_id: jsonString(data.tail_start_id),
+				},
+				timestamp,
+			),
+		];
+	}
+	if (type === "retry") {
+		return [
+			markerEvent(
+				sessionKey,
+				part.id,
+				"retry",
+				{ attempt: nonNegativeNumber(data.attempt), error: safeError(data.error) },
+				timestamp,
+			),
+		];
+	}
+	if (type === "step-start") {
+		return [markerEvent(sessionKey, part.id, "step_start", {}, timestamp)];
+	}
+	if (type === "step-finish") {
+		return [
+			markerEvent(
+				sessionKey,
+				part.id,
+				"step_finish",
+				{
+					reason: jsonString(data.reason),
+					cost: nonNegativeNumber(data.cost),
+					tokens: data.tokens,
+				},
+				timestamp,
+			),
+		];
+	}
+	if (type === "snapshot" || type === "patch") {
+		return [markerEvent(sessionKey, part.id, type, {}, timestamp)];
+	}
+	return [];
+}
+
+function parseMessages(db: ReadonlySqliteDatabase, sessionId: string): ParsedMessage[] {
+	const messageRows = db
+		.prepare(
+			`SELECT id, time_created, time_updated, data
+			 FROM message
+			 WHERE session_id = ?
+			 ORDER BY time_created ASC, id ASC`,
+		)
+		.all(sessionId) as OpenCodeMessageRow[];
+	const partRows = db
+		.prepare(
+			`SELECT id, message_id, time_created, time_updated, data
+			 FROM part
+			 WHERE session_id = ?
+			 ORDER BY id ASC`,
+		)
+		.all(sessionId) as OpenCodePartRow[];
+	const partsByMessage = new Map<string, Array<{ row: OpenCodePartRow; data: JsonObject }>>();
+	for (const row of partRows) {
+		const item = { row, data: parseStoredObject(row.data, `part ${row.id}`) };
+		const existing = partsByMessage.get(row.message_id);
+		if (existing) existing.push(item);
+		else partsByMessage.set(row.message_id, [item]);
+	}
+	return messageRows.map((row) => ({
+		row,
+		data: parseStoredObject(row.data, `message ${row.id}`),
+		parts: partsByMessage.get(row.id) ?? [],
+	}));
+}
+
+function parseSession(db: ReadonlySqliteDatabase, row: OpenCodeSessionRow): RawSession | null {
+	const parsedMessages = parseMessages(db, row.id);
+	const events = sequenceSessionEvents(
+		parsedMessages.flatMap((message) => [
+			...messagePreludeEvents(row.id, message.row, message.data),
+			...message.parts.flatMap((part) =>
+				partEvents(row.id, message.row, message.data, part.row, part.data),
+			),
+			...messageEpilogueEvents(row.id, message.row, message.data),
+		]),
+	);
+	if (events.length === 0) return null;
+	const messages = projectEventsToMessages(events);
+	const eventModels = events
+		.map((event) =>
+			event.type === "message" || event.type === "tool_call" || event.type === "reasoning"
+				? event.model
+				: undefined,
+		)
+		.filter((value): value is string => Boolean(value));
+	const fallbackModel = sessionModel(row.model);
+	const modelsUsed = [...new Set([...eventModels, ...(fallbackModel ? [fallbackModel] : [])])];
+	const startedAt = new Date(row.time_created);
+	const endedAt = new Date(row.time_updated);
+	const firstUser = messages.find((message) => message.role === "user");
+	const defaultTitle = row.title.startsWith("New session - ");
+	return {
+		localSessionId: `opencode.${row.id}`,
+		projectPath: row.directory,
+		startedAt,
+		endedAt,
+		messageCount: parsedMessages.length,
+		inputTokens: nonNegativeNumber(row.tokens_input),
+		outputTokens: nonNegativeNumber(row.tokens_output),
+		cacheReadTokens: nonNegativeNumber(row.tokens_cache_read),
+		model: eventModels.at(-1) ?? fallbackModel ?? null,
+		modelsUsed,
+		durationSeconds: durationSecondsBetween(startedAt, endedAt),
+		summary:
+			!defaultTitle && row.title.trim()
+				? row.title
+				: firstUser
+					? safeTruncate(firstUser.content, 200)
+					: null,
+		messages,
+		events,
+		rawFilePath: `${getOpenCodeDbPath()}#${row.id}`,
+	};
+}
+
+export class OpenCodeAdapter implements AgentAdapterCore {
+	readonly agentType = "opencode" as const;
+	readonly sessions = {
+		contentProtocol: async () => "events-v1" as const,
+		collect: (request: SessionScanRequest) => this.collectSessions(request),
+		resolve: (localSessionId: string) => this.resolveSession(localSessionId),
+		watchPaths: () => this.getSessionsWatchPaths(),
+	};
+
+	async detect(): Promise<boolean> {
+		return existsSync(getOpenCodeDbPath()) || existsSync(getOpenCodeDataDir());
+	}
+
+	async getVersion(): Promise<string | null> {
+		return readCommandVersion("opencode", ["--version"]);
+	}
+
+	private async collectSessions(request: SessionScanRequest): Promise<SessionScanResult> {
+		const sessions = await this.collectCurrentSessions(undefined, request.projectFilter);
+		return { sessions, dedupedCount: 0, coverage: "complete" };
+	}
+
+	private async resolveSession(localSessionId: string): Promise<RawSession | null> {
+		const sourceId = localSessionId.startsWith("opencode.")
+			? localSessionId.slice("opencode.".length)
+			: localSessionId;
+		return (await this.collectCurrentSessions(sourceId))[0] ?? null;
+	}
+
+	private async collectCurrentSessions(
+		sourceId?: string,
+		projectFilter?: string,
+	): Promise<RawSession[]> {
+		const databasePath = getOpenCodeDbPath();
+		if (!existsSync(databasePath)) return [];
+		const db = await openReadonlySqlite(databasePath);
+		try {
+			assertSupportedSchema(db);
+			const rows = db
+				.prepare(
+					`SELECT id, directory, title, version,
+					        tokens_input, tokens_output, tokens_reasoning,
+					        tokens_cache_read, tokens_cache_write,
+					        time_created, time_updated, time_archived, model, agent
+					 FROM session
+					 ${sourceId === undefined ? "" : "WHERE id = ?"}
+					 ORDER BY time_created DESC, id ASC`,
+				)
+				.all(...(sourceId === undefined ? [] : [sourceId])) as OpenCodeSessionRow[];
+			const normalizedFilter = projectFilter ? resolve(projectFilter) : null;
+			return rows
+				.filter((row) => normalizedFilter === null || resolve(row.directory) === normalizedFilter)
+				.map((row) => parseSession(db, row))
+				.filter((session): session is RawSession => session !== null);
+		} finally {
+			db.close();
+		}
+	}
+
+	private getSessionsWatchPaths(): string[] {
+		const database = getOpenCodeDbPath();
+		return [database, `${database}-wal`, `${database}-journal`];
+	}
+}

--- a/packages/cli/src/adapters/paths.ts
+++ b/packages/cli/src/adapters/paths.ts
@@ -63,6 +63,21 @@ export function getPiSessionsDir(): string {
 	return join(getPiHome(), "sessions");
 }
 
+/** OpenCode data root, matching the official xdg-basedir default. */
+export function getOpenCodeDataDir(): string {
+	const xdgData = process.env.XDG_DATA_HOME?.trim() || join(home(), ".local", "share");
+	return join(xdgData, "opencode");
+}
+
+/** OpenCode SQLite path; relative `$OPENCODE_DB` values live under its data root. */
+export function getOpenCodeDbPath(): string {
+	const override = process.env.OPENCODE_DB?.trim();
+	if (!override) return join(getOpenCodeDataDir(), "opencode.db");
+	return override === ":memory:" || isAbsolute(override)
+		? override
+		: join(getOpenCodeDataDir(), override);
+}
+
 /**
  * OpenClaw: honors `$OPENCLAW_STATE_DIR`, else probes home-relative names
  * (`.openclaw` → `.clawdbot` → `.moltbot` — same multi-name fallback

--- a/packages/cli/src/adapters/pi.test.ts
+++ b/packages/cli/src/adapters/pi.test.ts
@@ -39,7 +39,7 @@ function copyFixture(root: string, fixture: string, name: string): string {
 }
 
 describe("Pi session adapter", () => {
-	test("projects the active compaction tail without hidden thinking", async () => {
+	test("uploads private reasoning while projecting only the active visible tail", async () => {
 		const { adapter, file, root } = fixtureSession();
 		writeFileSync(file, readFileSync(file, "utf-8").replace(/\n$/, ""));
 		expect(await adapter.detect()).toBe(true);
@@ -54,7 +54,9 @@ describe("Pi session adapter", () => {
 			"message",
 			"message",
 			"message",
+			"reasoning",
 			"tool_call",
+			"reasoning",
 			"tool_result",
 			"message",
 		]);
@@ -62,7 +64,8 @@ describe("Pi session adapter", () => {
 		expect(serialized).not.toContain("old prompt");
 		expect(serialized).not.toContain("old answer");
 		expect(serialized).not.toContain("abandoned branch");
-		expect(serialized).not.toContain("hidden chain of thought");
+		expect(serialized).toContain("hidden chain of thought");
+		expect(serialized).toContain("opaque-tool-thought");
 		expect(serialized).not.toContain("thinkingSignature");
 		expect(serialized).not.toContain("hidden extension state");
 		expect(serialized).toContain("Visible compaction summary");
@@ -72,6 +75,7 @@ describe("Pi session adapter", () => {
 		expect(serialized).toContain('"availability":"metadata_only"');
 		expect(serialized).toContain('"sha256":');
 		expect(serialized).not.toContain("inline:sha256:");
+		expect(JSON.stringify(session?.messages)).not.toContain("hidden chain of thought");
 
 		const pathScan = await adapter.sessions.collect({ kind: "paths", paths: [file] });
 		expect(pathScan.coverage).toBe("partial");
@@ -130,5 +134,12 @@ describe("Pi session adapter", () => {
 		expect(serialized).not.toContain("abandoned answer");
 		expect(serialized).not.toContain("abandoned private reasoning");
 		expect(serialized).not.toContain("thinkingSignature");
+		expect(session?.events).toContainEqual(
+			expect.objectContaining({
+				type: "reasoning",
+				kind: "redacted",
+				payload_json: '{"signature":"private"}',
+			}),
+		);
 	});
 });

--- a/packages/cli/src/adapters/pi.ts
+++ b/packages/cli/src/adapters/pi.ts
@@ -17,6 +17,7 @@ import {
 	type JsonObject,
 	jsonObject,
 	jsonString,
+	reasoningContent,
 	toolResultContent,
 	visibleContentParts,
 } from "./rich-event-mapping";
@@ -320,7 +321,18 @@ function entryEvents(sessionKey: string, entry: ParsedPiEntry): SessionEventDraf
 		}
 		for (let index = 0; index < content.length; index++) {
 			const part = jsonObject(content[index]);
-			if (part?.type !== "toolCall") continue;
+			if (!part) continue;
+			const reasoning = reasoningContent(part);
+			if (reasoning) {
+				drafts.push({
+					type: "reasoning",
+					...reasoning,
+					source: source(sessionKey, entry, index + 1),
+					...(messageTimestamp ? { timestamp: messageTimestamp } : {}),
+					...(model ? { model } : {}),
+				});
+			}
+			if (part.type !== "toolCall") continue;
 			const callId = jsonString(part.id);
 			const name = jsonString(part.name);
 			if (!callId || !name) continue;
@@ -333,6 +345,19 @@ function entryEvents(sessionKey: string, entry: ParsedPiEntry): SessionEventDraf
 				...(messageTimestamp ? { timestamp: messageTimestamp } : {}),
 				...(model ? { model } : {}),
 			});
+			const toolThought = reasoningContent({
+				type: "redacted_thinking",
+				signature: part.thoughtSignature,
+			});
+			if (toolThought) {
+				drafts.push({
+					type: "reasoning",
+					...toolThought,
+					source: source(sessionKey, entry, index + 1),
+					...(messageTimestamp ? { timestamp: messageTimestamp } : {}),
+					...(model ? { model } : {}),
+				});
+			}
 		}
 		return drafts;
 	}
@@ -341,7 +366,7 @@ function entryEvents(sessionKey: string, entry: ParsedPiEntry): SessionEventDraf
 		if (!callId) return [];
 		const result = toolResultContent(message.content, message.details);
 		const toolName = jsonString(message.toolName);
-		return [
+		const drafts: SessionEventDraft[] = [
 			{
 				type: "tool_result",
 				call_id: callId,
@@ -352,6 +377,20 @@ function entryEvents(sessionKey: string, entry: ParsedPiEntry): SessionEventDraf
 				...(messageTimestamp ? { timestamp: messageTimestamp } : {}),
 			},
 		];
+		const details = jsonObject(message.details);
+		const privateState = reasoningContent({
+			type: "redacted_thinking",
+			signature: details?.thinkingSignature ?? details?.thoughtSignature,
+		});
+		if (privateState) {
+			drafts.push({
+				type: "reasoning",
+				...privateState,
+				source: source(sessionKey, entry, 1),
+				...(messageTimestamp ? { timestamp: messageTimestamp } : {}),
+			});
+		}
+		return drafts;
 	}
 	if (role === "bashExecution") {
 		const command = jsonString(message.command);
@@ -445,7 +484,9 @@ function parseSession(filePath: string, projectFilter?: string): RawSession | nu
 	const endedAt = timestamps.at(-1) ?? stat.mtime;
 	const models = events
 		.map((event) =>
-			event.type === "message" || event.type === "tool_call" ? event.model : undefined,
+			event.type === "message" || event.type === "tool_call" || event.type === "reasoning"
+				? event.model
+				: undefined,
 		)
 		.filter((value): value is string => Boolean(value));
 	const modelsUsed = [...new Set(models)];

--- a/packages/cli/src/adapters/registry.ts
+++ b/packages/cli/src/adapters/registry.ts
@@ -13,7 +13,15 @@ import {
 } from "./mcp-lifecycle";
 import { OpenClawAdapter } from "./openclaw";
 import { resolveOpenClawAgentWorkspace } from "./openclaw-workspace";
-import { getClaudeHome, getCodexHome, getHermesHome, getOpenClawHome, getPiHome } from "./paths";
+import { OpenCodeAdapter } from "./opencode";
+import {
+	getClaudeHome,
+	getCodexHome,
+	getHermesHome,
+	getOpenClawHome,
+	getOpenCodeDataDir,
+	getPiHome,
+} from "./paths";
 import { PiAdapter } from "./pi";
 
 export { AGENT_TYPES, type AgentType } from "./agent-types";
@@ -66,6 +74,12 @@ export const adapterRegistry: Record<AgentType, AdapterRegistryEntry> = {
 		envFileName: "pi.json",
 		home: getPiHome,
 		create: () => new PiAdapter(),
+	},
+	opencode: {
+		displayName: "OpenCode",
+		envFileName: "opencode.json",
+		home: getOpenCodeDataDir,
+		create: () => new OpenCodeAdapter(),
 	},
 };
 

--- a/packages/cli/src/adapters/rich-event-mapping.test.ts
+++ b/packages/cli/src/adapters/rich-event-mapping.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { completeJsonlRecords, toolResultContent, visibleContentParts } from "./rich-event-mapping";
+import {
+	completeJsonlRecords,
+	reasoningContent,
+	toolResultContent,
+	visibleContentParts,
+} from "./rich-event-mapping";
 
 describe("rich event mapping", () => {
 	test("keeps complete JSONL records without a trailing newline and ignores a partial tail", () => {
@@ -73,5 +78,22 @@ describe("rich event mapping", () => {
 		);
 		expect(JSON.stringify(mapped)).not.toContain("hidden reasoning");
 		expect(JSON.stringify(mapped)).not.toContain("opaque continuation");
+	});
+
+	test("maps reasoning text and provider continuation without retaining its source envelope", () => {
+		const mapped = reasoningContent({
+			type: "reasoning",
+			summary: [{ type: "summary_text", text: "private reasoning" }],
+			signature: "signed-state",
+			encrypted_content: "opaque continuation",
+			provider_envelope: { duplicate_visible_message: "do not retain" },
+		});
+
+		expect(mapped).toEqual({
+			kind: "reasoning",
+			parts: [{ type: "text", text: "private reasoning" }],
+			payload_json: '{"encrypted_content":"opaque continuation","signature":"signed-state"}',
+		});
+		expect(JSON.stringify(mapped)).not.toContain("duplicate_visible_message");
 	});
 });

--- a/packages/cli/src/adapters/rich-event-mapping.ts
+++ b/packages/cli/src/adapters/rich-event-mapping.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { isIP } from "node:net";
 import { basename } from "node:path";
 import { canonicalJson } from "../lib/session-events";
-import type { SessionContentPart } from "./base";
+import type { SessionContentPart, SessionReasoningEvent } from "./base";
 
 export type JsonObject = Record<string, unknown>;
 
@@ -207,6 +207,72 @@ export function visibleContentParts(content: unknown): SessionContentPart[] {
 		parts.push(attachmentPart(block));
 	}
 	return parts;
+}
+
+type ReasoningContent = Pick<SessionReasoningEvent, "kind" | "parts" | "payload_json">;
+
+function reasoningTexts(value: unknown): Array<{ type: "text"; text: string }> {
+	const direct = jsonObject(value);
+	const texts: string[] = [];
+	for (const candidate of [direct?.thinking, direct?.reasoning, direct?.text]) {
+		if (typeof candidate === "string" && candidate) texts.push(candidate);
+	}
+	for (const collection of [direct?.summary, direct?.content]) {
+		if (!Array.isArray(collection)) continue;
+		for (const item of collection) {
+			const block = jsonObject(item);
+			const text = jsonString(block?.text);
+			if (text) texts.push(text);
+		}
+	}
+	return texts.map((text) => ({ type: "text", text }));
+}
+
+/** Map only reasoning-specific fields; never seal the whole source record. */
+export function reasoningContent(value: unknown): ReasoningContent | null {
+	const block = jsonObject(value);
+	if (!block) return null;
+	const type = jsonString(block.type);
+	if (
+		type !== "thinking" &&
+		type !== "reasoning" &&
+		type !== "redacted_thinking" &&
+		type !== "encrypted_content"
+	)
+		return null;
+	const parts =
+		type === "encrypted_content" || type === "redacted_thinking" ? [] : reasoningTexts(block);
+	const signature =
+		jsonString(block.signature) ??
+		jsonString(block.thinkingSignature) ??
+		jsonString(block.thoughtSignature);
+	const encryptedContent =
+		jsonString(block.encrypted_content) ??
+		jsonString(block.encryptedContent) ??
+		(type === "encrypted_content" ? (jsonString(block.data) ?? jsonString(block.text)) : null);
+	const redactedData = type === "redacted_thinking" ? jsonString(block.data) : null;
+	const details = block.reasoning_details ?? block.reasoningDetails;
+	const items = block.codex_reasoning_items ?? block.codexReasoningItems;
+	const privateState: JsonObject = {
+		...(signature ? { signature } : {}),
+		...(encryptedContent ? { encrypted_content: encryptedContent } : {}),
+		...(redactedData ? { redacted_data: redactedData } : {}),
+		...(details === undefined ? {} : { details }),
+		...(items === undefined ? {} : { items }),
+	};
+	const payloadJson =
+		Object.keys(privateState).length > 0 ? canonicalJson(privateState) : undefined;
+	if (parts.length === 0 && payloadJson === undefined) return null;
+	return {
+		kind:
+			type === "redacted_thinking" || type === "encrypted_content"
+				? "redacted"
+				: type === "reasoning"
+					? "reasoning"
+					: "thinking",
+		parts,
+		...(payloadJson ? { payload_json: payloadJson } : {}),
+	};
 }
 
 function safeToolStructure(value: unknown): unknown | undefined {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -67,6 +67,7 @@ Environment:
   OPENCLAW_STATE_DIR       Custom OpenClaw state dir (else auto-detect)
   OPENCLAW_AGENT_ID        OpenClaw agent id (else "main")
   PI_CODING_AGENT_DIR      Custom Pi agent home (else ~/.pi/agent)
+  OPENCODE_DB              Custom OpenCode SQLite path (else XDG data/opencode/opencode.db)
   CI / GITHUB_ACTIONS / …  Disable interactive prompts in known CI
 
 Docs: https://github.com/Clawdi-AI/clawdi`,

--- a/packages/cli/src/lib/session-events.ts
+++ b/packages/cli/src/lib/session-events.ts
@@ -59,6 +59,7 @@ export function projectEventsToMessages(events: readonly SessionEvent[]): Sessio
 	const messages: SessionMessage[] = [];
 	for (const event of events) {
 		if (event.type !== "message" || (event.role !== "user" && event.role !== "assistant")) continue;
+		if (event.semantics?.display === "hidden") continue;
 		const content = event.parts
 			.filter(
 				(part): part is Extract<(typeof event.parts)[number], { type: "text" }> =>

--- a/packages/cli/src/serve/queue.ts
+++ b/packages/cli/src/serve/queue.ts
@@ -29,7 +29,7 @@
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import type { AgentType } from "../adapters/agent-types";
+import { AGENT_TYPES, type AgentType } from "../adapters/agent-types";
 import { isValidSkillKey } from "../lib/skill-key";
 import { log, toErrorMessage } from "./log";
 import { getServeStateDir } from "./paths";
@@ -575,13 +575,7 @@ export function hasSessionFence(
 }
 
 function isAgentType(value: unknown): value is AgentType {
-	return (
-		value === "claude_code" ||
-		value === "codex" ||
-		value === "openclaw" ||
-		value === "hermes" ||
-		value === "pi"
-	);
+	return typeof value === "string" && (AGENT_TYPES as readonly string[]).includes(value);
 }
 
 function isSkillOperation(

--- a/packages/cli/tests/adapters/claude-code.test.ts
+++ b/packages/cli/tests/adapters/claude-code.test.ts
@@ -102,6 +102,52 @@ describe("ClaudeCodeAdapter.collectSessions", () => {
 		expect(texts).toEqual(["hello", "world", "one more", "done"]);
 	});
 
+	it("uploads thinking and redacted continuation without adding it to messages", async () => {
+		const sessionPath = join(
+			tmpHome,
+			".claude",
+			"projects",
+			"-Users-fixture-project",
+			"11111111-2222-3333-4444-555555555555.jsonl",
+		);
+		const record = {
+			type: "assistant",
+			uuid: "reasoning-record",
+			timestamp: "2026-04-20T10:00:06.000Z",
+			message: {
+				role: "assistant",
+				model: "claude-opus-4-7",
+				content: [
+					{ type: "thinking", thinking: "private Claude thought", signature: "signed" },
+					{ type: "redacted_thinking", data: "opaque-redacted" },
+					{ type: "text", text: "visible answer after thinking" },
+				],
+			},
+		};
+		writeFileSync(
+			sessionPath,
+			`${readFileSync(sessionPath, "utf-8").trimEnd()}\n${JSON.stringify(record)}\n`,
+		);
+
+		const session = (await new ClaudeCodeAdapter().sessions.collect({ kind: "complete" }))
+			.sessions[0];
+		const reasoning = session?.events?.filter((event) => event.type === "reasoning") ?? [];
+		expect(reasoning).toMatchObject([
+			{
+				kind: "thinking",
+				parts: [{ type: "text", text: "private Claude thought" }],
+				payload_json: '{"signature":"signed"}',
+			},
+			{
+				kind: "redacted",
+				parts: [],
+				payload_json: '{"redacted_data":"opaque-redacted"}',
+			},
+		]);
+		expect(session?.messages.at(-1)?.content).toBe("visible answer after thinking");
+		expect(JSON.stringify(session?.messages)).not.toContain("private Claude thought");
+	});
+
 	it("filters by projectFilter (matching cwd → encoded dir)", async () => {
 		const a = new ClaudeCodeAdapter();
 		const matched = await a.sessions.collect({

--- a/packages/cli/tests/adapters/codex.test.ts
+++ b/packages/cli/tests/adapters/codex.test.ts
@@ -219,7 +219,7 @@ describe("CodexAdapter.collectSessions", () => {
 		});
 	});
 
-	it("maps persisted visible ResponseItem variants without raw or encrypted payloads", async () => {
+	it("maps visible ResponseItems and their private reasoning without raw envelopes", async () => {
 		const sessionPath = join(
 			tmpHome,
 			".codex",
@@ -267,11 +267,24 @@ describe("CodexAdapter.collectSessions", () => {
 				timestamp: "2026-04-20T10:00:09Z",
 				type: "response_item",
 				payload: {
+					type: "reasoning",
+					id: "rs_1",
+					summary: [{ type: "summary_text", text: "private Codex reasoning" }],
+					encrypted_content: "opaque Codex continuation",
+				},
+			},
+			{
+				timestamp: "2026-04-20T10:00:10Z",
+				type: "response_item",
+				payload: {
 					type: "agent_message",
 					id: "amsg_123",
 					author: "planner",
 					recipient: "worker",
-					content: [{ type: "input_text", text: "visible handoff" }],
+					content: [
+						{ type: "input_text", text: "visible handoff" },
+						{ type: "encrypted_content", data: "opaque handoff continuation" },
+					],
 				},
 			},
 		];
@@ -308,6 +321,22 @@ describe("CodexAdapter.collectSessions", () => {
 				type: "message",
 				role: "developer",
 				parts: [{ type: "text", text: "[Agent message from planner to worker]\nvisible handoff" }],
+			}),
+		);
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "reasoning",
+				kind: "reasoning",
+				parts: [{ type: "text", text: "private Codex reasoning" }],
+				payload_json: '{"encrypted_content":"opaque Codex continuation"}',
+			}),
+		);
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "reasoning",
+				kind: "redacted",
+				parts: [],
+				payload_json: '{"encrypted_content":"opaque handoff continuation"}',
 			}),
 		);
 		expect(JSON.stringify(events)).not.toContain(imageData);

--- a/packages/cli/tests/adapters/hermes.test.ts
+++ b/packages/cli/tests/adapters/hermes.test.ts
@@ -73,10 +73,12 @@ describe("HermesAdapter.collectSessions", () => {
 			"2",
 			"3",
 			"3",
+			"3",
 			"4",
 			"5",
 			"6",
 			"7",
+			"8",
 			"8",
 			"9",
 			"10",
@@ -106,18 +108,24 @@ describe("HermesAdapter.collectSessions", () => {
 			},
 		});
 		expect(events[2]).toMatchObject({
+			type: "reasoning",
+			parts: [{ type: "text", text: "hidden row reasoning" }],
+			payload_json: '{"items":[{"text":"hidden codex reasoning","type":"reasoning"}]}',
+			semantics: { lifecycle: "compacted" },
+		});
+		expect(events[3]).toMatchObject({
 			type: "tool_call",
 			call_id: "call-search",
 			name: "search",
 			arguments_json: '{"api_key":"sk-tool-secret","query":"Hermes"}',
 			semantics: { lifecycle: "compacted" },
 		});
-		expect(events[3]).toMatchObject({
+		expect(events[4]).toMatchObject({
 			type: "tool_call",
 			call_id: "call-read",
 			name: "read_file",
 		});
-		expect(events[4]).toMatchObject({
+		expect(events[5]).toMatchObject({
 			type: "tool_result",
 			call_id: "call-search",
 			name: "search",
@@ -125,7 +133,7 @@ describe("HermesAdapter.collectSessions", () => {
 			result_json: '[{"items":[{"id":1}],"ok":true,"password":"result-secret"}]',
 			semantics: { lifecycle: "compacted" },
 		});
-		expect(events[7]).toMatchObject({
+		expect(events[8]).toMatchObject({
 			type: "message",
 			role: "user",
 			semantics: {
@@ -135,16 +143,25 @@ describe("HermesAdapter.collectSessions", () => {
 				display_metadata: { attempt: 2 },
 			},
 		});
-		expect(events[6]).toMatchObject({
+		expect(events[7]).toMatchObject({
 			type: "message",
 			parts: [{ type: "text", text: "Summary of earlier turns" }],
 			semantics: { compressed_summary: true },
 		});
-		expect(events[8]).toMatchObject({
+		expect(events[9]).toMatchObject({
+			type: "reasoning",
+			parts: [
+				{ type: "text", text: "hidden reasoning" },
+				{ type: "text", text: "hidden reasoning content" },
+				{ type: "text", text: "hidden inline reasoning" },
+			],
+			payload_json: '{"details":{"encrypted_content":"opaque reasoning"}}',
+		});
+		expect(events[10]).toMatchObject({
 			type: "message",
 			parts: [{ type: "text", text: "Public answer" }],
 		});
-		expect(events[9]).toMatchObject({
+		expect(events[11]).toMatchObject({
 			semantics: {
 				display: "event",
 				display_kind: "async_delegation_complete",
@@ -152,24 +169,31 @@ describe("HermesAdapter.collectSessions", () => {
 			},
 		});
 		// Assistant rows with visible content + tool_calls produce one message and one call.
-		expect(events.slice(10, 12).map((event) => event.type)).toEqual(["message", "tool_call"]);
+		expect(events.slice(12, 14).map((event) => event.type)).toEqual(["message", "tool_call"]);
 		// Raw audit rows are retained: the compaction copy remains distinct and marked compacted.
-		expect(events[5]).toMatchObject({ source: { record_id: "5" } });
-		expect(events[13]).toMatchObject({
+		expect(events[6]).toMatchObject({ source: { record_id: "5" } });
+		expect(events[15]).toMatchObject({
 			source: { record_id: "12" },
 			semantics: { lifecycle: "compacted" },
 		});
-		expect(events[12]).toMatchObject({
+		expect(events[14]).toMatchObject({
 			type: "tool_result",
 			result_json: '{"authorization":"Bearer secret","lines":42,"ok":true}',
 		});
 
 		const serialized = JSON.stringify(session);
+		for (const reasoning of [
+			"hidden row reasoning",
+			"hidden codex reasoning",
+			"hidden inline reasoning",
+			"hidden reasoning content",
+			"opaque reasoning",
+		]) {
+			expect(serialized).toContain(reasoning);
+		}
 		for (const hidden of [
 			"sk-model-secret",
 			"sk-config-secret",
-			"hidden row reasoning",
-			"hidden inline reasoning",
 			"provider envelope secret",
 			"display-secret",
 			"metadata-secret",
@@ -275,7 +299,8 @@ describe("HermesAdapter.collectSessions", () => {
 		);
 		db.close();
 
-		const events = (await new HermesAdapter().sessions.resolve("s-modern"))?.events ?? [];
+		const session = await new HermesAdapter().sessions.resolve("s-modern");
+		const events = session?.events ?? [];
 		const added = events.filter((event) => event.source.record_seq > 12);
 		expect(added).toMatchObject([
 			{
@@ -293,9 +318,25 @@ describe("HermesAdapter.collectSessions", () => {
 				parts: [{ type: "text", text: "<REASONING_SCRATCHPAD>literal tool content" }],
 			},
 			{
+				type: "reasoning",
+				kind: "reasoning",
+				parts: [
+					{ type: "text", text: "hidden think" },
+					{ type: "text", text: "hidden thinking" },
+					{ type: "text", text: "hidden reasoning" },
+					{ type: "text", text: "hidden thought" },
+					{ type: "text", text: "hidden scratchpad" },
+				],
+			},
+			{
 				type: "message",
 				role: "assistant",
 				parts: [{ type: "text", text: "Visible assistant" }],
+			},
+			{
+				type: "reasoning",
+				kind: "reasoning",
+				parts: [{ type: "text", text: "hidden tail" }],
 			},
 			{
 				type: "message",
@@ -316,7 +357,8 @@ describe("HermesAdapter.collectSessions", () => {
 			"hidden scratchpad",
 			"hidden tail",
 		]) {
-			expect(JSON.stringify(added)).not.toContain(hidden);
+			expect(JSON.stringify(added)).toContain(hidden);
+			expect(JSON.stringify(session?.messages)).not.toContain(hidden);
 		}
 	});
 

--- a/packages/cli/tests/adapters/openclaw.test.ts
+++ b/packages/cli/tests/adapters/openclaw.test.ts
@@ -157,6 +157,45 @@ describe("OpenClawAdapter.collectSessions", () => {
 		});
 	});
 
+	it("uploads thinking while keeping the message projection visible-only", async () => {
+		const sessionPath = join(
+			tmpHome,
+			".openclaw",
+			"agents",
+			"main",
+			"sessions",
+			"oc-session-001.jsonl",
+		);
+		const record = {
+			type: "message",
+			timestamp: "2026-04-20T10:00:03.000Z",
+			message: {
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "private OpenClaw thought", signature: "signed" },
+					{ type: "text", text: "visible OpenClaw answer" },
+				],
+			},
+		};
+		writeFileSync(
+			sessionPath,
+			`${readFileSync(sessionPath, "utf-8").trimEnd()}\n${JSON.stringify(record)}\n`,
+		);
+
+		const session = (await new OpenClawAdapter().sessions.collect({ kind: "complete" }))
+			.sessions[0];
+		expect(session?.events).toContainEqual(
+			expect.objectContaining({
+				type: "reasoning",
+				kind: "thinking",
+				parts: [{ type: "text", text: "private OpenClaw thought" }],
+				payload_json: '{"signature":"signed"}',
+			}),
+		);
+		expect(session?.messages.at(-1)?.content).toBe("visible OpenClaw answer");
+		expect(JSON.stringify(session?.messages)).not.toContain("private OpenClaw thought");
+	});
+
 	it("uses displayName as summary", async () => {
 		const a = new OpenClawAdapter();
 		const s = (await a.sessions.collect({ kind: "complete" })).sessions[0]!;

--- a/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
+++ b/packages/cli/tests/e2e/runtime-official-installer-systemd.e2e.test.ts
@@ -339,6 +339,7 @@ test.each(["hermes", "openclaw"] as const)(
 				runUserSystemctl("stop", ...allUserUnits);
 			}
 			spawnSync("systemctl", ["stop", ...systemUnits]);
+			spawnSync("systemctl", ["disable", "--runtime", ...systemUnits]);
 			for (const unit of systemUnits) rmSync(join("/run/systemd/system", unit), { force: true });
 			spawnSync("systemctl", ["daemon-reload"]);
 			spawnSync("loginctl", ["disable-linger", "clawdi"]);
@@ -753,6 +754,7 @@ exec /usr/bin/systemctl "$@"
 				runUserSystemctl("stop", ...allUserUnits);
 			}
 			spawnSync("systemctl", ["stop", ...systemUnits]);
+			spawnSync("systemctl", ["disable", "--runtime", ...systemUnits]);
 			for (const unit of systemUnits) rmSync(join("/run/systemd/system", unit), { force: true });
 			spawnSync("systemctl", ["daemon-reload"]);
 			rmSync(runtimeHome, { recursive: true, force: true });

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -7887,7 +7887,7 @@ export interface components {
              * Adapter
              * @enum {string}
              */
-            adapter: "claude_code" | "codex" | "hermes" | "openclaw" | "pi";
+            adapter: "claude_code" | "codex" | "hermes" | "openclaw" | "pi" | "opencode";
             /** Session Key */
             session_key: string;
             /** Record Id */

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -7911,7 +7911,7 @@ export interface components {
             /** Head Hash */
             head_hash: string;
             /** Events */
-            events: (components["schemas"]["SessionMessageEvent"] | components["schemas"]["SessionToolCallEvent"] | components["schemas"]["SessionToolResultEvent"])[];
+            events: (components["schemas"]["SessionMessageEvent"] | components["schemas"]["SessionToolCallEvent"] | components["schemas"]["SessionToolResultEvent"] | components["schemas"]["SessionReasoningEvent"])[];
         };
         /**
          * SessionExtractResponse
@@ -8133,6 +8133,33 @@ export interface components {
         SessionPermissionsResponse: {
             /** Permissions */
             permissions: components["schemas"]["SessionPermissionResponse"][];
+        };
+        /** SessionReasoningEvent */
+        SessionReasoningEvent: {
+            /** Seq */
+            seq: number;
+            /** Event Id */
+            event_id: string;
+            source: components["schemas"]["SessionEventSource"];
+            /** Timestamp */
+            timestamp?: string | null;
+            semantics?: components["schemas"]["SessionEventSemantics"] | null;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "reasoning";
+            /**
+             * Kind
+             * @enum {string}
+             */
+            kind: "thinking" | "reasoning" | "redacted";
+            /** Parts */
+            parts: components["schemas"]["SessionTextPart"][];
+            /** Payload Json */
+            payload_json?: string | null;
+            /** Model */
+            model?: string | null;
         };
         /** SessionTextPart */
         SessionTextPart: {


### PR DESCRIPTION
## Summary

- extend the existing single events-v1 stream with owner-private Reasoning events
- preserve thinking, signatures, encrypted continuation, redacted state, and reasoning details from Claude Code, Codex, OpenClaw, Pi, and modern Hermes stores
- add OpenCode as a real Connected sessions-only adapter backed by its official SQLite store
- sync OpenCode visible and hidden text, reasoning/provider state, tool calls/results, safe attachment metadata, and lifecycle markers
- keep content, sharing, export, search, and memory projections visible-only while owner /events reads the complete stream
- regenerate the OpenAPI client and update the Session protocol and adapter capability documentation

## Compatibility

- no raw transcript copy, second content protocol, database migration, queue format, or fake adapter capability
- existing Message, ToolCall, and ToolResult clients remain valid against the expanded server union
- OpenCode reuses the existing events-v1 chunk/CAS upload path and exposes Sessions only; it is not a Hosted runtime, Skill store, or MCP target
- deploy the backend before publishing the matching CLI; the first upgraded scan may CAS-rewrite an existing generation when historical reasoning is inserted
- provider request envelopes, attachment bodies, snapshot bodies, patch paths, and local paths remain excluded

## Verification

- Docker workspace typecheck: 4/4 packages passed
- Docker CLI full suite: 1671 pass, 4 existing native lifecycle skips, 0 fail
- OpenCode/Session upload/queue/setup contract lane: 46 pass, 0 fail
- Backend Session event suite: 6 pass, 0 fail
- Shared: typecheck and 72 tests passed
- Web: typecheck, 24 tests, and OSS build passed
- Sidecar: 81 tests passed
- generated OpenAPI client drift check: passed
- full Biome 2.5.9: passed with one pre-existing Hosted Web unused-import warning
- Ruff 0.16.4 lint/format and git whitespace checks: passed
- OpenCode storage contract cross-checked against official v1.18.23 source