### PR TITLE
feat: persist runtime user activity for idle safety

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -155,7 +155,7 @@ jobs:
       github.event_name != 'schedule' &&
       needs.changes.outputs.client == 'true'
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       # Required for web typecheck/build — CI doesn't need real values
       VITE_CLERK_PUBLISHABLE_KEY: pk_test_dummy

--- a/backend/app/schemas/runtime_observation.py
+++ b/backend/app/schemas/runtime_observation.py
@@ -173,9 +173,7 @@ class HostedRuntimeObservedUserActivityV1(RuntimeObservationRequestModel):
             try:
                 parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
             except ValueError as exc:
-                raise ValueError(
-                    "runtime activity timestamps must be ISO 8601"
-                ) from exc
+                raise ValueError("runtime activity timestamps must be ISO 8601") from exc
         else:
             raise ValueError("runtime activity timestamps must be ISO 8601 strings")
         if parsed.tzinfo is None:
@@ -188,15 +186,9 @@ class HostedRuntimeObservedUserActivityV1(RuntimeObservationRequestModel):
             raise ValueError("enabledRuntimes must be unique")
         if self.enabled_runtimes != sorted(self.enabled_runtimes):
             raise ValueError("enabledRuntimes must be sorted")
-        if (
-            self.classification == "known_last_user_input"
-            and self.last_user_input_at is None
-        ):
+        if self.classification == "known_last_user_input" and self.last_user_input_at is None:
             raise ValueError("known activity requires lastUserInputAt")
-        if (
-            self.classification == "known_no_user_input"
-            and self.last_user_input_at is not None
-        ):
+        if self.classification == "known_no_user_input" and self.last_user_input_at is not None:
             raise ValueError("known empty activity cannot include lastUserInputAt")
         if self.classification != "unknown" and self.complete_at is None:
             raise ValueError("known activity requires completeAt")
@@ -206,10 +198,7 @@ class HostedRuntimeObservedUserActivityV1(RuntimeObservationRequestModel):
             raise ValueError("known activity cannot include error")
         if self.complete_at is not None and self.complete_at > self.observed_at:
             raise ValueError("completeAt cannot be later than observedAt")
-        if (
-            self.last_user_input_at is not None
-            and self.last_user_input_at > self.observed_at
-        ):
+        if self.last_user_input_at is not None and self.last_user_input_at > self.observed_at:
             raise ValueError("lastUserInputAt cannot be later than observedAt")
         return self
 

--- a/backend/app/schemas/runtime_observation.py
+++ b/backend/app/schemas/runtime_observation.py
@@ -139,6 +139,81 @@ class HostedRuntimeObservedAgentPluginsV1(RuntimeObservationRequestModel):
                 raise ValueError("Agent Plugin observation must match applied identity")
 
 
+RuntimeUserActivityClassification = Literal[
+    "known_last_user_input",
+    "known_no_user_input",
+    "unknown",
+]
+
+
+class HostedRuntimeObservedUserActivityV1(RuntimeObservationRequestModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, strict=True)
+
+    schema_version: Literal[1] = Field(alias="schemaVersion")
+    classifier_version: Literal[1] = Field(alias="classifierVersion")
+    classification: RuntimeUserActivityClassification
+    last_user_input_at: datetime | None = Field(alias="lastUserInputAt")
+    observed_at: datetime = Field(alias="observedAt")
+    complete_at: datetime | None = Field(alias="completeAt")
+    enabled_runtimes: list[Literal["hermes", "openclaw"]] = Field(
+        alias="enabledRuntimes",
+        min_length=1,
+        max_length=2,
+    )
+    error: str | None = Field(default=None, min_length=1, max_length=200)
+
+    @field_validator("last_user_input_at", "observed_at", "complete_at", mode="before")
+    @classmethod
+    def validate_activity_timestamp(cls, value: object) -> datetime | None:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            parsed = value
+        elif isinstance(value, str):
+            try:
+                parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError as exc:
+                raise ValueError(
+                    "runtime activity timestamps must be ISO 8601"
+                ) from exc
+        else:
+            raise ValueError("runtime activity timestamps must be ISO 8601 strings")
+        if parsed.tzinfo is None:
+            raise ValueError("runtime activity timestamps must include a timezone")
+        return parsed.astimezone(UTC)
+
+    @model_validator(mode="after")
+    def validate_activity_state(self) -> HostedRuntimeObservedUserActivityV1:
+        if len(self.enabled_runtimes) != len(set(self.enabled_runtimes)):
+            raise ValueError("enabledRuntimes must be unique")
+        if self.enabled_runtimes != sorted(self.enabled_runtimes):
+            raise ValueError("enabledRuntimes must be sorted")
+        if (
+            self.classification == "known_last_user_input"
+            and self.last_user_input_at is None
+        ):
+            raise ValueError("known activity requires lastUserInputAt")
+        if (
+            self.classification == "known_no_user_input"
+            and self.last_user_input_at is not None
+        ):
+            raise ValueError("known empty activity cannot include lastUserInputAt")
+        if self.classification != "unknown" and self.complete_at is None:
+            raise ValueError("known activity requires completeAt")
+        if self.classification == "unknown" and self.error is None:
+            raise ValueError("unknown activity requires error")
+        if self.classification != "unknown" and self.error is not None:
+            raise ValueError("known activity cannot include error")
+        if self.complete_at is not None and self.complete_at > self.observed_at:
+            raise ValueError("completeAt cannot be later than observedAt")
+        if (
+            self.last_user_input_at is not None
+            and self.last_user_input_at > self.observed_at
+        ):
+            raise ValueError("lastUserInputAt cannot be later than observedAt")
+        return self
+
+
 class RuntimeObservationEventV2(RuntimeObservationRequestModel):
     """Strict v2 companion event; deliberately separate from the frozen v1 wire model."""
 
@@ -161,6 +236,10 @@ class RuntimeObservationEventV2(RuntimeObservationRequestModel):
     providers: dict[str, HostedRuntimeObservedProviderPayload] | None = None
     agent_plugins: HostedRuntimeObservedAgentPluginsV1 | None = Field(
         alias="agentPlugins",
+        default=None,
+    )
+    user_activity: HostedRuntimeObservedUserActivityV1 | None = Field(
+        alias="userActivity",
         default=None,
     )
     error: str | None = Field(default=None, max_length=4000)

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -2992,6 +2992,7 @@ def _legacy_runtime_observed(value: RuntimeObservationEventV2) -> dict:
         "eventId",
         "capturedAt",
         "agentPlugins",
+        "userActivity",
     ):
         payload.pop(field)
     return payload

--- a/bun.lock
+++ b/bun.lock
@@ -100,7 +100,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.36",
+      "version": "0.14.37",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.36",
+	"version": "0.14.37",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/adapters/base.ts
+++ b/packages/cli/src/adapters/base.ts
@@ -116,6 +116,12 @@ export interface RawSession {
 	rawFilePath: string;
 	/** Opaque adapter revision used to avoid materializing unchanged backing content. */
 	sourceRevision?: string;
+	/**
+	 * Adapter-classified timestamp of the latest real user input in this
+	 * session. `null` means the complete materialized session contains no real
+	 * user input; `undefined` means the adapter does not provide this signal.
+	 */
+	realUserInputAt?: string | null;
 	// Set by `pushOneAgent` after collection — sha256 hex of the JSON
 	// the CLI is about to upload. Adapters do not populate this.
 	contentHash?: string;
@@ -146,6 +152,8 @@ export interface SessionScanBatch {
 	/** Every local session observed in this batch, including revision-matched sessions. */
 	observedLocalSessionIds: readonly string[];
 	dedupedCount: number;
+	/** False when the adapter could not classify activity for every inspected session. */
+	activityComplete?: boolean;
 }
 
 export interface SessionBatchScan {

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -8,6 +8,7 @@ import {
 	resolveOpenClawSdkExport,
 } from "../lib/codex-oauth-native-store";
 import { safeTruncate } from "../lib/sanitize";
+import { computeOpenClawRealUserActivity } from "../lib/session-activity";
 import { durationSecondsBetween } from "../lib/session-duration";
 import {
 	projectEventsToMessages,
@@ -88,18 +89,21 @@ function skillsDir() {
  * `OPENCLAW_AGENT_ID` as a single-agent override keeps the explicit-project
  * escape hatch from the issue's workaround.
  */
-function listAgentDirs(): string[] {
+interface AgentDirectoryListing {
+	dirs: string[];
+	complete: boolean;
+}
+
+function listAgentDirsWithCompleteness(): AgentDirectoryListing {
 	const root = agentsRoot();
-	if (!existsSync(root)) return [];
+	if (!existsSync(root)) return { dirs: [], complete: true };
 	const override = process.env.OPENCLAW_AGENT_ID?.trim();
-	if (override) {
-		const dir = join(root, override);
-		return existsSync(dir) ? [dir] : [];
-	}
 	try {
-		return readdirSync(root, { withFileTypes: true })
+		const dirs = readdirSync(root, { withFileTypes: true })
 			.filter((d) => d.isDirectory() && !d.name.startsWith("."))
+			.filter((d) => !override || d.name === override)
 			.map((d) => join(root, d.name));
+		return { dirs, complete: true };
 	} catch (e) {
 		// `agents/` is present but unreadable (perm bits, encrypted-at-rest,
 		// stale fuse mount, …). Silently treating that as "no agents" hides
@@ -108,7 +112,35 @@ function listAgentDirs(): string[] {
 		console.warn(
 			`[openclaw] could not enumerate ${root}: ${e instanceof Error ? e.message : String(e)}`,
 		);
-		return [];
+		return { dirs: [], complete: false };
+	}
+}
+
+function listAgentDirs(): string[] {
+	return listAgentDirsWithCompleteness().dirs;
+}
+
+function hasUnclassifiedTranscriptFiles(classified: ReadonlySet<string>): boolean {
+	try {
+		const listing = listAgentDirsWithCompleteness();
+		if (!listing.complete) return true;
+		for (const agentRoot of listing.dirs) {
+			const directory = join(agentRoot, "sessions");
+			if (!existsSync(directory)) continue;
+			for (const entry of readdirSync(directory, { withFileTypes: true })) {
+				if (!entry.isFile()) continue;
+				if (
+					!entry.name.endsWith(".jsonl") &&
+					!entry.name.includes(".jsonl.reset.") &&
+					!entry.name.includes(".jsonl.deleted.")
+				)
+					continue;
+				if (!classified.has(resolve(directory, entry.name))) return true;
+			}
+		}
+		return false;
+	} catch {
+		return true;
 	}
 }
 
@@ -437,6 +469,7 @@ interface SessionCollection {
 	observedLocalSessionIds: readonly string[];
 	dedupedCount: number;
 	matchedTranscriptPaths: Set<string>;
+	activityComplete: boolean;
 }
 
 function singleSessionBatch(
@@ -450,9 +483,15 @@ function singleSessionBatch(
 				sessions: collection.sessions,
 				observedLocalSessionIds: collection.observedLocalSessionIds,
 				dedupedCount: collection.dedupedCount,
+				activityComplete: collection.activityComplete,
 			};
 		})(),
 	};
+}
+
+interface MaterializedOpenClawSession {
+	session: RawSession | null;
+	activityComplete: boolean;
 }
 
 function materializeOpenClawJsonlSession(input: {
@@ -460,13 +499,22 @@ function materializeOpenClawJsonlSession(input: {
 	indexPath: string;
 	projectPath: string | null;
 	sourceAgentId: string;
+	sourceSessionKey: string;
 	sourceRevision: string;
 	transcriptPath: string;
-}): RawSession | null {
-	const { entry, indexPath, projectPath, sourceAgentId, sourceRevision, transcriptPath } = input;
+}): MaterializedOpenClawSession {
+	const {
+		entry,
+		indexPath,
+		projectPath,
+		sourceAgentId,
+		sourceSessionKey,
+		sourceRevision,
+		transcriptPath,
+	} = input;
 	const sessionId = entry.sessionId;
 	const updatedAt = entry.updatedAt ?? entry.acp?.lastActivityAt;
-	if (!sessionId || !updatedAt) return null;
+	if (!sessionId || !updatedAt) return { session: null, activityComplete: false };
 
 	let events = [] as import("./base").SessionEvent[];
 	let startedAt: Date | null = null;
@@ -474,16 +522,23 @@ function materializeOpenClawJsonlSession(input: {
 	const modelsUsed = new Set<string>();
 	if (entry.model) modelsUsed.add(entry.model);
 	let currentModel = entry.model ?? null;
+	const transcriptRecords: JsonObject[] = [];
+	let transcriptComplete = true;
 
 	if (!existsSync(transcriptPath)) {
 		if (entry.sessionFile) {
 			console.warn(`[openclaw] transcript missing for ${sessionId}: ${transcriptPath}`);
 		}
+		return { session: null, activityComplete: false };
 	} else {
 		try {
 			const transcriptContent = readFileSync(transcriptPath, "utf-8");
 			const drafts: SessionEventDraft[] = [];
-			for (const { data: raw, recordSeq } of completeJsonlRecords(transcriptContent)) {
+			const records = completeJsonlRecords(transcriptContent);
+			transcriptComplete =
+				records.length === transcriptContent.split("\n").filter((line) => line.trim()).length;
+			for (const { data: raw, recordSeq } of records) {
+				transcriptRecords.push(raw);
 				const parsed = raw as TranscriptLine;
 				drafts.push(
 					...openClawEventDrafts(raw, `${sourceAgentId}:${sessionId}`, recordSeq, currentModel),
@@ -501,36 +556,42 @@ function materializeOpenClawJsonlSession(input: {
 			}
 			events = sequenceSessionEvents(drafts);
 		} catch {
-			// An unreadable transcript is omitted without hiding other sessions.
+			return { session: null, activityComplete: false };
 		}
 	}
 
+	const userActivity = computeOpenClawRealUserActivity(transcriptRecords, sourceSessionKey, entry);
+	userActivity.complete &&= transcriptComplete;
 	const messages = projectEventsToMessages(events);
-	if (messages.length === 0) return null;
+	if (messages.length === 0) return { session: null, activityComplete: userActivity.complete };
 	startedAt ??= new Date(updatedAt);
 	endedAt ??= new Date(updatedAt);
 	const firstUserContent = messages.find((message) => message.role === "user")?.content;
 	return {
-		localSessionId: sessionId,
-		projectPath,
-		startedAt,
-		endedAt,
-		messageCount: messages.length,
-		inputTokens: entry.inputTokens ?? 0,
-		outputTokens: entry.outputTokens ?? 0,
-		cacheReadTokens: entry.cacheRead ?? 0,
-		model: currentModel,
-		modelsUsed: [...modelsUsed],
-		durationSeconds: durationSecondsBetween(startedAt, endedAt),
-		summary:
-			entry.displayName ??
-			entry.subject ??
-			entry.label ??
-			(firstUserContent === undefined ? null : safeTruncate(firstUserContent, 200)),
-		messages,
-		events,
-		rawFilePath: existsSync(transcriptPath) ? transcriptPath : indexPath,
-		sourceRevision,
+		activityComplete: userActivity.complete,
+		session: {
+			localSessionId: sessionId,
+			projectPath,
+			startedAt,
+			endedAt,
+			messageCount: messages.length,
+			inputTokens: entry.inputTokens ?? 0,
+			outputTokens: entry.outputTokens ?? 0,
+			cacheReadTokens: entry.cacheRead ?? 0,
+			model: currentModel,
+			modelsUsed: [...modelsUsed],
+			durationSeconds: durationSecondsBetween(startedAt, endedAt),
+			summary:
+				entry.displayName ??
+				entry.subject ??
+				entry.label ??
+				(firstUserContent === undefined ? null : safeTruncate(firstUserContent, 200)),
+			messages,
+			events,
+			rawFilePath: existsSync(transcriptPath) ? transcriptPath : indexPath,
+			sourceRevision,
+			realUserInputAt: userActivity.lastUserInputAt,
+		},
 	};
 }
 
@@ -685,13 +746,15 @@ export class OpenClawAdapter implements AgentAdapterCore {
 		localSessionId?: string,
 		knownSourceRevisions: ReadonlyMap<string, string> = new Map(),
 	): Promise<SessionCollection> {
-		const agentDirs = listAgentDirs();
+		const agentDirectoryListing = listAgentDirsWithCompleteness();
+		const agentDirs = agentDirectoryListing.dirs;
 		if (agentDirs.length === 0) {
 			return {
 				sessions: [],
 				dedupedCount: 0,
 				observedLocalSessionIds: [],
 				matchedTranscriptPaths: new Set(),
+				activityComplete: agentDirectoryListing.complete,
 			};
 		}
 
@@ -705,6 +768,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 		const sessions: RawSession[] = [];
 		const observedLocalSessionIds: string[] = [];
 		const matchedTranscriptPaths = new Set<string>();
+		let activityComplete = true;
 
 		for (const agentRoot of agentDirs) {
 			const sourceAgentId = basename(agentRoot);
@@ -716,6 +780,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			try {
 				index = JSON.parse(readFileSync(indexPath, "utf-8"));
 			} catch {
+				activityComplete = false;
 				continue;
 			}
 
@@ -741,21 +806,26 @@ export class OpenClawAdapter implements AgentAdapterCore {
 					: join(sessionsDirForAgent, `${sessionId}.jsonl`);
 				const normalizedTranscriptPath = resolve(transcriptPath);
 				if (transcriptPaths && !transcriptPaths.has(normalizedTranscriptPath)) continue;
-				if (transcriptPaths) matchedTranscriptPaths.add(normalizedTranscriptPath);
+				matchedTranscriptPaths.add(normalizedTranscriptPath);
 				observedLocalSessionIds.push(sessionId);
 				const sourceRevision = `${sessionId}:${updatedAt}`;
 				if (knownSourceRevisions.get(sessionId) === sourceRevision) continue;
 
-				const session = materializeOpenClawJsonlSession({
+				const materialized = materializeOpenClawJsonlSession({
 					entry: { ...entry, sessionId, updatedAt },
 					indexPath,
 					projectPath,
 					sourceAgentId,
+					sourceSessionKey: indexKey,
 					sourceRevision,
 					transcriptPath,
 				});
-				if (session) sessions.push(session);
+				activityComplete &&= materialized.activityComplete;
+				if (materialized.session) sessions.push(materialized.session);
 			}
+		}
+		if (knownSourceRevisions.size === 0 && hasUnclassifiedTranscriptFiles(matchedTranscriptPaths)) {
+			activityComplete = false;
 		}
 
 		// OpenClaw stores one session per ACP transcript with stable sessionIds
@@ -765,6 +835,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			dedupedCount: 0,
 			observedLocalSessionIds,
 			matchedTranscriptPaths,
+			activityComplete,
 		};
 	}
 
@@ -777,6 +848,8 @@ export class OpenClawAdapter implements AgentAdapterCore {
 		const absFilter = opts.projectFilter ? resolve(opts.projectFilter) : null;
 		const sessions: RawSession[] = [];
 		const observedLocalSessionIds: string[] = [];
+		const matchedTranscriptPaths = new Set<string>();
+		let activityComplete = true;
 		for (const entry of inventory.entries) {
 			if (localSessionId !== undefined && entry.sessionId !== localSessionId) continue;
 			const updatedAt = entry.updatedAt;
@@ -797,19 +870,23 @@ export class OpenClawAdapter implements AgentAdapterCore {
 				const transcriptPath = isAbsolute(entry.sessionFile)
 					? entry.sessionFile
 					: join(sessionsDirForAgent, entry.sessionFile);
+				matchedTranscriptPaths.add(resolve(transcriptPath));
 				const legacy = materializeOpenClawJsonlSession({
 					entry,
 					indexPath: join(sessionsDirForAgent, "sessions.json"),
 					projectPath,
 					sourceAgentId: entry.agentId,
+					sourceSessionKey: entry.key,
 					sourceRevision,
 					transcriptPath,
 				});
-				if (legacy) sessions.push(legacy);
+				activityComplete &&= legacy.activityComplete;
+				if (legacy.session) sessions.push(legacy.session);
 				continue;
 			}
 			transcript ??= readOfficialSessionMessagesFromGateway(entry);
 			if (!transcript) {
+				activityComplete = false;
 				console.warn(
 					`[openclaw] could not read active transcript for ${entry.sessionId} through official transcript surfaces`,
 				);
@@ -852,6 +929,8 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			}
 			const events = sequenceSessionEvents(drafts);
 			const messages = projectEventsToMessages(events);
+			const userActivity = computeOpenClawRealUserActivity(transcript, entry.key, entry);
+			activityComplete &&= userActivity.complete;
 			if (messages.length === 0) continue;
 			startedAt ??= new Date(entry.sessionStartedAt ?? updatedAt);
 			endedAt ??= new Date(updatedAt);
@@ -878,13 +957,18 @@ export class OpenClawAdapter implements AgentAdapterCore {
 				events,
 				rawFilePath: storePath,
 				sourceRevision,
+				realUserInputAt: userActivity.lastUserInputAt,
 			});
+		}
+		if (knownSourceRevisions.size === 0 && hasUnclassifiedTranscriptFiles(matchedTranscriptPaths)) {
+			activityComplete = false;
 		}
 		return {
 			sessions,
 			dedupedCount: 0,
 			observedLocalSessionIds,
-			matchedTranscriptPaths: new Set(),
+			matchedTranscriptPaths,
+			activityComplete,
 		};
 	}
 

--- a/packages/cli/src/lib/session-activity.test.ts
+++ b/packages/cli/src/lib/session-activity.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { computeOpenClawRealUserActivity } from "./session-activity";
+
+describe("computeOpenClawRealUserActivity", () => {
+	test("keeps only timestamped external user input across old and new records", () => {
+		const activity = computeOpenClawRealUserActivity(
+			[
+				{
+					type: "message",
+					timestamp: "2026-08-01T00:00:00Z",
+					message: { role: "user", content: "hello" },
+				},
+				{
+					role: "assistant",
+					content: "reply",
+					timestamp: "2026-08-02T00:00:00Z",
+				},
+				{
+					role: "user",
+					content: "internal",
+					origin: "inter-session",
+					timestamp: "2026-08-03T00:00:00Z",
+				},
+				{
+					role: "user",
+					content: "[OpenClaw heartbeat poll]",
+					timestamp: "2026-08-04T00:00:00Z",
+				},
+			],
+			"agent:main:main",
+		);
+
+		expect(activity).toEqual({
+			lastUserInputAt: "2026-08-01T00:00:00.000Z",
+			complete: true,
+		});
+	});
+
+	test("fails closed when a real user input has no usable timestamp", () => {
+		expect(
+			computeOpenClawRealUserActivity(
+				[{ role: "user", content: [{ type: "image", url: "fixture" }] }],
+				"agent:main:main",
+			),
+		).toEqual({ lastUserInputAt: null, complete: false });
+	});
+
+	test("treats cron and subagent sessions as internal", () => {
+		const record = {
+			role: "user",
+			content: "generated",
+			timestamp: "2026-08-01T00:00:00Z",
+		};
+		expect(computeOpenClawRealUserActivity([record], "agent:main:cron:daily")).toEqual({
+			lastUserInputAt: null,
+			complete: true,
+		});
+		expect(computeOpenClawRealUserActivity([record], "subagent:worker")).toEqual({
+			lastUserInputAt: null,
+			complete: true,
+		});
+		expect(
+			computeOpenClawRealUserActivity([record], "agent:main:main", {
+				source: "cron",
+			}),
+		).toEqual({ lastUserInputAt: null, complete: true });
+	});
+});

--- a/packages/cli/src/lib/session-activity.ts
+++ b/packages/cli/src/lib/session-activity.ts
@@ -26,6 +26,140 @@ export function computeLastActivityIso(s: RawSession): string {
 	return s.startedAt.toISOString();
 }
 
+export interface RealUserActivity {
+	lastUserInputAt: string | null;
+	complete: boolean;
+}
+
+/** Classify OpenClaw transcript records without losing newer provenance fields. */
+export function computeOpenClawRealUserActivity(
+	records: readonly unknown[],
+	sessionKey: string,
+	sessionMetadata?: unknown,
+): RealUserActivity {
+	if (internalOpenClawSession(sessionKey, sessionMetadata))
+		return { lastUserInputAt: null, complete: true };
+	let best: number | null = null;
+	for (const value of records) {
+		const record = objectRecord(value);
+		if (!record) continue;
+		const nested = objectRecord(record.message);
+		const message = nested ?? record;
+		if (message.role !== "user" || internalOpenClawMessage(message)) continue;
+		const { texts, nonText } = openClawContent(message.content);
+		if (!nonText && (texts.length === 0 || texts.every(generatedUserText))) continue;
+		const timestamp = activityTimestamp(
+			message.timestamp ?? message.createdAt ?? record.timestamp ?? record.createdAt,
+		);
+		if (timestamp === null) return { lastUserInputAt: null, complete: false };
+		if (best === null || timestamp > best) best = timestamp;
+	}
+	return {
+		lastUserInputAt: best === null ? null : new Date(best).toISOString(),
+		complete: true,
+	};
+}
+
+const INTERNAL_OPENCLAW_SOURCES = new Set([
+	"cron",
+	"dreaming",
+	"subagent",
+	"inter_session",
+	"internal_system",
+	"system_generated",
+]);
+
+function internalOpenClawSession(value: string, metadata: unknown): boolean {
+	const key = value.trim().toLowerCase();
+	if (
+		key.startsWith("cron:") ||
+		key.includes(":cron:") ||
+		key.startsWith("subagent:") ||
+		key.includes(":subagent:")
+	)
+		return true;
+	const row = objectRecord(metadata);
+	return ["key", "sessionKey", "kind", "source", "origin", "provenance"].some((field) => {
+		const candidate = row?.[field];
+		return (
+			typeof candidate === "string" &&
+			INTERNAL_OPENCLAW_SOURCES.has(candidate.trim().toLowerCase().replaceAll("-", "_"))
+		);
+	});
+}
+
+function generatedUserText(value: string): boolean {
+	const text = value.trim();
+	if (!text) return true;
+	if (text === "[OpenClaw heartbeat poll]") return true;
+	if (text.startsWith("Delivery:") && text.endsWith("[OpenClaw heartbeat poll]")) return true;
+	if (/^\[cron:[^\]]+\]\s*/i.test(text)) return true;
+	if (/^System(?: \(untrusted\))?: \[[^\]]+\]\s*/i.test(text)) return true;
+	return text.toLowerCase().startsWith("[inter-session message]");
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | null {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function internalOpenClawMessage(message: Record<string, unknown>): boolean {
+	for (const field of ["source", "origin", "provenance", "kind", "type", "channel"]) {
+		const value = message[field];
+		const record = objectRecord(value);
+		const candidates =
+			typeof value === "string"
+				? [value]
+				: record
+					? Object.values(record).filter((item): item is string => typeof item === "string")
+					: [];
+		if (
+			candidates.some((item) =>
+				INTERNAL_OPENCLAW_SOURCES.has(item.trim().toLowerCase().replaceAll("-", "_")),
+			)
+		)
+			return true;
+	}
+	return false;
+}
+
+function openClawContent(value: unknown): { texts: string[]; nonText: boolean } {
+	if (typeof value === "string") return { texts: [value], nonText: false };
+	if (!Array.isArray(value)) return { texts: [], nonText: value !== null && value !== undefined };
+	const texts: string[] = [];
+	let nonText = false;
+	for (const part of value) {
+		if (typeof part === "string") {
+			texts.push(part);
+			continue;
+		}
+		const item = objectRecord(part);
+		if (!item) {
+			nonText = true;
+			continue;
+		}
+		const kind = typeof item.type === "string" ? item.type.toLowerCase() : "";
+		if ((kind === "text" || kind === "input_text") && typeof item.text === "string") {
+			texts.push(item.text);
+		} else if (!new Set(["tool_result", "thinking", "reasoning"]).has(kind)) {
+			nonText = true;
+		}
+	}
+	return { texts, nonText };
+}
+
+function activityTimestamp(value: unknown): number | null {
+	if (typeof value === "number" && Number.isFinite(value) && value >= 0)
+		return value > 100_000_000_000 ? value : value * 1000;
+	if (typeof value !== "string" || !value.trim()) return null;
+	const numeric = Number(value);
+	if (Number.isFinite(numeric) && numeric >= 0)
+		return numeric > 100_000_000_000 ? numeric : numeric * 1000;
+	const timestamp = new Date(value).getTime();
+	return Number.isNaN(timestamp) ? null : timestamp;
+}
+
 function maxMessageTimestamp(messages: SessionMessage[]): string | null {
 	let best: number | null = null;
 	let bestIso: string | null = null;

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -17,11 +17,12 @@ import { runtimeSecretValue } from "./secret-values";
 import { type RuntimeBootStatus, readRuntimeBootStatus } from "./state";
 import { managedRuntimeSystemdUnitEntries, parseSystemctlShow, systemctlPath } from "./systemd";
 import { runtimeUserName } from "./systemd-user";
+import { readRuntimeUserActivityState, runtimeUserActivityStatePath } from "./user-activity-state";
 
 type JsonRecord = Record<string, unknown>;
 type ObservedStatus = "ok" | "error" | "unknown";
 export type HostedRuntimeObserved = components["schemas"]["HostedRuntimeObservedV2"] &
-	Pick<components["schemas"]["RuntimeObservationEventV2"], "agentPlugins">;
+	Pick<components["schemas"]["RuntimeObservationEventV2"], "agentPlugins" | "userActivity">;
 type HostedRuntimeObservedBoot = components["schemas"]["HostedRuntimeObservedBootV1"];
 type HostedRuntimeObservedCli = components["schemas"]["HostedRuntimeObservedCliV1"];
 type HostedRuntimeObservedProviderPayload =
@@ -86,10 +87,42 @@ export function readHostedRuntimeObserved(
 		});
 		if (agentPlugins) observed.agentPlugins = agentPlugins;
 	}
+	const userActivity = observedUserActivity(boot.status, observed.reportedAt);
+	if (userActivity) observed.userActivity = userActivity;
 	if (boot.error) observed.error = boot.error;
 	const convergeError = runtimeConvergeError(watchStatus);
 	if (convergeError) observed.convergeError = convergeError;
 	return observed;
+}
+
+function observedUserActivity(
+	bootStatus: RuntimeBootStatus | undefined,
+	reportedAt: string,
+): components["schemas"]["HostedRuntimeObservedUserActivityV1"] | null {
+	const enabledRuntimes = [...new Set(bootStatus?.enabledRuntimes ?? [])]
+		.filter(
+			(runtime): runtime is "hermes" | "openclaw" => runtime === "hermes" || runtime === "openclaw",
+		)
+		.sort();
+	if (enabledRuntimes.length === 0) return null;
+	const openclaw = enabledRuntimes.includes("openclaw")
+		? readRuntimeUserActivityState(runtimeUserActivityStatePath("openclaw"))
+		: null;
+	const unsupported = enabledRuntimes.some((runtime) => runtime !== "openclaw");
+	const classification = unsupported ? "unknown" : (openclaw?.classification ?? "unknown");
+	const error = unsupported
+		? "activity_runtime_unsupported"
+		: (openclaw?.error ?? (openclaw ? undefined : "activity_cache_missing"));
+	return {
+		schemaVersion: 1,
+		classifierVersion: 1,
+		classification,
+		lastUserInputAt: openclaw?.lastUserInputAt ?? null,
+		observedAt: openclaw?.observedAt ?? reportedAt,
+		completeAt: openclaw?.completeAt ?? null,
+		enabledRuntimes,
+		...(error ? { error } : {}),
+	};
 }
 
 function readJsonRecord(path: string): JsonRecord | null {

--- a/packages/cli/src/runtime/user-activity-state.test.ts
+++ b/packages/cli/src/runtime/user-activity-state.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RawSession } from "../adapters/base";
+import {
+	markRuntimeUserActivityUnknown,
+	readRuntimeUserActivityState,
+	recordRuntimeUserActivityScan,
+	runtimeUserActivityStatePath,
+} from "./user-activity-state";
+
+const roots: string[] = [];
+const originalStateDir = process.env.CLAWDI_STATE_DIR;
+
+afterEach(() => {
+	if (originalStateDir === undefined) delete process.env.CLAWDI_STATE_DIR;
+	else process.env.CLAWDI_STATE_DIR = originalStateDir;
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function statePath(): string {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-user-activity-"));
+	roots.push(root);
+	process.env.CLAWDI_STATE_DIR = root;
+	return runtimeUserActivityStatePath("openclaw");
+}
+
+function session(realUserInputAt: string | null): RawSession {
+	return {
+		localSessionId: "session-1",
+		projectPath: null,
+		startedAt: new Date("2026-08-01T00:00:00Z"),
+		endedAt: null,
+		messageCount: 0,
+		inputTokens: 0,
+		outputTokens: 0,
+		cacheReadTokens: 0,
+		model: null,
+		modelsUsed: [],
+		durationSeconds: null,
+		summary: null,
+		messages: [],
+		rawFilePath: "/fixture",
+		realUserInputAt,
+	};
+}
+
+describe("runtime user activity state", () => {
+	test("builds one complete baseline and refreshes it from watcher deltas", () => {
+		const path = statePath();
+		recordRuntimeUserActivityScan({
+			agentType: "openclaw",
+			sessions: [session("2026-08-01T00:00:00Z")],
+			complete: true,
+			activityComplete: true,
+			observedAt: new Date("2026-08-02T00:00:00Z"),
+		});
+		recordRuntimeUserActivityScan({
+			agentType: "openclaw",
+			sessions: [],
+			complete: false,
+			activityComplete: true,
+			observedAt: new Date("2026-08-03T00:00:00Z"),
+		});
+
+		expect(readRuntimeUserActivityState(path)).toMatchObject({
+			classification: "known_last_user_input",
+			lastUserInputAt: "2026-08-01T00:00:00.000Z",
+			observedAt: "2026-08-03T00:00:00.000Z",
+			completeAt: "2026-08-03T00:00:00.000Z",
+		});
+	});
+
+	test("requires another complete scan after any failed scan", () => {
+		const path = statePath();
+		recordRuntimeUserActivityScan({
+			agentType: "openclaw",
+			sessions: [session(null)],
+			complete: true,
+			activityComplete: true,
+			observedAt: new Date("2026-08-02T00:00:00Z"),
+		});
+		markRuntimeUserActivityUnknown("openclaw", "fixture_failure");
+		recordRuntimeUserActivityScan({
+			agentType: "openclaw",
+			sessions: [],
+			complete: false,
+			activityComplete: true,
+			observedAt: new Date("2026-08-03T00:00:00Z"),
+		});
+
+		expect(readRuntimeUserActivityState(path)?.classification).toBe("unknown");
+	});
+});

--- a/packages/cli/src/runtime/user-activity-state.ts
+++ b/packages/cli/src/runtime/user-activity-state.ts
@@ -1,0 +1,166 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { AgentType } from "../adapters/agent-types";
+import type { RawSession } from "../adapters/base";
+import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "../lib/private-file";
+import { getServeStateDir } from "../serve/paths";
+
+export const RUNTIME_USER_ACTIVITY_CLASSIFIER_VERSION = 1;
+
+export interface RuntimeUserActivityState {
+	schemaVersion: "clawdi.runtimeUserActivity.v1";
+	agentType: "openclaw";
+	classifierVersion: 1;
+	classification: "known_last_user_input" | "known_no_user_input" | "unknown";
+	lastUserInputAt: string | null;
+	observedAt: string;
+	completeAt: string | null;
+	error?: string;
+}
+
+export function supportsRuntimeUserActivity(agentType: AgentType): agentType is "openclaw" {
+	return agentType === "openclaw";
+}
+
+export function runtimeUserActivityStatePath(agentType: "openclaw"): string {
+	return join(getServeStateDir(agentType), "user-activity.json");
+}
+
+export function readRuntimeUserActivityState(path: string): RuntimeUserActivityState | null {
+	try {
+		const value = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+		if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+		const row = value as Record<string, unknown>;
+		if (
+			row.schemaVersion !== "clawdi.runtimeUserActivity.v1" ||
+			row.agentType !== "openclaw" ||
+			row.classifierVersion !== RUNTIME_USER_ACTIVITY_CLASSIFIER_VERSION ||
+			!isClassification(row.classification) ||
+			!isIsoTimestamp(row.observedAt) ||
+			!(row.completeAt === null || isIsoTimestamp(row.completeAt)) ||
+			!(row.lastUserInputAt === null || isIsoTimestamp(row.lastUserInputAt)) ||
+			!(row.error === undefined || typeof row.error === "string")
+		) {
+			return null;
+		}
+		if (row.classification === "known_last_user_input" && row.lastUserInputAt === null) {
+			return null;
+		}
+		if (row.classification === "known_no_user_input" && row.lastUserInputAt !== null) return null;
+		if (row.classification !== "unknown" && row.completeAt === null) return null;
+		if (row.classification === "unknown" ? !row.error : row.error !== undefined) return null;
+		const observedAt = new Date(row.observedAt).getTime();
+		if (row.completeAt !== null && new Date(row.completeAt).getTime() > observedAt) return null;
+		if (row.lastUserInputAt !== null && new Date(row.lastUserInputAt).getTime() > observedAt)
+			return null;
+		return {
+			schemaVersion: "clawdi.runtimeUserActivity.v1",
+			agentType: "openclaw",
+			classifierVersion: RUNTIME_USER_ACTIVITY_CLASSIFIER_VERSION,
+			classification: row.classification,
+			lastUserInputAt: row.lastUserInputAt,
+			observedAt: row.observedAt,
+			completeAt: row.completeAt,
+			...(typeof row.error === "string" ? { error: row.error } : {}),
+		};
+	} catch {
+		return null;
+	}
+}
+
+export function runtimeUserActivityNeedsMaterialization(agentType: AgentType): boolean {
+	if (!supportsRuntimeUserActivity(agentType)) return false;
+	const state = readRuntimeUserActivityState(runtimeUserActivityStatePath(agentType));
+	return state === null || state.classification === "unknown" || state.completeAt === null;
+}
+
+export function recordRuntimeUserActivityScan(input: {
+	agentType: AgentType;
+	sessions: readonly RawSession[];
+	complete: boolean;
+	activityComplete: boolean;
+	observedAt?: Date;
+}): void {
+	if (!supportsRuntimeUserActivity(input.agentType)) return;
+	const path = runtimeUserActivityStatePath(input.agentType);
+	const previous = readRuntimeUserActivityState(path);
+	const observedAt = maxTimestamp(
+		previous?.observedAt ?? null,
+		(input.observedAt ?? new Date()).toISOString(),
+	) as string;
+	const latest = maxTimestamp(
+		previous?.lastUserInputAt ?? null,
+		...input.sessions.map((session) => session.realUserInputAt ?? null),
+	);
+	const priorBaselineKnown =
+		previous !== null && previous.classification !== "unknown" && previous.completeAt !== null;
+	const known = input.activityComplete && (input.complete || priorBaselineKnown);
+	const timestampIsValid =
+		latest === null || new Date(latest).getTime() <= new Date(observedAt).getTime();
+	const completeAt = known && timestampIsValid ? observedAt : (previous?.completeAt ?? null);
+	writeState(path, {
+		schemaVersion: "clawdi.runtimeUserActivity.v1",
+		agentType: input.agentType,
+		classifierVersion: RUNTIME_USER_ACTIVITY_CLASSIFIER_VERSION,
+		classification:
+			known && timestampIsValid
+				? latest
+					? "known_last_user_input"
+					: "known_no_user_input"
+				: "unknown",
+		lastUserInputAt: timestampIsValid ? latest : (previous?.lastUserInputAt ?? null),
+		observedAt,
+		completeAt,
+		...(known && timestampIsValid
+			? {}
+			: {
+					error: timestampIsValid ? "activity_scan_incomplete" : "activity_timestamp_in_future",
+				}),
+	});
+}
+
+export function markRuntimeUserActivityUnknown(
+	agentType: AgentType,
+	error = "activity_scan_failed",
+): void {
+	if (!supportsRuntimeUserActivity(agentType)) return;
+	const path = runtimeUserActivityStatePath(agentType);
+	const previous = readRuntimeUserActivityState(path);
+	writeState(path, {
+		schemaVersion: "clawdi.runtimeUserActivity.v1",
+		agentType,
+		classifierVersion: RUNTIME_USER_ACTIVITY_CLASSIFIER_VERSION,
+		classification: "unknown",
+		lastUserInputAt: previous?.lastUserInputAt ?? null,
+		observedAt: new Date().toISOString(),
+		completeAt: previous?.completeAt ?? null,
+		error,
+	});
+}
+
+function writeState(path: string, state: RuntimeUserActivityState): void {
+	writePrivateFileAtomic(path, `${JSON.stringify(state, null, 2)}\n`, {
+		mode: PRIVATE_FILE_MODE,
+		dirMode: PRIVATE_DIR_MODE,
+	});
+}
+
+function isClassification(value: unknown): value is RuntimeUserActivityState["classification"] {
+	return (
+		value === "known_last_user_input" || value === "known_no_user_input" || value === "unknown"
+	);
+}
+
+function isIsoTimestamp(value: unknown): value is string {
+	return typeof value === "string" && !Number.isNaN(new Date(value).getTime());
+}
+
+function maxTimestamp(...values: Array<string | null>): string | null {
+	let best: number | null = null;
+	for (const value of values) {
+		if (!value) continue;
+		const timestamp = new Date(value).getTime();
+		if (!Number.isNaN(timestamp) && (best === null || timestamp > best)) best = timestamp;
+	}
+	return best === null ? null : new Date(best).toISOString();
+}

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -78,6 +78,11 @@ import { snapshotSkillArchive } from "../lib/tar";
 import { getCliVersion } from "../lib/version";
 import { shouldIgnoreUserSkill } from "../runtime/managed-skill-reservation";
 import { readHostedRuntimeObserved } from "../runtime/observed";
+import {
+	markRuntimeUserActivityUnknown,
+	recordRuntimeUserActivityScan,
+	runtimeUserActivityNeedsMaterialization,
+} from "../runtime/user-activity-state";
 
 export { isSafelyTerminalRuntimeObservationFailure } from "../runtime/observation-producer";
 
@@ -959,15 +964,22 @@ async function prepareSessionSync(
 	const executeScan = async (request: SessionScanRequest): Promise<void> => {
 		if (opts.abort.aborted) return;
 		try {
+			const materializeActivity =
+				request.kind === "complete" &&
+				runtimeUserActivityNeedsMaterialization(opts.adapter.agentType);
 			const scan = await scanSessionModule(
 				sessions,
 				request,
-				loadFencedSessionSourceRevisions(api, opts, protocol),
+				materializeActivity ? new Map() : loadFencedSessionSourceRevisions(api, opts, protocol),
 			);
 			const observedResources = new Set<string>();
 			const confirmedSourceRevisions: FencedSessionSourceRevisionUpdate[] = [];
+			const activitySessions: RawSession[] = [];
+			let activityComplete = true;
 			let enqueued = 0;
 			for await (const batch of scan.batches) {
+				activitySessions.push(...batch.sessions);
+				activityComplete &&= batch.activityComplete !== false;
 				for (const localSessionId of batch.observedLocalSessionIds) {
 					observedResources.add(`session:${localSessionId}`);
 				}
@@ -996,6 +1008,12 @@ async function prepareSessionSync(
 				confirmedSourceRevisions.push(...result.confirmedSourceRevisions);
 				if (opts.abort.aborted) return;
 			}
+			recordRuntimeUserActivityScan({
+				agentType: opts.adapter.agentType,
+				sessions: activitySessions,
+				complete: scan.coverage === "complete",
+				activityComplete,
+			});
 			persistFencedSessionSourceRevisions(confirmedSourceRevisions);
 			if (scan.coverage === "complete") {
 				health.clearAbsent("push", "session:", observedResources);
@@ -1004,6 +1022,7 @@ async function prepareSessionSync(
 			if (enqueued > 0) log.info("engine.sessions_enqueued", { count: enqueued });
 		} catch (error) {
 			if (opts.abort.aborted) return;
+			markRuntimeUserActivityUnknown(opts.adapter.agentType);
 			health.set("push", "session_scan", `session scan: ${toErrorMessage(error)}`);
 			log.warn("engine.sessions_enumerate_failed", { error: toErrorMessage(error) });
 		}

--- a/packages/cli/tests/adapters/openclaw.test.ts
+++ b/packages/cli/tests/adapters/openclaw.test.ts
@@ -170,6 +170,7 @@ describe("OpenClawAdapter.collectSessions", () => {
 			content: "world",
 			model: "claude-opus-4-7",
 		});
+		expect(s.realUserInputAt).toBe("2026-04-20T10:00:00.000Z");
 	});
 
 	it("uploads thinking while keeping the message projection visible-only", async () => {
@@ -277,6 +278,7 @@ describe("OpenClawAdapter.collectSessions", () => {
 			"SDK question",
 			"SDK answer",
 		]);
+		expect(sessions[0]?.realUserInputAt).toBe("2026-04-15T10:00:00.000Z");
 	});
 
 	it("falls back to OpenClaw's public Gateway transcript projection", async () => {
@@ -302,6 +304,7 @@ describe("OpenClawAdapter.collectSessions", () => {
 			"kept question",
 			"kept answer",
 		]);
+		expect(sessions[0]?.realUserInputAt).toBe("2026-04-15T10:00:00.000Z");
 		expect(adapter.sessions.watchPaths()).toContain(sqlitePath);
 		expect(adapter.sessions.watchPaths()).toContain(`${sqlitePath}-wal`);
 		expect(adapter.sessions.watchPaths()).toContain(`${sqlitePath}-journal`);

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -6329,6 +6329,37 @@ export interface components {
             /** Units */
             units: components["schemas"]["HostedRuntimeObservedSystemdUnitV1"][];
         };
+        /** HostedRuntimeObservedUserActivityV1 */
+        HostedRuntimeObservedUserActivityV1: {
+            /**
+             * Schemaversion
+             * @constant
+             */
+            schemaVersion: 1;
+            /**
+             * Classifierversion
+             * @constant
+             */
+            classifierVersion: 1;
+            /**
+             * Classification
+             * @enum {string}
+             */
+            classification: "known_last_user_input" | "known_no_user_input" | "unknown";
+            /** Lastuserinputat */
+            lastUserInputAt: string | null;
+            /**
+             * Observedat
+             * Format: date-time
+             */
+            observedAt: string;
+            /** Completeat */
+            completeAt: string | null;
+            /** Enabledruntimes */
+            enabledRuntimes: ("hermes" | "openclaw")[];
+            /** Error */
+            error?: string | null;
+        };
         /** HostedRuntimeObservedV2 */
         HostedRuntimeObservedV2: {
             /**
@@ -7414,6 +7445,7 @@ export interface components {
                 [key: string]: components["schemas"]["HostedRuntimeObservedProviderPayload"];
             } | null;
             agentPlugins?: components["schemas"]["HostedRuntimeObservedAgentPluginsV1"] | null;
+            userActivity?: components["schemas"]["HostedRuntimeObservedUserActivityV1"] | null;
             /** Error */
             error?: string | null;
             /** Convergeerror */


### PR DESCRIPTION
## Summary
- classify real OpenClaw user activity across legacy and current transcript formats
- persist last-user-activity state from the CLI watcher and expose it in health observations
- keep v1 runtime observation wire compatibility while adding the v2 activity companion field

## Safety
- activity cache is fail-closed; missing, stale, unknown, or incomplete state is not treated as idle
- no production, SSH, or deployment changes are included

## Verification
- isolated CLI typecheck and focused tests: 25 passed
- Biome check passed
