### PR TITLE
fix(web): stabilize session search controls

### DIFF
--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -1,4 +1,4 @@
-import { expect, type Route, test } from "@playwright/test";
+import { expect, type Locator, type Route, test } from "@playwright/test";
 
 const SESSION_ID = "11111111-1111-4111-8111-111111111111";
 const AGENT_ID = "22222222-2222-4222-8222-222222222222";
@@ -42,6 +42,13 @@ async function fulfillJson(route: Route, body: unknown) {
 		status: 200,
 		contentType: "application/json",
 		body: JSON.stringify(body),
+	});
+}
+
+async function horizontalBounds(locator: Locator) {
+	return locator.evaluate((element) => {
+		const bounds = element.getBoundingClientRect();
+		return { x: bounds.x, width: bounds.width };
 	});
 }
 
@@ -232,6 +239,10 @@ test("opens a message search result and returns to the same filtered list", asyn
 	await expect(page.locator('[data-search-match="true"]')).toBeVisible();
 	await expect(page.getByText("1 / 2")).toBeVisible();
 	const detailSearch = page.getByRole("textbox", { name: "Search messages" });
+	const searchInputGroup = detailSearch.locator("..");
+	const clearSearchButton = page.getByRole("button", { name: "Clear search" });
+	const initialSearchBounds = await horizontalBounds(searchInputGroup);
+	const initialClearBounds = await horizontalBounds(clearSearchButton);
 	await detailSearch.press("Enter");
 	await expect(page).toHaveURL((url) => url.searchParams.get("matchPosition") === "11");
 	await expect(page.locator('[data-search-match="true"]')).toContainText(
@@ -242,6 +253,8 @@ test("opens a message search result and returns to the same filtered list", asyn
 	await expect(page).toHaveURL((url) => url.searchParams.get("matchPosition") === "7");
 	await detailSearch.fill("x");
 	await expect(page.getByText("2+ chars")).toBeVisible();
+	expect(await horizontalBounds(searchInputGroup)).toEqual(initialSearchBounds);
+	expect(await horizontalBounds(clearSearchButton)).toEqual(initialClearBounds);
 	await page.waitForTimeout(350);
 	expect(requestedSearchQueries).not.toContain("x");
 	await detailSearch.fill("no longer");
@@ -256,6 +269,11 @@ test("opens a message search result and returns to the same filtered list", asyn
 	);
 	await expect(page.locator('[data-search-match="true"] mark')).toHaveText(["no longer"]);
 	await expect(page.getByText("1 / 1")).toBeVisible();
+	expect(await horizontalBounds(clearSearchButton)).toEqual(initialClearBounds);
+	await clearSearchButton.click();
+	await expect(detailSearch).toHaveValue("");
+	await expect(page).toHaveURL((url) => !url.searchParams.has("matchQuery"));
+	expect(await horizontalBounds(searchInputGroup)).toEqual(initialSearchBounds);
 
 	await page.getByText("Back to Sessions", { exact: true }).click();
 	await expect(page).toHaveURL((url) => {

--- a/apps/web/src/components/sessions/session-search-navigation.tsx
+++ b/apps/web/src/components/sessions/session-search-navigation.tsx
@@ -2,10 +2,15 @@
 
 import { SEARCH_QUERY_MIN_LENGTH, searchQueryLength } from "@clawdi/shared/consts";
 import { useRouter } from "@tanstack/react-router";
-import { ChevronDown, ChevronUp, LoaderCircle } from "lucide-react";
+import { ChevronDown, ChevronUp, LoaderCircle, Search, X } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Button } from "@/components/ui/button";
-import { SearchInput } from "@/components/ui/search-input";
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupButton,
+	InputGroupInput,
+	InputGroupText,
+} from "@/components/ui/input-group";
 import { agentSessionDetailLink } from "@/lib/agent-routes";
 import type { SessionMessagesPage } from "@/lib/api-schemas";
 import {
@@ -32,21 +37,20 @@ function MatchButton({
 }) {
 	if (!anchor) {
 		return (
-			<Button variant="ghost" size="icon-sm" disabled aria-label={label} title={label}>
+			<InputGroupButton size="icon-xs" disabled aria-label={label} title={label}>
 				{icon}
-			</Button>
+			</InputGroupButton>
 		);
 	}
 	return (
-		<Button
-			variant="ghost"
-			size="icon-sm"
+		<InputGroupButton
+			size="icon-xs"
 			onClick={() => onSelect(anchor)}
 			aria-label={label}
 			title={label}
 		>
 			{icon}
-		</Button>
+		</InputGroupButton>
 	);
 }
 
@@ -123,75 +127,95 @@ export function SessionSearchNavigation({
 	return (
 		<nav
 			aria-label="Search messages"
-			className={cn(
-				"flex min-w-0 flex-1 items-center gap-1.5 text-xs text-muted-foreground",
-				className,
-			)}
+			className={cn("min-w-0 flex-1 text-xs text-muted-foreground", className)}
 		>
-			<SearchInput
-				value={draftQuery}
-				onChange={updateQuery}
-				placeholder="Search messages…"
-				ariaLabel="Search messages"
-				className="min-w-36 flex-1"
-				ariaKeyShortcuts="Enter Shift+Enter Escape"
-				maxLength={maxLength}
-				onKeyDown={(event) => {
-					if (event.nativeEvent.isComposing) return;
-					if (event.key === "Escape" && draftQuery) {
+			<InputGroup className="min-w-36">
+				<InputGroupAddon>
+					<Search />
+				</InputGroupAddon>
+				<InputGroupInput
+					name="search"
+					aria-label="Search messages"
+					type="text"
+					value={draftQuery}
+					onChange={(event) => updateQuery(event.target.value)}
+					placeholder="Search messages…"
+					autoComplete="off"
+					aria-keyshortcuts="Enter Shift+Enter Escape"
+					maxLength={maxLength}
+					onKeyDown={(event) => {
+						if (event.nativeEvent.isComposing) return;
+						if (event.key === "Escape" && draftQuery) {
+							event.preventDefault();
+							updateQuery("");
+							return;
+						}
+						if (event.key !== "Enter") return;
+						const anchor = event.shiftKey ? activeNavigation?.previous : activeNavigation?.next;
+						if (!anchor) return;
 						event.preventDefault();
-						updateQuery("");
-						return;
-					}
-					if (event.key !== "Enter") return;
-					const anchor = event.shiftKey ? activeNavigation?.previous : activeNavigation?.next;
-					if (!anchor) return;
-					event.preventDefault();
-					navigateToMatch(anchor);
-				}}
-			/>
-			{query ? (
-				<div className="flex min-h-8 shrink-0 items-center gap-1 border-l pl-1.5">
-					<span
-						className="inline-flex min-w-10 shrink-0 items-center justify-center gap-1 tabular-nums text-foreground"
-						aria-live="polite"
-					>
-						{queryTooShort ? (
+						navigateToMatch(anchor);
+					}}
+				/>
+				{draftQuery ? (
+					<InputGroupAddon align="inline-end" className="gap-0.5">
+						{query ? (
+							<InputGroupText
+								className="w-16 shrink-0 justify-center truncate text-xs tabular-nums text-foreground"
+								aria-live="polite"
+							>
+								{queryTooShort ? (
+									<>
+										<span aria-hidden="true">{SEARCH_QUERY_MIN_LENGTH}+ chars</span>
+										<span className="sr-only">
+											Type at least {SEARCH_QUERY_MIN_LENGTH} characters
+										</span>
+									</>
+								) : isSearching ? (
+									<>
+										<LoaderCircle className="size-3.5 animate-spin" />
+										<span className="sr-only">Searching</span>
+									</>
+								) : null}
+								{queryTooShort ? null : hasSearchError ? (
+									"Unavailable"
+								) : isSearching ? null : activeNavigation ? (
+									`${activeNavigation.index} / ${activeNavigation.total}`
+								) : (
+									<>
+										<span aria-hidden="true">0 / 0</span>
+										<span className="sr-only">No matches</span>
+									</>
+								)}
+							</InputGroupText>
+						) : null}
+						{query ? (
 							<>
-								<span aria-hidden="true">{SEARCH_QUERY_MIN_LENGTH}+ chars</span>
-								<span className="sr-only">Type at least {SEARCH_QUERY_MIN_LENGTH} characters</span>
-							</>
-						) : isSearching ? (
-							<>
-								<LoaderCircle className="size-3.5 animate-spin" />
-								<span className="sr-only">Searching</span>
+								<MatchButton
+									label="Previous match"
+									anchor={activeNavigation?.previous}
+									onSelect={navigateToMatch}
+									icon={<ChevronUp />}
+								/>
+								<MatchButton
+									label="Next match"
+									anchor={activeNavigation?.next}
+									onSelect={navigateToMatch}
+									icon={<ChevronDown />}
+								/>
 							</>
 						) : null}
-						{queryTooShort ? null : hasSearchError ? (
-							"Unavailable"
-						) : isSearching ? null : activeNavigation ? (
-							`${activeNavigation.index} / ${activeNavigation.total}`
-						) : (
-							<>
-								<span aria-hidden="true">0 / 0</span>
-								<span className="sr-only">No matches</span>
-							</>
-						)}
-					</span>
-					<MatchButton
-						label="Previous match"
-						anchor={activeNavigation?.previous}
-						onSelect={navigateToMatch}
-						icon={<ChevronUp />}
-					/>
-					<MatchButton
-						label="Next match"
-						anchor={activeNavigation?.next}
-						onSelect={navigateToMatch}
-						icon={<ChevronDown />}
-					/>
-				</div>
-			) : null}
+						<InputGroupButton
+							size="icon-xs"
+							onClick={() => updateQuery("")}
+							aria-label="Clear search"
+							title="Clear search"
+						>
+							<X />
+						</InputGroupButton>
+					</InputGroupAddon>
+				) : null}
+			</InputGroup>
 		</nav>
 	);
 }

--- a/apps/web/src/components/ui/search-input.tsx
+++ b/apps/web/src/components/ui/search-input.tsx
@@ -2,21 +2,15 @@
 
 import { Search, X } from "lucide-react";
 import type { KeyboardEventHandler } from "react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { cn } from "@/lib/utils";
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupButton,
+	InputGroupInput,
+} from "@/components/ui/input-group";
 
 /**
- * Canonical search input with magnifying-glass icon + clear button.
- *
- * Used everywhere the dashboard offers a search box: list pages
- * (connectors, skills), table toolbars (`DataTableToolbar`), and
- * filtering panels in detail pages (connector tools list).
- *
- * Pulled out because the same `<div className="relative"><Search />
- * <Input pl-9 pr-9 /><X></div>` pattern was duplicated across four
- * call sites with subtle drift (icon position, clear-button size,
- * placeholder casing).
+ * Canonical shadcn Input Group composition for dashboard search fields.
  */
 export function SearchInput({
 	value,
@@ -42,16 +36,17 @@ export function SearchInput({
 	maxLength?: number;
 }) {
 	return (
-		<div className={cn("relative", className)}>
-			<Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
-			<Input
+		<InputGroup className={className}>
+			<InputGroupAddon>
+				<Search />
+			</InputGroupAddon>
+			<InputGroupInput
 				name={name}
 				aria-label={ariaLabel}
 				type="text"
 				value={value}
 				onChange={(e) => onChange(e.target.value)}
 				placeholder={placeholder}
-				className="pl-9 pr-9"
 				autoComplete="off"
 				autoFocus={autoFocus}
 				onKeyDown={onKeyDown}
@@ -59,16 +54,17 @@ export function SearchInput({
 				maxLength={maxLength}
 			/>
 			{value ? (
-				<Button
-					variant="ghost"
-					size="icon-sm"
-					onClick={() => onChange("")}
-					className="-translate-y-1/2 absolute top-1/2 right-1"
-					aria-label="Clear search"
-				>
-					<X className="size-4" />
-				</Button>
+				<InputGroupAddon align="inline-end">
+					<InputGroupButton
+						size="icon-xs"
+						onClick={() => onChange("")}
+						aria-label="Clear search"
+						title="Clear search"
+					>
+						<X />
+					</InputGroupButton>
+				</InputGroupAddon>
 			) : null}
-		</div>
+		</InputGroup>
 	);
 }

--- a/apps/web/src/components/ui/search-input.tsx
+++ b/apps/web/src/components/ui/search-input.tsx
@@ -13,6 +13,7 @@ import {
  * Canonical shadcn Input Group composition for dashboard search fields.
  */
 export function SearchInput({
+	id,
 	value,
 	onChange,
 	placeholder = "Search…",
@@ -24,6 +25,7 @@ export function SearchInput({
 	ariaKeyShortcuts,
 	maxLength,
 }: {
+	id?: string;
 	value: string;
 	onChange: (next: string) => void;
 	placeholder?: string;
@@ -41,6 +43,7 @@ export function SearchInput({
 				<Search />
 			</InputGroupAddon>
 			<InputGroupInput
+				id={id}
 				name={name}
 				aria-label={ariaLabel}
 				type="text"

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -87,6 +87,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { SearchInput } from "@/components/ui/search-input";
 import {
 	Select,
 	SelectContent,
@@ -1755,14 +1756,15 @@ function ProjectVaultActions({
 						>
 							<div className="space-y-1.5">
 								<Label htmlFor={`project-vault-search-${projectId}`}>Search Vaults</Label>
-								<Input
+								<SearchInput
 									id={`project-vault-search-${projectId}`}
 									value={attachSearch}
-									onChange={(event) => {
-										setAttachSearch(event.target.value);
+									onChange={(value) => {
+										setAttachSearch(value);
 										setSelectedVaultId("");
 									}}
 									placeholder="Search Vaults…"
+									ariaLabel="Search Vaults"
 								/>
 							</div>
 							{attachableVaults.length === 0 ? (

--- a/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
@@ -9,7 +9,6 @@ import {
 	FolderInput,
 	ListChecks,
 	Plus,
-	Search,
 	Share2,
 	Trash2,
 } from "lucide-react";
@@ -45,8 +44,8 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { SearchInput } from "@/components/ui/search-input";
 import {
 	Select,
 	SelectContent,
@@ -573,16 +572,13 @@ export default function VaultDetailPage({
 					<div className="flex w-full flex-col gap-2 sm:w-auto sm:shrink-0 sm:flex-row sm:items-center">
 						{keyNames.length > 0 ? (
 							<>
-								<div className="relative w-full sm:w-auto">
-									<Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-									<Input
-										value={search}
-										onChange={(e) => setSearch(e.target.value)}
-										placeholder="Search keys…"
-										aria-label="Search keys"
-										className="h-8 w-full pl-8 text-sm sm:w-52"
-									/>
-								</div>
+								<SearchInput
+									value={search}
+									onChange={setSearch}
+									placeholder="Search keys…"
+									ariaLabel="Search keys"
+									className="h-8 w-full sm:w-52"
+								/>
 								{canManageVault ? (
 									<Button
 										variant={selectMode ? "secondary" : "outline"}


### PR DESCRIPTION
## Summary

- rebuild the shared SearchInput with the existing shadcn InputGroup primitives
- keep Session result status, navigation, and clear action inside one trailing addon
- preserve the search field bounds and clear-button position across query states
- migrate the remaining Vault key and Project attach-Vault filters to the canonical SearchInput
- extend the existing Session search E2E flow with layout-stability assertions

## Verification

- scripts/test.sh web: typecheck, 1107 tests, and OSS production build passed
- Docker clean runner after the final migration: web typecheck, oss-clean 22/22, and OSS client/server build passed
- Playwright session-search-navigation.pw.ts: 4 passed in the official Playwright 1.62.1 Chromium image
- Biome and git diff check passed
- desktop 1280px and mobile 390px browser traces inspected