### PR TITLE
refactor(sessions): unify search behavior and navigation

### DIFF
--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -129,7 +129,7 @@ test("opens a message search result and returns to the same filtered list", asyn
 		.click();
 	await expect(page.locator('[data-search-match="true"]')).toBeVisible();
 	await expect(page.getByText("1 / 2")).toBeVisible();
-	const detailSearch = page.getByRole("textbox", { name: "Search this session" });
+	const detailSearch = page.getByRole("textbox", { name: "Search messages" });
 	await detailSearch.press("Enter");
 	await expect(page).toHaveURL((url) => url.searchParams.get("matchPosition") === "11");
 	await expect(page.locator('[data-search-match="true"]')).toContainText(
@@ -282,6 +282,7 @@ test("filters session activity and expands paired tool details", async ({ page }
 	});
 
 	await page.goto(`/sessions/${SESSION_ID}?timelineView=tools`);
+	await expect(page.getByRole("textbox", { name: "Search messages" })).not.toBeVisible();
 	const toolActivity = page.getByRole("button", { name: /read.*Done/ });
 	await expect(toolActivity).toBeVisible();
 	await expect(page.getByRole("button", { name: /search.*Error/ })).toBeVisible();
@@ -295,24 +296,24 @@ test("filters session activity and expands paired tool details", async ({ page }
 	await expect(page).toHaveURL((url) => url.searchParams.get("timelineView") === "user");
 	await expect(page.getByText("Read the repository instructions", { exact: true })).toBeVisible();
 	await expect(toolActivity).not.toBeVisible();
+	await page.getByRole("textbox", { name: "Search messages" }).fill("Read the repository");
+	await expect(page).toHaveURL(
+		(url) => url.searchParams.get("matchQuery") === "Read the repository",
+	);
 
 	await page.getByRole("button", { name: "Tool activity" }).click();
-	await expect(page).toHaveURL((url) => url.searchParams.get("timelineView") === "tools");
-	await page.getByRole("textbox", { name: "Search this session" }).fill("Final answer");
+	await expect(page).toHaveURL((url) => {
+		return url.searchParams.get("timelineView") === "tools" && !url.searchParams.has("matchQuery");
+	});
+	await expect(page.getByRole("textbox", { name: "Search messages" })).not.toBeVisible();
 	await expect(page.getByRole("button", { name: "Tool activity" })).toHaveAttribute(
 		"aria-pressed",
 		"true",
 	);
 	await expect(toolActivity).toBeVisible();
-	await expect(page).toHaveURL((url) => {
-		return (
-			url.searchParams.get("matchQuery") === "Final answer" &&
-			url.searchParams.get("timelineView") === "tools"
-		);
-	});
-	await expect(page.getByText("0 / 0")).toBeVisible();
 
 	await page.getByRole("button", { name: "Agent messages" }).click();
+	await page.getByRole("textbox", { name: "Search messages" }).fill("Final answer");
 	await expect(page).toHaveURL((url) => {
 		return (
 			url.searchParams.get("matchQuery") === "Final answer" &&

--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -301,19 +301,27 @@ test("filters session activity and expands paired tool details", async ({ page }
 		(url) => url.searchParams.get("matchQuery") === "Read the repository",
 	);
 
-	await page.getByRole("button", { name: "Tool activity" }).click();
+	await page.getByRole("button", { name: "Tools activity" }).click();
 	await expect(page).toHaveURL((url) => {
 		return url.searchParams.get("timelineView") === "tools" && !url.searchParams.has("matchQuery");
 	});
 	await expect(page.getByRole("textbox", { name: "Search messages" })).not.toBeVisible();
-	await expect(page.getByRole("button", { name: "Tool activity" })).toHaveAttribute(
+	await expect(page.getByRole("button", { name: "Tools activity" })).toHaveAttribute(
 		"aria-pressed",
 		"true",
 	);
 	await expect(toolActivity).toBeVisible();
 
 	await page.getByRole("button", { name: "Agent messages" }).click();
-	await page.getByRole("textbox", { name: "Search messages" }).fill("Final answer");
+	const restoredSearch = page.getByRole("textbox", { name: "Search messages" });
+	await expect(restoredSearch).toHaveValue("Read the repository");
+	await expect(page).toHaveURL((url) => {
+		return (
+			url.searchParams.get("matchQuery") === "Read the repository" &&
+			url.searchParams.get("timelineView") === "assistant"
+		);
+	});
+	await restoredSearch.fill("Final answer");
 	await expect(page).toHaveURL((url) => {
 		return (
 			url.searchParams.get("matchQuery") === "Final answer" &&

--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -168,7 +168,7 @@ test("filters session activity and expands paired tool details", async ({ page }
 	const timeline = [
 		{
 			kind: "message",
-			position: 4,
+			position: 6,
 			role: "assistant",
 			content: "Final answer after reading the file",
 			model: "gpt-5",
@@ -176,12 +176,31 @@ test("filters session activity and expands paired tool details", async ({ page }
 		},
 		{
 			kind: "tool_result",
-			position: 3,
+			position: 5,
+			call_id: "call-search",
+			name: "search",
+			status: "error",
+			content: "No matching file",
+			result_json: null,
+			timestamp: now,
+		},
+		{
+			kind: "tool_result",
+			position: 4,
 			call_id: "call-read",
 			name: "read",
 			status: "completed",
 			content: "Repository instructions",
 			result_json: null,
+			timestamp: now,
+		},
+		{
+			kind: "tool_call",
+			position: 3,
+			call_id: "call-search",
+			name: "search",
+			arguments_json: '{"query":"session"}',
+			model: "gpt-5",
 			timestamp: now,
 		},
 		{
@@ -226,7 +245,7 @@ test("filters session activity and expands paired tool details", async ({ page }
 			if (query) {
 				await new Promise((resolve) => setTimeout(resolve, 450));
 				if (view !== "assistant" && view !== "all") {
-					const items = view === "tools" ? timeline.slice(1, 3) : [timeline[3]];
+					const items = view === "tools" ? timeline.slice(1, 5) : [timeline[5]];
 					return fulfillJson(route, {
 						items,
 						total: items.length,
@@ -251,7 +270,7 @@ test("filters session activity and expands paired tool details", async ({ page }
 				});
 			}
 			const items =
-				view === "tools" ? timeline.slice(1, 3) : view === "user" ? [timeline[3]] : timeline;
+				view === "tools" ? timeline.slice(1, 5) : view === "user" ? [timeline[5]] : timeline;
 			return fulfillJson(route, {
 				items,
 				total: items.length,
@@ -265,6 +284,7 @@ test("filters session activity and expands paired tool details", async ({ page }
 	await page.goto(`/sessions/${SESSION_ID}?timelineView=tools`);
 	const toolActivity = page.getByRole("button", { name: /read.*Done/ });
 	await expect(toolActivity).toBeVisible();
+	await expect(page.getByRole("button", { name: /search.*Error/ })).toBeVisible();
 	await expect(page.getByText("Final answer after reading the file")).not.toBeVisible();
 	await toolActivity.click();
 	await expect(page.locator("pre").filter({ hasText: '"path": "README.md"' })).toBeVisible();

--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -45,6 +45,98 @@ async function fulfillJson(route: Route, body: unknown) {
 	});
 }
 
+test("opens a global Session body match at the exact message", async ({ page }) => {
+	const query = "global palette anchor";
+	await page.route("**/v1/**", async (route) => {
+		const url = new URL(route.request().url());
+		if (url.pathname === "/v1/agents") {
+			return fulfillJson(route, [
+				{
+					id: AGENT_ID,
+					name: "Search Codex",
+					display_name: "Search Codex",
+					default_name: "Codex",
+					machine_name: "search-machine",
+					agent_type: "codex",
+				},
+			]);
+		}
+		if (url.pathname === "/v1/sessions") {
+			return fulfillJson(route, { items: [], total: 0, page: 1, page_size: 25 });
+		}
+		if (url.pathname === "/v1/search") {
+			expect(url.searchParams.get("q")).toBe(query);
+			return fulfillJson(route, {
+				query,
+				results: [
+					{
+						type: "session",
+						id: SESSION_ID,
+						title: "Global search result",
+						subtitle: "codex · /workspace/clawdi",
+						href: `/sessions/${SESSION_ID}`,
+						search_match: {
+							role: "assistant",
+							excerpt: `Found the ${query} in this response`,
+							anchor,
+						},
+					},
+				],
+			});
+		}
+		if (url.pathname === `/v1/sessions/${SESSION_ID}`) {
+			return fulfillJson(route, session);
+		}
+		if (url.pathname === `/v1/sessions/${SESSION_ID}/messages`) {
+			expect(url.searchParams.get("search_query")).toBe(query);
+			expect(url.searchParams.get("anchor_position")).toBe(String(anchor.position));
+			return fulfillJson(route, {
+				items: [
+					{
+						kind: "message",
+						position: anchor.position,
+						role: "assistant",
+						content: `Found the ${query} in this response`,
+						model: "gpt-5",
+						timestamp: now,
+					},
+				],
+				total: 1,
+				offset: 0,
+				limit: 100,
+				anchor_offset: 0,
+				search_navigation: {
+					index: 1,
+					total: 1,
+					current: anchor,
+					previous: null,
+					next: null,
+				},
+			});
+		}
+		return fulfillJson(route, {});
+	});
+
+	await page.goto("/sessions");
+	await page.getByRole("button", { name: "Search" }).click();
+	const palette = page.getByRole("dialog", { name: "Search" });
+	await palette.getByPlaceholder("Search sessions, memories, skills, vaults…").fill(query);
+	await expect(palette.getByText(`Found the ${query} in this response`)).toBeVisible();
+	await expect(palette.locator("mark")).toHaveText(query);
+	await palette.getByText("Global search result").click();
+
+	await expect(page).toHaveURL((url) => {
+		return (
+			url.pathname === `/sessions/${SESSION_ID}` &&
+			url.searchParams.get("matchPosition") === String(anchor.position) &&
+			url.searchParams.get("matchQuery") === query
+		);
+	});
+	const current = page.locator('[data-search-match="true"]');
+	await expect(current).toContainText(`Found the ${query} in this response`);
+	await expect(current.locator("mark")).toHaveText(query);
+});
+
 test("opens a message search result and returns to the same filtered list", async ({ page }) => {
 	await page.setViewportSize({ width: 390, height: 844 });
 	await page.route("**/v1/**", async (route) => {
@@ -412,10 +504,20 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 
 	await page.goto(`/sessions/${SESSION_ID}`);
 	const scrollContainer = page.locator("#dashboard-scroll-container");
-	for (const expectedOffset of [100, 200, 300, 400]) {
-		await scrollContainer.evaluate((element) => element.scrollTo({ top: element.scrollHeight }));
-		await expect.poll(() => requestedOffsets.has(expectedOffset)).toBe(true);
+	await expect.poll(() => requestedOffsets.size).toBeGreaterThan(0);
+	for (let attempt = 0; attempt < 8 && requestedOffsets.size < 5; attempt++) {
+		const requestCount = requestedOffsets.size;
+		const loadMore = page.getByRole("button", { name: /^Load more \(/ });
+		if (await loadMore.isVisible()) {
+			await loadMore.click();
+		} else {
+			await scrollContainer.evaluate((element) => element.scrollTo({ top: element.scrollHeight }));
+		}
+		await expect.poll(() => requestedOffsets.size).toBeGreaterThan(requestCount);
 	}
+	expect([...requestedOffsets].sort((left, right) => left - right)).toEqual([
+		0, 100, 200, 300, 400,
+	]);
 	const mountedRows = page.locator(
 		'[data-testid="virtualized-session-timeline"] [data-item-index]',
 	);

--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -334,3 +334,107 @@ test("filters session activity and expands paired tool details", async ({ page }
 	);
 	await expect(page.getByText("1 / 1")).toBeVisible();
 });
+
+test("keeps a long anchored timeline windowed across desktop and mobile", async ({ page }) => {
+	await page.setViewportSize({ width: 1280, height: 900 });
+	const targetPosition = 1500;
+	const query = "virtualized needle";
+	const revision = "events:long-head";
+	const targetAnchor = { kind: "event_seq", position: targetPosition, revision };
+	const makeMessage = (position: number) => ({
+		kind: "message",
+		position,
+		role: position % 4 === 0 ? "user" : "assistant",
+		content:
+			position === targetPosition
+				? `Current ${query} result stays mounted`
+				: `Timeline message ${position} with enough content to exercise dynamic row measurement.`,
+		model: position % 4 === 0 ? null : "gpt-5",
+		timestamp: new Date(Date.parse(now) + position * 1_000).toISOString(),
+	});
+	const browseTimeline = Array.from({ length: 500 }, (_, position) => makeMessage(position));
+	const searchWindowOffset = 1450;
+	const searchWindow = Array.from({ length: 100 }, (_, index) =>
+		makeMessage(searchWindowOffset + index),
+	);
+	const requestedOffsets = new Set<number>();
+
+	await page.route("**/v1/**", async (route) => {
+		const url = new URL(route.request().url());
+		if (url.pathname === "/v1/agents") {
+			return fulfillJson(route, [
+				{
+					id: AGENT_ID,
+					name: "Search Codex",
+					display_name: "Search Codex",
+					default_name: "Codex",
+					machine_name: "search-machine",
+					agent_type: "codex",
+				},
+			]);
+		}
+		if (url.pathname === `/v1/sessions/${SESSION_ID}`) {
+			return fulfillJson(route, {
+				...session,
+				summary: "Long virtualized session",
+				message_count: 2000,
+				event_head_hash: "long-head",
+			});
+		}
+		if (url.pathname === `/v1/sessions/${SESSION_ID}/messages`) {
+			if (!url.searchParams.has("search_query")) {
+				const offset = Number(url.searchParams.get("offset") ?? 0);
+				requestedOffsets.add(offset);
+				return fulfillJson(route, {
+					items: browseTimeline.slice(offset, offset + 100),
+					total: browseTimeline.length,
+					offset,
+					limit: 100,
+				});
+			}
+			return fulfillJson(route, {
+				items: searchWindow,
+				total: 2000,
+				offset: searchWindowOffset,
+				limit: 100,
+				anchor_offset: targetPosition,
+				search_navigation: {
+					index: 1,
+					total: 1,
+					current: targetAnchor,
+					previous: null,
+					next: null,
+				},
+			});
+		}
+		return fulfillJson(route, {});
+	});
+
+	await page.goto(`/sessions/${SESSION_ID}`);
+	const scrollContainer = page.locator("#dashboard-scroll-container");
+	for (const expectedOffset of [100, 200, 300, 400]) {
+		await scrollContainer.evaluate((element) => element.scrollTo({ top: element.scrollHeight }));
+		await expect.poll(() => requestedOffsets.has(expectedOffset)).toBe(true);
+	}
+	const mountedRows = page.locator(
+		'[data-testid="virtualized-session-timeline"] [data-item-index]',
+	);
+	await expect.poll(() => mountedRows.count()).toBeGreaterThan(0);
+	expect(await mountedRows.count()).toBeLessThan(80);
+
+	const search = new URLSearchParams({
+		matchKind: targetAnchor.kind,
+		matchPosition: String(targetAnchor.position),
+		matchRevision: targetAnchor.revision,
+		matchQuery: query,
+	});
+	await page.goto(`/sessions/${SESSION_ID}?${search}`);
+	const current = page.locator('[data-search-match="true"]');
+	await expect(current).toContainText(`Current ${query} result stays mounted`);
+	await expect(current.locator("mark")).toHaveText(query);
+	expect(await mountedRows.count()).toBeLessThan(80);
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	await expect(current).toBeVisible();
+	expect(await mountedRows.count()).toBeLessThan(80);
+});

--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -128,18 +128,17 @@ test("opens a message search result and returns to the same filtered list", asyn
 		.getByRole("link", { name: "Open session Fix authentication timeout" })
 		.click();
 	await expect(page.locator('[data-search-match="true"]')).toBeVisible();
-	await expect(page.getByText("1 of 2")).toBeVisible();
+	await expect(page.getByText("1 / 2")).toBeVisible();
 	const detailSearch = page.getByRole("textbox", { name: "Search this session" });
 	await detailSearch.press("Enter");
 	await expect(page).toHaveURL((url) => url.searchParams.get("matchPosition") === "11");
 	await expect(page.locator('[data-search-match="true"]')).toContainText(
 		"Verified the authentication timeout no longer recurs",
 	);
-	await expect(page.getByText("2 of 2")).toBeVisible();
+	await expect(page.getByText("2 / 2")).toBeVisible();
 	await detailSearch.press("Shift+Enter");
 	await expect(page).toHaveURL((url) => url.searchParams.get("matchPosition") === "7");
-	await detailSearch.fill("");
-	await detailSearch.pressSequentially("no longer", { delay: 20 });
+	await detailSearch.fill("no longer");
 	await expect(page.getByRole("button", { name: "Next match" })).toBeDisabled();
 	await expect(page).toHaveURL((url) => {
 		return (
@@ -150,7 +149,7 @@ test("opens a message search result and returns to the same filtered list", asyn
 		"Verified the authentication timeout no longer recurs",
 	);
 	await expect(page.locator('[data-search-match="true"] mark')).toHaveText("no longer");
-	await expect(page.getByText("1 of 1")).toBeVisible();
+	await expect(page.getByText("1 / 1")).toBeVisible();
 
 	await page.getByText("Back to Sessions", { exact: true }).click();
 	await expect(page).toHaveURL((url) => {
@@ -225,8 +224,17 @@ test("filters session activity and expands paired tool details", async ({ page }
 			const view = url.searchParams.get("view");
 			const query = url.searchParams.get("search_query");
 			if (query) {
-				expect(view).toBe("all");
 				await new Promise((resolve) => setTimeout(resolve, 450));
+				if (view !== "assistant" && view !== "all") {
+					const items = view === "tools" ? timeline.slice(1, 3) : [timeline[3]];
+					return fulfillJson(route, {
+						items,
+						total: items.length,
+						offset: 0,
+						limit: 100,
+						search_navigation: null,
+					});
+				}
 				return fulfillJson(route, {
 					items: [timeline[0]],
 					total: 1,
@@ -255,7 +263,7 @@ test("filters session activity and expands paired tool details", async ({ page }
 	});
 
 	await page.goto(`/sessions/${SESSION_ID}?timelineView=tools`);
-	const toolActivity = page.getByRole("button", { name: /read.*Completed/ });
+	const toolActivity = page.getByRole("button", { name: /read.*Done/ });
 	await expect(toolActivity).toBeVisible();
 	await expect(page.getByText("Final answer after reading the file")).not.toBeVisible();
 	await toolActivity.click();
@@ -263,21 +271,37 @@ test("filters session activity and expands paired tool details", async ({ page }
 	await page.getByRole("tab", { name: "Output" }).click();
 	await expect(page.getByText("Repository instructions", { exact: true })).toBeVisible();
 
-	await page.getByRole("button", { name: "You" }).click();
+	await page.getByRole("button", { name: "Your messages" }).click();
 	await expect(page).toHaveURL((url) => url.searchParams.get("timelineView") === "user");
 	await expect(page.getByText("Read the repository instructions", { exact: true })).toBeVisible();
 	await expect(toolActivity).not.toBeVisible();
 
-	await page.getByRole("button", { name: "Tools" }).click();
+	await page.getByRole("button", { name: "Tool activity" }).click();
+	await expect(page).toHaveURL((url) => url.searchParams.get("timelineView") === "tools");
 	await page.getByRole("textbox", { name: "Search this session" }).fill("Final answer");
-	await expect(page.getByText("Searching", { exact: true })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Tool activity" })).toHaveAttribute(
+		"aria-pressed",
+		"true",
+	);
 	await expect(toolActivity).toBeVisible();
 	await expect(page).toHaveURL((url) => {
 		return (
-			url.searchParams.get("matchQuery") === "Final answer" && !url.searchParams.has("timelineView")
+			url.searchParams.get("matchQuery") === "Final answer" &&
+			url.searchParams.get("timelineView") === "tools"
+		);
+	});
+	await expect(page.getByText("0 / 0")).toBeVisible();
+
+	await page.getByRole("button", { name: "Agent messages" }).click();
+	await expect(page).toHaveURL((url) => {
+		return (
+			url.searchParams.get("matchQuery") === "Final answer" &&
+			url.searchParams.get("timelineView") === "assistant" &&
+			!url.searchParams.has("matchPosition")
 		);
 	});
 	await expect(page.locator('[data-search-match="true"]')).toContainText(
 		"Final answer after reading the file",
 	);
+	await expect(page.getByText("1 / 1")).toBeVisible();
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,6 +54,7 @@
 		"react": "catalog:",
 		"react-dom": "catalog:",
 		"react-markdown": "^10.1.0",
+		"react-virtuoso": "4.18.12",
 		"remark-breaks": "^4.0.0",
 		"remark-gfm": "^4.0.1",
 		"sonner": "^2.0.8",

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -12,6 +12,7 @@ import {
 	Sparkles,
 } from "lucide-react";
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { SessionSearchMatchExcerpt } from "@/components/sessions/search-match-excerpt";
 import { TruncatedText } from "@/components/truncated-text";
 import {
 	Command,
@@ -29,6 +30,7 @@ import type { SearchHit } from "@/lib/api-schemas";
 import { IS_HOSTED } from "@/lib/hosted";
 import { consoleCommandPaletteItems } from "@/lib/navigation-model";
 import { useProductAccess } from "@/lib/product-access";
+import { sessionDetailLink } from "@/lib/session-search-anchor";
 import type { SettingsSectionId } from "@/lib/settings-routes";
 import { useDebouncedValue } from "@/lib/use-debounced";
 
@@ -186,6 +188,22 @@ function CommandPalette({
 		},
 		[onOpenChange, router],
 	);
+	const openSearchHit = useCallback(
+		(hit: SearchHit) => {
+			if (hit.type !== "session") {
+				jump(hit.href);
+				return;
+			}
+			onOpenChange(false);
+			void router.navigate({
+				...sessionDetailLink(
+					{ id: hit.id, search_match: hit.search_match },
+					{ searchQuery: data?.query },
+				),
+			});
+		},
+		[data?.query, jump, onOpenChange, router],
+	);
 
 	// Group hits by type — cmdk groups handle the visual separator/label.
 	const grouped = useMemo(() => {
@@ -294,13 +312,19 @@ function CommandPalette({
 												<CommandItem
 													key={`${hit.type}-${hit.id}`}
 													value={`${hit.type}-${hit.id}`}
-													onSelect={() => jump(hit.href)}
+													onSelect={() => openSearchHit(hit)}
 													className={COMMAND_RESULT_ROW_CLASS}
 												>
 													<Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
 													<div className={COMMAND_RESULT_TEXT_CLASS}>
 														<TruncatedText>{hit.title}</TruncatedText>
-														{hit.subtitle ? (
+														{hit.type === "session" && hit.search_match ? (
+															<SessionSearchMatchExcerpt
+																match={hit.search_match}
+																query={data?.query ?? debounced}
+																className="line-clamp-2 text-xs leading-4 text-muted-foreground"
+															/>
+														) : hit.subtitle ? (
 															<TruncatedText className="text-xs text-muted-foreground">
 																{hit.subtitle}
 															</TruncatedText>

--- a/apps/web/src/components/sessions/message-list.test.tsx
+++ b/apps/web/src/components/sessions/message-list.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SessionTimelineList } from "@/components/sessions/message-list";
+import type { SessionTimelineItem } from "@/lib/api-schemas";
+
+const timestamp = "2026-08-29T10:00:00.000Z";
+
+function render(items: SessionTimelineItem[]) {
+	return renderToStaticMarkup(
+		createElement(SessionTimelineList, {
+			items,
+			agentType: "codex",
+			userName: "You",
+		}),
+	);
+}
+
+describe("SessionTimelineList", () => {
+	test("pairs parallel tool calls with results by call ID", () => {
+		const markup = render([
+			{
+				kind: "tool_call",
+				position: 1,
+				call_id: "call-read",
+				name: "read",
+				arguments_json: '{"path":"README.md"}',
+				timestamp,
+			},
+			{
+				kind: "tool_call",
+				position: 2,
+				call_id: "call-search",
+				name: "search",
+				arguments_json: '{"query":"session"}',
+				timestamp,
+			},
+			{
+				kind: "tool_result",
+				position: 3,
+				call_id: "call-read",
+				name: "read",
+				status: "completed",
+				content: "README contents",
+				timestamp,
+			},
+			{
+				kind: "tool_result",
+				position: 4,
+				call_id: "call-search",
+				name: "search",
+				status: "error",
+				content: "Search failed",
+				timestamp,
+			},
+		]);
+
+		expect(markup.match(/<button/g)).toHaveLength(2);
+		expect(markup.match(/Done/g)).toHaveLength(1);
+		expect(markup.match(/Error/g)).toHaveLength(1);
+	});
+
+	test("starts a new assistant group when the model changes", () => {
+		const markup = render([
+			{
+				kind: "message",
+				position: 1,
+				role: "assistant",
+				content: "First response",
+				model: "gpt-5",
+				timestamp,
+			},
+			{
+				kind: "message",
+				position: 2,
+				role: "assistant",
+				content: "Second response",
+				model: "claude-sonnet-4-5",
+				timestamp,
+			},
+		]);
+
+		expect(markup).toContain("GPT 5");
+		expect(markup).toContain("Sonnet 4.5");
+	});
+});

--- a/apps/web/src/components/sessions/message-list.test.tsx
+++ b/apps/web/src/components/sessions/message-list.test.tsx
@@ -60,6 +60,49 @@ describe("SessionTimelineList", () => {
 		expect(markup.match(/Error/g)).toHaveLength(1);
 	});
 
+	test("preserves repeated tool calls that reuse a call ID", () => {
+		const markup = render([
+			{
+				kind: "tool_call",
+				position: 1,
+				call_id: "reused-call",
+				name: "first-attempt",
+				arguments_json: '{"attempt":1}',
+				timestamp,
+			},
+			{
+				kind: "tool_call",
+				position: 2,
+				call_id: "reused-call",
+				name: "second-attempt",
+				arguments_json: '{"attempt":2}',
+				timestamp,
+			},
+			{
+				kind: "tool_result",
+				position: 3,
+				call_id: "reused-call",
+				name: "first-attempt",
+				status: "completed",
+				content: "first result",
+				timestamp,
+			},
+			{
+				kind: "tool_result",
+				position: 4,
+				call_id: "reused-call",
+				name: "second-attempt",
+				status: "completed",
+				content: "second result",
+				timestamp,
+			},
+		]);
+
+		expect(markup.match(/<button/g)).toHaveLength(2);
+		expect(markup).toContain("first-attempt");
+		expect(markup).toContain("second-attempt");
+	});
+
 	test("starts a new assistant group when the model changes", () => {
 		const markup = render([
 			{

--- a/apps/web/src/components/sessions/message-list.test.tsx
+++ b/apps/web/src/components/sessions/message-list.test.tsx
@@ -6,12 +6,20 @@ import type { SessionTimelineItem } from "@/lib/api-schemas";
 
 const timestamp = "2026-08-29T10:00:00.000Z";
 
-function render(items: SessionTimelineItem[]) {
+function render(
+	items: SessionTimelineItem[],
+	options: {
+		itemKeys?: string[];
+		highlightedMessageKey?: string;
+		highlightQuery?: string;
+	} = {},
+) {
 	return renderToStaticMarkup(
 		createElement(SessionTimelineList, {
 			items,
 			agentType: "codex",
 			userName: "You",
+			...options,
 		}),
 	);
 }
@@ -125,5 +133,43 @@ describe("SessionTimelineList", () => {
 
 		expect(markup).toContain("GPT 5");
 		expect(markup).toContain("Sonnet 4.5");
+	});
+
+	test("marks every visible match while only locating the active result", () => {
+		const markup = render(
+			[
+				{
+					kind: "message",
+					position: 1,
+					role: "user",
+					content: "First exact phrase match",
+					timestamp,
+				},
+				{
+					kind: "message",
+					position: 2,
+					role: "assistant",
+					content: "Current exact phrase match",
+					model: "gpt-5",
+					timestamp,
+				},
+				{
+					kind: "message",
+					position: 3,
+					role: "assistant",
+					content: "Final exact phrase match",
+					model: "gpt-5",
+					timestamp,
+				},
+			],
+			{
+				itemKeys: ["desc:0", "desc:1", "desc:2"],
+				highlightedMessageKey: "desc:1",
+				highlightQuery: "exact phrase",
+			},
+		);
+
+		expect(markup.match(/<mark/g)).toHaveLength(3);
+		expect(markup.match(/data-search-match="true"/g)).toHaveLength(1);
 	});
 });

--- a/apps/web/src/components/sessions/message-list.tsx
+++ b/apps/web/src/components/sessions/message-list.tsx
@@ -450,11 +450,14 @@ function ToolActivity({
 							})}
 						</span>
 					) : null}
-					{hasDetails ? (
-						<ChevronRight
-							className={cn("size-3.5 shrink-0 transition-transform", open && "rotate-90")}
-						/>
-					) : null}
+					<ChevronRight
+						aria-hidden="true"
+						className={cn(
+							"size-3.5 shrink-0 transition-transform",
+							open && "rotate-90",
+							!hasDetails && "invisible",
+						)}
+					/>
 				</button>
 				{open ? (
 					<div className="px-2 pb-2 pt-1">

--- a/apps/web/src/components/sessions/message-list.tsx
+++ b/apps/web/src/components/sessions/message-list.tsx
@@ -91,6 +91,7 @@ function MessageBlock({
 	isHighlighted,
 	highlightedRef,
 	highlightQuery,
+	deferOffscreenRendering,
 }: {
 	message: SessionMessage;
 	userAvatar?: string;
@@ -107,6 +108,7 @@ function MessageBlock({
 	isHighlighted?: boolean;
 	highlightedRef?: Ref<HTMLDivElement>;
 	highlightQuery?: string;
+	deferOffscreenRendering: boolean;
 }) {
 	const isUser = message.role === "user";
 	const agentName = agentTypeLabel(agentType);
@@ -120,7 +122,7 @@ function MessageBlock({
 			aria-current={isHighlighted ? "location" : undefined}
 			className={cn(
 				"group flex scroll-mt-24 gap-3 rounded-md",
-				OFFSCREEN_RENDERING_CLASS,
+				deferOffscreenRendering && OFFSCREEN_RENDERING_CLASS,
 				isGroupStart ? "pt-4" : "",
 				isHighlighted && "bg-primary/5 ring-1 ring-primary/30",
 			)}
@@ -196,7 +198,11 @@ function MessageBlock({
 					)}
 				>
 					{isUser ? (
-						<UserMessageBody content={message.content} highlightQuery={highlightQuery} />
+						<UserMessageBody
+							content={message.content}
+							highlightQuery={highlightQuery}
+							revealCollapsedMatch={isHighlighted}
+						/>
 					) : (
 						<Markdown content={message.content} highlightQuery={highlightQuery} />
 					)}
@@ -237,9 +243,11 @@ function isSkillExpansion(content: string): boolean {
 function UserMessageBody({
 	content,
 	highlightQuery,
+	revealCollapsedMatch,
 }: {
 	content: string;
 	highlightQuery?: string;
+	revealCollapsedMatch?: boolean;
 }) {
 	const cmd = parseSlashCommand(content);
 	if (cmd) {
@@ -256,6 +264,7 @@ function UserMessageBody({
 				label="Skill Setup Text"
 				content={content}
 				highlightQuery={highlightQuery}
+				revealMatch={revealCollapsedMatch}
 			/>
 		);
 	}
@@ -276,16 +285,18 @@ function CollapsibleBlock({
 	label,
 	content,
 	highlightQuery,
+	revealMatch,
 }: {
 	label: string;
 	content: string;
 	highlightQuery?: string;
+	revealMatch?: boolean;
 }) {
 	const [open, setOpen] = useState(false);
 	const containsMatch = highlightQuery
 		? splitSearchHighlight(content, highlightQuery).some((part) => part.highlighted)
 		: false;
-	const visible = open || containsMatch;
+	const visible = open || (revealMatch && containsMatch);
 	return (
 		<div className="rounded-md border border-dashed border-border/70 bg-muted/30">
 			<Button
@@ -403,10 +414,12 @@ function ToolActivity({
 	call,
 	result,
 	firstTimestamp,
+	deferOffscreenRendering,
 }: {
 	call?: SessionToolCall;
 	result?: SessionToolResult;
 	firstTimestamp?: string | null;
+	deferOffscreenRendering: boolean;
 }) {
 	const [open, setOpen] = useState(false);
 	const name = call?.name ?? result?.name ?? "Tool";
@@ -415,7 +428,7 @@ function ToolActivity({
 	const timestamp = firstTimestamp ?? call?.timestamp ?? result?.timestamp;
 
 	return (
-		<div className={cn("flex gap-3 py-1.5", OFFSCREEN_RENDERING_CLASS)}>
+		<div className={cn("flex gap-3 py-1.5", deferOffscreenRendering && OFFSCREEN_RENDERING_CLASS)}>
 			<div className="flex w-8 shrink-0 justify-center pt-2 text-muted-foreground">
 				<Wrench className="size-3.5" />
 			</div>
@@ -469,31 +482,7 @@ function ToolActivity({
 	);
 }
 
-/**
- * Renders an ordered session timeline. Calls and results in each contiguous
- * tool run collapse by call ID into one activity row; tools break message
- * author grouping. The 5-minute threshold matches Slack / Discord threads.
- *
- * `itemKeys` is an optional caller-provided per-row stable key
- * (e.g. the message's canonical position when the caller is paginating).
- * Falls back to the array index, which is fine for SSR / single-page
- * renders where order is stable.
- *
- * Exported as a Component (not a plain function) so server components
- * can render it as `<SessionTimelineList .../>` — React 19 rejects calls to
- * client-module functions from the server tree, but client components
- * rendered as JSX cross the boundary fine.
- */
-export function SessionTimelineList({
-	items,
-	itemKeys,
-	agentType,
-	userAvatar,
-	userName,
-	highlightedMessageKey,
-	highlightedMessageRef,
-	highlightQuery,
-}: {
+export interface SessionTimelineListProps {
 	items: TimelineEntry[];
 	itemKeys?: string[] | null;
 	agentType: string | null | undefined;
@@ -502,42 +491,71 @@ export function SessionTimelineList({
 	highlightedMessageKey?: string | null;
 	highlightedMessageRef?: Ref<HTMLDivElement>;
 	highlightQuery?: string;
-}) {
+}
+
+interface TimelineRowBase {
+	rowKey: string | number;
+	dividerTimestamp?: string;
+}
+
+interface MessageTimelineRow extends TimelineRowBase {
+	kind: "message";
+	message: TimelineMessage;
+	isGroupStart: boolean;
+}
+
+interface ToolTimelineRow extends TimelineRowBase {
+	kind: "tool";
+	call?: SessionToolCall;
+	result?: SessionToolResult;
+	firstTimestamp?: string | null;
+}
+
+export type SessionTimelineRow = MessageTimelineRow | ToolTimelineRow;
+
+/**
+ * Normalizes source events into the visual rows shared by the static public
+ * transcript and the virtualized dashboard timeline. Tool pairs and date
+ * dividers must be resolved before virtualization so both renderers preserve
+ * identical grouping semantics.
+ */
+export function buildSessionTimelineRows(
+	items: TimelineEntry[],
+	itemKeys?: string[] | null,
+): SessionTimelineRow[] {
 	const GROUP_GAP_MS = 5 * 60_000;
-	const out: React.ReactNode[] = [];
-	let prevDayKey: string | null = null;
+	const rows: SessionTimelineRow[] = [];
+	let previousDayKey: string | null = null;
 	let previousMessage: TimelineMessage | null = null;
-	const appendDateDivider = (timestamp: string | null | undefined) => {
+	const takeDividerTimestamp = (timestamp: string | null | undefined) => {
 		const nextDayKey = dayKey(timestamp);
-		if (!nextDayKey || nextDayKey === prevDayKey) return false;
-		out.push(<DateDivider key={`d-${nextDayKey}`} timestamp={timestamp ?? ""} />);
-		prevDayKey = nextDayKey;
-		return true;
+		if (!timestamp || !nextDayKey || nextDayKey === previousDayKey) return undefined;
+		previousDayKey = nextDayKey;
+		return timestamp;
 	};
+
 	for (let i = 0; i < items.length; i++) {
 		const item = items[i];
 		if (isToolEntry(item)) {
 			const { activities, nextIndex } = collectToolActivities(items, i);
 			for (const activity of activities) {
-				appendDateDivider(activity.firstItem.timestamp);
-				const toolKey =
-					itemKeys?.[activity.firstIndex] ??
-					`${activity.firstItem.kind}:${activity.firstItem.position}`;
-				out.push(
-					<ToolActivity
-						key={toolKey}
-						call={activity.call}
-						result={activity.result}
-						firstTimestamp={activity.firstItem.timestamp}
-					/>,
-				);
+				rows.push({
+					kind: "tool",
+					rowKey:
+						itemKeys?.[activity.firstIndex] ??
+						`${activity.firstItem.kind}:${activity.firstItem.position}`,
+					dividerTimestamp: takeDividerTimestamp(activity.firstItem.timestamp),
+					call: activity.call,
+					result: activity.result,
+					firstTimestamp: activity.firstItem.timestamp,
+				});
 			}
 			i = nextIndex - 1;
 			previousMessage = null;
 			continue;
 		}
 
-		const dividerJustEmitted = appendDateDivider(item.timestamp);
+		const dividerTimestamp = takeDividerTimestamp(item.timestamp);
 		const sameSpeaker =
 			previousMessage?.role === item.role &&
 			(item.role !== "assistant" || (previousMessage.model ?? null) === (item.model ?? null));
@@ -547,23 +565,80 @@ export function SessionTimelineList({
 						new Date(item.timestamp).getTime() - new Date(previousMessage.timestamp).getTime(),
 					) < GROUP_GAP_MS
 				: false;
-		const isGroupStart = !sameSpeaker || !closeInTime || dividerJustEmitted;
-		const messageKey = itemKeys?.[i] ?? i;
-		const isHighlighted = messageKey === highlightedMessageKey;
-		out.push(
-			<MessageBlock
-				key={messageKey}
-				message={item}
-				userAvatar={userAvatar}
-				userName={userName}
-				agentType={agentType}
-				isGroupStart={isGroupStart}
-				isHighlighted={isHighlighted}
-				highlightedRef={isHighlighted ? highlightedMessageRef : undefined}
-				highlightQuery={isHighlighted ? highlightQuery : undefined}
-			/>,
-		);
+		rows.push({
+			kind: "message",
+			rowKey: itemKeys?.[i] ?? i,
+			dividerTimestamp,
+			message: item,
+			isGroupStart: !sameSpeaker || !closeInTime || dividerTimestamp !== undefined,
+		});
 		previousMessage = item;
 	}
-	return <>{out}</>;
+	return rows;
+}
+
+export function SessionTimelineRowView({
+	row,
+	agentType,
+	userAvatar,
+	userName,
+	highlightedMessageKey,
+	highlightedMessageRef,
+	highlightQuery,
+	deferOffscreenRendering,
+}: Omit<SessionTimelineListProps, "items" | "itemKeys"> & {
+	row: SessionTimelineRow;
+	deferOffscreenRendering: boolean;
+}) {
+	const isHighlighted = row.kind === "message" && row.rowKey === highlightedMessageKey;
+	return (
+		<>
+			{row.dividerTimestamp ? <DateDivider timestamp={row.dividerTimestamp} /> : null}
+			{row.kind === "message" ? (
+				<MessageBlock
+					message={row.message}
+					userAvatar={userAvatar}
+					userName={userName}
+					agentType={agentType}
+					isGroupStart={row.isGroupStart}
+					isHighlighted={isHighlighted}
+					highlightedRef={isHighlighted ? highlightedMessageRef : undefined}
+					highlightQuery={highlightQuery}
+					deferOffscreenRendering={deferOffscreenRendering}
+				/>
+			) : (
+				<ToolActivity
+					call={row.call}
+					result={row.result}
+					firstTimestamp={row.firstTimestamp}
+					deferOffscreenRendering={deferOffscreenRendering}
+				/>
+			)}
+		</>
+	);
+}
+
+/**
+ * Static renderer used by public shares. Dashboard timelines use the same row
+ * model through the virtualized renderer.
+ */
+export function SessionTimelineList(props: SessionTimelineListProps) {
+	const rows = buildSessionTimelineRows(props.items, props.itemKeys);
+	return (
+		<>
+			{rows.map((row) => (
+				<SessionTimelineRowView
+					key={row.rowKey}
+					row={row}
+					agentType={props.agentType}
+					userAvatar={props.userAvatar}
+					userName={props.userName}
+					highlightedMessageKey={props.highlightedMessageKey}
+					highlightedMessageRef={props.highlightedMessageRef}
+					highlightQuery={props.highlightQuery}
+					deferOffscreenRendering
+				/>
+			))}
+		</>
+	);
 }

--- a/apps/web/src/components/sessions/message-list.tsx
+++ b/apps/web/src/components/sessions/message-list.tsx
@@ -369,11 +369,9 @@ function ToolActivity({ call, result }: { call?: SessionToolCall; result?: Sessi
 	const timestamp = call?.timestamp ?? result?.timestamp;
 
 	return (
-		<div className={cn("flex gap-3 py-2", OFFSCREEN_RENDERING_CLASS)}>
-			<div className="flex w-8 shrink-0 justify-center pt-1">
-				<span className="flex size-6 items-center justify-center rounded-md border bg-background text-muted-foreground shadow-xs">
-					<Wrench className="size-3.5" />
-				</span>
+		<div className={cn("flex gap-3 py-1.5", OFFSCREEN_RENDERING_CLASS)}>
+			<div className="flex w-8 shrink-0 justify-center pt-2 text-muted-foreground">
+				<Wrench className="size-3.5" />
 			</div>
 			<div className="min-w-0 flex-1">
 				<button
@@ -381,15 +379,8 @@ function ToolActivity({ call, result }: { call?: SessionToolCall; result?: Sessi
 					disabled={!hasDetails}
 					onClick={() => setOpen((value) => !value)}
 					aria-expanded={hasDetails ? open : undefined}
-					className="flex min-h-8 w-full min-w-0 items-center gap-2 rounded-md px-2 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/60 disabled:cursor-default disabled:hover:bg-transparent"
+					className="flex min-h-8 w-full min-w-0 items-center gap-2 rounded-md px-2 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/40 disabled:cursor-default disabled:hover:bg-transparent"
 				>
-					<ChevronRight
-						className={cn(
-							"size-3.5 shrink-0 transition-transform",
-							open && "rotate-90",
-							!hasDetails && "invisible",
-						)}
-					/>
 					<code className="truncate font-medium text-foreground">{name}</code>
 					{isError ? (
 						<span className="inline-flex shrink-0 items-center gap-1 text-destructive">
@@ -397,7 +388,7 @@ function ToolActivity({ call, result }: { call?: SessionToolCall; result?: Sessi
 						</span>
 					) : result ? (
 						<span className="inline-flex shrink-0 items-center gap-1">
-							<CheckCircle2 className="size-3.5" /> Completed
+							<CheckCircle2 className="size-3.5" /> Done
 						</span>
 					) : (
 						<span className="shrink-0">Called</span>
@@ -412,6 +403,11 @@ function ToolActivity({ call, result }: { call?: SessionToolCall; result?: Sessi
 								minute: "2-digit",
 							})}
 						</span>
+					) : null}
+					{hasDetails ? (
+						<ChevronRight
+							className={cn("size-3.5 shrink-0 transition-transform", open && "rotate-90")}
+						/>
 					) : null}
 				</button>
 				{open ? (

--- a/apps/web/src/components/sessions/message-list.tsx
+++ b/apps/web/src/components/sessions/message-list.tsx
@@ -361,12 +361,52 @@ function ToolDetails({ call, result }: { call?: SessionToolCall; result?: Sessio
 	);
 }
 
-function ToolActivity({ call, result }: { call?: SessionToolCall; result?: SessionToolResult }) {
+interface PairedToolActivity {
+	call?: SessionToolCall;
+	result?: SessionToolResult;
+	firstItem: SessionToolCall | SessionToolResult;
+	firstIndex: number;
+}
+
+// Parallel tool use is commonly serialized as call A, call B, result A,
+// result B. Pair a contiguous tool run by its stable call ID while preserving
+// the first-seen order of each activity.
+function collectToolActivities(items: TimelineEntry[], startIndex: number) {
+	const activities = new Map<string, PairedToolActivity>();
+	let nextIndex = startIndex;
+	while (nextIndex < items.length) {
+		const item = items[nextIndex];
+		if (!isToolEntry(item)) break;
+
+		let activity = activities.get(item.call_id);
+		if (!activity) {
+			activity = {
+				firstItem: item,
+				firstIndex: nextIndex,
+			};
+			activities.set(item.call_id, activity);
+		}
+		if (item.kind === "tool_call") activity.call ??= item;
+		else activity.result ??= item;
+		nextIndex++;
+	}
+	return { activities: [...activities.values()], nextIndex };
+}
+
+function ToolActivity({
+	call,
+	result,
+	firstTimestamp,
+}: {
+	call?: SessionToolCall;
+	result?: SessionToolResult;
+	firstTimestamp?: string | null;
+}) {
 	const [open, setOpen] = useState(false);
 	const name = call?.name ?? result?.name ?? "Tool";
 	const hasDetails = Boolean(call?.arguments_json || result?.content || result?.result_json);
 	const isError = result?.status === "error";
-	const timestamp = call?.timestamp ?? result?.timestamp;
+	const timestamp = firstTimestamp ?? call?.timestamp ?? result?.timestamp;
 
 	return (
 		<div className={cn("flex gap-3 py-1.5", OFFSCREEN_RENDERING_CLASS)}>
@@ -421,9 +461,9 @@ function ToolActivity({ call, result }: { call?: SessionToolCall; result?: Sessi
 }
 
 /**
- * Renders an ordered session timeline. Adjacent call/result events with the
- * same call ID collapse into one tool activity row; tools break message author
- * grouping. The 5-minute threshold matches Slack / Discord message threads.
+ * Renders an ordered session timeline. Calls and results in each contiguous
+ * tool run collapse by call ID into one activity row; tools break message
+ * author grouping. The 5-minute threshold matches Slack / Discord threads.
  *
  * `itemKeys` is an optional caller-provided per-row stable key
  * (e.g. the message's canonical position when the caller is paginating).
@@ -458,40 +498,47 @@ export function SessionTimelineList({
 	const out: React.ReactNode[] = [];
 	let prevDayKey: string | null = null;
 	let previousMessage: TimelineMessage | null = null;
+	const appendDateDivider = (timestamp: string | null | undefined) => {
+		const nextDayKey = dayKey(timestamp);
+		if (!nextDayKey || nextDayKey === prevDayKey) return false;
+		out.push(<DateDivider key={`d-${nextDayKey}`} timestamp={timestamp ?? ""} />);
+		prevDayKey = nextDayKey;
+		return true;
+	};
 	for (let i = 0; i < items.length; i++) {
 		const item = items[i];
-		const dKey = dayKey(item.timestamp);
-		const dividerJustEmitted = Boolean(dKey && dKey !== prevDayKey);
-		if (dKey && dKey !== prevDayKey) {
-			out.push(<DateDivider key={`d-${dKey}`} timestamp={item.timestamp ?? ""} />);
-			prevDayKey = dKey;
-		}
-
 		if (isToolEntry(item)) {
-			const next = items[i + 1];
-			const paired =
-				next && isToolEntry(next) && next.kind !== item.kind && next.call_id === item.call_id
-					? next
-					: null;
-			const call =
-				item.kind === "tool_call" ? item : paired?.kind === "tool_call" ? paired : undefined;
-			const result =
-				item.kind === "tool_result" ? item : paired?.kind === "tool_result" ? paired : undefined;
-			const toolKey = itemKeys?.[i] ?? `${item.kind}:${item.position}`;
-			out.push(<ToolActivity key={toolKey} call={call} result={result} />);
-			if (paired) i++;
+			const { activities, nextIndex } = collectToolActivities(items, i);
+			for (const activity of activities) {
+				appendDateDivider(activity.firstItem.timestamp);
+				const toolKey =
+					itemKeys?.[activity.firstIndex] ??
+					`${activity.firstItem.kind}:${activity.firstItem.position}`;
+				out.push(
+					<ToolActivity
+						key={toolKey}
+						call={activity.call}
+						result={activity.result}
+						firstTimestamp={activity.firstItem.timestamp}
+					/>,
+				);
+			}
+			i = nextIndex - 1;
 			previousMessage = null;
 			continue;
 		}
 
-		const sameAuthor = previousMessage?.role === item.role;
+		const dividerJustEmitted = appendDateDivider(item.timestamp);
+		const sameSpeaker =
+			previousMessage?.role === item.role &&
+			(item.role !== "assistant" || (previousMessage.model ?? null) === (item.model ?? null));
 		const closeInTime =
 			previousMessage?.timestamp && item.timestamp
 				? Math.abs(
 						new Date(item.timestamp).getTime() - new Date(previousMessage.timestamp).getTime(),
 					) < GROUP_GAP_MS
 				: false;
-		const isGroupStart = !sameAuthor || !closeInTime || dividerJustEmitted;
+		const isGroupStart = !sameSpeaker || !closeInTime || dividerJustEmitted;
 		const messageKey = itemKeys?.[i] ?? i;
 		const isHighlighted = messageKey === highlightedMessageKey;
 		out.push(

--- a/apps/web/src/components/sessions/message-list.tsx
+++ b/apps/web/src/components/sessions/message-list.tsx
@@ -370,27 +370,33 @@ interface PairedToolActivity {
 
 // Parallel tool use is commonly serialized as call A, call B, result A,
 // result B. Pair a contiguous tool run by its stable call ID while preserving
-// the first-seen order of each activity.
+// the first-seen order and every row when a broken producer reuses an ID.
 function collectToolActivities(items: TimelineEntry[], startIndex: number) {
-	const activities = new Map<string, PairedToolActivity>();
+	const activities: PairedToolActivity[] = [];
+	const activitiesByCallId = new Map<string, PairedToolActivity[]>();
 	let nextIndex = startIndex;
 	while (nextIndex < items.length) {
 		const item = items[nextIndex];
 		if (!isToolEntry(item)) break;
 
-		let activity = activities.get(item.call_id);
+		const matching = activitiesByCallId.get(item.call_id) ?? [];
+		let activity = matching.find((candidate) =>
+			item.kind === "tool_call" ? candidate.call === undefined : candidate.result === undefined,
+		);
 		if (!activity) {
 			activity = {
 				firstItem: item,
 				firstIndex: nextIndex,
 			};
-			activities.set(item.call_id, activity);
+			matching.push(activity);
+			activitiesByCallId.set(item.call_id, matching);
+			activities.push(activity);
 		}
-		if (item.kind === "tool_call") activity.call ??= item;
-		else activity.result ??= item;
+		if (item.kind === "tool_call") activity.call = item;
+		else activity.result = item;
 		nextIndex++;
 	}
-	return { activities: [...activities.values()], nextIndex };
+	return { activities, nextIndex };
 }
 
 function ToolActivity({

--- a/apps/web/src/components/sessions/session-search-navigation.tsx
+++ b/apps/web/src/components/sessions/session-search-navigation.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { Link, useRouter } from "@tanstack/react-router";
+import { useRouter } from "@tanstack/react-router";
 import { ChevronDown, ChevronUp, LoaderCircle } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/search-input";
+import { agentSessionDetailLink } from "@/lib/agent-routes";
 import type { SessionMessagesPage } from "@/lib/api-schemas";
 import {
+	parseSessionTimelineView,
 	type SessionSearchAnchor,
+	type SessionTimelineView,
 	sessionDetailSearchLink,
 	sessionSearchMatchLink,
 } from "@/lib/session-search-anchor";
@@ -18,16 +21,12 @@ type SearchNavigation = NonNullable<SessionMessagesPage["search_navigation"]>;
 function MatchButton({
 	label,
 	anchor,
-	sessionId,
-	query,
-	returnTo,
+	onSelect,
 	icon,
 }: {
 	label: string;
 	anchor: SessionSearchAnchor | null | undefined;
-	sessionId: string;
-	query: string;
-	returnTo?: string;
+	onSelect: (anchor: SessionSearchAnchor) => void;
 	icon: React.ReactNode;
 }) {
 	if (!anchor) {
@@ -41,14 +40,7 @@ function MatchButton({
 		<Button
 			variant="ghost"
 			size="icon-sm"
-			nativeButton={false}
-			render={
-				<Link
-					{...sessionSearchMatchLink(sessionId, anchor, { searchQuery: query, returnTo })}
-					replace
-					resetScroll={false}
-				/>
-			}
+			onClick={() => onSelect(anchor)}
 			aria-label={label}
 			title={label}
 		>
@@ -59,7 +51,9 @@ function MatchButton({
 
 export function SessionSearchNavigation({
 	sessionId,
+	agentId,
 	query,
+	timelineView,
 	navigation,
 	returnTo,
 	isSearching = false,
@@ -67,7 +61,9 @@ export function SessionSearchNavigation({
 	className,
 }: {
 	sessionId: string;
+	agentId?: string | null;
 	query: string;
+	timelineView: SessionTimelineView;
 	navigation?: SearchNavigation | null;
 	returnTo?: string;
 	isSearching?: boolean;
@@ -81,28 +77,50 @@ export function SessionSearchNavigation({
 		setDraftQuery((current) => (query && current.trim() === query ? current : query));
 	}, [query]);
 	const activeNavigation = isSearching || hasSearchError ? null : navigation;
-	const updateQuery = (next: string) => {
-		setDraftQuery(next);
+	const navigate = (search: Record<string, unknown>) => {
+		if (agentId) {
+			void router.navigate({
+				...agentSessionDetailLink(agentId, sessionId, search),
+				replace: true,
+				resetScroll: false,
+			});
+			return;
+		}
 		void router.navigate({
-			...sessionDetailSearchLink(sessionId, next, { returnTo }),
+			to: "/sessions/$id",
+			params: { id: sessionId },
+			search,
 			replace: true,
 			resetScroll: false,
 		});
 	};
+	const latestTimelineView = () =>
+		parseSessionTimelineView(router.state.location.search.timelineView) ?? timelineView;
+	const updateQuery = (next: string) => {
+		setDraftQuery(next);
+		navigate(
+			sessionDetailSearchLink(sessionId, next, {
+				returnTo,
+				timelineView: latestTimelineView(),
+			}).search,
+		);
+	};
 	const navigateToMatch = (anchor: SessionSearchAnchor | null | undefined) => {
 		if (!anchor) return;
-		void router.navigate({
-			...sessionSearchMatchLink(sessionId, anchor, { searchQuery: query, returnTo }),
-			replace: true,
-			resetScroll: false,
-		});
+		navigate(
+			sessionSearchMatchLink(sessionId, anchor, {
+				searchQuery: query,
+				timelineView: latestTimelineView(),
+				returnTo,
+			}).search,
+		);
 	};
 
 	return (
 		<nav
 			aria-label="Search this session"
 			className={cn(
-				"flex min-w-0 flex-1 flex-col gap-2 text-xs text-muted-foreground sm:flex-row sm:items-center",
+				"flex min-w-0 flex-1 items-center gap-1.5 text-xs text-muted-foreground",
 				className,
 			)}
 		>
@@ -111,7 +129,7 @@ export function SessionSearchNavigation({
 				onChange={updateQuery}
 				placeholder="Search this session…"
 				ariaLabel="Search this session"
-				className="min-w-0 flex-1"
+				className="min-w-36 flex-1"
 				ariaKeyShortcuts="Enter Shift+Enter Escape"
 				onKeyDown={(event) => {
 					if (event.nativeEvent.isComposing) return;
@@ -128,38 +146,38 @@ export function SessionSearchNavigation({
 				}}
 			/>
 			{query ? (
-				<div className="flex min-h-8 shrink-0 items-center justify-end gap-2">
+				<div className="flex min-h-8 shrink-0 items-center gap-1 border-l pl-1.5">
 					<span
-						className="inline-flex shrink-0 items-center gap-1.5 tabular-nums text-foreground"
+						className="inline-flex min-w-10 shrink-0 items-center justify-center gap-1 tabular-nums text-foreground"
 						aria-live="polite"
+						title={!isSearching && !hasSearchError && !activeNavigation ? "No matches" : undefined}
 					>
-						{isSearching ? <LoaderCircle className="size-3.5 animate-spin" /> : null}
+						{isSearching ? (
+							<>
+								<LoaderCircle className="size-3.5 animate-spin" />
+								<span className="sr-only">Searching</span>
+							</>
+						) : null}
 						{hasSearchError
 							? "Unavailable"
 							: isSearching
-								? "Searching"
+								? null
 								: activeNavigation
-									? `${activeNavigation.index} of ${activeNavigation.total}`
-									: "No matches"}
+									? `${activeNavigation.index} / ${activeNavigation.total}`
+									: "0 / 0"}
 					</span>
-					<div className="flex shrink-0 items-center">
-						<MatchButton
-							label="Previous match"
-							anchor={activeNavigation?.previous}
-							sessionId={sessionId}
-							query={query}
-							returnTo={returnTo}
-							icon={<ChevronUp />}
-						/>
-						<MatchButton
-							label="Next match"
-							anchor={activeNavigation?.next}
-							sessionId={sessionId}
-							query={query}
-							returnTo={returnTo}
-							icon={<ChevronDown />}
-						/>
-					</div>
+					<MatchButton
+						label="Previous match"
+						anchor={activeNavigation?.previous}
+						onSelect={navigateToMatch}
+						icon={<ChevronUp />}
+					/>
+					<MatchButton
+						label="Next match"
+						anchor={activeNavigation?.next}
+						onSelect={navigateToMatch}
+						icon={<ChevronDown />}
+					/>
 				</div>
 			) : null}
 		</nav>

--- a/apps/web/src/components/sessions/session-search-navigation.tsx
+++ b/apps/web/src/components/sessions/session-search-navigation.tsx
@@ -118,7 +118,7 @@ export function SessionSearchNavigation({
 
 	return (
 		<nav
-			aria-label="Search this session"
+			aria-label="Search messages"
 			className={cn(
 				"flex min-w-0 flex-1 items-center gap-1.5 text-xs text-muted-foreground",
 				className,
@@ -127,8 +127,8 @@ export function SessionSearchNavigation({
 			<SearchInput
 				value={draftQuery}
 				onChange={updateQuery}
-				placeholder="Search this session…"
-				ariaLabel="Search this session"
+				placeholder="Search messages…"
+				ariaLabel="Search messages"
 				className="min-w-36 flex-1"
 				ariaKeyShortcuts="Enter Shift+Enter Escape"
 				onKeyDown={(event) => {
@@ -150,7 +150,6 @@ export function SessionSearchNavigation({
 					<span
 						className="inline-flex min-w-10 shrink-0 items-center justify-center gap-1 tabular-nums text-foreground"
 						aria-live="polite"
-						title={!isSearching && !hasSearchError && !activeNavigation ? "No matches" : undefined}
 					>
 						{isSearching ? (
 							<>
@@ -158,13 +157,16 @@ export function SessionSearchNavigation({
 								<span className="sr-only">Searching</span>
 							</>
 						) : null}
-						{hasSearchError
-							? "Unavailable"
-							: isSearching
-								? null
-								: activeNavigation
-									? `${activeNavigation.index} / ${activeNavigation.total}`
-									: "0 / 0"}
+						{hasSearchError ? (
+							"Unavailable"
+						) : isSearching ? null : activeNavigation ? (
+							`${activeNavigation.index} / ${activeNavigation.total}`
+						) : (
+							<>
+								<span aria-hidden="true">0 / 0</span>
+								<span className="sr-only">No matches</span>
+							</>
+						)}
 					</span>
 					<MatchButton
 						label="Previous match"

--- a/apps/web/src/components/sessions/virtualized-message-list.tsx
+++ b/apps/web/src/components/sessions/virtualized-message-list.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
+import {
+	buildSessionTimelineRows,
+	type SessionTimelineListProps,
+	SessionTimelineRowView,
+} from "@/components/sessions/message-list";
+import { findScrollableContainer } from "@/lib/scroll-container";
+import { useIsomorphicLayoutEffect } from "@/lib/use-isomorphic-layout-effect";
+
+const DASHBOARD_SCROLL_CONTAINER_ID = "dashboard-scroll-container";
+
+/**
+ * Windowed dashboard renderer for variable-height Markdown and tool activity.
+ * React Virtuoso owns measurement and scroll anchoring. Public shares keep the
+ * static renderer; dashboard data is client-fetched, so its SSR shell is empty.
+ */
+export function VirtualizedSessionTimelineList(props: SessionTimelineListProps) {
+	const [scrollParent, setScrollParent] = useState<HTMLElement | Window | null>(null);
+	const virtuosoRef = useRef<VirtuosoHandle>(null);
+	const rows = useMemo(
+		() => buildSessionTimelineRows(props.items, props.itemKeys),
+		[props.items, props.itemKeys],
+	);
+	const highlightedRowIndex = props.highlightedMessageKey
+		? rows.findIndex((row) => row.rowKey === props.highlightedMessageKey)
+		: -1;
+
+	useIsomorphicLayoutEffect(() => {
+		const resolveScrollParent = () => {
+			setScrollParent(
+				findScrollableContainer(document.getElementById(DASHBOARD_SCROLL_CONTAINER_ID)),
+			);
+		};
+		resolveScrollParent();
+		window.addEventListener("resize", resolveScrollParent);
+		return () => window.removeEventListener("resize", resolveScrollParent);
+	}, []);
+
+	useEffect(() => {
+		if (!scrollParent || highlightedRowIndex < 0) return;
+		const frame = requestAnimationFrame(() => {
+			virtuosoRef.current?.scrollToIndex({
+				index: highlightedRowIndex,
+				align: "center",
+				behavior: "smooth",
+			});
+		});
+		return () => cancelAnimationFrame(frame);
+	}, [highlightedRowIndex, scrollParent]);
+
+	if (!scrollParent) return <div aria-hidden className="h-px" />;
+	const usesWindowScroll = scrollParent === window;
+
+	return (
+		<div data-testid="virtualized-session-timeline">
+			<Virtuoso
+				key={usesWindowScroll ? "window" : "container"}
+				ref={virtuosoRef}
+				{...(usesWindowScroll
+					? { useWindowScroll: true }
+					: { customScrollParent: scrollParent as HTMLElement })}
+				data={rows}
+				computeItemKey={(_index, row) => row.rowKey}
+				defaultItemHeight={96}
+				increaseViewportBy={{ top: 600, bottom: 900 }}
+				initialTopMostItemIndex={
+					highlightedRowIndex < 0 ? 0 : { index: highlightedRowIndex, align: "center" }
+				}
+				itemContent={(_index, row) => (
+					<SessionTimelineRowView
+						row={row}
+						agentType={props.agentType}
+						userAvatar={props.userAvatar}
+						userName={props.userName}
+						highlightedMessageKey={props.highlightedMessageKey}
+						highlightedMessageRef={props.highlightedMessageRef}
+						highlightQuery={props.highlightQuery}
+						deferOffscreenRendering={false}
+					/>
+				)}
+			/>
+		</div>
+	);
+}

--- a/apps/web/src/lib/scroll-container.ts
+++ b/apps/web/src/lib/scroll-container.ts
@@ -1,0 +1,9 @@
+export function findScrollableContainer(node: Element | null): HTMLElement | Window {
+	let current = node instanceof HTMLElement ? node : node?.parentElement;
+	while (current) {
+		const overflow = getComputedStyle(current).overflowY;
+		if (overflow === "auto" || overflow === "scroll") return current;
+		current = current.parentElement;
+	}
+	return window;
+}

--- a/apps/web/src/lib/session-search-anchor.test.ts
+++ b/apps/web/src/lib/session-search-anchor.test.ts
@@ -42,12 +42,14 @@ describe("Session search anchors", () => {
 		expect(
 			sessionDetailSearchLink("session-id", " authentication ", {
 				returnTo: "/sessions?q=authentication&page=2",
+				timelineView: "assistant",
 			}),
 		).toEqual({
 			to: "/sessions/$id",
 			params: { id: "session-id" },
 			search: {
 				matchQuery: "authentication",
+				timelineView: "assistant",
 				returnTo: "/sessions?q=authentication&page=2",
 			},
 		});
@@ -56,12 +58,13 @@ describe("Session search anchors", () => {
 		});
 	});
 
-	test("canonicalizes timeline filters and clears them for transcript search", () => {
+	test("canonicalizes timeline filters independently from transcript search", () => {
 		expect(validateSessionDetailSearch({ timelineView: "tools" })).toEqual({
 			timelineView: "tools",
 		});
 		expect(validateSessionDetailSearch({ timelineView: "tools", matchQuery: " answer " })).toEqual({
 			matchQuery: "answer",
+			timelineView: "tools",
 		});
 		expect(validateSessionDetailSearch({ timelineView: "unknown" })).toEqual({});
 		expect(sessionTimelineViewLink("session-id", "all")).toEqual({
@@ -73,6 +76,11 @@ describe("Session search anchors", () => {
 			to: "/sessions/$id",
 			params: { id: "session-id" },
 			search: { timelineView: "assistant" },
+		});
+		expect(sessionTimelineViewLink("session-id", "user", { searchQuery: " answer " })).toEqual({
+			to: "/sessions/$id",
+			params: { id: "session-id" },
+			search: { matchQuery: "answer", timelineView: "user" },
 		});
 	});
 

--- a/apps/web/src/lib/session-search-anchor.test.ts
+++ b/apps/web/src/lib/session-search-anchor.test.ts
@@ -58,14 +58,22 @@ describe("Session search anchors", () => {
 		});
 	});
 
-	test("canonicalizes timeline filters independently from transcript search", () => {
+	test("keeps message search out of the tools-only timeline", () => {
 		expect(validateSessionDetailSearch({ timelineView: "tools" })).toEqual({
 			timelineView: "tools",
 		});
 		expect(validateSessionDetailSearch({ timelineView: "tools", matchQuery: " answer " })).toEqual({
-			matchQuery: "answer",
 			timelineView: "tools",
 		});
+		expect(
+			validateSessionDetailSearch({
+				timelineView: "tools",
+				matchQuery: "answer",
+				matchKind: "event_seq",
+				matchPosition: 42,
+				matchRevision: "events:revision",
+			}),
+		).toEqual({ timelineView: "tools" });
 		expect(validateSessionDetailSearch({ timelineView: "unknown" })).toEqual({});
 		expect(sessionTimelineViewLink("session-id", "all")).toEqual({
 			to: "/sessions/$id",
@@ -81,6 +89,16 @@ describe("Session search anchors", () => {
 			to: "/sessions/$id",
 			params: { id: "session-id" },
 			search: { matchQuery: "answer", timelineView: "user" },
+		});
+		expect(sessionTimelineViewLink("session-id", "tools", { searchQuery: " answer " })).toEqual({
+			to: "/sessions/$id",
+			params: { id: "session-id" },
+			search: { timelineView: "tools" },
+		});
+		expect(sessionDetailSearchLink("session-id", "answer", { timelineView: "tools" })).toEqual({
+			to: "/sessions/$id",
+			params: { id: "session-id" },
+			search: { timelineView: "tools" },
 		});
 	});
 

--- a/apps/web/src/lib/session-search-anchor.ts
+++ b/apps/web/src/lib/session-search-anchor.ts
@@ -12,6 +12,12 @@ export interface SessionDetailSearch {
 	returnTo?: string;
 }
 
+interface SessionDetailLink {
+	to: "/sessions/$id";
+	params: { id: string };
+	search: SessionDetailSearch & Record<string, unknown>;
+}
+
 function validPosition(value: unknown): number | undefined {
 	const parsed =
 		typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
@@ -26,13 +32,15 @@ export function parseSessionTimelineView(
 
 export function validateSessionDetailSearch(search: Record<string, unknown>): SessionDetailSearch {
 	const returnTo = normalizeSessionListReturnTo(search.returnTo);
-	const matchQuery = normalizeSessionMatchQuery(search.matchQuery);
 	const timelineView = parseSessionTimelineView(search.timelineView);
+	const matchQuery =
+		timelineView === "tools" ? undefined : normalizeSessionMatchQuery(search.matchQuery);
 	const standalone = {
 		...(matchQuery ? { matchQuery } : {}),
 		...(timelineView ? { timelineView } : {}),
 		...(returnTo ? { returnTo } : {}),
 	};
+	if (timelineView === "tools") return standalone;
 	const kind =
 		search.matchKind === "snapshot_offset" || search.matchKind === "event_seq"
 			? search.matchKind
@@ -59,9 +67,9 @@ export function sessionTimelineViewLink(
 	sessionId: string,
 	view: SessionTimelineView,
 	options: { returnTo?: string; searchQuery?: string } = {},
-) {
+): SessionDetailLink {
 	const returnTo = normalizeSessionListReturnTo(options.returnTo);
-	const matchQuery = normalizeSessionMatchQuery(options.searchQuery);
+	const matchQuery = view === "tools" ? undefined : normalizeSessionMatchQuery(options.searchQuery);
 	return {
 		to: "/sessions/$id" as const,
 		params: { id: sessionId },
@@ -77,11 +85,11 @@ export function sessionDetailSearchLink(
 	sessionId: string,
 	query: string,
 	options: { returnTo?: string; timelineView?: SessionTimelineView } = {},
-) {
+): SessionDetailLink {
 	const returnTo = normalizeSessionListReturnTo(options.returnTo);
-	const matchQuery = normalizeSessionMatchQuery(query);
 	const timelineView =
 		options.timelineView === "all" ? undefined : parseSessionTimelineView(options.timelineView);
+	const matchQuery = timelineView === "tools" ? undefined : normalizeSessionMatchQuery(query);
 	return {
 		to: "/sessions/$id" as const,
 		params: { id: sessionId },
@@ -129,7 +137,7 @@ export function sessionSearchAnchorFromSearch(
 export function sessionDetailLink(
 	session: Pick<SessionListItem, "id" | "search_match">,
 	options: { returnTo?: string; searchQuery?: string } = {},
-) {
+): SessionDetailLink {
 	const anchor = session.search_match?.anchor;
 	if (anchor) {
 		return sessionSearchMatchLink(session.id, anchor, options);
@@ -152,11 +160,14 @@ export function sessionSearchMatchLink(
 		searchQuery?: string;
 		timelineView?: SessionTimelineView;
 	} = {},
-) {
+): SessionDetailLink {
 	const returnTo = normalizeSessionListReturnTo(options.returnTo);
-	const matchQuery = normalizeSessionMatchQuery(options.searchQuery);
 	const timelineView =
 		options.timelineView === "all" ? undefined : parseSessionTimelineView(options.timelineView);
+	if (timelineView === "tools") {
+		return sessionTimelineViewLink(sessionId, timelineView, { returnTo });
+	}
+	const matchQuery = normalizeSessionMatchQuery(options.searchQuery);
 	return {
 		to: "/sessions/$id" as const,
 		params: { id: sessionId },

--- a/apps/web/src/lib/session-search-anchor.ts
+++ b/apps/web/src/lib/session-search-anchor.ts
@@ -27,7 +27,7 @@ export function parseSessionTimelineView(
 export function validateSessionDetailSearch(search: Record<string, unknown>): SessionDetailSearch {
 	const returnTo = normalizeSessionListReturnTo(search.returnTo);
 	const matchQuery = normalizeSessionMatchQuery(search.matchQuery);
-	const timelineView = matchQuery ? undefined : parseSessionTimelineView(search.timelineView);
+	const timelineView = parseSessionTimelineView(search.timelineView);
 	const standalone = {
 		...(matchQuery ? { matchQuery } : {}),
 		...(timelineView ? { timelineView } : {}),
@@ -58,13 +58,15 @@ export function validateSessionDetailSearch(search: Record<string, unknown>): Se
 export function sessionTimelineViewLink(
 	sessionId: string,
 	view: SessionTimelineView,
-	options: { returnTo?: string } = {},
+	options: { returnTo?: string; searchQuery?: string } = {},
 ) {
 	const returnTo = normalizeSessionListReturnTo(options.returnTo);
+	const matchQuery = normalizeSessionMatchQuery(options.searchQuery);
 	return {
 		to: "/sessions/$id" as const,
 		params: { id: sessionId },
 		search: {
+			...(matchQuery ? { matchQuery } : {}),
 			...(view === "all" ? {} : { timelineView: view }),
 			...(returnTo ? { returnTo } : {}),
 		},
@@ -74,15 +76,18 @@ export function sessionTimelineViewLink(
 export function sessionDetailSearchLink(
 	sessionId: string,
 	query: string,
-	options: { returnTo?: string } = {},
+	options: { returnTo?: string; timelineView?: SessionTimelineView } = {},
 ) {
 	const returnTo = normalizeSessionListReturnTo(options.returnTo);
 	const matchQuery = normalizeSessionMatchQuery(query);
+	const timelineView =
+		options.timelineView === "all" ? undefined : parseSessionTimelineView(options.timelineView);
 	return {
 		to: "/sessions/$id" as const,
 		params: { id: sessionId },
 		search: {
 			...(matchQuery ? { matchQuery } : {}),
+			...(timelineView ? { timelineView } : {}),
 			...(returnTo ? { returnTo } : {}),
 		},
 	};
@@ -142,10 +147,16 @@ export function sessionDetailLink(
 export function sessionSearchMatchLink(
 	sessionId: string,
 	anchor: SessionSearchAnchor,
-	options: { returnTo?: string; searchQuery?: string } = {},
+	options: {
+		returnTo?: string;
+		searchQuery?: string;
+		timelineView?: SessionTimelineView;
+	} = {},
 ) {
 	const returnTo = normalizeSessionListReturnTo(options.returnTo);
 	const matchQuery = normalizeSessionMatchQuery(options.searchQuery);
+	const timelineView =
+		options.timelineView === "all" ? undefined : parseSessionTimelineView(options.timelineView);
 	return {
 		to: "/sessions/$id" as const,
 		params: { id: sessionId },
@@ -154,6 +165,7 @@ export function sessionSearchMatchLink(
 			matchPosition: anchor.position,
 			matchRevision: anchor.revision,
 			...(matchQuery ? { matchQuery } : {}),
+			...(timelineView ? { timelineView } : {}),
 			...(returnTo ? { returnTo } : {}),
 		},
 	};

--- a/apps/web/src/pages/dashboard/agents/agent-session-detail-page.tsx
+++ b/apps/web/src/pages/dashboard/agents/agent-session-detail-page.tsx
@@ -1,20 +1,30 @@
 "use client";
 
-import type { SessionTimelineView } from "@/lib/session-search-anchor";
+import type { SessionSearchAnchor, SessionTimelineView } from "@/lib/session-search-anchor";
 import { SessionDetailContent } from "@/pages/dashboard/sessions/[id]/page";
 
 type AgentSessionDetailPageProps = {
 	agentId: string;
 	sessionId: string;
+	searchAnchor?: SessionSearchAnchor;
+	searchQuery?: string;
 	timelineView: SessionTimelineView;
 };
 
 export default function AgentSessionDetailPage({
 	agentId,
 	sessionId,
+	searchAnchor,
+	searchQuery,
 	timelineView,
 }: AgentSessionDetailPageProps) {
 	return (
-		<SessionDetailContent sessionId={sessionId} agentId={agentId} timelineView={timelineView} />
+		<SessionDetailContent
+			sessionId={sessionId}
+			agentId={agentId}
+			searchAnchor={searchAnchor}
+			searchQuery={searchQuery}
+			timelineView={timelineView}
+		/>
 	);
 }

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -412,19 +412,22 @@ export function SessionDetailContent({
 		(normalizedSearchQuery !== debouncedSearchQuery || isContentFetching || isContentLoading);
 	const updateTimelineView = (selected: SessionTimelineView) => {
 		if (agentId) {
+			const search = {
+				...(normalizedSearchQuery ? { matchQuery: normalizedSearchQuery } : {}),
+				...(selected === "all" ? {} : { timelineView: selected }),
+			};
 			void router.navigate({
-				...agentSessionDetailLink(
-					agentId,
-					sessionId,
-					selected === "all" ? undefined : { timelineView: selected },
-				),
+				...agentSessionDetailLink(agentId, sessionId, search),
 				replace: true,
 				resetScroll: false,
 			});
 			return;
 		}
 		void router.navigate({
-			...sessionTimelineViewLink(sessionId, selected, { returnTo }),
+			...sessionTimelineViewLink(sessionId, selected, {
+				returnTo,
+				searchQuery: normalizedSearchQuery,
+			}),
 			replace: true,
 			resetScroll: false,
 		});
@@ -528,83 +531,76 @@ export function SessionDetailContent({
 
 			{session.has_content ? (
 				<div className="sticky top-(--header-height) z-10 -mx-4 border-y bg-background/95 px-4 py-2 backdrop-blur supports-[backdrop-filter]:bg-background/80 lg:-mx-6 lg:px-6">
-					<div className="flex min-w-0 flex-col gap-2 lg:flex-row lg:items-center">
+					<div className="grid min-w-0 gap-2 md:grid-cols-[minmax(16rem,1fr)_auto] md:items-center">
 						<SessionSearchNavigation
 							sessionId={sessionId}
+							agentId={agentId}
 							query={normalizedSearchQuery}
+							timelineView={timelineView}
 							navigation={searchNavigation}
 							returnTo={returnTo}
 							isSearching={isSearchUpdating}
 							hasSearchError={searchActive && isContentError}
-							className="lg:max-w-2xl"
+							className="md:max-w-xl"
 						/>
-						{searchActive ? null : (
-							<div className="flex min-w-0 items-center justify-between gap-2 lg:ml-auto lg:justify-end">
-								<ToggleGroup
-									value={[timelineView]}
-									onValueChange={(values) => {
-										const selected = values[0];
-										if (
-											selected === "all" ||
-											selected === "user" ||
-											selected === "assistant" ||
-											selected === "tools"
-										) {
-											updateTimelineView(selected);
-										}
-									}}
-									size="sm"
-									spacing={1}
-									aria-label="Timeline view"
-									className="min-w-0 bg-muted p-0.5"
+						<div className="flex min-w-0 items-center justify-between gap-2 md:justify-end">
+							<ToggleGroup
+								value={[timelineView]}
+								onValueChange={(values) => {
+									const selected = values[0];
+									if (
+										selected === "all" ||
+										selected === "user" ||
+										selected === "assistant" ||
+										selected === "tools"
+									) {
+										updateTimelineView(selected);
+									}
+								}}
+								variant="outline"
+								size="sm"
+								spacing={0}
+								aria-label="Timeline view"
+								className="min-w-0"
+							>
+								<ToggleGroupItem value="all" aria-label="All activity" title="All activity">
+									<MessageSquare /> <span className="hidden sm:inline">All</span>
+								</ToggleGroupItem>
+								<ToggleGroupItem value="user" aria-label="Your messages" title="Your messages">
+									<UserRound /> <span className="hidden sm:inline">You</span>
+								</ToggleGroupItem>
+								<ToggleGroupItem
+									value="assistant"
+									aria-label="Agent messages"
+									title="Agent messages"
 								>
-									<ToggleGroupItem
-										value="all"
-										className="px-2 data-[state=on]:bg-background data-[state=on]:shadow-xs"
-									>
-										<MessageSquare /> All
-									</ToggleGroupItem>
-									<ToggleGroupItem
-										value="user"
-										className="px-2 data-[state=on]:bg-background data-[state=on]:shadow-xs"
-									>
-										<UserRound /> You
-									</ToggleGroupItem>
-									<ToggleGroupItem
-										value="assistant"
-										className="px-2 data-[state=on]:bg-background data-[state=on]:shadow-xs"
-									>
-										<Bot /> Agent
-									</ToggleGroupItem>
-									<ToggleGroupItem
-										value="tools"
-										className="px-2 data-[state=on]:bg-background data-[state=on]:shadow-xs"
-									>
-										<Wrench /> Tools
-									</ToggleGroupItem>
-								</ToggleGroup>
-								<div className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
-									{loadedCount > 0 ? (
-										<span className="hidden tabular-nums sm:inline">
-											{loadedCount} of {totalItems}
-										</span>
-									) : null}
-									<Button
-										variant="ghost"
-										size="icon-sm"
-										onClick={() => persistDirection(direction === "desc" ? "asc" : "desc")}
-										aria-label={
-											direction === "desc"
-												? "Show oldest activity first"
-												: "Show newest activity first"
-										}
-										title={direction === "desc" ? "Newest first" : "Oldest first"}
-									>
-										{direction === "desc" ? <ArrowDownNarrowWide /> : <ArrowUpNarrowWide />}
-									</Button>
-								</div>
+									<Bot /> <span className="hidden sm:inline">Agent</span>
+								</ToggleGroupItem>
+								<ToggleGroupItem value="tools" aria-label="Tool activity" title="Tool activity">
+									<Wrench /> <span className="hidden sm:inline">Tools</span>
+								</ToggleGroupItem>
+							</ToggleGroup>
+							<div className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
+								{!searchActive && loadedCount > 0 && loadedCount < totalItems ? (
+									<span className="tabular-nums">
+										{loadedCount} of {totalItems}
+									</span>
+								) : null}
+								<Button
+									variant="ghost"
+									size="icon-sm"
+									onClick={() => persistDirection(direction === "desc" ? "asc" : "desc")}
+									aria-label={
+										direction === "desc"
+											? "Show oldest activity first"
+											: "Show newest activity first"
+									}
+									title={direction === "desc" ? "Newest first" : "Oldest first"}
+								>
+									{direction === "desc" ? <ArrowDownNarrowWide /> : <ArrowUpNarrowWide />}
+								</Button>
 							</div>
-						)}
+						</div>
 					</div>
 				</div>
 			) : null}

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -32,11 +32,11 @@ import { ModelBadge } from "@/components/meta/model-badge";
 import { Stat } from "@/components/meta/stat";
 import { PageHeader, PageHeaderSkeleton } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
-import { SessionTimelineList } from "@/components/sessions/message-list";
 import { sessionAgentIdentityInput } from "@/components/sessions/session-agent-label";
 import { SessionSearchNavigation } from "@/components/sessions/session-search-navigation";
 import { SessionSidebar } from "@/components/sessions/session-sidebar";
 import { SessionShareControls } from "@/components/sessions/share-controls";
+import { VirtualizedSessionTimelineList } from "@/components/sessions/virtualized-message-list";
 import { TimeTooltip } from "@/components/time-tooltip";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
@@ -55,6 +55,7 @@ import type {
 import { useCurrentUser } from "@/lib/auth-client";
 import { formatDuration } from "@/lib/format";
 import { shouldBlockQueryError } from "@/lib/query-state";
+import { findScrollableContainer } from "@/lib/scroll-container";
 import {
 	SESSION_DETAIL_GC_MS,
 	SESSION_DETAIL_STALE_MS,
@@ -340,7 +341,7 @@ export function SessionDetailContent({
 
 	useEffect(() => {
 		if (!anchorIdentity || !pagesData) return;
-		if (highlightedMessageKey && highlightedMessageRef.current) {
+		if (highlightedMessageKey) {
 			const handled = `resolved:${highlightedMessageKey}:${anchorIdentity}`;
 			if (handledAnchorRef.current === handled) return;
 			handledAnchorRef.current = handled;
@@ -644,7 +645,7 @@ export function SessionDetailContent({
 					// group-start rows; continuation rows render flush
 					// so a thread looks tight, not gapped.
 					<div>
-						<SessionTimelineList
+						<VirtualizedSessionTimelineList
 							items={timelineItems}
 							itemKeys={timelineKeys}
 							agentType={session.agent_type}
@@ -712,20 +713,7 @@ function JumpToBottomButton() {
 	const anchorRef = useRef<HTMLDivElement | null>(null);
 
 	useEffect(() => {
-		// Find nearest scrollable ancestor. `overflow-y: auto` on
-		// SidebarInset means it's the canonical scroller; falling
-		// back to `window` if nothing matches keeps single-page
-		// layouts (no sidebar) working.
-		const findScrollableAncestor = (node: Element | null): HTMLElement | Window => {
-			let cur = node?.parentElement ?? null;
-			while (cur) {
-				const overflow = getComputedStyle(cur).overflowY;
-				if (overflow === "auto" || overflow === "scroll") return cur;
-				cur = cur.parentElement;
-			}
-			return window;
-		};
-		const scroller = findScrollableAncestor(anchorRef.current);
+		const scroller = findScrollableContainer(anchorRef.current?.parentElement ?? null);
 		scrollerRef.current = scroller;
 
 		const onScroll = () => {

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -212,6 +212,7 @@ export function SessionDetailContent({
 	// "asc" swaps the query key without a wasted "desc" fetch.
 	const [direction, setDirection] = useState<Direction>("desc");
 	const normalizedSearchQuery = searchQuery?.trim() ?? "";
+	const rememberedSearchQueryRef = useRef(normalizedSearchQuery);
 	const debouncedSearchQuery = useDebouncedValue(normalizedSearchQuery, 250) || undefined;
 	useIsomorphicLayoutEffect(() => {
 		const stored = localStorage.getItem("clawdi.session.message-direction");
@@ -409,9 +410,17 @@ export function SessionDetailContent({
 	const searchActive = Boolean(normalizedSearchQuery);
 	const isSearchUpdating =
 		searchActive &&
-		(normalizedSearchQuery !== debouncedSearchQuery || isContentFetching || isContentLoading);
+		(normalizedSearchQuery !== debouncedSearchQuery ||
+			(isContentFetching && !isFetchingNextPage) ||
+			isContentLoading);
 	const updateTimelineView = (selected: SessionTimelineView) => {
-		const retainedSearchQuery = selected === "tools" ? undefined : normalizedSearchQuery;
+		if (timelineView !== "tools") {
+			rememberedSearchQueryRef.current = normalizedSearchQuery;
+		}
+		const retainedSearchQuery =
+			selected === "tools"
+				? undefined
+				: normalizedSearchQuery || rememberedSearchQueryRef.current || undefined;
 		if (agentId) {
 			const search = {
 				...(retainedSearchQuery ? { matchQuery: retainedSearchQuery } : {}),
@@ -553,7 +562,7 @@ export function SessionDetailContent({
 						)}
 						<div
 							className={cn(
-								"flex min-w-0 items-center justify-between gap-2 md:justify-end",
+								"flex min-h-9 min-w-0 items-center justify-between gap-2 md:justify-end",
 								timelineView === "tools" && "md:justify-self-end",
 							)}
 						>
@@ -589,7 +598,7 @@ export function SessionDetailContent({
 								>
 									<Bot /> <span className="hidden sm:inline">Agent</span>
 								</ToggleGroupItem>
-								<ToggleGroupItem value="tools" aria-label="Tool activity" title="Tool activity">
+								<ToggleGroupItem value="tools" aria-label="Tools activity" title="Tool activity">
 									<Wrench /> <span className="hidden sm:inline">Tools</span>
 								</ToggleGroupItem>
 							</ToggleGroup>

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -411,9 +411,10 @@ export function SessionDetailContent({
 		searchActive &&
 		(normalizedSearchQuery !== debouncedSearchQuery || isContentFetching || isContentLoading);
 	const updateTimelineView = (selected: SessionTimelineView) => {
+		const retainedSearchQuery = selected === "tools" ? undefined : normalizedSearchQuery;
 		if (agentId) {
 			const search = {
-				...(normalizedSearchQuery ? { matchQuery: normalizedSearchQuery } : {}),
+				...(retainedSearchQuery ? { matchQuery: retainedSearchQuery } : {}),
 				...(selected === "all" ? {} : { timelineView: selected }),
 			};
 			void router.navigate({
@@ -426,7 +427,7 @@ export function SessionDetailContent({
 		void router.navigate({
 			...sessionTimelineViewLink(sessionId, selected, {
 				returnTo,
-				searchQuery: normalizedSearchQuery,
+				searchQuery: retainedSearchQuery,
 			}),
 			replace: true,
 			resetScroll: false,
@@ -531,19 +532,31 @@ export function SessionDetailContent({
 
 			{session.has_content ? (
 				<div className="sticky top-(--header-height) z-10 -mx-4 border-y bg-background/95 px-4 py-2 backdrop-blur supports-[backdrop-filter]:bg-background/80 lg:-mx-6 lg:px-6">
-					<div className="grid min-w-0 gap-2 md:grid-cols-[minmax(16rem,1fr)_auto] md:items-center">
-						<SessionSearchNavigation
-							sessionId={sessionId}
-							agentId={agentId}
-							query={normalizedSearchQuery}
-							timelineView={timelineView}
-							navigation={searchNavigation}
-							returnTo={returnTo}
-							isSearching={isSearchUpdating}
-							hasSearchError={searchActive && isContentError}
-							className="md:max-w-xl"
-						/>
-						<div className="flex min-w-0 items-center justify-between gap-2 md:justify-end">
+					<div
+						className={cn(
+							"grid min-w-0 gap-2 md:items-center",
+							timelineView === "tools" ? "md:grid-cols-1" : "md:grid-cols-[minmax(16rem,1fr)_auto]",
+						)}
+					>
+						{timelineView === "tools" ? null : (
+							<SessionSearchNavigation
+								sessionId={sessionId}
+								agentId={agentId}
+								query={normalizedSearchQuery}
+								timelineView={timelineView}
+								navigation={searchNavigation}
+								returnTo={returnTo}
+								isSearching={isSearchUpdating}
+								hasSearchError={searchActive && isContentError}
+								className="md:max-w-xl"
+							/>
+						)}
+						<div
+							className={cn(
+								"flex min-w-0 items-center justify-between gap-2 md:justify-end",
+								timelineView === "tools" && "md:justify-self-end",
+							)}
+						>
 							<ToggleGroup
 								value={[timelineView]}
 								onValueChange={(values) => {

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -241,7 +241,7 @@ function SessionsListInner() {
 										: params.sort,
 						});
 					}}
-					placeholder="Search summaries, messages, folders, or IDs…"
+					placeholder="Search sessions…"
 				/>
 			}
 			filters={

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -241,7 +241,7 @@ function SessionsListInner() {
 										: params.sort,
 						});
 					}}
-					placeholder="Search sessions…"
+					placeholder="Search sessions and messages…"
 				/>
 			}
 			filters={

--- a/apps/web/src/routes/_protected/_dashboard/agents/$id/sessions/$sessionId.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/agents/$id/sessions/$sessionId.tsx
@@ -2,10 +2,14 @@ import { createFileRoute } from "@tanstack/react-router";
 import { AgentResourceRouteGate } from "@/components/dashboard/agent-resource-route-gate";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { routeHeadTitle } from "@/lib/document-title";
-import { parseSessionTimelineView } from "@/lib/session-search-anchor";
+import {
+	sessionSearchAnchorFromSearch,
+	validateSessionDetailSearch,
+} from "@/lib/session-search-anchor";
 import AgentSessionDetailPage from "@/pages/dashboard/agents/agent-session-detail-page";
 
 export const Route = createFileRoute("/_protected/_dashboard/agents/$id/sessions/$sessionId")({
+	validateSearch: validateSessionDetailSearch,
 	head: () => routeHeadTitle("Session"),
 	component: AgentSessionDetailRoute,
 });
@@ -13,6 +17,7 @@ export const Route = createFileRoute("/_protected/_dashboard/agents/$id/sessions
 function AgentSessionDetailRoute() {
 	const { id, sessionId } = Route.useParams();
 	const search = Route.useSearch();
+	const searchAnchor = sessionSearchAnchorFromSearch(search);
 	return (
 		<AgentResourceRouteGate
 			agentId={id}
@@ -23,7 +28,9 @@ function AgentSessionDetailRoute() {
 			<AgentSessionDetailPage
 				agentId={id}
 				sessionId={sessionId}
-				timelineView={parseSessionTimelineView(search.timelineView) ?? "all"}
+				searchAnchor={searchAnchor}
+				searchQuery={search.matchQuery}
+				timelineView={search.timelineView ?? "all"}
 			/>
 		</AgentResourceRouteGate>
 	);

--- a/backend/app/routes/mcp_bridge.py
+++ b/backend/app/routes/mcp_bridge.py
@@ -22,9 +22,8 @@ from pydantic import (
     ValidationError,
     field_validator,
 )
-from sqlalchemy import cast, func, or_, select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.types import String
 
 from app.core.auth import (
     AuthContext,
@@ -36,7 +35,6 @@ from app.core.auth import (
 )
 from app.core.database import get_session
 from app.core.project import project_ids_visible_to, resolve_default_write_project
-from app.core.query_utils import like_needle
 from app.models.project import Project
 from app.models.session import AgentEnvironment, Session
 from app.models.vault import Vault, VaultItem, VaultProjectAttachment
@@ -61,6 +59,7 @@ from app.services.session_content import (
     session_has_uploaded_content,
 )
 from app.services.session_export import session_to_markdown
+from app.services.session_search import session_search_excerpt, session_search_matches
 from app.services.vault_crypto import decrypt
 
 logger = logging.getLogger(__name__)
@@ -362,7 +361,10 @@ _NATIVE_TOOL_REGISTRY: dict[str, _NativeToolSpec] = {
             "properties": {
                 "query": {
                     "type": "string",
-                    "description": "Keyword query — matches session summary and metadata.",
+                    "description": (
+                        "Case-insensitive phrase query matching session metadata "
+                        "and visible messages."
+                    ),
                 },
                 "limit": {
                     "type": "integer",
@@ -769,33 +771,31 @@ async def _tool_session_search(
     arguments: JsonObject, *, auth: AuthContext, db: AsyncSession
 ) -> JsonObject:
     parsed = _validate_arguments(_SessionSearchArguments, arguments)
+    matches = session_search_matches(auth.user_id, parsed.query)
     stmt = (
         _user_sessions_stmt(auth)
-        .order_by(Session.last_activity_at.desc(), Session.id.asc())
+        .join(matches, matches.c.session_id == Session.id)
+        .add_columns(matches.c.content, matches.c.role)
+        .order_by(matches.c.score.desc(), Session.last_activity_at.desc(), Session.id.asc())
         .limit(parsed.limit)
-    )
-    pattern = like_needle(parsed.query)
-    stmt = stmt.where(
-        or_(
-            Session.summary.ilike(pattern, escape="\\"),
-            Session.project_path.ilike(pattern, escape="\\"),
-            Session.local_session_id.ilike(pattern, escape="\\"),
-            cast(Session.id, String).ilike(pattern, escape="\\"),
-        )
     )
     rows = (await db.execute(stmt)).all()
     if not rows:
         return _tool_text(f'No sessions matched "{parsed.query}".')
     lines: list[str] = []
-    for session, agent_type in rows:
+    for session, agent_type, message_content, message_role in rows:
         date = session.last_activity_at.date().isoformat() if session.last_activity_at else "-"
         summary = session.summary or session.local_session_id or "(untitled)"
         project = f" · {session.project_path}" if session.project_path else ""
         model = f" · {session.model}" if session.model else ""
+        message_match = ""
+        if isinstance(message_content, str) and message_role in ("user", "assistant"):
+            excerpt = session_search_excerpt(message_content, parsed.query)
+            message_match = f"\n  - matched {message_role}: {excerpt}"
         lines.append(
             f"- **{summary}**{project}{model}\n"
             f"  - id: `{session.id}` · {agent_type or 'unknown'} · {date} · "
-            f"{session.message_count or 0} msgs"
+            f"{session.message_count or 0} msgs{message_match}"
         )
     return _tool_text(
         f'Found {len(rows)} session(s) matching "{parsed.query}":\n\n' + "\n".join(lines)

--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -25,8 +25,13 @@ from app.models.project import Project
 from app.models.session import AgentEnvironment, Session
 from app.models.skill import Skill
 from app.models.vault import Vault, VaultProjectAttachment
+from app.schemas.session import SessionSearchMatchResponse
 from app.services.memory_provider import get_memory_provider
 from app.services.memory_types import MemoryItem
+from app.services.session_search import (
+    session_search_match_response,
+    session_search_matches,
+)
 
 
 def _has_scope(auth: AuthContext, scope: str) -> bool:
@@ -54,6 +59,7 @@ class SearchHit(BaseModel):
     title: str
     subtitle: str | None = None
     href: str
+    search_match: SessionSearchMatchResponse | None = None
 
 
 class SearchResponse(BaseModel):
@@ -69,21 +75,22 @@ type Searcher = Callable[
 
 
 async def _search_sessions(db: AsyncSession, auth: AuthContext, query: str) -> list[SearchHit]:
-    needle = like_needle(query)
+    matches = session_search_matches(auth.user_id, query)
     # Historical search retains archived Agent labels; this join grants no
     # operational Agent authority.
     stmt = (
-        select(Session, AgentEnvironment.agent_type)
-        .outerjoin(AgentEnvironment, Session.environment_id == AgentEnvironment.id)
-        .where(Session.user_id == auth.user_id)
-        .where(
-            or_(
-                Session.summary.ilike(needle, escape="\\"),
-                Session.project_path.ilike(needle, escape="\\"),
-                Session.local_session_id.ilike(needle, escape="\\"),
-            )
+        select(
+            Session,
+            AgentEnvironment.agent_type,
+            matches.c.content,
+            matches.c.role,
+            matches.c.position,
+            matches.c.content_revision,
         )
-        .order_by(Session.started_at.desc())
+        .outerjoin(AgentEnvironment, Session.environment_id == AgentEnvironment.id)
+        .join(matches, matches.c.session_id == Session.id)
+        .where(Session.user_id == auth.user_id)
+        .order_by(matches.c.score.desc(), Session.last_activity_at.desc(), Session.id.asc())
         .limit(TYPE_LIMIT)
     )
     # Bound api_keys can only see sessions in their own env — same
@@ -92,9 +99,17 @@ async def _search_sessions(db: AsyncSession, auth: AuthContext, query: str) -> l
         stmt = stmt.where(Session.environment_id == auth.api_key.environment_id)
     rows = (await db.execute(stmt)).all()
     hits: list[SearchHit] = []
-    for s, agent_type in rows:
+    for s, agent_type, content, role, position, revision in rows:
         title = (s.summary or "").strip() or s.local_session_id[:16]
         subtitle_parts = [p for p in (agent_type, s.project_path) if p]
+        search_match = session_search_match_response(
+            s,
+            query,
+            content=content,
+            role=role,
+            position=position,
+            revision=revision,
+        )
         hits.append(
             SearchHit(
                 type="session",
@@ -102,6 +117,7 @@ async def _search_sessions(db: AsyncSession, auth: AuthContext, query: str) -> l
                 title=title,
                 subtitle=" · ".join(subtitle_parts) or None,
                 href=f"/sessions/{s.id}",
+                search_match=search_match,
             )
         )
     return hits

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -136,12 +136,13 @@ from app.services.session_export import session_to_markdown
 from app.services.session_refs import extract_related_refs
 from app.services.session_search import (
     SearchableSessionMessage,
-    best_session_message_matches,
+    SearchRole,
     current_search_revision,
-    escaped_contains_pattern,
     replace_snapshot_search_index,
     searchable_snapshot_messages,
     session_message_search_navigation,
+    session_search_excerpt,
+    session_search_matches,
 )
 from app.services.sync_events import queue_environment_runtime_manifest_changed
 
@@ -2508,19 +2509,6 @@ _SESSION_SORT_COLUMNS = {
 }
 
 
-def _message_search_excerpt(content: str, query: str, *, limit: int = 240) -> str:
-    compact = " ".join(content.split())
-    if len(compact) <= limit:
-        return compact
-    match_at = compact.casefold().find(query.casefold())
-    if match_at < 0:
-        return f"{compact[: limit - 3]}..."
-    start = max(0, match_at - limit // 3)
-    end = min(len(compact), start + limit)
-    start = max(0, end - limit)
-    return f"{'...' if start else ''}{compact[start:end]}{'...' if end < len(compact) else ''}"
-
-
 @router.get("/sessions")
 async def list_sessions(
     # Deploy keys carry `sessions:write` (they upload sessions from
@@ -2604,32 +2592,7 @@ async def list_sessions(
     # IS NULL` makes this lookup index-only.
     is_shared_subq = _link_is_shared_subq()
 
-    # Search selection is deterministic phrase containment across metadata and
-    # visible messages. `similarity()` only ranks rows already known to contain
-    # the query; it never introduces typo-tolerant or unexplained candidates.
-    relevance_expr: Any | None
-    metadata_relevance_expr: Any | None = None
-    metadata_match_expr: Any | None = None
-    message_match: Any | None = None
-    message_relevance_expr: Any | None = None
-    if q:
-        contains_pattern = escaped_contains_pattern(q)
-        summary_match = func.coalesce(Session.summary, "").ilike(contains_pattern, escape="\\")
-        project_match = func.coalesce(Session.project_path, "").ilike(
-            contains_pattern,
-            escape="\\",
-        )
-        local_match = Session.local_session_id.ilike(contains_pattern, escape="\\")
-        metadata_match_expr = or_(summary_match, project_match, local_match)
-        sim_summary = func.similarity(func.coalesce(Session.summary, ""), q)
-        sim_project = func.similarity(func.coalesce(Session.project_path, ""), q)
-        sim_local = func.similarity(Session.local_session_id, q)
-        metadata_relevance_expr = func.greatest(sim_summary, sim_project, sim_local)
-        message_match = best_session_message_matches(auth.user_id, q)
-        message_relevance_expr = func.coalesce(message_match.c.score, 0.0)
-        relevance_expr = func.greatest(metadata_relevance_expr, message_relevance_expr)
-    else:
-        relevance_expr = None
+    search_matches = session_search_matches(auth.user_id, q) if q else None
 
     base = select(
         Session,
@@ -2639,16 +2602,13 @@ async def list_sessions(
         AgentEnvironment.machine_name,
         is_shared_subq,
     ).outerjoin(AgentEnvironment, Session.environment_id == AgentEnvironment.id)
-    if q:
-        assert message_match is not None
-        assert message_relevance_expr is not None
-        base = base.outerjoin(message_match, message_match.c.session_id == Session.id)
+    if search_matches is not None:
+        base = base.join(search_matches, search_matches.c.session_id == Session.id)
         base = base.add_columns(
-            message_relevance_expr,
-            message_match.c.content,
-            message_match.c.role,
-            message_match.c.position,
-            message_match.c.content_revision,
+            search_matches.c.content,
+            search_matches.c.role,
+            search_matches.c.position,
+            search_matches.c.content_revision,
         )
     session_filters: list[Any] = [Session.user_id == auth.user_id]
     agent_filter = AgentEnvironment.agent_type == agent if agent else None
@@ -2709,18 +2669,6 @@ async def list_sessions(
         else:
             session_filters.append(_MANUAL_SESSION_SUMMARY_FILTER)
 
-    if q:
-        assert relevance_expr is not None
-        assert metadata_relevance_expr is not None
-        assert metadata_match_expr is not None
-        assert message_match is not None
-        session_filters.append(
-            or_(
-                metadata_match_expr,
-                message_match.c.session_id.is_not(None),
-            )
-        )
-
     base = base.where(*session_filters)
     if agent_filter is not None:
         base = base.where(agent_filter)
@@ -2730,8 +2678,8 @@ async def list_sessions(
     # COUNT(*). For 50k+ session users this saves a measurable
     # fraction of list-page latency.
     count_base = select(Session.id).where(*session_filters)
-    if message_match is not None:
-        count_base = count_base.outerjoin(message_match, message_match.c.session_id == Session.id)
+    if search_matches is not None:
+        count_base = count_base.join(search_matches, search_matches.c.session_id == Session.id)
     if agent_filter is not None:
         count_base = count_base.outerjoin(
             AgentEnvironment,
@@ -2742,13 +2690,13 @@ async def list_sessions(
     # Resolve sort column. `relevance` is special — only valid when
     # `q` is present (else fall back to the date default so the empty-
     # search experience doesn't break). The relevance expression
-    # was built up above; reuse it here so the sort matches the
-    # similarity used for filtering.
+    # comes from the shared search subquery, keeping Web, CLI, and MCP
+    # ordering on the same contract.
     if sort == "relevance":
-        if relevance_expr is None:
+        if search_matches is None:
             sort_col = _SESSION_SORT_COLUMNS["last_activity_at"]
         else:
-            sort_col = relevance_expr
+            sort_col = search_matches.c.score
     else:
         sort_col = _SESSION_SORT_COLUMNS[sort]
     # Tiebreaker on `id` for deterministic offset-pagination order.
@@ -2774,15 +2722,13 @@ async def list_sessions(
                 default_name,
                 machine_name,
                 shared,
-                message_score,
                 message_content,
                 message_role,
                 message_position,
                 message_revision,
             ) = row
             if (
-                message_score is not None
-                and isinstance(message_content, str)
+                isinstance(message_content, str)
                 and message_role in ("user", "assistant")
                 and isinstance(message_position, int)
                 and isinstance(message_revision, str)
@@ -2792,7 +2738,7 @@ async def list_sessions(
                 )
                 search_match = SessionSearchMatchResponse(
                     role=message_role,
-                    excerpt=_message_search_excerpt(message_content, q),
+                    excerpt=session_search_excerpt(message_content, q),
                     anchor=SessionSearchAnchorResponse(
                         kind=anchor_kind,
                         position=message_position,
@@ -3190,11 +3136,21 @@ async def get_session_messages(
     resolved_anchor_position = anchor_position
     resolved_anchor_revision = anchor_revision
     navigation = None
+    search_roles: tuple[SearchRole, ...] | None
+    if view == "user":
+        search_roles = ("user",)
+    elif view == "assistant":
+        search_roles = ("assistant",)
+    elif view == "tools":
+        search_roles = ()
+    else:
+        search_roles = None
     if anchor_kind is None and search_query:
         navigation = await session_message_search_navigation(
             db,
             session,
             query=search_query,
+            roles=search_roles,
         )
         if navigation is not None:
             resolved_anchor_kind = expected_anchor_kind
@@ -3211,6 +3167,7 @@ async def get_session_messages(
             session,
             query=search_query,
             position=anchor_position,
+            roles=search_roles,
         )
     if (
         resolved_anchor_kind == expected_anchor_kind

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -141,7 +141,7 @@ from app.services.session_search import (
     replace_snapshot_search_index,
     searchable_snapshot_messages,
     session_message_search_navigation,
-    session_search_excerpt,
+    session_search_match_response,
     session_search_matches,
 )
 from app.services.sync_events import queue_environment_runtime_manifest_changed
@@ -2734,24 +2734,14 @@ async def list_sessions(
                 message_position,
                 message_revision,
             ) = row
-            if (
-                isinstance(message_content, str)
-                and message_role in ("user", "assistant")
-                and isinstance(message_position, int)
-                and isinstance(message_revision, str)
-            ):
-                anchor_kind: Literal["snapshot_offset", "event_seq"] = (
-                    "event_seq" if s.content_protocol == "events-v1" else "snapshot_offset"
-                )
-                search_match = SessionSearchMatchResponse(
-                    role=message_role,
-                    excerpt=session_search_excerpt(message_content, q),
-                    anchor=SessionSearchAnchorResponse(
-                        kind=anchor_kind,
-                        position=message_position,
-                        revision=message_revision,
-                    ),
-                )
+            search_match = session_search_match_response(
+                s,
+                q,
+                content=message_content,
+                role=message_role,
+                position=message_position,
+                revision=message_revision,
+            )
         else:
             s, agent_type, display_name, default_name, machine_name, shared = row
         items.append(

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -2521,7 +2521,10 @@ async def list_sessions(
     q: str | None = Query(
         default=None,
         max_length=500,
-        description="Case-insensitive phrase search on summary/project/id and visible message text",
+        description=(
+            "Case-insensitive phrase search on summary/project/local ID and visible message text; "
+            "cloud session IDs match by UUID prefix"
+        ),
     ),
     agent: str | None = Query(default=None, description="Filter by agent_type"),
     environment_id: UUID | None = Query(default=None, description="Filter by agent environment"),
@@ -2699,15 +2702,19 @@ async def list_sessions(
             sort_col = search_matches.c.score
     else:
         sort_col = _SESSION_SORT_COLUMNS[sort]
+    # Relevance ties are common because visible-message matches receive a
+    # constant score. Prefer recent Sessions before the stable UUID tiebreaker,
+    # matching the MCP search contract.
+    order_columns = [sort_col.asc() if order == "asc" else sort_col.desc()]
+    if sort == "relevance" and search_matches is not None:
+        order_columns.append(Session.last_activity_at.desc())
     # Tiebreaker on `id` for deterministic offset-pagination order.
     # Without this, two rows with identical `last_activity_at`
     # values (same `func.greatest()` clamp output, same
     # `func.now()` from a backfill) can swap positions across
     # page boundaries — UUIDs are unique so this tiebreaker is total.
-    ordered = base.order_by(
-        sort_col.asc() if order == "asc" else sort_col.desc(),
-        Session.id.asc(),
-    )
+    order_columns.append(Session.id.asc())
+    ordered = base.order_by(*order_columns)
 
     rows = (await db.execute(ordered.limit(page_size).offset((page - 1) * page_size))).all()
 

--- a/backend/app/services/session_search.py
+++ b/backend/app/services/session_search.py
@@ -12,6 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.selectable import Subquery
 
 from app.models.session import Session, SessionEventChunk, SessionMessageSearch
+from app.schemas.session import (
+    SessionSearchAnchorResponse,
+    SessionSearchMatchResponse,
+)
 from app.schemas.session_events import SessionEvent
 from app.services.session_content import load_session_events, load_session_messages
 from app.services.session_events import project_visible_messages
@@ -109,6 +113,34 @@ def session_search_excerpt(content: str, query: str, *, limit: int = 240) -> str
     end = min(len(compact), start + limit)
     start = max(0, end - limit)
     return f"{'...' if start else ''}{compact[start:end]}{'...' if end < len(compact) else ''}"
+
+
+def session_search_match_response(
+    session: Session,
+    query: str,
+    *,
+    content: object,
+    role: object,
+    position: object,
+    revision: object,
+) -> SessionSearchMatchResponse | None:
+    """Build the shared API match contract from a ranked search row."""
+    if (
+        not isinstance(content, str)
+        or role not in ("user", "assistant")
+        or not isinstance(position, int)
+        or not isinstance(revision, str)
+    ):
+        return None
+    return SessionSearchMatchResponse(
+        role=role,
+        excerpt=session_search_excerpt(content, query),
+        anchor=SessionSearchAnchorResponse(
+            kind="event_seq" if session.content_protocol == "events-v1" else "snapshot_offset",
+            position=position,
+            revision=revision,
+        ),
+    )
 
 
 def _searchable_text(content: str) -> str:

--- a/backend/app/services/session_search.py
+++ b/backend/app/services/session_search.py
@@ -6,7 +6,7 @@ from typing import Literal, Protocol
 from uuid import UUID
 
 from pydantic import JsonValue
-from sqlalchemy import case, delete, func, literal, select, update
+from sqlalchemy import String, case, cast, delete, func, literal, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.selectable import Subquery
 
@@ -88,6 +88,19 @@ def escaped_contains_pattern(value: str) -> str:
     return f"%{escaped}%"
 
 
+def session_search_excerpt(content: str, query: str, *, limit: int = 240) -> str:
+    compact = " ".join(content.split())
+    if len(compact) <= limit:
+        return compact
+    match_at = compact.casefold().find(query.casefold())
+    if match_at < 0:
+        return f"{compact[: limit - 3]}..."
+    start = max(0, match_at - limit // 3)
+    end = min(len(compact), start + limit)
+    start = max(0, end - limit)
+    return f"{'...' if start else ''}{compact[start:end]}{'...' if end < len(compact) else ''}"
+
+
 def _searchable_text(content: str) -> str:
     return content.replace("\x00", "\ufffd")
 
@@ -159,14 +172,52 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
     )
 
 
+def session_search_matches(user_id: UUID, query: str) -> Subquery:
+    """Return every exact phrase match with one ranked body hit per Session."""
+    pattern = escaped_contains_pattern(query)
+    message_match = best_session_message_matches(user_id, query)
+    metadata_match = or_(
+        func.coalesce(Session.summary, "").ilike(pattern, escape="\\"),
+        func.coalesce(Session.project_path, "").ilike(pattern, escape="\\"),
+        Session.local_session_id.ilike(pattern, escape="\\"),
+        cast(Session.id, String).ilike(pattern, escape="\\"),
+    )
+    metadata_score = func.greatest(
+        func.similarity(func.coalesce(Session.summary, ""), query),
+        func.similarity(func.coalesce(Session.project_path, ""), query),
+        func.similarity(Session.local_session_id, query),
+        func.similarity(cast(Session.id, String), query),
+    )
+    message_score = func.coalesce(message_match.c.score, 0.0)
+    return (
+        select(
+            Session.id.label("session_id"),
+            func.greatest(metadata_score, message_score).label("score"),
+            message_match.c.content,
+            message_match.c.role,
+            message_match.c.position,
+            message_match.c.content_revision,
+        )
+        .outerjoin(message_match, message_match.c.session_id == Session.id)
+        .where(
+            Session.user_id == user_id,
+            or_(metadata_match, message_match.c.session_id.is_not(None)),
+        )
+        .subquery("session_search_matches")
+    )
+
+
 async def session_message_search_navigation(
     db: AsyncSession,
     session: Session,
     *,
     query: str,
     position: int | None = None,
+    roles: Sequence[SearchRole] | None = None,
 ) -> SessionSearchNavigation | None:
     """Resolve one active match and its transcript-order neighbours."""
+    if roles is not None and not roles:
+        return None
     document_revision = current_document_revision(session)
     if document_revision is None or session.search_index_revision != current_search_revision(
         session
@@ -174,26 +225,25 @@ async def session_message_search_navigation(
         return None
 
     message_match = _message_match_expression(query)
-    ordered_matches = (
-        select(
-            SessionMessageSearch.position.label("position"),
-            func.row_number().over(order_by=SessionMessageSearch.position).label("match_index"),
-            func.count().over().label("match_total"),
-            func.lag(SessionMessageSearch.position)
-            .over(order_by=SessionMessageSearch.position)
-            .label("previous_position"),
-            func.lead(SessionMessageSearch.position)
-            .over(order_by=SessionMessageSearch.position)
-            .label("next_position"),
-        )
-        .where(
-            SessionMessageSearch.user_id == session.user_id,
-            SessionMessageSearch.session_id == session.id,
-            SessionMessageSearch.content_revision == document_revision,
-            message_match,
-        )
-        .subquery("ordered_session_message_matches")
+    ordered_matches_query = select(
+        SessionMessageSearch.position.label("position"),
+        func.row_number().over(order_by=SessionMessageSearch.position).label("match_index"),
+        func.count().over().label("match_total"),
+        func.lag(SessionMessageSearch.position)
+        .over(order_by=SessionMessageSearch.position)
+        .label("previous_position"),
+        func.lead(SessionMessageSearch.position)
+        .over(order_by=SessionMessageSearch.position)
+        .label("next_position"),
+    ).where(
+        SessionMessageSearch.user_id == session.user_id,
+        SessionMessageSearch.session_id == session.id,
+        SessionMessageSearch.content_revision == document_revision,
+        message_match,
     )
+    if roles is not None:
+        ordered_matches_query = ordered_matches_query.where(SessionMessageSearch.role.in_(roles))
+    ordered_matches = ordered_matches_query.subquery("ordered_session_message_matches")
     navigation_query = select(
         ordered_matches.c.position,
         ordered_matches.c.match_index,

--- a/backend/app/services/session_search.py
+++ b/backend/app/services/session_search.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal, Protocol
@@ -16,6 +17,8 @@ from app.services.session_content import load_session_events, load_session_messa
 from app.services.session_events import project_visible_messages
 
 type SearchRole = Literal["user", "assistant"]
+
+_UUID_PREFIX_RE = re.compile(r"^[0-9a-f]{8,32}$", re.IGNORECASE)
 
 
 class SessionSearchFileStore(Protocol):
@@ -86,6 +89,13 @@ async def event_search_projection_complete(
 def escaped_contains_pattern(value: str) -> str:
     escaped = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
     return f"%{escaped}%"
+
+
+def _uuid_prefix_pattern(value: str) -> str | None:
+    compact = value.strip().replace("-", "")
+    if not _UUID_PREFIX_RE.fullmatch(compact):
+        return None
+    return f"{compact}%"
 
 
 def session_search_excerpt(content: str, query: str, *, limit: int = 240) -> str:
@@ -176,18 +186,23 @@ def session_search_matches(user_id: UUID, query: str) -> Subquery:
     """Return every exact phrase match with one ranked body hit per Session."""
     pattern = escaped_contains_pattern(query)
     message_match = best_session_message_matches(user_id, query)
-    metadata_match = or_(
+    metadata_matches = [
         func.coalesce(Session.summary, "").ilike(pattern, escape="\\"),
         func.coalesce(Session.project_path, "").ilike(pattern, escape="\\"),
         Session.local_session_id.ilike(pattern, escape="\\"),
-        cast(Session.id, String).ilike(pattern, escape="\\"),
-    )
-    metadata_score = func.greatest(
+    ]
+    metadata_scores = [
         func.similarity(func.coalesce(Session.summary, ""), query),
         func.similarity(func.coalesce(Session.project_path, ""), query),
         func.similarity(Session.local_session_id, query),
-        func.similarity(cast(Session.id, String), query),
-    )
+    ]
+    uuid_prefix = _uuid_prefix_pattern(query)
+    if uuid_prefix is not None:
+        compact_session_id = func.replace(cast(Session.id, String), "-", "")
+        metadata_matches.append(compact_session_id.ilike(uuid_prefix))
+        metadata_scores.append(func.similarity(compact_session_id, uuid_prefix[:-1]))
+    metadata_match = or_(*metadata_matches)
+    metadata_score = func.greatest(*metadata_scores)
     message_score = func.coalesce(message_match.c.score, 0.0)
     return (
         select(

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -91,7 +91,7 @@ async def _push_session(
 @pytest.mark.asyncio
 async def test_metadata_search_requires_the_query_phrase(client: httpx.AsyncClient):
     env_id = await _register_env(client)
-    await _push_session(
+    session_id = await _push_session(
         client, env_id, local_session_id="auth-1", summary="user authentication migration"
     )
     await _push_session(client, env_id, local_session_id="dns-1", summary="DNS cache poisoning")
@@ -105,6 +105,10 @@ async def test_metadata_search_requires_the_query_phrase(client: httpx.AsyncClie
     typo = await client.get("/v1/sessions", params={"q": "athentication"})
     assert typo.status_code == 200
     assert typo.json()["items"] == []
+
+    by_id = await client.get("/v1/sessions", params={"q": session_id.upper()})
+    assert by_id.status_code == 200
+    assert [item["id"] for item in by_id.json()["items"]] == [session_id]
 
 
 @pytest.mark.asyncio
@@ -264,6 +268,30 @@ async def test_snapshot_message_search_navigates_matches_in_transcript_order(
             "revision": first_anchor["revision"],
         },
     }
+
+    assistant_only = await client.get(
+        f"/v1/sessions/{session_id}/messages",
+        params={"search_query": "needle", "view": "assistant"},
+    )
+    assert assistant_only.status_code == 200, assistant_only.text
+    assert assistant_only.json()["search_navigation"] == {
+        "index": 1,
+        "total": 1,
+        "current": {
+            "kind": "snapshot_offset",
+            "position": 2,
+            "revision": first_anchor["revision"],
+        },
+        "previous": None,
+        "next": None,
+    }
+
+    tools_only = await client.get(
+        f"/v1/sessions/{session_id}/messages",
+        params={"search_query": "needle", "view": "tools"},
+    )
+    assert tools_only.status_code == 200, tools_only.text
+    assert tools_only.json().get("search_navigation") is None
 
     first = await client.get(
         f"/v1/sessions/{session_id}/messages",

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -207,6 +207,10 @@ async def test_snapshot_message_search_tracks_current_content_and_escapes_wildca
             ),
         },
     }
+    global_search = (await client.get("/v1/search", params={"q": "Original needle"})).json()
+    global_hit = next(hit for hit in global_search["results"] if hit["type"] == "session")
+    assert global_hit["id"] == session_id
+    assert global_hit["search_match"] == matched["items"][0]["search_match"]
     typo = (await client.get("/v1/sessions", params={"q": "Orginal needle"})).json()
     assert typo["items"] == []
     case_insensitive = (await client.get("/v1/sessions", params={"q": "original NEEDLE"})).json()

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import httpx
 import pytest
@@ -53,11 +53,14 @@ async def _push_session(
     tags: list[str] | None = None,
     messages: list[dict] | None = None,
     upload: bool = False,
+    started_at: datetime | None = None,
+    last_activity_at: datetime | None = None,
 ) -> str:
     payload = {
         "environment_id": env_id,
         "local_session_id": local_session_id,
-        "started_at": datetime.now(UTC).isoformat(),
+        "started_at": (started_at or datetime.now(UTC)).isoformat(),
+        "last_activity_at": last_activity_at.isoformat() if last_activity_at else None,
         "message_count": len(messages) if messages else 0,
         "summary": summary,
         "project_path": project_path,
@@ -110,6 +113,13 @@ async def test_metadata_search_requires_the_query_phrase(client: httpx.AsyncClie
     assert by_id.status_code == 200
     assert [item["id"] for item in by_id.json()["items"]] == [session_id]
 
+    compact_id = session_id.replace("-", "")
+    by_prefix = await client.get("/v1/sessions", params={"q": compact_id[:8].upper()})
+    assert [item["id"] for item in by_prefix.json()["items"]] == [session_id]
+
+    short_prefix = await client.get("/v1/sessions", params={"q": compact_id[:7]})
+    assert session_id not in {item["id"] for item in short_prefix.json()["items"]}
+
 
 @pytest.mark.asyncio
 async def test_relevance_sort_only_ranks_phrase_matches(client: httpx.AsyncClient):
@@ -126,6 +136,32 @@ async def test_relevance_sort_only_ranks_phrase_matches(client: httpx.AsyncClien
     # Only the summary containing the complete phrase is eligible.
     assert items[0]["summary"] == "oauth token refresh bug"
     assert all(s["summary"] != "UI polish" for s in items)
+
+
+@pytest.mark.asyncio
+async def test_relevance_ties_prefer_recent_activity(client: httpx.AsyncClient):
+    env_id = await _register_env(client)
+    now = datetime.now(UTC)
+    for local_id, age in (("older-body-match", 2), ("newer-body-match", 1)):
+        activity_at = now - timedelta(hours=age)
+        await _push_session(
+            client,
+            env_id,
+            local_session_id=local_id,
+            messages=[{"role": "user", "content": "same ranked phrase"}],
+            upload=True,
+            started_at=activity_at,
+            last_activity_at=activity_at,
+        )
+
+    response = await client.get(
+        "/v1/sessions",
+        params={"q": "same ranked phrase", "sort": "relevance"},
+    )
+    assert [item["local_session_id"] for item in response.json()["items"]] == [
+        "newer-body-match",
+        "older-body-match",
+    ]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_settings_and_mcp.py
+++ b/backend/tests/test_settings_and_mcp.py
@@ -609,7 +609,7 @@ async def test_clawdi_mcp_memory_search_shares_account_memory_across_agents(
 
 
 @pytest.mark.asyncio
-async def test_clawdi_mcp_session_search_escapes_like_wildcards(
+async def test_clawdi_mcp_session_search_uses_shared_metadata_and_body_matches(
     db_session,
     seed_user,
 ):
@@ -617,6 +617,10 @@ async def test_clawdi_mcp_session_search_escapes_like_wildcards(
     from app.core.database import get_session
     from app.models.api_key import ApiKey
     from app.models.session import Session
+    from app.services.session_search import (
+        SearchableSessionMessage,
+        replace_snapshot_search_index,
+    )
     from tests.conftest import create_env_with_project
 
     env = await create_env_with_project(
@@ -627,25 +631,46 @@ async def test_clawdi_mcp_session_search_escapes_like_wildcards(
         agent_type="openclaw",
     )
     now = datetime.now(UTC)
-    db_session.add_all(
+    percent = Session(
+        user_id=seed_user.id,
+        environment_id=env.id,
+        local_session_id="mcp-percent",
+        project_path="/repo/percent",
+        started_at=now,
+        summary="Literal 100% rollout note",
+    )
+    plain = Session(
+        user_id=seed_user.id,
+        environment_id=env.id,
+        local_session_id="mcp-plain",
+        project_path="/repo/plain",
+        started_at=now,
+        summary="Plain runtime work",
+    )
+    body_hash = "a" * 64
+    body = Session(
+        user_id=seed_user.id,
+        environment_id=env.id,
+        local_session_id="mcp-body",
+        project_path="/repo/body",
+        started_at=now,
+        summary="Unrelated title",
+        content_protocol="snapshot-v1",
+        content_hash=body_hash,
+    )
+    db_session.add_all([percent, plain, body])
+    await db_session.flush()
+    await replace_snapshot_search_index(
+        db_session,
+        body,
+        body_hash,
         [
-            Session(
-                user_id=seed_user.id,
-                environment_id=env.id,
-                local_session_id="mcp-percent",
-                project_path="/repo/percent",
-                started_at=now,
-                summary="Literal 100% rollout note",
-            ),
-            Session(
-                user_id=seed_user.id,
-                environment_id=env.id,
-                local_session_id="mcp-plain",
-                project_path="/repo/plain",
-                started_at=now,
-                summary="Plain runtime work",
-            ),
-        ]
+            SearchableSessionMessage(
+                position=0,
+                role="assistant",
+                content="The visible body contains a deployment handoff phrase.",
+            )
+        ],
     )
     await db_session.commit()
 
@@ -663,25 +688,42 @@ async def test_clawdi_mcp_session_search_escapes_like_wildcards(
     try:
         transport = ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
-            response = await ac.post(
-                "/v1/mcp/clawdi",
-                json={
-                    "jsonrpc": "2.0",
-                    "id": 4,
-                    "method": "tools/call",
-                    "params": {
-                        "name": "session_search",
-                        "arguments": {"query": "%", "limit": 10},
+
+            async def search(query: str):
+                return await ac.post(
+                    "/v1/mcp/clawdi",
+                    json={
+                        "jsonrpc": "2.0",
+                        "id": 4,
+                        "method": "tools/call",
+                        "params": {
+                            "name": "session_search",
+                            "arguments": {"query": query, "limit": 10},
+                        },
                     },
-                },
-            )
+                )
+
+            wildcard_response = await search("%")
+            body_response = await search("deployment handoff phrase")
+            typo_response = await search("deployment handof phrase")
     finally:
         app.dependency_overrides.clear()
 
-    assert response.status_code == 200, response.text
-    text = response.json()["result"]["content"][0]["text"]
-    assert "Literal 100% rollout note" in text
-    assert "Plain runtime work" not in text
+    assert wildcard_response.status_code == 200, wildcard_response.text
+    wildcard_text = wildcard_response.json()["result"]["content"][0]["text"]
+    assert "Literal 100% rollout note" in wildcard_text
+    assert "Plain runtime work" not in wildcard_text
+
+    assert body_response.status_code == 200, body_response.text
+    body_text = body_response.json()["result"]["content"][0]["text"]
+    assert "Unrelated title" in body_text
+    assert "matched assistant: The visible body contains a deployment handoff phrase." in body_text
+
+    assert typo_response.status_code == 200, typo_response.text
+    assert (
+        'No sessions matched "deployment handof phrase".'
+        in typo_response.json()["result"]["content"][0]["text"]
+    )
 
 
 @pytest.mark.asyncio

--- a/bun.lock
+++ b/bun.lock
@@ -50,6 +50,7 @@
         "react": "catalog:",
         "react-dom": "catalog:",
         "react-markdown": "^10.1.0",
+        "react-virtuoso": "4.18.12",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.8",
@@ -2024,6 +2025,8 @@
     "react-rnd": ["react-rnd@10.5.3", "", { "dependencies": { "re-resizable": "^6.11.2", "react-draggable": "^4.5.0", "tslib": "2.6.2" }, "peerDependencies": { "react": ">=16.3.0", "react-dom": ">=16.3.0" } }, "sha512-s/sIT3pGZnQ+57egijkTp9mizjIWrJz68Pq6yd+F/wniFY3IriML18dUXnQe/HP9uMiJ+9MAp44hljG99fZu6Q=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "react-virtuoso": ["react-virtuoso@4.18.12", "", { "peerDependencies": { "react": ">=16 || >=17 || >= 18 || >= 19", "react-dom": ">=16 || >=17 || >= 18 || >=19" } }, "sha512-6c1SnRicSBfG+WnbhcyJUxzDHvvxD3vsux/EpcfVbgB7clyP1Od2r81TAGTgwbL7U2qP889RR4u+CH6WjgpW0g=="],
 
     "react-zoom-pan-pinch": ["react-zoom-pan-pinch@4.0.3", "", { "peerDependencies": { "react": "*", "react-dom": "*" } }, "sha512-N2Hi6L78fFmhRra+ORpFSW7WST5x6kxpOPplIvtB0b7b+U2anpo1z1wLgaWRPS2kUSqcraRG+JgBCIlDJnqqAg=="],
 

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -11683,7 +11683,7 @@ export interface operations {
     list_sessions_v1_sessions_get: {
         parameters: {
             query?: {
-                /** @description Case-insensitive phrase search on summary/project/id and visible message text */
+                /** @description Case-insensitive phrase search on summary/project/local ID and visible message text; cloud session IDs match by UUID prefix */
                 q?: string | null;
                 /** @description Filter by agent_type */
                 agent?: string | null;

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -7553,6 +7553,7 @@ export interface components {
             subtitle?: string | null;
             /** Href */
             href: string;
+            search_match?: components["schemas"]["SessionSearchMatchResponse"] | null;
         };
         /** SearchResponse */
         SearchResponse: {


### PR DESCRIPTION
## Summary
- centralize exact phrase Session search for Web, CLI, and MCP, including visible user/assistant message text
- keep transcript search and role filters composable across global and Agent-scoped Session details
- simplify the search toolbar and tool activity presentation using existing design-system primitives
- pair parallel tool calls/results by stable call ID and preserve model changes in message grouping

## Verification
- isolated Web typecheck, 1096 tests, and OSS build
- isolated PostgreSQL focused backend tests: 34 passed
- Ruff lint/format and BasedPyright: clean
- Playwright Session search/navigation E2E at mobile and desktop viewports: 2 passed
- focused message-list rendering tests: 2 passed
- Biome and git diff checks: clean