### PR TITLE
refactor(search): rank and explain Connector matches

### DIFF
--- a/apps/web/src/components/connectors/connector-card.tsx
+++ b/apps/web/src/components/connectors/connector-card.tsx
@@ -5,7 +5,9 @@ import { Check } from "lucide-react";
 import { useCallback } from "react";
 import { ConnectorConnectAction } from "@/components/connectors/connector-connect-action";
 import { ConnectorIcon } from "@/components/connectors/connector-icon";
+import { connectorSearchSupportingText } from "@/components/connectors/connector-search";
 import { ENTITY_GRID_CLASS, EntityCardSkeleton, EntityRow } from "@/components/entity-card";
+import { SearchHighlightedText } from "@/components/search-highlighted-text";
 import { useOpenApi } from "@/lib/api";
 import {
 	availableAppQueryOptions,
@@ -29,10 +31,12 @@ export function ConnectorCard({
 	app,
 	isConnected = false,
 	scope = LIBRARY_RESOURCE_SCOPE,
+	searchQuery,
 }: {
 	app: ConnectorAvailableApp;
 	isConnected?: boolean;
 	scope?: ResourceNavigationScope;
+	searchQuery?: string;
 }) {
 	const api = useOpenApi();
 	const queryClient = useQueryClient();
@@ -45,13 +49,28 @@ export function ConnectorCard({
 		<EntityRow
 			ariaLabel={app.display_name}
 			icon={<ConnectorIcon logo={app.logo} name={app.display_name} size="md" />}
-			title={app.display_name}
+			title={
+				searchQuery ? (
+					<SearchHighlightedText text={app.display_name} query={searchQuery} />
+				) : (
+					app.display_name
+				)
+			}
 			titleAdornment={
 				isConnected ? (
 					<Check className="size-3.5 shrink-0 text-success" aria-label="Connected" />
 				) : undefined
 			}
-			meta={app.description}
+			meta={
+				searchQuery ? (
+					<SearchHighlightedText
+						text={connectorSearchSupportingText(app, searchQuery)}
+						query={searchQuery}
+					/>
+				) : (
+					app.description
+				)
+			}
 			actions={
 				!isConnected ? (
 					<ConnectorConnectAction

--- a/apps/web/src/components/connectors/connector-search.ts
+++ b/apps/web/src/components/connectors/connector-search.ts
@@ -1,0 +1,26 @@
+import { searchExcerpt } from "@/lib/search-highlight";
+
+interface SearchableConnector {
+	name: string;
+	display_name: string;
+	description: string;
+}
+
+export function connectorSearchSupportingText(
+	connector: SearchableConnector,
+	query: string,
+): string {
+	const phrase = query.trim().toLowerCase();
+	if (
+		phrase &&
+		connector.name.toLowerCase().includes(phrase) &&
+		connector.name.toLowerCase() !== connector.display_name.toLowerCase()
+	) {
+		return `Slug: ${connector.name}`;
+	}
+	const description = connector.description.trim();
+	if (description && phrase && description.toLowerCase().includes(phrase)) {
+		return searchExcerpt(description, query, 160);
+	}
+	return description || `Slug: ${connector.name}`;
+}

--- a/apps/web/src/components/connectors/connectors-surface.tsx
+++ b/apps/web/src/components/connectors/connectors-surface.tsx
@@ -226,7 +226,7 @@ function ConnectorsList({
 				connectedNames={connectedNames}
 				isLoading={isCatalogLoading}
 				error={catalogError}
-				query={query}
+				query={debouncedQuery}
 				onRetry={() => {
 					void catalogQ.refetch();
 				}}
@@ -348,6 +348,7 @@ function CatalogSection({
 							app={app}
 							isConnected={connectedNames.has(app.name)}
 							scope={scope}
+							searchQuery={query.trim() || undefined}
 						/>
 					))}
 				</div>

--- a/apps/web/src/components/search-asset-quality.test.ts
+++ b/apps/web/src/components/search-asset-quality.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { connectorSearchSupportingText } from "@/components/connectors/connector-search";
 import { skillSearchSupportingText } from "@/components/skills/skill-search";
 import { vaultSearchRank, vaultSearchSupportingText } from "@/components/vault/vault-search";
 
@@ -20,5 +21,18 @@ describe("asset search presentation", () => {
 		expect(vaultSearchRank(nameMatch, "production")).toBe(0);
 		expect(vaultSearchRank(slugMatch, "production")).toBe(1);
 		expect(vaultSearchSupportingText(slugMatch, "production")).toBe("Slug: production");
+	});
+
+	test("explains Connector slug and long-description matches", () => {
+		const connector = {
+			name: "google_mail",
+			display_name: "Gmail",
+			description: `${"before ".repeat(30)}send campaign messages${" after".repeat(30)}`,
+		};
+
+		expect(connectorSearchSupportingText(connector, "google")).toBe("Slug: google_mail");
+		expect(connectorSearchSupportingText(connector, "campaign messages")).toContain(
+			"campaign messages",
+		);
 	});
 });

--- a/backend/app/services/composio.py
+++ b/backend/app/services/composio.py
@@ -1511,15 +1511,15 @@ async def get_available_apps(
     items = [
         (toolkit, _serialize_app(toolkit, allow_unknown_auth_type=True)) for toolkit in toolkits
     ]
-    if search:
-        q = search.lower()
-        items = [
-            (toolkit, app)
+    query = (search or "").strip().casefold()
+    if query:
+        ranked_items = [
+            (rank, toolkit, app)
             for toolkit, app in items
-            if q in app.name.lower()
-            or q in app.display_name.lower()
-            or q in app.description.lower()
+            if (rank := _connector_search_rank(app, query)) is not None
         ]
+        ranked_items.sort(key=lambda item: item[0])
+        items = [(toolkit, app) for _, toolkit, app in ranked_items]
     needs_custom_oauth = any(
         _requires_preconfigured_custom_oauth(
             toolkit,
@@ -1550,6 +1550,22 @@ async def get_available_apps(
         "page": page,
         "page_size": page_size,
     }
+
+
+def _connector_search_rank(app: ConnectorAvailableAppResponse, query: str) -> int | None:
+    identity = (app.display_name.casefold(), app.name.casefold())
+    for index, value in enumerate(identity):
+        if value == query:
+            return index
+    for index, value in enumerate(identity):
+        if value.startswith(query):
+            return len(identity) + index
+    for index, value in enumerate(identity):
+        if query in value:
+            return len(identity) * 2 + index
+    if query in app.description.casefold():
+        return len(identity) * 3
+    return None
 
 
 def _str_or_none(value: str | None) -> str | None:

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -238,6 +238,18 @@ def _hackernews_detail_toolkit() -> _FakeToolkit:
     )
 
 
+def _search_toolkit(slug: str, name: str, description: str) -> _FakeToolkit:
+    return _FakeToolkit(
+        slug=slug,
+        name=name,
+        meta=_meta(description),
+        auth_schemes=[],
+        composio_managed_auth_schemes=[],
+        no_auth=True,
+        auth_config_details=[],
+    )
+
+
 class FakeToolkits:
     def __init__(
         self,
@@ -461,6 +473,31 @@ async def test_catalog_without_auth_metadata_is_unknown_not_oauth2(
     page = await composio.get_available_apps(search="posthog")
 
     assert page["items"][0].auth_type == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_catalog_search_prioritizes_identity_before_description(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake = FakeClient(
+        list_toolkits=[
+            _search_toolkit("postal", "Postal", "Routes Gmail messages"),
+            _search_toolkit("team-mail", "Team Gmail", "Team inbox"),
+            _search_toolkit("gmail-analytics", "Mail insights", "Analytics"),
+            _search_toolkit("gmail", "Gmail", "Google email"),
+        ]
+    )
+    monkeypatch.setattr(settings, "composio_api_key", "composio_test_key")
+    monkeypatch.setattr(composio, "get_composio_client", lambda: fake)
+
+    page = await composio.get_available_apps(search="  GMAIL  ")
+
+    assert [app.name for app in page["items"]] == [
+        "gmail",
+        "gmail-analytics",
+        "team-mail",
+        "postal",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- rank Connector catalog matches by exact name/slug, prefix, substring, then description
- highlight the matching text and show slug or a contextual description excerpt
- keep the existing cached catalog endpoint, pagination, and search contract

## Verification

- full isolated clean runner: Web 1111 pass; Shared 72 pass; WhatsApp sidecar 81 pass; backend 2512 pass / 12 skip; CLI suite pass; workspace typecheck pass; Web OSS build pass
- Biome: 1116 files checked
- Ruff check and format: pass
- git diff --check: pass