### PR TITLE
fix(runtime): recover OpenClaw identity without journal logs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.43",
+      "version": "0.14.44",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.43",
+	"version": "0.14.44",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/hosted-openclaw-context.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-context.ts
@@ -23,7 +23,6 @@ import { parseSystemctlShow, systemctlPath } from "./systemd";
 const OPENCLAW_AGENT_ID = "main";
 const OPENCLAW_CONFIG_PROBE_TIMEOUT_MS = 15_000;
 const OPENCLAW_CONFIG_REPAIR_TIMEOUT_MS = 120_000;
-const OPENCLAW_STARTUP_LOG_PROBE_TIMEOUT_MS = 10_000;
 const OPENCLAW_GATEWAY_UNIT = "openclaw-gateway.service";
 const OPENCLAW_GATEWAY_TRANSITION_RETRIES = 2;
 const OPENCLAW_GATEWAY_TRANSITION_RETRY_DELAY_MS = 3_000;
@@ -71,12 +70,6 @@ function openClawDoctorRepairRequired(result: ReturnType<typeof spawnRuntimeUser
 		output.includes(OPENCLAW_STARTUP_MIGRATION_MARKER) &&
 		output.includes('Run "openclaw doctor --fix"')
 	);
-}
-
-function openClawStartupMigrationWarning(
-	result: ReturnType<typeof spawnRuntimeUserCommand>,
-): boolean {
-	return runtimeCommandOutput(result).includes(OPENCLAW_STARTUP_MIGRATION_MARKER);
 }
 
 function openClawDeviceIdentityConflict(
@@ -255,27 +248,6 @@ function runHostedOpenClawDoctor(home: string, command = commandPath(home)): voi
 	if (repair.status !== 0) throw new Error("OpenClaw official repair failed");
 }
 
-function openClawStartupMigrationFailed(home: string): boolean {
-	const legacyIdentity = join(home, ".openclaw", "identity", "device.json");
-	if (!existsSync(legacyIdentity)) return false;
-	const journalctl = process.env.CLAWDI_JOURNALCTL_PATH?.trim() || "journalctl";
-	const result = spawnRuntimeUserCommand(
-		journalctl,
-		[
-			`--user-unit=${OPENCLAW_GATEWAY_UNIT}`,
-			"--boot=0",
-			"--no-pager",
-			"--quiet",
-			"--output=cat",
-			"--lines=500",
-		],
-		home,
-		home,
-		{ timeoutMs: OPENCLAW_STARTUP_LOG_PROBE_TIMEOUT_MS, maxBufferBytes: 1024 * 1024 },
-	);
-	return result.status === 0 && openClawStartupMigrationWarning(result);
-}
-
 function archiveHostedLegacyOpenClawIdentity(home: string, command: string): void {
 	const sdkPath = resolveOpenClawSdkExport(
 		home,
@@ -304,7 +276,7 @@ function archiveHostedLegacyOpenClawIdentity(home: string, command: string): voi
 }
 
 export function repairHostedOpenClawStartupMigrations(home: string): boolean {
-	if (!openClawStartupMigrationFailed(home)) return false;
+	if (!existsSync(join(home, ".openclaw", "identity", "device.json"))) return false;
 	const command = commandPath(home);
 	const repair = runHostedOpenClawDoctorCommand(home, command);
 	if (!openClawDeviceIdentityConflict(repair)) {

--- a/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
+++ b/packages/cli/src/runtime/hosted-openclaw-skill.test.ts
@@ -20,14 +20,11 @@ import { activateHostedOpenClawSkill } from "./hosted-openclaw-skill";
 
 let root = "";
 const originalSystemctlPath = process.env.CLAWDI_SYSTEMCTL_PATH;
-const originalJournalctlPath = process.env.CLAWDI_JOURNALCTL_PATH;
 afterEach(() => {
 	if (root) rmSync(root, { recursive: true, force: true });
 	root = "";
 	if (originalSystemctlPath === undefined) delete process.env.CLAWDI_SYSTEMCTL_PATH;
 	else process.env.CLAWDI_SYSTEMCTL_PATH = originalSystemctlPath;
-	if (originalJournalctlPath === undefined) delete process.env.CLAWDI_JOURNALCTL_PATH;
-	else process.env.CLAWDI_JOURNALCTL_PATH = originalJournalctlPath;
 });
 
 test("retries the official workspace roster while the OpenClaw gateway is restarting", () => {
@@ -262,7 +259,7 @@ esac
 	]);
 });
 
-test("retires a conflicting legacy device identity reported only by gateway startup", () => {
+test("retires a conflicting legacy device identity without relying on gateway logs", () => {
 	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-identity-retirement-"));
 	const home = join(root, "home");
 	const workspaceRoot = join(home, "agent-workspace");
@@ -270,8 +267,6 @@ test("retires a conflicting legacy device identity reported only by gateway star
 	const packageRoot = join(home, ".local", "lib", "node_modules", "openclaw");
 	const archiveSdk = join(packageRoot, "runtime-doctor-migrations.mjs");
 	const legacyIdentity = join(home, ".openclaw", "identity", "device.json");
-	const journalctl = join(root, "journalctl");
-	const journalLog = join(root, "journal.log");
 	const commandLog = join(root, "commands.log");
 	mkdirSync(dirname(command), { recursive: true });
 	mkdirSync(dirname(legacyIdentity), { recursive: true });
@@ -313,29 +308,45 @@ case "$*" in
 esac
 `,
 	);
-	writeFileSync(
-		journalctl,
-		`#!/bin/sh
-printf '%s\n' "$*" > '${journalLog}'
-printf '%s\n' 'OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.'
-`,
-	);
 	chmodSync(command, 0o755);
-	chmodSync(journalctl, 0o755);
-	process.env.CLAWDI_JOURNALCTL_PATH = journalctl;
 
 	expect(repairHostedOpenClawStartupMigrations(home)).toBe(true);
 	expect(existsSync(legacyIdentity)).toBe(false);
 	expect(existsSync(`${legacyIdentity}.migrated`)).toBe(true);
-	expect(readFileSync(journalLog, "utf8").trim()).toBe(
-		"--user-unit=openclaw-gateway.service --boot=0 --no-pager --quiet --output=cat --lines=500",
-	);
 	expect(resolveHostedOpenClawWorkspace(home)).toBe(workspaceRoot);
 	expect(readFileSync(commandLog, "utf8").trim().split("\n")).toEqual([
 		"doctor --fix --non-interactive",
 		"doctor --fix --non-interactive",
 		"agents list --json",
 	]);
+});
+
+test("does not run OpenClaw doctor when no legacy device identity exists", () => {
+	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-no-legacy-identity-"));
+	expect(repairHostedOpenClawStartupMigrations(join(root, "home"))).toBe(false);
+});
+
+test("does not archive the legacy identity for an unrelated doctor failure", () => {
+	root = mkdtempSync(join(tmpdir(), "hosted-openclaw-unrelated-doctor-failure-"));
+	const home = join(root, "home");
+	const command = join(home, ".local", "bin", "openclaw");
+	const legacyIdentity = join(home, ".openclaw", "identity", "device.json");
+	mkdirSync(dirname(command), { recursive: true });
+	mkdirSync(dirname(legacyIdentity), { recursive: true });
+	writeFileSync(legacyIdentity, '{"version":1}\n');
+	writeFileSync(
+		command,
+		`#!/bin/sh
+printf '%s\n' 'unrelated doctor failure' >&2
+exit 1
+`,
+		{ mode: 0o755 },
+	);
+
+	expect(() => repairHostedOpenClawStartupMigrations(home)).toThrow(
+		"OpenClaw official repair failed",
+	);
+	expect(existsSync(legacyIdentity)).toBe(true);
 });
 
 test("does not repair without opt-in or a definitive invalid-config validation", () => {


### PR DESCRIPTION
## Summary
- remove the unreliable user-journal prerequisite from Hosted OpenClaw legacy identity recovery
- run the official state-migration doctor whenever the exact legacy device identity source exists
- archive only after the doctor reports the exact canonical/legacy identity conflict, then verify with a second doctor run
- release CLI version `0.14.44`

## Safety
- does not modify canonical SQLite identity
- does not touch Hosted, Incus, CI runner configuration, or user volumes
- unrelated doctor failures remain fail-closed and leave the legacy identity in place

## Verification
- isolated Docker CLI typecheck
- `packages/cli/src/runtime/hosted-openclaw-skill.test.ts`: 11 passed
- `git diff --check`
