### PR TITLE
fix(cli): bound Hermes session reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ database migration, CI, and implementation details.
 
 - Session detail search now preserves spaces while typing multi-word queries.
 
+## Clawdi CLI v0.14.29
+
+Package: `clawdi@0.14.29`
+
+### Fixed
+
+- Hosted Hermes session sync now scans large history stores in bounded batches
+  and avoids reloading unchanged transcripts, preventing daemon restart loops
+  on large state databases without dropping queued sessions.
+
 ## Clawdi CLI v0.14.28
 
 Package: `clawdi@0.14.28`

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.28",
+      "version": "0.14.29",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.28",
+	"version": "0.14.29",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/adapters/base.ts
+++ b/packages/cli/src/adapters/base.ts
@@ -114,6 +114,8 @@ export interface RawSession {
 	/** Present only when the source supports strict, stable events-v1. */
 	events?: SessionEvent[];
 	rawFilePath: string;
+	/** Opaque adapter revision used to avoid materializing unchanged backing content. */
+	sourceRevision?: string;
 	// Set by `pushOneAgent` after collection — sha256 hex of the JSON
 	// the CLI is about to upload. Adapters do not populate this.
 	contentHash?: string;
@@ -139,12 +141,51 @@ export interface SessionScanResult {
 	coverage: "complete" | "partial";
 }
 
+export interface SessionScanBatch {
+	sessions: RawSession[];
+	/** Every local session observed in this batch, including revision-matched sessions. */
+	observedLocalSessionIds: readonly string[];
+	dedupedCount: number;
+}
+
+export interface SessionBatchScan {
+	coverage: SessionScanResult["coverage"];
+	batches: AsyncIterable<SessionScanBatch>;
+}
+
 export interface SessionModule {
 	contentProtocol(): Promise<"events-v1" | "snapshot-v1">;
 	collect(request: SessionScanRequest): Promise<SessionScanResult>;
+	/**
+	 * Bounded scan for large or monolithic stores. Implementations may omit it;
+	 * callers then treat `collect` as one batch.
+	 */
+	scan?(
+		request: SessionScanRequest,
+		knownSourceRevisions: ReadonlyMap<string, string>,
+	): Promise<SessionBatchScan>;
 	resolve(localSessionId: string): Promise<RawSession | null>;
 	/** Paths watched as one backing-store stability group. */
 	watchPaths(): string[];
+}
+
+export async function scanSessionModule(
+	module: SessionModule,
+	request: SessionScanRequest,
+	knownSourceRevisions: ReadonlyMap<string, string> = new Map(),
+): Promise<SessionBatchScan> {
+	if (module.scan) return module.scan(request, knownSourceRevisions);
+	const result = await module.collect(request);
+	return {
+		coverage: result.coverage,
+		batches: (async function* () {
+			yield {
+				sessions: result.sessions,
+				observedLocalSessionIds: result.sessions.map((session) => session.localSessionId),
+				dedupedCount: result.dedupedCount,
+			};
+		})(),
+	};
 }
 
 export interface RawSkill {

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -82,7 +82,6 @@ interface TableInfoRow {
 }
 
 interface MessageRevisionRow {
-	content_bytes: number;
 	presentation_state: string;
 }
 
@@ -106,7 +105,7 @@ const MODERN_MESSAGE_OPTIONAL_COLUMNS = [
 const HERMES_CONTENT_JSON_PREFIX = "\0json:";
 const HERMES_SESSION_SCAN_BATCH_SIZE = 32;
 // Bump when persisted Hermes rows map to different Session/Event bytes.
-const HERMES_SESSION_PROJECTION_REVISION = 1;
+const HERMES_SESSION_PROJECTION_REVISION = 2;
 
 function messageTableInfo(db: ReadonlySqliteDatabase): TableInfoRow[] {
 	return db.prepare("PRAGMA table_info(messages)").all() as TableInfoRow[];
@@ -141,19 +140,23 @@ function messageRevisionQuery(columns: readonly TableInfoRow[]): string {
 	// Hermes appends and replaces rows with stable IDs, toggles lifecycle flags,
 	// updates presentation metadata in place, and may clear stale content. Keep
 	// that state exact while reducing large immutable payloads to byte lengths.
+	// SQLite can answer octet_length from the record header without reading the
+	// content payload from overflow pages.
 	return `
-		SELECT COALESCE(SUM(content_bytes), 0) AS content_bytes,
-		       json_group_array(json_array(id, timestamp, active, compacted, display_kind, display_metadata))
-		         AS presentation_state
+		SELECT json_group_array(
+		         json_array(
+		           id, timestamp, active, compacted, display_kind, display_metadata,
+		           octet_length(content)
+		         ) ORDER BY id
+		       ) AS presentation_state
 		FROM (
-			SELECT id, timestamp, LENGTH(CAST(content AS BLOB)) AS content_bytes,
+			SELECT id, timestamp, content,
 			       ${columnOr("active", "1")},
 			       ${columnOr("compacted", "0")},
 			       ${columnOr("display_kind", "NULL")},
 			       ${columnOr("display_metadata", "NULL")}
 			FROM messages
 			WHERE session_id = ?
-			ORDER BY id
 		)
 	`;
 }
@@ -173,7 +176,6 @@ function sessionSourceRevision(row: SessionRow, messages: MessageRevisionRow): s
 				row.input_tokens,
 				row.output_tokens,
 				row.cache_read_tokens,
-				messages.content_bytes,
 				messages.presentation_state,
 			]),
 		)

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join, relative } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
@@ -19,6 +20,7 @@ import type {
 	AgentAdapterCore,
 	RawSession,
 	RawSkill,
+	SessionBatchScan,
 	SessionContentPart,
 	SessionEventDisplayMetadata,
 	SessionEventSemantics,
@@ -79,6 +81,11 @@ interface TableInfoRow {
 	pk: number;
 }
 
+interface MessageRevisionRow {
+	content_bytes: number;
+	presentation_state: string;
+}
+
 const MODERN_MESSAGE_CORE_COLUMNS = ["session_id", "role", "content", "timestamp"] as const;
 
 const MODERN_MESSAGE_OPTIONAL_COLUMNS = [
@@ -97,6 +104,9 @@ const MODERN_MESSAGE_OPTIONAL_COLUMNS = [
 ] as const;
 
 const HERMES_CONTENT_JSON_PREFIX = "\0json:";
+const HERMES_SESSION_SCAN_BATCH_SIZE = 32;
+// Bump when persisted Hermes rows map to different Session/Event bytes.
+const HERMES_SESSION_PROJECTION_REVISION = 1;
 
 function messageTableInfo(db: ReadonlySqliteDatabase): TableInfoRow[] {
 	return db.prepare("PRAGMA table_info(messages)").all() as TableInfoRow[];
@@ -122,6 +132,52 @@ function modernMessageSelectColumns(columns: readonly TableInfoRow[]): string {
 		),
 		"timestamp",
 	].join(", ");
+}
+
+function messageRevisionQuery(columns: readonly TableInfoRow[]): string {
+	const names = new Set(columns.map((column) => column.name));
+	const columnOr = (name: string, fallback: string) =>
+		names.has(name) ? name : `${fallback} AS ${name}`;
+	// Hermes appends and replaces rows with stable IDs, toggles lifecycle flags,
+	// updates presentation metadata in place, and may clear stale content. Keep
+	// that state exact while reducing large immutable payloads to byte lengths.
+	return `
+		SELECT COALESCE(SUM(content_bytes), 0) AS content_bytes,
+		       json_group_array(json_array(id, timestamp, active, compacted, display_kind, display_metadata))
+		         AS presentation_state
+		FROM (
+			SELECT id, timestamp, LENGTH(CAST(content AS BLOB)) AS content_bytes,
+			       ${columnOr("active", "1")},
+			       ${columnOr("compacted", "0")},
+			       ${columnOr("display_kind", "NULL")},
+			       ${columnOr("display_metadata", "NULL")}
+			FROM messages
+			WHERE session_id = ?
+			ORDER BY id
+		)
+	`;
+}
+
+function sessionSourceRevision(row: SessionRow, messages: MessageRevisionRow): string {
+	return createHash("sha256")
+		.update(
+			JSON.stringify([
+				HERMES_SESSION_PROJECTION_REVISION,
+				row.id,
+				row.source,
+				row.model,
+				row.title,
+				row.started_at,
+				row.ended_at,
+				row.message_count,
+				row.input_tokens,
+				row.output_tokens,
+				row.cache_read_tokens,
+				messages.content_bytes,
+				messages.presentation_state,
+			]),
+		)
+		.digest("hex");
 }
 
 function decodeHermesContent(content: string | null): unknown {
@@ -414,6 +470,8 @@ export class HermesAdapter implements AgentAdapterCore {
 	readonly sessions = {
 		contentProtocol: () => this.getContentProtocol(),
 		collect: (request: SessionScanRequest) => this.collectSessions(request),
+		scan: (request: SessionScanRequest, knownSourceRevisions: ReadonlyMap<string, string>) =>
+			this.scanSessions(request, knownSourceRevisions),
 		resolve: (localSessionId: string) => this.resolveSession(localSessionId),
 		watchPaths: () => this.getSessionsWatchPaths(),
 	};
@@ -450,35 +508,117 @@ export class HermesAdapter implements AgentAdapterCore {
 		}
 	}
 
-	private async collectSessions(_request: SessionScanRequest): Promise<SessionScanResult> {
-		// Hermes' SQLite is a single file with no per-row stat info, so we
-		// always scan the whole `sessions` table. Cost is negligible
-		// (dozens to hundreds of rows). `projectFilter` has no analogue
-		// in Hermes' data model and is silently ignored.
-		return { sessions: await this.collectCurrentSessions(), dedupedCount: 0, coverage: "complete" };
+	private async collectSessions(request: SessionScanRequest): Promise<SessionScanResult> {
+		const scan = await this.scanSessions(request, new Map());
+		const sessions: RawSession[] = [];
+		let dedupedCount = 0;
+		for await (const batch of scan.batches) {
+			sessions.push(...batch.sessions);
+			dedupedCount += batch.dedupedCount;
+		}
+		return { sessions, dedupedCount, coverage: scan.coverage };
+	}
+
+	private async scanSessions(
+		_request: SessionScanRequest,
+		knownSourceRevisions: ReadonlyMap<string, string>,
+	): Promise<SessionBatchScan> {
+		if (!existsSync(stateDbPath())) {
+			return { coverage: "complete", batches: (async function* () {})() };
+		}
+		const db = await openReadonlySqlite(stateDbPath());
+		return {
+			coverage: "complete",
+			batches: this.readSessionBatches(db, knownSourceRevisions),
+		};
+	}
+
+	private async *readSessionBatches(
+		db: ReadonlySqliteDatabase,
+		knownSourceRevisions: ReadonlyMap<string, string>,
+	): AsyncGenerator<{
+		sessions: RawSession[];
+		observedLocalSessionIds: readonly string[];
+		dedupedCount: number;
+	}> {
+		try {
+			const readers = this.sessionReaders(db);
+			let cursor: Pick<SessionRow, "started_at" | "id"> | null = null;
+			while (true) {
+				const rows = db
+					.prepare(`
+						SELECT id, source, model, title, started_at, ended_at,
+						       message_count, input_tokens, output_tokens, cache_read_tokens
+						FROM sessions
+						${cursor ? "WHERE started_at < ? OR (started_at = ? AND id < ?)" : ""}
+						ORDER BY started_at DESC, id DESC
+						LIMIT ?
+					`)
+					.all(
+						...(cursor ? [cursor.started_at, cursor.started_at, cursor.id] : []),
+						HERMES_SESSION_SCAN_BATCH_SIZE,
+					) as SessionRow[];
+				if (rows.length === 0) return;
+
+				const observedLocalSessionIds = rows.map((row) => row.id);
+				const sessions: RawSession[] = [];
+				for (const row of rows) {
+					const sourceRevision = readers.revision
+						? sessionSourceRevision(row, readers.revision.get(row.id) as MessageRevisionRow)
+						: undefined;
+					if (sourceRevision && knownSourceRevisions.get(row.id) === sourceRevision) continue;
+					const session = this.materializeSession(
+						row,
+						sourceRevision,
+						readers.modern,
+						readers.messages,
+					);
+					if (session) sessions.push(session);
+				}
+				yield { sessions, observedLocalSessionIds, dedupedCount: 0 };
+				const last = rows.at(-1);
+				if (!last || rows.length < HERMES_SESSION_SCAN_BATCH_SIZE) return;
+				cursor = last;
+			}
+		} finally {
+			db.close();
+		}
 	}
 
 	private async resolveSession(localSessionId: string): Promise<RawSession | null> {
-		return (await this.collectCurrentSessions(localSessionId))[0] ?? null;
-	}
-
-	private async collectCurrentSessions(localSessionId?: string): Promise<RawSession[]> {
-		if (!existsSync(stateDbPath())) return [];
+		if (!existsSync(stateDbPath())) return null;
 		const db = await openReadonlySqlite(stateDbPath());
 		try {
-			const messageColumns = messageTableInfo(db);
-			const modern = hasStableModernMessageIds(messageColumns);
-			const selectSessions = `
-				SELECT id, source, model, title, started_at, ended_at,
-				       message_count, input_tokens, output_tokens, cache_read_tokens
-				FROM sessions
-				${localSessionId === undefined ? "" : "WHERE id = ?"}
-				ORDER BY started_at DESC
-			`;
-			const rows = db
-				.prepare(selectSessions)
-				.all(...(localSessionId === undefined ? [] : [localSessionId])) as SessionRow[];
-			const msgStmt = db.prepare(
+			const row = db
+				.prepare(`
+					SELECT id, source, model, title, started_at, ended_at,
+					       message_count, input_tokens, output_tokens, cache_read_tokens
+					FROM sessions
+					WHERE id = ?
+				`)
+				.get(localSessionId) as SessionRow | undefined;
+			if (!row) return null;
+			const readers = this.sessionReaders(db);
+			return this.materializeSession(
+				row,
+				readers.revision
+					? sessionSourceRevision(row, readers.revision.get(row.id) as MessageRevisionRow)
+					: undefined,
+				readers.modern,
+				readers.messages,
+			);
+		} finally {
+			db.close();
+		}
+	}
+
+	private sessionReaders(db: ReadonlySqliteDatabase) {
+		const messageColumns = messageTableInfo(db);
+		const modern = hasStableModernMessageIds(messageColumns);
+		return {
+			modern,
+			revision: modern ? db.prepare(messageRevisionQuery(messageColumns)) : null,
+			messages: db.prepare(
 				modern
 					? `
 						SELECT ${modernMessageSelectColumns(messageColumns)}
@@ -492,72 +632,63 @@ export class HermesAdapter implements AgentAdapterCore {
 						WHERE session_id = ? AND role IN ('user', 'assistant') AND content IS NOT NULL
 						ORDER BY timestamp ASC
 					`,
-			);
+			),
+		};
+	}
 
-			const sessions: RawSession[] = [];
+	private materializeSession(
+		row: SessionRow,
+		sourceRevision: string | undefined,
+		modern: boolean,
+		messagesStatement: ReturnType<ReadonlySqliteDatabase["prepare"]>,
+	): RawSession | null {
+		const model = parseModelField(row.model);
+		const startedAt = new Date(row.started_at * 1000);
+		const endedAt = row.ended_at ? new Date(row.ended_at * 1000) : null;
+		const durationSeconds = durationSecondsBetween(startedAt, endedAt);
+		const messageRows = messagesStatement.all(row.id) as Array<MessageRow | ModernMessageRow>;
+		const events = modern
+			? sequenceSessionEvents(
+					(messageRows as ModernMessageRow[]).flatMap((message) =>
+						hermesEventDrafts(message, row.id, model),
+					),
+				)
+			: undefined;
+		const messages: SessionMessage[] = events
+			? projectEventsToMessages(events)
+			: (messageRows as MessageRow[]).map((message) => ({
+					role: message.role as "user" | "assistant",
+					content: message.content ?? "",
+					model: message.role === "assistant" ? (model ?? undefined) : undefined,
+					...(timestampIso(message.timestamp)
+						? { timestamp: timestampIso(message.timestamp) }
+						: {}),
+				}));
+		if (modern ? events?.length === 0 : messages.length === 0) return null;
 
-			for (const row of rows) {
-				const model = parseModelField(row.model);
-				const startedAt = new Date(row.started_at * 1000);
-				const endedAt = row.ended_at ? new Date(row.ended_at * 1000) : null;
-				const durationSeconds = durationSecondsBetween(startedAt, endedAt);
-
-				const msgRows = msgStmt.all(row.id) as Array<MessageRow | ModernMessageRow>;
-				const events = modern
-					? sequenceSessionEvents(
-							(msgRows as ModernMessageRow[]).flatMap((message) =>
-								hermesEventDrafts(message, row.id, model),
-							),
-						)
-					: undefined;
-				const messages: SessionMessage[] = events
-					? projectEventsToMessages(events)
-					: (msgRows as MessageRow[]).map((message) => ({
-							role: message.role as "user" | "assistant",
-							content: message.content ?? "",
-							model: message.role === "assistant" ? (model ?? undefined) : undefined,
-							...(timestampIso(message.timestamp)
-								? { timestamp: timestampIso(message.timestamp) }
-								: {}),
-						}));
-
-				// Summary: use title or first user message
-				let summary = row.title;
-				if (!summary || summary === "New Chat" || summary.startsWith("New Chat #")) {
-					const firstUser = messages.find((m) => m.role === "user");
-					summary = firstUser ? safeTruncate(firstUser.content, 200) : null;
-				}
-
-				if (modern ? events?.length === 0 : messages.length === 0) continue;
-
-				sessions.push({
-					localSessionId: row.id,
-					// Hermes sessions have no filesystem cwd — `row.source` is a channel/origin
-					// tag (e.g. "telegram"), not a path. Leave null so the dashboard doesn't
-					// render a fake "hermes/..." project.
-					projectPath: null,
-					startedAt,
-					endedAt,
-					messageCount: row.message_count ?? messages.length,
-					inputTokens: row.input_tokens ?? 0,
-					outputTokens: row.output_tokens ?? 0,
-					cacheReadTokens: row.cache_read_tokens ?? 0,
-					model,
-					modelsUsed: model ? [model] : [],
-					durationSeconds,
-					summary,
-					messages,
-					...(events ? { events } : {}),
-					// The DB is shared across sessions — anchor to the row id so the pointer
-					// identifies the specific session rather than the whole store.
-					rawFilePath: `${stateDbPath()}#${row.id}`,
-				});
-			}
-
-			return sessions;
-		} finally {
-			db.close();
+		let summary = row.title;
+		if (!summary || summary === "New Chat" || summary.startsWith("New Chat #")) {
+			const firstUser = messages.find((message) => message.role === "user");
+			summary = firstUser ? safeTruncate(firstUser.content, 200) : null;
 		}
+		return {
+			localSessionId: row.id,
+			projectPath: null,
+			startedAt,
+			endedAt,
+			messageCount: row.message_count ?? messages.length,
+			inputTokens: row.input_tokens ?? 0,
+			outputTokens: row.output_tokens ?? 0,
+			cacheReadTokens: row.cache_read_tokens ?? 0,
+			model,
+			modelsUsed: model ? [model] : [],
+			durationSeconds,
+			summary,
+			messages,
+			...(events ? { events } : {}),
+			rawFilePath: `${stateDbPath()}#${row.id}`,
+			...(sourceRevision ? { sourceRevision } : {}),
+		};
 	}
 
 	private async collectSkills(): Promise<RawSkill[]> {

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -669,7 +669,7 @@ async function uploadOneAgent(
 					sourceSessionKey: id,
 				});
 				if (suppressedIds.has(id)) {
-					persistSuppressedSession(fence, plan);
+					persistSuppressedSession(fence, s, plan);
 					continue;
 				}
 				try {

--- a/packages/cli/src/lib/session-upload.test.ts
+++ b/packages/cli/src/lib/session-upload.test.ts
@@ -85,6 +85,7 @@ function rawSession(content: readonly SessionEvent[]): RawSession {
 		messages: projectEventsToMessages(content),
 		events: [...content],
 		rawFilePath: "/sessions/fixture.jsonl",
+		sourceRevision: "source-r1",
 	};
 }
 
@@ -218,6 +219,7 @@ describe("events-v1 incremental upload", () => {
 		expect(readFencedSessionEntry(readSessionsLock(), fence)).toMatchObject({
 			event_count: 2,
 			event_head_hash: finalHead,
+			source_revision: "source-r1",
 		});
 	});
 

--- a/packages/cli/src/lib/session-upload.ts
+++ b/packages/cli/src/lib/session-upload.ts
@@ -125,10 +125,19 @@ export function sessionPlanIsDurablyBlocked(
 	return entry?.local_hash === plan.localHash ? (entry.blocked?.message ?? null) : null;
 }
 
-export function persistSuppressedSession(fence: SessionFence, plan: SessionUploadPlan): void {
+function sourceRevisionEntry(session: RawSession): { source_revision?: string } {
+	return session.sourceRevision ? { source_revision: session.sourceRevision } : {};
+}
+
+export function persistSuppressedSession(
+	fence: SessionFence,
+	session: RawSession,
+	plan: SessionUploadPlan,
+): void {
 	persistFencedSessionEntry(fence, {
 		protocol: plan.protocol,
 		local_hash: plan.localHash,
+		...sourceRevisionEntry(session),
 		...(plan.protocol === "snapshot-v1" ? { snapshot_hash: plan.localHash } : {}),
 	});
 }
@@ -192,6 +201,7 @@ async function syncSnapshotSession(input: {
 	persistFencedSessionEntry(input.fence, {
 		protocol: "snapshot-v1",
 		local_hash: input.plan.localHash,
+		...sourceRevisionEntry(input.session),
 		snapshot_hash: input.plan.localHash,
 	});
 	return { status: "synced", uploaded, localHash: input.plan.localHash };
@@ -511,6 +521,7 @@ function persistEventSuccess(
 	persistFencedSessionEntry(input.fence, {
 		protocol: "events-v1",
 		local_hash: input.plan.localHash,
+		...sourceRevisionEntry(input.session),
 		event_generation: head.generation,
 		event_revision: head.revision,
 		event_count: head.count,
@@ -526,6 +537,7 @@ function persistPending(
 	persistFencedSessionEntry(input.fence, {
 		protocol: "events-v1",
 		local_hash: input.plan.localHash,
+		...(prior?.source_revision ? { source_revision: prior.source_revision } : {}),
 		...(prior?.event_generation ? { event_generation: prior.event_generation } : {}),
 		...(prior?.event_revision === undefined ? {} : { event_revision: prior.event_revision }),
 		...(prior?.event_count === undefined ? {} : { event_count: prior.event_count }),
@@ -570,6 +582,7 @@ function persistBlocked(
 	persistFencedSessionEntry(input.fence, {
 		protocol: input.plan.protocol,
 		local_hash: input.plan.localHash,
+		...sourceRevisionEntry(input.session),
 		...(input.plan.protocol === "snapshot-v1" ? { snapshot_hash: input.plan.localHash } : {}),
 		blocked: {
 			code: block.code,

--- a/packages/cli/src/lib/sessions-lock.ts
+++ b/packages/cli/src/lib/sessions-lock.ts
@@ -39,6 +39,7 @@ export interface FencedSessionLockEntry {
 	source_session_key: string;
 	protocol: "snapshot-v1" | "events-v1";
 	local_hash: string;
+	source_revision?: string;
 	snapshot_hash?: string;
 	event_generation?: string;
 	event_revision?: number;
@@ -202,6 +203,7 @@ export function isFencedSessionLockEntry(value: unknown): value is FencedSession
 		typeof value.environment_id === "string" &&
 		typeof value.adapter === "string" &&
 		typeof value.source_session_key === "string" &&
-		(value.protocol === "snapshot-v1" || value.protocol === "events-v1")
+		(value.protocol === "snapshot-v1" || value.protocol === "events-v1") &&
+		(value.source_revision === undefined || typeof value.source_revision === "string")
 	);
 }

--- a/packages/cli/src/lib/sessions-lock.ts
+++ b/packages/cli/src/lib/sessions-lock.ts
@@ -49,6 +49,13 @@ export interface FencedSessionLockEntry {
 	blocked?: SessionUploadBlock;
 }
 
+export interface FencedSessionSourceRevisionUpdate {
+	fence: SessionFence;
+	protocol: FencedSessionLockEntry["protocol"];
+	localHash: string;
+	sourceRevision: string;
+}
+
 export interface LegacySessionLockEntry {
 	hash: string;
 }
@@ -129,6 +136,29 @@ export function persistFencedSessionEntry(
 
 export function clearFencedSessionEntry(fence: SessionFence): void {
 	writeSessionsLock(removeFencedSessionEntry(readSessionsLock(), fence));
+}
+
+export function persistFencedSessionSourceRevisions(
+	updates: readonly FencedSessionSourceRevisionUpdate[],
+): void {
+	if (updates.length === 0) return;
+	const lock = readSessionsLock();
+	let changed = false;
+	for (const update of updates) {
+		const entry = readFencedSessionEntry(lock, update.fence);
+		if (
+			!entry ||
+			entry.pending !== undefined ||
+			entry.protocol !== update.protocol ||
+			entry.local_hash !== update.localHash ||
+			entry.source_revision === update.sourceRevision
+		) {
+			continue;
+		}
+		entry.source_revision = update.sourceRevision;
+		changed = true;
+	}
+	if (changed) writeSessionsLock(lock);
 }
 
 /** Read the current lock while accepting v1 without trusting its unfenced hash. */

--- a/packages/cli/src/serve/queue.test.ts
+++ b/packages/cli/src/serve/queue.test.ts
@@ -253,6 +253,48 @@ describe("RetryQueue", () => {
 		await q.flushPersist();
 	});
 
+	it("waits for capacity when reconciliation must preserve every session", async () => {
+		const q = new RetryQueue({ agentType: "claude_code", maxItems: 1 });
+		q.enqueue({
+			kind: "session_push",
+			...sessionFence("first"),
+			local_session_id: "first",
+			content_hash: "first-hash",
+			enqueued_at: "2026-01-01T00:00:00Z",
+			attempts: 0,
+		});
+		let secondEnqueued = false;
+		const pending = q
+			.enqueueWhenAvailable(
+				{
+					kind: "session_push",
+					...sessionFence("second"),
+					local_session_id: "second",
+					content_hash: "second-hash",
+					enqueued_at: "2026-01-01T00:00:01Z",
+					attempts: 0,
+				},
+				new AbortController().signal,
+			)
+			.then(() => {
+				secondEnqueued = true;
+			});
+
+		await Promise.resolve();
+		expect(secondEnqueued).toBe(false);
+		expect(q.drainDroppedDelta()).toBe(0);
+		const first = q.peek();
+		if (!first) throw new Error("expected first session");
+		q.markDoneIfVersion(first);
+		await pending;
+
+		expect(q.all().map((item) => item.kind === "session_push" && item.local_session_id)).toEqual([
+			"second",
+		]);
+		expect(q.drainDroppedDelta()).toBe(0);
+		await q.flushPersist();
+	});
+
 	it("markDoneIfVersion removes the item when version matches", async () => {
 		const q = new RetryQueue({ agentType: "claude_code" });
 		q.enqueue({

--- a/packages/cli/src/serve/queue.ts
+++ b/packages/cli/src/serve/queue.ts
@@ -402,9 +402,8 @@ export class RetryQueue {
 	 */
 	async enqueueWhenAvailable(item: QueueItemInput, abort: AbortSignal): Promise<number | null> {
 		while (!abort.aborted) {
-			const replacesExisting = this.items.some((existing) =>
-				sameKey(existing, stampVersion(item, this.nextVersion)),
-			);
+			const candidate = stampVersion(item, this.nextVersion);
+			const replacesExisting = this.items.some((existing) => sameKey(existing, candidate));
 			if (replacesExisting || this.items.length < this.maxItems) return this.enqueue(item);
 			await this.waitForCapacityChange(abort);
 		}

--- a/packages/cli/src/serve/queue.ts
+++ b/packages/cli/src/serve/queue.ts
@@ -203,6 +203,7 @@ export class RetryQueue {
 	private writeChain: Promise<void> = Promise.resolve();
 	private flushActive = false;
 	private readonly itemWaiters = new Set<() => void>();
+	private readonly capacityWaiters = new Set<() => void>();
 	// Latest snapshot waiting to be written. Multiple `persist()`
 	// calls within one tick coalesce into a single write because
 	// the flush loop reads this until it's null. Last-write-wins,
@@ -394,6 +395,22 @@ export class RetryQueue {
 		return stamped.version;
 	}
 
+	/**
+	 * Enqueue derived reconciliation work without evicting older work. Direct
+	 * producers may still use `enqueue`'s bounded latest-state policy; an
+	 * inventory scan can wait because it remains reproducible until queued.
+	 */
+	async enqueueWhenAvailable(item: QueueItemInput, abort: AbortSignal): Promise<number | null> {
+		while (!abort.aborted) {
+			const replacesExisting = this.items.some((existing) =>
+				sameKey(existing, stampVersion(item, this.nextVersion)),
+			);
+			if (replacesExisting || this.items.length < this.maxItems) return this.enqueue(item);
+			await this.waitForCapacityChange(abort);
+		}
+		return null;
+	}
+
 	/** Wait until an item is available, the timeout expires, or abort fires.
 	 * Used by the daemon drain loop so an idle queue can sleep until
 	 * enqueue() provides real work. */
@@ -421,6 +438,30 @@ export class RetryQueue {
 		if (this.itemWaiters.size === 0) return;
 		const waiters = [...this.itemWaiters];
 		this.itemWaiters.clear();
+		for (const finish of waiters) finish();
+	}
+
+	private waitForCapacityChange(abort: AbortSignal): Promise<void> {
+		if (this.items.length < this.maxItems || abort.aborted) return Promise.resolve();
+		return new Promise((resolve) => {
+			let settled = false;
+			const finish = () => {
+				if (settled) return;
+				settled = true;
+				this.capacityWaiters.delete(finish);
+				abort.removeEventListener("abort", finish);
+				resolve();
+			};
+			this.capacityWaiters.add(finish);
+			abort.addEventListener("abort", finish, { once: true });
+			if (this.items.length < this.maxItems) finish();
+		});
+	}
+
+	private notifyCapacityWaiters(): void {
+		if (this.capacityWaiters.size === 0) return;
+		const waiters = [...this.capacityWaiters];
+		this.capacityWaiters.clear();
 		for (const finish of waiters) finish();
 	}
 
@@ -488,6 +529,7 @@ export class RetryQueue {
 		if (this.items[idx].version !== item.version) return false;
 		this.items.splice(idx, 1);
 		this.persist();
+		this.notifyCapacityWaiters();
 		return true;
 	}
 

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -103,7 +103,12 @@ describe("stable session enqueue abort fence", () => {
 					rawFilePath: "/sessions/1.jsonl",
 				},
 			],
-			queue: { enqueue: (item: unknown) => queued.push(item) },
+			queue: {
+				enqueueWhenAvailable: async (item: unknown) => {
+					queued.push(item);
+					return 1;
+				},
+			},
 			lastPushedHash: new Map(),
 			inFlightHash: inFlight,
 			protocol: "snapshot-v1",

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -14,8 +14,13 @@ import { dirname, join } from "node:path";
 import type { AgentAdapter, RawSession, SkillModule } from "../adapters/base";
 import { adapterRegistry } from "../adapters/registry";
 import { AgentSkillSyncNotFoundError, ApiClient, ApiError } from "../lib/api-client";
-import { sessionFence } from "../lib/session-upload";
-import { readFencedSessionEntry, readSessionsLock } from "../lib/sessions-lock";
+import { planSessionUpload, sessionFence } from "../lib/session-upload";
+import {
+	persistFencedSessionEntry,
+	persistFencedSessionSourceRevisions,
+	readFencedSessionEntry,
+	readSessionsLock,
+} from "../lib/sessions-lock";
 import {
 	computeSkillFolderHash,
 	readSkillProjectionClaimsForAgent,
@@ -83,7 +88,7 @@ describe("stable session enqueue abort fence", () => {
 		const queued: unknown[] = [];
 		const inFlight = new Map<string, string>();
 		abort.abort();
-		const enqueued = await enqueueChangedSessionsAfterStability({
+		const result = await enqueueChangedSessionsAfterStability({
 			abort: abort.signal,
 			sessions: [
 				{
@@ -120,9 +125,73 @@ describe("stable session enqueue abort fence", () => {
 			}),
 		});
 
-		expect(enqueued).toBe(0);
+		expect(result.enqueued).toBe(0);
 		expect(queued).toEqual([]);
 		expect(inFlight.size).toBe(0);
+	});
+
+	it("backfills the source revision when the confirmed content hash still matches", async () => {
+		const root = mkdtempSync(join(tmpdir(), "session-revision-backfill-"));
+		const originalHome = process.env.HOME;
+		try {
+			process.env.HOME = root;
+			const session: RawSession = {
+				localSessionId: "session-1",
+				projectPath: null,
+				startedAt: new Date(0),
+				endedAt: null,
+				messageCount: 1,
+				inputTokens: 0,
+				outputTokens: 0,
+				cacheReadTokens: 0,
+				model: null,
+				modelsUsed: [],
+				durationSeconds: null,
+				summary: null,
+				messages: [{ role: "user", content: "already synced" }],
+				rawFilePath: "/sessions/1.jsonl",
+				sourceRevision: "source-r2",
+			};
+			const plan = planSessionUpload(session, "snapshot-v1");
+			const fence = {
+				apiOrigin: "https://cloud.example.test",
+				environmentId: "agent-1",
+				adapter: "hermes" as const,
+				sourceSessionKey: session.localSessionId,
+			};
+			persistFencedSessionEntry(fence, {
+				protocol: plan.protocol,
+				local_hash: plan.localHash,
+				snapshot_hash: plan.localHash,
+			});
+			const queued: unknown[] = [];
+			const result = await enqueueChangedSessionsAfterStability({
+				abort: new AbortController().signal,
+				sessions: [session],
+				queue: {
+					enqueueWhenAvailable: async (item: unknown) => {
+						queued.push(item);
+						return 1;
+					},
+				},
+				lastPushedHash: new Map([[session.localSessionId, plan.localHash]]),
+				inFlightHash: new Map(),
+				protocol: plan.protocol,
+				fenceFor: () => fence,
+			});
+
+			persistFencedSessionSourceRevisions(result.confirmedSourceRevisions);
+
+			expect(result.enqueued).toBe(0);
+			expect(queued).toEqual([]);
+			expect(readFencedSessionEntry(readSessionsLock(), fence)?.source_revision).toBe(
+				"source-r2",
+			);
+		} finally {
+			if (originalHome === undefined) delete process.env.HOME;
+			else process.env.HOME = originalHome;
+			rmSync(root, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -184,9 +184,7 @@ describe("stable session enqueue abort fence", () => {
 
 			expect(result.enqueued).toBe(0);
 			expect(queued).toEqual([]);
-			expect(readFencedSessionEntry(readSessionsLock(), fence)?.source_revision).toBe(
-				"source-r2",
-			);
+			expect(readFencedSessionEntry(readSessionsLock(), fence)?.source_revision).toBe("source-r2");
 		} finally {
 			if (originalHome === undefined) delete process.env.HOME;
 			else process.env.HOME = originalHome;

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -291,11 +291,11 @@ export async function enqueueChangedSessionsAfterStability(
 		const fence = opts.fenceFor(session);
 		const sourceRevisionUpdate = session.sourceRevision
 			? {
-				fence,
-				protocol: plan.protocol,
-				localHash: hash,
-				sourceRevision: session.sourceRevision,
-			}
+					fence,
+					protocol: plan.protocol,
+					localHash: hash,
+					sourceRevision: session.sourceRevision,
+				}
 			: null;
 		const blocked = sessionPlanIsDurablyBlocked(fence, plan);
 		if (blocked) {

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -60,6 +60,8 @@ import {
 } from "../lib/session-upload";
 import {
 	type FencedSessionLockEntry,
+	type FencedSessionSourceRevisionUpdate,
+	persistFencedSessionSourceRevisions,
 	readSessionsLock,
 	type SessionFence,
 } from "../lib/sessions-lock";
@@ -271,24 +273,42 @@ interface StableSessionEnqueueOptions {
 	onBlocked?(session: RawSession, message: string): void;
 }
 
+interface StableSessionEnqueueResult {
+	enqueued: number;
+	confirmedSourceRevisions: FencedSessionSourceRevisionUpdate[];
+}
+
 export async function enqueueChangedSessionsAfterStability(
 	opts: StableSessionEnqueueOptions,
-): Promise<number> {
-	if (opts.abort.aborted) return 0;
+): Promise<StableSessionEnqueueResult> {
+	const confirmedSourceRevisions: FencedSessionSourceRevisionUpdate[] = [];
+	if (opts.abort.aborted) return { enqueued: 0, confirmedSourceRevisions };
 	let enqueued = 0;
 	for (const session of opts.sessions) {
-		if (opts.abort.aborted) return enqueued;
+		if (opts.abort.aborted) return { enqueued, confirmedSourceRevisions };
 		const plan = planSessionUpload(session, opts.protocol);
 		const hash = plan.localHash;
 		const fence = opts.fenceFor(session);
+		const sourceRevisionUpdate = session.sourceRevision
+			? {
+				fence,
+				protocol: plan.protocol,
+				localHash: hash,
+				sourceRevision: session.sourceRevision,
+			}
+			: null;
 		const blocked = sessionPlanIsDurablyBlocked(fence, plan);
 		if (blocked) {
+			if (sourceRevisionUpdate) confirmedSourceRevisions.push(sourceRevisionUpdate);
 			opts.onBlocked?.(session, blocked);
 			continue;
 		}
-		if (opts.lastPushedHash.get(session.localSessionId) === hash) continue;
+		if (opts.lastPushedHash.get(session.localSessionId) === hash) {
+			if (sourceRevisionUpdate) confirmedSourceRevisions.push(sourceRevisionUpdate);
+			continue;
+		}
 		if (opts.inFlightHash.get(session.localSessionId) === hash) continue;
-		if (opts.abort.aborted) return enqueued;
+		if (opts.abort.aborted) return { enqueued, confirmedSourceRevisions };
 		const version = await opts.queue.enqueueWhenAvailable(
 			{
 				kind: "session_push",
@@ -303,11 +323,11 @@ export async function enqueueChangedSessionsAfterStability(
 			},
 			opts.abort,
 		);
-		if (version === null) return enqueued;
+		if (version === null) return { enqueued, confirmedSourceRevisions };
 		opts.inFlightHash.set(session.localSessionId, hash);
 		enqueued += 1;
 	}
-	return enqueued;
+	return { enqueued, confirmedSourceRevisions };
 }
 
 interface EngineOpts {
@@ -945,12 +965,13 @@ async function prepareSessionSync(
 				loadFencedSessionSourceRevisions(api, opts, protocol),
 			);
 			const observedResources = new Set<string>();
+			const confirmedSourceRevisions: FencedSessionSourceRevisionUpdate[] = [];
 			let enqueued = 0;
 			for await (const batch of scan.batches) {
 				for (const localSessionId of batch.observedLocalSessionIds) {
 					observedResources.add(`session:${localSessionId}`);
 				}
-				enqueued += await enqueueChangedSessionsAfterStability({
+				const result = await enqueueChangedSessionsAfterStability({
 					abort: opts.abort,
 					sessions: batch.sessions,
 					queue,
@@ -971,8 +992,11 @@ async function prepareSessionSync(
 						);
 					},
 				});
+				enqueued += result.enqueued;
+				confirmedSourceRevisions.push(...result.confirmedSourceRevisions);
 				if (opts.abort.aborted) return;
 			}
+			persistFencedSessionSourceRevisions(confirmedSourceRevisions);
 			if (scan.coverage === "complete") {
 				health.clearAbsent("push", "session:", observedResources);
 			}

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -45,6 +45,7 @@ import type {
 	SessionScanRequest,
 	SkillModule,
 } from "../adapters/base";
+import { scanSessionModule } from "../adapters/base";
 import { AgentSkillSyncNotFoundError, ApiClient, ApiError, unwrap } from "../lib/api-client";
 import { canonicalApiOrigin } from "../lib/api-origin";
 import { computeLastActivityIso } from "../lib/session-activity";
@@ -57,7 +58,11 @@ import {
 	sessionPlanIsDurablyBlocked,
 	syncSessionContent,
 } from "../lib/session-upload";
-import { readSessionsLock, type SessionFence } from "../lib/sessions-lock";
+import {
+	type FencedSessionLockEntry,
+	readSessionsLock,
+	type SessionFence,
+} from "../lib/sessions-lock";
 import { isValidSkillKey, SkillKeyValidationError } from "../lib/skill-key";
 import {
 	computeSkillFolderHash,
@@ -258,7 +263,7 @@ export class SyncHealth {
 interface StableSessionEnqueueOptions {
 	abort: AbortSignal;
 	sessions: readonly RawSession[];
-	queue: Pick<RetryQueue, "enqueue">;
+	queue: Pick<RetryQueue, "enqueueWhenAvailable">;
 	lastPushedHash: ReadonlyMap<string, string>;
 	inFlightHash: Map<string, string>;
 	protocol: SelectedSessionProtocol;
@@ -284,17 +289,21 @@ export async function enqueueChangedSessionsAfterStability(
 		if (opts.lastPushedHash.get(session.localSessionId) === hash) continue;
 		if (opts.inFlightHash.get(session.localSessionId) === hash) continue;
 		if (opts.abort.aborted) return enqueued;
-		opts.queue.enqueue({
-			kind: "session_push",
-			local_session_id: session.localSessionId,
-			content_hash: hash,
-			api_origin: fence.apiOrigin,
-			environment_id: fence.environmentId,
-			adapter: fence.adapter,
-			source_session_key: fence.sourceSessionKey,
-			enqueued_at: new Date().toISOString(),
-			attempts: 0,
-		});
+		const version = await opts.queue.enqueueWhenAvailable(
+			{
+				kind: "session_push",
+				local_session_id: session.localSessionId,
+				content_hash: hash,
+				api_origin: fence.apiOrigin,
+				environment_id: fence.environmentId,
+				adapter: fence.adapter,
+				source_session_key: fence.sourceSessionKey,
+				enqueued_at: new Date().toISOString(),
+				attempts: 0,
+			},
+			opts.abort,
+		);
+		if (version === null) return enqueued;
 		opts.inFlightHash.set(session.localSessionId, hash);
 		enqueued += 1;
 	}
@@ -915,39 +924,57 @@ async function prepareSessionSync(
 	const { api, queue, health, inFlightSessionHash } = common;
 	const protocol = await negotiateSessionProtocol(api, sessions);
 	const lastPushedSessionHash = loadFencedSessionHashes(api, opts);
+	for (const entry of currentFencedSessionEntries(api, opts)) {
+		if (entry.blocked) {
+			health.set(
+				"push",
+				`session:${entry.source_session_key}`,
+				`blocked: ${entry.blocked.message}`,
+			);
+		}
+	}
+	let pendingScan: SessionScanRequest | null = null;
+	let activeScan: Promise<void> | null = null;
 
-	const onSessionsStable = async (event?: SessionWatchEvent): Promise<void> => {
+	const executeScan = async (request: SessionScanRequest): Promise<void> => {
 		if (opts.abort.aborted) return;
 		try {
-			const request: SessionScanRequest = event?.kind === "paths" ? event : { kind: "complete" };
-			const result = await sessions.collect(request);
-			const enqueued = await enqueueChangedSessionsAfterStability({
-				abort: opts.abort,
-				sessions: result.sessions,
-				queue,
-				lastPushedHash: lastPushedSessionHash,
-				inFlightHash: inFlightSessionHash,
-				protocol,
-				fenceFor: (session) =>
-					sessionFence(api, {
-						environmentId: opts.environmentId,
-						adapter: opts.adapter.agentType,
-						sourceSessionKey: session.localSessionId,
-					}),
-				onBlocked: (session, message) => {
-					health.set("push", `session:${session.localSessionId}`, `blocked: ${message}`);
-					lastPushedSessionHash.set(
-						session.localSessionId,
-						planSessionUpload(session, protocol).localHash,
-					);
-				},
-			});
-			if (result.coverage === "complete") {
-				health.clearAbsent(
-					"push",
-					"session:",
-					new Set(result.sessions.map((session) => `session:${session.localSessionId}`)),
-				);
+			const scan = await scanSessionModule(
+				sessions,
+				request,
+				loadFencedSessionSourceRevisions(api, opts, protocol),
+			);
+			const observedResources = new Set<string>();
+			let enqueued = 0;
+			for await (const batch of scan.batches) {
+				for (const localSessionId of batch.observedLocalSessionIds) {
+					observedResources.add(`session:${localSessionId}`);
+				}
+				enqueued += await enqueueChangedSessionsAfterStability({
+					abort: opts.abort,
+					sessions: batch.sessions,
+					queue,
+					lastPushedHash: lastPushedSessionHash,
+					inFlightHash: inFlightSessionHash,
+					protocol,
+					fenceFor: (session) =>
+						sessionFence(api, {
+							environmentId: opts.environmentId,
+							adapter: opts.adapter.agentType,
+							sourceSessionKey: session.localSessionId,
+						}),
+					onBlocked: (session, message) => {
+						health.set("push", `session:${session.localSessionId}`, `blocked: ${message}`);
+						lastPushedSessionHash.set(
+							session.localSessionId,
+							planSessionUpload(session, protocol).localHash,
+						);
+					},
+				});
+				if (opts.abort.aborted) return;
+			}
+			if (scan.coverage === "complete") {
+				health.clearAbsent("push", "session:", observedResources);
 			}
 			health.clear("push", "session_scan");
 			if (enqueued > 0) log.info("engine.sessions_enqueued", { count: enqueued });
@@ -958,24 +985,50 @@ async function prepareSessionSync(
 		}
 	};
 
-	await onSessionsStable();
+	const mergeScanRequest = (
+		current: SessionScanRequest | null,
+		next: SessionScanRequest,
+	): SessionScanRequest => {
+		if (!current || current.kind === "complete" || next.kind === "complete") {
+			return current?.kind === "complete" ? current : next;
+		}
+		return { kind: "paths", paths: [...new Set([...current.paths, ...next.paths])] };
+	};
+	const requestScan = (event?: SessionWatchEvent): Promise<void> => {
+		const request: SessionScanRequest = event?.kind === "paths" ? event : { kind: "complete" };
+		pendingScan = mergeScanRequest(pendingScan, request);
+		if (!activeScan) {
+			activeScan = (async () => {
+				while (pendingScan && !opts.abort.aborted) {
+					const next = pendingScan;
+					pendingScan = null;
+					await executeScan(next);
+				}
+			})().finally(() => {
+				activeScan = null;
+			});
+		}
+		return activeScan;
+	};
+
 	return {
 		queueModule: { module: sessions, protocol },
 		lastPushedHash: lastPushedSessionHash,
 		run: async () => {
 			await Promise.all([
+				requestScan(),
 				watchSessions({
 					paths: sessions.watchPaths(),
 					abort: opts.abort,
 					onPathStable: (change) => {
-						if (!opts.abort.aborted) void onSessionsStable(change);
+						if (!opts.abort.aborted) void requestScan(change);
 					},
 					forcePoll: opts.forcePollWatcher,
 				}),
 				(async () => {
 					while (!opts.abort.aborted) {
 						await sleep(RECONCILE_INTERVAL_MS, opts.abort);
-						if (!opts.abort.aborted) await onSessionsStable();
+						if (!opts.abort.aborted) await requestScan();
 					}
 				})(),
 			]);
@@ -995,20 +1048,39 @@ async function runSessionSync(
 
 function loadFencedSessionHashes(api: ApiClient, opts: EngineOpts): Map<string, string> {
 	const hashes = new Map<string, string>();
-	const lock = readSessionsLock();
-	if (lock.version !== 2) return hashes;
-	for (const value of Object.values(lock.sessions)) {
-		if (
-			"local_hash" in value &&
-			value.api_origin === canonicalApiOrigin(api.baseUrl) &&
-			value.environment_id === opts.environmentId &&
-			value.adapter === opts.adapter.agentType &&
-			value.pending === undefined
-		) {
+	for (const value of currentFencedSessionEntries(api, opts)) {
+		if (value.pending === undefined) {
 			hashes.set(value.source_session_key, value.local_hash);
 		}
 	}
 	return hashes;
+}
+
+function loadFencedSessionSourceRevisions(
+	api: ApiClient,
+	opts: EngineOpts,
+	protocol: SelectedSessionProtocol,
+): Map<string, string> {
+	const revisions = new Map<string, string>();
+	for (const value of currentFencedSessionEntries(api, opts)) {
+		if (value.protocol === protocol && value.pending === undefined && value.source_revision) {
+			revisions.set(value.source_session_key, value.source_revision);
+		}
+	}
+	return revisions;
+}
+
+function currentFencedSessionEntries(api: ApiClient, opts: EngineOpts): FencedSessionLockEntry[] {
+	const lock = readSessionsLock();
+	if (lock.version !== 2) return [];
+	const apiOrigin = canonicalApiOrigin(api.baseUrl);
+	return Object.values(lock.sessions).filter(
+		(value): value is FencedSessionLockEntry =>
+			"local_hash" in value &&
+			value.api_origin === apiOrigin &&
+			value.environment_id === opts.environmentId &&
+			value.adapter === opts.adapter.agentType,
+	);
 }
 
 function enqueueMaterializedSkillClaimCleanup(
@@ -1753,7 +1825,7 @@ async function uploadSessionFromQueue(
 
 	const suppressed = result.suppressed?.includes(session.localSessionId) ?? false;
 	if (suppressed) {
-		persistSuppressedSession(fence, plan);
+		persistSuppressedSession(fence, session, plan);
 	} else {
 		const content = await syncSessionContent({
 			api,

--- a/packages/cli/tests/adapters/hermes.test.ts
+++ b/packages/cli/tests/adapters/hermes.test.ts
@@ -293,13 +293,7 @@ describe("HermesAdapter.collectSessions", () => {
 		for await (const batch of changed.batches) {
 			changedIds.push(...batch.sessions.map((session) => session.localSessionId));
 		}
-		expect(changedIds.sort()).toEqual([
-			"bulk-00",
-			"bulk-01",
-			"bulk-02",
-			"bulk-03",
-			"bulk-04",
-		]);
+		expect(changedIds.sort()).toEqual(["bulk-00", "bulk-01", "bulk-02", "bulk-03", "bulk-04"]);
 	});
 
 	it("uses events-v1 with stable ids when newer optional message columns are absent", async () => {

--- a/packages/cli/tests/adapters/hermes.test.ts
+++ b/packages/cli/tests/adapters/hermes.test.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { scanSessionModule } from "../../src/adapters/base";
 import { HermesAdapter } from "../../src/adapters/hermes";
 import { tarSkillDir } from "../../src/lib/tar";
 import { reserveManagedSkill } from "../../src/runtime/managed-skill-reservation";
@@ -224,6 +225,67 @@ describe("HermesAdapter.collectSessions", () => {
 			type: "message",
 			source: { adapter: "hermes", record_id: "13", record_seq: 13 },
 		});
+	});
+
+	it("scans large stores in bounded batches and expands only revised sessions", async () => {
+		const db = new Database(join(tmpHome, ".hermes", "state.db"));
+		for (let index = 0; index < 40; index++) {
+			const id = `bulk-${String(index).padStart(2, "0")}`;
+			db.run(
+				"INSERT INTO sessions (id, source, title, started_at, message_count) VALUES (?, 'cron', ?, ?, 1)",
+				id,
+				`Bulk ${index}`,
+				1776247000,
+			);
+			db.run(
+				"INSERT INTO messages (session_id, role, content, timestamp, active, compacted) VALUES (?, 'user', ?, ?, 1, 0)",
+				id,
+				`Message ${index}`,
+				1776247000,
+			);
+		}
+		db.close();
+
+		const adapter = new HermesAdapter();
+		const initial = await scanSessionModule(adapter.sessions, { kind: "complete" });
+		const revisions = new Map<string, string>();
+		const initialBatchSizes: number[] = [];
+		for await (const batch of initial.batches) {
+			initialBatchSizes.push(batch.observedLocalSessionIds.length);
+			for (const session of batch.sessions) {
+				if (!session.sourceRevision) throw new Error("expected Hermes source revision");
+				revisions.set(session.localSessionId, session.sourceRevision);
+			}
+		}
+		expect(initialBatchSizes).toEqual([32, 9]);
+		expect(revisions.size).toBe(41);
+
+		const unchanged = await scanSessionModule(adapter.sessions, { kind: "complete" }, revisions);
+		let observed = 0;
+		let expanded = 0;
+		for await (const batch of unchanged.batches) {
+			observed += batch.observedLocalSessionIds.length;
+			expanded += batch.sessions.length;
+		}
+		expect({ observed, expanded }).toEqual({ observed: 41, expanded: 0 });
+
+		const changedDb = new Database(join(tmpHome, ".hermes", "state.db"));
+		changedDb.run(
+			"INSERT INTO messages (session_id, role, content, timestamp, active, compacted) VALUES ('bulk-00', 'assistant', 'Changed', 1776247001, 1, 0)",
+		);
+		changedDb.run("UPDATE sessions SET title = 'Renamed' WHERE id = 'bulk-01'");
+		changedDb.run(
+			`UPDATE messages SET display_kind = 'auto_continue', display_metadata = '{"attempt":2}'
+			 WHERE session_id = 'bulk-02'`,
+		);
+		changedDb.run("UPDATE messages SET content = 'M' WHERE session_id = 'bulk-03'");
+		changedDb.close();
+		const changed = await scanSessionModule(adapter.sessions, { kind: "complete" }, revisions);
+		const changedIds: string[] = [];
+		for await (const batch of changed.batches) {
+			changedIds.push(...batch.sessions.map((session) => session.localSessionId));
+		}
+		expect(changedIds.sort()).toEqual(["bulk-00", "bulk-01", "bulk-02", "bulk-03"]);
 	});
 
 	it("uses events-v1 with stable ids when newer optional message columns are absent", async () => {

--- a/packages/cli/tests/adapters/hermes.test.ts
+++ b/packages/cli/tests/adapters/hermes.test.ts
@@ -244,6 +244,9 @@ describe("HermesAdapter.collectSessions", () => {
 				1776247000,
 			);
 		}
+		db.run(
+			"INSERT INTO messages (session_id, role, content, timestamp, active, compacted) VALUES ('bulk-04', 'assistant', 'Reply', 1776247001, 1, 0)",
+		);
 		db.close();
 
 		const adapter = new HermesAdapter();
@@ -279,13 +282,24 @@ describe("HermesAdapter.collectSessions", () => {
 			 WHERE session_id = 'bulk-02'`,
 		);
 		changedDb.run("UPDATE messages SET content = 'M' WHERE session_id = 'bulk-03'");
+		changedDb.run(
+			`UPDATE messages
+			 SET content = CASE role WHEN 'user' THEN 'Short' ELSE 'Message 4' END
+			 WHERE session_id = 'bulk-04'`,
+		);
 		changedDb.close();
 		const changed = await scanSessionModule(adapter.sessions, { kind: "complete" }, revisions);
 		const changedIds: string[] = [];
 		for await (const batch of changed.batches) {
 			changedIds.push(...batch.sessions.map((session) => session.localSessionId));
 		}
-		expect(changedIds.sort()).toEqual(["bulk-00", "bulk-01", "bulk-02", "bulk-03"]);
+		expect(changedIds.sort()).toEqual([
+			"bulk-00",
+			"bulk-01",
+			"bulk-02",
+			"bulk-03",
+			"bulk-04",
+		]);
 	});
 
 	it("uses events-v1 with stable ids when newer optional message columns are absent", async () => {


### PR DESCRIPTION
## Summary
- scan monolithic Hermes session stores in bounded keyset-paginated batches
- persist lightweight upstream-aware source revisions so unchanged transcripts are not materialized
- backfill revisions into matching pre-upgrade lock entries in one write per scan
- apply queue backpressure during inventory reconciliation instead of evicting session work

## Correctness
- follows current upstream Hermes append/replace, lifecycle, presentation metadata, and content-clearing write paths
- computes per-message byte lengths with SQLite `octet_length`, avoiding transcript overflow-page reads during steady-state scans
- leaves legacy schemas without stable message IDs on the conservative full-materialization path
- does not modify Hermes, its database, runtime configuration, or channel authorization

## Verification
- isolated affected suite: 104 passed, 0 failed, with CLI typecheck
- isolated full CLI suite on the core patch: 1675 passed, 4 skipped, 0 failed
- Node 24 native SQLite probe, Biome, and git diff check passed
- read-only production-shape scan: 8394 sessions in 6.223s; about 9.9MB total lightweight revision data, 30KB maximum for one session