### PR TITLE
fix(web): update GLM model presentation

### DIFF
--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
@@ -397,7 +397,6 @@ describe("derivedProviderFields", () => {
 		const zhipu = testPreset("zhipu-glm");
 		expect(zhipu.catalog.map((model) => [model.id, model.alias, model.context_window])).toEqual([
 			["glm-5.3", "GLM-5.3", undefined],
-			["glm-5.3-flash", "GLM-5.3-Flash", undefined],
 			["glm-5.2", "GLM-5.2", undefined],
 		]);
 		expect(testPreset("minimax").catalog.map((model) => [model.id, model.context_window])).toEqual([

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
@@ -123,8 +123,8 @@ describe("model binding", () => {
 			{
 				...managedMetadata,
 				description: "Variable cost for long, detailed work.",
-				id: "glm-5.2",
-				display_name: "GLM-5.2",
+				id: "z-ai/glm-5.3",
+				display_name: "GLM-5.3",
 				provider_id: "redpill",
 				is_default: false,
 				is_featured: true,
@@ -164,8 +164,8 @@ describe("model binding", () => {
 					description: "Higher cost for complex work.",
 				},
 				{
-					value: "glm-5.2",
-					label: "GLM-5.2",
+					value: "z-ai/glm-5.3",
+					label: "GLM-5.3",
 					iconId: "zai",
 					description: "Variable cost for long, detailed work.",
 				},

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -321,8 +321,11 @@ export function managedModelPickerItems(
 
 function managedModelBrandIconId(modelId: string, providerId: string): string {
 	const normalizedModelId = modelId.toLowerCase();
-	if (normalizedModelId.startsWith("deepseek-")) return "deepseek";
-	if (normalizedModelId.startsWith("glm-")) return "zai";
+	const providerSeparator = normalizedModelId.indexOf("/");
+	const modelName =
+		providerSeparator === -1 ? normalizedModelId : normalizedModelId.slice(providerSeparator + 1);
+	if (modelName.startsWith("deepseek-")) return "deepseek";
+	if (modelName.startsWith("glm-")) return "zai";
 	return providerId;
 }
 

--- a/apps/web/src/hosted/v2/ai-providers/provider-presets.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-presets.ts
@@ -112,7 +112,6 @@ export const PROVIDER_PRESETS = [
 		api_mode: "openai_chat",
 		catalog: [
 			{ id: "glm-5.3", alias: "GLM-5.3" },
-			{ id: "glm-5.3-flash", alias: "GLM-5.3-Flash" },
 			{ id: "glm-5.2", alias: "GLM-5.2" },
 		],
 		api_key_url: "https://bigmodel.cn/usercenter/proj-mgmt/apikeys",


### PR DESCRIPTION
## Summary
- remove `glm-5.3-flash` from the default Z.AI BYOK preset
- resolve managed model brand icons from the model name after an optional provider prefix
- keep `z-ai/glm-5.3` on the existing Z.ai icon path

## Verification
- `bash scripts/test.sh web src/hosted/v2/ai-providers/model-binding.test.ts src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts` (`42 passed`)
- Web typecheck passed
- OSS production build passed
- `bun x biome check apps/web/src/hosted/v2/ai-providers/model-binding.ts apps/web/src/hosted/v2/ai-providers/model-binding.test.ts apps/web/src/hosted/v2/ai-providers/provider-presets.ts apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts`
- `git diff --check`