### PR TITLE
fix(backend): make session cleanup cancellation-safe

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -14,6 +16,8 @@ from app.services.metrics import (
     db_pool_checked_out,
     db_query_duration,
 )
+
+log = logging.getLogger(__name__)
 
 _QUERY_STARTED_AT = "clawdi_query_started_at"
 _CONNECTION_CHECKED_OUT_AT = "clawdi_connection_checked_out_at"
@@ -105,9 +109,36 @@ event.listen(engine.sync_engine.pool, "checkin", _connection_checkin)
 async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
 
 
+async def _close_session(session: AsyncSession) -> None:
+    """Return the connection before propagating request cancellation."""
+    close_task = asyncio.create_task(session.close())
+    cancellation: asyncio.CancelledError | None = None
+    while not close_task.done():
+        try:
+            await asyncio.shield(close_task)
+        except asyncio.CancelledError as exc:
+            cancellation = exc
+        except Exception:
+            if cancellation is None:
+                raise
+            log.exception("Database session cleanup failed during request cancellation")
+            raise cancellation from None
+
+    if cancellation is not None:
+        try:
+            close_task.result()
+        except Exception:
+            log.exception("Database session cleanup failed during request cancellation")
+        raise cancellation
+    close_task.result()
+
+
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
-    async with async_session_factory() as session:
+    session = async_session_factory()
+    try:
         yield session
+    finally:
+        await _close_session(session)
 
 
 async def get_runtime_observation_session() -> AsyncGenerator[AsyncSession, None]:
@@ -119,17 +150,23 @@ async def get_runtime_observation_session() -> AsyncGenerator[AsyncSession, None
     cannot be PostgreSQL read-only.
     """
 
-    async with async_session_factory() as session:
+    session = async_session_factory()
+    try:
         await session.connection(execution_options={"isolation_level": "REPEATABLE READ"})
         yield session
+    finally:
+        await _close_session(session)
 
 
 @asynccontextmanager
 async def runtime_snapshot_session() -> AsyncGenerator[AsyncSession, None]:
     """Open the consistent read-only snapshot shared by runtime renderers."""
-    async with async_session_factory() as session:
+    session = async_session_factory()
+    try:
         await _configure_runtime_snapshot(session)
         yield session
+    finally:
+        await _close_session(session)
 
 
 async def _configure_runtime_snapshot(session: AsyncSession) -> None:

--- a/backend/tests/test_database_session_cleanup.py
+++ b/backend/tests/test_database_session_cleanup.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.core import database
+
+
+class _BlockingSession:
+    def __init__(self) -> None:
+        self.close_started = asyncio.Event()
+        self.close_release = asyncio.Event()
+        self.closed = asyncio.Event()
+
+    async def __aenter__(self) -> _BlockingSession:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        close_task = asyncio.create_task(self.close())
+        await asyncio.shield(close_task)
+
+    async def close(self) -> None:
+        self.close_started.set()
+        await self.close_release.wait()
+        self.closed.set()
+
+
+async def test_cancelled_dependency_waits_for_session_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _BlockingSession()
+    monkeypatch.setattr(database, "async_session_factory", lambda: session)
+    dependency = database.get_session()
+    assert await anext(dependency) is session
+
+    cleanup = asyncio.create_task(dependency.aclose())
+    await session.close_started.wait()
+    cleanup.cancel()
+    await asyncio.sleep(0)
+
+    assert not cleanup.done()
+    session.close_release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await cleanup
+    assert session.closed.is_set()


### PR DESCRIPTION
## Summary

- close request and runtime snapshot database sessions in a shielded task
- wait for connection cleanup before propagating request cancellation
- preserve the original cancellation while logging cleanup failures
- add a focused regression test for cancellation during session close

## Root cause

SQLAlchemy `AsyncSession.__aexit__` propagates outer request cancellation before its shielded close task is guaranteed to finish. Under disconnected requests this occasionally leaves asyncpg connections checked out until garbage collection terminates them.

## Verification

- `bash scripts/test.sh backend tests/test_database_session_cleanup.py tests/test_database_timeouts.py tests/test_metrics.py` (`12 passed`)
- agent verification: Ruff, format check, and BasedPyright passed

The observed steady API CPU and SQL rate are expected workload from authority checks and runtime synchronization; this change deliberately does not weaken authorization consistency or add speculative caching.