### PR TITLE
perf(backend): offload skill archive processing

### DIFF
--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hmac
 import io
 import tarfile
@@ -71,6 +72,32 @@ _PROJECT_SKILL_SUPPORT_DIRS = {"references", "templates", "scripts", "assets", "
 _MAX_PROJECT_SKILL_FILE_BYTES = 16 * 1024 * 1024
 _MAX_PROJECT_SKILL_ARCHIVE_BYTES = 25 * 1024 * 1024
 file_store = get_file_store()
+
+
+def _prepare_project_skill_archive_sync(
+    stored: bytes,
+    file_key: str,
+    source_skill_key: str,
+    local_skill_key: str,
+) -> bytes:
+    if file_key.endswith(".md"):
+        return tar_from_content(local_skill_key, stored.decode("utf-8"))[0]
+    return reroot_skill_archive(stored, source_skill_key, local_skill_key)
+
+
+async def _prepare_project_skill_archive(
+    stored: bytes,
+    file_key: str,
+    source_skill_key: str,
+    local_skill_key: str,
+) -> bytes:
+    return await asyncio.to_thread(
+        _prepare_project_skill_archive_sync,
+        stored,
+        file_key,
+        source_skill_key,
+        local_skill_key,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -484,10 +511,12 @@ async def get_project_skill_archive(
     ).local_skill_key
     try:
         stored = await file_store.get(skill.file_key)
-        if skill.file_key.endswith(".md"):
-            stored, _file_count = tar_from_content(local_skill_key, stored.decode("utf-8"))
-        else:
-            stored = reroot_skill_archive(stored, skill.skill_key, local_skill_key)
+        stored = await _prepare_project_skill_archive(
+            stored,
+            skill.file_key,
+            skill.skill_key,
+            local_skill_key,
+        )
     except Exception:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Skill archive not found") from None
     if len(stored) > _MAX_PROJECT_SKILL_ARCHIVE_BYTES:

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -1,9 +1,11 @@
+import asyncio
 import hashlib
 import io
 import json
 import logging
 import re
 import tarfile
+from dataclasses import dataclass
 from typing import TypedDict
 from uuid import UUID
 
@@ -277,6 +279,48 @@ def _compute_file_tree_hash(tar_bytes: bytes, skill_key: str | None = None) -> s
         h.update(path.encode("utf-8"))
         h.update(content)
     return h.hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class _SkillUploadAnalysis:
+    file_count: int
+    name: str
+    description: str
+    content_hash: str
+
+
+class _SkillArchiveRootMismatch(ValueError):
+    def __init__(self, member_name: str) -> None:
+        self.member_name = member_name
+        super().__init__(member_name)
+
+
+class _SkillDocumentMissing(ValueError):
+    pass
+
+
+def _analyze_skill_upload_sync(data: bytes, skill_key: str) -> _SkillUploadAnalysis:
+    file_count = validate_tar(data)
+    expected_prefix = f"{skill_key}/"
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tf:
+        for member in tf.getmembers():
+            if member.name != skill_key and not member.name.startswith(expected_prefix):
+                raise _SkillArchiveRootMismatch(member.name)
+
+    skill_md = extract_skill_md(data)
+    if not skill_md:
+        raise _SkillDocumentMissing
+    frontmatter = parse_frontmatter(skill_md)
+    return _SkillUploadAnalysis(
+        file_count=file_count,
+        name=frontmatter.get("name", skill_key),
+        description=frontmatter.get("description", ""),
+        content_hash=_compute_file_tree_hash(data, skill_key),
+    )
+
+
+async def _analyze_skill_upload(data: bytes, skill_key: str) -> _SkillUploadAnalysis:
+    return await asyncio.to_thread(_analyze_skill_upload_sync, data, skill_key)
 
 
 # ---------------------------------------------------------------------------
@@ -1607,7 +1651,7 @@ async def _do_upload_skill(
             f"({', '.join(sorted(RESERVED_SKILL_KEY_SUFFIXES))})",
         )
     try:
-        file_count = validate_tar(data)
+        analysis = await _analyze_skill_upload(data, skill_key)
     except TarValidationError as e:
         # `str(e)` echoes raw tar member names (attacker-controlled)
         # back to the client. Log internally, return a fixed message.
@@ -1618,42 +1662,22 @@ async def _do_upload_skill(
             _sanitize_log(e),
         )
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "archive validation failed") from None
-
-    # The archive's directory layout MUST be rooted at the
-    # declared skill_key. For a nested key `category/foo` we
-    # require every tar entry to start with `category/foo/`. Pre-
-    # fix the upload silently accepted an archive rooted at
-    # `foo/...` for `skill_key=category/foo`: the hash stripped 2
-    # leading components leaving an empty / wrong tree, the bytes
-    # were stored as-is, and a later download/extract on another
-    # machine plopped `foo/` at the skills root instead of
-    # `category/foo/` — breaking restore.
-    expected_prefix = f"{skill_key}/"
-    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tf:
-        for member in tf.getmembers():
-            # Pure directory entries (no slash, member.name == skill_key)
-            # are also accepted — the actual files always carry the
-            # full prefix.
-            if member.name == skill_key:
-                continue
-            if not member.name.startswith(expected_prefix):
-                log.warning(
-                    "skill_upload_root_mismatch user=%s skill_key=%s offending=%s",
-                    auth.user_id,
-                    skill_key,
-                    _sanitize_log(member.name),
-                )
-                raise HTTPException(
-                    status.HTTP_400_BAD_REQUEST,
-                    "archive root does not match skill_key",
-                )
-
-    skill_md = extract_skill_md(data)
-    if not skill_md:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Archive must contain a SKILL.md")
-
-    try:
-        fm = parse_frontmatter(skill_md)
+    except _SkillArchiveRootMismatch as e:
+        log.warning(
+            "skill_upload_root_mismatch user=%s skill_key=%s offending=%s",
+            auth.user_id,
+            skill_key,
+            _sanitize_log(e.member_name),
+        )
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "archive root does not match skill_key",
+        ) from None
+    except _SkillDocumentMissing:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Archive must contain a SKILL.md",
+        ) from None
     except SkillTextValidationError:
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,
@@ -1662,14 +1686,15 @@ async def _do_upload_skill(
                 "message": "SKILL.md must not contain NUL characters.",
             },
         ) from None
-    name = fm.get("name", skill_key)
-    description = fm.get("description", "")
+    file_count = analysis.file_count
+    name = analysis.name
+    description = analysis.description
 
     # The server is the integrity boundary. A caller-supplied hash is useful
     # for catching client bugs but never becomes evidence by itself: an Agent
     # claim must prove that the validated archive bytes equal the claimed
     # content or a forged existing hash could claim without storing new bytes.
-    computed_content_hash = _compute_file_tree_hash(data, skill_key)
+    computed_content_hash = analysis.content_hash
     if content_hash is not None and content_hash != computed_content_hash:
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,

--- a/backend/tests/test_project_runtime_skills.py
+++ b/backend/tests/test_project_runtime_skills.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import tarfile
+import threading
 import uuid
 from datetime import UTC, datetime, timedelta
 from urllib.parse import urlsplit
@@ -23,6 +24,7 @@ from app.models.project_membership import ProjectMembership
 from app.models.session import AgentEnvironment
 from app.models.skill import SKILL_AUTHORITY_AGENT_SYNC, SKILL_AUTHORITY_CLOUD, Skill
 from app.models.user import User
+from app.routes import runtime as runtime_routes
 from app.routes import skills as skill_routes
 from app.routes.skills import _compute_file_tree_hash
 from app.services import project_runtime_skills
@@ -51,6 +53,38 @@ def _skill_archive(
     )
     archive, _ = tar_from_content(skill_key, content)
     return archive
+
+
+@pytest.mark.asyncio
+async def test_project_skill_archive_preparation_runs_off_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_loop_thread = threading.get_ident()
+    preparation_thread: int | None = None
+    prepare = runtime_routes._prepare_project_skill_archive_sync
+
+    def capture_thread(
+        stored: bytes,
+        file_key: str,
+        source_skill_key: str,
+        local_skill_key: str,
+    ) -> bytes:
+        nonlocal preparation_thread
+        preparation_thread = threading.get_ident()
+        return prepare(stored, file_key, source_skill_key, local_skill_key)
+
+    monkeypatch.setattr(runtime_routes, "_prepare_project_skill_archive_sync", capture_thread)
+    archive = _skill_archive("source", local_skill_key="local")
+    result = await runtime_routes._prepare_project_skill_archive(
+        archive,
+        "skill.tar.gz",
+        "source",
+        "local",
+    )
+
+    assert result
+    assert preparation_thread is not None
+    assert preparation_thread != event_loop_thread
 
 
 async def _upload_project_skill(

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import io
 import logging
 import tarfile
+import threading
 import uuid
 
 import httpx
@@ -48,6 +49,28 @@ def _archive_with_files(skill_key: str, files: dict[str, bytes]) -> bytes:
             info.mode = 0o644
             archive.addfile(info, io.BytesIO(content))
     return output.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_skill_upload_analysis_runs_off_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_loop_thread = threading.get_ident()
+    analysis_thread: int | None = None
+    analyze = skill_routes._analyze_skill_upload_sync
+
+    def capture_thread(data: bytes, skill_key: str) -> skill_routes._SkillUploadAnalysis:
+        nonlocal analysis_thread
+        analysis_thread = threading.get_ident()
+        return analyze(data, skill_key)
+
+    monkeypatch.setattr(skill_routes, "_analyze_skill_upload_sync", capture_thread)
+    archive, _ = tar_from_content("threaded", "# Threaded\n")
+    result = await skill_routes._analyze_skill_upload(archive, "threaded")
+
+    assert result.file_count == 1
+    assert analysis_thread is not None
+    assert analysis_thread != event_loop_thread
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- move Skill upload tar validation, root checks, metadata parsing, and tree hashing off the API event loop
- move runtime Skill archive creation and rerooting off the event loop
- preserve validation responses, sanitized logging, content hashes, and persistence ordering

## Verification

- isolated Docker: 5 passed, 55 deselected
- Ruff check: passed
- Ruff format check: passed
- BasedPyright for changed production routes: 0 errors, 0 warnings
- `git diff --check`: passed