### PR TITLE
feat(cli): enable managed OpenClaw memory embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ database migration, CI, and implementation details.
 
 - Newest-first Session detail pages now paginate from the actual visible transcript instead of relying on separately reported message counts, including for incrementally appended event chunks.
 
+## Clawdi CLI v0.14.25
+
+Package: `clawdi@0.14.25`
+
+### Added
+
+- Hosted OpenClaw can use the embedding model declared by its runtime provider
+  for managed memory search without exposing that model as a chat option.
+
 ## Clawdi CLI v0.14.24
 
 Package: `clawdi@0.14.24`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.24",
+      "version": "0.14.25",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.24",
+	"version": "0.14.25",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/lib/ai-provider-projection.test.ts
+++ b/packages/cli/src/lib/ai-provider-projection.test.ts
@@ -9,6 +9,7 @@ import {
 	defaultAiProviderRuntimeEnvName,
 } from "@clawdi/shared";
 import { parse as parseYaml } from "yaml";
+import { buildOpenClawHostedProviderPatch } from "../runtime/manifest-providers";
 import { buildAgentTargetProjection } from "./ai-provider-projection";
 
 const byokOpenAiCatalog: AiProviderCatalog = {
@@ -198,7 +199,12 @@ describe("AI provider projection", () => {
 		expect(openclaw.provider_ids).toEqual([CLAWDI_MANAGED_PROVIDER_ID]);
 		expect(openclaw.primary_model).toEqual(primaryModel);
 		const openclawPatch = JSON.parse(openclaw.files[0]?.content ?? "{}") as {
-			agents?: { defaults?: { model?: { primary?: string } } };
+			agents?: {
+				defaults?: {
+					model?: { primary?: string };
+					memorySearch?: { model?: string; provider?: string };
+				};
+			};
 			models?: {
 				providers?: Record<
 					string,
@@ -207,6 +213,10 @@ describe("AI provider projection", () => {
 			};
 		};
 		expect(openclawPatch.agents?.defaults?.model?.primary).toBe("clawdi/grok-4.6");
+		expect(openclawPatch.agents?.defaults?.memorySearch).toEqual({
+			provider: CLAWDI_MANAGED_PROVIDER_ID,
+			model: "text-embedding-3-small",
+		});
 		expect(openclawPatch.models?.providers?.[CLAWDI_MANAGED_PROVIDER_ID]).toMatchObject({
 			baseUrl: "https://managed.example.test/v1",
 			auth: "api-key",
@@ -280,6 +290,24 @@ describe("AI provider projection", () => {
 		expect(openclaw.files[0]?.content).toContain('"api": "openai-responses"');
 		expect(openclaw.files[0]?.content).toContain('"id": "OPENAI_API_KEY"');
 		expect(openclaw.files[0]?.content).not.toContain('"auth": "api-key"');
+		expect(openclaw.files[0]?.content).not.toContain('"memorySearch"');
+		const managedToByokPatch = JSON.parse(
+			buildOpenClawHostedProviderPatch(
+				{
+					catalog: byokOpenAiCatalog,
+					primaryModel: openclaw.primary_model,
+				},
+				[CLAWDI_MANAGED_PROVIDER_ID],
+			).content,
+		) as {
+			agents?: { defaults?: { memorySearch?: { model?: null; provider?: null } } };
+			models?: { providers?: Record<string, unknown> };
+		};
+		expect(managedToByokPatch.agents?.defaults?.memorySearch).toEqual({
+			provider: null,
+			model: null,
+		});
+		expect(managedToByokPatch.models?.providers?.[CLAWDI_MANAGED_PROVIDER_ID]).toBeNull();
 
 		const hermes = buildAgentTargetProjection("hermes", byokOpenAiCatalog);
 		expect(hermes.files[0]?.content).toContain('provider: "custom:openai-main"');

--- a/packages/cli/src/lib/ai-provider-projection.test.ts
+++ b/packages/cli/src/lib/ai-provider-projection.test.ts
@@ -185,10 +185,20 @@ describe("AI provider projection", () => {
 					auth: { type: "api_key", source: "managed" },
 					managed_by: "clawdi",
 					runtime_env_name: "CLAWDI_AI_API_KEY",
-					models: [{ id: "k3", api_mode: "openai_chat" }, { id: "grok-4.6" }],
+					models: [
+						{ id: "k3", api_mode: "openai_chat" },
+						{ id: "grok-4.6" },
+						{
+							id: "manifest-embedding-model",
+							capabilities: { embeddings: true, chat: false },
+						},
+					],
 				},
 			],
-			defaults: { chat_provider_id: CLAWDI_MANAGED_PROVIDER_ID },
+			defaults: {
+				chat_provider_id: CLAWDI_MANAGED_PROVIDER_ID,
+				embedding_provider_id: CLAWDI_MANAGED_PROVIDER_ID,
+			},
 		};
 		const primaryModel = {
 			provider_id: CLAWDI_MANAGED_PROVIDER_ID,
@@ -215,7 +225,7 @@ describe("AI provider projection", () => {
 		expect(openclawPatch.agents?.defaults?.model?.primary).toBe("clawdi/grok-4.6");
 		expect(openclawPatch.agents?.defaults?.memorySearch).toEqual({
 			provider: CLAWDI_MANAGED_PROVIDER_ID,
-			model: "text-embedding-3-small",
+			model: "manifest-embedding-model",
 		});
 		expect(openclawPatch.models?.providers?.[CLAWDI_MANAGED_PROVIDER_ID]).toMatchObject({
 			baseUrl: "https://managed.example.test/v1",
@@ -247,6 +257,7 @@ describe("AI provider projection", () => {
 		expect(hermes.files[0]?.content).toContain('key_env: "CLAWDI_AI_API_KEY"');
 		expect(hermes.files[0]?.content).toContain('"k3": {}');
 		expect(hermes.files[0]?.content).toContain('"grok-4.6": {}');
+		expect(hermes.files[0]?.content).not.toContain("manifest-embedding-model");
 		expect(hermes.files[0]?.content).not.toContain("clawdi-v2");
 	});
 

--- a/packages/cli/src/lib/ai-provider-projection.ts
+++ b/packages/cli/src/lib/ai-provider-projection.ts
@@ -87,6 +87,8 @@ const OPENCLAW_API_LABELS: Partial<Record<AiProviderApiMode, string>> = {
 	google_generate_content: "google-generative-ai",
 };
 
+const CLAWDI_MANAGED_MEMORY_EMBEDDING_MODEL = "text-embedding-3-small";
+
 const HERMES_TRANSPORT_LABELS: Partial<Record<AiProviderApiMode, string>> = {
 	openai_chat: "chat_completions",
 	// Hermes' current target-native label for the OpenAI Responses API.
@@ -286,6 +288,10 @@ function buildOpenClawProjection(
 	primaryProvider: ProjectionProvider,
 	primaryModel: AgentPrimaryModel,
 ): string {
+	const hasClawdiManagedProvider = providers.some(
+		(provider) =>
+			provider.id === CLAWDI_MANAGED_PROVIDER_ID && provider.managed_by === "clawdi",
+	);
 	const projectedProviders = Object.fromEntries(
 		providers
 			.filter((provider) => !usesNativeCodexOpenAiProvider(provider))
@@ -327,6 +333,12 @@ function buildOpenClawProjection(
 				model: {
 					primary: openClawDefaultModelRef(primaryProvider, primaryModel.model),
 				},
+				memorySearch: hasClawdiManagedProvider
+					? {
+							provider: CLAWDI_MANAGED_PROVIDER_ID,
+							model: CLAWDI_MANAGED_MEMORY_EMBEDDING_MODEL,
+						}
+					: undefined,
 			},
 		},
 		models:

--- a/packages/cli/src/lib/ai-provider-projection.ts
+++ b/packages/cli/src/lib/ai-provider-projection.ts
@@ -87,8 +87,6 @@ const OPENCLAW_API_LABELS: Partial<Record<AiProviderApiMode, string>> = {
 	google_generate_content: "google-generative-ai",
 };
 
-const CLAWDI_MANAGED_MEMORY_EMBEDDING_MODEL = "text-embedding-3-small";
-
 const HERMES_TRANSPORT_LABELS: Partial<Record<AiProviderApiMode, string>> = {
 	openai_chat: "chat_completions",
 	// Hermes' current target-native label for the OpenAI Responses API.
@@ -112,9 +110,10 @@ export function buildAgentTargetProjection(
 	const primaryProvider = selection.primaryProvider;
 	const selectedPrimaryModel = selection.primaryModel;
 	const warnings = [...validation.warnings, ...selection.warnings];
+	const embeddingModel = selectCatalogEmbeddingModel(catalog, providers);
 	const projection =
 		target === "openclaw"
-			? buildOpenClawProjection(providers, primaryProvider, selectedPrimaryModel)
+			? buildOpenClawProjection(providers, primaryProvider, selectedPrimaryModel, embeddingModel)
 			: target === "hermes"
 				? buildHermesProjection(
 						providers,
@@ -266,6 +265,21 @@ function agentFacingProviderId(providerId: string): string {
 	return isClawdiManagedV2ProviderId(providerId) ? CLAWDI_MANAGED_PROVIDER_ID : providerId;
 }
 
+function selectCatalogEmbeddingModel(
+	catalog: AiProviderCatalog,
+	providers: ProjectionProvider[],
+): AgentPrimaryModel | undefined {
+	const configuredProviderId = catalog.defaults?.embedding_provider_id;
+	if (!configuredProviderId) return undefined;
+	const providerId = agentFacingProviderId(configuredProviderId);
+	if (!providers.some((provider) => provider.id === providerId)) return undefined;
+	const sourceProvider = catalog.providers.find((provider) => provider.id === configuredProviderId);
+	const model = sourceProvider?.models?.find(
+		(candidate) => candidate.capabilities?.embeddings === true,
+	);
+	return model ? { provider_id: providerId, model: model.id } : undefined;
+}
+
 function legacyProviderDefaultModel(provider: AiProvider): string | undefined {
 	const value = (provider as AiProvider & { default_model?: string }).default_model;
 	return typeof value === "string" && value.trim() ? value.trim() : undefined;
@@ -287,10 +301,10 @@ function buildOpenClawProjection(
 	providers: ProjectionProvider[],
 	primaryProvider: ProjectionProvider,
 	primaryModel: AgentPrimaryModel,
+	embeddingModel: AgentPrimaryModel | undefined,
 ): string {
 	const hasClawdiManagedProvider = providers.some(
-		(provider) =>
-			provider.id === CLAWDI_MANAGED_PROVIDER_ID && provider.managed_by === "clawdi",
+		(provider) => provider.id === CLAWDI_MANAGED_PROVIDER_ID && provider.managed_by === "clawdi",
 	);
 	const projectedProviders = Object.fromEntries(
 		providers
@@ -333,12 +347,14 @@ function buildOpenClawProjection(
 				model: {
 					primary: openClawDefaultModelRef(primaryProvider, primaryModel.model),
 				},
-				memorySearch: hasClawdiManagedProvider
+				memorySearch: embeddingModel
 					? {
-							provider: CLAWDI_MANAGED_PROVIDER_ID,
-							model: CLAWDI_MANAGED_MEMORY_EMBEDDING_MODEL,
+							provider: embeddingModel.provider_id,
+							model: embeddingModel.model,
 						}
-					: undefined,
+					: hasClawdiManagedProvider
+						? { provider: null, model: null }
+						: undefined,
 			},
 		},
 		models:
@@ -357,6 +373,7 @@ function openClawModels(
 	primaryModel?: string,
 ): Array<Record<string, unknown>> {
 	const models = (provider.models ?? [])
+		.filter((model) => model.capabilities?.chat !== false)
 		.map((model) => {
 			return compactObject({
 				id: model.id,
@@ -553,6 +570,7 @@ function hermesModels(provider: ProjectionProvider): HermesProjectedModel[] {
 	const seen = new Set<string>();
 	const entries: HermesProjectedModel[] = [];
 	for (const model of provider.models ?? []) {
+		if (model.capabilities?.chat === false) continue;
 		if (!model.id || seen.has(model.id)) continue;
 		seen.add(model.id);
 		const entry: HermesProjectedModel = { id: model.id };

--- a/packages/cli/src/runtime/hosted-provider-resolution.ts
+++ b/packages/cli/src/runtime/hosted-provider-resolution.ts
@@ -41,11 +41,20 @@ export function agentTargetProjectionInput(
 	});
 	const primaryProviderId = providerIdMap.get(input.primaryModel.provider_id);
 	if (!primaryProviderId) return input;
+	const embeddingProviderId = input.catalog.defaults?.embedding_provider_id;
 	return {
 		catalog: {
 			...input.catalog,
 			providers,
-			defaults: { ...input.catalog.defaults, chat_provider_id: primaryProviderId },
+			defaults: {
+				...input.catalog.defaults,
+				chat_provider_id: primaryProviderId,
+				...(embeddingProviderId
+					? {
+							embedding_provider_id: providerIdMap.get(embeddingProviderId) ?? embeddingProviderId,
+						}
+					: {}),
+			},
 		},
 		primaryModel: { ...input.primaryModel, provider_id: primaryProviderId },
 	};
@@ -87,11 +96,17 @@ export function hostedAiProviderCatalog(
 		})
 		.filter((entry): entry is NonNullable<typeof entry> => entry !== null);
 	if (entries.length === 0) return null;
+	const embeddingProvider = entries.find((provider) =>
+		provider.models.some((model) => model.capabilities?.embeddings === true),
+	);
 	return {
 		catalog: {
 			schema_version: 1,
 			providers: entries,
-			defaults: { chat_provider_id: primaryModel.provider_id },
+			defaults: {
+				chat_provider_id: primaryModel.provider_id,
+				...(embeddingProvider ? { embedding_provider_id: embeddingProvider.id } : {}),
+			},
 		},
 		primaryModel,
 	};

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -1,6 +1,9 @@
 import { mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { MANAGED_AI_PROVIDER_RUNTIME_ENV } from "@clawdi/shared";
+import {
+	isClawdiManagedV2ProviderId,
+	MANAGED_AI_PROVIDER_RUNTIME_ENV,
+} from "@clawdi/shared";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { buildAgentTargetProjection } from "../lib/ai-provider-projection";
 import { writePrivateFileAtomic } from "../lib/private-file";
@@ -571,9 +574,10 @@ export function buildOpenClawHostedProviderPatch(
 ): OpenClawHostedProviderPatch {
 	if (!projectionInput) {
 		const deletedProviderIds = staleProviderIds(new Set(previousProviderIds), new Set());
+		const deletePatch = `${JSON.stringify(openClawProviderDeletePatch(deletedProviderIds), null, 2)}\n`;
 		return {
 			apply: deletedProviderIds.length > 0,
-			content: `${JSON.stringify(openClawProviderDeletePatch(deletedProviderIds), null, 2)}\n`,
+			content: withOpenClawManagedMemoryCleanup(deletePatch, deletedProviderIds),
 			providerIds: [],
 		};
 	}
@@ -588,9 +592,14 @@ export function buildOpenClawHostedProviderPatch(
 	const deletedProviderIds = staleProviderIds(new Set(previousProviderIds), new Set(providerIds));
 	const providerPatchContent =
 		providerIds.length > 0 ? withOpenClawProviderMode(file.content, "replace") : file.content;
+	const patchWithDeletes = mergeProviderDeletes(
+		"openclaw",
+		providerPatchContent,
+		deletedProviderIds,
+	);
 	return {
 		apply: true,
-		content: mergeProviderDeletes("openclaw", providerPatchContent, deletedProviderIds),
+		content: withOpenClawManagedMemoryCleanup(patchWithDeletes, deletedProviderIds),
 		providerIds,
 	};
 }
@@ -626,6 +635,26 @@ function withOpenClawProviderMode(patchContent: string, mode: "merge" | "replace
 	const patch = { ...root };
 	const models = { ...(recordValue(patch.models) ?? {}), mode };
 	patch.models = models;
+	return `${JSON.stringify(patch, null, 2)}\n`;
+}
+
+function withOpenClawManagedMemoryCleanup(
+	patchContent: string,
+	deletedProviderIds: readonly string[],
+): string {
+	if (!deletedProviderIds.some(isClawdiManagedV2ProviderId)) return patchContent;
+	const root = providerPatchRoot("openclaw", patchContent);
+	if (!root) return patchContent;
+	const patch = { ...root };
+	const agents = { ...(recordValue(patch.agents) ?? {}) };
+	const defaults = { ...(recordValue(agents.defaults) ?? {}) };
+	defaults.memorySearch = {
+		...(recordValue(defaults.memorySearch) ?? {}),
+		provider: null,
+		model: null,
+	};
+	agents.defaults = defaults;
+	patch.agents = agents;
 	return `${JSON.stringify(patch, null, 2)}\n`;
 }
 function openClawProviderDeletePatch(

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -1,9 +1,6 @@
 import { mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import {
-	isClawdiManagedV2ProviderId,
-	MANAGED_AI_PROVIDER_RUNTIME_ENV,
-} from "@clawdi/shared";
+import { isClawdiManagedV2ProviderId, MANAGED_AI_PROVIDER_RUNTIME_ENV } from "@clawdi/shared";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { buildAgentTargetProjection } from "../lib/ai-provider-projection";
 import { writePrivateFileAtomic } from "../lib/private-file";
@@ -574,10 +571,9 @@ export function buildOpenClawHostedProviderPatch(
 ): OpenClawHostedProviderPatch {
 	if (!projectionInput) {
 		const deletedProviderIds = staleProviderIds(new Set(previousProviderIds), new Set());
-		const deletePatch = `${JSON.stringify(openClawProviderDeletePatch(deletedProviderIds), null, 2)}\n`;
 		return {
 			apply: deletedProviderIds.length > 0,
-			content: withOpenClawManagedMemoryCleanup(deletePatch, deletedProviderIds),
+			content: mergeProviderDeletes("openclaw", "{}\n", deletedProviderIds),
 			providerIds: [],
 		};
 	}
@@ -592,14 +588,9 @@ export function buildOpenClawHostedProviderPatch(
 	const deletedProviderIds = staleProviderIds(new Set(previousProviderIds), new Set(providerIds));
 	const providerPatchContent =
 		providerIds.length > 0 ? withOpenClawProviderMode(file.content, "replace") : file.content;
-	const patchWithDeletes = mergeProviderDeletes(
-		"openclaw",
-		providerPatchContent,
-		deletedProviderIds,
-	);
 	return {
 		apply: true,
-		content: withOpenClawManagedMemoryCleanup(patchWithDeletes, deletedProviderIds),
+		content: mergeProviderDeletes("openclaw", providerPatchContent, deletedProviderIds),
 		providerIds,
 	};
 }
@@ -638,35 +629,6 @@ function withOpenClawProviderMode(patchContent: string, mode: "merge" | "replace
 	return `${JSON.stringify(patch, null, 2)}\n`;
 }
 
-function withOpenClawManagedMemoryCleanup(
-	patchContent: string,
-	deletedProviderIds: readonly string[],
-): string {
-	if (!deletedProviderIds.some(isClawdiManagedV2ProviderId)) return patchContent;
-	const root = providerPatchRoot("openclaw", patchContent);
-	if (!root) return patchContent;
-	const patch = { ...root };
-	const agents = { ...(recordValue(patch.agents) ?? {}) };
-	const defaults = { ...(recordValue(agents.defaults) ?? {}) };
-	defaults.memorySearch = {
-		...(recordValue(defaults.memorySearch) ?? {}),
-		provider: null,
-		model: null,
-	};
-	agents.defaults = defaults;
-	patch.agents = agents;
-	return `${JSON.stringify(patch, null, 2)}\n`;
-}
-function openClawProviderDeletePatch(
-	deletedProviderIds: readonly string[],
-): Record<string, unknown> {
-	return {
-		models: {
-			mode: "merge",
-			providers: Object.fromEntries(deletedProviderIds.map((providerId) => [providerId, null])),
-		},
-	};
-}
 const HERMES_DIRECT_MODEL_FIELDS = [
 	"base_url",
 	"api_key",
@@ -791,7 +753,16 @@ function mergeProviderDeletes(
 		providers[providerId] = null;
 	}
 	container.providers = providers;
-	if (runtime === "openclaw") patch.models = container;
+	if (runtime === "openclaw") {
+		patch.models = container;
+		if (deletedProviderIds.some(isClawdiManagedV2ProviderId)) {
+			const agents = { ...(recordValue(patch.agents) ?? {}) };
+			const defaults = { ...(recordValue(agents.defaults) ?? {}) };
+			defaults.memorySearch = { provider: null, model: null };
+			agents.defaults = defaults;
+			patch.agents = agents;
+		}
+	}
 	return runtime === "openclaw"
 		? `${JSON.stringify(patch, null, 2)}\n`
 		: `${stringifyYaml(patch).trimEnd()}\n`;

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -2979,6 +2979,10 @@ describe("runtime manifest reconciliation invariants", () => {
 								},
 								{ id: "kimi-for-coding" },
 								{ id: "kimi-for-coding-highspeed", context_window: 262_144 },
+								{
+									id: "manifest-embedding-model",
+									capabilities: { embeddings: true, chat: false },
+								},
 							],
 							apiMode: "openai_responses",
 							runtimeEnvName: "CLAWDI_AI_API_KEY",
@@ -2991,6 +2995,7 @@ describe("runtime manifest reconciliation invariants", () => {
 
 		const projection = hostedAiProviderCatalog(manifest, "openclaw");
 		expect(projection?.primaryModel).toEqual({ provider_id: "default", model: "k3" });
+		expect(projection?.catalog.defaults?.embedding_provider_id).toBe("default");
 		expect(projection?.catalog.providers[0]?.models).toEqual([
 			{
 				id: "k3",
@@ -3003,6 +3008,10 @@ describe("runtime manifest reconciliation invariants", () => {
 			},
 			{ id: "kimi-for-coding" },
 			{ id: "kimi-for-coding-highspeed", context_window: 262_144 },
+			{
+				id: "manifest-embedding-model",
+				capabilities: { embeddings: true, chat: false },
+			},
 		]);
 	});
 


### PR DESCRIPTION
## Summary

- configure Hosted OpenClaw `memorySearch` from the embedding capability declared in the runtime manifest
- keep the concrete embedding model in Hosted App Settings; the CLI contains no model-name or env fallback
- exclude embedding-only models from OpenClaw and Hermes chat catalogs
- leave Hermes memory configuration unchanged
- remove only managed memory provider/model fields when switching away from Clawdi, including legacy V2 provider IDs
- release the compatible reader as `clawdi@0.14.25`

Companion Hosted PR: https://github.com/Clawdi-AI/clawdi-hosted/pull/1912

## Release impact

- reviewed head: `24f28871cb5af0af2f2d8cfb913aab7eb9fe73c6`
- merging this PR changes `packages/cli/package.json` and triggers the protected OIDC publish workflow
- this is a CLI-only release; no Hosted runtime or host image rebuild is required
- deploy this CLI reader before the Hosted manifest producer

## Verification

- `bash scripts/test.sh cli` (1672 passed, 4 skipped, 0 failed)
- `node packages/cli/scripts/check-publish-manifest.mjs`
- Biome pre-commit checks
- `git diff --check`
