### PR TITLE
refactor(web): consume authoritative subscription and power advice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ database migration, CI, and implementation details.
 - Managed runtimes accept released images' initial CLI bootstrap receipts
   without a spurious invalid-status warning. Adoption revalidates the installed
   CLI; malformed or unsafe state now stops instead of being overwritten.
+- Ending a hosted trial now shows subscription updates while the agent stops,
+  rather than waiting for payment. Expired checkouts can be retried, while
+  uncertain payment results retain the original request and provide support guidance.
+
 - OpenClaw sync serializes asynchronous discovery commands to reduce overlapping
   memory use. Skill polling survives inventory failures without reporting false
   deletions, and skill synchronization performs fewer workspace lookups.

--- a/apps/web/e2e/hosted-stub-api.ts
+++ b/apps/web/e2e/hosted-stub-api.ts
@@ -788,6 +788,7 @@ export type HostedApiStubOptions = {
 	planBillingCapability?: { enabled: boolean };
 	productAccessRequests?: string[];
 	cancelRequests?: string[];
+	cancelResponse?: DeployComponents["schemas"]["V2ComputeSubscriptionActionResponse"];
 	checkoutIdempotencyKeys?: string[];
 	checkoutRequests?: string[];
 	checkoutResponses?: StubResponse[];
@@ -820,7 +821,7 @@ export type HostedApiStubOptions = {
 	subscriptionPages?: Record<string, SubscriptionListResponse>;
 	subscriptionQuoteRequests?: string[];
 	subscriptionQuoteResponses?: unknown[];
-	startError?: { status: number; detail: string };
+	startError?: { status: number; detail: string; code?: string };
 	startRequests?: string[];
 	topUpIdempotencyKeys?: string[];
 	topUpRequests?: string[];
@@ -1102,13 +1103,16 @@ export async function stubHostedApi(page: Page, options: HostedApiStubOptions = 
 		}
 		if (p === "/v2/subscription/cancel" && r.request().method() === "POST") {
 			options.cancelRequests?.push(r.request().postData() ?? "");
-			return fulfillJson(r, {
-				status: "active",
-				billing_term_months: 12,
-				cancel_at_period_end: true,
-				current_period_end: "2026-08-15T00:00:00Z",
-				cancel_at: "2026-08-15T00:00:00Z",
-			});
+			return fulfillJson(
+				r,
+				options.cancelResponse ?? {
+					status: "active",
+					billing_term_months: 12,
+					cancel_at_period_end: true,
+					current_period_end: "2026-08-15T00:00:00Z",
+					cancel_at: "2026-08-15T00:00:00Z",
+				},
+			);
 		}
 		if (p === "/v2/subscription/resume" && r.request().method() === "POST") {
 			options.resumeRequests?.push(r.request().postData() ?? "");
@@ -1135,7 +1139,8 @@ export async function stubHostedApi(page: Page, options: HostedApiStubOptions = 
 		if (p.endsWith("/start") && r.request().method() === "POST") {
 			options.startRequests?.push(r.request().postData() ?? "");
 			if (options.startError) {
-				return fulfillJson(r, { detail: options.startError.detail }, options.startError.status);
+				const { status, ...body } = options.startError;
+				return fulfillJson(r, body, status);
 			}
 			return fulfillJson(r, { status: "starting" });
 		}

--- a/apps/web/e2e/hosted-stub-api.ts
+++ b/apps/web/e2e/hosted-stub-api.ts
@@ -249,8 +249,14 @@ export function mutationDeploymentReadFixture(
 					}
 			: null,
 		accepted_operation: null,
+		start_action: "start",
 		commercial_display: {
 			compute_subscription: deployment.compute_subscription ?? null,
+			recovery_action: deployment.compute_subscription?.funding_source
+				? (deployment.compute_subscription.recovery_action ?? null)
+				: fundingFact?.fact_kind === "funding_revoked"
+					? "start_new"
+					: null,
 			latest_funding_fact: fundingFact,
 		},
 		current_plan_slug: config.compute_plan_slug,
@@ -397,6 +403,7 @@ export const paidBasicDeployment = {
 		price_cents: 8_640,
 		currency: "usd",
 		cancel_at_period_end: false,
+		actions: { cancel: "cancel_at_period_end", resume: false, command_state: null },
 		current_period_end: "2027-07-15T00:00:00Z",
 	},
 } satisfies DeploymentMutationFixture;
@@ -546,9 +553,10 @@ export const walletActiveDeployment = {
 		price_cents: 900,
 		currency: "usd",
 		cancel_at_period_end: false,
+		actions: { cancel: "cancel_at_period_end", resume: false, command_state: null },
 		current_period_end: "2026-08-15T00:00:00Z",
 	},
-};
+} satisfies DeploymentMutationFixture;
 
 export const walletPastDueDeployment = {
 	...walletActiveDeployment,
@@ -556,6 +564,7 @@ export const walletPastDueDeployment = {
 		...walletActiveDeployment.compute_subscription,
 		status: "past_due",
 		payment_state: "past_due",
+		recovery_action: "top_up",
 		latest_failed_invoice_id: "in_wallet_open",
 		next_payment_attempt_at: "2026-07-16T00:00:00Z",
 	},
@@ -569,6 +578,7 @@ export const cardPastDueDeployment = {
 		...paidBasicDeployment.compute_subscription,
 		status: "past_due",
 		payment_state: "past_due",
+		recovery_action: "fix_payment",
 		latest_failed_invoice_id: "in_card_open",
 		latest_failed_invoice_hosted_url: null,
 		next_payment_attempt_at: "2026-07-16T00:00:00Z",
@@ -597,9 +607,10 @@ export const cancelPendingBasicDeployment = {
 	compute_subscription: {
 		...paidBasicDeployment.compute_subscription,
 		cancel_at_period_end: true,
+		actions: { cancel: null, resume: true, command_state: null },
 		cancel_at: "2027-07-15T00:00:00Z",
 	},
-};
+} satisfies DeploymentMutationFixture;
 
 export const walletAnnualDeployment = {
 	...paidBasicDeployment,

--- a/apps/web/e2e/hosted-subscription-power.pw.ts
+++ b/apps/web/e2e/hosted-subscription-power.pw.ts
@@ -18,6 +18,7 @@ for (const width of [1440, 320]) {
 		await page.setViewportSize({ width, height: 900 });
 		const errors = collectBrowserErrors(page);
 		const startRequests: string[] = [];
+		const checkoutIdempotencyKeys: string[] = [];
 		const deployment = {
 			...mutationDeploymentReadFixture({
 				...paidBasicDeployment,
@@ -36,6 +37,12 @@ for (const width of [1440, 320]) {
 			deployments: [deployment],
 			plans: [basicPlan, performancePlan],
 			startRequests,
+			checkoutIdempotencyKeys,
+			checkoutResponses: [
+				"checkout_reconciliation_required",
+				"checkout_attempt_expired",
+				"checkout_reconciliation_required",
+			].map((code) => ({ status: 409, body: { detail: { code, message: "provider_internal" } } })),
 		});
 		await page.goto("/agents");
 		await page.getByRole("link", { name: /^Open .*Status: Stopped$/ }).click();
@@ -72,6 +79,24 @@ for (const width of [1440, 320]) {
 			await page.keyboard.press("Escape");
 		}
 		expect(errors).toEqual([]);
+		if (width === 1440) {
+			await page.getByRole("button", { name: "Subscribe to start", exact: true }).click();
+			for (const message of ["Contact support", "This checkout has expired", "Contact support"]) {
+				await page.getByRole("button", { name: "Continue to card checkout" }).click();
+				await expect(page.locator("[data-sonner-toast]").last()).toContainText(message);
+				await expect(page.locator("[data-sonner-toast]").last()).not.toContainText(
+					"provider_internal",
+				);
+			}
+			expect(checkoutIdempotencyKeys).toHaveLength(3);
+			expect(checkoutIdempotencyKeys[0]).toBe(checkoutIdempotencyKeys[1]);
+			expect(checkoutIdempotencyKeys[1]).not.toBe(checkoutIdempotencyKeys[2]);
+			expect(errors).toEqual(
+				Array(3).fill(
+					"Failed to load resource: the server responded with a status of 409 (Conflict)",
+				),
+			);
+		}
 	});
 }
 
@@ -182,26 +207,31 @@ for (const status of ["trialing", "active"] as const) {
 	});
 }
 
-for (const width of [1440, 320]) {
-	for (const state of [
-		{
-			status: "incomplete",
-			blocked: "payment_pending",
-			start: "wait",
-			label: "Updating subscription",
-		},
-		{ status: "paused", blocked: "paused", start: "contact_support", label: "Contact support" },
-		{
-			status: "unpaid",
-			blocked: "authority_pending",
-			start: "contact_support",
-			label: "Contact support",
-		},
-		{ status: "canceled", blocked: null, start: "wait", label: "Updating subscription" },
-	] as const) {
+for (const state of [
+	{
+		status: "incomplete",
+		blocked: "payment_pending",
+		start: "wait",
+		label: "Updating subscription",
+	},
+	{ status: "paused", blocked: "paused", start: "contact_support", label: "Contact support" },
+	{
+		status: "unpaid",
+		blocked: "authority_pending",
+		start: "wait",
+		label: "Updating subscription",
+	},
+	{
+		status: "canceled",
+		blocked: "authority_pending",
+		start: "wait",
+		label: "Updating subscription",
+	},
+] as const) {
+	for (const width of state.status === "canceled" ? [1440, 320] : [1440]) {
 		test(`${state.status} does not sell a replacement or duplicate payment at ${width}px`, async ({
 			page,
-		}) => {
+		}, testInfo) => {
 			await page.setViewportSize({ width, height: 900 });
 			const startRequests: string[] = [];
 			const deployment = {
@@ -211,12 +241,10 @@ for (const width of [1440, 320]) {
 					compute_subscription: {
 						...paidBasicDeployment.compute_subscription,
 						status: state.status,
+						payment_state: state.status === "unpaid" ? "unpaid" : "ok",
 						recovery_action: null,
 						recovery_blocked_reason: state.blocked,
-						actions:
-							state.status === "canceled"
-								? { cancel: null, resume: false, command_state: "pending" }
-								: null,
+						actions: { cancel: null, resume: false, command_state: null },
 					},
 				}),
 				start_action: state.start,
@@ -234,6 +262,16 @@ for (const width of [1440, 320]) {
 				}),
 			).toHaveCount(0);
 			expect(startRequests).toEqual([]);
+			if (state.blocked === "authority_pending") {
+				await expect(
+					page.getByText(/Payment processing|Waiting for payment confirmation/),
+				).toHaveCount(0);
+				await page.getByRole("button", { name: state.label, exact: true }).scrollIntoViewIfNeeded();
+				await page.screenshot({
+					path: testInfo.outputPath(`subscription-updating-${width}.png`),
+					fullPage: true,
+				});
+			}
 			expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
 				width,
 			);

--- a/apps/web/e2e/hosted-subscription-power.pw.ts
+++ b/apps/web/e2e/hosted-subscription-power.pw.ts
@@ -19,6 +19,7 @@ for (const width of [1440, 320]) {
 		const errors = collectBrowserErrors(page);
 		const startRequests: string[] = [];
 		const checkoutIdempotencyKeys: string[] = [];
+		const checkoutRequests: string[] = [];
 		const deployment = {
 			...mutationDeploymentReadFixture({
 				...paidBasicDeployment,
@@ -38,10 +39,12 @@ for (const width of [1440, 320]) {
 			plans: [basicPlan, performancePlan],
 			startRequests,
 			checkoutIdempotencyKeys,
+			checkoutRequests,
 			checkoutResponses: [
 				"checkout_reconciliation_required",
 				"checkout_attempt_expired",
-				"checkout_reconciliation_required",
+				"checkout_attempt_expired",
+				"checkout_attempt_expired",
 			].map((code) => ({ status: 409, body: { detail: { code, message: "provider_internal" } } })),
 		});
 		await page.goto("/agents");
@@ -81,18 +84,27 @@ for (const width of [1440, 320]) {
 		expect(errors).toEqual([]);
 		if (width === 1440) {
 			await page.getByRole("button", { name: "Subscribe to start", exact: true }).click();
-			for (const message of ["Contact support", "This checkout has expired", "Contact support"]) {
+			for (const [message, requests] of [
+				["Contact support", 1],
+				["This checkout has expired", 3],
+			] as const) {
 				await page.getByRole("button", { name: "Continue to card checkout" }).click();
+				await expect.poll(() => checkoutRequests.length).toBe(requests);
 				await expect(page.locator("[data-sonner-toast]").last()).toContainText(message);
 				await expect(page.locator("[data-sonner-toast]").last()).not.toContainText(
 					"provider_internal",
 				);
 			}
-			expect(checkoutIdempotencyKeys).toHaveLength(3);
+			await page.getByRole("button", { name: "Continue to card checkout" }).click();
+			await expect(page).toHaveURL(/#mock-checkout$/);
+			expect(checkoutIdempotencyKeys).toHaveLength(5);
 			expect(checkoutIdempotencyKeys[0]).toBe(checkoutIdempotencyKeys[1]);
 			expect(checkoutIdempotencyKeys[1]).not.toBe(checkoutIdempotencyKeys[2]);
+			expect(checkoutIdempotencyKeys[2]).not.toBe(checkoutIdempotencyKeys[3]);
+			expect(checkoutIdempotencyKeys[3]).not.toBe(checkoutIdempotencyKeys[4]);
+			expect(new Set(checkoutRequests).size).toBe(1);
 			expect(errors).toEqual(
-				Array(3).fill(
+				Array(4).fill(
 					"Failed to load resource: the server responded with a status of 409 (Conflict)",
 				),
 			);
@@ -218,8 +230,8 @@ for (const state of [
 	{
 		status: "unpaid",
 		blocked: "authority_pending",
-		start: "wait",
-		label: "Updating subscription",
+		start: "contact_support",
+		label: "Contact support",
 	},
 	{
 		status: "canceled",

--- a/apps/web/e2e/hosted-subscription-power.pw.ts
+++ b/apps/web/e2e/hosted-subscription-power.pw.ts
@@ -80,13 +80,15 @@ test("a manually stopped paid agent still starts normally and explains a funding
 }) => {
 	const deployment = { ...paidBasicDeployment, status: "stopped" };
 	const startRequests: string[] = [];
-	await stubHostedApi(page, { deployments: [deployment], plans: [basicPlan, performancePlan] });
-	await page.route("**/v2/deployments/*/start", async (route) => {
-		startRequests.push(route.request().method());
-		await route.fulfill({
+	await stubHostedApi(page, {
+		deployments: [deployment],
+		plans: [basicPlan, performancePlan],
+		startRequests,
+		startError: {
 			status: 409,
-			json: { code: "funding_revoked_after_accept", detail: "Internal funding fence" },
-		});
+			code: "funding_revoked_after_accept",
+			detail: "Internal funding fence",
+		},
 	});
 	await gotoHostedAgentSettings(page, fixtureAgentId(deployment), "Basic");
 	await expect(page.getByRole("button", { name: "Subscribe to start" })).toHaveCount(0);
@@ -97,7 +99,7 @@ test("a manually stopped paid agent still starts normally and explains a funding
 	await expect(page.locator("[data-sonner-toast]")).not.toContainText(
 		/internal|another session|container|volume|disk/i,
 	);
-	expect(startRequests).toEqual(["POST"]);
+	expect(startRequests).toHaveLength(1);
 });
 
 for (const status of ["trialing", "active"] as const) {
@@ -117,19 +119,18 @@ for (const status of ["trialing", "active"] as const) {
 				},
 			},
 		};
-		const cancelRequests: unknown[] = [];
+		const cancelRequests: string[] = [];
 		const deleteRequests: unknown[] = [];
-		await stubHostedApi(page, { deployments: [deployment], plans: [basicPlan, performancePlan] });
-		await page.route("**/v2/subscription/cancel", async (route) => {
-			cancelRequests.push(route.request().postDataJSON());
-			await route.fulfill({
-				json: {
-					status: "canceled",
-					billing_term_months: 12,
-					cancel_at_period_end: false,
-					action_state: status === "trialing" ? "pending" : "reconciling",
-				},
-			});
+		await stubHostedApi(page, {
+			deployments: [deployment],
+			plans: [basicPlan, performancePlan],
+			cancelRequests,
+			cancelResponse: {
+				status: "canceled",
+				billing_term_months: 12,
+				cancel_at_period_end: false,
+				action_state: status === "trialing" ? "pending" : "reconciling",
+			},
 		});
 		await page.route(`**/v2/deployments/${deployment.id}`, async (route) => {
 			if (route.request().method() !== "DELETE") return route.fallback();
@@ -160,7 +161,9 @@ for (const status of ["trialing", "active"] as const) {
 		await expect(page.locator("[data-sonner-toast]")).not.toContainText(
 			/Subscription canceled|Cancellation scheduled|trial has ended/,
 		);
-		expect(cancelRequests).toEqual([{ deployment_id: deployment.id }]);
+		expect(cancelRequests.map((body) => JSON.parse(body))).toEqual([
+			{ deployment_id: deployment.id },
+		]);
 		expect(deleteRequests).toEqual([]);
 		await page.getByRole("button", { name: "Delete", exact: true }).click();
 		const deleteDialog = page.getByRole("alertdialog");
@@ -250,18 +253,17 @@ test("historical scheduled trial keeps its end date and offers an explicit immed
 			actions: { cancel: "end_trial" as const, resume: true, command_state: null },
 		},
 	};
-	const cancelRequests: unknown[] = [];
-	await stubHostedApi(page, { deployments: [deployment], plans: [basicPlan, performancePlan] });
-	await page.route("**/v2/subscription/cancel", async (route) => {
-		cancelRequests.push(route.request().postDataJSON());
-		await route.fulfill({
-			json: {
-				status: "canceled",
-				billing_term_months: 12,
-				cancel_at_period_end: false,
-				action_state: "pending",
-			},
-		});
+	const cancelRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [deployment],
+		plans: [basicPlan, performancePlan],
+		cancelRequests,
+		cancelResponse: {
+			status: "canceled",
+			billing_term_months: 12,
+			cancel_at_period_end: false,
+			action_state: "pending",
+		},
 	});
 	await gotoHostedAgentSettings(page, fixtureAgentId(deployment), "Basic");
 	await expect(page.getByRole("button", { name: "Keep subscription", exact: true })).toBeVisible();
@@ -273,7 +275,9 @@ test("historical scheduled trial keeps its end date and offers an explicit immed
 		.getByRole("alertdialog")
 		.getByRole("button", { name: "End trial now", exact: true })
 		.click();
-	expect(cancelRequests).toEqual([{ deployment_id: deployment.id }]);
+	expect(cancelRequests.map((body) => JSON.parse(body))).toEqual([
+		{ deployment_id: deployment.id },
+	]);
 	await expect(page.locator("[data-sonner-toast]")).toContainText(
 		"Cancellation is still processing",
 	);

--- a/apps/web/e2e/hosted-subscription-power.pw.ts
+++ b/apps/web/e2e/hosted-subscription-power.pw.ts
@@ -1,0 +1,160 @@
+import { expect, test } from "@playwright/test";
+import {
+	basicPlan,
+	collectBrowserErrors,
+	fixtureAgentId,
+	gotoHostedAgentSettings,
+	mutationDeploymentReadFixture,
+	paidBasicDeployment,
+	performancePlan,
+	stubHostedApi,
+} from "./hosted-stub-api";
+
+for (const width of [1440, 320]) {
+	test(`ended subscription power entries reuse subscription selection at ${width}px`, async ({
+		page,
+	}, testInfo) => {
+		test.setTimeout(120_000);
+		await page.setViewportSize({ width, height: 900 });
+		const errors = collectBrowserErrors(page);
+		const startRequests: string[] = [];
+		const deployment = {
+			...mutationDeploymentReadFixture({
+				...paidBasicDeployment,
+				status: "stopped",
+				compute_subscription: { ...paidBasicDeployment.compute_subscription, status: "canceled" },
+			}),
+			files_endpoint: { url: "https://files.example.test/" },
+		};
+		await stubHostedApi(page, {
+			deployments: [deployment],
+			plans: [basicPlan, performancePlan],
+			startRequests,
+		});
+		await page.goto("/agents");
+		await page.getByRole("link", { name: /^Open .*Status: Stopped$/ }).click();
+		await expect(page).toHaveURL(new RegExp(`/agents/${deployment.agent_id}$`));
+		for (const section of ["console", "files", "terminal", "channel-links", "settings"]) {
+			await page.goto(`/agents/${deployment.agent_id}/${section}`);
+			const start = page.getByRole("button", {
+				name: "Subscribe to start",
+				exact: true,
+			});
+			await expect(start).toBeVisible();
+			const startBox = await start.boundingBox();
+			expect(startBox).not.toBeNull();
+			expect(startBox?.x).toBeGreaterThanOrEqual(0);
+			expect((startBox?.x ?? 0) + (startBox?.width ?? 0)).toBeLessThanOrEqual(width);
+			await page.waitForLoadState("networkidle");
+			await start.click();
+			await expect(page.getByRole("dialog", { name: "Choose a paid subscription" })).toBeVisible();
+			expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+				width,
+			);
+			await expect(page.getByRole("dialog")).not.toContainText(/container|volume|disk/i);
+			await expect(
+				page.getByRole("dialog").getByRole("combobox", { name: "Compute plan" }),
+			).toBeVisible();
+			await expect(page.getByRole("button", { name: /^(Start|Start agent)$/ })).toHaveCount(0);
+			await expect.poll(() => startRequests.length).toBe(0);
+			if (section === "settings") {
+				await page.screenshot({
+					path: testInfo.outputPath(`subscribe-to-start-${width}.png`),
+					fullPage: true,
+				});
+			}
+			await page.keyboard.press("Escape");
+		}
+		expect(errors).toEqual([]);
+	});
+}
+
+test("a manually stopped paid agent still starts normally and explains a funding race", async ({
+	page,
+}) => {
+	const deployment = { ...paidBasicDeployment, status: "stopped" };
+	const startRequests: string[] = [];
+	await stubHostedApi(page, { deployments: [deployment], plans: [basicPlan, performancePlan] });
+	await page.route("**/v2/deployments/*/start", async (route) => {
+		startRequests.push(route.request().method());
+		await route.fulfill({
+			status: 409,
+			json: { code: "funding_revoked_after_accept", detail: "Internal funding fence" },
+		});
+	});
+	await gotoHostedAgentSettings(page, fixtureAgentId(deployment), "Basic");
+	await expect(page.getByRole("button", { name: "Subscribe to start" })).toHaveCount(0);
+	await page.getByRole("button", { name: "Start", exact: true }).click();
+	await expect(page.locator("[data-sonner-toast]")).toContainText(
+		"Open Agent settings and choose a subscription",
+	);
+	await expect(page.locator("[data-sonner-toast]")).not.toContainText(
+		/internal|another session|container|volume|disk/i,
+	);
+	expect(startRequests).toEqual(["POST"]);
+});
+
+for (const status of ["trialing", "active"] as const) {
+	test(`${status} cancellation keeps saved data and explicit Delete stays destructive`, async ({
+		page,
+	}) => {
+		const deployment = {
+			...paidBasicDeployment,
+			compute_subscription: { ...paidBasicDeployment.compute_subscription, status },
+		};
+		const cancelRequests: unknown[] = [];
+		const deleteRequests: unknown[] = [];
+		await stubHostedApi(page, { deployments: [deployment], plans: [basicPlan, performancePlan] });
+		await page.route("**/v2/subscription/cancel", async (route) => {
+			cancelRequests.push(route.request().postDataJSON());
+			await route.fulfill({
+				json: {
+					status: "canceled",
+					billing_term_months: 12,
+					cancel_at_period_end: false,
+					action_state: status === "trialing" ? "pending" : "reconciling",
+				},
+			});
+		});
+		await page.route(`**/v2/deployments/${deployment.id}`, async (route) => {
+			if (route.request().method() !== "DELETE") return route.fallback();
+			deleteRequests.push(route.request().postDataJSON());
+			await route.fulfill({ json: { deployment_id: deployment.id, status: "absent" } });
+		});
+		await gotoHostedAgentSettings(page, fixtureAgentId(deployment), "Basic");
+		await page.getByRole("button", { name: "Cancel subscription", exact: true }).click();
+		const cancelDialog = page.getByRole("alertdialog");
+		await expect(cancelDialog).toContainText("Your saved data is kept.");
+		await expect(cancelDialog).not.toContainText(/container|volume|disk|permanently delete/i);
+		await expect(cancelDialog).toContainText(
+			status === "trialing" ? "The trial ends immediately" : "The agent stops when the period ends",
+		);
+		await cancelDialog
+			.getByRole("button", {
+				name: status === "trialing" ? "End trial now" : "Cancel at period end",
+			})
+			.click();
+		await expect(page.locator("[data-sonner-toast]")).toContainText(
+			"Cancellation is still processing",
+		);
+		await expect(page.locator("[data-sonner-toast]")).not.toContainText(
+			/Subscription canceled|Cancellation scheduled|trial has ended/,
+		);
+		expect(cancelRequests).toEqual([{ deployment_id: deployment.id }]);
+		expect(deleteRequests).toEqual([]);
+		await page.getByRole("button", { name: "Delete", exact: true }).click();
+		const deleteDialog = page.getByRole("alertdialog");
+		await expect(deleteDialog).toContainText("permanently deletes the agent and its saved data");
+		await expect(deleteDialog).toContainText("can’t be undone");
+		await expect(deleteDialog).toContainText(
+			status === "trialing" ? "The trial ends immediately" : "remain active through",
+		);
+		await expect(deleteDialog).not.toContainText(/saved data is kept|container|volume|disk/i);
+		await deleteDialog
+			.getByRole("button", { name: "Delete agent and cancel subscription", exact: true })
+			.click();
+		await expect
+			.poll(() => deleteRequests)
+			.toEqual([{ subscription_choice: "cancel_subscription" }]);
+	});
+}

--- a/apps/web/e2e/hosted-subscription-power.pw.ts
+++ b/apps/web/e2e/hosted-subscription-power.pw.ts
@@ -22,8 +22,14 @@ for (const width of [1440, 320]) {
 			...mutationDeploymentReadFixture({
 				...paidBasicDeployment,
 				status: "stopped",
-				compute_subscription: { ...paidBasicDeployment.compute_subscription, status: "canceled" },
+				compute_subscription: {
+					...paidBasicDeployment.compute_subscription,
+					status: "canceled",
+					recovery_action: "start_new",
+					actions: null,
+				},
 			}),
+			start_action: "subscribe" as const,
 			files_endpoint: { url: "https://files.example.test/" },
 		};
 		await stubHostedApi(page, {
@@ -100,7 +106,16 @@ for (const status of ["trialing", "active"] as const) {
 	}) => {
 		const deployment = {
 			...paidBasicDeployment,
-			compute_subscription: { ...paidBasicDeployment.compute_subscription, status },
+			compute_subscription: {
+				...paidBasicDeployment.compute_subscription,
+				status,
+				actions: {
+					cancel:
+						status === "trialing" ? ("end_trial" as const) : ("cancel_at_period_end" as const),
+					resume: false,
+					command_state: null,
+				},
+			},
 		};
 		const cancelRequests: unknown[] = [];
 		const deleteRequests: unknown[] = [];
@@ -122,7 +137,12 @@ for (const status of ["trialing", "active"] as const) {
 			await route.fulfill({ json: { deployment_id: deployment.id, status: "absent" } });
 		});
 		await gotoHostedAgentSettings(page, fixtureAgentId(deployment), "Basic");
-		await page.getByRole("button", { name: "Cancel subscription", exact: true }).click();
+		await page
+			.getByRole("button", {
+				name: status === "trialing" ? "End trial now" : "Cancel subscription",
+				exact: true,
+			})
+			.click();
 		const cancelDialog = page.getByRole("alertdialog");
 		await expect(cancelDialog).toContainText("Your saved data is kept.");
 		await expect(cancelDialog).not.toContainText(/container|volume|disk|permanently delete/i);
@@ -158,3 +178,103 @@ for (const status of ["trialing", "active"] as const) {
 			.toEqual([{ subscription_choice: "cancel_subscription" }]);
 	});
 }
+
+for (const width of [1440, 320]) {
+	for (const state of [
+		{
+			status: "incomplete",
+			blocked: "payment_pending",
+			start: "wait",
+			label: "Updating subscription",
+		},
+		{ status: "paused", blocked: "paused", start: "contact_support", label: "Contact support" },
+		{
+			status: "unpaid",
+			blocked: "authority_pending",
+			start: "contact_support",
+			label: "Contact support",
+		},
+		{ status: "canceled", blocked: null, start: "wait", label: "Updating subscription" },
+	] as const) {
+		test(`${state.status} does not sell a replacement or duplicate payment at ${width}px`, async ({
+			page,
+		}) => {
+			await page.setViewportSize({ width, height: 900 });
+			const startRequests: string[] = [];
+			const deployment = {
+				...mutationDeploymentReadFixture({
+					...paidBasicDeployment,
+					status: "stopped",
+					compute_subscription: {
+						...paidBasicDeployment.compute_subscription,
+						status: state.status,
+						recovery_action: null,
+						recovery_blocked_reason: state.blocked,
+						actions:
+							state.status === "canceled"
+								? { cancel: null, resume: false, command_state: "pending" }
+								: null,
+					},
+				}),
+				start_action: state.start,
+			};
+			await stubHostedApi(page, {
+				deployments: [deployment],
+				plans: [basicPlan, performancePlan],
+				startRequests,
+			});
+			await gotoHostedAgentSettings(page, deployment.agent_id, "Basic");
+			await expect(page.getByRole("button", { name: state.label, exact: true })).toBeVisible();
+			await expect(
+				page.getByRole("button", {
+					name: /Subscribe to start|Fix payment|Start new subscription|Keep subscription/,
+				}),
+			).toHaveCount(0);
+			expect(startRequests).toEqual([]);
+			expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+				width,
+			);
+		});
+	}
+}
+
+test("historical scheduled trial keeps its end date and offers an explicit immediate end", async ({
+	page,
+}) => {
+	const deployment = {
+		...paidBasicDeployment,
+		compute_subscription: {
+			...paidBasicDeployment.compute_subscription,
+			status: "trialing",
+			cancel_at_period_end: true,
+			actions: { cancel: "end_trial" as const, resume: true, command_state: null },
+		},
+	};
+	const cancelRequests: unknown[] = [];
+	await stubHostedApi(page, { deployments: [deployment], plans: [basicPlan, performancePlan] });
+	await page.route("**/v2/subscription/cancel", async (route) => {
+		cancelRequests.push(route.request().postDataJSON());
+		await route.fulfill({
+			json: {
+				status: "canceled",
+				billing_term_months: 12,
+				cancel_at_period_end: false,
+				action_state: "pending",
+			},
+		});
+	});
+	await gotoHostedAgentSettings(page, fixtureAgentId(deployment), "Basic");
+	await expect(page.getByRole("button", { name: "Keep subscription", exact: true })).toBeVisible();
+	await expect(page.getByRole("button", { name: "End trial now", exact: true })).toBeVisible();
+	expect(cancelRequests).toEqual([]);
+	await page.getByRole("button", { name: "End trial now", exact: true }).click();
+	await expect(page.getByRole("alertdialog")).toContainText("Your saved data is kept");
+	await page
+		.getByRole("alertdialog")
+		.getByRole("button", { name: "End trial now", exact: true })
+		.click();
+	expect(cancelRequests).toEqual([{ deployment_id: deployment.id }]);
+	await expect(page.locator("[data-sonner-toast]")).toContainText(
+		"Cancellation is still processing",
+	);
+});

--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -319,7 +319,7 @@ async function expectAgentSettingsSectionsAligned(
 		"Avatar",
 		"Language & timezone",
 		"Compute plan",
-		"Lifecycle",
+		"Agent controls",
 		"Danger zone",
 	];
 	const boxes = await Promise.all(
@@ -974,7 +974,7 @@ test("agent settings uses compact canonical subscription management", async ({
 		.poll(() => scheduledPlanCancellationRequests.map((body) => JSON.parse(body)))
 		.toEqual([{ deployment_id: "hdep_scheduled_downgrade" }]);
 	await expect(
-		page.locator("[data-sonner-toast]").filter({ hasText: "Billing details are reconciling" }),
+		page.locator("[data-sonner-toast]").filter({ hasText: "Subscription details are updating" }),
 	).toBeVisible();
 	await expectCardsFit(page.locator("body"));
 

--- a/apps/web/e2e/hosted-subscriptions.pw.ts
+++ b/apps/web/e2e/hosted-subscriptions.pw.ts
@@ -130,6 +130,12 @@ function subscription(
 		plan_slug: "compute_performance",
 		funding_source: "stripe",
 		status,
+		lifecycle_status: status === "canceling" ? "active" : status,
+		actions: {
+			cancel: status === "active" || status === "past_due" ? "cancel_at_period_end" : null,
+			resume: status === "canceling",
+			command_state: null,
+		},
 		price_cents: 19_000,
 		currency: "usd",
 		billing_term_months: 12,
@@ -475,7 +481,6 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 						deployment_id: "hdep_deleted_stale_projection",
 						agent_name: "Stale deleted agent",
 						is_orphan: true,
-						recovery_action: "start_new",
 					}),
 					subscription("past_due", "past_due", {
 						plan_slug: "compute_basic",
@@ -590,7 +595,7 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 		name: "Cancel scheduled change",
 	});
 	await expect(cancelScheduledAccount).toBeEnabled();
-	await expect(cancelingCard.getByRole("button", { name: "Resume subscription" })).toHaveCount(0);
+	await expect(cancelingCard.getByRole("button", { name: "Keep subscription" })).toHaveCount(0);
 	await cancelScheduledAccount.click();
 	await expect
 		.poll(() => scheduledPlanCancellationRequests.map((body) => JSON.parse(body)))
@@ -785,6 +790,7 @@ test("subscription cards preserve pagination and reveal loaded history", async (
 test("agent settings uses compact canonical subscription management", async ({
 	page,
 }, testInfo) => {
+	test.setTimeout(120_000);
 	await page.setViewportSize({ width: 1440, height: 900 });
 	const errors = collectBrowserErrors(page);
 	const planQuoteRequests: string[] = [];
@@ -929,7 +935,7 @@ test("agent settings uses compact canonical subscription management", async ({
 		"warning",
 	);
 	await expect(cancelingCard.getByRole("button", { name: "Manage", exact: true })).toHaveCount(0);
-	await expect(cancelingCard.getByRole("button", { name: "Resume subscription" })).toBeEnabled();
+	await expect(cancelingCard.getByRole("button", { name: "Keep subscription" })).toBeEnabled();
 	await expectCardsFit(page.locator("body"));
 
 	await gotoHostedAgentSettings(page, fixtureAgentId(cardPastDueDeployment), "Basic");

--- a/apps/web/src/hosted/agents/deployment-delete-action.tsx
+++ b/apps/web/src/hosted/agents/deployment-delete-action.tsx
@@ -20,6 +20,7 @@ import { useDeleteDeployment } from "@/hosted/agents/deployment-hooks";
 import type { DeploymentDeleteRequest, HostedDeployment } from "@/hosted/billing/contracts";
 import {
 	computeFundingMode,
+	computeSubscriptionCancellationCopy,
 	isComputeSubscriptionRenewing,
 } from "@/hosted/billing/subscription/subscription-utils";
 import { formatShortDate } from "@/lib/format";
@@ -86,7 +87,11 @@ export function HostedDeploymentDeleteAction({
 	const keepDescription = `Keep subscription — it becomes available to choose for a future Agent.${
 		periodEnd === "—" ? "" : ` Valid through ${periodEnd}.`
 	}`;
-	const cancelDescription = `Stops at period end${periodEnd === "—" ? "." : ` on ${periodEnd}.`}`;
+	const cancelDescription = computeSubscriptionCancellationCopy({
+		isTrial: subscription?.status === "trialing",
+		periodEndLabel: periodEnd === "—" ? null : periodEnd,
+		hasRetainedDeployment: false,
+	}).description;
 
 	return (
 		<AlertDialog
@@ -102,7 +107,7 @@ export function HostedDeploymentDeleteAction({
 				<AlertDialogHeader>
 					<AlertDialogTitle>{`Delete ${name}?`}</AlertDialogTitle>
 					<AlertDialogDescription>
-						This permanently deletes the agent and releases its resources. This can’t be undone.
+						This permanently deletes the agent and its saved data. This can’t be undone.
 					</AlertDialogDescription>
 				</AlertDialogHeader>
 

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -140,7 +140,10 @@ import {
 	type CheckoutReturnNavigationTarget,
 	useCheckoutReturnHandler,
 } from "@/hosted/billing/checkout-return";
-import { computeDunningState } from "@/hosted/billing/components/compute-dunning.logic";
+import {
+	computeDunningState,
+	computeSubscriptionRequiredToStart,
+} from "@/hosted/billing/components/compute-dunning.logic";
 import { ComputeDunningBanner } from "@/hosted/billing/components/compute-dunning-banner";
 import type { DeploymentUpdateRequest, HostedDeployment } from "@/hosted/billing/contracts";
 import { navigateToAcceptedDeployment } from "@/hosted/billing/deploy/accepted-deployment-navigation";
@@ -401,19 +404,51 @@ function DeleteComputeAction({
 function StartComputeAction({
 	deployment,
 	label = "Start agent",
+	variant = "default",
+	disabled = false,
+	onSubscribe,
 }: {
 	deployment: HostedDeployment;
 	label?: string;
+	variant?: ComponentProps<typeof Button>["variant"];
+	disabled?: boolean;
+	onSubscribe?: () => void;
 }) {
 	const lifecycle = useDeploymentLifecycle();
 	const runAction = useActionLock();
 	const status = deploymentStatusFromResource(deployment.resource.status);
 	const canStart = canStartDeployment(status);
+	if (computeSubscriptionRequiredToStart(deployment)) {
+		return (
+			<Button
+				type="button"
+				size="sm"
+				variant={variant}
+				disabled={disabled || lifecycle.isPending || !canStart}
+				onClick={onSubscribe}
+				render={
+					onSubscribe ? undefined : (
+						<Link
+							to={agentSectionHref(deployment.agent_id, "settings", {
+								settings: "billing-plan",
+								subscription_action: "start_new",
+							})}
+						/>
+					)
+				}
+				nativeButton={Boolean(onSubscribe)}
+			>
+				<Plus className="size-3.5" />
+				Subscribe to start
+			</Button>
+		);
+	}
 	return (
 		<Button
 			type="button"
 			size="sm"
-			disabled={lifecycle.isPending || !canStart}
+			variant={variant}
+			disabled={disabled || lifecycle.isPending || !canStart}
 			onClick={() =>
 				void runAction(async () => {
 					await lifecycle.mutateAsync({ id: deployment.resource.id, action: "start" });
@@ -794,7 +829,11 @@ function StoppedAgentState({
 		<EmptyState
 			variant={variant}
 			title="Stopped"
-			description="This agent is stopped. Start it to use its tools again."
+			description={
+				computeSubscriptionRequiredToStart(deployment)
+					? "This agent is stopped. Choose a subscription to start it. Your saved data is kept."
+					: "This agent is stopped. Start it to use its tools again."
+			}
 			action={<StartComputeAction deployment={deployment} label="Start" />}
 		/>
 	);
@@ -3650,7 +3689,7 @@ function ComputeSettingsSections({
 	const subscriptionCancelPending = !!currentSubscription?.cancel_at_period_end;
 	const subscriptionCancellationCopy = computeSubscriptionCancellationCopy({
 		isTrial: currentSubscription?.status === "trialing",
-		periodEndLabel: subscriptionPeriodLabel,
+		periodEndLabel: subscriptionEndsAt ? subscriptionPeriodLabel : null,
 		hasRetainedDeployment: true,
 	});
 	const subscriptionLifecycle = currentSubscription
@@ -3752,7 +3791,12 @@ function ComputeSettingsSections({
 	useEffect(() => {
 		if (routeSearch.subscription_action !== "start_new") return;
 		if (hostedAccess.isLoading || plans.isLoading) return;
-		if (canOfferStartNew && hostedAccess.canCreateCloudAgents && (basicPlan || perfPlan)) {
+		if (
+			canOfferStartNew &&
+			!hasPendingComputeChange &&
+			hostedAccess.canCreateCloudAgents &&
+			(basicPlan || perfPlan)
+		) {
 			setSubscriptionCreateOpen(true);
 		}
 		void router.navigate({
@@ -3769,6 +3813,7 @@ function ComputeSettingsSections({
 	}, [
 		basicPlan,
 		canOfferStartNew,
+		hasPendingComputeChange,
 		hostedAccess.canCreateCloudAgents,
 		hostedAccess.isLoading,
 		perfPlan,
@@ -3843,6 +3888,7 @@ function ComputeSettingsSections({
 								confirmLabel: subscriptionCancellationCopy.confirmLabel,
 								successDescription: (result) =>
 									computeSubscriptionCancellationSuccessCopy({
+										isTrial: currentSubscription?.status === "trialing",
 										cancelAtPeriodEnd: result.cancel_at_period_end,
 										periodEndLabel: result.current_period_end
 											? formatShortDate(result.current_period_end)
@@ -3896,21 +3942,20 @@ function ComputeSettingsSections({
 							</Button>
 						</ConfirmAction>
 					) : (
-						<Button
+						<StartComputeAction
+							deployment={deployment}
+							label="Start"
 							variant="outline"
-							size="sm"
-							disabled={lifecycle.isPending || !canRunPrimaryLifecycleAction}
-							onClick={() =>
-								void runAction(() => runLifecycleAction(primaryLifecycleAction)).catch(
-									() => undefined,
-								)
+							disabled={
+								lifecycle.isPending ||
+								!canRunPrimaryLifecycleAction ||
+								(computeSubscriptionRequiredToStart(deployment) &&
+									(createUnavailableMessage !== null ||
+										hasPendingComputeChange ||
+										hostedAccess.isLoading))
 							}
-						>
-							{lifecycle.isPending && lifecycle.variables?.action === primaryLifecycleAction ? (
-								<Spinner className="size-3.5" />
-							) : null}
-							Start
-						</Button>
+							onSubscribe={() => setSubscriptionCreateOpen(true)}
+						/>
 					)}
 				</div>
 			</SettingsSection>
@@ -3924,7 +3969,7 @@ function ComputeSettingsSections({
 					<div>
 						<div className="text-sm font-medium">Delete this agent</div>
 						<p className="text-xs text-muted-foreground">
-							Deletes this agent and releases its resources. This can’t be undone.
+							Deletes this agent and its saved data. This can’t be undone.
 						</p>
 					</div>
 					<DeleteComputeAction

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -421,48 +421,35 @@ function StartComputeAction({
 	const status = deploymentStatusFromResource(deployment.resource.status);
 	const canStart = canStartDeployment(status);
 	const startAction = deployment.start_action;
-	if (computeSubscriptionRequiredToStart(deployment)) {
+	const needsSubscription = computeSubscriptionRequiredToStart(deployment);
+	if (needsSubscription || startAction === "fix_payment" || startAction === "top_up") {
+		const subscribe = needsSubscription ? onSubscribe : undefined;
+		const Icon = needsSubscription ? Plus : CreditCard;
 		return (
 			<Button
 				type="button"
 				size="sm"
 				variant={variant}
-				disabled={disabled || lifecycle.isPending || !canStart}
-				onClick={onSubscribe}
+				disabled={disabled || !canStart || (needsSubscription && lifecycle.isPending)}
+				onClick={subscribe}
 				render={
-					onSubscribe ? undefined : (
+					subscribe ? undefined : (
 						<Link
 							to={agentSectionHref(deployment.agent_id, "settings", {
 								settings: "billing-plan",
-								subscription_action: "start_new",
+								subscription_action: needsSubscription ? "start_new" : undefined,
 							})}
 						/>
 					)
 				}
-				nativeButton={Boolean(onSubscribe)}
+				nativeButton={Boolean(subscribe)}
 			>
-				<Plus className="size-3.5" />
-				Subscribe to start
-			</Button>
-		);
-	}
-	if (startAction === "fix_payment" || startAction === "top_up") {
-		return (
-			<Button
-				size="sm"
-				variant={variant}
-				disabled={disabled || !canStart}
-				render={
-					<Link
-						to={agentSectionHref(deployment.agent_id, "settings", {
-							settings: "billing-plan",
-						})}
-					/>
-				}
-				nativeButton={false}
-			>
-				<CreditCard className="size-3.5" />
-				{startAction === "top_up" ? "Top up to start" : "Pay to start"}
+				<Icon className="size-3.5" />
+				{needsSubscription
+					? "Subscribe to start"
+					: startAction === "top_up"
+						? "Top up to start"
+						: "Pay to start"}
 			</Button>
 		);
 	}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -9,11 +9,13 @@ import {
 	Check,
 	Copy,
 	Cpu,
+	CreditCard,
 	ExternalLink,
 	Eye,
 	EyeOff,
 	FolderOpen,
 	Info,
+	LifeBuoy,
 	Link2,
 	Link2Off,
 	type LucideIcon,
@@ -418,6 +420,7 @@ function StartComputeAction({
 	const runAction = useActionLock();
 	const status = deploymentStatusFromResource(deployment.resource.status);
 	const canStart = canStartDeployment(status);
+	const startAction = deployment.start_action;
 	if (computeSubscriptionRequiredToStart(deployment)) {
 		return (
 			<Button
@@ -440,6 +443,47 @@ function StartComputeAction({
 			>
 				<Plus className="size-3.5" />
 				Subscribe to start
+			</Button>
+		);
+	}
+	if (startAction === "fix_payment" || startAction === "top_up") {
+		return (
+			<Button
+				size="sm"
+				variant={variant}
+				disabled={disabled || !canStart}
+				render={
+					<Link
+						to={agentSectionHref(deployment.agent_id, "settings", {
+							settings: "billing-plan",
+						})}
+					/>
+				}
+				nativeButton={false}
+			>
+				<CreditCard className="size-3.5" />
+				{startAction === "top_up" ? "Top up to start" : "Pay to start"}
+			</Button>
+		);
+	}
+	if (startAction === "contact_support") {
+		return (
+			<Button
+				size="sm"
+				variant={variant}
+				disabled={disabled}
+				render={<a href="mailto:support@clawdi.ai" />}
+				nativeButton={false}
+			>
+				<LifeBuoy className="size-3.5" />
+				Contact support
+			</Button>
+		);
+	}
+	if (startAction !== "start") {
+		return (
+			<Button size="sm" variant={variant} disabled>
+				{startAction === "unavailable" ? "Start unavailable" : "Updating subscription"}
 			</Button>
 		);
 	}
@@ -832,7 +876,9 @@ function StoppedAgentState({
 			description={
 				computeSubscriptionRequiredToStart(deployment)
 					? "This agent is stopped. Choose a subscription to start it. Your saved data is kept."
-					: "This agent is stopped. Start it to use its tools again."
+					: deployment.start_action === "start"
+						? "This agent is stopped. Start it to use its tools again."
+						: "This agent is stopped. Your saved data is kept."
 			}
 			action={<StartComputeAction deployment={deployment} label="Start" />}
 		/>
@@ -3688,7 +3734,7 @@ function ComputeSettingsSections({
 	const subscriptionPeriodLabel = formatShortDate(subscriptionEndsAt);
 	const subscriptionCancelPending = !!currentSubscription?.cancel_at_period_end;
 	const subscriptionCancellationCopy = computeSubscriptionCancellationCopy({
-		isTrial: currentSubscription?.status === "trialing",
+		isTrial: currentSubscription?.actions?.cancel === "end_trial",
 		periodEndLabel: subscriptionEndsAt ? subscriptionPeriodLabel : null,
 		hasRetainedDeployment: true,
 	});
@@ -3777,6 +3823,7 @@ function ComputeSettingsSections({
 			paymentState: currentSubscription?.payment_state ?? "ok",
 			cancelAtPeriodEnd: subscriptionCancelPending,
 			pendingPlanSlug,
+			actions: currentSubscription?.actions,
 		},
 		management: computeManagement,
 		recoveryTarget: actionRecoveryTarget,
@@ -3888,7 +3935,7 @@ function ComputeSettingsSections({
 								confirmLabel: subscriptionCancellationCopy.confirmLabel,
 								successDescription: (result) =>
 									computeSubscriptionCancellationSuccessCopy({
-										isTrial: currentSubscription?.status === "trialing",
+										isTrial: currentSubscription?.actions?.cancel === "end_trial",
 										cancelAtPeriodEnd: result.cancel_at_period_end,
 										periodEndLabel: result.current_period_end
 											? formatShortDate(result.current_period_end)

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -785,6 +785,25 @@ describe("declarative deployment mutations", () => {
 		await expect(result).rejects.toThrow(DEPLOYMENT_CONFLICT_MESSAGE);
 	});
 
+	it("does not retry or wrap a start rejected for ended funding", async () => {
+		const requests: string[] = [];
+		const client = testClient(async (request) => {
+			const path = new URL(request.url).pathname;
+			requests.push(`${request.method} ${path}`);
+			if (request.method === "GET") {
+				return jsonResponse(hostedDeploymentFixture({ id: "hdep_ended", status: "stopped" }));
+			}
+			return jsonResponse({ code: "funding_revoked_after_accept" }, 409);
+		});
+		await expect(
+			client.setDeploymentDesiredState("hdep_ended", "running", "intent-start"),
+		).rejects.toBeInstanceOf(BillingApiError);
+		expect(requests).toEqual([
+			"GET /v2/deployments/hdep_ended",
+			"POST /v2/deployments/hdep_ended/start",
+		]);
+	});
+
 	it("reveals Runtime UI credentials against the displayed resource version", async () => {
 		const requests: Request[] = [];
 		const deployment = hostedDeploymentFixture({

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -240,7 +240,11 @@ function strongResourceEtag(resourceVersion: string): string {
 }
 
 function isPreconditionConflict(error: unknown): error is BillingApiError {
-	return error instanceof BillingApiError && (error.status === 409 || error.status === 412);
+	return (
+		error instanceof BillingApiError &&
+		(error.status === 409 || error.status === 412) &&
+		billingErrorDetail(error)?.code !== "funding_revoked_after_accept"
+	);
 }
 
 function isNotFound(error: unknown): error is BillingApiError {

--- a/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
+++ b/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
@@ -28,6 +28,7 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 					paymentState: state.paymentState,
 					cancelAtPeriodEnd: subscription?.cancel_at_period_end ?? false,
 					pendingPlanSlug: pendingComputePlanSlug(subscription),
+					actions: subscription?.actions,
 				},
 				management: { action: "hidden", target: null, unavailableReason: null },
 				recoveryTarget: state.recoveryTarget,

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
@@ -33,6 +33,7 @@ function deployment({
 		status,
 		currentPlanSlug,
 		computeSubscription,
+		recoveryAction: factKind === "funding_revoked" ? "start_new" : null,
 		fundingFact: factKind
 			? {
 					fact_kind: factKind,
@@ -107,7 +108,11 @@ describe("computeDunningState", () => {
 
 	test("routes card past due to payment remediation", () => {
 		const deploymentWithPastDueCard = deployment({
-			computeSubscription: subscription({ status: "past_due", payment_state: "past_due" }),
+			computeSubscription: subscription({
+				status: "past_due",
+				payment_state: "past_due",
+				recovery_action: "fix_payment",
+			}),
 			factKind: "funding_revoked",
 		});
 		expect(computeDunningState(deploymentWithPastDueCard)).toMatchObject({
@@ -122,6 +127,7 @@ describe("computeDunningState", () => {
 				computeSubscription: subscription({
 					status: "past_due",
 					payment_state: "requires_action",
+					recovery_action: "fix_payment",
 					latest_failed_invoice_hosted_url: "https://invoice.stripe.test/action",
 				}),
 			}),
@@ -144,6 +150,7 @@ describe("computeDunningState", () => {
 					status: "past_due",
 					payment_state: "requires_action",
 					pending_plan_slug: "compute_basic",
+					recovery_action: "fix_payment",
 				}),
 				currentPlanSlug: "compute_performance",
 			}),
@@ -152,7 +159,7 @@ describe("computeDunningState", () => {
 		expect(state?.recoveryPlanSlug).toBe("compute_basic");
 	});
 
-	test("presents every terminal rail as a new subscription", () => {
+	test("presents backend-finalized recovery on both payment rails", () => {
 		for (const fundingSource of ["stripe", "wallet"] as const) {
 			const state = computeDunningState(
 				deployment({
@@ -160,6 +167,7 @@ describe("computeDunningState", () => {
 						status: "unpaid",
 						funding_source: fundingSource,
 						payment_state: "unpaid",
+						recovery_action: "start_new",
 					}),
 					currentPlanSlug: "compute_basic",
 				}),
@@ -292,49 +300,17 @@ describe("computeDunningState", () => {
 	});
 });
 
-test("stopped power controls require a subscription only for known terminal entitlement", () => {
-	for (const status of [
-		"canceled",
-		"expired",
-		"incomplete",
-		"incomplete_expired",
-		"paused",
-		"unpaid",
-	]) {
-		expect(
-			computeSubscriptionRequiredToStart(
-				deployment({
-					status: "stopped",
-					computeSubscription: subscription({ status }),
-				}),
-			),
-			status,
-		).toBe(true);
+test("power controls use the backend start decision", () => {
+	expect(computeSubscriptionRequiredToStart({ start_action: "subscribe" })).toBe(true);
+	for (const start_action of [
+		"start",
+		"fix_payment",
+		"top_up",
+		"wait",
+		"contact_support",
+		"unavailable",
+		null,
+	] as const) {
+		expect(computeSubscriptionRequiredToStart({ start_action })).toBe(false);
 	}
-	for (const status of ["active", "trialing", "canceling", "past_due"]) {
-		expect(
-			computeSubscriptionRequiredToStart(
-				deployment({
-					status: "stopped",
-					computeSubscription: subscription({ status, cancel_at_period_end: true }),
-				}),
-			),
-			status,
-		).toBe(false);
-	}
-	expect(computeSubscriptionRequiredToStart(deployment({ status: "stopped" }))).toBe(false);
-	expect(
-		computeSubscriptionRequiredToStart(
-			deployment({ status: "stopped", factKind: "funding_revoked" }),
-		),
-	).toBe(true);
-	expect(
-		computeSubscriptionRequiredToStart(
-			deployment({
-				status: "stopped",
-				factKind: "funding_revoked",
-				computeSubscription: includedSubscription(),
-			}),
-		),
-	).toBe(false);
 });

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
@@ -6,7 +6,11 @@ import type {
 	HostedFundingFact,
 } from "@/hosted/billing/contracts";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
-import { computeDunningState, fallbackReasonSentence } from "./compute-dunning.logic";
+import {
+	computeDunningState,
+	computeSubscriptionRequiredToStart,
+	fallbackReasonSentence,
+} from "./compute-dunning.logic";
 
 function deployment({
 	computeSubscription = null,
@@ -165,7 +169,7 @@ describe("computeDunningState", () => {
 				recoveryTarget: { kind: "start_new", action: "start_new" },
 				tone: "destructive",
 			});
-			expect(state?.description).toContain("Start a new subscription");
+			expect(state?.description).toContain("Choose a subscription");
 		}
 	});
 
@@ -197,7 +201,7 @@ describe("computeDunningState", () => {
 				status: "stopped",
 			}),
 		);
-		expect(stopped?.description).toContain("No included Basic entitlement was available");
+		expect(stopped?.description).toContain("You can start it on included Basic");
 
 		const unavailable = computeDunningState(
 			deployment({
@@ -206,14 +210,14 @@ describe("computeDunningState", () => {
 				status: null,
 			}),
 		);
-		expect(unavailable?.description).toContain(
-			"can’t determine whether this agent stopped or is using included Basic",
-		);
+		expect(unavailable?.description).toContain("current status is unavailable");
 		expect(unavailable?.description).not.toContain("is now using included Basic");
 	});
 
-	test("does not recover a detached or already recovered subscription", () => {
-		expect(computeDunningState(deployment({ factKind: "funding_revoked" }))).toBeNull();
+	test("recovers revoked funding even without a subscription, but not an active replacement", () => {
+		expect(
+			computeDunningState(deployment({ factKind: "funding_revoked" }))?.recoveryTarget.kind,
+		).toBe("start_new");
 		expect(
 			computeDunningState(
 				deployment({
@@ -286,4 +290,51 @@ describe("computeDunningState", () => {
 			"changed by an administrator",
 		);
 	});
+});
+
+test("stopped power controls require a subscription only for known terminal entitlement", () => {
+	for (const status of [
+		"canceled",
+		"expired",
+		"incomplete",
+		"incomplete_expired",
+		"paused",
+		"unpaid",
+	]) {
+		expect(
+			computeSubscriptionRequiredToStart(
+				deployment({
+					status: "stopped",
+					computeSubscription: subscription({ status }),
+				}),
+			),
+			status,
+		).toBe(true);
+	}
+	for (const status of ["active", "trialing", "canceling", "past_due"]) {
+		expect(
+			computeSubscriptionRequiredToStart(
+				deployment({
+					status: "stopped",
+					computeSubscription: subscription({ status, cancel_at_period_end: true }),
+				}),
+			),
+			status,
+		).toBe(false);
+	}
+	expect(computeSubscriptionRequiredToStart(deployment({ status: "stopped" }))).toBe(false);
+	expect(
+		computeSubscriptionRequiredToStart(
+			deployment({ status: "stopped", factKind: "funding_revoked" }),
+		),
+	).toBe(true);
+	expect(
+		computeSubscriptionRequiredToStart(
+			deployment({
+				status: "stopped",
+				factKind: "funding_revoked",
+				computeSubscription: includedSubscription(),
+			}),
+		),
+	).toBe(false);
 });

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
@@ -67,6 +67,7 @@ function recoveryPlanSlugFor(
 
 function detachedFallbackState(deployment: DunningDeployment): ComputeDunningState | null {
 	const fallback = deployment.commercial_display?.latest_funding_fact;
+	if (deployment.commercial_display?.recovery_action !== "start_new") return null;
 	if (fallback?.fact_kind !== "funding_revoked") return null;
 	if (!fallback.reason || !fallback.funding_source) return null;
 	const recoveryPlanSlug = recoveryPlanSlugFor(deployment);
@@ -209,14 +210,8 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 	};
 }
 
-export function computeSubscriptionRequiredToStart(deployment: DunningDeployment): boolean {
-	const subscription = deployment.commercial_display?.compute_subscription;
-	if (
-		subscription &&
-		isIncludedBasicSubscription(deployment.current_plan_slug, subscription) &&
-		computeSubscriptionRecoveryTarget(subscription) === null
-	) {
-		return false;
-	}
-	return computeDunningState(deployment)?.recoveryTarget.kind === "start_new";
+export function computeSubscriptionRequiredToStart(
+	deployment: Pick<HostedDeployment, "start_action">,
+): boolean {
+	return deployment.start_action === "subscribe";
 }

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
@@ -76,6 +76,10 @@ function detachedFallbackState(deployment: DunningDeployment): ComputeDunningSta
 	const deploymentStatus = deploymentStatusFromResource(deployment.resource.status);
 	const stopped = deploymentStatus.kind === "stopped";
 	const statusUnavailable = !deploymentStatus.known;
+	const includedBasic = isIncludedBasicSubscription(
+		deployment.current_plan_slug,
+		deployment.commercial_display?.compute_subscription,
+	);
 	const presentation = (() => {
 		switch (fallback.reason) {
 			case "payment_failure":
@@ -117,10 +121,14 @@ function detachedFallbackState(deployment: DunningDeployment): ComputeDunningSta
 		fundingSource: fallback.funding_source,
 		recoveryTarget: { kind: "start_new", action: "start_new" },
 		description: statusUnavailable
-			? "We can’t determine whether this agent stopped or is using included Basic because its current status is unavailable. Start a new subscription to restore paid compute."
+			? "The agent’s current status is unavailable. Check again in a moment. Your saved data is kept."
 			: stopped
-				? "No included Basic entitlement was available, so this agent stopped. Start a new subscription to restore paid compute."
-				: "This agent is now using included Basic. Start a new subscription to restore paid compute.",
+				? includedBasic
+					? "This agent is stopped. You can start it on included Basic or choose a paid subscription. Your saved data is kept."
+					: "This agent is stopped. Choose a subscription to start it. Your saved data is kept."
+				: includedBasic
+					? "This agent is now using included Basic. Start a new subscription to restore paid compute."
+					: "This subscription ended. Choose a subscription to use this agent again. Your saved data is kept.",
 		fallbackOccurredAt: fallback.occurred_at,
 		fallbackPlanLabel,
 		fallbackReason: fallback.reason,
@@ -131,11 +139,13 @@ function detachedFallbackState(deployment: DunningDeployment): ComputeDunningSta
 export function computeDunningState(deployment: DunningDeployment): ComputeDunningState | null {
 	const subscription = deployment.commercial_display?.compute_subscription ?? null;
 	const fallbackState = detachedFallbackState(deployment);
-	if (fallbackState && isIncludedBasicSubscription(deployment.current_plan_slug, subscription)) {
+	if (
+		fallbackState &&
+		(!subscription || isIncludedBasicSubscription(deployment.current_plan_slug, subscription))
+	) {
 		return fallbackState;
 	}
 	if (!subscription) return null;
-	if (subscription.payment_state === "ok") return null;
 	const recoveryTarget = computeSubscriptionRecoveryTarget(subscription);
 	if (!recoveryTarget) return null;
 
@@ -153,7 +163,7 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 		secondaryTarget: null,
 	};
 
-	if (subscription.payment_state === "unpaid") {
+	if (recoveryTarget.kind === "start_new") {
 		return {
 			...common,
 			paymentState: "unpaid",
@@ -161,9 +171,10 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 			tone: "destructive",
 			title: "Compute subscription ended",
 			description:
-				"This paid subscription ended. Start a new subscription for this agent to restore paid compute.",
+				"This subscription is no longer active. Choose a subscription to start this agent. Your saved data is kept.",
 		};
 	}
+	if (subscription.payment_state === "ok") return null;
 
 	if (subscription.payment_state === "requires_action") {
 		return {
@@ -196,4 +207,16 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 		title: "Payment past due",
 		description: "Update the card payment method for the open invoice.",
 	};
+}
+
+export function computeSubscriptionRequiredToStart(deployment: DunningDeployment): boolean {
+	const subscription = deployment.commercial_display?.compute_subscription;
+	if (
+		subscription &&
+		isIncludedBasicSubscription(deployment.current_plan_slug, subscription) &&
+		computeSubscriptionRecoveryTarget(subscription) === null
+	) {
+		return false;
+	}
+	return computeDunningState(deployment)?.recoveryTarget.kind === "start_new";
 }

--- a/apps/web/src/hosted/billing/errors.ts
+++ b/apps/web/src/hosted/billing/errors.ts
@@ -411,6 +411,18 @@ export function normalizeBillingError(error: unknown): string {
 		if (code === "idempotency_key_reused") {
 			return "This request conflicts with an earlier submission. Review the details and try again.";
 		}
+		if (code === "checkout_attempt_expired") {
+			return "This checkout has expired. Try again to open a new checkout.";
+		}
+		if (code === "checkout_payment_pending") {
+			return "Your subscription is updating. Please check again shortly.";
+		}
+		if (code === "checkout_reconciliation_required") {
+			return "We could not confirm your previous checkout. Contact support before starting another payment.";
+		}
+		if (code === "checkout_target_reserved") {
+			return "A checkout is already open for this agent. Continue with the same subscription choice.";
+		}
 		if (typeof code === "string") {
 			return "The billing request could not be completed. Refresh and try again.";
 		}

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -394,6 +394,30 @@ describe("refreshCheckoutReturnQueries", () => {
 });
 
 describe("billingRecoveryRefetchIntervalFor", () => {
+	test("refreshes start advice while replacement funding is pending", () => {
+		const waiting = hostedDeploymentFixture({
+			status: "stopped",
+			startAction: "wait",
+			computeSubscription: {
+				status: "canceled",
+				payment_state: "ok",
+				billing_term_months: 1,
+				currency: "usd",
+				cancel_at_period_end: false,
+				recovery_action: "start_new",
+			},
+		});
+		for (const snapshot of [waiting, { ...waiting, commercial_display: {} }]) {
+			expect(billingRecoveryRefetchIntervalFor([snapshot], waiting.agent_id)).toBe(30_000);
+		}
+		expect(
+			billingRecoveryRefetchIntervalFor(
+				[{ ...waiting, start_action: "subscribe" }],
+				waiting.agent_id,
+			),
+		).toBe(false);
+	});
+
 	test("keeps foreground reads active while commands or payments are pending", () => {
 		for (const fields of [
 			{ actions: { cancel: null, resume: false, command_state: "pending" as const } },

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -161,6 +161,25 @@ describe("applyDeploymentSubscriptionResult", () => {
 });
 
 describe("applySubscriptionActionSuccess", () => {
+	test("pending subscription actions invalidate inventory without projecting success", async () => {
+		for (const action_state of ["pending", "reconciling"] as const) {
+			const qc = new QueryClient();
+			const previous = [hostedDeploymentFixture({ id: "dep_123" })];
+			qc.setQueryData(billingKeys.deployments, previous);
+			await applySubscriptionActionSuccess(
+				qc,
+				{ deployment_id: "dep_123" },
+				{
+					...subscriptionAction(true),
+					action_state,
+				},
+			);
+			expect(qc.getQueryData<HostedDeployment[]>(billingKeys.deployments)).toBe(previous);
+			expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(true);
+			qc.clear();
+		}
+	});
+
 	test("invalidates every compute subscription inventory after an action", async () => {
 		const qc = new QueryClient();
 		qc.setQueryData(billingKeys.deployments, { current: true });

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -147,6 +147,8 @@ describe("applyDeploymentSubscriptionResult", () => {
 		let patched = qc.getQueryData<HostedDeployment[]>(billingKeys.deployments);
 		expect(patched?.[0]?.commercial_display?.compute_subscription?.cancel_at_period_end).toBe(true);
 		expect(patched?.[0]?.commercial_display?.compute_subscription?.billing_term_months).toBe(12);
+		expect(patched?.[0]?.commercial_display?.compute_subscription?.actions).toBeNull();
+		expect(patched?.[0]?.start_action).toBeNull();
 		expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(false);
 
 		applyDeploymentSubscriptionResult(qc, "dep_123", subscriptionAction(false));
@@ -392,6 +394,23 @@ describe("refreshCheckoutReturnQueries", () => {
 });
 
 describe("billingRecoveryRefetchIntervalFor", () => {
+	test("keeps foreground reads active while commands or payments are pending", () => {
+		for (const fields of [
+			{ actions: { cancel: null, resume: false, command_state: "pending" as const } },
+			{ actions: { cancel: null, resume: false, command_state: "reconciling" as const } },
+			{ recovery_blocked_reason: "payment_pending" as const },
+		]) {
+			const pending = deployment({
+				status: "active",
+				billing_term_months: 1,
+				payment_state: "ok",
+				currency: "usd",
+				cancel_at_period_end: false,
+				...fields,
+			});
+			expect(billingRecoveryRefetchIntervalFor([pending], pending.resource.id)).toBe(30_000);
+		}
+	});
 	test("polls only the visible past-due deployment", () => {
 		const due = deployment(
 			{

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -31,6 +31,7 @@ import {
 	subscriptionCreateQuoteRequest,
 	subscriptionCreateQuoteView,
 } from "@/hosted/billing/subscription/subscription-create-adapter";
+import { isComputeSubscriptionActionUnconfirmed } from "@/hosted/billing/subscription/subscription-utils";
 import {
 	deploymentPollingState,
 	deploymentStatusFromResource,
@@ -127,7 +128,7 @@ export async function applySubscriptionActionSuccess(
 	body: ComputeSubscriptionCancelRequest | ComputeSubscriptionResumeRequest,
 	next: ComputeSubscriptionActionResult,
 ): Promise<void> {
-	if (body.deployment_id) {
+	if (body.deployment_id && !isComputeSubscriptionActionUnconfirmed(next)) {
 		applyDeploymentSubscriptionResult(qc, body.deployment_id, next);
 	}
 	await invalidateComputeSubscriptionInventory(qc);

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -46,17 +46,13 @@ function subscriptionFromAction(
 	previous: HostedComputeSubscription | null | undefined,
 	next: ComputeSubscriptionActionResult,
 ): HostedComputeSubscription {
-	const paymentState =
-		next.status === "past_due"
-			? (previous?.payment_state ?? "past_due")
-			: next.status === "unpaid"
-				? "unpaid"
-				: "ok";
 	return {
 		...(previous ?? {}),
+		actions: null,
+		recovery_action: next.recovery_action,
 		funding_source: next.funding_source ?? previous?.funding_source ?? "stripe",
 		status: next.status,
-		payment_state: paymentState,
+		payment_state: previous?.payment_state ?? "ok",
 		billing_term_months: next.billing_term_months,
 		currency: previous?.currency ?? "usd",
 		cancel_at_period_end: next.cancel_at_period_end,
@@ -66,12 +62,6 @@ function subscriptionFromAction(
 				: next.pending_plan_slug,
 		current_period_end: next.current_period_end ?? previous?.current_period_end ?? null,
 		cancel_at: next.cancel_at ?? null,
-		latest_failed_invoice_id:
-			paymentState === "ok" ? null : (previous?.latest_failed_invoice_id ?? null),
-		latest_failed_invoice_hosted_url:
-			paymentState === "ok" ? null : (previous?.latest_failed_invoice_hosted_url ?? null),
-		next_payment_attempt_at:
-			paymentState === "ok" ? null : (previous?.next_payment_attempt_at ?? null),
 	};
 }
 
@@ -87,6 +77,7 @@ function patchDeploymentSubscription(
 		patched = true;
 		return {
 			...deployment,
+			start_action: null,
 			commercial_display: {
 				...(deployment.commercial_display ?? {}),
 				compute_subscription: subscriptionFromAction(
@@ -206,6 +197,17 @@ export function useSubscriptions() {
 		getNextPageParam: billingNextPageParam,
 		enabled: isDeployApiConfigured(),
 		retry: billingQueryRetry,
+		refetchIntervalInBackground: false,
+		refetchInterval: (query) =>
+			query.state.data?.pages.some((page) =>
+				page.items?.some(
+					(subscription) =>
+						subscription.actions?.command_state != null ||
+						subscription.recovery_blocked_reason === "payment_pending",
+				),
+			)
+				? BILLING_RECOVERY_POLL_INTERVAL_MS
+				: false,
 	});
 }
 
@@ -437,7 +439,9 @@ export function billingRecoveryRefetchIntervalFor(
 	const subscription = deployment?.commercial_display?.compute_subscription;
 	if (!subscription) return false;
 	return subscription.payment_state === "past_due" ||
-		subscription.payment_state === "requires_action"
+		subscription.payment_state === "requires_action" ||
+		subscription.actions?.command_state != null ||
+		subscription.recovery_blocked_reason === "payment_pending"
 		? BILLING_RECOVERY_POLL_INTERVAL_MS
 		: false;
 }
@@ -472,9 +476,9 @@ export function useHostedDeployments({
 				q.state.data,
 				pollBillingRecoveryFor,
 			);
-			return eventStreamFallbackInterval(
-				shortestRefetchInterval(inventoryInterval, billingInterval),
-				eventStreamActive,
+			return shortestRefetchInterval(
+				eventStreamFallbackInterval(inventoryInterval, eventStreamActive),
+				billingInterval,
 			);
 		},
 		...HOSTED_DEPLOYMENTS_REFRESH_POLICY,

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -436,6 +436,7 @@ export function billingRecoveryRefetchIntervalFor(
 			candidate.resource.id.toLowerCase() === target || candidate.agent_id.toLowerCase() === target;
 		return matchesTarget;
 	});
+	if (deployment?.start_action === "wait") return BILLING_RECOVERY_POLL_INTERVAL_MS;
 	const subscription = deployment?.commercial_display?.compute_subscription;
 	if (!subscription) return false;
 	return subscription.payment_state === "past_due" ||

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-action-list.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-action-list.tsx
@@ -22,6 +22,7 @@ import {
 	ComputeSubscriptionRecoveryAction,
 	type ComputeSubscriptionStartNewAction,
 } from "@/hosted/billing/subscription/compute-subscription-recovery-action";
+import { isComputeSubscriptionActionUnconfirmed } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 
 export type ComputeSubscriptionActionTarget =
@@ -65,9 +66,9 @@ export function scheduledPlanCancellationNotice(result: ComputeSubscriptionActio
 		case "reconciling":
 			return {
 				kind: "info",
-				title: "Billing details are reconciling",
+				title: "Subscription details are updating",
 				description:
-					"The cancellation was accepted, but subscription details are still reconciling. Refresh in a moment.",
+					"The cancellation was accepted, but subscription details are still updating. Check again in a moment.",
 			};
 		default:
 			return {
@@ -76,6 +77,34 @@ export function scheduledPlanCancellationNotice(result: ComputeSubscriptionActio
 				description: "Refresh the subscription details before trying again.",
 			};
 	}
+}
+
+export function subscriptionMutationNotice(
+	result: ComputeSubscriptionActionResult,
+	action: "cancel" | "resume",
+	successDescription?: string,
+): { kind: "success" | "info"; title: string; description?: string } {
+	const confirmed =
+		action === "cancel"
+			? result.cancel_at_period_end || result.status === "canceled"
+			: !result.cancel_at_period_end && ["active", "trialing", "past_due"].includes(result.status);
+	if (isComputeSubscriptionActionUnconfirmed(result) || !confirmed) {
+		return {
+			kind: "info",
+			title: action === "cancel" ? "Cancellation is still processing" : "Renewal is still updating",
+			description: "Check the latest subscription details in a moment before trying again.",
+		};
+	}
+	return {
+		kind: "success",
+		title:
+			action === "resume"
+				? "Subscription resumed"
+				: result.cancel_at_period_end
+					? "Cancellation scheduled"
+					: "Subscription canceled",
+		description: successDescription,
+	};
 }
 
 export function ComputeSubscriptionActionList({
@@ -111,10 +140,12 @@ export function ComputeSubscriptionActionList({
 	async function cancel() {
 		try {
 			const result = await cancelSubscription.mutateAsync(actionTarget);
-			toast.success(
-				result.cancel_at_period_end ? "Cancellation scheduled" : "Subscription canceled",
-				{ description: cancelCopy?.successDescription?.(result) },
+			const notice = subscriptionMutationNotice(
+				result,
+				"cancel",
+				cancelCopy?.successDescription?.(result),
 			);
+			toast[notice.kind](notice.title, { description: notice.description });
 		} catch (error) {
 			toast.error("Couldn't cancel subscription", { description: normalizeBillingError(error) });
 			throw error;
@@ -123,8 +154,9 @@ export function ComputeSubscriptionActionList({
 
 	async function resume() {
 		try {
-			await resumeSubscription.mutateAsync(actionTarget);
-			toast.success("Subscription resumed");
+			const result = await resumeSubscription.mutateAsync(actionTarget);
+			const notice = subscriptionMutationNotice(result, "resume");
+			toast[notice.kind](notice.title, { description: notice.description });
 		} catch (error) {
 			toast.error("Couldn't resume subscription", { description: normalizeBillingError(error) });
 			throw error;

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-action-list.tsx
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-action-list.tsx
@@ -99,7 +99,7 @@ export function subscriptionMutationNotice(
 		kind: "success",
 		title:
 			action === "resume"
-				? "Subscription resumed"
+				? "Subscription renewal restored"
 				: result.cancel_at_period_end
 					? "Cancellation scheduled"
 					: "Subscription canceled",
@@ -245,9 +245,10 @@ export function ComputeSubscriptionActionList({
 						onClick={() => void runAction(resume).catch(() => undefined)}
 					>
 						{resumeSubscription.isPending ? <Spinner /> : <RefreshCw />}
-						Resume subscription
+						Keep subscription
 					</Button>
 				);
+			case "end_trial":
 			case "cancel":
 				if (!cancelCopy) return null;
 				return (
@@ -267,7 +268,7 @@ export function ComputeSubscriptionActionList({
 							disabled={pending || candidate.disabledReason !== null}
 						>
 							{cancelSubscription.isPending ? <Spinner /> : <Link2Off />}
-							Cancel subscription
+							{candidate.kind === "end_trial" ? "End trial now" : "Cancel subscription"}
 						</Button>
 					</ConfirmAction>
 				);

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-actions.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-actions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	computeSubscriptionActionRequest,
 	scheduledPlanCancellationNotice,
+	subscriptionMutationNotice,
 } from "./compute-subscription-action-list";
 import {
 	type ComputeSubscriptionActionEntitlement,
@@ -132,7 +133,8 @@ describe("resolveComputeSubscriptionActions", () => {
 		});
 		expect(kinds({ status: "canceled", paymentState: "unpaid" })).toEqual(["start_new"]);
 		for (const status of ["canceled", "expired", "incomplete", "paused"]) {
-			expect(kinds({ status }, { management: hiddenManagement }), status).toEqual([]);
+			expect(kinds({ status }, { management: hiddenManagement }), status).toEqual(["start_new"]);
+			expect(kinds({ status, deploymentId: null, isOrphan: true }), status).toEqual([]);
 		}
 	});
 
@@ -195,4 +197,50 @@ describe("scheduled plan cancellation execution", () => {
 			).toMatchObject({ kind: "info" });
 		}
 	});
+});
+
+test("subscription mutations only confirm completed cancellation or renewal", () => {
+	const result = {
+		status: "active",
+		billing_term_months: 1,
+		cancel_at_period_end: true,
+		action_state: null,
+		message: "Display-only service text",
+	};
+	expect(subscriptionMutationNotice(result, "cancel")).toMatchObject({
+		kind: "success",
+		title: "Cancellation scheduled",
+	});
+	expect(
+		subscriptionMutationNotice(
+			{ ...result, status: "canceled", cancel_at_period_end: false },
+			"cancel",
+		),
+	).toMatchObject({ kind: "success", title: "Subscription canceled" });
+	expect(
+		subscriptionMutationNotice({ ...result, cancel_at_period_end: false }, "resume"),
+	).toMatchObject({ kind: "success", title: "Subscription resumed" });
+	for (const action of ["cancel", "resume"] as const) {
+		for (const action_state of ["pending", "reconciling"] as const) {
+			expect(
+				subscriptionMutationNotice(
+					{
+						...result,
+						status: action === "cancel" ? "canceled" : "active",
+						cancel_at_period_end: false,
+						action_state,
+					},
+					action,
+					"Confirmed",
+				),
+			).toMatchObject({
+				kind: "info",
+				description: "Check the latest subscription details in a moment before trying again.",
+			});
+		}
+	}
+	expect(subscriptionMutationNotice(result, "resume").kind).toBe("info");
+	expect(
+		subscriptionMutationNotice({ ...result, cancel_at_period_end: false }, "cancel").kind,
+	).toBe("info");
 });

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-actions.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-actions.test.ts
@@ -47,6 +47,7 @@ function entitlement(
 		cancelAtPeriodEnd: false,
 		pendingPlanSlug: null,
 		isOrphan: false,
+		actions: { cancel: "cancel_at_period_end", resume: false, command_state: null },
 		...overrides,
 	};
 }
@@ -70,10 +71,15 @@ function kinds(
 describe("resolveComputeSubscriptionActions", () => {
 	test("covers healthy paid, trial, Included Basic, and orphan entitlements", () => {
 		expect(kinds()).toEqual(["manage", "cancel"]);
-		expect(kinds({ status: "trialing" })).toEqual(["cancel"]);
+		expect(
+			kinds({
+				status: "trialing",
+				actions: { cancel: "end_trial", resume: false, command_state: null },
+			}),
+		).toEqual(["end_trial"]);
 		expect(
 			kinds(
-				{ planSlug: "compute_basic", fundingSource: null, priceCents: 0 },
+				{ planSlug: "compute_basic", fundingSource: null, priceCents: 0, actions: null },
 				{ management: enabledManagement },
 			),
 		).toEqual(["upgrade"]);
@@ -110,18 +116,25 @@ describe("resolveComputeSubscriptionActions", () => {
 
 	test("gives pending, canceling, and terminal states exclusive recovery priority", () => {
 		expect(kinds({}, { hasPendingOperation: true })).toEqual(["check_change"]);
-		expect(kinds({ cancelAtPeriodEnd: true })).toEqual(["resume"]);
-		expect(kinds({ status: "trialing", cancelAtPeriodEnd: true })).toEqual(["resume"]);
+		expect(
+			kinds({
+				cancelAtPeriodEnd: true,
+				actions: { cancel: null, resume: true, command_state: null },
+			}),
+		).toEqual(["resume"]);
+		expect(
+			kinds({
+				status: "trialing",
+				cancelAtPeriodEnd: true,
+				actions: { cancel: "end_trial", resume: true, command_state: null },
+			}),
+		).toEqual(["resume", "end_trial"]);
 		const unpaid = resolveComputeSubscriptionActions({
-			entitlement: entitlement({ status: "unpaid", paymentState: "unpaid" }),
+			entitlement: entitlement({ status: "unpaid", paymentState: "unpaid", actions: null }),
 			management: enabledManagement,
 			recoveryTarget: null,
 		});
-		expect(unpaid.map(({ kind }) => kind)).toEqual(["start_new"]);
-		expect(unpaid[0]).toMatchObject({
-			kind: "start_new",
-			recoveryTarget: { kind: "start_new" },
-		});
+		expect(unpaid).toEqual([]);
 		const terminalRecovery = resolveComputeSubscriptionActions({
 			entitlement: entitlement({ status: "canceled", paymentState: "ok" }),
 			management: enabledManagement,
@@ -132,11 +145,24 @@ describe("resolveComputeSubscriptionActions", () => {
 			kind: "start_new",
 			recoveryTarget: { kind: "start_new" },
 		});
-		expect(kinds({ status: "canceled", paymentState: "unpaid" })).toEqual(["start_new"]);
-		for (const status of ["canceled", "expired", "incomplete", "paused"]) {
-			expect(kinds({ status }, { management: hiddenManagement }), status).toEqual(["start_new"]);
-			expect(kinds({ status, deploymentId: null, isOrphan: true }), status).toEqual([]);
+		for (const status of ["canceled", "unpaid", "expired", "incomplete", "paused"]) {
+			expect(kinds({ status, actions: null }, { management: hiddenManagement }), status).toEqual(
+				[],
+			);
+			expect(
+				kinds(
+					{ status, actions: null },
+					{
+						management: hiddenManagement,
+						recoveryTarget: { kind: "fix_payment", action: "fix_payment" },
+					},
+				),
+				status,
+			).toEqual(["fix_payment"]);
 		}
+		expect(kinds({ actions: { cancel: null, resume: false, command_state: "pending" } })).toEqual(
+			[],
+		);
 	});
 
 	test("keeps scheduled-downgrade cancellation ahead of subscription cancellation", () => {
@@ -155,18 +181,30 @@ describe("resolveComputeSubscriptionActions", () => {
 			),
 		).toEqual(["fix_payment", "cancel_scheduled_change", "cancel"]);
 		expect(
-			kinds({ cancelAtPeriodEnd: true, status: "canceling", pendingPlanSlug: "compute_basic" }),
+			kinds({
+				cancelAtPeriodEnd: true,
+				status: "canceling",
+				pendingPlanSlug: "compute_basic",
+				actions: null,
+			}),
 		).toEqual(["cancel_scheduled_change"]);
 	});
 
 	test("keeps payment recovery ahead of resuming a canceling subscription", () => {
 		expect(
 			kinds(
-				{ status: "past_due", paymentState: "requires_action", cancelAtPeriodEnd: true },
+				{
+					status: "past_due",
+					paymentState: "requires_action",
+					cancelAtPeriodEnd: true,
+					actions: { cancel: null, resume: true, command_state: null },
+				},
 				{ recoveryTarget: { kind: "fix_payment", action: "fix_payment" } },
 			),
 		).toEqual(["fix_payment", "resume"]);
-		expect(kinds({ deploymentId: null, isOrphan: true, status: "canceling" })).toEqual([]);
+		expect(
+			kinds({ deploymentId: null, isOrphan: true, status: "canceling", actions: null }),
+		).toEqual([]);
 	});
 });
 
@@ -220,7 +258,7 @@ test("subscription mutations only confirm completed cancellation or renewal", ()
 	).toMatchObject({ kind: "success", title: "Subscription canceled" });
 	expect(
 		subscriptionMutationNotice({ ...result, cancel_at_period_end: false }, "resume"),
-	).toMatchObject({ kind: "success", title: "Subscription resumed" });
+	).toMatchObject({ kind: "success", title: "Subscription renewal restored" });
 	for (const action of ["cancel", "resume"] as const) {
 		for (const action_state of ["pending", "reconciling"] as const) {
 			expect(

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-actions.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-actions.test.ts
@@ -111,6 +111,7 @@ describe("resolveComputeSubscriptionActions", () => {
 	test("gives pending, canceling, and terminal states exclusive recovery priority", () => {
 		expect(kinds({}, { hasPendingOperation: true })).toEqual(["check_change"]);
 		expect(kinds({ cancelAtPeriodEnd: true })).toEqual(["resume"]);
+		expect(kinds({ status: "trialing", cancelAtPeriodEnd: true })).toEqual(["resume"]);
 		const unpaid = resolveComputeSubscriptionActions({
 			entitlement: entitlement({ status: "unpaid", paymentState: "unpaid" }),
 			management: enabledManagement,

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-actions.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-actions.ts
@@ -1,11 +1,13 @@
+import type { HostedComputeSubscription } from "@/hosted/billing/contracts";
 import type { ComputeSubscriptionManagementResult } from "./compute-subscription-management";
 import type { ComputeRecoveryTarget } from "./compute-subscription-recovery";
-import { computeFundingSource, isTerminalComputeSubscriptionStatus } from "./subscription-utils";
+import { computeFundingSource } from "./subscription-utils";
 
 export type ComputeSubscriptionActionKind =
 	| "upgrade"
 	| "manage"
 	| "cancel"
+	| "end_trial"
 	| "resume"
 	| "fix_payment"
 	| "top_up"
@@ -39,9 +41,8 @@ export type ComputeSubscriptionActionEntitlement = {
 	cancelAtPeriodEnd: boolean;
 	pendingPlanSlug: string | null | undefined;
 	isOrphan?: boolean;
+	actions?: HostedComputeSubscription["actions"];
 };
-
-const CANCELABLE_STATUSES = new Set(["trialing", "active", "past_due"]);
 
 function action(
 	kind: ComputeSubscriptionDirectAction["kind"],
@@ -93,21 +94,19 @@ export function resolveComputeSubscriptionActions({
 		entitlement.subscriptionKind === "paid" ||
 		(entitlement.subscriptionKind === undefined &&
 			(fundingSource === "stripe" || fundingSource === "wallet"));
-	const canCancel = paid && !entitlement.cancelAtPeriodEnd && CANCELABLE_STATUSES.has(status);
-	const cancel = canCancel ? action("cancel") : null;
+	const canCancel = entitlement.actions?.cancel != null;
+	const cancel = canCancel
+		? action(entitlement.actions?.cancel === "end_trial" ? "end_trial" : "cancel")
+		: null;
 
+	if (entitlement.actions?.command_state != null) return [];
 	if (hasPendingOperation) return [action("check_change")];
 
-	if (
-		recoveryTarget?.kind === "start_new" ||
-		entitlement.paymentState === "unpaid" ||
-		isTerminalComputeSubscriptionStatus(status)
-	) {
+	if (recoveryTarget?.kind === "start_new") {
 		if (!deploymentBound) return [];
-		const startNewTarget: ComputeRecoveryTarget = { kind: "start_new", action: "start_new" };
 		return [
 			{
-				...recoveryAction(recoveryTarget?.kind === "start_new" ? recoveryTarget : startNewTarget),
+				...recoveryAction(recoveryTarget),
 				disabledReason: startNewUnavailableReason,
 			},
 		];
@@ -122,8 +121,8 @@ export function resolveComputeSubscriptionActions({
 		];
 	}
 
-	if (paid && (entitlement.cancelAtPeriodEnd || status === "canceling")) {
-		return [...(recovery ? [recovery] : []), ...(deploymentBound ? [action("resume")] : [])];
+	if (entitlement.actions?.resume) {
+		return [...(recovery ? [recovery] : []), action("resume"), ...(cancel ? [cancel] : [])];
 	}
 
 	if (!paid) {

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-actions.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-actions.ts
@@ -1,6 +1,6 @@
 import type { ComputeSubscriptionManagementResult } from "./compute-subscription-management";
 import type { ComputeRecoveryTarget } from "./compute-subscription-recovery";
-import { computeFundingSource } from "./subscription-utils";
+import { computeFundingSource, isTerminalComputeSubscriptionStatus } from "./subscription-utils";
 
 export type ComputeSubscriptionActionKind =
 	| "upgrade"
@@ -41,13 +41,6 @@ export type ComputeSubscriptionActionEntitlement = {
 	isOrphan?: boolean;
 };
 
-const TERMINAL_STATUSES = new Set([
-	"canceled",
-	"expired",
-	"incomplete",
-	"incomplete_expired",
-	"paused",
-]);
 const CANCELABLE_STATUSES = new Set(["trialing", "active", "past_due"]);
 
 function action(
@@ -108,7 +101,7 @@ export function resolveComputeSubscriptionActions({
 	if (
 		recoveryTarget?.kind === "start_new" ||
 		entitlement.paymentState === "unpaid" ||
-		status === "unpaid"
+		isTerminalComputeSubscriptionStatus(status)
 	) {
 		if (!deploymentBound) return [];
 		const startNewTarget: ComputeRecoveryTarget = { kind: "start_new", action: "start_new" };
@@ -119,8 +112,6 @@ export function resolveComputeSubscriptionActions({
 			},
 		];
 	}
-	if (TERMINAL_STATUSES.has(status)) return [];
-
 	const recovery = recoveryTarget ? recoveryAction(recoveryTarget) : null;
 
 	if (entitlement.pendingPlanSlug != null) {

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.test.ts
@@ -1,26 +1,35 @@
 import { describe, expect, test } from "bun:test";
-import { computeSubscriptionRecoveryPresentation } from "./compute-subscription-recovery";
+import {
+	computeSubscriptionRecoveryPresentation,
+	computeSubscriptionRecoveryTarget,
+} from "./compute-subscription-recovery";
 
 const active = { label: "Active", tone: "success" } as const;
 
 describe("computeSubscriptionRecoveryPresentation", () => {
-	test("pending cancellation does not promise completion or offer another purchase", () => {
-		expect(
-			computeSubscriptionRecoveryPresentation(
-				{
-					status: "canceled",
-					payment_state: "ok",
-					recovery_action: "start_new",
-					actions: { cancel: null, resume: false, command_state: "pending" },
+	test.each(["pending", "authority_pending"] as const)(
+		"%s cancellation does not promise completion or offer another purchase",
+		(pending) => {
+			const subscription = {
+				status: "canceled",
+				payment_state: "ok",
+				recovery_action: "start_new",
+				actions: {
+					cancel: null,
+					resume: false,
+					command_state: pending === "pending" ? "pending" : null,
 				},
-				active,
-			),
-		).toMatchObject({
-			status: { label: "Updating subscription" },
-			recoveryTarget: null,
-			schedule: { fallback: "Your request is still processing" },
-		});
-	});
+				recovery_blocked_reason: pending === "authority_pending" ? pending : null,
+			} as const;
+			expect(computeSubscriptionRecoveryTarget(subscription)).toBeNull();
+			expect(computeSubscriptionRecoveryPresentation(subscription, active)).toMatchObject({
+				status: { label: "Updating subscription" },
+				hasPaymentIssue: false,
+				recoveryTarget: null,
+				schedule: { fallback: "Your request is still processing" },
+			});
+		},
+	);
 
 	test("backend recovery is not overridden by a coarse lifecycle status", () => {
 		const canceled = { label: "Canceled", tone: "neutral" } as const;
@@ -67,6 +76,21 @@ describe("computeSubscriptionRecoveryPresentation", () => {
 	});
 
 	test("projects card, terminal, and healthy actions", () => {
+		expect(
+			computeSubscriptionRecoveryPresentation(
+				{
+					payment_state: "unpaid",
+					recovery_action: null,
+					recovery_blocked_reason: "authority_pending",
+				},
+				active,
+			),
+		).toMatchObject({
+			status: { label: "Needs attention" },
+			hasPaymentIssue: true,
+			recoveryTarget: null,
+			schedule: { fallback: "Contact support to restore this subscription" },
+		});
 		expect(
 			computeSubscriptionRecoveryPresentation(
 				{

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.test.ts
@@ -4,7 +4,25 @@ import { computeSubscriptionRecoveryPresentation } from "./compute-subscription-
 const active = { label: "Active", tone: "success" } as const;
 
 describe("computeSubscriptionRecoveryPresentation", () => {
-	test("ended subscriptions override stale payment retries without needing a recovery action", () => {
+	test("pending cancellation does not promise completion or offer another purchase", () => {
+		expect(
+			computeSubscriptionRecoveryPresentation(
+				{
+					status: "canceled",
+					payment_state: "ok",
+					recovery_action: "start_new",
+					actions: { cancel: null, resume: false, command_state: "pending" },
+				},
+				active,
+			),
+		).toMatchObject({
+			status: { label: "Updating subscription" },
+			recoveryTarget: null,
+			schedule: { fallback: "Your request is still processing" },
+		});
+	});
+
+	test("backend recovery is not overridden by a coarse lifecycle status", () => {
 		const canceled = { label: "Canceled", tone: "neutral" } as const;
 		expect(
 			computeSubscriptionRecoveryPresentation(
@@ -18,10 +36,10 @@ describe("computeSubscriptionRecoveryPresentation", () => {
 				canceled,
 			),
 		).toEqual({
-			status: canceled,
+			status: { label: "Past due", tone: "destructive" },
 			hasPaymentIssue: true,
-			recoveryTarget: { kind: "start_new", action: "start_new" },
-			schedule: null,
+			recoveryTarget: { kind: "top_up", action: "top_up" },
+			schedule: { verb: "Retries", at: "2026-09-12T00:00:00Z", fallback: null },
 		});
 	});
 
@@ -85,7 +103,7 @@ describe("computeSubscriptionRecoveryPresentation", () => {
 				active,
 			),
 		).toEqual({
-			status: { label: "Unpaid", tone: "destructive" },
+			status: { label: "Ended", tone: "neutral" },
 			hasPaymentIssue: true,
 			recoveryTarget: { kind: "start_new", action: "start_new" },
 			schedule: null,

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.test.ts
@@ -66,21 +66,7 @@ describe("computeSubscriptionRecoveryPresentation", () => {
 		});
 	});
 
-	test("projects wallet, card, terminal, and healthy actions", () => {
-		expect(
-			computeSubscriptionRecoveryPresentation(
-				{
-					payment_state: "past_due",
-					recovery_action: "top_up",
-					latest_failed_invoice_hosted_url: null,
-					next_payment_attempt_at: "2026-08-20T00:00:00Z",
-				},
-				active,
-			),
-		).toMatchObject({
-			recoveryTarget: { kind: "top_up", action: "top_up" },
-			schedule: { verb: "Retries", at: "2026-08-20T00:00:00Z", fallback: null },
-		});
+	test("projects card, terminal, and healthy actions", () => {
 		expect(
 			computeSubscriptionRecoveryPresentation(
 				{

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.test.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.test.ts
@@ -4,6 +4,27 @@ import { computeSubscriptionRecoveryPresentation } from "./compute-subscription-
 const active = { label: "Active", tone: "success" } as const;
 
 describe("computeSubscriptionRecoveryPresentation", () => {
+	test("ended subscriptions override stale payment retries without needing a recovery action", () => {
+		const canceled = { label: "Canceled", tone: "neutral" } as const;
+		expect(
+			computeSubscriptionRecoveryPresentation(
+				{
+					status: "canceled",
+					payment_state: "past_due",
+					recovery_action: "top_up",
+					latest_failed_invoice_hosted_url: null,
+					next_payment_attempt_at: "2026-09-12T00:00:00Z",
+				},
+				canceled,
+			),
+		).toEqual({
+			status: canceled,
+			hasPaymentIssue: true,
+			recoveryTarget: { kind: "start_new", action: "start_new" },
+			schedule: null,
+		});
+	});
+
 	test("prioritizes authoritative payment state over coarse lifecycle status", () => {
 		expect(
 			computeSubscriptionRecoveryPresentation(

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.ts
@@ -3,6 +3,7 @@ import type {
 	ComputeSubscriptionListItem,
 	HostedComputeSubscription,
 } from "@/hosted/billing/contracts";
+import { isTerminalComputeSubscriptionStatus } from "./subscription-utils";
 
 export type ComputeSubscriptionRecoveryFields =
 	| (Pick<
@@ -12,7 +13,7 @@ export type ComputeSubscriptionRecoveryFields =
 			| "payment_state"
 			| "recovery_action"
 	  > &
-			Partial<Pick<ComputeSubscriptionListItem, "funding_source">>)
+			Partial<Pick<ComputeSubscriptionListItem, "funding_source" | "status">>)
 	| (Pick<
 			HostedComputeSubscription,
 			| "latest_failed_invoice_hosted_url"
@@ -20,7 +21,7 @@ export type ComputeSubscriptionRecoveryFields =
 			| "payment_state"
 			| "recovery_action"
 	  > &
-			Partial<Pick<HostedComputeSubscription, "funding_source">>);
+			Partial<Pick<HostedComputeSubscription, "funding_source" | "status">>);
 
 export type ComputeRecoveryTarget =
 	| { kind: "invoice"; action: "fix_payment"; url: string }
@@ -41,6 +42,12 @@ export type ComputeSubscriptionRecoveryPresentation = {
 export function computeSubscriptionRecoveryTarget(
 	subscription: ComputeSubscriptionRecoveryFields,
 ): ComputeRecoveryTarget | null {
+	if (
+		isTerminalComputeSubscriptionStatus(subscription.status) ||
+		subscription.payment_state === "unpaid"
+	) {
+		return { kind: "start_new", action: "start_new" };
+	}
 	const action = subscription.recovery_action;
 	if (action === "top_up") return { kind: "top_up", action };
 	if (action === "start_new") return { kind: "start_new", action };
@@ -49,9 +56,6 @@ export function computeSubscriptionRecoveryTarget(
 		return invoiceUrl
 			? { kind: "invoice", action, url: invoiceUrl }
 			: { kind: "fix_payment", action };
-	}
-	if (subscription.payment_state === "unpaid") {
-		return { kind: "start_new", action: "start_new" };
 	}
 	if (subscription.payment_state === "requires_action") {
 		const invoiceUrl = subscription.latest_failed_invoice_hosted_url?.trim();
@@ -95,13 +99,16 @@ export function computeSubscriptionRecoveryPresentation(
 		}
 	})();
 	const target = computeSubscriptionRecoveryTarget(subscription);
+	const terminal = isTerminalComputeSubscriptionStatus(subscription.status);
 
 	return {
-		status: paymentStatus ?? lifecycleStatus,
+		status: terminal ? lifecycleStatus : (paymentStatus ?? lifecycleStatus),
 		hasPaymentIssue: paymentStatus !== null || target !== null,
 		recoveryTarget: target,
 		schedule:
-			subscription.payment_state === "past_due" || subscription.payment_state === "requires_action"
+			!terminal &&
+			(subscription.payment_state === "past_due" ||
+				subscription.payment_state === "requires_action")
 				? subscription.next_payment_attempt_at
 					? {
 							verb: "Retries",

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.ts
@@ -45,7 +45,8 @@ export type ComputeSubscriptionRecoveryPresentation = {
 export function computeSubscriptionRecoveryTarget(
 	subscription: ComputeSubscriptionRecoveryFields,
 ): ComputeRecoveryTarget | null {
-	if (subscription.actions?.command_state != null) return null;
+	if (subscription.actions?.command_state != null || subscription.recovery_blocked_reason != null)
+		return null;
 	const action = subscription.recovery_action;
 	if (action === "top_up") return { kind: "top_up", action };
 	if (action === "start_new") return { kind: "start_new", action };
@@ -70,7 +71,11 @@ export function computeSubscriptionRecoveryPresentation(
 			schedule: null,
 		};
 	}
-	if (subscription.actions?.command_state != null) {
+	if (
+		subscription.actions?.command_state != null ||
+		(subscription.recovery_blocked_reason === "authority_pending" &&
+			subscription.payment_state !== "unpaid")
+	) {
 		return {
 			status: { label: "Updating subscription", tone: "warning" },
 			hasPaymentIssue: false,

--- a/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.ts
+++ b/apps/web/src/hosted/billing/subscription/compute-subscription-recovery.ts
@@ -3,7 +3,6 @@ import type {
 	ComputeSubscriptionListItem,
 	HostedComputeSubscription,
 } from "@/hosted/billing/contracts";
-import { isTerminalComputeSubscriptionStatus } from "./subscription-utils";
 
 export type ComputeSubscriptionRecoveryFields =
 	| (Pick<
@@ -12,6 +11,8 @@ export type ComputeSubscriptionRecoveryFields =
 			| "next_payment_attempt_at"
 			| "payment_state"
 			| "recovery_action"
+			| "recovery_blocked_reason"
+			| "actions"
 	  > &
 			Partial<Pick<ComputeSubscriptionListItem, "funding_source" | "status">>)
 	| (Pick<
@@ -20,6 +21,8 @@ export type ComputeSubscriptionRecoveryFields =
 			| "next_payment_attempt_at"
 			| "payment_state"
 			| "recovery_action"
+			| "recovery_blocked_reason"
+			| "actions"
 	  > &
 			Partial<Pick<HostedComputeSubscription, "funding_source" | "status">>);
 
@@ -35,19 +38,14 @@ export type ComputeSubscriptionRecoveryPresentation = {
 	recoveryTarget: ComputeRecoveryTarget | null;
 	schedule:
 		| { verb: "Retries"; at: string; fallback: null }
-		| { verb: null; at: null; fallback: "Payment needs attention" }
+		| { verb: null; at: null; fallback: string }
 		| null;
 };
 
 export function computeSubscriptionRecoveryTarget(
 	subscription: ComputeSubscriptionRecoveryFields,
 ): ComputeRecoveryTarget | null {
-	if (
-		isTerminalComputeSubscriptionStatus(subscription.status) ||
-		subscription.payment_state === "unpaid"
-	) {
-		return { kind: "start_new", action: "start_new" };
-	}
+	if (subscription.actions?.command_state != null) return null;
 	const action = subscription.recovery_action;
 	if (action === "top_up") return { kind: "top_up", action };
 	if (action === "start_new") return { kind: "start_new", action };
@@ -56,17 +54,6 @@ export function computeSubscriptionRecoveryTarget(
 		return invoiceUrl
 			? { kind: "invoice", action, url: invoiceUrl }
 			: { kind: "fix_payment", action };
-	}
-	if (subscription.payment_state === "requires_action") {
-		const invoiceUrl = subscription.latest_failed_invoice_hosted_url?.trim();
-		return invoiceUrl
-			? { kind: "invoice", action: "fix_payment", url: invoiceUrl }
-			: { kind: "fix_payment", action: "fix_payment" };
-	}
-	if (subscription.payment_state === "past_due") {
-		return subscription.funding_source === "wallet"
-			? { kind: "top_up", action: "top_up" }
-			: { kind: "fix_payment", action: "fix_payment" };
 	}
 	return null;
 }
@@ -81,6 +68,14 @@ export function computeSubscriptionRecoveryPresentation(
 			hasPaymentIssue: false,
 			recoveryTarget: null,
 			schedule: null,
+		};
+	}
+	if (subscription.actions?.command_state != null) {
+		return {
+			status: { label: "Updating subscription", tone: "warning" },
+			hasPaymentIssue: false,
+			recoveryTarget: null,
+			schedule: { verb: null, at: null, fallback: "Your request is still processing" },
 		};
 	}
 
@@ -99,10 +94,29 @@ export function computeSubscriptionRecoveryPresentation(
 		}
 	})();
 	const target = computeSubscriptionRecoveryTarget(subscription);
-	const terminal = isTerminalComputeSubscriptionStatus(subscription.status);
+	const terminal = target?.kind === "start_new";
+	const blocked = subscription.recovery_blocked_reason;
+	if (blocked) {
+		return {
+			status: {
+				label: blocked === "payment_pending" ? "Payment processing" : "Needs attention",
+				tone: "warning",
+			},
+			hasPaymentIssue: true,
+			recoveryTarget: target,
+			schedule: {
+				verb: null,
+				at: null,
+				fallback:
+					blocked === "payment_pending"
+						? "Waiting for payment confirmation"
+						: "Contact support to restore this subscription",
+			},
+		};
+	}
 
 	return {
-		status: terminal ? lifecycleStatus : (paymentStatus ?? lifecycleStatus),
+		status: terminal ? { label: "Ended", tone: "neutral" } : (paymentStatus ?? lifecycleStatus),
 		hasPaymentIssue: paymentStatus !== null || target !== null,
 		recoveryTarget: target,
 		schedule:

--- a/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
@@ -36,6 +36,7 @@ import {
 	computePricePresentation,
 } from "@/hosted/billing/deploy/deploy-price-presentation";
 import {
+	billingErrorDetail,
 	billingErrorNormalizer,
 	isIdempotencyKeyReusedError,
 	isReusableSubscriptionUnavailableError,
@@ -328,7 +329,11 @@ export function SubscriptionCreateDialog({
 				void createQuote.refetch();
 				if (walletTopUp.handleFundingError(error)) return;
 			}
-			if (isIdempotencyKeyReusedError(error) && createAttemptRef.current) {
+			if (
+				(isIdempotencyKeyReusedError(error) ||
+					billingErrorDetail(error)?.code === "checkout_attempt_expired") &&
+				createAttemptRef.current
+			) {
 				forgetIdempotencyAttempt(
 					"subscription-terminal-fallback",
 					createAttemptRef.current.fingerprint,

--- a/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
@@ -268,13 +268,31 @@ export function SubscriptionCreateDialog({
 				fingerprint,
 				newIdempotencyKey,
 			);
-			const outcome = await createSubscription.execute({
-				selection: createSelection,
-				subscriptionSelection,
-				target,
-				uiMode: "hosted",
-				idempotencyKey: createAttemptRef.current.key,
-				quote: source.mode === "new" ? (createQuote.data ?? null) : null,
+			const execute = (attempt: IdempotencyAttempt) =>
+				createSubscription.execute({
+					selection: createSelection,
+					subscriptionSelection,
+					target,
+					uiMode: "hosted",
+					idempotencyKey: attempt.key,
+					quote: source.mode === "new" ? (createQuote.data ?? null) : null,
+				});
+			const outcome = await execute(createAttemptRef.current).catch((error: unknown) => {
+				if (
+					source.mode !== "new" ||
+					fundingSource !== "stripe" ||
+					billingErrorDetail(error)?.code !== "checkout_attempt_expired"
+				)
+					throw error;
+				forgetIdempotencyAttempt("subscription-terminal-fallback", fingerprint);
+				createAttemptRef.current = idempotencyAttemptFor(
+					null,
+					"subscription-terminal-fallback",
+					fingerprint,
+					newIdempotencyKey,
+				);
+				// Only this first failure is retried; a second failure reaches the outer handler.
+				return execute(createAttemptRef.current);
 			});
 			if (outcome.flowType === "subscription_activation") {
 				forgetIdempotencyAttempt("subscription-terminal-fallback", fingerprint);

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -374,15 +374,22 @@ describe("commonExplicitBillingOffers", () => {
 });
 
 describe("account subscription history", () => {
-	test("treats terminal canceled status as history regardless of service period", () => {
+	test("uses finalized recovery for history regardless of the coarse list status", () => {
 		const ended = {
 			status: "canceled" as const,
+			recovery_action: "start_new" as const,
 			cancel_at_period_end: false,
 			current_period_end: "2099-08-12T12:00:00Z",
 		};
 
 		expect(isHistoricalAccountSubscription(ended)).toBe(true);
-		expect(isHistoricalAccountSubscription({ ...ended, status: "canceling" })).toBe(false);
+		expect(isHistoricalAccountSubscription({ ...ended, recovery_action: null })).toBe(false);
+		expect(
+			isHistoricalAccountSubscription({
+				...ended,
+				actions: { cancel: null, resume: false, command_state: "pending" },
+			}),
+		).toBe(false);
 	});
 });
 

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -193,8 +193,7 @@ describe("compute subscription cancellation copy", () => {
 				hasRetainedDeployment: true,
 			}),
 		).toEqual({
-			description:
-				"The trial ends immediately. The agent stops, but its disk and data are retained.",
+			description: "The trial ends immediately and the agent stops. Your saved data is kept.",
 			confirmLabel: "End trial now",
 		});
 		expect(
@@ -205,25 +204,35 @@ describe("compute subscription cancellation copy", () => {
 			}),
 		).toEqual({
 			description:
-				"The subscription will stop renewing and remain active through Sep 12, 2026. At that point, the agent stops, but its disk and data are retained.",
+				"The subscription will stop renewing and remain active through Sep 12, 2026. The agent stops when the period ends. Your saved data is kept.",
 			confirmLabel: "Cancel at period end",
 		});
 		expect(
 			computeSubscriptionCancellationSuccessCopy({
+				isTrial: true,
 				cancelAtPeriodEnd: false,
 				periodEndLabel: null,
 				hasRetainedDeployment: true,
 			}),
-		).toBe("The trial has ended. The agent will stop; its disk and data are retained.");
+		).toBe("The trial has ended. The agent will stop. Your saved data is kept.");
 		expect(
 			computeSubscriptionCancellationSuccessCopy({
+				isTrial: false,
 				cancelAtPeriodEnd: true,
 				periodEndLabel: "Sep 12, 2026",
 				hasRetainedDeployment: true,
 			}),
 		).toBe(
-			"The subscription remains active through Sep 12, 2026. The agent will then stop; its disk and data are retained.",
+			"The subscription remains active through Sep 12, 2026. The agent will then stop. Your saved data is kept.",
 		);
+		expect(
+			computeSubscriptionCancellationSuccessCopy({
+				isTrial: false,
+				cancelAtPeriodEnd: false,
+				periodEndLabel: null,
+				hasRetainedDeployment: true,
+			}),
+		).toBe("The subscription has ended. The agent will stop. Your saved data is kept.");
 		expect(
 			computeSubscriptionCancellationCopy({
 				isTrial: false,
@@ -234,6 +243,16 @@ describe("compute subscription cancellation copy", () => {
 			description:
 				"The subscription will stop renewing at the end of the current billing period. This cannot restore a deleted agent.",
 			confirmLabel: "Cancel at period end",
+		});
+		expect(
+			computeSubscriptionCancellationCopy({
+				isTrial: true,
+				periodEndLabel: "Sep 12, 2026",
+				hasRetainedDeployment: false,
+			}),
+		).toEqual({
+			description: "The trial ends immediately. This cannot restore a deleted agent.",
+			confirmLabel: "End trial now",
 		});
 	});
 });

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -387,6 +387,24 @@ describe("account subscription history", () => {
 });
 
 describe("compute subscription lifecycle presentation", () => {
+	test("keeps a trial scheduled to cancel distinct from an ended trial", () => {
+		const trial = {
+			...subscription(),
+			status: "trialing",
+			cancel_at_period_end: true,
+			current_period_end: "2026-09-12T00:00:00Z",
+		};
+
+		expect(computeSubscriptionLifecycle(trial)).toEqual({
+			badgeLabel: "Canceling",
+			badgeTone: "warning",
+			dateAt: trial.current_period_end,
+			dateVerb: "Ends",
+			renews: false,
+		});
+		expect(isComputeSubscriptionRenewing(trial)).toBe(false);
+	});
+
 	test("only renewing states present as renewing", () => {
 		for (const status of ["active", "trialing", "past_due"]) {
 			expect(isComputeSubscriptionRenewing({ ...subscription(), status }), status).toBe(true);

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -61,14 +61,10 @@ function subscription(): HostedComputeSubscription {
 
 function includedSubscription(): HostedComputeSubscription {
 	return {
+		...subscription(),
 		subscription_id: 7,
-		status: "active",
 		funding_source: null,
-		payment_state: "ok",
-		billing_term_months: 1,
 		price_cents: 0,
-		currency: "usd",
-		cancel_at_period_end: false,
 	};
 }
 

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -3,6 +3,7 @@ import {
 	COMPUTE_BASIC_SLUG,
 	COMPUTE_PERFORMANCE_SLUG,
 	type ComputePlanSlug,
+	type ComputeSubscriptionActionResult,
 	type ComputeSubscriptionListItem,
 	type HostedComputeSubscription,
 	type Plan,
@@ -21,6 +22,18 @@ export function isHistoricalAccountSubscription(
 	return subscription.status === "canceled";
 }
 
+export function isTerminalComputeSubscriptionStatus(status: string | undefined): boolean {
+	return ["canceled", "expired", "incomplete", "incomplete_expired", "paused", "unpaid"].includes(
+		status?.toLowerCase() ?? "",
+	);
+}
+
+export function isComputeSubscriptionActionUnconfirmed(
+	result: ComputeSubscriptionActionResult,
+): boolean {
+	return result.action_state === "pending" || result.action_state === "reconciling";
+}
+
 export function computeSubscriptionCancellationCopy({
 	isTrial,
 	periodEndLabel,
@@ -33,7 +46,7 @@ export function computeSubscriptionCancellationCopy({
 	if (isTrial) {
 		return {
 			description: hasRetainedDeployment
-				? "The trial ends immediately. The agent stops, but its disk and data are retained."
+				? "The trial ends immediately and the agent stops. Your saved data is kept."
 				: "The trial ends immediately. This cannot restore a deleted agent.",
 			confirmLabel: "End trial now",
 		};
@@ -43,25 +56,28 @@ export function computeSubscriptionCancellationCopy({
 		: "The subscription will stop renewing at the end of the current billing period.";
 	return {
 		description: hasRetainedDeployment
-			? `${ending} At that point, the agent stops, but its disk and data are retained.`
+			? `${ending} The agent stops when the period ends. Your saved data is kept.`
 			: `${ending} This cannot restore a deleted agent.`,
 		confirmLabel: "Cancel at period end",
 	};
 }
 
 export function computeSubscriptionCancellationSuccessCopy({
+	isTrial,
 	cancelAtPeriodEnd,
 	periodEndLabel,
 	hasRetainedDeployment,
 }: {
+	isTrial: boolean;
 	cancelAtPeriodEnd: boolean;
 	periodEndLabel: string | null;
 	hasRetainedDeployment: boolean;
 }): string {
 	if (!cancelAtPeriodEnd) {
+		const ending = isTrial ? "The trial has ended." : "The subscription has ended.";
 		return hasRetainedDeployment
-			? "The trial has ended. The agent will stop; its disk and data are retained."
-			: "The trial has ended.";
+			? `${ending} The agent will stop. Your saved data is kept.`
+			: ending;
 	}
 	if (!hasRetainedDeployment) {
 		return periodEndLabel
@@ -69,8 +85,8 @@ export function computeSubscriptionCancellationSuccessCopy({
 			: "The subscription will not renew after the current billing period.";
 	}
 	return periodEndLabel
-		? `The subscription remains active through ${periodEndLabel}. The agent will then stop; its disk and data are retained.`
-		: "The agent will stop when the current billing period ends; its disk and data are retained.";
+		? `The subscription remains active through ${periodEndLabel}. The agent will then stop. Your saved data is kept.`
+		: "The agent will stop when the current billing period ends. Your saved data is kept.";
 }
 
 export function resolveBasicPlan(plans: Plan[] | undefined): Plan | undefined {

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -17,14 +17,10 @@ export type ResolvedBillingOffer = {
 };
 
 export function isHistoricalAccountSubscription(
-	subscription: Pick<ComputeSubscriptionListItem, "status">,
+	subscription: Pick<ComputeSubscriptionListItem, "status" | "recovery_action" | "actions">,
 ): boolean {
-	return subscription.status === "canceled";
-}
-
-export function isTerminalComputeSubscriptionStatus(status: string | undefined): boolean {
-	return ["canceled", "expired", "incomplete", "incomplete_expired", "paused", "unpaid"].includes(
-		status?.toLowerCase() ?? "",
+	return (
+		subscription.actions?.command_state == null && subscription.recovery_action === "start_new"
 	);
 }
 
@@ -205,6 +201,7 @@ export type ComputeSubscriptionLifecycle = {
 };
 
 type ComputeSubscriptionLifecycleInput = {
+	lifecycle_status?: string | null;
 	status: string;
 	cancel_at_period_end: boolean;
 	current_period_end?: string | null;
@@ -216,7 +213,7 @@ type ComputeSubscriptionLifecycleInput = {
 export function computeSubscriptionLifecycle(
 	subscription: ComputeSubscriptionLifecycleInput,
 ): ComputeSubscriptionLifecycle {
-	const status = subscription.status.toLowerCase();
+	const status = (subscription.lifecycle_status ?? subscription.status).toLowerCase();
 	const canceledAt = subscription.canceled_at ?? subscription.current_period_end ?? null;
 	if (
 		status === "canceling" ||
@@ -261,8 +258,8 @@ export function computeSubscriptionLifecycle(
 		return {
 			badgeLabel: "Unpaid",
 			badgeTone: "destructive",
-			dateAt: canceledAt,
-			dateVerb: "Ended",
+			dateAt: null,
+			dateVerb: null,
 			renews: false,
 		};
 	}

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -304,6 +304,7 @@ function SubscriptionRow({
 								confirmLabel: cancellationCopy.confirmLabel,
 								successDescription: (result) =>
 									computeSubscriptionCancellationSuccessCopy({
+										isTrial: subscription.status === "trialing",
 										cancelAtPeriodEnd: result.cancel_at_period_end,
 										periodEndLabel: result.current_period_end
 											? formatShortDate(result.current_period_end)

--- a/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscriptions-section.tsx
@@ -198,6 +198,7 @@ function SubscriptionRow({
 			cancelAtPeriodEnd: subscription.cancel_at_period_end,
 			pendingPlanSlug,
 			isOrphan: !deploymentBound,
+			actions: subscription.actions,
 		},
 		management,
 		recoveryTarget,
@@ -258,7 +259,7 @@ function SubscriptionRow({
 	);
 	const hasRetainedDeployment = !subscription.is_orphan && subscription.deployment_id !== null;
 	const cancellationCopy = computeSubscriptionCancellationCopy({
-		isTrial: subscription.status === "trialing",
+		isTrial: subscription.actions?.cancel === "end_trial",
 		periodEndLabel: subscription.current_period_end
 			? formatShortDate(subscription.current_period_end)
 			: null,
@@ -304,7 +305,7 @@ function SubscriptionRow({
 								confirmLabel: cancellationCopy.confirmLabel,
 								successDescription: (result) =>
 									computeSubscriptionCancellationSuccessCopy({
-										isTrial: subscription.status === "trialing",
+										isTrial: subscription.actions?.cancel === "end_trial",
 										cancelAtPeriodEnd: result.cancel_at_period_end,
 										periodEndLabel: result.current_period_end
 											? formatShortDate(result.current_period_end)

--- a/apps/web/src/hosted/deployment-failure.test.ts
+++ b/apps/web/src/hosted/deployment-failure.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { DeploymentOperation } from "@/hosted/billing/contracts";
-import { BillingApiError, BillingNetworkError } from "@/hosted/billing/errors";
+import {
+	BillingApiError,
+	BillingNetworkError,
+	DeploymentConflictError,
+} from "@/hosted/billing/errors";
 import {
 	deploymentFailurePresentation,
 	deploymentFailureProjection,
@@ -367,6 +371,43 @@ describe("deploymentFailureReason", () => {
 });
 
 describe("deploymentMutationErrorMessage", () => {
+	test("funding revocation stays actionable through conflict wrapping and failed operations", () => {
+		const problem = {
+			"@type": "type.googleapis.com/clawdi.v2.LifecycleProblemDetails" as const,
+			type: "https://api.clawdi.ai/problems/funding-revoked-after-accept",
+			title: "Internal funding fence",
+			detail: "Internal funding fence",
+			status: 409,
+			code: "funding_revoked_after_accept",
+			conditionReason: "FundingRevoked",
+			conditionMessage: "Internal resource details",
+			observedGeneration: 2,
+		};
+		const error = new BillingApiError(409, "Internal funding fence", problem);
+		const message = deploymentMutationErrorMessage(error);
+		expect(message).toContain("Open Agent settings and choose a subscription");
+		expect(message).not.toMatch(/internal|retry|container|volume|disk/i);
+		expect(deploymentMutationErrorMessage(new DeploymentConflictError({ cause: error }))).toBe(
+			message,
+		);
+		const operation = failedOperation("start");
+		const presentation = deploymentFailurePresentation(
+			hostedDeploymentFixture({
+				status: "stopped",
+				acceptedOperation: {
+					...operation,
+					error: { code: 9, message: "Internal funding fence", details: [problem] },
+				},
+			}),
+		);
+		expect(presentation).toMatchObject({
+			title: "Subscription required",
+			reason: message,
+			description: message,
+			remediation: { kind: "none", label: null },
+		});
+	});
+
 	test("does not map never-emitted provider codes to provider recovery copy", () => {
 		const error = new BillingApiError(404, "provider_not_found", {
 			detail: { code: "provider_not_found" },

--- a/apps/web/src/hosted/deployment-failure.ts
+++ b/apps/web/src/hosted/deployment-failure.ts
@@ -13,6 +13,8 @@ const PLAN_CHANGE_FAILURE_REASON =
 const DEFAULT_SERVICE_FAILURE_REASON = "The Clawdi service could not complete this request.";
 const RUNTIME_UNAVAILABLE_REASON =
 	"Clawdi is checking this Agent. Open Agent settings for details.";
+const SUBSCRIPTION_REQUIRED_REASON =
+	"This agent needs an active subscription to start. Open Agent settings and choose a subscription. Your saved data is kept.";
 
 export type DeploymentFailureProjection = {
 	reason: string;
@@ -53,6 +55,10 @@ function isRuntimeStatusFailure(failure: { code?: string }): boolean {
 
 /** Customer-safe copy for declarative agent mutations handled by the deploy API. */
 export function deploymentMutationErrorMessage(error: unknown): string {
+	const cause = error instanceof DeploymentConflictError ? error.cause : error;
+	if (billingErrorDetail(cause)?.code === "funding_revoked_after_accept") {
+		return SUBSCRIPTION_REQUIRED_REASON;
+	}
 	if (error instanceof DeploymentConflictError) return error.message;
 	if (error instanceof BillingNetworkError) {
 		return error.kind === "timeout"
@@ -133,6 +139,15 @@ export function deploymentFailurePresentation(
 	if (!failure) return null;
 	const operationLabel = deploymentOperationLabel(failure.failedVerb);
 	const operationName = operationLabel.toLocaleLowerCase();
+	if (failure.code === "funding_revoked_after_accept") {
+		return {
+			...failure,
+			title: "Subscription required",
+			description: SUBSCRIPTION_REQUIRED_REASON,
+			status: FAILED_STATUS,
+			remediation: { kind: "none", label: null },
+		};
+	}
 	const statusFailure =
 		deployment?.resource.status?.summary_state === "failed"
 			? deployment.resource.status.failure
@@ -255,6 +270,7 @@ export function deploymentFailureReason(
 ): string | null {
 	const failure = input?.failure;
 	if (!failure) return null;
+	if (failure.code === "funding_revoked_after_accept") return SUBSCRIPTION_REQUIRED_REASON;
 
 	// Failure title/detail/conditionMessage are free-form backend strings. Even
 	// after removing identifiers they can contain exception names or service

--- a/apps/web/src/hosted/hosted-deployment.test-fixture.ts
+++ b/apps/web/src/hosted/hosted-deployment.test-fixture.ts
@@ -29,6 +29,8 @@ type HostedDeploymentFixtureOptions = {
 	upgradeAvailable?: boolean;
 	upgradeEligibility?: HostedDeployment["upgrade_eligibility"];
 	acceptedOperation?: HostedDeployment["accepted_operation"];
+	startAction?: HostedDeployment["start_action"];
+	recoveryAction?: NonNullable<HostedDeployment["commercial_display"]>["recovery_action"];
 	cloudEnvironments?: HostedDeployment["clawdi_cloud_environments"];
 	aiProviderAuthKinds?: HostedDeployment["ai_provider_auth_kinds"];
 	runtimeUiEndpoint?: HostedDeployment["runtime_ui_endpoint"];
@@ -96,9 +98,11 @@ export function hostedDeploymentFixture(
 		runtime_ui_endpoint: options.runtimeUiEndpoint,
 		files_endpoint: options.filesEndpoint,
 		accepted_operation: options.acceptedOperation,
+		start_action: options.startAction,
 		commercial_display: {
 			compute_subscription: options.computeSubscription ?? null,
 			latest_funding_fact: options.fundingFact ?? null,
+			recovery_action: options.recoveryAction,
 		},
 		current_plan_slug: options.currentPlanSlug ?? "compute_basic",
 		upgrade_available: upgradeAvailable,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,6 +38,20 @@ The hosted box is intentionally opaque. This repo defines API contracts,
 dashboard surfaces, CLI behavior, local mock helpers, and runtime convergence
 code. Hosted service internals live outside this repository.
 
+Hosted subscription and power controls consume generated backend decisions:
+subscription `actions`, `recovery_action`, `recovery_blocked_reason`, and
+deployment `start_action`. The dashboard does not infer replacement purchases
+from raw billing status or treat undoing a scheduled cancellation as paused
+subscription resumption. Subscription cancellation retains saved data; explicit
+agent deletion remains separate. Pending requests do not imply completed stop.
+Deploy the additive Hosted contract before this dashboard; older stored
+responses without start advice wait for a fresh read. This is our product
+contract, not a claim that Stripe or Cashier cancellation defaults are identical.
+
+Done: regenerate `packages/shared/src/api/deploy.generated.ts` from the paired
+Hosted OpenAPI; run focused subscription consumer tests and
+`e2e/hosted-subscription-power.pw.ts` in an isolated Docker browser runner.
+
 Cross-platform client behavior and current decision owners are tracked in the
 [client capability matrix](cross-platform-capability-matrix.md).
 

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -922,6 +922,15 @@ export interface components {
             /** Fundinginvoiceid */
             fundingInvoiceId?: string | null;
         };
+        /** ComputeSubscriptionActions */
+        ComputeSubscriptionActions: {
+            /** Cancel */
+            cancel: ("end_trial" | "cancel_at_period_end") | null;
+            /** Resume */
+            resume: boolean;
+            /** Command State */
+            command_state: ("pending" | "reconciling") | null;
+        };
         /** ConditionChangedEventData */
         ConditionChangedEventData: {
             condition: components["schemas"]["DeploymentCondition"];
@@ -2052,6 +2061,11 @@ export interface components {
             recovery_action: ("top_up" | "fix_payment" | "start_new") | null;
             /** Pending Plan Slug */
             pending_plan_slug: string | null;
+            /** Lifecycle Status */
+            lifecycle_status?: string | null;
+            /** Recovery Blocked Reason */
+            recovery_blocked_reason?: ("payment_pending" | "paused" | "authority_pending") | null;
+            actions?: components["schemas"]["ComputeSubscriptionActions"] | null;
         };
         /** V2ComputeSubscriptionListResponse */
         V2ComputeSubscriptionListResponse: {
@@ -2360,6 +2374,9 @@ export interface components {
             recovery_action?: ("top_up" | "fix_payment" | "start_new") | null;
             /** Pending Plan Slug */
             pending_plan_slug?: string | null;
+            /** Recovery Blocked Reason */
+            recovery_blocked_reason?: ("payment_pending" | "paused" | "authority_pending") | null;
+            actions?: components["schemas"]["ComputeSubscriptionActions"] | null;
         };
         /** V2HostedComputeUpgradeEligibility */
         V2HostedComputeUpgradeEligibility: {
@@ -2491,6 +2508,8 @@ export interface components {
         V2HostedDeploymentCommercialDisplay: {
             compute_subscription?: components["schemas"]["V2HostedComputeSubscriptionInfo"] | null;
             latest_funding_fact?: components["schemas"]["V2HostedCommercialFundingFactInfo"] | null;
+            /** Recovery Action */
+            recovery_action?: ("top_up" | "fix_payment" | "start_new") | null;
         };
         /** V2HostedDeploymentReadResponse */
         V2HostedDeploymentReadResponse: {
@@ -2519,6 +2538,11 @@ export interface components {
             runtime_ui_endpoint?: (components["schemas"]["V2HermesRuntimeUiEndpointInfo"] | components["schemas"]["V2OpenClawRuntimeUiEndpointInfo"]) | null;
             files_endpoint?: components["schemas"]["V2HostedFilesEndpointInfo"] | null;
             accepted_operation?: components["schemas"]["LongRunningOperation"] | null;
+            /**
+             * Start Action
+             * @description Display decision only. Lifecycle mutations revalidate funding and owner fences.
+             */
+            start_action?: ("start" | "subscribe" | "fix_payment" | "top_up" | "wait" | "contact_support" | "unavailable") | null;
             commercial_display?: components["schemas"]["V2HostedDeploymentCommercialDisplay"];
             /**
              * Current Plan Slug


### PR DESCRIPTION
## Summary
- Includes all changes from #1368; this PR is its consolidated successor.
- Consume backend recovery, cancellation and start decisions; remove raw-status guesses that prompted replacement subscriptions.
- Reuse existing billing recovery and plain stop/start UI, preserve data, keep Delete separate.
- Handle pending requests and payment processing without premature success; historical scheduled trials offer explicit End trial now.
- Regenerate Hosted contract and keep polling for pending recovery.

## Verification
- 142 focused tests, typecheck, OSS build, Biome and contract drift checks passed.
- 17 mocked browser scenarios passed in rounds; long management scenario passed after timeout increased from 60 to 120 seconds.
- Earlier included fixes passed 1125 unit tests. No real payment/runtime integration; screenshots were generated but final manual visual review unavailable.

## Rollout
Requires paired Hosted refactor/subscription-power-policy deployed first. No production changes or deployment performed.