### PR TITLE
perf(web): unblock dashboard during suspension check

### DIFF
--- a/apps/web/src/components/account-suspension-boundary.tsx
+++ b/apps/web/src/components/account-suspension-boundary.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useSyncExternalStore } from "react";
 import { AccountSuspendedPage } from "@/components/account-suspended-page";
-import { Spinner } from "@/components/ui/spinner";
 import {
 	getAccountSuspendedServerSnapshot,
 	getAccountSuspendedSnapshot,
@@ -35,23 +34,10 @@ export function AccountSuspensionBoundary({ children }: { children: React.ReactN
 		},
 	);
 
-	if (!hydrated || !isLoaded || !isSignedIn || (accessCheckEnabled && access.isPending)) {
-		return <AccountAccessPending />;
-	}
 	if (suspended || isAccountSuspendedError(access.error)) {
 		return <SuspendedAccountState />;
 	}
 	return children;
-}
-
-function AccountAccessPending() {
-	return (
-		<main className="flex min-h-dvh items-center justify-center bg-background" aria-busy="true">
-			<div className="flex size-12 items-center justify-center">
-				<Spinner className="size-5 text-muted-foreground" aria-label="Checking account access" />
-			</div>
-		</main>
-	);
 }
 
 function SuspendedAccountState() {


### PR DESCRIPTION
## Summary
- render protected dashboard content immediately instead of showing a full-screen account-access spinner
- keep the existing `/v1/auth/me` suspension probe running in the background
- preserve global `account_suspended` response handling and the suspended-account page

## Verification
- `scripts/test.sh web src/lib/account-suspension.test.ts src/components/account-suspended-page.test.tsx`
- focused Biome check for `account-suspension-boundary.tsx`