### PR TITLE
fix(web): isolate session interaction state

### DIFF
--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -581,6 +581,7 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 	).toBeLessThan(2);
 	await jumpToLatest.click();
 	await expect(page.getByText(/^Timeline message 499 /)).toBeInViewport();
+	await expect(jumpToLatest).not.toBeVisible();
 	const mountedRows = page.locator(
 		'[data-testid="virtualized-session-timeline"] [data-item-index]',
 	);

--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -498,6 +498,13 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 	const searchAnchorOffset = searchWindowOffset + 49;
 	const requestedOffsets = new Set<number>();
 	const requestedSearchOffsets = new Set<number>();
+	const waitForTimelineLayout = () =>
+		page.evaluate(
+			() =>
+				new Promise<void>((resolve) => {
+					requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+				}),
+		);
 
 	await page.route("**/v1/**", async (route) => {
 		const url = new URL(route.request().url());
@@ -594,35 +601,34 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 		matchRevision: targetAnchor.revision,
 		matchQuery: query,
 	});
-	await page.goto(`/sessions/${SESSION_ID}?${search}`);
+	const searchUrl = `/sessions/${SESSION_ID}?${search}`;
+	await page.goto(searchUrl);
 	const current = page.locator('[data-search-match="true"]');
 	await expect(current).toContainText(`Current ${query} result stays mounted`);
 	await expect(current.locator("mark")).toHaveText(["virtualized needle"]);
 	expect(await mountedRows.count()).toBeLessThan(80);
 
+	await scrollContainer.evaluate((element) => element.scrollTo({ top: 0 }));
+	const loadEarlier = page.getByRole("button", { name: /^Load earlier/ });
+	await waitForTimelineLayout();
+	await expect(current).not.toBeInViewport();
+	if (!requestedSearchOffsets.has(1550)) {
+		await loadEarlier.press("Enter");
+	}
+	await expect.poll(() => requestedSearchOffsets.has(1550)).toBe(true);
+	await expect(page.getByRole("button", { name: /^Load earlier \(\d+\/2000\)$/ })).toBeVisible();
+	await expect
+		.poll(async () => {
+			const before = await scrollContainer.evaluate((element) => element.scrollTop);
+			await waitForTimelineLayout();
+			const after = await scrollContainer.evaluate((element) => element.scrollTop);
+			return Math.abs(after - before);
+		})
+		.toBeLessThan(2);
+	await expect(current).not.toBeInViewport();
+
 	await page.setViewportSize({ width: 390, height: 844 });
+	await page.goto(searchUrl);
 	await expect(current).toBeVisible();
 	expect(await mountedRows.count()).toBeLessThan(80);
-
-	await page.setViewportSize({ width: 1280, height: 900 });
-	await scrollContainer.evaluate((element) => element.scrollTo({ top: 0 }));
-	await page.getByRole("button", { name: "Load earlier (100/2000)" }).click();
-	await expect.poll(() => requestedSearchOffsets.has(1550)).toBe(true);
-	await expect(page.getByRole("button", { name: "Load earlier (200/2000)" })).toBeVisible();
-	const stableScrollTop = await scrollContainer.evaluate((element) => element.scrollTop);
-	await page.evaluate(
-		() =>
-			new Promise<void>((resolve) => {
-				requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-			}),
-	);
-	const settledScrollTop = await scrollContainer.evaluate((element) => element.scrollTop);
-	expect(Math.abs(settledScrollTop - stableScrollTop)).toBeLessThan(2);
-	const currentMatchInViewport = await current.evaluateAll((elements) =>
-		elements.some((element) => {
-			const bounds = element.getBoundingClientRect();
-			return bounds.bottom > 0 && bounds.top < window.innerHeight;
-		}),
-	);
-	expect(currentMatchInViewport).toBe(false);
 });

--- a/apps/web/src/pages/dashboard/agents/agent-session-detail-page.tsx
+++ b/apps/web/src/pages/dashboard/agents/agent-session-detail-page.tsx
@@ -20,6 +20,7 @@ export default function AgentSessionDetailPage({
 }: AgentSessionDetailPageProps) {
 	return (
 		<SessionDetailContent
+			key={sessionId}
 			sessionId={sessionId}
 			agentId={agentId}
 			searchAnchor={searchAnchor}

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -112,6 +112,7 @@ export default function SessionDetailPage({
 }) {
 	return (
 		<SessionDetailContent
+			key={sessionId}
 			sessionId={sessionId}
 			searchAnchor={searchAnchor}
 			searchQuery={searchQuery}
@@ -414,11 +415,10 @@ export function SessionDetailContent({
 
 	const totalTokens = (session.input_tokens ?? 0) + (session.output_tokens ?? 0);
 	const searchActive = Boolean(effectiveSearchQuery);
-	const isSearchUpdating =
-		searchActive &&
-		(effectiveSearchQuery !== debouncedSearchQuery ||
-			(isContentFetching && !isFetchingNextPage) ||
-			isContentLoading);
+	const isSearchDebouncing = effectiveSearchQuery !== (debouncedSearchQuery ?? "");
+	const isTimelineTransitioning =
+		isSearchDebouncing || isContentPlaceholderData || (isContentFetching && !isFetchingNextPage);
+	const isSearchUpdating = searchActive && (isTimelineTransitioning || isContentLoading);
 	const updateTimelineView = (selected: SessionTimelineView) => {
 		if (searchableTimeline) {
 			rememberedSearchQueryRef.current = normalizedSearchQuery;
@@ -699,7 +699,10 @@ export function SessionDetailContent({
 			    where the newest message is at the bottom of a long
 			    list. In desc mode the newest is already at the top,
 			    so there's nothing to jump to. */}
-			{direction === "asc" && timelineItems && timelineItems.length > 20 ? (
+			{direction === "asc" &&
+			timelineItems &&
+			timelineItems.length > 20 &&
+			!isTimelineTransitioning ? (
 				<JumpToBottomButton onJump={() => setLatestScrollRequestId((requestId) => requestId + 1)} />
 			) : null}
 		</div>


### PR DESCRIPTION
## Summary

- remount Session detail interaction state when client-side navigation changes the Session identity
- suppress the jump-to-latest action while search or timeline filters are still transitioning
- assert that the jump control disappears after returning to the latest message

## Verification

- isolated Web typecheck, unit tests, and OSS production build
- focused Chromium Session navigation E2E, including long-list pagination and scroll positioning
- Biome and `git diff --check`
