### PR TITLE
fix(web): keep terminal bottom row visible

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3627,7 +3627,7 @@ test("hosted live-tool routes keep scrolling inside their viewport", async ({ pa
 		await expect(page.getByTestId("overview-status-card-skeleton")).toHaveCount(0);
 		const dashboardContent = page.getByTestId("dashboard-page-content");
 		await expect(dashboardContent).toHaveAttribute("data-mava-launcher", "hidden");
-		await expect(dashboardContent).toHaveCSS("padding-bottom", "20px");
+		await expect(dashboardContent).toHaveCSS("padding-bottom", "0px");
 		await page.evaluate(() => {
 			const launcher = document.createElement("button");
 			launcher.id = "mava-webchat-launcher";
@@ -3650,7 +3650,7 @@ test("hosted live-tool routes keep scrolling inside their viewport", async ({ pa
 		await expectLiveToolFillsDashboard(page, liveSurface);
 
 		await page.setViewportSize({ width: 390, height: 844 });
-		await expect(dashboardContent).toHaveCSS("padding-bottom", "16px");
+		await expect(dashboardContent).toHaveCSS("padding-bottom", "0px");
 		await expectLiveToolFillsDashboard(page, liveSurface);
 
 		for (const section of ["files", "terminal"] as const) {
@@ -3661,6 +3661,57 @@ test("hosted live-tool routes keep scrolling inside their viewport", async ({ pa
 		}
 	} finally {
 		releaseDeploymentList?.();
+	}
+});
+
+test("hosted terminal keeps its fitted bottom row visible", async ({ page }) => {
+	const liveToolDeployment = mutationDeploymentReadFixture(railHostedDeployment);
+	await stubHostedApi(page, {
+		cloudAgents: [railHostedCloudAgent],
+		deployments: [liveToolDeployment],
+		deploymentListResponses: [[liveToolDeployment]],
+	});
+
+	for (const viewportSize of [
+		{ width: 1440, height: 900 },
+		{ width: 390, height: 844 },
+	] as const) {
+		await page.setViewportSize(viewportSize);
+		await page.goto(`/agents/${railHostedEnvironmentId}/terminal`);
+		const terminal = page.locator(".hosted-terminal");
+		await expect(terminal.locator(".xterm-screen")).toBeVisible();
+		await expect(page.getByRole("button", { name: "Retry terminal" })).toBeEnabled();
+
+		const geometry = await terminal.evaluate((host) => {
+			const requiredElement = (selector: string) => {
+				const element = host.querySelector<HTMLElement>(selector);
+				if (!element) throw new Error(`Expected terminal element ${selector}`);
+				return element;
+			};
+			const xterm = requiredElement(".xterm");
+			const viewport = requiredElement(".xterm-viewport");
+			const screen = requiredElement(".xterm-screen");
+			const lastRow = requiredElement(".xterm-rows > div:last-child");
+			return {
+				host: {
+					bottom: host.getBoundingClientRect().bottom,
+					clientHeight: host.clientHeight,
+					scrollHeight: host.scrollHeight,
+				},
+				xterm: {
+					clientHeight: xterm.clientHeight,
+					scrollHeight: xterm.scrollHeight,
+				},
+				viewport: viewport.getBoundingClientRect().toJSON(),
+				screen: screen.getBoundingClientRect().toJSON(),
+				lastRow: lastRow.getBoundingClientRect().toJSON(),
+			};
+		});
+		expect(geometry.host.scrollHeight).toBeLessThanOrEqual(geometry.host.clientHeight + 1);
+		expect(geometry.xterm.scrollHeight).toBeLessThanOrEqual(geometry.xterm.clientHeight + 1);
+		expect(geometry.viewport.bottom).toBeLessThanOrEqual(geometry.host.bottom + 1);
+		expect(geometry.screen.bottom).toBeLessThanOrEqual(geometry.viewport.bottom + 1);
+		expect(geometry.lastRow.bottom).toBeLessThanOrEqual(geometry.viewport.bottom + 1);
 	}
 });
 

--- a/apps/web/src/components/dashboard/agent-detail-loading-shell.test.ts
+++ b/apps/web/src/components/dashboard/agent-detail-loading-shell.test.ts
@@ -21,12 +21,10 @@ function render(section: Parameters<DetailSkeleton>[0]["section"]): string {
 }
 
 describe("agent detail loading shells", () => {
-	test("uses full-bleed live-tool geometry for live sections", () => {
+	test("uses the live-tool loading shell for live sections", () => {
 		for (const section of ["console", "files", "terminal"] as const) {
 			const markup = render(section);
 			expect(markup).toContain('data-testid="agent-live-tool-loading-shell"');
-			expect(markup).toContain("h-[calc(100svh-var(--header-height))]");
-			expect(markup).not.toContain("min-h-[calc(100svh-var(--header-height))]");
 			expect(markup).not.toContain("data-agent-detail-skeleton");
 			expect(markup).not.toContain("overview-status-card-skeleton");
 		}

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -380,7 +380,7 @@ export function ConnectedAgentDetailSkeleton({
 				data-testid="agent-live-tool-loading-shell"
 				role="status"
 				aria-label={`${agentSectionLabel(section)} loading`}
-				className="-my-4 flex h-[calc(100svh-var(--header-height))] min-h-0 w-full flex-col md:-my-5 md:h-[calc(100svh-var(--header-height)-1rem)]"
+				className="flex min-h-0 w-full flex-1 flex-col overflow-hidden"
 			>
 				<div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
 					<div className="flex h-12 shrink-0 items-center justify-between gap-3 px-4 lg:px-6">

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -533,7 +533,7 @@ export function HostedAgentDetail({
 			data-testid={isLiveToolTab ? "hosted-agent-live-surface" : undefined}
 			className={cn(
 				isLiveToolTab
-					? "-my-4 flex h-[calc(100svh-var(--header-height))] min-h-0 w-full flex-col md:-my-5 md:h-[calc(100svh-var(--header-height)-1rem)]"
+					? "flex min-h-0 w-full flex-1 flex-col overflow-hidden"
 					: cn(
 							activeTab === "settings" ? "w-full" : CENTERED_PAGE_WIDTH_CLASS.page,
 							"flex flex-col gap-6 px-4 lg:px-6",
@@ -1690,7 +1690,7 @@ function ConsoleTab({
 						}
 					/>
 				) : (
-					<div role="status" className="flex min-h-[420px] flex-1">
+					<div role="status" className="flex min-h-0 flex-1">
 						<EmptyState
 							icon={<Spinner className="size-5" />}
 							title={`Opening ${browserUiLabel}…`}
@@ -1703,7 +1703,7 @@ function ConsoleTab({
 					key={`${runtime}:${iframeUrl}`}
 					src={iframeUrl}
 					title={browserUiLabel}
-					className="min-h-[420px] flex-1 border-0 bg-background"
+					className="min-h-0 flex-1 border-0 bg-background"
 					allow="clipboard-read; clipboard-write"
 					onLoad={
 						runtime === "openclaw"
@@ -1786,7 +1786,7 @@ function FilesFrame({ url }: { url: string }) {
 				<iframe
 					src={url}
 					title="Files"
-					className="min-h-[420px] flex-1 border-0 bg-background"
+					className="min-h-0 flex-1 border-0 bg-background"
 					allow="clipboard-read; clipboard-write"
 				/>
 			)}

--- a/apps/web/src/hosted/agents/hosted-terminal-panel.tsx
+++ b/apps/web/src/hosted/agents/hosted-terminal-panel.tsx
@@ -570,7 +570,7 @@ export function HostedTerminalPanel({
 			<div
 				ref={containerRef}
 				data-terminal-theme={terminalThemeMode}
-				className="hosted-terminal min-h-0 flex-1 overflow-hidden p-2 transition-colors"
+				className="hosted-terminal min-h-0 flex-1 overflow-hidden transition-colors"
 			/>
 		</div>
 	);

--- a/apps/web/src/hosted/agents/hosted-terminal.css
+++ b/apps/web/src/hosted/agents/hosted-terminal.css
@@ -2,6 +2,7 @@
 
 .hosted-terminal .xterm {
 	height: 100%;
+	padding: 0.5rem;
 }
 
 .hosted-terminal[data-terminal-theme="dark"],

--- a/apps/web/src/pages/dashboard/layout.tsx
+++ b/apps/web/src/pages/dashboard/layout.tsx
@@ -159,12 +159,15 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
 											data-testid="dashboard-page-content"
 											data-mava-launcher={hideHostedLauncher ? "hidden" : undefined}
 											className={cn(
-												"mx-auto flex w-full flex-col gap-4 pt-4 md:gap-5 md:pt-5",
-												isAgentLiveToolRoute && "min-h-0 flex-1 overflow-hidden",
+												"mx-auto flex w-full flex-col",
+												isAgentLiveToolRoute
+													? "min-h-0 flex-1 overflow-hidden"
+													: "gap-4 pt-4 md:gap-5 md:pt-5",
 												CONTENT_MAX_WIDTH,
-												reserveHostedLauncherClearance
-													? "pb-[calc(--spacing(20)+env(safe-area-inset-bottom))]"
-													: "pb-4 md:pb-5",
+												!isAgentLiveToolRoute &&
+													(reserveHostedLauncherClearance
+														? "pb-[calc(--spacing(20)+env(safe-area-inset-bottom))]"
+														: "pb-4 md:pb-5"),
 											)}
 										>
 											{children}


### PR DESCRIPTION
## Summary
- let the dashboard flex chain own live-tool height instead of duplicating viewport calculations and negative margins
- move terminal inset padding onto the xterm element so FitAddon subtracts it when calculating rows
- cover desktop and mobile terminal bottom-row visibility with one browser geometry regression

## Root cause
FitAddon measures the terminal parent height but only subtracts padding from the xterm element. Padding on the parent made it overestimate available height, placing the last row 12px beyond the viewport on desktop and 4px beyond it on mobile.

## Verification
- Docker Web clean runner: typecheck, full Web test suite, OSS production build
- focused Bun tests: 13 passed
- focused hosted Playwright: 2 passed across desktop and mobile geometry
- exact Biome check and git diff check