### PR TITLE
feat(sessions): centralize share link management

### DIFF
--- a/apps/web/e2e/session-search-navigation.pw.ts
+++ b/apps/web/e2e/session-search-navigation.pw.ts
@@ -567,7 +567,7 @@ test("filters session activity and expands paired tool details", async ({ page }
 	);
 	await expect(page.getByText("1 / 1")).toBeVisible();
 	await page.getByRole("checkbox", { name: "You" }).click();
-	await expect(page).toHaveURL((url) => url.searchParams.get("timelineView") === "user,assistant");
+	await expect(page).toHaveURL((url) => !url.searchParams.has("timelineView"));
 	await expect(page.getByText("Read the repository instructions", { exact: true })).toBeVisible();
 	await expect(toolActivity).not.toBeVisible();
 });

--- a/apps/web/e2e/session-sharing.pw.ts
+++ b/apps/web/e2e/session-sharing.pw.ts
@@ -47,6 +47,7 @@ test("uses direct message actions and keeps older live links revocable", async (
 	let legacyLinkActive = true;
 	let shares: Array<Record<string, unknown>> = [];
 	let createdBody: unknown;
+	let requestedTimelineCategories: string[] = [];
 
 	await page.route("**/v1/**", async (route) => {
 		const url = new URL(route.request().url());
@@ -63,6 +64,7 @@ test("uses direct message actions and keeps older live links revocable", async (
 			return fulfillJson(route, session);
 		}
 		if (url.pathname === `/v1/sessions/${SESSION_ID}/messages`) {
+			requestedTimelineCategories = url.searchParams.getAll("include");
 			return fulfillJson(route, {
 				items: [
 					{
@@ -125,6 +127,10 @@ test("uses direct message actions and keeps older live links revocable", async (
 	});
 
 	await page.goto(`/sessions/${SESSION_ID}`);
+	await expect.poll(() => requestedTimelineCategories).toEqual(["user", "assistant"]);
+	await expect(page.getByRole("checkbox", { name: "You" })).toBeChecked();
+	await expect(page.getByRole("checkbox", { name: "Agent" })).toBeChecked();
+	await expect(page.getByRole("checkbox", { name: "Tools" })).not.toBeChecked();
 	const assistantMessage = page.getByText("Assistant response ready to share", {
 		exact: true,
 	});
@@ -165,4 +171,56 @@ test("uses direct message actions and keeps older live links revocable", async (
 	});
 	await confirmation.getByRole("button", { name: "Turn off link" }).click();
 	await expect(sessionDialog.getByText("Live Session link", { exact: true })).not.toBeVisible();
+});
+
+test("manages active Session links from one page", async ({ page }) => {
+	let active = true;
+
+	await page.route("**/v1/**", async (route) => {
+		const url = new URL(route.request().url());
+		if (url.pathname === "/v1/agents") return fulfillJson(route, []);
+		if (url.pathname === "/v1/sessions") {
+			return fulfillJson(route, { items: [], total: 0, page: 1, page_size: 25 });
+		}
+		if (url.pathname === "/v1/session-shares") {
+			return fulfillJson(route, {
+				items: active
+					? [
+							{
+								id: SHARE_ID,
+								kind: "snapshot",
+								session_id: SESSION_ID,
+								session_title: "Share a response",
+								scope: "response",
+								message_count: 1,
+								share_url: `http://127.0.0.1:3200/s/${SHARE_ID}`,
+								created_at: now,
+							},
+						]
+					: [],
+				total: active ? 1 : 0,
+				page: 1,
+				page_size: 25,
+			});
+		}
+		if (
+			url.pathname === `/v1/session-shares/${SHARE_ID}` &&
+			route.request().method() === "DELETE"
+		) {
+			active = false;
+			return route.fulfill({ status: 204 });
+		}
+		return fulfillJson(route, {});
+	});
+
+	await page.goto("/sessions/shared");
+	await expect(page.getByRole("heading", { name: "Shared Session links" })).toBeVisible();
+	await expect(page.getByText("Share a response", { exact: true })).toBeVisible();
+	await expect(page.getByText(/Single Agent response · 1 message/)).toBeVisible();
+	await page.getByRole("button", { name: "Turn off share link for Share a response" }).click();
+	await page
+		.getByRole("alertdialog", { name: "Turn off this share link?" })
+		.getByRole("button", { name: "Turn off link" })
+		.click();
+	await expect(page.getByText("No active Session links", { exact: true })).toBeVisible();
 });

--- a/apps/web/src/components/dialog-exit-lifecycle-inventory.test.ts
+++ b/apps/web/src/components/dialog-exit-lifecycle-inventory.test.ts
@@ -64,6 +64,7 @@ const STATELESS_OR_CANONICAL = [
 	"hosted/v2/channels/telegram-pair-dialog.tsx",
 	"hosted/v2/channels/whatsapp-pair-dialog.tsx",
 	"pages/dashboard/projects/[id]/page.tsx",
+	"pages/dashboard/sessions/shared-page.tsx",
 ] as const;
 
 describe("stateful popup lifecycle inventory", () => {

--- a/apps/web/src/lib/agent-routes.test.ts
+++ b/apps/web/src/lib/agent-routes.test.ts
@@ -283,6 +283,7 @@ describe("agent routes", () => {
 			future: "kept",
 		});
 		expect(validateAgentRouteSearch({ timelineView: "unknown" })).toEqual({});
+		expect(validateAgentRouteSearch({ timelineView: "all" })).toEqual({ timelineView: "all" });
 	});
 
 	it("canonicalizes legacy tab bookmarks through one explicit mapping", () => {

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -10,7 +10,7 @@ export type AgentRouteSearch = Record<string, unknown> & {
 	tab?: string;
 	project?: string;
 	vault?: string;
-	timelineView?: Exclude<SessionTimelineView, "all">;
+	timelineView?: SessionTimelineView;
 	subscription_action?: "start_new";
 };
 

--- a/apps/web/src/lib/session-search-anchor.test.ts
+++ b/apps/web/src/lib/session-search-anchor.test.ts
@@ -80,6 +80,11 @@ describe("Session search anchors", () => {
 		expect(sessionTimelineViewLink("session-id", "all")).toEqual({
 			to: "/sessions/$id",
 			params: { id: "session-id" },
+			search: { timelineView: "all" },
+		});
+		expect(sessionTimelineViewLink("session-id", "user,assistant")).toEqual({
+			to: "/sessions/$id",
+			params: { id: "session-id" },
 			search: {},
 		});
 		expect(sessionTimelineViewLink("session-id", "assistant")).toEqual({
@@ -112,7 +117,9 @@ describe("Session search anchors", () => {
 			validateSessionDetailSearch({ timelineView: "user,assistant", matchQuery: " answer " }),
 		).toEqual({
 			matchQuery: "answer",
-			timelineView: "user,assistant",
+		});
+		expect(validateSessionDetailSearch({ timelineView: "all" })).toEqual({
+			timelineView: "all",
 		});
 		expect(sessionTimelineCategories("all")).toEqual(["user", "assistant", "tools"]);
 		expect(sessionTimelineViewFromCategories(["tools", "assistant"])).toBe("assistant,tools");

--- a/apps/web/src/lib/session-search-anchor.ts
+++ b/apps/web/src/lib/session-search-anchor.ts
@@ -10,13 +10,14 @@ type SessionTimelineFilteredView =
 	| "user,tools"
 	| "assistant,tools";
 export type SessionTimelineView = "all" | SessionTimelineFilteredView;
+export const DEFAULT_SESSION_TIMELINE_VIEW: SessionTimelineFilteredView = "user,assistant";
 
 export interface SessionDetailSearch {
 	matchKind?: SessionSearchAnchor["kind"];
 	matchPosition?: number;
 	matchRevision?: string;
 	matchQuery?: string;
-	timelineView?: SessionTimelineFilteredView;
+	timelineView?: SessionTimelineView;
 	returnTo?: string;
 }
 
@@ -32,8 +33,9 @@ function validPosition(value: unknown): number | undefined {
 	return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
 }
 
-export function parseSessionTimelineView(value: unknown): SessionTimelineFilteredView | undefined {
+export function parseSessionTimelineView(value: unknown): SessionTimelineView | undefined {
 	if (typeof value !== "string") return undefined;
+	if (value === "all") return "all";
 	const values = value.split(",");
 	if (
 		values.length === 0 ||
@@ -44,7 +46,7 @@ export function parseSessionTimelineView(value: unknown): SessionTimelineFiltere
 		return undefined;
 	}
 	const view = sessionTimelineViewFromCategories(values);
-	return view === "all" || view === null ? undefined : view;
+	return view ?? undefined;
 }
 
 export function sessionTimelineCategories(view: SessionTimelineView): SessionTimelineCategory[] {
@@ -74,11 +76,13 @@ export function sessionTimelineIncludesMessages(view: SessionTimelineView): bool
 
 export function validateSessionDetailSearch(search: Record<string, unknown>): SessionDetailSearch {
 	const returnTo = normalizeSessionListReturnTo(search.returnTo);
-	const timelineView = parseSessionTimelineView(search.timelineView);
-	const matchQuery =
-		timelineView && !sessionTimelineIncludesMessages(timelineView)
-			? undefined
-			: normalizeSessionMatchQuery(search.matchQuery);
+	const parsedTimelineView = parseSessionTimelineView(search.timelineView);
+	const timelineView =
+		parsedTimelineView === DEFAULT_SESSION_TIMELINE_VIEW ? undefined : parsedTimelineView;
+	const effectiveTimelineView = timelineView ?? DEFAULT_SESSION_TIMELINE_VIEW;
+	const matchQuery = !sessionTimelineIncludesMessages(effectiveTimelineView)
+		? undefined
+		: normalizeSessionMatchQuery(search.matchQuery);
 	const standalone = {
 		...(matchQuery ? { matchQuery } : {}),
 		...(timelineView ? { timelineView } : {}),
@@ -116,12 +120,13 @@ export function sessionTimelineViewLink(
 	const matchQuery = sessionTimelineIncludesMessages(view)
 		? normalizeSessionMatchQuery(options.searchQuery)
 		: undefined;
+	const timelineView = view === DEFAULT_SESSION_TIMELINE_VIEW ? undefined : view;
 	return {
 		to: "/sessions/$id" as const,
 		params: { id: sessionId },
 		search: {
 			...(matchQuery ? { matchQuery } : {}),
-			...(view === "all" ? {} : { timelineView: view }),
+			...(timelineView ? { timelineView } : {}),
 			...(returnTo ? { returnTo } : {}),
 		},
 	};
@@ -133,12 +138,12 @@ export function sessionDetailSearchLink(
 	options: { returnTo?: string; timelineView?: SessionTimelineView } = {},
 ): SessionDetailLink {
 	const returnTo = normalizeSessionListReturnTo(options.returnTo);
+	const effectiveTimelineView = options.timelineView ?? DEFAULT_SESSION_TIMELINE_VIEW;
 	const timelineView =
-		options.timelineView === "all" ? undefined : parseSessionTimelineView(options.timelineView);
-	const matchQuery =
-		!timelineView || sessionTimelineIncludesMessages(timelineView)
-			? normalizeSessionMatchQuery(query)
-			: undefined;
+		effectiveTimelineView === DEFAULT_SESSION_TIMELINE_VIEW ? undefined : effectiveTimelineView;
+	const matchQuery = sessionTimelineIncludesMessages(effectiveTimelineView)
+		? normalizeSessionMatchQuery(query)
+		: undefined;
 	return {
 		to: "/sessions/$id" as const,
 		params: { id: sessionId },
@@ -213,10 +218,11 @@ export function sessionSearchMatchLink(
 	} = {},
 ): SessionDetailLink {
 	const returnTo = normalizeSessionListReturnTo(options.returnTo);
+	const effectiveTimelineView = options.timelineView ?? DEFAULT_SESSION_TIMELINE_VIEW;
 	const timelineView =
-		options.timelineView === "all" ? undefined : parseSessionTimelineView(options.timelineView);
-	if (timelineView && !sessionTimelineIncludesMessages(timelineView)) {
-		return sessionTimelineViewLink(sessionId, timelineView, { returnTo });
+		effectiveTimelineView === DEFAULT_SESSION_TIMELINE_VIEW ? undefined : effectiveTimelineView;
+	if (!sessionTimelineIncludesMessages(effectiveTimelineView)) {
+		return sessionTimelineViewLink(sessionId, effectiveTimelineView, { returnTo });
 	}
 	const matchQuery = normalizeSessionMatchQuery(options.searchQuery);
 	return {

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -58,6 +58,7 @@ import {
 	sessionDetailQueryKey,
 } from "@/lib/session-queries";
 import {
+	DEFAULT_SESSION_TIMELINE_VIEW,
 	type SessionSearchAnchor,
 	type SessionTimelineCategory,
 	type SessionTimelineView,
@@ -127,7 +128,7 @@ export function SessionDetailContent({
 	agentId,
 	searchAnchor,
 	searchQuery,
-	timelineView = "all",
+	timelineView = DEFAULT_SESSION_TIMELINE_VIEW,
 	returnTo,
 }: {
 	sessionId: string;
@@ -422,9 +423,11 @@ export function SessionDetailContent({
 	const isSearchUpdating = searchActive && (isTimelineTransitioning || isContentLoading);
 	const navigateTimelineView = (selected: SessionTimelineView, retainedSearchQuery?: string) => {
 		if (agentId) {
+			const serializedTimelineView =
+				selected === DEFAULT_SESSION_TIMELINE_VIEW ? undefined : selected;
 			const search = {
 				...(retainedSearchQuery ? { matchQuery: retainedSearchQuery } : {}),
-				...(selected === "all" ? {} : { timelineView: selected }),
+				...(serializedTimelineView ? { timelineView: serializedTimelineView } : {}),
 				...(returnTo ? { returnTo } : {}),
 			};
 			return router.navigate({

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -7,9 +7,9 @@ import {
 	searchQueryLength,
 } from "@clawdi/shared/consts";
 import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useLocation } from "@tanstack/react-router";
+import { Link, useLocation } from "@tanstack/react-router";
 import type { SortingState } from "@tanstack/react-table";
-import { LayoutList, Table2 } from "lucide-react";
+import { LayoutList, Link2, Table2 } from "lucide-react";
 import { parseAsBoolean, parseAsString, parseAsStringLiteral, useQueryStates } from "nuqs";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -61,7 +61,11 @@ export default function SessionsPage() {
 		<Suspense
 			fallback={
 				<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
-					<PageHeader title="Sessions" description={SESSIONS_RESOURCE.managementDescription} />
+					<PageHeader
+						title="Sessions"
+						description={SESSIONS_RESOURCE.managementDescription}
+						actions={<SharedLinksButton />}
+					/>
 					<SessionFeed sessions={[]} isLoading emptyMessage="" />
 				</div>
 			}
@@ -399,7 +403,11 @@ function SessionsListInner() {
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
-			<PageHeader title="Sessions" description={SESSIONS_RESOURCE.managementDescription} />
+			<PageHeader
+				title="Sessions"
+				description={SESSIONS_RESOURCE.managementDescription}
+				actions={<SharedLinksButton />}
+			/>
 
 			{shouldBlockQueryError(error, data) ? (
 				<ApiErrorPanel
@@ -468,5 +476,19 @@ function SessionsListInner() {
 				</div>
 			)}
 		</div>
+	);
+}
+
+function SharedLinksButton() {
+	return (
+		<Button
+			render={<Link to="/sessions/shared" />}
+			nativeButton={false}
+			variant="outline"
+			size="sm"
+		>
+			<Link2 />
+			Shared links
+		</Button>
 	);
 }

--- a/apps/web/src/pages/dashboard/sessions/shared-page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/shared-page.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import type { components } from "@clawdi/shared/api";
+import { keepPreviousData, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { ArrowLeft, Check, Copy, ExternalLink, Link2, Trash2 } from "lucide-react";
+import { useQueryStates } from "nuqs";
+import { useState } from "react";
+import { toast } from "sonner";
+import { ApiErrorPanel } from "@/components/api-error-panel";
+import { EmptyState } from "@/components/empty-state";
+import { PageHeader } from "@/components/page-header";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { DataTablePagination } from "@/components/ui/data-table-pagination";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+import { unwrap, useApi, useOpenApi } from "@/lib/api";
+import { normalizeApiError } from "@/lib/api-errors";
+import { parseAsPositiveInt } from "@/lib/url-search-parsers";
+import { cn, relativeTime } from "@/lib/utils";
+
+type SessionShare = components["schemas"]["SessionShareListItemResponse"];
+
+export default function SharedSessionLinksPage() {
+	const $api = useOpenApi();
+	const queryClient = useQueryClient();
+	const [params, setParams] = useQueryStates(
+		{
+			page: parseAsPositiveInt.withDefault(1),
+			pageSize: parseAsPositiveInt.withDefault(25),
+		},
+		{ clearOnDefault: true, history: "replace" },
+	);
+	const query = $api.useQuery(
+		"get",
+		"/v1/session-shares",
+		{
+			params: { query: { page: params.page, page_size: params.pageSize } },
+		},
+		{ placeholderData: keepPreviousData },
+	);
+	const items = query.data?.items ?? [];
+	const total = query.data?.total ?? 0;
+	const refresh = () => {
+		void queryClient.invalidateQueries({ queryKey: ["get", "/v1/session-shares"] });
+		void queryClient.invalidateQueries({ queryKey: ["get", "/v1/sessions"] });
+	};
+
+	return (
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
+			<PageHeader
+				title="Shared Session links"
+				description="Review and turn off every active Session link from one place."
+				actions={
+					<Button render={<Link to="/sessions" />} nativeButton={false} variant="outline" size="sm">
+						<ArrowLeft />
+						Sessions
+					</Button>
+				}
+			/>
+
+			{query.error && !query.data ? (
+				<ApiErrorPanel
+					error={query.error}
+					title="Couldn't load shared links"
+					onRetry={() => void query.refetch()}
+				/>
+			) : query.isLoading ? (
+				<SharedLinksSkeleton />
+			) : items.length === 0 ? (
+				<EmptyState
+					icon={Link2}
+					title="No active Session links"
+					description="Links you create from a Session will appear here."
+					action={
+						<Button render={<Link to="/sessions" />} nativeButton={false} variant="outline">
+							Browse Sessions
+						</Button>
+					}
+				/>
+			) : (
+				<div className="space-y-4">
+					<div className="overflow-hidden rounded-lg border bg-card">
+						{items.map((share, index) => (
+							<SharedLinkRow
+								key={`${share.kind}:${share.id}`}
+								share={share}
+								onRevoked={refresh}
+								className={index > 0 ? "border-t" : undefined}
+							/>
+						))}
+					</div>
+					<DataTablePagination
+						page={params.page}
+						pageSize={params.pageSize}
+						total={total}
+						onPageChange={(page) => void setParams({ page })}
+						onPageSizeChange={(pageSize) => void setParams({ page: 1, pageSize })}
+					/>
+				</div>
+			)}
+		</div>
+	);
+}
+
+function SharedLinkRow({
+	share,
+	onRevoked,
+	className,
+}: {
+	share: SessionShare;
+	onRevoked: () => void;
+	className?: string;
+}) {
+	const api = useApi();
+	const { copied, copy } = useCopyToClipboard({ success: "Share link copied" });
+	const [confirmOpen, setConfirmOpen] = useState(false);
+	const revoke = useMutation({
+		mutationFn: async () => {
+			if (share.kind === "snapshot") {
+				unwrap(
+					await api.DELETE("/v1/session-shares/{share_id}", {
+						params: { path: { share_id: share.id } },
+					}),
+				);
+				return;
+			}
+			unwrap(
+				await api.DELETE("/v1/sessions/{session_id}/permissions", {
+					params: {
+						path: { session_id: share.session_id },
+						query: { kind: "link" },
+					},
+				}),
+			);
+		},
+		onSuccess: () => {
+			setConfirmOpen(false);
+			onRevoked();
+			toast.success("Share link turned off");
+		},
+		onError: (error) =>
+			toast.error("Couldn't turn off share link", {
+				description: normalizeApiError(error),
+			}),
+	});
+	const scope = shareScopeLabel(share);
+
+	return (
+		<div className={cn("flex flex-col gap-3 p-4 sm:flex-row sm:items-center", className)}>
+			<div className="min-w-0 flex-1">
+				<div className="flex min-w-0 flex-wrap items-center gap-2">
+					<Link
+						to="/sessions/$id"
+						params={{ id: share.session_id }}
+						className="truncate text-sm font-medium underline-offset-4 hover:underline"
+					>
+						{share.session_title}
+					</Link>
+					<Badge variant="outline">{share.kind === "live" ? "Live" : "Snapshot"}</Badge>
+				</div>
+				<p className="mt-1 text-xs text-muted-foreground">
+					{scope} · {share.message_count} {share.message_count === 1 ? "message" : "messages"} ·
+					Created {relativeTime(share.created_at)}
+				</p>
+				{share.kind === "live" ? (
+					<p className="mt-1 text-xs text-muted-foreground">
+						Updates when the Session is uploaded again.
+					</p>
+				) : null}
+			</div>
+			<div className="flex shrink-0 flex-wrap items-center gap-2">
+				<Button variant="outline" size="sm" onClick={() => void copy(share.share_url)}>
+					{copied ? <Check /> : <Copy />}
+					Copy
+				</Button>
+				<Button
+					render={<a href={share.share_url} target="_blank" rel="noreferrer" />}
+					nativeButton={false}
+					variant="outline"
+					size="sm"
+				>
+					<ExternalLink />
+					Open
+				</Button>
+				<Button
+					variant="ghost"
+					size="icon-sm"
+					className="text-muted-foreground hover:text-destructive"
+					onClick={() => setConfirmOpen(true)}
+					aria-label={`Turn off share link for ${share.session_title}`}
+				>
+					<Trash2 />
+				</Button>
+			</div>
+
+			<AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Turn off this share link?</AlertDialogTitle>
+						<AlertDialogDescription>
+							Anyone using this link will immediately lose access. The original Session stays
+							unchanged.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel disabled={revoke.isPending}>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							variant="destructive"
+							disabled={revoke.isPending}
+							onClick={() => revoke.mutate()}
+						>
+							Turn off link
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	);
+}
+
+function shareScopeLabel(share: SessionShare): string {
+	if (share.kind === "live") return "Full Session, live";
+	if (share.scope === "response") return "Single Agent response";
+	if (share.scope === "through") return "Conversation excerpt";
+	return "Full Session snapshot";
+}
+
+function SharedLinksSkeleton() {
+	return (
+		<div className="overflow-hidden rounded-lg border" aria-hidden="true">
+			{Array.from({ length: 4 }, (_, index) => (
+				<div key={index} className={cn("flex items-center gap-4 p-4", index > 0 && "border-t")}>
+					<div className="min-w-0 flex-1 space-y-2">
+						<Skeleton className="h-4 w-48 max-w-full" />
+						<Skeleton className="h-3 w-72 max-w-full" />
+					</div>
+					<Skeleton className="h-8 w-32 shrink-0" />
+				</div>
+			))}
+		</div>
+	);
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -37,6 +37,7 @@ import { Route as ProtectedDashboardProjectsIndexRouteImport } from './routes/_p
 import { Route as ProtectedDashboardProjectsIdRouteImport } from './routes/_protected/_dashboard/projects/$id'
 import { Route as ProtectedDashboardSessionsIndexRouteImport } from './routes/_protected/_dashboard/sessions/index'
 import { Route as ProtectedDashboardSessionsIdRouteImport } from './routes/_protected/_dashboard/sessions/$id'
+import { Route as ProtectedDashboardSessionsSharedRouteImport } from './routes/_protected/_dashboard/sessions/shared'
 import { Route as ProtectedDashboardSkillsIndexRouteImport } from './routes/_protected/_dashboard/skills/index'
 import { Route as ProtectedDashboardSkillsKeyRouteImport } from './routes/_protected/_dashboard/skills/$key'
 import { Route as ProtectedDashboardVaultIndexRouteImport } from './routes/_protected/_dashboard/vault/index'
@@ -211,6 +212,12 @@ const ProtectedDashboardSessionsIdRoute =
     path: '/sessions/$id',
     getParentRoute: () => ProtectedDashboardRoute,
   } as any)
+const ProtectedDashboardSessionsSharedRoute =
+  ProtectedDashboardSessionsSharedRouteImport.update({
+    id: '/sessions/shared',
+    path: '/sessions/shared',
+    getParentRoute: () => ProtectedDashboardRoute,
+  } as any)
 const ProtectedDashboardSkillsIndexRoute =
   ProtectedDashboardSkillsIndexRouteImport.update({
     id: '/skills/',
@@ -353,6 +360,7 @@ export interface FileRoutesByFullPath {
   '/memories/$id': typeof ProtectedDashboardMemoriesIdRoute
   '/projects/$id': typeof ProtectedDashboardProjectsIdRoute
   '/sessions/$id': typeof ProtectedDashboardSessionsIdRoute
+  '/sessions/shared': typeof ProtectedDashboardSessionsSharedRoute
   '/skills/$key': typeof ProtectedDashboardSkillsKeyRoute
   '/vault/$slug': typeof ProtectedDashboardVaultSlugRoute
   '/vaults/$slug': typeof ProtectedDashboardVaultsSlugRoute
@@ -400,6 +408,7 @@ export interface FileRoutesByTo {
   '/memories/$id': typeof ProtectedDashboardMemoriesIdRoute
   '/projects/$id': typeof ProtectedDashboardProjectsIdRoute
   '/sessions/$id': typeof ProtectedDashboardSessionsIdRoute
+  '/sessions/shared': typeof ProtectedDashboardSessionsSharedRoute
   '/skills/$key': typeof ProtectedDashboardSkillsKeyRoute
   '/vault/$slug': typeof ProtectedDashboardVaultSlugRoute
   '/vaults/$slug': typeof ProtectedDashboardVaultsSlugRoute
@@ -450,6 +459,7 @@ export interface FileRoutesById {
   '/_protected/_dashboard/memories/$id': typeof ProtectedDashboardMemoriesIdRoute
   '/_protected/_dashboard/projects/$id': typeof ProtectedDashboardProjectsIdRoute
   '/_protected/_dashboard/sessions/$id': typeof ProtectedDashboardSessionsIdRoute
+  '/_protected/_dashboard/sessions/shared': typeof ProtectedDashboardSessionsSharedRoute
   '/_protected/_dashboard/skills/$key': typeof ProtectedDashboardSkillsKeyRoute
   '/_protected/_dashboard/vault/$slug': typeof ProtectedDashboardVaultSlugRoute
   '/_protected/_dashboard/vaults/$slug': typeof ProtectedDashboardVaultsSlugRoute
@@ -500,6 +510,7 @@ export interface FileRouteTypes {
     | '/memories/$id'
     | '/projects/$id'
     | '/sessions/$id'
+    | '/sessions/shared'
     | '/skills/$key'
     | '/vault/$slug'
     | '/vaults/$slug'
@@ -547,6 +558,7 @@ export interface FileRouteTypes {
     | '/memories/$id'
     | '/projects/$id'
     | '/sessions/$id'
+    | '/sessions/shared'
     | '/skills/$key'
     | '/vault/$slug'
     | '/vaults/$slug'
@@ -596,6 +608,7 @@ export interface FileRouteTypes {
     | '/_protected/_dashboard/memories/$id'
     | '/_protected/_dashboard/projects/$id'
     | '/_protected/_dashboard/sessions/$id'
+    | '/_protected/_dashboard/sessions/shared'
     | '/_protected/_dashboard/skills/$key'
     | '/_protected/_dashboard/vault/$slug'
     | '/_protected/_dashboard/vaults/$slug'
@@ -833,6 +846,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProtectedDashboardSessionsIdRouteImport
       parentRoute: typeof ProtectedDashboardRoute
     }
+    '/_protected/_dashboard/sessions/shared': {
+      id: '/_protected/_dashboard/sessions/shared'
+      path: '/sessions/shared'
+      fullPath: '/sessions/shared'
+      preLoaderRoute: typeof ProtectedDashboardSessionsSharedRouteImport
+      parentRoute: typeof ProtectedDashboardRoute
+    }
     '/_protected/_dashboard/skills/': {
       id: '/_protected/_dashboard/skills/'
       path: '/skills'
@@ -1048,6 +1068,7 @@ interface ProtectedDashboardRouteChildren {
   ProtectedDashboardMemoriesIdRoute: typeof ProtectedDashboardMemoriesIdRoute
   ProtectedDashboardProjectsIdRoute: typeof ProtectedDashboardProjectsIdRoute
   ProtectedDashboardSessionsIdRoute: typeof ProtectedDashboardSessionsIdRoute
+  ProtectedDashboardSessionsSharedRoute: typeof ProtectedDashboardSessionsSharedRoute
   ProtectedDashboardSkillsKeyRoute: typeof ProtectedDashboardSkillsKeyRoute
   ProtectedDashboardVaultSlugRoute: typeof ProtectedDashboardVaultSlugRoute
   ProtectedDashboardVaultsSlugRoute: typeof ProtectedDashboardVaultsSlugRoute
@@ -1072,6 +1093,7 @@ const ProtectedDashboardRouteChildren: ProtectedDashboardRouteChildren = {
   ProtectedDashboardMemoriesIdRoute: ProtectedDashboardMemoriesIdRoute,
   ProtectedDashboardProjectsIdRoute: ProtectedDashboardProjectsIdRoute,
   ProtectedDashboardSessionsIdRoute: ProtectedDashboardSessionsIdRoute,
+  ProtectedDashboardSessionsSharedRoute: ProtectedDashboardSessionsSharedRoute,
   ProtectedDashboardSkillsKeyRoute: ProtectedDashboardSkillsKeyRoute,
   ProtectedDashboardVaultSlugRoute: ProtectedDashboardVaultSlugRoute,
   ProtectedDashboardVaultsSlugRoute: ProtectedDashboardVaultsSlugRoute,

--- a/apps/web/src/routes/_protected/_dashboard/agents/$id/sessions/$sessionId.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/agents/$id/sessions/$sessionId.tsx
@@ -3,6 +3,7 @@ import { AgentResourceRouteGate } from "@/components/dashboard/agent-resource-ro
 import { agentSectionHref } from "@/lib/agent-routes";
 import { routeHeadTitle } from "@/lib/document-title";
 import {
+	DEFAULT_SESSION_TIMELINE_VIEW,
 	sessionSearchAnchorFromSearch,
 	validateSessionDetailSearch,
 } from "@/lib/session-search-anchor";
@@ -30,7 +31,7 @@ function AgentSessionDetailRoute() {
 				sessionId={sessionId}
 				searchAnchor={searchAnchor}
 				searchQuery={search.matchQuery}
-				timelineView={search.timelineView ?? "all"}
+				timelineView={search.timelineView ?? DEFAULT_SESSION_TIMELINE_VIEW}
 			/>
 		</AgentResourceRouteGate>
 	);

--- a/apps/web/src/routes/_protected/_dashboard/sessions/$id.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/sessions/$id.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { routeHeadTitle } from "@/lib/document-title";
 import {
+	DEFAULT_SESSION_TIMELINE_VIEW,
 	sessionSearchAnchorFromSearch,
 	validateSessionDetailSearch,
 } from "@/lib/session-search-anchor";
@@ -21,7 +22,7 @@ function SessionDetailRoute() {
 			sessionId={id}
 			searchAnchor={searchAnchor}
 			searchQuery={search.matchQuery}
-			timelineView={search.timelineView ?? "all"}
+			timelineView={search.timelineView ?? DEFAULT_SESSION_TIMELINE_VIEW}
 			returnTo={search.returnTo}
 		/>
 	);

--- a/apps/web/src/routes/_protected/_dashboard/sessions/shared.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/sessions/shared.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
+import SharedSessionLinksPage from "@/pages/dashboard/sessions/shared-page";
+
+export const Route = createFileRoute("/_protected/_dashboard/sessions/shared")({
+	head: () => routeHeadTitle("Shared Session links"),
+	component: SharedSessionLinksPage,
+});

--- a/backend/app/routes/session_shares.py
+++ b/backend/app/routes/session_shares.py
@@ -4,19 +4,23 @@ from datetime import UTC, datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response, status
-from sqlalchemy import select
+from sqlalchemy import func, literal, or_, select, union_all
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import AuthContext, require_web_auth
+from app.core.config import settings
 from app.core.database import get_session
 from app.models.session import AgentEnvironment, Session
+from app.models.session_permission import PERMISSION_KIND_LINK, SessionPermission
 from app.models.session_share import SessionShare
+from app.schemas.common import Paginated
 from app.schemas.session import (
     PublicSessionShareExportResponse,
     PublicSessionShareResponse,
     SessionMessageResponse,
     SessionMessagesPage,
     SessionShareCreate,
+    SessionShareListItemResponse,
     SessionShareResponse,
     SessionSharesResponse,
 )
@@ -73,6 +77,86 @@ def _share_response(share: SessionShare) -> SessionShareResponse:
         message_count=message_count,
         share_url=session_share_url(share.id),
         created_at=share.created_at,
+    )
+
+
+@router.get("/session-shares")
+async def list_all_session_shares(
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=25, ge=1, le=100),
+    auth: AuthContext = Depends(require_web_auth),
+    db: AsyncSession = Depends(get_session),
+) -> Paginated[SessionShareListItemResponse]:
+    """List every active Session link owned by the signed-in user."""
+    snapshot_rows = (
+        select(
+            SessionShare.id.label("id"),
+            literal("snapshot").label("kind"),
+            Session.id.label("session_id"),
+            Session.summary.label("session_summary"),
+            Session.local_session_id.label("local_session_id"),
+            SessionShare.scope.label("scope"),
+            SessionShare.public_metadata["message_count"].as_integer().label("message_count"),
+            SessionShare.created_at.label("created_at"),
+        )
+        .join(Session, Session.id == SessionShare.session_id)
+        .where(Session.user_id == auth.user_id, SessionShare.revoked_at.is_(None))
+    )
+    live_rows = (
+        select(
+            SessionPermission.id.label("id"),
+            literal("live").label("kind"),
+            Session.id.label("session_id"),
+            Session.summary.label("session_summary"),
+            Session.local_session_id.label("local_session_id"),
+            literal("session").label("scope"),
+            Session.message_count.label("message_count"),
+            SessionPermission.created_at.label("created_at"),
+        )
+        .join(Session, Session.id == SessionPermission.session_id)
+        .where(
+            Session.user_id == auth.user_id,
+            SessionPermission.kind == PERMISSION_KIND_LINK,
+            SessionPermission.revoked_at.is_(None),
+            or_(
+                SessionPermission.expires_at.is_(None),
+                SessionPermission.expires_at > func.now(),
+            ),
+        )
+    )
+    active_links = union_all(snapshot_rows, live_rows).subquery()
+    total = int((await db.execute(select(func.count()).select_from(active_links))).scalar_one())
+    rows = (
+        await db.execute(
+            select(active_links)
+            .order_by(active_links.c.created_at.desc(), active_links.c.id.desc())
+            .limit(page_size)
+            .offset((page - 1) * page_size)
+        )
+    ).all()
+    items = [
+        SessionShareListItemResponse(
+            id=str(row.id),
+            kind=row.kind,
+            session_id=str(row.session_id),
+            session_title=(row.session_summary or "").strip()
+            or f"Session {row.local_session_id[:8]}",
+            scope=row.scope,
+            message_count=row.message_count,
+            share_url=(
+                session_share_url(row.id)
+                if row.kind == "snapshot"
+                else f"{settings.web_origin}/s/{row.session_id}"
+            ),
+            created_at=row.created_at,
+        )
+        for row in rows
+    ]
+    return Paginated[SessionShareListItemResponse](
+        items=items,
+        total=total,
+        page=page,
+        page_size=page_size,
     )
 
 

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -644,6 +644,19 @@ class SessionSharesResponse(BaseModel):
     shares: list[SessionShareResponse]
 
 
+class SessionShareListItemResponse(BaseModel):
+    """One active Session link in the owner's cross-Session inventory."""
+
+    id: str
+    kind: Literal["snapshot", "live"]
+    session_id: str
+    session_title: str
+    scope: Literal["session", "through", "response"]
+    message_count: int = Field(ge=0)
+    share_url: str
+    created_at: datetime
+
+
 class PublicSessionShareResponse(BaseModel):
     id: str
     title: str

--- a/backend/tests/test_session_shares.py
+++ b/backend/tests/test_session_shares.py
@@ -265,6 +265,53 @@ async def test_session_shares_freeze_scope_and_revoke(
 
 
 @pytest.mark.asyncio
+async def test_owner_can_manage_all_active_session_links(
+    client: httpx.AsyncClient,
+) -> None:
+    session_id, _, _ = await _seed_session(client)
+    snapshot = await client.post(
+        f"/v1/sessions/{session_id}/shares",
+        json={"scope": "session"},
+    )
+    assert snapshot.status_code == 201, snapshot.text
+    live = await client.post(
+        f"/v1/sessions/{session_id}/permissions",
+        json={"kind": "link"},
+    )
+    assert live.status_code == 200, live.text
+
+    response = await client.get("/v1/session-shares", params={"page_size": 1})
+    assert response.status_code == 200, response.text
+    first_page = response.json()
+    assert first_page["total"] == 2
+    assert first_page["page"] == 1
+    assert first_page["page_size"] == 1
+
+    second_page = (
+        await client.get("/v1/session-shares", params={"page": 2, "page_size": 1})
+    ).json()
+    links = first_page["items"] + second_page["items"]
+    assert {item["kind"] for item in links} == {"snapshot", "live"}
+    assert {item["session_id"] for item in links} == {session_id}
+    assert {item["session_title"] for item in links} == {"Immutable share"}
+    assert next(item for item in links if item["kind"] == "snapshot")["share_url"].endswith(
+        f"/s/{snapshot.json()['id']}"
+    )
+    assert next(item for item in links if item["kind"] == "live")["share_url"].endswith(
+        f"/s/{session_id}"
+    )
+
+    revoked = await client.delete(
+        f"/v1/sessions/{session_id}/permissions",
+        params={"kind": "link"},
+    )
+    assert revoked.status_code == 204
+    remaining = (await client.get("/v1/session-shares")).json()
+    assert remaining["total"] == 1
+    assert remaining["items"][0]["kind"] == "snapshot"
+
+
+@pytest.mark.asyncio
 async def test_event_session_share_keeps_its_frozen_prefix_after_append(
     client: httpx.AsyncClient,
     anon_client: httpx.AsyncClient,

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -971,6 +971,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/session-shares": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List All Session Shares
+         * @description List every active Session link owned by the signed-in user.
+         */
+        get: operations["list_all_session_shares_v1_session_shares_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/sessions/{session_id}/shares": {
         parameters: {
             query?: never;
@@ -6769,6 +6789,17 @@ export interface components {
             /** Page Size */
             page_size: number;
         };
+        /** Paginated[SessionShareListItemResponse] */
+        Paginated_SessionShareListItemResponse_: {
+            /** Items */
+            items: components["schemas"]["SessionShareListItemResponse"][];
+            /** Total */
+            total: number;
+            /** Page */
+            page: number;
+            /** Page Size */
+            page_size: number;
+        };
         /** Paginated[SkillSummaryResponse] */
         Paginated_SkillSummaryResponse_: {
             /** Items */
@@ -8486,6 +8517,37 @@ export interface components {
             scope: "session" | "through" | "response";
             /** Position */
             position?: number | null;
+        };
+        /**
+         * SessionShareListItemResponse
+         * @description One active Session link in the owner's cross-Session inventory.
+         */
+        SessionShareListItemResponse: {
+            /** Id */
+            id: string;
+            /**
+             * Kind
+             * @enum {string}
+             */
+            kind: "snapshot" | "live";
+            /** Session Id */
+            session_id: string;
+            /** Session Title */
+            session_title: string;
+            /**
+             * Scope
+             * @enum {string}
+             */
+            scope: "session" | "through" | "response";
+            /** Message Count */
+            message_count: number;
+            /** Share Url */
+            share_url: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
         };
         /** SessionShareResponse */
         SessionShareResponse: {
@@ -11235,6 +11297,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SessionEventsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_all_session_shares_v1_session_shares_get: {
+        parameters: {
+            query?: {
+                page?: number;
+                page_size?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Paginated_SessionShareListItemResponse_"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary

- add one owner-scoped page for managing every active Session snapshot and legacy live link
- default Session timelines to You + Agent while keeping Tools opt-in and URL state canonical
- preserve the existing safe public projection: shared content excludes tools, reasoning, and hidden/system events

## Verification

- `bash scripts/test.sh web src/lib/session-search-anchor.test.ts src/lib/agent-routes.test.ts`
- `bash scripts/test.sh backend tests/test_session_shares.py`
- Playwright Chromium: `session-sharing.pw.ts` and `session-search-navigation.pw.ts` (7 passed; focused rerun 2 passed)
- Biome and Ruff format/check
- generated OpenAPI client consistency
- `git diff --check`