### PR TITLE
fix(web): preserve terminal across reconnects

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -123,24 +123,32 @@ async function expectOverviewResourceGeometry(grid: Locator, expectedRows: reado
 async function expectLiveToolFillsDashboard(page: Page, surface: Locator) {
 	const scrollContainer = page.locator("#dashboard-scroll-container");
 	const header = scrollContainer.locator(":scope > header");
-	const [surfaceBox, scrollBox, headerBox, scrollMetrics] = await Promise.all([
-		surface.boundingBox(),
-		scrollContainer.boundingBox(),
-		header.boundingBox(),
+	const [surfaceBox, scrollBox, headerBox, scrollMetrics, pageMetrics] = await Promise.all([
+		surface.evaluate((element) => element.getBoundingClientRect().toJSON()),
+		scrollContainer.evaluate((element) => element.getBoundingClientRect().toJSON()),
+		header.evaluate((element) => element.getBoundingClientRect().toJSON()),
 		scrollContainer.evaluate((element) => ({
 			clientHeight: element.clientHeight,
+			overflowY: getComputedStyle(element).overflowY,
 			scrollHeight: element.scrollHeight,
 		})),
+		page.evaluate(() => ({
+			bodyClientHeight: document.body.clientHeight,
+			bodyScrollHeight: document.body.scrollHeight,
+			documentClientHeight: document.documentElement.clientHeight,
+			documentScrollHeight: document.documentElement.scrollHeight,
+		})),
 	]);
-	if (!surfaceBox || !scrollBox || !headerBox) {
-		throw new Error("Live-tool dashboard geometry should be measurable.");
-	}
-
 	expect(Math.abs(surfaceBox.y - (headerBox.y + headerBox.height))).toBeLessThanOrEqual(1);
 	expect(
 		Math.abs(surfaceBox.y + surfaceBox.height - (scrollBox.y + scrollBox.height)),
 	).toBeLessThanOrEqual(1);
+	expect(scrollMetrics.overflowY).toBe("hidden");
 	expect(scrollMetrics.scrollHeight).toBeLessThanOrEqual(scrollMetrics.clientHeight + 1);
+	expect(pageMetrics.bodyScrollHeight).toBeLessThanOrEqual(pageMetrics.bodyClientHeight + 1);
+	expect(pageMetrics.documentScrollHeight).toBeLessThanOrEqual(
+		pageMetrics.documentClientHeight + 1,
+	);
 }
 
 async function _expectOverviewSessionSlot({
@@ -3596,14 +3604,19 @@ test("agent provider creation stays in context and updates only after Save chang
 	});
 });
 
-test("cold hosted live-tool routes keep full-bleed loading geometry", async ({ page }) => {
+test("hosted live-tool routes keep scrolling inside their viewport", async ({ page }) => {
 	let releaseDeploymentList: (() => void) | undefined;
 	const deploymentListGate = new Promise<void>((resolve) => {
 		releaseDeploymentList = resolve;
 	});
+	const liveToolDeployment = {
+		...mutationDeploymentReadFixture(railHostedDeployment),
+		files_endpoint: { url: "https://files.example.test/" },
+	};
 	await stubHostedApi(page, {
 		cloudAgents: [railHostedCloudAgent],
-		deploymentListResponses: [[railHostedDeployment]],
+		deployments: [liveToolDeployment],
+		deploymentListResponses: [[liveToolDeployment]],
 		deploymentListResponseGates: [deploymentListGate],
 	});
 
@@ -3639,6 +3652,13 @@ test("cold hosted live-tool routes keep full-bleed loading geometry", async ({ p
 		await page.setViewportSize({ width: 390, height: 844 });
 		await expect(dashboardContent).toHaveCSS("padding-bottom", "16px");
 		await expectLiveToolFillsDashboard(page, liveSurface);
+
+		for (const section of ["files", "terminal"] as const) {
+			await page.goto(`/agents/${railHostedEnvironmentId}/${section}`);
+			const routeSurface = page.getByTestId("hosted-agent-live-surface");
+			await expect(routeSurface).toBeVisible();
+			await expectLiveToolFillsDashboard(page, routeSurface);
+		}
 	} finally {
 		releaseDeploymentList?.();
 	}

--- a/apps/web/src/components/dashboard/agent-detail-loading-shell.test.ts
+++ b/apps/web/src/components/dashboard/agent-detail-loading-shell.test.ts
@@ -25,7 +25,8 @@ describe("agent detail loading shells", () => {
 		for (const section of ["console", "files", "terminal"] as const) {
 			const markup = render(section);
 			expect(markup).toContain('data-testid="agent-live-tool-loading-shell"');
-			expect(markup).toContain("min-h-[calc(100svh-var(--header-height))]");
+			expect(markup).toContain("h-[calc(100svh-var(--header-height))]");
+			expect(markup).not.toContain("min-h-[calc(100svh-var(--header-height))]");
 			expect(markup).not.toContain("data-agent-detail-skeleton");
 			expect(markup).not.toContain("overview-status-card-skeleton");
 		}

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -380,7 +380,7 @@ export function ConnectedAgentDetailSkeleton({
 				data-testid="agent-live-tool-loading-shell"
 				role="status"
 				aria-label={`${agentSectionLabel(section)} loading`}
-				className="-my-4 flex min-h-[calc(100svh-var(--header-height))] w-full flex-col md:-my-5 md:min-h-[calc(100svh-var(--header-height)-1rem)]"
+				className="-my-4 flex h-[calc(100svh-var(--header-height))] min-h-0 w-full flex-col md:-my-5 md:h-[calc(100svh-var(--header-height)-1rem)]"
 			>
 				<div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
 					<div className="flex h-12 shrink-0 items-center justify-between gap-3 px-4 lg:px-6">

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -154,11 +154,7 @@ import {
 	supportedTimezones,
 	TimezoneCombobox,
 } from "@/hosted/billing/deploy/language-timezone-controls";
-import {
-	billingErrorNormalizer,
-	billingQueryRetry,
-	normalizeBillingError,
-} from "@/hosted/billing/errors";
+import { billingErrorNormalizer, billingQueryRetry } from "@/hosted/billing/errors";
 import { billingKeys, useManagedModelCatalog, usePlans } from "@/hosted/billing/hooks";
 import { ComputeSubscriptionActionList } from "@/hosted/billing/subscription/compute-subscription-action-list";
 import { resolveComputeSubscriptionActions } from "@/hosted/billing/subscription/compute-subscription-actions";
@@ -537,7 +533,7 @@ export function HostedAgentDetail({
 			data-testid={isLiveToolTab ? "hosted-agent-live-surface" : undefined}
 			className={cn(
 				isLiveToolTab
-					? "-my-4 flex min-h-[calc(100svh-var(--header-height))] w-full flex-col md:-my-5 md:min-h-[calc(100svh-var(--header-height)-1rem)]"
+					? "-my-4 flex h-[calc(100svh-var(--header-height))] min-h-0 w-full flex-col md:-my-5 md:h-[calc(100svh-var(--header-height)-1rem)]"
 					: cn(
 							activeTab === "settings" ? "w-full" : CENTERED_PAGE_WIDTH_CLASS.page,
 							"flex flex-col gap-6 px-4 lg:px-6",
@@ -635,7 +631,11 @@ export function HostedAgentDetail({
 						/>
 					) : null}
 					{deploymentStatus.known && activeTab === "terminal" ? (
-						<TerminalTab deployment={deployment} agentName={availableAgentTitle} />
+						<TerminalTab
+							key={deployment.resource.id}
+							deployment={deployment}
+							agentName={availableAgentTitle}
+						/>
 					) : null}
 					{deploymentStatus.known && activeTab === "files" && filesUrl ? (
 						<FilesTab deployment={deployment} url={filesUrl} />
@@ -2147,12 +2147,14 @@ function LiveToolFrame({
 const TERMINAL_STATUS_LABELS: Record<HostedTerminalStatus, string> = {
 	connecting: "Connecting",
 	connected: "Connected",
+	reconnecting: "Reconnecting",
 	disconnected: "Disconnected",
 };
 
 const TERMINAL_STATUS_TONES: Record<HostedTerminalStatus, StatusTone> = {
 	connecting: "warning",
 	connected: "success",
+	reconnecting: "warning",
 	disconnected: "destructive",
 };
 
@@ -2179,78 +2181,12 @@ function TerminalTab({
 	const client = useBillingClient();
 	const terminal = useSensitiveAction(({ id }: { id: string }) => client.createTerminalSession(id));
 	const { isPending: isOpeningTerminal, execute: createTerminalSession } = terminal;
-	const [websocketUrl, setWebsocketUrl] = useState<string | null>(null);
-	const [terminalStatus, setTerminalStatus] = useState<HostedTerminalStatus>("disconnected");
-	const [terminalFailure, setTerminalFailure] = useState<string | null>(null);
-	const autoStartedDeploymentRef = useRef<string | null>(null);
-	const currentDeploymentIdRef = useRef(deployment.resource.id);
-	const terminalRequestRef = useRef(0);
-
-	const startTerminal = useCallback(async () => {
-		if (!isRunning || isOpeningTerminal) return;
-		const requestId = terminalRequestRef.current + 1;
-		terminalRequestRef.current = requestId;
-		setWebsocketUrl(null);
-		setTerminalFailure(null);
-		setTerminalStatus("connecting");
-		try {
-			const session = await createTerminalSession({ id: deployment.resource.id });
-			if (terminalRequestRef.current !== requestId) return;
-			if (!session.websocket_url) {
-				setTerminalStatus("disconnected");
-				setTerminalFailure("The secure terminal could not be opened. Try again.");
-				toast.error("Terminal unavailable", {
-					description: "The secure terminal could not be opened. Try again.",
-				});
-				return;
-			}
-			setWebsocketUrl(session.websocket_url);
-		} catch (error) {
-			if (terminalRequestRef.current !== requestId) return;
-			setTerminalStatus("disconnected");
-			setTerminalFailure("Couldn't open terminal. Try again.");
-			toast.error("Couldn't open terminal", { description: normalizeBillingError(error) });
-		}
-	}, [createTerminalSession, deployment.resource.id, isOpeningTerminal, isRunning]);
-
-	useEffect(() => {
-		if (currentDeploymentIdRef.current === deployment.resource.id) return;
-		currentDeploymentIdRef.current = deployment.resource.id;
-		autoStartedDeploymentRef.current = null;
-		setWebsocketUrl(null);
-		setTerminalFailure(null);
-		setTerminalStatus("disconnected");
-	}, [deployment.resource.id]);
-
-	useEffect(() => {
-		if (isRunning) return;
-		autoStartedDeploymentRef.current = null;
-		setWebsocketUrl(null);
-		setTerminalFailure(null);
-		setTerminalStatus("disconnected");
-	}, [isRunning]);
-
-	useEffect(() => {
-		if (!isRunning || websocketUrl || isOpeningTerminal || terminalFailure) return;
-		if (autoStartedDeploymentRef.current === deployment.resource.id) return;
-		autoStartedDeploymentRef.current = deployment.resource.id;
-		void startTerminal();
-	}, [
-		deployment.resource.id,
-		isOpeningTerminal,
-		isRunning,
-		startTerminal,
-		terminalFailure,
-		websocketUrl,
-	]);
-
-	const handleTerminalStatusChange = useCallback((status: HostedTerminalStatus) => {
-		setTerminalStatus(status);
-		if (status === "disconnected") {
-			setWebsocketUrl(null);
-			setTerminalFailure("Terminal connection closed. Reconnect to start a new session.");
-		}
-	}, []);
+	const [terminalStatus, setTerminalStatus] = useState<HostedTerminalStatus>("connecting");
+	const [reconnectRequest, setReconnectRequest] = useState(0);
+	const requestWebsocketUrl = useCallback(async () => {
+		const session = await createTerminalSession({ id: deployment.resource.id });
+		return session.websocket_url ?? "";
+	}, [createTerminalSession, deployment.resource.id]);
 
 	if (status.kind === "stopped") {
 		return <StoppedAgentState deployment={deployment} />;
@@ -2271,70 +2207,33 @@ function TerminalTab({
 		);
 	}
 
-	const displayStatus = websocketUrl
-		? terminalStatus
-		: terminalFailure
-			? "disconnected"
-			: "connecting";
 	const terminalAction = (
 		<>
-			<TerminalStatusIndicator status={displayStatus} />
+			<TerminalStatusIndicator status={terminalStatus} />
 			<Button
 				type="button"
 				variant="outline"
 				size="sm"
-				className="hidden sm:inline-flex"
-				disabled={isOpeningTerminal}
-				onClick={() => void startTerminal()}
+				aria-label={terminalStatus === "disconnected" ? "Retry terminal" : "Reconnect terminal"}
+				disabled={
+					isOpeningTerminal || terminalStatus === "connecting" || terminalStatus === "reconnecting"
+				}
+				onClick={() => setReconnectRequest((request) => request + 1)}
 			>
 				{isOpeningTerminal ? <Spinner className="size-3.5" /> : <RefreshCw className="size-3.5" />}
-				Reconnect
+				<span className="hidden sm:inline">
+					{terminalStatus === "disconnected" ? "Retry" : "Reconnect"}
+				</span>
 			</Button>
 		</>
 	);
 
-	if (!websocketUrl) {
-		return (
-			<LiveToolFrame icon={TerminalSquare} title="Terminal" detail={label} action={terminalAction}>
-				<div className="flex min-h-0 flex-1 items-center justify-center bg-background px-4 py-10">
-					<div className="flex w-full max-w-sm flex-col items-center gap-4 text-center">
-						<div className="flex size-11 items-center justify-center rounded-lg border bg-muted/30">
-							{terminalFailure ? (
-								<TerminalSquare className="size-5 text-muted-foreground" />
-							) : (
-								<Spinner className="size-5 text-muted-foreground" />
-							)}
-						</div>
-						<div>
-							<h2 className="text-base font-semibold">
-								{terminalFailure ? "Terminal unavailable" : "Opening secure terminal"}
-							</h2>
-							<p className="mt-1 text-sm text-muted-foreground">
-								{terminalFailure ?? "Starting a secure shell for your agent."}
-							</p>
-						</div>
-						{terminalFailure ? (
-							<Button onClick={() => void startTerminal()} disabled={isOpeningTerminal}>
-								{isOpeningTerminal ? (
-									<Spinner className="size-3.5" />
-								) : (
-									<RefreshCw className="size-3.5" />
-								)}
-								Retry
-							</Button>
-						) : null}
-					</div>
-				</div>
-			</LiveToolFrame>
-		);
-	}
-
 	return (
 		<LiveToolFrame icon={TerminalSquare} title="Terminal" detail={label} action={terminalAction}>
 			<HostedTerminalPanel
-				key={websocketUrl}
-				websocketUrl={websocketUrl}
-				onStatusChange={handleTerminalStatusChange}
+				requestWebsocketUrl={requestWebsocketUrl}
+				reconnectRequest={reconnectRequest}
+				onStatusChange={setTerminalStatus}
 			/>
 		</LiveToolFrame>
 	);

--- a/apps/web/src/hosted/agents/hosted-terminal-panel.test.ts
+++ b/apps/web/src/hosted/agents/hosted-terminal-panel.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import {
+	canUseTerminalTransport,
 	createTtydOutputWriter,
+	isRetryableTerminalCloseCode,
+	nextTerminalReconnect,
+	TERMINAL_CONNECTION_STABILITY_MS,
+	TERMINAL_RECONNECT_DELAYS_MS,
 	TTYD_OUTPUT_FLOW_CONTROL,
 	terminalConnectionClosedMessage,
+	terminalReconnectAttemptsForClose,
 	terminalWebSocketTarget,
 } from "@/hosted/agents/hosted-terminal-panel";
 
@@ -53,6 +59,87 @@ describe("terminal output flow control", () => {
 		expect(callbacks).toEqual([undefined]);
 		expect(commands).toEqual([]);
 	});
+
+	test("does not let an old write callback resume a replacement transport", () => {
+		const callbacks: Array<() => void> = [];
+		const commands: string[] = [];
+		let currentGeneration = 1;
+		let isCurrentSocket = true;
+		const writeOutput = createTtydOutputWriter({
+			write: (_data, callback) => {
+				if (callback) callbacks.push(callback);
+			},
+			send: (command) => {
+				if (
+					canUseTerminalTransport({
+						currentGeneration,
+						transportGeneration: 1,
+						isCurrentSocket,
+						failed: false,
+					})
+				) {
+					commands.push(command);
+				}
+			},
+		});
+		const checkpoint = "x".repeat(TTYD_OUTPUT_FLOW_CONTROL.writeLimit + 1);
+
+		for (let index = 0; index < TTYD_OUTPUT_FLOW_CONTROL.lowWater; index += 1) {
+			writeOutput(checkpoint);
+		}
+		currentGeneration = 2;
+		isCurrentSocket = false;
+		callbacks.shift()?.();
+
+		expect(commands).toEqual([]);
+	});
+});
+
+describe("terminal reconnect policy", () => {
+	test("retries only abnormal and explicitly temporary closes", () => {
+		for (const code of [1006, 1011, 1013]) {
+			expect(isRetryableTerminalCloseCode(code)).toBe(true);
+		}
+		for (const code of [1000, 1001, 1008, 1012, 4000]) {
+			expect(isRetryableTerminalCloseCode(code)).toBe(false);
+		}
+	});
+
+	test("uses a finite exponential retry sequence", () => {
+		expect(TERMINAL_RECONNECT_DELAYS_MS).toEqual([500, 1_000, 2_000]);
+		expect(nextTerminalReconnect(1011, 0)).toEqual({ attempt: 1, delayMs: 500 });
+		expect(nextTerminalReconnect(1011, 1)).toEqual({ attempt: 2, delayMs: 1_000 });
+		expect(nextTerminalReconnect(1011, 2)).toEqual({ attempt: 3, delayMs: 2_000 });
+		expect(nextTerminalReconnect(1011, 3)).toBeNull();
+		expect(nextTerminalReconnect(1000, 0)).toBeNull();
+		expect(nextTerminalReconnect(1008, 0)).toBeNull();
+	});
+
+	test("resets retry budget only after a connection is stable", () => {
+		expect(TERMINAL_CONNECTION_STABILITY_MS).toBe(5_000);
+		expect(nextTerminalReconnect(1011, terminalReconnectAttemptsForClose(2, false))).toEqual({
+			attempt: 3,
+			delayMs: 2_000,
+		});
+		expect(nextTerminalReconnect(1011, terminalReconnectAttemptsForClose(2, true))).toEqual({
+			attempt: 1,
+			delayMs: 500,
+		});
+	});
+
+	test("uses one transport-failure transition per current socket", () => {
+		const current = {
+			currentGeneration: 4,
+			transportGeneration: 4,
+			isCurrentSocket: true,
+		};
+
+		expect(canUseTerminalTransport({ ...current, failed: false })).toBe(true);
+		expect(canUseTerminalTransport({ ...current, failed: true })).toBe(false);
+		expect(canUseTerminalTransport({ ...current, transportGeneration: 3, failed: false })).toBe(
+			false,
+		);
+	});
 });
 
 describe("terminalWebSocketTarget", () => {
@@ -94,14 +181,16 @@ describe("terminalWebSocketTarget", () => {
 });
 
 describe("terminalConnectionClosedMessage", () => {
-	test("formats close code without leaking control characters from reason", () => {
+	test("uses safe status copy without exposing a backend close reason", () => {
 		const event = new CloseEvent("close", {
-			code: 1008,
-			reason: "policy\u0000violation",
+			code: 1011,
+			reason: "upstream postgres connection failed at internal-host:5432",
 		});
 
-		expect(terminalConnectionClosedMessage(event)).toBe(
-			"terminal connection closed: code 1008, policy violation",
-		);
+		const message = terminalConnectionClosedMessage(event);
+		expect(message).toBe("Terminal service encountered a temporary problem.");
+		expect(message).not.toContain("postgres");
+		expect(terminalConnectionClosedMessage({ code: 1000 })).toContain("exited normally");
+		expect(terminalConnectionClosedMessage({ code: 1008 })).toContain("access was rejected");
 	});
 });

--- a/apps/web/src/hosted/agents/hosted-terminal-panel.tsx
+++ b/apps/web/src/hosted/agents/hosted-terminal-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { Terminal as XTerm } from "@xterm/xterm";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useTheme } from "@/components/theme-provider";
 import "@/hosted/agents/hosted-terminal.css";
 
@@ -14,7 +14,6 @@ const TTYD_RESUME = "3";
 const TERMINAL_TOKEN_PROTOCOL_PREFIX = "clawdi-terminal.";
 const TERMINAL_NOTICE_STYLE = "\u001b[90m";
 const TERMINAL_RESET_STYLE = "\u001b[0m";
-const TERMINAL_CLOSE_REASON_MAX_LENGTH = 120;
 
 export const TTYD_OUTPUT_FLOW_CONTROL = {
 	writeLimit: 100_000,
@@ -22,7 +21,10 @@ export const TTYD_OUTPUT_FLOW_CONTROL = {
 	lowWater: 4,
 } as const;
 
-export type HostedTerminalStatus = "connecting" | "connected" | "disconnected";
+export const TERMINAL_RECONNECT_DELAYS_MS = [500, 1_000, 2_000] as const;
+export const TERMINAL_CONNECTION_STABILITY_MS = 5_000;
+
+export type HostedTerminalStatus = "connecting" | "connected" | "reconnecting" | "disconnected";
 type TerminalAuthMode = "subprotocol" | "query";
 type TerminalThemeMode = "dark" | "light";
 
@@ -34,7 +36,8 @@ type TerminalWebSocketTarget = {
 };
 
 type HostedTerminalPanelProps = {
-	websocketUrl: string;
+	requestWebsocketUrl: () => Promise<string>;
+	reconnectRequest: number;
 	onStatusChange?: (status: HostedTerminalStatus) => void;
 };
 
@@ -145,39 +148,85 @@ export function terminalWebSocketTarget(
 	}
 }
 
-function sanitizedCloseReason(reason: string): string {
-	return Array.from(reason, (char) => {
-		const code = char.charCodeAt(0);
-		return code < 32 || code === 127 ? " " : char;
-	})
-		.join("")
-		.trim()
-		.slice(0, TERMINAL_CLOSE_REASON_MAX_LENGTH);
+export function isRetryableTerminalCloseCode(code: number): boolean {
+	return code === 1006 || code === 1011 || code === 1013;
 }
 
-export function terminalConnectionClosedMessage(event: CloseEvent): string {
-	const reason = sanitizedCloseReason(event.reason);
-	return `terminal connection closed: code ${event.code}${reason ? `, ${reason}` : ""}`;
+export type TerminalReconnectState = {
+	attempt: number;
+	delayMs: (typeof TERMINAL_RECONNECT_DELAYS_MS)[number];
+};
+
+export function nextTerminalReconnect(
+	closeCode: number,
+	completedAttempts: number,
+): TerminalReconnectState | null {
+	if (!isRetryableTerminalCloseCode(closeCode)) return null;
+	const delayMs = TERMINAL_RECONNECT_DELAYS_MS[completedAttempts];
+	return delayMs === undefined ? null : { attempt: completedAttempts + 1, delayMs };
+}
+
+export function terminalReconnectAttemptsForClose(
+	completedAttempts: number,
+	connectionWasStable: boolean,
+): number {
+	return connectionWasStable ? 0 : completedAttempts;
+}
+
+export function canUseTerminalTransport({
+	currentGeneration,
+	transportGeneration,
+	isCurrentSocket,
+	failed,
+}: {
+	currentGeneration: number;
+	transportGeneration: number;
+	isCurrentSocket: boolean;
+	failed: boolean;
+}): boolean {
+	return !failed && currentGeneration === transportGeneration && isCurrentSocket;
+}
+
+export function terminalConnectionClosedMessage(event: Pick<CloseEvent, "code">): string {
+	switch (event.code) {
+		case 1000:
+			return "Shell exited normally. Reconnect to start a new session.";
+		case 1006:
+			return "Terminal connection was interrupted.";
+		case 1008:
+			return "Terminal access was rejected. Reconnect to request fresh access.";
+		case 1011:
+			return "Terminal service encountered a temporary problem.";
+		case 1013:
+			return "Terminal service is temporarily unavailable.";
+		default:
+			return `Terminal connection closed (code ${event.code}).`;
+	}
 }
 
 function writeTerminalNotice(term: XTerm, message: string) {
 	term.write(`\r\n${TERMINAL_NOTICE_STYLE}[${message}]${TERMINAL_RESET_STYLE}\r\n`);
 }
 
-export function HostedTerminalPanel({ websocketUrl, onStatusChange }: HostedTerminalPanelProps) {
+export function HostedTerminalPanel({
+	requestWebsocketUrl,
+	reconnectRequest,
+	onStatusChange,
+}: HostedTerminalPanelProps) {
 	const { resolvedTheme } = useTheme();
 	const containerRef = useRef<HTMLDivElement>(null);
 	const termRef = useRef<XTerm | null>(null);
 	const wsRef = useRef<WebSocket | null>(null);
 	const cleanupRef = useRef<(() => void) | null>(null);
+	const reconnectRef = useRef<(() => void) | null>(null);
+	const reconnectRequestRef = useRef(reconnectRequest);
+	const requestWebsocketUrlRef = useRef(requestWebsocketUrl);
+	const onStatusChangeRef = useRef(onStatusChange);
 	const terminalThemeMode: TerminalThemeMode = resolvedTheme === "dark" ? "dark" : "light";
 	const terminalTheme = TERMINAL_THEMES[terminalThemeMode];
 	const themeRef = useRef(terminalTheme);
-	const [status, setStatus] = useState<HostedTerminalStatus>("connecting");
-
-	useEffect(() => {
-		onStatusChange?.(status);
-	}, [onStatusChange, status]);
+	requestWebsocketUrlRef.current = requestWebsocketUrl;
+	onStatusChangeRef.current = onStatusChange;
 
 	useEffect(() => {
 		themeRef.current = terminalTheme;
@@ -186,7 +235,7 @@ export function HostedTerminalPanel({ websocketUrl, onStatusChange }: HostedTerm
 		}
 	}, [terminalTheme]);
 
-	const connect = useCallback(async () => {
+	const initialize = useCallback(async () => {
 		cleanupRef.current?.();
 		cleanupRef.current = null;
 		if (!containerRef.current) return;
@@ -212,11 +261,44 @@ export function HostedTerminalPanel({ websocketUrl, onStatusChange }: HostedTerm
 		term.open(container);
 		term.focus();
 
-		termRef.current = term;
-		setStatus("connecting");
-
 		let disposed = false;
 		let fitFrame: number | null = null;
+		let retryTimer: number | null = null;
+		let stabilityTimer: number | null = null;
+		let connectionGeneration = 0;
+		let reconnectAttempts = 0;
+		let hasConnected = false;
+		let sendCurrentSocket: ((data: string) => boolean) | null = null;
+
+		const updateStatus = (nextStatus: HostedTerminalStatus) => {
+			onStatusChangeRef.current?.(nextStatus);
+		};
+		const clearRetryTimer = () => {
+			if (retryTimer === null) return;
+			window.clearTimeout(retryTimer);
+			retryTimer = null;
+		};
+		const clearStabilityTimer = () => {
+			if (stabilityTimer === null) return;
+			window.clearTimeout(stabilityTimer);
+			stabilityTimer = null;
+		};
+		const closeCurrentSocket = () => {
+			clearStabilityTimer();
+			const current = wsRef.current;
+			wsRef.current = null;
+			sendCurrentSocket = null;
+			if (!current) return;
+			current.onopen = null;
+			current.onmessage = null;
+			current.onclose = null;
+			current.onerror = null;
+			try {
+				current.close();
+			} catch {
+				// A socket can finish closing between detaching its handlers and close().
+			}
+		};
 		const fitNow = () => {
 			if (fitFrame !== null) {
 				window.cancelAnimationFrame(fitFrame);
@@ -232,46 +314,139 @@ export function HostedTerminalPanel({ websocketUrl, onStatusChange }: HostedTerm
 			});
 		};
 		fitNow();
-		const writeOutput = createTtydOutputWriter({
-			write: (data, callback) => term.write(data, callback),
-			send: (command) => {
-				const ws = wsRef.current;
-				if (ws?.readyState !== WebSocket.OPEN) return;
-				try {
-					ws.send(command);
-				} catch {
-					// The socket can close between readyState and send; cleanup owns reconnection.
-				}
-			},
-		});
+		termRef.current = term;
 
-		const openWebSocket = (target: TerminalWebSocketTarget) => {
+		const scheduleReconnect = (message: string, closeCode: number, connectionWasStable = false) => {
+			const completedAttempts = terminalReconnectAttemptsForClose(
+				reconnectAttempts,
+				connectionWasStable,
+			);
+			const nextReconnect = nextTerminalReconnect(closeCode, completedAttempts);
+			if (!nextReconnect) {
+				updateStatus("disconnected");
+				writeTerminalNotice(term, `${message} Automatic reconnect stopped.`);
+				return;
+			}
+			reconnectAttempts = nextReconnect.attempt;
+			const delaySeconds = nextReconnect.delayMs / 1_000;
+			updateStatus("reconnecting");
+			writeTerminalNotice(
+				term,
+				`${message} Reconnecting ${reconnectAttempts}/${TERMINAL_RECONNECT_DELAYS_MS.length} in ${delaySeconds}s...`,
+			);
+			retryTimer = window.setTimeout(() => {
+				retryTimer = null;
+				void connect("automatic");
+			}, nextReconnect.delayMs);
+		};
+
+		const handleConnectionFailure = (message: string, mode: "initial" | "manual" | "automatic") => {
+			if (mode === "automatic") {
+				scheduleReconnect(message, 1011);
+				return;
+			}
+			updateStatus("disconnected");
+			writeTerminalNotice(term, message);
+		};
+
+		const openWebSocket = (
+			target: TerminalWebSocketTarget,
+			websocketUrl: string,
+			mode: "initial" | "manual" | "automatic",
+			generation: number,
+		) => {
 			let ws: WebSocket;
 			let opened = false;
 			try {
 				ws = new WebSocket(target.url, target.protocols);
 			} catch {
 				if (target.authMode === "subprotocol" && target.token) {
-					openWebSocket(terminalWebSocketTarget(websocketUrl, "query"));
+					openWebSocket(
+						terminalWebSocketTarget(websocketUrl, "query"),
+						websocketUrl,
+						mode,
+						generation,
+					);
 					return;
 				}
-				setStatus("disconnected");
-				writeTerminalNotice(term, "secure terminal could not be opened");
+				handleConnectionFailure("Secure terminal could not be opened.", mode);
 				return;
 			}
 			ws.binaryType = "arraybuffer";
 			wsRef.current = ws;
+			let connectionStable = false;
+			let transportFailed = false;
+
+			const isCurrentTransport = () =>
+				!disposed &&
+				canUseTerminalTransport({
+					currentGeneration: connectionGeneration,
+					transportGeneration: generation,
+					isCurrentSocket: wsRef.current === ws,
+					failed: transportFailed,
+				});
+			const detachTransport = () => {
+				if (wsRef.current === ws) wsRef.current = null;
+				if (sendCurrentSocket === sendTransport) sendCurrentSocket = null;
+				ws.onopen = null;
+				ws.onmessage = null;
+				ws.onclose = null;
+				ws.onerror = null;
+			};
+			const failTransport = () => {
+				if (!isCurrentTransport()) return;
+				transportFailed = true;
+				clearStabilityTimer();
+				detachTransport();
+				try {
+					ws.close();
+				} catch {
+					// The retry no longer depends on the browser's eventual close event.
+				}
+				scheduleReconnect("Terminal transport failed.", 1011, connectionStable);
+			};
+			const sendTransport = (data: string): boolean => {
+				if (!isCurrentTransport() || ws.readyState !== WebSocket.OPEN) return false;
+				try {
+					ws.send(data);
+					return true;
+				} catch {
+					failTransport();
+					return false;
+				}
+			};
+			const writeOutput = createTtydOutputWriter({
+				write: (data, callback) => term.write(data, callback),
+				send: (command) => {
+					void sendTransport(command);
+				},
+			});
+			sendCurrentSocket = sendTransport;
 
 			ws.onopen = () => {
-				if (disposed) return;
+				if (!isCurrentTransport()) return;
 				opened = true;
-				setStatus("connected");
+				if (
+					!sendTransport(JSON.stringify({ AuthToken: "", columns: term.cols, rows: term.rows }))
+				) {
+					return;
+				}
+				const reconnected = hasConnected || mode !== "initial";
+				hasConnected = true;
+				updateStatus("connected");
+				if (reconnected) writeTerminalNotice(term, "Terminal reconnected.");
 				term.focus();
-				ws.send(JSON.stringify({ AuthToken: "", columns: term.cols, rows: term.rows }));
+				clearStabilityTimer();
+				stabilityTimer = window.setTimeout(() => {
+					stabilityTimer = null;
+					if (isCurrentTransport() && ws.readyState === WebSocket.OPEN) {
+						connectionStable = true;
+					}
+				}, TERMINAL_CONNECTION_STABILITY_MS);
 			};
 
 			ws.onmessage = (ev) => {
-				if (disposed) return;
+				if (!isCurrentTransport()) return;
 				if (ev.data instanceof ArrayBuffer) {
 					const data = new Uint8Array(ev.data);
 					if (data[0] === TTYD_OUTPUT_CODE) writeOutput(data.subarray(1));
@@ -283,37 +458,64 @@ export function HostedTerminalPanel({ websocketUrl, onStatusChange }: HostedTerm
 			};
 
 			ws.onclose = (event) => {
-				if (disposed) return;
-				if (wsRef.current === ws) {
-					wsRef.current = null;
-				}
-				if (!opened && target.authMode === "subprotocol" && target.token) {
-					setStatus("connecting");
-					openWebSocket(terminalWebSocketTarget(websocketUrl, "query"));
+				if (!isCurrentTransport()) return;
+				transportFailed = true;
+				clearStabilityTimer();
+				detachTransport();
+				if (!opened && event.code === 1006 && target.authMode === "subprotocol" && target.token) {
+					openWebSocket(
+						terminalWebSocketTarget(websocketUrl, "query"),
+						websocketUrl,
+						mode,
+						generation,
+					);
 					return;
 				}
-				setStatus("disconnected");
-				writeTerminalNotice(term, terminalConnectionClosedMessage(event));
+				const message = terminalConnectionClosedMessage(event);
+				if (isRetryableTerminalCloseCode(event.code)) {
+					scheduleReconnect(message, event.code, connectionStable);
+					return;
+				}
+				updateStatus("disconnected");
+				writeTerminalNotice(term, message);
 			};
-			ws.onerror = () => {
-				if (!opened && target.authMode === "subprotocol" && target.token) return;
-				if (!disposed) setStatus("disconnected");
-			};
+			ws.onerror = () => undefined;
 		};
 
-		openWebSocket(terminalWebSocketTarget(websocketUrl));
+		async function connect(mode: "initial" | "manual" | "automatic") {
+			clearRetryTimer();
+			clearStabilityTimer();
+			closeCurrentSocket();
+			connectionGeneration += 1;
+			const generation = connectionGeneration;
+			updateStatus(mode === "initial" ? "connecting" : "reconnecting");
+			let websocketUrl: string;
+			try {
+				websocketUrl = await requestWebsocketUrlRef.current();
+			} catch {
+				if (disposed || generation !== connectionGeneration) return;
+				handleConnectionFailure("Fresh terminal access could not be requested. Try again.", mode);
+				return;
+			}
+			if (disposed || generation !== connectionGeneration) return;
+			if (!websocketUrl) {
+				handleConnectionFailure("Secure terminal could not be opened. Try again.", mode);
+				return;
+			}
+			openWebSocket(terminalWebSocketTarget(websocketUrl), websocketUrl, mode, generation);
+		}
+
+		reconnectRef.current = () => {
+			reconnectAttempts = 0;
+			void connect("manual");
+		};
+		void connect("initial");
 
 		term.onData((data) => {
-			const ws = wsRef.current;
-			if (ws?.readyState === WebSocket.OPEN) {
-				ws.send(TTYD_INPUT + data);
-			}
+			void sendCurrentSocket?.(TTYD_INPUT + data);
 		});
 		term.onResize(({ cols, rows }) => {
-			const ws = wsRef.current;
-			if (ws?.readyState === WebSocket.OPEN) {
-				ws.send(TTYD_RESIZE + JSON.stringify({ columns: cols, rows }));
-			}
+			void sendCurrentSocket?.(TTYD_RESIZE + JSON.stringify({ columns: cols, rows }));
 		});
 
 		const resizeObserver = new ResizeObserver(scheduleFit);
@@ -323,36 +525,45 @@ export function HostedTerminalPanel({ websocketUrl, onStatusChange }: HostedTerm
 
 		const cleanup = () => {
 			disposed = true;
+			connectionGeneration += 1;
+			clearRetryTimer();
+			clearStabilityTimer();
 			if (fitFrame !== null) {
 				window.cancelAnimationFrame(fitFrame);
 				fitFrame = null;
 			}
 			resizeObserver.disconnect();
 			container.removeEventListener("pointerdown", focusTerminal);
-			wsRef.current?.close();
+			closeCurrentSocket();
 			term.dispose();
 			termRef.current = null;
-			wsRef.current = null;
+			reconnectRef.current = null;
 		};
 		cleanupRef.current = cleanup;
 		return cleanup;
-	}, [websocketUrl]);
+	}, []);
 
 	useEffect(() => {
 		let cancelled = false;
-		connect()
+		initialize()
 			.then((fn) => {
 				if (cancelled) fn?.();
 			})
 			.catch(() => {
-				if (!cancelled) setStatus("disconnected");
+				if (!cancelled) onStatusChangeRef.current?.("disconnected");
 			});
 		return () => {
 			cancelled = true;
 			cleanupRef.current?.();
 			cleanupRef.current = null;
 		};
-	}, [connect]);
+	}, [initialize]);
+
+	useEffect(() => {
+		if (reconnectRequestRef.current === reconnectRequest) return;
+		reconnectRequestRef.current = reconnectRequest;
+		reconnectRef.current?.();
+	}, [reconnectRequest]);
 
 	return (
 		<div data-hosted="true" className="flex min-h-0 flex-1 flex-col">

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -191,12 +191,13 @@ describe("hosted agent security and copy", () => {
 		expect(agentDetailSource).not.toContain("This runtime is bound to");
 	});
 
-	test("uses product language for terminal startup and failures", () => {
-		expect(agentDetailSource).toContain("Opening secure terminal");
-		expect(agentDetailSource).toContain("Starting a secure shell for your agent.");
+	test("uses product language for terminal connection states and failures", () => {
+		expect(agentDetailSource).toContain('reconnecting: "Reconnecting"');
+		expect(agentDetailSource).toContain('disconnected: "Disconnected"');
 		expect(agentDetailSource).not.toContain("terminal websocket URL");
 		expect(agentDetailSource).not.toContain("Opening deployment terminal");
-		expect(terminalPanelSource).toContain("secure terminal could not be opened");
+		expect(terminalPanelSource).toContain("Secure terminal could not be opened");
+		expect(terminalPanelSource).toContain("Fresh terminal access could not be requested");
 		expect(terminalPanelSource).not.toContain("terminal websocket could not be opened");
 	});
 });

--- a/apps/web/src/pages/dashboard/layout.tsx
+++ b/apps/web/src/pages/dashboard/layout.tsx
@@ -120,7 +120,13 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
 							<SidebarInset
 								id="dashboard-scroll-container"
 								data-scroll-restoration-id="dashboard-scroll-container"
-								className="md:h-[calc(100svh-1rem)] md:overflow-y-auto"
+								data-live-tool-route={isAgentLiveToolRoute ? "true" : undefined}
+								className={cn(
+									"md:h-[calc(100svh-1rem)]",
+									isAgentLiveToolRoute
+										? "h-svh overflow-hidden md:overflow-hidden"
+										: "md:overflow-y-auto",
+								)}
 							>
 								<SiteHeader
 									actions={
@@ -137,13 +143,24 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
 										) : null
 									}
 								/>
-								<div className="flex flex-1 flex-col">
-									<div className="@container/main flex flex-1 flex-col gap-2">
+								<div
+									className={cn(
+										"flex flex-1 flex-col",
+										isAgentLiveToolRoute && "min-h-0 overflow-hidden",
+									)}
+								>
+									<div
+										className={cn(
+											"@container/main flex flex-1 flex-col gap-2",
+											isAgentLiveToolRoute && "min-h-0 overflow-hidden",
+										)}
+									>
 										<div
 											data-testid="dashboard-page-content"
 											data-mava-launcher={hideHostedLauncher ? "hidden" : undefined}
 											className={cn(
 												"mx-auto flex w-full flex-col gap-4 pt-4 md:gap-5 md:pt-5",
+												isAgentLiveToolRoute && "min-h-0 flex-1 overflow-hidden",
 												CONTENT_MAX_WIDTH,
 												reserveHostedLauncherClearance
 													? "pb-[calc(--spacing(20)+env(safe-area-inset-bottom))]"


### PR DESCRIPTION
## Summary

- keep one xterm.js instance and scrollback across bounded reconnect attempts
- refresh terminal credentials for every real reconnect and isolate ttyd flow control per socket
- classify close codes, deduplicate transport failures, and stop short-lived reconnect loops after three attempts
- constrain Console, Files, and Terminal to the dashboard viewport so only xterm scrollback scrolls

## Backend contract

Pairs with Clawdi-AI/clawdi-hosted#1911 for explicit 1000/1011 close semantics.

## Verification

- `bash scripts/test.sh web`
- focused terminal tests: 11 passed
- typecheck, Biome/check, and OSS production build passed
- Playwright viewport checks passed for desktop and mobile Console/Files/Terminal
- `git diff --check origin/main..HEAD`