### PR TITLE
feat(web): search within session transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ database migration, CI, and implementation details.
 ### Added
 
 - Session search now matches visible user and assistant message text in addition to summaries, folders, and IDs. CLI and Web results show the best matching message excerpt; private reasoning, tool payloads, system messages, and hidden events remain excluded.
+- Session detail pages can search the current transcript directly, move between matches, and highlight matching text without loading the whole conversation.
 
 ### Changed
 

--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -84,7 +84,8 @@ test("opens a message search result and returns to the same filtered list", asyn
 		if (url.pathname === `/v1/sessions/${SESSION_ID}/messages`) {
 			const searchQuery = url.searchParams.get("search_query");
 			const selectedPosition = Number(url.searchParams.get("anchor_position"));
-			const isSecond = selectedPosition === nextAnchor.position;
+			const isDirectDetailSearch = searchQuery === "no longer";
+			const isSecond = isDirectDetailSearch || selectedPosition === nextAnchor.position;
 			if (searchQuery === null) {
 				return fulfillJson(route, {
 					items: [],
@@ -93,7 +94,7 @@ test("opens a message search result and returns to the same filtered list", asyn
 					limit: 100,
 				});
 			}
-			expect(searchQuery).toBe("authentication timeout");
+			expect(["authentication timeout", "no longer"]).toContain(searchQuery);
 			return fulfillJson(route, {
 				items: [
 					{
@@ -109,9 +110,11 @@ test("opens a message search result and returns to the same filtered list", asyn
 				offset: 0,
 				limit: 100,
 				anchor_offset: 0,
-				search_navigation: isSecond
-					? { index: 2, total: 2, previous: anchor, next: null }
-					: { index: 1, total: 2, previous: null, next: nextAnchor },
+				search_navigation: isDirectDetailSearch
+					? { index: 1, total: 1, current: nextAnchor, previous: null, next: null }
+					: isSecond
+						? { index: 2, total: 2, current: nextAnchor, previous: anchor, next: null }
+						: { index: 1, total: 2, current: anchor, previous: null, next: nextAnchor },
 			});
 		}
 		return fulfillJson(route, {});
@@ -134,6 +137,18 @@ test("opens a message search result and returns to the same filtered list", asyn
 	await expect(page.getByText("2 of 2")).toBeVisible();
 	await page.getByRole("button", { name: "Previous match" }).click();
 	await expect(page).toHaveURL((url) => url.searchParams.get("matchPosition") === "7");
+	await page.getByRole("textbox", { name: "Search this session" }).fill("no longer");
+	await expect(page.getByRole("button", { name: "Next match" })).toBeDisabled();
+	await expect(page).toHaveURL((url) => {
+		return (
+			url.searchParams.get("matchQuery") === "no longer" && !url.searchParams.has("matchPosition")
+		);
+	});
+	await expect(page.locator('[data-search-match="true"]')).toContainText(
+		"Verified the authentication timeout no longer recurs",
+	);
+	await expect(page.locator('[data-search-match="true"] mark')).toHaveText("no longer");
+	await expect(page.getByText("1 of 1")).toBeVisible();
 
 	await page.getByText("Back to Sessions", { exact: true }).click();
 	await expect(page).toHaveURL((url) => {

--- a/apps/web/src/components/markdown.test.tsx
+++ b/apps/web/src/components/markdown.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Markdown } from "@/components/markdown";
+
+describe("Markdown search highlighting", () => {
+	test("highlights visible text without changing fenced code", () => {
+		const markup = renderToStaticMarkup(
+			createElement(Markdown, {
+				content: "Fixed **authentication** timeout.\n\n```text\nauthentication timeout\n```",
+				highlightQuery: "authentication timeout",
+			}),
+		);
+
+		expect(markup.match(/<mark/g)).toHaveLength(2);
+		expect(markup).toContain(">authentication</mark>");
+		expect(markup).toContain(">timeout</mark>");
+		expect(markup).toContain("authentication timeout\n</code>");
+	});
+});

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -15,6 +15,7 @@ import {
 import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
+import { createSearchHighlighter } from "@/lib/search-highlight";
 import { cn } from "@/lib/utils";
 
 /**
@@ -25,6 +26,51 @@ import { cn } from "@/lib/utils";
  *   - rehype plugins that decorate inline code with a non-language className
  */
 const InsidePreContext = createContext(false);
+
+interface MarkdownAstNode {
+	type: string;
+	value?: string;
+	children?: MarkdownAstNode[];
+	data?: {
+		hName?: string;
+		hProperties?: Record<string, string>;
+	};
+}
+
+function searchHighlightPlugin(query: string) {
+	const highlight = createSearchHighlighter(query);
+	return () => (tree: MarkdownAstNode) => {
+		const visit = (node: MarkdownAstNode) => {
+			if (!node.children) return;
+			for (let index = 0; index < node.children.length; index++) {
+				const child = node.children[index];
+				if (child.type !== "text" || child.value === undefined) {
+					visit(child);
+					continue;
+				}
+				const parts = highlight(child.value);
+				if (!parts.some((part) => part.highlighted)) continue;
+				const replacement: MarkdownAstNode[] = parts.map((part) =>
+					part.highlighted
+						? {
+								type: "searchHighlight",
+								data: {
+									hName: "mark",
+									hProperties: {
+										className: "rounded-sm bg-primary/20 px-0.5 text-inherit",
+									},
+								},
+								children: [{ type: "text", value: part.text }],
+							}
+						: { type: "text", value: part.text },
+				);
+				node.children.splice(index, 1, ...replacement);
+				index += replacement.length - 1;
+			}
+		};
+		visit(tree);
+	};
+}
 
 function useCopyToClipboard(duration = 2000) {
 	const [copied, setCopied] = useState(false);
@@ -112,10 +158,14 @@ function InlineCode({ className, children, ...props }: ComponentPropsWithoutRef<
 	);
 }
 
-function MarkdownImpl({ content }: { content: string }) {
+function MarkdownImpl({ content, highlightQuery }: { content: string; highlightQuery?: string }) {
 	return (
 		<ReactMarkdown
-			remarkPlugins={[remarkGfm, remarkBreaks]}
+			remarkPlugins={[
+				remarkGfm,
+				remarkBreaks,
+				...(highlightQuery ? [searchHighlightPlugin(highlightQuery)] : []),
+			]}
 			components={{
 				h1: ({ className, ...props }) => (
 					<h1 className={cn("mb-2 font-semibold text-base first:mt-0", className)} {...props} />

--- a/apps/web/src/components/sessions/message-list.tsx
+++ b/apps/web/src/components/sessions/message-list.tsx
@@ -8,6 +8,7 @@ import { Markdown } from "@/components/markdown";
 import { ModelBadge } from "@/components/meta/model-badge";
 import { Button } from "@/components/ui/button";
 import type { SessionMessage } from "@/lib/api-schemas";
+import { splitSearchHighlight } from "@/lib/search-highlight";
 import { cn, formatAbsoluteTooltip } from "@/lib/utils";
 
 /**
@@ -81,6 +82,7 @@ function MessageBlock({
 	isGroupStart,
 	isHighlighted,
 	highlightedRef,
+	highlightQuery,
 }: {
 	message: SessionMessage;
 	userAvatar?: string;
@@ -96,6 +98,7 @@ function MessageBlock({
 	isGroupStart: boolean;
 	isHighlighted?: boolean;
 	highlightedRef?: Ref<HTMLDivElement>;
+	highlightQuery?: string;
 }) {
 	const isUser = message.role === "user";
 	const agentName = agentTypeLabel(agentType);
@@ -184,9 +187,9 @@ function MessageBlock({
 					)}
 				>
 					{isUser ? (
-						<UserMessageBody content={message.content} />
+						<UserMessageBody content={message.content} highlightQuery={highlightQuery} />
 					) : (
-						<Markdown content={message.content} />
+						<Markdown content={message.content} highlightQuery={highlightQuery} />
 					)}
 				</div>
 			</div>
@@ -222,20 +225,32 @@ function isSkillExpansion(content: string): boolean {
 	return /^Base directory for this skill:/i.test(content.trimStart());
 }
 
-function UserMessageBody({ content }: { content: string }) {
+function UserMessageBody({
+	content,
+	highlightQuery,
+}: {
+	content: string;
+	highlightQuery?: string;
+}) {
 	const cmd = parseSlashCommand(content);
 	if (cmd) {
 		return (
 			<div className="space-y-2">
 				<SlashCommandPill name={cmd.name} args={cmd.args} />
-				{cmd.remaining && <Markdown content={cmd.remaining} />}
+				{cmd.remaining && <Markdown content={cmd.remaining} highlightQuery={highlightQuery} />}
 			</div>
 		);
 	}
 	if (isSkillExpansion(content)) {
-		return <CollapsibleBlock label="Skill Setup Text" content={content} />;
+		return (
+			<CollapsibleBlock
+				label="Skill Setup Text"
+				content={content}
+				highlightQuery={highlightQuery}
+			/>
+		);
 	}
-	return <Markdown content={content} />;
+	return <Markdown content={content} highlightQuery={highlightQuery} />;
 }
 
 function SlashCommandPill({ name, args }: { name: string; args?: string }) {
@@ -248,8 +263,20 @@ function SlashCommandPill({ name, args }: { name: string; args?: string }) {
 	);
 }
 
-function CollapsibleBlock({ label, content }: { label: string; content: string }) {
+function CollapsibleBlock({
+	label,
+	content,
+	highlightQuery,
+}: {
+	label: string;
+	content: string;
+	highlightQuery?: string;
+}) {
 	const [open, setOpen] = useState(false);
+	const containsMatch = highlightQuery
+		? splitSearchHighlight(content, highlightQuery).some((part) => part.highlighted)
+		: false;
+	const visible = open || containsMatch;
 	return (
 		<div className="rounded-md border border-dashed border-border/70 bg-muted/30">
 			<Button
@@ -258,17 +285,17 @@ function CollapsibleBlock({ label, content }: { label: string; content: string }
 				onClick={() => setOpen((v) => !v)}
 				className="h-auto w-full justify-start rounded-md px-2.5 py-1.5 text-xs font-normal text-muted-foreground hover:text-foreground"
 			>
-				<ChevronRight className={cn("size-3.5 transition-transform", open && "rotate-90")} />
+				<ChevronRight className={cn("size-3.5 transition-transform", visible && "rotate-90")} />
 				<span>{label}</span>
-				{!open && (
+				{!visible && (
 					<span className="text-xs text-muted-foreground">
 						({content.length.toLocaleString()} chars)
 					</span>
 				)}
 			</Button>
-			{open && (
+			{visible && (
 				<div className="border-t border-border/50 px-3 py-2">
-					<Markdown content={content} />
+					<Markdown content={content} highlightQuery={highlightQuery} />
 				</div>
 			)}
 		</div>
@@ -299,6 +326,7 @@ export function MessageList({
 	userName,
 	highlightedMessageKey,
 	highlightedMessageRef,
+	highlightQuery,
 }: {
 	messages: SessionMessage[];
 	messageKeys?: string[] | null;
@@ -307,6 +335,7 @@ export function MessageList({
 	userName: string;
 	highlightedMessageKey?: string | null;
 	highlightedMessageRef?: Ref<HTMLDivElement>;
+	highlightQuery?: string;
 }) {
 	const GROUP_GAP_MS = 5 * 60_000;
 	const out: React.ReactNode[] = [];
@@ -341,6 +370,7 @@ export function MessageList({
 				isGroupStart={isGroupStart}
 				isHighlighted={isHighlighted}
 				highlightedRef={isHighlighted ? highlightedMessageRef : undefined}
+				highlightQuery={isHighlighted ? highlightQuery : undefined}
 			/>,
 		);
 	}

--- a/apps/web/src/components/sessions/search-match-excerpt.tsx
+++ b/apps/web/src/components/sessions/search-match-excerpt.tsx
@@ -1,42 +1,17 @@
 import type { SessionListItem } from "@/lib/api-schemas";
+import { splitSearchHighlight } from "@/lib/search-highlight";
 import { cn } from "@/lib/utils";
 
 type SessionSearchMatch = NonNullable<SessionListItem["search_match"]>;
 
-function escapeRegExp(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function searchTerms(query: string): string[] {
-	const normalized = query.trim();
-	if (!normalized) return [];
-
-	const candidates = [normalized, ...(normalized.match(/[\p{L}\p{N}_]+/gu) ?? [])];
-	const seen = new Set<string>();
-	return candidates
-		.filter((term) => term.length > 1 || normalized.length === 1)
-		.filter((term) => {
-			const key = term.toLocaleLowerCase();
-			if (seen.has(key)) return false;
-			seen.add(key);
-			return true;
-		})
-		.sort((a, b) => b.length - a.length)
-		.slice(0, 24);
-}
-
 function HighlightedExcerpt({ excerpt, query }: { excerpt: string; query: string }) {
-	const terms = searchTerms(query);
-	if (terms.length === 0) return excerpt;
-
-	const pattern = new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "giu");
-	return excerpt.split(pattern).map((part, index) =>
-		terms.some((term) => term.toLocaleLowerCase() === part.toLocaleLowerCase()) ? (
-			<mark key={`${index}:${part}`} className="rounded-sm bg-primary/15 px-0.5 text-inherit">
-				{part}
+	return splitSearchHighlight(excerpt, query).map((part, index) =>
+		part.highlighted ? (
+			<mark key={`${index}:${part.text}`} className="rounded-sm bg-primary/15 px-0.5 text-inherit">
+				{part.text}
 			</mark>
 		) : (
-			part
+			part.text
 		),
 	);
 }

--- a/apps/web/src/components/sessions/session-search-navigation.tsx
+++ b/apps/web/src/components/sessions/session-search-navigation.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import { Link } from "@tanstack/react-router";
-import { ChevronDown, ChevronUp, Search } from "lucide-react";
+import { Link, useRouter } from "@tanstack/react-router";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { SearchInput } from "@/components/ui/search-input";
 import type { SessionMessagesPage } from "@/lib/api-schemas";
-import { type SessionSearchAnchor, sessionSearchMatchLink } from "@/lib/session-search-anchor";
+import {
+	type SessionSearchAnchor,
+	sessionDetailSearchLink,
+	sessionSearchMatchLink,
+} from "@/lib/session-search-anchor";
 
 type SearchNavigation = NonNullable<SessionMessagesPage["search_navigation"]>;
 
@@ -55,42 +60,69 @@ export function SessionSearchNavigation({
 	query,
 	navigation,
 	returnTo,
+	isSearching = false,
+	hasSearchError = false,
 }: {
 	sessionId: string;
 	query: string;
-	navigation: SearchNavigation;
+	navigation?: SearchNavigation | null;
 	returnTo?: string;
+	isSearching?: boolean;
+	hasSearchError?: boolean;
 }) {
+	const router = useRouter();
+	const activeNavigation = isSearching || hasSearchError ? null : navigation;
+	const updateQuery = (next: string) => {
+		void router.navigate({
+			...sessionDetailSearchLink(sessionId, next, { returnTo }),
+			replace: true,
+			resetScroll: false,
+		});
+	};
+
 	return (
 		<nav
-			aria-label="Search matches"
-			className="flex min-w-0 items-center gap-2 border-y py-2 text-xs text-muted-foreground"
+			aria-label="Search this session"
+			className="flex min-w-0 flex-col gap-2 border-y py-2 text-xs text-muted-foreground sm:flex-row sm:items-center"
 		>
-			<Search className="size-3.5 shrink-0" />
-			<span className="min-w-0 flex-1 truncate" title={query}>
-				Matches for <span className="font-medium text-foreground">{query}</span>
-			</span>
-			<span className="shrink-0 tabular-nums text-foreground">
-				{navigation.index} of {navigation.total}
-			</span>
-			<div className="flex shrink-0 items-center">
-				<MatchButton
-					label="Previous match"
-					anchor={navigation.previous}
-					sessionId={sessionId}
-					query={query}
-					returnTo={returnTo}
-					icon={<ChevronUp />}
-				/>
-				<MatchButton
-					label="Next match"
-					anchor={navigation.next}
-					sessionId={sessionId}
-					query={query}
-					returnTo={returnTo}
-					icon={<ChevronDown />}
-				/>
-			</div>
+			<SearchInput
+				value={query}
+				onChange={updateQuery}
+				placeholder="Search this session…"
+				ariaLabel="Search this session"
+				className="min-w-0 flex-1"
+			/>
+			{query ? (
+				<div className="flex min-h-8 shrink-0 items-center justify-end gap-2">
+					<span className="shrink-0 tabular-nums text-foreground" aria-live="polite">
+						{hasSearchError
+							? "Unavailable"
+							: isSearching
+								? "Searching…"
+								: activeNavigation
+									? `${activeNavigation.index} of ${activeNavigation.total}`
+									: "No matches"}
+					</span>
+					<div className="flex shrink-0 items-center">
+						<MatchButton
+							label="Previous match"
+							anchor={activeNavigation?.previous}
+							sessionId={sessionId}
+							query={query}
+							returnTo={returnTo}
+							icon={<ChevronUp />}
+						/>
+						<MatchButton
+							label="Next match"
+							anchor={activeNavigation?.next}
+							sessionId={sessionId}
+							query={query}
+							returnTo={returnTo}
+							icon={<ChevronDown />}
+						/>
+					</div>
+				</div>
+			) : null}
 		</nav>
 	);
 }

--- a/apps/web/src/lib/search-highlight.ts
+++ b/apps/web/src/lib/search-highlight.ts
@@ -1,0 +1,54 @@
+export interface SearchHighlightPart {
+	text: string;
+	highlighted: boolean;
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function searchTerms(query: string): string[] {
+	const normalized = query.trim();
+	if (!normalized) return [];
+
+	const candidates = [normalized, ...(normalized.match(/[\p{L}\p{N}_]+/gu) ?? [])];
+	const seen = new Set<string>();
+	return candidates
+		.filter((term) => term.length > 1 || normalized.length === 1)
+		.filter((term) => {
+			const key = term.toLocaleLowerCase();
+			if (seen.has(key)) return false;
+			seen.add(key);
+			return true;
+		})
+		.sort((a, b) => b.length - a.length)
+		.slice(0, 24);
+}
+
+export function createSearchHighlighter(query: string) {
+	const terms = searchTerms(query);
+	if (terms.length === 0) {
+		return (text: string): SearchHighlightPart[] => [{ text, highlighted: false }];
+	}
+
+	const pattern = new RegExp(terms.map(escapeRegExp).join("|"), "giu");
+	return (text: string): SearchHighlightPart[] => {
+		pattern.lastIndex = 0;
+		const parts: SearchHighlightPart[] = [];
+		let offset = 0;
+		for (let match = pattern.exec(text); match; match = pattern.exec(text)) {
+			const index = match.index;
+			const matched = match[0];
+			if (index > offset) parts.push({ text: text.slice(offset, index), highlighted: false });
+			parts.push({ text: matched, highlighted: true });
+			offset = index + matched.length;
+		}
+		if (parts.length === 0) return [{ text, highlighted: false }];
+		if (offset < text.length) parts.push({ text: text.slice(offset), highlighted: false });
+		return parts;
+	};
+}
+
+export function splitSearchHighlight(text: string, query: string): SearchHighlightPart[] {
+	return createSearchHighlighter(query)(text);
+}

--- a/apps/web/src/lib/session-search-anchor.test.ts
+++ b/apps/web/src/lib/session-search-anchor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
 	sessionDetailLink,
+	sessionDetailSearchLink,
 	sessionSearchAnchorFromSearch,
 	validateSessionDetailSearch,
 } from "@/lib/session-search-anchor";
@@ -33,6 +34,24 @@ describe("Session search anchors", () => {
 			kind: "event_seq",
 			position: 42,
 			revision: "events:revision",
+		});
+	});
+
+	test("keeps a standalone query and builds a query-only detail link", () => {
+		expect(
+			sessionDetailSearchLink("session-id", " authentication ", {
+				returnTo: "/sessions?q=authentication&page=2",
+			}),
+		).toEqual({
+			to: "/sessions/$id",
+			params: { id: "session-id" },
+			search: {
+				matchQuery: "authentication",
+				returnTo: "/sessions?q=authentication&page=2",
+			},
+		});
+		expect(validateSessionDetailSearch({ matchQuery: " authentication " })).toEqual({
+			matchQuery: "authentication",
 		});
 	});
 

--- a/apps/web/src/lib/session-search-anchor.ts
+++ b/apps/web/src/lib/session-search-anchor.ts
@@ -18,6 +18,11 @@ function validPosition(value: unknown): number | undefined {
 
 export function validateSessionDetailSearch(search: Record<string, unknown>): SessionDetailSearch {
 	const returnTo = normalizeSessionListReturnTo(search.returnTo);
+	const matchQuery = normalizeSessionMatchQuery(search.matchQuery);
+	const standalone = {
+		...(matchQuery ? { matchQuery } : {}),
+		...(returnTo ? { returnTo } : {}),
+	};
 	const kind =
 		search.matchKind === "snapshot_offset" || search.matchKind === "event_seq"
 			? search.matchKind
@@ -29,14 +34,30 @@ export function validateSessionDetailSearch(search: Record<string, unknown>): Se
 		search.matchRevision.length <= 80
 			? search.matchRevision
 			: undefined;
-	if (!kind || position === undefined || !revision) return returnTo ? { returnTo } : {};
-	const matchQuery = normalizeSessionMatchQuery(search.matchQuery);
+	if (!kind || position === undefined || !revision) return standalone;
 	return {
 		matchKind: kind,
 		matchPosition: position,
 		matchRevision: revision,
 		...(matchQuery ? { matchQuery } : {}),
 		...(returnTo ? { returnTo } : {}),
+	};
+}
+
+export function sessionDetailSearchLink(
+	sessionId: string,
+	query: string,
+	options: { returnTo?: string } = {},
+) {
+	const returnTo = normalizeSessionListReturnTo(options.returnTo);
+	const matchQuery = normalizeSessionMatchQuery(query);
+	return {
+		to: "/sessions/$id" as const,
+		params: { id: sessionId },
+		search: {
+			...(matchQuery ? { matchQuery } : {}),
+			...(returnTo ? { returnTo } : {}),
+		},
 	};
 }
 

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -50,6 +50,7 @@ import {
 	sessionDetailQueryKey,
 } from "@/lib/session-queries";
 import type { SessionSearchAnchor } from "@/lib/session-search-anchor";
+import { useDebouncedValue } from "@/lib/use-debounced";
 import { useIsomorphicLayoutEffect } from "@/lib/use-isomorphic-layout-effect";
 import { cn, formatNumber, formatSessionSummary, relativeTime } from "@/lib/utils";
 
@@ -172,6 +173,8 @@ export function SessionDetailContent({
 	// Layout effects run before the messages query subscribes, so a stored
 	// "asc" swaps the query key without a wasted "desc" fetch.
 	const [direction, setDirection] = useState<Direction>("desc");
+	const normalizedSearchQuery = searchQuery?.trim() ?? "";
+	const debouncedSearchQuery = useDebouncedValue(normalizedSearchQuery, 250) || undefined;
 	useIsomorphicLayoutEffect(() => {
 		const stored = localStorage.getItem("clawdi.session.message-direction");
 		if (stored === "asc") setDirection("asc");
@@ -219,7 +222,7 @@ export function SessionDetailContent({
 			searchAnchor?.kind ?? null,
 			searchAnchor?.position ?? null,
 			searchAnchor?.revision ?? null,
-			searchQuery ?? null,
+			debouncedSearchQuery ?? null,
 		],
 		initialPageParam: 0,
 		queryFn: async ({ pageParam }) => {
@@ -236,8 +239,10 @@ export function SessionDetailContent({
 										anchor_kind: searchAnchor.kind,
 										anchor_position: searchAnchor.position,
 										anchor_revision: searchAnchor.revision,
-										...(searchQuery ? { search_query: searchQuery } : {}),
 									}
+								: {}),
+							...(pageParam === 0 && debouncedSearchQuery
+								? { search_query: debouncedSearchQuery }
 								: {}),
 						},
 					},
@@ -282,10 +287,11 @@ export function SessionDetailContent({
 		typeof anchorOffset === "number" ? `${direction}:${anchorOffset}` : null;
 	const highlightedMessageRef = useRef<HTMLDivElement | null>(null);
 	const handledAnchorRef = useRef<string | null>(null);
-	const anchorIdentity = searchAnchor
-		? `${searchAnchor.kind}:${searchAnchor.position}:${searchAnchor.revision}`
-		: null;
 	const searchNavigation = pagesData?.pages[0]?.search_navigation;
+	const resolvedSearchAnchor = searchNavigation?.current ?? searchAnchor;
+	const anchorIdentity = resolvedSearchAnchor
+		? `${resolvedSearchAnchor.kind}:${resolvedSearchAnchor.position}:${resolvedSearchAnchor.revision}`
+		: null;
 
 	useEffect(() => {
 		if (!anchorIdentity || !pagesData) return;
@@ -453,12 +459,17 @@ export function SessionDetailContent({
 				/>
 			</DetailStats>
 
-			{searchQuery && searchNavigation ? (
+			{session.has_content ? (
 				<SessionSearchNavigation
 					sessionId={sessionId}
-					query={searchQuery}
+					query={normalizedSearchQuery}
 					navigation={searchNavigation}
 					returnTo={returnTo}
+					isSearching={
+						Boolean(normalizedSearchQuery) &&
+						(normalizedSearchQuery !== debouncedSearchQuery || isContentLoading)
+					}
+					hasSearchError={Boolean(normalizedSearchQuery) && isContentError}
 				/>
 			) : null}
 
@@ -518,6 +529,7 @@ export function SessionDetailContent({
 							userName={user?.fullName || "You"}
 							highlightedMessageKey={highlightedMessageKey}
 							highlightedMessageRef={highlightedMessageRef}
+							highlightQuery={debouncedSearchQuery}
 						/>
 						{hasNextPage ? (
 							<LoadMoreSentinel

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -3119,8 +3119,9 @@ async def get_session_messages(
     starts at the oldest visible message for ascending reads and at the newest
     visible message for descending reads. Clients pin pages to the parent
     session's `content_hash`, which changes after snapshot replacement or event
-    append. A complete search anchor recenters the first page around its match;
-    stale anchors degrade to ordinary offset pagination.
+    append. A search query without an anchor opens its first transcript match;
+    a complete anchor opens that exact match. Stale anchors degrade to ordinary
+    offset pagination.
     """
     search_query = search_query.strip() if search_query else None
     anchor_values = (anchor_kind, anchor_position, anchor_revision)
@@ -3168,15 +3169,40 @@ async def get_session_messages(
     expected_anchor_kind: Literal["snapshot_offset", "event_seq"] = (
         "event_seq" if session.content_protocol == "events-v1" else "snapshot_offset"
     )
-    if (
-        anchor_kind is not None
+    active_search_revision = current_search_revision(session)
+    resolved_anchor_kind = anchor_kind
+    resolved_anchor_position = anchor_position
+    resolved_anchor_revision = anchor_revision
+    navigation = None
+    if anchor_kind is None and search_query:
+        navigation = await session_message_search_navigation(
+            db,
+            session,
+            query=search_query,
+        )
+        if navigation is not None:
+            resolved_anchor_kind = expected_anchor_kind
+            resolved_anchor_position = navigation.current_position
+            resolved_anchor_revision = active_search_revision
+    elif (
+        anchor_kind == expected_anchor_kind
         and anchor_position is not None
-        and anchor_revision is not None
-        and anchor_kind == expected_anchor_kind
-        and anchor_revision == current_search_revision(session)
+        and anchor_revision == active_search_revision
+        and search_query
+    ):
+        navigation = await session_message_search_navigation(
+            db,
+            session,
+            query=search_query,
+            position=anchor_position,
+        )
+    if (
+        resolved_anchor_kind == expected_anchor_kind
+        and resolved_anchor_position is not None
+        and resolved_anchor_revision == active_search_revision
     ):
         try:
-            source_index = projection.source_positions.index(anchor_position)
+            source_index = projection.source_positions.index(resolved_anchor_position)
         except ValueError:
             pass
         else:
@@ -3185,32 +3211,31 @@ async def get_session_messages(
                 max(0, anchor_offset - limit // 2),
                 max(0, total - limit),
             )
-            if search_query:
-                navigation = await session_message_search_navigation(
-                    db,
-                    session,
-                    query=search_query,
-                    position=anchor_position,
-                )
-                if navigation is not None:
+            if navigation is not None:
+                assert resolved_anchor_revision is not None
 
-                    def navigation_anchor(
-                        position: int | None,
-                    ) -> SessionSearchAnchorResponse | None:
-                        if position is None:
-                            return None
-                        return SessionSearchAnchorResponse(
-                            kind=expected_anchor_kind,
-                            position=position,
-                            revision=anchor_revision,
-                        )
-
-                    search_navigation = SessionSearchNavigationResponse(
-                        index=navigation.index,
-                        total=navigation.total,
-                        previous=navigation_anchor(navigation.previous_position),
-                        next=navigation_anchor(navigation.next_position),
+                def navigation_anchor(position: int) -> SessionSearchAnchorResponse:
+                    return SessionSearchAnchorResponse(
+                        kind=expected_anchor_kind,
+                        position=position,
+                        revision=resolved_anchor_revision,
                     )
+
+                search_navigation = SessionSearchNavigationResponse(
+                    index=navigation.index,
+                    total=navigation.total,
+                    current=navigation_anchor(navigation.current_position),
+                    previous=(
+                        navigation_anchor(navigation.previous_position)
+                        if navigation.previous_position is not None
+                        else None
+                    ),
+                    next=(
+                        navigation_anchor(navigation.next_position)
+                        if navigation.next_position is not None
+                        else None
+                    ),
+                )
 
     sliced = slice_session_messages(
         projection.messages,

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -479,6 +479,7 @@ class SessionSearchMatchResponse(BaseModel):
 class SessionSearchNavigationResponse(BaseModel):
     index: int = Field(ge=1)
     total: int = Field(ge=1)
+    current: SessionSearchAnchorResponse
     previous: SessionSearchAnchorResponse | None = None
     next: SessionSearchAnchorResponse | None = None
 

--- a/backend/app/services/session_search.py
+++ b/backend/app/services/session_search.py
@@ -32,6 +32,7 @@ class SearchableSessionMessage:
 
 @dataclass(frozen=True, slots=True)
 class SessionSearchNavigation:
+    current_position: int
     index: int
     total: int
     previous_position: int | None
@@ -175,9 +176,9 @@ async def session_message_search_navigation(
     session: Session,
     *,
     query: str,
-    position: int,
+    position: int | None = None,
 ) -> SessionSearchNavigation | None:
-    """Resolve transcript-order neighbours for one active search match."""
+    """Resolve one active match and its transcript-order neighbours."""
     document_revision = current_document_revision(session)
     if document_revision is None or session.search_index_revision != current_search_revision(
         session
@@ -205,20 +206,23 @@ async def session_message_search_navigation(
         )
         .subquery("ordered_session_message_matches")
     )
-    row = (
-        await db.execute(
-            select(
-                ordered_matches.c.match_index,
-                ordered_matches.c.match_total,
-                ordered_matches.c.previous_position,
-                ordered_matches.c.next_position,
-            ).where(ordered_matches.c.position == position)
-        )
-    ).one_or_none()
+    navigation_query = select(
+        ordered_matches.c.position,
+        ordered_matches.c.match_index,
+        ordered_matches.c.match_total,
+        ordered_matches.c.previous_position,
+        ordered_matches.c.next_position,
+    )
+    if position is None:
+        navigation_query = navigation_query.order_by(ordered_matches.c.position).limit(1)
+    else:
+        navigation_query = navigation_query.where(ordered_matches.c.position == position)
+    row = (await db.execute(navigation_query)).one_or_none()
     if row is None:
         return None
-    match_index, match_total, previous_position, next_position = row
+    current_position, match_index, match_total, previous_position, next_position = row
     return SessionSearchNavigation(
+        current_position=current_position,
         index=match_index,
         total=match_total,
         previous_position=previous_position,

--- a/backend/tests/test_session_events.py
+++ b/backend/tests/test_session_events.py
@@ -681,6 +681,11 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
     assert event_navigation.json()["search_navigation"] == {
         "index": 1,
         "total": 2,
+        "current": {
+            "kind": "event_seq",
+            "position": 4,
+            "revision": f"events:{second_head}",
+        },
         "previous": None,
         "next": {
             "kind": "event_seq",

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -249,6 +249,24 @@ async def test_snapshot_message_search_navigates_matches_in_transcript_order(
     search = (await client.get("/v1/sessions", params={"q": "needle"})).json()
     first_anchor = search["items"][0]["search_match"]["anchor"]
 
+    direct = await client.get(
+        f"/v1/sessions/{session_id}/messages",
+        params={"search_query": "needle"},
+    )
+    assert direct.status_code == 200, direct.text
+    assert direct.json()["anchor_offset"] == 0
+    assert direct.json()["search_navigation"] == {
+        "index": 1,
+        "total": 3,
+        "current": first_anchor,
+        "previous": None,
+        "next": {
+            "kind": "snapshot_offset",
+            "position": 2,
+            "revision": first_anchor["revision"],
+        },
+    }
+
     first = await client.get(
         f"/v1/sessions/{session_id}/messages",
         params={
@@ -262,6 +280,7 @@ async def test_snapshot_message_search_navigates_matches_in_transcript_order(
     assert first.json()["search_navigation"] == {
         "index": 1,
         "total": 3,
+        "current": first_anchor,
         "previous": None,
         "next": {
             "kind": "snapshot_offset",
@@ -283,6 +302,11 @@ async def test_snapshot_message_search_navigates_matches_in_transcript_order(
     assert second.json()["search_navigation"] == {
         "index": 2,
         "total": 3,
+        "current": {
+            "kind": "snapshot_offset",
+            "position": 2,
+            "revision": first_anchor["revision"],
+        },
         "previous": {
             "kind": "snapshot_offset",
             "position": 0,

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1357,8 +1357,9 @@ export interface paths {
          *     starts at the oldest visible message for ascending reads and at the newest
          *     visible message for descending reads. Clients pin pages to the parent
          *     session's `content_hash`, which changes after snapshot replacement or event
-         *     append. A complete search anchor recenters the first page around its match;
-         *     stale anchors degrade to ordinary offset pagination.
+         *     append. A search query without an anchor opens its first transcript match;
+         *     a complete anchor opens that exact match. Stale anchors degrade to ordinary
+         *     offset pagination.
          */
         get: operations["get_session_messages_v1_sessions__session_id__messages_get"];
         put?: never;
@@ -8195,6 +8196,7 @@ export interface components {
             index: number;
             /** Total */
             total: number;
+            current: components["schemas"]["SessionSearchAnchorResponse"];
             previous?: components["schemas"]["SessionSearchAnchorResponse"] | null;
             next?: components["schemas"]["SessionSearchAnchorResponse"] | null;
         };


### PR DESCRIPTION
## Summary

- add debounced, URL-backed search directly to Session detail pages
- recenter paginated snapshot and events-v1 transcripts on the first or selected match
- highlight visible Markdown text while preserving code blocks and copy content
- keep search navigation, loading, error, mobile, and return-to-list states coherent

## Architecture

Reuses the existing PostgreSQL session_message_search projection and existing paginated message endpoint. No new table, migration, object-store scan, transcript copy, cache, or background worker.

## Verification

- Web TypeScript typecheck
- focused frontend tests
- OSS production build
- backend PostgreSQL tests for snapshot and events-v1
- Chromium mobile E2E at 390x844
- Biome, Ruff, compileall, OpenAPI generated-client freshness
- git diff --check