### PR TITLE
fix(billing): retry transient checkout startup

### DIFF
--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -59,6 +59,41 @@ describe("idempotent billing transport", () => {
 		}
 	});
 
+	it("absorbs brief checkout contention with the same idempotent request", async () => {
+		const seen: Array<{ body: string; key: string | null }> = [];
+		const delays: number[] = [];
+		const transport = retryIdempotentBillingTransport(async (request) => {
+			seen.push({
+				body: await request.text(),
+				key: request.headers.get("Idempotency-Key"),
+			});
+			if (seen.length === 1) throw new BillingNetworkError("timeout");
+			if (seen.length === 2) {
+				return jsonResponse({ detail: "A billing operation is already in progress" }, 409, {
+					"Retry-After": "1",
+				});
+			}
+			return new Response(null, { status: 204 });
+		}, async (delayMs) => {
+			delays.push(delayMs);
+		});
+		const response = await transport(
+			new Request("https://api.clawdi.ai/v2/subscription/checkout", {
+				method: "POST",
+				headers: { "Idempotency-Key": "checkout-1" },
+				body: '{"plan_slug":"compute_basic"}',
+			}),
+		);
+
+		expect(response.status).toBe(204);
+		expect(delays).toEqual([1_000]);
+		expect(seen).toEqual([
+			{ body: '{"plan_slug":"compute_basic"}', key: "checkout-1" },
+			{ body: '{"plan_slug":"compute_basic"}', key: "checkout-1" },
+			{ body: '{"plan_slug":"compute_basic"}', key: "checkout-1" },
+		]);
+	});
+
 	it("does not retry responses, aborts, or a second network failure", async () => {
 		for (const scenario of [
 			"response",
@@ -77,7 +112,7 @@ describe("idempotent billing transport", () => {
 			});
 			const path =
 				scenario === "other-endpoint"
-					? "/v2/subscription/checkout"
+					? "/v2/subscription/portal"
 					: scenario === "setup-finalize"
 						? "/v2/wallet/auto-reload/setup-intent/finalize"
 						: "/v2/wallet/topup";
@@ -140,10 +175,10 @@ describe("idempotent billing transport", () => {
 	});
 });
 
-function jsonResponse(body: unknown, status = 200): Response {
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
 	return new Response(JSON.stringify(body), {
 		status,
-		headers: { "Content-Type": "application/json" },
+		headers: { "Content-Type": "application/json", ...headers },
 	});
 }
 

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -63,7 +63,11 @@ const ROOT_BASE_URL = hostedApiBaseUrl(BASE_URL);
 export const BILLING_API_ORIGIN = new URL(ROOT_BASE_URL).origin;
 
 const REQUEST_TIMEOUT_MS = 20_000;
+const CHECKOUT_PATH = "/v2/subscription/checkout";
+const MAX_CHECKOUT_ATTEMPTS = 3;
+const MAX_CHECKOUT_RETRY_AFTER_MS = 2_000;
 const RETRYABLE_IDEMPOTENT_POST_PATHS = new Set([
+	CHECKOUT_PATH,
 	"/v2/wallet/topup",
 	"/v2/wallet/auto-reload/setup-intent",
 ]);
@@ -120,25 +124,59 @@ function fetchWithTimeout(request: Request, init?: RequestInit): Promise<Respons
 		});
 }
 
-export function retryIdempotentBillingTransport(fetcher: BillingFetch): BillingFetch {
+function checkoutRetryDelay(response: Response): number | null {
+	if (response.status !== 409 && response.status !== 503) return null;
+	const retryAfter = response.headers.get("Retry-After");
+	if (retryAfter === null) return null;
+	const seconds = Number(retryAfter);
+	if (!Number.isFinite(seconds) || seconds < 0) return null;
+	const delayMs = seconds * 1_000;
+	return delayMs <= MAX_CHECKOUT_RETRY_AFTER_MS ? delayMs : null;
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+	if (!signal.aborted) return;
+	throw signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
+}
+
+export function retryIdempotentBillingTransport(
+	fetcher: BillingFetch,
+	sleep: (delayMs: number) => Promise<void> = (delayMs) =>
+		new Promise<void>((resolve) => globalThis.setTimeout(resolve, delayMs)),
+): BillingFetch {
 	return async (request) => {
-		const retryRequest = request.clone();
-		try {
-			return await fetcher(request);
-		} catch (error) {
-			const idempotencyKey = request.headers.get("Idempotency-Key");
-			const url = new URL(request.url);
-			if (
-				!(error instanceof BillingNetworkError) ||
-				request.method !== "POST" ||
-				!RETRYABLE_IDEMPOTENT_POST_PATHS.has(url.pathname) ||
-				!idempotencyKey?.trim() ||
-				request.signal.aborted
-			) {
-				throw error;
+		const path = new URL(request.url).pathname;
+		const retryable =
+			request.method === "POST" &&
+			RETRYABLE_IDEMPOTENT_POST_PATHS.has(path) &&
+			!!request.headers.get("Idempotency-Key")?.trim();
+		if (!retryable) return fetcher(request);
+
+		const maxAttempts = path === CHECKOUT_PATH ? MAX_CHECKOUT_ATTEMPTS : 2;
+		const attempts = Array.from({ length: maxAttempts }, (_, index) =>
+			index === 0 ? request : request.clone(),
+		);
+		for (let attempt = 0; attempt < attempts.length; attempt += 1) {
+			throwIfAborted(request.signal);
+			let response: Response;
+			try {
+				response = await fetcher(attempts[attempt] as Request);
+			} catch (error) {
+				if (
+					!(error instanceof BillingNetworkError) ||
+					request.signal.aborted ||
+					attempt === attempts.length - 1
+				) {
+					throw error;
+				}
+				continue;
 			}
-			return fetcher(retryRequest);
+
+			const delayMs = path === CHECKOUT_PATH ? checkoutRetryDelay(response) : null;
+			if (delayMs === null || attempt === attempts.length - 1) return response;
+			await sleep(delayMs);
 		}
+		throw new BillingNetworkError("offline");
 	};
 }
 
@@ -472,9 +510,12 @@ export function createBillingClient(
 	getToken: BillingAuthTokenGetter,
 	options: BillingClientOptions = {},
 ) {
+	const sleep =
+		options.sleep ??
+		((delayMs: number) => new Promise<void>((resolve) => globalThis.setTimeout(resolve, delayMs)));
 	const api = createClient<DeployPaths>({
 		baseUrl: ROOT_BASE_URL,
-		fetch: retryIdempotentBillingTransport(options.fetch ?? fetchWithTimeout),
+		fetch: retryIdempotentBillingTransport(options.fetch ?? fetchWithTimeout, sleep),
 	});
 	api.use({
 		async onRequest({ request }) {
@@ -496,10 +537,6 @@ export function createBillingClient(
 	const deploymentRequestTimeoutMs = Number.isFinite(configuredDeploymentRequestTimeoutMs)
 		? Math.max(0, configuredDeploymentRequestTimeoutMs)
 		: 120_000;
-	const sleep =
-		options.sleep ??
-		((delayMs: number) => new Promise<void>((resolve) => globalThis.setTimeout(resolve, delayMs)));
-
 	const getDeployment = async (id: string): Promise<HostedDeployment> =>
 		unwrapDeploy(
 			await api.GET("/v2/deployments/{deployment_id}", {

--- a/packages/cli/src/lib/hosted-deploy-client.ts
+++ b/packages/cli/src/lib/hosted-deploy-client.ts
@@ -33,6 +33,8 @@ import {
 import { getCliVersion } from "./version";
 
 const REQUEST_TIMEOUT_MS = 20_000;
+const MAX_CHECKOUT_ATTEMPTS = 3;
+const MAX_CHECKOUT_RETRY_AFTER_MS = 2_000;
 const USER_AGENT = `clawdi-cli/${getCliVersion()}`;
 
 type HostedResult<T> = { data?: T; error?: unknown; response: Response };
@@ -82,6 +84,16 @@ function unwrapHosted<T>(result: HostedResult<T>): T {
 	return result.data;
 }
 
+function checkoutRetryDelay(response: Response): number | null {
+	if (response.status !== 409 && response.status !== 503) return null;
+	const retryAfter = response.headers.get("Retry-After");
+	if (retryAfter === null) return null;
+	const seconds = Number(retryAfter);
+	if (!Number.isFinite(seconds) || seconds < 0) return null;
+	const delayMs = seconds * 1_000;
+	return delayMs <= MAX_CHECKOUT_RETRY_AFTER_MS ? delayMs : null;
+}
+
 export type HostedDeployClientOptions = {
 	auth?: HostedDeployAuthProvider;
 	apiBaseUrl?: string;
@@ -89,6 +101,7 @@ export type HostedDeployClientOptions = {
 	fetch?: (request: Request) => Promise<Response>;
 	now?: () => number;
 	paidCheckoutSupported?: boolean;
+	sleep?: (delayMs: number) => Promise<void>;
 };
 
 /** Typed, auth-isolated adapter over the generated Hosted deploy API client. */
@@ -97,11 +110,15 @@ export class HostedDeployClient {
 	private readonly cloudClient: Client<paths>;
 	private readonly client: Client<DeployPaths>;
 	private readonly paidCheckoutSupported: boolean;
+	private readonly sleep: (delayMs: number) => Promise<void>;
 
 	constructor(options: HostedDeployClientOptions = {}) {
 		const config = getConfig();
 		const now = options.now ?? Date.now;
 		this.paidCheckoutSupported = options.paidCheckoutSupported ?? true;
+		this.sleep =
+			options.sleep ??
+			((delayMs) => new Promise<void>((resolve) => globalThis.setTimeout(resolve, delayMs)));
 		this.baseUrl = normalizeHostedDeployApiBaseUrl(options.baseUrl ?? config.deployApiUrl);
 		const cloudBaseUrl = normalizeCloudApiBaseUrl(options.apiBaseUrl ?? config.apiUrl);
 		const auth =
@@ -194,12 +211,29 @@ export class HostedDeployClient {
 	}
 
 	async checkout(body: HostedDeployCheckoutRequest, idempotencyKey: string) {
-		return unwrapHosted(
-			await this.client.POST("/v2/subscription/checkout", {
-				params: { header: { "Idempotency-Key": idempotencyKey } },
-				body,
-			}),
-		);
+		for (let attempt = 0; attempt < MAX_CHECKOUT_ATTEMPTS; attempt += 1) {
+			try {
+				const result = await this.client.POST("/v2/subscription/checkout", {
+					params: { header: { "Idempotency-Key": idempotencyKey } },
+					body,
+				});
+				const delayMs = checkoutRetryDelay(result.response);
+				if (delayMs === null || attempt === MAX_CHECKOUT_ATTEMPTS - 1) {
+					return unwrapHosted(result);
+				}
+				await this.sleep(delayMs);
+			} catch (error) {
+				if (
+					!(error instanceof HostedDeployApiError) ||
+					error.status !== 0 ||
+					attempt === MAX_CHECKOUT_ATTEMPTS - 1
+				) {
+					throw error;
+				}
+				continue;
+			}
+		}
+		throw new HostedDeployApiError(0, "Hosted deploy API request failed.");
 	}
 
 	async getOperation(operationName: string): Promise<HostedDeployOperation> {

--- a/packages/cli/tests/hosted-deploy-auth.test.ts
+++ b/packages/cli/tests/hosted-deploy-auth.test.ts
@@ -159,4 +159,54 @@ describe("Hosted deploy auth boundary", () => {
 			"https://cloud.example.test/v1/ai-providers",
 		]);
 	});
+
+	test("retries brief checkout contention with the same idempotency key", async () => {
+		const now = Date.now();
+		const token = oauthToken(Math.floor(now / 1_000) + 3_600);
+		const requests: Request[] = [];
+		const delays: number[] = [];
+		const hosted = new HostedDeployClient({
+			baseUrl: "https://deploy.example.test",
+			auth: {
+				getAccessToken: async () => ({
+					token,
+					expiresAt: new Date(now + 3_600_000).toISOString(),
+				}),
+			},
+			now: () => now,
+			sleep: async (delayMs) => {
+				delays.push(delayMs);
+			},
+			fetch: async (request) => {
+				requests.push(request.clone());
+				if (requests.length === 1) {
+					return Response.json(
+						{ detail: "A billing operation is already in progress" },
+						{ status: 409, headers: { "Retry-After": "1" } },
+					);
+				}
+				return Response.json({
+					flow_type: "checkout_session",
+					funding_source: "stripe",
+					checkout_url: "https://checkout.stripe.test/session/stable",
+				});
+			},
+		});
+
+		await hosted.checkout(
+			{
+				plan_slug: "compute_basic",
+				funding_source: "stripe",
+			},
+			"checkout-stable",
+		);
+
+		expect(delays).toEqual([1_000]);
+		expect(requests).toHaveLength(2);
+		expect(requests.map((request) => request.headers.get("Idempotency-Key"))).toEqual([
+			"checkout-stable",
+			"checkout-stable",
+		]);
+		expect(await requests[0]?.text()).toBe(await requests[1]?.text());
+	});
 });


### PR DESCRIPTION
## Summary
- retry idempotent Checkout startup after transport uncertainty
- honor short server-provided Retry-After windows for transient 409/503 responses
- keep the same request body and Idempotency-Key across browser and CLI retries

## Verification
- `bash scripts/test.sh web src/hosted/billing/billing-client.test.ts`
- `bash scripts/test.sh cli tests/hosted-deploy-auth.test.ts`