### PR TITLE
feat(web): refine session search workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ database migration, CI, and implementation details.
 ### Changed
 
 - Newest-first Session detail pages now paginate from the actual visible transcript instead of relying on separately reported message counts, including for incrementally appended event chunks.
+- Session search keeps its controls visible in long conversations, supports keyboard match navigation, shows clearer loading feedback, and gives message matches more context in result cards.
 
 ### Fixed
 

--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -129,15 +129,15 @@ test("opens a message search result and returns to the same filtered list", asyn
 		.click();
 	await expect(page.locator('[data-search-match="true"]')).toBeVisible();
 	await expect(page.getByText("1 of 2")).toBeVisible();
-	await page.getByRole("button", { name: "Next match" }).click();
+	const detailSearch = page.getByRole("textbox", { name: "Search this session" });
+	await detailSearch.press("Enter");
 	await expect(page).toHaveURL((url) => url.searchParams.get("matchPosition") === "11");
 	await expect(page.locator('[data-search-match="true"]')).toContainText(
 		"Verified the authentication timeout no longer recurs",
 	);
 	await expect(page.getByText("2 of 2")).toBeVisible();
-	await page.getByRole("button", { name: "Previous match" }).click();
+	await detailSearch.press("Shift+Enter");
 	await expect(page).toHaveURL((url) => url.searchParams.get("matchPosition") === "7");
-	const detailSearch = page.getByRole("textbox", { name: "Search this session" });
 	await detailSearch.fill("");
 	await detailSearch.pressSequentially("no longer", { delay: 20 });
 	await expect(page.getByRole("button", { name: "Next match" })).toBeDisabled();

--- a/apps/web/src/components/sessions/search-match-excerpt.tsx
+++ b/apps/web/src/components/sessions/search-match-excerpt.tsx
@@ -26,7 +26,7 @@ export function SessionSearchMatchExcerpt({
 	className?: string;
 }) {
 	return (
-		<span className={cn("truncate", className)} title={match.excerpt}>
+		<span className={cn(className)} title={match.excerpt}>
 			<span className="font-medium capitalize">{match.role}</span>
 			{": "}
 			<HighlightedExcerpt excerpt={match.excerpt} query={query} />

--- a/apps/web/src/components/sessions/session-feed.tsx
+++ b/apps/web/src/components/sessions/session-feed.tsx
@@ -277,7 +277,7 @@ export function SessionCard({
 						<SessionSearchMatchExcerpt
 							match={session.search_match}
 							query={searchQuery}
-							className="mt-0.5 block text-xs leading-4 text-foreground/75"
+							className="mt-0.5 line-clamp-2 text-xs leading-4 text-foreground/75"
 						/>
 					) : null}
 					<span

--- a/apps/web/src/components/sessions/session-search-navigation.tsx
+++ b/apps/web/src/components/sessions/session-search-navigation.tsx
@@ -86,11 +86,19 @@ export function SessionSearchNavigation({
 			resetScroll: false,
 		});
 	};
+	const navigateToMatch = (anchor: SessionSearchAnchor | null | undefined) => {
+		if (!anchor) return;
+		void router.navigate({
+			...sessionSearchMatchLink(sessionId, anchor, { searchQuery: query, returnTo }),
+			replace: true,
+			resetScroll: false,
+		});
+	};
 
 	return (
 		<nav
 			aria-label="Search this session"
-			className="flex min-w-0 flex-col gap-2 border-y py-2 text-xs text-muted-foreground sm:flex-row sm:items-center"
+			className="sticky top-(--header-height) z-10 -mx-1 flex min-w-0 flex-col gap-2 border-y bg-background/95 px-1 py-2 text-xs text-muted-foreground backdrop-blur supports-[backdrop-filter]:bg-background/80 sm:flex-row sm:items-center"
 		>
 			<SearchInput
 				value={draftQuery}
@@ -98,6 +106,20 @@ export function SessionSearchNavigation({
 				placeholder="Search this session…"
 				ariaLabel="Search this session"
 				className="min-w-0 flex-1"
+				ariaKeyShortcuts="Enter Shift+Enter Escape"
+				onKeyDown={(event) => {
+					if (event.nativeEvent.isComposing) return;
+					if (event.key === "Escape" && draftQuery) {
+						event.preventDefault();
+						updateQuery("");
+						return;
+					}
+					if (event.key !== "Enter") return;
+					const anchor = event.shiftKey ? activeNavigation?.previous : activeNavigation?.next;
+					if (!anchor) return;
+					event.preventDefault();
+					navigateToMatch(anchor);
+				}}
 			/>
 			{query ? (
 				<div className="flex min-h-8 shrink-0 items-center justify-end gap-2">

--- a/apps/web/src/components/ui/search-input.tsx
+++ b/apps/web/src/components/ui/search-input.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Search, X } from "lucide-react";
+import type { KeyboardEventHandler } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -25,6 +26,8 @@ export function SearchInput({
 	ariaLabel = "Search",
 	className,
 	autoFocus,
+	onKeyDown,
+	ariaKeyShortcuts,
 }: {
 	value: string;
 	onChange: (next: string) => void;
@@ -33,6 +36,8 @@ export function SearchInput({
 	ariaLabel?: string;
 	className?: string;
 	autoFocus?: boolean;
+	onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
+	ariaKeyShortcuts?: string;
 }) {
 	return (
 		<div className={cn("relative", className)}>
@@ -47,6 +52,8 @@ export function SearchInput({
 				className="pl-9 pr-9"
 				autoComplete="off"
 				autoFocus={autoFocus}
+				onKeyDown={onKeyDown}
+				aria-keyshortcuts={ariaKeyShortcuts}
 			/>
 			{value ? (
 				<Button

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -98,14 +98,15 @@ function SessionsListInner() {
 	);
 
 	const debouncedSearch = useDebouncedValue(params.q, 250);
+	const draftSearchQuery = params.q.trim();
+	const searchQuery = debouncedSearch.trim();
 	const getSessionLink = useCallback(
-		(session: SessionListItem) =>
-			sessionDetailLink(session, { returnTo, searchQuery: debouncedSearch }),
-		[returnTo, debouncedSearch],
+		(session: SessionListItem) => sessionDetailLink(session, { returnTo, searchQuery }),
+		[returnTo, searchQuery],
 	);
 	const columns = useMemo(
-		() => sessionColumns({ sessionLink: getSessionLink, searchQuery: debouncedSearch }),
-		[getSessionLink, debouncedSearch],
+		() => sessionColumns({ sessionLink: getSessionLink, searchQuery }),
+		[getSessionLink, searchQuery],
 	);
 
 	// Tanstack-react-table owns sorting state internally; mirror it
@@ -115,7 +116,7 @@ function SessionsListInner() {
 
 	const isFiltered =
 		params.agent !== "" ||
-		debouncedSearch !== "" ||
+		draftSearchQuery !== "" ||
 		params.has_pr !== null ||
 		params.automated !== null;
 
@@ -123,7 +124,7 @@ function SessionsListInner() {
 		() => ({
 			page: params.page,
 			page_size: params.pageSize,
-			q: debouncedSearch || undefined,
+			q: searchQuery || undefined,
 			sort: params.sort,
 			order: params.order,
 			agent: params.agent || undefined,
@@ -131,7 +132,7 @@ function SessionsListInner() {
 			automated: params.automated,
 		}),
 		[
-			debouncedSearch,
+			searchQuery,
 			params.agent,
 			params.automated,
 			params.has_pr,
@@ -142,7 +143,7 @@ function SessionsListInner() {
 		],
 	);
 
-	const { data, isLoading, error, refetch } = useQuery({
+	const { data, isLoading, isFetching, error, refetch } = useQuery({
 		...sessionListQueryOptions($api, sessionQuery),
 		// Keep the previous page visible while search, filters, or pagination
 		// move to a new query key.
@@ -189,6 +190,7 @@ function SessionsListInner() {
 
 	const total = data?.total ?? 0;
 	const pageCount = Math.max(1, Math.ceil(total / params.pageSize));
+	const isListUpdating = data !== undefined && (draftSearchQuery !== searchQuery || isFetching);
 
 	useEffect(() => {
 		if (!data || params.page >= pageCount) return;
@@ -211,9 +213,11 @@ function SessionsListInner() {
 	) {
 		setPaginationState({ pageIndex: params.page - 1, pageSize: params.pageSize });
 	}
-	const emptyMessage = isFiltered
-		? "No sessions match your filters."
-		: "No sessions yet. Once your agent has a conversation, it'll show up here.";
+	const emptyMessage = draftSearchQuery
+		? `No sessions found for “${draftSearchQuery}”.`
+		: isFiltered
+			? "No sessions match your filters."
+			: "No sessions yet. Once your agent has a conversation, it'll show up here.";
 	const sessionToolbar = (
 		<ListToolbar
 			search={
@@ -225,13 +229,14 @@ function SessionsListInner() {
 						// match quality" UX. Restore the date sort if the
 						// box is cleared so the empty-search default goes
 						// back to the activity timeline.
+						const hasQuery = v.trim().length > 0;
 						void setParams({
 							q: v,
 							page: 1,
 							sort:
-								v && params.sort === "last_activity_at"
+								hasQuery && params.sort === "last_activity_at"
 									? "relevance"
-									: !v && params.sort === "relevance"
+									: !hasQuery && params.sort === "relevance"
 										? "last_activity_at"
 										: params.sort,
 						});
@@ -281,9 +286,13 @@ function SessionsListInner() {
 			}
 			actions={
 				<>
-					{isFiltered && data ? (
-						<span className="text-xs text-muted-foreground tabular-nums">
-							{formatNumber(total)} {total === 1 ? "result" : "results"}
+					{(isFiltered || isListUpdating) && data ? (
+						<span className="text-xs text-muted-foreground tabular-nums" aria-live="polite">
+							{isListUpdating
+								? draftSearchQuery || searchQuery
+									? "Searching…"
+									: "Updating…"
+								: `${formatNumber(total)} ${total === 1 ? "result" : "results"}`}
 						</span>
 					) : null}
 					{isFiltered ? (
@@ -402,8 +411,8 @@ function SessionsListInner() {
 							emptyMessage={emptyMessage}
 							grouped={groupable}
 							groupBy={params.sort === "started_at" ? "started_at" : "last_activity_at"}
-							quietAutomated={debouncedSearch === ""}
-							searchQuery={debouncedSearch}
+							quietAutomated={searchQuery === ""}
+							searchQuery={searchQuery}
 							sessionLink={getSessionLink}
 						/>
 					</div>


### PR DESCRIPTION
## Summary

- keep transcript search available while scrolling long Sessions
- support Enter, Shift+Enter, and Escape in the Session search field
- show normalized list-search progress and two-line message excerpts

## Verification

- isolated Web typecheck
- isolated Chromium Session search E2E: 1 passed
- repository Biome check: passed with one pre-existing Hosted Channels unused-import warning
- git diff --check