### PR TITLE
fix(cli): converge durable runtime activity

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -100,7 +100,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.38",
+      "version": "0.14.39",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.38",
+	"version": "0.14.39",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/adapters/base.ts
+++ b/packages/cli/src/adapters/base.ts
@@ -152,12 +152,17 @@ export interface SessionScanBatch {
 	/** Every local session observed in this batch, including revision-matched sessions. */
 	observedLocalSessionIds: readonly string[];
 	dedupedCount: number;
-	/** False when the adapter could not classify activity for every inspected session. */
-	activityComplete?: boolean;
+}
+
+export interface SessionUserActivity {
+	lastUserInputAt: string | null;
+	complete: boolean;
 }
 
 export interface SessionBatchScan {
 	coverage: SessionScanResult["coverage"];
+	/** Runtime-wide aggregate from the canonical local inventory. */
+	userActivity?: SessionUserActivity;
 	batches: AsyncIterable<SessionScanBatch>;
 }
 

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -27,6 +27,7 @@ import type {
 	SessionMessage,
 	SessionScanRequest,
 	SessionScanResult,
+	SessionUserActivity,
 } from "./base";
 import { getHermesHome, SKIP_DIRS } from "./paths";
 import {
@@ -83,6 +84,10 @@ interface TableInfoRow {
 
 interface MessageRevisionRow {
 	presentation_state: string;
+}
+
+interface UserActivityRow {
+	last_user_input_at: number | string | null;
 }
 
 const MODERN_MESSAGE_CORE_COLUMNS = ["session_id", "role", "content", "timestamp"] as const;
@@ -180,6 +185,41 @@ function sessionSourceRevision(row: SessionRow, messages: MessageRevisionRow): s
 			]),
 		)
 		.digest("hex");
+}
+
+function hermesUserActivity(db: ReadonlySqliteDatabase): SessionUserActivity {
+	const sessionColumns = new Set(
+		(db.prepare("PRAGMA table_info(sessions)").all() as TableInfoRow[]).map(
+			(column) => column.name,
+		),
+	);
+	const messageColumns = new Set(messageTableInfo(db).map((column) => column.name));
+	if (
+		!["id", "source", "parent_session_id"].every((column) => sessionColumns.has(column)) ||
+		!["session_id", "role", "timestamp"].every((column) => messageColumns.has(column))
+	) {
+		return { lastUserInputAt: null, complete: false };
+	}
+	try {
+		const row = db
+			.prepare(`
+				SELECT MAX(m.timestamp) AS last_user_input_at
+				FROM messages AS m
+				JOIN sessions AS s ON s.id = m.session_id
+				WHERE lower(m.role) = 'user'
+				  AND lower(coalesce(s.source, '')) NOT IN ('cron', 'subagent', 'curator')
+				  AND s.parent_session_id IS NULL
+			`)
+			.get() as UserActivityRow | undefined;
+		const timestamp = row?.last_user_input_at ?? null;
+		if (timestamp === null) return { lastUserInputAt: null, complete: true };
+		const lastUserInputAt = timestampIso(Number(timestamp));
+		return lastUserInputAt
+			? { lastUserInputAt, complete: true }
+			: { lastUserInputAt: null, complete: false };
+	} catch {
+		return { lastUserInputAt: null, complete: false };
+	}
 }
 
 function decodeHermesContent(content: string | null): unknown {
@@ -526,11 +566,17 @@ export class HermesAdapter implements AgentAdapterCore {
 		knownSourceRevisions: ReadonlyMap<string, string>,
 	): Promise<SessionBatchScan> {
 		if (!existsSync(stateDbPath())) {
-			return { coverage: "complete", batches: (async function* () {})() };
+			return {
+				coverage: "complete",
+				userActivity: { lastUserInputAt: null, complete: false },
+				batches: (async function* () {})(),
+			};
 		}
 		const db = await openReadonlySqlite(stateDbPath());
+		const activity = hermesUserActivity(db);
 		return {
 			coverage: "complete",
+			userActivity: activity,
 			batches: this.readSessionBatches(db, knownSourceRevisions),
 		};
 	}

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -292,7 +292,11 @@ function collectCanonicalOpenClawActivity(
 			activity = mergeUserActivity(activity, readOpenClawTranscriptActivity(transcript.path));
 		}
 		for (const [name, reference] of references) {
-			if (reference.requiredExternal && !presentReferences.has(name)) {
+			if (
+				reference.requiredExternal &&
+				!presentReferences.has(name) &&
+				!classifiedPaths.has(resolve(sessionsRoot, name))
+			) {
 				activity.complete = false;
 			}
 		}
@@ -828,6 +832,8 @@ export class OpenClawAdapter implements AgentAdapterCore {
 		request: SessionScanRequest,
 		knownSourceRevisions: ReadonlyMap<string, string>,
 	): Promise<SessionBatchScan> {
+		const materializeCanonicalActivity =
+			request.kind === "complete" && knownSourceRevisions.size === 0;
 		const officialInventory = readOfficialSessionInventory();
 		if (officialInventory) {
 			const collection = await this.collectOfficialSessionsMatching(
@@ -836,15 +842,17 @@ export class OpenClawAdapter implements AgentAdapterCore {
 				undefined,
 				knownSourceRevisions,
 			);
-			collection.userActivity = mergeUserActivity(
-				collection.userActivity,
-				collectCanonicalOpenClawActivity(officialInventory, collection.classifiedTranscriptPaths),
-			);
+			if (materializeCanonicalActivity) {
+				collection.userActivity = mergeUserActivity(
+					collection.userActivity,
+					collectCanonicalOpenClawActivity(officialInventory, collection.classifiedTranscriptPaths),
+				);
+			}
 			return singleSessionBatch("complete", collection);
 		}
 
 		const collection = await this.collectLegacySessions(request, knownSourceRevisions);
-		if (collection.coverage === "complete") {
+		if (collection.coverage === "complete" && materializeCanonicalActivity) {
 			collection.userActivity = mergeUserActivity(
 				collection.userActivity,
 				collectCanonicalOpenClawActivity(null, collection.classifiedTranscriptPaths),
@@ -1000,7 +1008,9 @@ export class OpenClawAdapter implements AgentAdapterCore {
 				observedLocalSessionIds.push(sessionId);
 				const sourceRevision = `${sessionId}:${updatedAt}`;
 				const externalSession = !isInternalOpenClawSession(indexKey, entry);
-				if (externalSession) classifiedTranscriptPaths.add(normalizedTranscriptPath);
+				if (externalSession && existsSync(transcriptPath)) {
+					classifiedTranscriptPaths.add(normalizedTranscriptPath);
+				}
 				if (knownSourceRevisions.get(sessionId) === sourceRevision) continue;
 
 				const materialized = materializeOpenClawJsonlSession({
@@ -1063,13 +1073,14 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			if (knownSourceRevisions.get(entry.sessionId) === sourceRevision) continue;
 
 			let transcript = await readOfficialSessionMessagesFromSdk(entry);
+			transcript ??= readOfficialSessionMessagesFromGateway(entry);
 			if (transcript === null && entry.sessionFile) {
 				const sessionsDirForAgent = join(agentsRoot(), entry.agentId, "sessions");
 				const transcriptPath = isAbsolute(entry.sessionFile)
 					? entry.sessionFile
 					: join(sessionsDirForAgent, entry.sessionFile);
 				const normalizedTranscriptPath = resolve(transcriptPath);
-				if (!isInternalOpenClawSession(entry.key, entry)) {
+				if (!isInternalOpenClawSession(entry.key, entry) && existsSync(transcriptPath)) {
 					classifiedTranscriptPaths.add(normalizedTranscriptPath);
 				}
 				const legacy = materializeOpenClawJsonlSession({
@@ -1087,9 +1098,8 @@ export class OpenClawAdapter implements AgentAdapterCore {
 				if (legacy.session) sessions.push(legacy.session);
 				continue;
 			}
-			transcript ??= readOfficialSessionMessagesFromGateway(entry);
 			if (!transcript) {
-				if (!entry.sessionFile) userActivity.complete = false;
+				userActivity.complete = false;
 				console.warn(
 					`[openclaw] could not read active transcript for ${entry.sessionId} through official transcript surfaces`,
 				);
@@ -1133,8 +1143,13 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			const events = sequenceSessionEvents(drafts);
 			const messages = projectEventsToMessages(events);
 			const sessionUserActivity = computeOpenClawRealUserActivity(transcript, entry.key, entry);
-			if (!entry.sessionFile) {
-				userActivity = mergeUserActivity(userActivity, sessionUserActivity);
+			userActivity = mergeUserActivity(userActivity, sessionUserActivity);
+			if (entry.sessionFile && !isInternalOpenClawSession(entry.key, entry)) {
+				const sessionsDirForAgent = join(agentsRoot(), entry.agentId, "sessions");
+				const transcriptPath = isAbsolute(entry.sessionFile)
+					? entry.sessionFile
+					: join(sessionsDirForAgent, entry.sessionFile);
+				classifiedTranscriptPaths.add(resolve(transcriptPath));
 			}
 			if (messages.length === 0) continue;
 			startedAt ??= new Date(entry.sessionStartedAt ?? updatedAt);

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { basename, isAbsolute, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -8,7 +8,10 @@ import {
 	resolveOpenClawSdkExport,
 } from "../lib/codex-oauth-native-store";
 import { safeTruncate } from "../lib/sanitize";
-import { computeOpenClawRealUserActivity } from "../lib/session-activity";
+import {
+	computeOpenClawRealUserActivity,
+	isInternalOpenClawSession,
+} from "../lib/session-activity";
 import { durationSecondsBetween } from "../lib/session-duration";
 import {
 	projectEventsToMessages,
@@ -34,6 +37,7 @@ import type {
 	SessionBatchScan,
 	SessionScanRequest,
 	SessionScanResult,
+	SessionUserActivity,
 } from "./base";
 import {
 	listOpenClawAgentWorkspaces,
@@ -120,30 +124,6 @@ function listAgentDirs(): string[] {
 	return listAgentDirsWithCompleteness().dirs;
 }
 
-function hasUnclassifiedTranscriptFiles(classified: ReadonlySet<string>): boolean {
-	try {
-		const listing = listAgentDirsWithCompleteness();
-		if (!listing.complete) return true;
-		for (const agentRoot of listing.dirs) {
-			const directory = join(agentRoot, "sessions");
-			if (!existsSync(directory)) continue;
-			for (const entry of readdirSync(directory, { withFileTypes: true })) {
-				if (!entry.isFile()) continue;
-				if (
-					!entry.name.endsWith(".jsonl") &&
-					!entry.name.includes(".jsonl.reset.") &&
-					!entry.name.includes(".jsonl.deleted.")
-				)
-					continue;
-				if (!classified.has(resolve(directory, entry.name))) return true;
-			}
-		}
-		return false;
-	} catch {
-		return true;
-	}
-}
-
 interface SessionEntry {
 	// Real openclaw indexes key entries by composite strings like
 	// `agent:main:main` or `agent:main:telegram:group:-100…:topic:1`, with
@@ -154,6 +134,8 @@ interface SessionEntry {
 	// May be absolute (production openclaw writes the full `/data/openclaw/…`
 	// path) or relative to the agent's `sessions/` dir (older fixtures).
 	sessionFile?: string;
+	transcriptPath?: string;
+	path?: string;
 	model?: string;
 	modelProvider?: string;
 	inputTokens?: number;
@@ -179,6 +161,193 @@ interface OfficialSessionEntry extends SessionEntry {
 interface OfficialSessionInventory {
 	entries: OfficialSessionEntry[];
 	storePaths: Map<string, string>;
+	complete: boolean;
+}
+
+interface TranscriptReference {
+	internalOnly: boolean;
+	requiredExternal: boolean;
+}
+
+function canonicalTranscriptReferences(name: string): string[] {
+	if (
+		!name.endsWith(".jsonl") &&
+		!name.includes(".jsonl.reset.") &&
+		!name.includes(".jsonl.deleted.")
+	) {
+		return [];
+	}
+	const references = new Set([name]);
+	for (const marker of [".reset.", ".deleted."]) {
+		let offset = 0;
+		while (true) {
+			const index = name.indexOf(marker, offset);
+			if (index < 0) break;
+			if (index > 0) references.add(name.slice(0, index));
+			offset = index + marker.length;
+		}
+	}
+	return [...references];
+}
+
+function transcriptReferenceName(
+	sessionsRoot: string,
+	indexKey: string,
+	entry: SessionEntry,
+): string | undefined {
+	const explicit = [entry.sessionFile, entry.transcriptPath, entry.path].find(
+		(value): value is string => typeof value === "string" && value.trim().length > 0,
+	);
+	const raw = explicit?.trim() ?? `${entry.sessionId ?? indexKey}.jsonl`;
+	const name = basename(raw);
+	if (!name || name === "." || name === "..") return undefined;
+	if (!isAbsolute(raw)) {
+		const candidate = resolve(sessionsRoot, raw);
+		return isPathWithinRoots(candidate, [resolve(sessionsRoot)]) ? name : undefined;
+	}
+	const candidate = resolve(raw);
+	if (isPathWithinRoots(candidate, [resolve(sessionsRoot)])) return name;
+	return raw.startsWith("/data/openclaw/agents/") || raw.startsWith("/var/openclaw/agents/")
+		? name
+		: undefined;
+}
+
+function collectCanonicalOpenClawActivity(
+	officialInventory: OfficialSessionInventory | null,
+	classifiedPaths: ReadonlySet<string>,
+): SessionUserActivity {
+	const listing = listAgentDirsWithCompleteness();
+	let activity: SessionUserActivity = {
+		lastUserInputAt: null,
+		complete: listing.complete,
+	};
+	const visitedAgentIds = new Set<string>();
+	const officialByAgent = new Map<string, OfficialSessionEntry[]>();
+	for (const entry of officialInventory?.entries ?? []) {
+		const entries = officialByAgent.get(entry.agentId) ?? [];
+		entries.push(entry);
+		officialByAgent.set(entry.agentId, entries);
+	}
+	for (const agentRoot of listing.dirs) {
+		const agentId = basename(agentRoot);
+		const sessionsRoot = join(agentRoot, "sessions");
+		if (!existsSync(sessionsRoot)) continue;
+		visitedAgentIds.add(agentId);
+		let transcripts: Array<{ path: string; references: string[] }>;
+		try {
+			transcripts = readdirSync(sessionsRoot, { withFileTypes: true }).flatMap((entry) => {
+				if (!entry.isFile()) return [];
+				const references = canonicalTranscriptReferences(entry.name);
+				return references.length > 0
+					? [{ path: resolve(sessionsRoot, entry.name), references }]
+					: [];
+			});
+		} catch {
+			activity.complete = false;
+			continue;
+		}
+		const presentReferences = new Set(transcripts.flatMap((transcript) => transcript.references));
+		const references = new Map<string, TranscriptReference>();
+		const addReference = (identity: string, entry: SessionEntry, required: boolean): void => {
+			const name = transcriptReferenceName(sessionsRoot, identity, entry);
+			if (!name) {
+				activity.complete = false;
+				return;
+			}
+			const reference = references.get(name) ?? {
+				internalOnly: true,
+				requiredExternal: false,
+			};
+			const internal = isInternalOpenClawSession(identity, entry);
+			reference.internalOnly &&= internal;
+			reference.requiredExternal ||= required && !internal;
+			references.set(name, reference);
+		};
+		const indexPath = join(sessionsRoot, "sessions.json");
+		if (existsSync(indexPath)) {
+			try {
+				const parsed = JSON.parse(readFileSync(indexPath, "utf-8")) as unknown;
+				if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error();
+				for (const [key, value] of Object.entries(parsed)) {
+					if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error();
+					const entry = value as SessionEntry;
+					if (!entry.sessionFile && !entry.sessionId && !entry.transcriptPath && !entry.path)
+						continue;
+					addReference(key, entry, officialInventory === null);
+				}
+			} catch {
+				activity.complete = false;
+			}
+		}
+		for (const entry of officialByAgent.get(agentId) ?? []) {
+			if (entry.sessionFile) addReference(entry.key, entry, true);
+		}
+		for (const transcript of transcripts) {
+			if (classifiedPaths.has(transcript.path)) continue;
+			const matches = transcript.references.flatMap((name) => {
+				const reference = references.get(name);
+				return reference ? [reference] : [];
+			});
+			if (matches.length > 0 && matches.every((reference) => reference.internalOnly)) continue;
+			activity = mergeUserActivity(activity, readOpenClawTranscriptActivity(transcript.path));
+		}
+		for (const [name, reference] of references) {
+			if (reference.requiredExternal && !presentReferences.has(name)) {
+				activity.complete = false;
+			}
+		}
+	}
+	for (const entry of officialInventory?.entries ?? []) {
+		if (
+			entry.sessionFile &&
+			!visitedAgentIds.has(entry.agentId) &&
+			!isInternalOpenClawSession(entry.key, entry)
+		) {
+			activity.complete = false;
+		}
+	}
+	return activity;
+}
+
+function readOpenClawTranscriptActivity(path: string): SessionUserActivity {
+	try {
+		const before = statSync(path, { bigint: true });
+		const content = readFileSync(path, "utf-8");
+		const after = statSync(path, { bigint: true });
+		const records = completeJsonlRecords(content);
+		const activity = computeOpenClawRealUserActivity(
+			records.map((record) => record.data),
+			"",
+		);
+		return {
+			lastUserInputAt: activity.lastUserInputAt,
+			complete:
+				activity.complete &&
+				records.length === content.split("\n").filter((line) => line.trim()).length &&
+				before.dev === after.dev &&
+				before.ino === after.ino &&
+				before.size === after.size &&
+				before.mtimeNs === after.mtimeNs,
+		};
+	} catch {
+		return { lastUserInputAt: null, complete: false };
+	}
+}
+
+function maxActivityTimestamp(left: string | null, right: string | null): string | null {
+	if (!left) return right;
+	if (!right) return left;
+	return new Date(left).getTime() >= new Date(right).getTime() ? left : right;
+}
+
+function mergeUserActivity(
+	left: SessionUserActivity,
+	right: SessionUserActivity,
+): SessionUserActivity {
+	return {
+		lastUserInputAt: maxActivityTimestamp(left.lastUserInputAt, right.lastUserInputAt),
+		complete: left.complete && right.complete,
+	};
 }
 
 const OPENCLAW_COMMAND_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
@@ -209,12 +378,16 @@ function readOfficialSessionInventory(): OfficialSessionInventory | null {
 	]);
 	if (!payload || !Array.isArray(payload.sessions)) return null;
 
+	let complete = true;
 	const entries = payload.sessions.flatMap((value): OfficialSessionEntry[] => {
 		const row = jsonObject(value);
 		const agentId = jsonString(row?.agentId);
 		const key = jsonString(row?.key);
 		const sessionId = jsonString(row?.sessionId);
-		if (!row || !agentId || !key || !sessionId) return [];
+		if (!row || !agentId || !key || !sessionId) {
+			complete = false;
+			return [];
+		}
 		const number = (field: string) => {
 			const candidate = row[field];
 			return typeof candidate === "number" && Number.isFinite(candidate) ? candidate : undefined;
@@ -264,7 +437,7 @@ function readOfficialSessionInventory(): OfficialSessionInventory | null {
 			if (agentId && path) storePaths.set(agentId, path);
 		}
 	}
-	return { entries, storePaths };
+	return { entries, storePaths, complete };
 }
 
 async function readOfficialSessionMessagesFromSdk(
@@ -469,7 +642,8 @@ interface SessionCollection {
 	observedLocalSessionIds: readonly string[];
 	dedupedCount: number;
 	matchedTranscriptPaths: Set<string>;
-	activityComplete: boolean;
+	classifiedTranscriptPaths: Set<string>;
+	userActivity: SessionUserActivity;
 }
 
 function singleSessionBatch(
@@ -478,12 +652,12 @@ function singleSessionBatch(
 ): SessionBatchScan {
 	return {
 		coverage,
+		userActivity: collection.userActivity,
 		batches: (async function* () {
 			yield {
 				sessions: collection.sessions,
 				observedLocalSessionIds: collection.observedLocalSessionIds,
 				dedupedCount: collection.dedupedCount,
-				activityComplete: collection.activityComplete,
 			};
 		})(),
 	};
@@ -491,7 +665,7 @@ function singleSessionBatch(
 
 interface MaterializedOpenClawSession {
 	session: RawSession | null;
-	activityComplete: boolean;
+	userActivity: SessionUserActivity;
 }
 
 function materializeOpenClawJsonlSession(input: {
@@ -514,7 +688,11 @@ function materializeOpenClawJsonlSession(input: {
 	} = input;
 	const sessionId = entry.sessionId;
 	const updatedAt = entry.updatedAt ?? entry.acp?.lastActivityAt;
-	if (!sessionId || !updatedAt) return { session: null, activityComplete: false };
+	const internalSession = isInternalOpenClawSession(sourceSessionKey, entry);
+	const unavailableActivity = { lastUserInputAt: null, complete: internalSession };
+	if (!sessionId || !updatedAt) {
+		return { session: null, userActivity: unavailableActivity };
+	}
 
 	let events = [] as import("./base").SessionEvent[];
 	let startedAt: Date | null = null;
@@ -529,7 +707,7 @@ function materializeOpenClawJsonlSession(input: {
 		if (entry.sessionFile) {
 			console.warn(`[openclaw] transcript missing for ${sessionId}: ${transcriptPath}`);
 		}
-		return { session: null, activityComplete: false };
+		return { session: null, userActivity: unavailableActivity };
 	} else {
 		try {
 			const transcriptContent = readFileSync(transcriptPath, "utf-8");
@@ -556,19 +734,19 @@ function materializeOpenClawJsonlSession(input: {
 			}
 			events = sequenceSessionEvents(drafts);
 		} catch {
-			return { session: null, activityComplete: false };
+			return { session: null, userActivity: unavailableActivity };
 		}
 	}
 
 	const userActivity = computeOpenClawRealUserActivity(transcriptRecords, sourceSessionKey, entry);
-	userActivity.complete &&= transcriptComplete;
+	if (!internalSession) userActivity.complete &&= transcriptComplete;
 	const messages = projectEventsToMessages(events);
-	if (messages.length === 0) return { session: null, activityComplete: userActivity.complete };
+	if (messages.length === 0) return { session: null, userActivity };
 	startedAt ??= new Date(updatedAt);
 	endedAt ??= new Date(updatedAt);
 	const firstUserContent = messages.find((message) => message.role === "user")?.content;
 	return {
-		activityComplete: userActivity.complete,
+		userActivity,
 		session: {
 			localSessionId: sessionId,
 			projectPath,
@@ -658,10 +836,20 @@ export class OpenClawAdapter implements AgentAdapterCore {
 				undefined,
 				knownSourceRevisions,
 			);
+			collection.userActivity = mergeUserActivity(
+				collection.userActivity,
+				collectCanonicalOpenClawActivity(officialInventory, collection.classifiedTranscriptPaths),
+			);
 			return singleSessionBatch("complete", collection);
 		}
 
 		const collection = await this.collectLegacySessions(request, knownSourceRevisions);
+		if (collection.coverage === "complete") {
+			collection.userActivity = mergeUserActivity(
+				collection.userActivity,
+				collectCanonicalOpenClawActivity(null, collection.classifiedTranscriptPaths),
+			);
+		}
 		return singleSessionBatch(collection.coverage, collection);
 	}
 
@@ -754,7 +942,8 @@ export class OpenClawAdapter implements AgentAdapterCore {
 				dedupedCount: 0,
 				observedLocalSessionIds: [],
 				matchedTranscriptPaths: new Set(),
-				activityComplete: agentDirectoryListing.complete,
+				classifiedTranscriptPaths: new Set(),
+				userActivity: { lastUserInputAt: null, complete: agentDirectoryListing.complete },
 			};
 		}
 
@@ -768,7 +957,8 @@ export class OpenClawAdapter implements AgentAdapterCore {
 		const sessions: RawSession[] = [];
 		const observedLocalSessionIds: string[] = [];
 		const matchedTranscriptPaths = new Set<string>();
-		let activityComplete = true;
+		const classifiedTranscriptPaths = new Set<string>();
+		let userActivity: SessionUserActivity = { lastUserInputAt: null, complete: true };
 
 		for (const agentRoot of agentDirs) {
 			const sourceAgentId = basename(agentRoot);
@@ -780,7 +970,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			try {
 				index = JSON.parse(readFileSync(indexPath, "utf-8"));
 			} catch {
-				activityComplete = false;
+				userActivity.complete = false;
 				continue;
 			}
 
@@ -809,6 +999,8 @@ export class OpenClawAdapter implements AgentAdapterCore {
 				matchedTranscriptPaths.add(normalizedTranscriptPath);
 				observedLocalSessionIds.push(sessionId);
 				const sourceRevision = `${sessionId}:${updatedAt}`;
+				const externalSession = !isInternalOpenClawSession(indexKey, entry);
+				if (externalSession) classifiedTranscriptPaths.add(normalizedTranscriptPath);
 				if (knownSourceRevisions.get(sessionId) === sourceRevision) continue;
 
 				const materialized = materializeOpenClawJsonlSession({
@@ -820,12 +1012,11 @@ export class OpenClawAdapter implements AgentAdapterCore {
 					sourceRevision,
 					transcriptPath,
 				});
-				activityComplete &&= materialized.activityComplete;
+				if (existsSync(transcriptPath)) {
+					userActivity = mergeUserActivity(userActivity, materialized.userActivity);
+				}
 				if (materialized.session) sessions.push(materialized.session);
 			}
-		}
-		if (knownSourceRevisions.size === 0 && hasUnclassifiedTranscriptFiles(matchedTranscriptPaths)) {
-			activityComplete = false;
 		}
 
 		// OpenClaw stores one session per ACP transcript with stable sessionIds
@@ -835,7 +1026,8 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			dedupedCount: 0,
 			observedLocalSessionIds,
 			matchedTranscriptPaths,
-			activityComplete,
+			classifiedTranscriptPaths,
+			userActivity,
 		};
 	}
 
@@ -848,12 +1040,18 @@ export class OpenClawAdapter implements AgentAdapterCore {
 		const absFilter = opts.projectFilter ? resolve(opts.projectFilter) : null;
 		const sessions: RawSession[] = [];
 		const observedLocalSessionIds: string[] = [];
-		const matchedTranscriptPaths = new Set<string>();
-		let activityComplete = true;
+		const classifiedTranscriptPaths = new Set<string>();
+		let userActivity: SessionUserActivity = {
+			lastUserInputAt: null,
+			complete: inventory.complete,
+		};
 		for (const entry of inventory.entries) {
 			if (localSessionId !== undefined && entry.sessionId !== localSessionId) continue;
 			const updatedAt = entry.updatedAt;
-			if (typeof updatedAt !== "number" || !Number.isFinite(updatedAt)) continue;
+			if (typeof updatedAt !== "number" || !Number.isFinite(updatedAt)) {
+				userActivity.complete = false;
+				continue;
+			}
 			const projectPath = entry.spawnedCwd ?? entry.spawnedWorkspaceDir ?? entry.acp?.cwd ?? null;
 			if (
 				absFilter &&
@@ -870,7 +1068,10 @@ export class OpenClawAdapter implements AgentAdapterCore {
 				const transcriptPath = isAbsolute(entry.sessionFile)
 					? entry.sessionFile
 					: join(sessionsDirForAgent, entry.sessionFile);
-				matchedTranscriptPaths.add(resolve(transcriptPath));
+				const normalizedTranscriptPath = resolve(transcriptPath);
+				if (!isInternalOpenClawSession(entry.key, entry)) {
+					classifiedTranscriptPaths.add(normalizedTranscriptPath);
+				}
 				const legacy = materializeOpenClawJsonlSession({
 					entry,
 					indexPath: join(sessionsDirForAgent, "sessions.json"),
@@ -880,13 +1081,15 @@ export class OpenClawAdapter implements AgentAdapterCore {
 					sourceRevision,
 					transcriptPath,
 				});
-				activityComplete &&= legacy.activityComplete;
+				if (existsSync(transcriptPath)) {
+					userActivity = mergeUserActivity(userActivity, legacy.userActivity);
+				}
 				if (legacy.session) sessions.push(legacy.session);
 				continue;
 			}
 			transcript ??= readOfficialSessionMessagesFromGateway(entry);
 			if (!transcript) {
-				activityComplete = false;
+				if (!entry.sessionFile) userActivity.complete = false;
 				console.warn(
 					`[openclaw] could not read active transcript for ${entry.sessionId} through official transcript surfaces`,
 				);
@@ -929,8 +1132,10 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			}
 			const events = sequenceSessionEvents(drafts);
 			const messages = projectEventsToMessages(events);
-			const userActivity = computeOpenClawRealUserActivity(transcript, entry.key, entry);
-			activityComplete &&= userActivity.complete;
+			const sessionUserActivity = computeOpenClawRealUserActivity(transcript, entry.key, entry);
+			if (!entry.sessionFile) {
+				userActivity = mergeUserActivity(userActivity, sessionUserActivity);
+			}
 			if (messages.length === 0) continue;
 			startedAt ??= new Date(entry.sessionStartedAt ?? updatedAt);
 			endedAt ??= new Date(updatedAt);
@@ -957,18 +1162,16 @@ export class OpenClawAdapter implements AgentAdapterCore {
 				events,
 				rawFilePath: storePath,
 				sourceRevision,
-				realUserInputAt: userActivity.lastUserInputAt,
+				realUserInputAt: sessionUserActivity.lastUserInputAt,
 			});
-		}
-		if (knownSourceRevisions.size === 0 && hasUnclassifiedTranscriptFiles(matchedTranscriptPaths)) {
-			activityComplete = false;
 		}
 		return {
 			sessions,
 			dedupedCount: 0,
 			observedLocalSessionIds,
-			matchedTranscriptPaths,
-			activityComplete,
+			matchedTranscriptPaths: new Set(),
+			classifiedTranscriptPaths,
+			userActivity,
 		};
 	}
 

--- a/packages/cli/src/lib/session-activity.ts
+++ b/packages/cli/src/lib/session-activity.ts
@@ -1,4 +1,4 @@
-import type { RawSession, SessionMessage } from "../adapters/base";
+import type { RawSession, SessionMessage, SessionUserActivity } from "../adapters/base";
 
 /**
  * Compute the "user actually used the session last" timestamp for
@@ -26,20 +26,16 @@ export function computeLastActivityIso(s: RawSession): string {
 	return s.startedAt.toISOString();
 }
 
-export interface RealUserActivity {
-	lastUserInputAt: string | null;
-	complete: boolean;
-}
-
 /** Classify OpenClaw transcript records without losing newer provenance fields. */
 export function computeOpenClawRealUserActivity(
 	records: readonly unknown[],
 	sessionKey: string,
 	sessionMetadata?: unknown,
-): RealUserActivity {
-	if (internalOpenClawSession(sessionKey, sessionMetadata))
+): SessionUserActivity {
+	if (isInternalOpenClawSession(sessionKey, sessionMetadata))
 		return { lastUserInputAt: null, complete: true };
 	let best: number | null = null;
+	let complete = true;
 	for (const value of records) {
 		const record = objectRecord(value);
 		if (!record) continue;
@@ -51,12 +47,15 @@ export function computeOpenClawRealUserActivity(
 		const timestamp = activityTimestamp(
 			message.timestamp ?? message.createdAt ?? record.timestamp ?? record.createdAt,
 		);
-		if (timestamp === null) return { lastUserInputAt: null, complete: false };
+		if (timestamp === null) {
+			complete = false;
+			continue;
+		}
 		if (best === null || timestamp > best) best = timestamp;
 	}
 	return {
 		lastUserInputAt: best === null ? null : new Date(best).toISOString(),
-		complete: true,
+		complete,
 	};
 }
 
@@ -69,7 +68,7 @@ const INTERNAL_OPENCLAW_SOURCES = new Set([
 	"system_generated",
 ]);
 
-function internalOpenClawSession(value: string, metadata: unknown): boolean {
+export function isInternalOpenClawSession(value: string, metadata: unknown): boolean {
 	const key = value.trim().toLowerCase();
 	if (
 		key.startsWith("cron:") ||

--- a/packages/cli/src/runtime/observed-v2.test.ts
+++ b/packages/cli/src/runtime/observed-v2.test.ts
@@ -7,6 +7,7 @@ import { writeRuntimeAppliedState } from "./applied-state";
 import { readHostedRuntimeObserved } from "./observed";
 import { getRuntimePaths } from "./paths";
 import { buildRuntimeBootStatus, writeRuntimeBootStatus, writeRuntimeWatchStatus } from "./state";
+import { recordRuntimeUserActivityScan } from "./user-activity-state";
 
 const originalEnv = { ...process.env };
 const roots: string[] = [];
@@ -175,6 +176,30 @@ describe("hosted runtime observed v2", () => {
 		const observed = readHostedRuntimeObserved(paths);
 		expect(observed?.status).toBe("ok");
 		expect(observed?.convergeError).toBe("runtime hermes sourced Skill projection failed");
+	});
+
+	test("reports durable Hermes user activity through the existing observation contract", () => {
+		const paths = healthyAppliedRuntimePaths();
+		process.env.CLAWDI_STATE_DIR = join(paths.serviceStateRoot, "activity");
+		recordRuntimeUserActivityScan({
+			agentType: "hermes",
+			userActivity: {
+				lastUserInputAt: "2026-08-19T01:00:00.000Z",
+				complete: true,
+			},
+			complete: true,
+			observedAt: new Date("2026-08-19T02:00:00.000Z"),
+		});
+
+		expect(readHostedRuntimeObserved(paths)?.userActivity).toEqual({
+			schemaVersion: 1,
+			classifierVersion: 1,
+			classification: "known_last_user_input",
+			lastUserInputAt: "2026-08-19T01:00:00.000Z",
+			observedAt: "2026-08-19T02:00:00.000Z",
+			completeAt: "2026-08-19T02:00:00.000Z",
+			enabledRuntimes: ["hermes"],
+		});
 	});
 
 	test("reports an untyped watch apply failure as unhealthy", () => {

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -105,24 +105,57 @@ function observedUserActivity(
 		)
 		.sort();
 	if (enabledRuntimes.length === 0) return null;
-	const openclaw = enabledRuntimes.includes("openclaw")
-		? readRuntimeUserActivityState(runtimeUserActivityStatePath("openclaw"))
-		: null;
-	const unsupported = enabledRuntimes.some((runtime) => runtime !== "openclaw");
-	const classification = unsupported ? "unknown" : (openclaw?.classification ?? "unknown");
-	const error = unsupported
-		? "activity_runtime_unsupported"
-		: (openclaw?.error ?? (openclaw ? undefined : "activity_cache_missing"));
+	const states = enabledRuntimes.map((runtime) => {
+		const state = readRuntimeUserActivityState(runtimeUserActivityStatePath(runtime));
+		return state?.agentType === runtime ? state : null;
+	});
+	const missing = states.includes(null);
+	const unknown = states.find((state) => state?.classification === "unknown");
+	const known = !missing && unknown === undefined;
+	const lastUserInputAt = maxIso(states.map((state) => state?.lastUserInputAt ?? null));
+	const observedAt = maxIso(states.map((state) => state?.observedAt ?? reportedAt)) ?? reportedAt;
+	const completeAt = minIso(states.map((state) => state?.completeAt ?? null));
+	const classification = known
+		? lastUserInputAt
+			? "known_last_user_input"
+			: "known_no_user_input"
+		: "unknown";
+	const error = known
+		? undefined
+		: (unknown?.error ?? (missing ? "activity_cache_missing" : "activity_scan_incomplete"));
 	return {
 		schemaVersion: 1,
 		classifierVersion: 1,
 		classification,
-		lastUserInputAt: openclaw?.lastUserInputAt ?? null,
-		observedAt: openclaw?.observedAt ?? reportedAt,
-		completeAt: openclaw?.completeAt ?? null,
+		lastUserInputAt,
+		observedAt,
+		completeAt,
 		enabledRuntimes,
 		...(error ? { error } : {}),
 	};
+}
+
+function maxIso(values: readonly (string | null)[]): string | null {
+	return extremeIso(values, (candidate, current) => candidate > current);
+}
+
+function minIso(values: readonly (string | null)[]): string | null {
+	return extremeIso(values, (candidate, current) => candidate < current);
+}
+
+function extremeIso(
+	values: readonly (string | null)[],
+	prefer: (candidate: number, current: number) => boolean,
+): string | null {
+	let selected: number | null = null;
+	for (const value of values) {
+		if (!value) continue;
+		const candidate = new Date(value).getTime();
+		if (!Number.isNaN(candidate) && (selected === null || prefer(candidate, selected))) {
+			selected = candidate;
+		}
+	}
+	return selected === null ? null : new Date(selected).toISOString();
 }
 
 function readJsonRecord(path: string): JsonRecord | null {

--- a/packages/cli/src/runtime/user-activity-state.test.ts
+++ b/packages/cli/src/runtime/user-activity-state.test.ts
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { RawSession } from "../adapters/base";
 import {
 	markRuntimeUserActivityUnknown,
 	readRuntimeUserActivityState,
@@ -26,41 +25,19 @@ function statePath(): string {
 	return runtimeUserActivityStatePath("openclaw");
 }
 
-function session(realUserInputAt: string | null): RawSession {
-	return {
-		localSessionId: "session-1",
-		projectPath: null,
-		startedAt: new Date("2026-08-01T00:00:00Z"),
-		endedAt: null,
-		messageCount: 0,
-		inputTokens: 0,
-		outputTokens: 0,
-		cacheReadTokens: 0,
-		model: null,
-		modelsUsed: [],
-		durationSeconds: null,
-		summary: null,
-		messages: [],
-		rawFilePath: "/fixture",
-		realUserInputAt,
-	};
-}
-
 describe("runtime user activity state", () => {
 	test("builds one complete baseline and refreshes it from watcher deltas", () => {
 		const path = statePath();
 		recordRuntimeUserActivityScan({
 			agentType: "openclaw",
-			sessions: [session("2026-08-01T00:00:00Z")],
+			userActivity: { lastUserInputAt: "2026-08-01T00:00:00Z", complete: true },
 			complete: true,
-			activityComplete: true,
 			observedAt: new Date("2026-08-02T00:00:00Z"),
 		});
 		recordRuntimeUserActivityScan({
 			agentType: "openclaw",
-			sessions: [],
+			userActivity: { lastUserInputAt: null, complete: true },
 			complete: false,
-			activityComplete: true,
 			observedAt: new Date("2026-08-03T00:00:00Z"),
 		});
 
@@ -76,20 +53,41 @@ describe("runtime user activity state", () => {
 		const path = statePath();
 		recordRuntimeUserActivityScan({
 			agentType: "openclaw",
-			sessions: [session(null)],
+			userActivity: { lastUserInputAt: null, complete: true },
 			complete: true,
-			activityComplete: true,
 			observedAt: new Date("2026-08-02T00:00:00Z"),
 		});
 		markRuntimeUserActivityUnknown("openclaw", "fixture_failure");
 		recordRuntimeUserActivityScan({
 			agentType: "openclaw",
-			sessions: [],
+			userActivity: { lastUserInputAt: null, complete: true },
 			complete: false,
-			activityComplete: true,
 			observedAt: new Date("2026-08-03T00:00:00Z"),
 		});
 
 		expect(readRuntimeUserActivityState(path)?.classification).toBe("unknown");
+	});
+
+	test("converges after an incomplete scan without losing a trustworthy timestamp", () => {
+		const path = statePath();
+		recordRuntimeUserActivityScan({
+			agentType: "openclaw",
+			userActivity: { lastUserInputAt: "2026-08-01T00:00:00Z", complete: false },
+			complete: true,
+			observedAt: new Date("2026-08-02T00:00:00Z"),
+		});
+		recordRuntimeUserActivityScan({
+			agentType: "openclaw",
+			userActivity: { lastUserInputAt: null, complete: true },
+			complete: true,
+			observedAt: new Date("2026-08-03T00:00:00Z"),
+		});
+
+		expect(readRuntimeUserActivityState(path)).toMatchObject({
+			agentType: "openclaw",
+			classification: "known_last_user_input",
+			lastUserInputAt: "2026-08-01T00:00:00.000Z",
+			completeAt: "2026-08-03T00:00:00.000Z",
+		});
 	});
 });

--- a/packages/cli/src/runtime/user-activity-state.ts
+++ b/packages/cli/src/runtime/user-activity-state.ts
@@ -1,15 +1,17 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentType } from "../adapters/agent-types";
-import type { RawSession } from "../adapters/base";
+import type { SessionUserActivity } from "../adapters/base";
 import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "../lib/private-file";
 import { getServeStateDir } from "../serve/paths";
 
 export const RUNTIME_USER_ACTIVITY_CLASSIFIER_VERSION = 1;
 
+type SupportedRuntime = "hermes" | "openclaw";
+
 export interface RuntimeUserActivityState {
 	schemaVersion: "clawdi.runtimeUserActivity.v1";
-	agentType: "openclaw";
+	agentType: SupportedRuntime;
 	classifierVersion: 1;
 	classification: "known_last_user_input" | "known_no_user_input" | "unknown";
 	lastUserInputAt: string | null;
@@ -18,11 +20,11 @@ export interface RuntimeUserActivityState {
 	error?: string;
 }
 
-export function supportsRuntimeUserActivity(agentType: AgentType): agentType is "openclaw" {
-	return agentType === "openclaw";
+export function supportsRuntimeUserActivity(agentType: AgentType): agentType is SupportedRuntime {
+	return agentType === "hermes" || agentType === "openclaw";
 }
 
-export function runtimeUserActivityStatePath(agentType: "openclaw"): string {
+export function runtimeUserActivityStatePath(agentType: SupportedRuntime): string {
 	return join(getServeStateDir(agentType), "user-activity.json");
 }
 
@@ -33,7 +35,7 @@ export function readRuntimeUserActivityState(path: string): RuntimeUserActivityS
 		const row = value as Record<string, unknown>;
 		if (
 			row.schemaVersion !== "clawdi.runtimeUserActivity.v1" ||
-			row.agentType !== "openclaw" ||
+			!isSupportedRuntime(row.agentType) ||
 			row.classifierVersion !== RUNTIME_USER_ACTIVITY_CLASSIFIER_VERSION ||
 			!isClassification(row.classification) ||
 			!isIsoTimestamp(row.observedAt) ||
@@ -55,7 +57,7 @@ export function readRuntimeUserActivityState(path: string): RuntimeUserActivityS
 			return null;
 		return {
 			schemaVersion: "clawdi.runtimeUserActivity.v1",
-			agentType: "openclaw",
+			agentType: row.agentType,
 			classifierVersion: RUNTIME_USER_ACTIVITY_CLASSIFIER_VERSION,
 			classification: row.classification,
 			lastUserInputAt: row.lastUserInputAt,
@@ -71,33 +73,37 @@ export function readRuntimeUserActivityState(path: string): RuntimeUserActivityS
 export function runtimeUserActivityNeedsMaterialization(agentType: AgentType): boolean {
 	if (!supportsRuntimeUserActivity(agentType)) return false;
 	const state = readRuntimeUserActivityState(runtimeUserActivityStatePath(agentType));
-	return state === null || state.classification === "unknown" || state.completeAt === null;
+	return (
+		state === null ||
+		state.agentType !== agentType ||
+		state.classification === "unknown" ||
+		state.completeAt === null
+	);
 }
 
 export function recordRuntimeUserActivityScan(input: {
 	agentType: AgentType;
-	sessions: readonly RawSession[];
+	userActivity: SessionUserActivity;
 	complete: boolean;
-	activityComplete: boolean;
 	observedAt?: Date;
 }): void {
 	if (!supportsRuntimeUserActivity(input.agentType)) return;
 	const path = runtimeUserActivityStatePath(input.agentType);
-	const previous = readRuntimeUserActivityState(path);
+	const stored = readRuntimeUserActivityState(path);
+	const previous = stored?.agentType === input.agentType ? stored : null;
 	const observedAt = maxTimestamp(
 		previous?.observedAt ?? null,
 		(input.observedAt ?? new Date()).toISOString(),
 	) as string;
 	const latest = maxTimestamp(
 		previous?.lastUserInputAt ?? null,
-		...input.sessions.map((session) => session.realUserInputAt ?? null),
+		input.userActivity.lastUserInputAt,
 	);
 	const priorBaselineKnown =
 		previous !== null && previous.classification !== "unknown" && previous.completeAt !== null;
-	const known = input.activityComplete && (input.complete || priorBaselineKnown);
+	const known = input.userActivity.complete && (input.complete || priorBaselineKnown);
 	const timestampIsValid =
 		latest === null || new Date(latest).getTime() <= new Date(observedAt).getTime();
-	const completeAt = known && timestampIsValid ? observedAt : (previous?.completeAt ?? null);
 	writeState(path, {
 		schemaVersion: "clawdi.runtimeUserActivity.v1",
 		agentType: input.agentType,
@@ -110,7 +116,7 @@ export function recordRuntimeUserActivityScan(input: {
 				: "unknown",
 		lastUserInputAt: timestampIsValid ? latest : (previous?.lastUserInputAt ?? null),
 		observedAt,
-		completeAt,
+		completeAt: known && timestampIsValid ? observedAt : (previous?.completeAt ?? null),
 		...(known && timestampIsValid
 			? {}
 			: {
@@ -125,7 +131,8 @@ export function markRuntimeUserActivityUnknown(
 ): void {
 	if (!supportsRuntimeUserActivity(agentType)) return;
 	const path = runtimeUserActivityStatePath(agentType);
-	const previous = readRuntimeUserActivityState(path);
+	const stored = readRuntimeUserActivityState(path);
+	const previous = stored?.agentType === agentType ? stored : null;
 	writeState(path, {
 		schemaVersion: "clawdi.runtimeUserActivity.v1",
 		agentType,
@@ -143,6 +150,10 @@ function writeState(path: string, state: RuntimeUserActivityState): void {
 		mode: PRIVATE_FILE_MODE,
 		dirMode: PRIVATE_DIR_MODE,
 	});
+}
+
+function isSupportedRuntime(value: unknown): value is SupportedRuntime {
+	return value === "hermes" || value === "openclaw";
 }
 
 function isClassification(value: unknown): value is RuntimeUserActivityState["classification"] {

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -974,12 +974,8 @@ async function prepareSessionSync(
 			);
 			const observedResources = new Set<string>();
 			const confirmedSourceRevisions: FencedSessionSourceRevisionUpdate[] = [];
-			const activitySessions: RawSession[] = [];
-			let activityComplete = true;
 			let enqueued = 0;
 			for await (const batch of scan.batches) {
-				activitySessions.push(...batch.sessions);
-				activityComplete &&= batch.activityComplete !== false;
 				for (const localSessionId of batch.observedLocalSessionIds) {
 					observedResources.add(`session:${localSessionId}`);
 				}
@@ -1010,9 +1006,8 @@ async function prepareSessionSync(
 			}
 			recordRuntimeUserActivityScan({
 				agentType: opts.adapter.agentType,
-				sessions: activitySessions,
+				userActivity: scan.userActivity ?? { lastUserInputAt: null, complete: false },
 				complete: scan.coverage === "complete",
-				activityComplete,
 			});
 			persistFencedSessionSourceRevisions(confirmedSourceRevisions);
 			if (scan.coverage === "complete") {

--- a/packages/cli/tests/adapters/hermes.test.ts
+++ b/packages/cli/tests/adapters/hermes.test.ts
@@ -296,6 +296,53 @@ describe("HermesAdapter.collectSessions", () => {
 		expect(changedIds.sort()).toEqual(["bulk-00", "bulk-01", "bulk-02", "bulk-03", "bulk-04"]);
 	});
 
+	it("classifies only top-level user rows from non-internal Hermes sessions", async () => {
+		const db = new Database(join(tmpHome, ".hermes", "state.db"));
+		for (const [id, source, parentSessionId, timestamp] of [
+			["activity-user", "telegram", null, 2_000_000_000],
+			["activity-cron", "cron", null, 2_000_000_100],
+			["activity-subagent", "subagent", null, 2_000_000_200],
+			["activity-curator", "curator", null, 2_000_000_300],
+			["activity-child", "telegram", "activity-user", 2_000_000_400],
+		] as const) {
+			db.run(
+				"INSERT INTO sessions (id, source, parent_session_id, title, started_at, message_count) VALUES (?, ?, ?, ?, ?, 1)",
+				id,
+				source,
+				parentSessionId,
+				id,
+				timestamp,
+			);
+			db.run(
+				"INSERT INTO messages (session_id, role, content, timestamp, active, compacted) VALUES (?, 'user', 'input', ?, 1, 0)",
+				id,
+				timestamp,
+			);
+		}
+		db.close();
+
+		const scan = await scanSessionModule(new HermesAdapter().sessions, { kind: "complete" });
+
+		expect(scan.userActivity).toEqual({
+			lastUserInputAt: new Date(2_000_000_000 * 1000).toISOString(),
+			complete: true,
+		});
+	});
+
+	it("fails Hermes activity closed when the top-level session relation is unavailable", async () => {
+		const db = new Database(join(tmpHome, ".hermes", "state.db"));
+		db.exec(`
+			ALTER TABLE sessions DROP COLUMN parent_session_id;
+		`);
+		db.close();
+
+		const scan = await scanSessionModule(new HermesAdapter().sessions, { kind: "complete" });
+		expect(scan.userActivity).toEqual({ lastUserInputAt: null, complete: false });
+		for await (const _batch of scan.batches) {
+			// Consume the iterator so its read-only SQLite handle closes.
+		}
+	});
+
 	it("uses events-v1 with stable ids when newer optional message columns are absent", async () => {
 		const db = new Database(join(tmpHome, ".hermes", "state.db"));
 		db.exec(`

--- a/packages/cli/tests/adapters/openclaw.test.ts
+++ b/packages/cli/tests/adapters/openclaw.test.ts
@@ -312,8 +312,15 @@ describe("OpenClawAdapter.collectSessions", () => {
 
 	it("reads legacy inventory JSONL without requiring a live Gateway", async () => {
 		writeFileSync(join(tmpHome, ".openclaw", "legacy-inventory-test"), "enabled");
+		const sessionsDir = join(tmpHome, ".openclaw", "agents", "main", "sessions");
+		writeFileSync(
+			join(sessionsDir, "orphan.jsonl.deleted.2026-09-01"),
+			`${JSON.stringify({ role: "user", content: "archived input", timestamp: "2026-08-19T00:00:00Z" })}\n`,
+		);
 
-		const { sessions } = await new OpenClawAdapter().sessions.collect({ kind: "complete" });
+		const scan = await scanSessionModule(new OpenClawAdapter().sessions, { kind: "complete" });
+		const sessions = [];
+		for await (const batch of scan.batches) sessions.push(...batch.sessions);
 
 		expect(sessions).toHaveLength(1);
 		expect(sessions[0]).toMatchObject({
@@ -321,6 +328,10 @@ describe("OpenClawAdapter.collectSessions", () => {
 			projectPath: "/Users/fixture/project",
 			messageCount: 2,
 			sourceRevision: "oc-session-001:1776247205000",
+		});
+		expect(scan.userActivity).toEqual({
+			lastUserInputAt: "2026-08-19T00:00:00.000Z",
+			complete: true,
 		});
 	});
 
@@ -480,6 +491,56 @@ export async function readVisibleSessionTranscriptMessageEntries() {
 		const a = new OpenClawAdapter();
 		const { sessions } = await a.sessions.collect({ kind: "complete" });
 		expect(sessions.map((s) => s.localSessionId)).toEqual(["oc-financial-001"]);
+	});
+
+	it("classifies stale, orphaned, and internal OpenClaw archives from the canonical inventory", async () => {
+		const sessionsDir = join(tmpHome, ".openclaw", "agents", "main", "sessions");
+		const internal = join(sessionsDir, "internal.jsonl");
+		writeFileSync(
+			join(sessionsDir, "stale.jsonl.deleted.2026-09-01"),
+			`${JSON.stringify({ role: "user", content: "archived input", timestamp: "2026-08-20T00:00:00Z" })}\n`,
+		);
+		writeFileSync(
+			join(sessionsDir, "orphan.jsonl.reset.2026-09-02"),
+			`${JSON.stringify({ role: "user", content: "orphan input", timestamp: "2026-08-21T00:00:00Z" })}\n`,
+		);
+		writeFileSync(`${internal}.deleted.2026-09-03`, "{");
+		writeFileSync(internal, "{");
+		writeFileSync(
+			join(sessionsDir, "media.jsonl"),
+			`${JSON.stringify({ role: "user", content: [{ type: "image", url: "local" }], timestamp: "2026-08-24T00:00:00Z" })}\n`,
+		);
+		writeFileSync(
+			join(sessionsDir, "sessions.json"),
+			JSON.stringify({
+				main: { sessionId: "stale", updatedAt: 1776247205000 },
+				"agent:main:cron:daily": { sessionFile: internal, updatedAt: 1776247205000 },
+				media: { sessionId: "media", updatedAt: 1776247205000 },
+			}),
+		);
+
+		const scan = await scanSessionModule(new OpenClawAdapter().sessions, { kind: "complete" });
+
+		expect(scan.userActivity).toEqual({
+			lastUserInputAt: "2026-08-24T00:00:00.000Z",
+			complete: true,
+		});
+	});
+
+	it("keeps a trustworthy OpenClaw timestamp while an archive tail is incomplete", async () => {
+		const sessionsDir = join(tmpHome, ".openclaw", "agents", "main", "sessions");
+		writeFileSync(join(sessionsDir, "sessions.json"), "{}");
+		writeFileSync(
+			join(sessionsDir, "orphan.jsonl.deleted.2026-09-03"),
+			`${JSON.stringify({ role: "user", content: "known input", timestamp: "2026-08-23T00:00:00Z" })}\n{`,
+		);
+
+		const scan = await scanSessionModule(new OpenClawAdapter().sessions, { kind: "complete" });
+
+		expect(scan.userActivity).toEqual({
+			lastUserInputAt: "2026-08-23T00:00:00.000Z",
+			complete: false,
+		});
 	});
 });
 

--- a/packages/cli/tests/adapters/openclaw.test.ts
+++ b/packages/cli/tests/adapters/openclaw.test.ts
@@ -34,7 +34,7 @@ fi
 if [ "$*" = "sessions --json --all-agents --limit all" ] && [ -f "$HOME/.openclaw/sqlite-session-test" ]; then
   updated_at=1776247205000
   if [ -f "$HOME/.openclaw/sqlite-session-updated-at" ]; then updated_at=$(cat "$HOME/.openclaw/sqlite-session-updated-at"); fi
-  printf '{"path":null,"stores":[{"agentId":"main","path":"%s/.openclaw/agents/main/agent/openclaw-agent.sqlite"}],"allAgents":true,"sessions":[{"agentId":"main","key":"agent:main:main","sessionId":"sqlite-session-001","updatedAt":%s,"sessionStartedAt":1776247200000,"model":"gpt-5.6-sol","modelProvider":"openai","inputTokens":8,"outputTokens":5,"cacheRead":2,"label":"Active SQLite branch"}]}\n' "$HOME" "$updated_at"
+  printf '{"path":null,"stores":[{"agentId":"main","path":"%s/.openclaw/agents/main/agent/openclaw-agent.sqlite"}],"allAgents":true,"sessions":[{"agentId":"main","key":"agent:main:main","sessionId":"sqlite-session-001","updatedAt":%s,"sessionStartedAt":1776247200000,"sessionFile":"%s/.openclaw/agents/main/sessions/sqlite-session-001.jsonl","model":"gpt-5.6-sol","modelProvider":"openai","inputTokens":8,"outputTokens":5,"cacheRead":2,"label":"Active SQLite branch"}]}\n' "$HOME" "$updated_at" "$HOME"
   exit 0
 fi
 if [ "$1 $2 $3" = "gateway call chat.history" ] && [ -f "$HOME/.openclaw/sqlite-session-test" ]; then
@@ -335,14 +335,22 @@ describe("OpenClawAdapter.collectSessions", () => {
 		});
 	});
 
-	it("does not materialize an unchanged official transcript", async () => {
+	it("uses official current activity and only inventories archives during baseline", async () => {
 		const stateRoot = join(tmpHome, ".openclaw");
+		const sessionsRoot = join(stateRoot, "agents", "main", "sessions");
 		const packageRoot = join(tmpHome, ".local", "lib", "node_modules", "openclaw");
 		const readLog = join(stateRoot, "transcript-reads.log");
 		mkdirSync(join(stateRoot, "agents", "main", "agent"), { recursive: true });
 		mkdirSync(packageRoot, { recursive: true });
 		writeFileSync(join(stateRoot, "agents", "main", "agent", "openclaw-agent.sqlite"), "fixture");
 		writeFileSync(join(stateRoot, "sqlite-session-test"), "enabled");
+		const currentPath = join(sessionsRoot, "sqlite-session-001.jsonl");
+		writeFileSync(currentPath, "{");
+		const archivePath = join(sessionsRoot, "sqlite-session-001.jsonl.deleted.2026-09-01");
+		writeFileSync(
+			archivePath,
+			`${JSON.stringify({ role: "user", content: "archived input", timestamp: "2026-08-16T10:00:00Z" })}\n`,
+		);
 		writeFileSync(
 			join(packageRoot, "package.json"),
 			JSON.stringify({
@@ -372,7 +380,19 @@ export async function readVisibleSessionTranscriptMessageEntries() {
 		for await (const batch of first.batches) firstBatches.push(batch);
 		const revision = firstBatches[0]?.sessions[0]?.sourceRevision;
 		expect(revision).toBe("sqlite-session-001:1776247205000");
+		expect(first.userActivity).toEqual({
+			lastUserInputAt: "2026-08-16T10:00:00.000Z",
+			complete: true,
+		});
 		expect(readFileSync(readLog, "utf8")).toBe("read\n");
+		rmSync(currentPath);
+		const missingCurrent = await scanSessionModule(adapter.sessions, { kind: "complete" });
+		expect(missingCurrent.userActivity).toEqual({
+			lastUserInputAt: "2026-08-16T10:00:00.000Z",
+			complete: true,
+		});
+		expect(readFileSync(readLog, "utf8")).toBe("read\nread\n");
+		writeFileSync(archivePath, "{");
 
 		const unchanged = await scanSessionModule(
 			adapter.sessions,
@@ -383,7 +403,8 @@ export async function readVisibleSessionTranscriptMessageEntries() {
 		for await (const batch of unchanged.batches) unchangedBatches.push(batch);
 		expect(unchangedBatches[0]?.sessions).toEqual([]);
 		expect(unchangedBatches[0]?.observedLocalSessionIds).toEqual(["sqlite-session-001"]);
-		expect(readFileSync(readLog, "utf8")).toBe("read\n");
+		expect(unchanged.userActivity).toEqual({ lastUserInputAt: null, complete: true });
+		expect(readFileSync(readLog, "utf8")).toBe("read\nread\n");
 
 		writeFileSync(join(stateRoot, "sqlite-session-updated-at"), "1776247206000");
 		const changed = await scanSessionModule(
@@ -394,7 +415,11 @@ export async function readVisibleSessionTranscriptMessageEntries() {
 		const changedBatches: SessionScanBatch[] = [];
 		for await (const batch of changed.batches) changedBatches.push(batch);
 		expect(changedBatches[0]?.sessions[0]?.sourceRevision).toBe("sqlite-session-001:1776247206000");
-		expect(readFileSync(readLog, "utf8")).toBe("read\nread\n");
+		expect(changed.userActivity).toEqual({
+			lastUserInputAt: "2026-04-15T10:00:00.000Z",
+			complete: true,
+		});
+		expect(readFileSync(readLog, "utf8")).toBe("read\nread\nread\n");
 	});
 
 	it("scans every agents/<id>/ subdir (issue #28)", async () => {


### PR DESCRIPTION
## Summary

- persist authoritative user-activity aggregates from OpenClaw and Hermes through the existing runtime observation contract
- classify OpenClaw current, reset, deleted, and orphan transcripts once during baseline materialization, then update from changed sessions without repeated full scans
- classify Hermes activity from top-level user messages while excluding cron, subagent, and curator sessions
- keep missing, malformed, incomplete, and legacy-unsupported activity fail-closed
- release the CLI as `clawdi@0.14.39`

## Verification

- Docker-isolated CLI typecheck
- 47 focused activity/adapter/observation tests passed
- agent verification: 50-test clean-runner activity suite, publish manifest, Biome, release build, and dry-run package

## Rollout

- do not enable v2 idle reclaim yet
- do not enable the Customer.io campaign yet
- publish and roll out `clawdi@0.14.39`, then observe activity coverage convergence first