### PR TITLE
feat(sessions): navigate search results to messages

### DIFF
--- a/apps/web/src/components/sessions/message-list.tsx
+++ b/apps/web/src/components/sessions/message-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronRight, Terminal } from "lucide-react";
-import { useState } from "react";
+import { type Ref, useState } from "react";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import { agentTypeLabel } from "@/components/dashboard/agent-label";
 import { Markdown } from "@/components/markdown";
@@ -79,6 +79,8 @@ function MessageBlock({
 	userName,
 	agentType,
 	isGroupStart,
+	isHighlighted,
+	highlightedRef,
 }: {
 	message: SessionMessage;
 	userAvatar?: string;
@@ -92,6 +94,8 @@ function MessageBlock({
 	 * one agent fires 6 tool-uses in the same minute.
 	 */
 	isGroupStart: boolean;
+	isHighlighted?: boolean;
+	highlightedRef?: Ref<HTMLDivElement>;
 }) {
 	const isUser = message.role === "user";
 	const agentName = agentTypeLabel(agentType);
@@ -99,7 +103,16 @@ function MessageBlock({
 	return (
 		// `group` lives on the whole row so the continuation-row hover
 		// timestamp reveals from a hover anywhere on the message.
-		<div className={cn("group flex gap-3", isGroupStart ? "pt-4" : "")}>
+		<div
+			ref={isHighlighted ? highlightedRef : undefined}
+			data-search-match={isHighlighted ? "true" : undefined}
+			aria-current={isHighlighted ? "location" : undefined}
+			className={cn(
+				"group flex scroll-mt-24 gap-3 rounded-md",
+				isGroupStart ? "pt-4" : "",
+				isHighlighted && "bg-primary/5 ring-1 ring-primary/30",
+			)}
+		>
 			{/* Avatar column. Group-start: avatar (user image / agent icon).
 			    Continuation: faint HH:MM that reveals on row hover. */}
 			<div className="w-8 shrink-0 pt-0.5">
@@ -284,12 +297,16 @@ export function MessageList({
 	agentType,
 	userAvatar,
 	userName,
+	highlightedMessageKey,
+	highlightedMessageRef,
 }: {
 	messages: SessionMessage[];
 	messageKeys?: string[] | null;
 	agentType: string | null | undefined;
 	userAvatar?: string;
 	userName: string;
+	highlightedMessageKey?: string | null;
+	highlightedMessageRef?: Ref<HTMLDivElement>;
 }) {
 	const GROUP_GAP_MS = 5 * 60_000;
 	const out: React.ReactNode[] = [];
@@ -312,14 +329,18 @@ export function MessageList({
 		// across the divider shouldn't merge.
 		const dividerJustEmitted = i > 0 && dKey != null && dayKey(prev?.timestamp) !== dKey;
 		const isGroupStart = !sameAuthor || !closeInTime || dividerJustEmitted;
+		const messageKey = messageKeys?.[i] ?? i;
+		const isHighlighted = messageKey === highlightedMessageKey;
 		out.push(
 			<MessageBlock
-				key={messageKeys?.[i] ?? i}
+				key={messageKey}
 				message={msg}
 				userAvatar={userAvatar}
 				userName={userName}
 				agentType={agentType}
 				isGroupStart={isGroupStart}
+				isHighlighted={isHighlighted}
+				highlightedRef={isHighlighted ? highlightedMessageRef : undefined}
 			/>,
 		);
 	}

--- a/apps/web/src/components/sessions/session-columns.tsx
+++ b/apps/web/src/components/sessions/session-columns.tsx
@@ -5,6 +5,7 @@ import { SessionAgentLabel } from "@/components/sessions/session-agent-label";
 import type { DataTableColumnDef } from "@/components/ui/data-table";
 import { DataTableColumnHeader } from "@/components/ui/data-table-column-header";
 import type { SessionListItem } from "@/lib/api-schemas";
+import { sessionDetailLink } from "@/lib/session-search-anchor";
 import { formatAbsoluteTooltip, formatSessionSummary, relativeTime } from "@/lib/utils";
 
 const summaryColumn: DataTableColumnDef<SessionListItem> = {
@@ -19,8 +20,7 @@ const summaryColumn: DataTableColumnDef<SessionListItem> = {
 			<div className="min-w-0">
 				<div className="truncate" title={title}>
 					<Link
-						to="/sessions/$id"
-						params={{ id: s.id }}
+						{...sessionDetailLink(s)}
 						onClick={(e) => e.stopPropagation()}
 						className="font-medium hover:underline"
 					>

--- a/apps/web/src/components/sessions/session-feed.tsx
+++ b/apps/web/src/components/sessions/session-feed.tsx
@@ -10,6 +10,7 @@ import { SectionLabel } from "@/components/section-label";
 import { sessionAgentIdentityInput } from "@/components/sessions/session-agent-label";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { SessionListItem } from "@/lib/api-schemas";
+import { sessionDetailLink } from "@/lib/session-search-anchor";
 import {
 	cn,
 	formatAbsoluteTooltip,
@@ -124,7 +125,7 @@ export function SessionFeed({
 	groupBy = "last_activity_at",
 	showAgent = true,
 	quietAutomated = true,
-	sessionLink = (session) => ({ to: "/sessions/$id", params: { id: session.id } }),
+	sessionLink = sessionDetailLink,
 }: {
 	sessions: SessionListItem[];
 	isLoading: boolean;

--- a/apps/web/src/lib/session-search-anchor.test.ts
+++ b/apps/web/src/lib/session-search-anchor.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import {
+	sessionDetailLink,
+	sessionSearchAnchorFromSearch,
+	validateSessionDetailSearch,
+} from "@/lib/session-search-anchor";
+
+describe("Session search anchors", () => {
+	test("builds a detail link and round-trips a complete anchor", () => {
+		const link = sessionDetailLink({
+			id: "session-id",
+			search_match: {
+				role: "assistant",
+				excerpt: "matching text",
+				anchor: { kind: "event_seq", position: 42, revision: "events:revision" },
+			},
+		});
+		expect(link).toEqual({
+			to: "/sessions/$id",
+			params: { id: "session-id" },
+			search: {
+				matchKind: "event_seq",
+				matchPosition: 42,
+				matchRevision: "events:revision",
+			},
+		});
+		expect(sessionSearchAnchorFromSearch(validateSessionDetailSearch(link.search))).toEqual({
+			kind: "event_seq",
+			position: 42,
+			revision: "events:revision",
+		});
+	});
+
+	test("drops partial or malformed anchors as one unit", () => {
+		expect(validateSessionDetailSearch({ matchKind: "event_seq", matchPosition: 3 })).toEqual({});
+		expect(
+			validateSessionDetailSearch({
+				matchKind: "unknown",
+				matchPosition: -1,
+				matchRevision: "revision",
+			}),
+		).toEqual({});
+	});
+});

--- a/apps/web/src/lib/session-search-anchor.ts
+++ b/apps/web/src/lib/session-search-anchor.ts
@@ -1,0 +1,59 @@
+import type { SessionListItem } from "@clawdi/shared/api";
+
+export type SessionSearchAnchor = NonNullable<SessionListItem["search_match"]>["anchor"];
+
+export interface SessionDetailSearch {
+	matchKind?: SessionSearchAnchor["kind"];
+	matchPosition?: number;
+	matchRevision?: string;
+}
+
+function validPosition(value: unknown): number | undefined {
+	const parsed =
+		typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+	return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+export function validateSessionDetailSearch(search: Record<string, unknown>): SessionDetailSearch {
+	const kind =
+		search.matchKind === "snapshot_offset" || search.matchKind === "event_seq"
+			? search.matchKind
+			: undefined;
+	const position = validPosition(search.matchPosition);
+	const revision =
+		typeof search.matchRevision === "string" &&
+		search.matchRevision.length > 0 &&
+		search.matchRevision.length <= 80
+			? search.matchRevision
+			: undefined;
+	if (!kind || position === undefined || !revision) return {};
+	return { matchKind: kind, matchPosition: position, matchRevision: revision };
+}
+
+export function sessionSearchAnchorFromSearch(
+	search: SessionDetailSearch,
+): SessionSearchAnchor | undefined {
+	if (!search.matchKind || search.matchPosition === undefined || !search.matchRevision) {
+		return undefined;
+	}
+	return {
+		kind: search.matchKind,
+		position: search.matchPosition,
+		revision: search.matchRevision,
+	};
+}
+
+export function sessionDetailLink(session: Pick<SessionListItem, "id" | "search_match">) {
+	const anchor = session.search_match?.anchor;
+	return {
+		to: "/sessions/$id" as const,
+		params: { id: session.id },
+		search: anchor
+			? {
+					matchKind: anchor.kind,
+					matchPosition: anchor.position,
+					matchRevision: anchor.revision,
+				}
+			: {},
+	};
+}

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -48,19 +48,28 @@ import {
 	SESSION_MESSAGES_STALE_MS,
 	sessionDetailQueryKey,
 } from "@/lib/session-queries";
+import type { SessionSearchAnchor } from "@/lib/session-search-anchor";
 import { useIsomorphicLayoutEffect } from "@/lib/use-isomorphic-layout-effect";
 import { cn, formatNumber, formatSessionSummary, relativeTime } from "@/lib/utils";
 
-export default function SessionDetailPage({ sessionId }: { sessionId: string }) {
-	return <SessionDetailContent sessionId={sessionId} />;
+export default function SessionDetailPage({
+	sessionId,
+	searchAnchor,
+}: {
+	sessionId: string;
+	searchAnchor?: SessionSearchAnchor;
+}) {
+	return <SessionDetailContent sessionId={sessionId} searchAnchor={searchAnchor} />;
 }
 
 export function SessionDetailContent({
 	sessionId,
 	agentId,
+	searchAnchor,
 }: {
 	sessionId: string;
 	agentId?: string | null;
+	searchAnchor?: SessionSearchAnchor;
 }) {
 	const api = useApi();
 	const $api = useOpenApi();
@@ -186,14 +195,33 @@ export function SessionDetailContent({
 		// end (rather than reordering already-loaded pages, which
 		// would only show the OLDEST 100 in newest-first mode —
 		// confusing).
-		queryKey: ["session-messages", sessionId, session?.content_hash ?? null, direction],
+		queryKey: [
+			"session-messages",
+			sessionId,
+			session?.content_hash ?? null,
+			direction,
+			searchAnchor?.kind ?? null,
+			searchAnchor?.position ?? null,
+			searchAnchor?.revision ?? null,
+		],
 		initialPageParam: 0,
 		queryFn: async ({ pageParam }) => {
 			return unwrap(
 				await api.GET("/v1/sessions/{session_id}/messages", {
 					params: {
 						path: { session_id: sessionId },
-						query: { offset: pageParam, limit: PAGE_SIZE, direction },
+						query: {
+							offset: pageParam,
+							limit: PAGE_SIZE,
+							direction,
+							...(pageParam === 0 && searchAnchor
+								? {
+										anchor_kind: searchAnchor.kind,
+										anchor_position: searchAnchor.position,
+										anchor_revision: searchAnchor.revision,
+									}
+								: {}),
+						},
 					},
 				}),
 			);
@@ -231,6 +259,34 @@ export function SessionDetailContent({
 	}, [pagesData, direction]);
 	const totalMessages = pagesData?.pages[0]?.total ?? 0;
 	const loadedCount = messages?.length ?? 0;
+	const anchorOffset = pagesData?.pages[0]?.anchor_offset;
+	const highlightedMessageKey =
+		typeof anchorOffset === "number" ? `${direction}:${anchorOffset}` : null;
+	const highlightedMessageRef = useRef<HTMLDivElement | null>(null);
+	const handledAnchorRef = useRef<string | null>(null);
+	const anchorIdentity = searchAnchor
+		? `${searchAnchor.kind}:${searchAnchor.position}:${searchAnchor.revision}`
+		: null;
+
+	useEffect(() => {
+		if (!anchorIdentity || !pagesData) return;
+		if (highlightedMessageKey && highlightedMessageRef.current) {
+			const handled = `resolved:${highlightedMessageKey}:${anchorIdentity}`;
+			if (handledAnchorRef.current === handled) return;
+			handledAnchorRef.current = handled;
+			const frame = requestAnimationFrame(() => {
+				highlightedMessageRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+			});
+			return () => cancelAnimationFrame(frame);
+		}
+		const handled = `stale:${anchorIdentity}`;
+		if (handledAnchorRef.current !== handled) {
+			handledAnchorRef.current = handled;
+			toast.info("Search result changed", {
+				description: "This Session has newer content, so the conversation opened normally.",
+			});
+		}
+	}, [anchorIdentity, highlightedMessageKey, pagesData]);
 
 	// Hooks must run on every render in the same order — this includes the
 	// breadcrumb title hook. Compute the title (nullable while loading) and
@@ -432,6 +488,8 @@ export function SessionDetailContent({
 							agentType={session.agent_type}
 							userAvatar={user?.imageUrl}
 							userName={user?.fullName || "You"}
+							highlightedMessageKey={highlightedMessageKey}
+							highlightedMessageRef={highlightedMessageRef}
 						/>
 						{hasNextPage ? (
 							<LoadMoreSentinel

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -24,6 +24,7 @@ import type { SessionListItem } from "@/lib/api-schemas";
 import { getProjectResourceDefinition } from "@/lib/project-resource-model";
 import { shouldBlockQueryError } from "@/lib/query-state";
 import { type SessionListQuery, sessionListQueryOptions } from "@/lib/session-queries";
+import { sessionDetailLink } from "@/lib/session-search-anchor";
 import { parseAsPositiveInt } from "@/lib/url-search-parsers";
 import { useDebouncedValue } from "@/lib/use-debounced";
 import { cn, formatNumber, recencyBucketFor } from "@/lib/utils";
@@ -348,7 +349,7 @@ function SessionsListInner() {
 								data={data?.items ?? []}
 								isLoading={isLoading}
 								emptyMessage={emptyMessage}
-								getRowLink={(s) => ({ to: "/sessions/$id", params: { id: s.id } })}
+								getRowLink={sessionDetailLink}
 								rowAriaLabel={(s) => `Open session ${s.local_session_id}`}
 								sorting={sorting}
 								onSortingChange={(updater) => {

--- a/apps/web/src/routes/_protected/_dashboard/sessions/$id.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/sessions/$id.tsx
@@ -1,13 +1,19 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { routeHeadTitle } from "@/lib/document-title";
+import {
+	sessionSearchAnchorFromSearch,
+	validateSessionDetailSearch,
+} from "@/lib/session-search-anchor";
 import SessionDetailPage from "@/pages/dashboard/sessions/[id]/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/sessions/$id")({
+	validateSearch: validateSessionDetailSearch,
 	head: () => routeHeadTitle("Session"),
 	component: SessionDetailRoute,
 });
 
 function SessionDetailRoute() {
 	const { id } = Route.useParams();
-	return <SessionDetailPage sessionId={id} />;
+	const searchAnchor = sessionSearchAnchorFromSearch(Route.useSearch());
+	return <SessionDetailPage sessionId={id} searchAnchor={searchAnchor} />;
 }

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -125,6 +125,7 @@ from app.services.runtime_source_revision import (
 from app.services.session_content import (
     SessionContentInvalid,
     SessionContentMissing,
+    load_session_message_projection,
     load_session_messages,
     session_has_uploaded_content,
     slice_session_messages,
@@ -134,6 +135,7 @@ from app.services.session_refs import extract_related_refs
 from app.services.session_search import (
     SearchableSessionMessage,
     best_session_message_matches,
+    current_search_revision,
     replace_snapshot_search_index,
     searchable_snapshot_messages,
 )
@@ -3098,6 +3100,9 @@ async def get_session_messages(
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=100, ge=1, le=500),
     direction: Literal["asc", "desc"] = Query(default="asc"),
+    anchor_kind: Literal["snapshot_offset", "event_seq"] | None = Query(default=None),
+    anchor_position: int | None = Query(default=None, ge=0),
+    anchor_revision: str | None = Query(default=None, min_length=1, max_length=80),
     auth: AuthContext = Depends(require_scope("sessions:read")),
     db: AsyncSession = Depends(get_session),
 ) -> SessionMessagesPage:
@@ -3111,8 +3116,18 @@ async def get_session_messages(
     starts at the oldest visible message for ascending reads and at the newest
     visible message for descending reads. Clients pin pages to the parent
     session's `content_hash`, which changes after snapshot replacement or event
-    append.
+    append. A complete search anchor recenters the first page around its match;
+    stale anchors degrade to ordinary offset pagination.
     """
+    anchor_values = (anchor_kind, anchor_position, anchor_revision)
+    if any(value is not None for value in anchor_values) and not all(
+        value is not None for value in anchor_values
+    ):
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            "Search anchor requires kind, position, and revision",
+        )
+
     bound_env = _bound_env_id(auth)
     stmt = select(Session).where(
         Session.user_id == auth.user_id,
@@ -3134,7 +3149,7 @@ async def get_session_messages(
     # share the same cache — a popular shared link must not re-parse
     # a 10 MB JSON blob per visitor.
     try:
-        raw = await load_session_messages(session, file_store, db)
+        projection = await load_session_message_projection(session, file_store, db)
     except SessionContentMissing:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session content file not found") from None
     except SessionContentInvalid:
@@ -3142,13 +3157,42 @@ async def get_session_messages(
             status.HTTP_500_INTERNAL_SERVER_ERROR, "Internal server error"
         ) from None
 
-    total = len(raw)
-    sliced = slice_session_messages(raw, offset=offset, limit=limit, direction=direction)
+    total = len(projection.messages)
+    page_offset = offset
+    anchor_offset: int | None = None
+    expected_anchor_kind: Literal["snapshot_offset", "event_seq"] = (
+        "event_seq" if session.content_protocol == "events-v1" else "snapshot_offset"
+    )
+    if (
+        anchor_kind is not None
+        and anchor_position is not None
+        and anchor_revision is not None
+        and anchor_kind == expected_anchor_kind
+        and anchor_revision == current_search_revision(session)
+    ):
+        try:
+            source_index = projection.source_positions.index(anchor_position)
+        except ValueError:
+            pass
+        else:
+            anchor_offset = source_index if direction == "asc" else total - source_index - 1
+            page_offset = min(
+                max(0, anchor_offset - limit // 2),
+                max(0, total - limit),
+            )
+
+    sliced = slice_session_messages(
+        projection.messages,
+        offset=page_offset,
+        limit=limit,
+        direction=direction,
+    )
     return SessionMessagesPage(
         items=[SessionMessageResponse.model_validate(m) for m in sliced],
         total=total,
-        offset=offset,
+        offset=page_offset,
         limit=limit,
+        anchor_offset=anchor_offset,
     )
 
 

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -659,3 +659,10 @@ class SessionMessagesPage(BaseModel):
     total: int
     offset: int
     limit: int
+    # Absolute offset in the requested direction for a resolved search match.
+    # Omitted for ordinary pagination and stale or invalidated search anchors.
+    anchor_offset: int | None = Field(
+        default=None,
+        ge=0,
+        exclude_if=lambda value: value is None,
+    )

--- a/backend/app/services/session_content.py
+++ b/backend/app/services/session_content.py
@@ -17,6 +17,7 @@ import threading
 import time
 from collections import OrderedDict
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Literal, Protocol
 
 from pydantic import JsonValue, TypeAdapter, ValidationError
@@ -28,6 +29,7 @@ from app.schemas.session_events import SessionEvent
 from app.services.session_events import (
     EMPTY_EVENT_HEAD,
     project_safe_messages,
+    project_visible_messages,
     validate_event_chunk_async,
 )
 
@@ -49,10 +51,17 @@ _MESSAGES_CACHE_TTL_S = 300.0
 type SessionMessageValue = dict[str, JsonValue]
 type SessionMessageDirection = Literal["asc", "desc"]
 
+
+@dataclass(frozen=True, slots=True)
+class SessionMessageProjection:
+    messages: list[SessionMessageValue]
+    source_positions: tuple[int, ...]
+
+
 _SESSION_MESSAGES_ADAPTER: TypeAdapter[list[SessionMessageValue]] = TypeAdapter(
     list[SessionMessageValue]
 )
-_messages_cache: OrderedDict[tuple[str, str], tuple[float, list[SessionMessageValue]]] = (
+_messages_cache: OrderedDict[tuple[str, str], tuple[float, SessionMessageProjection]] = (
     OrderedDict()
 )
 _messages_cache_lock = threading.Lock()
@@ -73,7 +82,7 @@ def session_has_uploaded_content(session: Session) -> bool:
     )
 
 
-def _cache_get(key: tuple[str, str]) -> list[SessionMessageValue] | None:
+def _cache_get(key: tuple[str, str]) -> SessionMessageProjection | None:
     now = time.monotonic()
     with _messages_cache_lock:
         entry = _messages_cache.get(key)
@@ -88,10 +97,10 @@ def _cache_get(key: tuple[str, str]) -> list[SessionMessageValue] | None:
         return parsed
 
 
-def _cache_put(key: tuple[str, str], parsed: list[SessionMessageValue]) -> None:
+def _cache_put(key: tuple[str, str], projection: SessionMessageProjection) -> None:
     now = time.monotonic()
     with _messages_cache_lock:
-        _messages_cache[key] = (now, parsed)
+        _messages_cache[key] = (now, projection)
         _messages_cache.move_to_end(key)
         while len(_messages_cache) > _MESSAGES_CACHE_MAX:
             _messages_cache.popitem(last=False)
@@ -128,6 +137,16 @@ async def load_session_messages(
     - `SessionContentInvalid`: JSON decode failure or non-list payload.
       Indicates an upload corruption; route layer returns 500.
     """
+    projection = await load_session_message_projection(session, file_store, db)
+    return projection.messages
+
+
+async def load_session_message_projection(
+    session: Session,
+    file_store: _FileStoreLike,
+    db: AsyncSession | None = None,
+) -> SessionMessageProjection:
+    """Load visible messages with their canonical source positions."""
     if session.content_protocol == "events-v1" and session.event_generation_id is not None:
         if db is None:
             raise SessionContentInvalid("events-v1 content requires a database session")
@@ -139,9 +158,13 @@ async def load_session_messages(
         if cached is not None:
             return cached
         events = await load_session_events(session, file_store, db)
-        projected = _SESSION_MESSAGES_ADAPTER.validate_python(project_safe_messages(events))
-        _cache_put(cache_key, projected)
-        return projected
+        visible = project_visible_messages(events)
+        projection = SessionMessageProjection(
+            messages=_SESSION_MESSAGES_ADAPTER.validate_python(project_safe_messages(events)),
+            source_positions=tuple(message.position for message in visible),
+        )
+        _cache_put(cache_key, projection)
+        return projection
 
     if not session.file_key:
         raise SessionContentMissing(f"session {session.id} has no uploaded content")
@@ -170,8 +193,12 @@ async def load_session_messages(
             f"session {session.id} content is not a valid JSON message array"
         ) from exc
 
-    _cache_put(cache_key, parsed)
-    return parsed
+    projection = SessionMessageProjection(
+        messages=parsed,
+        source_positions=tuple(range(len(parsed))),
+    )
+    _cache_put(cache_key, projection)
+    return projection
 
 
 async def load_session_events(

--- a/backend/tests/test_session_events.py
+++ b/backend/tests/test_session_events.py
@@ -640,6 +640,23 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
         "limit": 2,
     }
 
+    anchored_messages = await client.get(
+        f"/v1/sessions/{session.id}/messages",
+        params={
+            "direction": "desc",
+            "limit": 2,
+            "anchor_kind": "event_seq",
+            "anchor_position": 4,
+            "anchor_revision": f"events:{second_head}",
+        },
+    )
+    assert anchored_messages.status_code == 200, anchored_messages.text
+    assert anchored_messages.json()["anchor_offset"] == 1
+    assert [item["content"] for item in anchored_messages.json()["items"]] == [
+        "appended left\x00right answer",
+        "visible answer",
+    ]
+
     visible_search = (await client.get("/v1/sessions", params={"q": "visible answer"})).json()
     assert [item["local_session_id"] for item in visible_search["items"]] == [local_id]
     assert visible_search["items"][0]["search_match"] == {

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -1042,6 +1042,38 @@ async def test_session_messages_endpoint_paginates_long_conversations(
     assert len(page3["items"]) == 50
     assert page3["items"][-1]["content"] == "msg 249"
 
+    revision = f"snapshot:{hashlib.sha256(body_bytes).hexdigest()}"
+    anchored = await client.get(
+        f"/v1/sessions/{session_id}/messages",
+        params={
+            "limit": 100,
+            "anchor_kind": "snapshot_offset",
+            "anchor_position": 125,
+            "anchor_revision": revision,
+        },
+    )
+    anchored_page = anchored.json()
+    assert anchored_page["offset"] == 75
+    assert anchored_page["anchor_offset"] == 125
+    assert anchored_page["items"][50]["content"] == "msg 125"
+
+    stale_anchor = await client.get(
+        f"/v1/sessions/{session_id}/messages",
+        params={
+            "anchor_kind": "snapshot_offset",
+            "anchor_position": 125,
+            "anchor_revision": "snapshot:" + "0" * 64,
+        },
+    )
+    assert stale_anchor.json()["offset"] == 0
+    assert "anchor_offset" not in stale_anchor.json()
+
+    partial_anchor = await client.get(
+        f"/v1/sessions/{session_id}/messages",
+        params={"anchor_kind": "snapshot_offset"},
+    )
+    assert partial_anchor.status_code == 422
+
     # Descending offsets are relative to the newest end. The server computes
     # this from the actual content rather than trusting batch metadata (which
     # intentionally says 5 above while the blob contains 250 messages).

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1357,7 +1357,8 @@ export interface paths {
          *     starts at the oldest visible message for ascending reads and at the newest
          *     visible message for descending reads. Clients pin pages to the parent
          *     session's `content_hash`, which changes after snapshot replacement or event
-         *     append.
+         *     append. A complete search anchor recenters the first page around its match;
+         *     stale anchors degrade to ordinary offset pagination.
          */
         get: operations["get_session_messages_v1_sessions__session_id__messages_get"];
         put?: never;
@@ -8064,6 +8065,8 @@ export interface components {
             offset: number;
             /** Limit */
             limit: number;
+            /** Anchor Offset */
+            anchor_offset?: number | null;
         };
         /**
          * SessionPermissionCreate
@@ -11739,6 +11742,9 @@ export interface operations {
                 offset?: number;
                 limit?: number;
                 direction?: "asc" | "desc";
+                anchor_kind?: ("snapshot_offset" | "event_seq") | null;
+                anchor_position?: number | null;
+                anchor_revision?: string | null;
             };
             header?: never;
             path: {


### PR DESCRIPTION
## Summary

- carry body-search anchors from Session feed and table results into detail URLs
- recenter the existing paginated messages endpoint around snapshot or events-v1 matches
- scroll to and highlight the exact message, with graceful fallback when content changed

## Compatibility

- additive optional query and response fields only
- ordinary pagination responses retain their existing nested message shape
- stale, mismatched, or missing source positions fall back to normal pagination
- no new endpoint, table, content copy, or global client state

## Verification

- isolated PostgreSQL backend tests: snapshot and events-v1 anchor paths, stale and partial anchors
- isolated Web runner: route generation, TypeScript, focused helper tests, OSS production build
- Playwright Chromium: desktop and mobile search-result navigation, centered highlight, stale-anchor toast, zero browser errors
- Ruff check/format/compileall, Biome, generated API consistency, backend type governance
