### PR TITLE
fix(backend): reduce upload stalls and prevent proxy credential logs

### DIFF
--- a/backend/app/middleware/request_timing.py
+++ b/backend/app/middleware/request_timing.py
@@ -16,7 +16,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 logger = logging.getLogger(__name__)
 _PROCESS_TIME_HEADER = b"x-process-time-ms"
-_SYNC_EVENTS_PATH = "/api/sync/events"
+_SYNC_EVENTS_PATHS = frozenset(("/v1/sync/events", "/api/sync/events"))
 _TELEGRAM_BOT_API_PATH_RE = re.compile(
     r"^(?P<prefix>/(?:api|v1)/channels/telegram/(?:file/)?bot/?)[^/]+(?P<suffix>/.*)?$",
     re.IGNORECASE,
@@ -105,7 +105,7 @@ def _log_safe_path(path: str) -> str:
 
 
 def _is_expected_long_request(path: str) -> bool:
-    if path == _SYNC_EVENTS_PATH:
+    if path in _SYNC_EVENTS_PATHS:
         return True
     match = _TELEGRAM_BOT_API_PATH_RE.match(path)
     if match is None or "/file/" in match.group("prefix").lower():

--- a/backend/app/routes/session_events.py
+++ b/backend/app/routes/session_events.py
@@ -32,7 +32,7 @@ from app.services.file_store import get_file_store
 from app.services.session_events import (
     EMPTY_EVENT_HEAD,
     SessionEventChunkInvalid,
-    validate_event_chunk,
+    validate_event_chunk_async,
 )
 
 router = APIRouter(tags=["session-events"])
@@ -217,7 +217,9 @@ async def upload_session_event_generation_chunk(
 ) -> SessionEventChunkResponse:
     data = await _read_upload(file)
     try:
-        validated = validate_event_chunk(data, start_seq=start_seq, base_head_hash=base_head_hash)
+        validated = await validate_event_chunk_async(
+            data, start_seq=start_seq, base_head_hash=base_head_hash
+        )
     except SessionEventChunkInvalid as exc:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
     if validated.content_hash != content_hash:
@@ -431,7 +433,9 @@ async def append_session_events(
 ) -> SessionEventAppendResponse:
     data = await _read_upload(file)
     try:
-        validated = validate_event_chunk(data, start_seq=base_count, base_head_hash=base_head_hash)
+        validated = await validate_event_chunk_async(
+            data, start_seq=base_count, base_head_hash=base_head_hash
+        )
     except SessionEventChunkInvalid as exc:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
     if (
@@ -579,7 +583,9 @@ async def get_session_events(
             )
         data = await file_store.get(chunk.file_key)
         try:
-            validated = validate_event_chunk(data, start_seq=next_seq, base_head_hash=head)
+            validated = await validate_event_chunk_async(
+                data, start_seq=next_seq, base_head_hash=head
+            )
         except SessionEventChunkInvalid as exc:
             raise HTTPException(
                 status.HTTP_500_INTERNAL_SERVER_ERROR, "Stored session event chunk is invalid"

--- a/backend/app/services/session_content.py
+++ b/backend/app/services/session_content.py
@@ -27,7 +27,7 @@ from app.schemas.session_events import SessionEvent
 from app.services.session_events import (
     EMPTY_EVENT_HEAD,
     project_safe_messages,
-    validate_event_chunk,
+    validate_event_chunk_async,
 )
 
 log = logging.getLogger(__name__)
@@ -137,7 +137,9 @@ async def load_session_messages(
                 raise SessionContentInvalid("events-v1 chunk index is not continuous")
             try:
                 data = await file_store.get(chunk.file_key)
-                validated = validate_event_chunk(data, start_seq=next_seq, base_head_hash=head)
+                validated = await validate_event_chunk_async(
+                    data, start_seq=next_seq, base_head_hash=head
+                )
             except Exception as exc:
                 log.exception("session_event_chunk_fetch_failed file_key=%s", chunk.file_key)
                 raise SessionContentInvalid("events-v1 chunk is unavailable or invalid") from exc

--- a/backend/app/services/session_events.py
+++ b/backend/app/services/session_events.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 from collections.abc import Sequence
@@ -84,6 +85,17 @@ def validate_event_chunk(
         raw_events=raw_events,
         content_hash=hashlib.sha256(data).hexdigest(),
         result_head_hash=advance_event_head(base_head_hash, raw_events),
+    )
+
+
+async def validate_event_chunk_async(
+    data: bytes, *, start_seq: int, base_head_hash: str
+) -> ValidatedEventChunk:
+    return await asyncio.to_thread(
+        validate_event_chunk,
+        data,
+        start_seq=start_seq,
+        base_head_hash=base_head_hash,
     )
 
 

--- a/backend/tests/test_request_timing.py
+++ b/backend/tests/test_request_timing.py
@@ -117,6 +117,7 @@ async def test_request_timing_redacts_telegram_routing_credentials(
 @pytest.mark.parametrize(
     "path",
     [
+        "/v1/sync/events",
         "/api/sync/events",
         "/v1/channels/telegram/bot123456:secret/getUpdates",
     ],

--- a/backend/tests/test_session_events.py
+++ b/backend/tests/test_session_events.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import threading
 import uuid
 from datetime import UTC, datetime
 from typing import Any
@@ -14,6 +15,7 @@ from app.models.session import Session
 from app.services.session_events import (
     EMPTY_EVENT_HEAD,
     EVENT_ADAPTER,
+    ValidatedEventChunk,
     advance_event_head,
     canonical_event_json,
 )
@@ -45,6 +47,40 @@ def _event(seq: int, event_type: str, record_id: str, **fields: Any) -> dict[str
 def _chunk(events: list[dict[str, Any]]) -> tuple[bytes, str]:
     data = b"".join(canonical_event_json(event) + b"\n" for event in events)
     return data, hashlib.sha256(data).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_event_chunk_validation_runs_off_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services import session_events
+
+    event_loop_thread = threading.get_ident()
+    validation_thread: int | None = None
+    expected = ValidatedEventChunk(
+        events=[],
+        raw_events=[],
+        content_hash="a" * 64,
+        result_head_hash="b" * 64,
+    )
+
+    def validate(data: bytes, *, start_seq: int, base_head_hash: str) -> ValidatedEventChunk:
+        nonlocal validation_thread
+        assert data == b"chunk"
+        assert start_seq == 7
+        assert base_head_hash == EMPTY_EVENT_HEAD
+        validation_thread = threading.get_ident()
+        return expected
+
+    monkeypatch.setattr(session_events, "validate_event_chunk", validate)
+
+    actual = await session_events.validate_event_chunk_async(
+        b"chunk", start_seq=7, base_head_hash=EMPTY_EVENT_HEAD
+    )
+
+    assert actual is expected
+    assert validation_thread is not None
+    assert validation_thread != event_loop_thread
 
 
 def test_hermes_event_semantics_are_strict_and_normalized() -> None:

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -89,12 +89,13 @@ proxy:
     interval: 5
     timeout: 5
 
-  # Kamal's proxy log_max_size controls the json-file driver and is separate
-  # from top-level logging. Disable it before selecting journald explicitly.
+  # kamal-proxy v0.9.2 always logs raw request paths, including credentials in
+  # provider-compatible Telegram URLs. Discard proxy stdout/stderr at Docker's
+  # logging boundary; app and accessory logs remain in journald.
   run:
     log_max_size: ""
     options:
-      log-driver: journald
+      log-driver: none
 
 deploy_timeout: 120 # api entrypoint runs alembic before listening
 

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -462,7 +462,9 @@ uses Python `logging` with `logging.basicConfig(level=logging.INFO)` in
 
 `RequestTimingMiddleware` adds `X-Process-Time-Ms` to HTTP responses. Requests
 at or above `SLOW_REQUEST_LOG_MS` log as `request_slow`; 5xx responses log as
-`request_error`, and uncaught exceptions log as `request_failed`.
+`request_error`, and uncaught exceptions log as `request_failed`. Successful
+canonical `/v1/sync/events` and compatibility `/api/sync/events` SSE streams are
+excluded from slow-request warnings because their duration is connection lifetime.
 
 ## Channel queue retention
 

--- a/docs/runbooks/kamal-service-logs.md
+++ b/docs/runbooks/kamal-service-logs.md
@@ -1,10 +1,11 @@
 # Kamal Service Logs
 
 Use this runbook for host-local operational logs from the production Kamal
-deployment. It covers the `web` and `channels-worker` app roles, the
-`whatsapp-baileys`, `postgres`, and `postgres-backup` accessories, and the
-shared `kamal-proxy`. It does not change self-hosted Compose deployments, tenant
-runtimes, or any guest journal configuration.
+deployment. It covers the `web` and `channels-worker` app roles and the
+`whatsapp-baileys`, `postgres`, and `postgres-backup` accessories. The shared
+`kamal-proxy` deliberately does not persist container logs. This does not change
+self-hosted Compose deployments, tenant runtimes, or any guest journal
+configuration.
 
 ## Design
 
@@ -14,16 +15,25 @@ available after Kamal removes the container. `docker logs` remains available
 for a current container, and `journalctl` can select current or removed
 containers by `CONTAINER_NAME`.
 
-Kamal 2.12 applies root [`logging`](https://github.com/basecamp/kamal/blob/bdefb8945ad61751b36d53f789df8c69cf3d0fbb/lib/kamal/configuration/docs/logging.yml)
+Kamal 2.12 applies root [`logging`](https://github.com/basecamp/kamal/blob/v2.12.0/lib/kamal/configuration/docs/logging.yml)
 to app roles and uses the same root arguments when it starts
-[`accessories`](https://github.com/basecamp/kamal/blob/bdefb8945ad61751b36d53f789df8c69cf3d0fbb/lib/kamal/commands/accessory.rb#L13-L30).
+[`accessories`](https://github.com/basecamp/kamal/blob/v2.12.0/lib/kamal/commands/accessory.rb#L13-L30).
 The proxy has a separate
-[`run`](https://github.com/basecamp/kamal/blob/bdefb8945ad61751b36d53f789df8c69cf3d0fbb/lib/kamal/configuration/proxy/run.rb#L48-L102)
-configuration, so its legacy file-size option is disabled and its Docker log
-driver is set explicitly.
+[`run`](https://github.com/basecamp/kamal/blob/v2.12.0/lib/kamal/configuration/proxy/run.rb#L48-L102)
+configuration. Kamal-proxy v0.9.2's
+[`LoggingMiddleware`](https://github.com/basecamp/kamal-proxy/blob/v0.9.2/internal/server/logging_middleware.go)
+unconditionally logs the raw request path and query at INFO, while its
+[`run` command](https://github.com/basecamp/kamal-proxy/blob/v0.9.2/internal/cmd/run.go)
+has no access-log disable or path-redaction option. Telegram-compatible routes
+carry the provider credential in the path, so `config/deploy.yml` uses Docker's
+official [`none` logging driver](https://docs.docker.com/engine/logging/configure/#supported-logging-drivers)
+for the proxy. This discards its stdout and stderr before persistence instead of
+trying to scrub credentials after they have reached the journal.
 
-The host journal is the only log store. Do not add a second application log
-database or mount log files into service data volumes.
+The host journal is the only log store for apps and accessories. Proxy
+request/operational logs are unavailable; use application timing/error logs and
+external health metrics for service diagnosis. Do not add a second application
+log database or mount log files into service data volumes.
 
 ## Host prerequisite
 
@@ -77,7 +87,7 @@ After the host prerequisite is verified:
 3. Reboot `postgres` only in an approved maintenance window; its data volume is
    unchanged, but the database is unavailable while the container restarts.
 4. Reboot the shared proxy once, after every Kamal deployment that can manage it
-   has the same journald configuration.
+   has the same `none` logging-driver configuration.
 
 Do not use this rollout to enable PostgreSQL statement logging, application
 debug logging, or provider protocol dumps. No data or auth volume needs to be
@@ -85,26 +95,33 @@ removed or recreated.
 
 ## Verification and access
 
-Confirm every current container reports `journald`:
+Confirm app and accessory containers report `journald`:
 
 ```bash
 docker ps --format '{{.Names}}' \
-  | grep -E '^clawdi-(web|channels-worker)-|^clawdi-(whatsapp-baileys|postgres|postgres-backup)$|^kamal-proxy$' \
+  | grep -E '^clawdi-(web|channels-worker)-|^clawdi-(whatsapp-baileys|postgres|postgres-backup)$' \
   | while read -r container; do
       docker inspect --format '{{.Name}} {{.HostConfig.LogConfig.Type}}' "$container"
     done
 ```
 
-Expected: both app roles, all three accessories, and `kamal-proxy` print
-`journald`. Use an exact container name to retrieve a bounded window:
+Expected: both app roles and all three accessories print `journald`. Confirm the
+proxy reports `none`:
+
+```bash
+docker inspect --format '{{.Name}} {{.HostConfig.LogConfig.Type}}' kamal-proxy
+```
+
+Use an exact app or accessory container name to retrieve a bounded window:
 
 ```bash
 sudo journalctl --since '1 hour ago' --lines 200 CONTAINER_NAME='<container-name>'
 ```
 
-After a later deploy removes an old app container, repeat the query with its
-old exact name. Seeing its pre-removal entries proves that retention is outside
-the Docker container lifecycle.
+After a later deploy removes an old app container, repeat the query with its old
+exact name. Seeing its pre-removal entries proves that retention is outside the
+Docker container lifecycle. `docker logs kamal-proxy` is intentionally
+unavailable while its logging driver is `none`.
 
 Journal access stays restricted to approved operators. Never paste or export
 raw logs without review. Logs must not contain secrets, QR or pairing values,
@@ -112,6 +129,11 @@ phone numbers or JIDs, message bodies, auth/Signal state, request bodies, or
 provider protocol objects. If any appear, treat that as a logging defect and a
 possible credential/privacy incident; fix the emitting service and rotate
 affected credentials before sharing evidence.
+
+After first applying the proxy logging change, treat any previously retained
+Telegram credential paths as an incident: rotate affected bot tokens and use the
+approved host-log remediation process. Do not inspect, copy, or export raw proxy
+history merely to enumerate credentials.
 
 Docker's official [`journald` driver](https://docs.docker.com/engine/logging/drivers/journald/)
 reference documents the `CONTAINER_NAME` field and continued `docker logs`

--- a/scripts/test-kamal-whatsapp-sidecar-render.sh
+++ b/scripts/test-kamal-whatsapp-sidecar-render.sh
@@ -187,8 +187,9 @@ unless whatsapp_command.include?(
 end
 
 proxy_args = config.proxy_run(config.primary_host).docker_options_args
-unless proxy_args.each_cons(2).include?(expected_logging_args)
-  raise "kamal-proxy logging did not render journald"
+expected_proxy_logging_args = [ "--log-driver", '"none"' ]
+unless proxy_args.each_cons(2).include?(expected_proxy_logging_args)
+  raise "kamal-proxy request logs were not disabled"
 end
 raise "kamal-proxy retained a json-file log option" if proxy_args.include?("--log-opt")
 RUBY


### PR DESCRIPTION
## Summary

- move events-v1 chunk parsing, validation, and hashing off the single API event loop
- classify both canonical and compatibility sync SSE paths as expected long requests
- disable persistence of kamal-proxy stdout/stderr because v0.9.2 logs raw credential-bearing paths with no redaction control
- document the operational boundary and enforce the rendered Kamal config

The shared proxy setting is paired with Clawdi-AI/clawdi-hosted#1888. Do not reboot the shared production proxy until both configurations are merged and deployed.

## Verification

- Docker backend tests: 13 passed
- Docker Ruff lint and format checks: passed
- Kamal 2.12 render contract: passed

## Production follow-up

Deployment and proxy reboot are intentionally out of scope for this PR. Existing Telegram tokens observed in retained proxy logs must be treated as exposed credentials and rotated through the approved incident process.