### PR TITLE
Fix Discord gateway reconnect backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ database migration, CI, and implementation details.
 
 ### Fixed
 
+- Managed Discord connections now reset reconnect backoff after a successful
+  Gateway session and resume immediately when Discord requests a reconnect,
+  avoiding minute-long offline windows after earlier transient failures.
 - Managed Discord reconnects now discard expired interaction events after their
   short-lived response tokens have been scrubbed, instead of repeatedly
   crashing upgraded clients before later messages can be delivered.

--- a/backend/app/services/discord_gateway_worker.py
+++ b/backend/app/services/discord_gateway_worker.py
@@ -52,6 +52,10 @@ type GatewayFrame = dict[str, JsonValue]
 _GATEWAY_JSON_ADAPTER: TypeAdapter[JsonValue] = TypeAdapter(JsonValue)
 
 
+class _GatewayReconnect(RuntimeError):
+    """Discord requested an immediate reconnect so the session can resume."""
+
+
 class _GatewayConnection(Protocol):
     """The WebSocket operations required by one Discord Gateway session."""
 
@@ -92,6 +96,9 @@ class _GatewayState:
     session_id: str | None = None
     resume_gateway_url: str | None = None
     account_revision: str | None = None
+    # Preserve this marker when INVALID_SESSION clears the resume fields so
+    # the outer loop still resets backoff after an established connection.
+    session_established: bool = False
 
     def can_resume(self) -> bool:
         return self.sequence is not None and bool(self.session_id) and bool(self.resume_gateway_url)
@@ -191,6 +198,10 @@ class DiscordGatewayWorker:
                 backoff_seconds = self._reconnect_initial_seconds
             except asyncio.CancelledError:
                 raise
+            except _GatewayReconnect:
+                state.session_established = False
+                backoff_seconds = self._reconnect_initial_seconds
+                continue
             except ConnectionClosed as exc:
                 close_code = discord_gateway_close_code(exc)
                 if close_code in _SESSION_RESET_CLOSE_CODES:
@@ -208,6 +219,9 @@ class DiscordGatewayWorker:
             except Exception as exc:
                 # Gateway workers must reconnect after transport and protocol faults.
                 log.exception("discord gateway account %s failed: %s", account_id, exc)
+            if state.session_established:
+                state.session_established = False
+                backoff_seconds = self._reconnect_initial_seconds
             await _sleep_until_stop(stop, backoff_seconds)
             backoff_seconds = min(backoff_seconds * 2, self._reconnect_max_seconds)
 
@@ -275,6 +289,7 @@ class DiscordGatewayWorker:
         resume: bool,
     ) -> None:
         state.heartbeat_acknowledged = True
+        state.session_established = False
         async with self._connect_factory(
             uri,
             ping_interval=None,
@@ -333,6 +348,8 @@ class DiscordGatewayWorker:
         op = frame.get("op")
         if op == 0:
             _update_gateway_session_state(state, frame)
+            if frame.get("t") in {"READY", "RESUMED"}:
+                state.session_established = True
             await record_discord_gateway_dispatch(
                 self._sessionmaker,
                 account_id,
@@ -347,7 +364,7 @@ class DiscordGatewayWorker:
         elif op == 1:
             await _send_heartbeat(websocket, state)
         elif op == 7:
-            raise RuntimeError("discord requested reconnect")
+            raise _GatewayReconnect
         elif op == 9:
             if frame.get("d") is not True:
                 state.clear_session()

--- a/backend/tests/test_discord_gateway_websockets.py
+++ b/backend/tests/test_discord_gateway_websockets.py
@@ -306,6 +306,129 @@ async def test_transient_discord_gateway_failures_use_bounded_exponential_backof
     assert delays == [1, 2, 4, 4, 1]
 
 
+@pytest.mark.parametrize("event_type", ["READY", "RESUMED"])
+@pytest.mark.asyncio
+async def test_established_discord_gateway_sessions_reset_reconnect_backoff(
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    event_type: str,
+) -> None:
+    worker = DiscordGatewayWorker(
+        async_sessionmaker(engine, expire_on_commit=False),
+        lock_engine=engine,
+        reconnect_initial_seconds=1,
+        reconnect_max_seconds=4,
+    )
+    stop = asyncio.Event()
+    attempts = 0
+    delays: list[float] = []
+
+    class NoopGatewayConnection:
+        async def send(self, _message: str) -> None:
+            return None
+
+    async def record_dispatch(*_args, **_kwargs) -> bool:
+        return False
+
+    async def run_account(_account_id, _stop, state):
+        nonlocal attempts
+        attempts += 1
+        if attempts in {1, 2}:
+            raise OSError("temporary DNS failure")
+        if attempts == 3:
+            frame = {
+                "op": 0,
+                "t": event_type,
+                "s": 3,
+                "d": (
+                    {
+                        "session_id": "session-1",
+                        "resume_gateway_url": "wss://gateway.discord.gg/resume",
+                    }
+                    if event_type == "READY"
+                    else None
+                ),
+            }
+            await worker._handle_gateway_frame(
+                uuid4(),
+                _gateway_json(frame),
+                state,
+                NoopGatewayConnection(),
+            )
+            raise OSError("disconnect after established session")
+        if attempts == 5:
+            stop.set()
+            return True
+        raise AssertionError(f"unexpected attempt {attempts}")
+
+    async def record_delay(_stop, timeout_seconds: float) -> None:
+        delays.append(timeout_seconds)
+
+    monkeypatch.setattr(worker, "_run_account_with_lock", run_account)
+    monkeypatch.setattr(discord_gateway_worker_module, "_sleep_until_stop", record_delay)
+    monkeypatch.setattr(
+        discord_gateway_worker_module,
+        "record_discord_gateway_dispatch",
+        record_dispatch,
+    )
+
+    await worker._run_account_forever(uuid4(), stop)
+
+    assert delays == [1, 2, 1, 2, 1]
+
+
+@pytest.mark.asyncio
+async def test_discord_reconnect_opcode_retries_immediately_with_resume_state(
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worker = DiscordGatewayWorker(
+        async_sessionmaker(engine, expire_on_commit=False),
+        lock_engine=engine,
+        reconnect_initial_seconds=1,
+        reconnect_max_seconds=4,
+    )
+    stop = asyncio.Event()
+    attempts = 0
+    delays: list[tuple[int, float]] = []
+
+    class NoopGatewayConnection:
+        async def send(self, _message: str) -> None:
+            return None
+
+    async def run_account(_account_id, _stop, state):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            state.session_established = True
+            state.session_id = "session-1"
+            state.resume_gateway_url = "wss://gateway.discord.gg/resume"
+            state.sequence = 3
+            await worker._handle_gateway_frame(
+                uuid4(),
+                _gateway_json({"op": 7, "d": None}),
+                state,
+                NoopGatewayConnection(),
+            )
+        if attempts == 2:
+            assert state.can_resume()
+            assert state.session_established is False
+            stop.set()
+            return True
+        raise AssertionError(f"unexpected attempt {attempts}")
+
+    async def record_delay(_stop, timeout_seconds: float) -> None:
+        delays.append((attempts, timeout_seconds))
+
+    monkeypatch.setattr(worker, "_run_account_with_lock", run_account)
+    monkeypatch.setattr(discord_gateway_worker_module, "_sleep_until_stop", record_delay)
+
+    await worker._run_account_forever(uuid4(), stop)
+
+    assert attempts == 2
+    assert delays == [(2, 1)]
+
+
 @pytest.mark.parametrize("resume", [False, True], ids=["identify", "resume"])
 @pytest.mark.asyncio
 async def test_real_websockets_discord_gateway_transport_contract(


### PR DESCRIPTION
## Summary

- reset Discord reconnect backoff after a READY or RESUMED session has been established
- reconnect immediately on Gateway opcode 7 while preserving resume state
- retain bounded exponential backoff for failures before session establishment
- document the user-visible reconnect fix in the changelog

## Production evidence

Read-only inspection on September 1, 2026 showed the healthy `channels-worker` accumulating reconnect delays across otherwise successful long-lived sessions. The public Discord account received opcode 7 at 15:34:33 UTC, attempted resume 60 seconds later, received opcode 9 at 15:35:33 UTC, and only then established a fresh session. The connection recovered without a restart and continued receiving inbound events.

A separate private account returned close code 4004 at worker startup and has no active bindings; that invalid credential is unrelated to this reconnect-delay fix. No production mutation, restart, or deployment was performed.

## Verification

- `bash scripts/test.sh backend tests/test_discord_gateway_websockets.py tests/test_channel_workers.py` (`26 passed`, Docker-isolated PostgreSQL runner)
- `uv run ruff check app/services/discord_gateway_worker.py tests/test_discord_gateway_websockets.py`
- `uv run ruff format --check app/services/discord_gateway_worker.py tests/test_discord_gateway_websockets.py`
- `uv run python scripts/type_governance.py changed app/services/discord_gateway_worker.py`
- `uv run python -m compileall -q app/services/discord_gateway_worker.py tests/test_discord_gateway_websockets.py`
- `git diff --check`