### PR TITLE
revert(ci): keep CLI build on configured runner

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -18,7 +18,7 @@ env:
 # Prereleases publish to beta; stable releases publish to latest.
 jobs:
   build-immutable-artifact:
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-latest' || vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     permissions:
       contents: read
     outputs:

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -81,7 +81,7 @@ describe("CLI publish workflow contract", () => {
 		expect(build).toBeGreaterThan(-1);
 		expect(publish).toBeGreaterThan(build);
 		expect(buildJob).toContain(
-			`runs-on: \${{ github.event_name == 'workflow_dispatch' && 'ubuntu-latest' || vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}`,
+			`runs-on: \${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}`,
 		);
 		expect(publishJob).toContain("runs-on: ubuntu-latest");
 		expect(publishJob).not.toContain("vars.CI_RUNNER");


### PR DESCRIPTION
Reverts the manual-dispatch runner override from #1354.

- restore `build-immutable-artifact` to `vars.CI_RUNNER` with the existing Blacksmith fallback
- restore the workflow contract assertion
- leave the OpenClaw `0.14.41` runtime recovery unchanged

Verification:
- changed files exactly match their state before #1354
- `git diff --check`
- pre-commit Biome hook passed