### PR TITLE
fix(cli): pin managed WhatsApp plugin to runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ database migration, CI, and implementation details.
 - Session search now indexes very large messages in bounded chunks, so long
   transcripts remain fully searchable without exceeding PostgreSQL full-text
   limits; results and match navigation still point to the original message.
+- Managed OpenClaw WhatsApp now installs the exact plugin version compatible with the runtime.
 
 ## Clawdi CLI v0.14.35
 

--- a/bun.lock
+++ b/bun.lock
@@ -101,7 +101,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.35",
+      "version": "0.14.36",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.35",
+	"version": "0.14.36",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest-channels.test.ts
+++ b/packages/cli/src/runtime/manifest-channels.test.ts
@@ -13,7 +13,10 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { materializeHostedChannelCredentials } from "./manifest-channels";
+import {
+	materializeHostedChannelCredentials,
+	normalizeOpenClawRuntimeVersion,
+} from "./manifest-channels";
 import type { RuntimeManifest } from "./manifest-contract";
 import { withRuntimeUserFileAccess } from "./runtime-user-command";
 
@@ -97,6 +100,19 @@ function credsJson(secret = "managed-secret", credentialId?: string): string {
 		},
 	});
 }
+
+describe("OpenClaw runtime version normalization", () => {
+	test.each([
+		["openclaw 2026.7.1-2", "2026.7.1"],
+		["openclaw 2026.7.1-beta.3", "2026.7.1-beta.3"],
+	])("normalizes %s to %s", (output, expected) => {
+		expect(normalizeOpenClawRuntimeVersion(output)).toBe(expected);
+	});
+
+	test("rejects output without a valid semver", () => {
+		expect(normalizeOpenClawRuntimeVersion("openclaw development build")).toBeNull();
+	});
+});
 
 describe("managed WhatsApp auth directories", () => {
 	test("materializes ownership in creds.json and removes stale managed auth", () => {

--- a/packages/cli/src/runtime/manifest-channels.ts
+++ b/packages/cli/src/runtime/manifest-channels.ts
@@ -11,8 +11,8 @@ import {
 } from "node:fs";
 import { join, resolve } from "node:path";
 import type { z } from "zod";
-import { isValidSemver } from "../lib/semver";
 import { writePrivateFileAtomic } from "../lib/private-file";
+import { isValidSemver } from "../lib/semver";
 import { type HermesConfigTransaction, reconcileHermesConfigValue } from "./hermes-config";
 import type { OpenClawHostedContext } from "./hosted-openclaw-context";
 import {
@@ -23,8 +23,8 @@ import type { RuntimeManifest } from "./manifest-contract";
 import {
 	type RuntimeInstallObservation,
 	runtimeCommandCurrentRevision,
-	runtimeFileCurrentRevision,
 	runtimeCommandVersion,
+	runtimeFileCurrentRevision,
 } from "./manifest-install";
 import { openClawConfigPatchIsApplied } from "./manifest-providers";
 import { canonicalJsonEqual, isPlainRecord, recordValue } from "./manifest-shared";

--- a/packages/cli/src/runtime/manifest-channels.ts
+++ b/packages/cli/src/runtime/manifest-channels.ts
@@ -11,6 +11,7 @@ import {
 } from "node:fs";
 import { join, resolve } from "node:path";
 import type { z } from "zod";
+import { isValidSemver } from "../lib/semver";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { type HermesConfigTransaction, reconcileHermesConfigValue } from "./hermes-config";
 import type { OpenClawHostedContext } from "./hosted-openclaw-context";
@@ -23,6 +24,7 @@ import {
 	type RuntimeInstallObservation,
 	runtimeCommandCurrentRevision,
 	runtimeFileCurrentRevision,
+	runtimeCommandVersion,
 } from "./manifest-install";
 import { openClawConfigPatchIsApplied } from "./manifest-providers";
 import { canonicalJsonEqual, isPlainRecord, recordValue } from "./manifest-shared";
@@ -590,7 +592,7 @@ function installOpenClawChannelPlugins(input: {
 	workspaceRoot: string;
 }): void {
 	for (const channel of Object.keys(input.channels).sort()) {
-		const specs = OPENCLAW_EXTERNAL_CHANNEL_PLUGIN_SPECS[channel];
+		const specs = openClawExternalChannelPluginSpecs(channel, input);
 		if (!specs) continue;
 		const isCurrent = () =>
 			channelPluginIsCurrent({
@@ -606,6 +608,19 @@ function installOpenClawChannelPlugins(input: {
 			throw new Error(`OpenClaw ${channel} channel plugin install could not be verified`);
 		}
 	}
+}
+function openClawExternalChannelPluginSpecs(
+	channel: string,
+	input: { commandPath: string; home: string; workspaceRoot: string },
+): readonly string[] | null {
+	if (channel !== "whatsapp") return OPENCLAW_EXTERNAL_CHANNEL_PLUGIN_SPECS[channel] ?? null;
+	const version = normalizeOpenClawRuntimeVersion(
+		runtimeCommandVersion(input.commandPath, input.home, input.workspaceRoot) ?? "",
+	);
+	if (!version) {
+		throw new Error("OpenClaw runtime version could not be determined for the WhatsApp plugin");
+	}
+	return [`clawhub:${OPENCLAW_WHATSAPP_PLUGIN_PACKAGE}@${version}`];
 }
 function runPluginInstallWithFallback(
 	commandPath: string,
@@ -679,7 +694,9 @@ function channelPluginIsCurrent(input: {
 		const sourceRevision = runtimeFileCurrentRevision(plugin.source);
 		if (
 			plugin.id !== input.channel ||
-			!input.specs.some((spec) => openClawPluginInstallMatchesSpec(install, spec)) ||
+			!input.specs.some((spec) =>
+				openClawPluginInstallMatchesSpec(install, spec, plugin.version),
+			) ||
 			plugin.status !== "loaded" ||
 			!plugin.enabled ||
 			!version ||
@@ -695,15 +712,43 @@ function channelPluginIsCurrent(input: {
 function openClawPluginInstallMatchesSpec(
 	install: z.infer<typeof openClawPluginInspectSchema>["install"],
 	spec: string,
+	pluginVersion?: string,
 ): boolean {
+	const clawHubSpec = /^clawhub:(.+)@([^@]+)$/.exec(spec);
+	if (clawHubSpec) {
+		const [, expectedPackage, expectedVersion] = clawHubSpec;
+		if (
+			install.source !== "clawhub" ||
+			install.clawhubPackage !== expectedPackage ||
+			!expectedVersion
+		) {
+			return false;
+		}
+		const installedVersions = [pluginVersion, install.resolvedVersion, install.version].filter(
+			(value): value is string => Boolean(value),
+		);
+		return (
+			installedVersions.length > 0 &&
+			installedVersions.every((version) => version === expectedVersion)
+		);
+	}
 	const recordedSpecs = [install.spec, install.resolvedSpec];
 	if (install.source === "clawhub" && install.clawhubPackage) {
 		recordedSpecs.push(`clawhub:${install.clawhubPackage}`);
 	}
 	return recordedSpecs.includes(spec);
 }
+const OPENCLAW_RUNTIME_VERSION_RE =
+	/(?:^|[^\d])(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)(?:$|[^\dA-Za-z-])/;
+const OPENCLAW_WHATSAPP_PLUGIN_PACKAGE = "@openclaw/whatsapp";
+
+export function normalizeOpenClawRuntimeVersion(output: string): string | null {
+	const version = OPENCLAW_RUNTIME_VERSION_RE.exec(output)?.[1];
+	if (!version) return null;
+	const normalized = version.replace(/-\d+$/, "");
+	return isValidSemver(normalized) ? normalized : null;
+}
 export const OPENCLAW_EXTERNAL_CHANNEL_PLUGIN_SPECS: Record<string, readonly string[]> = {
 	discord: ["@openclaw/discord"],
-	whatsapp: ["clawhub:@openclaw/whatsapp"],
 };
 const OPENCLAW_MANAGED_CHANNELS = ["telegram", "discord", "whatsapp"] as const;

--- a/packages/cli/src/runtime/manifest-install.ts
+++ b/packages/cli/src/runtime/manifest-install.ts
@@ -75,7 +75,7 @@ const HERMES_DASHBOARD_CAPABILITY_PROBE_TIMEOUT_MS = 30_000;
 const DEFAULT_RUNTIME_INSTALL_TIMEOUT_MS = 30 * 60 * 1000;
 const runtimeCommandRevisions = new Map<
 	string,
-	{ executableRevision: string; commandRevision: string }
+	{ executableRevision: string; commandRevision: string; version: string }
 >();
 const hermesDashboardCapabilityRevisions = new Map<string, string>();
 function runtimeInstallTimeoutMs(): number {
@@ -479,6 +479,15 @@ export function runtimeCommandCurrentRevision(
 	const cacheKey = `${command}\0${home}\0${cwd}`;
 	const cached = runtimeCommandRevisions.get(cacheKey);
 	if (cached?.executableRevision === executableRevision) return cached.commandRevision;
+	runtimeCommandVersion(command, home, cwd);
+	return runtimeCommandRevisions.get(cacheKey)?.commandRevision ?? null;
+}
+export function runtimeCommandVersion(command: string, home: string, cwd: string): string | null {
+	const executableRevision = runtimeFileCurrentRevision(command);
+	if (!executableRevision) return null;
+	const cacheKey = `${command}\0${home}\0${cwd}`;
+	const cached = runtimeCommandRevisions.get(cacheKey);
+	if (cached?.executableRevision === executableRevision) return cached.version;
 	try {
 		const versionResult = spawnRuntimeUserCommand(command, ["--version"], home, cwd, {
 			timeoutMs: 10_000,
@@ -503,8 +512,8 @@ export function runtimeCommandCurrentRevision(
 			executableRevision,
 			version,
 		});
-		runtimeCommandRevisions.set(cacheKey, { executableRevision, commandRevision });
-		return commandRevision;
+		runtimeCommandRevisions.set(cacheKey, { executableRevision, commandRevision, version });
+		return version;
 	} catch (error) {
 		if (error instanceof RuntimeUserCommandTimeoutError) throw error;
 		return null;

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1238,21 +1238,24 @@ function openClawDiscordPluginInspectFixture(pluginSource: string): Record<strin
 	};
 }
 
-function openClawWhatsAppPluginInspectFixture(pluginSource: string): Record<string, unknown> {
+function openClawWhatsAppPluginInspectFixture(
+	pluginSource: string,
+	version = "2026.7.1",
+): Record<string, unknown> {
 	return {
 		plugin: {
 			id: "whatsapp",
 			source: pluginSource,
 			origin: "global",
 			status: "loaded",
-			version: "2026.7.1",
+			version,
 			enabled: true,
 		},
 		install: {
 			source: "clawhub",
 			clawhubPackage: "@openclaw/whatsapp",
 			installPath: dirname(pluginSource),
-			version: "2026.7.1",
+			version,
 			integrity: "sha256-test",
 			npmIntegrity: "sha512-test",
 			clawpackSha256: "sha256-test-clawpack",
@@ -9738,6 +9741,7 @@ exit 64
 		const workspace = join(home, "clawdi");
 		const openclawBin = join(home, ".local", "bin", "openclaw");
 		const openclawPatch = join(root, "openclaw-channel-delete-patch.jsonl");
+		const openclawPluginInstalls = join(root, "openclaw-whatsapp-plugin-installs.txt");
 		const openclawPluginSource = join(
 			home,
 			".openclaw",
@@ -9758,10 +9762,11 @@ if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin
   exit 0
 fi
 if [ "\${1:-}" = "--version" ]; then
-  printf 'openclaw 2026.7.1\\n'
+  printf 'openclaw 2026.7.1-2\\n'
   exit 0
 fi
-if [ "$*" = "plugins install clawhub:@openclaw/whatsapp --force" ]; then
+if [ "$*" = "plugins install clawhub:@openclaw/whatsapp@2026.7.1 --force" ]; then
+  printf '%s\\n' "$*" >> '${openclawPluginInstalls}'
   mkdir -p '${dirname(openclawPluginSource)}'
   printf 'export const whatsappPlugin = true;\\n' > '${openclawPluginSource}'
   exit 0
@@ -9796,6 +9801,7 @@ exit 0
 		};
 
 		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+		const unchangedConvergence = convergeRuntimeManifest(loaded, getRuntimePaths());
 		const removed: RuntimeManifestLoad = {
 			...loaded,
 			manifest: {
@@ -9807,20 +9813,103 @@ exit 0
 		const removedConvergence = convergeRuntimeManifest(removed, getRuntimePaths());
 
 		expect(convergence.installErrors).toEqual([]);
+		expect(unchangedConvergence.installErrors).toEqual([]);
 		expect(removedConvergence.installErrors).toEqual([]);
+		expect(readFileSync(openclawPluginInstalls, "utf-8")).toBe(
+			"plugins install clawhub:@openclaw/whatsapp@2026.7.1 --force\n",
+		);
 		const patches = readFileSync(openclawPatch, "utf-8")
 			.split("\n---\n")
 			.filter((entry) => entry.trim().length > 0)
 			.map((entry) => JSON.parse(entry))
 			.filter((patch) => Object.hasOwn(patch, "channels"));
-		expect(patches).toHaveLength(2);
+		expect(patches).toHaveLength(3);
 		expect(patches[0].channels.whatsapp.accounts).toHaveProperty("clawdi_whatsapp");
 		expect(patches[0].channels.whatsapp.accounts.clawdi_whatsapp.authDir).toBe(
 			join(home, ".openclaw", "credentials", "whatsapp"),
 		);
 		expect(patches[0].session).toEqual({ dmScope: "per-account-channel-peer" });
-		expect(patches[1].channels.whatsapp).toBeNull();
-		expect(patches[1].session).toEqual({ dmScope: null });
+		expect(patches[2].channels.whatsapp).toBeNull();
+		expect(patches[2].session).toEqual({ dmScope: null });
+	});
+
+	it("reinstalls OpenClaw WhatsApp when the installed version differs", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const workspace = join(home, "clawdi");
+		const openclawBin = join(home, ".local", "bin", "openclaw");
+		const openclawPluginSource = join(
+			home,
+			".openclaw",
+			"extensions",
+			"whatsapp",
+			"dist",
+			"index.js",
+		);
+		const openclawPluginInstalls = join(root, "openclaw-whatsapp-plugin-installs.txt");
+		const installedMarker = join(root, "whatsapp-plugin-reinstalled");
+		mkdirSync(dirname(openclawBin), { recursive: true });
+		mkdirSync(dirname(openclawPluginSource), { recursive: true });
+		mkdirSync(workspace, { recursive: true });
+		writeFileSync(openclawPluginSource, "export const whatsappPlugin = true;\n");
+		writeFileSync(
+			openclawBin,
+			`#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "--version" ]; then
+  printf 'openclaw 2026.7.1-2\\n'
+  exit 0
+fi
+if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
+  cat >/dev/null
+  exit 0
+fi
+if [ "$*" = "plugins install clawhub:@openclaw/whatsapp@2026.7.1 --force" ]; then
+  printf '%s\\n' "$*" >> '${openclawPluginInstalls}'
+  touch '${installedMarker}'
+  exit 0
+fi
+if [ "$*" = "plugins inspect whatsapp --json" ]; then
+  if [ -f '${installedMarker}' ]; then
+    printf '%s\\n' '${JSON.stringify(openClawWhatsAppPluginInspectFixture(openclawPluginSource))}'
+  else
+    printf '%s\\n' '${JSON.stringify(openClawWhatsAppPluginInspectFixture(openclawPluginSource, "2026.8.2"))}'
+  fi
+  exit 0
+fi
+exit 0
+`,
+		);
+		chmodSync(openclawBin, 0o700);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+
+		const loaded = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 10);
+		loaded.manifest.projection = {
+			...loaded.manifest.projection,
+			channels: {
+				whatsapp: {
+					enabled: true,
+					defaultAccount: "clawdi_whatsapp",
+					accounts: {
+						clawdi_whatsapp: {
+							enabled: true,
+							authDir: join(home, ".openclaw", "credentials", "whatsapp"),
+						},
+					},
+				},
+			},
+		};
+
+		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+
+		expect(convergence.installErrors).toEqual([]);
+		expect(readFileSync(openclawPluginInstalls, "utf-8")).toBe(
+			"plugins install clawhub:@openclaw/whatsapp@2026.7.1 --force\n",
+		);
 	});
 
 	it("does not mutate live config when an OpenClaw channel plugin install fails", () => {


### PR DESCRIPTION
## Summary

- derive the managed WhatsApp ClawHub version from the installed OpenClaw runtime
- normalize OpenClaw correction builds such as `2026.7.1-2` to the published plugin version `2026.7.1`
- require exact official package provenance and version before treating the plugin as current
- release `clawdi@0.14.36`

## Verification

- Docker-isolated CLI focused suite: 146 passed
- CLI typecheck
- Biome
- publish manifest check
- `git diff --check`

## Release impact

The protected CLI publish workflow will publish `clawdi@0.14.36` after merge. Hosted rollout remains a separate manifest/AppSetting and Fleet API operation; no runtime or tenant was changed by this PR.
