### PR TITLE
fix(web): jump to the latest session window

### DIFF
--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -497,6 +497,7 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 	const searchAnchorOffset = searchWindowOffset + 49;
 	const requestedOffsets = new Set<number>();
 	const requestedSearchOffsets = new Set<number>();
+	let latestPageRequestCount = 0;
 	const waitForTimelineLayout = () =>
 		page.evaluate(
 			() =>
@@ -533,6 +534,7 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 			const isSearchPagination = offset >= searchWindowOffset;
 			if (!url.searchParams.has("search_query") && !isSearchPagination) {
 				requestedOffsets.add(offset);
+				if (offset === 0) latestPageRequestCount += 1;
 				return fulfillJson(route, {
 					items: browseTimeline.slice(offset, offset + 100),
 					total: browseTimeline.length,
@@ -616,6 +618,8 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 	const current = page.locator('[data-search-match="true"]');
 	await expect(current).toContainText(`Current ${query} result stays mounted`);
 	await expect(current.locator("mark")).toHaveText(["virtualized needle"]);
+	await expect(current).toBeInViewport();
+	await waitForTimelineLayout();
 	expect(await mountedRows.count()).toBeLessThan(80);
 
 	await scrollContainer.evaluate((element) => element.scrollTo({ top: 0 }));
@@ -635,6 +639,28 @@ test("keeps a long anchored timeline windowed across desktop and mobile", async 
 		})
 		.toBeLessThan(2);
 	await expect(current).not.toBeInViewport();
+	const latestRequestsBeforeJump = latestPageRequestCount;
+	await expect(jumpToLatest).toBeVisible();
+	await jumpToLatest.click();
+	await expect(page).toHaveURL((url) => {
+		return (
+			url.pathname === `/sessions/${SESSION_ID}` &&
+			!url.searchParams.has("matchKind") &&
+			!url.searchParams.has("matchPosition") &&
+			!url.searchParams.has("matchRevision") &&
+			!url.searchParams.has("matchQuery")
+		);
+	});
+	await expect.poll(() => latestPageRequestCount).toBeGreaterThan(latestRequestsBeforeJump);
+	await expect(page.getByText(/^Timeline message 499 /)).toBeInViewport();
+	await expect
+		.poll(() =>
+			scrollContainer.evaluate(
+				(element) => element.scrollHeight - element.scrollTop - element.clientHeight,
+			),
+		)
+		.toBeLessThan(2);
+	await expect(jumpToLatest).not.toBeVisible();
 
 	await page.setViewportSize({ width: 390, height: 844 });
 	await page.goto(searchUrl);

--- a/apps/web/src/components/sessions/virtualized-message-list.tsx
+++ b/apps/web/src/components/sessions/virtualized-message-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import {
 	buildSessionTimelineRows,
@@ -14,6 +14,7 @@ const DASHBOARD_SCROLL_CONTAINER_ID = "dashboard-scroll-container";
 
 interface VirtualizedSessionTimelineListProps extends SessionTimelineListProps {
 	totalItemCount: number;
+	windowStartOffset: number;
 	onAtBottomChange?: (atBottom: boolean) => void;
 	highlightScrollRequestKey?: string | null;
 	latestScrollRequestId?: number;
@@ -39,10 +40,16 @@ export function VirtualizedSessionTimelineList(props: VirtualizedSessionTimeline
 		? rows.findIndex((row) => row.rowKey === props.highlightedMessageKey)
 		: -1;
 	const initialHighlightedRowIndex = props.highlightScrollRequestKey ? highlightedRowIndex : -1;
-	const handledScrollRequestRef = useRef<string | null>(
-		initialHighlightedRowIndex >= 0 ? (props.highlightScrollRequestKey ?? null) : null,
-	);
-	const handledLatestScrollRequestRef = useRef(props.latestScrollRequestId ?? 0);
+	const handledScrollRequestRef = useRef<string | null>(null);
+	const issuedLatestScrollRequestRef = useRef(props.latestScrollRequestId ?? 0);
+	const activeLatestScrollRef = useRef<{
+		requestId: number;
+		reachedBottom: boolean;
+		windowKey: string | null;
+	} | null>(null);
+	const [readyWindowKey, setReadyWindowKey] = useState<string | null>(null);
+	const [atBottomWindowKey, setAtBottomWindowKey] = useState<string | null>(null);
+	const [measuredList, setMeasuredList] = useState({ windowKey: null as string | null, height: 0 });
 	// `firstItemIndex` is React Virtuoso's documented inverse-scrolling
 	// contract. It decreases by exactly the number of visual rows prepended,
 	// preserving the viewport while older pages load above the conversation.
@@ -59,14 +66,19 @@ export function VirtualizedSessionTimelineList(props: VirtualizedSessionTimeline
 		return () => window.removeEventListener("resize", resolveScrollParent);
 	}, []);
 
-	useEffect(() => {
+	const windowKey = scrollParent
+		? `${scrollParent === window ? "window" : "container"}:${props.windowStartOffset}`
+		: null;
+	const scrollToHighlight = useCallback(() => {
 		const requestKey = props.highlightScrollRequestKey;
 		if (!requestKey) {
 			handledScrollRequestRef.current = null;
 			return;
 		}
 		const virtuoso = virtuosoRef.current;
-		if (!scrollParent || highlightedRowIndex < 0 || !virtuoso) return;
+		if (!scrollParent || highlightedRowIndex < 0 || !virtuoso || readyWindowKey !== windowKey) {
+			return;
+		}
 		if (handledScrollRequestRef.current === requestKey) return;
 		handledScrollRequestRef.current = requestKey;
 		virtuoso.scrollToIndex({
@@ -74,30 +86,106 @@ export function VirtualizedSessionTimelineList(props: VirtualizedSessionTimeline
 			align: "center",
 			behavior: "smooth",
 		});
-	}, [highlightedRowIndex, props.highlightScrollRequestKey, scrollParent]);
+	}, [
+		highlightedRowIndex,
+		props.highlightScrollRequestKey,
+		readyWindowKey,
+		scrollParent,
+		windowKey,
+	]);
+	useEffect(scrollToHighlight, [scrollToHighlight]);
 
-	useEffect(() => {
+	const syncPageBottom = useCallback(() => {
+		const activeRequest = activeLatestScrollRef.current;
+		if (
+			!scrollParent ||
+			!activeRequest ||
+			activeRequest.requestId !== (props.latestScrollRequestId ?? 0) ||
+			!activeRequest.reachedBottom ||
+			activeRequest.windowKey !== windowKey ||
+			props.windowStartOffset !== 0 ||
+			atBottomWindowKey !== windowKey ||
+			measuredList.windowKey !== windowKey
+		) {
+			return;
+		}
+		const scrollHeight =
+			scrollParent instanceof HTMLElement
+				? scrollParent.scrollHeight
+				: document.documentElement.scrollHeight;
+		// Keep the shared page scroller aligned while Virtuoso settles dynamic
+		// row heights. Scrolling up clears the bottom state and stops following.
+		scrollParent.scrollTo({ top: scrollHeight, behavior: "auto" });
+	}, [
+		atBottomWindowKey,
+		measuredList,
+		props.latestScrollRequestId,
+		props.windowStartOffset,
+		scrollParent,
+		windowKey,
+	]);
+	useEffect(syncPageBottom, [syncPageBottom]);
+
+	const requestLatestScroll = useCallback(() => {
 		const requestId = props.latestScrollRequestId ?? 0;
 		const virtuoso = virtuosoRef.current;
 		if (
 			!scrollParent ||
 			!virtuoso ||
 			rows.length === 0 ||
-			handledLatestScrollRequestRef.current === requestId
+			props.windowStartOffset !== 0 ||
+			readyWindowKey !== windowKey ||
+			issuedLatestScrollRequestRef.current === requestId
 		) {
 			return;
 		}
-		handledLatestScrollRequestRef.current = requestId;
+		issuedLatestScrollRequestRef.current = requestId;
+		activeLatestScrollRef.current = { requestId, reachedBottom: false, windowKey };
 		virtuoso.scrollToIndex({ index: "LAST", align: "end", behavior: "auto" });
-	}, [props.latestScrollRequestId, rows.length, scrollParent]);
+	}, [
+		props.latestScrollRequestId,
+		props.windowStartOffset,
+		readyWindowKey,
+		rows.length,
+		scrollParent,
+		windowKey,
+	]);
+	useEffect(requestLatestScroll, [requestLatestScroll]);
+
+	const handleAtBottomChange = useCallback(
+		(atBottom: boolean) => {
+			const activeRequest = activeLatestScrollRef.current;
+			if (
+				activeRequest?.requestId === (props.latestScrollRequestId ?? 0) &&
+				activeRequest.windowKey === windowKey
+			) {
+				if (atBottom) activeRequest.reachedBottom = true;
+				else if (activeRequest.reachedBottom) activeLatestScrollRef.current = null;
+			}
+			setAtBottomWindowKey(atBottom ? windowKey : null);
+			props.onAtBottomChange?.(atBottom);
+		},
+		[props.latestScrollRequestId, props.onAtBottomChange, windowKey],
+	);
+	const handleTotalListHeightChanged = useCallback(
+		(height: number) => {
+			setMeasuredList({ windowKey, height });
+		},
+		[windowKey],
+	);
+	const handleRangeChanged = useCallback(() => {
+		setReadyWindowKey(windowKey);
+	}, [windowKey]);
 
 	if (!scrollParent) return <div aria-hidden className="h-px" />;
 	const usesWindowScroll = scrollParent === window;
+	// A different first-page offset is a discontinuous server window, not a
+	// prepend. Remount Virtuoso so the new window can apply its initial anchor.
 
 	return (
 		<div data-testid="virtualized-session-timeline">
 			<Virtuoso
-				key={usesWindowScroll ? "window" : "container"}
+				key={windowKey}
 				ref={virtuosoRef}
 				{...(usesWindowScroll
 					? { useWindowScroll: true }
@@ -107,7 +195,9 @@ export function VirtualizedSessionTimelineList(props: VirtualizedSessionTimeline
 				computeItemKey={(_index, row) => row.rowKey}
 				defaultItemHeight={96}
 				increaseViewportBy={{ top: 600, bottom: 900 }}
-				atBottomStateChange={props.onAtBottomChange}
+				atBottomStateChange={handleAtBottomChange}
+				totalListHeightChanged={handleTotalListHeightChanged}
+				rangeChanged={handleRangeChanged}
 				initialTopMostItemIndex={
 					initialHighlightedRowIndex >= 0
 						? { index: initialHighlightedRowIndex, align: "center" }

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -217,7 +217,8 @@ export function SessionDetailContent({
 	const effectiveSearchQuery = isSearchQueryReady(normalizedSearchQuery)
 		? normalizedSearchQuery
 		: "";
-	const debouncedSearchQuery = useDebouncedValue(effectiveSearchQuery, 250) || undefined;
+	const debouncedSearchValue = useDebouncedValue(effectiveSearchQuery, 250);
+	const debouncedSearchQuery = effectiveSearchQuery ? debouncedSearchValue || undefined : undefined;
 
 	// Paginated message fetch via the new `/messages` endpoint.
 	// Long sessions (5k+ messages, 10+ MB JSON) used to ship the
@@ -398,26 +399,20 @@ export function SessionDetailContent({
 	const isTimelineTransitioning =
 		isSearchDebouncing || isContentPlaceholderData || (isContentFetching && !isFetchingNextPage);
 	const isSearchUpdating = searchActive && (isTimelineTransitioning || isContentLoading);
-	const updateTimelineView = (selected: SessionTimelineView) => {
-		if (searchableTimeline) {
-			rememberedSearchQueryRef.current = normalizedSearchQuery;
-		}
-		const retainedSearchQuery = !sessionTimelineIncludesMessages(selected)
-			? undefined
-			: normalizedSearchQuery || rememberedSearchQueryRef.current || undefined;
+	const navigateTimelineView = (selected: SessionTimelineView, retainedSearchQuery?: string) => {
 		if (agentId) {
 			const search = {
 				...(retainedSearchQuery ? { matchQuery: retainedSearchQuery } : {}),
 				...(selected === "all" ? {} : { timelineView: selected }),
+				...(returnTo ? { returnTo } : {}),
 			};
-			void router.navigate({
+			return router.navigate({
 				...agentSessionDetailLink(agentId, sessionId, search),
 				replace: true,
 				resetScroll: false,
 			});
-			return;
 		}
-		void router.navigate({
+		return router.navigate({
 			...sessionTimelineViewLink(sessionId, selected, {
 				returnTo,
 				searchQuery: retainedSearchQuery,
@@ -426,12 +421,35 @@ export function SessionDetailContent({
 			resetScroll: false,
 		});
 	};
+	const updateTimelineView = (selected: SessionTimelineView) => {
+		if (searchableTimeline) {
+			rememberedSearchQueryRef.current = normalizedSearchQuery;
+		}
+		const retainedSearchQuery = !sessionTimelineIncludesMessages(selected)
+			? undefined
+			: normalizedSearchQuery || rememberedSearchQueryRef.current || undefined;
+		void navigateTimelineView(selected, retainedSearchQuery);
+	};
 	const updateTimelineCategory = (category: SessionTimelineCategory, included: boolean) => {
 		const categories = included
 			? [...timelineCategories, category]
 			: timelineCategories.filter((value) => value !== category);
 		const selected = sessionTimelineViewFromCategories(categories);
 		if (selected) updateTimelineView(selected);
+	};
+	const jumpToLatest = () => {
+		if (pagesData?.pages[0]?.offset === 0) {
+			setLatestScrollRequestId((requestId) => requestId + 1);
+			return;
+		}
+		rememberedSearchQueryRef.current = "";
+		void navigateTimelineView(timelineView).then(
+			() => setLatestScrollRequestId((requestId) => requestId + 1),
+			() => {
+				rememberedSearchQueryRef.current = normalizedSearchQuery;
+				toast.error("Couldn't open latest messages");
+			},
+		);
 	};
 
 	return (
@@ -624,6 +642,7 @@ export function SessionDetailContent({
 							highlightScrollRequestKey={highlightScrollRequestKey}
 							highlightQuery={debouncedSearchQuery}
 							totalItemCount={totalItems}
+							windowStartOffset={pagesData?.pages[0]?.offset ?? 0}
 							onAtBottomChange={setIsTimelineAtBottom}
 							latestScrollRequestId={latestScrollRequestId}
 						/>
@@ -655,7 +674,7 @@ export function SessionDetailContent({
 			timelineItems.length > 0 &&
 			!isTimelineAtBottom &&
 			!isTimelineTransitioning ? (
-				<JumpToBottomButton onJump={() => setLatestScrollRequestId((requestId) => requestId + 1)} />
+				<JumpToBottomButton onJump={jumpToLatest} />
 			) : null}
 		</div>
 	);


### PR DESCRIPTION
## Summary

- reload the true latest message window when jumping from a search anchor
- coordinate search and latest positioning with React Virtuoso readiness signals
- keep bottom alignment through dynamic row measurement without interrupting upward history browsing

## Verification

- Web TypeScript typecheck
- Web unit tests: 1108 passed
- OSS client/server build
- Session search navigation Playwright: 4 passed
- Biome check and git diff check