### PR TITLE
feat(agent): fence connected machine writes

### DIFF
--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -77,6 +77,7 @@ function env(overrides: Partial<Env> = {}): Env {
 		id: "11111111-1111-4111-8111-111111111111",
 		name: "hosted-openclaw",
 		default_name: "hosted-openclaw",
+		machine_id: "hosted-openclaw-machine",
 		machine_name: "hosted-openclaw",
 		agent_type: "openclaw",
 		agent_version: null,

--- a/apps/web/src/hosted/use-unified-agent-list.test.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.test.ts
@@ -51,6 +51,7 @@ function env(id: string, name: string): Env {
 		id,
 		name,
 		default_name: name,
+		machine_id: `${id}-machine`,
 		machine_name: name,
 		agent_type: "openclaw",
 		agent_version: null,

--- a/apps/web/src/lib/agent-queries.test.ts
+++ b/apps/web/src/lib/agent-queries.test.ts
@@ -13,6 +13,7 @@ function agent(id: string, displayName: string): Agent {
 	return {
 		id,
 		name: displayName,
+		machine_id: `${id}-machine`,
 		machine_name: `${id}.local`,
 		display_name: displayName,
 		sort_order: 0,

--- a/backend/alembic/versions/c8f2a6d1e4b9_connected_agent_machine_fence.py
+++ b/backend/alembic/versions/c8f2a6d1e4b9_connected_agent_machine_fence.py
@@ -1,0 +1,32 @@
+"""Add opt-in Connected Agent machine fencing.
+
+Revision ID: c8f2a6d1e4b9
+Revises: b6d1e4c9f2a7
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c8f2a6d1e4b9"
+down_revision: str | Sequence[str] | None = "b6d1e4c9f2a7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_environments",
+        sa.Column(
+            "machine_fence_required",
+            sa.Boolean(),
+            server_default=sa.false(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_environments", "machine_fence_required")

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -113,6 +113,12 @@ class AgentEnvironment(Base, TimestampMixin):
     # OAuth CLI or unbound unmanaged API key. Historical ambiguous rows remain
     # NULL; Admin, managed, and environment-bound registration never qualify.
     connected_agent_registered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    # False preserves pre-fence Connected installations. New setup/rebind
+    # enables this atomically with machine_id, after which every Agent write
+    # must prove the active machine binding.
+    machine_fence_required: Mapped[bool] = mapped_column(
+        Boolean, server_default="false", nullable=False
+    )
     # Connected Agent-only compatibility observation retained for deployed CLI
     # clients. Desired-state reads and writes do not depend on these fields.
     project_skill_reconcile_version: Mapped[int | None] = mapped_column(Integer)

--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -31,6 +31,11 @@ from app.models.session import AgentEnvironment
 from app.models.skill import SKILL_AUTHORITY_CLOUD, Skill
 from app.schemas.runtime import ProjectSkillCapabilityReport
 from app.schemas.session import AgentProjectSkillDesiredItem, AgentProjectSkillDesiredResponse
+from app.services.connected_agent_fence import (
+    ConnectedAgentFenceHeaders,
+    connected_agent_fence_headers,
+    require_connected_agent_fence,
+)
 from app.services.file_store import get_file_store
 from app.services.http_cache import if_none_match_contains
 from app.services.project_runtime_skills import (
@@ -331,11 +336,19 @@ async def report_project_skill_capability(
     body: ProjectSkillCapabilityReport,
     requested_environment_id: UUID | None = Query(default=None, alias="environment_id"),
     auth: AuthContext = Depends(require_cli_auth),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> None:
     """Renew the short-lived Connected Project Skill reconciliation lease."""
     require_auth_scopes(auth, "skills:write")
     agent_id = _authorized_environment_id(auth, requested_environment_id)
+    await require_connected_agent_fence(
+        db,
+        auth=auth,
+        agent_ids={agent_id},
+        headers=fence_headers,
+        lock=True,
+    )
     agent = await _connected_agent(db, auth=auth, agent_id=agent_id)
     # Compatibility observation only; desired-state reads and writes never
     # consult these fields.

--- a/backend/app/routes/session_events.py
+++ b/backend/app/routes/session_events.py
@@ -28,6 +28,11 @@ from app.schemas.session_events import (
     SessionEventsResponse,
     SessionUploadCapabilitiesResponse,
 )
+from app.services.connected_agent_fence import (
+    ConnectedAgentFenceHeaders,
+    connected_agent_fence_headers,
+    require_connected_agent_fence,
+)
 from app.services.file_store import get_file_store
 from app.services.session_events import (
     EMPTY_EVENT_HEAD,
@@ -67,23 +72,67 @@ async def _owned_session_by_local(
     auth: AuthContext,
     local_session_id: str,
     environment_id: UUID,
+    fence_headers: ConnectedAgentFenceHeaders | None = None,
     *,
     for_update: bool = False,
 ) -> Session:
+    if auth.is_cli and auth.api_key is not None and auth.api_key.environment_id is not None:
+        if auth.api_key.environment_id != environment_id:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, "api key bound to another environment")
+    if fence_headers is not None:
+        await require_connected_agent_fence(
+            db,
+            auth=auth,
+            agent_ids={environment_id},
+            headers=fence_headers,
+            lock=True,
+        )
     stmt = select(Session).where(
         Session.user_id == auth.user_id,
         Session.local_session_id == local_session_id,
         Session.origin_environment_id == environment_id,
     )
-    if auth.is_cli and auth.api_key is not None and auth.api_key.environment_id is not None:
-        if auth.api_key.environment_id != environment_id:
-            raise HTTPException(status.HTTP_403_FORBIDDEN, "api key bound to another environment")
     if for_update:
         stmt = stmt.with_for_update()
     session = (await db.execute(stmt)).scalar_one_or_none()
     if session is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
     return session
+
+
+async def _fence_event_generation_environment(
+    db: AsyncSession,
+    auth: AuthContext,
+    local_session_id: str,
+    generation_id: UUID,
+    fence_headers: ConnectedAgentFenceHeaders,
+) -> None:
+    row = (
+        await db.execute(
+            select(Session.origin_environment_id)
+            .join(SessionEventGeneration, SessionEventGeneration.session_id == Session.id)
+            .where(
+                SessionEventGeneration.id == generation_id,
+                Session.user_id == auth.user_id,
+                Session.local_session_id == local_session_id,
+            )
+        )
+    ).first()
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Staging generation not found")
+    environment_id = row.origin_environment_id
+    if environment_id is None:
+        return
+    if auth.is_cli and auth.api_key is not None and auth.api_key.environment_id is not None:
+        if auth.api_key.environment_id != environment_id:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "Staging generation not found")
+    await require_connected_agent_fence(
+        db,
+        auth=auth,
+        agent_ids={environment_id},
+        headers=fence_headers,
+        lock=True,
+    )
 
 
 async def _read_upload(file: UploadFile) -> bytes:
@@ -162,10 +211,11 @@ async def stage_session_event_generation(
     body: SessionEventGenerationCreate,
     local_session_id: str = Path(..., pattern=_LOCAL_ID_PATTERN),
     auth: AuthContext = Depends(require_scope("sessions:write")),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> SessionEventGenerationResponse:
     session = await _owned_session_by_local(
-        db, auth, local_session_id, body.environment_id, for_update=True
+        db, auth, local_session_id, body.environment_id, fence_headers, for_update=True
     )
     existing = await db.get(SessionEventGeneration, body.generation)
     if existing is not None:
@@ -237,6 +287,7 @@ async def upload_session_event_generation_chunk(
     content_hash: str = Form(..., pattern=r"^[0-9a-f]{64}$"),
     file: UploadFile = File(...),
     auth: AuthContext = Depends(require_scope("sessions:write")),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> SessionEventChunkResponse:
     data = await _read_upload(file)
@@ -248,6 +299,13 @@ async def upload_session_event_generation_chunk(
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
     if validated.content_hash != content_hash:
         raise HTTPException(status.HTTP_409_CONFLICT, "Event chunk content hash mismatch")
+    await _fence_event_generation_environment(
+        db,
+        auth,
+        local_session_id,
+        generation_id,
+        fence_headers,
+    )
     generation = (
         await db.execute(
             select(SessionEventGeneration)
@@ -356,8 +414,16 @@ async def commit_session_event_generation(
     local_session_id: str = Path(..., pattern=_LOCAL_ID_PATTERN),
     generation_id: UUID = Path(...),
     auth: AuthContext = Depends(require_scope("sessions:write")),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> SessionEventAppendResponse:
+    await _fence_event_generation_environment(
+        db,
+        auth,
+        local_session_id,
+        generation_id,
+        fence_headers,
+    )
     generation = (
         await db.execute(
             select(SessionEventGeneration)
@@ -480,6 +546,7 @@ async def append_session_events(
     content_hash: str = Form(..., pattern=r"^[0-9a-f]{64}$"),
     file: UploadFile = File(...),
     auth: AuthContext = Depends(require_scope("sessions:write")),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> SessionEventAppendResponse:
     data = await _read_upload(file)
@@ -496,7 +563,7 @@ async def append_session_events(
     ):
         raise HTTPException(status.HTTP_409_CONFLICT, "Event append final hash mismatch")
     session = await _owned_session_by_local(
-        db, auth, local_session_id, environment_id, for_update=True
+        db, auth, local_session_id, environment_id, fence_headers, for_update=True
     )
     receipt = (
         await db.execute(

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -120,6 +120,12 @@ from app.services.agent_lifecycle import (
     active_agent_filter,
     archive_agent_and_project,
 )
+from app.services.connected_agent_fence import (
+    ConnectedAgentFenceHeaders,
+    connected_agent_fence_headers,
+    machine_header_enables_fence,
+    require_connected_agent_fence,
+)
 from app.services.file_store import get_file_store
 from app.services.http_cache import if_none_match_contains, strong_json_etag
 from app.services.memory_provider import get_memory_provider
@@ -258,7 +264,9 @@ async def _register_agent_identity(
     body: EnvironmentCreate,
     auth: AuthContext,
     db: AsyncSession,
+    fence_headers: ConnectedAgentFenceHeaders,
 ) -> EnvironmentCreatedResponse:
+    enable_machine_fence = machine_header_enables_fence(body.machine_id, fence_headers)
     registration_key = local_machine_registration_key(body.machine_id, body.agent_type)
     # Bound deploy keys are pinned to a single env. Letting them
     # create *new* envs (and new env-local projects) would let a
@@ -326,6 +334,8 @@ async def _register_agent_identity(
         # an account-level CLI token from reclassifying that Agent identity.
         registered.env.connected_agent_registered_at = datetime.now(UTC)
         registered.env.adapter_modules = body.adapter_modules
+        if enable_machine_fence:
+            registered.env.machine_fence_required = True
     else:
         # A managed or environment-bound registration is positive evidence
         # against the Connected runtime shape; do not retain its observations.
@@ -343,9 +353,10 @@ async def register_agent(
     # session path then refuses to write — half-registered ghosts
     # in the dashboard.
     auth: AuthContext = Depends(require_any_scope("sessions:write", "skills:write")),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> EnvironmentCreatedResponse:
-    return await _register_agent_identity(body, auth, db)
+    return await _register_agent_identity(body, auth, db, fence_headers)
 
 
 @router.post("/agents/{agent_id}/rebind")
@@ -353,6 +364,7 @@ async def rebind_agent(
     agent_id: UUID,
     body: EnvironmentCreate,
     auth: AuthContext = Depends(require_oauth_cli_auth),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> EnvironmentCreatedResponse:
     """Reconnect one local installation to an existing Agent identity."""
@@ -398,6 +410,15 @@ async def rebind_agent(
             status.HTTP_409_CONFLICT,
             "The local Agent type does not match the selected Agent",
         )
+    if env.machine_fence_required and fence_headers.machine_id is None:
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "agent_rebound",
+                "message": "This Agent requires a current machine identity to be rebound.",
+                "recovery": "Upgrade Clawdi, then run `clawdi agent reconnect` again.",
+            },
+        )
 
     registration_key = local_machine_registration_key(body.machine_id, body.agent_type)
     conflict = await db.scalar(
@@ -417,6 +438,7 @@ async def rebind_agent(
             },
         )
 
+    enable_machine_fence = machine_header_enables_fence(body.machine_id, fence_headers)
     now = datetime.now(UTC)
     env.machine_id = body.machine_id
     env.machine_name = body.machine_name
@@ -433,6 +455,8 @@ async def rebind_agent(
     env.dropped_count_since_start = 0
     env.project_skill_reconcile_version = None
     env.project_skill_reconcile_observed_at = None
+    if enable_machine_fence:
+        env.machine_fence_required = True
     rebound_id = env.id
     try:
         await db.commit()
@@ -455,9 +479,10 @@ async def rebind_agent(
 async def register_environment(
     body: EnvironmentCreate,
     auth: AuthContext = Depends(require_any_scope("sessions:write", "skills:write")),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> EnvironmentCreatedResponse:
-    return await _register_agent_identity(body, auth, db)
+    return await _register_agent_identity(body, auth, db, fence_headers)
 
 
 @overload
@@ -1427,6 +1452,7 @@ def _agent_to_response(env: AgentEnvironment) -> AgentResponse:
             env.display_name, env.default_name, env.machine_name, env.agent_type
         ),
         default_name=env.default_name,
+        machine_id=env.machine_id,
         machine_name=env.machine_name,
         display_name=env.display_name,
         avatar_url=_asset_url(env.avatar_asset_key) if env.avatar_asset_key else None,
@@ -2064,6 +2090,7 @@ async def sync_heartbeat(
     # = None` and mask a real outage. `skills:write` is the daemon's
     # canonical write project (it always pushes skills), so reuse it.
     auth: AuthContext = Depends(require_scope("skills:write")),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> None:
     """Daemon writes its liveness state here every cycle. Extreme-
@@ -2081,6 +2108,13 @@ async def sync_heartbeat(
     ).scalar_one_or_none()
     if env is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "agent environment not found")
+    await require_connected_agent_fence(
+        db,
+        auth=auth,
+        agent_ids={agent_id},
+        headers=fence_headers,
+        lock=True,
+    )
 
     # If the deploy-key is bound to a specific env, refuse calls
     # for any other env. Resource-level project alone wasn't enough
@@ -2184,6 +2218,7 @@ async def batch_create_sessions(
     body: SessionBatchRequest,
     request: Request,
     auth: AuthContext = Depends(require_scope("sessions:write")),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> SessionBatchResponse:
     """Ingest a batch of sessions from a CLI sync.
@@ -2246,6 +2281,13 @@ async def batch_create_sessions(
     # batch — partial accept would silently drop the user's sessions and
     # they'd never know.
     requested_env_ids = {s.environment_id for s in body.sessions}
+    await require_connected_agent_fence(
+        db,
+        auth=auth,
+        agent_ids=requested_env_ids,
+        headers=fence_headers,
+        lock=True,
+    )
     valid_env_ids = set(
         (
             await db.execute(
@@ -3053,6 +3095,7 @@ async def upload_session_content(
     expected_content_hash: str | None = Form(default=None, pattern=r"^[0-9a-f]{64}$"),
     file: UploadFile = File(...),
     auth: AuthContext = Depends(require_scope("sessions:write")),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> SessionUploadResponse:
     """Upload session messages JSON to FileStore."""
@@ -3069,6 +3112,29 @@ async def upload_session_content(
         stmt = stmt.where(Session.origin_environment_id == bound_env)
     elif environment_id is not None:
         stmt = stmt.where(Session.origin_environment_id == environment_id)
+    sessions = list((await db.execute(stmt)).scalars())
+    if not sessions:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
+    if len(sessions) != 1:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail={
+                "code": "session_origin_required",
+                "message": (
+                    "More than one Agent owns this local_session_id; "
+                    "use an environment-bound credential."
+                ),
+            },
+        )
+    session = sessions[0]
+    if session.origin_environment_id is not None:
+        await require_connected_agent_fence(
+            db,
+            auth=auth,
+            agent_ids={session.origin_environment_id},
+            headers=fence_headers,
+            lock=True,
+        )
     sessions = list((await db.execute(stmt.with_for_update())).scalars())
     if not sessions:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
@@ -3429,6 +3495,7 @@ async def get_session_messages(
 async def extract_session_memories(
     local_session_id: str = Path(..., pattern=r"^[A-Za-z0-9][A-Za-z0-9._\-]{0,199}$"),
     auth: AuthContext = Depends(require_scope("memories:write")),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> SessionExtractResponse:
     """Extract memories from a session's content via the configured LLM.
@@ -3459,6 +3526,14 @@ async def extract_session_memories(
     session = (await db.execute(stmt)).scalar_one_or_none()
     if not session:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
+    if session.origin_environment_id is not None:
+        await require_connected_agent_fence(
+            db,
+            auth=auth,
+            agent_ids={session.origin_environment_id},
+            headers=fence_headers,
+            lock=True,
+        )
     if not session_has_uploaded_content(session):
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -74,6 +74,11 @@ from app.schemas.skill import (
     SkillUploadResponse,
 )
 from app.services.audit import record_control_plane_audit
+from app.services.connected_agent_fence import (
+    ConnectedAgentFenceHeaders,
+    connected_agent_fence_headers,
+    require_connected_agent_fence,
+)
 from app.services.file_store import get_file_store
 from app.services.http_cache import if_none_match_contains
 from app.services.project_runtime_skills import (
@@ -892,6 +897,7 @@ async def upload_skill_legacy(
     ),
     skill_sync_protocol: str | None = Header(default=None, alias=SKILL_SYNC_PROTOCOL_HEADER),
     auth: AuthContext = Depends(require_scope_short_session("skills:write")),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> SkillUploadResponse:
     """Back-compat shim for pre-PR-66 CLI binaries. Resolves the
@@ -950,6 +956,7 @@ async def upload_skill_legacy(
         content_hash=content_hash,
         authority=authority,
         authority_agent_id=authority_agent_id,
+        fence_headers=fence_headers,
     )
 
 
@@ -1089,6 +1096,7 @@ async def _upload_skill_project(
     create_only: bool,
     content_hash: str | None,
     skill_sync_protocol: str | None,
+    fence_headers: ConnectedAgentFenceHeaders,
 ) -> SkillUploadResponse:
     authority, authority_agent_id = await _project_upload_authority(
         db,
@@ -1110,6 +1118,7 @@ async def _upload_skill_project(
         create_only=create_only,
         authority=authority,
         authority_agent_id=authority_agent_id,
+        fence_headers=fence_headers,
     )
 
 
@@ -1125,6 +1134,7 @@ async def upload_agent_synced_skill(
         pattern=r"^[a-f0-9]{64}$",
     ),
     auth: AuthContext = Depends(require_scope_short_session("skills:write")),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> SkillUploadResponse:
     project_id = await _agent_sync_project(db, auth, agent_id)
@@ -1142,6 +1152,7 @@ async def upload_agent_synced_skill(
         content_hash=content_hash,
         authority=SKILL_AUTHORITY_AGENT_SYNC,
         authority_agent_id=agent_id,
+        fence_headers=fence_headers,
     )
 
 
@@ -1162,6 +1173,7 @@ async def upload_skill_project(
     ),
     skill_sync_protocol: str | None = Header(default=None, alias=SKILL_SYNC_PROTOCOL_HEADER),
     auth: AuthContext = Depends(require_scope_short_session("skills:write")),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> SkillUploadResponse:
     """Project-explicit tar.gz skill upload.
@@ -1181,6 +1193,7 @@ async def upload_skill_project(
         create_only=create_only,
         content_hash=content_hash,
         skill_sync_protocol=skill_sync_protocol,
+        fence_headers=fence_headers,
     )
 
 
@@ -1443,6 +1456,7 @@ async def upload_skill_project_legacy(
     ),
     skill_sync_protocol: str | None = Header(default=None, alias=SKILL_SYNC_PROTOCOL_HEADER),
     auth: AuthContext = Depends(require_scope_short_session("skills:write")),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> SkillUploadResponse | dict[str, bool]:
     """Preserve the released /api upload contract for legacy Agent scanners."""
@@ -1474,6 +1488,7 @@ async def upload_skill_project_legacy(
         create_only=create_only,
         content_hash=content_hash,
         skill_sync_protocol=skill_sync_protocol,
+        fence_headers=fence_headers,
     )
 
 
@@ -1628,6 +1643,7 @@ async def _do_upload_skill(
     create_only: bool = False,
     authority: str = SKILL_AUTHORITY_CLOUD,
     authority_agent_id: UUID | None = None,
+    fence_headers: ConnectedAgentFenceHeaders | None = None,
 ) -> SkillUploadResponse:
     """Validate and persist a Cloud row or Agent filesystem projection.
 
@@ -1712,11 +1728,17 @@ async def _do_upload_skill(
                     status.HTTP_403_FORBIDDEN,
                     "Agent sync authority is missing",
                 )
+            await require_connected_agent_fence(
+                db,
+                auth=auth,
+                agent_ids={authority_agent_id},
+                headers=fence_headers or ConnectedAgentFenceHeaders(machine_id=None),
+                lock=True,
+            )
             current_project_id = await _agent_sync_project(
                 db,
                 auth,
                 authority_agent_id,
-                lock_agent=True,
             )
             if current_project_id != project_id:
                 raise HTTPException(
@@ -2202,8 +2224,16 @@ async def delete_agent_synced_skill(
         ),
     ),
     auth: AuthContext = Depends(require_scope_short_session("skills:write")),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> Response:
+    await require_connected_agent_fence(
+        db,
+        auth=auth,
+        agent_ids={agent_id},
+        headers=fence_headers,
+        lock=True,
+    )
     await _do_delete_agent_synced_skill(
         db=db,
         auth=auth,
@@ -2346,6 +2376,7 @@ async def delete_skill_project(
     ),
     skill_sync_protocol: str | None = Header(default=None, alias=SKILL_SYNC_PROTOCOL_HEADER),
     auth: AuthContext = Depends(require_scope_short_session("skills:write")),
+    fence_headers: ConnectedAgentFenceHeaders = Depends(connected_agent_fence_headers),
     db: AsyncSession = Depends(get_session),
 ) -> SkillDeleteResponse:
     """Phase-2 project-explicit delete — only the named project's copy
@@ -2360,6 +2391,13 @@ async def delete_skill_project(
     if authority == SKILL_AUTHORITY_AGENT_SYNC:
         if authority_agent_id is None:
             raise HTTPException(status.HTTP_409_CONFLICT, "Agent identity is unavailable")
+        await require_connected_agent_fence(
+            db,
+            auth=auth,
+            agent_ids={authority_agent_id},
+            headers=fence_headers,
+            lock=True,
+        )
         return await _do_delete_agent_synced_skill(
             db=db,
             auth=auth,

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -270,6 +270,7 @@ class AgentResponse(BaseModel):
     id: str
     name: str
     default_name: str | None = None
+    machine_id: str
     machine_name: str
     display_name: str | None = None
     avatar_url: str | None = None

--- a/backend/app/services/agent_environments.py
+++ b/backend/app/services/agent_environments.py
@@ -53,6 +53,7 @@ def clear_connected_agent_registration(agent: AgentEnvironment) -> None:
     """Clear Connected-only origin and observations during hosted registration."""
 
     agent.connected_agent_registered_at = None
+    agent.machine_fence_required = False
     agent.project_skill_reconcile_version = None
     agent.project_skill_reconcile_observed_at = None
     agent.adapter_modules = None

--- a/backend/app/services/connected_agent_fence.py
+++ b/backend/app/services/connected_agent_fence.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from fastapi import Header, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import AuthContext, is_connected_agent_principal
+from app.models.session import AgentEnvironment
+
+MACHINE_ID_HEADER = "X-Clawdi-Machine-Id"
+MACHINE_ID_MAX_LENGTH = 200
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectedAgentFenceHeaders:
+    machine_id: str | None
+
+
+def connected_agent_fence_headers(
+    clawdi_machine_id: str | None = Header(
+        default=None,
+        alias=MACHINE_ID_HEADER,
+    ),
+) -> ConnectedAgentFenceHeaders:
+    machine_id = clawdi_machine_id.strip() if clawdi_machine_id is not None else None
+    if machine_id is not None and len(machine_id) > MACHINE_ID_MAX_LENGTH:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Machine identity header is too long")
+    return ConnectedAgentFenceHeaders(machine_id=machine_id or None)
+
+
+def machine_header_enables_fence(
+    expected_machine_id: str,
+    headers: ConnectedAgentFenceHeaders,
+) -> bool:
+    if headers.machine_id is None:
+        return False
+    if expected_machine_id != headers.machine_id:
+        raise _agent_rebound("Machine identity header does not match the registration request")
+    return True
+
+
+async def require_connected_agent_fence(
+    db: AsyncSession,
+    *,
+    auth: AuthContext,
+    agent_ids: set[UUID],
+    headers: ConnectedAgentFenceHeaders,
+    lock: bool = False,
+) -> None:
+    """Reject stale Connected installations after setup/rebind enables fencing."""
+
+    if not is_connected_agent_principal(auth) or not agent_ids:
+        return
+    statement = (
+        select(AgentEnvironment)
+        .where(
+            AgentEnvironment.id.in_(agent_ids),
+            AgentEnvironment.user_id == auth.user_id,
+            AgentEnvironment.archived_at.is_(None),
+            AgentEnvironment.connected_agent_registered_at.is_not(None),
+        )
+        .execution_options(populate_existing=True)
+    )
+    if lock:
+        statement = statement.order_by(AgentEnvironment.id).with_for_update()
+    connected = list((await db.execute(statement)).scalars())
+    if not connected:
+        return
+    machine_id = headers.machine_id
+    for agent in connected:
+        if machine_id is not None and agent.machine_id != machine_id:
+            raise _agent_rebound("This Agent is bound to another installation")
+        if agent.machine_fence_required and machine_id is None:
+            raise _agent_rebound("This Agent requires its active machine identity header")
+
+
+def _agent_rebound(message: str) -> HTTPException:
+    return HTTPException(
+        status.HTTP_403_FORBIDDEN,
+        detail={
+            "code": "agent_rebound",
+            "message": message,
+            "recovery": "Run `clawdi agent reconnect` to reclaim this Agent on this machine.",
+        },
+    )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -257,6 +257,7 @@ strict = [
     "app/services/clerk_cli_oauth_settings.py",
     "app/services/codex_oauth.py",
     "app/services/composio.py",
+    "app/services/connected_agent_fence.py",
     "app/services/discord_command_reconciliation_worker.py",
     "app/services/discord_gateway_worker.py",
     "app/services/discord_rate_limiter.py",

--- a/backend/tests/fixtures/v1_runtime_observation_baseline.json
+++ b/backend/tests/fixtures/v1_runtime_observation_baseline.json
@@ -24,7 +24,7 @@
 				"_validated_runtime_observed_diagnostics": "4e6bf338bbc8657b7a76e39abf4a32c63852069f966c2414a5c9f16d3231aa75",
 				"get_environment_runtime_observed": "d5fa28547faafa46433c37c4be4c799277f681fcaa02ade946ec58b853ccab12",
 				"list_environment_runtime_observed": "3fb1040c4effabbc50e7a5f5499d7c3bc1652c9ff050b68636d9a0b4906958d2",
-				"sync_heartbeat": "de3e1641ec12620870489f431c42c102a3d54bbd0b622fd0923aee6e9c4e006c"
+				"sync_heartbeat": "1a8c7ce4239d0384519e85d3d28c39870d2162285205a44967d1b7ae78860d3d"
 			}
 		},
 		"backend/app/routes/platform.py": {

--- a/backend/tests/test_agent_endpoints.py
+++ b/backend/tests/test_agent_endpoints.py
@@ -145,10 +145,221 @@ async def test_oauth_cli_rebind_preserves_agent_identity(
     assert env.dropped_count_since_start == 0
     assert env.project_skill_reconcile_version is None
     assert env.project_skill_reconcile_observed_at is None
+    assert env.machine_fence_required is False
 
     repeated = await client.post("/v1/agents", json=_agent_body("replacement-installation"))
     assert repeated.status_code == 200, repeated.text
     assert repeated.json() == {"id": agent_id}
+
+
+@pytest.mark.asyncio
+async def test_connected_agent_machine_fence_activates_and_rotates_on_rebind(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user: User,
+):
+    from app.models.session import AgentEnvironment
+
+    restore_auth = _set_oauth_cli_auth(seed_user)
+    try:
+        legacy = await client.post("/v1/agents", json=_agent_body("legacy-machine"))
+        assert legacy.status_code == 200, legacy.text
+        legacy_id = legacy.json()["id"]
+        assert (
+            await client.post(
+                f"/v1/agents/{legacy_id}/sync-heartbeat",
+                json={"queue_depth": 0},
+            )
+        ).status_code == 204
+        legacy_wrong = await client.post(
+            f"/v1/agents/{legacy_id}/sync-heartbeat",
+            headers={"X-Clawdi-Machine-Id": "wrong-machine"},
+            json={"queue_depth": 0},
+        )
+        assert legacy_wrong.status_code == 403
+        assert legacy_wrong.json()["detail"]["code"] == "agent_rebound"
+
+        current = await client.post(
+            "/v1/agents",
+            headers={"X-Clawdi-Machine-Id": "current-machine"},
+            json=_agent_body("current-machine"),
+        )
+        assert current.status_code == 200, current.text
+        current_id = current.json()["id"]
+        env = await db_session.get(AgentEnvironment, uuid.UUID(current_id))
+        assert env is not None
+        assert env.machine_fence_required is True
+
+        for headers in ({}, {"X-Clawdi-Machine-Id": "stale-machine"}):
+            rejected = await client.post(
+                f"/v1/agents/{current_id}/sync-heartbeat",
+                headers=headers,
+                json={"queue_depth": 0},
+            )
+            assert rejected.status_code == 403
+            assert rejected.json()["detail"]["code"] == "agent_rebound"
+        assert (
+            await client.post(
+                f"/v1/agents/{current_id}/sync-heartbeat",
+                headers={"X-Clawdi-Machine-Id": "current-machine"},
+                json={"queue_depth": 0},
+            )
+        ).status_code == 204
+
+        second_body = _agent_body("current-machine")
+        second_body["agent_type"] = "claude_code"
+        second = await client.post(
+            "/v1/agents",
+            headers={"X-Clawdi-Machine-Id": "current-machine"},
+            json=second_body,
+        )
+        assert second.status_code == 200, second.text
+        batch = await client.post(
+            "/v1/sessions/batch",
+            headers={"X-Clawdi-Machine-Id": "current-machine"},
+            json={
+                "sessions": [
+                    {
+                        "environment_id": environment_id,
+                        "local_session_id": local_session_id,
+                        "started_at": datetime.now(UTC).isoformat(),
+                    }
+                    for environment_id, local_session_id in (
+                        (current_id, "current-machine-session"),
+                        (second.json()["id"], "second-agent-session"),
+                    )
+                ]
+            },
+        )
+        assert batch.status_code == 200, batch.text
+
+        missing_rebind_header = await client.post(
+            f"/v1/agents/{current_id}/rebind",
+            json=_agent_body("unheadered-replacement"),
+        )
+        assert missing_rebind_header.status_code == 403
+        assert missing_rebind_header.json()["detail"]["code"] == "agent_rebound"
+        await db_session.refresh(env)
+        assert env.machine_id == "current-machine"
+        assert env.machine_fence_required is True
+
+        rebound = await client.post(
+            f"/v1/agents/{current_id}/rebind",
+            headers={"X-Clawdi-Machine-Id": "replacement-machine"},
+            json=_agent_body("replacement-machine"),
+        )
+        assert rebound.status_code == 200, rebound.text
+        old_machine = await client.post(
+            f"/v1/agents/{current_id}/sync-heartbeat",
+            headers={"X-Clawdi-Machine-Id": "current-machine"},
+            json={"queue_depth": 0},
+        )
+        assert old_machine.status_code == 403
+        assert old_machine.json()["detail"]["code"] == "agent_rebound"
+        assert (
+            await client.post(
+                f"/v1/agents/{current_id}/sync-heartbeat",
+                headers={"X-Clawdi-Machine-Id": "replacement-machine"},
+                json={"queue_depth": 0},
+            )
+        ).status_code == 204
+    finally:
+        restore_auth()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("fenced", "request_machine_id", "allowed"),
+    [
+        (False, None, True),
+        (True, "current-machine", True),
+        (True, None, False),
+        (True, "stale-machine", False),
+    ],
+)
+async def test_connected_agent_machine_fence_covers_session_write_routes(
+    client: httpx.AsyncClient,
+    seed_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    fenced: bool,
+    request_machine_id: str | None,
+    allowed: bool,
+) -> None:
+    from app.core.config import settings
+    from app.services.session_events import EMPTY_EVENT_HEAD
+
+    monkeypatch.setattr(settings, "llm_api_key", "test-key")
+    restore_auth = _set_oauth_cli_auth(seed_user)
+    registration_machine_id = "current-machine" if fenced else "legacy-machine"
+    registration_headers = {"X-Clawdi-Machine-Id": registration_machine_id} if fenced else {}
+    request_headers = (
+        {"X-Clawdi-Machine-Id": request_machine_id} if request_machine_id is not None else {}
+    )
+    suffix = uuid.uuid4().hex
+    snapshot_id = f"fence-snapshot-{suffix}"
+    events_id = f"fence-events-{suffix}"
+    try:
+        registered = await client.post(
+            "/v1/agents",
+            headers=registration_headers,
+            json=_agent_body(registration_machine_id),
+        )
+        assert registered.status_code == 200, registered.text
+        environment_id = registered.json()["id"]
+        batch = await client.post(
+            "/v1/sessions/batch",
+            headers=registration_headers,
+            json={
+                "sessions": [
+                    {
+                        "environment_id": environment_id,
+                        "local_session_id": snapshot_id,
+                        "started_at": datetime.now(UTC).isoformat(),
+                    },
+                    {
+                        "environment_id": environment_id,
+                        "local_session_id": events_id,
+                        "started_at": datetime.now(UTC).isoformat(),
+                        "content_protocol": "events-v1",
+                    },
+                ]
+            },
+        )
+        assert batch.status_code == 200, batch.text
+
+        responses = [
+            await client.post(f"/v1/sessions/{snapshot_id}/extract", headers=request_headers),
+            await client.post(
+                f"/v1/sessions/{snapshot_id}/upload",
+                headers=request_headers,
+                files={"file": ("session.json", b"[]", "application/json")},
+            ),
+            await client.post(
+                f"/v1/sessions/{events_id}/events/generations",
+                headers=request_headers,
+                json={
+                    "environment_id": environment_id,
+                    "generation": str(uuid.uuid4()),
+                    "append_id": str(uuid.uuid4()),
+                    "base_generation": None,
+                    "base_revision": 0,
+                    "base_count": 0,
+                    "base_head_hash": EMPTY_EVENT_HEAD,
+                    "final_count": 0,
+                    "final_head_hash": EMPTY_EVENT_HEAD,
+                },
+            ),
+        ]
+    finally:
+        restore_auth()
+
+    if allowed:
+        assert [response.status_code for response in responses] == [400, 200, 200]
+        return
+    for response in responses:
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"]["code"] == "agent_rebound"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connected_agent_fence.py
+++ b/backend/tests/test_connected_agent_fence.py
@@ -1,0 +1,22 @@
+import pytest
+from fastapi import HTTPException
+
+from app.services.connected_agent_fence import (
+    ConnectedAgentFenceHeaders,
+    connected_agent_fence_headers,
+    machine_header_enables_fence,
+)
+
+
+def test_machine_fence_header_rejects_invalid_values_without_type_errors() -> None:
+    with pytest.raises(HTTPException) as mismatch:
+        machine_header_enables_fence(
+            "machine-a",
+            ConnectedAgentFenceHeaders(machine_id="机器-b"),
+        )
+    assert mismatch.value.status_code == 403
+    assert mismatch.value.detail["code"] == "agent_rebound"
+
+    with pytest.raises(HTTPException) as oversized:
+        connected_agent_fence_headers("x" * 201)
+    assert oversized.value.status_code == 400

--- a/backend/tests/test_connected_agent_fence_migration.py
+++ b/backend/tests/test_connected_agent_fence_migration.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+
+def _load_migration():
+    path = (
+        Path(__file__).parents[1]
+        / "alembic"
+        / "versions"
+        / "c8f2a6d1e4b9_connected_agent_machine_fence.py"
+    )
+    spec = importlib.util.spec_from_file_location("connected_agent_machine_fence", path)
+    assert spec is not None and spec.loader is not None
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    return migration
+
+
+@pytest.mark.asyncio
+async def test_connected_agent_machine_fence_migration_is_legacy_compatible(
+    engine: AsyncEngine,
+) -> None:
+    migration = _load_migration()
+    schema = f"connected_agent_fence_{uuid.uuid4().hex}"
+
+    def run_migration(sync_conn: sa.Connection) -> None:
+        old_op = migration.op
+        sync_conn.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+        sync_conn.execute(sa.text(f'SET search_path TO "{schema}"'))
+        try:
+            sync_conn.execute(sa.text("CREATE TABLE agent_environments (id uuid PRIMARY KEY)"))
+            legacy_id = uuid.uuid4()
+            sync_conn.execute(
+                sa.text("INSERT INTO agent_environments (id) VALUES (CAST(:id AS uuid))"),
+                {"id": str(legacy_id)},
+            )
+            migration.op = Operations(MigrationContext.configure(sync_conn))
+            migration.upgrade()
+
+            column = next(
+                item
+                for item in sa.inspect(sync_conn).get_columns("agent_environments", schema=schema)
+                if item["name"] == "machine_fence_required"
+            )
+            assert column["nullable"] is False
+            assert column["default"] in ("false", "false::boolean")
+            assert (
+                sync_conn.scalar(
+                    sa.text("SELECT machine_fence_required FROM agent_environments WHERE id = :id"),
+                    {"id": legacy_id},
+                )
+                is False
+            )
+
+            inserted_id = uuid.uuid4()
+            sync_conn.execute(
+                sa.text("INSERT INTO agent_environments (id) VALUES (CAST(:id AS uuid))"),
+                {"id": str(inserted_id)},
+            )
+            assert (
+                sync_conn.scalar(
+                    sa.text("SELECT machine_fence_required FROM agent_environments WHERE id = :id"),
+                    {"id": inserted_id},
+                )
+                is False
+            )
+        finally:
+            migration.op = old_op
+            sync_conn.execute(sa.text("SET search_path TO public"))
+            sync_conn.execute(sa.text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+
+    async with engine.begin() as conn:
+        await conn.run_sync(run_migration)

--- a/backend/tests/test_skill_authority.py
+++ b/backend/tests/test_skill_authority.py
@@ -30,6 +30,7 @@ from app.services.agent_skill_projection import (
     delete_agent_project_skill_rows,
     delete_agent_skill_files_best_effort,
 )
+from app.services.connected_agent_fence import ConnectedAgentFenceHeaders
 from app.services.file_store import FileStore, get_file_store
 from app.services.sync_events import subscribe, unsubscribe
 from app.services.tar_utils import tar_from_content
@@ -1182,6 +1183,85 @@ async def test_agent_upload_storage_io_holds_no_db_lock_and_cannot_resurrect_del
         assert surviving_rows == []
     # A race loser may leave only its immutable, unreachable object. It cannot
     # overwrite a committed identity or resurrect the deleted projection.
+    assert await file_store.exists(file_key) is True
+    await file_store.delete(file_key)
+
+
+@pytest.mark.asyncio
+async def test_agent_upload_revalidates_machine_fence_after_storage_io(
+    engine: AsyncEngine,
+    db_session: AsyncSession,
+    seed_user: User,
+    environment_project,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    agent_id = environment_project.origin_environment_id
+    agent = await db_session.get(AgentEnvironment, agent_id)
+    assert agent is not None
+    agent.machine_id = "machine-old"
+    agent.machine_fence_required = True
+    agent.connected_agent_registered_at = datetime.now(UTC)
+    await db_session.commit()
+
+    archive = _skill_archive("rebind-race")
+    content_hash = _compute_file_tree_hash(archive, "rebind-race")
+    file_store = get_file_store()
+    file_key = skill_routes._file_key(
+        seed_user.id,
+        environment_project.id,
+        "rebind-race",
+        content_hash,
+    )
+    put_started = asyncio.Event()
+    release_put = asyncio.Event()
+    monkeypatch.setattr(
+        skill_routes,
+        "file_store",
+        _BlockingPutFileStore(
+            file_store,
+            put_started=put_started,
+            release_put=release_put,
+        ),
+    )
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def upload() -> None:
+        async with session_factory() as session:
+            await skill_routes._do_upload_skill(
+                db=session,
+                auth=_api_key_auth(seed_user),
+                project_id=environment_project.id,
+                skill_key="rebind-race",
+                data=archive,
+                content_hash=None,
+                authority=SKILL_AUTHORITY_AGENT_SYNC,
+                authority_agent_id=agent_id,
+                fence_headers=ConnectedAgentFenceHeaders(machine_id="machine-old"),
+            )
+
+    upload_task = asyncio.create_task(upload())
+    await asyncio.wait_for(put_started.wait(), timeout=2)
+    async with session_factory() as session:
+        rebound = await session.get(AgentEnvironment, agent_id, with_for_update=True)
+        assert rebound is not None
+        rebound.machine_id = "machine-new"
+        await session.commit()
+    release_put.set()
+
+    with pytest.raises(HTTPException) as upload_error:
+        await upload_task
+    assert upload_error.value.status_code == 403
+    assert upload_error.value.detail["code"] == "agent_rebound"
+
+    async with session_factory() as session:
+        surviving = await session.scalar(
+            select(Skill).where(
+                Skill.project_id == environment_project.id,
+                Skill.skill_key == "rebind-race",
+                Skill.is_active,
+            )
+        )
+        assert surviving is None
     assert await file_store.exists(file_key) is True
     await file_store.delete(file_key)
 

--- a/packages/cli/src/commands/agent-detect.test.ts
+++ b/packages/cli/src/commands/agent-detect.test.ts
@@ -1,6 +1,20 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { DesktopAgentType } from "@clawdi/shared/desktop";
-import { detectLocalAgents } from "./agent-detect";
+import { ApiError } from "../lib/api-client";
+import { setAuth } from "../lib/config";
+import { detectLocalAgents, inspectDesktopRegistration } from "./agent-detect";
+
+const originalClawdiHome = process.env.CLAWDI_HOME;
+const roots: string[] = [];
+
+afterEach(() => {
+	if (originalClawdiHome === undefined) delete process.env.CLAWDI_HOME;
+	else process.env.CLAWDI_HOME = originalClawdiHome;
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
 
 function entry(
 	type: DesktopAgentType,
@@ -28,7 +42,7 @@ describe("desktop agent detection", () => {
 					throw new Error("private path");
 				}),
 			],
-			new Set(["claude_code"]),
+			{ registeredTypes: new Set(["claude_code"]) },
 		);
 
 		expect(agents).toEqual([
@@ -58,4 +72,44 @@ describe("desktop agent detection", () => {
 			},
 		]);
 	});
+
+	test.each([
+		["owned", "registered", true, "complete"],
+		["missing", "not_registered", false, "complete"],
+		["offline", "failed", false, "failed"],
+	] as const)(
+		"inspects a legacy registration with a %s cloud result",
+		async (cloudResult, expectedStatus, registered, inspection) => {
+			const root = mkdtempSync(join(tmpdir(), "clawdi-agent-detect-"));
+			roots.push(root);
+			process.env.CLAWDI_HOME = root;
+			mkdirSync(join(root, "environments"), { recursive: true });
+			const registrationPath = join(root, "environments", "codex.json");
+			writeFileSync(
+				registrationPath,
+				`${JSON.stringify({ id: "agent-a", agentType: "codex", machineId: "machine-a" })}\n`,
+			);
+			setAuth({ apiKey: "account-b-key", userId: "account-b" });
+			const before = readFileSync(registrationPath, "utf8");
+			const lookup = async () => {
+				if (cloudResult === "missing") {
+					throw new ApiError({ status: 404, body: "", hint: "" });
+				}
+				if (cloudResult === "offline") throw new Error("network unavailable");
+			};
+
+			const agents = await detectLocalAgents([entry("codex", async () => true)], {
+				registeredTypes: new Set(["codex"]),
+				inspectRegistration: (agentType) => inspectDesktopRegistration(agentType, lookup),
+			});
+
+			expect(agents[0]).toMatchObject({ registered, inspection });
+			const after = readFileSync(registrationPath, "utf8");
+			if (expectedStatus === "registered") {
+				expect(JSON.parse(after)).toMatchObject({ id: "agent-a", userId: "account-b" });
+			} else {
+				expect(after).toBe(before);
+			}
+		},
+	);
 });

--- a/packages/cli/src/commands/agent-detect.ts
+++ b/packages/cli/src/commands/agent-detect.ts
@@ -1,5 +1,11 @@
 import type { DesktopAgentType, DesktopDetectedAgent } from "@clawdi/shared/desktop";
 import { allAdapterEntries } from "../adapters/registry";
+import { ApiClient, ApiError, unwrap } from "../lib/api-client";
+import { getAuth } from "../lib/config";
+import {
+	bindEnvironmentRegistrationUser,
+	readEnvironmentRegistration,
+} from "../lib/environment-registration";
 import { listRegisteredAgentTypes } from "../lib/select-adapter";
 
 interface DetectableAgentEntry {
@@ -11,29 +17,40 @@ interface DetectableAgentEntry {
 	};
 }
 
+type RegistrationInspection = "registered" | "not_registered" | "failed";
+
+interface DetectLocalAgentsOptions {
+	registeredTypes?: ReadonlySet<string>;
+	inspectRegistration?(agentType: DesktopAgentType): Promise<RegistrationInspection>;
+}
+
 export async function detectLocalAgents(
 	entries: readonly DetectableAgentEntry[] = allAdapterEntries(),
-	registeredTypes: ReadonlySet<string> = new Set(listRegisteredAgentTypes()),
+	options: DetectLocalAgentsOptions = {},
 ): Promise<DesktopDetectedAgent[]> {
+	const registeredTypes = options.registeredTypes ?? new Set(listRegisteredAgentTypes());
 	return Promise.all(
 		entries.map(async (entry) => {
 			const adapter = entry.create();
+			const registration = registeredTypes.has(entry.agentType)
+				? await (options.inspectRegistration?.(entry.agentType) ?? "registered")
+				: "not_registered";
 			try {
 				const detected = await adapter.detect();
 				return {
 					type: entry.agentType,
 					displayName: entry.displayName,
 					detected,
-					registered: registeredTypes.has(entry.agentType),
+					registered: registration === "registered",
 					version: detected ? await adapter.getVersion() : null,
-					inspection: "complete" as const,
+					inspection: registration === "failed" ? ("failed" as const) : ("complete" as const),
 				};
 			} catch {
 				return {
 					type: entry.agentType,
 					displayName: entry.displayName,
 					detected: false,
-					registered: registeredTypes.has(entry.agentType),
+					registered: registration === "registered",
 					version: null,
 					inspection: "failed" as const,
 				};
@@ -42,9 +59,39 @@ export async function detectLocalAgents(
 	);
 }
 
+export async function inspectDesktopRegistration(
+	agentType: DesktopAgentType,
+	lookup: (environmentId: string) => Promise<void> = async (environmentId) => {
+		unwrap(
+			await new ApiClient().GET("/v1/agents/{agent_id}", {
+				params: { path: { agent_id: environmentId } },
+			}),
+		);
+	},
+): Promise<RegistrationInspection> {
+	const registration = readEnvironmentRegistration(agentType);
+	if (!registration) return "not_registered";
+	if (registration.userId) return "registered";
+	try {
+		await lookup(registration.id);
+		const userId = getAuth()?.userId;
+		if (userId && !bindEnvironmentRegistrationUser(agentType, registration.id, userId)) {
+			const current = readEnvironmentRegistration(agentType);
+			return current?.id === registration.id && current.userId === userId ? "registered" : "failed";
+		}
+		return "registered";
+	} catch (error) {
+		if (error instanceof ApiError && error.status === 404) return "not_registered";
+		return "failed";
+	}
+}
+
 export async function agentDetectCommand(opts: { json?: boolean } = {}): Promise<void> {
-	const agents = await detectLocalAgents();
-	if (opts.json || !process.stdout.isTTY) {
+	const jsonOutput = opts.json || !process.stdout.isTTY;
+	const agents = await detectLocalAgents(allAdapterEntries(), {
+		inspectRegistration: jsonOutput ? inspectDesktopRegistration : undefined,
+	});
+	if (jsonOutput) {
 		console.log(JSON.stringify({ schemaVersion: "clawdi.agentDetection.v1", agents }, null, 2));
 		return;
 	}

--- a/packages/cli/src/commands/agent-reconnect.ts
+++ b/packages/cli/src/commands/agent-reconnect.ts
@@ -8,7 +8,7 @@ import { ApiClient, unwrap } from "../lib/api-client";
 import { getAuth } from "../lib/config";
 import { writeEnvironmentRegistration } from "../lib/environment-registration";
 import { errMessage } from "../lib/errors";
-import { getOrCreateMachineId } from "../lib/machine-identity";
+import { getOrCreateMachineId, readMachineId } from "../lib/machine-identity";
 import { getEnvIdByAgent } from "../lib/select-adapter";
 import { isInteractive } from "../lib/tty";
 import { type LocalAgentSetupOpts, maybeInstallDaemons, reconcileAgentIntegrations } from "./setup";
@@ -17,7 +17,11 @@ type AgentResponse = components["schemas"]["AgentResponse"];
 
 interface AgentReconnectOpts extends LocalAgentSetupOpts {
 	agent?: string;
+	desktopList?: boolean;
+	confirmTakeover?: boolean;
 }
+
+const DESKTOP_CANDIDATES_SCHEMA = "clawdi.agentReconnectCandidates.v1";
 
 export async function agentReconnect(
 	agentId: string | undefined,
@@ -46,6 +50,32 @@ export async function agentReconnect(
 		process.exitCode = 1;
 		return;
 	}
+	if (opts.desktopList) {
+		const currentMachineId = readMachineId();
+		console.log(
+			JSON.stringify({
+				schemaVersion: DESKTOP_CANDIDATES_SCHEMA,
+				agents: agents.flatMap((agent) => {
+					const type = AGENT_TYPES.includes(agent.agent_type as AgentType)
+						? (agent.agent_type as AgentType)
+						: null;
+					if (!type) return [];
+					return [
+						{
+							id: agent.id,
+							type,
+							displayName: adapterRegistry[type].displayName,
+							name: agent.name,
+							machineName: agent.machine_name,
+							isThisMachine: currentMachineId !== null && agent.machine_id === currentMachineId,
+							lastSyncAt: agent.last_sync_at ?? null,
+						},
+					];
+				}),
+			}),
+		);
+		return;
+	}
 
 	const candidate = await selectCandidate(agents, agentId, requestedType);
 	if (!candidate) return;
@@ -62,6 +92,27 @@ export async function agentReconnect(
 		console.log(
 			chalk.red(
 				`${adapterRegistry[agentType].displayName} is already connected locally. Run \`clawdi teardown --agent ${agentType}\` before reconnecting another identity.`,
+			),
+		);
+		process.exitCode = 1;
+		return;
+	}
+	let machineId: string;
+	let machineName: string;
+	try {
+		machineId = getOrCreateMachineId();
+		machineName = hostname();
+	} catch (error) {
+		console.log(chalk.red(`Could not prepare local Agent identity: ${errMessage(error)}`));
+		process.exitCode = 1;
+		return;
+	}
+	const recentOtherMachine =
+		candidate.machine_id !== machineId && isRecentlySynced(candidate.last_sync_at);
+	if (recentOtherMachine && opts.yes && !opts.confirmTakeover) {
+		console.log(
+			chalk.red(
+				"This Agent recently synced from another machine. Repeat with --confirm-takeover to disconnect it explicitly.",
 			),
 		);
 		process.exitCode = 1;
@@ -96,7 +147,9 @@ export async function agentReconnect(
 
 	if (!opts.yes && isInteractive()) {
 		const confirmed = await p.confirm({
-			message: `Reconnect ${adapterRegistry[agentType].displayName} to “${candidate.name}” and replace its previous installation binding?`,
+			message: recentOtherMachine
+				? `Take over “${candidate.name}” from the recently active machine “${candidate.machine_name}”? Its daemon will be fenced immediately.`
+				: `Reconnect ${adapterRegistry[agentType].displayName} to “${candidate.name}” and replace its previous installation binding?`,
 			initialValue: true,
 		});
 		if (p.isCancel(confirmed) || !confirmed) {
@@ -105,21 +158,10 @@ export async function agentReconnect(
 		}
 	}
 
-	let machineId: string;
-	let machineName: string;
-	try {
-		machineId = getOrCreateMachineId();
-		machineName = hostname();
-	} catch (error) {
-		console.log(chalk.red(`Could not prepare local Agent identity: ${errMessage(error)}`));
-		process.exitCode = 1;
-		return;
-	}
-
 	let rebound: components["schemas"]["EnvironmentCreatedResponse"];
 	try {
 		rebound = unwrap(
-			await api.POST("/v1/agents/{agent_id}/rebind", {
+			await new ApiClient({ machineId }).POST("/v1/agents/{agent_id}/rebind", {
 				params: { path: { agent_id: candidate.id } },
 				body: {
 					machine_id: machineId,
@@ -179,6 +221,12 @@ export async function agentReconnect(
 		);
 		process.exitCode = 1;
 	}
+}
+
+function isRecentlySynced(value: string | null | undefined): boolean {
+	if (!value) return false;
+	const timestamp = Date.parse(value);
+	return Number.isFinite(timestamp) && Date.now() - timestamp < 5 * 60_000;
 }
 
 function parseAgentType(value: string | undefined): AgentType | null {

--- a/packages/cli/src/commands/serve-cli-options.test.ts
+++ b/packages/cli/src/commands/serve-cli-options.test.ts
@@ -21,6 +21,7 @@ function makeHandlers(captured: { last: Record<string, unknown> | null }): Serve
 		serve: recordOpts,
 		serveInstall: recordOpts,
 		serveUninstall: recordOpts,
+		serveStop: recordOpts,
 		serveRestart: recordOpts,
 		serveStatus: recordOpts,
 		serveLogs: recordOpts,
@@ -166,6 +167,12 @@ describe("registerServeCommand", () => {
 	it("restart reaches the action", async () => {
 		const { program, captured } = buildTree();
 		await program.parseAsync(["node", "clawdi", "serve", "restart"]);
+		expect(captured.last).toEqual({});
+	});
+
+	it("stop reaches the action", async () => {
+		const { program, captured } = buildTree();
+		await program.parseAsync(["node", "clawdi", "daemon", "stop"]);
 		expect(captured.last).toEqual({});
 	});
 

--- a/packages/cli/src/commands/serve-cli.ts
+++ b/packages/cli/src/commands/serve-cli.ts
@@ -21,6 +21,7 @@ export interface ServeHandlers {
 	serve: (opts: Record<string, unknown>) => Promise<void> | void;
 	serveInstall: (opts: Record<string, unknown>) => Promise<void> | void;
 	serveUninstall: (opts: Record<string, unknown>) => Promise<void> | void;
+	serveStop: (opts: Record<string, unknown>) => Promise<void> | void;
 	serveRestart: (opts: Record<string, unknown>) => Promise<void> | void;
 	serveStatus: (opts: Record<string, unknown>) => Promise<void> | void;
 	serveLogs: (opts: Record<string, unknown>) => Promise<void> | void;
@@ -47,6 +48,7 @@ async function defaultHandlers(): Promise<ServeHandlers> {
 		serve: m.serve,
 		serveInstall: m.serveInstall,
 		serveUninstall: m.serveUninstall,
+		serveStop: m.serveStop,
 		serveRestart: m.serveRestart,
 		serveStatus: m.serveStatus,
 		serveLogs: m.serveLogs,
@@ -130,6 +132,14 @@ Examples:
 		.action(async (_opts, cmd) => {
 			const h = await get();
 			await h.serveUninstall(cmd.optsWithGlobals());
+		});
+
+	serveCmd
+		.command("stop")
+		.description("Stop the singleton daemon while preserving its installed service unit")
+		.action(async (_opts, cmd) => {
+			const h = await get();
+			await h.serveStop(cmd.optsWithGlobals());
 		});
 
 	serveCmd

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -73,6 +73,7 @@ import {
 	readHealth,
 	restart as restartService,
 	statusLines as serviceStatusLines,
+	stop as stopService,
 	uninstall as uninstallService,
 } from "../serve/installer";
 import { log, toErrorMessage } from "../serve/log";
@@ -363,6 +364,7 @@ export async function serveInstall(opts: ServeInstallOpts): Promise<void> {
 
 const INSTALL_ALLOWED = new Set(["host", "port", "allowRemote"]);
 const UNINSTALL_ALLOWED = new Set<string>();
+const STOP_ALLOWED = new Set<string>();
 const STATUS_ALLOWED = new Set(["agent"]);
 const DOCTOR_ALLOWED = new Set(["json"]);
 const RPC_ALLOWED = new Set(["host", "port", "token"]);
@@ -386,6 +388,17 @@ export async function serveUninstall(opts: ServeInstallOpts): Promise<void> {
 	failed += cleanupLegacyDaemonUnits();
 	if (removed === 0 && failed === 0) console.log("No daemon units installed.");
 	if (failed > 0) process.exit(1);
+}
+
+export async function serveStop(opts: ServeInstallOpts): Promise<void> {
+	rejectUnsupportedOpts("stop", opts as Record<string, unknown>, STOP_ALLOWED);
+	try {
+		stopService();
+		console.log("✓ Stopped singleton daemon; service unit remains installed.");
+	} catch (e) {
+		console.error(`Stop failed: ${toErrorMessage(e)}`);
+		process.exit(1);
+	}
 }
 
 const RESTART_ALLOWED = new Set<string>();

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -60,7 +60,7 @@ export async function setup(opts: SetupOpts) {
 		process.exitCode = 1;
 		return;
 	}
-	const api = new ApiClient();
+	const api = new ApiClient({ machineId });
 
 	if (opts.agent) {
 		if (!AGENT_TYPES.includes(opts.agent as AgentType)) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1588,6 +1588,7 @@ agentCmd
 	.description("Recover a local Agent binding without creating a new cloud identity")
 	.option("--agent <type>", `Agent type (${AGENT_TYPE_HELP_LABEL})`)
 	.option("-y, --yes", "Skip confirmation when the target is unambiguous")
+	.option("--confirm-takeover", "Confirm disconnecting a recently active installation")
 	.option("--no-daemon", "Skip installing/starting background sync daemons")
 	.addHelpText(
 		"after",

--- a/packages/cli/src/lib/api-client.test.ts
+++ b/packages/cli/src/lib/api-client.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { ApiClient } from "./api-client";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
 
 describe("ApiClient.uploadSkill", () => {
 	it("rejects invalid skill_key before building a multipart request", async () => {
@@ -13,5 +19,36 @@ describe("ApiClient.uploadSkill", () => {
 				".system.tar.gz",
 			),
 		).rejects.toThrow('Invalid skill_key: ".system"');
+	});
+});
+
+describe("ApiClient machine fence", () => {
+	it("sends one normalized identity through generated and handwritten request paths", async () => {
+		const captured: Request[] = [];
+		globalThis.fetch = (async (request: Request) => {
+			captured.push(request.clone());
+			if (request.method === "DELETE") return new Response(null, { status: 204 });
+			if (new URL(request.url).pathname === "/bytes") return new Response("content");
+			return Response.json({ status: "ok" });
+		}) as typeof fetch;
+
+		const api = new ApiClient({ requireAuth: false, machineId: "  machine-1  " });
+		await api.GET("/health");
+		await api.uploadAgentSkill(
+			"agent-1",
+			"project-1",
+			"demo",
+			Buffer.from("archive"),
+			"demo.tar.gz",
+		);
+		await api.deleteAgentSkill("agent-1", "demo", "project-1");
+		await api.postJson<Record<string, unknown>>("/post");
+		await api.postJsonBody<Record<string, unknown>>("/post-body", { ok: true });
+		await api.getBytes("/bytes");
+
+		expect(captured).toHaveLength(6);
+		expect(
+			captured.every((request) => request.headers.get("X-Clawdi-Machine-Id") === "machine-1"),
+		).toBe(true);
 	});
 });

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -4,6 +4,7 @@ import createClient, { type Client } from "openapi-fetch";
 import { canonicalApiOrigin, normalizeCloudApiBaseUrl } from "./api-origin";
 import { assertCloudCredentialEndpoint, getClawdiAccessToken } from "./clerk-oauth";
 import { getAuth, getConfig } from "./config";
+import { readMachineId } from "./machine-identity";
 import { MAX_SAFE_RETRY_AFTER_MS, parseRetryAfter } from "./retry-after";
 import { assertValidSkillKey } from "./skill-key";
 import {
@@ -26,6 +27,17 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_RETRIES = 3;
 const RETRY_DELAYS_MS = [100, 400, 1600] as const;
 const USER_AGENT = `clawdi-cli/${getCliVersion()}`;
+const MACHINE_ID_HEADER = "X-Clawdi-Machine-Id";
+const MACHINE_ID_MAX_LENGTH = 200;
+
+function normalizedMachineId(value: string | undefined): string | undefined {
+	if (value === undefined) return undefined;
+	const machineId = value.trim();
+	if (!machineId || machineId.length > MACHINE_ID_MAX_LENGTH) {
+		throw new Error("Connected Agent machine identity is invalid.");
+	}
+	return machineId;
+}
 // Node-compatible timers cannot safely schedule a single delay above this
 // value. Longer Retry-After waits are split into chunks without changing the
 // server-requested REST delay.
@@ -266,6 +278,7 @@ export class ApiClient {
 	private readonly client: Client<paths>;
 	private readonly abortSignal: AbortSignal | undefined;
 	private readonly requireAuth: boolean;
+	private readonly machineId: string | undefined;
 
 	/**
 	 * @param opts.requireAuth — Default true. Set false for public bootstrap
@@ -277,7 +290,13 @@ export class ApiClient {
 	 *   immediately instead of running its own retry/timeout to
 	 *   completion.
 	 */
-	constructor(opts: { requireAuth?: boolean; abortSignal?: AbortSignal } = {}) {
+	constructor(
+		opts: {
+			requireAuth?: boolean;
+			abortSignal?: AbortSignal;
+			machineId?: string;
+		} = {},
+	) {
 		const requireAuth = opts.requireAuth ?? true;
 		const config = getConfig();
 		const auth = getAuth();
@@ -292,6 +311,10 @@ export class ApiClient {
 		this.baseUrl = baseUrl;
 		this.requireAuth = requireAuth;
 		this.abortSignal = opts.abortSignal;
+		this.machineId = normalizedMachineId(
+			opts.machineId ?? (requireAuth ? (readMachineId() ?? undefined) : undefined),
+		);
+		const machineId = this.machineId;
 		this.client = createClient<paths>({
 			baseUrl: this.baseUrl,
 			fetch: (req) => retryingFetch(req, DEFAULT_TIMEOUT_MS, this.abortSignal),
@@ -309,6 +332,7 @@ export class ApiClient {
 					request.headers.set("Authorization", `Bearer ${await getClawdiAccessToken(baseUrl)}`);
 				}
 				request.headers.set("User-Agent", USER_AGENT);
+				if (machineId) request.headers.set(MACHINE_ID_HEADER, machineId);
 				request.headers.set(SKILL_SYNC_PROTOCOL_HEADER, SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1);
 				// Generate a per-request correlation ID. Backend's
 				// RequestIDMiddleware accepts the header and echoes
@@ -431,6 +455,7 @@ export class ApiClient {
 				"User-Agent": USER_AGENT,
 				"X-Request-ID": randomUUID(),
 				[SKILL_SYNC_PROTOCOL_HEADER]: SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
+				...(this.machineId ? { [MACHINE_ID_HEADER]: this.machineId } : {}),
 			},
 		});
 		const res = await retryingFetch(req, DEFAULT_TIMEOUT_MS, this.abortSignal);
@@ -606,6 +631,7 @@ export class ApiClient {
 				"X-Request-ID": randomUUID(),
 				[SKILL_SYNC_PROTOCOL_HEADER]: SKILL_SYNC_PROTOCOL_AGENT_AUTHORITATIVE_V1,
 				...(extraHeaders ?? {}),
+				...(this.machineId ? { [MACHINE_ID_HEADER]: this.machineId } : {}),
 			};
 			const request = new Request(`${this.baseUrl}${path}`, {
 				method,
@@ -636,6 +662,7 @@ export class ApiClient {
 			headers: {
 				Authorization: `Bearer ${accessToken}`,
 				"X-Request-ID": randomUUID(),
+				...(this.machineId ? { [MACHINE_ID_HEADER]: this.machineId } : {}),
 			},
 		});
 		const res = await retryingFetch(req, DEFAULT_TIMEOUT_MS, this.abortSignal);
@@ -662,6 +689,7 @@ export class ApiClient {
 				Authorization: `Bearer ${accessToken}`,
 				"Content-Type": "application/json",
 				"X-Request-ID": randomUUID(),
+				...(this.machineId ? { [MACHINE_ID_HEADER]: this.machineId } : {}),
 			},
 			body: JSON.stringify(body),
 		});
@@ -679,6 +707,7 @@ export class ApiClient {
 			headers: {
 				Authorization: `Bearer ${accessToken}`,
 				...(extraHeaders ?? {}),
+				...(this.machineId ? { [MACHINE_ID_HEADER]: this.machineId } : {}),
 			},
 		});
 		const res = await retryingFetch(req, DEFAULT_TIMEOUT_MS, this.abortSignal);

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -1,8 +1,7 @@
-import { existsSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { normalizeCloudApiBaseUrl, normalizeHostedDeployApiBaseUrl } from "./api-origin";
-import { withPrivateDirectoryLockSync } from "./private-directory-lock";
 import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "./private-file";
 
 // NOTE: these paths are computed lazily so tests can override HOME per-run
@@ -217,36 +216,10 @@ export function setAuth(auth: ClawdiAuth) {
 }
 
 export function clearAuth() {
-	const ownerUserId = getStoredAuth()?.userId?.trim();
-	if (ownerUserId) bindCachedEnvironmentsToUser(ownerUserId);
 	const p = authFile();
 	if (existsSync(p)) {
 		unlinkSync(p);
 	}
-}
-
-function bindCachedEnvironmentsToUser(userId: string): void {
-	const envDir = join(clawdiDir(), "environments");
-	if (!existsSync(envDir)) return;
-	withPrivateDirectoryLockSync(join(clawdiDir(), "environments.lock"), (lease) => {
-		for (const fileName of readdirSync(envDir)) {
-			if (!fileName.endsWith(".json")) continue;
-			const path = join(envDir, fileName);
-			const value = readRecoverablePrivateJson<unknown>(path);
-			if (typeof value !== "object" || value === null || Array.isArray(value)) continue;
-			const registration = value as Record<string, unknown>;
-			if (typeof registration.id !== "string" || typeof registration.agentType !== "string") {
-				continue;
-			}
-			if (typeof registration.userId === "string") continue;
-			lease.assertOwned();
-			writePrivateFileAtomic(path, `${JSON.stringify({ ...registration, userId }, null, 2)}\n`, {
-				mode: PRIVATE_FILE_MODE,
-				dirMode: PRIVATE_DIR_MODE,
-				durable: true,
-			});
-		}
-	});
 }
 
 export function isLoggedIn(): boolean {

--- a/packages/cli/src/lib/environment-registration.test.ts
+++ b/packages/cli/src/lib/environment-registration.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setAuth } from "./config";
+import { readEnvironmentRegistration } from "./environment-registration";
+
+const originalClawdiHome = process.env.CLAWDI_HOME;
+const roots: string[] = [];
+
+afterEach(() => {
+	if (originalClawdiHome === undefined) delete process.env.CLAWDI_HOME;
+	else process.env.CLAWDI_HOME = originalClawdiHome;
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("environment registration account binding", () => {
+	it("keeps a legacy registration readable until online ownership inspection", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-registration-account-"));
+		roots.push(root);
+		process.env.CLAWDI_HOME = root;
+		mkdirSync(join(root, "environments"), { recursive: true });
+		writeFileSync(
+			join(root, "environments", "codex.json"),
+			JSON.stringify({ id: "agent-a", agentType: "codex", machineId: "machine-a" }),
+		);
+		setAuth({ apiKey: "account-b-key", userId: "account-b" });
+
+		expect(readEnvironmentRegistration("codex")).toMatchObject({ id: "agent-a" });
+	});
+
+	it("does not adopt a registration explicitly bound to another account", () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-registration-account-"));
+		roots.push(root);
+		process.env.CLAWDI_HOME = root;
+		mkdirSync(join(root, "environments"), { recursive: true });
+		writeFileSync(
+			join(root, "environments", "codex.json"),
+			JSON.stringify({ id: "agent-a", agentType: "codex", userId: "account-a" }),
+		);
+		setAuth({ apiKey: "account-b-key", userId: "account-b" });
+
+		expect(readEnvironmentRegistration("codex")).toBeNull();
+	});
+});

--- a/packages/cli/src/lib/environment-registration.ts
+++ b/packages/cli/src/lib/environment-registration.ts
@@ -1,15 +1,90 @@
 import { join } from "node:path";
 import type { AgentType } from "../adapters/registry";
-import { getClawdiDir } from "./config";
+import { getAuth, getClawdiDir, readRecoverablePrivateJson } from "./config";
 import { withPrivateDirectoryLockSync } from "./private-directory-lock";
 import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "./private-file";
 
-interface EnvironmentRegistration {
+export interface EnvironmentRegistration {
 	id: string;
 	agentType: AgentType;
 	machineId: string;
 	machineName: string;
 	userId?: string;
+}
+
+export interface StoredEnvironmentRegistration {
+	id: string;
+	agentType: AgentType;
+	machineId?: string;
+	machineName?: string;
+	userId?: string;
+}
+
+export function readEnvironmentRegistration(
+	agentType: string,
+): StoredEnvironmentRegistration | null {
+	const value = readRecoverablePrivateJson<unknown>(environmentRegistrationPath(agentType));
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+	const record = value as Record<string, unknown>;
+	if (
+		typeof record.id !== "string" ||
+		!record.id.trim() ||
+		(record.agentType !== undefined && record.agentType !== agentType) ||
+		(record.machineId !== undefined &&
+			(typeof record.machineId !== "string" || !record.machineId.trim())) ||
+		(record.machineName !== undefined && typeof record.machineName !== "string") ||
+		(record.userId !== undefined &&
+			(typeof record.userId !== "string" ||
+				!record.userId.trim() ||
+				record.userId !== record.userId.trim()))
+	) {
+		return null;
+	}
+	const currentUserId = getAuth()?.userId?.trim();
+	if (typeof record.userId === "string" && record.userId !== currentUserId) return null;
+	return {
+		id: record.id,
+		agentType: agentType as AgentType,
+		...(typeof record.machineId === "string" ? { machineId: record.machineId } : {}),
+		...(typeof record.machineName === "string" ? { machineName: record.machineName } : {}),
+		...(typeof record.userId === "string" ? { userId: record.userId } : {}),
+	};
+}
+
+export function bindEnvironmentRegistrationUser(
+	agentType: AgentType,
+	environmentId: string,
+	userId: string,
+): boolean {
+	const normalizedUserId = userId.trim();
+	if (!normalizedUserId) throw new Error("Cannot bind an Agent registration without a user id.");
+	const clawdiDir = getClawdiDir();
+	return withPrivateDirectoryLockSync(join(clawdiDir, "environments.lock"), (lease) => {
+		const path = environmentRegistrationPath(agentType);
+		const value = readRecoverablePrivateJson<unknown>(path);
+		if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+		const registration = value as Record<string, unknown>;
+		if (
+			registration.id !== environmentId ||
+			(registration.agentType !== undefined && registration.agentType !== agentType)
+		) {
+			return false;
+		}
+		if (registration.userId !== undefined) {
+			return registration.userId === normalizedUserId;
+		}
+		lease.assertOwned();
+		writePrivateFileAtomic(
+			path,
+			`${JSON.stringify({ ...registration, userId: normalizedUserId }, null, 2)}\n`,
+			{
+				mode: PRIVATE_FILE_MODE,
+				dirMode: PRIVATE_DIR_MODE,
+				durable: true,
+			},
+		);
+		return true;
+	});
 }
 
 export function writeEnvironmentRegistration(registration: EnvironmentRegistration): void {
@@ -23,4 +98,8 @@ export function writeEnvironmentRegistration(registration: EnvironmentRegistrati
 			durable: true,
 		});
 	});
+}
+
+function environmentRegistrationPath(agentType: string): string {
+	return join(getClawdiDir(), "environments", `${agentType}.json`);
 }

--- a/packages/cli/src/lib/machine-identity.ts
+++ b/packages/cli/src/lib/machine-identity.ts
@@ -38,6 +38,11 @@ export function getOrCreateMachineId(): string {
 	});
 }
 
+/** Read the durable installation identity without creating or repairing it. */
+export function readMachineId(): string | null {
+	return readMachineIdentity(join(getClawdiDir(), "machine.json"))?.id ?? null;
+}
+
 function readMachineIdentity(path: string): MachineIdentity | null {
 	if (!existsSync(path)) return null;
 	try {

--- a/packages/cli/src/lib/select-adapter.ts
+++ b/packages/cli/src/lib/select-adapter.ts
@@ -9,42 +9,13 @@ import {
 	getAdapterEntry,
 } from "../adapters/registry";
 import { readJson } from "./api-client";
-import { getAuth, getClawdiDir, readRecoverablePrivateJson } from "./config";
-
-interface LocalEnvironmentRegistration {
-	id: string;
-	userId?: string;
-}
-
-function readEnvironmentRegistration(
-	agentType: string,
-	currentUserId: string | undefined,
-): LocalEnvironmentRegistration | null {
-	const envPath = join(getClawdiDir(), "environments", `${agentType}.json`);
-	const value = readRecoverablePrivateJson<unknown>(envPath);
-	if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
-	const record = value as Record<string, unknown>;
-	if (typeof record.id !== "string" || !record.id.trim()) return null;
-	if (record.agentType !== undefined && record.agentType !== agentType) return null;
-	if (
-		record.userId !== undefined &&
-		(typeof record.userId !== "string" ||
-			!record.userId.trim() ||
-			record.userId !== record.userId.trim())
-	) {
-		return null;
-	}
-	if (record.userId && (!currentUserId || record.userId !== currentUserId)) return null;
-	return {
-		id: record.id,
-		...(typeof record.userId === "string" ? { userId: record.userId } : {}),
-	};
-}
+import { getAuth, getClawdiDir } from "./config";
+import { readEnvironmentRegistration } from "./environment-registration";
 
 export function getEnvIdByAgent(agentType: string): string | null {
 	const auth = getAuth();
 	if (!auth) return null;
-	return readEnvironmentRegistration(agentType, auth.userId?.trim())?.id ?? null;
+	return readEnvironmentRegistration(agentType)?.id ?? null;
 }
 
 /** Ask the cloud which project this caller's next write would land
@@ -128,9 +99,8 @@ export function listRegisteredAgentTypes(): AgentType[] {
 	if (!existsSync(envDir)) return [];
 	const auth = getAuth();
 	if (!auth) return [];
-	const currentUserId = auth.userId?.trim();
 	return allAdapterEntries()
-		.filter((entry) => readEnvironmentRegistration(entry.agentType, currentUserId) !== null)
+		.filter((entry) => readEnvironmentRegistration(entry.agentType) !== null)
 		.map((entry) => entry.agentType);
 }
 

--- a/packages/cli/src/serve/installer.test.ts
+++ b/packages/cli/src/serve/installer.test.ts
@@ -258,6 +258,35 @@ describe("installer.install (macOS plist)", () => {
 });
 
 describe("installer.install (Linux systemd)", () => {
+	it("stops without removing the unit and restart cold-starts it", async () => {
+		const os = await import("node:os");
+		if (os.platform() !== "linux") return;
+
+		const stubBin = join(process.env.HOME ?? tmp, "stub-bin");
+		mkdirSync(stubBin, { recursive: true });
+		const calls = join(process.env.HOME ?? tmp, "systemctl-calls");
+		const stubSystemctl = join(stubBin, "systemctl");
+		writeFileSync(stubSystemctl, `#!/bin/sh\nprintf '%s\\n' "$*" >> "${calls}"\nexit 0\n`, {
+			mode: 0o755,
+		});
+		chmodSync(stubSystemctl, 0o755);
+		const oldPath = process.env.PATH;
+		process.env.PATH = `${stubBin}:${oldPath}`;
+
+		try {
+			const { install, restart, stop } = await import("./installer");
+			const installed = install();
+			stop();
+			expect(existsSync(installed.unit)).toBe(true);
+			restart();
+			const commands = readFileSync(calls, "utf8").trim().split("\n");
+			expect(commands).toContain("--user stop clawdi-serve.service");
+			expect(commands).toContain("--user restart clawdi-serve.service");
+		} finally {
+			process.env.PATH = oldPath;
+		}
+	});
+
 	it("captures RPC host, port, and remote opt-in into the unit Environment", async () => {
 		const os = await import("node:os");
 		if (os.platform() !== "linux") return;

--- a/packages/cli/src/serve/installer.ts
+++ b/packages/cli/src/serve/installer.ts
@@ -252,6 +252,18 @@ export function restart(opts: InstallOpts = {}): void {
 	}
 }
 
+/** Stop an installed daemon without removing or disabling its supervisor unit. */
+export function stop(opts: InstallOpts = {}): void {
+	const p = platform();
+	if (p === "darwin") {
+		stopLaunchd(opts);
+	} else if (p === "linux") {
+		stopSystemd(opts);
+	} else {
+		throw new Error(`unsupported platform for service stop: ${p}`);
+	}
+}
+
 function restartLaunchd(opts: InstallOpts): void {
 	const path = opts.agent ? plistPath(opts.agent) : singletonPlistPath();
 	if (!existsSync(path)) {
@@ -406,7 +418,6 @@ ${programArgs}
 function uninstallLaunchd(opts: InstallOpts): { removed: boolean } {
 	const path = opts.agent ? plistPath(opts.agent) : singletonPlistPath();
 	if (!existsSync(path)) return { removed: false };
-	const label = opts.agent ? legacyUnitName(opts.agent) : unitName();
 	// Stop the daemon BEFORE removing the plist. Pre-fix this used a
 	// bare `tryRun(["launchctl", "unload", path])` and ignored the
 	// return code, then `unlinkSync(path)` regardless — so a
@@ -419,23 +430,26 @@ function uninstallLaunchd(opts: InstallOpts): { removed: boolean } {
 	//     ~/Library/LaunchAgents.
 	//   - `launchctl bootout gui/<uid>/<label>`: modern (10.10+),
 	//     works regardless of whether the plist file still exists.
-	// Try unload first; fall back to bootout. Only proceed to
+	// Try bootout first; fall back to the legacy unload form. Only proceed to
 	// unlink the plist after we've confirmed the daemon is stopped
 	// (or was never loaded in the first place).
-	const wasLoaded = tryRunCapture(["launchctl", "list", label]) !== null;
-	if (wasLoaded) {
-		const stopped =
-			tryRun(["launchctl", "unload", path]) ||
-			tryRun(["launchctl", "bootout", `gui/${process.getuid?.() ?? 501}/${label}`]);
-		if (!stopped) {
-			throw new Error(
-				`Failed to stop running daemon ${label}. Try manually: ` +
-					`launchctl bootout gui/$(id -u)/${label} && rm "${path}"`,
-			);
-		}
-	}
+	stopLaunchd(opts);
 	unlinkSync(path);
 	return { removed: true };
+}
+
+function stopLaunchd(opts: InstallOpts): void {
+	const path = opts.agent ? plistPath(opts.agent) : singletonPlistPath();
+	if (!existsSync(path)) {
+		throw new Error("no daemon unit installed (run `clawdi daemon install` first)");
+	}
+	const label = opts.agent ? legacyUnitName(opts.agent) : unitName();
+	if (tryRunCapture(["launchctl", "list", label]) === null) return;
+	const target = `gui/${process.getuid?.() ?? 501}/${label}`;
+	if (tryRun(["launchctl", "bootout", target]) || tryRun(["launchctl", "unload", path])) return;
+	throw new Error(
+		`Failed to stop running daemon ${label}. Try manually: launchctl bootout gui/$(id -u)/${label}`,
+	);
 }
 
 function statusLaunchd(opts: InstallOpts): string[] {
@@ -582,10 +596,27 @@ WantedBy=default.target
 function uninstallSystemd(opts: InstallOpts): { removed: boolean } {
 	const path = unitPath(opts.agent);
 	if (!existsSync(path)) return { removed: false };
-	tryRun(["systemctl", "--user", "disable", "--now", unitFileName(opts.agent)]);
+	stopSystemd(opts);
+	if (!tryRun(["systemctl", "--user", "disable", unitFileName(opts.agent)])) {
+		throw new Error(`systemctl --user disable ${unitFileName(opts.agent)} failed.`);
+	}
 	unlinkSync(path);
 	tryRun(["systemctl", "--user", "daemon-reload"]);
 	return { removed: true };
+}
+
+function stopSystemd(opts: InstallOpts): void {
+	const path = unitPath(opts.agent);
+	const unit = unitFileName(opts.agent);
+	if (!existsSync(path)) {
+		throw new Error("no daemon unit installed (run `clawdi daemon install` first)");
+	}
+	if (!tryRun(["systemctl", "--user", "stop", unit])) {
+		throw new Error(
+			`systemctl --user stop ${unit} failed. ` +
+				`Check \`systemctl --user status ${unit}\` for details.`,
+		);
+	}
 }
 
 function statusSystemd(opts: InstallOpts): string[] {

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -14,6 +14,7 @@ import { dirname, join } from "node:path";
 import type { AgentAdapter, RawSession, SkillModule } from "../adapters/base";
 import { adapterRegistry } from "../adapters/registry";
 import { AgentSkillSyncNotFoundError, ApiClient, ApiError } from "../lib/api-client";
+import { setAuth } from "../lib/config";
 import { planSessionUpload, sessionFence } from "../lib/session-upload";
 import {
 	persistFencedSessionEntry,
@@ -36,6 +37,7 @@ import {
 	enqueueChangedSessionsAfterStability,
 	filterValidSkillKeysForSync,
 	heartbeatDelayMs,
+	heartbeatLoop,
 	isAuthFailure,
 	isOversizedUploadError,
 	isPermanentUploadError,
@@ -52,6 +54,7 @@ import {
 	SyncHealth,
 	skillInvalidationKey,
 	staleSkillProjectionProjectIds,
+	stopForDisconnectedAgent,
 } from "./sync-engine";
 
 function queueModules(adapter: AgentAdapter, projectId = "project-1") {
@@ -1319,6 +1322,9 @@ describe("Pi sessions-only daemon", () => {
 				const request = input instanceof Request ? input : new Request(input, init);
 				requests.push(request.clone());
 				const path = new URL(request.url).pathname;
+				if (path === "/v1/agents/agent-pi") {
+					return Response.json({ id: "agent-pi", default_project_id: "project-1" });
+				}
 				if (path === "/v1/sessions/upload-capabilities") {
 					return new Response('{"detail":"Not found"}', { status: 404 });
 				}
@@ -1361,7 +1367,7 @@ describe("Pi sessions-only daemon", () => {
 
 			const paths = requests.map((request) => new URL(request.url).pathname);
 			expect(paths).toContain("/v1/sessions/pi.fixture-session/upload");
-			expect(paths).not.toContain("/v1/agents/agent-pi");
+			expect(paths).toContain("/v1/agents/agent-pi");
 			expect(paths).not.toContain("/v1/sync/events");
 			expect(paths.some((path) => path.includes("/skills"))).toBe(false);
 		} finally {
@@ -1430,6 +1436,7 @@ describe("daemon startup Agent lookup", () => {
 			abortController: AbortController;
 			requests: Request[];
 			logs: string[];
+			root: string;
 		}) => Promise<void>,
 	): Promise<void> {
 		const root = mkdtempSync(join(tmpdir(), "clawdi-daemon-startup-"));
@@ -1459,7 +1466,7 @@ describe("daemon startup Agent lookup", () => {
 				logs.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
 				return true;
 			}) as typeof process.stderr.write;
-			await run({ abortController: new AbortController(), requests, logs });
+			await run({ abortController: new AbortController(), requests, logs, root });
 		} finally {
 			globalThis.fetch = originalFetch;
 			process.stderr.write = originalStderrWrite;
@@ -1477,6 +1484,125 @@ describe("daemon startup Agent lookup", () => {
 			rmSync(root, { recursive: true, force: true });
 		}
 	}
+
+	it("backfills a legacy registration only after the owning Agent lookup succeeds", async () => {
+		await withStartupCase(
+			async () => Response.json({ id: "agent-owned", default_project_id: "project-1" }),
+			async ({ abortController, requests, root }) => {
+				delete process.env.CLAWDI_AUTH_TOKEN;
+				delete process.env.CLAWDI_AUTH_TOKEN_ORIGIN;
+				setAuth({
+					apiKey: "account-a-key",
+					userId: "account-a",
+					endpointBinding: { version: 1, cloudApiOrigin: "https://cloud.example.test" },
+				});
+				const environmentsDir = join(root, "home", "environments");
+				mkdirSync(environmentsDir, { recursive: true });
+				const registrationPath = join(environmentsDir, "codex.json");
+				writeFileSync(
+					registrationPath,
+					`${JSON.stringify({ id: "agent-owned", agentType: "codex", machineId: "machine-a" })}\n`,
+				);
+				globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+					const request = input instanceof Request ? input : new Request(input, init);
+					requests.push(request);
+					abortController.abort();
+					return Response.json({ id: "agent-owned", default_project_id: "project-1" });
+				}) as typeof fetch;
+
+				await runSyncEngine({
+					environmentId: "agent-owned",
+					adapter: adapterRegistry.codex.create(),
+					abort: abortController.signal,
+					abortController,
+					forcePollWatcher: true,
+				});
+
+				expect(requests).toHaveLength(1);
+				expect(new URL(requests[0].url).pathname).toBe("/v1/agents/agent-owned");
+				expect(JSON.parse(readFileSync(registrationPath, "utf8"))).toMatchObject({
+					id: "agent-owned",
+					userId: "account-a",
+				});
+			},
+		);
+	});
+
+	it("self-stops when a legacy registration changes during ownership backfill", async () => {
+		await withStartupCase(
+			async () => Response.json({ id: "agent-old", default_project_id: "project-1" }),
+			async ({ abortController, requests, logs, root }) => {
+				delete process.env.CLAWDI_AUTH_TOKEN;
+				delete process.env.CLAWDI_AUTH_TOKEN_ORIGIN;
+				setAuth({
+					apiKey: "account-a-key",
+					userId: "account-a",
+					endpointBinding: { version: 1, cloudApiOrigin: "https://cloud.example.test" },
+				});
+				const environmentsDir = join(root, "home", "environments");
+				mkdirSync(environmentsDir, { recursive: true });
+				const registrationPath = join(environmentsDir, "codex.json");
+				writeFileSync(
+					registrationPath,
+					`${JSON.stringify({ id: "agent-old", agentType: "codex", machineId: "machine-a" })}\n`,
+				);
+				globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+					const request = input instanceof Request ? input : new Request(input, init);
+					requests.push(request);
+					writeFileSync(
+						registrationPath,
+						`${JSON.stringify({ id: "agent-new", agentType: "codex", machineId: "machine-a" })}\n`,
+					);
+					return Response.json({ id: "agent-old", default_project_id: "project-1" });
+				}) as typeof fetch;
+
+				await runSyncEngine({
+					environmentId: "agent-old",
+					adapter: adapterRegistry.codex.create(),
+					abort: abortController.signal,
+					abortController,
+					forcePollWatcher: true,
+				});
+
+				expect(requests).toHaveLength(1);
+				const registration = JSON.parse(readFileSync(registrationPath, "utf8"));
+				expect(registration).toMatchObject({ id: "agent-new" });
+				expect(Object.hasOwn(registration, "userId")).toBe(false);
+				expect(process.exitCode).toBe(2);
+				expect(abortController.signal.aborted).toBe(true);
+				expect(logs.join("")).toContain('"event":"engine.agent_disconnected"');
+				expect(logs.join("")).toContain("registration changed");
+			},
+		);
+	});
+
+	it("self-stops a stale engine whose local registration points at another Agent", async () => {
+		await withStartupCase(
+			async () => Response.json({ id: "agent-old", default_project_id: "project-1" }),
+			async ({ abortController, requests, logs, root }) => {
+				const environmentsDir = join(root, "home", "environments");
+				mkdirSync(environmentsDir, { recursive: true });
+				writeFileSync(
+					join(environmentsDir, "codex.json"),
+					`${JSON.stringify({ id: "agent-new", agentType: "codex", machineId: "machine-a" })}\n`,
+				);
+
+				await runSyncEngine({
+					environmentId: "agent-old",
+					adapter: adapterRegistry.codex.create(),
+					abort: abortController.signal,
+					abortController,
+					forcePollWatcher: true,
+				});
+
+				expect(requests).toHaveLength(1);
+				expect(new URL(requests[0].url).pathname).toBe("/v1/agents/agent-old");
+				expect(process.exitCode).toBe(2);
+				expect(abortController.signal.aborted).toBe(true);
+				expect(logs.join("")).toContain("registration changed");
+			},
+		);
+	});
 
 	it("maps the stable archived-Agent 403 to disconnected guidance and a no-restart stop", async () => {
 		await withStartupCase(
@@ -1506,10 +1632,53 @@ describe("daemon startup Agent lookup", () => {
 		);
 	});
 
+	it("maps a heartbeat agent_rebound to the disconnected self-stop path", async () => {
+		await withStartupCase(
+			async () =>
+				new Response('{"detail":{"code":"agent_rebound","message":"Agent moved"}}', {
+					status: 403,
+					headers: { "content-type": "application/json" },
+				}),
+			async ({ abortController, logs, requests }) => {
+				const opts = {
+					environmentId: "agent-rebound",
+					adapter: adapterRegistry.pi.create(),
+					abort: abortController.signal,
+					abortController,
+					forcePollWatcher: true,
+				};
+				await heartbeatLoop(
+					opts,
+					new ApiClient({ requireAuth: false, abortSignal: abortController.signal }),
+					new RetryQueue({ agentType: "pi" }),
+					abortController.signal,
+					() => ({ last_revision_seen: null, last_sync_error: null }),
+					(hint) => stopForDisconnectedAgent(opts, hint),
+				);
+
+				expect(requests).toHaveLength(1);
+				expect(new URL(requests[0].url).pathname).toBe("/v1/agents/agent-rebound/sync-heartbeat");
+				expect(process.exitCode).toBe(2);
+				expect(abortController.signal.aborted).toBe(true);
+				expect(logs.join("")).toContain('"event":"engine.agent_disconnected"');
+				expect(logs.join("")).not.toContain('"event":"engine.auth_failed"');
+			},
+		);
+	});
+
 	it("keeps an ambiguous 404 on a safe legacy-compatible stop path", async () => {
 		await withStartupCase(
 			async () => new Response('{"detail":"Agent not found"}', { status: 404 }),
-			async ({ abortController, requests, logs }) => {
+			async ({ abortController, requests, logs, root }) => {
+				const environmentsDir = join(root, "home", "environments");
+				mkdirSync(environmentsDir, { recursive: true });
+				const registrationPath = join(environmentsDir, "hermes.json");
+				const registration = `${JSON.stringify({
+					id: "agent-disconnected",
+					agentType: "hermes",
+					machineId: "machine-old",
+				})}\n`;
+				writeFileSync(registrationPath, registration);
 				await runSyncEngine({
 					environmentId: "agent-disconnected",
 					adapter: adapterRegistry.hermes.create(),
@@ -1520,6 +1689,7 @@ describe("daemon startup Agent lookup", () => {
 
 				expect(requests).toHaveLength(1);
 				expect(new URL(requests[0].url).pathname).toBe("/v1/agents/agent-disconnected");
+				expect(readFileSync(registrationPath, "utf8")).toBe(registration);
 				expect(process.exitCode).toBe(2);
 				expect(abortController.signal.aborted).toBe(true);
 				expect(logs.join("")).toContain('"level":"info","event":"engine.agent_disconnected"');

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -48,6 +48,11 @@ import type {
 import { scanSessionModule } from "../adapters/base";
 import { AgentSkillSyncNotFoundError, ApiClient, ApiError, unwrap } from "../lib/api-client";
 import { canonicalApiOrigin } from "../lib/api-origin";
+import { getAuth } from "../lib/config";
+import {
+	bindEnvironmentRegistrationUser,
+	readEnvironmentRegistration,
+} from "../lib/environment-registration";
 import { computeLastActivityIso } from "../lib/session-activity";
 import {
 	negotiateSessionProtocol,
@@ -108,7 +113,7 @@ export function isSkillSyncServerEvent(event: ServerEvent): event is SkillServer
 	);
 }
 
-const AGENT_DISCONNECTED_ERROR_CODE = "agent_disconnected";
+const AGENT_DISCONNECTED_ERROR_CODES = new Set(["agent_disconnected", "agent_rebound"]);
 
 function agentLookupStopHint(error: unknown): string | null {
 	if (!(error instanceof ApiError)) return null;
@@ -127,7 +132,8 @@ function agentLookupStopHint(error: unknown): string | null {
 			typeof detail === "object" &&
 			detail !== null &&
 			"code" in detail &&
-			detail.code === AGENT_DISCONNECTED_ERROR_CODE;
+			typeof detail.code === "string" &&
+			AGENT_DISCONNECTED_ERROR_CODES.has(detail.code);
 		return disconnected
 			? "This installation is disconnected. Run clawdi setup to reconnect it with retained data."
 			: null;
@@ -335,7 +341,7 @@ export async function enqueueChangedSessionsAfterStability(
 	return { enqueued, confirmedSourceRevisions };
 }
 
-interface EngineOpts {
+export interface EngineOpts {
 	environmentId: string;
 	adapter: AgentAdapter;
 	abort: AbortSignal;
@@ -347,6 +353,16 @@ interface EngineOpts {
 	/** Force the watcher into poll mode. Set by serve.ts based on
 	 * CLAWDI_SERVE_MODE=container. */
 	forcePollWatcher?: boolean;
+}
+
+export function stopForDisconnectedAgent(opts: EngineOpts, hint: string): void {
+	log.info("engine.agent_disconnected", {
+		environment_id: opts.environmentId,
+		hint,
+	});
+	process.exitCode = 2;
+	removeLaunchdDaemonSupervision(opts.adapter.agentType);
+	opts.abortController.abort();
 }
 
 export async function runSyncEngine(opts: EngineOpts): Promise<void> {
@@ -379,15 +395,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 	});
 
 	let lastSeenRevision: number | null = null;
-	const stopForDisconnectedAgent = (hint: string): void => {
-		log.info("engine.agent_disconnected", {
-			environment_id: opts.environmentId,
-			hint,
-		});
-		process.exitCode = 2;
-		removeLaunchdDaemonSupervision(opts.adapter.agentType);
-		opts.abortController.abort();
-	};
+	const stopDisconnectedAgent = (hint: string): void => stopForDisconnectedAgent(opts, hint);
 
 	let authFailureFired = false;
 	const triggerAuthFailureAbort = (origin: string): void => {
@@ -412,20 +420,75 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 		removeLaunchdDaemonSupervision(opts.adapter.agentType);
 		opts.abortController.abort();
 	};
+	const handleStartupFailure = (error: unknown, origin: string): boolean => {
+		const stopHint = agentLookupStopHint(error);
+		if (stopHint !== null) {
+			stopDisconnectedAgent(stopHint);
+			return true;
+		}
+		if (!isAuthFailure(error)) return false;
+		log.error("engine.auth_failed", { origin });
+		process.exitCode = 2;
+		removeLaunchdDaemonSupervision(opts.adapter.agentType);
+		opts.abortController.abort();
+		return true;
+	};
+
+	const registration = readEnvironmentRegistration(opts.adapter.agentType);
+	let agentIdentity: components["schemas"]["AgentResponse"];
+	try {
+		agentIdentity = unwrap(
+			await api.GET("/v1/agents/{agent_id}", {
+				params: { path: { agent_id: opts.environmentId } },
+			}),
+		);
+	} catch (error) {
+		if (handleStartupFailure(error, "boot_agent_fetch")) return;
+		throw error;
+	}
+	if (registration && registration.id !== opts.environmentId) {
+		stopDisconnectedAgent(
+			"The local Agent registration changed while background sync was starting. Restart Clawdi after the current setup finishes.",
+		);
+		return;
+	}
+	const userId = getAuth()?.userId;
+	if (registration?.id === opts.environmentId && !registration.userId && userId) {
+		const bound = bindEnvironmentRegistrationUser(
+			opts.adapter.agentType,
+			opts.environmentId,
+			userId,
+		);
+		if (!bound) {
+			stopDisconnectedAgent(
+				"The local Agent registration changed while background sync was starting. Restart Clawdi after the current setup finishes.",
+			);
+			return;
+		}
+	}
+	if (opts.abort.aborted) return;
 
 	const common: CommonSyncRuntime = {
 		api,
 		queue,
 		health,
 		inFlightSessionHash,
-		stopForDisconnectedAgent,
+		stopForDisconnectedAgent: stopDisconnectedAgent,
 		triggerAuthFailureAbort,
+		initialDefaultProjectId: agentIdentity.default_project_id,
 		setLastSeenRevision: (revision) => {
 			lastSeenRevision = revision;
 		},
 	};
-	const sessionSync = sessions ? await prepareSessionSync(opts, sessions, common) : null;
-	const skillSync = skills ? await prepareSkillSync(opts, skills, common) : null;
+	let sessionSync: PreparedSessionSync | null;
+	let skillSync: PreparedSkillSync | null;
+	try {
+		sessionSync = sessions ? await prepareSessionSync(opts, sessions, common) : null;
+		skillSync = skills ? await prepareSkillSync(opts, skills, common) : null;
+	} catch (error) {
+		if (handleStartupFailure(error, "boot_sync_prepare")) return;
+		throw error;
+	}
 	if (opts.abort.aborted) return;
 	const moduleTasks: Promise<void>[] = [];
 	if (sessions && sessionSync) moduleTasks.push(runSessionSync(opts, sessions, sessionSync));
@@ -447,10 +510,17 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			health,
 			triggerAuthFailureAbort,
 		),
-		heartbeatLoop(opts, api, queue, opts.abort, () => ({
-			last_revision_seen: lastSeenRevision,
-			last_sync_error: health.project(),
-		})),
+		heartbeatLoop(
+			opts,
+			api,
+			queue,
+			opts.abort,
+			() => ({
+				last_revision_seen: lastSeenRevision,
+				last_sync_error: health.project(),
+			}),
+			stopDisconnectedAgent,
+		),
 	]);
 	log.info("engine.stop", {});
 }
@@ -462,6 +532,7 @@ interface CommonSyncRuntime {
 	inFlightSessionHash: Map<string, string>;
 	stopForDisconnectedAgent(hint: string): void;
 	triggerAuthFailureAbort(origin: string): void;
+	initialDefaultProjectId: string;
 	setLastSeenRevision(revision: number | null): void;
 }
 
@@ -483,7 +554,7 @@ async function prepareSkillSync(
 		api,
 		queue,
 		health: syncHealth,
-		stopForDisconnectedAgent,
+		stopForDisconnectedAgent: stopDisconnectedAgent,
 		triggerAuthFailureAbort,
 	} = common;
 
@@ -516,41 +587,7 @@ async function prepareSkillSync(
 		}
 		return projectId;
 	};
-	// Boot-time auth-failure handling: `fetchDefaultProjectId()`
-	// throws ApiError on 401/403 if the daemon was started with a
-	// revoked / forbidden key. Pre-fix this bubbled up as a
-	// generic fatal — `serve()` set process.exitCode=1, which
-	// systemd's `RestartPreventExitStatus=2` doesn't suppress, so
-	// the daemon respawned every 10s in a tight loop with no
-	// auth_revoked heartbeat for the dashboard to surface. Exit
-	// with code 2 so systemd stops respawning + log the canonical
-	// `engine.auth_failed` event so /api/health and operators see
-	// a clean reason. (No best-effort heartbeat from this point
-	// because the daemon hasn't established its project/queue state
-	// yet — there's nothing meaningful to report beyond "auth dead
-	// at boot".)
-	let defaultProjectId: string;
-	try {
-		defaultProjectId = await fetchDefaultProjectId();
-	} catch (e) {
-		const stopHint = agentLookupStopHint(e);
-		if (stopHint !== null) {
-			stopForDisconnectedAgent(stopHint);
-			return null;
-		}
-		if (isAuthFailure(e)) {
-			log.error("engine.auth_failed", { origin: "boot_project_fetch" });
-			process.exitCode = 2;
-			// Same launchd self-unload as the main auth-failure
-			// handler below — boot-time auth failure also needs
-			// supervision removal on macOS or launchd respawns
-			// the daemon every 10s.
-			removeLaunchdDaemonSupervision(opts.adapter.agentType);
-			opts.abortController.abort();
-			return null;
-		}
-		throw e;
-	}
+	let defaultProjectId = common.initialDefaultProjectId;
 	log.info("engine.project_resolved", { default_project_id: defaultProjectId });
 	for (const [skillKey, hash] of readSkillProjectionState(
 		opts.adapter.agentType,
@@ -663,7 +700,7 @@ async function prepareSkillSync(
 			} catch (e) {
 				const stopHint = agentLookupStopHint(e);
 				if (stopHint !== null) {
-					stopForDisconnectedAgent(stopHint);
+					stopDisconnectedAgent(stopHint);
 					return;
 				}
 				if (isAuthFailure(e)) {
@@ -2383,12 +2420,13 @@ function isReservedSkill(skills: SkillModule, skillKey: string): boolean {
  * "last seen" / "daemon offline" indicators — a daemon that
  * just started must show up as online within seconds, not
  * after the first 30s sleep elapses. */
-async function heartbeatLoop(
+export async function heartbeatLoop(
 	opts: EngineOpts,
 	api: ApiClient,
 	queue: RetryQueue,
 	abort: AbortSignal,
 	snapshot: () => { last_revision_seen: number | null; last_sync_error: string | null },
+	stopForDisconnectedAgent: (hint: string) => void,
 ): Promise<void> {
 	let heartbeatFailureStreak = 0;
 	const send = async () => {
@@ -2396,23 +2434,25 @@ async function heartbeatLoop(
 		const dropped = queue.drainDroppedDelta();
 		const runtimeObserved = readHostedRuntimeObserved();
 		try {
-			await api.POST("/v1/agents/{agent_id}/sync-heartbeat", {
-				params: { path: { agent_id: opts.environmentId } },
-				body: {
-					// Peak since boot rather than sampled current
-					// depth — see the comment on the auth-failure
-					// final heartbeat above. Backend takes max
-					// across reports, so a monotonically-rising
-					// high-water mark from the daemon makes the
-					// dashboard's `queue_depth_high_water_since_start`
-					// converge to the actual peak.
-					queue_depth: queue.highWaterMark,
-					dropped_count_delta: dropped,
-					last_revision_seen: fields.last_revision_seen,
-					last_sync_error: fields.last_sync_error,
-					...(runtimeObserved ? { runtime_observed: runtimeObserved } : {}),
-				},
-			});
+			unwrap(
+				await api.POST("/v1/agents/{agent_id}/sync-heartbeat", {
+					params: { path: { agent_id: opts.environmentId } },
+					body: {
+						// Peak since boot rather than sampled current
+						// depth — see the comment on the auth-failure
+						// final heartbeat above. Backend takes max
+						// across reports, so a monotonically-rising
+						// high-water mark from the daemon makes the
+						// dashboard's `queue_depth_high_water_since_start`
+						// converge to the actual peak.
+						queue_depth: queue.highWaterMark,
+						dropped_count_delta: dropped,
+						last_revision_seen: fields.last_revision_seen,
+						last_sync_error: fields.last_sync_error,
+						...(runtimeObserved ? { runtime_observed: runtimeObserved } : {}),
+					},
+				}),
+			);
 			heartbeatFailureStreak = 0;
 			await touchHealthFile(opts.adapter.agentType);
 		} catch (e) {
@@ -2421,6 +2461,11 @@ async function heartbeatLoop(
 			// count is permanently lost on every flaky-network
 			// cycle, which is precisely when drops are most likely.
 			queue.restoreDroppedDelta(dropped);
+			const stopHint = agentLookupStopHint(e);
+			if (stopHint !== null) {
+				stopForDisconnectedAgent(stopHint);
+				return;
+			}
 			heartbeatFailureStreak += 1;
 			const classification = classifyHeartbeatFailure(heartbeatFailureStreak);
 			const fields = {

--- a/packages/cli/tests/commands/agent-reconnect.test.ts
+++ b/packages/cli/tests/commands/agent-reconnect.test.ts
@@ -59,6 +59,45 @@ afterEach(() => {
 });
 
 describe("agent reconnect", () => {
+	it("emits the stable Desktop candidate contract without mutating bindings", async () => {
+		const agentId = "00000000-0000-0000-0000-000000000123";
+		const mock = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/agents",
+				response: () =>
+					jsonResponse([
+						{
+							id: agentId,
+							name: "My Pi",
+							machine_name: "Previous Laptop",
+							agent_type: "pi",
+						},
+					]),
+			},
+		]);
+		restoreFetch = mock.restore;
+
+		await agentReconnect(undefined, { desktopList: true });
+
+		expect(JSON.parse(output.join("\n"))).toEqual({
+			schemaVersion: "clawdi.agentReconnectCandidates.v1",
+			agents: [
+				{
+					id: agentId,
+					type: "pi",
+					displayName: "Pi",
+					name: "My Pi",
+					machineName: "Previous Laptop",
+					isThisMachine: false,
+					lastSyncAt: null,
+				},
+			],
+		});
+		expect(mock.captured.some((request) => request.method === "POST")).toBe(false);
+		expect(process.exitCode).toBe(0);
+	});
+
 	it("requires explicit confirmation outside an interactive terminal", async () => {
 		const agentId = "00000000-0000-0000-0000-000000000123";
 		const mock = mockFetch([

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -113,9 +113,9 @@ describe("auth persistence", () => {
 		expect(isLoggedIn()).toBe(false);
 	});
 
-	it("preserves Agent registrations for the same account without exposing them to another", async () => {
+	it("does not claim legacy Agent registrations while clearing credentials", async () => {
 		const { clearAuth, setAuth } = await import("../src/lib/config");
-		const { getEnvIdByAgent, listRegisteredAgentTypes } = await import("../src/lib/select-adapter");
+		const { listRegisteredAgentTypes } = await import("../src/lib/select-adapter");
 		const envDir = join(fakeHome, ".clawdi", "environments");
 		const envPath = join(envDir, "codex.json");
 		mkdirSync(envDir, { recursive: true });
@@ -128,16 +128,7 @@ describe("auth persistence", () => {
 		expect(JSON.parse(readFileSync(envPath, "utf8"))).toEqual({
 			id: "env-codex",
 			agentType: "codex",
-			userId: "account-a",
 		});
-
-		setAuth({ apiKey: "account-a-key-2", userId: "account-a" });
-		expect(getEnvIdByAgent("codex")).toBe("env-codex");
-		expect(listRegisteredAgentTypes()).toEqual(["codex"]);
-
-		setAuth({ apiKey: "account-b-key", userId: "account-b" });
-		expect(getEnvIdByAgent("codex")).toBeNull();
-		expect(listRegisteredAgentTypes()).toEqual([]);
 	});
 
 	it("writes auth.json with mode 0o600", async () => {

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -3734,6 +3734,8 @@ export interface components {
             name: string;
             /** Default Name */
             default_name?: string | null;
+            /** Machine Id */
+            machine_id: string;
             /** Machine Name */
             machine_name: string;
             /** Display Name */
@@ -5675,6 +5677,8 @@ export interface components {
             name: string;
             /** Default Name */
             default_name?: string | null;
+            /** Machine Id */
+            machine_id: string;
             /** Machine Name */
             machine_name: string;
             /** Display Name */
@@ -11065,7 +11069,9 @@ export interface operations {
     stage_session_event_generation_v1_sessions__local_session_id__events_generations_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-Clawdi-Machine-Id"?: string | null;
+            };
             path: {
                 local_session_id: string;
             };
@@ -11100,7 +11106,9 @@ export interface operations {
     upload_session_event_generation_chunk_v1_sessions__local_session_id__events_generations__generation_id__chunks__start_seq__put: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-Clawdi-Machine-Id"?: string | null;
+            };
             path: {
                 local_session_id: string;
                 generation_id: string;
@@ -11137,7 +11145,9 @@ export interface operations {
     commit_session_event_generation_v1_sessions__local_session_id__events_generations__generation_id__commit_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-Clawdi-Machine-Id"?: string | null;
+            };
             path: {
                 local_session_id: string;
                 generation_id: string;
@@ -11173,7 +11183,9 @@ export interface operations {
     append_session_events_v1_sessions__local_session_id__events_append_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-Clawdi-Machine-Id"?: string | null;
+            };
             path: {
                 local_session_id: string;
             };
@@ -11502,7 +11514,9 @@ export interface operations {
     register_agent_v1_agents_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-Clawdi-Machine-Id"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -11535,7 +11549,9 @@ export interface operations {
     rebind_agent_v1_agents__agent_id__rebind_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-Clawdi-Machine-Id"?: string | null;
+            };
             path: {
                 agent_id: string;
             };
@@ -11597,7 +11613,9 @@ export interface operations {
     register_environment_v1_environments_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-Clawdi-Machine-Id"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -12187,7 +12205,9 @@ export interface operations {
     sync_heartbeat_v1_agents__agent_id__sync_heartbeat_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-Clawdi-Machine-Id"?: string | null;
+            };
             path: {
                 agent_id: string;
             };
@@ -12220,7 +12240,9 @@ export interface operations {
     batch_create_sessions_v1_sessions_batch_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-Clawdi-Machine-Id"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -12369,7 +12391,9 @@ export interface operations {
     upload_session_content_v1_sessions__local_session_id__upload_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-Clawdi-Machine-Id"?: string | null;
+            };
             path: {
                 local_session_id: string;
             };
@@ -12477,7 +12501,9 @@ export interface operations {
     extract_session_memories_v1_sessions__local_session_id__extract_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-Clawdi-Machine-Id"?: string | null;
+            };
             path: {
                 local_session_id: string;
             };
@@ -13136,7 +13162,9 @@ export interface operations {
             query?: {
                 environment_id?: string | null;
             };
-            header?: never;
+            header?: {
+                "X-Clawdi-Machine-Id"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -13240,6 +13268,7 @@ export interface operations {
             query?: never;
             header?: {
                 "X-Clawdi-Skill-Sync-Protocol"?: string | null;
+                "X-Clawdi-Machine-Id"?: string | null;
             };
             path?: never;
             cookie?: never;
@@ -13405,6 +13434,7 @@ export interface operations {
             query?: never;
             header?: {
                 "X-Clawdi-Skill-Sync-Protocol"?: string | null;
+                "X-Clawdi-Machine-Id"?: string | null;
             };
             path: {
                 project_id: string;
@@ -13617,6 +13647,7 @@ export interface operations {
             };
             header?: {
                 "X-Clawdi-Skill-Sync-Protocol"?: string | null;
+                "X-Clawdi-Machine-Id"?: string | null;
             };
             path: {
                 project_id: string;
@@ -13684,7 +13715,9 @@ export interface operations {
     upload_agent_synced_skill_v1_agents__agent_id__skills_sync_upload_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-Clawdi-Machine-Id"?: string | null;
+            };
             path: {
                 agent_id: string;
             };
@@ -13722,7 +13755,9 @@ export interface operations {
                 /** @description Project fence recorded when the Agent projection was claimed. Omit only for legacy clients deleting from the current Agent Project. */
                 project_id?: string | null;
             };
-            header?: never;
+            header?: {
+                "X-Clawdi-Machine-Id"?: string | null;
+            };
             path: {
                 agent_id: string;
                 skill_key: string;


### PR DESCRIPTION
## Summary

- make Connected Agent rebind single-active by fencing writes to the currently bound machine
- send one stable machine identity from CLI request boundaries and self-stop a displaced daemon on `agent_rebound`
- validate and account-bind legacy local registrations only after an online ownership check
- add `daemon stop` so Desktop account transitions can pause sync without deleting the installed-service intent
- expose reconnect candidate machine/recency metadata and require explicit takeover of a recently active other machine

## Server rollout

The migration is backward compatible:

- existing Agent rows default to `machine_fence_required = false`
- setup/rebind enables the fence only when the client request already carries `X-Clawdi-Machine-Id`
- once enabled, stale or headerless writers receive the stable `403 agent_rebound` response
- upload/commit paths revalidate at the final write boundary, including the object-storage race

This is the Backend/CLI prerequisite for Desktop PR #1318 and contains no Electron files.

## Verification

- clean isolated Backend suite: 62 passed
- clean isolated full CLI suite: 143 test files passed in 108s
- CLI typecheck passed
- migration upgraded from repository head successfully on PostgreSQL 18
- Biome and `git diff --check` passed
