### PR TITLE
fix(cli): accept OpenClaw session-key activity

### DIFF
--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -44,8 +44,9 @@ describe("relativeTime", () => {
 	});
 
 	test("returns future minute-granularity", () => {
-		const fiveMinFromNow = new Date(Date.now() + 5 * 60 * 1000).toISOString();
-		expect(relativeTime(fiveMinFromNow)).toBe("in 5m");
+		const now = new Date("2026-09-04T10:00:00Z");
+		const fiveMinFromNow = new Date(now.getTime() + 5 * 60 * 1000).toISOString();
+		expect(relativeTime(fiveMinFromNow, now)).toBe("in 5m");
 	});
 
 	test("switches to compact absolute at >=7 days (current year)", () => {

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -8,7 +8,7 @@ export { cn } from "cn";
  * `Mar 15 2025` cross-year), so users can tell at-a-glance whether
  * a session was last week or last month without hovering.
  */
-export function relativeTime(dateStr: string | null | undefined): string {
+export function relativeTime(dateStr: string | null | undefined, now = new Date()): string {
 	// Defensive: callers go through this with values from API
 	// responses, and during a deploy window a cached response might
 	// be missing a field that the new frontend reads as required.
@@ -18,7 +18,7 @@ export function relativeTime(dateStr: string | null | undefined): string {
 	if (!dateStr) return "—";
 	const d = new Date(dateStr);
 	if (Number.isNaN(d.getTime())) return "—";
-	const diffMs = d.getTime() - Date.now();
+	const diffMs = d.getTime() - now.getTime();
 	const future = diffMs > 0;
 	const phrase = (value: number, unit: string) =>
 		future ? `in ${value}${unit}` : `${value}${unit} ago`;
@@ -29,7 +29,6 @@ export function relativeTime(dateStr: string | null | undefined): string {
 	if (hours < 24) return phrase(hours, "h");
 	const days = Math.floor(hours / 24);
 	if (days < 7) return phrase(days, "d");
-	const now = new Date();
 	const sameYear = d.getFullYear() === now.getFullYear();
 	if (sameYear) {
 		// "Apr 28 14:30" — short month + 24h time, locale-aware

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.45",
+      "version": "0.14.46",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.45",
+	"version": "0.14.46",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -1132,12 +1132,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 					message,
 				};
 				drafts.push(
-					...openClawEventDrafts(
-						raw,
-						`${entry.agentId}:${sessionId}`,
-						recordSeq,
-						currentModel,
-					),
+					...openClawEventDrafts(raw, `${entry.agentId}:${sessionId}`, recordSeq, currentModel),
 				);
 				const messageModel = jsonString(message.model);
 				if (messageModel) {

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -152,7 +152,6 @@ interface SessionEntry {
 interface OfficialSessionEntry extends SessionEntry {
 	agentId: string;
 	key: string;
-	sessionId: string;
 	spawnedCwd?: string;
 	spawnedWorkspaceDir?: string;
 	sessionStartedAt?: number;
@@ -387,11 +386,11 @@ function readOfficialSessionInventory(): OfficialSessionInventory | null {
 		const row = jsonObject(value);
 		const agentId = jsonString(row?.agentId);
 		const key = jsonString(row?.key);
-		const sessionId = jsonString(row?.sessionId);
-		if (!row || !agentId || !key || !sessionId) {
+		if (!row || !agentId || !key) {
 			complete = false;
 			return [];
 		}
+		const sessionId = jsonString(row.sessionId) ?? undefined;
 		const number = (field: string) => {
 			const candidate = row[field];
 			return typeof candidate === "number" && Number.isFinite(candidate) ? candidate : undefined;
@@ -447,6 +446,7 @@ function readOfficialSessionInventory(): OfficialSessionInventory | null {
 async function readOfficialSessionMessagesFromSdk(
 	entry: OfficialSessionEntry,
 ): Promise<JsonObject[] | null> {
+	if (!entry.sessionId) return null;
 	const sdkPath = resolveOpenClawSdkExport(
 		process.env.HOME ?? homedir(),
 		[],
@@ -502,7 +502,6 @@ function readOfficialSessionMessagesFromGateway(entry: OfficialSessionEntry): Js
 				limit: 1000,
 				maxChars: 500_000,
 				offset,
-				sessionId: entry.sessionId,
 				sessionKey: entry.key,
 			}),
 			"--json",
@@ -1056,7 +1055,9 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			complete: inventory.complete,
 		};
 		for (const entry of inventory.entries) {
-			if (localSessionId !== undefined && entry.sessionId !== localSessionId) continue;
+			const sessionId = entry.sessionId;
+			if (localSessionId !== undefined && sessionId !== localSessionId) continue;
+			if (!sessionId && isInternalOpenClawSession(entry.key, entry)) continue;
 			const updatedAt = entry.updatedAt;
 			if (typeof updatedAt !== "number" || !Number.isFinite(updatedAt)) {
 				userActivity.complete = false;
@@ -1068,13 +1069,13 @@ export class OpenClawAdapter implements AgentAdapterCore {
 				(!projectPath || (projectPath !== absFilter && !projectPath.startsWith(`${absFilter}/`)))
 			)
 				continue;
-			observedLocalSessionIds.push(entry.sessionId);
-			const sourceRevision = `${entry.sessionId}:${updatedAt}`;
-			if (knownSourceRevisions.get(entry.sessionId) === sourceRevision) continue;
+			if (sessionId) observedLocalSessionIds.push(sessionId);
+			const sourceRevision = sessionId ? `${sessionId}:${updatedAt}` : null;
+			if (sessionId && knownSourceRevisions.get(sessionId) === sourceRevision) continue;
 
 			let transcript = await readOfficialSessionMessagesFromSdk(entry);
 			transcript ??= readOfficialSessionMessagesFromGateway(entry);
-			if (transcript === null && entry.sessionFile) {
+			if (transcript === null && entry.sessionFile && sessionId && sourceRevision) {
 				const sessionsDirForAgent = join(agentsRoot(), entry.agentId, "sessions");
 				const transcriptPath = isAbsolute(entry.sessionFile)
 					? entry.sessionFile
@@ -1101,10 +1102,21 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			if (!transcript) {
 				userActivity.complete = false;
 				console.warn(
-					`[openclaw] could not read active transcript for ${entry.sessionId} through official transcript surfaces`,
+					`[openclaw] could not read active transcript for ${sessionId ?? entry.key} through official transcript surfaces`,
 				);
 				continue;
 			}
+			const sessionUserActivity = computeOpenClawRealUserActivity(transcript, entry.key, entry);
+			userActivity = mergeUserActivity(userActivity, sessionUserActivity);
+			if (entry.sessionFile && !isInternalOpenClawSession(entry.key, entry)) {
+				const sessionsDirForAgent = join(agentsRoot(), entry.agentId, "sessions");
+				const transcriptPath = isAbsolute(entry.sessionFile)
+					? entry.sessionFile
+					: join(sessionsDirForAgent, entry.sessionFile);
+				classifiedTranscriptPaths.add(resolve(transcriptPath));
+			}
+			if (!sessionId || !sourceRevision) continue;
+
 			const drafts: SessionEventDraft[] = [];
 			const modelsUsed = new Set<string>();
 			if (entry.model) modelsUsed.add(entry.model);
@@ -1122,7 +1134,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 				drafts.push(
 					...openClawEventDrafts(
 						raw,
-						`${entry.agentId}:${entry.sessionId}`,
+						`${entry.agentId}:${sessionId}`,
 						recordSeq,
 						currentModel,
 					),
@@ -1142,15 +1154,6 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			}
 			const events = sequenceSessionEvents(drafts);
 			const messages = projectEventsToMessages(events);
-			const sessionUserActivity = computeOpenClawRealUserActivity(transcript, entry.key, entry);
-			userActivity = mergeUserActivity(userActivity, sessionUserActivity);
-			if (entry.sessionFile && !isInternalOpenClawSession(entry.key, entry)) {
-				const sessionsDirForAgent = join(agentsRoot(), entry.agentId, "sessions");
-				const transcriptPath = isAbsolute(entry.sessionFile)
-					? entry.sessionFile
-					: join(sessionsDirForAgent, entry.sessionFile);
-				classifiedTranscriptPaths.add(resolve(transcriptPath));
-			}
 			if (messages.length === 0) continue;
 			startedAt ??= new Date(entry.sessionStartedAt ?? updatedAt);
 			endedAt ??= new Date(updatedAt);
@@ -1159,7 +1162,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 				inventory.storePaths.get(entry.agentId) ??
 				join(agentsRoot(), entry.agentId, "agent", "openclaw-agent.sqlite");
 			sessions.push({
-				localSessionId: entry.sessionId,
+				localSessionId: sessionId,
 				projectPath,
 				startedAt,
 				endedAt,

--- a/packages/cli/tests/adapters/openclaw.test.ts
+++ b/packages/cli/tests/adapters/openclaw.test.ts
@@ -37,8 +37,19 @@ if [ "$*" = "sessions --json --all-agents --limit all" ] && [ -f "$HOME/.opencla
   printf '{"path":null,"stores":[{"agentId":"main","path":"%s/.openclaw/agents/main/agent/openclaw-agent.sqlite"}],"allAgents":true,"sessions":[{"agentId":"main","key":"agent:main:main","sessionId":"sqlite-session-001","updatedAt":%s,"sessionStartedAt":1776247200000,"sessionFile":"%s/.openclaw/agents/main/sessions/sqlite-session-001.jsonl","model":"gpt-5.6-sol","modelProvider":"openai","inputTokens":8,"outputTokens":5,"cacheRead":2,"label":"Active SQLite branch"}]}\n' "$HOME" "$updated_at" "$HOME"
   exit 0
 fi
+if [ "$*" = "sessions --json --all-agents --limit all" ] && [ -f "$HOME/.openclaw/session-key-only-test" ]; then
+  printf '%s\n' '{"path":null,"stores":[],"allAgents":true,"sessions":[{"agentId":"main","key":"agent:main:main","kind":"direct","updatedAt":1776247205000},{"agentId":"main","key":"agent:main:cron:daily","kind":"cron","updatedAt":1776247205000}]}'
+  exit 0
+fi
 if [ "$1 $2 $3" = "gateway call chat.history" ] && [ -f "$HOME/.openclaw/sqlite-session-test" ]; then
+  case "$*" in *sessionId*) exit 1 ;; esac
   printf '%s\n' '{"messages":[{"id":"active-user","role":"user","content":"kept question","timestamp":"2026-04-15T10:00:00.000Z"},{"id":"active-assistant","parentId":"active-user","role":"assistant","content":"kept answer","model":"gpt-5.6-sol","timestamp":"2026-04-15T10:00:05.000Z"}],"hasMore":false}'
+  exit 0
+fi
+if [ "$1 $2 $3" = "gateway call chat.history" ] && [ -f "$HOME/.openclaw/session-key-only-test" ]; then
+  case "$*" in *sessionId*) exit 1 ;; esac
+  case "$*" in *agent:main:cron:daily*) exit 1 ;; esac
+  printf '%s\n' '{"messages":[{"id":"key-only-user","role":"user","content":"key-only question","timestamp":"2026-04-15T10:00:00.000Z"}],"hasMore":false}'
   exit 0
 fi
 if [ "$*" = "agents list --json" ]; then
@@ -308,6 +319,23 @@ describe("OpenClawAdapter.collectSessions", () => {
 		expect(adapter.sessions.watchPaths()).toContain(sqlitePath);
 		expect(adapter.sessions.watchPaths()).toContain(`${sqlitePath}-wal`);
 		expect(adapter.sessions.watchPaths()).toContain(`${sqlitePath}-journal`);
+	});
+
+	it("classifies official sessionKey-only entries through Gateway history", async () => {
+		const sessionsRoot = join(tmpHome, ".openclaw", "agents", "main", "sessions");
+		rmSync(sessionsRoot, { recursive: true, force: true });
+		mkdirSync(sessionsRoot, { recursive: true });
+		writeFileSync(join(tmpHome, ".openclaw", "session-key-only-test"), "enabled");
+
+		const scan = await scanSessionModule(new OpenClawAdapter().sessions, { kind: "complete" });
+		const sessions = [];
+		for await (const batch of scan.batches) sessions.push(...batch.sessions);
+
+		expect(sessions).toEqual([]);
+		expect(scan.userActivity).toEqual({
+			lastUserInputAt: "2026-04-15T10:00:00.000Z",
+			complete: true,
+		});
 	});
 
 	it("reads legacy inventory JSONL without requiring a live Gateway", async () => {


### PR DESCRIPTION
## Summary

- accept official OpenClaw inventory entries that expose a stable `sessionKey` without a `sessionId`
- query Gateway history with `sessionKey` only, matching the public contract across current production versions
- classify session-key-only direct activity without inventing an uploadable session, while skipping explicitly internal cron/subagent entries
- bump the CLI package to `0.14.46` through the Bun package/lock workflow
- make the existing relative-time test deterministic by injecting the reference time, matching the utility pattern already used in the same file

## Why

Real OpenClaw deployments can return valid inventory rows without `sessionId`, and Gateway history rejects requests that send both `sessionId` and `sessionKey`. The previous adapter marked the full activity inventory incomplete, so durable v2 activity could not converge.

Client CI also exposed an existing boundary race: the test created a timestamp from one `Date.now()` call while `relativeTime()` read a later one, turning exactly five future minutes into four. The utility now accepts an optional reference time, as `recencyBucketFor()` already does.

## Safety

- no live filesystem fallback or repeated full scan
- malformed external history still fails closed
- no backend, database, Hosted, fleet, feature-flag, or Customer.io changes
- session-key-only rows contribute only user-activity classification; ordinary session upload still requires `sessionId`
- no sleeps, retries, widened assertions, or timing offsets in the test fix

## Verification

Head: `a436ac55bd95cf60289576ce4f135533635edb91`

- Docker focused activity suite: 35 passed
- Docker full CLI suite: 143 test files, 0 failures after version bump
- locked Biome 2.5.11: all 1120 files passed
- CLI typecheck: passed
- OpenClaw adapter: 23 passed
- Web typecheck: passed
- Web utility tests: 26 passed
- OSS web client and SSR build: passed
- `git diff --check`: passed
- publish manifest: passed
- release build: passed; compiled `clawdi --version` = `0.14.46`
- Bun dry-run pack: `clawdi-0.14.46.tgz`, expected 8 files

## Release impact

Merging triggers the Agent v2 CLI publish workflow for `clawdi@0.14.46`. Production fleet rollout remains a separate explicit operation.
