### PR TITLE
feat(search): improve project and agent discovery

### DIFF
--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -120,7 +120,9 @@ test("opens a global Session body match at the exact message", async ({ page }) 
 	await page.goto("/sessions");
 	await page.getByTestId("app-sidebar-search-button").click();
 	const palette = page.getByRole("dialog", { name: "Search" });
-	await palette.getByPlaceholder("Search sessions, memories, skills, vaults…").fill(query);
+	await palette
+		.getByPlaceholder("Search agents, sessions, memories, projects, skills, vaults…")
+		.fill(query);
 	await expect(palette.getByText(`Found the ${query} in this response`)).toBeVisible();
 	await expect(palette.locator("mark")).toHaveText(query);
 	await palette.getByText("Global search result").click();

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -3,6 +3,7 @@
 import { keepPreviousData } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import {
+	Bot,
 	Brain,
 	FolderKanban,
 	Key,
@@ -45,6 +46,7 @@ interface NavShortcut {
 }
 
 const TYPE_ICON: Record<SearchHit["type"], LucideIcon> = {
+	agent: Bot,
 	session: MessageSquare,
 	memory: Brain,
 	project: FolderKanban,
@@ -53,12 +55,14 @@ const TYPE_ICON: Record<SearchHit["type"], LucideIcon> = {
 };
 
 const TYPE_LABEL: Record<SearchHit["type"], string> = {
+	agent: "Agents",
 	session: "Sessions",
 	memory: "Memories",
 	project: "Projects",
 	skill: "Skills",
 	vault: "Vaults",
 };
+const SEARCH_RESULT_TYPES = ["agent", "session", "memory", "project", "skill", "vault"] as const;
 
 const COMMAND_RESULT_ROW_CLASS = "items-start gap-2 py-2.5";
 const COMMAND_RESULT_TEXT_CLASS = "flex min-w-0 flex-col gap-0.5";
@@ -217,6 +221,14 @@ function CommandPalette({
 		}
 		return g;
 	}, [data]);
+	const resultGroups = useMemo(
+		() =>
+			SEARCH_RESULT_TYPES.flatMap((type) => {
+				const hits = grouped[type];
+				return hits?.length ? [{ type, hits }] : [];
+			}),
+		[grouped],
+	);
 
 	const hasQuery = searchQuery.length > 0;
 	const normalizedQuery = searchQuery.toLowerCase();
@@ -251,14 +263,14 @@ function CommandPalette({
 				if (!nextOpen) setQuery("");
 			}}
 			title="Search"
-			description="Open a page or search sessions, memories, skills, and vaults. Use the Search button in the sidebar or Cmd/Ctrl+K."
+			description="Open a page or search agents, sessions, memories, projects, skills, and vaults. Use the Search button in the sidebar or Cmd/Ctrl+K."
 		>
 			<Command label="Global search" shouldFilter={false}>
 				<div className="relative">
 					<CommandInput
 						value={query}
 						onValueChange={setQuery}
-						placeholder="Search sessions, memories, skills, vaults…"
+						placeholder="Search agents, sessions, memories, projects, skills, vaults…"
 					/>
 					{hasQuery && isFetching ? (
 						<Spinner className="pointer-events-none absolute top-3.5 right-4 size-4 text-muted-foreground" />
@@ -303,9 +315,7 @@ function CommandPalette({
 					) : null}
 
 					{hasQuery
-						? (["session", "memory", "project", "skill", "vault"] as const).map((type, i) => {
-								const hits = grouped[type];
-								if (!hits?.length) return null;
+						? resultGroups.map(({ type, hits }, i) => {
 								const Icon = TYPE_ICON[type];
 								return (
 									<div key={type}>
@@ -331,7 +341,7 @@ function CommandPalette({
 															/>
 														) : hit.subtitle ? (
 															<TruncatedText className="text-xs text-muted-foreground">
-																{hit.subtitle}
+																<SearchHighlightedText text={hit.subtitle} query={resultQuery} />
 															</TruncatedText>
 														) : null}
 													</div>

--- a/apps/web/src/components/projects/project-metadata.test.ts
+++ b/apps/web/src/components/projects/project-metadata.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { projectAgentLabel } from "@/components/projects/project-metadata";
+import {
+	projectAgentLabel,
+	projectMatchesSearch,
+	projectSearchRank,
+	projectSearchSupportingText,
+} from "@/components/projects/project-metadata";
 
 describe("projectAgentLabel", () => {
 	test("uses the canonical agent identity fallback", () => {
@@ -24,5 +29,44 @@ describe("projectAgentLabel", () => {
 				agent_type: "codex",
 			}),
 		).toBe("Launch runner");
+	});
+});
+
+describe("Project search projection", () => {
+	const project = {
+		name: "Launch control",
+		slug: "launch-control",
+		description: "Coordinates the production rollout across services.",
+		is_owner: false,
+		owner_display: "Ada Lovelace",
+		owner_handle: "ada-lovelace-a1b2",
+	};
+
+	test("matches every visible Project identity field", () => {
+		for (const query of [
+			"launch control",
+			"launch-control",
+			"production rollout",
+			"ada lovelace",
+			"a1b2",
+		]) {
+			expect(projectMatchesSearch(project, query)).toBe(true);
+		}
+		expect(projectMatchesSearch(project, "unrelated")).toBe(false);
+	});
+
+	test("explains matches that are not visible in the title", () => {
+		expect(projectSearchSupportingText(project, "production rollout")).toContain(
+			"production rollout",
+		);
+		expect(projectSearchSupportingText(project, "launch-control")).toBe("Slug: launch-control");
+		expect(projectSearchSupportingText(project, "a1b2")).toBe("Shared by ada-lovelace-a1b2");
+	});
+
+	test("orders strong identity matches before supporting metadata", () => {
+		expect(projectSearchRank(project, "launch control")).toBe(0);
+		expect(projectSearchRank(project, "launch-")).toBe(3);
+		expect(projectSearchRank(project, "production rollout")).toBe(6);
+		expect(projectSearchRank(project, "a1b2")).toBe(7);
 	});
 });

--- a/apps/web/src/components/projects/project-metadata.tsx
+++ b/apps/web/src/components/projects/project-metadata.tsx
@@ -14,6 +14,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { identityFor } from "@/lib/identity";
+import { searchExcerpt } from "@/lib/search-highlight";
 import { cn } from "@/lib/utils";
 
 export interface ProjectMetadata {
@@ -56,6 +57,53 @@ export function projectSupportingText(project: ProjectMetadata) {
 	if (!isProjectOwner(project)) return `Shared by ${projectOwnerLabel(project)}`;
 	if (project.kind === "environment") return "Private Agent Workspace";
 	return "Project you own";
+}
+
+export function projectSearchRank(project: ProjectMetadata, query: string): number | null {
+	const phrase = query.trim().toLowerCase();
+	if (!phrase) return 0;
+	const name = displayProjectName(project).toLowerCase();
+	const slug = project.slug.toLowerCase();
+	if (name === phrase) return 0;
+	if (slug === phrase) return 1;
+	if (name.startsWith(phrase)) return 2;
+	if (slug.startsWith(phrase)) return 3;
+	if (name.includes(phrase)) return 4;
+	if (slug.includes(phrase)) return 5;
+	if (project.description?.toLowerCase().includes(phrase)) return 6;
+	if (
+		!isProjectOwner(project) &&
+		[project.owner_display, project.owner_handle].some((owner) =>
+			owner?.toLowerCase().includes(phrase),
+		)
+	) {
+		return 7;
+	}
+	return null;
+}
+
+export function projectMatchesSearch(project: ProjectMetadata, query: string): boolean {
+	return projectSearchRank(project, query) !== null;
+}
+
+export function projectSearchSupportingText(project: ProjectMetadata, query: string): string {
+	const phrase = query.trim().toLowerCase();
+	if (!phrase) return projectSupportingText(project);
+
+	if (project.slug.toLowerCase().includes(phrase)) return `Slug: ${project.slug}`;
+
+	const description = project.description?.trim();
+	if (description?.toLowerCase().includes(phrase)) {
+		return searchExcerpt(description, query, 160);
+	}
+
+	const matchingOwner = [project.owner_display, project.owner_handle].find((owner) =>
+		owner?.toLowerCase().includes(phrase),
+	);
+	if (!isProjectOwner(project) && matchingOwner) {
+		return `Shared by ${matchingOwner}`;
+	}
+	return projectSupportingText(project);
 }
 
 export function isCustomProject(project: Pick<ProjectMetadata, "kind">): boolean {

--- a/apps/web/src/components/projects/project-resource-card.tsx
+++ b/apps/web/src/components/projects/project-resource-card.tsx
@@ -7,8 +7,10 @@ import {
 	isProjectOwner,
 	ProjectKindBadge,
 	type ProjectMetadata,
+	projectSearchSupportingText,
 	projectSupportingText,
 } from "@/components/projects/project-metadata";
+import { SearchHighlightedText } from "@/components/search-highlighted-text";
 import { Badge } from "@/components/ui/badge";
 import { identityFor } from "@/lib/identity";
 import {
@@ -29,6 +31,7 @@ export function ProjectResourceCard({
 	showKind = false,
 	navigationScope = LIBRARY_RESOURCE_SCOPE,
 	link,
+	searchQuery,
 	className,
 }: {
 	project: ProjectMetadata;
@@ -38,6 +41,8 @@ export function ProjectResourceCard({
 	navigationScope?: ResourceNavigationScope;
 	/** Optional collection-local destination while retaining the canonical card. */
 	link?: EntityCardLinkOptions;
+	/** Collection-local search context; highlights and explains the matching field. */
+	searchQuery?: string;
 	className?: string;
 }) {
 	const projectName = displayProjectName(project);
@@ -52,7 +57,9 @@ export function ProjectResourceCard({
 					{identity.emoji}
 				</IconChip>
 			}
-			title={projectName}
+			title={
+				searchQuery ? <SearchHighlightedText text={projectName} query={searchQuery} /> : projectName
+			}
 			badges={
 				showKind || showViewer ? (
 					<>
@@ -61,7 +68,16 @@ export function ProjectResourceCard({
 					</>
 				) : undefined
 			}
-			description={projectSupportingText(project)}
+			description={
+				searchQuery ? (
+					<SearchHighlightedText
+						text={projectSearchSupportingText(project, searchQuery)}
+						query={searchQuery}
+					/>
+				) : (
+					projectSupportingText(project)
+				)
+			}
 			footer={footer}
 			actions={actions}
 			link={detailLink}

--- a/apps/web/src/pages/dashboard/projects/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/page.tsx
@@ -16,8 +16,9 @@ import { CreateProjectDialog } from "@/components/projects/create-project-dialog
 import { ProjectActions } from "@/components/projects/project-actions";
 import {
 	canManageCustomProject,
-	displayProjectName,
 	isCustomProject,
+	projectMatchesSearch,
+	projectSearchRank,
 } from "@/components/projects/project-metadata";
 import {
 	ProjectResourceCard,
@@ -79,14 +80,13 @@ export default function ProjectsPage() {
 			...customProjects.map((project) => ({ project, shared: false })),
 			...sharedProjects.map((project) => ({ project, shared: true })),
 		];
-		const q = search.trim().toLowerCase();
-		if (!q) return all;
-		return all.filter(({ project }) =>
-			[displayProjectName(project), project.slug, project.owner_display ?? ""]
-				.join(" ")
-				.toLowerCase()
-				.includes(q),
-		);
+		return all
+			.filter(({ project }) => projectMatchesSearch(project, search))
+			.sort(
+				(a, b) =>
+					(projectSearchRank(a.project, search) ?? Number.MAX_SAFE_INTEGER) -
+					(projectSearchRank(b.project, search) ?? Number.MAX_SAFE_INTEGER),
+			);
 	}, [customProjects, sharedProjects, search]);
 	const blockingProjectsError = shouldBlockQueryError(projects.error, projects.data);
 
@@ -167,6 +167,7 @@ export default function ProjectsPage() {
 						<ProjectResourceCard
 							key={project.id}
 							project={project}
+							searchQuery={search.trim() || undefined}
 							footer={[
 								formatResourceCount(project.skill_count, "skill"),
 								formatResourceCount(project.vault_count, "vault"),

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -156,6 +156,11 @@ class AuthContext:
     def user_id(self):
         return self._user_id
 
+    @property
+    def bound_environment_id(self) -> UUID | None:
+        """Environment fence carried by an Agent-bound API key."""
+        return self.api_key.environment_id if self.api_key is not None else None
+
 
 async def _auth_via_api_key(token: str, db: AsyncSession) -> AuthContext | None:
     if not token.startswith(API_KEY_PREFIX):

--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -11,27 +11,33 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Literal
 from urllib.parse import quote
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
-from sqlalchemy import or_, select
+from sqlalchemy import and_, case, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import AuthContext, get_auth, is_scoped_api_key
 from app.core.database import get_session
 from app.core.project import project_ids_visible_to
-from app.core.query_utils import like_needle, search_excerpt
+from app.core.query_utils import escape_like, like_needle, search_excerpt
 from app.models.project import Project
+from app.models.project_membership import ProjectMembership
 from app.models.session import AgentEnvironment, Session
 from app.models.skill import Skill
+from app.models.user import User
 from app.models.vault import Vault, VaultProjectAttachment
 from app.schemas.session import SessionSearchMatchResponse
+from app.services.agent_environments import agent_name_from_fields, agent_type_default_label
+from app.services.agent_lifecycle import active_agent_filter
 from app.services.memory_provider import get_memory_provider
 from app.services.memory_types import MemoryItem
 from app.services.session_search import (
     session_search_match_response,
     session_search_matches,
 )
+from app.services.sharing import safe_owner_display
 
 
 def _has_scope(auth: AuthContext, scope: str) -> bool:
@@ -50,7 +56,7 @@ log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/search", tags=["search"])
 
-SearchType = Literal["session", "memory", "project", "skill", "vault"]
+SearchType = Literal["agent", "session", "memory", "project", "skill", "vault"]
 
 
 class SearchHit(BaseModel):
@@ -74,6 +80,85 @@ type Searcher = Callable[
 ]
 
 
+async def _search_agents(db: AsyncSession, auth: AuthContext, query: str) -> list[SearchHit]:
+    exact = escape_like(query)
+    prefix = f"{exact}%"
+    needle = like_needle(query)
+    fields = (
+        AgentEnvironment.display_name,
+        AgentEnvironment.default_name,
+        AgentEnvironment.machine_name,
+        AgentEnvironment.agent_type,
+    )
+    rank = case(
+        *[(field.ilike(exact, escape="\\"), index) for index, field in enumerate(fields)],
+        *[
+            (field.ilike(prefix, escape="\\"), index + len(fields))
+            for index, field in enumerate(fields)
+        ],
+        else_=len(fields) * 2,
+    )
+    stmt = (
+        select(AgentEnvironment)
+        .where(
+            AgentEnvironment.user_id == auth.user_id,
+            active_agent_filter(),
+            or_(*(field.ilike(needle, escape="\\") for field in fields)),
+        )
+        .order_by(
+            rank,
+            AgentEnvironment.sort_order,
+            AgentEnvironment.created_at,
+            AgentEnvironment.id,
+        )
+        .limit(TYPE_LIMIT)
+    )
+    if auth.bound_environment_id is not None:
+        stmt = stmt.where(AgentEnvironment.id == auth.bound_environment_id)
+    agents = (await db.execute(stmt)).scalars().all()
+    return [
+        SearchHit(
+            type="agent",
+            id=str(agent.id),
+            title=agent_name_from_fields(
+                agent.display_name,
+                agent.default_name,
+                agent.machine_name,
+                agent.agent_type,
+            ),
+            subtitle=_agent_search_subtitle(agent, query),
+            href=f"/agents/{agent.id}",
+        )
+        for agent in agents
+    ]
+
+
+def _agent_search_subtitle(agent: AgentEnvironment, query: str) -> str | None:
+    title = agent_name_from_fields(
+        agent.display_name,
+        agent.default_name,
+        agent.machine_name,
+        agent.agent_type,
+    )
+    type_label = agent_type_default_label(agent.agent_type)
+    folded_query = query.casefold()
+    candidates = (
+        agent.display_name,
+        agent.default_name,
+        agent.machine_name,
+        type_label,
+        agent.agent_type,
+    )
+    for candidate in candidates:
+        label = (candidate or "").strip()
+        if label and label.casefold() != title.casefold() and folded_query in label.casefold():
+            return label
+    context = [
+        label for label in (type_label, agent.machine_name) if label.casefold() != title.casefold()
+    ]
+    return " · ".join(dict.fromkeys(context)) or None
+
+
 async def _search_sessions(db: AsyncSession, auth: AuthContext, query: str) -> list[SearchHit]:
     matches = session_search_matches(auth.user_id, query)
     # Historical search retains archived Agent labels; this join grants no
@@ -95,8 +180,8 @@ async def _search_sessions(db: AsyncSession, auth: AuthContext, query: str) -> l
     )
     # Bound api_keys can only see sessions in their own env — same
     # boundary the direct list_sessions route enforces.
-    if auth.is_cli and auth.api_key is not None and auth.api_key.environment_id is not None:
-        stmt = stmt.where(Session.environment_id == auth.api_key.environment_id)
+    if auth.bound_environment_id is not None:
+        stmt = stmt.where(Session.environment_id == auth.bound_environment_id)
     rows = (await db.execute(stmt)).all()
     hits: list[SearchHit] = []
     for s, agent_type, content, role, position, revision in rows:
@@ -197,32 +282,92 @@ async def _search_skills(db: AsyncSession, auth: AuthContext, query: str) -> lis
 
 
 async def _search_projects(db: AsyncSession, auth: AuthContext, query: str) -> list[SearchHit]:
+    exact = escape_like(query)
+    prefix = f"{exact}%"
     needle = like_needle(query)
     visible_project_ids = await project_ids_visible_to(db, auth)
+    membership_join = and_(
+        ProjectMembership.project_id == Project.id,
+        ProjectMembership.member_user_id == auth.user_id,
+    )
+    shared_owner_match = and_(
+        Project.user_id != auth.user_id,
+        or_(
+            User.name.ilike(needle, escape="\\"),
+            and_(User.name.is_(None), User.email.ilike(needle, escape="\\")),
+            ProjectMembership.resolved_owner_handle.ilike(needle, escape="\\"),
+        ),
+    )
+    rank = case(
+        (Project.name.ilike(exact, escape="\\"), 0),
+        (Project.slug.ilike(exact, escape="\\"), 1),
+        (Project.name.ilike(prefix, escape="\\"), 2),
+        (Project.slug.ilike(prefix, escape="\\"), 3),
+        (Project.name.ilike(needle, escape="\\"), 4),
+        (Project.slug.ilike(needle, escape="\\"), 5),
+        (Project.description.ilike(needle, escape="\\"), 6),
+        else_=7,
+    )
     stmt = (
-        select(Project)
+        select(Project, User, ProjectMembership)
+        .join(User, User.id == Project.user_id)
+        .outerjoin(ProjectMembership, membership_join)
         .where(
             Project.id.in_(visible_project_ids),
             Project.archived_at.is_(None),
             or_(
                 Project.name.ilike(needle, escape="\\"),
                 Project.slug.ilike(needle, escape="\\"),
+                Project.description.ilike(needle, escape="\\"),
+                shared_owner_match,
             ),
         )
-        .order_by(Project.name)
+        .order_by(rank, Project.name, Project.id)
         .limit(TYPE_LIMIT)
     )
-    rows = (await db.execute(stmt)).scalars().all()
+    rows = (await db.execute(stmt)).all()
     return [
         SearchHit(
             type="project",
             id=str(p.id),
             title=p.name,
-            subtitle=p.slug,
+            subtitle=_project_search_subtitle(
+                p,
+                query,
+                owner=owner,
+                membership=membership,
+                caller_user_id=auth.user_id,
+            ),
             href=f"/projects/{p.id}",
         )
-        for p in rows
+        for p, owner, membership in rows
     ]
+
+
+def _project_search_subtitle(
+    project: Project,
+    query: str,
+    *,
+    owner: User,
+    membership: ProjectMembership | None,
+    caller_user_id: UUID,
+) -> str:
+    description = (project.description or "").strip()
+    folded_query = query.casefold()
+    if folded_query in project.slug.casefold():
+        return project.slug
+    if description and folded_query in description.casefold():
+        return search_excerpt(description, query, limit=160)
+    if project.user_id != caller_user_id:
+        owner_labels = [safe_owner_display(owner)]
+        if membership is not None:
+            owner_labels.append(membership.resolved_owner_handle)
+        if label := next(
+            (label for label in owner_labels if folded_query in label.casefold()),
+            None,
+        ):
+            return f"Shared by {label}"
+    return description or project.slug
 
 
 async def _search_vaults(db: AsyncSession, auth: AuthContext, query: str) -> list[SearchHit]:
@@ -266,10 +411,10 @@ async def global_search(
     """Run each entity searcher and concat results.
 
     Each searcher returns at most `TYPE_LIMIT` rows; total is capped at
-    5*TYPE_LIMIT which keeps the palette responsive even with noisy queries.
+    6*TYPE_LIMIT which keeps the palette responsive even with noisy queries.
 
-    Sessions/skills/vaults use `ILIKE` (small tables) — memories goes through
-    the hybrid provider (FTS + trgm + optional pgvector) for quality.
+    Sessions/projects/skills/vaults use `ILIKE` (small tables) — memories goes
+    through the hybrid provider (FTS + trgm + optional pgvector) for quality.
 
     A single failing source (e.g. the memory provider briefly unavailable)
     degrades to partial results rather than failing the whole request —
@@ -293,7 +438,7 @@ async def global_search(
     # we limit it to user JWT and wide-access personal CLI keys
     # (mirrors `require_user_auth` semantics on the direct vault
     # routes).
-    jobs: list[tuple[str, Searcher]] = []
+    jobs: list[tuple[str, Searcher]] = [("agents", _search_agents)]
     if _has_scope(auth, "skills:read"):
         jobs.append(("skills", _search_skills))
     if not is_scoped_api_key(auth):

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -106,6 +106,7 @@ from app.schemas.session import (
 )
 from app.services import memory_extraction
 from app.services.agent_environments import (
+    agent_name_from_fields,
     clear_connected_agent_registration,
     local_machine_registration_key,
     register_agent_environment,
@@ -189,16 +190,6 @@ def _analyze_session_upload_sync(data: bytes) -> _SessionUploadAnalysis:
 
 async def _analyze_session_upload(data: bytes) -> _SessionUploadAnalysis:
     return await asyncio.to_thread(_analyze_session_upload_sync, data)
-
-
-def _bound_env_id(auth: AuthContext) -> UUID | None:
-    """Return the env_id this caller is bound to, or None for
-    Clerk JWT (multi-env) callers. Bound api_keys carry an
-    `environment_id` on their key row; that's the blast-radius
-    boundary every session read/write must respect."""
-    if auth.is_cli and auth.api_key is not None:
-        return auth.api_key.environment_id
-    return None
 
 
 # Clock-skew window for client-supplied `last_activity_at`. Anything
@@ -395,7 +386,7 @@ async def _list_agent_identities(
     # — the whole point of the env binding is to bound the blast
     # radius of a leaked key. The full list stays available to
     # Clerk JWT (dashboard) callers.
-    bound_env = _bound_env_id(auth)
+    bound_env = auth.bound_environment_id
     stmt = (
         select(AgentEnvironment)
         .where(AgentEnvironment.user_id == auth.user_id, active_agent_filter())
@@ -514,7 +505,7 @@ async def _get_agent_identity(
     *,
     agent_response: bool,
 ) -> AgentResponse | EnvironmentResponse | Response:
-    bound_env = _bound_env_id(auth)
+    bound_env = auth.bound_environment_id
     if bound_env is not None and agent_id != bound_env:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
     row = (
@@ -568,7 +559,7 @@ async def list_environment_runtime_observed(
     auth: AuthContext = Depends(get_auth),
     db: AsyncSession = Depends(get_session),
 ) -> RuntimeObservedSummaryResponse:
-    bound_env = _bound_env_id(auth)
+    bound_env = auth.bound_environment_id
     filters = [AgentEnvironment.user_id == auth.user_id, active_agent_filter()]
     if bound_env is not None:
         filters.append(AgentEnvironment.id == bound_env)
@@ -1063,7 +1054,7 @@ async def get_environment_runtime_observed(
     auth: AuthContext = Depends(get_auth),
     db: AsyncSession = Depends(get_session),
 ) -> RuntimeObservedResponse:
-    bound_env = _bound_env_id(auth)
+    bound_env = auth.bound_environment_id
     if bound_env is not None and environment_id != bound_env:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
 
@@ -1300,7 +1291,7 @@ async def _hosted_deployment_ids(
 def _agent_to_response(env: AgentEnvironment) -> AgentResponse:
     return AgentResponse(
         id=str(env.id),
-        name=_agent_name_from_fields(
+        name=agent_name_from_fields(
             env.display_name, env.default_name, env.machine_name, env.agent_type
         ),
         default_name=env.default_name,
@@ -1351,21 +1342,6 @@ def _identity_response(
     if agent_response:
         return _agent_to_response(env)
     return _env_to_response_with_deployment_id(env, hosted_deployment_id)
-
-
-def _agent_name_from_fields(
-    display_name: str | None,
-    default_name: str | None,
-    machine_name: str | None,
-    agent_type: str | None,
-) -> str:
-    return (
-        (display_name or "").strip()
-        or (default_name or "").strip()
-        or (machine_name or "").strip()
-        or agent_type
-        or "Unknown"
-    )
 
 
 def _detect_avatar_image(data: bytes) -> tuple[str, str] | None:
@@ -2579,7 +2555,7 @@ async def list_sessions(
     # Reject an explicit `environment_id` query that doesn't match
     # the binding rather than silently overriding it — the caller
     # asking for the wrong env is a bug worth surfacing.
-    bound_env = _bound_env_id(auth)
+    bound_env = auth.bound_environment_id
     if bound_env is not None and environment_id is not None and environment_id != bound_env:
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,
@@ -2770,7 +2746,7 @@ async def get_session_detail(
     auth: AuthContext = Depends(require_scope("sessions:read")),
     db: AsyncSession = Depends(get_session),
 ) -> SessionDetailResponse:
-    bound_env = _bound_env_id(auth)
+    bound_env = auth.bound_environment_id
     is_shared_subq = _link_is_shared_subq()
     stmt = (
         select(
@@ -2882,7 +2858,7 @@ async def upload_session_content(
     db: AsyncSession = Depends(get_session),
 ) -> SessionUploadResponse:
     """Upload session messages JSON to FileStore."""
-    bound_env = _bound_env_id(auth)
+    bound_env = auth.bound_environment_id
     stmt = select(Session).where(
         Session.user_id == auth.user_id,
         Session.local_session_id == local_session_id,
@@ -3006,7 +2982,7 @@ async def get_session_content(
     db: AsyncSession = Depends(get_session),
 ) -> list[SessionMessageResponse]:
     """Read session messages from FileStore, typed as SessionMessageResponse[]."""
-    bound_env = _bound_env_id(auth)
+    bound_env = auth.bound_environment_id
     stmt = select(Session).where(
         Session.user_id == auth.user_id,
         Session.id == session_id,
@@ -3072,7 +3048,7 @@ async def get_session_messages(
             "Search anchor requires kind, position, and revision",
         )
 
-    bound_env = _bound_env_id(auth)
+    bound_env = auth.bound_environment_id
     stmt = select(Session).where(
         Session.user_id == auth.user_id,
         Session.id == session_id,
@@ -3250,7 +3226,7 @@ async def extract_session_memories(
             "LLM is not configured on this deployment",
         )
 
-    bound_env = _bound_env_id(auth)
+    bound_env = auth.bound_environment_id
     stmt = select(Session).where(
         Session.user_id == auth.user_id,
         Session.local_session_id == local_session_id,
@@ -3339,7 +3315,7 @@ async def export_owned_session_markdown(
     and `source` is `clawdi-session` instead of `clawdi-shared-session`
     so the LLM can tell the two apart if it cares.
     """
-    bound_env = _bound_env_id(auth)
+    bound_env = auth.bound_environment_id
     stmt = (
         select(Session, AgentEnvironment.agent_type)
         .outerjoin(AgentEnvironment, Session.environment_id == AgentEnvironment.id)
@@ -3567,7 +3543,7 @@ def _session_to_response(
     search_match: SessionSearchMatchResponse | None = None,
 ) -> SessionListItemResponse:
     agent_name = (
-        _agent_name_from_fields(agent_display_name, agent_default_name, machine_name, None)
+        agent_name_from_fields(agent_display_name, agent_default_name, machine_name, None)
         if any((agent_display_name, agent_default_name, machine_name))
         else None
     )
@@ -3666,7 +3642,7 @@ async def _load_session_for_owner(
     404s rather than 403s on visibility violations (env-binding mismatch)
     to avoid leaking which session-ids exist outside the caller's project.
     """
-    bound_env = _bound_env_id(auth)
+    bound_env = auth.bound_environment_id
     stmt = select(Session).where(
         Session.user_id == auth.user_id,
         Session.id == session_id,

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -192,6 +192,11 @@ async def _analyze_session_upload(data: bytes) -> _SessionUploadAnalysis:
     return await asyncio.to_thread(_analyze_session_upload_sync, data)
 
 
+def _bound_env_id(auth: AuthContext) -> UUID | None:
+    """Return the environment fence carried by an Agent-bound API key."""
+    return auth.bound_environment_id
+
+
 # Clock-skew window for client-supplied `last_activity_at`. Anything
 # more than this far in the future is treated as a sign of broken
 # client clocks (laptop NTP off, container with wrong timezone) or a
@@ -386,7 +391,7 @@ async def _list_agent_identities(
     # — the whole point of the env binding is to bound the blast
     # radius of a leaked key. The full list stays available to
     # Clerk JWT (dashboard) callers.
-    bound_env = auth.bound_environment_id
+    bound_env = _bound_env_id(auth)
     stmt = (
         select(AgentEnvironment)
         .where(AgentEnvironment.user_id == auth.user_id, active_agent_filter())
@@ -505,7 +510,7 @@ async def _get_agent_identity(
     *,
     agent_response: bool,
 ) -> AgentResponse | EnvironmentResponse | Response:
-    bound_env = auth.bound_environment_id
+    bound_env = _bound_env_id(auth)
     if bound_env is not None and agent_id != bound_env:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
     row = (
@@ -559,7 +564,7 @@ async def list_environment_runtime_observed(
     auth: AuthContext = Depends(get_auth),
     db: AsyncSession = Depends(get_session),
 ) -> RuntimeObservedSummaryResponse:
-    bound_env = auth.bound_environment_id
+    bound_env = _bound_env_id(auth)
     filters = [AgentEnvironment.user_id == auth.user_id, active_agent_filter()]
     if bound_env is not None:
         filters.append(AgentEnvironment.id == bound_env)
@@ -1054,7 +1059,7 @@ async def get_environment_runtime_observed(
     auth: AuthContext = Depends(get_auth),
     db: AsyncSession = Depends(get_session),
 ) -> RuntimeObservedResponse:
-    bound_env = auth.bound_environment_id
+    bound_env = _bound_env_id(auth)
     if bound_env is not None and environment_id != bound_env:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
 
@@ -2555,7 +2560,7 @@ async def list_sessions(
     # Reject an explicit `environment_id` query that doesn't match
     # the binding rather than silently overriding it — the caller
     # asking for the wrong env is a bug worth surfacing.
-    bound_env = auth.bound_environment_id
+    bound_env = _bound_env_id(auth)
     if bound_env is not None and environment_id is not None and environment_id != bound_env:
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,
@@ -2746,7 +2751,7 @@ async def get_session_detail(
     auth: AuthContext = Depends(require_scope("sessions:read")),
     db: AsyncSession = Depends(get_session),
 ) -> SessionDetailResponse:
-    bound_env = auth.bound_environment_id
+    bound_env = _bound_env_id(auth)
     is_shared_subq = _link_is_shared_subq()
     stmt = (
         select(
@@ -2858,7 +2863,7 @@ async def upload_session_content(
     db: AsyncSession = Depends(get_session),
 ) -> SessionUploadResponse:
     """Upload session messages JSON to FileStore."""
-    bound_env = auth.bound_environment_id
+    bound_env = _bound_env_id(auth)
     stmt = select(Session).where(
         Session.user_id == auth.user_id,
         Session.local_session_id == local_session_id,
@@ -2982,7 +2987,7 @@ async def get_session_content(
     db: AsyncSession = Depends(get_session),
 ) -> list[SessionMessageResponse]:
     """Read session messages from FileStore, typed as SessionMessageResponse[]."""
-    bound_env = auth.bound_environment_id
+    bound_env = _bound_env_id(auth)
     stmt = select(Session).where(
         Session.user_id == auth.user_id,
         Session.id == session_id,
@@ -3048,7 +3053,7 @@ async def get_session_messages(
             "Search anchor requires kind, position, and revision",
         )
 
-    bound_env = auth.bound_environment_id
+    bound_env = _bound_env_id(auth)
     stmt = select(Session).where(
         Session.user_id == auth.user_id,
         Session.id == session_id,
@@ -3226,7 +3231,7 @@ async def extract_session_memories(
             "LLM is not configured on this deployment",
         )
 
-    bound_env = auth.bound_environment_id
+    bound_env = _bound_env_id(auth)
     stmt = select(Session).where(
         Session.user_id == auth.user_id,
         Session.local_session_id == local_session_id,
@@ -3315,7 +3320,7 @@ async def export_owned_session_markdown(
     and `source` is `clawdi-session` instead of `clawdi-shared-session`
     so the LLM can tell the two apart if it cares.
     """
-    bound_env = auth.bound_environment_id
+    bound_env = _bound_env_id(auth)
     stmt = (
         select(Session, AgentEnvironment.agent_type)
         .outerjoin(AgentEnvironment, Session.environment_id == AgentEnvironment.id)
@@ -3642,7 +3647,7 @@ async def _load_session_for_owner(
     404s rather than 403s on visibility violations (env-binding mismatch)
     to avoid leaking which session-ids exist outside the caller's project.
     """
-    bound_env = auth.bound_environment_id
+    bound_env = _bound_env_id(auth)
     stmt = select(Session).where(
         Session.user_id == auth.user_id,
         Session.id == session_id,

--- a/backend/app/services/agent_environments.py
+++ b/backend/app/services/agent_environments.py
@@ -361,6 +361,21 @@ def agent_type_default_label(agent_type: str) -> str:
     return _AGENT_TYPE_LABELS.get(agent_type, agent_type.strip() or "Agent")
 
 
+def agent_name_from_fields(
+    display_name: str | None,
+    default_name: str | None,
+    machine_name: str | None,
+    agent_type: str | None,
+) -> str:
+    return (
+        (display_name or "").strip()
+        or (default_name or "").strip()
+        or (machine_name or "").strip()
+        or agent_type
+        or "Unknown"
+    )
+
+
 def _agent_default_name_index(name: str, base: str) -> int | None:
     if name == base:
         return 1

--- a/backend/tests/test_project_isolation.py
+++ b/backend/tests/test_project_isolation.py
@@ -513,6 +513,11 @@ async def test_bound_deploy_key_still_pinned_to_its_env(
         )
         assert resp.status_code == 200
         assert resp.json()["items"] == [], resp.json()
+
+        search = await client.get("/v1/search", params={"q": "Env"})
+        assert search.status_code == 200, search.text
+        agent_ids = {hit["id"] for hit in search.json()["results"] if hit["type"] == "agent"}
+        assert agent_ids == {str(env_a.id)}
     finally:
         await client.aclose()
         app.dependency_overrides.clear()

--- a/backend/tests/test_project_visibility_shared.py
+++ b/backend/tests/test_project_visibility_shared.py
@@ -143,6 +143,12 @@ async def test_recipient_can_read_shared_project_skill_detail_and_search(
         skill_hits = [h for h in skill_search.json()["results"] if h["type"] == "skill"]
         assert any(h["id"] for h in skill_hits), skill_search.json()
 
+        project_search = await client.get("/v1/search", params={"q": f"ro-{nonce}"})
+        assert project_search.status_code == 200, project_search.text
+        project_hit = next(h for h in project_search.json()["results"] if h["type"] == "project")
+        assert project_hit["id"] == str(shared.id)
+        assert project_hit["subtitle"] == f"Shared by ro-{nonce}"
+
         vault_search = await client.get("/v1/search", params={"q": f"shared-vault-{nonce}"})
         assert vault_search.status_code == 200, vault_search.text
         vault_hits = [h for h in vault_search.json()["results"] if h["type"] == "vault"]

--- a/backend/tests/test_projects_routes.py
+++ b/backend/tests/test_projects_routes.py
@@ -460,15 +460,28 @@ async def test_project_agent_delta_is_atomic_and_skips_noop_notifications(
         sync_events.unsubscribe(user_id, conflict_queue)
 
 
-async def test_global_search_finds_projects_by_name_and_slug(client):
+async def test_global_search_finds_projects_by_name_slug_and_description(client):
     created = await client.post("/v1/projects", json={"name": "Redpill Launch"})
     assert created.status_code == 201, created.text
     project_id = created.json()["id"]
+    described = await client.post(
+        "/v1/projects",
+        json={
+            "name": "Alpha Migration Notes",
+            "description": "Coordinates the redpill rollout across services.",
+        },
+    )
+    assert described.status_code == 201, described.text
+    described_project_id = described.json()["id"]
 
     by_name = await client.get("/v1/search", params={"q": "redpill"})
     assert by_name.status_code == 200, by_name.text
     project_hits = [h for h in by_name.json()["results"] if h["type"] == "project"]
-    assert [(h["id"], h["href"]) for h in project_hits] == [(project_id, f"/projects/{project_id}")]
+    assert [(h["id"], h["href"]) for h in project_hits] == [
+        (project_id, f"/projects/{project_id}"),
+        (described_project_id, f"/projects/{described_project_id}"),
+    ]
+    assert "redpill" in project_hits[1]["subtitle"]
 
     by_slug = await client.get("/v1/search", params={"q": "redpill-launch"})
     slug_hits = [h for h in by_slug.json()["results"] if h["type"] == "project"]

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -462,7 +462,7 @@ async def test_session_batch_clamps_negative_duration_and_logs_user_agent(
 
 
 @pytest.mark.asyncio
-async def test_session_list_and_detail_include_canonical_agent_identity_fields(
+async def test_sessions_and_search_use_canonical_agent_identity_fields(
     client: httpx.AsyncClient, db_session: AsyncSession
 ):
     from sqlalchemy import select
@@ -510,6 +510,18 @@ async def test_session_list_and_detail_include_canonical_agent_identity_fields(
     assert detail_body["agent_name"] == "Launch runner"
     assert detail_body["agent_display_name"] == "Launch runner"
     assert detail_body["agent_default_name"] == "Research Agent"
+
+    search = await client.get("/v1/search", params={"q": "Research Agent"})
+    assert search.status_code == 200, search.text
+    agent_hit = next(hit for hit in search.json()["results"] if hit["type"] == "agent")
+    assert agent_hit == {
+        "type": "agent",
+        "id": env_id,
+        "title": "Launch runner",
+        "subtitle": "Research Agent",
+        "href": f"/agents/{env_id}",
+        "search_match": None,
+    }
 
 
 @pytest.mark.asyncio

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -2849,10 +2849,10 @@ export interface paths {
          * @description Run each entity searcher and concat results.
          *
          *     Each searcher returns at most `TYPE_LIMIT` rows; total is capped at
-         *     5*TYPE_LIMIT which keeps the palette responsive even with noisy queries.
+         *     6*TYPE_LIMIT which keeps the palette responsive even with noisy queries.
          *
-         *     Sessions/skills/vaults use `ILIKE` (small tables) — memories goes through
-         *     the hybrid provider (FTS + trgm + optional pgvector) for quality.
+         *     Sessions/projects/skills/vaults use `ILIKE` (small tables) — memories goes
+         *     through the hybrid provider (FTS + trgm + optional pgvector) for quality.
          *
          *     A single failing source (e.g. the memory provider briefly unavailable)
          *     degrades to partial results rather than failing the whole request —
@@ -7544,7 +7544,7 @@ export interface components {
              * Type
              * @enum {string}
              */
-            type: "session" | "memory" | "project" | "skill" | "vault";
+            type: "agent" | "session" | "memory" | "project" | "skill" | "vault";
             /** Id */
             id: string;
             /** Title */


### PR DESCRIPTION
## Summary

- make Projects searchable by name, slug, description, and shared owner in both the Projects page and global search
- rank Project matches by field quality and show highlighted context for slug, description, or owner matches
- add permission-fenced Agent search by display name, default name, machine name, and type with direct detail links
- centralize Agent-bound API-key and Agent display-name logic, and regenerate the OpenAPI client

## Verification

- `scripts/test.sh backend tests/test_projects_routes.py tests/test_project_visibility_shared.py tests/test_sessions.py::test_sessions_and_search_use_canonical_agent_identity_fields tests/test_project_isolation.py::test_bound_deploy_key_still_pinned_to_its_env` (23 passed)
- `scripts/test.sh web src/components/projects/project-metadata.test.ts` (typecheck, 5 tests, OSS production build)
- backend owned typecheck (204 files, 0 errors/warnings)
- generated API consistency check
- Ruff, Biome, and `git diff --check`
- Playwright desktop and 390px mobile visual checks: no console errors or horizontal overflow; Project/Agent highlighting and Agent direct navigation verified