### PR TITLE
fix(backend): isolate grouped Composio MCP failures

### DIFF
--- a/backend/app/services/composio.py
+++ b/backend/app/services/composio.py
@@ -482,6 +482,30 @@ _MCP_OPERATION_ERRORS = (
 )
 
 
+@asynccontextmanager
+async def _map_mcp_operation_errors(
+    operation: Literal["list_tools", "call_tool"],
+) -> AsyncGenerator[None, None]:
+    try:
+        yield
+    except _MCP_OPERATION_ERRORS as exc:
+        upstream_error = exc
+    except BaseExceptionGroup as exc:
+        matched, remainder = exc.split(_MCP_OPERATION_ERRORS)
+        if matched is None or remainder is not None:
+            raise
+        upstream_error = exc
+    else:
+        return
+
+    logger.warning(
+        "Composio MCP operation failed: operation=%s error_type=%s",
+        operation,
+        type(upstream_error).__name__,
+    )
+    raise ComposioMcpUpstreamError("Composio MCP operation failed") from None
+
+
 def get_composio_client() -> AsyncComposio:
     """Return the shared generated async Composio client."""
     global _client
@@ -645,32 +669,20 @@ def _finish_tool_router_mcp_tools_load(user_id: str, task: asyncio.Task[list[Jso
 
 async def list_tool_router_mcp_tools(session: ComposioMcpSession) -> ListToolsResult:
     """List tools through a fully initialized, operation-scoped MCP client."""
-    try:
+    async with _map_mcp_operation_errors("list_tools"):
         async with _tool_router_mcp_client(session) as client:
             response = await client.list_tools()
             return _normalize_mcp_response(response, ListToolsResult)
-    except _MCP_OPERATION_ERRORS as exc:
-        logger.warning(
-            "Composio MCP operation failed: operation=list_tools error_type=%s",
-            type(exc).__name__,
-        )
-        raise ComposioMcpUpstreamError("Composio MCP operation failed") from None
 
 
 async def call_tool_router_mcp_tool(
     session: ComposioMcpSession, name: str, arguments: JsonObject
 ) -> CallToolResult:
     """Call a tool through a fully initialized, operation-scoped MCP client."""
-    try:
+    async with _map_mcp_operation_errors("call_tool"):
         async with _tool_router_mcp_client(session) as client:
             response = await client.call_tool(name, arguments)
             return _normalize_mcp_response(response, CallToolResult)
-    except _MCP_OPERATION_ERRORS as exc:
-        logger.warning(
-            "Composio MCP operation failed: operation=call_tool error_type=%s",
-            type(exc).__name__,
-        )
-        raise ComposioMcpUpstreamError("Composio MCP operation failed") from None
 
 
 def _normalize_mcp_response[WireModelT: BaseModel](

--- a/backend/tests/test_settings_and_mcp.py
+++ b/backend/tests/test_settings_and_mcp.py
@@ -9,15 +9,17 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import httpx
+import httpx2
 import pytest
 from fastapi.routing import iter_route_contexts
 from httpx import ASGITransport
-from mcp.types import ListToolsResult
+from mcp.types import CallToolResult, ListToolsResult
 
 from app.main import app
 from app.services.composio import ComposioMcpSession
@@ -255,8 +257,6 @@ async def test_legacy_composio_bridge_rejects_unknown_methods_without_upstream_s
 
 @pytest.mark.asyncio
 async def test_legacy_composio_aliases_bridge_tools_list_and_call(monkeypatch):
-    from mcp.types import CallToolResult, ListToolsResult
-
     from app.core.config import settings
     from app.routes import mcp_bridge
     from app.services.composio import ComposioMcpSession, create_mcp_bridge_token
@@ -874,6 +874,76 @@ async def test_composio_mcp_client_runs_lifecycle_and_parses_json_and_sse(monkey
     }
     await session.retire()
     assert clients[0].is_closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["list_tools", "call_tool"])
+async def test_composio_mcp_operations_normalize_nested_upstream_groups(operation, monkeypatch):
+    from app.services import composio
+
+    failure = ExceptionGroup(
+        "MCP transport failed",
+        [
+            ExceptionGroup(
+                "request failed",
+                [httpx2.ConnectError("All connection attempts failed")],
+            ),
+            httpx2.RemoteProtocolError("invalid upstream response"),
+        ],
+    )
+
+    class FakeClient:
+        async def list_tools(self):
+            return _mcp_tools("unused")
+
+        async def call_tool(self, _name, _arguments):
+            return CallToolResult.model_validate({"content": [{"type": "text", "text": "unused"}]})
+
+    @asynccontextmanager
+    async def failing_client(_session):
+        yield FakeClient()
+        raise failure
+
+    monkeypatch.setattr(composio, "_tool_router_mcp_client", failing_client)
+    session = _mcp_session("upstream-group")
+
+    with pytest.raises(composio.ComposioMcpUpstreamError, match="operation failed"):
+        if operation == "list_tools":
+            await composio.list_tool_router_mcp_tools(session)
+        else:
+            await composio.call_tool_router_mcp_tool(session, "COMPOSIO_TEST", {})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    [
+        ExceptionGroup("program failure", [AssertionError("bug")]),
+        BaseExceptionGroup(
+            "cancelled",
+            [httpx2.ConnectError("connection failed"), asyncio.CancelledError()],
+        ),
+    ],
+    ids=["program-error", "cancellation"],
+)
+async def test_composio_mcp_operation_does_not_normalize_non_upstream_groups(failure, monkeypatch):
+    from app.services import composio
+
+    class FakeClient:
+        async def list_tools(self):
+            return _mcp_tools("unused")
+
+    @asynccontextmanager
+    async def failing_client(_session):
+        yield FakeClient()
+        raise failure
+
+    monkeypatch.setattr(composio, "_tool_router_mcp_client", failing_client)
+
+    with pytest.raises(BaseExceptionGroup) as exc_info:
+        await composio.list_tool_router_mcp_tools(_mcp_session("non-upstream-group"))
+
+    assert exc_info.value is failure
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- normalize nested MCP/HTTPX upstream exception groups to the existing `ComposioMcpUpstreamError`
- preserve unknown program errors, cancellation, `KeyboardInterrupt`, and `SystemExit`
- share one narrow error boundary across MCP tool listing and invocation

## Verification
- Docker focused tests: 6 passed
- BasedPyright owned and strict cohorts: zero diagnostics
- Ruff check/format, compileall, deptry, dependency/outbound governance: passed
- `git diff --check`: passed

## Production impact
Prevents Composio connection failures wrapped by AnyIO `BaseExceptionGroup` from escaping as unhandled ASGI exceptions. No retry, routing, authentication, connection-pool, or JSON-RPC contract changes.
