### PR TITLE
Align Hosted UI with the one-time Compute trial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ database migration, CI, and implementation details.
 
 ### Changed
 
+- Hosted plan selection now explains the single 7-day trial shared by an
+  account's first Basic or Performance subscription, while grandfathered Basic
+  capacity is labeled Included.
 - Newest-first Session detail pages now paginate from the actual visible transcript instead of relying on separately reported message counts, including for incrementally appended event chunks.
 - Session search keeps its controls visible in long conversations, supports keyboard match navigation, shows clearer loading feedback, and gives message matches more context in result cards.
 - The public README now focuses on the two run paths, current product capabilities, quickstart, and self-hosting entry points.

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -3848,14 +3848,14 @@ function ComputeSettingsSections({
 								description: (
 									<p>
 										Cancellation takes effect {subscriptionPeriodLabel}. The agent then falls back
-										to free compute if available; otherwise, it stops.
+										to an included Basic entitlement if available; otherwise, it stops.
 									</p>
 								),
 								confirmLabel: "Cancel at period end",
 								successDescription: (result) =>
 									result.current_period_end
-										? `Cancellation takes effect ${formatShortDate(result.current_period_end)}. The agent then falls back to free compute if available; otherwise, it stops.`
-										: "The agent falls back to free compute if available when cancellation takes effect; otherwise, it stops.",
+										? `Cancellation takes effect ${formatShortDate(result.current_period_end)}. The agent then falls back to an included Basic entitlement if available; otherwise, it stops.`
+										: "The agent falls back to an included Basic entitlement if available when cancellation takes effect; otherwise, it stops.",
 							}}
 						/>
 					}

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
@@ -188,7 +188,7 @@ describe("computeDunningState", () => {
 			recoveryPlanSlug: "compute_performance",
 		});
 		expect(running?.fallbackOccurredAt).not.toBe("2026-07-18T12:05:00Z");
-		expect(running?.description).toContain("now using free compute");
+		expect(running?.description).toContain("now using included Basic");
 
 		const stopped = computeDunningState(
 			deployment({
@@ -197,7 +197,7 @@ describe("computeDunningState", () => {
 				status: "stopped",
 			}),
 		);
-		expect(stopped?.description).toContain("No free compute slot was available");
+		expect(stopped?.description).toContain("No included Basic entitlement was available");
 
 		const unavailable = computeDunningState(
 			deployment({
@@ -207,9 +207,9 @@ describe("computeDunningState", () => {
 			}),
 		);
 		expect(unavailable?.description).toContain(
-			"can’t determine whether this agent stopped or is using free compute",
+			"can’t determine whether this agent stopped or is using included Basic",
 		);
-		expect(unavailable?.description).not.toContain("is now using free compute");
+		expect(unavailable?.description).not.toContain("is now using included Basic");
 	});
 
 	test("does not recover a detached or already recovered subscription", () => {

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
@@ -117,10 +117,10 @@ function detachedFallbackState(deployment: DunningDeployment): ComputeDunningSta
 		fundingSource: fallback.funding_source,
 		recoveryTarget: { kind: "start_new", action: "start_new" },
 		description: statusUnavailable
-			? "We can’t determine whether this agent stopped or is using free compute because its current status is unavailable. Start a new subscription to restore paid compute."
+			? "We can’t determine whether this agent stopped or is using included Basic because its current status is unavailable. Start a new subscription to restore paid compute."
 			: stopped
-				? "No free compute slot was available, so this agent stopped. Start a new subscription to restore paid compute."
-				: "This agent is now using free compute. Start a new subscription to restore paid compute.",
+				? "No included Basic entitlement was available, so this agent stopped. Start a new subscription to restore paid compute."
+				: "This agent is now using included Basic. Start a new subscription to restore paid compute.",
 		fallbackOccurredAt: fallback.occurred_at,
 		fallbackPlanLabel,
 		fallbackReason: fallback.reason,

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -139,7 +139,9 @@ describe("deploy wizard responsive layout", () => {
 
 	test("removes redundant payment badges and keeps concise funding copy", () => {
 		expect(wizardSource).not.toContain("hidden @3xl/main:inline-flex");
-		expect(wizardSource).toContain("Recurring subscription via Stripe. Manage or cancel anytime.");
+		expect(wizardSource).toContain(
+			"Card required. Eligible accounts get one 7-day trial on their first Basic or Performance subscription; one trial per account.",
+		);
 		expect(wizardSource).toContain("Paid upfront from your Wallet balance. Renews from Wallet.");
 	});
 });
@@ -217,6 +219,11 @@ describe("first Basic agent copy", () => {
 		expect(wizardSource).not.toContain("included Basic deployment");
 		expect(wizardSource).not.toContain("included slot");
 		expect(wizardSource).not.toContain("resolveWalletDeploymentId");
+		expect(wizardSource).toContain(
+			"Eligible accounts get one 7-day trial on their first Basic or Performance subscription; one trial per account.",
+		);
+		expect(agentDetailSource).toContain("an included Basic entitlement if available");
+		expect(agentDetailSource).not.toContain("falls back to free compute");
 	});
 
 	test("keeps post-acceptance waiting out of the customer flow", () => {
@@ -339,7 +346,7 @@ describe("billing-read gates", () => {
 			"shouldBlockQueryError(includedBasic.error, includedBasic.data)",
 		);
 		expect(wizardSource).toContain("includedBasic.data.available_slots > 0");
-		expect(wizardSource).toContain('title="Couldn\'t check free compute availability"');
+		expect(wizardSource).toContain('title="Couldn\'t check included Basic availability"');
 		expect(wizardSource).toContain("onRetry={() => void includedBasic.refetch()}");
 		expect(wizardSource).not.toContain("usesActiveIncludedBasicSlot");
 		expect(wizardSource).toContain('title="Couldn\'t load compute plans"');

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -602,10 +602,10 @@ export function DeployWizard() {
 		if (subscriptionSource.mode === "included") {
 			if (includedBasicAvailable === undefined) {
 				return blockingIncludedBasicError
-					? "Retry the free compute availability check above."
-					: "Checking your free compute availability.";
+					? "Retry the included Basic availability check above."
+					: "Checking included Basic availability.";
 			}
-			if (!includedBasicAvailable) return "Free compute is unavailable.";
+			if (!includedBasicAvailable) return "Included Basic is unavailable.";
 		} else {
 			if (reusableSubscriptions.isFetching) return "Checking reusable subscriptions.";
 			if (blockingReusableSubscriptionsError || reusableSubscriptionInventory === undefined) {
@@ -1255,7 +1255,7 @@ export function DeployWizard() {
 								normalizer={billingErrorNormalizer}
 								error={blockingIncludedBasicError}
 								onRetry={() => void includedBasic.refetch()}
-								title="Couldn't check free compute availability"
+								title="Couldn't check included Basic availability"
 							/>
 						) : null}
 						{subscriptionSource?.mode === "new" && plansLoadError ? (
@@ -1373,7 +1373,7 @@ export function DeployWizard() {
 													</IconChip>
 												}
 												title="Card subscription"
-												description="Recurring subscription via Stripe. Manage or cancel anytime."
+												description="Card required. Eligible accounts get one 7-day trial on their first Basic or Performance subscription; one trial per account."
 											/>
 											<EntityChoiceCard
 												selected={paymentMethod === "wallet"}

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -122,7 +122,7 @@ export function PlanComparison({
 			description={
 				sharedPricingUnavailable
 					? "A shared Basic and Performance billing term is not currently available."
-					: "Compare hosted compute plans before starting another agent."
+					: "Eligible accounts get one 7-day trial on their first Basic or Performance card subscription; one trial per account."
 			}
 		>
 			<div>
@@ -133,9 +133,9 @@ export function PlanComparison({
 							<CardTitle className="flex items-center gap-2">
 								<Cpu className="size-5 text-muted-foreground" aria-hidden /> Compute Basic
 							</CardTitle>
-							<CardDescription>First active Basic agent included at no charge.</CardDescription>
+							<CardDescription>Balanced capacity for everyday workloads.</CardDescription>
 							<div className="min-h-20 pt-1">
-								<p className="text-xs text-muted-foreground">Each additional Basic agent</p>
+								<p className="text-xs text-muted-foreground">Basic subscription</p>
 								{basicPrice ? (
 									<>
 										<p className="text-3xl font-semibold tracking-tight tabular-nums">
@@ -169,7 +169,7 @@ export function PlanComparison({
 							</CardTitle>
 							<CardDescription>Higher capacity for production workloads.</CardDescription>
 							<div className="min-h-20 pt-1">
-								<p className="text-xs text-muted-foreground">Each Performance agent</p>
+								<p className="text-xs text-muted-foreground">Performance subscription</p>
 								{performancePrice ? (
 									<>
 										<p className="text-3xl font-semibold tracking-tight tabular-nums">

--- a/apps/web/src/hosted/billing/subscription/subscription-source-picker.test.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-source-picker.test.tsx
@@ -26,6 +26,7 @@ describe("SubscriptionSourcePicker", () => {
 				isLoading={false}
 				error={null}
 				onRetry={() => undefined}
+				showIncluded
 			/>,
 		);
 
@@ -36,5 +37,7 @@ describe("SubscriptionSourcePicker", () => {
 		expect(markup).toContain('aria-pressed="true"');
 		expect(markup).toContain('title="Basic">Basic</span>');
 		expect(markup).toContain("Plan price");
+		expect(markup).toContain("Use your included Basic entitlement.");
+		expect(markup).toContain("Included");
 	});
 });

--- a/apps/web/src/hosted/billing/subscription/subscription-source-picker.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-source-picker.tsx
@@ -55,9 +55,9 @@ export function SubscriptionSourcePicker({
 							</IconChip>
 						}
 						title="Basic compute"
-						description="Use your free compute entitlement."
+						description="Use your included Basic entitlement."
 						details={<span className="text-xs font-medium text-foreground">$0 due now</span>}
-						badge={<Badge variant="secondary">Free</Badge>}
+						badge={<Badge variant="secondary">Included</Badge>}
 						className="items-start p-3"
 					/>
 				) : null}

--- a/bun.lock
+++ b/bun.lock
@@ -100,7 +100,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.38",
+      "version": "0.14.39",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.38",
+	"version": "0.14.39",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -70,6 +70,8 @@ export type DeployCommandDependencies = {
 
 type DeployAiMode = "managed" | "saved" | "unmanaged";
 type DeployPaymentMethod = "wallet" | "card";
+const HOSTED_CLI_PAID_CHECKOUT_UNAVAILABLE =
+	"This Hosted CLI authorization cannot purchase compute. No quote or payment was started; use the Web Deploy Wizard.";
 
 export type ParsedDeployOptions = {
 	runtime?: HostedDeployRuntime;
@@ -830,10 +832,7 @@ export async function runDeployFlow(
 	}
 	if (computeOptions.length === 0) {
 		if (!paidCheckoutSupported) {
-			throw new DeployInputError(
-				"paid_checkout_unavailable",
-				"This Hosted CLI authorization can create only the included free Basic agent. Paid Wallet and card checkout are not granted to CLI tokens; use the Web Deploy Wizard.",
-			);
+			throw new DeployInputError("paid_checkout_unavailable", HOSTED_CLI_PAID_CHECKOUT_UNAVAILABLE);
 		}
 		throw new PublicDeployFailure(
 			"compute_unavailable",
@@ -852,7 +851,7 @@ export async function runDeployFlow(
 	}
 	if (!computeOptions.some((option) => option.value === computePlanSlug)) {
 		const reason = !paidCheckoutSupported
-			? "This Hosted CLI authorization can create only the included free Basic agent. Paid Wallet and card checkout are not granted to CLI tokens; use the Web Deploy Wizard."
+			? HOSTED_CLI_PAID_CHECKOUT_UNAVAILABLE
 			: computePlanSlug === "compute_basic" && basicSelection.mode === "unavailable"
 				? `Basic compute is unavailable (${basicSelection.reason.replace(/_/g, " ")}).`
 				: `${planLabel(computePlanSlug)} compute is unavailable.`;
@@ -925,10 +924,7 @@ export async function runDeployFlow(
 	let payment = parsed.payment;
 	if (!includedBasic) {
 		if (!paidCheckoutSupported) {
-			throw new DeployInputError(
-				"paid_checkout_unavailable",
-				"This Hosted CLI authorization does not grant paid checkout. No quote or payment was started; use the Web Deploy Wizard.",
-			);
+			throw new DeployInputError("paid_checkout_unavailable", HOSTED_CLI_PAID_CHECKOUT_UNAVAILABLE);
 		}
 		if (interactive && !payment) {
 			const selected = await prompts.select(


### PR DESCRIPTION
## Summary

- present Basic and Performance as paid subscriptions with one shared 7-day card trial per eligible account
- retain grandfathered Basic capacity and label it consistently as Included across deploy, subscription, cancellation, and dunning surfaces
- remove stale CLI authorization copy that implied new free Basic creation and bump the CLI to `0.14.39`

## Verification

- `bash scripts/test.sh web` (typecheck passed, 1110 tests passed, OSS production build passed)
- `bash scripts/test.sh cli` (typecheck passed, 1710 tests passed, 4 existing native-only tests skipped, 0 failed)
- focused Biome check on all changed TypeScript/TSX files
- `git diff --check`

## Release impact

- Head SHA: `5bd52f979`
- No API or database migration
- `packages/cli/package.json` changes from `0.14.38` to `0.14.39`, so the standard CLI publish workflow is expected after merge
- No manual production command was run
