### PR TITLE
fix(web): polish session message layout

### DIFF
--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -137,6 +137,12 @@ test("opens a global Session body match at the exact message", async ({ page }) 
 	const current = page.locator('[data-search-match="true"]');
 	await expect(current).toContainText(`Found the ${query} in this response`);
 	await expect(current.locator("mark")).toHaveText(["global palette anchor"]);
+	expect(
+		await current.evaluate((element) => {
+			const style = getComputedStyle(element);
+			return [style.paddingTop, style.paddingRight, style.paddingBottom, style.paddingLeft];
+		}),
+	).toEqual(["8px", "8px", "8px", "8px"]);
 });
 
 test("opens a message search result and returns to the same filtered list", async ({ page }) => {
@@ -452,11 +458,12 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 		model: position % 4 === 0 ? null : "gpt-5",
 		timestamp: new Date(Date.parse(now) + position * 1_000).toISOString(),
 	});
-	const browseTimeline = Array.from({ length: 500 }, (_, position) => makeMessage(position));
+	const browseTimeline = Array.from({ length: 500 }, (_, index) => makeMessage(499 - index));
 	const searchWindowOffset = 1450;
 	const searchWindow = Array.from({ length: 100 }, (_, index) =>
-		makeMessage(searchWindowOffset + index),
+		makeMessage(searchWindowOffset + 99 - index),
 	);
+	const searchAnchorOffset = searchWindowOffset + 49;
 	const requestedOffsets = new Set<number>();
 
 	await page.route("**/v1/**", async (route) => {
@@ -482,6 +489,7 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 			});
 		}
 		if (url.pathname === `/v1/sessions/${SESSION_ID}/messages`) {
+			expect(url.searchParams.get("direction")).toBe("desc");
 			if (!url.searchParams.has("search_query")) {
 				const offset = Number(url.searchParams.get("offset") ?? 0);
 				requestedOffsets.add(offset);
@@ -497,7 +505,7 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 				total: 2000,
 				offset: searchWindowOffset,
 				limit: 100,
-				anchor_offset: targetPosition,
+				anchor_offset: searchAnchorOffset,
 				search_navigation: {
 					index: 1,
 					total: 1,
@@ -513,9 +521,10 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 	await page.goto(`/sessions/${SESSION_ID}`);
 	const scrollContainer = page.locator("#dashboard-scroll-container");
 	await expect.poll(() => requestedOffsets.size).toBeGreaterThan(0);
+	await expect(page.getByText(/^Timeline message 499 /)).toBeInViewport();
 	for (let attempt = 0; attempt < 8 && requestedOffsets.size < 5; attempt++) {
 		const requestCount = requestedOffsets.size;
-		await scrollContainer.evaluate((element) => element.scrollTo({ top: element.scrollHeight }));
+		await scrollContainer.evaluate((element) => element.scrollTo({ top: 0 }));
 		await expect.poll(() => requestedOffsets.size).toBeGreaterThan(requestCount);
 	}
 	expect([...requestedOffsets].sort((left, right) => left - right)).toEqual([

--- a/apps/web/src/components/sessions/message-list.tsx
+++ b/apps/web/src/components/sessions/message-list.tsx
@@ -121,9 +121,8 @@ function MessageBlock({
 			data-search-match={isHighlighted ? "true" : undefined}
 			aria-current={isHighlighted ? "location" : undefined}
 			className={cn(
-				"group flex scroll-mt-24 gap-3 rounded-md border-l-2 border-transparent",
+				"group flex scroll-mt-24 gap-3 rounded-md border-l-2 border-transparent p-2",
 				deferOffscreenRendering && OFFSCREEN_RENDERING_CLASS,
-				isGroupStart ? "pt-4" : "",
 				isHighlighted && "border-primary bg-primary/5",
 			)}
 		>
@@ -595,17 +594,19 @@ export function SessionTimelineRowView({
 		<>
 			{row.dividerTimestamp ? <DateDivider timestamp={row.dividerTimestamp} /> : null}
 			{row.kind === "message" ? (
-				<MessageBlock
-					message={row.message}
-					userAvatar={userAvatar}
-					userName={userName}
-					agentType={agentType}
-					isGroupStart={row.isGroupStart}
-					isHighlighted={isHighlighted}
-					highlightedRef={isHighlighted ? highlightedMessageRef : undefined}
-					highlightQuery={highlightQuery}
-					deferOffscreenRendering={deferOffscreenRendering}
-				/>
+				<div className={row.isGroupStart && !row.dividerTimestamp ? "pt-2" : undefined}>
+					<MessageBlock
+						message={row.message}
+						userAvatar={userAvatar}
+						userName={userName}
+						agentType={agentType}
+						isGroupStart={row.isGroupStart}
+						isHighlighted={isHighlighted}
+						highlightedRef={isHighlighted ? highlightedMessageRef : undefined}
+						highlightQuery={highlightQuery}
+						deferOffscreenRendering={deferOffscreenRendering}
+					/>
+				</div>
 			) : (
 				<ToolActivity
 					call={row.call}

--- a/apps/web/src/components/sessions/virtualized-message-list.tsx
+++ b/apps/web/src/components/sessions/virtualized-message-list.tsx
@@ -12,21 +12,39 @@ import { useIsomorphicLayoutEffect } from "@/lib/use-isomorphic-layout-effect";
 
 const DASHBOARD_SCROLL_CONTAINER_ID = "dashboard-scroll-container";
 
+interface VirtualizedSessionTimelineListProps extends SessionTimelineListProps {
+	direction: "asc" | "desc";
+	totalItemCount: number;
+	hasMoreItems: boolean;
+	isLoadingMore: boolean;
+	onLoadMore: () => void;
+}
+
 /**
  * Windowed dashboard renderer for variable-height Markdown and tool activity.
  * React Virtuoso owns measurement and scroll anchoring. Public shares keep the
  * static renderer; dashboard data is client-fetched, so its SSR shell is empty.
  */
-export function VirtualizedSessionTimelineList(props: SessionTimelineListProps) {
+export function VirtualizedSessionTimelineList(props: VirtualizedSessionTimelineListProps) {
 	const [scrollParent, setScrollParent] = useState<HTMLElement | Window | null>(null);
 	const virtuosoRef = useRef<VirtuosoHandle>(null);
-	const rows = useMemo(
-		() => buildSessionTimelineRows(props.items, props.itemKeys),
-		[props.items, props.itemKeys],
-	);
+	const rows = useMemo(() => {
+		if (props.direction === "desc") {
+			return buildSessionTimelineRows(props.items, props.itemKeys);
+		}
+		return buildSessionTimelineRows(
+			[...props.items].reverse(),
+			props.itemKeys ? [...props.itemKeys].reverse() : props.itemKeys,
+		);
+	}, [props.direction, props.itemKeys, props.items]);
 	const highlightedRowIndex = props.highlightedMessageKey
 		? rows.findIndex((row) => row.rowKey === props.highlightedMessageKey)
 		: -1;
+	// `firstItemIndex` is React Virtuoso's documented inverse-scrolling
+	// contract. It decreases by exactly the number of visual rows prepended,
+	// preserving the viewport while older pages load above the conversation.
+	const firstItemIndex =
+		props.direction === "asc" ? Math.max(1, props.totalItemCount - rows.length + 1) : undefined;
 
 	useIsomorphicLayoutEffect(() => {
 		const resolveScrollParent = () => {
@@ -57,17 +75,27 @@ export function VirtualizedSessionTimelineList(props: SessionTimelineListProps) 
 	return (
 		<div data-testid="virtualized-session-timeline">
 			<Virtuoso
-				key={usesWindowScroll ? "window" : "container"}
+				key={`${usesWindowScroll ? "window" : "container"}:${props.direction}`}
 				ref={virtuosoRef}
 				{...(usesWindowScroll
 					? { useWindowScroll: true }
 					: { customScrollParent: scrollParent as HTMLElement })}
 				data={rows}
+				firstItemIndex={firstItemIndex}
 				computeItemKey={(_index, row) => row.rowKey}
 				defaultItemHeight={96}
 				increaseViewportBy={{ top: 600, bottom: 900 }}
+				startReached={
+					props.direction === "asc" && props.hasMoreItems && !props.isLoadingMore
+						? props.onLoadMore
+						: undefined
+				}
 				initialTopMostItemIndex={
-					highlightedRowIndex < 0 ? 0 : { index: highlightedRowIndex, align: "center" }
+					highlightedRowIndex >= 0
+						? { index: highlightedRowIndex, align: "center" }
+						: props.direction === "asc"
+							? { index: rows.length - 1, align: "end" }
+							: 0
 				}
 				itemContent={(_index, row) => (
 					<SessionTimelineRowView

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -21,7 +21,7 @@ import {
 	Wrench,
 	Zap,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
@@ -72,6 +72,10 @@ import {
 import { useDebouncedValue } from "@/lib/use-debounced";
 import { useIsomorphicLayoutEffect } from "@/lib/use-isomorphic-layout-effect";
 import { cn, formatNumber, formatSessionSummary, relativeTime } from "@/lib/utils";
+
+const SESSION_MESSAGE_PAGE_SIZE = 100;
+const SESSION_MESSAGE_API_DIRECTION = "desc" as const;
+type SessionMessageDirection = "asc" | "desc";
 
 function normalizeTimelinePage(
 	page: SessionMessagesPage | SessionTimelinePage,
@@ -199,20 +203,15 @@ export function SessionDetailContent({
 		enabled: !!agentId,
 	});
 
-	// Direction toggle: "desc" (newest-first, default) is the most
-	// common review case for clawdi — users open a session to see
-	// "what happened recently". For 5000-message sessions, the old
-	// asc default forced the user to "Load more" through every page
-	// just to reach today's messages. Defaulting desc + persisting
-	// the user's choice in localStorage matches Slack/Discord (they
-	// scroll-to-bottom on open) without requiring a scroll gesture
-	// to find the latest reply.
-	type Direction = "asc" | "desc";
+	// Conversations default to chronological order with the latest message
+	// at the bottom. The API still returns newest-first pages so opening a
+	// long session only fetches its tail; the virtualized renderer reverses
+	// the loaded window and preserves the viewport as older pages prepend.
 	// SSR and hydration must agree on the first render, so the stored
 	// preference syncs in a layout effect instead of the state initializer.
 	// Layout effects run before the messages query subscribes, so a stored
-	// "asc" swaps the query key without a wasted "desc" fetch.
-	const [direction, setDirection] = useState<Direction>("desc");
+	// "desc" swaps the presentation before paint without a second fetch.
+	const [direction, setDirection] = useState<SessionMessageDirection>("asc");
 	const normalizedSearchQuery = searchQuery?.trim() ?? "";
 	const rememberedSearchQueryRef = useRef(normalizedSearchQuery);
 	const effectiveSearchQuery = isSearchQueryReady(normalizedSearchQuery)
@@ -221,9 +220,9 @@ export function SessionDetailContent({
 	const debouncedSearchQuery = useDebouncedValue(effectiveSearchQuery, 250) || undefined;
 	useIsomorphicLayoutEffect(() => {
 		const stored = localStorage.getItem("clawdi.session.message-direction");
-		if (stored === "asc") setDirection("asc");
+		if (stored === "desc") setDirection("desc");
 	}, []);
-	const persistDirection = (d: Direction) => {
+	const persistDirection = (d: SessionMessageDirection) => {
 		setDirection(d);
 		try {
 			localStorage.setItem("clawdi.session.message-direction", d);
@@ -236,14 +235,11 @@ export function SessionDetailContent({
 	// Long sessions (5k+ messages, 10+ MB JSON) used to ship the
 	// whole blob in one shot and Markdown-render every turn,
 	// which froze the page for seconds. Now we load 100 at a time
-	// and the IntersectionObserver in `LoadMoreSentinel` requests
-	// the next page when the user scrolls near the bottom.
+	// and the pagination controls request
+	// the next page when the user approaches the older edge.
 	//
-	// The backend applies the direction before offset pagination, so offset=0
-	// always means "start from the selected end". This keeps the newest-first
-	// page correct even while metadata and an incremental event append briefly
-	// describe different revisions.
-	const PAGE_SIZE = 100;
+	// Fetching newest-first is independent from presentation order. It avoids
+	// walking every older page just to render the current end of the chat.
 	const {
 		data: pagesData,
 		isLoading: isContentLoading,
@@ -255,16 +251,11 @@ export function SessionDetailContent({
 		isFetchingNextPage,
 		isFetching: isContentFetching,
 	} = useInfiniteQuery({
-		// Direction in queryKey so toggling refetches from the new
-		// end (rather than reordering already-loaded pages, which
-		// would only show the OLDEST 100 in newest-first mode —
-		// confusing).
 		queryKey: [
 			"session-messages",
 			sessionId,
 			session?.content_hash ?? null,
 			session?.event_head_hash ?? null,
-			direction,
 			timelineView,
 			searchAnchor?.kind ?? null,
 			searchAnchor?.position ?? null,
@@ -279,8 +270,8 @@ export function SessionDetailContent({
 						path: { session_id: sessionId },
 						query: {
 							offset: pageParam,
-							limit: PAGE_SIZE,
-							direction,
+							limit: SESSION_MESSAGE_PAGE_SIZE,
+							direction: SESSION_MESSAGE_API_DIRECTION,
 							view: timelineView,
 							...(pageParam === 0 && searchAnchor
 								? {
@@ -312,12 +303,13 @@ export function SessionDetailContent({
 		gcTime: SESSION_MESSAGES_GC_MS,
 		placeholderData: keepPreviousData,
 	});
+	const loadMoreMessages = useCallback(() => {
+		if (!isFetchingNextPage) void fetchNextPage();
+	}, [fetchNextPage, isFetchingNextPage]);
 
 	// Flatten pages → ordered message list, paired with a stable
-	// React key per row. The key is the message's canonical position
-	// (`page.offset + k`) so it stays put across pagination, direction
-	// toggles, and refetches — array-index keys would break grouping
-	// memo when prepended pages shift positions.
+	// React key per row. The key is the server page position
+	// (`page.offset + k`) so it stays put when older pages prepend.
 	const { timelineItems, timelineKeys } = useMemo(() => {
 		if (!pagesData) return { timelineItems: null, timelineKeys: null };
 		const items: SessionTimelineItem[] = [];
@@ -325,16 +317,16 @@ export function SessionDetailContent({
 		for (const page of pagesData.pages) {
 			for (let k = 0; k < page.items.length; k++) {
 				items.push(page.items[k]);
-				keys.push(`${direction}:${page.offset + k}`);
+				keys.push(`${SESSION_MESSAGE_API_DIRECTION}:${page.offset + k}`);
 			}
 		}
 		return { timelineItems: items, timelineKeys: keys };
-	}, [pagesData, direction]);
+	}, [pagesData]);
 	const totalItems = pagesData?.pages[0]?.total ?? 0;
 	const loadedCount = timelineItems?.length ?? 0;
 	const anchorOffset = pagesData?.pages[0]?.anchor_offset;
 	const highlightedMessageKey =
-		typeof anchorOffset === "number" ? `${direction}:${anchorOffset}` : null;
+		typeof anchorOffset === "number" ? `${SESSION_MESSAGE_API_DIRECTION}:${anchorOffset}` : null;
 	const highlightedMessageRef = useRef<HTMLDivElement | null>(null);
 	const handledAnchorRef = useRef<string | null>(null);
 	const searchNavigation = pagesData?.pages[0]?.search_navigation;
@@ -646,10 +638,17 @@ export function SessionDetailContent({
 						title="Couldn't load activity"
 					/>
 				) : timelineItems?.length ? (
-					// Spacing comes from MessageBlock's `pt-4` on
-					// group-start rows; continuation rows render flush
-					// so a thread looks tight, not gapped.
 					<div>
+						{direction === "asc" && hasNextPage ? (
+							<LoadMoreControl
+								loadedCount={loadedCount}
+								totalCount={totalItems}
+								isFetching={isFetchingNextPage}
+								onLoad={loadMoreMessages}
+								label="Load earlier"
+								autoLoad={false}
+							/>
+						) : null}
 						<VirtualizedSessionTimelineList
 							items={timelineItems}
 							itemKeys={timelineKeys}
@@ -659,13 +658,19 @@ export function SessionDetailContent({
 							highlightedMessageKey={highlightedMessageKey}
 							highlightedMessageRef={highlightedMessageRef}
 							highlightQuery={debouncedSearchQuery}
+							direction={direction}
+							totalItemCount={totalItems}
+							hasMoreItems={Boolean(hasNextPage)}
+							isLoadingMore={isFetchingNextPage}
+							onLoadMore={loadMoreMessages}
 						/>
-						{hasNextPage ? (
-							<LoadMoreSentinel
+						{direction === "desc" && hasNextPage ? (
+							<LoadMoreControl
 								loadedCount={loadedCount}
 								totalCount={totalItems}
 								isFetching={isFetchingNextPage}
-								onLoad={() => fetchNextPage()}
+								onLoad={loadMoreMessages}
+								label="Load older"
 							/>
 						) : null}
 					</div>
@@ -773,26 +778,28 @@ function JumpToBottomButton() {
 // ---------------------------------------------------------------------------
 
 /**
- * Auto-loads the next page when the user scrolls within ~300px of
- * this sentinel. The IntersectionObserver fires on enter; we
- * de-bounce with `isFetching` so a fast scroll doesn't queue up
- * multiple requests for the same page. The button is also clickable
- * — gives the user manual control AND a fallback if the observer
- * fails (older browsers, headless render contexts, etc.).
+ * Manual pagination fallback. Newest-first mode also observes this
+ * bottom-edge control; chronological mode uses Virtuoso's `startReached`
+ * so prepended rows retain their exact scroll position.
  */
-function LoadMoreSentinel({
+function LoadMoreControl({
 	loadedCount,
 	totalCount,
 	isFetching,
 	onLoad,
+	label,
+	autoLoad = true,
 }: {
 	loadedCount: number;
 	totalCount: number;
 	isFetching: boolean;
 	onLoad: () => void;
+	label: string;
+	autoLoad?: boolean;
 }) {
 	const ref = useRef<HTMLDivElement | null>(null);
 	useEffect(() => {
+		if (!autoLoad) return;
 		const node = ref.current;
 		if (!node) return;
 		if (typeof IntersectionObserver === "undefined") return;
@@ -801,21 +808,21 @@ function LoadMoreSentinel({
 				const entry = entries[0];
 				if (entry?.isIntersecting && !isFetching) onLoad();
 			},
-			// Trigger 300px before the sentinel is fully in view —
+			// Trigger 300px before the control is fully in view —
 			// keeps the scroll continuous instead of pausing while
 			// the next page fetches.
 			{ rootMargin: "300px" },
 		);
 		observer.observe(node);
 		return () => observer.disconnect();
-	}, [isFetching, onLoad]);
+	}, [autoLoad, isFetching, onLoad]);
 
 	return (
 		<div ref={ref} className="flex flex-col items-center gap-2 py-4">
 			<Button variant="ghost" size="sm" onClick={onLoad} disabled={isFetching}>
 				{isFetching
-					? `Loading more… (${loadedCount}/${totalCount})`
-					: `Load more (${loadedCount}/${totalCount})`}
+					? `Loading… (${loadedCount}/${totalCount})`
+					: `${label} (${loadedCount}/${totalCount})`}
 			</Button>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- give every Session message row stable 8px padding and keep group spacing outside search emphasis
- default Session timelines to chronological chat order while still fetching the newest page first
- prepend older pages with React Virtuoso scroll anchoring and preserve newest-first as a user preference

## Verification
- isolated Web typecheck, focused message-list tests, and OSS build
- Playwright Session search/navigation suite: 4 passed
- desktop light/dark and 390px mobile browser checks