### PR TITLE
feat(sessions): navigate transcript search matches

### DIFF
--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -4,6 +4,7 @@ const SESSION_ID = "11111111-1111-4111-8111-111111111111";
 const AGENT_ID = "22222222-2222-4222-8222-222222222222";
 const now = "2026-08-28T10:00:00.000Z";
 const anchor = { kind: "event_seq", position: 7, revision: "events:head-hash" };
+const nextAnchor = { kind: "event_seq", position: 11, revision: "events:head-hash" };
 
 const session = {
 	id: SESSION_ID,
@@ -81,19 +82,36 @@ test("opens a message search result and returns to the same filtered list", asyn
 			return fulfillJson(route, session);
 		}
 		if (url.pathname === `/v1/sessions/${SESSION_ID}/messages`) {
+			const searchQuery = url.searchParams.get("search_query");
+			const selectedPosition = Number(url.searchParams.get("anchor_position"));
+			const isSecond = selectedPosition === nextAnchor.position;
+			if (searchQuery === null) {
+				return fulfillJson(route, {
+					items: [],
+					total: 0,
+					offset: 0,
+					limit: 100,
+				});
+			}
+			expect(searchQuery).toBe("authentication timeout");
 			return fulfillJson(route, {
 				items: [
 					{
 						role: "assistant",
-						content: "Fixed the authentication timeout without retrying every request",
+						content: isSecond
+							? "Verified the authentication timeout no longer recurs"
+							: "Fixed the authentication timeout without retrying every request",
 						model: "gpt-5",
 						timestamp: now,
 					},
 				],
-				total: 1,
+				total: 2,
 				offset: 0,
 				limit: 100,
 				anchor_offset: 0,
+				search_navigation: isSecond
+					? { index: 2, total: 2, previous: anchor, next: null }
+					: { index: 1, total: 2, previous: null, next: nextAnchor },
 			});
 		}
 		return fulfillJson(route, {});
@@ -107,6 +125,15 @@ test("opens a message search result and returns to the same filtered list", asyn
 		.getByRole("link", { name: "Open session Fix authentication timeout" })
 		.click();
 	await expect(page.locator('[data-search-match="true"]')).toBeVisible();
+	await expect(page.getByText("1 of 2")).toBeVisible();
+	await page.getByRole("button", { name: "Next match" }).click();
+	await expect(page).toHaveURL((url) => url.searchParams.get("matchPosition") === "11");
+	await expect(page.locator('[data-search-match="true"]')).toContainText(
+		"Verified the authentication timeout no longer recurs",
+	);
+	await expect(page.getByText("2 of 2")).toBeVisible();
+	await page.getByRole("button", { name: "Previous match" }).click();
+	await expect(page).toHaveURL((url) => url.searchParams.get("matchPosition") === "7");
 
 	await page.getByText("Back to Sessions", { exact: true }).click();
 	await expect(page).toHaveURL((url) => {

--- a/apps/web/src/components/sessions/session-search-navigation.tsx
+++ b/apps/web/src/components/sessions/session-search-navigation.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Link } from "@tanstack/react-router";
+import { ChevronDown, ChevronUp, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { SessionMessagesPage } from "@/lib/api-schemas";
+import { type SessionSearchAnchor, sessionSearchMatchLink } from "@/lib/session-search-anchor";
+
+type SearchNavigation = NonNullable<SessionMessagesPage["search_navigation"]>;
+
+function MatchButton({
+	label,
+	anchor,
+	sessionId,
+	query,
+	returnTo,
+	icon,
+}: {
+	label: string;
+	anchor: SessionSearchAnchor | null | undefined;
+	sessionId: string;
+	query: string;
+	returnTo?: string;
+	icon: React.ReactNode;
+}) {
+	if (!anchor) {
+		return (
+			<Button variant="ghost" size="icon-sm" disabled aria-label={label} title={label}>
+				{icon}
+			</Button>
+		);
+	}
+	return (
+		<Button
+			variant="ghost"
+			size="icon-sm"
+			nativeButton={false}
+			render={
+				<Link
+					{...sessionSearchMatchLink(sessionId, anchor, { searchQuery: query, returnTo })}
+					replace
+					resetScroll={false}
+				/>
+			}
+			aria-label={label}
+			title={label}
+		>
+			{icon}
+		</Button>
+	);
+}
+
+export function SessionSearchNavigation({
+	sessionId,
+	query,
+	navigation,
+	returnTo,
+}: {
+	sessionId: string;
+	query: string;
+	navigation: SearchNavigation;
+	returnTo?: string;
+}) {
+	return (
+		<nav
+			aria-label="Search matches"
+			className="flex min-w-0 items-center gap-2 border-y py-2 text-xs text-muted-foreground"
+		>
+			<Search className="size-3.5 shrink-0" />
+			<span className="min-w-0 flex-1 truncate" title={query}>
+				Matches for <span className="font-medium text-foreground">{query}</span>
+			</span>
+			<span className="shrink-0 tabular-nums text-foreground">
+				{navigation.index} of {navigation.total}
+			</span>
+			<div className="flex shrink-0 items-center">
+				<MatchButton
+					label="Previous match"
+					anchor={navigation.previous}
+					sessionId={sessionId}
+					query={query}
+					returnTo={returnTo}
+					icon={<ChevronUp />}
+				/>
+				<MatchButton
+					label="Next match"
+					anchor={navigation.next}
+					sessionId={sessionId}
+					query={query}
+					returnTo={returnTo}
+					icon={<ChevronDown />}
+				/>
+			</div>
+		</nav>
+	);
+}

--- a/apps/web/src/lib/session-search-anchor.test.ts
+++ b/apps/web/src/lib/session-search-anchor.test.ts
@@ -16,7 +16,7 @@ describe("Session search anchors", () => {
 					anchor: { kind: "event_seq", position: 42, revision: "events:revision" },
 				},
 			},
-			{ returnTo: "/sessions?q=matching&page=2" },
+			{ returnTo: "/sessions?q=matching&page=2", searchQuery: " matching " },
 		);
 		expect(link).toEqual({
 			to: "/sessions/$id",
@@ -25,6 +25,7 @@ describe("Session search anchors", () => {
 				matchKind: "event_seq",
 				matchPosition: 42,
 				matchRevision: "events:revision",
+				matchQuery: "matching",
 				returnTo: "/sessions?q=matching&page=2",
 			},
 		});

--- a/apps/web/src/lib/session-search-anchor.ts
+++ b/apps/web/src/lib/session-search-anchor.ts
@@ -6,6 +6,7 @@ export interface SessionDetailSearch {
 	matchKind?: SessionSearchAnchor["kind"];
 	matchPosition?: number;
 	matchRevision?: string;
+	matchQuery?: string;
 	returnTo?: string;
 }
 
@@ -29,12 +30,20 @@ export function validateSessionDetailSearch(search: Record<string, unknown>): Se
 			? search.matchRevision
 			: undefined;
 	if (!kind || position === undefined || !revision) return returnTo ? { returnTo } : {};
+	const matchQuery = normalizeSessionMatchQuery(search.matchQuery);
 	return {
 		matchKind: kind,
 		matchPosition: position,
 		matchRevision: revision,
+		...(matchQuery ? { matchQuery } : {}),
 		...(returnTo ? { returnTo } : {}),
 	};
+}
+
+function normalizeSessionMatchQuery(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = value.trim();
+	return normalized.length > 0 && normalized.length <= 500 ? normalized : undefined;
 }
 
 export function normalizeSessionListReturnTo(value: unknown): string | undefined {
@@ -66,21 +75,37 @@ export function sessionSearchAnchorFromSearch(
 
 export function sessionDetailLink(
 	session: Pick<SessionListItem, "id" | "search_match">,
-	options: { returnTo?: string } = {},
+	options: { returnTo?: string; searchQuery?: string } = {},
 ) {
 	const anchor = session.search_match?.anchor;
+	if (anchor) {
+		return sessionSearchMatchLink(session.id, anchor, options);
+	}
 	const returnTo = normalizeSessionListReturnTo(options.returnTo);
 	return {
 		to: "/sessions/$id" as const,
 		params: { id: session.id },
 		search: {
-			...(anchor
-				? {
-						matchKind: anchor.kind,
-						matchPosition: anchor.position,
-						matchRevision: anchor.revision,
-					}
-				: {}),
+			...(returnTo ? { returnTo } : {}),
+		},
+	};
+}
+
+export function sessionSearchMatchLink(
+	sessionId: string,
+	anchor: SessionSearchAnchor,
+	options: { returnTo?: string; searchQuery?: string } = {},
+) {
+	const returnTo = normalizeSessionListReturnTo(options.returnTo);
+	const matchQuery = normalizeSessionMatchQuery(options.searchQuery);
+	return {
+		to: "/sessions/$id" as const,
+		params: { id: sessionId },
+		search: {
+			matchKind: anchor.kind,
+			matchPosition: anchor.position,
+			matchRevision: anchor.revision,
+			...(matchQuery ? { matchQuery } : {}),
 			...(returnTo ? { returnTo } : {}),
 		},
 	};

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -26,6 +26,7 @@ import { PageHeader, PageHeaderSkeleton } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { MessageList } from "@/components/sessions/message-list";
 import { sessionAgentIdentityInput } from "@/components/sessions/session-agent-label";
+import { SessionSearchNavigation } from "@/components/sessions/session-search-navigation";
 import { SessionSidebar } from "@/components/sessions/session-sidebar";
 import { SessionShareControls } from "@/components/sessions/share-controls";
 import { TimeTooltip } from "@/components/time-tooltip";
@@ -55,14 +56,21 @@ import { cn, formatNumber, formatSessionSummary, relativeTime } from "@/lib/util
 export default function SessionDetailPage({
 	sessionId,
 	searchAnchor,
+	searchQuery,
 	returnTo,
 }: {
 	sessionId: string;
 	searchAnchor?: SessionSearchAnchor;
+	searchQuery?: string;
 	returnTo?: string;
 }) {
 	return (
-		<SessionDetailContent sessionId={sessionId} searchAnchor={searchAnchor} returnTo={returnTo} />
+		<SessionDetailContent
+			sessionId={sessionId}
+			searchAnchor={searchAnchor}
+			searchQuery={searchQuery}
+			returnTo={returnTo}
+		/>
 	);
 }
 
@@ -70,11 +78,13 @@ export function SessionDetailContent({
 	sessionId,
 	agentId,
 	searchAnchor,
+	searchQuery,
 	returnTo,
 }: {
 	sessionId: string;
 	agentId?: string | null;
 	searchAnchor?: SessionSearchAnchor;
+	searchQuery?: string;
 	returnTo?: string;
 }) {
 	const api = useApi();
@@ -209,6 +219,7 @@ export function SessionDetailContent({
 			searchAnchor?.kind ?? null,
 			searchAnchor?.position ?? null,
 			searchAnchor?.revision ?? null,
+			searchQuery ?? null,
 		],
 		initialPageParam: 0,
 		queryFn: async ({ pageParam }) => {
@@ -225,6 +236,7 @@ export function SessionDetailContent({
 										anchor_kind: searchAnchor.kind,
 										anchor_position: searchAnchor.position,
 										anchor_revision: searchAnchor.revision,
+										...(searchQuery ? { search_query: searchQuery } : {}),
 									}
 								: {}),
 						},
@@ -273,6 +285,7 @@ export function SessionDetailContent({
 	const anchorIdentity = searchAnchor
 		? `${searchAnchor.kind}:${searchAnchor.position}:${searchAnchor.revision}`
 		: null;
+	const searchNavigation = pagesData?.pages[0]?.search_navigation;
 
 	useEffect(() => {
 		if (!anchorIdentity || !pagesData) return;
@@ -439,6 +452,15 @@ export function SessionDetailContent({
 					title={session.local_session_id}
 				/>
 			</DetailStats>
+
+			{searchQuery && searchNavigation ? (
+				<SessionSearchNavigation
+					sessionId={sessionId}
+					query={searchQuery}
+					navigation={searchNavigation}
+					returnTo={returnTo}
+				/>
+			) : null}
 
 			{/* Direction toggle. Gated on `has_content` (not on
 			    `messages.length`) so it stays visible while pages

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -99,8 +99,9 @@ function SessionsListInner() {
 
 	const debouncedSearch = useDebouncedValue(params.q, 250);
 	const getSessionLink = useCallback(
-		(session: SessionListItem) => sessionDetailLink(session, { returnTo }),
-		[returnTo],
+		(session: SessionListItem) =>
+			sessionDetailLink(session, { returnTo, searchQuery: debouncedSearch }),
+		[returnTo, debouncedSearch],
 	);
 	const columns = useMemo(
 		() => sessionColumns({ sessionLink: getSessionLink, searchQuery: debouncedSearch }),

--- a/apps/web/src/routes/_protected/_dashboard/sessions/$id.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/sessions/$id.tsx
@@ -17,6 +17,11 @@ function SessionDetailRoute() {
 	const search = Route.useSearch();
 	const searchAnchor = sessionSearchAnchorFromSearch(search);
 	return (
-		<SessionDetailPage sessionId={id} searchAnchor={searchAnchor} returnTo={search.returnTo} />
+		<SessionDetailPage
+			sessionId={id}
+			searchAnchor={searchAnchor}
+			searchQuery={search.matchQuery}
+			returnTo={search.returnTo}
+		/>
 	);
 }

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -100,6 +100,7 @@ from app.schemas.session import (
     SessionPermissionsResponse,
     SessionSearchAnchorResponse,
     SessionSearchMatchResponse,
+    SessionSearchNavigationResponse,
     SessionUploadResponse,
 )
 from app.services import memory_extraction
@@ -138,6 +139,7 @@ from app.services.session_search import (
     current_search_revision,
     replace_snapshot_search_index,
     searchable_snapshot_messages,
+    session_message_search_navigation,
 )
 from app.services.sync_events import queue_environment_runtime_manifest_changed
 
@@ -3103,6 +3105,7 @@ async def get_session_messages(
     anchor_kind: Literal["snapshot_offset", "event_seq"] | None = Query(default=None),
     anchor_position: int | None = Query(default=None, ge=0),
     anchor_revision: str | None = Query(default=None, min_length=1, max_length=80),
+    search_query: str | None = Query(default=None, max_length=500),
     auth: AuthContext = Depends(require_scope("sessions:read")),
     db: AsyncSession = Depends(get_session),
 ) -> SessionMessagesPage:
@@ -3119,6 +3122,7 @@ async def get_session_messages(
     append. A complete search anchor recenters the first page around its match;
     stale anchors degrade to ordinary offset pagination.
     """
+    search_query = search_query.strip() if search_query else None
     anchor_values = (anchor_kind, anchor_position, anchor_revision)
     if any(value is not None for value in anchor_values) and not all(
         value is not None for value in anchor_values
@@ -3160,6 +3164,7 @@ async def get_session_messages(
     total = len(projection.messages)
     page_offset = offset
     anchor_offset: int | None = None
+    search_navigation: SessionSearchNavigationResponse | None = None
     expected_anchor_kind: Literal["snapshot_offset", "event_seq"] = (
         "event_seq" if session.content_protocol == "events-v1" else "snapshot_offset"
     )
@@ -3180,6 +3185,32 @@ async def get_session_messages(
                 max(0, anchor_offset - limit // 2),
                 max(0, total - limit),
             )
+            if search_query:
+                navigation = await session_message_search_navigation(
+                    db,
+                    session,
+                    query=search_query,
+                    position=anchor_position,
+                )
+                if navigation is not None:
+
+                    def navigation_anchor(
+                        position: int | None,
+                    ) -> SessionSearchAnchorResponse | None:
+                        if position is None:
+                            return None
+                        return SessionSearchAnchorResponse(
+                            kind=expected_anchor_kind,
+                            position=position,
+                            revision=anchor_revision,
+                        )
+
+                    search_navigation = SessionSearchNavigationResponse(
+                        index=navigation.index,
+                        total=navigation.total,
+                        previous=navigation_anchor(navigation.previous_position),
+                        next=navigation_anchor(navigation.next_position),
+                    )
 
     sliced = slice_session_messages(
         projection.messages,
@@ -3193,6 +3224,7 @@ async def get_session_messages(
         offset=page_offset,
         limit=limit,
         anchor_offset=anchor_offset,
+        search_navigation=search_navigation,
     )
 
 

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -476,6 +476,13 @@ class SessionSearchMatchResponse(BaseModel):
     anchor: SessionSearchAnchorResponse
 
 
+class SessionSearchNavigationResponse(BaseModel):
+    index: int = Field(ge=1)
+    total: int = Field(ge=1)
+    previous: SessionSearchAnchorResponse | None = None
+    next: SessionSearchAnchorResponse | None = None
+
+
 class SessionListItemResponse(BaseModel):
     id: str
     local_session_id: str
@@ -664,5 +671,9 @@ class SessionMessagesPage(BaseModel):
     anchor_offset: int | None = Field(
         default=None,
         ge=0,
+        exclude_if=lambda value: value is None,
+    )
+    search_navigation: SessionSearchNavigationResponse | None = Field(
+        default=None,
         exclude_if=lambda value: value is None,
     )

--- a/backend/app/services/session_search.py
+++ b/backend/app/services/session_search.py
@@ -30,6 +30,14 @@ class SearchableSessionMessage:
     content: str
 
 
+@dataclass(frozen=True, slots=True)
+class SessionSearchNavigation:
+    index: int
+    total: int
+    previous_position: int | None
+    next_position: int | None
+
+
 def event_document_revision(generation_id: UUID) -> str:
     return f"events:{generation_id}"
 
@@ -84,6 +92,24 @@ def _searchable_text(content: str) -> str:
     return content.replace("\x00", "\ufffd")
 
 
+def _message_match_expressions(query: str):
+    exact_match = SessionMessageSearch.content.ilike(
+        _escaped_contains_pattern(query),
+        escape="\\",
+    )
+    candidate_filter = exact_match
+    if len(query) >= _MIN_TRGM_QUERY_LENGTH:
+        candidate_filter = or_(
+            exact_match,
+            literal(query).op("<%")(SessionMessageSearch.content),
+        )
+    score = case(
+        (exact_match, 1.0),
+        else_=func.word_similarity(query, SessionMessageSearch.content),
+    )
+    return candidate_filter, score
+
+
 def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
     """Return the strongest index-backed visible-message match per Session."""
     active_document_revision = case(
@@ -100,22 +126,9 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
         ),
         else_=func.concat("snapshot:", Session.content_hash),
     )
-    exact_match = SessionMessageSearch.content.ilike(
-        _escaped_contains_pattern(query),
-        escape="\\",
-    )
-    candidate_filter = exact_match
-    if len(query) >= _MIN_TRGM_QUERY_LENGTH:
-        # Official pg_trgm word-search shape: use the GIN-backed operator for
-        # candidates, then word_similarity() only to rank that bounded set.
-        candidate_filter = or_(
-            exact_match,
-            literal(query).op("<%")(SessionMessageSearch.content),
-        )
-    score = case(
-        (exact_match, 1.0),
-        else_=func.word_similarity(query, SessionMessageSearch.content),
-    ).label("score")
+    # Official pg_trgm word-search shape: use the GIN-backed operator for
+    # candidates, then word_similarity() only to rank that bounded set.
+    candidate_filter, score = _message_match_expressions(query)
     candidates = (
         select(
             SessionMessageSearch.session_id.label("session_id"),
@@ -123,7 +136,7 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
             SessionMessageSearch.position.label("position"),
             SessionMessageSearch.content.label("content"),
             SessionMessageSearch.role.label("role"),
-            score,
+            score.label("score"),
         )
         .where(
             SessionMessageSearch.user_id == user_id,
@@ -154,6 +167,62 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
             candidates.c.position.asc(),
         )
         .subquery("best_session_message_match")
+    )
+
+
+async def session_message_search_navigation(
+    db: AsyncSession,
+    session: Session,
+    *,
+    query: str,
+    position: int,
+) -> SessionSearchNavigation | None:
+    """Resolve transcript-order neighbours for one active search match."""
+    document_revision = current_document_revision(session)
+    if document_revision is None or session.search_index_revision != current_search_revision(
+        session
+    ):
+        return None
+
+    candidate_filter, _ = _message_match_expressions(query)
+    ordered_matches = (
+        select(
+            SessionMessageSearch.position.label("position"),
+            func.row_number().over(order_by=SessionMessageSearch.position).label("match_index"),
+            func.count().over().label("match_total"),
+            func.lag(SessionMessageSearch.position)
+            .over(order_by=SessionMessageSearch.position)
+            .label("previous_position"),
+            func.lead(SessionMessageSearch.position)
+            .over(order_by=SessionMessageSearch.position)
+            .label("next_position"),
+        )
+        .where(
+            SessionMessageSearch.user_id == session.user_id,
+            SessionMessageSearch.session_id == session.id,
+            SessionMessageSearch.content_revision == document_revision,
+            candidate_filter,
+        )
+        .subquery("ordered_session_message_matches")
+    )
+    row = (
+        await db.execute(
+            select(
+                ordered_matches.c.match_index,
+                ordered_matches.c.match_total,
+                ordered_matches.c.previous_position,
+                ordered_matches.c.next_position,
+            ).where(ordered_matches.c.position == position)
+        )
+    ).one_or_none()
+    if row is None:
+        return None
+    match_index, match_total, previous_position, next_position = row
+    return SessionSearchNavigation(
+        index=match_index,
+        total=match_total,
+        previous_position=previous_position,
+        next_position=next_position,
     )
 
 

--- a/backend/tests/test_session_events.py
+++ b/backend/tests/test_session_events.py
@@ -668,6 +668,26 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
             "revision": f"events:{second_head}",
         },
     }
+    event_navigation = await client.get(
+        f"/v1/sessions/{session.id}/messages",
+        params={
+            "anchor_kind": "event_seq",
+            "anchor_position": 4,
+            "anchor_revision": f"events:{second_head}",
+            "search_query": "answer",
+        },
+    )
+    assert event_navigation.status_code == 200, event_navigation.text
+    assert event_navigation.json()["search_navigation"] == {
+        "index": 1,
+        "total": 2,
+        "previous": None,
+        "next": {
+            "kind": "event_seq",
+            "position": 6,
+            "revision": f"events:{second_head}",
+        },
+    }
     appended_search = (await client.get("/v1/sessions", params={"q": "right answer"})).json()
     assert [item["local_session_id"] for item in appended_search["items"]] == [local_id]
     assert appended_search["items"][0]["search_match"] == {

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -228,6 +228,75 @@ async def test_snapshot_message_search_tracks_current_content_and_escapes_wildca
 
 
 @pytest.mark.asyncio
+async def test_snapshot_message_search_navigates_matches_in_transcript_order(
+    client: httpx.AsyncClient,
+) -> None:
+    env_id = await _register_env(client)
+    local_id = "snapshot-search-navigation"
+    messages = [
+        {"role": "user", "content": "needle first"},
+        {"role": "assistant", "content": "not a match"},
+        {"role": "assistant", "content": "needle second"},
+        {"role": "user", "content": "needle third"},
+    ]
+    session_id = await _push_session(
+        client,
+        env_id,
+        local_session_id=local_id,
+        messages=messages,
+        upload=True,
+    )
+    search = (await client.get("/v1/sessions", params={"q": "needle"})).json()
+    first_anchor = search["items"][0]["search_match"]["anchor"]
+
+    first = await client.get(
+        f"/v1/sessions/{session_id}/messages",
+        params={
+            "anchor_kind": first_anchor["kind"],
+            "anchor_position": first_anchor["position"],
+            "anchor_revision": first_anchor["revision"],
+            "search_query": "needle",
+        },
+    )
+    assert first.status_code == 200, first.text
+    assert first.json()["search_navigation"] == {
+        "index": 1,
+        "total": 3,
+        "previous": None,
+        "next": {
+            "kind": "snapshot_offset",
+            "position": 2,
+            "revision": first_anchor["revision"],
+        },
+    }
+
+    second = await client.get(
+        f"/v1/sessions/{session_id}/messages",
+        params={
+            "anchor_kind": "snapshot_offset",
+            "anchor_position": 2,
+            "anchor_revision": first_anchor["revision"],
+            "search_query": "needle",
+        },
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["search_navigation"] == {
+        "index": 2,
+        "total": 3,
+        "previous": {
+            "kind": "snapshot_offset",
+            "position": 0,
+            "revision": first_anchor["revision"],
+        },
+        "next": {
+            "kind": "snapshot_offset",
+            "position": 3,
+            "revision": first_anchor["revision"],
+        },
+    }
+
+
+@pytest.mark.asyncio
 @pytest.mark.committed_db
 async def test_rebuild_does_not_replace_a_newer_revision_after_object_read(
     client: httpx.AsyncClient,

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -8067,6 +8067,7 @@ export interface components {
             limit: number;
             /** Anchor Offset */
             anchor_offset?: number | null;
+            search_navigation?: components["schemas"]["SessionSearchNavigationResponse"] | null;
         };
         /**
          * SessionPermissionCreate
@@ -8187,6 +8188,15 @@ export interface components {
             /** Excerpt */
             excerpt: string;
             anchor: components["schemas"]["SessionSearchAnchorResponse"];
+        };
+        /** SessionSearchNavigationResponse */
+        SessionSearchNavigationResponse: {
+            /** Index */
+            index: number;
+            /** Total */
+            total: number;
+            previous?: components["schemas"]["SessionSearchAnchorResponse"] | null;
+            next?: components["schemas"]["SessionSearchAnchorResponse"] | null;
         };
         /** SessionTextPart */
         SessionTextPart: {
@@ -11745,6 +11755,7 @@ export interface operations {
                 anchor_kind?: ("snapshot_offset" | "event_seq") | null;
                 anchor_position?: number | null;
                 anchor_revision?: string | null;
+                search_query?: string | null;
             };
             header?: never;
             path: {

--- a/packages/shared/src/api/schemas.ts
+++ b/packages/shared/src/api/schemas.ts
@@ -30,6 +30,7 @@ export type ContributionDay = Schemas["ContributionDayResponse"];
 export type SessionListItem = Schemas["SessionListItemResponse"];
 export type SessionDetail = Schemas["SessionDetailResponse"];
 export type SessionMessage = Schemas["SessionMessageResponse"];
+export type SessionMessagesPage = Schemas["SessionMessagesPage"];
 export type SessionUploadResult = Schemas["SessionUploadResponse"];
 export type Environment = Schemas["EnvironmentResponse"];
 


### PR DESCRIPTION
## Summary

- add transcript-order previous/next navigation for Session message search matches
- reuse the existing `session_message_search` projection with no new storage, migration, or object-store scan
- preserve validated search and return context across match navigation

## Verification

- `scripts/test.sh web` (1091 pass, typecheck and OSS production build)
- focused Chromium E2E (1 pass)
- focused PostgreSQL backend tests for snapshot-v1 and events-v1 (2 pass)
- generated OpenAPI client consistency
- Ruff check/format, Biome, and `git diff --check`
