### PR TITLE
fix(cli): restore Hermes WhatsApp allow-all opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ database migration, CI, and implementation details.
 
 - Newest-first Session detail pages now paginate from the actual visible transcript instead of relying on separately reported message counts, including for incrementally appended event chunks.
 
+## Clawdi CLI v0.14.26
+
+Package: `clawdi@0.14.26`
+
+### Fixed
+
+- Hosted Hermes WhatsApp gateways now keep the explicit allow-all safety opt-in required by their managed open access policy after CLI upgrades.
+
 ## Clawdi CLI v0.14.25
 
 Package: `clawdi@0.14.25`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.25",
+      "version": "0.14.26",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.25",
+	"version": "0.14.26",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -28,6 +28,7 @@ const HERMES_MANAGED_CHANNEL_ENV = [
 	"WHATSAPP_ENABLED",
 	"WHATSAPP_MODE",
 	"WHATSAPP_ALLOWED_USERS",
+	"WHATSAPP_ALLOW_ALL_USERS",
 	"WHATSAPP_DM_POLICY",
 	"WHATSAPP_GROUP_POLICY",
 ] as const;
@@ -364,6 +365,7 @@ function applyHermesRuntimeChannelSettings(
 	if (whatsapp) {
 		env.WHATSAPP_MODE = "bot";
 		env.WHATSAPP_ALLOWED_USERS = "*";
+		env.WHATSAPP_ALLOW_ALL_USERS = "true";
 		env.WHATSAPP_DM_POLICY = "open";
 		env.WHATSAPP_GROUP_POLICY = "open";
 	}

--- a/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/hermes_consumer.py
+++ b/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/hermes_consumer.py
@@ -27,6 +27,8 @@ async def main() -> None:
         os.environ[key] = value
     if os.environ.get("WHATSAPP_ALLOWED_USERS") != "*":
         raise RuntimeError("managed Hermes projection must use the stock bridge wildcard")
+    if os.environ.get("WHATSAPP_ALLOW_ALL_USERS") != "true":
+        raise RuntimeError("managed Hermes projection must explicitly opt in to allow all users")
     if os.environ.get("WHATSAPP_DM_POLICY") != "open":
         raise RuntimeError("managed Hermes projection must use the stock open DM policy")
     if os.environ.get("WHATSAPP_GROUP_POLICY") != "open":

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -9577,6 +9577,7 @@ exit 64
 			HERMES_EXISTING_ENV: "kept",
 			WHATSAPP_MODE: "bot",
 			WHATSAPP_ALLOWED_USERS: "*",
+			WHATSAPP_ALLOW_ALL_USERS: "true",
 			WHATSAPP_DM_POLICY: "open",
 			WHATSAPP_GROUP_POLICY: "open",
 		});
@@ -9735,6 +9736,7 @@ exit 64
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_MODE).toBeUndefined();
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ENABLED).toBeUndefined();
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ALLOWED_USERS).toBeUndefined();
+		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_ALLOW_ALL_USERS).toBeUndefined();
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_DM_POLICY).toBeUndefined();
 		expect(removed.manifest.runtimes.hermes?.run?.env?.WHATSAPP_GROUP_POLICY).toBeUndefined();
 		expect(readSystemdEnvFile(paths, "hermes-gateway")).not.toContain("WHATSAPP_ENABLED");


### PR DESCRIPTION
## Summary

- restore the explicit `WHATSAPP_ALLOW_ALL_USERS=true` safety opt-in for managed Hermes WhatsApp
- retain the newer DM/group policy projection and clear the managed key on unlink
- release as `clawdi@0.14.26`

## Root cause

CLI 0.14.24 replaced `WHATSAPP_ALLOW_ALL_USERS` with policy environment fields. Hermes still requires the independent allow-all opt-in when either policy is `open`, so upgraded gateways refused to start.

## Verification

- `bash scripts/test.sh cli tests/runtime.test.ts -t 'projects and removes Hermes native WhatsApp through the stock adapter config'`
- TypeScript typecheck and the focused runtime test passed in the Docker-backed clean runner.