### PR TITLE
perf(backend): parallelize session search backfill

### DIFF
--- a/backend/scripts/backfill_session_search.py
+++ b/backend/scripts/backfill_session_search.py
@@ -3,6 +3,7 @@
 Usage:
     pdm run python -m scripts.backfill_session_search --user-id <uuid>
     pdm run python -m scripts.backfill_session_search --all
+    pdm run python -m scripts.backfill_session_search --all --workers 8
     pdm run python -m scripts.backfill_session_search --all --dry-run
     pdm run python -m scripts.backfill_session_search --all --force
 """
@@ -13,6 +14,7 @@ import argparse
 import asyncio
 import logging
 import uuid
+from typing import Literal
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import async_sessionmaker
@@ -29,10 +31,31 @@ from app.services.session_search import (
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 log = logging.getLogger("backfill-session-search")
 
-CHUNK_SIZE = 16
+MAX_WORKERS = 16
+CHUNK_SIZE = MAX_WORKERS
+
+type BackfillOutcome = Literal["indexed", "skipped", "failed"]
 
 
-async def backfill_user(user_id: uuid.UUID, *, force: bool, dry_run: bool) -> int:
+def worker_count(value: str) -> int:
+    try:
+        workers = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("workers must be an integer") from exc
+    if not 1 <= workers <= MAX_WORKERS:
+        raise argparse.ArgumentTypeError(f"workers must be between 1 and {MAX_WORKERS}")
+    return workers
+
+
+async def backfill_user(
+    user_id: uuid.UUID,
+    *,
+    force: bool,
+    dry_run: bool,
+    workers: int,
+) -> int:
+    if not 1 <= workers <= MAX_WORKERS:
+        raise ValueError(f"workers must be between 1 and {MAX_WORKERS}")
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
     target_filters = (
         Session.user_id == user_id,
@@ -56,22 +79,14 @@ async def backfill_user(user_id: uuid.UUID, *, force: bool, dry_run: bool) -> in
     failed = 0
     inspected = 0
     last_id: uuid.UUID | None = None
-    while True:
-        async with session_factory() as db:
-            query = select(Session.id).where(*target_filters)
-            if last_id is not None:
-                query = query.where(Session.id > last_id)
-            session_ids = list(
-                (await db.execute(query.order_by(Session.id).limit(CHUNK_SIZE))).scalars()
-            )
-        if not session_ids:
-            break
-        for session_id in session_ids:
-            async with session_factory() as db:
+    worker_slots = asyncio.Semaphore(workers)
+
+    async def backfill_session(session_id: uuid.UUID) -> BackfillOutcome:
+        async with worker_slots, session_factory() as db:
+            try:
                 session = await db.get(Session, session_id)
                 if session is None:
-                    skipped += 1
-                    continue
+                    return "skipped"
                 revision = current_search_revision(session)
                 projection_current = session.search_index_revision == revision
                 if (
@@ -84,21 +99,34 @@ async def backfill_user(user_id: uuid.UUID, *, force: bool, dry_run: bool) -> in
                         session.event_generation_id,
                     )
                 if revision is None or (not force and projection_current):
-                    skipped += 1
-                    continue
-                try:
-                    rebuilt = await rebuild_session_search_index(db, session, file_store)
-                    await db.commit()
-                    if rebuilt:
-                        indexed += 1
-                    else:
-                        # The authoritative revision changed while its object was
-                        # being read. The live ingest path indexed that revision;
-                        # a later backfill run can retry if it still needs work.
-                        skipped += 1
-                except Exception:
-                    failed += 1
-                    log.exception("session search backfill failed session_id=%s", session_id)
+                    return "skipped"
+                rebuilt = await rebuild_session_search_index(db, session, file_store)
+                await db.commit()
+            except Exception:
+                log.exception("session search backfill failed session_id=%s", session_id)
+                return "failed"
+            if rebuilt:
+                return "indexed"
+            # The authoritative revision changed while its object was being read.
+            # The live ingest path indexed that revision; a later run can retry.
+            return "skipped"
+
+    while True:
+        async with session_factory() as db:
+            query = select(Session.id).where(*target_filters)
+            if last_id is not None:
+                query = query.where(Session.id > last_id)
+            session_ids = list(
+                (await db.execute(query.order_by(Session.id).limit(CHUNK_SIZE))).scalars()
+            )
+        if not session_ids:
+            break
+        outcomes = await asyncio.gather(
+            *(backfill_session(session_id) for session_id in session_ids)
+        )
+        indexed += outcomes.count("indexed")
+        skipped += outcomes.count("skipped")
+        failed += outcomes.count("failed")
         inspected += len(session_ids)
         last_id = session_ids[-1]
         log.info(
@@ -112,29 +140,55 @@ async def backfill_user(user_id: uuid.UUID, *, force: bool, dry_run: bool) -> in
     return failed
 
 
-async def backfill_all(*, force: bool, dry_run: bool) -> int:
+async def backfill_all(*, force: bool, dry_run: bool, workers: int) -> int:
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
     async with session_factory() as db:
         user_ids = list((await db.execute(select(Session.user_id).distinct())).scalars())
     failed = 0
     for user_id in user_ids:
-        failed += await backfill_user(user_id, force=force, dry_run=dry_run)
+        failed += await backfill_user(
+            user_id,
+            force=force,
+            dry_run=dry_run,
+            workers=workers,
+        )
     return failed
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    parser = argparse.ArgumentParser(
+        description="Backfill the rebuildable visible-message Session search index."
+    )
     target = parser.add_mutually_exclusive_group(required=True)
     target.add_argument("--user-id", type=uuid.UUID)
     target.add_argument("--all", action="store_true")
     parser.add_argument("--force", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--workers",
+        type=worker_count,
+        default=1,
+        help=f"concurrent Session rebuilds (1-{MAX_WORKERS}; default: 1)",
+    )
     args = parser.parse_args()
     if args.all:
-        failed = asyncio.run(backfill_all(force=args.force, dry_run=args.dry_run))
+        failed = asyncio.run(
+            backfill_all(
+                force=args.force,
+                dry_run=args.dry_run,
+                workers=args.workers,
+            )
+        )
     else:
         assert args.user_id is not None
-        failed = asyncio.run(backfill_user(args.user_id, force=args.force, dry_run=args.dry_run))
+        failed = asyncio.run(
+            backfill_user(
+                args.user_id,
+                force=args.force,
+                dry_run=args.dry_run,
+                workers=args.workers,
+            )
+        )
     if failed:
         raise SystemExit(1)
 

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -9,6 +9,7 @@ Covers the upgraded `/api/sessions` list endpoint:
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 from datetime import UTC, datetime
@@ -297,6 +298,91 @@ async def test_rebuild_does_not_replace_a_newer_revision_after_object_read(
     assert current is not None
     assert current.search_index_revision == f"snapshot:{replacement_hash}"
     assert documents == [replacement_content]
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_search_backfill_bounds_parallel_session_rebuilds(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    engine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.routes import sessions as session_routes
+    from scripts import backfill_session_search
+
+    env_id = await _register_env(client)
+    local_ids = [f"parallel-search-backfill-{index}" for index in range(4)]
+    for index, local_id in enumerate(local_ids):
+        await _push_session(
+            client,
+            env_id,
+            local_session_id=local_id,
+            messages=[{"role": "user", "content": f"parallel body {index}"}],
+            upload=True,
+        )
+
+    sessions = list(
+        (
+            await db_session.execute(select(Session).where(Session.local_session_id.in_(local_ids)))
+        ).scalars()
+    )
+    assert len(sessions) == len(local_ids)
+    user_id = sessions[0].user_id
+    await db_session.execute(
+        delete(SessionMessageSearch).where(
+            SessionMessageSearch.session_id.in_([session.id for session in sessions])
+        )
+    )
+    for session in sessions:
+        session.search_index_revision = None
+    await db_session.commit()
+
+    real_rebuild = backfill_session_search.rebuild_session_search_index
+    pair_ready = asyncio.Event()
+    active = 0
+    max_active = 0
+
+    async def tracked_rebuild(db, session, file_store) -> bool:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        if active == 2:
+            pair_ready.set()
+        try:
+            await asyncio.wait_for(pair_ready.wait(), timeout=2)
+            return await real_rebuild(db, session, file_store)
+        finally:
+            active -= 1
+
+    monkeypatch.setattr(backfill_session_search, "engine", engine)
+    monkeypatch.setattr(
+        backfill_session_search,
+        "get_file_store",
+        lambda: session_routes.file_store,
+    )
+    monkeypatch.setattr(
+        backfill_session_search,
+        "rebuild_session_search_index",
+        tracked_rebuild,
+    )
+
+    failed = await backfill_session_search.backfill_user(
+        user_id,
+        force=False,
+        dry_run=False,
+        workers=2,
+    )
+    assert failed == 0
+    assert max_active == 2
+
+    db_session.expire_all()
+    current = list(
+        (
+            await db_session.execute(select(Session).where(Session.local_session_id.in_(local_ids)))
+        ).scalars()
+    )
+    assert all(session.search_index_revision is not None for session in current)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add a bounded --workers option (1-16, default 1) to the Session search backfill
- isolate each Session rebuild in its own database transaction and continue after per-item failures
- keep at most one 16-item chunk in flight and use semaphore-based scheduling
- verify bounded concurrency and complete rebuilding against PostgreSQL and the real test file store

## Verification

- focused Session search tests: 7 passed
- full backend: 2495 passed, 12 skipped
- Ruff check and format
- standalone BasedPyright for the backfill script
- changed-production type gate
- generated OpenAPI client check
- git diff --check

## Operational notes

The default remains one worker. Production backfill can start at 8 workers, observe database/S3 behavior, and safely rerun because each Session is independently committed and current projections are skipped.