### PR TITLE
fix(web): show ineligible trial checkout

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1651,6 +1651,9 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 	// Deploy API (/me, /v2/*).
 	await page.route(`${DEPLOY_API}/**`, async (r) => {
 		const p = new URL(r.request().url()).pathname;
+		if (p === "/v1/me/notifications") {
+			return fulfillJson(r, { items: [], next_cursor: null });
+		}
 		if (p === "/me" || p === "/v1/me") {
 			options.productAccessRequests?.push(`DEPLOY ${p}`);
 			await options.productAccessResponseGate;

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -4316,6 +4316,69 @@ test("Wallet auto-reload authorizes and replaces its dedicated card responsively
 	);
 });
 
+for (const entry of ["inline", "return"] as const) {
+	test(`rejected trial refreshes eligibility after ${entry} checkout`, async ({ page }) => {
+		let rejected = false;
+		const checkoutRequests: string[] = [];
+		await stubCompletedStripeCheckout(page);
+		await stubHostedApi(page, {
+			checkoutRequests,
+			checkoutResponses: [
+				{
+					status: 200,
+					body: {
+						flow_type: "checkout_session",
+						funding_source: "stripe",
+						action_url: null,
+						checkout_url: "https://checkout.stripe.test/session",
+						client_secret: "cs_test_rejected_trial",
+						trial_period_days: 7,
+					},
+				},
+			],
+			deployments: [includedBasicDeployment],
+			plans: [basicPlan],
+		});
+		await page.route("**/v2/subscription/plans", (route) =>
+			fulfillJson(route, [
+				{
+					...basicPlan,
+					offers: basicPlan.offers.map((offer) => ({
+						...offer,
+						card_trial_period_days: rejected ? null : 7,
+					})),
+				},
+			]),
+		);
+		await page.route("**/v2/deployments/by-request/**", (route) => {
+			rejected = true;
+			return fulfillJson(route, {
+				deploy_request_id: "rejected-trial",
+				request_status: "failed",
+				failure_code: "trial_ineligible",
+				lineage_tail: null,
+			});
+		});
+		await page.goto(
+			entry === "return"
+				? "/deploy?session_id=cs_trial&deploy_request_id=rejected-trial"
+				: "/deploy",
+		);
+		if (entry === "inline") {
+			await expect(page.getByText("7-day free trial", { exact: true }).first()).toBeVisible();
+			await page.getByRole("button", { name: "Continue" }).click();
+			await page
+				.getByRole("dialog", { name: /Complete .* checkout/ })
+				.getByRole("button", { name: "Subscribe", exact: true })
+				.click();
+		}
+		await expect(page.getByText("Free trial unavailable", { exact: true })).toBeVisible();
+		await expect(page.getByText("7-day free trial", { exact: true })).toHaveCount(0);
+		await expect(page.getByText("Checkout status refreshed", { exact: true })).toHaveCount(0);
+		await expect(page.getByRole("button", { name: "Continue" })).toBeEnabled();
+	});
+}
+
 test("paid checkout navigates on deployment acceptance without LRO convergence", async ({
 	page,
 }) => {

--- a/apps/web/src/hosted/billing/checkout-return.test.ts
+++ b/apps/web/src/hosted/billing/checkout-return.test.ts
@@ -3,6 +3,7 @@ import {
 	type CheckoutReturnNavigationTarget,
 	checkoutReturnHasNavigationOwner,
 	checkoutReturnMarker,
+	checkoutReturnNavigationResult,
 	checkoutReturnNavigationTarget,
 	checkoutReturnWasCanceled,
 	checkoutSearchAfterConsume,
@@ -50,6 +51,17 @@ describe("checkout return navigation", () => {
 		expect(await checkoutReturnHasNavigationOwner("?deployment_id=hdep_current", () => false)).toBe(
 			false,
 		);
+	});
+
+	test("preserves a handled terminal result without claiming navigation ownership", async () => {
+		expect(
+			await checkoutReturnNavigationResult("?deploy_request_id=checkout-rejected", () => "handled"),
+		).toBe("handled");
+		expect(
+			await checkoutReturnHasNavigationOwner("?deploy_request_id=checkout-rejected", () =>
+				Promise.resolve("handled"),
+			),
+		).toBe(false);
 	});
 
 	test("keeps only the billing destination after consuming callback state", () => {

--- a/apps/web/src/hosted/billing/checkout-return.ts
+++ b/apps/web/src/hosted/billing/checkout-return.ts
@@ -17,6 +17,7 @@ const MARKER_PARAMS = [
 export type CheckoutReturnNavigationTarget =
 	| { kind: "deploy_request"; deployRequestId: string }
 	| { kind: "deployment"; agentId?: string | null; deploymentId: string };
+export type CheckoutReturnNavigationResult = boolean | "handled";
 
 export function checkoutReturnWasCanceled(searchStr: string): boolean {
 	return new URLSearchParams(searchStr).get("checkout") === "cancel";
@@ -53,15 +54,22 @@ export function checkoutReturnNavigationTarget(
 
 type CheckoutReturnNavigationOwner = (
 	target: CheckoutReturnNavigationTarget,
-) => boolean | Promise<boolean>;
+) => CheckoutReturnNavigationResult | Promise<CheckoutReturnNavigationResult>;
+
+export async function checkoutReturnNavigationResult(
+	searchStr: string,
+	onNavigate: CheckoutReturnNavigationOwner,
+): Promise<CheckoutReturnNavigationResult> {
+	if (checkoutReturnWasCanceled(searchStr)) return false;
+	const target = checkoutReturnNavigationTarget(searchStr);
+	return target === null ? false : onNavigate(target);
+}
 
 export async function checkoutReturnHasNavigationOwner(
 	searchStr: string,
 	onNavigate: CheckoutReturnNavigationOwner,
 ): Promise<boolean> {
-	if (checkoutReturnWasCanceled(searchStr)) return false;
-	const target = checkoutReturnNavigationTarget(searchStr);
-	return target !== null && (await onNavigate(target));
+	return (await checkoutReturnNavigationResult(searchStr, onNavigate)) === true;
 }
 
 export function checkoutSearchAfterConsume(
@@ -88,8 +96,9 @@ export function useCheckoutReturnHandler({
 		if (!marker || handledMarkerRef.current === marker) return;
 		handledMarkerRef.current = marker;
 		const canceled = checkoutReturnWasCanceled(searchStr);
-		void checkoutReturnHasNavigationOwner(searchStr, onNavigate)
-			.then(async (owned) => {
+		void checkoutReturnNavigationResult(searchStr, onNavigate)
+			.then(async (navigationResult) => {
+				const owned = navigationResult === true;
 				let refreshFailed = false;
 				try {
 					await refreshCheckoutReturn(owned ? { includeDeployments: false } : undefined);
@@ -110,6 +119,7 @@ export function useCheckoutReturnHandler({
 					resetScroll: false,
 				});
 				if (refreshFailed) return;
+				if (navigationResult === "handled") return;
 				toast.message(canceled ? "Checkout canceled" : "Checkout status refreshed", {
 					description: canceled
 						? onCancelCopy

--- a/apps/web/src/hosted/billing/contracts.ts
+++ b/apps/web/src/hosted/billing/contracts.ts
@@ -52,7 +52,9 @@ export type HostedDeployment = Schemas["V2HostedDeploymentReadResponse"];
 export type HostedComputeSubscription = NonNullable<
 	NonNullable<HostedDeployment["commercial_display"]>["compute_subscription"]
 >;
-export type HostedDeployRequestStatus = Schemas["V2HostedDeployRequestReadResponse"];
+export type HostedDeployRequestStatus = Schemas["V2HostedDeployRequestReadResponse"] & {
+	failure_code?: "trial_ineligible" | null;
+};
 export type HostedEventStreamSnapshotHandoff = Schemas["EventStreamSnapshotHandoff"];
 export type HostedFundingFact = Schemas["V2HostedCommercialFundingFactInfo"];
 export type HostedUsageSummary = Schemas["V2HostedUsageSummaryResponse"];

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -113,6 +113,7 @@ import {
 } from "@/hosted/billing/errors";
 import { billingTermLabel, billingTermSuffix, formatCents } from "@/hosted/billing/format";
 import {
+	refreshCheckoutReturnQueries,
 	useIncludedBasicAvailability,
 	useManagedModelCatalog,
 	usePlans,
@@ -368,6 +369,15 @@ export function DeployWizard() {
 						toast.error(terminalOutcome.title, {
 							description: terminalOutcome.description,
 						});
+						if (terminalOutcome.kind === "trial_ineligible") {
+							try {
+								await refreshCheckoutReturnQueries(queryClient);
+							} catch {
+								toast.error("Couldn’t refresh trial eligibility", {
+									description: "Refresh this page before starting another checkout.",
+								});
+							}
+						}
 						if (terminalOutcome.kind === "review_agents") {
 							acceptanceNavigatingRef.current = true;
 							try {

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -44,6 +44,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { UnsavedNavigationGuard } from "@/components/unsaved-navigation-guard";
 import { useBillingClient } from "@/hosted/billing/billing-client";
 import {
+	type CheckoutReturnNavigationResult,
 	type CheckoutReturnNavigationTarget,
 	useCheckoutReturnHandler,
 } from "@/hosted/billing/checkout-return";
@@ -306,7 +307,10 @@ export function DeployWizard() {
 	const [deploymentCommitted, setDeploymentCommitted] = useState(false);
 	const acceptanceNavigatingRef = useRef(false);
 	const acceptDeployment = useCallback(
-		async (target: CheckoutReturnNavigationTarget, replace = false): Promise<boolean> => {
+		async (
+			target: CheckoutReturnNavigationTarget,
+			replace = false,
+		): Promise<CheckoutReturnNavigationResult> => {
 			setAcceptedDeploymentRecovery(null);
 			if (target.kind === "deployment") setDeploymentCommitted(true);
 			setSubmitting(true);
@@ -373,6 +377,8 @@ export function DeployWizard() {
 								acceptanceNavigatingRef.current = false;
 							}
 						}
+						setSubmitting(false);
+						return "handled";
 					}
 				} else {
 					setAcceptedDeploymentRecovery({ replace, target });

--- a/apps/web/src/hosted/billing/errors.test.ts
+++ b/apps/web/src/hosted/billing/errors.test.ts
@@ -289,4 +289,26 @@ describe("deployment request terminal outcome", () => {
 		expect(superseded?.kind).toBe("review_agents");
 		expect(withLineage).toEqual({ kind: "open_deployment", deploymentId: "hdep_failed" });
 	});
+
+	test("presents trial ineligibility without exposing the anti-abuse reason", () => {
+		const outcome = deploymentRequestTerminalOutcome(
+			new DeploymentRequestTerminalError(
+				{
+					deploy_request_id: "checkout-trial-ineligible",
+					request_status: "failed",
+					failure_code: "trial_ineligible",
+					lineage_tail: null,
+				},
+				"failed",
+			),
+		);
+
+		expect(outcome).toEqual({
+			kind: "trial_ineligible",
+			title: "Free trial unavailable",
+			description:
+				"This payment method isn’t eligible for a free trial. You can still deploy at the regular price.",
+		});
+		expect(JSON.stringify(outcome)).not.toContain("trial_card_ineligible");
+	});
 });

--- a/apps/web/src/hosted/billing/errors.ts
+++ b/apps/web/src/hosted/billing/errors.ts
@@ -73,7 +73,7 @@ export class DeploymentRequestTerminalError extends BillingApiError {
 export type DeploymentRequestTerminalOutcome =
 	| { kind: "open_deployment"; deploymentId: string }
 	| {
-			kind: "new_attempt" | "review_agents";
+			kind: "new_attempt" | "review_agents" | "trial_ineligible";
 			title: string;
 			description: string;
 	  };
@@ -86,6 +86,14 @@ export function deploymentRequestTerminalOutcome(
 	const deploymentId = error.request.lineage_tail?.deployment_id?.trim();
 	if (deploymentId) {
 		return { kind: "open_deployment", deploymentId };
+	}
+	if (error.request.failure_code === "trial_ineligible") {
+		return {
+			kind: "trial_ineligible",
+			title: "Free trial unavailable",
+			description:
+				"This payment method isn’t eligible for a free trial. You can still deploy at the regular price.",
+		};
 	}
 	if (requestStatus === "superseded") {
 		return {

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -250,8 +250,15 @@ describe("refreshCheckoutReturnQueries", () => {
 		});
 		const deploymentSnapshots: HostedDeployment[][] = [[beforeCheckout], [afterCheckout]];
 		const walletSnapshots = [{ balance_cents: 1_000 }, { balance_cents: 5_000 }];
+		const planSnapshots = [[{ id: "plan_before_checkout" }], [{ id: "plan_after_checkout" }]];
+		const subscriptionSnapshots = [
+			{ pages: [[{ id: "subscription_before_checkout" }]], pageParams: [null] },
+			{ pages: [[{ id: "subscription_after_checkout" }]], pageParams: [null] },
+		];
 		let deploymentsCalls = 0;
 		let walletCalls = 0;
+		let plansCalls = 0;
+		let subscriptionsCalls = 0;
 
 		await qc.prefetchQuery({
 			queryKey: billingKeys.deployments,
@@ -267,7 +274,25 @@ describe("refreshCheckoutReturnQueries", () => {
 				return walletSnapshots.shift() ?? { balance_cents: 5_000 };
 			},
 		});
-		qc.setQueryData(billingKeys.plans, [{ id: "plan_before_checkout" }]);
+		await qc.prefetchQuery({
+			queryKey: billingKeys.plans,
+			queryFn: async () => {
+				plansCalls += 1;
+				return planSnapshots.shift() ?? [{ id: "plan_after_checkout" }];
+			},
+		});
+		await qc.prefetchQuery({
+			queryKey: billingKeys.subscriptions,
+			queryFn: async () => {
+				subscriptionsCalls += 1;
+				return (
+					subscriptionSnapshots.shift() ?? {
+						pages: [[{ id: "subscription_after_checkout" }]],
+						pageParams: [null],
+					}
+				);
+			},
+		});
 		qc.setQueryData(billingKeys.transactions, { pages: [], pageParams: [] });
 		qc.setQueryData(["get", "/v1/agents"], [{ id: "agent_before_checkout" }]);
 
@@ -275,11 +300,19 @@ describe("refreshCheckoutReturnQueries", () => {
 
 		expect(deploymentsCalls).toBe(2);
 		expect(walletCalls).toBe(2);
+		expect(plansCalls).toBe(2);
+		expect(subscriptionsCalls).toBe(2);
 		expect(result?.[0]?.resource.name).toBe("Performance agent after checkout");
 		expect(qc.getQueryData<{ balance_cents: number }>(billingKeys.wallet)?.balance_cents).toBe(
 			5_000,
 		);
-		expect(qc.getQueryState(billingKeys.plans)?.isInvalidated).toBe(true);
+		expect(qc.getQueryData<Array<{ id: string }>>(billingKeys.plans)?.[0]?.id).toBe(
+			"plan_after_checkout",
+		);
+		expect(
+			qc.getQueryData<{ pages: Array<Array<{ id: string }>> }>(billingKeys.subscriptions)
+				?.pages[0]?.[0]?.id,
+		).toBe("subscription_after_checkout");
 		expect(qc.getQueryState(billingKeys.transactions)?.isInvalidated).toBe(true);
 		expect(qc.getQueryState(["get", "/v1/agents"])?.isInvalidated).toBe(true);
 	});

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -328,13 +328,19 @@ export async function refreshCheckoutReturnQueries(
 	qc: QueryClient,
 	{ includeDeployments = true }: CheckoutReturnRefreshOptions = {},
 ): Promise<HostedDeployment[] | undefined> {
-	const requiredRefreshes = [refetchExactCheckoutQuery(qc, billingKeys.wallet)];
+	const requiredRefreshes = [
+		refetchExactCheckoutQuery(qc, billingKeys.wallet),
+		refetchExactCheckoutQuery(qc, billingKeys.plans),
+		refetchExactCheckoutQuery(qc, billingKeys.subscriptions),
+	];
 	if (includeDeployments) {
 		requiredRefreshes.push(refetchExactCheckoutQuery(qc, billingKeys.deployments));
 	}
 	const results = await Promise.allSettled([
 		...requiredRefreshes,
-		qc.invalidateQueries({ queryKey: billingKeys.plans }),
+		qc.invalidateQueries({ queryKey: billingKeys.subscriptionCreateQuotes }),
+		qc.invalidateQueries({ queryKey: billingKeys.reusableSubscriptions }),
+		qc.invalidateQueries({ queryKey: billingKeys.includedBasicAvailability }),
 		qc.invalidateQueries({ queryKey: billingKeys.transactions }),
 		qc.invalidateQueries({ queryKey: ["get", "/v1/agents"] }),
 	]);

--- a/apps/web/src/hosted/problem-code-contract.test.ts
+++ b/apps/web/src/hosted/problem-code-contract.test.ts
@@ -39,7 +39,7 @@ const HOSTED_SMOKE_SOURCE = readFileSync(
  */
 function codeContextLiterals(source: string): string[] {
 	const literals: string[] = [];
-	for (const segment of source.matchAll(/code:[^\n]*/g)) {
+	for (const segment of source.matchAll(/\bcode:[^\n]*/g)) {
 		literals.push(...snakeCaseLiterals(segment[0]));
 	}
 	for (const segment of source.matchAll(/[A-Za-z_]*CODES?\s*=\s*new Set\(\[([^\]]*)\]\)/g)) {

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -2483,6 +2483,8 @@ export interface components {
              * @enum {string}
              */
             request_status: "pending" | "ready" | "processing" | "succeeded" | "failed" | "expired" | "superseded";
+            /** Failure Code */
+            failure_code?: "trial_ineligible" | null;
             lineage_tail?: components["schemas"]["V2HostedDeployRequestLineageTail"] | null;
         };
         /** V2HostedDeploymentCommercialDisplay */

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1443,7 +1443,7 @@ export interface components {
              * Action
              * @enum {string}
              */
-            action: "retry_retraction" | "verify_absent" | "rearm_external_ports_delete";
+            action: "retry_retraction" | "verify_absent" | "rearm_external_ports_delete" | "rearm_controller_terminal_hold";
             /** Intent Versions */
             intent_versions: [
                 number,
@@ -2483,8 +2483,6 @@ export interface components {
              * @enum {string}
              */
             request_status: "pending" | "ready" | "processing" | "succeeded" | "failed" | "expired" | "superseded";
-            /** Failure Code */
-            failure_code?: "trial_ineligible" | null;
             lineage_tail?: components["schemas"]["V2HostedDeployRequestLineageTail"] | null;
         };
         /** V2HostedDeploymentCommercialDisplay */


### PR DESCRIPTION
## Summary
- show a dedicated `Free trial unavailable` error when hosted returns `failure_code=trial_ineligible`
- consume the checkout callback without also showing the generic checkout refresh toast
- force-refetch plans and subscriptions, then invalidate quote and availability caches so the trial offer disappears immediately
- keep the generated client pinned to the deployed API and add a narrow forward-compatible response extension for the coordinated backend rollout
- keep the message generic and avoid exposing card fingerprint or anti-abuse matching details

## Verification
- `bash scripts/test.sh web src/hosted/billing/checkout-return.test.ts src/hosted/billing/errors.test.ts src/hosted/billing/hooks.test.ts` (`48 passed`)
- web typecheck and OSS production build
- strict deployed-contract drift check
- focused Biome check
- `git diff --check`

## Dependency
- depends on Clawdi-AI/clawdi-hosted#2044 for the `failure_code=trial_ineligible` response; the optional local response extension makes either rollout order safe
