### PR TITLE
fix(runtime): recover OpenClaw state migrations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.40",
+      "version": "0.14.41",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.40",
+	"version": "0.14.41",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/hosted-openclaw-context.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-context.ts
@@ -28,6 +28,13 @@ const OPENCLAW_GATEWAY_TRANSITION_RETRIES = 2;
 const OPENCLAW_GATEWAY_TRANSITION_RETRY_DELAY_MS = 3_000;
 const openClawWorkspaces = new Map<string, { revision: string; workspace: string }>();
 
+class OpenClawWorkspaceRosterError extends Error {
+	constructor(readonly doctorRepairRequired: boolean) {
+		super("OpenClaw official agent workspace roster is unavailable");
+		this.name = "OpenClawWorkspaceRosterError";
+	}
+}
+
 export type OpenClawHostedContext = ReturnType<typeof createOpenClawHostedContext>;
 
 function installedCommandPath(home: string): string | null {
@@ -137,7 +144,13 @@ export function resolveHostedOpenClawWorkspace(home: string): string {
 		});
 	}
 	if (result.status !== 0) {
-		throw new Error("OpenClaw official agent workspace roster is unavailable");
+		const output = [result.stderr, result.stdout]
+			.filter((value): value is string => typeof value === "string")
+			.join("\n");
+		throw new OpenClawWorkspaceRosterError(
+			output.includes("OpenClaw startup migrations did not complete cleanly") &&
+				output.includes('Run "openclaw doctor --fix"'),
+		);
 	}
 	const workspace = parseOfficialWorkspaceRoster(String(result.stdout));
 	openClawWorkspaces.set(home, { revision, workspace });
@@ -179,6 +192,11 @@ export function repairHostedOpenClawConfig(home: string): boolean {
 		{ timeoutMs: OPENCLAW_CONFIG_PROBE_TIMEOUT_MS, maxBufferBytes: 1024 * 1024 },
 	);
 	if (!invalidConfigValidation(validation)) return false;
+	runHostedOpenClawDoctor(home, command);
+	return true;
+}
+
+function runHostedOpenClawDoctor(home: string, command = commandPath(home)): void {
 	const repair = spawnRuntimeUserCommand(
 		command,
 		["doctor", "--fix", "--non-interactive"],
@@ -186,8 +204,15 @@ export function repairHostedOpenClawConfig(home: string): boolean {
 		home,
 		{ timeoutMs: OPENCLAW_CONFIG_REPAIR_TIMEOUT_MS, maxBufferBytes: 4 * 1024 * 1024 },
 	);
-	if (repair.status !== 0) throw new Error("OpenClaw official config repair failed");
-	return true;
+	if (repair.status !== 0) throw new Error("OpenClaw official repair failed");
+}
+
+export function repairHostedOpenClawWorkspace(home: string, error: unknown): boolean {
+	if (error instanceof OpenClawWorkspaceRosterError && error.doctorRepairRequired) {
+		runHostedOpenClawDoctor(home);
+		return true;
+	}
+	return repairHostedOpenClawConfig(home);
 }
 
 function resolveSdkExports(

--- a/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
 	repairHostedOpenClawConfig,
+	repairHostedOpenClawWorkspace,
 	resolveHostedOpenClawWorkspace,
 } from "./hosted-openclaw-context";
 import { activateHostedOpenClawSkill } from "./hosted-openclaw-skill";
@@ -213,6 +214,49 @@ esac
 		"agents list --json",
 	]);
 	expect(JSON.parse(readFileSync(configPath, "utf-8"))).toEqual(repairedConfig);
+});
+
+test("repairs an official state migration failure before retrying the workspace roster", () => {
+	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-state-repair-"));
+	const home = join(root, "home");
+	const workspaceRoot = join(home, "agent-workspace");
+	const command = join(home, ".local", "bin", "openclaw");
+	const repaired = join(root, "repaired");
+	const commandLog = join(root, "commands.log");
+	mkdirSync(dirname(command), { recursive: true });
+	writeFileSync(
+		command,
+		`#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> '${commandLog}'
+case "$*" in
+  "agents list --json")
+    if test ! -f '${repaired}'; then
+      printf '%s\n' 'OpenClaw startup migrations did not complete cleanly.' 'Run "openclaw doctor --fix" against the same state/config, then restart the gateway.' >&2
+      exit 1
+    fi
+    printf '%s\n' '[{"id":"main","workspace":"${workspaceRoot}"}]'
+    ;;
+  "doctor --fix --non-interactive") touch '${repaired}' ;;
+  *) exit 64 ;;
+esac
+`,
+	);
+	chmodSync(command, 0o755);
+
+	let rosterError: unknown;
+	try {
+		resolveHostedOpenClawWorkspace(home);
+	} catch (error) {
+		rosterError = error;
+	}
+	expect(repairHostedOpenClawWorkspace(home, rosterError)).toBe(true);
+	expect(resolveHostedOpenClawWorkspace(home)).toBe(workspaceRoot);
+	expect(readFileSync(commandLog, "utf-8").trim().split("\n")).toEqual([
+		"agents list --json",
+		"doctor --fix --non-interactive",
+		"agents list --json",
+	]);
 });
 
 test("does not repair without opt-in or a definitive invalid-config validation", () => {

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -20,7 +20,7 @@ import {
 } from "./hosted-agent-plugin-runtime";
 import {
 	createOpenClawHostedContext,
-	repairHostedOpenClawConfig,
+	repairHostedOpenClawWorkspace,
 	resolveHostedOpenClawWorkspace,
 } from "./hosted-openclaw-context";
 import { assertHostedRuntimeContract } from "./hosted-runtime-contract";
@@ -192,7 +192,7 @@ function resolveOpenClawWorkspaceForConvergence(
 	try {
 		return resolveHostedOpenClawWorkspace(home);
 	} catch (error) {
-		if (!repairInvalidConfig || !repairHostedOpenClawConfig(home)) throw error;
+		if (!repairInvalidConfig || !repairHostedOpenClawWorkspace(home, error)) throw error;
 		return resolveHostedOpenClawWorkspace(home);
 	}
 }


### PR DESCRIPTION
## Summary

- detect the official OpenClaw startup-migration repair diagnostic when the Hosted workspace roster probe fails
- run the existing `openclaw doctor --fix --non-interactive` recovery path before retrying the roster
- preserve the existing typed invalid-config gate for all other roster failures
- release as `clawdi@0.14.41`

## Production impact

Restores a desired-running Hosted OpenClaw deployment blocked by a canonical SQLite versus legacy device-identity migration conflict. The repair remains fail-closed unless OpenClaw itself emits its explicit Doctor instruction.

## Verification

- `bun test packages/cli/src/runtime/hosted-openclaw-skill.test.ts` (8 passed)
- `bun run --cwd packages/cli typecheck`
- `bunx biome check packages/cli/src/runtime/hosted-openclaw-context.ts packages/cli/src/runtime/manifest-converge.ts packages/cli/src/runtime/hosted-openclaw-skill.test.ts packages/cli/package.json bun.lock`
- `git diff --check`

OpenClaw upstream documents Doctor as the repair owner for legacy device identity migration into canonical SQLite state.
