### PR TITLE
perf(backend): remove remaining memory path stalls

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -127,7 +127,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
 
         async def _warm() -> None:
             try:
-                await asyncio.to_thread(LocalEmbedder.get)
+                await LocalEmbedder.get().initialize()
                 log.info("Local embedder warmed.")
             except (OSError, RuntimeError, ValueError) as exc:
                 log.warning("Local embedder warmup failed: %s", exc)

--- a/backend/app/services/embedding.py
+++ b/backend/app/services/embedding.py
@@ -25,7 +25,10 @@ import logging
 import math
 from collections.abc import Iterable
 from numbers import Real
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from fastembed import TextEmbedding
 
 from app.core.config import settings
 
@@ -53,10 +56,14 @@ class LocalEmbedder:
     _instance: LocalEmbedder | None = None
 
     def __init__(self) -> None:
+        self._model: TextEmbedding | None = None
+        self._initialization_task: asyncio.Task[TextEmbedding] | None = None
+
+    @staticmethod
+    def _load_model() -> TextEmbedding:
         from fastembed import TextEmbedding
 
-        # Lazy-load the model. Blocks on first call while downloading (~1GB).
-        self.model = TextEmbedding(LOCAL_MODEL_NAME)
+        return TextEmbedding(LOCAL_MODEL_NAME)
 
     @classmethod
     def get(cls) -> LocalEmbedder:
@@ -64,10 +71,45 @@ class LocalEmbedder:
             cls._instance = cls()
         return cls._instance
 
+    async def initialize(self) -> TextEmbedding:
+        """Load the model once without blocking the event loop."""
+        if self._model is not None:
+            return self._model
+
+        task = self._initialization_task
+        if task is None:
+            task = asyncio.create_task(
+                asyncio.to_thread(self._load_model),
+                name="local-embedder-initialize",
+            )
+            self._initialization_task = task
+
+        try:
+            model = await asyncio.shield(task)
+        except asyncio.CancelledError:
+            if task.cancelled() and self._initialization_task is task:
+                self._initialization_task = None
+            # A cancelled waiter does not cancel the shared load.
+            raise
+        except Exception:
+            if self._initialization_task is task:
+                self._initialization_task = None
+            raise
+
+        self._model = model
+        if self._initialization_task is task:
+            self._initialization_task = None
+        return model
+
     async def embed(self, text: str) -> list[float]:
+        try:
+            model = await self.initialize()
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise EmbeddingUpstreamError("Local embedding provider request failed") from exc
+
         def _embed_sync() -> list[float]:
             try:
-                values = next(iter(self.model.embed([text])))
+                values = next(iter(model.embed([text])))
             except (OSError, RuntimeError) as exc:
                 raise EmbeddingUpstreamError("Local embedding provider request failed") from exc
             except (StopIteration, TypeError, ValueError) as exc:
@@ -132,22 +174,14 @@ def _validate_embedding(values: Iterable[object], *, provider: str) -> list[floa
 def resolve_embedder() -> Embedder | None:
     """Pick the Embedder based on deployment settings (env vars).
 
-    Returns None only when the configured mode fails to initialize
-    (e.g. api mode without a key). Callers should treat None as
-    "fall back to FTS + trigram only".
+    Local model loading remains lazy and happens through
+    `LocalEmbedder.initialize`, off the event loop. Returns None for an
+    invalid deployment configuration; callers then fall back to FTS + trigram.
     """
     mode = (settings.memory_embedding_mode or "local").lower()
 
     if mode == "local":
-        try:
-            return LocalEmbedder.get()
-        except (OSError, RuntimeError, ValueError) as exc:
-            # fastembed 0.8.0 delegates downloads to requests/Hugging Face
-            # (their HTTP failures derive from OSError) and model loading to
-            # ONNX Runtime (RuntimeError); malformed model metadata is a
-            # ValueError. Unexpected programming errors must still surface.
-            log.warning("LocalEmbedder failed to initialize: %s", exc)
-            return None
+        return LocalEmbedder.get()
 
     if mode == "api":
         if not settings.memory_embedding_api_key:

--- a/backend/app/services/memory_recall.py
+++ b/backend/app/services/memory_recall.py
@@ -18,10 +18,9 @@ from uuid import UUID
 
 from pydantic import JsonValue
 from sqlalchemy import update
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.pool import NullPool
 
 from app.core.config import settings
+from app.core.database import async_session_factory
 from app.models.memory import Memory
 
 log = logging.getLogger(__name__)
@@ -34,18 +33,13 @@ def recall_counting_enabled() -> bool:
 async def bump_recall_counts(user_id: UUID, memory_ids: list[UUID]) -> None:
     """Increment access_count for the given memories. Never raises.
 
-    Uses an EPHEMERAL NullPool engine instead of the app's global
-    session factory: background tasks can outlive the event loop that
-    warmed the global pool (pytest's per-test loops surfaced this as
-    asyncpg "attached to a different loop" corruption bleeding into
-    unrelated tests). One fresh connect per bump is cheap at this
-    call-rate and leaves zero shared state behind.
+    The task owns a short-lived session from the process-wide bounded pool;
+    it never reuses the request session or creates an engine per recall.
     """
     if not memory_ids:
         return
-    engine = create_async_engine(settings.database_url, poolclass=NullPool)
     try:
-        async with AsyncSession(engine) as db:
+        async with async_session_factory() as db:
             await db.execute(
                 update(Memory)
                 .where(Memory.user_id == user_id, Memory.id.in_(memory_ids))
@@ -54,8 +48,6 @@ async def bump_recall_counts(user_id: UUID, memory_ids: list[UUID]) -> None:
             await db.commit()
     except Exception:  # noqa: BLE001 — counting must never break anything
         log.warning("memory_recall_count_failed user=%s n=%d", user_id, len(memory_ids))
-    finally:
-        await engine.dispose()
 
 
 def recall_ids_from_hits(hits: list[dict[str, JsonValue]]) -> list[UUID]:

--- a/backend/tests/test_openai_sdk_boundary.py
+++ b/backend/tests/test_openai_sdk_boundary.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 from collections.abc import Iterator
@@ -218,6 +219,39 @@ async def test_local_embedding_maps_sdk_errors(monkeypatch: pytest.MonkeyPatch) 
     with pytest.raises(EmbeddingUpstreamError, match="request failed") as exc_info:
         await LocalEmbedder().embed("hello")
     assert "provider-internal-detail" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_local_embedding_initialization_is_singleflight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    initialized = threading.Event()
+    release = threading.Event()
+    constructor_threads: list[int] = []
+
+    class FakeTextEmbedding:
+        def __init__(self, model_name: str) -> None:
+            assert model_name == "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
+            constructor_threads.append(threading.get_ident())
+            initialized.set()
+            release.wait(timeout=2)
+
+    monkeypatch.setattr(fastembed, "TextEmbedding", FakeTextEmbedding)
+    embedder = LocalEmbedder()
+    first = asyncio.create_task(embedder.initialize())
+    second: asyncio.Task[object] | None = None
+    try:
+        assert await asyncio.to_thread(initialized.wait, 1)
+        second = asyncio.create_task(embedder.initialize())
+        await asyncio.sleep(0)
+        assert len(constructor_threads) == 1
+        assert constructor_threads[0] != threading.get_ident()
+    finally:
+        release.set()
+
+    assert second is not None
+    first_model, second_model = await asyncio.gather(first, second)
+    assert first_model is second_model
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n\n- load the local fastembed model through an async singleflight so startup warmup and concurrent first requests share one off-loop initialization\n- reuse the bounded application database pool for background memory recall counts instead of creating and disposing a NullPool engine per recall\n- keep the production API at two workers after a read-only capacity check showed no CPU saturation and insufficient 6 GiB headroom for a third model replica\n\n## Production evidence\n\n- two API worker RSS: about 1.90 GiB each\n- web cgroup: 4.15 GiB current, 4.44 GiB peak, 6 GiB limit\n- OOM kills/restarts: 0/0\n- host: 16 CPUs, load about 2, API workers about 0.67 CPU combined\n- PostgreSQL: max_connections 100, 36 client connections, 1 active at inspection time\n\n## Verification\n\n- focused isolated backend tests: 29 passed\n- full isolated backend suite: 2489 passed, 12 skipped\n- post-review embedding boundary tests: 16 passed\n- Ruff check and format: passed\n- BasedPyright: 0 errors\n- Kamal 2.12 render/deployment contract: passed\n\nThe local commit hook could not run because lefthook is not installed on the host; all relevant checks above ran independently in isolated containers.