### PR TITLE
feat(web): open terminal in new tab

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3671,16 +3671,22 @@ test("hosted terminal keeps its fitted bottom row visible", async ({ page }) => 
 		deployments: [liveToolDeployment],
 		deploymentListResponses: [[liveToolDeployment]],
 	});
+	const terminalPath = `/agents/${railHostedEnvironmentId}/terminal`;
 
 	for (const viewportSize of [
 		{ width: 1440, height: 900 },
 		{ width: 390, height: 844 },
 	] as const) {
 		await page.setViewportSize(viewportSize);
-		await page.goto(`/agents/${railHostedEnvironmentId}/terminal`);
+		await page.goto(terminalPath);
 		const terminal = page.locator(".hosted-terminal");
+		const openInNewTab = page.locator('a[aria-label="Open terminal in new tab"]');
 		await expect(terminal.locator(".xterm-screen")).toBeVisible();
 		await expect(page.getByRole("button", { name: "Retry terminal" })).toBeEnabled();
+		await expect(openInNewTab).toHaveAttribute("href", terminalPath);
+		await expect(openInNewTab).toHaveAttribute("target", "_blank");
+		await expect(openInNewTab).toHaveAttribute("rel", "noopener noreferrer");
+		await expect(openInNewTab).toHaveAttribute("title", "Open terminal in new tab");
 
 		const geometry = await terminal.evaluate((host) => {
 			const requiredElement = (selector: string) => {

--- a/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
@@ -34,7 +34,6 @@ describe("hosted agent detail header", () => {
 		expect(source).toContain('title="Files"');
 		expect(source).toContain("Open in new tab");
 		expect(source).toContain("Opening Files…");
-		expect(source).not.toContain('target="_blank"');
 		expect(source).toContain("hostedAgentVisibleSectionIds(");
 		expect(source).toContain(
 			'const activeTab = visibleSectionIds.includes(parsedTab) ? parsedTab : "overview";',

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -635,6 +635,7 @@ export function HostedAgentDetail({
 							key={deployment.resource.id}
 							deployment={deployment}
 							agentName={availableAgentTitle}
+							terminalHref={terminalHref}
 						/>
 					) : null}
 					{deploymentStatus.known && activeTab === "files" && filesUrl ? (
@@ -2170,9 +2171,11 @@ function TerminalStatusIndicator({ status }: { status: HostedTerminalStatus }) {
 function TerminalTab({
 	deployment,
 	agentName,
+	terminalHref,
 }: {
 	deployment: HostedDeployment;
 	agentName: string;
+	terminalHref: string;
 }) {
 	const status = deploymentStatusFromResource(deployment.resource.status);
 	const isRunning = isRunningStatus(status);
@@ -2210,6 +2213,16 @@ function TerminalTab({
 	const terminalAction = (
 		<>
 			<TerminalStatusIndicator status={terminalStatus} />
+			<Button
+				render={<a href={terminalHref} target="_blank" rel="noopener noreferrer" />}
+				nativeButton={false}
+				variant="outline"
+				size="icon-sm"
+				aria-label="Open terminal in new tab"
+				title="Open terminal in new tab"
+			>
+				<ExternalLink />
+			</Button>
 			<Button
 				type="button"
 				variant="outline"


### PR DESCRIPTION
## Summary

- add an icon-only action that opens the current Terminal route in a new browser tab
- reuse the canonical agent Terminal URL so the new page creates its own terminal token and WebSocket session
- keep the existing terminal layout and reconnect behavior unchanged

No new route, backend protocol, dependency, tab state, or `window.open` handling is introduced. `clawdi-hosted` is untouched.

## Verification

- Docker Web typecheck, 18 focused tests, and OSS production build
- exact Biome check on the 3 changed files
- focused Playwright Chromium test at 1440x900 and 390x844
- `git diff --check origin/main..HEAD`