### PR TITLE
fix(cli): preserve managed channel preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.14.24
+
+Package: `clawdi@0.14.24`
+
+### Fixed
+
+- Hosted OpenClaw and Hermes channel reconciliation now preserves user-authored
+  access policies, allowlists, and channel experience preferences.
+
 ## Clawdi CLI v0.14.23
 
 Package: `clawdi@0.14.23`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.23",
+      "version": "0.14.24",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.23",
+	"version": "0.14.24",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -28,7 +28,8 @@ const HERMES_MANAGED_CHANNEL_ENV = [
 	"WHATSAPP_ENABLED",
 	"WHATSAPP_MODE",
 	"WHATSAPP_ALLOWED_USERS",
-	"WHATSAPP_ALLOW_ALL_USERS",
+	"WHATSAPP_DM_POLICY",
+	"WHATSAPP_GROUP_POLICY",
 ] as const;
 const HERMES_MANAGED_CHANNEL_SECRET_ENV = ["TELEGRAM_BOT_TOKEN", "DISCORD_BOT_TOKEN"] as const;
 const OPENCLAW_CHANNEL_TOKEN_ENV_PREFIX = "CLAWDI_CHANNEL_";
@@ -363,7 +364,8 @@ function applyHermesRuntimeChannelSettings(
 	if (whatsapp) {
 		env.WHATSAPP_MODE = "bot";
 		env.WHATSAPP_ALLOWED_USERS = "*";
-		env.WHATSAPP_ALLOW_ALL_USERS = "true";
+		env.WHATSAPP_DM_POLICY = "open";
+		env.WHATSAPP_GROUP_POLICY = "open";
 	}
 	return {
 		...manifest,

--- a/packages/cli/src/runtime/managed-channel-reconciliation.ts
+++ b/packages/cli/src/runtime/managed-channel-reconciliation.ts
@@ -25,107 +25,29 @@ export function buildHermesManagedChannelsPatch(
 	const whatsapp = whatsappEnabled
 		? {
 				enabled: true,
-				dm_policy: "allowlist",
-				group_policy: "open",
-				allow_from: ["*"],
-				group_allow_from: ["*"],
 			}
 		: {
 				enabled: false,
-				dm_policy: null,
-				group_policy: null,
-				allow_from: null,
-				group_allow_from: null,
 			};
 	const whatsappPlatform = whatsappEnabled
 		? {
 				enabled: true,
 				extra: {
 					session_path: whatsappAuthDir,
-					dm_policy: "allowlist",
-					group_policy: "open",
-					allow_from: ["*"],
-					group_allow_from: ["*"],
-					group_sessions_per_user: false,
-					thread_sessions_per_user: false,
 				},
 			}
 		: {
 				enabled: false,
 				extra: {
 					session_path: null,
-					dm_policy: null,
-					group_policy: null,
-					allow_from: null,
-					group_allow_from: null,
-					group_sessions_per_user: null,
-					thread_sessions_per_user: null,
 				},
 			};
-	const sharedChannelSessionsEnabled = telegramEnabled || discordEnabled || whatsappEnabled;
 	return {
-		telegram: telegramEnabled
-			? {
-					enabled: true,
-					dm_policy: "open",
-					group_policy: "open",
-					allow_from: ["*"],
-					group_allow_from: ["*"],
-					group_allowed_chats: ["*"],
-					require_mention: false,
-					extra: {
-						base_url: "https://api.telegram.org/bot",
-						base_file_url: "https://api.telegram.org/file/bot",
-					},
-				}
-			: {
-					enabled: false,
-					dm_policy: null,
-					group_policy: null,
-					allow_from: null,
-					group_allow_from: null,
-					group_allowed_chats: null,
-					require_mention: null,
-					extra: {
-						base_url: null,
-						base_file_url: null,
-					},
-				},
-		discord: discordEnabled
-			? {
-					enabled: true,
-					dm_policy: "open",
-					group_policy: "open",
-					require_mention: false,
-					thread_require_mention: false,
-					bots_require_inline_mention: false,
-				}
-			: {
-					enabled: false,
-					dm_policy: null,
-					group_policy: null,
-					require_mention: null,
-					thread_require_mention: null,
-					bots_require_inline_mention: null,
-				},
+		telegram: { enabled: telegramEnabled },
+		discord: { enabled: discordEnabled },
 		whatsapp,
-		group_sessions_per_user: sharedChannelSessionsEnabled ? false : null,
-		thread_sessions_per_user: sharedChannelSessionsEnabled ? false : null,
 		platforms: {
-			telegram: {
-				extra: {
-					group_sessions_per_user: telegramEnabled ? false : null,
-					thread_sessions_per_user: telegramEnabled ? false : null,
-				},
-			},
 			whatsapp: whatsappPlatform,
-		},
-		display: {
-			platforms: {
-				telegram: {
-					streaming: telegramEnabled ? true : null,
-				},
-			},
 		},
 	};
 }

--- a/packages/cli/src/runtime/manifest-channels.ts
+++ b/packages/cli/src/runtime/manifest-channels.ts
@@ -25,7 +25,7 @@ import {
 	runtimeFileCurrentRevision,
 } from "./manifest-install";
 import { openClawConfigPatchIsApplied } from "./manifest-providers";
-import { isPlainRecord, recordValue } from "./manifest-shared";
+import { canonicalJsonEqual, isPlainRecord, recordValue } from "./manifest-shared";
 import { openClawPluginInspectSchema } from "./openclaw-plugin-observation";
 import {
 	runRuntimeUserCommand,
@@ -423,8 +423,14 @@ export function applyHostedChannelProjection(
 			buildHermesManagedChannelsPatch(channels, hermesWhatsAppAuthDir),
 		);
 	}
-	const patch = openClawManagedChannelsPatch(channels);
-	if (openClawConfigPatchIsApplied(openClawContext, patch)) return false;
+	const currentConfig = readOpenClawConfig(openClawContext.configPath);
+	const patch = openClawManagedChannelsPatch(channels, currentConfig);
+	if (
+		openClawConfigPatchIsApplied(openClawContext, patch) &&
+		openClawManagedAccountMapsAreApplied(currentConfig, patch, channels)
+	) {
+		return false;
+	}
 	runRuntimeUserCommand(
 		observation.commandPath,
 		["config", "patch", "--stdin", ...openClawManagedAccountReplaceArgs(channels)],
@@ -461,6 +467,7 @@ function openClawManagedChannelUsesEnvSecretRefs(channels: Record<string, unknow
 }
 export function openClawManagedChannelsPatch(
 	channels: Record<string, unknown>,
+	currentConfig: Record<string, unknown> | null = null,
 ): Record<string, unknown> {
 	const deleteEntries = openClawManagedChannelDeletes();
 	const usesEnvSecretRefs = openClawManagedChannelUsesEnvSecretRefs(channels);
@@ -468,10 +475,11 @@ export function openClawManagedChannelsPatch(
 		managedChannelHasAccounts(channels.telegram) ||
 		managedChannelHasAccounts(channels.discord) ||
 		managedChannelHasAccounts(channels.whatsapp);
+	const effectiveChannels = mergeOpenClawManagedAccountPreferences(channels, currentConfig);
 	return {
 		channels: {
 			...deleteEntries,
-			...channels,
+			...effectiveChannels,
 		},
 		plugins: {
 			entries: {
@@ -493,6 +501,71 @@ export function openClawManagedChannelsPatch(
 			dmScope: isolatesManagedDms ? "per-account-channel-peer" : null,
 		},
 	};
+}
+
+function readOpenClawConfig(path: string): Record<string, unknown> | null {
+	try {
+		return recordValue(JSON.parse(readFileSync(path, "utf-8")) as unknown);
+	} catch {
+		return null;
+	}
+}
+
+function mergeOpenClawManagedAccountPreferences(
+	channels: Record<string, unknown>,
+	currentConfig: Record<string, unknown> | null,
+): Record<string, unknown> {
+	const currentChannels = recordValue(currentConfig?.channels);
+	if (!currentChannels) return channels;
+	const mergedChannels = { ...channels };
+	for (const provider of OPENCLAW_MANAGED_CHANNELS) {
+		const desiredChannel = recordValue(channels[provider]);
+		const desiredAccounts = recordValue(desiredChannel?.accounts);
+		if (!desiredChannel || !desiredAccounts) continue;
+		const currentAccounts = recordValue(recordValue(currentChannels[provider])?.accounts);
+		const mergedAccounts: Record<string, unknown> = {};
+		for (const [accountId, desiredValue] of Object.entries(desiredAccounts)) {
+			const desiredAccount = recordValue(desiredValue);
+			if (!desiredAccount) {
+				mergedAccounts[accountId] = desiredValue;
+				continue;
+			}
+			const currentAccount = recordValue(currentAccounts?.[accountId]);
+			const mergedAccount = { ...desiredAccount, ...(currentAccount ?? {}) };
+			for (const key of openClawManagedAccountFields(provider)) {
+				if (Object.hasOwn(desiredAccount, key)) mergedAccount[key] = desiredAccount[key];
+			}
+			mergedAccounts[accountId] = mergedAccount;
+		}
+		mergedChannels[provider] = { ...desiredChannel, accounts: mergedAccounts };
+	}
+	return mergedChannels;
+}
+
+function openClawManagedAccountFields(
+	provider: (typeof OPENCLAW_MANAGED_CHANNELS)[number],
+): readonly string[] {
+	if (provider === "telegram") return ["enabled", "botToken"];
+	if (provider === "discord") return ["enabled", "token"];
+	return ["enabled", "authDir"];
+}
+
+function openClawManagedAccountMapsAreApplied(
+	currentConfig: Record<string, unknown> | null,
+	patch: Record<string, unknown>,
+	channels: Record<string, unknown>,
+): boolean {
+	const currentChannels = recordValue(currentConfig?.channels);
+	const patchedChannels = recordValue(patch.channels);
+	for (const provider of OPENCLAW_MANAGED_CHANNELS) {
+		const desiredAccounts = recordValue(recordValue(channels[provider])?.accounts);
+		if (!desiredAccounts) continue;
+		if (!currentChannels || !patchedChannels) return false;
+		const currentAccounts = recordValue(recordValue(currentChannels[provider])?.accounts);
+		const patchedAccounts = recordValue(recordValue(patchedChannels[provider])?.accounts);
+		if (!canonicalJsonEqual(currentAccounts, patchedAccounts)) return false;
+	}
+	return true;
 }
 function openClawManagedAccountReplaceArgs(channels: Record<string, unknown>): string[] {
 	const args: string[] = [];

--- a/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/hermes_consumer.py
+++ b/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/hermes_consumer.py
@@ -26,9 +26,11 @@ async def main() -> None:
     for key, value in projection["run"]["env"].items():
         os.environ[key] = value
     if os.environ.get("WHATSAPP_ALLOWED_USERS") != "*":
-        raise RuntimeError("managed Hermes projection must use the stock wildcard allowlist")
-    if os.environ.get("WHATSAPP_ALLOW_ALL_USERS") != "true":
-        raise RuntimeError("managed Hermes projection must explicitly opt in to allow all users")
+        raise RuntimeError("managed Hermes projection must use the stock bridge wildcard")
+    if os.environ.get("WHATSAPP_DM_POLICY") != "open":
+        raise RuntimeError("managed Hermes projection must use the stock open DM policy")
+    if os.environ.get("WHATSAPP_GROUP_POLICY") != "open":
+        raise RuntimeError("managed Hermes projection must use the stock open group policy")
     discover_plugins()
 
     received: list[dict[str, Any]] = []

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -80,6 +80,7 @@ import {
 	officialInstallArgs,
 	validateUnmanagedProviderSecretValues,
 } from "../src/runtime/manifest-contract";
+import { recordValue } from "../src/runtime/manifest-shared";
 import {
 	HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
 	loadRemoteRuntimeManifest as loadRemoteRuntimeManifestWithContext,
@@ -8706,7 +8707,31 @@ exit 64
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(join(home, ".local", "bin"), { recursive: true });
+		mkdirSync(join(home, ".openclaw"), { recursive: true });
 		mkdirSync(join(root, "etc", "clawdi"), { recursive: true });
+		writeFileSync(
+			join(home, ".openclaw", "openclaw.json"),
+			`${JSON.stringify(
+				{
+					channels: {
+						discord: {
+							accounts: {
+								clawdi_acctdiscord1: {
+									enabled: false,
+									token: "user-token",
+									dmPolicy: "allowlist",
+									allowFrom: ["discord-user"],
+									guilds: { "discord-guild": { requireMention: true } },
+								},
+								stale: { enabled: true, token: "stale-token" },
+							},
+						},
+					},
+				},
+				null,
+				2,
+			)}\n`,
+		);
 		writeFileSync(
 			openclawBin,
 			`#!/usr/bin/env bash
@@ -8869,6 +8894,34 @@ exit 64
 			if (!isolationPatch) throw new Error("OpenClaw session isolation patch was not rendered");
 			const sessionPatch = expectRecord(isolationPatch.session, "OpenClaw session patch");
 			expect(sessionPatch).toEqual({ dmScope: "per-account-channel-peer" });
+			const channelPatch = patchText
+				.split("\n---\n")
+				.filter((entry) => entry.trim().length > 0)
+				.map((entry): unknown => JSON.parse(entry))
+				.map((entry) => expectRecord(entry, "OpenClaw config patch"))
+				.find((entry) => recordValue(entry.channels)?.telegram !== undefined);
+			if (!channelPatch) throw new Error("OpenClaw channel patch was not rendered");
+			const patchedChannels = expectRecord(channelPatch.channels, "OpenClaw channel patch");
+			const discordAccounts = expectRecord(
+				expectRecord(patchedChannels.discord, "OpenClaw Discord patch").accounts,
+				"OpenClaw Discord accounts",
+			);
+			const discordAccount = expectRecord(
+				discordAccounts.clawdi_acctdiscord1,
+				"OpenClaw Discord account",
+			);
+			expect(discordAccount).toMatchObject({
+				enabled: true,
+				token: {
+					source: "env",
+					provider: "default",
+					id: "CLAWDI_CHANNEL_DISCORD_CLAWDI_ACCTDISCORD1_AGENT_TOKEN",
+				},
+				dmPolicy: "allowlist",
+				allowFrom: ["discord-user"],
+				guilds: { "discord-guild": { requireMention: true } },
+			});
+			expect(Object.keys(discordAccounts)).toEqual(["clawdi_acctdiscord1"]);
 			for (const current of ["main", "per-peer", "per-channel-peer", "per-account-channel-peer"]) {
 				expect({ dmScope: current, resetTriggers: ["/new"], ...sessionPatch }).toEqual({
 					dmScope: "per-account-channel-peer",
@@ -9063,12 +9116,30 @@ exit 64
 			join(home, ".hermes", "config.yaml"),
 			[
 				"custom_root: keep",
+				"group_sessions_per_user: false",
+				"thread_sessions_per_user: true",
 				"streaming:",
 				"  enabled: false",
+				"telegram:",
+				"  dm_policy: allowlist",
+				"  group_policy: allowlist",
+				'  allow_from: ["telegram-user"]',
+				'  group_allow_from: ["telegram-group-user"]',
+				'  group_allowed_chats: ["telegram-chat"]',
+				"  require_mention: true",
+				"  extra:",
+				"    base_url: https://telegram.example.test/bot",
+				"    base_file_url: https://telegram.example.test/file/bot",
 				"discord:",
-				'  allow_from: ["*"]',
-				'  group_allow_from: ["*"]',
+				"  dm_policy: pairing",
+				"  group_policy: allowlist",
+				'  allow_from: ["discord-user"]',
+				'  group_allow_from: ["discord-group-user"]',
+				"  require_mention: true",
+				"  thread_require_mention: true",
+				"  bots_require_inline_mention: true",
 				'  free_response_channels: "123456789"',
+				"  auto_thread: true",
 				"display:",
 				"  theme: user-theme",
 				"  platforms:",
@@ -9076,11 +9147,14 @@ exit 64
 				"      streaming: false",
 				"    telegram:",
 				"      compact: true",
+				"      streaming: false",
 				"platforms:",
 				"  telegram:",
 				"    custom: keep-telegram",
 				"    extra:",
 				"      custom_extra: keep-extra",
+				"      group_sessions_per_user: true",
+				"      thread_sessions_per_user: true",
 				"  discord:",
 				"    custom: keep-discord",
 				"",
@@ -9172,20 +9246,37 @@ exit 64
 		const hermesConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf-8");
 		expect(hermesConfig).toContain("telegram:");
 		expect(hermesConfig).toContain("enabled: true");
-		expect(hermesConfig).toContain("base_url: https://api.telegram.org/bot");
-		expect(hermesConfig).toContain("base_file_url: https://api.telegram.org/file/bot");
 		expect(hermesConfig).toContain("discord:");
-		expect(hermesConfig).toContain("thread_require_mention: false");
+		expect(hermesConfig).toContain("thread_require_mention: true");
 		expect(hermesConfig).not.toContain("telegram-agent-token");
 		expect(hermesConfig).not.toContain("discord-agent-token");
 		const parsedHermesConfig = readHermesConfigYaml(home);
 		expect(parsedHermesConfig.streaming).toEqual({ enabled: false });
 		expect(parsedHermesConfig.group_sessions_per_user).toBe(false);
-		expect(parsedHermesConfig.thread_sessions_per_user).toBe(false);
+		expect(parsedHermesConfig.thread_sessions_per_user).toBe(true);
+		expect(parsedHermesConfig.telegram).toMatchObject({
+			enabled: true,
+			dm_policy: "allowlist",
+			group_policy: "allowlist",
+			allow_from: ["telegram-user"],
+			group_allow_from: ["telegram-group-user"],
+			group_allowed_chats: ["telegram-chat"],
+			require_mention: true,
+			extra: {
+				base_url: "https://telegram.example.test/bot",
+				base_file_url: "https://telegram.example.test/file/bot",
+			},
+		});
 		expect(parsedHermesConfig.discord).toMatchObject({
-			allow_from: ["*"],
-			group_allow_from: ["*"],
+			dm_policy: "pairing",
+			group_policy: "allowlist",
+			allow_from: ["discord-user"],
+			group_allow_from: ["discord-group-user"],
+			require_mention: true,
+			thread_require_mention: true,
+			bots_require_inline_mention: true,
 			free_response_channels: "123456789",
+			auto_thread: true,
 		});
 		expect(parsedHermesConfig).not.toHaveProperty("streaming.transport");
 		expect(parsedHermesConfig).toMatchObject({
@@ -9194,7 +9285,7 @@ exit 64
 				theme: "user-theme",
 				platforms: {
 					discord: { streaming: false },
-					telegram: { compact: true, streaming: true },
+					telegram: { compact: true, streaming: false },
 				},
 			},
 			platforms: {
@@ -9202,8 +9293,8 @@ exit 64
 					custom: "keep-telegram",
 					extra: {
 						custom_extra: "keep-extra",
-						group_sessions_per_user: false,
-						thread_sessions_per_user: false,
+						group_sessions_per_user: true,
+						thread_sessions_per_user: true,
 					},
 				},
 				discord: { custom: "keep-discord" },
@@ -9245,12 +9336,23 @@ exit 64
 		expect(discordOnly.installErrors).toEqual([]);
 		const discordOnlyHermesConfig = readHermesConfigYaml(home);
 		expect(discordOnlyHermesConfig.group_sessions_per_user).toBe(false);
-		expect(discordOnlyHermesConfig.thread_sessions_per_user).toBe(false);
-		expect(discordOnlyHermesConfig).not.toHaveProperty(
+		expect(discordOnlyHermesConfig.thread_sessions_per_user).toBe(true);
+		expect(discordOnlyHermesConfig.telegram).toMatchObject({
+			enabled: false,
+			dm_policy: "allowlist",
+			group_policy: "allowlist",
+			allow_from: ["telegram-user"],
+			group_allow_from: ["telegram-group-user"],
+			group_allowed_chats: ["telegram-chat"],
+			require_mention: true,
+		});
+		expect(discordOnlyHermesConfig).toHaveProperty(
 			"platforms.telegram.extra.group_sessions_per_user",
+			true,
 		);
-		expect(discordOnlyHermesConfig).not.toHaveProperty(
+		expect(discordOnlyHermesConfig).toHaveProperty(
 			"platforms.telegram.extra.thread_sessions_per_user",
+			true,
 		);
 
 		const removed = convergeRuntimeManifest(
@@ -9261,37 +9363,40 @@ exit 64
 		const clearedHermesConfig = readHermesConfigYaml(home);
 		expect(clearedHermesConfig.streaming).toEqual({ enabled: false });
 		expect(clearedHermesConfig.discord).toMatchObject({
-			allow_from: ["*"],
-			group_allow_from: ["*"],
+			dm_policy: "pairing",
+			group_policy: "allowlist",
+			allow_from: ["discord-user"],
+			group_allow_from: ["discord-group-user"],
+			require_mention: true,
+			thread_require_mention: true,
+			bots_require_inline_mention: true,
 			free_response_channels: "123456789",
+			auto_thread: true,
 		});
-		expect(clearedHermesConfig).not.toHaveProperty("group_sessions_per_user");
-		expect(clearedHermesConfig).not.toHaveProperty("thread_sessions_per_user");
+		expect(clearedHermesConfig.group_sessions_per_user).toBe(false);
+		expect(clearedHermesConfig.thread_sessions_per_user).toBe(true);
 		expect(clearedHermesConfig).not.toHaveProperty("streaming.transport");
-		expect(clearedHermesConfig).not.toHaveProperty(
-			"platforms.telegram.extra.thread_sessions_per_user",
-		);
 		expect(clearedHermesConfig).toMatchObject({
 			custom_root: "keep",
 			display: {
 				theme: "user-theme",
 				platforms: {
 					discord: { streaming: false },
-					telegram: { compact: true },
+					telegram: { compact: true, streaming: false },
 				},
 			},
 			platforms: {
 				telegram: {
 					custom: "keep-telegram",
-					extra: { custom_extra: "keep-extra" },
+					extra: {
+						custom_extra: "keep-extra",
+						group_sessions_per_user: true,
+						thread_sessions_per_user: true,
+					},
 				},
 				discord: { custom: "keep-discord" },
 			},
 		});
-		expect(clearedHermesConfig).not.toHaveProperty(
-			"platforms.telegram.extra.group_sessions_per_user",
-		);
-		expect(clearedHermesConfig).not.toHaveProperty("display.platforms.telegram.streaming");
 	}, 30_000);
 
 	it("projects and removes Hermes native WhatsApp through the stock adapter config", () => {
@@ -9329,6 +9434,10 @@ exit 64
 				"custom_root: keep",
 				"whatsapp:",
 				"  user_owned: keep-whatsapp",
+				"  dm_policy: allowlist",
+				'  allow_from: ["15550000001"]',
+				"  group_policy: allowlist",
+				'  group_allow_from: ["120363000000000000@g.us"]',
 				"platforms:",
 				"  matrix:",
 				"    custom: keep-matrix",
@@ -9336,6 +9445,12 @@ exit 64
 				"    custom: keep-platform",
 				"    extra:",
 				"      custom_extra: keep-extra",
+				"      dm_policy: allowlist",
+				'      allow_from: ["15550000001"]',
+				"      group_policy: allowlist",
+				'      group_allow_from: ["120363000000000000@g.us"]',
+				"      group_sessions_per_user: true",
+				"      thread_sessions_per_user: true",
 				"",
 			].join("\n"),
 		);
@@ -9462,7 +9577,8 @@ exit 64
 			HERMES_EXISTING_ENV: "kept",
 			WHATSAPP_MODE: "bot",
 			WHATSAPP_ALLOWED_USERS: "*",
-			WHATSAPP_ALLOW_ALL_USERS: "true",
+			WHATSAPP_DM_POLICY: "open",
+			WHATSAPP_GROUP_POLICY: "open",
 		});
 		const convergence = convergeRuntimeManifest(projected, paths);
 		expect(convergence.installErrors).toEqual([]);
@@ -9474,10 +9590,27 @@ exit 64
 		expect(readSystemdEnvFile(paths, "hermes-gateway")).not.toContain("WHATSAPP_ENABLED");
 		expect(existsSync(sessionDir)).toBe(true);
 		expect(readFileSync(legacySentinel, "utf-8")).toBe("preserved\n");
-		expect(readHermesConfigYaml(home)).toHaveProperty(
-			"platforms.whatsapp.extra.session_path",
-			sessionDir,
-		);
+		expect(readHermesConfigYaml(home)).toMatchObject({
+			whatsapp: {
+				dm_policy: "allowlist",
+				allow_from: ["15550000001"],
+				group_policy: "allowlist",
+				group_allow_from: ["120363000000000000@g.us"],
+			},
+			platforms: {
+				whatsapp: {
+					extra: {
+						session_path: sessionDir,
+						dm_policy: "allowlist",
+						allow_from: ["15550000001"],
+						group_policy: "allowlist",
+						group_allow_from: ["120363000000000000@g.us"],
+						group_sessions_per_user: true,
+						thread_sessions_per_user: true,
+					},
+				},
+			},
+		});
 		const initialHermesRevision = systemdEnvDigest(readSystemdEnvFile(paths, "hermes-gateway"));
 		const hermesDropIn = join(
 			paths.systemdUserRoot,
@@ -9576,12 +9709,24 @@ exit 64
 		const removedHermesConfig = readHermesConfigYaml(home);
 		expect(removedHermesConfig).toHaveProperty("whatsapp", {
 			user_owned: "keep-whatsapp",
+			dm_policy: "allowlist",
+			allow_from: ["15550000001"],
+			group_policy: "allowlist",
+			group_allow_from: ["120363000000000000@g.us"],
 			enabled: false,
 		});
 		expect(removedHermesConfig).toHaveProperty("platforms.whatsapp", {
 			custom: "keep-platform",
 			enabled: false,
-			extra: { custom_extra: "keep-extra" },
+			extra: {
+				custom_extra: "keep-extra",
+				dm_policy: "allowlist",
+				allow_from: ["15550000001"],
+				group_policy: "allowlist",
+				group_allow_from: ["120363000000000000@g.us"],
+				group_sessions_per_user: true,
+				thread_sessions_per_user: true,
+			},
 		});
 		expect(removedHermesConfig).toMatchObject({
 			custom_root: "keep",
@@ -9590,7 +9735,8 @@ exit 64
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_MODE).toBeUndefined();
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ENABLED).toBeUndefined();
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ALLOWED_USERS).toBeUndefined();
-		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ALLOW_ALL_USERS).toBeUndefined();
+		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_DM_POLICY).toBeUndefined();
+		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_GROUP_POLICY).toBeUndefined();
 		expect(readSystemdEnvFile(paths, "hermes-gateway")).not.toContain("WHATSAPP_ENABLED");
 		const removedHermesRevision = systemdEnvDigest(readSystemdEnvFile(paths, "hermes-gateway"));
 


### PR DESCRIPTION
## Summary

- apply the same Hosted ownership boundary to OpenClaw and Hermes channels
- manage only runtime connectivity fields while preserving user-authored access, allowlist, mention, thread, session, streaming, and channel experience preferences
- keep OpenClaw stale-account cleanup exact while rotating the Hosted token or auth directory
- retain only the stock Hermes WhatsApp bridge environment required for transport
- release the fix as stable CLI 0.14.24

## Upstream verification

- stock OpenClaw 2026.7.1 accepted the official config patch, preserved Discord account preferences, replaced the managed token, and removed the stale account
- stock Hermes 0.19.1 required WHATSAPP_ALLOWED_USERS and passed with the official DM/group bridge policies
- paired native WhatsApp smoke passed against both stock runtimes

## Verification

- scripts/test.sh cli: 1671 passed, 4 skipped, 0 failed
- focused manifest service regression: 26 passed, 0 failed
- paired OpenClaw/Hermes upstream smoke: passed
- CLI typecheck: passed
- Biome 2.5.9 on changed TypeScript: passed
- CLI publish manifest check: passed
- git diff --check: passed
