### PR TITLE
chore(billing): satisfy checkout retry checks

### DIFF
--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -62,21 +62,24 @@ describe("idempotent billing transport", () => {
 	it("absorbs brief checkout contention with the same idempotent request", async () => {
 		const seen: Array<{ body: string; key: string | null }> = [];
 		const delays: number[] = [];
-		const transport = retryIdempotentBillingTransport(async (request) => {
-			seen.push({
-				body: await request.text(),
-				key: request.headers.get("Idempotency-Key"),
-			});
-			if (seen.length === 1) throw new BillingNetworkError("timeout");
-			if (seen.length === 2) {
-				return jsonResponse({ detail: "A billing operation is already in progress" }, 409, {
-					"Retry-After": "1",
+		const transport = retryIdempotentBillingTransport(
+			async (request) => {
+				seen.push({
+					body: await request.text(),
+					key: request.headers.get("Idempotency-Key"),
 				});
-			}
-			return new Response(null, { status: 204 });
-		}, async (delayMs) => {
-			delays.push(delayMs);
-		});
+				if (seen.length === 1) throw new BillingNetworkError("timeout");
+				if (seen.length === 2) {
+					return jsonResponse({ detail: "A billing operation is already in progress" }, 409, {
+						"Retry-After": "1",
+					});
+				}
+				return new Response(null, { status: 204 });
+			},
+			async (delayMs) => {
+				delays.push(delayMs);
+			},
+		);
 		const response = await transport(
 			new Request("https://api.clawdi.ai/v2/subscription/checkout", {
 				method: "POST",

--- a/packages/cli/src/lib/hosted-deploy-client.ts
+++ b/packages/cli/src/lib/hosted-deploy-client.ts
@@ -230,7 +230,6 @@ export class HostedDeployClient {
 				) {
 					throw error;
 				}
-				continue;
 			}
 		}
 		throw new HostedDeployApiError(0, "Hosted deploy API request failed.");


### PR DESCRIPTION
## Summary
- apply repository Biome formatting to the checkout retry test
- remove the redundant loop `continue` flagged by CI

## Verification
- pre-commit Biome hook passed
- logic tests and builds passed in #1348; this forward fix is formatting-only