### PR TITLE
fix(ci): run Clawdi release on GitHub-hosted runner

### DIFF
--- a/.github/workflows/clawdi-release.yml
+++ b/.github/workflows/clawdi-release.yml
@@ -28,7 +28,8 @@ concurrency:
 
 jobs:
   release:
-    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
+    # This job uses the GitHub CLI provided by GitHub-hosted runner images.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:

--- a/packages/cli/tests/clawdi-image-release-workflow.test.ts
+++ b/packages/cli/tests/clawdi-image-release-workflow.test.ts
@@ -22,6 +22,7 @@ interface WorkflowJob {
 	name?: string;
 	needs?: string;
 	outputs?: Record<string, string>;
+	"runs-on"?: string;
 	steps?: WorkflowStep[];
 }
 
@@ -48,6 +49,11 @@ const imageReleaseSource = readFileSync(
 	"utf8",
 );
 const imageRelease = parse(imageReleaseSource) as WorkflowDocument;
+const clawdiReleaseSource = readFileSync(
+	resolve(import.meta.dir, "../../../.github/workflows/clawdi-release.yml"),
+	"utf8",
+);
+const clawdiRelease = parse(clawdiReleaseSource) as WorkflowDocument;
 const cliPublishSource = readFileSync(
 	resolve(import.meta.dir, "../../../.github/workflows/cli-publish.yml"),
 	"utf8",
@@ -90,6 +96,15 @@ const releaseClassifierSource = readFileSync(
 );
 
 describe("backend image release workflow contract", () => {
+	test("keeps manual GitHub releases on the runner that supplies GitHub CLI", () => {
+		const releaseJob = clawdiRelease.jobs.release;
+		const createRelease = releaseJob?.steps?.find((step) => step.name === "Create Clawdi release");
+
+		expect(releaseJob?.["runs-on"]).toBe("ubuntu-latest");
+		expect(createRelease?.run).toContain('gh release view "$TAG"');
+		expect(createRelease?.run).toContain(`gh "${"$"}{args[@]}"`);
+	});
+
 	test("routes changes through the bounded git fallback", () => {
 		const steps = backendCi.jobs.changes?.steps ?? [];
 


### PR DESCRIPTION
## Summary

- run the manual Clawdi GitHub Release job on `ubuntu-latest`, which supplies the `gh` CLI used by the workflow
- lock the runner and release-command contract with the existing workflow test suite

## Root cause

Manual run `33474786492` failed at `Create Clawdi release` with `gh: command not found` on the configurable Blacksmith runner. The workflow directly invokes `gh release view` and `gh release create`, so the job must run on an image with the GitHub CLI contract.

## Verification

- isolated Docker: `scripts/test.sh cli tests/clawdi-image-release-workflow.test.ts` — 14 passed
- `bun x biome check .github/workflows/clawdi-release.yml packages/cli/tests/clawdi-image-release-workflow.test.ts`
- `git diff --check`

Electron/Desktop code is not touched.