### PR TITLE
fix(cli): bound OpenClaw discovery concurrency and isolate polling failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ database migration, CI, and implementation details.
 
 ### Fixed
 
+- OpenClaw sync serializes asynchronous discovery commands to reduce overlapping
+  memory use. Skill polling survives inventory failures without reporting false
+  deletions, and skill synchronization performs fewer workspace lookups.
 - CLI health reporting no longer stalls during OpenClaw session scans, sends
   compatible sync heartbeats, and promptly refreshes observations after delayed
   acknowledgements while retaining bounded retries.

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.14.47",
+      "version": "0.14.48-beta.0",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.14.47",
+	"version": "0.14.48-beta.0",
 	"description": "The best home for all your AI agents. Run them in the cloud or connect your own—with their context and tools in one place.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/adapters/openclaw-command.ts
+++ b/packages/cli/src/adapters/openclaw-command.ts
@@ -1,0 +1,25 @@
+import { type ExecFileOptions, execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+let commandTail: Promise<void> = Promise.resolve();
+
+export function runOpenClawCommand(
+	args: string[],
+	options: Pick<ExecFileOptions, "timeout" | "maxBuffer">,
+): Promise<string> {
+	// Session reads and async Skill discovery share a subprocess slot, not the event loop.
+	const command = commandTail.then(async () => {
+		const { stdout } = await execFileAsync("openclaw", args, {
+			...options,
+			encoding: "utf8",
+			env: process.env,
+		});
+		return stdout;
+	});
+	commandTail = command.then(
+		() => {},
+		() => {},
+	);
+	return command;
+}

--- a/packages/cli/src/adapters/openclaw-workspace.test.ts
+++ b/packages/cli/src/adapters/openclaw-workspace.test.ts
@@ -2,7 +2,11 @@ import { afterEach, expect, test } from "bun:test";
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { listOpenClawAgentWorkspaces, resolveOpenClawAgentWorkspace } from "./openclaw-workspace";
+import {
+	listOpenClawAgentWorkspaces,
+	resolveOpenClawAgentWorkspace,
+	resolveOpenClawAgentWorkspaceAsync,
+} from "./openclaw-workspace";
 
 const originalPath = process.env.PATH;
 let root = "";
@@ -13,23 +17,62 @@ afterEach(() => {
 	root = "";
 });
 
-test("resolves Skills from the official agent workspace roster", () => {
+function installRosterCommand(status = 0): string {
 	root = mkdtempSync(join(tmpdir(), "openclaw-workspace-"));
 	const bin = join(root, "bin");
 	const command = join(bin, "openclaw");
+	const roster = join(root, "roster.json");
 	mkdirSync(bin, { recursive: true });
 	writeFileSync(
 		command,
 		`#!/bin/sh
-test "$*" = "agents list --json"
-printf '%s\n' '[{"id":"main","workspace":"${root}/main-workspace"},{"id":"sales","workspace":"${root}/sales-workspace"}]'
+test "$*" = "agents list --json" || exit 1
+cat "${roster}"
+exit ${status}
 `,
 	);
 	chmodSync(command, 0o755);
 	process.env.PATH = `${bin}:${originalPath ?? ""}`;
+	return roster;
+}
+
+test("resolves Skills from the official agent workspace roster", async () => {
+	const roster = installRosterCommand();
+	writeFileSync(
+		roster,
+		JSON.stringify([
+			{ id: "main", workspace: join(root, "main-workspace") },
+			{ id: "sales", workspace: join(root, "sales-workspace") },
+		]),
+	);
 
 	expect(listOpenClawAgentWorkspaces()).toHaveLength(2);
 	expect(resolveOpenClawAgentWorkspace()).toBe(join(root, "main-workspace"));
-	process.env.OPENCLAW_AGENT_ID = "sales";
+	expect(await resolveOpenClawAgentWorkspaceAsync()).toBe(join(root, "main-workspace"));
+	process.env.OPENCLAW_AGENT_ID = " sales ";
 	expect(resolveOpenClawAgentWorkspace()).toBe(join(root, "sales-workspace"));
+	expect(await resolveOpenClawAgentWorkspaceAsync()).toBe(join(root, "sales-workspace"));
+	expect(await resolveOpenClawAgentWorkspaceAsync("main")).toBe(join(root, "main-workspace"));
+	const missingAgent = "OpenClaw agent missing is not present in the official agent roster";
+	expect(() => resolveOpenClawAgentWorkspace("missing")).toThrow(missingAgent);
+	await expect(resolveOpenClawAgentWorkspaceAsync("missing")).rejects.toMatchObject({
+		message: missingAgent,
+	});
+});
+
+test.each([
+	{ name: "malformed JSON", output: "not JSON", status: 0 },
+	{ name: "empty roster", output: "[]", status: 0 },
+	{
+		name: "relative workspace",
+		output: '[{"id":"main","workspace":"relative"}]',
+		status: 0,
+	},
+	{ name: "nonzero exit", output: "fixture-sensitive-output", status: 1 },
+])("rejects $name through both workspace resolvers", async ({ output, status }) => {
+	const roster = installRosterCommand(status);
+	writeFileSync(roster, output);
+	const message = "OpenClaw workspace resolution requires `openclaw agents list --json`";
+	expect(() => resolveOpenClawAgentWorkspace()).toThrow(message);
+	await expect(resolveOpenClawAgentWorkspaceAsync()).rejects.toMatchObject({ message });
 });

--- a/packages/cli/src/adapters/openclaw-workspace.ts
+++ b/packages/cli/src/adapters/openclaw-workspace.ts
@@ -1,5 +1,9 @@
 import { spawnSync } from "node:child_process";
 import { isAbsolute } from "node:path";
+import { runOpenClawCommand } from "./openclaw-command";
+
+const WORKSPACE_RESOLUTION_ERROR =
+	"OpenClaw workspace resolution requires `openclaw agents list --json`";
 
 export interface OpenClawAgentWorkspace {
 	id: string;
@@ -31,19 +35,41 @@ export function listOpenClawAgentWorkspaces(): OpenClawAgentWorkspace[] {
 		maxBuffer: 1024 * 1024,
 		timeout: 15_000,
 	});
-	if (result.status === 0) {
-		try {
-			const summaries = parseOpenClawAgentWorkspaces(result.stdout);
-			if (summaries.length > 0) return summaries;
-		} catch {
-			// Invalid public CLI output is reported below.
-		}
-	}
-	throw new Error("OpenClaw workspace resolution requires `openclaw agents list --json`");
+	if (result.status !== 0) throw new Error(WORKSPACE_RESOLUTION_ERROR);
+	return requireOpenClawAgentWorkspaces(result.stdout);
 }
 
 export function resolveOpenClawAgentWorkspace(agentId = openClawAgentId()): string {
-	const workspace = listOpenClawAgentWorkspaces().find((entry) => entry.id === agentId)?.workspace;
+	return workspaceForAgent(listOpenClawAgentWorkspaces(), agentId);
+}
+
+export async function resolveOpenClawAgentWorkspaceAsync(
+	agentId = openClawAgentId(),
+): Promise<string> {
+	let stdout: string;
+	try {
+		stdout = await runOpenClawCommand(["agents", "list", "--json"], {
+			maxBuffer: 1024 * 1024,
+			timeout: 15_000,
+		});
+	} catch {
+		throw new Error(WORKSPACE_RESOLUTION_ERROR);
+	}
+	return workspaceForAgent(requireOpenClawAgentWorkspaces(stdout), agentId);
+}
+
+function requireOpenClawAgentWorkspaces(output: string): OpenClawAgentWorkspace[] {
+	try {
+		const summaries = parseOpenClawAgentWorkspaces(output);
+		if (summaries.length > 0) return summaries;
+	} catch {
+		// Invalid public CLI output is reported below.
+	}
+	throw new Error(WORKSPACE_RESOLUTION_ERROR);
+}
+
+function workspaceForAgent(workspaces: OpenClawAgentWorkspace[], agentId: string): string {
+	const workspace = workspaces.find((entry) => entry.id === agentId)?.workspace;
 	if (!workspace)
 		throw new Error(`OpenClaw agent ${agentId} is not present in the official agent roster`);
 	return workspace;

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -1,9 +1,8 @@
-import { execFile, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { basename, isAbsolute, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { promisify } from "node:util";
 import {
 	OPENCLAW_SDK_EXPORT_PATHS,
 	resolveOpenClawSdkExport,
@@ -40,10 +39,12 @@ import type {
 	SessionScanResult,
 	SessionUserActivity,
 } from "./base";
+import { runOpenClawCommand } from "./openclaw-command";
 import {
 	listOpenClawAgentWorkspaces,
 	openClawAgentId,
 	resolveOpenClawAgentWorkspace,
+	resolveOpenClawAgentWorkspaceAsync,
 } from "./openclaw-workspace";
 import { getOpenClawHome, isPathWithinRoots, SKIP_DIRS } from "./paths";
 import {
@@ -355,29 +356,17 @@ function mergeUserActivity(
 }
 
 const OPENCLAW_COMMAND_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
-const execFileAsync = promisify(execFile);
-let sessionCommandTail: Promise<void> = Promise.resolve();
 
 async function runOpenClawJson(args: string[]): Promise<JsonObject | null> {
-	// Scans and queue-time resolves share one subprocess slot, not the event loop.
-	const command = sessionCommandTail.then(async () => {
-		try {
-			const { stdout } = await execFileAsync("openclaw", args, {
-				encoding: "utf8",
-				env: process.env,
-				maxBuffer: OPENCLAW_COMMAND_MAX_BUFFER_BYTES,
-				timeout: 120_000,
-			});
-			return jsonObject(JSON.parse(stdout)) ?? null;
-		} catch {
-			return null;
-		}
-	});
-	sessionCommandTail = command.then(
-		() => {},
-		() => {},
-	);
-	return command;
+	try {
+		const stdout = await runOpenClawCommand(args, {
+			maxBuffer: OPENCLAW_COMMAND_MAX_BUFFER_BYTES,
+			timeout: 120_000,
+		});
+		return jsonObject(JSON.parse(stdout)) ?? null;
+	} catch {
+		return null;
+	}
 }
 
 async function readOfficialSessionInventory(): Promise<OfficialSessionInventory | null> {
@@ -1285,7 +1274,7 @@ export class OpenClawAdapter implements AgentAdapterCore {
 		// silently dropping those skills. Pre-fix the cross-agent
 		// enumerator silently lost OpenClaw skills under any
 		// agent other than the active one.
-		const root = skillsDir();
+		const root = join(await resolveOpenClawAgentWorkspaceAsync(agentId()), "skills");
 		migrateLegacyLocalSetupSkill({
 			targetDir: join(root, "clawdi"),
 			id: "clawdi",

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -356,19 +356,28 @@ function mergeUserActivity(
 
 const OPENCLAW_COMMAND_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
 const execFileAsync = promisify(execFile);
+let sessionCommandTail: Promise<void> = Promise.resolve();
 
 async function runOpenClawJson(args: string[]): Promise<JsonObject | null> {
-	try {
-		const { stdout } = await execFileAsync("openclaw", args, {
-			encoding: "utf8",
-			env: process.env,
-			maxBuffer: OPENCLAW_COMMAND_MAX_BUFFER_BYTES,
-			timeout: 120_000,
-		});
-		return jsonObject(JSON.parse(stdout)) ?? null;
-	} catch {
-		return null;
-	}
+	// Scans and queue-time resolves share one subprocess slot, not the event loop.
+	const command = sessionCommandTail.then(async () => {
+		try {
+			const { stdout } = await execFileAsync("openclaw", args, {
+				encoding: "utf8",
+				env: process.env,
+				maxBuffer: OPENCLAW_COMMAND_MAX_BUFFER_BYTES,
+				timeout: 120_000,
+			});
+			return jsonObject(JSON.parse(stdout)) ?? null;
+		} catch {
+			return null;
+		}
+	});
+	sessionCommandTail = command.then(
+		() => {},
+		() => {},
+	);
+	return command;
 }
 
 async function readOfficialSessionInventory(): Promise<OfficialSessionInventory | null> {

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { createHash } from "node:crypto";
 import {
 	existsSync,
@@ -499,6 +499,29 @@ describe("Agent filesystem projection reconcile", () => {
 		}
 	}
 
+	it("resolves the root once per reconciliation instead of once per key", async () => {
+		await withProjectionCase(async ({ root, skills, queue, reconcile }) => {
+			for (const key of ["alpha", "beta"]) {
+				const dir = join(root, key);
+				mkdirSync(dir);
+				writeFileSync(join(dir, "SKILL.md"), `# ${key}\n`);
+			}
+			const rootDir = spyOn(skills, "rootDir");
+			try {
+				await reconcile(new Map());
+				expect(rootDir).toHaveBeenCalledTimes(1);
+				await reconcile(new Map());
+				expect(rootDir).toHaveBeenCalledTimes(2);
+				expect(queue.all().map((item) => ("skill_key" in item ? item.skill_key : null))).toEqual([
+					"alpha",
+					"beta",
+				]);
+			} finally {
+				rootDir.mockRestore();
+			}
+		});
+	});
+
 	it("durably deletes a claimed nested key missing after directory removal", async () => {
 		await withProjectionCase(async ({ queue, reconcile }) => {
 			await reconcile(new Map([["category/demo", "claimed-hash"]]));
@@ -917,9 +940,10 @@ describe("Agent filesystem projection reconcile", () => {
 	});
 
 	it("uploads a symlink projection with the hash of the exact dereferenced archive", async () => {
-		await withProjectionCase(async ({ root, queue, keys, reconcile }) => {
+		await withProjectionCase(async ({ root, queue, keys, skills, reconcile }) => {
 			const originalHermesHome = process.env.HERMES_HOME;
 			const originalFetch = globalThis.fetch;
+			const rootDir = spyOn(skills, "rootDir");
 			try {
 				process.env.HERMES_HOME = dirname(root);
 				const shared = join(root, "shared");
@@ -931,6 +955,7 @@ describe("Agent filesystem projection reconcile", () => {
 				symlinkSync(join(shared, "body.md"), join(local, "body.md"));
 				keys.add("demo");
 				await reconcile(new Map());
+				rootDir.mockClear();
 				const item = queue.peek();
 				if (!item) throw new Error("expected queued projection");
 
@@ -954,6 +979,7 @@ describe("Agent filesystem projection reconcile", () => {
 				}) as typeof fetch;
 
 				const adapter = adapterRegistry.hermes.create();
+				adapter.skills = skills;
 				const abortController = new AbortController();
 				await processQueueItem(
 					{
@@ -971,7 +997,9 @@ describe("Agent filesystem projection reconcile", () => {
 					new Map(),
 				);
 				expect(verifiedHash).not.toBeNull();
+				expect(rootDir).toHaveBeenCalledTimes(1);
 			} finally {
+				rootDir.mockRestore();
 				globalThis.fetch = originalFetch;
 				if (originalHermesHome === undefined) delete process.env.HERMES_HOME;
 				else process.env.HERMES_HOME = originalHermesHome;

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -1217,7 +1217,7 @@ async function enqueueIfChanged(
 	}
 	const dir = join(skills.rootDir(), skillKey);
 	const projectId = getProjectId();
-	if (isReservedSkill(skills, skillKey) || !existsSync(join(dir, "SKILL.md"))) {
+	if (shouldIgnoreUserSkill(dir, skillKey) || !existsSync(join(dir, "SKILL.md"))) {
 		if (!lastPushedHash.has(skillKey)) return;
 		const version = queue.enqueue({
 			kind: "skill_delete",
@@ -1714,7 +1714,8 @@ export async function processQueueItem(
 			}
 			return "applied";
 		}
-		if (isReservedSkill(modules.skills.module, item.skill_key)) {
+		const skillDir = join(modules.skills.module.rootDir(), item.skill_key);
+		if (shouldIgnoreUserSkill(skillDir, item.skill_key)) {
 			await api.deleteAgentSkill(opts.environmentId, item.skill_key, item.project_id);
 			removeSkillProjectionClaim({
 				agentType: opts.adapter.agentType,
@@ -1728,7 +1729,7 @@ export async function processQueueItem(
 		}
 		// Every accepted Skill item is Agent+Project fenced above. The current
 		// item can now safely project the latest local bytes.
-		await uploadSkillFromQueue(opts, modules.skills.module, api, item, lastPushedHash, projectId);
+		await uploadSkillFromQueue(opts, skillDir, api, item, lastPushedHash, projectId);
 		// markDoneIfVersion — if a newer version of the same
 		// skill_key was enqueued while we were uploading, leave
 		// it in the queue so the next drain picks it up. The
@@ -1935,13 +1936,12 @@ async function uploadSessionFromQueue(
 
 async function uploadSkillFromQueue(
 	opts: EngineOpts,
-	skills: SkillModule,
+	dir: string,
 	api: ApiClient,
 	item: Extract<QueueItem, { kind: "skill_push" }>,
 	lastPushedHash: Map<string, string>,
 	projectId: string,
 ): Promise<void> {
-	const dir = join(skills.rootDir(), item.skill_key);
 	// Recompute the hash from the live directory at upload time
 	// rather than trusting `item.new_hash`. The watcher's hash
 	// could have aged out: enqueue stamps a hash, then the user
@@ -2233,7 +2233,7 @@ export async function reconcileAgentSkillProjection(input: {
 			enqueueMaterializedSkillClaimCleanup(opts, queue, skillKey);
 			continue;
 		}
-		const reserved = isReservedSkill(skills, skillKey);
+		const reserved = shouldIgnoreUserSkill(join(rootDir, skillKey), skillKey);
 		if (reserved || !localKeys.has(skillKey)) {
 			if (
 				claims.has(skillKey) ||
@@ -2402,17 +2402,6 @@ export function resolveOwningSkillKey(rootDir: string, pathFromRoot: string): st
 		cur = parent;
 	}
 	return null;
-}
-
-// Skill enumeration moved to `adapter.listSkillKeys()` —
-// Hermes nests skills under category dirs (`category/foo/SKILL.md`)
-// so a flat top-level walk silently dropped them; flat adapters
-// (Claude Code / Codex / OpenClaw) implement the same dotfile +
-// bundled-`clawdi` filtering inline. See base.ts AgentAdapter
-// docstring for the contract.
-
-function isReservedSkill(skills: SkillModule, skillKey: string): boolean {
-	return shouldIgnoreUserSkill(join(skills.rootDir(), skillKey), skillKey);
 }
 
 /** Heartbeat sender. Fires immediately on boot then every

--- a/packages/cli/src/serve/watcher.test.ts
+++ b/packages/cli/src/serve/watcher.test.ts
@@ -14,7 +14,7 @@ import { describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createDebouncedSkillChangeEmitter } from "./watcher";
+import { createDebouncedSkillChangeEmitter, watchSkills } from "./watcher";
 
 const SKILL_KEY_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/;
 
@@ -113,6 +113,56 @@ describe("createDebouncedSkillChangeEmitter", () => {
 
 		expect(seen).toEqual([]);
 	});
+});
+
+describe("skill inventory polling", () => {
+	it.each([false, true])(
+		"retains the last valid snapshot across failures (initial failure: %s)",
+		async (initialFailure) => {
+			const root = mkdtempSync(join(tmpdir(), "clawdi-skills-poll-"));
+			const abort = new AbortController();
+			const changed: string[] = [];
+			let inventoryChanges = 0;
+			const samples: Array<string[] | Error> = [
+				...(initialFailure ? [new Error("initial discovery failed")] : []),
+				["kept", "removed"],
+				new Error("discovery failed"),
+				["kept", "added"],
+			];
+			let sampleIndex = 0;
+			try {
+				await watchSkills(
+					{
+						rootDir: root,
+						abort: abort.signal,
+						forcePoll: true,
+						listSkillKeys: async () => {
+							const sample = samples[sampleIndex++];
+							if (sample instanceof Error) throw sample;
+							if (!sample) throw new Error("unexpected extra poll");
+							return sample;
+						},
+						onSkillChanged: (key) => changed.push(key),
+						onInventoryChanged: () => {
+							inventoryChanges++;
+							abort.abort();
+						},
+					},
+					async (ms) => {
+						expect(ms).toBe(30_000);
+						expect(changed).toEqual([]);
+						expect(inventoryChanges).toBe(0);
+					},
+				);
+				expect(sampleIndex).toBe(samples.length);
+				expect(changed).toEqual(["removed", "added"]);
+				expect(inventoryChanges).toBe(1);
+			} finally {
+				abort.abort();
+				rmSync(root, { recursive: true, force: true });
+			}
+		},
+	);
 });
 
 function sleep(ms: number): Promise<void> {

--- a/packages/cli/src/serve/watcher.ts
+++ b/packages/cli/src/serve/watcher.ts
@@ -81,10 +81,10 @@ interface Opts {
 	onInventoryChanged?: () => void;
 }
 
-export async function watchSkills(opts: Opts): Promise<void> {
+export async function watchSkills(opts: Opts, delay: typeof sleep = sleep): Promise<void> {
 	if (opts.forcePoll) {
 		log.info("watcher.mode", { mode: "poll", reason: "forced" });
-		await pollLoop(opts);
+		await pollLoop(opts, delay);
 		return;
 	}
 
@@ -95,7 +95,7 @@ export async function watchSkills(opts: Opts): Promise<void> {
 			error: toErrorMessage(e),
 			fallback: "poll",
 		});
-		await pollLoop(opts);
+		await pollLoop(opts, delay);
 	}
 }
 
@@ -328,21 +328,29 @@ async function watchEvents(opts: Opts): Promise<void> {
 
 /** Polling fallback. Walks `rootDir` every POLL_INTERVAL_MS and
  * compares per-skill mtime + size signatures. */
-async function pollLoop(opts: Opts): Promise<void> {
-	let prev = await snapshot(opts.rootDir, opts.listSkillKeys);
-	log.info("watcher.mode", { mode: "poll", root: opts.rootDir, skill_count: prev.size });
-
+async function pollLoop(opts: Opts, delay: typeof sleep): Promise<void> {
+	let prev: Map<string, string> | null = null;
 	while (!opts.abort.aborted) {
-		await sleep(POLL_INTERVAL_MS, opts.abort);
+		let next: Map<string, string> | null = null;
+		try {
+			next = await snapshot(opts.rootDir, opts.listSkillKeys);
+		} catch (error) {
+			log.warn("watcher.snapshot_failed", { error: toErrorMessage(error) });
+		}
 		if (opts.abort.aborted) return;
 
-		const next = await snapshot(opts.rootDir, opts.listSkillKeys);
-		const changed = diff(prev, next);
-		for (const key of changed) {
-			opts.onSkillChanged(key);
+		// Failed discovery is not an empty inventory; retain the last valid baseline.
+		if (next) {
+			if (prev) {
+				const changed = diff(prev, next);
+				for (const key of changed) opts.onSkillChanged(key);
+				if (changed.length > 0) opts.onInventoryChanged?.();
+			} else {
+				log.info("watcher.mode", { mode: "poll", root: opts.rootDir, skill_count: next.size });
+			}
+			prev = next;
 		}
-		if (changed.length > 0) opts.onInventoryChanged?.();
-		prev = next;
+		if (!opts.abort.aborted) await delay(POLL_INTERVAL_MS, opts.abort);
 	}
 }
 

--- a/packages/cli/tests/adapters/openclaw.test.ts
+++ b/packages/cli/tests/adapters/openclaw.test.ts
@@ -27,10 +27,18 @@ beforeEach(() => {
 	writeFileSync(
 		command,
 		`#!/bin/sh
+if [ -f "$HOME/.openclaw/command-log" ]; then
+  printf 'start:%s\n' "$1" >> "$HOME/.openclaw/command-log"
+  trap 'printf "end:%s\n" "$1" >> "$HOME/.openclaw/command-log"' EXIT
+fi
 if [ -f "$HOME/.openclaw/delay-$1" ]; then
   touch "$HOME/.openclaw/running-$1"
   sleep 0.2
   rm "$HOME/.openclaw/running-$1"
+fi
+if [ -f "$HOME/.openclaw/fail-once-$1" ]; then
+  rm "$HOME/.openclaw/fail-once-$1"
+  exit 1
 fi
 if [ "$*" = "sessions --json --all-agents --limit all" ] && [ -f "$HOME/.openclaw/legacy-inventory-test" ]; then
   printf '{"path":null,"stores":[{"agentId":"main","path":"%s/.openclaw/agents/main/sessions/sessions.json"}],"allAgents":true,"sessions":[{"agentId":"main","key":"agent:main:main","sessionId":"oc-session-001","updatedAt":1776247205000,"sessionFile":"%s/.openclaw/agents/main/sessions/oc-session-001.jsonl","model":"claude-opus-4-7","inputTokens":12,"outputTokens":6,"cacheRead":2,"displayName":"Fixture session","acp":{"cwd":"/Users/fixture/project","lastActivityAt":1776247205000}}]}\n' "$HOME" "$HOME"
@@ -164,6 +172,47 @@ describe("OpenClawAdapter.detect", () => {
 });
 
 describe("OpenClawAdapter.collectSessions", () => {
+	it.each(["none", "sessions", "gateway"])(
+		"serializes scan/resolve subprocesses (injected failure: %s)",
+		async (failingCommand) => {
+			const stateRoot = join(tmpHome, ".openclaw");
+			const commandLog = join(stateRoot, "command-log");
+			writeFileSync(commandLog, "");
+			writeFileSync(join(stateRoot, "sqlite-session-test"), "enabled");
+			for (const command of ["sessions", "gateway"]) {
+				writeFileSync(join(stateRoot, `delay-${command}`), "enabled");
+			}
+			if (failingCommand !== "none")
+				writeFileSync(join(stateRoot, `fail-once-${failingCommand}`), "enabled");
+
+			const adapter = new OpenClawAdapter();
+			await Promise.all([
+				adapter.sessions.scan({ kind: "complete" }, new Map()),
+				adapter.sessions.resolve("sqlite-session-001"),
+			]);
+			const recovered = await adapter.sessions.resolve("sqlite-session-001");
+			expect(recovered?.messages.map((message) => message.content)).toEqual([
+				"kept question",
+				"kept answer",
+			]);
+			if (failingCommand !== "none")
+				expect(existsSync(join(stateRoot, `fail-once-${failingCommand}`))).toBe(false);
+
+			const events = readFileSync(commandLog, "utf8").trim().split("\n");
+			expect(events.filter((event) => event === "start:sessions")).toHaveLength(3);
+			expect(events).toContain("start:gateway");
+			let active = 0;
+			let peak = 0;
+			for (const event of events) {
+				active += event.startsWith("start:") ? 1 : -1;
+				peak = Math.max(peak, active);
+				expect(active).toBeGreaterThanOrEqual(0);
+			}
+			expect(active).toBe(0);
+			expect(peak).toBe(1);
+		},
+	);
+
 	it.each(["sessions", "gateway"])(
 		"keeps the event loop responsive while %s is running",
 		async (command) => {

--- a/packages/cli/tests/adapters/openclaw.test.ts
+++ b/packages/cli/tests/adapters/openclaw.test.ts
@@ -172,24 +172,38 @@ describe("OpenClawAdapter.detect", () => {
 });
 
 describe("OpenClawAdapter.collectSessions", () => {
-	it.each(["none", "sessions", "gateway"])(
-		"serializes scan/resolve subprocesses (injected failure: %s)",
+	it.each(["none", "sessions", "gateway", "agents"])(
+		"serializes scan/resolve/roster subprocesses (injected failure: %s)",
 		async (failingCommand) => {
 			const stateRoot = join(tmpHome, ".openclaw");
 			const commandLog = join(stateRoot, "command-log");
 			writeFileSync(commandLog, "");
 			writeFileSync(join(stateRoot, "sqlite-session-test"), "enabled");
-			for (const command of ["sessions", "gateway"]) {
+			for (const command of ["sessions", "gateway", "agents"]) {
 				writeFileSync(join(stateRoot, `delay-${command}`), "enabled");
 			}
 			if (failingCommand !== "none")
 				writeFileSync(join(stateRoot, `fail-once-${failingCommand}`), "enabled");
 
 			const adapter = new OpenClawAdapter();
-			await Promise.all([
+			const [scan, resolution, skills] = await Promise.allSettled([
 				adapter.sessions.scan({ kind: "complete" }, new Map()),
 				adapter.sessions.resolve("sqlite-session-001"),
+				adapter.skills.listKeys(),
 			]);
+			expect(scan.status).toBe("fulfilled");
+			expect(resolution.status).toBe("fulfilled");
+			if (failingCommand === "agents") {
+				expect(skills).toMatchObject({
+					status: "rejected",
+					reason: {
+						message: "OpenClaw workspace resolution requires `openclaw agents list --json`",
+					},
+				});
+			} else {
+				expect(skills).toEqual({ status: "fulfilled", value: ["demo"] });
+			}
+			expect(await adapter.skills.listKeys()).toEqual(["demo"]);
 			const recovered = await adapter.sessions.resolve("sqlite-session-001");
 			expect(recovered?.messages.map((message) => message.content)).toEqual([
 				"kept question",
@@ -200,6 +214,7 @@ describe("OpenClawAdapter.collectSessions", () => {
 
 			const events = readFileSync(commandLog, "utf8").trim().split("\n");
 			expect(events.filter((event) => event === "start:sessions")).toHaveLength(3);
+			expect(events.filter((event) => event === "start:agents")).toHaveLength(2);
 			expect(events).toContain("start:gateway");
 			let active = 0;
 			let peak = 0;
@@ -213,7 +228,7 @@ describe("OpenClawAdapter.collectSessions", () => {
 		},
 	);
 
-	it.each(["sessions", "gateway"])(
+	it.each(["sessions", "gateway", "agents"])(
 		"keeps the event loop responsive while %s is running",
 		async (command) => {
 			const stateRoot = join(tmpHome, ".openclaw");
@@ -224,12 +239,17 @@ describe("OpenClawAdapter.collectSessions", () => {
 				observedRunning ||= existsSync(join(stateRoot, `running-${command}`));
 			}, 10);
 			try {
-				const { sessions } = await new OpenClawAdapter().sessions.collect({ kind: "complete" });
+				const adapter = new OpenClawAdapter();
+				if (command === "agents") {
+					expect(await adapter.skills.listKeys()).toEqual(["demo"]);
+				} else {
+					const { sessions } = await adapter.sessions.collect({ kind: "complete" });
+					expect(sessions[0]?.messages.map((message) => message.content)).toEqual([
+						"kept question",
+						"kept answer",
+					]);
+				}
 				expect(observedRunning).toBe(true);
-				expect(sessions[0]?.messages.map((message) => message.content)).toEqual([
-					"kept question",
-					"kept answer",
-				]);
 			} finally {
 				clearInterval(timer);
 			}
@@ -707,6 +727,18 @@ export async function readVisibleSessionTranscriptMessageEntries() {
 });
 
 describe("OpenClawAdapter.collectSkills", () => {
+	it("lists only the selected agent's Skills and rejects a missing agent", async () => {
+		addFinancialAgent(join(tmpHome, ".openclaw"));
+		const adapter = new OpenClawAdapter();
+		expect(await adapter.skills.listKeys()).toEqual(["demo"]);
+		process.env.OPENCLAW_AGENT_ID = " financial ";
+		expect(await adapter.skills.listKeys()).toEqual(["fin-skill"]);
+		process.env.OPENCLAW_AGENT_ID = "missing";
+		await expect(adapter.skills.listKeys()).rejects.toThrow(
+			"OpenClaw agent missing is not present in the official agent roster",
+		);
+	});
+
 	it("finds demo skill under agents/<id>/skills/ and skips SKIP_DIRS", async () => {
 		const a = new OpenClawAdapter();
 		const skills = await a.skills.collect();


### PR DESCRIPTION
## Summary
- Serialize asynchronous session, history, and skill-roster CLI reads through one failure-safe process slot while retaining event-loop responsiveness.
- Retain the last valid skill snapshot on polling failures, including failure before the first valid baseline, without producing false deletions.
- Reuse operation-local skill roots to remove repeated per-key discovery; keep workspace selection and validation shared between sync and async resolvers.

## Verification
- Isolated Docker fake HOME and fake OpenClaw: CLI typecheck and 118 focused tests passed.
- Biome checks and git diff --check passed.
- Root reviewed the actual implementation and regression-test diffs.

## Boundaries
- No cache, broad synchronous SkillModule API migration, or command environment/timeout/buffer changes.
- Startup discovery failures still fail closed; no unclassified retry or empty-inventory fallback.
- Synchronous discovery and other services remain outside the async slot. Queue wait is not part of the command execution timeout.
- No claim that all memory peaks are eliminated; real runtime validation remains a release gate.