### PR TITLE
fix(web): coordinate session timeline navigation

### DIFF
--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -364,37 +364,41 @@ test("filters session activity and expands paired tool details", async ({ page }
 			return fulfillJson(route, session);
 		}
 		if (url.pathname === `/v1/sessions/${SESSION_ID}/messages`) {
-			const view = url.searchParams.get("view");
+			expect(url.searchParams.get("view")).toBe("all");
+			const requestedCategories = url.searchParams.getAll("include");
+			const categories = new Set(
+				requestedCategories.length > 0 ? requestedCategories : ["user", "assistant", "tools"],
+			);
+			const items = timeline.filter((item) =>
+				item.kind === "message" ? categories.has(item.role) : categories.has("tools"),
+			);
 			const query = url.searchParams.get("search_query");
 			if (query) {
 				await new Promise((resolve) => setTimeout(resolve, 450));
-				if (view !== "assistant" && view !== "all") {
-					const items = view === "tools" ? timeline.slice(1, 5) : [timeline[5]];
-					return fulfillJson(route, {
-						items,
-						total: items.length,
-						offset: 0,
-						limit: 100,
-						search_navigation: null,
-					});
-				}
+				const matchIndex = items.findIndex(
+					(item) =>
+						item.kind === "message" && item.content.toLowerCase().includes(query.toLowerCase()),
+				);
+				const match = matchIndex >= 0 ? items[matchIndex] : null;
 				return fulfillJson(route, {
-					items: [timeline[0]],
-					total: 1,
+					items,
+					total: items.length,
 					offset: 0,
 					limit: 100,
-					anchor_offset: 0,
-					search_navigation: {
-						index: 1,
-						total: 1,
-						current: anchor,
-						previous: null,
-						next: null,
-					},
+					...(match
+						? {
+								anchor_offset: matchIndex,
+								search_navigation: {
+									index: 1,
+									total: 1,
+									current: { ...anchor, position: match.position },
+									previous: null,
+									next: null,
+								},
+							}
+						: { search_navigation: null }),
 				});
 			}
-			const items =
-				view === "tools" ? timeline.slice(1, 5) : view === "user" ? [timeline[5]] : timeline;
 			return fulfillJson(route, {
 				items,
 				total: items.length,
@@ -417,15 +421,15 @@ test("filters session activity and expands paired tool details", async ({ page }
 	await expect(page.getByText("Repository instructions", { exact: true })).toBeVisible();
 
 	await page.getByRole("button", { name: "Your messages" }).click();
-	await expect(page).toHaveURL((url) => url.searchParams.get("timelineView") === "user");
+	await expect(page).toHaveURL((url) => url.searchParams.get("timelineView") === "user,tools");
 	await expect(page.getByText("Read the repository instructions", { exact: true })).toBeVisible();
-	await expect(toolActivity).not.toBeVisible();
+	await expect(toolActivity).toBeVisible();
 	await page.getByRole("textbox", { name: "Search messages" }).fill("Read the repository");
 	await expect(page).toHaveURL(
 		(url) => url.searchParams.get("matchQuery") === "Read the repository",
 	);
 
-	await page.getByRole("button", { name: "Tools activity" }).click();
+	await page.getByRole("button", { name: "Your messages" }).click();
 	await expect(page).toHaveURL((url) => {
 		return url.searchParams.get("timelineView") === "tools" && !url.searchParams.has("matchQuery");
 	});
@@ -442,9 +446,12 @@ test("filters session activity and expands paired tool details", async ({ page }
 	await expect(page).toHaveURL((url) => {
 		return (
 			url.searchParams.get("matchQuery") === "Read the repository" &&
-			url.searchParams.get("timelineView") === "assistant"
+			url.searchParams.get("timelineView") === "assistant,tools"
 		);
 	});
+	await page.getByRole("button", { name: "Tools activity" }).click();
+	await expect(page).toHaveURL((url) => url.searchParams.get("timelineView") === "assistant");
+	await expect(toolActivity).not.toBeVisible();
 	await restoredSearch.fill("Final answer");
 	await expect(page).toHaveURL((url) => {
 		return (
@@ -457,6 +464,10 @@ test("filters session activity and expands paired tool details", async ({ page }
 		"Final answer after reading the file",
 	);
 	await expect(page.getByText("1 / 1")).toBeVisible();
+	await page.getByRole("button", { name: "Your messages" }).click();
+	await expect(page).toHaveURL((url) => url.searchParams.get("timelineView") === "user,assistant");
+	await expect(page.getByText("Read the repository instructions", { exact: true })).toBeVisible();
+	await expect(toolActivity).not.toBeVisible();
 });
 
 test("keeps a long anchored timeline windowed across desktop and mobile", async ({ page }) => {
@@ -481,8 +492,12 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 	const searchWindow = Array.from({ length: 100 }, (_, index) =>
 		makeMessage(searchWindowOffset + 99 - index),
 	);
+	const olderSearchWindow = Array.from({ length: 100 }, (_, index) =>
+		makeMessage(searchWindowOffset - 1 - index),
+	);
 	const searchAnchorOffset = searchWindowOffset + 49;
 	const requestedOffsets = new Set<number>();
+	const requestedSearchOffsets = new Set<number>();
 
 	await page.route("**/v1/**", async (route) => {
 		const url = new URL(route.request().url());
@@ -508,8 +523,9 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 		}
 		if (url.pathname === `/v1/sessions/${SESSION_ID}/messages`) {
 			expect(url.searchParams.get("direction")).toBe("desc");
-			if (!url.searchParams.has("search_query")) {
-				const offset = Number(url.searchParams.get("offset") ?? 0);
+			const offset = Number(url.searchParams.get("offset") ?? 0);
+			const isSearchPagination = offset >= searchWindowOffset;
+			if (!url.searchParams.has("search_query") && !isSearchPagination) {
 				requestedOffsets.add(offset);
 				return fulfillJson(route, {
 					items: browseTimeline.slice(offset, offset + 100),
@@ -518,19 +534,25 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 					limit: 100,
 				});
 			}
+			requestedSearchOffsets.add(offset);
+			const loadingOlder = offset === searchWindowOffset + searchWindow.length;
 			return fulfillJson(route, {
-				items: searchWindow,
+				items: loadingOlder ? olderSearchWindow : searchWindow,
 				total: 2000,
-				offset: searchWindowOffset,
+				offset: loadingOlder ? offset : searchWindowOffset,
 				limit: 100,
-				anchor_offset: searchAnchorOffset,
-				search_navigation: {
-					index: 1,
-					total: 1,
-					current: targetAnchor,
-					previous: null,
-					next: null,
-				},
+				...(loadingOlder
+					? {}
+					: {
+							anchor_offset: searchAnchorOffset,
+							search_navigation: {
+								index: 1,
+								total: 1,
+								current: targetAnchor,
+								previous: null,
+								next: null,
+							},
+						}),
 			});
 		}
 		return fulfillJson(route, {});
@@ -548,6 +570,17 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 	expect([...requestedOffsets].sort((left, right) => left - right)).toEqual([
 		0, 100, 200, 300, 400,
 	]);
+	const jumpToLatest = page.getByRole("button", { name: "Jump to latest" });
+	await expect(jumpToLatest).toBeVisible();
+	const [jumpBounds, scrollBounds] = await Promise.all([
+		horizontalBounds(jumpToLatest),
+		horizontalBounds(scrollContainer),
+	]);
+	expect(
+		Math.abs(jumpBounds.x + jumpBounds.width / 2 - (scrollBounds.x + scrollBounds.width / 2)),
+	).toBeLessThan(2);
+	await jumpToLatest.click();
+	await expect(page.getByText(/^Timeline message 499 /)).toBeInViewport();
 	const mountedRows = page.locator(
 		'[data-testid="virtualized-session-timeline"] [data-item-index]',
 	);
@@ -569,4 +602,26 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 	await page.setViewportSize({ width: 390, height: 844 });
 	await expect(current).toBeVisible();
 	expect(await mountedRows.count()).toBeLessThan(80);
+
+	await page.setViewportSize({ width: 1280, height: 900 });
+	await scrollContainer.evaluate((element) => element.scrollTo({ top: 0 }));
+	await page.getByRole("button", { name: "Load earlier (100/2000)" }).click();
+	await expect.poll(() => requestedSearchOffsets.has(1550)).toBe(true);
+	await expect(page.getByRole("button", { name: "Load earlier (200/2000)" })).toBeVisible();
+	const stableScrollTop = await scrollContainer.evaluate((element) => element.scrollTop);
+	await page.evaluate(
+		() =>
+			new Promise<void>((resolve) => {
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+			}),
+	);
+	const settledScrollTop = await scrollContainer.evaluate((element) => element.scrollTop);
+	expect(Math.abs(settledScrollTop - stableScrollTop)).toBeLessThan(2);
+	const currentMatchInViewport = await current.evaluateAll((elements) =>
+		elements.some((element) => {
+			const bounds = element.getBoundingClientRect();
+			return bounds.bottom > 0 && bounds.top < window.innerHeight;
+		}),
+	);
+	expect(currentMatchInViewport).toBe(false);
 });

--- a/apps/web/src/components/sessions/message-list.tsx
+++ b/apps/web/src/components/sessions/message-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CheckCircle2, ChevronRight, CircleX, Terminal, Wrench } from "lucide-react";
-import { type Ref, useState } from "react";
+import { useState } from "react";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import { agentTypeLabel } from "@/components/dashboard/agent-label";
 import { Markdown } from "@/components/markdown";
@@ -89,7 +89,6 @@ function MessageBlock({
 	agentType,
 	isGroupStart,
 	isHighlighted,
-	highlightedRef,
 	highlightQuery,
 	deferOffscreenRendering,
 }: {
@@ -106,7 +105,6 @@ function MessageBlock({
 	 */
 	isGroupStart: boolean;
 	isHighlighted?: boolean;
-	highlightedRef?: Ref<HTMLDivElement>;
 	highlightQuery?: string;
 	deferOffscreenRendering: boolean;
 }) {
@@ -117,7 +115,6 @@ function MessageBlock({
 		// `group` lives on the whole row so the continuation-row hover
 		// timestamp reveals from a hover anywhere on the message.
 		<div
-			ref={isHighlighted ? highlightedRef : undefined}
 			data-search-match={isHighlighted ? "true" : undefined}
 			aria-current={isHighlighted ? "location" : undefined}
 			className={cn(
@@ -488,7 +485,6 @@ export interface SessionTimelineListProps {
 	userAvatar?: string;
 	userName: string;
 	highlightedMessageKey?: string | null;
-	highlightedMessageRef?: Ref<HTMLDivElement>;
 	highlightQuery?: string;
 }
 
@@ -582,7 +578,6 @@ export function SessionTimelineRowView({
 	userAvatar,
 	userName,
 	highlightedMessageKey,
-	highlightedMessageRef,
 	highlightQuery,
 	deferOffscreenRendering,
 }: Omit<SessionTimelineListProps, "items" | "itemKeys"> & {
@@ -602,7 +597,6 @@ export function SessionTimelineRowView({
 						agentType={agentType}
 						isGroupStart={row.isGroupStart}
 						isHighlighted={isHighlighted}
-						highlightedRef={isHighlighted ? highlightedMessageRef : undefined}
 						highlightQuery={highlightQuery}
 						deferOffscreenRendering={deferOffscreenRendering}
 					/>
@@ -635,7 +629,6 @@ export function SessionTimelineList(props: SessionTimelineListProps) {
 					userAvatar={props.userAvatar}
 					userName={props.userName}
 					highlightedMessageKey={props.highlightedMessageKey}
-					highlightedMessageRef={props.highlightedMessageRef}
 					highlightQuery={props.highlightQuery}
 					deferOffscreenRendering
 				/>

--- a/apps/web/src/components/sessions/virtualized-message-list.tsx
+++ b/apps/web/src/components/sessions/virtualized-message-list.tsx
@@ -18,6 +18,8 @@ interface VirtualizedSessionTimelineListProps extends SessionTimelineListProps {
 	hasMoreItems: boolean;
 	isLoadingMore: boolean;
 	onLoadMore: () => void;
+	highlightScrollRequestKey?: string | null;
+	latestScrollRequestId?: number;
 }
 
 /**
@@ -40,6 +42,11 @@ export function VirtualizedSessionTimelineList(props: VirtualizedSessionTimeline
 	const highlightedRowIndex = props.highlightedMessageKey
 		? rows.findIndex((row) => row.rowKey === props.highlightedMessageKey)
 		: -1;
+	const initialHighlightedRowIndex = props.highlightScrollRequestKey ? highlightedRowIndex : -1;
+	const handledScrollRequestRef = useRef<string | null>(
+		initialHighlightedRowIndex >= 0 ? (props.highlightScrollRequestKey ?? null) : null,
+	);
+	const handledLatestScrollRequestRef = useRef(props.latestScrollRequestId ?? 0);
 	// `firstItemIndex` is React Virtuoso's documented inverse-scrolling
 	// contract. It decreases by exactly the number of visual rows prepended,
 	// preserving the viewport while older pages load above the conversation.
@@ -58,16 +65,36 @@ export function VirtualizedSessionTimelineList(props: VirtualizedSessionTimeline
 	}, []);
 
 	useEffect(() => {
-		if (!scrollParent || highlightedRowIndex < 0) return;
-		const frame = requestAnimationFrame(() => {
-			virtuosoRef.current?.scrollToIndex({
-				index: highlightedRowIndex,
-				align: "center",
-				behavior: "smooth",
-			});
+		const requestKey = props.highlightScrollRequestKey;
+		if (!requestKey) {
+			handledScrollRequestRef.current = null;
+			return;
+		}
+		const virtuoso = virtuosoRef.current;
+		if (!scrollParent || highlightedRowIndex < 0 || !virtuoso) return;
+		if (handledScrollRequestRef.current === requestKey) return;
+		handledScrollRequestRef.current = requestKey;
+		virtuoso.scrollToIndex({
+			index: highlightedRowIndex,
+			align: "center",
+			behavior: "smooth",
 		});
-		return () => cancelAnimationFrame(frame);
-	}, [highlightedRowIndex, scrollParent]);
+	}, [highlightedRowIndex, props.highlightScrollRequestKey, scrollParent]);
+
+	useEffect(() => {
+		const requestId = props.latestScrollRequestId ?? 0;
+		const virtuoso = virtuosoRef.current;
+		if (
+			!scrollParent ||
+			!virtuoso ||
+			rows.length === 0 ||
+			handledLatestScrollRequestRef.current === requestId
+		) {
+			return;
+		}
+		handledLatestScrollRequestRef.current = requestId;
+		virtuoso.scrollToIndex({ index: rows.length - 1, align: "end", behavior: "smooth" });
+	}, [props.latestScrollRequestId, rows.length, scrollParent]);
 
 	if (!scrollParent) return <div aria-hidden className="h-px" />;
 	const usesWindowScroll = scrollParent === window;
@@ -91,8 +118,8 @@ export function VirtualizedSessionTimelineList(props: VirtualizedSessionTimeline
 						: undefined
 				}
 				initialTopMostItemIndex={
-					highlightedRowIndex >= 0
-						? { index: highlightedRowIndex, align: "center" }
+					initialHighlightedRowIndex >= 0
+						? { index: initialHighlightedRowIndex, align: "center" }
 						: props.direction === "asc"
 							? { index: rows.length - 1, align: "end" }
 							: 0
@@ -104,7 +131,6 @@ export function VirtualizedSessionTimelineList(props: VirtualizedSessionTimeline
 						userAvatar={props.userAvatar}
 						userName={props.userName}
 						highlightedMessageKey={props.highlightedMessageKey}
-						highlightedMessageRef={props.highlightedMessageRef}
 						highlightQuery={props.highlightQuery}
 						deferOffscreenRendering={false}
 					/>

--- a/apps/web/src/lib/session-search-anchor.test.ts
+++ b/apps/web/src/lib/session-search-anchor.test.ts
@@ -3,6 +3,8 @@ import {
 	sessionDetailLink,
 	sessionDetailSearchLink,
 	sessionSearchAnchorFromSearch,
+	sessionTimelineCategories,
+	sessionTimelineViewFromCategories,
 	sessionTimelineViewLink,
 	validateSessionDetailSearch,
 } from "@/lib/session-search-anchor";
@@ -100,6 +102,21 @@ describe("Session search anchors", () => {
 			params: { id: "session-id" },
 			search: { timelineView: "tools" },
 		});
+	});
+
+	test("canonicalizes composable timeline categories", () => {
+		expect(validateSessionDetailSearch({ timelineView: "tools,user" })).toEqual({
+			timelineView: "user,tools",
+		});
+		expect(
+			validateSessionDetailSearch({ timelineView: "user,assistant", matchQuery: " answer " }),
+		).toEqual({
+			matchQuery: "answer",
+			timelineView: "user,assistant",
+		});
+		expect(sessionTimelineCategories("all")).toEqual(["user", "assistant", "tools"]);
+		expect(sessionTimelineViewFromCategories(["tools", "assistant"])).toBe("assistant,tools");
+		expect(sessionTimelineViewFromCategories([])).toBeNull();
 	});
 
 	test("drops partial or malformed anchors as one unit", () => {

--- a/apps/web/src/lib/session-search-anchor.ts
+++ b/apps/web/src/lib/session-search-anchor.ts
@@ -2,14 +2,21 @@ import type { SessionListItem } from "@clawdi/shared/api";
 import { SEARCH_QUERY_MAX_LENGTH, searchQueryLength } from "@clawdi/shared/consts";
 
 export type SessionSearchAnchor = NonNullable<SessionListItem["search_match"]>["anchor"];
-export type SessionTimelineView = "all" | "user" | "assistant" | "tools";
+export const SESSION_TIMELINE_CATEGORIES = ["user", "assistant", "tools"] as const;
+export type SessionTimelineCategory = (typeof SESSION_TIMELINE_CATEGORIES)[number];
+type SessionTimelineFilteredView =
+	| SessionTimelineCategory
+	| "user,assistant"
+	| "user,tools"
+	| "assistant,tools";
+export type SessionTimelineView = "all" | SessionTimelineFilteredView;
 
 export interface SessionDetailSearch {
 	matchKind?: SessionSearchAnchor["kind"];
 	matchPosition?: number;
 	matchRevision?: string;
 	matchQuery?: string;
-	timelineView?: Exclude<SessionTimelineView, "all">;
+	timelineView?: SessionTimelineFilteredView;
 	returnTo?: string;
 }
 
@@ -25,23 +32,59 @@ function validPosition(value: unknown): number | undefined {
 	return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
 }
 
-export function parseSessionTimelineView(
-	value: unknown,
-): Exclude<SessionTimelineView, "all"> | undefined {
-	return value === "user" || value === "assistant" || value === "tools" ? value : undefined;
+export function parseSessionTimelineView(value: unknown): SessionTimelineFilteredView | undefined {
+	if (typeof value !== "string") return undefined;
+	const values = value.split(",");
+	if (
+		values.length === 0 ||
+		values.some(
+			(category) => !SESSION_TIMELINE_CATEGORIES.includes(category as SessionTimelineCategory),
+		)
+	) {
+		return undefined;
+	}
+	const view = sessionTimelineViewFromCategories(values);
+	return view === "all" || view === null ? undefined : view;
+}
+
+export function sessionTimelineCategories(view: SessionTimelineView): SessionTimelineCategory[] {
+	return view === "all"
+		? [...SESSION_TIMELINE_CATEGORIES]
+		: (view.split(",") as SessionTimelineCategory[]);
+}
+
+export function sessionTimelineViewFromCategories(
+	values: readonly string[],
+): SessionTimelineView | null {
+	const selected = new Set(
+		values.filter((value): value is SessionTimelineCategory =>
+			SESSION_TIMELINE_CATEGORIES.includes(value as SessionTimelineCategory),
+		),
+	);
+	if (selected.size === 0) return null;
+	if (selected.size === SESSION_TIMELINE_CATEGORIES.length) return "all";
+	return SESSION_TIMELINE_CATEGORIES.filter((category) => selected.has(category)).join(
+		",",
+	) as SessionTimelineFilteredView;
+}
+
+export function sessionTimelineIncludesMessages(view: SessionTimelineView): boolean {
+	return sessionTimelineCategories(view).some((category) => category !== "tools");
 }
 
 export function validateSessionDetailSearch(search: Record<string, unknown>): SessionDetailSearch {
 	const returnTo = normalizeSessionListReturnTo(search.returnTo);
 	const timelineView = parseSessionTimelineView(search.timelineView);
 	const matchQuery =
-		timelineView === "tools" ? undefined : normalizeSessionMatchQuery(search.matchQuery);
+		timelineView && !sessionTimelineIncludesMessages(timelineView)
+			? undefined
+			: normalizeSessionMatchQuery(search.matchQuery);
 	const standalone = {
 		...(matchQuery ? { matchQuery } : {}),
 		...(timelineView ? { timelineView } : {}),
 		...(returnTo ? { returnTo } : {}),
 	};
-	if (timelineView === "tools") return standalone;
+	if (timelineView && !sessionTimelineIncludesMessages(timelineView)) return standalone;
 	const kind =
 		search.matchKind === "snapshot_offset" || search.matchKind === "event_seq"
 			? search.matchKind
@@ -70,7 +113,9 @@ export function sessionTimelineViewLink(
 	options: { returnTo?: string; searchQuery?: string } = {},
 ): SessionDetailLink {
 	const returnTo = normalizeSessionListReturnTo(options.returnTo);
-	const matchQuery = view === "tools" ? undefined : normalizeSessionMatchQuery(options.searchQuery);
+	const matchQuery = sessionTimelineIncludesMessages(view)
+		? normalizeSessionMatchQuery(options.searchQuery)
+		: undefined;
 	return {
 		to: "/sessions/$id" as const,
 		params: { id: sessionId },
@@ -90,7 +135,10 @@ export function sessionDetailSearchLink(
 	const returnTo = normalizeSessionListReturnTo(options.returnTo);
 	const timelineView =
 		options.timelineView === "all" ? undefined : parseSessionTimelineView(options.timelineView);
-	const matchQuery = timelineView === "tools" ? undefined : normalizeSessionMatchQuery(query);
+	const matchQuery =
+		!timelineView || sessionTimelineIncludesMessages(timelineView)
+			? normalizeSessionMatchQuery(query)
+			: undefined;
 	return {
 		to: "/sessions/$id" as const,
 		params: { id: sessionId },
@@ -167,7 +215,7 @@ export function sessionSearchMatchLink(
 	const returnTo = normalizeSessionListReturnTo(options.returnTo);
 	const timelineView =
 		options.timelineView === "all" ? undefined : parseSessionTimelineView(options.timelineView);
-	if (timelineView === "tools") {
+	if (timelineView && !sessionTimelineIncludesMessages(timelineView)) {
 		return sessionTimelineViewLink(sessionId, timelineView, { returnTo });
 	}
 	const matchQuery = normalizeSessionMatchQuery(options.searchQuery);

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -42,6 +42,7 @@ import { TimeTooltip } from "@/components/time-tooltip";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Separator } from "@/components/ui/separator";
+import { useSidebar } from "@/components/ui/sidebar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { agentDetailQueryOptions } from "@/lib/agent-queries";
@@ -67,6 +68,9 @@ import {
 import {
 	type SessionSearchAnchor,
 	type SessionTimelineView,
+	sessionTimelineCategories,
+	sessionTimelineIncludesMessages,
+	sessionTimelineViewFromCategories,
 	sessionTimelineViewLink,
 } from "@/lib/session-search-anchor";
 import { useDebouncedValue } from "@/lib/use-debounced";
@@ -212,8 +216,11 @@ export function SessionDetailContent({
 	// Layout effects run before the messages query subscribes, so a stored
 	// "desc" swaps the presentation before paint without a second fetch.
 	const [direction, setDirection] = useState<SessionMessageDirection>("asc");
+	const [latestScrollRequestId, setLatestScrollRequestId] = useState(0);
 	const normalizedSearchQuery = searchQuery?.trim() ?? "";
 	const rememberedSearchQueryRef = useRef(normalizedSearchQuery);
+	const timelineCategories = sessionTimelineCategories(timelineView);
+	const searchableTimeline = sessionTimelineIncludesMessages(timelineView);
 	const effectiveSearchQuery = isSearchQueryReady(normalizedSearchQuery)
 		? normalizedSearchQuery
 		: "";
@@ -250,6 +257,7 @@ export function SessionDetailContent({
 		hasNextPage,
 		isFetchingNextPage,
 		isFetching: isContentFetching,
+		isPlaceholderData: isContentPlaceholderData,
 	} = useInfiniteQuery({
 		queryKey: [
 			"session-messages",
@@ -272,7 +280,8 @@ export function SessionDetailContent({
 							offset: pageParam,
 							limit: SESSION_MESSAGE_PAGE_SIZE,
 							direction: SESSION_MESSAGE_API_DIRECTION,
-							view: timelineView,
+							view: "all",
+							...(timelineView === "all" ? {} : { include: timelineCategories }),
 							...(pageParam === 0 && searchAnchor
 								? {
 										anchor_kind: searchAnchor.kind,
@@ -327,33 +336,33 @@ export function SessionDetailContent({
 	const anchorOffset = pagesData?.pages[0]?.anchor_offset;
 	const highlightedMessageKey =
 		typeof anchorOffset === "number" ? `${SESSION_MESSAGE_API_DIRECTION}:${anchorOffset}` : null;
-	const highlightedMessageRef = useRef<HTMLDivElement | null>(null);
-	const handledAnchorRef = useRef<string | null>(null);
+	const notifiedStaleAnchorRef = useRef<string | null>(null);
 	const searchNavigation = pagesData?.pages[0]?.search_navigation;
 	const resolvedSearchAnchor = searchNavigation?.current ?? searchAnchor;
 	const anchorIdentity = resolvedSearchAnchor
 		? `${resolvedSearchAnchor.kind}:${resolvedSearchAnchor.position}:${resolvedSearchAnchor.revision}`
 		: null;
+	const highlightScrollRequestKey =
+		!isContentPlaceholderData && anchorIdentity && highlightedMessageKey
+			? JSON.stringify([
+					anchorIdentity,
+					highlightedMessageKey,
+					debouncedSearchQuery ?? null,
+					timelineView,
+				])
+			: null;
 
 	useEffect(() => {
-		if (!anchorIdentity || !pagesData) return;
-		if (highlightedMessageKey) {
-			const handled = `resolved:${highlightedMessageKey}:${anchorIdentity}`;
-			if (handledAnchorRef.current === handled) return;
-			handledAnchorRef.current = handled;
-			const frame = requestAnimationFrame(() => {
-				highlightedMessageRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
-			});
-			return () => cancelAnimationFrame(frame);
+		if (!anchorIdentity || !pagesData || isContentPlaceholderData || highlightedMessageKey) {
+			return;
 		}
-		const handled = `stale:${anchorIdentity}`;
-		if (handledAnchorRef.current !== handled) {
-			handledAnchorRef.current = handled;
+		if (notifiedStaleAnchorRef.current !== anchorIdentity) {
+			notifiedStaleAnchorRef.current = anchorIdentity;
 			toast.info("Search result changed", {
 				description: "This Session has newer content, so the conversation opened normally.",
 			});
 		}
-	}, [anchorIdentity, highlightedMessageKey, pagesData]);
+	}, [anchorIdentity, highlightedMessageKey, isContentPlaceholderData, pagesData]);
 
 	// Hooks must run on every render in the same order — this includes the
 	// breadcrumb title hook. Compute the title (nullable while loading) and
@@ -411,13 +420,12 @@ export function SessionDetailContent({
 			(isContentFetching && !isFetchingNextPage) ||
 			isContentLoading);
 	const updateTimelineView = (selected: SessionTimelineView) => {
-		if (timelineView !== "tools") {
+		if (searchableTimeline) {
 			rememberedSearchQueryRef.current = normalizedSearchQuery;
 		}
-		const retainedSearchQuery =
-			selected === "tools"
-				? undefined
-				: normalizedSearchQuery || rememberedSearchQueryRef.current || undefined;
+		const retainedSearchQuery = !sessionTimelineIncludesMessages(selected)
+			? undefined
+			: normalizedSearchQuery || rememberedSearchQueryRef.current || undefined;
 		if (agentId) {
 			const search = {
 				...(retainedSearchQuery ? { matchQuery: retainedSearchQuery } : {}),
@@ -541,10 +549,10 @@ export function SessionDetailContent({
 					<div
 						className={cn(
 							"grid min-w-0 gap-2 md:items-center",
-							timelineView === "tools" ? "md:grid-cols-1" : "md:grid-cols-[minmax(16rem,1fr)_auto]",
+							searchableTimeline ? "md:grid-cols-[minmax(16rem,1fr)_auto]" : "md:grid-cols-1",
 						)}
 					>
-						{timelineView === "tools" ? null : (
+						{searchableTimeline ? (
 							<SessionSearchNavigation
 								sessionId={sessionId}
 								agentId={agentId}
@@ -557,25 +565,19 @@ export function SessionDetailContent({
 								className="md:max-w-xl"
 								maxLength={SEARCH_QUERY_MAX_LENGTH}
 							/>
-						)}
+						) : null}
 						<div
 							className={cn(
 								"flex min-h-9 min-w-0 items-center justify-between gap-2 md:justify-end",
-								timelineView === "tools" && "md:justify-self-end",
+								!searchableTimeline && "md:justify-self-end",
 							)}
 						>
 							<ToggleGroup
-								value={[timelineView]}
+								multiple
+								value={timelineCategories}
 								onValueChange={(values) => {
-									const selected = values[0];
-									if (
-										selected === "all" ||
-										selected === "user" ||
-										selected === "assistant" ||
-										selected === "tools"
-									) {
-										updateTimelineView(selected);
-									}
+									const selected = sessionTimelineViewFromCategories(values);
+									if (selected) updateTimelineView(selected);
 								}}
 								variant="outline"
 								size="sm"
@@ -583,9 +585,6 @@ export function SessionDetailContent({
 								aria-label="Timeline view"
 								className="min-w-0"
 							>
-								<ToggleGroupItem value="all" aria-label="All activity" title="All activity">
-									<MessageSquare /> <span className="hidden sm:inline">All</span>
-								</ToggleGroupItem>
 								<ToggleGroupItem value="user" aria-label="Your messages" title="Your messages">
 									<UserRound /> <span className="hidden sm:inline">You</span>
 								</ToggleGroupItem>
@@ -656,13 +655,14 @@ export function SessionDetailContent({
 							userAvatar={user?.imageUrl}
 							userName={user?.fullName || "You"}
 							highlightedMessageKey={highlightedMessageKey}
-							highlightedMessageRef={highlightedMessageRef}
+							highlightScrollRequestKey={highlightScrollRequestKey}
 							highlightQuery={debouncedSearchQuery}
 							direction={direction}
 							totalItemCount={totalItems}
 							hasMoreItems={Boolean(hasNextPage)}
 							isLoadingMore={isFetchingNextPage}
 							onLoadMore={loadMoreMessages}
+							latestScrollRequestId={latestScrollRequestId}
 						/>
 						{direction === "desc" && hasNextPage ? (
 							<LoadMoreControl
@@ -700,7 +700,7 @@ export function SessionDetailContent({
 			    list. In desc mode the newest is already at the top,
 			    so there's nothing to jump to. */}
 			{direction === "asc" && timelineItems && timelineItems.length > 20 ? (
-				<JumpToBottomButton />
+				<JumpToBottomButton onJump={() => setLatestScrollRequestId((requestId) => requestId + 1)} />
 			) : null}
 		</div>
 	);
@@ -711,20 +711,16 @@ export function SessionDetailContent({
  * comment threads — when you've scrolled up in a long conversation,
  * the latest message becomes hard to find.
  *
- * Scroll source: the dashboard's actual scroll container is
- * `SidebarInset` (with `overflow-y-auto`), NOT `window`. Listening
- * on `window` made the button invisible and `window.scrollTo`
- * scrolled the wrong target. We walk up the DOM looking for the
- * nearest scrollable ancestor at mount time, then bind there.
+ * Visibility follows the dashboard's actual scroll container. The button
+ * emits a request; Virtuoso remains the sole owner of scroll positioning.
  */
-function JumpToBottomButton() {
+function JumpToBottomButton({ onJump }: { onJump: () => void }) {
+	const { state: sidebarState } = useSidebar();
 	const [visible, setVisible] = useState(false);
-	const scrollerRef = useRef<HTMLElement | Window | null>(null);
 	const anchorRef = useRef<HTMLDivElement | null>(null);
 
 	useEffect(() => {
 		const scroller = findScrollableContainer(anchorRef.current?.parentElement ?? null);
-		scrollerRef.current = scroller;
 
 		const onScroll = () => {
 			let scrollBottom: number;
@@ -741,16 +737,6 @@ function JumpToBottomButton() {
 		return () => scroller.removeEventListener("scroll", onScroll);
 	}, []);
 
-	const onJump = () => {
-		const scroller = scrollerRef.current;
-		if (!scroller) return;
-		if (scroller instanceof Window) {
-			window.scrollTo({ top: document.documentElement.scrollHeight, behavior: "smooth" });
-		} else {
-			scroller.scrollTo({ top: scroller.scrollHeight, behavior: "smooth" });
-		}
-	};
-
 	return (
 		<>
 			{/* Anchor used at mount to locate the scrollable ancestor.
@@ -758,16 +744,25 @@ function JumpToBottomButton() {
 			    at a valid node for the lifetime of the component. */}
 			<div ref={anchorRef} aria-hidden className="hidden" />
 			{visible ? (
-				<Button
-					type="button"
-					variant="secondary"
-					size="sm"
-					className="fixed bottom-6 right-6 z-20 shadow-md"
-					onClick={onJump}
+				<div
+					className={cn(
+						"pointer-events-none fixed inset-x-0 bottom-6 z-20 flex justify-center md:right-2",
+						sidebarState === "expanded"
+							? "md:left-[calc(var(--clawdi-rail-width)+var(--sidebar-width))]"
+							: "md:left-[calc(var(--clawdi-rail-width)+var(--spacing)*2)]",
+					)}
 				>
-					<ArrowDown className="size-4" />
-					Jump to latest
-				</Button>
+					<Button
+						type="button"
+						variant="secondary"
+						size="sm"
+						className="pointer-events-auto shadow-md"
+						onClick={onJump}
+					>
+						<ArrowDown className="size-4" />
+						Jump to latest
+					</Button>
+				</div>
 			) : null}
 		</>
 	);

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -3019,6 +3019,13 @@ async def get_session_messages(
     limit: int = Query(default=100, ge=1, le=500),
     direction: Literal["asc", "desc"] = Query(default="asc"),
     view: Literal["messages", "all", "user", "assistant", "tools"] = Query(default="messages"),
+    include: list[Literal["user", "assistant", "tools"]] | None = Query(
+        default=None,
+        description=(
+            "Composable timeline categories. When present, this takes precedence "
+            "over view and returns the typed timeline projection."
+        ),
+    ),
     anchor_kind: Literal["snapshot_offset", "event_seq"] | None = Query(default=None),
     anchor_position: int | None = Query(default=None, ge=0),
     anchor_revision: str | None = Query(default=None, min_length=1, max_length=80),
@@ -3031,8 +3038,9 @@ async def get_session_messages(
     `GET /v1/sessions/{id}/content` to grab the full JSON blob;
     this endpoint slices the same blob server-side so the
     dashboard doesn't ship 10+ MB of messages on a long session. The default
-    `view=messages` preserves the historical response exactly. Other views add
-    a typed message/tool timeline without exposing reasoning or hidden events.
+    `view=messages` preserves the historical response exactly. Other views and
+    the composable `include` filter add a typed message/tool timeline without
+    exposing reasoning or hidden events.
 
     Pagination is offset-based within the requested direction. `offset=0`
     starts at the oldest visible message for ascending reads and at the newest
@@ -3080,7 +3088,16 @@ async def get_session_messages(
             status.HTTP_500_INTERNAL_SERVER_ERROR, "Internal server error"
         ) from None
 
-    if view == "messages":
+    if include is not None:
+        included_categories = frozenset(include)
+    elif view == "messages":
+        included_categories = None
+    elif view == "all":
+        included_categories = frozenset(("user", "assistant", "tools"))
+    else:
+        included_categories = frozenset((view,))
+
+    if included_categories is None:
         projected_items = projection.messages
         source_positions = projection.source_positions
     else:
@@ -3092,9 +3109,12 @@ async def get_session_messages(
                 strict=True,
             )
             if (
-                view == "all"
-                or (view == "tools" and item.get("kind") in ("tool_call", "tool_result"))
-                or (view in ("user", "assistant") and item.get("role") == view)
+                (item.get("role") == "user" and "user" in included_categories)
+                or (item.get("role") == "assistant" and "assistant" in included_categories)
+                or (
+                    "tools" in included_categories
+                    and item.get("kind") in ("tool_call", "tool_result")
+                )
             )
         ]
         projected_items = [item for item, _ in filtered_timeline]
@@ -3113,14 +3133,10 @@ async def get_session_messages(
     resolved_anchor_revision = anchor_revision
     navigation = None
     search_roles: tuple[SearchRole, ...] | None
-    if view == "user":
-        search_roles = ("user",)
-    elif view == "assistant":
-        search_roles = ("assistant",)
-    elif view == "tools":
-        search_roles = ()
-    else:
+    if included_categories is None:
         search_roles = None
+    else:
+        search_roles = tuple(role for role in ("user", "assistant") if role in included_categories)
     if anchor_kind is None and search_query:
         navigation = await session_message_search_navigation(
             db,
@@ -3200,7 +3216,7 @@ async def get_session_messages(
         "anchor_offset": anchor_offset,
         "search_navigation": search_navigation,
     }
-    if view == "messages":
+    if included_categories is None:
         return SessionMessagesPage.model_validate(page_values)
     return SessionTimelinePage.model_validate(page_values)
 

--- a/backend/tests/test_session_events.py
+++ b/backend/tests/test_session_events.py
@@ -695,6 +695,20 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
     assert "private chain of thought" not in latest_timeline.text
     assert "opaque" not in latest_timeline.text
 
+    conversation_only = await client.get(
+        f"/v1/sessions/{session.id}/messages",
+        params=[("view", "tools"), ("include", "user"), ("include", "assistant")],
+    )
+    assert conversation_only.status_code == 200, conversation_only.text
+    assert [item["position"] for item in conversation_only.json()["items"]] == [1, 4, 6]
+
+    agent_and_tools = await client.get(
+        f"/v1/sessions/{session.id}/messages",
+        params=[("include", "assistant"), ("include", "tools")],
+    )
+    assert agent_and_tools.status_code == 200, agent_and_tools.text
+    assert [item["position"] for item in agent_and_tools.json()["items"]] == [2, 3, 4, 6]
+
     # The committed generation now spans three immutable chunks. The read path
     # must use the new event head after both appends instead of serving the
     # two-message projection cached before them.
@@ -753,12 +767,14 @@ async def test_events_v1_strict_append_idempotency_and_safe_projection(
     }
     event_navigation = await client.get(
         f"/v1/sessions/{session.id}/messages",
-        params={
-            "anchor_kind": "event_seq",
-            "anchor_position": 4,
-            "anchor_revision": f"events:{second_head}",
-            "search_query": "answer",
-        },
+        params=[
+            ("include", "assistant"),
+            ("include", "tools"),
+            ("anchor_kind", "event_seq"),
+            ("anchor_position", "4"),
+            ("anchor_revision", f"events:{second_head}"),
+            ("search_query", "answer"),
+        ],
     )
     assert event_navigation.status_code == 200, event_navigation.text
     assert event_navigation.json()["search_navigation"] == {

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1372,8 +1372,9 @@ export interface paths {
          *     `GET /v1/sessions/{id}/content` to grab the full JSON blob;
          *     this endpoint slices the same blob server-side so the
          *     dashboard doesn't ship 10+ MB of messages on a long session. The default
-         *     `view=messages` preserves the historical response exactly. Other views add
-         *     a typed message/tool timeline without exposing reasoning or hidden events.
+         *     `view=messages` preserves the historical response exactly. Other views and
+         *     the composable `include` filter add a typed message/tool timeline without
+         *     exposing reasoning or hidden events.
          *
          *     Pagination is offset-based within the requested direction. `offset=0`
          *     starts at the oldest visible message for ascending reads and at the newest
@@ -11920,6 +11921,8 @@ export interface operations {
                 limit?: number;
                 direction?: "asc" | "desc";
                 view?: "messages" | "all" | "user" | "assistant" | "tools";
+                /** @description Composable timeline categories. When present, this takes precedence over view and returns the typed timeline projection. */
+                include?: ("user" | "assistant" | "tools")[] | null;
                 anchor_kind?: ("snapshot_offset" | "event_seq") | null;
                 anchor_position?: number | null;
                 anchor_revision?: string | null;


### PR DESCRIPTION
## Summary

- make Virtuoso the sole owner of Session timeline positioning so prepending older pages preserves the viewport and does not replay search navigation
- center Jump to latest in the dashboard content area and route explicit jumps through Virtuoso
- replace the exclusive timeline view with composable You, Agent, and Tools toggles backed by one server-side filter contract for pagination, totals, and search navigation

## Verification

- Web typecheck, focused unit tests, and OSS client/server build in an isolated runner
- backend migrations plus `backend/tests/test_session_events.py` (`10 passed`) against isolated PostgreSQL
- Playwright Chromium `session-search-navigation.pw.ts` (`4 passed`), including long-list prepend stability and jump centering
- Biome, Ruff check/format, generated API consistency, and `git diff --check`
