### PR TITLE
fix(cli): preserve health during transient manifest fetch failures

### DIFF
--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1099,6 +1099,7 @@ function runtimeWatchEventForOutcome(
 			mode: outcome.failure.mode,
 			activeGeneration: outcome.failure.activeGeneration ?? null,
 			rejectedGeneration: outcome.failure.rejectedGeneration ?? null,
+			healthImpact: "resource_projection",
 			...(outcome.failure.etag ? { etag: outcome.failure.etag } : {}),
 		});
 	}

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -7152,6 +7152,14 @@ exit 64
 				testBundleEtag("etag-recovered"),
 			);
 			expect(existsSync(join(state, "cache", "manifest.etag"))).toBe(false);
+
+			const refreshFailure = await runOnce(() => {
+				throw new TypeError("fetch failed");
+			}, "error");
+			expect(refreshFailure.healthImpact).toBe("resource_projection");
+			expect(readRuntimeAppliedState(getRuntimePaths())?.etag).toBe(
+				testBundleEtag("etag-recovered"),
+			);
 		} finally {
 			console.log = previousLog;
 			process.exitCode = previousExitCode;


### PR DESCRIPTION
## Summary

- classify transient runtime manifest load failures as `resource_projection` in watch observations
- preserve the durable applied runtime as healthy while retaining `convergeError`
- keep boot, systemd, provider, and apply failures unhealthy

This prevents a transient control-plane/network fetch error from being projected as `runtime_unreachable` and entering Hosted failure cleanup that deletes the tenant instance.

## Verification

- Docker-isolated CLI typecheck
- Docker-isolated `tests/runtime.test.ts` and `src/runtime/observed-v2.test.ts`
- 118 passed, 0 failed
- Biome check
- `git diff --check`
