### PR TITLE
fix(backend): protect SSE lease release from cancellation

### DIFF
--- a/backend/app/routes/sync.py
+++ b/backend/app/routes/sync.py
@@ -159,10 +159,23 @@ async def _refresh_subscription_lease(lease_id: UUID, close_stream: asyncio.Even
 
 
 async def _release_subscription_lease_safely(lease_id: UUID) -> None:
-    try:
-        await release_sync_subscription_lease(lease_id)
-    except Exception as error:  # noqa: BLE001 - expiry is the crash-safe fallback
-        log.warning("sync events: subscription lease release failed: %s", error)
+    async def release() -> None:
+        try:
+            await release_sync_subscription_lease(lease_id)
+        except Exception as error:  # noqa: BLE001 - expiry is the crash-safe fallback
+            log.warning("sync events: subscription lease release failed: %s", error)
+
+    release_task = asyncio.create_task(release())
+    cancellation: asyncio.CancelledError | None = None
+    while not release_task.done():
+        try:
+            await asyncio.shield(release_task)
+        except asyncio.CancelledError as error:
+            cancellation = error
+
+    release_task.result()
+    if cancellation is not None:
+        raise cancellation
 
 
 async def _stream(

--- a/backend/tests/test_sync_events.py
+++ b/backend/tests/test_sync_events.py
@@ -39,6 +39,7 @@ from app.core.skill_sync_protocol import (
     resolve_skill_sync_protocol,
 )
 from app.models.api_key import ApiKey
+from app.models.distributed_state import SyncSubscriptionLease
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.user import User
 from app.services import sync_events
@@ -433,6 +434,59 @@ async def test_stream_cancellation_awaits_internal_wait_tasks(
 
     assert all(task.done() for task in internal_tasks)
     assert all(task.cancelled() for task in internal_tasks)
+
+
+@pytest.mark.asyncio
+async def test_stream_cancellation_waits_for_lease_release_transaction(
+    db_session: AsyncSession,
+    seed_user: User,
+):
+    """Repeated request cancellation must not interrupt the lease DELETE."""
+    _api_key, _auth, iterator = await _open_api_key_stream(db_session, seed_user)
+    pool = app_engine.sync_engine.pool
+    checked_out_before = pool.checkedout()
+    lease_id = (
+        await db_session.execute(
+            select(SyncSubscriptionLease.id)
+            .where(SyncSubscriptionLease.user_id == seed_user.id)
+            .with_for_update()
+        )
+    ).scalar_one()
+    release_started = asyncio.Event()
+
+    def capture_release(_connection, _cursor, statement: str, *_args) -> None:
+        if statement.lstrip().startswith("DELETE FROM sync_subscription_leases"):
+            release_started.set()
+
+    event.listen(app_engine.sync_engine, "before_cursor_execute", capture_release)
+    next_chunk = asyncio.create_task(iterator.__anext__())
+    try:
+        await asyncio.sleep(0)
+        assert next_chunk.cancel("disconnect")
+        await asyncio.wait_for(release_started.wait(), timeout=1)
+        assert next_chunk.cancel("disconnect-again")
+        await asyncio.sleep(0)
+        assert not next_chunk.done()
+
+        await db_session.commit()
+        with pytest.raises(asyncio.CancelledError, match="disconnect-again"):
+            await next_chunk
+
+        assert (
+            await db_session.scalar(
+                select(SyncSubscriptionLease.id).where(SyncSubscriptionLease.id == lease_id)
+            )
+            is None
+        )
+        assert pool.checkedout() == checked_out_before
+    finally:
+        event.remove(app_engine.sync_engine, "before_cursor_execute", capture_release)
+        if db_session.in_transaction():
+            await db_session.rollback()
+        if not next_chunk.done():
+            next_chunk.cancel()
+            await asyncio.gather(next_chunk, return_exceptions=True)
+        await iterator.aclose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- run SSE subscription lease release in an independent task
- defer repeated request cancellation until the DELETE/COMMIT transaction finishes
- cover lock contention plus repeated cancellation against PostgreSQL

## Root cause
ASGI request cancellation could interrupt the lease release transaction before session cleanup. The connection was already invalidated by the time the session close boundary ran, so protecting close alone was insufficient.

## Verification
- PostgreSQL regression and database cleanup: 2 passed
- sync events plus database cleanup: 38 passed
- type governance: 205 files, 0 errors/warnings
- deptry: passed
- Ruff lint/format: passed