### PR TITLE
fix(sessions): normalize NUL in search projections

### DIFF
--- a/backend/app/services/session_search.py
+++ b/backend/app/services/session_search.py
@@ -80,6 +80,10 @@ def _escaped_contains_pattern(value: str) -> str:
     return f"%{escaped}%"
 
 
+def _searchable_text(content: str) -> str:
+    return content.replace("\x00", "\ufffd")
+
+
 def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
     """Return the strongest index-backed visible-message match per Session."""
     active_document_revision = case(
@@ -158,7 +162,7 @@ def searchable_event_messages(events: Sequence[SessionEvent]) -> list[Searchable
         SearchableSessionMessage(
             position=message.position,
             role=message.role,
-            content=message.content,
+            content=_searchable_text(message.content),
         )
         for message in project_visible_messages(events)
         if message.role in ("user", "assistant")
@@ -174,7 +178,13 @@ def searchable_snapshot_messages(
         content = message.get("content")
         if role not in ("user", "assistant") or not isinstance(content, str) or not content:
             continue
-        projected.append(SearchableSessionMessage(position=position, role=role, content=content))
+        projected.append(
+            SearchableSessionMessage(
+                position=position,
+                role=role,
+                content=_searchable_text(content),
+            )
+        )
     return projected
 
 

--- a/backend/tests/test_session_events.py
+++ b/backend/tests/test_session_events.py
@@ -507,7 +507,7 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
         "message",
         "assistant-3",
         role="assistant",
-        parts=[{"type": "text", "text": "appended answer"}],
+        parts=[{"type": "text", "text": "appended left\x00right answer"}],
     )
     second_data, second_hash = _chunk([second_event])
     second_head = advance_event_head(final_head, [second_event])
@@ -587,6 +587,9 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
     assert private_reasoning["kind"] == "thinking"
     assert private_reasoning["parts"] == [{"type": "text", "text": "private chain of thought"}]
     assert private_reasoning["payload_json"] == '{"signature":"opaque"}'
+    assert private.json()["events"][6]["parts"] == [
+        {"type": "text", "text": "appended left\x00right answer"}
+    ]
     projected = await client.get(f"/v1/sessions/{session.id}/content")
     assert projected.status_code == 200, projected.text
     assert projected.json() == [
@@ -597,7 +600,12 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
             "model": "claude-sonnet",
             "timestamp": None,
         },
-        {"role": "assistant", "content": "appended answer", "model": None, "timestamp": None},
+        {
+            "role": "assistant",
+            "content": "appended left\x00right answer",
+            "model": None,
+            "timestamp": None,
+        },
     ]
     assert "private context" not in projected.text
     assert "private chain of thought" not in projected.text
@@ -614,7 +622,12 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
     assert latest_messages.status_code == 200, latest_messages.text
     assert latest_messages.json() == {
         "items": [
-            {"role": "assistant", "content": "appended answer", "model": None, "timestamp": None},
+            {
+                "role": "assistant",
+                "content": "appended left\x00right answer",
+                "model": None,
+                "timestamp": None,
+            },
             {
                 "role": "assistant",
                 "content": "visible answer",
@@ -635,6 +648,17 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
         "anchor": {
             "kind": "event_seq",
             "position": 4,
+            "revision": f"events:{second_head}",
+        },
+    }
+    appended_search = (await client.get("/v1/sessions", params={"q": "right answer"})).json()
+    assert [item["local_session_id"] for item in appended_search["items"]] == [local_id]
+    assert appended_search["items"][0]["search_match"] == {
+        "role": "assistant",
+        "excerpt": "appended left\ufffdright answer",
+        "anchor": {
+            "kind": "event_seq",
+            "position": 6,
             "revision": f"events:{second_head}",
         },
     }

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -139,10 +139,10 @@ async def test_snapshot_message_search_tracks_current_content_and_escapes_wildca
     original = [
         {
             "role": "assistant",
-            "content": "Original needle %_ and slash\\needle stay literal",
+            "content": "Original needle\x00%_ and slash\\needle stay literal",
         }
     ]
-    await _push_session(
+    session_id = await _push_session(
         client,
         env_id,
         local_session_id=local_id,
@@ -161,7 +161,7 @@ async def test_snapshot_message_search_tracks_current_content_and_escapes_wildca
     assert [item["local_session_id"] for item in matched["items"]] == [local_id]
     assert matched["items"][0]["search_match"] == {
         "role": "assistant",
-        "excerpt": original[0]["content"],
+        "excerpt": original[0]["content"].replace("\x00", "\ufffd"),
         "anchor": {
             "kind": "snapshot_offset",
             "position": 0,
@@ -176,6 +176,9 @@ async def test_snapshot_message_search_tracks_current_content_and_escapes_wildca
     assert [item["local_session_id"] for item in literal["items"]] == [local_id]
     backslash = (await client.get("/v1/sessions", params={"q": "slash\\needle"})).json()
     assert [item["local_session_id"] for item in backslash["items"]] == [local_id]
+    stored = await client.get(f"/v1/sessions/{session_id}/messages")
+    assert stored.status_code == 200, stored.text
+    assert stored.json()["items"][0]["content"] == original[0]["content"]
 
     replacement = [{"role": "user", "content": "Replacement body is now authoritative"}]
     await _push_session(


### PR DESCRIPTION
## Summary

- normalize embedded NUL bytes to U+FFFD only in the rebuildable Session search projection
- preserve authoritative snapshot/event content unchanged in object storage and read APIs
- cover snapshot upload and events-v1 append through existing end-to-end tests

## Verification

- focused backend tests: 16 passed
- full backend suite: 2494 passed, 12 skipped
- Ruff lint/format, compileall, BasedPyright, generated API drift, and git diff checks passed