### PR TITLE
fix(ci): keep manual CLI releases available

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -18,7 +18,7 @@ env:
 # Prereleases publish to beta; stable releases publish to latest.
 jobs:
   build-immutable-artifact:
-    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-latest' || vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     permissions:
       contents: read
     outputs:

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -81,7 +81,7 @@ describe("CLI publish workflow contract", () => {
 		expect(build).toBeGreaterThan(-1);
 		expect(publish).toBeGreaterThan(build);
 		expect(buildJob).toContain(
-			`runs-on: \${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}`,
+			`runs-on: \${{ github.event_name == 'workflow_dispatch' && 'ubuntu-latest' || vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}`,
 		);
 		expect(publishJob).toContain("runs-on: ubuntu-latest");
 		expect(publishJob).not.toContain("vars.CI_RUNNER");


### PR DESCRIPTION
## Summary

- run manually dispatched CLI release builds on GitHub-hosted `ubuntu-latest`
- keep automatic main-push release builds on the configured fast runner
- preserve the existing immutable artifact and protected npm OIDC publish topology

## Incident context

The configured Blacksmith runner became unavailable while publishing `clawdi@0.14.41`; the automatic attempt disconnected and the exact-commit manual retry remained queued without a runner. This keeps the existing manual recovery surface independent of that optional runner provider.

## Verification

- `bun test packages/cli/tests/cli-publish-workflow.test.ts` (6 passed)
- `bunx biome check .github/workflows/cli-publish.yml packages/cli/tests/cli-publish-workflow.test.ts`
- `git diff --check`
