### PR TITLE
fix(ci): bound CLI publish tests

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -70,7 +70,8 @@ jobs:
         run: bun run typecheck
 
       - name: Test (ephemeral internal suite)
-        run: bun test --isolate --max-concurrency=1 packages/cli
+        timeout-minutes: 20
+        run: bun run --cwd packages/cli test:internal
 
       - name: Build package and native release matrix
         id: build_native_release

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -36,7 +36,10 @@ const manifestContract = readFileSync(
 );
 const cliPackage = JSON.parse(
 	readFileSync(resolve(import.meta.dir, "../package.json"), "utf8"),
-) as { publishConfig?: { access?: string; tag?: unknown } };
+) as {
+	publishConfig?: { access?: string; tag?: unknown };
+	scripts?: Record<string, string>;
+};
 
 describe("CLI publish workflow contract", () => {
 	test("keeps current-run release decisions inside the protected publish topology", () => {
@@ -143,8 +146,12 @@ describe("CLI publish workflow contract", () => {
 		expect(workflow).toContain('tarball="$CLI_TARBALL_FILENAME"');
 		expect(workflow).toContain(`name: \${{ env.CLI_ARTIFACT_NAME }}`);
 		expect(workflow).toContain("run: bun run typecheck");
-		expect(workflow).toContain("- name: Test (ephemeral internal suite)");
-		expect(workflow).toContain("run: bun test --isolate --max-concurrency=1 packages/cli");
+		const testStep = build.steps?.find((step) => step.name === "Test (ephemeral internal suite)");
+		expect(testStep).toMatchObject({
+			"timeout-minutes": 20,
+			run: "bun run --cwd packages/cli test:internal",
+		});
+		expect(cliPackage.scripts?.["test:internal"]).toContain("--timeout=30000");
 		expect(workflow).toContain("- name: Native lifecycle (ephemeral internal suite)");
 		expect(workflow.indexOf("- name: Test")).toBeLessThan(
 			workflow.indexOf("- name: Build package and native release matrix"),


### PR DESCRIPTION
## Summary

- run the CLI publish gate through the canonical `test:internal` script
- bound the publish test step to 20 minutes
- lock the canonical test timeout and workflow step contract

## Root cause

The publish workflow had drifted from the canonical CLI test entrypoint. It invoked `bun test` directly without the per-test timeout already present in `test:internal`, and the Actions step had no overall timeout. A runner/test stall could therefore block the immutable release indefinitely.

The merged CLI tree was reproduced in a clean Bun 1.4.0 container: 1698 passed, 4 skipped, 0 failed, and exited in about 100 seconds. The #1315-focused tests also completed for 20 consecutive runs, so this change fixes the release boundary rather than hiding a product failure.

## Verification

- focused workflow contract: 6 passed
- CLI typecheck
- Biome
- isolated full CLI suite: 1698 passed, 4 skipped, 0 failed
- `git diff --check`

Electron/Desktop PR #1298 is untouched.