### PR TITLE
Isolate Cloud embedding capacity from API workers

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -90,6 +90,7 @@ COMPOSIO_API_KEY=
 
 # --- Memory embedder (used by the Builtin memory provider) ---
 # local = fastembed ONNX, ~1GB download on first use, no API key. Default.
+# local-service = one FastEmbed worker over a host-local Unix socket.
 # api   = OpenAI-compatible API. Set MEMORY_EMBEDDING_API_KEY and
 #         optionally MEMORY_EMBEDDING_BASE_URL + MEMORY_EMBEDDING_MODEL.
 MEMORY_EMBEDDING_MODE=local
@@ -99,6 +100,12 @@ MEMORY_EMBEDDING_API_KEY=
 MEMORY_EMBEDDING_BASE_URL=
 
 MEMORY_EMBEDDING_MODEL=text-embedding-3-small
+
+# Used only by local-service and the dedicated embedding worker.
+MEMORY_EMBEDDING_SERVICE_SOCKET_PATH=/run/clawdi-embedding/embedding.sock
+MEMORY_EMBEDDING_SERVICE_TIMEOUT_SECONDS=30
+MEMORY_EMBEDDING_THREADS=0
+MEMORY_EMBEDDING_WORKER_MAX_CONCURRENCY=1
 
 # Log API requests at or above this backend processing time, in milliseconds.
 # Set to 0 to disable slow-request logs. Responses always include

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,8 +28,9 @@ RUN uv sync --frozen --no-dev --no-install-project --extra mem0
 
 COPY --chown=app:app backend/ /app/backend/
 
-RUN mkdir -p /data/files /home/app/.cache/fastembed \
-    && chown -R app:app /data /home/app/.cache
+RUN mkdir -p /data/files /home/app/.cache/fastembed /run/clawdi-embedding \
+    && chmod 0770 /run/clawdi-embedding \
+    && chown -R app:app /data /home/app/.cache /run/clawdi-embedding
 
 USER app
 
@@ -38,8 +39,8 @@ LABEL service="clawdi"
 
 EXPOSE 8000
 
-# Kamal uses Docker health for non-proxied roles. Both the API and channels
-# worker serve readiness-aware GET /health on this port.
+# Kamal uses Docker health for non-proxied roles. The embedding role overrides
+# this command with its Unix-socket health endpoint in config/deploy.yml.
 HEALTHCHECK --interval=5s --timeout=5s --start-period=30s --retries=8 \
     CMD ["curl", "--fail", "--silent", "--show-error", "--max-time", "4", "http://127.0.0.1:8000/health"]
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,3 +1,4 @@
+import os
 from ipaddress import AddressValueError, IPv6Address
 from typing import Annotated, Self
 from urllib.parse import urlsplit, urlunsplit
@@ -128,6 +129,24 @@ class Settings(BaseSettings):
             return base64.b64decode(candidate, validate=True).decode("utf-8")
         except (binascii.Error, UnicodeDecodeError):
             return value  # not base64 (e.g. test fixtures); leave unchanged
+
+    @field_validator("memory_embedding_service_socket_path")
+    @classmethod
+    def _validate_memory_embedding_service_socket_path(cls, value: str) -> str:
+        if (
+            not value
+            or value != value.strip()
+            or "\x00" in value
+            or not os.path.isabs(value)
+            or os.path.normpath(value) != value
+            or len(os.fsencode(value)) > 103
+            or os.path.basename(value) != "embedding.sock"
+        ):
+            raise ValueError(
+                "memory_embedding_service_socket_path must be a bounded absolute "
+                "normalized embedding.sock path"
+            )
+        return value
 
     @field_validator("clerk_jwt_issuer")
     @classmethod
@@ -308,10 +327,21 @@ class Settings(BaseSettings):
     # - "api":   call an OpenAI-compatible embeddings endpoint. Set
     #   memory_embedding_api_key, and optionally memory_embedding_base_url
     #   (e.g. https://openrouter.ai/api/v1) and memory_embedding_model.
+    # - "local-service": call one host-local FastEmbed worker over a Unix
+    #   socket so multiple API workers do not each load the ONNX model.
     memory_embedding_mode: str = "local"
     memory_embedding_api_key: str = ""
     memory_embedding_base_url: str = ""
     memory_embedding_model: str = "text-embedding-3-small"
+    memory_embedding_service_socket_path: str = "/run/clawdi-embedding/embedding.sock"
+    memory_embedding_service_timeout_seconds: Annotated[float, Field(gt=0, le=300)] = 30.0
+    # Zero preserves FastEmbed/ONNX Runtime automatic thread selection. A
+    # dedicated worker should set this to its container CPU quota.
+    memory_embedding_threads: Annotated[int, Field(ge=0, le=256)] = 0
+    # Initial local-service rollout runs one inference at a time through one
+    # shared ONNX session. Raise only after latency and rejection metrics show
+    # that concurrent session use improves throughput within the CPU quota.
+    memory_embedding_worker_max_concurrency: Annotated[int, Field(ge=1, le=256)] = 1
 
     # Channel emulation waits. PostgreSQL notifications wake normal long polls;
     # the interval is a bounded fallback for listener failure or notification loss.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -71,7 +71,7 @@ from app.routes.vault import router as vault_router
 from app.services.ai_provider_auth_transition import OAuthCredentialPayloadCorruptError
 from app.services.channels import close_channel_provider_http_client
 from app.services.composio import close_composio_client
-from app.services.embedding import LocalEmbedder
+from app.services.embedding import LocalEmbedder, LocalServiceEmbedder
 from app.services.memory_types import MemoryProviderUnavailableError, MemoryProviderUpstreamError
 from app.services.metrics import db_pool_timeouts, observe_event_loop_lag
 from app.services.sync_events import start_postgres_listener, stop_postgres_listener
@@ -159,7 +159,10 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
                 try:
                     await close_channel_provider_http_client()
                 finally:
-                    await close_composio_client()
+                    try:
+                        await close_composio_client()
+                    finally:
+                        await LocalServiceEmbedder.close_shared()
 
 
 app = FastAPI(

--- a/backend/app/runtime_entrypoint.py
+++ b/backend/app/runtime_entrypoint.py
@@ -1,12 +1,29 @@
+import logging
 import os
 import signal
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from pathlib import Path
+from socket import socket
+from typing import cast
+
+from prometheus_client import multiprocess as prometheus_multiprocess
+from uvicorn.config import STARTUP_FAILURE, Config
+from uvicorn.server import Server
+from uvicorn.supervisors import Multiprocess
+from uvicorn.supervisors.multiprocess import Process
+
+logger = logging.getLogger("uvicorn.error")
+_mark_process_dead = cast(
+    Callable[[int, str], None],
+    prometheus_multiprocess.mark_process_dead,
+)
 
 API_ROLE = "api"
 CHANNELS_WORKER_ROLE = "channels-worker"
+EMBEDDING_WORKER_ROLE = "embedding-worker"
 PROMETHEUS_MULTIPROC_DIR_NAME = "clawdi-prometheus-multiproc"
 
 # How long the API keeps serving after SIGTERM. Some container proxies only
@@ -19,14 +36,104 @@ API_SIGTERM_DRAIN_SECONDS = 5
 
 _API_MIGRATE_ARGS = ["alembic", "upgrade", "head"]
 _API_SERVER_ARGS = [
-    "uvicorn",
-    "app.main:app",
-    "--host",
-    "0.0.0.0",
-    "--port",
-    "8000",
-    "--no-access-log",
+    "python",
+    "-m",
+    "app.runtime_entrypoint",
+    "_serve-api",
 ]
+
+
+class _PrometheusProcess(Process):
+    def __init__(self, config: Config, sockets: list[socket], metrics_dir: Path) -> None:
+        super().__init__(config, sockets)
+        self._metrics_dir = metrics_dir
+
+    def join(self) -> None:
+        pid = self.pid
+        super().join()
+        if pid is not None:
+            _mark_process_dead(pid, str(self._metrics_dir))
+
+
+class _PrometheusMultiprocess(Multiprocess):
+    """Uvicorn's pinned supervisor with worker-exit metric cleanup."""
+
+    def __init__(self, config: Config, sockets: list[socket], metrics_dir: Path) -> None:
+        super().__init__(config, sockets)
+        self.processes_num: int = config.workers
+        self._metrics_dir = metrics_dir
+
+    def _new_process(self) -> _PrometheusProcess:
+        return _PrometheusProcess(self.config, self.sockets, self._metrics_dir)
+
+    def init_processes(self) -> None:
+        for _ in range(self.processes_num):
+            process = self._new_process()
+            process.start()
+            self.processes.append(process)
+
+    def restart_all(self) -> None:
+        """Replace each worker only after its successor becomes ready."""
+        for index, old_process in enumerate(self.processes):
+            if self.should_exit.is_set():
+                return
+
+            new_process = self._new_process()
+            new_process.start()
+            if not new_process.wait_until_ready(
+                self.config.timeout_worker_healthcheck, self.should_exit
+            ):
+                new_process.kill()
+                new_process.join()
+                if not self.should_exit.is_set():
+                    logger.error(
+                        "New child process [%s] was not ready in time; keeping worker [%s] "
+                        "and aborting the restart.",
+                        new_process.pid,
+                        old_process.pid,
+                    )
+                return
+
+            old_process.terminate()
+            old_process.join()
+            self.processes[index] = new_process
+
+    def keep_subprocess_alive(self) -> None:
+        if self.should_exit.is_set():
+            return  # Parent is exiting; run() will terminate and join every worker.
+
+        for index, process in enumerate(self.processes):
+            if process.is_alive(timeout=self.config.timeout_worker_healthcheck):
+                continue
+
+            process.kill()
+            process.join()
+            if process.exitcode == STARTUP_FAILURE:
+                logger.error(
+                    "Child process [%s] failed to start, stopping the parent process.",
+                    process.pid,
+                )
+                self.should_exit.set()
+                return
+            if self.should_exit.is_set():
+                return
+
+            logger.info("Child process [%s] died", process.pid)
+            replacement = self._new_process()
+            replacement.start()
+            self.processes[index] = replacement
+
+    def handle_ttin(self) -> None:
+        if self.processes_num >= self.config.workers:
+            logger.warning(
+                "Ignoring TTIN: API worker capacity is capped at %s",
+                self.config.workers,
+            )
+            return
+        self.processes_num += 1
+        process = self._new_process()
+        process.start()
+        self.processes.append(process)
 
 
 def _prepare_prometheus_multiprocess_dir() -> None:
@@ -47,6 +154,39 @@ def _prepare_prometheus_multiprocess_dir() -> None:
 
 def _exec(args: list[str]) -> None:
     os.execvp(args[0], args)
+
+
+def _run_uvicorn(
+    app: str = "app.main:app",
+    host: str = "0.0.0.0",
+    port: int = 8000,
+    workers: int | None = None,
+) -> int:
+    config = Config(app, host=host, port=port, workers=workers, access_log=False)
+    if config.workers not in (1, 2):
+        raise RuntimeError("API worker count must be 1 or 2")
+    server = Server(config)
+
+    try:
+        if config.workers > 1:
+            raw_path = os.environ.get("PROMETHEUS_MULTIPROC_DIR", "").strip()
+            if not raw_path:
+                raise RuntimeError(
+                    "PROMETHEUS_MULTIPROC_DIR is required when WEB_CONCURRENCY exceeds 1"
+                )
+            metrics_dir = Path(raw_path).resolve()
+            if not metrics_dir.is_dir():
+                raise RuntimeError("PROMETHEUS_MULTIPROC_DIR must be an existing directory")
+            sock = config.bind_socket()
+            _PrometheusMultiprocess(config, sockets=[sock], metrics_dir=metrics_dir).run()
+        else:
+            server.run()
+    except KeyboardInterrupt:
+        pass
+
+    if config.workers == 1 and not server.started:
+        return STARTUP_FAILURE
+    return 0
 
 
 def _run_api_with_drain() -> int:
@@ -70,16 +210,21 @@ def _run_api_with_drain() -> int:
 
 
 def main() -> None:
+    if len(sys.argv) == 2 and sys.argv[1] == "_serve-api":
+        raise SystemExit(_run_uvicorn())
+
     role = os.environ.get("CLAWDI_PROCESS_ROLE", API_ROLE).strip() or API_ROLE
 
     if role == API_ROLE:
         raise SystemExit(_run_api_with_drain())
     if role == CHANNELS_WORKER_ROLE:
         _exec(["python", "-m", "app.workers.channels"])
+    if role == EMBEDDING_WORKER_ROLE:
+        _exec(["python", "-m", "app.workers.embedding"])
 
     print(
         f"Unsupported CLAWDI_PROCESS_ROLE={role!r}; expected "
-        f"{API_ROLE!r} or {CHANNELS_WORKER_ROLE!r}.",
+        f"{API_ROLE!r}, {CHANNELS_WORKER_ROLE!r}, or {EMBEDDING_WORKER_ROLE!r}.",
         file=sys.stderr,
     )
     raise SystemExit(64)

--- a/backend/app/services/embedding.py
+++ b/backend/app/services/embedding.py
@@ -14,6 +14,10 @@ choice — they just get working semantic search.
   and MEMORY_EMBEDDING_MODEL. `dimensions=768` is passed to the API so
   the on-disk vector column stays dimension-compatible with local mode.
 
+- "local-service" — the same local FastEmbed model hosted by one dedicated
+  process and reached over a Unix socket. This keeps the model and ONNX thread
+  pool out of each API worker.
+
 If mode is misconfigured, embedding is disabled and search falls back
 to FTS + trigram inside BuiltinProvider.
 """
@@ -23,14 +27,19 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
-from collections.abc import Iterable
+import time
+from collections.abc import Iterable, Sequence
 from numbers import Real
 from typing import TYPE_CHECKING, Protocol
+
+import httpx
+from pydantic import BaseModel, ConfigDict, StrictStr, ValidationError
 
 if TYPE_CHECKING:
     from fastembed import TextEmbedding
 
 from app.core.config import settings
+from app.services.metrics import embedding_duration, embedding_in_flight, embedding_rejections
 
 log = logging.getLogger(__name__)
 
@@ -44,6 +53,18 @@ class Embedder(Protocol):
 
 class EmbeddingUpstreamError(RuntimeError):
     """Sanitized OpenAI-compatible embedding failure."""
+
+
+class EmbeddingServiceRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    text: StrictStr
+
+
+class EmbeddingServiceResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    embedding: Sequence[object]
 
 
 class LocalEmbedder:
@@ -63,6 +84,8 @@ class LocalEmbedder:
     def _load_model() -> TextEmbedding:
         from fastembed import TextEmbedding
 
+        if settings.memory_embedding_threads > 0:
+            return TextEmbedding(LOCAL_MODEL_NAME, threads=settings.memory_embedding_threads)
         return TextEmbedding(LOCAL_MODEL_NAME)
 
     @classmethod
@@ -119,6 +142,113 @@ class LocalEmbedder:
             return _validate_embedding(values, provider="Local embedding provider")
 
         return await asyncio.to_thread(_embed_sync)
+
+
+class LocalServiceEmbedder:
+    """Reusable client for the dedicated local FastEmbed worker."""
+
+    _instance: LocalServiceEmbedder | None = None
+
+    def __init__(
+        self,
+        socket_path: str,
+        timeout_seconds: float,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.socket_path = socket_path
+        self.timeout_seconds = timeout_seconds
+        self._owns_client = http_client is None
+        self._client = http_client or httpx.AsyncClient(
+            base_url="http://localhost",
+            transport=httpx.AsyncHTTPTransport(
+                uds=socket_path,
+                # A pooled connection remains attached to the old listener
+                # after an atomic pathname replacement. Reconnect every POST
+                # to the currently published socket without automatic retry.
+                limits=httpx.Limits(max_keepalive_connections=0),
+                retries=0,
+                trust_env=False,
+            ),
+            timeout=httpx.Timeout(timeout_seconds),
+            trust_env=False,
+        )
+
+    @classmethod
+    def get(cls, socket_path: str, timeout_seconds: float) -> LocalServiceEmbedder:
+        instance = cls._instance
+        if instance is None:
+            instance = cls(socket_path, timeout_seconds)
+            cls._instance = instance
+        elif instance.socket_path != socket_path or instance.timeout_seconds != timeout_seconds:
+            raise RuntimeError("Local embedding service configuration changed at runtime")
+        return instance
+
+    @classmethod
+    async def close_shared(cls) -> None:
+        instance = cls._instance
+        cls._instance = None
+        if instance is not None:
+            await instance.aclose()
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def embed(self, text: str) -> list[float]:
+        backend = "local_service"
+        started = time.perf_counter()
+        outcome = "error"
+        embedding_in_flight.labels(backend=backend).inc()
+        try:
+            try:
+                response = await self._client.post(
+                    "/v1/embeddings",
+                    json=EmbeddingServiceRequest(text=text).model_dump(),
+                )
+            except httpx.HTTPError as exc:
+                outcome = "unavailable"
+                raise EmbeddingUpstreamError("Local embedding service request failed") from exc
+
+            if (
+                response.status_code == 503
+                and response.headers.get("X-Clawdi-Embedding-Rejection") == "capacity"
+            ):
+                outcome = "rejected"
+                embedding_rejections.labels(backend=backend, reason="capacity").inc()
+                raise EmbeddingUpstreamError("Local embedding service request rejected")
+
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                outcome = "unavailable" if response.status_code >= 500 else "invalid_response"
+                raise EmbeddingUpstreamError(
+                    "Local embedding service returned an invalid response"
+                ) from exc
+
+            try:
+                payload = EmbeddingServiceResponse.model_validate_json(response.content)
+            except ValidationError as exc:
+                outcome = "invalid_response"
+                raise EmbeddingUpstreamError(
+                    "Local embedding service returned an invalid response"
+                ) from exc
+
+            try:
+                result = _validate_embedding(
+                    payload.embedding,
+                    provider="Local embedding service",
+                )
+            except EmbeddingUpstreamError:
+                outcome = "invalid_response"
+                raise
+            outcome = "success"
+            return result
+        finally:
+            embedding_in_flight.labels(backend=backend).dec()
+            embedding_duration.labels(backend=backend, outcome=outcome).observe(
+                time.perf_counter() - started
+            )
 
 
 class ApiEmbedder:
@@ -182,6 +312,16 @@ def resolve_embedder() -> Embedder | None:
 
     if mode == "local":
         return LocalEmbedder.get()
+
+    if mode == "local-service":
+        try:
+            return LocalServiceEmbedder.get(
+                settings.memory_embedding_service_socket_path,
+                settings.memory_embedding_service_timeout_seconds,
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            log.warning("Local embedding service is misconfigured; disabling embedder: %s", exc)
+            return None
 
     if mode == "api":
         if not settings.memory_embedding_api_key:

--- a/backend/app/services/metrics.py
+++ b/backend/app/services/metrics.py
@@ -70,7 +70,7 @@ active_polls = Gauge(
     "msg_router_active_polls",
     "Number of active ingress poll loops",
     ["channel"],
-    multiprocess_mode="sum",
+    multiprocess_mode="livesum",
     registry=registry,
 )
 webhook_deliveries = Counter(
@@ -147,12 +147,32 @@ db_connection_hold_duration = Histogram(
 db_pool_checked_out = Gauge(
     "clawdi_backend_db_pool_checked_out",
     "Number of backend database connections currently checked out",
-    multiprocess_mode="sum",
+    multiprocess_mode="livesum",
     registry=registry,
 )
 db_pool_timeouts = Counter(
     "clawdi_backend_db_pool_timeouts_total",
     "Requests rejected because the backend database pool was exhausted",
+    registry=registry,
+)
+embedding_in_flight = Gauge(
+    "clawdi_backend_embedding_in_flight",
+    "Embedding requests currently executing or waiting on the configured backend",
+    ["backend"],
+    multiprocess_mode="livesum",
+    registry=registry,
+)
+embedding_duration = Histogram(
+    "clawdi_backend_embedding_duration_seconds",
+    "End-to-end embedding request latency by backend and outcome",
+    ["backend", "outcome"],
+    buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 15, 30),
+    registry=registry,
+)
+embedding_rejections = Counter(
+    "clawdi_backend_embedding_rejections_total",
+    "Embedding requests rejected before inference",
+    ["backend", "reason"],
     registry=registry,
 )
 

--- a/backend/app/workers/embedding.py
+++ b/backend/app/workers/embedding.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import stat
+import sys
+import tempfile
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import httpx
+import uvicorn
+from anyio import CapacityLimiter, WouldBlock
+from fastapi import FastAPI, HTTPException, status
+from pydantic import BaseModel, ConfigDict, StrictStr, ValidationError
+
+from app.core.config import settings
+from app.core.logging_config import configure_application_logging
+from app.services.embedding import (
+    Embedder,
+    EmbeddingServiceRequest,
+    EmbeddingServiceResponse,
+    EmbeddingUpstreamError,
+    LocalEmbedder,
+)
+
+configure_application_logging()
+
+
+class EmbeddingWorkerHealthResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"]
+    worker: Literal["embedding"]
+    instance_id: StrictStr
+
+
+def current_worker_instance_id() -> str:
+    instance_id = socket.gethostname().strip()
+    if not instance_id or "\x00" in instance_id:
+        raise RuntimeError("embedding worker instance identity is unavailable")
+    return instance_id
+
+
+async def check_embedding_worker_health(
+    socket_path: str,
+    expected_instance_id: str,
+    *,
+    timeout_seconds: float = 4,
+) -> bool:
+    if not expected_instance_id:
+        return False
+    try:
+        async with httpx.AsyncClient(
+            base_url="http://localhost",
+            transport=httpx.AsyncHTTPTransport(
+                uds=socket_path,
+                retries=0,
+                trust_env=False,
+            ),
+            timeout=httpx.Timeout(timeout_seconds),
+            trust_env=False,
+        ) as client:
+            response = await client.get("/health")
+            response.raise_for_status()
+            health = EmbeddingWorkerHealthResponse.model_validate_json(response.content)
+    except (httpx.HTTPError, OSError, RuntimeError, ValidationError, ValueError):
+        return False
+    return health.instance_id == expected_instance_id
+
+
+def create_embedding_worker_app(
+    embedder: Embedder,
+    *,
+    instance_id: str,
+    max_concurrency: int,
+) -> FastAPI:
+    limiter = CapacityLimiter(max_concurrency)
+    app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+
+    async def health() -> EmbeddingWorkerHealthResponse:
+        return EmbeddingWorkerHealthResponse(
+            status="ok",
+            worker="embedding",
+            instance_id=instance_id,
+        )
+
+    async def embed(body: EmbeddingServiceRequest) -> EmbeddingServiceResponse:
+        try:
+            limiter.acquire_nowait()
+        except WouldBlock:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Embedding capacity temporarily unavailable",
+                headers={
+                    "Retry-After": "1",
+                    "X-Clawdi-Embedding-Rejection": "capacity",
+                },
+            ) from None
+
+        try:
+            result = await embedder.embed(body.text)
+        except EmbeddingUpstreamError:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Embedding service temporarily unavailable",
+            ) from None
+        finally:
+            limiter.release()
+
+        return EmbeddingServiceResponse(embedding=result)
+
+    app.add_api_route(
+        "/health",
+        health,
+        methods=["GET"],
+        response_model=EmbeddingWorkerHealthResponse,
+    )
+    app.add_api_route(
+        "/v1/embeddings",
+        embed,
+        methods=["POST"],
+        response_model=EmbeddingServiceResponse,
+    )
+    return app
+
+
+def _is_owned_socket(path_stat: os.stat_result) -> bool:
+    return (
+        stat.S_ISSOCK(path_stat.st_mode)
+        and path_stat.st_uid == os.getuid()
+        and path_stat.st_gid == os.getgid()
+    )
+
+
+@dataclass
+class StagedEmbeddingSocket:
+    listener: socket.socket
+    stable_path: Path
+    staged_path: Path
+    owned: os.stat_result
+
+    def publish(self) -> None:
+        try:
+            existing = os.lstat(self.stable_path)
+        except FileNotFoundError:
+            pass
+        else:
+            if stat.S_ISLNK(existing.st_mode) or not _is_owned_socket(existing):
+                raise OSError("unsafe existing embedding socket")
+
+        os.replace(self.staged_path, self.stable_path)
+        published = os.lstat(self.stable_path)
+        if published.st_dev != self.owned.st_dev or published.st_ino != self.owned.st_ino:
+            raise OSError("embedding socket publication failed")
+
+
+@contextmanager
+def stage_embedding_socket(socket_path: str) -> Generator[StagedEmbeddingSocket, None, None]:
+    path = Path(socket_path)
+    parent = path.parent
+    parent.mkdir(mode=0o770, parents=True, exist_ok=True)
+    parent_stat = os.lstat(parent)
+    if (
+        stat.S_ISLNK(parent_stat.st_mode)
+        or not stat.S_ISDIR(parent_stat.st_mode)
+        or parent.resolve() != parent
+        or parent_stat.st_uid != os.getuid()
+        or parent_stat.st_gid != os.getgid()
+    ):
+        raise OSError("unsafe embedding socket directory")
+
+    descriptor, staged_name = tempfile.mkstemp(prefix=".", suffix=".sock", dir=parent)
+    os.close(descriptor)
+    staged_path = Path(staged_name)
+    staged_path.unlink()
+
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    owned: os.stat_result | None = None
+    try:
+        listener.bind(str(staged_path))
+        os.chmod(staged_path, 0o660)
+        owned = os.lstat(staged_path)
+        listener.listen(socket.SOMAXCONN)
+        listener.setblocking(False)
+        yield StagedEmbeddingSocket(
+            listener=listener,
+            stable_path=path,
+            staged_path=staged_path,
+            owned=owned,
+        )
+    finally:
+        listener.close()
+        for candidate in (staged_path, path):
+            try:
+                current = os.lstat(candidate)
+            except FileNotFoundError:
+                continue
+            if (
+                owned is not None
+                and _is_owned_socket(current)
+                and current.st_dev == owned.st_dev
+                and current.st_ino == owned.st_ino
+            ):
+                candidate.unlink()
+
+
+async def run() -> None:
+    instance_id = current_worker_instance_id()
+    embedder = LocalEmbedder.get()
+    await embedder.initialize()
+    app = create_embedding_worker_app(
+        embedder,
+        instance_id=instance_id,
+        max_concurrency=settings.memory_embedding_worker_max_concurrency,
+    )
+    with stage_embedding_socket(settings.memory_embedding_service_socket_path) as staged_socket:
+        config = uvicorn.Config(
+            app,
+            workers=1,
+            access_log=False,
+        )
+        server = uvicorn.Server(config)
+        server_task = asyncio.create_task(
+            server.serve(sockets=[staged_socket.listener]),
+            name="embedding-worker-server",
+        )
+        while not server.started and not server_task.done():
+            await asyncio.sleep(0.01)
+        if server_task.done():
+            await server_task
+            raise RuntimeError("embedding worker exited before startup")
+
+        staged_socket.publish()
+        await server_task
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    if args == ["healthcheck"]:
+        healthy = asyncio.run(
+            check_embedding_worker_health(
+                settings.memory_embedding_service_socket_path,
+                current_worker_instance_id(),
+            )
+        )
+        if not healthy:
+            print("embedding worker instance healthcheck failed", file=sys.stderr)
+        raise SystemExit(0 if healthy else 1)
+    if args:
+        print(f"Unsupported embedding worker arguments: {args!r}", file=sys.stderr)
+        raise SystemExit(64)
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -326,6 +326,7 @@ strict = [
     "app/workers/__init__.py",
     "app/workers/channels.py",
     "app/workers/discord_gateway.py",
+    "app/workers/embedding.py",
 ]
 
 [tool.deptry]
@@ -343,7 +344,6 @@ DEP003 = ["pydantic", "starlette"]
 # imported by name in app/. Removing them would actually
 # break the runtime, so silence the noise.
 DEP002 = [
-    "uvicorn",            # ASGI server runtime; invoked as a binary.
     "asyncpg",            # SQLAlchemy postgresql+asyncpg driver.
     "alembic",            # Migration CLI.
     "httpcore",           # Pinned transport behavior used by HTTPX request extensions.

--- a/backend/scripts/outbound_api_governance.py
+++ b/backend/scripts/outbound_api_governance.py
@@ -59,6 +59,7 @@ EXPECTED_THIRD_PARTY_IMPORT_ROOTS = frozenset(
         "sentry_sdk",
         "sqlalchemy",
         "starlette",
+        "uvicorn",
         "websockets",
         "xeddsa",
         "yaml",
@@ -82,11 +83,13 @@ EXPECTED_EXTERNAL_IMPORTS: dict[str, frozenset[str]] = {
             "app/services/ai_provider_oauth_revoke_worker.py",
             "app/services/channels.py",
             "app/services/codex_oauth.py",
+            "app/services/embedding.py",
             "app/services/memory_provider_mem0.py",
             "app/services/plugin_catalog.py",
             "app/services/safe_public_http.py",
             "app/services/skill_installer.py",
             "app/services/whatsapp_native_transport.py",
+            "app/workers/embedding.py",
         }
     ),
     "fastembed": frozenset({"app/services/embedding.py"}),
@@ -96,7 +99,13 @@ EXPECTED_EXTERNAL_IMPORTS: dict[str, frozenset[str]] = {
             "app/services/memory_extraction.py",
         }
     ),
-    "socket": frozenset({"app/services/safe_public_http.py"}),
+    "socket": frozenset(
+        {
+            "app/runtime_entrypoint.py",
+            "app/services/safe_public_http.py",
+            "app/workers/embedding.py",
+        }
+    ),
     "websockets": frozenset({"app/services/discord_gateway_worker.py"}),
 }
 

--- a/backend/tests/fixtures/prometheus_multiprocess_app.py
+++ b/backend/tests/fixtures/prometheus_multiprocess_app.py
@@ -1,0 +1,44 @@
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, Response
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, multiprocess
+from prometheus_client.exposition import CONTENT_TYPE_LATEST, generate_latest
+
+registry = CollectorRegistry()
+workers_live = Gauge(
+    "test_workers_live",
+    "Workers whose application lifespan is active",
+    multiprocess_mode="livesum",
+    registry=registry,
+)
+worker_starts = Counter(
+    "test_worker_starts_total",
+    "Worker application lifespan starts",
+    registry=registry,
+)
+worker_start_duration = Histogram(
+    "test_worker_start_duration_seconds",
+    "Worker application startup duration",
+    registry=registry,
+)
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    workers_live.inc()
+    worker_starts.inc()
+    worker_start_duration.observe(0.001)
+    try:
+        yield
+    finally:
+        workers_live.dec()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.get("/metrics")
+async def metrics() -> Response:
+    multiprocess_registry = CollectorRegistry()
+    multiprocess.MultiProcessCollector(multiprocess_registry)
+    return Response(generate_latest(multiprocess_registry), media_type=CONTENT_TYPE_LATEST)

--- a/backend/tests/test_embedding_worker.py
+++ b/backend/tests/test_embedding_worker.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+import pytest
+import uvicorn
+
+from app.services.embedding import EMBEDDING_DIM, EmbeddingUpstreamError, LocalServiceEmbedder
+from app.workers.embedding import (
+    StagedEmbeddingSocket,
+    check_embedding_worker_health,
+    create_embedding_worker_app,
+    stage_embedding_socket,
+)
+
+
+class _RecordingEmbedder:
+    def __init__(self, marker: float) -> None:
+        self.marker = marker
+        self.calls: list[str] = []
+
+    async def embed(self, text: str) -> list[float]:
+        self.calls.append(text)
+        return [self.marker] + ([0.0] * (EMBEDDING_DIM - 1))
+
+
+@dataclass
+class _RunningGeneration:
+    server: uvicorn.Server
+    task: asyncio.Task[None]
+    staged_socket: StagedEmbeddingSocket
+
+    def publish(self) -> None:
+        self.staged_socket.publish()
+
+    async def stop(self) -> None:
+        self.server.should_exit = True
+        async with asyncio.timeout(2):
+            await self.task
+
+
+@asynccontextmanager
+async def _running_generation(
+    socket_path: Path,
+    embedder: _RecordingEmbedder,
+    instance_id: str,
+    *,
+    publish: bool = True,
+) -> AsyncGenerator[_RunningGeneration, None]:
+    app = create_embedding_worker_app(
+        embedder,
+        instance_id=instance_id,
+        max_concurrency=1,
+    )
+    with stage_embedding_socket(str(socket_path)) as staged_socket:
+        server = uvicorn.Server(
+            uvicorn.Config(
+                app,
+                workers=1,
+                access_log=False,
+                log_level="critical",
+                lifespan="off",
+                timeout_keep_alive=1,
+            )
+        )
+        task = asyncio.create_task(
+            server.serve(sockets=[staged_socket.listener]),
+            name=f"embedding-worker-test-{instance_id}",
+        )
+        generation = _RunningGeneration(server, task, staged_socket)
+        try:
+            async with asyncio.timeout(2):
+                while not server.started and not task.done():
+                    await asyncio.sleep(0.01)
+            if task.done():
+                await task
+                raise RuntimeError("test embedding worker exited before startup")
+            if publish:
+                generation.publish()
+            yield generation
+        finally:
+            await generation.stop()
+
+
+async def test_embedding_worker_rejects_excess_inference_without_queueing() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class BlockingEmbedder:
+        async def embed(self, text: str) -> list[float]:
+            assert text == "first"
+            started.set()
+            await release.wait()
+            return [0.25] * EMBEDDING_DIM
+
+    app = create_embedding_worker_app(
+        BlockingEmbedder(),
+        instance_id="test-instance",
+        max_concurrency=1,
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        first = asyncio.create_task(client.post("/v1/embeddings", json={"text": "first"}))
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+        rejected = await client.post("/v1/embeddings", json={"text": "second"})
+        release.set()
+        completed = await asyncio.wait_for(first, timeout=1)
+
+    assert rejected.status_code == 503
+    assert rejected.headers["retry-after"] == "1"
+    assert rejected.headers["x-clawdi-embedding-rejection"] == "capacity"
+    assert completed.status_code == 200
+    assert completed.json() == {"embedding": [0.25] * EMBEDDING_DIM}
+
+
+async def test_embedding_worker_sanitizes_local_provider_failure() -> None:
+    class FailingEmbedder:
+        async def embed(self, text: str) -> list[float]:
+            raise EmbeddingUpstreamError(f"private provider detail: {text}")
+
+    app = create_embedding_worker_app(
+        FailingEmbedder(),
+        instance_id="test-instance",
+        max_concurrency=1,
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/v1/embeddings", json={"text": "secret"})
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Embedding service temporarily unavailable"}
+    assert "private provider detail" not in response.text
+
+
+async def test_local_service_transport_reconnects_to_published_uds_generation(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    socket_path = tmp_path_factory.mktemp("uds") / "embedding.sock"
+    old_embedder = _RecordingEmbedder(1.0)
+    new_embedder = _RecordingEmbedder(2.0)
+    client = LocalServiceEmbedder(str(socket_path), 2)
+
+    try:
+        async with _running_generation(
+            socket_path,
+            old_embedder,
+            "old-instance",
+        ) as old_generation:
+            assert (await client.embed("before-rollover"))[0] == 1.0
+            async with _running_generation(socket_path, new_embedder, "new-instance"):
+                assert (await client.embed("after-publish"))[0] == 2.0
+                await old_generation.stop()
+                assert (await client.embed("after-retire"))[0] == 2.0
+    finally:
+        await client.aclose()
+
+    assert old_embedder.calls == ["before-rollover"]
+    assert new_embedder.calls == ["after-publish", "after-retire"]
+
+
+async def test_embedding_healthcheck_requires_published_instance_identity(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    socket_path = tmp_path_factory.mktemp("health-uds") / "embedding.sock"
+    old_embedder = _RecordingEmbedder(1.0)
+    new_embedder = _RecordingEmbedder(2.0)
+
+    async with _running_generation(socket_path, old_embedder, "old-instance"):
+        assert await check_embedding_worker_health(str(socket_path), "old-instance")
+        async with _running_generation(
+            socket_path,
+            new_embedder,
+            "new-instance",
+            publish=False,
+        ) as new_generation:
+            assert not await check_embedding_worker_health(str(socket_path), "new-instance")
+            new_generation.publish()
+            assert await check_embedding_worker_health(str(socket_path), "new-instance")
+            assert not await check_embedding_worker_health(str(socket_path), "old-instance")
+
+
+def test_embedding_socket_rollover_does_not_let_old_owner_remove_new_socket(
+    tmp_path: Path,
+) -> None:
+    socket_directory = tmp_path / "run"
+    socket_path = socket_directory / "embedding.sock"
+    old_context = stage_embedding_socket(str(socket_path))
+    new_context = stage_embedding_socket(str(socket_path))
+
+    old_socket = old_context.__enter__()
+    old_socket.publish()
+    old_inode = os.lstat(socket_path).st_ino
+    new_socket = new_context.__enter__()
+    assert os.lstat(socket_path).st_ino == old_inode
+    new_socket.publish()
+    new_inode = os.lstat(socket_path).st_ino
+    try:
+        assert old_inode != new_inode
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.connect(str(socket_path))
+            connection, _address = new_socket.listener.accept()
+            connection.close()
+        old_context.__exit__(None, None, None)
+        assert socket_path.exists()
+        assert os.lstat(socket_path).st_ino == new_inode
+    finally:
+        new_context.__exit__(None, None, None)
+
+    assert not socket_path.exists()
+
+
+def test_embedding_socket_failed_rollout_keeps_published_socket(tmp_path: Path) -> None:
+    socket_path = tmp_path / "run" / "embedding.sock"
+    with stage_embedding_socket(str(socket_path)) as old_socket:
+        old_socket.publish()
+        old_inode = os.lstat(socket_path).st_ino
+
+        with stage_embedding_socket(str(socket_path)):
+            assert os.lstat(socket_path).st_ino == old_inode
+
+        assert os.lstat(socket_path).st_ino == old_inode

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -69,6 +69,9 @@ def test_metrics_exports_all_expected_metrics() -> None:
     assert "clawdi_backend_db_connection_hold_duration_seconds" in text
     assert "clawdi_backend_db_pool_checked_out" in text
     assert "clawdi_backend_db_pool_timeouts_total" in text
+    assert "clawdi_backend_embedding_in_flight" in text
+    assert "clawdi_backend_embedding_duration_seconds" in text
+    assert "clawdi_backend_embedding_rejections_total" in text
 
 
 def test_metrics_increment_counters() -> None:

--- a/backend/tests/test_openai_sdk_boundary.py
+++ b/backend/tests/test_openai_sdk_boundary.py
@@ -9,6 +9,7 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import fastembed
+import httpx
 import pytest
 from openai import AsyncOpenAI
 from pydantic import ValidationError
@@ -18,6 +19,7 @@ from app.services.embedding import (
     ApiEmbedder,
     EmbeddingUpstreamError,
     LocalEmbedder,
+    LocalServiceEmbedder,
 )
 from app.services.memory_extraction import (
     MemoryExtractionUpstreamError,
@@ -173,6 +175,57 @@ async def test_embedding_maps_sdk_status_errors() -> None:
     with _openai_compatible_server(embedding_status=HTTPStatus.SERVICE_UNAVAILABLE) as base_url:
         embedder = ApiEmbedder("test-key", base_url, "compatible-embedding-model")
         with pytest.raises(EmbeddingUpstreamError, match="request failed"):
+            await embedder.embed("hello")
+
+
+@pytest.mark.asyncio
+async def test_local_service_embedding_validates_the_internal_protocol() -> None:
+    requests: list[dict[str, object]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(200, json={"embedding": [0.25] * EMBEDDING_DIM})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://localhost",
+    ) as client:
+        embedder = LocalServiceEmbedder(
+            "/run/clawdi-embedding/embedding.sock",
+            5,
+            http_client=client,
+        )
+        result = await embedder.embed("hello")
+
+    assert result == [0.25] * EMBEDDING_DIM
+    assert requests == [{"text": "hello"}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response",
+    [
+        httpx.Response(
+            503,
+            headers={"X-Clawdi-Embedding-Rejection": "capacity"},
+            json={"detail": "busy"},
+        ),
+        httpx.Response(200, json={"embedding": [0.25] * (EMBEDDING_DIM - 1)}),
+    ],
+)
+async def test_local_service_embedding_maps_rejection_and_invalid_vectors(
+    response: httpx.Response,
+) -> None:
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _request: response),
+        base_url="http://localhost",
+    ) as client:
+        embedder = LocalServiceEmbedder(
+            "/run/clawdi-embedding/embedding.sock",
+            5,
+            http_client=client,
+        )
+        with pytest.raises(EmbeddingUpstreamError):
             await embedder.embed("hello")
 
 

--- a/backend/tests/test_runtime_entrypoint.py
+++ b/backend/tests/test_runtime_entrypoint.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 import os
 import signal
+import socket
+import subprocess
+import sys
 import threading
 import time
+from pathlib import Path
 
+import httpx
 import pytest
 
 from app import runtime_entrypoint
@@ -39,6 +44,16 @@ def test_runtime_entrypoint_starts_channels_worker_role(monkeypatch):
     assert exc.value.args_list == ["python", "-m", "app.workers.channels"]
 
 
+def test_runtime_entrypoint_starts_embedding_worker_role(monkeypatch):
+    monkeypatch.setenv("CLAWDI_PROCESS_ROLE", "embedding-worker")
+    monkeypatch.setattr(runtime_entrypoint, "_exec", _capture_exec)
+
+    with pytest.raises(ExecCalled) as exc:
+        runtime_entrypoint.main()
+
+    assert exc.value.args_list == ["python", "-m", "app.workers.embedding"]
+
+
 def test_runtime_entrypoint_rejects_unknown_role(monkeypatch):
     monkeypatch.setenv("CLAWDI_PROCESS_ROLE", "scheduler")
     monkeypatch.setattr(
@@ -51,6 +66,11 @@ def test_runtime_entrypoint_rejects_unknown_role(monkeypatch):
         runtime_entrypoint.main()
 
     assert exc.value.code == 64
+
+
+def test_api_runtime_rejects_unreviewed_worker_capacity() -> None:
+    with pytest.raises(RuntimeError, match="worker count must be 1 or 2"):
+        runtime_entrypoint._run_uvicorn(workers=3)
 
 
 def test_api_migration_failure_short_circuits(monkeypatch):
@@ -106,3 +126,102 @@ def test_api_sigterm_drains_before_forwarding(monkeypatch):
     # SIGTERM at ~0.2s + 0.3s drain: the server must not die before ~0.5s.
     assert elapsed >= 0.5
     assert elapsed < 5
+
+
+@pytest.mark.parametrize("worker_signal", [signal.SIGTERM, signal.SIGKILL])
+def test_uvicorn_supervisor_reaps_live_gauges_on_worker_exit(
+    tmp_path: Path,
+    worker_signal: signal.Signals,
+) -> None:
+    metrics_dir = tmp_path / runtime_entrypoint.PROMETHEUS_MULTIPROC_DIR_NAME
+    metrics_dir.mkdir()
+    backend_root = Path(__file__).parents[1]
+    with socket.socket() as port_socket:
+        port_socket.bind(("127.0.0.1", 0))
+        port = port_socket.getsockname()[1]
+
+    env = os.environ.copy()
+    env["PROMETHEUS_MULTIPROC_DIR"] = str(metrics_dir)
+    command = [
+        sys.executable,
+        "-c",
+        (
+            "from app.runtime_entrypoint import _run_uvicorn; "
+            "raise SystemExit(_run_uvicorn("
+            "app='tests.fixtures.prometheus_multiprocess_app:app', "
+            f"host='127.0.0.1', port={port}, workers=2))"
+        ),
+    ]
+    server = subprocess.Popen(
+        command,
+        cwd=backend_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    def worker_pids() -> set[int]:
+        return {
+            int(path.stem.removeprefix("gauge_livesum_"))
+            for path in metrics_dir.glob("gauge_livesum_*.db")
+        }
+
+    def metrics_text() -> str | None:
+        try:
+            return httpx.get(f"http://127.0.0.1:{port}/metrics", timeout=0.5).text
+        except httpx.HTTPError:
+            return None
+
+    try:
+        deadline = time.monotonic() + 15
+        initial_workers: set[int] = set()
+        while time.monotonic() < deadline:
+            initial_workers = worker_pids()
+            text = metrics_text()
+            if len(initial_workers) == 2 and text and "test_workers_live 2.0" in text:
+                break
+            if server.poll() is not None:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("Uvicorn workers did not become ready")
+
+        assert server.poll() is None
+        assert len(initial_workers) == 2
+        dead_pid = min(initial_workers)
+        assert (metrics_dir / f"gauge_livesum_{dead_pid}.db").exists()
+
+        os.kill(dead_pid, worker_signal)
+        deadline = time.monotonic() + 15
+        replacement_workers: set[int] = set()
+        while time.monotonic() < deadline:
+            replacement_workers = worker_pids()
+            text = metrics_text()
+            if (
+                len(replacement_workers) == 2
+                and dead_pid not in replacement_workers
+                and text is not None
+                and "test_workers_live 2.0" in text
+                and "test_worker_starts_total 3.0" in text
+                and "test_worker_start_duration_seconds_count 3.0" in text
+            ):
+                break
+            if server.poll() is not None:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("Uvicorn did not replace the exited worker with clean live gauges")
+
+        assert server.poll() is None
+        assert not (metrics_dir / f"gauge_livesum_{dead_pid}.db").exists()
+        assert (metrics_dir / f"counter_{dead_pid}.db").exists()
+        assert (metrics_dir / f"histogram_{dead_pid}.db").exists()
+
+        server.send_signal(signal.SIGTERM)
+        assert server.wait(timeout=15) == 0
+        assert list(metrics_dir.glob("gauge_live*.db")) == []
+    finally:
+        if server.poll() is None:
+            server.kill()
+            server.wait(timeout=5)

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -50,21 +50,38 @@ servers:
     hosts:
       - <%= ENV.fetch("DEPLOY_HOST") %>
     options:
-      memory: 6g # local embedding model + launch-load headroom
+      memory: 6g # preserve API headroom while the first two-worker slice is measured
       ulimit: nofile=65536:65536 # long-lived SSE/WebSocket connections
       # tini as PID 1 reaps orphaned subprocesses (zombie prevention).
       init: true
     env:
       clear:
-        # Each uvicorn worker loads its own local embedding model, so the
-        # production web role must stay single-process on this host.
-        WEB_CONCURRENCY: 1
-        # One 10+10 pool leaves room for the channels worker, one overlapping
-        # web generation during rollout, and PostgreSQL operational sessions.
-        DB_POOL_SIZE: 10
-        DB_MAX_OVERFLOW: 10
+        # This is the smallest measured capacity step. The local ONNX model is
+        # isolated below, so two API workers no longer duplicate its RSS.
+        WEB_CONCURRENCY: 2
+        # Keep the web role at 20 total connections across both workers. The
+        # release helper rolls database-owning roles sequentially (60/100 max).
+        DB_POOL_SIZE: 5
+        DB_MAX_OVERFLOW: 5
         DB_POOL_TIMEOUT: 5
         PROMETHEUS_MULTIPROC_DIR: /tmp/clawdi-prometheus-multiproc
+  embedding-worker:
+    hosts:
+      - <%= ENV.fetch("DEPLOY_HOST") %>
+    proxy: false
+    options:
+      memory: 4g # measured model RSS plus startup/inference headroom
+      cpus: 2 # rollout knob: bound inference so it cannot consume host-wide CPU
+      init: true
+      health-cmd: "python -m app.workers.embedding healthcheck"
+    env:
+      clear:
+        CLAWDI_PROCESS_ROLE: embedding-worker
+        # This role does not import the database engine and owns no DB pool.
+        # One ONNX session uses both quota-matched inference threads. Increase
+        # concurrency only after scraped local-service metrics justify it.
+        MEMORY_EMBEDDING_THREADS: 2
+        MEMORY_EMBEDDING_WORKER_MAX_CONCURRENCY: 1
   channels-worker:
     hosts:
       - <%= ENV.fetch("DEPLOY_HOST") %>
@@ -113,6 +130,7 @@ deploy_timeout: 120 # api entrypoint runs alembic before listening
 
 volumes:
   - clawdi-fastembed:/tmp/fastembed_cache # fastembed default cache; persists the ~1.1GB ONNX model across deploys
+  - clawdi-embedding:/run/clawdi-embedding # one UDS shared by API and embedding worker roles
   - /home/phala/clawdi-whatsapp/run:/run/clawdi-whatsapp:ro
 
 accessories:
@@ -323,7 +341,10 @@ env:
     TRUST_FORWARDED_FOR: "true"
     PLUGIN_CATALOG_SYNC_ENABLED: "true"
     FILE_STORE_TYPE: s3
-    MEMORY_EMBEDDING_MODE: local
+    # The release helper always stages and identity-checks embedding-worker
+    # before switching web to the shared Unix socket.
+    MEMORY_EMBEDDING_MODE: local-service
+    MEMORY_EMBEDDING_SERVICE_SOCKET_PATH: /run/clawdi-embedding/embedding.sock
     FILE_STORE_S3_BUCKET: clawdi
     FILE_STORE_S3_REGION: auto
     FILE_STORE_S3_FORCE_PATH_STYLE: true

--- a/docs/runbooks/kamal-service-logs.md
+++ b/docs/runbooks/kamal-service-logs.md
@@ -1,11 +1,11 @@
 # Kamal Service Logs
 
 Use this runbook for host-local operational logs from the production Kamal
-deployment. It covers the `web` and `channels-worker` app roles and the
-`whatsapp-baileys`, `postgres`, and `postgres-backup` accessories. The shared
-`kamal-proxy` deliberately does not persist container logs. This does not change
-self-hosted Compose deployments, tenant runtimes, or any guest journal
-configuration.
+deployment. It covers the `web`, `embedding-worker`, and `channels-worker` app
+roles and the `whatsapp-baileys`, `postgres`, and `postgres-backup` accessories.
+The shared `kamal-proxy` deliberately does not persist container logs. This
+does not change self-hosted Compose deployments, tenant runtimes, or any guest
+journal configuration.
 
 ## Design
 
@@ -79,7 +79,7 @@ four values or the journal service is unhealthy.
 ## Rollout
 
 Logging drivers are fixed when Docker creates a container. A normal app deploy
-recreates the two app roles, but it does not recreate accessories or the proxy.
+recreates the three app roles, but it does not recreate accessories or the proxy.
 After the host prerequisite is verified:
 
 1. Deploy the app through the normal release path.
@@ -99,14 +99,14 @@ Confirm app and accessory containers report `journald`:
 
 ```bash
 docker ps --format '{{.Names}}' \
-  | grep -E '^clawdi-(web|channels-worker)-|^clawdi-(whatsapp-baileys|postgres|postgres-backup)$' \
+  | grep -E '^clawdi-(web|embedding-worker|channels-worker)-|^clawdi-(whatsapp-baileys|postgres|postgres-backup)$' \
   | while read -r container; do
       docker inspect --format '{{.Name}} {{.HostConfig.LogConfig.Type}}' "$container"
     done
 ```
 
-Expected: both app roles and all three accessories print `journald`. Confirm the
-proxy reports `none`:
+Expected: all three app roles and all three accessories print `journald`.
+Confirm the proxy reports `none`:
 
 ```bash
 docker inspect --format '{{.Name}} {{.HostConfig.LogConfig.Type}}' kamal-proxy

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -348,25 +348,29 @@ release task on the primary host before rolling the application. This lets
 online migrations such as `CREATE INDEX CONCURRENTLY` finish while the old API
 continues serving, without consuming the new container's health deadline. The
 API entrypoint repeats the same idempotent migration command as a fail-closed
-safety check and starts Uvicorn only after it succeeds; the non-primary
-`channels-worker` role does not run migrations. Kamal then keeps the old API in
-rotation until the new primary passes the proxy `/health` gate, before booting
-non-primary roles. Every migration must therefore remain expand/contract
-compatible with the old API during this window. Operators must use the release
-workflow rather than running Alembic independently.
+safety check and starts Uvicorn only after it succeeds; the non-primary worker
+roles do not run migrations. Kamal then keeps the old API in rotation until the
+new primary passes the proxy `/health` gate, before booting non-primary roles.
+Every migration must therefore remain expand/contract compatible with the old
+API during this window. Operators must use the release workflow rather than
+running Alembic independently.
 
-Both application roles declare independent `10 + 10` PostgreSQL pools with a
-5-second acquisition timeout. The normal steady-state budget is 40 connections.
-The production workflow rolls `channels-worker` and `web` sequentially, so a
-bounded-pool release reserves at most 60 of PostgreSQL's 100 connections and
-leaves at least 40 for migrations, operators, and transient database work.
+The two-worker `web` role owns two `5 + 5` PostgreSQL pools, while
+`channels-worker` owns one `10 + 10` pool. Both roles use a 5-second acquisition
+timeout; `embedding-worker` does not import the database engine and owns no
+pool. Steady state therefore reserves 40 connections. The production workflow
+rolls database-owning roles sequentially, so a bounded-pool release normally
+reserves at most 60 of PostgreSQL's 100 connections and leaves at least 40 for
+migrations, operators, and transient database work.
 
-The deploy helper inspects the running roles before every release and accepts
-only the legacy `20 + 20` or bounded `10 + 10` pool contracts. Unknown or
-ambiguous runtime state fails closed. During the one-time legacy transition it
-stops the old channels worker before deploying `channels-worker`, then deploys
-`web` for the same full SHA. This keeps the transition at or below 80 reserved
-connections instead of the 120 possible with an all-role rollout:
+The deploy helper inspects the running roles before every release. It accepts
+only the known legacy and bounded pool contracts and fails closed on unknown or
+ambiguous runtime state. It then runs the exact-image migration, deploys and
+identity-checks `embedding-worker`, and rolls `channels-worker` and `web`
+sequentially for the same full SHA. During a legacy `20 + 20` transition it
+stops the old channels worker before replacing it, keeping the transition at or
+below 80 reserved connections instead of the 120 possible with an all-role
+rollout:
 
 ```bash
 scripts/deploy-backend.sh
@@ -374,23 +378,43 @@ scripts/deploy-backend.sh
 
 The helper checks for at least 20 currently available ordinary PostgreSQL
 connection slots, after subtracting reserved slots, before migration and before
-each role deployment. It also verifies that each role converged to the requested
-image and bounded pool. It is the normal release path after the transition; no
-rollout flag or manual mode switch is required.
+each database-owning role deployment. It verifies that every role converged to
+the requested image, that database pools match their bounded contracts, that
+the exact embedding container serves its own UDS, and that the exact Web
+container passes `/ready`. The embedding check compares the response instance
+ID with the reused container's own hostname, so a 200 response from an old
+generation cannot satisfy the new container's health gate. If it fails, the
+helper stops before switching Web. The Web client's UDS transport does not
+retain keep-alive connections, so the next embedding request opens the
+currently published socket without retrying the POST. This helper is the only
+normal release path; no rollout flag or manual first-adoption procedure is
+required.
 
 The proxy `/health` gate is process liveness and deliberately does not acquire
 a PostgreSQL connection. Database-aware verification uses `/ready`, so pool
 pressure cannot turn a recoverable database slowdown into a restart loop or
 remove the only API target. The image-level Docker HEALTHCHECK calls the same
-local liveness path for both roles. On the worker, `/health` returns failure until
-`ChannelWorkerHealth.ready` is true and returns failure again while stopping,
-so Docker cannot report the worker healthy before its worker stack is ready.
-Under Docker's official [HEALTHCHECK timing
-contract](https://docs.docker.com/reference/dockerfile/#healthcheck), the
-30-second start period still allows migration startup. Even allowing one full
-5-second check to straddle that boundary, the 5-second interval and timeout
-with eight counted retries give a conservative 115-second unhealthy deadline,
-strictly below the 120-second Kamal `deploy_timeout`.
+local liveness path for the API and channels worker. On the channels worker,
+`/health` returns failure until `ChannelWorkerHealth.ready` is true and returns
+failure again while stopping. The embedding worker overrides the image check
+with its Unix-socket `/health`; its health command also requires the response
+instance ID to match the checking container's hostname. It loads FastEmbed and
+starts Uvicorn on a staged socket before atomically publishing the shared path.
+Docker therefore cannot accept the old generation's shared-socket response or
+report either worker healthy before its own serving stack is ready. Under Docker's official
+[HEALTHCHECK timing contract](https://docs.docker.com/reference/dockerfile/#healthcheck),
+the 30-second start period still allows migration startup. For the image-level
+API/channels check, even allowing one full 5-second check to straddle that
+boundary, the 5-second interval and timeout with eight counted retries give a
+conservative 115-second unhealthy deadline, strictly below the 120-second Kamal
+`deploy_timeout`. The embedding role overrides only the command, so it retains
+the same image-level timing while withholding the socket until model
+initialization succeeds.
+
+Externally scraped Web metrics expose local-service in-flight requests,
+latency outcomes, and capacity rejections. The embedding worker intentionally
+serves only UDS health and embedding requests; it does not publish a second,
+unscraped metrics endpoint with duplicate observations.
 
 The workflow does not add a public-network post-deploy request: without an
 authenticated, environment-specific assertion it would be a brittle duplicate

--- a/scripts/deploy-backend.sh
+++ b/scripts/deploy-backend.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 readonly service="clawdi"
-readonly desired_pool="10:10:5"
+readonly web_pool="5:5:5"
+readonly channels_pool="10:10:5"
 readonly legacy_pool="20:20:45"
 readonly minimum_available_connections=20
 readonly backend_image="ghcr.io/clawdi-ai/clawdi-backend:${DEPLOY_IMAGE_VERSION:?}"
@@ -23,6 +24,7 @@ remote_value() {
 role_state() {
 	local role="$1"
 	remote_value "
+		set -eu
 		set -- \$(docker ps -q --no-trunc --filter 'label=service=${service}' --filter 'label=role=${role}')
 		if [ \"\$#\" -eq 0 ]; then printf 'CLAWDI_VALUE=missing\\n'; exit 0; fi
 		test \"\$#\" -eq 1
@@ -31,23 +33,47 @@ role_state() {
 		pool_size=\$(printf '%s\\n' \"\$environment\" | sed -n 's/^DB_POOL_SIZE=//p')
 		max_overflow=\$(printf '%s\\n' \"\$environment\" | sed -n 's/^DB_MAX_OVERFLOW=//p')
 		pool_timeout=\$(printf '%s\\n' \"\$environment\" | sed -n 's/^DB_POOL_TIMEOUT=//p')
+		web_concurrency=\$(printf '%s\\n' \"\$environment\" | sed -n 's/^WEB_CONCURRENCY=//p')
 		image=\$(docker inspect --format '{{.Config.Image}}' \"\$container\")
-		printf 'CLAWDI_VALUE=%s|%s|%s:%s:%s\\n' \"\$container\" \"\$image\" \"\$pool_size\" \"\$max_overflow\" \"\$pool_timeout\"
+		printf 'CLAWDI_VALUE=%s|%s|%s:%s:%s|%s\\n' \"\$container\" \"\$image\" \"\$pool_size\" \"\$max_overflow\" \"\$pool_timeout\" \"\$web_concurrency\"
 	"
 }
 
-validate_role_state() {
-	local role="$1" state="$2" container image pool
+validate_container_state() {
+	local role="$1" state="$2" container image pool workers
 	[[ "${state}" == missing ]] && return
-	IFS='|' read -r container image pool <<<"${state}"
+	IFS='|' read -r container image pool workers <<<"${state}"
 	[[ "${container}" =~ ^[0-9a-f]{64}$ && -n "${image}" ]] || {
 		echo "Invalid ${role} container state" >&2
 		exit 1
 	}
-	case "${pool}" in
-		"${legacy_pool}"|"${desired_pool}") ;;
+}
+
+validate_database_role_state() {
+	local role="$1" state="$2" container image pool workers
+	validate_container_state "${role}" "${state}"
+	[[ "${state}" == missing ]] && return
+	IFS='|' read -r container image pool workers <<<"${state}"
+	case "${role}:${pool}" in
+		"web:${legacy_pool}"|"web:${channels_pool}"|"web:${web_pool}"|\
+			"channels-worker:${legacy_pool}"|"channels-worker:${channels_pool}") ;;
 		*) echo "Refusing unknown ${role} database pool: ${pool}" >&2; exit 1 ;;
 	esac
+	case "${role}:${workers}" in
+		"web:"|"web:1"|"web:2"|"channels-worker:") ;;
+		*) echo "Refusing unknown ${role} worker count: ${workers}" >&2; exit 1 ;;
+	esac
+}
+
+validate_embedding_state() {
+	local state="$1" container image pool workers
+	validate_container_state embedding-worker "${state}"
+	[[ "${state}" == missing ]] && return
+	IFS='|' read -r container image pool workers <<<"${state}"
+	[[ "${pool}" == "::" && -z "${workers}" ]] || {
+		echo "Refusing embedding-worker with database pool or web worker settings" >&2
+		exit 1
+	}
 }
 
 require_database_headroom() {
@@ -62,35 +88,62 @@ require_database_headroom() {
 	}
 }
 
-assert_deployed_role() {
-	local role="$1" state container image pool
+assert_database_role() {
+	local role="$1" expected_pool="$2" state container image pool workers
 	state="$(role_state "${role}")"
-	validate_role_state "${role}" "${state}"
+	validate_database_role_state "${role}" "${state}"
 	[[ "${state}" != missing ]] || { echo "${role} is not running after deployment" >&2; exit 1; }
-	IFS='|' read -r container image pool <<<"${state}"
-	[[ "${image}" == "${backend_image}" && "${pool}" == "${desired_pool}" ]] || {
+	IFS='|' read -r container image pool workers <<<"${state}"
+	[[ "${image}" == "${backend_image}" && "${pool}" == "${expected_pool}" ]] || {
 		echo "${role} did not converge to the requested image and database pool" >&2
+		exit 1
+	}
+	[[ "${role}" != web || "${workers}" == 2 ]] || {
+		echo "web did not converge to two workers" >&2
+		exit 1
+	}
+}
+
+assert_embedding_role() {
+	local state container image pool workers
+	state="$(role_state embedding-worker)"
+	validate_embedding_state "${state}"
+	[[ "${state}" != missing ]] || { echo "embedding-worker is not running after deployment" >&2; exit 1; }
+	IFS='|' read -r container image pool workers <<<"${state}"
+	[[ "${image}" == "${backend_image}" ]] || {
+		echo "embedding-worker did not converge to the requested image" >&2
 		exit 1
 	}
 }
 
 web_state="$(role_state web)"
 channels_state="$(role_state channels-worker)"
-validate_role_state web "${web_state}"
-validate_role_state channels-worker "${channels_state}"
+embedding_state="$(role_state embedding-worker)"
+validate_database_role_state web "${web_state}"
+validate_database_role_state channels-worker "${channels_state}"
+validate_embedding_state "${embedding_state}"
 
 require_database_headroom
 kamal app exec --primary --roles web --raw \
 	--version "${DEPLOY_IMAGE_VERSION}" alembic upgrade head
 
-if [[ "${channels_state}" == *"|${legacy_pool}" ]]; then
+kamal deploy -P --roles embedding-worker --version "${DEPLOY_IMAGE_VERSION}"
+assert_embedding_role
+kamal app exec --primary --roles embedding-worker --reuse --raw \
+	--version "${DEPLOY_IMAGE_VERSION}" \
+	python -m app.workers.embedding healthcheck
+
+if [[ "${channels_state}" == *"|${legacy_pool}"* ]]; then
 	kamal app stop --roles channels-worker
 fi
 
 require_database_headroom
 kamal deploy -P --roles channels-worker --version "${DEPLOY_IMAGE_VERSION}"
-assert_deployed_role channels-worker
+assert_database_role channels-worker "${channels_pool}"
 
 require_database_headroom
 kamal deploy -P --roles web --version "${DEPLOY_IMAGE_VERSION}"
-assert_deployed_role web
+assert_database_role web "${web_pool}"
+kamal app exec --primary --roles web --reuse --raw \
+	--version "${DEPLOY_IMAGE_VERSION}" \
+	curl --fail --silent --show-error --max-time 4 http://127.0.0.1:8000/ready

--- a/scripts/test-deploy-backend.sh
+++ b/scripts/test-deploy-backend.sh
@@ -13,25 +13,49 @@ echo "$*" >> "${FAKE_LOG}"
 case "$*" in
 	"deploy -P --roles web "*) touch "${FAKE_LOG}.web.deployed"; exit 0 ;;
 	"deploy -P --roles channels-worker "*) touch "${FAKE_LOG}.channels-worker.deployed"; exit 0 ;;
+	"deploy -P --roles embedding-worker "*) touch "${FAKE_LOG}.embedding-worker.deployed"; exit 0 ;;
+	"app exec --primary --roles embedding-worker --reuse --raw "*"python -m app.workers.embedding healthcheck")
+		[[ "${FAIL_EMBEDDING_HEALTH:-0}" != 1 ]]
+		exit
+		;;
+	"app exec --primary --roles web --reuse --raw "*"curl "*"/ready")
+		[[ "${FAIL_WEB_READY:-0}" != 1 ]]
+		exit
+		;;
 	"app exec "*|"app stop "*) exit 0 ;;
 	"accessory exec postgres "*) echo "CLAWDI_VALUE=${AVAILABLE_CONNECTIONS:-80}"; exit 0 ;;
 	*"docker ps -q"*"role=web"*) role=web ;;
 	*"docker ps -q"*"role=channels-worker"*) role=channels-worker ;;
+	*"docker ps -q"*"role=embedding-worker"*) role=embedding-worker ;;
 	*) exit 0 ;;
 esac
 
-pool="${WEB_POOL}"
-[[ "${role}" == channels-worker ]] && pool="${CHANNELS_POOL}"
-if [[ "${pool}" == missing ]]; then
-	echo "CLAWDI_VALUE=missing"
-	exit 0
+if [[ "${role}" == embedding-worker ]]; then
+	if [[ "${EMBEDDING_STATE:-missing}" == missing && ! -f "${FAKE_LOG}.embedding-worker.deployed" ]]; then
+		echo "CLAWDI_VALUE=missing"
+		exit 0
+	fi
+	pool="${EMBEDDING_POOL:-::}"
+	workers=""
+else
+	pool="${WEB_POOL}"
+	workers="${WEB_WORKERS:-}"
+	if [[ "${role}" == channels-worker ]]; then
+		pool="${CHANNELS_POOL}"
+		workers=""
+	fi
 fi
+
 image="ghcr.io/clawdi-ai/clawdi-backend:${CURRENT_IMAGE}"
 if [[ -f "${FAKE_LOG}.${role}.deployed" ]]; then
-	pool=10:10:5
 	image="ghcr.io/clawdi-ai/clawdi-backend:${DEPLOY_IMAGE_VERSION}"
+	case "${role}" in
+		web) pool=5:5:5; workers=2 ;;
+		channels-worker) pool=10:10:5 ;;
+		embedding-worker) pool=:: ;;
+	esac
 fi
-echo "CLAWDI_VALUE=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|${image}|${pool}"
+echo "CLAWDI_VALUE=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|${image}|${pool}|${workers}"
 FAKE
 chmod +x "${tmp}/bin/kamal"
 
@@ -40,11 +64,15 @@ readonly current_image=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 run() {
 	local scenario="$1" web_pool="$2" channels_pool="$3" available="${4:-80}"
+	local embedding_state="${5:-missing}" fail_embedding_health="${6:-0}"
+	local fail_web_ready="${7:-0}" web_workers="${8:-}"
 	local log="${tmp}/${scenario}.log"
 	if ! FAKE_LOG="${log}" PATH="${tmp}/bin:${PATH}" \
 		DEPLOY_IMAGE_VERSION="${target_image}" CURRENT_IMAGE="${current_image}" \
 		WEB_POOL="${web_pool}" CHANNELS_POOL="${channels_pool}" \
-		AVAILABLE_CONNECTIONS="${available}" \
+		AVAILABLE_CONNECTIONS="${available}" EMBEDDING_STATE="${embedding_state}" \
+		FAIL_EMBEDDING_HEALTH="${fail_embedding_health}" FAIL_WEB_READY="${fail_web_ready}" \
+		WEB_WORKERS="${web_workers}" \
 		"${root}/scripts/deploy-backend.sh" >/dev/null; then
 		return 1
 	fi
@@ -53,26 +81,46 @@ run() {
 
 legacy="$(run legacy 20:20:45 20:20:45)"
 grep -q '^app stop --roles channels-worker$' "${legacy}"
-migration_line="$(grep -n 'app exec --primary --roles web --raw' "${legacy}" | cut -d: -f1)"
+migration_line="$(grep -n 'alembic upgrade head' "${legacy}" | cut -d: -f1)"
+embedding_line="$(grep -n 'deploy -P --roles embedding-worker' "${legacy}" | cut -d: -f1)"
+embedding_health_line="$(grep -n 'python -m app.workers.embedding healthcheck' "${legacy}" | cut -d: -f1)"
 channels_line="$(grep -n 'deploy -P --roles channels-worker' "${legacy}" | cut -d: -f1)"
 web_line="$(grep -n 'deploy -P --roles web' "${legacy}" | cut -d: -f1)"
-test "${migration_line}" -lt "${channels_line}" && test "${channels_line}" -lt "${web_line}"
+ready_line="$(grep -n 'curl .*\/ready' "${legacy}" | cut -d: -f1)"
+test "${migration_line}" -lt "${embedding_line}"
+test "${embedding_line}" -lt "${embedding_health_line}"
+test "${embedding_health_line}" -lt "${channels_line}"
+test "${channels_line}" -lt "${web_line}"
+test "${web_line}" -lt "${ready_line}"
 
 bounded="$(run bounded 10:10:5 10:10:5)"
 ! grep -q 'app stop' "${bounded}"
+grep -q 'deploy -P --roles embedding-worker' "${bounded}"
 grep -q 'deploy -P --roles channels-worker' "${bounded}"
 grep -q 'deploy -P --roles web' "${bounded}"
 
-resumed="$(run resumed 20:20:45 10:10:5)"
+resumed="$(run resumed 5:5:5 10:10:5 80 present 0 0 2)"
 ! grep -q 'app stop' "${resumed}"
-grep -q 'deploy -P --roles channels-worker' "${resumed}"
+grep -q 'python -m app.workers.embedding healthcheck' "${resumed}"
 
 if run invalid 12:12:5 10:10:5 >/dev/null 2>&1; then
 	echo "Expected an unknown pool configuration to fail" >&2
 	exit 1
 fi
 
-if run saturated 20:20:45 20:20:45 19 >/dev/null 2>&1; then
+if run saturated 10:10:5 10:10:5 19 >/dev/null 2>&1; then
 	echo "Expected insufficient PostgreSQL headroom to fail" >&2
+	exit 1
+fi
+
+if run embedding-health-failure 10:10:5 10:10:5 80 missing 1 >/dev/null 2>&1; then
+	echo "Expected failed embedding identity health to stop deployment" >&2
+	exit 1
+fi
+! grep -q 'deploy -P --roles channels-worker' "${tmp}/embedding-health-failure.log"
+! grep -q 'deploy -P --roles web' "${tmp}/embedding-health-failure.log"
+
+if run web-readiness-failure 10:10:5 10:10:5 80 missing 0 1 >/dev/null 2>&1; then
+	echo "Expected failed web readiness to fail deployment" >&2
 	exit 1
 fi

--- a/scripts/test-kamal-whatsapp-sidecar-render.sh
+++ b/scripts/test-kamal-whatsapp-sidecar-render.sh
@@ -143,9 +143,9 @@ end
 
 web = config.role("web")
 expected_web_env = {
-  "WEB_CONCURRENCY" => 1,
-  "DB_POOL_SIZE" => 10,
-  "DB_MAX_OVERFLOW" => 10,
+  "WEB_CONCURRENCY" => 2,
+  "DB_POOL_SIZE" => 5,
+  "DB_MAX_OVERFLOW" => 5,
   "DB_POOL_TIMEOUT" => 5,
   "PROMETHEUS_MULTIPROC_DIR" => "/tmp/clawdi-prometheus-multiproc",
 }
@@ -154,8 +154,27 @@ unless web.specialized_env.clear == expected_web_env
 end
 raise "web role memory drifted" unless config.raw_config.servers.dig("web", "options", "memory") == "6g"
 web_env = web.env(web.primary_host).clear
-unless web_env.values_at("DB_POOL_SIZE", "DB_MAX_OVERFLOW", "DB_POOL_TIMEOUT") == [ 10, 10, 5 ]
+unless web_env.values_at("DB_POOL_SIZE", "DB_MAX_OVERFLOW", "DB_POOL_TIMEOUT") == [ 5, 5, 5 ]
   raise "web role database pool drifted"
+end
+embedding_worker = config.role("embedding-worker")
+embedding_role = embedding_worker.specialized_env.clear == {
+  "CLAWDI_PROCESS_ROLE" => "embedding-worker",
+  "MEMORY_EMBEDDING_THREADS" => 2,
+  "MEMORY_EMBEDDING_WORKER_MAX_CONCURRENCY" => 1,
+}
+unless embedding_role && !embedding_worker.running_proxy?
+  raise "embedding-worker role contract drifted"
+end
+embedding_options = config.raw_config.servers.fetch("embedding-worker").fetch("options")
+raise "embedding worker memory drifted" unless embedding_options.fetch("memory") == "4g"
+raise "embedding worker CPU quota drifted" unless embedding_options.fetch("cpus") == 2
+unless embedding_options.fetch("health-cmd") == "python -m app.workers.embedding healthcheck"
+  raise "embedding worker healthcheck lost its instance identity gate"
+end
+embedding_env = embedding_worker.env(embedding_worker.primary_host).clear
+if embedding_env.keys.any? { |key| key.start_with?("DB_POOL_") }
+  raise "embedding worker unexpectedly owns a database pool"
 end
 channels_worker = config.role("channels-worker")
 expected_channels_worker_env = {
@@ -180,9 +199,16 @@ web_connections = web_env.fetch("WEB_CONCURRENCY") *
 worker_connections = channels_worker_env.fetch("DB_POOL_SIZE") +
   channels_worker_env.fetch("DB_MAX_OVERFLOW")
 steady_connections = web_connections + worker_connections
-rolling_connections = 2 * (web_connections + worker_connections)
+rolling_connections = [
+  2 * web_connections + worker_connections,
+  web_connections + 2 * worker_connections,
+].max
 raise "steady database connection budget drifted" unless steady_connections == 40
-raise "rolling database connection budget drifted" unless rolling_connections == 80
+raise "rolling database connection budget drifted" unless rolling_connections == 60
+shared_env = config.raw_config.env.clear
+if shared_env.keys.any? { |key| key.start_with?("DB_POOL_") }
+  raise "database pool ownership escaped the web and channels roles"
+end
 
 config.accessories.each do |accessory|
   command = Kamal::Commands::Accessory.new(config, name: accessory.name).run
@@ -199,6 +225,9 @@ whatsapp_command = Kamal::Commands::Accessory.new(config, name: "whatsapp-bailey
 app_socket_volume = "/home/phala/clawdi-whatsapp/run:/run/clawdi-whatsapp:ro"
 unless config.raw_config.volumes.include?(app_socket_volume)
   raise "backend roles lost the read-only WhatsApp Unix socket directory"
+end
+unless config.raw_config.volumes.include?("clawdi-embedding:/run/clawdi-embedding")
+  raise "backend roles lost the embedding Unix socket volume"
 end
 unless whatsapp_command.each_cons(2).include?([ "--network", "bridge" ])
   raise "disabled WhatsApp sidecar did not preserve bridge networking"


### PR DESCRIPTION
## Summary

- move the local FastEmbed/ONNX model into one dedicated `embedding-worker` reached over a shared Unix socket
- run two Uvicorn API workers without duplicating the model and ONNX thread pool in each API process
- bound embedding to 2 CPUs, 4 GiB, two ONNX threads, and one concurrent inference; reject excess work immediately instead of building an in-memory queue
- preserve core read/write availability by degrading memory writes to no-vector storage and search to FTS/trigram when embedding is unavailable
- make UDS publication generation-safe and require exact-container instance identity for Docker and release health gates
- clean up Prometheus multiprocess live gauges after worker exit while preserving cumulative counters and histograms
- include `embedding-worker` in the single production deploy helper; no rollout flag or manual first-adoption path is added

## Availability priority

The change isolates optional CPU- and memory-heavy semantic embedding from the API processes that serve new users, new deployments, existing deployment control/recovery, and critical API traffic. Embedding saturation fails fast and falls back; it does not consume all API workers or accumulate an unbounded local queue.

The Web role uses two workers with `5 + 5` database connections each. Channels keeps `10 + 10`; embedding owns no database pool. Steady state reserves 40 PostgreSQL connections. Sequential role rollout normally peaks at 60 of 100, leaving at least 40 for migration, operators, and transient work.

## Release contract

`scripts/deploy-backend.sh` is the only normal production path and performs:

1. validate the running Web, channels, and embedding role contracts; unknown state fails closed
2. require at least 20 available ordinary PostgreSQL slots
3. run the exact-image migration
4. deploy `embedding-worker` and verify the exact image plus its own instance-identity UDS health
5. deploy `channels-worker` and verify the exact image and `10 + 10 / 5s` pool
6. deploy Web and verify the exact image, two workers, `5 + 5 / 5s` pools, and `/ready`

The helper accepts the legacy `20 + 20 / 45s` and current bounded contracts during transition. It stops before changing database-owning roles when embedding health fails. No host-memory guess, PSI gate, rollout flag, or separate manual command sequence is introduced.

The embedding listener starts on a staged socket and atomically replaces the stable path only after Uvicorn is serving. Health succeeds only when the shared path reports the checking container own hostname/container ID. HTTPX disables UDS keep-alive and automatic retry, so each POST connects to the currently published generation and is never replayed automatically.

The API supervisor is based on the pinned Uvicorn 0.52.4 supervisor contract. It caps runtime worker count at the reviewed one- or two-worker range and marks a Prometheus worker dead only after `join()` confirms exit, including SIGTERM, SIGKILL/crash, health replacement, SIGHUP replacement, scale-down, and parent shutdown.

## Verification

- commit: `04c17f4cd` on `a3d58df8a` (`main`, including #1353)
- complete hermetic Backend suite: `2574 passed, 12 skipped`
- focused real Uvicorn/UDS and Prometheus lifecycle suite: `45 passed`
- Kamal 2.12.0 render, backend deploy helper, and sidecar deployment contracts: passed
- `uv lock --check`, dependency authority, Deptry, outbound API governance: passed
- Ruff check/format, compileall, strict exception audit: passed
- BasedPyright owned files: 211 files, 0 errors, 0 warnings
- generated API current: passed
- production Dockerfile build and non-root/runtime/socket-directory contracts: passed
- `git diff --check`: passed

No production load test or tenant operation was performed. Incus CPU and memory capacity are intentionally outside this change; deployment capacity continues to use operator-specified values.

## References

- FastAPI worker processes and per-process memory: https://fastapi.tiangolo.com/deployment/concepts/
- Prometheus multiprocess mode: https://prometheus.github.io/client_python/multiprocess/
- Uvicorn deployment: https://www.uvicorn.org/deployment/
- HTTPX Unix domain socket transport: https://www.python-httpx.org/advanced/transports/
- HTTPX resource limits: https://www.python-httpx.org/advanced/resource-limits/
- Docker resource constraints: https://docs.docker.com/engine/containers/resource_constraints/
- FastEmbed thread control: https://github.com/qdrant/fastembed/blob/v0.8.0/fastembed/text/text_embedding.py
- Kamal 2.12.0 boot implementation: https://github.com/basecamp/kamal/blob/v2.12.0/lib/kamal/cli/app/boot.rb