### PR TITLE
fix(search): align query validation and highlighting

### DIFF
--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -124,7 +124,7 @@ test("opens a global Session body match at the exact message", async ({ page }) 
 		.getByPlaceholder("Search agents, sessions, memories, projects, skills, vaults…")
 		.fill(query);
 	await expect(palette.getByText(`Found the ${query} in this response`)).toBeVisible();
-	await expect(palette.locator("mark")).toHaveText(["Global", "global", "palette", "anchor"]);
+	await expect(palette.locator("mark")).toHaveText(["Global", "global palette anchor"]);
 	await palette.getByText("Global search result").click();
 
 	await expect(page).toHaveURL((url) => {
@@ -136,11 +136,12 @@ test("opens a global Session body match at the exact message", async ({ page }) 
 	});
 	const current = page.locator('[data-search-match="true"]');
 	await expect(current).toContainText(`Found the ${query} in this response`);
-	await expect(current.locator("mark")).toHaveText(["global", "palette", "anchor"]);
+	await expect(current.locator("mark")).toHaveText(["global palette anchor"]);
 });
 
 test("opens a message search result and returns to the same filtered list", async ({ page }) => {
 	await page.setViewportSize({ width: 390, height: 844 });
+	const requestedSearchQueries: string[] = [];
 	await page.route("**/v1/**", async (route) => {
 		const url = new URL(route.request().url());
 		if (url.pathname === "/v1/agents") {
@@ -177,6 +178,7 @@ test("opens a message search result and returns to the same filtered list", asyn
 		}
 		if (url.pathname === `/v1/sessions/${SESSION_ID}/messages`) {
 			const searchQuery = url.searchParams.get("search_query");
+			if (searchQuery !== null) requestedSearchQueries.push(searchQuery);
 			const selectedPosition = Number(url.searchParams.get("anchor_position"));
 			const isDirectDetailSearch = searchQuery === "no longer";
 			const isSecond = isDirectDetailSearch || selectedPosition === nextAnchor.position;
@@ -216,7 +218,7 @@ test("opens a message search result and returns to the same filtered list", asyn
 
 	await page.goto("/sessions?q=authentication%20timeout&agent=codex&page=2&view=table");
 	const visibleResult = page.locator('[data-testid="session-card"]:visible');
-	await expect(visibleResult.locator("mark")).toHaveText(["authentication", "timeout"]);
+	await expect(visibleResult.locator("mark")).toHaveText(["authentication timeout"]);
 
 	await visibleResult
 		.getByRole("link", { name: "Open session Fix authentication timeout" })
@@ -232,6 +234,10 @@ test("opens a message search result and returns to the same filtered list", asyn
 	await expect(page.getByText("2 / 2")).toBeVisible();
 	await detailSearch.press("Shift+Enter");
 	await expect(page).toHaveURL((url) => url.searchParams.get("matchPosition") === "7");
+	await detailSearch.fill("x");
+	await expect(page.getByText("2+ chars")).toBeVisible();
+	await page.waitForTimeout(350);
+	expect(requestedSearchQueries).not.toContain("x");
 	await detailSearch.fill("no longer");
 	await expect(page.getByRole("button", { name: "Next match" })).toBeDisabled();
 	await expect(page).toHaveURL((url) => {
@@ -242,7 +248,7 @@ test("opens a message search result and returns to the same filtered list", asyn
 	await expect(page.locator('[data-search-match="true"]')).toContainText(
 		"Verified the authentication timeout no longer recurs",
 	);
-	await expect(page.locator('[data-search-match="true"] mark')).toHaveText(["no", "longer"]);
+	await expect(page.locator('[data-search-match="true"] mark')).toHaveText(["no longer"]);
 	await expect(page.getByText("1 / 1")).toBeVisible();
 
 	await page.getByText("Back to Sessions", { exact: true }).click();
@@ -530,7 +536,7 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 	await page.goto(`/sessions/${SESSION_ID}?${search}`);
 	const current = page.locator('[data-search-match="true"]');
 	await expect(current).toContainText(`Current ${query} result stays mounted`);
-	await expect(current.locator("mark")).toHaveText(["virtualized", "needle"]);
+	await expect(current.locator("mark")).toHaveText(["virtualized needle"]);
 	expect(await mountedRows.count()).toBeLessThan(80);
 
 	await page.setViewportSize({ width: 390, height: 844 });

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import {
+	isSearchQueryReady,
+	SEARCH_QUERY_MAX_LENGTH,
+	SEARCH_QUERY_MIN_LENGTH,
+} from "@clawdi/shared/consts";
 import { keepPreviousData } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import {
@@ -125,6 +130,7 @@ function CommandPalette({
 	const [query, setQuery] = useState("");
 	const debounced = useDebouncedValue(query, 180);
 	const searchQuery = debounced.trim();
+	const remoteSearchReady = isSearchQueryReady(searchQuery);
 	const navShortcuts = useMemo(() => {
 		const shortcuts: NavShortcut[] = consoleCommandPaletteItems(false).map((item) => ({
 			label: item.label,
@@ -163,7 +169,7 @@ function CommandPalette({
 		"/v1/search",
 		{ params: { query: { q: searchQuery } } },
 		{
-			enabled: open && searchQuery.length > 0,
+			enabled: open && remoteSearchReady,
 			staleTime: 30_000,
 			// Keep the last page of results visible while a new debounced query
 			// flies out — prevents the palette flashing to "empty" on every
@@ -215,13 +221,14 @@ function CommandPalette({
 	// Group hits by type — cmdk groups handle the visual separator/label.
 	const grouped = useMemo(() => {
 		const g: Partial<Record<SearchHit["type"], SearchHit[]>> = {};
+		if (!remoteSearchReady) return g;
 		for (const hit of data?.results ?? []) {
 			const existing = g[hit.type] ?? [];
 			existing.push(hit);
 			g[hit.type] = existing;
 		}
 		return g;
-	}, [data]);
+	}, [data, remoteSearchReady]);
 	const resultGroups = useMemo(
 		() =>
 			SEARCH_RESULT_TYPES.flatMap((type) => {
@@ -249,14 +256,14 @@ function CommandPalette({
 
 	// Whether we have a stale results payload we can keep showing while a
 	// new debounced query is in flight.
-	const hasStaleResults = hasQuery && (data?.results.length ?? 0) > 0;
+	const hasStaleResults = remoteSearchReady && (data?.results.length ?? 0) > 0;
 	const resultQuery = data?.query ?? searchQuery;
 
 	// Show "no results" only when (a) the debounced query is active, (b)
 	// fetching is finished, (c) we don't have any results. Previously we
 	// flashed through an in-between state each keystroke.
 	const showEmpty =
-		hasQuery &&
+		remoteSearchReady &&
 		!isFetching &&
 		!hasStaleResults &&
 		navMatches.length === 0 &&
@@ -278,20 +285,26 @@ function CommandPalette({
 						value={query}
 						onValueChange={setQuery}
 						placeholder="Search agents, sessions, memories, projects, skills, vaults…"
+						maxLength={SEARCH_QUERY_MAX_LENGTH}
 					/>
-					{hasQuery && isFetching ? (
+					{remoteSearchReady && isFetching ? (
 						<Spinner className="pointer-events-none absolute top-3.5 right-4 size-4 text-muted-foreground" />
 					) : null}
 				</div>
 				{/* Fixed min-height: stops the dialog from jumping as the user types
 				    (switching between 6 nav shortcuts → N result rows → empty). */}
 				<CommandList className="min-h-[320px]">
+					{hasQuery && !remoteSearchReady ? (
+						<div role="status" className="px-3 py-2 text-xs text-muted-foreground">
+							Type at least {SEARCH_QUERY_MIN_LENGTH} characters to search your workspace.
+						</div>
+					) : null}
 					{showEmpty ? <CommandEmpty>No results for "{searchQuery}".</CommandEmpty> : null}
 
 					{/* First-fetch state: query typed but no prior data yet — show a
 					    neutral loading row inside the list so the dialog isn't
 					    just an empty box while the debounce + network settles. */}
-					{hasQuery && isFetching && !hasStaleResults ? (
+					{remoteSearchReady && isFetching && !hasStaleResults ? (
 						<div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
 							<Spinner />
 							Searching…
@@ -321,7 +334,7 @@ function CommandPalette({
 						</CommandGroup>
 					) : null}
 
-					{hasQuery
+					{remoteSearchReady
 						? resultGroups.map(({ type, hits }, i) => {
 								const Icon = TYPE_ICON[type];
 								return (

--- a/apps/web/src/components/markdown.test.tsx
+++ b/apps/web/src/components/markdown.test.tsx
@@ -12,9 +12,8 @@ describe("Markdown search highlighting", () => {
 			}),
 		);
 
-		expect(markup.match(/<mark/g)).toHaveLength(2);
-		expect(markup).toContain(">authentication</mark> <mark");
-		expect(markup).toContain(">timeout</mark>");
+		expect(markup.match(/<mark/g)).toHaveLength(1);
+		expect(markup).toContain(">authentication timeout</mark>");
 		expect(markup).toContain("authentication timeout\n</code>");
 	});
 });

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -15,7 +15,7 @@ import {
 import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
-import { createSearchHighlighter } from "@/lib/search-highlight";
+import { createSearchHighlighter, SEARCH_MARK_CLASS } from "@/lib/search-highlight";
 import { cn } from "@/lib/utils";
 
 /**
@@ -57,8 +57,7 @@ function searchHighlightPlugin(query: string) {
 								data: {
 									hName: "mark",
 									hProperties: {
-										className:
-											"bg-transparent font-semibold text-foreground underline decoration-primary/50 decoration-1 underline-offset-2",
+										className: SEARCH_MARK_CLASS,
 									},
 								},
 								children: [{ type: "text", value: part.text }],

--- a/apps/web/src/components/memories/memories-surface.tsx
+++ b/apps/web/src/components/memories/memories-surface.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import { findLikelySecret, formatSecretMemoryWarning } from "@clawdi/shared";
+import {
+	isSearchQueryReady,
+	SEARCH_QUERY_MAX_LENGTH,
+	SEARCH_QUERY_MIN_LENGTH,
+	searchQueryLength,
+} from "@clawdi/shared/consts";
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import { Brain, Database, Key, Laptop, Plus, Trash2 } from "lucide-react";
@@ -116,7 +122,16 @@ function MemoriesSurfaceBody({ scope }: { scope: ResourceNavigationScope }) {
 	const page = params.page;
 	const pageSize = params.pageSize;
 	const debouncedSearch = useDebouncedValue(search, 250);
-	const searchQuery = debouncedSearch.trim();
+	const draftSearchQuery = search.trim();
+	const debouncedSearchQuery = debouncedSearch.trim();
+	const searchQuery = isSearchQueryReady(debouncedSearchQuery) ? debouncedSearchQuery : "";
+	const draftSearchLength = searchQueryLength(draftSearchQuery);
+	const searchQueryError =
+		draftSearchLength > 0 && draftSearchLength < SEARCH_QUERY_MIN_LENGTH
+			? `Type at least ${SEARCH_QUERY_MIN_LENGTH} characters`
+			: draftSearchLength > SEARCH_QUERY_MAX_LENGTH
+				? `Type at most ${SEARCH_QUERY_MAX_LENGTH} characters`
+				: null;
 	const apiCategory = category === ALL ? "" : category;
 
 	const { data: settings } = useQuery({
@@ -206,6 +221,7 @@ function MemoriesSurfaceBody({ scope }: { scope: ResourceNavigationScope }) {
 						value={search}
 						onChange={(v) => void setParams({ q: v, page: 1 })}
 						placeholder="Search memories…"
+						maxLength={SEARCH_QUERY_MAX_LENGTH}
 					/>
 				}
 				filters={
@@ -227,6 +243,13 @@ function MemoriesSurfaceBody({ scope }: { scope: ResourceNavigationScope }) {
 							</ToggleGroupItem>
 						))}
 					</ToggleGroup>
+				}
+				actions={
+					searchQueryError ? (
+						<span className="text-xs text-muted-foreground" role="status">
+							{searchQueryError}
+						</span>
+					) : null
 				}
 			/>
 

--- a/apps/web/src/components/search-highlighted-text.tsx
+++ b/apps/web/src/components/search-highlighted-text.tsx
@@ -1,4 +1,4 @@
-import { splitSearchHighlight } from "@/lib/search-highlight";
+import { SEARCH_MARK_CLASS, splitSearchHighlight } from "@/lib/search-highlight";
 import { cn } from "@/lib/utils";
 
 export function SearchHighlightedText({
@@ -16,13 +16,7 @@ export function SearchHighlightedText({
 		<span className={className}>
 			{splitSearchHighlight(text, query).map((part, index) =>
 				part.highlighted ? (
-					<mark
-						key={`${index}:${part.text}`}
-						className={cn(
-							"bg-transparent font-semibold text-foreground underline decoration-primary/50 decoration-1 underline-offset-2",
-							markClassName,
-						)}
-					>
+					<mark key={`${index}:${part.text}`} className={cn(SEARCH_MARK_CLASS, markClassName)}>
 						{part.text}
 					</mark>
 				) : (

--- a/apps/web/src/components/sessions/message-list.test.tsx
+++ b/apps/web/src/components/sessions/message-list.test.tsx
@@ -169,7 +169,7 @@ describe("SessionTimelineList", () => {
 			},
 		);
 
-		expect(markup.match(/<mark/g)).toHaveLength(6);
+		expect(markup.match(/<mark/g)).toHaveLength(3);
 		expect(markup.match(/data-search-match="true"/g)).toHaveLength(1);
 	});
 });

--- a/apps/web/src/components/sessions/message-list.tsx
+++ b/apps/web/src/components/sessions/message-list.tsx
@@ -121,10 +121,10 @@ function MessageBlock({
 			data-search-match={isHighlighted ? "true" : undefined}
 			aria-current={isHighlighted ? "location" : undefined}
 			className={cn(
-				"group flex scroll-mt-24 gap-3 rounded-md",
+				"group flex scroll-mt-24 gap-3 rounded-md border-l-2 border-transparent",
 				deferOffscreenRendering && OFFSCREEN_RENDERING_CLASS,
 				isGroupStart ? "pt-4" : "",
-				isHighlighted && "bg-primary/5 ring-1 ring-primary/30",
+				isHighlighted && "border-primary bg-primary/5",
 			)}
 		>
 			{/* Avatar column. Group-start: avatar (user image / agent icon).

--- a/apps/web/src/components/sessions/search-match-excerpt.test.tsx
+++ b/apps/web/src/components/sessions/search-match-excerpt.test.tsx
@@ -6,7 +6,7 @@ import { SessionSearchMatchExcerpt } from "@/components/sessions/search-match-ex
 const anchor = { kind: "event_seq" as const, position: 4, revision: "events:revision" };
 
 describe("SessionSearchMatchExcerpt", () => {
-	test("highlights every matching term without hiding the surrounding excerpt", () => {
+	test("highlights a contiguous phrase without hiding the surrounding excerpt", () => {
 		const markup = renderToStaticMarkup(
 			createElement(SessionSearchMatchExcerpt, {
 				match: { role: "assistant", excerpt: "Fixed the authentication timeout", anchor },
@@ -15,8 +15,7 @@ describe("SessionSearchMatchExcerpt", () => {
 		);
 
 		expect(markup).toContain("Fixed the ");
-		expect(markup).toContain(">authentication</mark> <mark");
-		expect(markup).toContain(">timeout</mark>");
+		expect(markup).toContain(">authentication timeout</mark>");
 	});
 
 	test("renders query text as escaped content", () => {

--- a/apps/web/src/components/sessions/session-search-navigation.tsx
+++ b/apps/web/src/components/sessions/session-search-navigation.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { SEARCH_QUERY_MIN_LENGTH, searchQueryLength } from "@clawdi/shared/consts";
 import { useRouter } from "@tanstack/react-router";
 import { ChevronDown, ChevronUp, LoaderCircle } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -59,6 +60,7 @@ export function SessionSearchNavigation({
 	isSearching = false,
 	hasSearchError = false,
 	className,
+	maxLength,
 }: {
 	sessionId: string;
 	agentId?: string | null;
@@ -69,6 +71,7 @@ export function SessionSearchNavigation({
 	isSearching?: boolean;
 	hasSearchError?: boolean;
 	className?: string;
+	maxLength?: number;
 }) {
 	const router = useRouter();
 	const [draftQuery, setDraftQuery] = useState(query);
@@ -77,6 +80,7 @@ export function SessionSearchNavigation({
 		setDraftQuery((current) => (query && current.trim() === query ? current : query));
 	}, [query]);
 	const activeNavigation = isSearching || hasSearchError ? null : navigation;
+	const queryTooShort = Boolean(query) && searchQueryLength(query) < SEARCH_QUERY_MIN_LENGTH;
 	const navigate = (search: Record<string, unknown>) => {
 		if (agentId) {
 			void router.navigate({
@@ -131,6 +135,7 @@ export function SessionSearchNavigation({
 				ariaLabel="Search messages"
 				className="min-w-36 flex-1"
 				ariaKeyShortcuts="Enter Shift+Enter Escape"
+				maxLength={maxLength}
 				onKeyDown={(event) => {
 					if (event.nativeEvent.isComposing) return;
 					if (event.key === "Escape" && draftQuery) {
@@ -151,13 +156,18 @@ export function SessionSearchNavigation({
 						className="inline-flex min-w-10 shrink-0 items-center justify-center gap-1 tabular-nums text-foreground"
 						aria-live="polite"
 					>
-						{isSearching ? (
+						{queryTooShort ? (
+							<>
+								<span aria-hidden="true">{SEARCH_QUERY_MIN_LENGTH}+ chars</span>
+								<span className="sr-only">Type at least {SEARCH_QUERY_MIN_LENGTH} characters</span>
+							</>
+						) : isSearching ? (
 							<>
 								<LoaderCircle className="size-3.5 animate-spin" />
 								<span className="sr-only">Searching</span>
 							</>
 						) : null}
-						{hasSearchError ? (
+						{queryTooShort ? null : hasSearchError ? (
 							"Unavailable"
 						) : isSearching ? null : activeNavigation ? (
 							`${activeNavigation.index} / ${activeNavigation.total}`

--- a/apps/web/src/components/ui/search-input.tsx
+++ b/apps/web/src/components/ui/search-input.tsx
@@ -28,6 +28,7 @@ export function SearchInput({
 	autoFocus,
 	onKeyDown,
 	ariaKeyShortcuts,
+	maxLength,
 }: {
 	value: string;
 	onChange: (next: string) => void;
@@ -38,6 +39,7 @@ export function SearchInput({
 	autoFocus?: boolean;
 	onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
 	ariaKeyShortcuts?: string;
+	maxLength?: number;
 }) {
 	return (
 		<div className={cn("relative", className)}>
@@ -54,6 +56,7 @@ export function SearchInput({
 				autoFocus={autoFocus}
 				onKeyDown={onKeyDown}
 				aria-keyshortcuts={ariaKeyShortcuts}
+				maxLength={maxLength}
 			/>
 			{value ? (
 				<Button

--- a/apps/web/src/lib/search-highlight.test.ts
+++ b/apps/web/src/lib/search-highlight.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	literalSearchRank,
 	searchExcerpt,
+	searchHighlightTerms,
 	searchTerms,
 	splitSearchHighlight,
 } from "@/lib/search-highlight";
@@ -35,6 +36,42 @@ describe("search highlighting", () => {
 			.map((part) => part.text.toLocaleLowerCase());
 
 		expect(highlighted).toEqual(["deploy", "handoff"]);
+	});
+
+	test("uses PostgreSQL web-search operands for display", () => {
+		expect(searchTerms('foo OR bar -draft -"private note" "exact phrase"')).toEqual([
+			"foo",
+			"bar",
+			"exact phrase",
+		]);
+		expect(searchHighlightTerms("oauth token refresh")).toEqual([
+			"oauth token refresh",
+			"oauth",
+			"token",
+			"refresh",
+		]);
+	});
+
+	test("highlights a contiguous phrase as one mark", () => {
+		const highlighted = splitSearchHighlight(
+			"The oauth token refresh completed",
+			'"oauth token refresh"',
+		)
+			.filter((part) => part.highlighted)
+			.map((part) => part.text);
+
+		expect(highlighted).toEqual(["oauth token refresh"]);
+	});
+
+	test("does not highlight web-search operators or excluded terms", () => {
+		const highlighted = splitSearchHighlight(
+			"foo before bar and a private draft",
+			"foo OR bar -draft -private",
+		)
+			.filter((part) => part.highlighted)
+			.map((part) => part.text.toLocaleLowerCase());
+
+		expect(highlighted).toEqual(["foo", "bar"]);
 	});
 
 	test("centers excerpts on the earliest term when the phrase is not contiguous", () => {

--- a/apps/web/src/lib/search-highlight.ts
+++ b/apps/web/src/lib/search-highlight.ts
@@ -5,10 +5,20 @@ export interface SearchHighlightPart {
 
 type SearchField = string | null | undefined;
 
+const WEBSEARCH_TOKEN_PATTERN = /(-?)"([^"]+)"|(\S+)/gu;
+
+export const SEARCH_MARK_CLASS =
+	"box-decoration-clone rounded-sm bg-primary/20 px-px text-foreground";
+
 export function searchTerms(query: string): string[] {
 	const terms: string[] = [];
 	const seen = new Set<string>();
-	for (const term of query.trim().split(/\s+/u)) {
+	for (const match of query.matchAll(WEBSEARCH_TOKEN_PATTERN)) {
+		const [, negated, quoted, unquoted] = match;
+		const term = quoted !== undefined ? quoted.trim() : (unquoted ?? "");
+		if (quoted !== undefined ? Boolean(negated) : term.startsWith("-") || /^or$/iu.test(term)) {
+			continue;
+		}
 		if (!term) continue;
 		const folded = term.toLocaleLowerCase();
 		if (seen.has(folded)) continue;
@@ -16,6 +26,15 @@ export function searchTerms(query: string): string[] {
 		terms.push(term);
 	}
 	return terms;
+}
+
+export function searchHighlightTerms(query: string): string[] {
+	const terms = searchTerms(query);
+	const phrase = query.trim();
+	const hasWebsearchOperator =
+		phrase.includes('"') ||
+		phrase.split(/\s+/u).some((term) => term.startsWith("-") || /^or$/iu.test(term));
+	return phrase && terms.length > 1 && !hasWebsearchOperator ? [phrase, ...terms] : terms;
 }
 
 export function literalSearchRank(
@@ -58,15 +77,19 @@ export function searchExcerpt(text: string, query: string, limit = 240): string 
 	const compact = text.replace(/\s+/g, " ").trim();
 	if (compact.length <= limit) return compact;
 
-	const phrase = query.trim();
-	const phraseMatch = phrase ? new RegExp(escapeRegExp(phrase), "iu").exec(compact) : null;
-	const folded = compact.toLocaleLowerCase();
+	const terms = searchTerms(query);
+	const highlightTerms = searchHighlightTerms(query);
+	const preferredPhrase = highlightTerms.length > terms.length ? highlightTerms[0] : undefined;
+	const preferredIndex = preferredPhrase
+		? (new RegExp(escapeRegExp(preferredPhrase), "iu").exec(compact)?.index ?? -1)
+		: -1;
 	const fallbackIndex = Math.min(
-		...searchTerms(query)
-			.map((term) => folded.indexOf(term.toLocaleLowerCase()))
+		...terms
+			.map((term) => new RegExp(escapeRegExp(term), "iu").exec(compact)?.index ?? -1)
 			.filter((index) => index >= 0),
 	);
-	const matchIndex = phraseMatch?.index ?? (Number.isFinite(fallbackIndex) ? fallbackIndex : -1);
+	const matchIndex =
+		preferredIndex >= 0 ? preferredIndex : Number.isFinite(fallbackIndex) ? fallbackIndex : -1;
 	if (matchIndex < 0) return `${compact.slice(0, Math.max(0, limit - 1)).trimEnd()}…`;
 
 	let start = Math.max(0, matchIndex - Math.floor(limit / 3));
@@ -76,7 +99,7 @@ export function searchExcerpt(text: string, query: string, limit = 240): string 
 }
 
 export function createSearchHighlighter(query: string) {
-	const terms = searchTerms(query).sort((a, b) => b.length - a.length);
+	const terms = searchHighlightTerms(query).sort((a, b) => b.length - a.length);
 	if (terms.length === 0) {
 		return (text: string): SearchHighlightPart[] => [{ text, highlighted: false }];
 	}

--- a/apps/web/src/lib/session-search-anchor.ts
+++ b/apps/web/src/lib/session-search-anchor.ts
@@ -1,4 +1,5 @@
 import type { SessionListItem } from "@clawdi/shared/api";
+import { SEARCH_QUERY_MAX_LENGTH, searchQueryLength } from "@clawdi/shared/consts";
 
 export type SessionSearchAnchor = NonNullable<SessionListItem["search_match"]>["anchor"];
 export type SessionTimelineView = "all" | "user" | "assistant" | "tools";
@@ -104,7 +105,9 @@ export function sessionDetailSearchLink(
 function normalizeSessionMatchQuery(value: unknown): string | undefined {
 	if (typeof value !== "string") return undefined;
 	const normalized = value.trim();
-	return normalized.length > 0 && normalized.length <= 500 ? normalized : undefined;
+	return normalized && searchQueryLength(normalized) <= SEARCH_QUERY_MAX_LENGTH
+		? normalized
+		: undefined;
 }
 
 export function normalizeSessionListReturnTo(value: unknown): string | undefined {

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { isSearchQueryReady, SEARCH_QUERY_MAX_LENGTH } from "@clawdi/shared/consts";
 import {
 	keepPreviousData,
 	useInfiniteQuery,
@@ -214,7 +215,10 @@ export function SessionDetailContent({
 	const [direction, setDirection] = useState<Direction>("desc");
 	const normalizedSearchQuery = searchQuery?.trim() ?? "";
 	const rememberedSearchQueryRef = useRef(normalizedSearchQuery);
-	const debouncedSearchQuery = useDebouncedValue(normalizedSearchQuery, 250) || undefined;
+	const effectiveSearchQuery = isSearchQueryReady(normalizedSearchQuery)
+		? normalizedSearchQuery
+		: "";
+	const debouncedSearchQuery = useDebouncedValue(effectiveSearchQuery, 250) || undefined;
 	useIsomorphicLayoutEffect(() => {
 		const stored = localStorage.getItem("clawdi.session.message-direction");
 		if (stored === "asc") setDirection("asc");
@@ -408,10 +412,10 @@ export function SessionDetailContent({
 	}
 
 	const totalTokens = (session.input_tokens ?? 0) + (session.output_tokens ?? 0);
-	const searchActive = Boolean(normalizedSearchQuery);
+	const searchActive = Boolean(effectiveSearchQuery);
 	const isSearchUpdating =
 		searchActive &&
-		(normalizedSearchQuery !== debouncedSearchQuery ||
+		(effectiveSearchQuery !== debouncedSearchQuery ||
 			(isContentFetching && !isFetchingNextPage) ||
 			isContentLoading);
 	const updateTimelineView = (selected: SessionTimelineView) => {
@@ -559,6 +563,7 @@ export function SessionDetailContent({
 								isSearching={isSearchUpdating}
 								hasSearchError={searchActive && isContentError}
 								className="md:max-w-xl"
+								maxLength={SEARCH_QUERY_MAX_LENGTH}
 							/>
 						)}
 						<div

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -1,5 +1,11 @@
 "use client";
 
+import {
+	isSearchQueryReady,
+	SEARCH_QUERY_MAX_LENGTH,
+	SEARCH_QUERY_MIN_LENGTH,
+	searchQueryLength,
+} from "@clawdi/shared/consts";
 import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocation } from "@tanstack/react-router";
 import type { SortingState } from "@tanstack/react-table";
@@ -99,7 +105,15 @@ function SessionsListInner() {
 
 	const debouncedSearch = useDebouncedValue(params.q, 250);
 	const draftSearchQuery = params.q.trim();
-	const searchQuery = debouncedSearch.trim();
+	const debouncedSearchQuery = debouncedSearch.trim();
+	const searchQuery = isSearchQueryReady(debouncedSearchQuery) ? debouncedSearchQuery : "";
+	const draftSearchLength = searchQueryLength(draftSearchQuery);
+	const searchQueryError =
+		draftSearchLength > 0 && draftSearchLength < SEARCH_QUERY_MIN_LENGTH
+			? `Type at least ${SEARCH_QUERY_MIN_LENGTH} characters`
+			: draftSearchLength > SEARCH_QUERY_MAX_LENGTH
+				? `Type at most ${SEARCH_QUERY_MAX_LENGTH} characters`
+				: null;
 	const getSessionLink = useCallback(
 		(session: SessionListItem) => sessionDetailLink(session, { returnTo, searchQuery }),
 		[returnTo, searchQuery],
@@ -190,7 +204,9 @@ function SessionsListInner() {
 
 	const total = data?.total ?? 0;
 	const pageCount = Math.max(1, Math.ceil(total / params.pageSize));
-	const isListUpdating = data !== undefined && (draftSearchQuery !== searchQuery || isFetching);
+	const isListUpdating =
+		data !== undefined &&
+		((isSearchQueryReady(draftSearchQuery) && draftSearchQuery !== searchQuery) || isFetching);
 
 	useEffect(() => {
 		if (!data || params.page >= pageCount) return;
@@ -213,7 +229,7 @@ function SessionsListInner() {
 	) {
 		setPaginationState({ pageIndex: params.page - 1, pageSize: params.pageSize });
 	}
-	const emptyMessage = draftSearchQuery
+	const emptyMessage = searchQuery
 		? `No sessions found for “${draftSearchQuery}”.`
 		: isFiltered
 			? "No sessions match your filters."
@@ -229,7 +245,7 @@ function SessionsListInner() {
 						// match quality" UX. Restore the date sort if the
 						// box is cleared so the empty-search default goes
 						// back to the activity timeline.
-						const hasQuery = v.trim().length > 0;
+						const hasQuery = isSearchQueryReady(v);
 						void setParams({
 							q: v,
 							page: 1,
@@ -242,6 +258,7 @@ function SessionsListInner() {
 						});
 					}}
 					placeholder="Search sessions and messages…"
+					maxLength={SEARCH_QUERY_MAX_LENGTH}
 				/>
 			}
 			filters={
@@ -288,11 +305,13 @@ function SessionsListInner() {
 				<>
 					{(isFiltered || isListUpdating) && data ? (
 						<span className="text-xs text-muted-foreground tabular-nums" aria-live="polite">
-							{isListUpdating
-								? draftSearchQuery || searchQuery
-									? "Searching…"
-									: "Updating…"
-								: `${formatNumber(total)} ${total === 1 ? "result" : "results"}`}
+							{searchQueryError
+								? searchQueryError
+								: isListUpdating
+									? draftSearchQuery || searchQuery
+										? "Searching…"
+										: "Updating…"
+									: `${formatNumber(total)} ${total === 1 ? "result" : "results"}`}
 						</span>
 					) : null}
 					{isFiltered ? (

--- a/backend/app/core/query_utils.py
+++ b/backend/app/core/query_utils.py
@@ -1,12 +1,26 @@
 """Query-string utilities shared by search + list endpoints."""
 
+import re
 from collections.abc import Sequence
-from typing import Any
+from typing import Annotated, Any
 
+from pydantic import StringConstraints
 from sqlalchemy import func, literal_column, or_
 from sqlalchemy.sql.elements import ColumnElement, SQLColumnExpression
 
 _SIMPLE_TEXT_SEARCH_CONFIG: SQLColumnExpression[Any] = literal_column("'simple'::regconfig")
+_WEBSEARCH_TOKEN_RE = re.compile(r'(-?)"([^"]+)"|(\S+)')
+
+SEARCH_QUERY_MIN_LENGTH = 2
+SEARCH_QUERY_MAX_LENGTH = 500
+SearchQuery = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        min_length=SEARCH_QUERY_MIN_LENGTH,
+        max_length=SEARCH_QUERY_MAX_LENGTH,
+    ),
+]
 
 
 def escape_like(s: str, escape_char: str = "\\") -> str:
@@ -31,16 +45,40 @@ def like_needle(query: str) -> str:
 
 
 def search_terms(query: str) -> tuple[str, ...]:
-    """Return unique, whitespace-delimited terms while preserving input order."""
+    """Return positive PostgreSQL web-search operands in display order."""
     terms: list[str] = []
     seen: set[str] = set()
-    for term in query.split():
+    for match in _WEBSEARCH_TOKEN_RE.finditer(query):
+        negated, quoted, unquoted = match.groups()
+        if quoted is not None:
+            if negated:
+                continue
+            term = quoted.strip()
+        else:
+            assert unquoted is not None
+            if unquoted.startswith("-") or unquoted.casefold() == "or":
+                continue
+            term = unquoted
+        if not term:
+            continue
         folded = term.casefold()
         if folded in seen:
             continue
         seen.add(folded)
         terms.append(term)
     return tuple(terms)
+
+
+def search_highlight_terms(query: str) -> tuple[str, ...]:
+    """Return display terms, preferring a contiguous plain query when present."""
+    terms = search_terms(query)
+    phrase = query.strip()
+    has_websearch_operator = '"' in phrase or any(
+        token.startswith("-") or token.casefold() == "or" for token in phrase.split()
+    )
+    if phrase and len(terms) > 1 and not has_websearch_operator:
+        return (phrase, *terms)
+    return terms
 
 
 def websearch_query(query: str) -> ColumnElement[Any]:
@@ -79,14 +117,16 @@ def search_excerpt(content: str, query: str, *, limit: int = 240) -> str:
     compact = " ".join(content.split())
     if len(compact) <= limit:
         return compact
-    phrase = query.strip()
-    match_at = compact.casefold().find(phrase.casefold()) if phrase else -1
-    if match_at < 0:
-        folded = compact.casefold()
-        term_matches = [
-            match for term in search_terms(query) if (match := folded.find(term.casefold())) >= 0
-        ]
-        match_at = min(term_matches, default=-1)
+    folded = compact.casefold()
+    terms = search_terms(query)
+    highlight_terms = search_highlight_terms(query)
+    preferred_phrase = highlight_terms[0] if len(highlight_terms) > len(terms) else None
+    preferred_match = folded.find(preferred_phrase.casefold()) if preferred_phrase else -1
+    fallback_match = min(
+        (match for term in terms if (match := folded.find(term.casefold())) >= 0),
+        default=-1,
+    )
+    match_at = preferred_match if preferred_match >= 0 else fallback_match
     if match_at < 0:
         return f"{compact[: limit - 3]}..."
     start = max(0, match_at - limit // 3)

--- a/backend/app/routes/mcp_bridge.py
+++ b/backend/app/routes/mcp_bridge.py
@@ -35,7 +35,12 @@ from app.core.auth import (
 )
 from app.core.database import get_session
 from app.core.project import project_ids_visible_to, resolve_default_write_project
-from app.core.query_utils import search_excerpt
+from app.core.query_utils import (
+    SEARCH_QUERY_MAX_LENGTH,
+    SEARCH_QUERY_MIN_LENGTH,
+    SearchQuery,
+    search_excerpt,
+)
 from app.models.project import Project
 from app.models.session import AgentEnvironment, Session
 from app.models.vault import Vault, VaultItem, VaultProjectAttachment
@@ -92,16 +97,8 @@ class _NoArguments(_ToolArguments):
 
 
 class _MemorySearchArguments(_ToolArguments):
-    query: StrictStr = Field(min_length=1, max_length=2_000)
+    query: SearchQuery
     limit: StrictInt = Field(default=10, ge=1, le=50)
-
-    @field_validator("query")
-    @classmethod
-    def _strip_query(cls, value: str) -> str:
-        value = value.strip()
-        if not value:
-            raise ValueError("query is required")
-        return value
 
 
 class _MemoryAddArguments(_ToolArguments):
@@ -118,16 +115,8 @@ class _MemoryAddArguments(_ToolArguments):
 
 
 class _SessionSearchArguments(_ToolArguments):
-    query: StrictStr = Field(min_length=1, max_length=2_000)
+    query: SearchQuery
     limit: StrictInt = Field(default=10, ge=1, le=20)
-
-    @field_validator("query")
-    @classmethod
-    def _strip_query(cls, value: str) -> str:
-        value = value.strip()
-        if not value:
-            raise ValueError("query is required")
-        return value
 
 
 class _SessionReadArguments(_ToolArguments):
@@ -259,6 +248,8 @@ _NATIVE_TOOL_REGISTRY: dict[str, _NativeToolSpec] = {
             "properties": {
                 "query": {
                     "type": "string",
+                    "minLength": SEARCH_QUERY_MIN_LENGTH,
+                    "maxLength": SEARCH_QUERY_MAX_LENGTH,
                     "description": (
                         "Natural-language query in any language — the search does semantic "
                         "matching, no keyword optimization needed. Pass the user's own phrasing "
@@ -367,6 +358,8 @@ _NATIVE_TOOL_REGISTRY: dict[str, _NativeToolSpec] = {
             "properties": {
                 "query": {
                     "type": "string",
+                    "minLength": SEARCH_QUERY_MIN_LENGTH,
+                    "maxLength": SEARCH_QUERY_MAX_LENGTH,
                     "description": (
                         "Case-insensitive phrase query matching session metadata "
                         "and visible messages."

--- a/backend/app/routes/memories.py
+++ b/backend/app/routes/memories.py
@@ -11,6 +11,7 @@ from app.core.auth import (
     require_scope,
 )
 from app.core.database import get_session
+from app.core.query_utils import SearchQuery
 from app.models.memory import Memory
 from app.models.session import AgentEnvironment, Session
 from app.schemas.common import Paginated
@@ -150,7 +151,7 @@ async def list_memories(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=25, ge=1, le=200),
     category: str | None = Query(default=None),
-    q: str | None = Query(default=None),
+    q: SearchQuery | None = Query(default=None),
     order: str = Query(default="desc", pattern=r"^(asc|desc)$"),
 ) -> Paginated[MemoryResponse]:
     provider = await get_memory_provider(str(auth.user_id), db)

--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -13,7 +13,7 @@ from typing import Literal
 from urllib.parse import quote
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy import and_, case, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -22,6 +22,7 @@ from app.core.auth import AuthContext, get_auth, is_scoped_api_key
 from app.core.database import get_session
 from app.core.project import project_ids_visible_to
 from app.core.query_utils import (
+    SearchQuery,
     escape_like,
     lexical_search_filter,
     like_needle,
@@ -442,9 +443,9 @@ async def _search_vaults(db: AsyncSession, auth: AuthContext, query: str) -> lis
 
 @router.get("")
 async def global_search(
+    q: SearchQuery,
     auth: AuthContext = Depends(get_auth),
     db: AsyncSession = Depends(get_session),
-    q: str = Query(..., min_length=1, max_length=200),
 ) -> SearchResponse:
     """Run each entity searcher and concat results.
 
@@ -460,9 +461,7 @@ async def global_search(
     sequentially because SQLAlchemy AsyncSession is not safe for concurrent
     operations on the same request-scoped session.
     """
-    query = q.strip()
-    if not query:
-        return SearchResponse(query=query, results=[])
+    query = q
 
     # Each subsource enforces the same permission boundary the direct
     # route does. Skills, sessions, and memories subqueries are

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -38,6 +38,7 @@ from app.core.auth import (
 )
 from app.core.config import settings
 from app.core.database import get_session
+from app.core.query_utils import SearchQuery
 from app.models.agent_project_binding import AgentProjectBinding
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
@@ -2499,9 +2500,8 @@ async def list_sessions(
     # summaries and project_paths it had no business reading.
     auth: AuthContext = Depends(require_scope("sessions:read")),
     db: AsyncSession = Depends(get_session),
-    q: str | None = Query(
+    q: SearchQuery | None = Query(
         default=None,
-        max_length=500,
         description=(
             "Web-style text search on summary/project/local ID and visible message text; "
             "cloud session IDs match by UUID prefix"
@@ -2553,7 +2553,6 @@ async def list_sessions(
     since: datetime | None = Query(default=None, description="Filter to last_activity_at >= since"),
     until: datetime | None = Query(default=None, description="Filter to last_activity_at < until"),
 ) -> Paginated[SessionListItemResponse]:
-    q = q.strip() if q else None
     # Env binding: a bound api_key (deploy key) can only see its
     # own env's sessions. Without this, a key for env A would list
     # env B's sessions because user_id alone doesn't fence them.
@@ -3023,7 +3022,7 @@ async def get_session_messages(
     anchor_kind: Literal["snapshot_offset", "event_seq"] | None = Query(default=None),
     anchor_position: int | None = Query(default=None, ge=0),
     anchor_revision: str | None = Query(default=None, min_length=1, max_length=80),
-    search_query: str | None = Query(default=None, max_length=500),
+    search_query: SearchQuery | None = Query(default=None),
     auth: AuthContext = Depends(require_scope("sessions:read")),
     db: AsyncSession = Depends(get_session),
 ) -> SessionMessagesPage | SessionTimelinePage:
@@ -3043,7 +3042,6 @@ async def get_session_messages(
     a complete anchor opens that exact match. Stale anchors degrade to ordinary
     offset pagination.
     """
-    search_query = search_query.strip() if search_query else None
     anchor_values = (anchor_kind, anchor_position, anchor_revision)
     if any(value is not None for value in anchor_values) and not all(
         value is not None for value in anchor_values

--- a/backend/app/services/session_search.py
+++ b/backend/app/services/session_search.py
@@ -255,7 +255,7 @@ def best_session_message_matches(user_id: UUID, query: str) -> Subquery:
 
 
 def session_search_matches(user_id: UUID, query: str) -> Subquery:
-    """Return every all-term match with one ranked body hit per Session."""
+    """Return every web-search match with one ranked body hit per Session."""
     pattern = like_needle(query)
     message_match = best_session_message_matches(user_id, query)
     metadata_fields = (

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -20,6 +20,7 @@ import pytest
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from app.core.query_utils import search_excerpt, search_highlight_terms, search_terms
 from app.models.session import (
     SESSION_SEARCH_CHUNK_BODY_CHARACTERS,
     SESSION_SEARCH_CHUNK_MAX_CHARACTERS,
@@ -95,6 +96,50 @@ async def _push_session(
 
     listing = (await client.get(f"/v1/sessions?q={local_session_id}")).json()
     return next(s["id"] for s in listing["items"] if s["local_session_id"] == local_session_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    (
+        "/v1/search",
+        "/v1/sessions",
+        "/v1/memories",
+        "/v1/sessions/00000000-0000-0000-0000-000000000001/messages",
+    ),
+)
+async def test_remote_search_rejects_single_character_queries(
+    client: httpx.AsyncClient,
+    path: str,
+) -> None:
+    parameter = "search_query" if path.endswith("/messages") else "q"
+    response = await client.get(path, params={parameter: " x "})
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_remote_search_accepts_two_character_cjk_query(client: httpx.AsyncClient) -> None:
+    response = await client.get("/v1/sessions", params={"q": "中文"})
+
+    assert response.status_code == 200
+
+
+def test_search_display_terms_follow_websearch_syntax() -> None:
+    query = 'foo OR bar -draft -"private note" "exact phrase"'
+    assert search_terms(query) == ("foo", "bar", "exact phrase")
+    assert search_highlight_terms("oauth token refresh") == (
+        "oauth token refresh",
+        "oauth",
+        "token",
+        "refresh",
+    )
+    excerpt = search_excerpt(
+        f"{'before ' * 40}oauth token refresh completed{' after' * 40}",
+        '"oauth token refresh"',
+        limit=80,
+    )
+    assert "oauth token refresh" in excerpt
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_settings_and_mcp.py
+++ b/backend/tests/test_settings_and_mcp.py
@@ -703,7 +703,7 @@ async def test_clawdi_mcp_session_search_uses_shared_metadata_and_body_matches(
                     },
                 )
 
-            wildcard_response = await search("%")
+            wildcard_response = await search("100%")
             body_response = await search("deployment handoff phrase")
             reordered_response = await search("phrase deployment")
             typo_response = await search("deployment handof phrase")
@@ -1357,7 +1357,7 @@ async def test_strict_runtime_mcp_has_cross_agent_sessions_connectors_and_accoun
                     "jsonrpc": "2.0",
                     "id": 5,
                     "method": "tools/call",
-                    "params": {"name": "memory_search", "arguments": {"query": "x"}},
+                    "params": {"name": "memory_search", "arguments": {"query": "xy"}},
                 },
             )
             runtime_key.scopes = None

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -4,6 +4,7 @@ import { ApiClient, unwrap } from "../lib/api-client";
 import type { Memory } from "../lib/api-schemas";
 import { isLoggedIn } from "../lib/config";
 import { sanitizeMetadata } from "../lib/sanitize";
+import { requireSearchQuery } from "../lib/search-query";
 
 function requireAuth() {
 	if (!isLoggedIn()) {
@@ -66,9 +67,10 @@ export async function memoryList(opts: ListOpts = {}) {
 
 export async function memorySearch(query: string, opts: ListOpts = {}) {
 	requireAuth();
+	const searchQuery = requireSearchQuery(query, "Memory");
 	const api = new ApiClient();
 	const page = unwrap(
-		await api.GET("/v1/memories", { params: { query: buildQuery({ ...opts, q: query }) } }),
+		await api.GET("/v1/memories", { params: { query: buildQuery({ ...opts, q: searchQuery }) } }),
 	);
 	const memories = page.items;
 
@@ -78,7 +80,7 @@ export async function memorySearch(query: string, opts: ListOpts = {}) {
 	}
 
 	if (memories.length === 0) {
-		console.log(chalk.gray(`No memories matching "${sanitizeMetadata(query)}".`));
+		console.log(chalk.gray(`No memories matching "${sanitizeMetadata(searchQuery)}".`));
 		return;
 	}
 

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -6,6 +6,7 @@ import { ApiClient, ApiError, unwrap } from "../lib/api-client";
 import type { SessionDetail, SessionListItem, SessionMessage } from "../lib/api-schemas";
 import { isLoggedIn } from "../lib/config";
 import { sanitizeMetadata, stripTerminalEscapes } from "../lib/sanitize";
+import { requireSearchQuery } from "../lib/search-query";
 import {
 	adapterForType,
 	listRegisteredAgentTypes,
@@ -225,8 +226,7 @@ function printCloudSessionRows(sessions: SessionListItem[], total: number): void
 
 export async function sessionSearch(query: string, opts: CloudSessionOpts = {}): Promise<void> {
 	if (!requireCloudSessionAuth()) return;
-	const trimmedQuery = query.trim();
-	if (!trimmedQuery) throw new Error("Session search query cannot be empty.");
+	const trimmedQuery = requireSearchQuery(query, "Session");
 
 	const api = new ApiClient();
 	const page = unwrap(

--- a/packages/cli/src/lib/search-query.ts
+++ b/packages/cli/src/lib/search-query.ts
@@ -1,0 +1,19 @@
+import {
+	SEARCH_QUERY_MAX_LENGTH,
+	SEARCH_QUERY_MIN_LENGTH,
+	searchQueryLength,
+} from "@clawdi/shared/consts";
+
+export function requireSearchQuery(value: string, label: string): string {
+	const query = value.trim();
+	const length = searchQueryLength(query);
+	if (length < SEARCH_QUERY_MIN_LENGTH) {
+		throw new Error(
+			`${label} search query must be at least ${SEARCH_QUERY_MIN_LENGTH} characters.`,
+		);
+	}
+	if (length > SEARCH_QUERY_MAX_LENGTH) {
+		throw new Error(`${label} search query must be at most ${SEARCH_QUERY_MAX_LENGTH} characters.`);
+	}
+	return query;
+}

--- a/packages/cli/src/runtime/runtime-user-command.test.ts
+++ b/packages/cli/src/runtime/runtime-user-command.test.ts
@@ -393,20 +393,14 @@ describe("privilege-drop command descriptors", () => {
 describe("runtime user command timeout", () => {
 	test("bounds synchronous runtime-user commands", () => {
 		expect(() =>
-			runRuntimeUserCommand("bash", ["-c", "while :; do :; done"], "", tmpdir(), tmpdir(), {
+			runRuntimeUserCommand("sleep", ["60"], "", tmpdir(), tmpdir(), {
 				timeoutMs: 20,
 			}),
 		).toThrow();
 	});
 
 	test("reports a bounded runtime-user probe timeout", () => {
-		const result = spawnRuntimeUserCommand(
-			"bash",
-			["-c", "while :; do :; done"],
-			tmpdir(),
-			tmpdir(),
-			{ timeoutMs: 20 },
-		);
+		const result = spawnRuntimeUserCommand("sleep", ["60"], tmpdir(), tmpdir(), { timeoutMs: 20 });
 		expect(result.status).toBeNull();
 		expect(result.error?.message).toContain("ETIMEDOUT");
 	});

--- a/packages/cli/tests/commands/session.test.ts
+++ b/packages/cli/tests/commands/session.test.ts
@@ -27,6 +27,12 @@ afterEach(() => {
 });
 
 describe("cloud session commands", () => {
+	it("rejects single-character searches before making a request", async () => {
+		await expect(sessionSearch(" x ")).rejects.toThrow(
+			"Session search query must be at least 2 characters.",
+		);
+	});
+
 	it("searches through the cloud session query contract", async () => {
 		const { captured, restore } = mockFetch([
 			{

--- a/packages/shared/src/consts/index.ts
+++ b/packages/shared/src/consts/index.ts
@@ -1,2 +1,3 @@
 export * from "./featured-skills";
+export * from "./search-query";
 export * from "./skill-key";

--- a/packages/shared/src/consts/search-query.test.ts
+++ b/packages/shared/src/consts/search-query.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { isSearchQueryReady, SEARCH_QUERY_MAX_LENGTH, searchQueryLength } from "./search-query";
+
+describe("remote search query contract", () => {
+	test("counts trimmed Unicode code points", () => {
+		expect(searchQueryLength("  x  ")).toBe(1);
+		expect(searchQueryLength("😀")).toBe(1);
+		expect(isSearchQueryReady("中文")).toBeTrue();
+		expect(isSearchQueryReady("x")).toBeFalse();
+		expect(isSearchQueryReady("x".repeat(SEARCH_QUERY_MAX_LENGTH + 1))).toBeFalse();
+	});
+});

--- a/packages/shared/src/consts/search-query.ts
+++ b/packages/shared/src/consts/search-query.ts
@@ -1,0 +1,11 @@
+export const SEARCH_QUERY_MIN_LENGTH = 2;
+export const SEARCH_QUERY_MAX_LENGTH = 500;
+
+export function searchQueryLength(value: string): number {
+	return Array.from(value.trim()).length;
+}
+
+export function isSearchQueryReady(value: string): boolean {
+	const length = searchQueryLength(value);
+	return length >= SEARCH_QUERY_MIN_LENGTH && length <= SEARCH_QUERY_MAX_LENGTH;
+}


### PR DESCRIPTION
## Summary

- enforce one 2-500 Unicode-code-point contract across global, session, memory, CLI, and MCP search boundaries
- align excerpts and highlights with PostgreSQL web-search operands while preserving contiguous phrase emphasis
- replace underline/ring search styling with standard tinted marks and a stable current-message accent
- prevent one-character requests in Web and CLI, including long-session navigation

## Why

Single-character searches were expensive and noisy, quoted phrases/operators were displayed inconsistently with backend matching, and the previous underline plus full-row ring conflicted with link/focus affordances.

## Verification

- Biome: 1120 files
- Web, CLI, Shared typecheck
- Ruff lint and format check; Python compileall
- generated OpenAPI client consistency
- Web search/highlight unit tests: 16 passed
- Shared query contract: 1 passed
- CLI Session tests: 5 passed
- Playwright Session search/navigation: 4 passed
- Backend Session/MCP focused tests: 42 passed
- Web OSS production build