### PR TITLE
fix(search): index oversized session messages in chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ database migration, CI, and implementation details.
 ### Fixed
 
 - Session detail search now preserves spaces while typing multi-word queries.
+- Session search now indexes very large messages in bounded chunks, so long
+  transcripts remain fully searchable without exceeding PostgreSQL full-text
+  limits; results and match navigation still point to the original message.
 
 ## Clawdi CLI v0.14.32
 

--- a/backend/alembic/versions/a4d8c1e7f2b6_session_message_search_chunks.py
+++ b/backend/alembic/versions/a4d8c1e7f2b6_session_message_search_chunks.py
@@ -1,0 +1,152 @@
+"""Index bounded Session message search chunks online.
+
+Revision ID: a4d8c1e7f2b6
+Revises: f7c9a2e5d1b4
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a4d8c1e7f2b6"
+down_revision: str | Sequence[str] | None = "f7c9a2e5d1b4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "session_message_search"
+_PRIMARY_KEY = "pk_session_message_search"
+_CHUNK_UNIQUE_INDEX = "ux_session_message_search_chunk_identity"
+_FTS_INDEX = "ix_session_message_search_content_fts"
+_NEXT_FTS_INDEX = "ix_session_message_search_content_fts_chunked"
+_MAX_CHUNK_CHARACTERS = 18_000
+
+
+def _index_validity(name: str) -> bool | None:
+    return (
+        op.get_bind()
+        .execute(
+            sa.text("SELECT indisvalid FROM pg_index WHERE indexrelid = to_regclass(:index_name)"),
+            {"index_name": name},
+        )
+        .scalar_one_or_none()
+    )
+
+
+def _primary_key_has_chunk_index() -> bool:
+    return bool(
+        op.get_bind()
+        .execute(
+            sa.text(
+                "SELECT EXISTS ("
+                "SELECT 1 FROM pg_constraint constraint_row "
+                "JOIN unnest(constraint_row.conkey) AS key(attnum) ON true "
+                "JOIN pg_attribute attribute "
+                "ON attribute.attrelid = constraint_row.conrelid "
+                "AND attribute.attnum = key.attnum "
+                "WHERE constraint_row.conrelid = to_regclass(:table_name) "
+                "AND constraint_row.contype = 'p' "
+                "AND attribute.attname = 'chunk_index'"
+                ")"
+            ),
+            {"table_name": _TABLE},
+        )
+        .scalar_one()
+    )
+
+
+def _drop_index_concurrently(name: str) -> None:
+    if _index_validity(name) is not None:
+        with op.get_context().autocommit_block():
+            op.drop_index(
+                name,
+                table_name=_TABLE,
+                postgresql_concurrently=True,
+            )
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            f"ALTER TABLE {_TABLE} ADD COLUMN IF NOT EXISTS chunk_index integer NOT NULL DEFAULT 0"
+        )
+    )
+    op.execute(
+        sa.text(
+            "DO $$ BEGIN "
+            "IF NOT EXISTS ("
+            "SELECT 1 FROM pg_constraint "
+            "WHERE conrelid = to_regclass('session_message_search') "
+            "AND conname = 'ck_session_message_search_chunk_index'"
+            ") THEN "
+            f"ALTER TABLE {_TABLE} ADD CONSTRAINT "
+            "ck_session_message_search_chunk_index "
+            "CHECK (chunk_index >= 0) NOT VALID; "
+            "END IF; END $$"
+        )
+    )
+
+    if not _primary_key_has_chunk_index():
+        if _index_validity(_CHUNK_UNIQUE_INDEX) is False:
+            _drop_index_concurrently(_CHUNK_UNIQUE_INDEX)
+        with op.get_context().autocommit_block():
+            op.create_index(
+                _CHUNK_UNIQUE_INDEX,
+                _TABLE,
+                ["session_id", "content_revision", "position", "chunk_index"],
+                unique=True,
+                postgresql_concurrently=True,
+                if_not_exists=True,
+            )
+        op.execute(
+            sa.text(
+                f"ALTER TABLE {_TABLE} DROP CONSTRAINT {_PRIMARY_KEY}, "
+                f"ADD CONSTRAINT {_PRIMARY_KEY} PRIMARY KEY "
+                f"USING INDEX {_CHUNK_UNIQUE_INDEX}"
+            )
+        )
+
+    if _index_validity(_NEXT_FTS_INDEX) is False:
+        _drop_index_concurrently(_NEXT_FTS_INDEX)
+    with op.get_context().autocommit_block():
+        op.create_index(
+            _NEXT_FTS_INDEX,
+            _TABLE,
+            [
+                sa.text(
+                    "(CASE WHEN char_length(content) <= "
+                    f"{_MAX_CHUNK_CHARACTERS} "
+                    "THEN to_tsvector('simple'::regconfig, content) "
+                    "ELSE to_tsvector('simple'::regconfig, ''::text) END)"
+                )
+            ],
+            postgresql_using="gin",
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+    _drop_index_concurrently(_FTS_INDEX)
+    op.execute(sa.text(f"ALTER INDEX {_NEXT_FTS_INDEX} RENAME TO {_FTS_INDEX}"))
+
+
+def downgrade() -> None:
+    # Search rows are a rebuildable S3 projection. Disable and clear them so an
+    # old application never evaluates an unbounded tsvector after the schema
+    # returns to one row per message.
+    op.execute(sa.text("UPDATE sessions SET search_index_revision = NULL"))
+    op.execute(sa.text("UPDATE session_event_chunks SET search_indexed_at = NULL"))
+    op.execute(sa.text(f"DELETE FROM {_TABLE}"))
+    _drop_index_concurrently(_FTS_INDEX)
+    op.execute(
+        sa.text(
+            f"ALTER TABLE {_TABLE} DROP CONSTRAINT {_PRIMARY_KEY}, "
+            f"ADD CONSTRAINT {_PRIMARY_KEY} PRIMARY KEY "
+            "(session_id, content_revision, position)"
+        )
+    )
+    op.execute(
+        sa.text(
+            f"ALTER TABLE {_TABLE} DROP CONSTRAINT IF EXISTS ck_session_message_search_chunk_index"
+        )
+    )
+    op.execute(sa.text(f"ALTER TABLE {_TABLE} DROP COLUMN chunk_index"))

--- a/backend/alembic/versions/f7c9a2e5d1b4_session_message_expression_search.py
+++ b/backend/alembic/versions/f7c9a2e5d1b4_session_message_expression_search.py
@@ -1,4 +1,4 @@
-"""Build Session message full-text search without rewriting the table.
+"""Reserve the online Session message search rollout revision.
 
 Revision ID: f7c9a2e5d1b4
 Revises: e4b8c2d6f1a9
@@ -6,53 +6,18 @@ Revises: e4b8c2d6f1a9
 
 from collections.abc import Sequence
 
-import sqlalchemy as sa
-
-from alembic import op
-
 revision: str = "f7c9a2e5d1b4"
 down_revision: str | Sequence[str] | None = "e4b8c2d6f1a9"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
-_EXPRESSION_INDEX = "ix_session_message_search_content_fts"
-
-
-def _expression_index_is_invalid() -> bool:
-    valid = op.get_bind().execute(
-        sa.text(
-            "SELECT indisvalid FROM pg_index "
-            "WHERE indexrelid = to_regclass(:index_name)"
-        ),
-        {"index_name": _EXPRESSION_INDEX},
-    ).scalar_one_or_none()
-    return valid is False
-
 
 def upgrade() -> None:
-    invalid_expression_index = _expression_index_is_invalid()
-    with op.get_context().autocommit_block():
-        if invalid_expression_index:
-            op.drop_index(
-                _EXPRESSION_INDEX,
-                table_name="session_message_search",
-                postgresql_concurrently=True,
-            )
-        op.create_index(
-            _EXPRESSION_INDEX,
-            "session_message_search",
-            [sa.text("to_tsvector('simple'::regconfig, content)")],
-            postgresql_using="gin",
-            postgresql_concurrently=True,
-            if_not_exists=True,
-        )
+    # Building one tsvector per complete message fails for PostgreSQL documents
+    # above 1 MiB. Keep this already-published revision as a compatibility
+    # marker; the successor introduces bounded message chunks before indexing.
+    pass
 
 
 def downgrade() -> None:
-    with op.get_context().autocommit_block():
-        op.drop_index(
-            _EXPRESSION_INDEX,
-            table_name="session_message_search",
-            postgresql_concurrently=True,
-            if_exists=True,
-        )
+    pass

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -268,10 +268,18 @@ class Session(Base, TimestampMixin):
     related_refs: Mapped[dict[str, JsonValue] | None] = mapped_column(JSONB(none_as_null=True))
 
 
+SESSION_SEARCH_CHUNK_BODY_CHARACTERS = 16_000
+SESSION_SEARCH_CHUNK_OVERLAP_CHARACTERS = 2_000
+SESSION_SEARCH_CHUNK_MAX_CHARACTERS = (
+    SESSION_SEARCH_CHUNK_BODY_CHARACTERS + SESSION_SEARCH_CHUNK_OVERLAP_CHARACTERS
+)
+
+
 class SessionMessageSearch(Base):
     __tablename__ = "session_message_search"
     __table_args__ = (
         CheckConstraint("position >= 0", name="ck_session_message_search_position"),
+        CheckConstraint("chunk_index >= 0", name="ck_session_message_search_chunk_index"),
         CheckConstraint(
             "role IN ('user', 'assistant')",
             name="ck_session_message_search_role",
@@ -286,7 +294,12 @@ class SessionMessageSearch(Base):
         ),
         Index(
             "ix_session_message_search_content_fts",
-            text("to_tsvector('simple'::regconfig, content)"),
+            text(
+                "CASE WHEN char_length(content) <= "
+                f"{SESSION_SEARCH_CHUNK_MAX_CHARACTERS} "
+                "THEN to_tsvector('simple'::regconfig, content) "
+                "ELSE to_tsvector('simple'::regconfig, ''::text) END"
+            ),
             postgresql_using="gin",
         ),
     )
@@ -306,6 +319,12 @@ class SessionMessageSearch(Base):
     )
     content_revision: Mapped[str] = mapped_column(String(80), primary_key=True, nullable=False)
     position: Mapped[int] = mapped_column(Integer, primary_key=True, nullable=False)
+    chunk_index: Mapped[int] = mapped_column(
+        Integer,
+        primary_key=True,
+        nullable=False,
+        server_default=text("0"),
+    )
     role: Mapped[Literal["user", "assistant"]] = mapped_column(String(20), nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
 

--- a/backend/app/services/session_search.py
+++ b/backend/app/services/session_search.py
@@ -7,7 +7,18 @@ from typing import Literal, Protocol
 from uuid import UUID
 
 from pydantic import JsonValue
-from sqlalchemy import String, case, cast, delete, func, literal, or_, select, update
+from sqlalchemy import (
+    String,
+    case,
+    cast,
+    delete,
+    func,
+    literal,
+    literal_column,
+    or_,
+    select,
+    update,
+)
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.selectable import Subquery
 
@@ -18,7 +29,13 @@ from app.core.query_utils import (
     text_search_document,
     websearch_query,
 )
-from app.models.session import Session, SessionEventChunk, SessionMessageSearch
+from app.models.session import (
+    SESSION_SEARCH_CHUNK_BODY_CHARACTERS,
+    SESSION_SEARCH_CHUNK_MAX_CHARACTERS,
+    Session,
+    SessionEventChunk,
+    SessionMessageSearch,
+)
 from app.schemas.session import (
     SessionSearchAnchorResponse,
     SessionSearchMatchResponse,
@@ -136,12 +153,36 @@ def _searchable_text(content: str) -> str:
     return content.replace("\x00", "\ufffd")
 
 
+def session_search_chunks(content: str) -> list[str]:
+    """Split one message into bounded, overlapping search documents."""
+    if len(content) <= SESSION_SEARCH_CHUNK_MAX_CHARACTERS:
+        return [content]
+
+    chunks: list[str] = []
+    start = 0
+    while start + SESSION_SEARCH_CHUNK_MAX_CHARACTERS < len(content):
+        chunks.append(content[start : start + SESSION_SEARCH_CHUNK_MAX_CHARACTERS])
+        start += SESSION_SEARCH_CHUNK_BODY_CHARACTERS
+    chunks.append(content[start:])
+    return chunks
+
+
+def _message_search_document():
+    content = SessionMessageSearch.content
+    return case(
+        (
+            func.char_length(content) <= literal_column(str(SESSION_SEARCH_CHUNK_MAX_CHARACTERS)),
+            text_search_document((content,)),
+        ),
+        else_=text_search_document((literal_column("''::text"),)),
+    )
+
+
 def _message_match_expression(query: str):
-    search_document = text_search_document((SessionMessageSearch.content,))
     return lexical_search_filter(
         query,
         (SessionMessageSearch.content,),
-        search_vector=search_document,
+        search_vector=_message_search_document(),
     )
 
 
@@ -164,7 +205,7 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
     message_match = _message_match_expression(query)
     phrase_match = SessionMessageSearch.content.ilike(like_needle(query), escape="\\")
     lexical_rank = func.ts_rank_cd(
-        text_search_document((SessionMessageSearch.content,)),
+        _message_search_document(),
         websearch_query(query),
     )
     candidates = (
@@ -172,6 +213,7 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
             SessionMessageSearch.session_id.label("session_id"),
             SessionMessageSearch.content_revision.label("content_revision"),
             SessionMessageSearch.position.label("position"),
+            SessionMessageSearch.chunk_index.label("chunk_index"),
             SessionMessageSearch.content.label("content"),
             SessionMessageSearch.role.label("role"),
             case(
@@ -206,6 +248,7 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
             candidates.c.session_id,
             candidates.c.score.desc(),
             candidates.c.position.asc(),
+            candidates.c.chunk_index.asc(),
         )
         .subquery("best_session_message_match")
     )
@@ -280,25 +323,30 @@ async def session_message_search_navigation(
         return None
 
     message_match = _message_match_expression(query)
-    ordered_matches_query = select(
-        SessionMessageSearch.position.label("position"),
-        func.row_number().over(order_by=SessionMessageSearch.position).label("match_index"),
-        func.count().over().label("match_total"),
-        func.lag(SessionMessageSearch.position)
-        .over(order_by=SessionMessageSearch.position)
-        .label("previous_position"),
-        func.lead(SessionMessageSearch.position)
-        .over(order_by=SessionMessageSearch.position)
-        .label("next_position"),
-    ).where(
+    matching_positions_query = select(SessionMessageSearch.position.label("position")).where(
         SessionMessageSearch.user_id == session.user_id,
         SessionMessageSearch.session_id == session.id,
         SessionMessageSearch.content_revision == document_revision,
         message_match,
     )
     if roles is not None:
-        ordered_matches_query = ordered_matches_query.where(SessionMessageSearch.role.in_(roles))
-    ordered_matches = ordered_matches_query.subquery("ordered_session_message_matches")
+        matching_positions_query = matching_positions_query.where(
+            SessionMessageSearch.role.in_(roles)
+        )
+    matching_positions = matching_positions_query.group_by(SessionMessageSearch.position).subquery(
+        "matching_session_message_positions"
+    )
+    ordered_matches = select(
+        matching_positions.c.position,
+        func.row_number().over(order_by=matching_positions.c.position).label("match_index"),
+        func.count().over().label("match_total"),
+        func.lag(matching_positions.c.position)
+        .over(order_by=matching_positions.c.position)
+        .label("previous_position"),
+        func.lead(matching_positions.c.position)
+        .over(order_by=matching_positions.c.position)
+        .label("next_position"),
+    ).subquery("ordered_session_message_matches")
     navigation_query = select(
         ordered_matches.c.position,
         ordered_matches.c.match_index,
@@ -371,10 +419,12 @@ def _add_documents(
                 generation_id=generation_id,
                 content_revision=content_revision,
                 position=message.position,
+                chunk_index=chunk_index,
                 role=message.role,
-                content=message.content,
+                content=content,
             )
             for message in messages
+            for chunk_index, content in enumerate(session_search_chunks(message.content))
         ]
     )
 

--- a/backend/scripts/backfill_session_search.py
+++ b/backend/scripts/backfill_session_search.py
@@ -6,6 +6,7 @@ Usage:
     pdm run python -m scripts.backfill_session_search --all --workers 8
     pdm run python -m scripts.backfill_session_search --all --dry-run
     pdm run python -m scripts.backfill_session_search --all --force
+    pdm run python -m scripts.backfill_session_search --all --chunks-only
 """
 
 from __future__ import annotations
@@ -16,16 +17,21 @@ import logging
 import uuid
 from typing import Literal
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, or_, select, tuple_
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from app.core.database import engine
-from app.models.session import Session
+from app.models.session import (
+    SESSION_SEARCH_CHUNK_MAX_CHARACTERS,
+    Session,
+    SessionMessageSearch,
+)
 from app.services.file_store import get_file_store
 from app.services.session_search import (
     current_search_revision,
     event_search_projection_complete,
     rebuild_session_search_index,
+    session_search_chunks,
 )
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -33,6 +39,7 @@ log = logging.getLogger("backfill-session-search")
 
 MAX_WORKERS = 16
 CHUNK_SIZE = MAX_WORKERS
+RECHUNK_BATCH_SIZE = 16
 
 type BackfillOutcome = Literal["indexed", "skipped", "failed"]
 
@@ -45,6 +52,92 @@ def worker_count(value: str) -> int:
     if not 1 <= workers <= MAX_WORKERS:
         raise argparse.ArgumentTypeError(f"workers must be between 1 and {MAX_WORKERS}")
     return workers
+
+
+async def rechunk_existing_documents(
+    *,
+    user_id: uuid.UUID | None,
+    dry_run: bool,
+) -> int:
+    """Convert legacy oversized rows in bounded, restartable transactions."""
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    filters = [
+        SessionMessageSearch.chunk_index == 0,
+        func.char_length(SessionMessageSearch.content) > SESSION_SEARCH_CHUNK_MAX_CHARACTERS,
+    ]
+    if user_id is not None:
+        filters.append(SessionMessageSearch.user_id == user_id)
+
+    if dry_run:
+        async with session_factory() as db:
+            total = (
+                await db.execute(
+                    select(func.count()).select_from(SessionMessageSearch).where(*filters)
+                )
+            ).scalar_one()
+        log.info("would rechunk %d oversized search documents", total)
+        return total
+
+    processed = 0
+    last_key: tuple[uuid.UUID, str, int, int] | None = None
+    while True:
+        async with session_factory() as db:
+            query = select(SessionMessageSearch).where(*filters)
+            if last_key is not None:
+                query = query.where(
+                    tuple_(
+                        SessionMessageSearch.session_id,
+                        SessionMessageSearch.content_revision,
+                        SessionMessageSearch.position,
+                        SessionMessageSearch.chunk_index,
+                    )
+                    > last_key
+                )
+            documents = list(
+                (
+                    await db.execute(
+                        query.order_by(
+                            SessionMessageSearch.session_id,
+                            SessionMessageSearch.content_revision,
+                            SessionMessageSearch.position,
+                            SessionMessageSearch.chunk_index,
+                        )
+                        .with_for_update(skip_locked=True)
+                        .limit(RECHUNK_BATCH_SIZE)
+                    )
+                ).scalars()
+            )
+            if not documents:
+                break
+            last_document = documents[-1]
+            last_key = (
+                last_document.session_id,
+                last_document.content_revision,
+                last_document.position,
+                last_document.chunk_index,
+            )
+            for document in documents:
+                chunks = session_search_chunks(document.content)
+                document.content = chunks[0]
+                db.add_all(
+                    [
+                        SessionMessageSearch(
+                            user_id=document.user_id,
+                            session_id=document.session_id,
+                            generation_id=document.generation_id,
+                            content_revision=document.content_revision,
+                            position=document.position,
+                            chunk_index=chunk_index,
+                            role=document.role,
+                            content=content,
+                        )
+                        for chunk_index, content in enumerate(chunks[1:], start=1)
+                    ]
+                )
+            await db.commit()
+        processed += len(documents)
+        log.info("rechunked=%d", processed)
+    return processed
 
 
 async def backfill_user(
@@ -165,12 +258,29 @@ def main() -> None:
     parser.add_argument("--force", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument(
+        "--chunks-only",
+        action="store_true",
+        help="rechunk legacy oversized projection rows without reading S3",
+    )
+    parser.add_argument(
         "--workers",
         type=worker_count,
         default=1,
         help=f"concurrent Session rebuilds (1-{MAX_WORKERS}; default: 1)",
     )
     args = parser.parse_args()
+    if args.chunks_only:
+        if args.force:
+            parser.error("--force does not apply to --chunks-only")
+        if args.workers != 1:
+            parser.error("--workers does not apply to --chunks-only")
+        asyncio.run(
+            rechunk_existing_documents(
+                user_id=None if args.all else args.user_id,
+                dry_run=args.dry_run,
+            )
+        )
+        return
     if args.all:
         failed = asyncio.run(
             backfill_all(

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -13,13 +13,19 @@ import asyncio
 import hashlib
 import json
 from datetime import UTC, datetime, timedelta
+from uuid import UUID
 
 import httpx
 import pytest
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from app.models.session import Session, SessionMessageSearch
+from app.models.session import (
+    SESSION_SEARCH_CHUNK_BODY_CHARACTERS,
+    SESSION_SEARCH_CHUNK_MAX_CHARACTERS,
+    Session,
+    SessionMessageSearch,
+)
 from app.services.session_search import (
     SearchableSessionMessage,
     rebuild_session_search_index,
@@ -280,6 +286,62 @@ async def test_snapshot_message_search_tracks_current_content_and_escapes_wildca
     await db_session.commit()
     rebuilt = (await client.get("/v1/sessions", params={"q": "authoritative"})).json()
     assert [item["local_session_id"] for item in rebuilt["items"]] == [local_id]
+
+
+@pytest.mark.asyncio
+async def test_oversized_snapshot_search_preserves_phrase_and_message_navigation(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    env_id = await _register_env(client)
+    local_id = "oversized-snapshot-search"
+    overlap_phrase = "overlap token pair"
+    crossing_phrase = "boundary phrase remains searchable"
+    phrase_start = SESSION_SEARCH_CHUNK_MAX_CHARACTERS - 8
+    prefix = "x " * (SESSION_SEARCH_CHUNK_BODY_CHARACTERS // 2) + overlap_phrase + " "
+    content = (
+        prefix
+        + "z" * (phrase_start - len(prefix) - 1)
+        + " "
+        + crossing_phrase
+        + " y" * ((SESSION_SEARCH_CHUNK_MAX_CHARACTERS // 2) + 1)
+    )
+    session_id = await _push_session(
+        client,
+        env_id,
+        local_session_id=local_id,
+        messages=[{"role": "user", "content": content}],
+        upload=True,
+    )
+
+    stored_chunks = list(
+        (
+            await db_session.execute(
+                select(SessionMessageSearch)
+                .where(SessionMessageSearch.session_id == UUID(session_id))
+                .order_by(SessionMessageSearch.chunk_index)
+            )
+        ).scalars()
+    )
+    assert len(stored_chunks) >= 2
+    assert all(len(chunk.content) <= SESSION_SEARCH_CHUNK_MAX_CHARACTERS for chunk in stored_chunks)
+    assert [chunk.chunk_index for chunk in stored_chunks] == list(range(len(stored_chunks)))
+
+    search = await client.get(
+        "/v1/sessions",
+        params={"q": crossing_phrase},
+    )
+    assert search.status_code == 200, search.text
+    assert [item["local_session_id"] for item in search.json()["items"]] == [local_id]
+    assert search.json()["items"][0]["search_match"]["anchor"]["position"] == 0
+
+    navigation = await client.get(
+        f"/v1/sessions/{session_id}/messages",
+        params={"search_query": overlap_phrase},
+    )
+    assert navigation.status_code == 200, navigation.text
+    assert navigation.json()["search_navigation"]["total"] == 1
+    assert navigation.json()["search_navigation"]["current"]["position"] == 0
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_session_search_chunk_migration.py
+++ b/backend/tests/test_session_search_chunk_migration.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, inspect, select, text
+from sqlalchemy.engine import URL, make_url
+from sqlalchemy.exc import DBAPIError
+
+from app.core.config import settings
+from app.core.query_utils import websearch_query
+from app.models.session import (
+    SESSION_SEARCH_CHUNK_MAX_CHARACTERS,
+    SESSION_SEARCH_CHUNK_OVERLAP_CHARACTERS,
+    SessionMessageSearch,
+)
+from app.services.session_search import _message_search_document
+
+PREVIOUS_REVISION = "e4b8c2d6f1a9"
+CHUNK_REVISION = "a4d8c1e7f2b6"
+BACKEND_DIR = Path(__file__).parents[1]
+
+
+def _sync_url(url: URL, *, database: str) -> URL:
+    return url.set(drivername="postgresql+psycopg2", database=database)
+
+
+def _run(database_url: URL, *args: str) -> None:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url.render_as_string(hide_password=False)
+    subprocess.run(args, cwd=BACKEND_DIR, env=env, check=True)
+
+
+def _run_alembic(database_url: URL, *args: str) -> None:
+    _run(database_url, str(Path(sys.executable).with_name("alembic")), *args)
+
+
+def test_session_search_chunk_migration_recovers_failed_expression_index() -> None:
+    source_url = make_url(os.getenv("DATABASE_URL", settings.database_url))
+    database_name = f"clawdi_session_search_chunks_{uuid.uuid4().hex}"
+    admin_engine = create_engine(
+        _sync_url(source_url, database="postgres"),
+        isolation_level="AUTOCOMMIT",
+    )
+    database_url = source_url.set(database=database_name)
+    database_engine = create_engine(_sync_url(source_url, database=database_name))
+    user_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    revision = "snapshot:" + "a" * 64
+    content = " ".join(f"token{index:08x}" for index in range(180_000))
+
+    with admin_engine.connect() as connection:
+        connection.execute(text(f'CREATE DATABASE "{database_name}"'))
+    try:
+        _run_alembic(database_url, "upgrade", PREVIOUS_REVISION)
+        with database_engine.begin() as connection:
+            connection.execute(
+                text("INSERT INTO users (id, clerk_id) VALUES (:id, :clerk_id)"),
+                {"id": user_id, "clerk_id": f"search-chunks-{user_id}"},
+            )
+            connection.execute(
+                text(
+                    "INSERT INTO sessions "
+                    "(id, user_id, local_session_id, started_at, content_hash, "
+                    "search_index_revision) "
+                    "VALUES (:id, :user_id, 'large-search-session', now(), :hash, :revision)"
+                ),
+                {
+                    "id": session_id,
+                    "user_id": user_id,
+                    "hash": "a" * 64,
+                    "revision": revision,
+                },
+            )
+            connection.execute(
+                text(
+                    "INSERT INTO session_message_search "
+                    "(user_id, session_id, content_revision, position, role, content) "
+                    "VALUES (:user_id, :session_id, :revision, 0, 'user', :content)"
+                ),
+                {
+                    "user_id": user_id,
+                    "session_id": session_id,
+                    "revision": revision,
+                    "content": content,
+                },
+            )
+
+        failing_index_engine = create_engine(
+            _sync_url(source_url, database=database_name),
+            isolation_level="AUTOCOMMIT",
+        )
+        try:
+            with pytest.raises(DBAPIError, match="string is too long for tsvector"):
+                with failing_index_engine.connect() as connection:
+                    connection.execute(
+                        text(
+                            "CREATE INDEX CONCURRENTLY "
+                            "ix_session_message_search_content_fts "
+                            "ON session_message_search USING gin "
+                            "(to_tsvector('simple'::regconfig, content))"
+                        )
+                    )
+        finally:
+            failing_index_engine.dispose()
+
+        with database_engine.connect() as connection:
+            assert (
+                connection.execute(
+                    text(
+                        "SELECT indisvalid FROM pg_index "
+                        "WHERE indexrelid = to_regclass("
+                        "'ix_session_message_search_content_fts')"
+                    )
+                ).scalar_one()
+                is False
+            )
+
+        _run_alembic(database_url, "upgrade", CHUNK_REVISION)
+        _run(
+            database_url,
+            sys.executable,
+            "-m",
+            "scripts.backfill_session_search",
+            "--all",
+            "--chunks-only",
+        )
+
+        with database_engine.connect() as connection:
+            chunks = list(
+                connection.execute(
+                    text(
+                        "SELECT chunk_index, content FROM session_message_search "
+                        "WHERE session_id = :session_id ORDER BY chunk_index"
+                    ),
+                    {"session_id": session_id},
+                )
+            )
+            assert len(chunks) > 100
+            assert [row.chunk_index for row in chunks] == list(range(len(chunks)))
+            assert all(len(row.content) <= SESSION_SEARCH_CHUNK_MAX_CHARACTERS for row in chunks)
+            reconstructed = chunks[0].content + "".join(
+                row.content[SESSION_SEARCH_CHUNK_OVERLAP_CHARACTERS:] for row in chunks[1:]
+            )
+            assert reconstructed == content
+            assert (
+                connection.execute(
+                    text(
+                        "SELECT indisvalid FROM pg_index "
+                        "WHERE indexrelid = to_regclass("
+                        "'ix_session_message_search_content_fts')"
+                    )
+                ).scalar_one()
+                is True
+            )
+            search_statement = select(SessionMessageSearch.position).where(
+                _message_search_document().op("@@")(websearch_query("token00000001 token00000002"))
+            )
+            compiled_search = search_statement.compile(
+                dialect=database_engine.dialect,
+                compile_kwargs={"literal_binds": True},
+            )
+            connection.execute(text("SET LOCAL enable_seqscan = off"))
+            plan = "\n".join(
+                row[0] for row in connection.execute(text(f"EXPLAIN {compiled_search}"))
+            )
+            assert "ix_session_message_search_content_fts" in plan
+
+        _run_alembic(database_url, "downgrade", PREVIOUS_REVISION)
+        assert "chunk_index" not in {
+            column["name"]
+            for column in inspect(database_engine).get_columns("session_message_search")
+        }
+    finally:
+        database_engine.dispose()
+        with admin_engine.connect() as connection:
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)'))
+        admin_engine.dispose()


### PR DESCRIPTION
## Summary

- Replace the one-row-per-message search projection with bounded 18k-character chunks and a 2k overlap.
- Keep S3 as the sole Session body authority while deduplicating chunk hits back to the original message position.
- Recover the failed online FTS rollout, build the guarded GIN and expanded primary key concurrently, and add restartable keyset backfill for existing oversized rows.

This follows PostgreSQL's documented 1 MiB `tsvector` limit and web-search query semantics:

- https://www.postgresql.org/docs/current/textsearch-limitations.html
- https://www.postgresql.org/docs/current/textsearch-controls.html

## Production Evidence

Read-only inspection before implementation:

- Alembic revision: `e4b8c2d6f1a9`
- `ix_session_message_search_content_fts`: invalid and not ready
- 2,705,764 projection rows total
- 17,694 rows exceed the new chunk size across 16,068 Sessions
- 18 rows exceed PostgreSQL's 1 MiB `tsvector` ceiling
- Largest message: 26,382,397 bytes

The failed `f7c9a2e5d1b4` revision becomes a compatibility marker. Successor `a4d8c1e7f2b6` handles clean, failed, and already-valid predecessor states.

## Verification

- Full isolated backend: `2515 passed, 12 skipped, 0 failed`
- Focused Session search and production-shape migration: `11 passed`
- Strict Python type governance: 205 production files, 0 errors
- Biome 2.5.9: 1116 files, no changes
- Ruff check/format, compileall, Alembic single-head, and diff whitespace: passed
- The migration test reproduces the real `tsvector` failure and invalid concurrent index, upgrades, confirms the application expression uses the new GIN, reconstructs a 2.5 MB message byte-for-byte from chunks, and downgrades cleanly.

## Rollout

After deploy, run the restartable one-time projection conversion:

```bash
python -m scripts.backfill_session_search --all --chunks-only
```

Then require zero rows where `chunk_index = 0 AND char_length(content) > 18000`, a valid FTS index, and smoke Session list/global search plus message navigation.
