### PR TITLE
fix(cli): preserve Hermes channel preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.23
+
+Package: `clawdi@0.14.23`
+
+### Fixed
+
+- Hosted Hermes channel reconciliation now preserves user-authored channel
+  preferences, including Discord free-response channels.
+
 ## Clawdi CLI v0.14.22
 
 Package: `clawdi@0.14.22`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.22",
+      "version": "0.14.23",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.22",
+	"version": "0.14.23",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/managed-channel-reconciliation.ts
+++ b/packages/cli/src/runtime/managed-channel-reconciliation.ts
@@ -78,7 +78,19 @@ export function buildHermesManagedChannelsPatch(
 						base_file_url: "https://api.telegram.org/file/bot",
 					},
 				}
-			: { enabled: false },
+			: {
+					enabled: false,
+					dm_policy: null,
+					group_policy: null,
+					allow_from: null,
+					group_allow_from: null,
+					group_allowed_chats: null,
+					require_mention: null,
+					extra: {
+						base_url: null,
+						base_file_url: null,
+					},
+				},
 		discord: discordEnabled
 			? {
 					enabled: true,
@@ -88,7 +100,14 @@ export function buildHermesManagedChannelsPatch(
 					thread_require_mention: false,
 					bots_require_inline_mention: false,
 				}
-			: { enabled: false },
+			: {
+					enabled: false,
+					dm_policy: null,
+					group_policy: null,
+					require_mention: null,
+					thread_require_mention: null,
+					bots_require_inline_mention: null,
+				},
 		whatsapp,
 		group_sessions_per_user: sharedChannelSessionsEnabled ? false : null,
 		thread_sessions_per_user: sharedChannelSessionsEnabled ? false : null,

--- a/packages/cli/src/runtime/manifest-channels.ts
+++ b/packages/cli/src/runtime/manifest-channels.ts
@@ -370,11 +370,7 @@ function applyHermesChannelConfig(
 	for (const [key, value] of Object.entries(patch).sort(([left], [right]) =>
 		left.localeCompare(right),
 	)) {
-		if (key === "telegram" || key === "discord") {
-			changed = reconcileHermesConfigValue(context, key, value) || changed;
-			continue;
-		}
-		if (key === "whatsapp" || key === "display") {
+		if (key === "telegram" || key === "discord" || key === "whatsapp" || key === "display") {
 			if (!isPlainRecord(value))
 				throw new Error(`Hermes channel patch field ${key} must be an object`);
 			changed = applyHermesNestedConfigPatch(context, key, value) || changed;

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -9068,6 +9068,7 @@ exit 64
 				"discord:",
 				'  allow_from: ["*"]',
 				'  group_allow_from: ["*"]',
+				'  free_response_channels: "123456789"',
 				"display:",
 				"  theme: user-theme",
 				"  platforms:",
@@ -9181,8 +9182,11 @@ exit 64
 		expect(parsedHermesConfig.streaming).toEqual({ enabled: false });
 		expect(parsedHermesConfig.group_sessions_per_user).toBe(false);
 		expect(parsedHermesConfig.thread_sessions_per_user).toBe(false);
-		expect(parsedHermesConfig).not.toHaveProperty("discord.allow_from");
-		expect(parsedHermesConfig).not.toHaveProperty("discord.group_allow_from");
+		expect(parsedHermesConfig.discord).toMatchObject({
+			allow_from: ["*"],
+			group_allow_from: ["*"],
+			free_response_channels: "123456789",
+		});
 		expect(parsedHermesConfig).not.toHaveProperty("streaming.transport");
 		expect(parsedHermesConfig).toMatchObject({
 			custom_root: "keep",
@@ -9256,6 +9260,11 @@ exit 64
 		expect(removed.installErrors).toEqual([]);
 		const clearedHermesConfig = readHermesConfigYaml(home);
 		expect(clearedHermesConfig.streaming).toEqual({ enabled: false });
+		expect(clearedHermesConfig.discord).toMatchObject({
+			allow_from: ["*"],
+			group_allow_from: ["*"],
+			free_response_channels: "123456789",
+		});
 		expect(clearedHermesConfig).not.toHaveProperty("group_sessions_per_user");
 		expect(clearedHermesConfig).not.toHaveProperty("thread_sessions_per_user");
 		expect(clearedHermesConfig).not.toHaveProperty("streaming.transport");


### PR DESCRIPTION
## Summary

- reconcile only Hermes channel fields owned by Hosted
- remove those owned fields explicitly when a managed channel is disabled
- preserve user-authored Discord preferences such as `free_response_channels` across enable, shrink, and removal
- release the fix as stable `clawdi@0.14.23`

## Verification

- head: `ab76fe008`
- `CLAWDI_TEST_COMPOSE_PROJECT_NAME=clawdi-cli-01423-release scripts/test.sh cli` (`1671 pass`, `4 skip`, `0 fail`)
- `bun run --cwd packages/cli check:publish-manifest`
- Biome on all changed CLI and release files
- `git diff --check`

## Release impact

Merging changes `packages/cli/package.json`, so the protected CLI publish workflow will build, verify, and publish `clawdi@0.14.23` to the stable `latest` channel. Hosted still requires its separate exact-package validation and promotion.