### PR TITLE
fix(runtime): repair OpenClaw migration warnings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.41",
+      "version": "0.14.42",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.41",
+	"version": "0.14.42",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/hosted-openclaw-context.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-context.ts
@@ -35,6 +35,16 @@ class OpenClawWorkspaceRosterError extends Error {
 	}
 }
 
+function openClawDoctorRepairRequired(result: ReturnType<typeof spawnRuntimeUserCommand>): boolean {
+	const output = [result.stderr, result.stdout]
+		.filter((value): value is string => typeof value === "string")
+		.join("\n");
+	return (
+		output.includes("OpenClaw startup migrations did not complete cleanly") &&
+		output.includes('Run "openclaw doctor --fix"')
+	);
+}
+
 export type OpenClawHostedContext = ReturnType<typeof createOpenClawHostedContext>;
 
 function installedCommandPath(home: string): string | null {
@@ -143,15 +153,8 @@ export function resolveHostedOpenClawWorkspace(home: string): string {
 			maxBufferBytes: 1024 * 1024,
 		});
 	}
-	if (result.status !== 0) {
-		const output = [result.stderr, result.stdout]
-			.filter((value): value is string => typeof value === "string")
-			.join("\n");
-		throw new OpenClawWorkspaceRosterError(
-			output.includes("OpenClaw startup migrations did not complete cleanly") &&
-				output.includes('Run "openclaw doctor --fix"'),
-		);
-	}
+	if (openClawDoctorRepairRequired(result)) throw new OpenClawWorkspaceRosterError(true);
+	if (result.status !== 0) throw new OpenClawWorkspaceRosterError(false);
 	const workspace = parseOfficialWorkspaceRoster(String(result.stdout));
 	openClawWorkspaces.set(home, { revision, workspace });
 	return workspace;

--- a/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
@@ -233,7 +233,6 @@ case "$*" in
   "agents list --json")
     if test ! -f '${repaired}'; then
       printf '%s\n' 'OpenClaw startup migrations did not complete cleanly.' 'Run "openclaw doctor --fix" against the same state/config, then restart the gateway.' >&2
-      exit 1
     fi
     printf '%s\n' '[{"id":"main","workspace":"${workspaceRoot}"}]'
     ;;


### PR DESCRIPTION
## Summary

- treat OpenClaw's explicit startup-migration doctor marker as repair-required even when `agents list --json` exits successfully
- keep every other roster failure fail-closed
- release CLI `0.14.42`

## Production evidence

The affected gateway repeatedly reports the official `OpenClaw startup migrations did not complete cleanly` / `Run "openclaw doctor --fix"` markers, while the existing `0.14.41` recovery did not trigger. The corrected test reproduces a successful roster response with the migration warning on stderr.

## Verification

- isolated Docker: hosted OpenClaw focused tests, 8 passed
- CLI TypeScript typecheck
- Biome on changed source/test/package files
- `git diff --check`