### PR TITLE
fix: unify subscription cancellation and agent power flow

### DIFF
--- a/apps/web/e2e/hosted-subscription-power.pw.ts
+++ b/apps/web/e2e/hosted-subscription-power.pw.ts
@@ -1,0 +1,160 @@
+import { expect, test } from "@playwright/test";
+import {
+	basicPlan,
+	collectBrowserErrors,
+	fixtureAgentId,
+	gotoHostedAgentSettings,
+	mutationDeploymentReadFixture,
+	paidBasicDeployment,
+	performancePlan,
+	stubHostedApi,
+} from "./hosted-stub-api";
+
+for (const width of [1440, 320]) {
+	test(`ended subscription power entries reuse subscription selection at ${width}px`, async ({
+		page,
+	}, testInfo) => {
+		test.setTimeout(120_000);
+		await page.setViewportSize({ width, height: 900 });
+		const errors = collectBrowserErrors(page);
+		const startRequests: string[] = [];
+		const deployment = {
+			...mutationDeploymentReadFixture({
+				...paidBasicDeployment,
+				status: "stopped",
+				compute_subscription: { ...paidBasicDeployment.compute_subscription, status: "canceled" },
+			}),
+			files_endpoint: { url: "https://files.example.test/" },
+		};
+		await stubHostedApi(page, {
+			deployments: [deployment],
+			plans: [basicPlan, performancePlan],
+			startRequests,
+		});
+		await page.goto("/agents");
+		await page.getByRole("link", { name: /^Open .*Status: Stopped$/ }).click();
+		await expect(page).toHaveURL(new RegExp(`/agents/${deployment.agent_id}$`));
+		for (const section of ["console", "files", "terminal", "channel-links", "settings"]) {
+			await page.goto(`/agents/${deployment.agent_id}/${section}`);
+			const start = page.getByRole("button", {
+				name: "Subscribe to start",
+				exact: true,
+			});
+			await expect(start).toBeVisible();
+			const startBox = await start.boundingBox();
+			expect(startBox).not.toBeNull();
+			expect(startBox?.x).toBeGreaterThanOrEqual(0);
+			expect((startBox?.x ?? 0) + (startBox?.width ?? 0)).toBeLessThanOrEqual(width);
+			await page.waitForLoadState("networkidle");
+			await start.click();
+			await expect(page.getByRole("dialog", { name: "Choose a paid subscription" })).toBeVisible();
+			expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+				width,
+			);
+			await expect(page.getByRole("dialog")).not.toContainText(/container|volume|disk/i);
+			await expect(
+				page.getByRole("dialog").getByRole("combobox", { name: "Compute plan" }),
+			).toBeVisible();
+			await expect(page.getByRole("button", { name: /^(Start|Start agent)$/ })).toHaveCount(0);
+			await expect.poll(() => startRequests.length).toBe(0);
+			if (section === "settings") {
+				await page.screenshot({
+					path: testInfo.outputPath(`subscribe-to-start-${width}.png`),
+					fullPage: true,
+				});
+			}
+			await page.keyboard.press("Escape");
+		}
+		expect(errors).toEqual([]);
+	});
+}
+
+test("a manually stopped paid agent still starts normally and explains a funding race", async ({
+	page,
+}) => {
+	const deployment = { ...paidBasicDeployment, status: "stopped" };
+	const startRequests: string[] = [];
+	await stubHostedApi(page, { deployments: [deployment], plans: [basicPlan, performancePlan] });
+	await page.route("**/v2/deployments/*/start", async (route) => {
+		startRequests.push(route.request().method());
+		await route.fulfill({
+			status: 409,
+			json: { code: "funding_revoked_after_accept", detail: "Internal funding fence" },
+		});
+	});
+	await gotoHostedAgentSettings(page, fixtureAgentId(deployment), "Basic");
+	await expect(page.getByRole("button", { name: "Subscribe to start" })).toHaveCount(0);
+	await page.getByRole("button", { name: "Start", exact: true }).click();
+	await expect(page.locator("[data-sonner-toast]")).toContainText(
+		"Open Agent settings and choose a subscription",
+	);
+	await expect(page.locator("[data-sonner-toast]")).not.toContainText(
+		/internal|another session|container|volume|disk/i,
+	);
+	expect(startRequests).toEqual(["POST"]);
+});
+
+for (const status of ["trialing", "active"] as const) {
+	test(`${status} cancellation keeps saved data and explicit Delete stays destructive`, async ({
+		page,
+	}) => {
+		const deployment = {
+			...paidBasicDeployment,
+			compute_subscription: { ...paidBasicDeployment.compute_subscription, status },
+		};
+		const cancelRequests: unknown[] = [];
+		const deleteRequests: unknown[] = [];
+		await stubHostedApi(page, { deployments: [deployment], plans: [basicPlan, performancePlan] });
+		await page.route("**/v2/subscription/cancel", async (route) => {
+			cancelRequests.push(route.request().postDataJSON());
+			await route.fulfill({
+				json: {
+					status: "canceled",
+					billing_term_months: 12,
+					cancel_at_period_end: false,
+					action_state: status === "trialing" ? "pending" : "reconciling",
+				},
+			});
+		});
+		await page.route(`**/v2/deployments/${deployment.id}`, async (route) => {
+			if (route.request().method() !== "DELETE") return route.fallback();
+			deleteRequests.push(route.request().postDataJSON());
+			await route.fulfill({ json: { deployment_id: deployment.id, status: "absent" } });
+		});
+		await gotoHostedAgentSettings(page, fixtureAgentId(deployment), "Basic");
+		await page.getByRole("button", { name: "Cancel subscription", exact: true }).click();
+		const cancelDialog = page.getByRole("alertdialog");
+		await expect(cancelDialog).toContainText("Your saved data is kept.");
+		await expect(cancelDialog).not.toContainText(/container|volume|disk|permanently delete/i);
+		await expect(cancelDialog).toContainText(
+			status === "trialing" ? "The trial ends immediately" : "The agent stops when the period ends",
+		);
+		await cancelDialog
+			.getByRole("button", {
+				name: status === "trialing" ? "End trial now" : "Cancel at period end",
+			})
+			.click();
+		await expect(page.locator("[data-sonner-toast]")).toContainText(
+			"Cancellation is still processing",
+		);
+		await expect(page.locator("[data-sonner-toast]")).not.toContainText(
+			/Subscription canceled|Cancellation scheduled|trial has ended/,
+		);
+		expect(cancelRequests).toEqual([{ deployment_id: deployment.id }]);
+		expect(deleteRequests).toEqual([]);
+		await page.getByRole("button", { name: "Delete", exact: true }).click();
+		const deleteDialog = page.getByRole("alertdialog");
+		await expect(deleteDialog).toContainText("permanently deletes the agent and its saved data");
+		await expect(deleteDialog).toContainText("can’t be undone");
+		await expect(deleteDialog).toContainText(
+			status === "trialing" ? "The trial ends immediately" : "remain active through",
+		);
+		await expect(deleteDialog).not.toContainText(/saved data is kept|container|volume|disk/i);
+		await deleteDialog
+			.getByRole("button", { name: "Delete agent and cancel subscription", exact: true })
+			.click();
+		await expect
+			.poll(() => deleteRequests)
+			.toEqual([{ subscription_choice: "cancel_subscription" }]);
+	});
+}

--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -319,7 +319,7 @@ async function expectAgentSettingsSectionsAligned(
 		"Avatar",
 		"Language & timezone",
 		"Compute plan",
-		"Lifecycle",
+		"Agent controls",
 		"Danger zone",
 	];
 	const boxes = await Promise.all(
@@ -974,7 +974,7 @@ test("agent settings uses compact canonical subscription management", async ({
 		.poll(() => scheduledPlanCancellationRequests.map((body) => JSON.parse(body)))
 		.toEqual([{ deployment_id: "hdep_scheduled_downgrade" }]);
 	await expect(
-		page.locator("[data-sonner-toast]").filter({ hasText: "Billing details are reconciling" }),
+		page.locator("[data-sonner-toast]").filter({ hasText: "Subscription details are updating" }),
 	).toBeVisible();
 	await expectCardsFit(page.locator("body"));
 

--- a/apps/web/src/hosted/agents/deployment-delete-action.tsx
+++ b/apps/web/src/hosted/agents/deployment-delete-action.tsx
@@ -20,6 +20,7 @@ import { useDeleteDeployment } from "@/hosted/agents/deployment-hooks";
 import type { DeploymentDeleteRequest, HostedDeployment } from "@/hosted/billing/contracts";
 import {
 	computeFundingMode,
+	computeSubscriptionCancellationCopy,
 	isComputeSubscriptionRenewing,
 } from "@/hosted/billing/subscription/subscription-utils";
 import { formatShortDate } from "@/lib/format";
@@ -86,7 +87,11 @@ export function HostedDeploymentDeleteAction({
 	const keepDescription = `Keep subscription — it becomes available to choose for a future Agent.${
 		periodEnd === "—" ? "" : ` Valid through ${periodEnd}.`
 	}`;
-	const cancelDescription = `Stops at period end${periodEnd === "—" ? "." : ` on ${periodEnd}.`}`;
+	const cancelDescription = computeSubscriptionCancellationCopy({
+		isTrial: subscription?.status === "trialing",
+		periodEndLabel: periodEnd === "—" ? null : periodEnd,
+		hasRetainedDeployment: false,
+	}).description;
 
 	return (
 		<AlertDialog
@@ -102,7 +107,7 @@ export function HostedDeploymentDeleteAction({
 				<AlertDialogHeader>
 					<AlertDialogTitle>{`Delete ${name}?`}</AlertDialogTitle>
 					<AlertDialogDescription>
-						This permanently deletes the agent and releases its resources. This can’t be undone.
+						This permanently deletes the agent and its saved data. This can’t be undone.
 					</AlertDialogDescription>
 				</AlertDialogHeader>
 

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -140,7 +140,10 @@ import {
 	type CheckoutReturnNavigationTarget,
 	useCheckoutReturnHandler,
 } from "@/hosted/billing/checkout-return";
-import { computeDunningState } from "@/hosted/billing/components/compute-dunning.logic";
+import {
+	computeDunningState,
+	computeSubscriptionRequiredToStart,
+} from "@/hosted/billing/components/compute-dunning.logic";
 import { ComputeDunningBanner } from "@/hosted/billing/components/compute-dunning-banner";
 import type { DeploymentUpdateRequest, HostedDeployment } from "@/hosted/billing/contracts";
 import { navigateToAcceptedDeployment } from "@/hosted/billing/deploy/accepted-deployment-navigation";
@@ -401,19 +404,51 @@ function DeleteComputeAction({
 function StartComputeAction({
 	deployment,
 	label = "Start agent",
+	variant = "default",
+	disabled = false,
+	onSubscribe,
 }: {
 	deployment: HostedDeployment;
 	label?: string;
+	variant?: ComponentProps<typeof Button>["variant"];
+	disabled?: boolean;
+	onSubscribe?: () => void;
 }) {
 	const lifecycle = useDeploymentLifecycle();
 	const runAction = useActionLock();
 	const status = deploymentStatusFromResource(deployment.resource.status);
 	const canStart = canStartDeployment(status);
+	if (computeSubscriptionRequiredToStart(deployment)) {
+		return (
+			<Button
+				type="button"
+				size="sm"
+				variant={variant}
+				disabled={disabled || lifecycle.isPending || !canStart}
+				onClick={onSubscribe}
+				render={
+					onSubscribe ? undefined : (
+						<Link
+							to={agentSectionHref(deployment.agent_id, "settings", {
+								settings: "billing-plan",
+								subscription_action: "start_new",
+							})}
+						/>
+					)
+				}
+				nativeButton={Boolean(onSubscribe)}
+			>
+				<Plus className="size-3.5" />
+				Subscribe to start
+			</Button>
+		);
+	}
 	return (
 		<Button
 			type="button"
 			size="sm"
-			disabled={lifecycle.isPending || !canStart}
+			variant={variant}
+			disabled={disabled || lifecycle.isPending || !canStart}
 			onClick={() =>
 				void runAction(async () => {
 					await lifecycle.mutateAsync({ id: deployment.resource.id, action: "start" });
@@ -794,7 +829,11 @@ function StoppedAgentState({
 		<EmptyState
 			variant={variant}
 			title="Stopped"
-			description="This agent is stopped. Start it to use its tools again."
+			description={
+				computeSubscriptionRequiredToStart(deployment)
+					? "This agent is stopped. Choose a subscription to start it. Your saved data is kept."
+					: "This agent is stopped. Start it to use its tools again."
+			}
 			action={<StartComputeAction deployment={deployment} label="Start" />}
 		/>
 	);
@@ -3650,7 +3689,7 @@ function ComputeSettingsSections({
 	const subscriptionCancelPending = !!currentSubscription?.cancel_at_period_end;
 	const subscriptionCancellationCopy = computeSubscriptionCancellationCopy({
 		isTrial: currentSubscription?.status === "trialing",
-		periodEndLabel: subscriptionPeriodLabel,
+		periodEndLabel: subscriptionEndsAt ? subscriptionPeriodLabel : null,
 		hasRetainedDeployment: true,
 	});
 	const subscriptionLifecycle = currentSubscription
@@ -3752,7 +3791,12 @@ function ComputeSettingsSections({
 	useEffect(() => {
 		if (routeSearch.subscription_action !== "start_new") return;
 		if (hostedAccess.isLoading || plans.isLoading) return;
-		if (canOfferStartNew && hostedAccess.canCreateCloudAgents && (basicPlan || perfPlan)) {
+		if (
+			canOfferStartNew &&
+			!hasPendingComputeChange &&
+			hostedAccess.canCreateCloudAgents &&
+			(basicPlan || perfPlan)
+		) {
 			setSubscriptionCreateOpen(true);
 		}
 		void router.navigate({
@@ -3769,6 +3813,7 @@ function ComputeSettingsSections({
 	}, [
 		basicPlan,
 		canOfferStartNew,
+		hasPendingComputeChange,
 		hostedAccess.canCreateCloudAgents,
 		hostedAccess.isLoading,
 		perfPlan,
@@ -3843,6 +3888,7 @@ function ComputeSettingsSections({
 								confirmLabel: subscriptionCancellationCopy.confirmLabel,
 								successDescription: (result) =>
 									computeSubscriptionCancellationSuccessCopy({
+										isTrial: currentSubscription?.status === "trialing",
 										cancelAtPeriodEnd: result.cancel_at_period_end,
 										periodEndLabel: result.current_period_end
 											? formatShortDate(result.current_period_end)
@@ -3896,21 +3942,20 @@ function ComputeSettingsSections({
 							</Button>
 						</ConfirmAction>
 					) : (
-						<Button
+						<StartComputeAction
+							deployment={deployment}
+							label="Start"
 							variant="outline"
-							size="sm"
-							disabled={lifecycle.isPending || !canRunPrimaryLifecycleAction}
-							onClick={() =>
-								void runAction(() => runLifecycleAction(primaryLifecycleAction)).catch(
-									() => undefined,
-								)
+							disabled={
+								lifecycle.isPending ||
+								!canRunPrimaryLifecycleAction ||
+								(computeSubscriptionRequiredToStart(deployment) &&
+									(createUnavailableMessage !== null ||
+										hasPendingComputeChange ||
+										hostedAccess.isLoading))
 							}
-						>
-							{lifecycle.isPending && lifecycle.variables?.action === primaryLifecycleAction ? (
-								<Spinner className="size-3.5" />
-							) : null}
-							Start
-						</Button>
+							onSubscribe={() => setSubscriptionCreateOpen(true)}
+						/>
 					)}
 				</div>
 			</SettingsSection>
@@ -3924,7 +3969,7 @@ function ComputeSettingsSections({
 					<div>
 						<div className="text-sm font-medium">Delete this agent</div>
 						<p className="text-xs text-muted-foreground">
-							Deletes this agent and releases its resources. This can’t be undone.
+							Deletes this agent and its saved data. This can’t be undone.
 						</p>
 					</div>
 					<DeleteComputeAction

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -785,6 +785,25 @@ describe("declarative deployment mutations", () => {
 		await expect(result).rejects.toThrow(DEPLOYMENT_CONFLICT_MESSAGE);
 	});
 
+	it("does not retry or wrap a start rejected for ended funding", async () => {
+		const requests: string[] = [];
+		const client = testClient(async (request) => {
+			const path = new URL(request.url).pathname;
+			requests.push(`${request.method} ${path}`);
+			if (request.method === "GET") {
+				return jsonResponse(hostedDeploymentFixture({ id: "hdep_ended", status: "stopped" }));
+			}
+			return jsonResponse({ code: "funding_revoked_after_accept" }, 409);
+		});
+		await expect(
+			client.setDeploymentDesiredState("hdep_ended", "running", "intent-start"),
+		).rejects.toBeInstanceOf(BillingApiError);
+		expect(requests).toEqual([
+			"GET /v2/deployments/hdep_ended",
+			"POST /v2/deployments/hdep_ended/start",
+		]);
+	});
+
 	it("reveals Runtime UI credentials against the displayed resource version", async () => {
 		const requests: Request[] = [];
 		const deployment = hostedDeploymentFixture({

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -240,7 +240,11 @@ function strongResourceEtag(resourceVersion: string): string {
 }
 
 function isPreconditionConflict(error: unknown): error is BillingApiError {
-	return error instanceof BillingApiError && (error.status === 409 || error.status === 412);
+	return (
+		error instanceof BillingApiError &&
+		(error.status === 409 || error.status === 412) &&
+		billingErrorDetail(error)?.code !== "funding_revoked_after_accept"
+	);
 }
 
 function isNotFound(error: unknown): error is BillingApiError {

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
@@ -6,7 +6,11 @@ import type {
 	HostedFundingFact,
 } from "@/hosted/billing/contracts";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
-import { computeDunningState, fallbackReasonSentence } from "./compute-dunning.logic";
+import {
+	computeDunningState,
+	computeSubscriptionRequiredToStart,
+	fallbackReasonSentence,
+} from "./compute-dunning.logic";
 
 function deployment({
 	computeSubscription = null,
@@ -165,7 +169,7 @@ describe("computeDunningState", () => {
 				recoveryTarget: { kind: "start_new", action: "start_new" },
 				tone: "destructive",
 			});
-			expect(state?.description).toContain("Start a new subscription");
+			expect(state?.description).toContain("Choose a subscription");
 		}
 	});
 
@@ -197,7 +201,7 @@ describe("computeDunningState", () => {
 				status: "stopped",
 			}),
 		);
-		expect(stopped?.description).toContain("No included Basic entitlement was available");
+		expect(stopped?.description).toContain("You can start it on included Basic");
 
 		const unavailable = computeDunningState(
 			deployment({
@@ -206,14 +210,14 @@ describe("computeDunningState", () => {
 				status: null,
 			}),
 		);
-		expect(unavailable?.description).toContain(
-			"can’t determine whether this agent stopped or is using included Basic",
-		);
+		expect(unavailable?.description).toContain("current status is unavailable");
 		expect(unavailable?.description).not.toContain("is now using included Basic");
 	});
 
-	test("does not recover a detached or already recovered subscription", () => {
-		expect(computeDunningState(deployment({ factKind: "funding_revoked" }))).toBeNull();
+	test("recovers revoked funding even without a subscription, but not an active replacement", () => {
+		expect(
+			computeDunningState(deployment({ factKind: "funding_revoked" }))?.recoveryTarget.kind,
+		).toBe("start_new");
 		expect(
 			computeDunningState(
 				deployment({
@@ -286,4 +290,51 @@ describe("computeDunningState", () => {
 			"changed by an administrator",
 		);
 	});
+});
+
+test("stopped power controls require a subscription only for known terminal entitlement", () => {
+	for (const status of [
+		"canceled",
+		"expired",
+		"incomplete",
+		"incomplete_expired",
+		"paused",
+		"unpaid",
+	]) {
+		expect(
+			computeSubscriptionRequiredToStart(
+				deployment({
+					status: "stopped",
+					computeSubscription: subscription({ status }),
+				}),
+			),
+			status,
+		).toBe(true);
+	}
+	for (const status of ["active", "trialing", "canceling", "past_due"]) {
+		expect(
+			computeSubscriptionRequiredToStart(
+				deployment({
+					status: "stopped",
+					computeSubscription: subscription({ status, cancel_at_period_end: true }),
+				}),
+			),
+			status,
+		).toBe(false);
+	}
+	expect(computeSubscriptionRequiredToStart(deployment({ status: "stopped" }))).toBe(false);
+	expect(
+		computeSubscriptionRequiredToStart(
+			deployment({ status: "stopped", factKind: "funding_revoked" }),
+		),
+	).toBe(true);
+	expect(
+		computeSubscriptionRequiredToStart(
+			deployment({
+				status: "stopped",
+				factKind: "funding_revoked",
+				computeSubscription: includedSubscription(),
+			}),
+		),
+	).toBe(false);
 });

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
@@ -76,6 +76,10 @@ function detachedFallbackState(deployment: DunningDeployment): ComputeDunningSta
 	const deploymentStatus = deploymentStatusFromResource(deployment.resource.status);
 	const stopped = deploymentStatus.kind === "stopped";
 	const statusUnavailable = !deploymentStatus.known;
+	const includedBasic = isIncludedBasicSubscription(
+		deployment.current_plan_slug,
+		deployment.commercial_display?.compute_subscription,
+	);
 	const presentation = (() => {
 		switch (fallback.reason) {
 			case "payment_failure":
@@ -117,10 +121,14 @@ function detachedFallbackState(deployment: DunningDeployment): ComputeDunningSta
 		fundingSource: fallback.funding_source,
 		recoveryTarget: { kind: "start_new", action: "start_new" },
 		description: statusUnavailable
-			? "We can’t determine whether this agent stopped or is using included Basic because its current status is unavailable. Start a new subscription to restore paid compute."
+			? "The agent’s current status is unavailable. Check again in a moment. Your saved data is kept."
 			: stopped
-				? "No included Basic entitlement was available, so this agent stopped. Start a new subscription to restore paid compute."
-				: "This agent is now using included Basic. Start a new subscription to restore paid compute.",
+				? includedBasic
+					? "This agent is stopped. You can start it on included Basic or choose a paid subscription. Your saved data is kept."
+					: "This agent is stopped. Choose a subscription to start it. Your saved data is kept."
+				: includedBasic
+					? "This agent is now using included Basic. Start a new subscription to restore paid compute."
+					: "This subscription ended. Choose a subscription to use this agent again. Your saved data is kept.",
 		fallbackOccurredAt: fallback.occurred_at,
 		fallbackPlanLabel,
 		fallbackReason: fallback.reason,
@@ -131,11 +139,13 @@ function detachedFallbackState(deployment: DunningDeployment): ComputeDunningSta
 export function computeDunningState(deployment: DunningDeployment): ComputeDunningState | null {
 	const subscription = deployment.commercial_display?.compute_subscription ?? null;
 	const fallbackState = detachedFallbackState(deployment);
-	if (fallbackState && isIncludedBasicSubscription(deployment.current_plan_slug, subscription)) {
+	if (
+		fallbackState &&
+		(!subscription || isIncludedBasicSubscription(deployment.current_plan_slug, subscription))
+	) {
 		return fallbackState;
 	}
 	if (!subscription) return null;
-	if (subscription.payment_state === "ok") return null;
 	const recoveryTarget = computeSubscriptionRecoveryTarget(subscription);
 	if (!recoveryTarget) return null;
 
@@ -153,7 +163,7 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 		secondaryTarget: null,
 	};
 
-	if (subscription.payment_state === "unpaid") {
+	if (recoveryTarget.kind === "start_new") {
 		return {
 			...common,
 			paymentState: "unpaid",
@@ -161,9 +171,10 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 			tone: "destructive",
 			title: "Compute subscription ended",
 			description:
-				"This paid subscription ended. Start a new subscription for this agent to restore paid compute.",
+				"This subscription is no longer active. Choose a subscription to start this agent. Your saved data is kept.",
 		};
 	}
+	if (subscription.payment_state === "ok") return null;
 
 	if (subscription.payment_state === "requires_action") {
 		return {
@@ -196,4 +207,16 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 		title: "Payment past due",
 		description: "Update the card payment method for the open invoice.",
 	};
+}
+
+export function computeSubscriptionRequiredToStart(deployment: DunningDeployment): boolean {
+	const subscription = deployment.commercial_display?.compute_subscription;
+	if (
+		subscription &&
+		isIncludedBasicSubscription(deployment.current_plan_slug, subscription) &&
+		computeSubscriptionRecoveryTarget(subscription) === null
+	) {
+		return false;
+	}
+	return computeDunningState(deployment)?.recoveryTarget.kind === "start_new";
 }

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -161,6 +161,25 @@ describe("applyDeploymentSubscriptionResult", () => {
 });
 
 describe("applySubscriptionActionSuccess", () => {
+	test("pending subscription actions invalidate inventory without projecting success", async () => {
+		for (const action_state of ["pending", "reconciling"] as const) {
+			const qc = new QueryClient();
+			const previous = [hostedDeploymentFixture({ id: "dep_123" })];
+			qc.setQueryData(billingKeys.deployments, previous);
+			await applySubscriptionActionSuccess(
+				qc,
+				{ deployment_id: "dep_123" },
+				{
+					...subscriptionAction(true),
+					action_state,
+				},
+			);
+			expect(qc.getQueryData<HostedDeployment[]>(billingKeys.deployments)).toBe(previous);
+			expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(true);
+			qc.clear();
+		}
+	});
+
 	test("invalidates every compute subscription inventory after an action", async () => {
 		const qc = new QueryClient();
 		qc.setQueryData(billingKeys.deployments, { current: true });

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -31,6 +31,7 @@ import {
 	subscriptionCreateQuoteRequest,
 	subscriptionCreateQuoteView,
 } from "@/hosted/billing/subscription/subscription-create-adapter";
+import { isComputeSubscriptionActionUnconfirmed } from "@/hosted/billing/subscription/subscription-utils";
 import {
 	deploymentPollingState,
 	deploymentStatusFromResource,
@@ -127,7 +128,7 @@ export async function applySubscriptionActionSuccess(
 	body: ComputeSubscriptionCancelRequest | ComputeSubscriptionResumeRequest,
 	next: ComputeSubscriptionActionResult,
 ): Promise<void> {
-	if (body.deployment_id) {
+	if (body.deployment_id && !isComputeSubscriptionActionUnconfirmed(next)) {
 		applyDeploymentSubscriptionResult(qc, body.deployment_id, next);
 	}
 	await invalidateComputeSubscriptionInventory(qc);

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-action-list.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-action-list.tsx
@@ -22,6 +22,7 @@ import {
 	ComputeSubscriptionRecoveryAction,
 	type ComputeSubscriptionStartNewAction,
 } from "@/hosted/billing/subscription/compute-subscription-recovery-action";
+import { isComputeSubscriptionActionUnconfirmed } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 
 export type ComputeSubscriptionActionTarget =
@@ -65,9 +66,9 @@ export function scheduledPlanCancellationNotice(result: ComputeSubscriptionActio
 		case "reconciling":
 			return {
 				kind: "info",
-				title: "Billing details are reconciling",
+				title: "Subscription details are updating",
 				description:
-					"The cancellation was accepted, but subscription details are still reconciling. Refresh in a moment.",
+					"The cancellation was accepted, but subscription details are still updating. Check again in a moment.",
 			};
 		default:
 			return {
@@ -76,6 +77,34 @@ export function scheduledPlanCancellationNotice(result: ComputeSubscriptionActio
 				description: "Refresh the subscription details before trying again.",
 			};
 	}
+}
+
+export function subscriptionMutationNotice(
+	result: ComputeSubscriptionActionResult,
+	action: "cancel" | "resume",
+	successDescription?: string,
+): { kind: "success" | "info"; title: string; description?: string } {
+	const confirmed =
+		action === "cancel"
+			? result.cancel_at_period_end || result.status === "canceled"
+			: !result.cancel_at_period_end && ["active", "trialing", "past_due"].includes(result.status);
+	if (isComputeSubscriptionActionUnconfirmed(result) || !confirmed) {
+		return {
+			kind: "info",
+			title: action === "cancel" ? "Cancellation is still processing" : "Renewal is still updating",
+			description: "Check the latest subscription details in a moment before trying again.",
+		};
+	}
+	return {
+		kind: "success",
+		title:
+			action === "resume"
+				? "Subscription resumed"
+				: result.cancel_at_period_end
+					? "Cancellation scheduled"
+					: "Subscription canceled",
+		description: successDescription,
+	};
 }
 
 export function ComputeSubscriptionActionList({
@@ -111,10 +140,12 @@ export function ComputeSubscriptionActionList({
 	async function cancel() {
 		try {
 			const result = await cancelSubscription.mutateAsync(actionTarget);
-			toast.success(
-				result.cancel_at_period_end ? "Cancellation scheduled" : "Subscription canceled",
-				{ description: cancelCopy?.successDescription?.(result) },
+			const notice = subscriptionMutationNotice(
+				result,
+				"cancel",
+				cancelCopy?.successDescription?.(result),
 			);
+			toast[notice.kind](notice.title, { description: notice.description });
 		} catch (error) {
 			toast.error("Couldn't cancel subscription", { description: normalizeBillingError(error) });
 			throw error;
@@ -123,8 +154,9 @@ export function ComputeSubscriptionActionList({
 
 	async function resume() {
 		try {
-			await resumeSubscription.mutateAsync(actionTarget);
-			toast.success("Subscription resumed");
+			const result = await resumeSubscription.mutateAsync(actionTarget);
+			const notice = subscriptionMutationNotice(result, "resume");
+			toast[notice.kind](notice.title, { description: notice.description });
 		} catch (error) {
 			toast.error("Couldn't resume subscription", { description: normalizeBillingError(error) });
 			throw error;

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-actions.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-actions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	computeSubscriptionActionRequest,
 	scheduledPlanCancellationNotice,
+	subscriptionMutationNotice,
 } from "./compute-subscription-action-list";
 import {
 	type ComputeSubscriptionActionEntitlement,
@@ -132,7 +133,8 @@ describe("resolveComputeSubscriptionActions", () => {
 		});
 		expect(kinds({ status: "canceled", paymentState: "unpaid" })).toEqual(["start_new"]);
 		for (const status of ["canceled", "expired", "incomplete", "paused"]) {
-			expect(kinds({ status }, { management: hiddenManagement }), status).toEqual([]);
+			expect(kinds({ status }, { management: hiddenManagement }), status).toEqual(["start_new"]);
+			expect(kinds({ status, deploymentId: null, isOrphan: true }), status).toEqual([]);
 		}
 	});
 
@@ -195,4 +197,50 @@ describe("scheduled plan cancellation execution", () => {
 			).toMatchObject({ kind: "info" });
 		}
 	});
+});
+
+test("subscription mutations only confirm completed cancellation or renewal", () => {
+	const result = {
+		status: "active",
+		billing_term_months: 1,
+		cancel_at_period_end: true,
+		action_state: null,
+		message: "Display-only service text",
+	};
+	expect(subscriptionMutationNotice(result, "cancel")).toMatchObject({
+		kind: "success",
+		title: "Cancellation scheduled",
+	});
+	expect(
+		subscriptionMutationNotice(
+			{ ...result, status: "canceled", cancel_at_period_end: false },
+			"cancel",
+		),
+	).toMatchObject({ kind: "success", title: "Subscription canceled" });
+	expect(
+		subscriptionMutationNotice({ ...result, cancel_at_period_end: false }, "resume"),
+	).toMatchObject({ kind: "success", title: "Subscription resumed" });
+	for (const action of ["cancel", "resume"] as const) {
+		for (const action_state of ["pending", "reconciling"] as const) {
+			expect(
+				subscriptionMutationNotice(
+					{
+						...result,
+						status: action === "cancel" ? "canceled" : "active",
+						cancel_at_period_end: false,
+						action_state,
+					},
+					action,
+					"Confirmed",
+				),
+			).toMatchObject({
+				kind: "info",
+				description: "Check the latest subscription details in a moment before trying again.",
+			});
+		}
+	}
+	expect(subscriptionMutationNotice(result, "resume").kind).toBe("info");
+	expect(
+		subscriptionMutationNotice({ ...result, cancel_at_period_end: false }, "cancel").kind,
+	).toBe("info");
 });

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-actions.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-actions.test.ts
@@ -111,6 +111,7 @@ describe("resolveComputeSubscriptionActions", () => {
 	test("gives pending, canceling, and terminal states exclusive recovery priority", () => {
 		expect(kinds({}, { hasPendingOperation: true })).toEqual(["check_change"]);
 		expect(kinds({ cancelAtPeriodEnd: true })).toEqual(["resume"]);
+		expect(kinds({ status: "trialing", cancelAtPeriodEnd: true })).toEqual(["resume"]);
 		const unpaid = resolveComputeSubscriptionActions({
 			entitlement: entitlement({ status: "unpaid", paymentState: "unpaid" }),
 			management: enabledManagement,

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-actions.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-actions.ts
@@ -1,6 +1,6 @@
 import type { ComputeSubscriptionManagementResult } from "./compute-subscription-management";
 import type { ComputeRecoveryTarget } from "./compute-subscription-recovery";
-import { computeFundingSource } from "./subscription-utils";
+import { computeFundingSource, isTerminalComputeSubscriptionStatus } from "./subscription-utils";
 
 export type ComputeSubscriptionActionKind =
 	| "upgrade"
@@ -41,13 +41,6 @@ export type ComputeSubscriptionActionEntitlement = {
 	isOrphan?: boolean;
 };
 
-const TERMINAL_STATUSES = new Set([
-	"canceled",
-	"expired",
-	"incomplete",
-	"incomplete_expired",
-	"paused",
-]);
 const CANCELABLE_STATUSES = new Set(["trialing", "active", "past_due"]);
 
 function action(
@@ -108,7 +101,7 @@ export function resolveComputeSubscriptionActions({
 	if (
 		recoveryTarget?.kind === "start_new" ||
 		entitlement.paymentState === "unpaid" ||
-		status === "unpaid"
+		isTerminalComputeSubscriptionStatus(status)
 	) {
 		if (!deploymentBound) return [];
 		const startNewTarget: ComputeRecoveryTarget = { kind: "start_new", action: "start_new" };
@@ -119,8 +112,6 @@ export function resolveComputeSubscriptionActions({
 			},
 		];
 	}
-	if (TERMINAL_STATUSES.has(status)) return [];
-
 	const recovery = recoveryTarget ? recoveryAction(recoveryTarget) : null;
 
 	if (entitlement.pendingPlanSlug != null) {

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.test.ts
@@ -4,6 +4,27 @@ import { computeSubscriptionRecoveryPresentation } from "./compute-subscription-
 const active = { label: "Active", tone: "success" } as const;
 
 describe("computeSubscriptionRecoveryPresentation", () => {
+	test("ended subscriptions override stale payment retries without needing a recovery action", () => {
+		const canceled = { label: "Canceled", tone: "neutral" } as const;
+		expect(
+			computeSubscriptionRecoveryPresentation(
+				{
+					status: "canceled",
+					payment_state: "past_due",
+					recovery_action: "top_up",
+					latest_failed_invoice_hosted_url: null,
+					next_payment_attempt_at: "2026-09-12T00:00:00Z",
+				},
+				canceled,
+			),
+		).toEqual({
+			status: canceled,
+			hasPaymentIssue: true,
+			recoveryTarget: { kind: "start_new", action: "start_new" },
+			schedule: null,
+		});
+	});
+
 	test("prioritizes authoritative payment state over coarse lifecycle status", () => {
 		expect(
 			computeSubscriptionRecoveryPresentation(

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.ts
@@ -3,6 +3,7 @@ import type {
 	ComputeSubscriptionListItem,
 	HostedComputeSubscription,
 } from "@/hosted/billing/contracts";
+import { isTerminalComputeSubscriptionStatus } from "./subscription-utils";
 
 export type ComputeSubscriptionRecoveryFields =
 	| (Pick<
@@ -12,7 +13,7 @@ export type ComputeSubscriptionRecoveryFields =
 			| "payment_state"
 			| "recovery_action"
 	  > &
-			Partial<Pick<ComputeSubscriptionListItem, "funding_source">>)
+			Partial<Pick<ComputeSubscriptionListItem, "funding_source" | "status">>)
 	| (Pick<
 			HostedComputeSubscription,
 			| "latest_failed_invoice_hosted_url"
@@ -20,7 +21,7 @@ export type ComputeSubscriptionRecoveryFields =
 			| "payment_state"
 			| "recovery_action"
 	  > &
-			Partial<Pick<HostedComputeSubscription, "funding_source">>);
+			Partial<Pick<HostedComputeSubscription, "funding_source" | "status">>);
 
 export type ComputeRecoveryTarget =
 	| { kind: "invoice"; action: "fix_payment"; url: string }
@@ -41,6 +42,12 @@ export type ComputeSubscriptionRecoveryPresentation = {
 export function computeSubscriptionRecoveryTarget(
 	subscription: ComputeSubscriptionRecoveryFields,
 ): ComputeRecoveryTarget | null {
+	if (
+		isTerminalComputeSubscriptionStatus(subscription.status) ||
+		subscription.payment_state === "unpaid"
+	) {
+		return { kind: "start_new", action: "start_new" };
+	}
 	const action = subscription.recovery_action;
 	if (action === "top_up") return { kind: "top_up", action };
 	if (action === "start_new") return { kind: "start_new", action };
@@ -49,9 +56,6 @@ export function computeSubscriptionRecoveryTarget(
 		return invoiceUrl
 			? { kind: "invoice", action, url: invoiceUrl }
 			: { kind: "fix_payment", action };
-	}
-	if (subscription.payment_state === "unpaid") {
-		return { kind: "start_new", action: "start_new" };
 	}
 	if (subscription.payment_state === "requires_action") {
 		const invoiceUrl = subscription.latest_failed_invoice_hosted_url?.trim();
@@ -95,13 +99,16 @@ export function computeSubscriptionRecoveryPresentation(
 		}
 	})();
 	const target = computeSubscriptionRecoveryTarget(subscription);
+	const terminal = isTerminalComputeSubscriptionStatus(subscription.status);
 
 	return {
-		status: paymentStatus ?? lifecycleStatus,
+		status: terminal ? lifecycleStatus : (paymentStatus ?? lifecycleStatus),
 		hasPaymentIssue: paymentStatus !== null || target !== null,
 		recoveryTarget: target,
 		schedule:
-			subscription.payment_state === "past_due" || subscription.payment_state === "requires_action"
+			!terminal &&
+			(subscription.payment_state === "past_due" ||
+				subscription.payment_state === "requires_action")
 				? subscription.next_payment_attempt_at
 					? {
 							verb: "Retries",

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -193,8 +193,7 @@ describe("compute subscription cancellation copy", () => {
 				hasRetainedDeployment: true,
 			}),
 		).toEqual({
-			description:
-				"The trial ends immediately. The agent stops, but its disk and data are retained.",
+			description: "The trial ends immediately and the agent stops. Your saved data is kept.",
 			confirmLabel: "End trial now",
 		});
 		expect(
@@ -205,25 +204,35 @@ describe("compute subscription cancellation copy", () => {
 			}),
 		).toEqual({
 			description:
-				"The subscription will stop renewing and remain active through Sep 12, 2026. At that point, the agent stops, but its disk and data are retained.",
+				"The subscription will stop renewing and remain active through Sep 12, 2026. The agent stops when the period ends. Your saved data is kept.",
 			confirmLabel: "Cancel at period end",
 		});
 		expect(
 			computeSubscriptionCancellationSuccessCopy({
+				isTrial: true,
 				cancelAtPeriodEnd: false,
 				periodEndLabel: null,
 				hasRetainedDeployment: true,
 			}),
-		).toBe("The trial has ended. The agent will stop; its disk and data are retained.");
+		).toBe("The trial has ended. The agent will stop. Your saved data is kept.");
 		expect(
 			computeSubscriptionCancellationSuccessCopy({
+				isTrial: false,
 				cancelAtPeriodEnd: true,
 				periodEndLabel: "Sep 12, 2026",
 				hasRetainedDeployment: true,
 			}),
 		).toBe(
-			"The subscription remains active through Sep 12, 2026. The agent will then stop; its disk and data are retained.",
+			"The subscription remains active through Sep 12, 2026. The agent will then stop. Your saved data is kept.",
 		);
+		expect(
+			computeSubscriptionCancellationSuccessCopy({
+				isTrial: false,
+				cancelAtPeriodEnd: false,
+				periodEndLabel: null,
+				hasRetainedDeployment: true,
+			}),
+		).toBe("The subscription has ended. The agent will stop. Your saved data is kept.");
 		expect(
 			computeSubscriptionCancellationCopy({
 				isTrial: false,
@@ -234,6 +243,16 @@ describe("compute subscription cancellation copy", () => {
 			description:
 				"The subscription will stop renewing at the end of the current billing period. This cannot restore a deleted agent.",
 			confirmLabel: "Cancel at period end",
+		});
+		expect(
+			computeSubscriptionCancellationCopy({
+				isTrial: true,
+				periodEndLabel: "Sep 12, 2026",
+				hasRetainedDeployment: false,
+			}),
+		).toEqual({
+			description: "The trial ends immediately. This cannot restore a deleted agent.",
+			confirmLabel: "End trial now",
 		});
 	});
 });

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -387,6 +387,24 @@ describe("account subscription history", () => {
 });
 
 describe("compute subscription lifecycle presentation", () => {
+	test("keeps a trial scheduled to cancel distinct from an ended trial", () => {
+		const trial = {
+			...subscription(),
+			status: "trialing",
+			cancel_at_period_end: true,
+			current_period_end: "2026-09-12T00:00:00Z",
+		};
+
+		expect(computeSubscriptionLifecycle(trial)).toEqual({
+			badgeLabel: "Canceling",
+			badgeTone: "warning",
+			dateAt: trial.current_period_end,
+			dateVerb: "Ends",
+			renews: false,
+		});
+		expect(isComputeSubscriptionRenewing(trial)).toBe(false);
+	});
+
 	test("only renewing states present as renewing", () => {
 		for (const status of ["active", "trialing", "past_due"]) {
 			expect(isComputeSubscriptionRenewing({ ...subscription(), status }), status).toBe(true);

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -3,6 +3,7 @@ import {
 	COMPUTE_BASIC_SLUG,
 	COMPUTE_PERFORMANCE_SLUG,
 	type ComputePlanSlug,
+	type ComputeSubscriptionActionResult,
 	type ComputeSubscriptionListItem,
 	type HostedComputeSubscription,
 	type Plan,
@@ -21,6 +22,18 @@ export function isHistoricalAccountSubscription(
 	return subscription.status === "canceled";
 }
 
+export function isTerminalComputeSubscriptionStatus(status: string | undefined): boolean {
+	return ["canceled", "expired", "incomplete", "incomplete_expired", "paused", "unpaid"].includes(
+		status?.toLowerCase() ?? "",
+	);
+}
+
+export function isComputeSubscriptionActionUnconfirmed(
+	result: ComputeSubscriptionActionResult,
+): boolean {
+	return result.action_state === "pending" || result.action_state === "reconciling";
+}
+
 export function computeSubscriptionCancellationCopy({
 	isTrial,
 	periodEndLabel,
@@ -33,7 +46,7 @@ export function computeSubscriptionCancellationCopy({
 	if (isTrial) {
 		return {
 			description: hasRetainedDeployment
-				? "The trial ends immediately. The agent stops, but its disk and data are retained."
+				? "The trial ends immediately and the agent stops. Your saved data is kept."
 				: "The trial ends immediately. This cannot restore a deleted agent.",
 			confirmLabel: "End trial now",
 		};
@@ -43,25 +56,28 @@ export function computeSubscriptionCancellationCopy({
 		: "The subscription will stop renewing at the end of the current billing period.";
 	return {
 		description: hasRetainedDeployment
-			? `${ending} At that point, the agent stops, but its disk and data are retained.`
+			? `${ending} The agent stops when the period ends. Your saved data is kept.`
 			: `${ending} This cannot restore a deleted agent.`,
 		confirmLabel: "Cancel at period end",
 	};
 }
 
 export function computeSubscriptionCancellationSuccessCopy({
+	isTrial,
 	cancelAtPeriodEnd,
 	periodEndLabel,
 	hasRetainedDeployment,
 }: {
+	isTrial: boolean;
 	cancelAtPeriodEnd: boolean;
 	periodEndLabel: string | null;
 	hasRetainedDeployment: boolean;
 }): string {
 	if (!cancelAtPeriodEnd) {
+		const ending = isTrial ? "The trial has ended." : "The subscription has ended.";
 		return hasRetainedDeployment
-			? "The trial has ended. The agent will stop; its disk and data are retained."
-			: "The trial has ended.";
+			? `${ending} The agent will stop. Your saved data is kept.`
+			: ending;
 	}
 	if (!hasRetainedDeployment) {
 		return periodEndLabel
@@ -69,8 +85,8 @@ export function computeSubscriptionCancellationSuccessCopy({
 			: "The subscription will not renew after the current billing period.";
 	}
 	return periodEndLabel
-		? `The subscription remains active through ${periodEndLabel}. The agent will then stop; its disk and data are retained.`
-		: "The agent will stop when the current billing period ends; its disk and data are retained.";
+		? `The subscription remains active through ${periodEndLabel}. The agent will then stop. Your saved data is kept.`
+		: "The agent will stop when the current billing period ends. Your saved data is kept.";
 }
 
 export function resolveBasicPlan(plans: Plan[] | undefined): Plan | undefined {

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -304,6 +304,7 @@ function SubscriptionRow({
 								confirmLabel: cancellationCopy.confirmLabel,
 								successDescription: (result) =>
 									computeSubscriptionCancellationSuccessCopy({
+										isTrial: subscription.status === "trialing",
 										cancelAtPeriodEnd: result.cancel_at_period_end,
 										periodEndLabel: result.current_period_end
 											? formatShortDate(result.current_period_end)

--- a/apps/web/src/hosted/deployment-failure.test.ts
+++ b/apps/web/src/hosted/deployment-failure.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { DeploymentOperation } from "@/hosted/billing/contracts";
-import { BillingApiError, BillingNetworkError } from "@/hosted/billing/errors";
+import {
+	BillingApiError,
+	BillingNetworkError,
+	DeploymentConflictError,
+} from "@/hosted/billing/errors";
 import {
 	deploymentFailurePresentation,
 	deploymentFailureProjection,
@@ -367,6 +371,43 @@ describe("deploymentFailureReason", () => {
 });
 
 describe("deploymentMutationErrorMessage", () => {
+	test("funding revocation stays actionable through conflict wrapping and failed operations", () => {
+		const problem = {
+			"@type": "type.googleapis.com/clawdi.v2.LifecycleProblemDetails" as const,
+			type: "https://api.clawdi.ai/problems/funding-revoked-after-accept",
+			title: "Internal funding fence",
+			detail: "Internal funding fence",
+			status: 409,
+			code: "funding_revoked_after_accept",
+			conditionReason: "FundingRevoked",
+			conditionMessage: "Internal resource details",
+			observedGeneration: 2,
+		};
+		const error = new BillingApiError(409, "Internal funding fence", problem);
+		const message = deploymentMutationErrorMessage(error);
+		expect(message).toContain("Open Agent settings and choose a subscription");
+		expect(message).not.toMatch(/internal|retry|container|volume|disk/i);
+		expect(deploymentMutationErrorMessage(new DeploymentConflictError({ cause: error }))).toBe(
+			message,
+		);
+		const operation = failedOperation("start");
+		const presentation = deploymentFailurePresentation(
+			hostedDeploymentFixture({
+				status: "stopped",
+				acceptedOperation: {
+					...operation,
+					error: { code: 9, message: "Internal funding fence", details: [problem] },
+				},
+			}),
+		);
+		expect(presentation).toMatchObject({
+			title: "Subscription required",
+			reason: message,
+			description: message,
+			remediation: { kind: "none", label: null },
+		});
+	});
+
 	test("does not map never-emitted provider codes to provider recovery copy", () => {
 		const error = new BillingApiError(404, "provider_not_found", {
 			detail: { code: "provider_not_found" },

--- a/apps/web/src/hosted/deployment-failure.ts
+++ b/apps/web/src/hosted/deployment-failure.ts
@@ -13,6 +13,8 @@ const PLAN_CHANGE_FAILURE_REASON =
 const DEFAULT_SERVICE_FAILURE_REASON = "The Clawdi service could not complete this request.";
 const RUNTIME_UNAVAILABLE_REASON =
 	"Clawdi is checking this Agent. Open Agent settings for details.";
+const SUBSCRIPTION_REQUIRED_REASON =
+	"This agent needs an active subscription to start. Open Agent settings and choose a subscription. Your saved data is kept.";
 
 export type DeploymentFailureProjection = {
 	reason: string;
@@ -53,6 +55,10 @@ function isRuntimeStatusFailure(failure: { code?: string }): boolean {
 
 /** Customer-safe copy for declarative agent mutations handled by the deploy API. */
 export function deploymentMutationErrorMessage(error: unknown): string {
+	const cause = error instanceof DeploymentConflictError ? error.cause : error;
+	if (billingErrorDetail(cause)?.code === "funding_revoked_after_accept") {
+		return SUBSCRIPTION_REQUIRED_REASON;
+	}
 	if (error instanceof DeploymentConflictError) return error.message;
 	if (error instanceof BillingNetworkError) {
 		return error.kind === "timeout"
@@ -133,6 +139,15 @@ export function deploymentFailurePresentation(
 	if (!failure) return null;
 	const operationLabel = deploymentOperationLabel(failure.failedVerb);
 	const operationName = operationLabel.toLocaleLowerCase();
+	if (failure.code === "funding_revoked_after_accept") {
+		return {
+			...failure,
+			title: "Subscription required",
+			description: SUBSCRIPTION_REQUIRED_REASON,
+			status: FAILED_STATUS,
+			remediation: { kind: "none", label: null },
+		};
+	}
 	const statusFailure =
 		deployment?.resource.status?.summary_state === "failed"
 			? deployment.resource.status.failure
@@ -255,6 +270,7 @@ export function deploymentFailureReason(
 ): string | null {
 	const failure = input?.failure;
 	if (!failure) return null;
+	if (failure.code === "funding_revoked_after_accept") return SUBSCRIPTION_REQUIRED_REASON;
 
 	// Failure title/detail/conditionMessage are free-form backend strings. Even
 	// after removing identifiers they can contain exception names or service


### PR DESCRIPTION
## Summary
- Route ended-subscription start actions into the existing subscription recovery flow; valid subscriptions still start normally.
- Explain trial cancellation as immediate stop and paid cancellation as period-end stop, retaining saved data. Keep permanent deletion separate.
- Use structured action_state for pending cancel/resume instead of message matching or premature success.
- Preserve accurate presentation for historical scheduled-cancel trials without guessing old canceling records.

## Verification
- Typecheck, 1125 unit tests, Biome and OSS build passed.
- Eight mocked browser scenarios passed across desktop/mobile; two cancellation scenarios rerun after action-state adjustment.
- Final historical-trial test follow-up: 40 focused tests, typecheck, Biome and OSS build passed.
- No real payment or production operations.

## Dependency
Pair with Clawdi-AI/clawdi-hosted#2062 for structured pending states and preserved trial identity. Not deployed.