### PR TITLE
feat(sessions): search visible message text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ database migration, CI, and implementation details.
 
 - Session search now matches visible user and assistant message text in addition to summaries, folders, and IDs. CLI and Web results show the best matching message excerpt; private reasoning, tool payloads, system messages, and hidden events remain excluded.
 
+### Changed
+
+- Newest-first Session detail pages now paginate from the actual visible transcript instead of relying on separately reported message counts, including for incrementally appended event chunks.
+
 ## Clawdi CLI v0.14.24
 
 Package: `clawdi@0.14.24`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Unreleased
+
+### Added
+
+- Session search now matches visible user and assistant message text in addition to summaries, folders, and IDs. CLI and Web results show the best matching message excerpt; private reasoning, tool payloads, system messages, and hidden events remain excluded.
+
 ## Clawdi CLI v0.14.24
 
 Package: `clawdi@0.14.24`

--- a/apps/web/src/components/sessions/session-columns.tsx
+++ b/apps/web/src/components/sessions/session-columns.tsx
@@ -35,6 +35,12 @@ const summaryColumn: DataTableColumnDef<SessionListItem> = {
 						{projectFolder}
 					</div>
 				) : null}
+				{s.search_match ? (
+					<div className="truncate text-xs text-foreground/70">
+						<span className="font-medium capitalize">{s.search_match.role}</span>
+						{`: ${s.search_match.excerpt}`}
+					</div>
+				) : null}
 			</div>
 		);
 	},

--- a/apps/web/src/components/sessions/session-feed.tsx
+++ b/apps/web/src/components/sessions/session-feed.tsx
@@ -265,6 +265,12 @@ export function SessionCard({
 					>
 						{title}
 					</span>
+					{session.search_match ? (
+						<span className="mt-0.5 block truncate text-xs leading-4 text-foreground/75">
+							<span className="font-medium capitalize">{session.search_match.role}</span>
+							{`: ${session.search_match.excerpt}`}
+						</span>
+					) : null}
 					<span
 						data-testid="session-card-meta"
 						className="mt-0.5 flex min-w-0 flex-wrap items-center gap-y-0 text-xs leading-4 text-muted-foreground"

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -167,28 +167,11 @@ export function SessionDetailContent({
 	// and the IntersectionObserver in `LoadMoreSentinel` requests
 	// the next page when the user scrolls near the bottom.
 	//
-	// Direction-aware pagination:
-	//   - asc: classic "load older first, append newer". pageParam
-	//     is the offset to fetch starting from 0.
-	//   - desc: load NEWEST page first, append progressively-older
-	//     pages as the user scrolls down. pageParam is the offset
-	//     of the slice to fetch (counted from 0 in canonical order
-	//     — the server endpoint is direction-agnostic). We compute
-	//     it from `session.message_count` so we don't need a
-	//     separate "total" round-trip.
+	// The backend applies the direction before offset pagination, so offset=0
+	// always means "start from the selected end". This keeps the newest-first
+	// page correct even while metadata and an incremental event append briefly
+	// describe different revisions.
 	const PAGE_SIZE = 100;
-	const totalForPaging = session?.message_count ?? 0;
-	// Page param carries both offset AND limit so the final desc
-	// page can shrink limit to fill exactly the items below the
-	// previous offset. A flat limit=PAGE_SIZE on the last page would
-	// re-fetch the tail of page-2 whenever total isn't a multiple
-	// of PAGE_SIZE (e.g. total=250: p2 covers 50..149, p3 with
-	// offset=0 limit=100 would re-cover 50..99).
-	type PageParam = { offset: number; limit: number };
-	const initialDescOffset = Math.max(0, totalForPaging - PAGE_SIZE);
-	// Backend rejects limit=0 (Query(ge=1)), so clamp ≥ 1 for the
-	// has_content=true + message_count=0 case (uploaded empty array).
-	const initialDescLimit = Math.max(1, totalForPaging - initialDescOffset);
 	const {
 		data: pagesData,
 		isLoading: isContentLoading,
@@ -204,35 +187,20 @@ export function SessionDetailContent({
 		// would only show the OLDEST 100 in newest-first mode —
 		// confusing).
 		queryKey: ["session-messages", sessionId, session?.content_hash ?? null, direction],
-		initialPageParam:
-			direction === "desc"
-				? ({ offset: initialDescOffset, limit: initialDescLimit } as PageParam)
-				: ({ offset: 0, limit: PAGE_SIZE } as PageParam),
+		initialPageParam: 0,
 		queryFn: async ({ pageParam }) => {
-			const { offset, limit } = pageParam as PageParam;
 			return unwrap(
 				await api.GET("/v1/sessions/{session_id}/messages", {
 					params: {
 						path: { session_id: sessionId },
-						query: { offset, limit },
+						query: { offset: pageParam, limit: PAGE_SIZE, direction },
 					},
 				}),
 			);
 		},
-		getNextPageParam: (last): PageParam | undefined => {
-			if (direction === "asc") {
-				const nextOffset = last.offset + last.items.length;
-				if (nextOffset >= last.total) return undefined;
-				return { offset: nextOffset, limit: PAGE_SIZE };
-			}
-			// desc: previous page covered [last.offset, last.offset +
-			// items.length). Next-older page ends EXACTLY at
-			// last.offset, so limit = (last.offset - nextOffset) — no
-			// overlap, no truncation.
-			if (last.offset === 0) return undefined;
-			const nextOffset = Math.max(0, last.offset - PAGE_SIZE);
-			const nextLimit = last.offset - nextOffset;
-			return { offset: nextOffset, limit: nextLimit };
+		getNextPageParam: (last): number | undefined => {
+			const nextOffset = last.offset + last.items.length;
+			return nextOffset < last.total ? nextOffset : undefined;
 		},
 		enabled: !!session?.has_content,
 		retry: (failureCount, err) => {
@@ -254,16 +222,9 @@ export function SessionDetailContent({
 		const msgs: SessionMessage[] = [];
 		const keys: string[] = [];
 		for (const page of pagesData.pages) {
-			if (direction === "asc") {
-				for (let k = 0; k < page.items.length; k++) {
-					msgs.push(page.items[k]);
-					keys.push(String(page.offset + k));
-				}
-			} else {
-				for (let k = page.items.length - 1; k >= 0; k--) {
-					msgs.push(page.items[k]);
-					keys.push(String(page.offset + k));
-				}
+			for (let k = 0; k < page.items.length; k++) {
+				msgs.push(page.items[k]);
+				keys.push(`${direction}:${page.offset + k}`);
 			}
 		}
 		return { messages: msgs, messageKeys: keys };

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -222,7 +222,7 @@ function SessionsListInner() {
 										: params.sort,
 						});
 					}}
-					placeholder="Search summary, folder, or session ID…"
+					placeholder="Search summaries, messages, folders, or IDs…"
 				/>
 			}
 			filters={

--- a/backend/alembic/versions/b1d7e3f9a4c2_session_message_search.py
+++ b/backend/alembic/versions/b1d7e3f9a4c2_session_message_search.py
@@ -18,6 +18,10 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     op.add_column(
+        "session_event_chunks",
+        sa.Column("search_indexed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
         "sessions",
         sa.Column("search_index_revision", sa.String(length=80), nullable=True),
     )
@@ -70,3 +74,4 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_table("session_message_search")
     op.drop_column("sessions", "search_index_revision")
+    op.drop_column("session_event_chunks", "search_indexed_at")

--- a/backend/alembic/versions/b1d7e3f9a4c2_session_message_search.py
+++ b/backend/alembic/versions/b1d7e3f9a4c2_session_message_search.py
@@ -1,0 +1,72 @@
+"""Add rebuildable Session message search projection.
+
+Revision ID: b1d7e3f9a4c2
+Revises: a9c4e2f7b1d6
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b1d7e3f9a4c2"
+down_revision: str | Sequence[str] | None = "a9c4e2f7b1d6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sessions",
+        sa.Column("search_index_revision", sa.String(length=80), nullable=True),
+    )
+    op.create_table(
+        "session_message_search",
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("session_id", sa.UUID(), nullable=False),
+        sa.Column("generation_id", sa.UUID(), nullable=True),
+        sa.Column("content_revision", sa.String(length=80), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("role", sa.String(length=20), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.CheckConstraint("position >= 0", name="ck_session_message_search_position"),
+        sa.CheckConstraint(
+            "role IN ('user', 'assistant')",
+            name="ck_session_message_search_role",
+        ),
+        sa.ForeignKeyConstraint(["session_id"], ["sessions.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["generation_id"],
+            ["session_event_generations.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "session_id",
+            "content_revision",
+            "position",
+            name="pk_session_message_search",
+        ),
+    )
+    op.create_index(
+        "ix_session_message_search_user",
+        "session_message_search",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_session_message_search_generation",
+        "session_message_search",
+        ["generation_id"],
+    )
+    op.create_index(
+        "ix_session_message_search_content_trgm",
+        "session_message_search",
+        ["content"],
+        postgresql_using="gin",
+        postgresql_ops={"content": "gin_trgm_ops"},
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("session_message_search")
+    op.drop_column("sessions", "search_index_revision")

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -364,6 +364,10 @@ class SessionEventChunk(Base, TimestampMixin):
     result_head_hash: Mapped[str] = mapped_column(String(64), nullable=False)
     content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
     file_key: Mapped[str] = mapped_column(Text, nullable=False)
+    # NULL means this chunk predates, or has not completed, the rebuildable
+    # visible-message search projection. Content remains authoritative in the
+    # object store regardless of this derived-state checkpoint.
+    search_indexed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
 
 class SessionEventAppendReceipt(Base, TimestampMixin):

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -246,6 +246,9 @@ class Session(Base, TimestampMixin):
     event_revision: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
     event_count: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
     event_head_hash: Mapped[str | None] = mapped_column(String(64))
+    # Derived, rebuildable search projection. A NULL value means the current
+    # content has not been indexed yet; it never changes content authority.
+    search_index_revision: Mapped[str | None] = mapped_column(String(80))
 
     # Extracted external entities surfaced in the session sidebar. Schema:
     #   {"prs": ["owner/repo#123"], "repos": [...], "branches": [...]}
@@ -263,6 +266,43 @@ class Session(Base, TimestampMixin):
     # Python None → SQL NULL, and the coalesce preserves the
     # server-computed value across re-pushes.
     related_refs: Mapped[dict[str, JsonValue] | None] = mapped_column(JSONB(none_as_null=True))
+
+
+class SessionMessageSearch(Base):
+    __tablename__ = "session_message_search"
+    __table_args__ = (
+        CheckConstraint("position >= 0", name="ck_session_message_search_position"),
+        CheckConstraint(
+            "role IN ('user', 'assistant')",
+            name="ck_session_message_search_role",
+        ),
+        Index("ix_session_message_search_user", "user_id"),
+        Index("ix_session_message_search_generation", "generation_id"),
+        Index(
+            "ix_session_message_search_content_trgm",
+            "content",
+            postgresql_using="gin",
+            postgresql_ops={"content": "gin_trgm_ops"},
+        ),
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    session_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("sessions.id", ondelete="CASCADE"),
+        primary_key=True,
+        nullable=False,
+    )
+    # Event rows follow generation retention automatically. Snapshot rows have
+    # no generation and are replaced atomically with the uploaded snapshot.
+    generation_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("session_event_generations.id", ondelete="CASCADE"),
+    )
+    content_revision: Mapped[str] = mapped_column(String(80), primary_key=True, nullable=False)
+    position: Mapped[int] = mapped_column(Integer, primary_key=True, nullable=False)
+    role: Mapped[Literal["user", "assistant"]] = mapped_column(String(20), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
 
 
 class SessionEventGeneration(Base, TimestampMixin):

--- a/backend/app/routes/public_sessions.py
+++ b/backend/app/routes/public_sessions.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import re
+from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response, status
@@ -45,6 +46,7 @@ from app.services.session_content import (
     SessionContentMissing,
     load_session_messages,
     session_has_uploaded_content,
+    slice_session_messages,
 )
 from app.services.session_export import (
     public_session_base_fields,
@@ -152,6 +154,7 @@ async def get_shared_session_messages(
     session_id: UUID = Path(...),
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=100, ge=1, le=500),
+    direction: Literal["asc", "desc"] = Query(default="asc"),
     db: AsyncSession = Depends(get_session),
     visitor: AuthContext | None = Depends(optional_web_auth),
 ) -> SessionMessagesPage:
@@ -175,7 +178,7 @@ async def get_shared_session_messages(
         ) from None
 
     total = len(raw)
-    sliced = raw[offset : offset + limit]
+    sliced = slice_session_messages(raw, offset=offset, limit=limit, direction=direction)
     return SessionMessagesPage(
         items=[SessionMessageResponse.model_validate(m) for m in sliced],
         total=total,

--- a/backend/app/routes/session_events.py
+++ b/backend/app/routes/session_events.py
@@ -35,7 +35,8 @@ from app.services.session_events import (
     validate_event_chunk_async,
 )
 from app.services.session_search import (
-    activate_event_search_index,
+    event_search_projection_complete,
+    finalize_event_search_index,
     stage_event_search_messages,
 )
 
@@ -90,6 +91,25 @@ async def _read_upload(file: UploadFile) -> bytes:
     if len(data) > _EVENT_CHUNK_MAX_BYTES:
         raise HTTPException(status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, "Event chunk exceeds 8 MiB")
     return data
+
+
+def _stage_missing_chunk_search_projection(
+    db: AsyncSession,
+    session: Session,
+    chunk: SessionEventChunk,
+    events: list[SessionEvent],
+) -> bool:
+    if chunk.search_indexed_at is not None:
+        return False
+    stage_event_search_messages(
+        db,
+        user_id=session.user_id,
+        session_id=session.id,
+        generation_id=chunk.generation_id,
+        events=events,
+    )
+    chunk.search_indexed_at = datetime.now(UTC)
+    return True
 
 
 def _cas_matches(
@@ -266,6 +286,19 @@ async def upload_session_event_generation_chunk(
             or existing.result_head_hash != validated.result_head_hash
         ):
             raise HTTPException(status.HTTP_409_CONFLICT, "Event chunk identity conflict")
+        if _stage_missing_chunk_search_projection(
+            db,
+            session,
+            existing,
+            validated.events,
+        ):
+            try:
+                await db.commit()
+            except IntegrityError as exc:
+                await db.rollback()
+                raise HTTPException(
+                    status.HTTP_409_CONFLICT, "Event chunk search projection conflict"
+                ) from exc
         return SessionEventChunkResponse(
             generation=generation_id,
             start_seq=existing.start_seq,
@@ -292,6 +325,7 @@ async def upload_session_event_generation_chunk(
             result_head_hash=validated.result_head_hash,
             content_hash=content_hash,
             file_key=key,
+            search_indexed_at=datetime.now(UTC),
         )
     )
     stage_event_search_messages(
@@ -417,7 +451,12 @@ async def commit_session_event_generation(
     session.event_count = body.final_count
     session.event_head_hash = body.final_head_hash
     generation.status = "committed"
-    await activate_event_search_index(db, session, generation_id)
+    await finalize_event_search_index(
+        db,
+        session,
+        generation_id,
+        projection_complete=all(chunk.search_indexed_at is not None for chunk in chunks),
+    )
     await db.commit()
     return SessionEventAppendResponse(
         generation=generation_id,
@@ -486,6 +525,36 @@ async def append_session_events(
             head_hash=receipt.result_head_hash,
         ):
             raise _cas_conflict()
+        existing_chunk = (
+            await db.execute(
+                select(SessionEventChunk).where(
+                    SessionEventChunk.generation_id == generation,
+                    SessionEventChunk.start_seq == base_count,
+                )
+            )
+        ).scalar_one_or_none()
+        if existing_chunk is None:
+            raise HTTPException(status.HTTP_409_CONFLICT, "Event append chunk is missing")
+        if _stage_missing_chunk_search_projection(
+            db,
+            session,
+            existing_chunk,
+            validated.events,
+        ):
+            try:
+                await db.flush()
+                await finalize_event_search_index(
+                    db,
+                    session,
+                    generation,
+                    projection_complete=await event_search_projection_complete(db, generation),
+                )
+                await db.commit()
+            except IntegrityError as exc:
+                await db.rollback()
+                raise HTTPException(
+                    status.HTTP_409_CONFLICT, "Event chunk search projection conflict"
+                ) from exc
         return SessionEventAppendResponse(
             generation=generation,
             revision=receipt.result_revision,
@@ -514,6 +583,7 @@ async def append_session_events(
     committed_generation = await db.get(SessionEventGeneration, generation)
     if committed_generation is None or committed_generation.status != "committed":
         raise HTTPException(status.HTTP_409_CONFLICT, "Event generation is not committed")
+    projection_complete = await event_search_projection_complete(db, generation)
     end_seq = final_count - 1
     key = (
         f"session-events/v1/{auth.user_id}/{session.id}/{generation}/chunks/"
@@ -533,6 +603,7 @@ async def append_session_events(
             result_head_hash=final_head_hash,
             content_hash=content_hash,
             file_key=key,
+            search_indexed_at=datetime.now(UTC),
         )
     )
     db.add(
@@ -562,7 +633,12 @@ async def append_session_events(
     session.event_head_hash = final_head_hash
     session.content_hash = final_head_hash
     session.content_uploaded_at = datetime.now(UTC)
-    await activate_event_search_index(db, session, generation)
+    await finalize_event_search_index(
+        db,
+        session,
+        generation,
+        projection_complete=projection_complete,
+    )
     await db.commit()
     return SessionEventAppendResponse(
         generation=generation,

--- a/backend/app/routes/session_events.py
+++ b/backend/app/routes/session_events.py
@@ -34,6 +34,10 @@ from app.services.session_events import (
     SessionEventChunkInvalid,
     validate_event_chunk_async,
 )
+from app.services.session_search import (
+    activate_event_search_index,
+    stage_event_search_messages,
+)
 
 router = APIRouter(tags=["session-events"])
 file_store = get_file_store()
@@ -290,6 +294,13 @@ async def upload_session_event_generation_chunk(
             file_key=key,
         )
     )
+    stage_event_search_messages(
+        db,
+        user_id=session.user_id,
+        session_id=session.id,
+        generation_id=generation_id,
+        events=validated.events,
+    )
     try:
         await db.commit()
     except IntegrityError as exc:
@@ -406,6 +417,7 @@ async def commit_session_event_generation(
     session.event_count = body.final_count
     session.event_head_hash = body.final_head_hash
     generation.status = "committed"
+    await activate_event_search_index(db, session, generation_id)
     await db.commit()
     return SessionEventAppendResponse(
         generation=generation_id,
@@ -538,11 +550,19 @@ async def append_session_events(
             result_head_hash=final_head_hash,
         )
     )
+    stage_event_search_messages(
+        db,
+        user_id=session.user_id,
+        session_id=session.id,
+        generation_id=generation,
+        events=validated.events,
+    )
     session.event_revision = result_revision
     session.event_count = final_count
     session.event_head_hash = final_head_hash
     session.content_hash = final_head_hash
     session.content_uploaded_at = datetime.now(UTC)
+    await activate_event_search_index(db, session, generation)
     await db.commit()
     return SessionEventAppendResponse(
         generation=generation,

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -98,6 +98,7 @@ from app.schemas.session import (
     SessionPermissionCreate,
     SessionPermissionResponse,
     SessionPermissionsResponse,
+    SessionSearchAnchorResponse,
     SessionSearchMatchResponse,
     SessionUploadResponse,
 )
@@ -126,6 +127,7 @@ from app.services.session_content import (
     SessionContentMissing,
     load_session_messages,
     session_has_uploaded_content,
+    slice_session_messages,
 )
 from app.services.session_export import session_to_markdown
 from app.services.session_refs import extract_related_refs
@@ -2642,6 +2644,8 @@ async def list_sessions(
             message_relevance_expr,
             message_match.c.content,
             message_match.c.role,
+            message_match.c.position,
+            message_match.c.content_revision,
         )
     session_filters: list[Any] = [Session.user_id == auth.user_id]
     agent_filter = AgentEnvironment.agent_type == agent if agent else None
@@ -2776,15 +2780,27 @@ async def list_sessions(
                 message_score,
                 message_content,
                 message_role,
+                message_position,
+                message_revision,
             ) = row
             if (
                 message_score is not None
                 and isinstance(message_content, str)
                 and message_role in ("user", "assistant")
+                and isinstance(message_position, int)
+                and isinstance(message_revision, str)
             ):
+                anchor_kind: Literal["snapshot_offset", "event_seq"] = (
+                    "event_seq" if s.content_protocol == "events-v1" else "snapshot_offset"
+                )
                 search_match = SessionSearchMatchResponse(
                     role=message_role,
                     excerpt=_message_search_excerpt(message_content, q),
+                    anchor=SessionSearchAnchorResponse(
+                        kind=anchor_kind,
+                        position=message_position,
+                        revision=message_revision,
+                    ),
                 )
         else:
             s, agent_type, display_name, default_name, machine_name, shared = row
@@ -3081,6 +3097,7 @@ async def get_session_messages(
     session_id: UUID,
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=100, ge=1, le=500),
+    direction: Literal["asc", "desc"] = Query(default="asc"),
     auth: AuthContext = Depends(require_scope("sessions:read")),
     db: AsyncSession = Depends(get_session),
 ) -> SessionMessagesPage:
@@ -3090,14 +3107,11 @@ async def get_session_messages(
     this endpoint slices the same blob server-side so the
     dashboard doesn't ship 10+ MB of messages on a long session.
 
-    Pagination is offset-based, NOT cursor-based: the underlying
-    file-store blob is immutable per upload (each push replaces
-    the entire JSON array), so `array[offset:offset+limit]` is
-    stable for a given `content_hash`. Clients pin to a snapshot
-    by reading `content_hash` from the parent
-    `/v1/sessions/{id}` response and refusing to mix pages
-    from different hashes — a daemon append in between would
-    show up as a hash change and trigger a refetch.
+    Pagination is offset-based within the requested direction. `offset=0`
+    starts at the oldest visible message for ascending reads and at the newest
+    visible message for descending reads. Clients pin pages to the parent
+    session's `content_hash`, which changes after snapshot replacement or event
+    append.
     """
     bound_env = _bound_env_id(auth)
     stmt = select(Session).where(
@@ -3129,7 +3143,7 @@ async def get_session_messages(
         ) from None
 
     total = len(raw)
-    sliced = raw[offset : offset + limit]
+    sliced = slice_session_messages(raw, offset=offset, limit=limit, direction=direction)
     return SessionMessagesPage(
         items=[SessionMessageResponse.model_validate(m) for m in sliced],
         total=total,

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -98,6 +98,7 @@ from app.schemas.session import (
     SessionPermissionCreate,
     SessionPermissionResponse,
     SessionPermissionsResponse,
+    SessionSearchMatchResponse,
     SessionUploadResponse,
 )
 from app.services import memory_extraction
@@ -128,6 +129,12 @@ from app.services.session_content import (
 )
 from app.services.session_export import session_to_markdown
 from app.services.session_refs import extract_related_refs
+from app.services.session_search import (
+    SearchableSessionMessage,
+    best_session_message_matches,
+    replace_snapshot_search_index,
+    searchable_snapshot_messages,
+)
 from app.services.sync_events import queue_environment_runtime_manifest_changed
 
 router = APIRouter(tags=["sessions"])
@@ -156,6 +163,7 @@ _MANUAL_SESSION_SUMMARY_FILTER = text(
 class _SessionUploadAnalysis:
     content_hash: str
     related_refs: dict[str, JsonValue] | None
+    search_messages: list[SearchableSessionMessage]
     parse_error: Exception | None = None
 
 
@@ -164,9 +172,10 @@ def _analyze_session_upload_sync(data: bytes) -> _SessionUploadAnalysis:
     try:
         parsed = _SESSION_MESSAGE_VALUES_ADAPTER.validate_json(data)
         related_refs = _related_refs_json(extract_related_refs(parsed)) or None
+        search_messages = searchable_snapshot_messages(parsed)
     except (ValidationError, ValueError, TypeError) as exc:
-        return _SessionUploadAnalysis(content_hash, None, exc)
-    return _SessionUploadAnalysis(content_hash, related_refs)
+        return _SessionUploadAnalysis(content_hash, None, [], exc)
+    return _SessionUploadAnalysis(content_hash, related_refs, search_messages)
 
 
 async def _analyze_session_upload(data: bytes) -> _SessionUploadAnalysis:
@@ -2374,6 +2383,10 @@ async def batch_create_sessions(
                 (hash_changed, None),
                 else_=Session.content_uploaded_at,
             ),
+            "search_index_revision": case(
+                (hash_changed, None),
+                else_=Session.search_index_revision,
+            ),
             # Only bump `updated_at` when the content actually changed.
             # Without this, a re-push of unchanged sessions (e.g. empty
             # client cache, multi-machine sync, manual cache reset) would
@@ -2496,6 +2509,19 @@ _SESSION_SORT_COLUMNS = {
 _TRGM_THRESHOLD = 0.15
 
 
+def _message_search_excerpt(content: str, query: str, *, limit: int = 240) -> str:
+    compact = " ".join(content.split())
+    if len(compact) <= limit:
+        return compact
+    match_at = compact.casefold().find(query.casefold())
+    if match_at < 0:
+        return f"{compact[: limit - 3]}..."
+    start = max(0, match_at - limit // 3)
+    end = min(len(compact), start + limit)
+    start = max(0, end - limit)
+    return f"{'...' if start else ''}{compact[start:end]}{'...' if end < len(compact) else ''}"
+
+
 @router.get("/sessions")
 async def list_sessions(
     # Deploy keys carry `sessions:write` (they upload sessions from
@@ -2505,7 +2531,11 @@ async def list_sessions(
     # summaries and project_paths it had no business reading.
     auth: AuthContext = Depends(require_scope("sessions:read")),
     db: AsyncSession = Depends(get_session),
-    q: str | None = Query(default=None, description="Fuzzy search on summary/project/id"),
+    q: str | None = Query(
+        default=None,
+        max_length=500,
+        description="Fuzzy search on summary/project/id and visible message text",
+    ),
     agent: str | None = Query(default=None, description="Filter by agent_type"),
     environment_id: UUID | None = Query(default=None, description="Filter by agent environment"),
     # Faceted filters. Multi-valued where the dashboard wants chip
@@ -2552,6 +2582,7 @@ async def list_sessions(
     since: datetime | None = Query(default=None, description="Filter to last_activity_at >= since"),
     until: datetime | None = Query(default=None, description="Filter to last_activity_at < until"),
 ) -> Paginated[SessionListItemResponse]:
+    q = q.strip() if q else None
     # Env binding: a bound api_key (deploy key) can only see its
     # own env's sessions. Without this, a key for env A would list
     # env B's sessions because user_id alone doesn't fence them.
@@ -2581,11 +2612,17 @@ async def list_sessions(
     # drives the rank. NULL-safe via COALESCE — sessions with NULL
     # summary still match if their project_path or id does.
     relevance_expr: Any | None
+    metadata_relevance_expr: Any | None = None
+    message_match: Any | None = None
+    message_relevance_expr: Any | None = None
     if q:
         sim_summary = func.similarity(func.coalesce(Session.summary, ""), q)
         sim_project = func.similarity(func.coalesce(Session.project_path, ""), q)
         sim_local = func.similarity(Session.local_session_id, q)
-        relevance_expr = func.greatest(sim_summary, sim_project, sim_local)
+        metadata_relevance_expr = func.greatest(sim_summary, sim_project, sim_local)
+        message_match = best_session_message_matches(auth.user_id, q)
+        message_relevance_expr = func.coalesce(message_match.c.score, 0.0)
+        relevance_expr = func.greatest(metadata_relevance_expr, message_relevance_expr)
     else:
         relevance_expr = None
 
@@ -2597,6 +2634,15 @@ async def list_sessions(
         AgentEnvironment.machine_name,
         is_shared_subq,
     ).outerjoin(AgentEnvironment, Session.environment_id == AgentEnvironment.id)
+    if q:
+        assert message_match is not None
+        assert message_relevance_expr is not None
+        base = base.outerjoin(message_match, message_match.c.session_id == Session.id)
+        base = base.add_columns(
+            message_relevance_expr,
+            message_match.c.content,
+            message_match.c.role,
+        )
     session_filters: list[Any] = [Session.user_id == auth.user_id]
     agent_filter = AgentEnvironment.agent_type == agent if agent else None
     if bound_env is not None:
@@ -2659,13 +2705,20 @@ async def list_sessions(
     if q:
         # pg_trgm `similarity()` for typo / partial-word tolerance.
         # NOT index-accelerated — the function-call form doesn't trigger
-        # the `gin_trgm_ops` operator class (only `%` / `<->` / `LIKE`
+        # the `gin_trgm_ops` operator class (only `%` / `<%` / `LIKE`
         # do). Runs as a Seq Scan over the user's session set; fine
         # for the typical few-thousand-rows-per-user. If a power user
         # ever hits real latency here, swap to `WHERE summary % :q`
         # plus a GIN index. Threshold tuned for "type to filter" UX.
         assert relevance_expr is not None
-        session_filters.append(relevance_expr >= _TRGM_THRESHOLD)
+        assert metadata_relevance_expr is not None
+        assert message_match is not None
+        session_filters.append(
+            or_(
+                metadata_relevance_expr >= _TRGM_THRESHOLD,
+                message_match.c.session_id.is_not(None),
+            )
+        )
 
     base = base.where(*session_filters)
     if agent_filter is not None:
@@ -2676,6 +2729,8 @@ async def list_sessions(
     # COUNT(*). For 50k+ session users this saves a measurable
     # fraction of list-page latency.
     count_base = select(Session.id).where(*session_filters)
+    if message_match is not None:
+        count_base = count_base.outerjoin(message_match, message_match.c.session_id == Session.id)
     if agent_filter is not None:
         count_base = count_base.outerjoin(
             AgentEnvironment,
@@ -2707,8 +2762,33 @@ async def list_sessions(
 
     rows = (await db.execute(ordered.limit(page_size).offset((page - 1) * page_size))).all()
 
-    return Paginated[SessionListItemResponse](
-        items=[
+    items: list[SessionListItemResponse] = []
+    for row in rows:
+        search_match: SessionSearchMatchResponse | None = None
+        if q:
+            (
+                s,
+                agent_type,
+                display_name,
+                default_name,
+                machine_name,
+                shared,
+                message_score,
+                message_content,
+                message_role,
+            ) = row
+            if (
+                message_score is not None
+                and isinstance(message_content, str)
+                and message_role in ("user", "assistant")
+            ):
+                search_match = SessionSearchMatchResponse(
+                    role=message_role,
+                    excerpt=_message_search_excerpt(message_content, q),
+                )
+        else:
+            s, agent_type, display_name, default_name, machine_name, shared = row
+        items.append(
             _session_to_response(
                 s,
                 agent_type=agent_type,
@@ -2716,9 +2796,12 @@ async def list_sessions(
                 agent_default_name=default_name,
                 machine_name=machine_name,
                 is_shared=bool(shared),
+                search_match=search_match,
             )
-            for s, agent_type, display_name, default_name, machine_name, shared in rows
-        ],
+        )
+
+    return Paginated[SessionListItemResponse](
+        items=items,
         total=total,
         page=page,
         page_size=page_size,
@@ -2936,6 +3019,12 @@ async def upload_session_content(
     # we'd rather have a session with NULL related_refs than a
     # half-committed upload).
     session.related_refs = analysis.related_refs
+    await replace_snapshot_search_index(
+        db,
+        session,
+        content_hash,
+        analysis.search_messages,
+    )
     if analysis.parse_error is not None:
         # Preserve the worker-thread traceback for diagnosing malformed
         # snapshots without failing their best-effort upload.
@@ -3387,6 +3476,7 @@ def _session_to_response(
     agent_default_name: str | None = None,
     machine_name: str | None = None,
     is_shared: bool = False,
+    search_match: SessionSearchMatchResponse | None = None,
 ) -> SessionListItemResponse:
     agent_name = (
         _agent_name_from_fields(agent_display_name, agent_default_name, machine_name, None)
@@ -3420,6 +3510,7 @@ def _session_to_response(
         content_protocol=s.content_protocol,
         event_head_hash=s.event_head_hash,
         is_shared=is_shared,
+        search_match=search_match,
         related_refs=_related_refs_response(s.related_refs),
     )
 

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -464,6 +464,11 @@ class SessionBatchResponse(BaseModel):
     suppressed: list[str] = []
 
 
+class SessionSearchMatchResponse(BaseModel):
+    role: Literal["user", "assistant"]
+    excerpt: str
+
+
 class SessionListItemResponse(BaseModel):
     id: str
     local_session_id: str
@@ -507,6 +512,9 @@ class SessionListItemResponse(BaseModel):
     # Default False so old generated clients that don't expect the field
     # still deserialize cleanly.
     is_shared: bool = False
+    # Present only when a message body contributed to a `q` search result.
+    # It is a bounded excerpt, never a second copy of the transcript.
+    search_match: SessionSearchMatchResponse | None = None
 
     # Extracted external entities (PR refs, repo names, branches),
     # surfaced as sidebar chips. NULL when nothing was found or when

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -464,9 +464,16 @@ class SessionBatchResponse(BaseModel):
     suppressed: list[str] = []
 
 
+class SessionSearchAnchorResponse(BaseModel):
+    kind: Literal["snapshot_offset", "event_seq"]
+    position: int = Field(ge=0)
+    revision: str
+
+
 class SessionSearchMatchResponse(BaseModel):
     role: Literal["user", "assistant"]
     excerpt: str
+    anchor: SessionSearchAnchorResponse
 
 
 class SessionListItemResponse(BaseModel):
@@ -641,9 +648,11 @@ class SessionMessagesPage(BaseModel):
     (`GET /v1/sessions/{id}/content`) stays unchanged so the CLI's
     `clawdi pull` mirror still gets a single full JSON array.
 
-    `total` is the count of messages in the underlying content file
+    `total` is the count of visible messages in the current content revision
     (not the count returned in `items`) so the client can render a
-    "loaded N/M" hint and decide whether to fetch more pages.
+    "loaded N/M" hint and decide whether to fetch more pages. `offset` is
+    relative to the requested order: zero means the oldest message for
+    ascending reads and the newest message for descending reads.
     """
 
     items: list[SessionMessageResponse]

--- a/backend/app/services/session_content.py
+++ b/backend/app/services/session_content.py
@@ -120,39 +120,7 @@ async def load_session_messages(
         cached = _cache_get(cache_key)
         if cached is not None:
             return cached
-        chunks = list(
-            (
-                await db.execute(
-                    select(SessionEventChunk)
-                    .where(SessionEventChunk.generation_id == session.event_generation_id)
-                    .order_by(SessionEventChunk.start_seq)
-                )
-            ).scalars()
-        )
-        events: list[SessionEvent] = []
-        next_seq = 0
-        head = EMPTY_EVENT_HEAD
-        for chunk in chunks:
-            if chunk.start_seq != next_seq or chunk.base_head_hash != head:
-                raise SessionContentInvalid("events-v1 chunk index is not continuous")
-            try:
-                data = await file_store.get(chunk.file_key)
-                validated = await validate_event_chunk_async(
-                    data, start_seq=next_seq, base_head_hash=head
-                )
-            except Exception as exc:
-                log.exception("session_event_chunk_fetch_failed file_key=%s", chunk.file_key)
-                raise SessionContentInvalid("events-v1 chunk is unavailable or invalid") from exc
-            if (
-                validated.content_hash != chunk.content_hash
-                or validated.result_head_hash != chunk.result_head_hash
-            ):
-                raise SessionContentInvalid("events-v1 chunk hash drift")
-            events.extend(validated.events)
-            next_seq = chunk.end_seq + 1
-            head = chunk.result_head_hash
-        if next_seq != session.event_count or head != (session.event_head_hash or EMPTY_EVENT_HEAD):
-            raise SessionContentInvalid("events-v1 head does not match its chunk index")
+        events = await load_session_events(session, file_store, db)
         projected = _SESSION_MESSAGES_ADAPTER.validate_python(project_safe_messages(events))
         _cache_put(cache_key, projected)
         return projected
@@ -186,3 +154,46 @@ async def load_session_messages(
 
     _cache_put(cache_key, parsed)
     return parsed
+
+
+async def load_session_events(
+    session: Session,
+    file_store: _FileStoreLike,
+    db: AsyncSession,
+) -> list[SessionEvent]:
+    if session.content_protocol != "events-v1" or session.event_generation_id is None:
+        raise SessionContentInvalid("session does not have events-v1 content")
+    chunks = list(
+        (
+            await db.execute(
+                select(SessionEventChunk)
+                .where(SessionEventChunk.generation_id == session.event_generation_id)
+                .order_by(SessionEventChunk.start_seq)
+            )
+        ).scalars()
+    )
+    events: list[SessionEvent] = []
+    next_seq = 0
+    head = EMPTY_EVENT_HEAD
+    for chunk in chunks:
+        if chunk.start_seq != next_seq or chunk.base_head_hash != head:
+            raise SessionContentInvalid("events-v1 chunk index is not continuous")
+        try:
+            data = await file_store.get(chunk.file_key)
+            validated = await validate_event_chunk_async(
+                data, start_seq=next_seq, base_head_hash=head
+            )
+        except Exception as exc:
+            log.exception("session_event_chunk_fetch_failed file_key=%s", chunk.file_key)
+            raise SessionContentInvalid("events-v1 chunk is unavailable or invalid") from exc
+        if (
+            validated.content_hash != chunk.content_hash
+            or validated.result_head_hash != chunk.result_head_hash
+        ):
+            raise SessionContentInvalid("events-v1 chunk hash drift")
+        events.extend(validated.events)
+        next_seq = chunk.end_seq + 1
+        head = chunk.result_head_hash
+    if next_seq != session.event_count or head != (session.event_head_hash or EMPTY_EVENT_HEAD):
+        raise SessionContentInvalid("events-v1 head does not match its chunk index")
+    return events

--- a/backend/app/services/session_content.py
+++ b/backend/app/services/session_content.py
@@ -16,7 +16,8 @@ import logging
 import threading
 import time
 from collections import OrderedDict
-from typing import Protocol
+from collections.abc import Sequence
+from typing import Literal, Protocol
 
 from pydantic import JsonValue, TypeAdapter, ValidationError
 from sqlalchemy import select
@@ -46,6 +47,7 @@ class _FileStoreLike(Protocol):
 _MESSAGES_CACHE_MAX = 16
 _MESSAGES_CACHE_TTL_S = 300.0
 type SessionMessageValue = dict[str, JsonValue]
+type SessionMessageDirection = Literal["asc", "desc"]
 
 _SESSION_MESSAGES_ADAPTER: TypeAdapter[list[SessionMessageValue]] = TypeAdapter(
     list[SessionMessageValue]
@@ -93,6 +95,22 @@ def _cache_put(key: tuple[str, str], parsed: list[SessionMessageValue]) -> None:
         _messages_cache.move_to_end(key)
         while len(_messages_cache) > _MESSAGES_CACHE_MAX:
             _messages_cache.popitem(last=False)
+
+
+def slice_session_messages(
+    messages: Sequence[SessionMessageValue],
+    *,
+    offset: int,
+    limit: int,
+    direction: SessionMessageDirection,
+) -> list[SessionMessageValue]:
+    """Slice messages in the requested order using an order-relative offset."""
+    if direction == "asc":
+        return list(messages[offset : offset + limit])
+
+    end = max(0, len(messages) - offset)
+    start = max(0, end - limit)
+    return list(reversed(messages[start:end]))
 
 
 async def load_session_messages(

--- a/backend/app/services/session_events.py
+++ b/backend/app/services/session_events.py
@@ -5,6 +5,8 @@ import hashlib
 import json
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
 
 from pydantic import JsonValue, TypeAdapter, ValidationError
 
@@ -26,6 +28,15 @@ class ValidatedEventChunk:
     raw_events: list[RawSessionEvent]
     content_hash: str
     result_head_hash: str
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectedSessionMessage:
+    position: int
+    role: Literal["user", "assistant"]
+    content: str
+    model: str | None
+    timestamp: datetime | None
 
 
 def canonical_event_json(value: object) -> bytes:
@@ -99,8 +110,8 @@ async def validate_event_chunk_async(
     )
 
 
-def project_safe_messages(events: Sequence[SessionEvent]) -> list[dict[str, object]]:
-    messages: list[dict[str, object]] = []
+def project_visible_messages(events: Sequence[SessionEvent]) -> list[ProjectedSessionMessage]:
+    messages: list[ProjectedSessionMessage] = []
     for event in events:
         if not isinstance(event, SessionMessageEvent) or event.role not in ("user", "assistant"):
             continue
@@ -111,10 +122,28 @@ def project_safe_messages(events: Sequence[SessionEvent]) -> list[dict[str, obje
         )
         if not text:
             continue
-        message: dict[str, object] = {"role": event.role, "content": text}
-        if event.model is not None:
-            message["model"] = event.model
-        if event.timestamp is not None:
-            message["timestamp"] = event.timestamp.isoformat()
+        messages.append(
+            ProjectedSessionMessage(
+                position=event.seq,
+                role=event.role,
+                content=text,
+                model=event.model,
+                timestamp=event.timestamp,
+            )
+        )
+    return messages
+
+
+def project_safe_messages(events: Sequence[SessionEvent]) -> list[dict[str, object]]:
+    messages: list[dict[str, object]] = []
+    for projected in project_visible_messages(events):
+        message: dict[str, object] = {
+            "role": projected.role,
+            "content": projected.content,
+        }
+        if projected.model is not None:
+            message["model"] = projected.model
+        if projected.timestamp is not None:
+            message["timestamp"] = projected.timestamp.isoformat()
         messages.append(message)
     return messages

--- a/backend/app/services/session_search.py
+++ b/backend/app/services/session_search.py
@@ -6,11 +6,11 @@ from typing import Literal, Protocol
 from uuid import UUID
 
 from pydantic import JsonValue
-from sqlalchemy import case, delete, func, literal, or_, select
+from sqlalchemy import case, delete, func, literal, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.selectable import Subquery
 
-from app.models.session import Session, SessionMessageSearch
+from app.models.session import Session, SessionEventChunk, SessionMessageSearch
 from app.schemas.session_events import SessionEvent
 from app.services.session_content import load_session_events, load_session_messages
 from app.services.session_events import project_visible_messages
@@ -30,8 +30,12 @@ class SearchableSessionMessage:
     content: str
 
 
-def event_search_revision(generation_id: UUID) -> str:
+def event_document_revision(generation_id: UUID) -> str:
     return f"events:{generation_id}"
+
+
+def event_search_revision(head_hash: str) -> str:
+    return f"events:{head_hash}"
 
 
 def snapshot_search_revision(content_hash: str) -> str:
@@ -39,11 +43,36 @@ def snapshot_search_revision(content_hash: str) -> str:
 
 
 def current_search_revision(session: Session) -> str | None:
-    if session.content_protocol == "events-v1" and session.event_generation_id is not None:
-        return event_search_revision(session.event_generation_id)
+    if session.content_protocol == "events-v1" and session.event_head_hash is not None:
+        return event_search_revision(session.event_head_hash)
     if session.content_protocol == "snapshot-v1" and session.content_hash is not None:
         return snapshot_search_revision(session.content_hash)
     return None
+
+
+def current_document_revision(session: Session) -> str | None:
+    if session.content_protocol == "events-v1" and session.event_generation_id is not None:
+        return event_document_revision(session.event_generation_id)
+    if session.content_protocol == "snapshot-v1" and session.content_hash is not None:
+        return snapshot_search_revision(session.content_hash)
+    return None
+
+
+async def event_search_projection_complete(
+    db: AsyncSession,
+    generation_id: UUID,
+) -> bool:
+    missing = (
+        await db.execute(
+            select(SessionEventChunk.id)
+            .where(
+                SessionEventChunk.generation_id == generation_id,
+                SessionEventChunk.search_indexed_at.is_(None),
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    return missing is None
 
 
 def _escaped_contains_pattern(value: str) -> str:
@@ -53,10 +82,17 @@ def _escaped_contains_pattern(value: str) -> str:
 
 def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
     """Return the strongest index-backed visible-message match per Session."""
-    active_revision = case(
+    active_document_revision = case(
         (
             Session.content_protocol == "events-v1",
             func.concat("events:", Session.event_generation_id),
+        ),
+        else_=func.concat("snapshot:", Session.content_hash),
+    )
+    active_search_revision = case(
+        (
+            Session.content_protocol == "events-v1",
+            func.concat("events:", Session.event_head_hash),
         ),
         else_=func.concat("snapshot:", Session.content_hash),
     )
@@ -99,13 +135,13 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
             candidates.c.role,
             candidates.c.score,
             candidates.c.position,
-            candidates.c.content_revision,
+            Session.search_index_revision.label("content_revision"),
         )
         .join(Session, Session.id == candidates.c.session_id)
         .where(
             Session.user_id == user_id,
-            candidates.c.content_revision == Session.search_index_revision,
-            Session.search_index_revision == active_revision,
+            candidates.c.content_revision == active_document_revision,
+            Session.search_index_revision == active_search_revision,
         )
         .distinct(candidates.c.session_id)
         .order_by(
@@ -180,23 +216,31 @@ def stage_event_search_messages(
         user_id=user_id,
         session_id=session_id,
         generation_id=generation_id,
-        content_revision=event_search_revision(generation_id),
+        content_revision=event_document_revision(generation_id),
         messages=searchable_event_messages(events),
     )
 
 
-async def activate_event_search_index(
+async def finalize_event_search_index(
     db: AsyncSession,
     session: Session,
     generation_id: UUID,
+    *,
+    projection_complete: bool,
 ) -> None:
-    revision = event_search_revision(generation_id)
+    document_revision = event_document_revision(generation_id)
     await db.execute(
         delete(SessionMessageSearch).where(
             SessionMessageSearch.session_id == session.id,
-            SessionMessageSearch.content_revision != revision,
+            SessionMessageSearch.content_revision != document_revision,
         )
     )
+    if not projection_complete:
+        session.search_index_revision = None
+        return
+    revision = current_search_revision(session)
+    if revision is None:
+        raise ValueError("events-v1 search activation requires a committed event head")
     session.search_index_revision = revision
 
 
@@ -227,17 +271,21 @@ async def rebuild_session_search_index(
     file_store: SessionSearchFileStore,
 ) -> bool:
     """Rebuild one revision without letting stale object reads replace newer data."""
-    revision = current_search_revision(session)
-    if revision is None:
+    search_revision = current_search_revision(session)
+    if search_revision is None:
         return False
     if session.content_protocol == "events-v1":
+        generation_id = session.event_generation_id
+        if generation_id is None:
+            return False
         events = await load_session_events(session, file_store, db)
         messages = searchable_event_messages(events)
-        generation_id = session.event_generation_id
+        document_revision = event_document_revision(generation_id)
     else:
         snapshot = await load_session_messages(session, file_store, db)
         messages = searchable_snapshot_messages(snapshot)
         generation_id = None
+        document_revision = search_revision
 
     current = (
         await db.execute(
@@ -247,7 +295,11 @@ async def rebuild_session_search_index(
             .execution_options(populate_existing=True)
         )
     ).scalar_one_or_none()
-    if current is None or current_search_revision(current) != revision:
+    if (
+        current is None
+        or current_search_revision(current) != search_revision
+        or current_document_revision(current) != document_revision
+    ):
         return False
 
     await db.execute(
@@ -258,8 +310,19 @@ async def rebuild_session_search_index(
         user_id=current.user_id,
         session_id=current.id,
         generation_id=generation_id,
-        content_revision=revision,
+        content_revision=document_revision,
         messages=messages,
     )
-    current.search_index_revision = revision
+    if generation_id is not None:
+        await db.execute(
+            update(SessionEventChunk)
+            .where(SessionEventChunk.generation_id == generation_id)
+            .values(
+                search_indexed_at=func.coalesce(
+                    SessionEventChunk.search_indexed_at,
+                    func.now(),
+                )
+            )
+        )
+    current.search_index_revision = search_revision
     return True

--- a/backend/app/services/session_search.py
+++ b/backend/app/services/session_search.py
@@ -98,6 +98,8 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
             candidates.c.content,
             candidates.c.role,
             candidates.c.score,
+            candidates.c.position,
+            candidates.c.content_revision,
         )
         .join(Session, Session.id == candidates.c.session_id)
         .where(

--- a/backend/app/services/session_search.py
+++ b/backend/app/services/session_search.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal, Protocol
+from uuid import UUID
+
+from pydantic import JsonValue
+from sqlalchemy import case, delete, func, literal, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.selectable import Subquery
+
+from app.models.session import Session, SessionMessageSearch
+from app.schemas.session_events import SessionEvent
+from app.services.session_content import load_session_events, load_session_messages
+from app.services.session_events import project_visible_messages
+
+type SearchRole = Literal["user", "assistant"]
+_MIN_TRGM_QUERY_LENGTH = 3
+
+
+class SessionSearchFileStore(Protocol):
+    async def get(self, key: str) -> bytes: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SearchableSessionMessage:
+    position: int
+    role: SearchRole
+    content: str
+
+
+def event_search_revision(generation_id: UUID) -> str:
+    return f"events:{generation_id}"
+
+
+def snapshot_search_revision(content_hash: str) -> str:
+    return f"snapshot:{content_hash}"
+
+
+def current_search_revision(session: Session) -> str | None:
+    if session.content_protocol == "events-v1" and session.event_generation_id is not None:
+        return event_search_revision(session.event_generation_id)
+    if session.content_protocol == "snapshot-v1" and session.content_hash is not None:
+        return snapshot_search_revision(session.content_hash)
+    return None
+
+
+def _escaped_contains_pattern(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"%{escaped}%"
+
+
+def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
+    """Return the strongest index-backed visible-message match per Session."""
+    active_revision = case(
+        (
+            Session.content_protocol == "events-v1",
+            func.concat("events:", Session.event_generation_id),
+        ),
+        else_=func.concat("snapshot:", Session.content_hash),
+    )
+    exact_match = SessionMessageSearch.content.ilike(
+        _escaped_contains_pattern(query),
+        escape="\\",
+    )
+    candidate_filter = exact_match
+    if len(query) >= _MIN_TRGM_QUERY_LENGTH:
+        # Official pg_trgm word-search shape: use the GIN-backed operator for
+        # candidates, then word_similarity() only to rank that bounded set.
+        candidate_filter = or_(
+            exact_match,
+            literal(query).op("<%")(SessionMessageSearch.content),
+        )
+    score = case(
+        (exact_match, 1.0),
+        else_=func.word_similarity(query, SessionMessageSearch.content),
+    ).label("score")
+    candidates = (
+        select(
+            SessionMessageSearch.session_id.label("session_id"),
+            SessionMessageSearch.content_revision.label("content_revision"),
+            SessionMessageSearch.position.label("position"),
+            SessionMessageSearch.content.label("content"),
+            SessionMessageSearch.role.label("role"),
+            score,
+        )
+        .where(
+            SessionMessageSearch.user_id == user_id,
+            candidate_filter,
+        )
+        .cte("session_message_candidates")
+        .prefix_with("MATERIALIZED")
+    )
+    return (
+        select(
+            candidates.c.session_id,
+            candidates.c.content,
+            candidates.c.role,
+            candidates.c.score,
+        )
+        .join(Session, Session.id == candidates.c.session_id)
+        .where(
+            Session.user_id == user_id,
+            candidates.c.content_revision == Session.search_index_revision,
+            Session.search_index_revision == active_revision,
+        )
+        .distinct(candidates.c.session_id)
+        .order_by(
+            candidates.c.session_id,
+            candidates.c.score.desc(),
+            candidates.c.position.asc(),
+        )
+        .subquery("best_session_message_match")
+    )
+
+
+def searchable_event_messages(events: Sequence[SessionEvent]) -> list[SearchableSessionMessage]:
+    return [
+        SearchableSessionMessage(
+            position=message.position,
+            role=message.role,
+            content=message.content,
+        )
+        for message in project_visible_messages(events)
+        if message.role in ("user", "assistant")
+    ]
+
+
+def searchable_snapshot_messages(
+    messages: Sequence[dict[str, JsonValue]],
+) -> list[SearchableSessionMessage]:
+    projected: list[SearchableSessionMessage] = []
+    for position, message in enumerate(messages):
+        role = message.get("role")
+        content = message.get("content")
+        if role not in ("user", "assistant") or not isinstance(content, str) or not content:
+            continue
+        projected.append(SearchableSessionMessage(position=position, role=role, content=content))
+    return projected
+
+
+def _add_documents(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    session_id: UUID,
+    generation_id: UUID | None,
+    content_revision: str,
+    messages: Sequence[SearchableSessionMessage],
+) -> None:
+    db.add_all(
+        [
+            SessionMessageSearch(
+                user_id=user_id,
+                session_id=session_id,
+                generation_id=generation_id,
+                content_revision=content_revision,
+                position=message.position,
+                role=message.role,
+                content=message.content,
+            )
+            for message in messages
+        ]
+    )
+
+
+def stage_event_search_messages(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    session_id: UUID,
+    generation_id: UUID,
+    events: Sequence[SessionEvent],
+) -> None:
+    _add_documents(
+        db,
+        user_id=user_id,
+        session_id=session_id,
+        generation_id=generation_id,
+        content_revision=event_search_revision(generation_id),
+        messages=searchable_event_messages(events),
+    )
+
+
+async def activate_event_search_index(
+    db: AsyncSession,
+    session: Session,
+    generation_id: UUID,
+) -> None:
+    revision = event_search_revision(generation_id)
+    await db.execute(
+        delete(SessionMessageSearch).where(
+            SessionMessageSearch.session_id == session.id,
+            SessionMessageSearch.content_revision != revision,
+        )
+    )
+    session.search_index_revision = revision
+
+
+async def replace_snapshot_search_index(
+    db: AsyncSession,
+    session: Session,
+    content_hash: str,
+    messages: Sequence[SearchableSessionMessage],
+) -> None:
+    revision = snapshot_search_revision(content_hash)
+    await db.execute(
+        delete(SessionMessageSearch).where(SessionMessageSearch.session_id == session.id)
+    )
+    _add_documents(
+        db,
+        user_id=session.user_id,
+        session_id=session.id,
+        generation_id=None,
+        content_revision=revision,
+        messages=messages,
+    )
+    session.search_index_revision = revision
+
+
+async def rebuild_session_search_index(
+    db: AsyncSession,
+    session: Session,
+    file_store: SessionSearchFileStore,
+) -> bool:
+    """Rebuild one revision without letting stale object reads replace newer data."""
+    revision = current_search_revision(session)
+    if revision is None:
+        return False
+    if session.content_protocol == "events-v1":
+        events = await load_session_events(session, file_store, db)
+        messages = searchable_event_messages(events)
+        generation_id = session.event_generation_id
+    else:
+        snapshot = await load_session_messages(session, file_store, db)
+        messages = searchable_snapshot_messages(snapshot)
+        generation_id = None
+
+    current = (
+        await db.execute(
+            select(Session)
+            .where(Session.id == session.id)
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one_or_none()
+    if current is None or current_search_revision(current) != revision:
+        return False
+
+    await db.execute(
+        delete(SessionMessageSearch).where(SessionMessageSearch.session_id == current.id)
+    )
+    _add_documents(
+        db,
+        user_id=current.user_id,
+        session_id=current.id,
+        generation_id=generation_id,
+        content_revision=revision,
+        messages=messages,
+    )
+    current.search_index_revision = revision
+    return True

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -295,6 +295,7 @@ strict = [
     "app/services/session_events.py",
     "app/services/session_export.py",
     "app/services/session_refs.py",
+    "app/services/session_search.py",
     "app/services/sharing.py",
     "app/services/skill_installer.py",
     "app/services/sync_events.py",

--- a/backend/scripts/backfill_session_search.py
+++ b/backend/scripts/backfill_session_search.py
@@ -20,7 +20,11 @@ from sqlalchemy.ext.asyncio import async_sessionmaker
 from app.core.database import engine
 from app.models.session import Session
 from app.services.file_store import get_file_store
-from app.services.session_search import current_search_revision, rebuild_session_search_index
+from app.services.session_search import (
+    current_search_revision,
+    event_search_projection_complete,
+    rebuild_session_search_index,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 log = logging.getLogger("backfill-session-search")
@@ -69,7 +73,17 @@ async def backfill_user(user_id: uuid.UUID, *, force: bool, dry_run: bool) -> in
                     skipped += 1
                     continue
                 revision = current_search_revision(session)
-                if revision is None or (not force and session.search_index_revision == revision):
+                projection_current = session.search_index_revision == revision
+                if (
+                    projection_current
+                    and session.content_protocol == "events-v1"
+                    and session.event_generation_id is not None
+                ):
+                    projection_current = await event_search_projection_complete(
+                        db,
+                        session.event_generation_id,
+                    )
+                if revision is None or (not force and projection_current):
                     skipped += 1
                     continue
                 try:

--- a/backend/scripts/backfill_session_search.py
+++ b/backend/scripts/backfill_session_search.py
@@ -1,0 +1,129 @@
+"""Backfill the rebuildable visible-message Session search index.
+
+Usage:
+    pdm run python -m scripts.backfill_session_search --user-id <uuid>
+    pdm run python -m scripts.backfill_session_search --all
+    pdm run python -m scripts.backfill_session_search --all --dry-run
+    pdm run python -m scripts.backfill_session_search --all --force
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import uuid
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.core.database import engine
+from app.models.session import Session
+from app.services.file_store import get_file_store
+from app.services.session_search import current_search_revision, rebuild_session_search_index
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("backfill-session-search")
+
+CHUNK_SIZE = 16
+
+
+async def backfill_user(user_id: uuid.UUID, *, force: bool, dry_run: bool) -> int:
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    target_filters = (
+        Session.user_id == user_id,
+        or_(
+            Session.file_key.is_not(None),
+            Session.event_generation_id.is_not(None),
+        ),
+    )
+
+    if dry_run:
+        async with session_factory() as db:
+            total = (
+                await db.execute(select(func.count(Session.id)).where(*target_filters))
+            ).scalar_one()
+        log.info("user %s: would inspect %d sessions", user_id, total)
+        return 0
+
+    file_store = get_file_store()
+    indexed = 0
+    skipped = 0
+    failed = 0
+    inspected = 0
+    last_id: uuid.UUID | None = None
+    while True:
+        async with session_factory() as db:
+            query = select(Session.id).where(*target_filters)
+            if last_id is not None:
+                query = query.where(Session.id > last_id)
+            session_ids = list(
+                (await db.execute(query.order_by(Session.id).limit(CHUNK_SIZE))).scalars()
+            )
+        if not session_ids:
+            break
+        for session_id in session_ids:
+            async with session_factory() as db:
+                session = await db.get(Session, session_id)
+                if session is None:
+                    skipped += 1
+                    continue
+                revision = current_search_revision(session)
+                if revision is None or (not force and session.search_index_revision == revision):
+                    skipped += 1
+                    continue
+                try:
+                    rebuilt = await rebuild_session_search_index(db, session, file_store)
+                    await db.commit()
+                    if rebuilt:
+                        indexed += 1
+                    else:
+                        # The authoritative revision changed while its object was
+                        # being read. The live ingest path indexed that revision;
+                        # a later backfill run can retry if it still needs work.
+                        skipped += 1
+                except Exception:
+                    failed += 1
+                    log.exception("session search backfill failed session_id=%s", session_id)
+        inspected += len(session_ids)
+        last_id = session_ids[-1]
+        log.info(
+            "user %s: inspected=%d indexed=%d skipped=%d failed=%d",
+            user_id,
+            inspected,
+            indexed,
+            skipped,
+            failed,
+        )
+    return failed
+
+
+async def backfill_all(*, force: bool, dry_run: bool) -> int:
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as db:
+        user_ids = list((await db.execute(select(Session.user_id).distinct())).scalars())
+    failed = 0
+    for user_id in user_ids:
+        failed += await backfill_user(user_id, force=force, dry_run=dry_run)
+    return failed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--user-id", type=uuid.UUID)
+    target.add_argument("--all", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    if args.all:
+        failed = asyncio.run(backfill_all(force=args.force, dry_run=args.dry_run))
+    else:
+        assert args.user_id is not None
+        failed = asyncio.run(backfill_user(args.user_id, force=args.force, dry_run=args.dry_run))
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_session_events.py
+++ b/backend/tests/test_session_events.py
@@ -9,10 +9,10 @@ from typing import Any
 import httpx
 import pytest
 from pydantic import ValidationError
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.session import Session
+from app.models.session import Session, SessionMessageSearch
 from app.services.session_events import (
     EMPTY_EVENT_HEAD,
     EVENT_ADAPTER,
@@ -21,6 +21,7 @@ from app.services.session_events import (
     canonical_event_json,
     project_safe_messages,
 )
+from app.services.session_search import rebuild_session_search_index
 
 
 def _source(record_id: str, part_index: int | None = None) -> dict[str, Any]:
@@ -580,6 +581,26 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
     assert "opaque" not in projected.text
     assert "secret tool output" not in projected.text
 
+    visible_search = (await client.get("/v1/sessions", params={"q": "visible answer"})).json()
+    assert [item["local_session_id"] for item in visible_search["items"]] == [local_id]
+    assert visible_search["items"][0]["search_match"] == {
+        "role": "assistant",
+        "excerpt": "visible answer",
+    }
+    for private_query in ("private chain of thought", "secret tool output"):
+        private_search = (await client.get("/v1/sessions", params={"q": private_query})).json()
+        assert all(item["search_match"] is None for item in private_search["items"])
+
+    await db_session.execute(
+        delete(SessionMessageSearch).where(SessionMessageSearch.session_id == session.id)
+    )
+    session.search_index_revision = None
+    await db_session.commit()
+    await rebuild_session_search_index(db_session, session, event_routes.file_store)
+    await db_session.commit()
+    rebuilt_search = (await client.get("/v1/sessions", params={"q": "visible answer"})).json()
+    assert [item["local_session_id"] for item in rebuilt_search["items"]] == [local_id]
+
 
 @pytest.mark.asyncio
 async def test_events_v1_rewrite_commit_is_cas_fenced(
@@ -588,7 +609,15 @@ async def test_events_v1_rewrite_commit_is_cas_fenced(
 ) -> None:
     local_id = "pi.rewrite-session"
     environment_id, _ = await _register_session(client, db_session, local_session_id=local_id)
-    original = [_event(0, "message", "user", role="user", parts=[{"type": "text", "text": "one"}])]
+    original = [
+        _event(
+            0,
+            "message",
+            "user",
+            role="user",
+            parts=[{"type": "text", "text": "orchid junction 731"}],
+        )
+    ]
     generation, original_head, _ = await _commit_generation(
         client,
         environment_id=environment_id,
@@ -597,7 +626,11 @@ async def test_events_v1_rewrite_commit_is_cas_fenced(
     )
     replacement = [
         _event(
-            0, "message", "replacement", role="user", parts=[{"type": "text", "text": "rewritten"}]
+            0,
+            "message",
+            "replacement",
+            role="user",
+            parts=[{"type": "text", "text": "velvet cosmos 942"}],
         )
     ]
     replacement_head = advance_event_head(EMPTY_EVENT_HEAD, replacement)
@@ -625,9 +658,15 @@ async def test_events_v1_rewrite_commit_is_cas_fenced(
         files={"file": ("0.ndjson", replacement_data, "application/x-ndjson")},
     )
     assert uploaded.status_code == 200, uploaded.text
+    staged_search = (await client.get("/v1/sessions", params={"q": "velvet cosmos 942"})).json()
+    assert all(item["search_match"] is None for item in staged_search["items"])
 
     concurrent = _event(
-        1, "message", "concurrent", role="assistant", parts=[{"type": "text", "text": "advanced"}]
+        1,
+        "message",
+        "concurrent",
+        role="assistant",
+        parts=[{"type": "text", "text": "cobalt river 583"}],
     )
     concurrent_data, concurrent_hash = _chunk([concurrent])
     concurrent_head = advance_event_head(original_head, [concurrent])
@@ -661,3 +700,48 @@ async def test_events_v1_rewrite_commit_is_cas_fenced(
         },
     )
     assert stale_commit.status_code == 409
+
+    fresh_generation = str(uuid.uuid4())
+    fresh_append_id = str(uuid.uuid4())
+    fresh_stage = await client.post(
+        f"/v1/sessions/{local_id}/events/generations",
+        json={
+            "environment_id": environment_id,
+            "generation": fresh_generation,
+            "append_id": fresh_append_id,
+            "base_generation": generation,
+            "base_revision": 2,
+            "base_count": 2,
+            "base_head_hash": concurrent_head,
+            "final_count": 1,
+            "final_head_hash": replacement_head,
+        },
+    )
+    assert fresh_stage.status_code == 200, fresh_stage.text
+    fresh_upload = await client.put(
+        f"/v1/sessions/{local_id}/events/generations/{fresh_generation}/chunks/0",
+        data={"base_head_hash": EMPTY_EVENT_HEAD, "content_hash": replacement_hash},
+        files={"file": ("0.ndjson", replacement_data, "application/x-ndjson")},
+    )
+    assert fresh_upload.status_code == 200, fresh_upload.text
+    fresh_commit = await client.post(
+        f"/v1/sessions/{local_id}/events/generations/{fresh_generation}/commit",
+        json={
+            "append_id": fresh_append_id,
+            "base_generation": generation,
+            "base_revision": 2,
+            "base_count": 2,
+            "base_head_hash": concurrent_head,
+            "final_count": 1,
+            "final_head_hash": replacement_head,
+        },
+    )
+    assert fresh_commit.status_code == 200, fresh_commit.text
+
+    replacement_search = (
+        await client.get("/v1/sessions", params={"q": "velvet cosmos 942"})
+    ).json()
+    assert [item["local_session_id"] for item in replacement_search["items"]] == [local_id]
+    for retired_query in ("orchid junction 731", "cobalt river 583"):
+        retired_search = (await client.get("/v1/sessions", params={"q": retired_query})).json()
+        assert all(item["search_match"] is None for item in retired_search["items"])

--- a/backend/tests/test_session_events.py
+++ b/backend/tests/test_session_events.py
@@ -210,6 +210,10 @@ async def _commit_generation(
     environment_id: str,
     local_session_id: str,
     events: list[dict[str, Any]],
+    base_generation: str | None = None,
+    base_revision: int = 0,
+    base_count: int = 0,
+    base_head_hash: str = EMPTY_EVENT_HEAD,
 ) -> tuple[str, str, str]:
     generation = str(uuid.uuid4())
     append_id = str(uuid.uuid4())
@@ -220,10 +224,10 @@ async def _commit_generation(
             "environment_id": environment_id,
             "generation": generation,
             "append_id": append_id,
-            "base_generation": None,
-            "base_revision": 0,
-            "base_count": 0,
-            "base_head_hash": EMPTY_EVENT_HEAD,
+            "base_generation": base_generation,
+            "base_revision": base_revision,
+            "base_count": base_count,
+            "base_head_hash": base_head_hash,
             "final_count": len(events),
             "final_head_hash": final_head,
         },
@@ -240,10 +244,10 @@ async def _commit_generation(
         f"/v1/sessions/{local_session_id}/events/generations/{generation}/commit",
         json={
             "append_id": append_id,
-            "base_generation": None,
-            "base_revision": 0,
-            "base_count": 0,
-            "base_head_hash": EMPTY_EVENT_HEAD,
+            "base_generation": base_generation,
+            "base_revision": base_revision,
+            "base_count": base_count,
+            "base_head_hash": base_head_hash,
             "final_count": len(events),
             "final_head_hash": final_head,
         },
@@ -631,7 +635,7 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
         "anchor": {
             "kind": "event_seq",
             "position": 4,
-            "revision": f"events:{generation}",
+            "revision": f"events:{second_head}",
         },
     }
     for private_query in ("private chain of thought", "secret tool output"):
@@ -647,6 +651,247 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
     await db_session.commit()
     rebuilt_search = (await client.get("/v1/sessions", params={"q": "visible answer"})).json()
     assert [item["local_session_id"] for item in rebuilt_search["items"]] == [local_id]
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_event_search_rebuild_does_not_replace_a_concurrent_append(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    engine,
+) -> None:
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from app.routes import session_events as event_routes
+
+    local_id = "pi.search-rebuild-race"
+    environment_id, session = await _register_session(client, db_session, local_session_id=local_id)
+    original = [
+        _event(
+            0,
+            "message",
+            "original",
+            role="user",
+            parts=[{"type": "text", "text": "original searchable event"}],
+        )
+    ]
+    generation, original_head, _ = await _commit_generation(
+        client,
+        environment_id=environment_id,
+        local_session_id=local_id,
+        events=original,
+    )
+    appended = _event(
+        1,
+        "message",
+        "appended",
+        role="assistant",
+        parts=[{"type": "text", "text": "concurrent appended search event"}],
+    )
+    appended_data, appended_hash = _chunk([appended])
+    appended_head = advance_event_head(original_head, [appended])
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    class RacingFileStore:
+        triggered = False
+
+        async def get(self, key: str) -> bytes:
+            if not self.triggered:
+                self.triggered = True
+                response = await client.post(
+                    f"/v1/sessions/{local_id}/events/append",
+                    data={
+                        "environment_id": environment_id,
+                        "append_id": str(uuid.uuid4()),
+                        "generation": generation,
+                        "base_revision": 1,
+                        "base_count": 1,
+                        "base_head_hash": original_head,
+                        "final_count": 2,
+                        "final_head_hash": appended_head,
+                        "content_hash": appended_hash,
+                    },
+                    files={
+                        "file": (
+                            "1.ndjson",
+                            appended_data,
+                            "application/x-ndjson",
+                        )
+                    },
+                )
+                assert response.status_code == 200, response.text
+            return await event_routes.file_store.get(key)
+
+    async with session_factory() as backfill_db:
+        stale = await backfill_db.get(Session, session.id)
+        assert stale is not None
+        rebuilt = await rebuild_session_search_index(backfill_db, stale, RacingFileStore())
+        await backfill_db.commit()
+    assert rebuilt is False
+
+    search = (
+        await client.get("/v1/sessions", params={"q": "concurrent appended search event"})
+    ).json()
+    assert [item["local_session_id"] for item in search["items"]] == [local_id]
+    assert search["items"][0]["search_match"]["anchor"]["revision"] == (f"events:{appended_head}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_event_search_rebuild_fences_same_head_generation_replacement(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    engine,
+) -> None:
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from app.routes import session_events as event_routes
+
+    local_id = "pi.search-rebuild-generation-race"
+    environment_id, session = await _register_session(client, db_session, local_session_id=local_id)
+    events = [
+        _event(
+            0,
+            "message",
+            "stable",
+            role="assistant",
+            parts=[{"type": "text", "text": "same head replacement remains searchable"}],
+        )
+    ]
+    generation, head, _ = await _commit_generation(
+        client,
+        environment_id=environment_id,
+        local_session_id=local_id,
+        events=events,
+    )
+    await db_session.refresh(session)
+    session.search_index_revision = None
+    await db_session.commit()
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    class RacingFileStore:
+        triggered = False
+
+        async def get(self, key: str) -> bytes:
+            if not self.triggered:
+                self.triggered = True
+                replacement_generation, replacement_head, _ = await _commit_generation(
+                    client,
+                    environment_id=environment_id,
+                    local_session_id=local_id,
+                    events=events,
+                    base_generation=generation,
+                    base_revision=1,
+                    base_count=1,
+                    base_head_hash=head,
+                )
+                assert replacement_generation != generation
+                assert replacement_head == head
+            return await event_routes.file_store.get(key)
+
+    async with session_factory() as backfill_db:
+        stale = await backfill_db.get(Session, session.id)
+        assert stale is not None
+        rebuilt = await rebuild_session_search_index(backfill_db, stale, RacingFileStore())
+        await backfill_db.commit()
+    assert rebuilt is False
+
+    search = (await client.get("/v1/sessions", params={"q": "same head replacement"})).json()
+    assert [item["local_session_id"] for item in search["items"]] == [local_id]
+    assert search["items"][0]["search_match"]["anchor"]["revision"] == f"events:{head}"
+
+
+@pytest.mark.asyncio
+async def test_generation_commit_does_not_publish_an_incomplete_search_projection(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    from app.models.session import SessionEventChunk
+    from app.routes import session_events as event_routes
+
+    local_id = "pi.incomplete-search-projection"
+    environment_id, session = await _register_session(client, db_session, local_session_id=local_id)
+    events = [
+        _event(
+            0,
+            "message",
+            "visible",
+            role="assistant",
+            parts=[{"type": "text", "text": "cross version searchable event"}],
+        )
+    ]
+    generation = str(uuid.uuid4())
+    append_id = str(uuid.uuid4())
+    final_head = advance_event_head(EMPTY_EVENT_HEAD, events)
+    staged = await client.post(
+        f"/v1/sessions/{local_id}/events/generations",
+        json={
+            "environment_id": environment_id,
+            "generation": generation,
+            "append_id": append_id,
+            "base_generation": None,
+            "base_revision": 0,
+            "base_count": 0,
+            "base_head_hash": EMPTY_EVENT_HEAD,
+            "final_count": 1,
+            "final_head_hash": final_head,
+        },
+    )
+    assert staged.status_code == 200, staged.text
+    data, content_hash = _chunk(events)
+    uploaded = await client.put(
+        f"/v1/sessions/{local_id}/events/generations/{generation}/chunks/0",
+        data={"base_head_hash": EMPTY_EVENT_HEAD, "content_hash": content_hash},
+        files={"file": ("0.ndjson", data, "application/x-ndjson")},
+    )
+    assert uploaded.status_code == 200, uploaded.text
+
+    generation_id = uuid.UUID(generation)
+    chunk = (
+        await db_session.execute(
+            select(SessionEventChunk).where(SessionEventChunk.generation_id == generation_id)
+        )
+    ).scalar_one()
+    await db_session.execute(
+        delete(SessionMessageSearch).where(SessionMessageSearch.generation_id == generation_id)
+    )
+    chunk.search_indexed_at = None
+    await db_session.commit()
+
+    committed = await client.post(
+        f"/v1/sessions/{local_id}/events/generations/{generation}/commit",
+        json={
+            "append_id": append_id,
+            "base_generation": None,
+            "base_revision": 0,
+            "base_count": 0,
+            "base_head_hash": EMPTY_EVENT_HEAD,
+            "final_count": 1,
+            "final_head_hash": final_head,
+        },
+    )
+    assert committed.status_code == 200, committed.text
+    await db_session.refresh(session)
+    assert session.search_index_revision is None
+    before_rebuild = (
+        await client.get("/v1/sessions", params={"q": "cross version searchable event"})
+    ).json()
+    assert all(item["search_match"] is None for item in before_rebuild["items"])
+
+    rebuilt = await rebuild_session_search_index(
+        db_session,
+        session,
+        event_routes.file_store,
+    )
+    await db_session.commit()
+    assert rebuilt is True
+    after_rebuild = (
+        await client.get("/v1/sessions", params={"q": "cross version searchable event"})
+    ).json()
+    assert [item["local_session_id"] for item in after_rebuild["items"]] == [local_id]
+    assert after_rebuild["items"][0]["search_match"]["anchor"]["revision"] == (
+        f"events:{final_head}"
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_session_events.py
+++ b/backend/tests/test_session_events.py
@@ -374,6 +374,25 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
         local_session_id=local_id,
         events=events,
     )
+    initial_messages = await client.get(
+        f"/v1/sessions/{session.id}/messages",
+        params={"direction": "desc", "limit": 2},
+    )
+    assert initial_messages.status_code == 200, initial_messages.text
+    assert initial_messages.json() == {
+        "items": [
+            {
+                "role": "assistant",
+                "content": "visible answer",
+                "model": "claude-sonnet",
+                "timestamp": None,
+            },
+            {"role": "user", "content": "inspect this", "model": None, "timestamp": None},
+        ],
+        "total": 2,
+        "offset": 0,
+        "limit": 2,
+    }
     generation_commit = {
         "append_id": generation_append_id,
         "base_generation": None,
@@ -581,11 +600,39 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
     assert "opaque" not in projected.text
     assert "secret tool output" not in projected.text
 
+    # The committed generation now spans three immutable chunks. The read path
+    # must use the new event head after both appends instead of serving the
+    # two-message projection cached before them.
+    latest_messages = await client.get(
+        f"/v1/sessions/{session.id}/messages",
+        params={"direction": "desc", "limit": 2},
+    )
+    assert latest_messages.status_code == 200, latest_messages.text
+    assert latest_messages.json() == {
+        "items": [
+            {"role": "assistant", "content": "appended answer", "model": None, "timestamp": None},
+            {
+                "role": "assistant",
+                "content": "visible answer",
+                "model": "claude-sonnet",
+                "timestamp": None,
+            },
+        ],
+        "total": 3,
+        "offset": 0,
+        "limit": 2,
+    }
+
     visible_search = (await client.get("/v1/sessions", params={"q": "visible answer"})).json()
     assert [item["local_session_id"] for item in visible_search["items"]] == [local_id]
     assert visible_search["items"][0]["search_match"] == {
         "role": "assistant",
         "excerpt": "visible answer",
+        "anchor": {
+            "kind": "event_seq",
+            "position": 4,
+            "revision": f"events:{generation}",
+        },
     }
     for private_query in ("private chain of thought", "secret tool output"):
         private_search = (await client.get("/v1/sessions", params={"q": private_query})).json()

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -15,6 +15,15 @@ from datetime import UTC, datetime
 
 import httpx
 import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models.session import Session, SessionMessageSearch
+from app.services.session_search import (
+    SearchableSessionMessage,
+    rebuild_session_search_index,
+    replace_snapshot_search_index,
+)
 
 
 async def _register_env(client: httpx.AsyncClient) -> str:
@@ -62,7 +71,7 @@ async def _push_session(
 
     if upload and messages:
         body_bytes = json.dumps(messages).encode("utf-8")
-        await client.post(
+        uploaded = await client.post(
             f"/v1/sessions/{local_session_id}/upload",
             files={
                 "file": (
@@ -72,6 +81,7 @@ async def _push_session(
                 )
             },
         )
+        assert uploaded.status_code == 200, uploaded.text
 
     listing = (await client.get(f"/v1/sessions?q={local_session_id}")).json()
     return next(s["id"] for s in listing["items"] if s["local_session_id"] == local_session_id)
@@ -115,6 +125,161 @@ async def test_relevance_sort_orders_by_similarity(client: httpx.AsyncClient):
     # rows ("UI polish") shouldn't appear at all.
     assert items[0]["summary"] == "oauth token refresh bug"
     assert all(s["summary"] != "UI polish" for s in items)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_message_search_tracks_current_content_and_escapes_wildcards(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    from app.routes import sessions as session_routes
+
+    env_id = await _register_env(client)
+    local_id = "snapshot-body-search"
+    original = [
+        {
+            "role": "assistant",
+            "content": "Original needle %_ and slash\\needle stay literal",
+        }
+    ]
+    await _push_session(
+        client,
+        env_id,
+        local_session_id=local_id,
+        messages=original,
+        upload=True,
+    )
+    await _push_session(
+        client,
+        env_id,
+        local_session_id="snapshot-body-search-decoy",
+        messages=[{"role": "user", "content": "A separate ordinary message"}],
+        upload=True,
+    )
+
+    matched = (await client.get("/v1/sessions", params={"q": "Original needle"})).json()
+    assert [item["local_session_id"] for item in matched["items"]] == [local_id]
+    assert matched["items"][0]["search_match"] == {
+        "role": "assistant",
+        "excerpt": original[0]["content"],
+    }
+    fuzzy = (await client.get("/v1/sessions", params={"q": "Orginal needle"})).json()
+    assert [item["local_session_id"] for item in fuzzy["items"]] == [local_id]
+    literal = (await client.get("/v1/sessions", params={"q": "%_"})).json()
+    assert [item["local_session_id"] for item in literal["items"]] == [local_id]
+    backslash = (await client.get("/v1/sessions", params={"q": "slash\\needle"})).json()
+    assert [item["local_session_id"] for item in backslash["items"]] == [local_id]
+
+    replacement = [{"role": "user", "content": "Replacement body is now authoritative"}]
+    await _push_session(
+        client,
+        env_id,
+        local_session_id=local_id,
+        messages=replacement,
+        upload=False,
+    )
+    stale = (await client.get("/v1/sessions", params={"q": "Original needle"})).json()
+    assert all(item["search_match"] is None for item in stale["items"])
+
+    await _push_session(
+        client,
+        env_id,
+        local_session_id=local_id,
+        messages=replacement,
+        upload=True,
+    )
+    current = (await client.get("/v1/sessions", params={"q": "authoritative"})).json()
+    assert [item["local_session_id"] for item in current["items"]] == [local_id]
+    assert current["items"][0]["search_match"] == {
+        "role": "user",
+        "excerpt": replacement[0]["content"],
+    }
+
+    session = (
+        await db_session.execute(select(Session).where(Session.local_session_id == local_id))
+    ).scalar_one()
+    await db_session.execute(
+        delete(SessionMessageSearch).where(SessionMessageSearch.session_id == session.id)
+    )
+    session.search_index_revision = None
+    await db_session.commit()
+    await rebuild_session_search_index(db_session, session, session_routes.file_store)
+    await db_session.commit()
+    rebuilt = (await client.get("/v1/sessions", params={"q": "authoritative"})).json()
+    assert [item["local_session_id"] for item in rebuilt["items"]] == [local_id]
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_rebuild_does_not_replace_a_newer_revision_after_object_read(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    engine,
+) -> None:
+    env_id = await _register_env(client)
+    local_id = "snapshot-search-rebuild-race"
+    original = [{"role": "user", "content": "old backfill content"}]
+    await _push_session(
+        client,
+        env_id,
+        local_session_id=local_id,
+        messages=original,
+        upload=True,
+    )
+    session = (
+        await db_session.execute(select(Session).where(Session.local_session_id == local_id))
+    ).scalar_one()
+    session.search_index_revision = None
+    await db_session.commit()
+
+    replacement_content = "new upload remains searchable"
+    replacement = [
+        SearchableSessionMessage(position=0, role="assistant", content=replacement_content)
+    ]
+    replacement_hash = hashlib.sha256(
+        json.dumps([{"role": "assistant", "content": replacement_content}]).encode("utf-8")
+    ).hexdigest()
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    class RacingFileStore:
+        async def get(self, _key: str) -> bytes:
+            async with session_factory() as writer:
+                current = (
+                    await writer.execute(
+                        select(Session).where(Session.id == session.id).with_for_update()
+                    )
+                ).scalar_one()
+                current.content_hash = replacement_hash
+                await replace_snapshot_search_index(
+                    writer,
+                    current,
+                    replacement_hash,
+                    replacement,
+                )
+                await writer.commit()
+            return json.dumps(original).encode("utf-8")
+
+    async with session_factory() as backfill_db:
+        stale = await backfill_db.get(Session, session.id)
+        assert stale is not None
+        rebuilt = await rebuild_session_search_index(backfill_db, stale, RacingFileStore())
+        await backfill_db.commit()
+    assert rebuilt is False
+
+    async with session_factory() as verification_db:
+        current = await verification_db.get(Session, session.id)
+        documents = list(
+            (
+                await verification_db.execute(
+                    select(SessionMessageSearch.content).where(
+                        SessionMessageSearch.session_id == session.id
+                    )
+                )
+            ).scalars()
+        )
+    assert current is not None
+    assert current.search_index_revision == f"snapshot:{replacement_hash}"
+    assert documents == [replacement_content]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -162,6 +162,13 @@ async def test_snapshot_message_search_tracks_current_content_and_escapes_wildca
     assert matched["items"][0]["search_match"] == {
         "role": "assistant",
         "excerpt": original[0]["content"],
+        "anchor": {
+            "kind": "snapshot_offset",
+            "position": 0,
+            "revision": (
+                "snapshot:" + hashlib.sha256(json.dumps(original).encode("utf-8")).hexdigest()
+            ),
+        },
     }
     fuzzy = (await client.get("/v1/sessions", params={"q": "Orginal needle"})).json()
     assert [item["local_session_id"] for item in fuzzy["items"]] == [local_id]
@@ -193,6 +200,13 @@ async def test_snapshot_message_search_tracks_current_content_and_escapes_wildca
     assert current["items"][0]["search_match"] == {
         "role": "user",
         "excerpt": replacement[0]["content"],
+        "anchor": {
+            "kind": "snapshot_offset",
+            "position": 0,
+            "revision": (
+                "snapshot:" + hashlib.sha256(json.dumps(replacement).encode("utf-8")).hexdigest()
+            ),
+        },
     }
 
     session = (

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -1042,6 +1042,23 @@ async def test_session_messages_endpoint_paginates_long_conversations(
     assert len(page3["items"]) == 50
     assert page3["items"][-1]["content"] == "msg 249"
 
+    # Descending offsets are relative to the newest end. The server computes
+    # this from the actual content rather than trusting batch metadata (which
+    # intentionally says 5 above while the blob contains 250 messages).
+    newest = await client.get(
+        f"/v1/sessions/{session_id}/messages?direction=desc&offset=0&limit=100"
+    )
+    newest_page = newest.json()
+    assert newest_page["total"] == 250
+    assert newest_page["offset"] == 0
+    assert newest_page["items"][0]["content"] == "msg 249"
+    assert newest_page["items"][-1]["content"] == "msg 150"
+    older = await client.get(
+        f"/v1/sessions/{session_id}/messages?direction=desc&offset=100&limit=100"
+    )
+    assert older.json()["items"][0]["content"] == "msg 149"
+    assert older.json()["items"][-1]["content"] == "msg 50"
+
     # Offset past the end → empty items, NOT 4xx (the blob may
     # have shrunk between paginated reads).
     r4 = await client.get(f"/v1/sessions/{session_id}/messages?offset=500&limit=100")

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -214,16 +214,19 @@ function printCloudSessionRows(sessions: SessionListItem[], total: number): void
 		console.log(
 			`  ${chalk.dim(session.id)}  ${chalk.white(summary)}  ${chalk.gray(project)}  ${chalk.gray(agent)}  ${chalk.gray(relativeTime(new Date(session.last_activity_at)))}`,
 		);
+		if (session.search_match) {
+			const role =
+				session.search_match.role === "user" ? chalk.cyan("user") : chalk.green("assistant");
+			console.log(`    ${role}: ${stripTerminalEscapes(session.search_match.excerpt)}`);
+		}
 	}
-	console.log(
-		chalk.gray(`\n  ${sessions.length} of ${total} metadata match${total === 1 ? "" : "es"}`),
-	);
+	console.log(chalk.gray(`\n  ${sessions.length} of ${total} match${total === 1 ? "" : "es"}`));
 }
 
 export async function sessionSearch(query: string, opts: CloudSessionOpts = {}): Promise<void> {
 	if (!requireCloudSessionAuth()) return;
 	const trimmedQuery = query.trim();
-	if (!trimmedQuery) throw new Error("Session metadata search query cannot be empty.");
+	if (!trimmedQuery) throw new Error("Session search query cannot be empty.");
 
 	const api = new ApiClient();
 	const page = unwrap(
@@ -246,7 +249,7 @@ export async function sessionSearch(query: string, opts: CloudSessionOpts = {}):
 		return;
 	}
 	if (page.items.length === 0) {
-		console.log(chalk.gray(`No uploaded session metadata matching "${sanitizeMetadata(query)}".`));
+		console.log(chalk.gray(`No uploaded sessions matching "${sanitizeMetadata(query)}".`));
 		return;
 	}
 	printCloudSessionRows(page.items, page.total);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1096,7 +1096,7 @@ Examples:
 
 sessionCmd
 	.command("search <query>")
-	.description("Search uploaded session metadata (summary, project, and IDs; not message text)")
+	.description("Search uploaded session summaries, messages, projects, and IDs")
 	.option("--agent <type>", "Filter by agent type")
 	.option("--since <date>", "Only sessions active after this date")
 	.option("--limit <n>", "Cap results (1-200)", "25")

--- a/packages/cli/tests/commands/session.test.ts
+++ b/packages/cli/tests/commands/session.test.ts
@@ -27,7 +27,7 @@ afterEach(() => {
 });
 
 describe("cloud session commands", () => {
-	it("searches only through the existing session metadata query contract", async () => {
+	it("searches through the cloud session query contract", async () => {
 		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
@@ -53,6 +53,50 @@ describe("cloud session commands", () => {
 			page_size: "7",
 			sort: "relevance",
 		});
+	});
+
+	it("prints the best matching message excerpt in terminal output", async () => {
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/sessions",
+				response: () =>
+					jsonResponse({
+						items: [
+							{
+								id: "00000000-0000-0000-0000-000000000123",
+								local_session_id: "local-123",
+								summary: "Fixture",
+								project_path: "/workspace",
+								agent_type: "codex",
+								last_activity_at: "2026-08-27T12:00:00Z",
+								search_match: {
+									role: "assistant",
+									excerpt: "The matching implementation detail",
+								},
+							},
+						],
+						total: 1,
+						page: 1,
+						page_size: 25,
+					}),
+			},
+		]);
+		const output: string[] = [];
+		const originalLog = console.log;
+		const ttyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		console.log = (value?: unknown) => output.push(String(value));
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		try {
+			await sessionSearch("implementation");
+		} finally {
+			console.log = originalLog;
+			if (ttyDescriptor) Object.defineProperty(process.stdout, "isTTY", ttyDescriptor);
+			else Object.defineProperty(process.stdout, "isTTY", { value: undefined, configurable: true });
+			restore();
+		}
+
+		expect(output.join("\n")).toContain("assistant: The matching implementation detail");
 	});
 
 	it("reads metadata and message content by cloud session id", async () => {

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -7725,6 +7725,7 @@ export interface components {
              * @default false
              */
             is_shared: boolean;
+            search_match?: components["schemas"]["SessionSearchMatchResponse"] | null;
             /** Related Refs */
             related_refs?: {
                 [key: string]: string[];
@@ -7991,6 +7992,7 @@ export interface components {
              * @default false
              */
             is_shared: boolean;
+            search_match?: components["schemas"]["SessionSearchMatchResponse"] | null;
             /** Related Refs */
             related_refs?: {
                 [key: string]: string[];
@@ -8160,6 +8162,16 @@ export interface components {
             payload_json?: string | null;
             /** Model */
             model?: string | null;
+        };
+        /** SessionSearchMatchResponse */
+        SessionSearchMatchResponse: {
+            /**
+             * Role
+             * @enum {string}
+             */
+            role: "user" | "assistant";
+            /** Excerpt */
+            excerpt: string;
         };
         /** SessionTextPart */
         SessionTextPart: {
@@ -11530,7 +11542,7 @@ export interface operations {
     list_sessions_v1_sessions_get: {
         parameters: {
             query?: {
-                /** @description Fuzzy search on summary/project/id */
+                /** @description Fuzzy search on summary/project/id and visible message text */
                 q?: string | null;
                 /** @description Filter by agent_type */
                 agent?: string | null;

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1353,14 +1353,11 @@ export interface paths {
          *     this endpoint slices the same blob server-side so the
          *     dashboard doesn't ship 10+ MB of messages on a long session.
          *
-         *     Pagination is offset-based, NOT cursor-based: the underlying
-         *     file-store blob is immutable per upload (each push replaces
-         *     the entire JSON array), so `array[offset:offset+limit]` is
-         *     stable for a given `content_hash`. Clients pin to a snapshot
-         *     by reading `content_hash` from the parent
-         *     `/v1/sessions/{id}` response and refusing to mix pages
-         *     from different hashes — a daemon append in between would
-         *     show up as a hash change and trigger a refetch.
+         *     Pagination is offset-based within the requested direction. `offset=0`
+         *     starts at the oldest visible message for ascending reads and at the newest
+         *     visible message for descending reads. Clients pin pages to the parent
+         *     session's `content_hash`, which changes after snapshot replacement or event
+         *     append.
          */
         get: operations["get_session_messages_v1_sessions__session_id__messages_get"];
         put?: never;
@@ -8052,9 +8049,11 @@ export interface components {
          *     (`GET /v1/sessions/{id}/content`) stays unchanged so the CLI's
          *     `clawdi pull` mirror still gets a single full JSON array.
          *
-         *     `total` is the count of messages in the underlying content file
+         *     `total` is the count of visible messages in the current content revision
          *     (not the count returned in `items`) so the client can render a
-         *     "loaded N/M" hint and decide whether to fetch more pages.
+         *     "loaded N/M" hint and decide whether to fetch more pages. `offset` is
+         *     relative to the requested order: zero means the oldest message for
+         *     ascending reads and the newest message for descending reads.
          */
         SessionMessagesPage: {
             /** Items */
@@ -8163,6 +8162,18 @@ export interface components {
             /** Model */
             model?: string | null;
         };
+        /** SessionSearchAnchorResponse */
+        SessionSearchAnchorResponse: {
+            /**
+             * Kind
+             * @enum {string}
+             */
+            kind: "snapshot_offset" | "event_seq";
+            /** Position */
+            position: number;
+            /** Revision */
+            revision: string;
+        };
         /** SessionSearchMatchResponse */
         SessionSearchMatchResponse: {
             /**
@@ -8172,6 +8183,7 @@ export interface components {
             role: "user" | "assistant";
             /** Excerpt */
             excerpt: string;
+            anchor: components["schemas"]["SessionSearchAnchorResponse"];
         };
         /** SessionTextPart */
         SessionTextPart: {
@@ -11726,6 +11738,7 @@ export interface operations {
             query?: {
                 offset?: number;
                 limit?: number;
+                direction?: "asc" | "desc";
             };
             header?: never;
             path: {
@@ -11952,6 +11965,7 @@ export interface operations {
             query?: {
                 offset?: number;
                 limit?: number;
+                direction?: "asc" | "desc";
             };
             header?: never;
             path: {


### PR DESCRIPTION
## Summary

- index visible user and assistant message text for both `snapshot-v1` and `events-v1` Sessions
- keep search atomically fenced to the current committed content revision
- separate immutable event-document ownership from the published event-head revision
- withhold incomplete projections during rolling deploys and repair them through idempotent retries or backfill
- return the best bounded excerpt plus a typed, revision-fenced search anchor
- paginate message reads in either direction from the actual visible transcript
- simplify Web newest-first paging so it no longer trusts separately reported message counts
- add an idempotent, bounded backfill command for historical Sessions

Private reasoning, tool payloads, system messages, hidden events, and raw event envelopes are not included in ordinary search. Canonical Session content remains authoritative in object storage; the PostgreSQL search projection and per-chunk completion markers are disposable derived state.

## Verification

- all PR checks green, including Backend CI, Client CI, Web E2E, clean runner, Vercel, and privileged systemd E2E
- complete local backend suite: `2494 passed / 12 skipped`
- focused event/search integration tests: `16 passed`
- strict backend typing: `204 files / 0 errors`
- PostgreSQL 18 benchmark, 10,000 Sessions / 300,000 messages: about `383.7 ms` before candidate-first planning and `2.01 ms` after; the plan uses the trigram GIN index
- Web complete tests: `1079 passed`; typecheck and OSS production build passed
- CLI typecheck and Session command tests: `4 passed`
- empty-database migration upgrade, downgrade to `a9c4e2f7b1d6`, and re-upgrade passed
- Ruff lint/format, generated OpenAPI client drift, and `git diff --check` passed

The event integration coverage spans immutable chunks containing visible messages, system context, tool calls/results, and private reasoning. It verifies append idempotency, full event ordering, visible message pagination, partial-projection suppression, concurrent append fencing, and same-head generation replacement.

## Rollout

The migration intentionally does not read object storage. New writes from the matching backend are indexed transactionally.

1. Apply the migration and roll out the new backend.
2. Wait until all old backend instances have drained. Old instances can still create chunks without completion markers; those chunks stay safely unsearchable rather than publishing a partial projection.
3. Backfill historical and rollout-window Sessions:

```bash
cd backend
pdm run python -m scripts.backfill_session_search --all
```

The command is resumable, checks both the current revision and current generation completion markers, and exits nonzero if any authoritative object could not be indexed.