### PR TITLE
fix(mcp): expose linked projects to v2 runtimes

### DIFF
--- a/backend/app/core/project.py
+++ b/backend/app/core/project.py
@@ -35,7 +35,8 @@ from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import AuthContext
+from app.core.auth import AuthContext, is_runtime_deployment_principal
+from app.models.agent_project_binding import AgentProjectBinding
 from app.models.project import PROJECT_KIND_PERSONAL, Project
 from app.models.session import AgentEnvironment
 
@@ -241,8 +242,8 @@ async def validate_project_read_for_caller(
 
     Rules:
       * project_id must appear in `project_ids_visible_to(auth)`.
-      * Agent API keys still only see their Agent Project
-        (enforced inside project_ids_visible_to itself).
+      * Environment keys remain inside their Agent boundary; strict-v2
+        runtime keys also see Projects explicitly linked to that Agent.
 
     404 if not in the visible set — same "don't leak existence"
     posture as the owner-only validator.
@@ -326,11 +327,9 @@ async def project_ids_visible_to(
         would query Personal but most data lives in env-local
         projects after backfill, producing a day-1 empty-list
         regression.
-      * api_key bound to an Agent environment → only that Agent Project
-        (daemons get their own Project's data,
-        nothing else). This is the deploy-key blast radius
-        boundary — a leaked key from env A must not gain
-        visibility into env B's data ever.
+      * legacy api_key bound to an Agent environment → only that Agent Project.
+      * strict-v2 runtime deployment key → that Agent Project plus Projects
+        explicitly linked to the Agent and still readable by its owner.
       * api_key WITHOUT env binding (the device-flow CLI key from
         `clawdi auth login`) → ALL the user's projects, same as
         Clerk JWT. The user authenticated as themselves; multi-
@@ -341,15 +340,31 @@ async def project_ids_visible_to(
         when its project wasn't the default, since the daemon's
         explicit `?project_id=...` listing intersected to empty.
     """
-    # Bound api_keys are ALWAYS restricted to their bound project.
-    #
-    # Agent API keys ALSO never see shared Projects via membership:
-    # the Agent boundary is the blast-radius boundary (PR #77). A leaked
-    # hosted-pod key must not gain visibility into projects the user
-    # later joined as a recipient.
     if auth.is_cli and auth.api_key is not None and auth.api_key.environment_id is not None:
         env_project = await resolve_default_write_project(db, auth)
-        return [env_project]
+        if not is_runtime_deployment_principal(auth):
+            return [env_project]
+
+        readable_project_ids = await project_ids_readable_by_user(db, auth.user_id)
+        linked_project_ids = list(
+            (
+                await db.execute(
+                    select(AgentProjectBinding.project_id)
+                    .where(
+                        AgentProjectBinding.agent_id == auth.api_key.environment_id,
+                        AgentProjectBinding.binding_type == "context",
+                        AgentProjectBinding.project_id.in_(readable_project_ids),
+                    )
+                    .order_by(
+                        AgentProjectBinding.priority.asc(),
+                        AgentProjectBinding.created_at.asc(),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return [env_project, *linked_project_ids]
 
     # Clerk JWT and unbound CLI key: owned projects UNION projects the
     # user joined as a member.

--- a/backend/tests/test_mcp_capability_parity.py
+++ b/backend/tests/test_mcp_capability_parity.py
@@ -16,9 +16,13 @@ from sqlalchemy import select
 from app.core.auth import AuthContext, get_auth
 from app.core.database import get_session
 from app.main import app
+from app.models.agent_project_binding import AgentProjectBinding
 from app.models.api_key import RUNTIME_DEPLOYMENT_KEY_SCOPES, ApiKey
 from app.models.memory import Memory
+from app.models.project import PROJECT_KIND_WORKSPACE, Project
+from app.models.project_membership import ProjectMembership
 from app.models.session import Session
+from app.models.user import User
 from app.models.vault import Vault, VaultItem, VaultProjectAttachment
 from app.routes import mcp_bridge
 from app.routes import memories as memory_routes
@@ -165,12 +169,43 @@ async def test_hosted_account_memory_and_project_vault_mcp_boundaries(
 
     vault_a = Vault(user_id=seed_user.id, slug="runtime-a", name="Runtime A")
     vault_b = Vault(user_id=seed_user.id, slug="runtime-b", name="Runtime B")
-    db_session.add_all([vault_a, vault_b])
+    linked_owner = User(
+        clerk_id="mcp_parity_linked_owner",
+        email="mcp_parity_linked_owner@test.dev",
+        name="MCP Parity Linked Owner",
+    )
+    db_session.add(linked_owner)
+    await db_session.flush()
+    linked_project = Project(
+        user_id=linked_owner.id,
+        slug="mcp-parity-linked",
+        name="MCP Parity Linked",
+        kind=PROJECT_KIND_WORKSPACE,
+    )
+    linked_vault = Vault(user_id=linked_owner.id, slug="runtime-linked", name="Runtime Linked")
+    db_session.add_all([vault_a, vault_b, linked_project, linked_vault])
     await db_session.flush()
     db_session.add_all(
         [
+            ProjectMembership(
+                project_id=linked_project.id,
+                member_user_id=seed_user.id,
+                role="viewer",
+                joined_via="link",
+                joined_at=now,
+                resolved_owner_handle="mcp-parity-linked-owner",
+            ),
+            AgentProjectBinding(
+                agent_id=env_a.id,
+                project_id=linked_project.id,
+                binding_type="context",
+                priority=1,
+                default_write_enabled=False,
+                created_by_user_id=seed_user.id,
+            ),
             VaultProjectAttachment(vault_id=vault_a.id, project_id=env_a.default_project_id),
             VaultProjectAttachment(vault_id=vault_b.id, project_id=env_b.default_project_id),
+            VaultProjectAttachment(vault_id=linked_vault.id, project_id=linked_project.id),
             VaultItem(
                 vault_id=vault_a.id,
                 section="",
@@ -191,6 +226,13 @@ async def test_hosted_account_memory_and_project_vault_mcp_boundaries(
                 item_name="OTHER_TOKEN",
                 encrypted_value=b"runtime-b-secret",
                 nonce=b"c" * 12,
+            ),
+            VaultItem(
+                vault_id=linked_vault.id,
+                section="",
+                item_name="LINKED_TOKEN",
+                encrypted_value=b"runtime-linked-secret",
+                nonce=b"d" * 12,
             ),
         ]
     )
@@ -263,10 +305,16 @@ async def test_hosted_account_memory_and_project_vault_mcp_boundaries(
             current = _tool_json(await _tool_call(client, 5, "project_current"))
             projects = _tool_json(await _tool_call(client, 6, "project_list"))["projects"]
             assert current["id"] == str(env_a.default_project_id)
-            assert [project["id"] for project in projects] == [str(env_a.default_project_id)]
+            assert {project["id"] for project in projects} == {
+                str(env_a.default_project_id),
+                str(linked_project.id),
+            }
 
             vaults = _tool_json(await _tool_call(client, 7, "vault_list"))["vaults"]
-            assert [entry["vault"]["id"] for entry in vaults] == [str(vault_a.id)]
+            assert {entry["vault"]["id"] for entry in vaults} == {
+                str(vault_a.id),
+                str(linked_vault.id),
+            }
             vault_result = _tool_json(
                 await _tool_call(
                     client,
@@ -314,6 +362,33 @@ async def test_hosted_account_memory_and_project_vault_mcp_boundaries(
                 "reference": default_reference,
                 "value": "runtime-a-default-secret",
             }
+            linked_reference = (
+                f"clawdi://project/{linked_project.id}/vault/runtime-linked/field/LINKED_TOKEN"
+            )
+            linked_result = _tool_json(
+                await _tool_call(
+                    client,
+                    82,
+                    "vault_resolve",
+                    {"reference": linked_reference},
+                )
+            )
+            assert linked_result == {
+                "reference": linked_reference,
+                "value": "runtime-linked-secret",
+            }
+
+            active_auth["value"] = AuthContext(
+                user=seed_user,
+                api_key=ApiKey(
+                    user_id=seed_user.id,
+                    environment_id=env_a.id,
+                    scopes=None,
+                ),
+            )
+            legacy_projects = _tool_json(await _tool_call(client, 84, "project_list"))["projects"]
+            assert [project["id"] for project in legacy_projects] == [str(env_a.default_project_id)]
+
             active_auth["value"] = _runtime_auth(seed_user, env_b.id)
             other_search = await _tool_call(
                 client,


### PR DESCRIPTION
## Summary
- allow strict-v2 runtime deployment keys to read their primary Project and explicitly linked context Projects
- preserve the legacy environment-key boundary and account membership revocation behavior
- cover linked Vault resolution through the native Clawdi MCP surface

## Verification
- `bash scripts/test.sh backend tests/test_mcp_capability_parity.py` (4 passed)
- Ruff check and format on the two changed files
- `git diff --check origin/main..HEAD`