### PR TITLE
fix(deploy): run cloud web as a single worker

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -50,17 +50,16 @@ servers:
     hosts:
       - <%= ENV.fetch("DEPLOY_HOST") %>
     options:
-      memory: 6g # two embedding-model workers (~1.6G resident each) + launch-load headroom
+      memory: 6g # local embedding model + launch-load headroom
       ulimit: nofile=65536:65536 # long-lived SSE/WebSocket connections
       # tini as PID 1 reaps orphaned subprocesses (zombie prevention).
       init: true
     env:
       clear:
-        # Discord Resume replay and provider rate-limit smoothing are
-        # process-local; PostgreSQL inbox state and upstream 429s stay authoritative.
-        WEB_CONCURRENCY: 2
-        # Each uvicorn worker owns its SQLAlchemy pool. Two 10+10 pools keep
-        # the web role at the previous 40-connection theoretical maximum.
+        # Each uvicorn worker loads its own local embedding model, so the
+        # production web role must stay single-process on this host.
+        WEB_CONCURRENCY: 1
+        # Keep the single worker's SQLAlchemy pool bounded at 10+10.
         DB_POOL_SIZE: 10
         DB_MAX_OVERFLOW: 10
         PROMETHEUS_MULTIPROC_DIR: /tmp/clawdi-prometheus-multiproc

--- a/scripts/test-kamal-whatsapp-sidecar-render.sh
+++ b/scripts/test-kamal-whatsapp-sidecar-render.sh
@@ -143,7 +143,7 @@ end
 
 web = config.role("web")
 expected_web_env = {
-  "WEB_CONCURRENCY" => 2,
+  "WEB_CONCURRENCY" => 1,
   "DB_POOL_SIZE" => 10,
   "DB_MAX_OVERFLOW" => 10,
   "PROMETHEUS_MULTIPROC_DIR" => "/tmp/clawdi-prometheus-multiproc",
@@ -172,7 +172,7 @@ web_connections = web_env.fetch("WEB_CONCURRENCY") *
   (web_env.fetch("DB_POOL_SIZE") + web_env.fetch("DB_MAX_OVERFLOW"))
 worker_connections = channels_worker_env.fetch("DB_POOL_SIZE") +
   channels_worker_env.fetch("DB_MAX_OVERFLOW")
-raise "total database connection budget drifted" unless web_connections + worker_connections == 80
+raise "total database connection budget drifted" unless web_connections + worker_connections == 60
 
 config.accessories.each do |accessory|
   command = Kamal::Commands::Accessory.new(config, name: accessory.name).run


### PR DESCRIPTION
## Summary

- run the Cloud production web role with one Uvicorn worker because each worker owns a separate local embedding model
- keep the local embedding mode and the existing bounded 10+10 SQLAlchemy pool
- update the existing Kamal render contract to lock the 60-connection aggregate budget

## Root cause

On September 2, 2026, two local-embedding workers each reached roughly 1.8-1.9 GiB RSS. During deployment overlap this exhausted the 15 GiB host and full swap, causing global OOM kills, worker restart storms, health timeouts, and downstream database pool timeouts.

## Verification

- Kamal 2.12.0 containerized render contract
- Biome 2.5.9
- bash -n
- git diff/check

## Risk

This reduces Cloud API process concurrency from two workers to one and lowers the theoretical aggregate DB connection budget from 80 to 60. The preceding session-lifetime fix removes the pool leak that motivated excess headroom; no Agent, MCP, gateway, schema, or data path changes are included.