### PR TITLE
fix(deploy): preserve cloud database capacity

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -59,9 +59,9 @@ servers:
         # Each uvicorn worker loads its own local embedding model, so the
         # production web role must stay single-process on this host.
         WEB_CONCURRENCY: 1
-        # Keep the single worker's SQLAlchemy pool bounded at 10+10.
-        DB_POOL_SIZE: 10
-        DB_MAX_OVERFLOW: 10
+        # Preserve the previous web role's aggregate 40-connection budget.
+        DB_POOL_SIZE: 20
+        DB_MAX_OVERFLOW: 20
         PROMETHEUS_MULTIPROC_DIR: /tmp/clawdi-prometheus-multiproc
   channels-worker:
     hosts:

--- a/scripts/test-kamal-whatsapp-sidecar-render.sh
+++ b/scripts/test-kamal-whatsapp-sidecar-render.sh
@@ -144,8 +144,8 @@ end
 web = config.role("web")
 expected_web_env = {
   "WEB_CONCURRENCY" => 1,
-  "DB_POOL_SIZE" => 10,
-  "DB_MAX_OVERFLOW" => 10,
+  "DB_POOL_SIZE" => 20,
+  "DB_MAX_OVERFLOW" => 20,
   "PROMETHEUS_MULTIPROC_DIR" => "/tmp/clawdi-prometheus-multiproc",
 }
 unless web.specialized_env.clear == expected_web_env
@@ -153,7 +153,7 @@ unless web.specialized_env.clear == expected_web_env
 end
 raise "web role memory drifted" unless config.raw_config.servers.dig("web", "options", "memory") == "6g"
 web_env = web.env(web.primary_host).clear
-unless web_env.values_at("DB_POOL_SIZE", "DB_MAX_OVERFLOW") == [ 10, 10 ]
+unless web_env.values_at("DB_POOL_SIZE", "DB_MAX_OVERFLOW") == [ 20, 20 ]
   raise "web role database pool drifted"
 end
 channels_worker = config.role("channels-worker")
@@ -172,7 +172,7 @@ web_connections = web_env.fetch("WEB_CONCURRENCY") *
   (web_env.fetch("DB_POOL_SIZE") + web_env.fetch("DB_MAX_OVERFLOW"))
 worker_connections = channels_worker_env.fetch("DB_POOL_SIZE") +
   channels_worker_env.fetch("DB_MAX_OVERFLOW")
-raise "total database connection budget drifted" unless web_connections + worker_connections == 60
+raise "total database connection budget drifted" unless web_connections + worker_connections == 80
 
 config.accessories.each do |accessory|
   command = Kamal::Commands::Accessory.new(config, name: accessory.name).run


### PR DESCRIPTION
## Summary

- keep the Cloud web role at one local-embedding worker
- restore that worker to a 20+20 SQLAlchemy pool, preserving the pre-change web aggregate budget of 40 connections
- restore the existing aggregate deployment contract to 80 connections across web and channels worker

## Production evidence

After the September 2, 2026 host reboot, the single-worker 10+10 deployment received a fleet-wide reconnect burst. PostgreSQL showed 17 idle-in-transaction sessions and the application reached `QueuePool limit of size 10 overflow 10`; `/health` timed out. Traffic was returned to the emergency container.

This does not increase the historical database budget: the previous two workers each owned 10+10, also totaling 40 for the web role. It avoids reintroducing the local embedding OOM while retaining the concurrency capacity already provisioned for production.

## Verification

- containerized Kamal 2.12 render contract
- deployment sidecar contract
- bash syntax
- git diff check

No Agent, MCP, gateway, schema, or application logic changes.