### PR TITLE
feat(cli): recover existing Agent bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,28 @@ database migration, CI, and implementation details.
   transcripts remain fully searchable without exceeding PostgreSQL full-text
   limits; results and match navigation still point to the original message.
 
+## Clawdi CLI v0.14.35
+
+Package: `clawdi@0.14.35`
+
+### Added
+
+- Connected Agents now use a stable local installation identity instead of
+  deriving identity from the hostname, platform, and architecture.
+- `clawdi agent reconnect` can restore a lost local binding to an existing
+  Connected Agent without creating a second Cloud identity.
+
+### Changed
+
+- Logging out preserves local Agent registrations with an account binding, so
+  signing back into the same account remains stable without exposing those
+  registrations after an account switch.
+
+### Fixed
+
+- Damaged installation identity state now fails safely instead of silently
+  rotating identity and risking a duplicate Agent registration.
+
 ## Clawdi CLI v0.14.34
 
 Package: `clawdi@0.14.34`

--- a/bun.lock
+++ b/bun.lock
@@ -101,7 +101,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.34",
+      "version": "0.14.35",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.34",
+	"version": "0.14.35",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/agent-reconnect.ts
+++ b/packages/cli/src/commands/agent-reconnect.ts
@@ -1,0 +1,235 @@
+import { hostname } from "node:os";
+import * as p from "@clack/prompts";
+import type { components } from "@clawdi/shared/api";
+import chalk from "chalk";
+import { adapterModuleNames } from "../adapters/base";
+import { AGENT_TYPES, type AgentType, adapterRegistry } from "../adapters/registry";
+import { ApiClient, unwrap } from "../lib/api-client";
+import { getAuth } from "../lib/config";
+import { writeEnvironmentRegistration } from "../lib/environment-registration";
+import { errMessage } from "../lib/errors";
+import { getOrCreateMachineId } from "../lib/machine-identity";
+import { getEnvIdByAgent } from "../lib/select-adapter";
+import { isInteractive } from "../lib/tty";
+import { type LocalAgentSetupOpts, maybeInstallDaemons, reconcileAgentIntegrations } from "./setup";
+
+type AgentResponse = components["schemas"]["AgentResponse"];
+
+interface AgentReconnectOpts extends LocalAgentSetupOpts {
+	agent?: string;
+}
+
+export async function agentReconnect(
+	agentId: string | undefined,
+	opts: AgentReconnectOpts,
+): Promise<void> {
+	const auth = getAuth();
+	if (auth?.authType !== "clerk_oauth") {
+		console.log(chalk.red("Reconnect requires Clerk OAuth. Run `clawdi auth login` first."));
+		process.exitCode = 1;
+		return;
+	}
+
+	const requestedType = parseAgentType(opts.agent);
+	if (opts.agent && !requestedType) return;
+
+	const api = new ApiClient();
+	let agents: AgentResponse[];
+	try {
+		agents = unwrap(
+			await api.GET("/v1/agents", {
+				params: { query: { reconnectable: true } },
+			}),
+		);
+	} catch (error) {
+		console.log(chalk.red(`Could not list Agents: ${errMessage(error)}`));
+		process.exitCode = 1;
+		return;
+	}
+
+	const candidate = await selectCandidate(agents, agentId, requestedType);
+	if (!candidate) return;
+	const agentType = parseAgentType(candidate.agent_type);
+	if (!agentType) return;
+	if (requestedType && requestedType !== agentType) {
+		console.log(chalk.red("The selected Agent does not match --agent."));
+		process.exitCode = 1;
+		return;
+	}
+
+	const currentRegistration = getEnvIdByAgent(agentType);
+	if (currentRegistration && currentRegistration !== candidate.id) {
+		console.log(
+			chalk.red(
+				`${adapterRegistry[agentType].displayName} is already connected locally. Run \`clawdi teardown --agent ${agentType}\` before reconnecting another identity.`,
+			),
+		);
+		process.exitCode = 1;
+		return;
+	}
+	if (!opts.yes && !isInteractive()) {
+		console.log(chalk.red("Non-interactive reconnect requires explicit confirmation with --yes."));
+		process.exitCode = 1;
+		return;
+	}
+
+	const adapter = adapterRegistry[agentType].create();
+	let agentVersion: string | null;
+	try {
+		if (!(await adapter.detect())) {
+			console.log(
+				chalk.red(`${adapterRegistry[agentType].displayName} is not available on this machine.`),
+			);
+			process.exitCode = 1;
+			return;
+		}
+		agentVersion = await adapter.getVersion();
+	} catch (error) {
+		console.log(
+			chalk.red(
+				`Could not inspect ${adapterRegistry[agentType].displayName}: ${errMessage(error)}`,
+			),
+		);
+		process.exitCode = 1;
+		return;
+	}
+
+	if (!opts.yes && isInteractive()) {
+		const confirmed = await p.confirm({
+			message: `Reconnect ${adapterRegistry[agentType].displayName} to “${candidate.name}” and replace its previous installation binding?`,
+			initialValue: true,
+		});
+		if (p.isCancel(confirmed) || !confirmed) {
+			p.cancel("Cancelled.");
+			return;
+		}
+	}
+
+	let machineId: string;
+	let machineName: string;
+	try {
+		machineId = getOrCreateMachineId();
+		machineName = hostname();
+	} catch (error) {
+		console.log(chalk.red(`Could not prepare local Agent identity: ${errMessage(error)}`));
+		process.exitCode = 1;
+		return;
+	}
+
+	let rebound: components["schemas"]["EnvironmentCreatedResponse"];
+	try {
+		rebound = unwrap(
+			await api.POST("/v1/agents/{agent_id}/rebind", {
+				params: { path: { agent_id: candidate.id } },
+				body: {
+					machine_id: machineId,
+					machine_name: machineName,
+					agent_type: agentType,
+					agent_version: agentVersion,
+					os: process.platform,
+					adapter_modules: adapterModuleNames(adapter),
+				},
+			}),
+		);
+	} catch (error) {
+		console.log(
+			chalk.red(
+				`Could not reconnect ${adapterRegistry[agentType].displayName}: ${errMessage(error)}`,
+			),
+		);
+		process.exitCode = 1;
+		return;
+	}
+
+	try {
+		writeEnvironmentRegistration({
+			id: rebound.id,
+			agentType,
+			machineId,
+			machineName,
+			userId: auth.userId,
+		});
+	} catch (error) {
+		console.log(
+			chalk.yellow(
+				`⚠ Agent was rebound in Clawdi, but local state could not be saved: ${errMessage(error)}`,
+			),
+		);
+		console.log(chalk.gray("  Fix local permissions, then run the same reconnect command again."));
+		process.exitCode = 1;
+		return;
+	}
+
+	console.log(chalk.green(`✓ ${adapterRegistry[agentType].displayName} reconnected`));
+	try {
+		await reconcileAgentIntegrations(adapter);
+	} catch (error) {
+		console.log(
+			chalk.yellow(
+				`⚠ Agent identity recovered, but local integration setup failed: ${errMessage(error)}`,
+			),
+		);
+		process.exitCode = 1;
+	}
+	try {
+		await maybeInstallDaemons(opts);
+	} catch (error) {
+		console.log(
+			chalk.yellow(`⚠ Agent identity recovered, but daemon setup failed: ${errMessage(error)}`),
+		);
+		process.exitCode = 1;
+	}
+}
+
+function parseAgentType(value: string | undefined): AgentType | null {
+	if (!value) return null;
+	if (AGENT_TYPES.includes(value as AgentType)) return value as AgentType;
+	console.log(chalk.red(`Unknown agent type: ${value}`));
+	console.log(chalk.gray(`Valid types: ${AGENT_TYPES.join(", ")}`));
+	process.exitCode = 1;
+	return null;
+}
+
+async function selectCandidate(
+	agents: AgentResponse[],
+	agentId: string | undefined,
+	agentType: AgentType | null,
+): Promise<AgentResponse | null> {
+	if (agentId) {
+		const candidate = agents.find((agent) => agent.id === agentId);
+		if (candidate) return candidate;
+		console.log(chalk.red("The selected Agent is unavailable or cannot be locally reconnected."));
+		process.exitCode = 1;
+		return null;
+	}
+	const reconnectable = agents.filter((agent) => !agentType || agent.agent_type === agentType);
+	if (reconnectable.length === 0) {
+		console.log(chalk.red("No reconnectable Agents were found for this account."));
+		process.exitCode = 1;
+		return null;
+	}
+	if (reconnectable.length === 1) return reconnectable[0] ?? null;
+	if (!isInteractive()) {
+		console.log(chalk.red("Multiple Agents match. Pass an Agent id to choose one."));
+		process.exitCode = 1;
+		return null;
+	}
+	const selected = await p.select<string>({
+		message: "Reconnect which Agent?",
+		options: reconnectable.map((agent) => {
+			const type = AGENT_TYPES.includes(agent.agent_type as AgentType)
+				? (agent.agent_type as AgentType)
+				: null;
+			return {
+				value: agent.id,
+				label: `${type ? adapterRegistry[type].displayName : agent.agent_type} — ${agent.name}`,
+				hint: `${agent.machine_name} · ${agent.id}`,
+			};
+		}),
+	});
+	if (p.isCancel(selected)) {
+		p.cancel("Cancelled.");
+		return null;
+	}
+	return reconnectable.find((agent) => agent.id === selected) ?? null;
+}

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -470,8 +470,8 @@ export async function authLogout() {
 	}
 
 	// Warn about running daemons before clearing creds. `clearAuth`
-	// deletes auth.json + ~/.clawdi/environments/*, but launchd /
-	// systemd units installed by `clawdi daemon install` keep
+	// deletes auth.json, but launchd / systemd units installed by
+	// `clawdi daemon install` keep
 	// running with the API key cached in their unit env. They'll
 	// keep posting heartbeats to the cloud (with a now-revoked
 	// token, getting 401s in a tight loop) until the user
@@ -505,7 +505,7 @@ export async function authLogout() {
 			"The local credential was removed. If remote OAuth revocation was unavailable, revoke the Clawdi OAuth application in your Clerk account if needed.",
 		);
 	}
-	p.log.success("Logged out. Credentials and cached environments removed.");
+	p.log.success("Logged out. Credentials removed; account-bound Agent registrations preserved.");
 }
 
 type AuthStatusSource = "auth.json" | "CLAWDI_AUTH_TOKEN" | "runtime-auth-token" | "none";

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1,5 +1,4 @@
-import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { hostname } from "node:os";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
@@ -13,9 +12,11 @@ import {
 	builtinSkillTargetDir,
 } from "../adapters/registry";
 import { ApiClient, unwrap } from "../lib/api-client";
-import { getClawdiDir, isLoggedIn } from "../lib/config";
+import { getAuth } from "../lib/config";
 import { resolveCurrentCliResourceRoot } from "../lib/current-cli-invocation";
+import { writeEnvironmentRegistration } from "../lib/environment-registration";
 import { errMessage } from "../lib/errors";
+import { getOrCreateMachineId } from "../lib/machine-identity";
 import { listRegisteredAgentTypes } from "../lib/select-adapter";
 import { isInteractive } from "../lib/tty";
 import { managedSkillDirectoryDigest } from "../runtime/hosted-bundled-skill";
@@ -31,25 +32,34 @@ import {
 	uninstall as uninstallDaemonService,
 } from "../serve/installer";
 
-interface SetupOpts {
-	agent?: string;
+export interface LocalAgentSetupOpts {
 	yes?: boolean;
 	/** Commander sets this to false for --no-daemon. Undefined means default-on. */
 	daemon?: boolean;
 }
 
+interface SetupOpts extends LocalAgentSetupOpts {
+	agent?: string;
+}
+
 export async function setup(opts: SetupOpts) {
-	if (!isLoggedIn()) {
+	const auth = getAuth();
+	if (!auth) {
 		console.log(chalk.red("Not logged in. Run `clawdi auth login` first."));
 		process.exitCode = 1;
 		return;
 	}
 
-	const machineId = createHash("sha256")
-		.update(`${hostname()}-${process.platform}-${process.arch}`)
-		.digest("hex")
-		.slice(0, 16);
-	const machineName = hostname();
+	let machineId: string;
+	let machineName: string;
+	try {
+		machineId = getOrCreateMachineId();
+		machineName = hostname();
+	} catch (error) {
+		console.log(chalk.red(`Could not prepare local Agent identity: ${errMessage(error)}`));
+		process.exitCode = 1;
+		return;
+	}
 	const api = new ApiClient();
 
 	if (opts.agent) {
@@ -61,13 +71,21 @@ export async function setup(opts: SetupOpts) {
 		}
 		const type = opts.agent as AgentType;
 		const adapter = adapterRegistry[type].create();
-		if (!(await registerEnv(api, adapter, await adapter.getVersion(), machineId, machineName))) {
+		if (
+			!(await registerEnv(
+				api,
+				adapter,
+				await adapter.getVersion(),
+				machineId,
+				machineName,
+				auth.userId,
+			))
+		) {
 			process.exitCode = 1;
 			return;
 		}
-		await adapterRegistry[type].mcpLifecycle?.register();
-		if (adapter.skills) await installBuiltinSkill(type);
-		if (await shouldInstallDaemons(opts)) installDaemonsForRegisteredAgents();
+		await reconcileAgentIntegrations(adapter);
+		await maybeInstallDaemons(opts);
 		return;
 	}
 
@@ -129,17 +147,14 @@ export async function setup(opts: SetupOpts) {
 	let registeredCount = 0;
 	let failedCount = 0;
 	for (const { adapter, version } of toRegister) {
-		if (!(await registerEnv(api, adapter, version, machineId, machineName))) {
+		if (!(await registerEnv(api, adapter, version, machineId, machineName, auth.userId))) {
 			failedCount += 1;
 			continue;
 		}
 		registeredCount += 1;
-		await adapterRegistry[adapter.agentType].mcpLifecycle?.register();
-		if (adapter.skills) await installBuiltinSkill(adapter.agentType);
+		await reconcileAgentIntegrations(adapter);
 	}
-	if (registeredCount > 0 && (await shouldInstallDaemons(opts))) {
-		installDaemonsForRegisteredAgents();
-	}
+	if (registeredCount > 0) await maybeInstallDaemons(opts);
 	if (failedCount > 0) process.exitCode = 1;
 }
 
@@ -149,6 +164,7 @@ async function registerEnv(
 	agentVersion: string | null,
 	machineId: string,
 	machineName: string,
+	userId?: string,
 ): Promise<boolean> {
 	const agentType = adapter.agentType;
 	try {
@@ -165,13 +181,13 @@ async function registerEnv(
 			}),
 		);
 
-		const envDir = join(getClawdiDir(), "environments");
-		mkdirSync(envDir, { recursive: true });
-		writeFileSync(
-			join(envDir, `${agentType}.json`),
-			`${JSON.stringify({ id: env.id, agentType, machineId, machineName }, null, 2)}\n`,
-			{ mode: 0o600 },
-		);
+		writeEnvironmentRegistration({
+			id: env.id,
+			agentType,
+			machineId,
+			machineName,
+			...(userId ? { userId } : {}),
+		});
 
 		console.log(chalk.green(`✓ ${adapterRegistry[agentType].displayName} registered`));
 		return true;
@@ -234,6 +250,15 @@ async function shouldInstallDaemons(opts: SetupOpts): Promise<boolean> {
 		return false;
 	}
 	return result === true;
+}
+
+export async function reconcileAgentIntegrations(adapter: AgentAdapter): Promise<void> {
+	await adapterRegistry[adapter.agentType].mcpLifecycle?.register();
+	if (adapter.skills) await installBuiltinSkill(adapter.agentType);
+}
+
+export async function maybeInstallDaemons(opts: LocalAgentSetupOpts): Promise<void> {
+	if (await shouldInstallDaemons(opts)) installDaemonsForRegisteredAgents();
 }
 
 function installDaemonsForRegisteredAgents() {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1583,6 +1583,21 @@ agentCmd
 		await agentDetectCommand(opts);
 	});
 
+agentCmd
+	.command("reconnect [agent-id]")
+	.description("Recover a local Agent binding without creating a new cloud identity")
+	.option("--agent <type>", `Agent type (${AGENT_TYPE_HELP_LABEL})`)
+	.option("-y, --yes", "Skip confirmation when the target is unambiguous")
+	.option("--no-daemon", "Skip installing/starting background sync daemons")
+	.addHelpText(
+		"after",
+		"\nExamples:\n  $ clawdi agent reconnect --agent codex\n  $ clawdi agent reconnect <agent-id>\n  $ clawdi agent reconnect <agent-id> --no-daemon",
+	)
+	.action(async (agentId: string | undefined, opts) => {
+		const { agentReconnect } = await import("./commands/agent-reconnect.js");
+		await agentReconnect(agentId, opts);
+	});
+
 const agentCredentialsCmd = agentCmd
 	.command("credentials")
 	.description("Sync local CLI credential profiles");

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -1,7 +1,8 @@
-import { existsSync, readFileSync, rmSync, unlinkSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { normalizeCloudApiBaseUrl, normalizeHostedDeployApiBaseUrl } from "./api-origin";
+import { withPrivateDirectoryLockSync } from "./private-directory-lock";
 import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "./private-file";
 
 // NOTE: these paths are computed lazily so tests can override HOME per-run
@@ -216,17 +217,36 @@ export function setAuth(auth: ClawdiAuth) {
 }
 
 export function clearAuth() {
+	const ownerUserId = getStoredAuth()?.userId?.trim();
+	if (ownerUserId) bindCachedEnvironmentsToUser(ownerUserId);
 	const p = authFile();
 	if (existsSync(p)) {
 		unlinkSync(p);
 	}
-	// Drop cached environment ids too — they belong to the user that just
-	// logged out. Surviving across an account switch is exactly how a stale
-	// env_id ends up in the next user's session uploads.
+}
+
+function bindCachedEnvironmentsToUser(userId: string): void {
 	const envDir = join(clawdiDir(), "environments");
-	if (existsSync(envDir)) {
-		rmSync(envDir, { recursive: true, force: true });
-	}
+	if (!existsSync(envDir)) return;
+	withPrivateDirectoryLockSync(join(clawdiDir(), "environments.lock"), (lease) => {
+		for (const fileName of readdirSync(envDir)) {
+			if (!fileName.endsWith(".json")) continue;
+			const path = join(envDir, fileName);
+			const value = readRecoverablePrivateJson<unknown>(path);
+			if (typeof value !== "object" || value === null || Array.isArray(value)) continue;
+			const registration = value as Record<string, unknown>;
+			if (typeof registration.id !== "string" || typeof registration.agentType !== "string") {
+				continue;
+			}
+			if (typeof registration.userId === "string") continue;
+			lease.assertOwned();
+			writePrivateFileAtomic(path, `${JSON.stringify({ ...registration, userId }, null, 2)}\n`, {
+				mode: PRIVATE_FILE_MODE,
+				dirMode: PRIVATE_DIR_MODE,
+				durable: true,
+			});
+		}
+	});
 }
 
 export function isLoggedIn(): boolean {

--- a/packages/cli/src/lib/environment-registration.ts
+++ b/packages/cli/src/lib/environment-registration.ts
@@ -1,0 +1,26 @@
+import { join } from "node:path";
+import type { AgentType } from "../adapters/registry";
+import { getClawdiDir } from "./config";
+import { withPrivateDirectoryLockSync } from "./private-directory-lock";
+import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "./private-file";
+
+interface EnvironmentRegistration {
+	id: string;
+	agentType: AgentType;
+	machineId: string;
+	machineName: string;
+	userId?: string;
+}
+
+export function writeEnvironmentRegistration(registration: EnvironmentRegistration): void {
+	const clawdiDir = getClawdiDir();
+	withPrivateDirectoryLockSync(join(clawdiDir, "environments.lock"), (lease) => {
+		const path = join(clawdiDir, "environments", `${registration.agentType}.json`);
+		lease.assertOwned();
+		writePrivateFileAtomic(path, `${JSON.stringify(registration, null, 2)}\n`, {
+			mode: PRIVATE_FILE_MODE,
+			dirMode: PRIVATE_DIR_MODE,
+			durable: true,
+		});
+	});
+}

--- a/packages/cli/src/lib/machine-identity.test.ts
+++ b/packages/cli/src/lib/machine-identity.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getOrCreateMachineId } from "./machine-identity";
+
+const originalClawdiHome = process.env.CLAWDI_HOME;
+const roots: string[] = [];
+
+afterEach(() => {
+	if (originalClawdiHome === undefined) delete process.env.CLAWDI_HOME;
+	else process.env.CLAWDI_HOME = originalClawdiHome;
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("machine identity", () => {
+	test("creates one stable installation identity", () => {
+		const root = isolatedClawdiHome();
+		const first = getOrCreateMachineId();
+		const second = getOrCreateMachineId();
+
+		expect(second).toBe(first);
+		expect(first).toMatch(/^[0-9a-f]{8}-[0-9a-f-]{27}$/);
+		expect(JSON.parse(readFileSync(join(root, "machine.json"), "utf8"))).toEqual({
+			schemaVersion: "clawdi.machineIdentity.v1",
+			id: first,
+		});
+	});
+
+	test("adopts the previous registration identity instead of duplicating the machine", () => {
+		const root = isolatedClawdiHome();
+		const envDir = join(root, "environments");
+		mkdirSync(envDir, { recursive: true });
+		writeFileSync(
+			join(envDir, "codex.json"),
+			JSON.stringify({ id: "env-codex", agentType: "codex", machineId: "legacy-machine" }),
+		);
+
+		expect(getOrCreateMachineId()).toBe("legacy-machine");
+		expect(getOrCreateMachineId()).toBe("legacy-machine");
+	});
+
+	test("refuses to rotate a damaged installation identity silently", () => {
+		const root = isolatedClawdiHome();
+		const identityPath = join(root, "machine.json");
+		writeFileSync(identityPath, "{damaged\n");
+
+		expect(() => getOrCreateMachineId()).toThrow("clawdi agent reconnect");
+		expect(readFileSync(identityPath, "utf8")).toBe("{damaged\n");
+	});
+});
+
+function isolatedClawdiHome(): string {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-machine-identity-"));
+	roots.push(root);
+	process.env.CLAWDI_HOME = root;
+	return root;
+}

--- a/packages/cli/src/lib/machine-identity.ts
+++ b/packages/cli/src/lib/machine-identity.ts
@@ -1,0 +1,83 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getClawdiDir } from "./config";
+import { withPrivateDirectoryLockSync } from "./private-directory-lock";
+import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "./private-file";
+
+interface MachineIdentity {
+	schemaVersion: "clawdi.machineIdentity.v1";
+	id: string;
+}
+
+const MACHINE_ID_MAX_LENGTH = 200;
+
+export function getOrCreateMachineId(): string {
+	const clawdiDir = getClawdiDir();
+	const identityPath = join(clawdiDir, "machine.json");
+	return withPrivateDirectoryLockSync(join(clawdiDir, "machine-identity.lock"), (lease) => {
+		const existing = readMachineIdentity(identityPath);
+		if (existing) return existing.id;
+		if (existsSync(identityPath)) {
+			throw new Error(
+				`Local installation identity is invalid at ${identityPath}. Move the damaged file aside, then run \`clawdi agent reconnect\` to recover the existing Agent identity.`,
+			);
+		}
+		const id = legacyMachineId(clawdiDir) ?? randomUUID();
+		const identity: MachineIdentity = {
+			schemaVersion: "clawdi.machineIdentity.v1",
+			id,
+		};
+		lease.assertOwned();
+		writePrivateFileAtomic(identityPath, `${JSON.stringify(identity, null, 2)}\n`, {
+			mode: PRIVATE_FILE_MODE,
+			dirMode: PRIVATE_DIR_MODE,
+			durable: true,
+		});
+		return id;
+	});
+}
+
+function readMachineIdentity(path: string): MachineIdentity | null {
+	if (!existsSync(path)) return null;
+	try {
+		const value = JSON.parse(readFileSync(path, "utf8")) as unknown;
+		if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+		const record = value as Record<string, unknown>;
+		if (record.schemaVersion !== "clawdi.machineIdentity.v1" || !validMachineId(record.id)) {
+			return null;
+		}
+		return {
+			schemaVersion: "clawdi.machineIdentity.v1",
+			id: record.id,
+		};
+	} catch {
+		return null;
+	}
+}
+
+function legacyMachineId(clawdiDir: string): string | null {
+	const environmentsDir = join(clawdiDir, "environments");
+	if (!existsSync(environmentsDir)) return null;
+	for (const fileName of readdirSync(environmentsDir).sort()) {
+		if (!fileName.endsWith(".json")) continue;
+		try {
+			const value = JSON.parse(readFileSync(join(environmentsDir, fileName), "utf8")) as unknown;
+			if (typeof value !== "object" || value === null || Array.isArray(value)) continue;
+			const machineId = (value as Record<string, unknown>).machineId;
+			if (validMachineId(machineId)) return machineId;
+		} catch {
+			// Ignore a damaged Agent cache and continue looking for a valid legacy identity.
+		}
+	}
+	return null;
+}
+
+function validMachineId(value: unknown): value is string {
+	return (
+		typeof value === "string" &&
+		value.length > 0 &&
+		value.length <= MACHINE_ID_MAX_LENGTH &&
+		value.trim() === value
+	);
+}

--- a/packages/cli/src/lib/select-adapter.ts
+++ b/packages/cli/src/lib/select-adapter.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import chalk from "chalk";
 import type { AgentAdapter } from "../adapters/base";
@@ -9,12 +9,42 @@ import {
 	getAdapterEntry,
 } from "../adapters/registry";
 import { readJson } from "./api-client";
-import { getClawdiDir } from "./config";
+import { getAuth, getClawdiDir, readRecoverablePrivateJson } from "./config";
+
+interface LocalEnvironmentRegistration {
+	id: string;
+	userId?: string;
+}
+
+function readEnvironmentRegistration(
+	agentType: string,
+	currentUserId: string | undefined,
+): LocalEnvironmentRegistration | null {
+	const envPath = join(getClawdiDir(), "environments", `${agentType}.json`);
+	const value = readRecoverablePrivateJson<unknown>(envPath);
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+	const record = value as Record<string, unknown>;
+	if (typeof record.id !== "string" || !record.id.trim()) return null;
+	if (record.agentType !== undefined && record.agentType !== agentType) return null;
+	if (
+		record.userId !== undefined &&
+		(typeof record.userId !== "string" ||
+			!record.userId.trim() ||
+			record.userId !== record.userId.trim())
+	) {
+		return null;
+	}
+	if (record.userId && (!currentUserId || record.userId !== currentUserId)) return null;
+	return {
+		id: record.id,
+		...(typeof record.userId === "string" ? { userId: record.userId } : {}),
+	};
+}
 
 export function getEnvIdByAgent(agentType: string): string | null {
-	const envPath = join(getClawdiDir(), "environments", `${agentType}.json`);
-	if (!existsSync(envPath)) return null;
-	return JSON.parse(readFileSync(envPath, "utf-8")).id;
+	const auth = getAuth();
+	if (!auth) return null;
+	return readEnvironmentRegistration(agentType, auth.userId?.trim())?.id ?? null;
 }
 
 /** Ask the cloud which project this caller's next write would land
@@ -96,12 +126,12 @@ export function adapterForType(agentType: AgentType): AgentAdapter | null {
 export function listRegisteredAgentTypes(): AgentType[] {
 	const envDir = join(getClawdiDir(), "environments");
 	if (!existsSync(envDir)) return [];
-	const types: AgentType[] = [];
-	const files = new Set(readdirSync(envDir));
-	for (const entry of allAdapterEntries()) {
-		if (files.has(entry.envFileName)) types.push(entry.agentType);
-	}
-	return types;
+	const auth = getAuth();
+	if (!auth) return [];
+	const currentUserId = auth.userId?.trim();
+	return allAdapterEntries()
+		.filter((entry) => readEnvironmentRegistration(entry.agentType, currentUserId) !== null)
+		.map((entry) => entry.agentType);
 }
 
 /**

--- a/packages/cli/src/runtime/host-policy.ts
+++ b/packages/cli/src/runtime/host-policy.ts
@@ -46,6 +46,10 @@ function hostedPolicy(): HostPolicy {
 		deniedCommands: [
 			{ command: "setup", reason: "runtime setup is managed by clawdi runtime init" },
 			{ command: "teardown", reason: "runtime teardown is managed by the host lifecycle" },
+			{
+				command: "agent reconnect",
+				reason: "Connected Agent identity is managed outside hosted runtimes",
+			},
 			{ command: "update", reason: "CLI updates are managed by the hosted runtime installation" },
 		],
 		managedState: [paths.serviceStateRoot, paths.runRoot],

--- a/packages/cli/tests/commands/agent-reconnect.test.ts
+++ b/packages/cli/tests/commands/agent-reconnect.test.ts
@@ -1,0 +1,165 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { agentReconnect } from "../../src/commands/agent-reconnect";
+import { jsonResponse, mockFetch } from "./helpers";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "clawdi-agent-reconnect-test-"));
+const ENV_KEYS = ["CI", "HOME", "CLAWDI_API_URL", "PI_CODING_AGENT_DIR"] as const;
+
+let envSnapshot: Partial<Record<(typeof ENV_KEYS)[number], string>> = {};
+let home = "";
+let restoreFetch: (() => void) | null = null;
+let restoreConsole: (() => void) | null = null;
+let output: string[] = [];
+
+afterAll(() => {
+	rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+	home = mkdtempSync(join(tmpRoot, "case-"));
+	envSnapshot = {};
+	for (const key of ENV_KEYS) {
+		const value = process.env[key];
+		if (value !== undefined) envSnapshot[key] = value;
+		delete process.env[key];
+	}
+	process.env.CI = "1";
+	process.env.HOME = home;
+	process.env.CLAWDI_API_URL = "https://api.test";
+	process.env.PI_CODING_AGENT_DIR = join(home, "pi-agent");
+	mkdirSync(process.env.PI_CODING_AGENT_DIR, { recursive: true });
+	seedOAuthAuth();
+
+	const originalLog = console.log;
+	const originalError = console.error;
+	output = [];
+	console.log = (...values: unknown[]) => output.push(values.map(String).join(" "));
+	console.error = (...values: unknown[]) => output.push(values.map(String).join(" "));
+	restoreConsole = () => {
+		console.log = originalLog;
+		console.error = originalError;
+	};
+	process.exitCode = 0;
+});
+
+afterEach(() => {
+	restoreFetch?.();
+	restoreFetch = null;
+	restoreConsole?.();
+	restoreConsole = null;
+	process.exitCode = 0;
+	for (const key of ENV_KEYS) delete process.env[key];
+	for (const [key, value] of Object.entries(envSnapshot)) {
+		if (value !== undefined) process.env[key as (typeof ENV_KEYS)[number]] = value;
+	}
+	rmSync(home, { recursive: true, force: true });
+});
+
+describe("agent reconnect", () => {
+	it("requires explicit confirmation outside an interactive terminal", async () => {
+		const agentId = "00000000-0000-0000-0000-000000000123";
+		const mock = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/agents",
+				response: () =>
+					jsonResponse([
+						{
+							id: agentId,
+							name: "Pi",
+							machine_name: "Previous Laptop",
+							agent_type: "pi",
+						},
+					]),
+			},
+		]);
+		restoreFetch = mock.restore;
+
+		await agentReconnect(agentId, { agent: "pi", daemon: false });
+
+		expect(mock.captured.some((request) => request.method === "POST")).toBe(false);
+		expect(output.some((line) => line.includes("requires explicit confirmation"))).toBe(true);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("rebuilds the local binding around the current installation identity", async () => {
+		const agentId = "00000000-0000-0000-0000-000000000123";
+		const mock = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/agents",
+				response: () =>
+					jsonResponse([
+						{
+							id: agentId,
+							name: "Pi",
+							machine_name: "Previous Laptop",
+							agent_type: "pi",
+						},
+					]),
+			},
+			{
+				method: "POST",
+				path: `/v1/agents/${agentId}/rebind`,
+				response: () => jsonResponse({ id: agentId }),
+			},
+		]);
+		restoreFetch = mock.restore;
+
+		await agentReconnect(agentId, { agent: "pi", yes: true, daemon: false });
+
+		const machine = JSON.parse(readFileSync(join(home, ".clawdi", "machine.json"), "utf-8")) as {
+			id: string;
+		};
+		const registration = JSON.parse(
+			readFileSync(join(home, ".clawdi", "environments", "pi.json"), "utf-8"),
+		) as Record<string, unknown>;
+		const listRequest = mock.captured.find((request) => request.method === "GET");
+		const rebindRequest = mock.captured.find((request) => request.method === "POST");
+
+		expect(listRequest?.path).toContain("reconnectable=true");
+		expect(rebindRequest?.body).toMatchObject({
+			machine_id: machine.id,
+			agent_type: "pi",
+			adapter_modules: ["sessions"],
+		});
+		expect(registration).toMatchObject({
+			id: agentId,
+			agentType: "pi",
+			machineId: machine.id,
+			userId: "cloud-user",
+		});
+		expect(existsSync(join(home, ".clawdi", "environments", "pi.json"))).toBe(true);
+		expect(output.some((line) => line.includes("Pi reconnected"))).toBe(true);
+		expect(process.exitCode).toBe(0);
+	});
+});
+
+function seedOAuthAuth(): void {
+	const clawdiDir = join(home, ".clawdi");
+	mkdirSync(clawdiDir, { recursive: true });
+	writeFileSync(
+		join(clawdiDir, "auth.json"),
+		`${JSON.stringify({
+			authType: "clerk_oauth",
+			apiKey: "oauth-access-token",
+			refreshToken: "oauth-refresh-token",
+			accessTokenExpiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+			issuer: "https://clerk.test",
+			clientId: "clawdi-cli",
+			audience: "clawdi-api",
+			tokenEndpoint: "https://clerk.test/oauth/token",
+			scopes: ["openid", "offline_access"],
+			subject: "clerk-user",
+			userId: "cloud-user",
+			endpointBinding: {
+				version: 1,
+				cloudApiOrigin: "https://api.test",
+			},
+		})}\n`,
+		{ mode: 0o600 },
+	);
+}

--- a/packages/cli/tests/commands/setup.test.ts
+++ b/packages/cli/tests/commands/setup.test.ts
@@ -200,7 +200,13 @@ describe("setup daemon install", () => {
 
 		await setup({ agent: "codex", yes: true, daemon: false });
 
-		expect(existsSync(join(home, ".clawdi", "environments", "codex.json"))).toBe(true);
+		const registrationPath = join(home, ".clawdi", "environments", "codex.json");
+		expect(existsSync(registrationPath)).toBe(true);
+		expect(JSON.parse(readFileSync(registrationPath, "utf8"))).toMatchObject({
+			id: "env-codex",
+			agentType: "codex",
+			userId: "u1",
+		});
 		expect(daemonUnitExists("daemon")).toBe(false);
 		expect(daemonUnitExists("codex")).toBe(false);
 	});

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -113,6 +113,33 @@ describe("auth persistence", () => {
 		expect(isLoggedIn()).toBe(false);
 	});
 
+	it("preserves Agent registrations for the same account without exposing them to another", async () => {
+		const { clearAuth, setAuth } = await import("../src/lib/config");
+		const { getEnvIdByAgent, listRegisteredAgentTypes } = await import("../src/lib/select-adapter");
+		const envDir = join(fakeHome, ".clawdi", "environments");
+		const envPath = join(envDir, "codex.json");
+		mkdirSync(envDir, { recursive: true });
+		writeFileSync(envPath, JSON.stringify({ id: "env-codex", agentType: "codex" }));
+
+		setAuth({ apiKey: "account-a-key", userId: "account-a" });
+		expect(listRegisteredAgentTypes()).toEqual(["codex"]);
+		clearAuth();
+		expect(listRegisteredAgentTypes()).toEqual([]);
+		expect(JSON.parse(readFileSync(envPath, "utf8"))).toEqual({
+			id: "env-codex",
+			agentType: "codex",
+			userId: "account-a",
+		});
+
+		setAuth({ apiKey: "account-a-key-2", userId: "account-a" });
+		expect(getEnvIdByAgent("codex")).toBe("env-codex");
+		expect(listRegisteredAgentTypes()).toEqual(["codex"]);
+
+		setAuth({ apiKey: "account-b-key", userId: "account-b" });
+		expect(getEnvIdByAgent("codex")).toBeNull();
+		expect(listRegisteredAgentTypes()).toEqual([]);
+	});
+
 	it("writes auth.json with mode 0o600", async () => {
 		const { setAuth } = await import("../src/lib/config");
 		setAuth({ apiKey: "secret" });

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -2434,6 +2434,9 @@ describe("host policy", () => {
 		expect(deniedCommandReason(result.policy, "setup")).toBe(
 			"runtime setup is managed by clawdi runtime init",
 		);
+		expect(deniedCommandReason(result.policy, "agent reconnect")).toBe(
+			"Connected Agent identity is managed outside hosted runtimes",
+		);
 		expect(deniedCommandReason(result.policy, "update")).toBe(
 			"CLI updates are managed by the hosted runtime installation",
 		);


### PR DESCRIPTION
## Summary

- persist one stable local installation identity instead of deriving identity from hostname/platform
- keep local Agent registration caches account-bound across logout/login, without exposing them after an account switch
- make setup writes atomic and continue using Cloud Agent ids as the durable identity
- add explicit `clawdi agent reconnect [agent-id]` recovery when local state is lost
- require OAuth CLI identity, explicit non-interactive confirmation, matching Agent type, and a server-confirmed reconnectable target
- deny reconnect inside hosted runtimes where the control plane owns Agent identity

## Rollout order

The additive Cloud API prerequisite shipped first in #1314 and is now on `main`. This PR contains only the standalone CLI layer and is safe to publish after the exact backend merge SHA is deployed.

## Verification

Head: `cfa177f81a20f08303aaff758880237f0b730602`

- `scripts/test.sh cli` — 1697 passed, 4 skipped, 0 failed in the Docker clean runner
- focused Biome 2.5.9 check on all touched CLI source/test files — passed
- `git diff --check` — passed
- npm `clawdi@0.14.35` and GitHub tag `clawdi-cli-v0.14.35` were absent before release
- required GitHub checks, including privileged systemd E2E, must be green on this exact head before merge

## Release impact

- publishes `clawdi@0.14.35` through the existing trusted release workflow
- no Electron, Desktop IPC/windowing, Web UI, or packaging code is included
