### PR TITLE
test(web): repair Hosted Wallet browser regressions

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -3924,7 +3924,7 @@ test("header Wallet adapts long balances across narrow touch layouts", async ({
 	const sidebarTrigger = page.getByRole("button", { name: "Toggle Sidebar" });
 	const separator = header.locator('[data-slot="separator"]');
 	const breadcrumb = header.locator('[data-slot="breadcrumb-list"]');
-	const notificationCenter = page.getByRole("button", { name: "Notification Center" });
+	const notificationCenter = page.getByRole("button", { name: "Notifications", exact: true });
 	await expectNoHorizontalOverflow(header, "Wallet header at 320px");
 	await expect(separator).toHaveCSS("width", "1px");
 	await expectContainedInOwnerAndViewport(
@@ -3977,7 +3977,7 @@ test("header Wallet adapts long balances across narrow touch layouts", async ({
 					header.locator('[data-slot="separator"]'),
 					header.locator('[data-slot="breadcrumb-list"]'),
 					walletControl,
-					touchPage.getByRole("button", { name: "Notification Center" }),
+					touchPage.getByRole("button", { name: "Notifications", exact: true }),
 				],
 				`Wallet header at ${viewport.width}px touch`,
 			);

--- a/apps/web/e2e/hosted-stub-api.ts
+++ b/apps/web/e2e/hosted-stub-api.ts
@@ -1132,6 +1132,23 @@ export async function stubHostedApi(page: Page, options: HostedApiStubOptions = 
 			options.deleteRequests?.push(p);
 			return fulfillJson(r, { status: "deleted", cvm_deleted: true });
 		}
+		if (/^\/v2\/deployments\/[^/]+\/events$/.test(p) && method === "GET") {
+			return r.fulfill({
+				status: 200,
+				contentType: "text/event-stream",
+				headers: { "Cache-Control": "no-store" },
+				body: ": heartbeat\n\n",
+			});
+		}
+		const workspaceSkillsMatch = p.match(/^\/v2\/deployments\/([^/]+)\/workspace-skills$/);
+		if (workspaceSkillsMatch && method === "GET") {
+			return fulfillJson(r, {
+				deployment_id: decodeURIComponent(workspaceSkillsMatch[1] ?? ""),
+				deployment_resource_version: "rv-workspace-skills",
+				manifest_generation: 1,
+				items: [],
+			});
+		}
 		if (p.startsWith("/v2/deployments/") && r.request().method() === "GET") {
 			const id = decodeURIComponent(p.slice("/v2/deployments/".length));
 			const deployment = deployments.find(

--- a/apps/web/e2e/hosted-wallet-billing.pw.ts
+++ b/apps/web/e2e/hosted-wallet-billing.pw.ts
@@ -8,7 +8,6 @@ import {
 	basicPlan,
 	collectBrowserErrors,
 	fixtureAgentId,
-	gotoHostedAgentSettings,
 	gotoHostedSettingsDialog,
 	performancePlan,
 	stubHostedApi,
@@ -29,7 +28,7 @@ test("wallet top-up completion refreshes an automatically paid open invoice", as
 		topUpRequests,
 		onTopUpSuccess: () => deployments.splice(0, 1, walletActiveDeployment),
 	});
-	await gotoHostedAgentSettings(page, fixtureAgentId(walletPastDueDeployment), "Basic");
+	await page.goto(`/agents/${fixtureAgentId(walletPastDueDeployment)}`);
 
 	const pastDueAlert = page.getByRole("alert").filter({ hasText: "Wallet payment past due" });
 	await expect(pastDueAlert).toBeVisible();
@@ -48,6 +47,7 @@ test("wallet top-up completion refreshes an automatically paid open invoice", as
 	await expect.poll(() => topUpRequests.length).toBe(1);
 	await expect(page.getByText("Payment accepted", { exact: true })).toBeVisible();
 	await expect(pastDueAlert).toHaveCount(0);
+	await page.getByRole("link", { name: "Settings", exact: true }).click();
 	await expect(page.getByText("Wallet", { exact: true })).toBeVisible();
 	expect(JSON.parse(topUpRequests[0] ?? "{}")).toEqual({ amount_cents: 2_500 });
 	expect(errors, `wallet open-invoice top-up: ${errors.join(" | ")}`).toEqual([]);
@@ -232,8 +232,8 @@ test("x402 stays gated, then binds and recovers an unverifiable browser-wallet p
 		x402_payment_attempt: null,
 	});
 	settings = await gotoHostedSettingsDialog(page, "billing-wallet");
-	await expect(settings.getByText("Not bound", { exact: true })).toBeVisible();
-	await settings.getByRole("button", { name: "Connect & bind" }).click();
+	await expect(settings.getByText("No wallet verified", { exact: true })).toBeVisible();
+	await settings.getByRole("button", { name: "Connect & verify" }).click();
 	await expect(settings.getByText(payer.address, { exact: true }).first()).toBeVisible();
 	await expect(settings.getByRole("button", { name: /Review \$5\.00 top-up/ })).toBeEnabled();
 
@@ -245,17 +245,15 @@ test("x402 stays gated, then binds and recovers an unverifiable browser-wallet p
 
 	await expect.poll(() => typedDataPayloads.length).toBe(1);
 	await expect.poll(() => publicPaymentHeaders.length).toBe(2);
-	await expect(settings.getByText("USDC payment processing", { exact: true })).toBeVisible();
+	await expect(settings.getByText("USDC payment in progress", { exact: true })).toBeVisible();
 	await expect(
-		settings.getByText(
-			"Do not create a new payment until this payment attempt reaches a final status.",
-		),
+		settings.getByText("Wait for this payment to complete before starting another."),
 	).toBeVisible();
 	await expect(settings.getByRole("button", { name: /\$5\.00 top-up/ })).toBeDisabled();
 
 	await page.reload();
 	settings = await gotoHostedSettingsDialog(page, "billing-wallet");
-	await expect(settings.getByText("USDC payment processing", { exact: true })).toBeVisible();
+	await expect(settings.getByText("USDC payment in progress", { exact: true })).toBeVisible();
 	await expect(settings.getByRole("button", { name: /\$5\.00 top-up/ })).toBeDisabled();
 	expect(attemptAuthorizations).toEqual(["Bearer dev-bypass"]);
 	expect(publicPaymentHeaders).toHaveLength(2);


### PR DESCRIPTION
## Summary
- Match current notification accessibility labels and x402 verification/payment copy.
- Exercise Wallet past-due top-up from the agent overview, then check the funding source in Settings.
- Supply empty deployment event-stream and workspace-skills fixtures for overview reads.
- Preserve layout, top-up refresh, duplicate-payment prevention, signature and authorization assertions. No production behavior changes.

## Verification
- Reproduced all three failures before fixes in isolated Docker Chromium.
- Fixed targeted browser suite: 3 passed.
- Docker web typecheck and Biome check for all three files passed.
- git diff --check passed.

The Hosted browser suite is separate from the OSS-only web-e2e CI job; targeted Hosted results above were run explicitly.