### PR TITLE
fix(web): complete Pi and OpenCode connected support

### DIFF
--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -56,7 +56,7 @@ If it prints "Still waiting for approval" (exit code 2), the user hasn't clicked
 clawdi setup
 ```
 
-Auto-detects every installed AI agent (Claude Code, Codex, Hermes, OpenClaw, Pi), registers each with the cloud, configures only the local modules each agent supports, and installs background sync daemons by default. Pi syncs Sessions only and receives no Skill or MCP installation. Without an `--agent` flag it picks up everything detected — which is what you want, so later sync steps can cover all of them.
+Auto-detects every installed AI agent (Claude Code, Codex, Hermes, OpenClaw, Pi, and OpenCode), registers each with the cloud, configures only the local modules each agent supports, and installs background sync daemons by default. Pi and OpenCode sync Sessions only; neither receives Skill or MCP installation. Without an `--agent` flag it picks up everything detected — which is what you want, so later sync steps can cover all of them.
 
 ## Sync the user's sessions
 

--- a/apps/web/src/components/agent-framework-icon.test.tsx
+++ b/apps/web/src/components/agent-framework-icon.test.tsx
@@ -9,6 +9,8 @@ const FRAMEWORKS = {
 	hermes: { label: "Hermes Agent", size: "75%" },
 	"claude-code": { label: "Claude Code", size: "70%" },
 	codex: { label: "Codex", size: "70%" },
+	pi: { label: "Pi", size: "65%" },
+	opencode: { label: "OpenCode", size: "75%" },
 } as const;
 
 describe("AgentFrameworkIcon", () => {
@@ -23,7 +25,7 @@ describe("AgentFrameworkIcon", () => {
 			expect(markup).toContain("<svg");
 			expect(markup).toContain('role="img"');
 			expect(markup).toContain(`aria-label="${label}"`);
-			expect(markup).toContain(`<title>${label}</title>`);
+			expect(markup).toContain(`<title>${id === "opencode" ? "opencode" : label}</title>`);
 			expect(markup).toContain('data-icon-source="lobehub"');
 			expect(markup).toContain(`width="${size}"`);
 			expect(markup).toContain(`height="${size}"`);
@@ -42,6 +44,16 @@ describe("AgentFrameworkIcon", () => {
 		);
 		expect(markup).toContain("bg-white");
 		expect(markup).toContain("text-black");
+	});
+
+	test("keeps the official Pi and OpenCode white marks on black avatar tiles", () => {
+		for (const agent of ["pi", "opencode"]) {
+			const markup = renderToStaticMarkup(
+				<AgentFrameworkIcon agent={agent} pixelSize={40} boxClassName="size-10" />,
+			);
+			expect(markup).toContain("bg-black");
+			expect(markup).toContain("text-white");
+		}
 	});
 
 	test("keeps colored framework marks on the shared neutral tile without forced dark backplates", () => {

--- a/apps/web/src/components/dashboard/add-agent-dialog.tsx
+++ b/apps/web/src/components/dashboard/add-agent-dialog.tsx
@@ -19,7 +19,8 @@ export function AddAgentDialog({ open, onClose }: { open: boolean; onClose: () =
 				<DialogHeader>
 					<DialogTitle>Add an Agent</DialogTitle>
 					<DialogDescription>
-						Connect an Agent on your machine — Claude Code, Codex, Hermes, or OpenClaw.
+						Connect an Agent on your machine — Claude Code, Codex, Hermes, OpenClaw, Pi, or
+						OpenCode.
 					</DialogDescription>
 				</DialogHeader>
 				<AddAgentSetup />

--- a/apps/web/src/components/dashboard/add-agent-setup.tsx
+++ b/apps/web/src/components/dashboard/add-agent-setup.tsx
@@ -39,7 +39,7 @@ const CLI_STEPS = [
 		title: "Connect and enable sync",
 		code: "clawdi setup",
 		description:
-			"Detects Claude Code, Codex, Hermes, and OpenClaw; connects each one to your account and enables background sync.",
+			"Detects Claude Code, Codex, Hermes, OpenClaw, Pi, and OpenCode; connects each one to your account and enables background sync.",
 	},
 ];
 
@@ -141,7 +141,8 @@ export function AddAgentSetup() {
 					<div>
 						<p className="text-sm font-medium">Ask your agent to set up Clawdi</p>
 						<p className="mt-1 text-xs text-muted-foreground">
-							Paste this prompt into Claude Code, Codex, Hermes, or OpenClaw on the machine.
+							Paste this prompt into Claude Code, Codex, Hermes, OpenClaw, Pi, or OpenCode on the
+							machine.
 						</p>
 					</div>
 					<div className="rounded-lg border bg-muted/30">

--- a/apps/web/src/components/dashboard/agent-onboarding.test.ts
+++ b/apps/web/src/components/dashboard/agent-onboarding.test.ts
@@ -5,6 +5,10 @@ const onboardingSource = readFileSync(new URL("./onboarding-card.tsx", import.me
 const setupSource = readFileSync(new URL("./add-agent-setup.tsx", import.meta.url), "utf8");
 const dialogSource = readFileSync(new URL("./add-agent-dialog.tsx", import.meta.url), "utf8");
 const newAgentSource = readFileSync(new URL("./new-agent-button.tsx", import.meta.url), "utf8");
+const publicSkillSource = readFileSync(
+	new URL("../../../public/skill.md", import.meta.url),
+	"utf8",
+);
 const hostedSectionSource = readFileSync(
 	new URL("../../hosted/hosted-agents-section.tsx", import.meta.url),
 	"utf8",
@@ -67,6 +71,24 @@ describe("dashboard agent onboarding", () => {
 });
 
 describe("connected-agent setup paths", () => {
+	test("lists every CLI-connected agent without implying hosted deployment support", () => {
+		expect(setupSource).toContain("Detects Claude Code, Codex, Hermes, OpenClaw, Pi, and OpenCode");
+		expect(setupSource).toContain(
+			"Paste this prompt into Claude Code, Codex, Hermes, OpenClaw, Pi, or OpenCode",
+		);
+		expect(dialogSource).toContain(
+			"Connect an Agent on your machine — Claude Code, Codex, Hermes, OpenClaw, Pi, or",
+		);
+		expect(dialogSource).toContain("OpenCode.");
+		expect(newAgentSource).toContain(
+			"Claude Code, Codex, Hermes, OpenClaw, Pi, or OpenCode via the CLI.",
+		);
+		expect(publicSkillSource).toContain("Claude Code, Codex, Hermes, OpenClaw, Pi, and OpenCode");
+		expect(publicSkillSource).toContain(
+			"Pi and OpenCode sync Sessions only; neither receives Skill or MCP installation.",
+		);
+	});
+
 	test("defaults to sequential npm commands with per-step copy controls", () => {
 		expect(setupSource).toContain('<Tabs defaultValue="commands">');
 		expect(setupSource).toContain('<TabsTrigger value="commands">');

--- a/apps/web/src/components/dashboard/new-agent-button.tsx
+++ b/apps/web/src/components/dashboard/new-agent-button.tsx
@@ -123,7 +123,7 @@ export function NewAgentButton({
 						<ChoiceCard
 							icon={<TerminalSquare />}
 							title="Connect an Agent on your machine"
-							description="Claude Code, Codex, Hermes, or OpenClaw via the CLI."
+							description="Claude Code, Codex, Hermes, OpenClaw, Pi, or OpenCode via the CLI."
 							onClick={chooseConnect}
 						/>
 					</div>

--- a/apps/web/src/components/entity-brand-icon-ids.ts
+++ b/apps/web/src/components/entity-brand-icon-ids.ts
@@ -1,4 +1,11 @@
-export const FRAMEWORK_BRAND_ICON_IDS = ["openclaw", "hermes", "claude-code", "codex"] as const;
+export const FRAMEWORK_BRAND_ICON_IDS = [
+	"openclaw",
+	"hermes",
+	"claude-code",
+	"codex",
+	"pi",
+	"opencode",
+] as const;
 export type FrameworkBrandIconId = (typeof FRAMEWORK_BRAND_ICON_IDS)[number];
 
 export const PROVIDER_BRAND_ICON_IDS = [

--- a/apps/web/src/components/entity-brand-icons.ts
+++ b/apps/web/src/components/entity-brand-icons.ts
@@ -11,7 +11,9 @@ import Minimax from "@lobehub/icons/es/Minimax/components/Color.js";
 import Mistral from "@lobehub/icons/es/Mistral/components/Color.js";
 import OpenAI from "@lobehub/icons/es/OpenAI/components/Mono.js";
 import OpenClaw from "@lobehub/icons/es/OpenClaw/components/Color.js";
+import OpenCode from "@lobehub/icons/es/OpenCode/components/Mono.js";
 import OpenRouter from "@lobehub/icons/es/OpenRouter/components/Color.js";
+import Pi from "@lobehub/icons/es/Pi/components/Mono.js";
 import Qwen from "@lobehub/icons/es/Qwen/components/Color.js";
 import Stepfun from "@lobehub/icons/es/Stepfun/components/Mono.js";
 import Together from "@lobehub/icons/es/Together/components/Color.js";
@@ -44,6 +46,20 @@ const FRAMEWORK_BRAND_ICON_DEFINITIONS = {
 		label: "Claude Code",
 	},
 	codex: { icon: Codex, iconScale: 0.7, label: "Codex", tileClassName: "bg-white" },
+	pi: {
+		icon: Pi,
+		iconClassName: "text-white",
+		iconScale: 0.65,
+		label: "Pi",
+		tileClassName: "bg-black",
+	},
+	opencode: {
+		icon: OpenCode,
+		iconClassName: "text-white",
+		iconScale: 0.75,
+		label: "OpenCode",
+		tileClassName: "bg-black",
+	},
 } satisfies Readonly<Record<FrameworkBrandIconId, BrandIconMetadata>>;
 
 const FRAMEWORK_BRAND_ICONS: Readonly<Record<string, BrandIconMetadata>> = {

--- a/apps/web/src/components/entity-icon.test.tsx
+++ b/apps/web/src/components/entity-icon.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import { FRAMEWORK_BRAND_ICON_IDS } from "@/components/entity-brand-icon-ids";
+import { frameworkBrandIcon } from "@/components/entity-brand-icons";
 import { EntityIcon } from "@/components/entity-icon";
 
 const SIZES = ["sm", "md", "lg"] as const;
@@ -17,9 +18,7 @@ describe("EntityIcon LobeHub brands", () => {
 				const expectedIconSize =
 					kindAndId.kind === "provider"
 						? "84%"
-						: kindAndId.id === "openclaw" || kindAndId.id === "hermes"
-							? "75%"
-							: "70%";
+						: `${(frameworkBrandIcon(kindAndId.id)?.iconScale ?? 0.84) * 100}%`;
 				expect(markup).toContain(`width="${expectedIconSize}"`);
 				expect(markup).toContain(`height="${expectedIconSize}"`);
 			}

--- a/apps/web/src/hosted/v2/ai-providers/provider-ui-consistency.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-ui-consistency.test.ts
@@ -18,6 +18,8 @@ describe("AI provider icon coverage", () => {
 		expect(iconSource).toContain("@lobehub/icons/es/HermesAgent/components/Mono.js");
 		expect(iconSource).toContain("@lobehub/icons/es/ClaudeCode/components/Color.js");
 		expect(iconSource).toContain("@lobehub/icons/es/Codex/components/Inner.js");
+		expect(iconSource).toContain("@lobehub/icons/es/Pi/components/Mono.js");
+		expect(iconSource).toContain("@lobehub/icons/es/OpenCode/components/Mono.js");
 		expect(viteSource).toContain('noExternal: ["@lobehub/icons"]');
 		expect(viteSource).not.toContain("noExternal: [/^@lobehub");
 		expect(viteSource).not.toContain("optimizeDeps");

--- a/packages/cli/tests/commands/setup.test.ts
+++ b/packages/cli/tests/commands/setup.test.ts
@@ -46,6 +46,7 @@ const ENV_KEYS = [
 	"CLAWDI_SERVE_DEBUG",
 	"HERMES_TEST_MCP_TOKEN",
 	"PI_CODING_AGENT_DIR",
+	"XDG_DATA_HOME",
 ] as const;
 
 let envSnapshot: Partial<Record<(typeof ENV_KEYS)[number], string>> = {};
@@ -156,6 +157,22 @@ describe("setup daemon install", () => {
 		});
 		expect(existsSync(join(home, "pi-agent", "skills"))).toBe(false);
 		expect(existsSync(join(home, "pi-agent", "mcp.json"))).toBe(false);
+	});
+
+	it("registers OpenCode as sessions-only without installing Skill or MCP state", async () => {
+		const { captured } = installEnvironmentMock("env-opencode");
+		process.env.XDG_DATA_HOME = join(home, "xdg-data");
+
+		await setup({ agent: "opencode", yes: true, daemon: false });
+
+		const registration = captured.find((req) => req.method === "POST" && req.path === "/v1/agents");
+		expect(registration?.body).toMatchObject({
+			agent_type: "opencode",
+			adapter_modules: ["sessions"],
+		});
+		const openCodeHome = join(home, "xdg-data", "opencode");
+		expect(existsSync(join(openCodeHome, "skills"))).toBe(false);
+		expect(existsSync(join(openCodeHome, "mcp.json"))).toBe(false);
 	});
 
 	it("defaults to installing one daemon unit for all registered agents", async () => {


### PR DESCRIPTION
## Summary

- render Pi and OpenCode with their official LobeHub framework marks
- list both sessions-only adapters throughout Connected-agent onboarding and setup guidance
- cover OpenCode setup registration and capability boundaries

## Verification

- Docker clean runner: Web typecheck, focused tests (22 pass, 352 assertions), and OSS production build
- Docker clean runner: CLI typecheck and setup tests (18 pass, 49 assertions)
- Biome check on touched TypeScript/TSX files
- git diff --check

## Scope

Pi and OpenCode remain Connected, Sessions-only adapters. Hosted runtime support remains limited to Hermes and OpenClaw.