### PR TITLE
Protect Cloud API during database saturation

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -19,10 +19,12 @@ on:
       - "patches/libsignal@6.0.0.patch"
       - "scripts/openapi-typescript.sh"
       - "scripts/test-kamal-whatsapp-sidecar-render.sh"
+      - "scripts/deploy-backend.sh"
       - "scripts/deploy-whatsapp-sidecar.sh"
       - "scripts/whatsapp-sidecar-deployment-revision.ts"
       - "scripts/clawdi-image-release-plan.ts"
       - "scripts/test-deploy-whatsapp-sidecar.sh"
+      - "scripts/test-deploy-backend.sh"
       - "scripts/check_postgres_image_parity.py"
       - "tools/openapi-typescript/**"
       - ".github/actions/setup-bun-ci/**"
@@ -47,10 +49,12 @@ on:
       - "patches/libsignal@6.0.0.patch"
       - "scripts/openapi-typescript.sh"
       - "scripts/test-kamal-whatsapp-sidecar-render.sh"
+      - "scripts/deploy-backend.sh"
       - "scripts/deploy-whatsapp-sidecar.sh"
       - "scripts/whatsapp-sidecar-deployment-revision.ts"
       - "scripts/clawdi-image-release-plan.ts"
       - "scripts/test-deploy-whatsapp-sidecar.sh"
+      - "scripts/test-deploy-backend.sh"
       - "scripts/check_postgres_image_parity.py"
       - "tools/openapi-typescript/**"
       - ".github/actions/setup-bun-ci/**"
@@ -121,10 +125,12 @@ jobs:
               - "packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts"
               - "packages/cli/tests/clawdi-image-release-workflow.test.ts"
               - "scripts/test-kamal-whatsapp-sidecar-render.sh"
+              - "scripts/deploy-backend.sh"
               - "scripts/deploy-whatsapp-sidecar.sh"
               - "scripts/whatsapp-sidecar-deployment-revision.ts"
               - "scripts/clawdi-image-release-plan.ts"
               - "scripts/test-deploy-whatsapp-sidecar.sh"
+              - "scripts/test-deploy-backend.sh"
               - "config/deploy.yml"
               - "package.json"
               - "bun.lock"
@@ -274,11 +280,13 @@ jobs:
           FROM ruby:3.4.10-bookworm@sha256:8ff02c55f0467a3d03bc6c41b7500f9f0b30086a1861c601cd4e9dc5b8536a66
           WORKDIR /repo
           COPY config/deploy.yml config/deploy.yml
+          COPY scripts/deploy-backend.sh scripts/deploy-backend.sh
           COPY scripts/deploy-whatsapp-sidecar.sh scripts/deploy-whatsapp-sidecar.sh
+          COPY scripts/test-deploy-backend.sh scripts/test-deploy-backend.sh
           COPY scripts/test-deploy-whatsapp-sidecar.sh scripts/test-deploy-whatsapp-sidecar.sh
           COPY scripts/test-kamal-whatsapp-sidecar-render.sh scripts/test-kamal-whatsapp-sidecar-render.sh
           RUN gem install kamal -v '2.12.0' --no-document
-          RUN scripts/test-kamal-whatsapp-sidecar-render.sh && scripts/test-deploy-whatsapp-sidecar.sh
+          RUN scripts/test-kamal-whatsapp-sidecar-render.sh && scripts/test-deploy-backend.sh && scripts/test-deploy-whatsapp-sidecar.sh
           DOCKERFILE
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -385,7 +385,4 @@ jobs:
             )"
           fi
           scripts/deploy-whatsapp-sidecar.sh
-          kamal app exec --primary --roles web --raw \
-            --version "${{ needs.build.outputs.image_tag }}" \
-            alembic upgrade head
-          kamal deploy -P --version "${{ needs.build.outputs.image_tag }}"
+          scripts/deploy-backend.sh

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import text
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
@@ -72,7 +73,7 @@ from app.services.channels import close_channel_provider_http_client
 from app.services.composio import close_composio_client
 from app.services.embedding import LocalEmbedder
 from app.services.memory_types import MemoryProviderUnavailableError, MemoryProviderUpstreamError
-from app.services.metrics import observe_event_loop_lag
+from app.services.metrics import db_pool_timeouts, observe_event_loop_lag
 from app.services.sync_events import start_postgres_listener, stop_postgres_listener
 from app.services.whatsapp_sidecar_registry import ConfiguredWhatsAppSidecarClientPool
 
@@ -410,6 +411,24 @@ async def memory_provider_upstream_exception_handler(
     )
 
 
+@app.exception_handler(SQLAlchemyTimeoutError)
+async def database_pool_timeout_exception_handler(
+    request: Request,
+    _exc: SQLAlchemyTimeoutError,
+) -> Response:
+    db_pool_timeouts.inc()
+    log.warning("database_pool_exhausted")
+    response = JSONResponse(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        content={"detail": "Database capacity temporarily unavailable"},
+        headers={"Retry-After": "1", "Cache-Control": "no-store"},
+    )
+    return _apply_whatsapp_onboarding_cache_policy(
+        request,
+        _apply_public_session_export_cache_policy(request, response),
+    )
+
+
 @app.exception_handler(StarletteHTTPException)
 async def clawdi_http_exception_handler(
     request: Request,
@@ -449,12 +468,13 @@ def _is_whatsapp_onboarding_request(request: Request) -> bool:
 
 
 @app.get("/health", response_model=HealthResponse)
-async def health(db: AsyncSession = Depends(get_session)) -> HealthResponse:
-    """Liveness + DB connectivity probe.
+async def health() -> HealthResponse:
+    """Return process liveness without coupling restarts to PostgreSQL."""
+    return HealthResponse(status="ok")
 
-    Returns 200 + ``{"status": "ok"}`` on success. If the DB is unreachable
-    the dependency raises and FastAPI returns 500 — the right signal for a
-    load balancer to yank this pod out of rotation.
-    """
+
+@app.get("/ready", response_model=HealthResponse)
+async def ready(db: AsyncSession = Depends(get_session)) -> HealthResponse:
+    """Return whether the API can currently acquire and query PostgreSQL."""
     await db.execute(text("SELECT 1"))
     return HealthResponse(status="ok")

--- a/backend/app/services/metrics.py
+++ b/backend/app/services/metrics.py
@@ -150,6 +150,11 @@ db_pool_checked_out = Gauge(
     multiprocess_mode="sum",
     registry=registry,
 )
+db_pool_timeouts = Counter(
+    "clawdi_backend_db_pool_timeouts_total",
+    "Requests rejected because the backend database pool was exhausted",
+    registry=registry,
+)
 
 
 def render_metrics() -> bytes:

--- a/backend/tests/test_api_version_alias.py
+++ b/backend/tests/test_api_version_alias.py
@@ -107,7 +107,11 @@ def test_openapi_schema_advertises_only_v1_and_direct_runtime_v2():
     routes = _routes_by_path()
     assert routes["/v1/webhooks/clerk"] == {"POST"}
 
-    non_v1 = {path for path in spec["paths"] if not path.startswith("/v1/") and path != "/health"}
+    non_v1 = {
+        path
+        for path in spec["paths"]
+        if not path.startswith("/v1/") and path not in {"/health", "/ready"}
+    }
     assert non_v1
     assert all(path.startswith("/v2/runtime/") for path in non_v1)
     assert all(not path.startswith("/api/") for path in spec["paths"])

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -68,6 +68,7 @@ def test_metrics_exports_all_expected_metrics() -> None:
     assert "clawdi_backend_db_query_duration_seconds" in text
     assert "clawdi_backend_db_connection_hold_duration_seconds" in text
     assert "clawdi_backend_db_pool_checked_out" in text
+    assert "clawdi_backend_db_pool_timeouts_total" in text
 
 
 def test_metrics_increment_counters() -> None:

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 import httpx
 import pytest
 from httpx import ASGITransport
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
+from app.core.database import get_session
 from app.main import app
 
 
@@ -26,6 +28,39 @@ async def test_health_endpoint(client: httpx.AsyncClient):
     r = await client.get("/health")
     assert r.status_code == 200
     assert r.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_readiness_endpoint(client: httpx.AsyncClient):
+    r = await client.get("/ready")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_liveness_survives_database_pool_exhaustion():
+    async def exhausted_session():
+        raise SQLAlchemyTimeoutError("private pool state")
+        yield
+
+    previous_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[get_session] = exhausted_session
+    try:
+        transport = ASGITransport(app=app, raise_app_exceptions=False)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+            health = await ac.get("/health")
+            ready = await ac.get("/ready")
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(previous_overrides)
+
+    assert health.status_code == 200
+    assert health.json() == {"status": "ok"}
+    assert ready.status_code == 503
+    assert ready.json() == {"detail": "Database capacity temporarily unavailable"}
+    assert ready.headers["Retry-After"] == "1"
+    assert ready.headers["Cache-Control"] == "no-store"
+    assert "private pool state" not in ready.text
 
 
 @pytest.mark.asyncio

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -59,9 +59,11 @@ servers:
         # Each uvicorn worker loads its own local embedding model, so the
         # production web role must stay single-process on this host.
         WEB_CONCURRENCY: 1
-        # Preserve the previous web role's aggregate 40-connection budget.
-        DB_POOL_SIZE: 20
-        DB_MAX_OVERFLOW: 20
+        # One 10+10 pool leaves room for the channels worker, one overlapping
+        # web generation during rollout, and PostgreSQL operational sessions.
+        DB_POOL_SIZE: 10
+        DB_MAX_OVERFLOW: 10
+        DB_POOL_TIMEOUT: 5
         PROMETHEUS_MULTIPROC_DIR: /tmp/clawdi-prometheus-multiproc
   channels-worker:
     hosts:
@@ -74,6 +76,11 @@ servers:
     env:
       clear:
         CLAWDI_PROCESS_ROLE: channels-worker
+        # Bound the non-proxied role independently: Kamal overlaps old and new
+        # containers for this role during an ordinary rolling deployment too.
+        DB_POOL_SIZE: 10
+        DB_MAX_OVERFLOW: 10
+        DB_POOL_TIMEOUT: 5
 
 proxy:
   hosts:
@@ -317,9 +324,6 @@ env:
     PLUGIN_CATALOG_SYNC_ENABLED: "true"
     FILE_STORE_TYPE: s3
     MEMORY_EMBEDDING_MODE: local
-    DB_POOL_SIZE: 20
-    DB_MAX_OVERFLOW: 20
-    DB_POOL_TIMEOUT: 45
     FILE_STORE_S3_BUCKET: clawdi
     FILE_STORE_S3_REGION: auto
     FILE_STORE_S3_FORCE_PATH_STYLE: true

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -355,9 +355,34 @@ non-primary roles. Every migration must therefore remain expand/contract
 compatible with the old API during this window. Operators must use the release
 workflow rather than running Alembic independently.
 
-The proxy `/health` gate reaches the API handler that executes database
-`SELECT 1`. The image-level Docker HEALTHCHECK calls the same local path for
-both roles. On the worker, `/health` returns failure until
+Both application roles declare independent `10 + 10` PostgreSQL pools with a
+5-second acquisition timeout. The normal steady-state budget is 40 connections.
+The production workflow rolls `channels-worker` and `web` sequentially, so a
+bounded-pool release reserves at most 60 of PostgreSQL's 100 connections and
+leaves at least 40 for migrations, operators, and transient database work.
+
+The deploy helper inspects the running roles before every release and accepts
+only the legacy `20 + 20` or bounded `10 + 10` pool contracts. Unknown or
+ambiguous runtime state fails closed. During the one-time legacy transition it
+stops the old channels worker before deploying `channels-worker`, then deploys
+`web` for the same full SHA. This keeps the transition at or below 80 reserved
+connections instead of the 120 possible with an all-role rollout:
+
+```bash
+scripts/deploy-backend.sh
+```
+
+The helper checks for at least 20 currently available ordinary PostgreSQL
+connection slots, after subtracting reserved slots, before migration and before
+each role deployment. It also verifies that each role converged to the requested
+image and bounded pool. It is the normal release path after the transition; no
+rollout flag or manual mode switch is required.
+
+The proxy `/health` gate is process liveness and deliberately does not acquire
+a PostgreSQL connection. Database-aware verification uses `/ready`, so pool
+pressure cannot turn a recoverable database slowdown into a restart loop or
+remove the only API target. The image-level Docker HEALTHCHECK calls the same
+local liveness path for both roles. On the worker, `/health` returns failure until
 `ChannelWorkerHealth.ready` is true and returns failure again while stopping,
 so Docker cannot report the worker healthy before its worker stack is ready.
 Under Docker's official [HEALTHCHECK timing

--- a/packages/cli/tests/clawdi-image-release-workflow.test.ts
+++ b/packages/cli/tests/clawdi-image-release-workflow.test.ts
@@ -243,9 +243,7 @@ describe("backend image release workflow contract", () => {
 			`deploy-vps \${{ needs.build.outputs.image_tag }}`,
 		);
 		expect(deployCheckout?.with?.ref).toBe(`\${{ needs.build.outputs.image_tag }}`);
-		expect(imageReleaseSource).toContain(
-			`kamal deploy -P --version "\${{ needs.build.outputs.image_tag }}"`,
-		);
+		expect(imageReleaseSource).toContain("scripts/deploy-backend.sh");
 		expect(releaseRunbook).toContain("commit-addressed OCI image tag");
 		expect(releaseRunbook).toContain("tags remain mutable");
 		expect(releaseRunbook).not.toContain("immutable OCI image tag");
@@ -324,8 +322,8 @@ describe("backend image release workflow contract", () => {
 					".github/workflows/clawdi-image-release.yml",
 					replaceOnce(
 						imageReleaseSource,
-						"kamal deploy -P --version",
-						"kamal deploy --verbose -P --version",
+						"scripts/deploy-backend.sh",
+						"scripts/deploy-backend.sh --verbose",
 					),
 				],
 			]),
@@ -445,12 +443,8 @@ describe("backend image release workflow contract", () => {
 		);
 		expect(kamalDeploy?.run).toContain("gem install kamal -v '2.12.0' --no-document");
 		expect(kamalDeploy?.run).toContain('test "$(kamal version)" = "2.12.0"');
-		expect(kamalDeploy?.run).toContain("kamal app exec --primary --roles web --raw");
-		expect(kamalDeploy?.run).toContain(`--version "\${{ needs.build.outputs.image_tag }}"`);
-		expect(kamalDeploy?.run).toContain("alembic upgrade head");
-		expect(kamalDeploy?.run).toContain(
-			`kamal deploy -P --version "\${{ needs.build.outputs.image_tag }}"`,
-		);
+		expect(kamalDeploy?.run).toContain("scripts/deploy-backend.sh");
+		expect(kamalDeploy?.run).not.toContain("kamal deploy -P --version");
 		expect(imageReleaseSource).not.toContain("~> 2.12");
 		expect(imageReleaseSource).not.toContain("--lock-wait");
 		expect(deployConfigSource).toMatch(/^minimum_version: 2\.12\.0$/m);

--- a/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
+++ b/packages/cli/tests/whatsapp-sidecar-deploy-contract.test.ts
@@ -83,9 +83,7 @@ describe("WhatsApp sidecar production deployment contract", () => {
 
 	test("prepares transparent egress before recreating the sidecar", () => {
 		const helperCall = workflow.lastIndexOf("scripts/deploy-whatsapp-sidecar.sh");
-		const appDeploy = workflow.indexOf(
-			`kamal deploy -P --version "\${{ needs.build.outputs.image_tag }}"`,
-		);
+		const appDeploy = workflow.indexOf("scripts/deploy-backend.sh");
 
 		expect(helperCall).toBeGreaterThan(0);
 		expect(appDeploy).toBeGreaterThan(helperCall);

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -3504,13 +3504,29 @@ export interface paths {
         };
         /**
          * Health
-         * @description Liveness + DB connectivity probe.
-         *
-         *     Returns 200 + ``{"status": "ok"}`` on success. If the DB is unreachable
-         *     the dependency raises and FastAPI returns 500 — the right signal for a
-         *     load balancer to yank this pod out of rotation.
+         * @description Return process liveness without coupling restarts to PostgreSQL.
          */
         get: operations["health_health_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ready": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Ready
+         * @description Return whether the API can currently acquire and query PostgreSQL.
+         */
+        get: operations["ready_ready_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -16400,6 +16416,26 @@ export interface operations {
         };
     };
     health_health_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HealthResponse"];
+                };
+            };
+        };
+    };
+    ready_ready_get: {
         parameters: {
             query?: never;
             header?: never;

--- a/scripts/clawdi-image-release-plan.ts
+++ b/scripts/clawdi-image-release-plan.ts
@@ -15,6 +15,7 @@ const IMAGE_RELEASE_WORKFLOW = ".github/workflows/clawdi-image-release.yml";
 const DEPLOYMENT_FILE_INPUTS = [
 	".github/actions/setup-bun-ci/action.yml",
 	"config/deploy.yml",
+	"scripts/deploy-backend.sh",
 	"scripts/deploy-whatsapp-sidecar.sh",
 ] as const;
 
@@ -60,13 +61,19 @@ export function calculateClawdiImageRevisionsFromSnapshot(
 		],
 	]);
 	for (const path of DEPLOYMENT_FILE_INPUTS) {
-		deploymentInputs.set(path, snapshot.readText(path));
+		deploymentInputs.set(path, readOptionalSnapshotText(snapshot, path));
 	}
 	return {
 		backend: hashInputs(backendInputs),
 		deployment: hashInputs(deploymentInputs),
 		sidecar: calculateWhatsAppSidecarDeploymentRevisionFromSnapshot(snapshot),
 	};
+}
+
+function readOptionalSnapshotText(snapshot: RevisionSnapshot, path: string): string {
+	return snapshot.listFiles(dirname(path)).includes(path)
+		? snapshot.readText(path)
+		: `<missing:${path}>`;
 }
 
 function assertBackendDockerInputContract(dockerfile: string, dockerignore: string): void {

--- a/scripts/deploy-backend.sh
+++ b/scripts/deploy-backend.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly service="clawdi"
+readonly desired_pool="10:10:5"
+readonly legacy_pool="20:20:45"
+readonly minimum_available_connections=20
+readonly backend_image="ghcr.io/clawdi-ai/clawdi-backend:${DEPLOY_IMAGE_VERSION:?}"
+
+[[ "${DEPLOY_IMAGE_VERSION}" =~ ^[0-9a-f]{40}$ ]] || {
+	echo "DEPLOY_IMAGE_VERSION must be a full Git SHA" >&2
+	exit 1
+}
+
+remote_value() {
+	local output value
+	output="$(kamal server exec "$1")"
+	value="$(printf '%s\n' "${output}" | sed -n 's/^.*CLAWDI_VALUE=//p' | tail -n 1)"
+	[[ -n "${value}" ]] || { echo "Remote inspection returned no value" >&2; exit 1; }
+	printf '%s\n' "${value}"
+}
+
+role_state() {
+	local role="$1"
+	remote_value "
+		set -- \$(docker ps -q --no-trunc --filter 'label=service=${service}' --filter 'label=role=${role}')
+		if [ \"\$#\" -eq 0 ]; then printf 'CLAWDI_VALUE=missing\\n'; exit 0; fi
+		test \"\$#\" -eq 1
+		container=\$1
+		environment=\$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' \"\$container\")
+		pool_size=\$(printf '%s\\n' \"\$environment\" | sed -n 's/^DB_POOL_SIZE=//p')
+		max_overflow=\$(printf '%s\\n' \"\$environment\" | sed -n 's/^DB_MAX_OVERFLOW=//p')
+		pool_timeout=\$(printf '%s\\n' \"\$environment\" | sed -n 's/^DB_POOL_TIMEOUT=//p')
+		image=\$(docker inspect --format '{{.Config.Image}}' \"\$container\")
+		printf 'CLAWDI_VALUE=%s|%s|%s:%s:%s\\n' \"\$container\" \"\$image\" \"\$pool_size\" \"\$max_overflow\" \"\$pool_timeout\"
+	"
+}
+
+validate_role_state() {
+	local role="$1" state="$2" container image pool
+	[[ "${state}" == missing ]] && return
+	IFS='|' read -r container image pool <<<"${state}"
+	[[ "${container}" =~ ^[0-9a-f]{64}$ && -n "${image}" ]] || {
+		echo "Invalid ${role} container state" >&2
+		exit 1
+	}
+	case "${pool}" in
+		"${legacy_pool}"|"${desired_pool}") ;;
+		*) echo "Refusing unknown ${role} database pool: ${pool}" >&2; exit 1 ;;
+	esac
+}
+
+require_database_headroom() {
+	local available output
+	output="$(kamal accessory exec postgres --reuse \
+		"psql -U clawdi -d clawdi -Atqc \"SELECT 'CLAWDI_VALUE=' || (current_setting('max_connections')::int - current_setting('superuser_reserved_connections')::int - current_setting('reserved_connections')::int - count(*) FILTER (WHERE backend_type = 'client backend')) FROM pg_stat_activity\"")"
+	available="$(printf '%s\n' "${output}" | sed -n 's/^.*CLAWDI_VALUE=//p' | tail -n 1)"
+	[[ "${available}" =~ ^[0-9]+$ ]] || { echo "Invalid PostgreSQL capacity result" >&2; exit 1; }
+	(( available >= minimum_available_connections )) || {
+		echo "PostgreSQL has ${available} available connections; ${minimum_available_connections} required" >&2
+		exit 1
+	}
+}
+
+assert_deployed_role() {
+	local role="$1" state container image pool
+	state="$(role_state "${role}")"
+	validate_role_state "${role}" "${state}"
+	[[ "${state}" != missing ]] || { echo "${role} is not running after deployment" >&2; exit 1; }
+	IFS='|' read -r container image pool <<<"${state}"
+	[[ "${image}" == "${backend_image}" && "${pool}" == "${desired_pool}" ]] || {
+		echo "${role} did not converge to the requested image and database pool" >&2
+		exit 1
+	}
+}
+
+web_state="$(role_state web)"
+channels_state="$(role_state channels-worker)"
+validate_role_state web "${web_state}"
+validate_role_state channels-worker "${channels_state}"
+
+require_database_headroom
+kamal app exec --primary --roles web --raw \
+	--version "${DEPLOY_IMAGE_VERSION}" alembic upgrade head
+
+if [[ "${channels_state}" == *"|${legacy_pool}" ]]; then
+	kamal app stop --roles channels-worker
+fi
+
+require_database_headroom
+kamal deploy -P --roles channels-worker --version "${DEPLOY_IMAGE_VERSION}"
+assert_deployed_role channels-worker
+
+require_database_headroom
+kamal deploy -P --roles web --version "${DEPLOY_IMAGE_VERSION}"
+assert_deployed_role web

--- a/scripts/test-deploy-backend.sh
+++ b/scripts/test-deploy-backend.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf -- "${tmp}"' EXIT
+mkdir -p "${tmp}/bin"
+
+cat > "${tmp}/bin/kamal" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "${FAKE_LOG}"
+case "$*" in
+	"deploy -P --roles web "*) touch "${FAKE_LOG}.web.deployed"; exit 0 ;;
+	"deploy -P --roles channels-worker "*) touch "${FAKE_LOG}.channels-worker.deployed"; exit 0 ;;
+	"app exec "*|"app stop "*) exit 0 ;;
+	"accessory exec postgres "*) echo "CLAWDI_VALUE=${AVAILABLE_CONNECTIONS:-80}"; exit 0 ;;
+	*"docker ps -q"*"role=web"*) role=web ;;
+	*"docker ps -q"*"role=channels-worker"*) role=channels-worker ;;
+	*) exit 0 ;;
+esac
+
+pool="${WEB_POOL}"
+[[ "${role}" == channels-worker ]] && pool="${CHANNELS_POOL}"
+if [[ "${pool}" == missing ]]; then
+	echo "CLAWDI_VALUE=missing"
+	exit 0
+fi
+image="ghcr.io/clawdi-ai/clawdi-backend:${CURRENT_IMAGE}"
+if [[ -f "${FAKE_LOG}.${role}.deployed" ]]; then
+	pool=10:10:5
+	image="ghcr.io/clawdi-ai/clawdi-backend:${DEPLOY_IMAGE_VERSION}"
+fi
+echo "CLAWDI_VALUE=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|${image}|${pool}"
+FAKE
+chmod +x "${tmp}/bin/kamal"
+
+readonly target_image=0123456789abcdef0123456789abcdef01234567
+readonly current_image=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+run() {
+	local scenario="$1" web_pool="$2" channels_pool="$3" available="${4:-80}"
+	local log="${tmp}/${scenario}.log"
+	if ! FAKE_LOG="${log}" PATH="${tmp}/bin:${PATH}" \
+		DEPLOY_IMAGE_VERSION="${target_image}" CURRENT_IMAGE="${current_image}" \
+		WEB_POOL="${web_pool}" CHANNELS_POOL="${channels_pool}" \
+		AVAILABLE_CONNECTIONS="${available}" \
+		"${root}/scripts/deploy-backend.sh" >/dev/null; then
+		return 1
+	fi
+	printf '%s\n' "${log}"
+}
+
+legacy="$(run legacy 20:20:45 20:20:45)"
+grep -q '^app stop --roles channels-worker$' "${legacy}"
+migration_line="$(grep -n 'app exec --primary --roles web --raw' "${legacy}" | cut -d: -f1)"
+channels_line="$(grep -n 'deploy -P --roles channels-worker' "${legacy}" | cut -d: -f1)"
+web_line="$(grep -n 'deploy -P --roles web' "${legacy}" | cut -d: -f1)"
+test "${migration_line}" -lt "${channels_line}" && test "${channels_line}" -lt "${web_line}"
+
+bounded="$(run bounded 10:10:5 10:10:5)"
+! grep -q 'app stop' "${bounded}"
+grep -q 'deploy -P --roles channels-worker' "${bounded}"
+grep -q 'deploy -P --roles web' "${bounded}"
+
+resumed="$(run resumed 20:20:45 10:10:5)"
+! grep -q 'app stop' "${resumed}"
+grep -q 'deploy -P --roles channels-worker' "${resumed}"
+
+if run invalid 12:12:5 10:10:5 >/dev/null 2>&1; then
+	echo "Expected an unknown pool configuration to fail" >&2
+	exit 1
+fi
+
+if run saturated 20:20:45 20:20:45 19 >/dev/null 2>&1; then
+	echo "Expected insufficient PostgreSQL headroom to fail" >&2
+	exit 1
+fi

--- a/scripts/test-kamal-whatsapp-sidecar-render.sh
+++ b/scripts/test-kamal-whatsapp-sidecar-render.sh
@@ -144,8 +144,9 @@ end
 web = config.role("web")
 expected_web_env = {
   "WEB_CONCURRENCY" => 1,
-  "DB_POOL_SIZE" => 20,
-  "DB_MAX_OVERFLOW" => 20,
+  "DB_POOL_SIZE" => 10,
+  "DB_MAX_OVERFLOW" => 10,
+  "DB_POOL_TIMEOUT" => 5,
   "PROMETHEUS_MULTIPROC_DIR" => "/tmp/clawdi-prometheus-multiproc",
 }
 unless web.specialized_env.clear == expected_web_env
@@ -153,16 +154,22 @@ unless web.specialized_env.clear == expected_web_env
 end
 raise "web role memory drifted" unless config.raw_config.servers.dig("web", "options", "memory") == "6g"
 web_env = web.env(web.primary_host).clear
-unless web_env.values_at("DB_POOL_SIZE", "DB_MAX_OVERFLOW") == [ 20, 20 ]
+unless web_env.values_at("DB_POOL_SIZE", "DB_MAX_OVERFLOW", "DB_POOL_TIMEOUT") == [ 10, 10, 5 ]
   raise "web role database pool drifted"
 end
 channels_worker = config.role("channels-worker")
-worker_role = channels_worker.specialized_env.clear == { "CLAWDI_PROCESS_ROLE" => "channels-worker" }
+expected_channels_worker_env = {
+  "CLAWDI_PROCESS_ROLE" => "channels-worker",
+  "DB_POOL_SIZE" => 10,
+  "DB_MAX_OVERFLOW" => 10,
+  "DB_POOL_TIMEOUT" => 5,
+}
+worker_role = channels_worker.specialized_env.clear == expected_channels_worker_env
 unless worker_role && !channels_worker.running_proxy?
   raise "channels-worker role contract drifted"
 end
 channels_worker_env = channels_worker.env(channels_worker.primary_host).clear
-unless channels_worker_env.values_at("DB_POOL_SIZE", "DB_MAX_OVERFLOW") == [ 20, 20 ]
+unless channels_worker_env.values_at("DB_POOL_SIZE", "DB_MAX_OVERFLOW", "DB_POOL_TIMEOUT") == [ 10, 10, 5 ]
   raise "channels-worker database pool drifted"
 end
 if channels_worker_env.key?("PROMETHEUS_MULTIPROC_DIR")
@@ -172,7 +179,10 @@ web_connections = web_env.fetch("WEB_CONCURRENCY") *
   (web_env.fetch("DB_POOL_SIZE") + web_env.fetch("DB_MAX_OVERFLOW"))
 worker_connections = channels_worker_env.fetch("DB_POOL_SIZE") +
   channels_worker_env.fetch("DB_MAX_OVERFLOW")
-raise "total database connection budget drifted" unless web_connections + worker_connections == 80
+steady_connections = web_connections + worker_connections
+rolling_connections = 2 * (web_connections + worker_connections)
+raise "steady database connection budget drifted" unless steady_connections == 40
+raise "rolling database connection budget drifted" unless rolling_connections == 80
 
 config.accessories.each do |accessory|
   command = Kamal::Commands::Accessory.new(config, name: accessory.name).run


### PR DESCRIPTION
## Summary

- split process liveness (`/health`) from database-aware readiness (`/ready`)
- return a bounded, non-cacheable HTTP 503 with `Retry-After` only for SQLAlchemy pool-acquisition timeouts
- expose `clawdi_backend_db_pool_timeouts_total`
- give both Cloud app roles explicit `10 + 10` database pools with 5-second acquisition timeouts
- replace the unsafe all-role production rollout with a guarded sequential `channels-worker` then `web` deployment

This is the first implementation slice from Clawdi-AI/clawdi-hosted#2033. It protects the API and preserves database capacity for new deployments, existing deployment control/recovery, and operator access before increasing worker parallelism.

## Production evidence

Read-only inspection of `ssh clawdi` on September 4, 2026 found:

- 24 CPUs and 23 GiB RAM on the host
- the Cloud web role is one Uvicorn process, approximately one CPU at saturation, with about 2.1 GiB RSS
- PostgreSQL `max_connections = 100`, `superuser_reserved_connections = 3`, and `reserved_connections = 0`
- the running web and channels roles still use the legacy `20 + 20` pools with a 45-second timeout
- historical two-web-worker rollout overlap exhausted the prior 15 GiB host and triggered global OOM because each process loaded its own embedding model

The new declared budget is:

- steady state: web 20 + channels worker 20 = 40
- normal sequential rolling overlap: at most 60
- one-time legacy transition: at most 80
- at least 20 ordinary PostgreSQL slots must be available before migration and each role deployment

## Rollout safety

The release workflow now calls one deployment helper. It inspects the running role containers and accepts only the known legacy `20 + 20 / 45s` or target `10 + 10 / 5s` pool contracts. Unknown or ambiguous state fails closed.

The helper runs the exact-image migration, stops the channels worker only when it still has the legacy pool, deploys `channels-worker`, then deploys `web`. It checks ordinary PostgreSQL capacity after subtracting reserved slots and verifies each role converged to the requested full-SHA image and bounded pool. The same sequential path remains the normal release path, so there is no rollout flag or manual mode switch.

This PR has not changed production yet.

## References

- Kubernetes probe semantics: https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/
- SQLAlchemy connection-pool timeout behavior: https://docs.sqlalchemy.org/en/20/errors.html
- HTTP 503 and `Retry-After`: https://www.rfc-editor.org/rfc/rfc9110.html
- Kamal 2.12.0 app boot ordering: https://github.com/basecamp/kamal/blob/v2.12.0/lib/kamal/cli/app/boot.rb
- Uvicorn resource-limit settings: https://www.uvicorn.org/settings/

## Verification

- isolated PostgreSQL focused suite: `31 passed`
- isolated CLI release workflow contract: `14 passed`
- pinned Kamal 2.12 render, deployment helper, and sidecar contracts: passed
- guarded deployment scenarios: legacy transition, bounded steady state, interrupted transition resume, unknown-pool rejection, and low-headroom rejection
- actual release-plan comparison from production SHA `9b446080ce608b5816c525460d6f0e3596547142` to this head classified `backend=true`, `deployment=true`, `sidecar=false`
- generated OpenAPI client consistency: passed
- `git diff --check`: passed
- current commit: `4d5183f37`

## Follow-up boundary

This PR intentionally does not add Uvicorn workers or an unmeasured `--limit-concurrency`. The next capacity slice isolates the per-process embedding model, adds API in-flight/latency/rejection telemetry, and load-tests critical deployment paths before selecting load-shedding thresholds.