### PR TITLE
fix(web): open terminal in standalone window

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -151,6 +151,39 @@ async function expectLiveToolFillsDashboard(page: Page, surface: Locator) {
 	);
 }
 
+async function expectTerminalFitsHost(terminal: Locator) {
+	const geometry = await terminal.evaluate((host) => {
+		const requiredElement = (selector: string) => {
+			const element = host.querySelector<HTMLElement>(selector);
+			if (!element) throw new Error(`Expected terminal element ${selector}`);
+			return element;
+		};
+		const xterm = requiredElement(".xterm");
+		const viewport = requiredElement(".xterm-viewport");
+		const screen = requiredElement(".xterm-screen");
+		const lastRow = requiredElement(".xterm-rows > div:last-child");
+		return {
+			host: {
+				bottom: host.getBoundingClientRect().bottom,
+				clientHeight: host.clientHeight,
+				scrollHeight: host.scrollHeight,
+			},
+			xterm: {
+				clientHeight: xterm.clientHeight,
+				scrollHeight: xterm.scrollHeight,
+			},
+			viewport: viewport.getBoundingClientRect().toJSON(),
+			screen: screen.getBoundingClientRect().toJSON(),
+			lastRow: lastRow.getBoundingClientRect().toJSON(),
+		};
+	});
+	expect(geometry.host.scrollHeight).toBeLessThanOrEqual(geometry.host.clientHeight + 1);
+	expect(geometry.xterm.scrollHeight).toBeLessThanOrEqual(geometry.xterm.clientHeight + 1);
+	expect(geometry.viewport.bottom).toBeLessThanOrEqual(geometry.host.bottom + 1);
+	expect(geometry.screen.bottom).toBeLessThanOrEqual(geometry.viewport.bottom + 1);
+	expect(geometry.lastRow.bottom).toBeLessThanOrEqual(geometry.viewport.bottom + 1);
+}
+
 async function _expectOverviewSessionSlot({
 	region,
 	statusCard,
@@ -3664,7 +3697,7 @@ test("hosted live-tool routes keep scrolling inside their viewport", async ({ pa
 	}
 });
 
-test("hosted terminal keeps its fitted bottom row visible", async ({ page }) => {
+test("hosted terminal opens a standalone fitted window", async ({ page, context }) => {
 	const liveToolDeployment = mutationDeploymentReadFixture(railHostedDeployment);
 	await stubHostedApi(page, {
 		cloudAgents: [railHostedCloudAgent],
@@ -3672,6 +3705,16 @@ test("hosted terminal keeps its fitted bottom row visible", async ({ page }) => 
 		deploymentListResponses: [[liveToolDeployment]],
 	});
 	const terminalPath = `/agents/${railHostedEnvironmentId}/terminal`;
+	const terminalWindowPath = `/terminal/${railHostedEnvironmentId}`;
+
+	await page.goto(terminalPath);
+	const openButton = page.getByRole("button", { name: "Open Terminal in new window" });
+	await expect(openButton).toContainText("Open in new window");
+	const popupPromise = context.waitForEvent("page");
+	await openButton.click();
+	const popup = await popupPromise;
+	await expect(popup).toHaveURL(terminalWindowPath);
+	await popup.close();
 
 	for (const viewportSize of [
 		{ width: 1440, height: 900 },
@@ -3680,44 +3723,42 @@ test("hosted terminal keeps its fitted bottom row visible", async ({ page }) => 
 		await page.setViewportSize(viewportSize);
 		await page.goto(terminalPath);
 		const terminal = page.locator(".hosted-terminal");
-		const openInNewTab = page.locator('a[aria-label="Open terminal in new tab"]');
 		await expect(terminal.locator(".xterm-screen")).toBeVisible();
 		await expect(page.getByRole("button", { name: "Retry terminal" })).toBeEnabled();
-		await expect(openInNewTab).toHaveAttribute("href", terminalPath);
-		await expect(openInNewTab).toHaveAttribute("target", "_blank");
-		await expect(openInNewTab).toHaveAttribute("rel", "noopener noreferrer");
-		await expect(openInNewTab).toHaveAttribute("title", "Open terminal in new tab");
+		await expectTerminalFitsHost(terminal);
 
-		const geometry = await terminal.evaluate((host) => {
-			const requiredElement = (selector: string) => {
-				const element = host.querySelector<HTMLElement>(selector);
-				if (!element) throw new Error(`Expected terminal element ${selector}`);
-				return element;
-			};
-			const xterm = requiredElement(".xterm");
-			const viewport = requiredElement(".xterm-viewport");
-			const screen = requiredElement(".xterm-screen");
-			const lastRow = requiredElement(".xterm-rows > div:last-child");
-			return {
-				host: {
-					bottom: host.getBoundingClientRect().bottom,
-					clientHeight: host.clientHeight,
-					scrollHeight: host.scrollHeight,
-				},
-				xterm: {
-					clientHeight: xterm.clientHeight,
-					scrollHeight: xterm.scrollHeight,
-				},
-				viewport: viewport.getBoundingClientRect().toJSON(),
-				screen: screen.getBoundingClientRect().toJSON(),
-				lastRow: lastRow.getBoundingClientRect().toJSON(),
-			};
-		});
-		expect(geometry.host.scrollHeight).toBeLessThanOrEqual(geometry.host.clientHeight + 1);
-		expect(geometry.xterm.scrollHeight).toBeLessThanOrEqual(geometry.xterm.clientHeight + 1);
-		expect(geometry.viewport.bottom).toBeLessThanOrEqual(geometry.host.bottom + 1);
-		expect(geometry.screen.bottom).toBeLessThanOrEqual(geometry.viewport.bottom + 1);
-		expect(geometry.lastRow.bottom).toBeLessThanOrEqual(geometry.viewport.bottom + 1);
+		await page.goto(terminalWindowPath);
+		const standaloneSurface = page.getByTestId("hosted-agent-live-surface");
+		const standaloneTerminal = standaloneSurface.locator(".hosted-terminal");
+		await expect(standaloneTerminal.locator(".xterm-screen")).toBeVisible();
+		await expect(page.getByRole("button", { name: "Open Terminal in new window" })).toHaveCount(0);
+		await expect(page.getByTestId("app-sidebar")).toHaveCount(0);
+		await expect(page.getByTestId("dashboard-page-content")).toHaveCount(0);
+		await expect(page.locator('main[data-mava-launcher="hidden"]')).toBeVisible();
+		const standaloneGeometry = await standaloneSurface.evaluate((surface) => ({
+			surface: surface.getBoundingClientRect().toJSON(),
+			viewport: { width: window.innerWidth, height: window.innerHeight },
+			body: { clientHeight: document.body.clientHeight, scrollHeight: document.body.scrollHeight },
+			document: {
+				clientHeight: document.documentElement.clientHeight,
+				scrollHeight: document.documentElement.scrollHeight,
+			},
+		}));
+		expect(Math.abs(standaloneGeometry.surface.x)).toBeLessThanOrEqual(1);
+		expect(Math.abs(standaloneGeometry.surface.y)).toBeLessThanOrEqual(1);
+		expect(
+			Math.abs(standaloneGeometry.surface.width - standaloneGeometry.viewport.width),
+		).toBeLessThanOrEqual(1);
+		expect(
+			Math.abs(standaloneGeometry.surface.height - standaloneGeometry.viewport.height),
+		).toBeLessThanOrEqual(1);
+		expect(standaloneGeometry.body.scrollHeight).toBeLessThanOrEqual(
+			standaloneGeometry.body.clientHeight + 1,
+		);
+		expect(standaloneGeometry.document.scrollHeight).toBeLessThanOrEqual(
+			standaloneGeometry.document.clientHeight + 1,
+		);
+		await expectTerminalFitsHost(standaloneTerminal);
 	}
 });
 

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -46,10 +46,12 @@ export function AgentHome({
 	environmentId,
 	section,
 	routeSearch,
+	standalone = false,
 }: {
 	environmentId: string;
 	section: AgentSectionId;
 	routeSearch: AgentRouteSearch;
+	standalone?: boolean;
 }) {
 	const router = useRouter();
 	const pathname = useLocation({ select: (location) => location.pathname });
@@ -171,6 +173,7 @@ export function AgentHome({
 				isCheckingDeployment={manualChecking}
 				onCheckDeploymentAgain={() => void handleCheckAgain()}
 				eventStreamActive={eventStreamActive}
+				standalone={standalone}
 			/>
 		);
 	}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
@@ -34,6 +34,7 @@ describe("hosted agent detail header", () => {
 		expect(source).toContain('title="Files"');
 		expect(source).toContain("Open in new tab");
 		expect(source).toContain("Opening Files…");
+		expect(source).not.toContain('target="_blank"');
 		expect(source).toContain("hostedAgentVisibleSectionIds(");
 		expect(source).toContain(
 			'const activeTab = visibleSectionIds.includes(parsedTab) ? parsedTab : "overview";',

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -294,6 +294,7 @@ import {
 	agentSectionLabel,
 	agentSectionLink,
 	agentSessionDetailLink,
+	agentTerminalWindowHref,
 	HOSTED_AGENT_SECTION_IDS,
 	isAgentRouteId,
 } from "@/lib/agent-routes";
@@ -443,6 +444,7 @@ export function HostedAgentDetail({
 	isCheckingDeployment,
 	onCheckDeploymentAgain,
 	eventStreamActive = false,
+	standalone = false,
 }: {
 	environmentId: string;
 	deployment: HostedDeployment;
@@ -455,6 +457,7 @@ export function HostedAgentDetail({
 	isCheckingDeployment: boolean;
 	onCheckDeploymentAgain: () => void;
 	eventStreamActive?: boolean;
+	standalone?: boolean;
 }) {
 	const $api = useOpenApi();
 	const queryClient = useQueryClient();
@@ -507,6 +510,7 @@ export function HostedAgentDetail({
 
 	const isPerformance = deployment.current_plan_slug === COMPUTE_PERFORMANCE_SLUG;
 	const terminalHref = agentSectionHref(environmentId, "terminal");
+	const terminalWindowHref = agentTerminalWindowHref(environmentId);
 	const scopedSessionLink = (sessionId: string) => ({
 		...agentSessionDetailLink(environmentId, sessionId),
 	});
@@ -635,7 +639,8 @@ export function HostedAgentDetail({
 							key={deployment.resource.id}
 							deployment={deployment}
 							agentName={availableAgentTitle}
-							terminalHref={terminalHref}
+							terminalWindowHref={terminalWindowHref}
+							standalone={standalone}
 						/>
 					) : null}
 					{deploymentStatus.known && activeTab === "files" && filesUrl ? (
@@ -2159,6 +2164,8 @@ const TERMINAL_STATUS_TONES: Record<HostedTerminalStatus, StatusTone> = {
 	disconnected: "destructive",
 };
 
+const TERMINAL_WINDOW_LAUNCH_TOAST_ID = "terminal-window-launch";
+
 function TerminalStatusIndicator({ status }: { status: HostedTerminalStatus }) {
 	return (
 		<div className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -2171,11 +2178,13 @@ function TerminalStatusIndicator({ status }: { status: HostedTerminalStatus }) {
 function TerminalTab({
 	deployment,
 	agentName,
-	terminalHref,
+	terminalWindowHref,
+	standalone,
 }: {
 	deployment: HostedDeployment;
 	agentName: string;
-	terminalHref: string;
+	terminalWindowHref: string;
+	standalone: boolean;
 }) {
 	const status = deploymentStatusFromResource(deployment.resource.status);
 	const isRunning = isRunningStatus(status);
@@ -2186,6 +2195,17 @@ function TerminalTab({
 	const { isPending: isOpeningTerminal, execute: createTerminalSession } = terminal;
 	const [terminalStatus, setTerminalStatus] = useState<HostedTerminalStatus>("connecting");
 	const [reconnectRequest, setReconnectRequest] = useState(0);
+	const openTerminalWindow = useCallback(() => {
+		const popup = openSecureRuntimeWindow(window.open.bind(window), terminalWindowHref);
+		if (!popup) {
+			toast.error("Couldn't open Terminal", {
+				id: TERMINAL_WINDOW_LAUNCH_TOAST_ID,
+				description: "Allow pop-ups, then try again.",
+			});
+			return;
+		}
+		trackRuntimeWindow(deployment.resource.id, popup);
+	}, [deployment.resource.id, terminalWindowHref]);
 	const requestWebsocketUrl = useCallback(async () => {
 		const session = await createTerminalSession({ id: deployment.resource.id });
 		return session.websocket_url ?? "";
@@ -2213,16 +2233,18 @@ function TerminalTab({
 	const terminalAction = (
 		<>
 			<TerminalStatusIndicator status={terminalStatus} />
-			<Button
-				render={<a href={terminalHref} target="_blank" rel="noopener noreferrer" />}
-				nativeButton={false}
-				variant="outline"
-				size="icon-sm"
-				aria-label="Open terminal in new tab"
-				title="Open terminal in new tab"
-			>
-				<ExternalLink />
-			</Button>
+			{standalone ? null : (
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					onClick={openTerminalWindow}
+					aria-label="Open Terminal in new window"
+				>
+					<ExternalLink className="size-3.5" />
+					<span className="hidden sm:inline">Open in new window</span>
+				</Button>
+			)}
 			<Button
 				type="button"
 				variant="outline"

--- a/apps/web/src/lib/agent-routes.test.ts
+++ b/apps/web/src/lib/agent-routes.test.ts
@@ -19,6 +19,7 @@ import {
 	agentSessionDetailLink,
 	agentSkillDetailHref,
 	agentSkillDetailLink,
+	agentTerminalWindowHref,
 	agentVaultDetailHref,
 	agentVaultDetailLink,
 	CONNECTED_AGENT_SECTION_IDS,
@@ -45,6 +46,7 @@ describe("agent routes", () => {
 		expect(agentSectionHref("agent 1", "plugins")).toBe("/agents/agent%201/plugins");
 		expect(agentSectionHref("agent 1", "files")).toBe("/agents/agent%201/files");
 		expect(agentSectionHref("agent 1", "settings")).toBe("/agents/agent%201/settings");
+		expect(agentTerminalWindowHref("agent 1")).toBe("/terminal/agent%201");
 		expect(agentSessionDetailHref("agent 1", "session 1")).toBe(
 			"/agents/agent%201/sessions/session%201",
 		);

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -243,6 +243,10 @@ export function agentSectionHref(
 	return queryString ? `${path}?${queryString}` : path;
 }
 
+export function agentTerminalWindowHref(agentId: string): string {
+	return `/terminal/${encodeURIComponent(agentId)}`;
+}
+
 /** Typed TanStack Router options for canonical agent section navigation. */
 export function agentSectionLink(
 	agentId: string,

--- a/apps/web/src/pages/dashboard/agents/agent-detail-client.tsx
+++ b/apps/web/src/pages/dashboard/agents/agent-detail-client.tsx
@@ -21,15 +21,22 @@ export function AgentDetailClient({
 	environmentId,
 	section,
 	routeSearch,
+	standalone = false,
 }: {
 	environmentId: string;
 	section: AgentSectionId;
 	routeSearch: AgentRouteSearch;
+	standalone?: boolean;
 }) {
 	if (AgentHome) {
 		return (
 			<Suspense fallback={<ConnectedAgentDetailSkeleton hosted section={section} />}>
-				<AgentHome environmentId={environmentId} section={section} routeSearch={routeSearch} />
+				<AgentHome
+					environmentId={environmentId}
+					section={section}
+					routeSearch={routeSearch}
+					standalone={standalone}
+				/>
 			</Suspense>
 		);
 	}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as SignUpSplatRouteImport } from './routes/sign-up/$'
 import { Route as ProtectedDashboardIndexRouteImport } from './routes/_protected/_dashboard/index'
 import { Route as ProtectedDashboardAiProvidersRouteImport } from './routes/_protected/_dashboard/ai-providers'
 import { Route as ProtectedDashboardDeployRouteImport } from './routes/_protected/_dashboard/deploy'
+import { Route as ProtectedTerminalIdRouteImport } from './routes/_protected/terminal/$id'
 import { Route as ProtectedDashboardAgentsIndexRouteImport } from './routes/_protected/_dashboard/agents/index'
 import { Route as ProtectedDashboardAgentsIdRouteImport } from './routes/_protected/_dashboard/agents/$id'
 import { Route as ProtectedDashboardChannelsIndexRouteImport } from './routes/_protected/_dashboard/channels/index'
@@ -127,6 +128,11 @@ const ProtectedDashboardDeployRoute =
     path: '/deploy',
     getParentRoute: () => ProtectedDashboardRoute,
   } as any)
+const ProtectedTerminalIdRoute = ProtectedTerminalIdRouteImport.update({
+  id: '/terminal/$id',
+  path: '/terminal/$id',
+  getParentRoute: () => ProtectedRoute,
+} as any)
 const ProtectedDashboardAgentsIndexRoute =
   ProtectedDashboardAgentsIndexRouteImport.update({
     id: '/agents/',
@@ -333,6 +339,7 @@ export interface FileRoutesByFullPath {
   '/sign-up/$': typeof SignUpSplatRoute
   '/ai-providers': typeof ProtectedDashboardAiProvidersRoute
   '/deploy': typeof ProtectedDashboardDeployRoute
+  '/terminal/$id': typeof ProtectedTerminalIdRoute
   '/agents/$id': typeof ProtectedDashboardAgentsIdRouteWithChildren
   '/channels/$id': typeof ProtectedDashboardChannelsIdRoute
   '/connectors/$name': typeof ProtectedDashboardConnectorsNameRoute
@@ -379,6 +386,7 @@ export interface FileRoutesByTo {
   '/sign-up/$': typeof SignUpSplatRoute
   '/ai-providers': typeof ProtectedDashboardAiProvidersRoute
   '/deploy': typeof ProtectedDashboardDeployRoute
+  '/terminal/$id': typeof ProtectedTerminalIdRoute
   '/channels/$id': typeof ProtectedDashboardChannelsIdRoute
   '/connectors/$name': typeof ProtectedDashboardConnectorsNameRoute
   '/memories/$id': typeof ProtectedDashboardMemoriesIdRoute
@@ -425,6 +433,7 @@ export interface FileRoutesById {
   '/sign-up/$': typeof SignUpSplatRoute
   '/_protected/_dashboard/ai-providers': typeof ProtectedDashboardAiProvidersRoute
   '/_protected/_dashboard/deploy': typeof ProtectedDashboardDeployRoute
+  '/_protected/terminal/$id': typeof ProtectedTerminalIdRoute
   '/_protected/_dashboard/': typeof ProtectedDashboardIndexRoute
   '/_protected/_dashboard/agents/$id': typeof ProtectedDashboardAgentsIdRouteWithChildren
   '/_protected/_dashboard/channels/$id': typeof ProtectedDashboardChannelsIdRoute
@@ -474,6 +483,7 @@ export interface FileRouteTypes {
     | '/sign-up/$'
     | '/ai-providers'
     | '/deploy'
+    | '/terminal/$id'
     | '/agents/$id'
     | '/channels/$id'
     | '/connectors/$name'
@@ -520,6 +530,7 @@ export interface FileRouteTypes {
     | '/sign-up/$'
     | '/ai-providers'
     | '/deploy'
+    | '/terminal/$id'
     | '/channels/$id'
     | '/connectors/$name'
     | '/memories/$id'
@@ -565,6 +576,7 @@ export interface FileRouteTypes {
     | '/sign-up/$'
     | '/_protected/_dashboard/ai-providers'
     | '/_protected/_dashboard/deploy'
+    | '/_protected/terminal/$id'
     | '/_protected/_dashboard/'
     | '/_protected/_dashboard/agents/$id'
     | '/_protected/_dashboard/channels/$id'
@@ -709,6 +721,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/deploy'
       preLoaderRoute: typeof ProtectedDashboardDeployRouteImport
       parentRoute: typeof ProtectedDashboardRoute
+    }
+    '/_protected/terminal/$id': {
+      id: '/_protected/terminal/$id'
+      path: '/terminal/$id'
+      fullPath: '/terminal/$id'
+      preLoaderRoute: typeof ProtectedTerminalIdRouteImport
+      parentRoute: typeof ProtectedRoute
     }
     '/_protected/_dashboard/agents/': {
       id: '/_protected/_dashboard/agents/'
@@ -1054,12 +1073,14 @@ const ProtectedDashboardRouteWithChildren =
 interface ProtectedRouteChildren {
   ProtectedDashboardRoute: typeof ProtectedDashboardRouteWithChildren
   ProtectedCliAuthorizeRoute: typeof ProtectedCliAuthorizeRoute
+  ProtectedTerminalIdRoute: typeof ProtectedTerminalIdRoute
   ProtectedOauthCodexCallbackRoute: typeof ProtectedOauthCodexCallbackRoute
 }
 
 const ProtectedRouteChildren: ProtectedRouteChildren = {
   ProtectedDashboardRoute: ProtectedDashboardRouteWithChildren,
   ProtectedCliAuthorizeRoute: ProtectedCliAuthorizeRoute,
+  ProtectedTerminalIdRoute: ProtectedTerminalIdRoute,
   ProtectedOauthCodexCallbackRoute: ProtectedOauthCodexCallbackRoute,
 }
 

--- a/apps/web/src/routes/_protected/terminal/$id.tsx
+++ b/apps/web/src/routes/_protected/terminal/$id.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { isAgentRouteId } from "@/lib/agent-routes";
+import { routeHeadTitle } from "@/lib/document-title";
+import { AgentDetailClient } from "@/pages/dashboard/agents/agent-detail-client";
+
+const IS_HOSTED_BUILD = import.meta.env.VITE_CLAWDI_HOSTED === "true";
+
+export const Route = createFileRoute("/_protected/terminal/$id")({
+	beforeLoad: ({ params }) => {
+		if (!IS_HOSTED_BUILD || !isAgentRouteId(params.id)) throw notFound();
+	},
+	head: () => routeHeadTitle("Terminal"),
+	component: TerminalWindowRoute,
+});
+
+function TerminalWindowRoute() {
+	const { id } = Route.useParams();
+	return (
+		<main
+			data-mava-launcher="hidden"
+			className="flex h-svh min-h-0 w-full overflow-hidden bg-background"
+		>
+			<AgentDetailClient environmentId={id} section="terminal" routeSearch={{}} standalone />
+		</main>
+	);
+}


### PR DESCRIPTION
## Summary

- replace the incorrect new-tab dashboard link from #1254 with the same secure popup flow used by Agent Interface
- add a protected `/terminal/:agentId` surface that fills the browser viewport without the dashboard sidebar or header
- reuse the existing AgentHome, HostedAgentDetail, xterm session, reconnect, and flow-control implementation
- hide the recursive window action inside the standalone terminal

No backend, protocol, terminal implementation, dependency, or `clawdi-hosted` change is included.

## Verification

- Web typecheck
- 31 focused route/detail/terminal tests
- 22 existing OSS boundary tests
- OSS production build
- exact Biome check on changed files
- focused Chromium popup and standalone geometry test at 1440x900 and 390x844
- `git diff --check origin/main..HEAD`