### PR TITLE
fix(web): preserve dashboard queries across login

### DIFF
--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -8,7 +8,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { clearAccountSuspension } from "@/lib/account-suspension";
 import { useCurrentUser } from "@/lib/auth-client";
-import { createAppQueryClient } from "@/lib/query-client";
+import { createAppQueryClient, resetQueryClientForAuthChange } from "@/lib/query-client";
 
 export function Providers({ children }: { children: React.ReactNode }) {
 	const [queryClient] = useState(createAppQueryClient);
@@ -47,7 +47,9 @@ function QueryCacheAuthBoundary({
 			return;
 		}
 		if (lastAuthKey.current !== authKey) {
-			queryClient.clear();
+			void resetQueryClientForAuthChange(queryClient).catch((error: unknown) => {
+				console.error("Failed to reset dashboard data after authentication changed", error);
+			});
 			clearAccountSuspension();
 			lastAuthKey.current = authKey;
 		}

--- a/apps/web/src/lib/query-client.test.ts
+++ b/apps/web/src/lib/query-client.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { resetQueryClientForAuthChange } from "@/lib/query-client";
+
+describe("query cache authentication boundary", () => {
+	test("refetches active observers while removing prior-user cached state", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		let attempt = 0;
+		const observer = new QueryObserver(queryClient, {
+			queryKey: ["auth-change", "active"],
+			queryFn: () => {
+				attempt += 1;
+				if (attempt === 1) return new Promise<string>(() => undefined);
+				return Promise.resolve("fresh-user-data");
+			},
+		});
+		const unsubscribe = observer.subscribe(() => undefined);
+		queryClient.setQueryData(["auth-change", "inactive"], "prior-user-data");
+		queryClient.getMutationCache().build(queryClient, {
+			mutationKey: ["auth-change", "mutation"],
+			mutationFn: async () => "prior-user-result",
+		});
+
+		try {
+			expect(observer.getCurrentResult().fetchStatus).toBe("fetching");
+			expect(queryClient.getMutationCache().getAll()).toHaveLength(1);
+
+			await resetQueryClientForAuthChange(queryClient);
+
+			expect(queryClient.getQueryData(["auth-change", "inactive"])).toBeUndefined();
+			expect(queryClient.getMutationCache().getAll()).toHaveLength(0);
+			expect(attempt).toBe(2);
+			expect(observer.getCurrentResult()).toMatchObject({
+				data: "fresh-user-data",
+				fetchStatus: "idle",
+				status: "success",
+			});
+		} finally {
+			unsubscribe();
+			queryClient.clear();
+		}
+	});
+});

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -29,3 +29,10 @@ export function createAppQueryClient(): QueryClient {
 		},
 	});
 }
+
+/** Clear prior-user state without detaching observers mounted during sign-in. */
+export async function resetQueryClientForAuthChange(queryClient: QueryClient): Promise<void> {
+	queryClient.getMutationCache().clear();
+	queryClient.removeQueries({ type: "inactive" });
+	await queryClient.resetQueries({ type: "active" });
+}


### PR DESCRIPTION
## Summary
- replace auth-change query cache clearing with an observer-preserving reset
- remove inactive prior-user queries and clear mutation state
- add a regression test for the first-login pending observer race

## Root cause
The root provider persists across sign-in. Calling `queryClient.clear()` during the signed-out to signed-in transition removes active query subscriptions after dashboard queries mount, leaving them pending until a full refresh remounts the observers.

## Verification
- `CLAWDI_TEST_COMPOSE_PROJECT_NAME=clawdi-auth-loading-root-review bash scripts/test.sh web src/lib/query-client.test.ts`
  - typecheck passed
  - 1 test passed
  - OSS production build passed
- pre-commit Biome hook passed
- `git diff --check origin/main..HEAD` passed

## Scope
`clawdi-hosted` was inspected and requires no change; its auth/bootstrap path does not use this client-side cache clear.