### PR TITLE
feat(api): support explicit Agent rebinding

### DIFF
--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -23,7 +23,7 @@ from fastapi import (
     status,
 )
 from pydantic import BaseModel, Field, JsonValue, TypeAdapter, ValidationError, field_validator
-from sqlalchemy import case, func, or_, select, text, true, tuple_, update
+from sqlalchemy import case, exists, func, or_, select, text, true, tuple_, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -34,6 +34,7 @@ from app.core.auth import (
     get_auth,
     is_connected_agent_principal,
     require_any_scope,
+    require_oauth_cli_auth,
     require_scope,
     require_web_auth,
 )
@@ -347,6 +348,109 @@ async def register_agent(
     return await _register_agent_identity(body, auth, db)
 
 
+@router.post("/agents/{agent_id}/rebind")
+async def rebind_agent(
+    agent_id: UUID,
+    body: EnvironmentCreate,
+    auth: AuthContext = Depends(require_oauth_cli_auth),
+    db: AsyncSession = Depends(get_session),
+) -> EnvironmentCreatedResponse:
+    """Reconnect one local installation to an existing Agent identity."""
+
+    if not is_connected_agent_principal(auth):
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            "This endpoint requires an account-level CLI identity",
+        )
+
+    env = (
+        await db.execute(
+            select(AgentEnvironment)
+            .where(
+                AgentEnvironment.id == agent_id,
+                AgentEnvironment.user_id == auth.user_id,
+                active_agent_filter(),
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if env is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
+    hosted_state = await db.get(HostedRuntimeState, env.id)
+    environment_bound_key_id = await db.scalar(
+        select(ApiKey.id).where(ApiKey.environment_id == env.id).limit(1)
+    )
+    if (
+        env.registration_key is None
+        or env.connected_agent_registered_at is None
+        or hosted_state is not None
+        or environment_bound_key_id is not None
+    ):
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            {
+                "code": "agent_not_reconnectable",
+                "message": "Only an existing Connected Agent can be rebound by a local CLI.",
+            },
+        )
+    if env.agent_type != body.agent_type:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "The local Agent type does not match the selected Agent",
+        )
+
+    registration_key = local_machine_registration_key(body.machine_id, body.agent_type)
+    conflict = await db.scalar(
+        select(AgentEnvironment.id).where(
+            AgentEnvironment.user_id == auth.user_id,
+            AgentEnvironment.registration_key == registration_key,
+            AgentEnvironment.id != agent_id,
+        )
+    )
+    if conflict is not None:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            {
+                "code": "agent_rebind_conflict",
+                "message": "This installation is already connected to another Agent.",
+                "conflicting_agent_id": str(conflict),
+            },
+        )
+
+    now = datetime.now(UTC)
+    env.machine_id = body.machine_id
+    env.machine_name = body.machine_name
+    env.agent_version = body.agent_version
+    env.os = body.os
+    env.adapter_modules = body.adapter_modules
+    env.registration_key = registration_key
+    env.connected_agent_registered_at = now
+    env.last_seen_at = now
+    env.last_sync_at = None
+    env.last_sync_error = None
+    env.last_revision_seen = None
+    env.queue_depth_high_water_since_start = 0
+    env.dropped_count_since_start = 0
+    env.project_skill_reconcile_version = None
+    env.project_skill_reconcile_observed_at = None
+    rebound_id = env.id
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "Another Agent claimed this installation while it was being rebound",
+        ) from None
+    log.info(
+        "connected_agent_rebound user_id=%s agent_id=%s agent_type=%s",
+        auth.user_id,
+        rebound_id,
+        env.agent_type,
+    )
+    return EnvironmentCreatedResponse(id=str(rebound_id))
+
+
 @router.post("/environments", deprecated=True)
 async def register_environment(
     body: EnvironmentCreate,
@@ -365,6 +469,7 @@ async def _list_agent_identities(
     *,
     agent_response: Literal[True],
     project_id: UUID | None = None,
+    reconnectable_only: bool = False,
 ) -> list[AgentResponse] | Response: ...
 
 
@@ -377,6 +482,7 @@ async def _list_agent_identities(
     *,
     agent_response: Literal[False],
     project_id: UUID | None = None,
+    reconnectable_only: bool = False,
 ) -> list[EnvironmentResponse] | Response: ...
 
 
@@ -388,6 +494,7 @@ async def _list_agent_identities(
     *,
     agent_response: bool,
     project_id: UUID | None = None,
+    reconnectable_only: bool = False,
 ) -> list[AgentResponse] | list[EnvironmentResponse] | Response:
     # Bound api_keys (deploy keys) only see their own env.
     # Returning every env of the user would let a leaked deploy
@@ -412,6 +519,15 @@ async def _list_agent_identities(
             AgentProjectBinding,
             AgentProjectBinding.agent_id == AgentEnvironment.id,
         ).where(AgentProjectBinding.project_id == project_id)
+    if reconnectable_only:
+        has_hosted_state = exists().where(HostedRuntimeState.environment_id == AgentEnvironment.id)
+        has_environment_bound_key = exists().where(ApiKey.environment_id == AgentEnvironment.id)
+        stmt = stmt.where(
+            AgentEnvironment.registration_key.is_not(None),
+            AgentEnvironment.connected_agent_registered_at.is_not(None),
+            ~has_hosted_state,
+            ~has_environment_bound_key,
+        )
     result = await db.execute(stmt)
     envs = result.scalars().all()
     hosted_deployment_ids: dict[UUID, str] = {}
@@ -446,9 +562,15 @@ async def list_agents(
         default=None,
         description="Return only the caller's Agents linked to this exact Project.",
     ),
+    reconnectable: bool = Query(
+        default=False,
+        description="Return only Connected Agents eligible for explicit local rebind.",
+    ),
     auth: AuthContext = Depends(get_auth),
     db: AsyncSession = Depends(get_session),
 ) -> list[AgentResponse] | Response:
+    if reconnectable:
+        await require_oauth_cli_auth(auth)
     return await _list_agent_identities(
         request,
         response,
@@ -456,6 +578,7 @@ async def list_agents(
         db,
         agent_response=True,
         project_id=project_id,
+        reconnectable_only=reconnectable,
     )
 
 

--- a/backend/tests/test_agent_endpoints.py
+++ b/backend/tests/test_agent_endpoints.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from urllib.parse import urlparse
 
 import httpx
@@ -36,6 +36,26 @@ async def _register_agent(client: httpx.AsyncClient, machine_id: str | None = No
     response = await client.post("/v1/agents", json=_agent_body(machine_id or uuid.uuid4().hex))
     assert response.status_code == 200, response.text
     return response.json()["id"]
+
+
+def _set_oauth_cli_auth(seed_user: User):
+    async def _oauth_cli_auth() -> AuthContext:
+        return AuthContext(
+            user=seed_user,
+            oauth_cli=True,
+            oauth_access_expires_at=datetime.now(UTC) + timedelta(minutes=5),
+        )
+
+    previous = app.dependency_overrides.get(get_auth)
+    app.dependency_overrides[get_auth] = _oauth_cli_auth
+
+    def restore() -> None:
+        if previous is None:
+            app.dependency_overrides.pop(get_auth, None)
+        else:
+            app.dependency_overrides[get_auth] = previous
+
+    return restore
 
 
 def _assert_same_response(left: httpx.Response, right: httpx.Response) -> None:
@@ -76,6 +96,126 @@ def _assert_agent_list_response_matches_environment(
         for item in environment_response.json()
     ] == agent_response.json()
     assert all(not _DEPRECATED_HOSTED_FIELDS.intersection(item) for item in agent_response.json())
+
+
+@pytest.mark.asyncio
+async def test_oauth_cli_rebind_preserves_agent_identity(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user: User,
+):
+    from app.models.session import AgentEnvironment
+    from app.services.agent_environments import local_machine_registration_key
+
+    restore_auth = _set_oauth_cli_auth(seed_user)
+    try:
+        agent_id = await _register_agent(client, "lost-installation")
+        stale_env = await db_session.get(AgentEnvironment, uuid.UUID(agent_id))
+        assert stale_env is not None
+        stale_env.last_sync_at = datetime.now(UTC) - timedelta(hours=1)
+        stale_env.last_sync_error = "old installation failed"
+        stale_env.last_revision_seen = 17
+        stale_env.queue_depth_high_water_since_start = 9
+        stale_env.dropped_count_since_start = 3
+        stale_env.project_skill_reconcile_version = 1
+        stale_env.project_skill_reconcile_observed_at = datetime.now(UTC) - timedelta(hours=1)
+        await db_session.commit()
+        candidates = await client.get("/v1/agents", params={"reconnectable": "true"})
+        body = _agent_body("replacement-installation")
+        body["machine_name"] = "Recovered Laptop"
+        response = await client.post(f"/v1/agents/{agent_id}/rebind", json=body)
+    finally:
+        restore_auth()
+
+    assert candidates.status_code == 200, candidates.text
+    assert [agent["id"] for agent in candidates.json()] == [agent_id]
+    assert response.status_code == 200, response.text
+    assert response.json() == {"id": agent_id}
+    env = await db_session.get(AgentEnvironment, uuid.UUID(agent_id))
+    assert env is not None
+    assert env.machine_id == "replacement-installation"
+    assert env.machine_name == "Recovered Laptop"
+    assert env.registration_key == local_machine_registration_key(
+        "replacement-installation", "codex"
+    )
+    assert env.last_sync_at is None
+    assert env.last_sync_error is None
+    assert env.last_revision_seen is None
+    assert env.queue_depth_high_water_since_start == 0
+    assert env.dropped_count_since_start == 0
+    assert env.project_skill_reconcile_version is None
+    assert env.project_skill_reconcile_observed_at is None
+
+    repeated = await client.post("/v1/agents", json=_agent_body("replacement-installation"))
+    assert repeated.status_code == 200, repeated.text
+    assert repeated.json() == {"id": agent_id}
+
+
+@pytest.mark.asyncio
+async def test_agent_rebind_requires_oauth_cli_auth(
+    client: httpx.AsyncClient,
+    seed_user: User,
+):
+    restore_auth = _set_oauth_cli_auth(seed_user)
+    try:
+        agent_id = await _register_agent(client)
+    finally:
+        restore_auth()
+
+    response = await client.post(
+        f"/v1/agents/{agent_id}/rebind",
+        json=_agent_body("replacement-installation"),
+    )
+    candidates = await client.get("/v1/agents", params={"reconnectable": "true"})
+
+    assert response.status_code == 403
+    assert candidates.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_agent_rebind_refuses_an_installation_identity_conflict(
+    client: httpx.AsyncClient,
+    seed_user: User,
+):
+    restore_auth = _set_oauth_cli_auth(seed_user)
+    try:
+        target_id = await _register_agent(client, "lost-installation")
+        conflicting_id = await _register_agent(client, "replacement-installation")
+        response = await client.post(
+            f"/v1/agents/{target_id}/rebind",
+            json=_agent_body("replacement-installation"),
+        )
+    finally:
+        restore_auth()
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "code": "agent_rebind_conflict",
+        "message": "This installation is already connected to another Agent.",
+        "conflicting_agent_id": conflicting_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_agent_rebind_rejects_ambiguous_legacy_identity(
+    client: httpx.AsyncClient,
+    seed_user: User,
+):
+    agent_id = await _register_agent(client, "legacy-installation")
+    restore_auth = _set_oauth_cli_auth(seed_user)
+    try:
+        candidates = await client.get("/v1/agents", params={"reconnectable": "true"})
+        response = await client.post(
+            f"/v1/agents/{agent_id}/rebind",
+            json=_agent_body("replacement-installation"),
+        )
+    finally:
+        restore_auth()
+
+    assert candidates.status_code == 200, candidates.text
+    assert candidates.json() == []
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "agent_not_reconnectable"
 
 
 @pytest.mark.asyncio

--- a/docs/adr/0001-agent-identity-is-the-stable-domain-object.md
+++ b/docs/adr/0001-agent-identity-is-the-stable-domain-object.md
@@ -81,6 +81,15 @@ codes, and error bodies remain unchanged. New optional response fields such as
 `name`, `default_name`, and `explicit_identity` are additive safe fields for old
 clients.
 
+If a self-managed installation loses both its local Agent cache and its
+installation id, the CLI must not infer identity from a hostname, display
+name, or recent activity. An account-level OAuth CLI may explicitly rebind a
+server-confirmed Connected Agent to a newly generated installation id. The
+operation preserves `AgentEnvironment.id`, rotates the machine-derived
+`registration_key`, and rebuilds the local cache. Explicit hosted identities
+and historical rows without positive Connected-origin evidence are not
+eligible for this recovery path.
+
 First-party hosted control planes register through the admin API.
 `/v1/admin/agents` accepts `agent_id` for agent-first callers.
 `/v1/admin/environments` remains intact for those control planes until that

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1092,6 +1092,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/agents/{agent_id}/rebind": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Rebind Agent
+         * @description Reconnect one local installation to an existing Agent identity.
+         */
+        post: operations["rebind_agent_v1_agents__agent_id__rebind_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/environments": {
         parameters: {
             query?: never;
@@ -11411,6 +11431,8 @@ export interface operations {
             query?: {
                 /** @description Return only the caller's Agents linked to this exact Project. */
                 project_id?: string | null;
+                /** @description Return only Connected Agents eligible for explicit local rebind. */
+                reconnectable?: boolean;
             };
             header?: never;
             path?: never;
@@ -11450,6 +11472,41 @@ export interface operations {
             query?: never;
             header?: never;
             path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EnvironmentCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EnvironmentCreatedResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    rebind_agent_v1_agents__agent_id__rebind_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agent_id: string;
+            };
             cookie?: never;
         };
         requestBody: {


### PR DESCRIPTION
## Summary

- add an OAuth CLI-only endpoint to rebind an eligible Connected Agent while preserving its stable Agent id
- add an OAuth CLI-only filtered listing for explicit recovery candidates
- reject hosted, environment-bound, archived, cross-account, type-mismatched, and conflicting rebinding attempts
- document the stable identity/recovery invariant and regenerate the OpenAPI client

## Why this ships first

This additive Cloud API contract is the prerequisite for the standalone CLI recovery flow and the macOS Electron app. Shipping it first prevents released clients from calling a route that is not deployed yet.

## Verification

Head: `b5d2836372cad2490d034d94ef8c93ac1ebffbc8`

- `scripts/test.sh backend tests/test_agent_endpoints.py` — 10 passed in the Docker clean runner
- Ruff check + format check for the changed Python files — passed in a pinned container
- focused Biome check — passed in a pinned container
- `git diff --check` — passed
- required GitHub checks must be green on this exact head before merge

## Release impact

- additive Cloud API change; no database migration
- deploy backend before merging/publishing the dependent CLI PR
- no Electron or Web UI code is included