### PR TITLE
chore(web): consume generated trial rejection contract

### DIFF
--- a/apps/web/src/hosted/billing/contracts.ts
+++ b/apps/web/src/hosted/billing/contracts.ts
@@ -52,9 +52,7 @@ export type HostedDeployment = Schemas["V2HostedDeploymentReadResponse"];
 export type HostedComputeSubscription = NonNullable<
 	NonNullable<HostedDeployment["commercial_display"]>["compute_subscription"]
 >;
-export type HostedDeployRequestStatus = Schemas["V2HostedDeployRequestReadResponse"] & {
-	failure_code?: "trial_ineligible" | null;
-};
+export type HostedDeployRequestStatus = Schemas["V2HostedDeployRequestReadResponse"];
 export type HostedEventStreamSnapshotHandoff = Schemas["EventStreamSnapshotHandoff"];
 export type HostedFundingFact = Schemas["V2HostedCommercialFundingFactInfo"];
 export type HostedUsageSummary = Schemas["V2HostedUsageSummaryResponse"];

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -2483,6 +2483,8 @@ export interface components {
              * @enum {string}
              */
             request_status: "pending" | "ready" | "processing" | "succeeded" | "failed" | "expired" | "superseded";
+            /** Failure Code */
+            failure_code?: "trial_ineligible" | null;
             lineage_tail?: components["schemas"]["V2HostedDeployRequestLineageTail"] | null;
         };
         /** V2HostedDeploymentCommercialDisplay */


### PR DESCRIPTION
## Summary
- Regenerate the deploy API client from the merged Hosted OpenAPI schema (#2044).
- Remove the temporary optional trial failure field extension and use generated types directly.

## Verification
- Isolated Docker web typecheck, 48 billing tests, and build passed.
- git diff --check passed.
- Merge after the Hosted rollout exposes the updated live schema and contract drift CI passes.