### PR TITLE
fix(sessions): make search results exact and explainable

### DIFF
--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -165,6 +165,7 @@ test("opens a message search result and returns to the same filtered list", asyn
 });
 
 test("filters session activity and expands paired tool details", async ({ page }) => {
+	await page.setViewportSize({ width: 1280, height: 900 });
 	const timeline = [
 		{
 			kind: "message",
@@ -225,6 +226,7 @@ test("filters session activity and expands paired tool details", async ({ page }
 			const query = url.searchParams.get("search_query");
 			if (query) {
 				expect(view).toBe("all");
+				await new Promise((resolve) => setTimeout(resolve, 450));
 				return fulfillJson(route, {
 					items: [timeline[0]],
 					total: 1,
@@ -258,6 +260,7 @@ test("filters session activity and expands paired tool details", async ({ page }
 	await expect(page.getByText("Final answer after reading the file")).not.toBeVisible();
 	await toolActivity.click();
 	await expect(page.locator("pre").filter({ hasText: '"path": "README.md"' })).toBeVisible();
+	await page.getByRole("tab", { name: "Output" }).click();
 	await expect(page.getByText("Repository instructions", { exact: true })).toBeVisible();
 
 	await page.getByRole("button", { name: "You" }).click();
@@ -267,6 +270,8 @@ test("filters session activity and expands paired tool details", async ({ page }
 
 	await page.getByRole("button", { name: "Tools" }).click();
 	await page.getByRole("textbox", { name: "Search this session" }).fill("Final answer");
+	await expect(page.getByText("Searching", { exact: true })).toBeVisible();
+	await expect(toolActivity).toBeVisible();
 	await expect(page).toHaveURL((url) => {
 		return (
 			url.searchParams.get("matchQuery") === "Final answer" && !url.searchParams.has("timelineView")

--- a/apps/web/src/components/markdown.test.tsx
+++ b/apps/web/src/components/markdown.test.tsx
@@ -7,14 +7,13 @@ describe("Markdown search highlighting", () => {
 	test("highlights visible text without changing fenced code", () => {
 		const markup = renderToStaticMarkup(
 			createElement(Markdown, {
-				content: "Fixed **authentication** timeout.\n\n```text\nauthentication timeout\n```",
+				content: "Fixed authentication timeout.\n\n```text\nauthentication timeout\n```",
 				highlightQuery: "authentication timeout",
 			}),
 		);
 
-		expect(markup.match(/<mark/g)).toHaveLength(2);
-		expect(markup).toContain(">authentication</mark>");
-		expect(markup).toContain(">timeout</mark>");
+		expect(markup.match(/<mark/g)).toHaveLength(1);
+		expect(markup).toContain(">authentication timeout</mark>");
 		expect(markup).toContain("authentication timeout\n</code>");
 	});
 });

--- a/apps/web/src/components/sessions/message-list.tsx
+++ b/apps/web/src/components/sessions/message-list.tsx
@@ -7,6 +7,7 @@ import { agentTypeLabel } from "@/components/dashboard/agent-label";
 import { Markdown } from "@/components/markdown";
 import { ModelBadge } from "@/components/meta/model-badge";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type {
 	SessionMessage,
 	SessionTimelineItem,
@@ -325,14 +326,38 @@ function formatToolPayload(value: string): string {
 	}
 }
 
-function ToolPayload({ label, value }: { label: string; value: string }) {
+function ToolDetails({ call, result }: { call?: SessionToolCall; result?: SessionToolResult }) {
+	const payloads = [
+		call?.arguments_json
+			? { key: "arguments", label: "Arguments", value: call.arguments_json }
+			: null,
+		result?.content ? { key: "output", label: "Output", value: result.content } : null,
+		result?.result_json ? { key: "result", label: "Result", value: result.result_json } : null,
+	].filter((payload): payload is { key: string; label: string; value: string } => payload !== null);
+	const first = payloads[0];
+	if (!first) return null;
+
 	return (
-		<div className="space-y-1">
-			<div className="text-3xs font-medium uppercase text-muted-foreground">{label}</div>
-			<pre className="max-h-80 overflow-auto whitespace-pre-wrap break-all rounded-md bg-muted/50 p-2 font-mono text-xs text-foreground">
-				{formatToolPayload(value)}
-			</pre>
-		</div>
+		<Tabs defaultValue={first.key} className="min-w-0 gap-1.5">
+			{payloads.length > 1 ? (
+				<TabsList variant="line" className="h-7">
+					{payloads.map((payload) => (
+						<TabsTrigger key={payload.key} value={payload.key} className="h-7 px-1.5 text-xs">
+							{payload.label}
+						</TabsTrigger>
+					))}
+				</TabsList>
+			) : (
+				<div className="text-3xs font-medium uppercase text-muted-foreground">{first.label}</div>
+			)}
+			{payloads.map((payload) => (
+				<TabsContent key={payload.key} value={payload.key}>
+					<pre className="max-h-80 overflow-auto whitespace-pre-wrap break-all border-l-2 border-border bg-muted/30 px-3 py-2 font-mono text-xs text-foreground">
+						{formatToolPayload(payload.value)}
+					</pre>
+				</TabsContent>
+			))}
+		</Tabs>
 	);
 }
 
@@ -344,17 +369,19 @@ function ToolActivity({ call, result }: { call?: SessionToolCall; result?: Sessi
 	const timestamp = call?.timestamp ?? result?.timestamp;
 
 	return (
-		<div className={cn("flex gap-3 py-1.5", OFFSCREEN_RENDERING_CLASS)}>
-			<div className="flex w-8 shrink-0 justify-end pt-1 text-muted-foreground">
-				<Wrench className="size-3.5" />
+		<div className={cn("flex gap-3 py-2", OFFSCREEN_RENDERING_CLASS)}>
+			<div className="flex w-8 shrink-0 justify-center pt-1">
+				<span className="flex size-6 items-center justify-center rounded-md border bg-background text-muted-foreground shadow-xs">
+					<Wrench className="size-3.5" />
+				</span>
 			</div>
-			<div className="min-w-0 flex-1 border-l pl-3">
+			<div className="min-w-0 flex-1">
 				<button
 					type="button"
 					disabled={!hasDetails}
 					onClick={() => setOpen((value) => !value)}
 					aria-expanded={hasDetails ? open : undefined}
-					className="flex min-h-7 w-full min-w-0 items-center gap-2 text-left text-xs text-muted-foreground disabled:cursor-default"
+					className="flex min-h-8 w-full min-w-0 items-center gap-2 rounded-md px-2 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/60 disabled:cursor-default disabled:hover:bg-transparent"
 				>
 					<ChevronRight
 						className={cn(
@@ -388,12 +415,8 @@ function ToolActivity({ call, result }: { call?: SessionToolCall; result?: Sessi
 					) : null}
 				</button>
 				{open ? (
-					<div className="space-y-3 pb-2 pt-1">
-						{call?.arguments_json ? (
-							<ToolPayload label="Arguments" value={call.arguments_json} />
-						) : null}
-						{result?.content ? <ToolPayload label="Output" value={result.content} /> : null}
-						{result?.result_json ? <ToolPayload label="Result" value={result.result_json} /> : null}
+					<div className="px-2 pb-2 pt-1">
+						<ToolDetails call={call} result={result} />
 					</div>
 				) : null}
 			</div>

--- a/apps/web/src/components/sessions/session-search-navigation.tsx
+++ b/apps/web/src/components/sessions/session-search-navigation.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Link, useRouter } from "@tanstack/react-router";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronUp, LoaderCircle } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/search-input";
@@ -11,6 +11,7 @@ import {
 	sessionDetailSearchLink,
 	sessionSearchMatchLink,
 } from "@/lib/session-search-anchor";
+import { cn } from "@/lib/utils";
 
 type SearchNavigation = NonNullable<SessionMessagesPage["search_navigation"]>;
 
@@ -63,6 +64,7 @@ export function SessionSearchNavigation({
 	returnTo,
 	isSearching = false,
 	hasSearchError = false,
+	className,
 }: {
 	sessionId: string;
 	query: string;
@@ -70,6 +72,7 @@ export function SessionSearchNavigation({
 	returnTo?: string;
 	isSearching?: boolean;
 	hasSearchError?: boolean;
+	className?: string;
 }) {
 	const router = useRouter();
 	const [draftQuery, setDraftQuery] = useState(query);
@@ -98,7 +101,10 @@ export function SessionSearchNavigation({
 	return (
 		<nav
 			aria-label="Search this session"
-			className="sticky top-(--header-height) z-10 -mx-1 flex min-w-0 flex-col gap-2 border-y bg-background/95 px-1 py-2 text-xs text-muted-foreground backdrop-blur supports-[backdrop-filter]:bg-background/80 sm:flex-row sm:items-center"
+			className={cn(
+				"flex min-w-0 flex-1 flex-col gap-2 text-xs text-muted-foreground sm:flex-row sm:items-center",
+				className,
+			)}
 		>
 			<SearchInput
 				value={draftQuery}
@@ -123,11 +129,15 @@ export function SessionSearchNavigation({
 			/>
 			{query ? (
 				<div className="flex min-h-8 shrink-0 items-center justify-end gap-2">
-					<span className="shrink-0 tabular-nums text-foreground" aria-live="polite">
+					<span
+						className="inline-flex shrink-0 items-center gap-1.5 tabular-nums text-foreground"
+						aria-live="polite"
+					>
+						{isSearching ? <LoaderCircle className="size-3.5 animate-spin" /> : null}
 						{hasSearchError
 							? "Unavailable"
 							: isSearching
-								? "Searching…"
+								? "Searching"
 								: activeNavigation
 									? `${activeNavigation.index} of ${activeNavigation.total}`
 									: "No matches"}

--- a/apps/web/src/lib/search-highlight.ts
+++ b/apps/web/src/lib/search-highlight.ts
@@ -7,31 +7,13 @@ function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function searchTerms(query: string): string[] {
-	const normalized = query.trim();
-	if (!normalized) return [];
-
-	const candidates = [normalized, ...(normalized.match(/[\p{L}\p{N}_]+/gu) ?? [])];
-	const seen = new Set<string>();
-	return candidates
-		.filter((term) => term.length > 1 || normalized.length === 1)
-		.filter((term) => {
-			const key = term.toLocaleLowerCase();
-			if (seen.has(key)) return false;
-			seen.add(key);
-			return true;
-		})
-		.sort((a, b) => b.length - a.length)
-		.slice(0, 24);
-}
-
 export function createSearchHighlighter(query: string) {
-	const terms = searchTerms(query);
-	if (terms.length === 0) {
+	const phrase = query.trim();
+	if (!phrase) {
 		return (text: string): SearchHighlightPart[] => [{ text, highlighted: false }];
 	}
 
-	const pattern = new RegExp(terms.map(escapeRegExp).join("|"), "giu");
+	const pattern = new RegExp(escapeRegExp(phrase), "giu");
 	return (text: string): SearchHighlightPart[] => {
 		pattern.lastIndex = 0;
 		const parts: SearchHighlightPart[] = [];

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -1,15 +1,23 @@
 "use client";
 
-import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	keepPreviousData,
+	useInfiniteQuery,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import {
 	ArrowDown,
 	ArrowDownNarrowWide,
 	ArrowUpNarrowWide,
+	Bot,
 	Clock,
 	Hash,
 	MessageSquare,
 	Trash2,
+	UserRound,
+	Wrench,
 	Zap,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -239,6 +247,7 @@ export function SessionDetailContent({
 		fetchNextPage,
 		hasNextPage,
 		isFetchingNextPage,
+		isFetching: isContentFetching,
 	} = useInfiniteQuery({
 		// Direction in queryKey so toggling refetches from the new
 		// end (rather than reordering already-loaded pages, which
@@ -295,6 +304,7 @@ export function SessionDetailContent({
 		},
 		staleTime: SESSION_MESSAGES_STALE_MS,
 		gcTime: SESSION_MESSAGES_GC_MS,
+		placeholderData: keepPreviousData,
 	});
 
 	// Flatten pages → ordered message list, paired with a stable
@@ -396,6 +406,29 @@ export function SessionDetailContent({
 	}
 
 	const totalTokens = (session.input_tokens ?? 0) + (session.output_tokens ?? 0);
+	const searchActive = Boolean(normalizedSearchQuery);
+	const isSearchUpdating =
+		searchActive &&
+		(normalizedSearchQuery !== debouncedSearchQuery || isContentFetching || isContentLoading);
+	const updateTimelineView = (selected: SessionTimelineView) => {
+		if (agentId) {
+			void router.navigate({
+				...agentSessionDetailLink(
+					agentId,
+					sessionId,
+					selected === "all" ? undefined : { timelineView: selected },
+				),
+				replace: true,
+				resetScroll: false,
+			});
+			return;
+		}
+		void router.navigate({
+			...sessionTimelineViewLink(sessionId, selected, { returnTo }),
+			replace: true,
+			resetScroll: false,
+		});
+	};
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
@@ -494,83 +527,84 @@ export function SessionDetailContent({
 			</DetailStats>
 
 			{session.has_content ? (
-				<SessionSearchNavigation
-					sessionId={sessionId}
-					query={normalizedSearchQuery}
-					navigation={searchNavigation}
-					returnTo={returnTo}
-					isSearching={
-						Boolean(normalizedSearchQuery) &&
-						(normalizedSearchQuery !== debouncedSearchQuery || isContentLoading)
-					}
-					hasSearchError={Boolean(normalizedSearchQuery) && isContentError}
-				/>
-			) : null}
-
-			{/* Timeline filters and direction stay visible while pages load. */}
-			{session.has_content ? (
-				<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-					<ToggleGroup
-						value={[timelineView]}
-						onValueChange={(values) => {
-							const selected = values[0];
-							if (
-								selected !== "all" &&
-								selected !== "user" &&
-								selected !== "assistant" &&
-								selected !== "tools"
-							) {
-								return;
-							}
-							if (agentId) {
-								void router.navigate({
-									...agentSessionDetailLink(
-										agentId,
-										sessionId,
-										selected === "all" ? undefined : { timelineView: selected },
-									),
-									replace: true,
-									resetScroll: false,
-								});
-								return;
-							}
-							void router.navigate({
-								...sessionTimelineViewLink(sessionId, selected, { returnTo }),
-								replace: true,
-								resetScroll: false,
-							});
-						}}
-						variant="outline"
-						size="sm"
-						spacing={0}
-						aria-label="Timeline view"
-					>
-						<ToggleGroupItem value="all">All</ToggleGroupItem>
-						<ToggleGroupItem value="user">You</ToggleGroupItem>
-						<ToggleGroupItem value="assistant">Agent</ToggleGroupItem>
-						<ToggleGroupItem value="tools">Tools</ToggleGroupItem>
-					</ToggleGroup>
-					<div className="flex items-center justify-end gap-2 text-xs text-muted-foreground">
-						{loadedCount > 0 ? (
-							<span className="tabular-nums">
-								{loadedCount}/{totalItems}
-							</span>
-						) : null}
-						<button
-							type="button"
-							onClick={() => persistDirection(direction === "desc" ? "asc" : "desc")}
-							aria-label={
-								direction === "desc" ? "Show oldest activity first" : "Show newest activity first"
-							}
-							className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 transition-colors hover:bg-accent hover:text-accent-foreground"
-						>
-							{direction === "desc" ? (
-								<ArrowDownNarrowWide className="size-3.5" />
-							) : (
-								<ArrowUpNarrowWide className="size-3.5" />
-							)}
-							{direction === "desc" ? "Newest first" : "Oldest first"}
-						</button>
+				<div className="sticky top-(--header-height) z-10 -mx-4 border-y bg-background/95 px-4 py-2 backdrop-blur supports-[backdrop-filter]:bg-background/80 lg:-mx-6 lg:px-6">
+					<div className="flex min-w-0 flex-col gap-2 lg:flex-row lg:items-center">
+						<SessionSearchNavigation
+							sessionId={sessionId}
+							query={normalizedSearchQuery}
+							navigation={searchNavigation}
+							returnTo={returnTo}
+							isSearching={isSearchUpdating}
+							hasSearchError={searchActive && isContentError}
+							className="lg:max-w-2xl"
+						/>
+						{searchActive ? null : (
+							<div className="flex min-w-0 items-center justify-between gap-2 lg:ml-auto lg:justify-end">
+								<ToggleGroup
+									value={[timelineView]}
+									onValueChange={(values) => {
+										const selected = values[0];
+										if (
+											selected === "all" ||
+											selected === "user" ||
+											selected === "assistant" ||
+											selected === "tools"
+										) {
+											updateTimelineView(selected);
+										}
+									}}
+									size="sm"
+									spacing={1}
+									aria-label="Timeline view"
+									className="min-w-0 bg-muted p-0.5"
+								>
+									<ToggleGroupItem
+										value="all"
+										className="px-2 data-[state=on]:bg-background data-[state=on]:shadow-xs"
+									>
+										<MessageSquare /> All
+									</ToggleGroupItem>
+									<ToggleGroupItem
+										value="user"
+										className="px-2 data-[state=on]:bg-background data-[state=on]:shadow-xs"
+									>
+										<UserRound /> You
+									</ToggleGroupItem>
+									<ToggleGroupItem
+										value="assistant"
+										className="px-2 data-[state=on]:bg-background data-[state=on]:shadow-xs"
+									>
+										<Bot /> Agent
+									</ToggleGroupItem>
+									<ToggleGroupItem
+										value="tools"
+										className="px-2 data-[state=on]:bg-background data-[state=on]:shadow-xs"
+									>
+										<Wrench /> Tools
+									</ToggleGroupItem>
+								</ToggleGroup>
+								<div className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
+									{loadedCount > 0 ? (
+										<span className="hidden tabular-nums sm:inline">
+											{loadedCount} of {totalItems}
+										</span>
+									) : null}
+									<Button
+										variant="ghost"
+										size="icon-sm"
+										onClick={() => persistDirection(direction === "desc" ? "asc" : "desc")}
+										aria-label={
+											direction === "desc"
+												? "Show oldest activity first"
+												: "Show newest activity first"
+										}
+										title={direction === "desc" ? "Newest first" : "Oldest first"}
+									>
+										{direction === "desc" ? <ArrowDownNarrowWide /> : <ArrowUpNarrowWide />}
+									</Button>
+								</div>
+							</div>
+						)}
 					</div>
 				</div>
 			) : null}

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -30,7 +30,7 @@ import { parseAsPositiveInt } from "@/lib/url-search-parsers";
 import { useDebouncedValue } from "@/lib/use-debounced";
 import { cn, formatNumber, recencyBucketFor } from "@/lib/utils";
 
-// `relevance` (trgm similarity) joins the legacy date/count sorts.
+// `relevance` ranks deterministic phrase matches across metadata and messages.
 // Relevance is special-cased server-side: it's only meaningful when q
 // is non-empty, and the route silently falls back to last_activity_at
 // otherwise. We mirror that in the UI by only surfacing the "Relevance"

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -138,6 +138,7 @@ from app.services.session_search import (
     SearchableSessionMessage,
     best_session_message_matches,
     current_search_revision,
+    escaped_contains_pattern,
     replace_snapshot_search_index,
     searchable_snapshot_messages,
     session_message_search_navigation,
@@ -2507,15 +2508,6 @@ _SESSION_SORT_COLUMNS = {
 }
 
 
-# pg_trgm similarity threshold. Default `pg_trgm.similarity_threshold`
-# is 0.3 which is fairly strict — close to "all the trigrams match".
-# For typo tolerance ("athentication" still surfacing "authentication")
-# we want something lower. 0.15 is the sweet spot from the memories
-# search benchmark — captures typos and partial-word matches without
-# drowning the results in distant relatives.
-_TRGM_THRESHOLD = 0.15
-
-
 def _message_search_excerpt(content: str, query: str, *, limit: int = 240) -> str:
     compact = " ".join(content.split())
     if len(compact) <= limit:
@@ -2541,7 +2533,7 @@ async def list_sessions(
     q: str | None = Query(
         default=None,
         max_length=500,
-        description="Fuzzy search on summary/project/id and visible message text",
+        description="Case-insensitive phrase search on summary/project/id and visible message text",
     ),
     agent: str | None = Query(default=None, description="Filter by agent_type"),
     environment_id: UUID | None = Query(default=None, description="Filter by agent environment"),
@@ -2612,17 +2604,23 @@ async def list_sessions(
     # IS NULL` makes this lookup index-only.
     is_shared_subq = _link_is_shared_subq()
 
-    # Build the trigram relevance expression once — used both for
-    # filtering (similarity > threshold) and for `sort=relevance`
-    # (ORDER BY similarity DESC). Greatest-of-three so a match in
-    # ANY of summary / project / id wins, and the strongest match
-    # drives the rank. NULL-safe via COALESCE — sessions with NULL
-    # summary still match if their project_path or id does.
+    # Search selection is deterministic phrase containment across metadata and
+    # visible messages. `similarity()` only ranks rows already known to contain
+    # the query; it never introduces typo-tolerant or unexplained candidates.
     relevance_expr: Any | None
     metadata_relevance_expr: Any | None = None
+    metadata_match_expr: Any | None = None
     message_match: Any | None = None
     message_relevance_expr: Any | None = None
     if q:
+        contains_pattern = escaped_contains_pattern(q)
+        summary_match = func.coalesce(Session.summary, "").ilike(contains_pattern, escape="\\")
+        project_match = func.coalesce(Session.project_path, "").ilike(
+            contains_pattern,
+            escape="\\",
+        )
+        local_match = Session.local_session_id.ilike(contains_pattern, escape="\\")
+        metadata_match_expr = or_(summary_match, project_match, local_match)
         sim_summary = func.similarity(func.coalesce(Session.summary, ""), q)
         sim_project = func.similarity(func.coalesce(Session.project_path, ""), q)
         sim_local = func.similarity(Session.local_session_id, q)
@@ -2712,19 +2710,13 @@ async def list_sessions(
             session_filters.append(_MANUAL_SESSION_SUMMARY_FILTER)
 
     if q:
-        # pg_trgm `similarity()` for typo / partial-word tolerance.
-        # NOT index-accelerated — the function-call form doesn't trigger
-        # the `gin_trgm_ops` operator class (only `%` / `<%` / `LIKE`
-        # do). Runs as a Seq Scan over the user's session set; fine
-        # for the typical few-thousand-rows-per-user. If a power user
-        # ever hits real latency here, swap to `WHERE summary % :q`
-        # plus a GIN index. Threshold tuned for "type to filter" UX.
         assert relevance_expr is not None
         assert metadata_relevance_expr is not None
+        assert metadata_match_expr is not None
         assert message_match is not None
         session_filters.append(
             or_(
-                metadata_relevance_expr >= _TRGM_THRESHOLD,
+                metadata_match_expr,
                 message_match.c.session_id.is_not(None),
             )
         )
@@ -2749,7 +2741,7 @@ async def list_sessions(
 
     # Resolve sort column. `relevance` is special — only valid when
     # `q` is present (else fall back to the date default so the empty-
-    # search experience doesn't break). The trgm-relevance expression
+    # search experience doesn't break). The relevance expression
     # was built up above; reuse it here so the sort matches the
     # similarity used for filtering.
     if sort == "relevance":

--- a/backend/app/services/session_search.py
+++ b/backend/app/services/session_search.py
@@ -6,7 +6,7 @@ from typing import Literal, Protocol
 from uuid import UUID
 
 from pydantic import JsonValue
-from sqlalchemy import case, delete, func, literal, or_, select, update
+from sqlalchemy import case, delete, func, literal, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.selectable import Subquery
 
@@ -16,7 +16,6 @@ from app.services.session_content import load_session_events, load_session_messa
 from app.services.session_events import project_visible_messages
 
 type SearchRole = Literal["user", "assistant"]
-_MIN_TRGM_QUERY_LENGTH = 3
 
 
 class SessionSearchFileStore(Protocol):
@@ -84,7 +83,7 @@ async def event_search_projection_complete(
     return missing is None
 
 
-def _escaped_contains_pattern(value: str) -> str:
+def escaped_contains_pattern(value: str) -> str:
     escaped = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
     return f"%{escaped}%"
 
@@ -93,22 +92,11 @@ def _searchable_text(content: str) -> str:
     return content.replace("\x00", "\ufffd")
 
 
-def _message_match_expressions(query: str):
-    exact_match = SessionMessageSearch.content.ilike(
-        _escaped_contains_pattern(query),
+def _message_match_expression(query: str):
+    return SessionMessageSearch.content.ilike(
+        escaped_contains_pattern(query),
         escape="\\",
     )
-    candidate_filter = exact_match
-    if len(query) >= _MIN_TRGM_QUERY_LENGTH:
-        candidate_filter = or_(
-            exact_match,
-            literal(query).op("<%")(SessionMessageSearch.content),
-        )
-    score = case(
-        (exact_match, 1.0),
-        else_=func.word_similarity(query, SessionMessageSearch.content),
-    )
-    return candidate_filter, score
 
 
 def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
@@ -127,9 +115,7 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
         ),
         else_=func.concat("snapshot:", Session.content_hash),
     )
-    # Official pg_trgm word-search shape: use the GIN-backed operator for
-    # candidates, then word_similarity() only to rank that bounded set.
-    candidate_filter, score = _message_match_expressions(query)
+    message_match = _message_match_expression(query)
     candidates = (
         select(
             SessionMessageSearch.session_id.label("session_id"),
@@ -137,11 +123,13 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
             SessionMessageSearch.position.label("position"),
             SessionMessageSearch.content.label("content"),
             SessionMessageSearch.role.label("role"),
-            score.label("score"),
+            # Body search is deterministic phrase containment. The constant
+            # only participates in cross-field ranking on the Session list.
+            literal(1.0).label("score"),
         )
         .where(
             SessionMessageSearch.user_id == user_id,
-            candidate_filter,
+            message_match,
         )
         .cte("session_message_candidates")
         .prefix_with("MATERIALIZED")
@@ -185,7 +173,7 @@ async def session_message_search_navigation(
     ):
         return None
 
-    candidate_filter, _ = _message_match_expressions(query)
+    message_match = _message_match_expression(query)
     ordered_matches = (
         select(
             SessionMessageSearch.position.label("position"),
@@ -202,7 +190,7 @@ async def session_message_search_navigation(
             SessionMessageSearch.user_id == session.user_id,
             SessionMessageSearch.session_id == session.id,
             SessionMessageSearch.content_revision == document_revision,
-            candidate_filter,
+            message_match,
         )
         .subquery("ordered_session_message_matches")
     )

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -1,7 +1,7 @@
 """Session list/search endpoint tests.
 
 Covers the upgraded `/api/sessions` list endpoint:
-  - pg_trgm similarity search replacing ILIKE — typo tolerance + ranking
+  - case-insensitive phrase search across metadata and visible messages
   - Filters: model, tag, min_messages, min_duration, has_pr
   - `sort=relevance` ordering
   - Default behavior unchanged (no q, no filters → date-sorted list)
@@ -89,29 +89,26 @@ async def _push_session(
 
 
 @pytest.mark.asyncio
-async def test_trgm_search_handles_typos(client: httpx.AsyncClient):
-    """`?q=athentication` should still surface a session whose summary
-    contains 'authentication'. ILIKE wouldn't match the typo; pg_trgm
-    similarity catches it because most trigrams overlap."""
+async def test_metadata_search_requires_the_query_phrase(client: httpx.AsyncClient):
     env_id = await _register_env(client)
     await _push_session(
         client, env_id, local_session_id="auth-1", summary="user authentication migration"
     )
     await _push_session(client, env_id, local_session_id="dns-1", summary="DNS cache poisoning")
 
-    # Typo: drop the 'u' in "authentication".
-    r = await client.get("/v1/sessions?q=athentication")
-    assert r.status_code == 200
-    items = r.json()["items"]
-    summaries = [s["summary"] for s in items]
-    assert "user authentication migration" in summaries
-    assert "DNS cache poisoning" not in summaries
+    matched = await client.get("/v1/sessions", params={"q": "AUTHENTICATION"})
+    assert matched.status_code == 200
+    assert [item["summary"] for item in matched.json()["items"]] == [
+        "user authentication migration"
+    ]
+
+    typo = await client.get("/v1/sessions", params={"q": "athentication"})
+    assert typo.status_code == 200
+    assert typo.json()["items"] == []
 
 
 @pytest.mark.asyncio
-async def test_relevance_sort_orders_by_similarity(client: httpx.AsyncClient):
-    """`sort=relevance` orders by trigram similarity — the closest
-    match comes first, irrelevant rows don't appear."""
+async def test_relevance_sort_only_ranks_phrase_matches(client: httpx.AsyncClient):
     env_id = await _register_env(client)
     # Exact-match summary, partial-match summary, no-match summary.
     await _push_session(client, env_id, local_session_id="exact", summary="oauth token refresh bug")
@@ -122,8 +119,7 @@ async def test_relevance_sort_orders_by_similarity(client: httpx.AsyncClient):
 
     r = await client.get("/v1/sessions?q=oauth+token+refresh&sort=relevance")
     items = r.json()["items"]
-    # The exact-match summary must appear first; below-threshold
-    # rows ("UI polish") shouldn't appear at all.
+    # Only the summary containing the complete phrase is eligible.
     assert items[0]["summary"] == "oauth token refresh bug"
     assert all(s["summary"] != "UI polish" for s in items)
 
@@ -171,8 +167,10 @@ async def test_snapshot_message_search_tracks_current_content_and_escapes_wildca
             ),
         },
     }
-    fuzzy = (await client.get("/v1/sessions", params={"q": "Orginal needle"})).json()
-    assert [item["local_session_id"] for item in fuzzy["items"]] == [local_id]
+    typo = (await client.get("/v1/sessions", params={"q": "Orginal needle"})).json()
+    assert typo["items"] == []
+    case_insensitive = (await client.get("/v1/sessions", params={"q": "original NEEDLE"})).json()
+    assert [item["local_session_id"] for item in case_insensitive["items"]] == [local_id]
     literal = (await client.get("/v1/sessions", params={"q": "%_"})).json()
     assert [item["local_session_id"] for item in literal["items"]] == [local_id]
     backslash = (await client.get("/v1/sessions", params={"q": "slash\\needle"})).json()

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -53,7 +53,7 @@ Do NOT save plaintext tokens, API keys, bearer credentials, or private keys in m
 Two tools for reading and finding past agent conversations stored in Clawdi Cloud:
 
 - `session_read` — Fetch a single session by reference and return its full conversation as Markdown. Accepts a Clawdi share URL (`https://cloud.clawdi.ai/s/{uuid}`) OR a session UUID for one of the user's own sessions. Handles owned and shared sessions transparently — you don't need to know which one.
-- `session_search` — Find sessions in the user's history by a case-insensitive phrase in metadata or visible messages. Returns matching sessions with summary, project, timestamps, and **session UUIDs you can pass back to `session_read`**.
+- `session_search` — Find sessions in the user's history by keyword. Trigram-ranked substring search with typo tolerance. Returns matching sessions with summary, project, timestamps, and **session UUIDs you can pass back to `session_read`**.
 
 ### When to read — call `session_read` whenever the user references a specific session
 

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -53,7 +53,7 @@ Do NOT save plaintext tokens, API keys, bearer credentials, or private keys in m
 Two tools for reading and finding past agent conversations stored in Clawdi Cloud:
 
 - `session_read` — Fetch a single session by reference and return its full conversation as Markdown. Accepts a Clawdi share URL (`https://cloud.clawdi.ai/s/{uuid}`) OR a session UUID for one of the user's own sessions. Handles owned and shared sessions transparently — you don't need to know which one.
-- `session_search` — Find sessions in the user's history by keyword. Trigram-ranked substring search with typo tolerance. Returns matching sessions with summary, project, timestamps, and **session UUIDs you can pass back to `session_read`**.
+- `session_search` — Find sessions in the user's history by a case-insensitive phrase in metadata or visible messages. Returns matching sessions with summary, project, timestamps, and **session UUIDs you can pass back to `session_read`**.
 
 ### When to read — call `session_read` whenever the user references a specific session
 

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -11663,7 +11663,7 @@ export interface operations {
     list_sessions_v1_sessions_get: {
         parameters: {
             query?: {
-                /** @description Fuzzy search on summary/project/id and visible message text */
+                /** @description Case-insensitive phrase search on summary/project/id and visible message text */
                 q?: string | null;
                 /** @description Filter by agent_type */
                 agent?: string | null;


### PR DESCRIPTION
## Summary

- require case-insensitive phrase containment for Session metadata and visible message search results
- align excerpts and highlighting with backend match semantics
- consolidate the detail search, activity filters, count, and ordering into one responsive toolbar
- keep prior timeline content visible during search and present tool arguments/output/results as compact tabs

## Verification

- Backend PostgreSQL focused suite: 8 passed
- Backend Ruff and BasedPyright: passed
- Web full suite: 1094 passed
- Web OSS production build: passed
- Playwright Session search/activity E2E: 2 passed (desktop and 390px mobile inspected)
- Generated OpenAPI client check: passed
- Biome focused checks: passed
- git diff --check: passed