### PR TITLE
feat(runtime): accept OpenClaw capability provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ database migration, CI, and implementation details.
 
 - Session detail search now preserves spaces while typing multi-word queries.
 
+## Clawdi CLI v0.14.28
+
+Package: `clawdi@0.14.28`
+
+### Added
+
+- Hosted OpenClaw can receive a separate manifest-declared embedding provider
+  without changing its primary chat provider.
+
 ## Clawdi CLI v0.14.27
 
 Package: `clawdi@0.14.27`

--- a/backend/app/schemas/runtime.py
+++ b/backend/app/schemas/runtime.py
@@ -1036,12 +1036,14 @@ def _validate_runtime_provider_ids(value: list[str]) -> list[str]:
         raise ValueError(
             "provider_ids must contain canonical non-empty strings up to 80 characters"
         )
+    if len(value) != len(set(value)):
+        raise ValueError("provider_ids must not contain duplicates")
     return value
 
 
 class HostedRuntimeConfiguredDesiredState(_HostedRuntimeDesiredStateBase):
     providerMode: Literal["configured"]
-    provider_ids: list[str] = Field(min_length=1, max_length=1)
+    provider_ids: list[str] = Field(min_length=1, max_length=2)
     primary_model: HostedRuntimePrimaryModel
 
     @field_validator("provider_ids")

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -755,7 +755,12 @@ async def test_runtime_only_bundle_is_explicitly_unmanaged(
         },
         {
             **next(iter(_runtime_state().values())),
-            "provider_ids": ["primary", "secondary"],
+            "provider_ids": ["primary", "secondary", "tertiary"],
+            "primary_model": {"provider_id": "primary", "model": "gpt-5.5"},
+        },
+        {
+            **next(iter(_runtime_state().values())),
+            "provider_ids": ["primary", "primary"],
             "primary_model": {"provider_id": "primary", "model": "gpt-5.5"},
         },
         {
@@ -770,6 +775,20 @@ def test_runtime_provider_mode_rejects_mixed_contracts(runtime):
         AdminRuntimeStateUpsert.model_validate(
             _runtime_state_body(str(uuid4()), runtimes={"openclaw": runtime})
         )
+
+
+def test_configured_runtime_accepts_primary_and_capability_providers():
+    runtime = {
+        **next(iter(_runtime_state().values())),
+        "provider_ids": ["primary", "capability"],
+        "primary_model": {"provider_id": "primary", "model": "gpt-5.5"},
+    }
+
+    state = AdminRuntimeStateUpsert.model_validate(
+        _runtime_state_body(str(uuid4()), runtimes={"openclaw": runtime})
+    )
+
+    assert state.runtimes["openclaw"].provider_ids == ["primary", "capability"]
 
 
 def test_unmanaged_runtime_allows_explicit_user_vault_backed_service_secret_ref():

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.27",
+      "version": "0.14.28",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/ai-provider-agent-contract-audit.md
+++ b/docs/ai-provider-agent-contract-audit.md
@@ -5,10 +5,11 @@ convergence. It does not describe a local Provider activation workflow.
 
 ## Scope
 
-Core stores a multi-record Provider Catalog, while each configured Hosted
-Hermes or OpenClaw runtime binds exactly one provider. The controller emits the
+Core stores a multi-record Provider Catalog. Each configured Hosted runtime has
+one primary provider; OpenClaw may additionally receive one capability provider
+for manifest-declared features such as embeddings. The controller emits the
 stable bootstrap and Hosted desired-state bundle; the CLI runtime reconciler
-projects that single selection into the target-native configuration and
+projects those selected projections into the target-native configuration and
 credential store.
 
 Provider requests continue to flow directly from the runtime to the selected

--- a/docs/ai-providers.md
+++ b/docs/ai-providers.md
@@ -160,7 +160,7 @@ The Hosted controller is the activation authority:
 provider catalog / auth payload
           |
           v
-Hosted controller admission (provider_ids length 0..1)
+Hosted controller admission (provider_ids length 0..2)
           |
           v
 stable runtime bootstrap bundle + scoped secretValues
@@ -174,12 +174,12 @@ CLI manifest validation before secret rendering/decryption
 
 The wire field remains `provider_ids: string[]`. Its Core Hosted semantics are:
 
-- configured mode contains exactly one provider ID;
+- configured mode contains one primary provider and may contain one additional
+  capability provider;
 - unmanaged mode contains an empty list;
-- `primary_model.provider_id` must equal the configured provider ID;
-- the manifest `providers` projection must exactly match the selected ID;
-- changing selection replaces the binding; there is no fallback, secondary,
-  toggle, or provider-pool ordering behavior.
+- `primary_model.provider_id` must belong to the configured provider IDs;
+- the manifest `providers` projection must exactly match the selected IDs;
+- the capability provider does not participate in chat fallback or ordering.
 
 The public REST provider arrays and their existing limits are separate API
 debt and are not the Hosted binding contract. Provider Catalog CRUD likewise
@@ -189,7 +189,8 @@ The bootstrap response is the only Hosted wire used for convergence. Provider
 selection does not alter that stable contract.
 
 Done: `bun test packages/cli/src/runtime/manifest-reconciliation.test.ts`
-exits 0 and includes rejection of multiple configured `provider_ids`.
+exits 0 and covers the optional capability provider plus duplicate and size
+limits.
 
 ## Hosted Hermes And OpenClaw Delivery
 

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -578,7 +578,7 @@ Normalization maps hosted fields into the internal shape:
 | `runtimes.<name>.install` | Required strict `{source: "official"}` selector; Hosted cannot select a version, channel, commit, digest, or custom installer. Both supported runtimes use the official installer's default latest release. |
 | `runtimes.<name>.run` | Exact official gateway argv; only OpenClaw may carry its single gateway-token secret reference. Hosted rejects custom commands, cwd, env, and PATH projection. |
 | `runtimes.<name>.providerMode` | Required runtime-provider ownership discriminator: `configured` or `unmanaged` |
-| `runtimes.<name>.provider_ids` | Core Hosted configured mode requires exactly one provider; unmanaged mode requires an exact empty list. Selection is replacement-only, with no fallback or secondary pool. |
+| `runtimes.<name>.provider_ids` | Core Hosted configured mode requires one primary provider and permits one additional capability provider; unmanaged mode requires an exact empty list. The capability provider does not participate in chat fallback or ordering. |
 | `runtimes.<name>.primary_model.{provider_id,model}` | Required only in configured mode and its provider must belong to `provider_ids`; absent in unmanaged mode |
 | Hosted filesystem defaults | Derived locally from Hosted `RuntimePaths`: HOME, workspace, persistence root, and installer home use `userHome`; Hosted rejects external path and cwd overrides. |
 | `providers.<id>` | Canonical Hosted provider projection: `kind` is exactly `openai-compatible`; normal entries also require `type` and `baseUrl`, while `provider_not_found` is the only reduced error entry |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.27",
+	"version": "0.14.28",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -366,7 +366,13 @@ const hostedPrimaryModelSchema = z
 	})
 	.strict();
 
-const hostedProviderIdsSchema = z.array(z.string().min(1)).min(1).max(1);
+const hostedProviderIdsSchema = z
+	.array(z.string().min(1))
+	.min(1)
+	.max(2)
+	.refine((providerIds) => new Set(providerIds).size === providerIds.length, {
+		message: "provider_ids must not contain duplicates",
+	});
 
 const hostedRuntimeEntryBaseShape = {
 	enabled: z.boolean(),

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -1406,19 +1406,31 @@ describe("runtime manifest reconciliation invariants", () => {
 		).toBe(false);
 	});
 
-	test("copies canonical runtime provider bindings without backfill", () => {
+	test("accepts a primary provider with an additional capability provider", () => {
 		const canonical = hostedRuntimeBundleV2ManifestSchema.parse(
 			hostedManifestFixture({
+				providers: {
+					default: {
+						kind: "openai-compatible",
+						status: "error",
+						error: { code: "provider_not_found", message: "fixture provider unavailable" },
+					},
+					capability: {
+						kind: "openai-compatible",
+						status: "error",
+						error: { code: "provider_not_found", message: "fixture provider unavailable" },
+					},
+				},
 				runtimes: {
 					openclaw: hostedRuntimeFixture({
-						provider_ids: ["default"],
+						provider_ids: ["default", "capability"],
 						primary_model: { provider_id: "default", model: "gpt-test" },
 					}),
 				},
 			}),
 		);
 		expect(canonical.runtimes.openclaw).toMatchObject({
-			provider_ids: ["default"],
+			provider_ids: ["default", "capability"],
 			primary_model: { provider_id: "default", model: "gpt-test" },
 		});
 	});
@@ -1567,7 +1579,8 @@ describe("runtime manifest reconciliation invariants", () => {
 	test.each([
 		["missing provider_ids", { provider_ids: undefined }],
 		["empty provider_ids", { provider_ids: [] }],
-		["multiple provider_ids", { provider_ids: ["default", "secondary"] }],
+		["duplicate provider_ids", { provider_ids: ["default", "default"] }],
+		["more than two provider_ids", { provider_ids: ["default", "secondary", "tertiary"] }],
 		["missing primary_model", { primary_model: undefined }],
 		[
 			"primary model provider outside provider_ids",


### PR DESCRIPTION
## Summary

- allow a configured Hosted runtime to carry one primary provider plus one capability provider
- keep primary chat selection explicit and reject duplicate or oversized provider sets in Cloud and CLI
- prepare and document clawdi@0.14.28 for the compatible CLI rollout

## Verification

- bash scripts/test.sh cli src/runtime/manifest-reconciliation.test.ts
- bash scripts/test.sh backend tests/test_runtime_manifest.py
- cd backend && uv run python scripts/check_generated_api.py
- Biome 2.5.9 on changed TypeScript and manifests
- git diff --check

## Rollout order

1. Merge and deploy the Cloud receiver.
2. Publish clawdi@0.14.28.
3. Refresh the Hosted Cloud API fixture and merge Clawdi-AI/clawdi-hosted#1917.
4. Roll out exact clawdi@0.14.28 manifests through the existing Admin API.