### PR TITLE
Refine deploy trial presentation

### DIFF
--- a/apps/web/src/hosted/billing/components/stripe-checkout-dialog.tsx
+++ b/apps/web/src/hosted/billing/components/stripe-checkout-dialog.tsx
@@ -80,9 +80,7 @@ function CheckoutSummaryPanel({ summary }: { summary: StripeCheckoutSummary | nu
 							<p className="text-sm font-medium tabular-nums sm:max-w-64">
 								{trial?.summary ?? summary.priceLabel}
 							</p>
-							{trial ? null : (
-								<p className="text-xs text-muted-foreground">{summary.termLabel}</p>
-							)}
+							{trial ? null : <p className="text-xs text-muted-foreground">{summary.termLabel}</p>}
 						</div>
 					</div>
 				</div>

--- a/apps/web/src/hosted/billing/deploy/deploy-price-presentation.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-price-presentation.test.ts
@@ -57,13 +57,13 @@ describe("CTA-adjacent amount presentation", () => {
 
 	test("uses term price for card checkout and authoritative debit for Wallet", () => {
 		expect(cardDeployAmountPresentation(monthly)).toEqual({
-			amount: "7-day free trial, then $20.00/mo",
-			caption: null,
+			amount: "7-day free trial",
+			caption: "then $20.00/mo",
 			detail: null,
 		});
 		expect(cardDeployAmountPresentation(annual)).toEqual({
-			amount: "7-day free trial, then $200.00/yr",
-			caption: null,
+			amount: "7-day free trial",
+			caption: "then $200.00/yr",
 			detail: null,
 		});
 		expect(cardDeployAmountPresentation({ ...monthly, card_trial_period_days: null })).toEqual({

--- a/apps/web/src/hosted/billing/deploy/deploy-price-presentation.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-price-presentation.ts
@@ -77,7 +77,7 @@ export function cardDeployAmountPresentation(offer: BillingOffer): DeployAmountP
 	const price = `${formatCents(offer.price_cents)}${billingTermSuffix(offer.billing_term_months)}`;
 	const trial = cardTrialPricePresentation(price, offer.card_trial_period_days);
 	if (trial) {
-		return { amount: trial.summary, caption: null, detail: null };
+		return { amount: trial.label, caption: `then ${price}`, detail: null };
 	}
 	if (offer.billing_term_months === 1) {
 		return {

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -134,12 +134,33 @@ describe("deploy wizard responsive layout", () => {
 		expect(wizardSource).toContain("sticky bottom-0 z-10");
 		expect(wizardSource).toContain("@2xl/main:flex-row");
 		expect(wizardSource).toContain("@2xl/main:w-auto");
+		expect(wizardSource).toContain("@2xl/main:w-56 @2xl/main:items-end");
+		expect(wizardSource).toContain("@2xl/main:w-40 @2xl/main:items-end");
 		expect(wizardSource).not.toContain("sm:sticky sm:bottom-0");
 	});
 
 	test("keeps concise funding copy", () => {
 		expect(wizardSource).not.toContain("hidden @3xl/main:inline-flex");
+		expect(wizardSource).toContain(
+			'description="Recurring subscription via Stripe. Manage or cancel anytime."',
+		);
+		expect(wizardSource).toContain('<Badge variant="secondary">{selectedCardTrial.label}</Badge>');
 		expect(wizardSource).toContain("Paid upfront from your Wallet balance. Renews from Wallet.");
+	});
+
+	test("summarizes runtime, AI selection, and compute without personalization", () => {
+		const summarySource = wizardSource.slice(
+			wizardSource.indexOf("const summaryLine"),
+			wizardSource.indexOf("const plansLoadError"),
+		);
+		expect(summarySource.indexOf("runtimeSummary")).toBeLessThan(
+			summarySource.indexOf("aiSummary"),
+		);
+		expect(summarySource.indexOf("aiSummary")).toBeLessThan(
+			summarySource.indexOf("selectedComputeLabel"),
+		);
+		expect(summarySource).not.toContain("LANGUAGE_OPTIONS");
+		expect(summarySource).not.toContain("timezone");
 	});
 });
 

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -1064,13 +1064,7 @@ export function DeployWizard() {
 			: compute === "performance"
 				? "Performance"
 				: "Basic";
-	const summaryLine = [
-		`${selectedComputeLabel} compute`,
-		aiSummary,
-		runtimeSummary,
-		LANGUAGE_OPTIONS.find((l) => l.code === language)?.label ?? null,
-		timezone || null,
-	]
+	const summaryLine = [runtimeSummary, aiSummary, `${selectedComputeLabel} compute`]
 		.filter(Boolean)
 		.join(" · ");
 
@@ -1385,7 +1379,12 @@ export function DeployWizard() {
 													</IconChip>
 												}
 												title="Card subscription"
-												description={selectedCardTrial?.summary}
+												description="Recurring subscription via Stripe. Manage or cancel anytime."
+												badge={
+													selectedCardTrial ? (
+														<Badge variant="secondary">{selectedCardTrial.label}</Badge>
+													) : null
+												}
 											/>
 											<EntityChoiceCard
 												selected={paymentMethod === "wallet"}
@@ -1540,7 +1539,7 @@ export function DeployWizard() {
 							{deployAmount ? (
 								<div
 									data-testid="deploy-amount"
-									className="flex min-w-0 flex-col @2xl/main:items-end @2xl/main:text-right"
+									className="flex min-w-0 flex-col @2xl/main:w-56 @2xl/main:items-end @2xl/main:text-right"
 									aria-live="polite"
 								>
 									<div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 @2xl/main:justify-end">
@@ -1575,7 +1574,7 @@ export function DeployWizard() {
 									) : null}
 								</div>
 							) : null}
-							<div className="flex min-w-0 flex-col gap-1 @2xl/main:items-end">
+							<div className="flex min-w-0 flex-col gap-1 @2xl/main:w-40 @2xl/main:items-end">
 								<Button
 									type={
 										acceptedDeploymentHydrationFailed || walletTopUpAction ? "button" : "submit"
@@ -1596,7 +1595,7 @@ export function DeployWizard() {
 												? () => walletTopUp.show(walletShortfallUsd)
 												: undefined
 									}
-									className="w-full shrink-0 @2xl/main:w-auto"
+									className="w-full shrink-0"
 								>
 									{submitting ? (
 										<Spinner data-icon="inline-start" />

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -46,15 +46,10 @@ function PlanPrice({
 	offer: BillingOffer;
 	presentation: ComputePricePresentation;
 }) {
-	const trial = cardTrialPricePresentation(
-		presentation.primary,
-		offer.card_trial_period_days,
-	);
+	const trial = cardTrialPricePresentation(presentation.primary, offer.card_trial_period_days);
 	return (
 		<>
-			<p className="text-3xl font-semibold tracking-normal tabular-nums">
-				{presentation.primary}
-			</p>
+			<p className="text-3xl font-semibold tracking-normal tabular-nums">{presentation.primary}</p>
 			<p className="text-xs text-muted-foreground tabular-nums">
 				{trial?.label ?? presentation.secondary}
 			</p>

--- a/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
@@ -149,10 +149,7 @@ export function SubscriptionCreateDialog({
 	const selectedPrice = selectedOffer ? computePricePresentation(selectedOffer, offers) : null;
 	const cardTrial =
 		fundingSource === "stripe" && selectedOffer && selectedPrice
-			? cardTrialPricePresentation(
-					selectedPrice.primary,
-					selectedOffer.card_trial_period_days,
-				)
+			? cardTrialPricePresentation(selectedPrice.primary, selectedOffer.card_trial_period_days)
 			: null;
 	const supportedTerm = supportedBillingTerm(billingTermMonths);
 	const newSubscriptionSelection: SubscriptionCreateSelection | null =


### PR DESCRIPTION
## Summary
- show the card trial as a badge while preserving the stable subscription description
- split the trial and recurring amount into primary and secondary lines
- stabilize deploy amount/action widths and simplify the configuration summary

## Verification
- `bash scripts/test.sh web`