### PR TITLE
Refine compute trial pricing presentation

### DIFF
--- a/apps/web/src/hosted/billing/components/stripe-checkout-dialog.tsx
+++ b/apps/web/src/hosted/billing/components/stripe-checkout-dialog.tsx
@@ -13,7 +13,6 @@ import type {
 import { AlertCircle, CreditCard, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -78,13 +77,12 @@ function CheckoutSummaryPanel({ summary }: { summary: StripeCheckoutSummary | nu
 							<p className="text-xs text-muted-foreground">{summary.detail}</p>
 						</div>
 						<div className="text-left sm:text-right">
-							<div className="flex flex-wrap items-center gap-1.5 sm:justify-end">
-								<p className="font-mono text-base tabular-nums">{summary.priceLabel}</p>
-								{trial ? <Badge variant="secondary">{trial.badge}</Badge> : null}
-							</div>
-							<p className="text-xs text-muted-foreground tabular-nums">
-								{trial?.afterTrial ?? summary.termLabel}
+							<p className="text-sm font-medium tabular-nums sm:max-w-64">
+								{trial?.summary ?? summary.priceLabel}
 							</p>
+							{trial ? null : (
+								<p className="text-xs text-muted-foreground">{summary.termLabel}</p>
+							)}
 						</div>
 					</div>
 				</div>

--- a/apps/web/src/hosted/billing/deploy/deploy-price-presentation.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-price-presentation.test.ts
@@ -28,13 +28,11 @@ describe("computePricePresentation", () => {
 			primary: "$20.00/mo",
 			secondary: "Billed monthly",
 			savings: null,
-			trial: { badge: "7 days free", afterTrial: "Then $20.00/mo" },
 		});
 		expect(computePricePresentation(annual, [monthly, annual])).toEqual({
 			primary: "$200.00/yr",
 			secondary: "$16.66/mo",
 			savings: "save $40.00",
-			trial: { badge: "7 days free", afterTrial: "Then $200.00/yr" },
 		});
 	});
 
@@ -43,7 +41,6 @@ describe("computePricePresentation", () => {
 			primary: "$200.00/yr",
 			secondary: "$16.66/mo",
 			savings: null,
-			trial: { badge: "7 days free", afterTrial: "Then $200.00/yr" },
 		});
 	});
 });
@@ -51,8 +48,8 @@ describe("computePricePresentation", () => {
 describe("CTA-adjacent amount presentation", () => {
 	test("uses only a positive Stripe trial period", () => {
 		expect(cardTrialPricePresentation("$20.00/mo", 1)).toEqual({
-			badge: "1 day free",
-			afterTrial: "Then $20.00/mo",
+			label: "1-day free trial",
+			summary: "1-day free trial, then $20.00/mo",
 		});
 		expect(cardTrialPricePresentation("$20.00/mo", null)).toBeNull();
 		expect(cardTrialPricePresentation("$20.00/mo", 0)).toBeNull();
@@ -60,20 +57,17 @@ describe("CTA-adjacent amount presentation", () => {
 
 	test("uses term price for card checkout and authoritative debit for Wallet", () => {
 		expect(cardDeployAmountPresentation(monthly)).toEqual({
-			amount: "$20.00/mo",
-			badge: "7 days free",
-			caption: "Then $20.00/mo",
+			amount: "7-day free trial, then $20.00/mo",
+			caption: null,
 			detail: null,
 		});
 		expect(cardDeployAmountPresentation(annual)).toEqual({
-			amount: "$200.00/yr",
-			badge: "7 days free",
-			caption: "Then $200.00/yr · $16.66/mo",
+			amount: "7-day free trial, then $200.00/yr",
+			caption: null,
 			detail: null,
 		});
 		expect(cardDeployAmountPresentation({ ...monthly, card_trial_period_days: null })).toEqual({
 			amount: "$20.00/mo",
-			badge: null,
 			caption: "Billed monthly",
 			detail: null,
 		});
@@ -89,7 +83,6 @@ describe("CTA-adjacent amount presentation", () => {
 			}),
 		).toEqual({
 			amount: "Debit today: $100.00",
-			badge: null,
 			caption: "From Wallet · renews yearly",
 			detail: null,
 		});
@@ -102,14 +95,14 @@ describe("CTA-adjacent amount presentation", () => {
 				state: "loading",
 				walletDebit: null,
 			}),
-		).toEqual({ amount: "Debit today: —", badge: null, caption: "Getting quote…", detail: null });
+		).toEqual({ amount: "Debit today: —", caption: "Getting quote…", detail: null });
 		expect(
 			walletDeployAmountPresentation({
 				billingTermMonths: 1,
 				state: "error",
 				walletDebit: null,
 			}),
-		).toEqual({ amount: "Quote unavailable", badge: null, caption: null, detail: null });
+		).toEqual({ amount: "Quote unavailable", caption: null, detail: null });
 		expect(
 			walletDeployAmountPresentation({
 				billingTermMonths: 1,
@@ -122,7 +115,6 @@ describe("CTA-adjacent amount presentation", () => {
 			}),
 		).toEqual({
 			amount: "Debit today: $20.00",
-			badge: null,
 			caption: "From Wallet · renews monthly",
 			detail: "Available $12.50 · short $7.50",
 		});

--- a/apps/web/src/hosted/billing/deploy/deploy-price-presentation.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-price-presentation.ts
@@ -12,23 +12,18 @@ export type ComputePricePresentation = {
 	primary: string;
 	secondary: string;
 	savings: string | null;
-	trial: CardTrialPricePresentation | null;
 };
 
 export type DeployAmountPresentation = {
 	amount: string;
-	badge: string | null;
 	caption: string | null;
 	detail: string | null;
 };
 
 export type CardTrialPricePresentation = {
-	badge: string;
-	afterTrial: string;
+	label: string;
+	summary: string;
 };
-
-export const COMPUTE_CARD_TRIAL_ELIGIBILITY =
-	"For eligible accounts on their first Basic or Performance card subscription. One trial per account.";
 
 export function cardTrialPricePresentation(
 	recurringPrice: string,
@@ -37,9 +32,10 @@ export function cardTrialPricePresentation(
 	if (typeof trialDays !== "number" || !Number.isInteger(trialDays) || trialDays < 1) {
 		return null;
 	}
+	const label = `${trialDays}-day free trial`;
 	return {
-		badge: `${trialDays} ${trialDays === 1 ? "day" : "days"} free`,
-		afterTrial: `Then ${recurringPrice}`,
+		label,
+		summary: `${label}, then ${recurringPrice}`,
 	};
 }
 
@@ -52,12 +48,10 @@ export function computePricePresentation(
 	offers: readonly BillingOffer[],
 ): ComputePricePresentation {
 	if (offer.billing_term_months === 1) {
-		const primary = monthlyPrice(offer);
 		return {
-			primary,
+			primary: monthlyPrice(offer),
 			secondary: "Billed monthly",
 			savings: null,
-			trial: cardTrialPricePresentation(primary, offer.card_trial_period_days),
 		};
 	}
 
@@ -72,42 +66,36 @@ export function computePricePresentation(
 		comparisonIsCheaper && undiscountedTermPrice !== null
 			? undiscountedTermPrice - offer.price_cents
 			: 0;
-	const primary = `${formatCents(offer.price_cents)}${billingTermSuffix(offer.billing_term_months)}`;
 	return {
-		primary,
+		primary: `${formatCents(offer.price_cents)}${billingTermSuffix(offer.billing_term_months)}`,
 		secondary: monthlyPrice(offer),
 		savings: savingsCents > 0 ? `save ${formatCents(savingsCents)}` : null,
-		trial: cardTrialPricePresentation(primary, offer.card_trial_period_days),
 	};
 }
 
 export function cardDeployAmountPresentation(offer: BillingOffer): DeployAmountPresentation {
 	const price = `${formatCents(offer.price_cents)}${billingTermSuffix(offer.billing_term_months)}`;
 	const trial = cardTrialPricePresentation(price, offer.card_trial_period_days);
+	if (trial) {
+		return { amount: trial.summary, caption: null, detail: null };
+	}
 	if (offer.billing_term_months === 1) {
 		return {
 			amount: price,
-			badge: trial?.badge ?? null,
-			caption: trial?.afterTrial ?? "Billed monthly",
+			caption: "Billed monthly",
 			detail: null,
 		};
 	}
 	if (offer.billing_term_months === 12) {
 		return {
 			amount: price,
-			badge: trial?.badge ?? null,
-			caption: trial
-				? `${trial.afterTrial} · ${monthlyPrice(offer)}`
-				: `${monthlyPrice(offer)}, billed annually`,
+			caption: `${monthlyPrice(offer)}, billed annually`,
 			detail: null,
 		};
 	}
 	return {
 		amount: price,
-		badge: trial?.badge ?? null,
-		caption: trial
-			? `${trial.afterTrial} · ${monthlyPrice(offer)}`
-			: `${monthlyPrice(offer)}, billed ${billingTermLabel(offer.billing_term_months).toLowerCase()}`,
+		caption: `${monthlyPrice(offer)}, billed ${billingTermLabel(offer.billing_term_months).toLowerCase()}`,
 		detail: null,
 	};
 }
@@ -122,16 +110,15 @@ export function walletDeployAmountPresentation({
 	walletDebit: WalletDebitSummary | null;
 }): DeployAmountPresentation {
 	if (state === "error") {
-		return { amount: "Quote unavailable", badge: null, caption: null, detail: null };
+		return { amount: "Quote unavailable", caption: null, detail: null };
 	}
 	if (state === "loading" || !walletDebit) {
-		return { amount: "Debit today: —", badge: null, caption: "Getting quote…", detail: null };
+		return { amount: "Debit today: —", caption: "Getting quote…", detail: null };
 	}
 
 	const shortfallUsd = walletDebitShortfallUsd(walletDebit);
 	return {
 		amount: `Debit today: ${formatUsdExact(walletDebit.debitAmountUsd)}`,
-		badge: null,
 		caption: `From Wallet · renews ${billingTermMonths === 12 ? "yearly" : "monthly"}`,
 		detail:
 			shortfallUsd === null

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -80,9 +80,9 @@ import {
 	deployWizardDraftIsDirty,
 } from "@/hosted/billing/deploy/deploy-dirty-state";
 import {
-	COMPUTE_CARD_TRIAL_ELIGIBILITY,
 	type ComputePricePresentation,
 	cardDeployAmountPresentation,
+	cardTrialPricePresentation,
 	computePricePresentation,
 	type DeployAmountPresentation,
 	walletDeployAmountPresentation,
@@ -239,28 +239,21 @@ function computeCheckoutSummary({
 }
 
 function ComputePriceBlock({
-	billingTermMonths,
 	presentation,
-	showTrial,
 	testId,
 }: {
-	billingTermMonths: number;
 	presentation: ComputePricePresentation;
-	showTrial: boolean;
 	testId: string;
 }) {
-	const trial = showTrial ? presentation.trial : null;
 	return (
 		<div data-testid={testId} className="flex min-w-0 flex-col items-end text-right tabular-nums">
-			<div className="flex flex-wrap items-center justify-end gap-1.5 leading-5">
+			<div className="flex items-baseline justify-end leading-5">
 				<span className="whitespace-nowrap text-sm font-semibold text-foreground">
 					{presentation.primary}
 				</span>
-				{trial ? <Badge variant="secondary">{trial.badge}</Badge> : null}
 			</div>
 			<div className="text-xs leading-4 font-normal text-muted-foreground">
-				{trial?.afterTrial ?? presentation.secondary}
-				{trial && billingTermMonths > 1 ? <> · {presentation.secondary}</> : null}
+				{presentation.secondary}
 				{presentation.savings ? (
 					<>
 						{" "}
@@ -516,10 +509,12 @@ export function DeployWizard() {
 						tierLabel: "Basic",
 					}
 				: null;
-	const selectedCardTrial =
-		compute === "performance"
-			? (perfPricePresentation?.trial ?? null)
-			: (basicPricePresentation?.trial ?? null);
+	const selectedCardTrial = paidSelection
+		? cardTrialPricePresentation(
+				`${formatCents(paidSelection.offer.price_cents)}${billingTermSuffix(paidSelection.billingTermMonths)}`,
+				paidSelection.offer.card_trial_period_days,
+			)
+		: null;
 	const walletBillingTerm = supportedBillingTerm(paidSelection?.billingTermMonths ?? 1);
 	const walletDisabledReason = walletBillingTerm
 		? null
@@ -1035,9 +1030,9 @@ export function DeployWizard() {
 	const runtimeSummary = runtimeDisplayName(runtime);
 	const deployAmount: DeployAmountPresentation | null =
 		subscriptionSource?.mode === "included"
-			? { amount: "Free", badge: null, caption: null, detail: null }
+			? { amount: "Free", caption: null, detail: null }
 			: selectedReusableSubscription
-				? { amount: "$0 due now", badge: null, caption: null, detail: null }
+				? { amount: "$0 due now", caption: null, detail: null }
 				: paidSelection
 					? paymentMethod === "wallet"
 						? walletDeployAmountPresentation({
@@ -1329,10 +1324,8 @@ export function DeployWizard() {
 										details={
 											basicPricePresentation ? (
 												<ComputePriceBlock
-													billingTermMonths={basicBillingTermMonths}
 													testId="basic-compute-price"
 													presentation={basicPricePresentation}
-													showTrial={paymentMethod === "card"}
 												/>
 											) : null
 										}
@@ -1369,10 +1362,8 @@ export function DeployWizard() {
 										details={
 											perfPricePresentation ? (
 												<ComputePriceBlock
-													billingTermMonths={perfBillingTermMonths}
 													testId="performance-compute-price"
 													presentation={perfPricePresentation}
-													showTrial={paymentMethod === "card"}
 												/>
 											) : null
 										}
@@ -1394,11 +1385,7 @@ export function DeployWizard() {
 													</IconChip>
 												}
 												title="Card subscription"
-												description={
-													selectedCardTrial
-														? `Card required. ${COMPUTE_CARD_TRIAL_ELIGIBILITY}`
-														: "Card required."
-												}
+												description={selectedCardTrial?.summary}
 											/>
 											<EntityChoiceCard
 												selected={paymentMethod === "wallet"}
@@ -1557,12 +1544,9 @@ export function DeployWizard() {
 									aria-live="polite"
 								>
 									<div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 @2xl/main:justify-end">
-										<span className="whitespace-nowrap font-semibold tabular-nums text-foreground">
+										<span className="font-semibold tabular-nums text-foreground">
 											{deployAmount.amount}
 										</span>
-										{deployAmount.badge ? (
-											<Badge variant="secondary">{deployAmount.badge}</Badge>
-										) : null}
 										{paymentMethod === "wallet" && walletQuoteState === "error" ? (
 											<Button
 												type="button"

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -4,14 +4,13 @@ import { Check, Cpu, Zap } from "lucide-react";
 import { useMemo } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { SettingsSection } from "@/components/settings-section";
-import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
 import type { BillingOffer, Plan } from "@/hosted/billing/contracts";
 import {
-	COMPUTE_CARD_TRIAL_ELIGIBILITY,
 	type ComputePricePresentation,
+	cardTrialPricePresentation,
 	computePricePresentation,
 } from "@/hosted/billing/deploy/deploy-price-presentation";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
@@ -47,19 +46,21 @@ function PlanPrice({
 	offer: BillingOffer;
 	presentation: ComputePricePresentation;
 }) {
-	const { trial } = presentation;
+	const trial = cardTrialPricePresentation(
+		presentation.primary,
+		offer.card_trial_period_days,
+	);
 	return (
 		<>
-			<div className="flex flex-wrap items-center gap-2">
-				<p className="text-3xl font-semibold tracking-normal tabular-nums">
-					{presentation.primary}
-				</p>
-				{trial ? <Badge variant="secondary">{trial.badge}</Badge> : null}
-			</div>
-			<p className="text-xs text-muted-foreground tabular-nums">
-				{trial?.afterTrial ?? presentation.secondary}
-				{trial && offer.billing_term_months > 1 ? <> · {presentation.secondary}</> : null}
+			<p className="text-3xl font-semibold tracking-normal tabular-nums">
+				{presentation.primary}
 			</p>
+			<p className="text-xs text-muted-foreground tabular-nums">
+				{trial?.label ?? presentation.secondary}
+			</p>
+			{trial && offer.billing_term_months > 1 ? (
+				<p className="text-xs text-muted-foreground tabular-nums">{presentation.secondary}</p>
+			) : null}
 		</>
 	);
 }
@@ -127,7 +128,6 @@ export function PlanComparison({
 	const performancePrice = performanceOffer
 		? computePricePresentation(performanceOffer, performanceOffers)
 		: null;
-	const hasCardTrial = Boolean(basicPrice?.trial || performancePrice?.trial);
 	const sharedPricingUnavailable =
 		basic !== undefined && performance !== undefined && !selectedTerm;
 
@@ -152,9 +152,7 @@ export function PlanComparison({
 			description={
 				sharedPricingUnavailable
 					? "A shared Basic and Performance billing term is not currently available."
-					: hasCardTrial
-						? COMPUTE_CARD_TRIAL_ELIGIBILITY
-						: "Compare hosted compute plans."
+					: "Compare hosted compute plans."
 			}
 		>
 			<div>

--- a/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
@@ -6,7 +6,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -33,7 +32,7 @@ import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
 import { WalletDebitEquation } from "@/hosted/billing/components/wallet-debit-equation";
 import type { ComputePlanSlug, Plan, SubscriptionSelection } from "@/hosted/billing/contracts";
 import {
-	COMPUTE_CARD_TRIAL_ELIGIBILITY,
+	cardTrialPricePresentation,
 	computePricePresentation,
 } from "@/hosted/billing/deploy/deploy-price-presentation";
 import {
@@ -148,7 +147,13 @@ export function SubscriptionCreateDialog({
 	const selectedOffer =
 		offers.find((offer) => offer.billing_term_months === billingTermMonths) ?? null;
 	const selectedPrice = selectedOffer ? computePricePresentation(selectedOffer, offers) : null;
-	const cardTrial = fundingSource === "stripe" ? (selectedPrice?.trial ?? null) : null;
+	const cardTrial =
+		fundingSource === "stripe" && selectedOffer && selectedPrice
+			? cardTrialPricePresentation(
+					selectedPrice.primary,
+					selectedOffer.card_trial_period_days,
+				)
+			: null;
 	const supportedTerm = supportedBillingTerm(billingTermMonths);
 	const newSubscriptionSelection: SubscriptionCreateSelection | null =
 		supportedTerm && selectedOffer
@@ -446,19 +451,15 @@ export function SubscriptionCreateDialog({
 										<span>
 											{computeTierLabel(planSlug)} · {billingTermLabel(billingTermMonths)}
 										</span>
-										<div className="flex flex-wrap items-center gap-2">
-											<span className="text-base font-semibold text-foreground tabular-nums">
-												{selectedPrice.primary}
-											</span>
-											{cardTrial ? <Badge variant="secondary">{cardTrial.badge}</Badge> : null}
-										</div>
+										<span className="text-base font-semibold text-foreground tabular-nums">
+											{selectedPrice.primary}
+										</span>
 										<p className="text-xs tabular-nums">
-											{cardTrial?.afterTrial ?? selectedPrice.secondary}
+											{cardTrial?.label ?? selectedPrice.secondary}
 											{cardTrial && billingTermMonths > 1 ? (
 												<> · {selectedPrice.secondary}</>
 											) : null}
 										</p>
-										{cardTrial ? <p className="text-xs">{COMPUTE_CARD_TRIAL_ELIGIBILITY}</p> : null}
 									</div>
 								) : (
 									<Alert variant="destructive">


### PR DESCRIPTION
## Summary
- remove trial badges from Basic and Performance deployment choices
- show a single `7-day free trial, then $X` message on Card subscription and beside the deploy action
- deduplicate trial copy in Checkout and subscription creation surfaces

## Verification
- `bash scripts/test.sh web`
- `git diff --check`

## Related
- Clawdi-AI/clawdi-hosted#2022
