### PR TITLE
fix(admin): support v1 managed provider metadata repair

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -174,10 +174,12 @@ from app.services.managed_ai_provider import (
     archive_clawdi_managed_provider,
     cleanup_deployment_managed_provider,
     find_clawdi_managed_provider,
-    is_supported_deployment_managed_provider_contract,
+    is_runtime_metadata_managed_provider_id,
+    is_supported_managed_provider_runtime_contract,
     is_v2_deployment_managed_provider_id,
     lock_deployment_managed_provider_mutation,
-    replace_deployment_managed_provider_metadata,
+    lock_runtime_metadata_managed_provider_mutation,
+    replace_managed_provider_runtime_metadata,
     upsert_clawdi_managed_provider,
 )
 from app.services.platform_contract import (
@@ -548,7 +550,7 @@ async def _resolve_or_create_admin_owner(
 
 
 def _require_managed_provider_contract(provider: AiProvider) -> None:
-    if not is_supported_deployment_managed_provider_contract(provider):
+    if not is_supported_managed_provider_runtime_contract(provider):
         raise HTTPException(
             status.HTTP_409_CONFLICT,
             "Stored managed AI provider contract is invalid",
@@ -1018,7 +1020,7 @@ async def admin_get_clawdi_managed_ai_provider(
 ) -> AdminDeploymentManagedAiProviderResponse:
     """Read one first-party managed provider within an explicit owner scope."""
 
-    if not is_v2_deployment_managed_provider_id(provider_id):
+    if not is_runtime_metadata_managed_provider_id(provider_id):
         raise HTTPException(
             status.HTTP_405_METHOD_NOT_ALLOWED,
             "Method Not Allowed",
@@ -1264,7 +1266,7 @@ async def admin_replace_deployment_managed_ai_provider_metadata(
 ) -> AdminDeploymentManagedAiProviderResponse:
     """Replace deployment-managed runtime metadata without changing auth state."""
 
-    if not is_v2_deployment_managed_provider_id(provider_id):
+    if not is_runtime_metadata_managed_provider_id(provider_id):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
     owner = body.owner
     action = "ai_provider.managed.runtime_metadata.replace"
@@ -1274,7 +1276,7 @@ async def admin_replace_deployment_managed_ai_provider_metadata(
         provider_id=provider_id,
         action=action,
     )
-    await lock_deployment_managed_provider_mutation(
+    await lock_runtime_metadata_managed_provider_mutation(
         db,
         owner_user_id=target.id,
         provider_id=provider_id,
@@ -1294,7 +1296,7 @@ async def admin_replace_deployment_managed_ai_provider_metadata(
         )
     try:
         _require_managed_provider_contract(provider)
-        changed = replace_deployment_managed_provider_metadata(
+        changed = replace_managed_provider_runtime_metadata(
             provider,
             base_url=body.base_url,
             models=(

--- a/backend/app/services/managed_ai_provider.py
+++ b/backend/app/services/managed_ai_provider.py
@@ -110,6 +110,14 @@ def is_managed_provider_id(provider_id: str) -> bool:
     return provider_id == V1_MANAGED_AI_PROVIDER_ID or is_v2_managed_provider_id(provider_id)
 
 
+def is_runtime_metadata_managed_provider_id(provider_id: str) -> bool:
+    """Return whether admin may read or replace non-auth runtime metadata."""
+
+    return provider_id == V1_MANAGED_AI_PROVIDER_ID or is_v2_deployment_managed_provider_id(
+        provider_id
+    )
+
+
 def runtime_managed_provider_id(provider_id: str) -> str:
     """Return the stable agent-facing id for a managed provider binding."""
 
@@ -144,11 +152,11 @@ def validate_managed_provider_base_url(base_url: str) -> None:
         raise ValueError(str(exc)) from exc
 
 
-def is_supported_deployment_managed_provider_contract(provider: AiProvider) -> bool:
-    """Return whether a stored deployment provider matches a released contract."""
+def is_supported_managed_provider_runtime_contract(provider: AiProvider) -> bool:
+    """Return whether a managed provider is safe for metadata-only admin writes."""
 
     return (
-        is_v2_deployment_managed_provider_id(provider.provider_id)
+        is_runtime_metadata_managed_provider_id(provider.provider_id)
         and provider.type == MANAGED_AI_PROVIDER_TYPE
         and (provider.api_mode, provider.runtime_env_name)
         in _SUPPORTED_DEPLOYMENT_MANAGED_PROVIDER_CONTRACTS
@@ -157,6 +165,17 @@ def is_supported_deployment_managed_provider_contract(provider: AiProvider) -> b
         and (provider.auth_metadata or {}).get("source") == "managed"
         and provider.managed_by == "clawdi"
     )
+
+
+async def _lock_managed_provider_mutation(
+    db: AsyncSession,
+    *,
+    owner_user_id: UUID,
+    provider_id: str,
+) -> None:
+    await lock_ai_provider_owner(db, owner_user_id)
+    lock_name = f"managed-ai-provider:{owner_user_id}:{provider_id}"
+    await db.execute(select(func.pg_advisory_xact_lock(func.hashtextextended(lock_name, 0))))
 
 
 async def lock_deployment_managed_provider_mutation(
@@ -173,9 +192,28 @@ async def lock_deployment_managed_provider_mutation(
 
     if not is_v2_deployment_managed_provider_id(provider_id):
         raise ValueError("unsupported deployment managed provider id")
-    await lock_ai_provider_owner(db, owner_user_id)
-    lock_name = f"managed-ai-provider:{owner_user_id}:{provider_id}"
-    await db.execute(select(func.pg_advisory_xact_lock(func.hashtextextended(lock_name, 0))))
+    await _lock_managed_provider_mutation(
+        db,
+        owner_user_id=owner_user_id,
+        provider_id=provider_id,
+    )
+
+
+async def lock_runtime_metadata_managed_provider_mutation(
+    db: AsyncSession,
+    *,
+    owner_user_id: UUID,
+    provider_id: str,
+) -> None:
+    """Serialize a metadata-only mutation for one supported managed provider."""
+
+    if not is_runtime_metadata_managed_provider_id(provider_id):
+        raise ValueError("unsupported runtime metadata managed provider id")
+    await _lock_managed_provider_mutation(
+        db,
+        owner_user_id=owner_user_id,
+        provider_id=provider_id,
+    )
 
 
 async def upsert_clawdi_managed_provider(
@@ -251,7 +289,7 @@ async def upsert_clawdi_managed_provider(
     return provider
 
 
-def replace_deployment_managed_provider_metadata(
+def replace_managed_provider_runtime_metadata(
     provider: AiProvider,
     *,
     base_url: str,
@@ -259,8 +297,8 @@ def replace_deployment_managed_provider_metadata(
 ) -> bool:
     """Replace runtime metadata without touching provider auth state."""
 
-    if not is_v2_deployment_managed_provider_id(provider.provider_id):
-        raise ValueError("unsupported deployment managed provider id")
+    if not is_runtime_metadata_managed_provider_id(provider.provider_id):
+        raise ValueError("unsupported runtime metadata managed provider id")
     validate_managed_provider_base_url(base_url)
     normalized_base_url = base_url.strip()
     if (
@@ -290,7 +328,7 @@ async def find_clawdi_managed_provider(
 ) -> AiProvider | None:
     """Find one managed provider without crossing its account boundary."""
 
-    if not is_v2_managed_provider_id(provider_id):
+    if not is_managed_provider_id(provider_id):
         raise ValueError("unsupported managed provider id")
     query = select(AiProvider).where(
         AiProvider.owner_user_id == owner_user_id,
@@ -364,7 +402,7 @@ async def cleanup_deployment_managed_provider(
     if provider is None:
         return None
     if (
-        not is_supported_deployment_managed_provider_contract(provider)
+        not is_supported_managed_provider_runtime_contract(provider)
         or provider.id != expected_provider_uuid
         or (provider.capabilities or {}).get(MANAGED_AI_PROVIDER_PROVENANCE_CAPABILITY)
         != provisioning_discovery_key

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -28,6 +28,7 @@ from app.services.managed_ai_provider import (
     MANAGED_AI_PROVIDER_API_MODE,
     MANAGED_AI_PROVIDER_PROVENANCE_CAPABILITY,
     MANAGED_AI_PROVIDER_RUNTIME_ENV,
+    V1_MANAGED_AI_PROVIDER_ID,
     V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX,
     V2_LEGACY_MANAGED_AI_PROVIDER_ID,
     V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
@@ -205,6 +206,82 @@ async def _replace_managed_provider_runtime_metadata(
         f"/v1/admin/ai-providers/{provider_id}/runtime-metadata",
         headers=_AUTH,
         json=body,
+    )
+
+
+@pytest.mark.asyncio
+async def test_admin_v1_managed_provider_supports_metadata_only_repair(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    from sqlalchemy import select
+
+    from app.models.ai_provider import AiProvider, AiProviderAuthPayload
+
+    old_url = "https://legacy-gateway.example.test/v1"
+    new_url = "https://stable-gateway.example.test/v1"
+    owner = {"kind": "clerk", "ref": seed_user.clerk_id}
+    provider = AiProvider(
+        owner_user_id=seed_user.id,
+        provider_id=V1_MANAGED_AI_PROVIDER_ID,
+        type="custom_openai_compatible",
+        label="Legacy managed provider",
+        base_url=old_url,
+        api_mode=MANAGED_AI_PROVIDER_API_MODE,
+        auth_type="api_key",
+        auth_ref=None,
+        auth_metadata={"source": "managed", "profile": "default"},
+        managed_by="clawdi",
+        runtime_env_name=MANAGED_AI_PROVIDER_RUNTIME_ENV,
+        models=[{"id": "gpt-5.6-sol"}],
+    )
+    db_session.add(provider)
+    await db_session.commit()
+
+    readback = await admin_client.get(
+        f"/v1/admin/ai-providers/{V1_MANAGED_AI_PROVIDER_ID}",
+        headers=_AUTH,
+        params=owner,
+    )
+    replaced = await _replace_managed_provider_runtime_metadata(
+        admin_client,
+        V1_MANAGED_AI_PROVIDER_ID,
+        {
+            "owner": owner,
+            "base_url": new_url,
+            "models": [{"id": "gpt-5.6-sol"}],
+        },
+    )
+    delete_response = await admin_client.delete(
+        f"/v1/admin/ai-providers/{V1_MANAGED_AI_PROVIDER_ID}",
+        headers=_AUTH,
+        params=owner,
+    )
+
+    assert readback.status_code == 200, readback.text
+    assert readback.json()["owner"] == owner
+    assert readback.json()["provider_id"] == V1_MANAGED_AI_PROVIDER_ID
+    assert readback.json()["base_url"] == old_url
+    assert replaced.status_code == 200, replaced.text
+    assert replaced.json()["owner"] == owner
+    assert replaced.json()["provider_id"] == V1_MANAGED_AI_PROVIDER_ID
+    assert replaced.json()["base_url"] == new_url
+    assert delete_response.status_code == 405, delete_response.text
+
+    await db_session.refresh(provider)
+    assert provider.base_url == new_url
+    assert provider.auth_type == "api_key"
+    assert provider.auth_ref is None
+    assert provider.auth_metadata == {"source": "managed", "profile": "default"}
+    assert (
+        await db_session.scalar(
+            select(AiProviderAuthPayload.id).where(
+                AiProviderAuthPayload.owner_user_id == seed_user.id,
+                AiProviderAuthPayload.provider_id == V1_MANAGED_AI_PROVIDER_ID,
+            )
+        )
+        is None
     )
 
 


### PR DESCRIPTION
## Summary

- allow the owner-scoped admin read and metadata-only replace surfaces for the exact legacy v1 managed provider ID
- preserve v2-only create, credential rotation, delete, and cleanup boundaries
- serialize v1 metadata updates with the existing owner/provider transaction lock and never read or mutate provider auth

## Production context

Hosted m040 correctly stopped after Cloud API returned 405 while reading `clawdi-managed`. This adds the missing Cloud API contract so the same audited repair can be retried idempotently.

## Verification

- Docker clean runner: `tests/test_admin_endpoints.py` (`89 passed`)
- Docker clean runner focused post-refactor: `4 passed`
- Ruff check and format check: passed
