### PR TITLE
fix(web): preserve spaces in session search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ database migration, CI, and implementation details.
 
 - Newest-first Session detail pages now paginate from the actual visible transcript instead of relying on separately reported message counts, including for incrementally appended event chunks.
 
+### Fixed
+
+- Session detail search now preserves spaces while typing multi-word queries.
+
 ## Clawdi CLI v0.14.27
 
 Package: `clawdi@0.14.27`

--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -137,7 +137,9 @@ test("opens a message search result and returns to the same filtered list", asyn
 	await expect(page.getByText("2 of 2")).toBeVisible();
 	await page.getByRole("button", { name: "Previous match" }).click();
 	await expect(page).toHaveURL((url) => url.searchParams.get("matchPosition") === "7");
-	await page.getByRole("textbox", { name: "Search this session" }).fill("no longer");
+	const detailSearch = page.getByRole("textbox", { name: "Search this session" });
+	await detailSearch.fill("");
+	await detailSearch.pressSequentially("no longer", { delay: 20 });
 	await expect(page.getByRole("button", { name: "Next match" })).toBeDisabled();
 	await expect(page).toHaveURL((url) => {
 		return (

--- a/apps/web/src/components/sessions/session-search-navigation.tsx
+++ b/apps/web/src/components/sessions/session-search-navigation.tsx
@@ -2,6 +2,7 @@
 
 import { Link, useRouter } from "@tanstack/react-router";
 import { ChevronDown, ChevronUp } from "lucide-react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/search-input";
 import type { SessionMessagesPage } from "@/lib/api-schemas";
@@ -71,8 +72,14 @@ export function SessionSearchNavigation({
 	hasSearchError?: boolean;
 }) {
 	const router = useRouter();
+	const [draftQuery, setDraftQuery] = useState(query);
+	useEffect(() => {
+		// Keep transient trailing whitespace while the URL stores the normalized query.
+		setDraftQuery((current) => (query && current.trim() === query ? current : query));
+	}, [query]);
 	const activeNavigation = isSearching || hasSearchError ? null : navigation;
 	const updateQuery = (next: string) => {
+		setDraftQuery(next);
 		void router.navigate({
 			...sessionDetailSearchLink(sessionId, next, { returnTo }),
 			replace: true,
@@ -86,7 +93,7 @@ export function SessionSearchNavigation({
 			className="flex min-w-0 flex-col gap-2 border-y py-2 text-xs text-muted-foreground sm:flex-row sm:items-center"
 		>
 			<SearchInput
-				value={query}
+				value={draftQuery}
 				onChange={updateQuery}
 				placeholder="Search this session…"
 				ariaLabel="Search this session"


### PR DESCRIPTION
## Summary

- keep a local search draft so normalized URL state cannot swallow transient spaces
- retain browser navigation and URL-backed search behavior
- exercise the real multi-word typing path with Playwright pressSequentially

## Verification

- Biome check (main has one pre-existing hosted unused-import warning)
- Web TypeScript typecheck
- focused Chromium E2E: 1 passed
- git diff --check