### PR TITLE
Unify account suspension copy

### DIFF
--- a/apps/web/src/components/account-suspended-page.test.tsx
+++ b/apps/web/src/components/account-suspended-page.test.tsx
@@ -9,8 +9,10 @@ describe("AccountSuspendedPage", () => {
 			createElement(AccountSuspendedPage, { onSignOut: () => undefined }),
 		);
 
-		expect(markup).toContain("Account deactivated");
-		expect(markup).toContain("can no longer access Clawdi");
+		expect(markup).toContain("Account suspended");
+		expect(markup).toContain(
+			"Your account has been suspended due to a violation of the Clawdi User Agreement.",
+		);
 		expect(markup).toContain('href="mailto:support@clawdi.ai"');
 		expect(markup).toContain("Sign out");
 		expect(markup).not.toContain("account_suspended");

--- a/apps/web/src/components/account-suspended-page.tsx
+++ b/apps/web/src/components/account-suspended-page.tsx
@@ -24,10 +24,10 @@ export function AccountSuspendedPage({
 					<ShieldOff className="size-5" aria-hidden="true" />
 				</div>
 				<h1 id="account-suspended-title" className="mt-5 text-xl font-semibold">
-					Account deactivated
+					Account suspended
 				</h1>
 				<p className="mx-auto mt-2 max-w-md text-sm leading-6 text-muted-foreground">
-					Your account has been deactivated and can no longer access Clawdi.
+					Your account has been suspended due to a violation of the Clawdi User Agreement.
 				</p>
 				<p className="mx-auto mt-1 max-w-md text-sm leading-6 text-muted-foreground">
 					Contact support if you believe this is a mistake or need help.


### PR DESCRIPTION
## Summary
- rename the suspended-account page heading to `Account suspended`
- use the same User Agreement violation copy as Hosted notifications and Customer.io
- preserve support and sign-out behavior

## Verification
- hermetic web typecheck
- focused account suspension page test (`1 pass`)
- OSS production build
- Biome and `git diff --check`

## Release impact
- web-only copy change; Vercel production deployment after merge
- no auth, backend, schema, or migration changes

Head SHA: `dd77e473790175a942856c59aa6ba05548f4fb97`