### PR TITLE
fix(cli): restore nonblocking and reliable runtime health reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ database migration, CI, and implementation details.
 
 ### Fixed
 
+- CLI health reporting no longer stalls during OpenClaw session scans, sends
+  compatible sync heartbeats, and promptly refreshes observations after delayed
+  acknowledgements while retaining bounded retries.
 - Hosted runtime reconciliation now reloads user systemd services after an
   official runtime installer replaces their unit definitions, even when the
   restored managed drop-in is byte-for-byte unchanged.

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.46",
+      "version": "0.14.47",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.46",
+	"version": "0.14.47",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -1,8 +1,9 @@
-import { spawnSync } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { basename, isAbsolute, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 import {
 	OPENCLAW_SDK_EXPORT_PATHS,
 	resolveOpenClawSdkExport,
@@ -354,25 +355,25 @@ function mergeUserActivity(
 }
 
 const OPENCLAW_COMMAND_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
+const execFileAsync = promisify(execFile);
 
-function runOpenClawJson(args: string[]): JsonObject | null {
-	const result = spawnSync("openclaw", args, {
-		encoding: "utf8",
-		env: process.env,
-		maxBuffer: OPENCLAW_COMMAND_MAX_BUFFER_BYTES,
-		timeout: 120_000,
-	});
-	if (result.status !== 0) return null;
+async function runOpenClawJson(args: string[]): Promise<JsonObject | null> {
 	try {
-		return jsonObject(JSON.parse(result.stdout)) ?? null;
+		const { stdout } = await execFileAsync("openclaw", args, {
+			encoding: "utf8",
+			env: process.env,
+			maxBuffer: OPENCLAW_COMMAND_MAX_BUFFER_BYTES,
+			timeout: 120_000,
+		});
+		return jsonObject(JSON.parse(stdout)) ?? null;
 	} catch {
 		return null;
 	}
 }
 
-function readOfficialSessionInventory(): OfficialSessionInventory | null {
+async function readOfficialSessionInventory(): Promise<OfficialSessionInventory | null> {
 	const override = process.env.OPENCLAW_AGENT_ID?.trim();
-	const payload = runOpenClawJson([
+	const payload = await runOpenClawJson([
 		"sessions",
 		"--json",
 		...(override ? ["--agent", override] : ["--all-agents"]),
@@ -486,13 +487,15 @@ async function readOfficialSessionMessagesFromSdk(
 	}
 }
 
-function readOfficialSessionMessagesFromGateway(entry: OfficialSessionEntry): JsonObject[] | null {
+async function readOfficialSessionMessagesFromGateway(
+	entry: OfficialSessionEntry,
+): Promise<JsonObject[] | null> {
 	let offset = 0;
 	let messages: JsonObject[] = [];
 	const seenOffsets = new Set<number>();
 	while (!seenOffsets.has(offset)) {
 		seenOffsets.add(offset);
-		const payload = runOpenClawJson([
+		const payload = await runOpenClawJson([
 			"gateway",
 			"call",
 			"chat.history",
@@ -833,7 +836,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 	): Promise<SessionBatchScan> {
 		const materializeCanonicalActivity =
 			request.kind === "complete" && knownSourceRevisions.size === 0;
-		const officialInventory = readOfficialSessionInventory();
+		const officialInventory = await readOfficialSessionInventory();
 		if (officialInventory) {
 			const collection = await this.collectOfficialSessionsMatching(
 				officialInventory,
@@ -916,7 +919,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 	}
 
 	private async resolveSession(localSessionId: string): Promise<RawSession | null> {
-		const officialInventory = readOfficialSessionInventory();
+		const officialInventory = await readOfficialSessionInventory();
 		if (officialInventory) {
 			return (
 				(
@@ -1074,7 +1077,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 			if (sessionId && knownSourceRevisions.get(sessionId) === sourceRevision) continue;
 
 			let transcript = await readOfficialSessionMessagesFromSdk(entry);
-			transcript ??= readOfficialSessionMessagesFromGateway(entry);
+			transcript ??= await readOfficialSessionMessagesFromGateway(entry);
 			if (transcript === null && entry.sessionFile && sessionId && sourceRevision) {
 				const sessionsDirForAgent = join(agentsRoot(), entry.agentId, "sessions");
 				const transcriptPath = isAbsolute(entry.sessionFile)

--- a/packages/cli/src/runtime/heartbeat-observation.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.ts
@@ -216,6 +216,7 @@ export class HostedRuntimeHeartbeatSession {
 			reportedAt: capturedAt,
 			appliedState: this.capturedAppliedState,
 			includeAgentPlugins: true,
+			includeUserActivity: true,
 		});
 		if (!snapshot) return null;
 		if (!snapshot.applied) {

--- a/packages/cli/src/runtime/observation-producer.test.ts
+++ b/packages/cli/src/runtime/observation-producer.test.ts
@@ -120,6 +120,7 @@ async function observationSchedule(
 	initialStatus: "ok" | "error",
 	stopAtMs: number,
 	transitionToOk = false,
+	terminalRejected = false,
 ): Promise<Array<{ at: number; status: "ok" | "error" | "unknown" }>> {
 	const paths = tempRuntimePaths();
 	writeApplyIdentityFile(paths, 1);
@@ -133,9 +134,15 @@ async function observationSchedule(
 		abort: abort.signal,
 		paths,
 		contextPath: runtimeContextPath(paths),
+		sessionFactory: (environmentId, sessionPaths) =>
+			new HostedRuntimeHeartbeatSession({
+				environmentId,
+				paths: sessionPaths,
+				now: () => new Date(clock),
+			}),
 		submit: async (_environmentId, event) => {
 			attempts.push({ at: clock, status: event.status });
-			return "accepted";
+			return terminalRejected ? "terminal-rejected" : "accepted";
 		},
 		now: () => clock,
 		delay: async (ms) => {
@@ -152,6 +159,59 @@ async function observationSchedule(
 }
 
 describe("hosted runtime observation producer", () => {
+	test("keeps permanent rejections at the normal observation interval", async () => {
+		const attempts = await observationSchedule("ok", 181_000, false, true);
+		expect(attempts.map((attempt) => attempt.at)).toEqual([0, 60_000, 120_000, 180_000]);
+	});
+
+	test("bounds failure retries and refreshes immediately after a delayed acknowledgement", async () => {
+		const paths = tempRuntimePaths();
+		writeApplyIdentityFile(paths, 1);
+		writeRuntimeAppliedState(appliedState(1), paths);
+		writeObservationHealth(paths, "ok");
+		const abort = new AbortController();
+		const epoch = Date.parse("2026-09-05T00:00:00.000Z");
+		let clock = epoch;
+		const attempts: Array<{ at: number; eventId: string; capturedAt: string }> = [];
+
+		await runRuntimeObservationProducer({
+			abort: abort.signal,
+			paths,
+			contextPath: runtimeContextPath(paths),
+			now: () => clock,
+			sessionFactory: (environmentId, sessionPaths) =>
+				new HostedRuntimeHeartbeatSession({
+					environmentId,
+					paths: sessionPaths,
+					now: () => new Date(clock),
+				}),
+			submit: async (_environmentId, event) => {
+				attempts.push({ at: clock - epoch, eventId: event.eventId, capturedAt: event.capturedAt });
+				if (attempts.length <= 5) throw new Error("temporary network failure");
+				if (attempts.length === 6) clock += 90_000;
+				if (attempts.length === 8) abort.abort();
+				return "accepted";
+			},
+			delay: async (ms) => {
+				await Promise.resolve();
+				await Promise.resolve();
+				await Promise.resolve();
+				clock += ms;
+				if (clock - epoch > 400_000) abort.abort();
+			},
+		});
+
+		expect(attempts.map((attempt) => attempt.at)).toEqual([
+			0, 5_000, 15_000, 35_000, 75_000, 135_000, 226_000, 286_000,
+		]);
+		expect(new Set(attempts.slice(0, 6).map((attempt) => attempt.eventId)).size).toBe(1);
+		expect(new Set(attempts.slice(0, 6).map((attempt) => attempt.capturedAt))).toEqual(
+			new Set([new Date(epoch).toISOString()]),
+		);
+		expect(attempts[6]?.eventId).not.toBe(attempts[0]?.eventId);
+		expect(attempts[6]?.capturedAt).toBe(new Date(epoch + 226_000).toISOString());
+	});
+
 	test("accepts apply generation three at checkpoint two and submits its exact identity", async () => {
 		const paths = tempRuntimePaths();
 		writeApplyIdentityFile(paths, 3);
@@ -182,7 +242,7 @@ describe("hosted runtime observation producer", () => {
 				}),
 		});
 
-		expect(await producer.sendOnce()).toEqual({ outcome: "accepted", status: "unknown" });
+		expect(await producer.sendOnce()).toMatchObject({ outcome: "accepted", status: "unknown" });
 		expect(submitted).toMatchObject({
 			generation: 3,
 			manifestETag: '"manifest-3"',
@@ -237,10 +297,10 @@ describe("hosted runtime observation producer", () => {
 				}),
 		});
 
-		expect(await producer.sendOnce()).toEqual({ outcome: "accepted", status: "unknown" });
+		expect(await producer.sendOnce()).toMatchObject({ outcome: "accepted", status: "unknown" });
 		writeApplyIdentityFile(paths, 2);
 		writeRuntimeAppliedState(appliedState(2), paths);
-		expect(await producer.sendOnce()).toEqual({ outcome: "accepted", status: "unknown" });
+		expect(await producer.sendOnce()).toMatchObject({ outcome: "accepted", status: "unknown" });
 
 		expect(events).toHaveLength(2);
 		expect(events[0]).toMatchObject({
@@ -352,7 +412,7 @@ describe("hosted runtime observation producer", () => {
 		expect(await producer.sendOnce()).toEqual({ outcome: "failed" });
 		writeApplyIdentityFile(paths, 2);
 		writeRuntimeAppliedState(appliedState(2), paths);
-		expect(await producer.sendOnce()).toEqual({ outcome: "accepted", status: "unknown" });
+		expect(await producer.sendOnce()).toMatchObject({ outcome: "accepted", status: "unknown" });
 
 		expect(submitted.map((event) => event.eventId)).toEqual([
 			"old-event-000001",
@@ -398,7 +458,7 @@ describe("hosted runtime observation producer", () => {
 		});
 
 		expect(await producer.sendOnce()).toEqual({ outcome: "sent" });
-		expect(await producer.sendOnce()).toEqual({ outcome: "accepted", status: "unknown" });
+		expect(await producer.sendOnce()).toMatchObject({ outcome: "accepted", status: "unknown" });
 		expect(submitted.map((event) => event.eventId)).toEqual([
 			"rejected-event-0001",
 			"fresh-event-000002",

--- a/packages/cli/src/runtime/observation-producer.ts
+++ b/packages/cli/src/runtime/observation-producer.ts
@@ -17,6 +17,7 @@ const OBSERVATION_INTERVAL_MS = 60_000;
 const CONVERGENCE_OBSERVATION_INTERVAL_MS = 5_000;
 const CONVERGENCE_OBSERVATION_WINDOW_MS = 90_000;
 const IDLE_RETRY_INTERVAL_MS = 1_000;
+const FAILURE_RETRY_INTERVAL_MS = 5_000;
 
 type ObservationSubmitResult = "accepted" | "terminal-rejected";
 type RuntimeObservedStatus = HostedRuntimeObservedEvent["status"];
@@ -25,7 +26,7 @@ type ObservationSendResult =
 	| { outcome: "idle" }
 	| { outcome: "sent" }
 	| { outcome: "failed" }
-	| { outcome: "accepted"; status: RuntimeObservedStatus };
+	| { outcome: "accepted"; status: RuntimeObservedStatus; capturedAt: string };
 
 interface RuntimeObservationProducerOptions {
 	abort: AbortSignal;
@@ -48,6 +49,7 @@ interface AttestedRuntimeObservationContext {
 
 interface ObservationSchedule {
 	nextAttemptAt: number;
+	consecutiveFailures: number;
 	convergenceWindowEnd: number | "closed" | null;
 	lastAttemptedAppliedReceipt: string | null;
 }
@@ -118,7 +120,11 @@ export class HostedRuntimeObservationProducer {
 			if (!this.session.acknowledge(buffered.event.eventId)) {
 				throw new Error("runtime observation acknowledgement did not match buffered event");
 			}
-			return { outcome: "accepted", status: buffered.event.status };
+			return {
+				outcome: "accepted",
+				status: buffered.event.status,
+				capturedAt: buffered.event.capturedAt,
+			};
 		} catch (error) {
 			log.info("daemon.runtime_observation_failed", {
 				error: toErrorMessage(error),
@@ -189,6 +195,7 @@ export async function runRuntimeObservationProducer(
 				const appliedReceipt = readRuntimeWatchAppliedReceipt(paths);
 				const schedule = schedules.get(identityKey) ?? {
 					nextAttemptAt: 0,
+					consecutiveFailures: 0,
 					convergenceWindowEnd: null,
 					lastAttemptedAppliedReceipt: null,
 				};
@@ -213,9 +220,26 @@ export async function runRuntimeObservationProducer(
 									);
 								}
 							}
+							// A retried event retains its capture time; acknowledging it must not
+							// postpone the next fresh sample by another full interval.
+							interval = Math.max(
+								IDLE_RETRY_INTERVAL_MS,
+								interval - Math.max(0, completedAt - Date.parse(result.capturedAt)),
+							);
 						}
-						schedule.nextAttemptAt =
-							completedAt + (result.outcome === "idle" ? IDLE_RETRY_INTERVAL_MS : interval);
+						if (result.outcome === "failed") {
+							schedule.consecutiveFailures = Math.min(schedule.consecutiveFailures + 1, 5);
+							interval = Math.min(
+								OBSERVATION_INTERVAL_MS,
+								FAILURE_RETRY_INTERVAL_MS * 2 ** (schedule.consecutiveFailures - 1),
+							);
+						} else {
+							schedule.consecutiveFailures = 0;
+						}
+						if (result.outcome === "idle") {
+							interval = IDLE_RETRY_INTERVAL_MS;
+						}
+						schedule.nextAttemptAt = completedAt + interval;
 						if (activeAttempts.get(identityKey) === attempt) {
 							activeAttempts.delete(identityKey);
 						}

--- a/packages/cli/src/runtime/observed-v2.test.ts
+++ b/packages/cli/src/runtime/observed-v2.test.ts
@@ -191,7 +191,8 @@ describe("hosted runtime observed v2", () => {
 			observedAt: new Date("2026-08-19T02:00:00.000Z"),
 		});
 
-		expect(readHostedRuntimeObserved(paths)?.userActivity).toEqual({
+		expect(readHostedRuntimeObserved(paths)).not.toHaveProperty("userActivity");
+		expect(readHostedRuntimeObserved(paths, { includeUserActivity: true })?.userActivity).toEqual({
 			schemaVersion: 1,
 			classifierVersion: 1,
 			classification: "known_last_user_input",

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -43,6 +43,7 @@ export function readHostedRuntimeObserved(
 		reportedAt?: string;
 		appliedState?: RuntimeAppliedState | null;
 		includeAgentPlugins?: boolean;
+		includeUserActivity?: boolean;
 	} = {},
 ): HostedRuntimeObserved | null {
 	if (paths.mode !== "hosted") return null;
@@ -87,8 +88,10 @@ export function readHostedRuntimeObserved(
 		});
 		if (agentPlugins) observed.agentPlugins = agentPlugins;
 	}
-	const userActivity = observedUserActivity(boot.status, observed.reportedAt);
-	if (userActivity) observed.userActivity = userActivity;
+	if (options.includeUserActivity) {
+		const userActivity = observedUserActivity(boot.status, observed.reportedAt);
+		if (userActivity) observed.userActivity = userActivity;
+	}
 	if (boot.error) observed.error = boot.error;
 	const convergeError = runtimeConvergeError(watchStatus);
 	if (convergeError) observed.convergeError = convergeError;

--- a/packages/cli/tests/adapters/openclaw.test.ts
+++ b/packages/cli/tests/adapters/openclaw.test.ts
@@ -27,6 +27,11 @@ beforeEach(() => {
 	writeFileSync(
 		command,
 		`#!/bin/sh
+if [ -f "$HOME/.openclaw/delay-$1" ]; then
+  touch "$HOME/.openclaw/running-$1"
+  sleep 0.2
+  rm "$HOME/.openclaw/running-$1"
+fi
 if [ "$*" = "sessions --json --all-agents --limit all" ] && [ -f "$HOME/.openclaw/legacy-inventory-test" ]; then
   printf '{"path":null,"stores":[{"agentId":"main","path":"%s/.openclaw/agents/main/sessions/sessions.json"}],"allAgents":true,"sessions":[{"agentId":"main","key":"agent:main:main","sessionId":"oc-session-001","updatedAt":1776247205000,"sessionFile":"%s/.openclaw/agents/main/sessions/oc-session-001.jsonl","model":"claude-opus-4-7","inputTokens":12,"outputTokens":6,"cacheRead":2,"displayName":"Fixture session","acp":{"cwd":"/Users/fixture/project","lastActivityAt":1776247205000}}]}\n' "$HOME" "$HOME"
   exit 0
@@ -159,6 +164,59 @@ describe("OpenClawAdapter.detect", () => {
 });
 
 describe("OpenClawAdapter.collectSessions", () => {
+	it.each(["sessions", "gateway"])(
+		"keeps the event loop responsive while %s is running",
+		async (command) => {
+			const stateRoot = join(tmpHome, ".openclaw");
+			writeFileSync(join(stateRoot, "sqlite-session-test"), "enabled");
+			writeFileSync(join(stateRoot, `delay-${command}`), "enabled");
+			let observedRunning = false;
+			const timer = setInterval(() => {
+				observedRunning ||= existsSync(join(stateRoot, `running-${command}`));
+			}, 10);
+			try {
+				const { sessions } = await new OpenClawAdapter().sessions.collect({ kind: "complete" });
+				expect(observedRunning).toBe(true);
+				expect(sessions[0]?.messages.map((message) => message.content)).toEqual([
+					"kept question",
+					"kept answer",
+				]);
+			} finally {
+				clearInterval(timer);
+			}
+		},
+	);
+
+	describe.each(["sessions", "gateway"])("%s failure fallback", (command) => {
+		it.each([
+			["nonzero exit", `printf '%s' '{"sessions":[],"messages":[]}'; exit 1`],
+			["invalid JSON", "printf 'invalid JSON'; exit 0"],
+		])("resolves the legacy transcript after %s", async (_failure, response) => {
+			writeFileSync(join(tmpHome, ".openclaw", "legacy-inventory-test"), "enabled");
+			const executable = join(tmpHome, "bin", "openclaw");
+			writeFileSync(
+				executable,
+				readFileSync(executable, "utf8").replace(
+					"#!/bin/sh",
+					`#!/bin/sh\nif [ "$1" = "${command}" ]; then ${response}; fi`,
+				),
+			);
+
+			const session = await new OpenClawAdapter().sessions.resolve("oc-session-001");
+
+			expect(session?.messages.map((message) => message.content)).toEqual(["hello", "world"]);
+		});
+	});
+
+	it("falls back to the legacy inventory when the executable is missing", async () => {
+		rmSync(join(tmpHome, "bin", "openclaw"));
+		process.env.PATH = join(tmpHome, "bin");
+
+		const { sessions } = await new OpenClawAdapter().sessions.collect({ kind: "complete" });
+
+		expect(sessions.map((session) => session.localSessionId)).toEqual(["oc-session-001"]);
+	});
+
 	it("parses the fixture session with index metadata + transcript messages", async () => {
 		const a = new OpenClawAdapter();
 		const { sessions, dedupedCount } = await a.sessions.collect({ kind: "complete" });
@@ -316,6 +374,8 @@ describe("OpenClawAdapter.collectSessions", () => {
 			"kept answer",
 		]);
 		expect(sessions[0]?.realUserInputAt).toBe("2026-04-15T10:00:00.000Z");
+		expect(await adapter.sessions.resolve("sqlite-session-001")).toEqual(sessions[0] ?? null);
+		expect(await adapter.sessions.resolve("missing-session")).toBeNull();
 		expect(adapter.sessions.watchPaths()).toContain(sqlitePath);
 		expect(adapter.sessions.watchPaths()).toContain(`${sqlitePath}-wal`);
 		expect(adapter.sessions.watchPaths()).toContain(`${sqlitePath}-journal`);


### PR DESCRIPTION
## Summary
- Replace blocking OpenClaw session subprocesses with promisified execFile, preserving timeout, environment, output limit, and failure fallback.
- Omit userActivity from legacy sync heartbeats while retaining it in v2 observations.
- Bound transient retries and account for capture age after acknowledgement without changing pending event identity; keep permanent rejections at the normal cadence.
- Bump CLI to 0.14.47; merge triggers the protected OIDC CLI publish workflow. No receiver schema or database migrations.

## Verification
- Isolated Docker full CLI suite: 143 test files passed; CLI typecheck passed.
- Final scheduling correction: 23 focused tests passed and CLI typecheck passed.
- Adapter regression mutation check: both event-loop tests fail with the original synchronous calls.
- Independent review identified permanent-rejection retry pressure, now corrected and regression-tested.
- Biome on runtime changes and git diff --check passed.

## Release
Head: 47fc3de25. Publish exact CLI artifact through the repository workflow; qualify the current digest-pinned Hosted runtime image, validate canaries, then use the documented durable rollout API. Operational tenant evidence stays in the private Hosted repository.