### PR TITLE
perf(backend): expose runtime bottleneck metrics

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,9 +1,22 @@
+import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
+from sqlalchemy import event
+from sqlalchemy.engine import Connection, ExceptionContext
+from sqlalchemy.engine.interfaces import DBAPIConnection, DBAPICursor, ExecutionContext
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import ConnectionPoolEntry, PoolProxiedConnection
 
 from app.core.config import settings
+from app.services.metrics import (
+    db_connection_hold_duration,
+    db_pool_checked_out,
+    db_query_duration,
+)
+
+_QUERY_STARTED_AT = "clawdi_query_started_at"
+_CONNECTION_CHECKED_OUT_AT = "clawdi_connection_checked_out_at"
 
 # Explicit pool sizing — sqlalchemy's defaults (5+10) starve at
 # ~10k daemons since each SSE refresh tick burns one connection
@@ -29,6 +42,66 @@ engine = create_async_engine(
         }
     },
 )
+
+
+def _finish_query(connection: Connection) -> None:
+    started = connection.info.pop(_QUERY_STARTED_AT, None)
+    if isinstance(started, float):
+        db_query_duration.observe(time.perf_counter() - started)
+
+
+def _before_cursor_execute(
+    connection: Connection,
+    _cursor: DBAPICursor,
+    _statement: str,
+    _parameters: object,
+    _context: ExecutionContext | None,
+    _executemany: bool,
+) -> None:
+    connection.info[_QUERY_STARTED_AT] = time.perf_counter()
+
+
+def _after_cursor_execute(
+    connection: Connection,
+    _cursor: DBAPICursor,
+    _statement: str,
+    _parameters: object,
+    _context: ExecutionContext | None,
+    _executemany: bool,
+) -> None:
+    _finish_query(connection)
+
+
+def _handle_error(exception_context: ExceptionContext) -> None:
+    if exception_context.connection is not None:
+        _finish_query(exception_context.connection)
+
+
+def _connection_checkout(
+    _dbapi_connection: DBAPIConnection,
+    connection_record: ConnectionPoolEntry,
+    _connection_proxy: PoolProxiedConnection,
+) -> None:
+    connection_record.info[_CONNECTION_CHECKED_OUT_AT] = time.perf_counter()
+    db_pool_checked_out.inc()
+
+
+def _connection_checkin(
+    _dbapi_connection: DBAPIConnection | None,
+    connection_record: ConnectionPoolEntry,
+) -> None:
+    started = connection_record.info.pop(_CONNECTION_CHECKED_OUT_AT, None)
+    if isinstance(started, float):
+        db_connection_hold_duration.observe(time.perf_counter() - started)
+        db_pool_checked_out.dec()
+
+
+event.listen(engine.sync_engine, "before_cursor_execute", _before_cursor_execute)
+event.listen(engine.sync_engine, "after_cursor_execute", _after_cursor_execute)
+event.listen(engine.sync_engine, "handle_error", _handle_error)
+event.listen(engine.sync_engine.pool, "checkout", _connection_checkout)
+event.listen(engine.sync_engine.pool, "checkin", _connection_checkin)
+
 async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -71,6 +71,7 @@ from app.services.channels import close_channel_provider_http_client
 from app.services.composio import close_composio_client
 from app.services.embedding import LocalEmbedder
 from app.services.memory_types import MemoryProviderUnavailableError, MemoryProviderUpstreamError
+from app.services.metrics import observe_event_loop_lag
 from app.services.sync_events import start_postgres_listener, stop_postgres_listener
 from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarClientPool
 
@@ -118,6 +119,9 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         raise
 
     await warm_clerk_jwks()
+    lag_monitor = asyncio.create_task(observe_event_loop_lag(), name="event-loop-lag")
+    background.add(lag_monitor)
+    lag_monitor.add_done_callback(background.discard)
 
     if settings.memory_embedding_mode.lower() == "local":
 

--- a/backend/app/services/metrics.py
+++ b/backend/app/services/metrics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -125,6 +126,30 @@ channel_retention_budget_exhaustions = Counter(
     ["record_kind"],
     registry=registry,
 )
+event_loop_lag = Histogram(
+    "clawdi_backend_event_loop_lag_seconds",
+    "Delay beyond the backend event loop's one-second sampling interval",
+    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5),
+    registry=registry,
+)
+db_query_duration = Histogram(
+    "clawdi_backend_db_query_duration_seconds",
+    "Time spent executing backend database statements",
+    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5),
+    registry=registry,
+)
+db_connection_hold_duration = Histogram(
+    "clawdi_backend_db_connection_hold_duration_seconds",
+    "Time backend database connections remain checked out",
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 15, 60),
+    registry=registry,
+)
+db_pool_checked_out = Gauge(
+    "clawdi_backend_db_pool_checked_out",
+    "Number of backend database connections currently checked out",
+    multiprocess_mode="sum",
+    registry=registry,
+)
 
 
 def render_metrics() -> bytes:
@@ -137,6 +162,14 @@ def render_metrics() -> bytes:
 
 def metrics_content_type() -> str:
     return CONTENT_TYPE_LATEST
+
+
+async def observe_event_loop_lag(interval_seconds: float = 1.0) -> None:
+    loop = asyncio.get_running_loop()
+    while True:
+        started = loop.time()
+        await asyncio.sleep(interval_seconds)
+        event_loop_lag.observe(max(0.0, loop.time() - started - interval_seconds))
 
 
 @contextmanager

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -9,8 +9,10 @@ import uuid
 from pathlib import Path
 
 import httpx
+from sqlalchemy import text
 
 from app.core.config import settings
+from app.core.database import engine
 from app.services.metrics import (
     active_polls,
     inbound_messages,
@@ -39,6 +41,11 @@ def _metric_value(name: str, labels: dict[str, str]) -> float:
     return float(match.group(1)) if match else 0.0
 
 
+def _unlabeled_metric_value(name: str) -> float:
+    match = re.search(rf"^{re.escape(name)} ([-+0-9.eE]+)$", _metrics_text(), re.MULTILINE)
+    return float(match.group(1)) if match else 0.0
+
+
 def test_metrics_exports_all_expected_metrics() -> None:
     text = _metrics_text()
     assert "msg_router_inbound_total" in text
@@ -57,6 +64,10 @@ def test_metrics_exports_all_expected_metrics() -> None:
     assert "msg_router_channel_retention_deletions_total" in text
     assert "msg_router_channel_retention_secret_scrubs_total" in text
     assert "msg_router_channel_retention_budget_exhaustions_total" in text
+    assert "clawdi_backend_event_loop_lag_seconds" in text
+    assert "clawdi_backend_db_query_duration_seconds" in text
+    assert "clawdi_backend_db_connection_hold_duration_seconds" in text
+    assert "clawdi_backend_db_pool_checked_out" in text
 
 
 def test_metrics_increment_counters() -> None:
@@ -93,6 +104,30 @@ def test_metrics_tracks_gauge_up_and_down() -> None:
 
     text = _metrics_text()
     assert f'msg_router_active_polls{{channel="{channel}"}} 1.0' in text
+
+
+async def test_database_metrics_follow_connection_lifecycle() -> None:
+    query_count_before = _unlabeled_metric_value("clawdi_backend_db_query_duration_seconds_count")
+    hold_count_before = _unlabeled_metric_value(
+        "clawdi_backend_db_connection_hold_duration_seconds_count"
+    )
+    checked_out_before = _unlabeled_metric_value("clawdi_backend_db_pool_checked_out")
+
+    async with engine.connect() as connection:
+        await connection.execute(text("SELECT 1"))
+        assert _unlabeled_metric_value("clawdi_backend_db_pool_checked_out") == (
+            checked_out_before + 1
+        )
+
+    assert (
+        _unlabeled_metric_value("clawdi_backend_db_query_duration_seconds_count")
+        == query_count_before + 1
+    )
+    assert (
+        _unlabeled_metric_value("clawdi_backend_db_connection_hold_duration_seconds_count")
+        == hold_count_before + 1
+    )
+    assert _unlabeled_metric_value("clawdi_backend_db_pool_checked_out") == checked_out_before
 
 
 def test_metrics_aggregate_counters_across_processes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- sample event-loop scheduler lag once per second in each API worker
- measure SQL execution time, connection checkout hold time, and current pool occupancy with public SQLAlchemy events
- keep all new metrics unlabeled to avoid cardinality and data exposure

## Verification

- Docker focused backend: 10 passed
- Docker full backend: 2488 passed, 12 skipped
- Ruff lint and format: passed
- BasedPyright changed production files: 0 errors

No SQL text, parameters, request paths, or user identifiers are exported.