### PR TITLE
feat(web): add session activity timeline

### DIFF
--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -163,3 +163,116 @@ test("opens a message search result and returns to the same filtered list", asyn
 		);
 	});
 });
+
+test("filters session activity and expands paired tool details", async ({ page }) => {
+	const timeline = [
+		{
+			kind: "message",
+			position: 4,
+			role: "assistant",
+			content: "Final answer after reading the file",
+			model: "gpt-5",
+			timestamp: now,
+		},
+		{
+			kind: "tool_result",
+			position: 3,
+			call_id: "call-read",
+			name: "read",
+			status: "completed",
+			content: "Repository instructions",
+			result_json: null,
+			timestamp: now,
+		},
+		{
+			kind: "tool_call",
+			position: 2,
+			call_id: "call-read",
+			name: "read",
+			arguments_json: '{"path":"README.md"}',
+			model: "gpt-5",
+			timestamp: now,
+		},
+		{
+			kind: "message",
+			position: 1,
+			role: "user",
+			content: "Read the repository instructions",
+			model: null,
+			timestamp: now,
+		},
+	] as const;
+
+	await page.route("**/v1/**", async (route) => {
+		const url = new URL(route.request().url());
+		if (url.pathname === "/v1/agents") {
+			return fulfillJson(route, [
+				{
+					id: AGENT_ID,
+					name: "Search Codex",
+					display_name: "Search Codex",
+					default_name: "Codex",
+					machine_name: "search-machine",
+					agent_type: "codex",
+				},
+			]);
+		}
+		if (url.pathname === `/v1/sessions/${SESSION_ID}`) {
+			return fulfillJson(route, session);
+		}
+		if (url.pathname === `/v1/sessions/${SESSION_ID}/messages`) {
+			const view = url.searchParams.get("view");
+			const query = url.searchParams.get("search_query");
+			if (query) {
+				expect(view).toBe("all");
+				return fulfillJson(route, {
+					items: [timeline[0]],
+					total: 1,
+					offset: 0,
+					limit: 100,
+					anchor_offset: 0,
+					search_navigation: {
+						index: 1,
+						total: 1,
+						current: anchor,
+						previous: null,
+						next: null,
+					},
+				});
+			}
+			const items =
+				view === "tools" ? timeline.slice(1, 3) : view === "user" ? [timeline[3]] : timeline;
+			return fulfillJson(route, {
+				items,
+				total: items.length,
+				offset: 0,
+				limit: 100,
+			});
+		}
+		return fulfillJson(route, {});
+	});
+
+	await page.goto(`/sessions/${SESSION_ID}?timelineView=tools`);
+	const toolActivity = page.getByRole("button", { name: /read.*Completed/ });
+	await expect(toolActivity).toBeVisible();
+	await expect(page.getByText("Final answer after reading the file")).not.toBeVisible();
+	await toolActivity.click();
+	await expect(page.locator("pre").filter({ hasText: '"path": "README.md"' })).toBeVisible();
+	await expect(page.getByText("Repository instructions", { exact: true })).toBeVisible();
+
+	await page.getByRole("button", { name: "You" }).click();
+	await expect(page).toHaveURL((url) => url.searchParams.get("timelineView") === "user");
+	await expect(page.getByText("Read the repository instructions", { exact: true })).toBeVisible();
+	await expect(toolActivity).not.toBeVisible();
+
+	await page.getByRole("button", { name: "Tools" }).click();
+	await page.getByRole("textbox", { name: "Search this session" }).fill("Final answer");
+	await expect(page).toHaveURL((url) => {
+		return (
+			url.searchParams.get("matchQuery") === "Final answer" && !url.searchParams.has("timelineView")
+		);
+	});
+	await expect(page.locator('[data-search-match="true"]')).toContainText(
+		"Final answer after reading the file",
+	);
+});

--- a/apps/web/src/components/sessions/message-list.tsx
+++ b/apps/web/src/components/sessions/message-list.tsx
@@ -1,15 +1,22 @@
 "use client";
 
-import { ChevronRight, Terminal } from "lucide-react";
+import { CheckCircle2, ChevronRight, CircleX, Terminal, Wrench } from "lucide-react";
 import { type Ref, useState } from "react";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import { agentTypeLabel } from "@/components/dashboard/agent-label";
 import { Markdown } from "@/components/markdown";
 import { ModelBadge } from "@/components/meta/model-badge";
 import { Button } from "@/components/ui/button";
-import type { SessionMessage } from "@/lib/api-schemas";
+import type {
+	SessionMessage,
+	SessionTimelineItem,
+	SessionToolCall,
+	SessionToolResult,
+} from "@/lib/api-schemas";
 import { splitSearchHighlight } from "@/lib/search-highlight";
 import { cn, formatAbsoluteTooltip } from "@/lib/utils";
+
+const OFFSCREEN_RENDERING_CLASS = "[content-visibility:auto] [contain-intrinsic-size:auto_160px]";
 
 /**
  * Message-thread rendering primitives, shared between the owner-dashboard
@@ -112,6 +119,7 @@ function MessageBlock({
 			aria-current={isHighlighted ? "location" : undefined}
 			className={cn(
 				"group flex scroll-mt-24 gap-3 rounded-md",
+				OFFSCREEN_RENDERING_CLASS,
 				isGroupStart ? "pt-4" : "",
 				isHighlighted && "bg-primary/5 ring-1 ring-primary/30",
 			)}
@@ -302,25 +310,115 @@ function CollapsibleBlock({
 	);
 }
 
+type TimelineMessage = SessionMessage | Extract<SessionTimelineItem, { kind: "message" }>;
+type TimelineEntry = SessionMessage | SessionTimelineItem;
+
+function isToolEntry(entry: TimelineEntry): entry is SessionToolCall | SessionToolResult {
+	return "kind" in entry && (entry.kind === "tool_call" || entry.kind === "tool_result");
+}
+
+function formatToolPayload(value: string): string {
+	try {
+		return JSON.stringify(JSON.parse(value), null, 2);
+	} catch {
+		return value;
+	}
+}
+
+function ToolPayload({ label, value }: { label: string; value: string }) {
+	return (
+		<div className="space-y-1">
+			<div className="text-3xs font-medium uppercase text-muted-foreground">{label}</div>
+			<pre className="max-h-80 overflow-auto whitespace-pre-wrap break-all rounded-md bg-muted/50 p-2 font-mono text-xs text-foreground">
+				{formatToolPayload(value)}
+			</pre>
+		</div>
+	);
+}
+
+function ToolActivity({ call, result }: { call?: SessionToolCall; result?: SessionToolResult }) {
+	const [open, setOpen] = useState(false);
+	const name = call?.name ?? result?.name ?? "Tool";
+	const hasDetails = Boolean(call?.arguments_json || result?.content || result?.result_json);
+	const isError = result?.status === "error";
+	const timestamp = call?.timestamp ?? result?.timestamp;
+
+	return (
+		<div className={cn("flex gap-3 py-1.5", OFFSCREEN_RENDERING_CLASS)}>
+			<div className="flex w-8 shrink-0 justify-end pt-1 text-muted-foreground">
+				<Wrench className="size-3.5" />
+			</div>
+			<div className="min-w-0 flex-1 border-l pl-3">
+				<button
+					type="button"
+					disabled={!hasDetails}
+					onClick={() => setOpen((value) => !value)}
+					aria-expanded={hasDetails ? open : undefined}
+					className="flex min-h-7 w-full min-w-0 items-center gap-2 text-left text-xs text-muted-foreground disabled:cursor-default"
+				>
+					<ChevronRight
+						className={cn(
+							"size-3.5 shrink-0 transition-transform",
+							open && "rotate-90",
+							!hasDetails && "invisible",
+						)}
+					/>
+					<code className="truncate font-medium text-foreground">{name}</code>
+					{isError ? (
+						<span className="inline-flex shrink-0 items-center gap-1 text-destructive">
+							<CircleX className="size-3.5" /> Error
+						</span>
+					) : result ? (
+						<span className="inline-flex shrink-0 items-center gap-1">
+							<CheckCircle2 className="size-3.5" /> Completed
+						</span>
+					) : (
+						<span className="shrink-0">Called</span>
+					)}
+					{timestamp ? (
+						<span
+							className="ml-auto shrink-0 tabular-nums"
+							title={formatAbsoluteTooltip(timestamp)}
+						>
+							{new Date(timestamp).toLocaleTimeString([], {
+								hour: "2-digit",
+								minute: "2-digit",
+							})}
+						</span>
+					) : null}
+				</button>
+				{open ? (
+					<div className="space-y-3 pb-2 pt-1">
+						{call?.arguments_json ? (
+							<ToolPayload label="Arguments" value={call.arguments_json} />
+						) : null}
+						{result?.content ? <ToolPayload label="Output" value={result.content} /> : null}
+						{result?.result_json ? <ToolPayload label="Result" value={result.result_json} /> : null}
+					</div>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
 /**
- * Renders an ordered message list with date dividers and group-start
- * grouping. The 5-minute GAP_MS threshold matches Slack / Discord —
- * same-author messages within 5 minutes collapse into a single visual
- * thread.
+ * Renders an ordered session timeline. Adjacent call/result events with the
+ * same call ID collapse into one tool activity row; tools break message author
+ * grouping. The 5-minute threshold matches Slack / Discord message threads.
  *
- * `messageKeys` is an optional caller-provided per-row stable key
+ * `itemKeys` is an optional caller-provided per-row stable key
  * (e.g. the message's canonical position when the caller is paginating).
  * Falls back to the array index, which is fine for SSR / single-page
  * renders where order is stable.
  *
  * Exported as a Component (not a plain function) so server components
- * can render it as `<MessageList .../>` — React 19 rejects calls to
+ * can render it as `<SessionTimelineList .../>` — React 19 rejects calls to
  * client-module functions from the server tree, but client components
  * rendered as JSX cross the boundary fine.
  */
-export function MessageList({
-	messages,
-	messageKeys,
+export function SessionTimelineList({
+	items,
+	itemKeys,
 	agentType,
 	userAvatar,
 	userName,
@@ -328,8 +426,8 @@ export function MessageList({
 	highlightedMessageRef,
 	highlightQuery,
 }: {
-	messages: SessionMessage[];
-	messageKeys?: string[] | null;
+	items: TimelineEntry[];
+	itemKeys?: string[] | null;
 	agentType: string | null | undefined;
 	userAvatar?: string;
 	userName: string;
@@ -340,30 +438,47 @@ export function MessageList({
 	const GROUP_GAP_MS = 5 * 60_000;
 	const out: React.ReactNode[] = [];
 	let prevDayKey: string | null = null;
-	for (let i = 0; i < messages.length; i++) {
-		const msg = messages[i];
-		const dKey = dayKey(msg.timestamp);
+	let previousMessage: TimelineMessage | null = null;
+	for (let i = 0; i < items.length; i++) {
+		const item = items[i];
+		const dKey = dayKey(item.timestamp);
+		const dividerJustEmitted = Boolean(dKey && dKey !== prevDayKey);
 		if (dKey && dKey !== prevDayKey) {
-			out.push(<DateDivider key={`d-${dKey}`} timestamp={msg.timestamp ?? ""} />);
+			out.push(<DateDivider key={`d-${dKey}`} timestamp={item.timestamp ?? ""} />);
 			prevDayKey = dKey;
 		}
-		const prev = i > 0 ? messages[i - 1] : null;
-		const sameAuthor = prev?.role === msg.role;
+
+		if (isToolEntry(item)) {
+			const next = items[i + 1];
+			const paired =
+				next && isToolEntry(next) && next.kind !== item.kind && next.call_id === item.call_id
+					? next
+					: null;
+			const call =
+				item.kind === "tool_call" ? item : paired?.kind === "tool_call" ? paired : undefined;
+			const result =
+				item.kind === "tool_result" ? item : paired?.kind === "tool_result" ? paired : undefined;
+			const toolKey = itemKeys?.[i] ?? `${item.kind}:${item.position}`;
+			out.push(<ToolActivity key={toolKey} call={call} result={result} />);
+			if (paired) i++;
+			previousMessage = null;
+			continue;
+		}
+
+		const sameAuthor = previousMessage?.role === item.role;
 		const closeInTime =
-			prev?.timestamp && msg.timestamp
-				? Math.abs(new Date(msg.timestamp).getTime() - new Date(prev.timestamp).getTime()) <
-					GROUP_GAP_MS
+			previousMessage?.timestamp && item.timestamp
+				? Math.abs(
+						new Date(item.timestamp).getTime() - new Date(previousMessage.timestamp).getTime(),
+					) < GROUP_GAP_MS
 				: false;
-		// A new day always starts a fresh group — even same-author messages
-		// across the divider shouldn't merge.
-		const dividerJustEmitted = i > 0 && dKey != null && dayKey(prev?.timestamp) !== dKey;
 		const isGroupStart = !sameAuthor || !closeInTime || dividerJustEmitted;
-		const messageKey = messageKeys?.[i] ?? i;
+		const messageKey = itemKeys?.[i] ?? i;
 		const isHighlighted = messageKey === highlightedMessageKey;
 		out.push(
 			<MessageBlock
 				key={messageKey}
-				message={msg}
+				message={item}
 				userAvatar={userAvatar}
 				userName={userName}
 				agentType={agentType}
@@ -373,6 +488,7 @@ export function MessageList({
 				highlightQuery={isHighlighted ? highlightQuery : undefined}
 			/>,
 		);
+		previousMessage = item;
 	}
 	return <>{out}</>;
 }

--- a/apps/web/src/lib/agent-routes.test.ts
+++ b/apps/web/src/lib/agent-routes.test.ts
@@ -273,13 +273,16 @@ describe("agent routes", () => {
 				tab: "sessions",
 				project: "project 1",
 				vault: 42,
+				timelineView: "tools",
 				future: "kept",
 			}),
 		).toEqual({
 			tab: "sessions",
 			project: "project 1",
+			timelineView: "tools",
 			future: "kept",
 		});
+		expect(validateAgentRouteSearch({ timelineView: "unknown" })).toEqual({});
 	});
 
 	it("canonicalizes legacy tab bookmarks through one explicit mapping", () => {

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -1,6 +1,7 @@
 import { defaultStringifySearch, linkOptions } from "@tanstack/react-router";
 import type { AgentSectionId } from "@/lib/navigation-model";
 import { AGENT_SECTION_NAVIGATION_ITEMS } from "@/lib/navigation-model";
+import { parseSessionTimelineView, type SessionTimelineView } from "@/lib/session-search-anchor";
 
 export type { AgentSectionId } from "@/lib/navigation-model";
 export { CONNECTED_AGENT_SECTION_IDS, HOSTED_AGENT_SECTION_IDS } from "@/lib/navigation-model";
@@ -9,6 +10,7 @@ export type AgentRouteSearch = Record<string, unknown> & {
 	tab?: string;
 	project?: string;
 	vault?: string;
+	timelineView?: Exclude<SessionTimelineView, "all">;
 	subscription_action?: "start_new";
 };
 
@@ -184,6 +186,9 @@ export function validateAgentRouteSearch(search: Record<string, unknown>): Agent
 		if (value === undefined) delete validated[key];
 		else validated[key] = value;
 	}
+	const timelineView = parseSessionTimelineView(search.timelineView);
+	if (timelineView === undefined) delete validated.timelineView;
+	else validated.timelineView = timelineView;
 	const action = subscriptionAction(search.subscription_action);
 	if (action === undefined) delete validated.subscription_action;
 	else validated.subscription_action = action;
@@ -276,10 +281,15 @@ export function agentSessionDetailHref(agentId: string, sessionId: string): stri
 }
 
 /** Typed TanStack Router options for an agent-scoped session detail link. */
-export function agentSessionDetailLink(agentId: string, sessionId: string) {
+export function agentSessionDetailLink(
+	agentId: string,
+	sessionId: string,
+	search?: AgentRouteSearch,
+) {
 	return linkOptions({
 		to: "/agents/$id/sessions/$sessionId",
 		params: { id: agentId, sessionId },
+		...(search ? { search } : {}),
 	});
 }
 

--- a/apps/web/src/lib/session-search-anchor.test.ts
+++ b/apps/web/src/lib/session-search-anchor.test.ts
@@ -3,6 +3,7 @@ import {
 	sessionDetailLink,
 	sessionDetailSearchLink,
 	sessionSearchAnchorFromSearch,
+	sessionTimelineViewLink,
 	validateSessionDetailSearch,
 } from "@/lib/session-search-anchor";
 
@@ -52,6 +53,26 @@ describe("Session search anchors", () => {
 		});
 		expect(validateSessionDetailSearch({ matchQuery: " authentication " })).toEqual({
 			matchQuery: "authentication",
+		});
+	});
+
+	test("canonicalizes timeline filters and clears them for transcript search", () => {
+		expect(validateSessionDetailSearch({ timelineView: "tools" })).toEqual({
+			timelineView: "tools",
+		});
+		expect(validateSessionDetailSearch({ timelineView: "tools", matchQuery: " answer " })).toEqual({
+			matchQuery: "answer",
+		});
+		expect(validateSessionDetailSearch({ timelineView: "unknown" })).toEqual({});
+		expect(sessionTimelineViewLink("session-id", "all")).toEqual({
+			to: "/sessions/$id",
+			params: { id: "session-id" },
+			search: {},
+		});
+		expect(sessionTimelineViewLink("session-id", "assistant")).toEqual({
+			to: "/sessions/$id",
+			params: { id: "session-id" },
+			search: { timelineView: "assistant" },
 		});
 	});
 

--- a/apps/web/src/lib/session-search-anchor.ts
+++ b/apps/web/src/lib/session-search-anchor.ts
@@ -1,12 +1,14 @@
 import type { SessionListItem } from "@clawdi/shared/api";
 
 export type SessionSearchAnchor = NonNullable<SessionListItem["search_match"]>["anchor"];
+export type SessionTimelineView = "all" | "user" | "assistant" | "tools";
 
 export interface SessionDetailSearch {
 	matchKind?: SessionSearchAnchor["kind"];
 	matchPosition?: number;
 	matchRevision?: string;
 	matchQuery?: string;
+	timelineView?: Exclude<SessionTimelineView, "all">;
 	returnTo?: string;
 }
 
@@ -16,11 +18,19 @@ function validPosition(value: unknown): number | undefined {
 	return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
 }
 
+export function parseSessionTimelineView(
+	value: unknown,
+): Exclude<SessionTimelineView, "all"> | undefined {
+	return value === "user" || value === "assistant" || value === "tools" ? value : undefined;
+}
+
 export function validateSessionDetailSearch(search: Record<string, unknown>): SessionDetailSearch {
 	const returnTo = normalizeSessionListReturnTo(search.returnTo);
 	const matchQuery = normalizeSessionMatchQuery(search.matchQuery);
+	const timelineView = matchQuery ? undefined : parseSessionTimelineView(search.timelineView);
 	const standalone = {
 		...(matchQuery ? { matchQuery } : {}),
+		...(timelineView ? { timelineView } : {}),
 		...(returnTo ? { returnTo } : {}),
 	};
 	const kind =
@@ -40,7 +50,24 @@ export function validateSessionDetailSearch(search: Record<string, unknown>): Se
 		matchPosition: position,
 		matchRevision: revision,
 		...(matchQuery ? { matchQuery } : {}),
+		...(timelineView ? { timelineView } : {}),
 		...(returnTo ? { returnTo } : {}),
+	};
+}
+
+export function sessionTimelineViewLink(
+	sessionId: string,
+	view: SessionTimelineView,
+	options: { returnTo?: string } = {},
+) {
+	const returnTo = normalizeSessionListReturnTo(options.returnTo);
+	return {
+		to: "/sessions/$id" as const,
+		params: { id: sessionId },
+		search: {
+			...(view === "all" ? {} : { timelineView: view }),
+			...(returnTo ? { returnTo } : {}),
+		},
 	};
 }
 

--- a/apps/web/src/pages/dashboard/agents/agent-session-detail-page.tsx
+++ b/apps/web/src/pages/dashboard/agents/agent-session-detail-page.tsx
@@ -1,15 +1,20 @@
 "use client";
 
+import type { SessionTimelineView } from "@/lib/session-search-anchor";
 import { SessionDetailContent } from "@/pages/dashboard/sessions/[id]/page";
 
 type AgentSessionDetailPageProps = {
 	agentId: string;
 	sessionId: string;
+	timelineView: SessionTimelineView;
 };
 
 export default function AgentSessionDetailPage({
 	agentId,
 	sessionId,
+	timelineView,
 }: AgentSessionDetailPageProps) {
-	return <SessionDetailContent sessionId={sessionId} agentId={agentId} />;
+	return (
+		<SessionDetailContent sessionId={sessionId} agentId={agentId} timelineView={timelineView} />
+	);
 }

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -24,7 +24,7 @@ import { ModelBadge } from "@/components/meta/model-badge";
 import { Stat } from "@/components/meta/stat";
 import { PageHeader, PageHeaderSkeleton } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
-import { MessageList } from "@/components/sessions/message-list";
+import { SessionTimelineList } from "@/components/sessions/message-list";
 import { sessionAgentIdentityInput } from "@/components/sessions/session-agent-label";
 import { SessionSearchNavigation } from "@/components/sessions/session-search-navigation";
 import { SessionSidebar } from "@/components/sessions/session-sidebar";
@@ -34,11 +34,16 @@ import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { agentDetailQueryOptions } from "@/lib/agent-queries";
-import { agentSectionHref } from "@/lib/agent-routes";
+import { agentSectionHref, agentSessionDetailLink } from "@/lib/agent-routes";
 import { ApiError, unwrap, useApi, useOpenApi } from "@/lib/api";
 import { isApiNotFoundError, normalizeApiError } from "@/lib/api-errors";
-import type { SessionMessage } from "@/lib/api-schemas";
+import type {
+	SessionMessagesPage,
+	SessionTimelineItem,
+	SessionTimelinePage,
+} from "@/lib/api-schemas";
 import { useCurrentUser } from "@/lib/auth-client";
 import { formatDuration } from "@/lib/format";
 import { shouldBlockQueryError } from "@/lib/query-state";
@@ -49,20 +54,42 @@ import {
 	SESSION_MESSAGES_STALE_MS,
 	sessionDetailQueryKey,
 } from "@/lib/session-queries";
-import type { SessionSearchAnchor } from "@/lib/session-search-anchor";
+import {
+	type SessionSearchAnchor,
+	type SessionTimelineView,
+	sessionTimelineViewLink,
+} from "@/lib/session-search-anchor";
 import { useDebouncedValue } from "@/lib/use-debounced";
 import { useIsomorphicLayoutEffect } from "@/lib/use-isomorphic-layout-effect";
 import { cn, formatNumber, formatSessionSummary, relativeTime } from "@/lib/utils";
+
+function normalizeTimelinePage(
+	page: SessionMessagesPage | SessionTimelinePage,
+): SessionTimelinePage {
+	return {
+		...page,
+		items: page.items.map((item, index): SessionTimelineItem => {
+			if ("kind" in item) return item;
+			return {
+				...item,
+				kind: "message",
+				position: page.offset + index,
+			};
+		}),
+	};
+}
 
 export default function SessionDetailPage({
 	sessionId,
 	searchAnchor,
 	searchQuery,
+	timelineView,
 	returnTo,
 }: {
 	sessionId: string;
 	searchAnchor?: SessionSearchAnchor;
 	searchQuery?: string;
+	timelineView: SessionTimelineView;
 	returnTo?: string;
 }) {
 	return (
@@ -70,6 +97,7 @@ export default function SessionDetailPage({
 			sessionId={sessionId}
 			searchAnchor={searchAnchor}
 			searchQuery={searchQuery}
+			timelineView={timelineView}
 			returnTo={returnTo}
 		/>
 	);
@@ -80,12 +108,14 @@ export function SessionDetailContent({
 	agentId,
 	searchAnchor,
 	searchQuery,
+	timelineView = "all",
 	returnTo,
 }: {
 	sessionId: string;
 	agentId?: string | null;
 	searchAnchor?: SessionSearchAnchor;
 	searchQuery?: string;
+	timelineView?: SessionTimelineView;
 	returnTo?: string;
 }) {
 	const api = useApi();
@@ -218,7 +248,9 @@ export function SessionDetailContent({
 			"session-messages",
 			sessionId,
 			session?.content_hash ?? null,
+			session?.event_head_hash ?? null,
 			direction,
+			timelineView,
 			searchAnchor?.kind ?? null,
 			searchAnchor?.position ?? null,
 			searchAnchor?.revision ?? null,
@@ -226,7 +258,7 @@ export function SessionDetailContent({
 		],
 		initialPageParam: 0,
 		queryFn: async ({ pageParam }) => {
-			return unwrap(
+			const page = unwrap(
 				await api.GET("/v1/sessions/{session_id}/messages", {
 					params: {
 						path: { session_id: sessionId },
@@ -234,6 +266,7 @@ export function SessionDetailContent({
 							offset: pageParam,
 							limit: PAGE_SIZE,
 							direction,
+							view: timelineView,
 							...(pageParam === 0 && searchAnchor
 								? {
 										anchor_kind: searchAnchor.kind,
@@ -248,6 +281,7 @@ export function SessionDetailContent({
 					},
 				}),
 			);
+			return normalizeTimelinePage(page);
 		},
 		getNextPageParam: (last): number | undefined => {
 			const nextOffset = last.offset + last.items.length;
@@ -268,20 +302,20 @@ export function SessionDetailContent({
 	// (`page.offset + k`) so it stays put across pagination, direction
 	// toggles, and refetches — array-index keys would break grouping
 	// memo when prepended pages shift positions.
-	const { messages, messageKeys } = useMemo(() => {
-		if (!pagesData) return { messages: null, messageKeys: null };
-		const msgs: SessionMessage[] = [];
+	const { timelineItems, timelineKeys } = useMemo(() => {
+		if (!pagesData) return { timelineItems: null, timelineKeys: null };
+		const items: SessionTimelineItem[] = [];
 		const keys: string[] = [];
 		for (const page of pagesData.pages) {
 			for (let k = 0; k < page.items.length; k++) {
-				msgs.push(page.items[k]);
+				items.push(page.items[k]);
 				keys.push(`${direction}:${page.offset + k}`);
 			}
 		}
-		return { messages: msgs, messageKeys: keys };
+		return { timelineItems: items, timelineKeys: keys };
 	}, [pagesData, direction]);
-	const totalMessages = pagesData?.pages[0]?.total ?? 0;
-	const loadedCount = messages?.length ?? 0;
+	const totalItems = pagesData?.pages[0]?.total ?? 0;
+	const loadedCount = timelineItems?.length ?? 0;
 	const anchorOffset = pagesData?.pages[0]?.anchor_offset;
 	const highlightedMessageKey =
 		typeof anchorOffset === "number" ? `${direction}:${anchorOffset}` : null;
@@ -473,38 +507,75 @@ export function SessionDetailContent({
 				/>
 			) : null}
 
-			{/* Direction toggle. Gated on `has_content` (not on
-			    `messages.length`) so it stays visible while pages
-			    are still loading. Status + flip control collapsed
-			    onto one muted line — the date-divider below provides
-			    the visual break between metadata and conversation,
-			    so no separator above is needed. */}
+			{/* Timeline filters and direction stay visible while pages load. */}
 			{session.has_content ? (
-				<div className="flex items-center justify-end gap-2 text-xs text-muted-foreground">
-					{loadedCount > 0 ? (
-						<span className="tabular-nums">
-							{loadedCount}/{totalMessages}
-						</span>
-					) : null}
-					<button
-						type="button"
-						onClick={() => persistDirection(direction === "desc" ? "asc" : "desc")}
-						aria-label={
-							direction === "desc" ? "Show oldest messages first" : "Show newest messages first"
-						}
-						className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 hover:bg-accent hover:text-accent-foreground transition-colors"
+				<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+					<ToggleGroup
+						value={[timelineView]}
+						onValueChange={(values) => {
+							const selected = values[0];
+							if (
+								selected !== "all" &&
+								selected !== "user" &&
+								selected !== "assistant" &&
+								selected !== "tools"
+							) {
+								return;
+							}
+							if (agentId) {
+								void router.navigate({
+									...agentSessionDetailLink(
+										agentId,
+										sessionId,
+										selected === "all" ? undefined : { timelineView: selected },
+									),
+									replace: true,
+									resetScroll: false,
+								});
+								return;
+							}
+							void router.navigate({
+								...sessionTimelineViewLink(sessionId, selected, { returnTo }),
+								replace: true,
+								resetScroll: false,
+							});
+						}}
+						variant="outline"
+						size="sm"
+						spacing={0}
+						aria-label="Timeline view"
 					>
-						{direction === "desc" ? (
-							<ArrowDownNarrowWide className="size-3.5" />
-						) : (
-							<ArrowUpNarrowWide className="size-3.5" />
-						)}
-						{direction === "desc" ? "Newest first" : "Oldest first"}
-					</button>
+						<ToggleGroupItem value="all">All</ToggleGroupItem>
+						<ToggleGroupItem value="user">You</ToggleGroupItem>
+						<ToggleGroupItem value="assistant">Agent</ToggleGroupItem>
+						<ToggleGroupItem value="tools">Tools</ToggleGroupItem>
+					</ToggleGroup>
+					<div className="flex items-center justify-end gap-2 text-xs text-muted-foreground">
+						{loadedCount > 0 ? (
+							<span className="tabular-nums">
+								{loadedCount}/{totalItems}
+							</span>
+						) : null}
+						<button
+							type="button"
+							onClick={() => persistDirection(direction === "desc" ? "asc" : "desc")}
+							aria-label={
+								direction === "desc" ? "Show oldest activity first" : "Show newest activity first"
+							}
+							className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 transition-colors hover:bg-accent hover:text-accent-foreground"
+						>
+							{direction === "desc" ? (
+								<ArrowDownNarrowWide className="size-3.5" />
+							) : (
+								<ArrowUpNarrowWide className="size-3.5" />
+							)}
+							{direction === "desc" ? "Newest first" : "Oldest first"}
+						</button>
+					</div>
 				</div>
 			) : null}
 
-			{/* Messages */}
+			{/* Timeline */}
 			{session.has_content ? (
 				isContentLoading ? (
 					<MessagesSkeleton />
@@ -514,16 +585,16 @@ export function SessionDetailContent({
 						onRetry={() => {
 							void refetchContent();
 						}}
-						title="Couldn't load messages"
+						title="Couldn't load activity"
 					/>
-				) : messages?.length ? (
+				) : timelineItems?.length ? (
 					// Spacing comes from MessageBlock's `pt-4` on
 					// group-start rows; continuation rows render flush
 					// so a thread looks tight, not gapped.
 					<div>
-						<MessageList
-							messages={messages}
-							messageKeys={messageKeys}
+						<SessionTimelineList
+							items={timelineItems}
+							itemKeys={timelineKeys}
 							agentType={session.agent_type}
 							userAvatar={user?.imageUrl}
 							userName={user?.fullName || "You"}
@@ -534,14 +605,14 @@ export function SessionDetailContent({
 						{hasNextPage ? (
 							<LoadMoreSentinel
 								loadedCount={loadedCount}
-								totalCount={totalMessages}
+								totalCount={totalItems}
 								isFetching={isFetchingNextPage}
 								onLoad={() => fetchNextPage()}
 							/>
 						) : null}
 					</div>
 				) : (
-					<EmptyContent />
+					<EmptyContent view={timelineView} />
 				)
 			) : (
 				<DetailPanel className="space-y-4">
@@ -565,7 +636,9 @@ export function SessionDetailContent({
 			    where the newest message is at the bottom of a long
 			    list. In desc mode the newest is already at the top,
 			    so there's nothing to jump to. */}
-			{direction === "asc" && messages && messages.length > 20 ? <JumpToBottomButton /> : null}
+			{direction === "asc" && timelineItems && timelineItems.length > 20 ? (
+				<JumpToBottomButton />
+			) : null}
 		</div>
 	);
 }
@@ -739,6 +812,14 @@ function MessagesSkeleton() {
 	);
 }
 
-function EmptyContent() {
-	return <EmptyState variant="inset" description="No messages in this session." />;
+function EmptyContent({ view }: { view: SessionTimelineView }) {
+	const description =
+		view === "tools"
+			? "No tool activity in this session."
+			: view === "user"
+				? "No user messages in this session."
+				: view === "assistant"
+					? "No agent messages in this session."
+					: "No visible activity in this session.";
+	return <EmptyState variant="inset" description={description} />;
 }

--- a/apps/web/src/pages/public-share/session-page.tsx
+++ b/apps/web/src/pages/public-share/session-page.tsx
@@ -5,7 +5,7 @@ import { DetailMeta, DetailStats, DetailTitle } from "@/components/detail/layout
 import { ModelBadge } from "@/components/meta/model-badge";
 import { Stat } from "@/components/meta/stat";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
-import { MessageList } from "@/components/sessions/message-list";
+import { SessionTimelineList } from "@/components/sessions/message-list";
 import { SessionSidebar } from "@/components/sessions/session-sidebar";
 import { ShareHeaderUser } from "@/components/share/header-user";
 import { NoAccess } from "@/components/share/no-access";
@@ -143,8 +143,8 @@ export default function PublicSharePage({
 					<p className="text-sm text-muted-foreground">This session has no readable content.</p>
 				) : (
 					<div>
-						<MessageList
-							messages={messagesPage.items}
+						<SessionTimelineList
+							items={messagesPage.items}
 							agentType={share.agent_type}
 							userAvatar={share.owner_avatar_url ?? undefined}
 							userName={share.owner_name || "User"}

--- a/apps/web/src/routes/_protected/_dashboard/agents/$id/sessions/$sessionId.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/agents/$id/sessions/$sessionId.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { AgentResourceRouteGate } from "@/components/dashboard/agent-resource-route-gate";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { routeHeadTitle } from "@/lib/document-title";
+import { parseSessionTimelineView } from "@/lib/session-search-anchor";
 import AgentSessionDetailPage from "@/pages/dashboard/agents/agent-session-detail-page";
 
 export const Route = createFileRoute("/_protected/_dashboard/agents/$id/sessions/$sessionId")({
@@ -11,6 +12,7 @@ export const Route = createFileRoute("/_protected/_dashboard/agents/$id/sessions
 
 function AgentSessionDetailRoute() {
 	const { id, sessionId } = Route.useParams();
+	const search = Route.useSearch();
 	return (
 		<AgentResourceRouteGate
 			agentId={id}
@@ -18,7 +20,11 @@ function AgentSessionDetailRoute() {
 			returnLabel="Agent overview"
 			requiredAdapterModule="sessions"
 		>
-			<AgentSessionDetailPage agentId={id} sessionId={sessionId} />
+			<AgentSessionDetailPage
+				agentId={id}
+				sessionId={sessionId}
+				timelineView={parseSessionTimelineView(search.timelineView) ?? "all"}
+			/>
 		</AgentResourceRouteGate>
 	);
 }

--- a/apps/web/src/routes/_protected/_dashboard/sessions/$id.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/sessions/$id.tsx
@@ -21,6 +21,7 @@ function SessionDetailRoute() {
 			sessionId={id}
 			searchAnchor={searchAnchor}
 			searchQuery={search.matchQuery}
+			timelineView={search.timelineView ?? "all"}
 			returnTo={search.returnTo}
 		/>
 	);

--- a/backend/app/routes/public_sessions.py
+++ b/backend/app/routes/public_sessions.py
@@ -46,7 +46,7 @@ from app.services.session_content import (
     SessionContentMissing,
     load_session_messages,
     session_has_uploaded_content,
-    slice_session_messages,
+    slice_session_items,
 )
 from app.services.session_export import (
     public_session_base_fields,
@@ -178,7 +178,7 @@ async def get_shared_session_messages(
         ) from None
 
     total = len(raw)
-    sliced = slice_session_messages(raw, offset=offset, limit=limit, direction=direction)
+    sliced = slice_session_items(raw, offset=offset, limit=limit, direction=direction)
     return SessionMessagesPage(
         items=[SessionMessageResponse.model_validate(m) for m in sliced],
         total=total,

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -101,6 +101,7 @@ from app.schemas.session import (
     SessionSearchAnchorResponse,
     SessionSearchMatchResponse,
     SessionSearchNavigationResponse,
+    SessionTimelinePage,
     SessionUploadResponse,
 )
 from app.services import memory_extraction
@@ -126,10 +127,10 @@ from app.services.runtime_source_revision import (
 from app.services.session_content import (
     SessionContentInvalid,
     SessionContentMissing,
-    load_session_message_projection,
+    load_session_content_projection,
     load_session_messages,
     session_has_uploaded_content,
-    slice_session_messages,
+    slice_session_items,
 )
 from app.services.session_export import session_to_markdown
 from app.services.session_refs import extract_related_refs
@@ -3102,18 +3103,21 @@ async def get_session_messages(
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=100, ge=1, le=500),
     direction: Literal["asc", "desc"] = Query(default="asc"),
+    view: Literal["messages", "all", "user", "assistant", "tools"] = Query(default="messages"),
     anchor_kind: Literal["snapshot_offset", "event_seq"] | None = Query(default=None),
     anchor_position: int | None = Query(default=None, ge=0),
     anchor_revision: str | None = Query(default=None, min_length=1, max_length=80),
     search_query: str | None = Query(default=None, max_length=500),
     auth: AuthContext = Depends(require_scope("sessions:read")),
     db: AsyncSession = Depends(get_session),
-) -> SessionMessagesPage:
-    """Paginated read of a session's messages, for the dashboard.
+) -> SessionMessagesPage | SessionTimelinePage:
+    """Paginated read of a session's owner-visible timeline.
     The CLI's `clawdi pull` mirror still uses
     `GET /v1/sessions/{id}/content` to grab the full JSON blob;
     this endpoint slices the same blob server-side so the
-    dashboard doesn't ship 10+ MB of messages on a long session.
+    dashboard doesn't ship 10+ MB of messages on a long session. The default
+    `view=messages` preserves the historical response exactly. Other views add
+    a typed message/tool timeline without exposing reasoning or hidden events.
 
     Pagination is offset-based within the requested direction. `offset=0`
     starts at the oldest visible message for ascending reads and at the newest
@@ -3154,7 +3158,7 @@ async def get_session_messages(
     # share the same cache — a popular shared link must not re-parse
     # a 10 MB JSON blob per visitor.
     try:
-        projection = await load_session_message_projection(session, file_store, db)
+        projection = await load_session_content_projection(session, file_store, db)
     except SessionContentMissing:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session content file not found") from None
     except SessionContentInvalid:
@@ -3162,7 +3166,27 @@ async def get_session_messages(
             status.HTTP_500_INTERNAL_SERVER_ERROR, "Internal server error"
         ) from None
 
-    total = len(projection.messages)
+    if view == "messages":
+        projected_items = projection.messages
+        source_positions = projection.source_positions
+    else:
+        filtered_timeline = [
+            (item, position)
+            for item, position in zip(
+                projection.timeline,
+                projection.timeline_source_positions,
+                strict=True,
+            )
+            if (
+                view == "all"
+                or (view == "tools" and item.get("kind") in ("tool_call", "tool_result"))
+                or (view in ("user", "assistant") and item.get("role") == view)
+            )
+        ]
+        projected_items = [item for item, _ in filtered_timeline]
+        source_positions = tuple(position for _, position in filtered_timeline)
+
+    total = len(projected_items)
     page_offset = offset
     anchor_offset: int | None = None
     search_navigation: SessionSearchNavigationResponse | None = None
@@ -3202,7 +3226,7 @@ async def get_session_messages(
         and resolved_anchor_revision == active_search_revision
     ):
         try:
-            source_index = projection.source_positions.index(resolved_anchor_position)
+            source_index = source_positions.index(resolved_anchor_position)
         except ValueError:
             pass
         else:
@@ -3237,20 +3261,23 @@ async def get_session_messages(
                     ),
                 )
 
-    sliced = slice_session_messages(
-        projection.messages,
+    sliced = slice_session_items(
+        projected_items,
         offset=page_offset,
         limit=limit,
         direction=direction,
     )
-    return SessionMessagesPage(
-        items=[SessionMessageResponse.model_validate(m) for m in sliced],
-        total=total,
-        offset=page_offset,
-        limit=limit,
-        anchor_offset=anchor_offset,
-        search_navigation=search_navigation,
-    )
+    page_values = {
+        "items": sliced,
+        "total": total,
+        "offset": page_offset,
+        "limit": limit,
+        "anchor_offset": anchor_offset,
+        "search_navigation": search_navigation,
+    }
+    if view == "messages":
+        return SessionMessagesPage.model_validate(page_values)
+    return SessionTimelinePage.model_validate(page_values)
 
 
 @router.post("/sessions/{local_session_id}/extract")

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -643,6 +643,44 @@ class SessionMessageResponse(BaseModel):
     timestamp: datetime | None = None
 
 
+class SessionTimelineMessageResponse(SessionMessageResponse):
+    """Dashboard timeline message with its canonical event position."""
+
+    kind: Literal["message"] = "message"
+    position: int = Field(ge=0)
+
+
+class SessionToolCallResponse(BaseModel):
+    """Safe, owner-only projection of a tool invocation."""
+
+    kind: Literal["tool_call"] = "tool_call"
+    position: int = Field(ge=0)
+    call_id: str
+    name: str
+    arguments_json: str | None = None
+    model: str | None = None
+    timestamp: datetime | None = None
+
+
+class SessionToolResultResponse(BaseModel):
+    """Safe, owner-only projection of a tool result."""
+
+    kind: Literal["tool_result"] = "tool_result"
+    position: int = Field(ge=0)
+    call_id: str
+    name: str | None = None
+    status: Literal["completed", "error"]
+    content: str | None = None
+    result_json: str | None = None
+    timestamp: datetime | None = None
+
+
+SessionTimelineItemResponse = Annotated[
+    SessionTimelineMessageResponse | SessionToolCallResponse | SessionToolResultResponse,
+    Field(discriminator="kind"),
+]
+
+
 class PublicSessionExportResponse(PublicSessionResponse):
     """Public-safe structured session export payload."""
 
@@ -669,6 +707,24 @@ class SessionMessagesPage(BaseModel):
     limit: int
     # Absolute offset in the requested direction for a resolved search match.
     # Omitted for ordinary pagination and stale or invalidated search anchors.
+    anchor_offset: int | None = Field(
+        default=None,
+        ge=0,
+        exclude_if=lambda value: value is None,
+    )
+    search_navigation: SessionSearchNavigationResponse | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+    )
+
+
+class SessionTimelinePage(BaseModel):
+    """Paginated owner-only projection of visible messages and tool activity."""
+
+    items: list[SessionTimelineItemResponse]
+    total: int
+    offset: int
+    limit: int
     anchor_offset: int | None = Field(
         default=None,
         ge=0,

--- a/backend/app/services/session_content.py
+++ b/backend/app/services/session_content.py
@@ -29,6 +29,7 @@ from app.schemas.session_events import SessionEvent
 from app.services.session_events import (
     EMPTY_EVENT_HEAD,
     project_safe_messages,
+    project_safe_timeline,
     project_visible_messages,
     validate_event_chunk_async,
 )
@@ -46,25 +47,26 @@ class _FileStoreLike(Protocol):
 # TTL exists for hygiene only: the (file_key, content_hash) key already
 # invalidates a stale snapshot, so a long-quiet entry is safe; the TTL just
 # stops it from pinning memory forever.
-_MESSAGES_CACHE_MAX = 16
-_MESSAGES_CACHE_TTL_S = 300.0
+_CONTENT_CACHE_MAX = 16
+_CONTENT_CACHE_TTL_S = 300.0
 type SessionMessageValue = dict[str, JsonValue]
+type SessionTimelineValue = dict[str, JsonValue]
 type SessionMessageDirection = Literal["asc", "desc"]
 
 
 @dataclass(frozen=True, slots=True)
-class SessionMessageProjection:
+class SessionContentProjection:
     messages: list[SessionMessageValue]
     source_positions: tuple[int, ...]
+    timeline: list[SessionTimelineValue]
+    timeline_source_positions: tuple[int, ...]
 
 
 _SESSION_MESSAGES_ADAPTER: TypeAdapter[list[SessionMessageValue]] = TypeAdapter(
     list[SessionMessageValue]
 )
-_messages_cache: OrderedDict[tuple[str, str], tuple[float, SessionMessageProjection]] = (
-    OrderedDict()
-)
-_messages_cache_lock = threading.Lock()
+_content_cache: OrderedDict[tuple[str, str], tuple[float, SessionContentProjection]] = OrderedDict()
+_content_cache_lock = threading.Lock()
 
 
 class SessionContentMissing(Exception):
@@ -82,44 +84,44 @@ def session_has_uploaded_content(session: Session) -> bool:
     )
 
 
-def _cache_get(key: tuple[str, str]) -> SessionMessageProjection | None:
+def _cache_get(key: tuple[str, str]) -> SessionContentProjection | None:
     now = time.monotonic()
-    with _messages_cache_lock:
-        entry = _messages_cache.get(key)
+    with _content_cache_lock:
+        entry = _content_cache.get(key)
         if entry is None:
             return None
         ts, parsed = entry
-        if now - ts > _MESSAGES_CACHE_TTL_S:
-            _messages_cache.pop(key, None)
+        if now - ts > _CONTENT_CACHE_TTL_S:
+            _content_cache.pop(key, None)
             return None
         # Touch — bump to end for LRU.
-        _messages_cache.move_to_end(key)
+        _content_cache.move_to_end(key)
         return parsed
 
 
-def _cache_put(key: tuple[str, str], projection: SessionMessageProjection) -> None:
+def _cache_put(key: tuple[str, str], projection: SessionContentProjection) -> None:
     now = time.monotonic()
-    with _messages_cache_lock:
-        _messages_cache[key] = (now, projection)
-        _messages_cache.move_to_end(key)
-        while len(_messages_cache) > _MESSAGES_CACHE_MAX:
-            _messages_cache.popitem(last=False)
+    with _content_cache_lock:
+        _content_cache[key] = (now, projection)
+        _content_cache.move_to_end(key)
+        while len(_content_cache) > _CONTENT_CACHE_MAX:
+            _content_cache.popitem(last=False)
 
 
-def slice_session_messages(
-    messages: Sequence[SessionMessageValue],
+def slice_session_items(
+    items: Sequence[SessionMessageValue],
     *,
     offset: int,
     limit: int,
     direction: SessionMessageDirection,
 ) -> list[SessionMessageValue]:
-    """Slice messages in the requested order using an order-relative offset."""
+    """Slice session projection items using an order-relative offset."""
     if direction == "asc":
-        return list(messages[offset : offset + limit])
+        return list(items[offset : offset + limit])
 
-    end = max(0, len(messages) - offset)
+    end = max(0, len(items) - offset)
     start = max(0, end - limit)
-    return list(reversed(messages[start:end]))
+    return list(reversed(items[start:end]))
 
 
 async def load_session_messages(
@@ -137,16 +139,16 @@ async def load_session_messages(
     - `SessionContentInvalid`: JSON decode failure or non-list payload.
       Indicates an upload corruption; route layer returns 500.
     """
-    projection = await load_session_message_projection(session, file_store, db)
+    projection = await load_session_content_projection(session, file_store, db)
     return projection.messages
 
 
-async def load_session_message_projection(
+async def load_session_content_projection(
     session: Session,
     file_store: _FileStoreLike,
     db: AsyncSession | None = None,
-) -> SessionMessageProjection:
-    """Load visible messages with their canonical source positions."""
+) -> SessionContentProjection:
+    """Load cached message and owner-only timeline projections."""
     if session.content_protocol == "events-v1" and session.event_generation_id is not None:
         if db is None:
             raise SessionContentInvalid("events-v1 content requires a database session")
@@ -159,9 +161,12 @@ async def load_session_message_projection(
             return cached
         events = await load_session_events(session, file_store, db)
         visible = project_visible_messages(events)
-        projection = SessionMessageProjection(
+        timeline = project_safe_timeline(events)
+        projection = SessionContentProjection(
             messages=_SESSION_MESSAGES_ADAPTER.validate_python(project_safe_messages(events)),
             source_positions=tuple(message.position for message in visible),
+            timeline=[item.value for item in timeline],
+            timeline_source_positions=tuple(item.position for item in timeline),
         )
         _cache_put(cache_key, projection)
         return projection
@@ -193,9 +198,14 @@ async def load_session_message_projection(
             f"session {session.id} content is not a valid JSON message array"
         ) from exc
 
-    projection = SessionMessageProjection(
+    projection = SessionContentProjection(
         messages=parsed,
         source_positions=tuple(range(len(parsed))),
+        timeline=[
+            {"kind": "message", "position": position, **message}
+            for position, message in enumerate(parsed)
+        ],
+        timeline_source_positions=tuple(range(len(parsed))),
     )
     _cache_put(cache_key, projection)
     return projection

--- a/backend/app/services/session_events.py
+++ b/backend/app/services/session_events.py
@@ -10,7 +10,13 @@ from typing import Literal
 
 from pydantic import JsonValue, TypeAdapter, ValidationError
 
-from app.schemas.session_events import SessionEvent, SessionMessageEvent, SessionTextPart
+from app.schemas.session_events import (
+    SessionEvent,
+    SessionMessageEvent,
+    SessionTextPart,
+    SessionToolCallEvent,
+    SessionToolResultEvent,
+)
 
 EMPTY_EVENT_HEAD = hashlib.sha256(b"clawdi-events-v1\n").hexdigest()
 EVENT_ADAPTER: TypeAdapter[SessionEvent] = TypeAdapter(SessionEvent)
@@ -37,6 +43,13 @@ class ProjectedSessionMessage:
     content: str
     model: str | None
     timestamp: datetime | None
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectedSessionTimelineItem:
+    position: int
+    kind: Literal["message", "tool_call", "tool_result"]
+    value: dict[str, JsonValue]
 
 
 def canonical_event_json(value: object) -> bytes:
@@ -134,16 +147,87 @@ def project_visible_messages(events: Sequence[SessionEvent]) -> list[ProjectedSe
     return messages
 
 
-def project_safe_messages(events: Sequence[SessionEvent]) -> list[dict[str, object]]:
-    messages: list[dict[str, object]] = []
-    for projected in project_visible_messages(events):
-        message: dict[str, object] = {
-            "role": projected.role,
-            "content": projected.content,
-        }
-        if projected.model is not None:
-            message["model"] = projected.model
-        if projected.timestamp is not None:
-            message["timestamp"] = projected.timestamp.isoformat()
-        messages.append(message)
-    return messages
+def _safe_message_value(message: ProjectedSessionMessage) -> dict[str, JsonValue]:
+    value: dict[str, JsonValue] = {
+        "role": message.role,
+        "content": message.content,
+    }
+    if message.model is not None:
+        value["model"] = message.model
+    if message.timestamp is not None:
+        value["timestamp"] = message.timestamp.isoformat()
+    return value
+
+
+def project_safe_messages(events: Sequence[SessionEvent]) -> list[dict[str, JsonValue]]:
+    return [_safe_message_value(message) for message in project_visible_messages(events)]
+
+
+def project_safe_timeline(events: Sequence[SessionEvent]) -> list[ProjectedSessionTimelineItem]:
+    """Project owner-visible messages and tool activity from canonical events.
+
+    Reasoning, system/developer messages, hidden events, raw provider envelopes,
+    and attachment bodies are deliberately absent. Public session routes do not
+    consume this projection.
+    """
+    items: list[ProjectedSessionTimelineItem] = []
+    for event in events:
+        if event.semantics is not None and event.semantics.display == "hidden":
+            continue
+        if isinstance(event, SessionMessageEvent):
+            if event.role not in ("user", "assistant"):
+                continue
+            text = "\n".join(
+                part.text for part in event.parts if isinstance(part, SessionTextPart) and part.text
+            )
+            if not text:
+                continue
+            message = ProjectedSessionMessage(
+                position=event.seq,
+                role=event.role,
+                content=text,
+                model=event.model,
+                timestamp=event.timestamp,
+            )
+            message_value: dict[str, JsonValue] = {
+                "kind": "message",
+                "position": event.seq,
+                **_safe_message_value(message),
+            }
+            items.append(ProjectedSessionTimelineItem(event.seq, "message", message_value))
+            continue
+        if isinstance(event, SessionToolCallEvent):
+            tool_call_value: dict[str, JsonValue] = {
+                "kind": "tool_call",
+                "position": event.seq,
+                "call_id": event.call_id,
+                "name": event.name,
+            }
+            if event.arguments_json is not None:
+                tool_call_value["arguments_json"] = event.arguments_json
+            if event.model is not None:
+                tool_call_value["model"] = event.model
+            if event.timestamp is not None:
+                tool_call_value["timestamp"] = event.timestamp.isoformat()
+            items.append(ProjectedSessionTimelineItem(event.seq, "tool_call", tool_call_value))
+            continue
+        if isinstance(event, SessionToolResultEvent):
+            text = "\n".join(
+                part.text for part in event.parts if isinstance(part, SessionTextPart) and part.text
+            )
+            tool_result_value: dict[str, JsonValue] = {
+                "kind": "tool_result",
+                "position": event.seq,
+                "call_id": event.call_id,
+                "status": event.status,
+            }
+            if event.name is not None:
+                tool_result_value["name"] = event.name
+            if text:
+                tool_result_value["content"] = text
+            if event.result_json is not None:
+                tool_result_value["result_json"] = event.result_json
+            if event.timestamp is not None:
+                tool_result_value["timestamp"] = event.timestamp.isoformat()
+            items.append(ProjectedSessionTimelineItem(event.seq, "tool_result", tool_result_value))
+    return items

--- a/backend/tests/test_session_events.py
+++ b/backend/tests/test_session_events.py
@@ -397,6 +397,78 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
         "offset": 0,
         "limit": 2,
     }
+    initial_timeline = await client.get(
+        f"/v1/sessions/{session.id}/messages",
+        params={"view": "all", "direction": "desc"},
+    )
+    assert initial_timeline.status_code == 200, initial_timeline.text
+    assert initial_timeline.json() == {
+        "items": [
+            {
+                "kind": "message",
+                "position": 4,
+                "role": "assistant",
+                "content": "visible answer",
+                "model": "claude-sonnet",
+                "timestamp": None,
+            },
+            {
+                "kind": "tool_result",
+                "position": 3,
+                "call_id": "call-1",
+                "name": "read",
+                "status": "completed",
+                "content": "secret tool output",
+                "result_json": None,
+                "timestamp": None,
+            },
+            {
+                "kind": "tool_call",
+                "position": 2,
+                "call_id": "call-1",
+                "name": "read",
+                "arguments_json": '{"path":"README.md"}',
+                "model": None,
+                "timestamp": None,
+            },
+            {
+                "kind": "message",
+                "position": 1,
+                "role": "user",
+                "content": "inspect this",
+                "model": None,
+                "timestamp": None,
+            },
+        ],
+        "total": 4,
+        "offset": 0,
+        "limit": 100,
+    }
+    tools_only = await client.get(
+        f"/v1/sessions/{session.id}/messages",
+        params={"view": "tools"},
+    )
+    assert tools_only.status_code == 200, tools_only.text
+    assert tools_only.json()["total"] == 2
+    assert [item["kind"] for item in tools_only.json()["items"]] == [
+        "tool_call",
+        "tool_result",
+    ]
+    user_only = await client.get(
+        f"/v1/sessions/{session.id}/messages",
+        params={"view": "user"},
+    )
+    assert user_only.status_code == 200, user_only.text
+    assert user_only.json()["items"] == [
+        {
+            "kind": "message",
+            "position": 1,
+            "role": "user",
+            "content": "inspect this",
+            "model": None,
+            "timestamp": None,
+        }
+    ]
     generation_commit = {
         "append_id": generation_append_id,
         "base_generation": None,
@@ -611,6 +683,17 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
     assert "private chain of thought" not in projected.text
     assert "opaque" not in projected.text
     assert "secret tool output" not in projected.text
+
+    latest_timeline = await client.get(
+        f"/v1/sessions/{session.id}/messages",
+        params={"view": "all"},
+    )
+    assert latest_timeline.status_code == 200, latest_timeline.text
+    assert latest_timeline.json()["total"] == 5
+    assert [item["position"] for item in latest_timeline.json()["items"]] == [1, 2, 3, 4, 6]
+    assert "private context" not in latest_timeline.text
+    assert "private chain of thought" not in latest_timeline.text
+    assert "opaque" not in latest_timeline.text
 
     # The committed generation now spans three immutable chunks. The read path
     # must use the new event head after both appends instead of serving the

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -1029,6 +1029,37 @@ async def test_session_messages_endpoint_paginates_long_conversations(
     assert page["items"][0]["content"] == "msg 0"
     assert page["items"][99]["content"] == "msg 99"
 
+    snapshot_timeline = await client.get(
+        f"/v1/sessions/{session_id}/messages",
+        params={"view": "all", "limit": 2},
+    )
+    assert snapshot_timeline.status_code == 200, snapshot_timeline.text
+    assert snapshot_timeline.json()["items"] == [
+        {
+            "kind": "message",
+            "position": 0,
+            "role": "user",
+            "content": "msg 0",
+            "model": None,
+            "timestamp": None,
+        },
+        {
+            "kind": "message",
+            "position": 1,
+            "role": "assistant",
+            "content": "msg 1",
+            "model": None,
+            "timestamp": None,
+        },
+    ]
+    snapshot_tools = await client.get(
+        f"/v1/sessions/{session_id}/messages",
+        params={"view": "tools"},
+    )
+    assert snapshot_tools.status_code == 200, snapshot_tools.text
+    assert snapshot_tools.json()["items"] == []
+    assert snapshot_tools.json()["total"] == 0
+
     # Second page picks up at offset=100.
     r2 = await client.get(f"/v1/sessions/{session_id}/messages?offset=100&limit=100")
     page2 = r2.json()
@@ -1153,7 +1184,7 @@ async def test_session_messages_endpoint_caches_parsed_blob(
     # without a real file_store.get hit. The cache moved to
     # services/session_content.py (shared with the public share
     # routes); the route handler is now a thin wrapper.
-    session_content._messages_cache.clear()
+    session_content._content_cache.clear()
 
     counting_store = _CountingGetFileStore(sessions_route.file_store)
     monkeypatch.setattr(sessions_route, "file_store", counting_store)

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1347,11 +1347,13 @@ export interface paths {
         };
         /**
          * Get Session Messages
-         * @description Paginated read of a session's messages, for the dashboard.
+         * @description Paginated read of a session's owner-visible timeline.
          *     The CLI's `clawdi pull` mirror still uses
          *     `GET /v1/sessions/{id}/content` to grab the full JSON blob;
          *     this endpoint slices the same blob server-side so the
-         *     dashboard doesn't ship 10+ MB of messages on a long session.
+         *     dashboard doesn't ship 10+ MB of messages on a long session. The default
+         *     `view=messages` preserves the historical response exactly. Other views add
+         *     a typed message/tool timeline without exposing reasoning or hidden events.
          *
          *     Pagination is offset-based within the requested direction. `offset=0`
          *     starts at the oldest visible message for ascending reads and at the newest
@@ -8210,6 +8212,47 @@ export interface components {
             /** Text */
             text: string;
         };
+        /**
+         * SessionTimelineMessageResponse
+         * @description Dashboard timeline message with its canonical event position.
+         */
+        SessionTimelineMessageResponse: {
+            /**
+             * Role
+             * @enum {string}
+             */
+            role: "user" | "assistant";
+            /** Content */
+            content: string;
+            /** Model */
+            model?: string | null;
+            /** Timestamp */
+            timestamp?: string | null;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "message";
+            /** Position */
+            position: number;
+        };
+        /**
+         * SessionTimelinePage
+         * @description Paginated owner-only projection of visible messages and tool activity.
+         */
+        SessionTimelinePage: {
+            /** Items */
+            items: (components["schemas"]["SessionTimelineMessageResponse"] | components["schemas"]["SessionToolCallResponse"] | components["schemas"]["SessionToolResultResponse"])[];
+            /** Total */
+            total: number;
+            /** Offset */
+            offset: number;
+            /** Limit */
+            limit: number;
+            /** Anchor Offset */
+            anchor_offset?: number | null;
+            search_navigation?: components["schemas"]["SessionSearchNavigationResponse"] | null;
+        };
         /** SessionToolCallEvent */
         SessionToolCallEvent: {
             /** Seq */
@@ -8233,6 +8276,29 @@ export interface components {
             arguments_json?: string | null;
             /** Model */
             model?: string | null;
+        };
+        /**
+         * SessionToolCallResponse
+         * @description Safe, owner-only projection of a tool invocation.
+         */
+        SessionToolCallResponse: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "tool_call";
+            /** Position */
+            position: number;
+            /** Call Id */
+            call_id: string;
+            /** Name */
+            name: string;
+            /** Arguments Json */
+            arguments_json?: string | null;
+            /** Model */
+            model?: string | null;
+            /** Timestamp */
+            timestamp?: string | null;
         };
         /** SessionToolResultEvent */
         SessionToolResultEvent: {
@@ -8262,6 +8328,34 @@ export interface components {
             parts: (components["schemas"]["SessionTextPart"] | components["schemas"]["SessionAttachmentPart"])[];
             /** Result Json */
             result_json?: string | null;
+        };
+        /**
+         * SessionToolResultResponse
+         * @description Safe, owner-only projection of a tool result.
+         */
+        SessionToolResultResponse: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "tool_result";
+            /** Position */
+            position: number;
+            /** Call Id */
+            call_id: string;
+            /** Name */
+            name?: string | null;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "completed" | "error";
+            /** Content */
+            content?: string | null;
+            /** Result Json */
+            result_json?: string | null;
+            /** Timestamp */
+            timestamp?: string | null;
         };
         /** SessionUploadCapabilitiesResponse */
         SessionUploadCapabilitiesResponse: {
@@ -11754,6 +11848,7 @@ export interface operations {
                 offset?: number;
                 limit?: number;
                 direction?: "asc" | "desc";
+                view?: "messages" | "all" | "user" | "assistant" | "tools";
                 anchor_kind?: ("snapshot_offset" | "event_seq") | null;
                 anchor_position?: number | null;
                 anchor_revision?: string | null;
@@ -11773,7 +11868,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SessionMessagesPage"];
+                    "application/json": components["schemas"]["SessionMessagesPage"] | components["schemas"]["SessionTimelinePage"];
                 };
             };
             /** @description Validation Error */

--- a/packages/shared/src/api/schemas.ts
+++ b/packages/shared/src/api/schemas.ts
@@ -31,6 +31,10 @@ export type SessionListItem = Schemas["SessionListItemResponse"];
 export type SessionDetail = Schemas["SessionDetailResponse"];
 export type SessionMessage = Schemas["SessionMessageResponse"];
 export type SessionMessagesPage = Schemas["SessionMessagesPage"];
+export type SessionTimelineItem = Schemas["SessionTimelinePage"]["items"][number];
+export type SessionTimelinePage = Schemas["SessionTimelinePage"];
+export type SessionToolCall = Schemas["SessionToolCallResponse"];
+export type SessionToolResult = Schemas["SessionToolResultResponse"];
 export type SessionUploadResult = Schemas["SessionUploadResponse"];
 export type Environment = Schemas["EnvironmentResponse"];
 


### PR DESCRIPTION
## Summary

- add a typed owner-only session timeline projected from existing events-v1 chunks, with no new database or object-store copy
- add All / You / Agent / Tools filters and collapsible paired tool call/result details
- improve long-session rendering while preserving legacy message responses, public-share safety, CLI mirrors, and rolling-deploy compatibility

## Verification

- backend focused tests with migrated PostgreSQL: 21 passed
- Ruff and focused BasedPyright: passed
- generated API consistency: passed
- web typecheck and focused unit tests: passed (18 tests)
- OSS production build: passed
- Chromium session search/timeline E2E: 2 passed
- modified files Biome 2.5.9 check: passed
- git diff --check: passed

Full-repository Biome reports one pre-existing unused import in apps/web/src/hosted/v2/channels/channels-hooks.ts; this branch does not modify that file.