### PR TITLE
fix(v1): validate legacy managed provider runtime env

### DIFF
--- a/backend/app/routes/ai_providers.py
+++ b/backend/app/routes/ai_providers.py
@@ -113,12 +113,12 @@ from app.services.codex_oauth import (
 )
 from app.services.managed_ai_provider import (
     MANAGED_AI_PROVIDER_IDS,
-    MANAGED_AI_PROVIDER_RUNTIME_ENV,
     V2_MANAGED_AI_PROVIDER_ID,
     V2_MANAGED_AI_PROVIDER_IDS,
     is_v2_deployment_managed_provider_id,
     managed_provider_accepted_api_modes,
     managed_provider_api_mode,
+    managed_provider_runtime_env_name,
     runtime_managed_provider_id,
 )
 from app.services.platform_contract import (
@@ -1903,9 +1903,10 @@ def _validate_managed_provider_contract(body: AiProviderUpsert | AiProviderRespo
         )
     if body.auth.type != "api_key" or body.auth.source != "managed":
         errors.append("managed Clawdi provider must use managed api_key auth")
-    if body.runtime_env_name != MANAGED_AI_PROVIDER_RUNTIME_ENV:
+    expected_runtime_env_name = managed_provider_runtime_env_name(body.provider_id)
+    if expected_runtime_env_name is not None and body.runtime_env_name != expected_runtime_env_name:
         errors.append(
-            f"managed Clawdi provider must use runtime_env_name {MANAGED_AI_PROVIDER_RUNTIME_ENV}"
+            f"managed Clawdi provider must use runtime_env_name {expected_runtime_env_name}"
         )
     return errors
 

--- a/backend/app/services/managed_ai_provider.py
+++ b/backend/app/services/managed_ai_provider.py
@@ -151,6 +151,14 @@ def managed_provider_accepted_api_modes(provider_id: str) -> tuple[str, ...] | N
     return None
 
 
+def managed_provider_runtime_env_name(provider_id: str) -> str | None:
+    if provider_id == V1_MANAGED_AI_PROVIDER_ID:
+        return _LEGACY_MANAGED_AI_PROVIDER_RUNTIME_ENV
+    if is_v2_managed_provider_id(provider_id):
+        return MANAGED_AI_PROVIDER_RUNTIME_ENV
+    return None
+
+
 def validate_managed_provider_base_url(base_url: str) -> None:
     try:
         validate_public_https_url(base_url, label="base_url")

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -62,6 +62,7 @@ from app.services.managed_ai_provider import (
     is_v2_managed_provider_id,
     managed_provider_accepted_api_modes,
     managed_provider_api_mode,
+    managed_provider_runtime_env_name,
     runtime_managed_provider_id,
     upsert_clawdi_managed_provider,
     v2_deployment_managed_provider_id,
@@ -294,6 +295,25 @@ def test_deployment_scoped_v2_provider_uses_canonical_responses_mode():
 
     assert is_v2_managed_provider_id(provider_id)
     assert managed_provider_api_mode(provider_id) == V2_MANAGED_AI_PROVIDER_API_MODE
+
+
+@pytest.mark.parametrize(
+    ("provider_id", "expected_runtime_env_name"),
+    [
+        (V1_MANAGED_AI_PROVIDER_ID, "CLAWDI_MANAGED_OPENAI_API_KEY"),
+        (V2_MANAGED_AI_PROVIDER_ID, MANAGED_AI_PROVIDER_RUNTIME_ENV),
+        (
+            f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}42",
+            MANAGED_AI_PROVIDER_RUNTIME_ENV,
+        ),
+        ("user-managed", None),
+    ],
+)
+def test_managed_provider_runtime_env_name_follows_provider_generation(
+    provider_id: str,
+    expected_runtime_env_name: str | None,
+):
+    assert managed_provider_runtime_env_name(provider_id) == expected_runtime_env_name
 
 
 @pytest.mark.parametrize(
@@ -2171,12 +2191,28 @@ async def test_ai_provider_rejects_invalid_auth_and_api_mode(client: httpx.Async
             "api_mode": "openai_responses",
             "auth": {"type": "api_key", "source": "managed"},
             "managed_by": "clawdi",
-            "runtime_env_name": "CLAWDI_AI_API_KEY",
+            "runtime_env_name": "CLAWDI_MANAGED_OPENAI_API_KEY",
         },
     )
     assert v1_managed.status_code == 200, v1_managed.text
     assert v1_managed.json()["provider_id"] == "clawdi-managed"
     assert v1_managed.json()["api_mode"] == "openai_responses"
+
+    v1_managed_wrong_runtime_env = await client.post(
+        "/v1/ai-providers",
+        json={
+            "provider_id": "clawdi-managed",
+            "type": "custom_openai_compatible",
+            "base_url": "https://managed.example/v1",
+            "models": [{"id": "openai-codex/gpt-5.5"}],
+            "api_mode": "openai_responses",
+            "auth": {"type": "api_key", "source": "managed"},
+            "managed_by": "clawdi",
+            "runtime_env_name": "CLAWDI_AI_API_KEY",
+        },
+    )
+    assert v1_managed_wrong_runtime_env.status_code == 422
+    assert "CLAWDI_MANAGED_OPENAI_API_KEY" in v1_managed_wrong_runtime_env.text
 
     v1_managed_wrong_mode = await client.post(
         "/v1/ai-providers",
@@ -2188,7 +2224,7 @@ async def test_ai_provider_rejects_invalid_auth_and_api_mode(client: httpx.Async
             "api_mode": "openai_chat",
             "auth": {"type": "api_key", "source": "managed"},
             "managed_by": "clawdi",
-            "runtime_env_name": "CLAWDI_AI_API_KEY",
+            "runtime_env_name": "CLAWDI_MANAGED_OPENAI_API_KEY",
         },
     )
     assert v1_managed_wrong_mode.status_code == 422, v1_managed_wrong_mode.text


### PR DESCRIPTION
## Summary
- validate the legacy managed provider against `CLAWDI_MANAGED_OPENAI_API_KEY`
- retain `CLAWDI_AI_API_KEY` for v2 managed providers
- cover v1/v2 runtime-env contracts and rejection behavior

## Verification
- `scripts/test.sh backend tests/test_ai_providers.py` (137 passed)
- Ruff check and format passed
- `git diff --check`