### PR TITLE
fix(backend): release database sessions across slow I/O

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -1049,6 +1049,13 @@ async def require_user_auth(auth: AuthContext = Depends(get_auth)) -> AuthContex
     return auth
 
 
+async def require_user_auth_short_session(
+    auth: AuthContext = Depends(get_auth_short_session),
+) -> AuthContext:
+    """Apply the user-level gate without holding auth DB state across slow I/O."""
+    return await require_user_auth(auth)
+
+
 def require_clerk_id(auth: AuthContext) -> str:
     """Return the Clerk id required by user-scoped integrations."""
     clerk_id = auth.user.clerk_id

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -4,6 +4,7 @@ import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
+import anyio
 from sqlalchemy import event
 from sqlalchemy.engine import Connection, ExceptionContext
 from sqlalchemy.engine.interfaces import DBAPIConnection, DBAPICursor, ExecutionContext
@@ -112,17 +113,18 @@ async def _close_session(session: AsyncSession) -> None:
     close_task = asyncio.create_task(session.close())
     cancellation: asyncio.CancelledError | None = None
 
-    while not close_task.done():
-        try:
-            await asyncio.shield(close_task)
-        except asyncio.CancelledError as exc:
-            cancellation = exc
-        except Exception as exc:
-            if cancellation is None:
-                raise
+    with anyio.CancelScope(shield=True):
+        while not close_task.done():
+            try:
+                await asyncio.shield(close_task)
+            except asyncio.CancelledError as exc:
+                cancellation = exc
+            except Exception as exc:
+                if cancellation is None:
+                    raise
 
-            log.exception("Database session cleanup failed during request cancellation")
-            raise cancellation from exc
+                log.exception("Database session cleanup failed during request cancellation")
+                raise cancellation from exc
 
     try:
         close_task.result()

--- a/backend/app/routes/connectors.py
+++ b/backend/app/routes/connectors.py
@@ -2,7 +2,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
-from app.core.auth import AuthContext, require_clerk_id, require_user_auth
+from app.core.auth import AuthContext, require_clerk_id, require_user_auth_short_session
 from app.core.config import settings
 from app.schemas.common import Paginated
 from app.schemas.connector import (
@@ -109,7 +109,7 @@ def _map_composio_error(exc: ComposioRouteError) -> HTTPException:
 
 @router.get("")
 async def list_connections(
-    auth: AuthContext = Depends(require_user_auth),
+    auth: AuthContext = Depends(require_user_auth_short_session),
 ) -> list[ConnectorConnectionResponse]:
     """List user's connected services."""
     if not settings.composio_api_key:
@@ -132,7 +132,7 @@ async def list_connections(
 
 @router.get("/available")
 async def list_available_apps(
-    auth: AuthContext = Depends(require_user_auth),
+    auth: AuthContext = Depends(require_user_auth_short_session),
     search: str | None = Query(default=None, max_length=100),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=24, ge=1, le=100),
@@ -166,7 +166,7 @@ async def list_available_apps(
 @router.get("/available/{app_name}")
 async def get_available_app(
     app_name: str,
-    auth: AuthContext = Depends(require_user_auth),
+    auth: AuthContext = Depends(require_user_auth_short_session),
 ) -> ConnectorAvailableAppResponse:
     """Single-app metadata lookup — used by the detail page so it doesn't
     have to page through the whole catalog to find one app's display name.
@@ -186,7 +186,7 @@ async def get_available_app(
 async def connect_app(
     app_name: str,
     body: ConnectRequest | None = None,
-    auth: AuthContext = Depends(require_user_auth),
+    auth: AuthContext = Depends(require_user_auth_short_session),
 ) -> ConnectorConnectResponse:
     """Generate OAuth connect link for an app.
 
@@ -222,7 +222,7 @@ async def connect_app(
 @router.get("/{app_name}/auth-fields")
 async def auth_fields(
     app_name: str,
-    auth: AuthContext = Depends(require_user_auth),
+    auth: AuthContext = Depends(require_user_auth_short_session),
 ) -> ConnectorAuthFieldsResponse:
     """Return the auth scheme + credential fields for non-OAuth apps.
 
@@ -244,7 +244,7 @@ async def auth_fields(
 async def connect_credentials(
     app_name: str,
     body: ConnectorCredentialsConnectRequest,
-    auth: AuthContext = Depends(require_user_auth),
+    auth: AuthContext = Depends(require_user_auth_short_session),
 ) -> ConnectorCredentialsConnectResponse:
     """Create a connection from user-supplied API-key credentials.
 
@@ -278,7 +278,7 @@ async def connect_credentials(
 @router.delete("/{connection_id}")
 async def disconnect(
     connection_id: str,
-    auth: AuthContext = Depends(require_user_auth),
+    auth: AuthContext = Depends(require_user_auth_short_session),
 ) -> ConnectorDisconnectResponse:
     """Disconnect a connected account.
 
@@ -309,7 +309,7 @@ async def disconnect(
 
 @router.get("/mcp-config", response_model=ConnectorMcpConfigResponse)
 async def get_mcp_config(
-    auth: AuthContext = Depends(require_user_auth),
+    auth: AuthContext = Depends(require_user_auth_short_session),
 ) -> ConnectorMcpConfigResponse:
     """Return the deprecated MCP bridge config required by legacy clients."""
     if not settings.composio_api_key:
@@ -324,7 +324,7 @@ async def get_mcp_config(
 @router.get("/{app_name}/tools")
 async def list_app_tools(
     app_name: str,
-    auth: AuthContext = Depends(require_user_auth),
+    auth: AuthContext = Depends(require_user_auth_short_session),
 ) -> list[ConnectorToolResponse]:
     """List available tools/actions for a specific app."""
     if not settings.composio_api_key:

--- a/backend/app/routes/dashboard.py
+++ b/backend/app/routes/dashboard.py
@@ -45,6 +45,7 @@ async def get_stats(
     days: int = Query(default=365, ge=1, le=_DASHBOARD_DAYS_MAX),
 ) -> DashboardStatsResponse:
     response.headers["Cache-Control"] = "private, max-age=30, stale-while-revalidate=30"
+    clerk_id = require_clerk_id(auth)
     now = datetime.now(UTC)
     since = now - timedelta(days=days)
     current_floor = now.date() - timedelta(days=1)
@@ -246,7 +247,8 @@ async def get_stats(
         if item["contribution_day"] is not None
     }
 
-    connectors_count = await _cached_connectors_count(require_clerk_id(auth))
+    await db.commit()
+    connectors_count = await _cached_connectors_count(clerk_id)
 
     return DashboardStatsResponse(
         total_sessions=int(row["total_sessions"] or 0),

--- a/backend/app/routes/mcp_bridge.py
+++ b/backend/app/routes/mcp_bridge.py
@@ -27,7 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import (
     AuthContext,
-    get_auth,
+    get_auth_short_session,
     is_env_bound_api_key,
     is_runtime_deployment_principal,
     require_auth_scopes,
@@ -547,7 +547,7 @@ async def mcp_composio_post(request: Request) -> JsonObject:
 @router.post("/clawdi", include_in_schema=False, response_model=None)
 async def mcp_clawdi_post(
     request: Request,
-    auth: AuthContext = Depends(get_auth),
+    auth: AuthContext = Depends(get_auth_short_session),
     db: AsyncSession = Depends(get_session),
 ) -> JsonObject | list[JsonObject] | Response:
     """Agent-facing stateless MCP endpoint backed directly by Clawdi Cloud."""

--- a/backend/app/services/memory_provider.py
+++ b/backend/app/services/memory_provider.py
@@ -58,6 +58,7 @@ class BuiltinProvider:
     ) -> MemoryItem:
         vec: list[float] | None = None
         if self.embedder is not None:
+            await self.db.commit()
             try:
                 vec = await self.embedder.embed(content)
             except EmbeddingUpstreamError as exc:
@@ -95,6 +96,7 @@ class BuiltinProvider:
         if self.embedder is None:
             return fts_rows
 
+        await self.db.commit()
         try:
             vec_rows = await self._search_vector(user_id, query, limit, category)
         except Exception as e:
@@ -384,12 +386,14 @@ async def get_memory_provider(user_id: str, db: AsyncSession) -> MemoryProvider:
         # land in user_settings, so this branch is the safety net,
         # not the primary gate.
         try:
-            return Mem0Provider(api_key=api_key)
+            provider = Mem0Provider(api_key=api_key)
         except MemoryProviderUnavailableError:
             log.warning(
                 "memory_provider=mem0 but the Mem0 SDK boundary is unavailable; "
                 "falling back to builtin"
             )
             return BuiltinProvider(db, embedder=resolve_embedder())
+        await db.commit()
+        return provider
 
     return BuiltinProvider(db, embedder=resolve_embedder())

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,6 +3,7 @@ name = "clawdi-backend"
 version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
+    "anyio>=4.0",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.34",
     "sqlalchemy[asyncio]>=2.0",

--- a/backend/scripts/outbound_api_governance.py
+++ b/backend/scripts/outbound_api_governance.py
@@ -35,6 +35,7 @@ SDK_IMPORT_OWNERS: dict[str, str] = {
 # removed dependency root requires an explicit review of its owner and types.
 EXPECTED_THIRD_PARTY_IMPORT_ROOTS = frozenset(
     {
+        "anyio",
         "asyncpg",
         "boto3",
         "botocore",

--- a/backend/tests/test_dashboard_performance.py
+++ b/backend/tests/test_dashboard_performance.py
@@ -246,6 +246,7 @@ async def test_dashboard_stats_matches_visible_inventory_and_one_week_started_at
 @pytest.mark.asyncio
 async def test_dashboard_stats_caches_connector_count(
     client: httpx.AsyncClient,
+    db_session: AsyncSession,
     monkeypatch,
 ) -> None:
     from app.services import composio
@@ -258,6 +259,7 @@ async def test_dashboard_stats_caches_connector_count(
         _clerk_id: str,
     ) -> list[ConnectorConnectionResponse]:
         nonlocal calls
+        assert not db_session.in_transaction()
         calls += 1
         return [
             ConnectorConnectionResponse(

--- a/backend/tests/test_database_session_cleanup.py
+++ b/backend/tests/test_database_session_cleanup.py
@@ -1,15 +1,30 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import secrets
+from datetime import UTC, datetime
 
+import anyio
+import httpx
 import pytest
 from sqlalchemy import event, text
+from sqlalchemy.pool import QueuePool
 
 from app.core import database
+from app.main import app
+from app.models.api_key import ApiKey
+from app.models.user import User
+
+
+def _database_pool() -> QueuePool:
+    pool = database.engine.sync_engine.pool
+    assert isinstance(pool, QueuePool)
+    return pool
 
 
 async def test_externally_cancelled_dependency_waits_for_session_close() -> None:
-    pool = database.engine.sync_engine.pool
+    pool = _database_pool()
     checked_out_before = pool.checkedout()
     connection_checked_out = asyncio.Event()
     close_started = asyncio.Event()
@@ -51,4 +66,141 @@ async def test_externally_cancelled_dependency_waits_for_session_close() -> None
             await asyncio.gather(request_task, return_exceptions=True)
 
     assert checked_out_at_request_finish == checked_out_before
+    assert pool.checkedout() == checked_out_before
+
+
+async def test_anyio_level_cancellation_still_returns_connection() -> None:
+    pool = _database_pool()
+    checked_out_before = pool.checkedout()
+    rollback_started = asyncio.Event()
+
+    def mark_rollback(_connection: object) -> None:
+        rollback_started.set()
+
+    async def run_cancelled_cleanup() -> None:
+        dependency = database.get_session()
+        session = await anext(dependency)
+        await session.execute(text("SELECT 1"))
+        assert pool.checkedout() == checked_out_before + 1
+
+        with anyio.CancelScope() as cancel_scope:
+            cancel_scope.cancel()
+            await dependency.aclose()
+            assert pool.checkedout() == checked_out_before
+
+    event.listen(database.engine.sync_engine, "rollback", mark_rollback)
+    try:
+        await asyncio.wait_for(run_cancelled_cleanup(), timeout=2)
+    finally:
+        event.remove(database.engine.sync_engine, "rollback", mark_rollback)
+
+    assert rollback_started.is_set()
+    assert pool.checkedout() == checked_out_before
+
+
+async def test_exceptional_dependency_exit_rolls_back_and_returns_connection() -> None:
+    pool = _database_pool()
+    checked_out_before = pool.checkedout()
+    rollback_started = asyncio.Event()
+
+    def mark_rollback(_connection: object) -> None:
+        rollback_started.set()
+
+    dependency = database.get_session()
+    session = await anext(dependency)
+    event.listen(database.engine.sync_engine, "rollback", mark_rollback)
+    try:
+        await session.execute(text("SELECT 1"))
+        assert pool.checkedout() == checked_out_before + 1
+        with pytest.raises(RuntimeError, match="handler failed"):
+            try:
+                raise RuntimeError("handler failed")
+            finally:
+                await dependency.aclose()
+    finally:
+        event.remove(database.engine.sync_engine, "rollback", mark_rollback)
+
+    assert rollback_started.is_set()
+    assert pool.checkedout() == checked_out_before
+
+
+@pytest.mark.committed_db
+@pytest.mark.parametrize("surface", ["mcp", "connectors"])
+async def test_external_connector_wait_does_not_hold_auth_transaction(
+    surface: str,
+    db_session,
+    seed_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.core.config import settings
+    from app.routes import connectors, mcp_bridge
+
+    raw_key = f"clawdi_{secrets.token_urlsafe(24)}"
+    db_session.add(
+        ApiKey(
+            user_id=seed_user.id,
+            key_hash=hashlib.sha256(raw_key.encode()).hexdigest(),
+            key_prefix=raw_key[:16],
+            label=f"{surface}-lifecycle-test",
+            last_used_at=datetime.now(UTC),
+            scopes=None,
+        )
+    )
+    await db_session.commit()
+
+    connector_started = asyncio.Event()
+    auth_rolled_back = asyncio.Event()
+    release_connector = asyncio.Event()
+
+    async def blocked_connector_call(_user_id: str) -> list[dict[str, object]]:
+        connector_started.set()
+        await release_connector.wait()
+        return []
+
+    def mark_auth_rollback(_connection: object) -> None:
+        auth_rolled_back.set()
+
+    monkeypatch.setattr(settings, "composio_api_key", "test-composio-key")
+    if surface == "mcp":
+        monkeypatch.setattr(mcp_bridge, "get_tool_router_mcp_tools", blocked_connector_call)
+    else:
+        monkeypatch.setattr(connectors, "get_connected_accounts", blocked_connector_call)
+    pool = _database_pool()
+    checked_out_before = pool.checkedout()
+    event.listen(database.engine.sync_engine, "rollback", mark_auth_rollback)
+    request_task: asyncio.Task[httpx.Response] | None = None
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            headers = {"Authorization": f"Bearer {raw_key}"}
+            if surface == "mcp":
+                request_task = asyncio.create_task(
+                    client.post(
+                        "/v1/mcp/clawdi",
+                        headers=headers,
+                        json={
+                            "jsonrpc": "2.0",
+                            "id": 1,
+                            "method": "tools/list",
+                            "params": {},
+                        },
+                    )
+                )
+            else:
+                request_task = asyncio.create_task(client.get("/v1/connectors", headers=headers))
+            await asyncio.wait_for(connector_started.wait(), timeout=2)
+
+            assert auth_rolled_back.is_set()
+            assert pool.checkedout() == checked_out_before
+
+            assert request_task.cancel("client-disconnect")
+            with pytest.raises(asyncio.CancelledError, match="client-disconnect"):
+                await request_task
+    finally:
+        event.remove(database.engine.sync_engine, "rollback", mark_auth_rollback)
+        release_connector.set()
+        if request_task is not None and not request_task.done():
+            request_task.cancel()
+            await asyncio.gather(request_task, return_exceptions=True)
+
     assert pool.checkedout() == checked_out_before

--- a/backend/tests/test_mcp_capability_parity.py
+++ b/backend/tests/test_mcp_capability_parity.py
@@ -13,7 +13,7 @@ from fastapi import HTTPException
 from httpx import ASGITransport
 from sqlalchemy import select
 
-from app.core.auth import AuthContext, get_auth
+from app.core.auth import AuthContext, get_auth, get_auth_short_session
 from app.core.database import get_session
 from app.main import app
 from app.models.agent_project_binding import AgentProjectBinding
@@ -252,6 +252,7 @@ async def test_hosted_account_memory_and_project_vault_mcp_boundaries(
     monkeypatch.setattr(mcp_bridge, "_connector_mcp_tools", no_connectors)
     app.dependency_overrides[get_session] = override_session
     app.dependency_overrides[get_auth] = override_auth
+    app.dependency_overrides[get_auth_short_session] = override_auth
     try:
         transport = ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
@@ -480,6 +481,7 @@ async def test_hosted_account_memory_and_project_vault_mcp_boundaries(
     finally:
         app.dependency_overrides.pop(get_session, None)
         app.dependency_overrides.pop(get_auth, None)
+        app.dependency_overrides.pop(get_auth_short_session, None)
 
 
 @pytest.mark.asyncio
@@ -609,6 +611,7 @@ async def test_mcp_scope_listing_strict_arguments_and_native_name_reservation(
     monkeypatch.setattr(mcp_bridge, "_connector_mcp_tools", colliding_connectors)
     app.dependency_overrides[get_session] = override_session
     app.dependency_overrides[get_auth] = override_auth
+    app.dependency_overrides[get_auth_short_session] = override_auth
     try:
         transport = ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
@@ -664,3 +667,4 @@ async def test_mcp_scope_listing_strict_arguments_and_native_name_reservation(
     finally:
         app.dependency_overrides.pop(get_session, None)
         app.dependency_overrides.pop(get_auth, None)
+        app.dependency_overrides.pop(get_auth_short_session, None)

--- a/backend/tests/test_memory_provider_fallback.py
+++ b/backend/tests/test_memory_provider_fallback.py
@@ -189,6 +189,7 @@ async def test_get_memory_provider_uses_mem0_when_exports_and_constructor_are_us
     assert mem0_available() is True
     provider = await get_memory_provider(str(seed_user.id), db_session)
     assert isinstance(provider, Mem0Provider)
+    assert not db_session.in_transaction()
     assert constructed == ["mock-api-key"]
 
 
@@ -205,3 +206,19 @@ async def test_get_memory_provider_uses_builtin_when_no_setting(
 async def test_get_memory_provider_handles_unknown_user_id(db_session: AsyncSession) -> None:
     provider = await get_memory_provider(str(uuid.uuid4()), db_session)
     assert isinstance(provider, BuiltinProvider)
+
+
+@pytest.mark.asyncio
+async def test_builtin_search_releases_transaction_before_embedding(
+    db_session: AsyncSession,
+    seed_user: User,
+) -> None:
+    class TransactionCheckingEmbedder:
+        async def embed(self, text: str) -> list[float]:
+            del text
+            assert not db_session.in_transaction()
+            return [0.0] * 768
+
+    provider = BuiltinProvider(db_session, embedder=TransactionCheckingEmbedder())
+
+    assert await provider.search(str(seed_user.id), "lifecycle probe") == []

--- a/backend/tests/test_settings_and_mcp.py
+++ b/backend/tests/test_settings_and_mcp.py
@@ -166,7 +166,7 @@ def test_legacy_mcp_compatibility_routes_and_schema():
 
 @pytest.mark.asyncio
 async def test_legacy_mcp_config_preserves_cli_response_for_both_aliases(monkeypatch):
-    from app.core.auth import AuthContext, get_auth
+    from app.core.auth import AuthContext, get_auth_short_session
     from app.core.config import settings
     from app.models.user import User
     from app.services.composio import verify_mcp_bridge_token
@@ -183,7 +183,7 @@ async def test_legacy_mcp_config_preserves_cli_response_for_both_aliases(monkeyp
     monkeypatch.setattr(settings, "composio_api_key", "composio_test_key")
     monkeypatch.setattr(settings, "encryption_key", "test-encryption-key-at-least-32-bytes")
     monkeypatch.setattr(settings, "public_api_url", "https://api.example.test/")
-    app.dependency_overrides[get_auth] = fake_auth
+    app.dependency_overrides[get_auth_short_session] = fake_auth
     try:
         transport = ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
@@ -321,7 +321,7 @@ async def test_legacy_composio_aliases_bridge_tools_list_and_call(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_clawdi_mcp_initializes_and_lists_native_tools(monkeypatch):
-    from app.core.auth import AuthContext, get_auth
+    from app.core.auth import AuthContext, get_auth_short_session
     from app.core.database import get_session
     from app.models.user import User
     from app.routes import mcp_bridge
@@ -342,7 +342,7 @@ async def test_clawdi_mcp_initializes_and_lists_native_tools(monkeypatch):
         raise mcp_bridge.ComposioMcpUpstreamError("connectors disabled for test")
 
     monkeypatch.setattr(mcp_bridge, "get_tool_router_mcp_tools", no_connector_tools)
-    app.dependency_overrides[get_auth] = fake_auth
+    app.dependency_overrides[get_auth_short_session] = fake_auth
     app.dependency_overrides[get_session] = fake_session
     try:
         transport = ASGITransport(app=app)
@@ -384,7 +384,7 @@ async def test_clawdi_mcp_initializes_and_lists_native_tools(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_clawdi_mcp_preserves_standard_composio_tool_contract(monkeypatch):
-    from app.core.auth import AuthContext, get_auth
+    from app.core.auth import AuthContext, get_auth_short_session
     from app.core.database import get_session
     from app.models.user import User
     from app.routes import mcp_bridge
@@ -468,7 +468,7 @@ async def test_clawdi_mcp_preserves_standard_composio_tool_contract(monkeypatch)
     monkeypatch.setattr(mcp_bridge, "get_tool_router_mcp_session", fake_composio_session)
     monkeypatch.setattr(mcp_bridge, "get_tool_router_mcp_tools", fake_connector_tools)
     monkeypatch.setattr(mcp_bridge, "call_tool_router_mcp_tool", fake_call)
-    app.dependency_overrides[get_auth] = fake_auth
+    app.dependency_overrides[get_auth_short_session] = fake_auth
     app.dependency_overrides[get_session] = fake_db_session
     try:
         transport = ASGITransport(app=app)
@@ -491,7 +491,7 @@ async def test_clawdi_mcp_preserves_standard_composio_tool_contract(monkeypatch)
             )
     finally:
         app.dependency_overrides.pop(get_session, None)
-        app.dependency_overrides.pop(get_auth, None)
+        app.dependency_overrides.pop(get_auth_short_session, None)
 
     listed_tools = listed.json()["result"]["tools"]
     listed_composio_tool = next(
@@ -508,7 +508,7 @@ async def test_clawdi_mcp_memory_search_shares_account_memory_across_agents(
     seed_user,
     monkeypatch,
 ):
-    from app.core.auth import AuthContext, get_auth
+    from app.core.auth import AuthContext, get_auth_short_session
     from app.core.database import get_session
     from app.models.api_key import ApiKey
     from app.models.memory import Memory
@@ -583,7 +583,7 @@ async def test_clawdi_mcp_memory_search_shares_account_memory_across_agents(
 
     monkeypatch.setattr(mcp_bridge, "get_tool_router_mcp_tools", no_connector_tools)
     app.dependency_overrides[get_session] = override_session
-    app.dependency_overrides[get_auth] = override_auth
+    app.dependency_overrides[get_auth_short_session] = override_auth
     try:
         transport = ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
@@ -613,7 +613,7 @@ async def test_clawdi_mcp_session_search_uses_shared_metadata_and_body_matches(
     db_session,
     seed_user,
 ):
-    from app.core.auth import AuthContext, get_auth
+    from app.core.auth import AuthContext, get_auth_short_session
     from app.core.database import get_session
     from app.models.api_key import ApiKey
     from app.models.session import Session
@@ -684,7 +684,7 @@ async def test_clawdi_mcp_session_search_uses_shared_metadata_and_body_matches(
         )
 
     app.dependency_overrides[get_session] = override_session
-    app.dependency_overrides[get_auth] = override_auth
+    app.dependency_overrides[get_auth_short_session] = override_auth
     try:
         transport = ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
@@ -1124,7 +1124,7 @@ async def test_clawdi_mcp_connector_tools_follow_scoped_key_permissions(
     """A scoped key without Connector permissions cannot list or invoke them."""
     from datetime import timedelta
 
-    from app.core.auth import AuthContext, get_auth
+    from app.core.auth import AuthContext, get_auth_short_session
     from app.core.database import get_session
     from app.models.api_key import ApiKey
     from app.routes import mcp_bridge
@@ -1166,7 +1166,7 @@ async def test_clawdi_mcp_connector_tools_follow_scoped_key_permissions(
     monkeypatch.setattr(mcp_bridge, "get_tool_router_mcp_tools", fake_connector_tools)
     monkeypatch.setattr(mcp_bridge, "call_tool_router_mcp_tool", fake_call)
     app.dependency_overrides[get_session] = override_session
-    app.dependency_overrides[get_auth] = override_auth
+    app.dependency_overrides[get_auth_short_session] = override_auth
     try:
         transport = ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
@@ -1199,7 +1199,7 @@ async def test_clawdi_mcp_connector_tools_follow_scoped_key_permissions(
             )
     finally:
         app.dependency_overrides.pop(get_session, None)
-        app.dependency_overrides.pop(get_auth, None)
+        app.dependency_overrides.pop(get_auth_short_session, None)
 
     assert listed.status_code == 200, listed.text
     tool_names = [tool["name"] for tool in listed.json()["result"]["tools"]]
@@ -1221,7 +1221,11 @@ async def test_strict_runtime_mcp_has_cross_agent_sessions_connectors_and_accoun
     seed_user,
     monkeypatch,
 ):
-    from app.core.auth import AuthContext, get_auth, is_runtime_deployment_principal
+    from app.core.auth import (
+        AuthContext,
+        get_auth_short_session,
+        is_runtime_deployment_principal,
+    )
     from app.core.database import get_session
     from app.models.api_key import RUNTIME_DEPLOYMENT_KEY_SCOPES, ApiKey
     from app.models.session import Session
@@ -1310,7 +1314,7 @@ async def test_strict_runtime_mcp_has_cross_agent_sessions_connectors_and_accoun
         "application/json",
     )
     app.dependency_overrides[get_session] = override_session
-    app.dependency_overrides[get_auth] = override_auth
+    app.dependency_overrides[get_auth_short_session] = override_auth
     try:
         transport = ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
@@ -1397,7 +1401,7 @@ async def test_strict_runtime_mcp_has_cross_agent_sessions_connectors_and_accoun
             )
     finally:
         app.dependency_overrides.pop(get_session, None)
-        app.dependency_overrides.pop(get_auth, None)
+        app.dependency_overrides.pop(get_auth_short_session, None)
         await mcp_bridge.file_store.delete(session_b_file_key)
 
     names = [tool["name"] for tool in listed.json()["result"]["tools"]]
@@ -1438,7 +1442,7 @@ async def test_clawdi_mcp_session_read_share_url_respects_env_binding(
     """An env-bound agent key must not use a share URL to owner-bypass
     into same-user sessions from other environments. Own-env sessions and
     actively link-shared sessions stay readable."""
-    from app.core.auth import AuthContext, get_auth
+    from app.core.auth import AuthContext, get_auth_short_session
     from app.core.database import get_session
     from app.models.api_key import ApiKey
     from app.models.session import Session
@@ -1498,7 +1502,7 @@ async def test_clawdi_mcp_session_read_share_url_respects_env_binding(
             "application/json",
         )
     app.dependency_overrides[get_session] = override_session
-    app.dependency_overrides[get_auth] = override_auth
+    app.dependency_overrides[get_auth_short_session] = override_auth
 
     async def read_share(ac, session_id):
         response = await ac.post(
@@ -1527,7 +1531,7 @@ async def test_clawdi_mcp_session_read_share_url_respects_env_binding(
             linked = await read_share(ac, session_b.id)
     finally:
         app.dependency_overrides.pop(get_session, None)
-        app.dependency_overrides.pop(get_auth, None)
+        app.dependency_overrides.pop(get_auth_short_session, None)
         for file_key in (session_a_file_key, session_b_file_key):
             await mcp_bridge.file_store.delete(file_key)
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -444,6 +444,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "alembic" },
+    { name = "anyio" },
     { name = "asyncpg" },
     { name = "boto3" },
     { name = "botocore" },
@@ -496,6 +497,7 @@ dev = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=24.1" },
     { name = "alembic", specifier = ">=1.14" },
+    { name = "anyio", specifier = ">=4.0" },
     { name = "asyncpg", specifier = "==0.31.0" },
     { name = "boto3", specifier = "==1.43.67" },
     { name = "botocore", specifier = "==1.43.67" },


### PR DESCRIPTION
## Root cause

Request-scoped authentication transactions, including shared principal advisory locks, remained open while MCP/connectors/dashboard/memory handlers waited on Composio, Mem0, and embedding I/O. Under fan-out this exhausted the PostgreSQL pool and turned unrelated endpoints into 500s. Repeated cancellation could also interrupt session cleanup before rollback/check-in completed.

## Fix

- authenticate MCP and connector requests in a short-lived session
- end route-owned read transactions before external I/O
- make database session close wait through repeated cancellation
- preserve MCP scopes, native tools, connector contracts, and Agent-managed gateway behavior
- do not expand the pool or classify errors by message/code

## Verification

- focused cancellation and pool checkout regression tests
- blocked Composio tests prove MCP/connectors hold no auth connection
- dashboard and memory transaction-boundary tests
- MCP capability/contract coverage
- ruff, basedpyright, compileall

Production observation on 2026-09-02 matched the regression exactly: `idle in transaction` sessions ended on API-key and `pg_advisory_xact_lock_shared` queries while external calls were pending.