### PR TITLE
fix(cli): project OpenClaw memory search config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ Package: `clawdi@0.14.26`
 
 ### Fixed
 
-- Managed OpenClaw embedding settings now use the compatible top-level
-  `memory.search` configuration and are cleared when the managed provider is removed.
+- Managed OpenClaw embedding settings now use top-level `memory.search`, repair
+  the legacy invalid config path, and clear when the managed provider is removed.
 
 ## Clawdi CLI v0.14.25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ Package: `clawdi@0.14.26`
 
 ### Fixed
 
-- Managed OpenClaw embedding settings now use top-level `memory.search`, repair
-  the legacy invalid config path, and clear when the managed provider is removed.
+- Managed OpenClaw embedding settings now follow the installed config schema,
+  repair the incompatible legacy path, and clear when the managed provider is removed.
 
 ## Clawdi CLI v0.14.25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ database migration, CI, and implementation details.
 
 - Newest-first Session detail pages now paginate from the actual visible transcript instead of relying on separately reported message counts, including for incrementally appended event chunks.
 
+## Clawdi CLI v0.14.26
+
+Package: `clawdi@0.14.26`
+
+### Fixed
+
+- Managed OpenClaw embedding settings now use the compatible top-level
+  `memory.search` configuration and are cleared when the managed provider is removed.
+
 ## Clawdi CLI v0.14.25
 
 Package: `clawdi@0.14.25`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.25",
+      "version": "0.14.26",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.25",
+	"version": "0.14.26",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/lib/ai-provider-projection.test.ts
+++ b/packages/cli/src/lib/ai-provider-projection.test.ts
@@ -212,6 +212,7 @@ describe("AI provider projection", () => {
 			agents?: {
 				defaults?: {
 					model?: { primary?: string };
+					memorySearch?: null;
 				};
 			};
 			memory?: { search?: { model?: string; provider?: string } };
@@ -223,7 +224,7 @@ describe("AI provider projection", () => {
 			};
 		};
 		expect(openclawPatch.agents?.defaults?.model?.primary).toBe("clawdi/grok-4.6");
-		expect(openclawPatch.agents?.defaults).not.toHaveProperty("memorySearch");
+		expect(openclawPatch.agents?.defaults?.memorySearch).toBeNull();
 		expect(openclawPatch.memory?.search).toEqual({
 			provider: CLAWDI_MANAGED_PROVIDER_ID,
 			model: "manifest-embedding-model",
@@ -312,11 +313,11 @@ describe("AI provider projection", () => {
 				[CLAWDI_MANAGED_PROVIDER_ID],
 			).content,
 		) as {
-			agents?: { defaults?: Record<string, unknown> };
+			agents?: { defaults?: { memorySearch?: null } };
 			memory?: { search?: { model?: null; provider?: null } };
 			models?: { providers?: Record<string, unknown> };
 		};
-		expect(managedToByokPatch.agents?.defaults).not.toHaveProperty("memorySearch");
+		expect(managedToByokPatch.agents?.defaults?.memorySearch).toBeNull();
 		expect(managedToByokPatch.memory?.search).toEqual({
 			provider: null,
 			model: null,

--- a/packages/cli/src/lib/ai-provider-projection.test.ts
+++ b/packages/cli/src/lib/ai-provider-projection.test.ts
@@ -348,13 +348,24 @@ describe("AI provider projection", () => {
 					api_mode: "google_generate_content",
 					auth: { type: "api_key", source: "managed" },
 					runtime_env_name: "GEMINI_API_KEY",
-					models: [{ id: "gemini-2.5-pro" }],
+					models: [
+						{ id: "gemini-2.5-pro" },
+						{
+							id: "gemini-embedding-001",
+							capabilities: { embeddings: true, chat: false },
+						},
+					],
 				},
 			],
-			defaults: { chat_provider_id: "gemini-main" },
+			defaults: {
+				chat_provider_id: "gemini-main",
+				embedding_provider_id: "gemini-main",
+			},
 		};
 
-		expect(buildAgentTargetProjection("openclaw", catalog).provider_ids).toEqual(["gemini-main"]);
+		const openclaw = buildAgentTargetProjection("openclaw", catalog);
+		expect(openclaw.provider_ids).toEqual(["gemini-main"]);
+		expect(JSON.parse(openclaw.files[0]?.content ?? "{}").agents.defaults.memorySearch).toBeNull();
 		expect(() => buildAgentTargetProjection("hermes", catalog)).toThrow(
 			"does not map to a verified Hermes custom-provider transport",
 		);

--- a/packages/cli/src/lib/ai-provider-projection.test.ts
+++ b/packages/cli/src/lib/ai-provider-projection.test.ts
@@ -212,9 +212,9 @@ describe("AI provider projection", () => {
 			agents?: {
 				defaults?: {
 					model?: { primary?: string };
-					memorySearch?: { model?: string; provider?: string };
 				};
 			};
+			memory?: { search?: { model?: string; provider?: string } };
 			models?: {
 				providers?: Record<
 					string,
@@ -223,7 +223,8 @@ describe("AI provider projection", () => {
 			};
 		};
 		expect(openclawPatch.agents?.defaults?.model?.primary).toBe("clawdi/grok-4.6");
-		expect(openclawPatch.agents?.defaults?.memorySearch).toEqual({
+		expect(openclawPatch.agents?.defaults).not.toHaveProperty("memorySearch");
+		expect(openclawPatch.memory?.search).toEqual({
 			provider: CLAWDI_MANAGED_PROVIDER_ID,
 			model: "manifest-embedding-model",
 		});
@@ -301,7 +302,7 @@ describe("AI provider projection", () => {
 		expect(openclaw.files[0]?.content).toContain('"api": "openai-responses"');
 		expect(openclaw.files[0]?.content).toContain('"id": "OPENAI_API_KEY"');
 		expect(openclaw.files[0]?.content).not.toContain('"auth": "api-key"');
-		expect(openclaw.files[0]?.content).not.toContain('"memorySearch"');
+		expect(openclaw.files[0]?.content).not.toContain('"memory"');
 		const managedToByokPatch = JSON.parse(
 			buildOpenClawHostedProviderPatch(
 				{
@@ -311,10 +312,12 @@ describe("AI provider projection", () => {
 				[CLAWDI_MANAGED_PROVIDER_ID],
 			).content,
 		) as {
-			agents?: { defaults?: { memorySearch?: { model?: null; provider?: null } } };
+			agents?: { defaults?: Record<string, unknown> };
+			memory?: { search?: { model?: null; provider?: null } };
 			models?: { providers?: Record<string, unknown> };
 		};
-		expect(managedToByokPatch.agents?.defaults?.memorySearch).toEqual({
+		expect(managedToByokPatch.agents?.defaults).not.toHaveProperty("memorySearch");
+		expect(managedToByokPatch.memory?.search).toEqual({
 			provider: null,
 			model: null,
 		});

--- a/packages/cli/src/lib/ai-provider-projection.ts
+++ b/packages/cli/src/lib/ai-provider-projection.ts
@@ -303,9 +303,7 @@ function buildOpenClawProjection(
 	primaryModel: AgentPrimaryModel,
 	embeddingModel: AgentPrimaryModel | undefined,
 ): string {
-	const hasClawdiManagedProvider = providers.some(
-		(provider) => provider.id === CLAWDI_MANAGED_PROVIDER_ID && provider.managed_by === "clawdi",
-	);
+	const hasClawdiManagedProvider = providers.some((provider) => provider.managed_by === "clawdi");
 	const projectedProviders = Object.fromEntries(
 		providers
 			.filter((provider) => !usesNativeCodexOpenAiProvider(provider))
@@ -347,6 +345,7 @@ function buildOpenClawProjection(
 				model: {
 					primary: openClawDefaultModelRef(primaryProvider, primaryModel.model),
 				},
+				memorySearch: hasClawdiManagedProvider ? null : undefined,
 			},
 		},
 		memory: embeddingModel

--- a/packages/cli/src/lib/ai-provider-projection.ts
+++ b/packages/cli/src/lib/ai-provider-projection.ts
@@ -347,16 +347,18 @@ function buildOpenClawProjection(
 				model: {
 					primary: openClawDefaultModelRef(primaryProvider, primaryModel.model),
 				},
-				memorySearch: embeddingModel
-					? {
-							provider: embeddingModel.provider_id,
-							model: embeddingModel.model,
-						}
-					: hasClawdiManagedProvider
-						? { provider: null, model: null }
-						: undefined,
 			},
 		},
+		memory: embeddingModel
+			? {
+					search: {
+						provider: embeddingModel.provider_id,
+						model: embeddingModel.model,
+					},
+				}
+			: hasClawdiManagedProvider
+				? { search: { provider: null, model: null } }
+				: undefined,
 		models:
 			Object.keys(projectedProviders).length > 0
 				? {

--- a/packages/cli/src/lib/ai-provider-projection.ts
+++ b/packages/cli/src/lib/ai-provider-projection.ts
@@ -345,7 +345,7 @@ function buildOpenClawProjection(
 				model: {
 					primary: openClawDefaultModelRef(primaryProvider, primaryModel.model),
 				},
-				memorySearch: hasClawdiManagedProvider ? null : undefined,
+				memorySearch: embeddingModel || hasClawdiManagedProvider ? null : undefined,
 			},
 		},
 		memory: embeddingModel

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -756,11 +756,12 @@ function mergeProviderDeletes(
 	if (runtime === "openclaw") {
 		patch.models = container;
 		if (deletedProviderIds.some(isClawdiManagedV2ProviderId)) {
-			const agents = { ...(recordValue(patch.agents) ?? {}) };
-			const defaults = { ...(recordValue(agents.defaults) ?? {}) };
-			defaults.memorySearch = { provider: null, model: null };
-			agents.defaults = defaults;
-			patch.agents = agents;
+			const memory = { ...(recordValue(patch.memory) ?? {}) };
+			const search = { ...(recordValue(memory.search) ?? {}) };
+			if (!Object.hasOwn(search, "provider")) search.provider = null;
+			if (!Object.hasOwn(search, "model")) search.model = null;
+			memory.search = search;
+			patch.memory = memory;
 		}
 	}
 	return runtime === "openclaw"

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { isClawdiManagedV2ProviderId, MANAGED_AI_PROVIDER_RUNTIME_ENV } from "@clawdi/shared";
+import { isClawdiManagedProviderId, MANAGED_AI_PROVIDER_RUNTIME_ENV } from "@clawdi/shared";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { buildAgentTargetProjection } from "../lib/ai-provider-projection";
 import { writePrivateFileAtomic } from "../lib/private-file";
@@ -524,12 +524,26 @@ const applyMergePatch = (target, source, path = []) => {
 };
 const configRead = await sdk.readConfigFileSnapshotForWrite({ skipPluginValidation: true });
 const snapshot = configRead?.snapshot;
-if (!snapshot || snapshot.valid !== true || !isRecord(snapshot.sourceConfig)) {
+const sourceConfig = snapshot?.sourceConfig;
+const sourceAgents = isRecord(sourceConfig) ? sourceConfig.agents : undefined;
+const sourceDefaults = isRecord(sourceAgents) ? sourceAgents.defaults : undefined;
+const patchAgents = patch.agents;
+const patchDefaults = isRecord(patchAgents) ? patchAgents.defaults : undefined;
+const repairsLegacyMemorySearch =
+  isRecord(sourceDefaults) &&
+  Object.hasOwn(sourceDefaults, "memorySearch") &&
+  isRecord(patchDefaults) &&
+  patchDefaults.memorySearch === null;
+if (
+  !snapshot ||
+  !isRecord(sourceConfig) ||
+  (snapshot.valid !== true && !repairsLegacyMemorySearch)
+) {
   throw new Error("OpenClaw config snapshot is unavailable for provider projection");
 }
-const projected = structuredClone(snapshot.sourceConfig);
+const projected = structuredClone(sourceConfig);
 applyMergePatch(projected, patch);
-if (isDeepStrictEqual(projected, snapshot.sourceConfig)) process.exit(0);
+if (isDeepStrictEqual(projected, sourceConfig)) process.exit(0);
 explicitSetPaths.length = 0;
 unsetPaths.length = 0;
 await sdk.mutateConfigFile({
@@ -755,7 +769,12 @@ function mergeProviderDeletes(
 	container.providers = providers;
 	if (runtime === "openclaw") {
 		patch.models = container;
-		if (deletedProviderIds.some(isClawdiManagedV2ProviderId)) {
+		if (deletedProviderIds.some(isClawdiManagedProviderId)) {
+			const agents = { ...(recordValue(patch.agents) ?? {}) };
+			const defaults = { ...(recordValue(agents.defaults) ?? {}) };
+			defaults.memorySearch = null;
+			agents.defaults = defaults;
+			patch.agents = agents;
 			const memory = { ...(recordValue(patch.memory) ?? {}) };
 			const search = { ...(recordValue(memory.search) ?? {}) };
 			if (!Object.hasOwn(search, "provider")) search.provider = null;

--- a/packages/cli/src/runtime/manifest-providers.ts
+++ b/packages/cli/src/runtime/manifest-providers.ts
@@ -38,7 +38,15 @@ import {
 import { runtimeSecretValue } from "./secret-values";
 
 const CODEX_BOOTSTRAP_TIMEOUT_MS = 600_000;
+const OPENCLAW_SCHEMA_PROBE_TIMEOUT_MS = 15_000;
+const OPENCLAW_SCHEMA_PROBE_MAX_BYTES = 16 * 1024 * 1024;
 const openClawProviderPatchRevisions = new Map<string, string>();
+const openClawMemorySearchLayouts = new Map<
+	string,
+	{ revision: string; layout: OpenClawMemorySearchLayout }
+>();
+
+type OpenClawMemorySearchLayout = "agents-defaults" | "top-level";
 
 export function providerHealthReasons(
 	provider: Record<string, unknown>,
@@ -162,6 +170,7 @@ export function applyHostedAiProviderProjection(
 		if (providerPatch.apply) {
 			applyOpenClawHostedProviderPatch(
 				providerPatch,
+				observation.commandPath,
 				openClawContext,
 				workspaceRoot,
 				providerRevision,
@@ -527,17 +536,24 @@ const snapshot = configRead?.snapshot;
 const sourceConfig = snapshot?.sourceConfig;
 const sourceAgents = isRecord(sourceConfig) ? sourceConfig.agents : undefined;
 const sourceDefaults = isRecord(sourceAgents) ? sourceAgents.defaults : undefined;
+const sourceMemory = isRecord(sourceConfig) ? sourceConfig.memory : undefined;
 const patchAgents = patch.agents;
 const patchDefaults = isRecord(patchAgents) ? patchAgents.defaults : undefined;
-const repairsLegacyMemorySearch =
-  isRecord(sourceDefaults) &&
-  Object.hasOwn(sourceDefaults, "memorySearch") &&
-  isRecord(patchDefaults) &&
-  patchDefaults.memorySearch === null;
+const patchMemory = patch.memory;
+const repairsUnsupportedMemorySearch =
+  (isRecord(sourceDefaults) &&
+    Object.hasOwn(sourceDefaults, "memorySearch") &&
+    isRecord(patchDefaults) &&
+    patchDefaults.memorySearch === null) ||
+  (isRecord(sourceMemory) &&
+    Object.hasOwn(sourceMemory, "search") &&
+    isRecord(patchMemory) &&
+    patchMemory.search === null &&
+    isRecord(patchDefaults?.memorySearch));
 if (
   !snapshot ||
   !isRecord(sourceConfig) ||
-  (snapshot.valid !== true && !repairsLegacyMemorySearch)
+  (snapshot.valid !== true && !repairsUnsupportedMemorySearch)
 ) {
   throw new Error("OpenClaw config snapshot is unavailable for provider projection");
 }
@@ -555,29 +571,109 @@ await sdk.mutateConfigFile({
 `;
 function applyOpenClawHostedProviderPatch(
 	patch: OpenClawHostedProviderPatch,
+	commandPath: string,
 	context: OpenClawHostedContext,
 	workspaceRoot: string,
 	providerRevision: string,
 ): void {
 	const sdkPath = context.requireSdkExport("configMutation");
+	const content = adaptOpenClawMemorySearchPatch(
+		patch.content,
+		commandPath,
+		context.home,
+		workspaceRoot,
+		sdkPath,
+	);
 	const patchRevision = runtimeImpactRevision({
 		providerRevision,
-		content: patch.content,
+		content,
 		sdk: runtimeFileCurrentRevision(sdkPath),
 	});
 	if (openClawProviderPatchRevisions.get(context.configPath) === patchRevision) {
-		const expected = recordValue(JSON.parse(patch.content) as unknown);
+		const expected = recordValue(JSON.parse(content) as unknown);
 		if (!expected) throw new Error("OpenClaw provider projection patch must be an object");
 		if (openClawConfigPatchIsApplied(context, expected)) return;
 	}
 	runRuntimeUserCommand(
 		"node",
 		["--input-type=module", "--eval", OPENCLAW_CONFIG_MUTATION_HELPER, sdkPath],
-		patch.content,
+		content,
 		context.home,
 		workspaceRoot,
 	);
 	openClawProviderPatchRevisions.set(context.configPath, patchRevision);
+}
+
+function adaptOpenClawMemorySearchPatch(
+	content: string,
+	commandPath: string,
+	home: string,
+	workspaceRoot: string,
+	sdkPath: string,
+): string {
+	const root = recordValue(JSON.parse(content) as unknown);
+	if (!root) throw new Error("OpenClaw provider projection patch must be an object");
+	const memory = recordValue(root.memory);
+	if (!memory || !Object.hasOwn(memory, "search")) return content;
+	const search = memory.search;
+	if (openClawMemorySearchLayout(commandPath, home, workspaceRoot, sdkPath) === "top-level") {
+		return content;
+	}
+
+	const patch = { ...root };
+	const agents = { ...(recordValue(patch.agents) ?? {}) };
+	const defaults = { ...(recordValue(agents.defaults) ?? {}) };
+	defaults.memorySearch = search;
+	agents.defaults = defaults;
+	patch.agents = agents;
+	patch.memory = { ...memory, search: null };
+	return `${JSON.stringify(patch, null, 2)}\n`;
+}
+
+function openClawMemorySearchLayout(
+	commandPath: string,
+	home: string,
+	workspaceRoot: string,
+	sdkPath: string,
+): OpenClawMemorySearchLayout {
+	const revision = [
+		runtimeFileCurrentRevision(commandPath),
+		runtimeFileCurrentRevision(sdkPath),
+	].join("\0");
+	const cached = openClawMemorySearchLayouts.get(commandPath);
+	if (cached?.revision === revision) return cached.layout;
+
+	const result = spawnRuntimeUserCommand(commandPath, ["config", "schema"], home, workspaceRoot, {
+		timeoutMs: OPENCLAW_SCHEMA_PROBE_TIMEOUT_MS,
+		maxBufferBytes: OPENCLAW_SCHEMA_PROBE_MAX_BYTES,
+	});
+	if (result.status !== 0) {
+		throw new Error("installed OpenClaw config schema is unavailable");
+	}
+	let schema: unknown;
+	try {
+		schema = JSON.parse(String(result.stdout));
+	} catch {
+		throw new Error("installed OpenClaw config schema is malformed");
+	}
+	const topLevel = jsonSchemaHasPropertyPath(schema, ["memory", "search"]);
+	const agentsDefaults = jsonSchemaHasPropertyPath(schema, ["agents", "defaults", "memorySearch"]);
+	if (topLevel === agentsDefaults) {
+		throw new Error("installed OpenClaw memory search schema is unsupported");
+	}
+	const layout: OpenClawMemorySearchLayout = topLevel ? "top-level" : "agents-defaults";
+	openClawMemorySearchLayouts.set(commandPath, { revision, layout });
+	return layout;
+}
+
+function jsonSchemaHasPropertyPath(schema: unknown, path: readonly string[]): boolean {
+	let current = recordValue(schema);
+	for (const segment of path) {
+		const properties = current ? recordValue(current.properties) : null;
+		current = properties ? recordValue(properties[segment]) : null;
+		if (!current) return false;
+	}
+	return true;
 }
 export function buildOpenClawHostedProviderPatch(
 	projectionInput: HostedAiProviderProjectionInput | null,

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -779,12 +779,16 @@ esac
 	chmodSync(input.path, 0o700);
 }
 
-function writeFakeOpenClawConfigMutationSdk(home: string, importLog?: string): string {
+function writeFakeOpenClawConfigMutationSdk(
+	home: string,
+	options: { importLog?: string; initialConfig?: Record<string, unknown> } = {},
+): string {
+	const { importLog, initialConfig = {} } = options;
 	const packageRoot = join(home, ".local", "lib", "node_modules", "openclaw");
 	const configPath = join(home, ".openclaw", "openclaw.json");
 	mkdirSync(packageRoot, { recursive: true });
 	mkdirSync(dirname(configPath), { recursive: true });
-	writeFileSync(configPath, "{}\n");
+	writeFileSync(configPath, `${JSON.stringify(initialConfig, null, 2)}\n`);
 	writeFileSync(
 		join(packageRoot, "package.json"),
 		JSON.stringify({
@@ -806,13 +810,20 @@ function writeFakeOpenClawConfigMutationSdk(home: string, importLog?: string): s
 		join(packageRoot, "config-mutation.mjs"),
 		`${logImport("config-mutation")}import { readFileSync, writeFileSync } from "node:fs";
 const configPath = ${JSON.stringify(configPath)};
+const isRecord = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
+const hasLegacyMemorySearch = (config) => {
+  const agents = isRecord(config) ? config.agents : undefined;
+  const defaults = isRecord(agents) ? agents.defaults : undefined;
+  return isRecord(defaults) && Object.hasOwn(defaults, "memorySearch");
+};
 export async function readConfigFileSnapshotForWrite() {
   const config = JSON.parse(readFileSync(configPath, "utf8"));
-  return { snapshot: { valid: true, config, sourceConfig: structuredClone(config) } };
+  return { snapshot: { valid: !hasLegacyMemorySearch(config), config, sourceConfig: structuredClone(config) } };
 }
 export async function mutateConfigFile(options) {
   const config = JSON.parse(readFileSync(configPath, "utf8"));
   await options.mutate(config, { snapshot: {}, previousHash: null, attempt: 1 });
+  if (hasLegacyMemorySearch(config)) throw new Error("OpenClaw config validation failed");
   writeFileSync(configPath, JSON.stringify(config, null, 2) + "\\n");
 }
 `,
@@ -2522,9 +2533,17 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(envFile).not.toContain("OPENCLAW_GATEWAY_TOKEN");
 	});
 
-	test("keeps hosted managed provider key out of the agent env", () => {
+	test("repairs legacy managed memory config and keeps the provider key out of agent env", () => {
 		const paths = tempRuntimePaths();
-		const configPath = writeFakeOpenClawConfigMutationSdk(paths.userHome);
+		const configPath = writeFakeOpenClawConfigMutationSdk(paths.userHome, {
+			initialConfig: {
+				agents: {
+					defaults: {
+						memorySearch: { provider: "clawdi", model: "legacy-embedding-model" },
+					},
+				},
+			},
+		});
 		writeFakeGatewayCli({
 			path: join(paths.userHome, ".local", "bin", "openclaw"),
 			runtime: "openclaw",
@@ -2563,7 +2582,9 @@ describe("runtime manifest reconciliation invariants", () => {
 
 		expect(result.installErrors).toEqual([]);
 		expect(result.projectedProviderIds.openclaw).toEqual(["clawdi-managed"]);
-		expect(JSON.parse(readFileSync(configPath, "utf8"))).toMatchObject({
+		const config = JSON.parse(readFileSync(configPath, "utf8"));
+		expect(config.agents.defaults).not.toHaveProperty("memorySearch");
+		expect(config).toMatchObject({
 			models: {
 				providers: {
 					"clawdi-managed": {
@@ -2594,7 +2615,7 @@ describe("runtime manifest reconciliation invariants", () => {
 		const paths = tempRuntimePaths();
 		const commandLog = join(paths.serviceStateRoot, "openclaw-probe-commands.log");
 		const sdkLog = join(paths.serviceStateRoot, "openclaw-probe-sdk.log");
-		const configPath = writeFakeOpenClawConfigMutationSdk(paths.userHome, sdkLog);
+		const configPath = writeFakeOpenClawConfigMutationSdk(paths.userHome, { importLog: sdkLog });
 		writeFakeGatewayCli({
 			path: join(paths.userHome, ".local", "bin", "openclaw"),
 			runtime: "openclaw",

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -726,6 +726,9 @@ case "$*" in
 	"config path"|"config get "*|"config set "*|"config unset "*)
 		HOME='${home}' exec '${process.execPath}' '${HERMES_CONFIG_CLI_MOCK}' "$@"
 		;;
+	"config schema")
+		printf '%s\n' '{"type":"object","properties":{"memory":{"type":"object","properties":{"search":{"type":"object"}}}}}'
+		;;
   "gateway install --force --json"|"gateway install --force"|"gateway install")
     ${
 			input.failInstall
@@ -2557,7 +2560,13 @@ describe("runtime manifest reconciliation invariants", () => {
 						type: "custom_openai_compatible",
 						managed_by: "clawdi",
 						baseUrl: "https://api.example.test/v1",
-						models: [{ id: "gpt-test" }],
+						models: [
+							{ id: "gpt-test" },
+							{
+								id: "test-embedding-model",
+								capabilities: { embeddings: true, chat: false },
+							},
+						],
 						apiMode: "openai_responses",
 						runtimeEnvName: "CLAWDI_AI_API_KEY",
 						apiKeySecretRef: "secret://providers/default/api-key",
@@ -2585,6 +2594,12 @@ describe("runtime manifest reconciliation invariants", () => {
 		const config = JSON.parse(readFileSync(configPath, "utf8"));
 		expect(config.agents.defaults).not.toHaveProperty("memorySearch");
 		expect(config).toMatchObject({
+			memory: {
+				search: {
+					provider: "clawdi-managed",
+					model: "test-embedding-model",
+				},
+			},
 			models: {
 				providers: {
 					"clawdi-managed": {

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -759,6 +759,7 @@ describe("hosted runtime bundle v2", () => {
 				"#!/usr/bin/env bash",
 				"set -euo pipefail",
 				`if [[ "$1" == "--version" ]]; then printf '%s\\n' 'OpenClaw test-version'; exit 0; fi`,
+				`if [[ "$1 $2" == "config schema" ]]; then printf '%s\\n' '{"type":"object","properties":{"memory":{"type":"object","properties":{"search":{"type":"object"}}}}}'; exit 0; fi`,
 				'if [[ "$1 $2 $3" == "agents list --json" ]]; then',
 				'  printf \'[{"id":"main","workspace":"%s"}]\\n\' "$HOME/.openclaw/workspace"',
 				'elif [[ "$1 $2 $3" == "config patch --stdin" ]]; then',
@@ -1602,6 +1603,10 @@ describe("hosted runtime bundle v2", () => {
 			`#!/usr/bin/env sh
 if [ "$*" = "--version" ]; then
   printf '%s\\n' 'OpenClaw test-version'
+  exit 0
+fi
+if [ "$*" = "config schema" ]; then
+  printf '%s\\n' '{"type":"object","properties":{"memory":{"type":"object","properties":{"search":{"type":"object"}}}}}'
   exit 0
 fi
 if [ "$*" = "agents list --json" ]; then

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1088,8 +1088,16 @@ fi
 `;
 }
 
+function fakeOpenClawConfigSchemaCommand(): string {
+	return `if [ "$*" = "config schema" ]; then
+  printf '%s\n' '{"type":"object","properties":{"memory":{"type":"object","properties":{"search":{"type":"object"}}}}}'
+  exit 0
+fi`;
+}
+
 function fakeOpenClawConfigPatchCommand(configPath: string): string {
-	return `if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
+	return `${fakeOpenClawConfigSchemaCommand()}
+if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
   patch="$(cat)"
   CLAWDI_TEST_OPENCLAW_PATCH="$patch" '${process.execPath}' - <<'NODE'
 const fs = require("node:fs");
@@ -1184,6 +1192,7 @@ if [ "\${1:-}" = "plugins" ] && grep -q 'legacyInvalidConfig' '${configPath}' 2>
   exit 1
 fi
 ${fakeManagedOpenClawProviderPluginCommands()}
+${fakeOpenClawConfigSchemaCommand()}
 if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then cat >/dev/null; fi
 exit 0
 `,
@@ -6966,6 +6975,7 @@ if [ "\${1:-}" = "--version" ]; then
   printf 'openclaw test-version\\n'
   exit 0
 fi
+${fakeOpenClawConfigSchemaCommand()}
 ${fakeManagedOpenClawProviderPluginCommands()}
 if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
   cat >/dev/null
@@ -8130,6 +8140,8 @@ set -euo pipefail
 printf '%s\n' "$*" >> '${installerLog}'
 if [ "$*" = "--version" ]; then
   printf '%s\n' '${runtime}-test-version'
+elif [ "${runtime}" = "openclaw" ] && [ "$*" = "config schema" ]; then
+  printf '%s\n' '{"type":"object","properties":{"memory":{"type":"object","properties":{"search":{"type":"object"}}}}}'
 elif [ "$*" = "agents list --json" ]; then
   printf '[{"id":"main","workspace":"${join(home, ".openclaw", "workspace")}"}]\n'
 elif [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ]; then


### PR DESCRIPTION
## Summary

- Project manifest-selected OpenClaw embedding provider and model fields to the schema-compatible top-level `memory.search` path.
- Include `agents.defaults.memorySearch: null` as a legacy deletion marker on managed-provider patches and managed-provider deletion patches.
- Allow the config mutation helper to repair an invalid snapshot only when the readable source contains that exact legacy key and the patch deletes it; normal `mutateConfigFile` result validation remains authoritative.
- Clear stale managed embedding provider/model fields without overwriting a replacement projection.
- Bump the CLI package and lockfile to `0.14.26` and document the compatibility recovery in the changelog.

## Verification

- `bun test --isolate --max-concurrency=1 --timeout=30000 packages/cli/src/lib/ai-provider-projection.test.ts packages/cli/tests/version.test.ts` (12 passed)
- `bun test --isolate --max-concurrency=1 --timeout=30000 packages/cli/src/runtime/manifest-reconciliation.test.ts -t "repairs legacy managed memory config"` (1 passed)
- `bun run --cwd packages/cli typecheck`
- `bunx biome check packages/cli/src/lib/ai-provider-projection.ts packages/cli/src/lib/ai-provider-projection.test.ts packages/cli/src/runtime/manifest-providers.ts packages/cli/src/runtime/manifest-reconciliation.test.ts packages/cli/package.json`
- `bun run --cwd packages/cli check:publish-manifest`

## Release

This recovery fix requires publishing `clawdi@0.14.26` after merge. The package version, matching `bun.lock` workspace entry, and changelog entry are included in this PR.