### PR TITLE
fix(runtime): recover managed channel services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,24 @@ database migration, CI, and implementation details.
 
 ### Fixed
 
+- Managed Discord reconnects now discard expired interaction events after their
+  short-lived response tokens have been scrubbed, instead of repeatedly
+  crashing upgraded clients before later messages can be delivered.
 - Session detail search now preserves spaces while typing multi-word queries.
 - Session search now indexes very large messages in bounded chunks, so long
   transcripts remain fully searchable without exceeding PostgreSQL full-text
   limits; results and match navigation still point to the original message.
+
+## Clawdi CLI v0.14.34
+
+Package: `clawdi@0.14.34`
+
+### Fixed
+
+- Hosted runtime reconciliation now restarts a failed systemd service when the
+  current transaction changed that service or still needs to activate its
+  latest definition. This lets managed environment drop-ins recover after an
+  official runtime installer replaces the base unit.
 
 ## Clawdi CLI v0.14.33
 

--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -1318,6 +1318,11 @@ async def discord_agent_gateway(
                     for removed_channel_id in set(deferred_channels) - set(channels):
                         deferred_channels.pop(removed_channel_id, None)
                     event_type = optional_str(payload.get("t"))
+                    event_data = payload.get("d")
+                    interaction_is_deliverable = event_type != "INTERACTION_CREATE" or (
+                        isinstance(event_data, dict)
+                        and optional_str(event_data.get("token")) is not None
+                    )
                     lifecycle = bool(
                         event_type and event_type.startswith(("GUILD_", "CHANNEL_", "THREAD_"))
                     )
@@ -1407,7 +1412,9 @@ async def discord_agent_gateway(
                         message=message,
                         send=(
                             send_message
-                            if authorized and (lifecycle or projected is not None)
+                            if interaction_is_deliverable
+                            and authorized
+                            and (lifecycle or projected is not None)
                             else None
                         ),
                     )

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -16056,6 +16056,99 @@ async def test_discord_gateway_new_identify_replays_unacknowledged_db_message_af
 
 
 @pytest.mark.asyncio
+async def test_discord_gateway_drops_scrubbed_interaction_and_delivers_next_message(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_discord_gateway_sessions(monkeypatch)
+    channel_id = "scrubbed-interaction-channel"
+    guild_id = "scrubbed-interaction-guild"
+    created = await _create_paired_discord_channel(
+        client,
+        name=f"discord-scrubbed-interaction-{uuid4().hex}",
+        channel_id=channel_id,
+        guild_id=guild_id,
+    )
+    account_id = UUID(created["id"])
+    binding = (
+        await db_session.execute(
+            select(ChannelBinding).where(ChannelBinding.account_id == account_id)
+        )
+    ).scalar_one()
+    common = {
+        "account_id": account_id,
+        "bot_agent_link_id": UUID(created["agent_link_id"]),
+        "binding_id": binding.id,
+        "user_id": binding.user_id,
+        "direction": MESSAGE_DIRECTION_INBOUND,
+        "external_chat_id": binding.external_chat_id,
+    }
+    scrubbed = ChannelMessage(
+        **common,
+        provider_message_id="scrubbed-interaction",
+        payload={
+            "t": "INTERACTION_CREATE",
+            "d": {
+                "id": "scrubbed-interaction",
+                "application_id": DISCORD_TEST_APPLICATION_ID,
+                "channel_id": channel_id,
+                "guild_id": guild_id,
+                "data": {"name": "expired"},
+            },
+        },
+    )
+    valid = ChannelMessage(
+        **common,
+        provider_message_id="message-after-scrubbed-interaction",
+        text="still deliver this",
+        payload={
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "message-after-scrubbed-interaction",
+                "channel_id": channel_id,
+                "guild_id": guild_id,
+                "content": "still deliver this",
+                "author": {"id": "scrubbed-interaction-user"},
+            },
+        },
+    )
+    db_session.add_all([scrubbed, valid])
+    await db_session.commit()
+
+    async def fake_provider_request(*, account, method: str, path: str, **_kwargs):
+        assert path == f"channels/{channel_id}"
+        return shared_router.DiscordProviderResult(
+            content=json.dumps(
+                {"id": channel_id, "guild_id": guild_id, "type": 0, "name": "scrubbed"}
+            ).encode(),
+            status_code=200,
+            media_type="application/json",
+        )
+
+    monkeypatch.setattr(discord_router, "request_discord_provider", fake_provider_request)
+    _install_discord_gateway_test_session_factory(monkeypatch)
+
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect("/v1/channels/discord/gateway") as websocket:
+            assert websocket.receive_json()["op"] == 10
+            websocket.send_json({"op": 2, "d": {"token": created["agent_token"], "intents": 0}})
+            assert websocket.receive_json()["t"] == "READY"
+            assert websocket.receive_json()["t"] == "GUILD_CREATE"
+            assert websocket.receive_json()["t"] == "CHANNEL_CREATE"
+            dispatch = websocket.receive_json()
+            assert dispatch["t"] == "MESSAGE_CREATE"
+            assert dispatch["d"]["id"] == "message-after-scrubbed-interaction"
+            websocket.send_json({"op": 1, "d": dispatch["s"]})
+            assert websocket.receive_json() == {"op": 11, "d": None}
+
+    await db_session.refresh(scrubbed)
+    await db_session.refresh(valid)
+    assert scrubbed.delivered_at is not None
+    assert valid.delivered_at is not None
+
+
+@pytest.mark.asyncio
 async def test_discord_gateway_resume_sequence_acks_and_replays_exact_db_message(
     client: httpx.AsyncClient,
     db_session: AsyncSession,

--- a/bun.lock
+++ b/bun.lock
@@ -101,7 +101,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.33",
+      "version": "0.14.34",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.33",
+	"version": "0.14.34",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/systemd-transaction.ts
+++ b/packages/cli/src/runtime/systemd-transaction.ts
@@ -38,6 +38,18 @@ export const RUNTIME_WATCH_SYSTEM_UNIT = "clawdi-runtime-watch.service";
 export const RUNTIME_SIDECAR_SYSTEM_UNIT = "clawdi-runtime-sidecar.service";
 const NON_TRANSACTIONAL_SYSTEM_UNITS = new Set([RUNTIME_WATCH_SYSTEM_UNIT]);
 
+export function shouldRecoverFailedSystemdUnit(input: {
+	activeState: string;
+	changed: boolean;
+	pendingActivation: boolean;
+	recoverFailedUnits: boolean;
+}): boolean {
+	return (
+		input.activeState === "failed" &&
+		(input.recoverFailedUnits || input.changed || input.pendingActivation)
+	);
+}
+
 export function readSystemdUnitSnapshot(
 	paths: ReturnType<typeof getRuntimePaths>,
 ): SystemdUnitSnapshot {
@@ -214,7 +226,14 @@ export function applySystemdRuntimeUpdate(
 		const state = requiredSystemdUnitState(systemStates, "system", unit);
 		if (skipActivatedSystemUnits.has(unit)) continue;
 		if (!systemdUnitEnabled(state)) enableSystemUnits.push(unit);
-		if (state.activeState === "failed" && recoverFailedUnits) {
+		if (
+			shouldRecoverFailedSystemdUnit({
+				activeState: state.activeState,
+				changed: system.added.includes(unit) || system.changed.includes(unit),
+				pendingActivation: pendingSystemActivation.has(unit),
+				recoverFailedUnits,
+			})
+		) {
 			resetFailedSystemUnits.push(unit);
 			startSystemUnits.push(unit);
 			systemUnitsChanged.add(unit);
@@ -256,14 +275,17 @@ export function applySystemdRuntimeUpdate(
 	for (const unit of user.present) {
 		const state = requiredSystemdUnitState(userStates, "user", unit);
 		if (!systemdUnitEnabled(state)) enableUserUnits.push(unit);
-		if (state.activeState === "failed" && recoverFailedUnits) {
+		const recoverFailedUserUnit = shouldRecoverFailedSystemdUnit({
+			activeState: state.activeState,
+			changed: user.added.includes(unit) || user.changed.includes(unit),
+			pendingActivation: pendingUserActivation.has(unit),
+			recoverFailedUnits,
+		});
+		if (recoverFailedUserUnit) {
 			resetFailedUserUnits.push(unit);
 			userUnitsChanged.add(unit);
 		}
-		if (
-			state.activeState === "inactive" ||
-			(state.activeState === "failed" && recoverFailedUnits)
-		) {
+		if (state.activeState === "inactive" || recoverFailedUserUnit) {
 			startUserUnits.push(unit);
 			userUnitsChanged.add(unit);
 			continue;

--- a/packages/cli/src/runtime/systemd.test.ts
+++ b/packages/cli/src/runtime/systemd.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { managedRuntimeSystemdUnitEntries, RUNTIME_SYSTEMD_DROP_IN_FILE } from "./systemd";
+import { shouldRecoverFailedSystemdUnit } from "./systemd-transaction";
 import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "./systemd-user";
 
 const roots: string[] = [];
@@ -43,5 +44,37 @@ describe("managed runtime systemd unit classification", () => {
 	test("returns no units for a missing root", () => {
 		const root = join(tmpdir(), `clawdi-systemd-missing-${crypto.randomUUID()}`);
 		expect(managedRuntimeSystemdUnitEntries(root)).toEqual([]);
+	});
+});
+
+describe("failed runtime systemd unit recovery", () => {
+	test("recovers a failed unit when the current activation changed it", () => {
+		expect(
+			shouldRecoverFailedSystemdUnit({
+				activeState: "failed",
+				changed: true,
+				pendingActivation: false,
+				recoverFailedUnits: false,
+			}),
+		).toBe(true);
+		expect(
+			shouldRecoverFailedSystemdUnit({
+				activeState: "failed",
+				changed: false,
+				pendingActivation: true,
+				recoverFailedUnits: false,
+			}),
+		).toBe(true);
+	});
+
+	test("leaves an unchanged failed unit for the scheduled recovery pass", () => {
+		expect(
+			shouldRecoverFailedSystemdUnit({
+				activeState: "failed",
+				changed: false,
+				pendingActivation: false,
+				recoverFailedUnits: false,
+			}),
+		).toBe(false);
 	});
 });

--- a/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/Dockerfile
+++ b/packages/cli/tests/fixtures/managed-whatsapp-native-e2e/Dockerfile
@@ -87,7 +87,7 @@ RUN --mount=type=bind,from=e2e_artifacts,source=/,target=/mnt/artifacts,ro \
 		HOME=/opt/stock/openclaw-home \
 		NPM_CONFIG_CACHE=/var/cache/npm \
 		/opt/stock/openclaw-home/.openclaw/bin/openclaw plugins install \
-			--force clawhub:@openclaw/whatsapp; do \
+			--force "clawhub:@openclaw/whatsapp@${OPENCLAW_VERSION}"; do \
 		if [ "${OPENCLAW_PLUGIN_INSTALL_ATTEMPT}" -ge 5 ]; then exit 1; fi; \
 		sleep "$((OPENCLAW_PLUGIN_INSTALL_ATTEMPT * 3))"; \
 		OPENCLAW_PLUGIN_INSTALL_ATTEMPT="$((OPENCLAW_PLUGIN_INSTALL_ATTEMPT + 1))"; \


### PR DESCRIPTION
## Summary

- drop expired Discord interaction replays after their short-lived response token has been scrubbed, so upgraded Discord clients can continue to later messages
- recover failed systemd units when the current hosted transaction changed them or still needs to activate their latest definition
- release `clawdi@0.14.34`

## Root cause

A Hermes service reinstall could replace the official user unit and remove Clawdi's environment drop-in. Notification reconciliation restored the file but did not restart an already-failed unit when scheduled failed-unit recovery was disabled, creating an installer/reconcile loop.

After the runtime was rebuilt, upgraded `discord.py` also rejected a durable `INTERACTION_CREATE` replay whose short-lived response token had already been scrubbed by retention. The V2 managed channel gateway repeatedly replayed that undeliverable row on reconnect, preventing later Discord events from flowing.

## Verification

- `bash scripts/test.sh backend tests/test_channels.py -k 'discord_gateway_drops_scrubbed_interaction_and_delivers_next_message'`
- `bash scripts/test.sh cli src/runtime/systemd.test.ts` (TypeScript typecheck + focused tests)
- Ruff check and format check for changed Python files
- `git diff --check`
