### PR TITLE
feat(web): polish session search navigation

### DIFF
--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -1,0 +1,121 @@
+import { expect, type Route, test } from "@playwright/test";
+
+const SESSION_ID = "11111111-1111-4111-8111-111111111111";
+const AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const now = "2026-08-28T10:00:00.000Z";
+const anchor = { kind: "event_seq", position: 7, revision: "events:head-hash" };
+
+const session = {
+	id: SESSION_ID,
+	local_session_id: "local-session-search",
+	project_path: "/workspace/clawdi",
+	agent_name: "Search Codex",
+	agent_display_name: "Search Codex",
+	agent_default_name: "Codex",
+	agent_type: "codex",
+	machine_name: "search-machine",
+	started_at: now,
+	ended_at: null,
+	updated_at: now,
+	last_activity_at: now,
+	duration_seconds: 120,
+	message_count: 2,
+	input_tokens: 120,
+	output_tokens: 80,
+	cache_read_tokens: 0,
+	model: "gpt-5",
+	models_used: ["gpt-5"],
+	summary: "Fix authentication timeout",
+	tags: [],
+	status: "completed",
+	content_hash: null,
+	content_protocol: "events-v1",
+	event_head_hash: "head-hash",
+	is_shared: false,
+	related_refs: null,
+	has_content: true,
+};
+
+async function fulfillJson(route: Route, body: unknown) {
+	await route.fulfill({
+		status: 200,
+		contentType: "application/json",
+		body: JSON.stringify(body),
+	});
+}
+
+test("opens a message search result and returns to the same filtered list", async ({ page }) => {
+	await page.setViewportSize({ width: 390, height: 844 });
+	await page.route("**/v1/**", async (route) => {
+		const url = new URL(route.request().url());
+		if (url.pathname === "/v1/agents") {
+			return fulfillJson(route, [
+				{
+					id: AGENT_ID,
+					name: "Search Codex",
+					display_name: "Search Codex",
+					default_name: "Codex",
+					machine_name: "search-machine",
+					agent_type: "codex",
+				},
+			]);
+		}
+		if (url.pathname === "/v1/sessions") {
+			return fulfillJson(route, {
+				items: [
+					{
+						...session,
+						search_match: {
+							role: "assistant",
+							excerpt: "Fixed the authentication timeout without retrying every request",
+							anchor,
+						},
+					},
+				],
+				total: 26,
+				page: 2,
+				page_size: 25,
+			});
+		}
+		if (url.pathname === `/v1/sessions/${SESSION_ID}`) {
+			return fulfillJson(route, session);
+		}
+		if (url.pathname === `/v1/sessions/${SESSION_ID}/messages`) {
+			return fulfillJson(route, {
+				items: [
+					{
+						role: "assistant",
+						content: "Fixed the authentication timeout without retrying every request",
+						model: "gpt-5",
+						timestamp: now,
+					},
+				],
+				total: 1,
+				offset: 0,
+				limit: 100,
+				anchor_offset: 0,
+			});
+		}
+		return fulfillJson(route, {});
+	});
+
+	await page.goto("/sessions?q=authentication%20timeout&agent=codex&page=2&view=table");
+	const visibleResult = page.locator('[data-testid="session-card"]:visible');
+	await expect(visibleResult.locator("mark")).toHaveText("authentication timeout");
+
+	await visibleResult
+		.getByRole("link", { name: "Open session Fix authentication timeout" })
+		.click();
+	await expect(page.locator('[data-search-match="true"]')).toBeVisible();
+
+	await page.getByText("Back to Sessions", { exact: true }).click();
+	await expect(page).toHaveURL((url) => {
+		return (
+			url.pathname === "/sessions" &&
+			url.searchParams.get("q") === "authentication timeout" &&
+			url.searchParams.get("agent") === "codex" &&
+			url.searchParams.get("page") === "2" &&
+			url.searchParams.get("view") === "table"
+		);
+	});
+});

--- a/apps/web/src/components/sessions/search-match-excerpt.test.tsx
+++ b/apps/web/src/components/sessions/search-match-excerpt.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SessionSearchMatchExcerpt } from "@/components/sessions/search-match-excerpt";
+
+const anchor = { kind: "event_seq" as const, position: 4, revision: "events:revision" };
+
+describe("SessionSearchMatchExcerpt", () => {
+	test("highlights the matching phrase without hiding the surrounding excerpt", () => {
+		const markup = renderToStaticMarkup(
+			createElement(SessionSearchMatchExcerpt, {
+				match: { role: "assistant", excerpt: "Fixed the authentication timeout", anchor },
+				query: "authentication timeout",
+			}),
+		);
+
+		expect(markup).toContain("Fixed the ");
+		expect(markup).toContain(">authentication timeout</mark>");
+	});
+
+	test("renders query text as escaped content", () => {
+		const markup = renderToStaticMarkup(
+			createElement(SessionSearchMatchExcerpt, {
+				match: { role: "user", excerpt: "Find <script> safely", anchor },
+				query: "<script>",
+			}),
+		);
+
+		expect(markup).toContain("&lt;script&gt;");
+		expect(markup).not.toContain("<script>");
+	});
+});

--- a/apps/web/src/components/sessions/search-match-excerpt.tsx
+++ b/apps/web/src/components/sessions/search-match-excerpt.tsx
@@ -1,0 +1,60 @@
+import type { SessionListItem } from "@/lib/api-schemas";
+import { cn } from "@/lib/utils";
+
+type SessionSearchMatch = NonNullable<SessionListItem["search_match"]>;
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function searchTerms(query: string): string[] {
+	const normalized = query.trim();
+	if (!normalized) return [];
+
+	const candidates = [normalized, ...(normalized.match(/[\p{L}\p{N}_]+/gu) ?? [])];
+	const seen = new Set<string>();
+	return candidates
+		.filter((term) => term.length > 1 || normalized.length === 1)
+		.filter((term) => {
+			const key = term.toLocaleLowerCase();
+			if (seen.has(key)) return false;
+			seen.add(key);
+			return true;
+		})
+		.sort((a, b) => b.length - a.length)
+		.slice(0, 24);
+}
+
+function HighlightedExcerpt({ excerpt, query }: { excerpt: string; query: string }) {
+	const terms = searchTerms(query);
+	if (terms.length === 0) return excerpt;
+
+	const pattern = new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "giu");
+	return excerpt.split(pattern).map((part, index) =>
+		terms.some((term) => term.toLocaleLowerCase() === part.toLocaleLowerCase()) ? (
+			<mark key={`${index}:${part}`} className="rounded-sm bg-primary/15 px-0.5 text-inherit">
+				{part}
+			</mark>
+		) : (
+			part
+		),
+	);
+}
+
+export function SessionSearchMatchExcerpt({
+	match,
+	query,
+	className,
+}: {
+	match: SessionSearchMatch;
+	query: string;
+	className?: string;
+}) {
+	return (
+		<span className={cn("truncate", className)} title={match.excerpt}>
+			<span className="font-medium capitalize">{match.role}</span>
+			{": "}
+			<HighlightedExcerpt excerpt={match.excerpt} query={query} />
+		</span>
+	);
+}

--- a/apps/web/src/components/sessions/session-columns.tsx
+++ b/apps/web/src/components/sessions/session-columns.tsx
@@ -1,51 +1,61 @@
 "use client";
 
 import { Link } from "@tanstack/react-router";
+import { SessionSearchMatchExcerpt } from "@/components/sessions/search-match-excerpt";
 import { SessionAgentLabel } from "@/components/sessions/session-agent-label";
 import type { DataTableColumnDef } from "@/components/ui/data-table";
 import { DataTableColumnHeader } from "@/components/ui/data-table-column-header";
 import type { SessionListItem } from "@/lib/api-schemas";
-import { sessionDetailLink } from "@/lib/session-search-anchor";
+import type { sessionDetailLink } from "@/lib/session-search-anchor";
 import { formatAbsoluteTooltip, formatSessionSummary, relativeTime } from "@/lib/utils";
 
-const summaryColumn: DataTableColumnDef<SessionListItem> = {
-	id: "summary",
-	accessorKey: "summary",
-	header: "Summary",
-	cell: ({ row }) => {
-		const s = row.original;
-		const title = formatSessionSummary(s.summary) || s.local_session_id.slice(0, 8);
-		const projectFolder = s.project_path?.split("/").pop();
-		return (
-			<div className="min-w-0">
-				<div className="truncate" title={title}>
-					<Link
-						{...sessionDetailLink(s)}
-						onClick={(e) => e.stopPropagation()}
-						className="font-medium hover:underline"
-					>
-						{title}
-					</Link>
+function summaryColumn({
+	sessionLink,
+	searchQuery,
+}: {
+	sessionLink: (session: SessionListItem) => ReturnType<typeof sessionDetailLink>;
+	searchQuery: string;
+}): DataTableColumnDef<SessionListItem> {
+	return {
+		id: "summary",
+		accessorKey: "summary",
+		header: "Summary",
+		cell: ({ row }) => {
+			const s = row.original;
+			const title = formatSessionSummary(s.summary) || s.local_session_id.slice(0, 8);
+			const projectFolder = s.project_path?.split("/").pop();
+			return (
+				<div className="min-w-0">
+					<div className="truncate" title={title}>
+						<Link
+							{...sessionLink(s)}
+							onClick={(e) => e.stopPropagation()}
+							className="font-medium hover:underline"
+						>
+							{title}
+						</Link>
+					</div>
+					{projectFolder ? (
+						<div
+							className="truncate text-xs text-muted-foreground"
+							title={s.project_path ?? undefined}
+						>
+							{projectFolder}
+						</div>
+					) : null}
+					{s.search_match ? (
+						<SessionSearchMatchExcerpt
+							match={s.search_match}
+							query={searchQuery}
+							className="block text-xs text-foreground/70"
+						/>
+					) : null}
 				</div>
-				{projectFolder ? (
-					<div
-						className="truncate text-xs text-muted-foreground"
-						title={s.project_path ?? undefined}
-					>
-						{projectFolder}
-					</div>
-				) : null}
-				{s.search_match ? (
-					<div className="truncate text-xs text-foreground/70">
-						<span className="font-medium capitalize">{s.search_match.role}</span>
-						{`: ${s.search_match.excerpt}`}
-					</div>
-				) : null}
-			</div>
-		);
-	},
-	size: 420,
-};
+			);
+		},
+		size: 420,
+	};
+}
 
 const agentColumn: DataTableColumnDef<SessionListItem> = {
 	id: "agent",
@@ -127,23 +137,19 @@ const tokensColumn: DataTableColumnDef<SessionListItem> = {
 	size: 90,
 };
 
-export const sessionColumns: DataTableColumnDef<SessionListItem>[] = [
-	summaryColumn,
-	agentColumn,
-	messagesColumn,
-	tokensColumn,
-	startedColumn,
-	lastActivityColumn,
-];
-
-const lastActivityColumnPlain: DataTableColumnDef<SessionListItem> = {
-	...lastActivityColumn,
-	enableSorting: false,
-	header: "Last activity",
-};
-
-export const sessionColumnsCompact: DataTableColumnDef<SessionListItem>[] = [
-	summaryColumn,
-	agentColumn,
-	lastActivityColumnPlain,
-];
+export function sessionColumns({
+	sessionLink,
+	searchQuery,
+}: {
+	sessionLink: (session: SessionListItem) => ReturnType<typeof sessionDetailLink>;
+	searchQuery: string;
+}): DataTableColumnDef<SessionListItem>[] {
+	return [
+		summaryColumn({ sessionLink, searchQuery }),
+		agentColumn,
+		messagesColumn,
+		tokensColumn,
+		startedColumn,
+		lastActivityColumn,
+	];
+}

--- a/apps/web/src/components/sessions/session-feed.tsx
+++ b/apps/web/src/components/sessions/session-feed.tsx
@@ -7,6 +7,7 @@ import { agentIdentity } from "@/components/dashboard/agent-label";
 import { EmptyState, type EmptyStateVariant } from "@/components/empty-state";
 import { ENTITY_CARD_BASE } from "@/components/entity-card";
 import { SectionLabel } from "@/components/section-label";
+import { SessionSearchMatchExcerpt } from "@/components/sessions/search-match-excerpt";
 import { sessionAgentIdentityInput } from "@/components/sessions/session-agent-label";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { SessionListItem } from "@/lib/api-schemas";
@@ -126,6 +127,7 @@ export function SessionFeed({
 	showAgent = true,
 	quietAutomated = true,
 	sessionLink = sessionDetailLink,
+	searchQuery = "",
 }: {
 	sessions: SessionListItem[];
 	isLoading: boolean;
@@ -141,6 +143,7 @@ export function SessionFeed({
 	quietAutomated?: boolean;
 	/** Build the detail link for the current navigation scope. */
 	sessionLink?: (session: SessionListItem) => SessionLinkOptions;
+	searchQuery?: string;
 }) {
 	if (isLoading) {
 		return (
@@ -166,6 +169,7 @@ export function SessionFeed({
 						showAgent={showAgent}
 						quietAutomated={quietAutomated}
 						link={sessionLink(session)}
+						searchQuery={searchQuery}
 					/>
 				))}
 			</div>
@@ -195,6 +199,7 @@ export function SessionFeed({
 								showAgent={showAgent}
 								quietAutomated={quietAutomated}
 								link={sessionLink(session)}
+								searchQuery={searchQuery}
 							/>
 						))}
 					</div>
@@ -209,11 +214,13 @@ export function SessionCard({
 	showAgent = true,
 	quietAutomated = true,
 	link,
+	searchQuery = "",
 }: {
 	session: SessionListItem;
 	showAgent?: boolean;
 	quietAutomated?: boolean;
 	link: SessionLinkOptions;
+	searchQuery?: string;
 }) {
 	const title = formatSessionSummary(session.summary) || session.local_session_id.slice(0, 8);
 	const projectFolder = session.project_path?.split("/").pop();
@@ -267,10 +274,11 @@ export function SessionCard({
 						{title}
 					</span>
 					{session.search_match ? (
-						<span className="mt-0.5 block truncate text-xs leading-4 text-foreground/75">
-							<span className="font-medium capitalize">{session.search_match.role}</span>
-							{`: ${session.search_match.excerpt}`}
-						</span>
+						<SessionSearchMatchExcerpt
+							match={session.search_match}
+							query={searchQuery}
+							className="mt-0.5 block text-xs leading-4 text-foreground/75"
+						/>
 					) : null}
 					<span
 						data-testid="session-card-meta"

--- a/apps/web/src/lib/session-search-anchor.test.ts
+++ b/apps/web/src/lib/session-search-anchor.test.ts
@@ -7,14 +7,17 @@ import {
 
 describe("Session search anchors", () => {
 	test("builds a detail link and round-trips a complete anchor", () => {
-		const link = sessionDetailLink({
-			id: "session-id",
-			search_match: {
-				role: "assistant",
-				excerpt: "matching text",
-				anchor: { kind: "event_seq", position: 42, revision: "events:revision" },
+		const link = sessionDetailLink(
+			{
+				id: "session-id",
+				search_match: {
+					role: "assistant",
+					excerpt: "matching text",
+					anchor: { kind: "event_seq", position: 42, revision: "events:revision" },
+				},
 			},
-		});
+			{ returnTo: "/sessions?q=matching&page=2" },
+		);
 		expect(link).toEqual({
 			to: "/sessions/$id",
 			params: { id: "session-id" },
@@ -22,6 +25,7 @@ describe("Session search anchors", () => {
 				matchKind: "event_seq",
 				matchPosition: 42,
 				matchRevision: "events:revision",
+				returnTo: "/sessions?q=matching&page=2",
 			},
 		});
 		expect(sessionSearchAnchorFromSearch(validateSessionDetailSearch(link.search))).toEqual({
@@ -40,5 +44,13 @@ describe("Session search anchors", () => {
 				matchRevision: "revision",
 			}),
 		).toEqual({});
+	});
+
+	test("keeps only a local Sessions collection return target", () => {
+		expect(validateSessionDetailSearch({ returnTo: "/sessions?q=auth&page=3" })).toEqual({
+			returnTo: "/sessions?q=auth&page=3",
+		});
+		expect(validateSessionDetailSearch({ returnTo: "https://example.com/sessions" })).toEqual({});
+		expect(validateSessionDetailSearch({ returnTo: "/sessions/unrelated" })).toEqual({});
 	});
 });

--- a/apps/web/src/lib/session-search-anchor.ts
+++ b/apps/web/src/lib/session-search-anchor.ts
@@ -6,6 +6,7 @@ export interface SessionDetailSearch {
 	matchKind?: SessionSearchAnchor["kind"];
 	matchPosition?: number;
 	matchRevision?: string;
+	returnTo?: string;
 }
 
 function validPosition(value: unknown): number | undefined {
@@ -15,6 +16,7 @@ function validPosition(value: unknown): number | undefined {
 }
 
 export function validateSessionDetailSearch(search: Record<string, unknown>): SessionDetailSearch {
+	const returnTo = normalizeSessionListReturnTo(search.returnTo);
 	const kind =
 		search.matchKind === "snapshot_offset" || search.matchKind === "event_seq"
 			? search.matchKind
@@ -26,8 +28,27 @@ export function validateSessionDetailSearch(search: Record<string, unknown>): Se
 		search.matchRevision.length <= 80
 			? search.matchRevision
 			: undefined;
-	if (!kind || position === undefined || !revision) return {};
-	return { matchKind: kind, matchPosition: position, matchRevision: revision };
+	if (!kind || position === undefined || !revision) return returnTo ? { returnTo } : {};
+	return {
+		matchKind: kind,
+		matchPosition: position,
+		matchRevision: revision,
+		...(returnTo ? { returnTo } : {}),
+	};
+}
+
+export function normalizeSessionListReturnTo(value: unknown): string | undefined {
+	if (typeof value !== "string" || value.length === 0 || value.length > 2048) return undefined;
+	try {
+		const base = new URL("https://clawdi.invalid");
+		const parsed = new URL(value, base);
+		if (parsed.origin !== base.origin || parsed.pathname !== "/sessions" || parsed.hash) {
+			return undefined;
+		}
+		return `${parsed.pathname}${parsed.search}`;
+	} catch {
+		return undefined;
+	}
 }
 
 export function sessionSearchAnchorFromSearch(
@@ -43,17 +64,24 @@ export function sessionSearchAnchorFromSearch(
 	};
 }
 
-export function sessionDetailLink(session: Pick<SessionListItem, "id" | "search_match">) {
+export function sessionDetailLink(
+	session: Pick<SessionListItem, "id" | "search_match">,
+	options: { returnTo?: string } = {},
+) {
 	const anchor = session.search_match?.anchor;
+	const returnTo = normalizeSessionListReturnTo(options.returnTo);
 	return {
 		to: "/sessions/$id" as const,
 		params: { id: session.id },
-		search: anchor
-			? {
-					matchKind: anchor.kind,
-					matchPosition: anchor.position,
-					matchRevision: anchor.revision,
-				}
-			: {},
+		search: {
+			...(anchor
+				? {
+						matchKind: anchor.kind,
+						matchPosition: anchor.position,
+						matchRevision: anchor.revision,
+					}
+				: {}),
+			...(returnTo ? { returnTo } : {}),
+		},
 	};
 }

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -55,28 +55,34 @@ import { cn, formatNumber, formatSessionSummary, relativeTime } from "@/lib/util
 export default function SessionDetailPage({
 	sessionId,
 	searchAnchor,
+	returnTo,
 }: {
 	sessionId: string;
 	searchAnchor?: SessionSearchAnchor;
+	returnTo?: string;
 }) {
-	return <SessionDetailContent sessionId={sessionId} searchAnchor={searchAnchor} />;
+	return (
+		<SessionDetailContent sessionId={sessionId} searchAnchor={searchAnchor} returnTo={returnTo} />
+	);
 }
 
 export function SessionDetailContent({
 	sessionId,
 	agentId,
 	searchAnchor,
+	returnTo,
 }: {
 	sessionId: string;
 	agentId?: string | null;
 	searchAnchor?: SessionSearchAnchor;
+	returnTo?: string;
 }) {
 	const api = useApi();
 	const $api = useOpenApi();
 	const queryClient = useQueryClient();
 	const router = useRouter();
 	const { user } = useCurrentUser();
-	const sessionsHref = agentId ? agentSectionHref(agentId, "sessions") : "/sessions";
+	const sessionsHref = agentId ? agentSectionHref(agentId, "sessions") : (returnTo ?? "/sessions");
 	const deleteSession = $api.useMutation("delete", "/v1/sessions/{session_id}", {
 		onSuccess: () => {
 			toast.success("Cloud Session permanently deleted", {

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useLocation } from "@tanstack/react-router";
 import type { SortingState } from "@tanstack/react-table";
 import { LayoutList, Table2 } from "lucide-react";
 import { parseAsBoolean, parseAsString, parseAsStringLiteral, useQueryStates } from "nuqs";
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import { agentTypeLabel } from "@/components/dashboard/agent-label";
@@ -67,6 +68,9 @@ export default function SessionsPage() {
 function SessionsListInner() {
 	const $api = useOpenApi();
 	const queryClient = useQueryClient();
+	const returnTo = useLocation({
+		select: (location) => `${location.pathname}${location.searchStr}`,
+	});
 
 	// All filter / sort / pagination state lives in the URL via
 	// nuqs. `clearOnDefault: true` keeps `/sessions` clean when
@@ -94,6 +98,14 @@ function SessionsListInner() {
 	);
 
 	const debouncedSearch = useDebouncedValue(params.q, 250);
+	const getSessionLink = useCallback(
+		(session: SessionListItem) => sessionDetailLink(session, { returnTo }),
+		[returnTo],
+	);
+	const columns = useMemo(
+		() => sessionColumns({ sessionLink: getSessionLink, searchQuery: debouncedSearch }),
+		[getSessionLink, debouncedSearch],
+	);
 
 	// Tanstack-react-table owns sorting state internally; mirror it
 	// onto our nuqs-backed sort/order params via the table's
@@ -345,11 +357,11 @@ function SessionsListInner() {
 					{params.view === "table" ? (
 						<div className="hidden md:block">
 							<DataTable
-								columns={sessionColumns}
+								columns={columns}
 								data={data?.items ?? []}
 								isLoading={isLoading}
 								emptyMessage={emptyMessage}
-								getRowLink={sessionDetailLink}
+								getRowLink={getSessionLink}
 								rowAriaLabel={(s) => `Open session ${s.local_session_id}`}
 								sorting={sorting}
 								onSortingChange={(updater) => {
@@ -390,6 +402,8 @@ function SessionsListInner() {
 							grouped={groupable}
 							groupBy={params.sort === "started_at" ? "started_at" : "last_activity_at"}
 							quietAutomated={debouncedSearch === ""}
+							searchQuery={debouncedSearch}
+							sessionLink={getSessionLink}
 						/>
 					</div>
 					{sessionFooter}

--- a/apps/web/src/routes/_protected/_dashboard/sessions/$id.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/sessions/$id.tsx
@@ -14,6 +14,9 @@ export const Route = createFileRoute("/_protected/_dashboard/sessions/$id")({
 
 function SessionDetailRoute() {
 	const { id } = Route.useParams();
-	const searchAnchor = sessionSearchAnchorFromSearch(Route.useSearch());
-	return <SessionDetailPage sessionId={id} searchAnchor={searchAnchor} />;
+	const search = Route.useSearch();
+	const searchAnchor = sessionSearchAnchorFromSearch(search);
+	return (
+		<SessionDetailPage sessionId={id} searchAnchor={searchAnchor} returnTo={search.returnTo} />
+	);
 }


### PR DESCRIPTION
## Summary

- highlight exact query phrases and terms in Session search excerpts across feed and table views
- preserve the full Session list search, filters, pagination, and view state when opening a result and returning
- validate return targets as local `/sessions` URLs and cover the complete browser flow

## Verification

- Docker-backed full Web suite: typecheck, all Web unit tests, OSS production build
- Playwright Chromium: search result -> anchored message -> return to filtered list
- Biome 2.5.9 on all changed files
- `git diff --check`

The local commit hook could not run because `lefthook` is not on the host PATH; the equivalent repository checks above passed in isolated runners.