### PR TITLE
fix(sessions): optimize list search requests

### DIFF
--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -52,6 +52,93 @@ async function horizontalBounds(locator: Locator) {
 	});
 }
 
+test("commits Session search keys atomically before prefetching", async ({ page }) => {
+	type ListRequest = { q: string | null; sort: string | null; page: string | null };
+	const requests: ListRequest[] = [];
+	let heldQuery: string | null | undefined;
+	let heldRequestStarted: (() => void) | undefined;
+	let releaseHeldRequest: (() => void) | undefined;
+	let heldRequestGate = Promise.resolve();
+
+	function holdPageOne(query: string | null) {
+		heldQuery = query;
+		const started = new Promise<void>((resolve) => {
+			heldRequestStarted = resolve;
+		});
+		heldRequestGate = new Promise<void>((resolve) => {
+			releaseHeldRequest = resolve;
+		});
+		return {
+			started,
+			release: () => {
+				heldQuery = undefined;
+				releaseHeldRequest?.();
+			},
+		};
+	}
+
+	await page.route("**/v1/**", async (route) => {
+		const url = new URL(route.request().url());
+		if (url.pathname === "/v1/agents") return fulfillJson(route, []);
+		if (url.pathname === "/v1/sessions") {
+			const request = {
+				q: url.searchParams.get("q"),
+				sort: url.searchParams.get("sort"),
+				page: url.searchParams.get("page"),
+			};
+			requests.push(request);
+			if (request.page === "1" && request.q === heldQuery) {
+				heldRequestStarted?.();
+				await heldRequestGate;
+			}
+			return fulfillJson(route, {
+				items: [],
+				total: 51,
+				page: Number(request.page),
+				page_size: 25,
+			});
+		}
+		return fulfillJson(route, {});
+	});
+
+	await page.goto("/sessions?q=initial%20needle&sort=relevance&page=2");
+	const search = page.getByPlaceholder("Search sessions and messages…");
+	await expect(search).toHaveValue("initial needle");
+	await expect
+		.poll(() => requests.some((request) => request.q === "initial needle" && request.page === "3"))
+		.toBe(true);
+
+	requests.length = 0;
+	const clearRequest = holdPageOne(null);
+	await search.fill("");
+	await expect(page).toHaveURL((url) => !url.searchParams.has("q") && !url.searchParams.has("sort"));
+	await clearRequest.started;
+	await page.evaluate(
+		() => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))),
+	);
+	expect(requests).toEqual([{ q: null, sort: "last_activity_at", page: "1" }]);
+	clearRequest.release();
+	await expect
+		.poll(() => requests.some((request) => request.q === null && request.page === "2"))
+		.toBe(true);
+
+	requests.length = 0;
+	const searchRequest = holdPageOne("fresh needle");
+	await search.fill("fresh needle");
+	await expect(page).toHaveURL(
+		(url) => url.searchParams.get("q") === "fresh needle" && url.searchParams.get("sort") === "relevance",
+	);
+	await searchRequest.started;
+	await page.evaluate(
+		() => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))),
+	);
+	expect(requests).toEqual([{ q: "fresh needle", sort: "relevance", page: "1" }]);
+	searchRequest.release();
+	await expect
+		.poll(() => requests.some((request) => request.q === "fresh needle" && request.page === "2"))
+		.toBe(true);
+});
+
 test("opens a global Session body match at the exact message", async ({ page }) => {
 	const query = "global palette anchor";
 	await page.route("**/v1/**", async (route) => {

--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -111,10 +111,15 @@ test("commits Session search keys atomically before prefetching", async ({ page 
 	requests.length = 0;
 	const clearRequest = holdPageOne(null);
 	await search.fill("");
-	await expect(page).toHaveURL((url) => !url.searchParams.has("q") && !url.searchParams.has("sort"));
+	await expect(page).toHaveURL(
+		(url) => !url.searchParams.has("q") && !url.searchParams.has("sort"),
+	);
 	await clearRequest.started;
 	await page.evaluate(
-		() => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))),
+		() =>
+			new Promise<void>((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+			),
 	);
 	expect(requests).toEqual([{ q: null, sort: "last_activity_at", page: "1" }]);
 	clearRequest.release();
@@ -126,11 +131,15 @@ test("commits Session search keys atomically before prefetching", async ({ page 
 	const searchRequest = holdPageOne("fresh needle");
 	await search.fill("fresh needle");
 	await expect(page).toHaveURL(
-		(url) => url.searchParams.get("q") === "fresh needle" && url.searchParams.get("sort") === "relevance",
+		(url) =>
+			url.searchParams.get("q") === "fresh needle" && url.searchParams.get("sort") === "relevance",
 	);
 	await searchRequest.started;
 	await page.evaluate(
-		() => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))),
+		() =>
+			new Promise<void>((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+			),
 	);
 	expect(requests).toEqual([{ q: "fresh needle", sort: "relevance", page: "1" }]);
 	searchRequest.release();

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -103,9 +103,15 @@ function SessionsListInner() {
 		{ clearOnDefault: true, history: "replace" },
 	);
 
-	const debouncedSearch = useDebouncedValue(params.q, 250);
+	const searchRequest = useMemo(
+		() => ({ query: params.q, sort: params.sort, order: params.order, page: params.page }),
+		[params.order, params.page, params.q, params.sort],
+	);
+	const debouncedSearchRequest = useDebouncedValue(searchRequest, 250);
+	const isSearchRequestPending = params.q !== debouncedSearchRequest.query;
+	const requestSearchState = isSearchRequestPending ? debouncedSearchRequest : searchRequest;
 	const draftSearchQuery = params.q.trim();
-	const debouncedSearchQuery = debouncedSearch.trim();
+	const debouncedSearchQuery = requestSearchState.query.trim();
 	const searchQuery = isSearchQueryReady(debouncedSearchQuery) ? debouncedSearchQuery : "";
 	const draftSearchLength = searchQueryLength(draftSearchQuery);
 	const searchQueryError =
@@ -136,11 +142,11 @@ function SessionsListInner() {
 
 	const sessionQuery = useMemo<SessionListQuery>(
 		() => ({
-			page: params.page,
+			page: requestSearchState.page,
 			page_size: params.pageSize,
 			q: searchQuery || undefined,
-			sort: params.sort,
-			order: params.order,
+			sort: requestSearchState.sort,
+			order: requestSearchState.order,
 			agent: params.agent || undefined,
 			has_pr: params.has_pr,
 			automated: params.automated,
@@ -150,14 +156,14 @@ function SessionsListInner() {
 			params.agent,
 			params.automated,
 			params.has_pr,
-			params.order,
-			params.page,
 			params.pageSize,
-			params.sort,
+			requestSearchState.order,
+			requestSearchState.page,
+			requestSearchState.sort,
 		],
 	);
 
-	const { data, isLoading, isFetching, error, refetch } = useQuery({
+	const { data, isLoading, isFetching, isPlaceholderData, error, refetch } = useQuery({
 		...sessionListQueryOptions($api, sessionQuery),
 		// Keep the previous page visible while search, filters, or pagination
 		// move to a new query key.
@@ -206,14 +212,36 @@ function SessionsListInner() {
 	const pageCount = Math.max(1, Math.ceil(total / params.pageSize));
 	const isListUpdating =
 		data !== undefined &&
-		((isSearchQueryReady(draftSearchQuery) && draftSearchQuery !== searchQuery) || isFetching);
+		((isSearchQueryReady(draftSearchQuery) && draftSearchQuery !== searchQuery) ||
+			params.order !== requestSearchState.order ||
+			params.page !== requestSearchState.page ||
+			params.sort !== requestSearchState.sort ||
+			isFetching);
 
 	useEffect(() => {
-		if (!data || params.page >= pageCount) return;
+		if (
+			!data ||
+			isSearchRequestPending ||
+			isPlaceholderData ||
+			isFetching ||
+			requestSearchState.page >= pageCount
+		) {
+			return;
+		}
 		void queryClient.prefetchQuery(
-			sessionListQueryOptions($api, { ...sessionQuery, page: params.page + 1 }),
+			sessionListQueryOptions($api, { ...sessionQuery, page: requestSearchState.page + 1 }),
 		);
-	}, [$api, data, pageCount, params.page, queryClient, sessionQuery]);
+	}, [
+		$api,
+		data,
+		isFetching,
+		isPlaceholderData,
+		isSearchRequestPending,
+		pageCount,
+		queryClient,
+		requestSearchState.page,
+		sessionQuery,
+	]);
 
 	const groupable = params.sort === "last_activity_at" || params.sort === "started_at";
 
@@ -326,6 +354,7 @@ function SessionsListInner() {
 									has_pr: null,
 									automated: null,
 									page: 1,
+									sort: params.sort === "relevance" ? "last_activity_at" : params.sort,
 								})
 							}
 						>

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -23,10 +23,11 @@ from fastapi import (
     status,
 )
 from pydantic import BaseModel, Field, JsonValue, TypeAdapter, ValidationError, field_validator
-from sqlalchemy import case, func, or_, select, text, tuple_, update
+from sqlalchemy import case, func, or_, select, text, true, tuple_, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from app.core.auth import (
     AuthContext,
@@ -2575,7 +2576,15 @@ async def list_sessions(
     # IS NULL` makes this lookup index-only.
     is_shared_subq = _link_is_shared_subq()
 
-    search_matches = session_search_matches(auth.user_id, q) if q else None
+    if q:
+        search_match_rows = session_search_matches(auth.user_id, q)
+        search_matches = (
+            select(*search_match_rows.c)
+            .cte("materialized_session_search_matches")
+            .prefix_with("MATERIALIZED")
+        )
+    else:
+        search_matches = None
 
     base = select(
         Session,
@@ -2668,8 +2677,6 @@ async def list_sessions(
             AgentEnvironment,
             Session.environment_id == AgentEnvironment.id,
         ).where(agent_filter)
-    total = (await db.execute(select(func.count()).select_from(count_base.subquery()))).scalar_one()
-
     # Resolve sort column. `relevance` is special — only valid when
     # `q` is present (else fall back to the date default so the empty-
     # search experience doesn't break). The relevance expression
@@ -2682,6 +2689,8 @@ async def list_sessions(
             sort_col = search_matches.c.score
     else:
         sort_col = _SESSION_SORT_COLUMNS[sort]
+    if search_matches is not None:
+        base = base.add_columns(sort_col.label("page_sort_value"))
     # Relevance ties are common because visible-message matches receive a
     # constant score. Prefer recent Sessions before the stable UUID tiebreaker,
     # matching the MCP search contract.
@@ -2696,7 +2705,52 @@ async def list_sessions(
     order_columns.append(Session.id.asc())
     ordered = base.order_by(*order_columns)
 
-    rows = (await db.execute(ordered.limit(page_size).offset((page - 1) * page_size))).all()
+    page_query = ordered.limit(page_size).offset((page - 1) * page_size)
+    if search_matches is None:
+        # Keep the common no-search path as two simple index-friendly queries.
+        total = (
+            await db.execute(select(func.count()).select_from(count_base.subquery()))
+        ).scalar_one()
+        rows = (await db.execute(page_query)).all()
+    else:
+        # The count and page both consume the materialized search CTE in one
+        # statement, so PostgreSQL evaluates the expensive search only once.
+        page_rows = page_query.cte("session_page")
+        total_row = (
+            select(func.count().label("total"))
+            .select_from(count_base.subquery())
+            .cte("session_total")
+        )
+        page_session = aliased(Session, page_rows)
+        page_order_columns = [
+            page_rows.c.page_sort_value.asc()
+            if order == "asc"
+            else page_rows.c.page_sort_value.desc()
+        ]
+        if sort == "relevance":
+            page_order_columns.append(page_rows.c.last_activity_at.desc())
+        page_order_columns.append(page_rows.c.id.asc())
+        result_rows = (
+            await db.execute(
+                select(
+                    page_session,
+                    page_rows.c.agent_type,
+                    page_rows.c.display_name,
+                    page_rows.c.default_name,
+                    page_rows.c.machine_name,
+                    page_rows.c.is_shared,
+                    page_rows.c.content,
+                    page_rows.c.role,
+                    page_rows.c.position,
+                    page_rows.c.content_revision,
+                    total_row.c.total,
+                )
+                .select_from(total_row.outerjoin(page_rows, true()))
+                .order_by(*page_order_columns)
+            )
+        ).all()
+        total = result_rows[0].total
+        rows = [row[:-1] for row in result_rows if row[0] is not None]
 
     items: list[SessionListItemResponse] = []
     for row in rows:

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -227,6 +227,56 @@ async def test_relevance_ties_prefer_recent_activity(client: httpx.AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_filtered_search_pagination_preserves_exact_total_and_empty_pages(
+    client: httpx.AsyncClient,
+) -> None:
+    env_id = await _register_env(client)
+    now = datetime.now(UTC)
+    for local_id, age, model in (
+        ("newer-filtered-match", 1, "target-model"),
+        ("older-filtered-match", 2, "target-model"),
+        ("excluded-model-match", 3, "other-model"),
+    ):
+        activity_at = now - timedelta(hours=age)
+        await _push_session(
+            client,
+            env_id,
+            local_session_id=local_id,
+            summary="shared pagination needle",
+            model=model,
+            started_at=activity_at,
+            last_activity_at=activity_at,
+        )
+
+    params = {
+        "q": "shared pagination needle",
+        "model": "target-model",
+        "sort": "relevance",
+        "page_size": 1,
+    }
+    first = (await client.get("/v1/sessions", params=params)).json()
+    assert first["total"] == 2
+    assert [item["local_session_id"] for item in first["items"]] == ["newer-filtered-match"]
+
+    second = (await client.get("/v1/sessions", params={**params, "page": 2})).json()
+    assert second["total"] == 2
+    assert [item["local_session_id"] for item in second["items"]] == ["older-filtered-match"]
+
+    empty_page = (await client.get("/v1/sessions", params={**params, "page": 3})).json()
+    assert empty_page["total"] == 2
+    assert empty_page["items"] == []
+
+    no_matches = (
+        await client.get(
+            "/v1/sessions",
+            params={**params, "q": "missing pagination phrase"},
+        )
+    ).json()
+    assert no_matches["total"] == 0
+    assert no_matches["items"] == []
+
+
+@pytest.mark.asyncio
 async def test_snapshot_message_search_tracks_current_content_and_escapes_wildcards(
     client: httpx.AsyncClient,
     db_session: AsyncSession,


### PR DESCRIPTION
## Summary

- commit Session search `q`, automatic sort, order, and page reset as one debounced request state
- prefetch only after the current non-placeholder page has settled
- reuse one materialized search match set for exact count and page results
- keep explicit sorting, regular pagination, empty-page totals, and the no-search fast path unchanged

## Verification

- focused backend search pagination and ordering tests against isolated PostgreSQL
- web TypeScript checks, focused unit tests, and OSS production build in Docker
- focused Playwright Chromium request-order regression
- Biome, Ruff lint/format, Python compileall, and diff whitespace checks
