### PR TITLE
docs: restore approved Best Home positioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Clawdi
 
-The best home for all your AI agents. Clawdi keeps every environment, session,
-memory, skill, cron job, and app connection in one place. This repository
+The best home for all your AI agents. Run them in the cloud or connect your
+own—with their context and tools in one place. This repository
 contains the CLI, FastAPI backend, TanStack dashboard, shared types, agent
 adapters, channels, and sync.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ database migration, CI, and implementation details.
 
 - Session detail search now preserves spaces while typing multi-word queries.
 
+## Clawdi CLI v0.14.32
+
+Package: `clawdi@0.14.32`
+
+### Changed
+
+- CLI help and package metadata now use the approved “best home” positioning and
+  concise run-path supporting copy.
+
 ## Clawdi CLI v0.14.31
 
 Package: `clawdi@0.14.31`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">Clawdi</h1>
 
 <p align="center">
-  <strong>Run and connect AI agents. Manage their sessions, memory, skills, secrets, and app tools in one place.</strong>
+  <strong>The best home for all your AI agents.<br>Run them in the cloud or connect your own—with their context and tools in one place.</strong>
 </p>
 
 <p align="center">

--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -6,7 +6,7 @@ homepage: https://cloud.clawdi.ai
 
 # Clawdi Cloud Setup
 
-You're helping the user connect this machine to Clawdi Cloud. Clawdi runs and connects AI agents, then manages their sessions, memory, skills, secrets, and app tools in one place.
+You're helping the user connect this machine to Clawdi Cloud—the best home for all their AI agents. They can run Agents in the cloud or connect their own, with context and tools in one place.
 
 This walkthrough takes 2-3 minutes. The end state: the user's existing session history shows up at their Clawdi Cloud dashboard. If you stop earlier, the dashboard stays empty and they assume the product is broken.
 

--- a/bun.lock
+++ b/bun.lock
@@ -79,7 +79,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.31",
+      "version": "0.14.32",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "clawdi",
-	"version": "0.14.31",
-	"description": "Run and connect AI agents. Manage their sessions, memory, skills, secrets, and app tools in one place.",
+	"version": "0.14.32",
+	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",
 	"sideEffects": false,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,7 +35,7 @@ function collectValues(value: string, prev: string[] = []): string[] {
 program
 	.name("clawdi")
 	.description(
-		"Run and connect AI agents. Manage their sessions, memory, skills, secrets, and app tools in one place.",
+		"The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	)
 	.version(getCliVersion())
 	.addHelpText(


### PR DESCRIPTION
## Summary

- restore the user-approved brand anchor: “The best home for all your AI agents.”
- use the approved concise supporting copy across README, CLI help/npm metadata, Cloud setup guidance, and repository guidance
- bump CLI to `0.14.32` so the approved metadata can publish as a new immutable release

## Approved copy

> The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.

## Verification

- [x] Root typecheck passes (4/4 packages)
- [x] Biome passes for changed CLI files
- [x] Publish-manifest validation passes
- [x] Focused CLI help smoke test passes (1 test, 21 assertions)
- [x] CLI `--version` returns `0.14.32`
- [x] CLI `--help` renders the approved copy
- [x] `git diff --check` passes

Approved by Kingsley in Discord before implementation and publication.