### PR TITLE
fix(web): align live tool window actions

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3710,6 +3710,9 @@ test("hosted terminal opens a standalone fitted window", async ({ page, context 
 	await page.goto(terminalPath);
 	const openButton = page.getByRole("button", { name: "Open Terminal in new window" });
 	await expect(openButton).toContainText("Open in new window");
+	expect(
+		await openButton.evaluate((button) => button === button.parentElement?.lastElementChild),
+	).toBe(true);
 	const popupPromise = context.waitForEvent("page");
 	await openButton.click();
 	const popup = await popupPromise;

--- a/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.test.ts
@@ -26,13 +26,14 @@ describe("hosted agent detail header", () => {
 		);
 
 		// The Files iframe is only rendered after the deployment-scoped grant is
-		// primed; the new-tab launch bootstraps then navigates (no direct anchor).
+		// primed; the new-window launch bootstraps then navigates (no direct anchor).
 		expect(source).toContain("function FilesFrame(");
 		expect(source).toContain("useFilesGrantBootstrap(url)");
-		expect(source).toContain("useOpenFilesInNewTab(url)");
+		expect(source).toContain("useOpenFilesInNewWindow(url, deploymentId)");
 		expect(source).toContain("src={url}");
 		expect(source).toContain('title="Files"');
-		expect(source).toContain("Open in new tab");
+		expect(source).toContain("Open in new window");
+		expect(source.match(/<OpenInNewWindowButton/g)).toHaveLength(3);
 		expect(source).toContain("Opening Files…");
 		expect(source).not.toContain('target="_blank"');
 		expect(source).toContain("hostedAgentVisibleSectionIds(");

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -134,7 +134,7 @@ import {
 import { trackRuntimeWindow } from "@/hosted/agents/runtime-window-lifecycle";
 import {
 	useFilesGrantBootstrap,
-	useOpenFilesInNewTab,
+	useOpenFilesInNewWindow,
 } from "@/hosted/agents/use-files-grant-bootstrap";
 import { useBillingClient } from "@/hosted/billing/billing-client";
 import {
@@ -1758,23 +1758,18 @@ function FilesTab({ deployment, url }: { deployment: HostedDeployment; url: stri
 		);
 	}
 
-	return <FilesFrame url={url} />;
+	return <FilesFrame deploymentId={deployment.resource.id} url={url} />;
 }
 
-function FilesFrame({ url }: { url: string }) {
+function FilesFrame({ deploymentId, url }: { deploymentId: string; url: string }) {
 	const bootstrap = useFilesGrantBootstrap(url);
-	const openInNewTab = useOpenFilesInNewTab(url);
+	const openInNewWindow = useOpenFilesInNewWindow(url, deploymentId);
 
 	return (
 		<LiveToolFrame
 			icon={FolderOpen}
 			title="Files"
-			action={
-				<Button nativeButton variant="outline" size="sm" onClick={() => void openInNewTab()}>
-					Open in new tab
-					<ExternalLink className="size-3.5" />
-				</Button>
-			}
+			action={<OpenInNewWindowButton label="Files" onClick={() => void openInNewWindow()} />}
 		>
 			{bootstrap === "error" ? (
 				<EmptyState
@@ -1851,6 +1846,30 @@ function RuntimeUiCredentialRow({
 				</Button>
 			</div>
 		</div>
+	);
+}
+
+function OpenInNewWindowButton({
+	label,
+	onClick,
+	disabled = false,
+}: {
+	label: string;
+	onClick: () => void;
+	disabled?: boolean;
+}) {
+	return (
+		<Button
+			type="button"
+			variant="outline"
+			size="sm"
+			disabled={disabled}
+			onClick={onClick}
+			aria-label={`Open ${label} in new window`}
+		>
+			<ExternalLink className="size-3.5" />
+			<span className="hidden sm:inline">Open in new window</span>
+		</Button>
 	);
 }
 
@@ -2020,17 +2039,7 @@ function RuntimeUiAccessDialog({
 						Reconnect
 					</Button>
 				)}
-				<Button
-					type="button"
-					variant="outline"
-					size="sm"
-					disabled={!windowTarget}
-					onClick={openRuntime}
-					aria-label={`Open ${label} in new window`}
-				>
-					<ExternalLink className="size-3.5" />
-					<span className="hidden sm:inline">Open in new window</span>
-				</Button>
+				<OpenInNewWindowButton label={label} disabled={!windowTarget} onClick={openRuntime} />
 			</div>
 			{runtime === "hermes" ? (
 				<DialogContent
@@ -2233,18 +2242,6 @@ function TerminalTab({
 	const terminalAction = (
 		<>
 			<TerminalStatusIndicator status={terminalStatus} />
-			{standalone ? null : (
-				<Button
-					type="button"
-					variant="outline"
-					size="sm"
-					onClick={openTerminalWindow}
-					aria-label="Open Terminal in new window"
-				>
-					<ExternalLink className="size-3.5" />
-					<span className="hidden sm:inline">Open in new window</span>
-				</Button>
-			)}
 			<Button
 				type="button"
 				variant="outline"
@@ -2260,6 +2257,7 @@ function TerminalTab({
 					{terminalStatus === "disconnected" ? "Retry" : "Reconnect"}
 				</span>
 			</Button>
+			{standalone ? null : <OpenInNewWindowButton label="Terminal" onClick={openTerminalWindow} />}
 		</>
 	);
 

--- a/apps/web/src/hosted/agents/use-files-grant-bootstrap.ts
+++ b/apps/web/src/hosted/agents/use-files-grant-bootstrap.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { openSecureRuntimeWindow } from "@/hosted/agents/runtime-ui-credentials";
+import { trackRuntimeWindow } from "@/hosted/agents/runtime-window-lifecycle";
 import { useAuthToken } from "@/lib/auth-client";
 import { toastError } from "@/lib/toast";
 
@@ -50,36 +51,37 @@ export function useFilesGrantBootstrap(url: string): FilesGrantBootstrapState {
 }
 
 /**
- * Open the Files origin in a new tab. The blank tab is opened synchronously so
- * the browser does not block it, the grant is primed, then the tab navigates —
- * the token still only travels in the `Authorization` header.
+ * Open the Files origin in a new window. The blank window is opened synchronously
+ * so the browser does not block it, the grant is primed, then it navigates. The
+ * token still only travels in the `Authorization` header.
  */
-export function useOpenFilesInNewTab(url: string): () => Promise<void> {
+export function useOpenFilesInNewWindow(url: string, deploymentId: string): () => Promise<void> {
 	const { getToken } = useAuthToken();
 	return useCallback(async () => {
-		const tab = openSecureRuntimeWindow(window.open.bind(window));
-		if (!tab) {
+		const popup = openSecureRuntimeWindow(window.open.bind(window));
+		if (!popup) {
 			toastError("Couldn't open Files", {
-				id: "files-new-tab",
+				id: "files-window-launch",
 				description: "Allow pop-ups for Clawdi, then try again.",
 			});
 			return;
 		}
+		trackRuntimeWindow(deploymentId, popup);
 		try {
 			const token = await getToken();
 			if (!token) throw new Error("No Clerk session token");
 			await primeFilesGrant(url, token);
-			tab.location.replace(url);
+			popup.location.replace(url);
 		} catch {
 			try {
-				tab.close();
+				popup.close();
 			} catch {
 				// Browser isolation may have severed the WindowProxy.
 			}
 			toastError("Couldn't open Files", {
-				id: "files-new-tab",
+				id: "files-window-launch",
 				description: "Files access couldn't be authenticated. Refresh the page and try again.",
 			});
 		}
-	}, [url, getToken]);
+	}, [deploymentId, url, getToken]);
 }


### PR DESCRIPTION
## Summary
- use one `Open in new window` button for Agent Interface, Files, and Terminal
- keep the open action rightmost and align Terminal action ordering
- track Files windows with the same runtime window lifecycle

## Verification
- `bash scripts/test.sh web src/hosted/agents/hosted-agent-detail.test.ts`
- Biome 2.5.9 exact check
- `git diff --check`