### PR TITLE
fix(web): align subscription cancellation copy

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -3649,7 +3649,7 @@ function ComputeSettingsSections({
 	const subscriptionPeriodLabel = formatShortDate(subscriptionEndsAt);
 	const subscriptionCancelPending = !!currentSubscription?.cancel_at_period_end;
 	const subscriptionCancellationCopy = computeSubscriptionCancellationCopy({
-		status: currentSubscription?.status ?? "active",
+		isTrial: currentSubscription?.status === "trialing",
 		periodEndLabel: subscriptionPeriodLabel,
 		hasRetainedDeployment: true,
 	});

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -175,6 +175,8 @@ import {
 	COMPUTE_BASIC_SLUG,
 	COMPUTE_PERFORMANCE_SLUG,
 	computeFundingSource,
+	computeSubscriptionCancellationCopy,
+	computeSubscriptionCancellationSuccessCopy,
 	computeSubscriptionLifecycle,
 	computeTierLabel,
 	pendingComputePlanSlug,
@@ -3646,6 +3648,11 @@ function ComputeSettingsSections({
 		currentSubscription?.cancel_at ?? currentSubscription?.current_period_end ?? null;
 	const subscriptionPeriodLabel = formatShortDate(subscriptionEndsAt);
 	const subscriptionCancelPending = !!currentSubscription?.cancel_at_period_end;
+	const subscriptionCancellationCopy = computeSubscriptionCancellationCopy({
+		status: currentSubscription?.status ?? "active",
+		periodEndLabel: subscriptionPeriodLabel,
+		hasRetainedDeployment: true,
+	});
 	const subscriptionLifecycle = currentSubscription
 		? computeSubscriptionLifecycle(currentSubscription)
 		: null;
@@ -3832,17 +3839,16 @@ function ComputeSettingsSections({
 							}}
 							cancelCopy={{
 								title: `Cancel ${tierLabel} subscription?`,
-								description: (
-									<p>
-										Cancellation takes effect {subscriptionPeriodLabel}. The agent then falls back
-										to an included Basic entitlement if available; otherwise, it stops.
-									</p>
-								),
-								confirmLabel: "Cancel at period end",
+								description: <p>{subscriptionCancellationCopy.description}</p>,
+								confirmLabel: subscriptionCancellationCopy.confirmLabel,
 								successDescription: (result) =>
-									result.current_period_end
-										? `Cancellation takes effect ${formatShortDate(result.current_period_end)}. The agent then falls back to an included Basic entitlement if available; otherwise, it stops.`
-										: "The agent falls back to an included Basic entitlement if available when cancellation takes effect; otherwise, it stops.",
+									computeSubscriptionCancellationSuccessCopy({
+										cancelAtPeriodEnd: result.cancel_at_period_end,
+										periodEndLabel: result.current_period_end
+											? formatShortDate(result.current_period_end)
+											: null,
+										hasRetainedDeployment: true,
+									}),
 							}}
 						/>
 					}

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -238,7 +238,6 @@ describe("first Basic agent copy", () => {
 		expect(wizardSource).not.toContain("included Basic deployment");
 		expect(wizardSource).not.toContain("included slot");
 		expect(wizardSource).not.toContain("resolveWalletDeploymentId");
-		expect(agentDetailSource).toContain("an included Basic entitlement if available");
 		expect(agentDetailSource).not.toContain("falls back to free compute");
 	});
 

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -6,6 +6,8 @@ import {
 	commonExplicitBillingOffers,
 	computeFundingMode,
 	computeFundingSource,
+	computeSubscriptionCancellationCopy,
+	computeSubscriptionCancellationSuccessCopy,
 	computeSubscriptionId,
 	computeSubscriptionLifecycle,
 	computeTierLabel,
@@ -179,6 +181,40 @@ describe("compute funding", () => {
 		expect(computeSubscriptionId(withMetadata)).toBe(42);
 		expect(pendingComputePlanSlug(withMetadata)).toBe(COMPUTE_BASIC_SLUG);
 		expect(computeSubscriptionId(subscription())).toBeNull();
+	});
+});
+
+describe("compute subscription cancellation copy", () => {
+	test("describes retained deployment behavior without promising a Basic fallback", () => {
+		expect(
+			computeSubscriptionCancellationCopy({
+				status: "trialing",
+				periodEndLabel: "Sep 12, 2026",
+				hasRetainedDeployment: true,
+			}),
+		).toEqual({
+			description:
+				"The trial ends immediately. The agent stops, but its disk and data are retained.",
+			confirmLabel: "End trial now",
+		});
+		expect(
+			computeSubscriptionCancellationCopy({
+				status: "active",
+				periodEndLabel: "Sep 12, 2026",
+				hasRetainedDeployment: true,
+			}),
+		).toEqual({
+			description:
+				"The subscription will stop renewing and remain active through Sep 12, 2026. At that point, the agent stops, but its disk and data are retained.",
+			confirmLabel: "Cancel at period end",
+		});
+		expect(
+			computeSubscriptionCancellationSuccessCopy({
+				cancelAtPeriodEnd: false,
+				periodEndLabel: null,
+				hasRetainedDeployment: true,
+			}),
+		).toBe("The trial has ended. The agent will stop; its disk and data are retained.");
 	});
 });
 

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -185,10 +185,10 @@ describe("compute funding", () => {
 });
 
 describe("compute subscription cancellation copy", () => {
-	test("describes retained deployment behavior without promising a Basic fallback", () => {
+	test("describes trial, paid, and deleted deployment cancellation outcomes", () => {
 		expect(
 			computeSubscriptionCancellationCopy({
-				status: "trialing",
+				isTrial: true,
 				periodEndLabel: "Sep 12, 2026",
 				hasRetainedDeployment: true,
 			}),
@@ -199,7 +199,7 @@ describe("compute subscription cancellation copy", () => {
 		});
 		expect(
 			computeSubscriptionCancellationCopy({
-				status: "active",
+				isTrial: false,
 				periodEndLabel: "Sep 12, 2026",
 				hasRetainedDeployment: true,
 			}),
@@ -215,6 +215,26 @@ describe("compute subscription cancellation copy", () => {
 				hasRetainedDeployment: true,
 			}),
 		).toBe("The trial has ended. The agent will stop; its disk and data are retained.");
+		expect(
+			computeSubscriptionCancellationSuccessCopy({
+				cancelAtPeriodEnd: true,
+				periodEndLabel: "Sep 12, 2026",
+				hasRetainedDeployment: true,
+			}),
+		).toBe(
+			"The subscription remains active through Sep 12, 2026. The agent will then stop; its disk and data are retained.",
+		);
+		expect(
+			computeSubscriptionCancellationCopy({
+				isTrial: false,
+				periodEndLabel: null,
+				hasRetainedDeployment: false,
+			}),
+		).toEqual({
+			description:
+				"The subscription will stop renewing at the end of the current billing period. This cannot restore a deleted agent.",
+			confirmLabel: "Cancel at period end",
+		});
 	});
 });
 

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -22,15 +22,15 @@ export function isHistoricalAccountSubscription(
 }
 
 export function computeSubscriptionCancellationCopy({
-	status,
+	isTrial,
 	periodEndLabel,
 	hasRetainedDeployment,
 }: {
-	status: string;
+	isTrial: boolean;
 	periodEndLabel: string | null;
 	hasRetainedDeployment: boolean;
 }): { description: string; confirmLabel: string } {
-	if (status === "trialing") {
+	if (isTrial) {
 		return {
 			description: hasRetainedDeployment
 				? "The trial ends immediately. The agent stops, but its disk and data are retained."

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -21,6 +21,58 @@ export function isHistoricalAccountSubscription(
 	return subscription.status === "canceled";
 }
 
+export function computeSubscriptionCancellationCopy({
+	status,
+	periodEndLabel,
+	hasRetainedDeployment,
+}: {
+	status: string;
+	periodEndLabel: string | null;
+	hasRetainedDeployment: boolean;
+}): { description: string; confirmLabel: string } {
+	if (status === "trialing") {
+		return {
+			description: hasRetainedDeployment
+				? "The trial ends immediately. The agent stops, but its disk and data are retained."
+				: "The trial ends immediately. This cannot restore a deleted agent.",
+			confirmLabel: "End trial now",
+		};
+	}
+	const ending = periodEndLabel
+		? `The subscription will stop renewing and remain active through ${periodEndLabel}.`
+		: "The subscription will stop renewing at the end of the current billing period.";
+	return {
+		description: hasRetainedDeployment
+			? `${ending} At that point, the agent stops, but its disk and data are retained.`
+			: `${ending} This cannot restore a deleted agent.`,
+		confirmLabel: "Cancel at period end",
+	};
+}
+
+export function computeSubscriptionCancellationSuccessCopy({
+	cancelAtPeriodEnd,
+	periodEndLabel,
+	hasRetainedDeployment,
+}: {
+	cancelAtPeriodEnd: boolean;
+	periodEndLabel: string | null;
+	hasRetainedDeployment: boolean;
+}): string {
+	if (!cancelAtPeriodEnd) {
+		return hasRetainedDeployment
+			? "The trial has ended. The agent will stop; its disk and data are retained."
+			: "The trial has ended.";
+	}
+	if (!hasRetainedDeployment) {
+		return periodEndLabel
+			? `The subscription remains active through ${periodEndLabel} and will not renew.`
+			: "The subscription will not renew after the current billing period.";
+	}
+	return periodEndLabel
+		? `The subscription remains active through ${periodEndLabel}. The agent will then stop; its disk and data are retained.`
+		: "The agent will stop when the current billing period ends; its disk and data are retained.";
+}
+
 export function resolveBasicPlan(plans: Plan[] | undefined): Plan | undefined {
 	return plans?.find((plan) => plan.slug === COMPUTE_BASIC_SLUG);
 }

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -30,6 +30,8 @@ import { PlanChangeController } from "@/hosted/billing/subscription/plan-change-
 import { useReusableSubscriptions } from "@/hosted/billing/subscription/reusable-subscriptions-query";
 import {
 	computeFundingSource,
+	computeSubscriptionCancellationCopy,
+	computeSubscriptionCancellationSuccessCopy,
 	computeSubscriptionLifecycle,
 	isHistoricalAccountSubscription,
 	pendingComputePlanSlug,
@@ -254,6 +256,14 @@ function SubscriptionRow({
 		agentHref,
 		reusableInventoryUncertain,
 	);
+	const hasRetainedDeployment = !subscription.is_orphan && subscription.deployment_id !== null;
+	const cancellationCopy = computeSubscriptionCancellationCopy({
+		status: subscription.status,
+		periodEndLabel: subscription.current_period_end
+			? formatShortDate(subscription.current_period_end)
+			: null,
+		hasRetainedDeployment,
+	});
 
 	return (
 		<li className="grid min-w-0 lg:row-span-5 lg:grid-rows-subgrid">
@@ -290,20 +300,16 @@ function SubscriptionRow({
 							}
 							cancelCopy={{
 								title: `Cancel ${computeSubscriptionPlanLabel(subscription.plan_slug)} subscription?`,
-								description: (
-									<p>
-										The subscription will stop renewing
-										{subscription.current_period_end
-											? ` and remain active through ${formatShortDate(subscription.current_period_end)}`
-											: ""}
-										. This cannot restore a deleted agent.
-									</p>
-								),
-								confirmLabel: "Cancel subscription",
+								description: <p>{cancellationCopy.description}</p>,
+								confirmLabel: cancellationCopy.confirmLabel,
 								successDescription: (result) =>
-									result.current_period_end
-										? `Access continues through ${formatShortDate(result.current_period_end)}.`
-										: undefined,
+									computeSubscriptionCancellationSuccessCopy({
+										cancelAtPeriodEnd: result.cancel_at_period_end,
+										periodEndLabel: result.current_period_end
+											? formatShortDate(result.current_period_end)
+											: null,
+										hasRetainedDeployment,
+									}),
 							}}
 						/>
 					) : null

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -258,7 +258,7 @@ function SubscriptionRow({
 	);
 	const hasRetainedDeployment = !subscription.is_orphan && subscription.deployment_id !== null;
 	const cancellationCopy = computeSubscriptionCancellationCopy({
-		status: subscription.status,
+		isTrial: subscription.status === "trialing",
 		periodEndLabel: subscription.current_period_end
 			? formatShortDate(subscription.current_period_end)
 			: null,


### PR DESCRIPTION
## Summary
- show immediate termination for trial cancellation
- keep paid cancellation at period end
- state that cancellation stops the agent while retaining disk and data
- remove the obsolete Included Basic fallback promise
- narrow the copy helper to the only decision it needs: trial vs. paid
- cover paid success and deleted-deployment copy

## Verification
- `bun run --cwd apps/web test`
- `bunx biome check`
- `git diff --check`