### PR TITLE
fix(runtime): reload reinstalled user units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ database migration, CI, and implementation details.
 
 ### Fixed
 
+- Hosted runtime reconciliation now reloads user systemd services after an
+  official runtime installer replaces their unit definitions, even when the
+  restored managed drop-in is byte-for-byte unchanged.
 - Managed Discord connections now reset reconnect backoff after a successful
   Gateway session and resume immediately when Discord requests a reconnect,
   avoiding minute-long offline windows after earlier transient failures.

--- a/bun.lock
+++ b/bun.lock
@@ -100,7 +100,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.37",
+      "version": "0.14.38",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.37",
+	"version": "0.14.38",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1336,7 +1336,7 @@ async function applyRuntimeDesiredState(
 						);
 					}
 				},
-				activate: ({ staleSystemUnits, staleUserUnits }) => {
+				activate: ({ staleSystemUnits, staleUserUnits, invalidatedUserUnits }) => {
 					// Official installers run after the prerequisite phase and add their
 					// base units, so final reconciliation must observe a fresh rendered state.
 					const candidateSystemdUnits = readSystemdUnitSnapshot(paths);
@@ -1353,6 +1353,7 @@ async function applyRuntimeDesiredState(
 							{
 								recoverFailedUnits: opts.recoverFailedSystemdUnits,
 								restartChangedUnits: load.source === "last-good-cache",
+								invalidatedUserUnits,
 								skipActivatedSystemUnits: egressPrerequisiteActivated
 									? [RUNTIME_SIDECAR_SYSTEM_UNIT]
 									: [],

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -1038,6 +1038,7 @@ function activateRuntimeServices(
 		const prerequisite = opts.systemdApply.activateEgressPrerequisite({
 			staleSystemUnits: [],
 			staleUserUnits: [],
+			invalidatedUserUnits: [],
 		});
 		if (!prerequisite.applied) {
 			throw new Error("transparent-egress system prerequisites did not reach readiness");
@@ -1067,6 +1068,7 @@ function activateRuntimeServices(
 		const activation = opts.systemdApply.activate({
 			staleSystemUnits: state.staleSystemdFiles.systemUnits,
 			staleUserUnits: state.staleSystemdFiles.userUnits,
+			invalidatedUserUnits: officialServicePlan.pending.map((item) => item.unitName),
 		});
 		if (!activation.applied) {
 			throw new Error("systemd runtime services did not reach required readiness");

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -1355,6 +1355,7 @@ esac
 
 		let prerequisiteActivations = 0;
 		let finalActivations = 0;
+		let invalidatedUserUnits: string[] = [];
 		const result = convergeRuntimeManifest(
 			{
 				manifest,
@@ -1369,8 +1370,9 @@ esac
 						prerequisiteActivations += 1;
 						return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
 					},
-					activate: () => {
+					activate: (signal) => {
 						finalActivations += 1;
+						invalidatedUserUnits = signal.invalidatedUserUnits;
 						return { applied: true, systemUnitsChanged: [], userUnitsChanged: [] };
 					},
 				},
@@ -1380,6 +1382,7 @@ esac
 		expect(result.installErrors).toEqual([]);
 		expect(prerequisiteActivations).toBe(0);
 		expect(finalActivations).toBe(1);
+		expect(invalidatedUserUnits).toEqual(["hermes-gateway.service", "openclaw-gateway.service"]);
 		expect(readFileSync(logPath, "utf8").trim().split("\n").slice(-4)).toEqual([
 			"hermes drop-in absent",
 			"hermes gateway install --force",

--- a/packages/cli/src/runtime/manifest-shared.ts
+++ b/packages/cli/src/runtime/manifest-shared.ts
@@ -47,6 +47,7 @@ type RuntimeSystemdApplyResult = {
 interface RuntimeSystemdApplySignal {
 	staleSystemUnits: string[];
 	staleUserUnits: string[];
+	invalidatedUserUnits: string[];
 }
 export interface RuntimeSystemdApplyHooks {
 	activateEgressPrerequisite: (signal: RuntimeSystemdApplySignal) => RuntimeSystemdApplyResult;

--- a/packages/cli/src/runtime/systemd-transaction.ts
+++ b/packages/cli/src/runtime/systemd-transaction.ts
@@ -93,20 +93,24 @@ function readManagedSystemdUnits(
 function changedSystemdUnits(
 	before: Map<string, string>,
 	after: Map<string, string>,
+	invalidated: readonly string[] = [],
 ): { added: string[]; changed: string[]; removed: string[]; present: string[] } {
-	const added: string[] = [];
-	const changed: string[] = [];
+	const added = new Set<string>();
+	const changed = new Set<string>();
 	const removed: string[] = [];
 	for (const [name, contents] of after) {
-		if (!before.has(name)) added.push(name);
-		else if (before.get(name) !== contents) changed.push(name);
+		if (!before.has(name)) added.add(name);
+		else if (before.get(name) !== contents) changed.add(name);
+	}
+	for (const name of invalidated) {
+		if (before.has(name) && after.has(name)) changed.add(name);
 	}
 	for (const name of before.keys()) {
 		if (!after.has(name)) removed.push(name);
 	}
 	return {
-		added: added.sort(),
-		changed: changed.sort(),
+		added: [...added].sort(),
+		changed: [...changed].sort(),
 		removed: removed.sort(),
 		present: [...after.keys()].sort(),
 	};
@@ -131,6 +135,7 @@ export function applySystemdRuntimeUpdate(
 	opts: {
 		recoverFailedUnits?: boolean;
 		restartChangedUnits?: boolean;
+		invalidatedUserUnits?: readonly string[];
 		activationScope?: {
 			systemUnits: readonly string[];
 			userUnits: readonly string[];
@@ -144,7 +149,7 @@ export function applySystemdRuntimeUpdate(
 	userUnitsChanged: string[];
 } {
 	const allSystem = changedSystemdUnits(before.system, after.system);
-	const allUser = changedSystemdUnits(before.user, after.user);
+	const allUser = changedSystemdUnits(before.user, after.user, opts.invalidatedUserUnits);
 	const filterChanges = (
 		changes: ReturnType<typeof changedSystemdUnits>,
 		units: Iterable<string>,

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -5944,6 +5944,44 @@ cp '${sdkSource}' '${sdkTarget}'
 		}
 	});
 
+	it("reapplies an invalidated user unit when its rendered snapshot is unchanged", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const bin = join(root, "bin");
+		const systemctlLog = join(root, "systemctl-invalidation.log");
+		const systemctlStateRoot = join(root, "systemctl-invalidation-state");
+		const paths = seedRuntimeWatchLocaleBaseline(home, state, run);
+		const snapshot = readSystemdUnitSnapshot(paths);
+		const unit = "openclaw-gateway.service";
+
+		writeFakeSystemdManager({
+			path: join(bin, "systemctl"),
+			logPath: systemctlLog,
+			stateRoot: systemctlStateRoot,
+		});
+		seedFakeSystemdSnapshotProcesses(paths, systemctlStateRoot, snapshot);
+		writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "failed"), "\n");
+		writeFileSync(fakeSystemdStatePath(systemctlStateRoot, "user", unit, "reload"), "\n");
+		process.env.CLAWDI_SYSTEMD_APPLY = "1";
+		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
+
+		const activation = applySystemdRuntimeUpdate(paths, snapshot, snapshot, {
+			recoverFailedUnits: false,
+			invalidatedUserUnits: [unit],
+		});
+
+		expect(activation).toMatchObject({
+			applied: true,
+			systemUnitsChanged: [],
+			userUnitsChanged: [unit],
+		});
+		const calls = readFileSync(systemctlLog, "utf-8").trim().split("\n");
+		expect(calls).toContain("--user daemon-reload");
+		expect(calls).toContain(`--user reset-failed ${unit}`);
+		expect(calls).toContain(`--user start ${unit}`);
+	});
+
 	it("runtime watch keeps polling after SSE authentication failure", async () => {
 		installSuccessfulSystemctlFixture();
 		const home = join(root, "home", "clawdi");


### PR DESCRIPTION
## Summary

- carry official runtime service reinstalls into the final systemd activation as explicit user-unit invalidations
- reload and reactivate invalidated units even when the restored managed drop-in has the same content fingerprint
- release `clawdi@0.14.38`

## Root cause

An official Hermes/OpenClaw installer can remove a managed drop-in, replace the base unit, and start the service before Clawdi republishes the drop-in. When the final base unit, drop-in, and environment file are byte-for-byte identical to the pre-install snapshot, content comparison sees no change even though the user systemd manager loaded the intermediate base-only definition. The transaction then skips `daemon-reload`; a non-retryable gateway exit remains failed with the managed environment still unloaded.

## Verification

- `bash scripts/test.sh cli tests/runtime.test.ts --test-name-pattern 'reapplies an invalidated user unit'`
- `bash scripts/test.sh cli src/runtime/systemd.test.ts src/runtime/manifest-services.test.ts`
- Biome check for all changed CLI source and test files
- `git diff --check`
