### PR TITLE
refactor(search): standardize hybrid retrieval

### DIFF
--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -507,12 +507,7 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 	await expect.poll(() => requestedOffsets.size).toBeGreaterThan(0);
 	for (let attempt = 0; attempt < 8 && requestedOffsets.size < 5; attempt++) {
 		const requestCount = requestedOffsets.size;
-		const loadMore = page.getByRole("button", { name: /^Load more \(/ });
-		if (await loadMore.isVisible()) {
-			await loadMore.click();
-		} else {
-			await scrollContainer.evaluate((element) => element.scrollTo({ top: element.scrollHeight }));
-		}
+		await scrollContainer.evaluate((element) => element.scrollTo({ top: element.scrollHeight }));
 		await expect.poll(() => requestedOffsets.size).toBeGreaterThan(requestCount);
 	}
 	expect([...requestedOffsets].sort((left, right) => left - right)).toEqual([

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -12,6 +12,7 @@ import {
 	Sparkles,
 } from "lucide-react";
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { SearchHighlightedText } from "@/components/search-highlighted-text";
 import { SessionSearchMatchExcerpt } from "@/components/sessions/search-match-excerpt";
 import { TruncatedText } from "@/components/truncated-text";
 import {
@@ -229,6 +230,7 @@ function CommandPalette({
 	// Whether we have a stale results payload we can keep showing while a
 	// new debounced query is in flight.
 	const hasStaleResults = hasQuery && (data?.results.length ?? 0) > 0;
+	const resultQuery = data?.query ?? debounced;
 
 	// Show "no results" only when (a) the debounced query is active, (b)
 	// fetching is finished, (c) we don't have any results. Previously we
@@ -317,11 +319,13 @@ function CommandPalette({
 												>
 													<Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
 													<div className={COMMAND_RESULT_TEXT_CLASS}>
-														<TruncatedText>{hit.title}</TruncatedText>
+														<TruncatedText title={hit.title}>
+															<SearchHighlightedText text={hit.title} query={resultQuery} />
+														</TruncatedText>
 														{hit.type === "session" && hit.search_match ? (
 															<SessionSearchMatchExcerpt
 																match={hit.search_match}
-																query={data?.query ?? debounced}
+																query={resultQuery}
 																className="line-clamp-2 text-xs leading-4 text-muted-foreground"
 															/>
 														) : hit.subtitle ? (

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -119,6 +119,7 @@ function CommandPalette({
 	const hostedAccess = useProductAccess();
 	const [query, setQuery] = useState("");
 	const debounced = useDebouncedValue(query, 180);
+	const searchQuery = debounced.trim();
 	const navShortcuts = useMemo(() => {
 		const shortcuts: NavShortcut[] = consoleCommandPaletteItems(false).map((item) => ({
 			label: item.label,
@@ -155,9 +156,9 @@ function CommandPalette({
 	const { data, isFetching } = api.useQuery(
 		"get",
 		"/v1/search",
-		{ params: { query: { q: debounced } } },
+		{ params: { query: { q: searchQuery } } },
 		{
-			enabled: open && debounced.trim().length > 0,
+			enabled: open && searchQuery.length > 0,
 			staleTime: 30_000,
 			// Keep the last page of results visible while a new debounced query
 			// flies out — prevents the palette flashing to "empty" on every
@@ -217,8 +218,8 @@ function CommandPalette({
 		return g;
 	}, [data]);
 
-	const hasQuery = debounced.trim().length > 0;
-	const normalizedQuery = debounced.trim().toLowerCase();
+	const hasQuery = searchQuery.length > 0;
+	const normalizedQuery = searchQuery.toLowerCase();
 	const navMatches = useMemo(
 		() =>
 			normalizedQuery
@@ -230,7 +231,7 @@ function CommandPalette({
 	// Whether we have a stale results payload we can keep showing while a
 	// new debounced query is in flight.
 	const hasStaleResults = hasQuery && (data?.results.length ?? 0) > 0;
-	const resultQuery = data?.query ?? debounced;
+	const resultQuery = data?.query ?? searchQuery;
 
 	// Show "no results" only when (a) the debounced query is active, (b)
 	// fetching is finished, (c) we don't have any results. Previously we
@@ -266,7 +267,7 @@ function CommandPalette({
 				{/* Fixed min-height: stops the dialog from jumping as the user types
 				    (switching between 6 nav shortcuts → N result rows → empty). */}
 				<CommandList className="min-h-[320px]">
-					{showEmpty ? <CommandEmpty>No results for "{debounced}".</CommandEmpty> : null}
+					{showEmpty ? <CommandEmpty>No results for "{searchQuery}".</CommandEmpty> : null}
 
 					{/* First-fetch state: query typed but no prior data yet — show a
 					    neutral loading row inside the list so the dialog isn't

--- a/apps/web/src/components/memories/memories-surface.tsx
+++ b/apps/web/src/components/memories/memories-surface.tsx
@@ -114,6 +114,7 @@ function MemoriesSurfaceBody({ scope }: { scope: ResourceNavigationScope }) {
 	const page = params.page;
 	const pageSize = params.pageSize;
 	const debouncedSearch = useDebouncedValue(search, 250);
+	const searchQuery = debouncedSearch.trim();
 	const apiCategory = category === ALL ? "" : category;
 
 	const { data: settings } = useQuery({
@@ -147,7 +148,7 @@ function MemoriesSurfaceBody({ scope }: { scope: ResourceNavigationScope }) {
 				query: {
 					page,
 					page_size: pageSize,
-					q: debouncedSearch || undefined,
+					q: searchQuery || undefined,
 					category: apiCategory || undefined,
 				},
 			},
@@ -170,7 +171,7 @@ function MemoriesSurfaceBody({ scope }: { scope: ResourceNavigationScope }) {
 	);
 
 	const emptyMessage =
-		debouncedSearch || apiCategory
+		searchQuery || apiCategory
 			? "No matches — try a different search or category."
 			: "No memories yet. Create one above, or your Agents will create them automatically as they work.";
 	const paginationFooter = (
@@ -243,7 +244,7 @@ function MemoriesSurfaceBody({ scope }: { scope: ResourceNavigationScope }) {
 						emptyMessage={emptyMessage}
 						onDelete={requestDeleteMemory}
 						scope={scope}
-						searchQuery={debouncedSearch}
+						searchQuery={searchQuery}
 					/>
 					{paginationFooter}
 				</div>

--- a/apps/web/src/components/memories/memories-surface.tsx
+++ b/apps/web/src/components/memories/memories-surface.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/entity-card";
 import { ListToolbar } from "@/components/list-toolbar";
 import { memorySettingsForCache } from "@/components/memories/memory-settings-cache";
+import { SearchHighlightedText } from "@/components/search-highlighted-text";
 import { TimeTooltip } from "@/components/time-tooltip";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -58,6 +59,7 @@ import {
 	memoryDetailLink,
 	type ResourceNavigationScope,
 } from "@/lib/resource-navigation";
+import { searchExcerpt } from "@/lib/search-highlight";
 import { parseAsPositiveInt } from "@/lib/url-search-parsers";
 import { useDebouncedValue } from "@/lib/use-debounced";
 import { useSensitiveAction } from "@/lib/use-sensitive-action";
@@ -241,6 +243,7 @@ function MemoriesSurfaceBody({ scope }: { scope: ResourceNavigationScope }) {
 						emptyMessage={emptyMessage}
 						onDelete={requestDeleteMemory}
 						scope={scope}
+						searchQuery={debouncedSearch}
 					/>
 					{paginationFooter}
 				</div>
@@ -316,12 +319,14 @@ function MemoryNotesGrid({
 	emptyMessage,
 	onDelete,
 	scope,
+	searchQuery,
 }: {
 	memories: Memory[];
 	isLoading: boolean;
 	emptyMessage: ReactNode;
 	onDelete: (id: string) => Promise<unknown>;
 	scope: ResourceNavigationScope;
+	searchQuery: string;
 }) {
 	if (isLoading) {
 		const cardLineCounts = [4, 7, 3, 5, 6, 4, 8, 3, 5];
@@ -341,7 +346,13 @@ function MemoryNotesGrid({
 	return (
 		<div className={ENTITY_CARD_MASONRY_CLASS}>
 			{memories.map((memory) => (
-				<MemoryCard key={memory.id} memory={memory} onDelete={onDelete} scope={scope} />
+				<MemoryCard
+					key={memory.id}
+					memory={memory}
+					onDelete={onDelete}
+					scope={scope}
+					searchQuery={searchQuery}
+				/>
 			))}
 		</div>
 	);
@@ -351,11 +362,16 @@ export function MemoryCard({
 	memory,
 	onDelete,
 	scope,
+	searchQuery = "",
 }: {
 	memory: Memory;
 	onDelete: (id: string) => Promise<unknown>;
 	scope: ResourceNavigationScope;
+	searchQuery?: string;
 }) {
+	const visibleContent = searchQuery
+		? searchExcerpt(memory.content, searchQuery, 320)
+		: memory.content;
 	return (
 		<EntityCardChassis as="article" variant="resource" interactive>
 			<EntityCardLink
@@ -363,7 +379,9 @@ export function MemoryCard({
 				{...memoryDetailLink(scope, memory.id)}
 				ariaLabel={`Open memory: ${memoryDisplayName(memory.content)}`}
 			/>
-			<p className="line-clamp-[8] break-words pr-10 text-sm leading-relaxed">{memory.content}</p>
+			<p className="line-clamp-[8] break-words pr-10 text-sm leading-relaxed">
+				<SearchHighlightedText text={visibleContent} query={searchQuery} />
+			</p>
 			<EntityMeta
 				className="mt-3 text-xs"
 				items={[

--- a/apps/web/src/components/search-highlighted-text.tsx
+++ b/apps/web/src/components/search-highlighted-text.tsx
@@ -1,0 +1,31 @@
+import { splitSearchHighlight } from "@/lib/search-highlight";
+import { cn } from "@/lib/utils";
+
+export function SearchHighlightedText({
+	text,
+	query,
+	className,
+	markClassName,
+}: {
+	text: string;
+	query: string;
+	className?: string;
+	markClassName?: string;
+}) {
+	return (
+		<span className={className}>
+			{splitSearchHighlight(text, query).map((part, index) =>
+				part.highlighted ? (
+					<mark
+						key={`${index}:${part.text}`}
+						className={cn("rounded-sm bg-primary/15 px-0.5 text-inherit", markClassName)}
+					>
+						{part.text}
+					</mark>
+				) : (
+					part.text
+				),
+			)}
+		</span>
+	);
+}

--- a/apps/web/src/components/sessions/search-match-excerpt.tsx
+++ b/apps/web/src/components/sessions/search-match-excerpt.tsx
@@ -1,20 +1,8 @@
+import { SearchHighlightedText } from "@/components/search-highlighted-text";
 import type { SessionListItem } from "@/lib/api-schemas";
-import { splitSearchHighlight } from "@/lib/search-highlight";
 import { cn } from "@/lib/utils";
 
 type SessionSearchMatch = NonNullable<SessionListItem["search_match"]>;
-
-function HighlightedExcerpt({ excerpt, query }: { excerpt: string; query: string }) {
-	return splitSearchHighlight(excerpt, query).map((part, index) =>
-		part.highlighted ? (
-			<mark key={`${index}:${part.text}`} className="rounded-sm bg-primary/15 px-0.5 text-inherit">
-				{part.text}
-			</mark>
-		) : (
-			part.text
-		),
-	);
-}
 
 export function SessionSearchMatchExcerpt({
 	match,
@@ -29,7 +17,7 @@ export function SessionSearchMatchExcerpt({
 		<span className={cn(className)} title={match.excerpt}>
 			<span className="font-medium capitalize">{match.role}</span>
 			{": "}
-			<HighlightedExcerpt excerpt={match.excerpt} query={query} />
+			<SearchHighlightedText text={match.excerpt} query={query} />
 		</span>
 	);
 }

--- a/apps/web/src/lib/search-highlight.test.ts
+++ b/apps/web/src/lib/search-highlight.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { searchExcerpt, splitSearchHighlight } from "@/lib/search-highlight";
+
+describe("search highlighting", () => {
+	test("centers a long excerpt on the literal match", () => {
+		const excerpt = searchExcerpt(
+			`${"before ".repeat(30)}deployment handoff${" after".repeat(30)}`,
+			"deployment handoff",
+			80,
+		);
+
+		expect(excerpt).toStartWith("…");
+		expect(excerpt).toContain("deployment handoff");
+		expect(excerpt).toEndWith("…");
+	});
+
+	test("treats regex characters as literal text", () => {
+		const parts = splitSearchHighlight("Keep 100%_ready and a+b literal", "a+b");
+
+		expect(parts.filter((part) => part.highlighted)).toEqual([{ text: "a+b", highlighted: true }]);
+	});
+});

--- a/apps/web/src/lib/search-highlight.ts
+++ b/apps/web/src/lib/search-highlight.ts
@@ -7,6 +7,20 @@ function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+export function searchExcerpt(text: string, query: string, limit = 240): string {
+	const compact = text.replace(/\s+/g, " ").trim();
+	if (compact.length <= limit) return compact;
+
+	const phrase = query.trim();
+	const match = phrase ? new RegExp(escapeRegExp(phrase), "iu").exec(compact) : null;
+	if (!match) return `${compact.slice(0, Math.max(0, limit - 1)).trimEnd()}…`;
+
+	let start = Math.max(0, match.index - Math.floor(limit / 3));
+	const end = Math.min(compact.length, start + limit);
+	start = Math.max(0, end - limit);
+	return `${start > 0 ? "…" : ""}${compact.slice(start, end).trim()}${end < compact.length ? "…" : ""}`;
+}
+
 export function createSearchHighlighter(query: string) {
 	const phrase = query.trim();
 	if (!phrase) {

--- a/backend/app/core/query_utils.py
+++ b/backend/app/core/query_utils.py
@@ -20,3 +20,18 @@ def escape_like(s: str, escape_char: str = "\\") -> str:
 def like_needle(query: str) -> str:
     """Build a safe ``%query%`` ILIKE needle. Pair with ``.ilike(n, escape="\\")``."""
     return f"%{escape_like(query)}%"
+
+
+def search_excerpt(content: str, query: str, *, limit: int = 240) -> str:
+    """Return compact context around a literal, case-insensitive match."""
+    compact = " ".join(content.split())
+    if len(compact) <= limit:
+        return compact
+    phrase = query.strip()
+    match_at = compact.casefold().find(phrase.casefold()) if phrase else -1
+    if match_at < 0:
+        return f"{compact[: limit - 3]}..."
+    start = max(0, match_at - limit // 3)
+    end = min(len(compact), start + limit)
+    start = max(0, end - limit)
+    return f"{'...' if start else ''}{compact[start:end]}{'...' if end < len(compact) else ''}"

--- a/backend/app/routes/mcp_bridge.py
+++ b/backend/app/routes/mcp_bridge.py
@@ -35,6 +35,7 @@ from app.core.auth import (
 )
 from app.core.database import get_session
 from app.core.project import project_ids_visible_to, resolve_default_write_project
+from app.core.query_utils import search_excerpt
 from app.models.project import Project
 from app.models.session import AgentEnvironment, Session
 from app.models.vault import Vault, VaultItem, VaultProjectAttachment
@@ -51,6 +52,11 @@ from app.services.composio import (
 )
 from app.services.file_store import get_file_store
 from app.services.memory_provider import get_memory_provider
+from app.services.memory_recall import (
+    bump_recall_counts,
+    recall_counting_enabled,
+    recall_ids_from_hits,
+)
 from app.services.secret_detection import find_likely_secret, secret_memory_warning
 from app.services.session_content import (
     SessionContentInvalid,
@@ -59,7 +65,7 @@ from app.services.session_content import (
     session_has_uploaded_content,
 )
 from app.services.session_export import session_to_markdown
-from app.services.session_search import session_search_excerpt, session_search_matches
+from app.services.session_search import session_search_matches
 from app.services.vault_crypto import decrypt
 
 logger = logging.getLogger(__name__)
@@ -714,6 +720,8 @@ async def _tool_memory_search(
         limit=parsed.limit,
     )
     await attach_source_machines(db, auth, hits)
+    if hits and recall_counting_enabled():
+        await bump_recall_counts(auth.user_id, recall_ids_from_hits(hits))
     text = (
         "\n\n".join(f"[{item.get('category', 'fact')}] {item.get('content', '')}" for item in hits)
         if hits
@@ -790,7 +798,7 @@ async def _tool_session_search(
         model = f" · {session.model}" if session.model else ""
         message_match = ""
         if isinstance(message_content, str) and message_role in ("user", "assistant"):
-            excerpt = session_search_excerpt(message_content, parsed.query)
+            excerpt = search_excerpt(message_content, parsed.query)
             message_match = f"\n  - matched {message_role}: {excerpt}"
         lines.append(
             f"- **{summary}**{project}{model}\n"

--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -20,7 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import AuthContext, get_auth, is_scoped_api_key
 from app.core.database import get_session
 from app.core.project import project_ids_visible_to
-from app.core.query_utils import like_needle
+from app.core.query_utils import like_needle, search_excerpt
 from app.models.project import Project
 from app.models.session import AgentEnvironment, Session
 from app.models.skill import Skill
@@ -132,12 +132,12 @@ async def _search_memories(db: AsyncSession, auth: AuthContext, query: str) -> l
     )
     hits: list[SearchHit] = []
     for item in rows:
-        if hit := _memory_search_hit(item):
+        if hit := _memory_search_hit(item, query):
             hits.append(hit)
     return hits
 
 
-def _memory_search_hit(item: MemoryItem) -> SearchHit | None:
+def _memory_search_hit(item: MemoryItem, query: str) -> SearchHit | None:
     memory_id = item.get("id")
     content = item.get("content")
     category = item.get("category")
@@ -146,7 +146,7 @@ def _memory_search_hit(item: MemoryItem) -> SearchHit | None:
     return SearchHit(
         type="memory",
         id=memory_id,
-        title=content[:80] + ("…" if len(content) > 80 else ""),
+        title=search_excerpt(content, query, limit=160),
         subtitle=category if isinstance(category, str) else None,
         href=f"/memories/{memory_id}",
     )
@@ -251,7 +251,7 @@ async def _search_vaults(db: AsyncSession, auth: AuthContext, query: str) -> lis
             id=str(v.id),
             title=v.name or v.slug,
             subtitle="encrypted secrets",
-            href="/vault",
+            href=f"/vaults/{quote(v.slug, safe='')}?vault={v.id}",
         )
         for v in rows
     ]
@@ -266,7 +266,7 @@ async def global_search(
     """Run each entity searcher and concat results.
 
     Each searcher returns at most `TYPE_LIMIT` rows; total is capped at
-    4*TYPE_LIMIT which keeps the palette responsive even with noisy queries.
+    5*TYPE_LIMIT which keeps the palette responsive even with noisy queries.
 
     Sessions/skills/vaults use `ILIKE` (small tables) — memories goes through
     the hybrid provider (FTS + trgm + optional pgvector) for quality.

--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -277,6 +277,10 @@ async def global_search(
     sequentially because SQLAlchemy AsyncSession is not safe for concurrent
     operations on the same request-scoped session.
     """
+    query = q.strip()
+    if not query:
+        return SearchResponse(query=query, results=[])
+
     # Each subsource enforces the same permission boundary the direct
     # route does. Skills, sessions, and memories subqueries are
     # gated by the caller's API-permission list so a narrowly-scoped
@@ -307,7 +311,7 @@ async def global_search(
     hits: list[SearchHit] = []
     for source, searcher in jobs:
         try:
-            r = await searcher(db, auth, q)
+            r = await searcher(db, auth, query)
         except Exception as exc:
             log.warning(
                 "search source %s failed for user %s: %s",
@@ -318,4 +322,4 @@ async def global_search(
             )
             continue
         hits.extend(r)
-    return SearchResponse(query=q, results=hits)
+    return SearchResponse(query=query, results=hits)

--- a/backend/app/services/memory_provider.py
+++ b/backend/app/services/memory_provider.py
@@ -3,16 +3,16 @@
 from __future__ import annotations
 
 import logging
-import re
 import uuid
 from collections.abc import Sequence
-from datetime import UTC, datetime
+from datetime import datetime
 
 from pydantic import BaseModel, JsonValue
 from sqlalchemy import select, text
 from sqlalchemy.engine import Row
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.query_utils import like_needle
 from app.models.memory import Memory
 from app.services.embedding import Embedder, EmbeddingUpstreamError, resolve_embedder
 from app.services.memory_provider_mem0 import Mem0Provider
@@ -32,15 +32,14 @@ class _RawMemorySearchRow(BaseModel):
     created_at: datetime
     source_session_id: uuid.UUID | None = None
     source_environment_id: uuid.UUID | None = None
-    combined_score: float | None = None
 
 
 class BuiltinProvider:
     """Memory provider backed by PostgreSQL.
 
-    Adaptive: FTS (tsvector + ts_rank) + pg_trgm fuzzy is always on.
-    When an `Embedder` is supplied, also does pgvector similarity search
-    and merges results with temporal decay and MMR-style diversity rerank.
+    FTS and pg_trgm provide lexical recall. When an `Embedder` is supplied,
+    pgvector results are merged with the lexical ranking using reciprocal
+    rank fusion.
     """
 
     def __init__(self, db: AsyncSession, embedder: Embedder | None = None):
@@ -89,18 +88,20 @@ class BuiltinProvider:
         limit: int = 50,
         category: str | None = None,
     ) -> list[MemoryItem]:
+        query = query.strip()
+        if not query:
+            return []
         fts_rows = await self._search_fts(user_id, query, limit, category)
         if self.embedder is None:
-            return [_strip_scores(r) for r in fts_rows]
+            return fts_rows
 
         try:
             vec_rows = await self._search_vector(user_id, query, limit, category)
         except Exception as e:
             log.warning("vector search failed, using FTS-only: %s", e)
-            return [_strip_scores(r) for r in fts_rows]
+            return fts_rows
 
-        merged = _merge_hybrid(vec_rows, fts_rows, limit)
-        return [_strip_scores(r) for r in merged]
+        return _reciprocal_rank_fusion((fts_rows, vec_rows), limit)
 
     async def _search_fts(
         self,
@@ -109,43 +110,45 @@ class BuiltinProvider:
         limit: int,
         category: str | None,
     ) -> list[MemoryItem]:
-        """FTS + trigram hybrid with strict/relaxed score floor.
-
-        Internal rows keep `combined_score` for downstream merge.
-        """
+        """Rank literal phrases first, then FTS and indexed trigram matches."""
         params = {
             "uid": uuid.UUID(user_id),
             "q": query,
-            "pattern": f"%{query}%",
+            "pattern": like_needle(query),
             "cat": category,
             "lim": limit,
         }
         sql = text("""
-            WITH candidates AS (
-              SELECT m.*,
-                     ts_rank_cd(content_tsv, websearch_to_tsquery('simple', :q)) AS fts_score,
-                     similarity(content, :q) AS trg_score
+            WITH search_query AS (
+              SELECT websearch_to_tsquery('simple', :q) AS value
+            ), candidates AS (
+              SELECT
+                m.*,
+                m.content ILIKE :pattern ESCAPE '\\' AS literal_match,
+                ts_rank_cd(m.content_tsv, search_query.value) AS fts_score,
+                word_similarity(:q, m.content) AS trgm_score
               FROM memories m
+              CROSS JOIN search_query
               WHERE user_id = :uid
                 AND (CAST(:cat AS text) IS NULL OR category = :cat)
                 AND (
-                  content_tsv @@ websearch_to_tsquery('simple', :q)
-                  OR similarity(content, :q) > 0.1
-                  OR content ILIKE :pattern
+                  m.content ILIKE :pattern ESCAPE '\\'
+                  OR m.content_tsv @@ search_query.value
+                  OR :q <% m.content
                 )
             )
-            SELECT *,
-                   (COALESCE(fts_score, 0) * 1.0
-                    + COALESCE(trg_score, 0) * 0.5) AS combined_score
+            SELECT *
             FROM candidates
-            WHERE (COALESCE(fts_score, 0) * 1.0 + COALESCE(trg_score, 0) * 0.5) >= :min_score
-            ORDER BY combined_score DESC, created_at DESC
+            ORDER BY
+              literal_match DESC,
+              fts_score DESC,
+              trgm_score DESC,
+              created_at DESC,
+              id ASC
             LIMIT :lim
         """)
-        rows = (await self.db.execute(sql, {**params, "min_score": 0.05})).mappings().all()
-        if not rows:
-            rows = (await self.db.execute(sql, {**params, "min_score": 0.0})).mappings().all()
-        return [_row_to_search_dict(row) for row in rows]
+        rows = (await self.db.execute(sql, params)).mappings().all()
+        return [_row_to_dict(row) for row in rows]
 
     # Cosine-distance thresholds for vector search. Empirically on
     # `paraphrase-multilingual-mpnet-base-v2`, the legitimate-match band
@@ -153,12 +156,8 @@ class BuiltinProvider:
     # short abstract queries paired with narrowly-phrased memories —
     # there is no single threshold that cleanly separates them.
     #
-    # Mirroring the FTS strict/relaxed pattern: try the strict floor
-    # first; if that returns nothing, fall back to a permissive floor
-    # so the user sees "kinda related" rather than nothing. MMR +
-    # temporal-decay ranking in _merge_hybrid put noise at the bottom
-    # when legitimate matches also exist, so the relaxed pass doesn't
-    # pollute common cases.
+    # Try the strict floor first; only use the relaxed floor when strict
+    # semantic recall returns nothing.
     VECTOR_DISTANCE_STRICT = 0.70  # sim ≥ 0.30 — high-confidence matches
     VECTOR_DISTANCE_RELAXED = 0.80  # sim ≥ 0.20 — fallback when strict empty
 
@@ -195,12 +194,8 @@ class BuiltinProvider:
                 self.VECTOR_DISTANCE_RELAXED,
             )
         out: list[MemoryItem] = []
-        for mem, dist in rows:
-            d = memory_to_dict(mem)
-            # cosine distance ∈ [0, 2]; convert to similarity ∈ [0, 1].
-            sim = max(0.0, 1.0 - float(dist))
-            d["vector_score"] = sim
-            out.append(d)
+        for mem, _dist in rows:
+            out.append(memory_to_dict(mem))
         return out
 
     async def _run_vector_search(
@@ -211,6 +206,10 @@ class BuiltinProvider:
         category: str | None,
         max_distance: float,
     ) -> Sequence[Row[tuple[Memory, float]]]:
+        # pgvector applies ordinary WHERE filters after an approximate HNSW
+        # scan. Iterative scans keep expanding until the tenant/category
+        # predicate has enough rows, while preserving exact distance order.
+        await self.db.execute(text("SET LOCAL hnsw.iterative_scan = strict_order"))
         distance = Memory.embedding.cosine_distance(q_vec)
         stmt = (
             select(Memory, distance.label("distance"))
@@ -313,137 +312,29 @@ def _row_to_dict(raw: object) -> MemoryItem:
     }
 
 
-def _row_to_search_dict(raw: object) -> MemoryItem:
-    """Like `_row_to_dict` but preserves an internal score field for merging."""
-    row = _RawMemorySearchRow.model_validate(raw)
-    item = _row_to_dict(row.model_dump())
-    if row.combined_score is not None:
-        item["combined_score"] = row.combined_score
-    return item
-
-
-def _strip_scores(item: MemoryItem) -> MemoryItem:
-    """Remove internal score fields before returning to the client."""
-    return {
-        key: value for key, value in item.items() if key not in ("combined_score", "vector_score")
-    }
-
-
-# --- hybrid merge: vector + FTS, with temporal decay and MMR rerank ---
-
-
-def _tokenize(s: str) -> set[str]:
-    return {t for t in re.split(r"\W+", (s or "").lower()) if len(t) > 2}
-
-
-def _jaccard(a: set[str], b: set[str]) -> float:
-    if not a or not b:
-        return 0.0
-    return len(a & b) / len(a | b)
-
-
-def _parse_iso_ts(v: object) -> datetime | None:
-    """Parse the ISO-formatted `created_at` string produced by the _*_to_dict
-    helpers. Returns None if the value isn't an ISO string we can parse."""
-    if not isinstance(v, str):
-        return None
-    try:
-        return datetime.fromisoformat(v.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-
-
-def _apply_temporal_decay(
-    scores: dict[str, float],
-    rows_by_id: dict[str, MemoryItem],
-    half_life_days: float = 30.0,
-) -> None:
-    """Halve each score every `half_life_days`. In-place mutation.
-
-    OpenClaw's `temporal-decay.ts` formula: e^(-ln(2)/halflife * age).
-    """
-    now = datetime.now(UTC)
-    for rid, r in rows_by_id.items():
-        created_at = _parse_iso_ts(r.get("created_at"))
-        if created_at is None:
-            continue
-        age_days = max(0.0, (now - created_at).total_seconds() / 86400.0)
-        scores[rid] *= 0.5 ** (age_days / half_life_days)
-
-
-def _mmr_rerank(
-    candidates: list[MemoryItem],
-    scores: dict[str, float],
+def _reciprocal_rank_fusion(
+    rankings: Sequence[Sequence[MemoryItem]],
     limit: int,
-    lam: float = 0.7,
+    *,
+    rank_constant: int = 60,
 ) -> list[MemoryItem]:
-    """Greedy MMR (Carbonell & Goldstein, 1998) on Jaccard token similarity.
-
-    λ=0.7 relevance / 0.3 diversity. Uses content tokens so no extra
-    embedding calls are needed to compute diversity.
-    """
-    picked: list[MemoryItem] = []
-    picked_tokens: list[set[str]] = []
-    rest = [(candidate, _tokenize(_memory_content(candidate))) for candidate in candidates]
-    while rest and len(picked) < limit:
-        best_idx, best_mmr = 0, -1e9
-        for i, (c, toks) in enumerate(rest):
-            max_sim = max(
-                (_jaccard(toks, pt) for pt in picked_tokens),
-                default=0.0,
-            )
-            mmr = lam * scores.get(_memory_id(c), 0.0) - (1 - lam) * max_sim
-            if mmr > best_mmr:
-                best_mmr, best_idx = mmr, i
-        c, toks = rest.pop(best_idx)
-        picked.append(c)
-        picked_tokens.append(toks)
-    return picked
-
-
-def _merge_hybrid(
-    vec_rows: list[MemoryItem],
-    fts_rows: list[MemoryItem],
-    limit: int,
-    vector_weight: float = 0.7,
-    text_weight: float = 0.3,
-) -> list[MemoryItem]:
-    """Merge vector + FTS results by weighted score, decay, then MMR rerank."""
-    vec_max = (
-        max(
-            (_memory_score(row, "vector_score") for row in vec_rows),
-            default=0.0,
-        )
-        or 1.0
-    )
-    fts_max = (
-        max(
-            (_memory_score(row, "combined_score") for row in fts_rows),
-            default=0.0,
-        )
-        or 1.0
-    )
-
+    """Fuse independently ranked result sets without comparing score scales."""
     by_id: dict[str, MemoryItem] = {}
-    vec_norm: dict[str, float] = {}
-    fts_norm: dict[str, float] = {}
-    for row in vec_rows:
-        memory_id = _memory_id(row)
-        by_id[memory_id] = row
-        vec_norm[memory_id] = _memory_score(row, "vector_score") / vec_max
-    for row in fts_rows:
-        memory_id = _memory_id(row)
-        by_id.setdefault(memory_id, row)
-        fts_norm[memory_id] = _memory_score(row, "combined_score") / fts_max
-
     scores: dict[str, float] = {}
-    for rid in by_id:
-        scores[rid] = vector_weight * vec_norm.get(rid, 0.0) + text_weight * fts_norm.get(rid, 0.0)
+    first_seen: dict[str, int] = {}
+    for ranking in rankings:
+        seen_in_ranking: set[str] = set()
+        for rank, row in enumerate(ranking, start=1):
+            memory_id = _memory_id(row)
+            if memory_id in seen_in_ranking:
+                continue
+            seen_in_ranking.add(memory_id)
+            by_id.setdefault(memory_id, row)
+            first_seen.setdefault(memory_id, len(first_seen))
+            scores[memory_id] = scores.get(memory_id, 0.0) + 1.0 / (rank_constant + rank)
 
-    _apply_temporal_decay(scores, by_id)
-
-    ranked = sorted(by_id.values(), key=lambda row: -scores[_memory_id(row)])
-    return _mmr_rerank(ranked, scores, limit, lam=0.7)
+    ranked_ids = sorted(by_id, key=lambda item_id: (-scores[item_id], first_seen[item_id]))
+    return [by_id[item_id] for item_id in ranked_ids[:limit]]
 
 
 def _memory_id(item: MemoryItem) -> str:
@@ -451,18 +342,6 @@ def _memory_id(item: MemoryItem) -> str:
     if not isinstance(memory_id, str) or not memory_id:
         raise ValueError("memory result is missing an id")
     return memory_id
-
-
-def _memory_content(item: MemoryItem) -> str:
-    content = item.get("content")
-    return content if isinstance(content, str) else ""
-
-
-def _memory_score(item: MemoryItem, key: str) -> float:
-    value = item.get(key)
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        return 0.0
-    return float(value)
 
 
 # ---------- provider selection ----------

--- a/backend/app/services/memory_provider_mem0.py
+++ b/backend/app/services/memory_provider_mem0.py
@@ -7,6 +7,7 @@ standard-mode adapter, then validate responses into first-party domain records.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from collections.abc import Callable
 from typing import TypeGuard
@@ -164,7 +165,7 @@ class Mem0Provider:
         if source_environment_id is not None:
             metadata["source_environment_id"] = str(source_environment_id)
         messages: list[dict[str, str]] = [{"role": "user", "content": content}]
-        result = self._invoke(
+        result = await self._invoke(
             lambda: self._add(
                 messages,
                 filters={"user_id": user_id},
@@ -181,7 +182,10 @@ class Mem0Provider:
         limit: int = 50,
         category: str | None = None,
     ) -> list[MemoryItem]:
-        result = self._invoke(
+        query = query.strip()
+        if not query:
+            return []
+        result = await self._invoke(
             lambda: self._search(
                 query,
                 filters=_mem0_filters(user_id, category=category),
@@ -204,7 +208,7 @@ class Mem0Provider:
         order: str = "desc",
     ) -> list[MemoryItem]:
         del order
-        result = self._invoke(
+        result = await self._invoke(
             lambda: self._get_all(
                 filters=_mem0_filters(user_id, category=category),
                 page=(offset // limit) + 1,
@@ -219,7 +223,7 @@ class Mem0Provider:
         user_id: str,
         category: str | None = None,
     ) -> int:
-        result = self._invoke(
+        result = await self._invoke(
             lambda: self._get_all(
                 filters=_mem0_filters(user_id, category=category),
                 page=1,
@@ -231,19 +235,19 @@ class Mem0Provider:
     async def delete(self, user_id: str, memory_id: str) -> bool:
         memory = _validate_response(
             _Mem0GetResponse,
-            self._invoke(lambda: self._get(memory_id)),
+            await self._invoke(lambda: self._get(memory_id)),
         )
         if memory.user_id != user_id:
             return False
         _validate_response(
             _Mem0DeleteResponse,
-            self._invoke(lambda: self._delete(memory_id)),
+            await self._invoke(lambda: self._delete(memory_id)),
         )
         return True
 
-    def _invoke(self, operation: Callable[[], object]) -> object:
+    async def _invoke(self, operation: Callable[[], object]) -> object:
         try:
-            return operation()
+            return await asyncio.to_thread(operation)
         except self._transient_error_types as exc:
             raise MemoryProviderUnavailableError("Mem0 request is unavailable") from exc
         except self._error_type as exc:

--- a/backend/app/services/memory_recall.py
+++ b/backend/app/services/memory_recall.py
@@ -1,11 +1,9 @@
 """Recall counting — bump `Memory.access_count` when agents retrieve memories.
 
-Lives in its own module (not inline in `routes/memories.py`) for two
-reasons: the route file is contested by parallel work, so the call site
-there stays one line; and the counter must be fully isolated from the
-search request path — it runs as a FastAPI background task on its OWN
-session after the response is sent, so it adds zero latency and a
-failed UPDATE can never break a search.
+The counter owns a short-lived database session and never raises. REST
+searches schedule it as a FastAPI background task; MCP searches await it
+before returning so their tool result and recall count stay in step. In
+both paths a failed UPDATE can never break search.
 
 Kill switch: `MEMORY_RECALL_COUNTING=false` disables counting entirely
 (no deploy needed) if the extra write per agent search ever matters.

--- a/backend/app/services/session_search.py
+++ b/backend/app/services/session_search.py
@@ -11,6 +11,7 @@ from sqlalchemy import String, case, cast, delete, func, literal, or_, select, u
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.selectable import Subquery
 
+from app.core.query_utils import like_needle, search_excerpt
 from app.models.session import Session, SessionEventChunk, SessionMessageSearch
 from app.schemas.session import (
     SessionSearchAnchorResponse,
@@ -90,29 +91,11 @@ async def event_search_projection_complete(
     return missing is None
 
 
-def escaped_contains_pattern(value: str) -> str:
-    escaped = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-    return f"%{escaped}%"
-
-
 def _uuid_prefix_pattern(value: str) -> str | None:
     compact = value.strip().replace("-", "")
     if not _UUID_PREFIX_RE.fullmatch(compact):
         return None
     return f"{compact}%"
-
-
-def session_search_excerpt(content: str, query: str, *, limit: int = 240) -> str:
-    compact = " ".join(content.split())
-    if len(compact) <= limit:
-        return compact
-    match_at = compact.casefold().find(query.casefold())
-    if match_at < 0:
-        return f"{compact[: limit - 3]}..."
-    start = max(0, match_at - limit // 3)
-    end = min(len(compact), start + limit)
-    start = max(0, end - limit)
-    return f"{'...' if start else ''}{compact[start:end]}{'...' if end < len(compact) else ''}"
 
 
 def session_search_match_response(
@@ -134,7 +117,7 @@ def session_search_match_response(
         return None
     return SessionSearchMatchResponse(
         role=role,
-        excerpt=session_search_excerpt(content, query),
+        excerpt=search_excerpt(content, query),
         anchor=SessionSearchAnchorResponse(
             kind="event_seq" if session.content_protocol == "events-v1" else "snapshot_offset",
             position=position,
@@ -149,7 +132,7 @@ def _searchable_text(content: str) -> str:
 
 def _message_match_expression(query: str):
     return SessionMessageSearch.content.ilike(
-        escaped_contains_pattern(query),
+        like_needle(query),
         escape="\\",
     )
 
@@ -216,7 +199,7 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
 
 def session_search_matches(user_id: UUID, query: str) -> Subquery:
     """Return every exact phrase match with one ranked body hit per Session."""
-    pattern = escaped_contains_pattern(query)
+    pattern = like_needle(query)
     message_match = best_session_message_matches(user_id, query)
     metadata_matches = [
         func.coalesce(Session.summary, "").ilike(pattern, escape="\\"),

--- a/backend/tests/test_memory_provider_mem0_v3.py
+++ b/backend/tests/test_memory_provider_mem0_v3.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import threading
 from types import ModuleType
 from uuid import UUID
 
@@ -110,6 +111,20 @@ class _RecordingMem0Client:
         return self.delete_result
 
 
+class _ThreadRecordingMem0Client(_RecordingMem0Client):
+    search_thread_id: int | None = None
+
+    def search(
+        self,
+        query: str,
+        *,
+        filters: dict[str, object],
+        top_k: int,
+    ) -> object:
+        self.search_thread_id = threading.get_ident()
+        return super().search(query, filters=filters, top_k=top_k)
+
+
 def _provider(
     monkeypatch: pytest.MonkeyPatch,
     client: _RecordingMem0Client,
@@ -182,6 +197,19 @@ async def test_mem0_v3_add_and_search_use_filters_and_top_k(
     ]
     assert sdk_client.search_calls == [("Scoped", _filters(category="decision"), 7)]
     assert hits[0]["source_environment_id"] == str(ENVIRONMENT_ID)
+
+
+@pytest.mark.asyncio
+async def test_mem0_sdk_calls_run_outside_the_event_loop_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sdk_client = _ThreadRecordingMem0Client(search_result={"results": []})
+    provider = _provider(monkeypatch, sdk_client)
+    event_loop_thread_id = threading.get_ident()
+
+    assert await provider.search(USER_ID, "memory") == []
+    assert sdk_client.search_thread_id is not None
+    assert sdk_client.search_thread_id != event_loop_thread_id
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_memory_recall_count.py
+++ b/backend/tests/test_memory_recall_count.py
@@ -39,6 +39,34 @@ async def test_agent_search_bumps_access_count(cli_client: httpx.AsyncClient):
 
 
 @pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_mcp_search_bumps_access_count(cli_client: httpx.AsyncClient):
+    created = await cli_client.post(
+        "/v1/memories",
+        json={"content": "MCP recalls count as agent retrievals", "category": "fact"},
+    )
+    memory_id = created.json()["id"]
+
+    response = await cli_client.post(
+        "/v1/mcp/clawdi",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "memory_search",
+                "arguments": {"query": "agent retrievals"},
+            },
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert "MCP recalls count" in response.json()["result"]["content"][0]["text"]
+
+    detail = (await cli_client.get(f"/v1/memories/{memory_id}")).json()
+    assert detail["access_count"] == 1
+
+
+@pytest.mark.asyncio
 async def test_dashboard_search_does_not_count_as_recall(client: httpx.AsyncClient):
     created = await client.post(
         "/v1/memories",

--- a/backend/tests/test_memory_search_quality.py
+++ b/backend/tests/test_memory_search_quality.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.services.memory_provider import _reciprocal_rank_fusion
+from app.services.memory_types import MemoryItem
+
+
+def _hit(memory_id: str, content: str) -> MemoryItem:
+    return {"id": memory_id, "content": content}
+
+
+def test_reciprocal_rank_fusion_rewards_results_found_by_both_retrievers() -> None:
+    lexical = [_hit("shared", "shared"), _hit("lexical", "lexical")]
+    semantic = [_hit("semantic", "semantic"), _hit("shared", "shared")]
+
+    assert [item["id"] for item in _reciprocal_rank_fusion((lexical, semantic), 3)] == [
+        "shared",
+        "semantic",
+        "lexical",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_memory_search_escapes_wildcards_and_keeps_typo_recall(
+    client: httpx.AsyncClient,
+) -> None:
+    memories = [
+        "Release marker is 100%_ready for the staged rollout.",
+        "Use the deployment handoff checklist before promoting.",
+        "Unrelated preference about concise status reports.",
+    ]
+    for content in memories:
+        response = await client.post("/v1/memories", json={"content": content, "category": "fact"})
+        assert response.status_code == 200, response.text
+
+    wildcard = await client.get("/v1/memories", params={"q": "%_"})
+    assert wildcard.status_code == 200, wildcard.text
+    assert [item["content"] for item in wildcard.json()["items"]] == [memories[0]]
+
+    typo = await client.get("/v1/memories", params={"q": "deployment handof checklist"})
+    assert typo.status_code == 200, typo.text
+    assert memories[1] in [item["content"] for item in typo.json()["items"]]
+
+
+@pytest.mark.asyncio
+async def test_global_memory_search_returns_context_around_the_match(
+    client: httpx.AsyncClient,
+) -> None:
+    needle = "deployment handoff marker"
+    content = f"{'Earlier context. ' * 30}{needle}. {'Later context. ' * 30}"
+    created = await client.post(
+        "/v1/memories",
+        json={"content": content, "category": "decision"},
+    )
+    assert created.status_code == 200, created.text
+
+    response = await client.get("/v1/search", params={"q": f"  {needle}  "})
+    assert response.status_code == 200, response.text
+    hit = next(item for item in response.json()["results"] if item["type"] == "memory")
+    assert hit["title"].startswith("...")
+    assert needle in hit["title"]
+    assert hit["title"].endswith("...")
+    assert hit["href"] == f"/memories/{created.json()['id']}"

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -1314,6 +1314,8 @@ async def test_global_search_returns_hits_across_types(client: httpx.AsyncClient
     # Session summary matched, vault slug matched.
     assert "session" in types
     assert "vault" in types
+    vault_hit = next(hit for hit in body["results"] if hit["type"] == "vault")
+    assert vault_hit["href"].startswith("/vaults/alpha-keys?vault=")
     # Every hit has the fields the UI depends on to render.
     for hit in body["results"]:
         assert hit["title"]

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -1307,9 +1307,10 @@ async def test_global_search_returns_hits_across_types(client: httpx.AsyncClient
     )
     await client.post("/v1/vault", json={"slug": "alpha-keys", "name": "alpha-keys"})
 
-    r = await client.get("/v1/search?q=alpha")
+    r = await client.get("/v1/search", params={"q": "  alpha  "})
     assert r.status_code == 200
     body = r.json()
+    assert body["query"] == "alpha"
     types = {hit["type"] for hit in body["results"]}
     # Session summary matched, vault slug matched.
     assert "session" in types

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -2849,7 +2849,7 @@ export interface paths {
          * @description Run each entity searcher and concat results.
          *
          *     Each searcher returns at most `TYPE_LIMIT` rows; total is capped at
-         *     4*TYPE_LIMIT which keeps the palette responsive even with noisy queries.
+         *     5*TYPE_LIMIT which keeps the palette responsive even with noisy queries.
          *
          *     Sessions/skills/vaults use `ILIKE` (small tables) — memories goes through
          *     the hybrid provider (FTS + trgm + optional pgvector) for quality.


### PR DESCRIPTION
## Summary

- keep Session search deterministic with one shared literal-match and excerpt boundary
- replace custom Memory score normalization, time decay, and MMR with PostgreSQL lexical retrieval plus optional pgvector results fused by standard RRF
- make global and Memory search results explainable with contextual excerpts, shared highlighting, and direct Vault links
- keep blocking Mem0 SDK calls off the event loop and count MCP memory recalls consistently

## Search contract

- Sessions: exact case-insensitive phrase containment; similarity only ranks metadata matches
- Memories: literal phrase + FTS + indexed pg_trgm, optionally fused with pgvector by reciprocal rank fusion
- no database migration or response-shape change

## Verification

- backend focused tests: 82 passed
- earlier branch verification: backend focused 35 passed; Web typecheck; 5 focused Web tests; OSS production build
- Biome 2.5.9: 1109 files passed
- Ruff check and format: passed
- Python compileall: passed
- generated OpenAPI client consistency: passed
- git diff --check: passed
- PostgreSQL runtime contract: PostgreSQL 18.4, pgvector 0.8.6, pg_trgm 1.6