### PR TITLE
fix(search): build session full-text index online

### DIFF
--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -385,4 +385,7 @@ jobs:
             )"
           fi
           scripts/deploy-whatsapp-sidecar.sh
+          kamal app exec --primary --roles web --raw \
+            --version "${{ needs.build.outputs.image_tag }}" \
+            alembic upgrade head
           kamal deploy -P --version "${{ needs.build.outputs.image_tag }}"

--- a/backend/alembic/versions/e4b8c2d6f1a9_session_message_full_text_search.py
+++ b/backend/alembic/versions/e4b8c2d6f1a9_session_message_full_text_search.py
@@ -1,15 +1,10 @@
-"""Add indexed full-text search to Session message projections.
+"""Reserve the Session message full-text search rollout revision.
 
 Revision ID: e4b8c2d6f1a9
 Revises: b1d7e3f9a4c2
 """
 
 from collections.abc import Sequence
-
-import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
-
-from alembic import op
 
 revision: str = "e4b8c2d6f1a9"
 down_revision: str | Sequence[str] | None = "b1d7e3f9a4c2"
@@ -18,23 +13,11 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "session_message_search",
-        sa.Column(
-            "content_tsv",
-            postgresql.TSVECTOR(),
-            sa.Computed("to_tsvector('simple', content)", persisted=True),
-            nullable=True,
-        ),
-    )
-    op.create_index(
-        "ix_session_message_search_content_tsv",
-        "session_message_search",
-        ["content_tsv"],
-        postgresql_using="gin",
-    )
+    # The original revision rewrote every historical message row into a stored
+    # generated column. Keep this published revision as a compatibility marker;
+    # the successor builds a non-redundant expression index online.
+    pass
 
 
 def downgrade() -> None:
-    op.drop_index("ix_session_message_search_content_tsv", table_name="session_message_search")
-    op.drop_column("session_message_search", "content_tsv")
+    pass

--- a/backend/alembic/versions/f7c9a2e5d1b4_session_message_expression_search.py
+++ b/backend/alembic/versions/f7c9a2e5d1b4_session_message_expression_search.py
@@ -1,0 +1,58 @@
+"""Build Session message full-text search without rewriting the table.
+
+Revision ID: f7c9a2e5d1b4
+Revises: e4b8c2d6f1a9
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "f7c9a2e5d1b4"
+down_revision: str | Sequence[str] | None = "e4b8c2d6f1a9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_EXPRESSION_INDEX = "ix_session_message_search_content_fts"
+
+
+def _expression_index_is_invalid() -> bool:
+    valid = op.get_bind().execute(
+        sa.text(
+            "SELECT indisvalid FROM pg_index "
+            "WHERE indexrelid = to_regclass(:index_name)"
+        ),
+        {"index_name": _EXPRESSION_INDEX},
+    ).scalar_one_or_none()
+    return valid is False
+
+
+def upgrade() -> None:
+    invalid_expression_index = _expression_index_is_invalid()
+    with op.get_context().autocommit_block():
+        if invalid_expression_index:
+            op.drop_index(
+                _EXPRESSION_INDEX,
+                table_name="session_message_search",
+                postgresql_concurrently=True,
+            )
+        op.create_index(
+            _EXPRESSION_INDEX,
+            "session_message_search",
+            [sa.text("to_tsvector('simple'::regconfig, content)")],
+            postgresql_using="gin",
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            _EXPRESSION_INDEX,
+            table_name="session_message_search",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/backend/app/core/query_utils.py
+++ b/backend/app/core/query_utils.py
@@ -48,6 +48,16 @@ def websearch_query(query: str) -> ColumnElement[Any]:
     return func.websearch_to_tsquery(_SIMPLE_TEXT_SEARCH_CONFIG, query)
 
 
+def text_search_document(
+    fields: Sequence[SQLColumnExpression[Any]],
+) -> ColumnElement[Any]:
+    """Build the canonical simple-config document used by filters and indexes."""
+    if not fields:
+        raise ValueError("text search requires at least one field")
+    source = fields[0] if len(fields) == 1 else func.concat_ws(" ", *fields)
+    return func.to_tsvector(_SIMPLE_TEXT_SEARCH_CONFIG, source)
+
+
 def lexical_search_filter(
     query: str,
     fields: Sequence[SQLColumnExpression[Any]],
@@ -60,10 +70,7 @@ def lexical_search_filter(
     )
     document = search_vector
     if document is None:
-        document = func.to_tsvector(
-            _SIMPLE_TEXT_SEARCH_CONFIG,
-            func.concat_ws(" ", *fields),
-        )
+        document = text_search_document(fields)
     return or_(literal_match, document.op("@@")(websearch_query(query)))
 
 

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -7,7 +7,6 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
-    Computed,
     DateTime,
     ForeignKey,
     Index,
@@ -18,7 +17,7 @@ from sqlalchemy import (
     func,
     text,
 )
-from sqlalchemy.dialects.postgresql import ARRAY, JSONB, TSVECTOR, UUID
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base, TimestampMixin
@@ -286,8 +285,8 @@ class SessionMessageSearch(Base):
             postgresql_ops={"content": "gin_trgm_ops"},
         ),
         Index(
-            "ix_session_message_search_content_tsv",
-            "content_tsv",
+            "ix_session_message_search_content_fts",
+            text("to_tsvector('simple'::regconfig, content)"),
             postgresql_using="gin",
         ),
     )
@@ -309,10 +308,6 @@ class SessionMessageSearch(Base):
     position: Mapped[int] = mapped_column(Integer, primary_key=True, nullable=False)
     role: Mapped[Literal["user", "assistant"]] = mapped_column(String(20), nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
-    content_tsv: Mapped[str | None] = mapped_column(
-        TSVECTOR,
-        Computed("to_tsvector('simple', content)", persisted=True),
-    )
 
 
 class SessionEventGeneration(Base, TimestampMixin):

--- a/backend/app/services/session_search.py
+++ b/backend/app/services/session_search.py
@@ -15,6 +15,7 @@ from app.core.query_utils import (
     lexical_search_filter,
     like_needle,
     search_excerpt,
+    text_search_document,
     websearch_query,
 )
 from app.models.session import Session, SessionEventChunk, SessionMessageSearch
@@ -136,10 +137,11 @@ def _searchable_text(content: str) -> str:
 
 
 def _message_match_expression(query: str):
+    search_document = text_search_document((SessionMessageSearch.content,))
     return lexical_search_filter(
         query,
         (SessionMessageSearch.content,),
-        search_vector=SessionMessageSearch.content_tsv,
+        search_vector=search_document,
     )
 
 
@@ -162,7 +164,7 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
     message_match = _message_match_expression(query)
     phrase_match = SessionMessageSearch.content.ilike(like_needle(query), escape="\\")
     lexical_rank = func.ts_rank_cd(
-        SessionMessageSearch.content_tsv,
+        text_search_document((SessionMessageSearch.content,)),
         websearch_query(query),
     )
     candidates = (

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -328,14 +328,17 @@ tag before authenticated readiness. It deliberately calls this reconcile
 because a normal `kamal deploy` does not update accessories; it never calls the
 broader `kamal accessory remove`, which also removes image/data resources.
 
-The Kamal `web` primary role runs the image's default API process. That API
-entrypoint alone runs `alembic upgrade head`, and it starts Uvicorn only after
-the migration succeeds; the non-primary `channels-worker` role does not run
-migrations. Kamal keeps the still-serving old API in rotation while the new
-primary boots, then requires the new primary to pass the proxy `/health` gate
-before it boots non-primary roles. Consequently every migration must use an
-expand/contract sequence compatible with the old API during this rolling
-window. A routine Kamal deploy must not separately run Alembic by hand.
+The release workflow runs `alembic upgrade head` once as an exact-image Kamal
+release task on the primary host before rolling the application. This lets
+online migrations such as `CREATE INDEX CONCURRENTLY` finish while the old API
+continues serving, without consuming the new container's health deadline. The
+API entrypoint repeats the same idempotent migration command as a fail-closed
+safety check and starts Uvicorn only after it succeeds; the non-primary
+`channels-worker` role does not run migrations. Kamal then keeps the old API in
+rotation until the new primary passes the proxy `/health` gate, before booting
+non-primary roles. Every migration must therefore remain expand/contract
+compatible with the old API during this window. Operators must use the release
+workflow rather than running Alembic independently.
 
 The proxy `/health` gate reaches the API handler that executes database
 `SELECT 1`. The image-level Docker HEALTHCHECK calls the same local path for

--- a/packages/cli/tests/clawdi-image-release-workflow.test.ts
+++ b/packages/cli/tests/clawdi-image-release-workflow.test.ts
@@ -425,6 +425,9 @@ describe("backend image release workflow contract", () => {
 		);
 		expect(kamalDeploy?.run).toContain("gem install kamal -v '2.12.0' --no-document");
 		expect(kamalDeploy?.run).toContain('test "$(kamal version)" = "2.12.0"');
+		expect(kamalDeploy?.run).toContain("kamal app exec --primary --roles web --raw");
+		expect(kamalDeploy?.run).toContain(`--version "\${{ needs.build.outputs.image_tag }}"`);
+		expect(kamalDeploy?.run).toContain("alembic upgrade head");
 		expect(kamalDeploy?.run).toContain(
 			`kamal deploy -P --version "\${{ needs.build.outputs.image_tag }}"`,
 		);
@@ -486,8 +489,9 @@ describe("backend image release workflow contract", () => {
 		expect(channelWorkerSource).toMatch(
 			/workers = build_channel_workers\(\)\n\s+if health is not None:\n\s+health\.ready = True/,
 		);
-		expect(releaseRunbook).toContain("every migration must use an");
-		expect(releaseRunbook).toContain("expand/contract sequence");
+		expect(releaseRunbook).toMatch(
+			/Every migration must therefore remain expand\/contract\s+compatible/,
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary

- replace the stored `content_tsv` generated column with a PostgreSQL expression GIN index built via `CREATE INDEX CONCURRENTLY`
- run Alembic from the exact release image before Kamal starts the rolling app deployment
- preserve already-applied legacy search columns/indexes during the expand phase so old containers remain compatible
- keep Session matching and ranking on the same canonical `to_tsvector('simple', content)` expression

## Why

The first deployment of #1285 reached the 120-second Kamal health deadline while PostgreSQL rewrote roughly 2.71 million `session_message_search` rows for the stored generated column. The transaction was terminated and production remained on revision `b1d7e3f9a4c2` with the previous healthy app image.

PostgreSQL's standard online pattern here is a non-redundant expression GIN created concurrently. Running that migration as an exact-image release task lets the old API continue serving while the index is built; the normal API entrypoint retains its idempotent migration check.

## Verification

- CLI workflow contract: 13 passed
- focused backend Session/MCP search tests: 10 passed
- Ruff lint and format: passed
- Python compileall: passed
- clean Docker Alembic upgrade from an empty PostgreSQL 18 database: passed
- real PostgreSQL expression-index check over 100,000 rows: valid GIN selected by the query plan
- search semantics: continuous sentence 1 hit, reordered terms 1 hit, quoted phrase 1 hit, typo 0 hits
- legacy generated-column/index compatibility: both legacy structures remained valid alongside the new expression index
- `git diff --check`: passed

## Release impact

Merging triggers Backend CI and, after it succeeds, the normal production image release. It does not publish a CLI package. After deployment, the existing Session search backfill must be run to completion and production search/navigation smoke-tested.
