### PR TITLE
fix(web): avoid stacked session toolbar divider

### DIFF
--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -537,7 +537,7 @@ export function SessionDetailContent({
 			</DetailStats>
 
 			{session.has_content ? (
-				<div className="sticky top-(--header-height) z-10 -mx-4 border-y bg-background/95 px-4 py-2 backdrop-blur supports-[backdrop-filter]:bg-background/80 lg:-mx-6 lg:px-6">
+				<div className="sticky top-(--header-height) z-10 -mx-4 border-b bg-background/95 px-4 py-2 backdrop-blur supports-[backdrop-filter]:bg-background/80 lg:-mx-6 lg:px-6">
 					<div
 						className={cn(
 							"grid min-w-0 gap-2 md:items-center",


### PR DESCRIPTION
## Summary

- let the sticky site header own the shared top divider
- keep only the session toolbar's bottom divider
- avoid a doubled border when the toolbar reaches its sticky position

## Verification

- `bash scripts/test.sh web`
- `git diff --check`

The Web suite passed in the clean Docker runner: typecheck, tests, and OSS client/server build. CI provides the authoritative clean Playwright run.
