### PR TITLE
Unify hosted selection cards

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -2392,11 +2392,6 @@ function AiProviderTab({
 					icon={<ProviderIcon provider={MANAGED_PROVIDER_ID} />}
 					title={MANAGED_PROVIDER_LABEL}
 					description="No setup required. Usage draws from your Wallet."
-					badge={
-						bindingMode === "configured" && primaryProviderChoice === MANAGED_AI_CHOICE ? (
-							<Badge variant="secondary">Selected</Badge>
-						) : null
-					}
 				/>
 				<EntityChoiceCard
 					onClick={() => setBindingMode("unmanaged")}
@@ -2408,7 +2403,6 @@ function AiProviderTab({
 					}
 					title={authCardLabel("unmanaged")}
 					description="Configure model access inside the agent."
-					badge={bindingMode === "unmanaged" ? <Badge variant="secondary">Current</Badge> : null}
 				/>
 				{providers.isLoading ? <EntityCardSkeleton titleBadge trailingBadge /> : null}
 				{shouldBlockQueryError(providers.error, providers.data) ? (
@@ -2428,7 +2422,6 @@ function AiProviderTab({
 						icon={<ProviderIcon provider={unresolvedProviderRef(primaryProviderChoice)} />}
 						title={`Using ${providerDisplayLabel(unresolvedProviderRef(primaryProviderChoice), list)}`}
 						description={`Saved connection details couldn't be loaded. Choose ${MANAGED_PROVIDER_LABEL} to replace it.`}
-						badge={<Badge variant="secondary">In use</Badge>}
 					/>
 				) : null}
 				{list.map((p) => {
@@ -2445,13 +2438,7 @@ function AiProviderTab({
 							title={providerDisplayLabel(p)}
 							description={issue?.message ?? providerCatalogDescription(p)}
 							badge={
-								selected ? (
-									<Badge variant="secondary">Selected</Badge>
-								) : issue ? (
-									<Badge variant="secondary">Unavailable</Badge>
-								) : (
-									<AuthBadge auth={p.auth} />
-								)
+								issue ? <Badge variant="secondary">Unavailable</Badge> : <AuthBadge auth={p.auth} />
 							}
 						/>
 					);

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -270,9 +270,12 @@ describe("managed model picker", () => {
 		expect(modelBindingPickerSource).toContain("isManaged && hasCatalogModels");
 		expect(wizardSource).not.toContain("compactManagedModelChoices");
 		expect(agentDetailSource).not.toContain("compactManagedModelChoices");
-		expect(modelBindingPickerSource).toContain("compactManagedItems.featured.map((item, index) =>");
+		expect(modelBindingPickerSource).toContain("compactManagedItems.featured.map((item) =>");
 		expect(modelBindingPickerSource).toContain("compactManagedItems.overflow.map((item) =>");
-		expect(modelBindingPickerSource).toContain("<RadioGroup");
+		expect(modelBindingPickerSource).toContain("<EntityChoiceCard");
+		expect(modelBindingPickerSource).not.toContain("entityChoiceCardClass");
+		expect(modelBindingPickerSource).not.toContain("<RadioGroup");
+		expect(modelBindingPickerSource).not.toContain("<Check");
 		expect(modelBindingPickerSource).toContain('data-testid="managed-model-overflow"');
 		expect(modelBindingPickerSource).toContain('placeholder="More models"');
 		expect(modelBindingPickerSource).toContain("aria-labelledby=");
@@ -288,9 +291,7 @@ describe("managed model picker", () => {
 		expect(modelBindingPickerSource).not.toContain("Primary model");
 		expect(modelBindingPickerSource).not.toContain("Catalog model");
 		expect(modelBindingPickerSource).toContain('className="flex w-full min-w-0 flex-col gap-3"');
-		expect(modelBindingPickerSource).toContain(
-			"grid-cols-1 gap-2 @md/main:grid-cols-2 @4xl/main:grid-cols-4",
-		);
+		expect(modelBindingPickerSource).toContain("@md/main:grid-cols-2 @4xl/main:grid-cols-4");
 		expect(modelBindingPickerSource).not.toContain("max-w-2xl");
 		expect(modelBindingPickerSource).not.toContain("bg-muted/20");
 		expect(modelBindingPickerSource).not.toContain("Primary provider");
@@ -341,6 +342,10 @@ describe("deploy provider choice", () => {
 		expect(wizardSource).toContain("selectAiProviderChoice(provider.provider_id)");
 		expect(wizardSource).not.toContain("showProviderSelect");
 		expect(wizardSource).not.toContain("onPrimaryProviderChange");
+		expect(wizardSource).not.toContain(">Selected</Badge>");
+		expect(agentDetailSource).not.toContain(">Selected</Badge>");
+		expect(agentDetailSource).not.toContain(">Current</Badge>");
+		expect(agentDetailSource).not.toContain(">In use</Badge>");
 	});
 });
 

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -1178,9 +1178,6 @@ export function DeployWizard() {
 								}
 								title={authCardLabel("unmanaged")}
 								description="Deploy first, then configure model access inside the Agent."
-								badge={
-									aiAccessMode === "unmanaged" ? <Badge variant="secondary">Selected</Badge> : null
-								}
 							/>
 							{aiProviders.isLoading ? (
 								<Skeleton className="h-[74px] w-full rounded-lg" />
@@ -1212,8 +1209,6 @@ export function DeployWizard() {
 										badge={
 											issue ? (
 												<Badge variant="secondary">Unavailable</Badge>
-											) : primaryProviderChoice === provider.provider_id ? (
-												<Badge variant="secondary">Selected</Badge>
 											) : (
 												<AuthBadge auth={provider.auth} />
 											)

--- a/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import { Check } from "lucide-react";
 import type { ApiErrorNormalizer } from "@/components/api-error-panel";
 import { ApiErrorPanel } from "@/components/api-error-panel";
-import { entityChoiceCardClass } from "@/components/entity-card";
+import { EntityChoiceCard } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
 	Select,
 	SelectContent,
@@ -24,7 +22,6 @@ import {
 	modelPickerItems,
 } from "@/hosted/v2/ai-providers/model-binding";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
-import { cn } from "@/lib/utils";
 
 export function ModelBindingPicker({
 	idPrefix,
@@ -86,66 +83,25 @@ export function ModelBindingPicker({
 						data-testid="managed-model-controls"
 					>
 						{compactManagedItems.featured.length > 0 ? (
-							<RadioGroup
+							<fieldset
 								id={catalogInputId}
-								value={primaryModel}
-								onValueChange={(value) => {
-									if (typeof value === "string") onPrimaryModelChange(value);
-								}}
-								className="grid w-full min-w-0 grid-cols-1 gap-2 @md/main:grid-cols-2 @4xl/main:grid-cols-4"
+								className="m-0 grid w-full min-w-0 grid-cols-1 gap-2 border-0 p-0 @md/main:grid-cols-2 @4xl/main:grid-cols-4"
 								aria-labelledby={`${catalogInputId}-label`}
 								data-testid="managed-model-choices"
 							>
-								{compactManagedItems.featured.map((item, index) => {
-									const radioId = `${catalogInputId}-featured-${index}`;
-									const titleId = `${catalogInputId}-featured-${index}-title`;
-									const descriptionId = `${catalogInputId}-featured-${index}-description`;
-									const selected = primaryModel === item.value;
-									return (
-										<Label
-											key={item.value}
-											htmlFor={radioId}
-											className={entityChoiceCardClass({
-												selected,
-												interactive: true,
-												className: "cursor-pointer gap-2 px-2.5 py-2",
-											})}
-										>
-											<RadioGroupItem
-												id={radioId}
-												value={item.value}
-												aria-labelledby={titleId}
-												aria-describedby={item.description ? descriptionId : undefined}
-												className="sr-only !absolute !size-px !border-0 !p-0"
-											/>
-											<EntityIcon kind="provider" id={item.iconId} size="sm" />
-											<span className="flex min-w-0 flex-1 flex-col gap-0.5 leading-tight">
-												<span
-													id={titleId}
-													className="min-w-0 break-words text-sm font-medium leading-snug"
-												>
-													{item.label}
-												</span>
-												{item.description ? (
-													<span
-														id={descriptionId}
-														className="line-clamp-2 min-w-0 break-words text-xs leading-snug font-normal text-muted-foreground"
-													>
-														{item.description}
-													</span>
-												) : null}
-											</span>
-											<Check
-												aria-hidden
-												className={cn(
-													"size-4 shrink-0 text-primary transition-opacity",
-													selected ? "opacity-100" : "opacity-0",
-												)}
-											/>
-										</Label>
-									);
-								})}
-							</RadioGroup>
+								{compactManagedItems.featured.map((item) => (
+									<EntityChoiceCard
+										key={item.value}
+										selected={primaryModel === item.value}
+										onClick={() => onPrimaryModelChange(item.value)}
+										icon={<EntityIcon kind="provider" id={item.iconId} size="sm" />}
+										title={item.label}
+										description={item.description}
+										variant="compact"
+										className="px-2.5 py-2"
+									/>
+								))}
+							</fieldset>
 						) : null}
 						{compactManagedItems.overflow.length > 0 ? (
 							<Select


### PR DESCRIPTION
## Summary
- use the shared EntityChoiceCard for managed model choices
- remove standalone Selected, Current, and In use badges
- preserve semantic Recommended, Unavailable, and auth badges

## Verification
- `bash scripts/test.sh web src/hosted/billing/deploy/deploy-wizard.test.ts`