### PR TITLE
perf(backend): enable two API workers

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -6,7 +6,6 @@ import hmac
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from time import monotonic
 from uuid import UUID
 
 import httpx
@@ -106,62 +105,6 @@ _clerk_jwks_client = (
 # long ago. Every authenticated CLI request used to write+commit the row,
 # which becomes write-lock contention on a hot key at scale.
 LAST_USED_THROTTLE = timedelta(minutes=1)
-# Daemons reconcile skills on a 60s cadence. The cache needs to span that
-# interval to avoid turning every conditional GET into three auth DB reads.
-# Dashboard revocation calls `invalidate_api_key_auth_cache`, so user-initiated
-# revokes still take effect immediately in the single-process deployment model.
-API_KEY_AUTH_CACHE_TTL_SECONDS = 75.0
-API_KEY_AUTH_CACHE_MAX_SIZE = 4096
-
-
-@dataclass(frozen=True)
-class _CachedApiKeyAuth:
-    api_key_id: UUID
-    user_id: UUID
-    key_hash: str
-    key_prefix: str
-    label: str
-    scopes: tuple[str, ...] | None
-    environment_id: UUID | None
-    runtime_deployment_id: str | None
-    managed: bool
-    expires_at: datetime | None
-    user_clerk_id: str | None
-    user_clerk_issuer: str | None
-    user_principal_kind: str
-    user_partner_tenant_ref: str | None
-    user_email: str | None
-    user_name: str | None
-    user_avatar_url: str | None
-    skills_revision: int
-    api_key_project_id: UUID | None
-
-    def to_auth_context(self) -> AuthContext:
-        user = User(
-            id=self.user_id,
-            clerk_id=self.user_clerk_id,
-            clerk_issuer=self.user_clerk_issuer,
-            principal_kind=self.user_principal_kind,
-            partner_tenant_ref=self.user_partner_tenant_ref,
-            email=self.user_email,
-            name=self.user_name,
-            avatar_url=self.user_avatar_url,
-            skills_revision=self.skills_revision,
-        )
-        api_key = ApiKey(
-            id=self.api_key_id,
-            user_id=self.user_id,
-            key_hash=self.key_hash,
-            key_prefix=self.key_prefix,
-            label=self.label,
-            scopes=list(self.scopes) if self.scopes is not None else None,
-            environment_id=self.environment_id,
-            runtime_deployment_id=self.runtime_deployment_id,
-            managed=self.managed,
-            expires_at=self.expires_at,
-            revoked_at=None,
-        )
-        return AuthContext(user=user, api_key=api_key, api_key_project_id=self.api_key_project_id)
 
 
 @dataclass(frozen=True, slots=True)
@@ -173,88 +116,12 @@ class _ApiKeyAuthority:
     disabled: bool
 
 
-_api_key_auth_cache: dict[str, tuple[float, _CachedApiKeyAuth]] = {}
-
-
-def _get_cached_api_key_auth(key_hash: str) -> AuthContext | None:
-    cached = _api_key_auth_cache.get(key_hash)
-    if cached is None:
-        return None
-    expires_at, snapshot = cached
-    if expires_at <= monotonic():
-        _api_key_auth_cache.pop(key_hash, None)
-        return None
-    return snapshot.to_auth_context()
-
-
-def _cache_api_key_auth(
-    *,
-    key_hash: str,
-    api_key: ApiKey,
-    user: User,
-    api_key_project_id: UUID | None,
-    now: datetime,
-) -> None:
-    ttl_seconds = API_KEY_AUTH_CACHE_TTL_SECONDS
-    if api_key.expires_at is not None:
-        ttl_seconds = min(ttl_seconds, max(0.0, (api_key.expires_at - now).total_seconds()))
-    if ttl_seconds <= 0:
-        return
-
-    if len(_api_key_auth_cache) >= API_KEY_AUTH_CACHE_MAX_SIZE:
-        current = monotonic()
-        expired = [k for k, (expires_at, _) in _api_key_auth_cache.items() if expires_at <= current]
-        for k in expired:
-            _api_key_auth_cache.pop(k, None)
-        while len(_api_key_auth_cache) >= API_KEY_AUTH_CACHE_MAX_SIZE:
-            _api_key_auth_cache.pop(next(iter(_api_key_auth_cache)))
-
-    _api_key_auth_cache[key_hash] = (
-        monotonic() + ttl_seconds,
-        _CachedApiKeyAuth(
-            api_key_id=api_key.id,
-            user_id=user.id,
-            key_hash=api_key.key_hash,
-            key_prefix=api_key.key_prefix,
-            label=api_key.label,
-            scopes=tuple(api_key.scopes) if api_key.scopes is not None else None,
-            environment_id=api_key.environment_id,
-            runtime_deployment_id=api_key.runtime_deployment_id,
-            managed=api_key.managed,
-            expires_at=api_key.expires_at,
-            user_clerk_id=user.clerk_id,
-            user_clerk_issuer=user.clerk_issuer,
-            user_principal_kind=user.principal_kind,
-            user_partner_tenant_ref=user.partner_tenant_ref,
-            user_email=user.email,
-            user_name=user.name,
-            user_avatar_url=user.avatar_url,
-            skills_revision=int(user.skills_revision or 0),
-            api_key_project_id=api_key_project_id,
-        ),
-    )
-
-
-def invalidate_api_key_auth_cache(api_key_id: UUID) -> None:
-    for key_hash, (_, snapshot) in list(_api_key_auth_cache.items()):
-        if snapshot.api_key_id == api_key_id:
-            _api_key_auth_cache.pop(key_hash, None)
-
-
-def invalidate_user_api_key_auth_cache(user_id: UUID) -> None:
-    for key_hash, (_, snapshot) in list(_api_key_auth_cache.items()):
-        if snapshot.user_id == user_id:
-            _api_key_auth_cache.pop(key_hash, None)
-
-
 async def _assert_active_user_or_401(db: AsyncSession, user_id: UUID) -> None:
     try:
         await assert_user_authority_active(db, user_id)
     except PrincipalSuspendedError:
-        invalidate_user_api_key_auth_cache(user_id)
         raise AccountSuspendedHTTPException() from None
     except PrincipalTerminatedError:
-        invalidate_user_api_key_auth_cache(user_id)
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated") from None
 
 
@@ -295,32 +162,6 @@ async def _auth_via_api_key(token: str, db: AsyncSession) -> AuthContext | None:
         return None
 
     key_hash = hashlib.sha256(token.encode()).hexdigest()
-    cached = _get_cached_api_key_auth(key_hash)
-    if cached is not None:
-        await _assert_active_user_or_401(db, cached.user_id)
-        # Bound Agent keys are an operational authority boundary. Revalidate
-        # their durable key + Agent lifecycle on every cache hit so a request
-        # racing archive commit cannot re-cache authority after the caller's
-        # post-commit invalidation, and so other worker-local caches fail
-        # closed immediately after they observe the committed archive.
-        if cached.api_key is not None and cached.api_key.environment_id is not None:
-            active_key_id = await db.scalar(
-                select(ApiKey.id)
-                .join(
-                    AgentEnvironment,
-                    AgentEnvironment.id == ApiKey.environment_id,
-                )
-                .where(
-                    ApiKey.id == cached.api_key.id,
-                    ApiKey.revoked_at.is_(None),
-                    AgentEnvironment.archived_at.is_(None),
-                )
-            )
-            if active_key_id is None:
-                _api_key_auth_cache.pop(key_hash, None)
-                raise HTTPException(status.HTTP_401_UNAUTHORIZED, "API key has been revoked")
-        return cached
-
     # A separate statement after the advisory lock is intentional: under
     # READ COMMITTED a statement snapshot is fixed before a lock wait, so the
     # joined authority read must start only after any committed lifecycle
@@ -349,18 +190,6 @@ async def _auth_via_api_key(token: str, db: AsyncSession) -> AuthContext | None:
         now = datetime.now(UTC)
         context = _validated_api_key_auth_context(authority, now=now)
 
-    # Agent-bound keys are lifecycle authority and must never be installed in
-    # a process-local cache. A cache fill racing archive commit could otherwise
-    # happen after the archive caller's post-commit invalidation. Unbound keys
-    # retain the existing cache behavior.
-    if authority.api_key.environment_id is None:
-        _cache_api_key_auth(
-            key_hash=key_hash,
-            api_key=authority.api_key,
-            user=context.user,
-            api_key_project_id=authority.api_key_project_id,
-            now=now,
-        )
     return context
 
 
@@ -417,10 +246,8 @@ def _validated_api_key_auth_context(
     if user is None:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "User not found")
     if authority.suspended:
-        invalidate_user_api_key_auth_cache(user.id)
         raise AccountSuspendedHTTPException()
     if authority.disabled:
-        invalidate_user_api_key_auth_cache(user.id)
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Account has been terminated")
     if api_key.environment_id is not None and authority.api_key_project_id is None:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Agent is archived")

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -39,11 +39,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
-from app.core.auth import (
-    invalidate_api_key_auth_cache,
-    invalidate_user_api_key_auth_cache,
-    require_admin_api_key,
-)
+from app.core.auth import require_admin_api_key
 from app.core.database import get_session
 from app.models.ai_provider import AiProvider, AiProviderAuthPayload
 from app.models.api_key import ApiKey
@@ -329,8 +325,6 @@ async def admin_set_principal_suspension(
     except Exception:
         await db.rollback()
         raise
-    if result.user_id is not None:
-        invalidate_user_api_key_auth_cache(result.user_id)
     return AdminPrincipalSuspensionResponse(
         target_clerk_id=body.target_clerk_id,
         suspended=result.suspended,
@@ -1002,7 +996,6 @@ async def admin_revoke_api_key(
         },
     )
     await db.commit()
-    invalidate_api_key_auth_cache(api_key.id)
     logger.info(
         "admin_api_key_revoked target_user_id=%s key_id=%s",
         api_key.user_id,
@@ -2365,7 +2358,7 @@ async def _admin_delete_environment(
     )
     await queue_environment_runtime_manifest_changed(db, env.user_id, environment_id)
     try:
-        revoked_key_ids = await archive_agent_and_project(db, agent=env)
+        await archive_agent_and_project(db, agent=env)
     except AgentLifecycleBoundaryError:
         await db.rollback()
         raise HTTPException(
@@ -2373,8 +2366,6 @@ async def _admin_delete_environment(
             "Agent Project ownership could not be proven; no resources were archived.",
         ) from None
     await db.commit()
-    for key_id in revoked_key_ids:
-        invalidate_api_key_auth_cache(key_id)
     logger.info(
         "admin_environment_deleted target_clerk_id=%s env_id=%s",
         target_clerk_id,

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import AuthContext, get_auth, invalidate_api_key_auth_cache, require_web_auth
+from app.core.auth import AuthContext, get_auth, require_web_auth
 from app.core.database import get_session
 from app.models.api_key import ApiKey
 from app.schemas.api_key import (
@@ -139,7 +139,6 @@ async def revoke_api_key(
     api_key.revoked_at = datetime.now(UTC)
     await notify_sync_subscriptions_changed(db, [api_key.user_id])
     await db.commit()
-    invalidate_api_key_auth_cache(api_key.id)
     return ApiKeyRevokeResponse(status="revoked")
 
 

--- a/backend/app/routes/clerk_webhooks.py
+++ b/backend/app/routes/clerk_webhooks.py
@@ -25,11 +25,9 @@ from pydantic import BaseModel, JsonValue, TypeAdapter, ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import invalidate_api_key_auth_cache, invalidate_user_api_key_auth_cache
 from app.core.config import settings
 from app.core.database import get_session
 from app.models.principal_lifecycle import PrincipalLifecycle
-from app.models.user import User
 from app.services.clerk_backend import clerk_backend_headers, clerk_user_url
 from app.services.principal_lifecycle import (
     PrincipalLifecycleConfigurationError,
@@ -228,7 +226,7 @@ async def clerk_user_lifecycle_webhook(
             return ClerkWebhookResponse()
         banned, authority_updated_at = await _fetch_clerk_authority(subject)
         try:
-            changed = await project_clerk_user_authority(
+            await project_clerk_user_authority(
                 db,
                 issuer=issuer,
                 subject=subject,
@@ -243,15 +241,6 @@ async def clerk_user_lifecycle_webhook(
                 "Clerk lifecycle receiver is not configured",
             ) from None
         await db.commit()
-        if changed:
-            user_id = await db.scalar(
-                select(User.id).where(
-                    User.clerk_issuer == issuer,
-                    User.clerk_id == subject,
-                )
-            )
-            if user_id is not None:
-                invalidate_user_api_key_auth_cache(user_id)
         return ClerkWebhookResponse()
 
     try:
@@ -279,7 +268,7 @@ async def clerk_user_lifecycle_webhook(
     # remains recoverable by the existing lifecycle worker.
     await db.commit()
     try:
-        cleanup = await complete_principal_cleanup(db, lifecycle_id=receipt.lifecycle_id)
+        await complete_principal_cleanup(db, lifecycle_id=receipt.lifecycle_id)
         await db.commit()
     except Exception:
         await db.rollback()
@@ -293,10 +282,6 @@ async def clerk_user_lifecycle_webhook(
             "Clerk deletion cleanup is pending retry",
         ) from None
 
-    if receipt.user_id is not None:
-        invalidate_user_api_key_auth_cache(receipt.user_id)
-    for key_id in cleanup.revoked_api_key_ids:
-        invalidate_api_key_auth_cache(key_id)
     return ClerkWebhookResponse()
 
 

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -10,7 +10,6 @@ from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import invalidate_api_key_auth_cache
 from app.core.database import get_session
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
@@ -770,7 +769,7 @@ async def platform_delete_agent(
     }
     await queue_environment_runtime_manifest_changed(db, owner.id, agent_id)
     try:
-        revoked_key_ids = await archive_agent_and_project(db, agent=agent)
+        await archive_agent_and_project(db, agent=agent)
     except AgentLifecycleBoundaryError:
         raise HTTPException(
             status.HTTP_409_CONFLICT,
@@ -797,8 +796,6 @@ async def platform_delete_agent(
         environment_id=agent_id,
         audit_details=audit_details,
     )
-    for key_id in revoked_key_ids:
-        invalidate_api_key_auth_cache(key_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -1330,8 +1327,6 @@ async def platform_revoke_api_key(
         environment_id=api_key.environment_id,
         audit_details={"already_revoked": already_revoked},
     )
-    if not already_revoked:
-        invalidate_api_key_auth_cache(api_key.id)
     return response
 
 

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -29,7 +29,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import (
     AuthContext,
     get_auth,
-    invalidate_api_key_auth_cache,
     is_connected_agent_principal,
     require_any_scope,
     require_scope,
@@ -1771,7 +1770,7 @@ async def _delete_agent_identity(
         )
     await queue_environment_runtime_manifest_changed(db, auth.user_id, agent_id)
     try:
-        revoked_key_ids = await archive_agent_and_project(db, agent=env)
+        await archive_agent_and_project(db, agent=env)
     except AgentLifecycleBoundaryError:
         await db.rollback()
         raise HTTPException(
@@ -1779,8 +1778,6 @@ async def _delete_agent_identity(
             "Agent Project ownership could not be proven; no resources were archived.",
         ) from None
     await db.commit()
-    for key_id in revoked_key_ids:
-        invalidate_api_key_auth_cache(key_id)
 
 
 @router.delete("/agents/{agent_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/runtime_entrypoint.py
+++ b/backend/app/runtime_entrypoint.py
@@ -3,9 +3,11 @@ import signal
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 API_ROLE = "api"
 CHANNELS_WORKER_ROLE = "channels-worker"
+PROMETHEUS_MULTIPROC_DIR_NAME = "clawdi-prometheus-multiproc"
 
 # How long the API keeps serving after SIGTERM. Some container proxies only
 # stop routing on the container's die event, so the listener must stay open
@@ -27,15 +29,33 @@ _API_SERVER_ARGS = [
 ]
 
 
+def _prepare_prometheus_multiprocess_dir() -> None:
+    raw_path = os.environ.get("PROMETHEUS_MULTIPROC_DIR", "").strip()
+    if not raw_path:
+        return
+    directory = Path(raw_path).resolve()
+    if directory.name != PROMETHEUS_MULTIPROC_DIR_NAME:
+        raise RuntimeError(
+            f"PROMETHEUS_MULTIPROC_DIR must end with {PROMETHEUS_MULTIPROC_DIR_NAME!r}"
+        )
+    directory.mkdir(parents=True, exist_ok=True)
+    for entry in directory.iterdir():
+        if not entry.is_file():
+            raise RuntimeError(f"Prometheus multiprocess directory contains {entry.name!r}")
+        entry.unlink()
+
+
 def _exec(args: list[str]) -> None:
     os.execvp(args[0], args)
 
 
 def _run_api_with_drain() -> int:
+    _prepare_prometheus_multiprocess_dir()
     migrate = subprocess.run(_API_MIGRATE_ARGS)
     if migrate.returncode != 0:
         return migrate.returncode
 
+    _prepare_prometheus_multiprocess_dir()
     server = subprocess.Popen(_API_SERVER_ARGS)
 
     def _drain_then_forward(_signum: int, _frame: object) -> None:

--- a/backend/app/services/metrics.py
+++ b/backend/app/services/metrics.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Generator
 from contextlib import contextmanager
 
-from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, Counter, Gauge, Histogram
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    multiprocess,
+)
 from prometheus_client.exposition import generate_latest
 
 registry = CollectorRegistry()
@@ -61,6 +69,7 @@ active_polls = Gauge(
     "msg_router_active_polls",
     "Number of active ingress poll loops",
     ["channel"],
+    multiprocess_mode="sum",
     registry=registry,
 )
 webhook_deliveries = Counter(
@@ -119,6 +128,10 @@ channel_retention_budget_exhaustions = Counter(
 
 
 def render_metrics() -> bytes:
+    if os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+        multiprocess_registry = CollectorRegistry()
+        multiprocess.MultiProcessCollector(multiprocess_registry)
+        return generate_latest(multiprocess_registry)
     return generate_latest(registry)
 
 

--- a/backend/tests/test_auth_keys.py
+++ b/backend/tests/test_auth_keys.py
@@ -113,16 +113,14 @@ async def test_revoked_api_key_is_rejected(db_session, seed_user):
 
 
 @pytest.mark.asyncio
-async def test_agent_key_is_not_cached_and_disconnect_revokes_after_commit(
-    client: httpx.AsyncClient, db_session, engine, seed_user
+async def test_agent_key_disconnect_revokes_after_commit(
+    client: httpx.AsyncClient, db_session, seed_user
 ):
-    import hashlib
     import uuid
 
     from fastapi import HTTPException
-    from sqlalchemy import event
 
-    from app.core.auth import _api_key_auth_cache, _auth_via_api_key
+    from app.core.auth import _auth_via_api_key
     from app.services.agent_environments import (
         local_machine_registration_key,
         register_agent_environment,
@@ -148,6 +146,44 @@ async def test_agent_key_is_not_cached_and_disconnect_revokes_after_commit(
         environment_id=registered.env.id,
     )
     assert await _auth_via_api_key(minted.raw_key, db_session) is not None
+    disconnected = await client.delete(f"/v1/agents/{registered.env.id}")
+    assert disconnected.status_code == 204, disconnected.text
+    with pytest.raises(HTTPException) as exc_info:
+        await _auth_via_api_key(minted.raw_key, db_session)
+    assert exc_info.value.status_code == 401
+    assert "revoked" in str(exc_info.value.detail).lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_unbound_api_key_auth_reloads_committed_scope_and_revocation(
+    db_session,
+    engine,
+    seed_user,
+):
+    from datetime import UTC, datetime
+
+    from sqlalchemy import event, update
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from app.core.auth import _auth_via_api_key
+    from app.services.api_key import mint_api_key
+
+    minted = await mint_api_key(
+        db_session,
+        user_id=seed_user.id,
+        label="durable authority key",
+        scopes=["vault:read", "vault:write"],
+    )
+    assert await _auth_via_api_key(minted.raw_key, db_session) is not None
+    await db_session.commit()
+
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    async with sessionmaker() as mutation_session:
+        await mutation_session.execute(
+            update(ApiKey).where(ApiKey.id == minted.api_key.id).values(scopes=["vault:read"])
+        )
+        await mutation_session.commit()
 
     statements: list[str] = []
 
@@ -156,19 +192,26 @@ async def test_agent_key_is_not_cached_and_disconnect_revokes_after_commit(
 
     event.listen(engine.sync_engine, "before_cursor_execute", capture_statement)
     try:
-        assert await _auth_via_api_key(minted.raw_key, db_session) is not None
+        refreshed = await _auth_via_api_key(minted.raw_key, db_session)
     finally:
         event.remove(engine.sync_engine, "before_cursor_execute", capture_statement)
 
+    assert refreshed is not None
+    assert refreshed.api_key is not None
+    assert refreshed.api_key.scopes == ["vault:read"]
     assert len(statements) == 2
     assert "pg_advisory_xact_lock_shared" in statements[0]
     assert "LEFT OUTER JOIN users" in statements[1]
-    assert "LEFT OUTER JOIN agent_environments" in statements[1]
-    key_hash = hashlib.sha256(minted.raw_key.encode()).hexdigest()
-    assert key_hash not in _api_key_auth_cache
+    await db_session.commit()
 
-    disconnected = await client.delete(f"/v1/agents/{registered.env.id}")
-    assert disconnected.status_code == 204, disconnected.text
+    async with sessionmaker() as mutation_session:
+        await mutation_session.execute(
+            update(ApiKey)
+            .where(ApiKey.id == minted.api_key.id)
+            .values(revoked_at=datetime.now(UTC))
+        )
+        await mutation_session.commit()
+
     with pytest.raises(HTTPException) as exc_info:
         await _auth_via_api_key(minted.raw_key, db_session)
     assert exc_info.value.status_code == 401

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import base64
+import os
 import re
+import subprocess
+import sys
 import uuid
+from pathlib import Path
 
 import httpx
 
@@ -89,6 +93,33 @@ def test_metrics_tracks_gauge_up_and_down() -> None:
 
     text = _metrics_text()
     assert f'msg_router_active_polls{{channel="{channel}"}} 1.0' in text
+
+
+def test_metrics_aggregate_counters_across_processes(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env["PROMETHEUS_MULTIPROC_DIR"] = str(tmp_path)
+    backend_root = Path(__file__).parents[1]
+    increment = (
+        "from app.services.metrics import inbound_messages; "
+        'inbound_messages.labels(channel="multiprocess-test").inc()'
+    )
+    for _ in range(2):
+        subprocess.run([sys.executable, "-c", increment], cwd=backend_root, env=env, check=True)
+    rendered = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from app.services.metrics import render_metrics; "
+            "print(render_metrics().decode(), end='')",
+        ],
+        cwd=backend_root,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+    assert 'msg_router_inbound_total{channel="multiprocess-test"} 2.0' in rendered
 
 
 async def test_metrics_route_allows_when_no_auth_is_configured(

--- a/backend/tests/test_runtime_entrypoint.py
+++ b/backend/tests/test_runtime_entrypoint.py
@@ -71,6 +71,18 @@ def test_api_server_exit_code_propagates(monkeypatch):
     assert runtime_entrypoint._run_api_with_drain() == 7
 
 
+def test_api_startup_wipes_prometheus_multiprocess_dir(monkeypatch, tmp_path):
+    metrics_dir = tmp_path / runtime_entrypoint.PROMETHEUS_MULTIPROC_DIR_NAME
+    metrics_dir.mkdir()
+    (metrics_dir / "counter_123.db").write_bytes(b"stale")
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(metrics_dir))
+    monkeypatch.setattr(runtime_entrypoint, "_API_MIGRATE_ARGS", ["true"])
+    monkeypatch.setattr(runtime_entrypoint, "_API_SERVER_ARGS", ["true"])
+
+    assert runtime_entrypoint._run_api_with_drain() == 0
+    assert list(metrics_dir.iterdir()) == []
+
+
 def test_api_sigterm_drains_before_forwarding(monkeypatch):
     """The listener must outlive the routing: on SIGTERM the entrypoint keeps
     the server running for the drain window, then forwards the signal. Uses a

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -1202,7 +1202,7 @@ async def test_bound_api_key_skills_etag_reads_current_db_revision(
     seed_user,
     project_id: str,
 ):
-    """A bound key must not 304 from its TTL-cached auth revision snapshot."""
+    """A bound key must not 304 from a stale request auth revision snapshot."""
     from sqlalchemy import update
 
     from app.core.auth import AuthContext, get_auth_short_session
@@ -1273,7 +1273,7 @@ async def test_bound_api_key_skills_etag_reads_current_db_revision(
     assert inline_replay.status_code == 200, inline_replay.text
     assert inline_replay.headers.get("etag") is None
 
-    # Simulate the API-key auth cache retaining its old user snapshot while a
+    # Simulate a request auth context retaining its old user snapshot while a
     # Skill mutation commits a newer revision in PostgreSQL.
     await db_session.execute(
         update(User)

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -50,14 +50,20 @@ servers:
     hosts:
       - <%= ENV.fetch("DEPLOY_HOST") %>
     options:
-      memory: 4g # embedding model (~1.6G resident) + launch-load headroom
+      memory: 6g # two embedding-model workers (~1.6G resident each) + launch-load headroom
       ulimit: nofile=65536:65536 # long-lived SSE/WebSocket connections
       # tini as PID 1 reaps orphaned subprocesses (zombie prevention).
       init: true
     env:
       clear:
-        # Resume replay, rate-limit, and SSE cap state is process-local.
-        WEB_CONCURRENCY: 1
+        # Discord Resume replay and provider rate-limit smoothing are
+        # process-local; PostgreSQL inbox state and upstream 429s stay authoritative.
+        WEB_CONCURRENCY: 2
+        # Each uvicorn worker owns its SQLAlchemy pool. Two 10+10 pools keep
+        # the web role at the previous 40-connection theoretical maximum.
+        DB_POOL_SIZE: 10
+        DB_MAX_OVERFLOW: 10
+        PROMETHEUS_MULTIPROC_DIR: /tmp/clawdi-prometheus-multiproc
   channels-worker:
     hosts:
       - <%= ENV.fetch("DEPLOY_HOST") %>

--- a/scripts/test-kamal-whatsapp-sidecar-render.sh
+++ b/scripts/test-kamal-whatsapp-sidecar-render.sh
@@ -142,19 +142,37 @@ config.roles.each do |role|
 end
 
 web = config.role("web")
-unless web.specialized_env.clear == { "WEB_CONCURRENCY" => 1 }
-  raise "web role lost its single-worker contract"
+expected_web_env = {
+  "WEB_CONCURRENCY" => 2,
+  "DB_POOL_SIZE" => 10,
+  "DB_MAX_OVERFLOW" => 10,
+  "PROMETHEUS_MULTIPROC_DIR" => "/tmp/clawdi-prometheus-multiproc",
+}
+unless web.specialized_env.clear == expected_web_env
+  raise "web role worker contract drifted"
 end
-raise "web role memory drifted" unless config.raw_config.servers.dig("web", "options", "memory") == "4g"
+raise "web role memory drifted" unless config.raw_config.servers.dig("web", "options", "memory") == "6g"
 web_env = web.env(web.primary_host).clear
-unless web_env.values_at("DB_POOL_SIZE", "DB_MAX_OVERFLOW") == [ 20, 20 ]
-  raise "web role did not inherit the top-level database pool"
+unless web_env.values_at("DB_POOL_SIZE", "DB_MAX_OVERFLOW") == [ 10, 10 ]
+  raise "web role database pool drifted"
 end
 channels_worker = config.role("channels-worker")
 worker_role = channels_worker.specialized_env.clear == { "CLAWDI_PROCESS_ROLE" => "channels-worker" }
 unless worker_role && !channels_worker.running_proxy?
   raise "channels-worker role contract drifted"
 end
+channels_worker_env = channels_worker.env(channels_worker.primary_host).clear
+unless channels_worker_env.values_at("DB_POOL_SIZE", "DB_MAX_OVERFLOW") == [ 20, 20 ]
+  raise "channels-worker database pool drifted"
+end
+if channels_worker_env.key?("PROMETHEUS_MULTIPROC_DIR")
+  raise "channels-worker unexpectedly enabled multiprocess metrics"
+end
+web_connections = web_env.fetch("WEB_CONCURRENCY") *
+  (web_env.fetch("DB_POOL_SIZE") + web_env.fetch("DB_MAX_OVERFLOW"))
+worker_connections = channels_worker_env.fetch("DB_POOL_SIZE") +
+  channels_worker_env.fetch("DB_MAX_OVERFLOW")
+raise "total database connection budget drifted" unless web_connections + worker_connections == 80
 
 config.accessories.each do |accessory|
   command = Kamal::Commands::Accessory.new(config, name: accessory.name).run


### PR DESCRIPTION
## Summary

- remove the process-local API-key authority cache so revocation and scope changes remain durable across workers
- run two API workers with a 6 GiB container and per-worker 10+10 database pools, preserving the existing aggregate pool budget
- aggregate web metrics with the Prometheus multiprocess collector and lock the rendered Kamal contract

## Verification

- isolated Docker backend tests: 32 passed
- focused runtime entrypoint tests: 7 passed
- Ruff, Ruff format, BasedPyright: passed
- Kamal 2.12 render contract: passed

## Risk and rollback

- API-key authentication now always performs the existing two durable Postgres authority reads; last-used writes remain throttled
- an unknown cross-worker Discord Resume falls back to protocol OP 9 then Identify; pending messages remain PostgreSQL-authoritative and replay
- a hard Uvicorn worker crash may leave the active-poll gauge high until the container restarts; counters remain valid for the container lifetime
- no schema migration; rollback is the previous image/config through the normal release path

Head: f59fdaeae