### PR TITLE
Align entity choice card indicators

### DIFF
--- a/apps/web/src/components/entity-card.test.tsx
+++ b/apps/web/src/components/entity-card.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { EntityChoiceCard } from "@/components/entity-card";
+
+function renderChoice(selected?: boolean) {
+	return renderToStaticMarkup(
+		<EntityChoiceCard
+			icon={<span>Icon</span>}
+			title="Choice"
+			badge={<span>Badge</span>}
+			selected={selected}
+		/>,
+	);
+}
+
+describe("EntityChoiceCard", () => {
+	test("keeps a centered trailing indicator slot for selectable cards", () => {
+		const selected = renderChoice(true);
+		const unselected = renderChoice(false);
+
+		for (const markup of [selected, unselected]) {
+			expect(markup).toContain('data-slot="entity-choice-indicator"');
+			expect(markup).toContain("self-center");
+		}
+		expect(selected).toContain("lucide-check");
+		expect(unselected).not.toContain("lucide-check");
+	});
+
+	test("does not reserve selection space for action cards", () => {
+		expect(renderChoice()).not.toContain('data-slot="entity-choice-indicator"');
+	});
+});

--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -611,7 +611,7 @@ export function EntityChoiceCard({
 	details?: ReactNode;
 	/** Keep dense, comparable details beside the main copy when space allows. */
 	detailsPlacement?: EntityChoiceDetailsPlacement;
-	/** Trailing badge in the title row (e.g. "Default", an auth chip). */
+	/** Trailing badge in the title row (e.g. "Recommended", an auth chip). */
 	badge?: ReactNode;
 	selected?: boolean;
 	onClick?: () => void;
@@ -673,18 +673,14 @@ export function EntityChoiceCard({
 					</div>
 				) : null}
 			</div>
-			{selected ? (
-				<Check
-					className={cn(
-						"mt-0.5 size-4 shrink-0 text-primary",
-						detailsPlacement === "responsive" && "hidden @md/choice:block",
-					)}
+			{selected !== undefined ? (
+				<span
+					data-slot="entity-choice-indicator"
+					className="flex size-4 shrink-0 self-center items-center justify-center"
 					aria-hidden
-				/>
-			) : detailsPlacement === "trailing" ? (
-				<span className="size-4 shrink-0" aria-hidden />
-			) : detailsPlacement === "responsive" ? (
-				<span className="hidden size-4 shrink-0 @md/choice:block" aria-hidden />
+				>
+					{selected ? <Check className="size-4 text-primary" /> : null}
+				</span>
 			) : null}
 		</>
 	);
@@ -732,7 +728,6 @@ export function EntityAddCard({
 }) {
 	return (
 		<EntityChoiceCard
-			selected={false}
 			onClick={onClick}
 			href={href}
 			icon={

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -182,7 +182,8 @@ describe("deploy wizard product copy and flow", () => {
 	});
 
 	test("makes the recommended agent software choice answerable", () => {
-		expect(wizardSource).toContain('<Badge variant="secondary">Recommended</Badge>');
+		expect(wizardSource.match(/<Badge variant="secondary">Recommended<\/Badge>/g)).toHaveLength(2);
+		expect(wizardSource).not.toContain('<Badge variant="secondary">Default</Badge>');
 		expect(wizardSource).not.toContain("Agent software can’t be changed later");
 		expect(wizardSource).not.toContain("To switch after creation");
 		expect(runtimesSource).toContain("Chat with and manage your agent in the Hermes Dashboard.");

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -1166,7 +1166,7 @@ export function DeployWizard() {
 								icon={<ProviderIcon provider={MANAGED_PROVIDER_ID} />}
 								title={MANAGED_PROVIDER_LABEL}
 								description="No setup required. Usage draws from your Wallet."
-								badge={<Badge variant="secondary">Default</Badge>}
+								badge={<Badge variant="secondary">Recommended</Badge>}
 							/>
 							<EntityChoiceCard
 								selected={aiAccessMode === "unmanaged"}


### PR DESCRIPTION
## Summary
- reserve a stable trailing indicator slot for selectable entity cards
- vertically center the selection check across card variants
- label Clawdi AI as Recommended in the deploy wizard

## Verification
- focused EntityChoiceCard and deploy wizard tests: 29 passed
- web typecheck passed
- OSS production build passed
- Biome passed
- full local web rerun was stopped after the isolated container stalled in `bun install`; GitHub CI will run the clean full suite