### PR TITLE
feat(search): improve Skill and Vault discovery

### DIFF
--- a/apps/web/src/components/projects/project-metadata.tsx
+++ b/apps/web/src/components/projects/project-metadata.tsx
@@ -14,7 +14,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { identityFor } from "@/lib/identity";
-import { searchExcerpt } from "@/lib/search-highlight";
+import { literalSearchRank, searchExcerpt } from "@/lib/search-highlight";
 import { cn } from "@/lib/utils";
 
 export interface ProjectMetadata {
@@ -60,26 +60,14 @@ export function projectSupportingText(project: ProjectMetadata) {
 }
 
 export function projectSearchRank(project: ProjectMetadata, query: string): number | null {
-	const phrase = query.trim().toLowerCase();
-	if (!phrase) return 0;
-	const name = displayProjectName(project).toLowerCase();
-	const slug = project.slug.toLowerCase();
-	if (name === phrase) return 0;
-	if (slug === phrase) return 1;
-	if (name.startsWith(phrase)) return 2;
-	if (slug.startsWith(phrase)) return 3;
-	if (name.includes(phrase)) return 4;
-	if (slug.includes(phrase)) return 5;
-	if (project.description?.toLowerCase().includes(phrase)) return 6;
-	if (
-		!isProjectOwner(project) &&
-		[project.owner_display, project.owner_handle].some((owner) =>
-			owner?.toLowerCase().includes(phrase),
-		)
-	) {
-		return 7;
-	}
-	return null;
+	const ownerIdentity = isProjectOwner(project)
+		? undefined
+		: `${project.owner_display ?? ""}\n${project.owner_handle ?? ""}`;
+	return literalSearchRank(
+		query,
+		[displayProjectName(project), project.slug],
+		[project.description, ownerIdentity],
+	);
 }
 
 export function projectMatchesSearch(project: ProjectMetadata, query: string): boolean {

--- a/apps/web/src/components/search-asset-quality.test.ts
+++ b/apps/web/src/components/search-asset-quality.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { skillSearchSupportingText } from "@/components/skills/skill-search";
+import { vaultSearchRank, vaultSearchSupportingText } from "@/components/vault/vault-search";
+
+describe("asset search presentation", () => {
+	test("reveals a long Skill description match", () => {
+		const supporting = {
+			skill_key: "runbook",
+			name: "Runbook",
+			description: `${"before ".repeat(30)}release handoff${" after".repeat(30)}`,
+		};
+
+		expect(skillSearchSupportingText(supporting, "release handoff")).toContain("release handoff");
+	});
+
+	test("orders Vault names before slugs and explains slug-only matches", () => {
+		const nameMatch = { name: "Production", slug: "shared-secrets" };
+		const slugMatch = { name: "Shared secrets", slug: "production" };
+
+		expect(vaultSearchRank(nameMatch, "production")).toBe(0);
+		expect(vaultSearchRank(slugMatch, "production")).toBe(1);
+		expect(vaultSearchSupportingText(slugMatch, "production")).toBe("Slug: production");
+	});
+});

--- a/apps/web/src/components/skills/skill-card.tsx
+++ b/apps/web/src/components/skills/skill-card.tsx
@@ -10,8 +10,10 @@ import {
 	HeroCardSkeleton,
 } from "@/components/entity-card";
 import { IconChip } from "@/components/icon-chip";
+import { SearchHighlightedText } from "@/components/search-highlighted-text";
 import { SendSkillDialog } from "@/components/skills/send-skill-dialog";
 import { SkillRemovalDescription } from "@/components/skills/skill-removal-description";
+import { skillSearchSupportingText } from "@/components/skills/skill-search";
 import { TruncatedText } from "@/components/truncated-text";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -43,6 +45,7 @@ export function SkillCard({
 	sourceLabel,
 	provenanceLabel,
 	skillLink,
+	searchQuery,
 }: {
 	skill: SkillCardEntity;
 	/** Real Cloud entity backing navigation/selection/Project mutations. */
@@ -59,6 +62,8 @@ export function SkillCard({
 	provenanceLabel?: string | null;
 	/** Build the detail link for the current navigation scope. */
 	skillLink?: SkillLinkBuilder;
+	/** Collection-local search context; highlights and explains the matching field. */
+	searchQuery?: string;
 }) {
 	const id = identityFor(skill.name || skill.skill_key);
 	const canUninstall = !readOnly && !!onUninstall && !!cloudSkill?.project_id;
@@ -109,7 +114,9 @@ export function SkillCard({
 					{id.emoji}
 				</IconChip>
 			}
-			title={skill.name}
+			title={
+				searchQuery ? <SearchHighlightedText text={skill.name} query={searchQuery} /> : skill.name
+			}
 			badges={
 				<>
 					{showVersion && skill.version !== undefined ? (
@@ -124,7 +131,16 @@ export function SkillCard({
 					) : null}
 				</>
 			}
-			description={skill.description}
+			description={
+				searchQuery ? (
+					<SearchHighlightedText
+						text={skillSearchSupportingText(skill, searchQuery)}
+						query={searchQuery}
+					/>
+				) : (
+					skill.description
+				)
+			}
 			footer={[
 				provenanceLabel ? <span key="provenance">{provenanceLabel}</span> : null,
 				sourceLabel ? (
@@ -169,6 +185,7 @@ export function SkillCardGrid({
 	skillLink,
 	actionsFor,
 	showVersionFor,
+	searchQuery,
 }: {
 	skills: SkillSummary[];
 	isLoading: boolean;
@@ -185,6 +202,7 @@ export function SkillCardGrid({
 	skillLink?: SkillLinkBuilder;
 	actionsFor?: (skill: SkillSummary) => ReactNode;
 	showVersionFor?: (skill: SkillSummary) => boolean;
+	searchQuery?: string;
 }) {
 	if (isLoading) {
 		return (
@@ -219,6 +237,7 @@ export function SkillCardGrid({
 						uninstallPending={uninstallPending}
 						sourceLabel={sourceLabelFor?.(skill) ?? null}
 						skillLink={skillLink}
+						searchQuery={searchQuery}
 					/>
 				);
 			})}

--- a/apps/web/src/components/skills/skill-search.ts
+++ b/apps/web/src/components/skills/skill-search.ts
@@ -1,0 +1,19 @@
+import { searchExcerpt } from "@/lib/search-highlight";
+
+interface SearchableSkill {
+	skill_key: string;
+	name: string;
+	description?: string | null;
+}
+
+export function skillSearchSupportingText(skill: SearchableSkill, query: string): string {
+	const phrase = query.trim().toLowerCase();
+	if (phrase && skill.skill_key.toLowerCase().includes(phrase)) {
+		return `Key: ${skill.skill_key}`;
+	}
+	const description = skill.description?.trim();
+	if (description && phrase && description.toLowerCase().includes(phrase)) {
+		return searchExcerpt(description, query, 160);
+	}
+	return description || `Key: ${skill.skill_key}`;
+}

--- a/apps/web/src/components/vault/vault-search.ts
+++ b/apps/web/src/components/vault/vault-search.ts
@@ -1,0 +1,22 @@
+import { literalSearchRank } from "@/lib/search-highlight";
+
+interface SearchableVault {
+	name: string;
+	slug: string;
+}
+
+export function vaultSearchRank(vault: SearchableVault, query: string): number | null {
+	return literalSearchRank(query, [vault.name, vault.slug]);
+}
+
+export function vaultSearchSupportingText(vault: SearchableVault, query: string): string | null {
+	const phrase = query.trim().toLowerCase();
+	if (
+		phrase &&
+		vault.slug.toLowerCase().includes(phrase) &&
+		vault.slug.toLowerCase() !== vault.name.toLowerCase()
+	) {
+		return `Slug: ${vault.slug}`;
+	}
+	return null;
+}

--- a/apps/web/src/components/vault/vaults-surface.tsx
+++ b/apps/web/src/components/vault/vaults-surface.tsx
@@ -15,6 +15,7 @@ import { ListToolbar } from "@/components/list-toolbar";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { displayProjectName } from "@/components/projects/project-metadata";
+import { SearchHighlightedText } from "@/components/search-highlighted-text";
 import { SectionLabel } from "@/components/section-label";
 import { Button } from "@/components/ui/button";
 import {
@@ -35,6 +36,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { AddKeysDialog } from "@/components/vault/add-keys-dialog";
 import { useAgentProjectVaults } from "@/components/vault/agent-vaults-query";
 import { vaultsForSelectedProject } from "@/components/vault/vault-scope";
+import { vaultSearchRank, vaultSearchSupportingText } from "@/components/vault/vault-search";
 import { slugFromVaultName } from "@/components/vault/vault-slug";
 import { unwrap, useApi, useOpenApi } from "@/lib/api";
 import { normalizeApiError } from "@/lib/api-errors";
@@ -126,10 +128,10 @@ export function VaultsSurface({
 	);
 	const hasActiveFilter = search.trim().length > 0 || projectFilter !== "all";
 	const filtered = useMemo(() => {
-		const q = search.trim().toLowerCase();
+		const q = search.trim();
 		const rows = vaultsForSelectedProject(items, projectFilter);
 		if (!q) return rows;
-		return rows.filter((v) => [v.name, v.slug].join(" ").toLowerCase().includes(q));
+		return rows.filter((vault) => vaultSearchRank(vault, q) !== null);
 	}, [items, search, projectFilter]);
 	// Only projects that actually hold a vault — an empty filter option is
 	// noise. Ranked by how many vaults they hold, busiest first.
@@ -158,8 +160,14 @@ export function VaultsSurface({
 	// where the curation work starts.
 	const byKeysDesc = (a: VaultSummary, b: VaultSummary) =>
 		(b.item_count ?? 0) - (a.item_count ?? 0) || a.name.localeCompare(b.name);
-	const mine = filtered.filter((v) => v.is_owner !== false).sort(byKeysDesc);
-	const shared = filtered.filter((v) => v.is_owner === false).sort(byKeysDesc);
+	const bySearchRank = (a: VaultSummary, b: VaultSummary) =>
+		(vaultSearchRank(a, search) ?? Number.MAX_SAFE_INTEGER) -
+			(vaultSearchRank(b, search) ?? Number.MAX_SAFE_INTEGER) ||
+		a.name.localeCompare(b.name) ||
+		a.id.localeCompare(b.id);
+	const sortVaults = search.trim() ? bySearchRank : byKeysDesc;
+	const mine = filtered.filter((v) => v.is_owner !== false).sort(sortVaults);
+	const shared = filtered.filter((v) => v.is_owner === false).sort(sortVaults);
 
 	return (
 		<div
@@ -261,6 +269,7 @@ export function VaultsSurface({
 								projectNamesUnavailable={projectNamesUnavailable}
 								visibleProjectIds={visibleProjectIds}
 								navigationScope={navigationScope}
+								searchQuery={search.trim() || undefined}
 							/>
 						))}
 					</div>
@@ -280,6 +289,7 @@ export function VaultsSurface({
 										visibleProjectIds={visibleProjectIds}
 										navigationScope={navigationScope}
 										shared
+										searchQuery={search.trim() || undefined}
 									/>
 								))}
 							</div>
@@ -299,6 +309,7 @@ export function VaultCard({
 	navigationScope,
 	shared = false,
 	actions,
+	searchQuery,
 }: {
 	vault: VaultSummary;
 	projectNameById: ReadonlyMap<string, string>;
@@ -307,6 +318,7 @@ export function VaultCard({
 	navigationScope: ResourceNavigationScope;
 	shared?: boolean;
 	actions?: ReactNode;
+	searchQuery?: string;
 }) {
 	const api = useApi();
 	const itemProjectId =
@@ -350,6 +362,7 @@ export function VaultCard({
 	) : (
 		formatResourceCount(keyCount, "key")
 	);
+	const searchSupportingText = searchQuery ? vaultSearchSupportingText(vault, searchQuery) : null;
 
 	return (
 		<HeroCard
@@ -363,7 +376,14 @@ export function VaultCard({
 					) : null}
 				</IconChip>
 			}
-			title={vault.name}
+			title={
+				searchQuery ? <SearchHighlightedText text={vault.name} query={searchQuery} /> : vault.name
+			}
+			description={
+				searchSupportingText ? (
+					<SearchHighlightedText text={searchSupportingText} query={searchQuery ?? ""} />
+				) : undefined
+			}
 			footer={[
 				keyCountLabel,
 				usedBy.length > 0 ? (

--- a/apps/web/src/lib/search-highlight.test.ts
+++ b/apps/web/src/lib/search-highlight.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { searchExcerpt, splitSearchHighlight } from "@/lib/search-highlight";
+import { literalSearchRank, searchExcerpt, splitSearchHighlight } from "@/lib/search-highlight";
 
 describe("search highlighting", () => {
 	test("centers a long excerpt on the literal match", () => {
@@ -18,5 +18,12 @@ describe("search highlighting", () => {
 		const parts = splitSearchHighlight("Keep 100%_ready and a+b literal", "a+b");
 
 		expect(parts.filter((part) => part.highlighted)).toEqual([{ text: "a+b", highlighted: true }]);
+	});
+
+	test("ranks identity matches before supporting text", () => {
+		expect(literalSearchRank("deploy", ["Deploy", "release-deploy"], ["runbook"])).toBe(0);
+		expect(literalSearchRank("release", ["Deploy", "release-deploy"], ["runbook"])).toBe(3);
+		expect(literalSearchRank("runbook", ["Deploy", "release-deploy"], ["runbook"])).toBe(6);
+		expect(literalSearchRank("missing", ["Deploy", "release-deploy"], ["runbook"])).toBeNull();
 	});
 });

--- a/apps/web/src/lib/search-highlight.ts
+++ b/apps/web/src/lib/search-highlight.ts
@@ -3,6 +3,31 @@ export interface SearchHighlightPart {
 	highlighted: boolean;
 }
 
+type SearchField = string | null | undefined;
+
+export function literalSearchRank(
+	query: string,
+	identityFields: readonly SearchField[],
+	supportingFields: readonly SearchField[] = [],
+): number | null {
+	const phrase = query.trim().toLowerCase();
+	if (!phrase) return 0;
+	const identity = identityFields.map((field) => field?.toLowerCase() ?? "");
+	for (const [index, field] of identity.entries()) {
+		if (field === phrase) return index;
+	}
+	for (const [index, field] of identity.entries()) {
+		if (field.startsWith(phrase)) return identity.length + index;
+	}
+	for (const [index, field] of identity.entries()) {
+		if (field.includes(phrase)) return identity.length * 2 + index;
+	}
+	for (const [index, field] of supportingFields.entries()) {
+		if (field?.toLowerCase().includes(phrase)) return identity.length * 3 + index;
+	}
+	return null;
+}
+
 function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/apps/web/src/pages/dashboard/skills/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/page.tsx
@@ -334,6 +334,7 @@ function SkillsPageInner() {
 						capabilitiesFor={(skill) => skillCapabilities(skill, selectedProject)}
 						onUninstall={writable ? (skillKey) => removeSkill.mutateAsync(skillKey) : undefined}
 						uninstallPending={removeSkill.isPending}
+						searchQuery={search.trim() || undefined}
 					/>
 
 					{total > PAGE_SIZE ? (

--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -38,6 +38,11 @@ from app.services.session_search import (
     session_search_matches,
 )
 from app.services.sharing import safe_owner_display
+from app.services.skill_search import (
+    skill_search_filter,
+    skill_search_rank,
+    skill_search_subtitle,
+)
 
 
 def _has_scope(auth: AuthContext, scope: str) -> bool:
@@ -238,7 +243,6 @@ def _memory_search_hit(item: MemoryItem, query: str) -> SearchHit | None:
 
 
 async def _search_skills(db: AsyncSession, auth: AuthContext, query: str) -> list[SearchHit]:
-    needle = like_needle(query)
     visible_project_ids = await project_ids_visible_to(db, auth)
     stmt = (
         select(Skill)
@@ -246,14 +250,8 @@ async def _search_skills(db: AsyncSession, auth: AuthContext, query: str) -> lis
             Skill.is_active,
             Skill.project_id.in_(visible_project_ids),
         )
-        .where(
-            or_(
-                Skill.skill_key.ilike(needle, escape="\\"),
-                Skill.name.ilike(needle, escape="\\"),
-                Skill.description.ilike(needle, escape="\\"),
-            )
-        )
-        .order_by(Skill.skill_key)
+        .where(skill_search_filter(query))
+        .order_by(skill_search_rank(query), Skill.skill_key, Skill.project_id, Skill.id)
         .limit(TYPE_LIMIT)
     )
     rows = (await db.execute(stmt)).scalars().all()
@@ -262,7 +260,7 @@ async def _search_skills(db: AsyncSession, auth: AuthContext, query: str) -> lis
             type="skill",
             id=str(s.id),
             title=s.name or s.skill_key,
-            subtitle=s.description,
+            subtitle=skill_search_subtitle(s, query),
             # Include the project so a multi-agent account where the
             # same `skill_key` exists in two projects routes the
             # palette click to the row that actually matched. The
@@ -371,22 +369,42 @@ def _project_search_subtitle(
 
 
 async def _search_vaults(db: AsyncSession, auth: AuthContext, query: str) -> list[SearchHit]:
+    exact = escape_like(query)
+    prefix = f"{exact}%"
     needle = like_needle(query)
     visible_project_ids = await project_ids_visible_to(db, auth)
-    stmt = (
-        select(Vault)
-        .join(VaultProjectAttachment, VaultProjectAttachment.vault_id == Vault.id)
+    visible_vault = (
+        select(VaultProjectAttachment.id)
         .where(
+            VaultProjectAttachment.vault_id == Vault.id,
             VaultProjectAttachment.project_id.in_(visible_project_ids),
         )
+        .exists()
+    )
+    visibility = (
+        visible_vault
+        if auth.bound_environment_id is not None
+        else or_(Vault.user_id == auth.user_id, visible_vault)
+    )
+    rank = case(
+        (Vault.name.ilike(exact, escape="\\"), 0),
+        (Vault.slug.ilike(exact, escape="\\"), 1),
+        (Vault.name.ilike(prefix, escape="\\"), 2),
+        (Vault.slug.ilike(prefix, escape="\\"), 3),
+        (Vault.name.ilike(needle, escape="\\"), 4),
+        (Vault.slug.ilike(needle, escape="\\"), 5),
+        else_=6,
+    )
+    stmt = (
+        select(Vault)
+        .where(visibility)
         .where(
             or_(
                 Vault.slug.ilike(needle, escape="\\"),
                 Vault.name.ilike(needle, escape="\\"),
             )
         )
-        .distinct()
-        .order_by(Vault.slug)
+        .order_by(rank, Vault.name, Vault.id)
         .limit(TYPE_LIMIT)
     )
     rows = (await db.execute(stmt)).scalars().all()
@@ -395,7 +413,11 @@ async def _search_vaults(db: AsyncSession, auth: AuthContext, query: str) -> lis
             type="vault",
             id=str(v.id),
             title=v.name or v.slug,
-            subtitle="encrypted secrets",
+            subtitle=(
+                v.slug
+                if query.casefold() in v.slug.casefold() and v.slug.casefold() != v.name.casefold()
+                else "encrypted secrets"
+            ),
             href=f"/vaults/{quote(v.slug, safe='')}?vault={v.id}",
         )
         for v in rows

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -34,7 +34,6 @@ from app.core.project import (
     validate_project_for_caller,
     validate_project_read_for_caller,
 )
-from app.core.query_utils import like_needle
 from app.core.skill_key import (
     MAX_SKILL_KEY_LEN,
     RESERVED_SKILL_KEY_SUFFIXES,
@@ -85,6 +84,7 @@ from app.services.runtime_manifest_resources import (
     assert_project_skill_not_runtime_managed,
     project_skill_advisory_lock_key,
 )
+from app.services.skill_search import skill_search_filter, skill_search_rank
 from app.services.sync_events import (
     AGENT_SKILL_CHANGED_EVENT,
     AGENT_SKILL_DELETED_EVENT,
@@ -478,25 +478,25 @@ async def _list_skills_with_db(
     # skills in projects they joined as recipients. Project-id-in-visible
     # already gates access correctly; the membership row earned the
     # project its slot in `visible_project_ids`.
-    base = (
-        select(Skill)
-        .where(
-            Skill.is_active,
-            Skill.project_id.in_(visible_project_ids),
-        )
-        .order_by(Skill.skill_key, Skill.project_id, Skill.id)
+    base = select(Skill).where(
+        Skill.is_active,
+        Skill.project_id.in_(visible_project_ids),
     )
-    if q:
-        needle = like_needle(q)
-        base = base.where(
-            or_(
-                Skill.skill_key.ilike(needle, escape="\\"),
-                Skill.name.ilike(needle, escape="\\"),
-                Skill.description.ilike(needle, escape="\\"),
-            )
-        )
+    query = q.strip() if q else ""
+    if query:
+        base = base.where(skill_search_filter(query))
 
     total = (await db.execute(select(func.count()).select_from(base.subquery()))).scalar_one()
+
+    if query:
+        base = base.order_by(
+            skill_search_rank(query),
+            Skill.skill_key,
+            Skill.project_id,
+            Skill.id,
+        )
+    else:
+        base = base.order_by(Skill.skill_key, Skill.project_id, Skill.id)
 
     skills = (
         (await db.execute(base.limit(page_size).offset((page - 1) * page_size))).scalars().all()

--- a/backend/app/services/skill_search.py
+++ b/backend/app/services/skill_search.py
@@ -1,0 +1,42 @@
+"""Shared literal search semantics for Skill collection surfaces."""
+
+from sqlalchemy import case, or_
+from sqlalchemy.sql.elements import ColumnElement
+
+from app.core.query_utils import escape_like, like_needle, search_excerpt
+from app.models.skill import Skill
+
+
+def skill_search_filter(query: str) -> ColumnElement[bool]:
+    needle = like_needle(query)
+    return or_(
+        Skill.name.ilike(needle, escape="\\"),
+        Skill.skill_key.ilike(needle, escape="\\"),
+        Skill.description.ilike(needle, escape="\\"),
+    )
+
+
+def skill_search_rank(query: str) -> ColumnElement[int]:
+    exact = escape_like(query)
+    prefix = f"{exact}%"
+    needle = like_needle(query)
+    return case(
+        (Skill.name.ilike(exact, escape="\\"), 0),
+        (Skill.skill_key.ilike(exact, escape="\\"), 1),
+        (Skill.name.ilike(prefix, escape="\\"), 2),
+        (Skill.skill_key.ilike(prefix, escape="\\"), 3),
+        (Skill.name.ilike(needle, escape="\\"), 4),
+        (Skill.skill_key.ilike(needle, escape="\\"), 5),
+        (Skill.description.ilike(needle, escape="\\"), 6),
+        else_=7,
+    )
+
+
+def skill_search_subtitle(skill: Skill, query: str) -> str:
+    folded_query = query.casefold()
+    if folded_query in skill.skill_key.casefold():
+        return skill.skill_key
+    description = (skill.description or "").strip()
+    if description and folded_query in description.casefold():
+        return search_excerpt(description, query, limit=160)
+    return description or skill.skill_key

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -298,6 +298,7 @@ strict = [
     "app/services/session_search.py",
     "app/services/sharing.py",
     "app/services/skill_installer.py",
+    "app/services/skill_search.py",
     "app/services/sync_events.py",
     "app/services/tar_utils.py",
     "app/services/telegram_rate_limiter.py",

--- a/backend/tests/test_project_visibility_shared.py
+++ b/backend/tests/test_project_visibility_shared.py
@@ -152,7 +152,8 @@ async def test_recipient_can_read_shared_project_skill_detail_and_search(
         vault_search = await client.get("/v1/search", params={"q": f"shared-vault-{nonce}"})
         assert vault_search.status_code == 200, vault_search.text
         vault_hits = [h for h in vault_search.json()["results"] if h["type"] == "vault"]
-        assert any(h["title"] == f"Shared Vault {nonce}" for h in vault_hits), vault_search.json()
+        vault_hit = next(h for h in vault_hits if h["title"] == f"Shared Vault {nonce}")
+        assert vault_hit["subtitle"] == f"shared-vault-{nonce}"
     finally:
         await db_session.delete(shared)
         await db_session.delete(owner)

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -1336,6 +1336,36 @@ async def test_global_search_returns_hits_across_types(client: httpx.AsyncClient
 
 
 @pytest.mark.asyncio
+async def test_global_vault_search_includes_unattached_owned_and_deduplicates_attachments(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    project_id: str,
+    workspace_project,
+):
+    from app.models.vault import Vault, VaultProjectAttachment
+
+    token = f"vault-{uuid.uuid4().hex[:10]}"
+    exact_name = Vault(user_id=seed_user.id, name=token, slug=f"z-{token}")
+    exact_slug = Vault(user_id=seed_user.id, name="Slug match", slug=token)
+    db_session.add_all([exact_slug, exact_name])
+    await db_session.flush()
+    db_session.add_all(
+        [
+            VaultProjectAttachment(vault_id=exact_slug.id, project_id=uuid.UUID(project_id)),
+            VaultProjectAttachment(vault_id=exact_slug.id, project_id=workspace_project.id),
+        ]
+    )
+    await db_session.commit()
+
+    response = await client.get("/v1/search", params={"q": token})
+    assert response.status_code == 200, response.text
+    hits = [hit for hit in response.json()["results"] if hit["type"] == "vault"]
+    assert [hit["id"] for hit in hits] == [str(exact_name.id), str(exact_slug.id)]
+    assert hits[1]["subtitle"] == token
+
+
+@pytest.mark.asyncio
 async def test_global_search_encodes_nested_skill_keys_in_href(
     client: httpx.AsyncClient, db_session, seed_user, project_id: str
 ):

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -1419,6 +1419,64 @@ async def test_list_skills_order_and_etag_are_stable_across_pages(
 
 
 @pytest.mark.asyncio
+async def test_skill_search_uses_shared_relevance_and_description_excerpt(
+    client: httpx.AsyncClient,
+    db_session,
+    seed_user,
+    project_id: str,
+):
+    token = f"deploy-{uuid.uuid4().hex[:10]}"
+    exact_name = Skill(
+        user_id=seed_user.id,
+        project_id=uuid.UUID(project_id),
+        skill_key=f"z-{token}",
+        name=token,
+        description="Exact display-name match",
+        content_hash="a" * 64,
+    )
+    exact_key = Skill(
+        user_id=seed_user.id,
+        project_id=uuid.UUID(project_id),
+        skill_key=token,
+        name="Key match",
+        description="Exact key match",
+        content_hash="b" * 64,
+    )
+    description_match = Skill(
+        user_id=seed_user.id,
+        project_id=uuid.UUID(project_id),
+        skill_key=f"supporting-{uuid.uuid4().hex[:10]}",
+        name="Description match",
+        description=f"{'before ' * 40}{token}{' after' * 40}",
+        content_hash="c" * 64,
+    )
+    db_session.add_all([description_match, exact_key, exact_name])
+    await db_session.commit()
+
+    listed = await client.get(
+        "/v1/skills",
+        params={"project_id": project_id, "q": token},
+    )
+    assert listed.status_code == 200, listed.text
+    assert [item["id"] for item in listed.json()["items"]] == [
+        str(exact_name.id),
+        str(exact_key.id),
+        str(description_match.id),
+    ]
+
+    searched = await client.get("/v1/search", params={"q": token})
+    assert searched.status_code == 200, searched.text
+    hits = [hit for hit in searched.json()["results"] if hit["type"] == "skill"]
+    assert [hit["id"] for hit in hits] == [
+        str(exact_name.id),
+        str(exact_key.id),
+        str(description_match.id),
+    ]
+    assert token in hits[-1]["subtitle"]
+    assert len(hits[-1]["subtitle"]) <= 166
+
+
+@pytest.mark.asyncio
 async def test_list_skills_etag_covers_project_and_machine_metadata(
     client: httpx.AsyncClient,
     db_session,


### PR DESCRIPTION
## Summary

- unify Skill list and global-search relevance across name, key, and description
- show highlighted Skill key/description and Vault slug evidence in collection cards
- rank Vault name/slug matches consistently, include unattached owned Vaults, and deduplicate multi-Project visibility with `EXISTS`
- reuse the existing literal ranking helper for Project and Vault collection search

## Verification

- Docker clean runner Web typecheck
- Docker clean runner focused Web tests: 10 passed
- Docker clean runner Web OSS build
- Docker PostgreSQL 18 migrations + focused backend tests: 3 passed
- Basedpyright: 0 errors
- Ruff check and format check
- full repository Biome check: 1115 files
- `git diff --check`
