### PR TITLE
fix(backend): await database cleanup after repeated cancellation

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,8 +1,9 @@
+import asyncio
+import logging
 import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
-import anyio
 from sqlalchemy import event
 from sqlalchemy.engine import Connection, ExceptionContext
 from sqlalchemy.engine.interfaces import DBAPIConnection, DBAPICursor, ExecutionContext
@@ -15,6 +16,8 @@ from app.services.metrics import (
     db_pool_checked_out,
     db_query_duration,
 )
+
+log = logging.getLogger(__name__)
 
 _QUERY_STARTED_AT = "clawdi_query_started_at"
 _CONNECTION_CHECKED_OUT_AT = "clawdi_connection_checked_out_at"
@@ -105,9 +108,33 @@ event.listen(engine.sync_engine.pool, "checkin", _connection_checkin)
 
 
 async def _close_session(session: AsyncSession) -> None:
-    """Return the connection before leaving a cancelled request scope."""
-    with anyio.CancelScope(shield=True):
-        await session.close()
+    """Return the connection before propagating request cancellation."""
+    close_task = asyncio.create_task(session.close())
+    cancellation: asyncio.CancelledError | None = None
+
+    while not close_task.done():
+        try:
+            await asyncio.shield(close_task)
+        except asyncio.CancelledError as exc:
+            cancellation = exc
+        except Exception as exc:
+            if cancellation is None:
+                raise
+
+            log.exception("Database session cleanup failed during request cancellation")
+            raise cancellation from exc
+
+    try:
+        close_task.result()
+    except Exception as exc:
+        if cancellation is None:
+            raise
+
+        log.exception("Database session cleanup failed during request cancellation")
+        raise cancellation from exc
+
+    if cancellation is not None:
+        raise cancellation
 
 
 class _CancellationSafeAsyncSession(AsyncSession):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,7 +3,6 @@ name = "clawdi-backend"
 version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
-    "anyio>=4.0,<5",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.34",
     "sqlalchemy[asyncio]>=2.0",

--- a/backend/scripts/outbound_api_governance.py
+++ b/backend/scripts/outbound_api_governance.py
@@ -35,7 +35,6 @@ SDK_IMPORT_OWNERS: dict[str, str] = {
 # removed dependency root requires an explicit review of its owner and types.
 EXPECTED_THIRD_PARTY_IMPORT_ROOTS = frozenset(
     {
-        "anyio",
         "asyncpg",
         "boto3",
         "botocore",

--- a/backend/tests/test_database_session_cleanup.py
+++ b/backend/tests/test_database_session_cleanup.py
@@ -1,21 +1,54 @@
 from __future__ import annotations
 
-import anyio
-from sqlalchemy import text
+import asyncio
+
+import pytest
+from sqlalchemy import event, text
 
 from app.core import database
 
 
-async def test_cancelled_session_context_returns_connection_before_exit_completes() -> None:
+async def test_externally_cancelled_dependency_waits_for_session_close() -> None:
     pool = database.engine.sync_engine.pool
     checked_out_before = pool.checkedout()
-    exit_completed = False
-    with anyio.CancelScope() as cancel_scope:
-        async with database.async_session_factory() as session:
+    connection_checked_out = asyncio.Event()
+    close_started = asyncio.Event()
+    checked_out_at_request_finish: int | None = None
+
+    def mark_close_started(_connection: object) -> None:
+        close_started.set()
+
+    async def run_request() -> None:
+        nonlocal checked_out_at_request_finish
+        dependency = database.get_session()
+        session = await anext(dependency)
+        try:
             await session.execute(text("SELECT 1"))
             assert pool.checkedout() == checked_out_before + 1
-            cancel_scope.cancel()
-        exit_completed = True
+            connection_checked_out.set()
+            await asyncio.Event().wait()
+        finally:
+            try:
+                await dependency.aclose()
+            finally:
+                checked_out_at_request_finish = pool.checkedout()
 
-    assert exit_completed
+    event.listen(database.engine.sync_engine, "rollback", mark_close_started)
+    request_task = asyncio.create_task(run_request())
+    try:
+        await connection_checked_out.wait()
+        assert request_task.cancel("disconnect")
+        await close_started.wait()
+        assert not request_task.done()
+        assert request_task.cancel("disconnect-again")
+
+        with pytest.raises(asyncio.CancelledError, match="disconnect-again"):
+            await request_task
+    finally:
+        event.remove(database.engine.sync_engine, "rollback", mark_close_started)
+        if not request_task.done():
+            request_task.cancel()
+            await asyncio.gather(request_task, return_exceptions=True)
+
+    assert checked_out_at_request_finish == checked_out_before
     assert pool.checkedout() == checked_out_before

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -444,7 +444,6 @@ source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "alembic" },
-    { name = "anyio" },
     { name = "asyncpg" },
     { name = "boto3" },
     { name = "botocore" },
@@ -497,7 +496,6 @@ dev = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=24.1" },
     { name = "alembic", specifier = ">=1.14" },
-    { name = "anyio", specifier = ">=4.0,<5" },
     { name = "asyncpg", specifier = "==0.31.0" },
     { name = "boto3", specifier = "==1.43.67" },
     { name = "botocore", specifier = "==1.43.67" },


### PR DESCRIPTION
## Summary

- run `AsyncSession.close()` in an independently owned task
- absorb repeated caller cancellation until the close task finishes, then propagate the final cancellation
- replace the false-positive AnyIO regression with a real PostgreSQL test that cancels again after rollback begins
- remove the no-longer-needed direct AnyIO dependency added by #1279

## Root cause

Production after #1279 continued emitting `Exception terminating connection` and GC non-checked-in connection warnings during SSE disconnect waves. `anyio.CancelScope(shield=True)` only shields cancellation delivered through its visible parent scope; a second direct `Task.cancel()` on the request task still interrupts `session.close()`.

The new regression reproduces that exact sequence against the production session factory and verifies the checked-out connection is returned before the request task exits.

## Verification

- focused PostgreSQL cleanup regression and dependency governance: 10 passed
- Ruff lint and format: 220 files passed
- strict type governance: 205 files, 0 diagnostics
- deptry: 205 files passed
- `uv lock --check` and outbound dependency governance passed
