### PR TITLE
fix(runtime): retire conflicting legacy OpenClaw identity

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.42",
+      "version": "0.14.43",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.42",
+	"version": "0.14.43",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/lib/codex-oauth-native-store.test.ts
+++ b/packages/cli/src/lib/codex-oauth-native-store.test.ts
@@ -63,6 +63,7 @@ describe("native OAuth store contracts", () => {
 		const providerAuthPath = join(packageRoot, "provider-auth.mjs");
 		const configMutationPath = join(packageRoot, "config-mutation.mjs");
 		const deviceBootstrapPath = join(packageRoot, "device-bootstrap.mjs");
+		const doctorMigrationsPath = join(packageRoot, "doctor-migrations.mjs");
 		const commandPath = join(home, ".local", "bin", "openclaw");
 		mkdirSync(dirname(commandPath), { recursive: true });
 		mkdirSync(packageRoot, { recursive: true });
@@ -77,6 +78,7 @@ exec "${join(home, ".local", "tools", "node", "bin", "node")}" "${join(packageRo
 		writeFileSync(providerAuthPath, "export const publicProviderAuth = true;\n");
 		writeFileSync(configMutationPath, "export const publicConfigMutation = true;\n");
 		writeFileSync(deviceBootstrapPath, "export const publicDeviceBootstrap = true;\n");
+		writeFileSync(doctorMigrationsPath, "export const publicDoctorMigrations = true;\n");
 		writeFileSync(
 			join(packageRoot, "package.json"),
 			JSON.stringify({
@@ -86,6 +88,7 @@ exec "${join(home, ".local", "tools", "node", "bin", "node")}" "${join(packageRo
 					"./plugin-sdk/provider-auth": "./provider-auth.mjs",
 					"./plugin-sdk/config-mutation": "./config-mutation.mjs",
 					"./plugin-sdk/device-bootstrap": "./device-bootstrap.mjs",
+					"./plugin-sdk/runtime-doctor-migrations": "./doctor-migrations.mjs",
 				},
 			}),
 		);
@@ -98,6 +101,7 @@ exec "${join(home, ".local", "tools", "node", "bin", "node")}" "${join(packageRo
 		expect(resolveSdk(OPENCLAW_SDK_EXPORT_PATHS.providerAuth)).toBe(providerAuthPath);
 		expect(resolveSdk(OPENCLAW_SDK_EXPORT_PATHS.configMutation)).toBe(configMutationPath);
 		expect(resolveSdk(OPENCLAW_SDK_EXPORT_PATHS.deviceBootstrap)).toBe(deviceBootstrapPath);
+		expect(resolveSdk(OPENCLAW_SDK_EXPORT_PATHS.doctorMigrations)).toBe(doctorMigrationsPath);
 	});
 
 	test("preserves a future Hermes store version and unrelated pool entries", () => {

--- a/packages/cli/src/lib/codex-oauth-native-store.ts
+++ b/packages/cli/src/lib/codex-oauth-native-store.ts
@@ -80,6 +80,7 @@ export function nativeOAuthCredentialEvidenceFingerprint(value: unknown): string
 export const OPENCLAW_SDK_EXPORT_PATHS = {
 	configMutation: "config-mutation",
 	deviceBootstrap: "device-bootstrap",
+	doctorMigrations: "runtime-doctor-migrations",
 	providerAuth: "provider-auth",
 	sessionTranscript: "session-transcript-runtime",
 } as const;

--- a/packages/cli/src/runtime/hosted-openclaw-context.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-context.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
 import {
 	CLAWDI_MANAGED_PROVIDER_ID,
@@ -23,10 +23,34 @@ import { parseSystemctlShow, systemctlPath } from "./systemd";
 const OPENCLAW_AGENT_ID = "main";
 const OPENCLAW_CONFIG_PROBE_TIMEOUT_MS = 15_000;
 const OPENCLAW_CONFIG_REPAIR_TIMEOUT_MS = 120_000;
+const OPENCLAW_STARTUP_LOG_PROBE_TIMEOUT_MS = 10_000;
 const OPENCLAW_GATEWAY_UNIT = "openclaw-gateway.service";
 const OPENCLAW_GATEWAY_TRANSITION_RETRIES = 2;
 const OPENCLAW_GATEWAY_TRANSITION_RETRY_DELAY_MS = 3_000;
 const openClawWorkspaces = new Map<string, { revision: string; workspace: string }>();
+const OPENCLAW_STARTUP_MIGRATION_MARKER = "OpenClaw startup migrations did not complete cleanly";
+const OPENCLAW_DEVICE_IDENTITY_CONFLICT =
+	"canonical SQLite device identity differs from the legacy identity";
+
+const OPENCLAW_ARCHIVE_LEGACY_IDENTITY_HELPER = `
+import { pathToFileURL } from "node:url";
+const sdk = await import(pathToFileURL(process.argv[1]).href);
+if (typeof sdk.archiveLegacyStateSource !== "function") {
+  throw new Error("required public migration archive export is missing");
+}
+const changes = [];
+const warnings = [];
+await sdk.archiveLegacyStateSource({
+  filePath: process.argv[2],
+  label: "device identity",
+  changes,
+  warnings,
+});
+if (warnings.length !== 0 || changes.length !== 1) {
+  throw new Error(warnings[0] ?? "legacy device identity was not archived");
+}
+process.stdout.write(JSON.stringify({ archived: true }));
+`;
 
 class OpenClawWorkspaceRosterError extends Error {
 	constructor(readonly doctorRepairRequired: boolean) {
@@ -35,13 +59,33 @@ class OpenClawWorkspaceRosterError extends Error {
 	}
 }
 
-function openClawDoctorRepairRequired(result: ReturnType<typeof spawnRuntimeUserCommand>): boolean {
-	const output = [result.stderr, result.stdout]
+function runtimeCommandOutput(result: ReturnType<typeof spawnRuntimeUserCommand>): string {
+	return [result.stderr, result.stdout]
 		.filter((value): value is string => typeof value === "string")
 		.join("\n");
+}
+
+function openClawDoctorRepairRequired(result: ReturnType<typeof spawnRuntimeUserCommand>): boolean {
+	const output = runtimeCommandOutput(result);
 	return (
-		output.includes("OpenClaw startup migrations did not complete cleanly") &&
+		output.includes(OPENCLAW_STARTUP_MIGRATION_MARKER) &&
 		output.includes('Run "openclaw doctor --fix"')
+	);
+}
+
+function openClawStartupMigrationWarning(
+	result: ReturnType<typeof spawnRuntimeUserCommand>,
+): boolean {
+	return runtimeCommandOutput(result).includes(OPENCLAW_STARTUP_MIGRATION_MARKER);
+}
+
+function openClawDeviceIdentityConflict(
+	result: ReturnType<typeof spawnRuntimeUserCommand>,
+): boolean {
+	return (
+		!result.error &&
+		!result.signal &&
+		runtimeCommandOutput(result).includes(OPENCLAW_DEVICE_IDENTITY_CONFLICT)
 	);
 }
 
@@ -199,15 +243,80 @@ export function repairHostedOpenClawConfig(home: string): boolean {
 	return true;
 }
 
+function runHostedOpenClawDoctorCommand(home: string, command = commandPath(home)) {
+	return spawnRuntimeUserCommand(command, ["doctor", "--fix", "--non-interactive"], home, home, {
+		timeoutMs: OPENCLAW_CONFIG_REPAIR_TIMEOUT_MS,
+		maxBufferBytes: 4 * 1024 * 1024,
+	});
+}
+
 function runHostedOpenClawDoctor(home: string, command = commandPath(home)): void {
-	const repair = spawnRuntimeUserCommand(
-		command,
-		["doctor", "--fix", "--non-interactive"],
-		home,
-		home,
-		{ timeoutMs: OPENCLAW_CONFIG_REPAIR_TIMEOUT_MS, maxBufferBytes: 4 * 1024 * 1024 },
-	);
+	const repair = runHostedOpenClawDoctorCommand(home, command);
 	if (repair.status !== 0) throw new Error("OpenClaw official repair failed");
+}
+
+function openClawStartupMigrationFailed(home: string): boolean {
+	const legacyIdentity = join(home, ".openclaw", "identity", "device.json");
+	if (!existsSync(legacyIdentity)) return false;
+	const journalctl = process.env.CLAWDI_JOURNALCTL_PATH?.trim() || "journalctl";
+	const result = spawnRuntimeUserCommand(
+		journalctl,
+		[
+			`--user-unit=${OPENCLAW_GATEWAY_UNIT}`,
+			"--boot=0",
+			"--no-pager",
+			"--quiet",
+			"--output=cat",
+			"--lines=500",
+		],
+		home,
+		home,
+		{ timeoutMs: OPENCLAW_STARTUP_LOG_PROBE_TIMEOUT_MS, maxBufferBytes: 1024 * 1024 },
+	);
+	return result.status === 0 && openClawStartupMigrationWarning(result);
+}
+
+function archiveHostedLegacyOpenClawIdentity(home: string, command: string): void {
+	const sdkPath = resolveOpenClawSdkExport(
+		home,
+		[command],
+		OPENCLAW_SDK_EXPORT_PATHS.doctorMigrations,
+	);
+	if (!sdkPath) {
+		throw new Error("installed OpenClaw public migration archive SDK is unavailable");
+	}
+	const result = spawnRuntimeUserCommand(
+		"node",
+		[
+			"--input-type=module",
+			"--eval",
+			OPENCLAW_ARCHIVE_LEGACY_IDENTITY_HELPER,
+			sdkPath,
+			join(home, ".openclaw", "identity", "device.json"),
+		],
+		home,
+		home,
+		{ timeoutMs: OPENCLAW_CONFIG_PROBE_TIMEOUT_MS, maxBufferBytes: 1024 * 1024 },
+	);
+	if (result.status !== 0) {
+		throw new Error("OpenClaw legacy device identity archive failed");
+	}
+}
+
+export function repairHostedOpenClawStartupMigrations(home: string): boolean {
+	if (!openClawStartupMigrationFailed(home)) return false;
+	const command = commandPath(home);
+	const repair = runHostedOpenClawDoctorCommand(home, command);
+	if (!openClawDeviceIdentityConflict(repair)) {
+		if (repair.status !== 0) throw new Error("OpenClaw official repair failed");
+		return true;
+	}
+	archiveHostedLegacyOpenClawIdentity(home, command);
+	const verified = runHostedOpenClawDoctorCommand(home, command);
+	if (verified.status !== 0 || openClawDeviceIdentityConflict(verified)) {
+		throw new Error("OpenClaw legacy device identity retirement did not clear the conflict");
+	}
+	return true;
 }
 
 export function repairHostedOpenClawWorkspace(home: string, error: unknown): boolean {

--- a/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
 	repairHostedOpenClawConfig,
+	repairHostedOpenClawStartupMigrations,
 	repairHostedOpenClawWorkspace,
 	resolveHostedOpenClawWorkspace,
 } from "./hosted-openclaw-context";
@@ -19,11 +20,14 @@ import { activateHostedOpenClawSkill } from "./hosted-openclaw-skill";
 
 let root = "";
 const originalSystemctlPath = process.env.CLAWDI_SYSTEMCTL_PATH;
+const originalJournalctlPath = process.env.CLAWDI_JOURNALCTL_PATH;
 afterEach(() => {
 	if (root) rmSync(root, { recursive: true, force: true });
 	root = "";
 	if (originalSystemctlPath === undefined) delete process.env.CLAWDI_SYSTEMCTL_PATH;
 	else process.env.CLAWDI_SYSTEMCTL_PATH = originalSystemctlPath;
+	if (originalJournalctlPath === undefined) delete process.env.CLAWDI_JOURNALCTL_PATH;
+	else process.env.CLAWDI_JOURNALCTL_PATH = originalJournalctlPath;
 });
 
 test("retries the official workspace roster while the OpenClaw gateway is restarting", () => {
@@ -253,6 +257,82 @@ esac
 	expect(resolveHostedOpenClawWorkspace(home)).toBe(workspaceRoot);
 	expect(readFileSync(commandLog, "utf-8").trim().split("\n")).toEqual([
 		"agents list --json",
+		"doctor --fix --non-interactive",
+		"agents list --json",
+	]);
+});
+
+test("retires a conflicting legacy device identity reported only by gateway startup", () => {
+	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-identity-retirement-"));
+	const home = join(root, "home");
+	const workspaceRoot = join(home, "agent-workspace");
+	const command = join(home, ".local", "bin", "openclaw");
+	const packageRoot = join(home, ".local", "lib", "node_modules", "openclaw");
+	const archiveSdk = join(packageRoot, "runtime-doctor-migrations.mjs");
+	const legacyIdentity = join(home, ".openclaw", "identity", "device.json");
+	const journalctl = join(root, "journalctl");
+	const journalLog = join(root, "journal.log");
+	const commandLog = join(root, "commands.log");
+	mkdirSync(dirname(command), { recursive: true });
+	mkdirSync(dirname(legacyIdentity), { recursive: true });
+	mkdirSync(packageRoot, { recursive: true });
+	writeFileSync(legacyIdentity, '{"version":1}\n');
+	writeFileSync(
+		join(packageRoot, "package.json"),
+		JSON.stringify({
+			name: "openclaw",
+			type: "module",
+			exports: {
+				"./plugin-sdk/runtime-doctor-migrations": "./runtime-doctor-migrations.mjs",
+			},
+		}),
+	);
+	writeFileSync(
+		archiveSdk,
+		`import { rename } from "node:fs/promises";
+export async function archiveLegacyStateSource({ filePath, changes }) {
+  const archived = filePath + ".migrated";
+  await rename(filePath, archived);
+  changes.push("archived");
+}
+`,
+	);
+	writeFileSync(
+		command,
+		`#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> '${commandLog}'
+case "$*" in
+  "agents list --json") printf '%s\n' '[{"id":"main","workspace":"${workspaceRoot}"}]' ;;
+  "doctor --fix --non-interactive")
+    if test -f '${legacyIdentity}'; then
+      printf '%s\n' 'Failed migrating legacy device identity: Error: canonical SQLite device identity differs from the legacy identity' >&2
+    fi
+    ;;
+  *) exit 64 ;;
+esac
+`,
+	);
+	writeFileSync(
+		journalctl,
+		`#!/bin/sh
+printf '%s\n' "$*" > '${journalLog}'
+printf '%s\n' 'OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.'
+`,
+	);
+	chmodSync(command, 0o755);
+	chmodSync(journalctl, 0o755);
+	process.env.CLAWDI_JOURNALCTL_PATH = journalctl;
+
+	expect(repairHostedOpenClawStartupMigrations(home)).toBe(true);
+	expect(existsSync(legacyIdentity)).toBe(false);
+	expect(existsSync(`${legacyIdentity}.migrated`)).toBe(true);
+	expect(readFileSync(journalLog, "utf8").trim()).toBe(
+		"--user-unit=openclaw-gateway.service --boot=0 --no-pager --quiet --output=cat --lines=500",
+	);
+	expect(resolveHostedOpenClawWorkspace(home)).toBe(workspaceRoot);
+	expect(readFileSync(commandLog, "utf8").trim().split("\n")).toEqual([
+		"doctor --fix --non-interactive",
 		"doctor --fix --non-interactive",
 		"agents list --json",
 	]);

--- a/packages/cli/src/runtime/manifest-converge.ts
+++ b/packages/cli/src/runtime/manifest-converge.ts
@@ -20,6 +20,7 @@ import {
 } from "./hosted-agent-plugin-runtime";
 import {
 	createOpenClawHostedContext,
+	repairHostedOpenClawStartupMigrations,
 	repairHostedOpenClawWorkspace,
 	resolveHostedOpenClawWorkspace,
 } from "./hosted-openclaw-context";
@@ -189,6 +190,7 @@ function resolveOpenClawWorkspaceForConvergence(
 	home: string,
 	repairInvalidConfig: boolean,
 ): string {
+	if (repairInvalidConfig) repairHostedOpenClawStartupMigrations(home);
 	try {
 		return resolveHostedOpenClawWorkspace(home);
 	} catch (error) {


### PR DESCRIPTION
## Summary
- detect the official OpenClaw startup-migration failure from the gateway user-unit journal before hosted convergence
- run `openclaw doctor --fix` and retire `identity/device.json` only when OpenClaw reports the exact canonical-SQLite vs legacy identity conflict
- use OpenClaw's public migration archive API, then rerun doctor and fail closed unless the conflict is gone
- release the fix as `clawdi@0.14.43`

## Safety boundary
- canonical SQLite identity remains authoritative and unchanged
- no database, key, volume, Incus, Hosted controller, workflow, or CI runner changes
- no archive on missing legacy state, missing startup marker, generic doctor failure, timeout, or signal termination

## Verification
- `bun test packages/cli/src/runtime/hosted-openclaw-skill.test.ts packages/cli/src/lib/codex-oauth-native-store.test.ts packages/cli/src/runtime/manifest-services.test.ts` (44 passed)
- `bun run --cwd packages/cli typecheck`
- changed-file Biome check
- `bun run --cwd packages/cli build`
- `bun run --cwd packages/cli check:publish-manifest`
- `git diff --check`
