### PR TITLE
feat(search): support multi-term queries

### DIFF
--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -124,7 +124,7 @@ test("opens a global Session body match at the exact message", async ({ page }) 
 		.getByPlaceholder("Search agents, sessions, memories, projects, skills, vaults…")
 		.fill(query);
 	await expect(palette.getByText(`Found the ${query} in this response`)).toBeVisible();
-	await expect(palette.locator("mark")).toHaveText(query);
+	await expect(palette.locator("mark")).toHaveText(["Global", "global", "palette", "anchor"]);
 	await palette.getByText("Global search result").click();
 
 	await expect(page).toHaveURL((url) => {
@@ -136,7 +136,7 @@ test("opens a global Session body match at the exact message", async ({ page }) 
 	});
 	const current = page.locator('[data-search-match="true"]');
 	await expect(current).toContainText(`Found the ${query} in this response`);
-	await expect(current.locator("mark")).toHaveText(query);
+	await expect(current.locator("mark")).toHaveText(["global", "palette", "anchor"]);
 });
 
 test("opens a message search result and returns to the same filtered list", async ({ page }) => {
@@ -216,7 +216,7 @@ test("opens a message search result and returns to the same filtered list", asyn
 
 	await page.goto("/sessions?q=authentication%20timeout&agent=codex&page=2&view=table");
 	const visibleResult = page.locator('[data-testid="session-card"]:visible');
-	await expect(visibleResult.locator("mark")).toHaveText("authentication timeout");
+	await expect(visibleResult.locator("mark")).toHaveText(["authentication", "timeout"]);
 
 	await visibleResult
 		.getByRole("link", { name: "Open session Fix authentication timeout" })
@@ -242,7 +242,7 @@ test("opens a message search result and returns to the same filtered list", asyn
 	await expect(page.locator('[data-search-match="true"]')).toContainText(
 		"Verified the authentication timeout no longer recurs",
 	);
-	await expect(page.locator('[data-search-match="true"] mark')).toHaveText("no longer");
+	await expect(page.locator('[data-search-match="true"] mark')).toHaveText(["no", "longer"]);
 	await expect(page.getByText("1 / 1")).toBeVisible();
 
 	await page.getByText("Back to Sessions", { exact: true }).click();
@@ -530,7 +530,7 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 	await page.goto(`/sessions/${SESSION_ID}?${search}`);
 	const current = page.locator('[data-search-match="true"]');
 	await expect(current).toContainText(`Current ${query} result stays mounted`);
-	await expect(current.locator("mark")).toHaveText(query);
+	await expect(current.locator("mark")).toHaveText(["virtualized", "needle"]);
 	expect(await mountedRows.count()).toBeLessThan(80);
 
 	await page.setViewportSize({ width: 390, height: 844 });

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -32,6 +32,7 @@ import type { SearchHit } from "@/lib/api-schemas";
 import { IS_HOSTED } from "@/lib/hosted";
 import { consoleCommandPaletteItems } from "@/lib/navigation-model";
 import { useProductAccess } from "@/lib/product-access";
+import { searchTerms } from "@/lib/search-highlight";
 import { sessionDetailLink } from "@/lib/session-search-anchor";
 import type { SettingsSectionId } from "@/lib/settings-routes";
 import { useDebouncedValue } from "@/lib/use-debounced";
@@ -231,13 +232,19 @@ function CommandPalette({
 	);
 
 	const hasQuery = searchQuery.length > 0;
-	const normalizedQuery = searchQuery.toLowerCase();
+	const normalizedTerms = useMemo(
+		() => searchTerms(searchQuery).map((term) => term.toLocaleLowerCase()),
+		[searchQuery],
+	);
 	const navMatches = useMemo(
 		() =>
-			normalizedQuery
-				? navShortcuts.filter((s) => s.searchText.toLowerCase().includes(normalizedQuery))
+			normalizedTerms.length > 0
+				? navShortcuts.filter((shortcut) => {
+						const text = shortcut.searchText.toLocaleLowerCase();
+						return normalizedTerms.every((term) => text.includes(term));
+					})
 				: navShortcuts,
-		[navShortcuts, normalizedQuery],
+		[navShortcuts, normalizedTerms],
 	);
 
 	// Whether we have a stale results payload we can keep showing while a

--- a/apps/web/src/components/connectors/connector-search.ts
+++ b/apps/web/src/components/connectors/connector-search.ts
@@ -1,4 +1,4 @@
-import { searchExcerpt } from "@/lib/search-highlight";
+import { searchExcerpt, searchTerms } from "@/lib/search-highlight";
 
 interface SearchableConnector {
 	name: string;
@@ -10,16 +10,18 @@ export function connectorSearchSupportingText(
 	connector: SearchableConnector,
 	query: string,
 ): string {
-	const phrase = query.trim().toLowerCase();
+	const terms = searchTerms(query).map((term) => term.toLocaleLowerCase());
+	const title = connector.display_name.toLocaleLowerCase();
+	const supportingTerms = terms.filter((term) => !title.includes(term));
+	const relevantTerms = supportingTerms.length > 0 ? supportingTerms : terms;
 	if (
-		phrase &&
-		connector.name.toLowerCase().includes(phrase) &&
-		connector.name.toLowerCase() !== connector.display_name.toLowerCase()
+		relevantTerms.some((term) => connector.name.toLocaleLowerCase().includes(term)) &&
+		connector.name.toLocaleLowerCase() !== title
 	) {
 		return `Slug: ${connector.name}`;
 	}
 	const description = connector.description.trim();
-	if (description && phrase && description.toLowerCase().includes(phrase)) {
+	if (description && relevantTerms.some((term) => description.toLocaleLowerCase().includes(term))) {
 		return searchExcerpt(description, query, 160);
 	}
 	return description || `Slug: ${connector.name}`;

--- a/apps/web/src/components/markdown.test.tsx
+++ b/apps/web/src/components/markdown.test.tsx
@@ -12,8 +12,9 @@ describe("Markdown search highlighting", () => {
 			}),
 		);
 
-		expect(markup.match(/<mark/g)).toHaveLength(1);
-		expect(markup).toContain(">authentication timeout</mark>");
+		expect(markup.match(/<mark/g)).toHaveLength(2);
+		expect(markup).toContain(">authentication</mark> <mark");
+		expect(markup).toContain(">timeout</mark>");
 		expect(markup).toContain("authentication timeout\n</code>");
 	});
 });

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -57,7 +57,8 @@ function searchHighlightPlugin(query: string) {
 								data: {
 									hName: "mark",
 									hProperties: {
-										className: "rounded-sm bg-primary/20 px-0.5 text-inherit",
+										className:
+											"bg-transparent font-semibold text-foreground underline decoration-primary/50 decoration-1 underline-offset-2",
 									},
 								},
 								children: [{ type: "text", value: part.text }],

--- a/apps/web/src/components/projects/project-metadata.test.ts
+++ b/apps/web/src/components/projects/project-metadata.test.ts
@@ -69,4 +69,10 @@ describe("Project search projection", () => {
 		expect(projectSearchRank(project, "production rollout")).toBe(6);
 		expect(projectSearchRank(project, "a1b2")).toBe(7);
 	});
+
+	test("matches terms across fields and explains the supporting match", () => {
+		expect(projectMatchesSearch(project, "launch production")).toBe(true);
+		expect(projectSearchSupportingText(project, "launch production")).toContain("production");
+		expect(projectMatchesSearch(project, "launch missing")).toBe(false);
+	});
 });

--- a/apps/web/src/components/projects/project-metadata.tsx
+++ b/apps/web/src/components/projects/project-metadata.tsx
@@ -14,7 +14,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { identityFor } from "@/lib/identity";
-import { literalSearchRank, searchExcerpt } from "@/lib/search-highlight";
+import { literalSearchRank, searchExcerpt, searchTerms } from "@/lib/search-highlight";
 import { cn } from "@/lib/utils";
 
 export interface ProjectMetadata {
@@ -75,18 +75,23 @@ export function projectMatchesSearch(project: ProjectMetadata, query: string): b
 }
 
 export function projectSearchSupportingText(project: ProjectMetadata, query: string): string {
-	const phrase = query.trim().toLowerCase();
-	if (!phrase) return projectSupportingText(project);
+	const terms = searchTerms(query).map((term) => term.toLocaleLowerCase());
+	if (terms.length === 0) return projectSupportingText(project);
+	const title = displayProjectName(project).toLocaleLowerCase();
+	const supportingTerms = terms.filter((term) => !title.includes(term));
+	const relevantTerms = supportingTerms.length > 0 ? supportingTerms : terms;
 
-	if (project.slug.toLowerCase().includes(phrase)) return `Slug: ${project.slug}`;
+	if (relevantTerms.some((term) => project.slug.toLocaleLowerCase().includes(term))) {
+		return `Slug: ${project.slug}`;
+	}
 
 	const description = project.description?.trim();
-	if (description?.toLowerCase().includes(phrase)) {
+	if (description && relevantTerms.some((term) => description.toLocaleLowerCase().includes(term))) {
 		return searchExcerpt(description, query, 160);
 	}
 
 	const matchingOwner = [project.owner_display, project.owner_handle].find((owner) =>
-		owner?.toLowerCase().includes(phrase),
+		relevantTerms.some((term) => owner?.toLocaleLowerCase().includes(term)),
 	);
 	if (!isProjectOwner(project) && matchingOwner) {
 		return `Shared by ${matchingOwner}`;

--- a/apps/web/src/components/search-highlighted-text.tsx
+++ b/apps/web/src/components/search-highlighted-text.tsx
@@ -18,7 +18,10 @@ export function SearchHighlightedText({
 				part.highlighted ? (
 					<mark
 						key={`${index}:${part.text}`}
-						className={cn("rounded-sm bg-primary/15 px-0.5 text-inherit", markClassName)}
+						className={cn(
+							"bg-transparent font-semibold text-foreground underline decoration-primary/50 decoration-1 underline-offset-2",
+							markClassName,
+						)}
 					>
 						{part.text}
 					</mark>

--- a/apps/web/src/components/sessions/message-list.test.tsx
+++ b/apps/web/src/components/sessions/message-list.test.tsx
@@ -169,7 +169,7 @@ describe("SessionTimelineList", () => {
 			},
 		);
 
-		expect(markup.match(/<mark/g)).toHaveLength(3);
+		expect(markup.match(/<mark/g)).toHaveLength(6);
 		expect(markup.match(/data-search-match="true"/g)).toHaveLength(1);
 	});
 });

--- a/apps/web/src/components/sessions/search-match-excerpt.test.tsx
+++ b/apps/web/src/components/sessions/search-match-excerpt.test.tsx
@@ -6,7 +6,7 @@ import { SessionSearchMatchExcerpt } from "@/components/sessions/search-match-ex
 const anchor = { kind: "event_seq" as const, position: 4, revision: "events:revision" };
 
 describe("SessionSearchMatchExcerpt", () => {
-	test("highlights the matching phrase without hiding the surrounding excerpt", () => {
+	test("highlights every matching term without hiding the surrounding excerpt", () => {
 		const markup = renderToStaticMarkup(
 			createElement(SessionSearchMatchExcerpt, {
 				match: { role: "assistant", excerpt: "Fixed the authentication timeout", anchor },
@@ -15,7 +15,8 @@ describe("SessionSearchMatchExcerpt", () => {
 		);
 
 		expect(markup).toContain("Fixed the ");
-		expect(markup).toContain(">authentication timeout</mark>");
+		expect(markup).toContain(">authentication</mark> <mark");
+		expect(markup).toContain(">timeout</mark>");
 	});
 
 	test("renders query text as escaped content", () => {

--- a/apps/web/src/components/skills/skill-search.ts
+++ b/apps/web/src/components/skills/skill-search.ts
@@ -1,4 +1,4 @@
-import { searchExcerpt } from "@/lib/search-highlight";
+import { searchExcerpt, searchTerms } from "@/lib/search-highlight";
 
 interface SearchableSkill {
 	skill_key: string;
@@ -7,12 +7,15 @@ interface SearchableSkill {
 }
 
 export function skillSearchSupportingText(skill: SearchableSkill, query: string): string {
-	const phrase = query.trim().toLowerCase();
-	if (phrase && skill.skill_key.toLowerCase().includes(phrase)) {
+	const terms = searchTerms(query).map((term) => term.toLocaleLowerCase());
+	const title = skill.name.toLocaleLowerCase();
+	const supportingTerms = terms.filter((term) => !title.includes(term));
+	const relevantTerms = supportingTerms.length > 0 ? supportingTerms : terms;
+	if (relevantTerms.some((term) => skill.skill_key.toLocaleLowerCase().includes(term))) {
 		return `Key: ${skill.skill_key}`;
 	}
 	const description = skill.description?.trim();
-	if (description && phrase && description.toLowerCase().includes(phrase)) {
+	if (description && relevantTerms.some((term) => description.toLocaleLowerCase().includes(term))) {
 		return searchExcerpt(description, query, 160);
 	}
 	return description || `Key: ${skill.skill_key}`;

--- a/apps/web/src/components/vault/vault-search.ts
+++ b/apps/web/src/components/vault/vault-search.ts
@@ -1,4 +1,4 @@
-import { literalSearchRank } from "@/lib/search-highlight";
+import { literalSearchRank, searchTerms } from "@/lib/search-highlight";
 
 interface SearchableVault {
 	name: string;
@@ -10,11 +10,12 @@ export function vaultSearchRank(vault: SearchableVault, query: string): number |
 }
 
 export function vaultSearchSupportingText(vault: SearchableVault, query: string): string | null {
-	const phrase = query.trim().toLowerCase();
+	const terms = searchTerms(query).map((term) => term.toLocaleLowerCase());
+	const title = vault.name.toLocaleLowerCase();
+	const relevantTerms = terms.filter((term) => !title.includes(term));
 	if (
-		phrase &&
-		vault.slug.toLowerCase().includes(phrase) &&
-		vault.slug.toLowerCase() !== vault.name.toLowerCase()
+		relevantTerms.some((term) => vault.slug.toLocaleLowerCase().includes(term)) &&
+		vault.slug.toLocaleLowerCase() !== title
 	) {
 		return `Slug: ${vault.slug}`;
 	}

--- a/apps/web/src/lib/search-highlight.test.ts
+++ b/apps/web/src/lib/search-highlight.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { literalSearchRank, searchExcerpt, splitSearchHighlight } from "@/lib/search-highlight";
+import {
+	literalSearchRank,
+	searchExcerpt,
+	searchTerms,
+	splitSearchHighlight,
+} from "@/lib/search-highlight";
 
 describe("search highlighting", () => {
 	test("centers a long excerpt on the literal match", () => {
@@ -20,10 +25,41 @@ describe("search highlighting", () => {
 		expect(parts.filter((part) => part.highlighted)).toEqual([{ text: "a+b", highlighted: true }]);
 	});
 
+	test("highlights every unique term in a multi-word query", () => {
+		expect(searchTerms("  Handoff deploy handoff  ")).toEqual(["Handoff", "deploy"]);
+		const highlighted = splitSearchHighlight(
+			"Deploy the release before the final handoff",
+			"handoff deploy",
+		)
+			.filter((part) => part.highlighted)
+			.map((part) => part.text.toLocaleLowerCase());
+
+		expect(highlighted).toEqual(["deploy", "handoff"]);
+	});
+
+	test("centers excerpts on the earliest term when the phrase is not contiguous", () => {
+		const excerpt = searchExcerpt(
+			`${"before ".repeat(30)}deployment is ready${" gap".repeat(30)}handoff${" after".repeat(30)}`,
+			"handoff deployment",
+			80,
+		);
+
+		expect(excerpt).toContain("deployment");
+	});
+
 	test("ranks identity matches before supporting text", () => {
 		expect(literalSearchRank("deploy", ["Deploy", "release-deploy"], ["runbook"])).toBe(0);
 		expect(literalSearchRank("release", ["Deploy", "release-deploy"], ["runbook"])).toBe(3);
 		expect(literalSearchRank("runbook", ["Deploy", "release-deploy"], ["runbook"])).toBe(6);
 		expect(literalSearchRank("missing", ["Deploy", "release-deploy"], ["runbook"])).toBeNull();
+	});
+
+	test("matches all terms across identity and supporting fields", () => {
+		expect(
+			literalSearchRank("handoff deploy", ["Deploy service"], ["Release handoff notes"]),
+		).not.toBeNull();
+		expect(
+			literalSearchRank("handoff missing", ["Deploy service"], ["Release handoff notes"]),
+		).toBeNull();
 	});
 });

--- a/apps/web/src/lib/search-highlight.ts
+++ b/apps/web/src/lib/search-highlight.ts
@@ -5,6 +5,19 @@ export interface SearchHighlightPart {
 
 type SearchField = string | null | undefined;
 
+export function searchTerms(query: string): string[] {
+	const terms: string[] = [];
+	const seen = new Set<string>();
+	for (const term of query.trim().split(/\s+/u)) {
+		if (!term) continue;
+		const folded = term.toLocaleLowerCase();
+		if (seen.has(folded)) continue;
+		seen.add(folded);
+		terms.push(term);
+	}
+	return terms;
+}
+
 export function literalSearchRank(
 	query: string,
 	identityFields: readonly SearchField[],
@@ -25,7 +38,16 @@ export function literalSearchRank(
 	for (const [index, field] of supportingFields.entries()) {
 		if (field?.toLowerCase().includes(phrase)) return identity.length * 3 + index;
 	}
-	return null;
+
+	const terms = searchTerms(query).map((term) => term.toLocaleLowerCase());
+	const supporting = supportingFields.map((field) => field?.toLocaleLowerCase() ?? "");
+	const fields = [...identity, ...supporting];
+	if (!terms.every((term) => fields.some((field) => field.includes(term)))) return null;
+
+	const supportingTermCount = terms.filter(
+		(term) => !identity.some((field) => field.includes(term)),
+	).length;
+	return identity.length * 3 + supporting.length + supportingTermCount;
 }
 
 function escapeRegExp(value: string): string {
@@ -37,22 +59,29 @@ export function searchExcerpt(text: string, query: string, limit = 240): string 
 	if (compact.length <= limit) return compact;
 
 	const phrase = query.trim();
-	const match = phrase ? new RegExp(escapeRegExp(phrase), "iu").exec(compact) : null;
-	if (!match) return `${compact.slice(0, Math.max(0, limit - 1)).trimEnd()}…`;
+	const phraseMatch = phrase ? new RegExp(escapeRegExp(phrase), "iu").exec(compact) : null;
+	const folded = compact.toLocaleLowerCase();
+	const fallbackIndex = Math.min(
+		...searchTerms(query)
+			.map((term) => folded.indexOf(term.toLocaleLowerCase()))
+			.filter((index) => index >= 0),
+	);
+	const matchIndex = phraseMatch?.index ?? (Number.isFinite(fallbackIndex) ? fallbackIndex : -1);
+	if (matchIndex < 0) return `${compact.slice(0, Math.max(0, limit - 1)).trimEnd()}…`;
 
-	let start = Math.max(0, match.index - Math.floor(limit / 3));
+	let start = Math.max(0, matchIndex - Math.floor(limit / 3));
 	const end = Math.min(compact.length, start + limit);
 	start = Math.max(0, end - limit);
 	return `${start > 0 ? "…" : ""}${compact.slice(start, end).trim()}${end < compact.length ? "…" : ""}`;
 }
 
 export function createSearchHighlighter(query: string) {
-	const phrase = query.trim();
-	if (!phrase) {
+	const terms = searchTerms(query).sort((a, b) => b.length - a.length);
+	if (terms.length === 0) {
 		return (text: string): SearchHighlightPart[] => [{ text, highlighted: false }];
 	}
 
-	const pattern = new RegExp(escapeRegExp(phrase), "giu");
+	const pattern = new RegExp(terms.map(escapeRegExp).join("|"), "giu");
 	return (text: string): SearchHighlightPart[] => {
 		pattern.lastIndex = 0;
 		const parts: SearchHighlightPart[] = [];

--- a/backend/alembic/versions/e4b8c2d6f1a9_session_message_full_text_search.py
+++ b/backend/alembic/versions/e4b8c2d6f1a9_session_message_full_text_search.py
@@ -1,0 +1,40 @@
+"""Add indexed full-text search to Session message projections.
+
+Revision ID: e4b8c2d6f1a9
+Revises: b1d7e3f9a4c2
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "e4b8c2d6f1a9"
+down_revision: str | Sequence[str] | None = "b1d7e3f9a4c2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "session_message_search",
+        sa.Column(
+            "content_tsv",
+            postgresql.TSVECTOR(),
+            sa.Computed("to_tsvector('simple', content)", persisted=True),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_session_message_search_content_tsv",
+        "session_message_search",
+        ["content_tsv"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_session_message_search_content_tsv", table_name="session_message_search")
+    op.drop_column("session_message_search", "content_tsv")

--- a/backend/app/core/query_utils.py
+++ b/backend/app/core/query_utils.py
@@ -1,5 +1,13 @@
 """Query-string utilities shared by search + list endpoints."""
 
+from collections.abc import Sequence
+from typing import Any
+
+from sqlalchemy import func, literal_column, or_
+from sqlalchemy.sql.elements import ColumnElement, SQLColumnExpression
+
+_SIMPLE_TEXT_SEARCH_CONFIG: SQLColumnExpression[Any] = literal_column("'simple'::regconfig")
+
 
 def escape_like(s: str, escape_char: str = "\\") -> str:
     """Escape ``%`` / ``_`` / escape-char so user input can't become a wildcard.
@@ -22,6 +30,43 @@ def like_needle(query: str) -> str:
     return f"%{escape_like(query)}%"
 
 
+def search_terms(query: str) -> tuple[str, ...]:
+    """Return unique, whitespace-delimited terms while preserving input order."""
+    terms: list[str] = []
+    seen: set[str] = set()
+    for term in query.split():
+        folded = term.casefold()
+        if folded in seen:
+            continue
+        seen.add(folded)
+        terms.append(term)
+    return tuple(terms)
+
+
+def websearch_query(query: str) -> ColumnElement[Any]:
+    """Build PostgreSQL's forgiving, web-style lexical query."""
+    return func.websearch_to_tsquery(_SIMPLE_TEXT_SEARCH_CONFIG, query)
+
+
+def lexical_search_filter(
+    query: str,
+    fields: Sequence[SQLColumnExpression[Any]],
+    *,
+    search_vector: SQLColumnExpression[Any] | None = None,
+) -> ColumnElement[bool]:
+    """Match a literal phrase or PostgreSQL web-search terms across fields."""
+    literal_match = or_(
+        *(field.ilike(like_needle(query), escape="\\") for field in fields),
+    )
+    document = search_vector
+    if document is None:
+        document = func.to_tsvector(
+            _SIMPLE_TEXT_SEARCH_CONFIG,
+            func.concat_ws(" ", *fields),
+        )
+    return or_(literal_match, document.op("@@")(websearch_query(query)))
+
+
 def search_excerpt(content: str, query: str, *, limit: int = 240) -> str:
     """Return compact context around a literal, case-insensitive match."""
     compact = " ".join(content.split())
@@ -29,6 +74,12 @@ def search_excerpt(content: str, query: str, *, limit: int = 240) -> str:
         return compact
     phrase = query.strip()
     match_at = compact.casefold().find(phrase.casefold()) if phrase else -1
+    if match_at < 0:
+        folded = compact.casefold()
+        term_matches = [
+            match for term in search_terms(query) if (match := folded.find(term.casefold())) >= 0
+        ]
+        match_at = min(term_matches, default=-1)
     if match_at < 0:
         return f"{compact[: limit - 3]}..."
     start = max(0, match_at - limit // 3)

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
+    Computed,
     DateTime,
     ForeignKey,
     Index,
@@ -17,7 +18,7 @@ from sqlalchemy import (
     func,
     text,
 )
-from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, TSVECTOR, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base, TimestampMixin
@@ -284,6 +285,11 @@ class SessionMessageSearch(Base):
             postgresql_using="gin",
             postgresql_ops={"content": "gin_trgm_ops"},
         ),
+        Index(
+            "ix_session_message_search_content_tsv",
+            "content_tsv",
+            postgresql_using="gin",
+        ),
     )
 
     user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
@@ -303,6 +309,10 @@ class SessionMessageSearch(Base):
     position: Mapped[int] = mapped_column(Integer, primary_key=True, nullable=False)
     role: Mapped[Literal["user", "assistant"]] = mapped_column(String(20), nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
+    content_tsv: Mapped[str | None] = mapped_column(
+        TSVECTOR,
+        Computed("to_tsvector('simple', content)", persisted=True),
+    )
 
 
 class SessionEventGeneration(Base, TimestampMixin):

--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -21,7 +21,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import AuthContext, get_auth, is_scoped_api_key
 from app.core.database import get_session
 from app.core.project import project_ids_visible_to
-from app.core.query_utils import escape_like, like_needle, search_excerpt
+from app.core.query_utils import (
+    escape_like,
+    lexical_search_filter,
+    like_needle,
+    search_excerpt,
+    search_terms,
+)
 from app.models.project import Project
 from app.models.project_membership import ProjectMembership
 from app.models.session import AgentEnvironment, Session
@@ -88,7 +94,6 @@ type Searcher = Callable[
 async def _search_agents(db: AsyncSession, auth: AuthContext, query: str) -> list[SearchHit]:
     exact = escape_like(query)
     prefix = f"{exact}%"
-    needle = like_needle(query)
     fields = (
         AgentEnvironment.display_name,
         AgentEnvironment.default_name,
@@ -108,7 +113,7 @@ async def _search_agents(db: AsyncSession, auth: AuthContext, query: str) -> lis
         .where(
             AgentEnvironment.user_id == auth.user_id,
             active_agent_filter(),
-            or_(*(field.ilike(needle, escape="\\") for field in fields)),
+            lexical_search_filter(query, fields),
         )
         .order_by(
             rank,
@@ -146,7 +151,8 @@ def _agent_search_subtitle(agent: AgentEnvironment, query: str) -> str | None:
         agent.agent_type,
     )
     type_label = agent_type_default_label(agent.agent_type)
-    folded_query = query.casefold()
+    terms = tuple(term.casefold() for term in search_terms(query))
+    title_terms = tuple(term for term in terms if term not in title.casefold())
     candidates = (
         agent.display_name,
         agent.default_name,
@@ -156,7 +162,11 @@ def _agent_search_subtitle(agent: AgentEnvironment, query: str) -> str | None:
     )
     for candidate in candidates:
         label = (candidate or "").strip()
-        if label and label.casefold() != title.casefold() and folded_query in label.casefold():
+        if (
+            label
+            and label.casefold() != title.casefold()
+            and any(term in label.casefold() for term in (title_terms or terms))
+        ):
             return label
     context = [
         label for label in (type_label, agent.machine_name) if label.casefold() != title.casefold()
@@ -288,12 +298,27 @@ async def _search_projects(db: AsyncSession, auth: AuthContext, query: str) -> l
         ProjectMembership.project_id == Project.id,
         ProjectMembership.member_user_id == auth.user_id,
     )
-    shared_owner_match = and_(
-        Project.user_id != auth.user_id,
-        or_(
-            User.name.ilike(needle, escape="\\"),
-            and_(User.name.is_(None), User.email.ilike(needle, escape="\\")),
-            ProjectMembership.resolved_owner_handle.ilike(needle, escape="\\"),
+    project_match = lexical_search_filter(
+        query,
+        (
+            Project.name,
+            Project.slug,
+            Project.description,
+            case((Project.user_id != auth.user_id, User.name), else_=""),
+            case(
+                (
+                    and_(Project.user_id != auth.user_id, User.name.is_(None)),
+                    User.email,
+                ),
+                else_="",
+            ),
+            case(
+                (
+                    Project.user_id != auth.user_id,
+                    ProjectMembership.resolved_owner_handle,
+                ),
+                else_="",
+            ),
         ),
     )
     rank = case(
@@ -313,12 +338,7 @@ async def _search_projects(db: AsyncSession, auth: AuthContext, query: str) -> l
         .where(
             Project.id.in_(visible_project_ids),
             Project.archived_at.is_(None),
-            or_(
-                Project.name.ilike(needle, escape="\\"),
-                Project.slug.ilike(needle, escape="\\"),
-                Project.description.ilike(needle, escape="\\"),
-                shared_owner_match,
-            ),
+            project_match,
         )
         .order_by(rank, Project.name, Project.id)
         .limit(TYPE_LIMIT)
@@ -351,17 +371,17 @@ def _project_search_subtitle(
     caller_user_id: UUID,
 ) -> str:
     description = (project.description or "").strip()
-    folded_query = query.casefold()
-    if folded_query in project.slug.casefold():
+    terms = tuple(term.casefold() for term in search_terms(query))
+    if any(term in project.slug.casefold() for term in terms):
         return project.slug
-    if description and folded_query in description.casefold():
+    if description and any(term in description.casefold() for term in terms):
         return search_excerpt(description, query, limit=160)
     if project.user_id != caller_user_id:
         owner_labels = [safe_owner_display(owner)]
         if membership is not None:
             owner_labels.append(membership.resolved_owner_handle)
         if label := next(
-            (label for label in owner_labels if folded_query in label.casefold()),
+            (label for label in owner_labels if any(term in label.casefold() for term in terms)),
             None,
         ):
             return f"Shared by {label}"
@@ -398,12 +418,7 @@ async def _search_vaults(db: AsyncSession, auth: AuthContext, query: str) -> lis
     stmt = (
         select(Vault)
         .where(visibility)
-        .where(
-            or_(
-                Vault.slug.ilike(needle, escape="\\"),
-                Vault.name.ilike(needle, escape="\\"),
-            )
-        )
+        .where(lexical_search_filter(query, (Vault.slug, Vault.name)))
         .order_by(rank, Vault.name, Vault.id)
         .limit(TYPE_LIMIT)
     )
@@ -415,7 +430,8 @@ async def _search_vaults(db: AsyncSession, auth: AuthContext, query: str) -> lis
             title=v.name or v.slug,
             subtitle=(
                 v.slug
-                if query.casefold() in v.slug.casefold() and v.slug.casefold() != v.name.casefold()
+                if any(term.casefold() in v.slug.casefold() for term in search_terms(query))
+                and v.slug.casefold() != v.name.casefold()
                 else "encrypted secrets"
             ),
             href=f"/vaults/{quote(v.slug, safe='')}?vault={v.id}",
@@ -435,8 +451,8 @@ async def global_search(
     Each searcher returns at most `TYPE_LIMIT` rows; total is capped at
     6*TYPE_LIMIT which keeps the palette responsive even with noisy queries.
 
-    Sessions/projects/skills/vaults use `ILIKE` (small tables) — memories goes
-    through the hybrid provider (FTS + trgm + optional pgvector) for quality.
+    Sessions/projects/skills/vaults use literal + PostgreSQL full-text search;
+    memories use the hybrid provider (FTS + trgm + optional pgvector).
 
     A single failing source (e.g. the memory provider briefly unavailable)
     degrades to partial results rather than failing the whole request —

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -2503,7 +2503,7 @@ async def list_sessions(
         default=None,
         max_length=500,
         description=(
-            "Case-insensitive phrase search on summary/project/local ID and visible message text; "
+            "Web-style text search on summary/project/local ID and visible message text; "
             "cloud session IDs match by UUID prefix"
         ),
     ),

--- a/backend/app/routes/vault.py
+++ b/backend/app/routes/vault.py
@@ -16,7 +16,7 @@ from app.core.project import (
     resolve_personal_project,
     validate_project_for_caller,
 )
-from app.core.query_utils import like_needle
+from app.core.query_utils import lexical_search_filter
 from app.models.agent_project_binding import AgentProjectBinding
 from app.models.project import Project
 from app.models.vault import (
@@ -118,13 +118,7 @@ async def list_vaults(
         .order_by(Vault.slug)
     )
     if q:
-        needle = like_needle(q)
-        base = base.where(
-            or_(
-                Vault.slug.ilike(needle, escape="\\"),
-                Vault.name.ilike(needle, escape="\\"),
-            )
-        )
+        base = base.where(lexical_search_filter(q, (Vault.slug, Vault.name)))
 
     total = (await db.execute(select(func.count()).select_from(base.subquery()))).scalar_one()
     rows = (await db.execute(base.limit(page_size).offset((page - 1) * page_size))).scalars().all()

--- a/backend/app/services/composio.py
+++ b/backend/app/services/composio.py
@@ -1565,6 +1565,11 @@ def _connector_search_rank(app: ConnectorAvailableAppResponse, query: str) -> in
             return len(identity) * 2 + index
     if query in app.description.casefold():
         return len(identity) * 3
+    fields = (*identity, app.description.casefold())
+    terms = tuple(dict.fromkeys(query.split()))
+    if terms and all(any(term in field for field in fields) for term in terms):
+        supporting_matches = sum(any(term in field for field in fields[2:]) for term in terms)
+        return len(identity) * 3 + 1 + supporting_matches
     return None
 
 

--- a/backend/app/services/session_search.py
+++ b/backend/app/services/session_search.py
@@ -11,7 +11,12 @@ from sqlalchemy import String, case, cast, delete, func, literal, or_, select, u
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.selectable import Subquery
 
-from app.core.query_utils import like_needle, search_excerpt
+from app.core.query_utils import (
+    lexical_search_filter,
+    like_needle,
+    search_excerpt,
+    websearch_query,
+)
 from app.models.session import Session, SessionEventChunk, SessionMessageSearch
 from app.schemas.session import (
     SessionSearchAnchorResponse,
@@ -131,9 +136,10 @@ def _searchable_text(content: str) -> str:
 
 
 def _message_match_expression(query: str):
-    return SessionMessageSearch.content.ilike(
-        like_needle(query),
-        escape="\\",
+    return lexical_search_filter(
+        query,
+        (SessionMessageSearch.content,),
+        search_vector=SessionMessageSearch.content_tsv,
     )
 
 
@@ -154,6 +160,11 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
         else_=func.concat("snapshot:", Session.content_hash),
     )
     message_match = _message_match_expression(query)
+    phrase_match = SessionMessageSearch.content.ilike(like_needle(query), escape="\\")
+    lexical_rank = func.ts_rank_cd(
+        SessionMessageSearch.content_tsv,
+        websearch_query(query),
+    )
     candidates = (
         select(
             SessionMessageSearch.session_id.label("session_id"),
@@ -161,9 +172,10 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
             SessionMessageSearch.position.label("position"),
             SessionMessageSearch.content.label("content"),
             SessionMessageSearch.role.label("role"),
-            # Body search is deterministic phrase containment. The constant
-            # only participates in cross-field ranking on the Session list.
-            literal(1.0).label("score"),
+            case(
+                (phrase_match, literal(2.0) + lexical_rank),
+                else_=literal(0.75) + lexical_rank,
+            ).label("score"),
         )
         .where(
             SessionMessageSearch.user_id == user_id,
@@ -198,14 +210,16 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
 
 
 def session_search_matches(user_id: UUID, query: str) -> Subquery:
-    """Return every exact phrase match with one ranked body hit per Session."""
+    """Return every all-term match with one ranked body hit per Session."""
     pattern = like_needle(query)
     message_match = best_session_message_matches(user_id, query)
-    metadata_matches = [
-        func.coalesce(Session.summary, "").ilike(pattern, escape="\\"),
-        func.coalesce(Session.project_path, "").ilike(pattern, escape="\\"),
-        Session.local_session_id.ilike(pattern, escape="\\"),
-    ]
+    metadata_fields = (
+        func.coalesce(Session.summary, ""),
+        func.coalesce(Session.project_path, ""),
+        Session.local_session_id,
+    )
+    metadata_match = lexical_search_filter(query, metadata_fields)
+    metadata_phrase_match = or_(*(field.ilike(pattern, escape="\\") for field in metadata_fields))
     metadata_scores = [
         func.similarity(func.coalesce(Session.summary, ""), query),
         func.similarity(func.coalesce(Session.project_path, ""), query),
@@ -214,10 +228,19 @@ def session_search_matches(user_id: UUID, query: str) -> Subquery:
     uuid_prefix = _uuid_prefix_pattern(query)
     if uuid_prefix is not None:
         compact_session_id = func.replace(cast(Session.id, String), "-", "")
-        metadata_matches.append(compact_session_id.ilike(uuid_prefix))
+        metadata_match = or_(metadata_match, compact_session_id.ilike(uuid_prefix))
+        metadata_phrase_match = or_(
+            metadata_phrase_match,
+            compact_session_id.ilike(uuid_prefix),
+        )
         metadata_scores.append(func.similarity(compact_session_id, uuid_prefix[:-1]))
-    metadata_match = or_(*metadata_matches)
-    metadata_score = func.greatest(*metadata_scores)
+    metadata_score = case(
+        (
+            metadata_phrase_match,
+            literal(1.0) + func.greatest(*metadata_scores),
+        ),
+        else_=literal(0.5),
+    )
     message_score = func.coalesce(message_match.c.score, 0.0)
     return (
         select(

--- a/backend/app/services/skill_search.py
+++ b/backend/app/services/skill_search.py
@@ -1,18 +1,22 @@
 """Shared literal search semantics for Skill collection surfaces."""
 
-from sqlalchemy import case, or_
+from sqlalchemy import case
 from sqlalchemy.sql.elements import ColumnElement
 
-from app.core.query_utils import escape_like, like_needle, search_excerpt
+from app.core.query_utils import (
+    escape_like,
+    lexical_search_filter,
+    like_needle,
+    search_excerpt,
+    search_terms,
+)
 from app.models.skill import Skill
 
 
 def skill_search_filter(query: str) -> ColumnElement[bool]:
-    needle = like_needle(query)
-    return or_(
-        Skill.name.ilike(needle, escape="\\"),
-        Skill.skill_key.ilike(needle, escape="\\"),
-        Skill.description.ilike(needle, escape="\\"),
+    return lexical_search_filter(
+        query,
+        (Skill.name, Skill.skill_key, Skill.description),
     )
 
 
@@ -33,10 +37,10 @@ def skill_search_rank(query: str) -> ColumnElement[int]:
 
 
 def skill_search_subtitle(skill: Skill, query: str) -> str:
-    folded_query = query.casefold()
-    if folded_query in skill.skill_key.casefold():
+    terms = tuple(term.casefold() for term in search_terms(query))
+    if any(term in skill.skill_key.casefold() for term in terms):
         return skill.skill_key
     description = (skill.description or "").strip()
-    if description and folded_query in description.casefold():
+    if description and any(term in description.casefold() for term in terms):
         return search_excerpt(description, query, limit=160)
     return description or skill.skill_key

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -499,6 +499,12 @@ async def test_catalog_search_prioritizes_identity_before_description(
         "postal",
     ]
 
+    multi_term = await composio.get_available_apps(search="gmail inbox")
+    assert [app.name for app in multi_term["items"]] == ["team-mail"]
+
+    missing_term = await composio.get_available_apps(search="gmail missing")
+    assert missing_term["items"] == []
+
 
 @pytest.mark.asyncio
 async def test_connector_detail_requires_explicit_toolkit_auth_metadata(

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -1,7 +1,7 @@
 """Session list/search endpoint tests.
 
 Covers the upgraded `/api/sessions` list endpoint:
-  - case-insensitive phrase search across metadata and visible messages
+  - PostgreSQL web search across metadata and visible messages
   - Filters: model, tag, min_messages, min_duration, has_pr
   - `sort=relevance` ordering
   - Default behavior unchanged (no q, no filters → date-sorted list)
@@ -92,7 +92,7 @@ async def _push_session(
 
 
 @pytest.mark.asyncio
-async def test_metadata_search_requires_the_query_phrase(client: httpx.AsyncClient):
+async def test_metadata_search_is_literal_and_case_insensitive(client: httpx.AsyncClient):
     env_id = await _register_env(client)
     session_id = await _push_session(
         client, env_id, local_session_id="auth-1", summary="user authentication migration"
@@ -122,20 +122,31 @@ async def test_metadata_search_requires_the_query_phrase(client: httpx.AsyncClie
 
 
 @pytest.mark.asyncio
-async def test_relevance_sort_only_ranks_phrase_matches(client: httpx.AsyncClient):
+async def test_relevance_sort_prioritizes_phrase_over_all_term_match(client: httpx.AsyncClient):
     env_id = await _register_env(client)
     # Exact-match summary, partial-match summary, no-match summary.
     await _push_session(client, env_id, local_session_id="exact", summary="oauth token refresh bug")
     await _push_session(
-        client, env_id, local_session_id="partial", summary="refresh the page on token error"
+        client,
+        env_id,
+        local_session_id="partial",
+        summary="refresh the OAuth flow after a token error",
     )
     await _push_session(client, env_id, local_session_id="other", summary="UI polish")
 
     r = await client.get("/v1/sessions?q=oauth+token+refresh&sort=relevance")
     items = r.json()["items"]
-    # Only the summary containing the complete phrase is eligible.
-    assert items[0]["summary"] == "oauth token refresh bug"
+    assert [item["summary"] for item in items] == [
+        "oauth token refresh bug",
+        "refresh the OAuth flow after a token error",
+    ]
     assert all(s["summary"] != "UI polish" for s in items)
+
+    quoted = await client.get(
+        "/v1/sessions",
+        params={"q": '"oauth token refresh"', "sort": "relevance"},
+    )
+    assert [item["summary"] for item in quoted.json()["items"]] == ["oauth token refresh bug"]
 
 
 @pytest.mark.asyncio
@@ -215,6 +226,8 @@ async def test_snapshot_message_search_tracks_current_content_and_escapes_wildca
     assert typo["items"] == []
     case_insensitive = (await client.get("/v1/sessions", params={"q": "original NEEDLE"})).json()
     assert [item["local_session_id"] for item in case_insensitive["items"]] == [local_id]
+    reordered = (await client.get("/v1/sessions", params={"q": "literal original"})).json()
+    assert [item["local_session_id"] for item in reordered["items"]] == [local_id]
     literal = (await client.get("/v1/sessions", params={"q": "%_"})).json()
     assert [item["local_session_id"] for item in literal["items"]] == [local_id]
     backslash = (await client.get("/v1/sessions", params={"q": "slash\\needle"})).json()

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -1334,6 +1334,15 @@ async def test_global_search_returns_hits_across_types(client: httpx.AsyncClient
         assert hit["title"]
         assert hit["href"].startswith("/")
 
+    multi_term = await client.get("/v1/search", params={"q": "searchable billing"})
+    assert multi_term.status_code == 200, multi_term.text
+    session_hits = [hit for hit in multi_term.json()["results"] if hit["type"] == "session"]
+    assert [hit["title"] for hit in session_hits] == ["Investigate alpha bug in billing"]
+
+    missing_term = await client.get("/v1/search", params={"q": "searchable missing"})
+    assert missing_term.status_code == 200, missing_term.text
+    assert not [hit for hit in missing_term.json()["results"] if hit["type"] == "session"]
+
 
 @pytest.mark.asyncio
 async def test_global_vault_search_includes_unattached_owned_and_deduplicates_attachments(
@@ -1363,6 +1372,11 @@ async def test_global_vault_search_includes_unattached_owned_and_deduplicates_at
     hits = [hit for hit in response.json()["results"] if hit["type"] == "vault"]
     assert [hit["id"] for hit in hits] == [str(exact_name.id), str(exact_slug.id)]
     assert hits[1]["subtitle"] == token
+
+    multi_term = await client.get("/v1/search", params={"q": f"slug {token}"})
+    assert multi_term.status_code == 200, multi_term.text
+    multi_term_hits = [hit for hit in multi_term.json()["results"] if hit["type"] == "vault"]
+    assert [hit["id"] for hit in multi_term_hits] == [str(exact_slug.id)]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_settings_and_mcp.py
+++ b/backend/tests/test_settings_and_mcp.py
@@ -705,6 +705,7 @@ async def test_clawdi_mcp_session_search_uses_shared_metadata_and_body_matches(
 
             wildcard_response = await search("%")
             body_response = await search("deployment handoff phrase")
+            reordered_response = await search("phrase deployment")
             typo_response = await search("deployment handof phrase")
     finally:
         app.dependency_overrides.clear()
@@ -718,6 +719,13 @@ async def test_clawdi_mcp_session_search_uses_shared_metadata_and_body_matches(
     body_text = body_response.json()["result"]["content"][0]["text"]
     assert "Unrelated title" in body_text
     assert "matched assistant: The visible body contains a deployment handoff phrase." in body_text
+
+    assert reordered_response.status_code == 200, reordered_response.text
+    reordered_text = reordered_response.json()["result"]["content"][0]["text"]
+    assert "Unrelated title" in reordered_text
+    assert "matched assistant: The visible body contains a deployment handoff phrase." in (
+        reordered_text
+    )
 
     assert typo_response.status_code == 200, typo_response.text
     assert (

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -1475,6 +1475,13 @@ async def test_skill_search_uses_shared_relevance_and_description_excerpt(
     assert token in hits[-1]["subtitle"]
     assert len(hits[-1]["subtitle"]) <= 166
 
+    multi_term = await client.get(
+        "/v1/skills",
+        params={"project_id": project_id, "q": f"{token} display-name"},
+    )
+    assert multi_term.status_code == 200, multi_term.text
+    assert [item["id"] for item in multi_term.json()["items"]] == [str(exact_name.id)]
+
 
 @pytest.mark.asyncio
 async def test_list_skills_etag_covers_project_and_machine_metadata(

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -2851,8 +2851,8 @@ export interface paths {
          *     Each searcher returns at most `TYPE_LIMIT` rows; total is capped at
          *     6*TYPE_LIMIT which keeps the palette responsive even with noisy queries.
          *
-         *     Sessions/projects/skills/vaults use `ILIKE` (small tables) — memories goes
-         *     through the hybrid provider (FTS + trgm + optional pgvector) for quality.
+         *     Sessions/projects/skills/vaults use literal + PostgreSQL full-text search;
+         *     memories use the hybrid provider (FTS + trgm + optional pgvector).
          *
          *     A single failing source (e.g. the memory provider briefly unavailable)
          *     degrades to partial results rather than failing the whole request —
@@ -11684,7 +11684,7 @@ export interface operations {
     list_sessions_v1_sessions_get: {
         parameters: {
             query?: {
-                /** @description Case-insensitive phrase search on summary/project/local ID and visible message text; cloud session IDs match by UUID prefix */
+                /** @description Web-style text search on summary/project/local ID and visible message text; cloud session IDs match by UUID prefix */
                 q?: string | null;
                 /** @description Filter by agent_type */
                 agent?: string | null;


### PR DESCRIPTION
## Summary

- use PostgreSQL `websearch_to_tsquery('simple', ...)` for forgiving all-term and quoted-phrase search across Sessions, Projects, Skills, Vaults, Agents, Connectors, and global search
- keep escaped literal containment as the highest-ranked match and add an indexed generated `tsvector` for Session message projections
- align excerpts and highlighting with multi-term results, replacing heavy highlight pills with restrained text emphasis

## Why

Session bodies live in object storage, while search reads the rebuildable `session_message_search` PostgreSQL projection. Exact multi-word queries previously required the full phrase in one field, and historical Sessions whose projection was never backfilled could not match body content at all.

The query syntax follows PostgreSQL's documented web-search contract: unquoted words are ANDed, quoted words form a phrase, and malformed raw input does not raise syntax errors. No fuzzy candidates are introduced.

## Verification

- `bun run check`
- Web TypeScript typecheck
- Web focused tests: 12 passed
- OSS production build
- Ruff lint and format check
- backend strict type governance: 205 files, 0 diagnostics
- PostgreSQL focused tests: 9 passed
- Alembic empty-db upgrade, downgrade to `b1d7e3f9a4c2`, re-upgrade; one head
- `git diff --check origin/main..HEAD`

## Required rollout step

After the migration is deployed, backfill the existing object-store Sessions so their visible-message projection exists:

```bash
cd backend
pdm run python -m scripts.backfill_session_search --all --workers 8
```

The backfill is idempotent and bounded. It must complete before historical Session body-search coverage is considered restored; new uploads continue to index on ingest.
